### PR TITLE
Chore/pr59 fix ci php drift and enforce com

### DIFF
--- a/.github/workflows/ci_dlq_replay_metrics.yml
+++ b/.github/workflows/ci_dlq_replay_metrics.yml
@@ -53,6 +53,12 @@ jobs:
         run: |
           composer install --no-interaction --prefer-dist --no-progress
 
+      - name: Composer validate & audit
+        working-directory: backend
+        run: |
+          composer validate --strict
+          composer audit --no-interaction
+
       - name: Prepare sqlite and seed defaults
         working-directory: backend
         env:

--- a/.github/workflows/ci_pr55_migration_observability.yml
+++ b/.github/workflows/ci_pr55_migration_observability.yml
@@ -52,6 +52,12 @@ jobs:
         run: |
           composer install --no-interaction --prefer-dist --no-progress
 
+      - name: Composer validate & audit
+        working-directory: backend
+        run: |
+          composer validate --strict
+          composer audit --no-interaction
+
       - name: Prepare sqlite and seed defaults
         working-directory: backend
         env:

--- a/.github/workflows/ci_pr56_workflow_composer_php84.yml
+++ b/.github/workflows/ci_pr56_workflow_composer_php84.yml
@@ -54,24 +54,20 @@ jobs:
       - name: Verify workflow PHP84 + composer security checks
         run: |
           set -euo pipefail
-          for wf in \
-            ".github/workflows/ci_verify_pr22_boot_v0_4.yml" \
-            ".github/workflows/ci_verify_pr23_feature_flags_sticky_experiments.yml" \
-            ".github/workflows/ci_verify_pr24_sitemap.yml" \
-            ".github/workflows/ci_verify_pr25_b2b_assessments_progress_rbac.yml" \
-            ".github/workflows/ci_pr56_workflow_composer_php84.yml"; do
+          for wf in $(find .github/workflows -type f \( -name "*.yml" -o -name "*.yaml" \)); do
             grep -E 'php-version:[[:space:]]*"8.4"' "${wf}" >/dev/null
-            grep -E 'composer audit --locked --no-interaction' "${wf}" >/dev/null
-            if grep -E 'php-version:[[:space:]]*"8.5"' "${wf}" >/dev/null; then
-              echo "unexpected php-version 8.5 in ${wf}" >&2
-              exit 1
-            fi
           done
 
-      - name: Composer security audit
+          for wf in $(grep -R -l -E 'composer[[:space:]]+install' .github/workflows); do
+            grep -E 'composer[[:space:]]+validate[[:space:]]+--strict' "${wf}" >/dev/null
+            grep -E 'composer[[:space:]]+audit[[:space:]]+--no-interaction' "${wf}" >/dev/null
+          done
+
+      - name: Composer validate & audit
+        working-directory: backend
         run: |
-          cd backend
-          composer audit --locked --no-interaction
+          composer validate --strict
+          composer audit --no-interaction
 
       - name: Prepare sqlite
         run: |

--- a/.github/workflows/ci_pr56_workflow_composer_php84.yml
+++ b/.github/workflows/ci_pr56_workflow_composer_php84.yml
@@ -54,7 +54,7 @@ jobs:
       - name: Verify workflow PHP84 + composer security checks
         run: |
           set -euo pipefail
-          for wf in $(find .github/workflows -type f \( -name "*.yml" -o -name "*.yaml" \)); do
+          for wf in $(grep -R -l -E 'shivammathur/setup-php@v2' .github/workflows); do
             grep -E 'php-version:[[:space:]]*"8.4"' "${wf}" >/dev/null
           done
 

--- a/.github/workflows/ci_verify_commerce_v2.yml
+++ b/.github/workflows/ci_verify_commerce_v2.yml
@@ -83,6 +83,12 @@ jobs:
         working-directory: backend
         run: composer install --no-interaction --prefer-dist
 
+      - name: Composer validate & audit
+        working-directory: backend
+        run: |
+          composer validate --strict
+          composer audit --no-interaction
+
       - name: Migrate
         working-directory: backend
         run: php artisan migrate --force -vvv

--- a/.github/workflows/ci_verify_mbti.yml
+++ b/.github/workflows/ci_verify_mbti.yml
@@ -73,6 +73,12 @@ jobs:
         run: |
           composer install --no-interaction --prefer-dist --no-progress
 
+      - name: Composer validate & audit
+        working-directory: backend
+        run: |
+          composer validate --strict
+          composer audit --no-interaction
+
       - name: Prepare Laravel env
         working-directory: backend
         run: |

--- a/.github/workflows/ci_verify_pr20_report_paywall.yml
+++ b/.github/workflows/ci_verify_pr20_report_paywall.yml
@@ -75,6 +75,12 @@ jobs:
         working-directory: backend
         run: composer install --no-interaction --prefer-dist
 
+      - name: Composer validate & audit
+        working-directory: backend
+        run: |
+          composer validate --strict
+          composer audit --no-interaction
+
       - name: Migrate
         working-directory: backend
         run: php artisan migrate --force -vvv

--- a/.github/workflows/ci_verify_pr21_answer_storage.yml
+++ b/.github/workflows/ci_verify_pr21_answer_storage.yml
@@ -55,6 +55,12 @@ jobs:
         working-directory: backend
         run: composer install --no-interaction --prefer-dist
 
+      - name: Composer validate & audit
+        working-directory: backend
+        run: |
+          composer validate --strict
+          composer audit --no-interaction
+
       - name: Migrate
         working-directory: backend
         run: php artisan migrate --force -vvv

--- a/.github/workflows/ci_verify_scales_registry.yml
+++ b/.github/workflows/ci_verify_scales_registry.yml
@@ -50,6 +50,12 @@ jobs:
         run: |
           composer install --no-interaction --prefer-dist --no-progress
 
+      - name: Composer validate & audit
+        working-directory: backend
+        run: |
+          composer validate --strict
+          composer audit --no-interaction
+
       - name: Prepare Laravel env
         working-directory: backend
         run: |

