### PR TITLE
chore(pr53): Enforce content pack manifest consistency

### DIFF
--- a/.github/workflows/ci_verify_mbti.yml
+++ b/.github/workflows/ci_verify_mbti.yml
@@ -109,6 +109,12 @@ jobs:
           php artisan test --filter MeAttemptsAuthContractTest
           php artisan test --filter ApiErrorContractMiddlewareTest
 
+      - name: Run content pack manifest consistency tests
+        working-directory: backend
+        run: |
+          php artisan test --filter ContentPacksIndexManifestConsistencyTest
+          php artisan test --filter ContentPackResolverCacheTest
+
       - name: Check content packs index endpoint
         working-directory: backend
         run: |

--- a/backend/database/seeders/CiScalesRegistrySeeder.php
+++ b/backend/database/seeders/CiScalesRegistrySeeder.php
@@ -19,14 +19,22 @@ final class CiScalesRegistrySeeder extends Seeder
 
         $now = now();
 
-        // ✅ 与 ScaleRegistrySeeder 同口径：默认值统一成 v0.2.1-TEST（CI 缺 config 时也不漂移）
-        $defaultPackId = (string) config('content_packs.default_pack_id', 'MBTI.cn-mainland.zh-CN.v0.2.1-TEST');
-        $defaultDirVersion = (string) config('content_packs.default_dir_version', 'MBTI-CN-v0.2.1-TEST');
-        $defaultRegion = (string) config('content_packs.default_region', 'CN_MAINLAND');
-        $defaultLocale = (string) config('content_packs.default_locale', 'zh-CN');
+        // Keep CI seeding aligned with content_packs config (no hardcoded default pack ids).
+        $defaultPackId = trim((string) config('content_packs.default_pack_id', ''));
+        $defaultDirVersion = trim((string) config('content_packs.default_dir_version', ''));
+        $defaultRegion = trim((string) config('content_packs.default_region', ''));
+        $defaultLocale = trim((string) config('content_packs.default_locale', ''));
+        if ($defaultPackId === '' || $defaultDirVersion === '' || $defaultRegion === '' || $defaultLocale === '') {
+            throw new \RuntimeException(
+                'CiScalesRegistrySeeder requires non-empty content_packs defaults: '
+                . 'default_pack_id/default_dir_version/default_region/default_locale'
+            );
+        }
 
