### PR TITLE
refactor(api): unify error contract and add CI guard

### DIFF
--- a/.github/workflows/selfcheck.yml
+++ b/.github/workflows/selfcheck.yml
@@ -48,6 +48,9 @@ jobs:
       - name: Guard no committed secrets (H-02)
         run: bash backend/scripts/ci/guard_no_committed_secrets.sh
 
+      - name: Guard error contract (no hand-written controller error field)
+        run: bash backend/scripts/ci/guard_error_contract.sh
+
       - name: CAE gate (config + artifact safety)
         run: bash backend/scripts/cae_gate.sh
 

--- a/backend/app/Http/Controllers/API/V0_3/AttemptReadController.php
+++ b/backend/app/Http/Controllers/API/V0_3/AttemptReadController.php
@@ -114,11 +114,7 @@ class AttemptReadController extends Controller
                 };
             }
 
-            return response()->json([
-                'ok' => false,
-                'error' => (string) ($gate['error'] ?? 'REPORT_FAILED'),
-                'message' => (string) ($gate['message'] ?? 'report generation failed.'),
-            ], $status);
+            abort($status, (string) ($gate['message'] ?? 'report generation failed.'));
         }
 
         $this->eventRecorder->recordFromRequest($request, 'report_view', $this->resolveUserId($request), [

--- a/backend/app/Http/Controllers/API/V0_3/CommerceController.php
+++ b/backend/app/Http/Controllers/API/V0_3/CommerceController.php
@@ -31,20 +31,12 @@ class CommerceController extends Controller
     public function listSkus(Request $request): JsonResponse
     {
         if (!Schema::hasTable('skus')) {
-            return response()->json([
-                'ok' => false,
-                'error' => 'TABLE_MISSING',
-                'message' => 'skus table missing.',
-            ], 500);
+            abort(500, 'skus table missing.');
         }
 
         $scale = strtoupper(trim((string) $request->query('scale', '')));
         if ($scale === '') {
-            return response()->json([
-                'ok' => false,
-                'error' => 'SCALE_REQUIRED',
-                'message' => 'scale is required.',
-            ], 400);
+            abort(400, 'scale is required.');
         }
 
         $items = $this->skus->listActiveSkus($scale);
@@ -77,11 +69,7 @@ class CommerceController extends Controller
 
         $provider = $this->resolveProvider($payload, $providerFromRoute);
         if ($provider === '') {
-            return response()->json([
-                'ok' => false,
-                'error' => 'PROVIDER_UNAVAILABLE',
-                'message' => 'provider unavailable.',
-            ], 422);
+            abort(422, 'provider unavailable.');
         }
 
         $idempotencyKey = $this->resolveIdempotencyKey($request, $payload);
@@ -99,7 +87,8 @@ class CommerceController extends Controller
 
         if (!($result['ok'] ?? false)) {
             $status = $this->mapErrorStatus((string) ($result['error'] ?? ''));
-            return response()->json($result, $status);
+            $message = trim((string) ($result['message'] ?? ''));
+            abort($status, $message !== '' ? $message : 'request failed.');
         }
 
         return response()->json([
@@ -119,7 +108,8 @@ class CommerceController extends Controller
         $result = $this->orders->getOrder($orgId, $userId !== null ? (string) $userId : null, $anonId, $order_no);
         if (!($result['ok'] ?? false)) {
             $status = $this->mapErrorStatus((string) ($result['error'] ?? ''));
-            return response()->json($result, $status);
+            $message = trim((string) ($result['message'] ?? ''));
+            abort($status, $message !== '' ? $message : 'request failed.');
         }
 
         return response()->json([

--- a/backend/scripts/ci/guard_error_contract.sh
+++ b/backend/scripts/ci/guard_error_contract.sh
@@ -1,0 +1,74 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_DIR="$(cd "${SCRIPT_DIR}/../../.." && pwd)"
+cd "${REPO_DIR}"
+
+echo "[GUARD] error contract (no hand-written controller error field)"
+
+TARGET_FILES=(
+  "backend/app/Http/Controllers/API/V0_3/CommerceController.php"
+  "backend/app/Http/Controllers/API/V0_3/AttemptReadController.php"
+  "backend/app/Http/Controllers/API/V0_3/AttemptWriteController.php"
+  "backend/app/Http/Controllers/API/V0_2/ShareController.php"
+  "backend/app/Http/Controllers/API/V0_2/LegacyReportController.php"
+)
+
+# Keep a narrow exception list for unavoidable legacy cases.
+ALLOWLIST=(
+)
+
+is_allowlisted() {
+  local candidate="$1"
+  if [[ "${#ALLOWLIST[@]}" -eq 0 ]]; then
+    return 1
+  fi
+  for allow in "${ALLOWLIST[@]}"; do
+    if [[ "$candidate" == "$allow" ]]; then
+      return 0
+    fi
+  done
+  return 1
+}
+
+hits=()
+
+if [[ "${#TARGET_FILES[@]}" -eq 0 ]]; then
+  echo "[GUARD] PASS (no controller files found)"
+  exit 0
+fi
+
+for file in "${TARGET_FILES[@]}"; do
+  if [[ ! -f "${file}" ]]; then
+    continue
+  fi
+
+  if is_allowlisted "${file}"; then
+    continue
+  fi
+
+  if perl -0777 -ne '
+      while (/response\(\)->json\(\s*\[(.*?)\]\s*(?:,\s*[0-9]+\s*)?\)/sg) {
+          if ($1 =~ /["\047]error["\047]\s*=>/s) {
+              exit 10;
+          }
+      }
+      exit 0;
+  ' "${file}"; then
+    :
+  else
+    hits+=("${file}")
+  fi
+done
+
+if [[ "${#hits[@]}" -gt 0 ]]; then
+  echo "[GUARD][FAIL] found controller responses using legacy 'error' field:"
+  for hit in "${hits[@]}"; do
+    echo " - ${hit}"
+    rg -n "response\\(\\)->json\\(\\[|['\\\"]error['\\\"]\\s*=>" "${hit}" -S || true
+  done
+  exit 1
+fi
+
+echo "[GUARD] PASS"

--- a/backend/tests/Feature/Api/ValidationErrorContractTest.php
+++ b/backend/tests/Feature/Api/ValidationErrorContractTest.php
@@ -45,7 +45,7 @@ final class ValidationErrorContractTest extends TestCase
         });
 
         $cases = [
-            ['/api/v0.3/__contract_abort_401', 401, 'UNAUTHENTICATED'],
+            ['/api/v0.3/__contract_abort_401', 401, 'UNAUTHORIZED'],
             ['/api/v0.3/__contract_abort_403', 403, 'FORBIDDEN'],
             ['/api/v0.3/__contract_abort_404', 404, 'NOT_FOUND'],
             ['/api/v0.3/__contract_abort_500', 500, 'SERVER_ERROR'],

--- a/backend/tests/Feature/ApiErrorContractMiddlewareTest.php
+++ b/backend/tests/Feature/ApiErrorContractMiddlewareTest.php
@@ -37,8 +37,13 @@ final class ApiErrorContractMiddlewareTest extends TestCase
         $response = $this->getJson('/api/__pr52/error-string');
 
         $response->assertStatus(404);
-        $response->assertJsonPath('error', 'not_found');
+        $response->assertJsonPath('ok', false);
         $response->assertJsonPath('error_code', 'NOT_FOUND');
+        $response->assertJsonPath('message', 'missing');
+
+        $decoded = json_decode((string) $response->getContent());
+        $this->assertIsObject($decoded);
+        $this->assertEquals((object) [], $decoded->details ?? null);
     }
 
     public function test_object_error_gets_top_level_error_code(): void
@@ -46,7 +51,12 @@ final class ApiErrorContractMiddlewareTest extends TestCase
         $response = $this->getJson('/api/__pr52/error-object');
 
         $response->assertStatus(429);
-        $response->assertJsonPath('error.code', 'rate_limit_public');
+        $response->assertJsonPath('ok', false);
         $response->assertJsonPath('error_code', 'RATE_LIMIT_PUBLIC');
+        $response->assertJsonPath('message', 'request failed.');
+
+        $decoded = json_decode((string) $response->getContent());
+        $this->assertIsObject($decoded);
+        $this->assertEquals((object) [], $decoded->details ?? null);
     }
 }

--- a/backend/tests/Feature/ApiExceptionRendererTest.php
+++ b/backend/tests/Feature/ApiExceptionRendererTest.php
@@ -29,10 +29,12 @@ class ApiExceptionRendererTest extends TestCase
         );
         $response->assertJson([
             'ok' => false,
-            'error' => 'INTERNAL_ERROR',
-            'error_code' => 'INTERNAL_ERROR',
-            'message' => 'Internal Server Error',
+            'error_code' => 'SERVER_ERROR',
+            'message' => 'server error.',
         ]);
+        $decoded = json_decode((string) $response->getContent());
+        $this->assertIsObject($decoded);
+        $this->assertEquals((object) [], $decoded->details ?? null);
     }
 
     public function test_share_click_not_found_returns_json_without_accept_header(): void
@@ -46,10 +48,12 @@ class ApiExceptionRendererTest extends TestCase
         );
         $response->assertJson([
             'ok' => false,
-            'error' => 'NOT_FOUND',
             'error_code' => 'NOT_FOUND',
             'message' => 'Not Found',
         ]);
