### PR TITLE
ci: add production deploy/rollback via Deployer with approval + healthcheck

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -1,0 +1,54 @@
+name: Deploy Production
+
+on:
+  push:
+    branches: ["main"]
+
+concurrency:
+  group: deploy-production
+  cancel-in-progress: false
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    environment: production
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: "8.4"
+          coverage: none
+
+      - name: Install Deployer (PHAR)
+        run: |
+          curl -sSLo dep.phar https://deployer.org/deployer.phar
+          php dep.phar --version
+
+      - name: Setup SSH Agent
+        uses: webfactory/ssh-agent@v0.9.0
+        with:
+          ssh-private-key: ${{ secrets.DEPLOY_SSH_PRIVATE_KEY }}
+
+      - name: Add known hosts
+        run: |
+          mkdir -p ~/.ssh
+          echo "${{ secrets.DEPLOY_KNOWN_HOSTS }}" > ~/.ssh/known_hosts
+          chmod 600 ~/.ssh/known_hosts
+
+      - name: Deploy via Deployer
+        env:
+          DEPLOY_HOST: ${{ secrets.DEPLOY_HOST }}
+          DEPLOY_USER: ${{ secrets.DEPLOY_USER }}
+          DEPLOY_PORT: ${{ secrets.DEPLOY_PORT }}
+        run: |
+          php dep.phar deploy production -vvv
+
+      - name: Post-deploy Health Check (public)
+        run: |
+          sleep 2
+          curl -fsS "https://fermatmind.com/api/v0.2/health" | grep -q '"ok":true'
+          curl -fsS "https://fermatmind.com/api/v0.2/scales/MBTI/questions" | grep -q '"ok":true'

--- a/.github/workflows/rollback-production.yml
+++ b/.github/workflows/rollback-production.yml
@@ -1,0 +1,58 @@
+name: Rollback Production
+
+on:
+  workflow_dispatch:
+    inputs:
+      reason:
+        description: "Rollback reason"
+        required: true
+        default: "Rollback requested"
+
+concurrency:
+  group: deploy-production
+  cancel-in-progress: false
+
+jobs:
+  rollback:
+    runs-on: ubuntu-latest
+    environment: production
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: "8.4"
+          coverage: none
+
+      - name: Install Deployer (PHAR)
+        run: |
+          curl -sSLo dep.phar https://deployer.org/deployer.phar
+          php dep.phar --version
+
+      - name: Setup SSH Agent
+        uses: webfactory/ssh-agent@v0.9.0
+        with:
+          ssh-private-key: ${{ secrets.DEPLOY_SSH_PRIVATE_KEY }}
+
+      - name: Add known hosts
+        run: |
+          mkdir -p ~/.ssh
+          echo "${{ secrets.DEPLOY_KNOWN_HOSTS }}" > ~/.ssh/known_hosts
+          chmod 600 ~/.ssh/known_hosts
+
+      - name: Rollback via Deployer
+        env:
+          DEPLOY_HOST: ${{ secrets.DEPLOY_HOST }}
+          DEPLOY_USER: ${{ secrets.DEPLOY_USER }}
+          DEPLOY_PORT: ${{ secrets.DEPLOY_PORT }}
+        run: |
+          php dep.phar rollback production -vvv
+
+      - name: Post-rollback Health Check (public)
+        run: |
+          sleep 2
+          curl -fsS "https://fermatmind.com/api/v0.2/health" | grep -q '"ok":true'
+          curl -fsS "https://fermatmind.com/api/v0.2/scales/MBTI/questions" | grep -q '"ok":true'

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@
 **/.DS_Store
 /content_packages/MBTI-CN-v0.2.1-TEST
 /content_packages/MBTI-CN-v0.2.1-TEST/
+
+/vendor/

