### PR TITLE
fix(security): Pack B high - enforce org_id tenant isolation in ReportComposer and AppServiceProvider

### DIFF
--- a/backend/app/Console/Commands/FapValidateReport.php
+++ b/backend/app/Console/Commands/FapValidateReport.php
@@ -26,7 +26,9 @@ class FapValidateReport extends Command
             ->where('attempt_id', $attempt->id)
             ->firstOrFail();
 
-        $out = app(ReportComposer::class)->compose($attempt, [], $result);
+        $out = app(ReportComposer::class)->compose($attempt, [
+            'org_id' => (int) ($attempt->org_id ?? 0),
+        ], $result);
         $report = is_array($out) ? ($out['report'] ?? $out) : [];
 
         if (!is_array($report) || $report === []) {

--- a/backend/app/Http/Controllers/API/V0_2/ShareController.php
+++ b/backend/app/Http/Controllers/API/V0_2/ShareController.php
@@ -230,6 +230,7 @@ $event->anon_id = ($clickAnonId !== null && $clickAnonId !== '') ? $clickAnonId 
                 ];
 
                 $attempt = Attempt::query()->where('id', $attemptId)->firstOrFail();
+                $ctx['org_id'] = (int) ($attempt->org_id ?? 0);
                 $result = Result::query()
                     ->where('org_id', (int) $attempt->org_id)
                     ->where('attempt_id', $attempt->id)

