### PR TITLE
chore(pr13): zero-input ingestion (mock+webhook+idempotency+replay)

### DIFF
--- a/backend/app/Http/Controllers/Integrations/ProvidersController.php
+++ b/backend/app/Http/Controllers/Integrations/ProvidersController.php
@@ -1,0 +1,140 @@
+<?php
+
+namespace App\Http\Controllers\Integrations;
+
+use App\Http\Controllers\Controller;
+use App\Services\Ingestion\ConsentService;
+use App\Services\Ingestion\IngestionService;
+use App\Services\Ingestion\ReplayService;
+use App\Support\Idempotency\IdempotencyKey;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Support\Str;
+
+class ProvidersController extends Controller
+{
+    public function oauthStart(Request $request, string $provider)
+    {
+        $state = (string) Str::uuid();
+        $userId = $this->resolveUserId($request);
+
+        if (Schema::hasTable('integrations')) {
+            DB::table('integrations')->updateOrInsert([
+                'user_id' => $userId !== null ? (int) $userId : null,
+                'provider' => $provider,
+            ], [
+                'user_id' => $userId !== null ? (int) $userId : null,
+                'provider' => $provider,
+                'status' => 'pending',
+                'scopes_json' => json_encode(['mock_scope'], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES),
+                'consent_version' => 'v0.1',
+                'connected_at' => null,
+                'revoked_at' => null,
+                'created_at' => now(),
+                'updated_at' => now(),
+            ]);
+        }
+
+        return response()->json([
+            'ok' => true,
+            'provider' => $provider,
+            'state' => $state,
+            'mock_url' => "/api/v0.2/integrations/{$provider}/oauth/callback?state={$state}&code=mock_code",
+        ]);
+    }
+
+    public function oauthCallback(Request $request, string $provider)
+    {
+        $state = (string) $request->query('state', '');
+        $code = (string) $request->query('code', '');
+        $userId = $this->resolveUserId($request);
+
+        $externalUserId = 'mock_' . substr(sha1($provider . '|' . $state . '|' . $code), 0, 12);
+        $scopes = ['mock_scope'];
+        $consentVersion = 'v0.1';
+
+        $consent = app(ConsentService::class)->recordConsent($userId, $provider, $consentVersion, $scopes);
+        if (($consent['ok'] ?? false) && Schema::hasTable('integrations')) {
+            DB::table('integrations')
+                ->where('user_id', $userId !== null ? (int) $userId : null)
+                ->where('provider', $provider)
+                ->update([
+                    'external_user_id' => $externalUserId,
+                    'status' => 'connected',
+                    'connected_at' => now(),
+                    'updated_at' => now(),
+                ]);
+        }
+
+        return response()->json([
+            'ok' => true,
+            'provider' => $provider,
+            'state' => $state,
+            'code' => $code,
+            'external_user_id' => $externalUserId,
+        ]);
+    }
+
+    public function revoke(Request $request, string $provider)
+    {
+        $userId = $this->resolveUserId($request);
+        $result = app(ConsentService::class)->revoke($userId, $provider);
+
+        return response()->json([
+            'ok' => $result['ok'] ?? false,
+            'provider' => $provider,
+            'user_id' => $userId,
+        ]);
+    }
+
+    public function ingest(Request $request, string $provider)
+    {
+        $userId = $this->resolveUserId($request);
+        $payload = $request->all();
+        if ($userId === null) {
+            $payloadUserId = (string) ($payload['user_id'] ?? '');
+            if ($payloadUserId !== '' && preg_match('/^\d+$/', $payloadUserId)) {
+                $userId = $payloadUserId;
+            }
+        }
+
+        $batchMeta = [
+            'range_start' => $payload['range_start'] ?? null,
+            'range_end' => $payload['range_end'] ?? null,
+            'raw_payload_hash' => IdempotencyKey::hashPayload($payload),
+        ];
+
+        $samples = $payload['samples'] ?? [];
+        if (!is_array($samples)) {
+            $samples = [];
+        }
+
+        $result = app(IngestionService::class)->ingestSamples($provider, $userId, $batchMeta, $samples);
+
+        return response()->json($result);
+    }
+
+    public function replay(Request $request, string $provider, string $batch_id)
+    {
+        $result = app(ReplayService::class)->replay($provider, $batch_id);
+        return response()->json($result);
+    }
+
+    private function resolveUserId(Request $request): ?string
+    {
+        $uid = $request->attributes->get('fm_user_id');
+        if (is_string($uid)) {
+            $uid = trim($uid);
+            if ($uid !== '' && preg_match('/^\d+$/', $uid)) return $uid;
+        }
+
+        $uid2 = $request->attributes->get('user_id');
+        if (is_string($uid2)) {
+            $uid2 = trim($uid2);
+            if ($uid2 !== '' && preg_match('/^\d+$/', $uid2)) return $uid2;
+        }
+
+        return null;
+    }
+}

--- a/backend/app/Http/Controllers/Webhooks/HandleProviderWebhook.php
+++ b/backend/app/Http/Controllers/Webhooks/HandleProviderWebhook.php
@@ -1,0 +1,92 @@
+<?php
+
+namespace App\Http\Controllers\Webhooks;
+
+use App\Http\Controllers\Controller;
+use App\Services\Ingestion\IngestionService;
+use App\Support\Idempotency\IdempotencyKey;
+use App\Support\Idempotency\IdempotencyStore;
+use Illuminate\Http\Request;
+
+class HandleProviderWebhook extends Controller
+{
+    public function handle(Request $request, string $provider)
+    {
+        $payload = $request->all();
+        $eventId = (string) ($payload['event_id'] ?? '');
+        $externalUserId = (string) ($payload['external_user_id'] ?? '');
+        $recordedAt = (string) ($payload['recorded_at'] ?? '');
+        $samples = $payload['samples'] ?? [];
+
+        if ($eventId === '' || $recordedAt === '') {
+            return response()->json([
+                'ok' => false,
+                'error' => 'INVALID_PAYLOAD',
+                'message' => 'event_id and recorded_at are required',
+            ], 422);
+        }
+
+        if (!$this->verifySignature($provider, $request)) {
+            return response()->json([
+                'ok' => false,
+                'error' => 'INVALID_SIGNATURE',
+                'message' => 'signature mismatch',
+            ], 401);
+        }
+
+        $idKey = IdempotencyKey::build($provider, $eventId, $recordedAt, $payload);
+        $store = new IdempotencyStore();
+        $existing = $store->find($idKey['provider'], $idKey['external_id'], $idKey['recorded_at'], $idKey['hash']);
+        if ($existing) {
+            $store->touch($idKey['provider'], $idKey['external_id'], $idKey['recorded_at'], $idKey['hash']);
+            return response()->json([
+                'ok' => true,
+                'status' => 'duplicate',
+                'event_id' => $eventId,
+            ]);
+        }
+
+        $store->record([
+            'provider' => $idKey['provider'],
+            'external_id' => $idKey['external_id'],
+            'recorded_at' => $idKey['recorded_at'],
+            'hash' => $idKey['hash'],
+            'ingest_batch_id' => null,
+        ]);
+
+        $batchMeta = [
+            'range_start' => $payload['range_start'] ?? null,
+            'range_end' => $payload['range_end'] ?? null,
+            'raw_payload_hash' => IdempotencyKey::hashPayload($payload),
+        ];
+
+        $result = app(IngestionService::class)->ingestSamples($provider, null, $batchMeta, is_array($samples) ? $samples : []);
+
+        return response()->json([
+            'ok' => true,
+            'event_id' => $eventId,
+            'external_user_id' => $externalUserId,
+            'batch_id' => $result['batch_id'] ?? null,
+            'inserted' => $result['inserted'] ?? 0,
+            'skipped' => $result['skipped'] ?? 0,
+        ]);
+    }
+
+    private function verifySignature(string $provider, Request $request): bool
+    {
+        $secret = (string) config("services.integrations.{$provider}.webhook_secret", '');
+        if ($secret === '') {
+            return true; // dev mode
+        }
+
+        $signature = (string) $request->header('X-Webhook-Signature', '');
+        if ($signature === '') {
+            return false;
+        }
+
+        $payload = $request->getContent();
+        $expected = hash_hmac('sha256', $payload, $secret);
+
+        return hash_equals($expected, $signature);
+    }
+}

--- a/backend/app/Http/Middleware/FmTokenAuth.php
+++ b/backend/app/Http/Middleware/FmTokenAuth.php
@@ -106,6 +106,12 @@ class FmTokenAuth
             if ($v !== '') return $v;
         }
 
