### PR TITLE
docs: add rules & card writing specs

### DIFF
--- a/docs/card_writing_spec.md
+++ b/docs/card_writing_spec.md
@@ -1,0 +1,192 @@
+# Card Writing Spec（卡片写作规范：report_cards_* / highlights templates / reads）
+
+目标：让内容同学写卡（JSON）时做到：
+- 不改代码也能上线
+- 文案一致、可读、可执行
+- 不触发敏感/夸张/医疗承诺风险
+- 可被规则稳定选中（tags/维度正确）
+- 可通过 verify_mbti / CI 验收
+
+> 不可变项（section/kind/ID 命名）先读：`docs/content_immutable.md`
+> 库存门槛/MVP 口径：`docs/content_inventory_spec.md`
+> 热修：`docs/overrides_hotfix_spec.md`
+
+---
+
+## 0. 适用范围（Scope）
+
+- REGION：`CN_MAINLAND`
+- LOCALE：`zh-CN`
+- 文件类型：
+  - 章节卡：`report_cards_traits.json` / `report_cards_relationships.json` / `report_cards_career.json` / `report_cards_growth.json`
+  - 章节兜底：`report_cards_fallback_*.json`
+  - Highlights 模板：`report_highlights_templates.json`
+  - Reads：`report_recommended_reads.json`（items + rules 同文件）
+
+---
+
+## 1. 统一写作原则（所有卡都遵守）
+
+### 1.1 一张卡必须回答 3 个问题
+1) **你在说什么**（一句话结论，避免空泛）
+2) **为什么**（给出可理解的理由/机制/观察线索）
+3) **怎么做**（给出 1~3 条可执行建议，动作化）
+
+> 建议结构：结论（1 句）→ 解释（2~3 句）→ 行动（1~3 条 bullet）
+
+### 1.2 语言风格
+- 用“你/我们”直呼，少用“人格类型标签化定性”
+- 避免绝对化：用“更可能/倾向/在…时”替代“你一定”
+- 建议可执行：动词开头（“尝试…/列出…/设置…”）
+- 不用灌鸡汤：每条建议必须能在 1 天内试一次
+
+### 1.3 风险红线（必须避开）
+🚫 禁止：
+- 医疗/诊断暗示（“你有抑郁/焦虑症”）
+- 夸张承诺（“100% 改变/立刻治愈/保证成功”）
+- 敏感歧视（性别/地域/职业刻板印象）
+- 指导违法/危险行为
+- 人身攻击/羞辱
+
+✅ 建议：
+- 用“自我观察/练习/沟通策略”替代“诊断/治疗”
+- 如果涉及压力/睡眠/情绪：用“建议寻求专业帮助”做边界语句（不下诊断）
+
+---
+
+## 2. ID / kind / tags（写卡时最容易写错的地方）
+
+### 2.1 ID 不可变
+- 已上线 id 永不改名；修文案只改字段内容
+- 版本演进：只增 `vN`，不改旧 id（旧的可下线/禁用）
+
+### 2.2 kind 不可自创
+- kind 必须来自系统允许列表（见 `docs/content_immutable.md`）
+- highlights 的结果 kind（strength/blindspot/action）由引擎/规则决定：模板库不要混写成结果库
+
+### 2.3 tags 必须可机器统计
+tags 是运营化的“维度标签”，必须满足：
+- 前缀在允许列表里（以 pack rules/contract 为准）
+- 一个维度一个值（不要一张卡同时写两个 strategy 或两个 axis）
+- tag 的值字典固定（别自创新 key）
+
+---
+
+## 3. 各类卡片的写法规范
+
+## 3.1 章节卡（report_cards_*.json）
+
+### 3.1.1 字段完整性（通用建议）
+（以你们 schema 为准；这里列“常见必需信息”）
+- `id`：稳定唯一
+- `kind`：系统认可
+- `title`：短标题（≤14 字）
+- `body` / `content`：主体（建议 80~180 字）
+- `bullets` / `actions`：1~3 条行动建议（可选但强烈建议）
+- `tags`：用于规则选择（role/axis/topic 等）
+
+### 3.1.2 文案模板（建议）
+- 标题：结果导向（“把冲突变成对齐”“在压力下恢复节律”）
+- 主体：
+  - 第 1 句：你在说什么（结论）
+  - 第 2~3 句：为什么（可理解机制）
+  - 最后：怎么做（行动）
+
+### 3.1.3 兜底卡（fallback）额外要求
+- 不能依赖 role/axis 才成立（必须“通用可用”）
+- 避免过于笼统（“多沟通”这种不算）
+- 每张兜底至少给 2 条“可执行动作”
+- 写作口径：**长期可用**（不会过时、不会引战、不会敏感）
+
+---
+
+## 3.2 Highlights Templates（report_highlights_templates.json）
+
+### 3.2.1 真实维度（必须遵守）
+templates 的维度是：`dim × side × level`
+- dim：EI/SN/TF/JP/AT
+- side：E/I, S/N, T/F, J/P, A/T
+- level：clear/strong/very_strong（MVP 口径）
+
+> 注意：templates 不是 strength/blindspot/action 的“结果库”；它是“轴向文案物料库”。
+
+### 3.2.2 模板写作要求
+- 每条模板必须能独立成段（不依赖上下文）
+- 避免绝对化，强调“在…情境下”
+- 给出“一个可执行建议”（哪怕只有一句）
+
+建议结构：
+- 1 句洞察（你更倾向…）
+- 1 句影响（因此在…会…）
+- 1 句建议（你可以尝试…）
+
+### 3.2.3 覆盖门槛（运营必须知道）
+- MVP：dim×side 在 level≥clear 必须命中（10/10 true）
+- 变强：每个 dim×side 清晰/强/很强各≥1
+
+---
+
+## 3.3 Reads（report_recommended_reads.json）
+
+### 3.3.1 Reads 的“卡片”应该是什么
+reads 本质是“推荐阅读/练习/资源卡”，比章节卡更偏：
+- 练习（5~10 分钟可做）
+- 复盘模板（可复制步骤）
+- 沟通脚本（可直接说的话）
+- 书/文章/关键词（可检索）
+
+### 3.3.2 strategy / role / axis / topic 的标注规则
+- 放进 `by_strategy.<KEY>[]` 的 item 必须带 `strategy:<KEY>`
+- 放进 `by_role.<KEY>[]` 的 item 必须带 `role:<KEY>`
+- 放进 `by_top_axis["axis:<DIM>:<SIDE>"][]` 的 item 必须带同一个 `axis:<DIM>:<SIDE>`
+- topic 必须来自 `catalog.topics`（别自创新 slug）
+- fallback items：必须通用可用，不依赖任何维度
+
+### 3.3.3 MVP 最低门槛（写卡时要对齐）
+- 去重后总量 `reads.total_unique ≥ 7`
+- fallback `≥ 2`
+- 非空 strategy 桶 `≥ 2`
+
+---
+
+## 4. 质量自检清单（写完一张卡就能自查）
+
+### 4.1 内容质量
+- [ ] 结论明确（1 句能说清）
+- [ ] 解释可理解（不是玄学）
+- [ ] 建议可执行（1 天内可试）
+- [ ] 没有医疗诊断/夸张承诺/歧视刻板印象
+
+### 4.2 机器可用性
+- [ ] id 唯一且符合命名规则
+- [ ] kind 合法
+- [ ] tags 前缀合法，值字典合法
+- [ ] 放入的 bucket 与 tags 一致（reads 特别容易错）
+
+### 4.3 上线前验收（建议每次 PR 跑）
+```bash
+# 去尾随空格
+sed -i '' -E 's/[[:space:]]+$//' content_packages/default/CN_MAINLAND/zh-CN/MBTI-CN-v0.2.1-TEST/*.json
+git diff --check
+
+# MVP 统计
+PACK_DIR="content_packages/default/CN_MAINLAND/zh-CN/MBTI-CN-v0.2.1-TEST"
+bash backend/scripts/mvp_check.sh "$PACK_DIR"
+
+# 全链路硬闸
+bash backend/scripts/ci_verify_mbti.sh
+```
+
+---
+
+## 5. 常见错误（最容易踩）
+
+- ❗写了新 tag key（规则/统计不认识）→ 规则选不中 / 盘点失真
+- ❗reads 放进 bucket 但没带对应 strategy/role/axis tag → “看起来在库里，实际选不中”
+- ❗兜底卡写得依赖某类型 → fallback 反而变成“错用”
+- ❗模板只写情绪化口号 → 不可解释、不可行动
+- ❗一张卡同时写两个 strategy（或两个 axis）→ 统计与选择都会混乱
+
+---
+
+（完）

