### PR TITLE
Fix: implement MbtiController::upsertResult for POST /api/v0.2/attempts/{id}/result

### DIFF
--- a/backend/app/Http/Controllers/MbtiController.php
+++ b/backend/app/Http/Controllers/MbtiController.php
@@ -614,6 +614,16 @@ public function storeAttempt(Request $request)
     });
 }
 
+public function upsertResult(\Illuminate\Http\Request $request, string $attemptId)
+{
+    // 让 /attempts/{id}/result 走你现有的 storeAttempt 逻辑（写 attempts.result_json + results 表）
+    $request->merge([
+        'attempt_id' => $attemptId,
+    ]);
+
+    return $this->storeAttempt($request);
+}
+
 /**
  * GET /api/v0.2/attempts/{id}/result
  * 注意：这里会写 report_view（但会在 logEvent 内 10 秒去抖）


### PR DESCRIPTION
## Summary（改了什么）
- 修复 `POST /api/v0.2/attempts/{id}/result` 500：routes/api.php 指向的 `MbtiController::upsertResult` 方法缺失
- 在 `MbtiController` 新增 `upsertResult`，将请求转发/兼容到现有写入逻辑，恢复 result 写入链路

简述本次改动（1-3 句）：
- 线上 smoke 测试中，写入 result 接口报错：`Call to undefined method MbtiController::upsertResult()`。
- 本 PR 补齐 controller 方法，确保 result/report 链路可继续推进。

---

## Scope（影响范围）
- API：
  - `POST /api/v0.2/attempts/{id}/result`（修复）
- 无 DB 迁移、无 schema 变更
- 不影响现有 `GET /api/v0.2/attempts/{id}/result`、`GET /api/v0.2/attempts/{id}/report` 的读取逻辑（但它们依赖 result 数据是否写入成功）

---

## How to verify（如何验证）
1) `POST /api/v0.2/attempts/start` 创建 attempt（200，返回 attempt_id）
2) `POST /api/v0.2/auth/provider` 获取 fm_token（Authorization: Bearer）
3) `POST /api/v0.2/attempts/{id}/result` 写入 answers_json（预期 200/ok=true）
4) `GET /api/v0.2/attempts/{id}/result`、`GET /api/v0.2/attempts/{id}/report` 在携带 token 时返回 200

---

## Notes（备注）
- 该修复用于恢复“从零上线”健康检查中的 result/report 关键链路。
- 合并后需要在服务器拉取 main 并 reload php-fpm/nginx（按既定发布流程）。