### PR TITLE
chore(pr34): Ops & Security: Redis-cached content loader + report IDOR guard

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -82,7 +82,7 @@ FAP_PACKS_DRIVER=local
 FAP_PACKS_ROOT=../content_packages
 FAP_PACKS_CACHE_DIR=storage/app/private/content_packs_cache
 FAP_PACKS_CACHE_TTL_SECONDS=3600
-CONTENT_LOADER_CACHE_STORE=hot_redis
+CONTENT_LOADER_CACHE_STORE=array
 CONTENT_LOADER_CACHE_TTL_SECONDS=300
 
 # 线上建议：driver=s3（本地也可用，但需要你把 S3/COS 的包同步到 cache_dir/<dir_version>/）

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -82,6 +82,8 @@ FAP_PACKS_DRIVER=local
 FAP_PACKS_ROOT=../content_packages
 FAP_PACKS_CACHE_DIR=storage/app/private/content_packs_cache
 FAP_PACKS_CACHE_TTL_SECONDS=3600
+CONTENT_LOADER_CACHE_STORE=hot_redis
+CONTENT_LOADER_CACHE_TTL_SECONDS=300
 
 # 线上建议：driver=s3（本地也可用，但需要你把 S3/COS 的包同步到 cache_dir/<dir_version>/）
 FAP_S3_DISK=s3

--- a/backend/app/Services/Content/ContentLoaderService.php
+++ b/backend/app/Services/Content/ContentLoaderService.php
@@ -1,0 +1,93 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\Content;
+
+use Illuminate\Contracts\Cache\Repository as CacheRepository;
+use Illuminate\Support\Facades\Cache;
+
+final class ContentLoaderService
+{
+    public function readText(
+        string $packId,
+        string $dirVersion,
+        string $relativePath,
+        callable $reader
+    ): ?string {
+        $cache = $this->cacheStore();
+        $key = $this->makeCacheKey($packId, $dirVersion, $relativePath);
+        $ttl = $this->cacheTtlSeconds();
+
+        $value = $cache->remember($key, $ttl, function () use ($reader): array {
+            $raw = $reader();
+            if (!is_string($raw)) {
+                return [
+                    'found' => false,
+                    'raw' => null,
+                ];
+            }
+
+            return [
+                'found' => true,
+                'raw' => $raw,
+            ];
+        });
+
+        if (!is_array($value) || !($value['found'] ?? false)) {
+            return null;
+        }
+
+        $raw = $value['raw'] ?? null;
+        return is_string($raw) ? $raw : null;
+    }
+
+    public function readJson(
+        string $packId,
+        string $dirVersion,
+        string $relativePath,
+        callable $reader
+    ): ?array {
+        $raw = $this->readText($packId, $dirVersion, $relativePath, $reader);
+        if ($raw === null || trim($raw) === '') {
+            return null;
+        }
+
+        $decoded = json_decode($raw, true);
+
+        return is_array($decoded) ? $decoded : null;
+    }
+
+    public function makeCacheKey(string $packId, string $dirVersion, string $relativePath): string
+    {
+        $path = ltrim(str_replace('\\', '/', trim($relativePath)), '/');
+        $seed = $packId . '|' . $dirVersion . '|' . $path;
+
+        return 'content_loader:' . sha1($seed);
+    }
+
+    private function cacheStore(): CacheRepository
+    {
+        if (app()->environment('testing')) {
+            return Cache::store();
+        }
+
+        $store = trim((string) config('content_packs.loader_cache_store', ''));
+        if ($store === '' || strtolower($store) === 'default') {
+            return Cache::store();
+        }
+
+        try {
+            return Cache::store($store);
+        } catch (\Throwable $e) {
+            return Cache::store();
+        }
+    }
+
+    private function cacheTtlSeconds(): int
+    {
+        $ttl = (int) config('content_packs.loader_cache_ttl_seconds', 300);
+
+        return $ttl > 0 ? $ttl : 300;
+    }
+}