-        // demo pack 维持走 config（仓库里通常是 'default'）
-        $demoPackId = (string) config('content_packs.demo_pack_id', 'default');
+        $demoPackId = trim((string) config('content_packs.demo_pack_id', ''));
+        if ($demoPackId === '') {
+            $demoPackId = $defaultPackId;
+        }
 
         $rows = [
             [

--- a/backend/database/seeders/ScaleRegistrySeeder.php
+++ b/backend/database/seeders/ScaleRegistrySeeder.php
@@ -17,11 +17,17 @@ final class ScaleRegistrySeeder extends Seeder
             return;
         }
 
-        // 关键：默认包/目录完全跟随 config，保证 CI 中 pr22/pr25 的一致性校验通过
-        $defaultPackId = (string) config('content_packs.default_pack_id', 'MBTI.cn-mainland.zh-CN.v0.2.1-TEST');
-        $defaultDirVersion = (string) config('content_packs.default_dir_version', 'MBTI-CN-v0.2.1-TEST');
-        $defaultRegion = (string) config('content_packs.default_region', 'CN_MAINLAND');
-        $defaultLocale = (string) config('content_packs.default_locale', 'zh-CN');
+        // Defaults must come from content_packs config to keep seed/config/pack contract consistent.
+        $defaultPackId = trim((string) config('content_packs.default_pack_id', ''));
+        $defaultDirVersion = trim((string) config('content_packs.default_dir_version', ''));
+        $defaultRegion = trim((string) config('content_packs.default_region', ''));
+        $defaultLocale = trim((string) config('content_packs.default_locale', ''));
+        if ($defaultPackId === '' || $defaultDirVersion === '' || $defaultRegion === '' || $defaultLocale === '') {
+            throw new \RuntimeException(
+                'ScaleRegistrySeeder requires non-empty content_packs defaults: '
+                . 'default_pack_id/default_dir_version/default_region/default_locale'
+            );
+        }
 
         $skuDefaults = $this->resolveSkuDefaults();
 

--- a/backend/scripts/pr53_accept.sh
+++ b/backend/scripts/pr53_accept.sh
@@ -1,0 +1,103 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+export CI=true
+export FAP_NONINTERACTIVE=1
+export COMPOSER_NO_INTERACTION=1
+export GIT_TERMINAL_PROMPT=0
+export NO_COLOR=1
+export PAGER=cat
+export GIT_PAGER=cat
+export TERM=dumb
+export XDEBUG_MODE=off
+export LANG=en_US.UTF-8
+
+REPO_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+BACKEND_DIR="${REPO_DIR}/backend"
+ART_DIR="${BACKEND_DIR}/artifacts/pr53"
+SERVE_PORT="${SERVE_PORT:-1853}"
+DB_PATH="/tmp/pr53.sqlite"
+
+mkdir -p "${ART_DIR}"
+
+cleanup_port() {
+  local port="$1"
+  lsof -nP -iTCP:"${port}" -sTCP:LISTEN || true
+  local pid_list
+  pid_list="$(lsof -ti tcp:"${port}" || true)"
+  if [[ -n "${pid_list}" ]]; then
+    echo "${pid_list}" | xargs kill -9 || true
+  fi
+  lsof -nP -iTCP:"${port}" -sTCP:LISTEN || true
+}
+
+cleanup() {
+  if [[ -f "${ART_DIR}/server.pid" ]]; then
+    local pid
+    pid="$(cat "${ART_DIR}/server.pid" || true)"
+    if [[ -n "${pid}" ]] && ps -p "${pid}" >/dev/null 2>&1; then
+      kill "${pid}" >/dev/null 2>&1 || true
+    fi
+  fi
+  cleanup_port "${SERVE_PORT}"
+  cleanup_port 18000
+  rm -f "${DB_PATH}"
+}
+trap cleanup EXIT
+
+cleanup_port "${SERVE_PORT}"
+cleanup_port 18000
+
+export APP_ENV=testing
+export CACHE_STORE=array
+export QUEUE_CONNECTION=sync
+export DB_CONNECTION=sqlite
+export DB_DATABASE="${DB_PATH}"
+export FAP_PACKS_ROOT="${FAP_PACKS_ROOT:-${REPO_DIR}/content_packages}"
+export FAP_DEFAULT_REGION="${FAP_DEFAULT_REGION:-CN_MAINLAND}"
+export FAP_DEFAULT_LOCALE="${FAP_DEFAULT_LOCALE:-zh-CN}"
+export FAP_DEFAULT_PACK_ID="${FAP_DEFAULT_PACK_ID:-MBTI.cn-mainland.zh-CN.v0.2.2}"
+export FAP_DEFAULT_DIR_VERSION="${FAP_DEFAULT_DIR_VERSION:-MBTI-CN-v0.2.2}"
+
+rm -f "${DB_PATH}"
+touch "${DB_PATH}"
+
+cd "${BACKEND_DIR}"
+composer install --no-interaction --no-progress
+php artisan migrate:fresh --force
+php artisan fap:scales:seed-default
+php artisan fap:scales:sync-slugs
+cd "${REPO_DIR}"
+
+SERVE_PORT="${SERVE_PORT}" ART_DIR="${ART_DIR}" bash "${BACKEND_DIR}/scripts/pr53_verify.sh"
+
+ATTEMPT_ID="$(cat "${ART_DIR}/attempt_id.txt" 2>/dev/null || true)"
+ANON_ID="$(cat "${ART_DIR}/anon_id.txt" 2>/dev/null || true)"
+QUESTION_COUNT="$(cat "${ART_DIR}/question_count.txt" 2>/dev/null || true)"
+DEFAULT_PACK_ID="$(cat "${ART_DIR}/config_default_pack_id.txt" 2>/dev/null || true)"
+DEFAULT_DIR_VERSION="$(cat "${ART_DIR}/config_default_dir_version.txt" 2>/dev/null || true)"
+
+cat > "${ART_DIR}/summary.txt" <<TXT
+PR53 Acceptance Summary
+- pass_items:
+  - content_pack_manifest_consistency: OK
+  - content_packs_index_cache_refresh: OK
+  - dynamic_answers_submit: OK
+  - pack_seed_config_consistency: OK
+- key_outputs:
+  - attempt_id: ${ATTEMPT_ID}
+  - anon_id: ${ANON_ID}
+  - question_count(dynamic): ${QUESTION_COUNT}
+  - default_pack_id: ${DEFAULT_PACK_ID}
+  - default_dir_version: ${DEFAULT_DIR_VERSION}
+- smoke_urls:
+  - http://127.0.0.1:${SERVE_PORT}/api/v0.2/content-packs/${DEFAULT_PACK_ID}/${DEFAULT_DIR_VERSION}/manifest
+  - http://127.0.0.1:${SERVE_PORT}/api/v0.3/scales/MBTI/questions
+- schema_changes:
+  - none
+TXT
+
+bash "${BACKEND_DIR}/scripts/sanitize_artifacts.sh" 53
+
+bash -n "${BACKEND_DIR}/scripts/pr53_accept.sh"
+bash -n "${BACKEND_DIR}/scripts/pr53_verify.sh"

--- a/backend/scripts/pr53_verify.sh
+++ b/backend/scripts/pr53_verify.sh
@@ -1,0 +1,337 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+export CI=true
+export FAP_NONINTERACTIVE=1
+export COMPOSER_NO_INTERACTION=1
+export GIT_TERMINAL_PROMPT=0
+export NO_COLOR=1
+export PAGER=cat
+export GIT_PAGER=cat
+export TERM=dumb
+export XDEBUG_MODE=off
+export LANG=en_US.UTF-8
+
+REPO_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+BACKEND_DIR="${REPO_DIR}/backend"
+ART_DIR="${ART_DIR:-${BACKEND_DIR}/artifacts/pr53}"
+SERVE_PORT="${SERVE_PORT:-1853}"
+HOST="127.0.0.1"
+API_BASE="http://${HOST}:${SERVE_PORT}"
+SCALE_CODE="${SCALE_CODE:-MBTI}"
+ANON_ID="${ANON_ID:-pr53-verify-anon}"
+
+mkdir -p "${ART_DIR}"
+exec > "${ART_DIR}/verify.log" 2>&1
+
+fail() {
+  echo "[PR53][FAIL] $*" >&2
+  exit 1
+}
+
+cleanup_port() {
+  local port="$1"
+  lsof -nP -iTCP:"${port}" -sTCP:LISTEN || true
+  local pid_list
+  pid_list="$(lsof -ti tcp:"${port}" || true)"
+  if [[ -n "${pid_list}" ]]; then
+    echo "${pid_list}" | xargs kill -9 || true
+  fi
+  lsof -nP -iTCP:"${port}" -sTCP:LISTEN || true
+}
+
+wait_health() {
+  local url="$1"
+  local body_file="${ART_DIR}/healthz.body"
+  local http_code=""
+
+  for _ in $(seq 1 80); do
+    http_code="$(curl -sS -o "${body_file}" -w "%{http_code}" "${url}" || true)"
+    if [[ "${http_code}" == "200" ]]; then
+      return 0
+    fi
+    sleep 0.25
+  done
+
+  echo "health_check_failed http=${http_code}" >&2
+  cat "${body_file}" >&2 || true
+  tail -n 120 "${ART_DIR}/server.log" >&2 || true
+  return 1
+}
+
+cleanup() {
+  if [[ -n "${SERVE_PID:-}" ]] && ps -p "${SERVE_PID}" >/dev/null 2>&1; then
+    kill "${SERVE_PID}" >/dev/null 2>&1 || true
+  fi
+  cleanup_port "${SERVE_PORT}"
+  cleanup_port 18000
+}
+trap cleanup EXIT
+
+cleanup_port "${SERVE_PORT}"
+cleanup_port 18000
+
+cd "${BACKEND_DIR}"
+php artisan serve --host="${HOST}" --port="${SERVE_PORT}" > "${ART_DIR}/server.log" 2>&1 &
+SERVE_PID="$!"
+echo "${SERVE_PID}" > "${ART_DIR}/server.pid"
+cd "${REPO_DIR}"
+
+wait_health "${API_BASE}/api/v0.2/healthz" || fail "healthz failed"
+curl -sS "${API_BASE}/api/v0.2/healthz" > "${ART_DIR}/healthz.json"
+
+cd "${BACKEND_DIR}"
+php -r '
+require "vendor/autoload.php";
+$app = require "bootstrap/app.php";
+$app->make(Illuminate\Contracts\Console\Kernel::class)->bootstrap();
+
+$configPackId = trim((string) config("content_packs.default_pack_id", ""));
+$configDirVersion = trim((string) config("content_packs.default_dir_version", ""));
+$configRegion = trim((string) config("content_packs.default_region", ""));
+$configLocale = trim((string) config("content_packs.default_locale", ""));
+
+echo "config_default_pack_id=".$configPackId.PHP_EOL;
+echo "config_default_dir_version=".$configDirVersion.PHP_EOL;
+echo "config_default_region=".$configRegion.PHP_EOL;
+echo "config_default_locale=".$configLocale.PHP_EOL;
+
+if ($configPackId === "" || $configDirVersion === "" || $configRegion === "" || $configLocale === "") {
+    fwrite(STDERR, "content_pack_defaults_missing\n");
+    exit(1);
+}
+
+if (!Illuminate\Support\Facades\Schema::hasTable("scales_registry")) {
+    fwrite(STDERR, "missing_scales_registry_table\n");
+    exit(1);
+}
+
+$row = Illuminate\Support\Facades\DB::table("scales_registry")
+    ->where("org_id", 0)
+    ->where("code", "MBTI")
+    ->first();
+if (!$row) {
+    fwrite(STDERR, "missing_scales_registry_mbti\n");
+    exit(1);
+}
+
+$registryPackId = trim((string) ($row->default_pack_id ?? ""));
+$registryDirVersion = trim((string) ($row->default_dir_version ?? ""));
+echo "registry_default_pack_id=".$registryPackId.PHP_EOL;
+echo "registry_default_dir_version=".$registryDirVersion.PHP_EOL;
+if ($registryPackId !== $configPackId) {
+    fwrite(STDERR, "default_pack_id_mismatch\n");
+    exit(1);
+}
+if ($registryDirVersion !== $configDirVersion) {
+    fwrite(STDERR, "default_dir_version_mismatch\n");
+    exit(1);
+}
+
+$index = app(App\Services\Content\ContentPacksIndex::class);
+$found = $index->find($configPackId, $configDirVersion);
+if (!($found["ok"] ?? false)) {
+    fwrite(STDERR, "pack_not_found\n");
+    exit(1);
+}
+
+$item = $found["item"] ?? [];
+$manifestPath = (string) ($item["manifest_path"] ?? "");
+$questionsPath = (string) ($item["questions_path"] ?? "");
+if ($manifestPath === "" || !is_file($manifestPath)) {
+    fwrite(STDERR, "manifest_missing\n");
+    exit(1);
+}
+if ($questionsPath === "" || !is_file($questionsPath)) {
+    fwrite(STDERR, "questions_missing\n");
+    exit(1);
+}
+
+$manifest = json_decode((string) file_get_contents($manifestPath), true);
+if (!is_array($manifest)) {
+    fwrite(STDERR, "manifest_invalid_json\n");
+    exit(1);
+}
+$packDir = dirname($manifestPath);
+$versionPath = $packDir.DIRECTORY_SEPARATOR."version.json";
+if (!is_file($versionPath)) {
+    fwrite(STDERR, "version_missing\n");
+    exit(1);
+}
+$version = json_decode((string) file_get_contents($versionPath), true);
+if (!is_array($version)) {
+    fwrite(STDERR, "version_invalid_json\n");
+    exit(1);
+}
+$questions = json_decode((string) file_get_contents($questionsPath), true);
+if (!is_array($questions)) {
+    fwrite(STDERR, "questions_invalid_json\n");
+    exit(1);
+}
+
+if (trim((string) ($manifest["pack_id"] ?? "")) !== $configPackId) {
+    fwrite(STDERR, "manifest_pack_id_mismatch\n");
+    exit(1);
+}
+if (trim((string) ($manifest["content_package_version"] ?? "")) === "") {
+    fwrite(STDERR, "manifest_content_package_version_missing\n");
+    exit(1);
+}
+if (trim((string) ($version["pack_id"] ?? "")) !== $configPackId) {
+    fwrite(STDERR, "version_pack_id_mismatch\n");
+    exit(1);
+}
+if (trim((string) ($version["dir_version"] ?? "")) !== $configDirVersion) {
+    fwrite(STDERR, "version_dir_version_mismatch\n");
+    exit(1);
+}
+if (trim((string) ($version["content_package_version"] ?? "")) !== trim((string) ($manifest["content_package_version"] ?? ""))) {
+    fwrite(STDERR, "manifest_version_json_mismatch\n");
+    exit(1);
+}
+
+echo "pack_dir=".$packDir.PHP_EOL;
+echo "pack_manifest=".$manifestPath.PHP_EOL;
+echo "pack_questions=".$questionsPath.PHP_EOL;
+echo "pack_version=".$versionPath.PHP_EOL;
+' > "${ART_DIR}/pack_seed_config.txt"
+cd "${REPO_DIR}"
+
+grep -E "^config_default_pack_id=" "${ART_DIR}/pack_seed_config.txt" | sed "s/^config_default_pack_id=//" > "${ART_DIR}/config_default_pack_id.txt"
+grep -E "^config_default_dir_version=" "${ART_DIR}/pack_seed_config.txt" | sed "s/^config_default_dir_version=//" > "${ART_DIR}/config_default_dir_version.txt"
+
+DEFAULT_PACK_ID="$(cat "${ART_DIR}/config_default_pack_id.txt")"
+DEFAULT_DIR_VERSION="$(cat "${ART_DIR}/config_default_dir_version.txt")"
+
+CONTENT_PACK_MANIFEST_JSON="${ART_DIR}/content_pack_manifest_api.json"
+http_code="$(curl -sS -o "${CONTENT_PACK_MANIFEST_JSON}" -w "%{http_code}" \
+  -H "Accept: application/json" \
+  "${API_BASE}/api/v0.2/content-packs/${DEFAULT_PACK_ID}/${DEFAULT_DIR_VERSION}/manifest" || true)"
+if [[ "${http_code}" != "200" ]]; then
+  echo "content_pack_manifest_api_failed http=${http_code}" >&2
+  cat "${CONTENT_PACK_MANIFEST_JSON}" >&2 || true
+  fail "content pack manifest endpoint failed"
+fi
+
+QUESTIONS_JSON="${ART_DIR}/questions.json"
+http_code="$(curl -sS -o "${QUESTIONS_JSON}" -w "%{http_code}" \
+  -H "Accept: application/json" \
+  "${API_BASE}/api/v0.3/scales/${SCALE_CODE}/questions" || true)"
+if [[ "${http_code}" != "200" ]]; then
+  echo "questions_failed http=${http_code}" >&2
+  cat "${QUESTIONS_JSON}" >&2 || true
+  tail -n 120 "${ART_DIR}/server.log" >&2 || true
+  fail "questions endpoint failed"
+fi
+
+ANSWERS_JSON="${ART_DIR}/answers.json"
+php -r '
+$raw = file_get_contents("php://stdin");
+$data = json_decode($raw, true);
+if (!is_array($data)) {
+    fwrite(STDERR, "questions_json_invalid\n");
+    exit(1);
+}
+$items = $data["questions"]["items"] ?? $data["questions"] ?? $data["items"] ?? $data["data"] ?? $data;
+if (!is_array($items)) {
+    fwrite(STDERR, "questions_items_invalid\n");
+    exit(1);
+}
+$answers = [];
+foreach ($items as $item) {
+    if (!is_array($item)) {
+        continue;
+    }
+    $questionId = (string) ($item["question_id"] ?? $item["id"] ?? "");
+    if ($questionId === "") {
+        continue;
+    }
+    $options = $item["options"] ?? [];
+    $code = "A";
+    if (is_array($options) && isset($options[0]) && is_array($options[0])) {
+        $code = (string) ($options[0]["code"] ?? $options[0]["option_code"] ?? "A");
+    }
+    if ($code === "") {
+        $code = "A";
+    }
+    $answers[] = [
+        "question_id" => $questionId,
+        "code" => $code,
+    ];
+}
+if (count($answers) === 0) {
+    fwrite(STDERR, "answers_empty\n");
+    exit(1);
+}
+echo json_encode($answers, JSON_UNESCAPED_UNICODE);
+' < "${QUESTIONS_JSON}" > "${ANSWERS_JSON}"
+
+QUESTION_COUNT="$(php -r '
+$data = json_decode(file_get_contents($argv[1]), true);
+if (!is_array($data)) { echo "0"; exit(0); }
+echo (string) count($data);
+' "${ANSWERS_JSON}")"
+if [[ "${QUESTION_COUNT}" == "0" ]]; then
+  fail "dynamic answers generation produced zero answers"
+fi
+echo "${QUESTION_COUNT}" > "${ART_DIR}/question_count.txt"
+
+ATTEMPT_START_JSON="${ART_DIR}/attempt_start.json"
+ATTEMPT_START_BODY="$(SCALE_CODE="${SCALE_CODE}" ANON_ID="${ANON_ID}" php -r '
+$payload = [
+    "scale_code" => getenv("SCALE_CODE"),
+    "anon_id" => getenv("ANON_ID"),
+];
+echo json_encode($payload, JSON_UNESCAPED_UNICODE);
+')"
+http_code="$(curl -sS -o "${ATTEMPT_START_JSON}" -w "%{http_code}" \
+  -X POST -H "Content-Type: application/json" -H "Accept: application/json" \
+  --data "${ATTEMPT_START_BODY}" \
+  "${API_BASE}/api/v0.3/attempts/start" || true)"
+if [[ "${http_code}" != "200" ]]; then
+  echo "attempt_start_failed http=${http_code}" >&2
+  cat "${ATTEMPT_START_JSON}" >&2 || true
+  tail -n 120 "${ART_DIR}/server.log" >&2 || true
+  fail "attempt start failed"
+fi
+
+ATTEMPT_ID="$(php -r '$j=json_decode(file_get_contents($argv[1]), true); echo (string)($j["attempt_id"] ?? "");' "${ATTEMPT_START_JSON}")"
+if [[ -z "${ATTEMPT_ID}" ]]; then
+  fail "missing attempt_id"
+fi
+echo "${ATTEMPT_ID}" > "${ART_DIR}/attempt_id.txt"
+echo "${ANON_ID}" > "${ART_DIR}/anon_id.txt"
+
+SUBMIT_PAYLOAD="${ART_DIR}/submit_payload.json"
+ATTEMPT_ID="${ATTEMPT_ID}" ANSWERS_PATH="${ANSWERS_JSON}" php -r '
+$answers = json_decode(file_get_contents(getenv("ANSWERS_PATH")), true);
+if (!is_array($answers) || count($answers) === 0) {
+    fwrite(STDERR, "answers_payload_invalid\n");
+    exit(1);
+}
+$payload = [
+    "attempt_id" => getenv("ATTEMPT_ID"),
+    "answers" => $answers,
+    "duration_ms" => 120000,
+];
+echo json_encode($payload, JSON_UNESCAPED_UNICODE);
+' > "${SUBMIT_PAYLOAD}"
+
+ATTEMPT_SUBMIT_JSON="${ART_DIR}/attempt_submit.json"
+http_code="$(curl -sS -o "${ATTEMPT_SUBMIT_JSON}" -w "%{http_code}" \
+  -X POST -H "Content-Type: application/json" -H "Accept: application/json" \
+  --data @"${SUBMIT_PAYLOAD}" \
+  "${API_BASE}/api/v0.3/attempts/submit" || true)"
+if [[ "${http_code}" != "200" ]]; then
+  echo "attempt_submit_failed http=${http_code}" >&2
+  cat "${ATTEMPT_SUBMIT_JSON}" >&2 || true
+  tail -n 120 "${ART_DIR}/server.log" >&2 || true
+  fail "attempt submit failed"
+fi
+
+cd "${BACKEND_DIR}"
+php artisan test --filter ContentPacksIndexManifestConsistencyTest > "${ART_DIR}/phpunit_content_packs_index_manifest_consistency.txt" 2>&1
+php artisan test --filter ContentPackResolverCacheTest > "${ART_DIR}/phpunit_content_pack_resolver_cache.txt" 2>&1
+cd "${REPO_DIR}"
+
+echo "verify_done" > "${ART_DIR}/verify_done.txt"

--- a/backend/tests/Unit/Services/Content/ContentPacksIndexManifestConsistencyTest.php
+++ b/backend/tests/Unit/Services/Content/ContentPacksIndexManifestConsistencyTest.php
@@ -1,0 +1,144 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Services\Content;
+
+use App\Services\Content\ContentPacksIndex;
+use App\Support\CacheKeys;
+use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Facades\File;
+use Tests\TestCase;
+
+final class ContentPacksIndexManifestConsistencyTest extends TestCase
+{
+    private string $packsRoot;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->packsRoot = sys_get_temp_dir() . '/pr53_content_packs_' . uniqid('', true);
+        File::ensureDirectoryExists($this->packsRoot);
+
+        config()->set('content_packs.driver', 'local');
+        config()->set('content_packs.root', $this->packsRoot);
+        config()->set('content_packs.default_pack_id', 'PACK_A');
+        config()->set('content_packs.default_dir_version', 'MBTI-CN-v-test');
+        config()->set('content_packs.default_region', 'CN_MAINLAND');
+        config()->set('content_packs.default_locale', 'zh-CN');
+
+        Cache::forget(CacheKeys::packsIndex());
+    }
+
+    protected function tearDown(): void
+    {
+        Cache::forget(CacheKeys::packsIndex());
+        File::deleteDirectory($this->packsRoot);
+        parent::tearDown();
+    }
+
+    public function test_find_refreshes_when_cached_manifest_becomes_stale(): void
+    {
+        $dirVersion = 'MBTI-CN-v-test';
+        $packDir = $this->makePackDir($dirVersion);
+
+        $this->writePack($packDir, 'PACK_A', $dirVersion, 'v-test');
+
+        /** @var ContentPacksIndex $index */
+        $index = app(ContentPacksIndex::class);
+
+        $first = $index->find('PACK_A', $dirVersion);
+        $this->assertTrue((bool) ($first['ok'] ?? false));
+        $this->assertSame('PACK_A', (string) ($first['item']['pack_id'] ?? ''));
+
+        // mutate manifest/version to a new pack_id in the same dir_version
+        $this->writePack($packDir, 'PACK_B', $dirVersion, 'v-test-2');
+
+        $stale = $index->find('PACK_A', $dirVersion);
+        $this->assertFalse((bool) ($stale['ok'] ?? false));
+
+        $fresh = $index->find('PACK_B', $dirVersion);
+        $this->assertTrue((bool) ($fresh['ok'] ?? false));
+        $this->assertSame('PACK_B', (string) ($fresh['item']['pack_id'] ?? ''));
+        $this->assertSame('v-test-2', (string) ($fresh['item']['content_package_version'] ?? ''));
+    }
+
+    public function test_invalid_manifest_version_pair_is_excluded_from_index(): void
+    {
+        $dirVersion = 'MBTI-CN-v-invalid';
+        $packDir = $this->makePackDir($dirVersion);
+
+        $this->writePack($packDir, 'PACK_BAD', $dirVersion, 'v-manifest', 'v-version-mismatch');
+
+        /** @var ContentPacksIndex $index */
+        $index = app(ContentPacksIndex::class);
+
+        $found = $index->find('PACK_BAD', $dirVersion);
+        $this->assertFalse((bool) ($found['ok'] ?? false));
+
+        $snapshot = $index->getIndex(true);
+        $this->assertTrue((bool) ($snapshot['ok'] ?? false));
+        $this->assertIsArray($snapshot['items'] ?? null);
+        $this->assertCount(0, (array) ($snapshot['items'] ?? []));
+    }
+
+    private function makePackDir(string $dirVersion): string
+    {
+        $packDir = $this->packsRoot . DIRECTORY_SEPARATOR . 'default'
+            . DIRECTORY_SEPARATOR . 'CN_MAINLAND'
+            . DIRECTORY_SEPARATOR . 'zh-CN'
+            . DIRECTORY_SEPARATOR . $dirVersion;
+
+        File::ensureDirectoryExists($packDir);
+
+        return $packDir;
+    }
+
+    private function writePack(
+        string $packDir,
+        string $packId,
+        string $dirVersion,
+        string $manifestContentVersion,
+        ?string $versionContentVersion = null
+    ): void {
+        $versionContentVersion = $versionContentVersion ?? $manifestContentVersion;
+
+        file_put_contents(
+            $packDir . DIRECTORY_SEPARATOR . 'manifest.json',
+            json_encode([
+                'schema_version' => 'pack-manifest@v1',
+                'pack_id' => $packId,
+                'scale_code' => 'MBTI',
+                'region' => 'CN_MAINLAND',
+                'locale' => 'zh-CN',
+                'content_package_version' => $manifestContentVersion,
+                'assets' => [
+                    'questions' => ['questions.json'],
+                ],
+            ], JSON_UNESCAPED_UNICODE)
+        );
+
+        file_put_contents(
+            $packDir . DIRECTORY_SEPARATOR . 'version.json',
+            json_encode([
+                'pack_id' => $packId,
+                'content_package_version' => $versionContentVersion,
+                'dir_version' => $dirVersion,
+            ], JSON_UNESCAPED_UNICODE)
+        );
+
+        file_put_contents(
+            $packDir . DIRECTORY_SEPARATOR . 'questions.json',
+            json_encode([
+                [
+                    'question_id' => 'q1',
+                    'text' => 'Q1',
+                    'options' => [
+                        ['code' => 'A', 'text' => 'Option A'],
+                    ],
+                ],
+            ], JSON_UNESCAPED_UNICODE)
+        );
+    }
+}

