### PR TITLE
feat(seo-audit): isolate sitemap and audit logs by org

### DIFF
--- a/backend/app/Filament/Resources/AuditLogResource.php
+++ b/backend/app/Filament/Resources/AuditLogResource.php
@@ -4,6 +4,7 @@ namespace App\Filament\Resources;
 
 use App\Filament\Resources\AuditLogResource\Pages;
 use App\Models\AuditLog;
+use App\Support\OrgContext;
 use Filament\Forms;
 use Filament\Forms\Form;
 use Filament\Resources\Resource;
@@ -20,9 +21,14 @@ class AuditLogResource extends Resource
     protected static ?string $navigationGroup = 'Observability';
     protected static ?string $navigationLabel = 'Audit Logs';
 
+    private static function orgContext(): OrgContext
+    {
+        return app(OrgContext::class);
+    }
+
     private static function orgId(): int
     {
-        return (int) app(\App\Support\OrgContext::class)->orgId();
+        return (int) self::orgContext()->orgId();
     }
 
     private static function scopedQuery(): Builder

--- a/backend/app/Http/Middleware/FmTokenAuth.php
+++ b/backend/app/Http/Middleware/FmTokenAuth.php
@@ -112,7 +112,13 @@ class FmTokenAuth
 
         $orgId = $this->resolveOrgId($row);
         if ($orgId === null) {
-            $headerOrgId = trim((string) $request->header('X-Org-Id', ''));
+            $headerOrgId = trim((string) $request->header('X-FM-Org-Id', ''));
+            if ($headerOrgId === '') {
+                $headerOrgId = trim((string) $request->header('X-Org-Id', ''));
+            }
+            if ($headerOrgId === '') {
+                $headerOrgId = trim((string) $request->query('org_id', ''));
+            }
             if ($headerOrgId !== '' && preg_match('/^\d+$/', $headerOrgId)) {
                 $orgId = (int) $headerOrgId;
             }

--- a/backend/app/Models/AuditLog.php
+++ b/backend/app/Models/AuditLog.php
@@ -11,6 +11,7 @@ class AuditLog extends Model
     public $timestamps = false;
 
     protected $fillable = [
+        'org_id',
         'actor_admin_id',
         'action',
         'target_type',
@@ -23,6 +24,7 @@ class AuditLog extends Model
     ];
 
     protected $casts = [
+        'org_id' => 'integer',
         'meta_json' => 'array',
         'created_at' => 'datetime',
     ];

--- a/backend/app/Providers/Filament/AdminPanelProvider.php
+++ b/backend/app/Providers/Filament/AdminPanelProvider.php
@@ -19,6 +19,7 @@ use Illuminate\Session\Middleware\StartSession;
 use Illuminate\View\Middleware\ShareErrorsFromSession;
 use Illuminate\Routing\Middleware\SubstituteBindings;
 use App\Http\Middleware\VerifyCsrfToken;
+use App\Http\Middleware\ResolveOrgContext;
 
 class AdminPanelProvider extends PanelProvider
 {
@@ -49,6 +50,7 @@ class AdminPanelProvider extends PanelProvider
                 ShareErrorsFromSession::class,
                 VerifyCsrfToken::class,
                 SubstituteBindings::class,
+                ResolveOrgContext::class,
             ])
             ->authMiddleware([
                 Authenticate::class,

--- a/backend/app/Services/Audit/AuditLogger.php
+++ b/backend/app/Services/Audit/AuditLogger.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Services\Audit;
 
 use App\Models\AuditLog;
+use App\Support\OrgContext;
 use App\Support\SensitiveDataRedactor;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Log;
@@ -60,7 +61,16 @@ class AuditLogger
             $meta['actor'] = $meta['actor'] ?? 'admin_token';
         }
 
+        $orgId = (int) app(OrgContext::class)->orgId();
+        if ($orgId <= 0) {
+            $rawOrgId = $request->attributes->get('org_id', $request->attributes->get('fm_org_id', 0));
+            if (is_numeric($rawOrgId)) {
+                $orgId = max(0, (int) $rawOrgId);
+            }
+        }
+
         AuditLog::create([
+            'org_id' => $orgId,
             'actor_admin_id' => $actorAdminId,
             'action' => $action,
             'target_type' => $targetType,

--- a/backend/app/Services/SEO/SitemapGenerator.php
+++ b/backend/app/Services/SEO/SitemapGenerator.php
@@ -14,6 +14,8 @@ class SitemapGenerator
         $rows = DB::table('scales_registry')
             ->select('primary_slug', 'slugs_json', 'updated_at')
             ->where('is_active', 1)
+            ->where('is_public', 1)
+            ->where('org_id', 0)
             ->get();
 
         $slugDates = [];

--- a/backend/database/migrations/2026_02_11_100200_add_org_id_to_audit_logs_table.php
+++ b/backend/database/migrations/2026_02_11_100200_add_org_id_to_audit_logs_table.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Support\Database\SchemaIndex;
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    private const TABLE = 'audit_logs';
+    private const INDEX = 'audit_logs_org_id_index';
+
+    public function up(): void
+    {
+        if (!Schema::hasTable(self::TABLE) || Schema::hasColumn(self::TABLE, 'org_id')) {
+            return;
+        }
+
+        Schema::table(self::TABLE, function (Blueprint $table): void {
+            $table->unsignedBigInteger('org_id')->default(0)->index();
+        });
+    }
+
+    public function down(): void
+    {
+        if (!Schema::hasTable(self::TABLE) || !Schema::hasColumn(self::TABLE, 'org_id')) {
+            return;
+        }
+
+        if (SchemaIndex::indexExists(self::TABLE, self::INDEX)) {
+            Schema::table(self::TABLE, function (Blueprint $table): void {
+                $table->dropIndex(self::INDEX);
+            });
+        }
+
+        Schema::table(self::TABLE, function (Blueprint $table): void {
+            $table->dropColumn('org_id');
+        });
+    }
+};

--- a/backend/routes/api.php
+++ b/backend/routes/api.php
@@ -39,6 +39,7 @@ use App\Http\Controllers\API\V0_3\Webhooks\PaymentWebhookController;
 use App\Http\Controllers\API\V0_4\BootController;
 use App\Http\Controllers\API\V0_4\AssessmentController;
 use App\Http\Middleware\LimitWebhookPayloadSize;
+use App\Http\Middleware\ResolveOrgContext;
 use App\Http\Controllers\Integrations\ProvidersController;
 use App\Http\Controllers\Webhooks\HandleProviderWebhook;
 
@@ -249,7 +250,7 @@ Route::prefix("v0.3")->middleware([
         ->middleware([LimitWebhookPayloadSize::class, 'throttle:api_webhook'])
         ->name('v0.3.webhooks.payment');
 
-    Route::middleware(\App\Http\Middleware\ResolveOrgContext::class)->group(function () {
+    Route::middleware(ResolveOrgContext::class)->group(function () {
         // 0) Boot (flags + experiments)
         Route::get("/boot", [BootV0_3Controller::class, "show"]);
         Route::get("/flags", [BootV0_3Controller::class, "flags"]);
@@ -283,7 +284,7 @@ Route::prefix("v0.3")->middleware([
         Route::get("/orders/{order_no}", "App\\Http\\Controllers\\API\\V0_3\\CommerceController@getOrder");
     });
 
-    Route::middleware([\App\Http\Middleware\FmTokenAuth::class, \App\Http\Middleware\ResolveOrgContext::class])
+    Route::middleware([\App\Http\Middleware\FmTokenAuth::class, ResolveOrgContext::class])
         ->group(function () {
             Route::post("/orgs", [OrgsController::class, "store"]);
             Route::get("/orgs/me", [OrgsController::class, "me"]);

--- a/backend/tests/Feature/Admin/AuditLogOrgScopeTest.php
+++ b/backend/tests/Feature/Admin/AuditLogOrgScopeTest.php
@@ -1,0 +1,88 @@
+<?php
+
+namespace Tests\Feature\Admin;
+
+use App\Filament\Resources\AuditLogResource;
+use App\Support\OrgContext;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\DB;
+use Tests\TestCase;
+
+class AuditLogOrgScopeTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_get_eloquent_query_only_returns_current_org_id(): void
+    {
+        $this->insertAuditLogs();
+
+        $context = app(OrgContext::class);
+        $context->set(1, null, 'admin');
+        app()->instance(OrgContext::class, $context);
+
+        $rows = AuditLogResource::getEloquentQuery()
+            ->orderBy('id')
+            ->get(['id', 'org_id'])
+            ->toArray();
+
+        $this->assertCount(1, $rows);
+        $this->assertSame(1, (int) ($rows[0]['org_id'] ?? -1));
+    }
+
+    public function test_get_eloquent_query_defaults_to_org_zero(): void
+    {
+        $this->insertAuditLogs();
+
+        $rows = AuditLogResource::getEloquentQuery()
+            ->orderBy('id')
+            ->get(['id', 'org_id'])
+            ->toArray();
+
+        $this->assertCount(1, $rows);
+        $this->assertSame(0, (int) ($rows[0]['org_id'] ?? -1));
+    }
+
+    private function insertAuditLogs(): void
+    {
+        $now = now();
+
+        DB::table('audit_logs')->insert([
+            [
+                'org_id' => 0,
+                'actor_admin_id' => null,
+                'action' => 'seed_org_0',
+                'target_type' => null,
+                'target_id' => null,
+                'meta_json' => json_encode(['case' => 'org0']),
+                'ip' => '127.0.0.1',
+                'user_agent' => 'phpunit',
+                'request_id' => 'req-org-0',
+                'created_at' => $now,
+            ],
+            [
+                'org_id' => 1,
+                'actor_admin_id' => null,
+                'action' => 'seed_org_1',
+                'target_type' => null,
+                'target_id' => null,
+                'meta_json' => json_encode(['case' => 'org1']),
+                'ip' => '127.0.0.1',
+                'user_agent' => 'phpunit',
+                'request_id' => 'req-org-1',
+                'created_at' => $now,
+            ],
+            [
+                'org_id' => 2,
+                'actor_admin_id' => null,
+                'action' => 'seed_org_2',
+                'target_type' => null,
+                'target_id' => null,
+                'meta_json' => json_encode(['case' => 'org2']),
+                'ip' => '127.0.0.1',
+                'user_agent' => 'phpunit',
+                'request_id' => 'req-org-2',
+                'created_at' => $now,
+            ],
+        ]);
+    }
+}

--- a/backend/tests/Feature/SEO/SitemapGeneratorTest.php
+++ b/backend/tests/Feature/SEO/SitemapGeneratorTest.php
@@ -1,0 +1,93 @@
+<?php
+
+namespace Tests\Feature\SEO;
+
+use App\Services\SEO\SitemapGenerator;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\DB;
+use Tests\TestCase;
+
+class SitemapGeneratorTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_generate_only_includes_public_global_scales(): void
+    {
+        $now = now();
+
+        DB::table('scales_registry')->insert([
+            [
+                'code' => 'P0_PUBLIC_GLOBAL',
+                'org_id' => 0,
+                'primary_slug' => 'public-global',
+                'slugs_json' => json_encode(['public-global-alt']),
+                'driver_type' => 'MBTI',
+                'default_pack_id' => null,
+                'default_region' => null,
+                'default_locale' => null,
+                'default_dir_version' => null,
+                'capabilities_json' => null,
+                'view_policy_json' => null,
+                'commercial_json' => null,
+                'seo_schema_json' => null,
+                'is_public' => 1,
+                'is_active' => 1,
+                'created_at' => $now,
+                'updated_at' => $now,
+            ],
+            [
+                'code' => 'P0_PRIVATE_GLOBAL',
+                'org_id' => 0,
+                'primary_slug' => 'private-global',
+                'slugs_json' => json_encode(['private-global-alt']),
+                'driver_type' => 'MBTI',
+                'default_pack_id' => null,
+                'default_region' => null,
+                'default_locale' => null,
+                'default_dir_version' => null,
+                'capabilities_json' => null,
+                'view_policy_json' => null,
+                'commercial_json' => null,
+                'seo_schema_json' => null,
+                'is_public' => 0,
+                'is_active' => 1,
+                'created_at' => $now,
+                'updated_at' => $now,
+            ],
+            [
+                'code' => 'P0_PUBLIC_TENANT',
+                'org_id' => 9,
+                'primary_slug' => 'tenant-public',
+                'slugs_json' => json_encode(['tenant-public-alt']),
+                'driver_type' => 'MBTI',
+                'default_pack_id' => null,
+                'default_region' => null,
+                'default_locale' => null,
+                'default_dir_version' => null,
+                'capabilities_json' => null,
+                'view_policy_json' => null,
+                'commercial_json' => null,
+                'seo_schema_json' => null,
+                'is_public' => 1,
+                'is_active' => 1,
+                'created_at' => $now,
+                'updated_at' => $now,
+            ],
+        ]);
+
+        $payload = app(SitemapGenerator::class)->generate();
+
+        $slugList = (array) ($payload['slug_list'] ?? []);
+        sort($slugList, SORT_STRING);
+
+        $this->assertSame(['public-global', 'public-global-alt'], $slugList);
+
+        $xml = (string) ($payload['xml'] ?? '');
+        $this->assertStringContainsString('https://fermatmind.com/tests/public-global', $xml);
+        $this->assertStringContainsString('https://fermatmind.com/tests/public-global-alt', $xml);
+        $this->assertStringNotContainsString('https://fermatmind.com/tests/private-global', $xml);
+        $this->assertStringNotContainsString('https://fermatmind.com/tests/private-global-alt', $xml);
+        $this->assertStringNotContainsString('https://fermatmind.com/tests/tenant-public', $xml);
+        $this->assertStringNotContainsString('https://fermatmind.com/tests/tenant-public-alt', $xml);
+    }
+}


### PR DESCRIPTION
## Summary
This PR delivers P0 tenant-isolation fixes for SEO sitemap and admin audit logs.

## Changes
1. Sitemap public-only output
- Update `/Users/rainie/Desktop/GitHub/fap-api/backend/app/Services/SEO/SitemapGenerator.php`
- Query now enforces:
  - `where('is_public', 1)`
  - `where('org_id', 0)`
  - (keeps existing `where('is_active', 1)`)

2. audit_logs org isolation
- Add migration:
  - `/Users/rainie/Desktop/GitHub/fap-api/backend/database/migrations/2026_02_11_100200_add_org_id_to_audit_logs_table.php`
  - `up()`: add `org_id` (`unsignedBigInteger`, default `0`) with index
  - `down()`: only drop index + column, no table drop
- Update model:
  - `/Users/rainie/Desktop/GitHub/fap-api/backend/app/Models/AuditLog.php`
  - add `org_id` into `fillable` and cast
- Update writer:
  - `/Users/rainie/Desktop/GitHub/fap-api/backend/app/Services/Audit/AuditLogger.php`
  - write `org_id` from `OrgContext` (fallback request attrs)

3. Filament audit query hard-scope
- `/Users/rainie/Desktop/GitHub/fap-api/backend/app/Filament/Resources/AuditLogResource.php`
- list/filter/export all use `AuditLog::query()->where('org_id', $context->orgId())`
- no cross-tenant query path

4. Ensure admin OrgContext availability
- `/Users/rainie/Desktop/GitHub/fap-api/backend/app/Providers/Filament/AdminPanelProvider.php`
- add `ResolveOrgContext::class` into panel middleware
- `/Users/rainie/Desktop/GitHub/fap-api/backend/app/Http/Middleware/ResolveOrgContext.php`
  - support `X-FM-Org-Id` / `X-Org-Id` / `query org_id`
  - default `org_id=0`
  - admin guard authenticated path can resolve org context without org-member check

5. Token middleware org header compatibility
- `/Users/rainie/Desktop/GitHub/fap-api/backend/app/Http/Middleware/FmTokenAuth.php`
- add org resolution fallback from `X-FM-Org-Id` and `query org_id`

6. Tests
- add `/Users/rainie/Desktop/GitHub/fap-api/backend/tests/Feature/SEO/SitemapGeneratorTest.php`
- add `/Users/rainie/Desktop/GitHub/fap-api/backend/tests/Feature/Admin/AuditLogOrgScopeTest.php`

## Verification
```bash
cd backend
php artisan route:list
php artisan migrate --force
php artisan migrate:rollback --step=1 --force
php artisan migrate --force
php artisan test --filter SitemapGeneratorTest
php artisan test --filter AuditLogOrgScopeTest
bash scripts/ci_verify_mbti.sh
echo PASS_PR3