--- a/docs/rules_writing_spec.md
+++ b/docs/rules_writing_spec.md
@@ -1,0 +1,174 @@
+# Rules Writing Spec（规则编写规范：只改 JSON 也能可验证）
+
+目标：让内容/运营在**不改代码**的前提下，改动 rules（选择逻辑/优先级/配额）仍然做到：
+- 可理解：规则意图清晰、字段含义统一
+- 可验证：`verify_mbti` / `ci_verify_mbti` 一票否决缺卡/回退/乱选
+- 可回滚：任何规则变更都能快速 revert
+- 可扩容：先 MVP 可用，再按数据逐步补库
+
+> 本文只写“怎么写规则、怎么验收”。不可变项（section/kind/ID 命名）请先读：`docs/content_immutable.md`
+> 库存门槛/MVP 口径请读：`docs/content_inventory_spec.md`
+
+---
+
+## 0. 适用范围（Scope）
+
+- REGION：`CN_MAINLAND`
+- LOCALE：`zh-CN`
+- 内容包示例：`content_packages/default/CN_MAINLAND/zh-CN/MBTI-CN-v0.2.1-TEST/`
+- 规则主要分两类：
+  1) **Highlights 规则**（拆文件）：`report_highlights_policy.json` / `report_highlights_rules.json` / `report_highlights_pools.json`
+  2) **章节卡片规则**（通用选择）：`report_rules.json` / `report_section_policies.json` / `report_select_rules.json`
+  3) **Reads 规则**（同文件）：`report_recommended_reads.json`（rules+items 同文件）
+
+---
+
+## 1. 分层与职责边界（必须遵守）
+
+### 1.1 Layer 规则（复述，防越权）
+- L1 Content：只写卡片内容/素材引用，不写选择逻辑
+- L2 Selection：rules / pools / policies（**本文重点**）
+- L3 Overrides：热修止血（另见：`docs/overrides_hotfix_spec.md`）
+
+### 1.2 规则允许做什么 / 不允许做什么
+✅ 可以：
+- 调整“选几张、优先级、兜底策略、桶配额（quota）”
+- 添加新规则分支（以可验证为前提）
+- 调整池（pools）的分组/权重/标签匹配（以可统计为前提）
+
+🚫 禁止：
+- 自创 section/kind/字段（违反 contract/immutable）
+- 依赖“随机兜底”掩盖缺库（会导致不可解释）
+- 通过规则变更让系统回退到 `GLOBAL/en` 或 `_deprecated`
+- 引入“规则隐式回退”：看似通过但实际走 generated_/fallback
+
+---
+
+## 2. 命名与可读性规范（让规则能被人读懂）
+
+### 2.1 每条规则必须写清 4 件事（在 JSON 允许的字段里表达）
+1) **目的（intent）**：这条规则要解决什么（例如“确保 action 必出”、“优先 axis 定向”）
+2) **范围（scope）**：作用在什么 section/kind 或哪个 selector 上
+3) **条件（condition）**：命中条件是什么（轴、role、strategy、topic、阈值等）
+4) **结果（effect）**：命中后选多少、从哪选、失败怎么兜底
+
+> 如果 schema 不支持注释字段，必须在 PR 描述里写清楚这 4 件事。
+
+### 2.2 规则 ID / key 命名（建议）
+- 规则 id：`rule.<domain>.<purpose>.vN`
+  - 例：`rule.highlights.ensure_action.v1`
+- 池 id：`pool.<domain>.<group>.vN`
+  - 例：`pool.highlights.axis_templates.v1`
+- policy id：`policy.<domain>.<name>.vN`
+
+规则只增不改（vN 递增），旧规则要么下线要么保留（看 schema 是否支持 enable/disabled）。
+
+---
+
+## 3. 约束：必须与库存口径对齐（写规则前先看库存是否够）
+
+### 3.1 Highlights（templates 口径）强约束
+- templates 的真实维度是 `dim × side × level`（见 inventory spec）
+- rules 中如果声明 `min_level=clear`，运营验收必须把“缺模板”定义为 FAIL
+- pools/rules **不能把缺模板** 推给 generated_ 或不可解释 fallback
+
+### 3.2 Reads（bucket + tags 口径）强约束
+- reads 的选择是**跨 bucket 汇总**，不能把某个 bucket 永久写死为“空也没关系”
+- bucket_quota 的调整必须与供给（supply）对齐：
+  - by_strategy quota=2 → 每个 strategy bucket 建议 ≥2 条
+  - by_role quota=2 → 每个 role bucket 建议 ≥2 条
+  - by_top_axis quota=1 → 每个 axis bucket 建议 ≥1 条
+- MVP 门槛：`total_unique≥7`、`fallback≥2`、`non_empty_strategy_buckets≥2`
+
+---
+
+## 4. 写规则的“黄金路径”（先稳后强）
+
+### 4.1 P0（先跑通）
+优先保证：
+- 不回退：无 `GLOBAL/en` / `fallback to GLOBAL` / `_deprecated`
+- 不缺卡：highlights 数量范围满足、kind 覆盖满足
+- templates 覆盖 10/10 true（dim×side level≥clear 任意命中）
+- reads 至少 2 个 strategy 非空桶
+
+### 4.2 P1（提升稳定性）
+- templates：同一 dim×side 至少 clear/strong/very_strong 三档各≥1（减少重复）
+- reads：补齐 4 个 strategy（EA/ET/IA/IT）与 role/axis 覆盖
+- 章节卡：开始补 role/axis 定向供给，减少 fallback 压力
+
+### 4.3 P2（运营化扩容）
+- 支持多版本 vN（同维度多条可选）
+- 规则更细：按数据微调优先级、权重、阈值
+- 低表现内容进入 fallback/下线
+
+---
+
+## 5. 规则改动的验收硬闸（必须过）
+
+### 5.1 本地（建议每次都跑）
+```bash
+# 0) 清理尾随空格
+sed -i '' -E 's/[[:space:]]+$//' content_packages/default/CN_MAINLAND/zh-CN/MBTI-CN-v0.2.1-TEST/*.json
+git diff --check
+
+# 1) MVP 统计（templates + reads）
+PACK_DIR="content_packages/default/CN_MAINLAND/zh-CN/MBTI-CN-v0.2.1-TEST"
+bash backend/scripts/mvp_check.sh "$PACK_DIR"
+echo "EXIT=$?"
+
+# 2) 全链路硬闸（self-check + MVP gate + verify_mbti + overrides D）
+bash backend/scripts/ci_verify_mbti.sh
+```
+
+### 5.2 CI（必须全绿）
+- `fap:self-check` 通过（contract/assets/schema）
+- `MVP check` 通过（templates+reads）
+- `verify_mbti` 通过（包含 highlights contract 断言）
+- 禁止信号不出现：`GLOBAL/en` / `fallback to GLOBAL` / `_deprecated`
+- 需要看回溯：`backend/artifacts/verify_mbti/logs/mvp_check.log` + `summary.txt`
+
+---
+
+## 6. 常见“规则坑”与修复方式
+
+### 6.1 调高 quota 但库存没补 → 结果不稳定/走兜底
+**症状**：报告偶发缺卡、或出现 generated_/fallback
+**修复**：先补库，再调 quota；或临时把 quota 降回可满足的水平。
+
+### 6.2 条件过严 → 规则永远命不中
+**症状**：某类定向（role/axis）几乎不出现
+**修复**：把条件拆成两层：严条件 → 宽条件 → fallback；并确保每层都有供给。
+
+### 6.3 隐式回退（看似 OK，实则回退 GLOBAL）
+**症状**：verify_mbti grep 出 `GLOBAL/en` 或 `fallback to GLOBAL`
+**修复**：先修 content pack / manifest / assets；规则层禁止引导回退路径。
+
+### 6.4 用 overrides 代替规则长期配置
+**症状**：overrides 文件越来越大且长期不撤
+**修复**：把长期逻辑下沉到 L1/L2；overrides 只保留短期止血并设 expires_at。
+
+---
+
+## 7. PR 模板（建议复制到 PR 描述）
+
+- 变更范围：哪些 rules/pools/policies 文件
+- 意图（intent）：这次规则要解决什么
+- 风险点：可能导致缺卡/回退/兜底的地方
+- 验收证据：
+  - `bash backend/scripts/ci_verify_mbti.sh`（EXIT=0）
+  - `backend/artifacts/verify_mbti/logs/mvp_check.log`（PASS）
+- 回滚方式：revert commit
+
+---
+
+## 8. 最小示例（写法风格示意，不绑定 schema）
+
+> 你们最终字段以 schema/contract 为准。这里展示“信息该怎么组织”，以便运营读得懂。
+
+- policy：写清“目标数量范围 / 必含 kind / 允许兜底”
+- rule：写清“条件 + 来源池 + 配额 + 失败链路”
+- pool：写清“标签/维度分组”，确保可统计
+
+---
+
+（完）


### PR DESCRIPTION
变更内容：
- 新增 docs/rules_writing_spec.md（规则编写规范）
- 新增 docs/card_writing_spec.md（卡片写作规范）

验收：
- bash backend/scripts/ci_verify_mbti.sh （PASS）
  - MVP check: PASS（see backend/artifacts/verify_mbti/logs/mvp_check.log）
  - verify_mbti: PASS

影响范围：
- 仅 docs 文档新增，无代码逻辑变更