### PR TITLE
fix(high3): enforce org member/viewer attempt ownership for submit & …

### DIFF
--- a/backend/app/Http/Controllers/API/V0_3/AttemptsController.php
+++ b/backend/app/Http/Controllers/API/V0_3/AttemptsController.php
@@ -521,6 +521,9 @@ if ($orgId > 0 && $entitlementBenefitCode !== '') {
         'attempt_id' => $attemptId,
         'trigger_source' => 'credit_consume',
         'order_no' => null,
+        'user_id' => $userId !== null ? (string) $userId : null,
+        'anon_id' => $anonId,
+        'org_role' => $this->orgContext->role(),
     ]);
     if (!($snapshot['ok'] ?? false)) {
         $status = (int) ($snapshot['status'] ?? 500);
@@ -608,6 +611,7 @@ if ($orgId > 0 && $entitlementBenefitCode !== '') {
             $id,
             $userId !== null ? (string) $userId : null,
             $anonId,
+            $this->orgContext->role(),
         );
 
         if (!($gate['ok'] ?? false)) {

--- a/backend/app/Services/Attempts/AttemptProgressService.php
+++ b/backend/app/Services/Attempts/AttemptProgressService.php
@@ -63,12 +63,21 @@ class AttemptProgressService
             ];
         }
 
+        if (($token === null || trim($token) === '') && $userId !== null && !$this->matchesAttemptOwner($attempt, $userId)) {
+            return [
+                'ok' => false,
+                'status' => 404,
+                'error' => 'DRAFT_NOT_FOUND',
+                'message' => 'draft not found.',
+            ];
+        }
+
         if (!$this->canAccessDraft($draft, $token, $userId)) {
             return [
                 'ok' => false,
-                'status' => 401,
-                'error' => 'RESUME_TOKEN_INVALID',
-                'message' => 'resume token invalid.',
+                'status' => 404,
+                'error' => 'DRAFT_NOT_FOUND',
+                'message' => 'draft not found.',
             ];
         }
 
@@ -152,12 +161,21 @@ class AttemptProgressService
             ];
         }
 
+        if (($token === null || trim($token) === '') && $userId !== null && !$this->matchesAttemptOwner($attempt, $userId)) {
+            return [
+                'ok' => false,
+                'status' => 404,
+                'error' => 'DRAFT_NOT_FOUND',
+                'message' => 'draft not found.',
+            ];
+        }
+
         if (!$this->canAccessDraft($draft, $token, $userId)) {
             return [
                 'ok' => false,
-                'status' => 401,
-                'error' => 'RESUME_TOKEN_INVALID',
-                'message' => 'resume token invalid.',
+                'status' => 404,
+                'error' => 'DRAFT_NOT_FOUND',
+                'message' => 'draft not found.',
             ];
         }
 
@@ -332,6 +350,16 @@ class AttemptProgressService
     {
         $salt = (string) config('app.key', '');
         return hash('sha256', $token . '|' . $salt);
+    }
+
+    private function matchesAttemptOwner(Attempt $attempt, int $userId): bool
+    {
+        $attemptOwnerId = trim((string) ($attempt->user_id ?? ''));
+        if ($attemptOwnerId === '') {
+            return false;
+        }
+
+        return $attemptOwnerId === (string) $userId;
     }
 
     private function canAccessDraft(array $draft, ?string $token, ?int $userId): bool

--- a/backend/app/Services/Commerce/PaymentWebhookProcessor.php
+++ b/backend/app/Services/Commerce/PaymentWebhookProcessor.php
@@ -454,6 +454,9 @@ class PaymentWebhookProcessor
                             'attempt_id' => $attemptId,
                             'trigger_source' => 'payment',
                             'order_no' => $orderNo,
