### PR TITLE
ci: add staging deploy via deployer

### DIFF
--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -1,0 +1,57 @@
+name: Deploy Staging
+
+on:
+  workflow_dispatch:
+  push:
+    branches: [ main ]
+
+concurrency:
+  group: deploy-staging
+  cancel-in-progress: false
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    environment: staging
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: "8.3"
+          tools: composer
+
+      - name: Install Deployer (PHAR v7.5.12)
+        run: |
+          curl -sSLo dep.phar https://github.com/deployphp/deployer/releases/download/v7.5.12/deployer.phar
+          php dep.phar --version
+
+      - name: Setup SSH Agent
+        uses: webfactory/ssh-agent@v0.9.0
+        with:
+          ssh-private-key: ${{ secrets.STAGING_DEPLOY_SSH_PRIVATE_KEY }}
+
+      - name: Write known_hosts
+        run: |
+          mkdir -p ~/.ssh
+          echo "${{ secrets.STAGING_DEPLOY_KNOWN_HOSTS }}" > ~/.ssh/known_hosts
+          chmod 600 ~/.ssh/known_hosts
+
+      - name: Deploy via Deployer (staging)
+        env:
+          DEPLOY_HOST: ${{ secrets.STAGING_DEPLOY_HOST }}
+          DEPLOY_USER: ${{ secrets.STAGING_DEPLOY_USER }}
+          DEPLOY_PORT: ${{ secrets.STAGING_DEPLOY_PORT }}
+          HEALTHCHECK_HOST: staging.fermatmind.com
+        run: |
+          php dep.phar -f deploy.php deploy staging -vvv
+
+      - name: Post-deploy Health Check (staging)
+        run: |
+          HOST=staging.fermatmind.com
+          curl -fsS http://${HOST}/api/v0.2/health | grep -q '"ok":true'
+          curl -fsS http://${HOST}/api/v0.2/scales/MBTI/questions | grep -q '"ok":true'
+          curl -fsS http://${HOST}/api/v0.2/content-packs | jq -e '.ok==true'


### PR DESCRIPTION
	1.	deploy.php 支持 staging 主机

	•	增加 host('staging')
	•	staging 的 deploy_path 用：/var/www/fap-api-staging
	•	staging 的 healthcheck_host 用：staging.fermatmind.com
	•	php-fpm reload 从固定的 php8.4-fpm 改为“按主机配置”
	•	production：php8.4-fpm
	•	staging：php8.3-fpm
	•	nginx root 检查那段，路径也按 deploy_path 拼出来（staging 就会检查 /var/www/fap-api-staging/current/backend/public）

	2.	新增一个 GitHub Actions：Deploy Staging

	•	新建文件：.github/workflows/deploy-staging.yml
	•	逻辑直接复制 deploy-production.yml 的结构
	•	区别：
	•	environment: staging
	•	secrets 改用你刚建的：
STAGING_DEPLOY_HOST / USER / PORT / SSH_PRIVATE_KEY / KNOWN_HOSTS
	•	执行命令：php dep.phar -f deploy.php deploy staging -vvv
	•	部署完成后做 staging 健康检查（先用 http 也行）：
curl -fsS http://staging.fermatmind.com/api/v0.2/health | jq -e '.ok==true'

⸻