+        // optional alias
+        if (property_exists($row, 'fm_user_id')) {
+            $v = trim((string) ($row->fm_user_id ?? ''));
+            if ($v !== '') return $v;
+        }
+
         // legacy candidates (keep numeric contract)
         foreach (['uid', 'user_uid', 'user'] as $c) {
             if (property_exists($row, $c)) {

--- a/backend/app/Services/Ingestion/ConsentService.php
+++ b/backend/app/Services/Ingestion/ConsentService.php
@@ -1,0 +1,80 @@
+<?php
+
+namespace App\Services\Ingestion;
+
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+class ConsentService
+{
+    public function recordConsent(?string $userId, string $provider, string $consentVersion, array $scopes): array
+    {
+        if (!Schema::hasTable('integrations')) {
+            return [
+                'ok' => false,
+                'error' => 'MISSING_TABLE',
+                'message' => 'integrations table not found',
+            ];
+        }
+
+        $now = now();
+        $payload = [
+            'user_id' => $userId !== null ? (int) $userId : null,
+            'provider' => $provider,
+            'status' => 'connected',
+            'scopes_json' => json_encode($scopes, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES),
+            'consent_version' => $consentVersion,
+            'connected_at' => $now,
+            'updated_at' => $now,
+            'created_at' => $now,
+        ];
+
+        $existing = DB::table('integrations')
+            ->where('user_id', $payload['user_id'])
+            ->where('provider', $provider)
+            ->first();
+
+        if ($existing) {
+            DB::table('integrations')
+                ->where('user_id', $payload['user_id'])
+                ->where('provider', $provider)
+                ->update($payload);
+        } else {
+            DB::table('integrations')->insert($payload);
+        }
+
+        return [
+            'ok' => true,
+            'user_id' => $payload['user_id'] ?? null,
+            'provider' => $provider,
+            'consent_version' => $consentVersion,
+        ];
+    }
+
+    public function revoke(?string $userId, string $provider): array
+    {
+        if (!Schema::hasTable('integrations')) {
+            return [
+                'ok' => false,
+                'error' => 'MISSING_TABLE',
+                'message' => 'integrations table not found',
+            ];
+        }
+
+        $now = now();
+        DB::table('integrations')
+            ->where('user_id', $userId !== null ? (int) $userId : null)
+            ->where('provider', $provider)
+            ->update([
+                'status' => 'revoked',
+                'revoked_at' => $now,
+                'updated_at' => $now,
+            ]);
+
+        return [
+            'ok' => true,
+            'user_id' => $userId !== null ? (int) $userId : null,
+            'provider' => $provider,
+        ];
+    }
+}

--- a/backend/app/Services/Ingestion/IngestionService.php
+++ b/backend/app/Services/Ingestion/IngestionService.php
@@ -1,0 +1,158 @@
+<?php
+
+namespace App\Services\Ingestion;
+
+use App\Support\Idempotency\IdempotencyKey;
+use App\Support\Idempotency\IdempotencyStore;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Support\Str;
+
+class IngestionService
+{
+    public function ingestSamples(string $provider, ?string $userId, array $batchMeta, array $samples): array
+    {
+        if (!Schema::hasTable('ingest_batches')) {
+            return [
+                'ok' => false,
+                'error' => 'MISSING_TABLE',
+                'message' => 'ingest_batches table not found',
+            ];
+        }
+
+        $batchId = (string) Str::uuid();
+        $rangeStart = $batchMeta['range_start'] ?? null;
+        $rangeEnd = $batchMeta['range_end'] ?? null;
+        if (is_string($rangeStart) && trim($rangeStart) !== '') {
+            $rangeStart = IdempotencyKey::normalizeRecordedAt($rangeStart);
+        } elseif ($rangeStart instanceof \DateTimeInterface) {
+            $rangeStart = IdempotencyKey::normalizeRecordedAt($rangeStart);
+        } else {
+            $rangeStart = null;
+        }
+        if (is_string($rangeEnd) && trim($rangeEnd) !== '') {
+            $rangeEnd = IdempotencyKey::normalizeRecordedAt($rangeEnd);
+        } elseif ($rangeEnd instanceof \DateTimeInterface) {
+            $rangeEnd = IdempotencyKey::normalizeRecordedAt($rangeEnd);
+        } else {
+            $rangeEnd = null;
+        }
+        $rawPayloadHash = $batchMeta['raw_payload_hash'] ?? null;
+
+        $now = now();
+        DB::table('ingest_batches')->insert([
+            'id' => $batchId,
+            'provider' => $provider,
+            'user_id' => $userId !== null ? (int) $userId : null,
+            'range_start' => $rangeStart,
+            'range_end' => $rangeEnd,
+            'raw_payload_hash' => $rawPayloadHash,
+            'status' => 'received',
+            'created_at' => $now,
+        ]);
+
+        $inserted = 0;
+        $skipped = 0;
+        $store = new IdempotencyStore();
+
+        foreach ($samples as $sample) {
+            if (!is_array($sample)) {
+                $skipped++;
+                continue;
+            }
+
+            $domain = (string) ($sample['domain'] ?? '');
+            $recordedAt = (string) ($sample['recorded_at'] ?? '');
+            $externalId = (string) ($sample['external_id'] ?? '');
+            $source = (string) ($sample['source'] ?? $provider);
+
+            if ($recordedAt === '') {
+                $skipped++;
+                continue;
+            }
+
+            $value = $sample['value'] ?? $sample;
+            $recordedAtNormalized = IdempotencyKey::normalizeRecordedAt($recordedAt);
+            $idKey = IdempotencyKey::build($provider, $externalId !== '' ? $externalId : $recordedAtNormalized, $recordedAtNormalized, $value);
+            $idRecord = $store->record([
+                'provider' => $idKey['provider'],
+                'external_id' => $idKey['external_id'],
+                'recorded_at' => $idKey['recorded_at'],
+                'hash' => $idKey['hash'],
+                'ingest_batch_id' => $batchId,
+            ]);
+
+            if (($idRecord['existing'] ?? false) === true) {
+                $skipped++;
+                continue;
+            }
+
+            $payloadHash = IdempotencyKey::hashPayload($value);
+            $confidence = (float) ($sample['confidence'] ?? 1.0);
+
+            if ($domain === 'sleep' && Schema::hasTable('sleep_samples')) {
+                DB::table('sleep_samples')->insert([
+                    'user_id' => $userId !== null ? (int) $userId : null,
+                    'source' => $source !== '' ? $source : 'ingestion',
+                    'recorded_at' => $recordedAtNormalized,
+                    'value_json' => json_encode($value, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES),
+                    'confidence' => $confidence,
+                    'raw_payload_hash' => $payloadHash,
+                    'ingest_batch_id' => $batchId,
+                    'created_at' => $now,
+                    'updated_at' => $now,
+                ]);
+                $inserted++;
+                continue;
+            }
+
+            if ($domain === 'screen_time' && Schema::hasTable('screen_time_samples')) {
+                DB::table('screen_time_samples')->insert([
+                    'user_id' => $userId !== null ? (int) $userId : null,
+                    'source' => $source !== '' ? $source : 'ingestion',
+                    'recorded_at' => $recordedAtNormalized,
+                    'value_json' => json_encode($value, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES),
+                    'confidence' => $confidence,
+                    'raw_payload_hash' => $payloadHash,
+                    'ingest_batch_id' => $batchId,
+                    'created_at' => $now,
+                    'updated_at' => $now,
+                ]);
+                $inserted++;
+                continue;
+            }
+
+            if (Schema::hasTable('health_samples')) {
+                DB::table('health_samples')->insert([
+                    'user_id' => $userId !== null ? (int) $userId : null,
+                    'source' => $source !== '' ? $source : 'ingestion',
+                    'domain' => $domain !== '' ? $domain : 'unknown',
+                    'recorded_at' => $recordedAtNormalized,
+                    'value_json' => json_encode($value, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES),
+                    'confidence' => $confidence,
+                    'raw_payload_hash' => $payloadHash,
+                    'ingest_batch_id' => $batchId,
+                    'created_at' => $now,
+                    'updated_at' => $now,
+                ]);
+                $inserted++;
+                continue;
+            }
+
+            $skipped++;
+        }
+
+        DB::table('ingest_batches')
+            ->where('id', $batchId)
+            ->update([
+                'status' => 'processed',
+            ]);
+
+        return [
+            'ok' => true,
+            'batch_id' => $batchId,
+            'inserted' => $inserted,
+            'skipped' => $skipped,
+        ];
+    }
+}

--- a/backend/app/Services/Ingestion/ReplayService.php
+++ b/backend/app/Services/Ingestion/ReplayService.php
@@ -1,0 +1,167 @@
+<?php
+
+namespace App\Services\Ingestion;
+
+use App\Support\Idempotency\IdempotencyKey;
+use App\Support\Idempotency\IdempotencyStore;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+class ReplayService
+{
+    public function replay(string $provider, string $batchId): array
+    {
+        if (!Schema::hasTable('ingest_batches')) {
+            return [
+                'ok' => false,
+                'error' => 'MISSING_TABLE',
+                'message' => 'ingest_batches table not found',
+            ];
+        }
+
+        $batch = DB::table('ingest_batches')->where('id', $batchId)->first();
+        if (!$batch) {
+            return [
+                'ok' => false,
+                'error' => 'NOT_FOUND',
+                'message' => 'ingest batch not found',
+            ];
+        }
+
+        $samples = [];
+        $samples = array_merge($samples, $this->loadSamples('sleep_samples', $batchId, 'sleep'));
+        $samples = array_merge($samples, $this->loadSamples('screen_time_samples', $batchId, 'screen_time'));
+        $samples = array_merge($samples, $this->loadSamples('health_samples', $batchId, 'health'));
+
+        $inserted = 0;
+        $skipped = 0;
+        $store = new IdempotencyStore();
+
+        foreach ($samples as $sample) {
+            $domain = (string) ($sample['domain'] ?? '');
+            $recordedAt = (string) ($sample['recorded_at'] ?? '');
+            $externalId = (string) ($sample['external_id'] ?? '');
+            $value = $sample['value'] ?? [];
+
+            $idKey = IdempotencyKey::build($provider, $externalId !== '' ? $externalId : $recordedAt, $recordedAt, $value);
+            $existing = $store->findByPayload($idKey['provider'], $idKey['recorded_at'], $idKey['hash']);
+            if ($existing) {
+                $store->touch($idKey['provider'], $idKey['external_id'], $idKey['recorded_at'], $idKey['hash']);
+                $skipped++;
+                continue;
+            }
+
+            $record = $store->record([
+                'provider' => $idKey['provider'],
+                'external_id' => $idKey['external_id'],
+                'recorded_at' => $idKey['recorded_at'],
+                'hash' => $idKey['hash'],
+                'ingest_batch_id' => $batchId,
+            ]);
+            if (($record['inserted'] ?? false) === false) {
+                $skipped++;
+                continue;
+            }
+
+            $payloadHash = IdempotencyKey::hashPayload($value);
+            $confidence = (float) ($sample['confidence'] ?? 1.0);
+            $userId = $sample['user_id'] ?? null;
+            $source = (string) ($sample['source'] ?? $provider);
+
+            if ($domain === 'sleep' && Schema::hasTable('sleep_samples')) {
+                DB::table('sleep_samples')->insert([
+                    'user_id' => $userId,
+                    'source' => $source !== '' ? $source : 'ingestion',
+                    'recorded_at' => $recordedAt,
+                    'value_json' => json_encode($value, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES),
+                    'confidence' => $confidence,
+                    'raw_payload_hash' => $payloadHash,
+                    'ingest_batch_id' => $batchId,
+                    'created_at' => now(),
+                    'updated_at' => now(),
+                ]);
+                $inserted++;
+                continue;
+            }
+
+            if ($domain === 'screen_time' && Schema::hasTable('screen_time_samples')) {
+                DB::table('screen_time_samples')->insert([
+                    'user_id' => $userId,
+                    'source' => $source !== '' ? $source : 'ingestion',
+                    'recorded_at' => $recordedAt,
+                    'value_json' => json_encode($value, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES),
+                    'confidence' => $confidence,
+                    'raw_payload_hash' => $payloadHash,
+                    'ingest_batch_id' => $batchId,
+                    'created_at' => now(),
+                    'updated_at' => now(),
+                ]);
+                $inserted++;
+                continue;
+            }
+
+            if (Schema::hasTable('health_samples')) {
+                DB::table('health_samples')->insert([
+                    'user_id' => $userId,
+                    'source' => $source !== '' ? $source : 'ingestion',
+                    'domain' => $domain !== '' ? $domain : 'unknown',
+                    'recorded_at' => $recordedAt,
+                    'value_json' => json_encode($value, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES),
+                    'confidence' => $confidence,
+                    'raw_payload_hash' => $payloadHash,
+                    'ingest_batch_id' => $batchId,
+                    'created_at' => now(),
+                    'updated_at' => now(),
+                ]);
+                $inserted++;
+                continue;
+            }
+
+            $skipped++;
+        }
+
+        DB::table('ingest_batches')
+            ->where('id', $batchId)
+            ->update([
+                'status' => 'replayed',
+            ]);
+
+        return [
+            'ok' => true,
+            'batch_id' => $batchId,
+            'inserted' => $inserted,
+            'skipped' => $skipped,
+        ];
+    }
+
+    private function loadSamples(string $table, string $batchId, string $domain): array
+    {
+        if (!Schema::hasTable($table)) {
+            return [];
+        }
+
+        $rows = DB::table($table)->where('ingest_batch_id', $batchId)->get();
+        $out = [];
+        foreach ($rows as $row) {
+            $value = [];
+            if (isset($row->value_json)) {
+                $decoded = json_decode((string) $row->value_json, true);
+                if (is_array($decoded)) {
+                    $value = $decoded;
+                }
+            }
+
+            $out[] = [
+                'domain' => $domain === 'health' ? ((string) ($row->domain ?? $domain)) : $domain,
+                'recorded_at' => (string) ($row->recorded_at ?? ''),
+                'external_id' => (string) ($row->id ?? ''),
+                'value' => $value,
+                'confidence' => (float) ($row->confidence ?? 1.0),
+                'user_id' => $row->user_id ?? null,
+                'source' => (string) ($row->source ?? ''),
+            ];
+        }
+
+        return $out;
+    }
+}

--- a/backend/app/Support/Idempotency/IdempotencyKey.php
+++ b/backend/app/Support/Idempotency/IdempotencyKey.php
@@ -1,0 +1,99 @@
+<?php
+
+namespace App\Support\Idempotency;
+
+use Carbon\Carbon;
+
+class IdempotencyKey
+{
+    /**
+     * Build a deterministic idempotency descriptor.
+     *
+     * Returns:
+     *  - provider
+     *  - external_id
+     *  - recorded_at (normalized)
+     *  - hash (sha256 of canonical payload)
+     *  - key (composite string)
+     */
+    public static function build(string $provider, string $externalId, $recordedAt, $payload): array
+    {
+        $provider = trim($provider);
+        $externalId = trim($externalId);
+        $recordedAtStr = self::normalizeRecordedAt($recordedAt);
+        $hash = self::hashPayload($payload);
+        $key = self::composeKey($provider, $externalId, $recordedAtStr, $hash);
+
+        return [
+            'provider' => $provider,
+            'external_id' => $externalId,
+            'recorded_at' => $recordedAtStr,
+            'hash' => $hash,
+            'key' => $key,
+        ];
+    }
+
+    public static function composeKey(string $provider, string $externalId, string $recordedAt, string $hash): string
+    {
+        return implode('|', [$provider, $externalId, $recordedAt, $hash]);
+    }
+
+    public static function hashPayload($payload): string
+    {
+        $canonical = self::canonicalJson($payload);
+        return hash('sha256', $canonical);
+    }
+
+    public static function canonicalJson($payload): string
+    {
+        $normalized = self::normalize($payload);
+        $json = json_encode($normalized, JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE);
+        if ($json === false) {
+            return '';
+        }
+        return $json;
+    }
+
+    public static function normalizeRecordedAt($value): string
+    {
+        if ($value instanceof \DateTimeInterface) {
+            return Carbon::instance($value)->toDateTimeString();
+        }
+
+        $s = trim((string) $value);
+        if ($s === '') {
+            return Carbon::now()->toDateTimeString();
+        }
+
+        try {
+            return Carbon::parse($s)->toDateTimeString();
+        } catch (\Throwable $e) {
+            return $s;
+        }
+    }
+
+    private static function normalize($value)
+    {
+        if (is_array($value)) {
+            $isAssoc = array_keys($value) !== range(0, count($value) - 1);
+            if ($isAssoc) {
+                ksort($value);
+            }
+            foreach ($value as $k => $v) {
+                $value[$k] = self::normalize($v);
+            }
+            return $value;
+        }
+
+        if (is_object($value)) {
+            $arr = (array) $value;
+            ksort($arr);
+            foreach ($arr as $k => $v) {
+                $arr[$k] = self::normalize($v);
+            }
+            return $arr;
+        }
+
+        return $value;
+    }
+}

--- a/backend/app/Support/Idempotency/IdempotencyStore.php
+++ b/backend/app/Support/Idempotency/IdempotencyStore.php
@@ -1,0 +1,99 @@
+<?php
+
+namespace App\Support\Idempotency;
+
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+class IdempotencyStore
+{
+    public function find(string $provider, string $externalId, string $recordedAt, string $hash): ?array
+    {
+        if (!Schema::hasTable('idempotency_keys')) {
+            return null;
+        }
+
+        $row = DB::table('idempotency_keys')
+            ->where('provider', $provider)
+            ->where('external_id', $externalId)
+            ->where('recorded_at', $recordedAt)
+            ->where('hash', $hash)
+            ->first();
+
+        if (!$row) {
+            return null;
+        }
+
+        return (array) $row;
+    }
+
+    public function findByPayload(string $provider, string $recordedAt, string $hash): ?array
+    {
+        if (!Schema::hasTable('idempotency_keys')) {
+            return null;
+        }
+
+        $row = DB::table('idempotency_keys')
+            ->where('provider', $provider)
+            ->where('recorded_at', $recordedAt)
+            ->where('hash', $hash)
+            ->first();
+
+        if (!$row) {
+            return null;
+        }
+
+        return (array) $row;
+    }
+
+    public function touch(string $provider, string $externalId, string $recordedAt, string $hash): void
+    {
+        if (!Schema::hasTable('idempotency_keys')) {
+            return;
+        }
+
+        DB::table('idempotency_keys')
+            ->where('provider', $provider)
+            ->where('external_id', $externalId)
+            ->where('recorded_at', $recordedAt)
+            ->where('hash', $hash)
+            ->update([
+                'last_seen_at' => now(),
+                'updated_at' => now(),
+            ]);
+    }
+
+    public function record(array $payload): array
+    {
+        if (!Schema::hasTable('idempotency_keys')) {
+            return ['inserted' => false, 'existing' => false];
+        }
+
+        $provider = (string) ($payload['provider'] ?? '');
+        $externalId = (string) ($payload['external_id'] ?? '');
+        $recordedAt = (string) ($payload['recorded_at'] ?? '');
+        $hash = (string) ($payload['hash'] ?? '');
+        $ingestBatchId = $payload['ingest_batch_id'] ?? null;
+
+        $existing = $this->find($provider, $externalId, $recordedAt, $hash);
+        if ($existing) {
+            $this->touch($provider, $externalId, $recordedAt, $hash);
+            return ['inserted' => false, 'existing' => true];
+        }
+
+        $now = now();
+        DB::table('idempotency_keys')->insert([
+            'provider' => $provider,
+            'external_id' => $externalId,
+            'recorded_at' => $recordedAt,
+            'hash' => $hash,
+            'first_seen_at' => $now,
+            'last_seen_at' => $now,
+            'ingest_batch_id' => $ingestBatchId,
+            'created_at' => $now,
+            'updated_at' => $now,
+        ]);
+
+        return ['inserted' => true, 'existing' => false];
+    }
+}

--- a/backend/database/migrations/2026_01_28_130000_create_integrations_tables.php
+++ b/backend/database/migrations/2026_01_28_130000_create_integrations_tables.php
@@ -1,0 +1,135 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        $driver = Schema::getConnection()->getDriverName();
+        $isSqlite = $driver === 'sqlite';
+
+        if (!Schema::hasTable('integrations')) {
+            Schema::create('integrations', function (Blueprint $table) use ($isSqlite) {
+                $table->unsignedBigInteger('user_id')->nullable();
+                $table->string('provider', 64);
+                $table->string('external_user_id', 128)->nullable();
+                $table->string('status', 32)->default('pending');
+                if ($isSqlite) {
+                    $table->text('scopes_json')->nullable();
+                } else {
+                    $table->json('scopes_json')->nullable();
+                }
+                $table->string('consent_version', 64)->nullable();
+                $table->timestamp('connected_at')->nullable();
+                $table->timestamp('revoked_at')->nullable();
+                $table->timestamps();
+            });
+        } else {
+            Schema::table('integrations', function (Blueprint $table) use ($isSqlite) {
+                if (!Schema::hasColumn('integrations', 'user_id')) {
+                    $table->unsignedBigInteger('user_id')->nullable();
+                }
+                if (!Schema::hasColumn('integrations', 'provider')) {
+                    $table->string('provider', 64);
+                }
+                if (!Schema::hasColumn('integrations', 'external_user_id')) {
+                    $table->string('external_user_id', 128)->nullable();
+                }
+                if (!Schema::hasColumn('integrations', 'status')) {
+                    $table->string('status', 32)->default('pending');
+                }
+                if (!Schema::hasColumn('integrations', 'scopes_json')) {
+                    if ($isSqlite) {
+                        $table->text('scopes_json')->nullable();
+                    } else {
+                        $table->json('scopes_json')->nullable();
+                    }
+                }
+                if (!Schema::hasColumn('integrations', 'consent_version')) {
+                    $table->string('consent_version', 64)->nullable();
+                }
+                if (!Schema::hasColumn('integrations', 'connected_at')) {
+                    $table->timestamp('connected_at')->nullable();
+                }
+                if (!Schema::hasColumn('integrations', 'revoked_at')) {
+                    $table->timestamp('revoked_at')->nullable();
+                }
+                if (!Schema::hasColumn('integrations', 'created_at')) {
+                    $table->timestamp('created_at')->nullable();
+                }
+                if (!Schema::hasColumn('integrations', 'updated_at')) {
+                    $table->timestamp('updated_at')->nullable();
+                }
+            });
+        }
+
+        $indexName = 'integrations_user_provider_unique';
+        if (
+            Schema::hasTable('integrations')
+            && Schema::hasColumn('integrations', 'user_id')
+            && Schema::hasColumn('integrations', 'provider')
+            && !$this->indexExists('integrations', $indexName)
+        ) {
+            Schema::table('integrations', function (Blueprint $table) use ($indexName) {
+                $table->unique(['user_id', 'provider'], $indexName);
+            });
+        }
+    }
+
+    public function down(): void
+    {
+        if (!Schema::hasTable('integrations')) {
+            return;
+        }
+
+        $indexName = 'integrations_user_provider_unique';
+        if ($this->indexExists('integrations', $indexName)) {
+            Schema::table('integrations', function (Blueprint $table) use ($indexName) {
+                $table->dropUnique($indexName);
+            });
+        }
+
+        Schema::dropIfExists('integrations');
+    }
+
+    private function indexExists(string $table, string $indexName): bool
+    {
+        $driver = Schema::getConnection()->getDriverName();
+
+        if ($driver === 'sqlite') {
+            $rows = DB::select("PRAGMA index_list('{$table}')");
+            foreach ($rows as $row) {
+                if ((string) ($row->name ?? '') === $indexName) {
+                    return true;
+                }
+            }
+            return false;
+        }
+
+        if ($driver === 'mysql') {
+            $rows = DB::select("SHOW INDEX FROM `{$table}`");
+            foreach ($rows as $row) {
+                if ((string) ($row->Key_name ?? '') === $indexName) {
+                    return true;
+                }
+            }
+            return false;
+        }
+
+        if ($driver === 'pgsql') {
+            $rows = DB::select('SELECT indexname FROM pg_indexes WHERE tablename = ?', [$table]);
+            foreach ($rows as $row) {
+                if ((string) ($row->indexname ?? '') === $indexName) {
+                    return true;
+                }
+            }
+            return false;
+        }
+
+        return false;
+    }
+};

