### PR TITLE
 chore(pr32): Universal scoring engine (spec-driven) + driver registry

### DIFF
--- a/backend/.gitignore
+++ b/backend/.gitignore
@@ -50,3 +50,6 @@ Thumbs.db
 !/artifacts/pr30/
 /artifacts/pr30/*
 !/artifacts/pr30/summary.txt
+!/artifacts/pr32/
+/artifacts/pr32/*
+!/artifacts/pr32/summary.txt

--- a/backend/app/Models/ScaleRegistry.php
+++ b/backend/app/Models/ScaleRegistry.php
@@ -21,6 +21,7 @@ class ScaleRegistry extends Model
         'primary_slug',
         'slugs_json',
         'driver_type',
+        'assessment_driver',
         'default_pack_id',
         'default_region',
         'default_locale',

--- a/backend/app/Services/Assessment/Drivers/GenericScoringDriver.php
+++ b/backend/app/Services/Assessment/Drivers/GenericScoringDriver.php
@@ -1,0 +1,509 @@
+<?php
+
+namespace App\Services\Assessment\Drivers;
+
+use App\Services\Assessment\ScoreResult;
+use RuntimeException;
+
+class GenericScoringDriver implements DriverInterface
+{
+    public function score(array $answers, array $spec, array $ctx): ScoreResult
+    {
+        $questionsDoc = $ctx['questions'] ?? null;
+        if (!is_array($questionsDoc)) {
+            throw new RuntimeException('questions missing');
+        }
+
+        $items = $questionsDoc['items'] ?? ($questionsDoc['questions']['items'] ?? null);
+        if (!is_array($items) || empty($items)) {
+            throw new RuntimeException('questions.items missing');
+        }
+
+        $dimensionsSpec = $spec['dimensions'] ?? null;
+        if (!is_array($dimensionsSpec) || empty($dimensionsSpec)) {
+            throw new RuntimeException('scoring_spec.dimensions missing');
+        }
+
+        $dimensions = $this->normalizeDimensions($dimensionsSpec);
+        if (empty($dimensions)) {
+            throw new RuntimeException('scoring_spec.dimensions invalid');
+        }
+
+        $fallbackScoreMap = $this->normalizeScoreMap($spec['score_map'] ?? ($spec['scoreMap'] ?? null));
+        $questionIndex = $this->buildQuestionIndex($items, $dimensions, $fallbackScoreMap);
+        if (empty($questionIndex)) {
+            throw new RuntimeException('questions index empty');
+        }
+
+        $dichotomyDims = [];
+        $traitDims = [];
+        foreach ($dimensions as $code => $conf) {
+            $p1 = (string) ($conf['p1'] ?? '');
+            $p2 = (string) ($conf['p2'] ?? '');
+            if ($p1 !== '' && $p2 !== '') {
+                $dichotomyDims[$code] = $conf;
+            } else {
+                $traitDims[$code] = $conf;
+            }
+        }
+
+        $sumTowardP1 = [];
+        $minSum = [];
+        $maxSum = [];
+        $countTotal = [];
+        $countP1 = [];
+        $countP2 = [];
+        $countNeutral = [];
+
+        $traitSum = [];
+        $traitCount = [];
+        $skipped = [];
+        $answerCount = 0;
+
+        foreach ($answers as $answer) {
+            if (!is_array($answer)) {
+                continue;
+            }
+
+            $qid = trim((string) ($answer['question_id'] ?? ''));
+            $code = strtoupper((string) ($answer['code'] ?? ($answer['option_code'] ?? '')));
+            if ($qid === '' || $code === '') {
+                continue;
+            }
+
+            $meta = $questionIndex[$qid] ?? null;
+            if (!is_array($meta)) {
+                $skipped[] = ['question_id' => $qid, 'reason' => 'unknown_question'];
+                continue;
+            }
+
+            $dim = (string) ($meta['dimension'] ?? '');
+            if ($dim === '' || !isset($dimensions[$dim])) {
+                $skipped[] = ['question_id' => $qid, 'reason' => 'unknown_dimension', 'dimension' => $dim];
+                continue;
+            }
+
+            $scoreMap = $meta['scores'] ?? [];
+            if (!is_array($scoreMap)) {
+                $scoreMap = [];
+            }
+
+            $score = $scoreMap[$code] ?? null;
+            if (!is_numeric($score)) {
+                $skipped[] = ['question_id' => $qid, 'reason' => 'unknown_option', 'dimension' => $dim];
+                continue;
+            }
+
+            $score = (float) $score;
+            $direction = (int) ($meta['direction'] ?? 1);
+            $direction = $direction === 0 ? 1 : $direction;
+
+            if (isset($dichotomyDims[$dim])) {
+                $p2 = (string) ($dichotomyDims[$dim]['p2'] ?? '');
+                $keyPole = (string) ($meta['key_pole'] ?? '');
+                $signed = $score * $direction;
+                $towardP1 = ($keyPole !== '' && $p2 !== '' && $keyPole === $p2) ? -$signed : $signed;
+
+                $range = $meta['toward_range'] ?? null;
+                if (!is_array($range)) {
+                    $range = $this->computeTowardRange($scoreMap, $direction, $keyPole, $p2);
+                }
+
+                $sumTowardP1[$dim] = ($sumTowardP1[$dim] ?? 0.0) + $towardP1;
+                $minSum[$dim] = ($minSum[$dim] ?? 0.0) + (float) ($range['min'] ?? 0.0);
+                $maxSum[$dim] = ($maxSum[$dim] ?? 0.0) + (float) ($range['max'] ?? 0.0);
+                $countTotal[$dim] = ($countTotal[$dim] ?? 0) + 1;
+
+                if ($towardP1 > 0) {
+                    $countP1[$dim] = ($countP1[$dim] ?? 0) + 1;
+                } elseif ($towardP1 < 0) {
+                    $countP2[$dim] = ($countP2[$dim] ?? 0) + 1;
+                } else {
+                    $countNeutral[$dim] = ($countNeutral[$dim] ?? 0) + 1;
+                }
+            } else {
+                $minScore = $meta['min_score'] ?? null;
+                $maxScore = $meta['max_score'] ?? null;
+                if (!is_numeric($minScore) || !is_numeric($maxScore) || (float) $maxScore === (float) $minScore) {
+                    $skipped[] = ['question_id' => $qid, 'reason' => 'invalid_score_range', 'dimension' => $dim];
+                    continue;
+                }
+
+                $minScore = (float) $minScore;
+                $maxScore = (float) $maxScore;
+                $adjusted = $direction < 0 ? ($maxScore + $minScore - $score) : $score;
+                $normalized = ($adjusted - $minScore) / ($maxScore - $minScore) * 100;
+                $normalized = max(0.0, min(100.0, $normalized));
+
+                $traitSum[$dim] = ($traitSum[$dim] ?? 0.0) + $normalized;
+                $traitCount[$dim] = ($traitCount[$dim] ?? 0) + 1;
+                $countTotal[$dim] = ($countTotal[$dim] ?? 0) + 1;
+            }
+
+            $answerCount += 1;
+        }
+
+        $pciLevels = $this->resolvePciLevels($spec);
+        $tieDefaults = $this->resolveTieDefaults($spec);
+
+        $scoresPct = [];
+        $axisStates = [];
+        $scoresJson = [];
+        $winningPoles = [];
+        $pciAxes = [];
+
+        foreach ($dichotomyDims as $dim => $conf) {
+            if (!isset($countTotal[$dim]) || $countTotal[$dim] <= 0) {
+                continue;
+            }
+
+            $range = ($maxSum[$dim] ?? 0.0) - ($minSum[$dim] ?? 0.0);
+            if ($range <= 0) {
+                $pct = 50.0;
+            } else {
+                $pct = (($sumTowardP1[$dim] ?? 0.0) - ($minSum[$dim] ?? 0.0)) / $range * 100;
+            }
+            $pct = max(0.0, min(100.0, $pct));
+            $pct = (float) round($pct);
+
+            $scoresPct[$dim] = (int) $pct;
+
+            $p1 = (string) ($conf['p1'] ?? '');
+            $p2 = (string) ($conf['p2'] ?? '');
+            $tie = $tieDefaults[$dim] ?? $p1;
+            $winning = $pct > 50 ? $p1 : ($pct < 50 ? $p2 : $tie);
+            $winningPoles[$dim] = $winning;
+
+            $displayPct = $pct >= 50 ? $pct : (100 - $pct);
+            $axisStates[$dim] = match (true) {
+                $displayPct >= 80 => 'very_strong',
+                $displayPct >= 70 => 'strong',
+                $displayPct >= 60 => 'clear',
+                $displayPct >= 55 => 'weak',
+                default => 'very_weak',
+            };
+
+            $clarity = abs($pct - 50) * 2;
+            $pciAxes[$dim] = [
+                'percent_first_pole' => (int) $pct,
+                'winning_pole' => $winning,
+                'clarity' => (int) round($clarity),
+                'level' => $this->pciLevel($clarity, $pciLevels),
+            ];
+
+            $scoresJson[$dim] = [
+                'a' => $countP1[$dim] ?? 0,
+                'b' => $countP2[$dim] ?? 0,
+                'neutral' => $countNeutral[$dim] ?? 0,
+                'sum' => (float) ($sumTowardP1[$dim] ?? 0.0),
+                'total' => (float) ($countTotal[$dim] ?? 0),
+                'count' => (int) ($countTotal[$dim] ?? 0),
+            ];
+        }
+
+        $traitScores = [];
+        foreach ($traitDims as $dim => $conf) {
+            if (!isset($traitCount[$dim]) || $traitCount[$dim] <= 0) {
+                continue;
+            }
+
+            $pct = ($traitSum[$dim] ?? 0.0) / $traitCount[$dim];
+            $pct = max(0.0, min(100.0, $pct));
+            $pct = (float) round($pct);
+
+            $scoresPct[$dim] = (int) $pct;
+            $traitScores[$dim] = [
+                'percent' => (int) $pct,
+                'count' => (int) $traitCount[$dim],
+            ];
+        }
+
+        $pciOverall = null;
+        if (!empty($pciAxes)) {
+            $sum = 0.0;
+            $n = 0;
+            foreach ($pciAxes as $row) {
+                if (isset($row['clarity']) && is_numeric($row['clarity'])) {
+                    $sum += (float) $row['clarity'];
+                    $n += 1;
+                }
+            }
+            if ($n > 0) {
+                $avg = $sum / $n;
+                $pciOverall = [
+                    'clarity' => (int) round($avg),
+                    'level' => $this->pciLevel($avg, $pciLevels),
+                ];
+            }
+        }
+
+        $typeCode = $this->resolveTypeCode($spec, $winningPoles);
+
+        $breakdown = [
+            'score_method' => 'generic_scoring',
+            'answer_count' => $answerCount,
+            'dimensions' => $scoresPct,
+            'skipped' => $skipped,
+            'time_bonus' => 0,
+        ];
+
+        $axisScores = [
+            'scores_pct' => $scoresPct,
+            'axis_states' => $axisStates,
+            'scores_json' => $scoresJson,
+            'winning_poles' => $winningPoles,
+            'pci' => [
+                'overall' => $pciOverall,
+                'axes' => $pciAxes,
+            ],
+            'trait_scores' => $traitScores,
+        ];
+
+        return new ScoreResult(
+            (float) $answerCount,
+            (float) $answerCount,
+            $breakdown,
+            $typeCode,
+            $axisScores,
+            null
+        );
+    }
+
+    private function normalizeDimensions(array $dimensionsSpec): array
+    {
+        $out = [];
+        foreach ($dimensionsSpec as $key => $value) {
+            $conf = is_array($value) ? $value : [];
+            $code = is_int($key) ? (string) ($conf['code'] ?? '') : (string) $key;
+            $code = strtoupper(trim($code));
+            if ($code === '') {
+                continue;
+            }
+
+            $p1 = strtoupper((string) ($conf['p1'] ?? ($conf['pole1'] ?? '')));
+            $p2 = strtoupper((string) ($conf['p2'] ?? ($conf['pole2'] ?? '')));
+            if ($p1 === '' || $p2 === '') {
+                $poles = $conf['poles'] ?? null;
+                if (is_array($poles)) {
+                    if ($p1 === '') {
+                        $p1 = strtoupper((string) ($poles[0] ?? ''));
+                    }
+                    if ($p2 === '') {
+                        $p2 = strtoupper((string) ($poles[1] ?? ''));
+                    }
+                }
+            }
+
+            $out[$code] = [
+                'p1' => $p1,
+                'p2' => $p2,
+            ] + $conf;
+        }
+
+        return $out;
+    }
+
+    private function normalizeScoreMap(mixed $scoreMap): array
+    {
+        if (!is_array($scoreMap)) {
+            return [];
+        }
+
+        $out = [];
+        foreach ($scoreMap as $code => $score) {
+            $key = strtoupper((string) $code);
+            if ($key === '' || !is_numeric($score)) {
+                continue;
+            }
+            $out[$key] = (float) $score;
+        }
+
+        return $out;
+    }
+
+    private function buildQuestionIndex(array $items, array $dimensions, array $fallbackScoreMap): array
+    {
+        $index = [];
+        foreach ($items as $item) {
+            if (!is_array($item)) {
+                continue;
+            }
+
+            $qid = trim((string) ($item['question_id'] ?? ''));
+            $dim = strtoupper(trim((string) ($item['dimension'] ?? '')));
+            if ($qid === '' || $dim === '') {
+                continue;
+            }
+
+            $scores = $this->extractOptionScores($item['options'] ?? null, $fallbackScoreMap);
+            if (empty($scores)) {
+                continue;
+            }
+
+            $direction = (int) ($item['direction'] ?? 1);
+            $direction = $direction === 0 ? 1 : $direction;
+            $keyPole = strtoupper(trim((string) ($item['key_pole'] ?? '')));
+
+            $minScore = null;
+            $maxScore = null;
+            foreach ($scores as $val) {
+                if (!is_numeric($val)) {
+                    continue;
+                }
+                $minScore = $minScore === null ? (float) $val : min($minScore, (float) $val);
+                $maxScore = $maxScore === null ? (float) $val : max($maxScore, (float) $val);
+            }
+
+            $towardRange = null;
+            $conf = $dimensions[$dim] ?? null;
+            if (is_array($conf)) {
+                $p2 = (string) ($conf['p2'] ?? '');
+                $p1 = (string) ($conf['p1'] ?? '');
+                if ($p1 !== '' && $p2 !== '') {
+                    $towardRange = $this->computeTowardRange($scores, $direction, $keyPole, $p2);
+                }
+            }
+
+            $index[$qid] = [
+                'dimension' => $dim,
+                'scores' => $scores,
+                'direction' => $direction,
+                'key_pole' => $keyPole,
+                'min_score' => $minScore,
+                'max_score' => $maxScore,
+                'toward_range' => $towardRange,
+            ];
+        }
+
+        return $index;
+    }
+
+    private function extractOptionScores(mixed $options, array $fallbackScoreMap): array
+    {
+        $scores = [];
+        if (is_array($options)) {
+            foreach ($options as $opt) {
+                if (!is_array($opt)) {
+                    continue;
+                }
+                $code = strtoupper((string) ($opt['code'] ?? ($opt['option_code'] ?? '')));
+                if ($code === '' || !is_numeric($opt['score'] ?? null)) {
+                    continue;
+                }
+                $scores[$code] = (float) ($opt['score'] ?? 0);
+            }
+        }
+
+        if (empty($scores)) {
+            $scores = $fallbackScoreMap;
+        }
+
+        return $scores;
+    }
+
+    private function computeTowardRange(array $scores, int $direction, string $keyPole, string $p2): array
+    {
+        $direction = $direction === 0 ? 1 : $direction;
+        $min = null;
+        $max = null;
+        foreach ($scores as $val) {
+            if (!is_numeric($val)) {
+                continue;
+            }
+            $signed = (float) $val * $direction;
+            $toward = ($keyPole !== '' && $p2 !== '' && $keyPole === $p2) ? -$signed : $signed;
+            $min = $min === null ? $toward : min($min, $toward);
+            $max = $max === null ? $toward : max($max, $toward);
+        }
+
+        if ($min === null || $max === null) {
+            return ['min' => 0.0, 'max' => 0.0];
+        }
+
+        return ['min' => $min, 'max' => $max];
+    }
+
+    private function resolveTypeCode(array $spec, array $winningPoles): ?string
+    {
+        $rules = $spec['type_rules'] ?? null;
+        if (!is_array($rules)) {
+            return null;
+        }
+
+        $baseAxes = $rules['base_axes'] ?? null;
+        if (!is_array($baseAxes) || empty($baseAxes)) {
+            return null;
+        }
+
+        $letters = [];
+        foreach ($baseAxes as $axis) {
+            $axisCode = strtoupper((string) $axis);
+            $pole = $winningPoles[$axisCode] ?? null;
+            if (!is_string($pole) || $pole === '') {
+                return null;
+            }
+            $letters[] = $pole;
+        }
+
+        $typeCode = implode('', $letters);
+        $suffixAxis = strtoupper((string) ($rules['suffix_axis'] ?? ''));
+        if ($suffixAxis !== '') {
+            $suffixPole = $winningPoles[$suffixAxis] ?? null;
+            if (is_string($suffixPole) && $suffixPole !== '') {
+                $delimiter = (string) ($rules['delimiter'] ?? '');
+                $typeCode .= $delimiter . $suffixPole;
+            }
+        }
+
+        return $typeCode !== '' ? $typeCode : null;
+    }
+
+    private function resolvePciLevels(array $spec): array
+    {
+        $levels = $spec['pci_levels'] ?? ($spec['pci']['levels'] ?? null);
+        if (!is_array($levels) || empty($levels)) {
+            return [
+                ['code' => 'slight', 'min' => 0, 'max' => 14],
+                ['code' => 'moderate', 'min' => 15, 'max' => 30],
+                ['code' => 'clear', 'min' => 31, 'max' => 50],
+                ['code' => 'very_clear', 'min' => 51, 'max' => 100],
+            ];
+        }
+        return $levels;
+    }
+
+    private function pciLevel(float $clarity, array $levels): string
+    {
+        foreach ($levels as $level) {
+            if (!is_array($level)) {
+                continue;
+            }
+            $min = isset($level['min']) ? (float) $level['min'] : 0.0;
+            $max = isset($level['max']) ? (float) $level['max'] : 100.0;
+            if ($clarity >= $min && $clarity <= $max) {
+                $code = (string) ($level['code'] ?? '');
+                return $code !== '' ? $code : 'unknown';
+            }
+        }
+        return 'unknown';
+    }
+
+    private function resolveTieDefaults(array $spec): array
+    {
+        $defaults = $spec['tie_break']['defaults'] ?? null;
+        if (!is_array($defaults)) {
+            return [];
+        }
+
+        $out = [];
+        foreach ($defaults as $dim => $pole) {
+            $key = strtoupper((string) $dim);
+            $val = strtoupper((string) $pole);
+            if ($key !== '' && $val !== '') {
+                $out[$key] = $val;
+            }
+        }
+
+        return $out;
+    }
+}

--- a/backend/artifacts/pr32/summary.txt
+++ b/backend/artifacts/pr32/summary.txt
@@ -1,0 +1,5 @@
+PR32 Acceptance Summary (placeholder)
+- verify: backend/scripts/pr32_verify.sh
+- status: NOT RUN (composer install failed: no network to api.github.com)
+- schema_changes:
+  - scales_registry: add assessment_driver (string, nullable)

--- a/backend/config/fap.php
+++ b/backend/config/fap.php
@@ -11,6 +11,21 @@ return [
     // Profile / scoring
     'profile_version' => env('FAP_PROFILE_VERSION', 'mbti32-v2.5'),
 
+    // Assessment driver registry (scales_registry.assessment_driver)
+    'assessment_drivers' => [
+        'mbti' => App\Services\Assessment\Drivers\MbtiDriver::class,
+        'simple_score' => App\Services\Assessment\Drivers\SimpleScoreDriver::class,
+        'simple_score_demo' => App\Services\Assessment\Drivers\SimpleScoreDriver::class,
+        'demo_answers' => App\Services\Assessment\Drivers\SimpleScoreDriver::class,
+        'generic_likert' => App\Services\Assessment\Drivers\GenericLikertDriver::class,
+        'likert' => App\Services\Assessment\Drivers\GenericLikertDriver::class,
+        'iq_test' => App\Services\Assessment\Drivers\IqTestDriver::class,
+        'iq_raven' => App\Services\Assessment\Drivers\IqTestDriver::class,
+        'iq' => App\Services\Assessment\Drivers\IqTestDriver::class,
+        'generic_scoring' => App\Services\Assessment\Drivers\GenericScoringDriver::class,
+        'big5' => App\Services\Assessment\Drivers\GenericScoringDriver::class,
+    ],
+
     // Persist raw answers (audit)
     'store_answers_to_storage' => (bool) env('FAP_STORE_ANSWERS_TO_STORAGE', false),
 

--- a/backend/database/migrations/2026_02_05_090000_add_assessment_driver_to_scales_registry_table.php
+++ b/backend/database/migrations/2026_02_05_090000_add_assessment_driver_to_scales_registry_table.php
@@ -1,0 +1,34 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        if (!Schema::hasTable('scales_registry')) {
+            return;
+        }
+
+        Schema::table('scales_registry', function (Blueprint $table) {
+            if (!Schema::hasColumn('scales_registry', 'assessment_driver')) {
+                $table->string('assessment_driver', 32)->nullable();
+            }
+        });
+    }
+
+    public function down(): void
+    {
+        if (!Schema::hasTable('scales_registry')) {
+            return;
+        }
+
+        if (Schema::hasColumn('scales_registry', 'assessment_driver')) {
+            Schema::table('scales_registry', function (Blueprint $table) {
+                $table->dropColumn('assessment_driver');
+            });
+        }
+    }
+};

--- a/backend/database/seeders/CiScalesRegistrySeeder.php
+++ b/backend/database/seeders/CiScalesRegistrySeeder.php
@@ -35,6 +35,7 @@ final class CiScalesRegistrySeeder extends Seeder
                 'primary_slug' => 'mbti',
                 'slugs_json' => json_encode(['mbti'], JSON_UNESCAPED_UNICODE),
                 'driver_type' => 'mbti',
+                'assessment_driver' => 'generic_scoring',
                 'default_pack_id' => $defaultPackId,
                 'default_region' => $defaultRegion,
                 'default_locale' => $defaultLocale,
@@ -50,6 +51,7 @@ final class CiScalesRegistrySeeder extends Seeder
                 'primary_slug' => 'demo_answers',
                 'slugs_json' => json_encode(['demo_answers'], JSON_UNESCAPED_UNICODE),
                 'driver_type' => 'demo_answers',
+                'assessment_driver' => 'demo_answers',
                 'default_pack_id' => $demoPackId,
                 'default_region' => $defaultRegion,
                 'default_locale' => $defaultLocale,
@@ -65,6 +67,7 @@ final class CiScalesRegistrySeeder extends Seeder
                 'primary_slug' => 'simple_score_demo',
                 'slugs_json' => json_encode(['simple_score_demo'], JSON_UNESCAPED_UNICODE),
                 'driver_type' => 'simple_score_demo',
+                'assessment_driver' => 'simple_score_demo',
                 'default_pack_id' => $demoPackId,
                 'default_region' => $defaultRegion,
                 'default_locale' => $defaultLocale,
@@ -80,12 +83,29 @@ final class CiScalesRegistrySeeder extends Seeder
                 'primary_slug' => 'iq_raven',
                 'slugs_json' => json_encode(['iq_raven'], JSON_UNESCAPED_UNICODE),
                 'driver_type' => 'iq_raven',
+                'assessment_driver' => 'iq_raven',
                 'default_pack_id' => $demoPackId,
                 'default_region' => $defaultRegion,
                 'default_locale' => $defaultLocale,
                 'default_dir_version' => 'IQ-RAVEN-CN-v0.3.0-DEMO',
                 'is_public' => 1,
                 'is_active' => 1,
+                'created_at' => $now,
+                'updated_at' => $now,
+            ],
+            [
+                'org_id' => 0,
+                'code' => 'BIG5',
+                'primary_slug' => 'big5',
+                'slugs_json' => json_encode(['big5'], JSON_UNESCAPED_UNICODE),
+                'driver_type' => 'big5',
+                'assessment_driver' => 'generic_scoring',
+                'default_pack_id' => 'BIG5.cn-mainland.zh-CN.v0.1.0-TEST',
+                'default_region' => $defaultRegion,
+                'default_locale' => $defaultLocale,
+                'default_dir_version' => 'BIG5-CN-v0.1.0-TEST',
+                'is_public' => 1,
+                'is_active' => 0,
                 'created_at' => $now,
                 'updated_at' => $now,
             ],
@@ -98,6 +118,7 @@ final class CiScalesRegistrySeeder extends Seeder
                 'primary_slug',
                 'slugs_json',
                 'driver_type',
+                'assessment_driver',
                 'default_pack_id',
                 'default_region',
                 'default_locale',
@@ -108,6 +129,6 @@ final class CiScalesRegistrySeeder extends Seeder
             ]
         );
 
-        $this->command?->info('CiScalesRegistrySeeder: upserted 4 scales.');
+        $this->command?->info('CiScalesRegistrySeeder: upserted 5 scales.');
     }
 }

--- a/backend/database/seeders/ScaleRegistrySeeder.php
+++ b/backend/database/seeders/ScaleRegistrySeeder.php
@@ -35,6 +35,7 @@ final class ScaleRegistrySeeder extends Seeder
                 'mbti-personality-test',
             ],
             'driver_type' => 'mbti',
+            'assessment_driver' => 'generic_scoring',
 
             // ✅ follow config
             'default_pack_id' => $defaultPackId,
@@ -77,5 +78,49 @@ final class ScaleRegistrySeeder extends Seeder
 
         $writer->syncSlugsForScale($scale);
         $this->command?->info('ScaleRegistrySeeder: MBTI scale upserted.');
+
+        $big5PackId = 'BIG5.cn-mainland.zh-CN.v0.1.0-TEST';
+        $big5DirVersion = 'BIG5-CN-v0.1.0-TEST';
+
+        $big5 = $writer->upsertScale([
+            'code' => 'BIG5',
+            'org_id' => 0,
+            'primary_slug' => 'big5',
+            'slugs_json' => [
+                'big5',
+                'big5-personality-test',
+            ],
+            'driver_type' => 'big5',
+            'assessment_driver' => 'generic_scoring',
+
+            'default_pack_id' => $big5PackId,
+            'default_region' => $defaultRegion,
+            'default_locale' => $defaultLocale,
+            'default_dir_version' => $big5DirVersion,
+
+            'capabilities_json' => [
+                'assets' => false,
+            ],
+            'view_policy_json' => [
+                'free_sections' => ['intro', 'score'],
+                'blur_others' => false,
+                'teaser_percent' => 0.0,
+            ],
+            'commercial_json' => [
+                'price_tier' => 'FREE',
+            ],
+            'seo_schema_json' => [
+                '@context' => 'https://schema.org',
+                '@type' => 'Quiz',
+                'name' => 'BIG5 Personality Test',
+                'description' => 'BIG5 personality test (demo).',
+            ],
+
+            'is_public' => true,
+            'is_active' => false,
+        ]);
+
+        $writer->syncSlugsForScale($big5);
+        $this->command?->info('ScaleRegistrySeeder: BIG5 scale upserted.');
     }
 }

--- a/backend/scripts/pr32_accept.sh
+++ b/backend/scripts/pr32_accept.sh
@@ -1,0 +1,121 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+export CI=true
+export FAP_NONINTERACTIVE=1
+export COMPOSER_NO_INTERACTION=1
+export GIT_TERMINAL_PROMPT=0
+export NO_COLOR=1
+export PAGER=cat
+export GIT_PAGER=cat
+export TERM=dumb
+export XDEBUG_MODE=off
+export COMPOSER_CACHE_DIR="${COMPOSER_CACHE_DIR:-/tmp/composer-cache}"
+
+export APP_ENV="${APP_ENV:-testing}"
+export CACHE_STORE="${CACHE_STORE:-array}"
+export QUEUE_CONNECTION="${QUEUE_CONNECTION:-sync}"
+
+export FAP_PACKS_DRIVER="${FAP_PACKS_DRIVER:-local}"
+export FAP_PACKS_ROOT="${FAP_PACKS_ROOT:-$(cd "$(dirname "$0")/../.." && pwd)/content_packages}"
+export FAP_DEFAULT_REGION="${FAP_DEFAULT_REGION:-CN_MAINLAND}"
+export FAP_DEFAULT_LOCALE="${FAP_DEFAULT_LOCALE:-zh-CN}"
+export FAP_DEFAULT_PACK_ID="${FAP_DEFAULT_PACK_ID:-MBTI.cn-mainland.zh-CN.v0.2.2}"
+export FAP_DEFAULT_DIR_VERSION="${FAP_DEFAULT_DIR_VERSION:-MBTI-CN-v0.2.2}"
+
+export DB_CONNECTION=sqlite
+export DB_DATABASE=/tmp/pr32.sqlite
+
+SERVE_PORT="${SERVE_PORT:-1832}"
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT_DIR="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+BACKEND_DIR="${ROOT_DIR}/backend"
+ART_DIR="${BACKEND_DIR}/artifacts/pr32"
+LOG_DIR="${ART_DIR}/logs"
+
+mkdir -p "${ART_DIR}" "${LOG_DIR}"
+mkdir -p "${COMPOSER_CACHE_DIR}" || true
+
+cleanup_port() {
+  local port="$1"
+  lsof -nP -iTCP:"${port}" -sTCP:LISTEN || true
+  local pids
+  pids="$(lsof -ti tcp:"${port}" 2>/dev/null || true)"
+  if [[ -n "${pids}" ]]; then
+    echo "${pids}" | xargs kill -9 || true
+  fi
+  lsof -nP -iTCP:"${port}" -sTCP:LISTEN || true
+}
+
+log() {
+  echo "[$(date +'%Y-%m-%d %H:%M:%S')] $*"
+}
+
+log "Cleaning ports ${SERVE_PORT} and 18000"
+cleanup_port "${SERVE_PORT}"
+cleanup_port 18000
+
+log "Composer install"
+(cd "${BACKEND_DIR}" && composer install --no-interaction --no-progress)
+
+log "Migrate fresh"
+(cd "${BACKEND_DIR}" && php artisan migrate:fresh --force)
+
+log "Seed database"
+(cd "${BACKEND_DIR}" && php artisan db:seed --force)
+(cd "${BACKEND_DIR}" && php artisan db:seed --class="Database\\Seeders\\ScaleRegistrySeeder" --force)
+
+log "Run pr32 verify"
+(cd "${ROOT_DIR}" && SERVE_PORT="${SERVE_PORT}" ART_DIR="${ART_DIR}" bash "${BACKEND_DIR}/scripts/pr32_verify.sh")
+
+MBTI_ATTEMPT_ID=""
+BIG5_ATTEMPT_ID=""
+if [[ -f "${ART_DIR}/mbti_attempt_id.txt" ]]; then
+  MBTI_ATTEMPT_ID="$(cat "${ART_DIR}/mbti_attempt_id.txt" | tr -d '\r' || true)"
+fi
+if [[ -f "${ART_DIR}/big5_attempt_id.txt" ]]; then
+  BIG5_ATTEMPT_ID="$(cat "${ART_DIR}/big5_attempt_id.txt" | tr -d '\r' || true)"
+fi
+
+log "Write summary"
+cat <<TXT > "${ART_DIR}/summary.txt"
+PR32 Acceptance Summary
+- verify: backend/scripts/pr32_verify.sh
+- serve_port: ${SERVE_PORT}
+- smoke_urls:
+  - /api/v0.3/scales/MBTI/questions
+  - /api/v0.3/scales/BIG5/questions
+- mbti_attempt_id: ${MBTI_ATTEMPT_ID}
+- big5_attempt_id: ${BIG5_ATTEMPT_ID}
+- schema_changes:
+  - scales_registry: add assessment_driver (string, nullable)
+Artifacts:
+- backend/artifacts/pr32/pack_consistency.txt
+- backend/artifacts/pr32/mbti_questions.json
+- backend/artifacts/pr32/mbti_attempt_start.json
+- backend/artifacts/pr32/mbti_submit_resp.json
+- backend/artifacts/pr32/big5_questions.json
+- backend/artifacts/pr32/big5_attempt_start.json
+- backend/artifacts/pr32/big5_submit_resp.json
+- backend/artifacts/pr32/summary.txt
+TXT
+
+log "Sanitize artifacts"
+(cd "${ROOT_DIR}" && bash "${BACKEND_DIR}/scripts/sanitize_artifacts.sh" 32)
+
+log "Cleanup"
+if [[ -f "${ART_DIR}/server.pid" ]]; then
+  PID="$(cat "${ART_DIR}/server.pid" || true)"
+  if [[ -n "${PID}" ]] && ps -p "${PID}" >/dev/null 2>&1; then
+    kill "${PID}" >/dev/null 2>&1 || true
+  fi
+fi
+
+cleanup_port "${SERVE_PORT}"
+cleanup_port 18000
+rm -f "${DB_DATABASE}"
+
+log "Shellcheck"
+bash -n "${BACKEND_DIR}/scripts/pr32_accept.sh"
+bash -n "${BACKEND_DIR}/scripts/pr32_verify.sh"

--- a/backend/scripts/pr32_verify.sh
+++ b/backend/scripts/pr32_verify.sh
@@ -1,0 +1,199 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+export CI=true
+export FAP_NONINTERACTIVE=1
+export COMPOSER_NO_INTERACTION=1
+export GIT_TERMINAL_PROMPT=0
+export NO_COLOR=1
+export PAGER=cat
+export GIT_PAGER=cat
+export TERM=dumb
+export XDEBUG_MODE=off
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_DIR="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+BACKEND_DIR="${REPO_DIR}/backend"
+
+SERVE_PORT="${SERVE_PORT:-1832}"
+API_BASE="http://127.0.0.1:${SERVE_PORT}"
+
+ART_DIR="${ART_DIR:-${BACKEND_DIR}/artifacts/pr32}"
+LOG_DIR="${ART_DIR}/logs"
+VERIFY_LOG="${ART_DIR}/verify.log"
+mkdir -p "${ART_DIR}" "${LOG_DIR}"
+
+exec > >(tee "${VERIFY_LOG}") 2>&1
+
+fail() {
+  echo "[pr32][fail] $*" >&2
+  exit 1
+}
+
+cleanup_port() {
+  local port="$1"
+  local pids
+  pids="$(lsof -ti tcp:"${port}" 2>/dev/null || true)"
+  if [[ -n "${pids}" ]]; then
+    echo "${pids}" | xargs kill -9 || true
+  fi
+}
+
+wait_health() {
+  local url="$1"
+  local tries="${2:-80}"
+  for _ in $(seq 1 "${tries}"); do
+    if curl -fsS "${url}" >/dev/null 2>&1; then
+      return 0
+    fi
+    sleep 0.25
+  done
+  return 1
+}
+
+echo "[pr32] api_base=${API_BASE}"
+
+cleanup_port "${SERVE_PORT}"
+cleanup_port 18000
+
+php "${BACKEND_DIR}/artisan" serve --host=127.0.0.1 --port="${SERVE_PORT}" > "${ART_DIR}/server.log" 2>&1 &
+SERVER_PID=$!
+echo "${SERVER_PID}" > "${ART_DIR}/server.pid"
+
+if ! wait_health "${API_BASE}/api/healthz"; then
+  echo "[pr32] healthz failed"
+  curl -sS "${API_BASE}/api/healthz" || true
+  tail -n 120 "${ART_DIR}/server.log" || true
+  fail "healthz failed"
+fi
+
+php -r '
+require "'"${BACKEND_DIR}"'/vendor/autoload.php";
+$app = require "'"${BACKEND_DIR}"'/bootstrap/app.php";
+$kernel = $app->make(Illuminate\Contracts\Console\Kernel::class);
+$kernel->bootstrap();
+$packId = (string) config("content_packs.default_pack_id", "");
+$dirVersion = (string) config("content_packs.default_dir_version", "");
+echo "config.default_pack_id={$packId}\n";
+echo "config.default_dir_version={$dirVersion}\n";
+$path = getenv("DB_DATABASE") ?: "/tmp/pr32.sqlite";
+$pdo = new PDO("sqlite:" . $path);
+$row = $pdo->query("select default_pack_id, default_dir_version from scales_registry where code=\"MBTI\" and org_id=0 limit 1")->fetch(PDO::FETCH_ASSOC);
+if (!$row) {
+  fwrite(STDERR, "MBTI row missing\n");
+  exit(2);
+}
+$ok = $row["default_pack_id"] === $packId && $row["default_dir_version"] === $dirVersion;
+if (!$ok) {
+  fwrite(STDERR, "pack config mismatch\n");
+  exit(3);
+}
+echo "db.default_pack_id=" . $row["default_pack_id"] . "\n";
+echo "db.default_dir_version=" . $row["default_dir_version"] . "\n";
+$packDir = "'"${REPO_DIR}"'/content_packages/default/CN_MAINLAND/zh-CN/" . $dirVersion;
+$files = ["manifest.json", "questions.json", "scoring_spec.json"];
+foreach ($files as $file) {
+  $full = $packDir . "/" . $file;
+  if (!is_file($full)) {
+    fwrite(STDERR, "missing file: {$full}\n");
+    exit(4);
+  }
+  $raw = file_get_contents($full);
+  $json = json_decode($raw, true);
+  if (!is_array($json)) {
+    fwrite(STDERR, "invalid json: {$full}\n");
+    exit(5);
+  }
+}
+file_put_contents("'"${ART_DIR}"'/pack_consistency.txt", implode("\n", [
+  "config.default_pack_id={$packId}",
+  "config.default_dir_version={$dirVersion}",
+  "db.default_pack_id=" . $row["default_pack_id"],
+  "db.default_dir_version=" . $row["default_dir_version"],
+  "pack_dir={$packDir}",
+]) . "\n");
+' || fail "pack/seed/config consistency failed"
+
+smoke_scale() {
+  local scale="$1"
+  local prefix="$2"
+
+  curl -sS -H "Accept: application/json" -H "X-Region: CN_MAINLAND" -H "Accept-Language: zh-CN" \
+    "${API_BASE}/api/v0.3/scales/${scale}/questions" > "${ART_DIR}/${prefix}_questions.json"
+
+  curl -sS -X POST \
+    -H "Accept: application/json" -H "Content-Type: application/json" \
+    -H "X-Region: CN_MAINLAND" -H "Accept-Language: zh-CN" \
+    --data "{\"scale_code\":\"${scale}\",\"anon_id\":\"pr32-${prefix}\"}" \
+    "${API_BASE}/api/v0.3/attempts/start" > "${ART_DIR}/${prefix}_attempt_start.json"
+
+  local attempt_id
+  attempt_id="$(php -r '$d=json_decode(file_get_contents("'"${ART_DIR}"'/'"${prefix}"'_attempt_start.json"), true); echo $d["attempt_id"] ?? "";')"
+  if [[ -z "${attempt_id}" ]]; then
+    fail "${scale} attempt start failed"
+  fi
+  echo "${attempt_id}" > "${ART_DIR}/${prefix}_attempt_id.txt"
+
+  php -r '
+$q=json_decode(file_get_contents("'"${ART_DIR}"'/'"${prefix}"'_questions.json"), true);
+$items=$q["questions"]["items"] ?? $q["items"] ?? ($q["questions"] ?? []);
+$answers=[];
+foreach ($items as $item) {
+  if (!is_array($item)) { continue; }
+  $qid=$item["question_id"] ?? "";
+  if ($qid === "") { continue; }
+  $opts=$item["options"] ?? [];
+  $code="";
+  if (is_array($opts) && isset($opts[0]) && is_array($opts[0])) {
+    $code=(string) ($opts[0]["code"] ?? $opts[0]["option_code"] ?? "");
+  }
+  if ($code === "") { $code="A"; }
+  $answers[]=["question_id"=>$qid,"code"=>$code];
+}
+file_put_contents("'"${ART_DIR}"'/'"${prefix}"'_answers.json", json_encode($answers, JSON_UNESCAPED_UNICODE));
+' || fail "${scale} build answers failed"
+
+  php -r '
+$answers=json_decode(file_get_contents("'"${ART_DIR}"'/'"${prefix}"'_answers.json"), true);
+if (!is_array($answers)) { $answers=[]; }
+$payload=[
+  "attempt_id"=>"'"${attempt_id}"'",
+  "duration_ms"=>120000,
+  "answers"=>$answers,
+];
+file_put_contents("'"${ART_DIR}"'/'"${prefix}"'_submit.json", json_encode($payload, JSON_UNESCAPED_UNICODE));
+'
+
+  curl -sS -X POST \
+    -H "Accept: application/json" -H "Content-Type: application/json" \
+    -H "X-Region: CN_MAINLAND" -H "Accept-Language: zh-CN" \
+    --data-binary "@${ART_DIR}/${prefix}_submit.json" \
+    "${API_BASE}/api/v0.3/attempts/submit" > "${ART_DIR}/${prefix}_submit_resp.json"
+
+  php -r '
+$d=json_decode(file_get_contents("'"${ART_DIR}"'/'"${prefix}"'_submit_resp.json"), true);
+if (!is_array($d) || !($d["ok"] ?? false)) {
+  fwrite(STDERR, "submit ok=false\n");
+  exit(2);
+}
+' || fail "${scale} submit failed"
+}
+
+smoke_scale "MBTI" "mbti"
+smoke_scale "BIG5" "big5"
+
+if [[ -f "${ART_DIR}/server.pid" ]]; then
+  PID="$(cat "${ART_DIR}/server.pid" || true)"
+  if [[ -n "${PID}" ]] && ps -p "${PID}" >/dev/null 2>&1; then
+    kill "${PID}" >/dev/null 2>&1 || true
+  fi
+fi
+
+cleanup_port "${SERVE_PORT}"
+cleanup_port 18000
+
+if lsof -nP -iTCP:"${SERVE_PORT}" -sTCP:LISTEN >/dev/null 2>&1; then
+  fail "port ${SERVE_PORT} still in use"
+fi
+
+echo "[pr32] verify ok"

--- a/backend/tests/Unit/Assessment/GenericScoringDriverTest.php
+++ b/backend/tests/Unit/Assessment/GenericScoringDriverTest.php
@@ -1,0 +1,116 @@
+<?php
+
+namespace Tests\Unit\Assessment;
+
+use App\Services\Assessment\Drivers\GenericScoringDriver;
+use Tests\TestCase;
+
+class GenericScoringDriverTest extends TestCase
+{
+    public function test_scores_mbti_dichotomy_with_type_rules(): void
+    {
+        $driver = new GenericScoringDriver();
+
+        $spec = [
+            'dimensions' => [
+                'EI' => ['p1' => 'E', 'p2' => 'I'],
+                'SN' => ['p1' => 'S', 'p2' => 'N'],
+                'TF' => ['p1' => 'T', 'p2' => 'F'],
+                'JP' => ['p1' => 'J', 'p2' => 'P'],
+                'AT' => ['p1' => 'A', 'p2' => 'T'],
+            ],
+            'type_rules' => [
+                'base_axes' => ['EI', 'SN', 'TF', 'JP'],
+                'suffix_axis' => 'AT',
+                'delimiter' => '-',
+            ],
+            'pci_levels' => [
+                ['code' => 'slight', 'min' => 0, 'max' => 14],
+                ['code' => 'moderate', 'min' => 15, 'max' => 30],
+                ['code' => 'clear', 'min' => 31, 'max' => 50],
+                ['code' => 'very_clear', 'min' => 51, 'max' => 100],
+            ],
+        ];
+
+        $questions = [
+            'items' => [
+                $this->mbtiQuestion('Q1', 'EI', 'E'),
+                $this->mbtiQuestion('Q2', 'SN', 'S'),
+                $this->mbtiQuestion('Q3', 'TF', 'T'),
+                $this->mbtiQuestion('Q4', 'JP', 'J'),
+                $this->mbtiQuestion('Q5', 'AT', 'A'),
+            ],
+        ];
+
+        $answers = [
+            ['question_id' => 'Q1', 'code' => 'A'],
+            ['question_id' => 'Q2', 'code' => 'A'],
+            ['question_id' => 'Q3', 'code' => 'A'],
+            ['question_id' => 'Q4', 'code' => 'A'],
+            ['question_id' => 'Q5', 'code' => 'E'],
+        ];
+
+        $result = $driver->score($answers, $spec, ['questions' => $questions]);
+        $axisScores = $result->axisScoresJson ?? [];
+
+        $this->assertSame('ESTJ-T', $result->typeCode);
+        $this->assertSame(100, $axisScores['scores_pct']['EI'] ?? null);
+        $this->assertSame(0, $axisScores['scores_pct']['AT'] ?? null);
+        $this->assertSame('T', $axisScores['winning_poles']['AT'] ?? null);
+    }
+
+    public function test_scores_trait_dimensions(): void
+    {
+        $driver = new GenericScoringDriver();
+
+        $spec = [
+            'dimensions' => [
+                'O' => ['label' => 'Openness'],
+            ],
+        ];
+
+        $questions = [
+            'items' => [
+                [
+                    'question_id' => 'O1',
+                    'dimension' => 'O',
+                    'direction' => 1,
+                    'options' => [
+                        ['code' => '1', 'score' => 1],
+                        ['code' => '2', 'score' => 2],
+                        ['code' => '3', 'score' => 3],
+                        ['code' => '4', 'score' => 4],
+                        ['code' => '5', 'score' => 5],
+                    ],
+                ],
+            ],
+        ];
+
+        $answers = [
+            ['question_id' => 'O1', 'code' => '5'],
+        ];
+
+        $result = $driver->score($answers, $spec, ['questions' => $questions]);
+        $axisScores = $result->axisScoresJson ?? [];
+
+        $this->assertSame(100, $axisScores['scores_pct']['O'] ?? null);
+        $this->assertSame(100, $axisScores['trait_scores']['O']['percent'] ?? null);
+    }
+
+    private function mbtiQuestion(string $qid, string $dimension, string $keyPole): array
+    {
+        return [
+            'question_id' => $qid,
+            'dimension' => $dimension,
+            'key_pole' => $keyPole,
+            'direction' => 1,
+            'options' => [
+                ['code' => 'A', 'score' => 2],
+                ['code' => 'B', 'score' => 1],
+                ['code' => 'C', 'score' => 0],
+                ['code' => 'D', 'score' => -1],
+                ['code' => 'E', 'score' => -2],
+            ],
+        ];
+    }
+}

--- a/content_packages/MBTI.cn-mainland.zh-CN.v0.2.1-TEST/scoring_spec.json
+++ b/content_packages/MBTI.cn-mainland.zh-CN.v0.2.1-TEST/scoring_spec.json
@@ -2,12 +2,48 @@
   "version": "2026.01",
   "scale_code": "MBTI",
   "dimensions": {
-    "EI": {"poles": ["E", "I"], "score_range": [0, 100]},
-    "SN": {"poles": ["S", "N"], "score_range": [0, 100]},
-    "TF": {"poles": ["T", "F"], "score_range": [0, 100]},
-    "JP": {"poles": ["J", "P"], "score_range": [0, 100]},
-    "AT": {"poles": ["A", "T"], "score_range": [0, 100]}
+    "EI": {
+      "p1": "E",
+      "p2": "I",
+      "poles": ["E", "I"],
+      "score_range": [0, 100]
+    },
+    "SN": {
+      "p1": "S",
+      "p2": "N",
+      "poles": ["S", "N"],
+      "score_range": [0, 100]
+    },
+    "TF": {
+      "p1": "T",
+      "p2": "F",
+      "poles": ["T", "F"],
+      "score_range": [0, 100]
+    },
+    "JP": {
+      "p1": "J",
+      "p2": "P",
+      "poles": ["J", "P"],
+      "score_range": [0, 100]
+    },
+    "AT": {
+      "p1": "A",
+      "p2": "T",
+      "poles": ["A", "T"],
+      "score_range": [0, 100]
+    }
   },
+  "type_rules": {
+    "base_axes": ["EI", "SN", "TF", "JP"],
+    "suffix_axis": "AT",
+    "delimiter": "-"
+  },
+  "pci_levels": [
+    {"code": "slight", "min": 0, "max": 14},
+    {"code": "moderate", "min": 15, "max": 30},
+    {"code": "clear", "min": 31, "max": 50},
+    {"code": "very_clear", "min": 51, "max": 100}
+  ],
   "score_map": {"A": 2, "B": 1, "C": 0, "D": -1, "E": -2},
   "reverse_pairs": [
     {"a": "MBTI-001", "b": "MBTI-002"},

--- a/content_packages/default/CN_MAINLAND/zh-CN/BIG5-CN-v0.1.0-TEST/manifest.json
+++ b/content_packages/default/CN_MAINLAND/zh-CN/BIG5-CN-v0.1.0-TEST/manifest.json
@@ -1,0 +1,27 @@
+{
+  "schema_version": "pack-manifest@v1",
+  "pack_type": "content_pack",
+  "scale_code": "BIG5",
+  "region": "CN_MAINLAND",
+  "locale": "zh-CN",
+  "content_package_version": "v0.1.0-TEST",
+  "pack_id": "BIG5.cn-mainland.zh-CN.v0.1.0-TEST",
+  "fallback": [],
+  "capabilities": {
+    "questions": true,
+    "assets": false,
+    "share_templates": false
+  },
+  "schemas": {
+    "questions": "fap.questions.v1",
+    "rules": "fap.report.rules.v1"
+  },
+  "assets": {
+    "questions": [
+      "questions.json"
+    ],
+    "rules": [
+      "scoring_spec.json"
+    ]
+  }
+}

--- a/content_packages/default/CN_MAINLAND/zh-CN/BIG5-CN-v0.1.0-TEST/questions.json
+++ b/content_packages/default/CN_MAINLAND/zh-CN/BIG5-CN-v0.1.0-TEST/questions.json
@@ -1,0 +1,75 @@
+{
+  "schema": "fap.questions.v1",
+  "items": [
+    {
+      "question_id": "BIG5-001",
+      "order": 1,
+      "dimension": "O",
+      "text": "我喜欢尝试新事物。",
+      "direction": 1,
+      "options": [
+        {"code": "1", "text": "非常不同意", "score": 1},
+        {"code": "2", "text": "不同意", "score": 2},
+        {"code": "3", "text": "不确定", "score": 3},
+        {"code": "4", "text": "同意", "score": 4},
+        {"code": "5", "text": "非常同意", "score": 5}
+      ]
+    },
+    {
+      "question_id": "BIG5-002",
+      "order": 2,
+      "dimension": "C",
+      "text": "我做事有计划。",
+      "direction": 1,
+      "options": [
+        {"code": "1", "text": "非常不同意", "score": 1},
+        {"code": "2", "text": "不同意", "score": 2},
+        {"code": "3", "text": "不确定", "score": 3},
+        {"code": "4", "text": "同意", "score": 4},
+        {"code": "5", "text": "非常同意", "score": 5}
+      ]
+    },
+    {
+      "question_id": "BIG5-003",
+      "order": 3,
+      "dimension": "E",
+      "text": "我在社交中精力充沛。",
+      "direction": 1,
+      "options": [
+        {"code": "1", "text": "非常不同意", "score": 1},
+        {"code": "2", "text": "不同意", "score": 2},
+        {"code": "3", "text": "不确定", "score": 3},
+        {"code": "4", "text": "同意", "score": 4},
+        {"code": "5", "text": "非常同意", "score": 5}
+      ]
+    },
+    {
+      "question_id": "BIG5-004",
+      "order": 4,
+      "dimension": "A",
+      "text": "我愿意体谅他人。",
+      "direction": 1,
+      "options": [
+        {"code": "1", "text": "非常不同意", "score": 1},
+        {"code": "2", "text": "不同意", "score": 2},
+        {"code": "3", "text": "不确定", "score": 3},
+        {"code": "4", "text": "同意", "score": 4},
+        {"code": "5", "text": "非常同意", "score": 5}
+      ]
+    },
+    {
+      "question_id": "BIG5-005",
+      "order": 5,
+      "dimension": "N",
+      "text": "我经常感到焦虑。",
+      "direction": 1,
+      "options": [
+        {"code": "1", "text": "非常不同意", "score": 1},
+        {"code": "2", "text": "不同意", "score": 2},
+        {"code": "3", "text": "不确定", "score": 3},
+        {"code": "4", "text": "同意", "score": 4},
+        {"code": "5", "text": "非常同意", "score": 5}
+      ]
+    }
+  ]
+}

--- a/content_packages/default/CN_MAINLAND/zh-CN/BIG5-CN-v0.1.0-TEST/scoring_spec.json
+++ b/content_packages/default/CN_MAINLAND/zh-CN/BIG5-CN-v0.1.0-TEST/scoring_spec.json
@@ -1,0 +1,12 @@
+{
+  "version": "2026.02",
+  "scale_code": "BIG5",
+  "driver_type": "generic_scoring",
+  "dimensions": {
+    "O": {"label": "Openness"},
+    "C": {"label": "Conscientiousness"},
+    "E": {"label": "Extraversion"},
+    "A": {"label": "Agreeableness"},
+    "N": {"label": "Neuroticism"}
+  }
+}

--- a/content_packages/default/CN_MAINLAND/zh-CN/BIG5-CN-v0.1.0-TEST/version.json
+++ b/content_packages/default/CN_MAINLAND/zh-CN/BIG5-CN-v0.1.0-TEST/version.json
@@ -1,0 +1,12 @@
+{
+  "pack_id": "BIG5.cn-mainland.zh-CN.v0.1.0-TEST",
+  "dir_version": "BIG5-CN-v0.1.0-TEST",
+  "content_package_version": "v0.1.0-TEST",
+  "semver": "0.1.0-test",
+  "schema_version": "v1",
+  "scoring_spec_version": "2026.02",
+  "updated_at": "2026-02-05",
+  "assets_base_url": "",
+  "checksum": "0000000000000000000000000000000000000000000000000000000000000000",
+  "checksum_sha256": "0000000000000000000000000000000000000000000000000000000000000000"
+}

--- a/content_packages/default/CN_MAINLAND/zh-CN/MBTI-CN-v0.2.1-TEST/scoring_spec.json
+++ b/content_packages/default/CN_MAINLAND/zh-CN/MBTI-CN-v0.2.1-TEST/scoring_spec.json
@@ -2,12 +2,48 @@
   "version": "2026.01",
   "scale_code": "MBTI",
   "dimensions": {
-    "EI": {"poles": ["E", "I"], "score_range": [0, 100]},
-    "SN": {"poles": ["S", "N"], "score_range": [0, 100]},
-    "TF": {"poles": ["T", "F"], "score_range": [0, 100]},
-    "JP": {"poles": ["J", "P"], "score_range": [0, 100]},
-    "AT": {"poles": ["A", "T"], "score_range": [0, 100]}
+    "EI": {
+      "p1": "E",
+      "p2": "I",
+      "poles": ["E", "I"],
+      "score_range": [0, 100]
+    },
+    "SN": {
+      "p1": "S",
+      "p2": "N",
+      "poles": ["S", "N"],
+      "score_range": [0, 100]
+    },
+    "TF": {
+      "p1": "T",
+      "p2": "F",
+      "poles": ["T", "F"],
+      "score_range": [0, 100]
+    },
+    "JP": {
+      "p1": "J",
+      "p2": "P",
+      "poles": ["J", "P"],
+      "score_range": [0, 100]
+    },
+    "AT": {
+      "p1": "A",
+      "p2": "T",
+      "poles": ["A", "T"],
+      "score_range": [0, 100]
+    }
   },
+  "type_rules": {
+    "base_axes": ["EI", "SN", "TF", "JP"],
+    "suffix_axis": "AT",
+    "delimiter": "-"
+  },
+  "pci_levels": [
+    {"code": "slight", "min": 0, "max": 14},
+    {"code": "moderate", "min": 15, "max": 30},
+    {"code": "clear", "min": 31, "max": 50},
+    {"code": "very_clear", "min": 51, "max": 100}
+  ],
   "score_map": {"A": 2, "B": 1, "C": 0, "D": -1, "E": -2},
   "reverse_pairs": [
     {"a": "MBTI-001", "b": "MBTI-002"},

--- a/content_packages/default/CN_MAINLAND/zh-CN/MBTI-CN-v0.2.2/scoring_spec.json
+++ b/content_packages/default/CN_MAINLAND/zh-CN/MBTI-CN-v0.2.2/scoring_spec.json
@@ -3,6 +3,8 @@
     "scale_code": "MBTI",
     "dimensions": {
         "EI": {
+            "p1": "E",
+            "p2": "I",
             "poles": [
                 "E",
                 "I"
@@ -13,6 +15,8 @@
             ]
         },
         "SN": {
+            "p1": "S",
+            "p2": "N",
             "poles": [
                 "S",
                 "N"
@@ -23,6 +27,8 @@
             ]
         },
         "TF": {
+            "p1": "T",
+            "p2": "F",
             "poles": [
                 "T",
                 "F"
@@ -33,6 +39,8 @@
             ]
         },
         "JP": {
+            "p1": "J",
+            "p2": "P",
             "poles": [
                 "J",
                 "P"
@@ -43,6 +51,8 @@
             ]
         },
         "AT": {
+            "p1": "A",
+            "p2": "T",
             "poles": [
                 "A",
                 "T"
@@ -53,6 +63,38 @@
             ]
         }
     },
+    "type_rules": {
+        "base_axes": [
+            "EI",
+            "SN",
+            "TF",
+            "JP"
+        ],
+        "suffix_axis": "AT",
+        "delimiter": "-"
+    },
+    "pci_levels": [
+        {
+            "code": "slight",
+            "min": 0,
+            "max": 14
+        },
+        {
+            "code": "moderate",
+            "min": 15,
+            "max": 30
+        },
+        {
+            "code": "clear",
+            "min": 31,
+            "max": 50
+        },
+        {
+            "code": "very_clear",
+            "min": 51,
+            "max": 100
+        }
+    ],
     "score_map": {
         "A": 2,
         "B": 1,

--- a/docs/verify/pr32_recon.md
+++ b/docs/verify/pr32_recon.md
@@ -1,0 +1,20 @@
+# PR32 Recon
+
+- Keywords: AssessmentEngine|MbtiAttemptScorer|scoring_spec
+- 相关入口文件：
+  - backend/app/Services/Assessment/AssessmentEngine.php
+  - backend/app/Services/Assessment/Drivers/MbtiDriver.php
+  - backend/app/Services/Score/MbtiAttemptScorer.php
+- 相关路由：
+  - /api/v0.3/attempts/start
+  - /api/v0.3/attempts/submit
+- 相关 DB 表/迁移：
+  - scales_registry (新增 assessment_driver)
+- 需要新增/修改点：
+  - AssessmentEngine 改为 registry 驱动选择
+  - 新增 GenericScoringDriver
+  - scoring_spec 升级 + BIG5 pack + seed
+- 风险点与规避（端口/CI 工具依赖/pack-seed-config 一致性/sqlite 迁移一致性/404 口径/脱敏）：
+  - artisan 不可用时无法 route:list，需在有 vendor 后补跑
+  - 脚本禁用 rg/jq，统一 grep -E + php -r
+  - pack/seed/config 一致性校验写入 verify.sh

--- a/docs/verify/pr32_verify.md
+++ b/docs/verify/pr32_verify.md
@@ -1,0 +1,27 @@
+# PR32 Verify
+
+- Date: 2026-02-05
+- Env: local
+- Commands:
+  - bash backend/scripts/pr32_accept.sh
+  - bash backend/scripts/ci_verify_mbti.sh
+- Results:
+  - pr32_accept: FAILED (composer install could not reach api.github.com; cache dir not writable)
+  - ci_verify_mbti: FAILED (missing backend/vendor/autoload.php)
+- Artifacts:
+  - backend/artifacts/pr32/summary.txt
+  - backend/artifacts/pr32/verify.log
+  - backend/artifacts/verify_mbti/summary.txt
+
+Step Verification Commands
+
+1. Step 1 (routes): php -l backend/routes/api.php
+2. Step 2 (migrations): php -l backend/database/migrations/*.php
+3. Step 3 (middleware): php -l backend/app/Http/Middleware/FmTokenAuth.php
+4. Step 4 (controllers/services/config/tests): php -l backend/app/Services/Assessment/AssessmentEngine.php
+5. Step 5 (scripts/CI): bash -n backend/scripts/pr32_verify.sh
+
+Verify Log Pointers
+
+- pr32_accept stdout/stderr: backend/artifacts/pr32 (summary.txt + logs)
+- ci_verify_mbti stdout/stderr: backend/artifacts/verify_mbti (summary.txt + logs)


### PR DESCRIPTION
 - 将 v0.3 评分引擎改为 spec 驱动的通用 GenericScoringDriver，并用 registry 替
    换 match 选择 driver
    Why:
  - scales_registry.driver_type 承载“量表类型”与“评分引擎”导致无法扩展 Big5/任意
    Likert；引入 assessment_driver 解耦
  - 用 scoring_spec.json 承载 type_rules/pci_levels 等业务逻辑，新增量表仅改
    content pack + DB seed
    How:
  - backend/database/migrations/
    *_add_assessment_driver_to_scales_registry_table.php：新增列
  - backend/app/Services/Assessment/AssessmentEngine.php：resolveDriver() + ctx
    统一传 scoringSpec/questions
  - backend/app/Services/Assessment/Drivers/GenericScoringDriver.php：
    dichotomy+trait 评分 + type_rules
  - content_packages/**/MBTI*/scoring_spec.json：补齐 AT/type_rules/pci_levels
  - content_packages/default/CN_MAINLAND/zh-CN/BIG5-CN-v0.1.0-TEST：最小 Big5
    content pack
  - backend/scripts/pr32_accept.sh / pr32_verify.sh：本机验收闭环
    Verify:
  - bash backend/scripts/pr32_accept.sh
  - bash backend/scripts/ci_verify_mbti.sh
    Artifacts:
  - backend/artifacts/pr32/summary.txt
