### PR TITLE
docs(tp5): add phase-a issue cards (A/B/C)

### DIFF
--- a/docs/product/issues/tp5-issue-a-ticket-code.md
+++ b/docs/product/issues/tp5-issue-a-ticket-code.md
@@ -1,0 +1,53 @@
+# TP5 Issue A: Ticket Code 生成 + 展示 + Lookup（P0）
+> Doc: docs/product/issues/tp5-issue-a-ticket-code.md  
+> Related PRD: docs/product/report-lookup-prd.md (Section 0.2 / 5.1 / 6.1)  
+> Priority: P0 (Phase A)
+
+---
+
+## 1. Scope（做什么）
+实现 Ticket Code 的 **端到端闭环**：
+- 生成：Attempt/Result 创建时生成 ticket_code（FMT-...）
+- 展示：结果页显著展示（登机牌/小票视觉）+ 可复制
+- 找回：/lookup 的 Ticket 入口支持输入 ticket_code 找回并打开报告/结果入口
+
+> Phase A 只要求 “可演示通过”，不要求与支付/邮箱/手机号打通。
+
+---
+
+## 2. Entry（入口）
+- 结果页：用户完成测试后生成结果时（Result Created）
+- /lookup：Ticket Code Tab（或卡片入口）
+
+---
+
+## 3. Output（输出）
+- 用户在结果页能看到 ticket_code，且能复制成功
+- 用户在 /lookup 输入 ticket_code 能命中并进入同一份报告/结果入口
+- 命中态区分：
+  - 已付费：可直达完整版（Phase A 可先同页标识/占位）
+  - 未付费：展示摘要卡 + 解锁入口（Phase A 可先简化）
+
+---
+
+## 4. Edge Cases（边界条件）
+- code 格式不合法：提示“格式错误”
+- code 不存在：提示“未找到记录”
+- 频繁查询：触发限频提示（文案/策略即可，Phase A 可先记录到审计）
+- 结果未生成/报告不存在：提示“记录存在但报告未就绪”，引导稍后重试
+
+---
+
+## 5. Acceptance（验收步骤：必须能 Demo）
+1) 完成一次测试，进入结果页
+2) 看到 Ticket Code（FMT-...）并点击复制
+3) 新开隐身窗口（无 localStorage/cookie）
+4) 打开 /lookup → Ticket Code → 输入该 code
+5) 命中后打开同一份报告/结果入口 ✅
+
+---
+
+## 6. Non-goals（本 Issue 不做）
+- 手机号绑定/登录
+- 邮箱发送 Magic Link
+- 复杂账号合并

--- a/docs/product/issues/tp5-issue-b-device-resume.md
+++ b/docs/product/issues/tp5-issue-b-device-resume.md
@@ -1,0 +1,49 @@
+# TP5 Issue B: Device Resume + 首页 Banner + Lookup(Device)（P0）
+> Doc: docs/product/issues/tp5-issue-b-device-resume.md  
+> Related PRD: docs/product/report-lookup-prd.md (Section 0.2 / 5.2 / 5.3 / 6.1)  
+> Priority: P0 (Phase A)
+
+---
+
+## 1. Scope（做什么）
+实现同设备“无感召回”闭环：
+- 记录本设备 latest_attempt（或 latest_attempt_ids）
+- 首页 Smart Resume Banner：检测到记录则展示“继续查看”
+- /lookup 的 Device 入口：展示本设备历史（至少 latest_attempt）
+- 一键继续：从列表跳转到报告/结果入口
+
+---
+
+## 2. Entry（入口）
+- 首页（/）：Smart Resume Banner
+- /lookup：Device Tab（默认）
+
+---
+
+## 3. Output（输出）
+- 同设备二次访问时，用户能看到“继续查看/历史记录”
+- 用户点一次即可回到报告/结果入口
+- /lookup 的 Device Tab 至少能展示 latest_attempt
+
+---
+
+## 4. Edge Cases（边界条件）
+- 本地记录为空：显示默认“开始测试”态
+- 本地记录存在但后端查不到：提示“记录已失效/已清理”，并提供重新开始
+- 多条记录：展示最近 N 条（N 可先固定，比如 5）
+- 用户主动清除缓存：自然回到默认态
+
+---
+
+## 5. Acceptance（验收步骤：必须能 Demo）
+1) 在同设备完成一次测试，进入结果页
+2) 关闭页面/浏览器标签
+3) 重新打开首页（/）或 /lookup
+4) 看到 Resume Banner 或 Device 列表
+5) 点击继续查看 → 打开报告/结果入口 ✅
+
+---
+
+## 6. Non-goals（本 Issue 不做）
+- 跨设备同步（手机号/邮箱）
+- 复杂历史筛选/排序（后置）

