### PR TITLE
  chore(pr25): B2B assessments + progress + RBAC + credits

### DIFF
--- a/.github/workflows/ci_verify_pr25_b2b_assessments_progress_rbac.yml
+++ b/.github/workflows/ci_verify_pr25_b2b_assessments_progress_rbac.yml
@@ -1,0 +1,54 @@
+name: ci-verify-pr25-b2b-assessments-progress-rbac
+
+on:
+  workflow_dispatch:
+  push:
+    paths:
+      - "backend/**"
+      - "docs/**"
+      - "content_packages/**"
+      - ".github/workflows/ci_verify_pr25_b2b_assessments_progress_rbac.yml"
+  pull_request:
+    paths:
+      - "backend/**"
+      - "docs/**"
+      - "content_packages/**"
+      - ".github/workflows/ci_verify_pr25_b2b_assessments_progress_rbac.yml"
+
+jobs:
+  verify:
+    runs-on: ubuntu-latest
+
+    env:
+      APP_ENV: testing
+      APP_KEY: base64:AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=
+      CI: true
+      FAP_NONINTERACTIVE: 1
+      COMPOSER_NO_INTERACTION: 1
+      GIT_TERMINAL_PROMPT: 0
+      NO_COLOR: 1
+      DB_CONNECTION: sqlite
+      DB_DATABASE: /tmp/pr25.sqlite
+      CACHE_DRIVER: array
+      SERVE_PORT: 1825
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: "8.5"
+          extensions: mbstring, xml, curl, zip, intl, sqlite, pdo_sqlite
+
+      - name: Prepare sqlite
+        run: |
+          rm -f /tmp/pr25.sqlite
+          touch /tmp/pr25.sqlite
+
+      - name: PR25 accept
+        run: bash backend/scripts/pr25_accept.sh
+
+      - name: CI verify mbti
+        run: bash backend/scripts/ci_verify_mbti.sh

--- a/backend/app/Http/Controllers/API/V0_4/AssessmentController.php
+++ b/backend/app/Http/Controllers/API/V0_4/AssessmentController.php
@@ -1,0 +1,245 @@
+<?php
+
+namespace App\Http\Controllers\API\V0_4;
+
+use App\Http\Controllers\Controller;
+use App\Models\Assessment;
+use App\Services\Assessments\AssessmentService;
+use App\Services\Scale\ScaleRegistry;
+use App\Support\OrgContext;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+use Illuminate\Support\Carbon;
+
+class AssessmentController extends Controller
+{
+    public function __construct(
+        private AssessmentService $assessments,
+        private ScaleRegistry $registry,
+        private OrgContext $orgContext,
+    ) {
+    }
+
+    /**
+     * POST /api/v0.4/orgs/{org_id}/assessments
+     */
+    public function store(Request $request, string $org_id): JsonResponse
+    {
+        $payload = $request->validate([
+            'scale_code' => ['required', 'string', 'max:64'],
+            'title' => ['required', 'string', 'max:255'],
+            'due_at' => ['nullable', 'date'],
+        ]);
+
+        $orgId = (int) $org_id;
+        if ($orgId <= 0 || $this->orgContext->orgId() !== $orgId) {
+            return $this->orgNotFound();
+        }
+
+        $userId = $this->resolveUserId($request);
+        if ($userId === null) {
+            return $this->orgNotFound();
+        }
+
+        $scaleCode = strtoupper(trim((string) $payload['scale_code']));
+        if ($scaleCode === '') {
+            return response()->json([
+                'ok' => false,
+                'error' => 'SCALE_REQUIRED',
+                'message' => 'scale_code is required.',
+            ], 400);
+        }
+
+        $row = $this->registry->getByCode($scaleCode, $orgId);
+        if (!$row) {
+            return response()->json([
+                'ok' => false,
+                'error' => 'NOT_FOUND',
+                'message' => 'scale not found.',
+            ], 404);
+        }
+
+        $dueAt = null;
+        if (!empty($payload['due_at'])) {
+            try {
+                $dueAt = Carbon::parse($payload['due_at']);
+            } catch (\Throwable $e) {
+                return response()->json([
+                    'ok' => false,
+                    'error' => 'DUE_AT_INVALID',
+                    'message' => 'due_at invalid.',
+                ], 422);
+            }
+        }
+
+        $assessment = $this->assessments->createAssessment(
+            $orgId,
+            $scaleCode,
+            (string) $payload['title'],
+            $userId,
+            $dueAt
+        );
+
+        return response()->json([
+            'ok' => true,
+            'assessment' => $this->payloadAssessment($assessment),
+        ]);
+    }
+
+    /**
+     * POST /api/v0.4/orgs/{org_id}/assessments/{id}/invite
+     */
+    public function invite(Request $request, string $org_id, string $id): JsonResponse
+    {
+        $payload = $request->validate([
+            'subjects' => ['required', 'array', 'min:1'],
+            'subjects.*.subject_type' => ['required', 'string', 'in:user,email'],
+            'subjects.*.subject_value' => ['required', 'string', 'max:255'],
+        ]);
+
+        $orgId = (int) $org_id;
+        $assessmentId = (int) $id;
+        if ($orgId <= 0 || $assessmentId <= 0 || $this->orgContext->orgId() !== $orgId) {
+            return $this->orgNotFound();
+        }
+
+        $assessment = $this->assessments->findForOrg($orgId, $assessmentId);
+        if (!$assessment) {
+            return $this->orgNotFound();
+        }
+
+        $subjects = $this->sanitizeSubjects($payload['subjects']);
+        if ($subjects === []) {
+            return response()->json([
+                'ok' => false,
+                'error' => 'SUBJECTS_INVALID',
+                'message' => 'subjects invalid.',
+            ], 422);
+        }
+
+        $invites = $this->assessments->invite($assessment, $subjects);
+
+        return response()->json([
+            'ok' => true,
+            'total' => count($subjects),
+            'created' => count($invites),
+            'invites' => $invites,
+        ]);
+    }
+
+    /**
+     * GET /api/v0.4/orgs/{org_id}/assessments/{id}/progress
+     */
+    public function progress(Request $request, string $org_id, string $id): JsonResponse
+    {
+        $orgId = (int) $org_id;
+        $assessmentId = (int) $id;
+        if ($orgId <= 0 || $assessmentId <= 0 || $this->orgContext->orgId() !== $orgId) {
+            return $this->orgNotFound();
+        }
+
+        $assessment = $this->assessments->findForOrg($orgId, $assessmentId);
+        if (!$assessment) {
+            return $this->orgNotFound();
+        }
+
+        $progress = $this->assessments->progress($assessment);
+
+        return response()->json(array_merge([
+            'ok' => true,
+            'assessment_id' => (int) $assessment->id,
+        ], $progress));
+    }
+
+    /**
+     * GET /api/v0.4/orgs/{org_id}/assessments/{id}/summary
+     */
+    public function summary(Request $request, string $org_id, string $id): JsonResponse
+    {
+        $orgId = (int) $org_id;
+        $assessmentId = (int) $id;
+        if ($orgId <= 0 || $assessmentId <= 0 || $this->orgContext->orgId() !== $orgId) {
+            return $this->orgNotFound();
+        }
+
+        $assessment = $this->assessments->findForOrg($orgId, $assessmentId);
+        if (!$assessment) {
+            return $this->orgNotFound();
+        }
+
+        $summary = $this->assessments->summary($assessment);
+
+        return response()->json([
+            'ok' => true,
+            'assessment_id' => (int) $assessment->id,
+            'summary' => $summary,
+        ]);
+    }
+
+    private function payloadAssessment(Assessment $assessment): array
+    {
+        return [
+            'id' => (int) $assessment->id,
+            'org_id' => (int) $assessment->org_id,
+            'scale_code' => (string) $assessment->scale_code,
+            'title' => (string) $assessment->title,
+            'created_by' => (int) $assessment->created_by,
+            'status' => (string) $assessment->status,
+            'due_at' => $assessment->due_at?->toISOString(),
+            'created_at' => $assessment->created_at?->toISOString(),
+            'updated_at' => $assessment->updated_at?->toISOString(),
+        ];
+    }
+
+    private function resolveUserId(Request $request): ?int
+    {
+        $raw = (string) ($request->attributes->get('fm_user_id') ?? $request->attributes->get('user_id') ?? '');
+        if ($raw === '' || !preg_match('/^\d+$/', $raw)) {
+            return null;
+        }
+
+        return (int) $raw;
+    }
+
+    private function sanitizeSubjects(array $subjects): array
+    {
+        $out = [];
+
+        foreach ($subjects as $subject) {
+            if (!is_array($subject)) {
+                continue;
+            }
+
+            $type = strtolower(trim((string) ($subject['subject_type'] ?? '')));
+            $value = trim((string) ($subject['subject_value'] ?? ''));
+
+            if ($type === '' || $value === '') {
+                continue;
+            }
+
+            if ($type === 'email' && !filter_var($value, FILTER_VALIDATE_EMAIL)) {
+                continue;
+            }
+
+            if ($type === 'user' && !preg_match('/^\d+$/', $value)) {
+                continue;
+            }
+
+            $out[] = [
+                'subject_type' => $type,
+                'subject_value' => $value,
+            ];
+        }
+
+        return $out;
+    }
+
+    private function orgNotFound(): JsonResponse
+    {
+        return response()->json([
+            'ok' => false,
+            'error' => 'ORG_NOT_FOUND',
+            'message' => 'org not found.',
+        ], 404);
+    }
+}

