### PR TITLE
feat(research): add whitepaper pdf build script (9D)

### DIFF
--- a/backend/scripts/whitepaper_build.sh
+++ b/backend/scripts/whitepaper_build.sh
@@ -1,0 +1,110 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+BACKEND_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+ROOT_DIR="$(cd "$BACKEND_DIR/.." && pwd)"
+
+INPUT_REL="research/whitepaper-2026-norms/index.html"
+DATA_NORMS_REL="research/whitepaper-2026-norms/data/norms.json"
+DATA_SCHEMA_REL="research/whitepaper-2026-norms/data/schema.json"
+OUT_REL="research/whitepaper-2026-norms/whitepaper.pdf"
+
+INPUT="$ROOT_DIR/$INPUT_REL"
+DATA_NORMS="$ROOT_DIR/$DATA_NORMS_REL"
+DATA_SCHEMA="$ROOT_DIR/$DATA_SCHEMA_REL"
+OUT="$ROOT_DIR/$OUT_REL"
+
+if [[ "${WHITEPAPER_ENABLED:-0}" != "1" ]]; then
+  echo "[WHITEPAPER] skip (disabled). Set WHITEPAPER_ENABLED=1 to build."
+  exit 0
+fi
+
+require_cmd() {
+  local cmd="$1"
+  if ! command -v "$cmd" >/dev/null 2>&1; then
+    echo "[FAIL] missing required command: $cmd" >&2
+    exit 1
+  fi
+}
+
+missing=0
+for f in "$INPUT" "$DATA_NORMS" "$DATA_SCHEMA"; do
+  if [[ ! -f "$f" ]]; then
+    echo "[FAIL] missing required file: $f" >&2
+    missing=1
+  fi
+done
+if [[ "$missing" -ne 0 ]]; then
+  echo "[FAIL] 请先完成 9B/9C" >&2
+  exit 2
+fi
+
+pick_chrome() {
+  local candidate
+  for candidate in \
+    "${CHROME_BIN:-}" \
+    "$(command -v google-chrome || true)" \
+    "$(command -v chromium || true)" \
+    "$(command -v chromium-browser || true)" \
+    "/Applications/Google Chrome.app/Contents/MacOS/Google Chrome"
+  do
+    if [[ -n "$candidate" && -x "$candidate" ]]; then
+      echo "$candidate"
+      return 0
+    fi
+  done
+  return 1
+}
+
+build_with_chrome() {
+  local bin="$1"
+  rm -f "$OUT"
+  "$bin" \
+    --headless \
+    --disable-gpu \
+    --no-sandbox \
+    --print-to-pdf="$OUT" \
+    "file://$INPUT"
+}
+
+build_with_wkhtmltopdf() {
+  rm -f "$OUT"
+  wkhtmltopdf "file://$INPUT" "$OUT"
+}
+
+TOOL_USED=""
+if chrome_bin="$(pick_chrome)"; then
+  build_with_chrome "$chrome_bin"
+  TOOL_USED="chrome"
+elif command -v wkhtmltopdf >/dev/null 2>&1; then
+  build_with_wkhtmltopdf
+  TOOL_USED="wkhtmltopdf"
+else
+  echo "[FAIL] no headless PDF tool found." >&2
+  echo "[HINT] macOS: brew install --cask google-chrome" >&2
+  echo "[HINT] macOS: brew install chromium" >&2
+  echo "[HINT] wkhtmltopdf: brew install wkhtmltopdf" >&2
+  exit 3
+fi
+
+if [[ ! -s "$OUT" ]]; then
+  echo "[FAIL] PDF not generated or empty: $OUT" >&2
+  exit 4
+fi
+
+require_cmd rg
+rg -n '"@type"\s*:\s*"Article"' "$INPUT" -S >/dev/null
+rg -n '"@type"\s*:\s*"Dataset"' "$INPUT" -S >/dev/null
+
+file_size() {
+  local file="$1"
+  if stat -f%z "$file" >/dev/null 2>&1; then
+    stat -f%z "$file"
+  else
+    stat -c%s "$file"
+  fi
+}
+
+echo "[WHITEPAPER] ok ($TOOL_USED) size=$(file_size "$OUT") bytes at $(date -u +"%Y-%m-%dT%H:%M:%SZ")"
+echo "[WHITEPAPER] output: $OUT_REL"


### PR DESCRIPTION
## Summary（改了什么）
- 新增 `backend/scripts/whitepaper_build.sh`：在 `WHITEPAPER_ENABLED=1` 时，从 `research/whitepaper-2026-norms/index.html` 同源生成 `research/whitepaper-2026-norms/whitepaper.pdf`
- 默认 `WHITEPAPER_ENABLED=0`：脚本直接 skip（不生成、不报错）
- 不改 routes/migrations/middleware/controller；不接入 `backend/scripts/ci_verify_mbti.sh` 主链路（主链路保持全绿）

## Preconditions（硬门槛）
- 必须已存在：
  - `research/whitepaper-2026-norms/index.html`（9C）
  - `research/whitepaper-2026-norms/data/norms.json`（9B）
  - `research/whitepaper-2026-norms/data/schema.json`（9B）
- 缺任意文件：脚本在 enabled 模式下 fail 并提示先完成 9B/9C

## Behavior（执行逻辑）
- 生成方式优先级：
  1) Chrome/Chromium headless `--print-to-pdf`
  2) `wkhtmltopdf`（若已安装）
- 若无可用工具：给出清晰错误与安装提示（macOS brew 提示）
- 最小校验（enabled 且生成后）：
  - `whitepaper.pdf` 存在且非空
  - `index.html` 含 JSON-LD 的 `Article` 与 `Dataset`

## Verification（最小验收命令集）
# Step 1 (Routes)
( cd backend && php artisan route:list | rg "whitepaper|research|dataset" || true )

# Step 2 (Migrations)
( cd backend && php artisan migrate )

# Step 3 (Middleware 401/200 sanity)
lsof -ti tcp:18000 | xargs kill -9 2>/dev/null || true
( cd backend && php artisan serve --host=127.0.0.1 --port=18000 >/tmp/fap_serve_18000.log 2>&1 & )
API="httphttp://127.0.0.1:18000"
curl -sS -i "$API/api/v0.2/me/attempts" -H "Accept: application/json" | head -n 20
FM_TOKEN="$(curl -sS -X POST "$API/api/v0.2/auth/wx_phone" -H "Content-Type: application/json" -d '{"wx_code":"dev","phone_code":"dev","anon_id":"wp_9d"}' | jq -r '.token')"
curl -sS -i "$API/api/v0.2/me/attempts" -H "Accept: application/json" -H "Authorization: Bearer ${FM_TOKEN}" | head -n 20

# Step 4 (Precheck)
test -f research/whitepaper-2026-norms/index.html
test -f research/whitepaper-2026-norms/data/norms.json
test -f research/whitepaper-2026-norms/data/schema.json

# Step 5 (Script build + CI green)
WHITEPAPER_ENABLED=1 bash backend/scripts/whitepaper_build.sh
test -s research/whitepaper-2026-norms/whitepaper.pdf
rg -n "\"@type\"\\s*:\\s*\"Dataset\"|\"@type\"\\s*:\\s*\"Article\"" research/whitepaper-2026-norms/index.html -S
lsof -ti tcp:18000 | xargs kill -9 2>/dev/null || true
API="http://127.0.0.1:18000" bash backend/scripts/ci_verify_mbti.sh

## Notes
- `whitepaper.pdf` 为本地生成产物，不纳入提交。