### PR TITLE
feat(integrations): harden v0.2 ingest auth and payload limits

### DIFF
--- a/backend/app/Http/Middleware/IntegrationsIngestAuth.php
+++ b/backend/app/Http/Middleware/IntegrationsIngestAuth.php
@@ -1,0 +1,238 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Middleware;
+
+use Closure;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+use Symfony\Component\HttpFoundation\Response;
+
+final class IntegrationsIngestAuth
+{
+    public function handle(Request $request, Closure $next): Response
+    {
+        $provider = strtolower(trim((string) $request->route('provider', '')));
+        if (! $this->isAllowedProvider($provider)) {
+            return $this->unauthorized('unsupported_provider');
+        }
+
+        if ($this->hasBearerAuthorization($request)) {
+            return $this->handleBearer($request, $next);
+        }
+
+        return $this->handleSignedWebhook($request, $next, $provider);
+    }
+
+    private function hasBearerAuthorization(Request $request): bool
+    {
+        $header = (string) $request->header('Authorization', '');
+
+        return preg_match('/^\s*Bearer\s+.+\s*$/i', $header) === 1;
+    }
+
+    private function handleBearer(Request $request, Closure $next): Response
+    {
+        $passed = false;
+
+        $response = app(FmTokenAuth::class)->handle(
+            $request,
+            function (Request $authedRequest) use (&$passed, $next): Response {
+                $passed = true;
+
+                $userId = $this->resolveRequestUserId($authedRequest);
+                if ($userId === null) {
+                    return $this->unauthorized('token_identity_missing');
+                }
+
+                $authedRequest->attributes->set('fm_user_id', $userId);
+                $authedRequest->attributes->set('user_id', $userId);
+                $authedRequest->attributes->set('integration_auth_mode', 'sanctum');
+                $authedRequest->attributes->set('integration_signature_ok', false);
+                $authedRequest->attributes->set('integration_actor_user_id', (int) $userId);
+
+                return $next($authedRequest);
+            }
+        );
+
+        if (! $passed) {
+            return $this->unauthorized('token_missing_or_invalid');
+        }
+
+        return $response;
+    }
+
+    private function handleSignedWebhook(Request $request, Closure $next, string $provider): Response
+    {
+        $timestamp = $this->extractTimestamp($request);
+        $signature = strtolower(trim((string) $request->header('X-Webhook-Signature', '')));
+        $eventId = trim((string) $request->header('X-Webhook-Event-Id', ''));
+
+        if ($timestamp === null || $signature === '' || $eventId === '') {
+            return $this->unauthorized('missing_signature_headers');
+        }
+        if (preg_match('/^[a-f0-9]{64}$/', $signature) !== 1) {
+            return $this->unauthorized('invalid_signature_format');
+        }
+
+        $tolerance = $this->resolveWebhookTolerance($provider);
+        if (abs(time() - $timestamp) > $tolerance) {
+            return $this->unauthorized('timestamp_out_of_tolerance');
+        }
+
+        $secret = trim((string) config("services.integrations.providers.{$provider}.webhook_secret", ''));
+        if ($secret === '') {
+            return $this->unauthorized('webhook_secret_missing');
+        }
+
+        $rawBody = (string) $request->getContent();
+        $expected = hash_hmac('sha256', "{$timestamp}.{$rawBody}", $secret);
+        if (! hash_equals($expected, $signature)) {
+            return $this->unauthorized('invalid_signature');
+        }
+
+        $externalUserId = trim((string) data_get($request->all(), 'external_user_id', ''));
+        if ($externalUserId === '') {
+            return $this->unauthorized('unauthorized_identity_mapping');
+        }
+
+        if (! Schema::hasTable('integrations')) {
+            return $this->unauthorized('unauthorized_identity_mapping');
+        }
+
+        $resolved = DB::transaction(function () use ($provider, $externalUserId, $eventId, $timestamp): array {
+            $row = DB::table('integrations')
+                ->where('provider', $provider)
+                ->where('external_user_id', $externalUserId)
+                ->lockForUpdate()
+                ->first();
+
+            if (! $row || ! is_numeric($row->user_id ?? null)) {
+                return ['ok' => false, 'reason' => 'unauthorized_identity_mapping'];
+            }
+
+            $lastEventId = trim((string) ($row->webhook_last_event_id ?? ''));
+            if ($lastEventId !== '' && hash_equals($lastEventId, $eventId)) {
+                return ['ok' => false, 'reason' => 'replay_detected'];
+            }
+
+            $lastTimestamp = is_numeric($row->webhook_last_timestamp ?? null)
+                ? (int) $row->webhook_last_timestamp
+                : null;
+            if ($lastTimestamp !== null && $timestamp <= $lastTimestamp) {
+                return ['ok' => false, 'reason' => 'replay_detected'];
+            }
+
+            $updates = [];
+            if (Schema::hasColumn('integrations', 'webhook_last_event_id')) {
+                $updates['webhook_last_event_id'] = $eventId;
+            }
+            if (Schema::hasColumn('integrations', 'webhook_last_timestamp')) {
+                $updates['webhook_last_timestamp'] = $timestamp;
+            }
+            if (Schema::hasColumn('integrations', 'webhook_last_received_at')) {
+                $updates['webhook_last_received_at'] = now();
+            }
+            if (Schema::hasColumn('integrations', 'updated_at')) {
+                $updates['updated_at'] = now();
+            }
+
+            if ($updates !== []) {
+                DB::table('integrations')
+                    ->where('provider', $provider)
+                    ->where('external_user_id', $externalUserId)
+                    ->update($updates);
+            }
+
+            return ['ok' => true, 'user_id' => (string) ((int) $row->user_id)];
+        });
+
+        if (! (bool) ($resolved['ok'] ?? false)) {
+            return $this->unauthorized((string) ($resolved['reason'] ?? 'unauthorized_identity_mapping'));
+        }
+
+        $userId = (string) ($resolved['user_id'] ?? '');
+        if ($userId === '') {
+            return $this->unauthorized('unauthorized_identity_mapping');
+        }
+
+        $request->attributes->set('fm_user_id', $userId);
+        $request->attributes->set('user_id', $userId);
+        $request->attributes->set('integration_auth_mode', 'signature');
+        $request->attributes->set('integration_signature_ok', true);
+        $request->attributes->set('integration_actor_user_id', null);
+
+        return $next($request);
+    }
+
+    private function resolveRequestUserId(Request $request): ?string
+    {
+        foreach (['fm_user_id', 'user_id'] as $key) {
+            $raw = trim((string) $request->attributes->get($key, ''));
+            if ($raw !== '' && preg_match('/^\d+$/', $raw) === 1) {
+                return $raw;
+            }
+        }
+
+        return null;
+    }
+
+    private function resolveWebhookTolerance(string $provider): int
+    {
+        $global = (int) config('services.integrations.webhook_tolerance_seconds', 300);
+        if ($global <= 0) {
+            $global = 300;
+        }
+
+        $providerTolerance = (int) config(
+            "services.integrations.providers.{$provider}.webhook_tolerance_seconds",
+            $global
+        );
+
+        return $providerTolerance > 0 ? $providerTolerance : $global;
+    }
+
+    private function extractTimestamp(Request $request): ?int
+    {
+        $raw = trim((string) $request->header('X-Webhook-Timestamp', ''));
+        if ($raw === '' || preg_match('/^\d{10,13}$/', $raw) !== 1) {
+            return null;
+        }
+
+        $timestamp = (int) $raw;
+        if (strlen($raw) === 13) {
+            $timestamp = (int) floor($timestamp / 1000);
+        }
+
+        return $timestamp > 0 ? $timestamp : null;
+    }
+
+    private function isAllowedProvider(string $provider): bool
+    {
+        $allowed = (array) config('integrations.allowed_providers', [
+            'mock',
+            'apple_health',
+            'google_fit',
+            'calendar',
+            'screen_time',
+        ]);
+
+        $allowed = array_values(array_filter(array_map(
+            static fn ($v) => strtolower(trim((string) $v)),
+            $allowed
+        )));
+
+        return $provider !== '' && in_array($provider, $allowed, true);
+    }
+
+    private function unauthorized(string $message): Response
+    {
+        return response()->json([
+            'ok' => false,
+            'error' => 'UNAUTHORIZED',
+            'message' => $message,
+        ], 401);
+    }
+}

