### PR TITLE
Chore/pr12 ai insights budget

### DIFF
--- a/backend/app/Http/Controllers/API/V0_2/InsightsController.php
+++ b/backend/app/Http/Controllers/API/V0_2/InsightsController.php
@@ -1,0 +1,300 @@
+<?php
+
+namespace App\Http\Controllers\API\V0_2;
+
+use App\Http\Controllers\Controller;
+use App\Jobs\GenerateInsightJob;
+use Illuminate\Http\Request;
+use Illuminate\Support\Carbon;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Support\Str;
+
+class InsightsController extends Controller
+{
+    /**
+     * POST /api/v0.2/insights/generate
+     */
+    public function generate(Request $request)
+    {
+        if (!(bool) config('ai.enabled', true) || !(bool) config('ai.insights_enabled', true)) {
+            return response()->json([
+                'ok' => false,
+                'error' => 'AI_DISABLED',
+                'error_code' => 'AI_DISABLED',
+                'message' => 'AI insights are currently disabled.',
+            ], 503);
+        }
+
+        if (!Schema::hasTable('ai_insights')) {
+            return response()->json([
+                'ok' => false,
+                'error' => 'TABLE_MISSING',
+                'error_code' => 'AI_TABLE_MISSING',
+                'message' => 'AI insights table not found.',
+            ], 500);
+        }
+
+        $periodType = trim((string) $request->input('period_type', ''));
+        if (!in_array($periodType, ['week', 'month'], true)) {
+            return response()->json([
+                'ok' => false,
+                'error' => 'INVALID_PERIOD_TYPE',
+                'message' => 'period_type must be week or month.',
+            ], 422);
+        }
+
+        $periodStart = $this->parseDate((string) $request->input('period_start', ''));
+        $periodEnd = $this->parseDate((string) $request->input('period_end', ''));
+
+        if (!$periodStart || !$periodEnd) {
+            return response()->json([
+                'ok' => false,
+                'error' => 'INVALID_PERIOD_RANGE',
+                'message' => 'period_start and period_end must be valid dates.',
+            ], 422);
+        }
+
+        $userId = trim((string) $request->attributes->get('fm_user_id', ''));
+        $anonIdInput = trim((string) $request->input('anon_id', ''));
+        $anonId = $userId === '' ? $anonIdInput : '';
+
+        $inputPayload = [
+            'period_type' => $periodType,
+            'period_start' => $periodStart->toDateString(),
+            'period_end' => $periodEnd->toDateString(),
+            'user_id' => $userId,
+            'anon_id' => $anonId,
+            'prompt_version' => (string) config('ai.prompt_version', 'v1.0.0'),
+            'provider' => (string) config('ai.provider', 'mock'),
+            'model' => (string) config('ai.model', 'mock-model'),
+        ];
+
+        $inputHash = hash('sha256', json_encode($inputPayload, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES));
+
+        $id = (string) Str::uuid();
+        DB::table('ai_insights')->insert([
+            'id' => $id,
+            'user_id' => $userId !== '' ? $userId : null,
+            'anon_id' => $anonId !== '' ? $anonId : null,
+            'period_type' => $periodType,
+            'period_start' => $periodStart->toDateString(),
+            'period_end' => $periodEnd->toDateString(),
+            'input_hash' => $inputHash,
+            'prompt_version' => (string) config('ai.prompt_version', 'v1.0.0'),
+            'model' => (string) config('ai.model', 'mock-model'),
+            'provider' => (string) config('ai.provider', 'mock'),
+            'tokens_in' => 0,
+            'tokens_out' => 0,
+            'cost_usd' => 0,
+            'status' => 'queued',
+            'output_json' => null,
+            'evidence_json' => null,
+            'error_code' => null,
+            'created_at' => now(),
+            'updated_at' => now(),
+        ]);
+
+        try {
+            GenerateInsightJob::dispatch($id);
+        } catch (\Throwable $e) {
+            DB::table('ai_insights')->where('id', $id)->update([
+                'status' => 'failed',
+                'error_code' => 'AI_DISPATCH_FAILED',
+                'updated_at' => now(),
+            ]);
+
+            return response()->json([
+                'ok' => false,
+                'error' => 'AI_DISPATCH_FAILED',
+                'message' => 'Failed to dispatch insight generation.',
+            ], 500);
+        }
+
+        $status = 'queued';
+        if ((string) config('queue.default', 'sync') === 'sync') {
+            $fresh = DB::table('ai_insights')->where('id', $id)->first();
+            if ($fresh && !empty($fresh->status)) {
+                $status = (string) $fresh->status;
+            }
+        }
+
+        return response()->json([
+            'ok' => true,
+            'id' => $id,
+            'status' => $status,
+        ]);
+    }
+
+    /**
+     * GET /api/v0.2/insights/{id}
+     */
+    public function show(Request $request, string $id)
+    {
+        if (!Schema::hasTable('ai_insights')) {
+            return response()->json([
+                'ok' => false,
+                'error' => 'TABLE_MISSING',
+            ], 500);
+        }
+
+        $row = DB::table('ai_insights')->where('id', $id)->first();
+        if (!$row) {
+            return response()->json([
+                'ok' => false,
+                'error' => 'NOT_FOUND',
+            ], 404);
+        }
+
+        $auth = $this->authorizeInsight($request, $row);
+        if ($auth !== null) {
+            return $auth;
+        }
+
+        $outputJson = $this->decodeJson($row->output_json ?? null);
+        $evidenceJson = $this->decodeJson($row->evidence_json ?? null);
+
+        return response()->json([
+            'ok' => true,
+            'id' => $row->id,
+            'status' => $row->status,
+            'output_json' => $outputJson,
+            'evidence_json' => $evidenceJson,
+            'tokens_in' => (int) ($row->tokens_in ?? 0),
+            'tokens_out' => (int) ($row->tokens_out ?? 0),
+            'cost_usd' => (float) ($row->cost_usd ?? 0),
+            'prompt_version' => (string) ($row->prompt_version ?? ''),
+            'model' => (string) ($row->model ?? ''),
+            'provider' => (string) ($row->provider ?? ''),
+            'error_code' => (string) ($row->error_code ?? ''),
+        ]);
+    }
+
+    /**
+     * POST /api/v0.2/insights/{id}/feedback
+     */
+    public function feedback(Request $request, string $id)
+    {
+        if (!Schema::hasTable('ai_insights') || !Schema::hasTable('ai_insight_feedback')) {
+            return response()->json([
+                'ok' => false,
+                'error' => 'TABLE_MISSING',
+            ], 500);
+        }
+
+        $row = DB::table('ai_insights')->where('id', $id)->first();
+        if (!$row) {
+            return response()->json([
+                'ok' => false,
+                'error' => 'NOT_FOUND',
+            ], 404);
+        }
+
+        $auth = $this->authorizeInsight($request, $row);
+        if ($auth !== null) {
+            return $auth;
+        }
+
+        $rating = (int) $request->input('rating', 0);
+        if ($rating < 1 || $rating > 5) {
+            return response()->json([
+                'ok' => false,
+                'error' => 'INVALID_RATING',
+                'message' => 'rating must be between 1 and 5.',
+            ], 422);
+        }
+
+        $reason = trim((string) $request->input('reason', ''));
+        if ($reason !== '' && strlen($reason) > 64) {
+            $reason = substr($reason, 0, 64);
+        }
+
+        $comment = trim((string) $request->input('comment', ''));
+        if ($comment !== '' && strlen($comment) > 2000) {
+            $comment = substr($comment, 0, 2000);
+        }
+
+        $feedbackId = (string) Str::uuid();
+        DB::table('ai_insight_feedback')->insert([
+            'id' => $feedbackId,
+            'insight_id' => $row->id,
+            'rating' => $rating,
+            'reason' => $reason !== '' ? $reason : null,
+            'comment' => $comment !== '' ? $comment : null,
+            'created_at' => now(),
+        ]);
+
+        return response()->json([
+            'ok' => true,
+            'id' => $feedbackId,
+        ]);
+    }
+
+    private function authorizeInsight(Request $request, object $row): ?\Illuminate\Http\JsonResponse
+    {
+        $rowUserId = trim((string) ($row->user_id ?? ''));
+        $rowAnonId = trim((string) ($row->anon_id ?? ''));
+
+        if ($rowUserId !== '') {
+            $reqUserId = trim((string) $request->attributes->get('fm_user_id', ''));
+            if ($reqUserId === '' || $reqUserId !== $rowUserId) {
+                return response()->json([
+                    'ok' => false,
+                    'error' => 'FORBIDDEN',
+                ], 403);
+            }
+        } elseif ($rowAnonId !== '') {
+            $allowDev = (bool) config('ai.dev_allow_anon_header', true);
+            $headerAnon = trim((string) $request->header('X-FAP-Anon-Id', ''));
+            if ($headerAnon === '') {
+                if ($allowDev) {
+                    return null;
+                }
+                return response()->json([
+                    'ok' => false,
+                    'error' => 'FORBIDDEN',
+                ], 403);
+            }
+            if ($headerAnon !== $rowAnonId && !$allowDev) {
+                return response()->json([
+                    'ok' => false,
+                    'error' => 'FORBIDDEN',
+                ], 403);
+            }
+        }
+
+        return null;
+    }
+
+    private function parseDate(string $value): ?Carbon
+    {
+        $value = trim($value);
+        if ($value === '') {
+            return null;
+        }
+
+        try {
+            return Carbon::parse($value);
+        } catch (\Throwable $e) {
+            return null;
+        }
+    }
+
+    private function decodeJson($value)
+    {
+        if ($value === null) {
+            return null;
+        }
+
+        if (is_array($value)) {
+            return $value;
+        }
+
+        if (is_string($value)) {
+            $decoded = json_decode($value, true);
+            return is_array($decoded) ? $decoded : $value;
+        }
+
+        return $value;
+    }
+}