--- a/backend/database/migrations/2026_01_28_130100_create_ingest_batches_table.php
+++ b/backend/database/migrations/2026_01_28_130100_create_ingest_batches_table.php
@@ -1,0 +1,120 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        $driver = Schema::getConnection()->getDriverName();
+        $isSqlite = $driver === 'sqlite';
+
+        if (!Schema::hasTable('ingest_batches')) {
+            Schema::create('ingest_batches', function (Blueprint $table) use ($isSqlite) {
+                $table->uuid('id')->primary();
+                $table->string('provider', 64);
+                $table->unsignedBigInteger('user_id')->nullable();
+                $table->timestamp('range_start')->nullable();
+                $table->timestamp('range_end')->nullable();
+                $table->string('raw_payload_hash', 64)->nullable();
+                $table->string('status', 32)->default('received');
+                $table->timestamp('created_at')->nullable();
+            });
+        } else {
+            Schema::table('ingest_batches', function (Blueprint $table) use ($isSqlite) {
+                if (!Schema::hasColumn('ingest_batches', 'id')) {
+                    $table->uuid('id')->primary();
+                }
+                if (!Schema::hasColumn('ingest_batches', 'provider')) {
+                    $table->string('provider', 64);
+                }
+                if (!Schema::hasColumn('ingest_batches', 'user_id')) {
+                    $table->unsignedBigInteger('user_id')->nullable();
+                }
+                if (!Schema::hasColumn('ingest_batches', 'range_start')) {
+                    $table->timestamp('range_start')->nullable();
+                }
+                if (!Schema::hasColumn('ingest_batches', 'range_end')) {
+                    $table->timestamp('range_end')->nullable();
+                }
+                if (!Schema::hasColumn('ingest_batches', 'raw_payload_hash')) {
+                    $table->string('raw_payload_hash', 64)->nullable();
+                }
+                if (!Schema::hasColumn('ingest_batches', 'status')) {
+                    $table->string('status', 32)->default('received');
+                }
+                if (!Schema::hasColumn('ingest_batches', 'created_at')) {
+                    $table->timestamp('created_at')->nullable();
+                }
+            });
+        }
+
+        $indexName = 'ingest_batches_provider_user_idx';
+        if (
+            Schema::hasTable('ingest_batches')
+            && Schema::hasColumn('ingest_batches', 'provider')
+            && Schema::hasColumn('ingest_batches', 'user_id')
+            && !$this->indexExists('ingest_batches', $indexName)
+        ) {
+            Schema::table('ingest_batches', function (Blueprint $table) use ($indexName) {
+                $table->index(['provider', 'user_id'], $indexName);
+            });
+        }
+    }
+
+    public function down(): void
+    {
+        if (!Schema::hasTable('ingest_batches')) {
+            return;
+        }
+
+        $indexName = 'ingest_batches_provider_user_idx';
+        if ($this->indexExists('ingest_batches', $indexName)) {
+            Schema::table('ingest_batches', function (Blueprint $table) use ($indexName) {
+                $table->dropIndex($indexName);
+            });
+        }
+
+        Schema::dropIfExists('ingest_batches');
+    }
+
+    private function indexExists(string $table, string $indexName): bool
+    {
+        $driver = Schema::getConnection()->getDriverName();
+
+        if ($driver === 'sqlite') {
+            $rows = DB::select("PRAGMA index_list('{$table}')");
+            foreach ($rows as $row) {
+                if ((string) ($row->name ?? '') === $indexName) {
+                    return true;
+                }
+            }
+            return false;
+        }
+
+        if ($driver === 'mysql') {
+            $rows = DB::select("SHOW INDEX FROM `{$table}`");
+            foreach ($rows as $row) {
+                if ((string) ($row->Key_name ?? '') === $indexName) {
+                    return true;
+                }
+            }
+            return false;
+        }
+
+        if ($driver === 'pgsql') {
+            $rows = DB::select('SELECT indexname FROM pg_indexes WHERE tablename = ?', [$table]);
+            foreach ($rows as $row) {
+                if ((string) ($row->indexname ?? '') === $indexName) {
+                    return true;
+                }
+            }
+            return false;
+        }
+
+        return false;
+    }
+};

