### PR TITLE
feat(tp5): ticket_code generate + lookup endpoint (phase-a p0)

### DIFF
--- a/backend/app/Http/Controllers/LookupController.php
+++ b/backend/app/Http/Controllers/LookupController.php
@@ -1,0 +1,62 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\Attempt;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+
+class LookupController extends Controller
+{
+    /**
+     * GET /api/v0.2/lookup/ticket/{code}
+     *
+     * Phase A (P0):
+     * - validate ticket code format: ^FMT-[A-Z0-9]{8}$
+     * - lookup attempts.ticket_code
+     * - return attempt_id + API entrypoints
+     */
+    public function lookupTicket(Request $request, string $code): JsonResponse
+    {
+        $raw = trim($code);
+        $normalized = strtoupper($raw);
+
+        // 1) format validation
+        if (!preg_match('/^FMT-[A-Z0-9]{8}$/', $normalized)) {
+            return response()->json([
+                'ok' => false,
+                'error' => 'invalid_format',
+                'message' => 'ticket_code format invalid (expected FMT-XXXXXXXX).',
+            ], 422);
+        }
+
+        // 2) lookup
+        $attempt = Attempt::query()
+            ->where('ticket_code', $normalized)
+            ->first();
+
+        // 3) not found
+        if (!$attempt) {
+            return response()->json([
+                'ok' => false,
+                'error' => 'not_found',
+                'message' => 'ticket_code not found.',
+            ], 404);
+        }
+
+        $id = $attempt->id;
+
+        // 4) success payload (Phase A: just return entrypoints)
+        return response()->json([
+            'ok' => true,
+            'attempt_id' => $id,
+            'ticket_code' => $attempt->ticket_code,
+            'result_api' => "/api/v0.2/attempts/{$id}/result",
+            'report_api' => "/api/v0.2/attempts/{$id}/report",
+
+            // Optional placeholders (Phase A can keep null)
+            'result_page' => null,
+            'report_page' => null,
+        ]);
+    }
+}

--- a/backend/database/migrations/2026_01_17_040640_add_ticket_code_to_attempts_table.php
+++ b/backend/database/migrations/2026_01_17_040640_add_ticket_code_to_attempts_table.php
@@ -1,0 +1,30 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('attempts', function (Blueprint $table) {
+            // Phase A: nullable for existing rows; new attempts will be auto-generated in model booted()
+            // Format expected: FMT-XXXXXXXX (12 chars), keep some headroom.
+            $table->string('ticket_code', 20)
+                ->nullable()
+                ->after('id');
+
+            // Name the unique index explicitly for stable rollback across drivers.
+            $table->unique('ticket_code', 'attempts_ticket_code_unique');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('attempts', function (Blueprint $table) {
+            $table->dropUnique('attempts_ticket_code_unique');
+            $table->dropColumn('ticket_code');
+        });
+    }
+};

--- a/backend/routes/api.php
+++ b/backend/routes/api.php
@@ -5,6 +5,7 @@ use Illuminate\Support\Facades\Route;
 
 use App\Http\Controllers\MbtiController;
 use App\Http\Controllers\EventController;
+use App\Http\Controllers\LookupController;
 use App\Http\Controllers\API\V0_2\ShareController;
 
 /*
@@ -41,6 +42,10 @@ Route::prefix("v0.2")->group(function () {
     Route::get("/attempts/{id}/result", [MbtiController::class, "getResult"]);
     Route::get("/attempts/{id}/report", [MbtiController::class, "getReport"]);
     Route::get("/attempts/{id}/share",  [MbtiController::class, "getShare"]);
+
+    // ✅ 6.5) Ticket Code Lookup（Phase A P0）
+    // GET /api/v0.2/lookup/ticket/FMT-XXXXXXXX
+    Route::get("/lookup/ticket/{code}", [LookupController::class, "lookupTicket"]);
 
     // ✅ 7) Share Click：你要的入口（命中 ShareController@click）
     // 访问路径：POST /api/v0.2/shares/{shareId}/click


### PR DESCRIPTION
## What
Phase A (TP5-A) P0: Ticket Code end-to-end
- Generate `ticket_code` on Attempt creating
- Add lookup endpoint: `GET /api/v0.2/lookup/ticket/{code}`

## Evidence (curl)
```bash
curl -sS "http://127.0.0.1:18000/api/v0.2/lookup/ticket/FMT-XDPAOWEU" | jq .

{
  "ok": true,
  "attempt_id": "056f3b52-c346-4fef-a392-d44d03914b4e",
  "ticket_code": "FMT-XDPAOWEU",
  "result_api": "/api/v0.2/attempts/056f3b52-c346-4fef-a392-d44d03914b4e/result",
  "report_api": "/api/v0.2/attempts/056f3b52-c346-4fef-a392-d44d03914b4e/report",
  "result_page": null,
  "report_page": null
}

Issue
	•	Closes #101 (or Related: #101)