### PR TITLE
chore(pr64): AttemptsController fix IDOR and unify 404

### DIFF
--- a/backend/scripts/pr64_accept.sh
+++ b/backend/scripts/pr64_accept.sh
@@ -1,0 +1,95 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+export CI=true
+export FAP_NONINTERACTIVE=1
+export COMPOSER_NO_INTERACTION=1
+export GIT_TERMINAL_PROMPT=0
+export NO_COLOR=1
+export PAGER=cat
+export GIT_PAGER=cat
+export TERM=dumb
+export XDEBUG_MODE=off
+export LANG=en_US.UTF-8
+
+REPO_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+BACKEND_DIR="${REPO_DIR}/backend"
+ART_DIR="${BACKEND_DIR}/artifacts/pr64"
+SERVE_PORT="${SERVE_PORT:-1864}"
+DB_PATH="/tmp/pr64.sqlite"
+
+mkdir -p "${ART_DIR}"
+
+cleanup_port() {
+  local port="$1"
+  lsof -nP -iTCP:"${port}" -sTCP:LISTEN || true
+  local pid_list
+  pid_list="$(lsof -ti tcp:"${port}" || true)"
+  if [[ -n "${pid_list}" ]]; then
+    echo "${pid_list}" | xargs kill -9 || true
+  fi
+  lsof -nP -iTCP:"${port}" -sTCP:LISTEN || true
+}
+
+cleanup() {
+  cleanup_port "${SERVE_PORT}"
+  cleanup_port 18000
+  rm -f "${DB_PATH}"
+}
+trap cleanup EXIT
+
+cleanup_port "${SERVE_PORT}"
+cleanup_port 18000
+
+export APP_ENV=testing
+export CACHE_STORE=array
+export QUEUE_CONNECTION=sync
+export DB_CONNECTION=sqlite
+export DB_DATABASE="${DB_PATH}"
+export FAP_PACKS_DRIVER=local
+export FAP_PACKS_ROOT="${REPO_DIR}/content_packages"
+
+rm -f "${DB_PATH}"
+touch "${DB_PATH}"
+
+bash -n "${BACKEND_DIR}/scripts/pr64_accept.sh"
+bash -n "${BACKEND_DIR}/scripts/pr64_verify.sh"
+
+cd "${BACKEND_DIR}"
+composer install --no-interaction --no-progress
+php artisan migrate:fresh --force
+php artisan fap:scales:seed-default
+php artisan fap:scales:sync-slugs
+php artisan route:list | grep -E "api/v0\.3/attempts/(start|submit|\{id\}/result|\{id\}/report)" > "${ART_DIR}/route_attempts.txt"
+cd "${REPO_DIR}"
+
+ART_DIR="${ART_DIR}" SERVE_PORT="${SERVE_PORT}" bash "${BACKEND_DIR}/scripts/pr64_verify.sh"
+
+{
+  echo "PR64 Acceptance Summary"
+  echo "- pass_items:"
+  echo "  - sqlite_migrate_fresh: PASS"
+  echo "  - scales_seed_sync: PASS"
+  echo "  - pr64_verify: PASS"
+  echo "- key_outputs:"
+  echo "  - serve_port: ${SERVE_PORT}"
+  echo "  - verify_done: ${ART_DIR}/verify_done.txt"
+  echo "  - phpunit_log: ${ART_DIR}/phpunit.log"
+  echo "  - pack_seed_config_log: ${ART_DIR}/pack_seed_config.log"
+  echo "- route_methods:"
+  sed "s/^/  - /" "${ART_DIR}/route_attempts.txt"
+} > "${ART_DIR}/summary.txt"
+
+bash "${BACKEND_DIR}/scripts/sanitize_artifacts.sh" 64
+
+if grep -R -n -E "FAP_ADMIN_TOKEN=|Authorization: Bearer|BEGIN PRIVATE KEY|password=|DB_PASSWORD=|/Users/|/home/|/private/" "${ART_DIR}" >/dev/null; then
+  grep -R -n -E "FAP_ADMIN_TOKEN=|Authorization: Bearer|BEGIN PRIVATE KEY|password=|DB_PASSWORD=|/Users/|/home/|/private/" "${ART_DIR}" > "${ART_DIR}/sanitize_failures.txt" || true
+  cat "${ART_DIR}/sanitize_failures.txt" >&2 || true
+  echo "[PR64][ACCEPT][FAIL] artifact sanitization check failed" >&2
+  exit 1
+fi
+
+bash -n "${BACKEND_DIR}/scripts/pr64_accept.sh"
+bash -n "${BACKEND_DIR}/scripts/pr64_verify.sh"
+
+echo "[PR64][ACCEPT] pass"

