### PR TITLE
feat(payments): orders + benefits MVP (11B)

### DIFF
--- a/backend/app/Http/Controllers/API/V0_2/PaymentsController.php
+++ b/backend/app/Http/Controllers/API/V0_2/PaymentsController.php
@@ -1,0 +1,259 @@
+<?php
+
+namespace App\Http\Controllers\API\V0_2;
+
+use App\Http\Controllers\Controller;
+use App\Http\Requests\V0_2\CreateOrderRequest;
+use App\Services\Payments\PaymentService;
+use Illuminate\Http\Request;
+
+class PaymentsController extends Controller
+{
+    public function createOrder(CreateOrderRequest $request)
+    {
+        if (!$this->paymentsEnabled()) {
+            return $this->paymentsDisabledResponse();
+        }
+
+        [$userId, $anonId] = $this->resolveActor($request);
+        if (!$userId && !$anonId) {
+            return $this->unauthorizedResponse();
+        }
+
+        $service = app(PaymentService::class);
+        $result = $service->createOrder([
+            'item_sku' => $request->itemSku(),
+            'currency' => $request->currency(),
+            'amount_total' => $request->amountTotal(),
+            'device_id' => $request->deviceId(),
+            'request_id' => $request->requestId(),
+            'ip' => (string) ($request->ip() ?? ''),
+        ], [
+            'user_id' => $userId ?? $anonId,
+            'anon_id' => $anonId,
+        ]);
+
+        if (!$result['ok']) {
+            return response()->json([
+                'ok' => false,
+                'error' => $result['error'] ?? 'CREATE_FAILED',
+                'message' => $result['message'] ?? 'create order failed.',
+            ], (int) ($result['status'] ?? 500));
+        }
+
+        $order = $result['order'];
+
+        return response()->json([
+            'ok' => true,
+            'order_id' => $order['id'],
+            'status' => $order['status'],
+            'currency' => $order['currency'],
+            'amount_total' => $order['amount_total'],
+            'item_sku' => $order['item_sku'],
+        ]);
+    }
+
+    public function markPaid(Request $request, string $id)
+    {
+        if (!$this->paymentsEnabled()) {
+            return $this->paymentsDisabledResponse();
+        }
+
+        if (!$this->devModeAllowed()) {
+            return response()->json([
+                'ok' => false,
+                'error' => 'DEV_ONLY',
+                'message' => 'mark_paid is only available in dev mode.',
+            ], 403);
+        }
+
+        [$userId, $anonId] = $this->resolveActor($request);
+        if (!$userId && !$anonId) {
+            return $this->unauthorizedResponse();
+        }
+
+        $service = app(PaymentService::class);
+        $result = $service->markPaid($id, (string) ($userId ?? $anonId), $anonId, [
+            'request_id' => $this->requestId($request),
+            'ip' => (string) ($request->ip() ?? ''),
+        ]);
+
+        if (!$result['ok']) {
+            return response()->json([
+                'ok' => false,
+                'error' => $result['error'] ?? 'MARK_PAID_FAILED',
+                'message' => $result['message'] ?? 'mark paid failed.',
+            ], (int) ($result['status'] ?? 500));
+        }
+
+        $order = $result['order'];
+
+        return response()->json([
+            'ok' => true,
+            'order_id' => $order->id,
+            'status' => $order->status,
+            'paid_at' => $order->paid_at,
+        ]);
+    }
+
+    public function fulfill(Request $request, string $id)
+    {
+        if (!$this->paymentsEnabled()) {
+            return $this->paymentsDisabledResponse();
+        }
+
+        [$userId, $anonId] = $this->resolveActor($request);
+        if (!$userId && !$anonId) {
+            return $this->unauthorizedResponse();
+        }
+
+        $service = app(PaymentService::class);
+        $result = $service->fulfill($id, (string) ($userId ?? $anonId), $anonId);
+
+        if (!$result['ok']) {
+            return response()->json([
+                'ok' => false,
+                'error' => $result['error'] ?? 'FULFILL_FAILED',
+                'message' => $result['message'] ?? 'fulfill failed.',
+            ], (int) ($result['status'] ?? 500));
+        }
+
+        $order = $result['order'];
+
+        return response()->json([
+            'ok' => true,
+            'order_id' => $order->id,
+            'status' => $order->status,
+            'fulfilled_at' => $order->fulfilled_at,
+            'benefit' => $result['benefit'] ?? null,
+        ]);
+    }
+
+    public function meBenefits(Request $request)
+    {
+        if (!$this->paymentsEnabled()) {
+            return $this->paymentsDisabledResponse();
+        }
+
+        [$userId, $anonId] = $this->resolveActor($request);
+        if (!$userId && !$anonId) {
+            return $this->unauthorizedResponse();
+        }
+
+        $service = app(PaymentService::class);
+        $result = $service->listBenefits((string) ($userId ?? $anonId));
+
+        if (!$result['ok']) {
+            return response()->json([
+                'ok' => false,
+                'error' => $result['error'] ?? 'BENEFITS_FAILED',
+                'message' => $result['message'] ?? 'benefits query failed.',
+            ], (int) ($result['status'] ?? 500));
+        }
+
+        return response()->json([
+            'ok' => true,
+            'user_id' => (string) ($userId ?? $anonId),
+            'items' => $result['items'] ?? [],
+        ]);
+    }
+
+    private function paymentsEnabled(): bool
+    {
+        return $this->boolish(env('PAYMENTS_ENABLED', '0'));
+    }
+
+    private function devModeAllowed(): bool
+    {
+        if (app()->environment('local')) {
+            return true;
+        }
+
+        if (config('app.debug') === true) {
+            return true;
+        }
+
+        return $this->boolish(env('PAYMENTS_DEV_MODE', '0'));
+    }
+
+    private function paymentsDisabledResponse()
+    {
+        return response()->json([
+            'ok' => false,
+            'error' => 'PAYMENTS_DISABLED',
+            'message' => 'Payments API is disabled.',
+        ], 404);
+    }
+
+    private function unauthorizedResponse()
+    {
+        return response()->json([
+            'ok' => false,
+            'error' => 'UNAUTHORIZED',
+            'message' => 'Missing or invalid fm_token.',
+        ], 401);
+    }
+
+    private function resolveActor(Request $request): array
+    {
+        $userId = $this->resolveUserId($request);
+        $anonId = $this->resolveAnonId($request);
+
+        if (!$userId && $anonId) {
+            $userId = $anonId;
+        }
+
+        return [$userId, $anonId];
+    }
+
+    private function resolveUserId(Request $request): ?string
+    {
+        $uid = $request->attributes->get('fm_user_id');
+        if (is_string($uid) && trim($uid) !== '') {
+            return trim($uid);
+        }
+
+        $authId = auth()->id();
+        if ($authId !== null && (string) $authId !== '') {
+            return (string) $authId;
+        }
+
+        $u = $request->user();
+        if ($u && isset($u->id)) {
+            return (string) $u->id;
+        }
+
+        return null;
+    }
+
+    private function resolveAnonId(Request $request): ?string
+    {
+        $anonId = $request->attributes->get('anon_id');
+        if (is_string($anonId) && trim($anonId) !== '') {
+            return trim($anonId);
+        }
+
+        $anonId = $request->input('anon_id', $request->header('X-Anon-Id', null));
+        $anonId = is_string($anonId) ? trim($anonId) : null;
+        return $anonId !== '' ? $anonId : null;
+    }
+
+    private function requestId(Request $request): ?string
+    {
+        $v = $request->header('X-Request-Id', $request->input('request_id', null));
+        $v = is_string($v) ? trim($v) : null;
+        return $v !== '' ? $v : null;
+    }
+
+    private function boolish($v): bool
+    {
+        if (is_bool($v)) {
+            return $v;
+        }
+        if ($v === null) {
+            return false;
+        }
+        $s = strtolower(trim((string) $v));
+        return in_array($s, ['1', 'true', 'yes', 'on'], true);
+    }
+}

