### PR TITLE
feat(api): unify error contract and surface content pack failures

### DIFF
--- a/backend/app/Http/Controllers/API/V0_2/ShareController.php
+++ b/backend/app/Http/Controllers/API/V0_2/ShareController.php
@@ -9,6 +9,7 @@ use App\Support\OrgContext;
 use Illuminate\Http\Request;
 use Illuminate\Support\Carbon;
 use Illuminate\Support\Str;
+use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Facades\Validator;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 
@@ -252,7 +253,16 @@ $event->anon_id = ($clickAnonId !== null && $clickAnonId !== '') ? $clickAnonId 
                 }
             }
         } catch (\Throwable $e) {
-            $report = null;
+            Log::error('[share] report compose failed', [
+                'share_id' => $shareId,
+                'attempt_id' => $attemptId,
+                'type_code' => $typeCode,
+                'engine' => $engine,
+                'content_package_version' => $packV,
+                'exception' => get_class($e),
+                'message' => $e->getMessage(),
+            ]);
+            throw $e;
         }
 
         if (!is_array($report)) $report = [];

--- a/backend/app/Support/ApiExceptionRenderer.php
+++ b/backend/app/Support/ApiExceptionRenderer.php
@@ -64,6 +64,24 @@ final class ApiExceptionRenderer
             );
         }
 
+        if ($e instanceof \RuntimeException && trim($e->getMessage()) === 'CONTENT_PACK_ERROR') {
+            $reason = trim((string) ($e->getPrevious()?->getMessage() ?? ''));
+            $payload = [
+                'ok' => false,
+                'error' => 'CONTENT_PACK_ERROR',
+                'error_code' => 'CONTENT_PACK_ERROR',
+                'message' => 'content pack resolve failed.',
+            ];
+            if ($reason !== '') {
+                $payload['details'] = ['reason' => $reason];
+            }
+
+            return response()->json(
+                self::withRequestId($payload, $requestId),
+                500
+            );
+        }
+
         if ($e instanceof HttpExceptionInterface) {
             $status = $e->getStatusCode();
             $errorCode = self::mapHttpExceptionErrorCode($status);
@@ -102,6 +120,7 @@ final class ApiExceptionRenderer
             403 => 'FORBIDDEN',
             404 => 'NOT_FOUND',
             429 => 'TOO_MANY_REQUESTS',
+            500 => 'SERVER_ERROR',
             default => 'HTTP_ERROR',
         };
     }

--- a/backend/tests/Feature/Api/ValidationErrorContractTest.php
+++ b/backend/tests/Feature/Api/ValidationErrorContractTest.php
@@ -1,0 +1,65 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Api;
+
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Route;
+use Tests\TestCase;
+
+final class ValidationErrorContractTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_form_request_validation_returns_unified_json_contract_without_accept_header(): void
+    {
+        $response = $this->post('/api/v0.3/attempts/start', []);
+
+        $response->assertStatus(422);
+        $this->assertStringContainsString(
+            'application/json',
+            strtolower((string) $response->headers->get('Content-Type', ''))
+        );
+        $response->assertJsonPath('error_code', 'VALIDATION_FAILED');
+        $response->assertJsonPath('message', 'The given data was invalid.');
+
+        $details = $response->json('details.scale_code');
+        $this->assertIsArray($details);
+        $this->assertNotEmpty($details);
+    }
+
+    public function test_abort_401_403_404_500_all_return_json_under_api_path(): void
+    {
+        Route::middleware('api')->get('/api/v0.3/__contract_abort_401', static function (): void {
+            abort(401, 'unauth');
+        });
+        Route::middleware('api')->get('/api/v0.3/__contract_abort_403', static function (): void {
+            abort(403, 'forbidden');
+        });
+        Route::middleware('api')->get('/api/v0.3/__contract_abort_404', static function (): void {
+            abort(404, 'missing');
+        });
+        Route::middleware('api')->get('/api/v0.3/__contract_abort_500', static function (): void {
+            abort(500, 'boom');
+        });
+
+        $cases = [
+            ['/api/v0.3/__contract_abort_401', 401, 'UNAUTHENTICATED'],
+            ['/api/v0.3/__contract_abort_403', 403, 'FORBIDDEN'],
+            ['/api/v0.3/__contract_abort_404', 404, 'NOT_FOUND'],
+            ['/api/v0.3/__contract_abort_500', 500, 'SERVER_ERROR'],
+        ];
+
+        foreach ($cases as [$uri, $status, $errorCode]) {
+            $response = $this->get((string) $uri);
+
+            $response->assertStatus((int) $status);
+            $this->assertStringContainsString(
+                'application/json',
+                strtolower((string) $response->headers->get('Content-Type', ''))
+            );
+            $response->assertJsonPath('error_code', (string) $errorCode);
+        }
+    }
+}

