### PR TITLE
chore(pr66): Migration safety: prevent drop-table rollback and remove…

### DIFF
--- a/backend/database/migrations/2025_12_17_165938_create_events_table.php
+++ b/backend/database/migrations/2025_12_17_165938_create_events_table.php
@@ -25,7 +25,7 @@ return new class extends Migration
 
     public function down(): void
     {
-        // Prevent accidental data loss. This table might have existed before.
+        // Safety: Down is a no-op to prevent accidental data loss.
         // Schema::dropIfExists('events');
     }
 };

--- a/backend/database/migrations/2026_01_22_090010_create_orders_table.php
+++ b/backend/database/migrations/2026_01_22_090010_create_orders_table.php
@@ -91,7 +91,7 @@ return new class extends Migration
 
     public function down(): void
     {
-        // Prevent accidental data loss. This table might have existed before.
+        // Safety: Down is a no-op to prevent accidental data loss.
         // Schema::dropIfExists('orders');
     }
 };

--- a/backend/database/migrations/2026_01_22_090020_create_benefit_grants_table.php
+++ b/backend/database/migrations/2026_01_22_090020_create_benefit_grants_table.php
@@ -67,7 +67,7 @@ return new class extends Migration
 
     public function down(): void
     {
-        // Prevent accidental data loss. This table might have existed before.
+        // Safety: Down is a no-op to prevent accidental data loss.
         // Schema::dropIfExists('benefit_grants');
     }
 };

--- a/backend/database/migrations/2026_01_22_090030_create_payment_events_table.php
+++ b/backend/database/migrations/2026_01_22_090030_create_payment_events_table.php
@@ -77,7 +77,7 @@ return new class extends Migration
 
     public function down(): void
     {
-        // Prevent accidental data loss. This table might have existed before.
+        // Safety: Down is a no-op to prevent accidental data loss.
         // Schema::dropIfExists('payment_events');
     }
 };

--- a/backend/database/migrations/2026_01_27_210000_pr9_add_observability_columns_to_events.php
+++ b/backend/database/migrations/2026_01_27_210000_pr9_add_observability_columns_to_events.php
@@ -166,19 +166,10 @@ return new class extends Migration
             return;
         }
 
-        try {
-            Schema::table($tableName, function (Blueprint $table) use ($columns, $indexName): void {
-                $table->index($columns, $indexName);
-            });
-            SchemaIndex::logIndexAction('create_index', $tableName, $indexName, $driver, ['phase' => 'up']);
-        } catch (\Throwable $e) {
-            if (SchemaIndex::isDuplicateIndexException($e, $indexName)) {
-                SchemaIndex::logIndexAction('create_index_skip_duplicate', $tableName, $indexName, $driver, ['phase' => 'up']);
-                return;
-            }
-
-            throw $e;
-        }
+        Schema::table($tableName, function (Blueprint $table) use ($columns, $indexName): void {
+            $table->index($columns, $indexName);
+        });
+        SchemaIndex::logIndexAction('create_index', $tableName, $indexName, $driver, ['phase' => 'up']);
     }
 
     private function dropIndexIfExists(string $tableName, string $indexName): void
@@ -190,18 +181,9 @@ return new class extends Migration
             return;
         }
 
-        try {
-            Schema::table($tableName, function (Blueprint $table) use ($indexName): void {
-                $table->dropIndex($indexName);
-            });
-            SchemaIndex::logIndexAction('drop_index', $tableName, $indexName, $driver, ['phase' => 'down']);
-        } catch (\Throwable $e) {
-            if (SchemaIndex::isMissingIndexException($e, $indexName)) {
-                SchemaIndex::logIndexAction('drop_index_skip_missing', $tableName, $indexName, $driver, ['phase' => 'down']);
-                return;
-            }
-
-            throw $e;
-        }
+        Schema::table($tableName, function (Blueprint $table) use ($indexName): void {
+            $table->dropIndex($indexName);
+        });
+        SchemaIndex::logIndexAction('drop_index', $tableName, $indexName, $driver, ['phase' => 'down']);
     }
 };

--- a/backend/database/migrations/2026_01_28_120000_create_ai_insights_table.php
+++ b/backend/database/migrations/2026_01_28_120000_create_ai_insights_table.php
@@ -39,10 +39,7 @@ return new class extends Migration
 
     public function down(): void
     {
-        if (!Schema::hasTable('ai_insights')) {
-            return;
-        }
-
-        Schema::drop('ai_insights');
+        // Safety: Down is a no-op to prevent accidental data loss.
+        // Schema::drop('ai_insights');
     }
 };