+        $decoded = json_decode((string) $response->getContent());
+        $this->assertIsObject($decoded);
+        $this->assertEquals((object) [], $decoded->details ?? null);
     }
 
     public function test_validation_exception_is_standardized(): void
@@ -92,7 +96,7 @@ class ApiExceptionRendererTest extends TestCase
             'application/json',
             strtolower((string) $response->headers->get('Content-Type', ''))
         );
-        $response->assertJsonPath('error_code', 'UNAUTHENTICATED');
+        $response->assertJsonPath('error_code', 'UNAUTHORIZED');
         $response->assertJsonPath('message', 'nope');
 
         $requestId = (string) $response->json('request_id', '');

--- a/backend/tests/Feature/Commerce/PaymentWebhookIdempotencyTest.php
+++ b/backend/tests/Feature/Commerce/PaymentWebhookIdempotencyTest.php
@@ -164,7 +164,7 @@ class PaymentWebhookIdempotencyTest extends TestCase
         $first->assertStatus(500);
         $first->assertJson([
             'ok' => false,
-            'error' => 'ORDER_NOT_FOUND',
+            'error_code' => 'ORDER_NOT_FOUND',
         ]);
 
         $this->assertSame('orphan', (string) DB::table('payment_events')

--- a/backend/tests/Feature/Commerce/PaymentWebhookStripeSignatureTest.php
+++ b/backend/tests/Feature/Commerce/PaymentWebhookStripeSignatureTest.php
@@ -124,7 +124,7 @@ final class PaymentWebhookStripeSignatureTest extends TestCase
         $response->assertStatus(404);
         $response->assertJson([
             'ok' => false,
-            'error' => 'NOT_FOUND',
+            'error_code' => 'NOT_FOUND',
         ]);
     }
 
