### PR TITLE
feat(tp5): phase-b phone otp + token gate + me attempts

### DIFF
--- a/backend/app/Http/Controllers/API/V0_2/AuthPhoneController.php
+++ b/backend/app/Http/Controllers/API/V0_2/AuthPhoneController.php
@@ -1,0 +1,334 @@
+<?php
+
+namespace App\Http\Controllers\API\V0_2;
+
+use App\Http\Controllers\Controller;
+use App\Services\Account\AssetCollector;
+use App\Services\Auth\FmTokenService;
+use App\Services\Auth\PhoneOtpService;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Support\Facades\DB;
+
+class AuthPhoneController extends Controller
+{
+    /**
+     * POST /api/v0.2/auth/phone/send_code
+     * body:
+     *  - phone (string)  必填
+     *  - scene (string)  可选，默认 "login"
+     *  - anon_id (string) 可选（用于归集）
+     *  - device_key (string) 可选（预留）
+     *  - consent (bool/accepted) 必填（PIPL 强制勾选）
+     */
+    public function sendCode(Request $request)
+    {
+        $this->mergeConsent($request);
+
+        $data = $request->validate([
+            'phone'    => ['required', 'string', 'max:32'],
+            'scene'    => ['nullable', 'string', 'max:32'],
+            'anon_id'  => ['nullable', 'string', 'max:128'],
+            'device_key' => ['nullable', 'string', 'max:256'],
+            'consent'  => ['accepted'], // ✅ 强制勾选
+        ]);
+
+        $phone = $this->normalizePhone((string) $data['phone']);
+        $scene = (string) ($data['scene'] ?? 'login');
+
+        /** @var PhoneOtpService $otp */
+        $otp = app(PhoneOtpService::class);
+
+        $ip = (string) ($request->ip() ?? '');
+        $deviceKey = isset($data['device_key']) ? (string) $data['device_key'] : null;
+
+        try {
+            $res = $otp->send($phone, $scene, $ip, $deviceKey);
+            // 约定：$res 至少包含 ttl_seconds；dev_mode 可包含 dev_code
+        } catch (\Throwable $e) {
+            // 这里统一按“限频/风控”处理
+            return response()->json([
+                'ok' => false,
+                'error' => 'OTP_SEND_FAILED',
+                'message' => $e->getMessage(),
+            ], 429);
+        }
+
+        $out = [
+            'ok' => true,
+            'phone' => $phone,
+            'scene' => $scene,
+            'ttl_seconds' => (int) ($res['ttl_seconds'] ?? 300),
+        ];
+
+        // ✅ DEV 可回传验证码（生产不要回传）
+        if (!empty($res['dev_code'])) {
+            $out['dev_code'] = (string) $res['dev_code'];
+        }
+
+        return response()->json($out);
+    }
+
+    /**
+     * POST /api/v0.2/auth/phone/verify
+     * body:
+     *  - phone (string) 必填
+     *  - code  (string) 必填
+     *  - scene (string) 可选，默认 "login"
+     *  - anon_id (string) 可选（用于归集）
+     *  - device_key (string) 可选（预留）
+     *  - consent (bool/accepted) 必填（PIPL 强制勾选）
+     *
+     * 成功：
+     *  - 签发 fm_token（统一口径）
+     *  - 触发最小归集：appendByAnonId(userId, anonId)
+     */
+    public function verify(Request $request)
+    {
+        $this->mergeConsent($request);
+
+        $data = $request->validate([
+            'phone'     => ['required', 'string', 'max:32'],
+            'code'      => ['required', 'string', 'max:16'],
+            'scene'     => ['nullable', 'string', 'max:32'],
+            'anon_id'   => ['nullable', 'string', 'max:128'],
+            'device_key'=> ['nullable', 'string', 'max:256'],
+            'consent'   => ['accepted'], // ✅ 强制勾选
+        ]);
+
+        $phone = $this->normalizePhone((string) $data['phone']);
+        $code  = trim((string) $data['code']);
+        $scene = (string) ($data['scene'] ?? 'login');
+
+        /** @var PhoneOtpService $otp */
+        $otp = app(PhoneOtpService::class);
+
+        $res = $otp->verify($phone, $code, $scene);
+
+$isOk = is_array($res) && (($res['ok'] ?? false) === true);
+if (!$isOk) {
+    $error = is_array($res) ? (string)($res['error'] ?? 'OTP_INVALID') : 'OTP_INVALID';
+    $msg   = is_array($res) ? (string)($res['message'] ?? 'Invalid code.') : 'Invalid code.';
+
+    // MVP：状态码简单映射
+    $status = 422;
+    if ($error === 'OTP_MISSING') $status = 410;   // expired/not found
+    if ($error === 'OTP_LOCKED')  $status = 429;   // too many fails
+
+    return response()->json([
+        'ok' => false,
+        'error' => $error,
+        'message' => $msg,
+    ], $status);
+}
+
+        $anonId = isset($data['anon_id']) ? $this->sanitizeAnonId((string) $data['anon_id']) : null;
+
+        // ✅ 找/建用户（MVP：按 phone 唯一）
+        [$userId, $userPayload] = $this->findOrCreateUserByPhone($phone, $anonId);
+
+        // ✅ 归集（MVP：只做 anon_id -> user 的 APPEND）
+        try {
+            if (is_string($anonId) && $anonId !== '') {
+                /** @var AssetCollector $collector */
+                $collector = app(AssetCollector::class);
+                $collector->appendByAnonId((string) $userId, (string) $anonId);
+            }
+        } catch (\Throwable $e) {
+            // 归集失败不挡登录，但要可观测
+            // 你可以在 AssetCollector 里打日志，这里不强行 Log 依赖
+        }
+
+        // ✅ 统一签发 token
+        /** @var FmTokenService $tokenSvc */
+        $tokenSvc = app(FmTokenService::class);
+        $issued = $tokenSvc->issueForUser((string) $userId, [
+    'provider' => 'phone',
+    'phone' => $phone,
+    'anon_id' => $anonId,
+]);
+
+        return response()->json([
+            'ok' => true,
+            'token' => (string) ($issued['token'] ?? ''),
+            'expires_at' => $issued['expires_at'] ?? null,
+            'user' => $userPayload,
+        ]);
+    }
+
+    // ------------------------------------------------------------
+    // Helpers
+    // ------------------------------------------------------------
+
+    /**
+     * 简单 phone 归一化：
+     * - 11 位大陆手机号 => +86XXXXXXXXXXX
+     * - 已带 + 的保持
+     * - 其它保持原样（MVP）
+     */
+    private function normalizePhone(string $raw): string
+    {
+        $s = trim($raw);
+        $s = str_replace([' ', '-', '(', ')'], '', $s);
+
+        if ($s === '') return $s;
+
+        if ($s[0] === '+') {
+            return $s;
+        }
+
+        // CN 11-digit
+        if (preg_match('/^1\d{10}$/', $s)) {
+            return '+86' . $s;
+        }
+
+        return $s;
+    }
+
+    private function mergeConsent(Request $request): void
+    {
+        $raw = $request->input('consent', null);
+        if ($raw === null) {
+            $raw = $request->input('agree', null);
+        }
+
+        $request->merge([
+            'consent' => $this->boolish($raw),
+        ]);
+    }
+
+    private function boolish($v): bool
+    {
+        if (is_bool($v)) return $v;
+        if ($v === null) return false;
+        $s = strtolower(trim((string) $v));
+        return in_array($s, ['1', 'true', 'yes', 'on'], true);
+    }
+
+    /**
+     * anon_id 防污染（沿用你事件那套黑名单思路，MVP 简化版）
+     */
+    private function sanitizeAnonId(string $anonId): ?string
+    {
+        $s = trim($anonId);
+        if ($s === '') return null;
+
+        $lower = mb_strtolower($s, 'UTF-8');
+        $badWords = [
+            'todo',
+            'placeholder',
+            'fixme',
+            'tbd',
+            '把你查到的anon_id填这里',
+            '把你查到的 anon_id 填这里',
+            '填这里',
+        ];
+
+        foreach ($badWords as $bad) {
+            $b = mb_strtolower(trim((string) $bad), 'UTF-8');
+            if ($b !== '' && mb_strpos($lower, $b) !== false) {
+                return null;
+            }
+        }
+
+        return $s;
+    }
+
+    /**
+     * 兼容不同 users 表结构的“最小可跑”写法：
+     * - 优先用 users.uid 作为 userId（如果存在）
+     * - 否则用 users.id
+     * - phone 字段优先写 phone_e164，其次 phone
+     * - verified 字段优先写 phone_verified_at，其次 verified_at（如果存在）
+     */
+    private function findOrCreateUserByPhone(string $phoneE164, ?string $anonId): array
+    {
+        $hasUid = Schema::hasColumn('users', 'uid');
+        $pk     = $hasUid ? 'uid' : 'id';
+
+        $hasPhoneE164 = Schema::hasColumn('users', 'phone_e164');
+        $hasPhone     = Schema::hasColumn('users', 'phone');
+
+        $phoneCol = $hasPhoneE164 ? 'phone_e164' : ($hasPhone ? 'phone' : null);
+
+        $query = DB::table('users');
+        if ($phoneCol) {
+            $query->where($phoneCol, $phoneE164);
+        } else {
+            // 实在没有 phone 字段：MVP 只能按 anon_id 找（很弱），这里直接创建一个“孤儿账号”
+            $query->where($pk, '__no_match__');
+        }
+
+        $row = $query->first();
+
+        if ($row) {
+            $userId = (string) ($row->{$pk} ?? '');
+            return [$userId, $this->buildUserPayloadFromRow($row, $pk, $phoneCol)];
+        }
+
+        // create
+        $insert = [];
+
+        if ($hasUid) {
+            $insert['uid'] = 'u_' . bin2hex(random_bytes(5));
+        }
+
+        if ($phoneCol) {
+            $insert[$phoneCol] = $phoneE164;
+        }
+
+        if ($anonId && Schema::hasColumn('users', 'anon_id')) {
+            $insert['anon_id'] = $anonId;
+        }
+
+        if (Schema::hasColumn('users', 'phone_verified_at')) {
+            $insert['phone_verified_at'] = now();
+        } elseif (Schema::hasColumn('users', 'verified_at')) {
+            $insert['verified_at'] = now();
+        }
+
+        if (Schema::hasColumn('users', 'created_at')) $insert['created_at'] = now();
+        if (Schema::hasColumn('users', 'updated_at')) $insert['updated_at'] = now();
+
+        // 如果是默认 Laravel users 表，可能有 name/email/password NOT NULL
+        // 这里尽量做兜底（不会覆盖你自定义结构）
+        if (Schema::hasColumn('users', 'name') && !array_key_exists('name', $insert)) {
+            $insert['name'] = 'user';
+        }
+        if (Schema::hasColumn('users', 'email') && !array_key_exists('email', $insert)) {
+            // 避免 unique 冲突
+            $insert['email'] = 'phone_' . md5($phoneE164) . '@example.local';
+        }
+        if (Schema::hasColumn('users', 'password') && !array_key_exists('password', $insert)) {
+            $insert['password'] = bcrypt(bin2hex(random_bytes(8)));
+        }
+
+        DB::table('users')->insert($insert);
+
+        // re-fetch
+        $row2 = DB::table('users')
+            ->when($phoneCol !== null, fn($q) => $q->where($phoneCol, $phoneE164))
+            ->orderByDesc($hasUid ? 'created_at' : 'id')
+            ->first();
+
+        $userId = $row2 ? (string) ($row2->{$pk} ?? '') : (string) ($insert[$pk] ?? '');
+
+        return [$userId, $this->buildUserPayloadFromRow($row2 ?? (object) $insert, $pk, $phoneCol)];
+    }
+
+    private function buildUserPayloadFromRow(object $row, string $pk, ?string $phoneCol): array
+    {
+        $uid = (string) ($row->{$pk} ?? '');
+        $phone = $phoneCol ? (string) ($row->{$phoneCol} ?? '') : null;
+
+        $anonId = property_exists($row, 'anon_id') ? (string) ($row->anon_id ?? '') : null;
+        if ($anonId === '') $anonId = null;
+
+        return [
+            'uid' => $uid,                // ✅ 统一对外叫 uid（即使底层 pk 是 id）
+            'bound' => true,
+            'phone' => ($phone !== '' ? $phone : null),
+            'anon_id' => $anonId,
+        ];
+    }
+}

