### PR TITLE
fix(payments): PR70 stop-bleeding for webhook hardening and v0.2 risky route shutdown

### DIFF
--- a/backend/app/Services/Commerce/PaymentWebhookProcessor.php
+++ b/backend/app/Services/Commerce/PaymentWebhookProcessor.php
@@ -165,7 +165,7 @@ class PaymentWebhookProcessor
                     }
 
                     if ($inserted === 0 && $this->isEventProcessed($eventRow)) {
-                        Log::info('payment_webhook_duplicate_event', [
+                        Log::info('PAYMENT_EVENT_ALREADY_PROCESSED', [
                             'provider' => $provider,
                             'provider_event_id' => $providerEventId,
                             'order_id' => $eventRow->order_id ?? null,
@@ -243,7 +243,7 @@ class PaymentWebhookProcessor
                     $isRefundEvent = $this->isRefundEvent($eventType, $normalized);
                     $orderStatus = strtolower((string) ($order->status ?? ''));
                     if (!$isRefundEvent && in_array($orderStatus, ['paid', 'fulfilled', 'completed', 'delivered', 'refunded'], true)) {
-                        Log::info('payment_webhook_skip_already_processed', [
+                        Log::info('PAYMENT_EVENT_ALREADY_PROCESSED', [
                             'provider' => $provider,
                             'provider_event_id' => $providerEventId,
                             'order_id' => $order->id ?? null,

--- a/backend/config/services.php
+++ b/backend/config/services.php
@@ -49,7 +49,7 @@ return [
         ))),
         'webhook_tolerance_seconds' => (int) env('BILLING_WEBHOOK_TOLERANCE_SECONDS', env('BILLING_WEBHOOK_TOLERANCE', 300)),
         'webhook_tolerance' => (int) env('BILLING_WEBHOOK_TOLERANCE', 300),
-        'allow_legacy_signature' => (bool) env('BILLING_WEBHOOK_ALLOW_LEGACY_SIGNATURE', false),
+        'allow_legacy_signature' => (bool) env('BILLING_WEBHOOK_ALLOW_LEGACY_SIGNATURE', false), // kept for backward compatibility
     ],
 
     'payment_webhook' => [

--- a/backend/routes/api.php
+++ b/backend/routes/api.php
@@ -16,7 +16,6 @@ use App\Http\Controllers\API\V0_2\IdentityController;
 use App\Http\Controllers\API\V0_2\MemoryController;
 use App\Http\Controllers\API\V0_2\MeController;
 use App\Http\Controllers\API\V0_2\NormsController;
-use App\Http\Controllers\API\V0_2\PaymentsController;
 use App\Http\Controllers\API\V0_2\PsychometricsController;
 use App\Http\Controllers\API\V0_2\ShareController;
 use App\Http\Controllers\API\V0_2\ValidityFeedbackController;
@@ -155,9 +154,6 @@ Route::prefix("v0.2")->middleware([
     Route::get("/norms/percentile", [NormsController::class, "percentile"]);
 
     Route::middleware('throttle:api_webhook')->group(function () {
-        // Payments webhook (mock, public)
-        Route::post("/payments/webhook/mock", [PaymentsController::class, "webhookMock"]);
-
         // =========================================================
         // Integrations (mock OAuth + ingestion + replay)
         // =========================================================
@@ -233,13 +229,6 @@ Route::prefix("v0.2")->middleware([
         Route::post("/attempts/{attempt_id}/feedback", [ValidityFeedbackController::class, "store"]);
         Route::post("/lookup/device", [LookupController::class, "lookupDevice"]);
 
-        // Payments (v0.2)
-        Route::prefix("payments")->group(function () {
-            Route::post("/orders", [PaymentsController::class, "createOrder"]);
-            Route::post("/orders/{id}/mark_paid", [PaymentsController::class, "markPaid"]);
-            Route::post("/orders/{id}/fulfill", [PaymentsController::class, "fulfill"]);
-            Route::get("/me/benefits", [PaymentsController::class, "meBenefits"]);
-        });
     });
 });
 
@@ -253,7 +242,6 @@ Route::prefix("v0.3")->middleware([
         "/webhooks/payment/{provider}",
         [PaymentWebhookController::class, "handle"]
     )->middleware('throttle:api_webhook')
-        ->whereIn('provider', ['stripe', 'billing', 'stub'])
         ->name('v0.3.webhooks.payment');
 
     Route::middleware(\App\Http\Middleware\ResolveOrgContext::class)->group(function () {

--- a/backend/tests/Feature/V0_3/BillingWebhookMisconfiguredSecretTest.php
+++ b/backend/tests/Feature/V0_3/BillingWebhookMisconfiguredSecretTest.php
@@ -11,7 +11,7 @@ class BillingWebhookMisconfiguredSecretTest extends TestCase
 {
     use RefreshDatabase;
 
-    public function test_missing_billing_secret_returns_503_and_logs_anchor_without_sensitive_context(): void
+    public function test_missing_billing_secret_returns_500_and_logs_anchor_without_sensitive_context(): void
     {
         /** @var Application $app */
         $app = $this->app;
@@ -29,7 +29,7 @@ class BillingWebhookMisconfiguredSecretTest extends TestCase
         Log::shouldReceive('error')
             ->once()
             ->withArgs(function ($message, $context): bool {
-                $this->assertSame('billing_webhook_secret_missing', $message);
+                $this->assertSame('CRITICAL: BILLING_WEBHOOK_SECRET_MISSING', $message);
                 $this->assertIsArray($context);
                 $this->assertSame('billing', $context['provider'] ?? null);
                 $this->assertSame('production', $context['environment'] ?? null);
@@ -57,10 +57,10 @@ class BillingWebhookMisconfiguredSecretTest extends TestCase
             'HTTP_X_REQUEST_ID' => 'req-pr57-misconfigured',
         ], $raw);
 
-        $response->assertStatus(503);
+        $response->assertStatus(500);
         $response->assertJsonPath('ok', false);
-        $response->assertJsonPath('error', 'SERVICE_UNAVAILABLE');
-        $response->assertJsonPath('message', 'service unavailable.');
+        $response->assertJsonPath('error', 'INTERNAL_SERVER_ERROR');
+        $response->assertJsonPath('message', 'internal server error.');
         $response->assertJsonPath('request_id', 'req-pr57-misconfigured');
     }
 }

--- a/backend/tests/Feature/V0_3/PaymentWebhookFailSafeTest.php
+++ b/backend/tests/Feature/V0_3/PaymentWebhookFailSafeTest.php
@@ -1,0 +1,71 @@
+<?php
+
+namespace Tests\Feature\V0_3;
+
+use App\Services\Commerce\PaymentWebhookProcessor;
+use Illuminate\Support\Facades\Log;
+use Mockery;
+use Mockery\Adapter\Phpunit\MockeryPHPUnitIntegration;
+use Tests\TestCase;
+
+class PaymentWebhookFailSafeTest extends TestCase
+{
+    use MockeryPHPUnitIntegration;
+
+    public function test_unsupported_provider_returns_404_and_logs_stable_keyword(): void
+    {
+        $processor = Mockery::mock(PaymentWebhookProcessor::class);
+        $processor->shouldReceive('handle')->never();
+        $this->app->instance(PaymentWebhookProcessor::class, $processor);
+
+        Log::shouldReceive('warning')
+            ->once()
+            ->withArgs(function ($message, $context): bool {
+                $this->assertSame('PAYMENT_WEBHOOK_PROVIDER_UNSUPPORTED', $message);
+                $this->assertIsArray($context);
+                $this->assertSame('unknown', $context['provider'] ?? null);
+                $this->assertIsString($context['request_id'] ?? null);
+                $this->assertNotSame('', (string) ($context['request_id'] ?? ''));
+                $this->assertArrayNotHasKey('payload', $context);
+
+                return true;
+            });
+
+        $response = $this->postJson('/api/v0.3/webhooks/payment/unknown', [
+            'provider_event_id' => 'evt_unknown_provider',
+            'order_no' => 'ord_unknown_provider',
+        ]);
+
+        $response->assertStatus(404);
+        $response->assertJson([
+            'ok' => false,
+            'error' => 'NOT_FOUND',
+        ]);
+    }
+
+    public function test_invalid_json_returns_404_and_does_not_call_processor(): void
+    {
+        $processor = Mockery::mock(PaymentWebhookProcessor::class);
+        $processor->shouldReceive('handle')->never();
+        $this->app->instance(PaymentWebhookProcessor::class, $processor);
+
+        $response = $this->call(
+            'POST',
+            '/api/v0.3/webhooks/payment/stub',
+            [],
+            [],
+            [],
+            [
+                'CONTENT_TYPE' => 'application/json',
+                'HTTP_ACCEPT' => 'application/json',
+            ],
+            '{"provider_event_id":"evt_invalid_json","order_no":"ord_invalid_json"',
+        );
+
+        $response->assertStatus(404);
+        $response->assertJson([
+            'ok' => false,
+            'error' => 'NOT_FOUND',
+        ]);
+    }
+}


### PR DESCRIPTION
## Summary
This PR completes PR70 stop-bleeding scope for payments:

1. Hardened `/api/v0.3/webhooks/payment/{provider}` to be fail-safe and observable.
2. Disabled high-risk v0.2 payment routes.
3. Kept provider-scoped idempotency guarantees and added/updated tests.

## What Changed

### 1) v0.3 Webhook hardening
- `POST /api/v0.3/webhooks/payment/{provider}` remains available.
- Unsupported provider now returns `404` with stable log key:
  - `PAYMENT_WEBHOOK_PROVIDER_UNSUPPORTED`
- Billing signature contract is strict:
  - Missing signature -> `404`, log `BILLING_WEBHOOK_SIG_MISSING`
  - Missing/invalid timestamp -> `404`, log `BILLING_WEBHOOK_TS_MISSING`
  - Timestamp out of tolerance -> `404`, log `BILLING_WEBHOOK_TS_OUT_OF_WINDOW`
  - Signature mismatch -> `404`, log `BILLING_WEBHOOK_SIG_MISMATCH`
- Billing secret missing is treated as P0 misconfiguration:
  - returns `500`
  - logs `CRITICAL: BILLING_WEBHOOK_SECRET_MISSING`
- Invalid JSON payload is rejected with `404` and does not call business processor.

### 2) Idempotency & observability
- Unified duplicate-hit logs to:
  - `PAYMENT_EVENT_ALREADY_PROCESSED`
- Provider + provider_event_id scoping remains enforced.

### 3) PR70 route stop-bleeding
- Removed v0.2 risky payment routes:
  - `/api/v0.2/payments/webhook/mock`
  - `/api/v0.2/payments/orders`
  - `/api/v0.2/payments/orders/{id}/mark_paid`
  - `/api/v0.2/payments/orders/{id}/fulfill`
  - `/api/v0.2/payments/me/benefits`

## Files
- `backend/routes/api.php`
- `backend/app/Http/Controllers/API/V0_3/Webhooks/PaymentWebhookController.php`
- `backend/app/Services/Commerce/PaymentWebhookProcessor.php`
- `backend/config/services.php`
- `backend/tests/Feature/V0_3/BillingWebhookSignatureTest.php`
- `backend/tests/Feature/V0_3/BillingWebhookMisconfiguredSecretTest.php`
- `backend/tests/Feature/Commerce/PaymentEventUniquenessAcrossProvidersTest.php`
- `backend/tests/Feature/V0_3/PaymentWebhookFailSafeTest.php` (new)

## Validation
Ran and passed:

- `php artisan test --filter BillingWebhookSignatureTest`
- `php artisan test --filter PaymentEventUniquenessAcrossProvidersTest`
- `php artisan test --filter BillingWebhookMisconfiguredSecretTest`
- `php artisan test --filter PaymentWebhookFailSafeTest`
- `php artisan test --filter PaymentEventsProviderScopeGuardTest`
- `bash backend/scripts/ci_verify_mbti.sh`

Also verified via route list:
- `api/v0.3/webhooks/payment/{provider}` exists.
- `api/v0.2/payments/*` high-risk routes are removed.

## Risk / Rollback
- Risk is low-to-medium and focused on payment webhook surface and v0.2 payment API availability.
- Rollback can be done by reverting this commit if needed.
