### PR TITLE
chore(pr56): Unify CI PHP 8.4 and composer security checks

### DIFF
--- a/.github/workflows/ci_pr56_workflow_composer_php84.yml
+++ b/.github/workflows/ci_pr56_workflow_composer_php84.yml
@@ -1,0 +1,85 @@
+name: ci-pr56-workflow-composer-php84
+
+on:
+  workflow_dispatch:
+  push:
+    paths:
+      - "backend/**"
+      - "docs/**"
+      - "content_packages/**"
+      - ".github/workflows/ci_pr56_workflow_composer_php84.yml"
+      - ".github/workflows/ci_verify_pr22_boot_v0_4.yml"
+      - ".github/workflows/ci_verify_pr23_feature_flags_sticky_experiments.yml"
+      - ".github/workflows/ci_verify_pr24_sitemap.yml"
+      - ".github/workflows/ci_verify_pr25_b2b_assessments_progress_rbac.yml"
+  pull_request:
+    paths:
+      - "backend/**"
+      - "docs/**"
+      - "content_packages/**"
+      - ".github/workflows/ci_pr56_workflow_composer_php84.yml"
+      - ".github/workflows/ci_verify_pr22_boot_v0_4.yml"
+      - ".github/workflows/ci_verify_pr23_feature_flags_sticky_experiments.yml"
+      - ".github/workflows/ci_verify_pr24_sitemap.yml"
+      - ".github/workflows/ci_verify_pr25_b2b_assessments_progress_rbac.yml"
+
+jobs:
+  verify:
+    runs-on: ubuntu-latest
+
+    env:
+      APP_ENV: testing
+      APP_KEY: base64:AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=
+      CI: true
+      FAP_NONINTERACTIVE: 1
+      COMPOSER_NO_INTERACTION: 1
+      GIT_TERMINAL_PROMPT: 0
+      NO_COLOR: 1
+      DB_CONNECTION: sqlite
+      DB_DATABASE: /tmp/pr56.sqlite
+      CACHE_DRIVER: array
+      SERVE_PORT: 1856
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: "8.4"
+          tools: composer:v2
+          extensions: mbstring, xml, curl, zip, intl, sqlite, pdo_sqlite
+
+      - name: Verify workflow PHP84 + composer security checks
+        run: |
+          set -euo pipefail
+          for wf in \
+            ".github/workflows/ci_verify_pr22_boot_v0_4.yml" \
+            ".github/workflows/ci_verify_pr23_feature_flags_sticky_experiments.yml" \
+            ".github/workflows/ci_verify_pr24_sitemap.yml" \
+            ".github/workflows/ci_verify_pr25_b2b_assessments_progress_rbac.yml" \
+            ".github/workflows/ci_pr56_workflow_composer_php84.yml"; do
+            grep -E 'php-version:[[:space:]]*"8.4"' "${wf}" >/dev/null
+            grep -E 'composer audit --locked --no-interaction' "${wf}" >/dev/null
+            if grep -E 'php-version:[[:space:]]*"8.5"' "${wf}" >/dev/null; then
+              echo "unexpected php-version 8.5 in ${wf}" >&2
+              exit 1
+            fi
+          done
+
+      - name: Composer security audit
+        run: |
+          cd backend
+          composer audit --locked --no-interaction
+
+      - name: Prepare sqlite
+        run: |
+          rm -f /tmp/pr56.sqlite
+          touch /tmp/pr56.sqlite
+
+      - name: PR56 accept
+        run: bash backend/scripts/pr56_accept.sh
+
+      - name: CI verify mbti
+        run: bash backend/scripts/ci_verify_mbti.sh

--- a/.github/workflows/ci_verify_pr22_boot_v0_4.yml
+++ b/.github/workflows/ci_verify_pr22_boot_v0_4.yml
@@ -38,8 +38,14 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: "8.5"
+          php-version: "8.4"
+          tools: composer:v2
           extensions: mbstring, xml, curl, zip, intl, sqlite, pdo_sqlite
