### PR TITLE
fix(v0.3): remove silent fallback and add error anchors for questions/cache

### DIFF
--- a/backend/app/Http/Controllers/MbtiController.php
+++ b/backend/app/Http/Controllers/MbtiController.php
@@ -155,10 +155,18 @@ class MbtiController extends Controller
         try {
             $cachedPayload = $cache->get($cacheKey);
         } catch (\Throwable $e) {
+            Log::warning('MBTI_CACHE_READ_FAILED', [
+                'key' => $cacheKey,
+                'message' => $e->getMessage(),
+            ]);
             try {
                 $cache = Cache::store();
                 $cachedPayload = $cache->get($cacheKey);
             } catch (\Throwable $e2) {
+                Log::warning('MBTI_CACHE_READ_FAILED', [
+                    'key' => $cacheKey,
+                    'message' => $e2->getMessage(),
+                ]);
                 $cachedPayload = null;
             }
         }
@@ -239,10 +247,17 @@ class MbtiController extends Controller
         try {
             $cache->put($cacheKey, $payload, self::HOT_CACHE_TTL_SECONDS);
         } catch (\Throwable $e) {
+            Log::warning('MBTI_CACHE_WRITE_FAILED', [
+                'key' => $cacheKey,
+                'message' => $e->getMessage(),
+            ]);
             try {
                 Cache::store()->put($cacheKey, $payload, self::HOT_CACHE_TTL_SECONDS);
             } catch (\Throwable $e2) {
-                // ignore cache write failure
+                Log::warning('MBTI_CACHE_WRITE_FAILED', [
+                    'key' => $cacheKey,
+                    'message' => $e2->getMessage(),
+                ]);
             }
         }
 
@@ -1998,7 +2013,11 @@ try {
         $out = $applier->apply($out, $ctx);
     }
 } catch (\Throwable $e) {
-    // swallow
+    Log::error('MBTI_HIGHLIGHTS_BUILD_FAILED', [
+        'attempt_id' => (string) (request()->route('id') ?? request()->route('attempt_id') ?? request()->input('attempt_id', '')),
+        'type_code' => $typeCode,
+        'message' => $e->getMessage(),
+    ]);
 }
 
 return array_slice($out, 0, 8);
@@ -2413,7 +2432,10 @@ private function findPackageFile(string $pkg, string $filename, int $maxDepth = 
                 }
             }
         } catch (\Throwable $e) {
-            // ignore this root and continue
+            Log::warning('MBTI_PACKAGE_FILE_PROBE_FAILED', [
+                'path' => $root,
+                'message' => $e->getMessage(),
+            ]);
             continue;
         }
     }
@@ -2505,7 +2527,11 @@ private function findPackageFile(string $pkg, string $filename, int $maxDepth = 
                     $path = $candidate;
                 }
             } catch (\Throwable $e) {
-                // ignore resolve failure
+                Log::error('MBTI_TYPE_PROFILE_LOAD_FAILED', [
+                    'package_id' => $contentPackageVersion,
+                    'type_code' => $typeCode,
+                    'message' => $e->getMessage(),
+                ]);
             }
         }
 


### PR DESCRIPTION
## Summary
- Fix silent fallback in v0.3 attempts start flow by hardening `resolveQuestionCount` in `AttemptWriteController`.
- Remove nullable return path and null-branch response for question count resolution.
- Add explicit error anchors in `MbtiController` for cache read/write and previously swallowed exceptions.

## Changes
- `backend/app/Http/Controllers/API/V0_3/AttemptWriteController.php`
  - Added `Log` facade import.
  - Changed `resolveQuestionCount(string $packId, string $dirVersion): ?int` to `: int`.
  - Added structured error logs + throw paths:
    - `QUESTIONS_INDEX_FIND_FAILED`
    - `QUESTIONS_FILE_MISSING`
    - `QUESTIONS_FILE_READ_FAILED`
    - `QUESTIONS_JSON_DECODE_FAILED`
    - `QUESTIONS_JSON_INVALID_SHAPE`
  - Removed `start()` null-check fallback response so questions errors go through global exception handling.

- `backend/app/Http/Controllers/MbtiController.php`
  - Added cache read warning anchors:
    - `MBTI_CACHE_READ_FAILED`
  - Added cache write warning anchors:
    - `MBTI_CACHE_WRITE_FAILED`
  - Replaced swallowed catches with explicit logs:
    - `MBTI_HIGHLIGHTS_BUILD_FAILED`
    - `MBTI_PACKAGE_FILE_PROBE_FAILED`
    - `MBTI_TYPE_PROFILE_LOAD_FAILED`

## Why
Patch B targets “error happened but not surfaced” paths. This change removes silent null fallbacks in v0.3 attempt start and makes MBTI controller catch points observable in logs while preserving non-blocking behavior for cache failures.

## Validation
- `php artisan route:list`
- `php artisan migrate`
- `grep -n "function resolveQuestionCount" app/Http/Controllers/API/V0_3/AttemptWriteController.php`
- empty-catch scan for controller catches (pass)
- `bash backend/scripts/ci_verify_mbti.sh` (pass)

## Notes
- Manual negative test for corrupted `questions.json` is intentionally not auto-executed in this patch run (requires temporary content mutation).