--- a/backend/app/Http/Middleware/CheckAiBudget.php
+++ b/backend/app/Http/Middleware/CheckAiBudget.php
@@ -1,0 +1,119 @@
+<?php
+
+namespace App\Http\Middleware;
+
+use App\Services\AI\BudgetLedger;
+use App\Services\AI\BudgetLedgerException;
+use Closure;
+use Illuminate\Http\Request;
+use Symfony\Component\HttpFoundation\Response;
+
+class CheckAiBudget
+{
+    private const MAX_ESTIMATED_TOKENS = 20000;
+
+    public function handle(Request $request, Closure $next): Response
+    {
+        if (!(bool) config('ai.enabled', true) || !(bool) config('ai.insights_enabled', true)) {
+            return response()->json([
+                'ok' => false,
+                'error' => 'AI_DISABLED',
+                'error_code' => 'AI_DISABLED',
+                'message' => 'AI insights are currently disabled.',
+            ], 503);
+        }
+
+        if (!(bool) config('ai.breaker_enabled', true)) {
+            return $next($request);
+        }
+
+        $provider = (string) config('ai.provider', 'mock');
+        $model = (string) config('ai.model', 'mock-model');
+        $subject = $this->resolveSubject($request);
+
+        $estimatedTokens = $this->estimateTokens($request);
+        $estimatedCost = $this->estimateCost($estimatedTokens);
+
+        $ledger = app(BudgetLedger::class);
+
+        try {
+            $ledger->checkAndThrow($provider, $model, $subject, $estimatedTokens, $estimatedCost, 'day');
+            $ledger->checkAndThrow($provider, $model, $subject, $estimatedTokens, $estimatedCost, 'month');
+        } catch (BudgetLedgerException $e) {
+            $code = $e->errorCode();
+            $status = $code === 'AI_BUDGET_EXCEEDED' ? 429 : 503;
+
+            return response()->json([
+                'ok' => false,
+                'error' => $code,
+                'error_code' => $code,
+                'message' => $code === 'AI_BUDGET_EXCEEDED'
+                    ? 'AI budget exceeded. Try again later.'
+                    : 'AI budget ledger unavailable.',
+            ], $status);
+        }
+
+        return $next($request);
+    }
+
+    private function resolveSubject(Request $request): string
+    {
+        $userId = trim((string) $request->attributes->get('fm_user_id', ''));
+        if ($userId !== '') {
+            return 'user:' . $userId;
+        }
+
+        $anonId = trim((string) $request->attributes->get('anon_id', ''));
+        if ($anonId === '') {
+            $anonId = trim((string) $request->input('anon_id', ''));
+        }
+
+        if ($anonId !== '') {
+            return 'anon:' . $anonId;
+        }
+
+        return 'unknown';
+    }
+
+    private function estimateTokens(Request $request): int
+    {
+        $estimated = (int) $request->input('estimated_tokens', 0);
+        if ($estimated > 0) {
+            return $this->capEstimatedTokens($estimated);
+        }
+
+        $body = (string) $request->getContent();
+        if ($body === '') {
+            $body = (string) json_encode($request->all());
+        }
+
+        $chars = strlen($body);
+        $tokens = (int) ceil($chars / 4);
+        if ($tokens <= 0) {
+            $tokens = 1;
+        }
+
+        return $this->capEstimatedTokens($tokens);
+    }
+
+    private function capEstimatedTokens(int $tokens): int
+    {
+        if ($tokens > self::MAX_ESTIMATED_TOKENS) {
+            return self::MAX_ESTIMATED_TOKENS;
+        }
+        if ($tokens < 1) {
+            return 1;
+        }
+        return $tokens;
+    }
+
+    private function estimateCost(int $estimatedTokens): float
+    {
+        $rate = (float) config('ai.cost_per_1k_tokens_usd', 0.0);
+        if ($rate <= 0) {
+            return 0.0;
+        }
+
+        return round(($estimatedTokens / 1000.0) * $rate, 6);
+    }
+}

--- a/backend/app/Jobs/GenerateInsightJob.php
+++ b/backend/app/Jobs/GenerateInsightJob.php
@@ -1,0 +1,197 @@
+<?php
+
+namespace App\Jobs;
+
+use App\Models\Attempt;
+use App\Models\Result;
+use App\Services\AI\BudgetLedger;
+use App\Services\AI\BudgetLedgerException;
+use App\Services\AI\EvidenceBuilder;
+use App\Services\AI\InsightGenerator;
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Bus\Dispatchable;
+use Illuminate\Queue\InteractsWithQueue;
+use Illuminate\Queue\SerializesModels;
+use Illuminate\Support\Carbon;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Log;
+use Illuminate\Support\Facades\Schema;
+
+class GenerateInsightJob implements ShouldQueue
+{
+    use Dispatchable, InteractsWithQueue, Queueable, SerializesModels;
+
+    public string $insightId;
+
+    public function __construct(string $insightId)
+    {
+        $this->insightId = $insightId;
+        $this->onQueue((string) config('ai.queue_name', 'insights'));
+    }
+
+    public function handle(InsightGenerator $generator, EvidenceBuilder $evidenceBuilder, BudgetLedger $ledger): void
+    {
+        if (!Schema::hasTable('ai_insights')) {
+            Log::warning('[ai_insights] table missing', ['id' => $this->insightId]);
+            return;
+        }
+
+        $insight = DB::table('ai_insights')->where('id', $this->insightId)->first();
+        if (!$insight) {
+            Log::warning('[ai_insights] record missing', ['id' => $this->insightId]);
+            return;
+        }
+
+        DB::table('ai_insights')->where('id', $this->insightId)->update([
+            'status' => 'running',
+            'updated_at' => now(),
+        ]);
+
+        try {
+            [$attempt, $result] = $this->resolveAttemptAndResult($insight);
+            $evidence = $evidenceBuilder->build($attempt, $result);
+
+            $generated = $generator->generate($insight, $evidence);
+            $tokensIn = (int) ($generated['tokens_in'] ?? 0);
+            $tokensOut = (int) ($generated['tokens_out'] ?? 0);
+            $costUsd = (float) ($generated['cost_usd'] ?? 0.0);
+            $outputJson = $this->normalizeJson($generated['output_json'] ?? []);
+            $evidenceJson = $this->normalizeJson($generated['evidence_json'] ?? []);
+
+            DB::table('ai_insights')->where('id', $this->insightId)->update([
+                'status' => 'succeeded',
+                'output_json' => $outputJson,
+                'evidence_json' => $evidenceJson,
+                'tokens_in' => $tokensIn,
+                'tokens_out' => $tokensOut,
+                'cost_usd' => $costUsd,
+                'error_code' => null,
+                'updated_at' => now(),
+            ]);
+
+            $subject = $this->resolveSubject($insight);
+            $provider = (string) ($insight->provider ?? config('ai.provider', 'mock'));
+            $model = (string) ($insight->model ?? config('ai.model', 'mock-model'));
+
+            $ledger->incrementTokens($provider, $model, $subject, $tokensIn, $tokensOut, $costUsd, now());
+        } catch (BudgetLedgerException $e) {
+            $failOpen = (bool) config('ai.fail_open_when_redis_down', false);
+            if (!$failOpen) {
+                $env = getenv('AI_FAIL_OPEN_WHEN_REDIS_DOWN');
+                if ($env !== false && $env !== '') {
+                    $failOpen = filter_var($env, FILTER_VALIDATE_BOOLEAN);
+                }
+            }
+
+            if ($e->errorCode() === 'AI_BUDGET_LEDGER_UNAVAILABLE' && $failOpen) {
+                Log::warning('[ai_insights] ledger unavailable (fail-open)', [
+                    'id' => $this->insightId,
+                ]);
+                return;
+            }
+
+            DB::table('ai_insights')->where('id', $this->insightId)->update([
+                'status' => 'failed',
+                'error_code' => $e->errorCode(),
+                'updated_at' => now(),
+            ]);
+
+            Log::warning('[ai_insights] budget ledger failed', [
+                'id' => $this->insightId,
+                'error' => $e->errorCode(),
+            ]);
+
+            throw $e;
+        } catch (\Throwable $e) {
+            DB::table('ai_insights')->where('id', $this->insightId)->update([
+                'status' => 'failed',
+                'error_code' => 'AI_INSIGHT_FAILED',
+                'updated_at' => now(),
+            ]);
+
+            Log::warning('[ai_insights] generation failed', [
+                'id' => $this->insightId,
+                'error' => $e->getMessage(),
+            ]);
+
+            throw $e;
+        }
+    }
+
+    private function resolveAttemptAndResult(object $insight): array
+    {
+        $userId = trim((string) ($insight->user_id ?? ''));
+        $anonId = trim((string) ($insight->anon_id ?? ''));
+
+        $query = Attempt::query();
+        if ($userId !== '') {
+            $query->where('user_id', $userId);
+        } elseif ($anonId !== '') {
+            $query->where('anon_id', $anonId);
+        }
+
+        $start = $this->parseDate((string) ($insight->period_start ?? ''));
+        $end = $this->parseDate((string) ($insight->period_end ?? ''));
+
+        if ($start && $end) {
+            $column = Schema::hasColumn('attempts', 'submitted_at') ? 'submitted_at' : 'created_at';
+            $query->whereBetween($column, [$start->startOfDay(), $end->endOfDay()]);
+            $query->orderByDesc($column);
+        } else {
+            $query->orderByDesc('created_at');
+        }
+
+        $attempt = $query->first();
+        $result = null;
+
+        if ($attempt) {
+            $result = Result::query()->where('attempt_id', $attempt->id)->first();
+        }
+
+        return [$attempt, $result];
+    }
+
+    private function parseDate(string $value): ?Carbon
+    {
+        $value = trim($value);
+        if ($value === '') {
+            return null;
+        }
+
+        try {
+            return Carbon::parse($value);
+        } catch (\Throwable $e) {
+            return null;
+        }
+    }
+
+    private function resolveSubject(object $insight): string
+    {
+        $userId = trim((string) ($insight->user_id ?? ''));
+        if ($userId !== '') {
+            return 'user:' . $userId;
+        }
+
+        $anonId = trim((string) ($insight->anon_id ?? ''));
+        if ($anonId !== '') {
+            return 'anon:' . $anonId;
+        }
+
+        return 'unknown';
+    }
+
+    private function normalizeJson($value): ?string
+    {
+        if ($value === null) {
+            return null;
+        }
+
+        if (is_string($value)) {
+            return $value;
+        }
+
+        $json = json_encode($value, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES);
+        return $json === false ? null : $json;
+    }
+}

