### PR TITLE
refactor(migrations): schema-only role backfill and safe rollback

### DIFF
--- a/backend/app/Jobs/Ops/BackfillRoleJob.php
+++ b/backend/app/Jobs/Ops/BackfillRoleJob.php
@@ -1,0 +1,84 @@
+<?php
+
+namespace App\Jobs\Ops;
+
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Bus\Dispatchable;
+use Illuminate\Queue\InteractsWithQueue;
+use Illuminate\Queue\SerializesModels;
+use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Log;
+use Illuminate\Support\Facades\Schema;
+
+class BackfillRoleJob implements ShouldQueue
+{
+    use Dispatchable, InteractsWithQueue, Queueable, SerializesModels;
+
+    public function handle(): void
+    {
+        $lock = Cache::lock('backfill:organization_members:role', 300);
+
+        if (!$lock->get()) {
+            Log::info('[backfill_role] lock busy, skip');
+            return;
+        }
+
+        $totalUpdated = 0;
+        $lastId = 0;
+
+        try {
+            if (!Schema::hasTable('organization_members')
+                || !Schema::hasColumn('organization_members', 'id')
+                || !Schema::hasColumn('organization_members', 'role')) {
+                Log::warning('[backfill_role] table/column missing');
+                return;
+            }
+
+            DB::table('organization_members')
+                ->select('id')
+                ->where(function ($query): void {
+                    $query->whereNull('role')->orWhere('role', '');
+                })
+                ->chunkById(1000, function ($rows) use (&$totalUpdated, &$lastId): void {
+                    $ids = [];
+                    foreach ($rows as $row) {
+                        $ids[] = (int) $row->id;
+                    }
+
+                    if ($ids === []) {
+                        return;
+                    }
+
+                    $updated = DB::table('organization_members')
+                        ->whereIn('id', $ids)
+                        ->where(function ($query): void {
+                            $query->whereNull('role')->orWhere('role', '');
+                        })
+                        ->update([
+                            'role' => 'member',
+                            'updated_at' => now(),
+                        ]);
+
+                    $lastId = max($ids);
+                    $totalUpdated += (int) $updated;
+
+                    Log::info('[backfill_role] progress', [
+                        'batch_updated' => (int) $updated,
+                        'total_updated' => $totalUpdated,
+                        'last_id' => $lastId,
+                    ]);
+
+                    usleep(50000);
+                }, 'id');
+
+            Log::info('[backfill_role] done', [
+                'total_updated' => $totalUpdated,
+                'last_id' => $lastId,
+            ]);
+        } finally {
+            $lock->release();
+        }
+    }
+}

--- a/backend/database/migrations/2026_01_29_120000_v03_attempts_results_fields.php
+++ b/backend/database/migrations/2026_01_29_120000_v03_attempts_results_fields.php
@@ -18,10 +18,10 @@ return new class extends Migration
                     $table->unsignedBigInteger('org_id')->default(0);
                 }
                 if (!Schema::hasColumn('attempts', 'scale_code')) {
-                    $table->string('scale_code', 32);
+                    $table->string('scale_code', 32)->nullable();
                 }
                 if (!Schema::hasColumn('attempts', 'scale_version')) {
-                    $table->string('scale_version', 16);
+                    $table->string('scale_version', 16)->nullable();
                 }
                 if (!Schema::hasColumn('attempts', 'pack_id')) {
                     $table->string('pack_id', 128)->nullable();
@@ -77,10 +77,10 @@ return new class extends Migration
                     $table->unsignedBigInteger('org_id')->default(0);
                 }
                 if (!Schema::hasColumn('results', 'attempt_id')) {
-                    $table->uuid('attempt_id');
+                    $table->uuid('attempt_id')->nullable();
                 }
                 if (!Schema::hasColumn('results', 'scale_code')) {
-                    $table->string('scale_code', 32);
+                    $table->string('scale_code', 32)->nullable();
                 }
                 if (!Schema::hasColumn('results', 'result_json')) {
                     if ($isSqlite) {
@@ -139,16 +139,16 @@ return new class extends Migration
 
             Schema::table('attempts', function (Blueprint $table) {
                 if (Schema::hasColumn('attempts', 'answers_digest')) {
-                    $table->dropColumn('answers_digest');
+                    // Irreversible operation: Column dropped manually if needed (rollback disabled to prevent data loss).
                 }
                 if (Schema::hasColumn('attempts', 'duration_ms')) {
-                    $table->dropColumn('duration_ms');
+                    // Irreversible operation: Column dropped manually if needed (rollback disabled to prevent data loss).
                 }
                 if (Schema::hasColumn('attempts', 'content_package_version')) {
-                    $table->dropColumn('content_package_version');
+                    // Irreversible operation: Column dropped manually if needed (rollback disabled to prevent data loss).
                 }
                 if (Schema::hasColumn('attempts', 'org_id')) {
-                    $table->dropColumn('org_id');
+                    // Irreversible operation: Column dropped manually if needed (rollback disabled to prevent data loss).
                 }
             });
         }
@@ -168,22 +168,22 @@ return new class extends Migration
 
             Schema::table('results', function (Blueprint $table) {
                 if (Schema::hasColumn('results', 'report_engine_version')) {
-                    $table->dropColumn('report_engine_version');
+                    // Irreversible operation: Column dropped manually if needed (rollback disabled to prevent data loss).
                 }
                 if (Schema::hasColumn('results', 'scoring_spec_version')) {
-                    $table->dropColumn('scoring_spec_version');
+                    // Irreversible operation: Column dropped manually if needed (rollback disabled to prevent data loss).
                 }
                 if (Schema::hasColumn('results', 'dir_version')) {
-                    $table->dropColumn('dir_version');
+                    // Irreversible operation: Column dropped manually if needed (rollback disabled to prevent data loss).
                 }
                 if (Schema::hasColumn('results', 'pack_id')) {
-                    $table->dropColumn('pack_id');
+                    // Irreversible operation: Column dropped manually if needed (rollback disabled to prevent data loss).
                 }
                 if (Schema::hasColumn('results', 'result_json')) {
-                    $table->dropColumn('result_json');
+                    // Irreversible operation: Column dropped manually if needed (rollback disabled to prevent data loss).
                 }
                 if (Schema::hasColumn('results', 'org_id')) {
-                    $table->dropColumn('org_id');
+                    // Irreversible operation: Column dropped manually if needed (rollback disabled to prevent data loss).
                 }
             });
         }

