### PR TITLE
chore(pr52): Stabilize API error codes and contract

### DIFF
--- a/.github/workflows/ci_verify_mbti.yml
+++ b/.github/workflows/ci_verify_mbti.yml
@@ -100,6 +100,15 @@ jobs:
         run: |
           bash scripts/ci/prepare_sqlite.sh
 
+      - name: Run API error contract regression tests
+        working-directory: backend
+        run: |
+          php artisan test --filter ApiExceptionRendererTest
+          php artisan test --filter UuidRouteParamsMiddlewareTest
+          php artisan test --filter OrgContextMiddlewareTest
+          php artisan test --filter MeAttemptsAuthContractTest
+          php artisan test --filter ApiErrorContractMiddlewareTest
+
       - name: Check content packs index endpoint
         working-directory: backend
         run: |

--- a/backend/app/Http/Middleware/EnsureUuidRouteParams.php
+++ b/backend/app/Http/Middleware/EnsureUuidRouteParams.php
@@ -21,6 +21,7 @@ class EnsureUuidRouteParams
                 return response()->json([
                     'ok' => false,
                     'error' => 'NOT_FOUND',
+                    'error_code' => 'NOT_FOUND',
                     'message' => 'Not Found',
                 ], 404);
             }

--- a/backend/app/Http/Middleware/FmTokenAuth.php
+++ b/backend/app/Http/Middleware/FmTokenAuth.php
@@ -216,8 +216,9 @@ class FmTokenAuth
         $this->logAuthResult($request, false, $reason);
 
         return response()->json([
-            'ok'      => false,
-            'error'   => 'UNAUTHORIZED',
+            'ok' => false,
+            'error' => 'UNAUTHORIZED',
+            'error_code' => 'UNAUTHORIZED',
             'message' => 'Missing or invalid fm_token. Please login.',
         ], 401)->withHeaders([
             'WWW-Authenticate' => 'Bearer realm="Fermat API", error="invalid_token"',

--- a/backend/app/Http/Middleware/NormalizeApiErrorContract.php
+++ b/backend/app/Http/Middleware/NormalizeApiErrorContract.php
@@ -1,0 +1,76 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Middleware;
+
+use Closure;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+use Symfony\Component\HttpFoundation\Response;
+
+final class NormalizeApiErrorContract
+{
+    public function handle(Request $request, Closure $next): Response
+    {
+        $response = $next($request);
+
+        if (!$request->is('api/*') || !($response instanceof JsonResponse)) {
+            return $response;
+        }
+
+        $payload = $response->getData(true);
+        if (!is_array($payload)) {
+            return $response;
+        }
+
+        $isError = $response->getStatusCode() >= 400 || (($payload['ok'] ?? null) === false);
+        if (!$isError) {
+            return $response;
+        }
+
+        $errorCode = $this->resolveErrorCode($payload);
+        if ($errorCode === '') {
+            return $response;
+        }
+
+        $payload['error_code'] = $errorCode;
+        $response->setData($payload);
+
+        return $response;
+    }
+
+    private function resolveErrorCode(array $payload): string
+    {
+        $raw = '';
+
+        if (isset($payload['error_code']) && is_string($payload['error_code'])) {
+            $raw = $payload['error_code'];
+        } elseif (isset($payload['error']) && is_string($payload['error'])) {
+            $raw = $payload['error'];
+        } elseif (
+            isset($payload['error'])
+            && is_array($payload['error'])
+            && isset($payload['error']['code'])
+            && is_string($payload['error']['code'])
+        ) {
+            $raw = $payload['error']['code'];
+        }
+
+        return $this->normalizeCode($raw);
+    }
+
+    private function normalizeCode(string $raw): string
+    {
+        $code = trim($raw);
+        if ($code === '') {
+            return '';
+        }
+
+        $code = str_replace(['-', ' '], '_', $code);
+        $code = (string) preg_replace('/[^A-Za-z0-9_]+/', '_', $code);
+        $code = trim($code, '_');
+
+        return strtoupper($code);
+    }
+}

--- a/backend/app/Support/ApiExceptionRenderer.php
+++ b/backend/app/Support/ApiExceptionRenderer.php
@@ -27,6 +27,7 @@ final class ApiExceptionRenderer
         $payload = [
             'ok' => false,
             'error' => 'INTERNAL_ERROR',
+            'error_code' => 'INTERNAL_ERROR',
             'message' => 'Internal Server Error',
         ];
 
@@ -35,6 +36,7 @@ final class ApiExceptionRenderer
             $payload = [
                 'ok' => false,
                 'error' => 'NOT_FOUND',
+                'error_code' => 'NOT_FOUND',
                 'message' => 'Not Found',
             ];
         }

--- a/backend/scripts/pr52_accept.sh
+++ b/backend/scripts/pr52_accept.sh
@@ -1,0 +1,103 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+export CI=true
+export FAP_NONINTERACTIVE=1
+export COMPOSER_NO_INTERACTION=1
+export GIT_TERMINAL_PROMPT=0
+export NO_COLOR=1
+export PAGER=cat
+export GIT_PAGER=cat
+export TERM=dumb
+export XDEBUG_MODE=off
+export LANG=en_US.UTF-8
+
+REPO_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+BACKEND_DIR="${REPO_DIR}/backend"
+ART_DIR="${BACKEND_DIR}/artifacts/pr52"
+SERVE_PORT="${SERVE_PORT:-1852}"
+DB_PATH="/tmp/pr52.sqlite"
+
+mkdir -p "${ART_DIR}"
+
+cleanup_port() {
+  local port="$1"
+  lsof -nP -iTCP:"${port}" -sTCP:LISTEN || true
+  local pid_list
+  pid_list="$(lsof -ti tcp:"${port}" || true)"
+  if [[ -n "${pid_list}" ]]; then
+    echo "${pid_list}" | xargs kill -9 || true
+  fi
+  lsof -nP -iTCP:"${port}" -sTCP:LISTEN || true
+}
+
+cleanup() {
+  if [[ -f "${ART_DIR}/server.pid" ]]; then
+    local pid
+    pid="$(cat "${ART_DIR}/server.pid" || true)"
+    if [[ -n "${pid}" ]] && ps -p "${pid}" >/dev/null 2>&1; then
+      kill "${pid}" >/dev/null 2>&1 || true
+    fi
+  fi
+  cleanup_port "${SERVE_PORT}"
+  cleanup_port 18000
+  rm -f "${DB_PATH}"
+}
+trap cleanup EXIT
+
+cleanup_port "${SERVE_PORT}"
+cleanup_port 18000
+
+export APP_ENV=testing
+export CACHE_STORE=array
+export QUEUE_CONNECTION=sync
+export DB_CONNECTION=sqlite
+export DB_DATABASE="${DB_PATH}"
+export FAP_PACKS_ROOT="${FAP_PACKS_ROOT:-${REPO_DIR}/content_packages}"
+export FAP_DEFAULT_REGION="${FAP_DEFAULT_REGION:-CN_MAINLAND}"
+export FAP_DEFAULT_LOCALE="${FAP_DEFAULT_LOCALE:-zh-CN}"
+export FAP_DEFAULT_PACK_ID="${FAP_DEFAULT_PACK_ID:-MBTI.cn-mainland.zh-CN.v0.2.2}"
+export FAP_DEFAULT_DIR_VERSION="${FAP_DEFAULT_DIR_VERSION:-MBTI-CN-v0.2.2}"
+
+rm -f "${DB_PATH}"
+touch "${DB_PATH}"
+
+cd "${BACKEND_DIR}"
+composer install --no-interaction --no-progress
+php artisan migrate:fresh --force
+php artisan fap:scales:seed-default
+php artisan fap:scales:sync-slugs
+cd "${REPO_DIR}"
+
+SERVE_PORT="${SERVE_PORT}" ART_DIR="${ART_DIR}" bash "${BACKEND_DIR}/scripts/pr52_verify.sh"
+
+ATTEMPT_ID="$(cat "${ART_DIR}/attempt_id.txt" 2>/dev/null || true)"
+ANON_ID="$(cat "${ART_DIR}/anon_id.txt" 2>/dev/null || true)"
+DEFAULT_PACK_ID="$(cat "${ART_DIR}/config_default_pack_id.txt" 2>/dev/null || true)"
+
+cat > "${ART_DIR}/summary.txt" <<TXT
+PR52 Acceptance Summary
+- pass_items:
+  - api_error_code_contract: OK
+  - uuid_route_guard_v03_attempts: OK
+  - exception_renderer_error_code: OK
+  - pack_seed_config_consistency: OK
+  - dynamic_answers_submit: OK
+  - phpunit(error_contract_suite): PASS
+- key_outputs:
+  - attempt_id: ${ATTEMPT_ID}
+  - anon_id: ${ANON_ID}
+  - default_pack_id: ${DEFAULT_PACK_ID}
+- smoke_urls:
+  - http://127.0.0.1:${SERVE_PORT}/api/v0.2/me/attempts
+  - http://127.0.0.1:${SERVE_PORT}/api/v0.2/shares/not-a-uuid/click
+  - http://127.0.0.1:${SERVE_PORT}/api/v0.3/attempts/not-a-uuid/report
+- schema_changes:
+  - none
+TXT
+
+cd "${REPO_DIR}"
+bash "${BACKEND_DIR}/scripts/sanitize_artifacts.sh" 52
+
+bash -n "${BACKEND_DIR}/scripts/pr52_accept.sh"
+bash -n "${BACKEND_DIR}/scripts/pr52_verify.sh"

--- a/backend/scripts/pr52_verify.sh
+++ b/backend/scripts/pr52_verify.sh
@@ -1,0 +1,302 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+export CI=true
+export FAP_NONINTERACTIVE=1
+export COMPOSER_NO_INTERACTION=1
+export GIT_TERMINAL_PROMPT=0
+export NO_COLOR=1
+export PAGER=cat
+export GIT_PAGER=cat
+export TERM=dumb
+export XDEBUG_MODE=off
+export LANG=en_US.UTF-8
+
+REPO_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+BACKEND_DIR="${REPO_DIR}/backend"
+ART_DIR="${ART_DIR:-${BACKEND_DIR}/artifacts/pr52}"
+SERVE_PORT="${SERVE_PORT:-1852}"
+HOST="127.0.0.1"
+API_BASE="http://${HOST}:${SERVE_PORT}"
+SCALE_CODE="${SCALE_CODE:-MBTI}"
+ANON_ID="${ANON_ID:-pr52-verify-anon}"
+
+export FAP_PACKS_ROOT="${FAP_PACKS_ROOT:-${REPO_DIR}/content_packages}"
+export FAP_DEFAULT_REGION="${FAP_DEFAULT_REGION:-CN_MAINLAND}"
+export FAP_DEFAULT_LOCALE="${FAP_DEFAULT_LOCALE:-zh-CN}"
+export FAP_DEFAULT_PACK_ID="${FAP_DEFAULT_PACK_ID:-MBTI.cn-mainland.zh-CN.v0.2.2}"
+export FAP_DEFAULT_DIR_VERSION="${FAP_DEFAULT_DIR_VERSION:-MBTI-CN-v0.2.2}"
+
+mkdir -p "${ART_DIR}"
+exec > "${ART_DIR}/verify.log" 2>&1
+
+fail() {
+  echo "[PR52][FAIL] $*" >&2
+  exit 1
+}
+
+cleanup_port() {
+  local port="$1"
+  lsof -nP -iTCP:"${port}" -sTCP:LISTEN || true
+  local pid_list
+  pid_list="$(lsof -ti tcp:"${port}" || true)"
+  if [[ -n "${pid_list}" ]]; then
+    echo "${pid_list}" | xargs kill -9 || true
+  fi
+  lsof -nP -iTCP:"${port}" -sTCP:LISTEN || true
+}
+
+wait_health() {
+  local url="$1"
+  local body_file="${ART_DIR}/healthz.body"
+  local http_code=""
+
+  for _ in $(seq 1 80); do
+    http_code="$(curl -sS -o "${body_file}" -w "%{http_code}" "${url}" || true)"
+    if [[ "${http_code}" == "200" ]]; then
+      return 0
+    fi
+    sleep 0.25
+  done
+
+  echo "health_check_failed http=${http_code}" >&2
+  cat "${body_file}" >&2 || true
+  tail -n 120 "${ART_DIR}/server.log" >&2 || true
+  return 1
+}
+
+cleanup() {
+  if [[ -n "${SERVE_PID:-}" ]] && ps -p "${SERVE_PID}" >/dev/null 2>&1; then
+    kill "${SERVE_PID}" >/dev/null 2>&1 || true
+  fi
+  cleanup_port "${SERVE_PORT}"
+  cleanup_port 18000
+}
+trap cleanup EXIT
+
+cleanup_port "${SERVE_PORT}"
+cleanup_port 18000
+
+cd "${BACKEND_DIR}"
+php artisan serve --host="${HOST}" --port="${SERVE_PORT}" > "${ART_DIR}/server.log" 2>&1 &
+SERVE_PID="$!"
+echo "${SERVE_PID}" > "${ART_DIR}/server.pid"
+cd "${REPO_DIR}"
+
+wait_health "${API_BASE}/api/v0.2/healthz" || fail "healthz failed"
+curl -sS "${API_BASE}/api/v0.2/healthz" > "${ART_DIR}/healthz.json"
+
+# pack/seed/config consistency
+cd "${BACKEND_DIR}"
+php -r '
+require "vendor/autoload.php";
+$app=require "bootstrap/app.php";
+$app->make(Illuminate\Contracts\Console\Kernel::class)->bootstrap();
+echo (string) config("content_packs.default_pack_id", "");
+' > "${ART_DIR}/config_default_pack_id.txt"
+
+php -r '
+require "vendor/autoload.php";
+$app=require "bootstrap/app.php";
+$app->make(Illuminate\Contracts\Console\Kernel::class)->bootstrap();
+$packId = (string) config("content_packs.default_pack_id", "");
+$dirVersion = (string) config("content_packs.default_dir_version", "");
+echo "config_default_pack_id=".$packId.PHP_EOL;
+echo "config_default_dir_version=".$dirVersion.PHP_EOL;
+if ($packId === "" || $dirVersion === "") {
+    fwrite(STDERR, "missing_content_pack_defaults\n");
+    exit(1);
+}
+if (!Illuminate\Support\Facades\Schema::hasTable("scales_registry")) {
+    fwrite(STDERR, "missing_scales_registry_table\n");
+    exit(1);
+}
+$row = Illuminate\Support\Facades\DB::table("scales_registry")
+    ->where("org_id", 0)
+    ->where("code", "MBTI")
+    ->first();
+if (!$row) {
+    fwrite(STDERR, "missing_scales_registry_mbti\n");
+    exit(1);
+}
+$registryPackId = (string) ($row->default_pack_id ?? "");
+$registryDirVersion = (string) ($row->default_dir_version ?? "");
+echo "registry_default_pack_id=".$registryPackId.PHP_EOL;
+echo "registry_default_dir_version=".$registryDirVersion.PHP_EOL;
+if ($registryPackId !== $packId) {
+    fwrite(STDERR, "default_pack_id_mismatch\n");
+    exit(1);
+}
+if ($registryDirVersion !== $dirVersion) {
+    fwrite(STDERR, "default_dir_version_mismatch\n");
+    exit(1);
+}
+$index = app(App\Services\Content\ContentPacksIndex::class);
+$found = $index->find($packId, $dirVersion);
+if (!($found["ok"] ?? false)) {
+    fwrite(STDERR, "pack_not_found\n");
+    exit(1);
+}
+$item = $found["item"] ?? [];
+$manifestPath = (string) ($item["manifest_path"] ?? "");
+$questionsPath = (string) ($item["questions_path"] ?? "");
+if ($manifestPath === "" || !is_file($manifestPath)) {
+    fwrite(STDERR, "manifest_missing\n");
+    exit(1);
+}
+if ($questionsPath === "" || !is_file($questionsPath)) {
+    fwrite(STDERR, "questions_missing\n");
+    exit(1);
+}
+$packDir = dirname($manifestPath);
+$versionPath = $packDir.DIRECTORY_SEPARATOR."version.json";
+if (!is_file($versionPath)) {
+    fwrite(STDERR, "version_missing\n");
+    exit(1);
+}
+$manifest = json_decode((string) file_get_contents($manifestPath), true);
+$questions = json_decode((string) file_get_contents($questionsPath), true);
+$version = json_decode((string) file_get_contents($versionPath), true);
+if (!is_array($manifest) || !is_array($questions) || !is_array($version)) {
+    fwrite(STDERR, "pack_json_invalid\n");
+    exit(1);
+}
+echo "pack_manifest=".$manifestPath.PHP_EOL;
+echo "pack_questions=".$questionsPath.PHP_EOL;
+echo "pack_version=".$versionPath.PHP_EOL;
+' > "${ART_DIR}/pack_seed_config.txt"
+cd "${REPO_DIR}"
+
+# error contract checks
+SHARE_INVALID_JSON="${ART_DIR}/share_invalid_uuid.json"
+http_code="$(curl -sS -o "${SHARE_INVALID_JSON}" -w "%{http_code}" -X POST "${API_BASE}/api/v0.2/shares/not-a-uuid/click" || true)"
+[[ "${http_code}" == "404" ]] || fail "invalid share uuid must return 404"
+php -r '$j=json_decode(file_get_contents($argv[1]), true); if (!is_array($j) || (($j["error_code"] ?? "") !== "NOT_FOUND")) {fwrite(STDERR,"share_invalid_uuid_error_code_mismatch\n"); exit(1);} ' "${SHARE_INVALID_JSON}"
+
+ME_ATTEMPTS_JSON="${ART_DIR}/me_attempts_unauthorized.json"
+http_code="$(curl -sS -o "${ME_ATTEMPTS_JSON}" -w "%{http_code}" "${API_BASE}/api/v0.2/me/attempts" || true)"
+[[ "${http_code}" == "401" ]] || fail "me attempts without token must return 401"
+php -r '$j=json_decode(file_get_contents($argv[1]), true); if (!is_array($j) || (($j["error_code"] ?? "") !== "UNAUTHORIZED")) {fwrite(STDERR,"me_attempts_error_code_mismatch\n"); exit(1);} ' "${ME_ATTEMPTS_JSON}"
+
+ORG_404_JSON="${ART_DIR}/org_not_found.json"
+http_code="$(curl -sS -o "${ORG_404_JSON}" -w "%{http_code}" -H "X-Org-Id: 999999" "${API_BASE}/api/v0.3/scales" || true)"
+[[ "${http_code}" == "404" ]] || fail "non-member org context must return 404"
+php -r '$j=json_decode(file_get_contents($argv[1]), true); if (!is_array($j) || (($j["error_code"] ?? "") !== "ORG_NOT_FOUND")) {fwrite(STDERR,"org_not_found_error_code_mismatch\n"); exit(1);} ' "${ORG_404_JSON}"
+
+V03_MISS_JSON="${ART_DIR}/v03_missing_route.json"
+http_code="$(curl -sS -o "${V03_MISS_JSON}" -w "%{http_code}" "${API_BASE}/api/v0.3/__missing" || true)"
+[[ "${http_code}" == "404" ]] || fail "missing v0.3 route must return 404"
+php -r '$j=json_decode(file_get_contents($argv[1]), true); if (!is_array($j) || (($j["error_code"] ?? "") !== "NOT_FOUND")) {fwrite(STDERR,"v03_missing_error_code_mismatch\n"); exit(1);} ' "${V03_MISS_JSON}"
+
+QUESTIONS_JSON="${ART_DIR}/questions.json"
+http_code="$(curl -sS -o "${QUESTIONS_JSON}" -w "%{http_code}" \
+  -H "Accept: application/json" \
+  "${API_BASE}/api/v0.3/scales/${SCALE_CODE}/questions" || true)"
+if [[ "${http_code}" != "200" ]]; then
+  echo "questions_failed http=${http_code}" >&2
+  cat "${QUESTIONS_JSON}" >&2 || true
+  fail "questions endpoint failed"
+fi
+
+ANSWERS_JSON="${ART_DIR}/answers.json"
+php -r '
+$raw = file_get_contents("php://stdin");
+$data = json_decode($raw, true);
+if (!is_array($data)) {
+    fwrite(STDERR, "questions_json_invalid\n");
+    exit(1);
+}
+$items = $data["questions"]["items"] ?? $data["questions"] ?? $data["items"] ?? $data["data"] ?? $data;
+if (!is_array($items)) {
+    fwrite(STDERR, "questions_items_invalid\n");
+    exit(1);
+}
+$answers = [];
+foreach ($items as $item) {
+    if (!is_array($item)) {
+        continue;
+    }
+    $questionId = (string) ($item["question_id"] ?? $item["id"] ?? "");
+    if ($questionId === "") {
+        continue;
+    }
+    $options = $item["options"] ?? [];
+    $code = "A";
+    if (is_array($options) && isset($options[0]) && is_array($options[0])) {
+        $code = (string) ($options[0]["code"] ?? $options[0]["option_code"] ?? "A");
+    }
+    if ($code === "") {
+        $code = "A";
+    }
+    $answers[] = [
+        "question_id" => $questionId,
+        "code" => $code,
+    ];
+}
+if (count($answers) === 0) {
+    fwrite(STDERR, "answers_empty\n");
+    exit(1);
+}
+echo json_encode($answers, JSON_UNESCAPED_UNICODE);
+' < "${QUESTIONS_JSON}" > "${ANSWERS_JSON}"
+
+ATTEMPT_START_JSON="${ART_DIR}/attempt_start.json"
+ATTEMPT_START_BODY="$(SCALE_CODE="${SCALE_CODE}" ANON_ID="${ANON_ID}" php -r '
+$payload = [
+    "scale_code" => getenv("SCALE_CODE"),
+    "anon_id" => getenv("ANON_ID"),
+];
+echo json_encode($payload, JSON_UNESCAPED_UNICODE);
+')"
+http_code="$(curl -sS -o "${ATTEMPT_START_JSON}" -w "%{http_code}" \
+  -X POST -H "Content-Type: application/json" -H "Accept: application/json" \
+  --data "${ATTEMPT_START_BODY}" \
+  "${API_BASE}/api/v0.3/attempts/start" || true)"
+if [[ "${http_code}" != "200" ]]; then
+  echo "attempt_start_failed http=${http_code}" >&2
+  cat "${ATTEMPT_START_JSON}" >&2 || true
+  fail "attempt start failed"
+fi
+
+ATTEMPT_ID="$(php -r '$j=json_decode(file_get_contents($argv[1]), true); echo (string)($j["attempt_id"] ?? "");' "${ATTEMPT_START_JSON}")"
+if [[ -z "${ATTEMPT_ID}" ]]; then
+  fail "missing attempt_id"
+fi
+echo "${ATTEMPT_ID}" > "${ART_DIR}/attempt_id.txt"
+echo "${ANON_ID}" > "${ART_DIR}/anon_id.txt"
+
+SUBMIT_PAYLOAD="${ART_DIR}/submit_payload.json"
+ATTEMPT_ID="${ATTEMPT_ID}" ANSWERS_PATH="${ANSWERS_JSON}" php -r '
+$answers = json_decode(file_get_contents(getenv("ANSWERS_PATH")), true);
+if (!is_array($answers) || count($answers) === 0) {
+    fwrite(STDERR, "answers_payload_invalid\n");
+    exit(1);
+}
+$payload = [
+    "attempt_id" => getenv("ATTEMPT_ID"),
+    "answers" => $answers,
+    "duration_ms" => 120000,
+];
+echo json_encode($payload, JSON_UNESCAPED_UNICODE);
+' > "${SUBMIT_PAYLOAD}"
+
+ATTEMPT_SUBMIT_JSON="${ART_DIR}/attempt_submit.json"
+http_code="$(curl -sS -o "${ATTEMPT_SUBMIT_JSON}" -w "%{http_code}" \
+  -X POST -H "Content-Type: application/json" -H "Accept: application/json" \
+  --data @"${SUBMIT_PAYLOAD}" \
+  "${API_BASE}/api/v0.3/attempts/submit" || true)"
+if [[ "${http_code}" != "200" ]]; then
+  echo "attempt_submit_failed http=${http_code}" >&2
+  cat "${ATTEMPT_SUBMIT_JSON}" >&2 || true
+  fail "attempt submit failed"
+fi
+
+cd "${BACKEND_DIR}"
+php artisan test --filter ApiExceptionRendererTest > "${ART_DIR}/phpunit_api_exception_renderer.txt" 2>&1
+php artisan test --filter UuidRouteParamsMiddlewareTest > "${ART_DIR}/phpunit_uuid_route_params.txt" 2>&1
+php artisan test --filter OrgContextMiddlewareTest > "${ART_DIR}/phpunit_org_context.txt" 2>&1
+php artisan test --filter MeAttemptsAuthContractTest > "${ART_DIR}/phpunit_me_attempts_contract.txt" 2>&1
+php artisan test --filter ApiErrorContractMiddlewareTest > "${ART_DIR}/phpunit_error_contract_middleware.txt" 2>&1
+cd "${REPO_DIR}"
+
+echo "verify_done" > "${ART_DIR}/verify_done.txt"

--- a/backend/tests/Feature/ApiErrorContractMiddlewareTest.php
+++ b/backend/tests/Feature/ApiErrorContractMiddlewareTest.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature;
+
+use App\Http\Middleware\NormalizeApiErrorContract;
+use Illuminate\Support\Facades\Route;
+use Tests\TestCase;
+
+final class ApiErrorContractMiddlewareTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        Route::middleware(NormalizeApiErrorContract::class)->get('/api/__pr52/error-string', static function () {
+            return response()->json([
+                'ok' => false,
+                'error' => 'not_found',
+                'message' => 'missing',
+            ], 404);
+        });
+
+        Route::middleware(NormalizeApiErrorContract::class)->get('/api/__pr52/error-object', static function () {
+            return response()->json([
+                'error' => [
+                    'code' => 'rate_limit_public',
+                    'message' => 'too many requests',
+                ],
+            ], 429);
+        });
+    }
+
+    public function test_string_error_gets_top_level_error_code(): void
+    {
+        $response = $this->getJson('/api/__pr52/error-string');
+
+        $response->assertStatus(404);
+        $response->assertJsonPath('error', 'not_found');
+        $response->assertJsonPath('error_code', 'NOT_FOUND');
+    }
+
+    public function test_object_error_gets_top_level_error_code(): void
+    {
+        $response = $this->getJson('/api/__pr52/error-object');
+
+        $response->assertStatus(429);
+        $response->assertJsonPath('error.code', 'rate_limit_public');
+        $response->assertJsonPath('error_code', 'RATE_LIMIT_PUBLIC');
+    }
+}

