### PR TITLE
fix(v0.2-payments): 移除客户端定价权并强制服务端 SKU 定价

### DIFF
--- a/backend/app/Exceptions/InvalidSkuException.php
+++ b/backend/app/Exceptions/InvalidSkuException.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Exceptions;
+
+use RuntimeException;
+
+final class InvalidSkuException extends RuntimeException
+{
+    public function __construct(string $message = 'invalid sku.')
+    {
+        parent::__construct($message);
+    }
+}

--- a/backend/app/Http/Requests/V0_2/CreateOrderRequest.php
+++ b/backend/app/Http/Requests/V0_2/CreateOrderRequest.php
@@ -2,7 +2,11 @@
 
 namespace App\Http\Requests\V0_2;
 
+use Illuminate\Database\Query\Builder;
 use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Validation\Rule;
+use Illuminate\Validation\Rules\Exists;
 
 class CreateOrderRequest extends FormRequest
 {
@@ -13,34 +17,37 @@ class CreateOrderRequest extends FormRequest
 
     protected function prepareForValidation(): void
     {
-        $amount = $this->input('amount_total', null);
-        if (is_numeric($amount)) {
-            $amount = (int) $amount;
-        }
-
         $currency = strtoupper(trim((string) $this->input('currency', 'CNY')));
         $provider = strtolower(trim((string) $this->input('provider', '')));
         $providerOrderId = trim((string) $this->input('provider_order_id', ''));
 
         $this->merge([
-            'item_sku' => trim((string) $this->input('item_sku', '')),
+            'item_sku' => strtoupper(trim((string) $this->input('item_sku', ''))),
             'currency' => $currency !== '' ? $currency : 'CNY',
-            'amount_total' => $amount,
             'device_id' => $this->input('device_id', $this->header('X-Device-Id', null)),
             'provider' => $provider !== '' ? $provider : null,
             'provider_order_id' => $providerOrderId !== '' ? $providerOrderId : null,
+            'request_id' => $this->header('X-Request-Id', $this->input('request_id', null)),
+            'org_id' => $this->input('org_id', 1),
         ]);
     }
 
     public function rules(): array
     {
         return [
-            'item_sku' => ['required', 'string', 'max:64'],
+            'item_sku' => ['required', 'string', 'max:64', $this->skuExistsRule()],
             'currency' => ['required', 'string', 'max:8'],
-            'amount_total' => ['required', 'integer', 'min:1'],
             'device_id' => ['nullable', 'string', 'max:128'],
             'provider' => ['nullable', 'string', 'max:32'],
             'provider_order_id' => ['nullable', 'string', 'max:128'],
+            'request_id' => ['nullable', 'string', 'max:128'],
+            'user_id' => ['nullable', 'string', 'max:64'],
+            'anon_id' => ['nullable', 'string', 'max:64'],
+            'attempt_id' => ['nullable', 'string', 'max:64'],
+            'platform' => ['nullable', 'string', 'max:32'],
+            'pay_source' => ['nullable', 'string', 'max:64'],
+            'org_id' => ['nullable', 'integer', 'min:1'],
+            'ip' => ['nullable', 'string', 'max:45'],
         ];
     }
 
@@ -52,11 +59,6 @@ class CreateOrderRequest extends FormRequest
     public function currency(): string
     {
         return (string) $this->validated()['currency'];
-    }
-
-    public function amountTotal(): int
-    {
-        return (int) $this->validated()['amount_total'];
     }
 
     public function deviceId(): ?string
@@ -82,8 +84,52 @@ class CreateOrderRequest extends FormRequest
 
     public function requestId(): ?string
     {
-        $v = $this->header('X-Request-Id', $this->input('request_id', null));
+        $v = $this->validated()['request_id'] ?? null;
         $v = is_string($v) ? trim($v) : null;
+        return $v !== '' ? $v : null;
+    }
+
+    public function orderData(): array
+    {
+        return [
+            'user_id' => $this->stringOrNull($this->input('user_id', null)),
+            'anon_id' => $this->stringOrNull($this->input('anon_id', null)),
+            'device_id' => $this->deviceId(),
+            'attempt_id' => $this->stringOrNull($this->input('attempt_id', null)),
+            'platform' => $this->stringOrNull($this->input('platform', null)),
+            'pay_source' => $this->stringOrNull($this->input('pay_source', null)),
+            'item_sku' => $this->itemSku(),
+            'currency' => $this->currency(),
+            'provider' => $this->provider(),
+            'provider_order_id' => $this->providerOrderId(),
+            'request_id' => $this->requestId(),
+            'org_id' => (int) ($this->validated()['org_id'] ?? 1),
+            'ip' => $this->stringOrNull($this->input('ip', null)),
+        ];
+    }
+
+    private function skuExistsRule(): Exists
+    {
+        $currency = strtoupper(trim((string) $this->input('currency', 'CNY')));
+        $currency = $currency !== '' ? $currency : 'CNY';
+
+        return Rule::exists('skus', 'sku')->where(function (Builder $query) use ($currency): void {
+            $query->where('currency', $currency)
+                ->where('is_active', 1);
+
+            if (Schema::hasColumn('skus', 'org_id')) {
+                $query->where('org_id', 1);
+            }
+        });
+    }
+
+    private function stringOrNull(mixed $value): ?string
+    {
+        if (!is_string($value) && !is_numeric($value)) {
+            return null;
+        }
+
+        $v = trim((string) $value);
         return $v !== '' ? $v : null;
     }
 }

