### PR TITLE
chore(pr68): CI lock PHP 8.4 and enforce composer validate/audit gates

### DIFF
--- a/.github/workflows/ci_dlq_replay_metrics.yml
+++ b/.github/workflows/ci_dlq_replay_metrics.yml
@@ -32,7 +32,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: "8.4"
+          php-version: '8.4'
           coverage: none
           tools: composer:v2
           extensions: >

--- a/.github/workflows/ci_pr55_migration_observability.yml
+++ b/.github/workflows/ci_pr55_migration_observability.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: "8.4"
+          php-version: '8.4'
           coverage: none
           tools: composer:v2
           extensions: >

--- a/.github/workflows/ci_pr56_workflow_composer_php84.yml
+++ b/.github/workflows/ci_pr56_workflow_composer_php84.yml
@@ -47,15 +47,19 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: "8.4"
+          php-version: '8.4'
           tools: composer:v2
           extensions: mbstring, xml, curl, zip, intl, sqlite, pdo_sqlite
+
+      - name: Install dependencies
+        working-directory: backend
+        run: composer install --no-interaction --prefer-dist --no-progress
 
       - name: Verify workflow PHP84 + composer security checks
         run: |
           set -euo pipefail
           for wf in $(grep -R -l -E 'shivammathur/setup-php@v2' .github/workflows); do
-            grep -E 'php-version:[[:space:]]*"8.4"' "${wf}" >/dev/null
+            grep -E "^[[:space:]]*php-version:[[:space:]]*['\"]?8\\.4" "${wf}" >/dev/null
           done
 
           for wf in $(grep -R -l -E 'composer[[:space:]]+install' .github/workflows); do
@@ -63,11 +67,13 @@ jobs:
             grep -E 'composer[[:space:]]+audit[[:space:]]+--no-interaction' "${wf}" >/dev/null
           done
 
-      - name: Composer validate & audit
+      - name: Composer validate (strict)
         working-directory: backend
-        run: |
-          composer validate --strict
-          composer audit --no-interaction
+        run: composer validate --strict
+
+      - name: Composer audit (CVE scan)
+        working-directory: backend
+        run: composer audit --no-interaction
 
       - name: Prepare sqlite
         run: |

--- a/.github/workflows/ci_verify_commerce_v2.yml
+++ b/.github/workflows/ci_verify_commerce_v2.yml
@@ -52,7 +52,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: "8.4"
+          php-version: '8.4'
           extensions: mbstring, xml, curl, zip, intl, sqlite, pdo_sqlite, mysql, pdo_mysql
 
       - name: Wait for mysql

--- a/.github/workflows/ci_verify_mbti.yml
+++ b/.github/workflows/ci_verify_mbti.yml
@@ -42,7 +42,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: "8.4"
+          php-version: '8.4'
           coverage: none
           tools: composer:v2
           extensions: >

--- a/.github/workflows/ci_verify_pr20_report_paywall.yml
+++ b/.github/workflows/ci_verify_pr20_report_paywall.yml
@@ -50,7 +50,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: "8.4"
+          php-version: '8.4'
           extensions: mbstring, xml, curl, zip, intl, sqlite, pdo_sqlite, mysql, pdo_mysql
 
       - name: Wait for mysql

--- a/.github/workflows/ci_verify_pr21_answer_storage.yml
+++ b/.github/workflows/ci_verify_pr21_answer_storage.yml
@@ -33,7 +33,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: "8.4"
+          php-version: '8.4'
           extensions: mbstring, xml, curl, zip, intl, sqlite, pdo_sqlite
 
       - name: Prepare sqlite

--- a/.github/workflows/ci_verify_pr22_boot_v0_4.yml
+++ b/.github/workflows/ci_verify_pr22_boot_v0_4.yml
@@ -38,14 +38,21 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: "8.4"
+          php-version: '8.4'
           tools: composer:v2
           extensions: mbstring, xml, curl, zip, intl, sqlite, pdo_sqlite
 
-      - name: Composer security audit
-        run: |
-          cd backend
-          composer audit --locked --no-interaction
+      - name: Install dependencies
+        working-directory: backend
+        run: composer install --no-interaction --prefer-dist --no-progress
+
+      - name: Composer validate (strict)
+        working-directory: backend
+        run: composer validate --strict
+
+      - name: Composer audit (CVE scan)
+        working-directory: backend
+        run: composer audit --no-interaction
 
       - name: Prepare sqlite
         run: |

