### PR TITLE
fix(v0.3): purge backend env file and keep runtime/webhook wiring green

### DIFF
--- a/backend/.gitignore
+++ b/backend/.gitignore
@@ -1,6 +1,7 @@
 *.log
 .DS_Store
 .env
+.env.*
 .env.backup
 .env.production
 .phpactor.json


### PR DESCRIPTION
## Summary
This PR closes the critical release blockers for v0.3 runtime/webhook stability and repo secret hygiene.

- Verified v0.3 AttemptRead/AttemptWrite controller + trait autoload chain is valid (no class/trait missing issues).
- Verified v0.3 webhook route is correctly wired to:
  - `App\Http\Controllers\API\V0_3\Webhooks\PaymentWebhookController@handle`
- Removed local `backend/.env` leak risk from workspace flow and hardened ignore rules by adding `.env.*`.
- Confirmed secrets guard passes after cleanup.

## Scope
No API contract changes.
No controller/service logic changes.
No migration file changes.

## A) Changed Files List (Added vs Modified)
- Added:
  - None
- Modified:
  - `/Users/rainie/Desktop/GitHub/fap-api/backend/.gitignore`
- Deleted (workspace file, not tracked in git index):
  - `/Users/rainie/Desktop/GitHub/fap-api/backend/.env`

## B) Copy-paste Blocks (exact insertion position / exact replacement range)

1) Update `/Users/rainie/Desktop/GitHub/fap-api/backend/.gitignore`  
Exact insertion position: immediately after `.env` line.

```gitignore
.env
.env.*
.env.backup
.env.production
