### PR TITLE
content: expand reads by_top_axis supply (add *_02)

### DIFF
--- a/content_packages/default/CN_MAINLAND/zh-CN/MBTI-CN-v0.2.1-TEST/report_recommended_reads.json
+++ b/content_packages/default/CN_MAINLAND/zh-CN/MBTI-CN-v0.2.1-TEST/report_recommended_reads.json
@@ -974,7 +974,29 @@
           "published_at": "2025-12-20",
           "updated_at": "2025-12-20",
           "canonical_url": "/reads/coming-soon?id=art_axis_ei_e_01"
-        }
+        },
+        {
+  "id": "art_axis_ei_e_02",
+  "canonical_id": "cn.read.axis.ei_e.energy_in_motion.v1",
+  "type": "article",
+  "title": "把社交变成推进器：主动建立连接",
+  "desc": "适合更偏 E 的你：用“先连接、后协作”的方式，让你在人群里更快进入状态。",
+  "url": "/reads/coming-soon?id=art_axis_ei_e_02",
+  "cover": "/covers/axis-ei-e.png",
+  "priority": 107,
+  "tags": [
+    "axis:EI:E",
+    "topic:communication",
+    "topic:relationships",
+    "stage:onboarding",
+    "channel:web"
+  ],
+  "estimated_minutes": 6,
+  "status": "active",
+  "published_at": "2026-01-12",
+  "updated_at": "2026-01-12",
+  "canonical_url": "/reads/coming-soon?id=art_axis_ei_e_02"
+}
       ],
       "axis:EI:I": [
         {
@@ -998,7 +1020,29 @@
           "published_at": "2025-12-20",
           "updated_at": "2025-12-20",
           "canonical_url": "/reads/coming-soon?id=art_axis_ei_i_01"
-        }
+        },
+        {
+  "id": "art_axis_ei_i_02",
+  "canonical_id": "cn.read.axis.ei_i.solo_recharge_boundaries.v1",
+  "type": "article",
+  "title": "内向充电：把独处变成高质量恢复",
+  "desc": "适合更偏 I 的你：用更清晰的边界与节奏，避免“被社交榨干”。",
+  "url": "/reads/coming-soon?id=art_axis_ei_i_02",
+  "cover": "/covers/axis-ei-i.png",
+  "priority": 107,
+  "tags": [
+    "axis:EI:I",
+    "topic:stress",
+    "topic:growth",
+    "stage:onboarding",
+    "channel:web"
+  ],
+  "estimated_minutes": 6,
+  "status": "active",
+  "published_at": "2026-01-12",
+  "updated_at": "2026-01-12",
+  "canonical_url": "/reads/coming-soon?id=art_axis_ei_i_02"
+}
       ],
       "axis:SN:S": [
         {
@@ -1022,7 +1066,29 @@
           "published_at": "2025-12-20",
           "updated_at": "2025-12-20",
           "canonical_url": "/reads/coming-soon?id=art_axis_sn_s_01"
-        }
+        },
+        {
+  "id": "art_axis_sn_s_02",
+  "canonical_id": "cn.read.axis.sn_s.details_to_results.v1",
+  "type": "article",
+  "title": "从细节到结果：把“做对”变成优势",
+  "desc": "适合更偏 S 的你：用可验证的步骤推进，不靠灵感也能稳定拿结果。",
+  "url": "/reads/coming-soon?id=art_axis_sn_s_02",
+  "cover": "/covers/axis-sn-s.png",
+  "priority": 107,
+  "tags": [
+    "axis:SN:S",
+    "topic:career",
+    "topic:growth",
+    "stage:onboarding",
+    "channel:web"
+  ],
+  "estimated_minutes": 6,
+  "status": "active",
+  "published_at": "2026-01-12",
+  "updated_at": "2026-01-12",
+  "canonical_url": "/reads/coming-soon?id=art_axis_sn_s_02"
+}
       ],
       "axis:SN:N": [
         {
@@ -1046,7 +1112,29 @@
           "published_at": "2025-12-20",
           "updated_at": "2025-12-20",
           "canonical_url": "/reads/coming-soon?id=art_axis_sn_n_01"
-        }
+        },
+        {
+  "id": "art_axis_sn_n_02",
+  "canonical_id": "cn.read.axis.sn_n.patterns_and_possibilities.v1",
+  "type": "article",
+  "title": "把直觉落地：从可能性到可执行计划",
+  "desc": "适合更偏 N 的你：保留想象力的同时，用一页纸把方向变成行动。",
+  "url": "/reads/coming-soon?id=art_axis_sn_n_02",
+  "cover": "/covers/axis-sn-n.png",
+  "priority": 107,
+  "tags": [
+    "axis:SN:N",
+    "topic:growth",
+    "topic:career",
+    "stage:onboarding",
+    "channel:web"
+  ],
+  "estimated_minutes": 7,
+  "status": "active",
+  "published_at": "2026-01-12",
+  "updated_at": "2026-01-12",
+  "canonical_url": "/reads/coming-soon?id=art_axis_sn_n_02"
+}
       ],
       "axis:TF:T": [
         {
@@ -1070,7 +1158,29 @@
           "published_at": "2025-12-20",
           "updated_at": "2025-12-20",
           "canonical_url": "/reads/coming-soon?id=art_axis_tf_t_01"
-        }
+        },
+        {
+  "id": "art_axis_tf_t_02",
+  "canonical_id": "cn.read.axis.tf_t.decide_with_criteria.v1",
+  "type": "article",
+  "title": "用标准做决策：减少纠结、提高一致性",
+  "desc": "适合更偏 T 的你：把“对不对”拆成可比较的标准，决策更快也更稳。",
+  "url": "/reads/coming-soon?id=art_axis_tf_t_02",
+  "cover": "/covers/axis-tf-t.png",
+  "priority": 107,
+  "tags": [
+    "axis:TF:T",
+    "topic:career",
+    "topic:communication",
+    "stage:onboarding",
+    "channel:web"
+  ],
+  "estimated_minutes": 6,
+  "status": "active",
+  "published_at": "2026-01-12",
+  "updated_at": "2026-01-12",
+  "canonical_url": "/reads/coming-soon?id=art_axis_tf_t_02"
+}
       ],
       "axis:TF:F": [
         {
@@ -1094,7 +1204,29 @@
           "published_at": "2025-12-20",
           "updated_at": "2025-12-20",
           "canonical_url": "/reads/coming-soon?id=art_axis_tf_f_01"
-        }
+        },
+        {
+  "id": "art_axis_tf_f_02",
+  "canonical_id": "cn.read.axis.tf_f.kindness_with_boundaries.v1",
+  "type": "article",
+  "title": "善意有边界：照顾感受但不委屈自己",
+  "desc": "适合更偏 F 的你：用更温和但清晰的表达，既体贴也不失原则。",
+  "url": "/reads/coming-soon?id=art_axis_tf_f_02",
+  "cover": "/covers/axis-tf-f.png",
+  "priority": 107,
+  "tags": [
+    "axis:TF:F",
+    "topic:relationships",
+    "topic:communication",
+    "stage:onboarding",
+    "channel:web"
+  ],
+  "estimated_minutes": 7,
+  "status": "active",
+  "published_at": "2026-01-12",
+  "updated_at": "2026-01-12",
+  "canonical_url": "/reads/coming-soon?id=art_axis_tf_f_02"
+}
       ],
       "axis:JP:J": [
         {
@@ -1118,7 +1250,29 @@
           "published_at": "2025-12-20",
           "updated_at": "2025-12-20",
           "canonical_url": "/reads/coming-soon?id=art_axis_jp_j_01"
-        }
+        },
+        {
+  "id": "art_axis_jp_j_02",
+  "canonical_id": "cn.read.axis.jp_j.plan_and_finish.v1",
+  "type": "article",
+  "title": "把计划做到底：用收尾感获得掌控",
+  "desc": "适合更偏 J 的你：用小颗粒的里程碑，把推进变成可见的完成。",
+  "url": "/reads/coming-soon?id=art_axis_jp_j_02",
+  "cover": "/covers/axis-jp-j.png",
+  "priority": 107,
+  "tags": [
+    "axis:JP:J",
+    "topic:career",
+    "topic:growth",
+    "stage:onboarding",
+    "channel:web"
+  ],
+  "estimated_minutes": 6,
+  "status": "active",
+  "published_at": "2026-01-12",
+  "updated_at": "2026-01-12",
+  "canonical_url": "/reads/coming-soon?id=art_axis_jp_j_02"
+}
       ],
       "axis:JP:P": [
         {
@@ -1142,7 +1296,29 @@
           "published_at": "2025-12-20",
           "updated_at": "2025-12-20",
           "canonical_url": "/reads/coming-soon?id=art_axis_jp_p_01"
-        }
+        },
+        {
+  "id": "art_axis_jp_p_02",
+  "canonical_id": "cn.read.axis.jp_p.flexible_structure.v1",
+  "type": "article",
+  "title": "自由但不散：给弹性加一个轻结构",
+  "desc": "适合更偏 P 的你：保留随机应变，同时用最小约束避免拖延失控。",
+  "url": "/reads/coming-soon?id=art_axis_jp_p_02",
+  "cover": "/covers/axis-jp-p.png",
+  "priority": 107,
+  "tags": [
+    "axis:JP:P",
+    "topic:stress",
+    "topic:growth",
+    "stage:onboarding",
+    "channel:web"
+  ],
+  "estimated_minutes": 7,
+  "status": "active",
+  "published_at": "2026-01-12",
+  "updated_at": "2026-01-12",
+  "canonical_url": "/reads/coming-soon?id=art_axis_jp_p_02"
+}
       ],
       "axis:AT:A": [
         {
@@ -1166,7 +1342,29 @@
           "published_at": "2025-12-20",
           "updated_at": "2025-12-20",
           "canonical_url": "/reads/coming-soon?id=art_axis_at_a_01"
-        }
+        },
+        {
+  "id": "art_axis_at_a_02",
+  "canonical_id": "cn.read.axis.at_a.steady_confidence.v1",
+  "type": "article",
+  "title": "稳定自信：把优势当成可复用流程",
+  "desc": "适合更偏 A 的你：把“我行”变成可复用的方法，让优势在不同场景复现。",
+  "url": "/reads/coming-soon?id=art_axis_at_a_02",
+  "cover": "/covers/axis-at-a.png",
+  "priority": 107,
+  "tags": [
+    "axis:AT:A",
+    "topic:growth",
+    "topic:career",
+    "stage:onboarding",
+    "channel:web"
+  ],
+  "estimated_minutes": 6,
+  "status": "active",
+  "published_at": "2026-01-12",
+  "updated_at": "2026-01-12",
+  "canonical_url": "/reads/coming-soon?id=art_axis_at_a_02"
+}
       ],
       "axis:AT:T": [
         {
@@ -1190,7 +1388,29 @@
           "published_at": "2025-12-20",
           "updated_at": "2025-12-20",
           "canonical_url": "/reads/coming-soon?id=art_axis_at_t_01"
-        }
+        },
+        {
+  "id": "art_axis_at_t_02",
+  "canonical_id": "cn.read.axis.at_t.calm_in_turbulence.v1",
+  "type": "article",
+  "title": "动荡中保持冷静：把压力转成行动",
+  "desc": "适合更偏 T 的你：遇到波动先稳住节奏，再用行动把不确定性降下来。",
+  "url": "/reads/coming-soon?id=art_axis_at_t_02",
+  "cover": "/covers/axis-at-t.png",
+  "priority": 107,
+  "tags": [
+    "axis:AT:T",
+    "topic:stress",
+    "topic:communication",
+    "stage:onboarding",
+    "channel:web"
+  ],
+  "estimated_minutes": 7,
+  "status": "active",
+  "published_at": "2026-01-12",
+  "updated_at": "2026-01-12",
+  "canonical_url": "/reads/coming-soon?id=art_axis_at_t_02"
+}
       ]
     },
     "fallback": [


### PR DESCRIPTION
## What
Expand `report_recommended_reads.json` supply for `.items.by_top_axis`:
- Add one additional item per axis bucket (`*_02`), so each axis has 2 items (10/10).

## Why
Increase selection stability & reduce repetition (avoid “single item” fatigue) while keeping rules behavior unchanged.

## Verify
- `bash backend/scripts/mvp_check.sh "$PACK_DIR"`
  - templates: 10/10 true
  - reads.total_unique=61
  - reads.fallback=8
  - reads.non_empty_strategy_buckets=4 => EA,ET,IA,IT
- `bash backend/scripts/ci_verify_mbti.sh` ✅ PASS (self-check + MVP + verify_mbti + overrides D)

## Scope
- Only content JSON update:
  - `content_packages/default/CN_MAINLAND/zh-CN/MBTI-CN-v0.2.1-TEST/report_recommended_reads.json`

## Rollback
Revert this PR commit.