--- a/backend/app/Http/Requests/V0_2/CreateOrderRequest.php
+++ b/backend/app/Http/Requests/V0_2/CreateOrderRequest.php
@@ -1,0 +1,69 @@
+<?php
+
+namespace App\Http\Requests\V0_2;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class CreateOrderRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    protected function prepareForValidation(): void
+    {
+        $amount = $this->input('amount_total', null);
+        if (is_numeric($amount)) {
+            $amount = (int) $amount;
+        }
+
+        $currency = strtoupper(trim((string) $this->input('currency', 'CNY')));
+
+        $this->merge([
+            'item_sku' => trim((string) $this->input('item_sku', '')),
+            'currency' => $currency !== '' ? $currency : 'CNY',
+            'amount_total' => $amount,
+            'device_id' => $this->input('device_id', $this->header('X-Device-Id', null)),
+        ]);
+    }
+
+    public function rules(): array
+    {
+        return [
+            'item_sku' => ['required', 'string', 'max:64'],
+            'currency' => ['required', 'string', 'max:8'],
+            'amount_total' => ['required', 'integer', 'min:1'],
+            'device_id' => ['nullable', 'string', 'max:128'],
+        ];
+    }
+
+    public function itemSku(): string
+    {
+        return (string) $this->validated()['item_sku'];
+    }
+
+    public function currency(): string
+    {
+        return (string) $this->validated()['currency'];
+    }
+
+    public function amountTotal(): int
+    {
+        return (int) $this->validated()['amount_total'];
+    }
+
+    public function deviceId(): ?string
+    {
+        $v = $this->validated()['device_id'] ?? null;
+        $v = is_string($v) ? trim($v) : null;
+        return $v !== '' ? $v : null;
+    }
+
+    public function requestId(): ?string
+    {
+        $v = $this->header('X-Request-Id', $this->input('request_id', null));
+        $v = is_string($v) ? trim($v) : null;
+        return $v !== '' ? $v : null;
+    }
+}

