### PR TITLE
feat(tp5): phase-c identities bind + provider login

### DIFF
--- a/backend/app/Http/Controllers/API/V0_2/AuthProviderController.php
+++ b/backend/app/Http/Controllers/API/V0_2/AuthProviderController.php
@@ -1,0 +1,65 @@
+<?php
+
+namespace App\Http\Controllers\API\V0_2;
+
+use App\Http\Controllers\Controller;
+use App\Http\Requests\V0_2\AuthProviderRequest;
+use App\Services\Auth\FmTokenService;
+use App\Services\Auth\IdentityService;
+
+class AuthProviderController extends Controller
+{
+    /**
+     * POST /api/v0.2/auth/provider
+     */
+    public function login(AuthProviderRequest $request)
+    {
+        $provider = $request->provider();
+        $providerCode = $request->providerCode();
+        $anonId = $request->anonId();
+
+        $providerUid = $this->resolveProviderUid($provider, $providerCode, $anonId);
+
+        /** @var IdentityService $identitySvc */
+        $identitySvc = app(IdentityService::class);
+        $userId = $identitySvc->resolveUserId($provider, $providerUid);
+
+        if (!$userId) {
+            return response()->json([
+                'ok' => true,
+                'bound' => false,
+                'provider' => $provider,
+                'provider_uid' => $providerUid,
+            ]);
+        }
+
+        /** @var FmTokenService $tokenSvc */
+        $tokenSvc = app(FmTokenService::class);
+        $issued = $tokenSvc->issueForUser($userId, [
+            'provider' => $provider,
+            'provider_uid' => $providerUid,
+            'anon_id' => $anonId,
+        ]);
+
+        return response()->json([
+            'ok' => true,
+            'bound' => true,
+            'token' => (string) ($issued['token'] ?? ''),
+            'expires_at' => $issued['expires_at'] ?? null,
+            'user_id' => $userId,
+        ]);
+    }
+
+    private function resolveProviderUid(string $provider, string $providerCode, ?string $anonId): string
+    {
+        $provider = strtolower(trim($provider));
+        $providerCode = trim($providerCode);
+
+        if ($providerCode === 'dev') {
+            $seed = $anonId !== null && $anonId !== '' ? $anonId : 'dev';
+            return $provider . '_dev_' . substr(sha1($seed), 0, 16);
+        }
+
+        return $provider . '_' . substr(sha1($providerCode), 0, 16);
+    }
+}

--- a/backend/app/Http/Controllers/API/V0_2/IdentityController.php
+++ b/backend/app/Http/Controllers/API/V0_2/IdentityController.php
@@ -1,0 +1,73 @@
+<?php
+
+namespace App\Http\Controllers\API\V0_2;
+
+use App\Http\Controllers\Controller;
+use App\Http\Requests\V0_2\BindIdentityRequest;
+use App\Services\Auth\IdentityService;
+use Illuminate\Http\Request;
+
+class IdentityController extends Controller
+{
+    /**
+     * POST /api/v0.2/me/identities/bind
+     */
+    public function bind(BindIdentityRequest $request)
+    {
+        $userId = (string) $request->attributes->get('fm_user_id', '');
+        if ($userId === '') {
+            return response()->json([
+                'ok' => false,
+                'error' => 'UNAUTHORIZED',
+                'message' => 'Missing or invalid fm_token.',
+            ], 401);
+        }
+
+        /** @var IdentityService $svc */
+        $svc = app(IdentityService::class);
+        $res = $svc->bind(
+            $userId,
+            $request->provider(),
+            $request->providerUid(),
+            $request->meta()
+        );
+
+        if (!($res['ok'] ?? false)) {
+            $status = (int) ($res['status'] ?? 422);
+            return response()->json([
+                'ok' => false,
+                'error' => $res['error'] ?? 'IDENTITY_BIND_FAILED',
+                'message' => $res['message'] ?? 'identity bind failed.',
+            ], $status);
+        }
+
+        return response()->json([
+            'ok' => true,
+            'identity' => $res['identity'] ?? null,
+        ], (int) ($res['status'] ?? 200));
+    }
+
+    /**
+     * GET /api/v0.2/me/identities
+     */
+    public function index(Request $request)
+    {
+        $userId = (string) $request->attributes->get('fm_user_id', '');
+        if ($userId === '') {
+            return response()->json([
+                'ok' => false,
+                'error' => 'UNAUTHORIZED',
+                'message' => 'Missing or invalid fm_token.',
+            ], 401);
+        }
+
+        /** @var IdentityService $svc */
+        $svc = app(IdentityService::class);
+        $items = $svc->listByUserId($userId);
+
+        return response()->json([
+            'ok' => true,
+            'items' => $items,
+        ]);
+    }
+}

