### PR TITLE
 chore(pr30): production hardening ratelimit cache observability ci-no-jq

### DIFF
--- a/.github/workflows/ci_verify_mbti.yml
+++ b/.github/workflows/ci_verify_mbti.yml
@@ -111,7 +111,7 @@ jobs:
             curl -sS http://127.0.0.1:18000/api/v0.2/health >/dev/null && break
             sleep 1
           done
-          curl -sS http://127.0.0.1:18000/api/v0.2/content-packs | jq -e '.ok==true'
+          curl -sS http://127.0.0.1:18000/api/v0.2/content-packs | php -r '$j=json_decode(stream_get_contents(STDIN), true); exit(($j["ok"] ?? false) ? 0 : 1);'
 
       - name: Run ci_verify_mbti
         working-directory: backend

--- a/.github/workflows/publish-content.yml
+++ b/.github/workflows/publish-content.yml
@@ -59,8 +59,8 @@ jobs:
           RESP=$(curl -sS -X POST "$BASE_URL/api/v0.2/admin/content-releases/upload" \
             -H "X-Admin-Token: ${ADMIN_TOKEN}" \
             -F "file=@/tmp/content_pack.zip")
-          echo "$RESP" | jq .
-          VERSION_ID=$(echo "$RESP" | jq -r '.version_id')
+          echo "$RESP" | php -r '$j=json_decode(stream_get_contents(STDIN), true); echo json_encode($j, JSON_PRETTY_PRINT|JSON_UNESCAPED_SLASHES).PHP_EOL;'
+          VERSION_ID=$(echo "$RESP" | php -r '$j=json_decode(stream_get_contents(STDIN), true); echo $j["version_id"] ?? "";')
           if [ -z "$VERSION_ID" ] || [ "$VERSION_ID" = "null" ]; then
             echo "version_id missing"
             exit 1
@@ -82,19 +82,22 @@ jobs:
           else
             PROBE_VALUE=false
           fi
-          PAYLOAD=$(jq -n \
-            --arg version_id "$VERSION_ID" \
-            --arg region "${{ inputs.region }}" \
-            --arg locale "${{ inputs.locale }}" \
-            --arg dir_alias "${{ inputs.dir_alias }}" \
-            --argjson probe "$PROBE_VALUE" \
-            '{version_id:$version_id,region:$region,locale:$locale,dir_alias:$dir_alias,probe:$probe}')
+          PAYLOAD=$(VERSION_ID="$VERSION_ID" REGION="${{ inputs.region }}" LOCALE="${{ inputs.locale }}" DIR_ALIAS="${{ inputs.dir_alias }}" PROBE_VALUE="$PROBE_VALUE" php -r '
+$payload = [
+  "version_id" => getenv("VERSION_ID") ?: "",
+  "region" => getenv("REGION") ?: "",
+  "locale" => getenv("LOCALE") ?: "",
+  "dir_alias" => getenv("DIR_ALIAS") ?: "",
+  "probe" => (getenv("PROBE_VALUE") === "true"),
+];
+echo json_encode($payload, JSON_UNESCAPED_UNICODE);
+')
           RESP=$(curl -sS -X POST "$BASE_URL/api/v0.2/admin/content-releases/publish" \
             -H "Content-Type: application/json" \
             -H "X-Admin-Token: ${ADMIN_TOKEN}" \
             -d "$PAYLOAD")
-          echo "$RESP" | jq .
-          RELEASE_ID=$(echo "$RESP" | jq -r '.release_id')
+          echo "$RESP" | php -r '$j=json_decode(stream_get_contents(STDIN), true); echo json_encode($j, JSON_PRETTY_PRINT|JSON_UNESCAPED_SLASHES).PHP_EOL;'
+          RELEASE_ID=$(echo "$RESP" | php -r '$j=json_decode(stream_get_contents(STDIN), true); echo $j["release_id"] ?? "";')
           if [ -z "$RELEASE_ID" ] || [ "$RELEASE_ID" = "null" ]; then
             echo "release_id missing"
             exit 1

--- a/.github/workflows/rollback-content.yml
+++ b/.github/workflows/rollback-content.yml
@@ -69,13 +69,16 @@ jobs:
             *) echo "::error::probe must be true/false, got: $PROBE"; exit 1;;
           esac
 
-          PAYLOAD="$(jq -n \
-            --arg release_id "$RELEASE_ID" \
-            --arg region "$REGION" \
-            --arg locale "$LOCALE" \
-            --arg dir_alias "$DIR_ALIAS" \
-            --argjson probe "$PROBE" \
-            '{release_id:$release_id, region:$region, locale:$locale, dir_alias:$dir_alias, probe:$probe}'
+          PAYLOAD="$(RELEASE_ID="$RELEASE_ID" REGION="$REGION" LOCALE="$LOCALE" DIR_ALIAS="$DIR_ALIAS" PROBE="$PROBE" php -r '
+$payload = [
+  "release_id" => getenv("RELEASE_ID") ?: "",
+  "region" => getenv("REGION") ?: "",
+  "locale" => getenv("LOCALE") ?: "",
+  "dir_alias" => getenv("DIR_ALIAS") ?: "",
+  "probe" => (getenv("PROBE") === "true"),
+];
+echo json_encode($payload, JSON_UNESCAPED_UNICODE);
+'
           )"
 
           echo "Payload=$PAYLOAD"
