### PR TITLE
Title: chore(pr29): commerce v2 hardening idempotency refunds webhook-security

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,9 +3,7 @@
 **/.DS_Store
 
 # content packages (local generated)
-# legacy explicit rule kept
-/content_packages/MBTI-CN-v0.2.1-TEST/
-/content_packages/MBTI-CN-v*/
+/content_packages/MBTI-CN-v*
 
 /vendor/
 

--- a/backend/app/Http/Controllers/API/V0_3/Webhooks/PaymentWebhookController.php
+++ b/backend/app/Http/Controllers/API/V0_3/Webhooks/PaymentWebhookController.php
@@ -21,6 +21,15 @@ class PaymentWebhookController extends Controller
      */
     public function handle(Request $request, string $provider): JsonResponse
     {
+        $provider = strtolower(trim($provider));
+        if ($provider === 'stub' && !app()->environment(['local', 'testing'])) {
+            return $this->notFoundResponse();
+        }
+
+        if ($provider === 'billing' && !$this->verifyBillingSignature($request)) {
+            return $this->notFoundResponse();
+        }
+
         $payload = $request->all();
         $orgId = $this->orgContext->orgId();
         $userId = $this->orgContext->userId();
@@ -45,5 +54,35 @@ class PaymentWebhookController extends Controller
             'order_no' => $result['order_no'] ?? null,
             'provider_event_id' => $result['provider_event_id'] ?? null,
         ]);
+    }
+
+    private function verifyBillingSignature(Request $request): bool
+    {
+        $secret = (string) (config('services.billing.webhook_secret') ?? env('BILLING_WEBHOOK_SECRET', ''));
+        if ($secret === '') {
+            return app()->environment(['local', 'testing']);
+        }
+
+        $signature = (string) $request->header('X-Billing-Signature', '');
+        if ($signature === '') {
+            $signature = (string) $request->header('X-Webhook-Signature', '');
+        }
+        if ($signature === '') {
+            return false;
+        }
+
+        $payload = (string) $request->getContent();
+        $expected = hash_hmac('sha256', $payload, $secret);
+
+        return hash_equals($expected, $signature);
+    }
+
+    private function notFoundResponse(): JsonResponse
+    {
+        return response()->json([
+            'ok' => false,
+            'error' => 'NOT_FOUND',
+            'message' => 'not found.',
+        ], 404);
     }
 }

--- a/backend/app/Http/Middleware/FmTokenAuth.php
+++ b/backend/app/Http/Middleware/FmTokenAuth.php
@@ -115,13 +115,13 @@ class FmTokenAuth
         // prefer: fm_tokens.user_id
         if (property_exists($row, 'user_id')) {
             $v = trim((string) ($row->user_id ?? ''));
-            if ($v !== '') return $v;
+            if ($v !== '' && preg_match('/^\d+$/', $v)) return $v;
         }
 
         // optional alias
         if (property_exists($row, 'fm_user_id')) {
             $v = trim((string) ($row->fm_user_id ?? ''));
-            if ($v !== '') return $v;
+            if ($v !== '' && preg_match('/^\d+$/', $v)) return $v;
         }
 
         // meta_json fallback (when tokens are issued by legacy services)
@@ -133,7 +133,7 @@ class FmTokenAuth
             }
             if (is_array($meta)) {
                 $v = trim((string) ($meta['user_id'] ?? $meta['fm_user_id'] ?? ''));
-                if ($v !== '') return $v;
+                if ($v !== '' && preg_match('/^\d+$/', $v)) return $v;
             }
         }
 
@@ -141,7 +141,7 @@ class FmTokenAuth
         foreach (['uid', 'user_uid', 'user'] as $c) {
             if (property_exists($row, $c)) {
                 $v = trim((string) ($row->{$c} ?? ''));
-                if ($v !== '') return $v;
+                if ($v !== '' && preg_match('/^\d+$/', $v)) return $v;
             }
         }
 

--- a/backend/app/Services/Commerce/PaymentGateway/StripeGateway.php
+++ b/backend/app/Services/Commerce/PaymentGateway/StripeGateway.php
@@ -1,0 +1,160 @@
+<?php
+
+namespace App\Services\Commerce\PaymentGateway;
+
+class StripeGateway implements PaymentGatewayInterface
+{
+    public function provider(): string
+    {
+        return 'stripe';
+    }
+
+    public function normalizePayload(array $payload): array
+    {
+        $object = $this->resolveObject($payload);
+
+        $providerEventId = $this->resolveString($payload, ['id']);
+        if ($providerEventId === '') {
+            $providerEventId = $this->resolveString($object, ['id', 'charge', 'payment_intent']);
+        }
+
+        $eventType = $this->resolveEventType($payload, $object);
+
+        $orderNo = $this->resolveString($payload, ['order_no', 'orderNo', 'order']);
+        if ($orderNo === '') {
+            $metadata = is_array($object['metadata'] ?? null) ? $object['metadata'] : [];
+            $orderNo = $this->resolveString($metadata, ['order_no', 'orderNo', 'order']);
+        }
+
+        $externalTradeNo = $this->resolveString($object, ['id', 'charge', 'payment_intent']);
+        $amountCents = $this->resolveAmountCents($object, ['amount', 'amount_total', 'amount_captured']);
+        if ($amountCents === 0) {
+            $amountCents = $this->resolveAmountCents($payload, ['amount', 'amount_total']);
+        }
+
+        $currency = $this->resolveString($object, ['currency']);
+        if ($currency === '') {
+            $currency = $this->resolveString($payload, ['currency']);
+        }
+        if ($currency === '') {
+            $currency = 'USD';
+        }
+
+        $refundAmountCents = $this->resolveRefundAmountCents($payload, $object);
+        $refundReason = $this->resolveRefundReason($object);
+
+        return [
+            'provider_event_id' => $providerEventId,
+            'order_no' => $orderNo,
+            'external_trade_no' => $externalTradeNo !== '' ? $externalTradeNo : null,
+            'paid_at' => $this->resolvePaidAt($object),
+            'amount_cents' => $amountCents,
+            'currency' => $currency,
+            'event_type' => $eventType,
+            'refund_amount_cents' => $refundAmountCents,
+            'refund_reason' => $refundReason,
+        ];
+    }
+
+    private function resolveObject(array $payload): array
+    {
+        $data = $payload['data'] ?? null;
+        if (is_array($data) && is_array($data['object'] ?? null)) {
+            return $data['object'];
+        }
+
+        return [];
+    }
+
+    private function resolveEventType(array $payload, array $object): string
+    {
+        $eventType = $this->resolveString($payload, ['type', 'event_type']);
+        if ($eventType !== '') {
+            return strtolower($eventType);
+        }
+
+        $refundAmount = $this->resolveRefundAmountCents($payload, $object);
+        if ($refundAmount > 0 || ($object['refunded'] ?? false)) {
+            return 'charge.refunded';
+        }
+
+        return 'payment_succeeded';
+    }
+
+    private function resolveRefundAmountCents(array $payload, array $object): int
+    {
+        $amount = $this->resolveAmountCents($object, ['amount_refunded', 'amount_refund', 'amount_refunds']);
+        if ($amount > 0) {
+            return $amount;
+        }
+
+        $refunds = $object['refunds']['data'] ?? null;
+        if (is_array($refunds)) {
+            $sum = 0;
+            foreach ($refunds as $refund) {
+                if (is_array($refund) && is_numeric($refund['amount'] ?? null)) {
+                    $sum += (int) round((float) $refund['amount']);
+                }
+            }
+            if ($sum > 0) {
+                return $sum;
+            }
+        }
+
+        return $this->resolveAmountCents($payload, ['refund_amount_cents', 'refund_amount', 'amount_refunded']);
+    }
+
+    private function resolveRefundReason(array $object): ?string
+    {
+        $refunds = $object['refunds']['data'] ?? null;
+        if (is_array($refunds) && isset($refunds[0]) && is_array($refunds[0])) {
+            $reason = trim((string) ($refunds[0]['reason'] ?? ''));
+            if ($reason !== '') {
+                return $reason;
+            }
+        }
+
+        return null;
+    }
+
+    private function resolvePaidAt(array $object): ?string
+    {
+        $created = $object['created'] ?? null;
+        if (is_numeric($created)) {
+            $ts = (int) $created;
+            if ($ts > 0) {
+                return date('c', $ts);
+            }
+        }
+
+        return null;
+    }
+
+    private function resolveString(array $payload, array $keys): string
+    {
+        foreach ($keys as $key) {
+            if (array_key_exists($key, $payload)) {
+                $value = trim((string) ($payload[$key] ?? ''));
+                if ($value !== '') {
+                    return $value;
+                }
+            }
+        }
+
+        return '';
+    }
+
+    private function resolveAmountCents(array $payload, array $keys): int
+    {
+        foreach ($keys as $key) {
+            if (array_key_exists($key, $payload)) {
+                $raw = $payload[$key];
+                if (is_numeric($raw)) {
+                    return (int) round((float) $raw);
+                }
+            }
+        }
+
+        return 0;
+    }
+}

