### PR TITLE
fix: remove public/storage placeholder to allow artisan storage:link

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,6 @@
 /content_packages/MBTI-CN-v0.2.1-TEST/
 
 /vendor/
+
+# laravel storage symlink
+/backend/public/storage


### PR DESCRIPTION
## Why
Fix production deploy failing at `artisan:storage:link`.

## What changed
- Remove tracked placeholder `backend/public/storage` so Laravel can create the symlink.
- Add `.gitignore` rule to prevent `backend/public/storage` from being committed again.

## How to verify
- Merge to `main`
- Actions → Deploy Production → Re-run jobs → Approve and deploy
- Deploy should pass `artisan:storage:link`