### PR TITLE
feat(api): unify high-frequency error contract to error_code

### DIFF
--- a/backend/app/Http/Controllers/API/V0_2/ValidityFeedbackController.php
+++ b/backend/app/Http/Controllers/API/V0_2/ValidityFeedbackController.php
@@ -25,7 +25,8 @@ class ValidityFeedbackController extends Controller
         if (!$enabled) {
             return response()->json([
                 'ok' => false,
-                'error' => 'NOT_ENABLED',
+                'error_code' => 'NOT_ENABLED',
+                'message' => 'feedback is disabled.',
             ], 200);
         }
 
@@ -45,7 +46,8 @@ class ValidityFeedbackController extends Controller
         if (!$attempt) {
             return response()->json([
                 'ok' => false,
-                'error' => 'NOT_FOUND',
+                'error_code' => 'NOT_FOUND',
+                'message' => 'attempt not found.',
             ], 404);
         }
 
@@ -146,7 +148,8 @@ class ValidityFeedbackController extends Controller
     {
         return response()->json([
             'ok' => false,
-            'error' => 'FORBIDDEN',
+            'error_code' => 'FORBIDDEN',
+            'message' => 'forbidden.',
         ], 403);
     }
 

--- a/backend/app/Http/Controllers/API/V0_3/AttemptReadController.php
+++ b/backend/app/Http/Controllers/API/V0_3/AttemptReadController.php
@@ -106,7 +106,7 @@ class AttemptReadController extends Controller
         if (!($gate['ok'] ?? false)) {
             $status = (int) ($gate['status'] ?? 0);
             if ($status <= 0) {
-                $error = strtoupper((string) ($gate['error'] ?? 'REPORT_FAILED'));
+                $error = strtoupper((string) data_get($gate, 'error_code', data_get($gate, 'error', 'REPORT_FAILED')));
                 $status = match ($error) {
                     'ATTEMPT_REQUIRED', 'SCALE_REQUIRED' => 400,
                     'ATTEMPT_NOT_FOUND', 'RESULT_NOT_FOUND', 'SCALE_NOT_FOUND' => 404,

--- a/backend/app/Http/Controllers/API/V0_3/AttemptWriteController.php
+++ b/backend/app/Http/Controllers/API/V0_3/AttemptWriteController.php
@@ -457,7 +457,7 @@ class AttemptWriteController extends Controller
                     Log::warning('SUBMIT_POST_COMMIT_B2B_CREDIT_CONSUME_FAILED', [
                         'org_id' => $orgId,
                         'attempt_id' => $attemptId,
-                        'error' => $consume['error'] ?? 'CREDITS_CONSUME_FAILED',
+                        'error_code' => (string) data_get($consume, 'error_code', data_get($consume, 'error', 'CREDITS_CONSUME_FAILED')),
                         'message' => $consume['message'] ?? 'credits consume failed.',
                     ]);
                 }
@@ -495,7 +495,7 @@ class AttemptWriteController extends Controller
                         'org_id' => $orgId,
                         'attempt_id' => $attemptId,
                         'benefit_code' => $creditBenefitCode,
-                        'error' => $consume['error'] ?? 'INSUFFICIENT_CREDITS',
+                        'error_code' => (string) data_get($consume, 'error_code', data_get($consume, 'error', 'INSUFFICIENT_CREDITS')),
                         'message' => $consume['message'] ?? 'insufficient credits.',
                     ]);
                 }
@@ -529,7 +529,7 @@ class AttemptWriteController extends Controller
                         'org_id' => $orgId,
                         'attempt_id' => $attemptId,
                         'benefit_code' => $entitlementBenefitCode,
-                        'error' => $grant['error'] ?? 'ENTITLEMENT_GRANT_FAILED',
+                        'error_code' => (string) data_get($grant, 'error_code', data_get($grant, 'error', 'ENTITLEMENT_GRANT_FAILED')),
                         'message' => $grant['message'] ?? 'entitlement grant failed.',
                     ]);
                 }

--- a/backend/app/Http/Controllers/API/V0_3/CommerceController.php
+++ b/backend/app/Http/Controllers/API/V0_3/CommerceController.php
@@ -86,7 +86,7 @@ class CommerceController extends Controller
         );
 
         if (!($result['ok'] ?? false)) {
-            $status = $this->mapErrorStatus((string) ($result['error'] ?? ''));
+            $status = $this->mapErrorStatus((string) data_get($result, 'error_code', data_get($result, 'error', '')));
             $message = trim((string) ($result['message'] ?? ''));
             abort($status, $message !== '' ? $message : 'request failed.');
         }
