### PR TITLE
chore(pr28): api v0.3-v0.4 multisource single-truth closure

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,9 +1,11 @@
-
 # macOS
 .DS_Store
 **/.DS_Store
-/content_packages/MBTI-CN-v0.2.1-TEST
+
+# content packages (local generated)
+# legacy explicit rule kept
 /content_packages/MBTI-CN-v0.2.1-TEST/
+/content_packages/MBTI-CN-v*/
 
 /vendor/
 

--- a/backend/app/Jobs/GenerateReportJob.php
+++ b/backend/app/Jobs/GenerateReportJob.php
@@ -59,15 +59,8 @@ class GenerateReportJob implements ShouldQueue
         $job->save();
 
         try {
-            $defaultDirVersion = (string) config(
-                'content_packs.default_dir_version',
-                config('content.default_versions.default', 'MBTI-CN-v0.2.1-TEST')
-            );
-
             $res = $composer->compose($this->attemptId, [
                 'defaultProfileVersion' => config('fap.profile_version', 'mbti32-v2.5'),
-                'defaultContentPackageVersion' => $defaultDirVersion,
-                'currentContentPackageVersion' => fn () => $defaultDirVersion,
             ]);
 
             if (!($res['ok'] ?? false)) {

--- a/backend/routes/api.php
+++ b/backend/routes/api.php
@@ -50,6 +50,8 @@ Route::middleware("auth:sanctum")->get("/user", function (Request $request) {
     return $request->user();
 });
 
+Route::get("/healthz", [HealthzController::class, "show"]);
+
 Route::prefix("v0.2")->group(function () {
 
     // 1) Health

--- a/backend/scripts/pr28_accept.sh
+++ b/backend/scripts/pr28_accept.sh
@@ -1,0 +1,87 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+export CI=true
+export FAP_NONINTERACTIVE=1
+export COMPOSER_NO_INTERACTION=1
+export GIT_TERMINAL_PROMPT=0
+export NO_COLOR=1
+export PAGER=cat
+export GIT_PAGER=cat
+export TERM=dumb
+export XDEBUG_MODE=off
+
+REPO_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+BACKEND_DIR="${REPO_DIR}/backend"
+ART_DIR="${BACKEND_DIR}/artifacts/pr28"
+SERVE_PORT="${SERVE_PORT:-18028}"
+DB_PATH="/tmp/pr28.sqlite"
+
+mkdir -p "${ART_DIR}"
+
+# Port cleanup
+for p in "${SERVE_PORT}" 18000; do
+  lsof -ti tcp:${p} | xargs -r kill -9 || true
+done
+
+# sqlite fresh
+export DB_CONNECTION=sqlite
+export DB_DATABASE="${DB_PATH}"
+rm -f "${DB_PATH}"
+touch "${DB_PATH}"
+
+cd "${BACKEND_DIR}"
+composer install --no-interaction --no-progress
+
+php artisan migrate:fresh --force --no-interaction
+php artisan db:seed --force --class=ScaleRegistrySeeder
+
+cd "${REPO_DIR}"
+SERVE_PORT="${SERVE_PORT}" bash "${BACKEND_DIR}/scripts/pr28_verify.sh"
+
+SUMMARY_TXT="${ART_DIR}/summary.txt"
+DEFAULT_PACK_ID="$(cat "${ART_DIR}/default_pack_id.txt")"
+DEFAULT_DIR_VERSION="$(cat "${ART_DIR}/default_dir_version.txt")"
+SCALES_PACK_ID="$(cat "${ART_DIR}/scales_registry_default_pack_id.txt")"
+SCALES_DIR_VERSION="$(cat "${ART_DIR}/scales_registry_default_dir_version.txt")"
+PACK_DIR_REL="$(cat "${ART_DIR}/pack_dir.txt")"
+ATTEMPT_ID="$(cat "${ART_DIR}/attempt_id.txt")"
+QUESTION_COUNT="$(php -r '$j=json_decode(file_get_contents($argv[1]), true); $q=$j["questions"]["items"] ?? $j["questions"] ?? $j["data"] ?? $j; echo is_array($q) ? count($q) : 0;' "${ART_DIR}/questions.json")"
+SCALE_CODE="$(php -r '$j=json_decode(file_get_contents($argv[1]), true); echo $j["scale_code"] ?? "";' "${ART_DIR}/questions.json")"
+
+cat > "${SUMMARY_TXT}" <<TXT
+PR28 Acceptance Summary
+- verify: backend/scripts/pr28_verify.sh
+- serve_port: ${SERVE_PORT}
+- smoke_url: http://127.0.0.1:${SERVE_PORT}/api/healthz
+- default_pack_id: ${DEFAULT_PACK_ID}
+- default_dir_version: ${DEFAULT_DIR_VERSION}
+- scales_registry_default_pack_id: ${SCALES_PACK_ID}
+- scales_registry_default_dir_version: ${SCALES_DIR_VERSION}
+- pack_dir: ${PACK_DIR_REL}
+- scale_code: ${SCALE_CODE}
+- attempt_id: ${ATTEMPT_ID}
+- question_count: ${QUESTION_COUNT}
+- schema_changes: none
+Artifacts:
+- backend/artifacts/pr28/health.json
+- backend/artifacts/pr28/default_pack_id.txt
+- backend/artifacts/pr28/default_dir_version.txt
+- backend/artifacts/pr28/scales_registry_default_pack_id.txt
+- backend/artifacts/pr28/scales_registry_default_dir_version.txt
+- backend/artifacts/pr28/pack_dir.txt
+- backend/artifacts/pr28/scales.json
+- backend/artifacts/pr28/questions.json
+- backend/artifacts/pr28/answers.json
+- backend/artifacts/pr28/attempt_start.json
+- backend/artifacts/pr28/submit.json
+- backend/artifacts/pr28/report.json
+TXT
+
+bash "${BACKEND_DIR}/scripts/sanitize_artifacts.sh" 28
+
+rm -f "${DB_PATH}"
+
+# Shellcheck: verify scripts are syntactically valid
+bash -n "${BACKEND_DIR}/scripts/pr28_verify.sh"
+bash -n "${BACKEND_DIR}/scripts/pr28_accept.sh"

--- a/backend/scripts/pr28_verify.sh
+++ b/backend/scripts/pr28_verify.sh
@@ -1,0 +1,285 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+export CI=true
+export FAP_NONINTERACTIVE=1
+export COMPOSER_NO_INTERACTION=1
+export GIT_TERMINAL_PROMPT=0
+export NO_COLOR=1
+export PAGER=cat
+export GIT_PAGER=cat
+export TERM=dumb
+export XDEBUG_MODE=off
+
+REPO_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+BACKEND_DIR="${REPO_DIR}/backend"
+ART_DIR="${BACKEND_DIR}/artifacts/pr28"
+SERVE_PORT="${SERVE_PORT:-18028}"
+API_BASE="http://127.0.0.1:${SERVE_PORT}"
+
+mkdir -p "${ART_DIR}"
+
+cd "${BACKEND_DIR}"
+if [[ ! -f ".env" ]]; then
+  cp -a .env.example .env
+fi
+php artisan key:generate --force >/dev/null 2>&1 || true
+
+SERVER_PID=""
+cleanup() {
+  if [[ -n "${SERVER_PID}" ]]; then
+    kill "${SERVER_PID}" >/dev/null 2>&1 || true
+    sleep 0.2
+    if kill -0 "${SERVER_PID}" >/dev/null 2>&1; then
+      kill -9 "${SERVER_PID}" >/dev/null 2>&1 || true
+    fi
+  fi
+  lsof -nP -iTCP:${SERVE_PORT} -sTCP:LISTEN >/dev/null 2>&1 && lsof -nP -iTCP:${SERVE_PORT} -sTCP:LISTEN || true
+}
+trap cleanup EXIT
+
+: > "${ART_DIR}/server.log"
+php artisan serve --host=127.0.0.1 --port="${SERVE_PORT}" >> "${ART_DIR}/server.log" 2>&1 &
+SERVER_PID=$!
+echo "${SERVER_PID}" > "${ART_DIR}/server.pid"
+
+internal_http() {
+  local method="$1"
+  local uri="$2"
+  local body="$3"
+  local out="$4"
+  local status_file="${out}.status"
+  REQ_METHOD="${method}" REQ_URI="${uri}" REQ_BODY="${body}" REQ_OUT="${out}" REQ_STATUS="${status_file}" php -r '
+require "vendor/autoload.php";
+$app=require "bootstrap/app.php";
+$kernel=$app->make(Illuminate\Contracts\Http\Kernel::class);
+$method=getenv("REQ_METHOD") ?: "GET";
+$uri=getenv("REQ_URI") ?: "/";
+$body=getenv("REQ_BODY") ?: "";
+$server=["CONTENT_TYPE"=>"application/json","HTTP_ACCEPT"=>"application/json"];
+$request=Illuminate\Http\Request::create($uri, $method, [], [], [], $server, $body);
+$response=$kernel->handle($request);
+file_put_contents(getenv("REQ_OUT"), (string) $response->getContent());
+file_put_contents(getenv("REQ_STATUS"), (string) $response->getStatusCode());
+$kernel->terminate($request, $response);
+';
+  if [[ -f "${status_file}" ]]; then
+    cat "${status_file}"
+    rm -f "${status_file}"
+  else
+    echo "500"
+  fi
+}
+
+HEALTH_OK=0
+set +e
+for i in $(seq 1 60); do
+  curl -fsS "${API_BASE}/api/healthz" >/dev/null 2>&1 && HEALTH_OK=1 && break
+  sleep 0.2
+done
+set -e
+
+if [[ "${HEALTH_OK}" == "1" ]]; then
+  curl -fsS "${API_BASE}/api/healthz" > "${ART_DIR}/health.json"
+else
+  http_code="$(internal_http GET "/api/healthz" "" "${ART_DIR}/health.json")"
+  if [[ "${http_code}" != "200" ]]; then
+    echo "healthz_failed" >&2
+    exit 1
+  fi
+fi
+
+# Config + seed consistency (config <-> scales_registry <-> pack dir)
+DEFAULT_PACK_ID_FILE="${ART_DIR}/default_pack_id.txt"
+DEFAULT_DIR_VERSION_FILE="${ART_DIR}/default_dir_version.txt"
+SCALES_PACK_ID_FILE="${ART_DIR}/scales_registry_default_pack_id.txt"
+SCALES_DIR_VERSION_FILE="${ART_DIR}/scales_registry_default_dir_version.txt"
+PACK_DIR_FILE="${ART_DIR}/pack_dir.txt"
+
+php -r 'require "vendor/autoload.php"; $app=require "bootstrap/app.php"; $app->make(Illuminate\Contracts\Console\Kernel::class)->bootstrap(); echo (string) config("content_packs.default_pack_id", "");' > "${DEFAULT_PACK_ID_FILE}"
+php -r 'require "vendor/autoload.php"; $app=require "bootstrap/app.php"; $app->make(Illuminate\Contracts\Console\Kernel::class)->bootstrap(); echo (string) config("content_packs.default_dir_version", "");' > "${DEFAULT_DIR_VERSION_FILE}"
+
+php -r '
+require "vendor/autoload.php";
+$app=require "bootstrap/app.php";
+$app->make(Illuminate\Contracts\Console\Kernel::class)->bootstrap();
+if (!Illuminate\Support\Facades\Schema::hasTable("scales_registry")) {
+  fwrite(STDERR, "missing scales_registry table\n"); exit(1);
+}
+$packId = (string) config("content_packs.default_pack_id", "");
+$dirVersion = (string) config("content_packs.default_dir_version", "");
+$index = app(App\Services\Content\ContentPacksIndex::class);
+$found = $index->find($packId, $dirVersion);
+if (!($found["ok"] ?? false)) { fwrite(STDERR, "pack_not_found\n"); exit(1); }
+$scaleCode = (string) ($found["item"]["scale_code"] ?? "");
+if ($scaleCode === "") { fwrite(STDERR, "missing scale_code\n"); exit(1); }
+$row = Illuminate\Support\Facades\DB::table("scales_registry")->where("org_id", 0)->where("code", $scaleCode)->first();
+if (!$row) { fwrite(STDERR, "missing scales_registry row\n"); exit(1); }
+echo (string) ($row->default_pack_id ?? "");
+' > "${SCALES_PACK_ID_FILE}"
+
+php -r '
+require "vendor/autoload.php";
+$app=require "bootstrap/app.php";
+$app->make(Illuminate\Contracts\Console\Kernel::class)->bootstrap();
+$packId = (string) config("content_packs.default_pack_id", "");
+$dirVersion = (string) config("content_packs.default_dir_version", "");
+$index = app(App\Services\Content\ContentPacksIndex::class);
+$found = $index->find($packId, $dirVersion);
+if (!($found["ok"] ?? false)) { fwrite(STDERR, "pack_not_found\n"); exit(1); }
+$scaleCode = (string) ($found["item"]["scale_code"] ?? "");
+if ($scaleCode === "") { fwrite(STDERR, "missing scale_code\n"); exit(1); }
+$row = Illuminate\Support\Facades\DB::table("scales_registry")->where("org_id", 0)->where("code", $scaleCode)->first();
+if (!$row) { fwrite(STDERR, "missing scales_registry row\n"); exit(1); }
+echo (string) ($row->default_dir_version ?? "");
+' > "${SCALES_DIR_VERSION_FILE}"
+
+if [[ "$(cat "${DEFAULT_PACK_ID_FILE}")" != "$(cat "${SCALES_PACK_ID_FILE}")" ]]; then
+  echo "default_pack_id_mismatch" >&2
+  echo "config=$(cat "${DEFAULT_PACK_ID_FILE}")" >&2
+  echo "scales_registry=$(cat "${SCALES_PACK_ID_FILE}")" >&2
+  exit 1
+fi
+
+if [[ "$(cat "${DEFAULT_DIR_VERSION_FILE}")" != "$(cat "${SCALES_DIR_VERSION_FILE}")" ]]; then
+  echo "default_dir_version_mismatch" >&2
+  echo "config=$(cat "${DEFAULT_DIR_VERSION_FILE}")" >&2
+  echo "scales_registry=$(cat "${SCALES_DIR_VERSION_FILE}")" >&2
+  exit 1
+fi
+
+PACK_DIR_REL="$(php -r '
+require "vendor/autoload.php";
+$app=require "bootstrap/app.php";
+$app->make(Illuminate\Contracts\Console\Kernel::class)->bootstrap();
+$root = (string) config("content_packs.root", "");
+$packId = (string) config("content_packs.default_pack_id", "");
+$dirVersion = (string) config("content_packs.default_dir_version", "");
+$index = app(App\Services\Content\ContentPacksIndex::class);
+$found = $index->find($packId, $dirVersion);
+if (!($found["ok"] ?? false)) { fwrite(STDERR, "pack_not_found\n"); exit(1); }
+$manifestPath = (string) ($found["item"]["manifest_path"] ?? "");
+if ($manifestPath === "") { fwrite(STDERR, "manifest_path_missing\n"); exit(1); }
+$baseDir = dirname($manifestPath);
+$rel = $baseDir;
+$prefix = rtrim($root, DIRECTORY_SEPARATOR) . DIRECTORY_SEPARATOR;
+if (str_starts_with($rel, $prefix)) { $rel = substr($rel, strlen($prefix)); }
+echo $rel;
+')"
+
+if [[ -z "${PACK_DIR_REL}" ]]; then
+  echo "pack_dir_resolve_failed" >&2
+  exit 1
+fi
+echo "${PACK_DIR_REL}" > "${PACK_DIR_FILE}"
+
+PACK_DIR_ABS="$(php -r 'require "vendor/autoload.php"; $app=require "bootstrap/app.php"; $app->make(Illuminate\Contracts\Console\Kernel::class)->bootstrap(); $root=(string) config("content_packs.root", ""); echo rtrim($root, DIRECTORY_SEPARATOR) . DIRECTORY_SEPARATOR . $argv[1];' "${PACK_DIR_REL}")"
+
+php -r '$p=$argv[1]; $j=json_decode(file_get_contents($p), true); if(!is_array($j)){fwrite(STDERR,"json parse failed: $p\n"); exit(1);} echo "OK $p\n";' "${PACK_DIR_ABS}/version.json" > "${ART_DIR}/pack_version_parse.txt"
+php -r '$p=$argv[1]; $j=json_decode(file_get_contents($p), true); if(!is_array($j)){fwrite(STDERR,"json parse failed: $p\n"); exit(1);} echo "OK $p\n";' "${PACK_DIR_ABS}/questions.json" > "${ART_DIR}/pack_questions_parse.txt"
+
+fetch_json() {
+  local method="$1"
+  local uri="$2"
+  local out="$3"
+  local body="${4:-}"
+  if [[ "${HEALTH_OK}" == "1" ]]; then
+    if [[ "${method}" == "GET" ]]; then
+      curl -sS -o "${out}" -w "%{http_code}" "${API_BASE}${uri}" || true
+    else
+      curl -sS -o "${out}" -w "%{http_code}" -X "${method}" \
+        -H "Content-Type: application/json" -H "Accept: application/json" \
+        -d "${body}" "${API_BASE}${uri}" || true
+    fi
+  else
+    internal_http "${method}" "${uri}" "${body}" "${out}"
+  fi
+}
+
+SCALES_JSON="${ART_DIR}/scales.json"
+http_code="$(fetch_json GET "/api/v0.3/scales" "${SCALES_JSON}")"
+if [[ "${http_code}" != "200" ]]; then
+  echo "scales_failed http=${http_code}" >&2
+  cat "${SCALES_JSON}" >&2 || true
+  exit 1
+fi
+
+SCALE_CODE="$(php -r '$j=json_decode(file_get_contents($argv[1]), true); $items=$j["items"] ?? []; $code=""; if (is_array($items) && count($items)>0) { $first=$items[0]; if (is_array($first)) { $code=$first["code"] ?? ""; } } echo $code;' "${SCALES_JSON}")"
+if [[ -z "${SCALE_CODE}" ]]; then
+  echo "scale_code_missing" >&2
+  exit 1
+fi
+
+QUESTIONS_JSON="${ART_DIR}/questions.json"
+http_code="$(fetch_json GET "/api/v0.3/scales/${SCALE_CODE}/questions" "${QUESTIONS_JSON}")"
+if [[ "${http_code}" != "200" ]]; then
+  echo "questions_failed http=${http_code}" >&2
+  cat "${QUESTIONS_JSON}" >&2 || true
+  exit 1
+fi
+
+ANSWERS_JSON="${ART_DIR}/answers.json"
+php -r '
+$raw = file_get_contents("php://stdin");
+$data = json_decode($raw, true);
+if (!is_array($data)) { fwrite(STDERR, "questions json not array\n"); exit(1); }
+$q = $data["questions"]["items"] ?? $data["questions"] ?? $data["data"] ?? $data;
+if (!is_array($q)) { fwrite(STDERR, "questions payload invalid\n"); exit(1); }
+$answers = [];
+foreach ($q as $item) {
+  if (!is_array($item)) { continue; }
+  $qid = $item["question_id"] ?? ($item["id"] ?? null);
+  if (!$qid) { continue; }
+  $opts = $item["options"] ?? [];
+  $code = "A";
+  if (is_array($opts) && count($opts) > 0) {
+    $code = (string) ($opts[0]["code"] ?? "A");
+  }
+  $answers[] = ["question_id" => $qid, "code" => $code];
+}
+if (count($answers) === 0) { fwrite(STDERR, "answers empty\n"); exit(1); }
+echo json_encode($answers, JSON_UNESCAPED_UNICODE);
+' < "${QUESTIONS_JSON}" > "${ANSWERS_JSON}"
+
+ATTEMPT_START_JSON="${ART_DIR}/attempt_start.json"
+http_code="$(fetch_json POST "/api/v0.3/attempts/start" "${ATTEMPT_START_JSON}" "{\"scale_code\":\"${SCALE_CODE}\"}")"
+if [[ "${http_code}" != "200" ]]; then
+  echo "attempt_start_failed http=${http_code}" >&2
+  cat "${ATTEMPT_START_JSON}" >&2 || true
+  exit 1
+fi
+
+ATTEMPT_ID="$(php -r '$j=json_decode(file_get_contents($argv[1]), true); echo $j["attempt_id"] ?? "";' "${ATTEMPT_START_JSON}")"
+if [[ -z "${ATTEMPT_ID}" ]]; then
+  echo "missing_attempt_id" >&2
+  exit 1
+fi
+echo "${ATTEMPT_ID}" > "${ART_DIR}/attempt_id.txt"
+
+SUBMIT_PAYLOAD="${ART_DIR}/submit_payload.json"
+ATTEMPT_ID="${ATTEMPT_ID}" ANSWERS_PATH="${ANSWERS_JSON}" php -r '
+$answers = json_decode(file_get_contents(getenv("ANSWERS_PATH")), true);
+if (!is_array($answers)) { fwrite(STDERR, "answers invalid\n"); exit(1); }
+$payload = [
+  "attempt_id" => getenv("ATTEMPT_ID"),
+  "answers" => $answers,
+  "duration_ms" => 120000,
+];
+file_put_contents("php://stdout", json_encode($payload, JSON_UNESCAPED_UNICODE));
+' > "${SUBMIT_PAYLOAD}"
+
+SUBMIT_JSON="${ART_DIR}/submit.json"
+http_code="$(fetch_json POST "/api/v0.3/attempts/submit" "${SUBMIT_JSON}" "$(cat "${SUBMIT_PAYLOAD}")")"
+if [[ "${http_code}" != "200" ]]; then
+  echo "submit_failed http=${http_code}" >&2
+  cat "${SUBMIT_JSON}" >&2 || true
+  exit 1
+fi
+
+REPORT_JSON="${ART_DIR}/report.json"
+http_code="$(fetch_json GET "/api/v0.3/attempts/${ATTEMPT_ID}/report" "${REPORT_JSON}")"
+if [[ "${http_code}" != "200" ]]; then
+  echo "report_failed http=${http_code}" >&2
+  cat "${REPORT_JSON}" >&2 || true
+  exit 1
+fi

--- a/backend/scripts/sanitize_artifacts.sh
+++ b/backend/scripts/sanitize_artifacts.sh
@@ -27,8 +27,11 @@ import os, re, sys
 base = sys.argv[1]
 patterns = [
     (re.compile(r'/Users/[^\s"\']+'), '<REPO>'),
+    (re.compile(r'\\/Users\\/[^\s"\']+'), '<REPO>'),
     (re.compile(r'/home/[^\s"\']+'), '<REPO>'),
+    (re.compile(r'\\/home\\/[^\s"\']+'), '<REPO>'),
     (re.compile(r'C:\\Users\\[^\s"\']+'), '<REPO>'),
+    (re.compile(r'C:\\\\Users\\\\[^\s"\']+'), '<REPO>'),
     (re.compile(r'Authorization:\s*Bearer\s+[A-Za-z0-9._\-]+'), 'Authorization: Bearer <REDACTED>'),
     (re.compile(r'FAP_ADMIN_TOKEN=\S+'), 'FAP_ADMIN_TOKEN=<REDACTED>'),
     (re.compile(r'DB_PASSWORD=\S+'), 'DB_PASSWORD=<REDACTED>'),

--- a/backend/storage/framework/.gitignore
+++ b/backend/storage/framework/.gitignore
@@ -7,3 +7,8 @@ routes.php
 routes.scanned.php
 schedule-*
 services.json
+
+cache/**
+sessions/**
+views/**
+testing/**

--- a/backend/tests/Feature/V0_3/ReportDirVersionTruthTest.php
+++ b/backend/tests/Feature/V0_3/ReportDirVersionTruthTest.php
@@ -1,0 +1,133 @@
+<?php
+
+namespace Tests\Feature\V0_3;
+
+use App\Jobs\GenerateReportJob;
+use App\Models\Attempt;
+use App\Models\ReportJob;
+use App\Models\Result;
+use App\Services\Content\ContentPacksIndex;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\File;
+use Illuminate\Support\Str;
+use Tests\TestCase;
+
+class ReportDirVersionTruthTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_report_uses_attempt_dir_version_as_single_truth(): void
+    {
+        config()->set('content_packs.default_dir_version', 'MBTI-CN-v0.2.2');
+        config()->set('content_packs.default_pack_id', 'MBTI.cn-mainland.zh-CN.v0.2.2');
+
+        $attemptId = (string) Str::uuid();
+        $packId = 'MBTI.cn-mainland.zh-CN.v0.2.1-TEST';
+        $dirVersion = 'MBTI-CN-v0.2.1-TEST';
+
+        Attempt::create([
+            'id' => $attemptId,
+            'org_id' => 0,
+            'anon_id' => 'anon_single_truth',
+            'scale_code' => 'MBTI',
+            'scale_version' => 'v0.3',
+            'region' => 'CN_MAINLAND',
+            'locale' => 'zh-CN',
+            'question_count' => 144,
+            'client_platform' => 'test',
+            'answers_summary_json' => ['stage' => 'seed'],
+            'started_at' => now(),
+            'submitted_at' => now(),
+            'pack_id' => $packId,
+            'dir_version' => $dirVersion,
+            'content_package_version' => 'v0.2.1-TEST',
+            'scoring_spec_version' => '2026.01',
+        ]);
+
+        Result::create([
+            'id' => (string) Str::uuid(),
+            'org_id' => 0,
+            'attempt_id' => $attemptId,
+            'scale_code' => 'MBTI',
+            'scale_version' => 'v0.3',
+            'type_code' => 'INTJ-A',
+            'scores_json' => [
+                'EI' => ['a' => 10, 'b' => 10, 'neutral' => 0, 'sum' => 0, 'total' => 20],
+                'SN' => ['a' => 10, 'b' => 10, 'neutral' => 0, 'sum' => 0, 'total' => 20],
+                'TF' => ['a' => 10, 'b' => 10, 'neutral' => 0, 'sum' => 0, 'total' => 20],
+                'JP' => ['a' => 10, 'b' => 10, 'neutral' => 0, 'sum' => 0, 'total' => 20],
+                'AT' => ['a' => 10, 'b' => 10, 'neutral' => 0, 'sum' => 0, 'total' => 20],
+            ],
+            'scores_pct' => [
+                'EI' => 50,
+                'SN' => 50,
+                'TF' => 50,
+                'JP' => 50,
+                'AT' => 50,
+            ],
+            'axis_states' => [
+                'EI' => 'clear',
+                'SN' => 'clear',
+                'TF' => 'clear',
+                'JP' => 'clear',
+                'AT' => 'clear',
+            ],
+            'content_package_version' => null,
+            'result_json' => [
+                'raw_score' => 0,
+                'final_score' => 0,
+                'breakdown_json' => [],
+                'type_code' => 'INTJ-A',
+                'axis_scores_json' => [
+                    'scores_pct' => [
+                        'EI' => 50,
+                        'SN' => 50,
+                        'TF' => 50,
+                        'JP' => 50,
+                        'AT' => 50,
+                    ],
+                    'axis_states' => [
+                        'EI' => 'clear',
+                        'SN' => 'clear',
+                        'TF' => 'clear',
+                        'JP' => 'clear',
+                        'AT' => 'clear',
+                    ],
+                ],
+            ],
+            'pack_id' => $packId,
+            'dir_version' => $dirVersion,
+            'scoring_spec_version' => '2026.01',
+            'report_engine_version' => 'v1.2',
+            'is_valid' => true,
+            'computed_at' => now(),
+        ]);
+
+        $job = new GenerateReportJob($attemptId);
+        $job->handle(app(\App\Services\Report\ReportComposer::class));
+
+        $reportJob = ReportJob::where('attempt_id', $attemptId)->first();
+        $this->assertNotNull($reportJob);
+
+        $report = is_array($reportJob?->report_json) ? $reportJob->report_json : [];
+        $this->assertSame($dirVersion, $report['versions']['legacy_dir'] ?? null);
+        $this->assertSame($dirVersion, $report['versions']['dir_version'] ?? null);
+        $this->assertSame('v0.2.1-TEST', $report['versions']['content_package_version'] ?? null);
+
+        $found = app(ContentPacksIndex::class)->find($packId, $dirVersion);
+        $this->assertTrue((bool) ($found['ok'] ?? false));
+
+        $manifestPath = (string) ($found['item']['manifest_path'] ?? '');
+        $baseDir = $manifestPath !== '' ? dirname($manifestPath) : '';
+        $versionPath = $baseDir !== '' ? $baseDir . DIRECTORY_SEPARATOR . 'version.json' : '';
+        $this->assertNotSame('', $versionPath);
+        $this->assertTrue(File::isFile($versionPath));
+
+        $versionJson = json_decode(File::get($versionPath), true);
+        $this->assertSame($dirVersion, $versionJson['dir_version'] ?? null);
+        $this->assertSame(
+            $versionJson['content_package_version'] ?? null,
+            $report['versions']['content_package_version'] ?? null
+        );
+    }
+}

--- a/docs/verify/pr28_verify.md
+++ b/docs/verify/pr28_verify.md
@@ -1,0 +1,13 @@
+# PR28 Verify
+
+- Date: 2026-02-04
+- Env: local
+- Commands:
+- bash backend/scripts/pr28_accept.sh
+- bash backend/scripts/ci_verify_mbti.sh
+- Results:
+- pr28_accept: PASS
+- ci_verify_mbti: PASS
+- Artifacts:
+- backend/artifacts/pr28/summary.txt
+- backend/artifacts/verify_mbti/summary.txt


### PR DESCRIPTION
 - What:
  - Unify pack_id/dir_version/scale_version into a single-truth pipeline across
    attempt->report.
  - Why:
  - Prevent default-value drift causing wrong report content in multi-scale
    production.
  - Stabilize content pack + registry + renderer consistency under sqlite fresh
    migrate and CI.
  - How:
  - Update AppServiceProvider bindings to stop hardcoding defaults.
  - Make GenerateReportJob read Attempt fields as the single truth.
  - Add tests proving version alignment end-to-end.
  - Add verify.sh checks for pack/seed/config alignment via php -r.
  - Verify:
  - bash backend/scripts/pr28_accept.sh
  - bash backend/scripts/ci_verify_mbti.sh
  - Artifacts:
  - backend/artifacts/pr28/summary.txt
  - [x] bash backend/scripts/ci_verify_mbti.sh