--- a/backend/app/Http/Controllers/API/V0_2/MeController.php
+++ b/backend/app/Http/Controllers/API/V0_2/MeController.php
@@ -1,0 +1,126 @@
+<?php
+
+namespace App\Http\Controllers\API\V0_2;
+
+use App\Http\Controllers\Controller;
+use App\Models\Attempt;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Schema;
+
+class MeController extends Controller
+{
+    /**
+     * GET /api/v0.2/me/attempts
+     * Query:
+     *  - page (int) default 1
+     *  - per_page (int) default 20, max 50
+     *
+     * 依赖：FmTokenAuth 中间件
+     * - 期望从 request attributes 读到 fm_user_id
+     * - 或者 auth()->id()
+     */
+    public function attempts(Request $request)
+    {
+        $userId = $this->resolveUserId($request);
+        if (!$userId) {
+            return response()->json([
+                'ok' => false,
+                'error' => 'unauthorized',
+                'message' => 'Missing or invalid fm_token.',
+            ], 401);
+        }
+
+        $page = max(1, (int) $request->query('page', 1));
+        $perPage = (int) $request->query('per_page', 20);
+        if ($perPage <= 0) $perPage = 20;
+        if ($perPage > 50) $perPage = 50;
+
+        $q = Attempt::query()->where('user_id', (string) $userId);
+
+        // 优先按 submitted_at 排序（如果有），否则 created_at
+        if (Schema::hasColumn('attempts', 'submitted_at')) {
+            $q->orderByDesc('submitted_at');
+        } else {
+            $q->orderByDesc('created_at');
+        }
+        $q->orderByDesc('id');
+
+        $p = $q->paginate($perPage, ['*'], 'page', $page);
+
+        $items = [];
+        foreach ($p->items() as $a) {
+            /** @var Attempt $a */
+            $items[] = $this->presentAttempt($a);
+        }
+
+        return response()->json([
+            'ok' => true,
+            'user_id' => (string) $userId,
+            'items' => $items,
+            'pagination' => [
+                'page' => $p->currentPage(),
+                'per_page' => $p->perPage(),
+                'total' => $p->total(),
+                'last_page' => $p->lastPage(),
+            ],
+        ]);
+    }
+
+    private function resolveUserId(Request $request): ?string
+    {
+        // 1) middleware 写入 attributes（推荐）
+        $uid = $request->attributes->get('fm_user_id');
+        if (is_string($uid) && trim($uid) !== '') {
+            return trim($uid);
+        }
+
+        // 2) 或者 middleware 登录了 Laravel Auth
+        $authId = auth()->id();
+        if ($authId !== null && (string)$authId !== '') {
+            return (string) $authId;
+        }
+
+        // 3) 或者 request->user()
+        $u = $request->user();
+        if ($u && isset($u->id)) {
+            return (string) $u->id;
+        }
+
+        return null;
+    }
+
+    private function presentAttempt(Attempt $a): array
+    {
+        // 只返回对外需要的字段，避免把 answers_json 等隐私字段带出去
+        $out = [
+            'attempt_id' => (string) ($a->id ?? ''),
+            'scale_code' => (string) ($a->scale_code ?? 'MBTI'),
+            'scale_version' => (string) ($a->scale_version ?? 'v0.2'),
+            'type_code' => (string) ($a->type_code ?? ''),
+            'region' => (string) ($a->region ?? 'CN_MAINLAND'),
+            'locale' => (string) ($a->locale ?? 'zh-CN'),
+        ];
+
+        // 可选字段（存在就带）
+        if (isset($a->ticket_code)) {
+            $out['ticket_code'] = (string) $a->ticket_code;
+        }
+
+        if (isset($a->submitted_at) && $a->submitted_at) {
+            $out['submitted_at'] = (string) $a->submitted_at;
+        } elseif (isset($a->created_at) && $a->created_at) {
+            $out['submitted_at'] = (string) $a->created_at;
+        } else {
+            $out['submitted_at'] = null;
+        }
+
+        // 轻量状态（前端可用来展示“简版/完整版/是否可打开”等）
+        if (property_exists($a, 'ticket_code') && (string)($a->ticket_code ?? '') !== '') {
+            $out['lookup_key'] = (string) $a->ticket_code;
+        } else {
+            $out['lookup_key'] = (string) ($a->id ?? '');
+        }
+
+        return $out;
+    }
+}

