### PR TITLE
fix(pack-a): critical webhook wiring + configurable sitemap + env leak gate

### DIFF
--- a/.github/workflows/ci_dlq_replay_metrics.yml
+++ b/.github/workflows/ci_dlq_replay_metrics.yml
@@ -56,8 +56,20 @@ jobs:
       - name: Composer validate & audit
         working-directory: backend
         run: |
+          set -euo pipefail
           composer validate --strict
-          composer audit --no-interaction
+          for attempt in 1 2 3; do
+            if composer audit --no-interaction; then
+              break
+            fi
+
+            if [[ "$attempt" -eq 3 ]]; then
+              echo "::error::composer audit failed after 3 attempts"
+              exit 1
+            fi
+
+            sleep $((attempt * 5))
+          done
 
       - name: Prepare sqlite and seed defaults
         working-directory: backend

--- a/.github/workflows/ci_pr56_workflow_composer_php84.yml
+++ b/.github/workflows/ci_pr56_workflow_composer_php84.yml
@@ -44,6 +44,10 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      - name: Guard backend .env not committed
+        run: |
+          test ! -f backend/.env || (echo "::error::backend/.env must not exist in the repository"; exit 1)
+
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:

--- a/.github/workflows/ci_verify_pr21_answer_storage.yml
+++ b/.github/workflows/ci_verify_pr21_answer_storage.yml
@@ -58,8 +58,20 @@ jobs:
       - name: Composer validate & audit
         working-directory: backend
         run: |
+          set -euo pipefail
           composer validate --strict
-          composer audit --no-interaction
+          for attempt in 1 2 3; do
+            if composer audit --no-interaction; then
+              break
+            fi
+
+            if [[ "$attempt" -eq 3 ]]; then
+              echo "::error::composer audit failed after 3 attempts"
+              exit 1
+            fi
+
+            sleep $((attempt * 5))
+          done
 
       - name: Migrate
         working-directory: backend

--- a/.github/workflows/ci_verify_pr23_feature_flags_sticky_experiments.yml
+++ b/.github/workflows/ci_verify_pr23_feature_flags_sticky_experiments.yml
@@ -52,7 +52,20 @@ jobs:
 
       - name: Composer audit (CVE scan)
         working-directory: backend
-        run: composer audit --no-interaction
+        run: |
+          set -euo pipefail
+          for attempt in 1 2 3; do
+            if composer audit --no-interaction; then
+              break
+            fi
+
+            if [[ "$attempt" -eq 3 ]]; then
+              echo "::error::composer audit failed after 3 attempts"
+              exit 1
+            fi
+
+            sleep $((attempt * 5))
+          done
 
       - name: Prepare sqlite
         run: |

--- a/.github/workflows/ci_verify_pr24_sitemap.yml
+++ b/.github/workflows/ci_verify_pr24_sitemap.yml
@@ -33,6 +33,7 @@ jobs:
       DB_DATABASE: /tmp/pr24.sqlite
       CACHE_DRIVER: array
       SERVE_PORT: 1824
+      SEO_TESTS_URL_PREFIX: https://fermatmind.com/tests/
 
     steps:
       - name: Checkout

--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@
 
 # laravel storage symlink
 /backend/public/storage
+/backend/.env
 tools/compose/.env
 
 # Filament published assets (generated)

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -13,6 +13,8 @@ APP_ENV=local
 APP_KEY=
 APP_DEBUG=false
 APP_URL=http://localhost
+# Sitemap <loc> URL prefix for public tests pages.
+SEO_TESTS_URL_PREFIX=http://localhost/tests/
 
 APP_LOCALE=en
 APP_FALLBACK_LOCALE=en

--- a/backend/app/Http/Controllers/API/V0_3/Webhooks/PaymentWebhookController.php
+++ b/backend/app/Http/Controllers/API/V0_3/Webhooks/PaymentWebhookController.php
@@ -12,7 +12,7 @@ use Illuminate\Http\Request;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Log;
 
