### PR TITLE
feat(pr71): 核心链路可验证可回归（算法/报告契约/隐私收口/查询足迹）

### DIFF
--- a/.github/workflows/selfcheck.yml
+++ b/.github/workflows/selfcheck.yml
@@ -38,8 +38,8 @@ jobs:
       # MBTI defaults (avoid selecting "default")
       FAP_DEFAULT_REGION: CN_MAINLAND
       FAP_DEFAULT_LOCALE: zh-CN
-      FAP_DEFAULT_PACK_ID: MBTI.cn-mainland.zh-CN.v0.2.1-TEST
-      FAP_DEFAULT_DIR_VERSION: MBTI-CN-v0.2.1-TEST
+      FAP_DEFAULT_PACK_ID: MBTI.cn-mainland.zh-CN.v0.2.2
+      FAP_DEFAULT_DIR_VERSION: MBTI-CN-v0.2.2
 
     steps:
       - uses: actions/checkout@v4
@@ -135,6 +135,9 @@ jobs:
           $resultId  = (string) Str::uuid();
           $anonId    = 'ci_' . Str::uuid();
           $now       = now();
+          $packId    = 'MBTI.cn-mainland.zh-CN.v0.2.2';
+          $dirVer    = 'MBTI-CN-v0.2.2';
+          $cpVer     = 'v0.2.2';
 
           $scoresPct = ["EI"=>55,"SN"=>45,"TF"=>60,"JP"=>52,"AT"=>58];
           $axisStates = ["EI"=>"moderate","SN"=>"moderate","TF"=>"moderate","JP"=>"moderate","AT"=>"moderate"];
@@ -158,7 +161,10 @@ jobs:
           $setIfCol($a, 'attempts', 'locale', 'zh-CN');
 
           $setIfCol($a, 'attempts', 'scale_code', 'MBTI');
-          $setIfCol($a, 'attempts', 'scale_version', 'v0.2.1-TEST');
+          $setIfCol($a, 'attempts', 'scale_version', 'v0.2.2');
+          $setIfCol($a, 'attempts', 'pack_id', $packId);
+          $setIfCol($a, 'attempts', 'dir_version', $dirVer);
+          $setIfCol($a, 'attempts', 'content_package_version', $cpVer);
           $setIfCol($a, 'attempts', 'question_count', 144);
 
           $setIfCol($a, 'attempts', 'answers_summary_json', '{}');
@@ -182,14 +188,16 @@ jobs:
           $setIfCol($r, 'results', 'anon_id', $anonId);
 
           $setIfCol($r, 'results', 'scale_code', 'MBTI');
-          $setIfCol($r, 'results', 'scale_version', 'v0.2.1-TEST');
+          $setIfCol($r, 'results', 'scale_version', 'v0.2.2');
+          $setIfCol($r, 'results', 'pack_id', $packId);
+          $setIfCol($r, 'results', 'dir_version', $dirVer);
 
           $setIfCol($r, 'results', 'type_code', 'ESTJ-A');
           $setIfCol($r, 'results', 'short_type', 'ESTJ');
           $setIfCol($r, 'results', 'variant_code', 'A');
 
           $setIfCol($r, 'results', 'profile_version', 'mbti32-v2.5');
-          $setIfCol($r, 'results', 'content_package_version', 'v0.2.1-TEST');
+          $setIfCol($r, 'results', 'content_package_version', $cpVer);
 
           $setJsonIfCol($r, 'results', 'scores_json', $scoresPct);
           $setJsonIfCol($r, 'results', 'scores_pct', $scoresPct);

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 .PHONY: selfcheck
 # 用法：
 #   make selfcheck
-#   make selfcheck MANIFEST=../content_packages/default/CN_MAINLAND/zh-CN/MBTI-CN-v0.2.1-TEST/manifest.json
+#   make selfcheck MANIFEST=../content_packages/default/CN_MAINLAND/zh-CN/MBTI-CN-v0.2.2/manifest.json
 
 selfcheck:
 	cd backend && ./scripts/selfcheck.sh "$(MANIFEST)"