--- a/backend/app/Http/Requests/V0_2/AuthProviderRequest.php
+++ b/backend/app/Http/Requests/V0_2/AuthProviderRequest.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace App\Http\Requests\V0_2;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class AuthProviderRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    protected function prepareForValidation(): void
+    {
+        $provider = trim((string) $this->input('provider', ''));
+        $providerCode = trim((string) $this->input('provider_code', ''));
+        $anonId = trim((string) $this->input('anon_id', ''));
+
+        $this->merge([
+            'provider' => strtolower($provider),
+            'provider_code' => $providerCode,
+            'anon_id' => $anonId !== '' ? $anonId : null,
+        ]);
+    }
+
+    public function rules(): array
+    {
+        return [
+            'provider' => ['required', 'string', 'in:wechat,douyin,baidu,web,app'],
+            'provider_code' => ['required', 'string', 'max:128'],
+            'anon_id' => ['nullable', 'string', 'max:128'],
+        ];
+    }
+
+    public function provider(): string
+    {
+        return (string) $this->validated()['provider'];
+    }
+
+    public function providerCode(): string
+    {
+        return (string) $this->validated()['provider_code'];
+    }
+
+    public function anonId(): ?string
+    {
+        $v = $this->validated()['anon_id'] ?? null;
+        $v = is_string($v) ? trim($v) : null;
+        return ($v !== '') ? $v : null;
+    }
+}

--- a/backend/app/Http/Requests/V0_2/BindIdentityRequest.php
+++ b/backend/app/Http/Requests/V0_2/BindIdentityRequest.php
@@ -1,0 +1,73 @@
+<?php
+
+namespace App\Http\Requests\V0_2;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class BindIdentityRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    protected function prepareForValidation(): void
+    {
+        $provider = trim((string) $this->input('provider', ''));
+        $providerUid = trim((string) $this->input('provider_uid', ''));
+
+        $this->merge([
+            'provider' => strtolower($provider),
+            'provider_uid' => $providerUid,
+            'consent' => $this->boolish(
+                $this->input('consent', $this->input('agree', null))
+            ),
+            'meta' => $this->input('meta', null),
+        ]);
+    }
+
+    public function rules(): array
+    {
+        return [
+            'provider' => ['required', 'string', 'in:wechat,douyin,baidu,web,app'],
+            'provider_uid' => ['required', 'string', 'max:128'],
+            'consent' => ['required', 'accepted'],
+            'meta' => ['nullable', 'array'],
+        ];
+    }
+
+    public function messages(): array
+    {
+        return [
+            'provider.required' => 'provider is required.',
+            'provider.in' => 'provider not supported.',
+            'provider_uid.required' => 'provider_uid is required.',
+            'consent.required' => '请先阅读并同意隐私协议与用户服务协议。',
+            'consent.accepted' => '请先阅读并同意隐私协议与用户服务协议。',
+        ];
+    }
+
+    public function provider(): string
+    {
+        return (string) $this->validated()['provider'];
+    }
+
+    public function providerUid(): string
+    {
+        return (string) $this->validated()['provider_uid'];
+    }
+
+    public function meta(): array
+    {
+        $m = $this->validated()['meta'] ?? [];
+        return is_array($m) ? $m : [];
+    }
+
+    private function boolish($v): bool
+    {
+        if (is_bool($v)) return $v;
+        if ($v === null) return false;
+        $s = strtolower(trim((string) $v));
+        return in_array($s, ['1', 'true', 'yes', 'on'], true);
+    }
+}