--- a/backend/app/Services/AI/BudgetLedger.php
+++ b/backend/app/Services/AI/BudgetLedger.php
@@ -1,0 +1,264 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\AI;
+
+use Illuminate\Support\Carbon;
+
+final class BudgetLedger
+{
+    private const DAY_TTL_SECONDS = 172800;   // 2 days
+    private const MONTH_TTL_SECONDS = 3456000; // 40 days
+    private ?\Redis $directClient = null;
+
+    public function incrementTokens(
+        string $provider,
+        string $model,
+        string $subject,
+        int $tokensIn,
+        int $tokensOut,
+        float $costUsd,
+        ?\DateTimeInterface $now = null
+    ): array {
+        $now = $this->normalizeNow($now);
+        $dayKey = $this->buildKey('day', $now->format('Y-m-d'), $provider, $model, $subject);
+        $monthKey = $this->buildKey('month', $now->format('Y-m'), $provider, $model, $subject);
+
+        $day = $this->incrementKey($dayKey, $tokensIn, $tokensOut, $costUsd, self::DAY_TTL_SECONDS);
+        $month = $this->incrementKey($monthKey, $tokensIn, $tokensOut, $costUsd, self::MONTH_TTL_SECONDS);
+
+        return [
+            'day' => $day,
+            'month' => $month,
+        ];
+    }
+
+    public function getUsage(
+        string $provider,
+        string $model,
+        string $subject,
+        string $period,
+        ?\DateTimeInterface $now = null
+    ): array {
+        $now = $this->normalizeNow($now);
+        $period = $period === 'month' ? 'month' : 'day';
+        $key = $this->buildKey(
+            $period,
+            $period === 'month' ? $now->format('Y-m') : $now->format('Y-m-d'),
+            $provider,
+            $model,
+            $subject
+        );
+
+        return $this->readKey($key);
+    }
+
+    public function checkAndThrow(
+        string $provider,
+        string $model,
+        string $subject,
+        int $addTokens,
+        float $addCostUsd,
+        string $period,
+        ?\DateTimeInterface $now = null
+    ): void {
+        if (!(bool) config('ai.breaker_enabled', true)) {
+            return;
+        }
+
+        $period = $period === 'month' ? 'month' : 'day';
+        $now = $this->normalizeNow($now);
+        $key = $this->buildKey(
+            $period,
+            $period === 'month' ? $now->format('Y-m') : $now->format('Y-m-d'),
+            $provider,
+            $model,
+            $subject
+        );
+        try {
+            $usage = $this->readWith($this->directClient(), $key);
+        } catch (\Throwable $e) {
+            $this->handleRedisFailure($e);
+            $usage = [
+                'tokens_in' => 0,
+                'tokens_out' => 0,
+                'cost_usd' => 0.0,
+            ];
+        }
+
+        $tokensLimit = (int) config('ai.budgets.' . ($period === 'month' ? 'monthly_tokens' : 'daily_tokens'), 0);
+        $costLimit = (float) config('ai.budgets.' . ($period === 'month' ? 'monthly_usd' : 'daily_usd'), 0);
+
+        $tokensNow = (int) ($usage['tokens_in'] + $usage['tokens_out']);
+        $costNow = (float) ($usage['cost_usd'] ?? 0.0);
+
+        if ($tokensLimit > 0 && ($tokensNow + $addTokens) > $tokensLimit) {
+            throw new BudgetLedgerException('AI_BUDGET_EXCEEDED', 'AI budget exceeded (tokens).');
+        }
+
+        if ($costLimit > 0 && ($costNow + $addCostUsd) > $costLimit) {
+            throw new BudgetLedgerException('AI_BUDGET_EXCEEDED', 'AI budget exceeded (cost).');
+        }
+    }
+
+    private function incrementKey(string $key, int $tokensIn, int $tokensOut, float $costUsd, int $ttlSeconds): array
+    {
+        try {
+            return $this->incrementWith($this->client(), $key, $tokensIn, $tokensOut, $costUsd, $ttlSeconds);
+        } catch (\Throwable $e) {
+            try {
+                return $this->incrementWith($this->directClient(), $key, $tokensIn, $tokensOut, $costUsd, $ttlSeconds);
+            } catch (\Throwable $e2) {
+                $this->handleRedisFailure($e2);
+                return [
+                    'ok' => false,
+                    'tokens_in' => 0,
+                    'tokens_out' => 0,
+                    'cost_usd' => 0.0,
+                    'requests' => 0,
+                ];
+            }
+        }
+    }
+
+    private function readKey(string $key): array
+    {
+        try {
+            return $this->readWith($this->client(), $key);
+        } catch (\Throwable $e) {
+            try {
+                return $this->readWith($this->directClient(), $key);
+            } catch (\Throwable $e2) {
+                $this->handleRedisFailure($e2);
+                return [
+                    'ok' => false,
+                    'tokens_in' => 0,
+                    'tokens_out' => 0,
+                    'cost_usd' => 0.0,
+                    'requests' => 0,
+                ];
+            }
+        }
+    }
+
+    private function handleRedisFailure(\Throwable $e): void
+    {
+        if (!(bool) config('ai.breaker_enabled', true)) {
+            return;
+        }
+
+        $failOpen = (bool) config('ai.fail_open_when_redis_down', false);
+        if (!$failOpen) {
+            $env = getenv('AI_FAIL_OPEN_WHEN_REDIS_DOWN');
+            if ($env !== false && $env !== '') {
+                $failOpen = filter_var($env, FILTER_VALIDATE_BOOLEAN);
+            }
+        }
+        if ($failOpen) {
+            return;
+        }
+
+        throw new BudgetLedgerException('AI_BUDGET_LEDGER_UNAVAILABLE', 'AI budget ledger unavailable.', 0, $e);
+    }
+
+    private function buildKey(string $granularity, string $period, string $provider, string $model, string $subject): string
+    {
+        $prefix = (string) config('ai.redis_prefix', 'ai:budget');
+
+        $granularity = $granularity === 'month' ? 'month' : 'day';
+        $provider = $this->sanitizeSegment($provider, 32);
+        $model = $this->sanitizeSegment($model, 64);
+        $subject = $this->sanitizeSegment($subject, 128);
+
+        return $prefix . ':' . $granularity . ':' . $period . ':' . $provider . ':' . $model . ':' . $subject;
+    }
+
+    private function sanitizeSegment(string $value, int $maxLen): string
+    {
+        $trimmed = trim($value);
+        if ($trimmed === '') {
+            return 'unknown';
+        }
+
+        $safe = preg_replace('/[^a-zA-Z0-9_:\\-\\.]/', '_', $trimmed);
+        $safe = $safe === null ? 'unknown' : $safe;
+
+        return substr($safe, 0, $maxLen);
+    }
+
+    private function normalizeNow(?\DateTimeInterface $now): Carbon
+    {
+        if ($now instanceof Carbon) {
+            return $now;
+        }
+
+        if ($now instanceof \DateTimeInterface) {
+            return Carbon::instance($now);
+        }
+
+        return now();
+    }
+
+    private function readWith($redis, string $key): array
+    {
+        $data = $redis->hMGet($key, ['tokens_in', 'tokens_out', 'cost_usd', 'requests']);
+        $tokensIn = (int) ($data['tokens_in'] ?? 0);
+        $tokensOut = (int) ($data['tokens_out'] ?? 0);
+        $costUsd = (float) ($data['cost_usd'] ?? 0.0);
+        $requests = (int) ($data['requests'] ?? 0);
+
+        return [
+            'ok' => true,
+            'tokens_in' => $tokensIn,
+            'tokens_out' => $tokensOut,
+            'cost_usd' => $costUsd,
+            'requests' => $requests,
+        ];
+    }
+
+    private function incrementWith($redis, string $key, int $tokensIn, int $tokensOut, float $costUsd, int $ttlSeconds): array
+    {
+        $redis->hIncrBy($key, 'tokens_in', $tokensIn);
+        $redis->hIncrBy($key, 'tokens_out', $tokensOut);
+        $redis->hIncrByFloat($key, 'cost_usd', $costUsd);
+        $redis->hIncrBy($key, 'requests', 1);
+        $redis->expire($key, $ttlSeconds);
+
+        return $this->readWith($redis, $key);
+    }
+
+    private function client()
+    {
+        return $this->directClient();
+    }
+
+    private function directClient(): \Redis
+    {
+        if ($this->directClient instanceof \Redis) {
+            return $this->directClient;
+        }
+
+        $host = (string) config('database.redis.default.host', '127.0.0.1');
+        $port = (int) config('database.redis.default.port', 6379);
+        $password = trim((string) (config('database.redis.default.password') ?? ''));
+        if (strtolower($password) === 'null') {
+            $password = '';
+        }
+        $database = (int) config('database.redis.default.database', 0);
+
+        $client = new \Redis();
+        $client->connect($host, $port, 1.5);
+
+        if ($password !== '') {
+            $client->auth($password);
+        }
+        if ($database > 0) {
+            $client->select($database);
+        }
+
+        $this->directClient = $client;
+
+        return $client;
+    }
+}

--- a/backend/app/Services/AI/BudgetLedgerException.php
+++ b/backend/app/Services/AI/BudgetLedgerException.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\AI;
+
+use RuntimeException;
+use Throwable;
+
+final class BudgetLedgerException extends RuntimeException
+{
+    private string $errorCode;
+
+    public function __construct(string $errorCode, string $message = '', int $code = 0, ?Throwable $previous = null)
+    {
+        $this->errorCode = $errorCode;
+        parent::__construct($message !== '' ? $message : $errorCode, $code, $previous);
+    }
+
+    public function errorCode(): string
+    {
+        return $this->errorCode;
+    }
+}