--- a/backend/database/migrations/2026_01_28_120100_create_ai_insight_feedback_table.php
+++ b/backend/database/migrations/2026_01_28_120100_create_ai_insight_feedback_table.php
@@ -26,10 +26,7 @@ return new class extends Migration
 
     public function down(): void
     {
-        if (!Schema::hasTable('ai_insight_feedback')) {
-            return;
-        }
-
-        Schema::drop('ai_insight_feedback');
+        // Safety: Down is a no-op to prevent accidental data loss.
+        // Schema::drop('ai_insight_feedback');
     }
 };

--- a/backend/database/migrations/2026_01_29_090000_create_scales_registry_table.php
+++ b/backend/database/migrations/2026_01_29_090000_create_scales_registry_table.php
@@ -178,9 +178,8 @@ return new class extends Migration
 
     public function down(): void
     {
-        if (Schema::hasTable('scales_registry')) {
-            Schema::drop('scales_registry');
-        }
+        // Safety: Down is a no-op to prevent accidental data loss.
+        // Schema::drop('scales_registry');
     }
 
     private function indexExists(string $table, string $indexName): bool

--- a/backend/database/migrations/2026_01_29_090010_create_scale_slugs_table.php
+++ b/backend/database/migrations/2026_01_29_090010_create_scale_slugs_table.php
@@ -86,9 +86,8 @@ return new class extends Migration
 
     public function down(): void
     {
-        if (Schema::hasTable('scale_slugs')) {
-            Schema::drop('scale_slugs');
-        }
+        // Safety: Down is a no-op to prevent accidental data loss.
+        // Schema::drop('scale_slugs');
     }
 
     private function indexExists(string $table, string $indexName): bool