+
+      - name: Composer security audit
+        run: |
+          cd backend
+          composer audit --locked --no-interaction
 
       - name: Prepare sqlite
         run: |

--- a/.github/workflows/ci_verify_pr23_feature_flags_sticky_experiments.yml
+++ b/.github/workflows/ci_verify_pr23_feature_flags_sticky_experiments.yml
@@ -38,8 +38,14 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: "8.5"
+          php-version: "8.4"
+          tools: composer:v2
           extensions: mbstring, xml, curl, zip, intl, sqlite, pdo_sqlite
+
+      - name: Composer security audit
+        run: |
+          cd backend
+          composer audit --locked --no-interaction
 
       - name: Prepare sqlite
         run: |

--- a/.github/workflows/ci_verify_pr24_sitemap.yml
+++ b/.github/workflows/ci_verify_pr24_sitemap.yml
@@ -41,8 +41,14 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: "8.5"
+          php-version: "8.4"
+          tools: composer:v2
           extensions: mbstring, xml, curl, zip, intl, sqlite, pdo_sqlite
+
+      - name: Composer security audit
+        run: |
+          cd backend
+          composer audit --locked --no-interaction
 
       - name: Prepare sqlite
         run: |

--- a/.github/workflows/ci_verify_pr25_b2b_assessments_progress_rbac.yml
+++ b/.github/workflows/ci_verify_pr25_b2b_assessments_progress_rbac.yml
@@ -39,8 +39,14 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: "8.5"
+          php-version: "8.4"
+          tools: composer:v2
           extensions: mbstring, xml, curl, zip, intl, sqlite, pdo_sqlite
+
+      - name: Composer security audit
+        run: |
+          cd backend
+          composer audit --locked --no-interaction
 
       - name: Prepare sqlite
         run: |