@@ -86,12 +89,12 @@ jobs:
             -H "X-Admin-Token: ${ADMIN_TOKEN}" \
             -d "$PAYLOAD")"
 
-          echo "$RESP" | jq .
+          echo "$RESP" | php -r '$j=json_decode(stream_get_contents(STDIN), true); echo json_encode($j, JSON_PRETTY_PRINT|JSON_UNESCAPED_SLASHES).PHP_EOL;'
 
-          OK="$(echo "$RESP" | jq -r '.ok // empty')"
-          STATUS="$(echo "$RESP" | jq -r '.status // empty')"
-          MSG="$(echo "$RESP" | jq -r '.message // empty')"
-          ERR="$(echo "$RESP" | jq -r '.error // empty')"
+          OK="$(echo "$RESP" | php -r '$j=json_decode(stream_get_contents(STDIN), true); if (!is_array($j) || !array_key_exists("ok", $j)) { echo ""; exit; } echo $j["ok"] ? "true" : "false";')"
+          STATUS="$(echo "$RESP" | php -r '$j=json_decode(stream_get_contents(STDIN), true); echo $j["status"] ?? "";')"
+          MSG="$(echo "$RESP" | php -r '$j=json_decode(stream_get_contents(STDIN), true); echo $j["message"] ?? "";')"
+          ERR="$(echo "$RESP" | php -r '$j=json_decode(stream_get_contents(STDIN), true); echo $j["error"] ?? "";')"
 
           if [[ "$OK" != "true" ]]; then
             echo "::error::rollback api call failed ok=$OK error=$ERR message=$MSG"
@@ -103,9 +106,9 @@ jobs:
             exit 1
           fi
 
-          NEW_RELEASE_ID="$(echo "$RESP" | jq -r '.release_id')"
-          RB_VERSION_ID="$(echo "$RESP" | jq -r '.rolled_back_to.version_id')"
-          RB_PACK_ID="$(echo "$RESP" | jq -r '.rolled_back_to.pack_id')"
+          NEW_RELEASE_ID="$(echo "$RESP" | php -r '$j=json_decode(stream_get_contents(STDIN), true); echo $j["release_id"] ?? "";')"
+          RB_VERSION_ID="$(echo "$RESP" | php -r '$j=json_decode(stream_get_contents(STDIN), true); echo $j["rolled_back_to"]["version_id"] ?? "";')"
+          RB_PACK_ID="$(echo "$RESP" | php -r '$j=json_decode(stream_get_contents(STDIN), true); echo $j["rolled_back_to"]["pack_id"] ?? "";')"
 
           echo "rolled_back_release_id=$NEW_RELEASE_ID" >> "$GITHUB_OUTPUT"
           echo "rolled_back_version_id=$RB_VERSION_ID" >> "$GITHUB_OUTPUT"
@@ -115,6 +118,6 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          curl -fsS "https://fermatmind.com/api/v0.2/health" | jq -e '.ok==true' >/dev/null
-          curl -fsS "https://fermatmind.com/api/v0.2/scales/MBTI/questions?region=CN_MAINLAND&locale=zh-CN" | jq -e '.ok==true' >/dev/null
-          curl -fsS "https://fermatmind.com/api/v0.2/content-packs" | jq -e '.ok==true' >/dev/null
+          curl -fsS "https://fermatmind.com/api/v0.2/health" | php -r '$j=json_decode(stream_get_contents(STDIN), true); exit(($j["ok"] ?? false) ? 0 : 1);' >/dev/null
+          curl -fsS "https://fermatmind.com/api/v0.2/scales/MBTI/questions?region=CN_MAINLAND&locale=zh-CN" | php -r '$j=json_decode(stream_get_contents(STDIN), true); exit(($j["ok"] ?? false) ? 0 : 1);' >/dev/null
+          curl -fsS "https://fermatmind.com/api/v0.2/content-packs" | php -r '$j=json_decode(stream_get_contents(STDIN), true); exit(($j["ok"] ?? false) ? 0 : 1);' >/dev/null

--- a/.github/workflows/rollback-production.yml
+++ b/.github/workflows/rollback-production.yml
@@ -56,5 +56,5 @@ jobs:
         run: |
           set -euo pipefail
           sleep 2