--- a/backend/app/Services/Payments/PaymentService.php
+++ b/backend/app/Services/Payments/PaymentService.php
@@ -1,0 +1,340 @@
+<?php
+
+namespace App\Services\Payments;
+
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Support\Str;
+
+class PaymentService
+{
+    public const BENEFIT_TYPE = 'report_unlock';
+    public const BENEFIT_REF = 'mbti_report_v1';
+
+    public function createOrder(array $data, array $actor): array
+    {
+        if (!Schema::hasTable('orders')) {
+            return $this->tableMissing('orders');
+        }
+
+        $orderId = (string) Str::uuid();
+        $now = now();
+
+        $row = [
+            'id' => $orderId,
+            'user_id' => $this->trimOrNull($actor['user_id'] ?? null),
+            'anon_id' => $this->trimOrNull($actor['anon_id'] ?? null),
+            'device_id' => $this->trimOrNull($data['device_id'] ?? null),
+            'provider' => 'internal',
+            'provider_order_id' => null,
+            'status' => 'pending',
+            'currency' => (string) ($data['currency'] ?? 'CNY'),
+            'amount_total' => (int) ($data['amount_total'] ?? 0),
+            'amount_refunded' => 0,
+            'item_sku' => (string) ($data['item_sku'] ?? ''),
+            'request_id' => $this->trimOrNull($data['request_id'] ?? null),
+            'created_ip' => $this->trimOrNull($data['ip'] ?? null),
+            'paid_at' => null,
+            'fulfilled_at' => null,
+            'refunded_at' => null,
+            'created_at' => $now,
+            'updated_at' => $now,
+        ];
+
+        DB::table('orders')->insert($row);
+
+        return [
+            'ok' => true,
+            'order' => $row,
+        ];
+    }
+
+    public function markPaid(string $orderId, string $userId, ?string $anonId, array $context = []): array
+    {
+        if (!Schema::hasTable('orders')) {
+            return $this->tableMissing('orders');
+        }
+
+        $order = DB::table('orders')->where('id', $orderId)->first();
+        if (!$order) {
+            return $this->notFound('ORDER_NOT_FOUND', 'order not found.');
+        }
+
+        if (!$this->orderBelongsToActor($order, $userId, $anonId)) {
+            return $this->forbidden('ORDER_FORBIDDEN', 'order not owned.');
+        }
+
+        if (in_array($order->status, ['paid', 'fulfilled'], true)) {
+            return [
+                'ok' => true,
+                'order' => $order,
+            ];
+        }
+
+        if ($order->status !== 'pending') {
+            return $this->conflict('ORDER_NOT_PENDING', 'order status not pending.');
+        }
+
+        $now = now();
+
+        if (Schema::hasTable('payment_events')) {
+            $providerEventId = 'dev_mark_paid:' . $orderId;
+            $existing = DB::table('payment_events')->where('provider_event_id', $providerEventId)->first();
+
+            if (!$existing) {
+                $payload = [
+                    'mode' => 'dev',
+                    'event' => 'mark_paid',
+                    'order_id' => $orderId,
+                ];
+
+                DB::table('payment_events')->insert([
+                    'id' => (string) Str::uuid(),
+                    'provider' => 'internal',
+                    'provider_event_id' => $providerEventId,
+                    'order_id' => $orderId,
+                    'event_type' => 'mark_paid',
+                    'payload_json' => json_encode($payload, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES),
+                    'signature_ok' => true,
+                    'handled_at' => $now,
+                    'handle_status' => 'ok',
+                    'request_id' => $this->trimOrNull($context['request_id'] ?? null),
+                    'ip' => $this->trimOrNull($context['ip'] ?? null),
+                    'headers_digest' => null,
+                    'created_at' => $now,
+                    'updated_at' => $now,
+                ]);
+            }
+        }
+
+        DB::table('orders')
+            ->where('id', $orderId)
+            ->update([
+                'status' => 'paid',
+                'paid_at' => $now,
+                'updated_at' => $now,
+            ]);
+
+        $order = DB::table('orders')->where('id', $orderId)->first();
+
+        return [
+            'ok' => true,
+            'order' => $order,
+        ];
+    }
+
+    public function fulfill(string $orderId, string $userId, ?string $anonId): array
+    {
+        if (!Schema::hasTable('orders')) {
+            return $this->tableMissing('orders');
+        }
+        if (!Schema::hasTable('benefit_grants')) {
+            return $this->tableMissing('benefit_grants');
+        }
+
+        $order = DB::table('orders')->where('id', $orderId)->first();
+        if (!$order) {
+            return $this->notFound('ORDER_NOT_FOUND', 'order not found.');
+        }
+
+        if (!$this->orderBelongsToActor($order, $userId, $anonId)) {
+            return $this->forbidden('ORDER_FORBIDDEN', 'order not owned.');
+        }
+
+        if (!in_array($order->status, ['paid', 'fulfilled'], true)) {
+            return $this->conflict('ORDER_NOT_PAID', 'order status not paid.');
+        }
+
+        $targetUserId = $this->trimOrNull($userId) ?: $this->trimOrNull($order->user_id ?? null);
+        if (!$targetUserId) {
+            $targetUserId = $this->trimOrNull($anonId) ?: $this->trimOrNull($order->anon_id ?? null);
+        }
+
+        if (!$targetUserId) {
+            return [
+                'ok' => false,
+                'status' => 422,
+                'error' => 'MISSING_USER',
+                'message' => 'missing user id for benefit grant.',
+            ];
+        }
+
+        $now = now();
+        $benefitRow = DB::table('benefit_grants')
+            ->where('source_order_id', $orderId)
+            ->where('benefit_type', self::BENEFIT_TYPE)
+            ->where('benefit_ref', self::BENEFIT_REF)
+            ->first();
+
+        if (!$benefitRow) {
+            $benefitRow = [
+                'id' => (string) Str::uuid(),
+                'user_id' => $targetUserId,
+                'benefit_type' => self::BENEFIT_TYPE,
+                'benefit_ref' => self::BENEFIT_REF,
+                'source_order_id' => $orderId,
+                'source_event_id' => null,
+                'status' => 'active',
+                'expires_at' => null,
+                'created_at' => $now,
+                'updated_at' => $now,
+            ];
+
+            DB::table('benefit_grants')->insert($benefitRow);
+        }
+
+        if ($order->status !== 'fulfilled') {
+            DB::table('orders')
+                ->where('id', $orderId)
+                ->update([
+                    'status' => 'fulfilled',
+                    'fulfilled_at' => $now,
+                    'updated_at' => $now,
+                ]);
+        }
+
+        $order = DB::table('orders')->where('id', $orderId)->first();
+
+        return [
+            'ok' => true,
+            'order' => $order,
+            'benefit' => $this->presentBenefit($benefitRow),
+        ];
+    }
+
+    public function listBenefits(string $userId): array
+    {
+        if (!Schema::hasTable('benefit_grants')) {
+            return $this->tableMissing('benefit_grants');
+        }
+
+        $userId = trim($userId);
+        if ($userId === '') {
+            return [
+                'ok' => false,
+                'status' => 422,
+                'error' => 'INVALID_USER',
+                'message' => 'user id missing.',
+            ];
+        }
+
+        $q = DB::table('benefit_grants')->where('user_id', $userId);
+
+        if (Schema::hasColumn('benefit_grants', 'status')) {
+            $q->where('status', 'active');
+        }
+
+        if (Schema::hasColumn('benefit_grants', 'expires_at')) {
+            $q->where(function ($sub) {
+                $sub->whereNull('expires_at')->orWhere('expires_at', '>', now());
+            });
+        }
+
+        $rows = $q->orderByDesc('created_at')->limit(100)->get();
+
+        $items = [];
+        foreach ($rows as $row) {
+            $items[] = [
+                'id' => $row->id ?? null,
+                'benefit_type' => $row->benefit_type ?? null,
+                'benefit_ref' => $row->benefit_ref ?? null,
+                'status' => $row->status ?? null,
+                'expires_at' => $row->expires_at ?? null,
+                'source_order_id' => $row->source_order_id ?? null,
+            ];
+        }
+
+        return [
+            'ok' => true,
+            'items' => $items,
+        ];
+    }
+
+    private function orderBelongsToActor(object $order, ?string $userId, ?string $anonId): bool
+    {
+        $userId = $this->trimOrNull($userId);
+        $anonId = $this->trimOrNull($anonId);
+
+        if ($userId && isset($order->user_id) && $order->user_id === $userId) {
+            return true;
+        }
+
+        if ($anonId && isset($order->anon_id) && $order->anon_id === $anonId) {
+            return true;
+        }
+
+        return false;
+    }
+
+    private function tableMissing(string $table): array
+    {
+        return [
+            'ok' => false,
+            'status' => 500,
+            'error' => 'TABLE_MISSING',
+            'message' => "{$table} table missing.",
+        ];
+    }
+
+    private function notFound(string $error, string $message): array
+    {
+        return [
+            'ok' => false,
+            'status' => 404,
+            'error' => $error,
+            'message' => $message,
+        ];
+    }
+
+    private function forbidden(string $error, string $message): array
+    {
+        return [
+            'ok' => false,
+            'status' => 403,
+            'error' => $error,
+            'message' => $message,
+        ];
+    }
+
+    private function conflict(string $error, string $message): array
+    {
+        return [
+            'ok' => false,
+            'status' => 409,
+            'error' => $error,
+            'message' => $message,
+        ];
+    }
+
+    private function trimOrNull($value): ?string
+    {
+        if (!is_string($value)) {
+            return null;
+        }
+        $v = trim($value);
+        return $v !== '' ? $v : null;
+    }
+
+    private function presentBenefit($row): array
+    {
+        if (is_array($row)) {
+            return [
+                'id' => $row['id'] ?? null,
+                'benefit_type' => $row['benefit_type'] ?? null,
+                'benefit_ref' => $row['benefit_ref'] ?? null,
+                'status' => $row['status'] ?? null,
+                'expires_at' => $row['expires_at'] ?? null,
+                'source_order_id' => $row['source_order_id'] ?? null,
+            ];
+        }
+
+        return [
+            'id' => $row->id ?? null,
+            'benefit_type' => $row->benefit_type ?? null,
+            'benefit_ref' => $row->benefit_ref ?? null,
+            'status' => $row->status ?? null,
+            'expires_at' => $row->expires_at ?? null,
+            'source_order_id' => $row->source_order_id ?? null,
+        ];
+    }
+}

