### PR TITLE
fix(v0.2-share): harden IDOR and extract legacy share service

### DIFF
--- a/.github/workflows/selfcheck.yml
+++ b/.github/workflows/selfcheck.yml
@@ -121,7 +121,23 @@ jobs:
             curl -sS http://127.0.0.1:18080/api/v0.2/health >/dev/null && break
             sleep 1
           done
-          API="http://127.0.0.1:18080" bash scripts/verify_mbti.sh
+          ANON_ID="ci_selfcheck"
+          AUTH_RAW="$(
+            curl -sS -X POST "http://127.0.0.1:18080/api/v0.2/auth/wx_phone" \
+              -H "Content-Type: application/json" \
+              -d "{\"wx_code\":\"dev\",\"phone_code\":\"dev\",\"anon_id\":\"${ANON_ID}\"}" \
+            || true
+          )"
+          AUTH_JSON="$(printf '%s\n' "$AUTH_RAW" | sed -n '/^{/,$p')"
+          FM_TOKEN="$(
+            printf '%s\n' "$AUTH_JSON" \
+              | php -r '$j=json_decode(stream_get_contents(STDIN), true); echo $j["token"] ?? "";'
+          )"
+          if [[ -z "$FM_TOKEN" || "$FM_TOKEN" == "null" ]]; then
+            echo "[selfcheck][FAIL] cannot get token from /api/v0.2/auth/wx_phone" >&2
+            exit 1
+          fi
+          API="http://127.0.0.1:18080" ANON_ID="$ANON_ID" FM_TOKEN="$FM_TOKEN" bash scripts/verify_mbti.sh
 
       - name: Seed demo attempt+result (for runtime validate)
         working-directory: backend