-          curl -fsS "https://fermatmind.com/api/v0.2/health" | jq -e '.ok==true' > /dev/null
-          curl -fsS "https://fermatmind.com/api/v0.2/scales/MBTI/questions" | jq -e '.ok==true' > /dev/null
+          curl -fsS "https://fermatmind.com/api/v0.2/health" | php -r '$j=json_decode(stream_get_contents(STDIN), true); exit(($j["ok"] ?? false) ? 0 : 1);' > /dev/null
+          curl -fsS "https://fermatmind.com/api/v0.2/scales/MBTI/questions" | php -r '$j=json_decode(stream_get_contents(STDIN), true); exit(($j["ok"] ?? false) ? 0 : 1);' > /dev/null

--- a/backend/.gitignore
+++ b/backend/.gitignore
@@ -47,3 +47,6 @@ Thumbs.db
 !/artifacts/pr215/
 /artifacts/pr215/*
 !/artifacts/pr215/summary.txt
+!/artifacts/pr30/
+/artifacts/pr30/*
+!/artifacts/pr30/summary.txt

--- a/backend/app/Providers/AppServiceProvider.php
+++ b/backend/app/Providers/AppServiceProvider.php
@@ -7,7 +7,9 @@ use App\Services\Content\ContentPack;
 use App\Services\Content\ContentPacksIndex;
 use App\Services\Content\ContentStore;
 use App\Services\ContentPackResolver;
+use Illuminate\Cache\RateLimiting\Limit;
 use Illuminate\Http\Request;
+use Illuminate\Support\Facades\RateLimiter;
 use Illuminate\Support\ServiceProvider;
 
 class AppServiceProvider extends ServiceProvider
@@ -215,6 +217,65 @@ class AppServiceProvider extends ServiceProvider
      */
     public function boot(): void
     {
-        //
+        $response = function (string $code, string $message) {
+            return function (Request $request, array $headers) use ($code, $message) {
+                return response()->json([
+                    'error' => [
+                        'code' => $code,
+                        'message' => $message,
+                    ],
+                ], 429)->withHeaders($headers);
+            };
+        };
+
+        RateLimiter::for('api_public', function (Request $request) use ($response) {
+            $limit = (int) config('fap.rate_limits.api_public_per_minute', 120);
+            $limit = max(1, $limit);
+
+            return Limit::perMinute($limit)
+                ->by('ip:' . $request->ip())
+                ->response($response('RATE_LIMIT_PUBLIC', 'Too many requests. Please retry later.'));
+        });
+
+        RateLimiter::for('api_auth', function (Request $request) use ($response) {
+            $limit = (int) config('fap.rate_limits.api_auth_per_minute', 30);
+            $limit = max(1, $limit);
+
+            return Limit::perMinute($limit)
+                ->by('ip:' . $request->ip())
+                ->response($response('RATE_LIMIT_AUTH', 'Too many auth requests. Please retry later.'));
+        });
+
+        RateLimiter::for('api_attempt_submit', function (Request $request) use ($response) {
+            $limit = (int) config('fap.rate_limits.api_attempt_submit_per_minute', 20);
+            $limit = max(1, $limit);
+
+            $userId = (string) ($request->attributes->get('fm_user_id') ?? '');
+            if ($userId === '' && $request->user()) {
+                $userId = (string) $request->user()->getAuthIdentifier();
+            }
+
+            $key = $userId !== '' ? ('user:' . $userId) : ('ip:' . $request->ip());
+
+            return Limit::perMinute($limit)
+                ->by($key)
+                ->response($response('RATE_LIMIT_ATTEMPT_SUBMIT', 'Too many attempt submissions. Please retry later.'));
+        });
+
+        RateLimiter::for('api_webhook', function (Request $request) use ($response) {
+            $limit = (int) config('fap.rate_limits.api_webhook_per_minute', 60);
+            $limit = max(1, $limit);
+
+            $provider = (string) $request->route('provider', '');
+            if ($provider === '') {
+                $provider = (string) $request->route('provider_code', '');
+            }
+
+            $key = $provider !== '' ? ('provider:' . $provider) : ('ip:' . $request->ip());
+
+            return Limit::perMinute($limit)
+                ->by($key)
+                ->response($response('RATE_LIMIT_WEBHOOK', 'Too many webhook requests. Please retry later.'));
+        });
     }
 }

--- a/backend/artifacts/pr30/summary.txt
+++ b/backend/artifacts/pr30/summary.txt
@@ -1,0 +1,15 @@
+PR30 Acceptance Summary
+- verify: backend/scripts/pr30_verify.sh
+- serve_port: 1830
+- db: sqlite (/tmp/pr30_local_0.sqlite)
+- attempt_id: 47a3bddd-b68f-49fd-8f2e-2d69101fa4ac
+- rate_limit: backend/artifacts/pr30/rate_limit.txt
+Artifacts:
+- backend/artifacts/pr30/healthz.json
+- backend/artifacts/pr30/questions.json
+- backend/artifacts/pr30/attempt_start.json
+- backend/artifacts/pr30/submit.json
+- backend/artifacts/pr30/submit_resp.json
+- backend/artifacts/pr30/report.json
+- backend/artifacts/pr30/rate_limit.txt
+- backend/artifacts/pr30/summary.txt