--- a/backend/database/migrations/2026_01_31_090020_expand_organization_members_role.php
+++ b/backend/database/migrations/2026_01_31_090020_expand_organization_members_role.php
@@ -1,24 +1,13 @@
 <?php
 
 use Illuminate\Database\Migrations\Migration;
-use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Schema;
 
 return new class extends Migration
 {
     public function up(): void
     {
-        if (!Schema::hasTable('organization_members')) {
-            return;
-        }
-
-        DB::table('organization_members')
-            ->whereNull('role')
-            ->orWhere('role', '')
-            ->update([
-                'role' => 'member',
-                'updated_at' => now(),
-            ]);
+        // Data backfill moved to app/Jobs/Ops/BackfillRoleJob.php
     }
 
     public function down(): void


### PR DESCRIPTION
## Summary
Pack A 零停机迁移改造完成：
- 将高风险 migration 改为 schema-only（移除 migration 内数据更新）
- 移除 down() 中 dropColumn 回滚删数风险（仅保留索引回滚）
- 新增可幂等、分批、节流、带分布式锁的角色回填 Job

## Scope (strict)
### Modified
- /Users/rainie/Desktop/GitHub/fap-api/backend/database/migrations/2026_01_29_120000_v03_attempts_results_fields.php
- /Users/rainie/Desktop/GitHub/fap-api/backend/database/migrations/2026_01_31_090020_expand_organization_members_role.php

### Added
- /Users/rainie/Desktop/GitHub/fap-api/backend/app/Jobs/Ops/BackfillRoleJob.php

## Key Changes
1. v03_attempts_results_fields migration
- `attempts.scale_code` -> `string(32)->nullable()`
- `attempts.scale_version` -> `string(16)->nullable()`
- `results.attempt_id` -> `uuid()->nullable()`
- `results.scale_code` -> `string(32)->nullable()`
- down() 保留 dropIndex/dropUnique，所有 dropColumn 改为不可逆注释（禁删列）

2. expand_organization_members_role migration
- `up()` 改为 no-op 注释
- 移除 `DB::table(...)->update(...)`

3. BackfillRoleJob
- `implements ShouldQueue`
- 分布式锁：`backfill:organization_members:role`
- 幂等条件：仅更新 `role IS NULL OR role = ''`
- 分批：`chunkById(1000)`
- 批次后节流：`usleep(50000)`
- 批量更新：收集 `id` 后 `whereIn('id', $ids)->update([...])`
- 批次进度日志：`batch_updated` / `total_updated` / `last_id`

## Verification
```bash
cd /Users/rainie/Desktop/GitHub/fap-api/backend && php artisan route:list
cd /Users/rainie/Desktop/GitHub/fap-api/backend && rg -n -- "->update\\(|->insert\\(" database/migrations
cd /Users/rainie/Desktop/GitHub/fap-api/backend && rg -n "dropColumn\\(" database/migrations/2026_01_29_120000_v03_attempts_results_fields.php
cd /Users/rainie/Desktop/GitHub/fap-api/backend && php artisan migrate --pretend
cd /Users/rainie/Desktop/GitHub/fap-api/backend && php artisan migrate
curl -sS -i http://127.0.0.1:8000/api/healthz
curl -sS -i http://127.0.0.1:8000/api/v0.2/healthz
cd /Users/rainie/Desktop/GitHub/fap-api/backend && bash scripts/ci_verify_mbti.sh