--- a/backend/app/Http/Middleware/FmTokenAuth.php
+++ b/backend/app/Http/Middleware/FmTokenAuth.php
@@ -5,6 +5,7 @@ namespace App\Http\Middleware;
 use Closure;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
 use Symfony\Component\HttpFoundation\Response;
 
 class FmTokenAuth
@@ -15,13 +16,10 @@ class FmTokenAuth
      * Expect:
      *   Authorization: Bearer fm_xxxxx
      *
-     * Phase A+:
+     * Phase B:
      * - validate fm_token format
-     * - resolve anon_id from fm_tokens table
-     * - attach fm_token / fm_anon_id to request attributes
-     *
-     * Compatibility:
-     * - if DB mapping missing, allow X-FM-Anon-Id as temporary fallback (optional)
+     * - resolve user_id from fm_tokens table
+     * - attach fm_token / fm_user_id to request attributes
      */
     public function handle(Request $request, Closure $next): Response
     {
@@ -42,73 +40,73 @@ class FmTokenAuth
             );
 
         if (!$isOk) {
-            return response()->json([
-                'ok'      => false,
-                'error'   => 'UNAUTHORIZED',
-                'message' => 'Missing or invalid fm_token. Please login.',
-            ], 401)->withHeaders([
-                'WWW-Authenticate' => 'Bearer realm="Fermat API", error="invalid_token"',
-            ]);
+            return $this->unauthorizedResponse();
         }
 
         // ✅ Always attach token for downstream use
         $request->attributes->set('fm_token', $token);
 
