### PR TITLE
PR8: healthz + observability + deploy healthcheck + sentry release

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -49,7 +49,8 @@ jobs:
           php dep.phar -f deploy.php deploy production -vvv
 
       - name: Post-deploy Health Check (public)
+        shell: bash
         run: |
           sleep 2
-          curl -fsS "https://fermatmind.com/api/v0.2/health" | grep -q '"ok":true'
-          curl -fsS "https://fermatmind.com/api/v0.2/scales/MBTI/questions" | grep -q '"ok":true'
+          set -euo pipefail
+          curl -fsS "https://fermatmind.com/api/v0.2/healthz" | jq -e '.ok==true and (.deps.db.ok==true) and (.deps.redis.ok==true) and (.deps.queue.ok==true) and (.deps.cache_dirs.ok==true) and (.deps.content_source.ok==true)' > /dev/null

--- a/backend/app/Http/Controllers/HealthzController.php
+++ b/backend/app/Http/Controllers/HealthzController.php
@@ -1,0 +1,232 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Redis;
+use Illuminate\Support\Facades\Schema;
+
+class HealthzController extends Controller
+{
+    public function show(Request $request)
+    {
+        $service = 'Fermat Assessment Platform API';
+        $version = config('app.version', env('APP_VERSION', 'unknown'));
+        $nowIso = now()->toIso8601String();
+
+        $region = (string) $request->query('region', 'CN_MAINLAND');
+        $locale = (string) $request->query('locale', 'zh-CN');
+
+        $deps = [];
+        $deps['db'] = $this->checkDb();
+        $deps['redis'] = $this->checkRedis();
+        $deps['queue'] = $this->checkQueue();
+        $deps['cache_dirs'] = $this->checkCacheDirs();
+        $deps['content_source'] = $this->checkContentSource($region, $locale);
+
+        $allOk = true;
+        foreach ($deps as $value) {
+            if (($value['ok'] ?? false) !== true) {
+                $allOk = false;
+                break;
+            }
+        }
+
+        return response()->json([
+            'ok' => $allOk,
+            'service' => $service,
+            'version' => $version,
+            'time' => $nowIso,
+            'deps' => $deps,
+        ]);
+    }
+
+    private function checkDb(): array
+    {
+        $t0 = microtime(true);
+        try {
+            DB::select('select 1 as ok');
+            $ms = (int) round((microtime(true) - $t0) * 1000);
+
+            return [
+                'ok' => true,
+                'driver' => (string) config('database.default'),
+                'latency_ms' => $ms,
+            ];
+        } catch (\Throwable $e) {
+            $ms = (int) round((microtime(true) - $t0) * 1000);
+
+            return [
+                'ok' => false,
+                'driver' => (string) config('database.default'),
+                'latency_ms' => $ms,
+                'error_code' => 'DB_UNAVAILABLE',
+                'message' => $e->getMessage(),
+            ];
+        }
+    }
+
+    private function checkRedis(): array
+    {
+        $t0 = microtime(true);
+        try {
+            $client = (string) config('database.redis.client', 'redis');
+            $pong = Redis::connection()->ping();
+            $ms = (int) round((microtime(true) - $t0) * 1000);
+
+            return [
+                'ok' => (string) $pong === 'PONG' || $pong === true,
+                'client' => $client,
+                'latency_ms' => $ms,
+            ];
+        } catch (\Throwable $e) {
+            $ms = (int) round((microtime(true) - $t0) * 1000);
+
+            return [
+                'ok' => false,
+                'client' => (string) config('database.redis.client', 'redis'),
+                'latency_ms' => $ms,
+                'error_code' => 'REDIS_UNAVAILABLE',
+                'message' => $e->getMessage(),
+            ];
+        }
+    }
+
+    private function checkQueue(): array
+    {
+        $driver = (string) config('queue.default', 'sync');
+
+        try {
+            if ($driver === 'database') {
+                $hasJobs = Schema::hasTable('jobs');
+                $hasFailed = Schema::hasTable('failed_jobs');
+
+                if (!$hasJobs) {
+                    return [
+                        'ok' => false,
+                        'driver' => $driver,
+                        'error_code' => 'QUEUE_TABLE_MISSING',
+                        'message' => 'jobs table not found',
+                    ];
+                }
+
+                DB::select('select 1 as ok');
+
+                return [
+                    'ok' => true,
+                    'driver' => $driver,
+                    'tables' => [
+                        'jobs' => $hasJobs,
+                        'failed_jobs' => $hasFailed,
+                    ],
+                ];
+            }
+
+            if ($driver === 'redis') {
+                $pong = Redis::connection()->ping();
+                $ok = ((string) $pong === 'PONG' || $pong === true);
+
+                return [
+                    'ok' => $ok,
+                    'driver' => $driver,
+                ];
+            }
+
+            return [
+                'ok' => true,
+                'driver' => $driver,
+            ];
+        } catch (\Throwable $e) {
+            return [
+                'ok' => false,
+                'driver' => $driver,
+                'error_code' => 'QUEUE_UNAVAILABLE',
+                'message' => $e->getMessage(),
+            ];
+        }
+    }
+
+    private function checkCacheDirs(): array
+    {
+        $paths = [
+            'storage_framework_cache' => storage_path('framework/cache'),
+            'storage_framework_sessions' => storage_path('framework/sessions'),
+            'storage_framework_views' => storage_path('framework/views'),
+            'bootstrap_cache' => base_path('bootstrap/cache'),
+        ];
+
+        $items = [];
+        $allOk = true;
+
+        foreach ($paths as $name => $path) {
+            $exists = is_dir($path);
+            if (!$exists) {
+                @mkdir($path, 0775, true);
+                $exists = is_dir($path);
+            }
+
+            $writable = $exists ? is_writable($path) : false;
+
+            $probeOk = false;
+            $probeErr = '';
+            if ($writable) {
+                $probeFile = rtrim($path, '/').'/.__healthz_probe';
+                try {
+                    @file_put_contents($probeFile, (string) time());
+                    @unlink($probeFile);
+                    $probeOk = true;
+                } catch (\Throwable $e) {
+                    $probeOk = false;
+                    $probeErr = $e->getMessage();
+                }
+            }
+
+            $ok = $exists && $writable && $probeOk;
+            if (!$ok) {
+                $allOk = false;
+            }
+
+            $items[$name] = [
+                'ok' => $ok,
+                'path' => $path,
+                'exists' => $exists,
+                'writable' => $writable,
+                'probe_ok' => $probeOk,
+                'message' => $probeErr,
+                'error_code' => $ok ? '' : 'CACHE_DIR_NOT_WRITABLE',
+            ];
+        }
+
+        return [
+            'ok' => $allOk,
+            'items' => $items,
+        ];
+    }
+
+    private function checkContentSource(string $region, string $locale): array
+    {
+        $base = realpath(base_path('..'.DIRECTORY_SEPARATOR.'content_packages'))
+            ?: base_path('..'.DIRECTORY_SEPARATOR.'content_packages');
+
+        $defaultDir = rtrim($base, '/').'/default/'.$region.'/'.$locale;
+
+        $existsBase = is_dir($base);
+        $existsDefault = is_dir($defaultDir);
+
+        $readableBase = $existsBase ? is_readable($base) : false;
+        $readableDefault = $existsDefault ? is_readable($defaultDir) : false;
+
+        $ok = $existsBase && $readableBase && $existsDefault && $readableDefault;
+
+        return [
+            'ok' => $ok,
+            'base_path' => $base,
+            'default_path' => $defaultDir,
+            'region' => $region,
+            'locale' => $locale,
+            'error_code' => $ok ? '' : 'CONTENT_SOURCE_NOT_READY',
+            'message' => $ok ? '' : 'content_packages default path not readable',
+        ];
+    }
+}

