### PR TITLE
feat(ci): add sqlite+mysql selfcheck lanes and v0.3 smoke; fix mysql-only test failures

### DIFF
--- a/.github/workflows/selfcheck.yml
+++ b/.github/workflows/selfcheck.yml
@@ -221,3 +221,75 @@ jobs:
       - name: Runtime validate report
         working-directory: backend
         run: php artisan fap:validate-report --attempt="$FAP_VALIDATE_ATTEMPT_ID"
+
+      - name: Smoke v0.3 (sqlite lane)
+        run: bash backend/scripts/ci_smoke_v0_3.sh
+
+  selfcheck-mysql:
+    runs-on: ubuntu-latest
+    timeout-minutes: 35
+
+    defaults:
+      run:
+        shell: bash
+
+    services:
+      mysql:
+        image: mysql:8.0
+        env:
+          MYSQL_DATABASE: fap_ci
+          MYSQL_ROOT_PASSWORD: root
+        ports: ["3306:3306"]
+        options: >-
+          --health-cmd="mysqladmin ping -h 127.0.0.1 -proot"
+          --health-interval=10s
+          --health-timeout=5s
+          --health-retries=12
+
+    env:
+      APP_ENV: ci
+      DB_CONNECTION: mysql
+      DB_HOST: 127.0.0.1
+      DB_PORT: 3306
+      DB_DATABASE: fap_ci
+      DB_USERNAME: root
+      DB_PASSWORD: root
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.4'
+          tools: composer:v2
+          extensions: mbstring, dom, xml, curl, pdo_mysql
+
+      - name: Wait for mysql
+        run: |
+          for i in $(seq 1 60); do
+            (echo > /dev/tcp/127.0.0.1/3306) >/dev/null 2>&1 && exit 0
+            sleep 1
+          done
+          echo "mysql not ready in 60s"
+          exit 1
+
+      - name: Prepare Laravel cache dirs (for package:discover)
+        working-directory: backend
+        run: bash scripts/ci/prepare_laravel_cache_dirs.sh
+
+      - name: Install backend deps
+        working-directory: backend
+        run: composer install --no-interaction --prefer-dist --no-progress
+
+      - name: Prepare CI mysql (migrate + seed + sync-slugs)
+        working-directory: backend
+        run: bash scripts/ci/prepare_mysql.sh
+
+      - name: Run tests with MySQL
+        working-directory: backend
+        run: php artisan test --configuration phpunit.mysql.xml
+
+      - name: Smoke v0.3 (mysql lane)
+        working-directory: backend
+        run: bash scripts/ci_smoke_v0_3.sh

--- a/.github/workflows/selfcheck.yml
+++ b/.github/workflows/selfcheck.yml
@@ -288,7 +288,7 @@ jobs:
 
       - name: Run tests with MySQL
         working-directory: backend
-        run: php artisan test --configuration phpunit.mysql.xml
+        run: php vendor/phpunit/phpunit/phpunit --configuration phpunit.mysql.xml
 
       - name: Smoke v0.3 (mysql lane)
         working-directory: backend

--- a/.github/workflows/selfcheck.yml
+++ b/.github/workflows/selfcheck.yml
@@ -282,6 +282,12 @@ jobs:
         working-directory: backend
         run: composer install --no-interaction --prefer-dist --no-progress
 
+      - name: Composer validate & audit
+        working-directory: backend
+        run: |
+          composer validate --strict
+          composer audit --no-interaction
+
       - name: Prepare CI mysql (migrate + seed + sync-slugs)
         working-directory: backend
         run: bash scripts/ci/prepare_mysql.sh

--- a/backend/app/Support/Database/SchemaIndex.php
+++ b/backend/app/Support/Database/SchemaIndex.php
@@ -61,6 +61,8 @@ final class SchemaIndex
             'does not exist',
             'unknown key name',
             'cannot drop index',
+            "can't drop",
+            'check that column/key exists',
         ]);
     }
 

