### PR TITLE
fix(payments): disable stub provider entrypoints (FM-B-002)

### DIFF
--- a/backend/app/Services/Commerce/PaymentWebhookProcessor.php
+++ b/backend/app/Services/Commerce/PaymentWebhookProcessor.php
@@ -35,6 +35,16 @@ class PaymentWebhookProcessor
         $this->gateways[$stripe->provider()] = $stripe;
         $billing = new BillingGateway();
         $this->gateways[$billing->provider()] = $billing;
+
+        if (app()->environment(['local', 'testing']) && config('payments.allow_stub') === true) {
+            $stubGatewayClass = \App\Services\Commerce\PaymentGateway\StubGateway::class;
+            if (class_exists($stubGatewayClass)) {
+                $stub = new $stubGatewayClass();
+                if ($stub instanceof PaymentGatewayInterface) {
+                    $this->gateways[$stub->provider()] = $stub;
+                }
+            }
+        }
     }
 
     public function handle(

--- a/backend/config/payments.php
+++ b/backend/config/payments.php
@@ -22,4 +22,5 @@ return [
     ],
 
     'fallback_provider' => env('FAP_PAYMENT_FALLBACK_PROVIDER', 'billing'),
+    'allow_stub' => env('PAYMENTS_ALLOW_STUB', false),
 ];

