### PR TITLE
chore(pr55): Make migrations deterministic and observable

### DIFF
--- a/.github/workflows/ci_pr55_migration_observability.yml
+++ b/.github/workflows/ci_pr55_migration_observability.yml
@@ -1,0 +1,77 @@
+name: CI PR55 Migration Observability
+
+on:
+  workflow_dispatch:
+  pull_request:
+  push:
+    branches: ["**"]
+
+jobs:
+  pr55-migration-observability:
+    runs-on: ubuntu-latest
+    timeout-minutes: 25
+    env:
+      APP_ENV: ci
+      APP_DEBUG: "true"
+      DB_CONNECTION: sqlite
+      DB_DATABASE: /tmp/fap-pr55-ci.sqlite
+      QUEUE_CONNECTION: database
+      FAP_PACKS_DRIVER: local
+      FAP_PACKS_ROOT: ${{ github.workspace }}/content_packages
+      FAP_DEFAULT_REGION: CN_MAINLAND
+      FAP_DEFAULT_LOCALE: zh-CN
+      FAP_DEFAULT_PACK_ID: MBTI.cn-mainland.zh-CN.v0.2.2
+      FAP_DEFAULT_DIR_VERSION: MBTI-CN-v0.2.2
+      FAP_ADMIN_TOKEN: pr55-ci-admin-token
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: "8.4"
+          coverage: none
+          tools: composer:v2
+          extensions: >
+            mbstring, intl, curl, json, openssl, fileinfo, pdo, pdo_sqlite, sqlite3
+
+      - name: Prepare Laravel cache dirs
+        working-directory: backend
+        run: |
+          mkdir -p storage/framework/cache/data
+          mkdir -p storage/framework/views
+          mkdir -p storage/framework/sessions
+          mkdir -p storage/logs
+          mkdir -p bootstrap/cache
+          chmod -R ug+rwX storage bootstrap/cache || true
+
+      - name: Install backend dependencies
+        working-directory: backend
+        run: |
+          composer install --no-interaction --prefer-dist --no-progress
+
+      - name: Prepare sqlite and seed defaults
+        working-directory: backend
+        env:
+          DB_DATABASE: /tmp/fap-pr55-ci.sqlite
+        run: |
+          bash scripts/ci/prepare_sqlite.sh
+          php artisan fap:scales:seed-default
+          php artisan fap:scales:sync-slugs
+
+      - name: Verify migration observability routes
+        working-directory: backend
+        run: |
+          php artisan route:list | grep -E "migrations/observability|migrations/rollback-preview"
+
+      - name: Run migration observability tests
+        working-directory: backend
+        run: |
+          php artisan test --filter AdminMigrationObservabilityTest
+          php artisan test --filter SchemaIndexTest
+
+      - name: Run PR55 acceptance script
+        run: |
+          bash backend/scripts/pr55_accept.sh

--- a/backend/app/Http/Controllers/API/V0_2/Admin/AdminMigrationController.php
+++ b/backend/app/Http/Controllers/API/V0_2/Admin/AdminMigrationController.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Controllers\API\V0_2\Admin;
+
+use App\Http\Controllers\Controller;
+use App\Services\Database\MigrationObservabilityService;
+use App\Support\Rbac\PermissionNames;
+use App\Support\Rbac\RbacService;
+use Illuminate\Http\Request;
+
+class AdminMigrationController extends Controller
+{
+    public function observability(Request $request, MigrationObservabilityService $service)
+    {
+        $this->assertPermission(PermissionNames::ADMIN_OPS_READ);
+
+        $limit = (int) $request->query('limit', 20);
+
+        return response()->json([
+            'ok' => true,
+            'data' => $service->snapshot($limit),
+        ]);
+    }
+
+    public function rollbackPreview(Request $request, MigrationObservabilityService $service)
+    {
+        $this->assertPermission(PermissionNames::ADMIN_OPS_READ);
+
+        $steps = (int) $request->query('steps', 1);
+
+        return response()->json([
+            'ok' => true,
+            'data' => $service->rollbackPreview($steps),
+        ]);
+    }
+
+    private function assertPermission(string $permission): void
+    {
+        $user = auth((string) config('admin.guard', 'admin'))->user();
+        if ($user !== null) {
+            app(RbacService::class)->assertCan($user, $permission);
+        }
+    }
+}

