### PR TITLE
fix(integrations): patch FM-B-004 ingest auth and user override

### DIFF
--- a/backend/app/Http/Kernel.php
+++ b/backend/app/Http/Kernel.php
@@ -67,6 +67,7 @@ class Kernel extends HttpKernel
 
         // ✅ our fm token gate
         'fm_token'   => \App\Http\Middleware\FmTokenAuth::class,
+        'integration.signature' => \App\Http\Middleware\VerifyIntegrationSignature::class,
     ];
 
     /**
@@ -89,5 +90,6 @@ class Kernel extends HttpKernel
 
         // ✅ our fm token gate
         'fm_token'   => \App\Http\Middleware\FmTokenAuth::class,
+        'integration.signature' => \App\Http\Middleware\VerifyIntegrationSignature::class,
     ];
 }

--- a/backend/app/Http/Middleware/VerifyIntegrationSignature.php
+++ b/backend/app/Http/Middleware/VerifyIntegrationSignature.php
@@ -1,0 +1,112 @@
+<?php
+
+namespace App\Http\Middleware;
+
+use Closure;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Auth;
+use Symfony\Component\HttpFoundation\Response;
+
+class VerifyIntegrationSignature
+{
+    public function handle(Request $request, Closure $next): Response
+    {
+        $provider = strtolower(trim((string) $request->route('provider', '')));
+        if (!$this->isAllowedProvider($provider)) {
+            return $this->unauthorizedResponse();
+        }
+
+        $authUserId = $this->resolveAuthenticatedUserId();
+        if ($authUserId !== null) {
+            $request->attributes->set('integration_auth_mode', 'sanctum');
+            $request->attributes->set('integration_signature_ok', false);
+            $request->attributes->set('integration_actor_user_id', $authUserId);
+            return $next($request);
+        }
+
+        $timestampRaw = trim((string) $request->header('X-Integration-Timestamp', ''));
+        $signature = strtolower(trim((string) $request->header('X-Integration-Signature', '')));
+        if ($timestampRaw === '' || $signature === '' || preg_match('/^\d+$/', $timestampRaw) !== 1) {
+            return $this->unauthorizedResponse();
+        }
+
+        if (preg_match('/^[a-f0-9]{64}$/', $signature) !== 1) {
+            return $this->unauthorizedResponse();
+        }
+
+        $timestamp = (int) $timestampRaw;
+        $tolerance = max(1, (int) config('integrations.signature_tolerance_seconds', 300));
+        if (abs(time() - $timestamp) > $tolerance) {
+            return $this->unauthorizedResponse();
+        }
+
+        $secret = trim((string) config("integrations.providers.{$provider}.secret", ''));
+        if ($secret === '') {
+            return $this->unauthorizedResponse();
+        }
+
+        $rawBody = (string) $request->getContent();
+        $expected = hash_hmac('sha256', "{$timestamp}.{$rawBody}", $secret);
+        if (!hash_equals($expected, $signature)) {
+            return $this->unauthorizedResponse();
+        }
+
+        $request->attributes->set('integration_auth_mode', 'signature');
+        $request->attributes->set('integration_signature_ok', true);
+        $request->attributes->set('integration_actor_user_id', null);
+
+        return $next($request);
+    }
+
+    private function resolveAuthenticatedUserId(): ?int
+    {
+        $id = auth()->id();
+        if (is_numeric($id)) {
+            return (int) $id;
+        }
+
+        try {
+            $sanctumGuard = (array) config('auth.guards.sanctum', []);
+            if ($sanctumGuard !== []) {
+                $sanctumId = Auth::guard('sanctum')->id();
+                if (is_numeric($sanctumId)) {
+                    Auth::shouldUse('sanctum');
+                    return (int) $sanctumId;
+                }
+            }
+        } catch (\Throwable $e) {
+            // no-op: guard missing / not available
+        }
+
+        return null;
+    }
+
+    private function isAllowedProvider(string $provider): bool
+    {
+        if ($provider === '') {
+            return false;
+        }
+
+        $allowed = (array) config('integrations.allowed_providers', []);
+        if ($allowed === []) {
+            $allowed = array_keys((array) config('integrations.providers', []));
+        }
+
+        $allowed = array_values(array_filter(array_map(
+            static fn ($v) => strtolower(trim((string) $v)),
+            $allowed
+        )));
+
+        return in_array($provider, $allowed, true);
+    }
+
+    private function unauthorizedResponse(): Response
+    {
+        return response()->json([
+            'ok' => false,
+            'error' => 'UNAUTHORIZED',
+            'error_code' => 'UNAUTHORIZED',
+            'message' => 'Missing authentication or invalid integration signature.',
+        ], 401);
+    }
+}

--- a/backend/app/Http/Requests/Integrations/IngestRequest.php
+++ b/backend/app/Http/Requests/Integrations/IngestRequest.php
@@ -1,0 +1,116 @@
+<?php
+
+namespace App\Http\Requests\Integrations;
+
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Validator;
+
+class IngestRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    protected function prepareForValidation(): void
+    {
+        $meta = $this->input('meta', []);
+        if (!is_array($meta)) {
+            $meta = [];
+        }
+
+        if (!array_key_exists('range_start', $meta) && $this->has('range_start')) {
+            $meta['range_start'] = $this->input('range_start');
+        }
+        if (!array_key_exists('range_end', $meta) && $this->has('range_end')) {
+            $meta['range_end'] = $this->input('range_end');
+        }
+
+        $this->merge([
+            'meta' => $meta,
+            'external_user_id' => trim((string) $this->input('external_user_id', '')),
+        ]);
+    }
+
+    public function rules(): array
+    {
+        $maxSamples = max(1, (int) config('integrations.ingest.max_samples', 500));
+
+        return [
+            'meta' => ['required', 'array'],
+            'meta.range_start' => ['required', 'date'],
+            'meta.range_end' => ['nullable', 'date'],
+            'external_user_id' => ['nullable', 'string', 'max:191'],
+
+            'samples' => ['required', 'array', "max:{$maxSamples}"],
+            'samples.*' => ['required', 'array'],
+            'samples.*.domain' => ['required', 'string', 'max:64'],
+            'samples.*.recorded_at' => ['required', 'date'],
+            'samples.*.value' => ['required'],
+            'samples.*.external_id' => ['nullable', 'string', 'max:128'],
+            'samples.*.source' => ['nullable', 'string', 'max:64'],
+            'samples.*.confidence' => ['nullable', 'numeric'],
+        ];
+    }
+
+    public function withValidator(Validator $validator): void
+    {
+        $validator->after(function (Validator $validator): void {
+            $authMode = (string) $this->attributes->get('integration_auth_mode', '');
+            if ($authMode === 'signature') {
+                $externalUserId = trim((string) $this->input('external_user_id', ''));
+                if ($externalUserId === '') {
+                    $validator->errors()->add('external_user_id', 'external_user_id is required for signature mode.');
+                }
+            }
+
+            $maxDepth = max(1, (int) config('integrations.ingest.max_value_depth', 8));
+            $maxBytes = max(1, (int) config('integrations.ingest.max_value_bytes', 8192));
+            $samples = $this->input('samples', []);
+            if (!is_array($samples)) {
+                return;
+            }
+
+            foreach ($samples as $i => $sample) {
+                if (!is_array($sample) || !array_key_exists('value', $sample)) {
+                    continue;
+                }
+
+                $value = $sample['value'];
+                $depth = $this->depth($value);
+                if ($depth > $maxDepth) {
+                    $validator->errors()->add("samples.{$i}.value", "value depth must be <= {$maxDepth}.");
+                }
+
+                $bytes = $this->jsonBytes($value);
+                if ($bytes > $maxBytes) {
+                    $validator->errors()->add("samples.{$i}.value", "value bytes must be <= {$maxBytes}.");
+                }
+            }
+        });
+    }
+
+    private function depth($value, int $depth = 0): int
+    {
+        if (!is_array($value)) {
+            return $depth;
+        }
+
+        $max = $depth;
+        foreach ($value as $child) {
+            $max = max($max, $this->depth($child, $depth + 1));
+        }
+
+        return $max;
+    }
+
+    private function jsonBytes($value): int
+    {
+        $encoded = json_encode($value, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES);
+        if (!is_string($encoded)) {
+            return 0;
+        }
+
+        return strlen($encoded);
+    }
+}

--- a/backend/app/Services/Ingestion/IntegrationUserResolver.php
+++ b/backend/app/Services/Ingestion/IntegrationUserResolver.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace App\Services\Ingestion;
+
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+class IntegrationUserResolver
+{
+    public function resolveInternalUserId(string $provider, string $externalUserId): ?int
+    {
+        $provider = strtolower(trim($provider));
+        $externalUserId = trim($externalUserId);
+        if ($provider === '' || $externalUserId === '') {
+            return null;
+        }
+
+        if (!Schema::hasTable('integration_user_bindings')) {
+            return null;
+        }
+
+        $row = DB::table('integration_user_bindings')
+            ->select(['user_id'])
+            ->where('provider', $provider)
+            ->where('external_user_id', $externalUserId)
+            ->first();
+
+        if (!$row || !is_numeric($row->user_id ?? null)) {
+            return null;
+        }
+
+        return (int) $row->user_id;
+    }
+}

--- a/backend/config/integrations.php
+++ b/backend/config/integrations.php
@@ -1,0 +1,27 @@
+<?php
+
+return [
+    'signature_tolerance_seconds' => (int) env('INTEGRATIONS_SIGNATURE_TOLERANCE_SECONDS', 300),
+
+    'allowed_providers' => array_values(array_filter(array_map(
+        static fn ($v) => strtolower(trim((string) $v)),
+        explode(',', (string) env(
+            'INTEGRATIONS_ALLOWED_PROVIDERS',
+            'mock,apple_health,google_fit,calendar,screen_time'
+        ))
+    ))),
+
+    'ingest' => [
+        'max_samples' => (int) env('INTEGRATIONS_INGEST_MAX_SAMPLES', 500),
+        'max_value_depth' => (int) env('INTEGRATIONS_INGEST_MAX_VALUE_DEPTH', 8),
+        'max_value_bytes' => (int) env('INTEGRATIONS_INGEST_MAX_VALUE_BYTES', 8192),
+    ],
+
+    'providers' => [
+        'mock' => ['secret' => (string) env('INTEGRATIONS_INGEST_MOCK_SECRET', '')],
+        'apple_health' => ['secret' => (string) env('INTEGRATIONS_INGEST_APPLE_HEALTH_SECRET', '')],
+        'google_fit' => ['secret' => (string) env('INTEGRATIONS_INGEST_GOOGLE_FIT_SECRET', '')],
+        'calendar' => ['secret' => (string) env('INTEGRATIONS_INGEST_CALENDAR_SECRET', '')],
+        'screen_time' => ['secret' => (string) env('INTEGRATIONS_INGEST_SCREEN_TIME_SECRET', '')],
+    ],
+];

--- a/backend/database/migrations/2026_02_10_140000_create_integration_user_bindings_table.php
+++ b/backend/database/migrations/2026_02_10_140000_create_integration_user_bindings_table.php
@@ -1,0 +1,27 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('integration_user_bindings', function (Blueprint $table) {
+            $table->id();
+            $table->string('provider', 64);
+            $table->string('external_user_id', 191);
+            $table->unsignedBigInteger('user_id');
+            $table->timestamps();
+
+            $table->unique(['provider', 'external_user_id'], 'integration_user_bindings_provider_external_unique');
+            $table->index(['user_id'], 'integration_user_bindings_user_id_idx');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('integration_user_bindings');
+    }
+};

--- a/backend/database/migrations/2026_02_10_140100_add_auth_audit_fields_to_ingest_batches_table.php
+++ b/backend/database/migrations/2026_02_10_140100_add_auth_audit_fields_to_ingest_batches_table.php
@@ -1,0 +1,52 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        if (!Schema::hasTable('ingest_batches')) {
+            return;
+        }
+
+        Schema::table('ingest_batches', function (Blueprint $table) {
+            if (!Schema::hasColumn('ingest_batches', 'actor_user_id')) {
+                $table->unsignedBigInteger('actor_user_id')->nullable();
+            }
+            if (!Schema::hasColumn('ingest_batches', 'auth_mode')) {
+                $table->enum('auth_mode', ['sanctum', 'signature'])->nullable();
+            }
+            if (!Schema::hasColumn('ingest_batches', 'signature_ok')) {
+                $table->boolean('signature_ok')->default(false);
+            }
+            if (!Schema::hasColumn('ingest_batches', 'source_ip')) {
+                $table->string('source_ip', 64)->nullable();
+            }
+        });
+    }
+
+    public function down(): void
+    {
+        if (!Schema::hasTable('ingest_batches')) {
+            return;
+        }
+
+        Schema::table('ingest_batches', function (Blueprint $table) {
+            if (Schema::hasColumn('ingest_batches', 'source_ip')) {
+                $table->dropColumn('source_ip');
+            }
+            if (Schema::hasColumn('ingest_batches', 'signature_ok')) {
+                $table->dropColumn('signature_ok');
+            }
+            if (Schema::hasColumn('ingest_batches', 'auth_mode')) {
+                $table->dropColumn('auth_mode');
+            }
+            if (Schema::hasColumn('ingest_batches', 'actor_user_id')) {
+                $table->dropColumn('actor_user_id');
+            }
+        });
+    }
+};

--- a/backend/routes/api.php
+++ b/backend/routes/api.php
@@ -161,7 +161,8 @@ Route::prefix("v0.2")->middleware([
             Route::get("/oauth/start", [ProvidersController::class, "oauthStart"]);
             Route::get("/oauth/callback", [ProvidersController::class, "oauthCallback"]);
             Route::post("/revoke", [ProvidersController::class, "revoke"]);
-            Route::post("/ingest", [ProvidersController::class, "ingest"]);
+            Route::post("/ingest", [ProvidersController::class, "ingest"])
+                ->middleware(\App\Http\Middleware\VerifyIntegrationSignature::class);
             Route::post("/replay/{batch_id}", [ProvidersController::class, "replay"]);
         });
 

--- a/backend/tests/Feature/Integrations/IngestAuthTest.php
+++ b/backend/tests/Feature/Integrations/IngestAuthTest.php
@@ -1,0 +1,152 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Integrations;
+
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\DB;
+use Tests\TestCase;
+
+final class IngestAuthTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_ingest_without_auth_and_without_signature_returns_401(): void
+    {
+        $response = $this->postJson('/api/v0.2/integrations/mock/ingest', $this->payload());
+
+        $response->assertStatus(401)->assertJson([
+            'ok' => false,
+            'error' => 'UNAUTHORIZED',
+        ]);
+    }
+
+    public function test_ingest_with_authenticated_user_uses_auth_id_and_ignores_body_user_id(): void
+    {
+        config()->set('auth.guards.sanctum', ['driver' => 'session', 'provider' => 'users']);
+
+        $user = User::factory()->create();
+        $response = $this->actingAs($user, 'sanctum')
+            ->postJson('/api/v0.2/integrations/mock/ingest', $this->payload([
+                'user_id' => '42',
+            ]));
+
+        $response->assertStatus(200)->assertJson(['ok' => true]);
+
+        $batchId = (string) $response->json('batch_id');
+        $batch = DB::table('ingest_batches')->where('id', $batchId)->first();
+
+        $this->assertNotNull($batch);
+        $this->assertSame($user->id, (int) $batch->user_id);
+        $this->assertSame($user->id, (int) ($batch->actor_user_id ?? 0));
+        $this->assertSame('sanctum', (string) ($batch->auth_mode ?? ''));
+        $this->assertSame(0, (int) ($batch->signature_ok ?? 0));
+
+        $sleep = DB::table('sleep_samples')->where('ingest_batch_id', $batchId)->first();
+        $this->assertNotNull($sleep);
+        $this->assertSame($user->id, (int) $sleep->user_id);
+    }
+
+    public function test_ingest_with_valid_signature_and_binding_writes_bound_user_id(): void
+    {
+        config()->set('integrations.providers.mock.secret', 'mock_ingest_secret');
+
+        $boundUser = User::factory()->create();
+        DB::table('integration_user_bindings')->insert([
+            'provider' => 'mock',
+            'external_user_id' => 'ext_001',
+            'user_id' => $boundUser->id,
+            'created_at' => now(),
+            'updated_at' => now(),
+        ]);
+
+        $payload = $this->payload([
+            'external_user_id' => 'ext_001',
+            'user_id' => '42',
+        ]);
+        $rawBody = json_encode($payload, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES);
+        self::assertIsString($rawBody);
+
+        $timestamp = time();
+        $signature = hash_hmac('sha256', "{$timestamp}.{$rawBody}", 'mock_ingest_secret');
+
+        $response = $this->call(
+            'POST',
+            '/api/v0.2/integrations/mock/ingest',
+            [],
+            [],
+            [],
+            [
+                'CONTENT_TYPE' => 'application/json',
+                'HTTP_ACCEPT' => 'application/json',
+                'HTTP_X_INTEGRATION_TIMESTAMP' => (string) $timestamp,
+                'HTTP_X_INTEGRATION_SIGNATURE' => $signature,
+            ],
+            $rawBody
+        );
+
+        $response->assertStatus(200)->assertJson(['ok' => true]);
+
+        $batchId = (string) $response->json('batch_id');
+        $batch = DB::table('ingest_batches')->where('id', $batchId)->first();
+
+        $this->assertNotNull($batch);
+        $this->assertSame($boundUser->id, (int) $batch->user_id);
+        $this->assertNull($batch->actor_user_id ?? null);
+        $this->assertSame('signature', (string) ($batch->auth_mode ?? ''));
+        $this->assertSame(1, (int) ($batch->signature_ok ?? 0));
+    }
+
+    public function test_ingest_with_invalid_signature_returns_401(): void
+    {
+        config()->set('integrations.providers.mock.secret', 'mock_ingest_secret');
+
+        $payload = $this->payload(['external_user_id' => 'ext_001']);
+        $rawBody = json_encode($payload, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES);
+        self::assertIsString($rawBody);
+
+        $timestamp = time();
+        $badSignature = hash_hmac('sha256', "{$timestamp}.{$rawBody}", 'wrong_secret');
+
+        $response = $this->call(
+            'POST',
+            '/api/v0.2/integrations/mock/ingest',
+            [],
+            [],
+            [],
+            [
+                'CONTENT_TYPE' => 'application/json',
+                'HTTP_ACCEPT' => 'application/json',
+                'HTTP_X_INTEGRATION_TIMESTAMP' => (string) $timestamp,
+                'HTTP_X_INTEGRATION_SIGNATURE' => $badSignature,
+            ],
+            $rawBody
+        );
+
+        $response->assertStatus(401)->assertJson([
+            'ok' => false,
+            'error' => 'UNAUTHORIZED',
+        ]);
+        $this->assertSame(0, DB::table('ingest_batches')->count());
+    }
+
+    private function payload(array $overrides = []): array
+    {
+        return array_merge([
+            'meta' => [
+                'range_start' => '2026-02-10T00:00:00Z',
+                'range_end' => '2026-02-10T01:00:00Z',
+            ],
+            'samples' => [
+                [
+                    'domain' => 'sleep',
+                    'recorded_at' => '2026-02-10T00:00:00Z',
+                    'value' => ['duration_minutes' => 420],
+                    'external_id' => 'sleep_001',
+                ],
+            ],
+        ], $overrides);
+    }
+}


### PR DESCRIPTION
## Summary
- patch FM-B-004: lock down `/api/v0.2/integrations/{provider}/ingest` with strong auth middleware
- add machine-to-machine signature verification via `X-Integration-Timestamp` + `X-Integration-Signature`
- remove `payload.user_id` fallback/override path in ingest controller
- add `integration_user_bindings` for `external_user_id -> user_id` resolution in signature mode
- add ingest request schema + limits (`samples` size, `value` depth/bytes)
- add ingest batch audit fields (`actor_user_id`, `auth_mode`, `signature_ok`, `source_ip`)
- add feature tests for unauthenticated access, authenticated flow, valid/invalid signatures

## Security Impact
- ingest endpoint is no longer writable through throttle-only unauthenticated path
- request body `user_id` no longer controls write identity
- signature failures are rejected with 401 before controller processing

## Changed Files
### Added
- `backend/app/Http/Middleware/VerifyIntegrationSignature.php`
- `backend/app/Http/Requests/Integrations/IngestRequest.php`
- `backend/app/Services/Ingestion/IntegrationUserResolver.php`
- `backend/config/integrations.php`
- `backend/database/migrations/2026_02_10_140000_create_integration_user_bindings_table.php`
- `backend/database/migrations/2026_02_10_140100_add_auth_audit_fields_to_ingest_batches_table.php`
- `backend/tests/Feature/Integrations/IngestAuthTest.php`

### Modified
- `backend/routes/api.php`
- `backend/app/Http/Kernel.php`
- `backend/app/Http/Controllers/Integrations/ProvidersController.php`
- `backend/app/Services/Ingestion/IngestionService.php`

## Verification Run
```bash
php artisan route:list --path=api/v0.2/integrations -v
php artisan migrate
php artisan test --filter IngestAuthTest
php artisan test
bash backend/scripts/ci_verify_mbti.sh
