### PR TITLE
feat(webhook): harden payload DoS with 256KB cap and digest summary

### DIFF
--- a/backend/database/migrations/2026_02_11_120300_add_payload_digest_to_payment_events.php
+++ b/backend/database/migrations/2026_02_11_120300_add_payload_digest_to_payment_events.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Support\Database\SchemaIndex;
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    private const TABLE = 'payment_events';
+    private const INDEX = 'idx_payment_events_payload_sha256';
+
+    public function up(): void
+    {
+        if (!Schema::hasTable(self::TABLE)) {
+            return;
+        }
+
+        Schema::table(self::TABLE, function (Blueprint $table): void {
+            if (!Schema::hasColumn(self::TABLE, 'payload_sha256')) {
+                $table->string('payload_sha256', 64)->nullable();
+            }
+            if (!Schema::hasColumn(self::TABLE, 'payload_size_bytes')) {
+                $table->unsignedInteger('payload_size_bytes')->nullable();
+            }
+        });
+
+        if (!Schema::hasColumn(self::TABLE, 'payload_sha256') || SchemaIndex::indexExists(self::TABLE, self::INDEX)) {
+            return;
+        }
+
+        Schema::table(self::TABLE, function (Blueprint $table): void {
+            $table->index('payload_sha256', self::INDEX);
+        });
+    }
+
+    public function down(): void
+    {
+        if (!Schema::hasTable(self::TABLE) || !SchemaIndex::indexExists(self::TABLE, self::INDEX)) {
+            return;
+        }
+
+        Schema::table(self::TABLE, function (Blueprint $table): void {
+            $table->dropIndex(self::INDEX);
+        });
+    }
+};

--- a/backend/routes/api.php
+++ b/backend/routes/api.php
@@ -38,7 +38,6 @@ use App\Http\Controllers\API\V0_3\ScalesLookupController;
 use App\Http\Controllers\API\V0_3\Webhooks\PaymentWebhookController;
 use App\Http\Controllers\API\V0_4\BootController;
 use App\Http\Controllers\API\V0_4\AssessmentController;
-use App\Http\Middleware\LimitWebhookPayloadSize;
 use App\Http\Middleware\ResolveOrgContext;
 use App\Http\Controllers\Integrations\ProvidersController;
 use App\Http\Controllers\Webhooks\HandleProviderWebhook;
@@ -251,7 +250,7 @@ Route::prefix("v0.3")->middleware([
         "/webhooks/payment/{provider}",
         [PaymentWebhookController::class, "handle"]
     )->whereIn('provider', $payProviders)
-        ->middleware([LimitWebhookPayloadSize::class, 'throttle:api_webhook'])
+        ->middleware(['throttle:api_webhook'])
         ->name('v0.3.webhooks.payment');
 
     Route::middleware(ResolveOrgContext::class)->group(function () use ($payProviders) {

--- a/backend/tests/Feature/Commerce/PaymentWebhookStripeSignatureTest.php
+++ b/backend/tests/Feature/Commerce/PaymentWebhookStripeSignatureTest.php
@@ -38,7 +38,9 @@ final class PaymentWebhookStripeSignatureTest extends TestCase
                 ?string $userId,
                 ?string $anonId,
                 bool $signatureOk,
-                array $payloadMeta
+                array $payloadMeta,
+                string $rawPayloadSha256,
+                int $rawPayloadBytes
             ) use ($payload, $rawBody): bool {
                 return $provider === 'stripe'
                     && $incomingPayload === $payload
@@ -48,6 +50,8 @@ final class PaymentWebhookStripeSignatureTest extends TestCase
                     && $signatureOk === true
                     && ($payloadMeta['size_bytes'] ?? null) === strlen($rawBody)
                     && ($payloadMeta['sha256'] ?? null) === hash('sha256', $rawBody)
+                    && $rawPayloadSha256 === hash('sha256', $rawBody)
+                    && $rawPayloadBytes === strlen($rawBody)
                     && array_key_exists('s3_key', $payloadMeta);
             })
             ->andReturn([


### PR DESCRIPTION
## Summary
- enforce a hard 256KB app-layer payload limit in `v0.3` payment webhook controller; requests above limit now return `413 payload_too_large`
- stop persisting full webhook payload content into `payment_events.payload_json`; persist a compact summary only
- persist and trace raw payload digest metadata (`payload_sha256`, `payload_size_bytes`) and include digest fields in summary JSON
- add migration to ensure digest columns exist and add index on `payload_sha256`
- add/adjust feature tests for oversized payload rejection and digest/summary persistence

## Scope (Pack D / FM-B-005)
- `backend/routes/api.php`
- `backend/database/migrations/2026_02_11_120300_add_payload_digest_to_payment_events.php`
- `backend/app/Http/Controllers/API/V0_3/Webhooks/PaymentWebhookController.php`
- `backend/app/Services/Commerce/PaymentWebhookProcessor.php`
- `backend/tests/Feature/Commerce/PaymentWebhookStripeSignatureTest.php`
- `backend/tests/Feature/Payments/WebhookPayloadSizeLimitTest.php`
- `backend/tests/Feature/V0_3/PaymentWebhookPayloadLimitTest.php`

## Behavior Changes
- webhook request body `> 262144` bytes: immediate `413` before JSON decode/signature validation
- `payment_events.payload_json` now stores only:
  - `provider_event_id`
  - `order_no`
  - `event_type`
  - `amount_cents`
  - `currency`
  - `external_trade_no`
  - `raw_sha256`
  - `raw_bytes`

## Verification
- `php artisan route:list | rg "v0\.3\.webhooks\.payment|webhooks/payment"`
- `php artisan migrate`
- `php -l backend/app/Http/Middleware/FmTokenAuth.php`
- `php artisan test --filter=PaymentWebhookPayloadLimitTest`
- `php artisan test --filter=WebhookPayloadSizeLimitTest`
- `php artisan test --filter=PaymentWebhookStripeSignatureTest`
- `php artisan test`
- `bash backend/scripts/ci_verify_mbti.sh` (environment-dependent OTP phase may fail)
- `ACCEPT_PHONE=0 bash backend/scripts/ci_verify_mbti.sh` (passed end-to-end in this run)