--- a/backend/phpunit.mysql.xml
+++ b/backend/phpunit.mysql.xml
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="vendor/phpunit/phpunit/phpunit.xsd"
+         bootstrap="vendor/autoload.php"
+         colors="true"
+>
+    <testsuites>
+        <testsuite name="Unit">
+            <directory>tests/Unit</directory>
+        </testsuite>
+        <testsuite name="Feature">
+            <directory>tests/Feature</directory>
+        </testsuite>
+    </testsuites>
+    <source>
+        <include>
+            <directory>app</directory>
+        </include>
+    </source>
+    <php>
+        <env name="APP_ENV" value="testing"/>
+        <env name="APP_MAINTENANCE_DRIVER" value="file"/>
+        <env name="BCRYPT_ROUNDS" value="4"/>
+        <env name="BROADCAST_CONNECTION" value="null"/>
+        <env name="CACHE_STORE" value="array"/>
+        <env name="DB_CONNECTION" value="mysql"/>
+        <env name="DB_HOST" value="127.0.0.1"/>
+        <env name="DB_PORT" value="3306"/>
+        <env name="DB_DATABASE" value="fap_ci"/>
+        <env name="DB_USERNAME" value="root"/>
+        <env name="DB_PASSWORD" value="root"/>
+        <env name="MAIL_MAILER" value="array"/>
+        <env name="QUEUE_CONNECTION" value="sync"/>
+        <env name="SESSION_DRIVER" value="array"/>
+        <env name="PULSE_ENABLED" value="false"/>
+        <env name="TELESCOPE_ENABLED" value="false"/>
+        <env name="NIGHTWATCH_ENABLED" value="false"/>
+    </php>
+</phpunit>

--- a/backend/scripts/ci/prepare_mysql.sh
+++ b/backend/scripts/ci/prepare_mysql.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+BACKEND_DIR="$(cd "$SCRIPT_DIR/../.." && pwd)"
+cd "$BACKEND_DIR"
+
+if [[ ! -f ".env" ]]; then
+  cp .env.example .env
+fi
+
+export APP_ENV=ci
+export DB_CONNECTION=mysql
+export DB_HOST=127.0.0.1
+export DB_PORT=3306
+export DB_DATABASE=fap_ci
+export DB_USERNAME=root
+export DB_PASSWORD=root
+
+php artisan key:generate --force
+php artisan migrate:fresh --force --no-interaction
+php artisan db:seed --class=CiScalesRegistrySeeder --force --no-interaction
+
+if php artisan fap:sync-slugs --no-interaction; then
+  :
+else
+  php artisan fap:scales:sync-slugs --no-interaction
+fi
+
+echo "PASS: prepare_mysql"

