### PR TITLE
fix(pr217): persist share + load type_profiles from items

### DIFF
--- a/backend/scripts/pr217_accept.sh
+++ b/backend/scripts/pr217_accept.sh
@@ -1,0 +1,109 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+export CI=true
+export FAP_NONINTERACTIVE=1
+export COMPOSER_NO_INTERACTION=1
+export GIT_TERMINAL_PROMPT=0
+export NO_COLOR=1
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+BACKEND_DIR="$(cd "${SCRIPT_DIR}/.." && pwd)"
+REPO_DIR="$(cd "${BACKEND_DIR}/.." && pwd)"
+
+SERVE_PORT="${SERVE_PORT:-18217}"
+ART_DIR="${ART_DIR:-${BACKEND_DIR}/artifacts/pr217}"
+mkdir -p "${ART_DIR}"
+
+SERVE_LOG_RAW="/tmp/pr217_server_raw.log"
+SERVE_LOG="${ART_DIR}/server.log"
+
+redact() {
+  sed -E \
+    -e 's#(/Users|/home)/[^ ]+#/REDACTED#g' \
+    -e 's#Authorization: Bearer [^[:space:]]+#Authorization: Bearer REDACTED#g' \
+    -e 's#(FAP_ADMIN_TOKEN|DB_PASSWORD|password)=([^[:space:]]+)#\1=REDACTED#g'
+}
+
+sanitize_server_log() {
+  if [ -f "${SERVE_LOG_RAW}" ]; then
+    redact < "${SERVE_LOG_RAW}" > "${SERVE_LOG}"
+  fi
+}
+
+fail() {
+  local code=$?
+  set +e
+  sanitize_server_log
+  {
+    echo "[FAIL] pr217_accept failed"
+    echo "reason=server_or_verify_failed"
+  } | tee "${ART_DIR}/summary.txt"
+
+  if [ -f "${SERVE_LOG}" ]; then
+    echo "--- server.log (tail) ---"
+    tail -n 200 "${SERVE_LOG}"
+  fi
+  if [ -f "${BACKEND_DIR}/storage/logs/laravel.log" ]; then
+    echo "--- laravel.log (tail) ---"
+    tail -n 200 "${BACKEND_DIR}/storage/logs/laravel.log" | redact
+  fi
+  exit "${code}"
+}
+trap fail ERR
+
+# kill ports
+for p in "${SERVE_PORT}" 18000; do
+  lsof -ti tcp:${p} | xargs -r kill -9 || true
+done
+
+DB_FILE="/tmp/pr217.sqlite"
+rm -f "${DB_FILE}"
+touch "${DB_FILE}"
+chmod 666 "${DB_FILE}"
+
+cd "${BACKEND_DIR}"
+composer install --no-interaction --prefer-dist --no-progress
+
+# env
+cp -n .env.example .env || true
+php artisan key:generate --force || true
+php artisan config:clear || true
+
+# migrate + seed
+export APP_ENV=testing
+export DB_CONNECTION=sqlite
+export DB_DATABASE="${DB_FILE}"
+export QUEUE_CONNECTION=sync
+
+php artisan migrate --force
+php artisan db:seed --class="Database\\Seeders\\CiScalesRegistrySeeder" --force --no-interaction || true
+php artisan fap:scales:sync-slugs || true
+
+# start server
+: > "${SERVE_LOG_RAW}"
+php artisan serve --host=127.0.0.1 --port="${SERVE_PORT}" >"${SERVE_LOG_RAW}" 2>&1 &
+PID=$!
+echo "${PID}" > "${ART_DIR}/server.pid"
+
+cleanup() {
+  kill "${PID}" >/dev/null 2>&1 || true
+  lsof -ti tcp:${SERVE_PORT} | xargs -r kill -9 || true
+  sanitize_server_log
+}
+trap cleanup EXIT
+
+# wait health
+API="http://127.0.0.1:${SERVE_PORT}"
+for i in $(seq 1 60); do
+  curl -fsS "${API}/api/v0.2/health" >/dev/null 2>&1 && break
+  sleep 0.2
+done
+curl -fsS "${API}/api/v0.2/health" > "${ART_DIR}/health.json"
+
+# run verify
+bash "${SCRIPT_DIR}/pr217_verify.sh"
+
+sanitize_server_log
+
+echo "[OK] pr217 accept passed" | tee "${ART_DIR}/summary.txt"