-        // ✅ Resolve identity from DB: fm_tokens.token -> anon_id
+        // ✅ Resolve identity from DB: fm_tokens.token -> user_id
         $row = DB::table('fm_tokens')
-            ->select(['anon_id', 'expires_at'])
             ->where('token', $token)
             ->first();
 
-        $anonId = $row && !empty($row->anon_id) ? trim((string)$row->anon_id) : '';
+        if (!$row) {
+            return $this->unauthorizedResponse();
+        }
 
         // Optional: expires check (目前你是 null，不会触发)
         if ($row && !empty($row->expires_at)) {
             $exp = strtotime((string)$row->expires_at);
             if ($exp !== false && $exp < time()) {
-                return response()->json([
-                    'ok'      => false,
-                    'error'   => 'UNAUTHORIZED',
-                    'message' => 'fm_token expired. Please login again.',
-                ], 401)->withHeaders([
-                    'WWW-Authenticate' => 'Bearer realm="Fermat API", error="invalid_token"',
-                ]);
+                return $this->unauthorizedResponse();
             }
         }
 
-        // ✅ Compatibility fallback (可选)：如果 DB 里没有映射，允许旧 header 临时兜底
-        if ($anonId === '') {
-            $anonId = trim((string) $request->header('X-FM-Anon-Id', ''));
-            if ($anonId === '') $anonId = trim((string) $request->header('X-Anon-Id', ''));
-            if ($anonId === '') $anonId = trim((string) $request->header('X-Device-Anon-Id', ''));
-        }
-
-        if ($anonId === '') {
-            return response()->json([
-                'ok'      => false,
-                'error'   => 'UNAUTHORIZED',
-                'message' => 'Invalid fm_token (no identity). Please login again.',
-            ], 401)->withHeaders([
-                'WWW-Authenticate' => 'Bearer realm="Fermat API", error="invalid_token"',
-            ]);
+        $userId = $this->resolveUserId($row);
+        if ($userId === '') {
+            return $this->unauthorizedResponse();
         }
 
         // basic sanity
-        if (strlen($anonId) > 128) {
-            return response()->json([
-                'ok'      => false,
-                'error'   => 'UNAUTHORIZED',
-                'message' => 'Invalid identity on token.',
-            ], 401);
+        if (strlen($userId) > 128) {
+            return $this->unauthorizedResponse();
         }
 
-        // ✅ Attach canonical + fm_* aliases so controllers can read either
-        $request->attributes->set('anon_id', $anonId);
-        $request->attributes->set('fm_anon_id', $anonId);
-
-        // Phase B 才会用到 user_id，这里先留空位
-        // $request->attributes->set('fm_user_id', $userId);
+        $request->attributes->set('fm_user_id', $userId);
 
         return $next($request);
+    }
+
+    private function resolveUserId(object $row): string
+    {
+        if (Schema::hasColumn('fm_tokens', 'user_id')) {
+            return trim((string) ($row->user_id ?? ''));
+        }
+
+        if (Schema::hasColumn('fm_tokens', 'anon_id')) {
+            return trim((string) ($row->anon_id ?? ''));
+        }
+
+        $candidates = ['uid', 'user_uid', 'user'];
+        foreach ($candidates as $c) {
+            if (property_exists($row, $c)) {
+                $val = trim((string) ($row->{$c} ?? ''));
+                if ($val !== '') return $val;
+            }
+        }
+
+        return '';
+    }
+
+    private function unauthorizedResponse(): Response
+    {
+        return response()->json([
+            'ok'      => false,
+            'error'   => 'UNAUTHORIZED',
+            'message' => 'Missing or invalid fm_token. Please login.',
+        ], 401)->withHeaders([
+            'WWW-Authenticate' => 'Bearer realm="Fermat API", error="invalid_token"',
+        ]);
     }
 }

--- a/backend/app/Http/Requests/V0_2/SendPhoneCodeRequest.php
+++ b/backend/app/Http/Requests/V0_2/SendPhoneCodeRequest.php
@@ -1,0 +1,140 @@
+<?php
+
+namespace App\Http\Requests\V0_2;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class SendPhoneCodeRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    /**
+     * 统一把 phone 规范化成 E.164 并写回 request
+     */
+    protected function prepareForValidation(): void
+    {
+        $raw = trim((string) $this->input('phone', ''));
+
+        $normalized = $this->normalizeToE164($raw);
+
+        $this->merge([
+            'phone' => $normalized ?? $raw,
+            'scene' => trim((string) $this->input('scene', 'login')),
+            'consent' => $this->boolish(
+                $this->input('consent', $this->input('agree', null))
+            ),
+            'device_key' => $this->input('device_key', null),
+        ]);
+    }
+
+    public function rules(): array
+    {
+        return [
+            // ✅ PIPL：必须显式同意
+            'consent' => ['required', 'accepted'],
+
+            // phone：要求 E.164（+xx...）或 +86...
+            'phone' => ['required', 'string', 'max:32', 'regex:/^\+[1-9]\d{6,20}$/'],
+
+            // scene：避免被滥用做其它业务场景
+            'scene' => ['nullable', 'string', 'in:login,bind,lookup'],
+
+            // 可选：设备 key（以后做 device 归集/限频更精确）
+            'device_key' => ['nullable', 'string', 'max:128'],
+        ];
+    }
+
+    public function messages(): array
+    {
+        return [
+            'consent.required' => '请先阅读并同意隐私协议与用户服务协议。',
+            'consent.accepted' => '请先阅读并同意隐私协议与用户服务协议。',
+            'phone.required' => '请输入手机号。',
+            'phone.regex'    => '手机号格式不正确（需为 +86xxxxxxxxxxx 或其它 E.164）。',
+            'scene.in'       => 'scene 不合法。',
+        ];
+    }
+
+    public function attributes(): array
+    {
+        return [
+            'phone' => '手机号',
+            'consent' => '协议勾选',
+            'scene' => '场景',
+        ];
+    }
+
+    /**
+     * 规范化后给 controller 使用
+     */
+    public function phoneE164(): string
+    {
+        return (string) $this->validated()['phone'];
+    }
+
+    public function scene(): string
+    {
+        $v = $this->validated()['scene'] ?? 'login';
+        return is_string($v) && $v !== '' ? $v : 'login';
+    }
+
+    public function deviceKey(): ?string
+    {
+        $v = $this->validated()['device_key'] ?? null;
+        $v = is_string($v) ? trim($v) : null;
+        return ($v !== '') ? $v : null;
+    }
+
+    // --------------------
+    // helpers
+    // --------------------
+
+    private function boolish($v): bool
+    {
+        if (is_bool($v)) return $v;
+        if ($v === null) return false;
+        $s = strtolower(trim((string) $v));
+        return in_array($s, ['1', 'true', 'yes', 'on'], true);
+    }
+
+    /**
+     * 支持：
+     * - +8613812345678 -> 原样
+     * - 13812345678 -> +8613812345678
+     * - 008613812345678 / 08613812345678 -> +8613812345678（简单处理）
+     * - 其他国家号：要求用户直接传 E.164（+xx...）
+     */
+    private function normalizeToE164(string $raw): ?string
+    {
+        if ($raw === '') return null;
+
+        // 去掉常见分隔符
+        $s = preg_replace('/[\s\-\(\)]/', '', $raw);
+        $s = trim((string) $s);
+        if ($s === '') return null;
+
+        // 0086 / 086 前缀转 +
+        if (str_starts_with($s, '0086')) {
+            $s = '+86' . substr($s, 4);
+        } elseif (str_starts_with($s, '086')) {
+            $s = '+86' . substr($s, 3);
+        }
+
+        // 已经是 + 开头：直接校验大致格式
+        if (str_starts_with($s, '+')) {
+            if (preg_match('/^\+[1-9]\d{6,20}$/', $s)) return $s;
+            return null;
+        }
+
+        // 纯数字：按中国大陆 11 位做 +86
+        if (preg_match('/^1\d{10}$/', $s)) {
+            return '+86' . $s;
+        }
+
+        // 其他情况不做猜测
+        return null;
+    }
+}