--- a/backend/scripts/ci_smoke_v0_3.sh
+++ b/backend/scripts/ci_smoke_v0_3.sh
@@ -1,0 +1,69 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+BACKEND_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+cd "$BACKEND_DIR"
+
+if [[ ! -f ".env" ]]; then
+  cp .env.example .env
+fi
+
+PORT=18001
+BASE_URL="http://127.0.0.1:${PORT}"
+SERVE_LOG="/tmp/fap_ci_serve.log"
+
+php artisan serve --host=127.0.0.1 --port="${PORT}" >"${SERVE_LOG}" 2>&1 &
+SRV_PID=$!
+
+cleanup() {
+  if [[ -n "${SRV_PID:-}" ]] && kill -0 "${SRV_PID}" >/dev/null 2>&1; then
+    kill "${SRV_PID}" >/dev/null 2>&1 || true
+    wait "${SRV_PID}" 2>/dev/null || true
+  fi
+}
+trap cleanup EXIT
+
+READY_URL=""
+for i in $(seq 1 30); do
+  if curl -fsS "${BASE_URL}/healthz" >/dev/null 2>&1; then
+    READY_URL="${BASE_URL}/healthz"
+    break
+  fi
+  if curl -fsS "${BASE_URL}/api/healthz" >/dev/null 2>&1; then
+    READY_URL="${BASE_URL}/api/healthz"
+    break
+  fi
+  sleep 1
+done
+
+if [[ -z "${READY_URL}" ]]; then
+  echo "[smoke_v0_3] healthz timeout"
+  tail -n 120 "${SERVE_LOG}" || true
+  exit 1
+fi
+
+BOOT_JSON="$(curl -fsS "${BASE_URL}/api/v0.3/boot")"
+php -r '
+$raw = stream_get_contents(STDIN);
+$j = json_decode($raw, true);
+if (!is_array($j)) { fwrite(STDERR, "boot: top-level must be object\n"); exit(1); }
+if (($j["ok"] ?? null) !== true) { fwrite(STDERR, "boot: ok must be true\n"); exit(1); }
+if (array_key_exists("version", $j) && (!is_string($j["version"]) || trim($j["version"]) === "")) {
+    fwrite(STDERR, "boot: version must be non-empty string when present\n");
+    exit(1);
+}
+' <<<"${BOOT_JSON}"
+
+FLAGS_JSON="$(curl -fsS "${BASE_URL}/api/v0.3/flags")"
+php -r '
+$raw = stream_get_contents(STDIN);
+$j = json_decode($raw, true);
+if (!is_array($j)) { fwrite(STDERR, "flags: top-level must be object\n"); exit(1); }
+if (!array_key_exists("ok", $j) && !array_key_exists("flags", $j)) {
+    fwrite(STDERR, "flags: missing ok/flags key\n");
+    exit(1);
+}
+' <<<"${FLAGS_JSON}"
+
+echo "PASS: smoke v0.3"


### PR DESCRIPTION
## Summary
This PR closes the CI evidence loop for Medium-A1 and Medium-A4.

It adds dual-lane CI verification (SQLite + MySQL), adds v0.3 smoke checks, and fixes two MySQL-only test failures that would otherwise keep the new MySQL job red.

## Changes
1. Added MySQL phpunit config: `backend/phpunit.mysql.xml`.
2. Added MySQL prepare script: `backend/scripts/ci/prepare_mysql.sh`.
3. Added v0.3 smoke script: `backend/scripts/ci_smoke_v0_3.sh`.
4. Updated workflow: `.github/workflows/selfcheck.yml`.
5. Appended SQLite lane smoke step for v0.3 boot/flags.
6. Added new MySQL lane `selfcheck-mysql` with MySQL service, prepare, tests, and smoke.
7. Fixed MySQL replay deletion path in `backend/app/Services/Queue/QueueDlqService.php` by handling failer forget with UUID-first fallback.
8. Improved MySQL missing-index exception matching in `backend/app/Support/Database/SchemaIndex.php`.
9. Switched MySQL workflow test command from `php artisan test --configuration ...` to direct phpunit binary to avoid duplicate `--configuration` injection in current toolchain.

## Scope / Non-Goals
1. No business API contract changes.
2. No route changes.
3. No migration file changes.
4. No `FmTokenAuth` changes.

## Validation Run
1. `php artisan route:list`
2. `php artisan migrate`
3. `bash backend/scripts/ci_verify_mbti.sh`
4. `DB_CONNECTION=sqlite DB_DATABASE=/tmp/fap-ci.sqlite bash backend/scripts/ci_smoke_v0_3.sh`
5. `bash backend/scripts/ci/prepare_mysql.sh` (with MySQL root/root test instance)
6. `php vendor/phpunit/phpunit/phpunit --configuration backend/phpunit.mysql.xml`
7. `DB_CONNECTION=mysql DB_HOST=127.0.0.1 DB_PORT=3306 DB_DATABASE=fap_ci DB_USERNAME=root DB_PASSWORD=root bash backend/scripts/ci_smoke_v0_3.sh`
8. Targeted regressions confirmed green on MySQL:
   - `SchemaIndexTest`
   - `AdminQueueDlqReplayTest`

## Risk
Low-to-medium. Main risk is CI runtime increase due to new MySQL lane. Behavior changes are limited to test/CI flow and MySQL-specific replay/index-error handling.