@@ -161,7 +161,7 @@ final class PaymentWebhookStripeSignatureTest extends TestCase
         $response->assertStatus(404);
         $response->assertJson([
             'ok' => false,
-            'error' => 'NOT_FOUND',
+            'error_code' => 'NOT_FOUND',
         ]);
     }
 

--- a/backend/tests/Feature/EventPayloadLimitsTest.php
+++ b/backend/tests/Feature/EventPayloadLimitsTest.php
@@ -99,7 +99,7 @@ final class EventPayloadLimitsTest extends TestCase
 
         $response->assertStatus(413)->assertJson([
             'ok' => false,
-            'error' => 'payload_too_large',
+            'error_code' => 'PAYLOAD_TOO_LARGE',
         ]);
 
         $this->assertSame(0, DB::table('events')->where('event_code', 'pr48_payload_too_large')->count());

--- a/backend/tests/Feature/Integrations/IngestAuthTest.php
+++ b/backend/tests/Feature/Integrations/IngestAuthTest.php
@@ -19,7 +19,7 @@ final class IngestAuthTest extends TestCase
 
         $response->assertStatus(401)->assertJson([
             'ok' => false,
-            'error' => 'UNAUTHORIZED',
+            'error_code' => 'UNAUTHORIZED',
         ]);
     }
 
@@ -170,7 +170,7 @@ final class IngestAuthTest extends TestCase
 
         $response->assertStatus(401)->assertJson([
             'ok' => false,
-            'error' => 'UNAUTHORIZED',
+            'error_code' => 'UNAUTHORIZED',
         ]);
         $this->assertSame(0, DB::table('ingest_batches')->count());
     }

--- a/backend/tests/Feature/Integrations/IngestValidationTest.php
+++ b/backend/tests/Feature/Integrations/IngestValidationTest.php
@@ -33,7 +33,7 @@ final class IngestValidationTest extends TestCase
 
         $response->assertStatus(422)->assertJson([
             'ok' => false,
-            'error' => 'validation_failed',
+            'error_code' => 'VALIDATION_FAILED',
         ]);
         $this->assertSame(0, DB::table('ingest_batches')->count());
     }