--- a/.github/workflows/ci_verify_v0_3_assessment_engine.yml
+++ b/.github/workflows/ci_verify_v0_3_assessment_engine.yml
@@ -70,6 +70,12 @@ jobs:
         run: |
           composer install --no-interaction --prefer-dist --no-progress
 
+      - name: Composer validate & audit
+        working-directory: backend
+        run: |
+          composer validate --strict
+          composer audit --no-interaction
+
       - name: Prepare Laravel env
         working-directory: backend
         run: |

--- a/.github/workflows/selfcheck.yml
+++ b/.github/workflows/selfcheck.yml
@@ -73,6 +73,12 @@ jobs:
         working-directory: backend
         run: composer install --no-interaction --prefer-dist --no-progress
 
+      - name: Composer validate & audit
+        working-directory: backend
+        run: |
+          composer validate --strict
+          composer audit --no-interaction
+
       - name: Guard release integrity (controllers + content pack + archive)
         run: bash backend/scripts/guard_release_integrity.sh
 

--- a/backend/composer.json
+++ b/backend/composer.json
@@ -84,6 +84,9 @@
     }
   },
   "config": {
+    "platform": {
+      "php": "8.4.0"
+    },
     "optimize-autoloader": true,
     "preferred-install": "dist",
     "sort-packages": true,

--- a/backend/composer.lock
+++ b/backend/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "3bfde54ce8512563a63dbb36a8c29d50",
+    "content-hash": "4d45f776e32454649e5bc4bf070520b3",
     "packages": [
         {
             "name": "anourvalar/eloquent-serialize",
@@ -10294,5 +10294,8 @@
         "php": "^8.2"
     },
     "platform-dev": {},
+    "platform-overrides": {
+        "php": "8.4.0"
+    },
     "plugin-api-version": "2.9.0"
 }

--- a/backend/scripts/pr56_accept.sh
+++ b/backend/scripts/pr56_accept.sh
@@ -10,99 +10,58 @@ export PAGER=cat
 export GIT_PAGER=cat
 export TERM=dumb
 export XDEBUG_MODE=off
-export LANG=en_US.UTF-8
 
 REPO_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 BACKEND_DIR="${REPO_DIR}/backend"
 ART_DIR="${BACKEND_DIR}/artifacts/pr56"
-SERVE_PORT="${SERVE_PORT:-1856}"
-DB_PATH="/tmp/pr56.sqlite"
 
 mkdir -p "${ART_DIR}"
+exec >"${ART_DIR}/pr56_accept.log" 2>&1
 
-cleanup_port() {
-  local port="$1"
-  lsof -nP -iTCP:"${port}" -sTCP:LISTEN || true
-  local pid_list
-  pid_list="$(lsof -ti tcp:"${port}" || true)"
-  if [[ -n "${pid_list}" ]]; then
-    echo "${pid_list}" | xargs kill -9 || true
-  fi
-  lsof -nP -iTCP:"${port}" -sTCP:LISTEN || true
-}
-
-cleanup() {
-  if [[ -f "${ART_DIR}/server.pid" ]]; then
-    local pid
-    pid="$(cat "${ART_DIR}/server.pid" || true)"
-    if [[ -n "${pid}" ]] && ps -p "${pid}" >/dev/null 2>&1; then
-      kill "${pid}" >/dev/null 2>&1 || true
-    fi
-  fi
-
-  cleanup_port "${SERVE_PORT}"
-  cleanup_port 18000
-  rm -f "${DB_PATH}"
-}
-trap cleanup EXIT
-
-cleanup_port "${SERVE_PORT}"
-cleanup_port 18000
-
-export APP_ENV=testing
-export CACHE_STORE=array
-export QUEUE_CONNECTION=database
-export DB_CONNECTION=sqlite
-export DB_DATABASE="${DB_PATH}"
-export FAP_PACKS_ROOT="${FAP_PACKS_ROOT:-${REPO_DIR}/content_packages}"
-export FAP_DEFAULT_REGION="${FAP_DEFAULT_REGION:-CN_MAINLAND}"
-export FAP_DEFAULT_LOCALE="${FAP_DEFAULT_LOCALE:-zh-CN}"
-export FAP_DEFAULT_PACK_ID="${FAP_DEFAULT_PACK_ID:-MBTI.cn-mainland.zh-CN.v0.2.2}"
-export FAP_DEFAULT_DIR_VERSION="${FAP_DEFAULT_DIR_VERSION:-MBTI-CN-v0.2.2}"
-
-rm -f "${DB_PATH}"
-touch "${DB_PATH}"
+echo "[PR56][ACCEPT] start"
+echo "[PR56][ACCEPT] repo=${REPO_DIR}"
+echo "[PR56][ACCEPT] art_dir=${ART_DIR}"
 
 cd "${BACKEND_DIR}"
 composer install --no-interaction --no-progress
-composer audit --locked --no-interaction > "${ART_DIR}/composer_audit.txt"
-php artisan migrate:fresh --force
-php artisan fap:scales:seed-default
-php artisan fap:scales:sync-slugs
+composer validate --strict >"${ART_DIR}/composer_validate.txt"
+composer audit --no-interaction >"${ART_DIR}/composer_audit.txt"
+composer --version >"${ART_DIR}/composer_version.txt"
 cd "${REPO_DIR}"
 
-SERVE_PORT="${SERVE_PORT}" ART_DIR="${ART_DIR}" bash "${BACKEND_DIR}/scripts/pr56_verify.sh"
+bash backend/scripts/pr56_verify.sh
 
-[[ -f "${ART_DIR}/verify_done.txt" ]] || { echo "verify script did not finish" >&2; exit 1; }
+bash -n backend/scripts/pr56_accept.sh >"${ART_DIR}/pr56_accept_syntax.txt"
+bash -n backend/scripts/pr56_verify.sh >"${ART_DIR}/pr56_verify_syntax.txt"
 
-ATTEMPT_ID="$(cat "${ART_DIR}/attempt_id.txt" 2>/dev/null || true)"
-ANON_ID="$(cat "${ART_DIR}/anon_id.txt" 2>/dev/null || true)"
-QUESTION_COUNT="$(cat "${ART_DIR}/question_count.txt" 2>/dev/null || true)"
-DEFAULT_PACK_ID="$(cat "${ART_DIR}/config_default_pack_id.txt" 2>/dev/null || true)"
-DEFAULT_DIR_VERSION="$(cat "${ART_DIR}/config_default_dir_version.txt" 2>/dev/null || true)"
+git status -sb >"${ART_DIR}/git_status_sb.txt"
+git --no-pager diff --name-only >"${ART_DIR}/changed_files.txt"
 
-cat > "${ART_DIR}/summary.txt" <<TXT
-PR56 Acceptance Summary
-- pass_items:
-  - workflows_php84_unified: OK
-  - composer_security_audit: OK
-  - dynamic_answers_submit: OK
-  - pack_seed_config_consistency: OK
-- key_outputs:
-  - attempt_id: ${ATTEMPT_ID}
-  - anon_id: ${ANON_ID}
-  - question_count(dynamic): ${QUESTION_COUNT}
-  - default_pack_id: ${DEFAULT_PACK_ID}
-  - default_dir_version: ${DEFAULT_DIR_VERSION}
-- smoke_urls:
-  - http://127.0.0.1:${SERVE_PORT}/api/v0.2/healthz
-  - http://127.0.0.1:${SERVE_PORT}/api/v0.3/scales/MBTI/questions
-  - http://127.0.0.1:${SERVE_PORT}/api/v0.3/attempts/submit
-- schema_changes:
-  - none
-TXT
+PHP_VERSION_LINES_COUNT="$(wc -l < "${ART_DIR}/workflow_php_version_lines.txt" | awk '{print $1}')"
+INSTALL_FILE_COUNT="$(wc -l < "${ART_DIR}/workflow_composer_install_files.txt" | awk '{print $1}')"
 
-bash "${BACKEND_DIR}/scripts/sanitize_artifacts.sh" 56
+{
+  echo "PR56 Acceptance Summary"
+  echo "repo=${REPO_DIR}"
+  echo "composer_version=$(cat "${ART_DIR}/composer_version.txt")"
+  echo "verify_status=$(cat "${ART_DIR}/pr56_verify_status.txt")"
+  echo "php_version_line_count=${PHP_VERSION_LINES_COUNT}"
+  echo "composer_install_workflow_count=${INSTALL_FILE_COUNT}"
+  echo "composer_platform=$(cat "${ART_DIR}/composer_platform_php.txt")"
+  echo ""
+  echo "Changed files:"
+  cat "${ART_DIR}/changed_files.txt"
+  echo ""
+  echo "Workflow gate report:"
+  cat "${ART_DIR}/workflow_composer_gate_report.txt"
+  echo ""
+  echo "Composer validate result:"
+  sed -n '1,20p' "${ART_DIR}/composer_validate.txt"
+  echo ""
+  echo "Composer audit result:"
+  sed -n '1,40p' "${ART_DIR}/composer_audit.txt"
+} >"${ART_DIR}/summary.txt"
 
-bash -n "${BACKEND_DIR}/scripts/pr56_accept.sh"
-bash -n "${BACKEND_DIR}/scripts/pr56_verify.sh"
+test -f backend/scripts/sanitize_artifacts.sh && bash backend/scripts/sanitize_artifacts.sh 56 || true
+
+echo "[PR56][ACCEPT] pass"

--- a/backend/scripts/pr56_verify.sh
+++ b/backend/scripts/pr56_verify.sh
@@ -10,331 +10,65 @@ export PAGER=cat
 export GIT_PAGER=cat
 export TERM=dumb
 export XDEBUG_MODE=off
-export LANG=en_US.UTF-8
 
 REPO_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
-BACKEND_DIR="${REPO_DIR}/backend"
-ART_DIR="${ART_DIR:-${BACKEND_DIR}/artifacts/pr56}"
-SERVE_PORT="${SERVE_PORT:-1856}"
-HOST="127.0.0.1"
-API_BASE="http://${HOST}:${SERVE_PORT}"
-SCALE_CODE="${SCALE_CODE:-MBTI}"
-ANON_ID="${ANON_ID:-pr56-verify-anon}"
+ART_DIR="${ART_DIR:-${REPO_DIR}/backend/artifacts/pr56}"
 
 mkdir -p "${ART_DIR}"
-exec > "${ART_DIR}/verify.log" 2>&1
+exec >"${ART_DIR}/pr56_verify.log" 2>&1
 
 fail() {
-  echo "[PR56][FAIL] $*" >&2
+  echo "[PR56][VERIFY][FAIL] $*"
   exit 1
 }
 
-cleanup_port() {
-  local port="$1"
-  lsof -nP -iTCP:"${port}" -sTCP:LISTEN || true
-  local pid_list
-  pid_list="$(lsof -ti tcp:"${port}" || true)"
-  if [[ -n "${pid_list}" ]]; then
-    echo "${pid_list}" | xargs kill -9 || true
+echo "[PR56][VERIFY] start"
+echo "[PR56][VERIFY] repo=${REPO_DIR}"
+echo "[PR56][VERIFY] art_dir=${ART_DIR}"
+
+WORKFLOW_LIST="${ART_DIR}/workflows_list.txt"
+WORKFLOW_PHP_VERSION_LINES="${ART_DIR}/workflow_php_version_lines.txt"
+WORKFLOW_PHP_VERSION_NON84="${ART_DIR}/workflow_php_version_non84.txt"
+WORKFLOW_INSTALL_FILES="${ART_DIR}/workflow_composer_install_files.txt"
+WORKFLOW_GATE_REPORT="${ART_DIR}/workflow_composer_gate_report.txt"
+COMPOSER_PLATFORM_FILE="${ART_DIR}/composer_platform_php.txt"
+
+find "${REPO_DIR}/.github/workflows" -type f \( -name "*.yml" -o -name "*.yaml" \) | sort >"${WORKFLOW_LIST}"
+
+# Check 1: all workflow php-version lines must be 8.4.
+grep -R -n -E 'php-version:' "${REPO_DIR}/.github/workflows" >"${WORKFLOW_PHP_VERSION_LINES}" || true
+if [ ! -s "${WORKFLOW_PHP_VERSION_LINES}" ]; then
+  fail "no php-version lines found in workflows"
+fi
+grep -E -v '8\.4' "${WORKFLOW_PHP_VERSION_LINES}" >"${WORKFLOW_PHP_VERSION_NON84}" || true
+if [ -s "${WORKFLOW_PHP_VERSION_NON84}" ]; then
+  fail "found non-8.4 php-version lines; see ${WORKFLOW_PHP_VERSION_NON84}"
+fi
+
+# Check 2: workflows containing composer install must also contain validate/audit gates.
+grep -R -l -E 'composer install' "${REPO_DIR}/.github/workflows" | sort >"${WORKFLOW_INSTALL_FILES}" || true
+if [ ! -s "${WORKFLOW_INSTALL_FILES}" ]; then
+  fail "no workflow contains composer install"
+fi
+
+: >"${WORKFLOW_GATE_REPORT}"
+for wf in $(cat "${WORKFLOW_INSTALL_FILES}"); do
+  install_count="$(grep -c -E 'composer install' "${wf}")"
+  validate_count="$(grep -c -E 'composer validate --strict' "${wf}" || true)"
+  audit_count="$(grep -c -E 'composer audit --no-interaction' "${wf}" || true)"
+
+  echo "${wf}: install=${install_count} validate=${validate_count} audit=${audit_count}" >>"${WORKFLOW_GATE_REPORT}"
+
+  if [ "${validate_count}" -ne "${install_count}" ]; then
+    fail "validate gate count mismatch in ${wf}"
   fi
-  lsof -nP -iTCP:"${port}" -sTCP:LISTEN || true
-}
-
-wait_health() {
-  local url="$1"
-  local body_file="${ART_DIR}/healthz.body"
-  local http_code=""
-
-  for _ in $(seq 1 80); do
-    http_code="$(curl -sS -o "${body_file}" -w "%{http_code}" "${url}" || true)"
-    if [[ "${http_code}" == "200" ]]; then
-      return 0
-    fi
-    sleep 0.25
-  done
-
-  echo "health_check_failed http=${http_code}" >&2
-  cat "${body_file}" >&2 || true
-  tail -n 120 "${ART_DIR}/server.log" >&2 || true
-  return 1
-}
-
-cleanup() {
-  if [[ -n "${SERVE_PID:-}" ]] && ps -p "${SERVE_PID}" >/dev/null 2>&1; then
-    kill "${SERVE_PID}" >/dev/null 2>&1 || true
+  if [ "${audit_count}" -ne "${install_count}" ]; then
+    fail "audit gate count mismatch in ${wf}"
   fi
-
-  if [[ -f "${ART_DIR}/server.pid" ]]; then
-    local pid
-    pid="$(cat "${ART_DIR}/server.pid" || true)"
-    if [[ -n "${pid}" ]] && ps -p "${pid}" >/dev/null 2>&1; then
-      kill "${pid}" >/dev/null 2>&1 || true
-    fi
-  fi
-
-  cleanup_port "${SERVE_PORT}"
-  cleanup_port 18000
-}
-trap cleanup EXIT
-
-cleanup_port "${SERVE_PORT}"
-cleanup_port 18000
-
-cd "${BACKEND_DIR}"
-php artisan serve --host="${HOST}" --port="${SERVE_PORT}" > "${ART_DIR}/server.log" 2>&1 &
-SERVE_PID="$!"
-echo "${SERVE_PID}" > "${ART_DIR}/server.pid"
-cd "${REPO_DIR}"
-
-wait_health "${API_BASE}/api/v0.2/healthz" || fail "healthz failed"
-curl -sS "${API_BASE}/api/v0.2/healthz" > "${ART_DIR}/healthz.json"
-
-cd "${BACKEND_DIR}"
-php -r '
-require "vendor/autoload.php";
-$app = require "bootstrap/app.php";
-$app->make(Illuminate\Contracts\Console\Kernel::class)->bootstrap();
-
-$configPackId = trim((string) config("content_packs.default_pack_id", ""));
-$configDirVersion = trim((string) config("content_packs.default_dir_version", ""));
-$configRegion = trim((string) config("content_packs.default_region", ""));
-$configLocale = trim((string) config("content_packs.default_locale", ""));
-
-echo "config_default_pack_id=".$configPackId.PHP_EOL;
-echo "config_default_dir_version=".$configDirVersion.PHP_EOL;
-echo "config_default_region=".$configRegion.PHP_EOL;
-echo "config_default_locale=".$configLocale.PHP_EOL;
-
-if ($configPackId === "" || $configDirVersion === "" || $configRegion === "" || $configLocale === "") {
-    fwrite(STDERR, "content_pack_defaults_missing\n");
-    exit(1);
-}
-
-if (!Illuminate\Support\Facades\Schema::hasTable("scales_registry")) {
-    fwrite(STDERR, "missing_scales_registry_table\n");
-    exit(1);
-}
-
-$row = Illuminate\Support\Facades\DB::table("scales_registry")
-    ->where("org_id", 0)
-    ->where("code", "MBTI")
-    ->first();
-if (!$row) {
-    fwrite(STDERR, "missing_scales_registry_mbti\n");
-    exit(1);
-}
-
-$registryPackId = trim((string) ($row->default_pack_id ?? ""));
-$registryDirVersion = trim((string) ($row->default_dir_version ?? ""));
-
-echo "registry_default_pack_id=".$registryPackId.PHP_EOL;
-echo "registry_default_dir_version=".$registryDirVersion.PHP_EOL;
-
-if ($registryPackId !== $configPackId) {
-    fwrite(STDERR, "default_pack_id_mismatch\n");
-    exit(1);
-}
-if ($registryDirVersion !== $configDirVersion) {
-    fwrite(STDERR, "default_dir_version_mismatch\n");
-    exit(1);
-}
-
-$index = app(App\Services\Content\ContentPacksIndex::class);
-$found = $index->find($configPackId, $configDirVersion);
-if (!($found["ok"] ?? false)) {
-    fwrite(STDERR, "pack_not_found\n");
-    exit(1);
-}
-
-$item = $found["item"] ?? [];
-$manifestPath = (string) ($item["manifest_path"] ?? "");
-$questionsPath = (string) ($item["questions_path"] ?? "");
-if ($manifestPath === "" || !is_file($manifestPath)) {
-    fwrite(STDERR, "manifest_missing\n");
-    exit(1);
-}
-if ($questionsPath === "" || !is_file($questionsPath)) {
-    fwrite(STDERR, "questions_missing\n");
-    exit(1);
-}
-
-$packDir = dirname($manifestPath);
-$versionPath = $packDir.DIRECTORY_SEPARATOR."version.json";
-if (!is_file($versionPath)) {
-    fwrite(STDERR, "version_missing\n");
-    exit(1);
-}
-
-$manifest = json_decode((string) file_get_contents($manifestPath), true);
-$version = json_decode((string) file_get_contents($versionPath), true);
-$questions = json_decode((string) file_get_contents($questionsPath), true);
-
-if (!is_array($manifest) || !is_array($version) || !is_array($questions)) {
-    fwrite(STDERR, "pack_json_invalid\n");
-    exit(1);
-}
-if (trim((string) ($manifest["pack_id"] ?? "")) !== $configPackId) {
-    fwrite(STDERR, "manifest_pack_id_mismatch\n");
-    exit(1);
-}
-if (trim((string) ($version["pack_id"] ?? "")) !== $configPackId) {
-    fwrite(STDERR, "version_pack_id_mismatch\n");
-    exit(1);
-}
-if (trim((string) ($version["dir_version"] ?? "")) !== $configDirVersion) {
-    fwrite(STDERR, "version_dir_version_mismatch\n");
-    exit(1);
-}
-
-echo "pack_dir=".$packDir.PHP_EOL;
-echo "pack_manifest=".$manifestPath.PHP_EOL;
-echo "pack_questions=".$questionsPath.PHP_EOL;
-echo "pack_version=".$versionPath.PHP_EOL;
-' > "${ART_DIR}/pack_seed_config.txt"
-cd "${REPO_DIR}"
-
-grep -E "^config_default_pack_id=" "${ART_DIR}/pack_seed_config.txt" | sed "s/^config_default_pack_id=//" > "${ART_DIR}/config_default_pack_id.txt"
-grep -E "^config_default_dir_version=" "${ART_DIR}/pack_seed_config.txt" | sed "s/^config_default_dir_version=//" > "${ART_DIR}/config_default_dir_version.txt"
-
-QUESTIONS_JSON="${ART_DIR}/questions.json"
-http_code="$(curl -sS -o "${QUESTIONS_JSON}" -w "%{http_code}" \
-  -H "Accept: application/json" \
-  "${API_BASE}/api/v0.3/scales/${SCALE_CODE}/questions" || true)"
-if [[ "${http_code}" != "200" ]]; then
-  echo "questions_failed http=${http_code}" >&2
-  cat "${QUESTIONS_JSON}" >&2 || true
-  tail -n 120 "${ART_DIR}/server.log" >&2 || true
-  fail "questions endpoint failed"
-fi
-
-ANSWERS_JSON="${ART_DIR}/answers.json"
-php -r '
-$raw = file_get_contents("php://stdin");
-$data = json_decode($raw, true);
-if (!is_array($data)) {
-    fwrite(STDERR, "questions_json_invalid\n");
-    exit(1);
-}
-$items = $data["questions"]["items"] ?? $data["questions"] ?? $data["items"] ?? $data["data"] ?? $data;
-if (!is_array($items)) {
-    fwrite(STDERR, "questions_items_invalid\n");
-    exit(1);
-}
-$answers = [];
-foreach ($items as $item) {
-    if (!is_array($item)) {
-        continue;
-    }
-    $questionId = (string) ($item["question_id"] ?? $item["id"] ?? "");
-    if ($questionId === "") {
-        continue;
-    }
-    $options = $item["options"] ?? [];
-    $code = "A";
-    if (is_array($options) && isset($options[0]) && is_array($options[0])) {
-        $code = (string) ($options[0]["code"] ?? $options[0]["option_code"] ?? "A");
-    }
-    if ($code === "") {
-        $code = "A";
-    }
-    $answers[] = [
-        "question_id" => $questionId,
-        "code" => $code,
-    ];
-}
-if (count($answers) === 0) {
-    fwrite(STDERR, "answers_empty\n");
-    exit(1);
-}
-echo json_encode($answers, JSON_UNESCAPED_UNICODE);
-' < "${QUESTIONS_JSON}" > "${ANSWERS_JSON}"
-
-QUESTION_COUNT="$(php -r '
-$data = json_decode(file_get_contents($argv[1]), true);
-if (!is_array($data)) {
-    echo "0";
-    exit(0);
-}
-echo (string) count($data);
-' "${ANSWERS_JSON}")"
-if [[ "${QUESTION_COUNT}" == "0" ]]; then
-  fail "dynamic answers generation produced zero answers"
-fi
-echo "${QUESTION_COUNT}" > "${ART_DIR}/question_count.txt"
-
-ATTEMPT_START_JSON="${ART_DIR}/attempt_start.json"
-ATTEMPT_START_BODY="$(SCALE_CODE="${SCALE_CODE}" ANON_ID="${ANON_ID}" php -r '
-$payload = [
-    "scale_code" => getenv("SCALE_CODE"),
-    "anon_id" => getenv("ANON_ID"),
-];
-echo json_encode($payload, JSON_UNESCAPED_UNICODE);
-')"
-http_code="$(curl -sS -o "${ATTEMPT_START_JSON}" -w "%{http_code}" \
-  -X POST -H "Content-Type: application/json" -H "Accept: application/json" \
-  --data "${ATTEMPT_START_BODY}" \
-  "${API_BASE}/api/v0.3/attempts/start" || true)"
-if [[ "${http_code}" != "200" ]]; then
-  echo "attempt_start_failed http=${http_code}" >&2
-  cat "${ATTEMPT_START_JSON}" >&2 || true
-  tail -n 120 "${ART_DIR}/server.log" >&2 || true
-  fail "attempt start failed"
-fi
-
-ATTEMPT_ID="$(php -r '$j=json_decode(file_get_contents($argv[1]), true); echo (string)($j["attempt_id"] ?? "");' "${ATTEMPT_START_JSON}")"
-if [[ -z "${ATTEMPT_ID}" ]]; then
-  fail "missing attempt_id"
-fi
-echo "${ATTEMPT_ID}" > "${ART_DIR}/attempt_id.txt"
-echo "${ANON_ID}" > "${ART_DIR}/anon_id.txt"
-
-SUBMIT_PAYLOAD="${ART_DIR}/submit_payload.json"
-ATTEMPT_ID="${ATTEMPT_ID}" ANSWERS_PATH="${ANSWERS_JSON}" php -r '
-$answers = json_decode(file_get_contents(getenv("ANSWERS_PATH")), true);
-if (!is_array($answers) || count($answers) === 0) {
-    fwrite(STDERR, "answers_payload_invalid\n");
-    exit(1);
-}
-$payload = [
-    "attempt_id" => getenv("ATTEMPT_ID"),
-    "answers" => $answers,
-    "duration_ms" => 120000,
-];
-echo json_encode($payload, JSON_UNESCAPED_UNICODE);
-' > "${SUBMIT_PAYLOAD}"
-
-ATTEMPT_SUBMIT_JSON="${ART_DIR}/attempt_submit.json"
-http_code="$(curl -sS -o "${ATTEMPT_SUBMIT_JSON}" -w "%{http_code}" \
-  -X POST -H "Content-Type: application/json" -H "Accept: application/json" \
-  --data @"${SUBMIT_PAYLOAD}" \
-  "${API_BASE}/api/v0.3/attempts/submit" || true)"
-if [[ "${http_code}" != "200" ]]; then
-  echo "attempt_submit_failed http=${http_code}" >&2
-  cat "${ATTEMPT_SUBMIT_JSON}" >&2 || true
-  tail -n 120 "${ART_DIR}/server.log" >&2 || true
-  fail "attempt submit failed"
-fi
-
-WORKFLOW_ASSERTIONS="${ART_DIR}/workflow_php84_composer_checks.txt"
-: > "${WORKFLOW_ASSERTIONS}"
-
-for wf in \
-  ".github/workflows/ci_verify_pr22_boot_v0_4.yml" \
-  ".github/workflows/ci_verify_pr23_feature_flags_sticky_experiments.yml" \
-  ".github/workflows/ci_verify_pr24_sitemap.yml" \
-  ".github/workflows/ci_verify_pr25_b2b_assessments_progress_rbac.yml" \
-  ".github/workflows/ci_pr56_workflow_composer_php84.yml"
-do
-  file_path="${REPO_DIR}/${wf}"
-  [[ -f "${file_path}" ]] || fail "missing workflow file: ${wf}"
-
-  grep -E 'php-version:[[:space:]]*"8.4"' "${file_path}" >/dev/null || fail "${wf} missing php-version 8.4"
-  grep -E 'composer audit --locked --no-interaction' "${file_path}" >/dev/null || fail "${wf} missing composer audit"
-  if grep -E 'php-version:[[:space:]]*"8.5"' "${file_path}" >/dev/null; then
-    fail "${wf} still contains php-version 8.5"
-  fi
-
-  echo "${wf}: php84_and_composer_audit=ok" >> "${WORKFLOW_ASSERTIONS}"
 done
 
-echo "verify_done" > "${ART_DIR}/verify_done.txt"
+# Check 3: backend/composer.json config.platform.php must be 8.4.0.
+php -r '$p=$argv[1]; if(!file_exists($p)){fwrite(STDERR, "missing composer.json\n"); exit(2);} $c=json_decode(file_get_contents($p), true); if(!is_array($c)){fwrite(STDERR, "composer.json decode failed\n"); exit(3);} $v=$c["config"]["platform"]["php"] ?? null; echo "config.platform.php=".(string)$v.PHP_EOL; if($v!=="8.4.0"){fwrite(STDERR, "config.platform.php must be 8.4.0\n"); exit(4);} ' "${REPO_DIR}/backend/composer.json" >"${COMPOSER_PLATFORM_FILE}"
+
+echo "PASS" >"${ART_DIR}/pr56_verify_status.txt"
+echo "[PR56][VERIFY] pass"

--- a/docs/verify/pr56_recon.md
+++ b/docs/verify/pr56_recon.md
@@ -1,30 +1,96 @@
-# PR56 Recon
+# PR56 Recon — CI 环境漂移 & 供应链硬约束缺失修复
 
-- Keywords: workflow|composer|php84
-- 相关入口文件：
-  - `.github/workflows/ci_verify_pr22_boot_v0_4.yml`
-  - `.github/workflows/ci_verify_pr23_feature_flags_sticky_experiments.yml`
-  - `.github/workflows/ci_verify_pr24_sitemap.yml`
-  - `.github/workflows/ci_verify_pr25_b2b_assessments_progress_rbac.yml`
-  - `backend/scripts/pr56_accept.sh`（新增）
-  - `backend/scripts/pr56_verify.sh`（新增）
-- 相关路由：
-  - `/api/v0.2/healthz`
-  - `/api/v0.3/scales/{code}/questions`
-  - `/api/v0.3/attempts/start`
-  - `/api/v0.3/attempts/submit`
-- 相关 DB 表/迁移：
-  - 无新增迁移；验收使用 `migrate:fresh` + `fap:scales:seed-default` + `fap:scales:sync-slugs`
-  - 读表校验：`scales_registry`（`default_pack_id/default_dir_version`）
-- 需要新增/修改点：
-  - 将 4 个 CI workflow 的 PHP 版本统一为 8.4
-  - 为 4 个 workflow 增加 Composer 安全审计（`composer audit --locked`）
-  - 新增 PR56 本机验收脚本（accept + verify）与 artifacts 输出
-  - 新增 PR56 CI workflow（统一性断言 + 验收闭环）
-- 风险点与规避（端口/CI 工具依赖/pack-seed-config 一致性/sqlite 迁移一致性/404 口径/脱敏）：
-  - 端口冲突：脚本启动前强制清理 `1856/18000`，退出时 kill PID 并复查
-  - CI 工具依赖：脚本/workflow 禁用 `rg/jq`，统一 `grep -E/sed/awk/php -r`
-  - pack/seed/config 一致性：`php -r` 校验 `config(content_packs)`、`scales_registry`、pack 目录与 JSON 可解析
-  - sqlite 一致性：使用 `/tmp/pr56.sqlite` 执行 `migrate:fresh --force`
-  - 404 口径：本 PR 不新增权限路由/中间件逻辑，不改变既有 404 策略
-  - 脱敏：验收后统一执行 `backend/scripts/sanitize_artifacts.sh 56`
+- Keywords: php-version|composer install|composer audit
+
+## 扫描范围
+- .github/workflows/*.yml / *.yaml
+- backend/composer.json
+
+## 诊断目标
+1) Version Drift
+- 检查 workflow 中 `php-version:` 是否全部固定为 `8.4`
+
+2) Supply Chain Gap
+- 对包含 `composer install` 的 workflow，检查是否包含：
+  - `composer validate --strict`
+  - `composer audit --no-interaction`
+
+3) Composer Platform Pin
+- 检查 `backend/composer.json` 中 `config.platform.php` 是否为 `8.4.0`
+
+## 原始证据（命令输出）
+
+== WORKFLOWS ==
+- .github/workflows/ci_dlq_replay_metrics.yml
+- .github/workflows/ci_pr55_migration_observability.yml
+- .github/workflows/ci_pr56_workflow_composer_php84.yml
+- .github/workflows/ci_verify_commerce_v2.yml
+- .github/workflows/ci_verify_mbti.yml
+- .github/workflows/ci_verify_pr20_report_paywall.yml
+- .github/workflows/ci_verify_pr21_answer_storage.yml
+- .github/workflows/ci_verify_pr22_boot_v0_4.yml
+- .github/workflows/ci_verify_pr23_feature_flags_sticky_experiments.yml
+- .github/workflows/ci_verify_pr24_sitemap.yml
+- .github/workflows/ci_verify_pr25_b2b_assessments_progress_rbac.yml
+- .github/workflows/ci_verify_scales_registry.yml
+- .github/workflows/ci_verify_v0_3_assessment_engine.yml
+- .github/workflows/deploy.yml
+- .github/workflows/publish-content.yml
+- .github/workflows/rollback-content.yml
+- .github/workflows/rollback-production.yml
+- .github/workflows/selfcheck.yml
+
+== php-version occurrences ==
+- .github/workflows/ci_verify_pr21_answer_storage.yml:36:          php-version: "8.4"
+- .github/workflows/ci_verify_pr25_b2b_assessments_progress_rbac.yml:42:          php-version: "8.4"
+- .github/workflows/ci_verify_mbti.yml:45:          php-version: "8.4"
+- .github/workflows/ci_pr55_migration_observability.yml:34:          php-version: "8.4"
+- .github/workflows/ci_dlq_replay_metrics.yml:35:          php-version: "8.4"
+- .github/workflows/ci_pr56_workflow_composer_php84.yml:50:          php-version: "8.4"
+- .github/workflows/ci_pr56_workflow_composer_php84.yml:58:            grep -E 'php-version:[[:space:]]*"8.4"' "${wf}" >/dev/null
+- .github/workflows/ci_verify_pr22_boot_v0_4.yml:41:          php-version: "8.4"
+- .github/workflows/ci_verify_pr24_sitemap.yml:44:          php-version: "8.4"
+- .github/workflows/ci_verify_pr20_report_paywall.yml:53:          php-version: "8.4"
+- .github/workflows/ci_verify_pr23_feature_flags_sticky_experiments.yml:41:          php-version: "8.4"
+- .github/workflows/ci_verify_commerce_v2.yml:55:          php-version: "8.4"
+- .github/workflows/ci_verify_v0_3_assessment_engine.yml:42:          php-version: "8.4"
+- .github/workflows/selfcheck.yml:50:          php-version: "8.4"
+- .github/workflows/ci_verify_scales_registry.yml:22:          php-version: "8.4"
+
+== composer install / validate / audit occurrences ==
+- .github/workflows/ci_verify_pr21_answer_storage.yml:56:        run: composer install --no-interaction --prefer-dist
+- .github/workflows/ci_verify_pr21_answer_storage.yml:61:          composer validate --strict
+- .github/workflows/ci_verify_pr21_answer_storage.yml:62:          composer audit --no-interaction
+- .github/workflows/ci_verify_pr25_b2b_assessments_progress_rbac.yml:49:          composer audit --locked --no-interaction
+- .github/workflows/ci_verify_mbti.yml:74:          composer install --no-interaction --prefer-dist --no-progress
+- .github/workflows/ci_verify_mbti.yml:79:          composer validate --strict
+- .github/workflows/ci_verify_mbti.yml:80:          composer audit --no-interaction
+- .github/workflows/ci_pr55_migration_observability.yml:53:          composer install --no-interaction --prefer-dist --no-progress
+- .github/workflows/ci_pr55_migration_observability.yml:58:          composer validate --strict
+- .github/workflows/ci_pr55_migration_observability.yml:59:          composer audit --no-interaction
+- .github/workflows/ci_dlq_replay_metrics.yml:54:          composer install --no-interaction --prefer-dist --no-progress
+- .github/workflows/ci_dlq_replay_metrics.yml:59:          composer validate --strict
+- .github/workflows/ci_dlq_replay_metrics.yml:60:          composer audit --no-interaction
+- .github/workflows/ci_pr56_workflow_composer_php84.yml:69:          composer validate --strict
+- .github/workflows/ci_pr56_workflow_composer_php84.yml:70:          composer audit --no-interaction
+- .github/workflows/ci_verify_pr22_boot_v0_4.yml:48:          composer audit --locked --no-interaction
+- .github/workflows/ci_verify_pr24_sitemap.yml:51:          composer audit --locked --no-interaction
+- .github/workflows/ci_verify_pr20_report_paywall.yml:76:        run: composer install --no-interaction --prefer-dist
+- .github/workflows/ci_verify_pr20_report_paywall.yml:81:          composer validate --strict
+- .github/workflows/ci_verify_pr20_report_paywall.yml:82:          composer audit --no-interaction
+- .github/workflows/ci_verify_pr23_feature_flags_sticky_experiments.yml:48:          composer audit --locked --no-interaction
+- .github/workflows/ci_verify_commerce_v2.yml:84:        run: composer install --no-interaction --prefer-dist
+- .github/workflows/ci_verify_commerce_v2.yml:89:          composer validate --strict
+- .github/workflows/ci_verify_commerce_v2.yml:90:          composer audit --no-interaction
+- .github/workflows/ci_verify_v0_3_assessment_engine.yml:71:          composer install --no-interaction --prefer-dist --no-progress
+- .github/workflows/ci_verify_v0_3_assessment_engine.yml:76:          composer validate --strict
+- .github/workflows/ci_verify_v0_3_assessment_engine.yml:77:          composer audit --no-interaction
+- .github/workflows/selfcheck.yml:74:        run: composer install --no-interaction --prefer-dist --no-progress
+- .github/workflows/selfcheck.yml:79:          composer validate --strict
+- .github/workflows/selfcheck.yml:80:          composer audit --no-interaction
+- .github/workflows/ci_verify_scales_registry.yml:51:          composer install --no-interaction --prefer-dist --no-progress
+- .github/workflows/ci_verify_scales_registry.yml:56:          composer validate --strict
+- .github/workflows/ci_verify_scales_registry.yml:57:          composer audit --no-interaction
+
+== backend/composer.json config.platform.php ==
+- config.platform.php=8.4.0

--- a/docs/verify/pr56_verify.md
+++ b/docs/verify/pr56_verify.md
@@ -1,28 +1,30 @@
-# PR56 Verify
+# PR56 Verify — Fix CI PHP drift and enforce composer validate/audit gates
 
-## 环境
-- Repo: `<REPO_PATH>`
-- Branch: `chore/pr56-unify-ci-php-84-and-composer-sec`
-- SERVE_PORT: `1856`
+## 执行环境
+- Repo: `/Users/rainie/Desktop/GitHub/fap-api`
+- Branch: `chore/pr56-fix-ci-php-drift-and-enforce-com`
+- Date: `2026-02-08`
 
 ## 执行命令
 - `bash backend/scripts/pr56_accept.sh`
-- `bash backend/scripts/ci_verify_mbti.sh`
+- `bash backend/scripts/pr56_verify.sh`
 
 ## 阻塞错误与修复
-- 【错误原因】`composer audit --locked` 报告安全公告并返回非零（`psy/psysh`、`symfony/process`）
-- 【最小修复动作】仅升级受影响依赖至安全版本，保留 audit 强校验
-- 【对应命令】`cd backend && composer update psy/psysh symfony/process --with-all-dependencies --no-interaction --no-progress`
+1) `composer validate --strict` 失败（lock 与 composer.json 不一致）
+- 【错误原因】`backend/composer.json` 新增 `config.platform.php=8.4.0` 后，`backend/composer.lock` 未同步
+- 【最小修复动作】刷新 lock 元数据
+- 【对应命令】
+  - `cd backend && composer update --lock --no-interaction --no-progress`
+  - `cd backend && composer validate --strict`
 
 ## 结果
-- `pr56_accept.sh`：PASS
-- `ci_verify_mbti.sh`：PASS
-- workflow 断言：PASS（见 `backend/artifacts/pr56/workflow_php84_composer_checks.txt`）
-- artifacts 汇总：`backend/artifacts/pr56/summary.txt`
+- `backend/scripts/pr56_accept.sh`: PASS
+- `backend/scripts/pr56_verify.sh`: PASS
+- workflow 断言：PASS（所有 `php-version` 为 `8.4`，所有包含 `composer install` 的 workflow 含 `validate/audit`）
+- composer 平台锁定：PASS（`config.platform.php=8.4.0`）
 
-## 关键输出
-- attempt_id: `36cf9f50-effb-4929-81c1-16ecf32a0f49`
-- anon_id: `pr56-verify-anon`
-- question_count(dynamic): `144`
-- default_pack_id: `MBTI.cn-mainland.zh-CN.v0.2.2`
-- default_dir_version: `MBTI-CN-v0.2.2`
+## 产物
+- `backend/artifacts/pr56/summary.txt`
+- `backend/artifacts/pr56/pr56_accept.log`
+- `backend/artifacts/pr56/pr56_verify.log`
+- `backend/artifacts/pr56/workflow_composer_gate_report.txt`


### PR DESCRIPTION
What:
Unify GitHub Actions PHP runtime to 8.4 across workflows.
Add Composer supply-chain gates (validate --strict + audit --no-interaction) after install and before tests.
Lock backend Composer platform PHP to 8.4.0.
Why:
Eliminate CI vs production runtime drift that can hide syntax/runtime incompatibilities.
Enforce hard pre-merge supply-chain policy to block known-vulnerable dependencies and invalid composer metadata.
How:
Update [*.yml|*.yaml](app://-/index.html#): set php-version to '8.4'; inject Composer validate/audit step.
Update [composer.json](app://-/index.html#): config.platform.php = 8.4.0.
Add local non-interactive acceptance scripts: [pr56_accept.sh](app://-/index.html#) and [pr56_verify.sh](app://-/index.html#).
Verify:
[pr56_accept.sh](app://-/index.html#)
Artifacts:
[summary.txt](app://-/index.html#)