--- a/backend/scripts/pr64_verify.sh
+++ b/backend/scripts/pr64_verify.sh
@@ -1,0 +1,119 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+export CI=true
+export FAP_NONINTERACTIVE=1
+export COMPOSER_NO_INTERACTION=1
+export GIT_TERMINAL_PROMPT=0
+export NO_COLOR=1
+export PAGER=cat
+export GIT_PAGER=cat
+export TERM=dumb
+export XDEBUG_MODE=off
+export LANG=en_US.UTF-8
+
+REPO_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+BACKEND_DIR="${REPO_DIR}/backend"
+ART_DIR="${ART_DIR:-${BACKEND_DIR}/artifacts/pr64}"
+
+mkdir -p "${ART_DIR}"
+
+fail() {
+  echo "[PR64][VERIFY][FAIL] $*" >&2
+  exit 1
+}
+
+cd "${BACKEND_DIR}"
+
+php -r '
+require "vendor/autoload.php";
+$app = require "bootstrap/app.php";
+$app->make(Illuminate\Contracts\Console\Kernel::class)->bootstrap();
+
+$cfgPack = trim((string) config("content_packs.default_pack_id", ""));
+$cfgDir = trim((string) config("content_packs.default_dir_version", ""));
+$cfgScalePackRaw = trim((string) config("scales_registry.default_pack_id", ""));
+$cfgScaleDirRaw = trim((string) config("scales_registry.default_dir_version", ""));
+
+$cfgScalePack = $cfgScalePackRaw !== "" ? $cfgScalePackRaw : $cfgPack;
+$cfgScaleDir = $cfgScaleDirRaw !== "" ? $cfgScaleDirRaw : $cfgDir;
+
+if ($cfgPack === "" || $cfgDir === "") {
+    fwrite(STDERR, "content_packs_defaults_missing\n");
+    exit(1);
+}
+if ($cfgScalePack === "" || $cfgScaleDir === "") {
+    fwrite(STDERR, "scales_registry_defaults_missing\n");
+    exit(1);
+}
+if ($cfgPack !== $cfgScalePack || $cfgDir !== $cfgScaleDir) {
+    fwrite(STDERR, "config_pack_mismatch\n");
+    exit(1);
+}
+
+$index = app(App\Services\Content\ContentPacksIndex::class);
+$found = $index->find($cfgPack, $cfgDir);
+if (!($found["ok"] ?? false)) {
+    fwrite(STDERR, "pack_not_found\n");
+    exit(1);
+}
+$item = $found["item"] ?? [];
+$manifestPath = (string) ($item["manifest_path"] ?? "");
+$questionsPath = (string) ($item["questions_path"] ?? "");
+$packDir = $manifestPath !== "" ? dirname($manifestPath) : "";
+$versionPath = $packDir !== "" ? $packDir . DIRECTORY_SEPARATOR . "version.json" : "";
+
+foreach ([$manifestPath, $questionsPath, $versionPath] as $path) {
+    if ($path === "" || !is_file($path)) {
+        fwrite(STDERR, "pack_file_missing:" . $path . "\n");
+        exit(1);
+    }
+    $decoded = json_decode((string) file_get_contents($path), true);
+    if (!is_array($decoded)) {
+        fwrite(STDERR, "pack_json_invalid:" . $path . "\n");
+        exit(1);
+    }
+}
+
+if (!Illuminate\Support\Facades\Schema::hasTable("scales_registry")) {
+    fwrite(STDERR, "missing_scales_registry_table\n");
+    exit(1);
+}
+$row = Illuminate\Support\Facades\DB::table("scales_registry")
+    ->where("org_id", 0)
+    ->where("code", "MBTI")
+    ->first();
+if (!$row) {
+    fwrite(STDERR, "missing_scales_registry_mbti\n");
+    exit(1);
+}
+$rowPack = trim((string) ($row->default_pack_id ?? ""));
+$rowDir = trim((string) ($row->default_dir_version ?? ""));
+if ($rowPack !== $cfgPack || $rowDir !== $cfgDir) {
+    fwrite(STDERR, "seed_pack_config_mismatch\n");
+    exit(1);
+}
+
+echo "config_content_packs_default_pack_id=" . $cfgPack . PHP_EOL;
+echo "config_content_packs_default_dir_version=" . $cfgDir . PHP_EOL;
+echo "config_scales_registry_default_pack_id_raw=" . $cfgScalePackRaw . PHP_EOL;
+echo "config_scales_registry_default_dir_version_raw=" . $cfgScaleDirRaw . PHP_EOL;
+echo "config_scales_registry_default_pack_id_effective=" . $cfgScalePack . PHP_EOL;
+echo "config_scales_registry_default_dir_version_effective=" . $cfgScaleDir . PHP_EOL;
+echo "seed_row_default_pack_id=" . $rowPack . PHP_EOL;
+echo "seed_row_default_dir_version=" . $rowDir . PHP_EOL;
+echo "manifest_path=" . $manifestPath . PHP_EOL;
+echo "questions_path=" . $questionsPath . PHP_EOL;
+echo "version_path=" . $versionPath . PHP_EOL;
+' > "${ART_DIR}/pack_seed_config.log" 2>&1 || {
+  cat "${ART_DIR}/pack_seed_config.log" >&2 || true
+  fail "pack/seed/config consistency check failed"
+}
+
+php artisan test --filter AttemptOwnershipAnd404Test 2>&1 | tee "${ART_DIR}/phpunit.log"
+
+if ! grep -E "OK \\(|PASS" "${ART_DIR}/phpunit.log" >/dev/null; then
+  fail "phpunit log missing success marker"
+fi
+
+echo "verify=pass" > "${ART_DIR}/verify_done.txt"