--- a/backend/app/Http/Middleware/RequireOrgRole.php
+++ b/backend/app/Http/Middleware/RequireOrgRole.php
@@ -1,0 +1,94 @@
+<?php
+
+namespace App\Http\Middleware;
+
+use App\Services\Org\MembershipService;
+use App\Support\OrgContext;
+use Closure;
+use Illuminate\Http\Request;
+use Symfony\Component\HttpFoundation\Response;
+
+class RequireOrgRole
+{
+    public function __construct(
+        private MembershipService $memberships,
+        private OrgContext $orgContext,
+    ) {
+    }
+
+    public function handle(Request $request, Closure $next, string ...$roles): Response
+    {
+        $orgId = $this->resolveOrgId($request);
+        if ($orgId <= 0) {
+            return $this->orgNotFound();
+        }
+
+        $userId = $this->resolveUserId($request);
+        if ($userId === null) {
+            return $this->orgNotFound();
+        }
+
+        $role = $this->memberships->getRole($orgId, $userId);
+        if ($role === null) {
+            return $this->orgNotFound();
+        }
+
+        if ($roles !== [] && !in_array($role, $roles, true)) {
+            return $this->orgNotFound();
+        }
+
+        $request->attributes->set('org_id', $orgId);
+        $request->attributes->set('org_role', $role);
+
+        $anonId = $this->resolveAnonId($request);
+        $this->orgContext->set($orgId, $userId, $role, $anonId);
+        app()->instance(OrgContext::class, $this->orgContext);
+
+        return $next($request);
+    }
+
+    private function resolveOrgId(Request $request): int
+    {
+        $raw = $request->route('org_id');
+        if (is_string($raw) || is_numeric($raw)) {
+            $val = trim((string) $raw);
+            if ($val !== '' && preg_match('/^\d+$/', $val)) {
+                return (int) $val;
+            }
+        }
+
+        return 0;
+    }
+
+    private function resolveUserId(Request $request): ?int
+    {
+        $raw = (string) ($request->attributes->get('fm_user_id') ?? $request->attributes->get('user_id') ?? '');
+        if ($raw === '' || !preg_match('/^\d+$/', $raw)) {
+            return null;
+        }
+
+        return (int) $raw;
+    }
+
+    private function resolveAnonId(Request $request): ?string
+    {
+        $raw = $request->attributes->get('anon_id') ?? $request->attributes->get('fm_anon_id') ?? '';
+        if (is_string($raw) || is_numeric($raw)) {
+            $val = trim((string) $raw);
+            if ($val !== '') {
+                return $val;
+            }
+        }
+
+        return null;
+    }
+
+    private function orgNotFound(): Response
+    {
+        return response()->json([
+            'ok' => false,
+            'error' => 'ORG_NOT_FOUND',
+            'message' => 'org not found.',
+        ], 404);
+    }
+}

--- a/backend/app/Models/Assessment.php
+++ b/backend/app/Models/Assessment.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+
+class Assessment extends Model
+{
+    use HasFactory;
+
+    protected $table = 'assessments';
+
+    protected $fillable = [
+        'org_id',
+        'scale_code',
+        'title',
+        'created_by',
+        'due_at',
+        'status',
+    ];
+
+    protected $casts = [
+        'org_id' => 'integer',
+        'created_by' => 'integer',
+        'due_at' => 'datetime',
+        'created_at' => 'datetime',
+        'updated_at' => 'datetime',
+    ];
+
+    public function assignments(): HasMany
+    {
+        return $this->hasMany(AssessmentAssignment::class, 'assessment_id');
+    }
+}

--- a/backend/app/Models/AssessmentAssignment.php
+++ b/backend/app/Models/AssessmentAssignment.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+class AssessmentAssignment extends Model
+{
+    use HasFactory;
+
+    protected $table = 'assessment_assignments';
+
+    protected $fillable = [
+        'org_id',
+        'assessment_id',
+        'subject_type',
+        'subject_value',
+        'invite_token',
+        'started_at',
+        'completed_at',
+        'attempt_id',
+    ];
+
+    protected $casts = [
+        'org_id' => 'integer',
+        'assessment_id' => 'integer',
+        'started_at' => 'datetime',
+        'completed_at' => 'datetime',
+        'created_at' => 'datetime',
+        'updated_at' => 'datetime',
+    ];
+
+    public function assessment(): BelongsTo
+    {
+        return $this->belongsTo(Assessment::class, 'assessment_id');
+    }
+}

--- a/backend/app/Services/Assessments/AssessmentService.php
+++ b/backend/app/Services/Assessments/AssessmentService.php
@@ -1,0 +1,191 @@
+<?php
+
+namespace App\Services\Assessments;
+
+use App\Models\Assessment;
+use App\Models\AssessmentAssignment;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Str;
+
+class AssessmentService
+{
+    public function __construct(private AssessmentSummaryService $summaryService)
+    {
+    }
+
+    public function findForOrg(int $orgId, int $assessmentId): ?Assessment
+    {
+        return Assessment::query()
+            ->where('org_id', $orgId)
+            ->where('id', $assessmentId)
+            ->first();
+    }
+
+    public function createAssessment(
+        int $orgId,
+        string $scaleCode,
+        string $title,
+        int $createdBy,
+        ?\DateTimeInterface $dueAt
+    ): Assessment {
+        $now = now();
+
+        return Assessment::create([
+            'org_id' => $orgId,
+            'scale_code' => $scaleCode,
+            'title' => $title,
+            'created_by' => $createdBy,
+            'due_at' => $dueAt,
+            'status' => 'open',
+            'created_at' => $now,
+            'updated_at' => $now,
+        ]);
+    }
+
+    public function invite(Assessment $assessment, array $subjects): array
+    {
+        $invites = [];
+        $now = now();
+
+        DB::transaction(function () use ($assessment, $subjects, $now, &$invites) {
+            foreach ($subjects as $subject) {
+                if (!is_array($subject)) {
+                    continue;
+                }
+
+                $type = strtolower(trim((string) ($subject['subject_type'] ?? '')));
+                $value = trim((string) ($subject['subject_value'] ?? ''));
+                if ($type === '' || $value === '') {
+                    continue;
+                }
+
+                $token = $this->generateInviteToken();
+
+                AssessmentAssignment::create([
+                    'org_id' => (int) $assessment->org_id,
+                    'assessment_id' => (int) $assessment->id,
+                    'subject_type' => $type,
+                    'subject_value' => $value,
+                    'invite_token' => $token,
+                    'started_at' => null,
+                    'completed_at' => null,
+                    'attempt_id' => null,
+                    'created_at' => $now,
+                    'updated_at' => $now,
+                ]);
+
+                $invites[] = [
+                    'subject_type' => $type,
+                    'subject_value' => $value,
+                    'invite_token' => $token,
+                ];
+            }
+        });
+
+        return $invites;
+    }
+
+    public function progress(Assessment $assessment): array
+    {
+        $rows = AssessmentAssignment::query()
+            ->where('org_id', (int) $assessment->org_id)
+            ->where('assessment_id', (int) $assessment->id)
+            ->orderBy('id')
+            ->get();
+
+        $total = $rows->count();
+        $completedList = [];
+        $pendingList = [];
+
+        foreach ($rows as $row) {
+            $payload = [
+                'subject_type' => (string) $row->subject_type,
+                'subject_value' => (string) $row->subject_value,
+            ];
+
+            if ($row->completed_at !== null) {
+                $completedList[] = array_merge($payload, [
+                    'attempt_id' => $row->attempt_id !== null ? (string) $row->attempt_id : null,
+                    'completed_at' => $row->completed_at?->toISOString(),
+                ]);
+            } else {
+                $pendingList[] = array_merge($payload, [
+                    'invite_token' => (string) $row->invite_token,
+                    'started_at' => $row->started_at?->toISOString(),
+                ]);
+            }
+        }
+
+        $completed = count($completedList);
+        $pending = $total - $completed;
+
+        return [
+            'total' => $total,
+            'completed' => $completed,
+            'pending' => $pending,
+            'completed_list' => $completedList,
+            'pending_list' => $pendingList,
+        ];
+    }
+
+    public function summary(Assessment $assessment): array
+    {
+        return $this->summaryService->buildSummary($assessment);
+    }
+
+    public function attachAttemptByInviteToken(int $orgId, string $inviteToken, string $attemptId): ?AssessmentAssignment
+    {
+        $inviteToken = trim($inviteToken);
+        if ($orgId <= 0 || $inviteToken === '') {
+            return null;
+        }
+
+        $attemptId = trim($attemptId);
+        if ($attemptId === '') {
+            return null;
+        }
+
+        return DB::transaction(function () use ($orgId, $inviteToken, $attemptId) {
+            $row = AssessmentAssignment::query()
+                ->where('org_id', $orgId)
+                ->where('invite_token', $inviteToken)
+                ->lockForUpdate()
+                ->first();
+
+            if (!$row) {
+                return null;
+            }
+
+            $existingAttempt = trim((string) ($row->attempt_id ?? ''));
+            if ($existingAttempt !== '' && $existingAttempt !== $attemptId) {
+                return $row;
+            }
+
+            $now = now();
+            $row->attempt_id = $attemptId;
+            if ($row->started_at === null) {
+                $row->started_at = $now;
+            }
+            $row->completed_at = $now;
+            $row->updated_at = $now;
+            $row->save();
+
+            return $row;
+        });
+    }
+
+    private function generateInviteToken(): string
+    {
+        for ($i = 0; $i < 5; $i++) {
+            $token = Str::random(40);
+            $exists = AssessmentAssignment::query()
+                ->where('invite_token', $token)
+                ->exists();
+            if (!$exists) {
+                return $token;
+            }
+        }
+
+        return Str::uuid()->toString();
+    }
+}

