### PR TITLE
feat(migrations): schema-only pack-b deploy migrations + resumable org_id backfill

### DIFF
--- a/backend/app/Jobs/Ops/BackfillOrgIdJob.php
+++ b/backend/app/Jobs/Ops/BackfillOrgIdJob.php
@@ -1,0 +1,230 @@
+<?php
+
+namespace App\Jobs\Ops;
+
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Bus\Dispatchable;
+use Illuminate\Queue\InteractsWithQueue;
+use Illuminate\Queue\SerializesModels;
+use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Log;
+use Illuminate\Support\Facades\Schema;
+
+class BackfillOrgIdJob implements ShouldQueue
+{
+    use Dispatchable, InteractsWithQueue, Queueable, SerializesModels;
+
+    public function __construct(
+        public string $table,
+        public string $idColumn = 'id',
+        public string $orgIdColumn = 'org_id',
+        public int $batchSize = 1000
+    ) {
+        $this->batchSize = max(1, $batchSize);
+    }
+
+    public function handle(): void
+    {
+        if (!$this->isSafeIdentifier($this->table)
+            || !$this->isSafeIdentifier($this->idColumn)
+            || !$this->isSafeIdentifier($this->orgIdColumn)) {
+            Log::warning('[org_id_backfill] invalid identifier', [
+                'table' => $this->table,
+                'id_column' => $this->idColumn,
+                'org_id_column' => $this->orgIdColumn,
+            ]);
+
+            return;
+        }
+
+        if (!Schema::hasTable('migration_backfills')
+            || !Schema::hasTable($this->table)
+            || !Schema::hasColumn($this->table, $this->idColumn)
+            || !Schema::hasColumn($this->table, $this->orgIdColumn)) {
+            Log::warning('[org_id_backfill] table/column missing', [
+                'table' => $this->table,
+                'id_column' => $this->idColumn,
+                'org_id_column' => $this->orgIdColumn,
+            ]);
+
+            return;
+        }
+
+        $lock = Cache::lock($this->lockKey(), 900);
+        if (!$lock->get()) {
+            Log::info('[org_id_backfill] lock busy, skip', ['table' => $this->table]);
+
+            return;
+        }
+
+        try {
+            [$lastId, $lastCursor] = $this->loadState();
+            $mode = $this->determineMode($lastCursor);
+
+            if ($mode === 'string') {
+                $this->runStringBackfill($lastId, $lastCursor);
+
+                return;
+            }
+
+            $this->runNumericBackfill($lastId);
+        } finally {
+            $lock->release();
+        }
+    }
+
+    private function runNumericBackfill(int $lastId): void
+    {
+        while (true) {
+            $rows = DB::table($this->table)
+                ->select($this->idColumn)
+                ->whereNull($this->orgIdColumn)
+                ->where($this->idColumn, '>', $lastId)
+                ->orderBy($this->idColumn)
+                ->limit($this->batchSize)
+                ->get();
+
+            if ($rows->isEmpty()) {
+                return;
+            }
+
+            $ids = [];
+            foreach ($rows as $row) {
+                $ids[] = (int) $row->{$this->idColumn};
+            }
+
+            DB::table($this->table)
+                ->whereIn($this->idColumn, $ids)
+                ->update([$this->orgIdColumn => 0]);
+
+            $lastId = max($ids);
+            $this->persistState($lastId, null);
+
+            Log::info('[org_id_backfill] chunk', [
+                'table' => $this->table,
+                'mode' => 'numeric',
+                'updated' => count($ids),
+                'last_id' => $lastId,
+            ]);
+
+            usleep(50000);
+        }
+    }
+
+    private function runStringBackfill(int $lastId, ?string $lastCursor): void
+    {
+        $cursor = $lastCursor;
+
+        while (true) {
+            $query = DB::table($this->table)
+                ->select($this->idColumn)
+                ->whereNull($this->orgIdColumn);
+
+            if ($cursor !== null && $cursor !== '') {
+                $query->where($this->idColumn, '>', $cursor);
+            }
+
+            $rows = $query
+                ->orderBy($this->idColumn)
+                ->limit($this->batchSize)
+                ->get();
+
+            if ($rows->isEmpty()) {
+                return;
+            }
+
+            $ids = [];
+            foreach ($rows as $row) {
+                $ids[] = (string) $row->{$this->idColumn};
+            }
+
+            DB::table($this->table)
+                ->whereIn($this->idColumn, $ids)
+                ->update([$this->orgIdColumn => 0]);
+
+            $cursor = (string) end($ids);
+            if (ctype_digit($cursor)) {
+                $lastId = (int) $cursor;
+            }
+
+            $this->persistState($lastId, $cursor);
+
+            Log::info('[org_id_backfill] chunk', [
+                'table' => $this->table,
+                'mode' => 'string',
+                'updated' => count($ids),
+                'last_cursor' => $cursor,
+            ]);
+
+            usleep(50000);
+        }
+    }
+
+    private function determineMode(?string $lastCursor): string
+    {
+        if ($lastCursor !== null && $lastCursor !== '') {
+            return 'string';
+        }
+
+        $probe = DB::table($this->table)
+            ->whereNull($this->orgIdColumn)
+            ->orderBy($this->idColumn)
+            ->value($this->idColumn);
+
+        if ($probe === null) {
+            return 'numeric';
+        }
+
+        return is_numeric((string) $probe) ? 'numeric' : 'string';
+    }
+
+    /**
+     * @return array{0:int, 1:?string}
+     */
+    private function loadState(): array
+    {
+        $row = DB::table('migration_backfills')
+            ->where('key', $this->stateKey())
+            ->first();
+
+        if ($row === null) {
+            $this->persistState(0, null);
+
+            return [0, null];
+        }
+
+        return [
+            (int) ($row->last_id ?? 0),
+            $row->last_cursor !== null ? (string) $row->last_cursor : null,
+        ];
+    }
+
+    private function persistState(int $lastId, ?string $lastCursor): void
+    {
+        DB::table('migration_backfills')->updateOrInsert(
+            ['key' => $this->stateKey()],
+            [
+                'last_id' => $lastId,
+                'last_cursor' => $lastCursor,
+                'updated_at' => now(),
+            ]
+        );
+    }
+
+    private function stateKey(): string
+    {
+        return "org_id_backfill:{$this->table}";
+    }
+
+    private function lockKey(): string
+    {
+        return "org_id_backfill_lock:{$this->table}";
+    }
+
+    private function isSafeIdentifier(string $value): bool
+    {
+        return (bool) preg_match('/^[A-Za-z0-9_]+$/', $value);
+    }
+}

