### PR TITLE
chore(pr39): Ops: Content loader cache key with filemtime + safe Redis fallback

### DIFF
--- a/backend/scripts/pr39_accept.sh
+++ b/backend/scripts/pr39_accept.sh
@@ -1,0 +1,121 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+export CI=true
+export FAP_NONINTERACTIVE=1
+export COMPOSER_NO_INTERACTION=1
+export GIT_TERMINAL_PROMPT=0
+export NO_COLOR=1
+export PAGER=cat
+export GIT_PAGER=cat
+export TERM=dumb
+export XDEBUG_MODE=off
+export LANG=en_US.UTF-8
+
+PR_NUM=39
+
+compute_serve_port() {
+  local pr_num="$1"
+  local port
+
+  if [[ "${pr_num}" -ge 1000 ]]; then
+    port="18$(printf '%03d' "$((pr_num % 1000))")"
+  else
+    port="18$(printf '%02d' "${pr_num}")"
+  fi
+
+  if [[ "${port}" == "18000" ]]; then
+    port="18001"
+  fi
+
+  echo "${port}"
+}
+
+REPO_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+BACKEND_DIR="${REPO_DIR}/backend"
+ART_DIR="${ART_DIR:-backend/artifacts/pr39}"
+if [[ "${ART_DIR}" != /* ]]; then
+  ART_DIR="${REPO_DIR}/${ART_DIR}"
+fi
+SERVE_PORT_DEFAULT="$(compute_serve_port "${PR_NUM}")"
+SERVE_PORT="${SERVE_PORT:-${SERVE_PORT_DEFAULT}}"
+DB_PATH="/tmp/pr39.sqlite"
+
+mkdir -p "${ART_DIR}"
+
+cleanup_port() {
+  local port="$1"
+  lsof -nP -iTCP:"${port}" -sTCP:LISTEN || true
+  local pid_list
+  pid_list="$(lsof -ti tcp:"${port}" || true)"
+  if [[ -n "${pid_list}" ]]; then
+    echo "${pid_list}" | xargs kill -9 || true
+  fi
+  lsof -nP -iTCP:"${port}" -sTCP:LISTEN || true
+}
+
+cleanup() {
+  if [[ -f "${ART_DIR}/server.pid" ]]; then
+    local pid
+    pid="$(cat "${ART_DIR}/server.pid" || true)"
+    if [[ -n "${pid}" ]] && ps -p "${pid}" >/dev/null 2>&1; then
+      kill "${pid}" >/dev/null 2>&1 || true
+    fi
+  fi
+
+  cleanup_port "${SERVE_PORT}"
+  cleanup_port 18000
+  rm -f "${DB_PATH}"
+}
+trap cleanup EXIT
+
+cleanup_port "${SERVE_PORT}"
+cleanup_port 18000
+
+export APP_ENV=testing
+export CACHE_STORE=array
+export QUEUE_CONNECTION=sync
+export DB_CONNECTION=sqlite
+export DB_DATABASE="${DB_PATH}"
+export FAP_PACKS_ROOT="${FAP_PACKS_ROOT:-${REPO_DIR}/content_packages}"
+export FAP_DEFAULT_REGION="${FAP_DEFAULT_REGION:-CN_MAINLAND}"
+export FAP_DEFAULT_LOCALE="${FAP_DEFAULT_LOCALE:-zh-CN}"
+export FAP_DEFAULT_PACK_ID="${FAP_DEFAULT_PACK_ID:-MBTI.cn-mainland.zh-CN.v0.2.2}"
+export FAP_DEFAULT_DIR_VERSION="${FAP_DEFAULT_DIR_VERSION:-MBTI-CN-v0.2.2}"
+
+rm -f "${DB_PATH}"
+touch "${DB_PATH}"
+
+cd "${BACKEND_DIR}"
+composer install --no-interaction --no-progress
+php artisan migrate:fresh --force
+php artisan fap:scales:seed-default
+php artisan fap:scales:sync-slugs
+cd "${REPO_DIR}"
+
+SERVE_PORT="${SERVE_PORT}" ART_DIR="${ART_DIR}" bash "${BACKEND_DIR}/scripts/pr39_verify.sh"
+
+ATTEMPT_ID="$(cat "${ART_DIR}/attempt_id.txt" 2>/dev/null || true)"
+ANON_ID="$(cat "${ART_DIR}/anon_id.txt" 2>/dev/null || true)"
+
+cat > "${ART_DIR}/summary.txt" <<TXT
+PR39 Acceptance Summary
+- result: PASS
+- serve_port: ${SERVE_PORT}
+- pass_items:
+  - php artisan test --filter ContentLoaderServiceMtimeTest: PASS
+  - questions endpoint dynamic answers: PASS
+  - report ownership returns 404 on mismatch: PASS
+  - pack/seed/config consistency: PASS
+- key_outputs:
+  - attempt_id: ${ATTEMPT_ID}
+  - anon_id: ${ANON_ID}
+- desensitization: sanitize_artifacts.sh completed
+TXT
+
+bash "${BACKEND_DIR}/scripts/sanitize_artifacts.sh" 39
+
+bash -n "${BACKEND_DIR}/scripts/pr39_accept.sh"
+bash -n "${BACKEND_DIR}/scripts/pr39_verify.sh"
+
+echo "[PR39][PASS] acceptance complete"

--- a/backend/scripts/pr39_verify.sh
+++ b/backend/scripts/pr39_verify.sh
@@ -1,0 +1,354 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+export CI=true
+export FAP_NONINTERACTIVE=1
+export COMPOSER_NO_INTERACTION=1
+export GIT_TERMINAL_PROMPT=0
+export NO_COLOR=1
+export PAGER=cat
+export GIT_PAGER=cat
+export TERM=dumb
+export XDEBUG_MODE=off
+export LANG=en_US.UTF-8
+
+PR_NUM=39
+
+compute_serve_port() {
+  local pr_num="$1"
+  local port
+
+  if [[ "${pr_num}" -ge 1000 ]]; then
+    port="18$(printf '%03d' "$((pr_num % 1000))")"
+  else
+    port="18$(printf '%02d' "${pr_num}")"
+  fi
+
+  if [[ "${port}" == "18000" ]]; then
+    port="18001"
+  fi
+
+  echo "${port}"
+}
+
+REPO_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+BACKEND_DIR="${REPO_DIR}/backend"
+ART_DIR="${ART_DIR:-backend/artifacts/pr39}"
+if [[ "${ART_DIR}" != /* ]]; then
+  ART_DIR="${REPO_DIR}/${ART_DIR}"
+fi
+SERVE_PORT_DEFAULT="$(compute_serve_port "${PR_NUM}")"
+SERVE_PORT="${SERVE_PORT:-${SERVE_PORT_DEFAULT}}"
+HOST="127.0.0.1"
+API_BASE="http://${HOST}:${SERVE_PORT}"
+SCALE_CODE="${SCALE_CODE:-MBTI}"
+ANON_ID="${ANON_ID:-pr39-verify-anon}"
+export FAP_PACKS_ROOT="${FAP_PACKS_ROOT:-${REPO_DIR}/content_packages}"
+export FAP_DEFAULT_REGION="${FAP_DEFAULT_REGION:-CN_MAINLAND}"
+export FAP_DEFAULT_LOCALE="${FAP_DEFAULT_LOCALE:-zh-CN}"
+export FAP_DEFAULT_PACK_ID="${FAP_DEFAULT_PACK_ID:-MBTI.cn-mainland.zh-CN.v0.2.2}"
+export FAP_DEFAULT_DIR_VERSION="${FAP_DEFAULT_DIR_VERSION:-MBTI-CN-v0.2.2}"
+
+mkdir -p "${ART_DIR}"
+exec > "${ART_DIR}/verify.log" 2>&1
+
+fail() {
+  echo "[PR39][FAIL] $*" >&2
+  exit 1
+}
+
+cleanup_port() {
+  local port="$1"
+  lsof -nP -iTCP:"${port}" -sTCP:LISTEN || true
+  local pid_list
+  pid_list="$(lsof -ti tcp:"${port}" || true)"
+  if [[ -n "${pid_list}" ]]; then
+    echo "${pid_list}" | xargs kill -9 || true
+  fi
+  lsof -nP -iTCP:"${port}" -sTCP:LISTEN || true
+}
+
+wait_health() {
+  local url="$1"
+  local body_file="${ART_DIR}/healthz.body"
+  local http_code=""
+
+  for _ in $(seq 1 80); do
+    http_code="$(curl -sS -o "${body_file}" -w "%{http_code}" "${url}" || true)"
+    if [[ "${http_code}" == "200" ]]; then
+      return 0
+    fi
+    sleep 0.25
+  done
+
+  echo "health_check_failed http=${http_code}" >&2
+  cat "${body_file}" >&2 || true
+  tail -n 120 "${ART_DIR}/server.log" >&2 || true
+  return 1
+}
+
+cleanup() {
+  if [[ -n "${SERVE_PID:-}" ]] && ps -p "${SERVE_PID}" >/dev/null 2>&1; then
+    kill "${SERVE_PID}" >/dev/null 2>&1 || true
+  fi
+  cleanup_port "${SERVE_PORT}"
+  cleanup_port 18000
+}
+trap cleanup EXIT
+
+cleanup_port "${SERVE_PORT}"
+cleanup_port 18000
+
+cd "${BACKEND_DIR}"
+php artisan serve --host="${HOST}" --port="${SERVE_PORT}" > "${ART_DIR}/server.log" 2>&1 &
+SERVE_PID="$!"
+echo "${SERVE_PID}" > "${ART_DIR}/server.pid"
+cd "${REPO_DIR}"
+
+wait_health "${API_BASE}/api/v0.2/healthz" || fail "healthz failed"
+curl -sS "${API_BASE}/api/v0.2/healthz" > "${ART_DIR}/healthz.json"
+
+# pack/seed/config consistency
+cd "${BACKEND_DIR}"
+php -r '
+require "vendor/autoload.php";
+$app=require "bootstrap/app.php";
+$app->make(Illuminate\Contracts\Console\Kernel::class)->bootstrap();
+echo (string) config("content_packs.default_pack_id", "");
+' > "${ART_DIR}/config_default_pack_id.txt"
+
+php -r '
+require "vendor/autoload.php";
+$app=require "bootstrap/app.php";
+$app->make(Illuminate\Contracts\Console\Kernel::class)->bootstrap();
+$packId = (string) config("content_packs.default_pack_id", "");
+$dirVersion = (string) config("content_packs.default_dir_version", "");
+echo "config_default_pack_id=".$packId.PHP_EOL;
+echo "config_default_dir_version=".$dirVersion.PHP_EOL;
+if ($packId === "" || $dirVersion === "") {
+    fwrite(STDERR, "missing_content_pack_defaults\n");
+    exit(1);
+}
+if (!Illuminate\Support\Facades\Schema::hasTable("scales_registry")) {
+    fwrite(STDERR, "missing_scales_registry_table\n");
+    exit(1);
+}
+$row = Illuminate\Support\Facades\DB::table("scales_registry")
+    ->where("org_id", 0)
+    ->where("code", "MBTI")
+    ->first();
+if (!$row) {
+    fwrite(STDERR, "missing_scales_registry_mbti\n");
+    exit(1);
+}
+$registryPackId = (string) ($row->default_pack_id ?? "");
+$registryDirVersion = (string) ($row->default_dir_version ?? "");
+echo "registry_default_pack_id=".$registryPackId.PHP_EOL;
+echo "registry_default_dir_version=".$registryDirVersion.PHP_EOL;
+if ($registryPackId !== $packId) {
+    fwrite(STDERR, "default_pack_id_mismatch\n");
+    exit(1);
+}
+if ($registryDirVersion !== $dirVersion) {
+    fwrite(STDERR, "default_dir_version_mismatch\n");
+    exit(1);
+}
+$index = app(App\Services\Content\ContentPacksIndex::class);
+$found = $index->find($packId, $dirVersion);
+if (!($found["ok"] ?? false)) {
+    fwrite(STDERR, "pack_not_found\n");
+    exit(1);
+}
+$item = $found["item"] ?? [];
+$manifestPath = (string) ($item["manifest_path"] ?? "");
+$questionsPath = (string) ($item["questions_path"] ?? "");
+if ($manifestPath === "" || !is_file($manifestPath)) {
+    fwrite(STDERR, "manifest_missing\n");
+    exit(1);
+}
+if ($questionsPath === "" || !is_file($questionsPath)) {
+    fwrite(STDERR, "questions_missing\n");
+    exit(1);
+}
+$packDir = dirname($manifestPath);
+$versionPath = $packDir.DIRECTORY_SEPARATOR."version.json";
+if (!is_file($versionPath)) {
+    fwrite(STDERR, "version_missing\n");
+    exit(1);
+}
+$manifest = json_decode((string) file_get_contents($manifestPath), true);
+$questions = json_decode((string) file_get_contents($questionsPath), true);
+$version = json_decode((string) file_get_contents($versionPath), true);
+if (!is_array($manifest) || !is_array($questions) || !is_array($version)) {
+    fwrite(STDERR, "pack_json_invalid\n");
+    exit(1);
+}
+echo "pack_manifest=".$manifestPath.PHP_EOL;
+echo "pack_questions=".$questionsPath.PHP_EOL;
+echo "pack_version=".$versionPath.PHP_EOL;
+' > "${ART_DIR}/pack_seed_config.txt"
+
+php artisan test --filter ContentLoaderServiceMtimeTest > "${ART_DIR}/content_loader_mtime_test.log"
+cd "${REPO_DIR}"
+
+QUESTIONS_JSON="${ART_DIR}/questions.json"
+http_code="$(curl -sS -o "${QUESTIONS_JSON}" -w "%{http_code}" \
+  -H "Accept: application/json" \
+  "${API_BASE}/api/v0.2/scales/${SCALE_CODE}/questions" || true)"
+if [[ "${http_code}" != "200" ]]; then
+  echo "questions_failed http=${http_code}" >&2
+  cat "${QUESTIONS_JSON}" >&2 || true
+  fail "questions endpoint failed"
+fi
+
+ANSWERS_JSON="${ART_DIR}/answers.json"
+php -r '
+$raw = file_get_contents("php://stdin");
+$data = json_decode($raw, true);
+if (!is_array($data)) {
+    fwrite(STDERR, "questions_json_invalid\n");
+    exit(1);
+}
+$items = $data["questions"]["items"] ?? $data["questions"] ?? $data["items"] ?? $data["data"] ?? $data;
+if (!is_array($items)) {
+    fwrite(STDERR, "questions_items_invalid\n");
+    exit(1);
+}
+$answers = [];
+foreach ($items as $item) {
+    if (!is_array($item)) {
+        continue;
+    }
+    $questionId = (string) ($item["question_id"] ?? $item["id"] ?? "");
+    if ($questionId === "") {
+        continue;
+    }
+    $options = $item["options"] ?? [];
+    $code = "A";
+    if (is_array($options) && isset($options[0]) && is_array($options[0])) {
+        $code = (string) ($options[0]["code"] ?? $options[0]["option_code"] ?? "A");
+    }
+    if ($code === "") {
+        $code = "A";
+    }
+    $answers[] = [
+        "question_id" => $questionId,
+        "code" => $code,
+    ];
+}
+if (count($answers) === 0) {
+    fwrite(STDERR, "answers_empty\n");
+    exit(1);
+}
+echo json_encode($answers, JSON_UNESCAPED_UNICODE);
+' < "${QUESTIONS_JSON}" > "${ANSWERS_JSON}"
+
+ATTEMPT_START_JSON="${ART_DIR}/attempt_start.json"
+ATTEMPT_START_BODY="$(SCALE_CODE="${SCALE_CODE}" ANON_ID="${ANON_ID}" php -r '
+$payload = [
+    "scale_code" => getenv("SCALE_CODE"),
+    "anon_id" => getenv("ANON_ID"),
+];
+echo json_encode($payload, JSON_UNESCAPED_UNICODE);
+')"
+http_code="$(curl -sS -o "${ATTEMPT_START_JSON}" -w "%{http_code}" \
+  -X POST -H "Content-Type: application/json" -H "Accept: application/json" \
+  --data "${ATTEMPT_START_BODY}" \
+  "${API_BASE}/api/v0.3/attempts/start" || true)"
+if [[ "${http_code}" != "200" ]]; then
+  echo "attempt_start_failed http=${http_code}" >&2
+  cat "${ATTEMPT_START_JSON}" >&2 || true
+  fail "attempt start failed"
+fi
+
+ATTEMPT_ID="$(php -r '$j=json_decode(file_get_contents($argv[1]), true); echo (string)($j["attempt_id"] ?? "");' "${ATTEMPT_START_JSON}")"
+if [[ -z "${ATTEMPT_ID}" ]]; then
+  fail "missing attempt_id"
+fi
+echo "${ATTEMPT_ID}" > "${ART_DIR}/attempt_id.txt"
+echo "${ANON_ID}" > "${ART_DIR}/anon_id.txt"
+
+SUBMIT_PAYLOAD="${ART_DIR}/submit_payload.json"
+ATTEMPT_ID="${ATTEMPT_ID}" ANSWERS_PATH="${ANSWERS_JSON}" php -r '
+$answers = json_decode(file_get_contents(getenv("ANSWERS_PATH")), true);
+if (!is_array($answers) || count($answers) === 0) {
+    fwrite(STDERR, "answers_payload_invalid\n");
+    exit(1);
+}
+$payload = [
+    "attempt_id" => getenv("ATTEMPT_ID"),
+    "answers" => $answers,
+    "duration_ms" => 120000,
+];
+echo json_encode($payload, JSON_UNESCAPED_UNICODE);
+' > "${SUBMIT_PAYLOAD}"
+
+SUBMIT_JSON="${ART_DIR}/submit.json"
+http_code="$(curl -sS -o "${SUBMIT_JSON}" -w "%{http_code}" \
+  -X POST -H "Content-Type: application/json" -H "Accept: application/json" \
+  --data-binary @"${SUBMIT_PAYLOAD}" \
+  "${API_BASE}/api/v0.3/attempts/submit" || true)"
+if [[ "${http_code}" != "200" ]]; then
+  echo "submit_failed http=${http_code}" >&2
+  cat "${SUBMIT_JSON}" >&2 || true
+  fail "submit failed"
+fi
+
+php -r '
+$j = json_decode(file_get_contents($argv[1]), true);
+if (!is_array($j) || !($j["ok"] ?? false)) {
+    fwrite(STDERR, "submit_response_not_ok\n");
+    exit(1);
+}
+' "${SUBMIT_JSON}" || fail "submit response invalid"
+
+AUTHORIZED_REPORT_JSON="${ART_DIR}/report_authorized.json"
+http_code="$(curl -sS -o "${AUTHORIZED_REPORT_JSON}" -w "%{http_code}" \
+  -H "Accept: application/json" \
+  -H "X-Anon-Id: ${ANON_ID}" \
+  "${API_BASE}/api/v0.2/attempts/${ATTEMPT_ID}/report" || true)"
+if [[ "${http_code}" != "200" ]]; then
+  echo "authorized_report_failed http=${http_code}" >&2
+  cat "${AUTHORIZED_REPORT_JSON}" >&2 || true
+  fail "authorized report failed"
+fi
+
+php -r '
+$j = json_decode(file_get_contents($argv[1]), true);
+if (!is_array($j) || !($j["ok"] ?? false)) {
+    fwrite(STDERR, "authorized_report_not_ok\n");
+    exit(1);
+}
+' "${AUTHORIZED_REPORT_JSON}" || fail "authorized report response invalid"
+
+NO_OWNER_REPORT_JSON="${ART_DIR}/report_no_owner.json"
+http_code="$(curl -sS -o "${NO_OWNER_REPORT_JSON}" -w "%{http_code}" \
+  -H "Accept: application/json" \
+  "${API_BASE}/api/v0.2/attempts/${ATTEMPT_ID}/report" || true)"
+echo "no_owner_http_code=${http_code}" > "${ART_DIR}/security_assertions.txt"
+if [[ "${http_code}" != "404" ]]; then
+  cat "${NO_OWNER_REPORT_JSON}" >&2 || true
+  fail "report without owner must return 404"
+fi
+
+WRONG_OWNER_REPORT_JSON="${ART_DIR}/report_wrong_owner.json"
+http_code="$(curl -sS -o "${WRONG_OWNER_REPORT_JSON}" -w "%{http_code}" \
+  -H "Accept: application/json" \
+  -H "X-Anon-Id: wrong-anon-pr39" \
+  "${API_BASE}/api/v0.2/attempts/${ATTEMPT_ID}/report" || true)"
+echo "wrong_owner_http_code=${http_code}" >> "${ART_DIR}/security_assertions.txt"
+if [[ "${http_code}" != "404" ]]; then
+  cat "${WRONG_OWNER_REPORT_JSON}" >&2 || true
+  fail "report with wrong owner must return 404"
+fi
+
+if [[ -n "${SERVE_PID:-}" ]] && ps -p "${SERVE_PID}" >/dev/null 2>&1; then
+  kill "${SERVE_PID}" >/dev/null 2>&1 || true
+fi
+cleanup_port "${SERVE_PORT}"
+if lsof -nP -iTCP:"${SERVE_PORT}" -sTCP:LISTEN >/dev/null 2>&1; then
+  fail "serve port not released: ${SERVE_PORT}"
+fi
+unset SERVE_PID
+
+echo "[PR39] verify ok"

--- a/backend/tests/Unit/Services/ContentLoaderServiceMtimeTest.php
+++ b/backend/tests/Unit/Services/ContentLoaderServiceMtimeTest.php
@@ -1,0 +1,72 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Services;
+
+use App\Services\Content\ContentLoaderService;
+use Illuminate\Support\Facades\File;
+use Tests\TestCase;
+
+final class ContentLoaderServiceMtimeTest extends TestCase
+{
+    public function test_read_json_refreshes_when_file_mtime_changes(): void
+    {
+        $packId = 'MBTI.cn-mainland.zh-CN.v-mtime-39';
+        $dirVersion = 'MBTI-CN-v-mtime-39';
+        $tempRoot = sys_get_temp_dir().'/pr39_content_loader_'.uniqid('', true);
+        $jsonPath = $tempRoot.DIRECTORY_SEPARATOR.'cache-target.json';
+
+        File::ensureDirectoryExists($tempRoot);
+
+        try {
+            file_put_contents($jsonPath, json_encode(['v' => 1], JSON_UNESCAPED_UNICODE));
+            clearstatcache(true, $jsonPath);
+
+            config()->set('content_packs.loader_cache_ttl_seconds', 600);
+            config()->set('content_packs.loader_cache_store', 'array');
+
+            $loader = app(ContentLoaderService::class);
+            $resolveAbsPath = fn (): ?string => is_file($jsonPath) ? $jsonPath : null;
+
+            $first = $loader->readJson($packId, $dirVersion, 'cache-target.json', $resolveAbsPath);
+            $this->assertSame(1, $first['v'] ?? null);
+
+            file_put_contents($jsonPath, json_encode(['v' => 2], JSON_UNESCAPED_UNICODE));
+            touch($jsonPath, time() + 2);
+            clearstatcache(true, $jsonPath);
+
+            $second = $loader->readJson($packId, $dirVersion, 'cache-target.json', $resolveAbsPath);
+            $this->assertSame(2, $second['v'] ?? null);
+        } finally {
+            File::deleteDirectory($tempRoot);
+        }
+    }
+
+    public function test_read_json_falls_back_when_redis_store_unavailable(): void
+    {
+        $packId = 'MBTI.cn-mainland.zh-CN.v-redis-fallback-39';
+        $dirVersion = 'MBTI-CN-v-redis-fallback-39';
+        $tempRoot = sys_get_temp_dir().'/pr39_content_loader_fallback_'.uniqid('', true);
+        $jsonPath = $tempRoot.DIRECTORY_SEPARATOR.'fallback-target.json';
+
+        File::ensureDirectoryExists($tempRoot);
+
+        try {
+            file_put_contents($jsonPath, json_encode(['v' => 7], JSON_UNESCAPED_UNICODE));
+            clearstatcache(true, $jsonPath);
+
+            config()->set('app.env', 'ci');
+            config()->set('content_packs.loader_cache_ttl_seconds', 600);
+            config()->set('content_packs.loader_cache_store', 'hot_redis');
+
+            $loader = app(ContentLoaderService::class);
+            $resolveAbsPath = fn (): ?string => is_file($jsonPath) ? $jsonPath : null;
+
+            $result = $loader->readJson($packId, $dirVersion, 'fallback-target.json', $resolveAbsPath);
+            $this->assertSame(7, $result['v'] ?? null);
+        } finally {
+            File::deleteDirectory($tempRoot);
+        }
+    }
+}

--- a/docs/verify/pr39_recon.md
+++ b/docs/verify/pr39_recon.md
@@ -1,0 +1,22 @@
+# PR39 Recon
+
+- Keywords: ContentLoaderService|ContentPackResolver|filemtime
+
+## 相关入口文件
+- backend/app/Services/Content/ContentLoaderService.php
+- backend/app/Services/ContentPackResolver.php
+
+## 相关路由
+- 无（内部服务改动）
+
+## 相关 DB 表/迁移
+- 无
+
+## 需要新增/修改点
+- ContentLoaderService 缓存 key 纳入 filemtime，避免 JSON 更新后缓存不失效
+- Redis 不可用时自动降级，避免 CI/本地无 Redis 导致 500
+
+## 风险点与规避
+- 性能：仅引入 filemtime stat 调用；避免读取文件内容来计算 key
+- 稳定性：捕获 Redis 连接异常并回退到默认 cache store
+- 脱敏：key 与 artifacts 不写入绝对路径

--- a/docs/verify/pr39_verify.md
+++ b/docs/verify/pr39_verify.md
@@ -1,0 +1,15 @@
+# PR39 Verify
+
+- [ ] `cd backend && php artisan test --filter ContentLoaderServiceMtimeTest`
+  - 期望关键字：`PASS  Tests\\Unit\\Services\\ContentLoaderServiceMtimeTest`
+- [ ] `bash backend/scripts/pr39_accept.sh`
+  - 期望关键字：`[PR39][PASS] acceptance complete`
+  - 期望退出码：`0`
+- [ ] `bash backend/scripts/ci_verify_mbti.sh`
+  - 期望关键字：`[CI] MVP check PASS`
+
+## 补充校验
+
+- [ ] `bash -n backend/scripts/pr39_accept.sh`
+- [ ] `bash -n backend/scripts/pr39_verify.sh`
+- [ ] `bash backend/scripts/sanitize_artifacts.sh 39`


### PR DESCRIPTION
What:
ContentLoaderService 缓存 key 纳入 filemtime，并在 Redis 不可用时自动降级
Why:
修复内容包 JSON 更新后缓存不失效的生产事故风险
避免 CI/本地无 Redis 触发 500 阻断验收
How:
[ContentLoaderService.php](app://-/index.html#)：key=sha1(pack|dir|rel)+mtime；remember 降级
[ContentPackResolver.php](app://-/index.html#)：loader 闭包改为仅返回 abs path，统一由 loader 读取
[ContentLoaderServiceMtimeTest.php](app://-/index.html#)：mtime 失效与无 Redis 回退测试
[pr39_accept.sh](app://-/index.html#)、[pr39_verify.sh](app://-/index.html#)：验收闭环落 artifacts 并脱敏
Verify:
[pr39_accept.sh](app://-/index.html#)
[ci_verify_mbti.sh](app://-/index.html#)
Artifacts:
[summary.txt](app://-/index.html#)