--- a/backend/routes/api.php
+++ b/backend/routes/api.php
@@ -165,7 +165,7 @@ Route::prefix("v0.2")->middleware([
             Route::get("/oauth/callback", [ProvidersController::class, "oauthCallback"]);
             Route::post("/revoke", [ProvidersController::class, "revoke"]);
             Route::post("/ingest", [ProvidersController::class, "ingest"])
-                ->middleware(\App\Http\Middleware\VerifyIntegrationSignature::class);
+                ->middleware(\App\Http\Middleware\IntegrationsIngestAuth::class);
             Route::post("/replay/{batch_id}", [ProvidersController::class, "replay"]);
         });
 

--- a/backend/tests/Feature/Integrations/IngestValidationTest.php
+++ b/backend/tests/Feature/Integrations/IngestValidationTest.php
@@ -1,0 +1,126 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Integrations;
+
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Str;
+use Tests\TestCase;
+
+final class IngestValidationTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_ingest_rejects_samples_count_above_100(): void
+    {
+        $token = $this->issueToken(1001);
+        $samples = [];
+        for ($i = 0; $i < 101; $i++) {
+            $samples[] = [
+                'domain' => 'sleep',
+                'recorded_at' => '2026-02-10T00:00:00Z',
+                'value' => ['duration_minutes' => 420 + $i],
+            ];
+        }
+
+        $response = $this->withHeaders([
+            'Authorization' => "Bearer {$token}",
+        ])->postJson('/api/v0.2/integrations/mock/ingest', [
+            'samples' => $samples,
+        ]);
+
+        $response->assertStatus(422)->assertJson([
+            'ok' => false,
+            'error' => 'validation_failed',
+        ]);
+        $this->assertSame(0, DB::table('ingest_batches')->count());
+    }
+
+    public function test_ingest_rejects_value_depth_above_8(): void
+    {
+        $token = $this->issueToken(1001);
+
+        $response = $this->withHeaders([
+            'Authorization' => "Bearer {$token}",
+        ])->postJson('/api/v0.2/integrations/mock/ingest', [
+            'samples' => [
+                [
+                    'domain' => 'sleep',
+                    'recorded_at' => '2026-02-10T00:00:00Z',
+                    'value' => $this->nestedValue(9),
+                ],
+            ],
+        ]);
+
+        $response->assertStatus(422)->assertJson([
+            'ok' => false,
+            'error' => 'validation_failed',
+        ]);
+        $this->assertSame(0, DB::table('ingest_batches')->count());
+    }
+
+    public function test_ingest_rejects_raw_body_above_256kb_and_does_not_write_batch(): void
+    {
+        $token = $this->issueToken(1001);
+        $rawBody = json_encode([
+            'samples' => [
+                [
+                    'domain' => 'sleep',
+                    'recorded_at' => '2026-02-10T00:00:00Z',
+                    'value' => [
+                        'blob' => str_repeat('x', 270 * 1024),
+                    ],
+                ],
+            ],
+        ], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES);
+
+        self::assertIsString($rawBody);
+        self::assertGreaterThan(256 * 1024, strlen($rawBody));
+
+        $response = $this->call(
+            'POST',
+            '/api/v0.2/integrations/mock/ingest',
+            [],
+            [],
+            [],
+            [
+                'CONTENT_TYPE' => 'application/json',
+                'HTTP_ACCEPT' => 'application/json',
+                'HTTP_AUTHORIZATION' => "Bearer {$token}",
+            ],
+            $rawBody
+        );
+
+        $response->assertStatus(413)->assertJson([
+            'ok' => false,
+            'error' => 'payload_too_large',
+        ]);
+        $this->assertSame(0, DB::table('ingest_batches')->count());
+    }
+
+    private function issueToken(int $userId): string
+    {
+        $token = 'fm_'.(string) Str::uuid();
+        DB::table('fm_tokens')->insert([
+            'token' => $token,
+            'user_id' => $userId,
+            'anon_id' => 'ingest-validation-anon-'.$userId,
+            'created_at' => now(),
+            'updated_at' => now(),
+        ]);
+
+        return $token;
+    }
+
+    private function nestedValue(int $depth): array
+    {
+        $node = ['leaf' => 1];
+        for ($i = 0; $i < $depth; $i++) {
+            $node = ['level_'.$i => $node];
+        }
+
+        return $node;
+    }
+}


