### PR TITLE
docs: update docs index (add Content Ops entry)

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,6 +1,6 @@
 > Status: Active
 > Owner: liufuwei
-> Last Updated: 2025-12-16
+> Last Updated: 2026-01-12
 > Version: Docs Index v0.2.1
 > Related Docs:
 > - docs/03-stage1/README.md
@@ -21,6 +21,9 @@
 - Stage 2（V0.2-B）：中国大陆业务闭环（测评→报告→分享→增长）
   - docs/04-stage2/README.md
 
+- Content Ops（运营只改 JSON）：内容资产（content_packages）迭代、验收、热修
+  - docs/content_ops_playbook.md
+
 ---
 
 ## 1) 文档体系与目录约定
@@ -28,6 +31,7 @@
 - `docs/03-stage1/`：Stage 1 产物（全局口径、API 规范、合规基础、发布清单）
 - `docs/04-stage2/`：Stage 2 产物（闭环总纲、报告引擎 v1.2、漏斗、用户权益、验收剧本）
 - `content_packages/`：内容资产包（可版本化、可灰度、可回滚）
+- `docs/*.md`：跨阶段的公共规范（内容运营、验收口径、写作规范等）
 
 ---
 
@@ -68,11 +72,20 @@
 
 ## 4) 推荐阅读顺序（新加入项目时）
 
+### 工程/产品（主链路）
 1) docs/03-stage1/README.md（先理解口径与规范）
 2) docs/03-stage1/api-v0.2-spec.md（接口口径）
 3) docs/04-stage2/README.md（Stage2 总纲与里程碑）
 4) docs/04-stage2/mbti-report-engine-v1.2.md（报告引擎结构）
 5) docs/04-stage2/analytics-stage2-funnel-spec.md（漏斗指标与事件映射）
+
+### 内容/运营（只改 JSON）
+1) docs/content_immutable.md（不可变契约：section/kind/ID 规则）
+2) docs/content_ops_playbook.md（运营手册主入口：分层、流程、MVP check）
+3) docs/content_inventory_spec.md（库存口径与 MVP 门槛）
+4) docs/overrides_hotfix_spec.md（Overrides 热修规范：刹车/到期撤销/回滚）
+5) docs/rules_writing_spec.md（规则写作规范：可改但可验证）
+6) docs/card_writing_spec.md（卡片/reads 写作规范：字段、tags、质量）
 
 ---
 
@@ -80,3 +93,35 @@
 
 - Stage 1 验收：见 `docs/03-stage1/README.md`
 - Stage 2 验收：见 `docs/04-stage2/acceptance-playbook.md`
+
+---
+
+## 6) Content Ops（运营入口：内容资产与验收）
+
+目标：让内容/运营在**不改代码**前提下，只改 JSON 也能稳定迭代，并且**不回退 GLOBAL/en、不卡 silent fallback**。
+
+### 6.1 不可变契约（先读）
+- docs/content_immutable.md
+
+### 6.2 运营主手册（分层/流程/验收）
+- docs/content_ops_playbook.md
+
+### 6.3 库存口径与 MVP（硬闸）
+- docs/content_inventory_spec.md
+- 验收脚本：`backend/scripts/mvp_check.sh`
+
+### 6.4 热修（Overrides：最危险能力）
+- docs/overrides_hotfix_spec.md
+- 唯一 canonical 文件（示例）：
+  - `content_packages/default/CN_MAINLAND/zh-CN/MBTI-CN-v0.2.1-TEST/report_overrides.json`
+
+### 6.5 写作规范（长期建设）
+- docs/rules_writing_spec.md
+- docs/card_writing_spec.md
+
+### 6.6 一键验收（本地/CI）
+- `bash backend/scripts/ci_verify_mbti.sh`
+  - self-check
+  - MVP check（templates + reads，log: `backend/artifacts/verify_mbti/logs/mvp_check.log`）
+  - verify_mbti（summary: `backend/artifacts/verify_mbti/summary.txt`）
+  - overrides 验收（log: `backend/artifacts/verify_mbti/logs/overrides_accept_D.log`）


### PR DESCRIPTION
•	“docs/README.md: add Content Ops navigation + links to inventory/ops/overrides/rules/cards specs”