--- a/backend/app/Services/Database/MigrationObservabilityService.php
+++ b/backend/app/Services/Database/MigrationObservabilityService.php
@@ -1,0 +1,183 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\Database;
+
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+final class MigrationObservabilityService
+{
+    public function snapshot(int $limit = 20): array
+    {
+        $limit = $this->sanitizeLimit($limit);
+
+        return [
+            'migrations' => $this->migrationSummary($limit),
+            'index_audit' => $this->indexAuditSummary($limit),
+        ];
+    }
+
+    public function rollbackPreview(int $steps = 1): array
+    {
+        $steps = max(1, min($steps, 20));
+
+        if (!Schema::hasTable('migrations')) {
+            return [
+                'steps' => $steps,
+                'items' => [],
+            ];
+        }
+
+        $rows = DB::table('migrations')
+            ->select(['migration', 'batch'])
+            ->orderByDesc('batch')
+            ->orderByDesc('migration')
+            ->limit($steps)
+            ->get();
+
+        $items = [];
+        foreach ($rows as $row) {
+            $items[] = [
+                'migration' => (string) ($row->migration ?? ''),
+                'batch' => (int) ($row->batch ?? 0),
+            ];
+        }
+
+        return [
+            'steps' => $steps,
+            'items' => $items,
+        ];
+    }
+
+    private function migrationSummary(int $limit): array
+    {
+        if (!Schema::hasTable('migrations')) {
+            return [
+                'current_batch' => 0,
+                'total' => 0,
+                'recent' => [],
+            ];
+        }
+
+        $currentBatch = (int) (DB::table('migrations')->max('batch') ?? 0);
+        $total = (int) DB::table('migrations')->count();
+        $rows = DB::table('migrations')
+            ->select(['migration', 'batch'])
+            ->orderByDesc('batch')
+            ->orderByDesc('migration')
+            ->limit($limit)
+            ->get();
+
+        $recent = [];
+        foreach ($rows as $row) {
+            $recent[] = [
+                'migration' => (string) ($row->migration ?? ''),
+                'batch' => (int) ($row->batch ?? 0),
+            ];
+        }
+
+        return [
+            'current_batch' => $currentBatch,
+            'total' => $total,
+            'recent' => $recent,
+        ];
+    }
+
+    private function indexAuditSummary(int $limit): array
+    {
+        if (!Schema::hasTable('migration_index_audits')) {
+            return [
+                'total' => 0,
+                'by_action' => [],
+                'by_status' => [],
+                'recent' => [],
+            ];
+        }
+
+        $total = (int) DB::table('migration_index_audits')->count();
+        $byAction = DB::table('migration_index_audits')
+            ->select('action', DB::raw('COUNT(*) as total'))
+            ->groupBy('action')
+            ->orderBy('action')
+            ->get();
+        $byStatus = DB::table('migration_index_audits')
+            ->select('status', DB::raw('COUNT(*) as total'))
+            ->groupBy('status')
+            ->orderBy('status')
+            ->get();
+        $recentRows = DB::table('migration_index_audits')
+            ->select([
+                'id',
+                'migration_name',
+                'table_name',
+                'index_name',
+                'action',
+                'phase',
+                'driver',
+                'status',
+                'reason',
+                'recorded_at',
+                'created_at',
+            ])
+            ->orderByDesc('id')
+            ->limit($limit)
+            ->get();
+
+        return [
+            'total' => $total,
+            'by_action' => $this->toBucketRows($byAction, 'action'),
+            'by_status' => $this->toBucketRows($byStatus, 'status'),
+            'recent' => $this->toRecentRows($recentRows),
+        ];
+    }
+
+    private function sanitizeLimit(int $limit): int
+    {
+        return max(1, min($limit, 200));
+    }
+
+    /**
+     * @param iterable<object> $rows
+     * @return list<array{key: string, total: int}>
+     */
+    private function toBucketRows(iterable $rows, string $field): array
+    {
+        $items = [];
+        foreach ($rows as $row) {
+            $items[] = [
+                'key' => (string) ($row->{$field} ?? ''),
+                'total' => (int) ($row->total ?? 0),
+            ];
+        }
+
+        return $items;
+    }
+
+    /**
+     * @param iterable<object> $rows
+     * @return list<array<string, mixed>>
+     */
+    private function toRecentRows(iterable $rows): array
+    {
+        $items = [];
+        foreach ($rows as $row) {
+            $items[] = [
+                'id' => (int) ($row->id ?? 0),
+                'migration_name' => (string) ($row->migration_name ?? ''),
+                'table_name' => (string) ($row->table_name ?? ''),
+                'index_name' => (string) ($row->index_name ?? ''),
+                'action' => (string) ($row->action ?? ''),
+                'phase' => (string) ($row->phase ?? ''),
+                'driver' => (string) ($row->driver ?? ''),
+                'status' => (string) ($row->status ?? ''),
+                'reason' => (string) ($row->reason ?? ''),
+                'recorded_at' => $row->recorded_at,
+                'created_at' => $row->created_at,
+            ];
+        }
+
+        return $items;
+    }
+};

--- a/backend/database/migrations/2026_02_08_040000_create_migration_index_audits_table.php
+++ b/backend/database/migrations/2026_02_08_040000_create_migration_index_audits_table.php
@@ -1,0 +1,104 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Support\Database\SchemaIndex;
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    private const TABLE = 'migration_index_audits';
+
+    public function up(): void
+    {
+        if (!Schema::hasTable(self::TABLE)) {
+            Schema::create(self::TABLE, function (Blueprint $table): void {
+                $table->bigIncrements('id');
+                $table->string('migration_name', 191)->nullable();
+                $table->string('table_name', 128);
+                $table->string('index_name', 128);
+                $table->string('action', 64);
+                $table->string('phase', 32)->nullable();
+                $table->string('driver', 32);
+                $table->string('status', 32)->default('logged');
+                $table->string('reason', 191)->nullable();
+                $table->text('meta_json')->nullable();
+                $table->timestamp('recorded_at')->nullable();
+                $table->timestamps();
+            });
+        }
+
+        Schema::table(self::TABLE, function (Blueprint $table): void {
+            if (!Schema::hasColumn(self::TABLE, 'migration_name')) {
+                $table->string('migration_name', 191)->nullable();
+            }
+            if (!Schema::hasColumn(self::TABLE, 'table_name')) {
+                $table->string('table_name', 128);
+            }
+            if (!Schema::hasColumn(self::TABLE, 'index_name')) {
+                $table->string('index_name', 128);
+            }
+            if (!Schema::hasColumn(self::TABLE, 'action')) {
+                $table->string('action', 64);
+            }
+            if (!Schema::hasColumn(self::TABLE, 'phase')) {
+                $table->string('phase', 32)->nullable();
+            }
+            if (!Schema::hasColumn(self::TABLE, 'driver')) {
+                $table->string('driver', 32)->default('');
+            }
+            if (!Schema::hasColumn(self::TABLE, 'status')) {
+                $table->string('status', 32)->default('logged');
+            }
+            if (!Schema::hasColumn(self::TABLE, 'reason')) {
+                $table->string('reason', 191)->nullable();
+            }
+            if (!Schema::hasColumn(self::TABLE, 'meta_json')) {
+                $table->text('meta_json')->nullable();
+            }
+            if (!Schema::hasColumn(self::TABLE, 'recorded_at')) {
+                $table->timestamp('recorded_at')->nullable();
+            }
+            if (!Schema::hasColumn(self::TABLE, 'created_at')) {
+                $table->timestamp('created_at')->nullable();
+            }
+            if (!Schema::hasColumn(self::TABLE, 'updated_at')) {
+                $table->timestamp('updated_at')->nullable();
+            }
+        });
+
+        $this->ensureIndex(['migration_name'], 'migration_index_audits_migration_idx');
+        $this->ensureIndex(['action', 'phase'], 'migration_index_audits_action_phase_idx');
+        $this->ensureIndex(['recorded_at'], 'migration_index_audits_recorded_at_idx');
+        $this->ensureIndex(['table_name', 'index_name'], 'migration_index_audits_table_index_idx');
+    }
+
+    public function down(): void
+    {
+        if (Schema::hasTable(self::TABLE)) {
+            Schema::drop(self::TABLE);
+        }
+    }
+
+    /**
+     * @param list<string> $columns
+     */
+    private function ensureIndex(array $columns, string $indexName): void
+    {
+        if (SchemaIndex::indexExists(self::TABLE, $indexName)) {
+            return;
+        }
+
+        foreach ($columns as $column) {
+            if (!Schema::hasColumn(self::TABLE, $column)) {
+                return;
+            }
+        }
+
+        Schema::table(self::TABLE, function (Blueprint $table) use ($columns, $indexName): void {
+            $table->index($columns, $indexName);
+        });
+    }
+};