-class PaymentWebhookController extends Controller
+final class PaymentWebhookController extends Controller
 {
     public function __construct(
         private PaymentWebhookProcessor $processor,

--- a/backend/config/services.php
+++ b/backend/config/services.php
@@ -73,6 +73,13 @@ return [
         ],
     ],
 
+    'seo' => [
+        'tests_url_prefix' => env(
+            'SEO_TESTS_URL_PREFIX',
+            rtrim((string) env('APP_URL', 'http://localhost'), '/') . '/tests/'
+        ),
+    ],
+
     'integrations' => [
         'webhook_tolerance_seconds' => (int) env('INTEGRATIONS_WEBHOOK_TOLERANCE_SECONDS', 300),
         'allow_unsigned_without_secret' => (bool) env('INTEGRATIONS_WEBHOOK_ALLOW_UNSIGNED', false),

--- a/backend/tests/Feature/SEO/SitemapGeneratorTest.php
+++ b/backend/tests/Feature/SEO/SitemapGeneratorTest.php
@@ -13,7 +13,7 @@ class SitemapGeneratorTest extends TestCase
 
     public function test_generate_only_includes_public_global_scales(): void
     {
-        config(['app.url' => 'https://fermatmind.com']);
+        config(['services.seo.tests_url_prefix' => 'https://fermatmind.com/tests/']);
 
         $now = now();
 
@@ -85,12 +85,12 @@ class SitemapGeneratorTest extends TestCase
         $this->assertSame(['public-global', 'public-global-alt'], $slugList);
 
         $xml = (string) ($payload['xml'] ?? '');
-        $baseUrl = rtrim((string) config('app.url'), '/');
-        $this->assertStringContainsString($baseUrl . '/tests/public-global', $xml);
-        $this->assertStringContainsString($baseUrl . '/tests/public-global-alt', $xml);
-        $this->assertStringNotContainsString($baseUrl . '/tests/private-global', $xml);
-        $this->assertStringNotContainsString($baseUrl . '/tests/private-global-alt', $xml);
-        $this->assertStringNotContainsString($baseUrl . '/tests/tenant-public', $xml);
-        $this->assertStringNotContainsString($baseUrl . '/tests/tenant-public-alt', $xml);
+        $prefix = rtrim((string) config('services.seo.tests_url_prefix'), '/') . '/';
+        $this->assertStringContainsString($prefix . 'public-global', $xml);
+        $this->assertStringContainsString($prefix . 'public-global-alt', $xml);
+        $this->assertStringNotContainsString($prefix . 'private-global', $xml);
+        $this->assertStringNotContainsString($prefix . 'private-global-alt', $xml);
+        $this->assertStringNotContainsString($prefix . 'tenant-public', $xml);
+        $this->assertStringNotContainsString($prefix . 'tenant-public-alt', $xml);
     }
 }

--- a/backend/tests/Feature/SEO/SitemapXmlTest.php
+++ b/backend/tests/Feature/SEO/SitemapXmlTest.php
@@ -13,7 +13,7 @@ class SitemapXmlTest extends TestCase
 
     public function test_sitemap_xml_is_cached_and_filtered(): void
     {
-        config(['app.url' => 'https://fermatmind.com']);
+        config(['services.seo.tests_url_prefix' => 'https://fermatmind.com/tests/']);
 
         $nowA = Carbon::create(2026, 1, 30, 10, 0, 0);
         $nowB = Carbon::create(2026, 1, 31, 12, 0, 0);
@@ -94,18 +94,18 @@ class SitemapXmlTest extends TestCase
         $response->assertHeaderMissing('Set-Cookie');
 
         $body = (string) $response->getContent();
-        $baseUrl = rtrim((string) config('app.url'), '/');
-        $this->assertStringContainsString('<loc>' . $baseUrl . '/tests/alpha</loc>', $body);
-        $this->assertStringContainsString('<loc>' . $baseUrl . '/tests/beta</loc>', $body);
-        $this->assertStringContainsString('<loc>' . $baseUrl . '/tests/gamma</loc>', $body);
-        $this->assertStringContainsString('<loc>' . $baseUrl . '/tests/delta</loc>', $body);
-        $this->assertStringNotContainsString('<loc>' . $baseUrl . '/tests/hidden</loc>', $body);
-        $this->assertStringNotContainsString('<loc>' . $baseUrl . '/tests/hidden-alt</loc>', $body);
+        $prefix = rtrim((string) config('services.seo.tests_url_prefix'), '/') . '/';
+        $this->assertStringContainsString('<loc>' . $prefix . 'alpha</loc>', $body);
+        $this->assertStringContainsString('<loc>' . $prefix . 'beta</loc>', $body);
+        $this->assertStringContainsString('<loc>' . $prefix . 'gamma</loc>', $body);
+        $this->assertStringContainsString('<loc>' . $prefix . 'delta</loc>', $body);
+        $this->assertStringNotContainsString('<loc>' . $prefix . 'hidden</loc>', $body);
+        $this->assertStringNotContainsString('<loc>' . $prefix . 'hidden-alt</loc>', $body);
         $this->assertStringContainsString('<changefreq>weekly</changefreq>', $body);
         $this->assertStringContainsString('<priority>0.7</priority>', $body);
         $this->assertStringContainsString('<lastmod>2026-01-30</lastmod>', $body);
         $this->assertStringContainsString('<lastmod>2026-01-31</lastmod>', $body);
-        $this->assertSame(1, substr_count($body, '<loc>' . $baseUrl . '/tests/alpha</loc>'));
+        $this->assertSame(1, substr_count($body, '<loc>' . $prefix . 'alpha</loc>'));
 
         $second = $this->withHeaders(['If-None-Match' => $etag])->get('/sitemap.xml');
         $second->assertStatus(304);

--- a/backend/tests/Feature/V0_3/PaymentWebhookRouteWiringTest.php
+++ b/backend/tests/Feature/V0_3/PaymentWebhookRouteWiringTest.php
@@ -29,8 +29,12 @@ class PaymentWebhookRouteWiringTest extends TestCase
             $this->assertStringNotContainsString('stub', $providerWhere);
         }
 
-        $response = $this->postJson('/api/v0.3/webhooks/payment/stub', []);
-        $this->assertNotSame(500, $response->getStatusCode());
-        $response->assertStatus(404);
+        $stubResponse = $this->postJson('/api/v0.3/webhooks/payment/stub', []);
+        $this->assertNotSame(500, $stubResponse->getStatusCode());
+        $stubResponse->assertStatus(404);
+
+        $stripeResponse = $this->postJson('/api/v0.3/webhooks/payment/stripe', []);
+        $this->assertNotSame(500, $stripeResponse->getStatusCode());
+        $stripeResponse->assertStatus(400);
     }
 }