--- a/backend/app/Http/Requests/V0_2/VerifyPhoneCodeRequest.php
+++ b/backend/app/Http/Requests/V0_2/VerifyPhoneCodeRequest.php
@@ -1,0 +1,130 @@
+<?php
+
+namespace App\Http\Requests\V0_2;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class VerifyPhoneCodeRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    protected function prepareForValidation(): void
+    {
+        $rawPhone = trim((string) $this->input('phone', ''));
+        $normalized = $this->normalizeToE164($rawPhone);
+
+        $this->merge([
+            'phone' => $normalized ?? $rawPhone,
+            'code'  => trim((string) $this->input('code', '')),
+            'scene' => trim((string) $this->input('scene', 'login')),
+            'consent' => $this->boolish(
+                $this->input('consent', $this->input('agree', null))
+            ),
+            'anon_id' => $this->input('anon_id', null),         // ✅ 归集用（appendByAnonId）
+            'device_key' => $this->input('device_key', null),   // ✅ 可选
+        ]);
+    }
+
+    public function rules(): array
+    {
+        return [
+            // ✅ PIPL：verify 也必须同意（避免绕过）
+            'consent' => ['required', 'accepted'],
+
+            'phone' => ['required', 'string', 'max:32', 'regex:/^\+[1-9]\d{6,20}$/'],
+            'code'  => ['required', 'string', 'regex:/^\d{4,8}$/'], // MVP：4~8 位都行；你服务里一般是 6 位
+
+            'scene' => ['nullable', 'string', 'in:login,bind,lookup'],
+
+            // ✅ 归集（MVP：anon_id）
+            'anon_id' => ['nullable', 'string', 'max:128'],
+
+            // 可选：设备 key
+            'device_key' => ['nullable', 'string', 'max:128'],
+        ];
+    }
+
+    public function messages(): array
+    {
+        return [
+            'consent.required' => '请先阅读并同意隐私协议与用户服务协议。',
+            'consent.accepted' => '请先阅读并同意隐私协议与用户服务协议。',
+            'phone.required' => '请输入手机号。',
+            'phone.regex'    => '手机号格式不正确（需为 +86xxxxxxxxxxx 或其它 E.164）。',
+            'code.required'  => '请输入验证码。',
+            'code.regex'     => '验证码格式不正确。',
+            'scene.in'       => 'scene 不合法。',
+        ];
+    }
+
+    public function phoneE164(): string
+    {
+        return (string) $this->validated()['phone'];
+    }
+
+    public function code(): string
+    {
+        return (string) $this->validated()['code'];
+    }
+
+    public function scene(): string
+    {
+        $v = $this->validated()['scene'] ?? 'login';
+        return is_string($v) && $v !== '' ? $v : 'login';
+    }
+
+    public function anonId(): ?string
+    {
+        $v = $this->validated()['anon_id'] ?? null;
+        $v = is_string($v) ? trim($v) : null;
+        return ($v !== '') ? $v : null;
+    }
+
+    public function deviceKey(): ?string
+    {
+        $v = $this->validated()['device_key'] ?? null;
+        $v = is_string($v) ? trim($v) : null;
+        return ($v !== '') ? $v : null;
+    }
+
+    // --------------------
+    // helpers
+    // --------------------
+
+    private function boolish($v): bool
+    {
+        if (is_bool($v)) return $v;
+        if ($v === null) return false;
+        $s = strtolower(trim((string) $v));
+        return in_array($s, ['1', 'true', 'yes', 'on'], true);
+    }
+
+    private function normalizeToE164(string $raw): ?string
+    {
+        if ($raw === '') return null;
+
+        $s = preg_replace('/[\s\-\(\)]/', '', $raw);
+        $s = trim((string) $s);
+        if ($s === '') return null;
+
+        if (str_starts_with($s, '0086')) {
+            $s = '+86' . substr($s, 4);
+        } elseif (str_starts_with($s, '086')) {
+            $s = '+86' . substr($s, 3);
+        }
+
+        if (str_starts_with($s, '+')) {
+            if (preg_match('/^\+[1-9]\d{6,20}$/', $s)) return $s;
+            return null;
+        }
+
+        if (preg_match('/^1\d{10}$/', $s)) {
+            return '+86' . $s;
+        }
+
+        return null;
+    }
+}