--- a/backend/database/migrations/2026_01_22_090010_create_orders_table.php
+++ b/backend/database/migrations/2026_01_22_090010_create_orders_table.php
@@ -1,0 +1,96 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        if (!Schema::hasTable('orders')) {
+            Schema::create('orders', function (Blueprint $table) {
+                $table->uuid('id')->primary();
+                $table->string('user_id', 64)->nullable()->index();
+                $table->string('anon_id', 64)->nullable()->index();
+                $table->string('device_id', 128)->nullable();
+                $table->string('provider', 32)->default('internal');
+                $table->string('provider_order_id', 128)->nullable();
+                $table->string('status', 32)->default('pending')->index();
+                $table->string('currency', 8);
+                $table->integer('amount_total');
+                $table->integer('amount_refunded')->default(0);
+                $table->string('item_sku', 64);
+                $table->string('request_id', 128)->nullable();
+                $table->string('created_ip', 45)->nullable();
+                $table->timestamp('paid_at')->nullable();
+                $table->timestamp('fulfilled_at')->nullable();
+                $table->timestamp('refunded_at')->nullable();
+                $table->timestamps();
+            });
+            return;
+        }
+
+        Schema::table('orders', function (Blueprint $table) {
+            if (!Schema::hasColumn('orders', 'id')) {
+                $table->uuid('id')->primary();
+            }
+            if (!Schema::hasColumn('orders', 'user_id')) {
+                $table->string('user_id', 64)->nullable()->index();
+            }
+            if (!Schema::hasColumn('orders', 'anon_id')) {
+                $table->string('anon_id', 64)->nullable()->index();
+            }
+            if (!Schema::hasColumn('orders', 'device_id')) {
+                $table->string('device_id', 128)->nullable();
+            }
+            if (!Schema::hasColumn('orders', 'provider')) {
+                $table->string('provider', 32)->default('internal');
+            }
+            if (!Schema::hasColumn('orders', 'provider_order_id')) {
+                $table->string('provider_order_id', 128)->nullable();
+            }
+            if (!Schema::hasColumn('orders', 'status')) {
+                $table->string('status', 32)->default('pending')->index();
+            }
+            if (!Schema::hasColumn('orders', 'currency')) {
+                $table->string('currency', 8)->nullable();
+            }
+            if (!Schema::hasColumn('orders', 'amount_total')) {
+                $table->integer('amount_total')->default(0);
+            }
+            if (!Schema::hasColumn('orders', 'amount_refunded')) {
+                $table->integer('amount_refunded')->default(0);
+            }
+            if (!Schema::hasColumn('orders', 'item_sku')) {
+                $table->string('item_sku', 64)->nullable();
+            }
+            if (!Schema::hasColumn('orders', 'request_id')) {
+                $table->string('request_id', 128)->nullable();
+            }
+            if (!Schema::hasColumn('orders', 'created_ip')) {
+                $table->string('created_ip', 45)->nullable();
+            }
+            if (!Schema::hasColumn('orders', 'paid_at')) {
+                $table->timestamp('paid_at')->nullable();
+            }
+            if (!Schema::hasColumn('orders', 'fulfilled_at')) {
+                $table->timestamp('fulfilled_at')->nullable();
+            }
+            if (!Schema::hasColumn('orders', 'refunded_at')) {
+                $table->timestamp('refunded_at')->nullable();
+            }
+            if (!Schema::hasColumn('orders', 'created_at')) {
+                $table->timestamp('created_at')->nullable();
+            }
+            if (!Schema::hasColumn('orders', 'updated_at')) {
+                $table->timestamp('updated_at')->nullable();
+            }
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('orders');
+    }
+};