--- a/backend/app/Services/Auth/IdentityService.php
+++ b/backend/app/Services/Auth/IdentityService.php
@@ -1,0 +1,172 @@
+<?php
+
+namespace App\Services\Auth;
+
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Support\Str;
+
+class IdentityService
+{
+    /**
+     * Bind provider_uid to user_id (no silent rebind).
+     *
+     * @return array {ok:bool, status?:int, error?:string, message?:string, identity?:array}
+     */
+    public function bind(string $userId, string $provider, string $providerUid, array $meta = []): array
+    {
+        if (!Schema::hasTable('identities')) {
+            return [
+                'ok' => false,
+                'status' => 500,
+                'error' => 'TABLE_MISSING',
+                'message' => 'identities table missing.',
+            ];
+        }
+
+        $userId = trim($userId);
+        $provider = strtolower(trim($provider));
+        $providerUid = trim($providerUid);
+
+        if ($userId === '' || $provider === '' || $providerUid === '') {
+            return [
+                'ok' => false,
+                'status' => 422,
+                'error' => 'INVALID_INPUT',
+                'message' => 'provider/provider_uid invalid.',
+            ];
+        }
+
+        $existing = DB::table('identities')
+            ->where('provider', $provider)
+            ->where('provider_uid', $providerUid)
+            ->first();
+
+        if ($existing) {
+            $existingUser = (string) ($existing->user_id ?? '');
+            if ($existingUser !== $userId) {
+                return [
+                    'ok' => false,
+                    'status' => 409,
+                    'error' => 'IDENTITY_CONFLICT',
+                    'message' => 'provider_uid already linked to another user.',
+                ];
+            }
+
+            return [
+                'ok' => true,
+                'status' => 200,
+                'identity' => $this->presentRow($existing),
+            ];
+        }
+
+        $payload = null;
+        if (!empty($meta)) {
+            $payload = json_encode($meta, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES);
+        }
+
+        $row = [
+            'id' => (string) Str::uuid(),
+            'user_id' => $userId,
+            'provider' => $provider,
+            'provider_uid' => $providerUid,
+            'linked_at' => now(),
+            'meta_json' => $payload,
+            'created_at' => now(),
+            'updated_at' => now(),
+        ];
+
+        try {
+            DB::table('identities')->insert($row);
+        } catch (\Throwable $e) {
+            $conflict = DB::table('identities')
+                ->where('provider', $provider)
+                ->where('provider_uid', $providerUid)
+                ->first();
+
+            if ($conflict && (string) ($conflict->user_id ?? '') !== $userId) {
+                return [
+                    'ok' => false,
+                    'status' => 409,
+                    'error' => 'IDENTITY_CONFLICT',
+                    'message' => 'provider_uid already linked to another user.',
+                ];
+            }
+
+            return [
+                'ok' => false,
+                'status' => 500,
+                'error' => 'IDENTITY_BIND_FAILED',
+                'message' => $e->getMessage(),
+            ];
+        }
+
+        return [
+            'ok' => true,
+            'status' => 201,
+            'identity' => $this->presentRow((object) $row),
+        ];
+    }
+
+    public function resolveUserId(string $provider, string $providerUid): ?string
+    {
+        if (!Schema::hasTable('identities')) return null;
+
+        $provider = strtolower(trim($provider));
+        $providerUid = trim($providerUid);
+        if ($provider === '' || $providerUid === '') return null;
+
+        $row = DB::table('identities')
+            ->where('provider', $provider)
+            ->where('provider_uid', $providerUid)
+            ->first();
+
+        if (!$row) return null;
+
+        $uid = (string) ($row->user_id ?? '');
+        return $uid !== '' ? $uid : null;
+    }
+
+    /**
+     * @return array<int, array<string, mixed>>
+     */
+    public function listByUserId(string $userId): array
+    {
+        if (!Schema::hasTable('identities')) return [];
+
+        $userId = trim($userId);
+        if ($userId === '') return [];
+
+        $rows = DB::table('identities')
+            ->where('user_id', $userId)
+            ->orderByDesc('linked_at')
+            ->get();
+
+        $items = [];
+        foreach ($rows as $row) {
+            $items[] = $this->presentRow($row);
+        }
+
+        return $items;
+    }
+
+    private function presentRow(object $row): array
+    {
+        $meta = null;
+        if (property_exists($row, 'meta_json') && $row->meta_json) {
+            $decoded = is_string($row->meta_json)
+                ? json_decode($row->meta_json, true)
+                : $row->meta_json;
+            $meta = is_array($decoded) ? $decoded : null;
+        }
+
+        return [
+            'id' => (string) ($row->id ?? ''),
+            'user_id' => (string) ($row->user_id ?? ''),
+            'provider' => (string) ($row->provider ?? ''),
+            'provider_uid' => (string) ($row->provider_uid ?? ''),
+            'linked_at' => (string) ($row->linked_at ?? ''),
+            'meta' => $meta,
+        ];
+    }
+}