--- a/backend/app/Services/Account/AssetCollector.php
+++ b/backend/app/Services/Account/AssetCollector.php
@@ -1,0 +1,94 @@
+<?php
+
+namespace App\Services\Account;
+
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+class AssetCollector
+{
+    /**
+     * MVP：APPEND 归集（anon_id -> user_id）
+     * 规则：
+     * - 只更新 attempts.user_id IS NULL 且 attempts.anon_id = $anonId 的记录
+     * - 不做账号合并，不做双向同步
+     *
+     * @return array {updated:int}
+     */
+    public function appendByAnonId(string $userId, string $anonId): array
+    {
+        $userId = trim($userId);
+        $anonId = trim($anonId);
+
+        if ($userId === '' || $anonId === '') {
+            return ['updated' => 0];
+        }
+
+        if (!Schema::hasTable('attempts')) {
+            return ['updated' => 0];
+        }
+        if (!Schema::hasColumn('attempts', 'user_id')) {
+            // 你还没做 add_user_id_to_attempts_table 的话，这里不会炸
+            return ['updated' => 0];
+        }
+        if (!Schema::hasColumn('attempts', 'anon_id')) {
+            return ['updated' => 0];
+        }
+
+        $q = DB::table('attempts')
+            ->whereNull('user_id')
+            ->where('anon_id', $anonId);
+
+        $update = [
+            'user_id' => $userId,
+        ];
+
+        if (Schema::hasColumn('attempts', 'updated_at')) {
+            $update['updated_at'] = now();
+        }
+
+        $n = $q->update($update);
+
+        return ['updated' => (int) $n];
+    }
+
+    /**
+     * 可选：device_key_hash -> user_id（你后面有 device_key 再启用）
+     * @return array {updated:int}
+     */
+    public function appendByDeviceKeyHash(string $userId, string $deviceKeyHash): array
+    {
+        $userId = trim($userId);
+        $deviceKeyHash = trim($deviceKeyHash);
+
+        if ($userId === '' || $deviceKeyHash === '') {
+            return ['updated' => 0];
+        }
+
+        if (!Schema::hasTable('attempts')) return ['updated' => 0];
+        if (!Schema::hasColumn('attempts', 'user_id')) return ['updated' => 0];
+
+        // 兼容字段名
+        $col = null;
+        foreach (['device_key_hash', 'device_hash', 'device_key'] as $c) {
+            if (Schema::hasColumn('attempts', $c)) {
+                $col = $c;
+                break;
+            }
+        }
+        if ($col === null) return ['updated' => 0];
+
+        $q = DB::table('attempts')
+            ->whereNull('user_id')
+            ->where($col, $deviceKeyHash);
+
+        $update = ['user_id' => $userId];
+        if (Schema::hasColumn('attempts', 'updated_at')) {
+            $update['updated_at'] = now();
+        }
+
+        $n = $q->update($update);
+
+        return ['updated' => (int) $n];
+    }
+}

--- a/backend/app/Services/Auth/FmTokenService.php
+++ b/backend/app/Services/Auth/FmTokenService.php
@@ -1,0 +1,133 @@
+<?php
+
+namespace App\Services\Auth;
+
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Support\Str;
+
+class FmTokenService
+{
+    /**
+     * 统一签发 fm_token（给 wx_phone / phone_verify 共用）
+     *
+     * @param string $userId 你的主账号 id（建议用 users.uid；也兼容 users.id）
+     * @param array  $meta   可选：写入 meta_json 方便审计
+     *
+     * @return array {token: string, expires_at: string|null, user_id: string}
+     */
+    public function issueForUser(string $userId, array $meta = []): array
+    {
+        $userId = trim($userId);
+        if ($userId === '') {
+            throw new \InvalidArgumentException('userId is required');
+        }
+
+        $token = 'fm_' . (string) Str::uuid();
+
+        $ttlDays = (int) config('fap.fm_token_ttl_days', 30);
+        if ($ttlDays <= 0) $ttlDays = 30;
+
+        $expiresAt = now()->addDays($ttlDays);
+
+        $row = [
+            'token' => $token,
+        ];
+
+        // 兼容不同 fm_tokens 表字段命名
+        $userCol = $this->detectUserColumn();
+        if ($userCol !== null) {
+            $row[$userCol] = $userId;
+        }
+
+        if (!array_key_exists('anon_id', $row) && Schema::hasColumn('fm_tokens', 'anon_id')) {
+            $anonId = null;
+            if (isset($meta['anon_id']) && is_string($meta['anon_id'])) {
+                $anonId = trim($meta['anon_id']);
+            }
+            $row['anon_id'] = $anonId !== null && $anonId !== '' ? $anonId : $userId;
+        }
+
+        if (Schema::hasColumn('fm_tokens', 'expires_at')) {
+            $row['expires_at'] = $expiresAt;
+        }
+
+        if (Schema::hasColumn('fm_tokens', 'meta_json')) {
+            $row['meta_json'] = $meta;
+        }
+
+        if (Schema::hasColumn('fm_tokens', 'created_at')) $row['created_at'] = now();
+        if (Schema::hasColumn('fm_tokens', 'updated_at')) $row['updated_at'] = now();
+
+        // 有些表会有 id 主键
+        if (Schema::hasColumn('fm_tokens', 'id')) {
+            $row['id'] = (string) Str::uuid();
+        }
+
+        DB::table('fm_tokens')->insert($row);
+
+        return [
+            'token' => $token,
+            'expires_at' => Schema::hasColumn('fm_tokens', 'expires_at') ? $expiresAt->toIso8601String() : null,
+            'user_id' => $userId,
+        ];
+    }
+
+    /**
+     * 校验 token（给 FmTokenAuth 中间件用）
+     *
+     * @return array {ok: bool, user_id?: string, expires_at?: string}
+     */
+    public function validateToken(string $token): array
+    {
+        $token = trim($token);
+        if ($token === '' || !preg_match('/^fm_[0-9a-fA-F-]{36}$/', $token)) {
+            return ['ok' => false];
+        }
+
+        $q = DB::table('fm_tokens')->where('token', $token);
+
+        $row = $q->first();
+        if (!$row) {
+            return ['ok' => false];
+        }
+
+        $expiresAt = null;
+        if (property_exists($row, 'expires_at') && $row->expires_at) {
+            $expiresAt = (string) $row->expires_at;
+            try {
+                if (now()->greaterThan(\Illuminate\Support\Carbon::parse($row->expires_at))) {
+                    return ['ok' => false];
+                }
+            } catch (\Throwable $e) {
+                // expires_at 解析失败就当无效
+                return ['ok' => false];
+            }
+        }
+
+        $userCol = $this->detectUserColumn();
+        $uid = $userCol ? (string) ($row->{$userCol} ?? '') : '';
+        if ($uid === '') {
+            // 没有 user 字段也不算通过（否则 /me 无法知道是谁）
+            return ['ok' => false];
+        }
+
+        return [
+            'ok' => true,
+            'user_id' => $uid,
+            'expires_at' => $expiresAt,
+        ];
+    }
+
+    /**
+     * 自动识别 fm_tokens 里哪一列存 user id
+     */
+    private function detectUserColumn(): ?string
+    {
+        $candidates = ['user_id', 'uid', 'user_uid', 'user', 'anon_id'];
+        foreach ($candidates as $c) {
+            if (Schema::hasColumn('fm_tokens', $c)) return $c;
+        }
+        return null;
+    }
+}