--- a/.github/workflows/ci_verify_pr23_feature_flags_sticky_experiments.yml
+++ b/.github/workflows/ci_verify_pr23_feature_flags_sticky_experiments.yml
@@ -38,14 +38,21 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: "8.4"
+          php-version: '8.4'
           tools: composer:v2
           extensions: mbstring, xml, curl, zip, intl, sqlite, pdo_sqlite
 
-      - name: Composer security audit
-        run: |
-          cd backend
-          composer audit --locked --no-interaction
+      - name: Install dependencies
+        working-directory: backend
+        run: composer install --no-interaction --prefer-dist --no-progress
+
+      - name: Composer validate (strict)
+        working-directory: backend
+        run: composer validate --strict
+
+      - name: Composer audit (CVE scan)
+        working-directory: backend
+        run: composer audit --no-interaction
 
       - name: Prepare sqlite
         run: |

--- a/.github/workflows/ci_verify_pr24_sitemap.yml
+++ b/.github/workflows/ci_verify_pr24_sitemap.yml
@@ -41,14 +41,21 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: "8.4"
+          php-version: '8.4'
           tools: composer:v2
           extensions: mbstring, xml, curl, zip, intl, sqlite, pdo_sqlite
 
-      - name: Composer security audit
-        run: |
-          cd backend
-          composer audit --locked --no-interaction
+      - name: Install dependencies
+        working-directory: backend
+        run: composer install --no-interaction --prefer-dist --no-progress
+
+      - name: Composer validate (strict)
+        working-directory: backend
+        run: composer validate --strict
+
+      - name: Composer audit (CVE scan)
+        working-directory: backend
+        run: composer audit --no-interaction
 
       - name: Prepare sqlite
         run: |

--- a/.github/workflows/ci_verify_pr25_b2b_assessments_progress_rbac.yml
+++ b/.github/workflows/ci_verify_pr25_b2b_assessments_progress_rbac.yml
@@ -39,14 +39,21 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: "8.4"
+          php-version: '8.4'
           tools: composer:v2
           extensions: mbstring, xml, curl, zip, intl, sqlite, pdo_sqlite
 
-      - name: Composer security audit
-        run: |
-          cd backend
-          composer audit --locked --no-interaction
+      - name: Install dependencies
+        working-directory: backend
+        run: composer install --no-interaction --prefer-dist --no-progress
+
+      - name: Composer validate (strict)
+        working-directory: backend
+        run: composer validate --strict
+
+      - name: Composer audit (CVE scan)
+        working-directory: backend
+        run: composer audit --no-interaction
 
       - name: Prepare sqlite
         run: |

--- a/.github/workflows/ci_verify_scales_registry.yml
+++ b/.github/workflows/ci_verify_scales_registry.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: "8.4"
+          php-version: '8.4'
           coverage: none
           tools: composer:v2
           extensions: >

--- a/.github/workflows/ci_verify_v0_3_assessment_engine.yml
+++ b/.github/workflows/ci_verify_v0_3_assessment_engine.yml
@@ -39,7 +39,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: "8.4"
+          php-version: '8.4'
           coverage: none
           tools: composer:v2
           extensions: >

--- a/.github/workflows/selfcheck.yml
+++ b/.github/workflows/selfcheck.yml
@@ -47,7 +47,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: "8.4"
+          php-version: '8.4'
           tools: composer:v2
 
       - name: Cache Composer

