### PR TITLE
chore(pr49): Migration safety: no silent catch

### DIFF
--- a/backend/app/Support/Database/SchemaIndex.php
+++ b/backend/app/Support/Database/SchemaIndex.php
@@ -1,0 +1,193 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Support\Database;
+
+use Illuminate\Database\ConnectionInterface;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Log;
+use Throwable;
+
+final class SchemaIndex
+{
+    private const SAFE_EXTRA_KEYS = [
+        'connection',
+        'phase',
+        'reason',
+        'status',
+    ];
+
+    public static function indexExists(string $table, string $indexName, ?string $connection = null): bool
+    {
+        if (!self::isSafeIdentifier($table) || !self::isSafeIdentifier($indexName)) {
+            return false;
+        }
+
+        $conn = self::connection($connection);
+        $driver = $conn->getDriverName();
+
+        if ($driver === 'sqlite') {
+            return self::indexExistsSqlite($conn, $table, $indexName);
+        }
+
+        if ($driver === 'mysql') {
+            return self::indexExistsMySql($conn, $table, $indexName);
+        }
+
+        if ($driver === 'pgsql') {
+            return self::indexExistsPgSql($conn, $table, $indexName);
+        }
+
+        return false;
+    }
+
+    public static function isDuplicateIndexException(Throwable $e, string $indexName): bool
+    {
+        return self::matchesException($e, $indexName, [
+            'already exists',
+            'already an index named',
+            'duplicate key name',
+            'duplicate',
+        ]);
+    }
+
+    public static function isMissingIndexException(Throwable $e, string $indexName): bool
+    {
+        return self::matchesException($e, $indexName, [
+            'no such index',
+            'does not exist',
+            'unknown key name',
+            'cannot drop index',
+        ]);
+    }
+
+    public static function logIndexAction(
+        string $action,
+        string $table,
+        string $indexName,
+        ?string $driver = null,
+        array $extra = []
+    ): void {
+        $context = [
+            'action' => $action,
+            'table' => $table,
+            'index' => $indexName,
+            'driver' => $driver ?? '',
+        ];
+
+        foreach (self::SAFE_EXTRA_KEYS as $key) {
+            if (!array_key_exists($key, $extra)) {
+                continue;
+            }
+
+            $value = $extra[$key];
+            if (is_scalar($value) || $value === null) {
+                $context[$key] = self::truncate((string) $value);
+            }
+        }
+
+        Log::info('[schema_index] action', $context);
+    }
+
+    private static function indexExistsSqlite(ConnectionInterface $conn, string $table, string $indexName): bool
+    {
+        $tableName = str_replace("'", "''", $table);
+        $rows = $conn->select("PRAGMA index_list('{$tableName}')");
+
+        foreach ($rows as $row) {
+            $name = (string) ($row->name ?? '');
+            if ($name !== '' && strcasecmp($name, $indexName) === 0) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private static function indexExistsMySql(ConnectionInterface $conn, string $table, string $indexName): bool
+    {
+        $database = (string) $conn->getDatabaseName();
+        if ($database === '') {
+            return false;
+        }
+
+        $rows = $conn->select(
+            'SELECT index_name FROM information_schema.statistics WHERE table_schema = ? AND table_name = ?',
+            [$database, $table]
+        );
+
+        foreach ($rows as $row) {
+            $name = (string) ($row->index_name ?? $row->INDEX_NAME ?? '');
+            if ($name !== '' && strcasecmp($name, $indexName) === 0) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private static function indexExistsPgSql(ConnectionInterface $conn, string $table, string $indexName): bool
+    {
+        $schema = (string) ($conn->getConfig('schema') ?? 'public');
+        $schema = trim(explode(',', $schema)[0]);
+        if ($schema === '') {
+            $schema = 'public';
+        }
+
+        $rows = $conn->select(
+            'SELECT indexname FROM pg_indexes WHERE schemaname = ? AND tablename = ?',
+            [$schema, $table]
+        );
+
+        foreach ($rows as $row) {
+            $name = (string) ($row->indexname ?? '');
+            if ($name !== '' && strcasecmp($name, $indexName) === 0) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private static function matchesException(Throwable $e, string $indexName, array $needles): bool
+    {
+        $message = mb_strtolower((string) $e->getMessage(), 'UTF-8');
+        $indexNeedle = mb_strtolower($indexName, 'UTF-8');
+
+        if ($indexNeedle === '' || mb_strpos($message, $indexNeedle) === false) {
+            return false;
+        }
+
+        foreach ($needles as $needle) {
+            if (mb_strpos($message, $needle) !== false) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private static function connection(?string $connection = null): ConnectionInterface
+    {
+        if ($connection !== null && $connection !== '') {
+            return DB::connection($connection);
+        }
+
+        return DB::connection();
+    }
+
+    private static function isSafeIdentifier(string $value): bool
+    {
+        return (bool) preg_match('/^[A-Za-z0-9_]+$/', $value);
+    }
+
+    private static function truncate(string $value, int $maxLength = 128): string
+    {
+        if (strlen($value) <= $maxLength) {
+            return $value;
+        }
+
+        return substr($value, 0, $maxLength);
+    }
+}

--- a/backend/database/migrations/2026_01_18_999999_add_share_id_to_events_table.php
+++ b/backend/database/migrations/2026_01_18_999999_add_share_id_to_events_table.php
@@ -1,5 +1,8 @@
 <?php
 
+declare(strict_types=1);
+
+use App\Support\Database\SchemaIndex;
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
@@ -8,8 +11,7 @@ return new class extends Migration
 {
     public function up(): void
     {
-        Schema::table('events', function (Blueprint $table) {
-            // ✅ sqlite 兼容：uuid = char(36)
+        Schema::table('events', function (Blueprint $table): void {
             if (!Schema::hasColumn('events', 'share_id')) {
                 $table->uuid('share_id')->nullable()->index();
             }
@@ -18,13 +20,33 @@ return new class extends Migration
 
     public function down(): void
     {
-        // ⚠️ sqlite 对 dropIndex/dropColumn 支持不一致，尽量写稳
-        Schema::table('events', function (Blueprint $table) {
-            if (Schema::hasColumn('events', 'share_id')) {
-                // 默认索引名：events_share_id_index
-                try { $table->dropIndex('events_share_id_index'); } catch (\Throwable $e) {}
-                $table->dropColumn('share_id');
+        if (!Schema::hasTable('events') || !Schema::hasColumn('events', 'share_id')) {
+            return;
+        }
+
+        $tableName = 'events';
+        $indexName = 'events_share_id_index';
+        $driver = Schema::getConnection()->getDriverName();
+
+        if (SchemaIndex::indexExists($tableName, $indexName)) {
+            try {
+                Schema::table($tableName, function (Blueprint $table): void {
+                    $table->dropIndex('events_share_id_index');
+                });
+                SchemaIndex::logIndexAction('drop_index', $tableName, $indexName, $driver, ['phase' => 'down']);
+            } catch (\Throwable $e) {
+                if (SchemaIndex::isMissingIndexException($e, $indexName)) {
+                    SchemaIndex::logIndexAction('drop_index_skip_missing', $tableName, $indexName, $driver, ['phase' => 'down']);
+                } else {
+                    throw $e;
+                }
             }
+        } else {
+            SchemaIndex::logIndexAction('drop_index_skip_absent', $tableName, $indexName, $driver, ['phase' => 'down']);
+        }
+
+        Schema::table($tableName, function (Blueprint $table): void {
+            $table->dropColumn('share_id');
         });
     }
 };

--- a/backend/database/migrations/2026_01_28_090000_create_admin_users_table.php
+++ b/backend/database/migrations/2026_01_28_090000_create_admin_users_table.php
@@ -1,5 +1,8 @@
 <?php
 
+declare(strict_types=1);
+
+use App\Support\Database\SchemaIndex;
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
@@ -9,7 +12,7 @@ return new class extends Migration
     public function up(): void
     {
         if (!Schema::hasTable('admin_users')) {
-            Schema::create('admin_users', function (Blueprint $table) {
+            Schema::create('admin_users', function (Blueprint $table): void {
                 $table->bigIncrements('id');
                 $table->string('name', 64);
                 $table->string('email', 191)->unique();
@@ -22,7 +25,7 @@ return new class extends Migration
             return;
         }
 
-        Schema::table('admin_users', function (Blueprint $table) {
+        Schema::table('admin_users', function (Blueprint $table): void {
             if (!Schema::hasColumn('admin_users', 'id')) {
                 $table->bigIncrements('id');
             }
@@ -52,16 +55,40 @@ return new class extends Migration
             }
         });
 
-        try {
-            Schema::table('admin_users', function (Blueprint $table) {
-                $table->unique('email', 'uniq_admin_users_email');
-            });
-        } catch (\Throwable $e) {
+        if (Schema::hasColumn('admin_users', 'email')) {
+            $this->ensureUniqueIndex('admin_users', ['email'], 'uniq_admin_users_email', ['admin_users_email_unique']);
         }
     }
 
     public function down(): void
     {
         Schema::dropIfExists('admin_users');
+    }
+
+    private function ensureUniqueIndex(string $tableName, array $columns, string $indexName, array $alternateNames = []): void
+    {
+        $driver = Schema::getConnection()->getDriverName();
+        $knownNames = array_values(array_unique(array_merge([$indexName], $alternateNames)));
+
+        foreach ($knownNames as $knownName) {
+            if (SchemaIndex::indexExists($tableName, $knownName)) {
+                SchemaIndex::logIndexAction('create_unique_skip_exists', $tableName, $knownName, $driver, ['phase' => 'up']);
+                return;
+            }
+        }
+
+        try {
+            Schema::table($tableName, function (Blueprint $table) use ($columns, $indexName): void {
+                $table->unique($columns, $indexName);
+            });
+            SchemaIndex::logIndexAction('create_unique', $tableName, $indexName, $driver, ['phase' => 'up']);
+        } catch (\Throwable $e) {
+            if (SchemaIndex::isDuplicateIndexException($e, $indexName)) {
+                SchemaIndex::logIndexAction('create_unique_skip_duplicate', $tableName, $indexName, $driver, ['phase' => 'up']);
+                return;
+            }
+
+            throw $e;
+        }
     }
 };

--- a/backend/database/migrations/2026_01_28_090010_create_roles_table.php
+++ b/backend/database/migrations/2026_01_28_090010_create_roles_table.php
@@ -1,5 +1,8 @@
 <?php
 
+declare(strict_types=1);
+
+use App\Support\Database\SchemaIndex;
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
@@ -9,7 +12,7 @@ return new class extends Migration
     public function up(): void
     {
         if (!Schema::hasTable('roles')) {
-            Schema::create('roles', function (Blueprint $table) {
+            Schema::create('roles', function (Blueprint $table): void {
                 $table->bigIncrements('id');
                 $table->string('name', 64)->unique();
                 $table->string('description', 255)->nullable();
@@ -18,7 +21,7 @@ return new class extends Migration
             return;
         }
 
-        Schema::table('roles', function (Blueprint $table) {
+        Schema::table('roles', function (Blueprint $table): void {
             if (!Schema::hasColumn('roles', 'id')) {
                 $table->bigIncrements('id');
             }
@@ -36,16 +39,40 @@ return new class extends Migration
             }
         });
 
-        try {
-            Schema::table('roles', function (Blueprint $table) {
-                $table->unique('name', 'uniq_roles_name');
-            });
-        } catch (\Throwable $e) {
+        if (Schema::hasColumn('roles', 'name')) {
+            $this->ensureUniqueIndex('roles', ['name'], 'uniq_roles_name', ['roles_name_unique']);
         }
     }
 
     public function down(): void
     {
         Schema::dropIfExists('roles');
+    }
+
+    private function ensureUniqueIndex(string $tableName, array $columns, string $indexName, array $alternateNames = []): void
+    {
+        $driver = Schema::getConnection()->getDriverName();
+        $knownNames = array_values(array_unique(array_merge([$indexName], $alternateNames)));
+
+        foreach ($knownNames as $knownName) {
+            if (SchemaIndex::indexExists($tableName, $knownName)) {
+                SchemaIndex::logIndexAction('create_unique_skip_exists', $tableName, $knownName, $driver, ['phase' => 'up']);
+                return;
+            }
+        }
+
+        try {
+            Schema::table($tableName, function (Blueprint $table) use ($columns, $indexName): void {
+                $table->unique($columns, $indexName);
+            });
+            SchemaIndex::logIndexAction('create_unique', $tableName, $indexName, $driver, ['phase' => 'up']);
+        } catch (\Throwable $e) {
+            if (SchemaIndex::isDuplicateIndexException($e, $indexName)) {
+                SchemaIndex::logIndexAction('create_unique_skip_duplicate', $tableName, $indexName, $driver, ['phase' => 'up']);
+                return;
+            }
+
+            throw $e;
+        }
     }
 };

--- a/backend/database/migrations/2026_01_28_090020_create_permissions_table.php
+++ b/backend/database/migrations/2026_01_28_090020_create_permissions_table.php
@@ -1,5 +1,8 @@
 <?php
 
+declare(strict_types=1);
+
+use App\Support\Database\SchemaIndex;
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
@@ -9,7 +12,7 @@ return new class extends Migration
     public function up(): void
     {
         if (!Schema::hasTable('permissions')) {
-            Schema::create('permissions', function (Blueprint $table) {
+            Schema::create('permissions', function (Blueprint $table): void {
                 $table->bigIncrements('id');
                 $table->string('name', 128)->unique();
                 $table->string('description', 255)->nullable();
@@ -18,7 +21,7 @@ return new class extends Migration
             return;
         }
 
-        Schema::table('permissions', function (Blueprint $table) {
+        Schema::table('permissions', function (Blueprint $table): void {
             if (!Schema::hasColumn('permissions', 'id')) {
                 $table->bigIncrements('id');
             }
@@ -36,16 +39,40 @@ return new class extends Migration
             }
         });
 
-        try {
-            Schema::table('permissions', function (Blueprint $table) {
-                $table->unique('name', 'uniq_permissions_name');
-            });
-        } catch (\Throwable $e) {
+        if (Schema::hasColumn('permissions', 'name')) {
+            $this->ensureUniqueIndex('permissions', ['name'], 'uniq_permissions_name', ['permissions_name_unique']);
         }
     }
 
     public function down(): void
     {
         Schema::dropIfExists('permissions');
+    }
+
+    private function ensureUniqueIndex(string $tableName, array $columns, string $indexName, array $alternateNames = []): void
+    {
+        $driver = Schema::getConnection()->getDriverName();
+        $knownNames = array_values(array_unique(array_merge([$indexName], $alternateNames)));
+
+        foreach ($knownNames as $knownName) {
+            if (SchemaIndex::indexExists($tableName, $knownName)) {
+                SchemaIndex::logIndexAction('create_unique_skip_exists', $tableName, $knownName, $driver, ['phase' => 'up']);
+                return;
+            }
+        }
+
+        try {
+            Schema::table($tableName, function (Blueprint $table) use ($columns, $indexName): void {
+                $table->unique($columns, $indexName);
+            });
+            SchemaIndex::logIndexAction('create_unique', $tableName, $indexName, $driver, ['phase' => 'up']);
+        } catch (\Throwable $e) {
+            if (SchemaIndex::isDuplicateIndexException($e, $indexName)) {
+                SchemaIndex::logIndexAction('create_unique_skip_duplicate', $tableName, $indexName, $driver, ['phase' => 'up']);
+                return;
+            }
+
+            throw $e;
+        }
     }
 };

--- a/backend/database/migrations/2026_01_28_090030_create_role_user_table.php
+++ b/backend/database/migrations/2026_01_28_090030_create_role_user_table.php
@@ -1,5 +1,8 @@
 <?php
 
+declare(strict_types=1);
+
+use App\Support\Database\SchemaIndex;
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
@@ -9,7 +12,7 @@ return new class extends Migration
     public function up(): void
     {
         if (!Schema::hasTable('role_user')) {
-            Schema::create('role_user', function (Blueprint $table) {
+            Schema::create('role_user', function (Blueprint $table): void {
                 $table->unsignedBigInteger('role_id');
                 $table->unsignedBigInteger('admin_user_id');
                 $table->unique(['role_id', 'admin_user_id'], 'uniq_role_user');
@@ -19,7 +22,7 @@ return new class extends Migration
             return;
         }
 
-        Schema::table('role_user', function (Blueprint $table) {
+        Schema::table('role_user', function (Blueprint $table): void {
             if (!Schema::hasColumn('role_user', 'role_id')) {
                 $table->unsignedBigInteger('role_id')->nullable();
             }
@@ -28,28 +31,67 @@ return new class extends Migration
             }
         });
 
-        try {
-            Schema::table('role_user', function (Blueprint $table) {
-                $table->unique(['role_id', 'admin_user_id'], 'uniq_role_user');
-            });
-        } catch (\Throwable $e) {
+        if (Schema::hasColumn('role_user', 'role_id') && Schema::hasColumn('role_user', 'admin_user_id')) {
+            $this->ensureUniqueIndex('role_user', ['role_id', 'admin_user_id'], 'uniq_role_user');
         }
-        try {
-            Schema::table('role_user', function (Blueprint $table) {
-                $table->index(['admin_user_id'], 'idx_role_user_admin');
-            });
-        } catch (\Throwable $e) {
+        if (Schema::hasColumn('role_user', 'admin_user_id')) {
+            $this->ensureIndex('role_user', ['admin_user_id'], 'idx_role_user_admin');
         }
-        try {
-            Schema::table('role_user', function (Blueprint $table) {
-                $table->index(['role_id'], 'idx_role_user_role');
-            });
-        } catch (\Throwable $e) {
+        if (Schema::hasColumn('role_user', 'role_id')) {
+            $this->ensureIndex('role_user', ['role_id'], 'idx_role_user_role');
         }
     }
 
     public function down(): void
     {
         Schema::dropIfExists('role_user');
+    }
+
+    private function ensureUniqueIndex(string $tableName, array $columns, string $indexName): void
+    {
+        $driver = Schema::getConnection()->getDriverName();
+
+        if (SchemaIndex::indexExists($tableName, $indexName)) {
+            SchemaIndex::logIndexAction('create_unique_skip_exists', $tableName, $indexName, $driver, ['phase' => 'up']);
+            return;
+        }
+
+        try {
+            Schema::table($tableName, function (Blueprint $table) use ($columns, $indexName): void {
+                $table->unique($columns, $indexName);
+            });
+            SchemaIndex::logIndexAction('create_unique', $tableName, $indexName, $driver, ['phase' => 'up']);
+        } catch (\Throwable $e) {
+            if (SchemaIndex::isDuplicateIndexException($e, $indexName)) {
+                SchemaIndex::logIndexAction('create_unique_skip_duplicate', $tableName, $indexName, $driver, ['phase' => 'up']);
+                return;
+            }
+
+            throw $e;
+        }
+    }
+
+    private function ensureIndex(string $tableName, array $columns, string $indexName): void
+    {
+        $driver = Schema::getConnection()->getDriverName();
+
+        if (SchemaIndex::indexExists($tableName, $indexName)) {
+            SchemaIndex::logIndexAction('create_index_skip_exists', $tableName, $indexName, $driver, ['phase' => 'up']);
+            return;
+        }
+
+        try {
+            Schema::table($tableName, function (Blueprint $table) use ($columns, $indexName): void {
+                $table->index($columns, $indexName);
+            });
+            SchemaIndex::logIndexAction('create_index', $tableName, $indexName, $driver, ['phase' => 'up']);
+        } catch (\Throwable $e) {
+            if (SchemaIndex::isDuplicateIndexException($e, $indexName)) {
+                SchemaIndex::logIndexAction('create_index_skip_duplicate', $tableName, $indexName, $driver, ['phase' => 'up']);
+                return;
+            }
+
+            throw $e;
+        }
     }
 };

--- a/backend/database/migrations/2026_01_28_090040_create_permission_role_table.php
+++ b/backend/database/migrations/2026_01_28_090040_create_permission_role_table.php
@@ -1,5 +1,8 @@
 <?php
 
+declare(strict_types=1);
+
+use App\Support\Database\SchemaIndex;
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
@@ -9,7 +12,7 @@ return new class extends Migration
     public function up(): void
     {
         if (!Schema::hasTable('permission_role')) {
-            Schema::create('permission_role', function (Blueprint $table) {
+            Schema::create('permission_role', function (Blueprint $table): void {
                 $table->unsignedBigInteger('permission_id');
                 $table->unsignedBigInteger('role_id');
                 $table->unique(['permission_id', 'role_id'], 'uniq_permission_role');
@@ -19,7 +22,7 @@ return new class extends Migration
             return;
         }
 
-        Schema::table('permission_role', function (Blueprint $table) {
+        Schema::table('permission_role', function (Blueprint $table): void {
             if (!Schema::hasColumn('permission_role', 'permission_id')) {
                 $table->unsignedBigInteger('permission_id')->nullable();
             }
@@ -28,28 +31,67 @@ return new class extends Migration
             }
         });
 
-        try {
-            Schema::table('permission_role', function (Blueprint $table) {
-                $table->unique(['permission_id', 'role_id'], 'uniq_permission_role');
-            });
-        } catch (\Throwable $e) {
+        if (Schema::hasColumn('permission_role', 'permission_id') && Schema::hasColumn('permission_role', 'role_id')) {
+            $this->ensureUniqueIndex('permission_role', ['permission_id', 'role_id'], 'uniq_permission_role');
         }
-        try {
-            Schema::table('permission_role', function (Blueprint $table) {
-                $table->index(['role_id'], 'idx_permission_role_role');
-            });
-        } catch (\Throwable $e) {
+        if (Schema::hasColumn('permission_role', 'role_id')) {
+            $this->ensureIndex('permission_role', ['role_id'], 'idx_permission_role_role');
         }
-        try {
-            Schema::table('permission_role', function (Blueprint $table) {
-                $table->index(['permission_id'], 'idx_permission_role_permission');
-            });
-        } catch (\Throwable $e) {
+        if (Schema::hasColumn('permission_role', 'permission_id')) {
+            $this->ensureIndex('permission_role', ['permission_id'], 'idx_permission_role_permission');
         }
     }
 
     public function down(): void
     {
         Schema::dropIfExists('permission_role');
+    }
+
+    private function ensureUniqueIndex(string $tableName, array $columns, string $indexName): void
+    {
+        $driver = Schema::getConnection()->getDriverName();
+
+        if (SchemaIndex::indexExists($tableName, $indexName)) {
+            SchemaIndex::logIndexAction('create_unique_skip_exists', $tableName, $indexName, $driver, ['phase' => 'up']);
+            return;
+        }
+
+        try {
+            Schema::table($tableName, function (Blueprint $table) use ($columns, $indexName): void {
+                $table->unique($columns, $indexName);
+            });
+            SchemaIndex::logIndexAction('create_unique', $tableName, $indexName, $driver, ['phase' => 'up']);
+        } catch (\Throwable $e) {
+            if (SchemaIndex::isDuplicateIndexException($e, $indexName)) {
+                SchemaIndex::logIndexAction('create_unique_skip_duplicate', $tableName, $indexName, $driver, ['phase' => 'up']);
+                return;
+            }
+
+            throw $e;
+        }
+    }
+
+    private function ensureIndex(string $tableName, array $columns, string $indexName): void
+    {
+        $driver = Schema::getConnection()->getDriverName();
+
+        if (SchemaIndex::indexExists($tableName, $indexName)) {
+            SchemaIndex::logIndexAction('create_index_skip_exists', $tableName, $indexName, $driver, ['phase' => 'up']);
+            return;
+        }
+
+        try {
+            Schema::table($tableName, function (Blueprint $table) use ($columns, $indexName): void {
+                $table->index($columns, $indexName);
+            });
+            SchemaIndex::logIndexAction('create_index', $tableName, $indexName, $driver, ['phase' => 'up']);
+        } catch (\Throwable $e) {
+            if (SchemaIndex::isDuplicateIndexException($e, $indexName)) {
+                SchemaIndex::logIndexAction('create_index_skip_duplicate', $tableName, $indexName, $driver, ['phase' => 'up']);
+                return;
+            }
+
+            throw $e;
+        }
     }
 };

--- a/backend/database/migrations/2026_01_28_090050_create_audit_logs_table.php
+++ b/backend/database/migrations/2026_01_28_090050_create_audit_logs_table.php
@@ -1,5 +1,8 @@
 <?php
 
+declare(strict_types=1);
+
+use App\Support\Database\SchemaIndex;
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
@@ -9,7 +12,7 @@ return new class extends Migration
     public function up(): void
     {
         if (!Schema::hasTable('audit_logs')) {
-            Schema::create('audit_logs', function (Blueprint $table) {
+            Schema::create('audit_logs', function (Blueprint $table): void {
                 $table->bigIncrements('id');
                 $table->unsignedBigInteger('actor_admin_id')->nullable();
                 $table->string('action', 64);
@@ -21,83 +24,72 @@ return new class extends Migration
                 $table->string('request_id', 128)->nullable();
                 $table->dateTime('created_at');
             });
-
-            try {
-                Schema::table('audit_logs', function (Blueprint $table) {
-                    $table->index(['actor_admin_id', 'created_at'], 'idx_audit_actor_time');
-                });
-            } catch (\Throwable $e) {
-            }
-            try {
-                Schema::table('audit_logs', function (Blueprint $table) {
-                    $table->index(['action', 'created_at'], 'idx_audit_action_time');
-                });
-            } catch (\Throwable $e) {
-            }
-            try {
-                Schema::table('audit_logs', function (Blueprint $table) {
-                    $table->index(['target_type', 'target_id'], 'idx_audit_target');
-                });
-            } catch (\Throwable $e) {
-            }
-            return;
-        }
-
-        Schema::table('audit_logs', function (Blueprint $table) {
-            if (!Schema::hasColumn('audit_logs', 'id')) {
-                $table->bigIncrements('id');
-            }
-            if (!Schema::hasColumn('audit_logs', 'actor_admin_id')) {
-                $table->unsignedBigInteger('actor_admin_id')->nullable();
-            }
-            if (!Schema::hasColumn('audit_logs', 'action')) {
-                $table->string('action', 64)->nullable();
-            }
-            if (!Schema::hasColumn('audit_logs', 'target_type')) {
-                $table->string('target_type', 64)->nullable();
-            }
-            if (!Schema::hasColumn('audit_logs', 'target_id')) {
-                $table->string('target_id', 64)->nullable();
-            }
-            if (!Schema::hasColumn('audit_logs', 'meta_json')) {
-                $table->json('meta_json')->nullable();
-            }
-            if (!Schema::hasColumn('audit_logs', 'ip')) {
-                $table->string('ip', 64)->nullable();
-            }
-            if (!Schema::hasColumn('audit_logs', 'user_agent')) {
-                $table->string('user_agent', 255)->nullable();
-            }
-            if (!Schema::hasColumn('audit_logs', 'request_id')) {
-                $table->string('request_id', 128)->nullable();
-            }
-            if (!Schema::hasColumn('audit_logs', 'created_at')) {
-                $table->dateTime('created_at')->nullable();
-            }
-        });
-
-        try {
-            Schema::table('audit_logs', function (Blueprint $table) {
-                $table->index(['actor_admin_id', 'created_at'], 'idx_audit_actor_time');
+        } else {
+            Schema::table('audit_logs', function (Blueprint $table): void {
+                if (!Schema::hasColumn('audit_logs', 'id')) {
+                    $table->bigIncrements('id');
+                }
+                if (!Schema::hasColumn('audit_logs', 'actor_admin_id')) {
+                    $table->unsignedBigInteger('actor_admin_id')->nullable();
+                }
+                if (!Schema::hasColumn('audit_logs', 'action')) {
+                    $table->string('action', 64)->nullable();
+                }
+                if (!Schema::hasColumn('audit_logs', 'target_type')) {
+                    $table->string('target_type', 64)->nullable();
+                }
+                if (!Schema::hasColumn('audit_logs', 'target_id')) {
+                    $table->string('target_id', 64)->nullable();
+                }
+                if (!Schema::hasColumn('audit_logs', 'meta_json')) {
+                    $table->json('meta_json')->nullable();
+                }
+                if (!Schema::hasColumn('audit_logs', 'ip')) {
+                    $table->string('ip', 64)->nullable();
+                }
+                if (!Schema::hasColumn('audit_logs', 'user_agent')) {
+                    $table->string('user_agent', 255)->nullable();
+                }
+                if (!Schema::hasColumn('audit_logs', 'request_id')) {
+                    $table->string('request_id', 128)->nullable();
+                }
+                if (!Schema::hasColumn('audit_logs', 'created_at')) {
+                    $table->dateTime('created_at')->nullable();
+                }
             });
-        } catch (\Throwable $e) {
         }
-        try {
-            Schema::table('audit_logs', function (Blueprint $table) {
-                $table->index(['action', 'created_at'], 'idx_audit_action_time');
-            });
-        } catch (\Throwable $e) {
-        }
-        try {
-            Schema::table('audit_logs', function (Blueprint $table) {
-                $table->index(['target_type', 'target_id'], 'idx_audit_target');
-            });
-        } catch (\Throwable $e) {
-        }
+
+        $this->ensureIndex('audit_logs', ['actor_admin_id', 'created_at'], 'idx_audit_actor_time');
+        $this->ensureIndex('audit_logs', ['action', 'created_at'], 'idx_audit_action_time');
+        $this->ensureIndex('audit_logs', ['target_type', 'target_id'], 'idx_audit_target');
     }
 
     public function down(): void
     {
         Schema::dropIfExists('audit_logs');
+    }
+
+    private function ensureIndex(string $tableName, array $columns, string $indexName): void
+    {
+        $driver = Schema::getConnection()->getDriverName();
+
+        if (SchemaIndex::indexExists($tableName, $indexName)) {
+            SchemaIndex::logIndexAction('create_index_skip_exists', $tableName, $indexName, $driver, ['phase' => 'up']);
+            return;
+        }
+
+        try {
+            Schema::table($tableName, function (Blueprint $table) use ($columns, $indexName): void {
+                $table->index($columns, $indexName);
+            });
+            SchemaIndex::logIndexAction('create_index', $tableName, $indexName, $driver, ['phase' => 'up']);
+        } catch (\Throwable $e) {
+            if (SchemaIndex::isDuplicateIndexException($e, $indexName)) {
+                SchemaIndex::logIndexAction('create_index_skip_duplicate', $tableName, $indexName, $driver, ['phase' => 'up']);
+                return;
+            }
+
+            throw $e;
+        }
     }
 };

--- a/backend/scripts/pr49_accept.sh
+++ b/backend/scripts/pr49_accept.sh
@@ -1,0 +1,101 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+export CI=true
+export FAP_NONINTERACTIVE=1
+export COMPOSER_NO_INTERACTION=1
+export GIT_TERMINAL_PROMPT=0
+export NO_COLOR=1
+export PAGER=cat
+export GIT_PAGER=cat
+export TERM=dumb
+export XDEBUG_MODE=off
+export LANG=en_US.UTF-8
+
+REPO_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+BACKEND_DIR="${REPO_DIR}/backend"
+ART_DIR="${BACKEND_DIR}/artifacts/pr49"
+SERVE_PORT="${SERVE_PORT:-1849}"
+DB_PATH="/tmp/pr49.sqlite"
+
+mkdir -p "${ART_DIR}"
+
+cleanup_port() {
+  local port="$1"
+  lsof -nP -iTCP:"${port}" -sTCP:LISTEN || true
+  local pid_list
+  pid_list="$(lsof -ti tcp:"${port}" || true)"
+  if [[ -n "${pid_list}" ]]; then
+    echo "${pid_list}" | xargs kill -9 || true
+  fi
+  lsof -nP -iTCP:"${port}" -sTCP:LISTEN || true
+}
+
+cleanup() {
+  if [[ -f "${ART_DIR}/server.pid" ]]; then
+    local pid
+    pid="$(cat "${ART_DIR}/server.pid" || true)"
+    if [[ -n "${pid}" ]] && ps -p "${pid}" >/dev/null 2>&1; then
+      kill "${pid}" >/dev/null 2>&1 || true
+    fi
+  fi
+  cleanup_port "${SERVE_PORT}"
+  cleanup_port 18000
+  rm -f "${DB_PATH}"
+}
+trap cleanup EXIT
+
+cleanup_port "${SERVE_PORT}"
+cleanup_port 18000
+
+export APP_ENV=testing
+export CACHE_STORE=array
+export QUEUE_CONNECTION=sync
+export DB_CONNECTION=sqlite
+export DB_DATABASE="${DB_PATH}"
+export FAP_PACKS_ROOT="${FAP_PACKS_ROOT:-${REPO_DIR}/content_packages}"
+export FAP_DEFAULT_REGION="${FAP_DEFAULT_REGION:-CN_MAINLAND}"
+export FAP_DEFAULT_LOCALE="${FAP_DEFAULT_LOCALE:-zh-CN}"
+export FAP_DEFAULT_PACK_ID="${FAP_DEFAULT_PACK_ID:-MBTI.cn-mainland.zh-CN.v0.2.2}"
+export FAP_DEFAULT_DIR_VERSION="${FAP_DEFAULT_DIR_VERSION:-MBTI-CN-v0.2.2}"
+
+rm -f "${DB_PATH}"
+touch "${DB_PATH}"
+
+cd "${BACKEND_DIR}"
+composer install --no-interaction --no-progress
+php artisan migrate:fresh --force
+php artisan fap:scales:seed-default
+php artisan fap:scales:sync-slugs
+cd "${REPO_DIR}"
+
+SERVE_PORT="${SERVE_PORT}" ART_DIR="${ART_DIR}" bash "${BACKEND_DIR}/scripts/pr49_verify.sh"
+
+ATTEMPT_ID="$(cat "${ART_DIR}/attempt_id.txt" 2>/dev/null || true)"
+ANON_ID="$(cat "${ART_DIR}/anon_id.txt" 2>/dev/null || true)"
+DEFAULT_PACK_ID="$(cat "${ART_DIR}/config_default_pack_id.txt" 2>/dev/null || true)"
+
+cat > "${ART_DIR}/summary.txt" <<TXT
+PR49 Acceptance Summary
+- pass_items:
+  - migration_no_silent_catch: OK
+  - schema_index_helper: OK
+  - pack_seed_config_consistency: OK
+  - dynamic_answers_submit: OK
+  - phpunit(SchemaIndexTest): PASS
+  - phpunit(MigrationsNoSilentCatchTest): PASS
+- key_outputs:
+  - attempt_id: ${ATTEMPT_ID}
+  - anon_id: ${ANON_ID}
+  - default_pack_id: ${DEFAULT_PACK_ID}
+- smoke_urls:
+  - http://127.0.0.1:${SERVE_PORT}/api/v0.3/scales/MBTI/questions
+  - http://127.0.0.1:${SERVE_PORT}/api/v0.3/attempts/start
+- schema_changes:
+  - deterministic index handling in PR49 migration set
+TXT
+
+bash "${BACKEND_DIR}/scripts/sanitize_artifacts.sh" 49
+
+bash -n "${BACKEND_DIR}/scripts/pr49_accept.sh"
+bash -n "${BACKEND_DIR}/scripts/pr49_verify.sh"

--- a/backend/scripts/pr49_verify.sh
+++ b/backend/scripts/pr49_verify.sh
@@ -1,0 +1,271 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+export CI=true
+export FAP_NONINTERACTIVE=1
+export COMPOSER_NO_INTERACTION=1
+export GIT_TERMINAL_PROMPT=0
+export NO_COLOR=1
+export PAGER=cat
+export GIT_PAGER=cat
+export TERM=dumb
+export XDEBUG_MODE=off
+export LANG=en_US.UTF-8
+
+REPO_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+BACKEND_DIR="${REPO_DIR}/backend"
+ART_DIR="${ART_DIR:-${BACKEND_DIR}/artifacts/pr49}"
+SERVE_PORT="${SERVE_PORT:-1849}"
+HOST="127.0.0.1"
+API_BASE="http://${HOST}:${SERVE_PORT}"
+SCALE_CODE="${SCALE_CODE:-MBTI}"
+ANON_ID="${ANON_ID:-pr49-verify-anon}"
+
+mkdir -p "${ART_DIR}"
+exec > "${ART_DIR}/verify.log" 2>&1
+
+fail() {
+  echo "[PR49][FAIL] $*" >&2
+  exit 1
+}
+
+cleanup_port() {
+  local port="$1"
+  lsof -nP -iTCP:"${port}" -sTCP:LISTEN || true
+  local pid_list
+  pid_list="$(lsof -ti tcp:"${port}" || true)"
+  if [[ -n "${pid_list}" ]]; then
+    echo "${pid_list}" | xargs kill -9 || true
+  fi
+  lsof -nP -iTCP:"${port}" -sTCP:LISTEN || true
+}
+
+wait_health() {
+  local url="$1"
+  local body_file="${ART_DIR}/healthz.body"
+  local http_code=""
+
+  for _ in $(seq 1 80); do
+    http_code="$(curl -sS -o "${body_file}" -w "%{http_code}" "${url}" || true)"
+    if [[ "${http_code}" == "200" ]]; then
+      return 0
+    fi
+    sleep 0.25
+  done
+
+  echo "health_check_failed http=${http_code}" >&2
+  cat "${body_file}" >&2 || true
+  tail -n 120 "${ART_DIR}/server.log" >&2 || true
+  return 1
+}
+
+cleanup() {
+  if [[ -n "${SERVE_PID:-}" ]] && ps -p "${SERVE_PID}" >/dev/null 2>&1; then
+    kill "${SERVE_PID}" >/dev/null 2>&1 || true
+  fi
+  cleanup_port "${SERVE_PORT}"
+  cleanup_port 18000
+}
+trap cleanup EXIT
+
+cleanup_port "${SERVE_PORT}"
+cleanup_port 18000
+
+cd "${BACKEND_DIR}"
+php artisan serve --host="${HOST}" --port="${SERVE_PORT}" > "${ART_DIR}/server.log" 2>&1 &
+SERVE_PID="$!"
+echo "${SERVE_PID}" > "${ART_DIR}/server.pid"
+cd "${REPO_DIR}"
+
+wait_health "${API_BASE}/api/v0.2/healthz" || fail "healthz failed"
+curl -sS "${API_BASE}/api/v0.2/healthz" > "${ART_DIR}/healthz.json"
+
+cd "${BACKEND_DIR}"
+php -r '
+require "vendor/autoload.php";
+$app=require "bootstrap/app.php";
+$app->make(Illuminate\Contracts\Console\Kernel::class)->bootstrap();
+echo (string) config("content_packs.default_pack_id", "");
+' > "${ART_DIR}/config_default_pack_id.txt"
+
+php -r '
+require "vendor/autoload.php";
+$app=require "bootstrap/app.php";
+$app->make(Illuminate\Contracts\Console\Kernel::class)->bootstrap();
+$packId = (string) config("content_packs.default_pack_id", "");
+$dirVersion = (string) config("content_packs.default_dir_version", "");
+echo "config_default_pack_id=".$packId.PHP_EOL;
+echo "config_default_dir_version=".$dirVersion.PHP_EOL;
+if ($packId === "" || $dirVersion === "") {
+    fwrite(STDERR, "missing_content_pack_defaults\n");
+    exit(1);
+}
+if (!Illuminate\Support\Facades\Schema::hasTable("scales_registry")) {
+    fwrite(STDERR, "missing_scales_registry_table\n");
+    exit(1);
+}
+$row = Illuminate\Support\Facades\DB::table("scales_registry")
+    ->where("org_id", 0)
+    ->where("code", "MBTI")
+    ->first();
+if (!$row) {
+    fwrite(STDERR, "missing_scales_registry_mbti\n");
+    exit(1);
+}
+$registryPackId = (string) ($row->default_pack_id ?? "");
+$registryDirVersion = (string) ($row->default_dir_version ?? "");
+echo "registry_default_pack_id=".$registryPackId.PHP_EOL;
+echo "registry_default_dir_version=".$registryDirVersion.PHP_EOL;
+if ($registryPackId !== $packId) {
+    fwrite(STDERR, "default_pack_id_mismatch\n");
+    exit(1);
+}
+if ($registryDirVersion !== $dirVersion) {
+    fwrite(STDERR, "default_dir_version_mismatch\n");
+    exit(1);
+}
+$index = app(App\Services\Content\ContentPacksIndex::class);
+$found = $index->find($packId, $dirVersion);
+if (!($found["ok"] ?? false)) {
+    fwrite(STDERR, "pack_not_found\n");
+    exit(1);
+}
+$item = $found["item"] ?? [];
+$manifestPath = (string) ($item["manifest_path"] ?? "");
+$questionsPath = (string) ($item["questions_path"] ?? "");
+if ($manifestPath === "" || !is_file($manifestPath)) {
+    fwrite(STDERR, "manifest_missing\n");
+    exit(1);
+}
+if ($questionsPath === "" || !is_file($questionsPath)) {
+    fwrite(STDERR, "questions_missing\n");
+    exit(1);
+}
+$packDir = dirname($manifestPath);
+$versionPath = $packDir.DIRECTORY_SEPARATOR."version.json";
+if (!is_file($versionPath)) {
+    fwrite(STDERR, "version_missing\n");
+    exit(1);
+}
+$manifest = json_decode((string) file_get_contents($manifestPath), true);
+$questions = json_decode((string) file_get_contents($questionsPath), true);
+$version = json_decode((string) file_get_contents($versionPath), true);
+if (!is_array($manifest) || !is_array($questions) || !is_array($version)) {
+    fwrite(STDERR, "pack_json_invalid\n");
+    exit(1);
+}
+echo "pack_manifest=".$manifestPath.PHP_EOL;
+echo "pack_questions=".$questionsPath.PHP_EOL;
+echo "pack_version=".$versionPath.PHP_EOL;
+' > "${ART_DIR}/pack_seed_config.txt"
+cd "${REPO_DIR}"
+
+QUESTIONS_JSON="${ART_DIR}/questions.json"
+http_code="$(curl -sS -o "${QUESTIONS_JSON}" -w "%{http_code}" \
+  -H "Accept: application/json" \
+  "${API_BASE}/api/v0.3/scales/${SCALE_CODE}/questions" || true)"
+if [[ "${http_code}" != "200" ]]; then
+  echo "questions_failed http=${http_code}" >&2
+  cat "${QUESTIONS_JSON}" >&2 || true
+  fail "questions endpoint failed"
+fi
+
+ANSWERS_JSON="${ART_DIR}/answers.json"
+php -r '
+$raw = file_get_contents("php://stdin");
+$data = json_decode($raw, true);
+if (!is_array($data)) {
+    fwrite(STDERR, "questions_json_invalid\n");
+    exit(1);
+}
+$items = $data["questions"]["items"] ?? $data["questions"] ?? $data["items"] ?? $data["data"] ?? $data;
+if (!is_array($items)) {
+    fwrite(STDERR, "questions_items_invalid\n");
+    exit(1);
+}
+$answers = [];
+foreach ($items as $item) {
+    if (!is_array($item)) {
+        continue;
+    }
+    $questionId = (string) ($item["question_id"] ?? $item["id"] ?? "");
+    if ($questionId === "") {
+        continue;
+    }
+    $options = $item["options"] ?? [];
+    $code = "A";
+    if (is_array($options) && isset($options[0]) && is_array($options[0])) {
+        $code = (string) ($options[0]["code"] ?? $options[0]["option_code"] ?? "A");
+    }
+    if ($code === "") {
+        $code = "A";
+    }
+    $answers[] = [
+        "question_id" => $questionId,
+        "code" => $code,
+    ];
+}
+if (count($answers) === 0) {
+    fwrite(STDERR, "answers_empty\n");
+    exit(1);
+}
+echo json_encode($answers, JSON_UNESCAPED_UNICODE);
+' < "${QUESTIONS_JSON}" > "${ANSWERS_JSON}"
+
+ATTEMPT_START_JSON="${ART_DIR}/attempt_start.json"
+ATTEMPT_START_BODY="$(SCALE_CODE="${SCALE_CODE}" ANON_ID="${ANON_ID}" php -r '
+$payload = [
+    "scale_code" => getenv("SCALE_CODE"),
+    "anon_id" => getenv("ANON_ID"),
+];
+echo json_encode($payload, JSON_UNESCAPED_UNICODE);
+')"
+http_code="$(curl -sS -o "${ATTEMPT_START_JSON}" -w "%{http_code}" \
+  -X POST -H "Content-Type: application/json" -H "Accept: application/json" \
+  --data "${ATTEMPT_START_BODY}" \
+  "${API_BASE}/api/v0.3/attempts/start" || true)"
+if [[ "${http_code}" != "200" ]]; then
+  echo "attempt_start_failed http=${http_code}" >&2
+  cat "${ATTEMPT_START_JSON}" >&2 || true
+  fail "attempt start failed"
+fi
+
+ATTEMPT_ID="$(php -r '$j=json_decode(file_get_contents($argv[1]), true); echo (string)($j["attempt_id"] ?? "");' "${ATTEMPT_START_JSON}")"
+if [[ -z "${ATTEMPT_ID}" ]]; then
+  fail "missing attempt_id"
+fi
+echo "${ATTEMPT_ID}" > "${ART_DIR}/attempt_id.txt"
+echo "${ANON_ID}" > "${ART_DIR}/anon_id.txt"
+
+SUBMIT_PAYLOAD="${ART_DIR}/submit_payload.json"
+ATTEMPT_ID="${ATTEMPT_ID}" ANSWERS_PATH="${ANSWERS_JSON}" php -r '
+$answers = json_decode(file_get_contents(getenv("ANSWERS_PATH")), true);
+if (!is_array($answers) || count($answers) === 0) {
+    fwrite(STDERR, "answers_payload_invalid\n");
+    exit(1);
+}
+$payload = [
+    "attempt_id" => getenv("ATTEMPT_ID"),
+    "answers" => $answers,
+    "duration_ms" => 120000,
+];
+echo json_encode($payload, JSON_UNESCAPED_UNICODE);
+' > "${SUBMIT_PAYLOAD}"
+
+ATTEMPT_SUBMIT_JSON="${ART_DIR}/attempt_submit.json"
+http_code="$(curl -sS -o "${ATTEMPT_SUBMIT_JSON}" -w "%{http_code}" \
+  -X POST -H "Content-Type: application/json" -H "Accept: application/json" \
+  --data @"${SUBMIT_PAYLOAD}" \
+  "${API_BASE}/api/v0.3/attempts/submit" || true)"
+if [[ "${http_code}" != "200" ]]; then
+  echo "attempt_submit_failed http=${http_code}" >&2
+  cat "${ATTEMPT_SUBMIT_JSON}" >&2 || true
+  fail "attempt submit failed"
+fi
+
+cd "${BACKEND_DIR}"
+php artisan test --filter SchemaIndexTest > "${ART_DIR}/phpunit_schema_index.txt" 2>&1
+php artisan test --filter MigrationsNoSilentCatchTest > "${ART_DIR}/phpunit_migrations_no_silent_catch.txt" 2>&1
+cd "${REPO_DIR}"
+
+echo "verify_done" > "${ART_DIR}/verify_done.txt"

--- a/backend/tests/Feature/Migrations/MigrationsNoSilentCatchTest.php
+++ b/backend/tests/Feature/Migrations/MigrationsNoSilentCatchTest.php
@@ -1,0 +1,131 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Migrations;
+
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+final class MigrationsNoSilentCatchTest extends TestCase
+{
+    #[Test]
+    public function migration_catch_blocks_are_not_empty_or_comment_only(): void
+    {
+        foreach ($this->migrationFiles() as $filePath) {
+            $source = (string) file_get_contents($filePath);
+            foreach ($this->extractCatchBodies($source) as $catchBody) {
+                $bodyWithoutComments = trim($this->stripComments($catchBody));
+                $this->assertNotSame('', $bodyWithoutComments, "Empty catch block found in {$filePath}");
+            }
+        }
+    }
+
+    #[Test]
+    public function migration_catch_blocks_include_classifier_or_throw(): void
+    {
+        foreach ($this->migrationFiles() as $filePath) {
+            $source = (string) file_get_contents($filePath);
+            foreach ($this->extractCatchBodies($source) as $catchBody) {
+                $bodyWithoutComments = $this->stripComments($catchBody);
+                $hasClassifier = preg_match('/SchemaIndex::is(?:Duplicate|Missing)IndexException/', $bodyWithoutComments) === 1;
+                $hasThrow = preg_match('/\bthrow\b/', $bodyWithoutComments) === 1;
+
+                $this->assertTrue(
+                    $hasClassifier || $hasThrow,
+                    "Catch block must include classifier-or-throw in {$filePath}"
+                );
+            }
+        }
+    }
+
+    /**
+     * @return array<int, string>
+     */
+    private function migrationFiles(): array
+    {
+        $files = glob(base_path('database/migrations/*.php'));
+
+        if (!is_array($files)) {
+            return [];
+        }
+
+        sort($files);
+
+        return array_values($files);
+    }
+
+    /**
+     * @return array<int, string>
+     */
+    private function extractCatchBodies(string $source): array
+    {
+        $tokens = token_get_all($source);
+        $bodies = [];
+        $count = count($tokens);
+
+        for ($i = 0; $i < $count; $i++) {
+            $token = $tokens[$i];
+            if (!is_array($token) || $token[0] !== T_CATCH) {
+                continue;
+            }
+
+            while ($i < $count && $this->tokenText($tokens[$i]) !== '{') {
+                $i++;
+            }
+
+            if ($i >= $count || $this->tokenText($tokens[$i]) !== '{') {
+                continue;
+            }
+
+            $braceDepth = 1;
+            $i++;
+            $body = '';
+
+            for (; $i < $count; $i++) {
+                $text = $this->tokenText($tokens[$i]);
+
+                if ($text === '{') {
+                    $braceDepth++;
+                    $body .= $text;
+                    continue;
+                }
+
+                if ($text === '}') {
+                    $braceDepth--;
+                    if ($braceDepth === 0) {
+                        break;
+                    }
+                    $body .= $text;
+                    continue;
+                }
+
+                $body .= $text;
+            }
+
+            $bodies[] = $body;
+        }
+
+        return $bodies;
+    }
+
+    /**
+     * @param string|array{int, string, int} $token
+     */
+    private function tokenText(string|array $token): string
+    {
+        if (is_string($token)) {
+            return $token;
+        }
+
+        return $token[1];
+    }
+
+    private function stripComments(string $source): string
+    {
+        $withoutBlock = preg_replace('/\/\*.*?\*\//s', '', $source);
+        $withoutLine = preg_replace('/\/\/[^\n]*|#[^\n]*/', '', (string) $withoutBlock);
+
+        return (string) $withoutLine;
+    }
+}

--- a/backend/tests/Unit/Support/Database/SchemaIndexTest.php
+++ b/backend/tests/Unit/Support/Database/SchemaIndexTest.php
@@ -1,0 +1,87 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Support\Database;
+
+use App\Support\Database\SchemaIndex;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+use Tests\TestCase;
+
+final class SchemaIndexTest extends TestCase
+{
+    private string $tableName = 'schema_index_test_rows';
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        Schema::dropIfExists($this->tableName);
+        Schema::create($this->tableName, function (Blueprint $table): void {
+            $table->id();
+            $table->string('name', 64)->nullable();
+        });
+    }
+
+    protected function tearDown(): void
+    {
+        Schema::dropIfExists($this->tableName);
+        parent::tearDown();
+    }
+
+    public function test_index_exists_returns_true_after_create_and_false_after_drop(): void
+    {
+        $indexName = 'idx_schema_index_name';
+
+        $this->assertFalse(SchemaIndex::indexExists($this->tableName, $indexName));
+
+        Schema::table($this->tableName, function (Blueprint $table) use ($indexName): void {
+            $table->index('name', $indexName);
+        });
+
+        $this->assertTrue(SchemaIndex::indexExists($this->tableName, $indexName));
+
+        Schema::table($this->tableName, function (Blueprint $table) use ($indexName): void {
+            $table->dropIndex($indexName);
+        });
+
+        $this->assertFalse(SchemaIndex::indexExists($this->tableName, $indexName));
+    }
+
+    public function test_is_duplicate_index_exception_returns_true_for_duplicate_create(): void
+    {
+        $indexName = 'idx_schema_index_duplicate';
+
+        Schema::table($this->tableName, function (Blueprint $table) use ($indexName): void {
+            $table->index('name', $indexName);
+        });
+
+        try {
+            Schema::table($this->tableName, function (Blueprint $table) use ($indexName): void {
+                $table->index('name', $indexName);
+            });
+        } catch (\Throwable $e) {
+            $this->assertTrue(SchemaIndex::isDuplicateIndexException($e, $indexName));
+            return;
+        }
+
+        $this->fail('Expected duplicate index exception was not thrown.');
+    }
+
+    public function test_is_missing_index_exception_returns_true_for_drop_missing_index(): void
+    {
+        $indexName = 'idx_schema_index_missing';
+
+        try {
+            Schema::table($this->tableName, function (Blueprint $table) use ($indexName): void {
+                $table->dropIndex($indexName);
+            });
+        } catch (\Throwable $e) {
+            $this->assertTrue(SchemaIndex::isMissingIndexException($e, $indexName));
+            return;
+        }
+
+        $this->fail('Expected missing index exception was not thrown.');
+    }
+}

--- a/docs/verify/pr49_recon.md
+++ b/docs/verify/pr49_recon.md
@@ -1,0 +1,22 @@
+# PR49 Recon
+
+- Keywords: Throwable|migrations|index
+- 相关入口文件：
+  - backend/database/migrations/*
+  - backend/app/Support/Database/SchemaIndex.php
+- 相关路由：
+  - 本 PR 不新增路由
+- 相关 DB 表/迁移：
+  - 扫描所有 migrations 的 catch 块并移除 silent catch
+  - 重点修复 index create/drop 的吞异常点
+- 需要新增/修改点：
+  - 迁移仅允许可判定场景忽略（index 已存在/不存在）
+  - 非可判定异常必须 rethrow
+  - 增加 SchemaIndex 工具类（sqlite/mysql/pgsql index exists + exception classifier + safe logs）
+  - 增加防回归测试与 PR49 accept/verify 脚本
+- 风险点与规避：
+  - sqlite 与 mysql/pgsql 的 index introspection 差异：统一走 SchemaIndex
+  - sqlite fresh migrate/rollback 路径：纳入 PR49 accept 脚本
+  - pack/seed/config 一致性：verify 脚本内做 config + scales_registry + pack 文件闭环检查
+  - API 验收题量：由 /questions 动态生成 answers，禁止写死题量
+  - artifacts 脱敏：统一执行 backend/scripts/sanitize_artifacts.sh 49

--- a/docs/verify/pr49_verify.md
+++ b/docs/verify/pr49_verify.md
@@ -1,0 +1,32 @@
+# PR49 Verify
+
+- Date: 2026-02-07
+- Commands:
+  - php artisan route:list
+  - php artisan migrate
+  - php artisan test --filter SchemaIndexTest
+  - php artisan test --filter MigrationsNoSilentCatchTest
+  - bash backend/scripts/pr49_accept.sh
+  - bash backend/scripts/ci_verify_mbti.sh
+- Result:
+  - route:list: PASS
+  - migrate: PASS
+  - SchemaIndexTest: PASS
+  - MigrationsNoSilentCatchTest: PASS
+  - pr49_accept: PASS
+  - ci_verify_mbti: PASS
+- Artifacts:
+  - backend/artifacts/pr49/summary.txt
+  - backend/artifacts/pr49/verify.log
+  - backend/artifacts/pr49/pack_seed_config.txt
+  - backend/artifacts/pr49/phpunit_schema_index.txt
+  - backend/artifacts/pr49/phpunit_migrations_no_silent_catch.txt
+  - backend/artifacts/verify_mbti/summary.txt
+
+Step Verification Commands
+
+1. Step 1 (routes): `cd backend && php artisan route:list | grep -E "api/v0.3/scales/\{scale_code\}/questions|api/v0.3/attempts/start|api/v0.3/attempts/submit|api/v0.2/healthz"`
+2. Step 2 (migrations): `cd backend && touch /tmp/pr49.sqlite && DB_CONNECTION=sqlite DB_DATABASE=/tmp/pr49.sqlite php artisan migrate:fresh --force && DB_CONNECTION=sqlite DB_DATABASE=/tmp/pr49.sqlite php artisan migrate:rollback --step=1 --force && DB_CONNECTION=sqlite DB_DATABASE=/tmp/pr49.sqlite php artisan migrate --force`
+3. Step 3 (middleware): `grep -n -E "DB::table\\('fm_tokens'\\)|DB::table\\(\"fm_tokens\"\\)" backend/app/Http/Middleware/FmTokenAuth.php && grep -n -E "attributes->set\\('fm_user_id'|attributes->set\\(\"fm_user_id\"" backend/app/Http/Middleware/FmTokenAuth.php`
+4. Step 4 (service/tests): `cd backend && php -l app/Support/Database/SchemaIndex.php && php artisan test --filter SchemaIndexTest && php artisan test --filter MigrationsNoSilentCatchTest`
+5. Step 5 (scripts/CI): `bash -n backend/scripts/pr49_verify.sh && bash -n backend/scripts/pr49_accept.sh && bash backend/scripts/pr49_accept.sh && bash backend/scripts/ci_verify_mbti.sh`


### PR DESCRIPTION
What:
Remove silent exception swallowing in migrations; make index ops deterministic (only ignore “index already exists / missing”); add observability logs and tests.
Why:
Prevent hidden migration failures that silently corrupt schema state.
Ensure rollback safety and predictable CI behavior across sqlite/mysql/pgsql.
How:
[SchemaIndex.php](app://-/index.html#): index existence checks + duplicate/missing exception classifiers + safe logs
backend/database/migrations/*: refactor try/catch to deterministic index create/drop with rethrow on unknown errors
[SchemaIndexTest.php](app://-/index.html#)
[MigrationsNoSilentCatchTest.php](app://-/index.html#)
[pr49_accept.sh](app://-/index.html#) / [pr49_verify.sh](app://-/index.html#)
Verify:
[pr49_accept.sh](app://-/index.html#)
[ci_verify_mbti.sh](app://-/index.html#)
Artifacts:
[summary.txt](app://-/index.html#)