--- a/backend/database/migrations/2026_01_28_130200_create_sleep_samples_table.php
+++ b/backend/database/migrations/2026_01_28_130200_create_sleep_samples_table.php
@@ -1,0 +1,135 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        $driver = Schema::getConnection()->getDriverName();
+        $isSqlite = $driver === 'sqlite';
+
+        if (!Schema::hasTable('sleep_samples')) {
+            Schema::create('sleep_samples', function (Blueprint $table) use ($isSqlite) {
+                $table->bigIncrements('id');
+                $table->unsignedBigInteger('user_id')->nullable();
+                $table->string('source', 64)->default('ingestion');
+                $table->timestamp('recorded_at');
+                if ($isSqlite) {
+                    $table->text('value_json');
+                } else {
+                    $table->json('value_json');
+                }
+                $table->decimal('confidence', 4, 2)->default(1.0);
+                $table->string('raw_payload_hash', 64)->nullable();
+                $table->uuid('ingest_batch_id')->nullable();
+                $table->timestamps();
+            });
+        } else {
+            Schema::table('sleep_samples', function (Blueprint $table) use ($isSqlite) {
+                if (!Schema::hasColumn('sleep_samples', 'id')) {
+                    $table->bigIncrements('id');
+                }
+                if (!Schema::hasColumn('sleep_samples', 'user_id')) {
+                    $table->unsignedBigInteger('user_id')->nullable();
+                }
+                if (!Schema::hasColumn('sleep_samples', 'source')) {
+                    $table->string('source', 64)->default('ingestion');
+                }
+                if (!Schema::hasColumn('sleep_samples', 'recorded_at')) {
+                    $table->timestamp('recorded_at');
+                }
+                if (!Schema::hasColumn('sleep_samples', 'value_json')) {
+                    if ($isSqlite) {
+                        $table->text('value_json');
+                    } else {
+                        $table->json('value_json');
+                    }
+                }
+                if (!Schema::hasColumn('sleep_samples', 'confidence')) {
+                    $table->decimal('confidence', 4, 2)->default(1.0);
+                }
+                if (!Schema::hasColumn('sleep_samples', 'raw_payload_hash')) {
+                    $table->string('raw_payload_hash', 64)->nullable();
+                }
+                if (!Schema::hasColumn('sleep_samples', 'ingest_batch_id')) {
+                    $table->uuid('ingest_batch_id')->nullable();
+                }
+                if (!Schema::hasColumn('sleep_samples', 'created_at')) {
+                    $table->timestamp('created_at')->nullable();
+                }
+                if (!Schema::hasColumn('sleep_samples', 'updated_at')) {
+                    $table->timestamp('updated_at')->nullable();
+                }
+            });
+        }
+
+        $indexName = 'sleep_samples_user_recorded_idx';
+        if (
+            Schema::hasTable('sleep_samples')
+            && Schema::hasColumn('sleep_samples', 'user_id')
+            && Schema::hasColumn('sleep_samples', 'recorded_at')
+            && !$this->indexExists('sleep_samples', $indexName)
+        ) {
+            Schema::table('sleep_samples', function (Blueprint $table) use ($indexName) {
+                $table->index(['user_id', 'recorded_at'], $indexName);
+            });
+        }
+    }
+
+    public function down(): void
+    {
+        if (!Schema::hasTable('sleep_samples')) {
+            return;
+        }
+
+        $indexName = 'sleep_samples_user_recorded_idx';
+        if ($this->indexExists('sleep_samples', $indexName)) {
+            Schema::table('sleep_samples', function (Blueprint $table) use ($indexName) {
+                $table->dropIndex($indexName);
+            });
+        }
+
+        Schema::dropIfExists('sleep_samples');
+    }
+
+    private function indexExists(string $table, string $indexName): bool
+    {
+        $driver = Schema::getConnection()->getDriverName();
+
+        if ($driver === 'sqlite') {
+            $rows = DB::select("PRAGMA index_list('{$table}')");
+            foreach ($rows as $row) {
+                if ((string) ($row->name ?? '') === $indexName) {
+                    return true;
+                }
+            }
+            return false;
+        }
+
+        if ($driver === 'mysql') {
+            $rows = DB::select("SHOW INDEX FROM `{$table}`");
+            foreach ($rows as $row) {
+                if ((string) ($row->Key_name ?? '') === $indexName) {
+                    return true;
+                }
+            }
+            return false;
+        }
+
+        if ($driver === 'pgsql') {
+            $rows = DB::select('SELECT indexname FROM pg_indexes WHERE tablename = ?', [$table]);
+            foreach ($rows as $row) {
+                if ((string) ($row->indexname ?? '') === $indexName) {
+                    return true;
+                }
+            }
+            return false;
+        }
+
+        return false;
+    }
+};

--- a/backend/database/migrations/2026_01_28_130300_create_health_samples_table.php
+++ b/backend/database/migrations/2026_01_28_130300_create_health_samples_table.php
@@ -1,0 +1,139 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        $driver = Schema::getConnection()->getDriverName();
+        $isSqlite = $driver === 'sqlite';
+
+        if (!Schema::hasTable('health_samples')) {
+            Schema::create('health_samples', function (Blueprint $table) use ($isSqlite) {
+                $table->bigIncrements('id');
+                $table->unsignedBigInteger('user_id')->nullable();
+                $table->string('source', 64)->default('ingestion');
+                $table->string('domain', 64)->default('unknown');
+                $table->timestamp('recorded_at');
+                if ($isSqlite) {
+                    $table->text('value_json');
+                } else {
+                    $table->json('value_json');
+                }
+                $table->decimal('confidence', 4, 2)->default(1.0);
+                $table->string('raw_payload_hash', 64)->nullable();
+                $table->uuid('ingest_batch_id')->nullable();
+                $table->timestamps();
+            });
+        } else {
+            Schema::table('health_samples', function (Blueprint $table) use ($isSqlite) {
+                if (!Schema::hasColumn('health_samples', 'id')) {
+                    $table->bigIncrements('id');
+                }
+                if (!Schema::hasColumn('health_samples', 'user_id')) {
+                    $table->unsignedBigInteger('user_id')->nullable();
+                }
+                if (!Schema::hasColumn('health_samples', 'source')) {
+                    $table->string('source', 64)->default('ingestion');
+                }
+                if (!Schema::hasColumn('health_samples', 'domain')) {
+                    $table->string('domain', 64)->default('unknown');
+                }
+                if (!Schema::hasColumn('health_samples', 'recorded_at')) {
+                    $table->timestamp('recorded_at');
+                }
+                if (!Schema::hasColumn('health_samples', 'value_json')) {
+                    if ($isSqlite) {
+                        $table->text('value_json');
+                    } else {
+                        $table->json('value_json');
+                    }
+                }
+                if (!Schema::hasColumn('health_samples', 'confidence')) {
+                    $table->decimal('confidence', 4, 2)->default(1.0);
+                }
+                if (!Schema::hasColumn('health_samples', 'raw_payload_hash')) {
+                    $table->string('raw_payload_hash', 64)->nullable();
+                }
+                if (!Schema::hasColumn('health_samples', 'ingest_batch_id')) {
+                    $table->uuid('ingest_batch_id')->nullable();
+                }
+                if (!Schema::hasColumn('health_samples', 'created_at')) {
+                    $table->timestamp('created_at')->nullable();
+                }
+                if (!Schema::hasColumn('health_samples', 'updated_at')) {
+                    $table->timestamp('updated_at')->nullable();
+                }
+            });
+        }
+
+        $indexName = 'health_samples_user_recorded_idx';
+        if (
+            Schema::hasTable('health_samples')
+            && Schema::hasColumn('health_samples', 'user_id')
+            && Schema::hasColumn('health_samples', 'recorded_at')
+            && !$this->indexExists('health_samples', $indexName)
+        ) {
+            Schema::table('health_samples', function (Blueprint $table) use ($indexName) {
+                $table->index(['user_id', 'recorded_at'], $indexName);
+            });
+        }
+    }
+
+    public function down(): void
+    {
+        if (!Schema::hasTable('health_samples')) {
+            return;
+        }
+
+        $indexName = 'health_samples_user_recorded_idx';
+        if ($this->indexExists('health_samples', $indexName)) {
+            Schema::table('health_samples', function (Blueprint $table) use ($indexName) {
+                $table->dropIndex($indexName);
+            });
+        }
+
+        Schema::dropIfExists('health_samples');
+    }
+
+    private function indexExists(string $table, string $indexName): bool
+    {
+        $driver = Schema::getConnection()->getDriverName();
+
+        if ($driver === 'sqlite') {
+            $rows = DB::select("PRAGMA index_list('{$table}')");
+            foreach ($rows as $row) {
+                if ((string) ($row->name ?? '') === $indexName) {
+                    return true;
+                }
+            }
+            return false;
+        }
+
+        if ($driver === 'mysql') {
+            $rows = DB::select("SHOW INDEX FROM `{$table}`");
+            foreach ($rows as $row) {
+                if ((string) ($row->Key_name ?? '') === $indexName) {
+                    return true;
+                }
+            }
+            return false;
+        }
+
+        if ($driver === 'pgsql') {
+            $rows = DB::select('SELECT indexname FROM pg_indexes WHERE tablename = ?', [$table]);
+            foreach ($rows as $row) {
+                if ((string) ($row->indexname ?? '') === $indexName) {
+                    return true;
+                }
+            }
+            return false;
+        }
+
+        return false;
+    }
+};