--- a/backend/app/Services/Commerce/SkuPriceService.php
+++ b/backend/app/Services/Commerce/SkuPriceService.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\Commerce;
+
+use App\Exceptions\InvalidSkuException;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+final class SkuPriceService
+{
+    public function getPrice(string $sku, string $currency, int $orgId = 1): int
+    {
+        if (!Schema::hasTable('skus')) {
+            throw new InvalidSkuException();
+        }
+
+        $sku = strtoupper(trim($sku));
+        $currency = strtoupper(trim($currency));
+
+        if ($sku === '' || $currency === '') {
+            throw new InvalidSkuException();
+        }
+
+        $query = DB::table('skus')
+            ->where('sku', $sku)
+            ->where('currency', $currency)
+            ->where('is_active', 1);
+
+        if (Schema::hasColumn('skus', 'org_id')) {
+            $query->where('org_id', $orgId);
+        }
+
+        $row = $query->first();
+        if (!$row) {
+            throw new InvalidSkuException();
+        }
+
+        return (int) ($row->price_cents ?? 0);
+    }
+}

--- a/backend/app/Support/ApiExceptionRenderer.php
+++ b/backend/app/Support/ApiExceptionRenderer.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Support;
 
+use App\Exceptions\InvalidSkuException;
 use Illuminate\Database\Eloquent\ModelNotFoundException;
 use Illuminate\Http\Exceptions\HttpResponseException;
 use Illuminate\Http\JsonResponse;
@@ -32,6 +33,16 @@ final class ApiExceptionRenderer
             'error_code' => 'INTERNAL_ERROR',
             'message' => 'Internal Server Error',
         ];