--- a/backend/bootstrap/app.php
+++ b/backend/bootstrap/app.php
@@ -4,6 +4,20 @@ use Illuminate\Foundation\Application;
 use Illuminate\Foundation\Configuration\Exceptions;
 use Illuminate\Foundation\Configuration\Middleware;
 
+$runtimeDirs = [
+    __DIR__ . '/../storage/framework/cache',
+    __DIR__ . '/../storage/framework/sessions',
+    __DIR__ . '/../storage/framework/views',
+    __DIR__ . '/../storage/framework/testing',
+    __DIR__ . '/../bootstrap/cache',
+];
+
+foreach ($runtimeDirs as $dir) {
+    if (!is_dir($dir)) {
+        @mkdir($dir, 0775, true);
+    }
+}
+
 return Application::configure(basePath: dirname(__DIR__))
     ->withRouting(
         web: __DIR__ . '/../routes/web.php',

--- a/backend/config/services.php
+++ b/backend/config/services.php
@@ -35,4 +35,8 @@ return [
         ],
     ],
 
+    'billing' => [
+        'webhook_secret' => env('BILLING_WEBHOOK_SECRET'),
+    ],
+
 ];

--- a/backend/config/view.php
+++ b/backend/config/view.php
@@ -1,0 +1,12 @@
+<?php
+
+return [
+    'paths' => [
+        resource_path('views'),
+    ],
+
+    'compiled' => env(
+        'VIEW_COMPILED_PATH',
+        realpath(storage_path('framework/views')) ?: storage_path('framework/views')
+    ),
+];

--- a/backend/database/migrations/2026_02_04_090000_add_idempotency_refunds_to_orders_benefit_grants.php
+++ b/backend/database/migrations/2026_02_04_090000_add_idempotency_refunds_to_orders_benefit_grants.php
@@ -1,0 +1,142 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        if (Schema::hasTable('orders')) {
+            Schema::table('orders', function (Blueprint $table) {
+                if (!Schema::hasColumn('orders', 'idempotency_key')) {
+                    $table->string('idempotency_key', 128)->nullable();
+                }
+                if (!Schema::hasColumn('orders', 'refunded_at')) {
+                    $table->timestamp('refunded_at')->nullable();
+                }
+                if (!Schema::hasColumn('orders', 'refund_amount_cents')) {
+                    $table->integer('refund_amount_cents')->nullable();
+                }
+                if (!Schema::hasColumn('orders', 'refund_reason')) {
+                    $table->string('refund_reason', 255)->nullable();
+                }
+            });
+
+            if (!$this->indexExists('orders', 'orders_org_idempotency_key_unique')
+                && Schema::hasColumn('orders', 'org_id')
+                && Schema::hasColumn('orders', 'idempotency_key')) {
+                $duplicates = DB::table('orders')
+                    ->select('org_id', 'idempotency_key')
+                    ->whereNotNull('idempotency_key')
+                    ->where('idempotency_key', '!=', '')
+                    ->groupBy('org_id', 'idempotency_key')
+                    ->havingRaw('count(*) > 1')
+                    ->limit(1)
+                    ->get();
+                if ($duplicates->count() === 0) {
+                    Schema::table('orders', function (Blueprint $table) {
+                        $table->unique(['org_id', 'idempotency_key'], 'orders_org_idempotency_key_unique');
+                    });
+                }
+            }
+        }
+
+        if (Schema::hasTable('benefit_grants')) {
+            Schema::table('benefit_grants', function (Blueprint $table) {
+                if (!Schema::hasColumn('benefit_grants', 'revoked_at')) {
+                    $table->timestamp('revoked_at')->nullable();
+                }
+            });
+
+            if (!$this->indexExists('benefit_grants', 'benefit_grants_org_benefit_attempt_status_idx')
+                && Schema::hasColumn('benefit_grants', 'org_id')
+                && Schema::hasColumn('benefit_grants', 'benefit_code')
+                && Schema::hasColumn('benefit_grants', 'attempt_id')
+                && Schema::hasColumn('benefit_grants', 'status')) {
+                Schema::table('benefit_grants', function (Blueprint $table) {
+                    $table->index(
+                        ['org_id', 'benefit_code', 'attempt_id', 'status'],
+                        'benefit_grants_org_benefit_attempt_status_idx'
+                    );
+                });
+            }
+        }
+    }
+
+    public function down(): void
+    {
+        if (Schema::hasTable('orders')) {
+            if ($this->indexExists('orders', 'orders_org_idempotency_key_unique')) {
+                Schema::table('orders', function (Blueprint $table) {
+                    $table->dropUnique('orders_org_idempotency_key_unique');
+                });
+            }
+
+            Schema::table('orders', function (Blueprint $table) {
+                if (Schema::hasColumn('orders', 'idempotency_key')) {
+                    $table->dropColumn('idempotency_key');
+                }
+                if (Schema::hasColumn('orders', 'refunded_at')) {
+                    $table->dropColumn('refunded_at');
+                }
+                if (Schema::hasColumn('orders', 'refund_amount_cents')) {
+                    $table->dropColumn('refund_amount_cents');
+                }
+                if (Schema::hasColumn('orders', 'refund_reason')) {
+                    $table->dropColumn('refund_reason');
+                }
+            });
+        }
+
+        if (Schema::hasTable('benefit_grants')) {
+            if ($this->indexExists('benefit_grants', 'benefit_grants_org_benefit_attempt_status_idx')) {
+                Schema::table('benefit_grants', function (Blueprint $table) {
+                    $table->dropIndex('benefit_grants_org_benefit_attempt_status_idx');
+                });
+            }
+
+            Schema::table('benefit_grants', function (Blueprint $table) {
+                if (Schema::hasColumn('benefit_grants', 'revoked_at')) {
+                    $table->dropColumn('revoked_at');
+                }
+            });
+        }
+    }
+
+    private function indexExists(string $table, string $indexName): bool
+    {
+        $driver = DB::connection()->getDriverName();
+
+        if ($driver === 'sqlite') {
+            $rows = DB::select("PRAGMA index_list('{$table}')");
+            foreach ($rows as $row) {
+                if ((string) ($row->name ?? '') === $indexName) {
+                    return true;
+                }
+            }
+            return false;
+        }
+
+        if ($driver === 'pgsql') {
+            $rows = DB::select('SELECT indexname FROM pg_indexes WHERE tablename = ?', [$table]);
+            foreach ($rows as $row) {
+                if ((string) ($row->indexname ?? '') === $indexName) {
+                    return true;
+                }
+            }
+            return false;
+        }
+
+        $db = DB::getDatabaseName();
+        $rows = DB::select(
+            "SELECT 1 FROM information_schema.statistics
+             WHERE table_schema = ? AND table_name = ? AND index_name = ?
+             LIMIT 1",
+            [$db, $table, $indexName]
+        );
+        return !empty($rows);
+    }
+};

