### PR TITLE
test(migrations): add guarded-create rollback safety tests

### DIFF
--- a/backend/tests/Feature/Migrations/EventsGuardedCreateRollbackDoesNotDropTableTest.php
+++ b/backend/tests/Feature/Migrations/EventsGuardedCreateRollbackDoesNotDropTableTest.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Migrations;
+
+use Illuminate\Support\Facades\Artisan;
+use Illuminate\Support\Facades\Schema;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+final class EventsGuardedCreateRollbackDoesNotDropTableTest extends TestCase
+{
+    #[Test]
+    public function rollback_one_step_after_two_create_events_migrations_keeps_events_table(): void
+    {
+        Artisan::call('migrate', [
+            '--path' => 'database/migrations/2025_12_14_091106_create_events_table.php',
+            '--force' => true,
+        ]);
+
+        Artisan::call('migrate', [
+            '--path' => 'database/migrations/2025_12_17_165938_create_events_table.php',
+            '--force' => true,
+        ]);
+
+        Artisan::call('migrate:rollback', [
+            '--step' => 1,
+            '--force' => true,
+        ]);
+
+        $this->assertTrue(
+            Schema::hasTable('events'),
+            'events table must still exist after rolling back one guarded create migration step.'
+        );
+    }
+}

--- a/backend/tests/Unit/Migrations/GuardedCreateMigrationsNoDropTest.php
+++ b/backend/tests/Unit/Migrations/GuardedCreateMigrationsNoDropTest.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Migrations;
+
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+final class GuardedCreateMigrationsNoDropTest extends TestCase
+{
+    #[Test]
+    public function migration_file_must_not_contain_has_table_and_drop_if_exists_together(): void
+    {
+        $violations = [];
+
+        foreach ($this->migrationFiles() as $filePath) {
+            $source = (string) file_get_contents($filePath);
+
+            if (str_contains($source, 'Schema::hasTable') && str_contains($source, 'Schema::dropIfExists')) {
+                $violations[] = $filePath;
+            }
+        }
+
+        $this->assertSame(
+            [],
+            $violations,
+            "Found guarded-create rollback risk migrations:\n" . implode("\n", $violations)
+        );
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function migrationFiles(): array
+    {
+        $files = glob(base_path('database/migrations/*.php'));
+
+        if (!is_array($files)) {
+            return [];
+        }
+
+        sort($files);
+
+        return array_values($files);
+    }
+}


### PR DESCRIPTION
A. Changed files（本次提交）

Added:
[EventsGuardedCreateRollbackDoesNotDropTableTest.php](app://-/index.html#)
[GuardedCreateMigrationsNoDropTest.php](app://-/index.html#)
Modified: 无（本次提交）
B. Copy-paste blocks

本步骤仅执行 Git 操作（开分支/提交/推送/建 PR 链接），未新增代码编辑。
C. Minimal acceptance commands set（已跑）

php artisan route:list ✅
php artisan migrate ✅
curl -i http://127.0.0.1:8000/api/v0.2/healthz ✅ (200)
curl -i -X POST http://127.0.0.1:8000/api/v0.2/events ... ✅ (401, 鉴权预期)
[ci_verify_mbti.sh](app://-/index.html#) ✅