--- a/backend/app/Services/Assessments/AssessmentSummaryService.php
+++ b/backend/app/Services/Assessments/AssessmentSummaryService.php
@@ -1,0 +1,219 @@
+<?php
+
+namespace App\Services\Assessments;
+
+use App\Models\Assessment;
+use App\Models\AssessmentAssignment;
+use App\Models\Result;
+use App\Services\Scale\ScaleRegistry;
+use Illuminate\Support\Collection;
+
+class AssessmentSummaryService
+{
+    public function __construct(private ScaleRegistry $registry)
+    {
+    }
+
+    public function buildSummary(Assessment $assessment): array
+    {
+        $orgId = (int) $assessment->org_id;
+
+        $assignments = AssessmentAssignment::query()
+            ->where('org_id', $orgId)
+            ->where('assessment_id', (int) $assessment->id)
+            ->get(['attempt_id', 'completed_at']);
+
+        $total = $assignments->count();
+        $completedAssignments = $assignments->filter(function ($row) {
+            return $row->completed_at !== null;
+        });
+
+        $completed = $completedAssignments->count();
+        $attemptIds = $completedAssignments
+            ->pluck('attempt_id')
+            ->filter(function ($val) {
+                return is_string($val) && trim($val) !== '';
+            })
+            ->map(function ($val) {
+                return trim((string) $val);
+            })
+            ->values()
+            ->all();
+
+        $results = $attemptIds !== []
+            ? Result::query()
+                ->where('org_id', $orgId)
+                ->whereIn('attempt_id', $attemptIds)
+                ->get(['attempt_id', 'type_code', 'scores_pct', 'result_json'])
+            : collect();
+
+        $driverType = $this->resolveDriverType($assessment);
+
+        return [
+            'completion_rate' => [
+                'completed' => $completed,
+                'total' => $total,
+            ],
+            'due_at' => $assessment->due_at?->toISOString(),
+            'window' => [
+                'start_at' => $assessment->created_at?->toISOString(),
+                'end_at' => $assessment->due_at?->toISOString(),
+            ],
+            'score_distribution' => $this->scoreDistribution($driverType, $results),
+            'dimension_means' => $this->dimensionMeans($driverType, $results),
+        ];
+    }
+
+    private function resolveDriverType(Assessment $assessment): string
+    {
+        $code = strtoupper(trim((string) $assessment->scale_code));
+        if ($code === '') {
+            return '';
+        }
+
+        $row = $this->registry->getByCode($code, (int) $assessment->org_id);
+        return strtoupper(trim((string) ($row['driver_type'] ?? '')));
+    }
+
+    private function scoreDistribution(string $driverType, Collection $results): array
+    {
+        $counts = [];
+
+        foreach ($results as $row) {
+            $label = '';
+
+            $typeCode = trim((string) ($row->type_code ?? ''));
+            if ($typeCode !== '') {
+                $label = strtoupper($typeCode);
+            } else {
+                $payload = $row->result_json;
+                if (is_string($payload)) {
+                    $decoded = json_decode($payload, true);
+                    $payload = is_array($decoded) ? $decoded : null;
+                }
+                if (is_array($payload)) {
+                    $score = $payload['final_score'] ?? $payload['raw_score'] ?? null;
+                    if (is_numeric($score)) {
+                        $label = (string) $score;
+                    }
+                }
+            }
+
+            if ($label === '') {
+                continue;
+            }
+
+            $counts[$label] = ($counts[$label] ?? 0) + 1;
+        }
+
+        $out = [];
+        foreach ($counts as $label => $count) {
+            $out[] = [
+                'label' => $label,
+                'count' => $count,
+            ];
+        }
+
+        return $out;
+    }
+
+    private function dimensionMeans(string $driverType, Collection $results): array
+    {
+        if ($driverType === 'MBTI') {
+            return $this->mbtiMeans($results);
+        }
+
+        if ($driverType === 'GENERIC_LIKERT') {
+            return $this->likertMeans($results);
+        }
+
+        return [];
+    }
+
+    private function mbtiMeans(Collection $results): array
+    {
+        $sum = [];
+        $count = [];
+        $dims = ['EI', 'SN', 'TF', 'JP', 'AT'];
+
+        foreach ($results as $row) {
+            $scores = $row->scores_pct;
+            if (is_string($scores)) {
+                $decoded = json_decode($scores, true);
+                $scores = is_array($decoded) ? $decoded : null;
+            }
+            if (!is_array($scores)) {
+                $payload = $row->result_json;
+                if (is_string($payload)) {
+                    $decoded = json_decode($payload, true);
+                    $payload = is_array($decoded) ? $decoded : null;
+                }
+                $scores = is_array($payload['axis_scores_json']['scores_pct'] ?? null)
+                    ? $payload['axis_scores_json']['scores_pct']
+                    : [];
+            }
+
+            foreach ($dims as $dim) {
+                $val = $scores[$dim] ?? null;
+                if (is_numeric($val)) {
+                    $sum[$dim] = ($sum[$dim] ?? 0) + (float) $val;
+                    $count[$dim] = ($count[$dim] ?? 0) + 1;
+                }
+            }
+        }
+
+        $means = [];
+        foreach ($sum as $dim => $total) {
+            $div = (int) ($count[$dim] ?? 0);
+            if ($div > 0) {
+                $means[$dim] = round($total / $div, 2);
+            }
+        }
+
+        return $means;
+    }
+
+    private function likertMeans(Collection $results): array
+    {
+        $sum = [];
+        $count = [];
+
+        foreach ($results as $row) {
+            $payload = $row->result_json;
+            if (is_string($payload)) {
+                $decoded = json_decode($payload, true);
+                $payload = is_array($decoded) ? $decoded : null;
+            }
+            if (!is_array($payload)) {
+                continue;
+            }
+
+            $dimensions = $payload['breakdown_json']['dimensions'] ?? [];
+            if (!is_array($dimensions)) {
+                continue;
+            }
+
+            foreach ($dimensions as $dim => $info) {
+                if (!is_array($info)) {
+                    continue;
+                }
+                $val = $info['score'] ?? null;
+                if (!is_numeric($val)) {
+                    continue;
+                }
+                $sum[$dim] = ($sum[$dim] ?? 0) + (float) $val;
+                $count[$dim] = ($count[$dim] ?? 0) + 1;
+            }
+        }
+
+        $means = [];
+        foreach ($sum as $dim => $total) {
+            $div = (int) ($count[$dim] ?? 0);
+            if ($div > 0) {
+                $means[$dim] = round($total / $div, 2);
+            }
+        }
+
+        return $means;
+    }
+}

