### PR TITLE
Pack B: performance tuning for replay idempotency and assessment progress

### DIFF
--- a/backend/app/Services/Ingestion/ReplayService.php
+++ b/backend/app/Services/Ingestion/ReplayService.php
@@ -104,14 +104,7 @@ class ReplayService
                     $value = $sample['value'] ?? [];
 
                     $idKey = IdempotencyKey::build($provider, $externalId !== '' ? $externalId : $recordedAt, $recordedAt, $value);
-                    $existing = $store->findByPayload($idKey['provider'], $idKey['recorded_at'], $idKey['hash']);
-                    if ($existing) {
-                        $store->touch($idKey['provider'], $idKey['external_id'], $idKey['recorded_at'], $idKey['hash']);
-                        $skipped++;
-                        continue;
-                    }
-
-                    $record = $store->record([
+                    $record = $store->recordFast([
                         'provider' => $idKey['provider'],
                         'external_id' => $idKey['external_id'],
                         'recorded_at' => $idKey['recorded_at'],


### PR DESCRIPTION
## Summary
- switch replay idempotency path to write-first `recordFast()` so chunk loop no longer does per-row `findByPayload/touch`
- add `IdempotencyStore::recordFast()` backed by `insertOrIgnore` and keep existing `record/find/touch` APIs unchanged
- refactor assessment invite to build rows in PHP and perform one transactional bulk insert
- refactor assessment progress to count + capped lists (`limit 50`) and add truncation metadata

## Changed Files
- /Users/rainie/Desktop/GitHub/fap-api/backend/app/Services/Ingestion/ReplayService.php
- /Users/rainie/Desktop/GitHub/fap-api/backend/app/Support/Idempotency/IdempotencyStore.php
- /Users/rainie/Desktop/GitHub/fap-api/backend/app/Services/Assessments/AssessmentService.php

## Validation
- `php artisan route:list`
- `php artisan migrate`
- `rg -n "findByPayload\\(|touch\\(" app/Services/Ingestion/ReplayService.php` (no match)
- `rg -n "function recordFast\\(" app/Support/Idempotency/IdempotencyStore.php`
- `rg -n "insertOrIgnore" app/Support/Idempotency/IdempotencyStore.php`
- `rg -n "function progress\\(" app/Services/Assessments/AssessmentService.php`
- `rg -n -- "->get\\(" app/Services/Assessments/AssessmentService.php` (only 2 list queries)
- `php artisan test` (210 passed)
- `bash backend/scripts/ci_verify_mbti.sh` (passed)