--- a/backend/app/Services/Legacy/LegacyShareService.php
+++ b/backend/app/Services/Legacy/LegacyShareService.php
@@ -1,0 +1,143 @@
+<?php
+
+namespace App\Services\Legacy;
+
+use App\Models\Attempt;
+use App\Models\Result;
+use App\Models\Share;
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\ModelNotFoundException;
+use Illuminate\Database\QueryException;
+
+class LegacyShareService
+{
+    /**
+     * Generate or fetch a share id for an attempt (v0.2 legacy).
+     *
+     * Security:
+     * - Strict tenant/ownership filtering at SQL layer (org_id + user_id/anon_id).
+     * - Unauthorized access yields ModelNotFoundException (404).
+     * - share_id uses bin2hex(random_bytes(16)).
+     */
+    public function getOrCreateAttemptShare(string $attemptId, int $orgId, ?int $userId, ?string $anonId): array
+    {
+        $attempt = $this->findAccessibleAttempt($attemptId, $orgId, $userId, $anonId);
+
+        $result = Result::query()
+            ->where('attempt_id', $attempt->id)
+            ->when($this->hasColumn('results', 'org_id'), fn (Builder $q) => $q->where('org_id', $orgId))
+            ->first();
+
+        if (!$result) {
+            throw (new ModelNotFoundException())->setModel(Result::class, [$attempt->id]);
+        }
+
+        $share = Share::query()
+            ->where('attempt_id', $attempt->id)
+            ->first();
+
+        if (!$share) {
+            $share = $this->createShare($attempt, $anonId);
+        }
+
+        $typeCode = (string) ($result->type_code ?? '');
+        $resultJson = is_array($result->result_json ?? null) ? $result->result_json : [];
+        $typeName = (string) ($resultJson['type_name'] ?? $resultJson['type'] ?? $typeCode);
+
+        return [
+            'attempt_id' => (string) $attempt->id,
+            'share_id' => (string) $share->id,
+            'org_id' => (int) $orgId,
+            'content_package_version' => (string) ($attempt->content_package_version ?? $result->content_package_version ?? ''),
+            'type_code' => $typeCode,
+            'type_name' => $typeName,
+            'created_at' => $share->created_at?->toISOString(),
+        ];
+    }
+
+    /**
+     * Resolve share view payload by share_id (v0.2 legacy).
+     */
+    public function getShareView(string $shareId): array
+    {
+        $share = Share::query()->where('id', $shareId)->firstOrFail();
+
+        $attempt = Attempt::query()
+            ->where('id', $share->attempt_id)
+            ->firstOrFail();
+
+        $orgId = (int) ($attempt->org_id ?? 0);
+
+        $result = Result::query()
+            ->where('attempt_id', $attempt->id)
+            ->when($this->hasColumn('results', 'org_id'), fn (Builder $q) => $q->where('org_id', $orgId))
+            ->first();
+
+        $typeCode = (string) ($result->type_code ?? '');
+        $resultJson = is_array($result->result_json ?? null) ? $result->result_json : [];
+        $typeName = (string) ($resultJson['type_name'] ?? $resultJson['type'] ?? $typeCode);
+
+        return [
+            'share_id' => (string) $share->id,
+            'attempt_id' => (string) $attempt->id,
+            'org_id' => $orgId,
+            'type_code' => $typeCode,
+            'type_name' => $typeName,
+            'created_at' => $share->created_at?->toISOString(),
+        ];
+    }
+
+    /**
+     * Strict ownership + org_id filtering at SQL layer.
+     * Unauthorized access is expressed as ModelNotFoundException (404).
+     */
+    private function findAccessibleAttempt(string $attemptId, int $orgId, ?int $userId, ?string $anonId): Attempt
+    {
+        $q = Attempt::query()
+            ->where('id', $attemptId)
+            ->where('org_id', $orgId);
+
+        if ($userId === null && ($anonId === null || $anonId === '')) {
+            throw (new ModelNotFoundException())->setModel(Attempt::class, [$attemptId]);
+        }
+
+        $q->where(function (Builder $sub) use ($userId, $anonId) {
+            if ($userId !== null) {
+                $sub->orWhere('user_id', (string) $userId);
+            }
+            if ($anonId !== null && $anonId !== '') {
+                $sub->orWhere('anon_id', $anonId);
+            }
+        });
+
+        return $q->firstOrFail();
+    }
+
+    private function createShare(Attempt $attempt, ?string $anonId): Share
+    {
+        $id = bin2hex(random_bytes(16));
+
+        try {
+            return Share::query()->create([
+                'id' => $id,
+                'attempt_id' => (string) $attempt->id,
+                'anon_id' => $anonId,
+                'scale_code' => (string) ($attempt->scale_code ?? ''),
+                'scale_version' => (string) ($attempt->scale_version ?? ''),
+                'content_package_version' => (string) ($attempt->content_package_version ?? ''),
+            ]);
+        } catch (QueryException $e) {
+            // Unique(attempt_id) race: fetch the existing row
+            return Share::query()->where('attempt_id', (string) $attempt->id)->firstOrFail();
+        }
+    }
+
+    private function hasColumn(string $table, string $column): bool
+    {
+        try {
+            return \Illuminate\Support\Facades\Schema::hasColumn($table, $column);
+        } catch (\Throwable $e) {
+            return false;
+        }
+    }
+}

--- a/backend/routes/api.php
+++ b/backend/routes/api.php
@@ -128,16 +128,16 @@ Route::prefix("v0.2")->middleware([
         Route::post("/attempts/start", [MbtiController::class, "startAttempt"]);
     });
 
-    // 6) Public share info
-    Route::get("/attempts/{id}/share", [MbtiController::class, "getShare"]);
+    // 6) Public share view (legacy)
+    Route::get("/share/{shareId}", [ShareController::class, "getShareView"]);
 
     // 6.5) Lookups
     Route::get("/lookup/ticket/{code}", [LookupController::class, "lookupTicket"]);
     Route::post("/lookup/order", [LookupController::class, "lookupOrder"]);
 
     // 7) Share click (public)