--- a/backend/routes/api.php
+++ b/backend/routes/api.php
@@ -248,7 +248,7 @@ Route::prefix("v0.3")->group(function () {
         Route::post(
             "/webhooks/payment/{provider}",
             "App\\Http\\Controllers\\API\\V0_3\\Webhooks\\PaymentWebhookController@handle"
-        );
+        )->whereIn('provider', ['stripe', 'billing', 'stub']);
     });
 
     Route::middleware([\App\Http\Middleware\FmTokenAuth::class, \App\Http\Middleware\ResolveOrgContext::class])

--- a/backend/scripts/ci_verify_mbti.sh
+++ b/backend/scripts/ci_verify_mbti.sh
@@ -218,6 +218,14 @@ CANON_REL="default/${REGION}/${LOCALE}/${LEGACY_DIR}"
 CANON_ABS="$CONTENT_ROOT/$CANON_REL"
 ALIAS_ABS="$CONTENT_ROOT/$LEGACY_DIR"
 
+cleanup_legacy_alias() {
+  if [[ -L "$ALIAS_ABS" ]]; then
+    echo "[CI] cleanup legacy alias: $ALIAS_ABS"
+    rm -f "$ALIAS_ABS"
+  fi
+}
+trap cleanup_legacy_alias EXIT INT TERM
+
 if [[ -d "$CANON_ABS" ]]; then
   if [[ ! -e "$ALIAS_ABS" ]]; then
     echo "[CI] create legacy alias: $ALIAS_ABS -> $CANON_REL"

--- a/backend/scripts/pr29_accept.sh
+++ b/backend/scripts/pr29_accept.sh
@@ -1,0 +1,96 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+export CI=true
+export FAP_NONINTERACTIVE=1
+export COMPOSER_NO_INTERACTION=1
+export GIT_TERMINAL_PROMPT=0
+export NO_COLOR=1
+export PAGER=cat
+export GIT_PAGER=cat
+export TERM=dumb
+export XDEBUG_MODE=off
+
+REPO_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+BACKEND_DIR="${REPO_DIR}/backend"
+ART_DIR="${BACKEND_DIR}/artifacts/pr29"
+SERVE_PORT="${SERVE_PORT:-1829}"
+DB_PATH="/tmp/pr29.sqlite"
+
+mkdir -p "${ART_DIR}"
+mkdir -p "${BACKEND_DIR}/storage/framework/cache" \
+  "${BACKEND_DIR}/storage/framework/sessions" \
+  "${BACKEND_DIR}/storage/framework/views" \
+  "${BACKEND_DIR}/storage/framework/testing" \
+  "${BACKEND_DIR}/bootstrap/cache"
+
+# Port cleanup
+for p in "${SERVE_PORT}" 18000; do
+  lsof -ti tcp:${p} | xargs -r kill -9 || true
+  lsof -nP -iTCP:${p} -sTCP:LISTEN || true
+  lsof -ti tcp:${p} | xargs -r kill -9 || true
+  lsof -nP -iTCP:${p} -sTCP:LISTEN || true
+  done
+
+export APP_ENV=testing
+export DB_CONNECTION=sqlite
+export DB_DATABASE="${DB_PATH}"
+
+rm -f "${DB_DATABASE}"
+touch "${DB_DATABASE}"
+
+cd "${BACKEND_DIR}"
+composer install --no-interaction --no-progress
+
+SERVE_PORT="${SERVE_PORT}" bash "${BACKEND_DIR}/scripts/pr29_verify.sh"
+
+cd "${REPO_DIR}"
+
+bash "${BACKEND_DIR}/scripts/ci_verify_mbti.sh"
+
+echo "== git status after ci_verify_mbti"
+git status -sb
+git status -sb | grep -E '^\?\?\s+content_packages/MBTI-CN-v' >/dev/null && {
+  echo "[FAIL] legacy alias leaked: content_packages/MBTI-CN-v*"
+  echo "== ls -la content_packages | grep MBTI-CN-v =="
+  ls -la content_packages | grep -E 'MBTI-CN-v' || true
+  exit 1
+} || true
+
+SUMMARY_TXT="${ART_DIR}/summary.txt"
+ORDER_NO="$(cat "${ART_DIR}/order_no.txt" 2>/dev/null || true)"
+ATTEMPT_ID="$(cat "${ART_DIR}/attempt_id.txt" 2>/dev/null || true)"
+ORG_ID="$(cat "${ART_DIR}/org_id.txt" 2>/dev/null || true)"
+LOCKED_BEFORE="$(cat "${ART_DIR}/locked_before.txt" 2>/dev/null || true)"
+LOCKED_AFTER_PAID="$(cat "${ART_DIR}/locked_after_paid.txt" 2>/dev/null || true)"
+LOCKED_AFTER_REFUND="$(cat "${ART_DIR}/locked_after_refund.txt" 2>/dev/null || true)"
+
+cat > "${SUMMARY_TXT}" <<TXT
+PR29 Acceptance Summary
+- verify: backend/scripts/pr29_verify.sh
+- serve_port: ${SERVE_PORT}
+- org_id: ${ORG_ID}
+- attempt_id: ${ATTEMPT_ID}
+- order_no: ${ORDER_NO}
+- locked_before: ${LOCKED_BEFORE}
+- locked_after_paid: ${LOCKED_AFTER_PAID}
+- locked_after_refund: ${LOCKED_AFTER_REFUND}
+- ci_verify_mbti: PASS (alias cleaned)
+Artifacts:
+- backend/artifacts/pr29/skus.json
+- backend/artifacts/pr29/attempt_start.json
+- backend/artifacts/pr29/submit.json
+- backend/artifacts/pr29/report_before.json
+- backend/artifacts/pr29/order_create_1.json
+- backend/artifacts/pr29/order_create_2.json
+- backend/artifacts/pr29/webhook_paid.json
+- backend/artifacts/pr29/report_after_paid.json
+- backend/artifacts/pr29/webhook_refund.json
+- backend/artifacts/pr29/report_after_refund.json
+TXT
+
+bash "${BACKEND_DIR}/scripts/sanitize_artifacts.sh" 29
+
+# Shellcheck: verify scripts are syntactically valid
+bash -n "${BACKEND_DIR}/scripts/pr29_verify.sh"
+bash -n "${BACKEND_DIR}/scripts/pr29_accept.sh"