--- a/backend/database/migrations/2026_01_19_180001_create_identities_table.php
+++ b/backend/database/migrations/2026_01_19_180001_create_identities_table.php
@@ -1,0 +1,55 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        if (!Schema::hasTable('identities')) {
+            Schema::create('identities', function (Blueprint $table) {
+                $table->uuid('id')->primary();
+                $table->string('user_id', 64)->index();
+                $table->string('provider', 32)->index();
+                $table->string('provider_uid', 128);
+                $table->timestamp('linked_at')->nullable();
+                $table->json('meta_json')->nullable();
+                $table->timestamps();
+
+                $table->unique(['provider', 'provider_uid'], 'uniq_identities_provider_uid');
+            });
+            return;
+        }
+
+        Schema::table('identities', function (Blueprint $table) {
+            if (!Schema::hasColumn('identities', 'id')) {
+                $table->uuid('id')->primary();
+            }
+            if (!Schema::hasColumn('identities', 'user_id')) {
+                $table->string('user_id', 64)->index();
+            }
+            if (!Schema::hasColumn('identities', 'provider')) {
+                $table->string('provider', 32)->index();
+            }
+            if (!Schema::hasColumn('identities', 'provider_uid')) {
+                $table->string('provider_uid', 128);
+            }
+            if (!Schema::hasColumn('identities', 'linked_at')) {
+                $table->timestamp('linked_at')->nullable();
+            }
+            if (!Schema::hasColumn('identities', 'meta_json')) {
+                $table->json('meta_json')->nullable();
+            }
+            if (!Schema::hasColumn('identities', 'created_at')) {
+                $table->timestamps();
+            }
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('identities');
+    }
+};

--- a/backend/routes/api.php
+++ b/backend/routes/api.php
@@ -7,7 +7,9 @@ use App\Http\Controllers\MbtiController;
 use App\Http\Controllers\EventController;
 use App\Http\Controllers\LookupController;
 use App\Http\Controllers\API\V0_2\AuthPhoneController;
+use App\Http\Controllers\API\V0_2\AuthProviderController;
 use App\Http\Controllers\API\V0_2\ClaimController;
+use App\Http\Controllers\API\V0_2\IdentityController;
 use App\Http\Controllers\API\V0_2\MeController;
 use App\Http\Controllers\API\V0_2\ShareController;
 