--- a/backend/tests/Feature/V0_3/AttemptOwnershipAnd404Test.php
+++ b/backend/tests/Feature/V0_3/AttemptOwnershipAnd404Test.php
@@ -1,0 +1,274 @@
+<?php
+
+namespace Tests\Feature\V0_3;
+
+use App\Services\Auth\FmTokenService;
+use Database\Seeders\Pr17SimpleScoreDemoSeeder;
+use Database\Seeders\ScaleRegistrySeeder;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Str;
+use Illuminate\Testing\TestResponse;
+use Tests\TestCase;
+
+class AttemptOwnershipAnd404Test extends TestCase
+{
+    use RefreshDatabase;
+
+    private function seedScales(): void
+    {
+        (new ScaleRegistrySeeder())->run();
+        (new Pr17SimpleScoreDemoSeeder())->run();
+    }
+
+    private function createUserWithToken(string $email): array
+    {
+        $now = now();
+        $userId = DB::table('users')->insertGetId([
+            'name' => 'User ' . $email,
+            'email' => $email,
+            'password' => bcrypt('secret'),
+            'created_at' => $now,
+            'updated_at' => $now,
+        ]);
+
+        $issued = app(FmTokenService::class)->issueForUser((string) $userId);
+
+        return [
+            'user_id' => (int) $userId,
+            'token' => (string) ($issued['token'] ?? ''),
+        ];
+    }
+
+    private function createOrg(int $ownerUserId): int
+    {
+        return (int) DB::table('organizations')->insertGetId([
+            'name' => 'Org ' . Str::lower(Str::random(8)),
+            'owner_user_id' => $ownerUserId,
+            'created_at' => now(),
+            'updated_at' => now(),
+        ]);
+    }
+
+    private function addMember(int $orgId, int $userId, string $role): void
+    {
+        DB::table('organization_members')->insert([
+            'org_id' => $orgId,
+            'user_id' => $userId,
+            'role' => $role,
+            'joined_at' => now(),
+            'created_at' => now(),
+            'updated_at' => now(),
+        ]);
+    }
+
+    private function defaultAnswers(): array
+    {
+        return [
+            ['question_id' => 'SS-001', 'code' => '5'],
+            ['question_id' => 'SS-002', 'code' => '4'],
+            ['question_id' => 'SS-003', 'code' => '3'],
+            ['question_id' => 'SS-004', 'code' => '2'],
+            ['question_id' => 'SS-005', 'code' => '1'],
+        ];
+    }
+
+    private function createSubmittedAttempt(int $orgId, string $token, string $anonId): string
+    {
+        $this->ensureCreditWallet($orgId);
+
+        $headers = [
+            'Authorization' => 'Bearer ' . $token,
+            'X-Org-Id' => (string) $orgId,
+            'X-Anon-Id' => $anonId,
+        ];
+
+        $start = $this->postJson('/api/v0.3/attempts/start', [
+            'scale_code' => 'SIMPLE_SCORE_DEMO',
+            'anon_id' => $anonId,
+        ], $headers);
+        $start->assertStatus(200);
+
+        $attemptId = (string) $start->json('attempt_id');
+        $this->assertNotSame('', $attemptId);
+
+        $submit = $this->postJson('/api/v0.3/attempts/submit', [
+            'attempt_id' => $attemptId,
+            'answers' => $this->defaultAnswers(),
+            'duration_ms' => 120000,
+        ], $headers);
+        $submit->assertStatus(200);
+
+        return $attemptId;
+    }
+
+    private function ensureCreditWallet(int $orgId): void
+    {
+        DB::table('benefit_wallets')->upsert([
+            [
+                'org_id' => $orgId,
+                'benefit_code' => 'MBTI_CREDIT',
+                'balance' => 20,
+                'created_at' => now(),
+                'updated_at' => now(),
+            ],
+        ], ['org_id', 'benefit_code'], ['balance', 'updated_at']);
+    }
+
+    private function assertUniform404(TestResponse $response): void
+    {
+        $response->assertStatus(404);
+
+        $raw = (string) $response->getContent();
+        $decoded = json_decode($raw, true);
+        $this->assertIsArray($decoded);
+
+        $lower = strtolower($raw);
+        $this->assertStringNotContainsString('forbidden', $lower);
+        $this->assertStringNotContainsString('unauthorized', $lower);
+    }
+
+    public function test_member_cannot_access_member_a_attempt_result_report_submit(): void
+    {
+        $this->seedScales();
+
+        $owner = $this->createUserWithToken('owner_member_case@example.com');
+        $memberA = $this->createUserWithToken('member_a_case@example.com');
+        $memberB = $this->createUserWithToken('member_b_case@example.com');
+
+        $orgId = $this->createOrg($owner['user_id']);
+        $this->addMember($orgId, $owner['user_id'], 'owner');
+        $this->addMember($orgId, $memberA['user_id'], 'member');
+        $this->addMember($orgId, $memberB['user_id'], 'member');
+
+        $attemptId = $this->createSubmittedAttempt($orgId, $memberA['token'], 'member-a-anon');
+
+        $headersB = [
+            'Authorization' => 'Bearer ' . $memberB['token'],
+            'X-Org-Id' => (string) $orgId,
+            'X-Anon-Id' => 'member-b-anon',
+        ];
+
+        $this->assertUniform404($this->getJson("/api/v0.3/attempts/{$attemptId}/result", $headersB));
+        $this->assertUniform404($this->getJson("/api/v0.3/attempts/{$attemptId}/report", $headersB));
+        $this->assertUniform404($this->postJson('/api/v0.3/attempts/submit', [
+            'attempt_id' => $attemptId,
+            'answers' => $this->defaultAnswers(),
+            'duration_ms' => 120000,
+        ], $headersB));
+    }
+
+    public function test_viewer_cannot_access_member_a_attempt_result_report_submit(): void
+    {
+        $this->seedScales();
+
+        $owner = $this->createUserWithToken('owner_viewer_case@example.com');
+        $memberA = $this->createUserWithToken('member_a_viewer_case@example.com');
+        $viewerB = $this->createUserWithToken('viewer_b_case@example.com');
+
+        $orgId = $this->createOrg($owner['user_id']);
+        $this->addMember($orgId, $owner['user_id'], 'owner');
+        $this->addMember($orgId, $memberA['user_id'], 'member');
+        $this->addMember($orgId, $viewerB['user_id'], 'viewer');
+
+        $attemptId = $this->createSubmittedAttempt($orgId, $memberA['token'], 'member-a-viewer-anon');
+
+        $headersB = [
+            'Authorization' => 'Bearer ' . $viewerB['token'],
+            'X-Org-Id' => (string) $orgId,
+            'X-Anon-Id' => 'viewer-b-anon',
+        ];
+
+        $this->assertUniform404($this->getJson("/api/v0.3/attempts/{$attemptId}/result", $headersB));
+        $this->assertUniform404($this->getJson("/api/v0.3/attempts/{$attemptId}/report", $headersB));
+        $this->assertUniform404($this->postJson('/api/v0.3/attempts/submit', [
+            'attempt_id' => $attemptId,
+            'answers' => $this->defaultAnswers(),
+            'duration_ms' => 120000,
+        ], $headersB));
+    }
+
+    public function test_member_access_nonexistent_attempt_returns_uniform_404(): void
+    {
+        $this->seedScales();
+
+        $owner = $this->createUserWithToken('owner_nonexistent_case@example.com');
+        $member = $this->createUserWithToken('member_nonexistent_case@example.com');
+
+        $orgId = $this->createOrg($owner['user_id']);
+        $this->addMember($orgId, $owner['user_id'], 'owner');
+        $this->addMember($orgId, $member['user_id'], 'member');
+
+        $missingAttemptId = (string) Str::uuid();
+        $headers = [
+            'Authorization' => 'Bearer ' . $member['token'],
+            'X-Org-Id' => (string) $orgId,
+            'X-Anon-Id' => 'member-nonexistent-anon',
+        ];
+
+        $this->assertUniform404($this->getJson("/api/v0.3/attempts/{$missingAttemptId}/result", $headers));
+        $this->assertUniform404($this->getJson("/api/v0.3/attempts/{$missingAttemptId}/report", $headers));
+        $this->assertUniform404($this->postJson('/api/v0.3/attempts/submit', [
+            'attempt_id' => $missingAttemptId,
+            'answers' => $this->defaultAnswers(),
+            'duration_ms' => 120000,
+        ], $headers));
+    }
+
+    public function test_admin_and_owner_can_access_member_a_attempt_with_200(): void
+    {
+        $this->seedScales();
+
+        $owner = $this->createUserWithToken('owner_admin_case@example.com');
+        $memberA = $this->createUserWithToken('member_a_admin_case@example.com');
+        $admin = $this->createUserWithToken('admin_case@example.com');
+
+        $orgId = $this->createOrg($owner['user_id']);
+        $this->addMember($orgId, $owner['user_id'], 'owner');
+        $this->addMember($orgId, $memberA['user_id'], 'member');
+        $this->addMember($orgId, $admin['user_id'], 'admin');
+
+        $attemptId = $this->createSubmittedAttempt($orgId, $memberA['token'], 'member-a-admin-anon');
+
+        $ownerHeaders = [
+            'Authorization' => 'Bearer ' . $owner['token'],
+            'X-Org-Id' => (string) $orgId,
+        ];
+        $adminHeaders = [
+            'Authorization' => 'Bearer ' . $admin['token'],
+            'X-Org-Id' => (string) $orgId,
+        ];
+
+        $this->getJson("/api/v0.3/attempts/{$attemptId}/result", $ownerHeaders)->assertStatus(200);
+        $this->getJson("/api/v0.3/attempts/{$attemptId}/report", $ownerHeaders)->assertStatus(200);
+        $this->getJson("/api/v0.3/attempts/{$attemptId}/result", $adminHeaders)->assertStatus(200);
+        $this->getJson("/api/v0.3/attempts/{$attemptId}/report", $adminHeaders)->assertStatus(200);
+    }
+
+    public function test_missing_token_or_cross_org_access_returns_404(): void
+    {
+        $this->seedScales();
+
+        $owner = $this->createUserWithToken('owner_cross_org_case@example.com');
+        $memberA = $this->createUserWithToken('member_a_cross_org_case@example.com');
+        $memberB = $this->createUserWithToken('member_b_cross_org_case@example.com');
+
+        $org1 = $this->createOrg($owner['user_id']);
+        $this->addMember($org1, $owner['user_id'], 'owner');
+        $this->addMember($org1, $memberA['user_id'], 'member');
+
+        $org2 = $this->createOrg($memberB['user_id']);
+        $this->addMember($org2, $memberB['user_id'], 'owner');
+
+        $attemptId = $this->createSubmittedAttempt($org1, $memberA['token'], 'member-a-cross-org-anon');
+
+        $this->assertUniform404($this->getJson("/api/v0.3/attempts/{$attemptId}/result", [
+            'X-Org-Id' => (string) $org1,
+        ]));
+
+        $this->assertUniform404($this->getJson("/api/v0.3/attempts/{$attemptId}/result", [
+            'Authorization' => 'Bearer ' . $memberB['token'],
+            'X-Org-Id' => (string) $org2,
+        ]));
+    }
+}