--- a/backend/scripts/pr29_verify.sh
+++ b/backend/scripts/pr29_verify.sh
@@ -1,0 +1,381 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+export CI=true
+export FAP_NONINTERACTIVE=1
+export COMPOSER_NO_INTERACTION=1
+export GIT_TERMINAL_PROMPT=0
+export NO_COLOR=1
+export PAGER=cat
+export GIT_PAGER=cat
+export TERM=dumb
+export XDEBUG_MODE=off
+export FAP_PAYMENT_FALLBACK_PROVIDER=stub
+
+REPO_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+BACKEND_DIR="${REPO_DIR}/backend"
+ART_DIR="${BACKEND_DIR}/artifacts/pr29"
+LOG_DIR="${ART_DIR}/logs"
+SERVE_PORT="${SERVE_PORT:-1829}"
+HOST="127.0.0.1"
+API="http://${HOST}:${SERVE_PORT}"
+DB_PATH="${DB_DATABASE:-/tmp/pr29.sqlite}"
+
+mkdir -p "${ART_DIR}" "${LOG_DIR}"
+mkdir -p "${BACKEND_DIR}/storage/framework/cache" \
+  "${BACKEND_DIR}/storage/framework/sessions" \
+  "${BACKEND_DIR}/storage/framework/views" \
+  "${BACKEND_DIR}/storage/framework/testing" \
+  "${BACKEND_DIR}/bootstrap/cache"
+
+fail() { echo "[PR29][FAIL] $*" >&2; exit 1; }
+
+cleanup_port() {
+  local port="$1"
+  lsof -ti tcp:"${port}" | xargs -r kill -9 || true
+}
+
+wait_health() {
+  local url="$1"
+  for _ in $(seq 1 80); do
+    if curl -fsS "${url}" >/dev/null 2>&1; then
+      return 0
+    fi
+    sleep 0.2
+  done
+  return 1
+}
+
+cleanup() {
+  cp -f "${BACKEND_DIR}/storage/logs/laravel.log" "${LOG_DIR}/laravel.log" 2>/dev/null || true
+  if [[ -n "${SERVE_PID:-}" ]] && kill -0 "${SERVE_PID}" >/dev/null 2>&1; then
+    kill "${SERVE_PID}" >/dev/null 2>&1 || true
+  fi
+}
+trap cleanup EXIT
+
+table_exists() {
+  local tbl="$1"
+  sqlite3 "$DB_PATH" "SELECT name FROM sqlite_master WHERE type='table' AND name='${tbl}' LIMIT 1;" \
+    | tr -d '\r' | grep -qx "${tbl}"
+}
+
+col_exists() {
+  local tbl="$1"
+  local col="$2"
+  sqlite3 "$DB_PATH" "PRAGMA table_info(${tbl});" \
+    | awk -F'|' '{print $2}' | tr -d '\r' | grep -qx "${col}"
+}
+
+# Always treat attempt id as string (UUID) in sqlite
+sql_quote() {
+  # escape single quotes for sqlite
+  printf "%s" "$1" | sed "s/'/''/g"
+}
+
+delete_attempt_scoped_rows() {
+  local tbl="$1"
+  local org_id="$2"
+  local attempt_id="$3"
+  local benefit_code="$4"
+
+  table_exists "${tbl}" || return 0
+
+  local aid
+  aid="$(sql_quote "${attempt_id}")"
+
+  local clauses=()
+
+  if col_exists "${tbl}" "scope" && col_exists "${tbl}" "scope_id"; then
+    clauses+=("scope='attempt'")
+    clauses+=("scope_id='${aid}'")
+  elif col_exists "${tbl}" "attempt_id"; then
+    clauses+=("attempt_id='${aid}'")
+  elif col_exists "${tbl}" "target_attempt_id"; then
+    clauses+=("target_attempt_id='${aid}'")
+  else
+    fail "table ${tbl} has no attempt scope column"
+  fi
+
+  if col_exists "${tbl}" "org_id"; then
+    clauses+=("org_id=${org_id}")
+  fi
+  if col_exists "${tbl}" "benefit_code"; then
+    clauses+=("benefit_code='${benefit_code}'")
+  fi
+
+  local cond=""
+  local i=0
+  for c in "${clauses[@]}"; do
+    if [[ $i -eq 0 ]]; then
+      cond="${c}"
+    else
+      cond="${cond} AND ${c}"
+    fi
+    i=$((i+1))
+  done
+
+  sqlite3 "$DB_PATH" "
+PRAGMA busy_timeout=5000;
+DELETE FROM ${tbl} WHERE ${cond};
+SELECT changes();
+"
+}
+
+topup_wallet() {
+  local org_id="$1"
+  local benefit_code="$2"
+  local amount="$3"
+  table_exists "benefit_wallets" || fail "missing benefit_wallets table"
+
+  sqlite3 "$DB_PATH" "
+PRAGMA busy_timeout=5000;
+INSERT INTO benefit_wallets (org_id, benefit_code, balance, created_at, updated_at)
+VALUES (${org_id}, '${benefit_code}', ${amount}, datetime('now'), datetime('now'))
+ON CONFLICT(org_id, benefit_code) DO UPDATE SET
+  balance=excluded.balance,
+  updated_at=datetime('now');
+"
+}
+
+reset_wallet_zero() {
+  local org_id="$1"
+  local benefit_code="$2"
+  table_exists "benefit_wallets" || return 0
+
+  sqlite3 "$DB_PATH" "
+PRAGMA busy_timeout=5000;
+UPDATE benefit_wallets
+SET balance=0, updated_at=datetime('now')
+WHERE org_id=${org_id} AND benefit_code='${benefit_code}';
+SELECT changes();
+"
+}
+
+cleanup_port "${SERVE_PORT}"
+cleanup_port 18000
+
+export APP_ENV=testing
+export DB_CONNECTION=sqlite
+export DB_DATABASE="${DB_PATH}"
+
+rm -f "${DB_DATABASE}"
+touch "${DB_DATABASE}"
+
+cd "${BACKEND_DIR}"
+
+php artisan migrate --force
+php artisan db:seed --force --class=Database\\Seeders\\ScaleRegistrySeeder
+php artisan db:seed --force --class=Database\\Seeders\\Pr17SimpleScoreDemoSeeder
+php artisan db:seed --force --class=Database\\Seeders\\Pr19CommerceSeeder
+
+# Ensure SIMPLE_SCORE_DEMO uses MBTI_REPORT_FULL as report benefit gate
+php artisan tinker --execute='
+use Illuminate\Support\Facades\DB;
+$row = DB::table("scales_registry")->where("org_id", 0)->where("code", "SIMPLE_SCORE_DEMO")->first();
+if (!$row) { throw new RuntimeException("missing scales_registry SIMPLE_SCORE_DEMO"); }
+$commercial = $row->commercial_json ?? null;
+if (is_string($commercial)) {
+  $decoded = json_decode($commercial, true);
+  $commercial = is_array($decoded) ? $decoded : null;
+}
+if (!is_array($commercial)) { $commercial = []; }
+$commercial["report_benefit_code"] = "MBTI_REPORT_FULL";
+DB::table("scales_registry")
+  ->where("org_id", 0)
+  ->where("code", "SIMPLE_SCORE_DEMO")
+  ->update([
+    "commercial_json" => json_encode($commercial, JSON_UNESCAPED_UNICODE),
+    "updated_at" => now(),
+  ]);
+' >/dev/null
+
+USER_JSON="${ART_DIR}/user.json"
+php artisan tinker --execute='
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Str;
+$uid = 9029;
+if (!DB::table("users")->where("id", $uid)->exists()) {
+  DB::table("users")->insert([
+    "id" => $uid,
+    "name" => "PR29 User",
+    "email" => "pr29_user@example.com",
+    "password" => "secret",
+    "created_at" => now(),
+    "updated_at" => now(),
+  ]);
+}
+$orgId = 2929;
+if (!DB::table("organizations")->where("id", $orgId)->exists()) {
+  DB::table("organizations")->insert([
+    "id" => $orgId,
+    "name" => "PR29 Org",
+    "owner_user_id" => $uid,
+    "created_at" => now(),
+    "updated_at" => now(),
+  ]);
+}
+if (!DB::table("organization_members")->where("org_id", $orgId)->where("user_id", $uid)->exists()) {
+  DB::table("organization_members")->insert([
+    "org_id" => $orgId,
+    "user_id" => $uid,
+    "role" => "owner",
+    "joined_at" => now(),
+    "created_at" => now(),
+    "updated_at" => now(),
+  ]);
+}
+$token = "fm_" . (string) Str::uuid();
+DB::table("fm_tokens")->insert([
+  "token" => $token,
+  "anon_id" => "anon_pr29",
+  "user_id" => $uid,
+  "expires_at" => now()->addDays(1),
+  "created_at" => now(),
+  "updated_at" => now(),
+]);
+print(json_encode(["user_id" => $uid, "org_id" => $orgId, "token" => $token]));
+' | tail -n 1 >"${USER_JSON}"
+
+TOKEN="$(php -r '$j=json_decode(file_get_contents($argv[1]), true); echo $j["token"] ?? "";' "${USER_JSON}")"
+ORG_ID="$(php -r '$j=json_decode(file_get_contents($argv[1]), true); echo $j["org_id"] ?? "";' "${USER_JSON}")"
+[[ -n "${TOKEN}" ]] || fail "missing fm_token"
+[[ -n "${ORG_ID}" ]] || fail "missing org_id"
+echo "${ORG_ID}" > "${ART_DIR}/org_id.txt"
+
+php artisan serve --host="${HOST}" --port="${SERVE_PORT}" >"${LOG_DIR}/server.log" 2>&1 &
+SERVE_PID=$!
+wait_health "${API}/api/v0.2/health" || fail "server not healthy on ${API}"
+
+SKUS_JSON="${ART_DIR}/skus.json"
+http_code=$(curl -sS -L -o "${SKUS_JSON}" -w "%{http_code}" \
+  "${API}/api/v0.3/skus?scale=MBTI" \
+  -H "Accept: application/json" \
+  -H "Authorization: Bearer ${TOKEN}" \
+  -H "X-Org-Id: ${ORG_ID}" || true)
+[[ "${http_code}" == "200" ]] || fail "skus failed (http=${http_code})"
+
+ATTEMPT_START_JSON="${ART_DIR}/attempt_start.json"
+http_code=$(curl -sS -L -o "${ATTEMPT_START_JSON}" -w "%{http_code}" \
+  -X POST "${API}/api/v0.3/attempts/start" \
+  -H "Content-Type: application/json" -H "Accept: application/json" \
+  -H "Authorization: Bearer ${TOKEN}" \
+  -H "X-Org-Id: ${ORG_ID}" \
+  -d '{"scale_code":"SIMPLE_SCORE_DEMO"}' || true)
+[[ "${http_code}" == "200" ]] || fail "attempt start failed (http=${http_code})"
+ATTEMPT_ID="$(php -r '$j=json_decode(file_get_contents($argv[1]), true); echo $j["attempt_id"] ?? "";' "${ATTEMPT_START_JSON}")"
+[[ -n "${ATTEMPT_ID}" ]] || fail "missing attempt_id"
+echo "${ATTEMPT_ID}" > "${ART_DIR}/attempt_id.txt"
+
+ANSWERS_PAYLOAD='{"attempt_id":"'"${ATTEMPT_ID}"'","answers":[{"question_id":"SS-001","code":"5"},{"question_id":"SS-002","code":"4"},{"question_id":"SS-003","code":"3"},{"question_id":"SS-004","code":"2"},{"question_id":"SS-005","code":"1"}],"duration_ms":120000}'
+
+# Topup credits ONLY to pass submit gate
+topup_wallet "${ORG_ID}" "MBTI_CREDIT" 999999
+sqlite3 "$DB_PATH" "SELECT org_id, benefit_code, balance FROM benefit_wallets WHERE org_id=${ORG_ID} AND benefit_code='MBTI_CREDIT' LIMIT 1;" \
+  > "${ART_DIR}/wallet_before_submit.txt" || true
+
+SUBMIT_JSON="${ART_DIR}/submit.json"
+http_code=$(curl -sS -L -o "${SUBMIT_JSON}" -w "%{http_code}" \
+  -X POST "${API}/api/v0.3/attempts/submit" \
+  -H "Content-Type: application/json" -H "Accept: application/json" \
+  -H "Authorization: Bearer ${TOKEN}" \
+  -H "X-Org-Id: ${ORG_ID}" \
+  -d "${ANSWERS_PAYLOAD}" || true)
+[[ "${http_code}" == "200" ]] || fail "submit failed (http=${http_code})"
+
+# Force baseline: locked before payment
+# 1) zero wallet
+reset_wallet_zero "${ORG_ID}" "MBTI_CREDIT" > "${ART_DIR}/wallet_reset_changes.txt" || true
+sqlite3 "$DB_PATH" "SELECT org_id, benefit_code, balance FROM benefit_wallets WHERE org_id=${ORG_ID} AND benefit_code='MBTI_CREDIT' LIMIT 1;" \
+  > "${ART_DIR}/wallet_after_submit.txt" || true
+
+# 2) delete auto-granted report unlock + the consumed credit entry for this attempt
+delete_attempt_scoped_rows "benefit_grants" "${ORG_ID}" "${ATTEMPT_ID}" "MBTI_REPORT_FULL" \
+  > "${ART_DIR}/deleted_benefit_grants.txt" || true
+delete_attempt_scoped_rows "benefit_consumptions" "${ORG_ID}" "${ATTEMPT_ID}" "MBTI_CREDIT" \
+  > "${ART_DIR}/deleted_benefit_consumptions.txt" || true
+
+# Dump proof after cleanup
+table_exists "benefit_grants" && sqlite3 "$DB_PATH" "SELECT * FROM benefit_grants WHERE org_id=${ORG_ID};" \
+  > "${ART_DIR}/benefit_grants_after_cleanup.txt" || true
+table_exists "benefit_consumptions" && sqlite3 "$DB_PATH" "SELECT * FROM benefit_consumptions WHERE org_id=${ORG_ID};" \
+  > "${ART_DIR}/benefit_consumptions_after_cleanup.txt" || true
+
+REPORT_BEFORE_JSON="${ART_DIR}/report_before.json"
+http_code=$(curl -sS -L -o "${REPORT_BEFORE_JSON}" -w "%{http_code}" \
+  "${API}/api/v0.3/attempts/${ATTEMPT_ID}/report" \
+  -H "Accept: application/json" \
+  -H "Authorization: Bearer ${TOKEN}" \
+  -H "X-Org-Id: ${ORG_ID}" || true)
+[[ "${http_code}" == "200" ]] || fail "report before failed (http=${http_code})"
+LOCKED_BEFORE="$(php -r '$j=json_decode(file_get_contents($argv[1]), true); echo !empty($j["locked"]) ? "1" : "0";' "${REPORT_BEFORE_JSON}")"
+[[ "${LOCKED_BEFORE}" == "1" ]] || fail "expected report locked before payment"
+echo "${LOCKED_BEFORE}" > "${ART_DIR}/locked_before.txt"
+
+IDEMPOTENCY_KEY="idem_pr29_1"
+ORDER_JSON="${ART_DIR}/order_create_1.json"
+http_code=$(curl -sS -L -o "${ORDER_JSON}" -w "%{http_code}" \
+  -X POST "${API}/api/v0.3/orders" \
+  -H "Content-Type: application/json" -H "Accept: application/json" \
+  -H "Authorization: Bearer ${TOKEN}" \
+  -H "X-Org-Id: ${ORG_ID}" \
+  -H "Idempotency-Key: ${IDEMPOTENCY_KEY}" \
+  -d '{"sku":"MBTI_REPORT_FULL_199","quantity":1,"provider":"stub","target_attempt_id":"'"${ATTEMPT_ID}"'"}' || true)
+[[ "${http_code}" == "200" ]] || fail "create order failed (http=${http_code})"
+ORDER_NO="$(php -r '$j=json_decode(file_get_contents($argv[1]), true); echo $j["order_no"] ?? "";' "${ORDER_JSON}")"
+[[ -n "${ORDER_NO}" ]] || fail "missing order_no"
+echo "${ORDER_NO}" > "${ART_DIR}/order_no.txt"
+
+ORDER_JSON_2="${ART_DIR}/order_create_2.json"
+http_code=$(curl -sS -L -o "${ORDER_JSON_2}" -w "%{http_code}" \
+  -X POST "${API}/api/v0.3/orders" \
+  -H "Content-Type: application/json" -H "Accept: application/json" \
+  -H "Authorization: Bearer ${TOKEN}" \
+  -H "X-Org-Id: ${ORG_ID}" \
+  -H "Idempotency-Key: ${IDEMPOTENCY_KEY}" \
+  -d '{"sku":"MBTI_REPORT_FULL_199","quantity":1,"provider":"stub","target_attempt_id":"'"${ATTEMPT_ID}"'"}' || true)
+[[ "${http_code}" == "200" ]] || fail "create order idempotent failed (http=${http_code})"
+ORDER_NO_2="$(php -r '$j=json_decode(file_get_contents($argv[1]), true); echo $j["order_no"] ?? "";' "${ORDER_JSON_2}")"
+[[ "${ORDER_NO_2}" == "${ORDER_NO}" ]] || fail "idempotency_key mismatch"
+
+WEBHOOK_PAID_JSON="${ART_DIR}/webhook_paid.json"
+http_code=$(curl -sS -L -o "${WEBHOOK_PAID_JSON}" -w "%{http_code}" \
+  -X POST "${API}/api/v0.3/webhooks/payment/stub" \
+  -H "Content-Type: application/json" -H "Accept: application/json" \
+  -H "Authorization: Bearer ${TOKEN}" \
+  -H "X-Org-Id: ${ORG_ID}" \
+  -d '{"provider_event_id":"evt_pr29_paid","order_no":"'"${ORDER_NO}"'","external_trade_no":"trade_pr29","amount_cents":199,"currency":"CNY"}' || true)
+[[ "${http_code}" == "200" ]] || fail "webhook paid failed (http=${http_code})"
+
+REPORT_AFTER_PAID_JSON="${ART_DIR}/report_after_paid.json"
+http_code=$(curl -sS -L -o "${REPORT_AFTER_PAID_JSON}" -w "%{http_code}" \
+  "${API}/api/v0.3/attempts/${ATTEMPT_ID}/report" \
+  -H "Accept: application/json" \
+  -H "Authorization: Bearer ${TOKEN}" \
+  -H "X-Org-Id: ${ORG_ID}" || true)
+[[ "${http_code}" == "200" ]] || fail "report after paid failed (http=${http_code})"
+LOCKED_AFTER_PAID="$(php -r '$j=json_decode(file_get_contents($argv[1]), true); echo !empty($j["locked"]) ? "1" : "0";' "${REPORT_AFTER_PAID_JSON}")"
+[[ "${LOCKED_AFTER_PAID}" == "0" ]] || fail "expected report unlocked after payment"
+echo "${LOCKED_AFTER_PAID}" > "${ART_DIR}/locked_after_paid.txt"
+
+WEBHOOK_REFUND_JSON="${ART_DIR}/webhook_refund.json"
+http_code=$(curl -sS -L -o "${WEBHOOK_REFUND_JSON}" -w "%{http_code}" \
+  -X POST "${API}/api/v0.3/webhooks/payment/stub" \
+  -H "Content-Type: application/json" -H "Accept: application/json" \
+  -H "Authorization: Bearer ${TOKEN}" \
+  -H "X-Org-Id: ${ORG_ID}" \
+  -d '{"provider_event_id":"evt_pr29_refund","order_no":"'"${ORDER_NO}"'","event_type":"refund_succeeded","refund_amount_cents":199,"refund_reason":"requested_by_customer"}' || true)
+[[ "${http_code}" == "200" ]] || fail "webhook refund failed (http=${http_code})"
+
+REPORT_AFTER_REFUND_JSON="${ART_DIR}/report_after_refund.json"
+http_code=$(curl -sS -L -o "${REPORT_AFTER_REFUND_JSON}" -w "%{http_code}" \
+  "${API}/api/v0.3/attempts/${ATTEMPT_ID}/report" \
+  -H "Accept: application/json" \
+  -H "Authorization: Bearer ${TOKEN}" \
+  -H "X-Org-Id: ${ORG_ID}" || true)
+[[ "${http_code}" == "200" ]] || fail "report after refund failed (http=${http_code})"
+LOCKED_AFTER_REFUND="$(php -r '$j=json_decode(file_get_contents($argv[1]), true); echo !empty($j["locked"]) ? "1" : "0";' "${REPORT_AFTER_REFUND_JSON}")"
+[[ "${LOCKED_AFTER_REFUND}" == "1" ]] || fail "expected report locked after refund"
+echo "${LOCKED_AFTER_REFUND}" > "${ART_DIR}/locked_after_refund.txt"
+
+bash -n "${BACKEND_DIR}/scripts/pr29_verify.sh"

