### PR TITLE
feat(perf): Pack C step3 OOM + resilient HTTP + audit log index-safe date filter

### DIFF
--- a/backend/app/Filament/Resources/AuditLogResource.php
+++ b/backend/app/Filament/Resources/AuditLogResource.php
@@ -9,6 +9,7 @@ use Filament\Forms\Form;
 use Filament\Resources\Resource;
 use Filament\Tables;
 use Filament\Tables\Table;
+use Illuminate\Support\Carbon;
 use Illuminate\Support\Facades\DB;
 
 class AuditLogResource extends Resource
@@ -64,10 +65,12 @@ class AuditLogResource extends Resource
                     ])
                     ->query(function ($query, array $data) {
                         if (!empty($data['date_from'])) {
-                            $query->whereDate('created_at', '>=', $data['date_from']);
+                            $from = Carbon::parse((string) $data['date_from'])->startOfDay();
+                            $query->where('created_at', '>=', $from);
                         }
                         if (!empty($data['date_to'])) {
-                            $query->whereDate('created_at', '<=', $data['date_to']);
+                            $toExclusive = Carbon::parse((string) $data['date_to'])->addDay()->startOfDay();
+                            $query->where('created_at', '<', $toExclusive);
                         }
                     }),
             ])

--- a/backend/app/Services/Content/Publisher/ContentPackPublisher.php
+++ b/backend/app/Services/Content/Publisher/ContentPackPublisher.php
@@ -3,12 +3,12 @@
 namespace App\Services\Content\Publisher;
 
 use App\Support\CacheKeys;
+use App\Support\Http\ResilientClient;
 use Illuminate\Http\UploadedFile;
 use Illuminate\Support\Facades\Artisan;
 use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\File;
-use Illuminate\Support\Facades\Http;
 use Illuminate\Support\Str;
 use RuntimeException;
 use ZipArchive;