--- a/backend/app/Services/Auth/PhoneOtpService.php
+++ b/backend/app/Services/Auth/PhoneOtpService.php
@@ -1,0 +1,201 @@
+<?php
+
+namespace App\Services\Auth;
+
+use Illuminate\Support\Facades\Cache;
+
+class PhoneOtpService
+{
+    /**
+     * MVP defaults (可后续移到 config/fap.php)
+     */
+    private int $ttlSeconds = 300;      // 5 min
+    private int $maxSendPerIp = 20;     // per hour
+    private int $maxSendPerPhone = 10;  // per hour
+    private int $maxFail = 8;           // per ttl window
+
+    /**
+     * 发送验证码：生成 code -> 写 cache -> 返回 (MVP: local/dev 可返回 dev_code)
+     */
+    public function send(string $phone, string $scene, string $ip = '', ?string $deviceKey = null): array
+    {
+        $scene = $this->normalizeScene($scene);
+        $p = $this->normalizePhone($phone);
+
+        // rate limit (MVP)
+        $this->throttleOrFail($p, $scene, $ip);
+
+        $code = $this->generateCode();
+
+        Cache::put($this->otpKey($p, $scene), $code, $this->ttlSeconds);
+        Cache::put($this->failKey($p, $scene), 0, $this->ttlSeconds);
+
+        $res = [
+            'ok'          => true,
+            'phone'       => $p,
+            'scene'       => $scene,
+            'ttl_seconds' => $this->ttlSeconds,
+        ];
+
+        // local/dev: 允许返回 dev_code 便于验收（不影响线上）
+        if ($this->allowDevCode()) {
+            $res['dev_code'] = $this->devCode() ?? $code;
+            // 如果配置了固定 dev code，就覆盖 cache，保证 verify 用同一个
+            if ($this->devCode()) {
+                Cache::put($this->otpKey($p, $scene), $this->devCode(), $this->ttlSeconds);
+            }
+        }
+
+        return $res;
+    }
+
+    /**
+     * 校验验证码：支持 local/dev 固定码；成功后清理 otp + fail
+     */
+    public function verify(string $phone, string $code, string $scene): array
+    {
+        $scene = $this->normalizeScene($scene);
+        $p = $this->normalizePhone($phone);
+
+        $code = trim((string) $code);
+
+        // local/dev: 固定码直通（MVP 验收用）
+        if ($this->allowDevCode()) {
+            $dev = $this->devCode();
+            if (is_string($dev) && $dev !== '' && hash_equals($dev, $code)) {
+                Cache::forget($this->otpKey($p, $scene));
+                Cache::forget($this->failKey($p, $scene));
+                return ['ok' => true, 'phone' => $p, 'scene' => $scene, 'via' => 'dev_code'];
+            }
+        }
+
+        $expected = Cache::get($this->otpKey($p, $scene));
+        if (!is_string($expected) || $expected === '') {
+            return ['ok' => false, 'error' => 'OTP_MISSING', 'message' => 'OTP expired or not found.'];
+        }
+
+        if (!hash_equals($expected, $code)) {
+            $fails = (int) Cache::get($this->failKey($p, $scene), 0);
+            $fails++;
+            Cache::put($this->failKey($p, $scene), $fails, $this->ttlSeconds);
+
+            if ($fails >= $this->maxFail) {
+                Cache::forget($this->otpKey($p, $scene));
+                return ['ok' => false, 'error' => 'OTP_LOCKED', 'message' => 'Too many failed attempts.'];
+            }
+
+            return ['ok' => false, 'error' => 'OTP_INVALID', 'message' => 'Invalid code.'];
+        }
+
+        Cache::forget($this->otpKey($p, $scene));
+        Cache::forget($this->failKey($p, $scene));
+
+        return ['ok' => true, 'phone' => $p, 'scene' => $scene, 'via' => 'cache'];
+    }
+
+    // ----------------------------
+    // Internal helpers
+    // ----------------------------
+
+    private function normalizeScene(string $scene): string
+    {
+        $s = strtolower(trim($scene));
+        return $s !== '' ? $s : 'login';
+    }
+
+    /**
+     * 关键：phone 归一化必须在 send/verify 两端一致
+     * - 去空格
+     * - 保留 + 和数字
+     * - 若没有 +，默认 +86（你 CN 主站 MVP）
+     */
+    private function normalizePhone(string $phone): string
+    {
+        $raw = trim($phone);
+        // keep digits and leading +
+        $raw = preg_replace('/[^\d\+]/', '', $raw) ?? '';
+        $raw = trim($raw);
+
+        if ($raw === '') return '';
+
+        if ($raw[0] !== '+') {
+            // MVP：默认中国区
+            $raw = '+86' . ltrim($raw, '0');
+        }
+
+        return $raw;
+    }
+
+    private function otpKey(string $phone, string $scene): string
+    {
+        return "otp:{$scene}:{$phone}";
+    }
+
+    private function failKey(string $phone, string $scene): string
+    {
+        return "otp:{$scene}:{$phone}:fail";
+    }
+
+    private function rateKeyIp(string $ip): string
+    {
+        return "otp:rate:ip:{$ip}";
+    }
+
+    private function rateKeyPhone(string $phone): string
+    {
+        return "otp:rate:phone:{$phone}";
+    }
+
+    private function throttleOrFail(string $phone, string $scene, string $ip): void
+    {
+        // ip limit (1h)
+        if ($ip !== '') {
+            $k = $this->rateKeyIp($ip);
+            $n = (int) Cache::get($k, 0);
+            if ($n >= $this->maxSendPerIp) {
+                abort(response()->json([
+                    'ok' => false,
+                    'error' => 'RATE_LIMITED',
+                    'message' => 'Too many requests from this IP.',
+                ], 429));
+            }
+            Cache::put($k, $n + 1, 3600);
+        }
+
+        // phone limit (1h)
+        if ($phone !== '') {
+            $k = $this->rateKeyPhone($phone);
+            $n = (int) Cache::get($k, 0);
+            if ($n >= $this->maxSendPerPhone) {
+                abort(response()->json([
+                    'ok' => false,
+                    'error' => 'RATE_LIMITED',
+                    'message' => 'Too many OTP requests for this phone.',
+                ], 429));
+            }
+            Cache::put($k, $n + 1, 3600);
+        }
+    }
+
+    private function generateCode(): string
+    {
+        $n = random_int(0, 999999);
+        return str_pad((string) $n, 6, '0', STR_PAD_LEFT);
+    }
+
+    private function allowDevCode(): bool
+    {
+        return app()->environment(['local', 'development']);
+    }
+
+    /**
+     * 固定 dev code（可选）：env FAP_OTP_DEV_CODE=123456
+     */
+    private function devCode(): ?string
+    {
+        $v = (string) env('FAP_OTP_DEV_CODE', '');
+        $v = trim($v);
+        if ($v === '') return null;
+        return preg_match('/^\d{6}$/', $v) ? $v : null;
+    }
+}