--- a/backend/tests/Feature/ApiExceptionRendererTest.php
+++ b/backend/tests/Feature/ApiExceptionRendererTest.php
@@ -29,6 +29,7 @@ class ApiExceptionRendererTest extends TestCase
         $response->assertJson([
             'ok' => false,
             'error' => 'INTERNAL_ERROR',
+            'error_code' => 'INTERNAL_ERROR',
             'message' => 'Internal Server Error',
         ]);
     }
@@ -45,6 +46,7 @@ class ApiExceptionRendererTest extends TestCase
         $response->assertJson([
             'ok' => false,
             'error' => 'NOT_FOUND',
+            'error_code' => 'NOT_FOUND',
             'message' => 'Not Found',
         ]);
     }

--- a/backend/tests/Feature/UuidRouteParamsMiddlewareTest.php
+++ b/backend/tests/Feature/UuidRouteParamsMiddlewareTest.php
@@ -16,6 +16,7 @@ final class UuidRouteParamsMiddlewareTest extends TestCase
         $response->assertJson([
             'ok' => false,
             'error' => 'NOT_FOUND',
+            'error_code' => 'NOT_FOUND',
             'message' => 'Not Found',
         ]);
     }
@@ -28,7 +29,20 @@ final class UuidRouteParamsMiddlewareTest extends TestCase
         $response->assertJson([
             'ok' => false,
             'error' => 'NOT_FOUND',
+            'error_code' => 'NOT_FOUND',
             'message' => 'Not Found',
+        ]);
+    }
+
+    public function test_v03_attempt_report_with_invalid_uuid_returns_uniform_404_json(): void
+    {
+        $response = $this->getJson('/api/v0.3/attempts/not-a-uuid/report');
+
+        $response->assertStatus(404);
+        $response->assertJson([
+            'ok' => false,
+            'error' => 'NOT_FOUND',
+            'error_code' => 'NOT_FOUND',
         ]);
     }
 }