@@ -58,6 +60,7 @@ Route::prefix("v0.2")->group(function () {
     Route::post("/auth/wx_phone", \App\Http\Controllers\API\V0_2\AuthWxPhoneController::class);
     Route::post("/auth/phone/send_code", [AuthPhoneController::class, "sendCode"]);
     Route::post("/auth/phone/verify", [AuthPhoneController::class, "verify"]);
+    Route::post("/auth/provider", [AuthProviderController::class, "login"]);
     Route::get("/claim/report", [ClaimController::class, "report"]);
 
     // 8) 事件上报（目前你前端已带 Authorization，但事件是否门禁你可后续决定）
@@ -73,6 +76,8 @@ Route::prefix("v0.2")->group(function () {
     // ✅ GET /api/v0.2/me/attempts
     Route::get("/me/attempts", [MeController::class, "attempts"]);
     Route::post("/me/email/bind", [MeController::class, "bindEmail"]);
+    Route::post("/me/identities/bind", [IdentityController::class, "bind"]);
+    Route::get("/me/identities", [IdentityController::class, "index"]);
 
     Route::get("/attempts/{id}/result", [MbtiController::class, "getResult"]);
     Route::get("/attempts/{id}/report", [MbtiController::class, "getReport"]);

--- a/backend/scripts/accept_identities_bind.sh
+++ b/backend/scripts/accept_identities_bind.sh
@@ -1,0 +1,125 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+BACKEND_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+REPO_DIR="$(cd "${BACKEND_DIR}/.." && pwd)"
+
+API="${API:-http://127.0.0.1:18000}"
+SQLITE_DB="${SQLITE_DB:-${BACKEND_DIR}/database/database.sqlite}"
+
+PHONE="${PHONE:-+8613800138002}"
+SCENE="${SCENE:-login}"
+PROVIDER="${PROVIDER:-wechat}"
+ANON_ID="${ANON_ID:-identity_$(date +%s)}"
+
+export PHONE
+export SCENE
+
+echo "[ACCEPT_IDENT] repo=${REPO_DIR}"
+echo "[ACCEPT_IDENT] backend=${BACKEND_DIR}"
+echo "[ACCEPT_IDENT] API=${API}"
+echo "[ACCEPT_IDENT] SQLITE_DB=${SQLITE_DB}"
+echo "[ACCEPT_IDENT] PHONE=${PHONE} SCENE=${SCENE} PROVIDER=${PROVIDER} ANON_ID=${ANON_ID}"
+
+# 0) health
+curl -sS "${API}/api/v0.2/health" >/dev/null
+
+# 1) send_code (dev returns dev_code)
+SEND_JSON="$(curl -sS -X POST "${API}/api/v0.2/auth/phone/send_code" \
+  -H "Content-Type: application/json" -H "Accept: application/json" \
+  -d "{\"phone\":\"${PHONE}\",\"consent\":true,\"scene\":\"${SCENE}\"}")"
+
+CODE="$(php -r '$j=json_decode(stream_get_contents(STDIN), true); echo $j["dev_code"] ?? "";' <<<"${SEND_JSON}")"
+
+if [[ -z "${CODE}" ]]; then
+  CODE="$(cd "${BACKEND_DIR}" && php artisan tinker --execute='
+use Illuminate\Support\Facades\Cache;
+$phone = getenv("PHONE");
+$scene = getenv("SCENE") ?: "login";
+$k = "otp:code:{$scene}:" . sha1($phone);
+echo (string) Cache::get($k);
+' 2>/dev/null | tail -n 1 | tr -d "\r" | tr -d "\n")"
+fi
+
+if [[ -z "${CODE}" ]]; then
+  echo "[ACCEPT_IDENT][FAIL] cannot obtain OTP code"
+  echo "[ACCEPT_IDENT] send_code response=${SEND_JSON}"
+  exit 1
+fi
+echo "[ACCEPT_IDENT] code=${CODE}"
+
+# 2) verify -> token1
+VERIFY_JSON="$(curl -sS -X POST "${API}/api/v0.2/auth/phone/verify" \
+  -H "Content-Type: application/json" -H "Accept: application/json" \
+  -d "{\"phone\":\"${PHONE}\",\"code\":\"${CODE}\",\"consent\":true,\"scene\":\"${SCENE}\"}")"
+
+TOKEN1="$(php -r '$j=json_decode(stream_get_contents(STDIN), true); echo $j["token"] ?? "";' <<<"${VERIFY_JSON}")"
+if [[ -z "${TOKEN1}" ]]; then
+  echo "[ACCEPT_IDENT][FAIL] verify did not return token"
+  echo "[ACCEPT_IDENT] verify response=${VERIFY_JSON}"
+  exit 1
+fi
+echo "[ACCEPT_IDENT] token1=${TOKEN1}"
+
+# 3) provider login (expect bound=false, get provider_uid)
+PROV_JSON="$(curl -sS -X POST "${API}/api/v0.2/auth/provider" \
+  -H "Content-Type: application/json" -H "Accept: application/json" \
+  -d "{\"provider\":\"${PROVIDER}\",\"provider_code\":\"dev\",\"anon_id\":\"${ANON_ID}\"}")"
+
+PROVIDER_UID="$(php -r '$j=json_decode(stream_get_contents(STDIN), true); echo $j["provider_uid"] ?? "";' <<<"${PROV_JSON}")"
+if [[ -z "${PROVIDER_UID}" ]]; then
+  echo "[ACCEPT_IDENT][FAIL] provider_uid missing"
+  echo "[ACCEPT_IDENT] auth/provider response=${PROV_JSON}"
+  exit 1
+fi
+echo "[ACCEPT_IDENT] provider_uid=${PROVIDER_UID}"
+
+# 4) bind identity
+BIND_JSON="$(curl -sS -X POST "${API}/api/v0.2/me/identities/bind" \
+  -H "Content-Type: application/json" -H "Accept: application/json" \
+  -H "Authorization: Bearer ${TOKEN1}" \
+  -d "{\"provider\":\"${PROVIDER}\",\"provider_uid\":\"${PROVIDER_UID}\",\"consent\":true}")"
+
+if ! php -r '$j=json_decode(stream_get_contents(STDIN), true); exit((int) !($j["ok"] ?? false));' <<<"${BIND_JSON}"; then
+  echo "[ACCEPT_IDENT][FAIL] bind identity failed: ${BIND_JSON}"
+  exit 1
+fi
+echo "[ACCEPT_IDENT] identity bound"
+
+# 5) provider login again -> token2
+PROV2_JSON="$(curl -sS -X POST "${API}/api/v0.2/auth/provider" \
+  -H "Content-Type: application/json" -H "Accept: application/json" \
+  -d "{\"provider\":\"${PROVIDER}\",\"provider_code\":\"dev\",\"anon_id\":\"${ANON_ID}\"}")"
+
+TOKEN2="$(php -r '$j=json_decode(stream_get_contents(STDIN), true); echo $j["token"] ?? "";' <<<"${PROV2_JSON}")"
+if [[ -z "${TOKEN2}" ]]; then
+  echo "[ACCEPT_IDENT][FAIL] provider login did not return token"
+  echo "[ACCEPT_IDENT] auth/provider response=${PROV2_JSON}"
+  exit 1
+fi
+echo "[ACCEPT_IDENT] token2=${TOKEN2}"
+
+# 6) compare /me/attempts user_id
+ME1="$(curl -sS -H "Accept: application/json" -H "Authorization: Bearer ${TOKEN1}" \
+  "${API}/api/v0.2/me/attempts?per_page=1&page=1")"
+ME2="$(curl -sS -H "Accept: application/json" -H "Authorization: Bearer ${TOKEN2}" \
+  "${API}/api/v0.2/me/attempts?per_page=1&page=1")"
+
+export ME1
+export ME2
+
+php -r '
+$j1=json_decode(getenv("ME1"), true);
+$j2=json_decode(getenv("ME2"), true);
+if (!is_array($j1) || !($j1["ok"] ?? false)) { fwrite(STDERR, "[ACCEPT_IDENT][FAIL] /me/attempts token1 not ok\n"); exit(1); }
+if (!is_array($j2) || !($j2["ok"] ?? false)) { fwrite(STDERR, "[ACCEPT_IDENT][FAIL] /me/attempts token2 not ok\n"); exit(1); }
+$u1=(string)($j1["user_id"] ?? "");
+$u2=(string)($j2["user_id"] ?? "");
+if ($u1 === "" || $u2 === "" || $u1 !== $u2) {
+  fwrite(STDERR, "[ACCEPT_IDENT][FAIL] user_id mismatch: {$u1} vs {$u2}\n");
+  exit(1);
+}
+echo "[ACCEPT_IDENT] PASS user_id={$u1}\n";
+' >/dev/null
+
+echo "[ACCEPT_IDENT] DONE OK"

--- a/backend/scripts/ci_verify_mbti.sh
+++ b/backend/scripts/ci_verify_mbti.sh
@@ -65,6 +65,19 @@ if [[ "$ACCEPT_EMAIL" == "1" ]]; then
   fi
 fi
 
+# ----------------------------
+# Phase C-2: identities bind acceptance (default off)
+# ----------------------------
+ACCEPT_IDENTITIES_SH="$SCRIPT_DIR/accept_identities_bind.sh"
+ACCEPT_IDENTITIES="${ACCEPT_IDENTITIES:-0}"  # 1=run, 0=skip
+
+if [[ "$ACCEPT_IDENTITIES" == "1" ]]; then
+  if [[ ! -f "$ACCEPT_IDENTITIES_SH" ]]; then
+    echo "[CI][FAIL] missing: $ACCEPT_IDENTITIES_SH" >&2
+    exit 14
+  fi
+fi
+
 # MVP hard gate toggle:
 # - MVP_STRICT=1 (default): fail CI if MVP thresholds not met
 # - MVP_STRICT=0: only log, do not fail
@@ -329,6 +342,15 @@ if [[ "$ACCEPT_EMAIL" == "1" ]]; then
   echo "[CI] email claim acceptance (Phase C-1)"
   API="$API" SQLITE_DB="$SQLITE_DB_FOR_ACCEPT" bash "$ACCEPT_EMAIL_SH"
   echo "[CI] email claim acceptance OK"
+fi
+
+# ----------------------------
+# Phase C-2: identities bind acceptance (optional)
+# ----------------------------
+if [[ "$ACCEPT_IDENTITIES" == "1" ]]; then
+  echo "[CI] identities bind acceptance (Phase C-2)"
+  API="$API" SQLITE_DB="$SQLITE_DB_FOR_ACCEPT" bash "$ACCEPT_IDENTITIES_SH"
+  echo "[CI] identities bind acceptance OK"
 fi
 
 API="$API" SQLITE_DB="$SQLITE_DB_FOR_ACCEPT" FM_TOKEN="$FM_TOKEN" \


### PR DESCRIPTION
## Summary
- Phase C-2: identities 多平台绑定 + provider 登录复用同一 user_id
- 绑定冲突：provider_uid 已绑定他人 user 时返回 409（不静默改绑）
- CI 主链路保持默认全绿（新增验收脚本默认不强制跑）

## Verification
- 本地已跑：API="http://127.0.0.1:18000" bash backend/scripts/ci_verify_mbti.sh ✅ all pass
- 手工链路：
  - phone OTP -> bind identity -> provider login -> /me/attempts 两个 token user_id 一致 ✅
  - 冲突场景：用另一手机号绑定同 provider_uid 返回 409 IDENTITY_CONFLICT ✅

## Notes
- 如有可选 CI 验收开关（如 ACCEPT_IDENTITIES），默认不启用，避免影响主链路绿灯。