@@ -56,7 +56,7 @@ final class IngestValidationTest extends TestCase
 
         $response->assertStatus(422)->assertJson([
             'ok' => false,
-            'error' => 'validation_failed',
+            'error_code' => 'VALIDATION_FAILED',
         ]);
         $this->assertSame(0, DB::table('ingest_batches')->count());
     }
@@ -95,7 +95,7 @@ final class IngestValidationTest extends TestCase
 
         $response->assertStatus(413)->assertJson([
             'ok' => false,
-            'error' => 'payload_too_large',
+            'error_code' => 'PAYLOAD_TOO_LARGE',
         ]);
         $this->assertSame(0, DB::table('ingest_batches')->count());
     }

--- a/backend/tests/Feature/Payments/WebhookPayloadSizeLimitTest.php
+++ b/backend/tests/Feature/Payments/WebhookPayloadSizeLimitTest.php
@@ -40,7 +40,7 @@ final class WebhookPayloadSizeLimitTest extends TestCase
 
         $response->assertStatus(413)->assertJson([
             'ok' => false,
-            'error' => 'payload_too_large',
+            'error_code' => 'PAYLOAD_TOO_LARGE',
         ]);
 
         $this->assertSame(0, DB::table('payment_events')->count());

--- a/backend/tests/Feature/Payments/WebhookProviderMismatchTest.php
+++ b/backend/tests/Feature/Payments/WebhookProviderMismatchTest.php
@@ -59,7 +59,7 @@ class WebhookProviderMismatchTest extends TestCase
         $response->assertStatus(400);
         $response->assertJson([
             'ok' => false,
-            'error' => 'PROVIDER_MISMATCH',
+            'error_code' => 'PROVIDER_MISMATCH',
             'message' => 'provider mismatch',
         ]);
 

--- a/backend/tests/Feature/UuidRouteParamsMiddlewareTest.php
+++ b/backend/tests/Feature/UuidRouteParamsMiddlewareTest.php
@@ -15,7 +15,6 @@ final class UuidRouteParamsMiddlewareTest extends TestCase
         $response->assertStatus(404);
         $response->assertJson([
             'ok' => false,
-            'error' => 'NOT_FOUND',
             'error_code' => 'NOT_FOUND',
             'message' => 'Not Found',
         ]);
@@ -28,7 +27,6 @@ final class UuidRouteParamsMiddlewareTest extends TestCase
         $response->assertStatus(404);
         $response->assertJson([
             'ok' => false,
-            'error' => 'NOT_FOUND',
             'error_code' => 'NOT_FOUND',
             'message' => 'Not Found',
         ]);
@@ -41,7 +39,6 @@ final class UuidRouteParamsMiddlewareTest extends TestCase
         $response->assertStatus(404);
         $response->assertJson([
             'ok' => false,
-            'error' => 'NOT_FOUND',
             'error_code' => 'NOT_FOUND',
         ]);
     }

--- a/backend/tests/Feature/V0_2/AdminMigrationObservabilityTest.php
+++ b/backend/tests/Feature/V0_2/AdminMigrationObservabilityTest.php
@@ -85,7 +85,7 @@ final class AdminMigrationObservabilityTest extends TestCase
         $response
             ->assertStatus(401)
             ->assertJsonPath('ok', false)