@@ -711,7 +711,7 @@ final class ContentPackPublisher
         }
 
         try {
-            $resp = Http::timeout(8)->get($url);
+            $resp = ResilientClient::get($url);
         } catch (\Throwable $e) {
             return [
                 'ok' => false,

--- a/backend/app/Services/Content/Publisher/ContentProbeService.php
+++ b/backend/app/Services/Content/Publisher/ContentProbeService.php
@@ -2,7 +2,7 @@
 
 namespace App\Services\Content\Publisher;
 
-use Illuminate\Support\Facades\Http;
+use App\Support\Http\ResilientClient;
 
 class ContentProbeService
 {
@@ -72,7 +72,7 @@ class ContentProbeService
         }
 
         try {
-            $resp = Http::timeout(8)->get($url);
+            $resp = ResilientClient::get($url);
         } catch (\Throwable $e) {
             return [
                 'ok' => false,

--- a/backend/app/Services/Ingestion/ReplayService.php
+++ b/backend/app/Services/Ingestion/ReplayService.php
@@ -28,97 +28,18 @@ class ReplayService
             ];
         }
 
-        $samples = [];
-        $samples = array_merge($samples, $this->loadSamples('sleep_samples', $batchId, 'sleep'));
-        $samples = array_merge($samples, $this->loadSamples('screen_time_samples', $batchId, 'screen_time'));
-        $samples = array_merge($samples, $this->loadSamples('health_samples', $batchId, 'health'));
-
         $inserted = 0;
         $skipped = 0;
         $store = new IdempotencyStore();
+        $tables = [
+            'sleep_samples' => Schema::hasTable('sleep_samples'),
+            'screen_time_samples' => Schema::hasTable('screen_time_samples'),
+            'health_samples' => Schema::hasTable('health_samples'),
+        ];
 
-        foreach ($samples as $sample) {
-            $domain = (string) ($sample['domain'] ?? '');
-            $recordedAt = (string) ($sample['recorded_at'] ?? '');
-            $externalId = (string) ($sample['external_id'] ?? '');
-            $value = $sample['value'] ?? [];
-
-            $idKey = IdempotencyKey::build($provider, $externalId !== '' ? $externalId : $recordedAt, $recordedAt, $value);
-            $existing = $store->findByPayload($idKey['provider'], $idKey['recorded_at'], $idKey['hash']);
-            if ($existing) {
-                $store->touch($idKey['provider'], $idKey['external_id'], $idKey['recorded_at'], $idKey['hash']);
-                $skipped++;
-                continue;
-            }
-
-            $record = $store->record([
-                'provider' => $idKey['provider'],
-                'external_id' => $idKey['external_id'],
-                'recorded_at' => $idKey['recorded_at'],
-                'hash' => $idKey['hash'],
-                'ingest_batch_id' => $batchId,
-            ]);
-            if (($record['inserted'] ?? false) === false) {
-                $skipped++;
-                continue;
-            }
-
-            $payloadHash = IdempotencyKey::hashPayload($value);
-            $confidence = (float) ($sample['confidence'] ?? 1.0);
-            $userId = $sample['user_id'] ?? null;
-            $source = (string) ($sample['source'] ?? $provider);
-
-            if ($domain === 'sleep' && Schema::hasTable('sleep_samples')) {
-                DB::table('sleep_samples')->insert([
-                    'user_id' => $userId,
-                    'source' => $source !== '' ? $source : 'ingestion',
-                    'recorded_at' => $recordedAt,
-                    'value_json' => json_encode($value, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES),
-                    'confidence' => $confidence,
-                    'raw_payload_hash' => $payloadHash,
-                    'ingest_batch_id' => $batchId,
-                    'created_at' => now(),
-                    'updated_at' => now(),
-                ]);
-                $inserted++;
-                continue;
-            }
-
-            if ($domain === 'screen_time' && Schema::hasTable('screen_time_samples')) {
-                DB::table('screen_time_samples')->insert([
-                    'user_id' => $userId,
-                    'source' => $source !== '' ? $source : 'ingestion',
-                    'recorded_at' => $recordedAt,
-                    'value_json' => json_encode($value, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES),
-                    'confidence' => $confidence,
-                    'raw_payload_hash' => $payloadHash,
-                    'ingest_batch_id' => $batchId,
-                    'created_at' => now(),
-                    'updated_at' => now(),
-                ]);
-                $inserted++;
-                continue;
-            }
-
-            if (Schema::hasTable('health_samples')) {
-                DB::table('health_samples')->insert([
-                    'user_id' => $userId,
-                    'source' => $source !== '' ? $source : 'ingestion',
-                    'domain' => $domain !== '' ? $domain : 'unknown',
-                    'recorded_at' => $recordedAt,
-                    'value_json' => json_encode($value, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES),
-                    'confidence' => $confidence,
-                    'raw_payload_hash' => $payloadHash,
-                    'ingest_batch_id' => $batchId,
-                    'created_at' => now(),
-                    'updated_at' => now(),
-                ]);
-                $inserted++;
-                continue;
-            }
-
-            $skipped++;
-        }
+        $this->streamSamplesFromTable('sleep_samples', $batchId, 'sleep', $provider, $store, $tables, $inserted, $skipped);
+        $this->streamSamplesFromTable('screen_time_samples', $batchId, 'screen_time', $provider, $store, $tables, $inserted, $skipped);
+        $this->streamSamplesFromTable('health_samples', $batchId, 'health', $provider, $store, $tables, $inserted, $skipped);
 
         DB::table('ingest_batches')
             ->where('id', $batchId)
@@ -134,34 +55,146 @@ class ReplayService
         ];
     }
 