--- a/backend/tests/Feature/V0_3/BillingWebhookSignatureTest.php
+++ b/backend/tests/Feature/V0_3/BillingWebhookSignatureTest.php
@@ -1,0 +1,80 @@
+<?php
+
+namespace Tests\Feature\V0_3;
+
+use Database\Seeders\Pr19CommerceSeeder;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Str;
+use Tests\TestCase;
+
+class BillingWebhookSignatureTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_billing_signature_required_and_valid(): void
+    {
+        (new Pr19CommerceSeeder())->run();
+
+        config(['services.billing.webhook_secret' => 'billing_secret']);
+
+        $orderNo = 'ord_billing_1';
+        DB::table('orders')->insert([
+            'id' => (string) Str::uuid(),
+            'order_no' => $orderNo,
+            'org_id' => 0,
+            'user_id' => null,
+            'anon_id' => null,
+            'sku' => 'MBTI_CREDIT',
+            'quantity' => 1,
+            'target_attempt_id' => null,
+            'amount_cents' => 4990,
+            'currency' => 'USD',
+            'status' => 'created',
+            'provider' => 'billing',
+            'external_trade_no' => null,
+            'paid_at' => null,
+            'created_at' => now(),
+            'updated_at' => now(),
+            'amount_total' => 4990,
+            'amount_refunded' => 0,
+            'item_sku' => 'MBTI_CREDIT',
+            'provider_order_id' => null,
+            'device_id' => null,
+            'request_id' => null,
+            'created_ip' => null,
+            'fulfilled_at' => null,
+            'refunded_at' => null,
+        ]);
+
+        $payload = [
+            'provider_event_id' => 'evt_bill_1',
+            'order_no' => $orderNo,
+            'amount_cents' => 4990,
+            'currency' => 'USD',
+        ];
+
+        $missing = $this->postJson('/api/v0.3/webhooks/payment/billing', $payload, [
+            'X-Org-Id' => '0',
+        ]);
+        $missing->assertStatus(404);
+
+        $bad = $this->postJson('/api/v0.3/webhooks/payment/billing', $payload, [
+            'X-Org-Id' => '0',
+            'X-Billing-Signature' => 'bad',
+        ]);
+        $bad->assertStatus(404);
+
+        $raw = json_encode($payload);
+        $signature = hash_hmac('sha256', $raw ?: '', 'billing_secret');
+
+        $ok = $this->postJson('/api/v0.3/webhooks/payment/billing', $payload, [
+            'X-Org-Id' => '0',
+            'X-Billing-Signature' => $signature,
+        ]);
+        $ok->assertStatus(200);
+        $ok->assertJson([
+            'ok' => true,
+        ]);
+    }
+}

