### PR TITLE
feat(v0.3): Pack D API compatibility bridge + business indexes

### DIFF
--- a/backend/app/Http/Controllers/API/V0_3/AttemptReadController.php
+++ b/backend/app/Http/Controllers/API/V0_3/AttemptReadController.php
@@ -39,6 +39,24 @@ class AttemptReadController extends Controller
             $payload = [];
         }
 
+        $compatTypeCode = (string) (($payload['type_code'] ?? null) ?? ($result->type_code ?? ''));
+
+        $compatScores = $result->scores_json;
+        if (!is_array($compatScores)) {
+            $compatScores = $payload['scores_json'] ?? $payload['scores'] ?? [];
+        }
+        if (!is_array($compatScores)) {
+            $compatScores = [];
+        }
+
+        $compatScoresPct = $result->scores_pct;
+        if (!is_array($compatScoresPct)) {
+            $compatScoresPct = $payload['scores_pct'] ?? ($payload['axis_scores_json']['scores_pct'] ?? null);
+        }
+        if (!is_array($compatScoresPct)) {
+            $compatScoresPct = [];
+        }
+
         $this->eventRecorder->recordFromRequest($request, 'result_view', $this->resolveUserId($request), [
             'scale_code' => (string) ($attempt->scale_code ?? ''),
             'pack_id' => (string) ($attempt->pack_id ?? ''),
@@ -50,6 +68,9 @@ class AttemptReadController extends Controller
         return response()->json([
             'ok' => true,
             'attempt_id' => (string) $attempt->id,
+            'type_code' => $compatTypeCode,
+            'scores' => $compatScores,
+            'scores_pct' => $compatScoresPct,
             'result' => $payload,
             'meta' => [
                 'scale_code' => (string) ($attempt->scale_code ?? ''),

--- a/backend/app/Http/Controllers/API/V0_3/AttemptWriteController.php
+++ b/backend/app/Http/Controllers/API/V0_3/AttemptWriteController.php
@@ -748,9 +748,30 @@ class AttemptWriteController extends Controller
             $payload = [];
         }
 
+        $compatTypeCode = (string) (($payload['type_code'] ?? null) ?? ($result->type_code ?? ''));
+
+        $compatScores = $result->scores_json;
+        if (!is_array($compatScores)) {
+            $compatScores = $payload['scores_json'] ?? $payload['scores'] ?? [];
+        }
+        if (!is_array($compatScores)) {
+            $compatScores = [];
+        }
+
+        $compatScoresPct = $result->scores_pct;
+        if (!is_array($compatScoresPct)) {
+            $compatScoresPct = $payload['scores_pct'] ?? ($payload['axis_scores_json']['scores_pct'] ?? null);
+        }
+        if (!is_array($compatScoresPct)) {
+            $compatScoresPct = [];
+        }
+
         return response()->json([
             'ok' => true,
             'attempt_id' => (string) $attempt->id,
+            'type_code' => $compatTypeCode,
+            'scores' => $compatScores,
+            'scores_pct' => $compatScoresPct,
             'result' => $payload,
             'meta' => [
                 'scale_code' => (string) ($attempt->scale_code ?? ''),

--- a/backend/database/migrations/2026_02_10_999999_add_business_indexes.php
+++ b/backend/database/migrations/2026_02_10_999999_add_business_indexes.php
@@ -1,0 +1,88 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Support\Database\SchemaIndex;
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    private const BENEFIT_GRANTS = 'benefit_grants';
+    private const PAYMENT_EVENTS = 'payment_events';
+
+    private const IDX_GRANT_USER = 'idx_benefit_grants_org_benefit_status_user';
+    private const IDX_GRANT_ATTEMPT = 'idx_benefit_grants_org_benefit_status_attempt';
+    private const IDX_PAYMENT = 'idx_payment_events_provider_status_received';
+    private const IDX_PAYMENT_EQUIV = 'idx_pay_status_time';
+
+    public function up(): void
+    {
+        if (Schema::hasTable(self::BENEFIT_GRANTS)
+            && Schema::hasColumn(self::BENEFIT_GRANTS, 'org_id')
+            && Schema::hasColumn(self::BENEFIT_GRANTS, 'benefit_code')
+            && Schema::hasColumn(self::BENEFIT_GRANTS, 'status')
+            && Schema::hasColumn(self::BENEFIT_GRANTS, 'user_id')
+            && !SchemaIndex::indexExists(self::BENEFIT_GRANTS, self::IDX_GRANT_USER)) {
+            Schema::table(self::BENEFIT_GRANTS, function (Blueprint $table): void {
+                $table->index(
+                    ['org_id', 'benefit_code', 'status', 'user_id'],
+                    self::IDX_GRANT_USER
+                );
+            });
+        }
+
+        if (Schema::hasTable(self::BENEFIT_GRANTS)
+            && Schema::hasColumn(self::BENEFIT_GRANTS, 'org_id')
+            && Schema::hasColumn(self::BENEFIT_GRANTS, 'benefit_code')
+            && Schema::hasColumn(self::BENEFIT_GRANTS, 'status')
+            && Schema::hasColumn(self::BENEFIT_GRANTS, 'attempt_id')
+            && !SchemaIndex::indexExists(self::BENEFIT_GRANTS, self::IDX_GRANT_ATTEMPT)) {
+            Schema::table(self::BENEFIT_GRANTS, function (Blueprint $table): void {
+                $table->index(
+                    ['org_id', 'benefit_code', 'status', 'attempt_id'],
+                    self::IDX_GRANT_ATTEMPT
+                );
+            });
+        }
+
+        if (Schema::hasTable(self::PAYMENT_EVENTS)
+            && Schema::hasColumn(self::PAYMENT_EVENTS, 'provider')
+            && Schema::hasColumn(self::PAYMENT_EVENTS, 'status')
+            && Schema::hasColumn(self::PAYMENT_EVENTS, 'received_at')
+            && !SchemaIndex::indexExists(self::PAYMENT_EVENTS, self::IDX_PAYMENT)
+            && !SchemaIndex::indexExists(self::PAYMENT_EVENTS, self::IDX_PAYMENT_EQUIV)) {
+            Schema::table(self::PAYMENT_EVENTS, function (Blueprint $table): void {
+                $table->index(
+                    ['provider', 'status', 'received_at'],
+                    self::IDX_PAYMENT
+                );
+            });
+        }
+    }
+
+    public function down(): void
+    {
+        if (Schema::hasTable(self::BENEFIT_GRANTS)
+            && SchemaIndex::indexExists(self::BENEFIT_GRANTS, self::IDX_GRANT_USER)) {
+            Schema::table(self::BENEFIT_GRANTS, function (Blueprint $table): void {
+                $table->dropIndex(self::IDX_GRANT_USER);
+            });
+        }
+
+        if (Schema::hasTable(self::BENEFIT_GRANTS)
+            && SchemaIndex::indexExists(self::BENEFIT_GRANTS, self::IDX_GRANT_ATTEMPT)) {
+            Schema::table(self::BENEFIT_GRANTS, function (Blueprint $table): void {
+                $table->dropIndex(self::IDX_GRANT_ATTEMPT);
+            });
+        }
+
+        if (Schema::hasTable(self::PAYMENT_EVENTS)
+            && SchemaIndex::indexExists(self::PAYMENT_EVENTS, self::IDX_PAYMENT)) {
+            Schema::table(self::PAYMENT_EVENTS, function (Blueprint $table): void {
+                $table->dropIndex(self::IDX_PAYMENT);
+            });
+        }
+    }
+};

--- a/backend/tests/Feature/V0_3/AttemptsStartSubmitTest.php
+++ b/backend/tests/Feature/V0_3/AttemptsStartSubmitTest.php
@@ -194,6 +194,16 @@ class AttemptsStartSubmitTest extends TestCase
             'computed_at' => now(),
         ]);
 
+        $resultResp = $this->withHeaders([
+            'X-Anon-Id' => 'anon_test',
+        ])->getJson("/api/v0.3/attempts/{$attemptId}/result");
+
+        $resultResp->assertStatus(200);
+        $resultResp->assertJsonPath('type_code', 'INTJ-A');
+        $this->assertIsArray($resultResp->json('scores'));
+        $this->assertSame(50, (int) $resultResp->json('scores_pct.EI'));
+        $this->assertSame('INTJ-A', (string) $resultResp->json('result.type_code'));
+
         $report = $this->withHeaders([
             'X-Anon-Id' => 'anon_test',
         ])->getJson("/api/v0.3/attempts/{$attemptId}/report");


### PR DESCRIPTION
## Summary
- add v0.2 compatibility top-level fields (`type_code`, `scores`, `scores_pct`) to v0.3 attempt result/read responses
- add schema-only migration for missing business indexes on `benefit_grants` and `payment_events`
- keep backward compatibility: no existing v0.3 field removed/renamed/type-changed

## Changes
- `/Users/rainie/Desktop/GitHub/fap-api/backend/app/Http/Controllers/API/V0_3/AttemptReadController.php`
  - add top-level mirrors for `type_code`, `scores`, `scores_pct` in `GET /api/v0.3/attempts/{id}/result`
- `/Users/rainie/Desktop/GitHub/fap-api/backend/app/Http/Controllers/API/V0_3/AttemptWriteController.php`
  - add top-level mirrors for `type_code`, `scores`, `scores_pct` in submit response
- `/Users/rainie/Desktop/GitHub/fap-api/backend/database/migrations/2026_02_10_999999_add_business_indexes.php`
  - add indexes:
    - `idx_benefit_grants_org_benefit_status_user`
    - `idx_benefit_grants_org_benefit_status_attempt`
    - `idx_payment_events_provider_status_received` (guarded; skipped if equivalent `idx_pay_status_time` exists)
- `/Users/rainie/Desktop/GitHub/fap-api/backend/tests/Feature/V0_3/AttemptsStartSubmitTest.php`
  - add assertions for v0.3 result top-level compatibility fields

## Validation
- `php artisan route:list --path=api/v0.3/attempts`
- `php artisan migrate --pretend`
- `php artisan migrate`
- `rg -n "fm_user_id|DB::table\('fm_tokens'\)" backend/app/Http/Middleware/FmTokenAuth.php`
- `php artisan test --filter=AttemptsStartSubmitTest`
- `bash backend/scripts/ci_verify_mbti.sh`
- `rg "whereDate\(" backend/app/Http/Controllers/API/V0_3/AttemptsController.php`
- `rg "dropIfExists" backend/database/migrations`

## Risk / Rollback
- migration is schema-only (no data backfill/update)
- payment index creation is idempotent and avoids duplicate equivalent index
- optional rollback hardening (`dropIfExists` sanitization) intentionally deferred to next small loop
