### PR TITLE
fix(v0.3): align payment webhook controller contract

### DIFF
--- a/backend/tests/Feature/V0_3/PaymentWebhookFailSafeTest.php
+++ b/backend/tests/Feature/V0_3/PaymentWebhookFailSafeTest.php
@@ -51,7 +51,7 @@ class PaymentWebhookFailSafeTest extends TestCase
         $response->assertStatus(400);
         $response->assertJson([
             'ok' => false,
-            'error_code' => 'INVALID_JSON',
+            'error_code' => 'INVALID_PAYLOAD',
         ]);
     }
 }


### PR DESCRIPTION
## Summary
- Align `/api/v0.3/webhooks/payment/{provider}` controller behavior with v0.3 contract.
- Normalize controller-level errors to `ok/error_code/message/details`.
- Parse `org_id` from `X-Org-Id` (fallback `0`), and include `payloadMeta` (`size_bytes`/`sha256`/`headers`) before calling processor.
- Switch invalid JSON contract from `INVALID_JSON` to `INVALID_PAYLOAD` in fail-safe assertion.

## Scope
- No route path changes.
- No migrations.
- No `FmTokenAuth` changes.
- No CI script changes.

## Validation
- `php artisan route:list`
- `php artisan migrate`
- `php artisan test --filter=PaymentWebhookControllerTest`
- `php artisan test --filter=BillingWebhookSignatureTest`
- `php artisan test --filter=PaymentWebhookRouteWiringTest`
- `php artisan test --filter=PaymentWebhookFailSafeTest`
- `php artisan test --filter=PaymentWebhookStripeSignatureTest`
- `php artisan test --filter=BillingWebhookMisconfiguredSecretTest`
- `bash backend/scripts/ci_verify_mbti.sh`

## Manual Checks
- `POST /api/v0.3/webhooks/payment/stripe` without signature => `400` + `INVALID_SIGNATURE`
- `POST /api/v0.3/webhooks/payment/stub` => `404`
