### PR TITLE
fix(commerce): block webhook provider track switching

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,24 @@
-.PHONY: selfcheck
+.PHONY: selfcheck selfcheck-mysql
 # 用法：
 #   make selfcheck
 #   make selfcheck MANIFEST=../content_packages/default/CN_MAINLAND/zh-CN/MBTI-CN-v0.2.2/manifest.json
 
 selfcheck:
 	cd backend && ./scripts/selfcheck.sh "$(MANIFEST)"
+
+# 用法：
+#   make selfcheck-mysql
+# 说明：
+#   需先准备本地 MySQL（127.0.0.1:3306, root/root, database=fap_ci）
+selfcheck-mysql:
+	cd backend && \
+	export APP_ENV="$${APP_ENV:-ci}" && \
+	export DB_CONNECTION="$${DB_CONNECTION:-mysql}" && \
+	export DB_HOST="$${DB_HOST:-127.0.0.1}" && \
+	export DB_PORT="$${DB_PORT:-3306}" && \
+	export DB_DATABASE="$${DB_DATABASE:-fap_ci}" && \
+	export DB_USERNAME="$${DB_USERNAME:-root}" && \
+	export DB_PASSWORD="$${DB_PASSWORD:-root}" && \
+	bash scripts/ci/prepare_mysql.sh && \
+	APP_ENV=testing php artisan test && \
+	APP_ENV=testing bash scripts/ci_smoke_v0_3.sh

--- a/backend/app/Http/Controllers/API/V0_3/Webhooks/PaymentWebhookController.php
+++ b/backend/app/Http/Controllers/API/V0_3/Webhooks/PaymentWebhookController.php
@@ -81,12 +81,18 @@ class PaymentWebhookController extends Controller
             return response()->json($result, $status);
         }
 