--- a/backend/database/migrations/2026_01_28_130400_create_screen_time_samples_table.php
+++ b/backend/database/migrations/2026_01_28_130400_create_screen_time_samples_table.php
@@ -1,0 +1,135 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        $driver = Schema::getConnection()->getDriverName();
+        $isSqlite = $driver === 'sqlite';
+
+        if (!Schema::hasTable('screen_time_samples')) {
+            Schema::create('screen_time_samples', function (Blueprint $table) use ($isSqlite) {
+                $table->bigIncrements('id');
+                $table->unsignedBigInteger('user_id')->nullable();
+                $table->string('source', 64)->default('ingestion');
+                $table->timestamp('recorded_at');
+                if ($isSqlite) {
+                    $table->text('value_json');
+                } else {
+                    $table->json('value_json');
+                }
+                $table->decimal('confidence', 4, 2)->default(1.0);
+                $table->string('raw_payload_hash', 64)->nullable();
+                $table->uuid('ingest_batch_id')->nullable();
+                $table->timestamps();
+            });
+        } else {
+            Schema::table('screen_time_samples', function (Blueprint $table) use ($isSqlite) {
+                if (!Schema::hasColumn('screen_time_samples', 'id')) {
+                    $table->bigIncrements('id');
+                }
+                if (!Schema::hasColumn('screen_time_samples', 'user_id')) {
+                    $table->unsignedBigInteger('user_id')->nullable();
+                }
+                if (!Schema::hasColumn('screen_time_samples', 'source')) {
+                    $table->string('source', 64)->default('ingestion');
+                }
+                if (!Schema::hasColumn('screen_time_samples', 'recorded_at')) {
+                    $table->timestamp('recorded_at');
+                }
+                if (!Schema::hasColumn('screen_time_samples', 'value_json')) {
+                    if ($isSqlite) {
+                        $table->text('value_json');
+                    } else {
+                        $table->json('value_json');
+                    }
+                }
+                if (!Schema::hasColumn('screen_time_samples', 'confidence')) {
+                    $table->decimal('confidence', 4, 2)->default(1.0);
+                }
+                if (!Schema::hasColumn('screen_time_samples', 'raw_payload_hash')) {
+                    $table->string('raw_payload_hash', 64)->nullable();
+                }
+                if (!Schema::hasColumn('screen_time_samples', 'ingest_batch_id')) {
+                    $table->uuid('ingest_batch_id')->nullable();
+                }
+                if (!Schema::hasColumn('screen_time_samples', 'created_at')) {
+                    $table->timestamp('created_at')->nullable();
+                }
+                if (!Schema::hasColumn('screen_time_samples', 'updated_at')) {
+                    $table->timestamp('updated_at')->nullable();
+                }
+            });
+        }
+
+        $indexName = 'screen_time_samples_user_recorded_idx';
+        if (
+            Schema::hasTable('screen_time_samples')
+            && Schema::hasColumn('screen_time_samples', 'user_id')
+            && Schema::hasColumn('screen_time_samples', 'recorded_at')
+            && !$this->indexExists('screen_time_samples', $indexName)
+        ) {
+            Schema::table('screen_time_samples', function (Blueprint $table) use ($indexName) {
+                $table->index(['user_id', 'recorded_at'], $indexName);
+            });
+        }
+    }
+
+    public function down(): void
+    {
+        if (!Schema::hasTable('screen_time_samples')) {
+            return;
+        }
+
+        $indexName = 'screen_time_samples_user_recorded_idx';
+        if ($this->indexExists('screen_time_samples', $indexName)) {
+            Schema::table('screen_time_samples', function (Blueprint $table) use ($indexName) {
+                $table->dropIndex($indexName);
+            });
+        }
+
+        Schema::dropIfExists('screen_time_samples');
+    }
+
+    private function indexExists(string $table, string $indexName): bool
+    {
+        $driver = Schema::getConnection()->getDriverName();
+
+        if ($driver === 'sqlite') {
+            $rows = DB::select("PRAGMA index_list('{$table}')");
+            foreach ($rows as $row) {
+                if ((string) ($row->name ?? '') === $indexName) {
+                    return true;
+                }
+            }
+            return false;
+        }
+
+        if ($driver === 'mysql') {
+            $rows = DB::select("SHOW INDEX FROM `{$table}`");
+            foreach ($rows as $row) {
+                if ((string) ($row->Key_name ?? '') === $indexName) {
+                    return true;
+                }
+            }
+            return false;
+        }
+
+        if ($driver === 'pgsql') {
+            $rows = DB::select('SELECT indexname FROM pg_indexes WHERE tablename = ?', [$table]);
+            foreach ($rows as $row) {
+                if ((string) ($row->indexname ?? '') === $indexName) {
+                    return true;
+                }
+            }
+            return false;
+        }
+
+        return false;
+    }
+};

--- a/backend/database/migrations/2026_01_28_130500_create_idempotency_keys_table.php
+++ b/backend/database/migrations/2026_01_28_130500_create_idempotency_keys_table.php
@@ -1,0 +1,148 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        $driver = Schema::getConnection()->getDriverName();
+        $isSqlite = $driver === 'sqlite';
+
+        if (!Schema::hasTable('idempotency_keys')) {
+            Schema::create('idempotency_keys', function (Blueprint $table) {
+                $table->bigIncrements('id');
+                $table->string('provider', 64);
+                $table->string('external_id', 128);
+                $table->timestamp('recorded_at');
+                $table->string('hash', 64);
+                $table->timestamp('first_seen_at')->nullable();
+                $table->timestamp('last_seen_at')->nullable();
+                $table->uuid('ingest_batch_id')->nullable();
+                $table->timestamps();
+            });
+        } else {
+            Schema::table('idempotency_keys', function (Blueprint $table) {
+                if (!Schema::hasColumn('idempotency_keys', 'id')) {
+                    $table->bigIncrements('id');
+                }
+                if (!Schema::hasColumn('idempotency_keys', 'provider')) {
+                    $table->string('provider', 64);
+                }
+                if (!Schema::hasColumn('idempotency_keys', 'external_id')) {
+                    $table->string('external_id', 128);
+                }
+                if (!Schema::hasColumn('idempotency_keys', 'recorded_at')) {
+                    $table->timestamp('recorded_at');
+                }
+                if (!Schema::hasColumn('idempotency_keys', 'hash')) {
+                    $table->string('hash', 64);
+                }
+                if (!Schema::hasColumn('idempotency_keys', 'first_seen_at')) {
+                    $table->timestamp('first_seen_at')->nullable();
+                }
+                if (!Schema::hasColumn('idempotency_keys', 'last_seen_at')) {
+                    $table->timestamp('last_seen_at')->nullable();
+                }
+                if (!Schema::hasColumn('idempotency_keys', 'ingest_batch_id')) {
+                    $table->uuid('ingest_batch_id')->nullable();
+                }
+                if (!Schema::hasColumn('idempotency_keys', 'created_at')) {
+                    $table->timestamp('created_at')->nullable();
+                }
+                if (!Schema::hasColumn('idempotency_keys', 'updated_at')) {
+                    $table->timestamp('updated_at')->nullable();
+                }
+            });
+        }
+
+        $uniqueName = 'idempotency_keys_unique';
+        if (
+            Schema::hasTable('idempotency_keys')
+            && Schema::hasColumn('idempotency_keys', 'provider')
+            && Schema::hasColumn('idempotency_keys', 'external_id')
+            && Schema::hasColumn('idempotency_keys', 'recorded_at')
+            && Schema::hasColumn('idempotency_keys', 'hash')
+            && !$this->indexExists('idempotency_keys', $uniqueName)
+        ) {
+            Schema::table('idempotency_keys', function (Blueprint $table) use ($uniqueName) {
+                $table->unique(['provider', 'external_id', 'recorded_at', 'hash'], $uniqueName);
+            });
+        }
+
+        $lookupName = 'idempotency_keys_lookup_idx';
+        if (
+            Schema::hasTable('idempotency_keys')
+            && Schema::hasColumn('idempotency_keys', 'provider')
+            && Schema::hasColumn('idempotency_keys', 'external_id')
+            && !$this->indexExists('idempotency_keys', $lookupName)
+        ) {
+            Schema::table('idempotency_keys', function (Blueprint $table) use ($lookupName) {
+                $table->index(['provider', 'external_id'], $lookupName);
+            });
+        }
+    }
+
+    public function down(): void
+    {
+        if (!Schema::hasTable('idempotency_keys')) {
+            return;
+        }
+
+        $uniqueName = 'idempotency_keys_unique';
+        if ($this->indexExists('idempotency_keys', $uniqueName)) {
+            Schema::table('idempotency_keys', function (Blueprint $table) use ($uniqueName) {
+                $table->dropUnique($uniqueName);
+            });
+        }
+
+        $lookupName = 'idempotency_keys_lookup_idx';
+        if ($this->indexExists('idempotency_keys', $lookupName)) {
+            Schema::table('idempotency_keys', function (Blueprint $table) use ($lookupName) {
+                $table->dropIndex($lookupName);
+            });
+        }
+
+        Schema::dropIfExists('idempotency_keys');
+    }
+
+    private function indexExists(string $table, string $indexName): bool
+    {
+        $driver = Schema::getConnection()->getDriverName();
+
+        if ($driver === 'sqlite') {
+            $rows = DB::select("PRAGMA index_list('{$table}')");
+            foreach ($rows as $row) {
+                if ((string) ($row->name ?? '') === $indexName) {
+                    return true;
+                }
+            }
+            return false;
+        }
+
+        if ($driver === 'mysql') {
+            $rows = DB::select("SHOW INDEX FROM `{$table}`");
+            foreach ($rows as $row) {
+                if ((string) ($row->Key_name ?? '') === $indexName) {
+                    return true;
+                }
+            }
+            return false;
+        }
+
+        if ($driver === 'pgsql') {
+            $rows = DB::select('SELECT indexname FROM pg_indexes WHERE tablename = ?', [$table]);
+            foreach ($rows as $row) {
+                if ((string) ($row->indexname ?? '') === $indexName) {
+                    return true;
+                }
+            }
+            return false;
+        }
+
+        return false;
+    }
+};