--- a/backend/config/content_packs.php
+++ b/backend/config/content_packs.php
@@ -22,6 +22,8 @@ return [
     // - cache_ttl_seconds：到期触发一次 etag 校验与刷新
     'cache_dir' => env('FAP_PACKS_CACHE_DIR', storage_path('app/private/content_packs_cache')),
     'cache_ttl_seconds' => (int)env('FAP_PACKS_CACHE_TTL_SECONDS', 3600),
+    'loader_cache_store' => env('CONTENT_LOADER_CACHE_STORE', 'hot_redis'),
+    'loader_cache_ttl_seconds' => (int) env('CONTENT_LOADER_CACHE_TTL_SECONDS', 300),
 
     // ✅ CI/服务器建议强约束：默认 pack_id 明确指向你的主包，避免回退到 GLOBAL/en
     // default_pack_id 对应 manifest.json.pack_id（MBTI.cn-mainland.zh-CN.v0.2.2）

--- a/backend/config/content_packs.php
+++ b/backend/config/content_packs.php
@@ -3,6 +3,9 @@
 
 declare(strict_types=1);
 
+$appEnv = env('APP_ENV', 'production');
+$defaultLoaderStore = in_array($appEnv, ['local', 'testing', 'ci'], true) ? 'array' : 'hot_redis';
+
 return [
     // content_packages 根目录（本机/服务器/CI 都建议通过 env 固定）
     // - 本机默认：base_path('../content_packages')
@@ -22,7 +25,7 @@ return [
     // - cache_ttl_seconds：到期触发一次 etag 校验与刷新
     'cache_dir' => env('FAP_PACKS_CACHE_DIR', storage_path('app/private/content_packs_cache')),
     'cache_ttl_seconds' => (int)env('FAP_PACKS_CACHE_TTL_SECONDS', 3600),
-    'loader_cache_store' => env('CONTENT_LOADER_CACHE_STORE', 'hot_redis'),
+    'loader_cache_store' => env('CONTENT_LOADER_CACHE_STORE', $defaultLoaderStore),
     'loader_cache_ttl_seconds' => (int) env('CONTENT_LOADER_CACHE_TTL_SECONDS', 300),
 
     // ✅ CI/服务器建议强约束：默认 pack_id 明确指向你的主包，避免回退到 GLOBAL/en

--- a/backend/scripts/accept_events_C.sh
+++ b/backend/scripts/accept_events_C.sh
@@ -60,10 +60,24 @@ fi
 echo "[ACCEPT] ATT=$ATT"
 export ATT
 
+ANON_ID="${ANON_ID:-}"
+ANON_ID_FILE="$BACKEND_DIR/artifacts/verify_mbti/anon_id.txt"
+if [[ -z "$ANON_ID" && -s "$ANON_ID_FILE" ]]; then
+  ANON_ID="$(cat "$ANON_ID_FILE")"
+fi
+if [[ -z "$ANON_ID" ]]; then
+  echo "[ERR] missing anon_id; set ANON_ID=... or ensure $ANON_ID_FILE exists" >&2
+  exit 1
+fi
+echo "[ACCEPT] ANON_ID=$ANON_ID"
+export ANON_ID
+
 # ---- 1) result_view: refresh=1 then cache hit ----
-curl -sS "$API/api/v0.2/attempts/$ATT/report?refresh=1" >/dev/null
+curl -sS -H "X-Anon-Id: $ANON_ID" \
+  "$API/api/v0.2/attempts/$ATT/report?refresh=1&anon_id=$ANON_ID" >/dev/null
 sleep 1
-curl -sS "$API/api/v0.2/attempts/$ATT/report" >/dev/null
+curl -sS -H "X-Anon-Id: $ANON_ID" \
+  "$API/api/v0.2/attempts/$ATT/report?anon_id=$ANON_ID" >/dev/null
 
 # ---- 2) share_generate (with optional headers) ----
 # Use set -u safe array expansion in case HDRS is empty.

--- a/backend/scripts/accept_overrides_D.sh
+++ b/backend/scripts/accept_overrides_D.sh
@@ -1,6 +1,18 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+BACKEND_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+ARTIFACTS="${ARTIFACTS:-${BACKEND_DIR}/artifacts/verify_mbti}"
+ANON_ID=""
+if [[ -f "${ARTIFACTS}/anon_id.txt" ]]; then
+  ANON_ID="$(tr -d '\r\n' < "${ARTIFACTS}/anon_id.txt")"
+fi
+OWNER_HDR=()
+if [[ -n "${ANON_ID}" ]]; then
+  OWNER_HDR=(-H "X-Anon-Id: ${ANON_ID}")
+fi
+
 # -----------------------------
 # Auth (fm_token) for gated endpoints
 # -----------------------------
@@ -25,8 +37,6 @@ need_cmd() { command -v "$1" >/dev/null 2>&1 || { echo "❌ missing command: $1"
 need_cmd curl
 need_cmd php
 
-SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-BACKEND_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
 REPO_DIR="$(cd "$BACKEND_DIR/.." && pwd)"
 CONTENT_ROOT="${CONTENT_ROOT:-$REPO_DIR/content_packages}"
 
@@ -121,6 +131,7 @@ call_refresh() {
 
   http="$(curl -sS -L -o "$TMP_REPORT" -w "%{http_code}" \
     "${CURL_AUTH[@]}" \
+    "${OWNER_HDR[@]}" \
     -H 'Accept: application/json' \
     "$url" || true)"
 

--- a/backend/scripts/ci_verify_mbti.sh
+++ b/backend/scripts/ci_verify_mbti.sh
@@ -61,6 +61,7 @@ API="http://${HOST}:${PORT}"
 
 REGION="${REGION:-CN_MAINLAND}"
 LOCALE="${LOCALE:-zh-CN}"
+VERIFY_ANON_ID="${VERIFY_ANON_ID:-ci_verify}"
 
 # Your stable pack identifiers
 PACK_ID="${PACK_ID:-MBTI.cn-mainland.zh-CN.v0.2.2}"
@@ -564,10 +565,11 @@ echo "[CI] smoke OK"
 # Run E2E verify
 # -----------------------------
 echo "[CI] get fm_token for gated endpoints"
+echo "[CI] verify anon_id=$VERIFY_ANON_ID"
 FM_TOKEN="$(
   curl -sS -X POST "$API/api/v0.2/auth/wx_phone" \
     -H "Content-Type: application/json" \
-    -d '{"wx_code":"dev","phone_code":"dev","anon_id":"ci_verify"}' \
+    -d "{\"wx_code\":\"dev\",\"phone_code\":\"dev\",\"anon_id\":\"${VERIFY_ANON_ID}\"}" \
   | php -r '$j=json_decode(stream_get_contents(STDIN), true); echo $j["token"] ?? "";'
 )"
 
@@ -579,7 +581,7 @@ fi
 set_curl_auth
 
 echo "[CI] running verify_mbti.sh (with FM_TOKEN)"
-API="$API" REGION="$REGION" LOCALE="$LOCALE" RUN_DIR="$RUN_DIR" FM_TOKEN="$FM_TOKEN" \
+API="$API" REGION="$REGION" LOCALE="$LOCALE" RUN_DIR="$RUN_DIR" ANON_ID="$VERIFY_ANON_ID" FM_TOKEN="$FM_TOKEN" \
   bash "$SCRIPT_DIR/verify_mbti.sh"
 echo "[CI] verify_mbti OK ✅"
 
@@ -761,7 +763,7 @@ if [[ "$ACCEPT_ORDER" == "1" ]]; then
   echo "[CI] lookup order acceptance OK"
 fi
 
-API="$API" SQLITE_DB="$SQLITE_DB_FOR_ACCEPT" FM_TOKEN="$FM_TOKEN" \
+API="$API" SQLITE_DB="$SQLITE_DB_FOR_ACCEPT" ANON_ID="$VERIFY_ANON_ID" FM_TOKEN="$FM_TOKEN" \
   "$SCRIPT_DIR/accept_events_C.sh" >/dev/null
 
 API="$API" SQLITE_DB="$SQLITE_DB_FOR_ACCEPT" FM_TOKEN="$FM_TOKEN" \

--- a/backend/scripts/pr34_accept.sh
+++ b/backend/scripts/pr34_accept.sh
@@ -1,0 +1,99 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+export CI=true
+export FAP_NONINTERACTIVE=1
+export COMPOSER_NO_INTERACTION=1
+export GIT_TERMINAL_PROMPT=0
+export NO_COLOR=1
+export PAGER=cat
+export GIT_PAGER=cat
+export TERM=dumb
+export XDEBUG_MODE=off
+export LANG=en_US.UTF-8
+
+REPO_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+BACKEND_DIR="${REPO_DIR}/backend"
+ART_DIR="${BACKEND_DIR}/artifacts/pr34"
+SERVE_PORT="${SERVE_PORT:-1834}"
+DB_PATH="/tmp/pr34.sqlite"
+
+mkdir -p "${ART_DIR}"
+
+cleanup_port() {
+  local port="$1"
+  lsof -nP -iTCP:"${port}" -sTCP:LISTEN || true
+  local pid_list
+  pid_list="$(lsof -ti tcp:"${port}" || true)"
+  if [[ -n "${pid_list}" ]]; then
+    echo "${pid_list}" | xargs kill -9 || true
+  fi
+  lsof -nP -iTCP:"${port}" -sTCP:LISTEN || true
+}
+
+cleanup() {
+  if [[ -f "${ART_DIR}/server.pid" ]]; then
+    local pid
+    pid="$(cat "${ART_DIR}/server.pid" || true)"
+    if [[ -n "${pid}" ]] && ps -p "${pid}" >/dev/null 2>&1; then
+      kill "${pid}" >/dev/null 2>&1 || true
+    fi
+  fi
+  cleanup_port "${SERVE_PORT}"
+  cleanup_port 18000
+  rm -f "${DB_PATH}"
+}
+trap cleanup EXIT
+
+cleanup_port "${SERVE_PORT}"
+cleanup_port 18000
+
+export APP_ENV=testing
+export CACHE_STORE=array
+export QUEUE_CONNECTION=sync
+export DB_CONNECTION=sqlite
+export DB_DATABASE="${DB_PATH}"
+export FAP_PACKS_ROOT="${FAP_PACKS_ROOT:-${REPO_DIR}/content_packages}"
+export FAP_DEFAULT_REGION="${FAP_DEFAULT_REGION:-CN_MAINLAND}"
+export FAP_DEFAULT_LOCALE="${FAP_DEFAULT_LOCALE:-zh-CN}"
+export FAP_DEFAULT_PACK_ID="${FAP_DEFAULT_PACK_ID:-MBTI.cn-mainland.zh-CN.v0.2.2}"
+export FAP_DEFAULT_DIR_VERSION="${FAP_DEFAULT_DIR_VERSION:-MBTI-CN-v0.2.2}"
+
+rm -f "${DB_PATH}"
+touch "${DB_PATH}"
+
+cd "${BACKEND_DIR}"
+composer install --no-interaction --no-progress
+php artisan migrate:fresh --force
+php artisan fap:scales:seed-default
+php artisan fap:scales:sync-slugs
+cd "${REPO_DIR}"
+
+SERVE_PORT="${SERVE_PORT}" ART_DIR="${ART_DIR}" bash "${BACKEND_DIR}/scripts/pr34_verify.sh"
+
+ATTEMPT_ID="$(cat "${ART_DIR}/attempt_id.txt" 2>/dev/null || true)"
+ANON_ID="$(cat "${ART_DIR}/anon_id.txt" 2>/dev/null || true)"
+DEFAULT_PACK_ID="$(cat "${ART_DIR}/config_default_pack_id.txt" 2>/dev/null || true)"
+
+cat > "${ART_DIR}/summary.txt" <<TXT
+PR34 Acceptance Summary
+- pass_items:
+  - content_loader_cache: OK
+  - report_idor_guard: OK
+  - pack_seed_config_consistency: OK
+  - dynamic_answers_submit: OK
+- key_outputs:
+  - attempt_id: ${ATTEMPT_ID}
+  - anon_id: ${ANON_ID}
+  - default_pack_id: ${DEFAULT_PACK_ID}
+- smoke_urls:
+  - http://127.0.0.1:${SERVE_PORT}/api/v0.3/scales/MBTI/questions
+  - http://127.0.0.1:${SERVE_PORT}/api/v0.2/attempts/${ATTEMPT_ID}/report?anon_id=${ANON_ID}
+- schema_changes:
+  - none
+TXT
+
+bash "${BACKEND_DIR}/scripts/sanitize_artifacts.sh" 34
+
+bash -n "${BACKEND_DIR}/scripts/pr34_accept.sh"
+bash -n "${BACKEND_DIR}/scripts/pr34_verify.sh"

--- a/backend/scripts/pr34_verify.sh
+++ b/backend/scripts/pr34_verify.sh
@@ -1,0 +1,329 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+export CI=true
+export FAP_NONINTERACTIVE=1
+export COMPOSER_NO_INTERACTION=1
+export GIT_TERMINAL_PROMPT=0
+export NO_COLOR=1
+export PAGER=cat
+export GIT_PAGER=cat
+export TERM=dumb
+export XDEBUG_MODE=off
+export LANG=en_US.UTF-8
+
+REPO_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+BACKEND_DIR="${REPO_DIR}/backend"
+ART_DIR="${ART_DIR:-${BACKEND_DIR}/artifacts/pr34}"
+SERVE_PORT="${SERVE_PORT:-1834}"
+HOST="127.0.0.1"
+API_BASE="http://${HOST}:${SERVE_PORT}"
+SCALE_CODE="${SCALE_CODE:-MBTI}"
+ANON_ID="${ANON_ID:-pr34-verify-anon}"
+export FAP_PACKS_ROOT="${FAP_PACKS_ROOT:-${REPO_DIR}/content_packages}"
+export FAP_DEFAULT_REGION="${FAP_DEFAULT_REGION:-CN_MAINLAND}"
+export FAP_DEFAULT_LOCALE="${FAP_DEFAULT_LOCALE:-zh-CN}"
+export FAP_DEFAULT_PACK_ID="${FAP_DEFAULT_PACK_ID:-MBTI.cn-mainland.zh-CN.v0.2.2}"
+export FAP_DEFAULT_DIR_VERSION="${FAP_DEFAULT_DIR_VERSION:-MBTI-CN-v0.2.2}"
+
+mkdir -p "${ART_DIR}"
+exec > "${ART_DIR}/verify.log" 2>&1
+
+fail() {
+  echo "[PR34][FAIL] $*" >&2
+  exit 1
+}
+
+cleanup_port() {
+  local port="$1"
+  lsof -nP -iTCP:"${port}" -sTCP:LISTEN || true
+  local pid_list
+  pid_list="$(lsof -ti tcp:"${port}" || true)"
+  if [[ -n "${pid_list}" ]]; then
+    echo "${pid_list}" | xargs kill -9 || true
+  fi
+  lsof -nP -iTCP:"${port}" -sTCP:LISTEN || true
+}
+
+wait_health() {
+  local url="$1"
+  local body_file="${ART_DIR}/healthz.body"
+  local http_code=""
+
+  for _ in $(seq 1 80); do
+    http_code="$(curl -sS -o "${body_file}" -w "%{http_code}" "${url}" || true)"
+    if [[ "${http_code}" == "200" ]]; then
+      return 0
+    fi
+    sleep 0.25
+  done
+
+  echo "health_check_failed http=${http_code}" >&2
+  cat "${body_file}" >&2 || true
+  tail -n 120 "${ART_DIR}/server.log" >&2 || true
+  return 1
+}
+
+cleanup() {
+  if [[ -n "${SERVE_PID:-}" ]] && ps -p "${SERVE_PID}" >/dev/null 2>&1; then
+    kill "${SERVE_PID}" >/dev/null 2>&1 || true
+  fi
+  cleanup_port "${SERVE_PORT}"
+  cleanup_port 18000
+}
+trap cleanup EXIT
+
+cleanup_port "${SERVE_PORT}"
+cleanup_port 18000
+
+cd "${BACKEND_DIR}"
+php artisan serve --host="${HOST}" --port="${SERVE_PORT}" > "${ART_DIR}/server.log" 2>&1 &
+SERVE_PID="$!"
+echo "${SERVE_PID}" > "${ART_DIR}/server.pid"
+cd "${REPO_DIR}"
+
+wait_health "${API_BASE}/api/v0.2/healthz" || fail "healthz failed"
+curl -sS "${API_BASE}/api/v0.2/healthz" > "${ART_DIR}/healthz.json"
+
+# pack/seed/config consistency
+cd "${BACKEND_DIR}"
+php -r '
+require "vendor/autoload.php";
+$app=require "bootstrap/app.php";
+$app->make(Illuminate\Contracts\Console\Kernel::class)->bootstrap();
+echo (string) config("content_packs.default_pack_id", "");
+' > "${ART_DIR}/config_default_pack_id.txt"
+
+php -r '
+require "vendor/autoload.php";
+$app=require "bootstrap/app.php";
+$app->make(Illuminate\Contracts\Console\Kernel::class)->bootstrap();
+$packId = (string) config("content_packs.default_pack_id", "");
+$dirVersion = (string) config("content_packs.default_dir_version", "");
+echo "config_default_pack_id=".$packId.PHP_EOL;
+echo "config_default_dir_version=".$dirVersion.PHP_EOL;
+if ($packId === "" || $dirVersion === "") {
+    fwrite(STDERR, "missing_content_pack_defaults\n");
+    exit(1);
+}
+if (!Illuminate\Support\Facades\Schema::hasTable("scales_registry")) {
+    fwrite(STDERR, "missing_scales_registry_table\n");
+    exit(1);
+}
+$row = Illuminate\Support\Facades\DB::table("scales_registry")
+    ->where("org_id", 0)
+    ->where("code", "MBTI")
+    ->first();
+if (!$row) {
+    fwrite(STDERR, "missing_scales_registry_mbti\n");
+    exit(1);
+}
+$registryPackId = (string) ($row->default_pack_id ?? "");
+$registryDirVersion = (string) ($row->default_dir_version ?? "");
+echo "registry_default_pack_id=".$registryPackId.PHP_EOL;
+echo "registry_default_dir_version=".$registryDirVersion.PHP_EOL;
+if ($registryPackId !== $packId) {
+    fwrite(STDERR, "default_pack_id_mismatch\n");
+    exit(1);
+}
+if ($registryDirVersion !== $dirVersion) {
+    fwrite(STDERR, "default_dir_version_mismatch\n");
+    exit(1);
+}
+$index = app(App\Services\Content\ContentPacksIndex::class);
+$found = $index->find($packId, $dirVersion);
+if (!($found["ok"] ?? false)) {
+    fwrite(STDERR, "pack_not_found\n");
+    exit(1);
+}
+$item = $found["item"] ?? [];
+$manifestPath = (string) ($item["manifest_path"] ?? "");
+$questionsPath = (string) ($item["questions_path"] ?? "");
+if ($manifestPath === "" || !is_file($manifestPath)) {
+    fwrite(STDERR, "manifest_missing\n");
+    exit(1);
+}
+if ($questionsPath === "" || !is_file($questionsPath)) {
+    fwrite(STDERR, "questions_missing\n");
+    exit(1);
+}
+$packDir = dirname($manifestPath);
+$versionPath = $packDir.DIRECTORY_SEPARATOR."version.json";
+if (!is_file($versionPath)) {
+    fwrite(STDERR, "version_missing\n");
+    exit(1);
+}
+$manifest = json_decode((string) file_get_contents($manifestPath), true);
+$questions = json_decode((string) file_get_contents($questionsPath), true);
+$version = json_decode((string) file_get_contents($versionPath), true);
+if (!is_array($manifest) || !is_array($questions) || !is_array($version)) {
+    fwrite(STDERR, "pack_json_invalid\n");
+    exit(1);
+}
+echo "pack_manifest=".$manifestPath.PHP_EOL;
+echo "pack_questions=".$questionsPath.PHP_EOL;
+echo "pack_version=".$versionPath.PHP_EOL;
+' > "${ART_DIR}/pack_seed_config.txt"
+cd "${REPO_DIR}"
+
+QUESTIONS_JSON="${ART_DIR}/questions.json"
+http_code="$(curl -sS -o "${QUESTIONS_JSON}" -w "%{http_code}" \
+  -H "Accept: application/json" \
+  "${API_BASE}/api/v0.3/scales/${SCALE_CODE}/questions" || true)"
+if [[ "${http_code}" != "200" ]]; then
+  echo "questions_failed http=${http_code}" >&2
+  cat "${QUESTIONS_JSON}" >&2 || true
+  fail "questions endpoint failed"
+fi
+
+ANSWERS_JSON="${ART_DIR}/answers.json"
+php -r '
+$raw = file_get_contents("php://stdin");
+$data = json_decode($raw, true);
+if (!is_array($data)) {
+    fwrite(STDERR, "questions_json_invalid\n");
+    exit(1);
+}
+$items = $data["questions"]["items"] ?? $data["questions"] ?? $data["items"] ?? $data["data"] ?? $data;
+if (!is_array($items)) {
+    fwrite(STDERR, "questions_items_invalid\n");
+    exit(1);
+}
+$answers = [];
+foreach ($items as $item) {
+    if (!is_array($item)) {
+        continue;
+    }
+    $questionId = (string) ($item["question_id"] ?? $item["id"] ?? "");
+    if ($questionId === "") {
+        continue;
+    }
+    $options = $item["options"] ?? [];
+    $code = "A";
+    if (is_array($options) && isset($options[0]) && is_array($options[0])) {
+        $code = (string) ($options[0]["code"] ?? $options[0]["option_code"] ?? "A");
+    }
+    if ($code === "") {
+        $code = "A";
+    }
+    $answers[] = [
+        "question_id" => $questionId,
+        "code" => $code,
+    ];
+}
+if (count($answers) === 0) {
+    fwrite(STDERR, "answers_empty\n");
+    exit(1);
+}
+echo json_encode($answers, JSON_UNESCAPED_UNICODE);
+' < "${QUESTIONS_JSON}" > "${ANSWERS_JSON}"
+
+ATTEMPT_START_JSON="${ART_DIR}/attempt_start.json"
+ATTEMPT_START_BODY="$(SCALE_CODE="${SCALE_CODE}" ANON_ID="${ANON_ID}" php -r '
+$payload = [
+    "scale_code" => getenv("SCALE_CODE"),
+    "anon_id" => getenv("ANON_ID"),
+];
+echo json_encode($payload, JSON_UNESCAPED_UNICODE);
+')"
+http_code="$(curl -sS -o "${ATTEMPT_START_JSON}" -w "%{http_code}" \
+  -X POST -H "Content-Type: application/json" -H "Accept: application/json" \
+  --data "${ATTEMPT_START_BODY}" \
+  "${API_BASE}/api/v0.3/attempts/start" || true)"
+if [[ "${http_code}" != "200" ]]; then
+  echo "attempt_start_failed http=${http_code}" >&2
+  cat "${ATTEMPT_START_JSON}" >&2 || true
+  fail "attempt start failed"
+fi
+
+ATTEMPT_ID="$(php -r '$j=json_decode(file_get_contents($argv[1]), true); echo (string)($j["attempt_id"] ?? "");' "${ATTEMPT_START_JSON}")"
+if [[ -z "${ATTEMPT_ID}" ]]; then
+  fail "missing attempt_id"
+fi
+echo "${ATTEMPT_ID}" > "${ART_DIR}/attempt_id.txt"
+echo "${ANON_ID}" > "${ART_DIR}/anon_id.txt"
+
+SUBMIT_PAYLOAD="${ART_DIR}/submit_payload.json"
+ATTEMPT_ID="${ATTEMPT_ID}" ANSWERS_PATH="${ANSWERS_JSON}" php -r '
+$answers = json_decode(file_get_contents(getenv("ANSWERS_PATH")), true);
+if (!is_array($answers) || count($answers) === 0) {
+    fwrite(STDERR, "answers_payload_invalid\n");
+    exit(1);
+}
+$payload = [
+    "attempt_id" => getenv("ATTEMPT_ID"),
+    "answers" => $answers,
+    "duration_ms" => 120000,
+];
+echo json_encode($payload, JSON_UNESCAPED_UNICODE);
+' > "${SUBMIT_PAYLOAD}"
+
+SUBMIT_JSON="${ART_DIR}/submit.json"
+http_code="$(curl -sS -o "${SUBMIT_JSON}" -w "%{http_code}" \
+  -X POST -H "Content-Type: application/json" -H "Accept: application/json" \
+  --data-binary @"${SUBMIT_PAYLOAD}" \
+  "${API_BASE}/api/v0.3/attempts/submit" || true)"
+if [[ "${http_code}" != "200" ]]; then
+  echo "submit_failed http=${http_code}" >&2
+  cat "${SUBMIT_JSON}" >&2 || true
+  fail "submit failed"
+fi
+
+php -r '
+$j = json_decode(file_get_contents($argv[1]), true);
+if (!is_array($j) || !($j["ok"] ?? false)) {
+    fwrite(STDERR, "submit_response_not_ok\n");
+    exit(1);
+}
+' "${SUBMIT_JSON}" || fail "submit response invalid"
+
+AUTHORIZED_REPORT_JSON="${ART_DIR}/report_authorized.json"
+http_code="$(curl -sS -o "${AUTHORIZED_REPORT_JSON}" -w "%{http_code}" \
+  -H "Accept: application/json" \
+  -H "X-Anon-Id: ${ANON_ID}" \
+  "${API_BASE}/api/v0.2/attempts/${ATTEMPT_ID}/report" || true)"
+if [[ "${http_code}" != "200" ]]; then
+  echo "authorized_report_failed http=${http_code}" >&2
+  cat "${AUTHORIZED_REPORT_JSON}" >&2 || true
+  fail "authorized report failed"
+fi
+
+php -r '
+$j = json_decode(file_get_contents($argv[1]), true);
+if (!is_array($j) || !($j["ok"] ?? false)) {
+    fwrite(STDERR, "authorized_report_not_ok\n");
+    exit(1);
+}
+' "${AUTHORIZED_REPORT_JSON}" || fail "authorized report response invalid"
+
+NO_OWNER_REPORT_JSON="${ART_DIR}/report_no_owner.json"
+http_code="$(curl -sS -o "${NO_OWNER_REPORT_JSON}" -w "%{http_code}" \
+  -H "Accept: application/json" \
+  "${API_BASE}/api/v0.2/attempts/${ATTEMPT_ID}/report" || true)"
+echo "no_owner_http_code=${http_code}" > "${ART_DIR}/security_assertions.txt"
+if [[ "${http_code}" != "404" ]]; then
+  cat "${NO_OWNER_REPORT_JSON}" >&2 || true
+  fail "report without owner must return 404"
+fi
+
+WRONG_OWNER_REPORT_JSON="${ART_DIR}/report_wrong_owner.json"
+http_code="$(curl -sS -o "${WRONG_OWNER_REPORT_JSON}" -w "%{http_code}" \
+  -H "Accept: application/json" \
+  -H "X-Anon-Id: wrong-anon-pr34" \
+  "${API_BASE}/api/v0.2/attempts/${ATTEMPT_ID}/report" || true)"
+echo "wrong_owner_http_code=${http_code}" >> "${ART_DIR}/security_assertions.txt"
+if [[ "${http_code}" != "404" ]]; then
+  cat "${WRONG_OWNER_REPORT_JSON}" >&2 || true
+  fail "report with wrong owner must return 404"
+fi
+
+if [[ -n "${SERVE_PID:-}" ]] && ps -p "${SERVE_PID}" >/dev/null 2>&1; then
+  kill "${SERVE_PID}" >/dev/null 2>&1 || true
+fi
+cleanup_port "${SERVE_PORT}"
+if lsof -nP -iTCP:"${SERVE_PORT}" -sTCP:LISTEN >/dev/null 2>&1; then
+  fail "serve port not released: ${SERVE_PORT}"
+fi
+unset SERVE_PID
+
+echo "[PR34] verify ok"

--- a/backend/tests/Feature/V0_2/AttemptReportOwnershipTest.php
+++ b/backend/tests/Feature/V0_2/AttemptReportOwnershipTest.php
@@ -1,0 +1,161 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\V0_2;
+
+use App\Models\Attempt;
+use App\Models\ReportJob;
+use App\Models\Result;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Str;
+use Tests\TestCase;
+
+final class AttemptReportOwnershipTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_report_requires_owner_when_no_token_and_no_anon_id(): void
+    {
+        $attemptId = $this->seedReportFixture();
+
+        $this->getJson("/api/v0.2/attempts/{$attemptId}/report")
+            ->assertStatus(404);
+    }
+
+    public function test_report_returns_404_for_wrong_anon_id(): void
+    {
+        $attemptId = $this->seedReportFixture();
+
+        $this->withHeader('X-Anon-Id', 'anon_wrong_owner')
+            ->getJson("/api/v0.2/attempts/{$attemptId}/report")
+            ->assertStatus(404);
+    }
+
+    public function test_report_returns_200_for_correct_anon_id(): void
+    {
+        $attemptId = $this->seedReportFixture();
+
+        $this->withHeader('X-Anon-Id', 'anon_pr34_owner')
+            ->getJson("/api/v0.2/attempts/{$attemptId}/report")
+            ->assertStatus(200)
+            ->assertJson([
+                'ok' => true,
+                'attempt_id' => $attemptId,
+            ]);
+    }
+
+    public function test_report_returns_200_for_fm_token_owner(): void
+    {
+        $attemptId = $this->seedReportFixture();
+        $token = 'fm_' . (string) Str::uuid();
+
+        DB::table('fm_tokens')->insert([
+            'token' => $token,
+            'anon_id' => 'anon_bound_from_token',
+            'user_id' => 1001,
+            'expires_at' => now()->addHour(),
+            'created_at' => now(),
+            'updated_at' => now(),
+        ]);
+
+        $this->withHeader('Authorization', "Bearer {$token}")
+            ->getJson("/api/v0.2/attempts/{$attemptId}/report")
+            ->assertStatus(200)
+            ->assertJson([
+                'ok' => true,
+                'attempt_id' => $attemptId,
+            ]);
+    }
+
+    private function seedReportFixture(): string
+    {
+        $attemptId = (string) Str::uuid();
+        $anonId = 'anon_pr34_owner';
+        $userId = '1001';
+
+        Attempt::create([
+            'id' => $attemptId,
+            'org_id' => 0,
+            'anon_id' => $anonId,
+            'user_id' => $userId,
+            'scale_code' => 'MBTI',
+            'scale_version' => 'v0.2',
+            'region' => 'CN_MAINLAND',
+            'locale' => 'zh-CN',
+            'question_count' => 144,
+            'answers_summary_json' => ['seed' => true],
+            'client_platform' => 'test',
+            'client_version' => '1.0.0',
+            'channel' => 'test',
+            'started_at' => now(),
+            'submitted_at' => now(),
+            'pack_id' => (string) config('content_packs.default_pack_id'),
+            'dir_version' => (string) config('content_packs.default_dir_version'),
+            'content_package_version' => 'v0.2.2',
+            'scoring_spec_version' => '2026.01',
+        ]);
+
+        Result::create([
+            'id' => (string) Str::uuid(),
+            'org_id' => 0,
+            'attempt_id' => $attemptId,
+            'scale_code' => 'MBTI',
+            'scale_version' => 'v0.2',
+            'type_code' => 'INTJ-A',
+            'scores_json' => [
+                'EI' => ['a' => 10, 'b' => 10, 'sum' => 0, 'total' => 20],
+                'SN' => ['a' => 10, 'b' => 10, 'sum' => 0, 'total' => 20],
+                'TF' => ['a' => 10, 'b' => 10, 'sum' => 0, 'total' => 20],
+                'JP' => ['a' => 10, 'b' => 10, 'sum' => 0, 'total' => 20],
+                'AT' => ['a' => 10, 'b' => 10, 'sum' => 0, 'total' => 20],
+            ],
+            'scores_pct' => [
+                'EI' => 50,
+                'SN' => 50,
+                'TF' => 50,
+                'JP' => 50,
+                'AT' => 50,
+            ],
+            'axis_states' => [
+                'EI' => 'clear',
+                'SN' => 'clear',
+                'TF' => 'clear',
+                'JP' => 'clear',
+                'AT' => 'clear',
+            ],
+            'profile_version' => 'mbti32-v2.5',
+            'content_package_version' => 'v0.2.2',
+            'pack_id' => (string) config('content_packs.default_pack_id'),
+            'dir_version' => (string) config('content_packs.default_dir_version'),
+            'scoring_spec_version' => '2026.01',
+            'report_engine_version' => 'v1.2',
+            'is_valid' => true,
+            'computed_at' => now(),
+        ]);
+
+        ReportJob::create([
+            'id' => (string) Str::uuid(),
+            'org_id' => 0,
+            'attempt_id' => $attemptId,
+            'status' => 'success',
+            'tries' => 1,
+            'available_at' => now(),
+            'started_at' => now(),
+            'finished_at' => now(),
+            'report_json' => [
+                'profile' => [
+                    'type_code' => 'INTJ-A',
+                ],
+                'highlights' => [],
+                'tags' => [],
+            ],
+            'meta' => [
+                'seed' => 'pr34',
+            ],
+        ]);
+
+        return $attemptId;
+    }
+}

--- a/backend/tests/Unit/Services/ContentPackResolverCacheTest.php
+++ b/backend/tests/Unit/Services/ContentPackResolverCacheTest.php
@@ -1,0 +1,64 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Services;
+
+use App\Services\Content\ContentLoaderService;
+use App\Services\ContentPackResolver;
+use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Facades\File;
+use Tests\TestCase;
+
+final class ContentPackResolverCacheTest extends TestCase
+{
+    public function test_load_json_is_cached_until_forget(): void
+    {
+        $packId = 'MBTI.cn-mainland.zh-CN.v-cache';
+        $dirVersion = 'MBTI-CN-v-cache';
+
+        $root = sys_get_temp_dir() . '/pr34_content_pack_' . uniqid('', true);
+        $packDir = $root . DIRECTORY_SEPARATOR . $dirVersion;
+        File::ensureDirectoryExists($packDir);
+
+        file_put_contents($packDir . DIRECTORY_SEPARATOR . 'manifest.json', json_encode([
+            'pack_id' => $packId,
+            'scale_code' => 'MBTI',
+            'region' => 'CN_MAINLAND',
+            'locale' => 'zh-CN',
+            'content_package_version' => 'v-cache',
+        ], JSON_UNESCAPED_UNICODE));
+        file_put_contents($packDir . DIRECTORY_SEPARATOR . 'cache-target.json', json_encode([
+            'value' => 'v1',
+        ], JSON_UNESCAPED_UNICODE));
+
+        config()->set('content_packs.root', $root);
+        config()->set('content_packs.default_pack_id', $packId);
+        config()->set('content_packs.default_region', 'CN_MAINLAND');
+        config()->set('content_packs.default_locale', 'zh-CN');
+        config()->set('content_packs.loader_cache_ttl_seconds', 600);
+        config()->set('content_packs.loader_cache_store', 'array');
+
+        $resolver = new ContentPackResolver();
+        $resolved = $resolver->resolve('MBTI', 'CN_MAINLAND', 'zh-CN', 'v-cache');
+        $readJson = $resolved->loaders['readJson'];
+
+        $first = $readJson('cache-target.json');
+        $this->assertSame('v1', $first['value'] ?? null);
+
+        file_put_contents($packDir . DIRECTORY_SEPARATOR . 'cache-target.json', json_encode([
+            'value' => 'v2',
+        ], JSON_UNESCAPED_UNICODE));
+
+        $second = $readJson('cache-target.json');
+        $this->assertSame('v1', $second['value'] ?? null);
+
+        $loader = app(ContentLoaderService::class);
+        Cache::forget($loader->makeCacheKey($packId, $dirVersion, 'cache-target.json'));
+
+        $third = $readJson('cache-target.json');
+        $this->assertSame('v2', $third['value'] ?? null);
+
+        File::deleteDirectory($root);
+    }
+}

--- a/docs/verify/pr34_recon.md
+++ b/docs/verify/pr34_recon.md
@@ -1,0 +1,36 @@
+# PR34 Recon
+
+- Keywords: ContentPackResolver|file_get_contents|getReport
+
+- 相关入口文件（命中 KEY_RE 后补齐）：
+  - backend/app/Services/ContentPackResolver.php（legacy：fallback + loadJson/loadText 热路径）
+  - backend/app/Services/Content/ContentStore.php（hot_redis 资产缓存策略）
+  - backend/app/Http/Controllers/MbtiController.php（/api/v0.2/attempts/{id}/report）
+  - backend/app/Http/Middleware/FmTokenOptional.php（fm_user_id / fm_anon_id 注入）
+  - backend/routes/api.php（v0.2 路由与 middleware 口径）
+  - backend/config/cache.php（hot_redis store）
+  - backend/config/content_packs.php（TTL/store 参数）
+
+- 相关路由：
+  - GET  /api/v0.2/scales/MBTI/questions
+  - POST /api/v0.2/attempts
+  - GET  /api/v0.2/attempts/{attempt_id}/report
+  - POST /api/v0.2/shares
+  - GET  /api/v0.2/shares/{share_id}/click
+
+- 相关 DB 表/迁移：
+  - attempts
+  - shares
+  - fm_tokens
+  - (按需) cache_keys / redis keys（仅缓存层，不入库）
+
+- 需要新增/修改点：
+  - ContentLoaderService：Cache::remember 统一缓存读盘（pack_id + dir_version + rel_path → key）
+  - ContentPackResolver：fallback 扫描与 file_get_contents 只在 cache miss 执行
+  - MbtiController::getReport：IDOR 防护（owner 校验失败统一 404）
+
+- 风险点与规避（端口/CI 工具依赖/pack-seed-config 一致性/sqlite 迁移一致性/404 口径/脱敏）：
+  - 缓存 key 禁止写入绝对路径；key 使用 pack_id + dir_version + rel_path 的 hash
+  - testing 环境 cache store 走 array；生产环境走 hot_redis/redis
+  - 越权与匿名缺省访问统一 404，避免 attempt_id 枚举侧信道
+  - artifacts 必须脱敏（绝对路径、token、Authorization）

--- a/docs/verify/pr34_verify.md
+++ b/docs/verify/pr34_verify.md
@@ -1,0 +1,33 @@
+# PR34 Verify
+
+- Date: 2026-02-06
+- Commands:
+  - bash backend/scripts/pr34_accept.sh
+  - bash backend/scripts/ci_verify_mbti.sh
+- Result:
+  - pr34_accept: PASS
+  - ci_verify_mbti: PASS
+- Artifacts:
+  - backend/artifacts/pr34/summary.txt
+  - backend/artifacts/pr34/verify.log
+  - backend/artifacts/verify_mbti/summary.txt
+  - backend/artifacts/verify_mbti/logs/overrides_accept_D.log
+
+Key Notes
+
+- report owner guard verified:
+  - no owner => 404
+  - wrong owner => 404
+  - correct anon_id or token owner => 200
+- content loader cache verified:
+  - first read returns v1
+  - cache hit keeps v1 after file overwrite
+  - Cache::forget then returns v2
+
+Step Verification Commands
+
+1. Step 1 (routes): php artisan route:list
+2. Step 2 (migrations): php artisan migrate
+3. Step 3 (middleware): php -l backend/app/Http/Middleware/FmTokenAuth.php
+4. Step 4 (controllers/services/tests): php artisan test tests/Unit/Services/ContentPackResolverCacheTest.php tests/Feature/V0_2/AttemptReportOwnershipTest.php
+5. Step 5 (scripts/CI): bash -n backend/scripts/pr34_verify.sh && bash -n backend/scripts/pr34_accept.sh && bash backend/scripts/pr34_accept.sh && bash backend/scripts/ci_verify_mbti.sh


### PR DESCRIPTION
What:

Introduce cached content loading in resolver hot path and enforce owner-based access guard for v0.2 report endpoint with unified 404 behavior.
Why:

Reduce repeated filesystem reads in content resolve/load paths and stabilize cache behavior across redis/array environments.
Prevent IDOR/resource-enumeration on report endpoint by requiring anon/user ownership match.
How:

Add [ContentLoaderService.php](app://-/index.html#) (Cache::remember, hashed key by pack_id|dir_version|rel_path, testing fallback store).
Refactor [ContentPackResolver.php](app://-/index.html#) loaders to use ContentLoaderService and propagate dir_version in fallback chain.
Update [MbtiController.php](app://-/index.html#) getReport with owner resolution priority: attributes -> X-Anon-Id -> query anon_id; mismatch/missing owner => 404.
Add tests:
[ContentPackResolverCacheTest.php](app://-/index.html#)
[AttemptReportOwnershipTest.php](app://-/index.html#)
Add acceptance scripts:
[pr34_verify.sh](app://-/index.html#)
[pr34_accept.sh](app://-/index.html#)
Align CI verification scripts with owner-guard semantics:
[verify_mbti.sh](app://-/index.html#)
[ci_verify_mbti.sh](app://-/index.html#)
[accept_events_C.sh](app://-/index.html#)
[accept_events_G_report_view_meta.sh](app://-/index.html#)