### PR TITLE
feat(report): Pack A Step 1 transaction slimming with afterCommit snapshot job

### DIFF
--- a/backend/app/Jobs/GenerateReportSnapshotJob.php
+++ b/backend/app/Jobs/GenerateReportSnapshotJob.php
@@ -1,0 +1,139 @@
+<?php
+
+namespace App\Jobs;
+
+use App\Services\Report\ReportSnapshotStore;
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Database\Query\Builder;
+use Illuminate\Foundation\Bus\Dispatchable;
+use Illuminate\Queue\InteractsWithQueue;
+use Illuminate\Queue\SerializesModels;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Log;
+use Illuminate\Support\Facades\Schema;
+
+class GenerateReportSnapshotJob implements ShouldQueue
+{
+    use Dispatchable, InteractsWithQueue, Queueable, SerializesModels;
+
+    public int $tries = 3;
+
+    /** @var array<int, int> */
+    public array $backoff = [5, 10, 20];
+
+    public function __construct(
+        public int $orgId,
+        public string $attemptId,
+        public string $triggerSource,
+        public ?string $orderNo = null,
+    ) {
+    }
+
+    public function handle(ReportSnapshotStore $store): void
+    {
+        $attemptId = trim($this->attemptId);
+        if ($attemptId === '' || !Schema::hasTable('report_snapshots')) {
+            return;
+        }
+
+        $snapshot = $this->snapshotQuery($attemptId)->first();
+        if (!$snapshot) {
+            return;
+        }
+
+        $status = strtolower(trim((string) ($snapshot->status ?? 'ready')));
+        if ($status === 'ready') {
+            return;
+        }
+
+        try {
+            $result = $store->createSnapshotForAttempt([
+                'org_id' => $this->orgId,
+                'attempt_id' => $attemptId,
+                'trigger_source' => $this->triggerSource,
+                'order_no' => $this->orderNo,
+                'org_role' => 'system',
+            ]);
+
+            if (!($result['ok'] ?? false)) {
+                $error = (string) ($result['error'] ?? 'SNAPSHOT_FAILED');
+                $message = (string) ($result['message'] ?? 'report snapshot generation failed.');
+                throw new \RuntimeException($error . ': ' . $message);
+            }
+
+            $this->updateSnapshotState($attemptId, [
+                'status' => 'ready',
+                'last_error' => null,
+            ]);
+        } catch (\Throwable $e) {
+            $this->updateSnapshotState($attemptId, [
+                'status' => 'failed',
+                'last_error' => $this->truncateError($e::class . ': ' . $e->getMessage()),
+            ]);
+
+            Log::error('REPORT_SNAPSHOT_GENERATE_FAILED', [
+                'org_id' => $this->orgId,
+                'attempt_id' => $attemptId,
+                'trigger_source' => $this->triggerSource,
+                'order_no' => $this->orderNo,
+                'error' => $e->getMessage(),
+            ]);
+
+            throw $e;
+        }
+    }
+
+    private function updateSnapshotState(string $attemptId, array $fields): void
+    {
+        if (!Schema::hasTable('report_snapshots')) {
+            return;
+        }
+
+        $updates = [];
+        if (Schema::hasColumn('report_snapshots', 'status') && array_key_exists('status', $fields)) {
+            $updates['status'] = $fields['status'];
+        }
+        if (Schema::hasColumn('report_snapshots', 'last_error') && array_key_exists('last_error', $fields)) {
+            $updates['last_error'] = $fields['last_error'];
+        }
+        if (Schema::hasColumn('report_snapshots', 'updated_at')) {
+            $updates['updated_at'] = now();
+        }
+
+        if (count($updates) > 0) {
+            $this->snapshotQuery($attemptId)->update($updates);
+        }
+    }
+
+    private function snapshotQuery(string $attemptId): Builder
+    {
+        $base = DB::table('report_snapshots')->where('attempt_id', $attemptId);
+        if (!Schema::hasColumn('report_snapshots', 'org_id')) {
+            return $base;
+        }
+
+        $byOrg = DB::table('report_snapshots')
+            ->where('attempt_id', $attemptId)
+            ->where('org_id', $this->orgId);
+        if ($byOrg->exists()) {
+            return $byOrg;
+        }
+
+        return $base;
+    }
+
+    private function truncateError(string $error): string
+    {
+        $error = trim($error);
+        if ($error === '') {
+            return 'snapshot generation failed';
+        }
+
+        if (strlen($error) <= 1024) {
+            return $error;
+        }
+
+        return substr($error, 0, 1024);
+    }
+}

