### PR TITLE
fix(payments): isolate payment_events by provider and event id

### DIFF
--- a/backend/database/migrations/2026_02_08_000001_add_provider_composite_unique_to_payment_events.php
+++ b/backend/database/migrations/2026_02_08_000001_add_provider_composite_unique_to_payment_events.php
@@ -10,20 +10,34 @@ return new class extends Migration
 {
     private const TABLE = 'payment_events';
     private const OLD_UNIQUE = 'payment_events_provider_event_id_unique';
-    private const NEW_UNIQUE = 'payment_events_provider_provider_event_unique';
+    private const NEW_UNIQUE = 'payment_events_provider_provider_event_id_unique';
+    private const LEGACY_UNIQUE = 'payment_events_provider_provider_event_unique';
 
     public function up(): void
     {
         if (!Schema::hasTable(self::TABLE)) {
             return;
         }
-        if (!Schema::hasColumn(self::TABLE, 'provider') || !Schema::hasColumn(self::TABLE, 'provider_event_id')) {
+
+        if (!Schema::hasColumn(self::TABLE, 'provider')) {
+            Schema::table(self::TABLE, function (Blueprint $table) {
+                $table->string('provider', 50)->default('billing');
+            });
+        }
+
+        if (!Schema::hasColumn(self::TABLE, 'provider_event_id')) {
             return;
         }
 
         if (SchemaIndex::indexExists(self::TABLE, self::OLD_UNIQUE)) {
             Schema::table(self::TABLE, function (Blueprint $table) {
                 $table->dropUnique(self::OLD_UNIQUE);
+            });
+        }
+
+        if (SchemaIndex::indexExists(self::TABLE, self::LEGACY_UNIQUE)) {
+            Schema::table(self::TABLE, function (Blueprint $table) {
+                $table->dropUnique(self::LEGACY_UNIQUE);
             });
         }
 
@@ -39,6 +53,7 @@ return new class extends Migration
         if (!Schema::hasTable(self::TABLE)) {
             return;
         }
+
         if (!Schema::hasColumn(self::TABLE, 'provider_event_id')) {
             return;
         }

--- a/backend/database/migrations/2026_02_08_050000_scope_payment_event_uniqueness_by_provider.php
+++ b/backend/database/migrations/2026_02_08_050000_scope_payment_event_uniqueness_by_provider.php
@@ -1,92 +1,20 @@
 <?php
 
-use App\Support\Database\SchemaIndex;
 use Illuminate\Database\Migrations\Migration;
-use Illuminate\Database\Schema\Blueprint;
-use Illuminate\Support\Facades\DB;
-use Illuminate\Support\Facades\Schema;
 
 return new class extends Migration
 {
-    private const TABLE = 'payment_events';
-    private const OLD_UNIQUE = 'payment_events_provider_event_id_unique';
-    private const NEW_UNIQUE = 'payment_events_provider_provider_event_unique';
-
     public function up(): void
     {
-        if (!Schema::hasTable(self::TABLE)) {
-            return;
-        }
-        if (!Schema::hasColumn(self::TABLE, 'provider') || !Schema::hasColumn(self::TABLE, 'provider_event_id')) {
-            return;
-        }
-
-        $driver = DB::connection()->getDriverName();
-
-        if (SchemaIndex::indexExists(self::TABLE, self::OLD_UNIQUE)) {
-            try {
-                Schema::table(self::TABLE, function (Blueprint $table) {
-                    $table->dropUnique(self::OLD_UNIQUE);
-                });
-                SchemaIndex::logIndexAction('drop_unique', self::TABLE, self::OLD_UNIQUE, $driver, ['phase' => 'up']);
-            } catch (\Throwable $e) {
-                if (SchemaIndex::isMissingIndexException($e, self::OLD_UNIQUE)) {
-                    SchemaIndex::logIndexAction('drop_unique_skip_missing', self::TABLE, self::OLD_UNIQUE, $driver, ['phase' => 'up']);
-                } else {
-                    throw $e;
-                }
-            }
-        }
-
-        if (!SchemaIndex::indexExists(self::TABLE, self::NEW_UNIQUE)) {
-            Schema::table(self::TABLE, function (Blueprint $table) {
-                $table->unique(['provider', 'provider_event_id'], self::NEW_UNIQUE);
-            });
-            SchemaIndex::logIndexAction('create_unique', self::TABLE, self::NEW_UNIQUE, $driver, ['phase' => 'up']);
-        }
+        // Replaced by 2026_02_08_000001_add_provider_composite_unique_to_payment_events.php.
+        // Keep this migration for history consistency, but make execution a no-op
+        // to avoid duplicate index creation and migration non-determinism.
+        return;
     }
 
     public function down(): void
     {
-        if (!Schema::hasTable(self::TABLE)) {
-            return;
-        }
-        if (!Schema::hasColumn(self::TABLE, 'provider_event_id')) {
-            return;
-        }
-
-        $driver = DB::connection()->getDriverName();
-
-        if (SchemaIndex::indexExists(self::TABLE, self::NEW_UNIQUE)) {
-            try {
-                Schema::table(self::TABLE, function (Blueprint $table) {
-                    $table->dropUnique(self::NEW_UNIQUE);
-                });
-                SchemaIndex::logIndexAction('drop_unique', self::TABLE, self::NEW_UNIQUE, $driver, ['phase' => 'down']);
-            } catch (\Throwable $e) {
-                if (SchemaIndex::isMissingIndexException($e, self::NEW_UNIQUE)) {
-                    SchemaIndex::logIndexAction('drop_unique_skip_missing', self::TABLE, self::NEW_UNIQUE, $driver, ['phase' => 'down']);
-                } else {
-                    throw $e;
-                }
-            }
-        }
-
-        if (!SchemaIndex::indexExists(self::TABLE, self::OLD_UNIQUE)) {
-            $crossProviderDuplicates = DB::table(self::TABLE)
-                ->select('provider_event_id')
-                ->whereNotNull('provider_event_id')
-                ->groupBy('provider_event_id')
-                ->havingRaw('count(*) > 1')
-                ->limit(1)
-                ->exists();
-
-            if (!$crossProviderDuplicates) {
-                Schema::table(self::TABLE, function (Blueprint $table) {
-                    $table->unique('provider_event_id', self::OLD_UNIQUE);
-                });
-                SchemaIndex::logIndexAction('create_unique', self::TABLE, self::OLD_UNIQUE, $driver, ['phase' => 'down']);
-            }
-        }
+        // Intentionally no-op: rollback behavior is owned by 2026_02_08_000001 migration.
+        return;
     }
 };

--- a/backend/tests/Feature/V0_2/PaymentsMockWebhookProviderIsolationTest.php
+++ b/backend/tests/Feature/V0_2/PaymentsMockWebhookProviderIsolationTest.php
@@ -1,0 +1,117 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\V0_2;
+
+use App\Services\Payments\PaymentService;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Str;
+use Tests\TestCase;
+
+final class PaymentsMockWebhookProviderIsolationTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_mock_webhook_does_not_pollute_billing_row_when_provider_event_id_is_shared(): void
+    {
+        $orderId = (string) Str::uuid();
+        $providerOrderId = 'po_evt_shared';
+        $now = now();
+
+        DB::table('orders')->insert([
+            'id' => $orderId,
+            'user_id' => null,
+            'anon_id' => null,
+            'device_id' => null,
+            'provider' => 'mock',
+            'provider_order_id' => $providerOrderId,
+            'status' => 'pending',
+            'currency' => 'USD',
+            'amount_total' => 1000,
+            'amount_refunded' => 0,
+            'item_sku' => 'MBTI_REPORT_FULL',
+            'request_id' => null,
+            'created_ip' => null,
+            'paid_at' => null,
+            'fulfilled_at' => null,
+            'refunded_at' => null,
+            'created_at' => $now,
+            'updated_at' => $now,
+            'order_no' => 'ord_evt_shared_provider_isolation',
+            'org_id' => 0,
+            'sku' => 'MBTI_REPORT_FULL',
+            'quantity' => 1,
+            'target_attempt_id' => null,
+            'amount_cents' => 1000,
+            'external_trade_no' => null,
+        ]);
+
+        DB::table('payment_events')->insert([
+            'id' => (string) Str::uuid(),
+            'provider' => 'billing',
+            'provider_event_id' => 'evt_shared',
+            'order_id' => $orderId,
+            'event_type' => 'billing.seed',
+            'payload_json' => json_encode(['seed' => true], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES),
+            'signature_ok' => true,
+            'handled_at' => $now->copy()->subHour(),
+            'handle_status' => 'billing_seed_hold',
+            'request_id' => null,
+            'ip' => null,
+            'headers_digest' => null,
+            'status' => 'received',
+            'created_at' => $now,
+            'updated_at' => $now,
+        ]);
+
+        $billingBefore = DB::table('payment_events')
+            ->where('provider', 'billing')
+            ->where('provider_event_id', 'evt_shared')
+            ->first();
+
+        $result = (new PaymentService())->handleWebhookMock(
+            [
+                'provider_event_id' => 'evt_shared',
+                'provider_order_id' => $providerOrderId,
+                'order_id' => $orderId,
+                'event_type' => 'mock.payment_succeeded',
+                'type' => 'mock.payment_succeeded',
+                'amount_total' => 1000,
+                'currency' => 'USD',
+            ],
+            [
+                'signature_ok' => true,
+            ]
+        );
+
+        $this->assertTrue($result['ok']);
+        $this->assertFalse((bool) ($result['idempotent'] ?? true));
+
+        $billingAfter = DB::table('payment_events')
+            ->where('provider', 'billing')
+            ->where('provider_event_id', 'evt_shared')
+            ->first();
+
+        $mockRow = DB::table('payment_events')
+            ->where('provider', 'mock')
+            ->where('provider_event_id', 'evt_shared')
+            ->first();
+
+        $this->assertNotNull($billingBefore);
+        $this->assertNotNull($billingAfter);
+        $this->assertNotNull($mockRow);
+
+        $this->assertSame('billing.seed', (string) ($billingAfter->event_type ?? ''));
+        $this->assertSame('received', (string) ($billingAfter->status ?? ''));
+        $this->assertSame((string) ($billingBefore->handle_status ?? ''), (string) ($billingAfter->handle_status ?? ''));
+        $this->assertSame((string) ($billingBefore->handled_at ?? ''), (string) ($billingAfter->handled_at ?? ''));
+
+        $this->assertSame(2, DB::table('payment_events')
+            ->where('provider_event_id', 'evt_shared')
+            ->count());
+
+        $this->assertSame('mock.payment_succeeded', (string) ($mockRow->event_type ?? ''));
+    }
+}


### PR DESCRIPTION
## Summary
Fix High-A3 by fully scoping `payment_events` idempotency and updates to `(provider, provider_event_id)`.

## Problem
`payment_events` previously had paths that relied on `provider_event_id` alone, which could cause cross-provider pollution when the same event id existed under different providers.

## Changes
- Migration hardening:
  - `/Users/rainie/Desktop/GitHub/fap-api/backend/database/migrations/2026_02_08_000001_add_provider_composite_unique_to_payment_events.php`
  - Normalize final unique index to `payment_events_provider_provider_event_id_unique`
  - Drop old single-column unique `payment_events_provider_event_id_unique`
  - Drop legacy duplicate/wrong-name unique `payment_events_provider_provider_event_unique`
  - Ensure `provider` column exists before creating composite unique
- Migration no-op:
  - `/Users/rainie/Desktop/GitHub/fap-api/backend/database/migrations/2026_02_08_050000_scope_payment_event_uniqueness_by_provider.php`
  - `up()` and `down()` are intentionally no-op to avoid duplicate index creation during `migrate:fresh`
- Service scoping fix:
  - `/Users/rainie/Desktop/GitHub/fap-api/backend/app/Services/Payments/PaymentService.php`
  - Added provider constants (`internal`, `mock`)
  - Added `paymentEventQuery($provider, $providerEventId)` helper
  - Updated `markPaid()` and all `handleWebhookMock()` event reads/updates to always include provider + provider_event_id
  - Duplicate branch now writes `handle_status=already_processed` on provider-scoped row
- New regression test:
  - `/Users/rainie/Desktop/GitHub/fap-api/backend/tests/Feature/V0_2/PaymentsMockWebhookProviderIsolationTest.php`
  - Verifies same `provider_event_id` can coexist for `billing` and `mock`
  - Verifies mock webhook only updates mock row and does not mutate billing row

## Verification
- `php artisan route:list`
- `php artisan migrate`
- `php artisan migrate:fresh --force`
- `php artisan test --filter PaymentEventUniquenessAcrossProvidersTest`
- `php artisan test --filter PaymentsMockWebhookProviderIsolationTest`
- `php artisan test`
- `bash backend/scripts/ci_verify_mbti.sh`
- `grep -R -n "where('provider_event_id'" backend/app/Services/Payments/PaymentService.php` (only provider-scoped helper remains)

## Result
All checks passed locally, including full test suite and `ci_verify_mbti` chain.