--- a/backend/database/seeders/QuantifiedSelfSeeder.php
+++ b/backend/database/seeders/QuantifiedSelfSeeder.php
@@ -1,0 +1,101 @@
+<?php
+
+namespace Database\Seeders;
+
+use Illuminate\Database\Seeder;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+class QuantifiedSelfSeeder extends Seeder
+{
+    public function run(): void
+    {
+        $userId = 1;
+        $now = now()->startOfDay();
+
+        mt_srand(13);
+
+        if (!Schema::hasTable('sleep_samples') || !Schema::hasTable('health_samples') || !Schema::hasTable('screen_time_samples')) {
+            $this->command?->warn('QuantifiedSelfSeeder skipped: missing tables.');
+            return;
+        }
+
+        for ($i = 0; $i < 30; $i++) {
+            $day = $now->copy()->subDays($i);
+            $dateStr = $day->format('Y-m-d');
+
+            // Sleep sample (nightly)
+            $sleepStart = $day->copy()->subHours(7 + ($i % 3))->setTime(23, 0);
+            $sleepEnd = $day->copy()->setTime(7, 0);
+            $durationMinutes = $sleepEnd->diffInMinutes($sleepStart);
+            DB::table('sleep_samples')->insert([
+                'user_id' => $userId,
+                'source' => 'seed',
+                'recorded_at' => $day->copy()->setTime(8, 0),
+                'value_json' => json_encode([
+                    'start' => $sleepStart->toDateTimeString(),
+                    'end' => $sleepEnd->toDateTimeString(),
+                    'duration_minutes' => $durationMinutes,
+                ], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES),
+                'confidence' => 0.95,
+                'raw_payload_hash' => hash('sha256', $dateStr . '|sleep'),
+                'ingest_batch_id' => null,
+                'created_at' => now(),
+                'updated_at' => now(),
+            ]);
+
+            // Health samples: steps (daily)
+            $steps = 4000 + ($i * 137) % 6000;
+            DB::table('health_samples')->insert([
+                'user_id' => $userId,
+                'source' => 'seed',
+                'domain' => 'steps',
+                'recorded_at' => $day->copy()->setTime(12, 0),
+                'value_json' => json_encode([
+                    'steps' => $steps,
+                ], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES),
+                'confidence' => 0.98,
+                'raw_payload_hash' => hash('sha256', $dateStr . '|steps'),
+                'ingest_batch_id' => null,
+                'created_at' => now(),
+                'updated_at' => now(),
+            ]);
+
+            // Health samples: heart rate (5 samples)
+            for ($j = 0; $j < 5; $j++) {
+                $minute = 10 + $j * 8;
+                $bpm = 62 + (($i + $j) % 12);
+                DB::table('health_samples')->insert([
+                    'user_id' => $userId,
+                    'source' => 'seed',
+                    'domain' => 'heart_rate',
+                    'recorded_at' => $day->copy()->setTime(9, $minute),
+                    'value_json' => json_encode([
+                        'bpm' => $bpm,
+                    ], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES),
+                    'confidence' => 0.96,
+                    'raw_payload_hash' => hash('sha256', $dateStr . '|hr|' . $j),
+                    'ingest_batch_id' => null,
+                    'created_at' => now(),
+                    'updated_at' => now(),
+                ]);
+            }
+
+            // Screen time sample (daily)
+            $screenMinutes = 120 + (($i * 23) % 180);
+            DB::table('screen_time_samples')->insert([
+                'user_id' => $userId,
+                'source' => 'seed',
+                'recorded_at' => $day->copy()->setTime(22, 0),
+                'value_json' => json_encode([
+                    'total_screen_minutes' => $screenMinutes,
+                ], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES),
+                'confidence' => 0.9,
+                'raw_payload_hash' => hash('sha256', $dateStr . '|screen'),
+                'ingest_batch_id' => null,
+                'created_at' => now(),
+                'updated_at' => now(),
+            ]);
+        }
+    }
+}

--- a/backend/routes/api.php
+++ b/backend/routes/api.php
@@ -22,6 +22,8 @@ use App\Http\Controllers\API\V0_2\Admin\AdminOpsController;
 use App\Http\Controllers\API\V0_2\Admin\AdminAuditController;
 use App\Http\Controllers\API\V0_2\Admin\AdminEventsController;
 use App\Http\Controllers\API\V0_2\Admin\AdminContentController;