--- a/backend/config/logging.php
+++ b/backend/config/logging.php
@@ -1,5 +1,6 @@
 <?php
 
+use Monolog\Formatter\JsonFormatter;
 use Monolog\Handler\NullHandler;
 use Monolog\Handler\StreamHandler;
 use Monolog\Handler\SyslogUdpHandler;
@@ -62,6 +63,10 @@ return [
             'driver' => 'single',
             'path' => storage_path('logs/laravel.log'),
             'level' => env('LOG_LEVEL', 'debug'),
+            'formatter' => JsonFormatter::class,
+            'formatter_with' => [
+                'includeStacktraces' => true,
+            ],
             'replace_placeholders' => true,
         ],
 
@@ -70,6 +75,10 @@ return [
             'path' => storage_path('logs/laravel.log'),
             'level' => env('LOG_LEVEL', 'debug'),
             'days' => env('LOG_DAILY_DAYS', 14),
+            'formatter' => JsonFormatter::class,
+            'formatter_with' => [
+                'includeStacktraces' => true,
+            ],
             'replace_placeholders' => true,
         ],
 

--- a/backend/routes/api.php
+++ b/backend/routes/api.php
@@ -3,6 +3,7 @@
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Route;
 
+use App\Http\Controllers\HealthzController;
 use App\Http\Controllers\MbtiController;
 use App\Http\Controllers\EventController;
 use App\Http\Controllers\LookupController;
