### PR TITLE
PR6: async report generation via queue + report_jobs status

### DIFF
--- a/.github/workflows/ci_verify_mbti.yml
+++ b/.github/workflows/ci_verify_mbti.yml
@@ -58,6 +58,19 @@ jobs:
           # Make scripts executable (some repos lose +x on Windows)
           chmod +x scripts/*.sh || true
 
+      - name: Prepare SQLite DB + migrate
+        working-directory: backend
+        env:
+          APP_ENV: ci
+          DB_CONNECTION: sqlite
+          DB_DATABASE: ${{ github.workspace }}/backend/database/database.sqlite
+          QUEUE_CONNECTION: sync
+        run: |
+          set -euo pipefail
+          mkdir -p database
+          touch database/database.sqlite
+          php artisan migrate --force
+
       - name: Check content packs index endpoint
         run: |
           set -euo pipefail
@@ -81,6 +94,11 @@ jobs:
           FAP_DEFAULT_REGION: CN_MAINLAND
           FAP_DEFAULT_LOCALE: zh-CN
           FAP_DEFAULT_PACK_ID: MBTI.cn-mainland.zh-CN.v0.2.1-TEST
+
+          # DB + queue (PR6)
+          DB_CONNECTION: sqlite
+          DB_DATABASE: ${{ github.workspace }}/backend/database/database.sqlite
+          QUEUE_CONNECTION: sync
 
           # Keep E2E strict
           STRICT: "1"

--- a/.github/workflows/selfcheck.yml
+++ b/.github/workflows/selfcheck.yml
@@ -16,6 +16,7 @@ jobs:
       APP_ENV: testing
       DB_CONNECTION: sqlite
       DB_DATABASE: ${{ github.workspace }}/backend/database/database.sqlite
+      QUEUE_CONNECTION: sync
 
     steps:
       - uses: actions/checkout@v4
@@ -50,6 +51,19 @@ jobs:
       - name: Run selfcheck (default manifest)
         working-directory: backend
         run: php artisan fap:self-check --strict-assets --pkg=default/CN_MAINLAND/zh-CN/MBTI-CN-v0.2.1-TEST
+
+      - name: PR6 queue (sync) smoke
+        working-directory: backend
+        run: |
+          set -euo pipefail
+          php artisan serve --host=127.0.0.1 --port=18080 >/tmp/pr6_srv.log 2>&1 &
+          SRV_PID=$!
+          trap "kill ${SRV_PID}" EXIT
+          for i in $(seq 1 30); do
+            curl -sS http://127.0.0.1:18080/api/v0.2/health >/dev/null && break
+            sleep 1
+          done
+          API="http://127.0.0.1:18080" bash scripts/verify_mbti.sh
 
       - name: Seed demo attempt+result (for runtime validate)
         working-directory: backend

--- a/backend/app/Jobs/GenerateReportJob.php
+++ b/backend/app/Jobs/GenerateReportJob.php
@@ -1,0 +1,139 @@
+<?php
+
+namespace App\Jobs;
+
+use App\Models\ReportJob;
+use App\Services\Report\ReportComposer;
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Bus\Dispatchable;
+use Illuminate\Queue\InteractsWithQueue;
+use Illuminate\Queue\SerializesModels;
+use Illuminate\Support\Facades\Log;
+use Illuminate\Support\Facades\Storage;
+use Illuminate\Support\Str;
+
+class GenerateReportJob implements ShouldQueue
+{
+    use Dispatchable, InteractsWithQueue, Queueable, SerializesModels;
+
+    public string $attemptId;
+    public ?string $jobId;
+
+    public function __construct(string $attemptId, ?string $jobId = null)
+    {
+        $this->attemptId = $attemptId;
+        $this->jobId = $jobId;
+    }
+
+    public function handle(ReportComposer $composer): void
+    {
+        $job = ReportJob::where('attempt_id', $this->attemptId)->first();
+
+        if (!$job) {
+            $job = ReportJob::create([
+                'id' => $this->jobId ?: (string) Str::uuid(),
+                'attempt_id' => $this->attemptId,
+                'status' => 'queued',
+                'tries' => 0,
+                'available_at' => now(),
+            ]);
+        }
+
+        $job->tries = ((int) ($job->tries ?? 0)) + 1;
+        $job->status = 'running';
+        $job->started_at = now();
+        $job->failed_at = null;
+        $job->finished_at = null;
+        $job->last_error = null;
+        $job->last_error_trace = null;
+        $job->save();
+
+        try {
+            $defaultDirVersion = (string) config(
+                'content_packs.default_dir_version',
+                config('content.default_versions.default', 'MBTI-CN-v0.2.1-TEST')
+            );
+
+            $res = $composer->compose($this->attemptId, [
+                'defaultProfileVersion' => config('fap.profile_version', 'mbti32-v2.5'),
+                'defaultContentPackageVersion' => $defaultDirVersion,
+                'currentContentPackageVersion' => fn () => $defaultDirVersion,
+            ]);
+
+            if (!($res['ok'] ?? false)) {
+                $msg = $res['message'] ?? 'Report compose failed';
+                $err = $res['error'] ?? 'REPORT_FAILED';
+                throw new \RuntimeException("{$err}: {$msg}");
+            }
+
+            $reportPayload = $res['report'] ?? [];
+            if (!is_array($reportPayload)) $reportPayload = [];
+
+            $reportPayload['tags'] = $res['tags'] ?? ($reportPayload['tags'] ?? []);
+            if (!is_array($reportPayload['tags'])) $reportPayload['tags'] = [];
+
+            $job->status = 'success';
+            $job->finished_at = now();
+            $job->report_json = $reportPayload;
+            $job->save();
+
+            $this->persistReportJson($this->attemptId, $reportPayload);
+        } catch (\Throwable $e) {
+            $job->status = 'failed';
+            $job->failed_at = now();
+            $job->last_error = $e->getMessage();
+            $job->last_error_trace = $e->getTraceAsString();
+            $job->save();
+
+            Log::warning('[report_job] failed', [
+                'attempt_id' => $this->attemptId,
+                'job_id' => $job->id,
+                'err' => $e->getMessage(),
+            ]);
+
+            throw $e;
+        }
+    }
+
+    private function persistReportJson(string $attemptId, array $reportPayload): void
+    {
+        $disk = array_key_exists('private', config('filesystems.disks', []))
+            ? Storage::disk('private')
+            : Storage::disk(config('filesystems.default', 'local'));
+
+        $latestRelPath = "reports/{$attemptId}/report.json";
+
+        try {
+            $json = json_encode($reportPayload, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES);
+            if ($json === false) {
+                throw new \RuntimeException('json_encode_failed: ' . json_last_error_msg());
+            }
+
+            if (method_exists($disk, 'makeDirectory')) {
+                $disk->makeDirectory("reports/{$attemptId}");
+            }
+
+            $disk->put($latestRelPath, $json);
+
+            $ts = function_exists('now') ? now()->format('Ymd_His') : date('Ymd_His');
+            $snapRelPath = "reports/{$attemptId}/report.{$ts}.json";
+            $disk->put($snapRelPath, $json);
+
+            Log::info('[report_job] persisted report.json', [
+                'attempt_id' => $attemptId,
+                'disk' => array_key_exists('private', config('filesystems.disks', []))
+                    ? 'private'
+                    : config('filesystems.default', 'local'),
+                'latest' => $latestRelPath,
+                'snapshot' => $snapRelPath,
+            ]);
+        } catch (\Throwable $e) {
+            Log::warning('[report_job] persist report.json failed', [
+                'attempt_id' => $attemptId,
+                'path' => $latestRelPath,
+                'err' => $e->getMessage(),
+            ]);
+        }
+    }
+}

--- a/backend/app/Models/ReportJob.php
+++ b/backend/app/Models/ReportJob.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class ReportJob extends Model
+{
+    use HasFactory;
+
+    protected $table = 'report_jobs';
+
+    protected $primaryKey = 'id';
+    public $incrementing = false;
+    protected $keyType = 'string';
+
+    protected $fillable = [
+        'id',
+        'attempt_id',
+        'status',
+        'tries',
+        'available_at',
+        'started_at',
+        'finished_at',
+        'failed_at',
+        'last_error',
+        'last_error_trace',
+        'report_json',
+        'meta',
+    ];
+
+    protected $casts = [
+        'tries' => 'integer',
+        'available_at' => 'datetime',
+        'started_at' => 'datetime',
+        'finished_at' => 'datetime',
+        'failed_at' => 'datetime',
+        'report_json' => 'array',
+        'meta' => 'array',
+    ];
+}

--- a/backend/config/queue.php
+++ b/backend/config/queue.php
@@ -13,7 +13,7 @@ return [
     |
     */
 