@@ -107,7 +107,7 @@ class CommerceController extends Controller
         $anonId = $this->resolveAnonId($request);
         $result = $this->orders->getOrder($orgId, $userId !== null ? (string) $userId : null, $anonId, $order_no);
         if (!($result['ok'] ?? false)) {
-            $status = $this->mapErrorStatus((string) ($result['error'] ?? ''));
+            $status = $this->mapErrorStatus((string) data_get($result, 'error_code', data_get($result, 'error', '')));
             $message = trim((string) ($result['message'] ?? ''));
             abort($status, $message !== '' ? $message : 'request failed.');
         }

--- a/backend/app/Http/Controllers/LookupController.php
+++ b/backend/app/Http/Controllers/LookupController.php
@@ -32,7 +32,7 @@ class LookupController extends Controller
             ]);
             return response()->json([
                 'ok' => false,
-                'error' => 'RATE_LIMITED',
+                'error_code' => 'RATE_LIMITED',
                 'message' => 'Too many requests from this IP.',
             ], 429);
         }
@@ -47,7 +47,7 @@ class LookupController extends Controller
             ]);
             return response()->json([
                 'ok' => false,
-                'error' => 'invalid_format',
+                'error_code' => 'INVALID_FORMAT',
                 'message' => 'ticket_code format invalid (expected FMT-XXXXXXXX).',
             ], 422);
         }
@@ -66,7 +66,7 @@ class LookupController extends Controller
             ]);
             return response()->json([
                 'ok' => false,
-                'error' => 'not_found',
+                'error_code' => 'NOT_FOUND',
                 'message' => 'ticket_code not found.',
             ], 404);
         }
@@ -105,7 +105,7 @@ class LookupController extends Controller
             ]);
             return response()->json([
                 'ok' => false,
-                'error' => 'RATE_LIMITED',
+                'error_code' => 'RATE_LIMITED',
                 'message' => 'Too many requests from this IP.',
             ], 429);
         }
@@ -118,7 +118,7 @@ class LookupController extends Controller
             ]);
             return response()->json([
                 'ok' => false,
-                'error' => 'invalid_payload',
+                'error_code' => 'INVALID_PAYLOAD',
                 'message' => 'attempt_ids must be an array.',
             ], 422);
         }
@@ -153,7 +153,7 @@ class LookupController extends Controller
                 ]);
                 return response()->json([
                     'ok' => false,
-                    'error' => 'invalid_id',
+                    'error_code' => 'INVALID_ID',
                     'message' => 'attempt_ids contains invalid uuid.',
                 ], 422);
             }
@@ -184,7 +184,7 @@ class LookupController extends Controller
 
             return response()->json([
                 'ok' => false,
-                'error' => 'not_found',
+                'error_code' => 'NOT_FOUND',
                 'message' => 'attempt not found.',
             ], 404);
         }
@@ -229,7 +229,7 @@ class LookupController extends Controller
             ]);
             return response()->json([
                 'ok' => false,
-                'error' => 'RATE_LIMITED',
+                'error_code' => 'RATE_LIMITED',
                 'message' => 'Too many requests from this IP.',
             ], 429);
         }
@@ -240,7 +240,7 @@ class LookupController extends Controller
             ]);
             return response()->json([
                 'ok' => false,
-                'error' => 'NOT_ENABLED',
+                'error_code' => 'NOT_ENABLED',
                 'message' => 'lookup/order disabled.',
             ]);
         }
@@ -252,7 +252,7 @@ class LookupController extends Controller
             ]);
             return response()->json([
                 'ok' => false,
-                'error' => 'INVALID_ORDER',
+                'error_code' => 'INVALID_ORDER',
                 'message' => 'order_no is required.',
             ], 422);
         }
@@ -264,7 +264,7 @@ class LookupController extends Controller
             ]);
             return response()->json([
                 'ok' => false,
-                'error' => 'NOT_SUPPORTED',
+                'error_code' => 'NOT_SUPPORTED',
                 'message' => 'order lookup not supported.',
             ]);
         }
@@ -277,7 +277,7 @@ class LookupController extends Controller
             ]);
             return response()->json([
                 'ok' => false,
-                'error' => 'NOT_SUPPORTED',
+                'error_code' => 'NOT_SUPPORTED',
                 'message' => 'order lookup not supported.',
             ]);
         }
@@ -290,7 +290,7 @@ class LookupController extends Controller
             ]);
             return response()->json([
                 'ok' => false,
-                'error' => 'NOT_FOUND',
+                'error_code' => 'NOT_FOUND',
                 'message' => 'order not found.',
             ], 404);
         }