--- a/backend/database/migrations/2026_02_08_040000_create_migration_index_audits_table.php
+++ b/backend/database/migrations/2026_02_08_040000_create_migration_index_audits_table.php
@@ -77,9 +77,8 @@ return new class extends Migration
 
     public function down(): void
     {
-        if (Schema::hasTable(self::TABLE)) {
-            Schema::drop(self::TABLE);
-        }
+        // Safety: Down is a no-op to prevent accidental data loss.
+        // Schema::drop(self::TABLE);
     }
 
     /**

--- a/backend/scripts/pr66_accept.sh
+++ b/backend/scripts/pr66_accept.sh
@@ -1,0 +1,127 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+export CI=true
+export FAP_NONINTERACTIVE=1
+export COMPOSER_NO_INTERACTION=1
+export GIT_TERMINAL_PROMPT=0
+export NO_COLOR=1
+export PAGER=cat
+export GIT_PAGER=cat
+export TERM=dumb
+export XDEBUG_MODE=off
+export LANG=en_US.UTF-8
+
+REPO_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+BACKEND_DIR="${REPO_DIR}/backend"
+ART_DIR="${BACKEND_DIR}/artifacts/pr66"
+SERVE_PORT="${SERVE_PORT:-1866}"
+DB_PATH="/tmp/pr66.sqlite"
+
+mkdir -p "${ART_DIR}"
+
+cleanup_port() {
+  local port="$1"
+  lsof -nP -iTCP:"${port}" -sTCP:LISTEN || true
+  local pid_list
+  pid_list="$(lsof -ti tcp:"${port}" || true)"
+  if [[ -n "${pid_list}" ]]; then
+    echo "${pid_list}" | xargs kill -9 || true
+  fi
+  lsof -nP -iTCP:"${port}" -sTCP:LISTEN || true
+}
+
+cleanup() {
+  cleanup_port "${SERVE_PORT}"
+  cleanup_port 18000
+  rm -f "${DB_PATH}"
+}
+trap cleanup EXIT
+
+cleanup_port "${SERVE_PORT}"
+cleanup_port 18000
+
+export APP_ENV=testing
+export CACHE_STORE=array
+export QUEUE_CONNECTION=sync
+export DB_CONNECTION=sqlite
+export DB_DATABASE="${DB_PATH}"
+export FAP_PACKS_DRIVER=local
+export FAP_PACKS_ROOT="${REPO_DIR}/content_packages"
+
+rm -f "${DB_PATH}"
+touch "${DB_PATH}"
+
+bash -n "${BACKEND_DIR}/scripts/pr66_accept.sh"
+bash -n "${BACKEND_DIR}/scripts/pr66_verify.sh"
+
+cd "${BACKEND_DIR}"
+composer install --no-interaction --no-progress
+php artisan migrate:fresh --force
+cd "${REPO_DIR}"
+
+ART_DIR="${ART_DIR}" SERVE_PORT="${SERVE_PORT}" bash "${BACKEND_DIR}/scripts/pr66_verify.sh"
+
+if [[ ! -f "${ART_DIR}/verify_done.txt" ]]; then
+  echo "[PR66][ACCEPT][FAIL] verify_done.txt not found" >&2
+  exit 1
+fi
+
+GATE_MIGRATION_SAFETY="FAIL"
+if grep -E "PASS[[:space:]]+Tests\\\\Unit\\\\Migrations\\\\MigrationSafetyTest" "${ART_DIR}/unit_tests.log" >/dev/null 2>&1; then
+  GATE_MIGRATION_SAFETY="PASS"
+fi
+
+GATE_ROLLBACK="FAIL"
+if grep -E "PASS[[:space:]]+Tests\\\\Unit\\\\Migrations\\\\MigrationRollbackSafetyTest" "${ART_DIR}/unit_tests.log" >/dev/null 2>&1; then
+  GATE_ROLLBACK="PASS"
+fi
+
+GATE_NO_SILENT_CATCH="FAIL"
+if grep -E "PASS[[:space:]]+Tests\\\\Unit\\\\Migrations\\\\MigrationNoSilentCatchTest" "${ART_DIR}/unit_tests.log" >/dev/null 2>&1; then
+  GATE_NO_SILENT_CATCH="PASS"
+fi
+
+{
+  echo "PR66 Acceptance Summary"
+  echo "- pass_items:"
+  echo "  - sqlite_migrate_fresh: PASS"
+  echo "  - migration_lint: PASS"
+  echo "  - unit_testsuite: PASS"
+  echo "  - pr66_verify: PASS"
+  echo "- key_outputs:"
+  echo "  - serve_port: ${SERVE_PORT}"
+  echo "  - verify_log: ${ART_DIR}/verify.log"
+  echo "  - unit_tests_log: ${ART_DIR}/unit_tests.log"
+  echo "  - migration_lint_log: ${ART_DIR}/migration_lint.log"
+  echo "  - drop_hits: ${ART_DIR}/dropifexists_hits.txt"
+  echo "  - catch_hits: ${ART_DIR}/catch_hits.txt"
+  echo "- migration_fix_targets:"
+  echo "  - backend/database/migrations/2025_12_17_165938_create_events_table.php"
+  echo "  - backend/database/migrations/2026_01_22_090010_create_orders_table.php"
+  echo "  - backend/database/migrations/2026_01_22_090020_create_benefit_grants_table.php"
+  echo "  - backend/database/migrations/2026_01_22_090030_create_payment_events_table.php"
+  echo "  - backend/database/migrations/2026_01_28_120000_create_ai_insights_table.php"
+  echo "  - backend/database/migrations/2026_01_28_120100_create_ai_insight_feedback_table.php"
+  echo "  - backend/database/migrations/2026_01_29_090000_create_scales_registry_table.php"
+  echo "  - backend/database/migrations/2026_01_29_090010_create_scale_slugs_table.php"
+  echo "  - backend/database/migrations/2026_02_08_040000_create_migration_index_audits_table.php"
+  echo "- gate_tests:"
+  echo "  - MigrationSafetyTest: ${GATE_MIGRATION_SAFETY}"
+  echo "  - MigrationRollbackSafetyTest: ${GATE_ROLLBACK}"
+  echo "  - MigrationNoSilentCatchTest: ${GATE_NO_SILENT_CATCH}"
+} > "${ART_DIR}/summary.txt"
+
+bash "${BACKEND_DIR}/scripts/sanitize_artifacts.sh" 66
+
+if grep -R -n -E "FAP_ADMIN_TOKEN=|Authorization: Bearer|BEGIN PRIVATE KEY|password=|DB_PASSWORD=|/Users/|/home/|/private/" "${ART_DIR}" >/dev/null; then
+  grep -R -n -E "FAP_ADMIN_TOKEN=|Authorization: Bearer|BEGIN PRIVATE KEY|password=|DB_PASSWORD=|/Users/|/home/|/private/" "${ART_DIR}" > "${ART_DIR}/sanitize_failures.txt" || true
+  cat "${ART_DIR}/sanitize_failures.txt" >&2 || true
+  echo "[PR66][ACCEPT][FAIL] artifact sanitization check failed" >&2
+  exit 1
+fi
+
+bash -n "${BACKEND_DIR}/scripts/pr66_accept.sh"
+bash -n "${BACKEND_DIR}/scripts/pr66_verify.sh"
+
+echo "[PR66][ACCEPT] pass"

--- a/backend/scripts/pr66_verify.sh
+++ b/backend/scripts/pr66_verify.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+export CI=true
+export FAP_NONINTERACTIVE=1
+export COMPOSER_NO_INTERACTION=1
+export GIT_TERMINAL_PROMPT=0
+export NO_COLOR=1
+export PAGER=cat
+export GIT_PAGER=cat
+export TERM=dumb
+export XDEBUG_MODE=off
+export LANG=en_US.UTF-8
+
+REPO_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+BACKEND_DIR="${REPO_DIR}/backend"
+ART_DIR="${ART_DIR:-${BACKEND_DIR}/artifacts/pr66}"
+
+mkdir -p "${ART_DIR}"
+exec > "${ART_DIR}/verify.log" 2>&1
+
+echo "[PR66][VERIFY] start"
+
+find "${BACKEND_DIR}/database/migrations" -name '*.php' -print0 | xargs -0 -n1 php -l > "${ART_DIR}/migration_lint.log"
+
+cd "${BACKEND_DIR}"
+php artisan test --testsuite=Unit | tee "${ART_DIR}/unit_tests.log"
+cd "${REPO_DIR}"
+
+grep -R -n -E "Schema::dropIfExists\(|Schema::drop\(" "${BACKEND_DIR}/database/migrations" | tee "${ART_DIR}/dropifexists_hits.txt" || true
+grep -R -n -E "catch[[:space:]]*\([[:space:]]*\\?Throwable|catch[[:space:]]*\([[:space:]]*\\?Exception" "${BACKEND_DIR}/database/migrations" | tee "${ART_DIR}/catch_hits.txt" || true
+
+echo "verify=pass" > "${ART_DIR}/verify_done.txt"
+echo "[PR66][VERIFY] pass"

--- a/backend/tests/Unit/Migrations/MigrationSafetyTest.php
+++ b/backend/tests/Unit/Migrations/MigrationSafetyTest.php
@@ -1,0 +1,241 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Migrations;
+
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+final class MigrationSafetyTest extends TestCase
+{
+    #[Test]
+    public function migration_catch_blocks_must_not_be_empty_after_comment_strip(): void
+    {
+        foreach ($this->migrationFiles() as $filePath) {
+            $source = (string) file_get_contents($filePath);
+
+            foreach ($this->extractCatchBodies($source) as $catchBlock) {
+                $signature = $catchBlock['signature'];
+                if (!$this->isThrowableOrExceptionCatch($signature)) {
+                    continue;
+                }
+
+                $bodyWithoutComments = trim($this->stripComments($catchBlock['body']));
+                $this->assertNotSame('', $bodyWithoutComments, "Empty catch block found in {$filePath}");
+            }
+        }
+    }
+
+    #[Test]
+    public function pseudo_create_migrations_must_not_drop_tables_in_down(): void
+    {
+        foreach ($this->migrationFiles() as $filePath) {
+            if (!str_contains(basename($filePath), 'create_')) {
+                continue;
+            }
+
+            $source = (string) file_get_contents($filePath);
+            $upBody = $this->methodBody($source, 'up');
+            $downBody = $this->methodBody($source, 'down');
+
+            if ($upBody === null || $downBody === null) {
+                continue;
+            }
+
+            $upBodyWithoutComments = $this->stripComments($upBody);
+            $downBodyWithoutComments = $this->stripComments($downBody);
+            $hasHasTableGuard = str_contains($upBodyWithoutComments, 'Schema::hasTable(')
+                && preg_match('/\breturn\s*;/', $upBodyWithoutComments) === 1;
+            $hasDropStatement = preg_match('/\bSchema::dropIfExists\s*\(/', $downBodyWithoutComments) === 1
+                || preg_match('/\bSchema::drop\s*\(/', $downBodyWithoutComments) === 1;
+
+            if ($hasHasTableGuard) {
+                $this->assertFalse(
+                    $hasDropStatement,
+                    "Pseudo-create migration must not drop table in down(): {$filePath}"
+                );
+            }
+        }
+    }
+
+    /**
+     * @return array<int, string>
+     */
+    private function migrationFiles(): array
+    {
+        $files = glob(base_path('database/migrations/*.php'));
+
+        if (!is_array($files)) {
+            return [];
+        }
+
+        sort($files);
+
+        return array_values($files);
+    }
+
+    /**
+     * @return array<int, array{signature: string, body: string}>
+     */
+    private function extractCatchBodies(string $source): array
+    {
+        $tokens = token_get_all($source);
+        $blocks = [];
+        $count = count($tokens);
+
+        for ($i = 0; $i < $count; $i++) {
+            $token = $tokens[$i];
+            if (!is_array($token) || $token[0] !== T_CATCH) {
+                continue;
+            }
+
+            $signature = '';
+            $i++;
+            while ($i < $count && $this->tokenText($tokens[$i]) !== '{') {
+                $signature .= $this->tokenText($tokens[$i]);
+                $i++;
+            }
+
+            if ($i >= $count || $this->tokenText($tokens[$i]) !== '{') {
+                continue;
+            }
+
+            $braceDepth = 1;
+            $i++;
+            $body = '';
+
+            for (; $i < $count; $i++) {
+                $text = $this->tokenText($tokens[$i]);
+
+                if ($text === '{') {
+                    $braceDepth++;
+                    $body .= $text;
+                    continue;
+                }
+
+                if ($text === '}') {
+                    $braceDepth--;
+                    if ($braceDepth === 0) {
+                        break;
+                    }
+                    $body .= $text;
+                    continue;
+                }
+
+                $body .= $text;
+            }
+
+            $blocks[] = [
+                'signature' => $signature,
+                'body' => $body,
+            ];
+        }
+
+        return $blocks;
+    }
+
+    private function methodBody(string $source, string $methodName): ?string
+    {
+        $tokens = token_get_all($source);
+        $count = count($tokens);
+
+        for ($i = 0; $i < $count; $i++) {
+            $token = $tokens[$i];
+            if (!is_array($token) || $token[0] !== T_FUNCTION) {
+                continue;
+            }
+
+            $name = null;
+            for ($j = $i + 1; $j < $count; $j++) {
+                $next = $tokens[$j];
+                if (is_array($next) && $next[0] === T_STRING) {
+                    $name = $next[1];
+                    $i = $j;
+                    break;
+                }
+            }
+
+            if ($name !== $methodName) {
+                continue;
+            }
+
+            while ($i < $count && $this->tokenText($tokens[$i]) !== '{') {
+                $i++;
+            }
+
+            if ($i >= $count || $this->tokenText($tokens[$i]) !== '{') {
+                return null;
+            }
+
+            $braceDepth = 1;
+            $i++;
+            $body = '';
+
+            for (; $i < $count; $i++) {
+                $text = $this->tokenText($tokens[$i]);
+
+                if ($text === '{') {
+                    $braceDepth++;
+                    $body .= $text;
+                    continue;
+                }
+
+                if ($text === '}') {
+                    $braceDepth--;
+                    if ($braceDepth === 0) {
+                        return $body;
+                    }
+                    $body .= $text;
+                    continue;
+                }
+
+                $body .= $text;
+            }
+
+            return null;
+        }
+
+        return null;
+    }
+
+    /**
+     * @param string|array{int, string, int} $token
+     */
+    private function tokenText(string|array $token): string
+    {
+        if (is_string($token)) {
+            return $token;
+        }
+
+        return $token[1];
+    }
+
+    private function isThrowableOrExceptionCatch(string $signature): bool
+    {
+        return preg_match('/\\\\?(Throwable|Exception)\b/', $signature) === 1;
+    }
+
+    private function stripComments(string $source): string
+    {
+        $code = str_starts_with(ltrim($source), '<?php') ? $source : "<?php\n{$source}";
+        $tokens = token_get_all($code);
+        $output = '';
+
+        foreach ($tokens as $token) {
+            if (is_string($token)) {
+                $output .= $token;
+                continue;
+            }
+
+            $tokenId = $token[0];
+            if ($tokenId === T_COMMENT || $tokenId === T_DOC_COMMENT || $tokenId === T_OPEN_TAG) {
+                continue;
+            }
+
+            $output .= $token[1];
+        }
+
+        return $output;
+    }
+}