-    private function loadSamples(string $table, string $batchId, string $domain): array
+    private function streamSamplesFromTable(
+        string $sourceTable,
+        string $batchId,
+        string $defaultDomain,
+        string $provider,
+        IdempotencyStore $store,
+        array $tables,
+        int &$inserted,
+        int &$skipped
+    ): void
     {
-        if (!Schema::hasTable($table)) {
-            return [];
+        if (!($tables[$sourceTable] ?? false)) {
+            return;
         }
 
-        $rows = DB::table($table)->where('ingest_batch_id', $batchId)->get();
-        $out = [];
-        foreach ($rows as $row) {
-            $value = [];
-            if (isset($row->value_json)) {
-                $decoded = json_decode((string) $row->value_json, true);
-                if (is_array($decoded)) {
-                    $value = $decoded;
+        $maxId = (int) DB::table($sourceTable)
+            ->where('ingest_batch_id', $batchId)
+            ->max('id');
+
+        if ($maxId <= 0) {
+            return;
+        }
+
+        DB::table($sourceTable)
+            ->where('ingest_batch_id', $batchId)
+            ->where('id', '<=', $maxId)
+            ->orderBy('id')
+            ->chunkById(1000, function ($rows) use (
+                $batchId,
+                $defaultDomain,
+                &$inserted,
+                $provider,
+                &$skipped,
+                $store,
+                $tables
+            ): void {
+                $sleepInserts = [];
+                $screenTimeInserts = [];
+                $healthInserts = [];
+                $now = now();
+
+                foreach ($rows as $row) {
+                    $sample = $this->normalizeSample($row, $defaultDomain);
+                    $domain = (string) ($sample['domain'] ?? '');
+                    $recordedAt = (string) ($sample['recorded_at'] ?? '');
+                    $externalId = (string) ($sample['external_id'] ?? '');
+                    $value = $sample['value'] ?? [];
+
+                    $idKey = IdempotencyKey::build($provider, $externalId !== '' ? $externalId : $recordedAt, $recordedAt, $value);
+                    $existing = $store->findByPayload($idKey['provider'], $idKey['recorded_at'], $idKey['hash']);
+                    if ($existing) {
+                        $store->touch($idKey['provider'], $idKey['external_id'], $idKey['recorded_at'], $idKey['hash']);
+                        $skipped++;
+                        continue;
+                    }
+
+                    $record = $store->record([
+                        'provider' => $idKey['provider'],
+                        'external_id' => $idKey['external_id'],
+                        'recorded_at' => $idKey['recorded_at'],
+                        'hash' => $idKey['hash'],
+                        'ingest_batch_id' => $batchId,
+                    ]);
+                    if (($record['inserted'] ?? false) === false) {
+                        $skipped++;
+                        continue;
+                    }
+
+                    $payloadHash = IdempotencyKey::hashPayload($value);
+                    $confidence = (float) ($sample['confidence'] ?? 1.0);
+                    $userId = $sample['user_id'] ?? null;
+                    $source = (string) ($sample['source'] ?? $provider);
+
+                    $payload = [
+                        'user_id' => $userId,
+                        'source' => $source !== '' ? $source : 'ingestion',
+                        'recorded_at' => $recordedAt,
+                        'value_json' => json_encode($value, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES),
+                        'confidence' => $confidence,
+                        'raw_payload_hash' => $payloadHash,
+                        'ingest_batch_id' => $batchId,
+                        'created_at' => $now,
+                        'updated_at' => $now,
+                    ];
+
+                    if ($domain === 'sleep' && ($tables['sleep_samples'] ?? false)) {
+                        $sleepInserts[] = $payload;
+                        continue;
+                    }
+
+                    if ($domain === 'screen_time' && ($tables['screen_time_samples'] ?? false)) {
+                        $screenTimeInserts[] = $payload;
+                        continue;
+                    }
+
+                    if ($tables['health_samples'] ?? false) {
+                        $healthPayload = $payload;
+                        $healthPayload['domain'] = $domain !== '' ? $domain : 'unknown';
+                        $healthInserts[] = $healthPayload;
+                        continue;
+                    }
+
+                    $skipped++;
                 }
-            }
 
-            $out[] = [
-                'domain' => $domain === 'health' ? ((string) ($row->domain ?? $domain)) : $domain,
-                'recorded_at' => (string) ($row->recorded_at ?? ''),
-                'external_id' => (string) ($row->id ?? ''),
-                'value' => $value,
-                'confidence' => (float) ($row->confidence ?? 1.0),
-                'user_id' => $row->user_id ?? null,
-                'source' => (string) ($row->source ?? ''),
-            ];
+                $inserted += $this->flushInserts('sleep_samples', $sleepInserts);
+                $inserted += $this->flushInserts('screen_time_samples', $screenTimeInserts);
+                $inserted += $this->flushInserts('health_samples', $healthInserts);
+            }, 'id');
+    }
+
+    private function normalizeSample(object $row, string $domain): array
+    {
+        $value = [];
+        if (isset($row->value_json)) {
+            $decoded = json_decode((string) $row->value_json, true);
+            if (is_array($decoded)) {
+                $value = $decoded;
+            }
         }
 
-        return $out;
+        return [
+            'domain' => $domain === 'health' ? ((string) ($row->domain ?? $domain)) : $domain,
+            'recorded_at' => (string) ($row->recorded_at ?? ''),
+            'external_id' => (string) ($row->id ?? ''),
+            'value' => $value,
+            'confidence' => (float) ($row->confidence ?? 1.0),
+            'user_id' => $row->user_id ?? null,
+            'source' => (string) ($row->source ?? ''),
+        ];
+    }
+
+    private function flushInserts(string $table, array $rows): int
+    {
+        if ($rows === []) {
+            return 0;
+        }
+
+        DB::table($table)->insert($rows);
+
+        return count($rows);
     }
 }

--- a/backend/app/Services/VectorStore/Drivers/QdrantDriver.php
+++ b/backend/app/Services/VectorStore/Drivers/QdrantDriver.php
@@ -3,7 +3,7 @@
 namespace App\Services\VectorStore\Drivers;
 
 use App\Services\VectorStore\VectorStoreInterface;
-use Illuminate\Support\Facades\Http;
+use App\Support\Http\ResilientClient;
 
 final class QdrantDriver implements VectorStoreInterface
 {
@@ -23,8 +23,7 @@ final class QdrantDriver implements VectorStoreInterface
         }
 
         try {
-            $timeout = (int) config('vectorstore.timeouts.request_seconds', 8);
-            $resp = Http::timeout($timeout)->get($endpoint . '/healthz');
+            $resp = ResilientClient::get($endpoint . '/healthz');
             if ($resp->ok()) {
                 return [
                     'ok' => true,

--- a/backend/app/Support/Http/ResilientClient.php
+++ b/backend/app/Support/Http/ResilientClient.php
@@ -1,0 +1,90 @@
+<?php
+
+namespace App\Support\Http;
+
+use Illuminate\Http\Client\ConnectionException;
+use Illuminate\Http\Client\PendingRequest;
+use Illuminate\Http\Client\RequestException;
+use Illuminate\Http\Client\Response;
+use Illuminate\Support\Facades\Http;
+use Illuminate\Support\Facades\Log;
+
+final class ResilientClient
+{
+    /**
+     * Build a pre-configured HTTP client for resilient outbound requests.
+     */
+    public static function request(): PendingRequest
+    {
+        return Http::connectTimeout(3)
+            ->timeout(10)
+            ->retry(
+                [200, 400, 800],
+                200,
+                function (\Throwable $exception): bool {
+                    if ($exception instanceof ConnectionException) {
+                        return true;
+                    }
+
+                    if ($exception instanceof RequestException) {
+                        $status = $exception->response?->status();
+                        if ($status === null) {
+                            return true;
+                        }
+
+                        return $status >= 500 || in_array($status, [408, 429], true);
+                    }
+
+                    return true;
+                },
+                false
+            );
+    }
+
+    public static function get(string $url, array $query = []): Response
+    {
+        $startedAt = microtime(true);
+
+        try {
+            $response = self::request()->get($url, $query);
+        } catch (\Throwable $e) {
+            self::logFailure($url, null, $startedAt);
+            throw $e;
+        }
+
+        if (!$response->successful()) {
+            self::logFailure($url, $response->status(), $startedAt);
+        }
+
+        return $response;
+    }
+
+    public static function post(string $url, array $payload = []): Response
+    {
+        $startedAt = microtime(true);
+
+        try {
+            $response = self::request()->post($url, $payload);
+        } catch (\Throwable $e) {
+            self::logFailure($url, null, $startedAt);
+            throw $e;
+        }
+
+        if (!$response->successful()) {
+            self::logFailure($url, $response->status(), $startedAt);
+        }
+
+        return $response;
+    }
+
+    private static function logFailure(string $url, ?int $status, float $startedAt): void
+    {
+        $elapsedMs = (int) round((microtime(true) - $startedAt) * 1000);
+
+        Log::warning('http_resilient_request_failed', [
+            'url' => $url,
+            'status' => $status,
+            'elapsed_ms' => $elapsedMs,
+        ]);
+    }
+}


### PR DESCRIPTION
## Summary
- Refactored ReplayService to stream source rows with chunked processing (no full-table get, no unbounded array_merge).
- Added ResilientClient with connect timeout, total timeout, exponential retry backoff, and failure logging.
- Routed outbound HTTP in ContentProbeService, ContentPackPublisher, and QdrantDriver through ResilientClient.
- Replaced whereDate(created_at) filters in AuditLogResource with index-friendly datetime range predicates.

## Changed Files
- Added: `backend/app/Support/Http/ResilientClient.php`
- Modified: `backend/app/Services/Ingestion/ReplayService.php`
- Modified: `backend/app/Services/Content/Publisher/ContentPackPublisher.php`
- Modified: `backend/app/Services/Content/Publisher/ContentProbeService.php`
- Modified: `backend/app/Services/VectorStore/Drivers/QdrantDriver.php`
- Modified: `backend/app/Filament/Resources/AuditLogResource.php`

## Validation
- `php artisan route:list`
- `php artisan migrate`
- `rg -n -- "->get\\(\\)" app/Services/Ingestion/ReplayService.php`
- `rg -n "array_merge\\(" app/Services/Ingestion/ReplayService.php`
- `rg -n "Http::timeout\\(" app/Services/Content/Publisher app/Services/VectorStore/Drivers`
- `rg -n "whereDate\\(" app/Filament/Resources/AuditLogResource.php`
- `php artisan test`
- `php artisan cache:clear && bash scripts/ci_verify_mbti.sh`

## Notes
- If `ci_verify_mbti.sh` is rerun many times locally, OTP sub-acceptance may fail with `OTP_SEND_FAILED` due to cached rate-limit counters.
- Mitigation: run `php artisan cache:clear` before rerun.