--- a/backend/artifacts/pr68/summary.txt
+++ b/backend/artifacts/pr68/summary.txt
@@ -1,0 +1,25 @@
+PR68 Acceptance Summary
+- pass_items:
+  - composer_install: PASS
+  - composer_validate_strict: PASS
+  - composer_audit_no_interaction: PASS
+  - pr68_verify: PASS
+- key_assertions:
+  - php_version_84_hits_file: <REPO>
+  - php_version_non84_hits_file: <REPO>
+  - composer_gate_report: <REPO>
+- workflow_changes:
+.github/workflows/ci_dlq_replay_metrics.yml
+.github/workflows/ci_pr55_migration_observability.yml
+.github/workflows/ci_pr56_workflow_composer_php84.yml
+.github/workflows/ci_verify_commerce_v2.yml
+.github/workflows/ci_verify_mbti.yml
+.github/workflows/ci_verify_pr20_report_paywall.yml
+.github/workflows/ci_verify_pr21_answer_storage.yml
+.github/workflows/ci_verify_pr22_boot_v0_4.yml
+.github/workflows/ci_verify_pr23_feature_flags_sticky_experiments.yml
+.github/workflows/ci_verify_pr24_sitemap.yml
+.github/workflows/ci_verify_pr25_b2b_assessments_progress_rbac.yml
+.github/workflows/ci_verify_scales_registry.yml
+.github/workflows/ci_verify_v0_3_assessment_engine.yml
+.github/workflows/selfcheck.yml

--- a/backend/scripts/pr56_verify.sh
+++ b/backend/scripts/pr56_verify.sh
@@ -35,8 +35,9 @@ COMPOSER_PLATFORM_FILE="${ART_DIR}/composer_platform_php.txt"
 
 find "${REPO_DIR}/.github/workflows" -type f \( -name "*.yml" -o -name "*.yaml" \) | sort >"${WORKFLOW_LIST}"
 
-# Check 1: all workflow php-version lines must be 8.4.
-grep -R -n -E 'php-version:' "${REPO_DIR}/.github/workflows" >"${WORKFLOW_PHP_VERSION_LINES}" || true
+# Check 1: all workflow php-version config lines must be 8.4.
+# Restrict to YAML key lines to avoid matching shell grep commands in workflow scripts.
+grep -R -n -E '^[[:space:]]*php-version:' "${REPO_DIR}/.github/workflows" >"${WORKFLOW_PHP_VERSION_LINES}" || true
 if [ ! -s "${WORKFLOW_PHP_VERSION_LINES}" ]; then
   fail "no php-version lines found in workflows"
 fi

--- a/backend/scripts/pr68_accept.sh
+++ b/backend/scripts/pr68_accept.sh
@@ -1,0 +1,83 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+export CI=true
+export FAP_NONINTERACTIVE=1
+export COMPOSER_NO_INTERACTION=1
+export GIT_TERMINAL_PROMPT=0
+export NO_COLOR=1
+export PAGER=cat
+export GIT_PAGER=cat
+export TERM=dumb
+export XDEBUG_MODE=off
+export LANG=en_US.UTF-8
+
+REPO_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+BACKEND_DIR="${REPO_DIR}/backend"
+ART_DIR="${BACKEND_DIR}/artifacts/pr68"
+SERVE_PORT="${SERVE_PORT:-1868}"
+
+mkdir -p "${ART_DIR}"
+exec > "${ART_DIR}/pr68_accept.log" 2>&1
+
+cleanup_port() {
+  local port="$1"
+  lsof -nP -iTCP:"${port}" -sTCP:LISTEN || true
+  local pid_list
+  pid_list="$(lsof -ti tcp:"${port}" || true)"
+  if [ -n "${pid_list}" ]; then
+    echo "${pid_list}" | xargs kill -9 || true
+  fi
+  lsof -nP -iTCP:"${port}" -sTCP:LISTEN || true
+}
+
+cleanup() {
+  cleanup_port "${SERVE_PORT}"
+  cleanup_port 18000
+}
+trap cleanup EXIT
+
+cleanup_port "${SERVE_PORT}"
+cleanup_port 18000
+
+bash -n "${BACKEND_DIR}/scripts/pr68_accept.sh"
+bash -n "${BACKEND_DIR}/scripts/pr68_verify.sh"
+
+cd "${BACKEND_DIR}"
+composer install --no-interaction --no-progress | tee "${ART_DIR}/composer_install.txt"
+composer validate --strict | tee "${ART_DIR}/composer_validate.txt"
+composer audit --no-interaction | tee "${ART_DIR}/composer_audit.txt"
+cd "${REPO_DIR}"
+
+ART_DIR="${ART_DIR}" bash "${BACKEND_DIR}/scripts/pr68_verify.sh"
+
+git --no-pager diff --name-only -- .github/workflows > "${ART_DIR}/workflow_changed_files.txt" || true
+
+{
+  echo "PR68 Acceptance Summary"
+  echo "- pass_items:"
+  echo "  - composer_install: PASS"
+  echo "  - composer_validate_strict: PASS"
+  echo "  - composer_audit_no_interaction: PASS"
+  echo "  - pr68_verify: PASS"
+  echo "- key_assertions:"
+  echo "  - php_version_84_hits_file: ${ART_DIR}/workflow_php_version_84.txt"
+  echo "  - php_version_non84_hits_file: ${ART_DIR}/workflow_php_version_non84.txt"
+  echo "  - composer_gate_report: ${ART_DIR}/workflow_composer_gate_report.txt"
+  echo "- workflow_changes:"
+  cat "${ART_DIR}/workflow_changed_files.txt"
+} > "${ART_DIR}/summary.txt"
+
+test -f "${BACKEND_DIR}/scripts/sanitize_artifacts.sh" && bash "${BACKEND_DIR}/scripts/sanitize_artifacts.sh" 68 || true
+
+if grep -R -n -E "FAP_ADMIN_TOKEN=|Authorization: Bearer|BEGIN PRIVATE KEY|password=|DB_PASSWORD=|/Users/|/home/|/private/" "${ART_DIR}" >/dev/null; then
+  grep -R -n -E "FAP_ADMIN_TOKEN=|Authorization: Bearer|BEGIN PRIVATE KEY|password=|DB_PASSWORD=|/Users/|/home/|/private/" "${ART_DIR}" > "${ART_DIR}/sanitize_failures.txt" || true
+  cat "${ART_DIR}/sanitize_failures.txt" >&2 || true
+  echo "[PR68][ACCEPT][FAIL] artifact sanitization check failed" >&2
+  exit 1
+fi
+
+bash -n "${BACKEND_DIR}/scripts/pr68_accept.sh"
+bash -n "${BACKEND_DIR}/scripts/pr68_verify.sh"
+
+echo "[PR68][ACCEPT] pass"