--- a/backend/scripts/pr217_verify.sh
+++ b/backend/scripts/pr217_verify.sh
@@ -1,0 +1,126 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+export CI=true
+export FAP_NONINTERACTIVE=1
+export COMPOSER_NO_INTERACTION=1
+export GIT_TERMINAL_PROMPT=0
+export NO_COLOR=1
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+BACKEND_DIR="$(cd "${SCRIPT_DIR}/.." && pwd)"
+REPO_DIR="$(cd "${BACKEND_DIR}/.." && pwd)"
+
+SERVE_PORT="${SERVE_PORT:-18217}"
+ART_DIR="${ART_DIR:-${BACKEND_DIR}/artifacts/pr217}"
+mkdir -p "${ART_DIR}"
+API="http://127.0.0.1:${SERVE_PORT}"
+
+redact() {
+  sed -E \
+    -e 's#(/Users|/home)/[^ ]+#/REDACTED#g' \
+    -e 's#Authorization: Bearer [^[:space:]]+#Authorization: Bearer REDACTED#g' \
+    -e 's#(FAP_ADMIN_TOKEN|DB_PASSWORD|password)=([^[:space:]]+)#\1=REDACTED#g'
+}
+
+fail() {
+  local code=$?
+  set +e
+  echo "[FAIL] pr217_verify failed"
+  if [ -f "${ART_DIR}/server.log" ]; then
+    echo "--- server.log (tail) ---"
+    tail -n 200 "${ART_DIR}/server.log" | redact
+  fi
+  if [ -f "${BACKEND_DIR}/storage/logs/laravel.log" ]; then
+    echo "--- laravel.log (tail) ---"
+    tail -n 200 "${BACKEND_DIR}/storage/logs/laravel.log" | redact
+  fi
+  exit "${code}"
+}
+trap fail ERR
+
+cd "${BACKEND_DIR}"
+
+# 1) fetch questions (v0.3)
+curl -fsS -H "Accept: application/json" -H "X-Region: CN_MAINLAND" -H "Accept-Language: zh-CN" \
+  "${API}/api/v0.3/scales/MBTI/questions" > "${ART_DIR}/questions.json"
+
+# 2) create attempt
+curl -fsS -X POST \
+  -H "Accept: application/json" -H "Content-Type: application/json" \
+  -H "X-Region: CN_MAINLAND" -H "Accept-Language: zh-CN" \
+  --data '{"scale_code":"MBTI","anon_id":"pr217-cli"}' \
+  "${API}/api/v0.3/attempts/start" > "${ART_DIR}/attempt_start.json"
+
+ATTEMPT_ID="$(php -r ' $d=json_decode(file_get_contents("'"${ART_DIR}/attempt_start.json"'"),true); echo $d["attempt_id"]??""; ')"
+test -n "${ATTEMPT_ID}"
+echo "${ATTEMPT_ID}" > "${ART_DIR}/attempt_id.txt"
+
+# 3) build answers dynamically
+php -r '
+$q=json_decode(file_get_contents("'"${ART_DIR}/questions.json"'"),true);
+$items=$q["questions"]["items"] ?? $q["items"] ?? ($q["questions"] ?? []);
+$ans=[];
+foreach($items as $it){
+  $qid=$it["question_id"] ?? "";
+  if($qid==="") continue;
+  $ans[$qid] = ["question_id"=>$qid,"option_code"=>"C"];
+}
+file_put_contents("'"${ART_DIR}/submit.json"'", json_encode([
+  "attempt_id"=>"'"${ATTEMPT_ID}"'",
+  "duration_ms"=>45000,
+  "answers"=>$ans,
+], JSON_UNESCAPED_UNICODE));
+'
+
+# 4) submit
+curl -fsS -X POST \
+  -H "Accept: application/json" -H "Content-Type: application/json" \
+  -H "X-Region: CN_MAINLAND" -H "Accept-Language: zh-CN" \
+  --data-binary @"${ART_DIR}/submit.json" \
+  "${API}/api/v0.3/attempts/submit" > "${ART_DIR}/submit_resp.json"
+
+# 5) share (v0.2)
+curl -fsS -H "Accept: application/json" -H "X-Region: CN_MAINLAND" -H "Accept-Language: zh-CN" \
+  "${API}/api/v0.2/attempts/${ATTEMPT_ID}/share" > "${ART_DIR}/share.json"
+
+# 6) assert response (no jq)
+php -r '
+$d=json_decode(file_get_contents("'"${ART_DIR}/share.json"'"),true);
+if(!is_array($d) || !($d["ok"]??false)) { fwrite(STDERR,"share ok=false\n"); exit(2); }
+$shareId = $d["share_id"] ?? "";
+$typeName = $d["type_name"] ?? "";
+if(!is_string($shareId) || $shareId==="") { fwrite(STDERR,"share_id empty\n"); exit(3); }
+if(!is_string($typeName) || trim($typeName)==="") { fwrite(STDERR,"type_name empty\n"); exit(4); }
+echo "share_id=".$shareId.PHP_EOL;
+echo "type_name=".$typeName.PHP_EOL;
+' > "${ART_DIR}/assert_share.txt"
+
+SHARE_ID="$(grep -E '^share_id=' "${ART_DIR}/assert_share.txt" | sed -E 's/^share_id=//')"
+test -n "${SHARE_ID}"
+
+# 7) verify shares table persisted (tinker non-interactive)
+HOME=/tmp XDG_CONFIG_HOME=/tmp ATTEMPT_ID="${ATTEMPT_ID}" SHARE_ID="${SHARE_ID}" \
+php artisan tinker --execute='
+use Illuminate\Support\Facades\DB;
+
+$attemptId=getenv("ATTEMPT_ID");
+$shareId=getenv("SHARE_ID");
+
+$cnt=DB::table("shares")->count();
+$row=DB::table("shares")->where("attempt_id",$attemptId)->first();
+
+dump([
+  "shares_count"=>$cnt,
+  "share_row"=>$row,
+  "expect_attempt_id"=>$attemptId,
+  "expect_share_id"=>$shareId,
+]);
+
+if ($cnt <= 0) { throw new Exception("shares_count <= 0"); }
+if (!$row) { throw new Exception("share_row missing"); }
+if ((string)$row->attempt_id !== (string)$attemptId) { throw new Exception("attempt_id mismatch"); }
+if ((string)$row->id !== (string)$shareId) { throw new Exception("share_id(id) mismatch"); }
+' > "${ART_DIR}/tinker_shares.txt" 2>&1
+
+echo "[OK] pr217_verify passed"


### PR DESCRIPTION
Description:

  - What:
      - Persist share_id into shares table in getShare(); load type_name from
        type_profiles.json.items (fallback to types).
  - Why:
      - Production share endpoint returns share_id but DB has 0 rows; share
        payload type_name is null due to loader mismatch.
  - How:
      - getShare(): after computing share_id, insert/update shares(attempt_id ->
        id=share_id).
      - loadTypeProfile(): accept doc.items[type] and doc.types[type].
      - Add local acceptance scripts pr217_accept.sh/pr217_verify.sh for
        repeatable verification.
  - Verify:
      - bash backend/scripts/pr217_accept.sh
  - Artifacts:
      - backend/artifacts/pr217/summary.txt