--- a/backend/tests/Feature/V0_2/MeAttemptsAuthContractTest.php
+++ b/backend/tests/Feature/V0_2/MeAttemptsAuthContractTest.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\V0_2;
+
+use Tests\TestCase;
+
+final class MeAttemptsAuthContractTest extends TestCase
+{
+    public function test_me_attempts_unauthorized_contains_error_code(): void
+    {
+        $response = $this->getJson('/api/v0.2/me/attempts');
+
+        $response->assertStatus(401);
+        $response->assertJson([
+            'ok' => false,
+            'error' => 'UNAUTHORIZED',
+            'error_code' => 'UNAUTHORIZED',
+        ]);
+    }
+}

--- a/backend/tests/Feature/V0_3/OrgContextMiddlewareTest.php
+++ b/backend/tests/Feature/V0_3/OrgContextMiddlewareTest.php
@@ -54,6 +54,7 @@ class OrgContextMiddlewareTest extends TestCase
         $resp->assertJson([
             'ok' => false,
             'error' => 'ORG_NOT_FOUND',
+            'error_code' => 'ORG_NOT_FOUND',
         ]);
     }
 

--- a/docs/verify/pr52_recon.md
+++ b/docs/verify/pr52_recon.md
@@ -1,0 +1,30 @@
+# PR52 Recon
+
+- Keywords: error_code|json|renderer
+- 相关入口文件：
+  - backend/routes/api.php
+  - backend/app/Http/Middleware/FmTokenAuth.php
+  - backend/app/Http/Middleware/EnsureUuidRouteParams.php
+  - backend/app/Http/Middleware/NormalizeApiErrorContract.php
+  - backend/app/Support/ApiExceptionRenderer.php
+- 相关路由：
+  - GET /api/v0.2/me/attempts
+  - POST /api/v0.2/shares/{shareId}/click
+  - GET|PUT /api/v0.3/attempts/{attempt_id}/progress
+  - GET /api/v0.3/attempts/{id}/result
+  - GET /api/v0.3/attempts/{id}/report
+- 相关 DB 表/迁移：
+  - 本 PR 不新增迁移；需验证 sqlite migrate:fresh 可通过
+- 需要新增/修改点：
+  - 统一 API 错误响应包含 `error_code`
+  - `FmTokenAuth` 未授权响应补齐 `error_code=UNAUTHORIZED`
+  - UUID 参数错误返回 404 时补齐 `error_code=NOT_FOUND`
+  - v0.3 attempt 读取类路由补 UUID 守卫
+  - 新增 PR52 accept/verify 脚本并固化错误契约回归
+- 风险点与规避（端口/CI 工具依赖/pack-seed-config 一致性/sqlite 迁移一致性/404 口径/脱敏）：
+  - 端口冲突：统一清理 1852/18000
+  - 脚本工具依赖：仅使用 grep -E/sed/awk/php -r/curl/lsof
+  - pack/seed/config：verify 脚本检查 config + scales_registry + pack 文件可解析
+  - sqlite 一致性：accept 脚本固定 sqlite fresh migrate + seed
+  - 404 口径：跨 org 与 UUID 错误均为 404 且输出 error_code
+  - artifacts 脱敏：统一执行 backend/scripts/sanitize_artifacts.sh 52

