### PR TITLE
PR4: content packs index API + manifest/questions endpoints

### DIFF
--- a/.github/workflows/ci_verify_mbti.yml
+++ b/.github/workflows/ci_verify_mbti.yml
@@ -58,6 +58,19 @@ jobs:
           # Make scripts executable (some repos lose +x on Windows)
           chmod +x scripts/*.sh || true
 
+      - name: Check content packs index endpoint
+        run: |
+          set -euo pipefail
+          cd backend
+          php artisan serve --host=127.0.0.1 --port=18000 >/tmp/pr4_srv.log 2>&1 &
+          SRV_PID=$!
+          trap "kill ${SRV_PID}" EXIT
+          for i in $(seq 1 30); do
+            curl -sS http://127.0.0.1:18000/api/v0.2/health >/dev/null && break
+            sleep 1
+          done
+          curl -sS http://127.0.0.1:18000/api/v0.2/content-packs | jq -e '.ok==true'
+
       - name: Run ci_verify_mbti
         working-directory: backend
         env:

--- a/backend/app/Http/Controllers/API/V0_2/ContentPacksController.php
+++ b/backend/app/Http/Controllers/API/V0_2/ContentPacksController.php
@@ -1,0 +1,123 @@
+<?php
+
+namespace App\Http\Controllers\API\V0_2;
+
+use App\Http\Controllers\Controller;
+use App\Services\Content\ContentPacksIndex;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\File;
+
+class ContentPacksController extends Controller
+{
+    /**
+     * GET /api/v0.2/content-packs
+     */
+    public function index(Request $request, ContentPacksIndex $index)
+    {
+        $refresh = (string) $request->query('refresh', '') === '1';
+        return response()->json($index->getIndex($refresh));
+    }
+
+    /**
+     * GET /api/v0.2/content-packs/{pack_id}/{dir_version}/manifest
+     */
+    public function manifest(string $pack_id, string $dir_version, ContentPacksIndex $index)
+    {
+        $found = $index->find($pack_id, $dir_version);
+        if (!($found['ok'] ?? false)) {
+            return $this->notFound();
+        }
+
+        $item = $found['item'] ?? [];
+        $path = (string) ($item['manifest_path'] ?? '');
+        $read = $this->readJsonFile($path);
+        if (!($read['ok'] ?? false)) {
+            return $this->readFailed((string) ($read['error'] ?? 'READ_FAILED'), (string) ($read['message'] ?? ''));
+        }
+
+        return response()->json([
+            'ok' => true,
+            'pack_id' => $pack_id,
+            'dir_version' => $dir_version,
+            'manifest' => $read['data'],
+        ]);
+    }
+
+    /**
+     * GET /api/v0.2/content-packs/{pack_id}/{dir_version}/questions
+     */
+    public function questions(string $pack_id, string $dir_version, ContentPacksIndex $index)
+    {
+        $found = $index->find($pack_id, $dir_version);
+        if (!($found['ok'] ?? false)) {
+            return $this->notFound();
+        }
+
+        $item = $found['item'] ?? [];
+        $path = (string) ($item['questions_path'] ?? '');
+        $read = $this->readJsonFile($path);
+        if (!($read['ok'] ?? false)) {
+            return $this->readFailed((string) ($read['error'] ?? 'READ_FAILED'), (string) ($read['message'] ?? ''));
+        }
+
+        return response()->json([
+            'ok' => true,
+            'pack_id' => $pack_id,
+            'dir_version' => $dir_version,
+            'questions' => $read['data'],
+        ]);
+    }
+
+    private function readJsonFile(string $path): array
+    {
+        if ($path === '' || !File::exists($path) || !File::isFile($path)) {
+            return [
+                'ok' => false,
+                'error' => 'READ_FAILED',
+                'message' => $path === '' ? 'missing file path' : "file not found: {$path}",
+            ];
+        }
+
+        try {
+            $raw = File::get($path);
+        } catch (\Throwable $e) {
+            return [
+                'ok' => false,
+                'error' => 'READ_FAILED',
+                'message' => "failed to read: {$path}",
+            ];
+        }
+
+        $decoded = json_decode($raw, true);
+        if (!is_array($decoded)) {
+            return [
+                'ok' => false,
+                'error' => 'INVALID_JSON',
+                'message' => "invalid json: {$path}",
+            ];
+        }
+
+        return [
+            'ok' => true,
+            'data' => $decoded,
+        ];
+    }
+
+    private function notFound()
+    {
+        return response()->json([
+            'ok' => false,
+            'error' => 'NOT_FOUND',
+            'message' => 'pack not found',
+        ], 404);
+    }
+
+    private function readFailed(string $error, string $message)
+    {
+        return response()->json([
+            'ok' => false,
+            'error' => $error,
+            'message' => $message,
+        ], 500);
+    }
+}