--- a/backend/tests/Feature/V0_3/CommerceOrderIdempotencyTest.php
+++ b/backend/tests/Feature/V0_3/CommerceOrderIdempotencyTest.php
@@ -1,0 +1,141 @@
+<?php
+
+namespace Tests\Feature\V0_3;
+
+use Database\Seeders\Pr19CommerceSeeder;
+use Database\Seeders\ScaleRegistrySeeder;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Str;
+use Tests\TestCase;
+
+class CommerceOrderIdempotencyTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private function seedOrgWithToken(int $orgId, int $userId): array
+    {
+        DB::table('users')->insert([
+            'id' => $userId,
+            'name' => 'Commerce User ' . $userId,
+            'email' => 'commerce_' . $userId . '@example.com',
+            'password' => 'secret',
+            'created_at' => now(),
+            'updated_at' => now(),
+        ]);
+
+        DB::table('organizations')->insert([
+            'id' => $orgId,
+            'name' => 'Commerce Org ' . $orgId,
+            'owner_user_id' => $userId,
+            'created_at' => now(),
+            'updated_at' => now(),
+        ]);
+
+        DB::table('organization_members')->insert([
+            'org_id' => $orgId,
+            'user_id' => $userId,
+            'role' => 'owner',
+            'joined_at' => now(),
+            'created_at' => now(),
+            'updated_at' => now(),
+        ]);
+
+        $token = 'fm_' . (string) Str::uuid();
+        DB::table('fm_tokens')->insert([
+            'token' => $token,
+            'anon_id' => 'anon_' . $userId,
+            'user_id' => $userId,
+            'expires_at' => now()->addDays(1),
+            'created_at' => now(),
+            'updated_at' => now(),
+        ]);
+
+        return [$orgId, $userId, $token];
+    }
+
+    public function test_order_create_idempotent(): void
+    {
+        (new ScaleRegistrySeeder())->run();
+        (new Pr19CommerceSeeder())->run();
+
+        [$orgId, $userId, $token] = $this->seedOrgWithToken(9101, 9101);
+
+        $payload = [
+            'sku' => 'MBTI_CREDIT',
+            'quantity' => 1,
+            'provider' => 'stub',
+        ];
+
+        $idempotencyKey = 'idem_order_1';
+
+        $first = $this->postJson('/api/v0.3/orders', $payload, [
+            'X-Org-Id' => (string) $orgId,
+            'Authorization' => 'Bearer ' . $token,
+            'Idempotency-Key' => $idempotencyKey,
+        ]);
+        $first->assertStatus(200);
+        $first->assertJson(['ok' => true]);
+        $orderNo = (string) $first->json('order_no');
+        $this->assertNotSame('', $orderNo);
+
+        $second = $this->postJson('/api/v0.3/orders', $payload, [
+            'X-Org-Id' => (string) $orgId,
+            'Authorization' => 'Bearer ' . $token,
+            'Idempotency-Key' => $idempotencyKey,
+        ]);
+        $second->assertStatus(200);
+        $second->assertJson(['ok' => true]);
+        $this->assertSame($orderNo, (string) $second->json('order_no'));
+
+        $this->assertSame(1, DB::table('orders')->where('org_id', $orgId)->where('idempotency_key', $idempotencyKey)->count());
+    }
+
+    public function test_cross_org_order_lookup_returns_404(): void
+    {
+        (new Pr19CommerceSeeder())->run();
+
+        [$orgA, $userA, $tokenA] = $this->seedOrgWithToken(9201, 9201);
+        [$orgB, $userB, $tokenB] = $this->seedOrgWithToken(9202, 9202);
+
+        $orderNo = 'ord_cross_org_1';
+        DB::table('orders')->insert([
+            'id' => (string) Str::uuid(),
+            'order_no' => $orderNo,
+            'org_id' => $orgA,
+            'user_id' => (string) $userA,
+            'anon_id' => 'anon_' . $userA,
+            'sku' => 'MBTI_CREDIT',
+            'quantity' => 1,
+            'target_attempt_id' => null,
+            'amount_cents' => 4990,
+            'currency' => 'USD',
+            'status' => 'created',
+            'provider' => 'stub',
+            'external_trade_no' => null,
+            'paid_at' => null,
+            'created_at' => now(),
+            'updated_at' => now(),
+            'amount_total' => 4990,
+            'amount_refunded' => 0,
+            'item_sku' => 'MBTI_CREDIT',
+            'provider_order_id' => null,
+            'device_id' => null,
+            'request_id' => null,
+            'created_ip' => null,
+            'fulfilled_at' => null,
+            'refunded_at' => null,
+        ]);
+
+        $res = $this->getJson('/api/v0.3/orders/' . $orderNo, [
+            'X-Org-Id' => (string) $orgB,
+            'Authorization' => 'Bearer ' . $tokenB,
+        ]);
+
+        $res->assertStatus(404);
+        $res->assertJson([
+            'ok' => false,
+            'error' => 'ORDER_NOT_FOUND',
+        ]);
+    }
+}

