### PR TITLE
feat(migrations): converge guarded create schema patches

### DIFF
--- a/backend/database/migrations/2025_12_17_165938_create_events_table.php
+++ b/backend/database/migrations/2025_12_17_165938_create_events_table.php
@@ -8,18 +8,41 @@ return new class extends Migration
 {
     public function up(): void
     {
-        // 幂等：线上表已存在时，直接跳过，避免部署炸迁移
-        if (Schema::hasTable('events')) {
-            return;
+        $tableName = 'events';
+
+        if (!Schema::hasTable($tableName)) {
+            Schema::create($tableName, function (Blueprint $table): void {
+                $table->char('id', 36)->primary();
+                $table->string('event_code', 64);
+                $table->string('anon_id', 128)->nullable();
+                $table->string('attempt_id', 64);
+                $table->json('meta_json')->nullable();
+                $table->timestamps();
+            });
         }
 
-        Schema::create('events', function (Blueprint $table) {
-            $table->char('id', 36)->primary();
-            $table->string('event_code', 64);
-            $table->string('anon_id', 128)->nullable();
-            $table->string('attempt_id', 64);
-            $table->json('meta_json')->nullable();
-            $table->timestamps();
+        Schema::table($tableName, function (Blueprint $table) use ($tableName): void {
+            if (!Schema::hasColumn($tableName, 'id')) {
+                $table->char('id', 36)->nullable();
+            }
+            if (!Schema::hasColumn($tableName, 'event_code')) {
+                $table->string('event_code', 64)->nullable();
+            }
+            if (!Schema::hasColumn($tableName, 'anon_id')) {
+                $table->string('anon_id', 128)->nullable();
+            }
+            if (!Schema::hasColumn($tableName, 'attempt_id')) {
+                $table->string('attempt_id', 64)->nullable();
+            }
+            if (!Schema::hasColumn($tableName, 'meta_json')) {
+                $table->json('meta_json')->nullable();
+            }
+            if (!Schema::hasColumn($tableName, 'created_at')) {
+                $table->timestamp('created_at')->nullable();
+            }
+            if (!Schema::hasColumn($tableName, 'updated_at')) {
+                $table->timestamp('updated_at')->nullable();
+            }
         });
     }
 

--- a/backend/database/migrations/2026_01_19_170607_create_email_outbox_table.php
+++ b/backend/database/migrations/2026_01_19_170607_create_email_outbox_table.php
@@ -1,5 +1,6 @@
 <?php
 
+use App\Support\Database\SchemaIndex;
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
@@ -8,23 +9,93 @@ return new class extends Migration
 {
     public function up(): void
     {
-        if (Schema::hasTable('email_outbox')) {
-            return;
+        $tableName = 'email_outbox';
+
+        if (!Schema::hasTable($tableName)) {
+            Schema::create($tableName, function (Blueprint $table): void {
+                $table->uuid('id')->primary();
+                $table->string('user_id', 64);
+                $table->string('email');
+                $table->string('template', 64);
+                $table->json('payload_json')->nullable();
+                $table->string('claim_token_hash', 64);
+                $table->timestamp('claim_expires_at')->nullable();
+                $table->string('status', 24)->default('pending');
+                $table->timestamp('sent_at')->nullable();
+                $table->timestamp('consumed_at')->nullable();
+                $table->timestamps();
+
+                $table->index('user_id', 'email_outbox_user_id_index');
+                $table->unique('claim_token_hash', 'email_outbox_claim_token_hash_unique');
+                $table->index('claim_expires_at', 'email_outbox_claim_expires_at_index');
+                $table->index('status', 'email_outbox_status_index');
+            });
         }
 
-        Schema::create('email_outbox', function (Blueprint $table) {
-            $table->uuid('id')->primary();
-            $table->string('user_id', 64)->index();
-            $table->string('email');
-            $table->string('template', 64);
-            $table->json('payload_json')->nullable();
-            $table->string('claim_token_hash', 64)->unique();
-            $table->timestamp('claim_expires_at')->nullable()->index();
-            $table->string('status', 24)->default('pending')->index();
-            $table->timestamp('sent_at')->nullable();
-            $table->timestamp('consumed_at')->nullable();
-            $table->timestamps();
+        Schema::table($tableName, function (Blueprint $table) use ($tableName): void {
+            if (!Schema::hasColumn($tableName, 'id')) {
+                $table->uuid('id')->nullable();
+            }
+            if (!Schema::hasColumn($tableName, 'user_id')) {
+                $table->string('user_id', 64)->nullable();
+            }
+            if (!Schema::hasColumn($tableName, 'email')) {
+                $table->string('email')->nullable();
+            }
+            if (!Schema::hasColumn($tableName, 'template')) {
+                $table->string('template', 64)->nullable();
+            }
+            if (!Schema::hasColumn($tableName, 'payload_json')) {
+                $table->json('payload_json')->nullable();
+            }
+            if (!Schema::hasColumn($tableName, 'claim_token_hash')) {
+                $table->string('claim_token_hash', 64)->nullable();
+            }
+            if (!Schema::hasColumn($tableName, 'claim_expires_at')) {
+                $table->timestamp('claim_expires_at')->nullable();
+            }
+            if (!Schema::hasColumn($tableName, 'status')) {
+                $table->string('status', 24)->default('pending');
+            }
+            if (!Schema::hasColumn($tableName, 'sent_at')) {
+                $table->timestamp('sent_at')->nullable();
+            }
+            if (!Schema::hasColumn($tableName, 'consumed_at')) {
+                $table->timestamp('consumed_at')->nullable();
+            }
+            if (!Schema::hasColumn($tableName, 'created_at')) {
+                $table->timestamp('created_at')->nullable();
+            }
+            if (!Schema::hasColumn($tableName, 'updated_at')) {
+                $table->timestamp('updated_at')->nullable();
+            }
         });
+
+        if (Schema::hasColumn($tableName, 'user_id') && !SchemaIndex::indexExists($tableName, 'email_outbox_user_id_index')) {
+            Schema::table($tableName, function (Blueprint $table): void {
+                $table->index('user_id', 'email_outbox_user_id_index');
+            });
+        }
+
+        if (Schema::hasColumn($tableName, 'claim_token_hash')
+            && !SchemaIndex::indexExists($tableName, 'email_outbox_claim_token_hash_unique')) {
+            Schema::table($tableName, function (Blueprint $table): void {
+                $table->unique('claim_token_hash', 'email_outbox_claim_token_hash_unique');
+            });
+        }
+
+        if (Schema::hasColumn($tableName, 'claim_expires_at')
+            && !SchemaIndex::indexExists($tableName, 'email_outbox_claim_expires_at_index')) {
+            Schema::table($tableName, function (Blueprint $table): void {
+                $table->index('claim_expires_at', 'email_outbox_claim_expires_at_index');
+            });
+        }
+
+        if (Schema::hasColumn($tableName, 'status') && !SchemaIndex::indexExists($tableName, 'email_outbox_status_index')) {
+            Schema::table($tableName, function (Blueprint $table): void {
+                $table->index('status', 'email_outbox_status_index');
+            });
+        }
     }
 
     public function down(): void

--- a/backend/database/migrations/2026_01_27_210100_create_ops_deploy_events.php
+++ b/backend/database/migrations/2026_01_27_210100_create_ops_deploy_events.php
@@ -1,5 +1,6 @@
 <?php
 
+use App\Support\Database\SchemaIndex;
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
@@ -8,22 +9,60 @@ return new class extends Migration
 {
     public function up(): void
     {
-        if (Schema::hasTable('ops_deploy_events')) {
-            return;
+        $tableName = 'ops_deploy_events';
+
+        if (!Schema::hasTable($tableName)) {
+            Schema::create($tableName, function (Blueprint $table): void {
+                $table->bigIncrements('id');
+                $table->string('env', 32);
+                $table->string('revision', 64);
+                $table->string('status', 32);
+                $table->string('actor', 64)->nullable();
+                $table->json('meta_json')->nullable();
+                $table->dateTime('occurred_at');
+                $table->timestamps();
+
+                $table->index(['env', 'occurred_at'], 'idx_ops_deploy_events_env_time');
+            });
         }
 
-        Schema::create('ops_deploy_events', function (Blueprint $table) {
-            $table->bigIncrements('id');
-            $table->string('env', 32);
-            $table->string('revision', 64);
-            $table->string('status', 32);
-            $table->string('actor', 64)->nullable();
-            $table->json('meta_json')->nullable();
-            $table->dateTime('occurred_at');
-            $table->timestamps();
-
-            $table->index(['env', 'occurred_at'], 'idx_ops_deploy_events_env_time');
+        Schema::table($tableName, function (Blueprint $table) use ($tableName): void {
+            if (!Schema::hasColumn($tableName, 'id')) {
+                $table->unsignedBigInteger('id')->nullable();
+            }
+            if (!Schema::hasColumn($tableName, 'env')) {
+                $table->string('env', 32)->nullable();
+            }
+            if (!Schema::hasColumn($tableName, 'revision')) {
+                $table->string('revision', 64)->nullable();
+            }
+            if (!Schema::hasColumn($tableName, 'status')) {
+                $table->string('status', 32)->nullable();
+            }
+            if (!Schema::hasColumn($tableName, 'actor')) {
+                $table->string('actor', 64)->nullable();
+            }
+            if (!Schema::hasColumn($tableName, 'meta_json')) {
+                $table->json('meta_json')->nullable();
+            }
+            if (!Schema::hasColumn($tableName, 'occurred_at')) {
+                $table->dateTime('occurred_at')->nullable();
+            }
+            if (!Schema::hasColumn($tableName, 'created_at')) {
+                $table->timestamp('created_at')->nullable();
+            }
+            if (!Schema::hasColumn($tableName, 'updated_at')) {
+                $table->timestamp('updated_at')->nullable();
+            }
         });
+
+        if (Schema::hasColumn($tableName, 'env')
+            && Schema::hasColumn($tableName, 'occurred_at')
+            && !SchemaIndex::indexExists($tableName, 'idx_ops_deploy_events_env_time')) {
+            Schema::table($tableName, function (Blueprint $table): void {
+                $table->index(['env', 'occurred_at'], 'idx_ops_deploy_events_env_time');
+            });
+        }
     }
 
     public function down(): void

--- a/backend/database/migrations/2026_01_27_210200_create_ops_healthz_snapshots.php
+++ b/backend/database/migrations/2026_01_27_210200_create_ops_healthz_snapshots.php
@@ -1,5 +1,6 @@
 <?php
 
+use App\Support\Database\SchemaIndex;
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
@@ -8,23 +9,70 @@ return new class extends Migration
 {
     public function up(): void
     {
-        if (Schema::hasTable('ops_healthz_snapshots')) {
-            return;
+        $tableName = 'ops_healthz_snapshots';
+
+        if (!Schema::hasTable($tableName)) {
+            Schema::create($tableName, function (Blueprint $table): void {
+                $table->bigIncrements('id');
+                $table->string('env', 32);
+                $table->string('revision', 64);
+                $table->unsignedTinyInteger('ok');
+                $table->json('deps_json');
+                $table->json('error_codes_json')->nullable();
+                $table->dateTime('occurred_at');
+                $table->timestamps();
+
+                $table->index(['env', 'occurred_at'], 'idx_ops_healthz_env_time');
+                $table->index(['env', 'ok', 'occurred_at'], 'idx_ops_healthz_ok');
+            });
         }
 
-        Schema::create('ops_healthz_snapshots', function (Blueprint $table) {
-            $table->bigIncrements('id');
-            $table->string('env', 32);
-            $table->string('revision', 64);
-            $table->unsignedTinyInteger('ok');
-            $table->json('deps_json');
-            $table->json('error_codes_json')->nullable();
-            $table->dateTime('occurred_at');
-            $table->timestamps();
-
-            $table->index(['env', 'occurred_at'], 'idx_ops_healthz_env_time');
-            $table->index(['env', 'ok', 'occurred_at'], 'idx_ops_healthz_ok');
+        Schema::table($tableName, function (Blueprint $table) use ($tableName): void {
+            if (!Schema::hasColumn($tableName, 'id')) {
+                $table->unsignedBigInteger('id')->nullable();
+            }
+            if (!Schema::hasColumn($tableName, 'env')) {
+                $table->string('env', 32)->nullable();
+            }
+            if (!Schema::hasColumn($tableName, 'revision')) {
+                $table->string('revision', 64)->nullable();
+            }
+            if (!Schema::hasColumn($tableName, 'ok')) {
+                $table->unsignedTinyInteger('ok')->default(0);
+            }
+            if (!Schema::hasColumn($tableName, 'deps_json')) {
+                $table->json('deps_json')->nullable();
+            }
+            if (!Schema::hasColumn($tableName, 'error_codes_json')) {
+                $table->json('error_codes_json')->nullable();
+            }
+            if (!Schema::hasColumn($tableName, 'occurred_at')) {
+                $table->dateTime('occurred_at')->nullable();
+            }
+            if (!Schema::hasColumn($tableName, 'created_at')) {
+                $table->timestamp('created_at')->nullable();
+            }
+            if (!Schema::hasColumn($tableName, 'updated_at')) {
+                $table->timestamp('updated_at')->nullable();
+            }
         });
+
+        if (Schema::hasColumn($tableName, 'env')
+            && Schema::hasColumn($tableName, 'occurred_at')
+            && !SchemaIndex::indexExists($tableName, 'idx_ops_healthz_env_time')) {
+            Schema::table($tableName, function (Blueprint $table): void {
+                $table->index(['env', 'occurred_at'], 'idx_ops_healthz_env_time');
+            });
+        }
+
+        if (Schema::hasColumn($tableName, 'env')
+            && Schema::hasColumn($tableName, 'ok')
+            && Schema::hasColumn($tableName, 'occurred_at')
+            && !SchemaIndex::indexExists($tableName, 'idx_ops_healthz_ok')) {
+            Schema::table($tableName, function (Blueprint $table): void {
+                $table->index(['env', 'ok', 'occurred_at'], 'idx_ops_healthz_ok');
+            });
+        }
     }
 
     public function down(): void

--- a/backend/database/migrations/2026_01_28_120000_create_ai_insights_table.php
+++ b/backend/database/migrations/2026_01_28_120000_create_ai_insights_table.php
@@ -1,5 +1,6 @@
 <?php
 
+use App\Support\Database\SchemaIndex;
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
@@ -8,33 +9,124 @@ return new class extends Migration
 {
     public function up(): void
     {
-        if (Schema::hasTable('ai_insights')) {
-            return;
+        $tableName = 'ai_insights';
+
+        if (!Schema::hasTable($tableName)) {
+            Schema::create($tableName, function (Blueprint $table): void {
+                $table->uuid('id')->primary();
+                $table->string('user_id')->nullable();
+                $table->string('anon_id')->nullable();
+                $table->string('period_type', 16);
+                $table->date('period_start');
+                $table->date('period_end');
+                $table->string('input_hash', 64);
+                $table->string('prompt_version', 64);
+                $table->string('model', 64);
+                $table->string('provider', 32);
+                $table->integer('tokens_in')->default(0);
+                $table->integer('tokens_out')->default(0);
+                $table->decimal('cost_usd', 10, 4)->default(0);
+                $table->string('status', 16);
+                $table->json('output_json')->nullable();
+                $table->json('evidence_json')->nullable();
+                $table->string('error_code', 64)->nullable();
+                $table->timestamps();
+
+                $table->index('input_hash', 'ai_insights_input_hash_index');
+                $table->index('status', 'ai_insights_status_index');
+                $table->index(['user_id', 'created_at'], 'ai_insights_user_id_created_at_index');
+                $table->index(['period_start', 'period_end'], 'ai_insights_period_start_period_end_index');
+            });
         }
 
-        Schema::create('ai_insights', function (Blueprint $table) {
-            $table->uuid('id')->primary();
-            $table->string('user_id')->nullable();
-            $table->string('anon_id')->nullable();
-            $table->string('period_type', 16);
-            $table->date('period_start');
-            $table->date('period_end');
-            $table->string('input_hash', 64)->index();
-            $table->string('prompt_version', 64);
-            $table->string('model', 64);
-            $table->string('provider', 32);
-            $table->integer('tokens_in')->default(0);
-            $table->integer('tokens_out')->default(0);
-            $table->decimal('cost_usd', 10, 4)->default(0);
-            $table->string('status', 16)->index();
-            $table->json('output_json')->nullable();
-            $table->json('evidence_json')->nullable();
-            $table->string('error_code', 64)->nullable();
-            $table->timestamps();
-
-            $table->index(['user_id', 'created_at']);
-            $table->index(['period_start', 'period_end']);
+        Schema::table($tableName, function (Blueprint $table) use ($tableName): void {
+            if (!Schema::hasColumn($tableName, 'id')) {
+                $table->uuid('id')->nullable();
+            }
+            if (!Schema::hasColumn($tableName, 'user_id')) {
+                $table->string('user_id')->nullable();
+            }
+            if (!Schema::hasColumn($tableName, 'anon_id')) {
+                $table->string('anon_id')->nullable();
+            }
+            if (!Schema::hasColumn($tableName, 'period_type')) {
+                $table->string('period_type', 16)->nullable();
+            }
+            if (!Schema::hasColumn($tableName, 'period_start')) {
+                $table->date('period_start')->nullable();
+            }
+            if (!Schema::hasColumn($tableName, 'period_end')) {
+                $table->date('period_end')->nullable();
+            }
+            if (!Schema::hasColumn($tableName, 'input_hash')) {
+                $table->string('input_hash', 64)->nullable();
+            }
+            if (!Schema::hasColumn($tableName, 'prompt_version')) {
+                $table->string('prompt_version', 64)->nullable();
+            }
+            if (!Schema::hasColumn($tableName, 'model')) {
+                $table->string('model', 64)->nullable();
+            }
+            if (!Schema::hasColumn($tableName, 'provider')) {
+                $table->string('provider', 32)->nullable();
+            }
+            if (!Schema::hasColumn($tableName, 'tokens_in')) {
+                $table->integer('tokens_in')->default(0);
+            }
+            if (!Schema::hasColumn($tableName, 'tokens_out')) {
+                $table->integer('tokens_out')->default(0);
+            }
+            if (!Schema::hasColumn($tableName, 'cost_usd')) {
+                $table->decimal('cost_usd', 10, 4)->default(0);
+            }
+            if (!Schema::hasColumn($tableName, 'status')) {
+                $table->string('status', 16)->nullable();
+            }
+            if (!Schema::hasColumn($tableName, 'output_json')) {
+                $table->json('output_json')->nullable();
+            }
+            if (!Schema::hasColumn($tableName, 'evidence_json')) {
+                $table->json('evidence_json')->nullable();
+            }
+            if (!Schema::hasColumn($tableName, 'error_code')) {
+                $table->string('error_code', 64)->nullable();
+            }
+            if (!Schema::hasColumn($tableName, 'created_at')) {
+                $table->timestamp('created_at')->nullable();
+            }
+            if (!Schema::hasColumn($tableName, 'updated_at')) {
+                $table->timestamp('updated_at')->nullable();
+            }
         });
+
+        if (Schema::hasColumn($tableName, 'input_hash')
+            && !SchemaIndex::indexExists($tableName, 'ai_insights_input_hash_index')) {
+            Schema::table($tableName, function (Blueprint $table): void {
+                $table->index('input_hash', 'ai_insights_input_hash_index');
+            });
+        }
+
+        if (Schema::hasColumn($tableName, 'status') && !SchemaIndex::indexExists($tableName, 'ai_insights_status_index')) {
+            Schema::table($tableName, function (Blueprint $table): void {
+                $table->index('status', 'ai_insights_status_index');
+            });
+        }
+
+        if (Schema::hasColumn($tableName, 'user_id')
+            && Schema::hasColumn($tableName, 'created_at')
+            && !SchemaIndex::indexExists($tableName, 'ai_insights_user_id_created_at_index')) {
+            Schema::table($tableName, function (Blueprint $table): void {
+                $table->index(['user_id', 'created_at'], 'ai_insights_user_id_created_at_index');
+            });
+        }
+
+        if (Schema::hasColumn($tableName, 'period_start')
+            && Schema::hasColumn($tableName, 'period_end')
+            && !SchemaIndex::indexExists($tableName, 'ai_insights_period_start_period_end_index')) {
+            Schema::table($tableName, function (Blueprint $table): void {
+                $table->index(['period_start', 'period_end'], 'ai_insights_period_start_period_end_index');
+            });
+        }
     }
 
     public function down(): void

--- a/backend/database/migrations/2026_01_28_120100_create_ai_insight_feedback_table.php
+++ b/backend/database/migrations/2026_01_28_120100_create_ai_insight_feedback_table.php
@@ -1,5 +1,6 @@
 <?php
 
+use App\Support\Database\SchemaIndex;
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
@@ -8,20 +9,48 @@ return new class extends Migration
 {
     public function up(): void
     {
-        if (Schema::hasTable('ai_insight_feedback')) {
-            return;
+        $tableName = 'ai_insight_feedback';
+
+        if (!Schema::hasTable($tableName)) {
+            Schema::create($tableName, function (Blueprint $table): void {
+                $table->uuid('id')->primary();
+                $table->uuid('insight_id');
+                $table->integer('rating');
+                $table->string('reason', 64)->nullable();
+                $table->text('comment')->nullable();
+                $table->timestamp('created_at')->useCurrent();
+
+                $table->index(['insight_id'], 'ai_insight_feedback_insight_id_index');
+            });
         }
 
-        Schema::create('ai_insight_feedback', function (Blueprint $table) {
-            $table->uuid('id')->primary();
-            $table->uuid('insight_id');
-            $table->integer('rating');
-            $table->string('reason', 64)->nullable();
-            $table->text('comment')->nullable();
-            $table->timestamp('created_at')->useCurrent();
-
-            $table->index(['insight_id']);
+        Schema::table($tableName, function (Blueprint $table) use ($tableName): void {
+            if (!Schema::hasColumn($tableName, 'id')) {
+                $table->uuid('id')->nullable();
+            }
+            if (!Schema::hasColumn($tableName, 'insight_id')) {
+                $table->uuid('insight_id')->nullable();
+            }
+            if (!Schema::hasColumn($tableName, 'rating')) {
+                $table->integer('rating')->nullable();
+            }
+            if (!Schema::hasColumn($tableName, 'reason')) {
+                $table->string('reason', 64)->nullable();
+            }
+            if (!Schema::hasColumn($tableName, 'comment')) {
+                $table->text('comment')->nullable();
+            }
+            if (!Schema::hasColumn($tableName, 'created_at')) {
+                $table->timestamp('created_at')->nullable()->useCurrent();
+            }
         });
+
+        if (Schema::hasColumn($tableName, 'insight_id')
+            && !SchemaIndex::indexExists($tableName, 'ai_insight_feedback_insight_id_index')) {
+            Schema::table($tableName, function (Blueprint $table): void {
+                $table->index(['insight_id'], 'ai_insight_feedback_insight_id_index');
+            });
+        }
     }
 
     public function down(): void

--- a/backend/database/migrations/2026_01_29_000001_create_organizations_table.php
+++ b/backend/database/migrations/2026_01_29_000001_create_organizations_table.php
@@ -1,5 +1,6 @@
 <?php
 
+use App\Support\Database\SchemaIndex;
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
@@ -8,18 +9,43 @@ return new class extends Migration
 {
     public function up(): void
     {
-        if (Schema::hasTable('organizations')) {
-            return;
+        $tableName = 'organizations';
+
+        if (!Schema::hasTable($tableName)) {
+            Schema::create($tableName, function (Blueprint $table): void {
+                $table->bigIncrements('id');
+                $table->string('name', 255);
+                $table->unsignedBigInteger('owner_user_id');
+                $table->timestamps();
+
+                $table->index('owner_user_id', 'organizations_owner_user_id_idx');
+            });
         }
 
-        Schema::create('organizations', function (Blueprint $table) {
-            $table->bigIncrements('id');
-            $table->string('name', 255);
-            $table->unsignedBigInteger('owner_user_id');
-            $table->timestamps();
-
-            $table->index('owner_user_id', 'organizations_owner_user_id_idx');
+        Schema::table($tableName, function (Blueprint $table) use ($tableName): void {
+            if (!Schema::hasColumn($tableName, 'id')) {
+                $table->unsignedBigInteger('id')->nullable();
+            }
+            if (!Schema::hasColumn($tableName, 'name')) {
+                $table->string('name', 255)->nullable();
+            }
+            if (!Schema::hasColumn($tableName, 'owner_user_id')) {
+                $table->unsignedBigInteger('owner_user_id')->nullable();
+            }
+            if (!Schema::hasColumn($tableName, 'created_at')) {
+                $table->timestamp('created_at')->nullable();
+            }
+            if (!Schema::hasColumn($tableName, 'updated_at')) {
+                $table->timestamp('updated_at')->nullable();
+            }
         });
+
+        if (Schema::hasColumn($tableName, 'owner_user_id')
+            && !SchemaIndex::indexExists($tableName, 'organizations_owner_user_id_idx')) {
+            Schema::table($tableName, function (Blueprint $table): void {
+                $table->index('owner_user_id', 'organizations_owner_user_id_idx');
+            });
+        }
     }
 
     public function down(): void

--- a/backend/database/migrations/2026_01_29_000002_create_organization_members_table.php
+++ b/backend/database/migrations/2026_01_29_000002_create_organization_members_table.php
@@ -1,5 +1,6 @@
 <?php
 
+use App\Support\Database\SchemaIndex;
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
@@ -8,22 +9,68 @@ return new class extends Migration
 {
     public function up(): void
     {
-        if (Schema::hasTable('organization_members')) {
-            return;
+        $tableName = 'organization_members';
+
+        if (!Schema::hasTable($tableName)) {
+            Schema::create($tableName, function (Blueprint $table): void {
+                $table->bigIncrements('id');
+                $table->unsignedBigInteger('org_id');
+                $table->unsignedBigInteger('user_id');
+                $table->string('role', 32);
+                $table->timestamp('joined_at')->nullable();
+                $table->timestamps();
+
+                $table->unique(['org_id', 'user_id'], 'organization_members_org_user_unique');
+                $table->index('org_id', 'organization_members_org_id_idx');
+                $table->index('user_id', 'organization_members_user_id_idx');
+            });
         }
 
-        Schema::create('organization_members', function (Blueprint $table) {
-            $table->bigIncrements('id');
-            $table->unsignedBigInteger('org_id');
-            $table->unsignedBigInteger('user_id');
-            $table->string('role', 32);
-            $table->timestamp('joined_at')->nullable();
-            $table->timestamps();
-
-            $table->unique(['org_id', 'user_id'], 'organization_members_org_user_unique');
-            $table->index('org_id', 'organization_members_org_id_idx');
-            $table->index('user_id', 'organization_members_user_id_idx');
+        Schema::table($tableName, function (Blueprint $table) use ($tableName): void {
+            if (!Schema::hasColumn($tableName, 'id')) {
+                $table->unsignedBigInteger('id')->nullable();
+            }
+            if (!Schema::hasColumn($tableName, 'org_id')) {
+                $table->unsignedBigInteger('org_id')->nullable();
+            }
+            if (!Schema::hasColumn($tableName, 'user_id')) {
+                $table->unsignedBigInteger('user_id')->nullable();
+            }
+            if (!Schema::hasColumn($tableName, 'role')) {
+                $table->string('role', 32)->nullable();
+            }
+            if (!Schema::hasColumn($tableName, 'joined_at')) {
+                $table->timestamp('joined_at')->nullable();
+            }
+            if (!Schema::hasColumn($tableName, 'created_at')) {
+                $table->timestamp('created_at')->nullable();
+            }
+            if (!Schema::hasColumn($tableName, 'updated_at')) {
+                $table->timestamp('updated_at')->nullable();
+            }
         });
+
+        if (Schema::hasColumn($tableName, 'org_id')
+            && Schema::hasColumn($tableName, 'user_id')
+            && !SchemaIndex::indexExists($tableName, 'organization_members_org_user_unique')) {
+            Schema::table($tableName, function (Blueprint $table): void {
+                $table->unique(['org_id', 'user_id'], 'organization_members_org_user_unique');
+            });
+        }
+
+        if (Schema::hasColumn($tableName, 'org_id')
+            && !SchemaIndex::indexExists($tableName, 'organization_members_org_id_idx')) {
+            Schema::table($tableName, function (Blueprint $table): void {
+                $table->index('org_id', 'organization_members_org_id_idx');
+            });
+        }
+
+        if (Schema::hasColumn($tableName, 'user_id')
+            && !SchemaIndex::indexExists($tableName, 'organization_members_user_id_idx')) {
+            Schema::table($tableName, function (Blueprint $table): void {
+                $table->index('user_id', 'organization_members_user_id_idx');
+            });
+        }
     }
 
     public function down(): void

--- a/backend/database/migrations/2026_01_29_000003_create_organization_invites_table.php
+++ b/backend/database/migrations/2026_01_29_000003_create_organization_invites_table.php
@@ -1,5 +1,6 @@
 <?php
 
+use App\Support\Database\SchemaIndex;
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
@@ -8,22 +9,70 @@ return new class extends Migration
 {
     public function up(): void
     {
-        if (Schema::hasTable('organization_invites')) {
-            return;
+        $tableName = 'organization_invites';
+
+        if (!Schema::hasTable($tableName)) {
+            Schema::create($tableName, function (Blueprint $table): void {
+                $table->bigIncrements('id');
+                $table->unsignedBigInteger('org_id');
+                $table->string('email', 255);
+                $table->string('token', 128)->unique('organization_invites_token_unique');
+                $table->timestamp('expires_at')->nullable();
+                $table->timestamp('accepted_at')->nullable();
+                $table->timestamps();
+
+                $table->index('org_id', 'organization_invites_org_id_idx');
+                $table->index('email', 'organization_invites_email_idx');
+            });
         }
 
-        Schema::create('organization_invites', function (Blueprint $table) {
-            $table->bigIncrements('id');
-            $table->unsignedBigInteger('org_id');
-            $table->string('email', 255);
-            $table->string('token', 128)->unique('organization_invites_token_unique');
-            $table->timestamp('expires_at')->nullable();
-            $table->timestamp('accepted_at')->nullable();
-            $table->timestamps();
-
-            $table->index('org_id', 'organization_invites_org_id_idx');
-            $table->index('email', 'organization_invites_email_idx');
+        Schema::table($tableName, function (Blueprint $table) use ($tableName): void {
+            if (!Schema::hasColumn($tableName, 'id')) {
+                $table->unsignedBigInteger('id')->nullable();
+            }
+            if (!Schema::hasColumn($tableName, 'org_id')) {
+                $table->unsignedBigInteger('org_id')->nullable();
+            }
+            if (!Schema::hasColumn($tableName, 'email')) {
+                $table->string('email', 255)->nullable();
+            }
+            if (!Schema::hasColumn($tableName, 'token')) {
+                $table->string('token', 128)->nullable();
+            }
+            if (!Schema::hasColumn($tableName, 'expires_at')) {
+                $table->timestamp('expires_at')->nullable();
+            }
+            if (!Schema::hasColumn($tableName, 'accepted_at')) {
+                $table->timestamp('accepted_at')->nullable();
+            }
+            if (!Schema::hasColumn($tableName, 'created_at')) {
+                $table->timestamp('created_at')->nullable();
+            }
+            if (!Schema::hasColumn($tableName, 'updated_at')) {
+                $table->timestamp('updated_at')->nullable();
+            }
         });
+
+        if (Schema::hasColumn($tableName, 'token')
+            && !SchemaIndex::indexExists($tableName, 'organization_invites_token_unique')) {
+            Schema::table($tableName, function (Blueprint $table): void {
+                $table->unique('token', 'organization_invites_token_unique');
+            });
+        }
+
+        if (Schema::hasColumn($tableName, 'org_id')
+            && !SchemaIndex::indexExists($tableName, 'organization_invites_org_id_idx')) {
+            Schema::table($tableName, function (Blueprint $table): void {
+                $table->index('org_id', 'organization_invites_org_id_idx');
+            });
+        }
+
+        if (Schema::hasColumn($tableName, 'email')
+            && !SchemaIndex::indexExists($tableName, 'organization_invites_email_idx')) {
+            Schema::table($tableName, function (Blueprint $table): void {
+                $table->index('email', 'organization_invites_email_idx');
+            });
+        }
     }
 
     public function down(): void

--- a/backend/database/migrations/2026_01_30_120001_create_feature_flags_table.php
+++ b/backend/database/migrations/2026_01_30_120001_create_feature_flags_table.php
@@ -1,5 +1,6 @@
 <?php
 
+use App\Support\Database\SchemaIndex;
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
@@ -8,17 +9,45 @@ return new class extends Migration
 {
     public function up(): void
     {
-        if (Schema::hasTable('feature_flags')) {
-            return;
+        $tableName = 'feature_flags';
+
+        if (!Schema::hasTable($tableName)) {
+            Schema::create($tableName, function (Blueprint $table): void {
+                $table->id();
+                $table->string('key')->unique('feature_flags_key_unique');
+                $table->json('rules_json')->nullable();
+                $table->boolean('is_active')->default(true);
+                $table->timestamps();
+            });
         }
 
-        Schema::create('feature_flags', function (Blueprint $table) {
-            $table->id();
-            $table->string('key')->unique('feature_flags_key_unique');
-            $table->json('rules_json')->nullable();
-            $table->boolean('is_active')->default(true);
-            $table->timestamps();
+        Schema::table($tableName, function (Blueprint $table) use ($tableName): void {
+            if (!Schema::hasColumn($tableName, 'id')) {
+                $table->unsignedBigInteger('id')->nullable();
+            }
+            if (!Schema::hasColumn($tableName, 'key')) {
+                $table->string('key')->nullable();
+            }
+            if (!Schema::hasColumn($tableName, 'rules_json')) {
+                $table->json('rules_json')->nullable();
+            }
+            if (!Schema::hasColumn($tableName, 'is_active')) {
+                $table->boolean('is_active')->default(true);
+            }
+            if (!Schema::hasColumn($tableName, 'created_at')) {
+                $table->timestamp('created_at')->nullable();
+            }
+            if (!Schema::hasColumn($tableName, 'updated_at')) {
+                $table->timestamp('updated_at')->nullable();
+            }
         });
+
+        if (Schema::hasColumn($tableName, 'key')
+            && !SchemaIndex::indexExists($tableName, 'feature_flags_key_unique')) {
+            Schema::table($tableName, function (Blueprint $table): void {
+                $table->unique('key', 'feature_flags_key_unique');
+            });
+        }
     }
 
     public function down(): void

--- a/backend/database/migrations/2026_01_30_120002_create_experiment_assignments_table.php
+++ b/backend/database/migrations/2026_01_30_120002_create_experiment_assignments_table.php
@@ -1,5 +1,6 @@
 <?php
 
+use App\Support\Database\SchemaIndex;
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
@@ -8,24 +9,80 @@ return new class extends Migration
 {
     public function up(): void
     {
-        if (Schema::hasTable('experiment_assignments')) {
-            return;
+        $tableName = 'experiment_assignments';
+
+        if (!Schema::hasTable($tableName)) {
+            Schema::create($tableName, function (Blueprint $table): void {
+                $table->id();
+                $table->unsignedBigInteger('org_id')->default(0);
+                $table->string('anon_id');
+                $table->unsignedBigInteger('user_id')->nullable();
+                $table->string('experiment_key');
+                $table->string('variant');
+                $table->timestamp('assigned_at');
+                $table->timestamps();
+
+                $table->unique(['org_id', 'anon_id', 'experiment_key'], 'experiment_assignments_org_anon_experiment_unique');
+                $table->index(['org_id', 'user_id', 'experiment_key'], 'experiment_assignments_org_user_experiment_idx');
+                $table->index(['org_id', 'experiment_key'], 'experiment_assignments_org_experiment_idx');
+            });
         }
 
-        Schema::create('experiment_assignments', function (Blueprint $table) {
-            $table->id();
-            $table->unsignedBigInteger('org_id')->default(0);
-            $table->string('anon_id');
-            $table->unsignedBigInteger('user_id')->nullable();
-            $table->string('experiment_key');
-            $table->string('variant');
-            $table->timestamp('assigned_at');
-            $table->timestamps();
-
-            $table->unique(['org_id', 'anon_id', 'experiment_key'], 'experiment_assignments_org_anon_experiment_unique');
-            $table->index(['org_id', 'user_id', 'experiment_key'], 'experiment_assignments_org_user_experiment_idx');
-            $table->index(['org_id', 'experiment_key'], 'experiment_assignments_org_experiment_idx');
+        Schema::table($tableName, function (Blueprint $table) use ($tableName): void {
+            if (!Schema::hasColumn($tableName, 'id')) {
+                $table->unsignedBigInteger('id')->nullable();
+            }
+            if (!Schema::hasColumn($tableName, 'org_id')) {
+                $table->unsignedBigInteger('org_id')->default(0);
+            }
+            if (!Schema::hasColumn($tableName, 'anon_id')) {
+                $table->string('anon_id')->nullable();
+            }
+            if (!Schema::hasColumn($tableName, 'user_id')) {
+                $table->unsignedBigInteger('user_id')->nullable();
+            }
+            if (!Schema::hasColumn($tableName, 'experiment_key')) {
+                $table->string('experiment_key')->nullable();
+            }
+            if (!Schema::hasColumn($tableName, 'variant')) {
+                $table->string('variant')->nullable();
+            }
+            if (!Schema::hasColumn($tableName, 'assigned_at')) {
+                $table->timestamp('assigned_at')->nullable();
+            }
+            if (!Schema::hasColumn($tableName, 'created_at')) {
+                $table->timestamp('created_at')->nullable();
+            }
+            if (!Schema::hasColumn($tableName, 'updated_at')) {
+                $table->timestamp('updated_at')->nullable();
+            }
         });
+
+        if (Schema::hasColumn($tableName, 'org_id')
+            && Schema::hasColumn($tableName, 'anon_id')
+            && Schema::hasColumn($tableName, 'experiment_key')
+            && !SchemaIndex::indexExists($tableName, 'experiment_assignments_org_anon_experiment_unique')) {
+            Schema::table($tableName, function (Blueprint $table): void {
+                $table->unique(['org_id', 'anon_id', 'experiment_key'], 'experiment_assignments_org_anon_experiment_unique');
+            });
+        }
+
+        if (Schema::hasColumn($tableName, 'org_id')
+            && Schema::hasColumn($tableName, 'user_id')
+            && Schema::hasColumn($tableName, 'experiment_key')
+            && !SchemaIndex::indexExists($tableName, 'experiment_assignments_org_user_experiment_idx')) {
+            Schema::table($tableName, function (Blueprint $table): void {
+                $table->index(['org_id', 'user_id', 'experiment_key'], 'experiment_assignments_org_user_experiment_idx');
+            });
+        }
+
+        if (Schema::hasColumn($tableName, 'org_id')
+            && Schema::hasColumn($tableName, 'experiment_key')
+            && !SchemaIndex::indexExists($tableName, 'experiment_assignments_org_experiment_idx')) {
+            Schema::table($tableName, function (Blueprint $table): void {
+                $table->index(['org_id', 'experiment_key'], 'experiment_assignments_org_experiment_idx');
+            });
+        }
     }
 
     public function down(): void

--- a/backend/database/migrations/2026_01_31_090000_create_assessments_table.php
+++ b/backend/database/migrations/2026_01_31_090000_create_assessments_table.php
@@ -1,5 +1,6 @@
 <?php
 
+use App\Support\Database\SchemaIndex;
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
@@ -8,23 +9,69 @@ return new class extends Migration
 {
     public function up(): void
     {
-        if (Schema::hasTable('assessments')) {
-            return;
+        $tableName = 'assessments';
+
+        if (!Schema::hasTable($tableName)) {
+            Schema::create($tableName, function (Blueprint $table): void {
+                $table->bigIncrements('id');
+                $table->unsignedBigInteger('org_id');
+                $table->string('scale_code', 64);
+                $table->string('title', 255);
+                $table->unsignedBigInteger('created_by');
+                $table->timestamp('due_at')->nullable();
+                $table->string('status', 32)->default('open');
+                $table->timestamps();
+
+                $table->index(['org_id', 'created_at'], 'assessments_org_created_idx');
+                $table->index(['org_id', 'status'], 'assessments_org_status_idx');
+            });
         }
 
-        Schema::create('assessments', function (Blueprint $table) {
-            $table->bigIncrements('id');
-            $table->unsignedBigInteger('org_id');
-            $table->string('scale_code', 64);
-            $table->string('title', 255);
-            $table->unsignedBigInteger('created_by');
-            $table->timestamp('due_at')->nullable();
-            $table->string('status', 32)->default('open');
-            $table->timestamps();
-
-            $table->index(['org_id', 'created_at'], 'assessments_org_created_idx');
-            $table->index(['org_id', 'status'], 'assessments_org_status_idx');
+        Schema::table($tableName, function (Blueprint $table) use ($tableName): void {
+            if (!Schema::hasColumn($tableName, 'id')) {
+                $table->unsignedBigInteger('id')->nullable();
+            }
+            if (!Schema::hasColumn($tableName, 'org_id')) {
+                $table->unsignedBigInteger('org_id')->nullable();
+            }
+            if (!Schema::hasColumn($tableName, 'scale_code')) {
+                $table->string('scale_code', 64)->nullable();
+            }
+            if (!Schema::hasColumn($tableName, 'title')) {
+                $table->string('title', 255)->nullable();
+            }
+            if (!Schema::hasColumn($tableName, 'created_by')) {
+                $table->unsignedBigInteger('created_by')->nullable();
+            }
+            if (!Schema::hasColumn($tableName, 'due_at')) {
+                $table->timestamp('due_at')->nullable();
+            }
+            if (!Schema::hasColumn($tableName, 'status')) {
+                $table->string('status', 32)->default('open');
+            }
+            if (!Schema::hasColumn($tableName, 'created_at')) {
+                $table->timestamp('created_at')->nullable();
+            }
+            if (!Schema::hasColumn($tableName, 'updated_at')) {
+                $table->timestamp('updated_at')->nullable();
+            }
         });
+
+        if (Schema::hasColumn($tableName, 'org_id')
+            && Schema::hasColumn($tableName, 'created_at')
+            && !SchemaIndex::indexExists($tableName, 'assessments_org_created_idx')) {
+            Schema::table($tableName, function (Blueprint $table): void {
+                $table->index(['org_id', 'created_at'], 'assessments_org_created_idx');
+            });
+        }
+
+        if (Schema::hasColumn($tableName, 'org_id')
+            && Schema::hasColumn($tableName, 'status')
+            && !SchemaIndex::indexExists($tableName, 'assessments_org_status_idx')) {
+            Schema::table($tableName, function (Blueprint $table): void {
+                $table->index(['org_id', 'status'], 'assessments_org_status_idx');
+            });
+        }
     }
 
     public function down(): void

--- a/backend/database/migrations/2026_01_31_090010_create_assessment_assignments_table.php
+++ b/backend/database/migrations/2026_01_31_090010_create_assessment_assignments_table.php
@@ -1,5 +1,6 @@
 <?php
 
+use App\Support\Database\SchemaIndex;
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
@@ -8,27 +9,93 @@ return new class extends Migration
 {
     public function up(): void
     {
-        if (Schema::hasTable('assessment_assignments')) {
-            return;
+        $tableName = 'assessment_assignments';
+
+        if (!Schema::hasTable($tableName)) {
+            Schema::create($tableName, function (Blueprint $table): void {
+                $table->bigIncrements('id');
+                $table->unsignedBigInteger('org_id');
+                $table->unsignedBigInteger('assessment_id');
+                $table->string('subject_type', 16);
+                $table->string('subject_value', 255);
+                $table->string('invite_token', 64);
+                $table->timestamp('started_at')->nullable();
+                $table->timestamp('completed_at')->nullable();
+                $table->string('attempt_id', 64)->nullable();
+                $table->timestamps();
+
+                $table->unique('invite_token', 'assessment_assignments_invite_unique');
+                $table->index(['org_id', 'assessment_id'], 'assessment_assignments_org_assessment_idx');
+                $table->index(['org_id', 'invite_token'], 'assessment_assignments_org_invite_idx');
+                $table->index('attempt_id', 'assessment_assignments_attempt_idx');
+            });
         }
 
-        Schema::create('assessment_assignments', function (Blueprint $table) {
-            $table->bigIncrements('id');
-            $table->unsignedBigInteger('org_id');
-            $table->unsignedBigInteger('assessment_id');
-            $table->string('subject_type', 16);
-            $table->string('subject_value', 255);
-            $table->string('invite_token', 64);
-            $table->timestamp('started_at')->nullable();
-            $table->timestamp('completed_at')->nullable();
-            $table->string('attempt_id', 64)->nullable();
-            $table->timestamps();
-
-            $table->unique('invite_token', 'assessment_assignments_invite_unique');
-            $table->index(['org_id', 'assessment_id'], 'assessment_assignments_org_assessment_idx');
-            $table->index(['org_id', 'invite_token'], 'assessment_assignments_org_invite_idx');
-            $table->index('attempt_id', 'assessment_assignments_attempt_idx');
+        Schema::table($tableName, function (Blueprint $table) use ($tableName): void {
+            if (!Schema::hasColumn($tableName, 'id')) {
+                $table->unsignedBigInteger('id')->nullable();
+            }
+            if (!Schema::hasColumn($tableName, 'org_id')) {
+                $table->unsignedBigInteger('org_id')->nullable();
+            }
+            if (!Schema::hasColumn($tableName, 'assessment_id')) {
+                $table->unsignedBigInteger('assessment_id')->nullable();
+            }
+            if (!Schema::hasColumn($tableName, 'subject_type')) {
+                $table->string('subject_type', 16)->nullable();
+            }
+            if (!Schema::hasColumn($tableName, 'subject_value')) {
+                $table->string('subject_value', 255)->nullable();
+            }
+            if (!Schema::hasColumn($tableName, 'invite_token')) {
+                $table->string('invite_token', 64)->nullable();
+            }
+            if (!Schema::hasColumn($tableName, 'started_at')) {
+                $table->timestamp('started_at')->nullable();
+            }
+            if (!Schema::hasColumn($tableName, 'completed_at')) {
+                $table->timestamp('completed_at')->nullable();
+            }
+            if (!Schema::hasColumn($tableName, 'attempt_id')) {
+                $table->string('attempt_id', 64)->nullable();
+            }
+            if (!Schema::hasColumn($tableName, 'created_at')) {
+                $table->timestamp('created_at')->nullable();
+            }
+            if (!Schema::hasColumn($tableName, 'updated_at')) {
+                $table->timestamp('updated_at')->nullable();
+            }
         });
+
+        if (Schema::hasColumn($tableName, 'invite_token')
+            && !SchemaIndex::indexExists($tableName, 'assessment_assignments_invite_unique')) {
+            Schema::table($tableName, function (Blueprint $table): void {
+                $table->unique('invite_token', 'assessment_assignments_invite_unique');
+            });
+        }
+
+        if (Schema::hasColumn($tableName, 'org_id')
+            && Schema::hasColumn($tableName, 'assessment_id')
+            && !SchemaIndex::indexExists($tableName, 'assessment_assignments_org_assessment_idx')) {
+            Schema::table($tableName, function (Blueprint $table): void {
+                $table->index(['org_id', 'assessment_id'], 'assessment_assignments_org_assessment_idx');
+            });
+        }
+
+        if (Schema::hasColumn($tableName, 'org_id')
+            && Schema::hasColumn($tableName, 'invite_token')
+            && !SchemaIndex::indexExists($tableName, 'assessment_assignments_org_invite_idx')) {
+            Schema::table($tableName, function (Blueprint $table): void {
+                $table->index(['org_id', 'invite_token'], 'assessment_assignments_org_invite_idx');
+            });
+        }
+
+        if (Schema::hasColumn($tableName, 'attempt_id')
+            && !SchemaIndex::indexExists($tableName, 'assessment_assignments_attempt_idx')) {
+            Schema::table($tableName, function (Blueprint $table): void {
+                $table->index('attempt_id', 'assessment_assignments_attempt_idx');
+            });
+        }
     }
 
     public function down(): void

--- a/backend/tests/Unit/Migrations/CreateMigrationsMustConvergeTest.php
+++ b/backend/tests/Unit/Migrations/CreateMigrationsMustConvergeTest.php
@@ -1,0 +1,141 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Migrations;
+
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+final class CreateMigrationsMustConvergeTest extends TestCase
+{
+    #[Test]
+    public function guarded_create_migration_must_include_schema_table_patch_in_up(): void
+    {
+        $violations = [];
+
+        foreach ($this->migrationFiles() as $filePath) {
+            $source = (string) file_get_contents($filePath);
+            $upBody = $this->methodBody($source, 'up');
+
+            if ($upBody === null) {
+                continue;
+            }
+
+            $matched = preg_match_all(
+                "/if\\s*\\(\\s*Schema::hasTable\\('([^']+)'\\)\\s*\\)\\s*\\{\\s*return;\\s*\\}/m",
+                $upBody,
+                $matches
+            );
+
+            if ($matched === false || $matched === 0) {
+                continue;
+            }
+
+            foreach ($matches[1] as $tableName) {
+                $tablePattern = "/Schema::table\\s*\\(\\s*'" . preg_quote((string) $tableName, '/') . "'\\s*,/m";
+                if (preg_match($tablePattern, $upBody) !== 1) {
+                    $violations[] = "{$filePath} -> {$tableName}";
+                }
+            }
+        }
+
+        $this->assertSame(
+            [],
+            $violations,
+            "Found non-convergent guarded create migrations (missing Schema::table patch in up()):\n" . implode("\n", $violations)
+        );
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function migrationFiles(): array
+    {
+        $files = glob(base_path('database/migrations/*.php'));
+
+        if (!is_array($files)) {
+            return [];
+        }
+
+        sort($files);
+
+        return array_values($files);
+    }
+
+    private function methodBody(string $source, string $methodName): ?string
+    {
+        $tokens = token_get_all($source);
+        $count = count($tokens);
+
+        for ($i = 0; $i < $count; $i++) {
+            $token = $tokens[$i];
+            if (!is_array($token) || $token[0] !== T_FUNCTION) {
+                continue;
+            }
+
+            $name = null;
+            for ($j = $i + 1; $j < $count; $j++) {
+                $next = $tokens[$j];
+                if (is_array($next) && $next[0] === T_STRING) {
+                    $name = $next[1];
+                    $i = $j;
+                    break;
+                }
+            }
+
+            if ($name !== $methodName) {
+                continue;
+            }
+
+            while ($i < $count && $this->tokenText($tokens[$i]) !== '{') {
+                $i++;
+            }
+
+            if ($i >= $count || $this->tokenText($tokens[$i]) !== '{') {
+                return null;
+            }
+
+            $braceDepth = 1;
+            $i++;
+            $body = '';
+
+            for (; $i < $count; $i++) {
+                $text = $this->tokenText($tokens[$i]);
+
+                if ($text === '{') {
+                    $braceDepth++;
+                    $body .= $text;
+                    continue;
+                }
+
+                if ($text === '}') {
+                    $braceDepth--;
+                    if ($braceDepth === 0) {
+                        return $body;
+                    }
+                    $body .= $text;
+                    continue;
+                }
+
+                $body .= $text;
+            }
+
+            return null;
+        }
+
+        return null;
+    }
+
+    /**
+     * @param string|array{int, string, int} $token
+     */
+    private function tokenText(string|array $token): string
+    {
+        if (is_string($token)) {
+            return $token;
+        }
+
+        return $token[1];
+    }
+}


### PR DESCRIPTION
## Summary
- Refactor 13 risky guarded-create migrations from `if (Schema::hasTable('x')) { return; }` into convergent `create + patch` flow.
- For each targeted table:
  - keep `Schema::create(...)` for table-not-exists path
  - add `Schema::table(...)` patch path with per-column `Schema::hasColumn(...)` guards
  - guard index/unique creation via `SchemaIndex::indexExists(...)`
- Add static unit guardrail:
  - `CreateMigrationsMustConvergeTest`
  - fails when a migration has guarded `hasTable + return` in `up()` but no matching `Schema::table(...)` patch.

## Scope
- Changed only detected risky migration files under `backend/database/migrations`.
- Added one unit test under `backend/tests/Unit/Migrations`.
- No route/controller/service/middleware/script logic changes.

## Verification
- Drift scanner: `HIT 0`
- `php artisan route:list`
- `php artisan migrate` (`Nothing to migrate`)
- `php artisan test --testsuite=Unit` (`49 passed`)
- `curl -sS http://127.0.0.1:8000/api/healthz` (`200`)
- `curl -sS http://127.0.0.1:8000/api/v0.2/healthz` (`200`)
- `bash backend/scripts/ci_verify_mbti.sh` (green end-to-end)

## Risk/Compatibility
- `down()` semantics unchanged.
- Patch path uses nullable/default-safe additions to avoid impossible constraints on existing data.
- Index names are explicit and guarded for cross-driver consistency.