--- a/backend/database/migrations/2026_01_29_000004_add_org_id_to_attempts_results_events_report_jobs.php
+++ b/backend/database/migrations/2026_01_29_000004_add_org_id_to_attempts_results_events_report_jobs.php
@@ -41,19 +41,6 @@ return new class extends Migration
             });
         }
 
-        if (Schema::hasTable('attempts') && Schema::hasColumn('attempts', 'org_id')) {
-            DB::table('attempts')->whereNull('org_id')->update(['org_id' => 0]);
-        }
-        if (Schema::hasTable('results') && Schema::hasColumn('results', 'org_id')) {
-            DB::table('results')->whereNull('org_id')->update(['org_id' => 0]);
-        }
-        if (Schema::hasTable('events') && Schema::hasColumn('events', 'org_id')) {
-            DB::table('events')->whereNull('org_id')->update(['org_id' => 0]);
-        }
-        if (Schema::hasTable('report_jobs') && Schema::hasColumn('report_jobs', 'org_id')) {
-            DB::table('report_jobs')->whereNull('org_id')->update(['org_id' => 0]);
-        }
-
         $indexName = 'attempts_org_id_idx';
         if (Schema::hasTable('attempts') && Schema::hasColumn('attempts', 'org_id') && !$this->indexExists('attempts', $indexName)) {
             Schema::table('attempts', function (Blueprint $table) use ($indexName) {

--- a/backend/database/migrations/2026_01_29_200010_create_orders_table.php
+++ b/backend/database/migrations/2026_01_29_200010_create_orders_table.php
@@ -60,23 +60,10 @@ return new class extends Migration
             }
         });
 