--- a/backend/app/Services/Content/ContentPacksIndex.php
+++ b/backend/app/Services/Content/ContentPacksIndex.php
@@ -1,0 +1,272 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\Content;
+
+use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Facades\File;
+
+final class ContentPacksIndex
+{
+    public const CACHE_KEY = 'fap:content_packs_index:v0.2';
+    public const CACHE_TTL_SECONDS = 30;
+
+    public function getIndex(bool $refresh = false): array
+    {
+        $driver = (string) config('content_packs.driver', 'local');
+        $driver = $driver === 's3' ? 's3' : 'local';
+
+        $packsRoot = $driver === 's3'
+            ? (string) config('content_packs.cache_dir', '')
+            : (string) config('content_packs.root', '');
+
+        $packsRootFs = rtrim($packsRoot, "/\\");
+        $defaults = $this->defaults();
+
+        $cache = $this->cacheStore();
+
+        if (!$refresh) {
+            try {
+                $cached = $cache->get(self::CACHE_KEY);
+            } catch (\Throwable $e) {
+                $cached = null;
+            }
+
+            if (is_array($cached)) {
+                return $cached;
+            }
+        }
+
+        if ($packsRootFs === '' || !File::isDirectory($packsRootFs)) {
+            return [
+                'ok' => false,
+                'driver' => $driver,
+                'packs_root' => $packsRootFs,
+                'defaults' => $defaults,
+                'items' => [],
+                'by_pack_id' => [],
+            ];
+        }
+
+        $items = $this->scanItems($packsRootFs);
+        $byPackId = $this->buildByPackId($items, $defaults);
+
+        $index = [
+            'ok' => true,
+            'driver' => $driver,
+            'packs_root' => $packsRootFs,
+            'defaults' => $defaults,
+            'items' => $items,
+            'by_pack_id' => $byPackId,
+        ];
+
+        try {
+            $cache->put(self::CACHE_KEY, $index, self::CACHE_TTL_SECONDS);
+        } catch (\Throwable $e) {
+            // ignore cache write failure
+        }
+
+        return $index;
+    }
+
+    public function find(string $packId, string $dirVersion): array
+    {
+        $index = $this->getIndex(false);
+        if (!($index['ok'] ?? false)) {
+            return [
+                'ok' => false,
+                'error' => 'NOT_FOUND',
+            ];
+        }
+
+        $items = $index['items'] ?? [];
+        foreach ($items as $item) {
+            if (($item['pack_id'] ?? '') === $packId && ($item['dir_version'] ?? '') === $dirVersion) {
+                return [
+                    'ok' => true,
+                    'item' => $item,
+                ];
+            }
+        }
+
+        return [
+            'ok' => false,
+            'error' => 'NOT_FOUND',
+        ];
+    }
+
+    private function cacheStore()
+    {
+        $client = (string) config('database.redis.client', 'phpredis');
+        $redisUsable = $client === 'predis' || class_exists('Redis');
+
+        if ($redisUsable) {
+            try {
+                return Cache::store('redis');
+            } catch (\Throwable $e) {
+                // fall through
+            }
+        }
+
+        return Cache::store();
+    }
+
+    private function defaults(): array
+    {
+        return [
+            'default_pack_id' => (string) config('content_packs.default_pack_id', ''),
+            'default_dir_version' => (string) config('content_packs.default_dir_version', ''),
+            'default_region' => (string) config('content_packs.default_region', ''),
+            'default_locale' => (string) config('content_packs.default_locale', ''),
+            'region_fallbacks' => (array) config('content_packs.region_fallbacks', []),
+            'locale_fallback' => (bool) config('content_packs.locale_fallback', false),
+        ];
+    }
+
+    private function scanItems(string $packsRootFs): array
+    {
+        $items = [];
+        $seen = [];
+        $rootNorm = rtrim(str_replace(DIRECTORY_SEPARATOR, '/', $packsRootFs), '/');
+
+        foreach (File::allFiles($packsRootFs) as $file) {
+            if ($file->getFilename() !== 'manifest.json') {
+                continue;
+            }
+
+            $manifestPath = $file->getPathname();
+            $manifestPathNorm = str_replace(DIRECTORY_SEPARATOR, '/', $manifestPath);
+            if (str_contains($manifestPathNorm, '/_deprecated/')) {
+                continue;
+            }
+
+            try {
+                $manifestRaw = File::get($manifestPath);
+            } catch (\Throwable $e) {
+                continue;
+            }
+
+            $manifest = json_decode($manifestRaw, true);
+            if (!is_array($manifest)) {
+                continue;
+            }
+
+            $packId = $manifest['pack_id'] ?? null;
+            if (!is_string($packId) || trim($packId) === '') {
+                continue;
+            }
+
+            $packDir = dirname($manifestPath);
+            $questionsPath = $packDir . DIRECTORY_SEPARATOR . 'questions.json';
+            if (!File::exists($questionsPath)) {
+                continue;
+            }
+
+            $dirVersion = basename($packDir);
+
+            $key = $packId . '|' . $dirVersion;
+            if (isset($seen[$key])) {
+                continue;
+            }
+
+            $packPath = $this->relativePath($rootNorm, $packDir);
+            $updatedAt = @filemtime($manifestPath);
+            $updatedAt = is_int($updatedAt) ? $updatedAt : 0;
+
+            $items[] = [
+                'pack_id' => $packId,
+                'dir_version' => $dirVersion,
+                'content_package_version' => (string) ($manifest['content_package_version'] ?? ''),
+                'scale_code' => (string) ($manifest['scale_code'] ?? ''),
+                'region' => (string) ($manifest['region'] ?? ''),
+                'locale' => (string) ($manifest['locale'] ?? ''),
+                'pack_path' => $packPath,
+                'manifest_path' => $manifestPath,
+                'questions_path' => $questionsPath,
+                'updated_at' => $updatedAt,
+            ];
+
+            $seen[$key] = true;
+        }
+
+        usort($items, function (array $a, array $b): int {
+            $cmp = strcmp((string) ($a['pack_id'] ?? ''), (string) ($b['pack_id'] ?? ''));
+            if ($cmp !== 0) {
+                return $cmp;
+            }
+            return strcmp((string) ($a['dir_version'] ?? ''), (string) ($b['dir_version'] ?? ''));
+        });
+
+        return $items;
+    }
+
+    private function buildByPackId(array $items, array $defaults): array
+    {
+        $byPackId = [];
+        $latest = [];
+        $defaultPackId = (string) ($defaults['default_pack_id'] ?? '');
+        $defaultDirVersion = (string) ($defaults['default_dir_version'] ?? '');
+
+        foreach ($items as $item) {
+            $packId = (string) ($item['pack_id'] ?? '');
+            $dirVersion = (string) ($item['dir_version'] ?? '');
+            if ($packId === '' || $dirVersion === '') {
+                continue;
+            }
+
+            if (!isset($byPackId[$packId])) {
+                $byPackId[$packId] = [
+                    'default_dir_version' => '',
+                    'versions' => [],
+                ];
+            }
+
+            $byPackId[$packId]['versions'][] = $dirVersion;
+
+            $updatedAt = (int) ($item['updated_at'] ?? 0);
+            if (!isset($latest[$packId]) || $updatedAt > (int) ($latest[$packId]['updated_at'] ?? 0)) {
+                $latest[$packId] = [
+                    'dir_version' => $dirVersion,
+                    'updated_at' => $updatedAt,
+                ];
+            }
+        }
+
+        foreach ($byPackId as $packId => $info) {
+            $versions = array_values(array_unique($info['versions'] ?? []));
+            sort($versions, SORT_STRING);
+
+            $default = '';
+            if ($packId === $defaultPackId && $defaultDirVersion !== '') {
+                $default = $defaultDirVersion;
+            } else {
+                $default = (string) ($latest[$packId]['dir_version'] ?? '');
+                if ($default === '') {
+                    $default = (string) ($versions[0] ?? '');
+                }
+            }
+
+            $byPackId[$packId] = [
+                'default_dir_version' => $default,
+                'versions' => $versions,
+            ];
+        }
+
+        ksort($byPackId, SORT_STRING);
+
+        return $byPackId;
+    }
+
+    private function relativePath(string $rootNorm, string $path): string
+    {
+        $pathNorm = str_replace(DIRECTORY_SEPARATOR, '/', $path);
+        $rootNorm = rtrim($rootNorm, '/');
+
+        if ($rootNorm !== '' && str_starts_with($pathNorm, $rootNorm . '/')) {
+            return substr($pathNorm, strlen($rootNorm) + 1);
+        }
+
+        return ltrim($pathNorm, '/');
+    }
+}