--- a/docs/verify/pr52_verify.md
+++ b/docs/verify/pr52_verify.md
@@ -1,0 +1,47 @@
+# PR52 Verify
+
+- Date: 2026-02-07
+- Commands:
+  - php artisan route:list
+  - php artisan migrate
+  - php artisan test --filter ApiExceptionRendererTest
+  - php artisan test --filter UuidRouteParamsMiddlewareTest
+  - php artisan test --filter OrgContextMiddlewareTest
+  - php artisan test --filter MeAttemptsAuthContractTest
+  - php artisan test --filter ApiErrorContractMiddlewareTest
+  - bash backend/scripts/pr52_accept.sh
+  - bash backend/scripts/ci_verify_mbti.sh
+- Result:
+  - route:list: PASS
+  - migrate: PASS
+  - ApiExceptionRendererTest: PASS
+  - UuidRouteParamsMiddlewareTest: PASS
+  - OrgContextMiddlewareTest: PASS
+  - MeAttemptsAuthContractTest: PASS
+  - ApiErrorContractMiddlewareTest: PASS
+  - pr52_accept: PASS
+  - ci_verify_mbti: PASS
+- Artifacts:
+  - backend/artifacts/pr52/summary.txt
+  - backend/artifacts/pr52/verify.log
+  - backend/artifacts/pr52/pack_seed_config.txt
+  - backend/artifacts/pr52/me_attempts_unauthorized.json
+  - backend/artifacts/pr52/share_invalid_uuid.json
+  - backend/artifacts/pr52/org_not_found.json
+  - backend/artifacts/pr52/v03_missing_route.json
+  - backend/artifacts/verify_mbti/summary.txt
+
+Step Verification Commands
+
+1. Step 1 (routes): `cd backend && php artisan route:list | grep -E "api/v0.2/me/attempts|api/v0.3/attempts/\{attempt_id\}/progress|api/v0.3/attempts/\{id\}/(result|report)"`
+2. Step 2 (migrations): `cd backend && php artisan migrate --force && rm -f /tmp/pr52.sqlite && touch /tmp/pr52.sqlite && DB_CONNECTION=sqlite DB_DATABASE=/tmp/pr52.sqlite php artisan migrate:fresh --force`
+3. Step 3 (middleware): `grep -n -E "DB::table\('fm_tokens'\)|attributes->set\('fm_user_id'" backend/app/Http/Middleware/FmTokenAuth.php && php -l backend/app/Http/Middleware/FmTokenAuth.php && php -l backend/app/Http/Middleware/EnsureUuidRouteParams.php`
+4. Step 4 (controller/service/tests): `php -l backend/app/Support/ApiExceptionRenderer.php && php -l backend/app/Http/Middleware/NormalizeApiErrorContract.php && cd backend && php artisan test --filter ApiExceptionRendererTest && php artisan test --filter UuidRouteParamsMiddlewareTest && php artisan test --filter OrgContextMiddlewareTest && php artisan test --filter MeAttemptsAuthContractTest && php artisan test --filter ApiErrorContractMiddlewareTest`
+5. Step 5 (scripts/CI): `bash -n backend/scripts/pr52_verify.sh && bash -n backend/scripts/pr52_accept.sh && bash backend/scripts/pr52_accept.sh && bash backend/scripts/ci_verify_mbti.sh`
+
+Contract Smoke (curl)
+
+- `curl -i http://127.0.0.1:1852/api/v0.2/me/attempts` -> `401` + `error_code=UNAUTHORIZED`
+- `curl -i -X POST http://127.0.0.1:1852/api/v0.2/shares/not-a-uuid/click` -> `404` + `error_code=NOT_FOUND`
+- `curl -i -H "X-Org-Id: 999999" http://127.0.0.1:1852/api/v0.3/scales` -> `404` + `error_code=ORG_NOT_FOUND`
+- `curl -i http://127.0.0.1:1852/api/v0.3/__missing` -> `404` + `error_code=NOT_FOUND`