--- a/deploy.php
+++ b/deploy.php
@@ -1,0 +1,73 @@
+<?php
+namespace Deployer;
+
+require 'recipe/laravel.php';
+
+// ========= 基础信息 =========
+set('application', 'fap-api');
+set('repository', 'git@github.com:fermatmind/fap-api.git');
+
+set('git_tty', false);
+set('keep_releases', 5);
+set('default_timeout', 900);
+
+// 你的 Laravel 在 backend 子目录
+set('artisan', '{{release_path}}/backend/artisan');
+set('public_path', 'backend/public');
+set('bin/php', 'php');
+set('bin/composer', 'composer');
+
+// 共享：.env + storage/cache + content_packages
+// 注意：content_packages 是仓库根目录下的目录名（你仓库里就叫 content_packages）
+// Deployer 会把它映射到 {{deploy_path}}/shared/content_packages
+set('shared_files', [
+    'backend/.env',
+]);
+
+set('shared_dirs', [
+    'backend/storage',
+    'backend/bootstrap/cache',
+    'content_packages',
+]);
+
+set('writable_dirs', [
+    'backend/storage',
+    'backend/bootstrap/cache',
+]);
+
+// ========= 生产机 =========
+host('production')
+    ->setHostname(getenv('DEPLOY_HOST') ?: '122.152.221.126')
+    ->setRemoteUser(getenv('DEPLOY_USER') ?: 'deploy')
+    ->setPort((int)(getenv('DEPLOY_PORT') ?: 22))
+    ->set('deploy_path', '/var/www/fap-api');
+
+// ========= 覆盖 vendors：在 backend 里 composer install =========
+task('deploy:vendors', function () {
+    run('cd {{release_path}}/backend && {{bin/composer}} install --no-interaction --prefer-dist --optimize-autoloader --no-dev');
+});
+
+// ========= 服务重载 =========
+task('reload:php-fpm', function () {
+    run('sudo /usr/bin/systemctl reload php8.4-fpm');
+});
+task('reload:nginx', function () {
+    run('sudo /usr/bin/systemctl reload nginx');
+});
+
+// ========= 健康检查（服务器本机 localhost，不依赖外网 DNS） =========
+task('healthcheck', function () {
+    // 1) questions
+    run('curl -fsS http://127.0.0.1/api/v0.2/scales/MBTI/questions | grep -q "\"ok\":true"');
+
+    // 2) attempts/start（按你接口必填字段）
+    $payload = '{"anon_id":"dep-health-001","scale_code":"MBTI","scale_version":"v0.2","question_count":144,"client_platform":"web","region":"CN_MAINLAND","locale":"zh-CN"}';
+    run('curl -fsS -X POST http://127.0.0.1/api/v0.2/attempts/start -H "Content-Type: application/json" -H "Accept: application/json" -d \'' . $payload . '\' | grep -q "\"ok\":true"');
+});
+
+// ========= 部署流（laravel.php 自带 deploy 流） =========
+after('artisan:migrate', 'reload:php-fpm');
+after('deploy:symlink', 'reload:nginx');
+after('deploy:symlink', 'healthcheck');
+
+after('deploy:failed', 'deploy:unlock');


### PR DESCRIPTION
## Summary
- 新增 Deployer 配置：`deploy.php`（production host / shared / writable / reload / healthcheck）
- 新增 GitHub Actions 自动发布：`deploy-production.yml`（main push → production 环境审批 → dep deploy → healthcheck）
- 新增 GitHub Actions 回滚：`rollback-production.yml`（手动触发 → production 环境审批 → dep rollback → healthcheck）
- `.gitignore` 增加 `/vendor/`，避免把依赖提交进仓库

## Ops behavior (long-run standard)
- Deploy 必须走 Environment `production` 审批（Required reviewers）
- Rollback 独立 workflow，手动触发
- 回滚只回滚代码/current symlink，不回滚数据库结构（迁移仅做增量）

## Verification
- Actions logs：Deploy Production / Rollback Production 都能跑通
- Healthcheck：
  - `GET /api/v0.2/scales/MBTI/questions` 返回包含 `"ok":true`
  - `POST /api/v0.2/attempts/start` 返回包含 `"ok":true`

## Notes
- 服务器侧已完成：deploy 用户免密 reload php-fpm/nginx；certbot 自动续签；域名 HTTPS 可用
- 生产 secrets 已配置在 environment `production`：
  - `DEPLOY_HOST / DEPLOY_USER / DEPLOY_PORT / DEPLOY_SSH_PRIVATE_KEY / DEPLOY_KNOWN_HOSTS`