### PR TITLE
share_click: allow recommended_reads when content_graph enabled

### DIFF
--- a/backend/app/Http/Controllers/API/V0_2/ShareController.php
+++ b/backend/app/Http/Controllers/API/V0_2/ShareController.php
@@ -292,7 +292,16 @@ $event->anon_id = ($clickAnonId !== null && $clickAnonId !== '') ? $clickAnonId 
     private function allowedReportKeys(): array
     {
         $keys = config('report.share_report_allowed_keys', []);
-        return is_array($keys) ? $keys : [];
+        $keys = is_array($keys) ? $keys : [];
+
+        // ✅ content_graph 打开时：share_click 响应允许透传 recommended_reads
+        if ((bool) env('CONTENT_GRAPH_ENABLED', false)) {
+            if (!in_array('recommended_reads', $keys, true)) {
+                $keys[] = 'recommended_reads';
+            }
+        }
+
+        return $keys;
     }
 
     /**


### PR DESCRIPTION
•	What: share_click 白名单在 CONTENT_GRAPH_ENABLED=1 时追加 recommended_reads
	•	Why: 与 /attempts/{id}/report 保持一致；share_click 返回 report 需要推荐内容
	•	Verify: CONTENT_GRAPH_ENABLED=1 PHONE=... API=... bash backend/scripts/ci_verify_mbti.sh 全绿