### PR TITLE
PR0: content packs SSOT via config + remove hardcoded version + updat…

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 .PHONY: selfcheck
 # 用法：
 #   make selfcheck
-#   make selfcheck MANIFEST=../content_packages/MBTI/CN_MAINLAND/zh-CN/v0.2.1-TEST/manifest.json
+#   make selfcheck MANIFEST=../content_packages/default/CN_MAINLAND/zh-CN/MBTI-CN-v0.2.1-TEST/manifest.json
 
 selfcheck:
 	cd backend && ./scripts/selfcheck.sh "$(MANIFEST)"

--- a/backend/app/Services/ContentPackage.php
+++ b/backend/app/Services/ContentPackage.php
@@ -7,7 +7,7 @@ class ContentPackage
     public static function mbtiPackageVersion(): string
     {
         // 跟你 share 返回的 content_package_version 保持一致
-        return env('MBTI_CONTENT_PACKAGE', 'MBTI-CN-v0.2.1-TEST');
+        return (string) config('content_packs.default_dir_version', 'MBTI-CN-v0.2.1-TEST');
     }
 
     /**
@@ -17,7 +17,9 @@ class ContentPackage
      */
     private static function resolvePkgFile(string $pkg, string $file): string
     {
+        $packsRoot = rtrim((string) config('content_packs.root', base_path('../content_packages')), '/');
         $candidates = [
+            "{$packsRoot}/{$pkg}/{$file}",
             // ✅ 你当前真实存在的位置（repo 根目录）
             base_path("../content_packages/{$pkg}/{$file}"),
 

--- a/backend/config/content.php
+++ b/backend/config/content.php
@@ -1,6 +1,7 @@
 <?php
 
 // file: backend/config/content.php
+// 本文件为 legacy/兼容桥接，内容包定位以 config/content_packs.php 为单一真相源。
 
 return [
     /**
@@ -12,7 +13,7 @@ return [
      *
      * 所以 packs_root 必须指向 base_path('../content_packages')
      */
-    'packs_root' => base_path('..' . DIRECTORY_SEPARATOR . 'content_packages'),
+    'packs_root' => env('FAP_PACKS_ROOT', base_path('../content_packages')),
 
     /**
      * 默认版本映射：没传 content_package_version 时用它
@@ -26,10 +27,10 @@ return [
      */
     'default_versions' => [
         // ✅ 线上默认 scale=default 时用这个
-        'default' => env('FAP_CONTENT_PACKAGE_VERSION', 'MBTI-CN-v0.2.1-TEST'),
+        'default' => env('FAP_DEFAULT_DIR_VERSION', 'MBTI-CN-v0.2.1-TEST'),
 
         // ✅ 可选：兼容旧路径/旧调用（如果历史上有人传 scale=MBTI）
-        'MBTI' => env('FAP_CONTENT_PACKAGE_VERSION', 'MBTI-CN-v0.2.1-TEST'),
+        'MBTI' => env('FAP_DEFAULT_DIR_VERSION', 'MBTI-CN-v0.2.1-TEST'),
     ],
 
     /**

--- a/backend/config/content_packs.php
+++ b/backend/config/content_packs.php
@@ -10,8 +10,10 @@ return [
     'root' => env('FAP_PACKS_ROOT', base_path('../content_packages')),
 
     // ✅ CI/服务器建议强约束：默认 pack_id 明确指向你的主包，避免回退到 GLOBAL/en
-    // 你现在最稳定的就是：MBTI.cn-mainland.zh-CN.v0.2.1-TEST
+    // default_pack_id 对应 manifest.json.pack_id（MBTI.cn-mainland.zh-CN.v0.2.1-TEST）
     'default_pack_id' => env('FAP_DEFAULT_PACK_ID', 'MBTI.cn-mainland.zh-CN.v0.2.1-TEST'),
+    // default_dir_version 对应目录名（MBTI-CN-v0.2.1-TEST）
+    'default_dir_version' => env('FAP_DEFAULT_DIR_VERSION', 'MBTI-CN-v0.2.1-TEST'),
 
     // ✅ 默认 region/locale 也钉死到 CN_MAINLAND/zh-CN（仍保留 fallback 机制）
     'default_region' => env('FAP_DEFAULT_REGION', 'CN_MAINLAND'),

--- a/backend/scripts/verify_contentstore_hot_reload.sh
+++ b/backend/scripts/verify_contentstore_hot_reload.sh
@@ -14,7 +14,7 @@ set -euo pipefail
 API="http://127.0.0.1:8000/api/v0.2/attempts/${ID}/report"
 
 # 默认文件/卡片（你现在验证用的那套）
-FILE="${FILE:-../content_packages/MBTI/GLOBAL/en/v0.2.1-TEST/report_cards_traits.json}"
+FILE="${FILE:-../content_packages/default/CN_MAINLAND/zh-CN/MBTI-CN-v0.2.1-TEST/report_cards_traits.json}"
 CARD_ID="${CARD_ID:-traits_axis_SN_N_strong}"
 CANARY_PREFIX="${CANARY_PREFIX:-@@CANARY@@}"
 

--- a/backend/scripts/verify_store_hot_reload_highlights.sh
+++ b/backend/scripts/verify_store_hot_reload_highlights.sh
@@ -4,7 +4,7 @@ set -euo pipefail
 : "${ID:?Please export ID=<attempt_uuid> first}"
 
 API="${API:-http://127.0.0.1:8000/api/v0.2/attempts/$ID/report}"
-FILE="${FILE:-../content_packages/MBTI/GLOBAL/en/v0.2.1-TEST/report_highlights_templates.json}"
+FILE="${FILE:-../content_packages/default/CN_MAINLAND/zh-CN/MBTI-CN-v0.2.1-TEST/report_highlights_templates.json}"
 CANARY_PREFIX="${CANARY_PREFIX:-@@CANARY_HL@@}"
 
 echo "[INFO] api=$API"

--- a/backend/scripts/verify_store_hot_reload_overrides.sh
+++ b/backend/scripts/verify_store_hot_reload_overrides.sh
@@ -4,7 +4,7 @@ set -euo pipefail
 : "${ID:?Please export ID=<attempt_uuid> first}"
 
 API="${API:-http://127.0.0.1:8000/api/v0.2/attempts/$ID/report}"
-FILE="${FILE:-../content_packages/MBTI/GLOBAL/en/v0.2.1-TEST/report_overrides.json}"
+FILE="${FILE:-../content_packages/default/CN_MAINLAND/zh-CN/MBTI-CN-v0.2.1-TEST/report_overrides.json}"
 CANARY_PREFIX="${CANARY_PREFIX:-@@CANARY_OV@@}"
 
 echo "[INFO] api=$API"

--- a/backend/scripts/verify_store_hot_reload_reads.sh
+++ b/backend/scripts/verify_store_hot_reload_reads.sh
@@ -4,7 +4,7 @@ set -euo pipefail
 : "${ID:?Please export ID=<attempt_uuid> first}"
 
 API="${API:-http://127.0.0.1:8000/api/v0.2/attempts/$ID/report}"
-FILE="${FILE:-../content_packages/MBTI/GLOBAL/en/v0.2.1-TEST/report_recommended_reads.json}"
+FILE="${FILE:-../content_packages/default/CN_MAINLAND/zh-CN/MBTI-CN-v0.2.1-TEST/report_recommended_reads.json}"
 CANARY_PREFIX="${CANARY_PREFIX:-@@CANARY_READS@@}"
 
 echo "[INFO] api=$API"

--- a/docs/04-ops/content-pack-resolution.md
+++ b/docs/04-ops/content-pack-resolution.md
@@ -1,0 +1,23 @@
+# 内容包定位规则（单一真相源）
+
+## 1) 单一真相源
+- backend/config/content_packs.php
+- root / default_pack_id / default_dir_version / default_region / default_locale / ci_strict
+
+## 2) 目录与字段定义
+- pack_id：manifest.json.pack_id
+- dir_version：目录名（MBTI-CN-v0.2.1-TEST）
+- content_package_version：manifest.json.content_package_version（v0.2.1-TEST）
+
+## 3) 解析步骤
+1. 先取 X-Region/X-Locale header
+2. 再取请求体 region/locale
+3. 再落到 config 默认 region/locale
+4. dir_version 默认来自 config(content_packs.default_dir_version)
+
+## 4) CI 严格策略
+- FAP_CI_STRICT=1 时，默认值必须存在且不可静默回退
+- 失败时返回明确错误（提示检查 env/config）
+
+## 5) 与 legacy config/content.php 的关系
+- content.php 仅做旧调用兼容，默认值与 env FAP_DEFAULT_DIR_VERSION 对齐


### PR DESCRIPTION
	•	make selfcheck
	•	cd backend && php artisan fap:self-check --strict-assets --pkg=default/CN_MAINLAND/zh-CN/MBTI-CN-v0.2.1-TEST
	•	cd backend && bash scripts/ci_verify_mbti.sh
	•	curl -sS http://127.0.0.1:8000/api/v0.2/scales/MBTI/questions | jq '{ok,pack_id,dir_version,content_package_version,region,locale,items_count:(.items|length)}'
	•	expected: ok=true, items_count=144, pack_id/dir_version/content_package_version 正确

Notes:
	•	smoke-v0.2.strict.sh 目前 POST /attempts 只发 1 条 answer，接口已要求 144 条；脚本修复放到后续独立 PR（不混入 PR0）。