--- a/backend/app/Services/AI/EvidenceBuilder.php
+++ b/backend/app/Services/AI/EvidenceBuilder.php
@@ -1,0 +1,156 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\AI;
+
+use App\Models\Attempt;
+use App\Models\Result;
+final class EvidenceBuilder
+{
+    public function build(?Attempt $attempt, ?Result $result): array
+    {
+        $items = [];
+        $now = now()->toIso8601String();
+
+        if ($attempt) {
+            $typeCode = trim((string) ($attempt->type_code ?? ''));
+            if ($typeCode !== '') {
+                $this->pushEvidence($items, 'type_code', 'attempt', 'attempts.type_code', "type_code={$typeCode}", $now);
+            }
+
+            $packId = trim((string) ($attempt->pack_id ?? ''));
+            if ($packId !== '') {
+                $this->pushEvidence($items, 'pack_id', 'attempt', 'attempts.pack_id', "pack_id={$packId}", $now);
+            }
+
+            $dirVersion = trim((string) ($attempt->dir_version ?? ''));
+            if ($dirVersion !== '') {
+                $this->pushEvidence($items, 'dir_version', 'attempt', 'attempts.dir_version', "dir_version={$dirVersion}", $now);
+            }
+
+            $normVersion = trim((string) ($attempt->norm_version ?? ''));
+            if ($normVersion !== '') {
+                $this->pushEvidence($items, 'norm_version', 'attempt', 'attempts.norm_version', "norm_version={$normVersion}", $now);
+            }
+
+            $scoringSpec = trim((string) ($attempt->scoring_spec_version ?? ''));
+            if ($scoringSpec !== '') {
+                $this->pushEvidence(
+                    $items,
+                    'scoring_spec_version',
+                    'attempt',
+                    'attempts.scoring_spec_version',
+                    "scoring_spec_version={$scoringSpec}",
+                    $now
+                );
+            }
+
+            $snapshot = $attempt->calculation_snapshot_json;
+            if (is_string($snapshot)) {
+                $decoded = json_decode($snapshot, true);
+                $snapshot = is_array($decoded) ? $decoded : null;
+            }
+
+            if (is_array($snapshot)) {
+                $version = trim((string) ($snapshot['version'] ?? ''));
+                if ($version !== '') {
+                    $this->pushEvidence(
+                        $items,
+                        'calc_snapshot_version',
+                        'psychometrics',
+                        'attempts.calculation_snapshot_json.version',
+                        "snapshot_version={$version}",
+                        $now
+                    );
+                }
+            }
+        }
+
+        if ($result) {
+            $typeCode = trim((string) ($result->type_code ?? ''));
+            if ($typeCode !== '') {
+                $this->pushEvidence($items, 'type_code', 'result', 'results.type_code', "type_code={$typeCode}", $now);
+            }
+
+            $scoresPct = $result->scores_pct;
+            if (is_string($scoresPct)) {
+                $decoded = json_decode($scoresPct, true);
+                $scoresPct = is_array($decoded) ? $decoded : null;
+            }
+
+            if (is_array($scoresPct)) {
+                $this->appendKeyValueEvidence($items, 'score_pct', 'result', 'results.scores_pct', $scoresPct, 4, $now);
+            }
+
+            $axisStates = $result->axis_states;
+            if (is_string($axisStates)) {
+                $decoded = json_decode($axisStates, true);
+                $axisStates = is_array($decoded) ? $decoded : null;
+            }
+
+            if (is_array($axisStates)) {
+                $this->appendKeyValueEvidence($items, 'axis_state', 'result', 'results.axis_states', $axisStates, 4, $now);
+            }
+        }
+
+        return $items;
+    }
+
+    private function appendKeyValueEvidence(
+        array &$items,
+        string $type,
+        string $source,
+        string $pointerPrefix,
+        array $data,
+        int $limit,
+        string $createdAt
+    ): void {
+        $count = 0;
+        foreach ($data as $key => $value) {
+            if ($count >= $limit) {
+                break;
+            }
+            if (!is_scalar($value)) {
+                continue;
+            }
+            $keyStr = is_string($key) ? $key : (string) $key;
+            $valStr = is_bool($value) ? ($value ? 'true' : 'false') : (string) $value;
+            $this->pushEvidence(
+                $items,
+                $type,
+                $source,
+                $pointerPrefix . '.' . $keyStr,
+                "{$keyStr}={$valStr}",
+                $createdAt
+            );
+            $count++;
+        }
+    }
+
+    private function pushEvidence(
+        array &$items,
+        string $type,
+        string $source,
+        string $pointer,
+        string $quote,
+        string $createdAt
+    ): void {
+        $payload = [
+            'type' => $type,
+            'source' => $source,
+            'pointer' => $pointer,
+            'quote' => $quote,
+        ];
+        $hash = hash('sha256', json_encode($payload, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES));
+
+        $items[] = [
+            'type' => $type,
+            'source' => $source,
+            'pointer' => $pointer,
+            'quote' => $quote,
+            'hash' => $hash,
+            'created_at' => $createdAt,
+        ];
+    }
+}

--- a/backend/app/Services/AI/InsightGenerator.php
+++ b/backend/app/Services/AI/InsightGenerator.php
@@ -1,0 +1,101 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\AI;
+
+final class InsightGenerator
+{
+    public function generate(object $insight, array $evidence): array
+    {
+        $provider = (string) config('ai.provider', 'mock');
+        $model = (string) config('ai.model', 'mock-model');
+
+        $inputPayload = [
+            'period_type' => (string) ($insight->period_type ?? ''),
+            'period_start' => (string) ($insight->period_start ?? ''),
+            'period_end' => (string) ($insight->period_end ?? ''),
+            'prompt_version' => (string) config('ai.prompt_version', 'v1.0.0'),
+            'evidence' => $evidence,
+        ];
+
+        $inputJson = json_encode($inputPayload, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES);
+        if ($inputJson === false) {
+            $inputJson = '{}';
+        }
+
+        $tokensIn = $this->estimateTokens($inputJson);
+        $tokensOut = $this->estimateTokensOut($tokensIn);
+        $costUsd = $this->estimateCostUsd($tokensIn + $tokensOut);
+
+        $output = $this->mockOutput($inputPayload);
+
+        return [
+            'output_json' => $output,
+            'evidence_json' => $evidence,
+            'tokens_in' => $tokensIn,
+            'tokens_out' => $tokensOut,
+            'cost_usd' => $costUsd,
+            'provider' => $provider,
+            'model' => $model,
+        ];
+    }
+
+    private function estimateTokens(string $payload): int
+    {
+        $chars = strlen($payload);
+        $tokens = (int) ceil($chars / 4);
+        if ($tokens < 1) {
+            $tokens = 1;
+        }
+        return $tokens;
+    }
+
+    private function estimateTokensOut(int $tokensIn): int
+    {
+        if ($tokensIn > 1200) {
+            return 200;
+        }
+        if ($tokensIn > 600) {
+            return 180;
+        }
+        return 160;
+    }
+
+    private function estimateCostUsd(int $totalTokens): float
+    {
+        $rate = (float) config('ai.cost_per_1k_tokens_usd', 0.0);
+        if ($rate <= 0) {
+            return 0.0;
+        }
+        return round(($totalTokens / 1000.0) * $rate, 6);
+    }
+
+    private function mockOutput(array $inputPayload): array
+    {
+        $periodType = (string) ($inputPayload['period_type'] ?? '');
+        $periodStart = (string) ($inputPayload['period_start'] ?? '');
+        $periodEnd = (string) ($inputPayload['period_end'] ?? '');
+
+        $summary = 'Mock AI insight generated from available structured evidence.';
+        if ($periodType !== '' && $periodStart !== '' && $periodEnd !== '') {
+            $summary = "Mock AI insight for {$periodType} period {$periodStart} → {$periodEnd}.";
+        }
+
+        return [
+            'summary' => $summary,
+            'strengths' => [
+                'Pattern recognition and structured reasoning appear consistent.',
+                'Scores suggest stable preference signals.',
+            ],
+            'risks' => [
+                'Over-reliance on a single context may bias conclusions.',
+            ],
+            'actions' => [
+                'Review recent attempts for consistency across contexts.',
+                'Re-run assessments after major life changes to verify stability.',
+            ],
+            'disclaimer' => 'This AI-generated insight is for informational purposes only and not medical or psychological advice.',
+        ];
+    }
+}

--- a/backend/config/ai.php
+++ b/backend/config/ai.php
@@ -1,0 +1,29 @@
+<?php
+
+return [
+    'enabled' => env('AI_ENABLED', true),
+    'insights_enabled' => env('AI_INSIGHTS_ENABLED', true),
+
+    'provider' => env('AI_PROVIDER', 'mock'),
+    'model' => env('AI_MODEL', 'mock-model'),
+    'prompt_version' => env('AI_PROMPT_VERSION', 'v1.0.0'),
+
+    'timeouts' => [
+        'connect_seconds' => (int) env('AI_TIMEOUT_CONNECT', 5),
+        'request_seconds' => (int) env('AI_TIMEOUT_REQUEST', 30),
+    ],
+
+    'budgets' => [
+        'daily_usd' => (float) env('AI_DAILY_USD', 5.0),
+        'monthly_usd' => (float) env('AI_MONTHLY_USD', 50.0),
+        'daily_tokens' => (int) env('AI_DAILY_TOKENS', 25000),
+        'monthly_tokens' => (int) env('AI_MONTHLY_TOKENS', 250000),
+    ],
+
+    'breaker_enabled' => env('AI_BREAKER_ENABLED', true),
+    'fail_open_when_redis_down' => env('AI_FAIL_OPEN_WHEN_REDIS_DOWN', false),
+    'redis_prefix' => env('AI_REDIS_PREFIX', 'ai:budget'),
+    'queue_name' => env('AI_INSIGHTS_QUEUE', 'insights'),
+    'cost_per_1k_tokens_usd' => (float) env('AI_COST_PER_1K_TOKENS_USD', 0.002),
+    'dev_allow_anon_header' => env('AI_DEV_ALLOW_ANON_HEADER', true),
+];

