### PR TITLE
chore(payments): reconciliation & anomalies scripts (11D)

### DIFF
--- a/backend/scripts/payments_anomalies.sh
+++ b/backend/scripts/payments_anomalies.sh
@@ -1,0 +1,204 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# payments_anomalies.sh
+# Minimal anomaly scan for payments (orders/benefit_grants/payment_events).
+#
+# Env:
+#   RECONCILIATION_ENABLED=0|1  (default 0; 0 -> skip exit 0)
+#   DATE=YYYY-MM-DD             (optional; default today in TZ)
+#   ANOMALY_FULFILL_LAG_MINUTES (optional; default 30)
+#   ANOMALY_MAX_LIST            (optional; default 200)
+#   DB_CONNECTION=sqlite|mysql|pgsql (optional; default sqlite)
+#   SQLITE_DB=/abs/path/to/backend/database/database.sqlite (optional)
+#   APP_ENV=testing|production  (optional; default testing)
+#   WRITE_ARTIFACT=0|1          (optional; default 0)
+#   ARTIFACT_DIR=...            (optional; default backend/artifacts/payments)
+#
+# Output:
+#   JSON to stdout (grep-friendly), optional artifact file when WRITE_ARTIFACT=1.
+
+need_cmd() { command -v "$1" >/dev/null 2>&1 || { echo "[ERR] missing cmd: $1" >&2; exit 2; }; }
+need_cmd php
+
+REPO_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+BACKEND_DIR="$REPO_DIR/backend"
+cd "$BACKEND_DIR"
+
+RECONCILIATION_ENABLED="${RECONCILIATION_ENABLED:-0}"
+if [[ "$RECONCILIATION_ENABLED" != "1" ]]; then
+  echo "[ANOMALY] RECONCILIATION_ENABLED=0 -> skip"
+  exit 0
+fi
+
+RECON_TZ="Asia/Shanghai"
+DATE="${DATE:-$(TZ="$RECON_TZ" date +%F)}"
+APP_ENV="${APP_ENV:-testing}"
+DB_CONNECTION="${DB_CONNECTION:-sqlite}"
+SQLITE_DB="${SQLITE_DB:-$BACKEND_DIR/database/database.sqlite}"
+ANOMALY_FULFILL_LAG_MINUTES="${ANOMALY_FULFILL_LAG_MINUTES:-30}"
+ANOMALY_MAX_LIST="${ANOMALY_MAX_LIST:-200}"
+WRITE_ARTIFACT="${WRITE_ARTIFACT:-0}"
+ARTIFACT_DIR="${ARTIFACT_DIR:-$REPO_DIR/backend/artifacts/payments}"
+
+echo "[ANOMALY] repo=$REPO_DIR"
+echo "[ANOMALY] backend=$BACKEND_DIR"
+echo "[ANOMALY] date=$DATE tz=$RECON_TZ"
+echo "[ANOMALY] fulfill_lag_minutes=$ANOMALY_FULFILL_LAG_MINUTES max_list=$ANOMALY_MAX_LIST"
+echo "[ANOMALY] APP_ENV=$APP_ENV DB_CONNECTION=$DB_CONNECTION"
+echo "[ANOMALY] SQLITE_DB=$SQLITE_DB"
+
+if [[ "$DB_CONNECTION" == "sqlite" && ! -f "$SQLITE_DB" ]]; then
+  echo "[ERR] sqlite db not found: $SQLITE_DB" >&2
+  exit 1
+fi
+
+PHP_CODE='
+use Illuminate\Support\Carbon;
+
+$tz = getenv("RECON_TZ") ?: "Asia/Shanghai";
+$date = getenv("DATE") ?: Carbon::now($tz)->format("Y-m-d");
+$start = Carbon::createFromFormat("Y-m-d", $date, $tz)->startOfDay();
+$end = (clone $start)->addDay();
+$lagMinutes = (int) (getenv("ANOMALY_FULFILL_LAG_MINUTES") ?: 30);
+$maxList = (int) (getenv("ANOMALY_MAX_LIST") ?: 200);
+$cutoff = Carbon::now($tz)->subMinutes($lagMinutes);
+
+if (!\Schema::hasTable("orders")) {
+  fwrite(STDERR, "[ANOMALY][ERR] missing table: orders\n");
+  exit(2);
+}
+if (!\Schema::hasTable("benefit_grants")) {
+  fwrite(STDERR, "[ANOMALY][ERR] missing table: benefit_grants\n");
+  exit(2);
+}
+if (!\Schema::hasTable("payment_events")) {
+  fwrite(STDERR, "[ANOMALY][ERR] missing table: payment_events\n");
+  exit(2);
+}
+
+$paidNoGrantQ = \DB::table("orders")
+  ->leftJoin("benefit_grants", "benefit_grants.source_order_id", "=", "orders.id")
+  ->where("orders.status", "paid")
+  ->whereNull("benefit_grants.id")
+  ->whereNotNull("orders.paid_at")
+  ->where("orders.paid_at", ">=", $start)
+  ->where("orders.paid_at", "<", $end);
+
+$paidNoGrantTotal = (clone $paidNoGrantQ)->count();
+$paidNoGrantItems = (clone $paidNoGrantQ)
+  ->orderBy("orders.paid_at")
+  ->limit($maxList)
+  ->get([
+    "orders.id as order_id",
+    "orders.user_id",
+    "orders.anon_id",
+    "orders.paid_at",
+    "orders.amount_total",
+    "orders.request_id",
+    "orders.status",
+  ]);
+
+$paidNoFulfillQ = \DB::table("orders")
+  ->where("status", "paid")
+  ->whereNull("fulfilled_at")
+  ->whereNotNull("paid_at")
+  ->where("paid_at", ">=", $start)
+  ->where("paid_at", "<", $end)
+  ->where("paid_at", "<=", $cutoff);
+
+$paidNoFulfillTotal = (clone $paidNoFulfillQ)->count();
+$paidNoFulfillItems = (clone $paidNoFulfillQ)
+  ->orderBy("paid_at")
+  ->limit($maxList)
+  ->get([
+    "id as order_id",
+    "user_id",
+    "anon_id",
+    "paid_at",
+    "amount_total",
+    "request_id",
+    "status",
+  ]);
+
+$grantWithoutPaidQ = \DB::table("benefit_grants")
+  ->leftJoin("orders", "orders.id", "=", "benefit_grants.source_order_id")
+  ->where("benefit_grants.created_at", ">=", $start)
+  ->where("benefit_grants.created_at", "<", $end)
+  ->where(function ($q) {
+    $q->whereNull("orders.id")
+      ->orWhereNotIn("orders.status", ["paid", "fulfilled", "gifted"]);
+  });
+
+$grantWithoutPaidTotal = (clone $grantWithoutPaidQ)->count();
+$grantWithoutPaidItems = (clone $grantWithoutPaidQ)
+  ->orderBy("benefit_grants.created_at")
+  ->limit($maxList)
+  ->get([
+    "benefit_grants.id as grant_id",
+    "benefit_grants.source_order_id as order_id",
+    "benefit_grants.benefit_type",
+    "benefit_grants.benefit_ref",
+    "benefit_grants.created_at",
+    "orders.status as order_status",
+    "orders.request_id as order_request_id",
+  ]);
+
+$badSigCount = \DB::table("payment_events")
+  ->where("signature_ok", false)
+  ->where("created_at", ">=", $start)
+  ->where("created_at", "<", $end)
+  ->count();
+
+$out = [
+  "date" => $date,
+  "timezone" => $tz,
+  "window" => [
+    "start" => $start->toDateTimeString(),
+    "end" => $end->toDateTimeString(),
+  ],
+  "fulfill_lag_minutes" => $lagMinutes,
+  "cutoff_at" => $cutoff->toDateTimeString(),
+  "max_list" => $maxList,
+  "paid_no_grant" => [
+    "total" => $paidNoGrantTotal,
+    "items" => $paidNoGrantItems,
+  ],
+  "paid_no_fulfill_overdue" => [
+    "total" => $paidNoFulfillTotal,
+    "items" => $paidNoFulfillItems,
+  ],
+  "grant_without_paid" => [
+    "total" => $grantWithoutPaidTotal,
+    "items" => $grantWithoutPaidItems,
+  ],
+  "payment_events_signature_bad" => [
+    "total" => $badSigCount,
+  ],
+];
+
+echo json_encode($out, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES) . PHP_EOL;
+';
+
+if [[ "$DB_CONNECTION" == "sqlite" ]]; then
+  OUTPUT="$(APP_ENV="$APP_ENV" DB_CONNECTION="$DB_CONNECTION" DB_DATABASE="$SQLITE_DB" \
+    DATE="$DATE" RECON_TZ="$RECON_TZ" \
+    ANOMALY_FULFILL_LAG_MINUTES="$ANOMALY_FULFILL_LAG_MINUTES" \
+    ANOMALY_MAX_LIST="$ANOMALY_MAX_LIST" \
+    php artisan tinker --execute="$PHP_CODE")"
+else
+  OUTPUT="$(APP_ENV="$APP_ENV" DB_CONNECTION="$DB_CONNECTION" \
+    DATE="$DATE" RECON_TZ="$RECON_TZ" \
+    ANOMALY_FULFILL_LAG_MINUTES="$ANOMALY_FULFILL_LAG_MINUTES" \
+    ANOMALY_MAX_LIST="$ANOMALY_MAX_LIST" \
+    php artisan tinker --execute="$PHP_CODE")"
+fi
+
+echo "$OUTPUT"
+
+if [[ "$WRITE_ARTIFACT" == "1" ]]; then
+  mkdir -p "$ARTIFACT_DIR"
+  ARTIFACT_PATH="$ARTIFACT_DIR/anomalies_${DATE}.json"
+  printf "%s\n" "$OUTPUT" > "$ARTIFACT_PATH"
+  echo "[ANOMALY] artifact=$ARTIFACT_PATH"
+fi