-    Route::post("/shares/{shareId}/click", [ShareController::class, "click"])
-        ->middleware('uuid:shareId');
+    // share_id now supports 32-hex legacy ids, so remove uuid middleware.
+    Route::post("/shares/{shareId}/click", [ShareController::class, "click"]);
 
     Route::middleware('throttle:api_auth')->group(function () {
         // Auth (public)
@@ -227,6 +227,7 @@ Route::prefix("v0.2")->middleware([
 
         // Attempts gated endpoints
         Route::post("/attempts/{id}/result", [MbtiController::class, "upsertResult"]);
+        Route::get("/attempts/{id}/share", [ShareController::class, "getShare"]);
 
         Route::post("/attempts/{attempt_id}/feedback", [ValidityFeedbackController::class, "store"]);
         Route::post("/lookup/device", [LookupController::class, "lookupDevice"]);

--- a/backend/scripts/accept_events_C.sh
+++ b/backend/scripts/accept_events_C.sh
@@ -28,6 +28,11 @@ BACKEND_DIR="$REPO_DIR/backend"
 API="${API:-http://127.0.0.1:1827}"
 SQLITE_DB="${SQLITE_DB:-$BACKEND_DIR/database/database.sqlite}"
 
+AUTH_HDRS=()
+if [[ -n "${FM_TOKEN:-}" && "${FM_TOKEN}" != "null" ]]; then
+  AUTH_HDRS=(-H "Authorization: Bearer ${FM_TOKEN}")
+fi
+
 echo "[ACCEPT] repo=$REPO_DIR"
 echo "[ACCEPT] backend=$BACKEND_DIR"
 echo "[ACCEPT] API=$API"
@@ -82,7 +87,9 @@ curl -sS -H "X-Anon-Id: $ANON_ID" \
 # ---- 2) share_generate (with optional headers) ----
 # Use set -u safe array expansion in case HDRS is empty.
 SHARE_RAW="$(
-  curl -sS "$API/api/v0.2/attempts/$ATT/share" \
+  curl -sS \
+    ${AUTH_HDRS[@]+"${AUTH_HDRS[@]}"} \
+    "$API/api/v0.2/attempts/$ATT/share" \
     ${HDRS[@]+"${HDRS[@]}"} \
   || true
 )"

--- a/backend/scripts/accept_events_D_anon.sh
+++ b/backend/scripts/accept_events_D_anon.sh
@@ -20,6 +20,11 @@ BACKEND_DIR="$REPO_DIR/backend"
 API="${API:-http://127.0.0.1:1827}"
 SQLITE_DB="${SQLITE_DB:-$BACKEND_DIR/database/database.sqlite}"
 
+AUTH_HDRS=()
+if [[ -n "${FM_TOKEN:-}" && "${FM_TOKEN}" != "null" ]]; then
+  AUTH_HDRS=(-H "Authorization: Bearer ${FM_TOKEN}")
+fi
+
 echo "[ACCEPT_D] repo=$REPO_DIR"
 echo "[ACCEPT_D] backend=$BACKEND_DIR"
 echo "[ACCEPT_D] API=$API"
@@ -67,7 +72,9 @@ export ATT
 # 1) If accept_events_C.sh exported SHARE_ID in current shell (unlikely), use it
 # 2) Else: call /share ourselves with headers, so we get a deterministic SHARE_ID and
 #    the share_generate event should have same anon_id as attempt-side (if implemented).
-SHARE_RAW="$(curl -sS "$API/api/v0.2/attempts/$ATT/share" \
+SHARE_RAW="$(curl -sS \
+  ${AUTH_HDRS[@]+"${AUTH_HDRS[@]}"} \
+  "$API/api/v0.2/attempts/$ATT/share" \
   -H "X-Experiment: $EXPERIMENT" \
   -H "X-App-Version: $APPV" \
   -H "X-Channel: $CHANNEL" \

--- a/backend/scripts/accept_events_D_anon_block_placeholder_click.sh
+++ b/backend/scripts/accept_events_D_anon_block_placeholder_click.sh
@@ -21,6 +21,11 @@ API="${API:-http://127.0.0.1:1827}"
 SQLITE_DB="${SQLITE_DB:-$BACKEND_DIR/database/database.sqlite}"
 BAD_ANON="${BAD_ANON:-把你查到的anon_id填这里}"
 
+AUTH_HDRS=()
+if [[ -n "${FM_TOKEN:-}" && "${FM_TOKEN}" != "null" ]]; then
+  AUTH_HDRS=(-H "Authorization: Bearer ${FM_TOKEN}")
+fi
+
 echo "[ACCEPT_D3] repo=$REPO_DIR"
 echo "[ACCEPT_D3] backend=$BACKEND_DIR"
 echo "[ACCEPT_D3] API=$API"
@@ -41,7 +46,7 @@ fi
 echo "[ACCEPT_D3] ATT=$ATT"
 
 # /share
-SHARE_RAW="$(curl -sS "$API/api/v0.2/attempts/$ATT/share" || true)"
+SHARE_RAW="$(curl -sS ${AUTH_HDRS[@]+"${AUTH_HDRS[@]}"} "$API/api/v0.2/attempts/$ATT/share" || true)"
 SHARE_JSON="$(printf '%s\n' "$SHARE_RAW" | sed -n '/^{/,$p')"
 SHARE_ID="$(printf '%s\n' "$SHARE_JSON" | php -r '$j=json_decode(stream_get_contents(STDIN), true); echo $j["share_id"] ?? ($j["shareId"] ?? "");' 2>/dev/null || true)"
 if [[ -z "$SHARE_ID" || "$SHARE_ID" == "null" ]]; then

--- a/backend/scripts/accept_events_D_click_anon_override.sh
+++ b/backend/scripts/accept_events_D_click_anon_override.sh
@@ -22,6 +22,11 @@ BACKEND_DIR="$REPO_DIR/backend"
 API="${API:-http://127.0.0.1:1827}"
 SQLITE_DB="${SQLITE_DB:-$BACKEND_DIR/database/database.sqlite}"
 
+AUTH_HDRS=()
+if [[ -n "${FM_TOKEN:-}" && "${FM_TOKEN}" != "null" ]]; then
+  AUTH_HDRS=(-H "Authorization: Bearer ${FM_TOKEN}")
+fi
+
 echo "[ACCEPT_D2] repo=$REPO_DIR"
 echo "[ACCEPT_D2] backend=$BACKEND_DIR"
 echo "[ACCEPT_D2] API=$API"
@@ -43,7 +48,7 @@ echo "[ACCEPT_D2] ATT=$ATT"
 export ATT
 
 # --- Call /share to get SHARE_ID
-SHARE_RAW="$(curl -sS "$API/api/v0.2/attempts/$ATT/share" || true)"
+SHARE_RAW="$(curl -sS ${AUTH_HDRS[@]+"${AUTH_HDRS[@]}"} "$API/api/v0.2/attempts/$ATT/share" || true)"
 SHARE_JSON="$(printf '%s\n' "$SHARE_RAW" | sed -n '/^{/,$p')"
 SHARE_ID="$(printf '%s\n' "$SHARE_JSON" | php -r '$j=json_decode(stream_get_contents(STDIN), true); echo $j["share_id"] ?? ($j["shareId"] ?? "");' 2>/dev/null || true)"
 

--- a/backend/scripts/accept_events_E_share_meta.sh
+++ b/backend/scripts/accept_events_E_share_meta.sh
@@ -18,6 +18,11 @@ BACKEND_DIR="$REPO_DIR/backend"
 API="${API:-http://127.0.0.1:1827}"
 SQLITE_DB="${SQLITE_DB:-$BACKEND_DIR/database/database.sqlite}"
 
+AUTH_HDRS=()
+if [[ -n "${FM_TOKEN:-}" && "${FM_TOKEN}" != "null" ]]; then
+  AUTH_HDRS=(-H "Authorization: Bearer ${FM_TOKEN}")
+fi
+
 echo "[ACCEPT_E] repo=$REPO_DIR"
 echo "[ACCEPT_E] backend=$BACKEND_DIR"
 echo "[ACCEPT_E] API=$API"
@@ -67,7 +72,9 @@ export ATT
 # --------------------------------------------
 # 3) /share with headers (must produce share_generate meta)
 # --------------------------------------------
-SHARE_RAW="$(curl -sS "$API/api/v0.2/attempts/$ATT/share" \
+SHARE_RAW="$(curl -sS \
+  ${AUTH_HDRS[@]+"${AUTH_HDRS[@]}"} \
+  "$API/api/v0.2/attempts/$ATT/share" \
   -H "X-Experiment: $EXPERIMENT" \
   -H "X-App-Version: $APPV" \
   -H "X-Channel: $CHANNEL" \

--- a/backend/scripts/accept_events_H_share_view_meta.sh
+++ b/backend/scripts/accept_events_H_share_view_meta.sh
@@ -12,6 +12,11 @@ cd "$BACKEND_DIR"
 
 API="${API:-http://127.0.0.1:1827}"
 
+AUTH_HDRS=()
+if [[ -n "${FM_TOKEN:-}" && "${FM_TOKEN}" != "null" ]]; then
+  AUTH_HDRS=(-H "Authorization: Bearer ${FM_TOKEN}")
+fi
+
 # -----------------------------
 # Resolve SQLITE_DB to ABS path
 # -----------------------------
@@ -80,6 +85,7 @@ echo "[ACCEPT_H] share_id(from_artifacts)=$SHARE_ID_OLD"
 # IMPORTANT: Do NOT discard response; use share_id from THIS response
 # -----------------------------
 curl -fsS \
+  ${AUTH_HDRS[@]+"${AUTH_HDRS[@]}"} \
   -H "X-Experiment: H_accept" \
   -H "X-App-Version: 1.2.3-accept" \
   -H "X-Channel: miniapp" \

--- a/backend/scripts/verify_mbti.sh
+++ b/backend/scripts/verify_mbti.sh
@@ -332,8 +332,8 @@ echo "[5/8] fetch report & share"
 REPORT_URL="$API/api/v0.2/attempts/$ATTEMPT_ID/report?anon_id=$ATTEMPT_ANON_ID"
 # ✅ report uses owner anon_id guard; avoid mismatched fm_token owner overriding anon_id
 fetch_json "$REPORT_URL" "$REPORT_JSON" 0
-# share is public (not gated)
-fetch_json "$API/api/v0.2/attempts/$ATTEMPT_ID/share"  "$SHARE_JSON" 0
+# share is now gated by fm_token
+fetch_json "$API/api/v0.2/attempts/$ATTEMPT_ID/share"  "$SHARE_JSON" 1
 echo "[OK] report=$REPORT_JSON"
 echo "[OK] share=$SHARE_JSON"
 

--- a/backend/tests/Feature/V0_2/ShareSecurityTest.php
+++ b/backend/tests/Feature/V0_2/ShareSecurityTest.php
@@ -1,0 +1,140 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\V0_2;
+
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Str;
+use Tests\TestCase;
+
+final class ShareSecurityTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_user_can_access_own_attempt_share_returns_200(): void
+    {
+        $orgId = 1;
+        $ownerAnon = 'anon_owner_' . Str::random(8);
+
+        $attemptId = (string) Str::uuid();
+        $this->seedAttemptAndResult($attemptId, $orgId, $ownerAnon, null);
+
+        $token = $this->seedFmToken($ownerAnon);
+
+        $resp = $this->withHeaders([
+            'Authorization' => 'Bearer ' . $token,
+            'X-Org-Id' => (string) $orgId,
+        ])->getJson('/api/v0.2/attempts/' . $attemptId . '/share');
+
+        $resp->assertStatus(200);
+        $resp->assertJson([
+            'ok' => true,
+            'attempt_id' => $attemptId,
+            'org_id' => $orgId,
+        ]);
+
+        $shareId = $resp->json('share_id');
+        $this->assertIsString($shareId);
+        $this->assertSame(32, strlen($shareId));
+        $this->assertTrue(ctype_xdigit($shareId));
+    }
+
+    public function test_user_cannot_access_other_members_attempt_in_same_org_returns_404(): void
+    {
+        $orgId = 2;
+        $ownerAnon = 'anon_owner_' . Str::random(8);
+        $attackerAnon = 'anon_attacker_' . Str::random(8);
+
+        $attemptId = (string) Str::uuid();
+        $this->seedAttemptAndResult($attemptId, $orgId, $ownerAnon, null);
+
+        $token = $this->seedFmToken($attackerAnon);
+
+        $resp = $this->withHeaders([
+            'Authorization' => 'Bearer ' . $token,
+            'X-Org-Id' => (string) $orgId,
+        ])->getJson('/api/v0.2/attempts/' . $attemptId . '/share');
+
+        $resp->assertStatus(404);
+    }
+
+    public function test_cross_org_access_returns_404(): void
+    {
+        $orgA = 10;
+        $orgB = 11;
+
+        $anonA = 'anon_a_' . Str::random(8);
+
+        $attemptIdB = (string) Str::uuid();
+        $this->seedAttemptAndResult($attemptIdB, $orgB, 'anon_b_' . Str::random(8), null);
+
+        $token = $this->seedFmToken($anonA);
+
+        $resp = $this->withHeaders([
+            'Authorization' => 'Bearer ' . $token,
+            'X-Org-Id' => (string) $orgA,
+        ])->getJson('/api/v0.2/attempts/' . $attemptIdB . '/share');
+
+        $resp->assertStatus(404);
+    }
+
+    private function seedFmToken(string $anonId, ?int $userId = null): string
+    {
+        $token = 'fm_' . (string) Str::uuid();
+
+        DB::table('fm_tokens')->insert([
+            'token' => $token,
+            'anon_id' => $anonId,
+            'user_id' => $userId,
+            'expires_at' => now()->addHour(),
+            'created_at' => now(),
+            'updated_at' => now(),
+        ]);
+
+        return $token;
+    }
+
+    private function seedAttemptAndResult(string $attemptId, int $orgId, string $anonId, ?int $userId): void
+    {
+        $now = now();
+
+        DB::table('attempts')->insert([
+            'id' => $attemptId,
+            'org_id' => $orgId,
+            'anon_id' => $anonId,
+            'user_id' => $userId ? (string) $userId : null,
+            'scale_code' => 'MBTI',
+            'scale_version' => 'v0.2',
+            'question_count' => 10,
+            'answers_summary_json' => json_encode(['answered' => 10], JSON_UNESCAPED_UNICODE),
+            'client_platform' => 'web',
+            'content_package_version' => 'cp_v1',
+            'started_at' => $now->copy()->subMinutes(3),
+            'submitted_at' => $now->copy()->subMinutes(1),
+            'created_at' => $now,
+            'updated_at' => $now,
+        ]);
+
+        DB::table('results')->insert([
+            'id' => (string) Str::uuid(),
+            'org_id' => $orgId,
+            'attempt_id' => $attemptId,
+            'scale_code' => 'MBTI',
+            'scale_version' => 'v0.2',
+            'content_package_version' => 'cp_v1',
+            'type_code' => 'INTJ',
+            'scores_json' => json_encode(['EI' => ['a' => 10, 'b' => 20, 'sum' => -10, 'total' => 30]], JSON_UNESCAPED_UNICODE),
+            'scores_pct' => json_encode(['EI' => 33], JSON_UNESCAPED_UNICODE),
+            'axis_states' => json_encode(['EI' => 'clear'], JSON_UNESCAPED_UNICODE),
+            'result_json' => json_encode([
+                'type_code' => 'INTJ',
+                'type_name' => 'Architect',
+            ], JSON_UNESCAPED_UNICODE),
+            'computed_at' => $now,
+            'created_at' => $now,
+            'updated_at' => $now,
+        ]);
+    }
+}


### PR DESCRIPTION
## Summary
This PR fully fixes v0.2 share IDOR and refactors legacy share logic into a dedicated service + slim controller.

Key points:
- Add `LegacyShareService` to centralize v0.2 share generate/view logic.
- Enforce SQL-level access control on attempts: `org_id` + `(user_id OR anon_id)` ownership.
- Route `GET /api/v0.2/attempts/{id}/share` under `FmTokenAuth` and move handler to `ShareController@getShare`.
- Add `GET /api/v0.2/share/{shareId}` via `ShareController@getShareView`.
- Keep unauthorized and non-existent resources unified as `404`.
- Replace weak share id generation with `bin2hex(random_bytes(16))`.
- Handle concurrent create unique conflict by reading existing share row.
- Add `ShareSecurityTest` with 3 required cases.
- Update acceptance scripts for bearer passthrough so `ci_verify_mbti.sh` remains green.

## API Contract Changes
- `GET /api/v0.2/attempts/{id}/share` is now auth-gated by `FmTokenAuth`.
- `share_id` is now 32-char hex (legacy ID), not uuid-only route semantics.
- `GET /api/v0.2/share/{shareId}` is served by `ShareController@getShareView`.
- Unauthorized vs not-found are both represented as `404` for IDOR hardening.

## Security Guarantees
1. Share endpoint entry moved away from `MbtiController` path for v0.2 share generation.
2. Attempt lookup is SQL-filtered by tenant + ownership (`org_id` + `user_id/anon_id`).
3. Unauthorized and non-existent return uniform `404`.
4. Share id generation uses cryptographically secure random bytes.
5. PHPUnit security tests cover own/same-org-other/cross-org cases.

## Tests Run
- `composer install`
- `php artisan route:list | rg "v0.2/(attempts/\{id\}/share|share/\{shareId\}|shares/\{shareId\}/click)"`
- `php artisan migrate:fresh --force`
- `php artisan migrate --force`
- `php artisan test --filter=MeAttemptsAuthContractTest`
- `php artisan test --filter=ShareSecurityTest`
- `php artisan test`
- `bash scripts/ci_verify_mbti.sh`

All passed.
