### PR TITLE
refactor(migrations): zero-downtime schema-only migrations and org backfill ops

### DIFF
--- a/backend/app/Console/Commands/Ops/RunBackfillOrgId.php
+++ b/backend/app/Console/Commands/Ops/RunBackfillOrgId.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace App\Console\Commands\Ops;
+
+use App\Jobs\Ops\BackfillOrgIdJob;
+use Illuminate\Console\Command;
+
+class RunBackfillOrgId extends Command
+{
+    protected $signature = 'ops:run-backfill-org-id
+        {table : Target table name}
+        {--id-column=id : Primary key / cursor column}
+        {--org-id-column=org_id : Org id column}
+        {--batch-size=1000 : Chunk size}
+        {--progress-key= : Override progress key}
+        {--sync : Run immediately in current process}';
+
+    protected $description = 'Run throttled + resumable org_id backfill safely';
+
+    public function handle(): int
+    {
+        $table = trim((string) $this->argument('table'));
+        $idColumn = trim((string) $this->option('id-column'));
+        $orgIdColumn = trim((string) $this->option('org-id-column'));
+        $batchSize = (int) $this->option('batch-size');
+        $progressKey = trim((string) $this->option('progress-key'));
+
+        if ($table === '' || $idColumn === '' || $orgIdColumn === '') {
+            $this->error('table / id-column / org-id-column cannot be empty');
+            return self::FAILURE;
+        }
+
+        if ($batchSize <= 0) {
+            $this->error('batch-size must be > 0');
+            return self::FAILURE;
+        }
+
+        $job = new BackfillOrgIdJob(
+            table: $table,
+            idColumn: $idColumn,
+            orgIdColumn: $orgIdColumn,
+            batchSize: $batchSize,
+            progressKey: $progressKey !== '' ? $progressKey : null
+        );
+
+        if ((bool) $this->option('sync')) {
+            $job->handle();
+            $this->info('backfill completed (sync)');
+            return self::SUCCESS;
+        }
+
+        dispatch($job);
+        $this->info('backfill dispatched');
+
+        return self::SUCCESS;
+    }
+}

--- a/backend/database/migrations/2026_01_29_140000_create_report_snapshots_table.php
+++ b/backend/database/migrations/2026_01_29_140000_create_report_snapshots_table.php
@@ -79,26 +79,15 @@ return new class extends Migration
             }
         });
 
-        if (Schema::hasTable('report_snapshots') && Schema::hasColumn('report_snapshots', 'org_id')) {
-            DB::table('report_snapshots')->whereNull('org_id')->update(['org_id' => 0]);
-        }
+        // Data backfill moved to ops job to keep migration schema-only.
 
         $uniqueName = 'report_snapshots_attempt_id_unique';
         if (Schema::hasTable('report_snapshots')
             && Schema::hasColumn('report_snapshots', 'attempt_id')
             && !$this->indexExists('report_snapshots', $uniqueName)) {
-            $duplicates = DB::table('report_snapshots')
-                ->select('attempt_id')
-                ->whereNotNull('attempt_id')
-                ->groupBy('attempt_id')
-                ->havingRaw('count(*) > 1')
-                ->limit(1)
-                ->get();
-            if ($duplicates->count() === 0) {
-                Schema::table('report_snapshots', function (Blueprint $table) use ($uniqueName) {
-                    $table->unique(['attempt_id'], $uniqueName);
-                });
-            }
+            Schema::table('report_snapshots', function (Blueprint $table) use ($uniqueName) {
+                $table->unique(['attempt_id'], $uniqueName);
+            });
         }
 
         if (!$this->indexExists('report_snapshots', 'report_snapshots_org_id_idx')

--- a/backend/database/migrations/2026_01_29_200020_create_payment_events_table.php
+++ b/backend/database/migrations/2026_01_29_200020_create_payment_events_table.php
@@ -37,20 +37,9 @@ return new class extends Migration
         if (!$this->indexExists('payment_events', 'payment_events_provider_provider_event_id_unique')
             && Schema::hasColumn('payment_events', 'provider')
             && Schema::hasColumn('payment_events', 'provider_event_id')) {
-            $duplicates = DB::table('payment_events')
-                ->select('provider', 'provider_event_id')
-                ->whereNotNull('provider')
-                ->whereNotNull('provider_event_id')
-                ->groupBy('provider', 'provider_event_id')
-                ->havingRaw('count(*) > 1')
-                ->limit(1)
-                ->get();
-
-            if ($duplicates->count() === 0) {
-                Schema::table('payment_events', function (Blueprint $table) {
-                    $table->unique(['provider', 'provider_event_id'], 'payment_events_provider_provider_event_id_unique');
-                });
-            }
+            Schema::table('payment_events', function (Blueprint $table) {
+                $table->unique(['provider', 'provider_event_id'], 'payment_events_provider_provider_event_id_unique');
+            });
         }
 
         if (!$this->indexExists('payment_events', 'payment_events_order_received_idx')

--- a/backend/database/migrations/2026_02_04_090000_add_idempotency_refunds_to_orders_benefit_grants.php
+++ b/backend/database/migrations/2026_02_04_090000_add_idempotency_refunds_to_orders_benefit_grants.php
@@ -28,19 +28,9 @@ return new class extends Migration
             if (!$this->indexExists('orders', 'orders_org_idempotency_key_unique')
                 && Schema::hasColumn('orders', 'org_id')
                 && Schema::hasColumn('orders', 'idempotency_key')) {
-                $duplicates = DB::table('orders')
-                    ->select('org_id', 'idempotency_key')
-                    ->whereNotNull('idempotency_key')
-                    ->where('idempotency_key', '!=', '')
-                    ->groupBy('org_id', 'idempotency_key')
-                    ->havingRaw('count(*) > 1')
-                    ->limit(1)
-                    ->get();
-                if ($duplicates->count() === 0) {
-                    Schema::table('orders', function (Blueprint $table) {
-                        $table->unique(['org_id', 'idempotency_key'], 'orders_org_idempotency_key_unique');
-                    });
-                }
+                Schema::table('orders', function (Blueprint $table) {
+                    $table->unique(['org_id', 'idempotency_key'], 'orders_org_idempotency_key_unique');
+                });
             }
         }
 

--- a/backend/database/migrations/2026_02_08_000001_add_provider_composite_unique_to_payment_events.php
+++ b/backend/database/migrations/2026_02_08_000001_add_provider_composite_unique_to_payment_events.php
@@ -3,7 +3,6 @@
 use App\Support\Database\SchemaIndex;
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
-use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Schema;
 
 return new class extends Migration
@@ -65,19 +64,9 @@ return new class extends Migration
         }
 
         if (!SchemaIndex::indexExists(self::TABLE, self::OLD_UNIQUE)) {
-            $hasCrossProviderDuplicates = DB::table(self::TABLE)
-                ->select('provider_event_id')
-                ->whereNotNull('provider_event_id')
-                ->groupBy('provider_event_id')
-                ->havingRaw('count(*) > 1')
-                ->limit(1)
-                ->exists();
-
-            if (!$hasCrossProviderDuplicates) {
-                Schema::table(self::TABLE, function (Blueprint $table) {
-                    $table->unique('provider_event_id', self::OLD_UNIQUE);
-                });
-            }
+            Schema::table(self::TABLE, function (Blueprint $table) {
+                $table->unique('provider_event_id', self::OLD_UNIQUE);
+            });
         }
     }
 };