@@ -386,7 +386,7 @@ class LookupController extends Controller
         if (!$userId && !$anonId) {
             return response()->json([
                 'ok' => false,
-                'error' => 'UNAUTHORIZED',
+                'error_code' => 'UNAUTHORIZED',
                 'message' => 'missing identity on request (user_id/anon_id).',
             ], 401);
         }

--- a/backend/app/Services/Payments/PaymentService.php
+++ b/backend/app/Services/Payments/PaymentService.php
@@ -190,7 +190,7 @@ class PaymentService
             return [
                 'ok' => false,
                 'status' => 422,
-                'error' => 'MISSING_USER',
+                'error_code' => 'MISSING_USER',
                 'message' => 'missing user id for benefit grant.',
             ];
         }
@@ -249,7 +249,7 @@ class PaymentService
             return [
                 'ok' => false,
                 'status' => 422,
-                'error' => 'INVALID_USER',
+                'error_code' => 'INVALID_USER',
                 'message' => 'user id missing.',
             ];
         }
@@ -331,7 +331,7 @@ class PaymentService
                 return [
                     'ok' => false,
                     'status' => 404,
-                    'error' => 'ORDER_NOT_FOUND',
+                    'error_code' => 'ORDER_NOT_FOUND',
                     'message' => 'order not found.',
                 ];
             }
@@ -477,47 +477,47 @@ class PaymentService
         return [
             'ok' => false,
             'status' => 500,
-            'error' => 'TABLE_MISSING',
+            'error_code' => 'TABLE_MISSING',
             'message' => "{$table} table missing.",
         ];
     }
 
-    private function notFound(string $error, string $message): array
+    private function notFound(string $errorCode, string $message): array
     {
         return [
             'ok' => false,
             'status' => 404,
-            'error' => $error,
+            'error_code' => $errorCode,
             'message' => $message,
         ];
     }
 
-    private function forbidden(string $error, string $message): array
+    private function forbidden(string $errorCode, string $message): array
     {
         return [
             'ok' => false,
             'status' => 403,
-            'error' => $error,
+            'error_code' => $errorCode,
             'message' => $message,
         ];
     }
 
-    private function conflict(string $error, string $message): array
+    private function conflict(string $errorCode, string $message): array
     {
         return [
             'ok' => false,
             'status' => 409,
-            'error' => $error,
+            'error_code' => $errorCode,
             'message' => $message,
         ];
     }
 
-    private function invalid(string $error, string $message): array
+    private function invalid(string $errorCode, string $message): array
     {
         return [
             'ok' => false,
             'status' => 422,
-            'error' => $error,
+            'error_code' => $errorCode,
             'message' => $message,
         ];
     }

