### PR TITLE
chore(security): harden backend env leak guardrails

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -7,3 +7,5 @@
 backend/app/Http/Controllers/** -export-ignore
 backend/routes/** -export-ignore
 content_packages/** -export-ignore
+backend/.env export-ignore
+backend/.env.* export-ignore

--- a/.github/workflows/ci_dlq_replay_metrics.yml
+++ b/.github/workflows/ci_dlq_replay_metrics.yml
@@ -29,6 +29,9 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      - name: CAE gate (config + artifact safety)
+        run: bash backend/scripts/cae_gate.sh
+
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:

--- a/.github/workflows/ci_pr55_migration_observability.yml
+++ b/.github/workflows/ci_pr55_migration_observability.yml
@@ -28,6 +28,9 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      - name: CAE gate (config + artifact safety)
+        run: bash backend/scripts/cae_gate.sh
+
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:

--- a/.github/workflows/ci_pr56_workflow_composer_php84.yml
+++ b/.github/workflows/ci_pr56_workflow_composer_php84.yml
@@ -48,6 +48,9 @@ jobs:
         run: |
           test ! -f backend/.env || (echo "::error::backend/.env must not exist in the repository"; exit 1)
 
+      - name: CAE gate (config + artifact safety)
+        run: bash backend/scripts/cae_gate.sh
+
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:

--- a/.github/workflows/ci_verify_commerce_v2.yml
+++ b/.github/workflows/ci_verify_commerce_v2.yml
@@ -49,6 +49,9 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      - name: CAE gate (config + artifact safety)
+        run: bash backend/scripts/cae_gate.sh
+
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:

--- a/.github/workflows/ci_verify_pr20_report_paywall.yml
+++ b/.github/workflows/ci_verify_pr20_report_paywall.yml
@@ -47,6 +47,9 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      - name: CAE gate (config + artifact safety)
+        run: bash backend/scripts/cae_gate.sh
+
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:

--- a/.github/workflows/ci_verify_pr21_answer_storage.yml
+++ b/.github/workflows/ci_verify_pr21_answer_storage.yml
@@ -30,6 +30,9 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      - name: CAE gate (config + artifact safety)
+        run: bash backend/scripts/cae_gate.sh
+
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:

--- a/.github/workflows/ci_verify_pr22_boot_v0_4.yml
+++ b/.github/workflows/ci_verify_pr22_boot_v0_4.yml
@@ -35,6 +35,9 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      - name: CAE gate (config + artifact safety)
+        run: bash backend/scripts/cae_gate.sh
+
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:

--- a/.github/workflows/ci_verify_pr23_feature_flags_sticky_experiments.yml
+++ b/.github/workflows/ci_verify_pr23_feature_flags_sticky_experiments.yml
@@ -35,6 +35,9 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      - name: CAE gate (config + artifact safety)
+        run: bash backend/scripts/cae_gate.sh
+
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:

--- a/.github/workflows/ci_verify_pr24_sitemap.yml
+++ b/.github/workflows/ci_verify_pr24_sitemap.yml
@@ -39,6 +39,9 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      - name: CAE gate (config + artifact safety)
+        run: bash backend/scripts/cae_gate.sh
+
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:

--- a/.github/workflows/ci_verify_pr25_b2b_assessments_progress_rbac.yml
+++ b/.github/workflows/ci_verify_pr25_b2b_assessments_progress_rbac.yml
@@ -36,6 +36,9 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      - name: CAE gate (config + artifact safety)
+        run: bash backend/scripts/cae_gate.sh
+
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:

--- a/.github/workflows/ci_verify_scales_registry.yml
+++ b/.github/workflows/ci_verify_scales_registry.yml
@@ -16,6 +16,9 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      - name: CAE gate (config + artifact safety)
+        run: bash backend/scripts/cae_gate.sh
+
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:

--- a/.github/workflows/ci_verify_v0_3_assessment_engine.yml
+++ b/.github/workflows/ci_verify_v0_3_assessment_engine.yml
@@ -36,6 +36,9 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      - name: CAE gate (config + artifact safety)
+        run: bash backend/scripts/cae_gate.sh
+
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -53,6 +53,9 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
+      - name: CAE gate (config + artifact safety)
+        run: bash backend/scripts/cae_gate.sh
+
       - name: Resolve target vars
         shell: bash
         run: |

--- a/.github/workflows/rollback-content.yml
+++ b/.github/workflows/rollback-content.yml
@@ -54,6 +54,12 @@ jobs:
     environment: ${{ inputs.target_env }}
 
     steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: CAE gate (config + artifact safety)
+        run: bash backend/scripts/cae_gate.sh
+
       - name: Rollback via API
         id: rollback
         env:

--- a/.github/workflows/rollback-production.yml
+++ b/.github/workflows/rollback-production.yml
@@ -34,6 +34,9 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
+      - name: CAE gate (config + artifact safety)
+        run: bash backend/scripts/cae_gate.sh
+
       - name: Set up SSH
         uses: webfactory/ssh-agent@v0.9.0
         with:

--- a/backend/README.md
+++ b/backend/README.md
@@ -127,6 +127,32 @@ echo "EXIT=$?"
 
 ---
 
+## F. 本地 pre-commit 安全门禁（阻断 backend/.env）
+
+在仓库根目录执行：
+
+```bash
+cd /Users/rainie/Desktop/GitHub/fap-api
+chmod +x backend/scripts/pre_commit_env_guard.sh
+cat > .git/hooks/pre-commit <<'HOOK'
+#!/usr/bin/env bash
+set -euo pipefail
+bash backend/scripts/pre_commit_env_guard.sh
+HOOK
+chmod +x .git/hooks/pre-commit
+```
+
+手工验证：
+
+```bash
+cd /Users/rainie/Desktop/GitHub/fap-api
+bash backend/scripts/pre_commit_env_guard.sh
+```
+
+说明：执行 `bash backend/scripts/ci_verify_mbti.sh` 或部分本地 artisan 命令后，可能生成 `backend/.env`；提交前执行 `rm -f backend/.env`。
+
+---
+
 ## 常见问题
 
 ### 1) `Usage: ./scripts/accept_overrides_D.sh <ATTEMPT_ID>`

--- a/backend/docs/runbooks/secret-rotation.md
+++ b/backend/docs/runbooks/secret-rotation.md
@@ -1,0 +1,31 @@
+# Secret Rotation Runbook (backend/.env Exposure)
+
+## 1. 事件触发与目标
+触发条件：发现 `backend/.env` 被纳入产物或疑似泄露。
+目标：在最短时间内完成密钥轮换、部署收口、可审计留痕。
+
+## 2. 立即遏制（T+0）
+- [ ] 冻结发布窗口（暂停 deploy/publish/rollback 手工触发）。
+- [ ] 删除工作区 `backend/.env`，确认不再进入归档/产物。
+- [ ] 触发全量 CI，确认 `cae_gate.sh` 通过。
+- [ ] 排查泄露面：仓库快照、CI artifacts、对象存储、聊天工具、工单附件。
+
+## 3. 强制轮换清单（必须全部完成）
+- [ ] APP_KEY：在 Secrets Manager 生成新值，更新运行环境后滚动重启；评估并记录对历史加密数据/会话的影响。
+- [ ] Stripe webhook secret / Billing webhook secret：在 Stripe/Billing 控制台重新签发，更新环境变量并验证 webhook 签名通过。
+- [ ] DB 密码：重置应用账号密码，更新连接串并验证读写；旧密码立即失效。
+- [ ] Redis 密码：重置 Redis ACL/密码，更新客户端连接串并验证队列/缓存恢复。
+- [ ] 任意第三方 Token（短信、邮件、对象存储、监控、支付扩展等）：逐项吊销旧 token 并替换为新 token。
+
+## 4. 发布流程收口动作
+- [ ] 先在 staging 注入新密钥并部署，完成 healthcheck 与核心接口冒烟。
+- [ ] staging 验证通过后再生产发布，执行同样冒烟。
+- [ ] 清理配置缓存与重启队列工作进程，确保新密钥生效。
+- [ ] 回看最近 24h 认证/支付/队列错误率，确认无异常抬升。
+- [ ] 将本次轮换编号、执行人、时间戳、验证结果写入变更记录。
+
+## 5. 完成判定（Exit Criteria）
+- [ ] `backend/.env` 不存在于 workspace、Git 跟踪、归档产物。
+- [ ] 所有 workflow 都包含并通过 `bash backend/scripts/cae_gate.sh`。
+- [ ] 受影响密钥全部轮换并完成功能验证。
+- [ ] 形成书面复盘与审计证据（命令输出、CI 链接、发布记录）。

--- a/backend/scripts/pre_commit_env_guard.sh
+++ b/backend/scripts/pre_commit_env_guard.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_DIR="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+cd "${REPO_DIR}"
+
+if [ -f "backend/.env" ]; then
+  echo "[ENV_GUARD][FAIL] backend/.env exists in workspace; remove it before commit." >&2
+  exit 1
+fi
+
+tracked_env_hits="$(
+  git ls-files \
+    | grep -E '^backend/\.env(\.[^/]+)?$' \
+    | grep -vE '^backend/\.env\.example$' \
+    || true
+)"
+if [ -n "${tracked_env_hits}" ]; then
+  echo "[ENV_GUARD][FAIL] tracked backend .env files detected:" >&2
+  echo "${tracked_env_hits}" >&2
+  exit 1
+fi
+
+echo "[ENV_GUARD] PASS"


### PR DESCRIPTION
## Summary
- remove `backend/.env` from workspace and enforce archive-level exclusion via `.gitattributes`
- add explicit `CAE gate (config + artifact safety)` step to workflows missing `bash backend/scripts/cae_gate.sh`
- add local pre-commit env guard script and document hook setup in `backend/README.md`
- add runbook for mandatory secret rotation and release containment: `backend/docs/runbooks/secret-rotation.md`

## Scope
- no API/DB/business logic changes
- security/process hardening only

## Files
### Added
- `backend/scripts/pre_commit_env_guard.sh`
- `backend/docs/runbooks/secret-rotation.md`

### Modified
- `.gitattributes`
- `backend/README.md`
- `.github/workflows/ci_dlq_replay_metrics.yml`
- `.github/workflows/ci_pr55_migration_observability.yml`
- `.github/workflows/ci_pr56_workflow_composer_php84.yml`
- `.github/workflows/ci_verify_commerce_v2.yml`
- `.github/workflows/ci_verify_pr20_report_paywall.yml`
- `.github/workflows/ci_verify_pr21_answer_storage.yml`
- `.github/workflows/ci_verify_pr22_boot_v0_4.yml`
- `.github/workflows/ci_verify_pr23_feature_flags_sticky_experiments.yml`
- `.github/workflows/ci_verify_pr24_sitemap.yml`
- `.github/workflows/ci_verify_pr25_b2b_assessments_progress_rbac.yml`
- `.github/workflows/ci_verify_scales_registry.yml`
- `.github/workflows/ci_verify_v0_3_assessment_engine.yml`
- `.github/workflows/deploy.yml`
- `.github/workflows/rollback-content.yml`
- `.github/workflows/rollback-production.yml`

## Validation
- `php artisan route:list`
- `APP_ENV=local DB_CONNECTION=sqlite DB_DATABASE=/tmp/fap-h03.sqlite php artisan migrate --force`
- `curl -fsS http://127.0.0.1:18080/api/v0.2/health`
- `curl -fsS http://127.0.0.1:18080/api/v0.2/content-packs`
- `bash backend/scripts/cae_gate.sh`
- `bash backend/scripts/ci_verify_mbti.sh`
- `test -f backend/.env` (expects non-zero)
- `git -c core.attributesfile=.gitattributes archive --format=tar HEAD | tar -tf -` check excludes `backend/.env*`

## Notes
- `ci_verify_mbti.sh` can generate `backend/.env` during local runs; this branch documents and enforces cleanup before commit.
- pre-commit guard explicitly excludes `backend/.env.example` from tracked-file checks.