--- a/backend/app/Services/Org/MembershipService.php
+++ b/backend/app/Services/Org/MembershipService.php
@@ -7,6 +7,8 @@ use Illuminate\Support\Facades\Schema;
 
 final class MembershipService
 {
+    private const ALLOWED_ROLES = ['owner', 'admin', 'member', 'viewer'];
+
     public function getRole(int $orgId, int $userId): ?string
     {
         if (!Schema::hasTable('organization_members')) {
@@ -30,7 +32,7 @@ final class MembershipService
     public function addMember(int $orgId, int $userId, string $role): void
     {
         $role = trim($role);
-        if ($role === '') {
+        if ($role === '' || !in_array($role, self::ALLOWED_ROLES, true)) {
             $role = 'member';
         }
 

--- a/backend/database/migrations/2026_01_31_090000_create_assessments_table.php
+++ b/backend/database/migrations/2026_01_31_090000_create_assessments_table.php
@@ -1,0 +1,34 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        if (Schema::hasTable('assessments')) {
+            return;
+        }
+
+        Schema::create('assessments', function (Blueprint $table) {
+            $table->bigIncrements('id');
+            $table->unsignedBigInteger('org_id');
+            $table->string('scale_code', 64);
+            $table->string('title', 255);
+            $table->unsignedBigInteger('created_by');
+            $table->timestamp('due_at')->nullable();
+            $table->string('status', 32)->default('open');
+            $table->timestamps();
+
+            $table->index(['org_id', 'created_at'], 'assessments_org_created_idx');
+            $table->index(['org_id', 'status'], 'assessments_org_status_idx');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('assessments');
+    }
+};

--- a/backend/database/migrations/2026_01_31_090010_create_assessment_assignments_table.php
+++ b/backend/database/migrations/2026_01_31_090010_create_assessment_assignments_table.php
@@ -1,0 +1,38 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        if (Schema::hasTable('assessment_assignments')) {
+            return;
+        }
+
+        Schema::create('assessment_assignments', function (Blueprint $table) {
+            $table->bigIncrements('id');
+            $table->unsignedBigInteger('org_id');
+            $table->unsignedBigInteger('assessment_id');
+            $table->string('subject_type', 16);
+            $table->string('subject_value', 255);
+            $table->string('invite_token', 64);
+            $table->timestamp('started_at')->nullable();
+            $table->timestamp('completed_at')->nullable();
+            $table->string('attempt_id', 64)->nullable();
+            $table->timestamps();
+
+            $table->unique('invite_token', 'assessment_assignments_invite_unique');
+            $table->index(['org_id', 'assessment_id'], 'assessment_assignments_org_assessment_idx');
+            $table->index(['org_id', 'invite_token'], 'assessment_assignments_org_invite_idx');
+            $table->index('attempt_id', 'assessment_assignments_attempt_idx');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('assessment_assignments');
+    }
+};

--- a/backend/database/migrations/2026_01_31_090020_expand_organization_members_role.php
+++ b/backend/database/migrations/2026_01_31_090020_expand_organization_members_role.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        if (!Schema::hasTable('organization_members')) {
+            return;
+        }
+
+        DB::table('organization_members')
+            ->whereNull('role')
+            ->orWhere('role', '')
+            ->update([
+                'role' => 'member',
+                'updated_at' => now(),
+            ]);
+    }
+
+    public function down(): void
+    {
+        // no-op (data backfill only)
+    }
+};

--- a/backend/routes/api.php
+++ b/backend/routes/api.php
@@ -33,6 +33,7 @@ use App\Http\Controllers\API\V0_3\OrgInvitesController;
 use App\Http\Controllers\API\V0_3\ScalesController;
 use App\Http\Controllers\API\V0_3\ScalesLookupController;
 use App\Http\Controllers\API\V0_4\BootController;
+use App\Http\Controllers\API\V0_4\AssessmentController;
 use App\Http\Controllers\Integrations\ProvidersController;
 use App\Http\Controllers\Webhooks\HandleProviderWebhook;
 
@@ -266,4 +267,14 @@ Route::prefix("v0.3")->group(function () {
 
 Route::prefix("v0.4")->group(function () {
     Route::get("/boot", [BootController::class, "show"]);
+
+    Route::middleware([
+        \App\Http\Middleware\FmTokenAuth::class,
+        \App\Http\Middleware\RequireOrgRole::class . ':owner,admin',
+    ])->group(function () {
+        Route::post("/orgs/{org_id}/assessments", [AssessmentController::class, "store"]);
+        Route::post("/orgs/{org_id}/assessments/{id}/invite", [AssessmentController::class, "invite"]);
+        Route::get("/orgs/{org_id}/assessments/{id}/progress", [AssessmentController::class, "progress"]);
+        Route::get("/orgs/{org_id}/assessments/{id}/summary", [AssessmentController::class, "summary"]);
+    });
 });

--- a/backend/scripts/pr25_accept.sh
+++ b/backend/scripts/pr25_accept.sh
@@ -1,0 +1,113 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+export CI=true
+export FAP_NONINTERACTIVE=1
+export COMPOSER_NO_INTERACTION=1
+export GIT_TERMINAL_PROMPT=0
+export NO_COLOR=1
+
+export FAP_DEFAULT_PACK_ID="${FAP_DEFAULT_PACK_ID:-MBTI.cn-mainland.zh-CN.v0.2.1-TEST}"
+export FAP_DEFAULT_DIR_VERSION="${FAP_DEFAULT_DIR_VERSION:-MBTI-CN-v0.2.1-TEST}"
+export FAP_DEFAULT_REGION="${FAP_DEFAULT_REGION:-CN_MAINLAND}"
+export FAP_DEFAULT_LOCALE="${FAP_DEFAULT_LOCALE:-zh-CN}"
+
+export DB_CONNECTION=sqlite
+export DB_DATABASE="${DB_DATABASE:-/tmp/pr25.sqlite}"
+export SERVE_PORT="${SERVE_PORT:-1825}"
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT_DIR="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+BACKEND_DIR="${ROOT_DIR}/backend"
+ART_DIR="${BACKEND_DIR}/artifacts/pr25"
+
+mkdir -p "${ART_DIR}"
+
+cleanup_port() {
+  local port="$1"
+  local pids
+  pids="$(lsof -ti tcp:"${port}" 2>/dev/null || true)"
+  if [[ -n "${pids}" ]]; then
+    kill -9 ${pids} || true
+  fi
+}
+
+log() {
+  echo "[$(date +'%Y-%m-%d %H:%M:%S')] $*"
+}
+
+log "Cleaning ports ${SERVE_PORT} and 18000"
+cleanup_port "${SERVE_PORT}"
+cleanup_port 18000
+
+rm -f "${DB_DATABASE}"
+
+log "composer install"
+(
+  cd "${BACKEND_DIR}"
+  composer install --no-interaction --no-progress
+)
+
+log "migrate"
+(
+  cd "${BACKEND_DIR}"
+  php artisan migrate --force
+)
+
+log "seed scales"
+(
+  cd "${BACKEND_DIR}"
+  php artisan fap:scales:seed-default
+  php artisan fap:scales:sync-slugs
+)
+
+log "pr25 verify"
+(
+  cd "${ROOT_DIR}"
+  bash "${BACKEND_DIR}/scripts/pr25_verify.sh"
+)
+
+log "summary"
+cat <<TXT > "${ART_DIR}/summary.txt"
+PR25 acceptance summary
+- status: ok
+- serve_port: ${SERVE_PORT}
+- db: sqlite (${DB_DATABASE})
+- smoke_url: http://127.0.0.1:${SERVE_PORT}/api/v0.4/boot
+- scripts:
+  - backend/scripts/pr25_verify.sh
+  - backend/scripts/ci_verify_mbti.sh
+- tables:
+  - assessments
+  - assessment_assignments
+  - organization_members.role (owner/admin/member/viewer)
+- artifacts:
+  - backend/artifacts/pr25/verify.log
+  - backend/artifacts/pr25/server.log
+  - backend/artifacts/pr25/progress.json
+  - backend/artifacts/pr25/summary.json
+  - backend/artifacts/pr25/summary.txt
+TXT
+
+log "sanitize artifacts"
+(
+  cd "${ROOT_DIR}"
+  bash "${BACKEND_DIR}/scripts/sanitize_artifacts.sh" 25
+)
+
+log "cleanup"
+if [[ -f "${ART_DIR}/server.pid" ]]; then
+  SERVER_PID="$(cat "${ART_DIR}/server.pid")"
+  if [[ -n "${SERVER_PID}" ]] && ps -p "${SERVER_PID}" >/dev/null 2>&1; then
+    kill "${SERVER_PID}" >/dev/null 2>&1 || true
+  fi
+fi
+
+cleanup_port "${SERVE_PORT}"
+cleanup_port 18000
+rm -f "${DB_DATABASE}"
+
+if lsof -nP -iTCP:"${SERVE_PORT}" -sTCP:LISTEN >/dev/null 2>&1; then
+  log "Port ${SERVE_PORT} still in use"
+  exit 1
+fi

--- a/backend/scripts/pr25_verify.sh
+++ b/backend/scripts/pr25_verify.sh
@@ -1,0 +1,305 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+export CI=true
+export FAP_NONINTERACTIVE=1
+export COMPOSER_NO_INTERACTION=1
+export GIT_TERMINAL_PROMPT=0
+export NO_COLOR=1
+
+export FAP_DEFAULT_PACK_ID="${FAP_DEFAULT_PACK_ID:-MBTI.cn-mainland.zh-CN.v0.2.1-TEST}"
+export FAP_DEFAULT_DIR_VERSION="${FAP_DEFAULT_DIR_VERSION:-MBTI-CN-v0.2.1-TEST}"
+export FAP_DEFAULT_REGION="${FAP_DEFAULT_REGION:-CN_MAINLAND}"
+export FAP_DEFAULT_LOCALE="${FAP_DEFAULT_LOCALE:-zh-CN}"
+
+export DB_CONNECTION="${DB_CONNECTION:-sqlite}"
+export DB_DATABASE="${DB_DATABASE:-/tmp/pr25.sqlite}"
+
+SERVE_PORT="${SERVE_PORT:-1825}"
+API_BASE="http://127.0.0.1:${SERVE_PORT}"
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT_DIR="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+BACKEND_DIR="${ROOT_DIR}/backend"
+ART_DIR="${BACKEND_DIR}/artifacts/pr25"
+
+mkdir -p "${ART_DIR}"
+
+VERIFY_LOG="${ART_DIR}/verify.log"
+SERVER_LOG="${ART_DIR}/server.log"
+SERVER_PID_FILE="${ART_DIR}/server.pid"
+
+exec > >(tee "${VERIFY_LOG}") 2>&1
+
+echo "[pr25] api_base=${API_BASE}"
+
+timestamp() {
+  date +'%Y-%m-%d %H:%M:%S'
+}
+
+cleanup_port() {
+  local port="$1"
+  local pids
+  pids="$(lsof -ti tcp:"${port}" 2>/dev/null || true)"
+  if [[ -n "${pids}" ]]; then
+    kill -9 ${pids} || true
+  fi
+}
+
+cleanup_port "${SERVE_PORT}"
+cleanup_port 18000
+
+php "${BACKEND_DIR}/artisan" fap:scales:seed-default
+php "${BACKEND_DIR}/artisan" fap:scales:sync-slugs
+
+php -r '
+require "'"${BACKEND_DIR}"'/vendor/autoload.php";
+$app = require "'"${BACKEND_DIR}"'/bootstrap/app.php";
+$app->make(Illuminate\Contracts\Console\Kernel::class)->bootstrap();
+$packId = (string) config("content_packs.default_pack_id", "");
+$dirVersion = (string) config("content_packs.default_dir_version", "");
+echo "[pr25] default_pack_id={$packId}\n";
+echo "[pr25] default_dir_version={$dirVersion}\n";
+$scale = DB::table("scales_registry")->where("org_id", 0)->where("code", "MBTI")->first();
+$scalePack = $scale->default_pack_id ?? "";
+$scaleDir = $scale->default_dir_version ?? "";
+if ($scalePack !== $packId) { fwrite(STDERR, "[pr25][fail] scales_registry.default_pack_id mismatch\n"); exit(1); }
+if ($scaleDir !== $dirVersion) { fwrite(STDERR, "[pr25][fail] scales_registry.default_dir_version mismatch\n"); exit(1); }
+$index = app(App\Services\Content\ContentPacksIndex::class);
+$found = $index->find($packId, $dirVersion);
+if (!($found["ok"] ?? false)) { fwrite(STDERR, "[pr25][fail] pack not found\n"); exit(1); }
+$item = $found["item"] ?? [];
+$questionsPath = (string) ($item["questions_path"] ?? "");
+if ($questionsPath === "" || !file_exists($questionsPath)) { fwrite(STDERR, "[pr25][fail] questions.json missing\n"); exit(1); }
+$versionPath = dirname($questionsPath) . "/version.json";
+if (!file_exists($versionPath)) { fwrite(STDERR, "[pr25][fail] version.json missing\n"); exit(1); }
+$questions = json_decode(file_get_contents($questionsPath), true);
+$version = json_decode(file_get_contents($versionPath), true);
+if (!is_array($questions) || !is_array($version)) { fwrite(STDERR, "[pr25][fail] questions/version invalid\n"); exit(1); }
+echo "[pr25] pack_path=" . (string) ($item["pack_path"] ?? "") . "\n";
+'
+
+php "${BACKEND_DIR}/artisan" serve --host=127.0.0.1 --port="${SERVE_PORT}" >"${SERVER_LOG}" 2>&1 &
+SERVER_PID=$!
+echo "${SERVER_PID}" > "${SERVER_PID_FILE}"
+
+echo "[pr25] server_pid=${SERVER_PID}"
+
+HEALTH_OK=0
+for _ in {1..30}; do
+  if curl -sS "${API_BASE}/api/v0.2/health" >/dev/null 2>&1; then
+    HEALTH_OK=1
+    break
+  fi
+  sleep 0.5
+done
+
+if [[ "${HEALTH_OK}" -ne 1 ]]; then
+  echo "[pr25][fail] health check failed"
+  curl -sS "${API_BASE}/api/v0.2/health" || true
+  tail -n 80 "${SERVER_LOG}" || true
+  exit 1
+fi
+
+echo "[pr25] seed org + members + wallet"
+php -r '
+$pdo = new PDO("sqlite:" . getenv("DB_DATABASE"));
+$pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+$now = date("Y-m-d H:i:s");
+$orgId = 2500;
+$adminId = 9001;
+$memberId = 9002;
+$pdo->exec("INSERT INTO organizations (id, name, owner_user_id, created_at, updated_at) VALUES (" . (int)$orgId . ", " . $pdo->quote("PR25 Org") . ", " . (int)$adminId . ", " . $pdo->quote($now) . ", " . $pdo->quote($now) . ")");
+$pdo->exec("INSERT INTO organization_members (org_id, user_id, role, joined_at, created_at, updated_at) VALUES (" . (int)$orgId . ", " . (int)$adminId . ", " . $pdo->quote("admin") . ", " . $pdo->quote($now) . ", " . $pdo->quote($now) . ", " . $pdo->quote($now) . ")");
+$pdo->exec("INSERT INTO organization_members (org_id, user_id, role, joined_at, created_at, updated_at) VALUES (" . (int)$orgId . ", " . (int)$memberId . ", " . $pdo->quote("member") . ", " . $pdo->quote($now) . ", " . $pdo->quote($now) . ", " . $pdo->quote($now) . ")");
+$adminToken = "fm_00000000-0000-4000-8000-000000000001";
+$memberToken = "fm_11111111-1111-4111-8111-111111111111";
+$pdo->exec("INSERT INTO fm_tokens (token, user_id, anon_id, expires_at, created_at, updated_at) VALUES (" . $pdo->quote($adminToken) . ", " . $pdo->quote((string)$adminId) . ", " . $pdo->quote("anon_admin") . ", " . $pdo->quote(date("Y-m-d H:i:s", strtotime("+1 day"))) . ", " . $pdo->quote($now) . ", " . $pdo->quote($now) . ")");
+$pdo->exec("INSERT INTO fm_tokens (token, user_id, anon_id, expires_at, created_at, updated_at) VALUES (" . $pdo->quote($memberToken) . ", " . $pdo->quote((string)$memberId) . ", " . $pdo->quote("anon_member") . ", " . $pdo->quote(date("Y-m-d H:i:s", strtotime("+1 day"))) . ", " . $pdo->quote($now) . ", " . $pdo->quote($now) . ")");
+$pdo->exec("INSERT INTO benefit_wallets (org_id, benefit_code, balance, created_at, updated_at) VALUES (" . (int)$orgId . ", " . $pdo->quote("B2B_ASSESSMENT_ATTEMPT_SUBMIT") . ", 10, " . $pdo->quote($now) . ", " . $pdo->quote($now) . ")");
+'
+
+ADMIN_TOKEN="fm_00000000-0000-4000-8000-000000000001"
+MEMBER_TOKEN="fm_11111111-1111-4111-8111-111111111111"
+ORG_ID=2500
+
+CREATE_JSON="${ART_DIR}/create_assessment.json"
+CREATE_BODY="$(php -r 'echo json_encode(["scale_code"=>"MBTI","title"=>"PR25 Team MBTI","due_at"=>date(DATE_ATOM, strtotime("+7 days"))], JSON_UNESCAPED_UNICODE);')"
+
+curl -sS -X POST "${API_BASE}/api/v0.4/orgs/${ORG_ID}/assessments" \
+  -H "Content-Type: application/json" -H "Accept: application/json" \
+  -H "Authorization: Bearer ${ADMIN_TOKEN}" \
+  -d "${CREATE_BODY}" > "${CREATE_JSON}"
+
+ASSESSMENT_ID="$(php -r '$j=json_decode(stream_get_contents(STDIN), true); echo $j["assessment"]["id"] ?? "";' < "${CREATE_JSON}")"
+if [[ -z "${ASSESSMENT_ID}" ]]; then
+  echo "[pr25][fail] assessment create failed"
+  cat "${CREATE_JSON}"
+  exit 1
+fi
+
+INVITE_JSON="${ART_DIR}/invite.json"
+INVITE_BODY="$(php -r '$subjects=[]; for ($i=0;$i<10;$i++){ $subjects[]=["subject_type"=>"email","subject_value"=>"member{$i}@example.com"]; } echo json_encode(["subjects"=>$subjects], JSON_UNESCAPED_UNICODE);')"
+
+curl -sS -X POST "${API_BASE}/api/v0.4/orgs/${ORG_ID}/assessments/${ASSESSMENT_ID}/invite" \
+  -H "Content-Type: application/json" -H "Accept: application/json" \
+  -H "Authorization: Bearer ${ADMIN_TOKEN}" \
+  -d "${INVITE_BODY}" > "${INVITE_JSON}"
+
+php -r '$j=json_decode(stream_get_contents(STDIN), true); $inv=$j["invites"] ?? []; $tokens=[]; foreach ($inv as $it){ $tokens[]=$it["invite_token"] ?? ""; } echo json_encode($tokens, JSON_UNESCAPED_UNICODE);' < "${INVITE_JSON}" > "${ART_DIR}/invite_tokens.json"
+
+if [[ ! -s "${ART_DIR}/invite_tokens.json" ]]; then
+  echo "[pr25][fail] invite tokens missing"
+  cat "${INVITE_JSON}"
+  exit 1
+fi
+
+QUESTIONS_JSON="${ART_DIR}/questions.json"
+curl -sS "${API_BASE}/api/v0.3/scales/MBTI/questions" \
+  -H "Accept: application/json" \
+  -H "Authorization: Bearer ${ADMIN_TOKEN}" \
+  -H "X-Org-Id: ${ORG_ID}" > "${QUESTIONS_JSON}"
+
+ANSWERS_JSON="${ART_DIR}/answers.json"
+php -r '
+$j=json_decode(stream_get_contents(STDIN), true);
+$items=$j["questions"]["items"] ?? [];
+$answers=[];
+foreach ($items as $item) {
+  if (!is_array($item)) continue;
+  $qid=$item["question_id"] ?? "";
+  $opts=$item["options"] ?? [];
+  if ($qid === "" || !is_array($opts) || count($opts) === 0) continue;
+  $code=$opts[0]["code"] ?? "";
+  if ($code === "") { $code="A"; }
+  $answers[]=["question_id"=>$qid, "code"=>$code];
+}
+echo json_encode($answers, JSON_UNESCAPED_UNICODE);
+' < "${QUESTIONS_JSON}" > "${ANSWERS_JSON}"
+
+if [[ ! -s "${ANSWERS_JSON}" ]]; then
+  echo "[pr25][fail] answers json empty"
+  exit 1
+fi
+
+for i in 0 1 2; do
+  START_JSON="${ART_DIR}/attempt_start_${i}.json"
+  START_BODY='{"scale_code":"MBTI"}'
+  curl -sS -X POST "${API_BASE}/api/v0.3/attempts/start" \
+    -H "Content-Type: application/json" -H "Accept: application/json" \
+    -H "Authorization: Bearer ${ADMIN_TOKEN}" \
+    -H "X-Org-Id: ${ORG_ID}" \
+    -d "${START_BODY}" > "${START_JSON}"
+
+  ATTEMPT_ID="$(php -r '$j=json_decode(stream_get_contents(STDIN), true); echo $j["attempt_id"] ?? "";' < "${START_JSON}")"
+  if [[ -z "${ATTEMPT_ID}" ]]; then
+    echo "[pr25][fail] attempt start failed"
+    cat "${START_JSON}"
+    exit 1
+  fi
+
+  INVITE_TOKEN="$(php -r '$list=json_decode(stream_get_contents(STDIN), true); echo $list['"${i}"'] ?? "";' < "${ART_DIR}/invite_tokens.json")"
+  SUBMIT_JSON="${ART_DIR}/attempt_submit_${i}.json"
+  SUBMIT_BODY="$(INVITE_TOKEN="${INVITE_TOKEN}" ATTEMPT_ID="${ATTEMPT_ID}" ANSWERS_PATH="${ANSWERS_JSON}" php -r '$answers=json_decode(file_get_contents(getenv("ANSWERS_PATH")), true); $token=getenv("INVITE_TOKEN"); $payload=["attempt_id"=>getenv("ATTEMPT_ID"),"answers"=>$answers,"duration_ms"=>120000,"invite_token"=>$token]; echo json_encode($payload, JSON_UNESCAPED_UNICODE);')"
+
+  curl -sS -X POST "${API_BASE}/api/v0.3/attempts/submit" \
+    -H "Content-Type: application/json" -H "Accept: application/json" \
+    -H "Authorization: Bearer ${ADMIN_TOKEN}" \
+    -H "X-Org-Id: ${ORG_ID}" \
+    -d "${SUBMIT_BODY}" > "${SUBMIT_JSON}"
+
+  OK_FLAG="$(php -r '$j=json_decode(stream_get_contents(STDIN), true); echo ($j["ok"] ?? false) ? "ok" : "";' < "${SUBMIT_JSON}")"
+  if [[ "${OK_FLAG}" != "ok" ]]; then
+    echo "[pr25][fail] attempt submit failed"
+    cat "${SUBMIT_JSON}"
+    exit 1
+  fi
+
+  BALANCE="$(php -r '$db=new PDO("sqlite:" . getenv("DB_DATABASE")); $stmt=$db->prepare("select balance from benefit_wallets where org_id=? and benefit_code=?"); $stmt->execute([2500, "B2B_ASSESSMENT_ATTEMPT_SUBMIT"]); $row=$stmt->fetch(PDO::FETCH_ASSOC); echo $row["balance"] ?? "";')"
+  EXPECTED=$((10 - i - 1))
+  if [[ "${BALANCE}" != "${EXPECTED}" ]]; then
+    echo "[pr25][fail] credits balance expected ${EXPECTED}, got ${BALANCE}"
+    exit 1
+  fi
+  echo "[pr25] credits_balance_after_${i}=${BALANCE}"
+
+done
+
+PROGRESS_JSON="${ART_DIR}/progress.json"
+curl -sS "${API_BASE}/api/v0.4/orgs/${ORG_ID}/assessments/${ASSESSMENT_ID}/progress" \
+  -H "Accept: application/json" \
+  -H "Authorization: Bearer ${ADMIN_TOKEN}" > "${PROGRESS_JSON}"
+
+php -r '$j=json_decode(stream_get_contents(STDIN), true); $c=$j["completed"] ?? null; $t=$j["total"] ?? null; $p=$j["pending"] ?? null; if ($c!==3 || $t!==10 || $p!==7) { fwrite(STDERR, "[pr25][fail] progress counts mismatch\n"); exit(1);} echo "[pr25] progress ok\n";' < "${PROGRESS_JSON}"
+
+SUMMARY_JSON="${ART_DIR}/summary.json"
+curl -sS "${API_BASE}/api/v0.4/orgs/${ORG_ID}/assessments/${ASSESSMENT_ID}/summary" \
+  -H "Accept: application/json" \
+  -H "Authorization: Bearer ${ADMIN_TOKEN}" > "${SUMMARY_JSON}"
+
+php -r '$j=json_decode(stream_get_contents(STDIN), true); $s=$j["summary"] ?? []; $need=["completion_rate","due_at","window","score_distribution","dimension_means"]; foreach ($need as $k){ if (!array_key_exists($k, $s)){ fwrite(STDERR, "[pr25][fail] summary missing {$k}\n"); exit(1);} } echo "[pr25] summary ok\n";' < "${SUMMARY_JSON}"
+
+RBAC_PROGRESS_JSON="${ART_DIR}/rbac_progress.json"
+RBAC_STATUS="$(curl -sS -o "${RBAC_PROGRESS_JSON}" -w "%{http_code}" "${API_BASE}/api/v0.4/orgs/${ORG_ID}/assessments/${ASSESSMENT_ID}/progress" \
+  -H "Accept: application/json" \
+  -H "Authorization: Bearer ${MEMBER_TOKEN}")"
+if [[ "${RBAC_STATUS}" != "404" ]]; then
+  echo "[pr25][fail] member progress should be 404"
+  cat "${RBAC_PROGRESS_JSON}"
+  exit 1
+fi
+
+RBAC_SUMMARY_JSON="${ART_DIR}/rbac_summary.json"
+RBAC_SUMMARY_STATUS="$(curl -sS -o "${RBAC_SUMMARY_JSON}" -w "%{http_code}" "${API_BASE}/api/v0.4/orgs/${ORG_ID}/assessments/${ASSESSMENT_ID}/summary" \
+  -H "Accept: application/json" \
+  -H "Authorization: Bearer ${MEMBER_TOKEN}")"
+if [[ "${RBAC_SUMMARY_STATUS}" != "404" ]]; then
+  echo "[pr25][fail] member summary should be 404"
+  cat "${RBAC_SUMMARY_JSON}"
+  exit 1
+fi
+
+php -r '$db=new PDO("sqlite:" . getenv("DB_DATABASE")); $db->exec("UPDATE benefit_wallets SET balance=0, updated_at=strftime(\"%Y-%m-%d %H:%M:%S\", \"now\") WHERE org_id=2500 AND benefit_code=\"B2B_ASSESSMENT_ATTEMPT_SUBMIT\"");'
+
+START_JSON="${ART_DIR}/attempt_start_insufficient.json"
+curl -sS -X POST "${API_BASE}/api/v0.3/attempts/start" \
+  -H "Content-Type: application/json" -H "Accept: application/json" \
+  -H "Authorization: Bearer ${ADMIN_TOKEN}" \
+  -H "X-Org-Id: ${ORG_ID}" \
+  -d '{"scale_code":"MBTI"}' > "${START_JSON}"
+ATTEMPT_ID="$(php -r '$j=json_decode(stream_get_contents(STDIN), true); echo $j["attempt_id"] ?? "";' < "${START_JSON}")"
+INVITE_TOKEN="$(php -r '$list=json_decode(stream_get_contents(STDIN), true); echo $list[3] ?? "";' < "${ART_DIR}/invite_tokens.json")"
+
+SUBMIT_JSON="${ART_DIR}/attempt_submit_insufficient.json"
+SUBMIT_BODY="$(ATTEMPT_ID="${ATTEMPT_ID}" INVITE_TOKEN="${INVITE_TOKEN}" ANSWERS_PATH="${ANSWERS_JSON}" php -r '$answers=json_decode(file_get_contents(getenv("ANSWERS_PATH")), true); $payload=["attempt_id"=>getenv("ATTEMPT_ID"),"answers"=>$answers,"duration_ms"=>120000,"invite_token"=>getenv("INVITE_TOKEN")]; echo json_encode($payload, JSON_UNESCAPED_UNICODE);')"
+
+SUBMIT_STATUS="$(curl -sS -o "${SUBMIT_JSON}" -w "%{http_code}" -X POST "${API_BASE}/api/v0.3/attempts/submit" \
+  -H "Content-Type: application/json" -H "Accept: application/json" \
+  -H "Authorization: Bearer ${ADMIN_TOKEN}" \
+  -H "X-Org-Id: ${ORG_ID}" \
+  -d "${SUBMIT_BODY}")"
+
+if [[ "${SUBMIT_STATUS}" != "402" ]]; then
+  echo "[pr25][fail] insufficient credits status mismatch"
+  cat "${SUBMIT_JSON}"
+  exit 1
+fi
+
+php -r '$j=json_decode(stream_get_contents(STDIN), true); $code=$j["error"]["code"] ?? ""; if ($code !== "CREDITS_INSUFFICIENT") { fwrite(STDERR, "[pr25][fail] insufficient code mismatch\n"); exit(1);} echo "[pr25] insufficient ok\n";' < "${SUBMIT_JSON}"
+
+if [[ -f "${SERVER_PID_FILE}" ]]; then
+  SERVER_PID="$(cat "${SERVER_PID_FILE}")"
+  if [[ -n "${SERVER_PID}" ]] && ps -p "${SERVER_PID}" >/dev/null 2>&1; then
+    kill "${SERVER_PID}" >/dev/null 2>&1 || true
+  fi
+fi
+
+cleanup_port "${SERVE_PORT}"
+cleanup_port 18000
+
+if lsof -nP -iTCP:"${SERVE_PORT}" -sTCP:LISTEN >/dev/null 2>&1; then
+  echo "[pr25][fail] port ${SERVE_PORT} still in use"
+  exit 1
+fi
+
+echo "[pr25] verify ok"

--- a/backend/tests/Feature/V0_3/CreditsConsumeOnAttemptSubmitTest.php
+++ b/backend/tests/Feature/V0_3/CreditsConsumeOnAttemptSubmitTest.php
@@ -1,0 +1,241 @@
+<?php
+
+namespace Tests\Feature\V0_3;
+
+use App\Services\Auth\FmTokenService;
+use Database\Seeders\Pr17SimpleScoreDemoSeeder;
+use Database\Seeders\ScaleRegistrySeeder;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Str;
+use Tests\TestCase;
+
+class CreditsConsumeOnAttemptSubmitTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private function seedScales(): void
+    {
+        (new ScaleRegistrySeeder())->run();
+        (new Pr17SimpleScoreDemoSeeder())->run();
+
+        $row = DB::table('scales_registry')
+            ->where('org_id', 0)
+            ->where('code', 'SIMPLE_SCORE_DEMO')
+            ->first();
+
+        if ($row) {
+            $commercial = $row->commercial_json ?? null;
+            if (is_string($commercial)) {
+                $decoded = json_decode($commercial, true);
+                $commercial = is_array($decoded) ? $decoded : null;
+            }
+            if (!is_array($commercial)) {
+                $commercial = [];
+            }
+
+            unset($commercial['credit_benefit_code']);
+            $payload = json_encode($commercial, JSON_UNESCAPED_UNICODE);
+
+            DB::table('scales_registry')
+                ->where('org_id', 0)
+                ->where('code', 'SIMPLE_SCORE_DEMO')
+                ->update([
+                    'commercial_json' => $payload,
+                    'updated_at' => now(),
+                ]);
+        }
+
+        Cache::flush();
+    }
+
+    private function seedOrgWithToken(): array
+    {
+        $userId = (int) DB::table('users')->insertGetId([
+            'name' => 'B2B User',
+            'email' => 'b2b-user@example.com',
+            'password' => bcrypt('secret'),
+            'created_at' => now(),
+            'updated_at' => now(),
+        ]);
+
+        $orgId = (int) DB::table('organizations')->insertGetId([
+            'name' => 'B2B Org',
+            'owner_user_id' => $userId,
+            'created_at' => now(),
+            'updated_at' => now(),
+        ]);
+
+        DB::table('organization_members')->insert([
+            'org_id' => $orgId,
+            'user_id' => $userId,
+            'role' => 'member',
+            'joined_at' => now(),
+            'created_at' => now(),
+            'updated_at' => now(),
+        ]);
+
+        $issued = app(FmTokenService::class)->issueForUser((string) $userId);
+
+        return [$orgId, $userId, (string) ($issued['token'] ?? '')];
+    }
+
+    private function seedWallet(int $orgId, int $balance): void
+    {
+        DB::table('benefit_wallets')->insert([
+            'org_id' => $orgId,
+            'benefit_code' => 'B2B_ASSESSMENT_ATTEMPT_SUBMIT',
+            'balance' => $balance,
+            'created_at' => now(),
+            'updated_at' => now(),
+        ]);
+    }
+
+    private function createAssessmentWithAssignments(int $orgId, int $userId, int $count): array
+    {
+        $assessmentId = (int) DB::table('assessments')->insertGetId([
+            'org_id' => $orgId,
+            'scale_code' => 'SIMPLE_SCORE_DEMO',
+            'title' => 'Credits Demo',
+            'created_by' => $userId,
+            'due_at' => now()->addDays(3),
+            'status' => 'open',
+            'created_at' => now(),
+            'updated_at' => now(),
+        ]);
+
+        $tokens = [];
+        for ($i = 0; $i < $count; $i++) {
+            $token = Str::random(40);
+            $tokens[] = $token;
+
+            DB::table('assessment_assignments')->insert([
+                'org_id' => $orgId,
+                'assessment_id' => $assessmentId,
+                'subject_type' => 'email',
+                'subject_value' => "member{$i}@example.com",
+                'invite_token' => $token,
+                'started_at' => null,
+                'completed_at' => null,
+                'attempt_id' => null,
+                'created_at' => now(),
+                'updated_at' => now(),
+            ]);
+        }
+
+        return $tokens;
+    }
+
+    private function fetchAnswers(int $orgId, string $token): array
+    {
+        $questions = $this->withHeaders([
+            'Authorization' => 'Bearer ' . $token,
+            'X-Org-Id' => (string) $orgId,
+        ])->getJson('/api/v0.3/scales/SIMPLE_SCORE_DEMO/questions');
+
+        $questions->assertStatus(200);
+        $items = $questions->json('questions.items');
+        $this->assertIsArray($items);
+
+        $answers = [];
+        foreach ($items as $item) {
+            if (!is_array($item)) {
+                continue;
+            }
+            $qid = (string) ($item['question_id'] ?? '');
+            $options = $item['options'] ?? [];
+            if ($qid === '' || !is_array($options) || $options === []) {
+                continue;
+            }
+            $code = (string) ($options[0]['code'] ?? '');
+            if ($code === '') {
+                continue;
+            }
+            $answers[] = [
+                'question_id' => $qid,
+                'code' => $code,
+            ];
+        }
+
+        return $answers;
+    }
+
+    public function test_consume_b2b_credits_and_insufficient_response(): void
+    {
+        $this->seedScales();
+        [$orgId, $userId, $token] = $this->seedOrgWithToken();
+
+        $this->seedWallet($orgId, 3);
+        $inviteTokens = $this->createAssessmentWithAssignments($orgId, $userId, 4);
+
+        $answers = $this->fetchAnswers($orgId, $token);
+        $this->assertNotEmpty($answers);
+
+        for ($i = 0; $i < 3; $i++) {
+            $start = $this->withHeaders([
+                'Authorization' => 'Bearer ' . $token,
+                'X-Org-Id' => (string) $orgId,
+            ])->postJson('/api/v0.3/attempts/start', [
+                'scale_code' => 'SIMPLE_SCORE_DEMO',
+            ]);
+            $start->assertStatus(200);
+            $attemptId = (string) $start->json('attempt_id');
+
+            $submit = $this->withHeaders([
+                'Authorization' => 'Bearer ' . $token,
+                'X-Org-Id' => (string) $orgId,
+            ])->postJson('/api/v0.3/attempts/submit', [
+                'attempt_id' => $attemptId,
+                'answers' => $answers,
+                'duration_ms' => 120000,
+                'invite_token' => $inviteTokens[$i],
+            ]);
+            $submit->assertStatus(200);
+            $submit->assertJson(['ok' => true]);
+
+            $wallet = DB::table('benefit_wallets')
+                ->where('org_id', $orgId)
+                ->where('benefit_code', 'B2B_ASSESSMENT_ATTEMPT_SUBMIT')
+                ->first();
+            $this->assertSame(2 - $i, (int) ($wallet->balance ?? -1));
+        }
+
+        DB::table('benefit_wallets')
+            ->where('org_id', $orgId)
+            ->where('benefit_code', 'B2B_ASSESSMENT_ATTEMPT_SUBMIT')
+            ->update([
+                'balance' => 0,
+                'updated_at' => now(),
+            ]);
+
+        $start = $this->withHeaders([
+            'Authorization' => 'Bearer ' . $token,
+            'X-Org-Id' => (string) $orgId,
+        ])->postJson('/api/v0.3/attempts/start', [
+            'scale_code' => 'SIMPLE_SCORE_DEMO',
+        ]);
+        $start->assertStatus(200);
+        $attemptId = (string) $start->json('attempt_id');
+
+        $submit = $this->withHeaders([
+            'Authorization' => 'Bearer ' . $token,
+            'X-Org-Id' => (string) $orgId,
+        ])->postJson('/api/v0.3/attempts/submit', [
+            'attempt_id' => $attemptId,
+            'answers' => $answers,
+            'duration_ms' => 120000,
+            'invite_token' => $inviteTokens[3],
+        ]);
+
+        $submit->assertStatus(402);
+        $submit->assertJson([
+            'ok' => false,
+            'error' => [
+                'code' => 'CREDITS_INSUFFICIENT',
+                'benefit_code' => 'B2B_ASSESSMENT_ATTEMPT_SUBMIT',
+                'required' => 1,
+            ],
+        ]);
+    }
+}

--- a/backend/tests/Feature/V0_4/AssessmentsProgressSummaryTest.php
+++ b/backend/tests/Feature/V0_4/AssessmentsProgressSummaryTest.php
@@ -1,0 +1,189 @@
+<?php
+
+namespace Tests\Feature\V0_4;
+
+use App\Services\Auth\FmTokenService;
+use Database\Seeders\ScaleRegistrySeeder;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Str;
+use Tests\TestCase;
+
+class AssessmentsProgressSummaryTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private function seedScales(): void
+    {
+        (new ScaleRegistrySeeder())->run();
+    }
+
+    private function createUser(string $email): int
+    {
+        return (int) DB::table('users')->insertGetId([
+            'name' => $email,
+            'email' => $email,
+            'password' => bcrypt('secret'),
+            'created_at' => now(),
+            'updated_at' => now(),
+        ]);
+    }
+
+    private function issueToken(int $userId): string
+    {
+        $issued = app(FmTokenService::class)->issueForUser((string) $userId);
+        return (string) ($issued['token'] ?? '');
+    }
+
+    public function test_progress_and_summary_fields(): void
+    {
+        $this->seedScales();
+
+        $adminId = $this->createUser('admin@summary.test');
+        $orgId = DB::table('organizations')->insertGetId([
+            'name' => 'Org Summary',
+            'owner_user_id' => $adminId,
+            'created_at' => now(),
+            'updated_at' => now(),
+        ]);
+
+        DB::table('organization_members')->insert([
+            'org_id' => $orgId,
+            'user_id' => $adminId,
+            'role' => 'admin',
+            'joined_at' => now(),
+            'created_at' => now(),
+            'updated_at' => now(),
+        ]);
+
+        $token = $this->issueToken($adminId);
+
+        $create = $this->withHeaders([
+            'Authorization' => 'Bearer ' . $token,
+        ])->postJson("/api/v0.4/orgs/{$orgId}/assessments", [
+            'scale_code' => 'MBTI',
+            'title' => 'Team MBTI',
+            'due_at' => now()->addDays(7)->toISOString(),
+        ]);
+        $create->assertStatus(200);
+        $assessmentId = (int) $create->json('assessment.id');
+        $this->assertGreaterThan(0, $assessmentId);
+
+        $subjects = [];
+        for ($i = 0; $i < 10; $i++) {
+            $subjects[] = [
+                'subject_type' => 'email',
+                'subject_value' => "member{$i}@example.com",
+            ];
+        }
+
+        $invite = $this->withHeaders([
+            'Authorization' => 'Bearer ' . $token,
+        ])->postJson("/api/v0.4/orgs/{$orgId}/assessments/{$assessmentId}/invite", [
+            'subjects' => $subjects,
+        ]);
+        $invite->assertStatus(200);
+        $invite->assertJson([
+            'ok' => true,
+            'total' => 10,
+        ]);
+        $invites = $invite->json('invites');
+        $this->assertIsArray($invites);
+        $this->assertCount(10, $invites);
+
+        $now = now();
+        for ($i = 0; $i < 3; $i++) {
+            $attemptId = (string) Str::uuid();
+            DB::table('attempts')->insert([
+                'id' => $attemptId,
+                'anon_id' => 'anon_' . $attemptId,
+                'user_id' => (string) $adminId,
+                'org_id' => $orgId,
+                'scale_code' => 'MBTI',
+                'scale_version' => 'v0.3',
+                'question_count' => 144,
+                'answers_summary_json' => json_encode(['stage' => 'submit']),
+                'client_platform' => 'test',
+                'client_version' => null,
+                'channel' => null,
+                'referrer' => null,
+                'started_at' => $now,
+                'submitted_at' => $now,
+                'created_at' => $now,
+                'updated_at' => $now,
+            ]);
+
+            DB::table('results')->insert([
+                'id' => (string) Str::uuid(),
+                'attempt_id' => $attemptId,
+                'org_id' => $orgId,
+                'scale_code' => 'MBTI',
+                'scale_version' => 'v0.3',
+                'type_code' => 'INTJ-A',
+                'scores_json' => json_encode(['EI' => 10, 'SN' => 12, 'TF' => 14, 'JP' => 8, 'AT' => 6]),
+                'scores_pct' => json_encode(['EI' => 55, 'SN' => 62, 'TF' => 71, 'JP' => 48, 'AT' => 60]),
+                'axis_states' => json_encode(['EI' => 'weak', 'SN' => 'clear', 'TF' => 'strong', 'JP' => 'weak', 'AT' => 'clear']),
+                'profile_version' => null,
+                'content_package_version' => 'v0.2.1-TEST',
+                'result_json' => json_encode([
+                    'final_score' => 144,
+                    'axis_scores_json' => [
+                        'scores_pct' => ['EI' => 55, 'SN' => 62, 'TF' => 71, 'JP' => 48, 'AT' => 60],
+                    ],
+                ]),
+                'pack_id' => 'MBTI.cn-mainland.zh-CN.v0.2.1-TEST',
+                'dir_version' => 'MBTI-CN-v0.2.1-TEST',
+                'scoring_spec_version' => '2026.01',
+                'report_engine_version' => 'v1.2',
+                'is_valid' => 1,
+                'computed_at' => $now,
+                'created_at' => $now,
+                'updated_at' => $now,
+            ]);
+
+            $tokenRow = (string) ($invites[$i]['invite_token'] ?? '');
+            DB::table('assessment_assignments')
+                ->where('invite_token', $tokenRow)
+                ->update([
+                    'attempt_id' => $attemptId,
+                    'started_at' => $now,
+                    'completed_at' => $now,
+                    'updated_at' => $now,
+                ]);
+        }
+
+        $progress = $this->withHeaders([
+            'Authorization' => 'Bearer ' . $token,
+        ])->getJson("/api/v0.4/orgs/{$orgId}/assessments/{$assessmentId}/progress");
+        $progress->assertStatus(200);
+        $progress->assertJson([
+            'ok' => true,
+            'total' => 10,
+            'completed' => 3,
+            'pending' => 7,
+        ]);
+
+        $summary = $this->withHeaders([
+            'Authorization' => 'Bearer ' . $token,
+        ])->getJson("/api/v0.4/orgs/{$orgId}/assessments/{$assessmentId}/summary");
+        $summary->assertStatus(200);
+        $summary->assertJson([
+            'ok' => true,
+            'summary' => [
+                'completion_rate' => [
+                    'completed' => 3,
+                    'total' => 10,
+                ],
+            ],
+        ]);
+        $summary->assertJsonStructure([
+            'summary' => [
+                'completion_rate',
+                'due_at',
+                'window' => ['start_at', 'end_at'],
+                'score_distribution',
+                'dimension_means',
+            ],
+        ]);
+    }
+}

--- a/backend/tests/Feature/V0_4/AssessmentsRbacIsolationTest.php
+++ b/backend/tests/Feature/V0_4/AssessmentsRbacIsolationTest.php
@@ -1,0 +1,117 @@
+<?php
+
+namespace Tests\Feature\V0_4;
+
+use App\Services\Auth\FmTokenService;
+use Database\Seeders\ScaleRegistrySeeder;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\DB;
+use Tests\TestCase;
+
+class AssessmentsRbacIsolationTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private function seedScales(): void
+    {
+        (new ScaleRegistrySeeder())->run();
+    }
+
+    private function createUser(string $email): int
+    {
+        return (int) DB::table('users')->insertGetId([
+            'name' => $email,
+            'email' => $email,
+            'password' => bcrypt('secret'),
+            'created_at' => now(),
+            'updated_at' => now(),
+        ]);
+    }
+
+    private function issueToken(int $userId): string
+    {
+        $issued = app(FmTokenService::class)->issueForUser((string) $userId);
+        return (string) ($issued['token'] ?? '');
+    }
+
+    public function test_member_viewer_blocked_and_cross_org_isolated(): void
+    {
+        $this->seedScales();
+
+        $adminId = $this->createUser('admin@org.test');
+        $memberId = $this->createUser('member@org.test');
+        $viewerId = $this->createUser('viewer@org.test');
+
+        $orgId = DB::table('organizations')->insertGetId([
+            'name' => 'Org Alpha',
+            'owner_user_id' => $adminId,
+            'created_at' => now(),
+            'updated_at' => now(),
+        ]);
+
+        DB::table('organization_members')->insert([
+            [
+                'org_id' => $orgId,
+                'user_id' => $adminId,
+                'role' => 'admin',
+                'joined_at' => now(),
+                'created_at' => now(),
+                'updated_at' => now(),
+            ],
+            [
+                'org_id' => $orgId,
+                'user_id' => $memberId,
+                'role' => 'member',
+                'joined_at' => now(),
+                'created_at' => now(),
+                'updated_at' => now(),
+            ],
+            [
+                'org_id' => $orgId,
+                'user_id' => $viewerId,
+                'role' => 'viewer',
+                'joined_at' => now(),
+                'created_at' => now(),
+                'updated_at' => now(),
+            ],
+        ]);
+
+        $adminToken = $this->issueToken($adminId);
+        $memberToken = $this->issueToken($memberId);
+        $viewerToken = $this->issueToken($viewerId);
+
+        $create = $this->withHeaders([
+            'Authorization' => 'Bearer ' . $adminToken,
+        ])->postJson("/api/v0.4/orgs/{$orgId}/assessments", [
+            'scale_code' => 'MBTI',
+            'title' => 'Q1 MBTI',
+            'due_at' => now()->addDays(14)->toISOString(),
+        ]);
+
+        $create->assertStatus(200);
+        $assessmentId = (int) $create->json('assessment.id');
+        $this->assertGreaterThan(0, $assessmentId);
+
+        $memberProgress = $this->withHeaders([
+            'Authorization' => 'Bearer ' . $memberToken,
+        ])->getJson("/api/v0.4/orgs/{$orgId}/assessments/{$assessmentId}/progress");
+        $memberProgress->assertStatus(404);
+
+        $viewerSummary = $this->withHeaders([
+            'Authorization' => 'Bearer ' . $viewerToken,
+        ])->getJson("/api/v0.4/orgs/{$orgId}/assessments/{$assessmentId}/summary");
+        $viewerSummary->assertStatus(404);
+
+        $otherOrgId = DB::table('organizations')->insertGetId([
+            'name' => 'Org Beta',
+            'owner_user_id' => $adminId,
+            'created_at' => now(),
+            'updated_at' => now(),
+        ]);
+
+        $cross = $this->withHeaders([
+            'Authorization' => 'Bearer ' . $adminToken,
+        ])->getJson("/api/v0.4/orgs/{$otherOrgId}/assessments/{$assessmentId}/progress");
+        $cross->assertStatus(404);
+    }
+}

--- a/docs/verify/pr25_recon.md
+++ b/docs/verify/pr25_recon.md
@@ -1,0 +1,29 @@
+# PR25 Recon
+
+- 相关入口文件：
+  - backend/routes/api.php
+  - backend/app/Http/Controllers/API/V0_4/AssessmentController.php
+  - backend/app/Http/Controllers/API/V0_3/AttemptsController.php
+  - backend/app/Http/Middleware/RequireOrgRole.php
+- 相关路由：
+  - POST /api/v0.4/orgs/{org_id}/assessments
+  - POST /api/v0.4/orgs/{org_id}/assessments/{id}/invite
+  - GET /api/v0.4/orgs/{org_id}/assessments/{id}/progress
+  - GET /api/v0.4/orgs/{org_id}/assessments/{id}/summary
+  - POST /api/v0.3/attempts/submit (invite_token + credits)
+- 相关 DB 表/迁移：
+  - assessments
+  - assessment_assignments
+  - organization_members.role 扩展 (owner/admin/member/viewer)
+- 需要新增/修改点：
+  - v0.4 assessments create/invite/progress/summary
+  - attempt_submit 绑定 invite_token + credits 消耗
+  - RequireOrgRole 中间件 + member/viewer 只读自身结果
+  - 验收脚本/Workflow/测试覆盖
+- 风险点与规避（端口/CI 工具依赖/pack-seed-config 一致性/sqlite 迁移一致性/404 口径/脱敏）：
+  - 固定端口 1825，脚本强制清理端口 + 回收 PID
+  - CI/脚本禁止 rg/jq，使用 grep -E + php -r
+  - 校验 config/scales_registry/pack 目录一致性
+  - sqlite fresh migrate 可跑通（迁移幂等）
+  - RBAC/跨 org 一律 404
+  - artifacts 输出后统一 sanitize

--- a/docs/verify/pr25_verify.md
+++ b/docs/verify/pr25_verify.md
@@ -1,0 +1,23 @@
+# PR25 Verify
+
+## Commands
+```bash
+export CI=true
+export FAP_NONINTERACTIVE=1
+export COMPOSER_NO_INTERACTION=1
+export GIT_TERMINAL_PROMPT=0
+export NO_COLOR=1
+
+bash backend/scripts/pr25_accept.sh
+bash backend/scripts/ci_verify_mbti.sh
+```
+
+## Expected outputs
+- Artifacts in `backend/artifacts/pr25/`
+  - `verify.log`, `server.log`, `summary.txt`
+  - `progress.json`, `summary.json`
+  - `attempt_start_*.json`, `attempt_submit_*.json`
+- `/api/v0.4/orgs/{org_id}/assessments/*` available for owner/admin only
+- progress shows total=10 completed=3 pending=7 after 3 submits
+- summary includes `completion_rate`, `window`, `score_distribution`, `dimension_means`
+- credits insufficient returns 402 + `CREDITS_INSUFFICIENT`


### PR DESCRIPTION
 - What:
      - 新增企业版团队测评任务（assessments）与邀请分发
        （assessment_assignments），提供进度与汇总统计接口，并在 attempt_submit
        完成时消耗 credits。
  - Why:
      - 对齐 Truity 团队版闭环：管理员分发、跟踪进度、统一汇总；org_id 强隔离与
        PR9 仪表盘口径一致。
  - How:
      - 新增 assessments/assessment_assignments 迁移与索引
      - organization_members.role 扩展 owner/admin/member/viewer，并用中间件做
        RBAC（越权 404）
      - v0.4 新增 assessments create/invite/progress/summary
      - summary 聚合复用 PR9 的 results/events 统计口径
      - attempt_submit 支持 invite_token 回写 assignment，同时按
        benefit_code=B2B_ASSESSMENT_ATTEMPT_SUBMIT 消耗 1 credit；不足返回 402 +
        CREDITS_INSUFFICIENT
  - Verify:
      - bash backend/scripts/pr25_accept.sh
      - bash backend/scripts/ci_verify_mbti.sh
  - Artifacts:
      - backend/artifacts/pr25/summary.txt