--- a/backend/app/Services/Assessment/Drivers/GenericLikertDriver.php
+++ b/backend/app/Services/Assessment/Drivers/GenericLikertDriver.php
@@ -321,7 +321,7 @@ class GenericLikertDriver implements DriverInterface
 
     private function logInvalidAnswer(string $qId, string $answer): void
     {
-        Log::warning('Invalid answer option', [
+        Log::warning('LIKERT_ANSWER_UNKNOWN', [
             'question' => $qId,
             'answer' => $answer,
         ]);

--- a/backend/app/Services/Assessment/GenericReportBuilder.php
+++ b/backend/app/Services/Assessment/GenericReportBuilder.php
@@ -34,13 +34,11 @@ class GenericReportBuilder
             'scale_code' => (string) ($attempt->scale_code ?? ''),
             'summary' => [
                 'title' => (string) ($attempt->scale_code ?? 'Assessment Report'),
-                'raw_score' => $rawScore,
                 'final_score' => $finalScore,
                 'severity' => $severity,
                 'type_code' => $typeCode,
             ],
             'scores' => $resultJson['axis_scores_json'] ?? null,
-            'breakdown' => $breakdown,
             'generated_at' => now()->toISOString(),
         ];
     }

--- a/backend/app/Services/Report/ReportComposer.php
+++ b/backend/app/Services/Report/ReportComposer.php
@@ -75,11 +75,13 @@ class ReportComposer
         $region = (string) ($attempt->region ?? '');
         $locale = (string) ($attempt->locale ?? '');
 
-        if ($packId === '') {
-            $packId = (string) config('content_packs.default_pack_id', '');
-        }
-        if ($dirVersion === '') {
-            $dirVersion = (string) config('content_packs.default_dir_version', '');
+        if ($packId === '' || $dirVersion === '') {
+            return [
+                'ok' => false,
+                'error' => 'REPORT_CONTEXT_MISSING',
+                'message' => 'attempt pack context missing.',
+                'status' => 500,
+            ];
         }
 
         if ($packId !== '' && $dirVersion !== '') {

--- a/backend/scripts/selfcheck.sh
+++ b/backend/scripts/selfcheck.sh
@@ -3,9 +3,9 @@ set -euo pipefail
 
 # 用法：
 #   ./scripts/selfcheck.sh
-#   ./scripts/selfcheck.sh ../content_packages/default/CN_MAINLAND/zh-CN/MBTI-CN-v0.2.1-TEST/manifest.json
+#   ./scripts/selfcheck.sh ../content_packages/default/CN_MAINLAND/zh-CN/MBTI-CN-v0.2.2/manifest.json
 
-MANIFEST="${1:-../content_packages/default/CN_MAINLAND/zh-CN/MBTI-CN-v0.2.1-TEST/manifest.json}"
+MANIFEST="${1:-../content_packages/default/CN_MAINLAND/zh-CN/MBTI-CN-v0.2.2/manifest.json}"
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 BACKEND_DIR="$(cd "${SCRIPT_DIR}/.." && pwd)"

--- a/backend/tests/Feature/V0_3/AttemptReportPaymentUnlockFlowTest.php
+++ b/backend/tests/Feature/V0_3/AttemptReportPaymentUnlockFlowTest.php
@@ -1,0 +1,129 @@
+<?php
+
+namespace Tests\Feature\V0_3;
+
+use Database\Seeders\Pr17SimpleScoreDemoSeeder;
+use Database\Seeders\Pr19CommerceSeeder;
+use Database\Seeders\ScaleRegistrySeeder;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\DB;
+use Tests\TestCase;
+
+final class AttemptReportPaymentUnlockFlowTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private function seedScales(): void
+    {
+        (new ScaleRegistrySeeder())->run();
+        (new Pr17SimpleScoreDemoSeeder())->run();
+        (new Pr19CommerceSeeder())->run();
+    }
+
+    /**
+     * @return array<int,array<string,string>>
+     */
+    private function simpleScoreAnswers(): array
+    {
+        return [
+            ['question_id' => 'SS-001', 'code' => '5'],
+            ['question_id' => 'SS-002', 'code' => '4'],
+            ['question_id' => 'SS-003', 'code' => '3'],
+            ['question_id' => 'SS-004', 'code' => '2'],
+            ['question_id' => 'SS-005', 'code' => '1'],
+        ];
+    }
+
+    public function test_attempt_submit_report_payment_unlock_full_report_flow(): void
+    {
+        $this->seedScales();
+
+        $anonId = 'anon_pr2_flow';
+        $start = $this->withHeaders([
+            'X-Anon-Id' => $anonId,
+        ])->postJson('/api/v0.3/attempts/start', [
+            'scale_code' => 'SIMPLE_SCORE_DEMO',
+            'anon_id' => $anonId,
+        ]);
+        $start->assertStatus(200);
+        $attemptId = (string) $start->json('attempt_id');
+        $this->assertNotSame('', $attemptId);
+
+        $submit = $this->withHeaders([
+            'X-Anon-Id' => $anonId,
+        ])->postJson('/api/v0.3/attempts/submit', [
+            'attempt_id' => $attemptId,
+            'answers' => $this->simpleScoreAnswers(),
+            'duration_ms' => 120000,
+        ]);
+        $submit->assertStatus(200);
+        $submit->assertJson([
+            'ok' => true,
+            'attempt_id' => $attemptId,
+        ]);
+
+        $reportBefore = $this->withHeaders([
+            'X-Anon-Id' => $anonId,
+        ])->getJson("/api/v0.3/attempts/{$attemptId}/report");
+        $reportBefore->assertStatus(200);
+        $reportBefore->assertJson([
+            'ok' => true,
+            'locked' => true,
+            'access_level' => 'free',
+        ]);
+
+        $beforePayload = $reportBefore->json('report');
+        $this->assertIsArray($beforePayload);
+        $this->assertArrayNotHasKey('breakdown', $beforePayload);
+        $this->assertArrayNotHasKey('answers', $beforePayload);
+
+        $order = $this->withHeaders([
+            'X-Anon-Id' => $anonId,
+        ])->postJson('/api/v0.3/orders', [
+            'sku' => 'MBTI_REPORT_FULL_199',
+            'provider' => 'stub',
+            'target_attempt_id' => $attemptId,
+        ]);
+        $order->assertStatus(200);
+        $order->assertJson(['ok' => true]);
+        $orderNo = (string) $order->json('order_no');
+        $this->assertNotSame('', $orderNo);
+
+        $webhook = $this->postJson('/api/v0.3/webhooks/payment/stub', [
+            'provider_event_id' => 'evt_pr2_flow_1',
+            'order_no' => $orderNo,
+            'external_trade_no' => 'trade_pr2_flow_1',
+            'amount_cents' => 199,
+            'currency' => 'CNY',
+        ]);
+        $webhook->assertStatus(200);
+        $webhook->assertJson(['ok' => true]);
+
+        $reportAfter = $this->withHeaders([
+            'X-Anon-Id' => $anonId,
+        ])->getJson("/api/v0.3/attempts/{$attemptId}/report");
+        $reportAfter->assertStatus(200);
+        $reportAfter->assertJson([
+            'ok' => true,
+            'locked' => false,
+            'access_level' => 'full',
+        ]);
+
+        $afterPayload = $reportAfter->json('report');
+        $this->assertIsArray($afterPayload);
+        $this->assertArrayNotHasKey('breakdown', $afterPayload);
+        $this->assertArrayNotHasKey('answers', $afterPayload);
+
+        $this->assertSame(
+            1,
+            DB::table('report_snapshots')->where('attempt_id', $attemptId)->count()
+        );
+        $this->assertSame(
+            1,
+            DB::table('benefit_grants')
+                ->where('attempt_id', $attemptId)
+                ->where('status', 'active')
+                ->count()
+        );
+    }
+}

--- a/backend/tests/Feature/V0_3/ReportErrorContractTest.php
+++ b/backend/tests/Feature/V0_3/ReportErrorContractTest.php
@@ -1,0 +1,123 @@
+<?php
+
+namespace Tests\Feature\V0_3;
+
+use App\Models\Attempt;
+use App\Models\Result;
+use Database\Seeders\Pr19CommerceSeeder;
+use Database\Seeders\ScaleRegistrySeeder;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Str;
+use Tests\TestCase;
+
+final class ReportErrorContractTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private function seedScales(): void
+    {
+        (new ScaleRegistrySeeder())->run();
+        (new Pr19CommerceSeeder())->run();
+    }
+
+    private function createMbtiAttemptWithoutPackContext(string $anonId): string
+    {
+        $attemptId = (string) Str::uuid();
+
+        Attempt::create([
+            'id' => $attemptId,
+            'org_id' => 0,
+            'anon_id' => $anonId,
+            'scale_code' => 'MBTI',
+            'scale_version' => 'v0.3',
+            'region' => 'CN_MAINLAND',
+            'locale' => 'zh-CN',
+            'question_count' => 144,
+            'client_platform' => 'test',
+            'answers_summary_json' => ['stage' => 'seed'],
+            'started_at' => now(),
+            'submitted_at' => now(),
+            'pack_id' => null,
+            'dir_version' => null,
+            'content_package_version' => null,
+            'scoring_spec_version' => '2026.01',
+        ]);
+
+        Result::create([
+            'id' => (string) Str::uuid(),
+            'org_id' => 0,
+            'attempt_id' => $attemptId,
+            'scale_code' => 'MBTI',
+            'scale_version' => 'v0.3',
+            'type_code' => 'INTJ-A',
+            'scores_json' => [],
+            'scores_pct' => [
+                'EI' => 50,
+                'SN' => 50,
+                'TF' => 50,
+                'JP' => 50,
+                'AT' => 50,
+            ],
+            'axis_states' => [
+                'EI' => 'clear',
+                'SN' => 'clear',
+                'TF' => 'clear',
+                'JP' => 'clear',
+                'AT' => 'clear',
+            ],
+            'content_package_version' => null,
+            'result_json' => [
+                'raw_score' => 0,
+                'final_score' => 0,
+                'breakdown_json' => [],
+                'type_code' => 'INTJ-A',
+                'axis_scores_json' => [
+                    'scores_pct' => [
+                        'EI' => 50,
+                        'SN' => 50,
+                        'TF' => 50,
+                        'JP' => 50,
+                        'AT' => 50,
+                    ],
+                    'axis_states' => [
+                        'EI' => 'clear',
+                        'SN' => 'clear',
+                        'TF' => 'clear',
+                        'JP' => 'clear',
+                        'AT' => 'clear',
+                    ],
+                ],
+            ],
+            'pack_id' => null,
+            'dir_version' => null,
+            'scoring_spec_version' => '2026.01',
+            'report_engine_version' => 'v1.2',
+            'is_valid' => true,
+            'computed_at' => now(),
+        ]);
+
+        return $attemptId;
+    }
+
+    public function test_report_returns_stable_json_contract_when_context_missing(): void
+    {
+        $this->seedScales();
+
+        $anonId = 'anon_report_error_contract';
+        $attemptId = $this->createMbtiAttemptWithoutPackContext($anonId);
+
+        $response = $this->withHeaders([
+            'X-Anon-Id' => $anonId,
+        ])->getJson("/api/v0.3/attempts/{$attemptId}/report");
+
+        $response->assertStatus(500);
+        $response->assertJsonPath('ok', false);
+
+        $error = (string) $response->json('error');
+        $this->assertContains($error, ['REPORT_CONTEXT_MISSING', 'REPORT_FAILED']);
+
+        $errorCode = (string) $response->json('error_code');
+        $this->assertNotSame('', $errorCode);
+        $this->assertSame(strtoupper($errorCode), $errorCode);
+    }
+}

--- a/backend/tests/Feature/V0_3/ReportQueryFootprintTest.php
+++ b/backend/tests/Feature/V0_3/ReportQueryFootprintTest.php
@@ -1,0 +1,128 @@
+<?php
+
+namespace Tests\Feature\V0_3;
+
+use App\Models\Attempt;
+use App\Models\Result;
+use Database\Seeders\Pr19CommerceSeeder;
+use Database\Seeders\ScaleRegistrySeeder;
+use Illuminate\Database\Events\QueryExecuted;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Str;
+use Tests\TestCase;
+
+final class ReportQueryFootprintTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private function seedScales(): void
+    {
+        (new ScaleRegistrySeeder())->run();
+        (new Pr19CommerceSeeder())->run();
+    }
+
+    private function createMbtiAttemptWithResult(string $anonId): string
+    {
+        $attemptId = (string) Str::uuid();
+        $packId = (string) config('content_packs.default_pack_id', 'MBTI.cn-mainland.zh-CN.v0.2.1-TEST');
+        $dirVersion = (string) config('content_packs.default_dir_version', 'MBTI-CN-v0.2.1-TEST');
+
+        Attempt::create([
+            'id' => $attemptId,
+            'org_id' => 0,
+            'anon_id' => $anonId,
+            'scale_code' => 'MBTI',
+            'scale_version' => 'v0.3',
+            'region' => 'CN_MAINLAND',
+            'locale' => 'zh-CN',
+            'question_count' => 144,
+            'client_platform' => 'test',
+            'answers_summary_json' => ['stage' => 'seed'],
+            'started_at' => now(),
+            'submitted_at' => now(),
+            'pack_id' => $packId,
+            'dir_version' => $dirVersion,
+            'content_package_version' => 'v0.2.1-TEST',
+            'scoring_spec_version' => '2026.01',
+        ]);
+
+        Result::create([
+            'id' => (string) Str::uuid(),
+            'org_id' => 0,
+            'attempt_id' => $attemptId,
+            'scale_code' => 'MBTI',
+            'scale_version' => 'v0.3',
+            'type_code' => 'INTJ-A',
+            'scores_json' => [],
+            'scores_pct' => [
+                'EI' => 50,
+                'SN' => 50,
+                'TF' => 50,
+                'JP' => 50,
+                'AT' => 50,
+            ],
+            'axis_states' => [
+                'EI' => 'clear',
+                'SN' => 'clear',
+                'TF' => 'clear',
+                'JP' => 'clear',
+                'AT' => 'clear',
+            ],
+            'content_package_version' => 'v0.2.1-TEST',
+            'result_json' => [
+                'raw_score' => 0,
+                'final_score' => 0,
+                'breakdown_json' => [],
+                'type_code' => 'INTJ-A',
+                'axis_scores_json' => [
+                    'scores_pct' => [
+                        'EI' => 50,
+                        'SN' => 50,
+                        'TF' => 50,
+                        'JP' => 50,
+                        'AT' => 50,
+                    ],
+                    'axis_states' => [
+                        'EI' => 'clear',
+                        'SN' => 'clear',
+                        'TF' => 'clear',
+                        'JP' => 'clear',
+                        'AT' => 'clear',
+                    ],
+                ],
+            ],
+            'pack_id' => $packId,
+            'dir_version' => $dirVersion,
+            'scoring_spec_version' => '2026.01',
+            'report_engine_version' => 'v1.2',
+            'is_valid' => true,
+            'computed_at' => now(),
+        ]);
+
+        return $attemptId;
+    }
+
+    public function test_report_path_does_not_query_answer_set_big_table(): void
+    {
+        $this->seedScales();
+
+        $anonId = 'anon_report_query_footprint';
+        $attemptId = $this->createMbtiAttemptWithResult($anonId);
+
+        $queries = [];
+        DB::listen(static function (QueryExecuted $query) use (&$queries): void {
+            $queries[] = strtolower($query->sql);
+        });
+
+        $report = $this->withHeaders([
+            'X-Anon-Id' => $anonId,
+        ])->getJson("/api/v0.3/attempts/{$attemptId}/report");
+        $report->assertStatus(200);
+        $report->assertJsonPath('ok', true);
+
+        $allSql = implode("\n", $queries);
+        $this->assertStringNotContainsString('attempt_answer_sets', $allSql);
+        $this->assertStringNotContainsString('attempt_answers', $allSql);
+    }
+}