--- a/backend/app/Jobs/GenerateReportJob.php
+++ b/backend/app/Jobs/GenerateReportJob.php
@@ -68,6 +68,7 @@ class GenerateReportJob implements ShouldQueue
 
         try {
             $res = $composer->compose($attempt, [
+                'org_id' => $orgId,
                 'defaultProfileVersion' => config('fap.profile_version', 'mbti32-v2.5'),
             ], $result);
 

--- a/backend/app/Services/Report/ReportGatekeeper.php
+++ b/backend/app/Services/Report/ReportGatekeeper.php
@@ -452,7 +452,9 @@ class ReportGatekeeper
     {
         try {
             if ($scaleCode === 'MBTI') {
-                $composed = $this->reportComposer->compose($attempt, [], $result);
+                $composed = $this->reportComposer->compose($attempt, [
+                    'org_id' => (int) ($attempt->org_id ?? 0),
+                ], $result);
                 if (!($composed['ok'] ?? false)) {
                     return [
                         'ok' => false,

--- a/backend/app/Services/Report/ReportSnapshotStore.php
+++ b/backend/app/Services/Report/ReportSnapshotStore.php
@@ -304,7 +304,9 @@ class ReportSnapshotStore
     private function buildReport(string $scaleCode, Attempt $attempt, Result $result): ?array
     {
         if ($scaleCode === 'MBTI') {
-            $composed = $this->reportComposer->compose($attempt, [], $result);
+            $composed = $this->reportComposer->compose($attempt, [
+                'org_id' => (int) ($attempt->org_id ?? 0),
+            ], $result);
             if (!($composed['ok'] ?? false)) {
                 return null;
             }

--- a/backend/tests/Feature/AppServiceProviderContentStoreIsolationTest.php
+++ b/backend/tests/Feature/AppServiceProviderContentStoreIsolationTest.php
@@ -1,0 +1,160 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature;
+
+use App\Models\Attempt;
+use App\Services\Content\ContentStore;
+use App\Support\OrgContext;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Str;
+use Tests\TestCase;
+
+final class AppServiceProviderContentStoreIsolationTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_content_store_attempt_lookup_scopes_by_request_attribute_org_id_and_ignores_input_org_id(): void
+    {
+        $attemptId = $this->seedCrossTenantAttempt(orgId: 999);
+
+        $request = Request::create('/api/v0.2/content-packs', 'GET', [
+            'attempt_id' => $attemptId,
+            'org_id' => 999,
+        ]);
+        $request->attributes->set('org_id', 1);
+
+        [$queries, $store] = $this->resolveStoreWithCapturedQueries($request);
+        $attemptQuery = $this->firstAttemptsQuery($queries);
+
+        $this->assertNotNull($attemptQuery);
+        $this->assertStringContainsString('org_id', strtolower((string) ($attemptQuery['sql'] ?? '')));
+
+        $orgBindings = $this->numericBindings($attemptQuery['bindings'] ?? []);
+        $this->assertContains(1, $orgBindings);
+        $this->assertNotContains(999, $orgBindings);
+
+        $highlights = $store->loadHighlights();
+        $this->assertSame('MBTI-CN-v0.2.2', (string) ($highlights['meta']['package'] ?? ''));
+        $this->assertNotSame('MBTI-CN-v0.2.1-TEST', (string) ($highlights['meta']['package'] ?? ''));
+    }
+
+    public function test_content_store_attempt_lookup_falls_back_to_org_context_when_request_attrs_missing(): void
+    {
+        $attemptId = $this->seedCrossTenantAttempt(orgId: 999);
+
+        $request = Request::create('/api/v0.2/content-packs', 'GET', [
+            'attempt_id' => $attemptId,
+            'org_id' => 999,
+        ]);
+
+        $orgContext = app(OrgContext::class);
+        $orgContext->set(1, null, 'public');
+        app()->instance(OrgContext::class, $orgContext);
+
+        [$queries, $store] = $this->resolveStoreWithCapturedQueries($request);
+        $attemptQuery = $this->firstAttemptsQuery($queries);
+
+        $this->assertNotNull($attemptQuery);
+        $this->assertStringContainsString('org_id', strtolower((string) ($attemptQuery['sql'] ?? '')));
+
+        $orgBindings = $this->numericBindings($attemptQuery['bindings'] ?? []);
+        $this->assertContains(1, $orgBindings);
+        $this->assertNotContains(999, $orgBindings);
+
+        $highlights = $store->loadHighlights();
+        $this->assertSame('MBTI-CN-v0.2.2', (string) ($highlights['meta']['package'] ?? ''));
+        $this->assertNotSame('MBTI-CN-v0.2.1-TEST', (string) ($highlights['meta']['package'] ?? ''));
+    }
+
+    private function seedCrossTenantAttempt(int $orgId): string
+    {
+        config()->set('content_packs.default_pack_id', 'MBTI.cn-mainland.zh-CN.v0.2.2');
+        config()->set('content_packs.default_dir_version', 'MBTI-CN-v0.2.2');
+        config()->set('content_packs.default_region', 'CN_MAINLAND');
+        config()->set('content_packs.default_locale', 'zh-CN');
+
+        $attemptId = (string) Str::uuid();
+
+        Attempt::create([
+            'id' => $attemptId,
+            'org_id' => $orgId,
+            'anon_id' => 'tenant_inject_anon',
+            'user_id' => '1001',
+            'scale_code' => 'MBTI',
+            'scale_version' => 'v0.3',
+            'region' => 'CN_MAINLAND',
+            'locale' => 'zh-CN',
+            'question_count' => 144,
+            'answers_summary_json' => ['seed' => true],
+            'client_platform' => 'test',
+            'client_version' => '1.0.0',
+            'channel' => 'test',
+            'started_at' => now(),
+            'submitted_at' => now(),
+            'pack_id' => 'MBTI.cn-mainland.zh-CN.v0.2.1-TEST',
+            'dir_version' => 'MBTI-CN-v0.2.1-TEST',
+            'content_package_version' => 'v0.2.1-TEST',
+            'scoring_spec_version' => '2026.01',
+        ]);
+
+        return $attemptId;
+    }
+
+    /**
+     * @return array{0:array<int,array{sql:string,bindings:array}>,1:ContentStore}
+     */
+    private function resolveStoreWithCapturedQueries(Request $request): array
+    {
+        $queries = [];
+        DB::listen(function ($query) use (&$queries): void {
+            $queries[] = [
+                'sql' => (string) ($query->sql ?? ''),
+                'bindings' => is_array($query->bindings ?? null) ? $query->bindings : [],
+            ];
+        });
+
+        $this->app->instance('request', $request);
+        $this->app->forgetInstance(ContentStore::class);
+
+        /** @var ContentStore $store */
+        $store = app(ContentStore::class);
+
+        return [$queries, $store];
+    }
+
+    /**
+     * @param array<int,array{sql:string,bindings:array}> $queries
+     * @return array{sql:string,bindings:array}|null
+     */
+    private function firstAttemptsQuery(array $queries): ?array
+    {
+        foreach ($queries as $query) {
+            $sql = strtolower((string) ($query['sql'] ?? ''));
+            if (str_contains($sql, 'from "attempts"') || str_contains($sql, 'from `attempts`')) {
+                return $query;
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * @param array<int,mixed> $bindings
+     * @return array<int,int>
+     */
+    private function numericBindings(array $bindings): array
+    {
+        $values = [];
+        foreach ($bindings as $binding) {
+            if (is_numeric($binding)) {
+                $values[] = (int) $binding;
+            }
+        }
+
+        return $values;
+    }
+}

--- a/backend/tests/Feature/ReportComposerTenantIsolationTest.php
+++ b/backend/tests/Feature/ReportComposerTenantIsolationTest.php
@@ -1,0 +1,127 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature;
+
+use App\Models\Attempt;
+use App\Models\Result;
+use App\Services\Report\ReportComposer;
+use App\Support\OrgContext;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Str;
+use Tests\TestCase;
+
+final class ReportComposerTenantIsolationTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_compose_returns_attempt_not_found_when_ctx_org_mismatches_attempt_org(): void
+    {
+        $attempt = $this->seedAttempt(orgId: 200);
+
+        $out = app(ReportComposer::class)->compose($attempt, [
+            'org_id' => 100,
+        ]);
+
+        $this->assertFalse((bool) ($out['ok'] ?? false));
+        $this->assertSame('ATTEMPT_NOT_FOUND', (string) ($out['error'] ?? ''));
+        $this->assertSame(404, (int) ($out['status'] ?? 0));
+    }
+
+    public function test_compose_returns_attempt_not_found_when_org_context_mismatches_attempt_org(): void
+    {
+        $attempt = $this->seedAttempt(orgId: 201);
+
+        $orgContext = app(OrgContext::class);
+        $orgContext->set(101, null, 'public');
+        app()->instance(OrgContext::class, $orgContext);
+
+        $out = app(ReportComposer::class)->compose($attempt, []);
+
+        $this->assertFalse((bool) ($out['ok'] ?? false));
+        $this->assertSame('ATTEMPT_NOT_FOUND', (string) ($out['error'] ?? ''));
+        $this->assertSame(404, (int) ($out['status'] ?? 0));
+    }
+
+    public function test_compose_returns_result_not_found_when_result_exists_only_in_other_org(): void
+    {
+        $attempt = $this->seedAttempt(orgId: 300);
+
+        $this->seedResult((string) $attempt->id, 301);
+
+        $out = app(ReportComposer::class)->compose($attempt, [
+            'org_id' => 300,
+        ]);
+
+        $this->assertFalse((bool) ($out['ok'] ?? false));
+        $this->assertSame('RESULT_NOT_FOUND', (string) ($out['error'] ?? ''));
+        $this->assertSame(404, (int) ($out['status'] ?? 0));
+    }
+
+    private function seedAttempt(int $orgId): Attempt
+    {
+        return Attempt::create([
+            'id' => (string) Str::uuid(),
+            'org_id' => $orgId,
+            'anon_id' => 'tenant_iso_anon_' . $orgId,
+            'user_id' => '1001',
+            'scale_code' => 'MBTI',
+            'scale_version' => 'v0.3',
+            'region' => 'CN_MAINLAND',
+            'locale' => 'zh-CN',
+            'question_count' => 144,
+            'answers_summary_json' => ['seed' => true],
+            'client_platform' => 'test',
+            'client_version' => '1.0.0',
+            'channel' => 'test',
+            'started_at' => now(),
+            'submitted_at' => now(),
+            'pack_id' => (string) config('content_packs.default_pack_id', 'MBTI.cn-mainland.zh-CN.v0.2.2'),
+            'dir_version' => (string) config('content_packs.default_dir_version', 'MBTI-CN-v0.2.2'),
+            'content_package_version' => 'v0.2.2',
+            'scoring_spec_version' => '2026.01',
+        ]);
+    }
+
+    private function seedResult(string $attemptId, int $orgId): void
+    {
+        Result::create([
+            'id' => (string) Str::uuid(),
+            'org_id' => $orgId,
+            'attempt_id' => $attemptId,
+            'scale_code' => 'MBTI',
+            'scale_version' => 'v0.3',
+            'type_code' => 'INTJ-A',
+            'scores_json' => [
+                'EI' => ['a' => 10, 'b' => 10, 'sum' => 0, 'total' => 20],
+                'SN' => ['a' => 10, 'b' => 10, 'sum' => 0, 'total' => 20],
+                'TF' => ['a' => 10, 'b' => 10, 'sum' => 0, 'total' => 20],
+                'JP' => ['a' => 10, 'b' => 10, 'sum' => 0, 'total' => 20],
+                'AT' => ['a' => 10, 'b' => 10, 'sum' => 0, 'total' => 20],
+            ],
+            'scores_pct' => [
+                'EI' => 50,
+                'SN' => 50,
+                'TF' => 50,
+                'JP' => 50,
+                'AT' => 50,
+            ],
+            'axis_states' => [
+                'EI' => 'clear',
+                'SN' => 'clear',
+                'TF' => 'clear',
+                'JP' => 'clear',
+                'AT' => 'clear',
+            ],
+            'profile_version' => 'mbti32-v2.5',
+            'content_package_version' => 'v0.2.2',
+            'pack_id' => (string) config('content_packs.default_pack_id', 'MBTI.cn-mainland.zh-CN.v0.2.2'),
+            'dir_version' => (string) config('content_packs.default_dir_version', 'MBTI-CN-v0.2.2'),
+            'scoring_spec_version' => '2026.01',
+            'report_engine_version' => 'v1.2',
+            'is_valid' => true,
+            'computed_at' => now(),
+        ]);
+    }
+}


### PR DESCRIPTION
## Summary

Pack B（High）租户隔离修复，单闭环提交，重点修复两处跨租户注入点：

1. `ReportComposer` 不再仅凭 `attempt_id` 读取 Attempt/Result，统一收口到服务端 `org_id`。
2. `AppServiceProvider` 不再用 request 的 `attempt_id` 直接查 Attempt，改为 `id + org_id` 约束，且 `org_id` 仅来自服务端上下文（request attributes / OrgContext）。

## Key Changes

### 1) ReportComposer 强制 org 作用域
- 文件：`backend/app/Services/Report/ReportComposer.php`
- `compose()` 开头改为：
  - 从服务端上下文解析 `org_id`（`ctx['org_id']` 或 `OrgContext::orgId()`）
  - Attempt 查询：`where('id', $attemptId)->where('org_id', $orgId)`
  - Result 查询：`where('attempt_id', $attemptId)->where('org_id', $orgId)`
- 查不到时返回稳定错误契约（不抛异常）：
  - `ATTEMPT_NOT_FOUND` + `status: 404`
  - `RESULT_NOT_FOUND` + `status: 404`
- 新增私有方法：`resolveServerOrgId(array $ctx): int`

### 2) AppServiceProvider 修复 request 注入点
- 文件：`backend/app/Providers/AppServiceProvider.php`
- `ContentStore` singleton 内：
  - `org_id` 仅从服务端上下文获取：
    - request attributes `org_id` / `fm_org_id`
    - 或 `OrgContext::orgId()`
  - Attempt 查询改为：
    - `Attempt::query()->where('id', $attemptId)->where('org_id', $orgId)->first()`
- 查不到 Attempt 保持 fallback，不中断主流程（继续走默认 pack 解析）。

### 3) compose 调用点补齐服务端 org_id
- `backend/app/Jobs/GenerateReportJob.php`
- `backend/app/Services/Report/ReportGatekeeper.php`
- `backend/app/Services/Report/ReportSnapshotStore.php`
- `backend/app/Console/Commands/FapValidateReport.php`
- `backend/app/Http/Controllers/API/V0_2/ShareController.php`

以上调用点统一传入 `ctx['org_id']`（来源为服务端）。

### 4) 新增安全回归测试
- `backend/tests/Feature/ReportComposerTenantIsolationTest.php`
  - 覆盖跨租户 compose 的 404 语义（ATTEMPT_NOT_FOUND / RESULT_NOT_FOUND）
- `backend/tests/Feature/AppServiceProviderContentStoreIsolationTest.php`
  - 断言 attempts 查询包含 `org_id` 约束
  - 断言 org 来源为 request attributes / OrgContext，而非客户端注入 `org_id`
  - 断言跨租户 attempt 注入时回退到默认 pack

## Validation

已执行并通过：

- `php artisan route:list`
- `php artisan migrate`
- `php artisan test --filter=ShareClickSecurityTest --testsuite=Feature`
- `php artisan test --filter=ReportComposerTenantIsolationTest --testsuite=Feature`
- `php artisan test --filter=AppServiceProviderContentStoreIsolationTest --testsuite=Feature`
- `php artisan test --testsuite=Feature`（164 passed）
- `bash backend/scripts/ci_verify_mbti.sh`（全链路通过）

## Security Outcome

- 跨租户 `attempt_id` 无法通过 `ReportComposer` 读取他租户 Attempt/Result。
- `AppServiceProvider` 的 content/pack 解析无法被跨租户 `attempt_id` 注入污染。
- 报告与内容选择路径均完成 `where('org_id', $orgId)` 收口。
