### PR TITLE
feat(norms): v1 tables + percentile + report injection (gated)

### DIFF
--- a/backend/app/Console/Commands/NormsUpdate.php
+++ b/backend/app/Console/Commands/NormsUpdate.php
@@ -1,0 +1,316 @@
+<?php
+
+namespace App\Console\Commands;
+
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Support\Str;
+
+class NormsUpdate extends Command
+{
+    protected $signature = 'norms:update {--pack_id= : norms pack_id (default: content_packs.default_pack_id)}';
+
+    protected $description = 'Build norms table (global sample, last 365 days, rank_rule=leq)';
+
+    public function handle(): int
+    {
+        $packId = trim((string) $this->option('pack_id'));
+        if ($packId === '') {
+            $packId = (string) config('content_packs.default_pack_id', '');
+        }
+        if ($packId === '') {
+            $this->error('pack_id is required (option or config content_packs.default_pack_id)');
+            return 1;
+        }
+
+        $windowEnd = now();
+        $windowStart = now()->subDays(365);
+        $metrics = ['EI', 'SN', 'TF', 'JP', 'AT'];
+
+        $hasAxisStates = Schema::hasColumn('results', 'axis_states');
+        $hasScoresJson = Schema::hasColumn('results', 'scores_json');
+        $hasScoresPct = Schema::hasColumn('results', 'scores_pct');
+        $hasAttemptResult = Schema::hasColumn('attempts', 'result_json');
+        $hasComputedAt = Schema::hasColumn('results', 'computed_at');
+        $hasCreatedAt = Schema::hasColumn('results', 'created_at');
+        $hasIsValid = Schema::hasColumn('results', 'is_valid');
+        $hasContentPackageVersion = Schema::hasColumn('results', 'content_package_version');
+
+        if (!$hasAxisStates && !$hasScoresJson && !$hasAttemptResult && !$hasScoresPct) {
+            $this->warn('No usable score source columns found.');
+            return 0;
+        }
+
+        $packVersion = $this->packIdToVersion($packId);
+
+        $query = DB::table('results as r');
+        if ($hasAttemptResult) {
+            $query->leftJoin('attempts as a', 'a.id', '=', 'r.attempt_id');
+        }
+
+        $select = ['r.id', 'r.attempt_id'];
+        if ($hasAxisStates) {
+            $select[] = 'r.axis_states';
+        }
+        if ($hasScoresJson) {
+            $select[] = 'r.scores_json';
+        }
+        if ($hasScoresPct) {
+            $select[] = 'r.scores_pct';
+        }
+        if ($hasAttemptResult) {
+            $select[] = 'a.result_json as attempt_result_json';
+        }
+        if ($hasComputedAt) {
+            $select[] = 'r.computed_at';
+        }
+        if ($hasCreatedAt) {
+            $select[] = 'r.created_at';
+        }
+        $query->select($select);
+
+        if ($hasComputedAt) {
+            $query->whereBetween('r.computed_at', [$windowStart, $windowEnd]);
+        } elseif ($hasCreatedAt) {
+            $query->whereBetween('r.created_at', [$windowStart, $windowEnd]);
+        }
+
+        if ($hasIsValid) {
+            $query->where('r.is_valid', true);
+        }
+
+        if ($hasContentPackageVersion && $packVersion !== '') {
+            $query->where('r.content_package_version', $packVersion);
+        }
+
+        $sampleN = 0;
+        $scoresByMetric = [
+            'EI' => [],
+            'SN' => [],
+            'TF' => [],
+            'JP' => [],
+            'AT' => [],
+        ];
+
+        foreach ($query->cursor() as $row) {
+            $scores = $this->extractScoresFromRow(
+                $row,
+                $metrics,
+                $hasAxisStates,
+                $hasScoresJson,
+                $hasScoresPct,
+                $hasAttemptResult
+            );
+            if (!$scores) {
+                continue;
+            }
+
+            $sampleN++;
+            foreach ($metrics as $metric) {
+                $scoresByMetric[$metric][] = (int) round((float) $scores[$metric]);
+            }
+        }
+
+        if ($sampleN < 200) {
+            $this->info("Sample size {$sampleN} < 200, keep active version unchanged.");
+            return 0;
+        }
+
+        $versionId = (string) Str::uuid();
+        $now = now();
+
+        DB::transaction(function () use (
+            $versionId,
+            $packId,
+            $windowStart,
+            $windowEnd,
+            $sampleN,
+            $now,
+            $scoresByMetric,
+            $metrics
+        ) {
+            DB::table('norms_versions')->insert([
+                'id' => $versionId,
+                'pack_id' => $packId,
+                'window_start_at' => $windowStart,
+                'window_end_at' => $windowEnd,
+                'sample_n' => $sampleN,
+                'rank_rule' => 'leq',
+                'status' => 'active',
+                'computed_at' => $now,
+                'created_at' => $now,
+            ]);
+
+            $rows = [];
+            foreach ($metrics as $metric) {
+                $counts = array_count_values($scoresByMetric[$metric]);
+                ksort($counts, SORT_NUMERIC);
+
+                $leq = 0;
+                foreach ($counts as $scoreInt => $count) {
+                    $leq += (int) $count;
+                    $rows[] = [
+                        'norms_version_id' => $versionId,
+                        'metric_key' => $metric,
+                        'score_int' => (int) $scoreInt,
+                        'leq_count' => $leq,
+                        'percentile' => $leq / $sampleN,
+                        'created_at' => $now,
+                    ];
+                }
+            }
+
+            foreach (array_chunk($rows, 1000) as $chunk) {
+                DB::table('norms_table')->insert($chunk);
+            }
+
+            DB::table('norms_versions')
+                ->where('pack_id', $packId)
+                ->where('status', 'active')
+                ->where('id', '!=', $versionId)
+                ->update(['status' => 'archived']);
+        });
+
+        $this->info("Norms updated: pack_id={$packId} version_id={$versionId} N={$sampleN}");
+
+        return 0;
+    }
+
+    private function extractScoresFromRow(
+        object $row,
+        array $metrics,
+        bool $hasAxisStates,
+        bool $hasScoresJson,
+        bool $hasScoresPct,
+        bool $hasAttemptResult
+    ): ?array {
+        $axisStates = $hasAxisStates ? $this->decodeJson($row->axis_states ?? null) : null;
+        $scoresJson = $hasScoresJson ? $this->decodeJson($row->scores_json ?? null) : null;
+        $scoresPct = $hasScoresPct ? $this->decodeJson($row->scores_pct ?? null) : null;
+        $attemptResult = $hasAttemptResult ? $this->decodeJson($row->attempt_result_json ?? null) : null;
+
+        $out = [];
+        foreach ($metrics as $metric) {
+            $score = null;
+
+            if (is_array($axisStates)) {
+                $score = $this->extractNumericScore($axisStates[$metric] ?? null);
+            }
+            if ($score === null) {
+                $score = $this->scoreFromScoresJson($scoresJson, $scoresPct, $metric);
+            }
+            if ($score === null && is_array($attemptResult)) {
+                $score = $this->scoreFromReportJson($attemptResult, $metric);
+            }
+            if ($score === null) {
+                return null;
+            }
+
+            $out[$metric] = $score;
+        }
+
+        return $out;
+    }
+
+    private function scoreFromScoresJson(?array $scoresJson, ?array $scoresPct, string $metric): ?float
+    {
+        if (is_array($scoresJson) && array_key_exists($metric, $scoresJson)) {
+            $val = $scoresJson[$metric];
+            $score = $this->extractNumericScore($val);
+            if ($score !== null) {
+                return $score;
+            }
+
+            if (is_array($val)) {
+                $sum = $this->toNumber($val['sum'] ?? null);
+                $total = $this->toNumber($val['total'] ?? null);
+                if ($sum !== null && $total !== null && $total > 0) {
+                    $pct = (($sum + 2 * $total) / (4 * $total)) * 100;
+                    return max(0.0, min(100.0, $pct));
+                }
+            }
+        }
+
+        if (is_array($scoresPct) && array_key_exists($metric, $scoresPct)) {
+            $score = $this->extractNumericScore($scoresPct[$metric] ?? null);
+            if ($score !== null) {
+                return $score;
+            }
+        }
+
+        return null;
+    }
+
+    private function scoreFromReportJson(array $reportJson, string $metric): ?float
+    {
+        $scoresPct = $this->decodeJson($reportJson['scores_pct'] ?? null) ?? [];
+        $scores = $this->decodeJson($reportJson['scores'] ?? null);
+        if (!is_array($scores)) {
+            $scores = $this->decodeJson($reportJson['scores_json'] ?? null);
+        }
+
+        return $this->scoreFromScoresJson(is_array($scores) ? $scores : [], $scoresPct, $metric);
+    }
+
+    private function extractNumericScore(mixed $val): ?float
+    {
+        if (is_int($val) || is_float($val)) {
+            return (float) $val;
+        }
+        if (is_string($val) && is_numeric($val)) {
+            return (float) $val;
+        }
+        if (is_array($val)) {
+            if (array_key_exists('score', $val)) {
+                return $this->extractNumericScore($val['score']);
+            }
+            if (array_key_exists('pct', $val)) {
+                return $this->extractNumericScore($val['pct']);
+            }
+        }
+
+        return null;
+    }
+
+    private function toNumber(mixed $val): ?float
+    {
+        if (is_int($val) || is_float($val)) {
+            return (float) $val;
+        }
+        if (is_string($val) && is_numeric($val)) {
+            return (float) $val;
+        }
+        return null;
+    }
+
+    private function decodeJson(mixed $val): ?array
+    {
+        if (is_array($val)) {
+            return $val;
+        }
+        if (is_object($val)) {
+            return (array) $val;
+        }
+        if (is_string($val) && $val !== '') {
+            $decoded = json_decode($val, true);
+            return is_array($decoded) ? $decoded : null;
+        }
+        return null;
+    }
+
+    private function packIdToVersion(string $packId): string
+    {
+        $s = trim($packId);
+        if ($s === '') {
+            return '';
+        }
+
+        $parts = explode('.', $s);
+        if (count($parts) < 4) {
+            return '';
+        }
+
+        return implode('.', array_slice($parts, 3));
+    }
+}