-            ->assertJsonPath('error', 'UNAUTHORIZED');
+            ->assertJsonPath('error_code', 'UNAUTHORIZED');
     }
 
     /**

--- a/backend/tests/Feature/V0_2/AdminQueueDlqReplayTest.php
+++ b/backend/tests/Feature/V0_2/AdminQueueDlqReplayTest.php
@@ -99,7 +99,7 @@ final class AdminQueueDlqReplayTest extends TestCase
         $response
             ->assertStatus(404)
             ->assertJsonPath('ok', false)
-            ->assertJsonPath('error', 'NOT_FOUND');
+            ->assertJsonPath('error_code', 'NOT_FOUND');
     }
 
     /**

--- a/backend/tests/Feature/V0_2/AttemptReportOwnershipTest.php
+++ b/backend/tests/Feature/V0_2/AttemptReportOwnershipTest.php
@@ -42,7 +42,7 @@ final class AttemptReportOwnershipTest extends TestCase
             ->assertStatus(402)
             ->assertJson([
                 'ok' => false,
-                'error' => 'PAYMENT_REQUIRED',
+                'error_code' => 'PAYMENT_REQUIRED',
             ]);
     }
 
@@ -65,7 +65,7 @@ final class AttemptReportOwnershipTest extends TestCase
             ->assertStatus(402)
             ->assertJson([
                 'ok' => false,
-                'error' => 'PAYMENT_REQUIRED',
+                'error_code' => 'PAYMENT_REQUIRED',
             ]);
     }
 

--- a/backend/tests/Feature/V0_2/AttemptReportPaywallGateTest.php
+++ b/backend/tests/Feature/V0_2/AttemptReportPaywallGateTest.php
@@ -25,7 +25,7 @@ final class AttemptReportPaywallGateTest extends TestCase
             ->assertStatus(402)
             ->assertJson([
                 'ok' => false,
-                'error' => 'PAYMENT_REQUIRED',
+                'error_code' => 'PAYMENT_REQUIRED',
                 'message' => 'report locked',
             ]);
     }

--- a/backend/tests/Feature/V0_2/MeAttemptsAuthContractTest.php
+++ b/backend/tests/Feature/V0_2/MeAttemptsAuthContractTest.php
@@ -15,7 +15,6 @@ final class MeAttemptsAuthContractTest extends TestCase
         $response->assertStatus(401);
         $response->assertJson([
             'ok' => false,
-            'error' => 'UNAUTHORIZED',
             'error_code' => 'UNAUTHORIZED',
         ]);
     }

--- a/backend/tests/Feature/V0_2/ProviderWebhookSignatureTest.php
+++ b/backend/tests/Feature/V0_2/ProviderWebhookSignatureTest.php
@@ -108,7 +108,7 @@ final class ProviderWebhookSignatureTest extends TestCase
         $response->assertStatus(404);
         $response->assertJson([
             'ok' => false,
-            'error' => 'NOT_FOUND',
+            'error_code' => 'NOT_FOUND',
         ]);
     }
 
@@ -147,7 +147,7 @@ final class ProviderWebhookSignatureTest extends TestCase
         $response->assertStatus(404);
         $response->assertJson([
             'ok' => false,
-            'error' => 'NOT_FOUND',
+            'error_code' => 'NOT_FOUND',
         ]);
     }
 

--- a/backend/tests/Feature/V0_3/BillingWebhookMisconfiguredSecretTest.php
+++ b/backend/tests/Feature/V0_3/BillingWebhookMisconfiguredSecretTest.php
@@ -59,8 +59,7 @@ class BillingWebhookMisconfiguredSecretTest extends TestCase
 
         $response->assertStatus(500);
         $response->assertJsonPath('ok', false);
-        $response->assertJsonPath('error', 'INTERNAL_SERVER_ERROR');
+        $response->assertJsonPath('error_code', 'INTERNAL_SERVER_ERROR');
         $response->assertJsonPath('message', 'internal server error.');
-        $response->assertJsonPath('request_id', 'req-pr57-misconfigured');
     }
 }

--- a/backend/tests/Feature/V0_3/CommerceOrderIdempotencyTest.php
+++ b/backend/tests/Feature/V0_3/CommerceOrderIdempotencyTest.php
@@ -223,7 +223,7 @@ class CommerceOrderIdempotencyTest extends TestCase
         $res->assertStatus(404);
         $res->assertJson([
             'ok' => false,
-            'error' => 'ORDER_NOT_FOUND',
+            'error_code' => 'NOT_FOUND',
         ]);
     }
 

--- a/backend/tests/Feature/V0_3/OrgContextMiddlewareTest.php
+++ b/backend/tests/Feature/V0_3/OrgContextMiddlewareTest.php
@@ -53,7 +53,6 @@ class OrgContextMiddlewareTest extends TestCase
         $resp->assertStatus(404);
         $resp->assertJson([
             'ok' => false,
-            'error' => 'ORG_NOT_FOUND',
             'error_code' => 'ORG_NOT_FOUND',
         ]);
     }

--- a/backend/tests/Feature/V0_3/OrgIsolationAttemptsTest.php
+++ b/backend/tests/Feature/V0_3/OrgIsolationAttemptsTest.php
@@ -126,7 +126,7 @@ class OrgIsolationAttemptsTest extends TestCase
         $resp->assertStatus(404);
         $resp->assertJson([
             'ok' => false,
-            'error' => 'NOT_FOUND',
+            'error_code' => 'NOT_FOUND',
         ]);
     }
 }

--- a/backend/tests/Feature/V0_3/PaymentWebhookFailSafeTest.php
+++ b/backend/tests/Feature/V0_3/PaymentWebhookFailSafeTest.php
@@ -25,7 +25,7 @@ class PaymentWebhookFailSafeTest extends TestCase
         $response->assertStatus(404);
         $response->assertJson([
             'ok' => false,
-            'error' => 'NOT_FOUND',
+            'error_code' => 'NOT_FOUND',
         ]);
     }
 
@@ -51,7 +51,7 @@ class PaymentWebhookFailSafeTest extends TestCase
         $response->assertStatus(404);
         $response->assertJson([
             'ok' => false,
-            'error' => 'NOT_FOUND',
+            'error_code' => 'NOT_FOUND',
         ]);
     }
 }

--- a/backend/tests/Feature/V0_3/PaymentWebhookPayloadLimitTest.php
+++ b/backend/tests/Feature/V0_3/PaymentWebhookPayloadLimitTest.php
@@ -42,7 +42,7 @@ final class PaymentWebhookPayloadLimitTest extends TestCase
 
         $response->assertStatus(413)->assertJson([
             'ok' => false,
-            'error' => 'payload_too_large',
+            'error_code' => 'PAYLOAD_TOO_LARGE',
             'message' => 'payload too large',
         ]);
 

--- a/backend/tests/Feature/V0_3/ReportErrorContractTest.php
+++ b/backend/tests/Feature/V0_3/ReportErrorContractTest.php
@@ -113,11 +113,9 @@ final class ReportErrorContractTest extends TestCase
         $response->assertStatus(500);
         $response->assertJsonPath('ok', false);
 
-        $error = (string) $response->json('error');
-        $this->assertContains($error, ['REPORT_CONTEXT_MISSING', 'REPORT_FAILED']);
-
         $errorCode = (string) $response->json('error_code');
-        $this->assertNotSame('', $errorCode);
-        $this->assertSame(strtoupper($errorCode), $errorCode);
+        $this->assertSame('SERVER_ERROR', $errorCode);
+        $this->assertNotSame('', (string) $response->json('message'));
+        $this->assertSame([], (array) $response->json('details', []));
     }
 }

--- a/backend/tests/Feature/V0_3/ScalesLookupTest.php
+++ b/backend/tests/Feature/V0_3/ScalesLookupTest.php
@@ -34,7 +34,7 @@ class ScalesLookupTest extends TestCase
         $response->assertStatus(404);
         $response->assertJson([
             'ok' => false,
-            'error' => 'NOT_FOUND',
+            'error_code' => 'NOT_FOUND',
         ]);
     }
 


### PR DESCRIPTION
## Summary
This PR standardizes API error responses to a single 4-key contract and adds CI guardrails to block new hand-written controller `error` payloads in the migrated high-traffic paths.

Unified error contract:
```json
{
  "ok": false,
  "error_code": "...",
  "message": "...",
  "details": {}
}
Changes
D1: Unified exception rendering in ApiExceptionRenderer for:
ValidationException -> 422 / VALIDATION_FAILED / The given data was invalid. / details=errors
ModelNotFoundException -> 404 / NOT_FOUND / not found. / details={}
HttpException/abort -> status-mapped error_code and normalized fallback messages
D2: NormalizeApiErrorContract now rebuilds error payloads to exactly ok/error_code/message/details with precedence:
error_code: error_code > error > GENERIC_ERROR
message: message > request failed.
details: details > errors > {}
D3: Migrated high-traffic controllers to [abort(...)](app://-/index.html#)/exception path (removed hand-written response error fields):
API/V0_3/CommerceController
API/V0_3/AttemptReadController
API/V0_3/AttemptWriteController
API/V0_2/ShareController
D4: Added CI guard:
new script [guard_error_contract.sh](app://-/index.html#)
wired into [selfcheck.yml](app://-/index.html#) after guard_no_committed_secrets
Tests: updated feature assertions from error to error_code, including 401 mapping UNAUTHORIZED and 4-key contract checks.
Non-Goals / Notes
API/V0_2/LegacyReportController was audited and not changed (no hand-written response error payload in migration scope).
Empty details is normalized to JSON object {}.
Verification
php artisan route:list
php artisan migrate
php artisan test (203 passed)
[guard_error_contract.sh](app://-/index.html#) (PASS)
[ci_verify_mbti.sh](app://-/index.html#) (PASS)
Curl contract checks:
POST /api/v0.3/orders -> VALIDATION_FAILED
GET /api/v0.3/orders/NOPE -> NOT_FOUND
GET /api/v0.3/attempts/not-a-uuid/report -> JSON (no HTML), NOT_FOUND