### PR DESCRIPTION
What:
Stabilize API error JSON contract by adding/normalizing error_code across v0.2/v0.3/v0.4 error paths.
Why:
Prevent client-side branching failures caused by inconsistent error payload shapes.
Keep existing status-code semantics and legacy error field behavior while improving contract consistency.
How:
Add [NormalizeApiErrorContract.php](app://-/index.html#).
Wire middleware in [api.php](app://-/index.html#) for v0.2/v0.3/v0.4 groups.
Add explicit error_code in [FmTokenAuth.php](app://-/index.html#) and [ApiExceptionRenderer.php](app://-/index.html#).
Harden v0.3 attempt read routes with UUID middleware in [api.php](app://-/index.html#).
Add regression tests: [MeAttemptsAuthContractTest.php](app://-/index.html#) and [ApiErrorContractMiddlewareTest.php](app://-/index.html#), plus updated assertions in existing tests.
Add acceptance scripts [pr52_accept.sh](app://-/index.html#) and [pr52_verify.sh](app://-/index.html#).
Add docs [pr52_recon.md](app://-/index.html#) and [pr52_verify.md](app://-/index.html#).
Extend CI workflow [ci_verify_mbti.yml](app://-/index.html#) with API error-contract regression tests.
Verify:
[pr52_accept.sh](app://-/index.html#)
[ci_verify_mbti.sh](app://-/index.html#)
Artifacts:
[summary.txt](app://-/index.html#)