### PR TITLE
chore(pr54): Add queue DLQ replay and metrics

### DIFF
--- a/.github/workflows/ci_dlq_replay_metrics.yml
+++ b/.github/workflows/ci_dlq_replay_metrics.yml
@@ -1,0 +1,73 @@
+name: CI DLQ Replay Metrics
+
+on:
+  workflow_dispatch:
+  push:
+    branches: ["**"]
+  pull_request:
+
+jobs:
+  dlq-replay-metrics:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+
+    env:
+      APP_ENV: ci
+      APP_DEBUG: "true"
+      DB_CONNECTION: sqlite
+      DB_DATABASE: /tmp/fap-dlq-ci.sqlite
+      QUEUE_CONNECTION: database
+      FAP_PACKS_DRIVER: local
+      FAP_PACKS_ROOT: ${{ github.workspace }}/content_packages
+      FAP_DEFAULT_REGION: CN_MAINLAND
+      FAP_DEFAULT_LOCALE: zh-CN
+      FAP_DEFAULT_PACK_ID: MBTI.cn-mainland.zh-CN.v0.2.2
+      FAP_DEFAULT_DIR_VERSION: MBTI-CN-v0.2.2
+      FAP_ADMIN_TOKEN: pr54-ci-admin-token
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: "8.4"
+          coverage: none
+          tools: composer:v2
+          extensions: >
+            mbstring, intl, curl, json, openssl, fileinfo, pdo, pdo_sqlite, sqlite3
+
+      - name: Prepare Laravel cache dirs
+        working-directory: backend
+        run: |
+          mkdir -p storage/framework/cache/data
+          mkdir -p storage/framework/views
+          mkdir -p storage/framework/sessions
+          mkdir -p storage/logs
+          mkdir -p bootstrap/cache
+          chmod -R ug+rwX storage bootstrap/cache || true
+
+      - name: Install backend dependencies
+        working-directory: backend
+        run: |
+          composer install --no-interaction --prefer-dist --no-progress
+
+      - name: Prepare sqlite and seed defaults
+        working-directory: backend
+        env:
+          DB_DATABASE: /tmp/fap-dlq-ci.sqlite
+        run: |
+          bash scripts/ci/prepare_sqlite.sh
+          php artisan fap:scales:seed-default
+          php artisan fap:scales:sync-slugs
+
+      - name: Route contract for DLQ APIs
+        working-directory: backend
+        run: |
+          php artisan route:list | grep -E "queue/dlq/metrics|queue/dlq/replay"
+
+      - name: Run DLQ replay metrics tests
+        working-directory: backend
+        run: |
+          php artisan test --filter AdminQueueDlqReplayTest

--- a/backend/app/Http/Controllers/API/V0_2/Admin/AdminQueueController.php
+++ b/backend/app/Http/Controllers/API/V0_2/Admin/AdminQueueController.php
@@ -1,0 +1,116 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Controllers\API\V0_2\Admin;
+
+use App\Http\Controllers\Controller;
+use App\Services\Audit\AuditLogger;
+use App\Services\Queue\QueueDlqService;
+use App\Support\Rbac\PermissionNames;
+use App\Support\Rbac\RbacService;
+use Illuminate\Http\Request;
+
+class AdminQueueController extends Controller
+{
+    public function metrics(Request $request, QueueDlqService $queueDlqService)
+    {
+        $this->assertPermission(PermissionNames::ADMIN_OPS_READ);
+
+        return response()->json([
+            'ok' => true,
+            'data' => $queueDlqService->metrics(),
+        ]);
+    }
+
+    public function replay(
+        Request $request,
+        string $failed_job_id,
+        QueueDlqService $queueDlqService,
+        AuditLogger $auditLogger
+    ) {
+        $this->assertPermission(PermissionNames::ADMIN_OPS_WRITE);
+
+        if (!preg_match('/^\d+$/', $failed_job_id)) {
+            return response()->json([
+                'ok' => false,
+                'error' => 'NOT_FOUND',
+                'message' => 'failed job not found.',
+            ], 404);
+        }
+
+        $force = $request->boolean('force', false);
+        $requestedBy = $this->resolveRequestedBy($request);
+        $failedJobIdInt = (int) $failed_job_id;
+
+        $result = $queueDlqService->replayFailedJob($failedJobIdInt, $requestedBy, $force);
+
+        $auditLogger->log(
+            $request,
+            'queue_dlq_replay',
+            'failed_job',
+            $failed_job_id,
+            [
+                'force' => $force,
+                'status_intended' => $result['status'] ?? '',
+                'result' => $result,
+            ]
+        );
+
+        $status = (string) ($result['status'] ?? '');
+        if ($status === 'not_found') {
+            return response()->json([
+                'ok' => false,
+                'error' => 'NOT_FOUND',
+                'message' => 'failed job not found.',
+            ], 404);
+        }
+
+        if ($status === 'invalid_payload') {
+            return response()->json([
+                'ok' => false,
+                'error' => 'INVALID_PAYLOAD',
+                'message' => 'failed job payload invalid.',
+                'data' => $result,
+            ], 422);
+        }
+
+        if ($status === 'push_failed') {
+            return response()->json([
+                'ok' => false,
+                'error' => 'REPLAY_FAILED',
+                'message' => 'failed job replay failed.',
+                'data' => $result,
+            ], 500);
+        }
+
+        return response()->json([
+            'ok' => true,
+            'data' => $result,
+        ]);
+    }
+
+    private function assertPermission(string $permission): void
+    {
+        $user = auth((string) config('admin.guard', 'admin'))->user();
+        if ($user !== null) {
+            app(RbacService::class)->assertCan($user, $permission);
+        }
+    }
+
+    private function resolveRequestedBy(Request $request): string
+    {
+        $guard = (string) config('admin.guard', 'admin');
+        $user = auth($guard)->user();
+        if ($user !== null && property_exists($user, 'id')) {
+            return 'admin:' . (string) $user->id;
+        }
+
+        $requestId = trim((string) ($request->attributes->get('request_id') ?? ''));
+        if ($requestId !== '') {
+            return 'admin_token:' . $requestId;
+        }
+
+        return 'admin_token';
+    }
+}

--- a/backend/app/Http/Middleware/FmTokenAuth.php
+++ b/backend/app/Http/Middleware/FmTokenAuth.php
@@ -64,6 +64,10 @@ class FmTokenAuth
             return $this->unauthorizedResponse($request, 'token_not_found');
         }
 