--- a/backend/database/migrations/2026_01_22_090020_create_benefit_grants_table.php
+++ b/backend/database/migrations/2026_01_22_090020_create_benefit_grants_table.php
@@ -1,0 +1,66 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        if (!Schema::hasTable('benefit_grants')) {
+            Schema::create('benefit_grants', function (Blueprint $table) {
+                $table->uuid('id')->primary();
+                $table->string('user_id', 64)->index();
+                $table->string('benefit_type', 64);
+                $table->string('benefit_ref', 128);
+                $table->uuid('source_order_id');
+                $table->uuid('source_event_id')->nullable();
+                $table->string('status', 32)->default('active')->index();
+                $table->timestamp('expires_at')->nullable();
+                $table->timestamps();
+
+                $table->unique(['source_order_id', 'benefit_type', 'benefit_ref'], 'uq_benefit_grants_source');
+            });
+            return;
+        }
+
+        Schema::table('benefit_grants', function (Blueprint $table) {
+            if (!Schema::hasColumn('benefit_grants', 'id')) {
+                $table->uuid('id')->primary();
+            }
+            if (!Schema::hasColumn('benefit_grants', 'user_id')) {
+                $table->string('user_id', 64)->nullable()->index();
+            }
+            if (!Schema::hasColumn('benefit_grants', 'benefit_type')) {
+                $table->string('benefit_type', 64)->nullable();
+            }
+            if (!Schema::hasColumn('benefit_grants', 'benefit_ref')) {
+                $table->string('benefit_ref', 128)->nullable();
+            }
+            if (!Schema::hasColumn('benefit_grants', 'source_order_id')) {
+                $table->uuid('source_order_id')->nullable();
+            }
+            if (!Schema::hasColumn('benefit_grants', 'source_event_id')) {
+                $table->uuid('source_event_id')->nullable();
+            }
+            if (!Schema::hasColumn('benefit_grants', 'status')) {
+                $table->string('status', 32)->default('active')->index();
+            }
+            if (!Schema::hasColumn('benefit_grants', 'expires_at')) {
+                $table->timestamp('expires_at')->nullable();
+            }
+            if (!Schema::hasColumn('benefit_grants', 'created_at')) {
+                $table->timestamp('created_at')->nullable();
+            }
+            if (!Schema::hasColumn('benefit_grants', 'updated_at')) {
+                $table->timestamp('updated_at')->nullable();
+            }
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('benefit_grants');
+    }
+};