+                            'user_id' => $order->user_id ? (string) $order->user_id : null,
+                            'anon_id' => $order->anon_id ? (string) $order->anon_id : null,
+                            'org_role' => 'system',
                         ]);
                         if (!($snapshot['ok'] ?? false)) {
                             $this->markEventError(

--- a/backend/tests/Feature/V0_3/AttemptMemberViewerOwnershipTest.php
+++ b/backend/tests/Feature/V0_3/AttemptMemberViewerOwnershipTest.php
@@ -1,0 +1,166 @@
+<?php
+
+namespace Tests\Feature\V0_3;
+
+use App\Services\Auth\FmTokenService;
+use Database\Seeders\Pr17SimpleScoreDemoSeeder;
+use Database\Seeders\ScaleRegistrySeeder;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Str;
+use Illuminate\Testing\TestResponse;
+use Tests\TestCase;
+
+class AttemptMemberViewerOwnershipTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private function seedScales(): void
+    {
+        (new ScaleRegistrySeeder())->run();
+        (new Pr17SimpleScoreDemoSeeder())->run();
+    }
+
+    private function createUserWithToken(string $email): array
+    {
+        $now = now();
+        $userId = DB::table('users')->insertGetId([
+            'name' => 'User ' . $email,
+            'email' => $email,
+            'password' => bcrypt('secret'),
+            'created_at' => $now,
+            'updated_at' => $now,
+        ]);
+
+        $issued = app(FmTokenService::class)->issueForUser((string) $userId);
+
+        return [
+            'user_id' => (int) $userId,
+            'token' => (string) ($issued['token'] ?? ''),
+        ];
+    }
+
+    private function createOrg(int $ownerUserId): int
+    {
+        return (int) DB::table('organizations')->insertGetId([
+            'name' => 'Org ' . Str::lower(Str::random(8)),
+            'owner_user_id' => $ownerUserId,
+            'created_at' => now(),
+            'updated_at' => now(),
+        ]);
+    }
+
+    private function addMember(int $orgId, int $userId, string $role): void
+    {
+        DB::table('organization_members')->insert([
+            'org_id' => $orgId,
+            'user_id' => $userId,
+            'role' => $role,
+            'joined_at' => now(),
+            'created_at' => now(),
+            'updated_at' => now(),
+        ]);
+    }
+
+    private function ensureCreditWallet(int $orgId): void
+    {
+        DB::table('benefit_wallets')->upsert([
+            [
+                'org_id' => $orgId,
+                'benefit_code' => 'MBTI_CREDIT',
+                'balance' => 20,
+                'created_at' => now(),
+                'updated_at' => now(),
+            ],
+        ], ['org_id', 'benefit_code'], ['balance', 'updated_at']);
+    }
+
+    private function defaultAnswers(): array
+    {
+        return [
+            ['question_id' => 'SS-001', 'code' => '5'],
+            ['question_id' => 'SS-002', 'code' => '4'],
+            ['question_id' => 'SS-003', 'code' => '3'],
+            ['question_id' => 'SS-004', 'code' => '2'],
+            ['question_id' => 'SS-005', 'code' => '1'],
+        ];
+    }
+
+    private function startAttempt(int $orgId, string $token, string $anonId): string
+    {
+        $headers = [
+            'Authorization' => 'Bearer ' . $token,
+            'X-Org-Id' => (string) $orgId,
+            'X-Anon-Id' => $anonId,
+        ];
+
+        $start = $this->postJson('/api/v0.3/attempts/start', [
+            'scale_code' => 'SIMPLE_SCORE_DEMO',
+            'anon_id' => $anonId,
+        ], $headers);
+        $start->assertStatus(200);
+
+        $attemptId = (string) $start->json('attempt_id');
+        $this->assertNotSame('', $attemptId);
+
+        return $attemptId;
+    }
+
+    private function assertUniform404(TestResponse $response): void
+    {
+        $response->assertStatus(404);
+
+        $raw = (string) $response->getContent();
+        $decoded = json_decode($raw, true);
+        $this->assertIsArray($decoded);
+
+        $lower = strtolower($raw);
+        $this->assertStringNotContainsString('forbidden', $lower);
+        $this->assertStringNotContainsString('unauthorized', $lower);
+    }
+
+    public function test_member_cannot_tamper_other_member_attempt_submit_or_progress(): void
+    {
+        $this->seedScales();
+
+        $owner = $this->createUserWithToken('high3_owner@example.com');
+        $memberA = $this->createUserWithToken('high3_member_a@example.com');
+        $memberB = $this->createUserWithToken('high3_member_b@example.com');
+
+        $orgId = $this->createOrg($owner['user_id']);
+        $this->addMember($orgId, $owner['user_id'], 'owner');
+        $this->addMember($orgId, $memberA['user_id'], 'member');
+        $this->addMember($orgId, $memberB['user_id'], 'member');
+        $this->ensureCreditWallet($orgId);
+
+        $attemptId = $this->startAttempt($orgId, $memberA['token'], 'high3-member-a-anon');
+
+        $headersB = [
+            'Authorization' => 'Bearer ' . $memberB['token'],
+            'X-Org-Id' => (string) $orgId,
+            'X-Anon-Id' => 'high3-member-b-anon',
+        ];
+
+        $this->assertUniform404($this->postJson('/api/v0.3/attempts/submit', [
+            'attempt_id' => $attemptId,
+            'answers' => $this->defaultAnswers(),
+            'duration_ms' => 120000,
+        ], $headersB));
+
+        $this->assertUniform404($this->getJson("/api/v0.3/attempts/{$attemptId}/progress", $headersB));
+
+        $this->assertUniform404($this->putJson("/api/v0.3/attempts/{$attemptId}/progress", [
+            'seq' => 1,
+            'cursor' => 'page-1',
+            'duration_ms' => 1000,
+            'answers' => [
+                [
+                    'question_id' => 'SS-001',
+                    'question_type' => 'single_choice',
+                    'question_index' => 0,
+                    'code' => '5',
+                ],
+            ],
+        ], $headersB));
+    }
+}

--- a/docs/security/high3_attempt_horizontal_tampering.md
+++ b/docs/security/high3_attempt_horizontal_tampering.md
@@ -1,0 +1,34 @@
+# High-3: Attempt Horizontal Tampering (Org Member/Viewer)
+
+## Risk
+Attempt submit/progress endpoints allow org users to tamper with other members' attempt by referencing `attempt_id` and bypassing ownership binding. Impact: integrity + privacy compliance.
+
+## Scan Artifacts
+- `/Users/rainie/Desktop/GitHub/fap-api/backend/artifacts/high3_scan/scan.txt`
+
+## Findings
+- [x] `AttemptProgressController::show/upsert` only used `attempt_id + org_id`, missing `user_id` ownership filter for org member/viewer.
+- [x] `AttemptProgressController` returned `401 RESUME_TOKEN_REQUIRED` for anonymous requests; this leaks existence semantics.
+- [x] `AttemptProgressService::canAccessDraft` allowed any logged-in org user when resume token is absent (`$userId !== null`) without checking `attempt.user_id`.
+- [x] `AttemptProgressService` returned `401 RESUME_TOKEN_INVALID` on draft access failure (should collapse to `404`).
+- [x] `ReportGatekeeper` and `ReportSnapshotStore` fetched attempt by `attempt_id + org_id` only; actor-binding missing in service layer (future footgun if reused directly).
+
+## Fix Applied
+- `AttemptProgressController`
+  - org 登录用户查询 attempt 强制 `where('user_id', current_user_id)`。
+  - 未登录且无 `X-Resume-Token` 直接 `404`。
+  - service 返回 `401/403` 统一映射为 `404`。
+- `AttemptProgressService`
+  - token 为空且 userId 存在时，新增 `attempt.user_id == userId` 强绑定校验。
+  - `canAccessDraft` 失败统一返回 `404`（不再返回 `401`）。
+- `ReportGatekeeper`
+  - 新增 actor-aware `ownedAttemptQuery(...)`，支持 role-aware ownership 约束。
+- `ReportSnapshotStore`
+  - 新增 actor-aware `ownedAttemptQuery(...)` 与 `org_role/user_id/anon_id` 安全默认。
+  - 对 system/job/webhook 调用保持兼容（`system` 角色）。
+
+## Post-fix Status
+- [x] MemberB submit MemberA attempt returns `404`.
+- [x] MemberB progress show/upsert MemberA attempt returns `404`.
+- [x] Touched files do not contain `abort(403)`.
+- [x] `backend/scripts/ci_verify_mbti.sh` remains green.

--- a/docs/verify/high3_attempt_ownership_verify.md
+++ b/docs/verify/high3_attempt_ownership_verify.md
@@ -1,0 +1,29 @@
+# High-3 Attempt Ownership Verify
+
+## What fixed
+- Org member/viewer can no longer submit another user's attempt by guessing `attempt_id`.
+- Org member/viewer can no longer read/write another user's attempt progress.
+- Draft access without resume token now requires `attempt.user_id` ownership match at service layer.
+- Report services now use actor-aware attempt lookup to reduce unsafe direct reuse risk.
+
+## Files changed
+- `/Users/rainie/Desktop/GitHub/fap-api/backend/app/Http/Controllers/API/V0_3/AttemptsController.php`
+- `/Users/rainie/Desktop/GitHub/fap-api/backend/app/Http/Controllers/API/V0_3/AttemptProgressController.php`
+- `/Users/rainie/Desktop/GitHub/fap-api/backend/app/Services/Attempts/AttemptProgressService.php`
+- `/Users/rainie/Desktop/GitHub/fap-api/backend/app/Services/Report/ReportGatekeeper.php`
+- `/Users/rainie/Desktop/GitHub/fap-api/backend/app/Services/Report/ReportSnapshotStore.php`
+- `/Users/rainie/Desktop/GitHub/fap-api/backend/app/Services/Commerce/PaymentWebhookProcessor.php`
+- `/Users/rainie/Desktop/GitHub/fap-api/backend/tests/Feature/V0_3/AttemptMemberViewerOwnershipTest.php`
+- `/Users/rainie/Desktop/GitHub/fap-api/docs/security/high3_attempt_horizontal_tampering.md`
+
+## How to verify
+- `cd /Users/rainie/Desktop/GitHub/fap-api/backend`
+- `composer install --no-interaction --no-progress`
+- `php artisan migrate:fresh --force`
+- `php artisan test --filter AttemptMemberViewerOwnershipTest`
+- `php artisan test --filter "AttemptOwnershipAnd404Test|AttemptProgressFlowTest|ReportSnapshotB2BTest|ReportSnapshotB2CTest"`
+- `cd /Users/rainie/Desktop/GitHub/fap-api && bash backend/scripts/ci_verify_mbti.sh`
+
+## Artifacts
+- `/Users/rainie/Desktop/GitHub/fap-api/backend/artifacts/high3_scan/scan.txt`
+- `/Users/rainie/Desktop/GitHub/fap-api/backend/artifacts/high3_scan/test.log`


### PR DESCRIPTION
- What:
  - 修复 High-3 组织内横向篡改：同 org 的 member/viewer 不能再通过猜测 `attempt_id` 提交或读写他人 attempt/progress。
- Why:
  - 防止组织内完整性破坏（答案/结果/报告）与隐私合规风险。
  - 统一越权与不存在口径为 404，降低资源存在性枚举风险。
- How:
  - AttemptProgressController:
    - `show/upsert` 查询改为 `id + org_id + user_id`（登录 org 用户）。
    - 未登录且无 `X-Resume-Token` 直接 404。
    - service 返回 401/403 统一映射 404。
  - AttemptProgressService:
    - token 缺失且有 userId 时，新增 `attempt.user_id == userId` 强绑定校验。
    - `canAccessDraft` 未通过统一返回 404（不再返回 401）。
  - ReportGatekeeper:
    - 增加 role-aware `ownedAttemptQuery(...)`，默认安全化 attempt 获取。
  - ReportSnapshotStore:
    - 增加 actor-aware `ownedAttemptQuery(...)`，支持 `user_id/anon_id/org_role`。
    - 兼容系统调用（payment/job）`org_role=system`。
  - AttemptsController / PaymentWebhookProcessor:
    - 调用 report service 时补传 actor context（`user_id/anon_id/org_role`）。
  - Tests:
    - 新增 `AttemptMemberViewerOwnershipTest`，覆盖同 org member 对他人 attempt 的 submit/progress show/upsert 均返回 404。
- Scan & Docs:
  - `backend/artifacts/high3_scan/scan.txt`
  - `docs/security/high3_attempt_horizontal_tampering.md`
  - `docs/verify/high3_attempt_ownership_verify.md`
- Verify:
  - `cd backend && php artisan route:list`
  - `cd backend && php artisan migrate --force`
  - `cd backend && php artisan test --filter AttemptMemberViewerOwnershipTest`
  - `cd backend && php artisan test --filter "AttemptOwnershipAnd404Test|AttemptProgressFlowTest|ReportSnapshotB2BTest|ReportSnapshotB2CTest"`
  - `cd .. && bash backend/scripts/ci_verify_mbti.sh`
- Result:
  - 本地回归通过，`ci_verify_mbti.sh` 主链保持绿色。

