### PR TITLE
docs: document phpredis requirement

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -212,8 +212,23 @@ The Laravel framework is open-sourced software licensed under the [MIT license](
 #### 0) 前置条件
 服务器需要具备：
 - `bash`, `curl`, `jq`, `python3`
+- PHP 必备扩展：`redis`（phpredis）
 - 能访问 API（建议用内网域名或本机回环）
 - 已部署正确的 content_packages（且默认 region/locale/pack 不会掉回 GLOBAL/en）
+
+安装与验证（Ubuntu + ondrej/php）：
+
+```bash
+# 安装当前 PHP 小版本对应的 redis 扩展（示例：php8.4-redis）
+sudo apt-get update
+sudo apt-get install -y php$(php -r 'echo PHP_MAJOR_VERSION.".".PHP_MINOR_VERSION;')-redis
+
+# 重启 php-fpm（示例：php8.4-fpm）
+sudo systemctl restart php$(php -r 'echo PHP_MAJOR_VERSION.".".PHP_MINOR_VERSION;')-fpm
+
+# 验证扩展已加载
+php -m | grep -i '^redis$'
+php --ri redis
 
 #### 1) 必要参数：ATTEMPT_ID 从哪来？
 有两种方式：


### PR DESCRIPTION
## Summary（改了什么）
- [x] 文档补充：服务器前置条件新增 PHP Redis 扩展（phpredis）说明
- [x] 增加安装与验证步骤：Ubuntu + ondrej/php 一键安装 `php$(php -r 'echo PHP_MAJOR_VERSION.".".PHP_MINOR_VERSION;')-redis`，并重启对应 php-fpm
- [x] 增加验证命令：`php -m | grep -i '^redis$'`、`php --ri redis`

简述本次改动（1-3 句话）：
- 线上 healthz 依赖 Redis 扩展，缺失会导致部署 healthcheck 失败。本 PR 将该系统依赖与安装验证步骤写入 README，避免新机重复踩坑。

## Scope（影响范围）
- 文档/Runbook：backend/README.md
- 部署脚本：deploy.php（仅补充依赖提示/不改业务逻辑）

## Verify（怎么验证）
- 文档检查：README 中包含 phpredis 前置条件与安装验证步骤
- 服务器验证：
  - `php -m | grep -i '^redis$'`
  - `curl -sS -H 'Accept: application/json' https://fermatmind.com/api/v0.2/healthz | jq -e '.ok==true'`