+        // Always expose identity keys after DB lookup; values remain null when unresolved.
+        $request->attributes->set('fm_user_id', null);
+        $request->attributes->set('user_id', null);
+
         // expires_at check (only when present)
         if (property_exists($row, 'expires_at') && !empty($row->expires_at)) {
             $exp = strtotime((string) $row->expires_at);

--- a/backend/app/Services/Queue/QueueDlqService.php
+++ b/backend/app/Services/Queue/QueueDlqService.php
@@ -1,0 +1,313 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\Queue;
+
+use Illuminate\Contracts\Queue\Factory as QueueFactory;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Log;
+use Illuminate\Support\Facades\Schema;
+
+class QueueDlqService
+{
+    public function __construct(
+        private readonly QueueFactory $queueFactory,
+    ) {
+    }
+
+    public function metrics(): array
+    {
+        $failedTableExists = Schema::hasTable('failed_jobs');
+        $replayTableExists = Schema::hasTable('queue_dlq_replays');
+
+        $failedTotal = 0;
+        $failedByQueue = [];
+        if ($failedTableExists) {
+            $failedTotal = (int) DB::table('failed_jobs')->count();
+            $failedRows = DB::table('failed_jobs')
+                ->select('queue', DB::raw('count(*) as total'))
+                ->groupBy('queue')
+                ->orderBy('queue')
+                ->get();
+
+            foreach ($failedRows as $row) {
+                $failedByQueue[] = [
+                    'queue' => (string) ($row->queue ?? ''),
+                    'total' => (int) ($row->total ?? 0),
+                ];
+            }
+        }
+
+        $replayTotal = 0;
+        $replayStatus = [];
+        $lastReplayedAt = null;
+        if ($replayTableExists) {
+            $replayTotal = (int) DB::table('queue_dlq_replays')->count();
+
+            $statusRows = DB::table('queue_dlq_replays')
+                ->select('replay_status', DB::raw('count(*) as total'))
+                ->groupBy('replay_status')
+                ->orderBy('replay_status')
+                ->get();
+
+            foreach ($statusRows as $row) {
+                $replayStatus[] = [
+                    'status' => (string) ($row->replay_status ?? ''),
+                    'total' => (int) ($row->total ?? 0),
+                ];
+            }
+
+            $lastReplayedAt = DB::table('queue_dlq_replays')
+                ->where('replay_status', 'replayed')
+                ->max('replayed_at');
+        }
+
+        $replayedCount = $this->statusCount($replayStatus, 'replayed');
+        $failedReplayCount = $this->statusCount($replayStatus, 'push_failed');
+        $denominator = $replayedCount + $failedReplayCount;
+        $successRate = $denominator === 0 ? 1.0 : round($replayedCount / $denominator, 4);
+
+        return [
+            'tables' => [
+                'failed_jobs' => $failedTableExists,
+                'queue_dlq_replays' => $replayTableExists,
+            ],
+            'failed' => [
+                'total' => $failedTotal,
+                'by_queue' => $failedByQueue,
+            ],
+            'replay' => [
+                'total' => $replayTotal,
+                'by_status' => $replayStatus,
+                'last_replayed_at' => $lastReplayedAt,
+                'success_rate' => $successRate,
+            ],
+        ];
+    }
+
+    public function replayFailedJob(int $failedJobId, string $requestedBy, bool $force = false): array
+    {
+        if ($failedJobId <= 0) {
+            return [
+                'ok' => false,
+                'status' => 'not_found',
+                'error' => 'FAILED_JOB_NOT_FOUND',
+                'message' => 'failed job not found.',
+            ];
+        }
+
+        if (!$force && Schema::hasTable('queue_dlq_replays')) {
+            $already = DB::table('queue_dlq_replays')
+                ->where('failed_job_id', $failedJobId)
+                ->where('replay_status', 'replayed')
+                ->orderByDesc('id')
+                ->first();
+
+            if ($already) {
+                return [
+                    'ok' => true,
+                    'status' => 'already_replayed',
+                    'failed_job_id' => $failedJobId,
+                    'replay_log_id' => (int) ($already->id ?? 0),
+                    'replayed_job_id' => (string) ($already->replayed_job_id ?? ''),
+                    'message' => 'failed job already replayed.',
+                ];
+            }
+        }
+
+        $failedJob = $this->findFailedJob($failedJobId);
+        if ($failedJob === null) {
+            $this->insertReplayLog($failedJobId, null, '', '', 'not_found', null, $requestedBy, 'failed job not found');
+
+            return [
+                'ok' => false,
+                'status' => 'not_found',
+                'error' => 'FAILED_JOB_NOT_FOUND',
+                'message' => 'failed job not found.',
+            ];
+        }
+
+        $payload = (string) ($failedJob->payload ?? '');
+        if ($payload === '' || !$this->isJsonObject($payload)) {
+            $this->insertReplayLog(
+                $failedJobId,
+                $this->failedJobUuid($failedJob),
+                (string) ($failedJob->connection ?? ''),
+                (string) ($failedJob->queue ?? ''),
+                'invalid_payload',
+                null,
+                $requestedBy,
+                'payload invalid json object'
+            );
+
+            return [
+                'ok' => false,
+                'status' => 'invalid_payload',
+                'error' => 'FAILED_JOB_PAYLOAD_INVALID',
+                'message' => 'failed job payload invalid.',
+            ];
+        }
+
+        $connection = trim((string) ($failedJob->connection ?? ''));
+        if ($connection === '') {
+            $connection = (string) config('queue.default', 'sync');
+        }
+        $queue = trim((string) ($failedJob->queue ?? ''));
+        if ($queue === '') {
+            $queue = 'default';
+        }
+
+        try {
+            $replayedJobId = $this->queueFactory
+                ->connection($connection)
+                ->pushRaw($payload, $queue);
+
+            $this->forgetFailedJob($failedJobId);
+            $replayLogId = $this->insertReplayLog(
+                $failedJobId,
+                $this->failedJobUuid($failedJob),
+                $connection,
+                $queue,
+                'replayed',
+                $this->normalizeJobId($replayedJobId),
+                $requestedBy,
+                null
+            );
+
+            return [
+                'ok' => true,
+                'status' => 'replayed',
+                'failed_job_id' => $failedJobId,
+                'replayed_job_id' => $this->normalizeJobId($replayedJobId),
+                'replay_log_id' => $replayLogId,
+            ];
+        } catch (\Throwable $e) {
+            Log::warning('[queue_dlq] replay failed', [
+                'failed_job_id' => $failedJobId,
+                'error' => $e->getMessage(),
+            ]);
+
+            $this->insertReplayLog(
+                $failedJobId,
+                $this->failedJobUuid($failedJob),
+                $connection,
+                $queue,
+                'push_failed',
+                null,
+                $requestedBy,
+                $e->getMessage()
+            );
+
+            return [
+                'ok' => false,
+                'status' => 'push_failed',
+                'error' => 'REPLAY_FAILED',
+                'message' => 'failed job replay failed.',
+            ];
+        }
+    }
+
+    private function findFailedJob(int $failedJobId): ?object
+    {
+        $failer = app('queue.failer');
+        if (is_object($failer) && method_exists($failer, 'find')) {
+            $row = $failer->find((string) $failedJobId);
+            if (is_object($row)) {
+                return $row;
+            }
+
+            $row = $failer->find($failedJobId);
+            if (is_object($row)) {
+                return $row;
+            }
+        }
+
+        if (!Schema::hasTable('failed_jobs')) {
+            return null;
+        }
+
+        $row = DB::table('failed_jobs')->where('id', $failedJobId)->first();
+        return is_object($row) ? $row : null;
+    }
+
+    private function forgetFailedJob(int $failedJobId): void
+    {
+        $failer = app('queue.failer');
+        if (is_object($failer) && method_exists($failer, 'forget')) {
+            $failer->forget((string) $failedJobId);
+            $failer->forget($failedJobId);
+        }
+
+        if (Schema::hasTable('failed_jobs')) {
+            DB::table('failed_jobs')->where('id', $failedJobId)->delete();
+        }
+    }
+
+    private function insertReplayLog(
+        int $failedJobId,
+        ?string $failedJobUuid,
+        string $connection,
+        string $queue,
+        string $status,
+        ?string $replayedJobId,
+        string $requestedBy,
+        ?string $notes
+    ): int {
+        if (!Schema::hasTable('queue_dlq_replays')) {
+            return 0;
+        }
+
+        $id = DB::table('queue_dlq_replays')->insertGetId([
+            'failed_job_id' => $failedJobId,
+            'failed_job_uuid' => $failedJobUuid !== null && $failedJobUuid !== '' ? $failedJobUuid : null,
+            'connection_name' => $connection,
+            'queue_name' => $queue,
+            'replay_status' => $status,
+            'replayed_job_id' => $replayedJobId !== null && $replayedJobId !== '' ? $replayedJobId : null,
+            'requested_by' => $requestedBy !== '' ? $requestedBy : null,
+            'request_source' => 'api',
+            'notes' => $notes,
+            'replayed_at' => $status === 'replayed' ? now() : null,
+            'created_at' => now(),
+            'updated_at' => now(),
+        ]);
+
+        return (int) $id;
+    }
+
+    private function failedJobUuid(object $failedJob): ?string
+    {
+        $value = trim((string) ($failedJob->uuid ?? ''));
+        return $value !== '' ? $value : null;
+    }
+
+    private function isJsonObject(string $payload): bool
+    {
+        $decoded = json_decode($payload, true);
+        return is_array($decoded);
+    }
+
+    private function normalizeJobId(mixed $value): string
+    {
+        if (is_int($value) || is_float($value) || is_string($value)) {
+            return trim((string) $value);
+        }
+
+        return '';
+    }
+
+    /**
+     * @param array<int, array{status: string, total: int}> $replayStatus
+     */
+    private function statusCount(array $replayStatus, string $status): int
+    {
+        foreach ($replayStatus as $item) {
+            if (($item['status'] ?? '') === $status) {
+                return (int) ($item['total'] ?? 0);
+            }
+        }
+
+        return 0;
+    }
+}

--- a/backend/database/migrations/2026_02_08_030000_create_queue_dlq_replays_table.php
+++ b/backend/database/migrations/2026_02_08_030000_create_queue_dlq_replays_table.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('queue_dlq_replays', function (Blueprint $table): void {
+            $table->id();
+            $table->unsignedBigInteger('failed_job_id')->index();
+            $table->string('failed_job_uuid', 64)->nullable()->index();
+            $table->string('connection_name', 64)->default('');
+            $table->string('queue_name', 128)->default('');
+            $table->string('replay_status', 32)->default('replayed')->index();
+            $table->string('replayed_job_id', 64)->nullable();
+            $table->string('requested_by', 64)->nullable();
+            $table->string('request_source', 32)->default('api');
+            $table->text('notes')->nullable();
+            $table->timestamp('replayed_at')->nullable();
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('queue_dlq_replays');
+    }
+};

--- a/backend/routes/api.php
+++ b/backend/routes/api.php
@@ -24,6 +24,7 @@ use App\Http\Controllers\API\V0_2\AgentController;
 use App\Http\Controllers\API\V0_2\Admin\AdminOpsController;
 use App\Http\Controllers\API\V0_2\Admin\AdminAuditController;
 use App\Http\Controllers\API\V0_2\Admin\AdminAgentController;
+use App\Http\Controllers\API\V0_2\Admin\AdminQueueController;
 use App\Http\Controllers\API\V0_2\Admin\AdminEventsController;
 use App\Http\Controllers\API\V0_2\Admin\AdminContentController;
 use App\Http\Controllers\API\V0_3\AttemptsController;
@@ -75,6 +76,9 @@ Route::prefix("v0.2")->middleware([
         ->group(function () {
             // Ops snapshot
             Route::get("/healthz/snapshot", [AdminOpsController::class, "healthzSnapshot"]);
+            Route::get("/queue/dlq/metrics", [AdminQueueController::class, "metrics"]);
+            Route::post("/queue/dlq/replay/{failed_job_id}", [AdminQueueController::class, "replay"])
+                ->whereNumber('failed_job_id');
 
             // Audit logs (read-only)
             Route::get("/audit-logs", [AdminAuditController::class, "index"]);

--- a/backend/scripts/accept_auth_phone.sh
+++ b/backend/scripts/accept_auth_phone.sh
@@ -7,7 +7,8 @@ REPO_DIR="$(cd "${BACKEND_DIR}/.." && pwd)"
 API="${API:-http://127.0.0.1:1827}"
 SQLITE_DB="${SQLITE_DB:-${BACKEND_DIR}/database/database.sqlite}"
 
-PHONE="${PHONE:-+8613800138000}"
+DEFAULT_PHONE="$(php -r 'echo "+86139".(string) random_int(10000000, 99999999);')"
+PHONE="${PHONE:-${DEFAULT_PHONE}}"
 SCENE="${SCENE:-login}"
 
 # 每次验收用一个固定但不容易撞的 anon_id

--- a/backend/scripts/pr54_accept.sh
+++ b/backend/scripts/pr54_accept.sh
@@ -1,0 +1,114 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+export CI=true
+export FAP_NONINTERACTIVE=1
+export COMPOSER_NO_INTERACTION=1
+export GIT_TERMINAL_PROMPT=0
+export NO_COLOR=1
+export PAGER=cat
+export GIT_PAGER=cat
+export TERM=dumb
+export XDEBUG_MODE=off
+export LANG=en_US.UTF-8
+
+REPO_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+BACKEND_DIR="${REPO_DIR}/backend"
+ART_DIR="${BACKEND_DIR}/artifacts/pr54"
+SERVE_PORT="${SERVE_PORT:-1854}"
+DB_PATH="/tmp/pr54.sqlite"
+FAP_ADMIN_TOKEN="${FAP_ADMIN_TOKEN:-pr54-admin-token}"
+
+mkdir -p "${ART_DIR}"
+
+cleanup_port() {
+  local port="$1"
+  lsof -nP -iTCP:"${port}" -sTCP:LISTEN || true
+  local pid_list
+  pid_list="$(lsof -ti tcp:"${port}" || true)"
+  if [[ -n "${pid_list}" ]]; then
+    echo "${pid_list}" | xargs kill -9 || true
+  fi
+  lsof -nP -iTCP:"${port}" -sTCP:LISTEN || true
+}
+
+cleanup() {
+  if [[ -f "${ART_DIR}/server.pid" ]]; then
+    local pid
+    pid="$(cat "${ART_DIR}/server.pid" || true)"
+    if [[ -n "${pid}" ]] && ps -p "${pid}" >/dev/null 2>&1; then
+      kill "${pid}" >/dev/null 2>&1 || true
+    fi
+  fi
+
+  cleanup_port "${SERVE_PORT}"
+  cleanup_port 18000
+  rm -f "${DB_PATH}"
+}
+trap cleanup EXIT
+
+cleanup_port "${SERVE_PORT}"
+cleanup_port 18000
+
+export APP_ENV=testing
+export CACHE_STORE=array
+export QUEUE_CONNECTION=database
+export DB_CONNECTION=sqlite
+export DB_DATABASE="${DB_PATH}"
+export FAP_PACKS_ROOT="${FAP_PACKS_ROOT:-${REPO_DIR}/content_packages}"
+export FAP_DEFAULT_REGION="${FAP_DEFAULT_REGION:-CN_MAINLAND}"
+export FAP_DEFAULT_LOCALE="${FAP_DEFAULT_LOCALE:-zh-CN}"
+export FAP_DEFAULT_PACK_ID="${FAP_DEFAULT_PACK_ID:-MBTI.cn-mainland.zh-CN.v0.2.2}"
+export FAP_DEFAULT_DIR_VERSION="${FAP_DEFAULT_DIR_VERSION:-MBTI-CN-v0.2.2}"
+export FAP_ADMIN_TOKEN
+
+rm -f "${DB_PATH}"
+touch "${DB_PATH}"
+
+cd "${BACKEND_DIR}"
+composer install --no-interaction --no-progress
+php artisan migrate:fresh --force
+php artisan fap:scales:seed-default
+php artisan fap:scales:sync-slugs
+cd "${REPO_DIR}"
+
+SERVE_PORT="${SERVE_PORT}" ART_DIR="${ART_DIR}" FAP_ADMIN_TOKEN="${FAP_ADMIN_TOKEN}" bash "${BACKEND_DIR}/scripts/pr54_verify.sh"
+
+ATTEMPT_ID="$(cat "${ART_DIR}/attempt_id.txt" 2>/dev/null || true)"
+ANON_ID="$(cat "${ART_DIR}/anon_id.txt" 2>/dev/null || true)"
+QUESTION_COUNT="$(cat "${ART_DIR}/question_count.txt" 2>/dev/null || true)"
+FAILED_JOB_ID="$(cat "${ART_DIR}/failed_job_id.txt" 2>/dev/null || true)"
+REPLAY_STATUS="$(cat "${ART_DIR}/dlq_replay_status.txt" 2>/dev/null || true)"
+REPLAY_TOTAL_AFTER="$(cat "${ART_DIR}/dlq_replay_total_after.txt" 2>/dev/null || true)"
+DEFAULT_PACK_ID="$(cat "${ART_DIR}/config_default_pack_id.txt" 2>/dev/null || true)"
+DEFAULT_DIR_VERSION="$(cat "${ART_DIR}/config_default_dir_version.txt" 2>/dev/null || true)"
+
+cat > "${ART_DIR}/summary.txt" <<TXT
+PR54 Acceptance Summary
+- pass_items:
+  - queue_dlq_metrics_endpoint: OK
+  - queue_dlq_replay_endpoint: OK
+  - dynamic_answers_submit: OK
+  - pack_seed_config_consistency: OK
+  - admin_queue_dlq_feature_test: OK
+- key_outputs:
+  - attempt_id: ${ATTEMPT_ID}
+  - anon_id: ${ANON_ID}
+  - question_count(dynamic): ${QUESTION_COUNT}
+  - failed_job_id_seeded: ${FAILED_JOB_ID}
+  - replay_status: ${REPLAY_STATUS}
+  - replay_total_after: ${REPLAY_TOTAL_AFTER}
+  - default_pack_id: ${DEFAULT_PACK_ID}
+  - default_dir_version: ${DEFAULT_DIR_VERSION}
+- smoke_urls:
+  - http://127.0.0.1:${SERVE_PORT}/api/v0.2/admin/queue/dlq/metrics
+  - http://127.0.0.1:${SERVE_PORT}/api/v0.2/admin/queue/dlq/replay/${FAILED_JOB_ID}
+  - http://127.0.0.1:${SERVE_PORT}/api/v0.3/scales/MBTI/questions
+- schema_changes:
+  - create table queue_dlq_replays
+TXT
+
+bash "${BACKEND_DIR}/scripts/sanitize_artifacts.sh" 54
+
+bash -n "${BACKEND_DIR}/scripts/pr54_accept.sh"
+bash -n "${BACKEND_DIR}/scripts/pr54_verify.sh"

--- a/backend/scripts/pr54_verify.sh
+++ b/backend/scripts/pr54_verify.sh
@@ -1,0 +1,411 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+export CI=true
+export FAP_NONINTERACTIVE=1
+export COMPOSER_NO_INTERACTION=1
+export GIT_TERMINAL_PROMPT=0
+export NO_COLOR=1
+export PAGER=cat
+export GIT_PAGER=cat
+export TERM=dumb
+export XDEBUG_MODE=off
+export LANG=en_US.UTF-8
+
+REPO_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+BACKEND_DIR="${REPO_DIR}/backend"
+ART_DIR="${ART_DIR:-${BACKEND_DIR}/artifacts/pr54}"
+SERVE_PORT="${SERVE_PORT:-1854}"
+HOST="127.0.0.1"
+API_BASE="http://${HOST}:${SERVE_PORT}"
+SCALE_CODE="${SCALE_CODE:-MBTI}"
+ANON_ID="${ANON_ID:-pr54-verify-anon}"
+FAP_ADMIN_TOKEN="${FAP_ADMIN_TOKEN:-pr54-admin-token}"
+
+mkdir -p "${ART_DIR}"
+exec > "${ART_DIR}/verify.log" 2>&1
+
+fail() {
+  echo "[PR54][FAIL] $*" >&2
+  exit 1
+}
+
+cleanup_port() {
+  local port="$1"
+  lsof -nP -iTCP:"${port}" -sTCP:LISTEN || true
+  local pid_list
+  pid_list="$(lsof -ti tcp:"${port}" || true)"
+  if [[ -n "${pid_list}" ]]; then
+    echo "${pid_list}" | xargs kill -9 || true
+  fi
+  lsof -nP -iTCP:"${port}" -sTCP:LISTEN || true
+}
+
+wait_health() {
+  local url="$1"
+  local body_file="${ART_DIR}/healthz.body"
+  local http_code=""
+
+  for _ in $(seq 1 80); do
+    http_code="$(curl -sS -o "${body_file}" -w "%{http_code}" "${url}" || true)"
+    if [[ "${http_code}" == "200" ]]; then
+      return 0
+    fi
+    sleep 0.25
+  done
+
+  echo "health_check_failed http=${http_code}" >&2
+  cat "${body_file}" >&2 || true
+  tail -n 120 "${ART_DIR}/server.log" >&2 || true
+  return 1
+}
+
+cleanup() {
+  if [[ -n "${SERVE_PID:-}" ]] && ps -p "${SERVE_PID}" >/dev/null 2>&1; then
+    kill "${SERVE_PID}" >/dev/null 2>&1 || true
+  fi
+
+  if [[ -f "${ART_DIR}/server.pid" ]]; then
+    local pid
+    pid="$(cat "${ART_DIR}/server.pid" || true)"
+    if [[ -n "${pid}" ]] && ps -p "${pid}" >/dev/null 2>&1; then
+      kill "${pid}" >/dev/null 2>&1 || true
+    fi
+  fi
+
+  cleanup_port "${SERVE_PORT}"
+  cleanup_port 18000
+}
+trap cleanup EXIT
+
+cleanup_port "${SERVE_PORT}"
+cleanup_port 18000
+
+cd "${BACKEND_DIR}"
+php artisan serve --host="${HOST}" --port="${SERVE_PORT}" > "${ART_DIR}/server.log" 2>&1 &
+SERVE_PID="$!"
+echo "${SERVE_PID}" > "${ART_DIR}/server.pid"
+cd "${REPO_DIR}"
+
+wait_health "${API_BASE}/api/v0.2/healthz" || fail "healthz failed"
+curl -sS "${API_BASE}/api/v0.2/healthz" > "${ART_DIR}/healthz.json"
+
+cd "${BACKEND_DIR}"
+php -r '
+require "vendor/autoload.php";
+$app = require "bootstrap/app.php";
+$app->make(Illuminate\Contracts\Console\Kernel::class)->bootstrap();
+
+$configPackId = trim((string) config("content_packs.default_pack_id", ""));
+$configDirVersion = trim((string) config("content_packs.default_dir_version", ""));
+$configRegion = trim((string) config("content_packs.default_region", ""));
+$configLocale = trim((string) config("content_packs.default_locale", ""));
+
+echo "config_default_pack_id=".$configPackId.PHP_EOL;
+echo "config_default_dir_version=".$configDirVersion.PHP_EOL;
+echo "config_default_region=".$configRegion.PHP_EOL;
+echo "config_default_locale=".$configLocale.PHP_EOL;
+
+if ($configPackId === "" || $configDirVersion === "" || $configRegion === "" || $configLocale === "") {
+    fwrite(STDERR, "content_pack_defaults_missing\n");
+    exit(1);
+}
+
+if (!Illuminate\Support\Facades\Schema::hasTable("scales_registry")) {
+    fwrite(STDERR, "missing_scales_registry_table\n");
+    exit(1);
+}
+
+$row = Illuminate\Support\Facades\DB::table("scales_registry")
+    ->where("org_id", 0)
+    ->where("code", "MBTI")
+    ->first();
+if (!$row) {
+    fwrite(STDERR, "missing_scales_registry_mbti\n");
+    exit(1);
+}
+
+$registryPackId = trim((string) ($row->default_pack_id ?? ""));
+$registryDirVersion = trim((string) ($row->default_dir_version ?? ""));
+
+echo "registry_default_pack_id=".$registryPackId.PHP_EOL;
+echo "registry_default_dir_version=".$registryDirVersion.PHP_EOL;
+
+if ($registryPackId !== $configPackId) {
+    fwrite(STDERR, "default_pack_id_mismatch\n");
+    exit(1);
+}
+if ($registryDirVersion !== $configDirVersion) {
+    fwrite(STDERR, "default_dir_version_mismatch\n");
+    exit(1);
+}
+
+$index = app(App\Services\Content\ContentPacksIndex::class);
+$found = $index->find($configPackId, $configDirVersion);
+if (!($found["ok"] ?? false)) {
+    fwrite(STDERR, "pack_not_found\n");
+    exit(1);
+}
+
+$item = $found["item"] ?? [];
+$manifestPath = (string) ($item["manifest_path"] ?? "");
+$questionsPath = (string) ($item["questions_path"] ?? "");
+if ($manifestPath === "" || !is_file($manifestPath)) {
+    fwrite(STDERR, "manifest_missing\n");
+    exit(1);
+}
+if ($questionsPath === "" || !is_file($questionsPath)) {
+    fwrite(STDERR, "questions_missing\n");
+    exit(1);
+}
+
+$packDir = dirname($manifestPath);
+$versionPath = $packDir.DIRECTORY_SEPARATOR."version.json";
+if (!is_file($versionPath)) {
+    fwrite(STDERR, "version_missing\n");
+    exit(1);
+}
+
+$manifest = json_decode((string) file_get_contents($manifestPath), true);
+$version = json_decode((string) file_get_contents($versionPath), true);
+$questions = json_decode((string) file_get_contents($questionsPath), true);
+
+if (!is_array($manifest) || !is_array($version) || !is_array($questions)) {
+    fwrite(STDERR, "pack_json_invalid\n");
+    exit(1);
+}
+if (trim((string) ($manifest["pack_id"] ?? "")) !== $configPackId) {
+    fwrite(STDERR, "manifest_pack_id_mismatch\n");
+    exit(1);
+}
+if (trim((string) ($version["pack_id"] ?? "")) !== $configPackId) {
+    fwrite(STDERR, "version_pack_id_mismatch\n");
+    exit(1);
+}
+if (trim((string) ($version["dir_version"] ?? "")) !== $configDirVersion) {
+    fwrite(STDERR, "version_dir_version_mismatch\n");
+    exit(1);
+}
+
+echo "pack_dir=".$packDir.PHP_EOL;
+echo "pack_manifest=".$manifestPath.PHP_EOL;
+echo "pack_questions=".$questionsPath.PHP_EOL;
+echo "pack_version=".$versionPath.PHP_EOL;
+' > "${ART_DIR}/pack_seed_config.txt"
+cd "${REPO_DIR}"
+
+grep -E "^config_default_pack_id=" "${ART_DIR}/pack_seed_config.txt" | sed "s/^config_default_pack_id=//" > "${ART_DIR}/config_default_pack_id.txt"
+grep -E "^config_default_dir_version=" "${ART_DIR}/pack_seed_config.txt" | sed "s/^config_default_dir_version=//" > "${ART_DIR}/config_default_dir_version.txt"
+
+QUESTIONS_JSON="${ART_DIR}/questions.json"
+http_code="$(curl -sS -o "${QUESTIONS_JSON}" -w "%{http_code}" \
+  -H "Accept: application/json" \
+  "${API_BASE}/api/v0.3/scales/${SCALE_CODE}/questions" || true)"
+if [[ "${http_code}" != "200" ]]; then
+  echo "questions_failed http=${http_code}" >&2
+  cat "${QUESTIONS_JSON}" >&2 || true
+  tail -n 120 "${ART_DIR}/server.log" >&2 || true
+  fail "questions endpoint failed"
+fi
+
+ANSWERS_JSON="${ART_DIR}/answers.json"
+php -r '
+$raw = file_get_contents("php://stdin");
+$data = json_decode($raw, true);
+if (!is_array($data)) {
+    fwrite(STDERR, "questions_json_invalid\n");
+    exit(1);
+}
+$items = $data["questions"]["items"] ?? $data["questions"] ?? $data["items"] ?? $data["data"] ?? $data;
+if (!is_array($items)) {
+    fwrite(STDERR, "questions_items_invalid\n");
+    exit(1);
+}
+$answers = [];
+foreach ($items as $item) {
+    if (!is_array($item)) {
+        continue;
+    }
+    $questionId = (string) ($item["question_id"] ?? $item["id"] ?? "");
+    if ($questionId === "") {
+        continue;
+    }
+    $options = $item["options"] ?? [];
+    $code = "A";
+    if (is_array($options) && isset($options[0]) && is_array($options[0])) {
+        $code = (string) ($options[0]["code"] ?? $options[0]["option_code"] ?? "A");
+    }
+    if ($code === "") {
+        $code = "A";
+    }
+    $answers[] = [
+        "question_id" => $questionId,
+        "code" => $code,
+    ];
+}
+if (count($answers) === 0) {
+    fwrite(STDERR, "answers_empty\n");
+    exit(1);
+}
+echo json_encode($answers, JSON_UNESCAPED_UNICODE);
+' < "${QUESTIONS_JSON}" > "${ANSWERS_JSON}"
+
+QUESTION_COUNT="$(php -r '
+$data = json_decode(file_get_contents($argv[1]), true);
+if (!is_array($data)) {
+    echo "0";
+    exit(0);
+}
+echo (string) count($data);
+' "${ANSWERS_JSON}")"
+if [[ "${QUESTION_COUNT}" == "0" ]]; then
+  fail "dynamic answers generation produced zero answers"
+fi
+echo "${QUESTION_COUNT}" > "${ART_DIR}/question_count.txt"
+
+ATTEMPT_START_JSON="${ART_DIR}/attempt_start.json"
+ATTEMPT_START_BODY="$(SCALE_CODE="${SCALE_CODE}" ANON_ID="${ANON_ID}" php -r '
+$payload = [
+    "scale_code" => getenv("SCALE_CODE"),
+    "anon_id" => getenv("ANON_ID"),
+];
+echo json_encode($payload, JSON_UNESCAPED_UNICODE);
+')"
+http_code="$(curl -sS -o "${ATTEMPT_START_JSON}" -w "%{http_code}" \
+  -X POST -H "Content-Type: application/json" -H "Accept: application/json" \
+  --data "${ATTEMPT_START_BODY}" \
+  "${API_BASE}/api/v0.3/attempts/start" || true)"
+if [[ "${http_code}" != "200" ]]; then
+  echo "attempt_start_failed http=${http_code}" >&2
+  cat "${ATTEMPT_START_JSON}" >&2 || true
+  tail -n 120 "${ART_DIR}/server.log" >&2 || true
+  fail "attempt start failed"
+fi
+
+ATTEMPT_ID="$(php -r '$j=json_decode(file_get_contents($argv[1]), true); echo (string)($j["attempt_id"] ?? "");' "${ATTEMPT_START_JSON}")"
+if [[ -z "${ATTEMPT_ID}" ]]; then
+  fail "missing attempt_id"
+fi
+echo "${ATTEMPT_ID}" > "${ART_DIR}/attempt_id.txt"
+echo "${ANON_ID}" > "${ART_DIR}/anon_id.txt"
+
+SUBMIT_PAYLOAD="${ART_DIR}/submit_payload.json"
+ATTEMPT_ID="${ATTEMPT_ID}" ANSWERS_PATH="${ANSWERS_JSON}" php -r '
+$answers = json_decode(file_get_contents(getenv("ANSWERS_PATH")), true);
+if (!is_array($answers) || count($answers) === 0) {
+    fwrite(STDERR, "answers_payload_invalid\n");
+    exit(1);
+}
+$payload = [
+    "attempt_id" => getenv("ATTEMPT_ID"),
+    "answers" => $answers,
+    "duration_ms" => 120000,
+];
+echo json_encode($payload, JSON_UNESCAPED_UNICODE);
+' > "${SUBMIT_PAYLOAD}"
+
+ATTEMPT_SUBMIT_JSON="${ART_DIR}/attempt_submit.json"
+http_code="$(curl -sS -o "${ATTEMPT_SUBMIT_JSON}" -w "%{http_code}" \
+  -X POST -H "Content-Type: application/json" -H "Accept: application/json" \
+  --data @"${SUBMIT_PAYLOAD}" \
+  "${API_BASE}/api/v0.3/attempts/submit" || true)"
+if [[ "${http_code}" != "200" ]]; then
+  echo "attempt_submit_failed http=${http_code}" >&2
+  cat "${ATTEMPT_SUBMIT_JSON}" >&2 || true
+  tail -n 120 "${ART_DIR}/server.log" >&2 || true
+  fail "attempt submit failed"
+fi
+
+cd "${BACKEND_DIR}"
+php -r '
+require "vendor/autoload.php";
+$app = require "bootstrap/app.php";
+$app->make(Illuminate\Contracts\Console\Kernel::class)->bootstrap();
+
+$payload = json_encode([
+    "uuid" => (string) Illuminate\Support\Str::uuid(),
+    "displayName" => "PR54\\DLQReplay",
+    "job" => "Illuminate\\Queue\\CallQueuedHandler@call",
+    "data" => [
+        "commandName" => "PR54\\DLQReplay",
+        "command" => "serialized",
+    ],
+], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES);
+
+$id = Illuminate\Support\Facades\DB::table("failed_jobs")->insertGetId([
+    "uuid" => (string) Illuminate\Support\Str::uuid(),
+    "connection" => "database",
+    "queue" => "reports",
+    "payload" => $payload,
+    "exception" => "RuntimeException: seeded by pr54_verify",
+    "failed_at" => now(),
+]);
+
+echo "failed_job_id=".$id.PHP_EOL;
+' > "${ART_DIR}/dlq_seed.txt"
+cd "${REPO_DIR}"
+
+FAILED_JOB_ID="$(grep -E '^failed_job_id=' "${ART_DIR}/dlq_seed.txt" | sed 's/^failed_job_id=//')"
+if [[ -z "${FAILED_JOB_ID}" ]]; then
+  fail "failed job seed missing id"
+fi
+echo "${FAILED_JOB_ID}" > "${ART_DIR}/failed_job_id.txt"
+
+DLQ_METRICS_BEFORE_JSON="${ART_DIR}/dlq_metrics_before.json"
+http_code="$(curl -sS -o "${DLQ_METRICS_BEFORE_JSON}" -w "%{http_code}" \
+  -H "Accept: application/json" \
+  -H "X-FAP-Admin-Token: ${FAP_ADMIN_TOKEN}" \
+  "${API_BASE}/api/v0.2/admin/queue/dlq/metrics" || true)"
+if [[ "${http_code}" != "200" ]]; then
+  echo "dlq_metrics_before_failed http=${http_code}" >&2
+  cat "${DLQ_METRICS_BEFORE_JSON}" >&2 || true
+  tail -n 120 "${ART_DIR}/server.log" >&2 || true
+  fail "dlq metrics before replay failed"
+fi
+
+DLQ_REPLAY_JSON="${ART_DIR}/dlq_replay_response.json"
+http_code="$(curl -sS -o "${DLQ_REPLAY_JSON}" -w "%{http_code}" \
+  -X POST \
+  -H "Content-Type: application/json" \
+  -H "Accept: application/json" \
+  -H "X-FAP-Admin-Token: ${FAP_ADMIN_TOKEN}" \
+  --data '{"force":false}' \
+  "${API_BASE}/api/v0.2/admin/queue/dlq/replay/${FAILED_JOB_ID}" || true)"
+if [[ "${http_code}" != "200" ]]; then
+  echo "dlq_replay_failed http=${http_code}" >&2
+  cat "${DLQ_REPLAY_JSON}" >&2 || true
+  tail -n 120 "${ART_DIR}/server.log" >&2 || true
+  fail "dlq replay failed"
+fi
+
+REPLAY_STATUS="$(php -r '$j=json_decode(file_get_contents($argv[1]), true); echo (string)($j["data"]["status"] ?? "");' "${DLQ_REPLAY_JSON}")"
+if [[ "${REPLAY_STATUS}" != "replayed" && "${REPLAY_STATUS}" != "already_replayed" ]]; then
+  fail "unexpected replay status: ${REPLAY_STATUS}"
+fi
+
+echo "${REPLAY_STATUS}" > "${ART_DIR}/dlq_replay_status.txt"
+
+DLQ_METRICS_AFTER_JSON="${ART_DIR}/dlq_metrics_after.json"
+http_code="$(curl -sS -o "${DLQ_METRICS_AFTER_JSON}" -w "%{http_code}" \
+  -H "Accept: application/json" \
+  -H "X-FAP-Admin-Token: ${FAP_ADMIN_TOKEN}" \
+  "${API_BASE}/api/v0.2/admin/queue/dlq/metrics" || true)"
+if [[ "${http_code}" != "200" ]]; then
+  echo "dlq_metrics_after_failed http=${http_code}" >&2
+  cat "${DLQ_METRICS_AFTER_JSON}" >&2 || true
+  tail -n 120 "${ART_DIR}/server.log" >&2 || true
+  fail "dlq metrics after replay failed"
+fi
+
+REPLAY_TOTAL_AFTER="$(php -r '$j=json_decode(file_get_contents($argv[1]), true); echo (string)($j["data"]["replay"]["total"] ?? "0");' "${DLQ_METRICS_AFTER_JSON}")"
+if [[ "${REPLAY_TOTAL_AFTER}" == "0" ]]; then
+  fail "dlq replay metrics total is zero"
+fi
+
+echo "${REPLAY_TOTAL_AFTER}" > "${ART_DIR}/dlq_replay_total_after.txt"
+
+cd "${BACKEND_DIR}"
+php artisan test --filter AdminQueueDlqReplayTest > "${ART_DIR}/phpunit_admin_queue_dlq_replay.txt" 2>&1
+cd "${REPO_DIR}"
+
+echo "verify_done" > "${ART_DIR}/verify_done.txt"

--- a/backend/tests/Feature/V0_2/AdminQueueDlqReplayTest.php
+++ b/backend/tests/Feature/V0_2/AdminQueueDlqReplayTest.php
@@ -1,0 +1,137 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\V0_2;
+
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Str;
+use Tests\TestCase;
+
+final class AdminQueueDlqReplayTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private const ADMIN_TOKEN = 'pr54-admin-token';
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        config([
+            'admin.token' => self::ADMIN_TOKEN,
+            'queue.default' => 'database',
+        ]);
+    }
+
+    public function test_metrics_endpoint_returns_failed_and_replay_counts(): void
+    {
+        $firstFailedJobId = $this->seedFailedJob('reports');
+        $this->seedFailedJob('insights');
+
+        DB::table('queue_dlq_replays')->insert([
+            'failed_job_id' => $firstFailedJobId,
+            'failed_job_uuid' => (string) Str::uuid(),
+            'connection_name' => 'database',
+            'queue_name' => 'reports',
+            'replay_status' => 'replayed',
+            'replayed_job_id' => '123',
+            'requested_by' => 'admin_token',
+            'request_source' => 'api',
+            'notes' => null,
+            'replayed_at' => now(),
+            'created_at' => now(),
+            'updated_at' => now(),
+        ]);
+
+        $response = $this->withHeaders($this->adminHeaders())
+            ->getJson('/api/v0.2/admin/queue/dlq/metrics');
+
+        $response
+            ->assertStatus(200)
+            ->assertJsonPath('ok', true)
+            ->assertJsonPath('data.failed.total', 2)
+            ->assertJsonPath('data.replay.total', 1);
+
+        $failedByQueue = $response->json('data.failed.by_queue');
+        $this->assertIsArray($failedByQueue);
+
+        $reports = collect($failedByQueue)->firstWhere('queue', 'reports');
+        $insights = collect($failedByQueue)->firstWhere('queue', 'insights');
+
+        $this->assertSame(1, (int) ($reports['total'] ?? 0));
+        $this->assertSame(1, (int) ($insights['total'] ?? 0));
+    }
+
+    public function test_replay_endpoint_requeues_failed_job_and_removes_from_dlq(): void
+    {
+        $failedJobId = $this->seedFailedJob('reports');
+
+        $response = $this->withHeaders($this->adminHeaders())
+            ->postJson("/api/v0.2/admin/queue/dlq/replay/{$failedJobId}", [
+                'force' => false,
+            ]);
+
+        $response
+            ->assertStatus(200)
+            ->assertJsonPath('ok', true)
+            ->assertJsonPath('data.status', 'replayed')
+            ->assertJsonPath('data.failed_job_id', $failedJobId);
+
+        $this->assertDatabaseMissing('failed_jobs', [
+            'id' => $failedJobId,
+        ]);
+
+        $this->assertDatabaseCount('jobs', 1);
+
+        $this->assertDatabaseHas('queue_dlq_replays', [
+            'failed_job_id' => $failedJobId,
+            'replay_status' => 'replayed',
+        ]);
+    }
+
+    public function test_replay_endpoint_returns_404_when_failed_job_missing(): void
+    {
+        $response = $this->withHeaders($this->adminHeaders())
+            ->postJson('/api/v0.2/admin/queue/dlq/replay/999999');
+
+        $response
+            ->assertStatus(404)
+            ->assertJsonPath('ok', false)
+            ->assertJsonPath('error', 'NOT_FOUND');
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    private function adminHeaders(): array
+    {
+        return [
+            'X-FAP-Admin-Token' => self::ADMIN_TOKEN,
+            'Accept' => 'application/json',
+        ];
+    }
+
+    private function seedFailedJob(string $queue): int
+    {
+        $payload = json_encode([
+            'uuid' => (string) Str::uuid(),
+            'displayName' => 'Tests\\Fixtures\\ReplayableJob',
+            'job' => 'Illuminate\\Queue\\CallQueuedHandler@call',
+            'data' => [
+                'commandName' => 'Tests\\Fixtures\\ReplayableJob',
+                'command' => 'serialized',
+            ],
+        ], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES);
+
+        return (int) DB::table('failed_jobs')->insertGetId([
+            'uuid' => (string) Str::uuid(),
+            'connection' => 'database',
+            'queue' => $queue,
+            'payload' => $payload === false ? '{}' : $payload,
+            'exception' => 'RuntimeException: pr54 replay test',
+            'failed_at' => now(),
+        ]);
+    }
+}

--- a/docs/verify/pr54_verify.md
+++ b/docs/verify/pr54_verify.md
@@ -1,0 +1,31 @@
+# PR54 Verify
+
+- Date: 2026-02-07
+- Commands:
+  - `php artisan route:list`
+  - `php artisan migrate`
+  - `php artisan test --filter AdminQueueDlqReplayTest`
+  - `bash backend/scripts/pr54_accept.sh`
+  - `bash backend/scripts/ci_verify_mbti.sh`
+- Result:
+  - `php artisan route:list` 通过（DLQ metrics/replay 路由可见）
+  - `php artisan migrate` 通过（`queue_dlq_replays` 成功执行）
+  - `php artisan test --filter AdminQueueDlqReplayTest` 通过
+  - `bash backend/scripts/pr54_accept.sh` 通过
+  - `bash backend/scripts/ci_verify_mbti.sh` 通过
+- Artifacts:
+  - `backend/artifacts/pr54/summary.txt`
+  - `backend/artifacts/pr54/verify.log`
+  - `backend/artifacts/pr54/dlq_metrics_before.json`
+  - `backend/artifacts/pr54/dlq_replay_response.json`
+  - `backend/artifacts/pr54/dlq_metrics_after.json`
+  - `backend/artifacts/pr54/phpunit_admin_queue_dlq_replay.txt`
+  - `backend/artifacts/verify_mbti/summary.txt`
+
+Step Verification Commands
+
+1. Step 1 (routes): `cd backend && php artisan route:list | grep -E "queue/dlq/metrics|queue/dlq/replay"`
+2. Step 2 (migrations): `cd backend && php artisan migrate --force && rm -f /tmp/pr54.sqlite && touch /tmp/pr54.sqlite && DB_CONNECTION=sqlite DB_DATABASE=/tmp/pr54.sqlite php artisan migrate:fresh --force`
+3. Step 3 (middleware): `php -l backend/app/Http/Middleware/FmTokenAuth.php && grep -n "DB::table('fm_tokens')" backend/app/Http/Middleware/FmTokenAuth.php && grep -n "attributes->set('fm_user_id'" backend/app/Http/Middleware/FmTokenAuth.php`
+4. Step 4 (controller/service/tests): `php -l backend/app/Http/Controllers/API/V0_2/Admin/AdminQueueController.php && php -l backend/app/Services/Queue/QueueDlqService.php && cd backend && php artisan test --filter AdminQueueDlqReplayTest`
+5. Step 5 (scripts/CI): `bash -n backend/scripts/pr54_verify.sh && bash -n backend/scripts/pr54_accept.sh && bash backend/scripts/pr54_accept.sh && bash backend/scripts/ci_verify_mbti.sh`


### PR DESCRIPTION
What:
增加 admin 侧 DLQ 回放与指标 API，并补齐本机验收脚本、测试和 CI 回归。
Why:
降低 failed_jobs 人工处理成本，支持可控 replay。
提供 DLQ backlog 与 replay 成功率观测，便于运维追踪。
How:
新增路由：/api/v0.2/admin/queue/dlq/metrics 与 /api/v0.2/admin/queue/dlq/replay/{failed_job_id}（[api.php](app://-/index.html#)）。
新增控制器：[AdminQueueController.php](app://-/index.html#)。
新增服务：[QueueDlqService.php](app://-/index.html#)（failed job 查询、pushRaw replay、日志落表、指标聚合）。
新增迁移：[2026_02_08_030000_create_queue_dlq_replays_table.php](app://-/index.html#)。
新增测试：[AdminQueueDlqReplayTest.php](app://-/index.html#)。
新增验收脚本：[pr54_accept.sh](app://-/index.html#)、[pr54_verify.sh](app://-/index.html#)。
新增 CI workflow：[ci_dlq_replay_metrics.yml](app://-/index.html#)。
Verify:
[pr54_accept.sh](app://-/index.html#)
[ci_verify_mbti.sh](app://-/index.html#)
Artifacts:
[summary.txt](app://-/index.html#)