--- a/backend/composer.lock
+++ b/backend/composer.lock
@@ -4633,16 +4633,16 @@
         },
         {
             "name": "psy/psysh",
-            "version": "v0.12.16",
+            "version": "v0.12.19",
             "source": {
                 "type": "git",
                 "url": "https://github.com/bobthecow/psysh.git",
-                "reference": "ee6d5028be4774f56c6c2c85ec4e6bc9acfe6b67"
+                "reference": "a4f766e5c5b6773d8399711019bb7d90875a50ee"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/bobthecow/psysh/zipball/ee6d5028be4774f56c6c2c85ec4e6bc9acfe6b67",
-                "reference": "ee6d5028be4774f56c6c2c85ec4e6bc9acfe6b67",
+                "url": "https://api.github.com/repos/bobthecow/psysh/zipball/a4f766e5c5b6773d8399711019bb7d90875a50ee",
+                "reference": "a4f766e5c5b6773d8399711019bb7d90875a50ee",
                 "shasum": ""
             },
             "require": {
@@ -4706,9 +4706,9 @@
             ],
             "support": {
                 "issues": "https://github.com/bobthecow/psysh/issues",
-                "source": "https://github.com/bobthecow/psysh/tree/v0.12.16"
+                "source": "https://github.com/bobthecow/psysh/tree/v0.12.19"
             },
-            "time": "2025-12-07T03:39:01+00:00"
+            "time": "2026-01-30T17:33:13+00:00"
         },
         {
             "name": "ralouphie/getallheaders",
@@ -7136,16 +7136,16 @@
         },
         {
             "name": "symfony/process",
-            "version": "v7.4.4",
+            "version": "v7.4.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/process.git",
-                "reference": "626f07a53f4b4e2f00e11824cc29f928d797783b"
+                "reference": "608476f4604102976d687c483ac63a79ba18cc97"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/process/zipball/626f07a53f4b4e2f00e11824cc29f928d797783b",
-                "reference": "626f07a53f4b4e2f00e11824cc29f928d797783b",
+                "url": "https://api.github.com/repos/symfony/process/zipball/608476f4604102976d687c483ac63a79ba18cc97",
+                "reference": "608476f4604102976d687c483ac63a79ba18cc97",
                 "shasum": ""
             },
             "require": {
@@ -7177,7 +7177,7 @@
             "description": "Executes commands in sub-processes",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/process/tree/v7.4.4"
+                "source": "https://github.com/symfony/process/tree/v7.4.5"
             },
             "funding": [
                 {
@@ -7197,7 +7197,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-01-20T09:23:51+00:00"
+            "time": "2026-01-26T15:07:59+00:00"
         },
         {
             "name": "symfony/routing",

--- a/backend/scripts/pr56_accept.sh
+++ b/backend/scripts/pr56_accept.sh
@@ -1,0 +1,108 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+export CI=true
+export FAP_NONINTERACTIVE=1
+export COMPOSER_NO_INTERACTION=1
+export GIT_TERMINAL_PROMPT=0
+export NO_COLOR=1
+export PAGER=cat
+export GIT_PAGER=cat
+export TERM=dumb
+export XDEBUG_MODE=off
+export LANG=en_US.UTF-8
+
+REPO_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+BACKEND_DIR="${REPO_DIR}/backend"
+ART_DIR="${BACKEND_DIR}/artifacts/pr56"
+SERVE_PORT="${SERVE_PORT:-1856}"
+DB_PATH="/tmp/pr56.sqlite"
+
+mkdir -p "${ART_DIR}"
+
+cleanup_port() {
+  local port="$1"
+  lsof -nP -iTCP:"${port}" -sTCP:LISTEN || true
+  local pid_list
+  pid_list="$(lsof -ti tcp:"${port}" || true)"
+  if [[ -n "${pid_list}" ]]; then
+    echo "${pid_list}" | xargs kill -9 || true
+  fi
+  lsof -nP -iTCP:"${port}" -sTCP:LISTEN || true
+}
+
+cleanup() {
+  if [[ -f "${ART_DIR}/server.pid" ]]; then
+    local pid
+    pid="$(cat "${ART_DIR}/server.pid" || true)"
+    if [[ -n "${pid}" ]] && ps -p "${pid}" >/dev/null 2>&1; then
+      kill "${pid}" >/dev/null 2>&1 || true
+    fi
+  fi
+
+  cleanup_port "${SERVE_PORT}"
+  cleanup_port 18000
+  rm -f "${DB_PATH}"
+}
+trap cleanup EXIT
+
+cleanup_port "${SERVE_PORT}"
+cleanup_port 18000
+
+export APP_ENV=testing
+export CACHE_STORE=array
+export QUEUE_CONNECTION=database
+export DB_CONNECTION=sqlite
+export DB_DATABASE="${DB_PATH}"
+export FAP_PACKS_ROOT="${FAP_PACKS_ROOT:-${REPO_DIR}/content_packages}"
+export FAP_DEFAULT_REGION="${FAP_DEFAULT_REGION:-CN_MAINLAND}"
+export FAP_DEFAULT_LOCALE="${FAP_DEFAULT_LOCALE:-zh-CN}"
+export FAP_DEFAULT_PACK_ID="${FAP_DEFAULT_PACK_ID:-MBTI.cn-mainland.zh-CN.v0.2.2}"
+export FAP_DEFAULT_DIR_VERSION="${FAP_DEFAULT_DIR_VERSION:-MBTI-CN-v0.2.2}"
+
+rm -f "${DB_PATH}"
+touch "${DB_PATH}"
+
+cd "${BACKEND_DIR}"
+composer install --no-interaction --no-progress
+composer audit --locked --no-interaction > "${ART_DIR}/composer_audit.txt"
+php artisan migrate:fresh --force
+php artisan fap:scales:seed-default
+php artisan fap:scales:sync-slugs
+cd "${REPO_DIR}"
+
+SERVE_PORT="${SERVE_PORT}" ART_DIR="${ART_DIR}" bash "${BACKEND_DIR}/scripts/pr56_verify.sh"
+
+[[ -f "${ART_DIR}/verify_done.txt" ]] || { echo "verify script did not finish" >&2; exit 1; }
+
+ATTEMPT_ID="$(cat "${ART_DIR}/attempt_id.txt" 2>/dev/null || true)"
+ANON_ID="$(cat "${ART_DIR}/anon_id.txt" 2>/dev/null || true)"
+QUESTION_COUNT="$(cat "${ART_DIR}/question_count.txt" 2>/dev/null || true)"
+DEFAULT_PACK_ID="$(cat "${ART_DIR}/config_default_pack_id.txt" 2>/dev/null || true)"
+DEFAULT_DIR_VERSION="$(cat "${ART_DIR}/config_default_dir_version.txt" 2>/dev/null || true)"
+
+cat > "${ART_DIR}/summary.txt" <<TXT
+PR56 Acceptance Summary
+- pass_items:
+  - workflows_php84_unified: OK
+  - composer_security_audit: OK
+  - dynamic_answers_submit: OK
+  - pack_seed_config_consistency: OK
+- key_outputs:
+  - attempt_id: ${ATTEMPT_ID}
+  - anon_id: ${ANON_ID}
+  - question_count(dynamic): ${QUESTION_COUNT}
+  - default_pack_id: ${DEFAULT_PACK_ID}
+  - default_dir_version: ${DEFAULT_DIR_VERSION}
+- smoke_urls:
+  - http://127.0.0.1:${SERVE_PORT}/api/v0.2/healthz
+  - http://127.0.0.1:${SERVE_PORT}/api/v0.3/scales/MBTI/questions
+  - http://127.0.0.1:${SERVE_PORT}/api/v0.3/attempts/submit
+- schema_changes:
+  - none
+TXT
+
+bash "${BACKEND_DIR}/scripts/sanitize_artifacts.sh" 56
+
+bash -n "${BACKEND_DIR}/scripts/pr56_accept.sh"
+bash -n "${BACKEND_DIR}/scripts/pr56_verify.sh"

--- a/backend/scripts/pr56_verify.sh
+++ b/backend/scripts/pr56_verify.sh
@@ -1,0 +1,340 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+export CI=true
+export FAP_NONINTERACTIVE=1
+export COMPOSER_NO_INTERACTION=1
+export GIT_TERMINAL_PROMPT=0
+export NO_COLOR=1
+export PAGER=cat
+export GIT_PAGER=cat
+export TERM=dumb
+export XDEBUG_MODE=off
+export LANG=en_US.UTF-8
+
+REPO_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+BACKEND_DIR="${REPO_DIR}/backend"
+ART_DIR="${ART_DIR:-${BACKEND_DIR}/artifacts/pr56}"
+SERVE_PORT="${SERVE_PORT:-1856}"
+HOST="127.0.0.1"
+API_BASE="http://${HOST}:${SERVE_PORT}"
+SCALE_CODE="${SCALE_CODE:-MBTI}"
+ANON_ID="${ANON_ID:-pr56-verify-anon}"
+
+mkdir -p "${ART_DIR}"
+exec > "${ART_DIR}/verify.log" 2>&1
+
+fail() {
+  echo "[PR56][FAIL] $*" >&2
+  exit 1
+}
+
+cleanup_port() {
+  local port="$1"
+  lsof -nP -iTCP:"${port}" -sTCP:LISTEN || true
+  local pid_list
+  pid_list="$(lsof -ti tcp:"${port}" || true)"
+  if [[ -n "${pid_list}" ]]; then
+    echo "${pid_list}" | xargs kill -9 || true
+  fi
+  lsof -nP -iTCP:"${port}" -sTCP:LISTEN || true
+}
+
+wait_health() {
+  local url="$1"
+  local body_file="${ART_DIR}/healthz.body"
+  local http_code=""
+
+  for _ in $(seq 1 80); do
+    http_code="$(curl -sS -o "${body_file}" -w "%{http_code}" "${url}" || true)"
+    if [[ "${http_code}" == "200" ]]; then
+      return 0
+    fi
+    sleep 0.25
+  done
+
+  echo "health_check_failed http=${http_code}" >&2
+  cat "${body_file}" >&2 || true
+  tail -n 120 "${ART_DIR}/server.log" >&2 || true
+  return 1
+}
+
+cleanup() {
+  if [[ -n "${SERVE_PID:-}" ]] && ps -p "${SERVE_PID}" >/dev/null 2>&1; then
+    kill "${SERVE_PID}" >/dev/null 2>&1 || true
+  fi
+
+  if [[ -f "${ART_DIR}/server.pid" ]]; then
+    local pid
+    pid="$(cat "${ART_DIR}/server.pid" || true)"
+    if [[ -n "${pid}" ]] && ps -p "${pid}" >/dev/null 2>&1; then
+      kill "${pid}" >/dev/null 2>&1 || true
+    fi
+  fi
+
+  cleanup_port "${SERVE_PORT}"
+  cleanup_port 18000
+}
+trap cleanup EXIT
+
+cleanup_port "${SERVE_PORT}"
+cleanup_port 18000
+
+cd "${BACKEND_DIR}"
+php artisan serve --host="${HOST}" --port="${SERVE_PORT}" > "${ART_DIR}/server.log" 2>&1 &
+SERVE_PID="$!"
+echo "${SERVE_PID}" > "${ART_DIR}/server.pid"
+cd "${REPO_DIR}"
+
+wait_health "${API_BASE}/api/v0.2/healthz" || fail "healthz failed"
+curl -sS "${API_BASE}/api/v0.2/healthz" > "${ART_DIR}/healthz.json"
+
+cd "${BACKEND_DIR}"
+php -r '
+require "vendor/autoload.php";
+$app = require "bootstrap/app.php";
+$app->make(Illuminate\Contracts\Console\Kernel::class)->bootstrap();
+
+$configPackId = trim((string) config("content_packs.default_pack_id", ""));
+$configDirVersion = trim((string) config("content_packs.default_dir_version", ""));
+$configRegion = trim((string) config("content_packs.default_region", ""));
+$configLocale = trim((string) config("content_packs.default_locale", ""));
+
+echo "config_default_pack_id=".$configPackId.PHP_EOL;
+echo "config_default_dir_version=".$configDirVersion.PHP_EOL;
+echo "config_default_region=".$configRegion.PHP_EOL;
+echo "config_default_locale=".$configLocale.PHP_EOL;
+
+if ($configPackId === "" || $configDirVersion === "" || $configRegion === "" || $configLocale === "") {
+    fwrite(STDERR, "content_pack_defaults_missing\n");
+    exit(1);
+}
+
+if (!Illuminate\Support\Facades\Schema::hasTable("scales_registry")) {
+    fwrite(STDERR, "missing_scales_registry_table\n");
+    exit(1);
+}
+
+$row = Illuminate\Support\Facades\DB::table("scales_registry")
+    ->where("org_id", 0)
+    ->where("code", "MBTI")
+    ->first();
+if (!$row) {
+    fwrite(STDERR, "missing_scales_registry_mbti\n");
+    exit(1);
+}
+
+$registryPackId = trim((string) ($row->default_pack_id ?? ""));
+$registryDirVersion = trim((string) ($row->default_dir_version ?? ""));
+
+echo "registry_default_pack_id=".$registryPackId.PHP_EOL;
+echo "registry_default_dir_version=".$registryDirVersion.PHP_EOL;
+
+if ($registryPackId !== $configPackId) {
+    fwrite(STDERR, "default_pack_id_mismatch\n");
+    exit(1);
+}
+if ($registryDirVersion !== $configDirVersion) {
+    fwrite(STDERR, "default_dir_version_mismatch\n");
+    exit(1);
+}
+
+$index = app(App\Services\Content\ContentPacksIndex::class);
+$found = $index->find($configPackId, $configDirVersion);
+if (!($found["ok"] ?? false)) {
+    fwrite(STDERR, "pack_not_found\n");
+    exit(1);
+}
+
+$item = $found["item"] ?? [];
+$manifestPath = (string) ($item["manifest_path"] ?? "");
+$questionsPath = (string) ($item["questions_path"] ?? "");
+if ($manifestPath === "" || !is_file($manifestPath)) {
+    fwrite(STDERR, "manifest_missing\n");
+    exit(1);
+}
+if ($questionsPath === "" || !is_file($questionsPath)) {
+    fwrite(STDERR, "questions_missing\n");
+    exit(1);
+}
+
+$packDir = dirname($manifestPath);
+$versionPath = $packDir.DIRECTORY_SEPARATOR."version.json";
+if (!is_file($versionPath)) {
+    fwrite(STDERR, "version_missing\n");
+    exit(1);
+}
+
+$manifest = json_decode((string) file_get_contents($manifestPath), true);
+$version = json_decode((string) file_get_contents($versionPath), true);
+$questions = json_decode((string) file_get_contents($questionsPath), true);
+
+if (!is_array($manifest) || !is_array($version) || !is_array($questions)) {
+    fwrite(STDERR, "pack_json_invalid\n");
+    exit(1);
+}
+if (trim((string) ($manifest["pack_id"] ?? "")) !== $configPackId) {
+    fwrite(STDERR, "manifest_pack_id_mismatch\n");
+    exit(1);
+}
+if (trim((string) ($version["pack_id"] ?? "")) !== $configPackId) {
+    fwrite(STDERR, "version_pack_id_mismatch\n");
+    exit(1);
+}
+if (trim((string) ($version["dir_version"] ?? "")) !== $configDirVersion) {
+    fwrite(STDERR, "version_dir_version_mismatch\n");
+    exit(1);
+}
+
+echo "pack_dir=".$packDir.PHP_EOL;
+echo "pack_manifest=".$manifestPath.PHP_EOL;
+echo "pack_questions=".$questionsPath.PHP_EOL;
+echo "pack_version=".$versionPath.PHP_EOL;
+' > "${ART_DIR}/pack_seed_config.txt"
+cd "${REPO_DIR}"
+
+grep -E "^config_default_pack_id=" "${ART_DIR}/pack_seed_config.txt" | sed "s/^config_default_pack_id=//" > "${ART_DIR}/config_default_pack_id.txt"
+grep -E "^config_default_dir_version=" "${ART_DIR}/pack_seed_config.txt" | sed "s/^config_default_dir_version=//" > "${ART_DIR}/config_default_dir_version.txt"
+
+QUESTIONS_JSON="${ART_DIR}/questions.json"
+http_code="$(curl -sS -o "${QUESTIONS_JSON}" -w "%{http_code}" \
+  -H "Accept: application/json" \
+  "${API_BASE}/api/v0.3/scales/${SCALE_CODE}/questions" || true)"
+if [[ "${http_code}" != "200" ]]; then
+  echo "questions_failed http=${http_code}" >&2
+  cat "${QUESTIONS_JSON}" >&2 || true
+  tail -n 120 "${ART_DIR}/server.log" >&2 || true
+  fail "questions endpoint failed"
+fi
+
+ANSWERS_JSON="${ART_DIR}/answers.json"
+php -r '
+$raw = file_get_contents("php://stdin");
+$data = json_decode($raw, true);
+if (!is_array($data)) {
+    fwrite(STDERR, "questions_json_invalid\n");
+    exit(1);
+}
+$items = $data["questions"]["items"] ?? $data["questions"] ?? $data["items"] ?? $data["data"] ?? $data;
+if (!is_array($items)) {
+    fwrite(STDERR, "questions_items_invalid\n");
+    exit(1);
+}
+$answers = [];
+foreach ($items as $item) {
+    if (!is_array($item)) {
+        continue;
+    }
+    $questionId = (string) ($item["question_id"] ?? $item["id"] ?? "");
+    if ($questionId === "") {
+        continue;
+    }
+    $options = $item["options"] ?? [];
+    $code = "A";
+    if (is_array($options) && isset($options[0]) && is_array($options[0])) {
+        $code = (string) ($options[0]["code"] ?? $options[0]["option_code"] ?? "A");
+    }
+    if ($code === "") {
+        $code = "A";
+    }
+    $answers[] = [
+        "question_id" => $questionId,
+        "code" => $code,
+    ];
+}
+if (count($answers) === 0) {
+    fwrite(STDERR, "answers_empty\n");
+    exit(1);
+}
+echo json_encode($answers, JSON_UNESCAPED_UNICODE);
+' < "${QUESTIONS_JSON}" > "${ANSWERS_JSON}"
+
+QUESTION_COUNT="$(php -r '
+$data = json_decode(file_get_contents($argv[1]), true);
+if (!is_array($data)) {
+    echo "0";
+    exit(0);
+}
+echo (string) count($data);
+' "${ANSWERS_JSON}")"
+if [[ "${QUESTION_COUNT}" == "0" ]]; then
+  fail "dynamic answers generation produced zero answers"
+fi
+echo "${QUESTION_COUNT}" > "${ART_DIR}/question_count.txt"
+
+ATTEMPT_START_JSON="${ART_DIR}/attempt_start.json"
+ATTEMPT_START_BODY="$(SCALE_CODE="${SCALE_CODE}" ANON_ID="${ANON_ID}" php -r '
+$payload = [
+    "scale_code" => getenv("SCALE_CODE"),
+    "anon_id" => getenv("ANON_ID"),
+];
+echo json_encode($payload, JSON_UNESCAPED_UNICODE);
+')"
+http_code="$(curl -sS -o "${ATTEMPT_START_JSON}" -w "%{http_code}" \
+  -X POST -H "Content-Type: application/json" -H "Accept: application/json" \
+  --data "${ATTEMPT_START_BODY}" \
+  "${API_BASE}/api/v0.3/attempts/start" || true)"
+if [[ "${http_code}" != "200" ]]; then
+  echo "attempt_start_failed http=${http_code}" >&2
+  cat "${ATTEMPT_START_JSON}" >&2 || true
+  tail -n 120 "${ART_DIR}/server.log" >&2 || true
+  fail "attempt start failed"
+fi
+
+ATTEMPT_ID="$(php -r '$j=json_decode(file_get_contents($argv[1]), true); echo (string)($j["attempt_id"] ?? "");' "${ATTEMPT_START_JSON}")"
+if [[ -z "${ATTEMPT_ID}" ]]; then
+  fail "missing attempt_id"
+fi
+echo "${ATTEMPT_ID}" > "${ART_DIR}/attempt_id.txt"
+echo "${ANON_ID}" > "${ART_DIR}/anon_id.txt"
+
+SUBMIT_PAYLOAD="${ART_DIR}/submit_payload.json"
+ATTEMPT_ID="${ATTEMPT_ID}" ANSWERS_PATH="${ANSWERS_JSON}" php -r '
+$answers = json_decode(file_get_contents(getenv("ANSWERS_PATH")), true);
+if (!is_array($answers) || count($answers) === 0) {
+    fwrite(STDERR, "answers_payload_invalid\n");
+    exit(1);
+}
+$payload = [
+    "attempt_id" => getenv("ATTEMPT_ID"),
+    "answers" => $answers,
+    "duration_ms" => 120000,
+];
+echo json_encode($payload, JSON_UNESCAPED_UNICODE);
+' > "${SUBMIT_PAYLOAD}"
+
+ATTEMPT_SUBMIT_JSON="${ART_DIR}/attempt_submit.json"
+http_code="$(curl -sS -o "${ATTEMPT_SUBMIT_JSON}" -w "%{http_code}" \
+  -X POST -H "Content-Type: application/json" -H "Accept: application/json" \
+  --data @"${SUBMIT_PAYLOAD}" \
+  "${API_BASE}/api/v0.3/attempts/submit" || true)"
+if [[ "${http_code}" != "200" ]]; then
+  echo "attempt_submit_failed http=${http_code}" >&2
+  cat "${ATTEMPT_SUBMIT_JSON}" >&2 || true
+  tail -n 120 "${ART_DIR}/server.log" >&2 || true
+  fail "attempt submit failed"
+fi
+
+WORKFLOW_ASSERTIONS="${ART_DIR}/workflow_php84_composer_checks.txt"
+: > "${WORKFLOW_ASSERTIONS}"
+
+for wf in \
+  ".github/workflows/ci_verify_pr22_boot_v0_4.yml" \
+  ".github/workflows/ci_verify_pr23_feature_flags_sticky_experiments.yml" \
+  ".github/workflows/ci_verify_pr24_sitemap.yml" \
+  ".github/workflows/ci_verify_pr25_b2b_assessments_progress_rbac.yml" \
+  ".github/workflows/ci_pr56_workflow_composer_php84.yml"
+do
+  file_path="${REPO_DIR}/${wf}"
+  [[ -f "${file_path}" ]] || fail "missing workflow file: ${wf}"
+
+  grep -E 'php-version:[[:space:]]*"8.4"' "${file_path}" >/dev/null || fail "${wf} missing php-version 8.4"
+  grep -E 'composer audit --locked --no-interaction' "${file_path}" >/dev/null || fail "${wf} missing composer audit"
+  if grep -E 'php-version:[[:space:]]*"8.5"' "${file_path}" >/dev/null; then
+    fail "${wf} still contains php-version 8.5"
+  fi
+
+  echo "${wf}: php84_and_composer_audit=ok" >> "${WORKFLOW_ASSERTIONS}"
+done
+
+echo "verify_done" > "${ART_DIR}/verify_done.txt"

--- a/docs/verify/pr56_verify.md
+++ b/docs/verify/pr56_verify.md
@@ -1,0 +1,28 @@
+# PR56 Verify
+
+## 环境
+- Repo: `<REPO_PATH>`
+- Branch: `chore/pr56-unify-ci-php-84-and-composer-sec`
+- SERVE_PORT: `1856`
+
+## 执行命令
+- `bash backend/scripts/pr56_accept.sh`
+- `bash backend/scripts/ci_verify_mbti.sh`
+
+## 阻塞错误与修复
+- 【错误原因】`composer audit --locked` 报告安全公告并返回非零（`psy/psysh`、`symfony/process`）
+- 【最小修复动作】仅升级受影响依赖至安全版本，保留 audit 强校验
+- 【对应命令】`cd backend && composer update psy/psysh symfony/process --with-all-dependencies --no-interaction --no-progress`
+
+## 结果
+- `pr56_accept.sh`：PASS
+- `ci_verify_mbti.sh`：PASS
+- workflow 断言：PASS（见 `backend/artifacts/pr56/workflow_php84_composer_checks.txt`）
+- artifacts 汇总：`backend/artifacts/pr56/summary.txt`
+
+## 关键输出
+- attempt_id: `36cf9f50-effb-4929-81c1-16ecf32a0f49`
+- anon_id: `pr56-verify-anon`
+- question_count(dynamic): `144`
+- default_pack_id: `MBTI.cn-mainland.zh-CN.v0.2.2`
+- default_dir_version: `MBTI-CN-v0.2.2`


### PR DESCRIPTION
统一 4 个 CI workflow 到 PHP 8.4，补齐 composer 安全审计，并新增 PR56 验收 workflow/脚本。
Why:
消除 8.5/8.4 混跑导致的 CI 环境漂移。
将 composer 安全检查前置为 workflow 必经环节。
How:
修改 4 个 workflow 的 php-version 和 composer audit。
新增 [ci_pr56_workflow_composer_php84.yml](app://-/index.html#)。
新增 [pr56_accept.sh](app://-/index.html#)、[pr56_verify.sh](app://-/index.html#)。
在 [composer.lock](app://-/index.html#) 升级 psy/psysh 与 symfony/process，解决 audit 阻塞。
新增 [pr56_recon.md](app://-/index.html#)、[pr56_verify.md](app://-/index.html#)。
Verify:
[pr56_accept.sh](app://-/index.html#)
[ci_verify_mbti.sh](app://-/index.html#)
Artifacts:
[summary.txt](app://-/index.html#)