### PR TITLE
feat(v0.2): enforce attempt org isolation on lookup paths

### DIFF
--- a/backend/app/Http/Controllers/API/V0_2/MeController.php
+++ b/backend/app/Http/Controllers/API/V0_2/MeController.php
@@ -2,6 +2,7 @@
 
 namespace App\Http\Controllers\API\V0_2;
 
+use App\Http\Controllers\Concerns\ResolvesOrgId;
 use App\Http\Controllers\Controller;
 use App\Http\Requests\V0_2\BindEmailRequest;
 use App\Models\Attempt;
@@ -14,6 +15,8 @@ use Illuminate\Support\Facades\Schema;
 
 class MeController extends Controller
 {
+    use ResolvesOrgId;
+
     /**
      * GET /api/v0.2/me/attempts
      * Query:
@@ -43,8 +46,9 @@ class MeController extends Controller
         $perPage = (int) $request->query('per_page', 20);
         if ($perPage <= 0) $perPage = 20;
         if ($perPage > 50) $perPage = 50;
+        $orgId = $this->resolveOrgId($request);
 
-        $q = Attempt::query();
+        $q = Attempt::query()->where('org_id', $orgId);
 
         if ($userId !== null) {
             $q->where('user_id', $userId);

--- a/backend/app/Http/Controllers/API/V0_2/ValidityFeedbackController.php
+++ b/backend/app/Http/Controllers/API/V0_2/ValidityFeedbackController.php
@@ -3,6 +3,7 @@
 namespace App\Http\Controllers\API\V0_2;
 
 use App\Http\Controllers\Controller;
+use App\Http\Controllers\Concerns\ResolvesOrgId;
 use App\Models\Attempt;
 use Illuminate\Database\QueryException;
 use Illuminate\Http\JsonResponse;
@@ -13,6 +14,8 @@ use Illuminate\Support\Facades\Storage;
 
 class ValidityFeedbackController extends Controller
 {
+    use ResolvesOrgId;
+
     /**
      * POST /api/v0.2/attempts/{attempt_id}/feedback
      */
@@ -33,8 +36,12 @@ class ValidityFeedbackController extends Controller
             'free_text' => ['sometimes', 'string', 'max:200'],
         ]);
 
+        $orgId = $this->resolveOrgId($request);
+
         /** @var Attempt|null $attempt */