--- a/backend/tests/Unit/Psychometrics/GenericLikertDriverTest.php
+++ b/backend/tests/Unit/Psychometrics/GenericLikertDriverTest.php
@@ -72,7 +72,7 @@ final class GenericLikertDriverTest extends TestCase
 
         Log::shouldHaveReceived('warning')
             ->once()
-            ->with('Invalid answer option', \Mockery::on(function ($context): bool {
+            ->with('LIKERT_ANSWER_UNKNOWN', \Mockery::on(function ($context): bool {
                 return is_array($context)
                     && ($context['question'] ?? null) === 'Q2'
                     && ($context['answer'] ?? null) === 'Z';


### PR DESCRIPTION
## Summary
PR#2（P0）落实核心链路 `attempt -> scoring -> report(paywall) -> payment -> unlock -> report_full` 的可验证可回归能力，固化算法与报告契约，补齐端到端与性能证据测试。

## What Changed
1. 算分契约（GenericLikertDriver）
- unknown answer 日志关键字统一为 `LIKERT_ANSWER_UNKNOWN`
- 固化 reverse 公式 `(min+max)-raw`（含非线性 score map）
- 固化 weight 乘法行为
- unknown answer 计 0 且不中断计算

2. 报告契约与隐私收口
- ReportComposer 去掉 `pack_id/dir_version` 隐式 config 回退
- 缺少上下文时返回稳定错误：`REPORT_CONTEXT_MISSING`（500）
- ReportGatekeeper 透传 build/composer 失败契约，不再吞成 null
- AttemptsController/report 对 gate 失败返回稳定 JSON：`ok/error/message` + 合理 HTTP 状态映射
- GenericReportBuilder 去掉中间明细暴露（移除 `breakdown` 与 `summary.raw_score`）

3. 回归测试补齐
- 新增 e2e：`AttemptReportPaymentUnlockFlowTest`
  - start -> submit -> report(locked/free) -> order -> webhook -> report(unlocked/full)
  - 断言 report 不含 `breakdown/answers`
- 新增错误契约：`ReportErrorContractTest`
  - MBTI attempt 缺少 pack 上下文时，断言 500 + 稳定 error/error_code
- 新增查询足迹：`ReportQueryFootprintTest`
  - 断言 report 路径不触达 `attempt_answer_sets/attempt_answers`

## Validation
```bash
cd backend
php artisan route:list
php artisan migrate
php artisan test --testsuite=Unit
php artisan test --testsuite=Feature --filter "Attempt|Report|Likert"
