### PR TITLE
chore(pr46): Assessment: add reverse mapping support for GenericLikertDriver

### DIFF
--- a/backend/tests/Unit/Services/Assessment/GenericLikertDriverTest.php
+++ b/backend/tests/Unit/Services/Assessment/GenericLikertDriverTest.php
@@ -9,6 +9,40 @@ use Tests\TestCase;
 
 final class GenericLikertDriverTest extends TestCase
 {
+    public function testReverseWeightObjectRuleUsesLikertReverseMapping(): void
+    {
+        $driver = new GenericLikertDriver();
+
+        $answers = [
+            'q1' => 'A',
+        ];
+
+        $spec = [
+            'items_map' => [
+                'q1' => ['weight' => 2, 'reverse' => true],
+            ],
+            'options_score_map' => [
+                'A' => 1,
+                'B' => 2,
+                'C' => 3,
+                'D' => 4,
+            ],
+            'dimensions_map' => [
+                'D1' => ['q1'],
+            ],
+        ];
+
+        $out = $driver->compute($answers, $spec);
+
+        self::assertSame(8.0, $out['score_total']);
+        self::assertSame(8.0, $out['dimensions']['D1']);
+
+        self::assertSame(true, $out['debug']['items']['q1']['reverse']);
+        self::assertSame(2.0, $out['debug']['items']['q1']['weight']);
+        self::assertSame(4.0, $out['debug']['items']['q1']['effective']);
+        self::assertSame(8.0, $out['debug']['items']['q1']['weighted']);
+    }
+
     public function test_items_map_supports_reverse_and_weight_object_rule(): void
     {
         $driver = new GenericLikertDriver();


### PR DESCRIPTION
## Summary
- Add backward-compatible `compute()` adapter to `GenericLikertDriver`.
- Ensure reverse + weight object rule uses Likert reverse mapping (min + max − raw).
- Add unit coverage for reverse mapping behavior.

## Details
- Supports legacy specs/tests that rely on `compute()` output format.
- Reverse mapping is applied before weight multiplication.
- No changes to routes, migrations, or CI workflows.

## Verify
- php artisan test --filter GenericLikertDriverTest
- php artisan route:list
- php artisan migrate
- bash backend/scripts/ci_verify_mbti.sh