--- a/backend/tests/Feature/ErrorContractConsistencyTest.php
+++ b/backend/tests/Feature/ErrorContractConsistencyTest.php
@@ -1,0 +1,160 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature;
+
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Support\Str;
+use Illuminate\Testing\TestResponse;
+use Tests\TestCase;
+
+final class ErrorContractConsistencyTest extends TestCase
+{
+    use RefreshDatabase;
+
+    /** @var array<string, string|null> */
+    private array $envBackup = [];
+
+    protected function tearDown(): void
+    {
+        foreach ($this->envBackup as $key => $value) {
+            if ($value === null) {
+                putenv($key);
+                unset($_ENV[$key], $_SERVER[$key]);
+                continue;
+            }
+
+            putenv("{$key}={$value}");
+            $_ENV[$key] = $value;
+            $_SERVER[$key] = $value;
+        }
+
+        parent::tearDown();
+    }
+
+    public function test_lookup_ticket_invalid_format_returns_unified_error_contract(): void
+    {
+        $response = $this->getJson('/api/v0.2/lookup/ticket/BAD');
+
+        $response->assertStatus(422);
+        $response->assertJsonPath('error_code', 'INVALID_FORMAT');
+        $this->assertUnifiedErrorContract($response);
+    }
+
+    public function test_lookup_order_disabled_returns_unified_error_contract(): void
+    {
+        $this->setEnv('LOOKUP_ORDER', '0');
+
+        $response = $this->postJson('/api/v0.2/lookup/order', [
+            'order_no' => 'ord_contract_disabled',
+        ]);
+
+        $response->assertStatus(200);
+        $response->assertJsonPath('error_code', 'NOT_ENABLED');
+        $this->assertUnifiedErrorContract($response);
+    }
+
+    public function test_validity_feedback_disabled_returns_unified_error_contract(): void
+    {
+        $this->setEnv('FEEDBACK_ENABLED', '0');
+        $token = $this->seedFmToken('anon_contract_feedback');
+
+        $response = $this->withHeaders([
+            'Authorization' => "Bearer {$token}",
+        ])->postJson('/api/v0.2/attempts/' . (string) Str::uuid() . '/feedback', [
+            'score' => 5,
+        ]);
+
+        $response->assertStatus(200);
+        $response->assertJsonPath('error_code', 'NOT_ENABLED');
+        $this->assertUnifiedErrorContract($response);
+    }
+
+    public function test_v03_payment_webhook_invalid_signature_returns_unified_error_contract(): void
+    {
+        config([
+            'services.stripe.webhook_secret' => 'whsec_error_contract_test',
+            'services.stripe.webhook_tolerance_seconds' => 300,
+        ]);
+
+        $raw = json_encode([
+            'id' => 'evt_contract_invalid_sig',
+            'type' => 'payment_intent.succeeded',
+            'data' => [
+                'object' => [
+                    'id' => 'pi_contract_invalid_sig',
+                    'metadata' => ['order_no' => 'ord_contract_invalid_sig'],
+                ],
+            ],
+        ], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES);
+
+        if (!is_string($raw)) {
+            self::fail('Failed to encode webhook payload.');
+        }
+
+        $response = $this->call(
+            'POST',
+            '/api/v0.3/webhooks/payment/stripe',
+            [],
+            [],
+            [],
+            [
+                'CONTENT_TYPE' => 'application/json',
+                'HTTP_ACCEPT' => 'application/json',
+            ],
+            $raw
+        );
+
+        $response->assertStatus(400);
+        $response->assertJsonPath('error_code', 'INVALID_SIGNATURE');
+        $this->assertUnifiedErrorContract($response);
+    }
+
+    private function assertUnifiedErrorContract(TestResponse $response): void
+    {
+        $response->assertJsonPath('ok', false);
+        $response->assertJsonMissingPath('error');
+
+        $errorCode = (string) $response->json('error_code', '');
+        $message = (string) $response->json('message', '');
+
+        $this->assertNotSame('', trim($errorCode));
+        $this->assertNotSame('', trim($message));
+    }
+
+    private function seedFmToken(string $anonId): string
+    {
+        $token = 'fm_' . (string) Str::uuid();
+
+        $row = [
+            'token' => $token,
+            'anon_id' => $anonId,
+            'expires_at' => now()->addHour(),
+            'created_at' => now(),
+            'updated_at' => now(),
+        ];
+
+        if (Schema::hasColumn('fm_tokens', 'user_id')) {
+            $row['user_id'] = null;
+        }
+
+        DB::table('fm_tokens')->insert($row);
+
+        return $token;
+    }
+
+    private function setEnv(string $key, string $value): void
+    {
+        if (!array_key_exists($key, $this->envBackup)) {
+            $current = getenv($key);
+            $this->envBackup[$key] = $current === false ? null : (string) $current;
+        }
+
+        putenv("{$key}={$value}");
+        $_ENV[$key] = $value;
+        $_SERVER[$key] = $value;
+    }
+}


### PR DESCRIPTION
Summary
unify high-frequency API error contract to { ok:false, error_code, message, details? }
enhance NormalizeApiErrorContract to normalize status>=400 JSON object responses containing error_code/error/message, and all ok=false responses
migrate v0.2 high-frequency controller error responses (LookupController, ValidityFeedbackController, PaymentsController) from error to error_code
align PaymentService failure payload keys from error to error_code
update v0.3 high-frequency paths (AttemptReadController, AttemptWriteController, CommerceController) to prefer error_code fallback reads
add ErrorContractConsistencyTest to gate contract consistency across representative error entrypoints
no changes in [api.php](app://-/index.html#), database/migrations/*, [FmTokenAuth.php](app://-/index.html#), ShareController, PaymentWebhookController
Testing
cd backend && php artisan route:list
cd backend && php artisan migrate
[FmTokenAuth.php](app://-/index.html#)
cd backend && php artisan test --filter=ErrorContractConsistencyTest
[LookupController.php](app://-/index.html#)
grep -R "'error' =>" backend/app/Services/Payments
[ci_verify_mbti.sh](app://-/index.html#)
Validation cURL Samples
curl -i -H "Accept: application/json" "http://127.0.0.1:1830/api/v0.2/lookup/ticket/BAD"
curl -i -X POST -H "Content-Type: application/json" -d '{"id":"evt_x","type":"payment_intent.succeeded"}' "http://127.0.0.1:1830/api/v0.3/webhooks/payment/stripe"