--- a/backend/scripts/payments_reconcile_daily.sh
+++ b/backend/scripts/payments_reconcile_daily.sh
@@ -1,0 +1,156 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# payments_reconcile_daily.sh
+# Minimal daily reconciliation for payments (orders/payment_events).
+#
+# Env:
+#   RECONCILIATION_ENABLED=0|1  (default 0; 0 -> skip exit 0)
+#   DATE=YYYY-MM-DD             (optional; default today in TZ)
+#   DB_CONNECTION=sqlite|mysql|pgsql (optional; default sqlite)
+#   SQLITE_DB=/abs/path/to/backend/database/database.sqlite (optional)
+#   APP_ENV=testing|production  (optional; default testing)
+#   WRITE_ARTIFACT=0|1          (optional; default 0)
+#   ARTIFACT_DIR=...            (optional; default backend/artifacts/payments)
+#
+# Output:
+#   JSON to stdout (grep-friendly), optional artifact file when WRITE_ARTIFACT=1.
+
+need_cmd() { command -v "$1" >/dev/null 2>&1 || { echo "[ERR] missing cmd: $1" >&2; exit 2; }; }
+need_cmd php
+
+REPO_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+BACKEND_DIR="$REPO_DIR/backend"
+cd "$BACKEND_DIR"
+
+RECONCILIATION_ENABLED="${RECONCILIATION_ENABLED:-0}"
+if [[ "$RECONCILIATION_ENABLED" != "1" ]]; then
+  echo "[RECON] RECONCILIATION_ENABLED=0 -> skip"
+  exit 0
+fi
+
+RECON_TZ="Asia/Shanghai"
+DATE="${DATE:-$(TZ="$RECON_TZ" date +%F)}"
+APP_ENV="${APP_ENV:-testing}"
+DB_CONNECTION="${DB_CONNECTION:-sqlite}"
+SQLITE_DB="${SQLITE_DB:-$BACKEND_DIR/database/database.sqlite}"
+WRITE_ARTIFACT="${WRITE_ARTIFACT:-0}"
+ARTIFACT_DIR="${ARTIFACT_DIR:-$REPO_DIR/backend/artifacts/payments}"
+
+echo "[RECON] repo=$REPO_DIR"
+echo "[RECON] backend=$BACKEND_DIR"
+echo "[RECON] date=$DATE tz=$RECON_TZ"
+echo "[RECON] APP_ENV=$APP_ENV DB_CONNECTION=$DB_CONNECTION"
+echo "[RECON] SQLITE_DB=$SQLITE_DB"
+
+if [[ "$DB_CONNECTION" == "sqlite" && ! -f "$SQLITE_DB" ]]; then
+  echo "[ERR] sqlite db not found: $SQLITE_DB" >&2
+  exit 1
+fi
+
+PHP_CODE='
+use Illuminate\Support\Carbon;
+
+$tz = getenv("RECON_TZ") ?: "Asia/Shanghai";
+$date = getenv("DATE") ?: Carbon::now($tz)->format("Y-m-d");
+$start = Carbon::createFromFormat("Y-m-d", $date, $tz)->startOfDay();
+$end = (clone $start)->addDay();
+
+if (!\Schema::hasTable("orders")) {
+  fwrite(STDERR, "[RECON][ERR] missing table: orders\n");
+  exit(2);
+}
+if (!\Schema::hasTable("payment_events")) {
+  fwrite(STDERR, "[RECON][ERR] missing table: payment_events\n");
+  exit(2);
+}
+
+$ordersPaid = \DB::table("orders")
+  ->whereNotNull("paid_at")
+  ->where("paid_at", ">=", $start)
+  ->where("paid_at", "<", $end);
+
+$ordersRefunded = \DB::table("orders")
+  ->whereNotNull("refunded_at")
+  ->where("refunded_at", ">=", $start)
+  ->where("refunded_at", "<", $end);
+
+$ordersFulfilled = \DB::table("orders")
+  ->whereNotNull("fulfilled_at")
+  ->where("fulfilled_at", ">=", $start)
+  ->where("fulfilled_at", "<", $end);
+
+$ordersByStatus = (clone $ordersPaid)
+  ->select("status", \DB::raw("count(*) as cnt"))
+  ->groupBy("status")
+  ->orderByDesc("cnt")
+  ->get();
+
+$paidCount = (clone $ordersPaid)->count();
+$paidAmount = (int) (clone $ordersPaid)->sum("amount_total");
+
+$fulfilledCount = (clone $ordersFulfilled)->count();
+
+$refundCount = (clone $ordersRefunded)->count();
+$refundAmount = (int) (clone $ordersRefunded)->sum("amount_refunded");
+
+$netRevenue = $paidAmount - $refundAmount;
+
+$eventsQuery = \DB::table("payment_events")
+  ->where("created_at", ">=", $start)
+  ->where("created_at", "<", $end);
+
+$eventsTotal = (clone $eventsQuery)->count();
+$eventsByType = (clone $eventsQuery)
+  ->select("event_type", \DB::raw("count(*) as cnt"))
+  ->groupBy("event_type")
+  ->orderByDesc("cnt")
+  ->get();
+
+$out = [
+  "date" => $date,
+  "timezone" => $tz,
+  "window" => [
+    "start" => $start->toDateTimeString(),
+    "end" => $end->toDateTimeString(),
+  ],
+  "orders_by_status" => $ordersByStatus,
+  "success_paid" => [
+    "count" => $paidCount,
+    "amount_total" => $paidAmount,
+  ],
+  "success_fulfilled" => [
+    "count" => $fulfilledCount,
+  ],
+  "refunds" => [
+    "count" => $refundCount,
+    "amount_total" => $refundAmount,
+  ],
+  "net_revenue" => $netRevenue,
+  "payment_events" => [
+    "total" => $eventsTotal,
+    "by_type" => $eventsByType,
+  ],
+];
+
+echo json_encode($out, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES) . PHP_EOL;
+';
+
+if [[ "$DB_CONNECTION" == "sqlite" ]]; then
+  OUTPUT="$(APP_ENV="$APP_ENV" DB_CONNECTION="$DB_CONNECTION" DB_DATABASE="$SQLITE_DB" \
+    DATE="$DATE" RECON_TZ="$RECON_TZ" \
+    php artisan tinker --execute="$PHP_CODE")"
+else
+  OUTPUT="$(APP_ENV="$APP_ENV" DB_CONNECTION="$DB_CONNECTION" \
+    DATE="$DATE" RECON_TZ="$RECON_TZ" \
+    php artisan tinker --execute="$PHP_CODE")"
+fi
+
+echo "$OUTPUT"
+
+if [[ "$WRITE_ARTIFACT" == "1" ]]; then
+  mkdir -p "$ARTIFACT_DIR"
+  ARTIFACT_PATH="$ARTIFACT_DIR/reconcile_${DATE}.json"
+  printf "%s\n" "$OUTPUT" > "$ARTIFACT_PATH"
+  echo "[RECON] artifact=$ARTIFACT_PATH"
+fi