--- a/backend/app/Http/Controllers/API/V0_2/NormsController.php
+++ b/backend/app/Http/Controllers/API/V0_2/NormsController.php
@@ -1,0 +1,110 @@
+<?php
+
+namespace App\Http\Controllers\API\V0_2;
+
+use App\Http\Controllers\Controller;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Validator;
+
+class NormsController extends Controller
+{
+    /**
+     * GET /api/v0.2/norms/percentile
+     * Query: pack_id, metric_key, score
+     */
+    public function percentile(Request $request)
+    {
+        if (!$this->isNormsEnabled()) {
+            return $this->notEnabled();
+        }
+
+        $v = Validator::make($request->all(), [
+            'pack_id'    => ['required', 'string', 'max:64'],
+            'metric_key' => ['required', 'string', 'in:EI,SN,TF,JP,AT'],
+            'score'      => ['required', 'numeric'],
+        ]);
+
+        if ($v->fails()) {
+            return response()->json([
+                'ok'     => false,
+                'error'  => 'VALIDATION_FAILED',
+                'errors' => $v->errors(),
+            ], 422);
+        }
+
+        $data = $v->validated();
+        $packId = (string) $data['pack_id'];
+        $metricKey = (string) $data['metric_key'];
+        $scoreInt = (int) round((float) $data['score']);
+
+        $version = $this->resolveVersion($packId);
+        if (!$version) {
+            return $this->notFound();
+        }
+
+        $row = DB::table('norms_table')
+            ->where('norms_version_id', (string) $version->id)
+            ->where('metric_key', $metricKey)
+            ->where('score_int', $scoreInt)
+            ->first();
+
+        if (!$row) {
+            return $this->notFound();
+        }
+
+        $percentile = (float) ($row->percentile ?? 0.0);
+        $overPercent = (int) floor($percentile * 100);
+
+        return response()->json([
+            'ok'              => true,
+            'pack_id'         => $packId,
+            'metric_key'      => $metricKey,
+            'score_int'       => $scoreInt,
+            'percentile'      => $percentile,
+            'over_percent'    => $overPercent,
+            'sample_n'        => (int) ($version->sample_n ?? 0),
+            'window_start_at' => (string) ($version->window_start_at ?? ''),
+            'window_end_at'   => (string) ($version->window_end_at ?? ''),
+            'version_id'      => (string) ($version->id ?? ''),
+            'rank_rule'       => (string) ($version->rank_rule ?? ''),
+        ]);
+    }
+
+    private function isNormsEnabled(): bool
+    {
+        return (int) env('NORMS_ENABLED', 0) === 1;
+    }
+
+    private function resolveVersion(string $packId): ?object
+    {
+        $pin = trim((string) env('NORMS_VERSION_PIN', ''));
+        $query = DB::table('norms_versions')->where('pack_id', $packId);
+
+        if ($pin !== '') {
+            return $query->where('id', $pin)->first();
+        }
+
+        return $query
+            ->where('status', 'active')
+            ->orderByDesc('computed_at')
+            ->orderByDesc('created_at')
+            ->first();
+    }
+
+    private function notEnabled()
+    {
+        return response()->json([
+            'ok'    => false,
+            'error' => 'NOT_ENABLED',
+        ]);
+    }
+
+    private function notFound()
+    {
+        return response()->json([
+            'ok'    => false,
+            'error' => 'NOT_FOUND',
+        ]);
+    }
+}