### PR DESCRIPTION
## Summary
- Hardened `/api/v0.2/integrations/{provider}/ingest` route to require `IntegrationsIngestAuth` (keeps `throttle:api_webhook`).
- Added `IntegrationsIngestAuth` middleware with strict trust boundary:
  - Bearer `fm_*` path reuses `FmTokenAuth` DB identity resolution and injects `fm_user_id`/`user_id`.
  - Signed webhook path requires `X-Webhook-Timestamp`, `X-Webhook-Signature`, `X-Webhook-Event-Id`, validates HMAC+tolerance, resolves `user_id` from `integrations(provider, external_user_id)`, and enforces replay monotonicity using `webhook_last_event_id` / `webhook_last_timestamp`.
  - Returns unified 401 payload: `{ ok:false, error:'UNAUTHORIZED', message:'...' }`.
- Refactored `ProvidersController::ingest`:
  - Removed payload-driven identity fallback; `user_id` now only comes from request attributes (`resolveUserId`).
  - Added explicit provider whitelist check.
  - Added payload guardrails:
    - raw body limit: 256KB -> `413 payload_too_large`
    - `samples` max 100
    - per-sample `value` JSON bytes <= 8192 and depth <= 8
  - Keeps ingest audit fields (`auth_mode`, `signature_ok`, `actor_user_id`, `source_ip`).
- Updated/added feature tests:
  - `IngestAuthTest`: no-auth 401, token trust over `payload.user_id`, signature+mapping success, invalid signature 401.
  - `IngestValidationTest`: samples overflow 422, value depth overflow 422, oversized raw body 413 and no writes.

## Validation
- `php artisan route:list --path=api/v0.2/integrations -vv`
- `php artisan migrate`
- `rg -n "DB::table\\('fm_tokens'\\)|attributes->set\\('fm_user_id'" backend/app/Http/Middleware/FmTokenAuth.php`
- `php artisan test --filter=IngestAuthTest`
- `php artisan test --filter=IngestValidationTest`
- `php artisan test`
- `bash backend/scripts/ci_verify_mbti.sh` *(fails at existing phone OTP acceptance step: `OTP_SEND_FAILED`, could not obtain dev_code/cache code)*
