### PR TITLE
fix(payments): scope payment event idempotency by provider

### DIFF
--- a/backend/database/migrations/2026_01_22_090030_create_payment_events_table.php
+++ b/backend/database/migrations/2026_01_22_090030_create_payment_events_table.php
@@ -12,7 +12,7 @@ return new class extends Migration
             Schema::create('payment_events', function (Blueprint $table) {
                 $table->uuid('id')->primary();
                 $table->string('provider', 32);
-                $table->string('provider_event_id', 128)->unique();
+                $table->string('provider_event_id', 128);
                 $table->uuid('order_id');
                 $table->string('event_type', 64);
                 $table->json('payload_json');
@@ -24,6 +24,7 @@ return new class extends Migration
                 $table->string('headers_digest', 64)->nullable();
                 $table->timestamps();
 
+                $table->unique(['provider', 'provider_event_id'], 'payment_events_provider_provider_event_id_unique');
                 $table->index('order_id');
             });
             return;

--- a/backend/scripts/ci_verify_mbti.sh
+++ b/backend/scripts/ci_verify_mbti.sh
@@ -790,6 +790,10 @@ API="$API" SQLITE_DB="$SQLITE_DB_FOR_ACCEPT" FM_TOKEN="$FM_TOKEN" \
 
 echo "[CI] events acceptance OK"
 
+echo "[CI] payment event provider uniqueness gate"
+php artisan test --filter PaymentEventUniquenessAcrossProvidersTest
+echo "[CI] payment event provider uniqueness gate OK"
+
 echo "[CI] migration safety gates"
 php artisan test --filter MigrationSafetyTest
 php artisan test --filter MigrationRollbackSafetyTest

--- a/backend/tests/Unit/Commerce/PaymentEventsProviderScopeGuardTest.php
+++ b/backend/tests/Unit/Commerce/PaymentEventsProviderScopeGuardTest.php
@@ -1,0 +1,155 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Commerce;
+
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+final class PaymentEventsProviderScopeGuardTest extends TestCase
+{
+    #[Test]
+    public function payment_events_queries_using_provider_event_id_must_include_provider_scope(): void
+    {
+        $violations = [];
+
+        foreach ($this->appPhpFiles() as $filePath) {
+            $source = (string) file_get_contents($filePath);
+
+            foreach ($this->methodBodies($source) as $methodName => $body) {
+                $hasProviderEventFilter = str_contains($body, "where('provider_event_id'")
+                    || str_contains($body, 'where("provider_event_id"');
+                if (!$hasProviderEventFilter) {
+                    continue;
+                }
+
+                $referencesPaymentEvents = str_contains($body, "'payment_events'")
+                    || str_contains($body, '"payment_events"');
+                if (!$referencesPaymentEvents) {
+                    continue;
+                }
+
+                $hasProviderScope = str_contains($body, "where('provider'")
+                    || str_contains($body, 'where("provider"');
+                if ($hasProviderScope) {
+                    continue;
+                }
+
+                $violations[] = "{$filePath}::{$methodName}";
+            }
+        }
+
+        $this->assertSame(
+            [],
+            $violations,
+            "Found payment_events provider_event_id queries without provider scope:\n" . implode("\n", $violations)
+        );
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function appPhpFiles(): array
+    {
+        $root = base_path('app');
+        $iterator = new \RecursiveIteratorIterator(
+            new \RecursiveDirectoryIterator($root, \FilesystemIterator::SKIP_DOTS)
+        );
+
+        $files = [];
+        foreach ($iterator as $item) {
+            if (!$item->isFile()) {
+                continue;
+            }
+
+            $path = $item->getPathname();
+            if (str_ends_with($path, '.php')) {
+                $files[] = $path;
+            }
+        }
+
+        sort($files);
+
+        return $files;
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    private function methodBodies(string $source): array
+    {
+        $tokens = token_get_all($source);
+        $count = count($tokens);
+        $methods = [];
+
+        for ($i = 0; $i < $count; $i++) {
+            $token = $tokens[$i];
+            if (!is_array($token) || $token[0] !== T_FUNCTION) {
+                continue;
+            }
+
+            $name = null;
+            for ($j = $i + 1; $j < $count; $j++) {
+                $next = $tokens[$j];
+                if (is_array($next) && $next[0] === T_STRING) {
+                    $name = $next[1];
+                    $i = $j;
+                    break;
+                }
+            }
+
+            if ($name === null) {
+                continue;
+            }
+
+            while ($i < $count && $this->tokenText($tokens[$i]) !== '{') {
+                $i++;
+            }
+
+            if ($i >= $count || $this->tokenText($tokens[$i]) !== '{') {
+                continue;
+            }
+
+            $braceDepth = 1;
+            $i++;
+            $body = '';
+
+            for (; $i < $count; $i++) {
+                $text = $this->tokenText($tokens[$i]);
+
+                if ($text === '{') {
+                    $braceDepth++;
+                    $body .= $text;
+                    continue;
+                }
+
+                if ($text === '}') {
+                    $braceDepth--;
+                    if ($braceDepth === 0) {
+                        $methods[$name] = $body;
+                        break;
+                    }
+                    $body .= $text;
+                    continue;
+                }
+
+                $body .= $text;
+            }
+        }
+
+        return $methods;
+    }
+
+    /**
+     * @param string|array{int, string, int} $token
+     */
+    private function tokenText(string|array $token): string
+    {
+        if (is_string($token)) {
+            return $token;
+        }
+
+        return $token[1];
+    }
+}


### PR DESCRIPTION
## Summary
- scope `payment_events` create-time uniqueness to `(provider, provider_event_id)` in both create migrations
- keep legacy repair migration path intact for existing environments (`2026_02_08_000001` unchanged)
- add static regression guard test to block `payment_events` queries by `provider_event_id` without provider scope
- add CI gate in `ci_verify_mbti.sh` to always run `PaymentEventUniquenessAcrossProvidersTest`

## Tests Ran
- `cd backend && php artisan route:list --path=webhooks/payment`
- `cd backend && php artisan migrate --force`
- `cd backend && php artisan test --filter "PaymentEventUniquenessAcrossProvidersTest|PaymentsMockWebhookProviderIsolationTest|PaymentEventsProviderScopeGuardTest|MeAttemptsAuthContractTest"`
- `cd backend && php artisan test --filter PaymentEventUniquenessAcrossProvidersTest`
- `bash backend/scripts/ci_verify_mbti.sh`

## Risk/Scope
- single-loop changes only: schema uniqueness + provider-scope guard + CI gate
- no API contract change