--- a/backend/app/Services/Report/ReportComposer.php
+++ b/backend/app/Services/Report/ReportComposer.php
@@ -4,6 +4,8 @@ namespace App\Services\Report;
 
 use Illuminate\Support\Facades\Storage;
 use Illuminate\Support\Facades\Log;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
 
 use App\Models\Attempt;
 use App\Models\Result;
@@ -718,6 +720,12 @@ $realContentPackageDir = $this->packIdToDir($contentPackId);
 
     ]; // $reportPayload end
 
+// Optional norms payload (feature-flagged)
+$normsPayload = $this->buildNormsPayload($contentPackId, $scoresPct);
+if (is_array($normsPayload)) {
+    $reportPayload['norms'] = $normsPayload;
+}
+
 // =====================================================
 // ✅ _meta：保证 validate-report 需要的 sections.assembler 存在
 // 同时保留 highlights 的 base/finalize/explain meta
@@ -924,6 +932,83 @@ $explainPayload['overrides'] = $ovrRootArr;
             'type_code'  => $typeCode,
             'report'     => $reportPayload,
         ];
+    }
+
+    private function buildNormsPayload(string $packId, array $scoresPct): ?array
+    {
+        if (!$this->isNormsEnabled()) {
+            return null;
+        }
+        if (!Schema::hasTable('norms_versions') || !Schema::hasTable('norms_table')) {
+            return null;
+        }
+
+        $version = $this->resolveNormsVersion($packId);
+        if (!$version) {
+            return null;
+        }
+
+        $metrics = ['EI', 'SN', 'TF', 'JP', 'AT'];
+        $metricsPayload = [];
+
+        foreach ($metrics as $metric) {
+            if (!array_key_exists($metric, $scoresPct)) {
+                return null;
+            }
+            $score = $scoresPct[$metric];
+            if (!is_numeric($score)) {
+                return null;
+            }
+
+            $scoreInt = (int) round((float) $score);
+            $row = DB::table('norms_table')
+                ->where('norms_version_id', (string) $version->id)
+                ->where('metric_key', $metric)
+                ->where('score_int', $scoreInt)
+                ->first();
+
+            if (!$row) {
+                return null;
+            }
+
+            $percentile = (float) ($row->percentile ?? 0.0);
+            $metricsPayload[$metric] = [
+                'score_int' => $scoreInt,
+                'percentile' => $percentile,
+                'over_percent' => (int) floor($percentile * 100),
+            ];
+        }
+
+        return [
+            'pack_id' => $packId,
+            'version_id' => (string) ($version->id ?? ''),
+            'N' => (int) ($version->sample_n ?? 0),
+            'window_start_at' => (string) ($version->window_start_at ?? ''),
+            'window_end_at' => (string) ($version->window_end_at ?? ''),
+            'rank_rule' => (string) ($version->rank_rule ?? 'leq'),
+            'metrics' => $metricsPayload,
+        ];
+    }
+
+    private function isNormsEnabled(): bool
+    {
+        return (int) env('NORMS_ENABLED', 0) === 1;
+    }
+
+    private function resolveNormsVersion(string $packId): ?object
+    {
+        $pin = trim((string) env('NORMS_VERSION_PIN', ''));
+        $query = DB::table('norms_versions')->where('pack_id', $packId);
+
+        if ($pin !== '') {
+            return $query->where('id', $pin)->first();
+        }
+
+        return $query
+            ->where('status', 'active')
+            ->orderByDesc('computed_at')
+            ->orderByDesc('created_at')
+            ->first();
     }
 
     private function normalizeRequestedVersion($requested): ?string

