### PR TITLE
chore(pr42): Security: strengthen audit log redaction

### DIFF
--- a/backend/app/Support/SensitiveDataRedactor.php
+++ b/backend/app/Support/SensitiveDataRedactor.php
@@ -1,0 +1,62 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Support;
+
+final class SensitiveDataRedactor
+{
+    private const REDACTED = '[REDACTED]';
+
+    /** @var list<string> */
+    private const SENSITIVE_KEY_PARTS = [
+        'token',
+        'secret',
+        'password',
+        'authorization',
+        'cookie',
+        'stripe-signature',
+        'client_secret',
+        'api_key',
+        'private_key',
+        'signature',
+    ];
+
+    /**
+     * @param array<mixed> $data
+     * @return array<mixed>
+     */
+    public function redact(array $data): array
+    {
+        $redacted = [];
+
+        foreach ($data as $key => $value) {
+            if ($this->isSensitiveKey($key)) {
+                $redacted[$key] = self::REDACTED;
+                continue;
+            }
+
+            if (is_array($value)) {
+                $redacted[$key] = $this->redact($value);
+                continue;
+            }
+
+            $redacted[$key] = $value;
+        }
+
+        return $redacted;
+    }
+
+    private function isSensitiveKey(int|string $key): bool
+    {
+        $lowerKey = strtolower((string) $key);
+
+        foreach (self::SENSITIVE_KEY_PARTS as $part) {
+            if ($part !== '' && str_contains($lowerKey, $part)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+}

--- a/backend/scripts/pr42_accept.sh
+++ b/backend/scripts/pr42_accept.sh
@@ -1,0 +1,100 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+export CI=true
+export FAP_NONINTERACTIVE=1
+export COMPOSER_NO_INTERACTION=1
+export GIT_TERMINAL_PROMPT=0
+export NO_COLOR=1
+export PAGER=cat
+export GIT_PAGER=cat
+export TERM=dumb
+export XDEBUG_MODE=off
+export LANG=en_US.UTF-8
+
+REPO_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+BACKEND_DIR="${REPO_DIR}/backend"
+ART_DIR="${BACKEND_DIR}/artifacts/pr42"
+SERVE_PORT="${SERVE_PORT:-1842}"
+DB_PATH="/tmp/pr42.sqlite"
+
+mkdir -p "${ART_DIR}"
+
+cleanup_port() {
+  local port="$1"
+  lsof -nP -iTCP:"${port}" -sTCP:LISTEN || true
+  local pid_list
+  pid_list="$(lsof -ti tcp:"${port}" || true)"
+  if [[ -n "${pid_list}" ]]; then
+    echo "${pid_list}" | xargs kill -9 || true
+  fi
+  lsof -nP -iTCP:"${port}" -sTCP:LISTEN || true
+}
+
+cleanup() {
+  if [[ -f "${ART_DIR}/server.pid" ]]; then
+    local pid
+    pid="$(cat "${ART_DIR}/server.pid" || true)"
+    if [[ -n "${pid}" ]] && ps -p "${pid}" >/dev/null 2>&1; then
+      kill "${pid}" >/dev/null 2>&1 || true
+    fi
+  fi
+  cleanup_port "${SERVE_PORT}"
+  cleanup_port 18000
+  rm -f "${DB_PATH}"
+}
+trap cleanup EXIT
+
+cleanup_port "${SERVE_PORT}"
+cleanup_port 18000
+
+export APP_ENV=testing
+export CACHE_STORE=array
+export QUEUE_CONNECTION=sync
+export DB_CONNECTION=sqlite
+export DB_DATABASE="${DB_PATH}"
+export FAP_PACKS_ROOT="${FAP_PACKS_ROOT:-${REPO_DIR}/content_packages}"
+export FAP_DEFAULT_REGION="${FAP_DEFAULT_REGION:-CN_MAINLAND}"
+export FAP_DEFAULT_LOCALE="${FAP_DEFAULT_LOCALE:-zh-CN}"
+export FAP_DEFAULT_PACK_ID="${FAP_DEFAULT_PACK_ID:-MBTI.cn-mainland.zh-CN.v0.2.2}"
+export FAP_DEFAULT_DIR_VERSION="${FAP_DEFAULT_DIR_VERSION:-MBTI-CN-v0.2.2}"
+
+rm -f "${DB_PATH}"
+touch "${DB_PATH}"
+
+cd "${BACKEND_DIR}"
+composer install --no-interaction --no-progress
+php artisan migrate:fresh --force
+php artisan fap:scales:seed-default
+php artisan fap:scales:sync-slugs
+cd "${REPO_DIR}"
+
+SERVE_PORT="${SERVE_PORT}" ART_DIR="${ART_DIR}" bash "${BACKEND_DIR}/scripts/pr42_verify.sh"
+
+ATTEMPT_ID="$(cat "${ART_DIR}/attempt_id.txt" 2>/dev/null || true)"
+ANON_ID="$(cat "${ART_DIR}/anon_id.txt" 2>/dev/null || true)"
+DEFAULT_PACK_ID="$(cat "${ART_DIR}/config_default_pack_id.txt" 2>/dev/null || true)"
+
+cat > "${ART_DIR}/summary.txt" <<TXT
+PR42 Acceptance Summary
+- pass_items:
+  - content_loader_cache: OK
+  - report_idor_guard: OK
+  - pack_seed_config_consistency: OK
+  - dynamic_answers_submit: OK
+  - phpunit(SensitiveDataRedactorTest): PASS
+- key_outputs:
+  - attempt_id: ${ATTEMPT_ID}
+  - anon_id: ${ANON_ID}
+  - default_pack_id: ${DEFAULT_PACK_ID}
+- smoke_urls:
+  - http://127.0.0.1:${SERVE_PORT}/api/v0.3/scales/MBTI/questions
+  - http://127.0.0.1:${SERVE_PORT}/api/v0.2/attempts/${ATTEMPT_ID}/report?anon_id=${ANON_ID}
+- schema_changes:
+  - none
+TXT
+
+bash "${BACKEND_DIR}/scripts/sanitize_artifacts.sh" 42
+
+bash -n "${BACKEND_DIR}/scripts/pr42_accept.sh"
+bash -n "${BACKEND_DIR}/scripts/pr42_verify.sh"

--- a/backend/scripts/pr42_verify.sh
+++ b/backend/scripts/pr42_verify.sh
@@ -1,0 +1,333 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+export CI=true
+export FAP_NONINTERACTIVE=1
+export COMPOSER_NO_INTERACTION=1
+export GIT_TERMINAL_PROMPT=0
+export NO_COLOR=1
+export PAGER=cat
+export GIT_PAGER=cat
+export TERM=dumb
+export XDEBUG_MODE=off
+export LANG=en_US.UTF-8
+
+REPO_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+BACKEND_DIR="${REPO_DIR}/backend"
+ART_DIR="${ART_DIR:-${BACKEND_DIR}/artifacts/pr42}"
+SERVE_PORT="${SERVE_PORT:-1842}"
+HOST="127.0.0.1"
+API_BASE="http://${HOST}:${SERVE_PORT}"
+SCALE_CODE="${SCALE_CODE:-MBTI}"
+ANON_ID="${ANON_ID:-pr42-verify-anon}"
+export FAP_PACKS_ROOT="${FAP_PACKS_ROOT:-${REPO_DIR}/content_packages}"
+export FAP_DEFAULT_REGION="${FAP_DEFAULT_REGION:-CN_MAINLAND}"
+export FAP_DEFAULT_LOCALE="${FAP_DEFAULT_LOCALE:-zh-CN}"
+export FAP_DEFAULT_PACK_ID="${FAP_DEFAULT_PACK_ID:-MBTI.cn-mainland.zh-CN.v0.2.2}"
+export FAP_DEFAULT_DIR_VERSION="${FAP_DEFAULT_DIR_VERSION:-MBTI-CN-v0.2.2}"
+
+mkdir -p "${ART_DIR}"
+exec > "${ART_DIR}/verify.log" 2>&1
+
+fail() {
+  echo "[PR42][FAIL] $*" >&2
+  exit 1
+}
+
+cleanup_port() {
+  local port="$1"
+  lsof -nP -iTCP:"${port}" -sTCP:LISTEN || true
+  local pid_list
+  pid_list="$(lsof -ti tcp:"${port}" || true)"
+  if [[ -n "${pid_list}" ]]; then
+    echo "${pid_list}" | xargs kill -9 || true
+  fi
+  lsof -nP -iTCP:"${port}" -sTCP:LISTEN || true
+}
+
+wait_health() {
+  local url="$1"
+  local body_file="${ART_DIR}/healthz.body"
+  local http_code=""
+
+  for _ in $(seq 1 80); do
+    http_code="$(curl -sS -o "${body_file}" -w "%{http_code}" "${url}" || true)"
+    if [[ "${http_code}" == "200" ]]; then
+      return 0
+    fi
+    sleep 0.25
+  done
+
+  echo "health_check_failed http=${http_code}" >&2
+  cat "${body_file}" >&2 || true
+  tail -n 120 "${ART_DIR}/server.log" >&2 || true
+  return 1
+}
+
+cleanup() {
+  if [[ -n "${SERVE_PID:-}" ]] && ps -p "${SERVE_PID}" >/dev/null 2>&1; then
+    kill "${SERVE_PID}" >/dev/null 2>&1 || true
+  fi
+  cleanup_port "${SERVE_PORT}"
+  cleanup_port 18000
+}
+trap cleanup EXIT
+
+cleanup_port "${SERVE_PORT}"
+cleanup_port 18000
+
+cd "${BACKEND_DIR}"
+php artisan serve --host="${HOST}" --port="${SERVE_PORT}" > "${ART_DIR}/server.log" 2>&1 &
+SERVE_PID="$!"
+echo "${SERVE_PID}" > "${ART_DIR}/server.pid"
+cd "${REPO_DIR}"
+
+wait_health "${API_BASE}/api/v0.2/healthz" || fail "healthz failed"
+curl -sS "${API_BASE}/api/v0.2/healthz" > "${ART_DIR}/healthz.json"
+
+# pack/seed/config consistency
+cd "${BACKEND_DIR}"
+php -r '
+require "vendor/autoload.php";
+$app=require "bootstrap/app.php";
+$app->make(Illuminate\Contracts\Console\Kernel::class)->bootstrap();
+echo (string) config("content_packs.default_pack_id", "");
+' > "${ART_DIR}/config_default_pack_id.txt"
+
+php -r '
+require "vendor/autoload.php";
+$app=require "bootstrap/app.php";
+$app->make(Illuminate\Contracts\Console\Kernel::class)->bootstrap();
+$packId = (string) config("content_packs.default_pack_id", "");
+$dirVersion = (string) config("content_packs.default_dir_version", "");
+echo "config_default_pack_id=".$packId.PHP_EOL;
+echo "config_default_dir_version=".$dirVersion.PHP_EOL;
+if ($packId === "" || $dirVersion === "") {
+    fwrite(STDERR, "missing_content_pack_defaults\n");
+    exit(1);
+}
+if (!Illuminate\Support\Facades\Schema::hasTable("scales_registry")) {
+    fwrite(STDERR, "missing_scales_registry_table\n");
+    exit(1);
+}
+$row = Illuminate\Support\Facades\DB::table("scales_registry")
+    ->where("org_id", 0)
+    ->where("code", "MBTI")
+    ->first();
+if (!$row) {
+    fwrite(STDERR, "missing_scales_registry_mbti\n");
+    exit(1);
+}
+$registryPackId = (string) ($row->default_pack_id ?? "");
+$registryDirVersion = (string) ($row->default_dir_version ?? "");
+echo "registry_default_pack_id=".$registryPackId.PHP_EOL;
+echo "registry_default_dir_version=".$registryDirVersion.PHP_EOL;
+if ($registryPackId !== $packId) {
+    fwrite(STDERR, "default_pack_id_mismatch\n");
+    exit(1);
+}
+if ($registryDirVersion !== $dirVersion) {
+    fwrite(STDERR, "default_dir_version_mismatch\n");
+    exit(1);
+}
+$index = app(App\Services\Content\ContentPacksIndex::class);
+$found = $index->find($packId, $dirVersion);
+if (!($found["ok"] ?? false)) {
+    fwrite(STDERR, "pack_not_found\n");
+    exit(1);
+}
+$item = $found["item"] ?? [];
+$manifestPath = (string) ($item["manifest_path"] ?? "");
+$questionsPath = (string) ($item["questions_path"] ?? "");
+if ($manifestPath === "" || !is_file($manifestPath)) {
+    fwrite(STDERR, "manifest_missing\n");
+    exit(1);
+}
+if ($questionsPath === "" || !is_file($questionsPath)) {
+    fwrite(STDERR, "questions_missing\n");
+    exit(1);
+}
+$packDir = dirname($manifestPath);
+$versionPath = $packDir.DIRECTORY_SEPARATOR."version.json";
+if (!is_file($versionPath)) {
+    fwrite(STDERR, "version_missing\n");
+    exit(1);
+}
+$manifest = json_decode((string) file_get_contents($manifestPath), true);
+$questions = json_decode((string) file_get_contents($questionsPath), true);
+$version = json_decode((string) file_get_contents($versionPath), true);
+if (!is_array($manifest) || !is_array($questions) || !is_array($version)) {
+    fwrite(STDERR, "pack_json_invalid\n");
+    exit(1);
+}
+echo "pack_manifest=".$manifestPath.PHP_EOL;
+echo "pack_questions=".$questionsPath.PHP_EOL;
+echo "pack_version=".$versionPath.PHP_EOL;
+' > "${ART_DIR}/pack_seed_config.txt"
+cd "${REPO_DIR}"
+
+QUESTIONS_JSON="${ART_DIR}/questions.json"
+http_code="$(curl -sS -o "${QUESTIONS_JSON}" -w "%{http_code}" \
+  -H "Accept: application/json" \
+  "${API_BASE}/api/v0.3/scales/${SCALE_CODE}/questions" || true)"
+if [[ "${http_code}" != "200" ]]; then
+  echo "questions_failed http=${http_code}" >&2
+  cat "${QUESTIONS_JSON}" >&2 || true
+  fail "questions endpoint failed"
+fi
+
+ANSWERS_JSON="${ART_DIR}/answers.json"
+php -r '
+$raw = file_get_contents("php://stdin");
+$data = json_decode($raw, true);
+if (!is_array($data)) {
+    fwrite(STDERR, "questions_json_invalid\n");
+    exit(1);
+}
+$items = $data["questions"]["items"] ?? $data["questions"] ?? $data["items"] ?? $data["data"] ?? $data;
+if (!is_array($items)) {
+    fwrite(STDERR, "questions_items_invalid\n");
+    exit(1);
+}
+$answers = [];
+foreach ($items as $item) {
+    if (!is_array($item)) {
+        continue;
+    }
+    $questionId = (string) ($item["question_id"] ?? $item["id"] ?? "");
+    if ($questionId === "") {
+        continue;
+    }
+    $options = $item["options"] ?? [];
+    $code = "A";
+    if (is_array($options) && isset($options[0]) && is_array($options[0])) {
+        $code = (string) ($options[0]["code"] ?? $options[0]["option_code"] ?? "A");
+    }
+    if ($code === "") {
+        $code = "A";
+    }
+    $answers[] = [
+        "question_id" => $questionId,
+        "code" => $code,
+    ];
+}
+if (count($answers) === 0) {
+    fwrite(STDERR, "answers_empty\n");
+    exit(1);
+}
+echo json_encode($answers, JSON_UNESCAPED_UNICODE);
+' < "${QUESTIONS_JSON}" > "${ANSWERS_JSON}"
+
+ATTEMPT_START_JSON="${ART_DIR}/attempt_start.json"
+ATTEMPT_START_BODY="$(SCALE_CODE="${SCALE_CODE}" ANON_ID="${ANON_ID}" php -r '
+$payload = [
+    "scale_code" => getenv("SCALE_CODE"),
+    "anon_id" => getenv("ANON_ID"),
+];
+echo json_encode($payload, JSON_UNESCAPED_UNICODE);
+')"
+http_code="$(curl -sS -o "${ATTEMPT_START_JSON}" -w "%{http_code}" \
+  -X POST -H "Content-Type: application/json" -H "Accept: application/json" \
+  --data "${ATTEMPT_START_BODY}" \
+  "${API_BASE}/api/v0.3/attempts/start" || true)"
+if [[ "${http_code}" != "200" ]]; then
+  echo "attempt_start_failed http=${http_code}" >&2
+  cat "${ATTEMPT_START_JSON}" >&2 || true
+  fail "attempt start failed"
+fi
+
+ATTEMPT_ID="$(php -r '$j=json_decode(file_get_contents($argv[1]), true); echo (string)($j["attempt_id"] ?? "");' "${ATTEMPT_START_JSON}")"
+if [[ -z "${ATTEMPT_ID}" ]]; then
+  fail "missing attempt_id"
+fi
+echo "${ATTEMPT_ID}" > "${ART_DIR}/attempt_id.txt"
+echo "${ANON_ID}" > "${ART_DIR}/anon_id.txt"
+
+SUBMIT_PAYLOAD="${ART_DIR}/submit_payload.json"
+ATTEMPT_ID="${ATTEMPT_ID}" ANSWERS_PATH="${ANSWERS_JSON}" php -r '
+$answers = json_decode(file_get_contents(getenv("ANSWERS_PATH")), true);
+if (!is_array($answers) || count($answers) === 0) {
+    fwrite(STDERR, "answers_payload_invalid\n");
+    exit(1);
+}
+$payload = [
+    "attempt_id" => getenv("ATTEMPT_ID"),
+    "answers" => $answers,
+    "duration_ms" => 120000,
+];
+echo json_encode($payload, JSON_UNESCAPED_UNICODE);
+' > "${SUBMIT_PAYLOAD}"
+
+SUBMIT_JSON="${ART_DIR}/submit.json"
+http_code="$(curl -sS -o "${SUBMIT_JSON}" -w "%{http_code}" \
+  -X POST -H "Content-Type: application/json" -H "Accept: application/json" \
+  --data-binary @"${SUBMIT_PAYLOAD}" \
+  "${API_BASE}/api/v0.3/attempts/submit" || true)"
+if [[ "${http_code}" != "200" ]]; then
+  echo "submit_failed http=${http_code}" >&2
+  cat "${SUBMIT_JSON}" >&2 || true
+  fail "submit failed"
+fi
+
+php -r '
+$j = json_decode(file_get_contents($argv[1]), true);
+if (!is_array($j) || !($j["ok"] ?? false)) {
+    fwrite(STDERR, "submit_response_not_ok\n");
+    exit(1);
+}
+' "${SUBMIT_JSON}" || fail "submit response invalid"
+
+AUTHORIZED_REPORT_JSON="${ART_DIR}/report_authorized.json"
+http_code="$(curl -sS -o "${AUTHORIZED_REPORT_JSON}" -w "%{http_code}" \
+  -H "Accept: application/json" \
+  -H "X-Anon-Id: ${ANON_ID}" \
+  "${API_BASE}/api/v0.2/attempts/${ATTEMPT_ID}/report" || true)"
+if [[ "${http_code}" != "200" ]]; then
+  echo "authorized_report_failed http=${http_code}" >&2
+  cat "${AUTHORIZED_REPORT_JSON}" >&2 || true
+  fail "authorized report failed"
+fi
+
+php -r '
+$j = json_decode(file_get_contents($argv[1]), true);
+if (!is_array($j) || !($j["ok"] ?? false)) {
+    fwrite(STDERR, "authorized_report_not_ok\n");
+    exit(1);
+}
+' "${AUTHORIZED_REPORT_JSON}" || fail "authorized report response invalid"
+
+NO_OWNER_REPORT_JSON="${ART_DIR}/report_no_owner.json"
+http_code="$(curl -sS -o "${NO_OWNER_REPORT_JSON}" -w "%{http_code}" \
+  -H "Accept: application/json" \
+  "${API_BASE}/api/v0.2/attempts/${ATTEMPT_ID}/report" || true)"
+echo "no_owner_http_code=${http_code}" > "${ART_DIR}/security_assertions.txt"
+if [[ "${http_code}" != "404" ]]; then
+  cat "${NO_OWNER_REPORT_JSON}" >&2 || true
+  fail "report without owner must return 404"
+fi
+
+WRONG_OWNER_REPORT_JSON="${ART_DIR}/report_wrong_owner.json"
+http_code="$(curl -sS -o "${WRONG_OWNER_REPORT_JSON}" -w "%{http_code}" \
+  -H "Accept: application/json" \
+  -H "X-Anon-Id: wrong-anon-pr42" \
+  "${API_BASE}/api/v0.2/attempts/${ATTEMPT_ID}/report" || true)"
+echo "wrong_owner_http_code=${http_code}" >> "${ART_DIR}/security_assertions.txt"
+if [[ "${http_code}" != "404" ]]; then
+  cat "${WRONG_OWNER_REPORT_JSON}" >&2 || true
+  fail "report with wrong owner must return 404"
+fi
+
+if [[ -n "${SERVE_PID:-}" ]] && ps -p "${SERVE_PID}" >/dev/null 2>&1; then
+  kill "${SERVE_PID}" >/dev/null 2>&1 || true
+fi
+cleanup_port "${SERVE_PORT}"
+if lsof -nP -iTCP:"${SERVE_PORT}" -sTCP:LISTEN >/dev/null 2>&1; then
+  fail "serve port not released: ${SERVE_PORT}"
+fi
+unset SERVE_PID
+
+cd "${BACKEND_DIR}"
+php artisan test --filter SensitiveDataRedactorTest > "${ART_DIR}/phpunit.txt"
+cd "${REPO_DIR}"
+
+echo "[PR42] verify ok"

--- a/backend/tests/Unit/Support/SensitiveDataRedactorTest.php
+++ b/backend/tests/Unit/Support/SensitiveDataRedactorTest.php
@@ -1,0 +1,69 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Support;
+
+use App\Support\SensitiveDataRedactor;
+use PHPUnit\Framework\TestCase;
+
+final class SensitiveDataRedactorTest extends TestCase
+{
+    public function test_top_level_sensitive_key_is_redacted(): void
+    {
+        $redactor = new SensitiveDataRedactor();
+
+        $data = [
+            'api_key' => 'sk_test_123',
+            'name' => 'demo',
+        ];
+
+        $result = $redactor->redact($data);
+
+        $this->assertSame('[REDACTED]', $result['api_key']);
+        $this->assertSame('demo', $result['name']);
+    }
+
+    public function test_nested_sensitive_key_is_redacted(): void
+    {
+        $redactor = new SensitiveDataRedactor();
+
+        $data = [
+            'meta' => [
+                'client_secret' => 'cs_test_123',
+                'headers' => [
+                    'stripe-signature' => 'sig_123',
+                ],
+            ],
+            'items' => [
+                [
+                    'private_key' => 'pk_123',
+                ],
+            ],
+        ];
+
+        $result = $redactor->redact($data);
+
+        $this->assertSame('[REDACTED]', $result['meta']['client_secret']);
+        $this->assertSame('[REDACTED]', $result['meta']['headers']['stripe-signature']);
+        $this->assertSame('[REDACTED]', $result['items'][0]['private_key']);
+    }
+
+    public function test_non_sensitive_keys_are_kept(): void
+    {
+        $redactor = new SensitiveDataRedactor();
+
+        $data = [
+            'age' => 28,
+            'display_name' => 'alice',
+            'nested' => [
+                'score' => 96,
+                'enabled' => true,
+            ],
+        ];
+
+        $result = $redactor->redact($data);
+
+        $this->assertSame($data, $result);
+    }
+}

--- a/docs/verify/pr42_recon.md
+++ b/docs/verify/pr42_recon.md
@@ -1,0 +1,14 @@
+# PR42 Recon
+
+- Keywords: AuditLogger|SensitiveDataRedactor|redact
+- 相关入口文件：
+  - backend/app/Services/Audit/AuditLogger.php
+- 相关路由：
+  - N/A（审计日志工具类）
+- 相关 DB 表/迁移：
+  - audit_logs（现有）
+- 需要新增/修改点：
+  - 新增递归脱敏工具（支持嵌套数组）
+  - AuditLogger 统一走新脱敏逻辑
+- 风险点与规避（端口/CI 工具依赖/pack-seed-config 一致性/sqlite 迁移一致性/404 口径/脱敏）：
+  - 脱敏误杀：以 key 规则为主，单测覆盖典型 key

--- a/docs/verify/pr42_verify.md
+++ b/docs/verify/pr42_verify.md
@@ -1,0 +1,35 @@
+# PR42 Verify
+
+- Date: 2026-02-07
+- Commands:
+  - bash backend/scripts/pr42_accept.sh
+  - bash backend/scripts/ci_verify_mbti.sh
+  - php artisan test --filter SensitiveDataRedactorTest
+- Result:
+  - pr42_accept: PASS
+  - ci_verify_mbti: PASS
+  - SensitiveDataRedactorTest: PASS
+- Artifacts:
+  - backend/artifacts/pr42/summary.txt
+  - backend/artifacts/pr42/verify.log
+  - backend/artifacts/pr42/phpunit.txt
+  - backend/artifacts/verify_mbti/summary.txt
+
+Key Notes
+
+- redaction coverage in audit log params:
+  - substring-based key matching (case-insensitive)
+  - nested arrays are redacted recursively
+  - non-sensitive keys remain unchanged
+- report owner guard verified:
+  - no owner => 404
+  - wrong owner => 404
+  - correct anon_id or token owner => 200
+
+Step Verification Commands
+
+1. Step 1 (routes): php artisan route:list
+2. Step 2 (migrations): php artisan migrate
+3. Step 3 (middleware): php -l backend/app/Http/Middleware/FmTokenAuth.php
+4. Step 4 (controllers/services/tests): php artisan test --filter SensitiveDataRedactorTest
+5. Step 5 (scripts/CI): bash -n backend/scripts/pr42_verify.sh && bash -n backend/scripts/pr42_accept.sh && bash backend/scripts/pr42_accept.sh && bash backend/scripts/ci_verify_mbti.sh


### PR DESCRIPTION
What:
Expand audit log redaction to nested arrays with substring-based key matching.
Why:
Prevent sensitive tokens/secrets leaking via audit logs.
Reduce security risk during incident/debug sessions and artifact collection.
How:
[SensitiveDataRedactor.php](app://-/index.html#): recursive redaction utility
[AuditLogger.php](app://-/index.html#): route all params through redactor
[SensitiveDataRedactorTest.php](app://-/index.html#): unit coverage
[pr42_accept.sh](app://-/index.html#) + [pr42_verify.sh](app://-/index.html#): local acceptance & artifacts
Verify:
[pr42_accept.sh](app://-/index.html#)
[ci_verify_mbti.sh](app://-/index.html#)
Artifacts:
[summary.txt](app://-/index.html#)