+use App\Http\Controllers\Integrations\ProvidersController;
+use App\Http\Controllers\Webhooks\HandleProviderWebhook;
 
 /*
 |--------------------------------------------------------------------------
@@ -121,6 +123,22 @@ Route::prefix("v0.2")->group(function () {
     Route::post("/payments/webhook/mock", [PaymentsController::class, "webhookMock"]);
 
     // =========================================================
+    // Integrations (mock OAuth + ingestion + replay)
+    // =========================================================
+    Route::prefix("integrations/{provider}")->group(function () {
+        Route::get("/oauth/start", [ProvidersController::class, "oauthStart"]);
+        Route::get("/oauth/callback", [ProvidersController::class, "oauthCallback"]);
+        Route::post("/revoke", [ProvidersController::class, "revoke"]);
+        Route::post("/ingest", [ProvidersController::class, "ingest"]);
+        Route::post("/replay/{batch_id}", [ProvidersController::class, "replay"]);
+    });
+
+    // =========================================================
+    // Webhooks (provider push)
+    // =========================================================
+    Route::post("/webhooks/{provider}", [HandleProviderWebhook::class, "handle"]);
+
+    // =========================================================
     // AI Insights (async, budget guarded)
     // =========================================================
     Route::middleware('App\\Http\\Middleware\\CheckAiBudget')->group(function () {
@@ -149,6 +167,9 @@ Route::prefix("v0.2")->group(function () {
         Route::post("/me/email/bind", [MeController::class, "bindEmail"]);
         Route::post("/me/identities/bind", [IdentityController::class, "bind"]);
         Route::get("/me/identities", [IdentityController::class, "index"]);
+        Route::get("/me/data/sleep", [MeController::class, "sleepData"]);
+        Route::get("/me/data/mood", [MeController::class, "moodData"]);
+        Route::get("/me/data/screen-time", [MeController::class, "screenTimeData"]);
 
         // Attempts gated endpoints
         Route::post("/attempts/{id}/result", [MbtiController::class, "upsertResult"]);

--- a/backend/scripts/pr13_verify_ingestion.sh
+++ b/backend/scripts/pr13_verify_ingestion.sh
@@ -1,0 +1,153 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+BACKEND_DIR="${ROOT_DIR}/backend"
+ART_DIR="${BACKEND_DIR}/artifacts/pr13"
+LOG_DIR="${ART_DIR}/logs"
+SERVER_LOG="${LOG_DIR}/server.log"
+
+mkdir -p "${LOG_DIR}"
+
+PORT="${PORT:-18030}"
+HOST="127.0.0.1"
+
+detect_port() {
+  local p="${PORT}"
+  for i in $(seq 0 29); do
+    local try=$((p + i))
+    if ! lsof -iTCP -sTCP:LISTEN -n -P 2>/dev/null | rg -q ":${try}"; then
+      PORT="${try}"
+      return 0
+    fi
+  done
+  echo "No available port in 18030-18059" >&2
+  exit 1
+}
+
+start_server() {
+  detect_port
+  cd "${BACKEND_DIR}"
+  php artisan serve --host="${HOST}" --port="${PORT}" >"${SERVER_LOG}" 2>&1 &
+  SERVER_PID=$!
+  echo "${SERVER_PID}" > "${ART_DIR}/server.pid"
+  sleep 2
+}
+
+stop_server() {
+  if [[ -f "${ART_DIR}/server.pid" ]]; then
+    local pid
+    pid="$(cat "${ART_DIR}/server.pid")"
+    if kill -0 "${pid}" 2>/dev/null; then
+      kill "${pid}" || true
+    fi
+    rm -f "${ART_DIR}/server.pid"
+  fi
+}
+
+cleanup() {
+  stop_server
+}
+
+trap cleanup EXIT
+
+cd "${BACKEND_DIR}"
+php artisan migrate
+php artisan db:seed --class=QuantifiedSelfSeeder
+
+start_server
+
+BASE_URL="http://${HOST}:${PORT}/api/v0.2"
+
+oauth_start=$(curl -s "${BASE_URL}/integrations/mock/oauth/start")
+state=$(echo "${oauth_start}" | php -r 'echo json_decode(stream_get_contents(STDIN), true)["state"] ?? "";')
+oauth_cb=$(curl -s "${BASE_URL}/integrations/mock/oauth/callback?state=${state}&code=mock_code")
+
+phone_send=$(curl -s -X POST "${BASE_URL}/auth/phone/send_code" -H "Content-Type: application/json" -d '{"phone":"15500000001","scene":"login","anon_id":"anon_pr13","consent":true}')
+dev_code=$(echo "${phone_send}" | php -r 'echo json_decode(stream_get_contents(STDIN), true)["dev_code"] ?? "";')
+phone_verify=$(curl -s -X POST "${BASE_URL}/auth/phone/verify" -H "Content-Type: application/json" -d "{\"phone\":\"15500000001\",\"code\":\"${dev_code}\",\"scene\":\"login\",\"anon_id\":\"anon_pr13\",\"consent\":true}")
+fm_token=$(echo "${phone_verify}" | php -r 'echo json_decode(stream_get_contents(STDIN), true)["token"] ?? "";')
+user_id=$(echo "${phone_verify}" | php -r 'echo json_decode(stream_get_contents(STDIN), true)["user"]["uid"] ?? "";')
+if [[ -z "${fm_token}" ]]; then
+  echo "Failed to get fm_token from phone_verify" >&2
+  echo "phone_send=${phone_send}" >&2
+  echo "phone_verify=${phone_verify}" >&2
+  exit 1
+fi
+if [[ -z "${user_id}" ]]; then
+  echo "Failed to get user_id from phone_verify" >&2
+  echo "phone_verify=${phone_verify}" >&2
+  exit 1
+fi
+
+payload="{\"user_id\":${user_id},\"range_start\":\"2026-01-01T00:00:00Z\",\"range_end\":\"2026-01-10T00:00:00Z\",\"samples\":[{\"domain\":\"sleep\",\"recorded_at\":\"2026-01-10T00:00:00Z\",\"value\":{\"duration_minutes\":420},\"external_id\":\"sleep_1\"},{\"domain\":\"screen_time\",\"recorded_at\":\"2026-01-10T00:00:00Z\",\"value\":{\"total_screen_minutes\":180},\"external_id\":\"screen_1\"},{\"domain\":\"steps\",\"recorded_at\":\"2026-01-10T00:00:00Z\",\"value\":{\"steps\":8000},\"external_id\":\"steps_1\"},{\"domain\":\"heart_rate\",\"recorded_at\":\"2026-01-10T01:00:00Z\",\"value\":{\"bpm\":72},\"external_id\":\"hr_1\"},{\"domain\":\"mood\",\"recorded_at\":\"2026-01-10T02:00:00Z\",\"value\":{\"score\":4},\"external_id\":\"mood_1\"},{\"domain\":\"sleep\",\"recorded_at\":\"2026-01-11T00:00:00Z\",\"value\":{\"duration_minutes\":390},\"external_id\":\"sleep_2\"},{\"domain\":\"screen_time\",\"recorded_at\":\"2026-01-11T00:00:00Z\",\"value\":{\"total_screen_minutes\":210},\"external_id\":\"screen_2\"},{\"domain\":\"steps\",\"recorded_at\":\"2026-01-11T00:00:00Z\",\"value\":{\"steps\":7000},\"external_id\":\"steps_2\"},{\"domain\":\"heart_rate\",\"recorded_at\":\"2026-01-11T01:00:00Z\",\"value\":{\"bpm\":68},\"external_id\":\"hr_2\"},{\"domain\":\"mood\",\"recorded_at\":\"2026-01-11T02:00:00Z\",\"value\":{\"score\":3},\"external_id\":\"mood_2\"}]}"
+
+ingest=$(curl -s -X POST "${BASE_URL}/integrations/mock/ingest" -H "Content-Type: application/json" -d "${payload}")
+batch_id=$(echo "${ingest}" | php -r 'echo json_decode(stream_get_contents(STDIN), true)["batch_id"] ?? "";')
+skipped=$(echo "${ingest}" | php -r 'echo json_decode(stream_get_contents(STDIN), true)["skipped"] ?? "0";')
+if [[ -z "${batch_id}" ]]; then
+  echo "Failed to get batch_id from ingest" >&2
+  echo "ingest=${ingest}" >&2
+  exit 1
+fi
+
+ingest_repeat=$(curl -s -X POST "${BASE_URL}/integrations/mock/ingest" -H "Content-Type: application/json" -d "${payload}")
+skipped_repeat=$(echo "${ingest_repeat}" | php -r 'echo json_decode(stream_get_contents(STDIN), true)["skipped"] ?? "0";')
+if [[ "${skipped_repeat}" == "0" ]]; then
+  echo "Expected skipped_repeat > 0" >&2
+  echo "ingest_repeat=${ingest_repeat}" >&2
+  exit 1
+fi
+
+replay=$(curl -s -X POST "${BASE_URL}/integrations/mock/replay/${batch_id}")
+replay_inserted=$(echo "${replay}" | php -r 'echo json_decode(stream_get_contents(STDIN), true)["inserted"] ?? "0";')
+if [[ "${replay_inserted}" != "0" ]]; then
+  echo "Expected replay_inserted == 0" >&2
+  echo "replay=${replay}" >&2
+  exit 1
+fi
+
+webhook_payload='{"event_id":"evt_001","external_user_id":"ext_001","recorded_at":"2026-01-12T00:00:00Z","samples":[{"domain":"sleep","recorded_at":"2026-01-12T00:00:00Z","value":{"duration_minutes":410},"external_id":"sleep_3"}]}'
+webhook_first=$(curl -s -X POST "${BASE_URL}/webhooks/mock" -H "Content-Type: application/json" -d "${webhook_payload}")
+webhook_second=$(curl -s -X POST "${BASE_URL}/webhooks/mock" -H "Content-Type: application/json" -d "${webhook_payload}")
+webhook_second_status=$(echo "${webhook_second}" | php -r 'echo json_decode(stream_get_contents(STDIN), true)["status"] ?? "";')
+if [[ "${webhook_second_status}" != "duplicate" ]]; then
+  echo "Expected webhook_second status=duplicate" >&2
+  echo "webhook_second=${webhook_second}" >&2
+  exit 1
+fi
+
+sleep_resp=$(curl -s "${BASE_URL}/me/data/sleep" -H "Authorization: Bearer ${fm_token}" || true)
+screen_resp=$(curl -s "${BASE_URL}/me/data/screen-time" -H "Authorization: Bearer ${fm_token}" || true)
+sleep_ok=$(echo "${sleep_resp}" | php -r 'echo json_decode(stream_get_contents(STDIN), true)["ok"] ?? "";')
+screen_ok=$(echo "${screen_resp}" | php -r 'echo json_decode(stream_get_contents(STDIN), true)["ok"] ?? "";')
+if [[ "${sleep_ok}" != "1" && "${sleep_ok}" != "true" ]]; then
+  echo "Expected sleep_ok true" >&2
+  echo "sleep_resp=${sleep_resp}" >&2
+  exit 1
+fi
+if [[ "${screen_ok}" != "1" && "${screen_ok}" != "true" ]]; then
+  echo "Expected screen_ok true" >&2
+  echo "screen_resp=${screen_resp}" >&2
+  exit 1
+fi
+
+{
+  echo "checks=oauth_start,oauth_callback,phone_login,ingest,ingest_repeat,replay,webhook_duplicate,me_data"
+  echo "PR13 Ingestion Verify Summary"
+  echo "BASE_URL=${BASE_URL}"
+  echo "port=${PORT}"
+  echo "urls=${BASE_URL}/integrations/mock/ingest,${BASE_URL}/integrations/mock/replay/${batch_id},${BASE_URL}/webhooks/mock,${BASE_URL}/me/data/sleep"
+  echo "oauth_start=${oauth_start}"
+  echo "oauth_cb=${oauth_cb}"
+  echo "ingest=${ingest}"
+  echo "ingest_repeat=${ingest_repeat}"
+  echo "replay=${replay}"
+  echo "webhook_first=${webhook_first}"
+  echo "webhook_second=${webhook_second}"
+  echo "batch_id=${batch_id}"
+  echo "skipped=${skipped}"
+  echo "skipped_repeat=${skipped_repeat}"
+  echo "replay_inserted=${replay_inserted}"
+  echo "tables=integrations,ingest_batches,sleep_samples,health_samples,screen_time_samples,idempotency_keys"
+} | tee "${ART_DIR}/summary.txt"

--- a/docs/04-ops/ingestion-runbook.md
+++ b/docs/04-ops/ingestion-runbook.md
@@ -1,0 +1,28 @@
+# Ingestion Runbook (PR13)
+
+## 监控指标
+- 延迟：`v_ingestion_latency.sql`
+- 缺失率：`v_ingestion_missing_rate.sql`
+- 量级：`v_ingestion_volume_by_source.sql`
+
+## 常见问题排查
+1) 延迟飙升
+   - 检查 provider webhook 推送是否延迟。
+   - 查看 ingest_batches 是否 stuck 在 received。
+2) 缺失率升高
+   - sleep_samples 是否断流；核对 provider/source。
+3) 重复写入
+   - 检查 idempotency_keys 是否异常增长。
+   - 确认 Replay 调用后是否重复插入。
+
+## 回放流程（Replay）
+1) 确认 batch_id：来自 ingest 返回或 webhook 回执。
+2) 调用：
+   - `POST /api/v0.2/integrations/{provider}/replay/{batch_id}`
+3) 预期：
+   - inserted=0 且 skipped>0（幂等生效）。
+
+## 紧急止血
+- 暂停某 provider：
+  - 标记 integrations.status=revoked
+  - 停止 webhook 回调或 drop 请求

--- a/docs/data/consent.md
+++ b/docs/data/consent.md
@@ -1,0 +1,21 @@
+# 数据授权与同意（Consent v0.1）
+
+## consent_version
+- 当前版本：`v0.1`
+- 记录位置：`integrations.consent_version`
+- 变更策略：如需升级，新增版本号并在 providers 文档中说明。
+
+## 用途声明（最小可执行）
+- 用途：为用户生成个人数据洞察与趋势统计。
+- 处理范围：sleep / health / screen_time 样本。
+- 非用途：不用于广告画像；不外部分享原始数据。
+
+## 留存策略（最小可执行）
+- 原始样本保留 365 天（后续可配置）。
+- 聚合结果保留 2 年。
+- 用户撤回后：停止写入 + 标记 revoked_at。
+
+## 撤回流程
+1) `POST /api/v0.2/integrations/{provider}/revoke`
+2) integrations.status = revoked，写 revoked_at
+3) 后续 PR 可增加数据删除与导出任务

--- a/docs/data/ingestion.md
+++ b/docs/data/ingestion.md
@@ -1,0 +1,77 @@
+# Zero-Input 数据管线（Mock 版）
+
+## 目标
+本 PR 提供“零输入”数据通道的最小可用链路：Mock OAuth + Ingest + Webhook + 幂等回放。真实 provider 细节（OAuth/签名/字段）留待后续 PR。
+
+## 支持数据域
+- sleep（睡眠）
+- health（通用健康：steps / heart_rate / mood 等）
+- screen_time（屏幕时间）
+
+## 数据字段口径
+统一 sample 协议：
+```
+{
+  "domain": "sleep|steps|heart_rate|mood|screen_time",
+  "recorded_at": "2026-01-10T00:00:00Z",
+  "value": { ... },
+  "external_id": "provider_event_id_optional",
+  "source": "provider|seed|ingestion",
+  "confidence": 1.0
+}
+```
+- `domain`：sleep/screen_time 写入独立表；其他 domain 写入 health_samples。
+- `value`：原样存入 value_json。
+- `external_id`：可选，用于幂等键生成。
+
+## 授权/撤回
+Mock OAuth：
+- `GET /api/v0.2/integrations/{provider}/oauth/start`
+- `GET /api/v0.2/integrations/{provider}/oauth/callback`
+
+撤回：
+- `POST /api/v0.2/integrations/{provider}/revoke`
+
+## Ingest & Replay
+- `POST /api/v0.2/integrations/{provider}/ingest`
+- `POST /api/v0.2/integrations/{provider}/replay/{batch_id}`
+
+Ingest 会写入 `ingest_batches` 并分发到 domain 表，Replay 重放依赖 `idempotency_keys` 保证不重复。
+
+### Ingest 示例
+```
+POST /api/v0.2/integrations/mock/ingest
+{
+  "user_id": 1,
+  "range_start": "2026-01-01T00:00:00Z",
+  "range_end": "2026-01-02T00:00:00Z",
+  "samples": [
+    {"domain":"sleep","recorded_at":"2026-01-01T00:00:00Z","value":{"duration_minutes":420},"external_id":"sleep_1"},
+    {"domain":"steps","recorded_at":"2026-01-01T12:00:00Z","value":{"steps":8000},"external_id":"steps_1"}
+  ]
+}
+```
+
+## Webhook（可选）
+- `POST /api/v0.2/webhooks/{provider}`
+- body: `{event_id, external_user_id, recorded_at, samples:[] }`
+- 若配置 `services.integrations.{provider}.webhook_secret`，则必须发送 `X-Webhook-Signature`（HMAC-SHA256）。
+
+### Webhook 示例
+```
+POST /api/v0.2/webhooks/mock
+{
+  "event_id": "evt_001",
+  "external_user_id": "ext_001",
+  "recorded_at": "2026-01-01T00:00:00Z",
+  "samples": [
+    {"domain":"sleep","recorded_at":"2026-01-01T00:00:00Z","value":{"duration_minutes":410},"external_id":"sleep_3"}
+  ]
+}
+```
+
+## 导出/删除流程（最小可执行）
+当前 PR 不实现真实导出/删除，仅提供流程占位：
+1) 通过 integrations 记录 consent_version 与 scopes。
+2) 若用户撤回，标记 revoked_at，停止写入。
+3) 后续 PR 将接入导出 job + 删除 job（需审计日志）。

--- a/docs/data/providers.md
+++ b/docs/data/providers.md
@@ -1,0 +1,46 @@
+# Providers 接入契约（Mock v0.1）
+
+## 通用字段
+### OAuth
+1) Start：
+   - `GET /api/v0.2/integrations/{provider}/oauth/start`
+2) Callback：
+   - `GET /api/v0.2/integrations/{provider}/oauth/callback?state=...&code=...`
+
+### Webhook
+- `POST /api/v0.2/webhooks/{provider}`
+- Headers:
+  - `X-Webhook-Signature`（可选；若配置 services.integrations.{provider}.webhook_secret 即校验）
+
+### Ingest
+- `POST /api/v0.2/integrations/{provider}/ingest`
+- Body:
+```
+{
+  "user_id": 1,
+  "range_start": "2026-01-01T00:00:00Z",
+  "range_end": "2026-01-02T00:00:00Z",
+  "samples": [ ... ]
+}
+```
+
+## 具体 Provider（占位）
+### Apple Health
+- data domains: sleep, steps, heart_rate
+- webhook: optional
+- note: 本 PR 仅 mock，不含真实 OAuth。
+
+### Google Fit
+- data domains: sleep, steps, heart_rate
+- webhook: optional
+- note: 本 PR 仅 mock，不含真实 OAuth。
+
+### Calendar
+- data domains: sleep (calendar inferred)
+- webhook: optional
+- note: 本 PR 仅 mock，不含真实 OAuth。
+
+### ScreenTime
+- data domains: screen_time
+- webhook: optional
+- note: 本 PR 仅 mock，不含真实 OAuth。

--- a/docs/verify/pr13_recon.md
+++ b/docs/verify/pr13_recon.md
@@ -1,0 +1,49 @@
+# PR13 勘察结论（Zero-Input 数据管线）
+
+## 相关入口文件
+- backend/routes/api.php
+  - 现有 v0.2 路由入口；当前仅有 events ingestion 与 payments webhook mock。
+- backend/app/Http/Middleware/FmTokenAuth.php
+  - 负责解析 fm_token 并注入 fm_user_id / anon_id；后续 /me/data 需要沿用该注入逻辑。
+- backend/app/Http/Controllers/API/V0_2/PaymentsController.php
+  - 已有 webhook mock + 幂等概念，供本 PR webhook 设计参考。
+- backend/app/Http/Controllers/EventController.php
+  - 现有事件 ingestion 入口，需避免与新 /integrations 路由冲突。
+- docs/payments/webhook-idempotency.md
+  - 支付幂等/重放约束文档，可复用在数据回放的规则描述。
+
+## 相关 DB 表/迁移
+- 现有关键表/迁移：
+  - events / payment_events / fm_tokens / attempts / results 等（见 backend/database/migrations/*）。
+- 当前不存在：
+  - integrations / ingest_batches / sleep_samples / health_samples / screen_time_samples / idempotency_keys。
+- 风险点：
+  - 需保证迁移幂等（判断表/列/索引是否存在）。
+  - 需避免与 payment_events 的幂等语义混淆（命名/表结构清晰隔离）。
+
+## 相关路由
+- 已存在：
+  - POST /api/v0.2/events
+  - POST /api/v0.2/payments/webhook/mock
+  - POST /api/v0.2/auth/provider
+  - /api/v0.2/me/*（需要 FmTokenAuth）
+- 当前不存在：
+  - /api/v0.2/integrations/*
+  - /api/v0.2/webhooks/*
+  - /api/v0.2/me/data/*
+
+## 需要新增/修改点
+- 新增路由：/api/v0.2/integrations/{provider}/* 与 /api/v0.2/webhooks/{provider}。
+- 新增 /me/data/sleep|mood|screen-time 查询路由（FmTokenAuth 下）。
+- 新增 migrations：integrations / ingest_batches / domain samples / idempotency_keys。
+- 新增 Service/Support：IngestionService / ReplayService / ConsentService / IdempotencyStore。
+- 新增 Controller：Integrations/ProvidersController 与 Webhooks/HandleProviderWebhook。
+- Seeder：QuantifiedSelfSeeder（30 天样本）。
+- 验收脚本与 Metabase 视图。
+
+## 潜在风险与规避
+- 路由冲突：避开 /events 与 /payments/webhook/mock，统一放在 /integrations 与 /webhooks 前缀下。
+- 幂等策略不一致：统一使用 idempotency_keys 表记录并复用 ReplayService。
+- FmTokenAuth 行为变更风险：仅新增 fm_user_id 注入时保持既有逻辑不变。
+- 迁移重复执行风险：所有创建动作加 Schema::hasTable / hasColumn / hasIndex 判定。
+- 验收端口冲突：脚本遵循 18030-18059 自动探测。

--- a/docs/verify/pr13_verify.md
+++ b/docs/verify/pr13_verify.md
@@ -1,0 +1,30 @@
+# PR13 验收指引
+
+## 预置
+确保 migrations 已执行，并完成 seeded 数据：
+```
+cd backend
+php artisan migrate
+php artisan db:seed --class=QuantifiedSelfSeeder
+```
+
+## 验收命令（复制即可）
+```
+cd backend && composer install && composer audit
+cd backend && php artisan migrate && php artisan db:seed --class=QuantifiedSelfSeeder
+cd /Users/rainie/Desktop/GitHub/fap-api/backend
+PORT=18030 bash scripts/pr13_verify_ingestion.sh
+cd /Users/rainie/Desktop/GitHub/fap-api
+bash backend/scripts/ci_verify_mbti.sh
+```
+
+## 预期关键输出
+`backend/artifacts/pr13/summary.txt` 中应包含：
+- `batch_id=...`
+- `skipped_repeat` > 0
+- `replay_inserted=0`
+- `webhook_second` 返回 `status=duplicate`
+- tables 列表包含 `integrations,ingest_batches,sleep_samples,health_samples,screen_time_samples,idempotency_keys`
+
+日志位置：
+- `backend/artifacts/pr13/logs/server.log`

--- a/tools/metabase/views/v_ingestion_latency.sql
+++ b/tools/metabase/views/v_ingestion_latency.sql
@@ -1,0 +1,15 @@
+-- Ingestion latency: latest ingest time - latest recorded_at per provider/day
+SELECT
+  source AS provider,
+  DATE(recorded_at) AS day,
+  MAX(created_at) AS latest_ingest_at,
+  MAX(recorded_at) AS latest_recorded_at,
+  TIMESTAMPDIFF(MINUTE, MAX(recorded_at), MAX(created_at)) AS latency_minutes
+FROM (
+  SELECT source, recorded_at, created_at FROM sleep_samples
+  UNION ALL
+  SELECT source, recorded_at, created_at FROM health_samples
+  UNION ALL
+  SELECT source, recorded_at, created_at FROM screen_time_samples
+) t
+GROUP BY source, DATE(recorded_at);

--- a/tools/metabase/views/v_ingestion_missing_rate.sql
+++ b/tools/metabase/views/v_ingestion_missing_rate.sql
@@ -1,0 +1,28 @@
+-- Ingestion missing rate (sleep_samples as baseline, last 30 days)
+WITH RECURSIVE dates AS (
+  SELECT CURDATE() AS day
+  UNION ALL
+  SELECT day - INTERVAL 1 DAY
+  FROM dates
+  WHERE day > CURDATE() - INTERVAL 29 DAY
+),
+providers AS (
+  SELECT DISTINCT source AS provider FROM sleep_samples
+),
+daily AS (
+  SELECT source AS provider, DATE(recorded_at) AS day, 1 AS actual_days
+  FROM sleep_samples
+  GROUP BY source, DATE(recorded_at)
+)
+SELECT
+  p.provider,
+  d.day,
+  1 AS expected_days,
+  COALESCE(dly.actual_days, 0) AS actual_days,
+  (1 - COALESCE(dly.actual_days, 0)) AS missing_days,
+  (1 - COALESCE(dly.actual_days, 0)) AS missing_rate
+FROM providers p
+CROSS JOIN dates d
+LEFT JOIN daily dly
+  ON dly.provider = p.provider
+ AND dly.day = d.day;

--- a/tools/metabase/views/v_ingestion_volume_by_source.sql
+++ b/tools/metabase/views/v_ingestion_volume_by_source.sql
@@ -1,0 +1,13 @@
+-- Ingestion volume by source/provider per day
+SELECT
+  source AS provider,
+  DATE(recorded_at) AS day,
+  COUNT(*) AS sample_count
+FROM (
+  SELECT source, recorded_at FROM sleep_samples
+  UNION ALL
+  SELECT source, recorded_at FROM health_samples
+  UNION ALL
+  SELECT source, recorded_at FROM screen_time_samples
+) t
+GROUP BY source, DATE(recorded_at);


### PR DESCRIPTION
 - What:
      - Add ingestion framework with mock OAuth, webhook push, idempotent
        ingest, and replay.
      - Add 30-day QuantifiedSelfSeeder for dev/test data.
  - Why:
      - Enable “zero-input” data pipeline for early development + long-term
        provider ecosystem.
      - Ensure safe replays without duplicates via idempotency keys.
  - How:
      - New DB tables: integrations, ingest_batches, domain samples,
        idempotency_keys.
      - IngestionService + ReplayService + IdempotencyStore.
      - Provider routes under /api/v0.2/integrations/* plus /webhooks/*.
      - Metabase views for latency/missing/volume.
  - Verify:
      - cd backend && composer install && composer audit
      - cd backend && php artisan migrate && php artisan db:seed
        --class=QuantifiedSelfSeeder
      - cd backend && PORT=18030 bash scripts/pr13_verify_ingestion.sh
      - cd .. && bash backend/scripts/ci_verify_mbti.sh
  - Artifacts:
      - backend/artifacts/pr13/summary.txt
      - backend/artifacts/pr13/logs/server.log

