### PR TITLE
feat(hardening): cache assessment json and add healthz retry

### DIFF
--- a/backend/app/Console/Commands/OpsHealthzSnapshot.php
+++ b/backend/app/Console/Commands/OpsHealthzSnapshot.php
@@ -34,7 +34,7 @@ class OpsHealthzSnapshot extends Command
         try {
             $data = null;
             try {
-                $response = Http::acceptJson()->timeout(5)->get($url);
+                $response = Http::acceptJson()->retry(3, 100)->timeout(5)->get($url);
                 if ($response->ok()) {
                     $json = $response->json();
                     if (is_array($json)) {


### PR DESCRIPTION
## Summary
- cache `scoring_spec.json` and `questions.json` in `AssessmentEngine` via `Cache::remember(..., 3600, ...)`
- add `readJsonCached(string $packId, string $dirVersion, string $baseDir, string $filename): ?array` with key format `fap:pack_json:{packId}:{dirVersion}:{filename}`
- switch `score()` to read both JSON files through cached entry while keeping existing error semantics
- harden `OpsHealthzSnapshot` external HTTP call with `retry(3, 100)` while keeping `timeout(5)` and existing fallback logic

## Changed Files
- `backend/app/Services/Assessment/AssessmentEngine.php`
- `backend/app/Console/Commands/OpsHealthzSnapshot.php`

## Validation
- `cd backend && php artisan route:list`
- `cd backend && php artisan migrate`
- `cd backend && rg -n "Cache::remember\\(.*3600" app/Services/Assessment/AssessmentEngine.php`
- `cd backend && rg -n "retry\\(3,\\s*100\\)" app/Console/Commands/OpsHealthzSnapshot.php`
- `cd backend && php artisan test`
- `cd backend && bash scripts/ci_verify_mbti.sh`
- `curl -sS http://127.0.0.1:8000/api/v0.2/healthz` *(failed locally: no service listening on 127.0.0.1:8000 in this session)*
- `curl -sS http://127.0.0.1:8000/api/v0.2/health` *(failed locally: no service listening on 127.0.0.1:8000 in this session)*