-        if (Schema::hasTable('orders') && Schema::hasColumn('orders', 'org_id')) {
-            DB::table('orders')->whereNull('org_id')->update(['org_id' => 0]);
-        }
-
         if (!$this->indexExists('orders', 'orders_order_no_unique') && Schema::hasColumn('orders', 'order_no')) {
-            $duplicates = DB::table('orders')
-                ->select('order_no')
-                ->whereNotNull('order_no')
-                ->groupBy('order_no')
-                ->havingRaw('count(*) > 1')
-                ->limit(1)
-                ->get();
-            if ($duplicates->count() === 0) {
-                Schema::table('orders', function (Blueprint $table) {
-                    $table->unique('order_no', 'orders_order_no_unique');
-                });
-            }
+            Schema::table('orders', function (Blueprint $table) {
+                $table->unique('order_no', 'orders_order_no_unique');
+            });
         }
 
         if (!$this->indexExists('orders', 'orders_org_created_idx')

--- a/backend/database/migrations/2026_02_10_160000_create_migration_backfills_table.php
+++ b/backend/database/migrations/2026_02_10_160000_create_migration_backfills_table.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    private const TABLE = 'migration_backfills';
+
+    public function up(): void
+    {
+        if (!Schema::hasTable(self::TABLE)) {
+            Schema::create(self::TABLE, function (Blueprint $table): void {
+                $table->string('key', 64)->primary();
+                $table->unsignedBigInteger('last_id')->default(0);
+                $table->string('last_cursor', 64)->nullable();
+                $table->timestamp('updated_at')->nullable();
+            });
+
+            return;
+        }
+
+        Schema::table(self::TABLE, function (Blueprint $table): void {
+            if (!Schema::hasColumn(self::TABLE, 'last_id')) {
+                $table->unsignedBigInteger('last_id')->default(0);
+            }
+
+            if (!Schema::hasColumn(self::TABLE, 'last_cursor')) {
+                $table->string('last_cursor', 64)->nullable();
+            }
+
+            if (!Schema::hasColumn(self::TABLE, 'updated_at')) {
+                $table->timestamp('updated_at')->nullable();
+            }
+        });
+    }
+
+    public function down(): void
+    {
+        // Safety: no-op.
+    }
+};

--- a/backend/database/migrations/2026_02_10_160100_add_idx_idempo_payload.php
+++ b/backend/database/migrations/2026_02_10_160100_add_idx_idempo_payload.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Support\Database\SchemaIndex;
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    private const TABLE = 'idempotency_keys';
+    private const INDEX = 'idx_idempo_payload';
+
+    public function up(): void
+    {
+        if (!Schema::hasTable(self::TABLE)
+            || !Schema::hasColumn(self::TABLE, 'provider')
+            || !Schema::hasColumn(self::TABLE, 'recorded_at')
+            || !Schema::hasColumn(self::TABLE, 'hash')
+            || SchemaIndex::indexExists(self::TABLE, self::INDEX)) {
+            return;
+        }
+
+        Schema::table(self::TABLE, function (Blueprint $table): void {
+            $table->index(['provider', 'recorded_at', 'hash'], self::INDEX);
+        });
+    }
+
+    public function down(): void
+    {
+        if (!Schema::hasTable(self::TABLE) || !SchemaIndex::indexExists(self::TABLE, self::INDEX)) {
+            return;
+        }
+
+        Schema::table(self::TABLE, function (Blueprint $table): void {
+            $table->dropIndex(self::INDEX);
+        });
+    }
+};

--- a/backend/database/migrations/2026_02_10_160200_add_benefit_grants_composite_indexes.php
+++ b/backend/database/migrations/2026_02_10_160200_add_benefit_grants_composite_indexes.php
@@ -1,0 +1,78 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Support\Database\SchemaIndex;
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    private const TABLE = 'benefit_grants';
+    private const IDX_USER = 'idx_grant_user_access';
+    private const IDX_ANON = 'idx_grant_anon_access';
+    private const IDX_SCOPE = 'idx_grant_scope_org';
+
+    public function up(): void
+    {
+        if (!Schema::hasTable(self::TABLE)) {
+            return;
+        }
+
+        $this->addIndex(
+            ['org_id', 'benefit_code', 'status', 'attempt_id', 'user_id', 'expires_at'],
+            self::IDX_USER
+        );
+        $this->addIndex(
+            ['org_id', 'benefit_code', 'status', 'attempt_id', 'benefit_ref', 'expires_at'],
+            self::IDX_ANON
+        );
+        $this->addIndex(
+            ['org_id', 'benefit_code', 'status', 'scope', 'expires_at'],
+            self::IDX_SCOPE
+        );
+    }
+
+    public function down(): void
+    {
+        if (!Schema::hasTable(self::TABLE)) {
+            return;
+        }
+
+        $this->dropIndex(self::IDX_USER);
+        $this->dropIndex(self::IDX_ANON);
+        $this->dropIndex(self::IDX_SCOPE);
+    }
+
+    /**
+     * @param list<string> $columns
+     */
+    private function addIndex(array $columns, string $index): void
+    {
+        if (SchemaIndex::indexExists(self::TABLE, $index)) {
+            return;
+        }
+
+        foreach ($columns as $column) {
+            if (!Schema::hasColumn(self::TABLE, $column)) {
+                return;
+            }
+        }
+
+        Schema::table(self::TABLE, function (Blueprint $table) use ($columns, $index): void {
+            $table->index($columns, $index);
+        });
+    }
+
+    private function dropIndex(string $index): void
+    {
+        if (!SchemaIndex::indexExists(self::TABLE, $index)) {
+            return;
+        }
+
+        Schema::table(self::TABLE, function (Blueprint $table) use ($index): void {
+            $table->dropIndex($index);
+        });
+    }
+};

