### PR TITLE
feat(payments): mock webhook idempotency (11C)

### DIFF
--- a/backend/app/Http/Requests/V0_2/CreateOrderRequest.php
+++ b/backend/app/Http/Requests/V0_2/CreateOrderRequest.php
@@ -19,12 +19,16 @@ class CreateOrderRequest extends FormRequest
         }
 
         $currency = strtoupper(trim((string) $this->input('currency', 'CNY')));
+        $provider = strtolower(trim((string) $this->input('provider', '')));
+        $providerOrderId = trim((string) $this->input('provider_order_id', ''));
 
         $this->merge([
             'item_sku' => trim((string) $this->input('item_sku', '')),
             'currency' => $currency !== '' ? $currency : 'CNY',
             'amount_total' => $amount,
             'device_id' => $this->input('device_id', $this->header('X-Device-Id', null)),
+            'provider' => $provider !== '' ? $provider : null,
+            'provider_order_id' => $providerOrderId !== '' ? $providerOrderId : null,
         ]);
     }
 
@@ -35,6 +39,8 @@ class CreateOrderRequest extends FormRequest
             'currency' => ['required', 'string', 'max:8'],
             'amount_total' => ['required', 'integer', 'min:1'],
             'device_id' => ['nullable', 'string', 'max:128'],
+            'provider' => ['nullable', 'string', 'max:32'],
+            'provider_order_id' => ['nullable', 'string', 'max:128'],
         ];
     }
 
@@ -56,6 +62,20 @@ class CreateOrderRequest extends FormRequest
     public function deviceId(): ?string
     {
         $v = $this->validated()['device_id'] ?? null;
+        $v = is_string($v) ? trim($v) : null;
+        return $v !== '' ? $v : null;
+    }
+
+    public function provider(): ?string
+    {
+        $v = $this->validated()['provider'] ?? null;
+        $v = is_string($v) ? trim($v) : null;
+        return $v !== '' ? $v : null;
+    }
+
+    public function providerOrderId(): ?string
+    {
+        $v = $this->validated()['provider_order_id'] ?? null;
         $v = is_string($v) ? trim($v) : null;
         return $v !== '' ? $v : null;
     }

--- a/backend/routes/api.php
+++ b/backend/routes/api.php
@@ -74,6 +74,9 @@ Route::prefix("v0.2")->group(function () {
     // 9) Norms percentile (stub controller, implemented later)
     Route::get("/norms/percentile", [NormsController::class, "percentile"]);
 
+    // ✅ Payments Webhook (mock provider, public)
+    Route::post("/payments/webhook/mock", [PaymentsController::class, "webhookMock"]);
+
     // =========================================================
     // ✅ Step 1：最小后端鉴权（只 gate 你指定的 3 个接口）
     // 关键：Laravel 12 里你 alias 还没注册成功，所以这里直接用类名


### PR DESCRIPTION
•	WEBHOOK_ENABLED=0 默认关闭，不影响主链路
	•	新增 /payments/webhook/mock：provider_event_id 幂等落库，可重放
	•	payment_succeeded 驱动 pending->paid->fulfill；重放不重复发权益