--- a/docs/verify/pr53_verify.md
+++ b/docs/verify/pr53_verify.md
@@ -1,0 +1,32 @@
+# PR53 Verify
+
+- Date: 2026-02-08
+- Commands:
+  - `php artisan route:list`
+  - `php artisan migrate`
+  - `php artisan test --filter ContentPacksIndexManifestConsistencyTest`
+  - `php artisan test --filter ContentPackResolverCacheTest`
+  - `bash backend/scripts/pr53_accept.sh`
+  - `bash backend/scripts/ci_verify_mbti.sh`
+- Result:
+  - `php artisan route:list` 通过（目标路由可见）
+  - `php artisan migrate` 通过（无待执行迁移）
+  - `php artisan test --filter ContentPacksIndexManifestConsistencyTest` 通过
+  - `php artisan test --filter ContentPackResolverCacheTest` 通过
+  - `bash backend/scripts/pr53_accept.sh` 通过
+  - `bash backend/scripts/ci_verify_mbti.sh` 通过
+- Artifacts:
+  - `backend/artifacts/pr53/summary.txt`
+  - `backend/artifacts/pr53/verify.log`
+  - `backend/artifacts/pr53/pack_seed_config.txt`
+  - `backend/artifacts/pr53/phpunit_content_packs_index_manifest_consistency.txt`
+  - `backend/artifacts/pr53/phpunit_content_pack_resolver_cache.txt`
+  - `backend/artifacts/verify_mbti/summary.txt`
+
+Step Verification Commands
+
+1. Step 1 (routes): `cd backend && php artisan route:list | grep -E "api/v0.2/content-packs|api/v0.3/scales/\\{scale_code\\}/questions"`
+2. Step 2 (migrations): `cd backend && php artisan migrate --force && rm -f /tmp/pr53.sqlite && touch /tmp/pr53.sqlite && DB_CONNECTION=sqlite DB_DATABASE=/tmp/pr53.sqlite php artisan migrate:fresh --force`
+3. Step 3 (middleware): `php -l backend/app/Http/Middleware/FmTokenAuth.php && grep -n "DB::table('fm_tokens')" backend/app/Http/Middleware/FmTokenAuth.php && grep -n "attributes->set('fm_user_id'" backend/app/Http/Middleware/FmTokenAuth.php`
+4. Step 4 (controller/service/tests): `php -l backend/app/Services/Content/ContentPacksIndex.php && cd backend && php artisan test --filter ContentPacksIndexManifestConsistencyTest && php artisan test --filter ContentPackResolverCacheTest`
+5. Step 5 (scripts/CI): `bash -n backend/scripts/pr53_verify.sh && bash -n backend/scripts/pr53_accept.sh && bash backend/scripts/pr53_accept.sh && bash backend/scripts/ci_verify_mbti.sh`