-        return response()->json([
+        $response = [
             'ok' => true,
             'duplicate' => (bool) ($result['duplicate'] ?? false),
             'order_no' => $result['order_no'] ?? null,
             'provider_event_id' => $result['provider_event_id'] ?? null,
-        ]);
+        ];
+
+        if (array_key_exists('ignored', $result)) {
+            $response['ignored'] = (bool) $result['ignored'];
+        }
+
+        return response()->json($response);
     }
 
     /**

--- a/backend/app/Services/Commerce/OrderManager.php
+++ b/backend/app/Services/Commerce/OrderManager.php
@@ -222,7 +222,6 @@ class OrderManager
     public function transitionToPaidAtomic(
         string $orderNo,
         int $orgId,
-        string $provider,
         ?string $externalTradeNo = null,
         ?string $paidAt = null
     ): array {
@@ -272,10 +271,6 @@ class OrderManager
 
         if (Schema::hasColumn('orders', 'paid_at') && empty($order->paid_at)) {
             $updates['paid_at'] = ($paidAt !== null && $paidAt !== '') ? $paidAt : $now;
-        }
-
-        if ($provider !== '' && Schema::hasColumn('orders', 'provider')) {
-            $updates['provider'] = $provider;
         }
 
         if ($externalTradeNo && Schema::hasColumn('orders', 'external_trade_no')) {

--- a/backend/database/migrations/2026_02_10_090000_add_reason_to_payment_events_table.php
+++ b/backend/database/migrations/2026_02_10_090000_add_reason_to_payment_events_table.php
@@ -1,0 +1,36 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        if (!Schema::hasTable('payment_events')) {
+            return;
+        }
+
+        Schema::table('payment_events', function (Blueprint $table) {
+            if (!Schema::hasColumn('payment_events', 'reason')) {
+                $table->string('reason', 64)->nullable();
+            }
+        });
+    }
+
+    public function down(): void
+    {
+        if (!Schema::hasTable('payment_events')) {
+            return;
+        }
+
+        if (!Schema::hasColumn('payment_events', 'reason')) {
+            return;
+        }
+
+        Schema::table('payment_events', function (Blueprint $table) {
+            $table->dropColumn('reason');
+        });
+    }
+};

--- a/backend/scripts/ci/prepare_mysql.sh
+++ b/backend/scripts/ci/prepare_mysql.sh
@@ -9,13 +9,13 @@ if [[ ! -f ".env" ]]; then
   cp .env.example .env
 fi
 
-export APP_ENV=ci
-export DB_CONNECTION=mysql
-export DB_HOST=127.0.0.1
-export DB_PORT=3306
-export DB_DATABASE=fap_ci
-export DB_USERNAME=root
-export DB_PASSWORD=root
+export APP_ENV="${APP_ENV:-ci}"
+export DB_CONNECTION="${DB_CONNECTION:-mysql}"
+export DB_HOST="${DB_HOST:-127.0.0.1}"
+export DB_PORT="${DB_PORT:-3306}"
+export DB_DATABASE="${DB_DATABASE:-fap_ci}"
+export DB_USERNAME="${DB_USERNAME:-root}"
+export DB_PASSWORD="${DB_PASSWORD:-root}"
 
 php artisan key:generate --force
 php artisan migrate:fresh --force --no-interaction

--- a/backend/tests/Feature/Migrations/EventsGuardedCreateRollbackDoesNotDropTableTest.php
+++ b/backend/tests/Feature/Migrations/EventsGuardedCreateRollbackDoesNotDropTableTest.php
@@ -25,6 +25,7 @@ final class EventsGuardedCreateRollbackDoesNotDropTableTest extends TestCase
         ]);
 
         Artisan::call('migrate:rollback', [
+            '--path' => 'database/migrations/2025_12_17_165938_create_events_table.php',
             '--step' => 1,
             '--force' => true,
         ]);

--- a/backend/tests/Feature/Payments/WebhookProviderMismatchTest.php
+++ b/backend/tests/Feature/Payments/WebhookProviderMismatchTest.php
@@ -1,0 +1,80 @@
+<?php
+
+namespace Tests\Feature\Payments;
+
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Str;
+use Tests\Concerns\SignedBillingWebhook;
+use Tests\TestCase;
+
+class WebhookProviderMismatchTest extends TestCase
+{
+    use RefreshDatabase;
+    use SignedBillingWebhook;
+
+    public function test_billing_webhook_is_ignored_when_order_provider_is_stripe(): void
+    {
+        $orderNo = 'ord_provider_mismatch_1';
+
+        DB::table('orders')->insert([
+            'id' => (string) Str::uuid(),
+            'order_no' => $orderNo,
+            'org_id' => 0,
+            'user_id' => null,
+            'anon_id' => null,
+            'sku' => 'MBTI_CREDIT',
+            'quantity' => 1,
+            'target_attempt_id' => null,
+            'amount_cents' => 4990,
+            'currency' => 'USD',
+            'status' => 'created',
+            'provider' => 'stripe',
+            'external_trade_no' => null,
+            'paid_at' => null,
+            'created_at' => now(),
+            'updated_at' => now(),
+            'amount_total' => 4990,
+            'amount_refunded' => 0,
+            'item_sku' => 'MBTI_CREDIT',
+            'provider_order_id' => null,
+            'device_id' => null,
+            'request_id' => null,
+            'created_ip' => null,
+            'fulfilled_at' => null,
+            'refunded_at' => null,
+        ]);
+
+        $response = $this->postSignedBillingWebhook([
+            'provider_event_id' => 'evt_provider_mismatch_1',
+            'order_no' => $orderNo,
+            'amount_cents' => 4990,
+            'currency' => 'USD',
+            'external_trade_no' => 'trade_provider_mismatch_1',
+            'event_type' => 'payment_succeeded',
+        ], [
+            'X-Org-Id' => '0',
+        ]);
+
+        $response->assertStatus(200);
+        $response->assertJson([
+            'ok' => true,
+            'ignored' => true,
+            'order_no' => $orderNo,
+            'provider_event_id' => 'evt_provider_mismatch_1',
+        ]);
+
+        $this->assertSame('created', (string) DB::table('orders')->where('order_no', $orderNo)->value('status'));
+        $this->assertSame('stripe', (string) DB::table('orders')->where('order_no', $orderNo)->value('provider'));
+        $this->assertSame('rejected', (string) DB::table('payment_events')
+            ->where('provider', 'billing')
+            ->where('provider_event_id', 'evt_provider_mismatch_1')
+            ->value('status'));
+        $this->assertSame('PROVIDER_MISMATCH', (string) DB::table('payment_events')
+            ->where('provider', 'billing')
+            ->where('provider_event_id', 'evt_provider_mismatch_1')
+            ->value('reason'));
+        $this->assertSame(0, DB::table('benefit_grants')->count());
+        $this->assertSame(0, DB::table('report_snapshots')->count());
+    }
+}


### PR DESCRIPTION
## Summary
- add strict provider consistency check in payment webhook processing
- reject mismatched provider events with `status=rejected` and `reason=PROVIDER_MISMATCH`
- return HTTP 200 with `ignored=true` for mismatch events to avoid retry storms
- remove provider writes from paid transition path by updating `OrderManager::transitionToPaidAtomic` signature and call sites
- add migration to include `payment_events.reason` column
- add `WebhookProviderMismatchTest` coverage for the track-switching attack path

## Tests
- `php artisan route:list --name=v0.3.webhooks.payment`
- `php artisan migrate`
- `php -l app/Http/Middleware/FmTokenAuth.php`
- `php artisan test --filter WebhookProviderMismatchTest`
- `php artisan test --filter PaymentWebhookIdempotencyTest`
- `php artisan test --filter PaymentEventUniquenessAcrossProvidersTest`
- `php artisan test`
- `bash backend/scripts/ci_verify_mbti.sh`