--- a/backend/routes/api.php
+++ b/backend/routes/api.php
@@ -24,6 +24,7 @@ use App\Http\Controllers\API\V0_2\AgentController;
 use App\Http\Controllers\API\V0_2\Admin\AdminOpsController;
 use App\Http\Controllers\API\V0_2\Admin\AdminAuditController;
 use App\Http\Controllers\API\V0_2\Admin\AdminAgentController;
+use App\Http\Controllers\API\V0_2\Admin\AdminMigrationController;
 use App\Http\Controllers\API\V0_2\Admin\AdminQueueController;
 use App\Http\Controllers\API\V0_2\Admin\AdminEventsController;
 use App\Http\Controllers\API\V0_2\Admin\AdminContentController;
@@ -76,6 +77,8 @@ Route::prefix("v0.2")->middleware([
         ->group(function () {
             // Ops snapshot
             Route::get("/healthz/snapshot", [AdminOpsController::class, "healthzSnapshot"]);
+            Route::get("/migrations/observability", [AdminMigrationController::class, "observability"]);
+            Route::get("/migrations/rollback-preview", [AdminMigrationController::class, "rollbackPreview"]);
             Route::get("/queue/dlq/metrics", [AdminQueueController::class, "metrics"]);
             Route::post("/queue/dlq/replay/{failed_job_id}", [AdminQueueController::class, "replay"])
                 ->whereNumber('failed_job_id');

--- a/backend/scripts/pr55_accept.sh
+++ b/backend/scripts/pr55_accept.sh
@@ -1,0 +1,120 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+export CI=true
+export FAP_NONINTERACTIVE=1
+export COMPOSER_NO_INTERACTION=1
+export GIT_TERMINAL_PROMPT=0
+export NO_COLOR=1
+export PAGER=cat
+export GIT_PAGER=cat
+export TERM=dumb
+export XDEBUG_MODE=off
+export LANG=en_US.UTF-8
+
+REPO_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+BACKEND_DIR="${REPO_DIR}/backend"
+ART_DIR="${BACKEND_DIR}/artifacts/pr55"
+SERVE_PORT="${SERVE_PORT:-1855}"
+DB_PATH="/tmp/pr55.sqlite"
+FAP_ADMIN_TOKEN="${FAP_ADMIN_TOKEN:-pr55-admin-token}"
+
+mkdir -p "${ART_DIR}"
+
+cleanup_port() {
+  local port="$1"
+  lsof -nP -iTCP:"${port}" -sTCP:LISTEN || true
+  local pid_list
+  pid_list="$(lsof -ti tcp:"${port}" || true)"
+  if [[ -n "${pid_list}" ]]; then
+    echo "${pid_list}" | xargs kill -9 || true
+  fi
+  lsof -nP -iTCP:"${port}" -sTCP:LISTEN || true
+}
+
+cleanup() {
+  if [[ -f "${ART_DIR}/server.pid" ]]; then
+    local pid
+    pid="$(cat "${ART_DIR}/server.pid" || true)"
+    if [[ -n "${pid}" ]] && ps -p "${pid}" >/dev/null 2>&1; then
+      kill "${pid}" >/dev/null 2>&1 || true
+    fi
+  fi
+
+  cleanup_port "${SERVE_PORT}"
+  cleanup_port 18000
+  rm -f "${DB_PATH}"
+}
+trap cleanup EXIT
+
+cleanup_port "${SERVE_PORT}"
+cleanup_port 18000
+
+export APP_ENV=testing
+export CACHE_STORE=array
+export QUEUE_CONNECTION=database
+export DB_CONNECTION=sqlite
+export DB_DATABASE="${DB_PATH}"
+export FAP_PACKS_ROOT="${FAP_PACKS_ROOT:-${REPO_DIR}/content_packages}"
+export FAP_DEFAULT_REGION="${FAP_DEFAULT_REGION:-CN_MAINLAND}"
+export FAP_DEFAULT_LOCALE="${FAP_DEFAULT_LOCALE:-zh-CN}"
+export FAP_DEFAULT_PACK_ID="${FAP_DEFAULT_PACK_ID:-MBTI.cn-mainland.zh-CN.v0.2.2}"
+export FAP_DEFAULT_DIR_VERSION="${FAP_DEFAULT_DIR_VERSION:-MBTI-CN-v0.2.2}"
+export FAP_ADMIN_TOKEN
+
+rm -f "${DB_PATH}"
+touch "${DB_PATH}"
+
+cd "${BACKEND_DIR}"
+composer install --no-interaction --no-progress
+php artisan migrate:fresh --force
+php artisan fap:scales:seed-default
+php artisan fap:scales:sync-slugs
+php artisan migrate:rollback --step=1 --force
+php artisan migrate --force
+cd "${REPO_DIR}"
+
+SERVE_PORT="${SERVE_PORT}" ART_DIR="${ART_DIR}" FAP_ADMIN_TOKEN="${FAP_ADMIN_TOKEN}" bash "${BACKEND_DIR}/scripts/pr55_verify.sh"
+
+ATTEMPT_ID="$(cat "${ART_DIR}/attempt_id.txt" 2>/dev/null || true)"
+ANON_ID="$(cat "${ART_DIR}/anon_id.txt" 2>/dev/null || true)"
+QUESTION_COUNT="$(cat "${ART_DIR}/question_count.txt" 2>/dev/null || true)"
+DEFAULT_PACK_ID="$(cat "${ART_DIR}/config_default_pack_id.txt" 2>/dev/null || true)"
+DEFAULT_DIR_VERSION="$(cat "${ART_DIR}/config_default_dir_version.txt" 2>/dev/null || true)"
+INDEX_AUDIT_TOTAL="$(cat "${ART_DIR}/index_audit_total.txt" 2>/dev/null || true)"
+ROLLBACK_COUNT="$(cat "${ART_DIR}/rollback_preview_count.txt" 2>/dev/null || true)"
+
+cat > "${ART_DIR}/summary.txt" <<TXT
+PR55 Acceptance Summary
+- pass_items:
+  - migration_observability_endpoint: OK
+  - migration_rollback_preview_endpoint: OK
+  - migration_rollback_reapply_deterministic: OK
+  - dynamic_answers_submit: OK
+  - pack_seed_config_consistency: OK
+  - phpunit(AdminMigrationObservabilityTest): PASS
+  - phpunit(SchemaIndexTest): PASS
+- key_outputs:
+  - attempt_id: ${ATTEMPT_ID}
+  - anon_id: ${ANON_ID}
+  - question_count(dynamic): ${QUESTION_COUNT}
+  - default_pack_id: ${DEFAULT_PACK_ID}
+  - default_dir_version: ${DEFAULT_DIR_VERSION}
+  - index_audit_total: ${INDEX_AUDIT_TOTAL}
+  - rollback_preview_items: ${ROLLBACK_COUNT}
+- smoke_urls:
+  - http://127.0.0.1:${SERVE_PORT}/api/v0.2/admin/migrations/observability?limit=5
+  - http://127.0.0.1:${SERVE_PORT}/api/v0.2/admin/migrations/rollback-preview?steps=2
+  - http://127.0.0.1:${SERVE_PORT}/api/v0.3/scales/MBTI/questions
+- schema_changes:
+  - create table migration_index_audits
+  - create index migration_index_audits_migration_idx
+  - create index migration_index_audits_action_phase_idx
+  - create index migration_index_audits_recorded_at_idx
+  - create index migration_index_audits_table_index_idx
+TXT
+
+bash "${BACKEND_DIR}/scripts/sanitize_artifacts.sh" 55
+
+bash -n "${BACKEND_DIR}/scripts/pr55_accept.sh"
+bash -n "${BACKEND_DIR}/scripts/pr55_verify.sh"

--- a/backend/scripts/pr55_verify.sh
+++ b/backend/scripts/pr55_verify.sh
@@ -1,0 +1,390 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+export CI=true
+export FAP_NONINTERACTIVE=1
+export COMPOSER_NO_INTERACTION=1
+export GIT_TERMINAL_PROMPT=0
+export NO_COLOR=1
+export PAGER=cat
+export GIT_PAGER=cat
+export TERM=dumb
+export XDEBUG_MODE=off
+export LANG=en_US.UTF-8
+
+REPO_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+BACKEND_DIR="${REPO_DIR}/backend"
+ART_DIR="${ART_DIR:-${BACKEND_DIR}/artifacts/pr55}"
+SERVE_PORT="${SERVE_PORT:-1855}"
+HOST="127.0.0.1"
+API_BASE="http://${HOST}:${SERVE_PORT}"
+SCALE_CODE="${SCALE_CODE:-MBTI}"
+ANON_ID="${ANON_ID:-pr55-verify-anon}"
+FAP_ADMIN_TOKEN="${FAP_ADMIN_TOKEN:-pr55-admin-token}"
+
+mkdir -p "${ART_DIR}"
+exec > "${ART_DIR}/verify.log" 2>&1
+
+fail() {
+  echo "[PR55][FAIL] $*" >&2
+  exit 1
+}
+
+cleanup_port() {
+  local port="$1"
+  lsof -nP -iTCP:"${port}" -sTCP:LISTEN || true
+  local pid_list
+  pid_list="$(lsof -ti tcp:"${port}" || true)"
+  if [[ -n "${pid_list}" ]]; then
+    echo "${pid_list}" | xargs kill -9 || true
+  fi
+  lsof -nP -iTCP:"${port}" -sTCP:LISTEN || true
+}
+
+wait_health() {
+  local url="$1"
+  local body_file="${ART_DIR}/healthz.body"
+  local http_code=""
+
+  for _ in $(seq 1 80); do
+    http_code="$(curl -sS -o "${body_file}" -w "%{http_code}" "${url}" || true)"
+    if [[ "${http_code}" == "200" ]]; then
+      return 0
+    fi
+    sleep 0.25
+  done
+
+  echo "health_check_failed http=${http_code}" >&2
+  cat "${body_file}" >&2 || true
+  tail -n 120 "${ART_DIR}/server.log" >&2 || true
+  return 1
+}
+
+cleanup() {
+  if [[ -n "${SERVE_PID:-}" ]] && ps -p "${SERVE_PID}" >/dev/null 2>&1; then
+    kill "${SERVE_PID}" >/dev/null 2>&1 || true
+  fi
+
+  if [[ -f "${ART_DIR}/server.pid" ]]; then
+    local pid
+    pid="$(cat "${ART_DIR}/server.pid" || true)"
+    if [[ -n "${pid}" ]] && ps -p "${pid}" >/dev/null 2>&1; then
+      kill "${pid}" >/dev/null 2>&1 || true
+    fi
+  fi
+
+  cleanup_port "${SERVE_PORT}"
+  cleanup_port 18000
+}
+trap cleanup EXIT
+
+cleanup_port "${SERVE_PORT}"
+cleanup_port 18000
+
+cd "${BACKEND_DIR}"
+php artisan serve --host="${HOST}" --port="${SERVE_PORT}" > "${ART_DIR}/server.log" 2>&1 &
+SERVE_PID="$!"
+echo "${SERVE_PID}" > "${ART_DIR}/server.pid"
+cd "${REPO_DIR}"
+
+wait_health "${API_BASE}/api/v0.2/healthz" || fail "healthz failed"
+curl -sS "${API_BASE}/api/v0.2/healthz" > "${ART_DIR}/healthz.json"
+
+cd "${BACKEND_DIR}"
+php -r '
+require "vendor/autoload.php";
+$app = require "bootstrap/app.php";
+$app->make(Illuminate\Contracts\Console\Kernel::class)->bootstrap();
+
+$configPackId = trim((string) config("content_packs.default_pack_id", ""));
+$configDirVersion = trim((string) config("content_packs.default_dir_version", ""));
+$configRegion = trim((string) config("content_packs.default_region", ""));
+$configLocale = trim((string) config("content_packs.default_locale", ""));
+
+echo "config_default_pack_id=".$configPackId.PHP_EOL;
+echo "config_default_dir_version=".$configDirVersion.PHP_EOL;
+echo "config_default_region=".$configRegion.PHP_EOL;
+echo "config_default_locale=".$configLocale.PHP_EOL;
+
+if ($configPackId === "" || $configDirVersion === "" || $configRegion === "" || $configLocale === "") {
+    fwrite(STDERR, "content_pack_defaults_missing\n");
+    exit(1);
+}
+
+if (!Illuminate\Support\Facades\Schema::hasTable("scales_registry")) {
+    fwrite(STDERR, "missing_scales_registry_table\n");
+    exit(1);
+}
+
+$row = Illuminate\Support\Facades\DB::table("scales_registry")
+    ->where("org_id", 0)
+    ->where("code", "MBTI")
+    ->first();
+if (!$row) {
+    fwrite(STDERR, "missing_scales_registry_mbti\n");
+    exit(1);
+}
+
+$registryPackId = trim((string) ($row->default_pack_id ?? ""));
+$registryDirVersion = trim((string) ($row->default_dir_version ?? ""));
+
+echo "registry_default_pack_id=".$registryPackId.PHP_EOL;
+echo "registry_default_dir_version=".$registryDirVersion.PHP_EOL;
+
+if ($registryPackId !== $configPackId) {
+    fwrite(STDERR, "default_pack_id_mismatch\n");
+    exit(1);
+}
+if ($registryDirVersion !== $configDirVersion) {
+    fwrite(STDERR, "default_dir_version_mismatch\n");
+    exit(1);
+}
+
+$index = app(App\Services\Content\ContentPacksIndex::class);
+$found = $index->find($configPackId, $configDirVersion);
+if (!($found["ok"] ?? false)) {
+    fwrite(STDERR, "pack_not_found\n");
+    exit(1);
+}
+
+$item = $found["item"] ?? [];
+$manifestPath = (string) ($item["manifest_path"] ?? "");
+$questionsPath = (string) ($item["questions_path"] ?? "");
+if ($manifestPath === "" || !is_file($manifestPath)) {
+    fwrite(STDERR, "manifest_missing\n");
+    exit(1);
+}
+if ($questionsPath === "" || !is_file($questionsPath)) {
+    fwrite(STDERR, "questions_missing\n");
+    exit(1);
+}
+
+$packDir = dirname($manifestPath);
+$versionPath = $packDir.DIRECTORY_SEPARATOR."version.json";
+if (!is_file($versionPath)) {
+    fwrite(STDERR, "version_missing\n");
+    exit(1);
+}
+
+$manifest = json_decode((string) file_get_contents($manifestPath), true);
+$version = json_decode((string) file_get_contents($versionPath), true);
+$questions = json_decode((string) file_get_contents($questionsPath), true);
+
+if (!is_array($manifest) || !is_array($version) || !is_array($questions)) {
+    fwrite(STDERR, "pack_json_invalid\n");
+    exit(1);
+}
+if (trim((string) ($manifest["pack_id"] ?? "")) !== $configPackId) {
+    fwrite(STDERR, "manifest_pack_id_mismatch\n");
+    exit(1);
+}
+if (trim((string) ($version["pack_id"] ?? "")) !== $configPackId) {
+    fwrite(STDERR, "version_pack_id_mismatch\n");
+    exit(1);
+}
+if (trim((string) ($version["dir_version"] ?? "")) !== $configDirVersion) {
+    fwrite(STDERR, "version_dir_version_mismatch\n");
+    exit(1);
+}
+
+echo "pack_dir=".$packDir.PHP_EOL;
+echo "pack_manifest=".$manifestPath.PHP_EOL;
+echo "pack_questions=".$questionsPath.PHP_EOL;
+echo "pack_version=".$versionPath.PHP_EOL;
+' > "${ART_DIR}/pack_seed_config.txt"
+cd "${REPO_DIR}"
+
+grep -E "^config_default_pack_id=" "${ART_DIR}/pack_seed_config.txt" | sed "s/^config_default_pack_id=//" > "${ART_DIR}/config_default_pack_id.txt"
+grep -E "^config_default_dir_version=" "${ART_DIR}/pack_seed_config.txt" | sed "s/^config_default_dir_version=//" > "${ART_DIR}/config_default_dir_version.txt"
+
+QUESTIONS_JSON="${ART_DIR}/questions.json"
+http_code="$(curl -sS -o "${QUESTIONS_JSON}" -w "%{http_code}" \
+  -H "Accept: application/json" \
+  "${API_BASE}/api/v0.3/scales/${SCALE_CODE}/questions" || true)"
+if [[ "${http_code}" != "200" ]]; then
+  echo "questions_failed http=${http_code}" >&2
+  cat "${QUESTIONS_JSON}" >&2 || true
+  tail -n 120 "${ART_DIR}/server.log" >&2 || true
+  fail "questions endpoint failed"
+fi
+
+ANSWERS_JSON="${ART_DIR}/answers.json"
+php -r '
+$raw = file_get_contents("php://stdin");
+$data = json_decode($raw, true);
+if (!is_array($data)) {
+    fwrite(STDERR, "questions_json_invalid\n");
+    exit(1);
+}
+$items = $data["questions"]["items"] ?? $data["questions"] ?? $data["items"] ?? $data["data"] ?? $data;
+if (!is_array($items)) {
+    fwrite(STDERR, "questions_items_invalid\n");
+    exit(1);
+}
+$answers = [];
+foreach ($items as $item) {
+    if (!is_array($item)) {
+        continue;
+    }
+    $questionId = (string) ($item["question_id"] ?? $item["id"] ?? "");
+    if ($questionId === "") {
+        continue;
+    }
+    $options = $item["options"] ?? [];
+    $code = "A";
+    if (is_array($options) && isset($options[0]) && is_array($options[0])) {
+        $code = (string) ($options[0]["code"] ?? $options[0]["option_code"] ?? "A");
+    }
+    if ($code === "") {
+        $code = "A";
+    }
+    $answers[] = [
+        "question_id" => $questionId,
+        "code" => $code,
+    ];
+}
+if (count($answers) === 0) {
+    fwrite(STDERR, "answers_empty\n");
+    exit(1);
+}
+echo json_encode($answers, JSON_UNESCAPED_UNICODE);
+' < "${QUESTIONS_JSON}" > "${ANSWERS_JSON}"
+
+QUESTION_COUNT="$(php -r '
+$data = json_decode(file_get_contents($argv[1]), true);
+if (!is_array($data)) {
+    echo "0";
+    exit(0);
+}
+echo (string) count($data);
+' "${ANSWERS_JSON}")"
+if [[ "${QUESTION_COUNT}" == "0" ]]; then
+  fail "dynamic answers generation produced zero answers"
+fi
+echo "${QUESTION_COUNT}" > "${ART_DIR}/question_count.txt"
+
+ATTEMPT_START_JSON="${ART_DIR}/attempt_start.json"
+ATTEMPT_START_BODY="$(SCALE_CODE="${SCALE_CODE}" ANON_ID="${ANON_ID}" php -r '
+$payload = [
+    "scale_code" => getenv("SCALE_CODE"),
+    "anon_id" => getenv("ANON_ID"),
+];
+echo json_encode($payload, JSON_UNESCAPED_UNICODE);
+')"
+http_code="$(curl -sS -o "${ATTEMPT_START_JSON}" -w "%{http_code}" \
+  -X POST -H "Content-Type: application/json" -H "Accept: application/json" \
+  --data "${ATTEMPT_START_BODY}" \
+  "${API_BASE}/api/v0.3/attempts/start" || true)"
+if [[ "${http_code}" != "200" ]]; then
+  echo "attempt_start_failed http=${http_code}" >&2
+  cat "${ATTEMPT_START_JSON}" >&2 || true
+  tail -n 120 "${ART_DIR}/server.log" >&2 || true
+  fail "attempt start failed"
+fi
+
+ATTEMPT_ID="$(php -r '$j=json_decode(file_get_contents($argv[1]), true); echo (string)($j["attempt_id"] ?? "");' "${ATTEMPT_START_JSON}")"
+if [[ -z "${ATTEMPT_ID}" ]]; then
+  fail "missing attempt_id"
+fi
+echo "${ATTEMPT_ID}" > "${ART_DIR}/attempt_id.txt"
+echo "${ANON_ID}" > "${ART_DIR}/anon_id.txt"
+
+SUBMIT_PAYLOAD="${ART_DIR}/submit_payload.json"
+ATTEMPT_ID="${ATTEMPT_ID}" ANSWERS_PATH="${ANSWERS_JSON}" php -r '
+$answers = json_decode(file_get_contents(getenv("ANSWERS_PATH")), true);
+if (!is_array($answers) || count($answers) === 0) {
+    fwrite(STDERR, "answers_payload_invalid\n");
+    exit(1);
+}
+$payload = [
+    "attempt_id" => getenv("ATTEMPT_ID"),
+    "answers" => $answers,
+    "duration_ms" => 120000,
+];
+echo json_encode($payload, JSON_UNESCAPED_UNICODE);
+' > "${SUBMIT_PAYLOAD}"
+
+ATTEMPT_SUBMIT_JSON="${ART_DIR}/attempt_submit.json"
+http_code="$(curl -sS -o "${ATTEMPT_SUBMIT_JSON}" -w "%{http_code}" \
+  -X POST -H "Content-Type: application/json" -H "Accept: application/json" \
+  --data @"${SUBMIT_PAYLOAD}" \
+  "${API_BASE}/api/v0.3/attempts/submit" || true)"
+if [[ "${http_code}" != "200" ]]; then
+  echo "attempt_submit_failed http=${http_code}" >&2
+  cat "${ATTEMPT_SUBMIT_JSON}" >&2 || true
+  tail -n 120 "${ART_DIR}/server.log" >&2 || true
+  fail "attempt submit failed"
+fi
+
+cd "${BACKEND_DIR}"
+php -r '
+require "vendor/autoload.php";
+$app = require "bootstrap/app.php";
+$app->make(Illuminate\Contracts\Console\Kernel::class)->bootstrap();
+
+App\Support\Database\SchemaIndex::logIndexAction(
+    "create_index",
+    "migration_index_audits",
+    "migration_index_audits_migration_idx",
+    null,
+    [
+        "phase" => "up",
+        "status" => "logged",
+        "reason" => "pr55_verify",
+    ]
+);
+
+$total = (int) Illuminate\Support\Facades\DB::table("migration_index_audits")->count();
+echo "audit_total=".$total.PHP_EOL;
+' > "${ART_DIR}/schema_index_log_seed.txt"
+cd "${REPO_DIR}"
+
+AUDIT_TOTAL="$(grep -E '^audit_total=' "${ART_DIR}/schema_index_log_seed.txt" | sed 's/^audit_total=//')"
+if [[ -z "${AUDIT_TOTAL}" || "${AUDIT_TOTAL}" == "0" ]]; then
+  fail "schema index audit seed failed"
+fi
+
+echo "${AUDIT_TOTAL}" > "${ART_DIR}/audit_total.txt"
+
+MIGRATION_OBS_JSON="${ART_DIR}/migration_observability.json"
+http_code="$(curl -sS -o "${MIGRATION_OBS_JSON}" -w "%{http_code}" \
+  -H "Accept: application/json" \
+  -H "X-FAP-Admin-Token: ${FAP_ADMIN_TOKEN}" \
+  "${API_BASE}/api/v0.2/admin/migrations/observability?limit=5" || true)"
+if [[ "${http_code}" != "200" ]]; then
+  echo "migration_observability_failed http=${http_code}" >&2
+  cat "${MIGRATION_OBS_JSON}" >&2 || true
+  tail -n 120 "${ART_DIR}/server.log" >&2 || true
+  fail "migration observability endpoint failed"
+fi
+
+INDEX_AUDIT_TOTAL="$(php -r '$j=json_decode(file_get_contents($argv[1]), true); echo (string)($j["data"]["index_audit"]["total"] ?? "0");' "${MIGRATION_OBS_JSON}")"
+if [[ "${INDEX_AUDIT_TOTAL}" == "0" ]]; then
+  fail "migration observability index_audit total is zero"
+fi
+echo "${INDEX_AUDIT_TOTAL}" > "${ART_DIR}/index_audit_total.txt"
+
+ROLLBACK_PREVIEW_JSON="${ART_DIR}/migration_rollback_preview.json"
+http_code="$(curl -sS -o "${ROLLBACK_PREVIEW_JSON}" -w "%{http_code}" \
+  -H "Accept: application/json" \
+  -H "X-FAP-Admin-Token: ${FAP_ADMIN_TOKEN}" \
+  "${API_BASE}/api/v0.2/admin/migrations/rollback-preview?steps=2" || true)"
+if [[ "${http_code}" != "200" ]]; then
+  echo "rollback_preview_failed http=${http_code}" >&2
+  cat "${ROLLBACK_PREVIEW_JSON}" >&2 || true
+  tail -n 120 "${ART_DIR}/server.log" >&2 || true
+  fail "rollback preview endpoint failed"
+fi
+
+ROLLBACK_COUNT="$(php -r '$j=json_decode(file_get_contents($argv[1]), true); $items=$j["data"]["items"] ?? []; echo (string)(is_array($items) ? count($items) : 0);' "${ROLLBACK_PREVIEW_JSON}")"
+if [[ "${ROLLBACK_COUNT}" == "0" ]]; then
+  fail "rollback preview returned no items"
+fi
+echo "${ROLLBACK_COUNT}" > "${ART_DIR}/rollback_preview_count.txt"
+
+cd "${BACKEND_DIR}"
+php artisan test --filter AdminMigrationObservabilityTest > "${ART_DIR}/phpunit_admin_migration_observability.txt" 2>&1
+php artisan test --filter SchemaIndexTest > "${ART_DIR}/phpunit_schema_index.txt" 2>&1
+cd "${REPO_DIR}"
+
+echo "verify_done" > "${ART_DIR}/verify_done.txt"

--- a/backend/tests/Feature/V0_2/AdminMigrationObservabilityTest.php
+++ b/backend/tests/Feature/V0_2/AdminMigrationObservabilityTest.php
@@ -1,0 +1,99 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\V0_2;
+
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\DB;
+use Tests\TestCase;
+
+final class AdminMigrationObservabilityTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private const ADMIN_TOKEN = 'pr55-admin-token';
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        config([
+            'admin.token' => self::ADMIN_TOKEN,
+        ]);
+    }
+
+    public function test_observability_returns_migrations_and_index_audit_summary(): void
+    {
+        DB::table('migration_index_audits')->insert([
+            'migration_name' => '2026_02_08_040000_create_migration_index_audits_table',
+            'table_name' => 'attempts',
+            'index_name' => 'attempts_org_id_idx',
+            'action' => 'create_index',
+            'phase' => 'up',
+            'driver' => 'sqlite',
+            'status' => 'logged',
+            'reason' => 'feature_test',
+            'meta_json' => null,
+            'recorded_at' => now(),
+            'created_at' => now(),
+            'updated_at' => now(),
+        ]);
+
+        $response = $this->withHeaders($this->adminHeaders())
+            ->getJson('/api/v0.2/admin/migrations/observability?limit=5');
+
+        $response
+            ->assertStatus(200)
+            ->assertJsonPath('ok', true)
+            ->assertJsonPath('data.index_audit.total', 1);
+
+        $recent = $response->json('data.migrations.recent');
+        $this->assertIsArray($recent);
+        $this->assertNotEmpty($recent);
+
+        $recentAudit = $response->json('data.index_audit.recent');
+        $this->assertIsArray($recentAudit);
+        $this->assertNotEmpty($recentAudit);
+        $this->assertSame('attempts', (string) ($recentAudit[0]['table_name'] ?? ''));
+        $this->assertSame('attempts_org_id_idx', (string) ($recentAudit[0]['index_name'] ?? ''));
+    }
+
+    public function test_rollback_preview_returns_latest_items_by_steps(): void
+    {
+        $response = $this->withHeaders($this->adminHeaders())
+            ->getJson('/api/v0.2/admin/migrations/rollback-preview?steps=2');
+
+        $response
+            ->assertStatus(200)
+            ->assertJsonPath('ok', true)
+            ->assertJsonPath('data.steps', 2);
+
+        $items = $response->json('data.items');
+        $this->assertIsArray($items);
+        $this->assertNotEmpty($items);
+        $this->assertLessThanOrEqual(2, count($items));
+        $this->assertNotSame('', (string) ($items[0]['migration'] ?? ''));
+    }
+
+    public function test_observability_requires_admin_token(): void
+    {
+        $response = $this->getJson('/api/v0.2/admin/migrations/observability');
+
+        $response
+            ->assertStatus(401)
+            ->assertJsonPath('ok', false)
+            ->assertJsonPath('error', 'UNAUTHORIZED');
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    private function adminHeaders(): array
+    {
+        return [
+            'X-FAP-Admin-Token' => self::ADMIN_TOKEN,
+            'Accept' => 'application/json',
+        ];
+    }
+}

--- a/backend/tests/Unit/Support/Database/SchemaIndexTest.php
+++ b/backend/tests/Unit/Support/Database/SchemaIndexTest.php
@@ -6,16 +6,38 @@ namespace Tests\Unit\Support\Database;
 
 use App\Support\Database\SchemaIndex;
 use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Schema;
 use Tests\TestCase;
 
 final class SchemaIndexTest extends TestCase
 {
     private string $tableName = 'schema_index_test_rows';
+    private bool $dropAuditTableAfterTest = false;
 
     protected function setUp(): void
     {
         parent::setUp();
+
+        if (!Schema::hasTable('migration_index_audits')) {
+            Schema::create('migration_index_audits', function (Blueprint $table): void {
+                $table->bigIncrements('id');
+                $table->string('migration_name', 191)->nullable();
+                $table->string('table_name', 128);
+                $table->string('index_name', 128);
+                $table->string('action', 64);
+                $table->string('phase', 32)->nullable();
+                $table->string('driver', 32);
+                $table->string('status', 32)->default('logged');
+                $table->string('reason', 191)->nullable();
+                $table->text('meta_json')->nullable();
+                $table->timestamp('recorded_at')->nullable();
+                $table->timestamps();
+            });
+            $this->dropAuditTableAfterTest = true;
+        }
+
+        DB::table('migration_index_audits')->delete();
 
         Schema::dropIfExists($this->tableName);
         Schema::create($this->tableName, function (Blueprint $table): void {
@@ -27,6 +49,9 @@ final class SchemaIndexTest extends TestCase
     protected function tearDown(): void
     {
         Schema::dropIfExists($this->tableName);
+        if ($this->dropAuditTableAfterTest) {
+            Schema::dropIfExists('migration_index_audits');
+        }
         parent::tearDown();
     }
 
@@ -83,5 +108,29 @@ final class SchemaIndexTest extends TestCase
         }
 
         $this->fail('Expected missing index exception was not thrown.');
+    }
+
+    public function test_log_index_action_persists_observability_record_when_audit_table_exists(): void
+    {
+        SchemaIndex::logIndexAction(
+            'create_index',
+            $this->tableName,
+            'idx_schema_index_name',
+            'sqlite',
+            [
+                'phase' => 'up',
+                'status' => 'logged',
+                'reason' => 'unit_test',
+            ]
+        );
+
+        $this->assertDatabaseHas('migration_index_audits', [
+            'table_name' => $this->tableName,
+            'index_name' => 'idx_schema_index_name',
+            'action' => 'create_index',
+            'phase' => 'up',
+            'status' => 'logged',
+            'reason' => 'unit_test',
+        ]);
     }
 }

--- a/docs/verify/pr55_verify.md
+++ b/docs/verify/pr55_verify.md
@@ -1,0 +1,38 @@
+# PR55 Verify
+
+- Date: 2026-02-07
+- Commands:
+  - `php artisan route:list`
+  - `php artisan migrate`
+  - `php artisan test --filter AdminMigrationObservabilityTest`
+  - `php artisan test --filter SchemaIndexTest`
+  - `bash backend/scripts/pr55_accept.sh`
+  - `bash backend/scripts/ci_verify_mbti.sh`
+- Result:
+  - `php artisan route:list` 通过（migration observability/rollback-preview 路由可见）
+  - `php artisan migrate` 通过（`migration_index_audits` 成功执行）
+  - `php artisan test --filter AdminMigrationObservabilityTest` 通过
+  - `php artisan test --filter SchemaIndexTest` 通过
+  - `bash backend/scripts/pr55_accept.sh` 通过
+  - `bash backend/scripts/ci_verify_mbti.sh` 通过
+- Artifacts:
+  - `backend/artifacts/pr55/summary.txt`
+  - `backend/artifacts/pr55/verify.log`
+  - `backend/artifacts/pr55/migration_observability.json`
+  - `backend/artifacts/pr55/migration_rollback_preview.json`
+  - `backend/artifacts/pr55/phpunit_admin_migration_observability.txt`
+  - `backend/artifacts/pr55/phpunit_schema_index.txt`
+  - `backend/artifacts/verify_mbti/summary.txt`
+
+Step Verification Commands
+
+1. Step 1 (routes): `cd backend && php artisan route:list | grep -E "migrations/observability|migrations/rollback-preview"`
+2. Step 2 (migrations): `cd backend && php artisan migrate --force && rm -f /tmp/pr55.sqlite && touch /tmp/pr55.sqlite && DB_CONNECTION=sqlite DB_DATABASE=/tmp/pr55.sqlite php artisan migrate:fresh --force && DB_CONNECTION=sqlite DB_DATABASE=/tmp/pr55.sqlite php artisan migrate:rollback --step=1 --force && DB_CONNECTION=sqlite DB_DATABASE=/tmp/pr55.sqlite php artisan migrate --force`
+3. Step 3 (middleware): `php -l backend/app/Http/Middleware/FmTokenAuth.php && grep -n "DB::table('fm_tokens')" backend/app/Http/Middleware/FmTokenAuth.php && grep -n "attributes->set('fm_user_id'" backend/app/Http/Middleware/FmTokenAuth.php`
+4. Step 4 (controller/service/tests): `php -l backend/app/Http/Controllers/API/V0_2/Admin/AdminMigrationController.php && php -l backend/app/Services/Database/MigrationObservabilityService.php && php -l backend/app/Support/Database/SchemaIndex.php && cd backend && php artisan test --filter AdminMigrationObservabilityTest && php artisan test --filter SchemaIndexTest`
+5. Step 5 (scripts/CI): `bash -n backend/scripts/pr55_verify.sh && bash -n backend/scripts/pr55_accept.sh && bash backend/scripts/pr55_accept.sh && bash backend/scripts/ci_verify_mbti.sh`
+
+Curl Smoke Examples
+
+- `curl -sS -H "X-FAP-Admin-Token: pr55-admin-token" "http://127.0.0.1:1855/api/v0.2/admin/migrations/observability?limit=5"`
+- `curl -sS -H "X-FAP-Admin-Token: pr55-admin-token" "http://127.0.0.1:1855/api/v0.2/admin/migrations/rollback-preview?steps=2"`


### PR DESCRIPTION
What:
Add deterministic migration observability surfaces (API + audit persistence + acceptance/CI loop).
Why:
Improve visibility into migration/index behaviors for rollback planning and incident triage.
Keep sqlite fresh/rollback/reapply deterministic while preserving existing CI MBTI chain stability.
How:
Add admin routes in [api.php](app://-/index.html#) for observability and rollback preview.
Add [2026_02_08_040000_create_migration_index_audits_table.php](app://-/index.html#).
Extend [SchemaIndex.php](app://-/index.html#) to persist index action audits.
Add [AdminMigrationController.php](app://-/index.html#) and [MigrationObservabilityService.php](app://-/index.html#).
Harden fm token identity injection in [FmTokenAuth.php](app://-/index.html#).
Add tests in [AdminMigrationObservabilityTest.php](app://-/index.html#) and [SchemaIndexTest.php](app://-/index.html#).
Add local acceptance scripts and CI workflow: [pr55_accept.sh](app://-/index.html#), [pr55_verify.sh](app://-/index.html#), [ci_pr55_migration_observability.yml](app://-/index.html#).
Verify:
[pr55_accept.sh](app://-/index.html#)
[ci_verify_mbti.sh](app://-/index.html#)
Artifacts:
[summary.txt](app://-/index.html#)