### PR DESCRIPTION
## Summary
- 修复 v0.3 payment webhook 路由接线回归风险，避免上线因类接线问题触发 500。
- sitemap `<loc>` 前缀改为可配置：`SEO_TESTS_URL_PREFIX`，不再依赖代码硬编码。
- PR24 sitemap 校验脚本与 workflow 同步改为环境变量驱动，CI 输出稳定。
- 增加 `backend/.env` 泄露防线：仓库忽略 + CI gate。

## Changes

### A-2 Webhook 接线硬化
- `/backend/app/Http/Controllers/API/V0_3/Webhooks/PaymentWebhookController.php`
  - `PaymentWebhookController` 改为 `final class`。
- `/backend/tests/Feature/V0_3/PaymentWebhookRouteWiringTest.php`
  - 保留 route wiring 断言。
  - 新增 `stripe` 请求断言：不允许 500，空 payload 期望 400。

### A-1 Sitemap 前缀配置化
- `/backend/app/Services/SEO/SitemapGenerator.php`
  - 增加 `$urlPrefix` 和构造函数读取配置。
  - `<loc>` 改为使用 `services.seo.tests_url_prefix`。
- `/backend/config/services.php`
  - 新增 `seo.tests_url_prefix`，读取 `SEO_TESTS_URL_PREFIX`。
  - fallback：`APP_URL + /tests/`。
- `/backend/.env.example`
  - 新增 `SEO_TESTS_URL_PREFIX=http://localhost/tests/`。
- `/backend/tests/Feature/SEO/SitemapGeneratorTest.php`
- `/backend/tests/Feature/SEO/SitemapXmlTest.php`
  - 断言改为验证可配置前缀。

### A-1 CI 同步
- `/backend/scripts/pr24_verify_sitemap.sh`
  - 使用 `URL_PREFIX="${SEO_TESTS_URL_PREFIX:-https://fermatmind.com/tests/}"`。
  - 统一末尾 `/`。
  - `grep -F "<loc>${URL_PREFIX}pr24-"` 固定匹配。
  - 运行前清缓存，避免缓存导致前缀校验假阴性。
- `/.github/workflows/ci_verify_pr24_sitemap.yml`
  - 增加 env：`SEO_TESTS_URL_PREFIX: https://fermatmind.com/tests/`。

### A-3 backend/.env 防泄露
- `/.gitignore`
  - 新增 `/backend/.env`。
- `/.github/workflows/ci_pr56_workflow_composer_php84.yml`
  - checkout 后增加 gate：
    - `test ! -f backend/.env || (echo "::error::backend/.env must not exist in the repository"; exit 1)`
- 本地 `backend/.env` 已删除；分支中 `git ls-files backend/.env` 为空（未跟踪）。

## Verification
按固定顺序执行：
1. `php artisan route:list | rg "v0.3.webhooks.payment"`
2. `php artisan migrate --force`
3. `rg -n "DB::table\('fm_tokens'\)|fm_user_id" backend/app/Http/Middleware/FmTokenAuth.php`
4. `php artisan test --filter=PaymentWebhookRouteWiringTest --stop-on-failure`
5. `php artisan test --filter=SitemapGeneratorTest --stop-on-failure`
6. `php artisan test --filter=SitemapXmlTest --stop-on-failure`
7. `DB_DATABASE=/tmp/pr24-verify-<timestamp>.sqlite bash backend/scripts/pr24_verify_sitemap.sh`
8. `test ! -f backend/.env`