--- a/backend/tests/Feature/V0_3/AttemptContentPackErrorTest.php
+++ b/backend/tests/Feature/V0_3/AttemptContentPackErrorTest.php
@@ -1,0 +1,60 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\V0_3;
+
+use App\Models\ScaleRegistry;
+use Database\Seeders\ScaleRegistrySeeder;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Facades\Log;
+use Tests\TestCase;
+
+final class AttemptContentPackErrorTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_attempt_start_returns_500_with_content_pack_error_code_when_pack_resolution_fails(): void
+    {
+        (new ScaleRegistrySeeder())->run();
+
+        $brokenPackId = 'PACK_DOES_NOT_EXIST';
+        $brokenDirVersion = 'DIR_VERSION_DOES_NOT_EXIST';
+
+        ScaleRegistry::query()
+            ->where('org_id', 0)
+            ->where('code', 'MBTI')
+            ->update([
+                'default_pack_id' => $brokenPackId,
+                'default_dir_version' => $brokenDirVersion,
+            ]);
+
+        Cache::flush();
+        Log::spy();
+
+        $response = $this->postJson('/api/v0.3/attempts/start', [
+            'scale_code' => 'MBTI',
+        ]);
+
+        $response->assertStatus(500);
+        $response->assertJsonPath('error_code', 'CONTENT_PACK_ERROR');
+
+        Log::shouldHaveReceived('error')
+            ->atLeast()
+            ->once()
+            ->withArgs(function ($message, $context) use ($brokenPackId, $brokenDirVersion): bool {
+                $this->assertIsString($message);
+                $this->assertIsArray($context);
+                if (!str_starts_with($message, 'QUESTIONS_')) {
+                    return false;
+                }
+                $this->assertSame($brokenPackId, $context['pack_id'] ?? null);
+                $this->assertSame($brokenDirVersion, $context['dir_version'] ?? null);
+                $this->assertArrayHasKey('questions_path', $context);
+                $this->assertNotSame('', (string) ($context['exception_message'] ?? ''));
+
+                return true;
+            });
+    }
+}


### PR DESCRIPTION
## Summary
This PR implements PR4 to unify API error contracts and stop swallowing content/report failures.

### What changed
1. `ApiExceptionRenderer` now:
- keeps unified `ValidationException` JSON format with `error_code/message/details`
- maps `abort(500, ...)` under `/api/*` to `error_code=SERVER_ERROR`
- handles content-pack runtime failures via `CONTENT_PACK_ERROR` contract

2. `AttemptWriteController::resolveQuestionCount` now:
- never returns a nullable fallback path
- logs `Log::error` with `pack_id/dir_version/questions_path/exception_message`
- throws `RuntimeException('CONTENT_PACK_ERROR')` to let unified renderer handle response

3. `ShareController::click` report compose now:
- no longer swallows exceptions
- logs `[share] report compose failed`
- rethrows to unified exception renderer

4. Added tests:
- `ValidationErrorContractTest`
- `AttemptContentPackErrorTest`

## Contract impact
- `/api/*` abort 401/403/404/500 all return JSON (no HTML)
- validation errors stay in one JSON shape:
  - `error_code=VALIDATION_FAILED`
  - `message=The given data was invalid.`
  - `details={...}`
- content-pack resolution failures in `/api/v0.3/attempts/start` return:
  - `status=500`
  - `error_code=CONTENT_PACK_ERROR`

## Verification
Executed:
- `php artisan route:list | rg "api/v0.3/attempts/start|api/v0.3/attempts/submit|api/v0.2/shares/{shareId}/click|api/v0.2/share/{id}"`
- `php artisan migrate`
- `php artisan test --filter MeAttemptsAuthContractTest`
- `php artisan test --filter ValidationErrorContractTest`
- `php artisan test --filter AttemptContentPackErrorTest`
- `php artisan test --filter ApiExceptionRendererTest`
- `bash backend/scripts/ci_verify_mbti.sh`
- `echo PASS_PR4`