--- a/backend/config/cache.php
+++ b/backend/config/cache.php
@@ -13,7 +13,20 @@ return [
     |
     */
 
-    'default' => env('CACHE_STORE', 'database'),
+    // Default: production -> redis, local/testing -> array
+    'default' => env('CACHE_STORE', env('APP_ENV', 'production') === 'production' ? 'redis' : 'array'),
+
+    /*
+    |--------------------------------------------------------------------------
+    | Rate Limiter Store
+    |--------------------------------------------------------------------------
+    |
+    | The rate limiter requires a persistent store. Use file locally and
+    | redis in production unless explicitly overridden.
+    |
+    */
+
+    'limiter' => env('CACHE_LIMITER', env('APP_ENV', 'production') === 'production' ? 'redis' : 'file'),
 
     /*
     |--------------------------------------------------------------------------
@@ -72,6 +85,7 @@ return [
 
         'redis' => [
             'driver' => 'redis',
+            // cache connection: REDIS_CACHE_CONNECTION=cache
             'connection' => env('REDIS_CACHE_CONNECTION', 'cache'),
             'lock_connection' => env('REDIS_CACHE_LOCK_CONNECTION', 'default'),
         ],

--- a/backend/config/fap.php
+++ b/backend/config/fap.php
@@ -25,6 +25,13 @@ return [
 
     're_tags_debug_n' => (int) env('RE_TAGS_DEBUG_N', 0),
 
+    'rate_limits' => [
+        'api_public_per_minute' => (int) env('FAP_RATE_LIMIT_PUBLIC_PER_MINUTE', 120),
+        'api_auth_per_minute' => (int) env('FAP_RATE_LIMIT_AUTH_PER_MINUTE', 30),
+        'api_attempt_submit_per_minute' => (int) env('FAP_RATE_LIMIT_ATTEMPT_SUBMIT_PER_MINUTE', 20),
+        'api_webhook_per_minute' => (int) env('FAP_RATE_LIMIT_WEBHOOK_PER_MINUTE', 60),
+    ],
+
     'selfcheck_known_assets' => [
         'manifest.json',
         'version.json',

--- a/backend/config/queue.php
+++ b/backend/config/queue.php
@@ -13,7 +13,8 @@ return [
     |
     */
 
-    'default' => env('QUEUE_CONNECTION', 'sync'),
+    // Default: production -> redis, local/testing -> sync
+    'default' => env('QUEUE_CONNECTION', env('APP_ENV', 'production') === 'production' ? 'redis' : 'sync'),
 
     // Dedicated queue name for AI insights jobs (when using database/redis queues)
     'insights_queue' => env('AI_INSIGHTS_QUEUE', 'insights'),
@@ -69,6 +70,7 @@ return [
 
         'redis' => [
             'driver' => 'redis',
+            // queue connection: REDIS_QUEUE_CONNECTION=default
             'connection' => env('REDIS_QUEUE_CONNECTION', 'default'),
             'queue' => env('REDIS_QUEUE', 'default'),
             'retry_after' => (int) env('REDIS_QUEUE_RETRY_AFTER', 90),

--- a/backend/scripts/pr30_accept.sh
+++ b/backend/scripts/pr30_accept.sh
@@ -1,0 +1,158 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+export CI=true
+export FAP_NONINTERACTIVE=1
+export COMPOSER_NO_INTERACTION=1
+export GIT_TERMINAL_PROMPT=0
+export NO_COLOR=1
+export PAGER=cat
+export GIT_PAGER=cat
+export TERM=dumb
+export XDEBUG_MODE=off
+
+export FAP_PACKS_ROOT="${FAP_PACKS_ROOT:-$(cd "$(dirname "$0")/../.." && pwd)/content_packages}"
+export FAP_DEFAULT_REGION="${FAP_DEFAULT_REGION:-CN_MAINLAND}"
+export FAP_DEFAULT_LOCALE="${FAP_DEFAULT_LOCALE:-zh-CN}"
+export FAP_DEFAULT_PACK_ID="${FAP_DEFAULT_PACK_ID:-MBTI.cn-mainland.zh-CN.v0.2.2}"
+export FAP_DEFAULT_DIR_VERSION="${FAP_DEFAULT_DIR_VERSION:-MBTI-CN-v0.2.2}"
+export FAP_CONTENT_PACKAGE_VERSION="${FAP_CONTENT_PACKAGE_VERSION:-MBTI-CN-v0.2.2}"
+
+export APP_ENV="${APP_ENV:-testing}"
+export CACHE_STORE="${CACHE_STORE:-array}"
+export QUEUE_CONNECTION="${QUEUE_CONNECTION:-sync}"
+export DB_CONNECTION="${DB_CONNECTION:-sqlite}"
+export DB_DATABASE="${DB_DATABASE:-/tmp/pr30_${GITHUB_RUN_ID:-local}_${GITHUB_RUN_ATTEMPT:-0}.sqlite}"
+
+export FAP_RATE_LIMIT_PUBLIC_PER_MINUTE="${FAP_RATE_LIMIT_PUBLIC_PER_MINUTE:-12}"
+export FAP_RATE_LIMIT_AUTH_PER_MINUTE="${FAP_RATE_LIMIT_AUTH_PER_MINUTE:-6}"
+export FAP_RATE_LIMIT_ATTEMPT_SUBMIT_PER_MINUTE="${FAP_RATE_LIMIT_ATTEMPT_SUBMIT_PER_MINUTE:-6}"
+export FAP_RATE_LIMIT_WEBHOOK_PER_MINUTE="${FAP_RATE_LIMIT_WEBHOOK_PER_MINUTE:-30}"
+
+SERVE_PORT="${SERVE_PORT:-1830}"
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT_DIR="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+BACKEND_DIR="${ROOT_DIR}/backend"
+ART_DIR="${BACKEND_DIR}/artifacts/pr30"
+LOG_DIR="${ART_DIR}/logs"
+
+mkdir -p "${ART_DIR}" "${LOG_DIR}"
+
+cleanup_port() {
+  local port="$1"
+  local pids
+  pids="$(lsof -ti tcp:"${port}" 2>/dev/null || true)"
+  if [[ -n "${pids}" ]]; then
+    kill -9 ${pids} || true
+  fi
+}
+
+wait_health() {
+  local url="$1"
+  for _ in $(seq 1 80); do
+    if curl -fsS "${url}" >/dev/null 2>&1; then
+      return 0
+    fi
+    sleep 0.25
+  done
+  return 1
+}
+
+log() {
+  echo "[$(date +'%Y-%m-%d %H:%M:%S')] $*"
+}
+
+log "Cleaning ports ${SERVE_PORT} and 18000"
+cleanup_port "${SERVE_PORT}"
+cleanup_port 18000
+
+PORT_IN_USE=0
+if lsof -nP -iTCP:"${SERVE_PORT}" -sTCP:LISTEN >/dev/null 2>&1; then
+  PORT_IN_USE=1
+  log "Port ${SERVE_PORT} already in use; reusing existing server"
+fi
+
+if [[ "${PORT_IN_USE}" -eq 0 ]]; then
+  rm -f "${DB_DATABASE}"
+fi
+
+log "Prepare Laravel cache dirs"
+bash "${BACKEND_DIR}/scripts/ci/prepare_laravel_cache_dirs.sh"
+
+if [[ "${PORT_IN_USE}" -eq 0 ]]; then
+  log "Composer install"
+  (cd "${BACKEND_DIR}" && composer install --no-interaction --no-progress)
+fi
+
+if [[ "${PORT_IN_USE}" -eq 0 ]]; then
+  log "Migrate"
+  (cd "${BACKEND_DIR}" && php artisan migrate --force)
+fi
+
+if [[ "${PORT_IN_USE}" -eq 0 ]]; then
+  log "Seed scales"
+  (cd "${BACKEND_DIR}" && php artisan fap:scales:seed-default && php artisan fap:scales:sync-slugs)
+fi
+
+if [[ "${PORT_IN_USE}" -eq 0 ]]; then
+  log "Start server"
+  php "${BACKEND_DIR}/artisan" serve --host=127.0.0.1 --port="${SERVE_PORT}" > "${ART_DIR}/server.log" 2>&1 &
+  SERVER_PID=$!
+  echo "${SERVER_PID}" > "${ART_DIR}/server.pid"
+fi
+
+if ! wait_health "http://127.0.0.1:${SERVE_PORT}/api/healthz"; then
+  log "Server healthz failed"
+  tail -n 120 "${ART_DIR}/server.log" || true
+  exit 1
+fi
+
+log "Run pr30 verify"
+(cd "${ROOT_DIR}" && SERVE_PORT="${SERVE_PORT}" ART_DIR="${ART_DIR}" bash "${BACKEND_DIR}/scripts/pr30_verify.sh")
+
+ATTEMPT_ID=""
+if [[ -f "${ART_DIR}/attempt_id.txt" ]]; then
+  ATTEMPT_ID="$(cat "${ART_DIR}/attempt_id.txt" | tr -d '\r' || true)"
+fi
+
+log "Write summary"
+cat <<TXT > "${ART_DIR}/summary.txt"
+PR30 Acceptance Summary
+- verify: backend/scripts/pr30_verify.sh
+- serve_port: ${SERVE_PORT}
+- db: sqlite (${DB_DATABASE})
+- attempt_id: ${ATTEMPT_ID}
+- rate_limit: ${ART_DIR}/rate_limit.txt
+Artifacts:
+- backend/artifacts/pr30/healthz.json
+- backend/artifacts/pr30/questions.json
+- backend/artifacts/pr30/attempt_start.json
+- backend/artifacts/pr30/submit.json
+- backend/artifacts/pr30/submit_resp.json
+- backend/artifacts/pr30/report.json
+- backend/artifacts/pr30/rate_limit.txt
+- backend/artifacts/pr30/summary.txt
+TXT
+
+log "Sanitize artifacts"
+(cd "${ROOT_DIR}" && bash "${BACKEND_DIR}/scripts/sanitize_artifacts.sh" 30)
+
+log "Cleanup"
+if [[ "${PORT_IN_USE}" -eq 0 ]]; then
+  if [[ -f "${ART_DIR}/server.pid" ]]; then
+    PID="$(cat "${ART_DIR}/server.pid" || true)"
+    if [[ -n "${PID}" ]] && ps -p "${PID}" >/dev/null 2>&1; then
+      kill "${PID}" >/dev/null 2>&1 || true
+    fi
+  fi
+
+  cleanup_port "${SERVE_PORT}"
+  cleanup_port 18000
+  rm -f "${DB_DATABASE}"
+
+  if lsof -nP -iTCP:"${SERVE_PORT}" -sTCP:LISTEN >/dev/null 2>&1; then
+    log "Port ${SERVE_PORT} still in use"
+    exit 1
+  fi
+fi

--- a/backend/scripts/pr30_verify.sh
+++ b/backend/scripts/pr30_verify.sh
@@ -1,0 +1,162 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+export CI=true
+export FAP_NONINTERACTIVE=1
+export COMPOSER_NO_INTERACTION=1
+export GIT_TERMINAL_PROMPT=0
+export NO_COLOR=1
+export PAGER=cat
+export GIT_PAGER=cat
+export TERM=dumb
+export XDEBUG_MODE=off
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_DIR="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+BACKEND_DIR="${REPO_DIR}/backend"
+
+SERVE_PORT="${SERVE_PORT:-1830}"
+API_BASE="http://127.0.0.1:${SERVE_PORT}"
+
+ART_DIR="${ART_DIR:-${BACKEND_DIR}/artifacts/pr30}"
+LOG_DIR="${ART_DIR}/logs"
+VERIFY_LOG="${ART_DIR}/verify.log"
+mkdir -p "${ART_DIR}" "${LOG_DIR}"
+
+exec > >(tee "${VERIFY_LOG}") 2>&1
+
+fail() {
+  echo "[pr30][fail] $*" >&2
+  exit 1
+}
+
+echo "[pr30] api_base=${API_BASE}"
+
+# 1) healthz
+curl -sS "${API_BASE}/api/healthz" > "${ART_DIR}/healthz.json"
+php -r '
+$j=json_decode(file_get_contents("'"${ART_DIR}/healthz.json"'"), true);
+if (!is_array($j) || !($j["ok"] ?? false)) {
+  fwrite(STDERR, "healthz ok=false\n");
+  exit(2);
+}
+' || fail "healthz failed"
+
+# 2) v0.3 questions
+curl -sS -H "Accept: application/json" -H "X-Region: CN_MAINLAND" -H "Accept-Language: zh-CN" \
+  "${API_BASE}/api/v0.3/scales/MBTI/questions" > "${ART_DIR}/questions.json"
+
+# 3) start attempt
+curl -sS -X POST \
+  -H "Accept: application/json" -H "Content-Type: application/json" \
+  -H "X-Region: CN_MAINLAND" -H "Accept-Language: zh-CN" \
+  --data '{"scale_code":"MBTI","anon_id":"pr30-cli"}' \
+  "${API_BASE}/api/v0.3/attempts/start" > "${ART_DIR}/attempt_start.json"
+
+ATTEMPT_ID="$(php -r '$d=json_decode(file_get_contents("'"${ART_DIR}/attempt_start.json"'"), true); echo $d["attempt_id"] ?? "";')"
+if [[ -z "${ATTEMPT_ID}" ]]; then
+  fail "attempt start failed"
+fi
+echo "${ATTEMPT_ID}" > "${ART_DIR}/attempt_id.txt"
+
+# 4) build answers dynamically
+php -r '
+$q=json_decode(file_get_contents("'"${ART_DIR}/questions.json"'"), true);
+$items=$q["questions"]["items"] ?? $q["items"] ?? ($q["questions"] ?? []);
+$answers=[];
+foreach ($items as $item) {
+  if (!is_array($item)) { continue; }
+  $qid=$item["question_id"] ?? "";
+  if ($qid === "") { continue; }
+  $opts=$item["options"] ?? [];
+  $code="";
+  if (is_array($opts) && isset($opts[0]) && is_array($opts[0])) {
+    $code=(string) ($opts[0]["code"] ?? $opts[0]["option_code"] ?? "");
+  }
+  if ($code === "") { $code="A"; }
+  $answers[]=["question_id"=>$qid,"code"=>$code];
+}
+file_put_contents("'"${ART_DIR}/answers.json"'", json_encode($answers, JSON_UNESCAPED_UNICODE));
+' || fail "build answers failed"
+
+if [[ ! -s "${ART_DIR}/answers.json" ]]; then
+  fail "answers.json empty"
+fi
+
+# 5) submit attempt
+php -r '
+$answers=json_decode(file_get_contents("'"${ART_DIR}/answers.json"'"), true);
+if (!is_array($answers)) { $answers=[]; }
+$payload=[
+  "attempt_id"=>"'"${ATTEMPT_ID}"'",
+  "duration_ms"=>120000,
+  "answers"=>$answers,
+];
+file_put_contents("'"${ART_DIR}/submit.json"'", json_encode($payload, JSON_UNESCAPED_UNICODE));
+'
+
+curl -sS -X POST \
+  -H "Accept: application/json" -H "Content-Type: application/json" \
+  -H "X-Region: CN_MAINLAND" -H "Accept-Language: zh-CN" \
+  --data-binary @"${ART_DIR}/submit.json" \
+  "${API_BASE}/api/v0.3/attempts/submit" > "${ART_DIR}/submit_resp.json"
+
+php -r '
+$d=json_decode(file_get_contents("'"${ART_DIR}/submit_resp.json"'"), true);
+if (!is_array($d) || !($d["ok"] ?? false)) {
+  fwrite(STDERR, "submit ok=false\n");
+  exit(2);
+}
+' || fail "attempt submit failed"
+
+# 6) report
+curl -sS -H "Accept: application/json" \
+  "${API_BASE}/api/v0.3/attempts/${ATTEMPT_ID}/report" > "${ART_DIR}/report.json"
+
+php -r '
+$d=json_decode(file_get_contents("'"${ART_DIR}/report.json"'"), true);
+if (!is_array($d) || !($d["ok"] ?? false)) {
+  fwrite(STDERR, "report ok=false\n");
+  exit(2);
+}
+' || fail "report failed"
+
+# 7) rate limit probe (public GET)
+RATE_HEADERS="${ART_DIR}/rate_limit_headers.txt"
+HTTP_CODE="$(curl -sS -D "${RATE_HEADERS}" -o /dev/null -w "%{http_code}" "${API_BASE}/api/v0.2/health")"
+if [[ "${HTTP_CODE}" != "200" ]]; then
+  fail "rate limit probe initial request failed http=${HTTP_CODE}"
+fi
+
+LIMIT="$(grep -i '^X-RateLimit-Limit:' "${RATE_HEADERS}" | tail -n 1 | awk '{print $2}' | tr -d '\r')"
+REMAINING="$(grep -i '^X-RateLimit-Remaining:' "${RATE_HEADERS}" | tail -n 1 | awk '{print $2}' | tr -d '\r')"
+
+if [[ -z "${LIMIT}" || -z "${REMAINING}" ]]; then
+  fail "rate limit headers missing"
+fi
+
+echo "rate_limit_limit=${LIMIT}" > "${ART_DIR}/rate_limit.txt"
+echo "rate_limit_remaining=${REMAINING}" >> "${ART_DIR}/rate_limit.txt"
+
+ATTEMPTS=$((REMAINING + 1))
+HIT=0
+for i in $(seq 1 "${ATTEMPTS}"); do
+  HDR="${ART_DIR}/rate_limit_attempt_${i}.headers"
+  CODE="$(curl -sS -D "${HDR}" -o /dev/null -w "%{http_code}" "${API_BASE}/api/v0.2/health")"
+  if [[ "${CODE}" == "429" ]]; then
+    HIT=1
+    RETRY_AFTER="$(grep -i '^Retry-After:' "${HDR}" | tail -n 1 | awk '{print $2}' | tr -d '\r')"
+    if [[ -z "${RETRY_AFTER}" ]]; then
+      fail "Retry-After header missing"
+    fi
+    echo "rate_limit_hit_after=${i}" >> "${ART_DIR}/rate_limit.txt"
+    echo "rate_limit_retry_after=${RETRY_AFTER}" >> "${ART_DIR}/rate_limit.txt"
+    break
+  fi
+done
+
+if [[ "${HIT}" -ne 1 ]]; then
+  fail "rate limit not triggered"
+fi
+
+echo "[pr30] verify ok"

--- a/backend/tests/Feature/HealthzRateLimitTest.php
+++ b/backend/tests/Feature/HealthzRateLimitTest.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace Tests\Feature;
+
+use Tests\TestCase;
+
+class HealthzRateLimitTest extends TestCase
+{
+    public function test_healthz_reports_cache_queue_and_request_id(): void
+    {
+        $response = $this->getJson('/api/healthz');
+
+        $response->assertStatus(200);
+        $response->assertJsonPath('ok', true);
+        $response->assertJsonPath('deps.cache_store.ok', true);
+        $response->assertJsonPath('deps.queue.ok', true);
+        $response->assertJsonPath('deps.queue.driver', 'sync');
+        $this->assertTrue($response->headers->has('X-Request-Id'));
+    }
+
+    public function test_public_rate_limit_returns_retry_after(): void
+    {
+        config(['fap.rate_limits.api_public_per_minute' => 2]);
+
+        $this->getJson('/api/v0.2/health')->assertStatus(200);
+        $this->getJson('/api/v0.2/health')->assertStatus(200);
+
+        $response = $this->getJson('/api/v0.2/health');
+
+        $response->assertStatus(429);
+        $response->assertJsonStructure([
+            'error' => ['code', 'message'],
+        ]);
+        $response->assertJsonPath('error.code', 'RATE_LIMIT_PUBLIC');
+        $this->assertTrue($response->headers->has('Retry-After'));
+        $this->assertTrue($response->headers->has('X-Request-Id'));
+    }
+}

--- a/docs/verify/pr30_recon.md
+++ b/docs/verify/pr30_recon.md
@@ -1,0 +1,22 @@
+# PR30 Recon
+
+- Keywords: throttle|redis|sentry
+- 限流/缓存/可观测性/CI 相关入口文件：
+  - backend/routes/api.php
+  - backend/app/Providers/AppServiceProvider.php
+  - backend/app/Http/Controllers/HealthzController.php
+  - backend/config/cache.php
+  - backend/config/queue.php
+  - backend/config/fap.php
+  - .github/workflows/ci_verify_mbti.yml
+  - .github/workflows/publish-content.yml
+  - .github/workflows/rollback-content.yml
+  - .github/workflows/rollback-production.yml
+  - backend/scripts/pr30_accept.sh
+  - backend/scripts/pr30_verify.sh
+- 风险点与规避（429 语义/跨 org 404/redis 可切换/脚本去 jq/rg/脱敏）：
+  - 429 语义：RateLimiter 统一 JSON 错误体并保留 Retry-After header。
+  - 跨 org 404：ResolveOrgContext/FmTokenAuth 逻辑不变，仅新增 throttle middleware。
+  - redis 可切换：cache/queue 默认按 APP_ENV 选 array/sync，本地不依赖 redis；healthz 在 redis 未启用时跳过 ping。
+  - 脚本去 jq/rg：workflow 改用 php -r 解析 JSON；pr30 scripts 使用 grep/sed/awk。
+  - artifacts 脱敏：accept 脚本调用 sanitize_artifacts.sh。

--- a/docs/verify/pr30_verify.md
+++ b/docs/verify/pr30_verify.md
@@ -1,0 +1,28 @@
+# PR30 Verify
+
+- Date: 2026-02-04
+- Env: local
+- Commands:
+  - bash backend/scripts/pr30_accept.sh
+  - bash backend/scripts/ci_verify_mbti.sh
+- Results:
+  - pr30_accept: OK
+  - ci_verify_mbti: OK
+- Artifacts:
+  - backend/artifacts/pr30/summary.txt
+  - backend/artifacts/pr30/rate_limit.txt
+  - backend/artifacts/pr30/verify.log
+  - backend/artifacts/verify_mbti/summary.txt
+
+Step Verification Commands
+
+1. Step 1 (routes): php -l backend/routes/api.php
+2. Step 2 (migrations): php -l backend/database/migrations/*.php
+3. Step 3 (middleware): php -l backend/app/Http/Middleware/FmTokenAuth.php
+4. Step 4 (controllers/services/config/tests): php -l backend/app/Http/Controllers/HealthzController.php
+5. Step 5 (scripts/CI): bash -n backend/scripts/pr30_verify.sh
+
+Verify Log Pointers
+
+- pr30_accept stdout/stderr: backend/artifacts/pr30 (summary.txt + logs)
+- ci_verify_mbti stdout/stderr: backend/artifacts/verify_mbti (summary.txt + logs)


### PR DESCRIPTION
 - What:
      - Add named throttles, improve healthz (cache store + queue checks), and
        remove jq from workflows.
  - Why:
      - Production stability under abuse traffic and deterministic CI execution.
      - Ensure rate limiting works with a persistent limiter store while keeping
        local cache defaults.
  - How:
      - Define RateLimiter policies and attach throttle:* middleware to route
        groups.
      - Extend healthz to cover cache store read/write and queue config.
      - Replace jq with php -r JSON parsing in workflows.
      - Add PR30 acceptance scripts and feature tests for 429 + healthz.
  - Verify:
      - bash backend/scripts/pr30_accept.sh
      - bash backend/scripts/ci_verify_mbti.sh
  - Artifacts:
      - backend/artifacts/pr30/summary.txt