--- a/backend/tests/Feature/V0_3/CommerceRefundWebhookTest.php
+++ b/backend/tests/Feature/V0_3/CommerceRefundWebhookTest.php
@@ -1,0 +1,238 @@
+<?php
+
+namespace Tests\Feature\V0_3;
+
+use App\Models\Attempt;
+use App\Models\Result;
+use Database\Seeders\Pr19CommerceSeeder;
+use Database\Seeders\ScaleRegistrySeeder;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Str;
+use Tests\TestCase;
+
+class CommerceRefundWebhookTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private function seedScales(): void
+    {
+        (new ScaleRegistrySeeder())->run();
+        (new Pr19CommerceSeeder())->run();
+    }
+
+    private function seedOrgWithToken(): array
+    {
+        $userId = 9301;
+        DB::table('users')->insert([
+            'id' => $userId,
+            'name' => 'Refund User',
+            'email' => 'refund_user@example.com',
+            'password' => 'secret',
+            'created_at' => now(),
+            'updated_at' => now(),
+        ]);
+
+        $orgId = 9301;
+        DB::table('organizations')->insert([
+            'id' => $orgId,
+            'name' => 'Refund Org',
+            'owner_user_id' => $userId,
+            'created_at' => now(),
+            'updated_at' => now(),
+        ]);
+
+        DB::table('organization_members')->insert([
+            'org_id' => $orgId,
+            'user_id' => $userId,
+            'role' => 'owner',
+            'joined_at' => now(),
+            'created_at' => now(),
+            'updated_at' => now(),
+        ]);
+
+        $token = 'fm_' . (string) Str::uuid();
+        DB::table('fm_tokens')->insert([
+            'token' => $token,
+            'anon_id' => 'anon_' . $userId,
+            'user_id' => $userId,
+            'expires_at' => now()->addDays(1),
+            'created_at' => now(),
+            'updated_at' => now(),
+        ]);
+
+        return [$orgId, $userId, $token];
+    }
+
+    private function createMbtiAttemptWithResult(int $orgId): string
+    {
+        $attemptId = (string) Str::uuid();
+
+        Attempt::create([
+            'id' => $attemptId,
+            'org_id' => $orgId,
+            'anon_id' => 'anon_refund',
+            'scale_code' => 'MBTI',
+            'scale_version' => 'v0.3',
+            'region' => 'CN_MAINLAND',
+            'locale' => 'zh-CN',
+            'question_count' => 144,
+            'client_platform' => 'test',
+            'answers_summary_json' => ['stage' => 'seed'],
+            'started_at' => now(),
+            'submitted_at' => now(),
+            'pack_id' => (string) config('content_packs.default_pack_id'),
+            'dir_version' => 'MBTI-CN-v0.2.1-TEST',
+            'content_package_version' => 'v0.2.1-TEST',
+            'scoring_spec_version' => '2026.01',
+        ]);
+
+        Result::create([
+            'id' => (string) Str::uuid(),
+            'org_id' => $orgId,
+            'attempt_id' => $attemptId,
+            'scale_code' => 'MBTI',
+            'scale_version' => 'v0.3',
+            'type_code' => 'INTJ-A',
+            'scores_json' => [
+                'EI' => ['a' => 10, 'b' => 10, 'neutral' => 0, 'sum' => 0, 'total' => 20],
+                'SN' => ['a' => 10, 'b' => 10, 'neutral' => 0, 'sum' => 0, 'total' => 20],
+                'TF' => ['a' => 10, 'b' => 10, 'neutral' => 0, 'sum' => 0, 'total' => 20],
+                'JP' => ['a' => 10, 'b' => 10, 'neutral' => 0, 'sum' => 0, 'total' => 20],
+                'AT' => ['a' => 10, 'b' => 10, 'neutral' => 0, 'sum' => 0, 'total' => 20],
+            ],
+            'scores_pct' => [
+                'EI' => 50,
+                'SN' => 50,
+                'TF' => 50,
+                'JP' => 50,
+                'AT' => 50,
+            ],
+            'axis_states' => [
+                'EI' => 'clear',
+                'SN' => 'clear',
+                'TF' => 'clear',
+                'JP' => 'clear',
+                'AT' => 'clear',
+            ],
+            'content_package_version' => 'v0.2.1-TEST',
+            'result_json' => [
+                'raw_score' => 0,
+                'final_score' => 0,
+                'breakdown_json' => [],
+                'type_code' => 'INTJ-A',
+                'axis_scores_json' => [
+                    'scores_pct' => [
+                        'EI' => 50,
+                        'SN' => 50,
+                        'TF' => 50,
+                        'JP' => 50,
+                        'AT' => 50,
+                    ],
+                    'axis_states' => [
+                        'EI' => 'clear',
+                        'SN' => 'clear',
+                        'TF' => 'clear',
+                        'JP' => 'clear',
+                        'AT' => 'clear',
+                    ],
+                ],
+            ],
+            'pack_id' => (string) config('content_packs.default_pack_id'),
+            'dir_version' => 'MBTI-CN-v0.2.1-TEST',
+            'scoring_spec_version' => '2026.01',
+            'report_engine_version' => 'v1.2',
+            'is_valid' => true,
+            'computed_at' => now(),
+        ]);
+
+        return $attemptId;
+    }
+
+    public function test_refund_revokes_entitlement_and_locks_report(): void
+    {
+        $this->seedScales();
+        [$orgId, $userId, $token] = $this->seedOrgWithToken();
+
+        $attemptId = $this->createMbtiAttemptWithResult($orgId);
+
+        $orderNo = 'ord_refund_1';
+        DB::table('orders')->insert([
+            'id' => (string) Str::uuid(),
+            'order_no' => $orderNo,
+            'org_id' => $orgId,
+            'user_id' => (string) $userId,
+            'anon_id' => 'anon_' . $userId,
+            'sku' => 'MBTI_REPORT_FULL',
+            'quantity' => 1,
+            'target_attempt_id' => $attemptId,
+            'amount_cents' => 990,
+            'currency' => 'USD',
+            'status' => 'created',
+            'provider' => 'stub',
+            'external_trade_no' => null,
+            'paid_at' => null,
+            'created_at' => now(),
+            'updated_at' => now(),
+            'amount_total' => 990,
+            'amount_refunded' => 0,
+            'item_sku' => 'MBTI_REPORT_FULL',
+            'provider_order_id' => null,
+            'device_id' => null,
+            'request_id' => null,
+            'created_ip' => null,
+            'fulfilled_at' => null,
+            'refunded_at' => null,
+        ]);
+
+        $payload = [
+            'provider_event_id' => 'evt_refund_paid',
+            'order_no' => $orderNo,
+            'external_trade_no' => 'trade_refund_1',
+            'amount_cents' => 990,
+            'currency' => 'USD',
+        ];
+
+        $paid = $this->postJson('/api/v0.3/webhooks/payment/stub', $payload, [
+            'X-Org-Id' => (string) $orgId,
+            'Authorization' => 'Bearer ' . $token,
+        ]);
+        $paid->assertStatus(200);
+        $paid->assertJson(['ok' => true]);
+
+        $report = $this->getJson("/api/v0.3/attempts/{$attemptId}/report", [
+            'X-Org-Id' => (string) $orgId,
+            'Authorization' => 'Bearer ' . $token,
+        ]);
+        $report->assertStatus(200);
+        $report->assertJson([
+            'ok' => true,
+            'locked' => false,
+        ]);
+
+        $refundPayload = [
+            'provider_event_id' => 'evt_refund_1',
+            'order_no' => $orderNo,
+            'event_type' => 'refund_succeeded',
+            'refund_amount_cents' => 990,
+            'refund_reason' => 'requested_by_customer',
+        ];
+
+        $refund = $this->postJson('/api/v0.3/webhooks/payment/stub', $refundPayload, [
+            'X-Org-Id' => (string) $orgId,
+            'Authorization' => 'Bearer ' . $token,
+        ]);
+        $refund->assertStatus(200);
+        $refund->assertJson(['ok' => true]);
+
+        $reportAfter = $this->getJson("/api/v0.3/attempts/{$attemptId}/report", [
+            'X-Org-Id' => (string) $orgId,
+            'Authorization' => 'Bearer ' . $token,
+        ]);
+        $reportAfter->assertStatus(200);
+        $reportAfter->assertJson([
+            'ok' => true,
+            'locked' => true,
+        ]);
+    }
+}

