### PR TITLE
PR5: add redis hot cache + unified cache keys

### DIFF
--- a/backend/app/Support/CacheKeys.php
+++ b/backend/app/Support/CacheKeys.php
@@ -1,0 +1,70 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Support;
+
+final class CacheKeys
+{
+    private const PREFIX = 'fap';
+
+    public static function versionTag(): string
+    {
+        $appVersion = trim((string) config('app.version', ''));
+        if ($appVersion === '') {
+            $appVersion = trim((string) env('APP_VERSION', ''));
+        }
+        if ($appVersion === '') {
+            $appVersion = 'dev';
+        }
+
+        $cachePrefix = trim((string) config('cache.prefix', ''));
+        if ($cachePrefix === '') {
+            $cachePrefix = trim((string) env('CACHE_PREFIX', ''));
+        }
+
+        return $cachePrefix === '' ? $appVersion : $appVersion . ':' . $cachePrefix;
+    }
+
+    public static function packsIndex(): string
+    {
+        return self::base() . ':content_packs:index';
+    }
+
+    public static function packManifest(string $packId, string $dirVersion): string
+    {
+        $packId = trim($packId);
+        $dirVersion = trim($dirVersion);
+
+        return self::base() . ':content_packs:manifest:' . $packId . ':' . $dirVersion;
+    }
+
+    public static function packQuestions(string $packId, string $dirVersion): string
+    {
+        $packId = trim($packId);
+        $dirVersion = trim($dirVersion);
+
+        return self::base() . ':content_packs:questions:' . $packId . ':' . $dirVersion;
+    }
+
+    public static function mbtiQuestions(string $packId, string $dirVersion): string
+    {
+        $packId = trim($packId);
+        $dirVersion = trim($dirVersion);
+
+        return self::base() . ':mbti:questions:' . $packId . ':' . $dirVersion;
+    }
+
+    public static function contentAsset(string $packPath, string $relPath): string
+    {
+        $packPath = trim($packPath);
+        $relPath = trim($relPath);
+
+        return self::base() . ':asset:' . $packPath . ':' . $relPath;
+    }
+
+    private static function base(): string
+    {
+        return self::PREFIX . ':v=' . self::versionTag();
+    }
+}

--- a/backend/config/cache.php
+++ b/backend/config/cache.php
@@ -1,7 +1,5 @@
 <?php
 
-use Illuminate\Support\Str;
-
 return [
 
     /*
@@ -77,6 +75,11 @@ return [
             'connection' => env('REDIS_CACHE_CONNECTION', 'cache'),
             'lock_connection' => env('REDIS_CACHE_LOCK_CONNECTION', 'default'),
         ],
+        'hot_redis' => [
+            'driver' => 'redis',
+            'connection' => 'cache',
+            'lock_connection' => 'default',
+        ],
 
         'dynamodb' => [
             'driver' => 'dynamodb',
@@ -112,6 +115,6 @@ return [
     |
     */
 
-    'prefix' => env('CACHE_PREFIX', Str::slug((string) env('APP_NAME', 'laravel')).'-cache-'),
+    'prefix' => env('CACHE_PREFIX', env('APP_NAME', 'fap').'_cache'),
 
 ];

--- a/backend/config/database.php
+++ b/backend/config/database.php
@@ -1,7 +1,5 @@
 <?php
 
-use Illuminate\Support\Str;
-
 return [
 
     /*
@@ -145,7 +143,7 @@ return [
 
         'options' => [
             'cluster' => env('REDIS_CLUSTER', 'redis'),
-            'prefix' => env('REDIS_PREFIX', Str::slug((string) env('APP_NAME', 'laravel')).'-database-'),
+            'prefix' => env('REDIS_PREFIX', env('APP_NAME', 'fap').':'),
             'persistent' => env('REDIS_PERSISTENT', false),
         ],
 

--- a/backend/docker-compose.yml
+++ b/backend/docker-compose.yml
@@ -1,0 +1,7 @@
+version: "3.8"
+
+services:
+  redis:
+    image: redis:7-alpine
+    ports:
+      - "6379:6379"

--- a/docs/04-ops/cache-keys.md
+++ b/docs/04-ops/cache-keys.md
@@ -1,0 +1,46 @@
+# Cache Keys (Hot Redis)
+
+## Key Rule
+
+Format:
+
+`fap:v=<versionTag>:<domain>:<resource>:...`
+
+Where:
+
+- `versionTag` = `config('app.version')` or `APP_VERSION` (fallback to `dev`), plus `config('cache.prefix')`.
+- `cache.prefix` provides environment isolation; `APP_VERSION` provides release-based invalidation.
+
+## Keys List (CacheKeys)
+
+- `CacheKeys::packsIndex()`
+  - `fap:v=<versionTag>:content_packs:index`
+- `CacheKeys::packManifest($packId, $dirVersion)`
+  - `fap:v=<versionTag>:content_packs:manifest:<packId>:<dirVersion>`
+- `CacheKeys::packQuestions($packId, $dirVersion)`
+  - `fap:v=<versionTag>:content_packs:questions:<packId>:<dirVersion>`
+- `CacheKeys::mbtiQuestions($packId, $dirVersion)`
+  - `fap:v=<versionTag>:mbti:questions:<packId>:<dirVersion>`
+- `CacheKeys::contentAsset($packPath, $relPath)`
+  - `fap:v=<versionTag>:asset:<packPath>:<relPath>`
+
+Notes:
+
+- `packPath` / `relPath` keep `/` for readability.
+- No spaces in keys; inputs are trimmed.
+
+## Precise Invalidation
+
+- On release, bump `APP_VERSION` (or inject via CI).
+- This changes `versionTag` and shifts to a new key space.
+- No `flushdb` required in production.
+
+## Local Troubleshooting
+
+- If Redis is unavailable, the app falls back to the default cache store or direct file reads.
+- Check logs for hot cache hits/misses:
+  - `[HOTCACHE] kind=asset key=... hit=1`
+  - `[HOTCACHE] kind=mbti_questions ... hit=1`
+- Manual cleanup:
+  - Default store: `php artisan cache:clear`
+  - Redis (local only): `redis-cli FLUSHDB`


### PR DESCRIPTION
- docker compose up -d redis
- GET /api/v0.2/scales/MBTI/questions twice => HOTCACHE miss then hit (ms drop)
- PORT=18010 bash backend/scripts/ci_verify_mbti.sh => PASS
- docs: docs/04-ops/cache-keys.md