--- a/backend/routes/api.php
+++ b/backend/routes/api.php
@@ -9,6 +9,7 @@ use App\Http\Controllers\LookupController;
 use App\Http\Controllers\API\V0_2\AuthPhoneController;
 use App\Http\Controllers\API\V0_2\AuthProviderController;
 use App\Http\Controllers\API\V0_2\ClaimController;
+use App\Http\Controllers\API\V0_2\ContentPacksController;
 use App\Http\Controllers\API\V0_2\IdentityController;
 use App\Http\Controllers\API\V0_2\MeController;
 use App\Http\Controllers\API\V0_2\NormsController;
@@ -33,6 +34,11 @@ Route::prefix("v0.2")->group(function () {
 
     // 1) Health
     Route::get("/health", [MbtiController::class, "health"]);
+
+    // 1.5) Content packs
+    Route::get("/content-packs", [ContentPacksController::class, "index"]);
+    Route::get("/content-packs/{pack_id}/{dir_version}/manifest", [ContentPacksController::class, "manifest"]);
+    Route::get("/content-packs/{pack_id}/{dir_version}/questions", [ContentPacksController::class, "questions"]);
 
     // 2) Scale meta
     Route::get("/scales/MBTI", [MbtiController::class, "scaleMeta"]);

--- a/docs/03-stage1/content_packs_endpoints.md
+++ b/docs/03-stage1/content_packs_endpoints.md
@@ -1,0 +1,91 @@
+# Content Packs Index API
+
+## 背景
+前端热更新/灰度需要可查询的内容包列表、版本、默认版本与回退规则（region/locale），以便在运行时做包选择与切换。
+
+## GET /api/v0.2/content-packs
+说明：返回内容包索引（支持 refresh=1 强制重建缓存）。
+
+Query:
+- refresh=1：强制刷新索引缓存
+
+响应结构（示例字段）：
+```json
+{
+  "ok": true,
+  "driver": "local",
+  "packs_root": "/abs/path/to/content_packages",
+  "defaults": {
+    "default_pack_id": "MBTI.cn-mainland.zh-CN.v0.2.1-TEST",
+    "default_dir_version": "MBTI-CN-v0.2.1-TEST",
+    "default_region": "CN_MAINLAND",
+    "default_locale": "zh-CN",
+    "region_fallbacks": {"*": ["GLOBAL"]},
+    "locale_fallback": true
+  },
+  "items": [
+    {
+      "pack_id": "MBTI.cn-mainland.zh-CN.v0.2.1-TEST",
+      "dir_version": "MBTI-CN-v0.2.1-TEST",
+      "content_package_version": "v0.2.1",
+      "scale_code": "MBTI",
+      "region": "CN_MAINLAND",
+      "locale": "zh-CN",
+      "pack_path": "default/CN_MAINLAND/zh-CN/MBTI-CN-v0.2.1-TEST",
+      "manifest_path": "/abs/path/to/manifest.json",
+      "questions_path": "/abs/path/to/questions.json",
+      "updated_at": 1700000000
+    }
+  ],
+  "by_pack_id": {
+    "MBTI.cn-mainland.zh-CN.v0.2.1-TEST": {
+      "default_dir_version": "MBTI-CN-v0.2.1-TEST",
+      "versions": ["MBTI-CN-v0.2.1-TEST"]
+    }
+  }
+}
+```
+
+## GET /api/v0.2/content-packs/{pack_id}/{dir_version}/manifest
+说明：读取指定内容包的 manifest.json。
+
+示例：
+```bash
+curl -sS http://127.0.0.1:8000/api/v0.2/content-packs/MBTI.cn-mainland.zh-CN.v0.2.1-TEST/MBTI-CN-v0.2.1-TEST/manifest
+```
+
+响应：
+```json
+{
+  "ok": true,
+  "pack_id": "MBTI.cn-mainland.zh-CN.v0.2.1-TEST",
+  "dir_version": "MBTI-CN-v0.2.1-TEST",
+  "manifest": {"schema_version": "pack-manifest@v1"}
+}
+```
+
+## GET /api/v0.2/content-packs/{pack_id}/{dir_version}/questions
+说明：读取指定内容包的 questions.json。
+
+示例：
+```bash
+curl -sS http://127.0.0.1:8000/api/v0.2/content-packs/MBTI.cn-mainland.zh-CN.v0.2.1-TEST/MBTI-CN-v0.2.1-TEST/questions
+```
+
+响应：
+```json
+{
+  "ok": true,
+  "pack_id": "MBTI.cn-mainland.zh-CN.v0.2.1-TEST",
+  "dir_version": "MBTI-CN-v0.2.1-TEST",
+  "questions": [{"id": 1}]
+}
+```
+
+## 缓存
+- 索引缓存优先走 Redis，TTL 30 秒。
+- refresh=1 可强制刷新索引。
+
+## S3 模式
+- driver=s3 时，packs_root 指向 content_packs.cache_dir。
+- PackCache 负责将 s3 内容拉齐到 cache_dir，再由索引扫描本地缓存。


### PR DESCRIPTION
## Summary（改了什么）
- 新增内容包索引服务：扫描 packs_root 下 manifest.json，建立 index，并做缓存（优先 redis，不可用自动回退默认 cache store）
- 新增 v0.2 API：
  - GET /api/v0.2/content-packs（支持 ?refresh=1）
  - GET /api/v0.2/content-packs/{pack_id}/{dir_version}/manifest
  - GET /api/v0.2/content-packs/{pack_id}/{dir_version}/questions
- 新增文档：docs/03-stage1/content_packs_endpoints.md
- CI：ci_verify_mbti.yml 增加一步请求 /api/v0.2/content-packs 并断言 ok=true

## Scope（影响范围）
- 只新增接口与索引扫描，不改现有测评/报告生成链路
- packs_root 规则：
  - driver=local：使用 content_packs.root
  - driver=s3：使用 content_packs.cache_dir（依赖 PR3 PackCache 先把内容落到本机）

## Verify（本地验收）
- php artisan serve --port=8000
- curl /api/v0.2/content-packs | jq .ok  => true
- curl /api/v0.2/content-packs/{pack_id}/{dir_version}/manifest | jq .ok => true
- curl /api/v0.2/content-packs/{pack_id}/{dir_version}/questions | jq .ok => true
- PORT=18010 bash backend/scripts/ci_verify_mbti.sh  => PASS