--- a/backend/tests/Feature/ViewCompiledPathTest.php
+++ b/backend/tests/Feature/ViewCompiledPathTest.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Tests\Feature;
+
+use Tests\TestCase;
+
+class ViewCompiledPathTest extends TestCase
+{
+    public function test_view_compiled_path_ready(): void
+    {
+        $path = (string) config('view.compiled');
+        $this->assertNotSame('', $path);
+        $this->assertTrue(is_dir($path), 'view.compiled directory missing: ' . $path);
+    }
+}

--- a/docs/verify/pr29_verify.md
+++ b/docs/verify/pr29_verify.md
@@ -1,0 +1,29 @@
+# PR29 Verify
+
+- Date: 2026-02-04
+- Env: local
+- Commands:
+  - bash backend/scripts/pr29_accept.sh
+  - bash backend/scripts/ci_verify_mbti.sh
+- Results:
+  - pr29_accept: OK
+  - ci_verify_mbti: OK
+- Artifacts:
+  - backend/artifacts/pr29/summary.txt
+  - backend/artifacts/pr29/locked_before.txt
+  - backend/artifacts/pr29/locked_after_paid.txt
+  - backend/artifacts/pr29/locked_after_refund.txt
+  - backend/artifacts/verify_mbti/summary.txt
+
+Step Verification Commands
+
+1. Step 1 (routes): php -l backend/routes/api.php
+2. Step 2 (migrations): php -l backend/database/migrations/2026_02_04_090000_add_idempotency_refunds_to_orders_benefit_grants.php
+3. Step 3 (middleware): php -l backend/app/Http/Middleware/FmTokenAuth.php
+4. Step 4 (controllers/services/config/tests): php -l backend/app/Services/Commerce/PaymentWebhookProcessor.php
+5. Step 5 (scripts/CI): bash -n backend/scripts/ci_verify_mbti.sh
+
+Verify Log Pointers
+
+- pr29_accept stdout/stderr: backend/artifacts/pr29 (summary.txt + logs)
+- ci_verify_mbti stdout/stderr: backend/artifacts/verify_mbti (summary.txt + logs)


### PR DESCRIPTION
- What:
  - Add order idempotency, secure webhooks, implement refunds + entitlement
    revocation.
  - Fix ci_verify_mbti legacy alias cleanup and harden Laravel cache path.
  - Why:
  - Prevent duplicate orders under retries and concurrent clients.
  - Guarantee refund correctness and avoid unauthorized webhook abuse.
  - Keep workspace clean and make composer/artisan stable after runtime
    cleanups.
  - How:
  - Add idempotency_key pipeline (controller -> OrderManager) + unique index.
  - Add refund fields + revocation flow in EntitlementManager + webhook
    processor.
  - Enforce billing signature and disable stub in production (404 uniform).
  - ci_verify_mbti.sh uses trap to cleanup legacy alias symlink; .gitignore
    covers MBTI-CN-v*.
  - view compiled path has fallback; bootstrap creates runtime dirs early.
  - Add tests for idempotency/refund/signature/404 policy and compiled path
    contract.
  - Verify:
  - bash backend/scripts/pr29_accept.sh
  - bash backend/scripts/ci_verify_mbti.sh
  - Artifacts:
  - backend/artifacts/pr29/summary.txt