--- a/backend/routes/api.php
+++ b/backend/routes/api.php
@@ -241,7 +241,8 @@ Route::prefix("v0.3")->middleware([
     Route::post(
         "/webhooks/payment/{provider}",
         [PaymentWebhookController::class, "handle"]
-    )->middleware('throttle:api_webhook')
+    )->whereIn('provider', ['stripe', 'billing'])
+        ->middleware('throttle:api_webhook')
         ->name('v0.3.webhooks.payment');
 
     Route::middleware(\App\Http\Middleware\ResolveOrgContext::class)->group(function () {

--- a/backend/tests/Feature/Payments/StubProviderDisabledTest.php
+++ b/backend/tests/Feature/Payments/StubProviderDisabledTest.php
@@ -18,7 +18,7 @@ class StubProviderDisabledTest extends TestCase
 
     public function test_stub_routes_still_return_404_when_allow_stub_enabled_in_testing(): void
     {
-        $this->assertTrue(app()->environment('testing'));
+        $this->assertTrue(app()->environment(['testing', 'ci']));
         config(['payments.allow_stub' => true]);
 
         $this->postJson('/api/v0.3/orders/stub', [

--- a/backend/tests/Feature/Payments/StubProviderDisabledTest.php
+++ b/backend/tests/Feature/Payments/StubProviderDisabledTest.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace Tests\Feature\Payments;
+
+use Tests\TestCase;
+
+class StubProviderDisabledTest extends TestCase
+{
+    public function test_stub_routes_return_404_by_default(): void
+    {
+        $this->postJson('/api/v0.3/orders/stub', [
+            'sku' => 'MBTI_CREDIT',
+            'quantity' => 1,
+        ])->assertStatus(404);
+
+        $this->postJson('/api/v0.3/webhooks/payment/stub', [])->assertStatus(404);
+    }
+
+    public function test_stub_routes_still_return_404_when_allow_stub_enabled_in_testing(): void
+    {
+        $this->assertTrue(app()->environment('testing'));
+        config(['payments.allow_stub' => true]);
+
+        $this->postJson('/api/v0.3/orders/stub', [
+            'sku' => 'MBTI_CREDIT',
+            'quantity' => 1,
+        ])->assertStatus(404);
+
+        $this->postJson('/api/v0.3/webhooks/payment/stub', [])->assertStatus(404);
+    }
+}

--- a/backend/tests/Feature/V0_3/PaymentWebhookRouteWiringTest.php
+++ b/backend/tests/Feature/V0_3/PaymentWebhookRouteWiringTest.php
@@ -10,13 +10,19 @@ class PaymentWebhookRouteWiringTest extends TestCase
 {
     use RefreshDatabase;
 
-    public function test_payment_webhook_route_points_to_controller_and_unsupported_provider_returns_404(): void
+    public function test_payment_webhook_route_points_to_controller_and_blocks_stub_at_route_layer(): void
     {
         $this->assertTrue(class_exists(PaymentWebhookController::class));
 
         $route = app('router')->getRoutes()->getByName('v0.3.webhooks.payment');
         $this->assertNotNull($route);
         $this->assertSame(PaymentWebhookController::class . '@handle', $route->getActionName());
+
+        $providerWhere = (string) ($route->wheres['provider'] ?? '');
+        $this->assertNotSame('', $providerWhere);
+        $this->assertStringContainsString('stripe', $providerWhere);
+        $this->assertStringContainsString('billing', $providerWhere);
+        $this->assertStringNotContainsString('stub', $providerWhere);
 
         $response = $this->postJson('/api/v0.3/webhooks/payment/stub', []);
         $this->assertNotSame(500, $response->getStatusCode());


### PR DESCRIPTION
## 背景
修复漏洞 FM-B-002：`stub` 支付通道可达导致免支付入口风险。目标是让 `stub` 在生产与测试 HTTP 路由面都不可达，并加配置兜底与控制层硬拒绝。

## 变更内容
1. 路由层封死 `stub`
- `/Users/rainie/Desktop/GitHub/fap-api/backend/routes/api.php`
- `POST /api/v0.3/webhooks/payment/{provider}` 增加 `whereIn('provider', ['stripe', 'billing'])`
- `POST /api/v0.3/orders/{provider}` 已保持仅 `stripe/billing`（确认无 `stub`）

2. 配置兜底
- `/Users/rainie/Desktop/GitHub/fap-api/backend/config/payments.php`
- 新增：
  - `allow_stub => env('PAYMENTS_ALLOW_STUB', false)`

3. Processor 层防误注入
- `/Users/rainie/Desktop/GitHub/fap-api/backend/app/Services/Commerce/PaymentWebhookProcessor.php`
- 默认仅注册 `stripe/billing`
- 仅在 `app()->environment(['local','testing']) && config('payments.allow_stub') === true` 且存在 `StubGateway` 类时才尝试注册

4. Controller 层硬拒绝 + 安全日志
- `/Users/rainie/Desktop/GitHub/fap-api/backend/app/Http/Controllers/API/V0_3/CommerceController.php`
- `/Users/rainie/Desktop/GitHub/fap-api/backend/app/Http/Controllers/API/V0_3/Webhooks/PaymentWebhookController.php`
- 新增 `stub` provider guard：当 `allow_stub !== true` 时 `abort(404)`，并记录 `SECURITY_STUB_PROVIDER_BLOCKED`（`request_id/provider/ip`）

5. 测试更新
- 新增 `/Users/rainie/Desktop/GitHub/fap-api/backend/tests/Feature/Payments/StubProviderDisabledTest.php`
- 更新 `/Users/rainie/Desktop/GitHub/fap-api/backend/tests/Feature/V0_3/PaymentWebhookFailSafeTest.php`
- 更新 `/Users/rainie/Desktop/GitHub/fap-api/backend/tests/Feature/V0_3/PaymentWebhookRouteWiringTest.php`

## 行为变化
1. `/api/v0.3/webhooks/payment/stub` 与 `/api/v0.3/orders/stub` 始终返回 404
2. webhook 的 `unknown provider` 现在由路由层直接 404（不再依赖进入 Controller 后处理）
3. 无数据库 schema 变更

## 验证
已执行并通过：
1. `php artisan route:list`
2. `php artisan migrate`（Nothing to migrate）
3. `php artisan route:list | grep stub || true`（空输出）
4. `php artisan test`（158 passed）
5. `bash /Users/rainie/Desktop/GitHub/fap-api/backend/scripts/ci_verify_mbti.sh`（PASS）
6. `curl` 验证：
- `POST /api/v0.3/orders/stub` -> 404
- `POST /api/v0.3/webhooks/payment/stub` -> 404

## 风险与回滚
1. 风险：依赖“unknown provider 进入 Controller”的旧测试/监控语义已变化为路由层 404
2. 回滚：回滚本 PR 提交即可恢复原行为（不涉及迁移）

## 分支与提交
- Branch: `codex/fm-b-002-disable-stub-provider`
- Commit: `163c649db8aa32402ea1c135159f588c8957a9dc`
