### PR TITLE
feat(db): Pack C index governance for replay and idempotency

### DIFF
--- a/backend/database/migrations/2026_02_11_090100_add_idx_idempotency_keys_provider_recorded_hash.php
+++ b/backend/database/migrations/2026_02_11_090100_add_idx_idempotency_keys_provider_recorded_hash.php
@@ -5,12 +5,14 @@ declare(strict_types=1);
 use App\Support\Database\SchemaIndex;
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Schema;
 
 return new class extends Migration
 {
     private const TABLE = 'idempotency_keys';
     private const INDEX = 'idx_idempo_provider_recorded_hash';
+    private const ALT_INDEX = 'idx_idempo_payload';
 
     public function up(): void
     {
@@ -18,7 +20,9 @@ return new class extends Migration
             || !Schema::hasColumn(self::TABLE, 'provider')
             || !Schema::hasColumn(self::TABLE, 'recorded_at')
             || !Schema::hasColumn(self::TABLE, 'hash')
-            || SchemaIndex::indexExists(self::TABLE, self::INDEX)) {
+            || SchemaIndex::indexExists(self::TABLE, self::INDEX)
+            || SchemaIndex::indexExists(self::TABLE, self::ALT_INDEX)
+            || $this->hasAnyIndexOnColumns(self::TABLE, ['provider', 'recorded_at', 'hash'])) {
             return;
         }
 
@@ -36,5 +40,40 @@ return new class extends Migration
         Schema::table(self::TABLE, function (Blueprint $table): void {
             $table->dropIndex(self::INDEX);
         });
+    }
+
+    /**
+     * @param list<string> $columns
+     */
+    private function hasAnyIndexOnColumns(string $table, array $columns): bool
+    {
+        if (DB::connection()->getDriverName() !== 'mysql') {
+            return false;
+        }
+
+        $database = DB::getDatabaseName();
+        if (!is_string($database) || $database === '') {
+            return false;
+        }
+
+        $expectedSequence = implode(',', $columns);
+
+        $rows = DB::select(
+            "SELECT index_name,
+                    GROUP_CONCAT(column_name ORDER BY seq_in_index SEPARATOR ',') AS column_sequence
+             FROM information_schema.statistics
+             WHERE table_schema = ? AND table_name = ?
+             GROUP BY index_name",
+            [$database, $table]
+        );
+
+        foreach ($rows as $row) {
+            $columnSequence = (string) ($row->column_sequence ?? $row->COLUMN_SEQUENCE ?? '');
+            if ($columnSequence === $expectedSequence) {
+                return true;
+            }
+        }
+
+        return false;
     }
 };

--- a/backend/database/migrations/2026_02_12_000000_add_replay_indexes.php
+++ b/backend/database/migrations/2026_02_12_000000_add_replay_indexes.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Support\Database\SchemaIndex;
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        $this->addReplayIndex('sleep_samples', 'sleep_samples_ingest_id_idx');
+        $this->addReplayIndex('screen_time_samples', 'screen_time_samples_ingest_id_idx');
+        $this->addReplayIndex('health_samples', 'health_samples_ingest_id_idx');
+    }
+
+    public function down(): void
+    {
+        // forward-only: do not drop replay indexes on rollback.
+    }
+
+    private function addReplayIndex(string $table, string $indexName): void
+    {
+        if (!Schema::hasTable($table)
+            || !Schema::hasColumn($table, 'ingest_batch_id')
+            || !Schema::hasColumn($table, 'id')
+            || SchemaIndex::indexExists($table, $indexName)) {
+            return;
+        }
+
+        Schema::table($table, function (Blueprint $blueprint) use ($indexName): void {
+            $blueprint->index(['ingest_batch_id', 'id'], $indexName);
+        });
+    }
+};


### PR DESCRIPTION
## Summary
Pack C — Index Governance（单一小闭环）

### What changed
1. `/Users/rainie/Desktop/GitHub/fap-api/backend/database/migrations/2026_02_10_160100_add_idx_idempo_payload.php`
- 将 `idempotency_keys(provider, recorded_at, hash)` 的 guard 从“按索引名”升级为“按列集合”检测。
- 使用 `information_schema.statistics + GROUP_CONCAT(... ORDER BY seq_in_index)`，命中任意同列索引即跳过创建，避免“同列不同名”重复索引。

2. `/Users/rainie/Desktop/GitHub/fap-api/backend/database/migrations/2026_02_11_090100_add_idx_idempotency_keys_provider_recorded_hash.php`
- 增加同列集合 guard + 备用索引名 guard（`idx_idempo_payload`）。
- 目的：新库完整迁移链路下，确保 `(provider, recorded_at, hash)` 只保留一份。

3. `/Users/rainie/Desktop/GitHub/fap-api/backend/database/migrations/2026_02_12_000000_add_replay_indexes.php` (new)
- 为以下表新增复合索引 `(ingest_batch_id, id)`：
  - `sleep_samples_ingest_id_idx`
  - `screen_time_samples_ingest_id_idx`
  - `health_samples_ingest_id_idx`
- 使用 `SchemaIndex::indexExists($table, $indexName)` 做 guard。
- `down()` 为 forward-only no-op（避免 rollback 误删线上索引）。

## Changed Files
### Added
- `/Users/rainie/Desktop/GitHub/fap-api/backend/database/migrations/2026_02_12_000000_add_replay_indexes.php`

### Modified
- `/Users/rainie/Desktop/GitHub/fap-api/backend/database/migrations/2026_02_10_160100_add_idx_idempo_payload.php`
- `/Users/rainie/Desktop/GitHub/fap-api/backend/database/migrations/2026_02_11_090100_add_idx_idempotency_keys_provider_recorded_hash.php`

## Verification
```bash
cd /Users/rainie/Desktop/GitHub/fap-api/backend
php artisan route:list
php artisan migrate --pretend
php artisan migrate

curl -sS http://127.0.0.1:8000/api/v0.2/health
curl -sS http://127.0.0.1:8000/api/healthz

cd /Users/rainie/Desktop/GitHub/fap-api
bash backend/scripts/ci_verify_mbti.sh

cd /Users/rainie/Desktop/GitHub/fap-api/backend
php artisan tinker --execute="dump(DB::select('SHOW INDEX FROM sleep_samples'));"
php artisan tinker --execute="dump(DB::select('SHOW INDEX FROM screen_time_samples'));"
php artisan tinker --execute="dump(DB::select('SHOW INDEX FROM health_samples'));"
php artisan tinker --execute="dump(DB::select('SHOW INDEX FROM idempotency_keys'));"