### PR DESCRIPTION
## Summary
- sanitize hot-table related migrations to be schema-only (remove data backfills and duplicate-scan queries from migrations)
- keep deploy path `php artisan migrate` free of row updates/inserts for these migration paths
- add throttled, resumable org backfill ops entrypoint

## Changes
- removed migration-time data writes (`DB::table()->update(...)`) from:
  - `backend/database/migrations/2026_01_29_140000_create_report_snapshots_table.php`
  - `backend/database/migrations/2026_01_29_200030_create_benefit_wallets_table.php`
  - `backend/database/migrations/2026_01_29_200040_create_benefit_wallet_ledgers_table.php`
  - `backend/database/migrations/2026_01_29_200050_create_benefit_consumptions_table.php`
- removed migration-time duplicate detection scans (`groupBy/having/havingRaw`) from:
  - `backend/database/migrations/2026_01_29_140000_create_report_snapshots_table.php`
  - `backend/database/migrations/2026_01_29_200020_create_payment_events_table.php`
  - `backend/database/migrations/2026_01_29_200030_create_benefit_wallets_table.php`
  - `backend/database/migrations/2026_01_29_200040_create_benefit_wallet_ledgers_table.php`
  - `backend/database/migrations/2026_01_29_200050_create_benefit_consumptions_table.php`
  - `backend/database/migrations/2026_02_04_090000_add_idempotency_refunds_to_orders_benefit_grants.php`
  - `backend/database/migrations/2026_02_08_000001_add_provider_composite_unique_to_payment_events.php`
- upgraded `backend/app/Jobs/Ops/BackfillOrgIdJob.php`:
  - distributed lock: `Cache::lock("backfill:org_id:<table>", 300)`
  - resumable checkpoint with `migration_backfills`
  - numeric path uses `chunkById(...)`
  - throttling with `usleep(50000)`
  - progress logging and safe rerun behavior
  - supports optional `progressKey` and keeps `last_cursor` compatibility
- added command: `backend/app/Console/Commands/Ops/RunBackfillOrgId.php`
  - `php artisan ops:run-backfill-org-id ...`
  - supports `--sync` and queue dispatch modes

## Verification Run
- `php artisan route:list`
- `rg -n "DB::table\\(.*->update\\(|DB::table\\(.*->insert\\(|->groupBy\\(|->having\\(|havingRaw\\(" backend/database/migrations`
- `DB_CONNECTION=sqlite DB_DATABASE=/tmp/fap-zero-downtime.sqlite php artisan migrate --pretend`
- `DB_CONNECTION=sqlite DB_DATABASE=/tmp/fap-zero-downtime.sqlite php artisan migrate`
- `DB_CONNECTION=sqlite DB_DATABASE=/tmp/fap-zero-downtime-fresh.sqlite php artisan migrate:fresh`
- `DB_CONNECTION=sqlite DB_DATABASE=/tmp/fap-zero-downtime.sqlite php artisan list | rg "ops:run-backfill-org-id"`
- `DB_CONNECTION=sqlite DB_DATABASE=/tmp/fap-zero-downtime.sqlite php artisan ops:run-backfill-org-id benefit_wallets --id-column=id --org-id-column=org_id --batch-size=1000 --sync`
- `curl -i http://127.0.0.1:8000/api/v0.2/me/attempts` (401 expected without token)
- `curl -sS http://127.0.0.1:8000/api/v0.2/healthz`
- `bash backend/scripts/ci_verify_mbti.sh`

## Risk Notes
- migration unique/index creation now relies on runtime DDL behavior (no pre-scan). This keeps migrations deploy-safe and removes full-table scan/write risk in deploy path.