+
+        if ($e instanceof InvalidSkuException) {
+            $status = 422;
+            $payload = [
+                'ok' => false,
+                'error' => 'INVALID_SKU',
+                'error_code' => 'INVALID_SKU',
+                'message' => 'invalid sku.',
+            ];
+        }
 
         if (
             $e instanceof ModelNotFoundException

--- a/backend/tests/Feature/V0_2/PaymentsMockWebhookProviderIsolationTest.php
+++ b/backend/tests/Feature/V0_2/PaymentsMockWebhookProviderIsolationTest.php
@@ -71,7 +71,7 @@ final class PaymentsMockWebhookProviderIsolationTest extends TestCase
             ->where('provider_event_id', 'evt_shared')
             ->first();
 
-        $result = (new PaymentService())->handleWebhookMock(
+        $result = app(PaymentService::class)->handleWebhookMock(
             [
                 'provider_event_id' => 'evt_shared',
                 'provider_order_id' => $providerOrderId,

--- a/backend/tests/Feature/V0_2/SecureOrderTest.php
+++ b/backend/tests/Feature/V0_2/SecureOrderTest.php
@@ -1,0 +1,137 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\V0_2;
+
+use App\Services\Payments\PaymentService;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+use Tests\TestCase;
+
+final class SecureOrderTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_create_order_uses_server_price_for_normal_order(): void
+    {
+        $this->seedSku(1990);
+
+        $result = app(PaymentService::class)->createOrder([
+            'user_id' => 'u1',
+            'item_sku' => 'MBTI_FULL',
+            'currency' => 'USD',
+            'amount_total' => 999999,
+        ]);
+
+        $this->assertTrue($result['ok']);
+
+        $order = $result['order'];
+        $orderId = $this->extractOrderId($order);
+
+        $this->assertSame(1990, $this->extractAmountTotal($order));
+        if ($this->hasAmountCents($order)) {
+            $this->assertSame(1990, $this->extractAmountCents($order));
+        }
+
+        $dbOrder = DB::table('orders')->where('id', $orderId)->first();
+        $this->assertNotNull($dbOrder);
+        $this->assertSame(1990, (int) ($dbOrder->amount_total ?? 0));
+        if (isset($dbOrder->amount_cents)) {
+            $this->assertSame(1990, (int) $dbOrder->amount_cents);
+        }
+    }
+
+    public function test_create_order_ignores_client_supplied_amount_total_attack(): void
+    {
+        $this->seedSku(1990);
+
+        $result = app(PaymentService::class)->createOrder([
+            'user_id' => 'u1',
+            'item_sku' => 'MBTI_FULL',
+            'currency' => 'USD',
+            'amount_total' => 1,
+        ]);
+
+        $this->assertTrue($result['ok']);
+
+        $order = $result['order'];
+        $orderId = $this->extractOrderId($order);
+
+        $this->assertSame(1990, $this->extractAmountTotal($order));
+        if ($this->hasAmountCents($order)) {
+            $this->assertSame(1990, $this->extractAmountCents($order));
+        }
+
+        $dbOrder = DB::table('orders')->where('id', $orderId)->first();
+        $this->assertNotNull($dbOrder);
+        $this->assertSame(1990, (int) ($dbOrder->amount_total ?? 0));
+        if (isset($dbOrder->amount_cents)) {
+            $this->assertSame(1990, (int) $dbOrder->amount_cents);
+        }
+    }
+
+    private function seedSku(int $priceCents): void
+    {
+        $row = [
+            'sku' => 'MBTI_FULL',
+            'scale_code' => 'MBTI',
+            'kind' => 'report_unlock',
+            'unit_qty' => 1,
+            'benefit_code' => 'MBTI_REPORT_FULL',
+            'scope' => 'user',
+            'price_cents' => $priceCents,
+            'currency' => 'USD',
+            'is_active' => 1,
+            'meta_json' => null,
+            'created_at' => now(),
+            'updated_at' => now(),
+        ];
+
+        if (Schema::hasColumn('skus', 'org_id')) {
+            $row['org_id'] = 1;
+        }
+        if (Schema::hasColumn('skus', 'title')) {
+            $row['title'] = 'MBTI Full';
+        }
+
+        DB::table('skus')->updateOrInsert(['sku' => 'MBTI_FULL'], $row);
+    }
+
+    private function extractOrderId(mixed $order): string
+    {
+        if (is_array($order)) {
+            return (string) ($order['id'] ?? '');
+        }
+
+        return (string) ($order->id ?? '');
+    }
+
+    private function extractAmountTotal(mixed $order): int
+    {
+        if (is_array($order)) {
+            return (int) ($order['amount_total'] ?? 0);
+        }
+
+        return (int) ($order->amount_total ?? 0);
+    }
+
+    private function hasAmountCents(mixed $order): bool
+    {
+        if (is_array($order)) {
+            return array_key_exists('amount_cents', $order);
+        }
+
+        return is_object($order) && property_exists($order, 'amount_cents');
+    }
+
+    private function extractAmountCents(mixed $order): int
+    {
+        if (is_array($order)) {
+            return (int) ($order['amount_cents'] ?? 0);
+        }
+
+        return (int) ($order->amount_cents ?? 0);
+    }
+}


### PR DESCRIPTION
## 背景

本 PR 修复 v0.2 订单创建的信任边界问题：客户端传入的 `amount_total` 不再参与定价，服务端统一从 `skus` 表按 `item_sku + currency` 读取价格。

## 主要改动

- 新增 `InvalidSkuException`：SKU 不存在 / inactive / currency 不匹配时作为硬门禁。
- 新增 `SkuPriceService::getPrice(string $sku, string $currency, int $orgId = 1): int`。
- `CreateOrderRequest`：
  - 移除 `amount_total` 校验与输出。
  - `item_sku` 校验升级为 DB exists，并附加 `currency` + `is_active=1` 约束（有 `org_id` 列时追加 `org_id=1`）。
  - 新增 `orderData()`，切断客户端价格流入 service。
- `PaymentService::createOrder`：
  - 构造注入 `SkuPriceService`。
  - 仅使用服务端价格写入订单：
    - `orders.amount_total = price_cents`
    - 若有列则同步 `orders.amount_cents = price_cents`
  - 客户端 `amount_total` 完全忽略。
- `PaymentsController@createOrder` 改为 `createOrder($request->orderData())`。
- `ApiExceptionRenderer` 新增 `InvalidSkuException -> HTTP 422 / INVALID_SKU`。
- 新增 `SecureOrderTest`：
  - 正常下单金额正确
  - 攻击模拟 `amount_total=1` 仍写入服务端价格
- 修复 `PaymentsMockWebhookProviderIsolationTest`：改为 `app(PaymentService::class)` 实例化，兼容依赖注入。

## 测试与验收

已通过：

- `php artisan route:list`
- `php artisan migrate`
- `php artisan test --filter SecureOrderTest`（OK，Tests: 2）
- `php artisan test --filter PaymentsMockWebhookProviderIsolationTest`（OK）
- 人工 tinker 复核：输出 `int(1990)`
- `bash backend/scripts/ci_verify_mbti.sh`（全链路通过）

## 兼容性说明

当前仓库 `skus` 表在不同环境可能不存在 `org_id` 列，代码采用了列存在检查：有列则按 `org_id=1` 过滤，无列时保持兼容查询。
