### PR TITLE
PR3: local pack cache (ttl+etag) + resolver uses cache_dir for s3

### DIFF
--- a/backend/app/Services/Content/PackCache.php
+++ b/backend/app/Services/Content/PackCache.php
@@ -1,0 +1,232 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\Content;
+
+use App\Contracts\ContentSourceDriver;
+use App\Services\Content\Drivers\LocalDriver;
+use App\Services\Content\Drivers\S3Driver;
+use RuntimeException;
+
+final class PackCache
+{
+    public function ensureCached(string $pack): string
+    {
+        $pack = $this->normalizePack($pack);
+
+        $cacheRoot = rtrim((string)config('content_packs.cache_dir', ''), '/');
+        if ($cacheRoot === '') {
+            throw new RuntimeException('Missing config: content_packs.cache_dir');
+        }
+
+        $localPackDir = $cacheRoot . '/' . $pack;
+
+        $lockHandle = $this->acquireLock($cacheRoot, $pack);
+        try {
+            $driverName = (string)config('content_packs.driver', 'local');
+            $driver = $this->makeDriver($driverName);
+            $ttl = (int)config('content_packs.cache_ttl_seconds', 3600);
+
+            $manifestKey = $pack . '/manifest.json';
+            $sourceEtag = $driver->etag($manifestKey);
+
+            $metaPath = $localPackDir . '/.pack_cache_meta.json';
+            $meta = $this->loadMeta($metaPath);
+
+            if ($this->needsRefresh($localPackDir, $meta, $ttl, $sourceEtag)) {
+                $this->refresh($pack, $localPackDir, $driver, $driverName, $sourceEtag);
+            }
+        } finally {
+            $this->releaseLock($lockHandle);
+        }
+
+        return $this->fsPath($localPackDir);
+    }
+
+    private function refresh(string $pack, string $localPackDir, ContentSourceDriver $driver, string $driverName, ?string $sourceEtag): void
+    {
+        $keys = $driver->list($pack . '/');
+
+        $localPackDirFs = $this->fsPath($localPackDir);
+        if (!is_dir($localPackDirFs) && !mkdir($localPackDirFs, 0775, true) && !is_dir($localPackDirFs)) {
+            throw new RuntimeException("Failed to create cache dir: {$localPackDirFs}");
+        }
+
+        $prefix = rtrim($pack, '/') . '/';
+        foreach ($keys as $key) {
+            $key = $this->normalizeKey($key);
+            if (!str_starts_with($key, $prefix)) {
+                continue;
+            }
+
+            $rel = substr($key, strlen($prefix));
+            if ($rel === '') {
+                continue;
+            }
+
+            $contents = $driver->get($key);
+            $this->writeFileAtomic($localPackDir, $rel, $contents);
+        }
+
+        $meta = $this->makeMeta($pack, $sourceEtag, $driverName);
+        $meta->saveAtomic($this->fsPath($localPackDir . '/.pack_cache_meta.json'));
+    }
+
+    private function needsRefresh(string $localPackDir, ?PackCacheMeta $meta, int $ttl, ?string $sourceEtag): bool
+    {
+        $localPackDirFs = $this->fsPath($localPackDir);
+
+        if (!is_dir($localPackDirFs)) return true;
+        if ($meta === null) return true;
+        if ($meta->fetchedAt <= 0) return true;
+        if ((time() - $meta->fetchedAt) >= $ttl) return true;
+
+        if ($sourceEtag !== null && $meta->manifestEtag !== null && $sourceEtag !== $meta->manifestEtag) {
+            return true;
+        }
+
+        return false;
+    }
+
+    private function makeMeta(string $pack, ?string $sourceEtag, string $driverName): PackCacheMeta
+    {
+        $driverName = $driverName === 's3' ? 's3' : 'local';
+
+        $source = $driverName === 's3'
+            ? [
+                'disk' => (string)config('content_packs.s3_disk', 's3'),
+                'prefix' => (string)config('content_packs.s3_prefix', ''),
+            ]
+            : [
+                'root' => (string)config('content_packs.root', ''),
+            ];
+
+        return new PackCacheMeta(
+            $pack,
+            time(),
+            $sourceEtag,
+            $driverName,
+            $source
+        );
+    }
+
+    private function loadMeta(string $path): ?PackCacheMeta
+    {
+        $pathFs = $this->fsPath($path);
+        try {
+            return PackCacheMeta::fromFile($pathFs);
+        } catch (\Throwable $e) {
+            return null;
+        }
+    }
+
+    private function makeDriver(string $driverName): ContentSourceDriver
+    {
+        if ($driverName === 's3') {
+            return new S3Driver(
+                (string)config('content_packs.s3_disk', 's3'),
+                (string)config('content_packs.s3_prefix', '')
+            );
+        }
+
+        return new LocalDriver((string)config('content_packs.root', ''));
+    }
+
+    private function normalizePack(string $pack): string
+    {
+        $pack = str_replace(DIRECTORY_SEPARATOR, '/', $pack);
+        $pack = trim($pack, '/');
+
+        if ($pack === '') {
+            throw new RuntimeException('Pack cannot be empty.');
+        }
+
+        if (str_contains($pack, '..')) {
+            throw new RuntimeException('Invalid pack (.. not allowed).');
+        }
+
+        return $pack;
+    }
+
+    private function normalizeKey(string $key): string
+    {
+        $key = str_replace(DIRECTORY_SEPARATOR, '/', $key);
+        $key = ltrim($key, '/');
+
+        if (str_contains($key, '..')) {
+            throw new RuntimeException('Invalid content key (.. not allowed).');
+        }
+
+        return $key;
+    }
+
+    private function writeFileAtomic(string $localPackDir, string $rel, string $contents): void
+    {
+        $rel = str_replace(DIRECTORY_SEPARATOR, '/', $rel);
+        $rel = ltrim($rel, '/');
+
+        if ($rel === '' || str_contains($rel, '..')) {
+            throw new RuntimeException('Invalid cache write path.');
+        }
+
+        $dest = $localPackDir . '/' . $rel;
+        $destFs = $this->fsPath($dest);
+        $dirFs = dirname($destFs);
+
+        if (!is_dir($dirFs) && !mkdir($dirFs, 0775, true) && !is_dir($dirFs)) {
+            throw new RuntimeException("Failed to create cache dir: {$dirFs}");
+        }
+
+        $tmp = tempnam($dirFs, '.tmp-');
+        if ($tmp === false) {
+            throw new RuntimeException("Failed to create temp file in: {$dirFs}");
+        }
+
+        if (file_put_contents($tmp, $contents) === false) {
+            @unlink($tmp);
+            throw new RuntimeException("Failed to write temp cache file: {$tmp}");
+        }
+
+        if (!rename($tmp, $destFs)) {
+            @unlink($tmp);
+            throw new RuntimeException("Failed to move cache file into place: {$destFs}");
+        }
+    }
+
+    private function acquireLock(string $cacheRoot, string $pack)
+    {
+        $lockDir = $cacheRoot . '/.locks';
+        $lockDirFs = $this->fsPath($lockDir);
+        if (!is_dir($lockDirFs) && !mkdir($lockDirFs, 0775, true) && !is_dir($lockDirFs)) {
+            throw new RuntimeException("Failed to create lock dir: {$lockDirFs}");
+        }
+
+        $lockPath = $lockDir . '/' . sha1($pack) . '.lock';
+        $lockPathFs = $this->fsPath($lockPath);
+        $handle = fopen($lockPathFs, 'c');
+        if ($handle === false) {
+            throw new RuntimeException("Failed to open lock file: {$lockPathFs}");
+        }
+
+        if (!flock($handle, LOCK_EX)) {
+            fclose($handle);
+            throw new RuntimeException("Failed to lock cache file: {$lockPathFs}");
+        }
+
+        return $handle;
+    }
+
+    private function releaseLock($handle): void
+    {
+        if (is_resource($handle)) {
+            flock($handle, LOCK_UN);
+            fclose($handle);
+        }
+    }
+
+    private function fsPath(string $path): string
+    {
+        return str_replace('/', DIRECTORY_SEPARATOR, $path);
+    }
+}