--- a/docs/product/issues/tp5-issue-c-anti-loss-hook.md
+++ b/docs/product/issues/tp5-issue-c-anti-loss-hook.md
@@ -1,0 +1,55 @@
+# TP5 Issue C: 防丢失 Hook（结果/支付/离场）+ “复制票据码/引导绑定”UI（P0）
+> Doc: docs/product/issues/tp5-issue-c-anti-loss-hook.md  
+> Related PRD: docs/product/report-lookup-prd.md (Section 0.2 / 5.1.2 / 7.2)  
+> Priority: P0 (Phase A)
+
+---
+
+## 1. Scope（做什么）
+实现“防丢失 Hook”的最小闭环：
+- 结果生成完成后（必做）：弹出/浮层提示用户“复制票据码”
+- 主 CTA：复制 Ticket Code
+- 次 CTA：引导绑定手机号/邮箱（Phase A 可只做按钮与门禁位置，不要求打通）
+- PIPL 门禁：任何“手机号相关动作”必须先勾选协议（Phase A 落文案+阻断）
+
+> Phase A 只要求：强提示出现 + 可复制 + 门禁逻辑位置明确且可验收。
+
+---
+
+## 2. Triggers（触发点）
+- 必做：Result Created（loading 结束后的第一次进入结果页）
+- 可选（Phase A 可不实现但应在 UI/文档预留）：
+  - 支付成功
+  - Exit Intent（PC 关闭意图；移动端停留>30s 无操作）
+
+---
+
+## 3. Output（输出）
+- 用户明确看到“防丢失提示”
+- 点击“复制票据码”成功（toast/反馈）
+- UI 中清晰展示：绑定手机号/发送验证码前必须先勾选《隐私协议》《用户服务协议》
+
+---
+
+## 4. PIPL Gate Acceptance（门禁验收口径）
+- 未勾选协议时：
+  - 点击“绑定手机号/获取手机号/发送验证码” → 必须被阻断
+  - 出现提示（弹窗/抖动/inline error）“请先阅读并同意…”
+- 已勾选协议时：
+  - 允许进入下一步（Phase A 允许只进入“下一步 UI”，不要求后端成功）
+
+---
+
+## 5. Acceptance（验收步骤：必须能 Demo）
+1) 完成一次测试 → 进入结果页
+2) 看到防丢失 Hook（强提示）
+3) 点击复制票据码 → 成功反馈 ✅
+4) 未勾选协议时尝试触发手机号动作 → 被阻断且提示 ✅
+5) 勾选协议后再次触发 → 进入下一步 UI（Phase A 允许不联通后端）✅
+
+---
+
+## 6. Non-goals（本 Issue 不做）
+- 短信服务接入与真实验证码验证（Phase B）
+- 平台一键取号真实换取手机号（Phase B）
+- 邮箱 Magic Link 发送（Phase D）


### PR DESCRIPTION
Links: #99（并贴上这三个 md 文件路径）

•	docs/product/issues/tp5-issue-a-ticket-code.md
•	docs/product/issues/tp5-issue-b-device-resume.md
•	docs/product/issues/tp5-issue-c-anti-loss-hook.md