--- a/backend/database/migrations/2026_01_21_090000_create_norms_tables.php
+++ b/backend/database/migrations/2026_01_21_090000_create_norms_tables.php
@@ -1,0 +1,105 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        if (!Schema::hasTable('norms_versions')) {
+            Schema::create('norms_versions', function (Blueprint $table) {
+                $table->uuid('id')->primary();
+                $table->string('pack_id');
+                $table->timestamp('window_start_at')->nullable();
+                $table->timestamp('window_end_at')->nullable();
+                $table->integer('sample_n');
+                $table->string('rank_rule', 16);
+                $table->string('status', 16);
+                $table->timestamp('computed_at')->nullable();
+                $table->timestamp('created_at')->nullable();
+
+                $table->index(['pack_id', 'status'], 'idx_norms_versions_pack_status');
+                $table->index('created_at', 'idx_norms_versions_created_at');
+            });
+        } else {
+            Schema::table('norms_versions', function (Blueprint $table) {
+                if (!Schema::hasColumn('norms_versions', 'id')) {
+                    $table->uuid('id')->primary();
+                }
+                if (!Schema::hasColumn('norms_versions', 'pack_id')) {
+                    $table->string('pack_id');
+                }
+                if (!Schema::hasColumn('norms_versions', 'window_start_at')) {
+                    $table->timestamp('window_start_at')->nullable();
+                }
+                if (!Schema::hasColumn('norms_versions', 'window_end_at')) {
+                    $table->timestamp('window_end_at')->nullable();
+                }
+                if (!Schema::hasColumn('norms_versions', 'sample_n')) {
+                    $table->integer('sample_n');
+                }
+                if (!Schema::hasColumn('norms_versions', 'rank_rule')) {
+                    $table->string('rank_rule', 16);
+                }
+                if (!Schema::hasColumn('norms_versions', 'status')) {
+                    $table->string('status', 16);
+                }
+                if (!Schema::hasColumn('norms_versions', 'computed_at')) {
+                    $table->timestamp('computed_at')->nullable();
+                }
+                if (!Schema::hasColumn('norms_versions', 'created_at')) {
+                    $table->timestamp('created_at')->nullable();
+                }
+            });
+        }
+
+        if (!Schema::hasTable('norms_table')) {
+            Schema::create('norms_table', function (Blueprint $table) {
+                $table->bigIncrements('id');
+                $table->uuid('norms_version_id');
+                $table->string('metric_key', 8);
+                $table->integer('score_int');
+                $table->integer('leq_count');
+                $table->decimal('percentile', 8, 6);
+                $table->timestamp('created_at')->nullable();
+
+                $table->index(
+                    ['norms_version_id', 'metric_key', 'score_int'],
+                    'idx_norms_table_version_metric_score'
+                );
+            });
+        } else {
+            Schema::table('norms_table', function (Blueprint $table) {
+                if (!Schema::hasColumn('norms_table', 'id')) {
+                    $table->bigIncrements('id');
+                }
+                if (!Schema::hasColumn('norms_table', 'norms_version_id')) {
+                    $table->uuid('norms_version_id');
+                }
+                if (!Schema::hasColumn('norms_table', 'metric_key')) {
+                    $table->string('metric_key', 8);
+                }
+                if (!Schema::hasColumn('norms_table', 'score_int')) {
+                    $table->integer('score_int');
+                }
+                if (!Schema::hasColumn('norms_table', 'leq_count')) {
+                    $table->integer('leq_count');
+                }
+                if (!Schema::hasColumn('norms_table', 'percentile')) {
+                    $table->decimal('percentile', 8, 6);
+                }
+                if (!Schema::hasColumn('norms_table', 'created_at')) {
+                    $table->timestamp('created_at')->nullable();
+                }
+            });
+        }
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('norms_table');
+        Schema::dropIfExists('norms_versions');
+    }
+};