--- a/backend/app/Services/Content/PackCacheMeta.php
+++ b/backend/app/Services/Content/PackCacheMeta.php
@@ -1,0 +1,117 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\Content;
+
+use RuntimeException;
+
+final class PackCacheMeta
+{
+    public string $pack;
+    public int $fetchedAt;
+    public ?string $manifestEtag;
+    public string $driver;
+    /** @var array<string, string> */
+    public array $source;
+
+    /**
+     * @param array<string, string> $source
+     */
+    public function __construct(string $pack, int $fetchedAt, ?string $manifestEtag, string $driver, array $source)
+    {
+        $this->pack = $pack;
+        $this->fetchedAt = $fetchedAt;
+        $this->manifestEtag = $manifestEtag;
+        $this->driver = $driver;
+        $this->source = $source;
+    }
+
+    public static function fromFile(string $path): self
+    {
+        if (!is_file($path)) {
+            throw new RuntimeException("Pack cache meta not found: {$path}");
+        }
+
+        $raw = file_get_contents($path);
+        if ($raw === false || trim($raw) === '') {
+            throw new RuntimeException("Pack cache meta is empty: {$path}");
+        }
+
+        $data = json_decode($raw, true);
+        if (!is_array($data)) {
+            throw new RuntimeException("Pack cache meta invalid json: {$path}");
+        }
+
+        $pack = $data['pack'] ?? null;
+        $fetchedAt = $data['fetched_at'] ?? null;
+        $driver = $data['driver'] ?? null;
+        $source = $data['source'] ?? null;
+
+        if (!is_string($pack) || $pack === '') {
+            throw new RuntimeException("Pack cache meta missing pack: {$path}");
+        }
+
+        if (!is_int($fetchedAt)) {
+            throw new RuntimeException("Pack cache meta missing fetched_at: {$path}");
+        }
+
+        if (!is_string($driver) || $driver === '') {
+            throw new RuntimeException("Pack cache meta missing driver: {$path}");
+        }
+
+        if (!is_array($source)) {
+            throw new RuntimeException("Pack cache meta missing source: {$path}");
+        }
+
+        $manifestEtag = $data['manifest_etag'] ?? null;
+        if ($manifestEtag !== null && !is_string($manifestEtag)) {
+            throw new RuntimeException("Pack cache meta invalid manifest_etag: {$path}");
+        }
+
+        return new self($pack, $fetchedAt, $manifestEtag, $driver, $source);
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(): array
+    {
+        return [
+            'pack' => $this->pack,
+            'fetched_at' => $this->fetchedAt,
+            'manifest_etag' => $this->manifestEtag,
+            'driver' => $this->driver,
+            'source' => $this->source,
+        ];
+    }
+
+    public function saveAtomic(string $path): void
+    {
+        $dir = dirname($path);
+        if (!is_dir($dir) && !mkdir($dir, 0775, true) && !is_dir($dir)) {
+            throw new RuntimeException("Failed to create meta dir: {$dir}");
+        }
+
+        $tmp = tempnam($dir, '.tmp-');
+        if ($tmp === false) {
+            throw new RuntimeException("Failed to create temp meta file in: {$dir}");
+        }
+
+        $json = json_encode($this->toArray(), JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES);
+        if ($json === false) {
+            @unlink($tmp);
+            throw new RuntimeException('Failed to encode pack cache meta to json.');
+        }
+
+        if (file_put_contents($tmp, $json) === false) {
+            @unlink($tmp);
+            throw new RuntimeException("Failed to write temp meta file: {$tmp}");
+        }
+
+        if (!rename($tmp, $path)) {
+            @unlink($tmp);
+            throw new RuntimeException("Failed to move meta file into place: {$path}");
+        }
+    }
+}

--- a/backend/config/content_packs.php
+++ b/backend/config/content_packs.php
@@ -16,6 +16,13 @@ return [
     's3_disk' => env('FAP_S3_DISK', 's3'),
     's3_prefix' => env('FAP_S3_PREFIX', ''),
 
+    // 缓存策略：
+    // - driver=local：读取 root
+    // - driver=s3：源来自 disk/prefix；实际读取落到 cache_dir（由 PackCache 保证目录存在/更新）
+    // - cache_ttl_seconds：到期触发一次 etag 校验与刷新
+    'cache_dir' => env('FAP_PACKS_CACHE_DIR', storage_path('app/private/content_packs_cache')),
+    'cache_ttl_seconds' => (int)env('FAP_PACKS_CACHE_TTL_SECONDS', 3600),
+
     // ✅ CI/服务器建议强约束：默认 pack_id 明确指向你的主包，避免回退到 GLOBAL/en
     // default_pack_id 对应 manifest.json.pack_id（MBTI.cn-mainland.zh-CN.v0.2.1-TEST）
     'default_pack_id' => env('FAP_DEFAULT_PACK_ID', 'MBTI.cn-mainland.zh-CN.v0.2.1-TEST'),

--- a/docs/04-ops/pack-cache.md
+++ b/docs/04-ops/pack-cache.md
@@ -1,0 +1,32 @@
+# 内容包本机缓存（Pack Cache）
+
+## 背景
+当 `content_packs.driver=s3` 时，对象存储只是内容“源”，线上读取必须落到本机 `cache_dir`。PackCache 会在本机拉齐内容包并维护元数据，确保解析器只读本地目录。
+
+## 目录位置
+默认缓存目录：
+`backend/storage/app/private/content_packs_cache/<pack>/...`
+
+其中 `<pack>` 形如：`default/CN_MAINLAND/zh-CN/MBTI-CN-v0.2.1-TEST`。
+
+## 元数据
+每个 pack 目录包含 `.pack_cache_meta.json`，字段含义：
+- `pack`：pack 相对路径
+- `fetched_at`：拉取时间（Unix 秒）
+- `manifest_etag`：manifest.json 的 etag/sha1（可能为 null）
+- `driver`：local 或 s3
+- `source`：local 为 `{root: ...}`，s3 为 `{disk: ..., prefix: ...}`
+
+`cache_ttl_seconds` 控制缓存有效期，到期触发一次 etag 校验与刷新。
+
+## 刷新规则
+满足任意条件即刷新：
+- 目录不存在
+- meta 缺失或解析失败
+- `now - fetched_at >= cache_ttl_seconds`
+- `manifest_etag` 变化
+
+## 运维排障
+- `cache_dir` 权限：确保运行用户可读写。
+- 锁文件目录：`cache_dir/.locks`（确保可创建/写入）。
+- 手动清缓存：删除单个 pack 目录，`ensureCached` 会重建。


### PR DESCRIPTION
	•	cd backend && php artisan tinker → app(PackCache::class)->ensureCached('default/CN_MAINLAND/zh-CN/MBTI-CN-v0.2.1-TEST')（目录/manifest/questions/meta 生成）
	•	cd backend && PORT=18003 bash scripts/ci_verify_mbti.sh ✅ PASS