-    'default' => env('QUEUE_CONNECTION', 'database'),
+    'default' => env('QUEUE_CONNECTION', 'sync'),
 
     /*
     |--------------------------------------------------------------------------

--- a/backend/database/migrations/2026_01_26_090000_create_report_jobs_table.php
+++ b/backend/database/migrations/2026_01_26_090000_create_report_jobs_table.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('report_jobs', function (Blueprint $table) {
+            $table->uuid('id')->primary();
+            $table->string('attempt_id')->unique();
+            $table->string('status', 16)->index();
+            $table->unsignedSmallInteger('tries')->default(0);
+            $table->timestamp('available_at')->nullable()->index();
+            $table->timestamp('started_at')->nullable()->index();
+            $table->timestamp('finished_at')->nullable()->index();
+            $table->timestamp('failed_at')->nullable()->index();
+            $table->text('last_error')->nullable();
+            $table->longText('last_error_trace')->nullable();
+            $table->longText('report_json')->nullable();
+            $table->longText('meta')->nullable();
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('report_jobs');
+    }
+};

--- a/docs/04-ops/queue-runbook.md
+++ b/docs/04-ops/queue-runbook.md
@@ -1,0 +1,17 @@
+# Queue Runbook (Report Jobs)
+
+## Local (sqlite + database queue)
+1) `cd backend && php artisan migrate`
+2) `cd backend && QUEUE_CONNECTION=database php artisan queue:work --queue=reports --tries=3`
+3) `cd backend && bash scripts/verify_mbti.sh`
+
+## Troubleshooting
+- `status=failed`:
+  - Check `report_jobs.last_error`, `report_jobs.last_error_trace`, `report_jobs.failed_at`.
+- Requeue a single attempt (tinker):
+  - `cd backend && php artisan tinker`
+  - `\App\Models\ReportJob::where('attempt_id', 'ATTEMPT_ID')->update(['status' => 'queued', 'available_at' => now(), 'failed_at' => null, 'last_error' => null, 'last_error_trace' => null, 'report_json' => null]);`
+
+## Environment strategy
+- CI: `QUEUE_CONNECTION=sync` (no worker; selfcheck/verify still pass)
+- Production: `QUEUE_CONNECTION=database` or `QUEUE_CONNECTION=redis` (choose by infra)


### PR DESCRIPTION
	•	异步队列：报告生成从 HTTP 线程移走（submit 仅 dispatch job）
	•	新增 report_jobs 表：记录 job 状态 queued/running/success/failed + 失败原因落库
	•	GET /attempts/{id}/report 支持状态返回：queued/running(202) / success(200) / failed(500)，并短轮询最多 3s
	•	CI selfcheck 增加 QUEUE_CONNECTION=sync 的队列 smoke（不启 worker 也能验证）

简述本次改动（1-3 句）：
	•	submit 后立即返回 job_id/status；report 由 GenerateReportJob 异步生成并落库/落盘，report 接口按状态返回或短轮询等待完成。

⸻

Scope（影响范围）

API
	•	submit attempt：返回新增 job: {job_id,status}
	•	report endpoint：增加 status 分支（202/200/500）

Data
	•	新增表：report_jobs（attempt_id unique）

Queue
	•	新增 Job：GenerateReportJob（queue=reports）
	•	queue driver：CI 使用 sync；本地可用 database + queue:work

⸻

Acceptance（验收）

本地：
	•	cd backend && php artisan migrate
	•	cd backend && QUEUE_CONNECTION=database php artisan queue:work --queue=reports --tries=3
	•	cd backend && API="http://127.0.0.1:18010" FM_TOKEN="<token>" bash scripts/verify_mbti.sh  ✅

CI：
	•	selfcheck：QUEUE_CONNECTION=sync smoke 通过 ✅

⸻

Files changed

新增：
	•	backend/app/Jobs/GenerateReportJob.php
	•	backend/app/Models/ReportJob.php
	•	backend/database/migrations/*create_report_jobs_table.php
	•	docs/04-ops/queue-runbook.md

修改：
	•	backend/app/Http/Controllers/MbtiController.php
	•	backend/config/queue.php
	•	.github/workflows/selfcheck.yml

⸻
