### PR TITLE
perf(index): add idempotency provider-recorded-hash composite index

### DIFF
--- a/backend/database/migrations/2026_02_11_090100_add_idx_idempotency_keys_provider_recorded_hash.php
+++ b/backend/database/migrations/2026_02_11_090100_add_idx_idempotency_keys_provider_recorded_hash.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Support\Database\SchemaIndex;
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    private const TABLE = 'idempotency_keys';
+    private const INDEX = 'idx_idempo_provider_recorded_hash';
+
+    public function up(): void
+    {
+        if (!Schema::hasTable(self::TABLE)
+            || !Schema::hasColumn(self::TABLE, 'provider')
+            || !Schema::hasColumn(self::TABLE, 'recorded_at')
+            || !Schema::hasColumn(self::TABLE, 'hash')
+            || SchemaIndex::indexExists(self::TABLE, self::INDEX)) {
+            return;
+        }
+
+        Schema::table(self::TABLE, function (Blueprint $table): void {
+            $table->index(['provider', 'recorded_at', 'hash'], self::INDEX);
+        });
+    }
+
+    public function down(): void
+    {
+        if (!Schema::hasTable(self::TABLE) || !SchemaIndex::indexExists(self::TABLE, self::INDEX)) {
+            return;
+        }
+
+        Schema::table(self::TABLE, function (Blueprint $table): void {
+            $table->dropIndex(self::INDEX);
+        });
+    }
+};


### PR DESCRIPTION
## Summary
- add migration for index `idx_idempo_provider_recorded_hash` on `idempotency_keys(provider, recorded_at, hash)`
- keep business logic unchanged (OOM/whereDate/HTTP resilience checks remain compliant)

## Changed Files
- added: `/Users/rainie/Desktop/GitHub/fap-api/backend/database/migrations/2026_02_11_090100_add_idx_idempotency_keys_provider_recorded_hash.php`

## Verification
- `php artisan route:list`
- `php artisan migrate --pretend`
- `php artisan migrate`
- `php -l app/Http/Middleware/FmTokenAuth.php`
- `rg -- "->get\\(" app/Services/Ingestion/ReplayService.php` => 0 matches
- `rg "array_merge\\(" app/Services/Ingestion/ReplayService.php` => 0 matches
- `rg "whereDate\\(" app/Filament/Resources/AuditLogResource.php` => 0 matches
- `rg "Http::timeout\\(" app/Services/Content app/Services/VectorStore` => 0 matches
- `curl -sS "http://127.0.0.1:8000/api/v0.2/health"`
- `curl -sS "http://127.0.0.1:8000/api/v0.2/content-packs?region=CN_MAINLAND&locale=zh-CN"`
- `bash scripts/ci_verify_mbti.sh`
- `php artisan test`