--- a/docs/payments/reconciliation.md
+++ b/docs/payments/reconciliation.md
@@ -1,0 +1,94 @@
+# 支付对账与异常队列（reconciliation）
+
+> 口径写死；不接主链路；脚本默认关闭（`RECONCILIATION_ENABLED=0`）。
+
+## 一、统一口径（写死）
+- 时区：`Asia/Shanghai`（脚本内写死）。
+- 日期：`DATE=YYYY-MM-DD`；未传则取当前日期（按上面的时区）。
+- 时间窗口：`[DATE 00:00:00, DATE+1 00:00:00)`。
+- 主要数据源：`orders` / `payment_events` / `benefit_grants`。
+
+## 二、对账输出口径（payments_reconcile_daily.sh）
+### 订单数（按状态）
+```
+orders_by_status = orders where paid_at in window
+group by orders.status
+```
+
+### 成功数（两套）
+```
+success_paid.count = orders where paid_at in window
+success_fulfilled.count = orders where fulfilled_at in window
+```
+
+### 退款数与金额
+```
+refunds.count = orders where refunded_at in window
+refunds.amount_total = sum(orders.amount_refunded) in refunded_at window
+```
+
+### 净收入
+```
+paid_amount = sum(orders.amount_total) in paid_at window
+refund_amount = sum(orders.amount_refunded) in refunded_at window
+net_revenue = paid_amount - refund_amount
+```
+
+### 支付事件（补充统计）
+```
+payment_events.total = payment_events where created_at in window
+payment_events.by_type = group by event_type in window
+```
+
+## 三、异常定义（payments_anomalies.sh）
+### 1) paid 但未发放权益
+```
+orders.status = paid
+AND paid_at in window
+AND (
+  benefit_grants 不存在
+  OR fulfilled_at 为空且 paid_at <= (now - ANOMALY_FULFILL_LAG_MINUTES)
+)
+```
+说明：
+- `ANOMALY_FULFILL_LAG_MINUTES` 默认 `30`。
+
+### 2) 发放但未 paid
+```
+benefit_grants created_at in window
+AND (
+  orders.status NOT IN (paid, fulfilled, gifted)
+  OR order 记录不存在
+)
+```
+
+### 3) signature_ok = false
+```
+payment_events where signature_ok = false and created_at in window
+```
+
+## 四、输出与归档
+- 输出：脚本打印 JSON 到 stdout，可直接 grep。
+- 归档（可选）：`WRITE_ARTIFACT=1` 时写入 `backend/artifacts/payments/*`。
+
+## 五、处理 SOP（写死）
+1) 拿到脚本输出中的 `order_id` / `request_id` / `grant_id` / `event_id`。
+2) 查订单：
+```
+orders.id = order_id
+orders.request_id = request_id
+```
+3) 查权益：
+```
+benefit_grants.source_order_id = order_id
+benefit_grants.id = grant_id
+```
+4) 查支付事件：
+```
+payment_events.order_id = order_id
+payment_events.provider_event_id / payment_events.request_id
+```
+5) 关联日志与回调：
+```
+request_id / provider_event_id 在日志中定位回调与处理链路
+```