@@ -34,6 +35,7 @@ Route::prefix("v0.2")->group(function () {
 
     // 1) Health
     Route::get("/health", [MbtiController::class, "health"]);
+    Route::get("/healthz", [HealthzController::class, "show"]);
 
     // 1.5) Content packs
     Route::get("/content-packs", [ContentPacksController::class, "index"]);

--- a/docs/04-ops/observability.md
+++ b/docs/04-ops/observability.md
@@ -1,0 +1,41 @@
+# PR8 Observability & Alerts
+
+## Healthz Endpoint
+- Path: `GET /api/v0.2/healthz`
+- 期望：
+  - `.ok == true`
+  - `.deps.db.ok == true`
+  - `.deps.redis.ok == true`
+  - `.deps.queue.ok == true`
+  - `.deps.cache_dirs.ok == true`
+  - `.deps.content_source.ok == true`
+
+### Dep Error Codes
+- DB_UNAVAILABLE
+- REDIS_UNAVAILABLE
+- QUEUE_TABLE_MISSING / QUEUE_UNAVAILABLE
+- CACHE_DIR_NOT_WRITABLE
+- CONTENT_SOURCE_NOT_READY
+
+## Metrics & Alerts (建议阈值)
+### Availability
+- Healthz `.ok==false` 连续 1 分钟：P1
+- Healthz `.deps.redis.ok==false`：P1
+- Healthz `.deps.db.ok==false`：P1
+- Healthz `.deps.cache_dirs.ok==false`：P2
+
+### Latency (API)
+- `/api/v0.2/healthz` p95 > 300ms 持续 5 分钟：P2
+- `/api/v0.2/scales/MBTI/questions` p95 > 800ms 持续 5 分钟：P2
+
+### Errors
+- 5xx rate > 1% 持续 5 分钟：P1
+- 5xx rate > 0.2% 持续 10 分钟：P2
+
+### Queue
+- database queue：failed_jobs 增长速率异常：P2
+- redis queue：连接失败：P1
+
+## Sentry Release
+- 部署写入 `SENTRY_RELEASE={{release_name}}`
+- 事件聚合按 release 追踪回归与发布影响范围

--- a/scripts/ci_verify_mbti.sh
+++ b/scripts/ci_verify_mbti.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+BASE_URL="${BASE_URL:-http://127.0.0.1:8000}"
+
+echo "[ci_verify_mbti] BASE_URL=${BASE_URL}"
+
+# 1) healthz ok
+curl -fsS "${BASE_URL}/api/v0.2/healthz" | jq -e '.ok==true' >/dev/null
+echo "[ok] healthz"
+
+# 2) mbti questions ok
+curl -fsS "${BASE_URL}/api/v0.2/scales/MBTI/questions?region=CN_MAINLAND&locale=zh-CN" | jq -e '.ok==true' >/dev/null
+echo "[ok] MBTI questions"
+
+# 3) content-packs ok
+curl -fsS "${BASE_URL}/api/v0.2/content-packs" | jq -e '.ok==true' >/dev/null
+echo "[ok] content-packs"
+
+echo "[ci_verify_mbti] DONE"


### PR DESCRIPTION
## Summary（改了什么）
- [x] 新增 GET /api/v0.2/healthz：覆盖 DB / Redis / 队列 / 缓存目录 / 内容源（content_packages/default/...）
- [x] deploy.php：健康检查优先 healthz；并写入 SENTRY_RELEASE={{release_name}}
- [x] deploy-production.yml：部署后改为调用 healthz 并断言 deps 全绿
- [x] logging.php：daily/single 输出 JSON（便于结构化字段透传）
- [x] 新增 docs/04-ops/observability.md：指标与告警阈值
- [x] 新增 scripts/ci_verify_mbti.sh：本地验收脚本

简述本次改动（1-3 句话）：
- 把健康检查标准化到 /healthz，并把 deploy/CI 全部改为以 healthz 为准；同时补齐 Sentry release 关联与可观测性文档，形成工业级收口。

---

## Scope（影响范围）
**API / Ops**
- 新增端点：/api/v0.2/healthz
- 影响：deploy 健康检查、CI 部署后探针、日志输出格式（json）

**Files changed**
- 新增：
  - backend/app/Http/Controllers/HealthzController.php
  - docs/04-ops/observability.md
  - scripts/ci_verify_mbti.sh
- 修改：
  - backend/routes/api.php
  - deploy.php
  - .github/workflows/deploy-production.yml
  - backend/config/logging.php

---

## Verification（验收）
本地：
- curl http://127.0.0.1:8000/api/v0.2/healthz | jq .ok
- 手动停 redis 后：/healthz deps.redis.ok=false 且 error_code=REDIS_UNAVAILABLE
- bash scripts/ci_verify_mbti.sh

生产：
- deploy 后：/api/v0.2/healthz 全绿
- rollback 后：/api/v0.2/healthz 仍全绿