--- a/backend/database/migrations/2026_02_10_150000_add_status_and_last_error_to_report_snapshots.php
+++ b/backend/database/migrations/2026_02_10_150000_add_status_and_last_error_to_report_snapshots.php
@@ -1,0 +1,105 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    private const STATUS_INDEX = 'idx_report_snapshots_status';
+
+    public function up(): void
+    {
+        if (!Schema::hasTable('report_snapshots')) {
+            return;
+        }
+
+        Schema::table('report_snapshots', function (Blueprint $table): void {
+            if (!Schema::hasColumn('report_snapshots', 'status')) {
+                $table->string('status', 16)->default('ready');
+            }
+
+            if (!Schema::hasColumn('report_snapshots', 'last_error')) {
+                $table->text('last_error')->nullable();
+            }
+
+            if (!Schema::hasColumn('report_snapshots', 'updated_at')) {
+                $table->timestamp('updated_at')->nullable();
+            }
+        });
+
+        if (!$this->indexExists(self::STATUS_INDEX)) {
+            Schema::table('report_snapshots', function (Blueprint $table): void {
+                $table->index(['org_id', 'attempt_id', 'status'], self::STATUS_INDEX);
+            });
+        }
+    }
+
+    public function down(): void
+    {
+        if (!Schema::hasTable('report_snapshots')) {
+            return;
+        }
+
+        if ($this->indexExists(self::STATUS_INDEX)) {
+            Schema::table('report_snapshots', function (Blueprint $table): void {
+                $table->dropIndex(self::STATUS_INDEX);
+            });
+        }
+
+        Schema::table('report_snapshots', function (Blueprint $table): void {
+            if (Schema::hasColumn('report_snapshots', 'updated_at')) {
+                $table->dropColumn('updated_at');
+            }
+
+            if (Schema::hasColumn('report_snapshots', 'last_error')) {
+                $table->dropColumn('last_error');
+            }
+
+            if (Schema::hasColumn('report_snapshots', 'status')) {
+                $table->dropColumn('status');
+            }
+        });
+    }
+
+    private function indexExists(string $indexName): bool
+    {
+        $connection = Schema::getConnection();
+        $driver = $connection->getDriverName();
+
+        if ($driver === 'sqlite') {
+            $rows = $connection->select("PRAGMA index_list('report_snapshots')");
+            foreach ($rows as $row) {
+                if ((string) ($row->name ?? '') === $indexName) {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
+        if ($driver === 'pgsql') {
+            $rows = $connection->select(
+                'SELECT indexname FROM pg_indexes WHERE tablename = ?',
+                ['report_snapshots']
+            );
+            foreach ($rows as $row) {
+                if ((string) ($row->indexname ?? '') === $indexName) {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
+        $database = $connection->getDatabaseName();
+        $rows = $connection->select(
+            "SELECT 1 FROM information_schema.statistics
+             WHERE table_schema = ? AND table_name = ? AND index_name = ?
+             LIMIT 1",
+            [$database, 'report_snapshots', $indexName]
+        );
+
+        return !empty($rows);
+    }
+};

--- a/backend/tests/Feature/SRE/TransactionSlimmingTest.php
+++ b/backend/tests/Feature/SRE/TransactionSlimmingTest.php
@@ -1,0 +1,310 @@
+<?php
+
+namespace Tests\Feature\SRE;
+
+use App\Jobs\GenerateReportSnapshotJob;
+use App\Models\Attempt;
+use App\Models\Result;
+use App\Services\Attempts\AnswerRowWriter;
+use App\Services\Report\ReportSnapshotStore;
+use Database\Seeders\Pr17SimpleScoreDemoSeeder;
+use Database\Seeders\Pr19CommerceSeeder;
+use Database\Seeders\ScaleRegistrySeeder;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Queue;
+use Illuminate\Support\Facades\Storage;
+use Illuminate\Support\Str;
+use Mockery;
+use Tests\Concerns\SignedBillingWebhook;
+use Tests\TestCase;
+
+class TransactionSlimmingTest extends TestCase
+{
+    use RefreshDatabase;
+    use SignedBillingWebhook;
+
+    protected function tearDown(): void
+    {
+        Mockery::close();
+        parent::tearDown();
+    }
+
+    public function test_attempt_submit_seeds_pending_snapshot_and_dispatches_job(): void
+    {
+        $this->seedScales();
+        $anonId = 'anon_tx_submit';
+        $attemptId = $this->startSimpleScoreAttempt($anonId);
+
+        Storage::fake('local');
+        Queue::fake();
+
+        $submit = $this->withHeaders([
+            'X-Anon-Id' => $anonId,
+        ])->postJson('/api/v0.3/attempts/submit', [
+            'attempt_id' => $attemptId,
+            'answers' => $this->simpleScoreAnswers(),
+            'duration_ms' => 120000,
+        ]);
+        $submit->assertStatus(200);
+
+        $snapshot = DB::table('report_snapshots')
+            ->where('attempt_id', $attemptId)
+            ->first();
+        $this->assertNotNull($snapshot);
+        $this->assertSame('pending', (string) ($snapshot->status ?? ''));
+
+        Queue::assertPushed(GenerateReportSnapshotJob::class, function (GenerateReportSnapshotJob $job) use ($attemptId): bool {
+            return $job->orgId === 0
+                && $job->attemptId === $attemptId
+                && $job->triggerSource === 'submit';
+        });
+        $this->assertSame([], Storage::disk('local')->allFiles());
+    }
+
+    public function test_attempt_submit_rollback_does_not_dispatch_job(): void
+    {
+        $this->seedScales();
+        $anonId = 'anon_tx_rollback';
+        $attemptId = $this->startSimpleScoreAttempt($anonId);
+
+        $writer = Mockery::mock(AnswerRowWriter::class);
+        $writer->shouldReceive('writeRows')
+            ->once()
+            ->andThrow(new \RuntimeException('forced_answer_row_write_failure'));
+        $this->app->instance(AnswerRowWriter::class, $writer);
+
+        Queue::fake();
+
+        $submit = $this->withHeaders([
+            'X-Anon-Id' => $anonId,
+        ])->postJson('/api/v0.3/attempts/submit', [
+            'attempt_id' => $attemptId,
+            'answers' => $this->simpleScoreAnswers(),
+            'duration_ms' => 120000,
+        ]);
+        $submit->assertStatus(500);
+
+        Queue::assertNothingPushed();
+        $this->assertSame(0, DB::table('report_snapshots')
+            ->where('attempt_id', $attemptId)
+            ->count());
+    }
+
+    public function test_webhook_seeds_pending_snapshot_and_dispatches_job(): void
+    {
+        $this->seedScales();
+        $attemptId = $this->createMbtiAttemptWithResult(0);
+        $orderNo = 'ord_tx_webhook_1';
+
+        DB::table('orders')->insert([
+            'id' => (string) Str::uuid(),
+            'order_no' => $orderNo,
+            'org_id' => 0,
+            'user_id' => null,
+            'anon_id' => 'anon_tx_webhook',
+            'sku' => 'MBTI_REPORT_FULL',
+            'quantity' => 1,
+            'target_attempt_id' => $attemptId,
+            'amount_cents' => 990,
+            'currency' => 'USD',
+            'status' => 'created',
+            'provider' => 'billing',
+            'external_trade_no' => null,
+            'paid_at' => null,
+            'created_at' => now(),
+            'updated_at' => now(),
+            'amount_total' => 990,
+            'amount_refunded' => 0,
+            'item_sku' => 'MBTI_REPORT_FULL',
+            'provider_order_id' => null,
+            'device_id' => null,
+            'request_id' => null,
+            'created_ip' => null,
+            'fulfilled_at' => null,
+            'refunded_at' => null,
+        ]);
+
+        Queue::fake();
+        Storage::fake('s3');
+
+        $response = $this->postSignedBillingWebhook([
+            'provider_event_id' => 'evt_tx_webhook_1',
+            'order_no' => $orderNo,
+            'external_trade_no' => 'trade_tx_webhook_1',
+            'amount_cents' => 990,
+            'currency' => 'USD',
+        ], [
+            'X-Org-Id' => '0',
+        ]);
+        $response->assertStatus(200);
+        $response->assertJson(['ok' => true]);
+
+        $snapshot = DB::table('report_snapshots')
+            ->where('attempt_id', $attemptId)
+            ->first();
+        $this->assertNotNull($snapshot);
+        $this->assertSame('pending', (string) ($snapshot->status ?? ''));
+
+        Queue::assertPushed(GenerateReportSnapshotJob::class, function (GenerateReportSnapshotJob $job) use ($attemptId, $orderNo): bool {
+            return $job->attemptId === $attemptId
+                && $job->orgId === 0
+                && $job->triggerSource === 'payment'
+                && $job->orderNo === $orderNo;
+        });
+    }
+
+    public function test_generate_report_snapshot_job_sets_snapshot_ready(): void
+    {
+        $this->seedScales();
+        $anonId = 'anon_tx_job';
+        $attemptId = $this->startSimpleScoreAttempt($anonId);
+
+        Queue::fake();
+
+        $submit = $this->withHeaders([
+            'X-Anon-Id' => $anonId,
+        ])->postJson('/api/v0.3/attempts/submit', [
+            'attempt_id' => $attemptId,
+            'answers' => $this->simpleScoreAnswers(),
+            'duration_ms' => 120000,
+        ]);
+        $submit->assertStatus(200);
+
+        $pending = DB::table('report_snapshots')
+            ->where('attempt_id', $attemptId)
+            ->first();
+        $this->assertNotNull($pending);
+        $this->assertSame('pending', (string) ($pending->status ?? ''));
+
+        $job = new GenerateReportSnapshotJob(0, $attemptId, 'submit', null);
+        $job->handle(app(ReportSnapshotStore::class));
+
+        $ready = DB::table('report_snapshots')
+            ->where('attempt_id', $attemptId)
+            ->first();
+        $this->assertNotNull($ready);
+        $this->assertSame('ready', (string) ($ready->status ?? ''));
+        $this->assertNull($ready->last_error ?? null);
+        $this->assertNotSame('{}', (string) ($ready->report_json ?? '{}'));
+    }
+
+    private function seedScales(): void
+    {
+        (new ScaleRegistrySeeder())->run();
+        (new Pr17SimpleScoreDemoSeeder())->run();
+        (new Pr19CommerceSeeder())->run();
+    }
+
+    /**
+     * @return array<int, array{question_id:string, code:string}>
+     */
+    private function simpleScoreAnswers(): array
+    {
+        return [
+            ['question_id' => 'SS-001', 'code' => '5'],
+            ['question_id' => 'SS-002', 'code' => '4'],
+            ['question_id' => 'SS-003', 'code' => '3'],
+            ['question_id' => 'SS-004', 'code' => '2'],
+            ['question_id' => 'SS-005', 'code' => '1'],
+        ];
+    }
+
+    private function startSimpleScoreAttempt(string $anonId): string
+    {
+        $start = $this->withHeaders([
+            'X-Anon-Id' => $anonId,
+        ])->postJson('/api/v0.3/attempts/start', [
+            'scale_code' => 'SIMPLE_SCORE_DEMO',
+            'anon_id' => $anonId,
+        ]);
+        $start->assertStatus(200);
+
+        return (string) $start->json('attempt_id');
+    }
+
+    private function createMbtiAttemptWithResult(int $orgId): string
+    {
+        $attemptId = (string) Str::uuid();
+
+        Attempt::create([
+            'id' => $attemptId,
+            'org_id' => $orgId,
+            'anon_id' => 'anon_tx_webhook',
+            'scale_code' => 'MBTI',
+            'scale_version' => 'v0.3',
+            'region' => 'CN_MAINLAND',
+            'locale' => 'zh-CN',
+            'question_count' => 144,
+            'client_platform' => 'test',
+            'answers_summary_json' => ['stage' => 'seed'],
+            'started_at' => now(),
+            'submitted_at' => now(),
+            'pack_id' => (string) config('content_packs.default_pack_id'),
+            'dir_version' => 'MBTI-CN-v0.2.1-TEST',
+            'content_package_version' => 'v0.2.1-TEST',
+            'scoring_spec_version' => '2026.01',
+        ]);
+
+        Result::create([
+            'id' => (string) Str::uuid(),
+            'org_id' => $orgId,
+            'attempt_id' => $attemptId,
+            'scale_code' => 'MBTI',
+            'scale_version' => 'v0.3',
+            'type_code' => 'INTJ-A',
+            'scores_json' => [
+                'EI' => ['a' => 10, 'b' => 10, 'neutral' => 0, 'sum' => 0, 'total' => 20],
+                'SN' => ['a' => 10, 'b' => 10, 'neutral' => 0, 'sum' => 0, 'total' => 20],
+                'TF' => ['a' => 10, 'b' => 10, 'neutral' => 0, 'sum' => 0, 'total' => 20],
+                'JP' => ['a' => 10, 'b' => 10, 'neutral' => 0, 'sum' => 0, 'total' => 20],
+                'AT' => ['a' => 10, 'b' => 10, 'neutral' => 0, 'sum' => 0, 'total' => 20],
+            ],
+            'scores_pct' => [
+                'EI' => 50,
+                'SN' => 50,
+                'TF' => 50,
+                'JP' => 50,
+                'AT' => 50,
+            ],
+            'axis_states' => [
+                'EI' => 'clear',
+                'SN' => 'clear',
+                'TF' => 'clear',
+                'JP' => 'clear',
+                'AT' => 'clear',
+            ],
+            'content_package_version' => 'v0.2.1-TEST',
+            'result_json' => [
+                'raw_score' => 0,
+                'final_score' => 0,
+                'breakdown_json' => [],
+                'type_code' => 'INTJ-A',
+                'axis_scores_json' => [
+                    'scores_pct' => [
+                        'EI' => 50,
+                        'SN' => 50,
+                        'TF' => 50,
+                        'JP' => 50,
+                        'AT' => 50,
+                    ],
+                    'axis_states' => [
+                        'EI' => 'clear',
+                        'SN' => 'clear',
+                        'TF' => 'clear',
+                        'JP' => 'clear',
+                        'AT' => 'clear',
+                    ],
+                ],
+            ],
+            'pack_id' => (string) config('content_packs.default_pack_id'),
+            'dir_version' => 'MBTI-CN-v0.2.1-TEST',
+            'scoring_spec_version' => '2026.01',
+            'report_engine_version' => 'v1.2',
+            'is_valid' => true,
+            'computed_at' => now(),
+        ]);
+
+        return $attemptId;
+    }
+}


### PR DESCRIPTION
## Summary
Implement Pack A / Step 1 (Transaction Slimming) to remove heavy I/O and synchronous snapshot generation from critical `DB::transaction` paths, and switch to async snapshot generation with `pending -> ready/failed` lifecycle.

## Scope
- Keep this change limited to one small loop:
  - submit/webhook critical path writes remain transactional
  - snapshot generation moved out of transaction and executed after commit

## Changed Files
### Added
- /Users/rainie/Desktop/GitHub/fap-api/backend/app/Jobs/GenerateReportSnapshotJob.php
- /Users/rainie/Desktop/GitHub/fap-api/backend/database/migrations/2026_02_10_150000_add_status_and_last_error_to_report_snapshots.php
- /Users/rainie/Desktop/GitHub/fap-api/backend/tests/Feature/SRE/TransactionSlimmingTest.php

### Modified
- /Users/rainie/Desktop/GitHub/fap-api/backend/app/Http/Controllers/API/V0_3/AttemptsController.php
- /Users/rainie/Desktop/GitHub/fap-api/backend/app/Services/Commerce/PaymentWebhookProcessor.php
- /Users/rainie/Desktop/GitHub/fap-api/backend/app/Services/Report/ReportSnapshotStore.php
- /Users/rainie/Desktop/GitHub/fap-api/backend/app/Services/Report/ReportGatekeeper.php

### No-change confirmations
- /Users/rainie/Desktop/GitHub/fap-api/backend/routes/api.php
- /Users/rainie/Desktop/GitHub/fap-api/backend/app/Http/Middleware/FmTokenAuth.php

## What Changed
- Added `report_snapshots` lifecycle columns:
  - `status` (`pending|ready|failed`, default `ready`)
  - `last_error` (nullable text)
  - `updated_at` (nullable timestamp if missing)
  - index: `(org_id, attempt_id, status)`
- Added `ReportSnapshotStore::seedPendingSnapshot(...)`:
  - writes minimal placeholder snapshot (`status=pending`)
  - no composer call, no disk write
- Added async queue job `GenerateReportSnapshotJob`:
  - `tries=3`, `backoff=[5,10,20]`
  - idempotent return if already `ready`
  - heavy snapshot generation outside transaction
  - success -> `ready`; failure -> `failed` + truncated `last_error`, then rethrow for retry
- `AttemptsController::submit`:
  - moved scoring before transaction
  - transaction keeps only DB writes + seed pending snapshot
  - dispatches `GenerateReportSnapshotJob::dispatch(...)->afterCommit()`
- `PaymentWebhookProcessor`:
  - removed synchronous snapshot generation from transaction
  - seed pending inside transaction
  - dispatches snapshot job with `afterCommit()`
- `ReportGatekeeper`:
  - `ready`: keep full report behavior
  - `pending`: `locked=true`, `meta.generating=true`, `meta.retry_after_seconds`
  - `failed`: `locked=true`, `meta.generating=false`, `meta.snapshot_error=true`
  - no synchronous generation on read path

## Validation Run
```bash
cd /Users/rainie/Desktop/GitHub/fap-api/backend

rg -n "DB::transaction\\(" app/Http/Controllers/API/V0_3/AttemptsController.php app/Services/Commerce/PaymentWebhookProcessor.php
rg -n "File::get\\(|Storage::|createSnapshotForAttempt\\(|ReportComposer|Http::" app/Http/Controllers/API/V0_3/AttemptsController.php app/Services/Commerce/PaymentWebhookProcessor.php

php artisan route:list
php artisan migrate --no-interaction

php artisan test --filter TransactionSlimming
php artisan test tests/Feature/SRE

cd /Users/rainie/Desktop/GitHub/fap-api
bash backend/scripts/ci_verify_mbti.sh