--- a/backend/database/migrations/2026_02_10_160300_add_payment_events_status_time_index.php
+++ b/backend/database/migrations/2026_02_10_160300_add_payment_events_status_time_index.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Support\Database\SchemaIndex;
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    private const TABLE = 'payment_events';
+    private const INDEX = 'idx_pay_status_time';
+
+    public function up(): void
+    {
+        if (!Schema::hasTable(self::TABLE)
+            || !Schema::hasColumn(self::TABLE, 'provider')
+            || !Schema::hasColumn(self::TABLE, 'status')
+            || !Schema::hasColumn(self::TABLE, 'received_at')
+            || SchemaIndex::indexExists(self::TABLE, self::INDEX)) {
+            return;
+        }
+
+        Schema::table(self::TABLE, function (Blueprint $table): void {
+            $table->index(['provider', 'status', 'received_at'], self::INDEX);
+        });
+    }
+
+    public function down(): void
+    {
+        if (!Schema::hasTable(self::TABLE) || !SchemaIndex::indexExists(self::TABLE, self::INDEX)) {
+            return;
+        }
+
+        Schema::table(self::TABLE, function (Blueprint $table): void {
+            $table->dropIndex(self::INDEX);
+        });
+    }
+};


### PR DESCRIPTION
## Summary
Step 2 / Pack B: make deployment migrations schema-only to avoid full-table writes/scans during deploy, and move org_id backfill to a resumable throttled job.

## Changes
- Sanitized target migrations to remove migration-time data writes/scans:
  - `backend/database/migrations/2026_01_29_000004_add_org_id_to_attempts_results_events_report_jobs.php`
  - `backend/database/migrations/2026_01_29_200010_create_orders_table.php`
  - `backend/database/migrations/2026_01_29_200060_create_benefit_grants_table.php`
  - `backend/database/migrations/2026_02_07_190000_scope_order_idempotency_key_by_provider.php`
- Added resumable backfill state table:
  - `backend/database/migrations/2026_02_10_160000_create_migration_backfills_table.php`
  - fields: `key`, `last_id`, `last_cursor`, `updated_at`
- Added throttled/resumable job:
  - `backend/app/Jobs/Ops/BackfillOrgIdJob.php`
  - per-table cache lock, chunked updates, 50ms throttle, progress logging, resume state persistence
- Added hardening index migrations:
  - `backend/database/migrations/2026_02_10_160100_add_idx_idempo_payload.php`
  - `backend/database/migrations/2026_02_10_160200_add_benefit_grants_composite_indexes.php`
  - `backend/database/migrations/2026_02_10_160300_add_payment_events_status_time_index.php`

## Notes
- Scope intentionally limited to target files for this step.
- Repository-wide migration scan still reports legacy non-target migrations with data writes/scans; target 4 files are clean.

## Validation
- `php artisan route:list`
- `rg -n "DB::table\\(.*\\)->update\\(|->insert\\(|groupBy\\(|having\\(" database/migrations`
- `rg -n "DB::table\\(.*\\)->update\\(|->insert\\(|groupBy\\(|having\\(" database/migrations/2026_01_29_000004_add_org_id_to_attempts_results_events_report_jobs.php database/migrations/2026_01_29_200010_create_orders_table.php database/migrations/2026_01_29_200060_create_benefit_grants_table.php database/migrations/2026_02_07_190000_scope_order_idempotency_key_by_provider.php`
- `php artisan migrate --pretend`
- `php artisan migrate`
- `php artisan migrate:fresh`
- `php artisan queue:work --once`
- `curl -sS http://127.0.0.1:8000/api/healthz`
- `bash backend/scripts/ci_verify_mbti.sh`