### PR DESCRIPTION
What:
强化 content pack 索引缓存一致性与 manifest/version/questions 三方契约校验，并补齐本机一键验收链。
Why:
避免缓存命中旧 manifest 导致错误 pack 映射。
保证 config/scales_registry/pack 目录语义一致，降低 CI 与线上漂移风险。
How:
修改 [ContentPacksIndex.php](app://-/index.html#)：find() 增加 stale 命中强制 refresh；scanItems() 增加 manifest/version/questions 严格过滤。
修改 [ScaleRegistrySeeder.php](app://-/index.html#) 与 [CiScalesRegistrySeeder.php](app://-/index.html#)：移除硬编码默认包，改为严格读取 [content_packs.*](app://-/index.html#)。
修改 [ContentPackResolverCacheTest.php](app://-/index.html#)：改为 mtime 驱动刷新断言。
新增 [ContentPacksIndexManifestConsistencyTest.php](app://-/index.html#)：覆盖 stale cache refresh 与 manifest/version mismatch 排除。
新增 [pr53_verify.sh](app://-/index.html#) 与 [pr53_accept.sh](app://-/index.html#)：动态题量 answers、pack/seed/config 一致性检查、产物脱敏与闭环清理。
修改 [ci_verify_mbti.yml](app://-/index.html#)：加入 manifest consistency 回归测试步骤。
Verify:
[pr53_accept.sh](app://-/index.html#)
[ci_verify_mbti.sh](app://-/index.html#)
Artifacts:
[summary.txt](app://-/index.html#)