--- a/backend/database/migrations/2026_01_22_090030_create_payment_events_table.php
+++ b/backend/database/migrations/2026_01_22_090030_create_payment_events_table.php
@@ -1,0 +1,82 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        if (!Schema::hasTable('payment_events')) {
+            Schema::create('payment_events', function (Blueprint $table) {
+                $table->uuid('id')->primary();
+                $table->string('provider', 32);
+                $table->string('provider_event_id', 128)->unique();
+                $table->uuid('order_id');
+                $table->string('event_type', 64);
+                $table->json('payload_json');
+                $table->boolean('signature_ok')->default(false);
+                $table->timestamp('handled_at')->nullable();
+                $table->string('handle_status', 32)->nullable();
+                $table->string('request_id', 128)->nullable();
+                $table->string('ip', 45)->nullable();
+                $table->string('headers_digest', 64)->nullable();
+                $table->timestamps();
+
+                $table->index('order_id');
+            });
+            return;
+        }
+
+        Schema::table('payment_events', function (Blueprint $table) {
+            if (!Schema::hasColumn('payment_events', 'id')) {
+                $table->uuid('id')->primary();
+            }
+            if (!Schema::hasColumn('payment_events', 'provider')) {
+                $table->string('provider', 32)->nullable();
+            }
+            if (!Schema::hasColumn('payment_events', 'provider_event_id')) {
+                $table->string('provider_event_id', 128)->nullable();
+            }
+            if (!Schema::hasColumn('payment_events', 'order_id')) {
+                $table->uuid('order_id')->nullable();
+            }
+            if (!Schema::hasColumn('payment_events', 'event_type')) {
+                $table->string('event_type', 64)->nullable();
+            }
+            if (!Schema::hasColumn('payment_events', 'payload_json')) {
+                $table->json('payload_json')->nullable();
+            }
+            if (!Schema::hasColumn('payment_events', 'signature_ok')) {
+                $table->boolean('signature_ok')->default(false);
+            }
+            if (!Schema::hasColumn('payment_events', 'handled_at')) {
+                $table->timestamp('handled_at')->nullable();
+            }
+            if (!Schema::hasColumn('payment_events', 'handle_status')) {
+                $table->string('handle_status', 32)->nullable();
+            }
+            if (!Schema::hasColumn('payment_events', 'request_id')) {
+                $table->string('request_id', 128)->nullable();
+            }
+            if (!Schema::hasColumn('payment_events', 'ip')) {
+                $table->string('ip', 45)->nullable();
+            }
+            if (!Schema::hasColumn('payment_events', 'headers_digest')) {
+                $table->string('headers_digest', 64)->nullable();
+            }
+            if (!Schema::hasColumn('payment_events', 'created_at')) {
+                $table->timestamp('created_at')->nullable();
+            }
+            if (!Schema::hasColumn('payment_events', 'updated_at')) {
+                $table->timestamp('updated_at')->nullable();
+            }
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('payment_events');
+    }
+};