--- a/backend/scripts/pr68_verify.sh
+++ b/backend/scripts/pr68_verify.sh
@@ -1,0 +1,70 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+export CI=true
+export FAP_NONINTERACTIVE=1
+export COMPOSER_NO_INTERACTION=1
+export GIT_TERMINAL_PROMPT=0
+export NO_COLOR=1
+export PAGER=cat
+export GIT_PAGER=cat
+export TERM=dumb
+export XDEBUG_MODE=off
+export LANG=en_US.UTF-8
+
+REPO_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+BACKEND_DIR="${REPO_DIR}/backend"
+ART_DIR="${ART_DIR:-${BACKEND_DIR}/artifacts/pr68}"
+WORKFLOW_DIR="${REPO_DIR}/.github/workflows"
+
+mkdir -p "${ART_DIR}"
+exec > "${ART_DIR}/verify.log" 2>&1
+
+fail() {
+  echo "[PR68][VERIFY][FAIL] $*"
+  exit 1
+}
+
+echo "[PR68][VERIFY] start"
+
+WORKFLOW_LIST="${ART_DIR}/workflows_list.txt"
+WORKFLOW_PHP84="${ART_DIR}/workflow_php_version_84.txt"
+WORKFLOW_NON84="${ART_DIR}/workflow_php_version_non84.txt"
+WORKFLOW_INSTALL_FILES="${ART_DIR}/workflow_composer_install_files.txt"
+WORKFLOW_GATE_REPORT="${ART_DIR}/workflow_composer_gate_report.txt"
+
+find "${WORKFLOW_DIR}" -type f \( -name "*.yml" -o -name "*.yaml" \) | sort > "${WORKFLOW_LIST}"
+
+grep -R -n -E "^[[:space:]]*php-version:[[:space:]]*['\"]?8\\.4" "${WORKFLOW_DIR}" > "${WORKFLOW_PHP84}" || true
+if [ ! -s "${WORKFLOW_PHP84}" ]; then
+  fail "no php-version 8.4 lines found"
+fi
+
+grep -R -n -E "^[[:space:]]*php-version:[[:space:]]*['\"]?8\\.(0|1|2|3|5|6|7|8|9)" "${WORKFLOW_DIR}" > "${WORKFLOW_NON84}" || true
+if [ -s "${WORKFLOW_NON84}" ]; then
+  fail "found non-8.4 php-version lines; see ${WORKFLOW_NON84}"
+fi
+
+grep -R -l -E "composer[[:space:]]+install" "${WORKFLOW_DIR}" | sort > "${WORKFLOW_INSTALL_FILES}" || true
+if [ ! -s "${WORKFLOW_INSTALL_FILES}" ]; then
+  fail "no workflow contains composer install"
+fi
+
+: > "${WORKFLOW_GATE_REPORT}"
+while IFS= read -r wf; do
+  install_count="$(grep -c -E "composer[[:space:]]+install" "${wf}" || true)"
+  validate_count="$(grep -c -E "composer[[:space:]]+validate[[:space:]]+--strict" "${wf}" || true)"
+  audit_count="$(grep -c -E "composer[[:space:]]+audit[[:space:]]+--no-interaction" "${wf}" || true)"
+
+  echo "${wf}: install=${install_count} validate=${validate_count} audit=${audit_count}" >> "${WORKFLOW_GATE_REPORT}"
+
+  if [ "${validate_count}" -lt 1 ]; then
+    fail "missing composer validate --strict in ${wf}"
+  fi
+  if [ "${audit_count}" -lt 1 ]; then
+    fail "missing composer audit --no-interaction in ${wf}"
+  fi
+done < "${WORKFLOW_INSTALL_FILES}"
+
+echo "verify=pass" > "${ART_DIR}/verify_done.txt"
+echo "[PR68][VERIFY] pass"