--- a/backend/database/migrations/2026_01_19_111914_add_phone_fields_to_users_table.php
+++ b/backend/database/migrations/2026_01_19_111914_add_phone_fields_to_users_table.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('users', function (Blueprint $table) {
+            if (!Schema::hasColumn('users', 'phone_e164')) {
+                $table->string('phone_e164')->nullable()->unique();
+            }
+            if (!Schema::hasColumn('users', 'phone_verified_at')) {
+                $table->timestamp('phone_verified_at')->nullable();
+            }
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('users', function (Blueprint $table) {
+            if (Schema::hasColumn('users', 'phone_verified_at')) {
+                $table->dropColumn('phone_verified_at');
+            }
+            if (Schema::hasColumn('users', 'phone_e164')) {
+                $table->dropColumn('phone_e164');
+            }
+        });
+    }
+};

--- a/backend/database/migrations/2026_01_19_111915_add_user_id_to_attempts_table.php
+++ b/backend/database/migrations/2026_01_19_111915_add_user_id_to_attempts_table.php
@@ -1,0 +1,26 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('attempts', function (Blueprint $table) {
+            if (!Schema::hasColumn('attempts', 'user_id')) {
+                $table->string('user_id', 64)->nullable()->index();
+            }
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('attempts', function (Blueprint $table) {
+            if (Schema::hasColumn('attempts', 'user_id')) {
+                $table->dropColumn('user_id');
+            }
+        });
+    }
+};

--- a/backend/routes/api.php
+++ b/backend/routes/api.php
@@ -6,6 +6,8 @@ use Illuminate\Support\Facades\Route;
 use App\Http\Controllers\MbtiController;
 use App\Http\Controllers\EventController;
 use App\Http\Controllers\LookupController;
+use App\Http\Controllers\API\V0_2\AuthPhoneController;
+use App\Http\Controllers\API\V0_2\MeController;
 use App\Http\Controllers\API\V0_2\ShareController;
 
 /*
@@ -53,6 +55,8 @@ Route::prefix("v0.2")->group(function () {
 
     // ✅ 登录接口（必须公开，否则无法拿 token）
     Route::post("/auth/wx_phone", \App\Http\Controllers\API\V0_2\AuthWxPhoneController::class);
+    Route::post("/auth/phone/send_code", [AuthPhoneController::class, "sendCode"]);
+    Route::post("/auth/phone/verify", [AuthPhoneController::class, "verify"]);
 
     // 8) 事件上报（目前你前端已带 Authorization，但事件是否门禁你可后续决定）
     // 这里先保持公开（不影响主链路）
@@ -65,7 +69,7 @@ Route::prefix("v0.2")->group(function () {
     Route::middleware(\App\Http\Middleware\FmTokenAuth::class)->group(function () {
 
     // ✅ GET /api/v0.2/me/attempts
-    Route::get("/me/attempts", [LookupController::class, "meAttempts"]);
+    Route::get("/me/attempts", [MeController::class, "attempts"]);
 
     Route::get("/attempts/{id}/result", [MbtiController::class, "getResult"]);
     Route::get("/attempts/{id}/report", [MbtiController::class, "getReport"]);


### PR DESCRIPTION
## What
Phase B: phone OTP login + unified fm_token + /me/attempts + anon_id -> user_id collection.

## API
- POST /api/v0.2/auth/phone/send_code
- POST /api/v0.2/auth/phone/verify
- GET  /api/v0.2/me/attempts (FmTokenAuth)

## DB
- users: phone_e164 (unique, nullable), phone_verified_at (nullable)
- attempts: user_id (nullable, index)

## Token
- wx_phone + phone_verify both issue token via fm_tokens (FmTokenService)
- FmTokenAuth resolves user_id from fm_tokens and injects request attribute fm_user_id

## Verification
- bash backend/scripts/ci_verify_mbti.sh  ✅ all pass
- Manual OTP flow:
  - send_code -> verify -> Authorization: Bearer fm_xxx -> GET /me/attempts (200)
  - verify with anon_id triggers collection into attempts.user_id