--- a/backend/docs/norms/norms-table-spec.md
+++ b/backend/docs/norms/norms-table-spec.md
@@ -1,0 +1,153 @@
+# 动态常模 v1：Norms Table 规范（全体样本 percentile）
+
+## 目标
+v1 仅提供**全体样本**的「超过 X% 的人」能力，默认不开启，不影响主链路。
+
+- 展示口径：超过 `over_percent`% 的人
+- 必须可解释、可回滚、可增量更新（v1 用全量窗口重算）
+- v1 不做分群（性别/年龄/地区）
+
+## Feature Flags
+- `NORMS_ENABLED=0/1`（默认 0）
+- `NORMS_VERSION_PIN=<uuid>`（可选：固定到某个 version_id，用于紧急回滚/线上 pin）
+
+## 数据口径（v1 写死）
+### 样本来源
+- 首选：`results` 表（attempt 完成并产出结果）
+- 必须能提取到 5 个维度分数（EI/SN/TF/JP/AT），v1 以 **scores_pct(0~100)** 为主
+
+### 纳入条件（MVP）
+- `results.is_valid = 1`（若该列存在；否则不作为过滤条件）
+- 时间窗口内：优先 `results.computed_at`，否则 `results.created_at`
+- pack 过滤：若 `results.content_package_version` 存在，则与 pack_id 的 version 对齐（见下）
+
+> v1 暂不强制 answers_count、答题时长（字段缺失则不做）
+
+### 指标维度（固定集合）
+- `metric_key` ∈ `EI | SN | TF | JP | AT`
+
+### score_int 离散化规则（写死）
+- 输入 score（来自 report 的 `scores_pct[metric_key]`）：
+  - `score_int = round(score)`（四舍五入，PHP round）
+- v1 仅支持整数 score_int 查询
+
+### pack_id 与 results 过滤
+- norms 以 `pack_id` 作为版本归属（例：`MBTI.cn-mainland.zh-CN.v0.2.1-TEST`）
+- 当 `results.content_package_version` 存在时：
+  - 从 `pack_id` 解析 version（示例：`v0.2.1-TEST`）
+  - 过滤 `results.content_package_version == version`
+
+## percentile 算法（写死）
+- 采用 **<= 排名规则**：
+  - `P(score) = count(scores <= score) / N`
+- 返回展示用：
+  - `over_percent = floor(P * 100)`（向下取整）
+
+## 数据表设计
+### 1) norms_versions
+用途：每次生成常模产生一个版本；回滚/Pin 的单位。
+
+字段：
+- `id` (uuid, pk)
+- `pack_id` (string)
+- `window_start_at` (timestamp, nullable)
+- `window_end_at` (timestamp, nullable)
+- `sample_n` (int)
+- `rank_rule` (string, 固定 `leq`)
+- `status` (string: `active | archived | failed`)
+- `computed_at` (timestamp, nullable)
+- `created_at` (timestamp, nullable)
+
+索引：
+- `(pack_id, status)`：`idx_norms_versions_pack_status`
+- `(created_at)`：`idx_norms_versions_created_at`
+
+约束/约定：
+- 同一 `pack_id` 同时只应有 1 条 `status=active`
+- 回滚：将历史版本切回 `active`，并将当前 active 置为 `archived`
+
+### 2) norms_table
+用途：查询 percentile 的映射表（O(1) 命中）。
+
+字段：
+- `id` (bigIncrements, pk)
+- `norms_version_id` (uuid)
+- `metric_key` (string(8))
+- `score_int` (int)
+- `leq_count` (int)
+- `percentile` (decimal(8,6), 0~1)
+- `created_at` (timestamp, nullable)
+
+索引：
+- `(norms_version_id, metric_key, score_int)`：`idx_norms_table_version_metric_score`
+
+说明：
+- 存 `leq_count` 便于校验与 debug
+- `N` 从 `norms_versions.sample_n` 获取
+
+## 查询契约
+### API：percentile 查询
+`GET /api/v0.2/norms/percentile?pack_id=...&metric_key=EI&score=42`
+
+返回字段（固定）：
+- `ok`
+- `pack_id`
+- `metric_key`
+- `score_int`
+- `percentile`（0~1）
+- `over_percent`（0~100）
+- `sample_n`
+- `window_start_at`
+- `window_end_at`
+- `version_id`
+- `rank_rule`（固定 leq）
+
+错误约定：
+- `NORMS_ENABLED=0`：`{ok:false,error:"NOT_ENABLED"}`
+- 无 active/pin version：`{ok:false,error:"NOT_FOUND"}`
+- metric_key 非法：HTTP 422
+
+## report 注入契约（后端）
+当 `NORMS_ENABLED=1` 且能命中所有维度 percentile 时，report 追加：
+
+`report.norms`：
+- `pack_id`
+- `version_id`
+- `N`
+- `window_start_at`
+- `window_end_at`
+- `rank_rule`
+- `metrics`（EI/SN/TF/JP/AT）：
+  - `score_int`
+  - `percentile`
+  - `over_percent`
+
+降级：
+- 任一条件不满足（未启用/无版本/无表/任一维度缺行）→ **不注入** `report.norms`，不影响报告主体
+
+## 回滚策略（写死）
+- 线上紧急回滚优先使用：
+  - `NORMS_VERSION_PIN=<历史version_id>`
+- 或数据层回滚：
+  - 将历史版本置为 `active`
+  - 将当前 active 置为 `archived`
+
+## v1 样例（用于前端展示）
+### 结果页文案
+- `超过 {{over_percent}}% 的人（N={{N}}，统计区间：{{window_start_at}}~{{window_end_at}}）`
+
+### API JSON 示例
+```json
+{
+  "ok": true,
+  "pack_id": "MBTI.cn-mainland.zh-CN.v0.2.1-TEST",
+  "metric_key": "EI",
+  "score_int": 50,
+  "percentile": 0.5,
+  "over_percent": 50,
+  "sample_n": 200,
+  "window_start_at": "2025-01-20 06:14:01",
+  "window_end_at": "2026-01-20 06:14:01",
+  "version_id": "c4b43172-bb70-4eca-8455-32b0bf27883a",
+  "rank_rule": "leq"
+}

--- a/backend/docs/norms/update-schedule.md
+++ b/backend/docs/norms/update-schedule.md
@@ -1,0 +1,55 @@
+# 动态常模 v1：更新频率与降级/回滚策略
+
+## 默认状态（未正式上线提醒）
+- 默认 **不启用**：`NORMS_ENABLED=0`
+- 未满足上线 checklist 前禁止开启（见文末）
+
+## 更新频率（v1）
+- 建议：每周一 03:00（本地/线上 cron）
+- v1 采用 **全量窗口重算**（简单可靠，可回滚）
+
+## 窗口策略（写死）
+- 默认窗口：最近 365 天
+- 样本阈值（写死）：`N < 200` → 不产生新版本，保留现有 `active`
+
+## 更新命令（v1）
+- `php artisan norms:update --pack_id="<pack_id>"`
+- 产物：
+  - 新增一条 `norms_versions(status=active)`
+  - 写入 `norms_table`
+  - 将旧 active（同 pack_id）置为 `archived`
+
+## 失败降级策略（写死）
+任一条件不满足时：
+- 命令端：
+  - 无可用分数源列 → 直接退出（不改动现有 active）
+  - `N < 200` → 直接退出（不改动现有 active）
+  - DB 事务失败 → 不改动现有 active
+- 服务端（report 注入 / percentile API）：
+  - 缺表/缺版本/缺行 → 返回 NOT_FOUND 或不注入 norms
+  - 不影响 `/attempts/:id/report` 主体结构与 CI 主链路
+
+## 回滚步骤（两种）
+### 方案 A：Pin（推荐线上应急）
+1. 查出历史版本 `version_id`
+2. 设置环境变量：
+   - `NORMS_VERSION_PIN=<version_id>`
+3. 重启服务
+
+### 方案 B：切换 active（数据层回滚）
+1. 将目标历史版本置为 active：
+   - `UPDATE norms_versions SET status='active' WHERE id='<version_id>';`
+2. 将其他同 pack_id 的 active 置为 archived：
+   - `UPDATE norms_versions SET status='archived' WHERE pack_id='<pack_id>' AND id!='<version_id>' AND status='active';`
+
+## 审计记录（v1 最小）
+- `norms_versions` 本身即为审计：computed_at/window/sample_n/status
+- 如需更强审计（可选）：增加 norms_runs 表记录每次执行与错误栈（v1 可后置）
+
+## 上线 checklist（开启 NORMS_ENABLED 前必须满足）
+- [ ] `norms:update` 可稳定产出 `active` 版本（N>=200）
+- [ ] percentile API 在 `NORMS_ENABLED=1` 时可命中（至少 1 个 pack）
+- [ ] 回滚演练通过（Pin/切 active 任一方式）
+- [ ] 监控项（可选）：
+  - active 版本 computed_at 距今 > 14 天告警
+  - 版本 sample_n 异常波动告警

--- a/backend/routes/api.php
+++ b/backend/routes/api.php
@@ -11,6 +11,7 @@ use App\Http\Controllers\API\V0_2\AuthProviderController;
 use App\Http\Controllers\API\V0_2\ClaimController;
 use App\Http\Controllers\API\V0_2\IdentityController;
 use App\Http\Controllers\API\V0_2\MeController;
+use App\Http\Controllers\API\V0_2\NormsController;
 use App\Http\Controllers\API\V0_2\ShareController;
 
 /*
@@ -67,6 +68,9 @@ Route::prefix("v0.2")->group(function () {
     // 8) 事件上报（目前你前端已带 Authorization，但事件是否门禁你可后续决定）
     // 这里先保持公开（不影响主链路）
     Route::post("/events", [EventController::class, "store"]);
+
+    // 9) Norms percentile (stub controller, implemented later)
+    Route::get("/norms/percentile", [NormsController::class, "percentile"]);
 
     // =========================================================
     // ✅ Step 1：最小后端鉴权（只 gate 你指定的 3 个接口）


### PR DESCRIPTION
	做了什么：新增 norms 三表 + norms:update 命令 + /api/v0.2/norms/percentile + report 可选注入
	•	默认行为不变：NORMS_ENABLED=0 时 report 不含 report.norms（且 CI 主链路不受影响）
	•	如何验证：NORMS_ENABLED=1 + 先 php artisan norms:update --pack_id=... 再请求 report/percentile