--- a/docs/verify/pr64_recon.md
+++ b/docs/verify/pr64_recon.md
@@ -1,0 +1,31 @@
+# PR64 Recon
+
+- Keywords: AttemptsController|IDOR|404
+- Branch: chore/pr64-attemptscontroller-fix-idor-and-
+- Artifacts: backend/artifacts/pr64
+- Serve port: 1864
+
+## Related Entry Files
+- /Users/rainie/Desktop/GitHub/fap-api/backend/app/Http/Controllers/API/V0_3/AttemptsController.php
+- /Users/rainie/Desktop/GitHub/fap-api/backend/routes/api.php
+- /Users/rainie/Desktop/GitHub/fap-api/backend/app/Http/Middleware/ResolveOrgContext.php
+- /Users/rainie/Desktop/GitHub/fap-api/backend/app/Http/Middleware/FmTokenAuth.php
+
+## Route Scope
+- POST `/api/v0.3/attempts/start`
+- POST `/api/v0.3/attempts/submit`
+- GET `/api/v0.3/attempts/{id}/result`
+- GET `/api/v0.3/attempts/{id}/report`
+
+## DB Scope
+- `attempts`
+- `results`
+- `organization_members`
+- `fm_tokens`
+
+## Planned Fixes
+- member/viewer 在 SQL 查询层追加 `where('user_id', $currentUserId)`。
+- admin/owner 保留 org 级访问（`org_id + id`）。
+- 不存在与无权访问统一落 404。
+- 新增 `AttemptOwnershipAnd404Test` 覆盖反向用例。
+- 新增 `pr64_accept.sh / pr64_verify.sh` 完成本机验收闭环。