--- a/backend/routes/api.php
+++ b/backend/routes/api.php
@@ -12,6 +12,7 @@ use App\Http\Controllers\API\V0_2\ClaimController;
 use App\Http\Controllers\API\V0_2\IdentityController;
 use App\Http\Controllers\API\V0_2\MeController;
 use App\Http\Controllers\API\V0_2\NormsController;
+use App\Http\Controllers\API\V0_2\PaymentsController;
 use App\Http\Controllers\API\V0_2\ShareController;
 use App\Http\Controllers\API\V0_2\ValidityFeedbackController;
 
@@ -89,5 +90,13 @@ Route::prefix("v0.2")->group(function () {
     Route::get("/attempts/{id}/report", [MbtiController::class, "getReport"]);
     Route::post("/attempts/{attempt_id}/feedback", [ValidityFeedbackController::class, "store"]);
     Route::post("/lookup/device", [LookupController::class, "lookupDevice"]);
+
+    // ✅ Payments (v0.2)
+    Route::prefix("payments")->group(function () {
+        Route::post("/orders", [PaymentsController::class, "createOrder"]);
+        Route::post("/orders/{id}/mark_paid", [PaymentsController::class, "markPaid"]);
+        Route::post("/orders/{id}/fulfill", [PaymentsController::class, "fulfill"]);
+        Route::get("/me/benefits", [PaymentsController::class, "meBenefits"]);
+    });
 });
 });


### PR DESCRIPTION
•	PAYMENTS_ENABLED=0 默认禁用（返回 404 PAYMENTS_DISABLED，不影响主链路）
	•	新增表：orders / benefit_grants / payment_events（含唯一约束：provider_event_id；(source_order_id, benefit_type, benefit_ref)）
	•	API：create order / mark_paid(dev-only) / fulfill / me benefits
	•	本地验证：create→paid→fulfilled→benefits 返回 1 条 report_unlock；ci_verify_mbti.sh 全绿

⸻
