### PR TITLE
fix(api): harden request-id flow and runtime guard toggles

### DIFF
--- a/backend/app/Http/Middleware/AttachRequestId.php
+++ b/backend/app/Http/Middleware/AttachRequestId.php
@@ -3,6 +3,7 @@
 namespace App\Http\Middleware;
 
 use Closure;
+use Illuminate\Http\Exceptions\HttpResponseException;
 use Illuminate\Http\Request;
 use Illuminate\Support\Str;
 use Symfony\Component\HttpFoundation\Response;
@@ -27,7 +28,14 @@ class AttachRequestId
 
         $request->attributes->set('request_id', $requestId);
 
-        $response = $next($request);
+        try {
+            $response = $next($request);
+        } catch (HttpResponseException $e) {
+            $response = $e->getResponse();
+            $response->headers->set('X-Request-Id', $requestId);
+
+            throw $e;
+        }
         $response->headers->set('X-Request-Id', $requestId);
 
         return $response;

--- a/backend/app/Support/ApiExceptionRenderer.php
+++ b/backend/app/Support/ApiExceptionRenderer.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Support;
 
 use Illuminate\Database\Eloquent\ModelNotFoundException;
+use Illuminate\Http\Exceptions\HttpResponseException;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
 use Illuminate\Validation\ValidationException;
@@ -19,7 +20,7 @@ final class ApiExceptionRenderer
             return null;
         }
 
-        if ($e instanceof ValidationException) {
+        if ($e instanceof ValidationException || $e instanceof HttpResponseException) {
             return null;
         }
 

--- a/backend/bootstrap/app.php
+++ b/backend/bootstrap/app.php
@@ -37,6 +37,8 @@ return Application::configure(basePath: dirname(__DIR__))
             'uuid' => \App\Http\Middleware\EnsureUuidRouteParams::class,
         ]);
 
+        // Ensure every API response (including throttled responses) gets a request id header.
+        $middleware->prependToGroup('api', \App\Http\Middleware\AttachRequestId::class);
         $middleware->appendToGroup('api', \App\Http\Middleware\DetectRegion::class);
 
         // 你原来其他 middleware 配置保留

--- a/backend/config/fap.php
+++ b/backend/config/fap.php
@@ -45,6 +45,7 @@ return [
         'api_auth_per_minute' => (int) env('FAP_RATE_LIMIT_AUTH_PER_MINUTE', 30),
         'api_attempt_submit_per_minute' => (int) env('FAP_RATE_LIMIT_ATTEMPT_SUBMIT_PER_MINUTE', 20),
         'api_webhook_per_minute' => (int) env('FAP_RATE_LIMIT_WEBHOOK_PER_MINUTE', 60),
+        'bypass_in_test_env' => (bool) env('FAP_RATE_LIMIT_BYPASS_IN_TEST_ENV', true),
     ],
 
     'events' => [


### PR DESCRIPTION
## Summary
本 PR 聚焦 API 运行时稳健性与测试可控性，解决两类问题：
1. 限流/异常路径下 `X-Request-Id` 头不稳定。
2. 测试环境中的限流绕过与内容加载兜底开关在运行时不够可控，导致用例易抖动。

## Changes
- `bootstrap/app.php`
  - 将 `AttachRequestId` prepend 到 `api` middleware 组，确保包括 throttled 响应在内都能附带 `X-Request-Id`。
- `app/Http/Middleware/AttachRequestId.php`
  - 捕获 `HttpResponseException` 时给响应补 `X-Request-Id`，然后继续抛出，保持框架原有行为。
- `app/Support/ApiExceptionRenderer.php`
  - 对 `HttpResponseException` 返回 `null`，交由 Laravel 原生处理，避免覆盖 429 等响应。
- `app/Providers/AppServiceProvider.php`
  - 限流 bypass 从启动期固定布尔值改为运行时闭包判定。
  - 新增可配开关 `fap.rate_limits.bypass_in_test_env`（默认 `true`）。
- `config/fap.php`
  - 新增 `rate_limits.bypass_in_test_env` 配置项（映射 `FAP_RATE_LIMIT_BYPASS_IN_TEST_ENV`）。
- `app/Services/Content/ContentStore.php`
  - 新增运行时环境变量读取方法，替换对 `FAP_FORBID_STORE_ASSET_SCAN` / `FAP_FORBID_LEGACY_CTX_LOADER` 的静态读取，保证测试中动态开关即时生效。
- `tests/Feature/HealthzRateLimitTest.php`
  - 明确关闭测试限流绕过，固定测试 IP，清理 limiter key，稳定断言 429/`Retry-After`/`X-Request-Id`。
- `tests/Feature/HighlightBuilderBuildFromStoreTest.php`
  - 补齐 content config 覆盖。
  - 精准破坏 `report_highlights_templates.json` 对应 asset，避免随机破坏导致不稳定。

## Compatibility / Risk
- 不涉及 DB schema 变更。
- 不变更公开 API 路由与响应结构（仅增强响应头稳定性与运行时开关行为）。
- 风险点主要在限流策略与异常链路，已用 Feature 测试覆盖。

## Verification
已本地通过：
- `php artisan test --filter HealthzRateLimitTest`
- `php artisan test --filter HighlightBuilderBuildFromStoreTest`
- `php artisan route:list --path=api/v0.2/healthz`
- `php artisan migrate`
- `bash backend/scripts/ci_verify_mbti.sh`

## Branch / Commit
- branch: `codex/runtime-hardening-healthz-contentstore`
- commit: `7c1238d0db601d9751a2d5ec0b52f47f72336d39`