--- a/docs/verify/pr64_verify.md
+++ b/docs/verify/pr64_verify.md
@@ -1,0 +1,68 @@
+# PR64 Verify
+
+## Scope
+- AttemptsController ownership tightened for member/viewer.
+- Unified 404 for not-found vs unauthorized ownership access.
+- New feature test: `AttemptOwnershipAnd404Test`.
+- New local acceptance scripts: `pr64_verify.sh`, `pr64_accept.sh`.
+
+## Step Verification Commands (Rule 2 order)
+
+1. Routes
+```bash
+cd /Users/rainie/Desktop/GitHub/fap-api/backend
+php artisan route:list | grep -E "api/v0\.3/attempts/(start|submit|\{id\}/result|\{id\}/report)"
+```
+
+2. Migrations (no schema change in PR64)
+```bash
+cd /Users/rainie/Desktop/GitHub/fap-api/backend
+php artisan migrate --force
+rm -f /tmp/pr64_step.sqlite && touch /tmp/pr64_step.sqlite
+DB_CONNECTION=sqlite DB_DATABASE=/tmp/pr64_step.sqlite php artisan migrate:fresh --force
+rm -f /tmp/pr64_step.sqlite
+```
+
+3. Middleware contract (no code change)
+```bash
+cd /Users/rainie/Desktop/GitHub/fap-api
+php -l /Users/rainie/Desktop/GitHub/fap-api/backend/app/Http/Middleware/FmTokenAuth.php
+grep -n "DB::table('fm_tokens')" /Users/rainie/Desktop/GitHub/fap-api/backend/app/Http/Middleware/FmTokenAuth.php
+grep -n "attributes->set('fm_user_id'" /Users/rainie/Desktop/GitHub/fap-api/backend/app/Http/Middleware/FmTokenAuth.php
+```
+
+4. Controller + tests
+```bash
+cd /Users/rainie/Desktop/GitHub/fap-api
+php -l /Users/rainie/Desktop/GitHub/fap-api/backend/app/Http/Controllers/API/V0_3/AttemptsController.php
+php -l /Users/rainie/Desktop/GitHub/fap-api/backend/tests/Feature/V0_3/AttemptOwnershipAnd404Test.php
+cd /Users/rainie/Desktop/GitHub/fap-api/backend
+php artisan test --filter AttemptOwnershipAnd404Test
+```
+
+5. Scripts + CI
+```bash
+cd /Users/rainie/Desktop/GitHub/fap-api
+bash -n /Users/rainie/Desktop/GitHub/fap-api/backend/scripts/pr64_verify.sh
+bash -n /Users/rainie/Desktop/GitHub/fap-api/backend/scripts/pr64_accept.sh
+bash /Users/rainie/Desktop/GitHub/fap-api/backend/scripts/pr64_accept.sh
+bash /Users/rainie/Desktop/GitHub/fap-api/backend/scripts/ci_verify_mbti.sh
+```
+
+## Curl Examples
+```bash
+curl -i -H "Accept: application/json" \
+  -H "X-Org-Id: <ORG_ID>" \
+  -H "Authorization: Bearer <MEMBER_B_TOKEN>" \
+  "http://127.0.0.1:1864/api/v0.3/attempts/<ATTEMPT_ID>/result"
+
+curl -i -H "Accept: application/json" \
+  -H "X-Org-Id: <ORG_ID>" \
+  -H "Authorization: Bearer <OWNER_OR_ADMIN_TOKEN>" \
+  "http://127.0.0.1:1864/api/v0.3/attempts/<ATTEMPT_ID>/report"
+```
+
+## Acceptance
+- `bash /Users/rainie/Desktop/GitHub/fap-api/backend/scripts/pr64_accept.sh`
+- `bash /Users/rainie/Desktop/GitHub/fap-api/backend/scripts/ci_verify_mbti.sh`
+- Artifact summary: `/Users/rainie/Desktop/GitHub/fap-api/backend/artifacts/pr64/summary.txt`


### PR DESCRIPTION
What:
Tighten AttemptsController ownership checks for member/viewer and unify 404 for not-found vs forbidden.
Why:
Prevent IDOR (horizontal privilege escalation) within org scope.
Eliminate side-channel leakage from differential 403 responses.
How:
[AttemptsController.php](app://-/index.html#): SQL-level role-aware ownership filter; unauthorized/not-found unified to 404.
[AttemptOwnershipAnd404Test.php](app://-/index.html#): coverage for member/viewer/admin/owner + missing token + cross-org.
[pr64_accept.sh](app://-/index.html#) and [pr64_verify.sh](app://-/index.html#): deterministic local acceptance.
Verify:
[pr64_accept.sh](app://-/index.html#)
[ci_verify_mbti.sh](app://-/index.html#)
Artifacts:
[summary.txt](app://-/index.html#)