--- a/docs/verify/pr68_recon.md
+++ b/docs/verify/pr68_recon.md
@@ -1,0 +1,86 @@
+# PR68 Recon
+
+- Keywords: php-version|composer validate|composer audit
+- 扫描范围：.github/workflows/*.yml 与 .github/workflows/*.yaml
+- 需要修复：
+  1) php-version 统一为 '8.4'
+  2) composer 门禁：composer install 之后、Run Tests 之前必须包含：
+     - composer validate --strict
+     - composer audit --no-interaction
+
+## 扫描输出（粘贴命令输出）
+- workflows 列表：
+- php-version 命中行：
+- composer install / validate / audit 命中行：
+
+## workflows 列表
+- .github/workflows/ci_dlq_replay_metrics.yml
+- .github/workflows/ci_pr55_migration_observability.yml
+- .github/workflows/ci_pr56_workflow_composer_php84.yml
+- .github/workflows/ci_verify_commerce_v2.yml
+- .github/workflows/ci_verify_mbti.yml
+- .github/workflows/ci_verify_pr20_report_paywall.yml
+- .github/workflows/ci_verify_pr21_answer_storage.yml
+- .github/workflows/ci_verify_pr22_boot_v0_4.yml
+- .github/workflows/ci_verify_pr23_feature_flags_sticky_experiments.yml
+- .github/workflows/ci_verify_pr24_sitemap.yml
+- .github/workflows/ci_verify_pr25_b2b_assessments_progress_rbac.yml
+- .github/workflows/ci_verify_scales_registry.yml
+- .github/workflows/ci_verify_v0_3_assessment_engine.yml
+- .github/workflows/deploy.yml
+- .github/workflows/publish-content.yml
+- .github/workflows/rollback-content.yml
+- .github/workflows/rollback-production.yml
+- .github/workflows/selfcheck.yml
+
+## php-version 命中行
+- .github/workflows/ci_verify_pr21_answer_storage.yml:36:          php-version: "8.4"
+- .github/workflows/ci_verify_pr25_b2b_assessments_progress_rbac.yml:42:          php-version: "8.4"
+- .github/workflows/ci_verify_mbti.yml:45:          php-version: "8.4"
+- .github/workflows/ci_pr55_migration_observability.yml:34:          php-version: "8.4"
+- .github/workflows/ci_dlq_replay_metrics.yml:35:          php-version: "8.4"
+- .github/workflows/ci_pr56_workflow_composer_php84.yml:50:          php-version: "8.4"
+- .github/workflows/ci_pr56_workflow_composer_php84.yml:58:            grep -E 'php-version:[[:space:]]*"8.4"' "${wf}" >/dev/null
+- .github/workflows/ci_verify_pr22_boot_v0_4.yml:41:          php-version: "8.4"
+- .github/workflows/ci_verify_pr24_sitemap.yml:44:          php-version: "8.4"
+- .github/workflows/ci_verify_pr20_report_paywall.yml:53:          php-version: "8.4"
+- .github/workflows/ci_verify_pr23_feature_flags_sticky_experiments.yml:41:          php-version: "8.4"
+- .github/workflows/ci_verify_commerce_v2.yml:55:          php-version: "8.4"
+- .github/workflows/ci_verify_v0_3_assessment_engine.yml:42:          php-version: "8.4"
+- .github/workflows/selfcheck.yml:50:          php-version: "8.4"
+- .github/workflows/ci_verify_scales_registry.yml:22:          php-version: "8.4"
+
+## composer install / validate / audit 命中行
+- .github/workflows/ci_verify_pr21_answer_storage.yml:56:        run: composer install --no-interaction --prefer-dist
+- .github/workflows/ci_verify_pr21_answer_storage.yml:61:          composer validate --strict
+- .github/workflows/ci_verify_pr21_answer_storage.yml:62:          composer audit --no-interaction
+- .github/workflows/ci_verify_pr25_b2b_assessments_progress_rbac.yml:49:          composer audit --locked --no-interaction
+- .github/workflows/ci_verify_mbti.yml:74:          composer install --no-interaction --prefer-dist --no-progress
+- .github/workflows/ci_verify_mbti.yml:79:          composer validate --strict
+- .github/workflows/ci_verify_mbti.yml:80:          composer audit --no-interaction
+- .github/workflows/ci_pr55_migration_observability.yml:53:          composer install --no-interaction --prefer-dist --no-progress
+- .github/workflows/ci_pr55_migration_observability.yml:58:          composer validate --strict
+- .github/workflows/ci_pr55_migration_observability.yml:59:          composer audit --no-interaction
+- .github/workflows/ci_dlq_replay_metrics.yml:54:          composer install --no-interaction --prefer-dist --no-progress
+- .github/workflows/ci_dlq_replay_metrics.yml:59:          composer validate --strict
+- .github/workflows/ci_dlq_replay_metrics.yml:60:          composer audit --no-interaction
+- .github/workflows/ci_pr56_workflow_composer_php84.yml:69:          composer validate --strict
+- .github/workflows/ci_pr56_workflow_composer_php84.yml:70:          composer audit --no-interaction
+- .github/workflows/ci_verify_pr22_boot_v0_4.yml:48:          composer audit --locked --no-interaction
+- .github/workflows/ci_verify_pr24_sitemap.yml:51:          composer audit --locked --no-interaction
+- .github/workflows/ci_verify_pr20_report_paywall.yml:76:        run: composer install --no-interaction --prefer-dist
+- .github/workflows/ci_verify_pr20_report_paywall.yml:81:          composer validate --strict
+- .github/workflows/ci_verify_pr20_report_paywall.yml:82:          composer audit --no-interaction
+- .github/workflows/ci_verify_pr23_feature_flags_sticky_experiments.yml:48:          composer audit --locked --no-interaction
+- .github/workflows/ci_verify_commerce_v2.yml:84:        run: composer install --no-interaction --prefer-dist
+- .github/workflows/ci_verify_commerce_v2.yml:89:          composer validate --strict
+- .github/workflows/ci_verify_commerce_v2.yml:90:          composer audit --no-interaction
+- .github/workflows/ci_verify_v0_3_assessment_engine.yml:71:          composer install --no-interaction --prefer-dist --no-progress
+- .github/workflows/ci_verify_v0_3_assessment_engine.yml:76:          composer validate --strict
+- .github/workflows/ci_verify_v0_3_assessment_engine.yml:77:          composer audit --no-interaction
+- .github/workflows/selfcheck.yml:74:        run: composer install --no-interaction --prefer-dist --no-progress
+- .github/workflows/selfcheck.yml:79:          composer validate --strict
+- .github/workflows/selfcheck.yml:80:          composer audit --no-interaction
+- .github/workflows/ci_verify_scales_registry.yml:51:          composer install --no-interaction --prefer-dist --no-progress
+- .github/workflows/ci_verify_scales_registry.yml:56:          composer validate --strict
+- .github/workflows/ci_verify_scales_registry.yml:57:          composer audit --no-interaction

--- a/docs/verify/pr68_verify.md
+++ b/docs/verify/pr68_verify.md
@@ -1,0 +1,65 @@
+# PR68 Verify
+
+## Step 1: routes/api.php (verify only)
+```bash
+cd /Users/rainie/Desktop/GitHub/fap-api/backend
+php artisan route:list
+```
+
+## Step 2: migrations (verify only)
+```bash
+cd /Users/rainie/Desktop/GitHub/fap-api/backend
+php artisan migrate --force
+```
+
+## Step 3: FmTokenAuth.php (verify only)
+```bash
+cd /Users/rainie/Desktop/GitHub/fap-api
+php -l backend/app/Http/Middleware/FmTokenAuth.php
+grep -n -E "DB::table\\('fm_tokens'\\)|attributes->set\\('fm_user_id'" backend/app/Http/Middleware/FmTokenAuth.php
+```
+
+## Step 4: PR68 static gate
+```bash
+cd /Users/rainie/Desktop/GitHub/fap-api
+bash backend/scripts/pr68_verify.sh
+```
+
+## Step 5: acceptance + CI chain
+```bash
+cd /Users/rainie/Desktop/GitHub/fap-api
+bash backend/scripts/pr68_accept.sh
+bash backend/scripts/ci_verify_mbti.sh
+```
+
+## Curl examples
+```bash
+curl -sS -i http://127.0.0.1:1868/api/v0.2/healthz || true
+curl -sS -i http://127.0.0.1:1868/api/v0.3/scales/MBTI/questions || true
+```
+
+## PASS Criteria
+- 无 php-version 非 8.4
+- 任意出现 composer install 的 workflow，同文件必含：
+  - composer validate --strict
+  - composer audit --no-interaction
+- 本地验收链全绿
+
+## 执行记录
+- Commands:
+  - `php artisan route:list`
+  - `php artisan migrate --force`
+  - `php -l backend/app/Http/Middleware/FmTokenAuth.php`
+  - `grep -n -E "DB::table\\('fm_tokens'\\)|attributes->set\\('fm_user_id'" backend/app/Http/Middleware/FmTokenAuth.php`
+  - `bash backend/scripts/pr68_accept.sh`
+  - `bash backend/scripts/ci_verify_mbti.sh`
+- Key assertion outputs:
+  - route list: `api/healthz`、`api/v0.2/admin/agent/disable-trigger` 等路由存在。
+  - migrate: `INFO  Nothing to migrate.`
+  - FmTokenAuth: `No syntax errors detected`，并命中 `DB::table('fm_tokens')` 与 `attributes->set('fm_user_id', ...)`。
+  - PR68 gate artifacts:
+    - `backend/artifacts/pr68/workflow_php_version_non84.txt` 为空（PASS）
+    - `backend/artifacts/pr68/workflow_php_version_84.txt` 命中 14 行（PASS）
+    - `backend/artifacts/pr68/workflow_composer_gate_report.txt` 中 14 个 workflow 全部 `install=1 validate=1 audit=1`（PASS）
+  - CI chain: `bash backend/scripts/ci_verify_mbti.sh` 返回 0（PASS）
+- PASS: 无 php-version 漂移、所有 composer install 之后必含 validate+audit


### PR DESCRIPTION
What:
Lock GitHub Actions PHP runtime to 8.4 across workflows.
Enforce supply-chain gates after composer install: composer validate --strict and composer audit --no-interaction.
Why:
Eliminate CI/production runtime drift.
Block vulnerable dependencies and invalid composer metadata at PR time.
How:
[*.yml](app://-/index.html#): php-version set to ['8.4'](app://-/index.html#), gates inserted before test/accept steps.
Added [pr68_accept.sh](app://-/index.html#) and [pr68_verify.sh](app://-/index.html#).
Added [pr68_recon.md](app://-/index.html#) and [pr68_verify.md](app://-/index.html#).
Added [summary.txt](app://-/index.html#).
Verify:
[pr68_accept.sh](app://-/index.html#)
[ci_verify_mbti.sh](app://-/index.html#)
Artifacts:
[summary.txt](app://-/index.html#)