-        $attempt = Attempt::where('id', $attemptId)->first();
+        $attempt = Attempt::where('id', $attemptId)
+            ->where('org_id', $orgId)
+            ->first();
         if (!$attempt) {
             return response()->json([
                 'ok' => false,

--- a/backend/app/Http/Controllers/Concerns/ResolvesOrgId.php
+++ b/backend/app/Http/Controllers/Concerns/ResolvesOrgId.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace App\Http\Controllers\Concerns;
+
+use Illuminate\Http\Request;
+
+trait ResolvesOrgId
+{
+    protected function resolveOrgId(Request $request): int
+    {
+        $raw = trim((string) $request->header('X-Org-Id', ''));
+        if ($raw === '') {
+            $raw = trim((string) $request->query('org_id', ''));
+        }
+
+        if ($raw !== '' && preg_match('/^\d+$/', $raw)) {
+            return (int) $raw;
+        }
+
+        return 0;
+    }
+}

--- a/backend/tests/Feature/V0_2/AttemptOrgIsolationTest.php
+++ b/backend/tests/Feature/V0_2/AttemptOrgIsolationTest.php
@@ -1,0 +1,186 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\V0_2;
+
+use App\Models\Attempt;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Str;
+use Tests\TestCase;
+
+final class AttemptOrgIsolationTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_org0_attempt_is_readable_in_org0_and_me_attempts_is_scoped_to_org0(): void
+    {
+        $userId = '9101';
+        $anonId = 'anon_org0_owner';
+
+        $this->seedUser((int) $userId);
+        $token = $this->seedFmToken($anonId, (int) $userId);
+
+        $attemptOrg0 = $this->seedAttempt(
+            orgId: 0,
+            anonId: $anonId,
+            userId: $userId
+        );
+        $attemptOrg1 = $this->seedAttempt(
+            orgId: 1,
+            anonId: $anonId,
+            userId: $userId
+        );
+
+        $this->withHeaders([
+            'X-Anon-Id' => $anonId,
+        ])->getJson("/api/v0.2/attempts/{$attemptOrg0}/stats")
+            ->assertStatus(200)
+            ->assertJsonPath('ok', true)
+            ->assertJsonPath('attempt_id', $attemptOrg0);
+
+        $resp = $this->withHeaders([
+            'Authorization' => "Bearer {$token}",
+        ])->getJson('/api/v0.2/me/attempts');
+
+        $resp->assertStatus(200);
+        $resp->assertJsonPath('ok', true);
+
+        $ids = array_map(static fn (array $row): string => (string) ($row['attempt_id'] ?? ''), (array) $resp->json('items', []));
+
+        $this->assertContains($attemptOrg0, $ids);
+        $this->assertNotContains($attemptOrg1, $ids);
+    }
+
+    public function test_org1_attempt_returns_404_when_read_from_org0_and_200_in_org1(): void
+    {
+        $userId = '9201';
+        $anonId = 'anon_org1_owner';
+
+        $attemptId = $this->seedAttempt(
+            orgId: 1,
+            anonId: $anonId,
+            userId: $userId
+        );
+
+        $this->withHeaders([
+            'X-Org-Id' => '0',
+            'X-Anon-Id' => $anonId,
+        ])->getJson("/api/v0.2/attempts/{$attemptId}/stats")
+            ->assertStatus(404);
+
+        $this->withHeaders([
+            'X-Org-Id' => '1',
+            'X-Anon-Id' => $anonId,
+        ])->getJson("/api/v0.2/attempts/{$attemptId}/stats")
+            ->assertStatus(200)
+            ->assertJsonPath('ok', true)
+            ->assertJsonPath('attempt_id', $attemptId);
+    }
+
+    public function test_lookup_ticket_and_device_return_404_when_org_mismatched(): void
+    {
+        $userId = '9301';
+        $anonId = 'anon_lookup_owner';
+
+        $this->seedUser((int) $userId);
+        $token = $this->seedFmToken($anonId, (int) $userId);
+
+        $ticketCode = 'FMT-' . strtoupper(substr(str_replace('-', '', (string) Str::uuid()), 0, 8));
+        $attemptId = $this->seedAttempt(
+            orgId: 1,
+            anonId: $anonId,
+            userId: $userId,
+            ticketCode: $ticketCode
+        );
+
+        $this->withHeader('X-Org-Id', '0')
+            ->getJson("/api/v0.2/lookup/ticket/{$ticketCode}")
+            ->assertStatus(404);
+
+        $this->withHeader('X-Org-Id', '1')
+            ->getJson("/api/v0.2/lookup/ticket/{$ticketCode}")
+            ->assertStatus(200)
+            ->assertJsonPath('ok', true)
+            ->assertJsonPath('attempt_id', $attemptId);
+
+        $this->withHeaders([
+            'Authorization' => "Bearer {$token}",
+            'X-Org-Id' => '0',
+        ])->postJson('/api/v0.2/lookup/device', [
+            'attempt_ids' => [$attemptId],
+        ])->assertStatus(404);
+
+        $this->withHeaders([
+            'Authorization' => "Bearer {$token}",
+            'X-Org-Id' => '1',
+        ])->postJson('/api/v0.2/lookup/device', [
+            'attempt_ids' => [$attemptId],
+        ])->assertStatus(200)
+            ->assertJsonPath('ok', true)
+            ->assertJsonPath('items.0.attempt_id', $attemptId);
+    }
+
+    private function seedAttempt(int $orgId, string $anonId, string $userId, ?string $ticketCode = null): string
+    {
+        $attemptId = (string) Str::uuid();
+
+        Attempt::create([
+            'id' => $attemptId,
+            'ticket_code' => $ticketCode,
+            'org_id' => $orgId,
+            'anon_id' => $anonId,
+            'user_id' => $userId,
+            'scale_code' => 'MBTI',
+            'scale_version' => 'v0.2',
+            'region' => 'CN_MAINLAND',
+            'locale' => 'zh-CN',
+            'question_count' => 144,
+            'answers_summary_json' => ['seed' => true],
+            'client_platform' => 'test',
+            'client_version' => '1.0.0',
+            'channel' => 'test',
+            'started_at' => now()->subMinutes(2),
+            'submitted_at' => now()->subMinute(),
+            'pack_id' => (string) config('content_packs.default_pack_id'),
+            'dir_version' => (string) config('content_packs.default_dir_version'),
+            'content_package_version' => 'v0.2.2',
+            'scoring_spec_version' => '2026.01',
+            'calculation_snapshot_json' => [
+                'stats' => ['score' => 42],
+                'norm' => ['version' => 'test'],
+            ],
+        ]);
+
+        return $attemptId;
+    }
+
+    private function seedUser(int $id): void
+    {
+        DB::table('users')->insert([
+            'id' => $id,
+            'name' => "user_{$id}",
+            'email' => "user_{$id}@example.test",
+            'password' => bcrypt('secret'),
+            'created_at' => now(),
+            'updated_at' => now(),
+        ]);
+    }
+
+    private function seedFmToken(string $anonId, int $userId): string
+    {
+        $token = 'fm_' . (string) Str::uuid();
+
+        DB::table('fm_tokens')->insert([
+            'token' => $token,
+            'anon_id' => $anonId,
+            'user_id' => $userId,
+            'expires_at' => now()->addHour(),
+            'created_at' => now(),
+            'updated_at' => now(),
+        ]);
+
+        return $token;
+    }
+}


### PR DESCRIPTION
## Summary
- Add shared org resolver trait for v0.2 controllers: `X-Org-Id` -> query `org_id` -> default `0`.
- Enforce `org_id` scoping on attempt-locating queries in `PsychometricsController`, `ValidityFeedbackController`, `MeController`, and `LookupController`.
- Close cross-org resource existence side-channel by returning `404` on org mismatch.
- Harden `POST /api/v0.2/lookup/device` with `any miss => 404` behavior.
- Add `AttemptOrgIsolationTest` to cover org0 compatibility and cross-org denial paths.

## Changes
- Added `backend/app/Http/Controllers/Concerns/ResolvesOrgId.php`
- Added `backend/tests/Feature/V0_2/AttemptOrgIsolationTest.php`
- Updated v0.2 attempt/ticket/device lookup query chains to include `where('org_id', $orgId)`.

## Validation
- `php artisan route:list | rg "v0.2/(attempts/.*/(stats|quality)|lookup/(ticket|device)|me/attempts)"`
- `php artisan migrate` (nothing to migrate)
- `php artisan test --filter=AttemptOrgIsolationTest`
- `bash backend/scripts/ci_verify_mbti.sh`