--- a/docs/verify/pr66_recon.md
+++ b/docs/verify/pr66_recon.md
@@ -1,0 +1,24 @@
+# PR66 Recon
+
+- Keywords: migrations|dropIfExists|catch
+- Scope:
+  - backend/database/migrations/*.php
+  - backend/tests/Unit/Migrations/MigrationSafetyTest.php
+
+## Findings
+- pseudo-create migration with executable `Schema::dropIfExists(...)` in `down()`: 0
+- pseudo-create migration with executable `Schema::drop(...)` in `down()`: 5
+- empty catch blocks in migrations: 0
+- `2026_01_27_210000_pr9_add_observability_columns_to_events.php` used non-empty try/catch around index DDL; switched to fail-fast direct execution.
+
+## Targets
+- Pseudo-create migrations (`create_*.php` + `up()` has `Schema::hasTable(...)` guard and return):
+  - `down()` must be no-op with safety comment.
+  - no executable `Schema::dropIfExists(...)` or `Schema::drop(...)`.
+- Migrations catch policy:
+  - no empty catch blocks.
+  - observability migration remove suppression-style try/catch and fail-fast.
+
+## Safety Rule
+- Down for pseudo-create should keep this comment:
+  - `// Safety: Down is a no-op to prevent accidental data loss.`

--- a/docs/verify/pr66_verify.md
+++ b/docs/verify/pr66_verify.md
@@ -1,0 +1,56 @@
+# PR66 Verify
+
+## Step 1: routes/api.php (verify only)
+```bash
+cd /Users/rainie/Desktop/GitHub/fap-api/backend
+php artisan route:list
+```
+
+## Step 2: migrations
+```bash
+cd /Users/rainie/Desktop/GitHub/fap-api
+find backend/database/migrations -name '*.php' -print0 | xargs -0 -n1 php -l
+
+cd /Users/rainie/Desktop/GitHub/fap-api/backend
+php artisan migrate --force
+rm -f /tmp/pr66_step2.sqlite && touch /tmp/pr66_step2.sqlite
+DB_CONNECTION=sqlite DB_DATABASE=/tmp/pr66_step2.sqlite php artisan migrate:fresh --force
+rm -f /tmp/pr66_step2.sqlite
+```
+
+## Step 3: FmTokenAuth.php (verify only)
+```bash
+cd /Users/rainie/Desktop/GitHub/fap-api
+php -l backend/app/Http/Middleware/FmTokenAuth.php
+grep -n -E "DB::table\('fm_tokens'\)|DB::table\(\"fm_tokens\"\)" backend/app/Http/Middleware/FmTokenAuth.php
+grep -n -E "attributes->set\('fm_user_id'|attributes->set\(\"fm_user_id\"" backend/app/Http/Middleware/FmTokenAuth.php
+```
+
+## Step 4: unit gates
+```bash
+cd /Users/rainie/Desktop/GitHub/fap-api/backend
+php artisan test --filter MigrationSafetyTest
+php artisan test --filter MigrationRollbackSafetyTest
+php artisan test --filter MigrationNoSilentCatchTest
+```
+
+## Step 5: scripts/CI
+```bash
+cd /Users/rainie/Desktop/GitHub/fap-api
+bash -n backend/scripts/pr66_verify.sh
+bash -n backend/scripts/pr66_accept.sh
+bash backend/scripts/pr66_accept.sh
+bash backend/scripts/ci_verify_mbti.sh
+```
+
+## Curl example
+```bash
+curl -sS -i http://127.0.0.1:1866/api/v0.2/healthz || true
+```
+
+## Artifacts
+- backend/artifacts/pr66/summary.txt
+- backend/artifacts/pr66/unit_tests.log
+- backend/artifacts/pr66/migration_lint.log
+- backend/artifacts/pr66/dropifexists_hits.txt
+- backend/artifacts/pr66/catch_hits.txt


### PR DESCRIPTION
What:

Harden migration safety: rollback no longer drops core tables for pseudo-create migrations; remove silent try/catch suppression to enforce fail-fast schema changes.
Why:

Prevent catastrophic production data loss from “drop table on rollback” in patch-style create migrations.
Prevent schema drift by disallowing empty catch blocks that hide migration failures.
How:

[*.php](app://-/index.html#): comment out/replace drop behavior in pseudo-create down() and add safety comment.
[2026_01_27_210000_pr9_add_observability_columns_to_events.php](app://-/index.html#): remove try/catch suppression for index operations.
[MigrationSafetyTest.php](app://-/index.html#): guardrails for empty catch blocks and unsafe pseudo-create down() drops.
[pr66_accept.sh](app://-/index.html#) and [pr66_verify.sh](app://-/index.html#): non-interactive acceptance and artifacts output.
Verify:

[pr66_accept.sh](app://-/index.html#)
Artifacts:

[summary.txt](app://-/index.html#)