### PR DESCRIPTION
## Summary（改了什么）
- 新增手动对账脚本：backend/scripts/payments_reconcile_daily.sh（默认关闭）
- 新增手动异常扫描脚本：backend/scripts/payments_anomalies.sh（默认关闭）
- 新增口径文档：docs/payments/reconciliation.md（对账公式/异常定义/SOP 写死）
- 不改主链路：ci_verify_mbti.sh 不接入；不影响现有 API/CI

## Scope（影响范围）
- 仅新增 scripts + docs；不改 routes/migrations/middleware/controller/service
- 默认开关：RECONCILIATION_ENABLED=0 时脚本直接 skip exit 0
- 兼容：macOS bash 3；输出 stdout（可 grep），可选归档到 backend/artifacts/payments/*

## How to verify（本地验证）
```bash
RECONCILIATION_ENABLED=0 bash backend/scripts/payments_reconcile_daily.sh
RECONCILIATION_ENABLED=0 bash backend/scripts/payments_anomalies.sh

RECONCILIATION_ENABLED=1 DATE="$(date +%F)" bash backend/scripts/payments_reconcile_daily.sh
RECONCILIATION_ENABLED=1 DATE="$(date +%F)" bash backend/scripts/payments_anomalies.sh

lsof -ti tcp:18000 | xargs kill -9 2>/dev/null || true
API="http://127.0.0.1:18000" bash backend/scripts/ci_verify_mbti.sh