--- a/backend/config/queue.php
+++ b/backend/config/queue.php
@@ -15,6 +15,9 @@ return [
 
     'default' => env('QUEUE_CONNECTION', 'sync'),
 
+    // Dedicated queue name for AI insights jobs (when using database/redis queues)
+    'insights_queue' => env('AI_INSIGHTS_QUEUE', 'insights'),
+
     /*
     |--------------------------------------------------------------------------
     | Queue Connections

--- a/backend/database/migrations/2026_01_28_120000_create_ai_insights_table.php
+++ b/backend/database/migrations/2026_01_28_120000_create_ai_insights_table.php
@@ -1,0 +1,48 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        if (Schema::hasTable('ai_insights')) {
+            return;
+        }
+
+        Schema::create('ai_insights', function (Blueprint $table) {
+            $table->uuid('id')->primary();
+            $table->string('user_id')->nullable();
+            $table->string('anon_id')->nullable();
+            $table->string('period_type', 16);
+            $table->date('period_start');
+            $table->date('period_end');
+            $table->string('input_hash', 64)->index();
+            $table->string('prompt_version', 64);
+            $table->string('model', 64);
+            $table->string('provider', 32);
+            $table->integer('tokens_in')->default(0);
+            $table->integer('tokens_out')->default(0);
+            $table->decimal('cost_usd', 10, 4)->default(0);
+            $table->string('status', 16)->index();
+            $table->json('output_json')->nullable();
+            $table->json('evidence_json')->nullable();
+            $table->string('error_code', 64)->nullable();
+            $table->timestamps();
+
+            $table->index(['user_id', 'created_at']);
+            $table->index(['period_start', 'period_end']);
+        });
+    }
+
+    public function down(): void
+    {
+        if (!Schema::hasTable('ai_insights')) {
+            return;
+        }
+
+        Schema::drop('ai_insights');
+    }
+};

--- a/backend/database/migrations/2026_01_28_120100_create_ai_insight_feedback_table.php
+++ b/backend/database/migrations/2026_01_28_120100_create_ai_insight_feedback_table.php
@@ -1,0 +1,35 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        if (Schema::hasTable('ai_insight_feedback')) {
+            return;
+        }
+
+        Schema::create('ai_insight_feedback', function (Blueprint $table) {
+            $table->uuid('id')->primary();
+            $table->uuid('insight_id');
+            $table->integer('rating');
+            $table->string('reason', 64)->nullable();
+            $table->text('comment')->nullable();
+            $table->timestamp('created_at')->useCurrent();
+
+            $table->index(['insight_id']);
+        });
+    }
+
+    public function down(): void
+    {
+        if (!Schema::hasTable('ai_insight_feedback')) {
+            return;
+        }
+
+        Schema::drop('ai_insight_feedback');
+    }
+};

--- a/backend/routes/api.php
+++ b/backend/routes/api.php
@@ -121,6 +121,15 @@ Route::prefix("v0.2")->group(function () {
     Route::post("/payments/webhook/mock", [PaymentsController::class, "webhookMock"]);
 
     // =========================================================
+    // AI Insights (async, budget guarded)
+    // =========================================================
+    Route::middleware('App\\Http\\Middleware\\CheckAiBudget')->group(function () {
+        Route::post("/insights/generate", "App\\Http\\Controllers\\API\\V0_2\\InsightsController@generate");
+    });
+    Route::get("/insights/{id}", "App\\Http\\Controllers\\API\\V0_2\\InsightsController@show");
+    Route::post("/insights/{id}/feedback", "App\\Http\\Controllers\\API\\V0_2\\InsightsController@feedback");
+
+    // =========================================================
     // Optional token attach (no 401): allow anon access + enrich events.user_id when token exists
     // =========================================================
     Route::middleware(\App\Http\Middleware\FmTokenOptional::class)->group(function () {

--- a/backend/scripts/pr12_verify_ai_insights.sh
+++ b/backend/scripts/pr12_verify_ai_insights.sh
@@ -1,0 +1,444 @@
+#!/usr/bin/env bash
+# Usage: PORT=18020 bash scripts/pr12_verify_ai_insights.sh
+# Artifacts: backend/artifacts/pr12/
+set -euo pipefail
+
+require_cmd() {
+  command -v "$1" >/dev/null 2>&1 || {
+    echo "[FAIL] missing command: $1" >&2
+    exit 2
+  }
+}
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+BACKEND_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+REPO_DIR="$(cd "$BACKEND_DIR/.." && pwd)"
+
+RUN_DIR="$BACKEND_DIR/artifacts/pr12"
+LOG_DIR="$RUN_DIR/logs"
+mkdir -p "$LOG_DIR"
+export XDG_CONFIG_HOME="$RUN_DIR/.xdg"
+mkdir -p "$XDG_CONFIG_HOME"
+
+SERVER_LOG="$LOG_DIR/server.log"
+SUMMARY="$RUN_DIR/summary.txt"
+
+PAYLOAD_JSON="$RUN_DIR/attempt_payload.json"
+ATTEMPT_JSON="$RUN_DIR/attempt.json"
+INSIGHT_REQ_JSON="$RUN_DIR/insight_request.json"
+INSIGHT_CREATE_JSON="$RUN_DIR/insight_create.json"
+INSIGHT_SHOW_JSON="$RUN_DIR/insight_show.json"
+INSIGHT_FEEDBACK_JSON="$RUN_DIR/insight_feedback.json"
+INSIGHT_CREATE_BREAKER_JSON="$RUN_DIR/insight_create_breaker.json"
+
+require_cmd curl
+require_cmd jq
+require_cmd php
+
+USE_INTERNAL=0
+
+if [[ -z "${DB_CONNECTION:-}" ]]; then
+  export DB_CONNECTION=sqlite
+fi
+if [[ -z "${DB_DATABASE:-}" ]]; then
+  export DB_DATABASE="$BACKEND_DIR/database/database.sqlite"
+fi
+
+PHP_BIND_OK=1
+if ! php -r '$s=@stream_socket_server("tcp://127.0.0.1:0",$e,$s); if ($s){fclose($s); echo "OK";} else {echo "FAIL";}' | grep -q "OK"; then
+  PHP_BIND_OK=0
+  echo "[WARN] php cannot bind local ports; will skip artisan serve" >&2
+fi
+
+REDIS_SOCKET_OK=1
+if ! php -r '$fp=@fsockopen("127.0.0.1",6379,$e,$s,1); if ($fp){fclose($fp); echo "OK";} else {echo "FAIL";}' | grep -q "OK"; then
+  REDIS_SOCKET_OK=0
+  echo "[WARN] php cannot open redis socket; will bypass breaker for main flow" >&2
+fi
+AI_FAIL_OPEN_ENV=""
+if [[ "$REDIS_SOCKET_OK" -eq 0 ]]; then
+  AI_FAIL_OPEN_ENV="AI_FAIL_OPEN_WHEN_REDIS_DOWN=true"
+fi
+
+port_in_use() {
+  local port="$1"
+  if command -v lsof >/dev/null 2>&1; then
+    lsof -iTCP:"$port" -sTCP:LISTEN -P >/dev/null 2>&1
+    return $?
+  fi
+  if command -v nc >/dev/null 2>&1; then
+    nc -z 127.0.0.1 "$port" >/dev/null 2>&1
+    return $?
+  fi
+  return 1
+}
+
+select_port() {
+  local base_port="$1"
+  local end_port=18039
+  local port
+  for port in $(seq "$base_port" "$end_port"); do
+    if port_in_use "$port"; then
+      echo "[PR12] port $port in use. If needed: lsof -iTCP:$port -sTCP:LISTEN -P" >&2
+      continue
+    fi
+    echo "$port"
+    return 0
+  done
+  return 1
+}
+
+wait_health() {
+  local retries=12
+  for i in $(seq 1 "$retries"); do
+    if curl -fsS "$API/health" >/dev/null 2>&1; then
+      return 0
+    fi
+    sleep 0.4
+  done
+  return 1
+}
+
+start_server() {
+  local extra_env="$1"
+  echo "[PR12] starting server on :$PORT ${extra_env}"
+  (
+    cd "$BACKEND_DIR"
+    env $extra_env php artisan serve --host=127.0.0.1 --port=$PORT >"$SERVER_LOG" 2>&1
+  ) &
+  SERVER_PID=$!
+
+  if ! wait_health; then
+    echo "[WARN] server not healthy on $API" >&2
+    return 1
+  fi
+  return 0
+}
+
+stop_server() {
+  if [[ -n "${SERVER_PID:-}" ]]; then
+    kill "$SERVER_PID" >/dev/null 2>&1 || true
+    unset SERVER_PID
+  fi
+}
+
+cleanup() {
+  local code=$?
+  stop_server
+  exit $code
+}
+trap cleanup EXIT
+
+PORT_BASE="${PORT:-18020}"
+PORT=""
+SERVER_OK=0
+if [[ "$PHP_BIND_OK" -eq 1 ]]; then
+  for candidate in $(seq "$PORT_BASE" 18039); do
+    if port_in_use "$candidate"; then
+      echo "[PR12] port $candidate in use. If needed: lsof -iTCP:$candidate -sTCP:LISTEN -P" >&2
+      continue
+    fi
+
+    PORT="$candidate"
+    API="http://127.0.0.1:${PORT}/api/v0.2"
+
+    if start_server ""; then
+      SERVER_OK=1
+      break
+    fi
+
+    stop_server
+  done
+fi
+
+if [[ "$SERVER_OK" -ne 1 ]]; then
+  USE_INTERNAL=1
+  echo "[WARN] unable to start php artisan serve; falling back to internal requests" >&2
+fi
+
+http_request() {
+  local method="$1"
+  local path="$2"
+  local body_file="$3"
+  local out_file="$4"
+  local extra_env="${5:-}"
+  local req_path="$path"
+
+  if [[ "$USE_INTERNAL" -eq 1 ]]; then
+    if [[ "$req_path" != /api/* ]]; then
+      req_path="/api/v0.2${req_path}"
+    fi
+    local cmd=(php -r '
+require "vendor/autoload.php";
+$app = require "bootstrap/app.php";
+$kernel = $app->make(Illuminate\Contracts\Http\Kernel::class);
+$method = getenv("REQ_METHOD") ?: "GET";
+$path = getenv("REQ_PATH") ?: "/";
+$bodyPath = getenv("REQ_BODY") ?: "";
+$outPath = getenv("REQ_OUT") ?: "";
+$body = $bodyPath !== "" && file_exists($bodyPath) ? file_get_contents($bodyPath) : "";
+$request = Illuminate\Http\Request::create($path, $method, [], [], [], [], $body);
+$request->headers->set("Content-Type", "application/json");
+$response = $kernel->handle($request);
+if ($outPath !== "") {
+  file_put_contents($outPath, $response->getContent());
+}
+echo (string) $response->getStatusCode();
+$kernel->terminate($request, $response);
+');
+    if [[ -n "$extra_env" ]]; then
+      (
+        cd "$BACKEND_DIR"
+        REQ_METHOD="$method" REQ_PATH="$req_path" REQ_BODY="$body_file" REQ_OUT="$out_file" \
+          env $extra_env "${cmd[@]}"
+      )
+    else
+      (
+        cd "$BACKEND_DIR"
+        REQ_METHOD="$method" REQ_PATH="$req_path" REQ_BODY="$body_file" REQ_OUT="$out_file" \
+          "${cmd[@]}"
+      )
+    fi
+    return 0
+  fi
+
+  local url="$API$path"
+  if [[ -n "$body_file" ]]; then
+    curl -sS -o "$out_file" -w "%{http_code}" \
+      -H "Content-Type: application/json" \
+      -d @"$body_file" \
+      "$url"
+  else
+    curl -sS -o "$out_file" -w "%{http_code}" "$url"
+  fi
+}
+
+echo "[PR12] artifacts: $RUN_DIR"
+
+PACK_DIR="$REPO_DIR/content_packages/default/CN_MAINLAND/zh-CN/MBTI-CN-v0.2.1-TEST"
+QUESTIONS_JSON="$PACK_DIR/questions.json"
+if [[ ! -f "$QUESTIONS_JSON" ]]; then
+  echo "[FAIL] questions.json not found: $QUESTIONS_JSON" >&2
+  exit 5
+fi
+
+ANON_ID="anon_pr12_$(date +%s)"
+
+QUESTIONS_JSON="$QUESTIONS_JSON" PAYLOAD_JSON="$PAYLOAD_JSON" ANON_ID="$ANON_ID" php -r '
+$path = getenv("QUESTIONS_JSON");
+$raw = file_get_contents($path);
+$doc = json_decode($raw, true);
+$items = isset($doc["items"]) ? $doc["items"] : $doc;
+$answers = [];
+foreach ($items as $q) {
+    $answers[] = ["question_id" => $q["question_id"], "code" => "C"];
+}
+$payload = [
+  "anon_id" => getenv("ANON_ID"),
+  "scale_code" => "MBTI",
+  "scale_version" => "v0.2.1-TEST",
+  "question_count" => count($answers),
+  "answers" => $answers,
+  "client_platform" => "web",
+  "region" => "CN_MAINLAND",
+  "locale" => "zh-CN"
+];
+file_put_contents(getenv("PAYLOAD_JSON"), json_encode($payload, JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE));
+'
+
+echo "[PR12] POST attempt"
+http_attempt=$(http_request "POST" "/attempts" "$PAYLOAD_JSON" "$ATTEMPT_JSON" || true)
+if [[ "$http_attempt" != "200" && "$http_attempt" != "201" ]]; then
+  echo "[FAIL] attempt HTTP=$http_attempt" >&2
+  head -c 400 "$ATTEMPT_JSON" >&2 || true
+  exit 6
+fi
+
+ATTEMPT_ID=$(jq -r '.attempt_id // .id // empty' "$ATTEMPT_JSON")
+if [[ -z "$ATTEMPT_ID" || "$ATTEMPT_ID" == "null" ]]; then
+  echo "[FAIL] attempt id missing" >&2
+  exit 7
+fi
+
+PERIOD_END=$(php -r 'echo date("Y-m-d");')
+PERIOD_START=$(php -r 'echo date("Y-m-d", strtotime("-7 days"));')
+
+cat > "$INSIGHT_REQ_JSON" <<JSON
+{"period_type":"week","period_start":"$PERIOD_START","period_end":"$PERIOD_END","anon_id":"$ANON_ID"}
+JSON
+
+echo "[PR12] POST /insights/generate"
+http_insight=$(http_request "POST" "/insights/generate" "$INSIGHT_REQ_JSON" "$INSIGHT_CREATE_JSON" "$AI_FAIL_OPEN_ENV" || true)
+
+if [[ "$http_insight" != "200" && "$http_insight" != "201" ]]; then
+  echo "[FAIL] generate HTTP=$http_insight" >&2
+  head -c 400 "$INSIGHT_CREATE_JSON" >&2 || true
+  exit 8
+fi
+
+INSIGHT_ID=$(jq -r '.id // empty' "$INSIGHT_CREATE_JSON")
+if [[ -z "$INSIGHT_ID" || "$INSIGHT_ID" == "null" ]]; then
+  echo "[FAIL] insight id missing" >&2
+  exit 9
+fi
+
+STATUS=""
+for i in $(seq 1 30); do
+  http_request "GET" "/insights/$INSIGHT_ID" "" "$INSIGHT_SHOW_JSON" >/dev/null || true
+  STATUS=$(jq -r '.status // empty' "$INSIGHT_SHOW_JSON")
+  if [[ "$STATUS" == "succeeded" ]]; then
+    break
+  fi
+  if [[ "$STATUS" == "failed" ]]; then
+    echo "[FAIL] insight failed" >&2
+    cat "$INSIGHT_SHOW_JSON" >&2
+    exit 10
+  fi
+
+  (
+    cd "$BACKEND_DIR"
+    if [[ -n "$AI_FAIL_OPEN_ENV" ]]; then
+      env $AI_FAIL_OPEN_ENV php artisan queue:work --once --queue=insights >/dev/null 2>&1 || true
+    else
+      php artisan queue:work --once --queue=insights >/dev/null 2>&1 || true
+    fi
+  )
+  sleep 1
+
+done
+
+if [[ "$STATUS" != "succeeded" ]]; then
+  echo "[FAIL] insight status timeout ($STATUS)" >&2
+  cat "$INSIGHT_SHOW_JSON" >&2
+  exit 11
+fi
+
+jq -e '.output_json.summary and (.output_json.strengths|type=="array") and (.output_json.risks|type=="array") and (.output_json.actions|type=="array") and (.output_json.disclaimer|type=="string")' \
+  "$INSIGHT_SHOW_JSON" >/dev/null || {
+    echo "[FAIL] output_json schema invalid" >&2
+    exit 12
+  }
+
+jq -e '.evidence_json|type=="array"' "$INSIGHT_SHOW_JSON" >/dev/null || {
+  echo "[FAIL] evidence_json not array" >&2
+  exit 13
+}
+
+if [[ $(jq '.evidence_json | length' "$INSIGHT_SHOW_JSON") -gt 0 ]]; then
+  jq -e '.evidence_json[0].type and .evidence_json[0].source and .evidence_json[0].pointer and .evidence_json[0].quote and .evidence_json[0].hash and .evidence_json[0].created_at' \
+    "$INSIGHT_SHOW_JSON" >/dev/null || {
+      echo "[FAIL] evidence_json schema invalid" >&2
+      exit 14
+    }
+fi
+
+TOKEN_IN=$(jq -r '.tokens_in // 0' "$INSIGHT_SHOW_JSON")
+TOKEN_OUT=$(jq -r '.tokens_out // 0' "$INSIGHT_SHOW_JSON")
+COST_USD=$(jq -r '.cost_usd // 0' "$INSIGHT_SHOW_JSON")
+
+cat > "$INSIGHT_FEEDBACK_JSON" <<JSON
+{"rating":4,"reason":"helpful","comment":"PR12 verify"}
+JSON
+
+http_feedback=$(http_request "POST" "/insights/$INSIGHT_ID/feedback" "$INSIGHT_FEEDBACK_JSON" "$RUN_DIR/feedback_resp.json" || true)
+if [[ "$http_feedback" != "200" && "$http_feedback" != "201" ]]; then
+  echo "[FAIL] feedback HTTP=$http_feedback" >&2
+  head -c 400 "$RUN_DIR/feedback_resp.json" >&2 || true
+  exit 15
+fi
+
+FEEDBACK_COUNT=$(cd "$BACKEND_DIR" && php artisan tinker --execute="echo DB::table('ai_insight_feedback')->where('insight_id', '$INSIGHT_ID')->count();")
+if [[ "${FEEDBACK_COUNT:-0}" -lt 1 ]]; then
+  echo "[FAIL] feedback not stored" >&2
+  exit 16
+fi
+
+BREAKER_CODE=""
+if [[ "$REDIS_SOCKET_OK" -eq 1 ]]; then
+  if [[ "$USE_INTERNAL" -eq 0 ]]; then
+    stop_server
+    start_server "AI_DAILY_TOKENS=1 AI_BREAKER_ENABLED=true AI_INSIGHTS_ENABLED=true AI_ENABLED=true"
+  fi
+
+  http_breaker=$(http_request "POST" "/insights/generate" "$INSIGHT_REQ_JSON" "$INSIGHT_CREATE_BREAKER_JSON" "AI_DAILY_TOKENS=1 AI_BREAKER_ENABLED=true AI_INSIGHTS_ENABLED=true AI_ENABLED=true" || true)
+
+  BREAKER_CODE=$(jq -r '.error_code // empty' "$INSIGHT_CREATE_BREAKER_JSON")
+  if [[ "$http_breaker" == "200" || "$http_breaker" == "201" ]]; then
+    echo "[FAIL] breaker test should fail but succeeded" >&2
+    cat "$INSIGHT_CREATE_BREAKER_JSON" >&2
+    exit 17
+  fi
+
+  if [[ "$BREAKER_CODE" != "AI_BUDGET_EXCEEDED" ]]; then
+    echo "[FAIL] breaker error_code mismatch: $BREAKER_CODE" >&2
+    cat "$INSIGHT_CREATE_BREAKER_JSON" >&2
+    exit 18
+  fi
+else
+  BREAKER_CODE="SKIPPED_REDIS_SOCKET_BLOCKED"
+  echo "[WARN] breaker test skipped: php socket blocked" >&2
+fi
+
+INPUT_HASH=$(PERIOD_TYPE=week PERIOD_START="$PERIOD_START" PERIOD_END="$PERIOD_END" \
+ANON_ID="$ANON_ID" PROMPT_VERSION="v1.0.0" PROVIDER="mock" MODEL="mock-model" \
+php -r '
+$payload = [
+  "period_type" => getenv("PERIOD_TYPE"),
+  "period_start" => getenv("PERIOD_START"),
+  "period_end" => getenv("PERIOD_END"),
+  "user_id" => "",
+  "anon_id" => getenv("ANON_ID"),
+  "prompt_version" => getenv("PROMPT_VERSION"),
+  "provider" => getenv("PROVIDER"),
+  "model" => getenv("MODEL"),
+];
+$hash = hash("sha256", json_encode($payload, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES));
+echo $hash;
+')
+
+CLEAN_JSON=$(cd "$BACKEND_DIR" && php artisan tinker --execute="
+\$ids = DB::table('ai_insights')->where('input_hash', '$INPUT_HASH')->pluck('id');
+\$feedbackDeleted = 0;
+if (count(\$ids) > 0) {
+  \$feedbackDeleted = DB::table('ai_insight_feedback')->whereIn('insight_id', \$ids)->delete();
+}
+\$insightsDeleted = DB::table('ai_insights')->where('input_hash', '$INPUT_HASH')->delete();
+
+echo json_encode(['feedback_deleted' => \$feedbackDeleted, 'insights_deleted' => \$insightsDeleted]);")
+
+CLEAN_FEEDBACK=$(echo "$CLEAN_JSON" | jq -r '.feedback_deleted // 0')
+CLEAN_INSIGHTS=$(echo "$CLEAN_JSON" | jq -r '.insights_deleted // 0')
+
+REDIS_DEL=""
+if [[ "$REDIS_SOCKET_OK" -eq 1 ]]; then
+  DAY_KEY="ai:budget:day:$(date +%F):mock:mock-model:anon:$ANON_ID"
+  MONTH_KEY="ai:budget:month:$(date +%Y-%m):mock:mock-model:anon:$ANON_ID"
+
+  REDIS_DEL=$(cd "$BACKEND_DIR" && php artisan tinker --execute="
+\$redis = app('redis');
+\$deleted = \$redis->del('$DAY_KEY', '$MONTH_KEY');
+echo (string) \$deleted;")
+else
+  REDIS_DEL="SKIPPED_SOCKET_BLOCKED"
+fi
+
+{
+  MODE="server"
+  if [[ "$USE_INTERNAL" -eq 1 ]]; then
+    MODE="internal"
+  fi
+  echo "insight_id=$INSIGHT_ID"
+  echo "attempt_id=$ATTEMPT_ID"
+  echo "tokens_in=$TOKEN_IN"
+  echo "tokens_out=$TOKEN_OUT"
+  echo "cost_usd=$COST_USD"
+  echo "breaker_test=$BREAKER_CODE"
+  echo "port=${PORT:-internal}"
+  echo "mode=$MODE"
+  echo "cleanup_feedback_deleted=$CLEAN_FEEDBACK"
+  echo "cleanup_insights_deleted=$CLEAN_INSIGHTS"
+  echo "cleanup_redis_deleted=$REDIS_DEL"
+  echo "artifacts=$RUN_DIR"
+} > "$SUMMARY"
+
+echo "[PR12] done. summary: $SUMMARY"

--- a/docs/04-ops/ai-cost-runbook.md
+++ b/docs/04-ops/ai-cost-runbook.md
@@ -1,0 +1,36 @@
+# AI Cost Runbook
+
+## Symptoms
+- AI insights blocked with `AI_BUDGET_EXCEEDED`
+- Insights stuck in `queued` or `running`
+- Sudden spike in `cost_usd` or `tokens` usage
+
+## Quick Checks
+1) Redis availability
+   - `php artisan tinker --execute="Redis::connection()->ping();"`
+2) Budget ledger keys
+   - `php artisan tinker --execute="Redis::keys('ai:budget:*');"`
+3) DB usage
+   - `php artisan tinker --execute="DB::table('ai_insights')->orderByDesc('created_at')->limit(5)->get();"`
+4) Queue health
+   - `php artisan queue:work --once --queue=insights`
+
+## Breaker Reset / Recovery
+- Temporary relief (raise limits):
+  - Set env: `AI_DAILY_TOKENS`, `AI_MONTHLY_TOKENS`, `AI_DAILY_USD`, `AI_MONTHLY_USD`
+- Clear ledger keys (last resort):
+  - `php artisan tinker --execute="Redis::del(Redis::keys('ai:budget:day:*'));"`
+  - `php artisan tinker --execute="Redis::del(Redis::keys('ai:budget:month:*'));"`
+- Disable breaker (short-term only):
+  - `AI_BREAKER_ENABLED=false`
+
+## Common Failures
+- Redis down → `AI_BUDGET_LEDGER_UNAVAILABLE`
+- Queue worker not running → `queued` insights never complete
+- Provider timeout → `AI_INSIGHT_FAILED`
+
+## Monitoring
+- `tools/metabase/views/v_ai_cost_daily.sql`
+- `tools/metabase/views/v_ai_cost_alert.sql`
+- `tools/metabase/views/v_ai_failure_reasons.sql`
+- `tools/metabase/views/v_ai_quality_feedback.sql`

--- a/docs/ai/insight-spec.md
+++ b/docs/ai/insight-spec.md
@@ -1,0 +1,108 @@
+# AI Insight Spec (PR12)
+
+## Overview
+AI Insights provide a summarized, explainable insight payload for a given time period. Outputs are traceable via `evidence_json`, `input_hash`, `prompt_version`, and model metadata.
+
+## API Endpoints
+### POST /api/v0.2/insights/generate
+Request JSON:
+```json
+{
+  "period_type": "week",
+  "period_start": "2026-01-21",
+  "period_end": "2026-01-28",
+  "anon_id": "anon_abc" 
+}
+```
+Notes:
+- `period_type`: `week` or `month`
+- `period_start` / `period_end`: date strings (YYYY-MM-DD)
+- `anon_id` required if no authenticated user
+
+Response JSON:
+```json
+{
+  "ok": true,
+  "id": "<uuid>",
+  "status": "queued"
+}
+```
+
+### GET /api/v0.2/insights/{id}
+Response JSON:
+```json
+{
+  "ok": true,
+  "id": "<uuid>",
+  "status": "succeeded",
+  "output_json": { "summary": "...", "strengths": [], "risks": [], "actions": [], "disclaimer": "..." },
+  "evidence_json": [
+    {
+      "type": "type_code",
+      "source": "attempt",
+      "pointer": "attempts.type_code",
+      "quote": "type_code=INTJ",
+      "hash": "<sha256>",
+      "created_at": "2026-01-28T12:34:56+00:00"
+    }
+  ],
+  "tokens_in": 120,
+  "tokens_out": 160,
+  "cost_usd": 0.0006,
+  "prompt_version": "v1.0.0",
+  "model": "mock-model",
+  "provider": "mock",
+  "error_code": ""
+}
+```
+
+### POST /api/v0.2/insights/{id}/feedback
+Request JSON:
+```json
+{
+  "rating": 4,
+  "reason": "helpful",
+  "comment": "Clear summary."
+}
+```
+Response JSON:
+```json
+{ "ok": true, "id": "<uuid>" }
+```
+
+## output_json Structure
+- `summary` (string)
+- `strengths` (array of strings)
+- `risks` (array of strings)
+- `actions` (array of strings)
+- `disclaimer` (string, required)
+
+## evidence_json Structure
+Array of evidence objects:
+- `type` (string) — evidence type (e.g., `type_code`, `score_pct`, `axis_state`)
+- `source` (string) — origin (e.g., `attempt`, `result`, `psychometrics`)
+- `pointer` (string) — canonical field pointer
+- `quote` (string) — short, safe excerpt of structured data
+- `hash` (string) — sha256 of `{type,source,pointer,quote}`
+- `created_at` (ISO 8601 string)
+
+## Evidence & Privacy Guardrails
+Forbidden in evidence:
+- Raw user answers
+- Free-form user text
+- Email/phone/PII
+- Tokens or billing secrets
+
+Allowed:
+- Derived, structured fields (e.g., type_code, norm version, score percentiles)
+- Non-identifying metadata (pack/version pointers)
+
+## Status Values
+- `queued`, `running`, `succeeded`, `failed`
+
+## Error Codes
+- `AI_DISABLED`
+- `AI_BUDGET_EXCEEDED`
+- `AI_BUDGET_LEDGER_UNAVAILABLE`
+- `AI_DISPATCH_FAILED`
+- `AI_INSIGHT_FAILED`

--- a/docs/ai/prompt-versioning.md
+++ b/docs/ai/prompt-versioning.md
@@ -1,0 +1,27 @@
+# Prompt Versioning
+
+## Version Format
+- Use semantic versions: `vMAJOR.MINOR.PATCH` (e.g., `v1.0.0`).
+- Store in `config/ai.php` as `prompt_version` and persist per insight row.
+
+## Change Policy
+- PATCH: wording changes that do not alter expected outputs.
+- MINOR: new evidence fields or output sections.
+- MAJOR: behavior or schema changes requiring re-baselining.
+
+## Regression Dataset (JSONL)
+Store regression prompts in JSONL for deterministic evaluation:
+```json
+{"input": {"period_type": "week", "period_start": "2026-01-01", "period_end": "2026-01-07"}, "evidence": [...], "expected": {"summary": "..."}}
+```
+
+Each line includes:
+- `input`: structured request payload
+- `evidence`: evidence_json snapshot
+- `expected`: required output fields
+
+## Rollout Process
+1) Bump `prompt_version` in config.
+2) Run regression dataset (offline evaluation).
+3) Update `docs/ai/insight-spec.md` if output schema changes.
+4) Deploy and monitor `v_ai_*` views for cost/quality anomalies.

--- a/docs/ai/safety-policy.md
+++ b/docs/ai/safety-policy.md
@@ -1,0 +1,23 @@
+# AI Insight Safety Policy
+
+## Required Output
+All AI insight outputs must include a `disclaimer` field that explicitly states the content is informational only and not medical or psychological advice.
+
+## High-Risk Topics
+If evidence indicates any high-risk contexts (self-harm, immediate danger, or crisis content), the response must:
+- Avoid diagnosis or treatment advice.
+- Provide a neutral, supportive disclaimer.
+- Recommend seeking qualified professional help.
+
+## Prohibited Content
+- Medical diagnosis or treatment instructions
+- Legal advice
+- Explicit or sensitive personal data
+- Direct quotes from user answers or private messages
+
+## Escalation Copy (Template)
+- "If you feel unsafe or are in immediate danger, please seek local emergency help or contact a qualified professional."
+
+## Operational Guardrails
+- Evidence must only include structured, non-identifying fields.
+- Prompt versions are logged and reviewed on each deployment.

--- a/docs/verify/pr12_recon.md
+++ b/docs/verify/pr12_recon.md
@@ -1,0 +1,58 @@
+# PR12 Recon — AI insights: evidence + budget breaker (Redis)
+
+Date: 2026-01-28
+Branch: chore/pr12-ai-insights-budget
+
+## Scope
+- Goal: add AI insight generation (mock provider) with evidence trace, feedback loop, and Redis-backed budget breaker.
+- Constraints: keep changes minimal; follow change order; migrations must be idempotent; keep CI chain green.
+
+## Recon Commands (executed)
+- `ls -lah`
+- `rg -n "insight|insights|ai_insight|Budget|redis|queue|metabase|v_ai_" backend/app backend/routes backend/database docs tools -S`
+- `ls -lah backend/database/migrations | tail -n 120`
+- `php -v`
+- `php artisan -V`
+- `php artisan route:list > /tmp/routes_pr12.txt && rg -n "insight|insights|ai|psychometrics|admin" /tmp/routes_pr12.txt`
+- `php -m | rg -n "^redis$"`
+
+## Existing Entry Points / Related Files
+- Routes: `backend/routes/api.php` has `/api/v0.2/*` groups with Admin, Auth, Attempts, Reports, Payments, etc. No insights routes yet.
+- Middleware: `backend/app/Http/Middleware/FmTokenAuth.php` resolves `fm_user_id`/`anon_id` and injects into request attributes.
+- Queue: `backend/config/queue.php` defines `sync`, `database`, `redis`, etc. No dedicated insights queue name yet.
+- Redis: PHP `redis` extension is installed; Healthz controller checks redis/queue (`backend/app/Http/Controllers/HealthzController.php`).
+- Content/Report: `backend/app/Services/Report/HighlightBuilder.php` includes “insight” placeholders but no AI insight pipeline.
+- Metabase: no existing `v_ai_*` views; Metabase SQL templates live under `tools/metabase/*`.
+
+## Existing DB Tables (by migrations)
+- No `ai_*` tables currently present in `backend/database/migrations`.
+- Latest migrations are for admin, psychometrics snapshot, and quality tables (2026-01-28).
+
+## Routes Snapshot
+- Current `/api/v0.2` includes auth, attempts, reports, payments, admin endpoints.
+- No `/api/v0.2/insights` routes in `php artisan route:list` output.
+
+## Risks + Avoidance
+- Redis unavailable → budget ledger cannot increment/check.
+  - Mitigate with explicit `fail_open_when_redis_down` config; default fail-closed if breaker enabled.
+- Queue not running → insights remain queued.
+  - Mitigate by using database queue by default; provide verify script with polling + timeout.
+- Cost runaway → budget breaker required at enqueue (estimated) and on completion (actual tokens).
+- Prompt drift / regressions → enforce `prompt_version` and document versioning workflow.
+- Evidence not traceable → build evidence hash + structured pointers; avoid PII.
+
+## Required Additions/Changes (PR12)
+- Routes: `/api/v0.2/insights/*` endpoints under v0.2 group with budget middleware.
+- Config: new `backend/config/ai.php` + optional queue config note.
+- Migrations: `ai_insights` + `ai_insight_feedback` tables (idempotent).
+- Services: `BudgetLedger`, `InsightGenerator`, `EvidenceBuilder`.
+- Middleware: `CheckAiBudget` (Redis-backed checks).
+- Job: `GenerateInsightJob` (async generation + ledger increment).
+- Controller: `API/V0_2/InsightsController` (generate/get/feedback).
+- Metabase views: `v_ai_*` SQL templates in `tools/metabase/views/`.
+- Script: `backend/scripts/pr12_verify_ai_insights.sh` with artifacts in `backend/artifacts/pr12/`.
+- Docs: insight spec, prompt versioning, safety policy, cost runbook, verify notes.
+
+## Notes
+- No code changes made beyond this recon doc in this loop.
+- Next loop must follow change order: `backend/routes/api.php` → migrations → `CheckAiBudget` → controller/service → scripts.

--- a/docs/verify/pr12_verify.md
+++ b/docs/verify/pr12_verify.md
@@ -1,0 +1,26 @@
+# PR12 Verify — AI Insights
+
+## Commands
+```bash
+cd /Users/rainie/Desktop/GitHub/fap-api/backend
+composer install
+composer audit
+php artisan migrate
+PORT=18020 bash scripts/pr12_verify_ai_insights.sh
+
+cd /Users/rainie/Desktop/GitHub/fap-api
+bash backend/scripts/ci_verify_mbti.sh
+```
+
+## Expected Outputs
+- `backend/artifacts/pr12/summary.txt` exists
+- `summary.txt` includes:
+  - `insight_id=...`
+  - `tokens_in=...` and `tokens_out=...`
+  - `cost_usd=...`
+  - `breaker_test=AI_BUDGET_EXCEEDED`
+  - `port=...`
+
+## Notes
+- If port 18020 is busy, the script will auto-pick from 18020–18039 and log a kill hint.
+- Budget breaker test uses `AI_DAILY_TOKENS=1` during the second server run.

--- a/tools/metabase/views/v_ai_cost_alert.sql
+++ b/tools/metabase/views/v_ai_cost_alert.sql
@@ -1,0 +1,7 @@
+-- Update threshold_usd to match current daily budget.
+SELECT
+  COALESCE(SUM(cost_usd), 0) AS today_cost_usd,
+  5.0 AS threshold_usd,
+  CASE WHEN COALESCE(SUM(cost_usd), 0) >= 5.0 THEN 1 ELSE 0 END AS is_alert
+FROM ai_insights
+WHERE DATE(created_at) = CURRENT_DATE;

--- a/tools/metabase/views/v_ai_cost_daily.sql
+++ b/tools/metabase/views/v_ai_cost_daily.sql
@@ -1,0 +1,12 @@
+SELECT
+  DATE(created_at) AS day,
+  provider,
+  model,
+  status,
+  COUNT(*) AS insights_count,
+  SUM(tokens_in) AS tokens_in,
+  SUM(tokens_out) AS tokens_out,
+  SUM(cost_usd) AS cost_usd
+FROM ai_insights
+WHERE created_at IS NOT NULL
+GROUP BY DATE(created_at), provider, model, status;

--- a/tools/metabase/views/v_ai_failure_reasons.sql
+++ b/tools/metabase/views/v_ai_failure_reasons.sql
@@ -1,0 +1,10 @@
+SELECT
+  DATE(created_at) AS day,
+  provider,
+  model,
+  COALESCE(error_code, 'NONE') AS error_code,
+  COUNT(*) AS failure_count
+FROM ai_insights
+WHERE status = 'failed'
+  AND created_at >= (CURRENT_DATE - INTERVAL 7 DAY)
+GROUP BY DATE(created_at), provider, model, COALESCE(error_code, 'NONE');

--- a/tools/metabase/views/v_ai_quality_feedback.sql
+++ b/tools/metabase/views/v_ai_quality_feedback.sql
@@ -1,0 +1,11 @@
+SELECT
+  DATE(f.created_at) AS day,
+  i.provider,
+  i.model,
+  f.rating,
+  f.reason,
+  COUNT(*) AS feedback_count
+FROM ai_insight_feedback f
+JOIN ai_insights i ON i.id = f.insight_id
+WHERE f.created_at IS NOT NULL
+GROUP BY DATE(f.created_at), i.provider, i.model, f.rating, f.reason;


### PR DESCRIPTION
## Summary（改了什么）
- [x] 新增 AI Insights 生成闭环（generate / show / feedback）
- [x] 新增 evidence 结构（可追溯：source/pointer/quote/hash/created_at）
- [x] 新增预算熔断：Redis 计数 + Middleware 硬闸（日/月）
- [x] 新增成本/质量/失败原因的 Metabase 视图 SQL 模板
- [x] 新增本机验收脚本与 artifacts 输出（可复现）

简述本次改动（1-3 句）：
- 为“智能洞察”引入异步生成、证据链与反馈闭环，并通过 Redis 预算熔断控制 token/成本，避免长期运营成本失控与不可审计。

---

## Scope（影响范围）
**API**
- POST /api/v0.2/insights/generate（budget guarded）
- GET  /api/v0.2/insights/{id}
- POST /api/v0.2/insights/{id}/feedback

**DB**
- ai_insights
- ai_insight_feedback

**Middleware / Services / Jobs**
- App\Http\Middleware\CheckAiBudget
- App\Services\AI\BudgetLedger / InsightGenerator / EvidenceBuilder
- App\Jobs\GenerateInsightJob

**Config**
- backend/config/ai.php（provider/model/prompt_version/预算阈值/开关）

**Metabase**
- tools/metabase/views/v_ai_cost_daily.sql
- tools/metabase/views/v_ai_quality_feedback.sql
- tools/metabase/views/v_ai_failure_reasons.sql
- tools/metabase/views/v_ai_cost_alert.sql

---

## Verify（本机验收命令）
```bash
cd backend
composer install
composer audit
php artisan migrate

# 清理（避免被上次遗留预算影响）
redis-cli --scan --pattern 'ai:budget:*' | xargs -r redis-cli del
rm -rf artifacts/pr12
php artisan optimize:clear

PORT=18020 bash scripts/pr12_verify_ai_insights.sh
cat artifacts/pr12/summary.txt

cd ..
bash backend/scripts/ci_verify_mbti.sh

预期关键输出：
	•	artifacts/pr12/summary.txt 包含 breaker_test=AI_BUDGET_EXCEEDED
	•	ci_verify_mbti.sh 全绿 ✅

⸻

Notes（注意事项）
	•	预算维度：provider/model/subject(user_id/anon_id)，日/月两级
	•	Redis 不可用时：按配置 fail_open_when_redis_down 控制开/关闸策略