### PR TITLE
fix(webhook): harden v0.3 payment callback entry (SEC-002)

### DIFF
--- a/backend/app/Services/Commerce/PaymentGateway/StripeGateway.php
+++ b/backend/app/Services/Commerce/PaymentGateway/StripeGateway.php
@@ -78,7 +78,7 @@ class StripeGateway implements PaymentGatewayInterface
     {
         $object = $this->resolveObject($payload);
 
-        $providerEventId = $this->resolveString($payload, ['id']);
+        $providerEventId = $this->resolveString($payload, ['provider_event_id', 'event_id', 'id']);
         if ($providerEventId === '') {
             $providerEventId = $this->resolveString($object, ['id', 'charge', 'payment_intent']);
         }

--- a/backend/tests/Feature/V0_3/PaymentWebhookControllerTest.php
+++ b/backend/tests/Feature/V0_3/PaymentWebhookControllerTest.php
@@ -1,0 +1,263 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\V0_3;
+
+use App\Services\Commerce\PaymentWebhookProcessor;
+use Database\Seeders\Pr19CommerceSeeder;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Str;
+use Illuminate\Testing\TestResponse;
+use Mockery;
+use Mockery\Adapter\Phpunit\MockeryPHPUnitIntegration;
+use Tests\TestCase;
+
+final class PaymentWebhookControllerTest extends TestCase
+{
+    use RefreshDatabase;
+    use MockeryPHPUnitIntegration;
+
+    public function test_invalid_json_returns_400_and_processor_not_called(): void
+    {
+        $processor = Mockery::mock(PaymentWebhookProcessor::class);
+        $processor->shouldReceive('handle')->never();
+        $this->app->instance(PaymentWebhookProcessor::class, $processor);
+
+        $response = $this->call(
+            'POST',
+            '/api/v0.3/webhooks/payment/stripe',
+            [],
+            [],
+            [],
+            [
+                'CONTENT_TYPE' => 'application/json',
+                'HTTP_ACCEPT' => 'application/json',
+            ],
+            '{"id":"evt_invalid_json"',
+        );
+
+        $response->assertStatus(400);
+        $response->assertJsonPath('error_code', 'INVALID_JSON');
+    }
+
+    public function test_invalid_signature_returns_400_and_processor_not_called(): void
+    {
+        config([
+            'services.stripe.webhook_secret' => 'whsec_sec002',
+            'services.stripe.webhook_tolerance_seconds' => 300,
+        ]);
+
+        $processor = Mockery::mock(PaymentWebhookProcessor::class);
+        $processor->shouldReceive('handle')->never();
+        $this->app->instance(PaymentWebhookProcessor::class, $processor);
+
+        $raw = $this->encodePayload([
+            'id' => 'evt_invalid_sig',
+            'type' => 'payment_intent.succeeded',
+            'data' => [
+                'object' => [
+                    'id' => 'pi_invalid_sig',
+                    'metadata' => ['order_no' => 'ord_invalid_sig'],
+                ],
+            ],
+        ]);
+
+        $response = $this->call(
+            'POST',
+            '/api/v0.3/webhooks/payment/stripe',
+            [],
+            [],
+            [],
+            [
+                'CONTENT_TYPE' => 'application/json',
+                'HTTP_ACCEPT' => 'application/json',
+            ],
+            $raw
+        );
+
+        $response->assertStatus(400);
+        $response->assertJsonPath('error_code', 'INVALID_SIGNATURE');
+    }
+
+    public function test_missing_event_id_returns_400_and_processor_not_called(): void
+    {
+        config([
+            'services.stripe.webhook_secret' => 'whsec_sec002_missing_event',
+            'services.stripe.webhook_tolerance_seconds' => 300,
+        ]);
+
+        $processor = Mockery::mock(PaymentWebhookProcessor::class);
+        $processor->shouldReceive('handle')->never();
+        $this->app->instance(PaymentWebhookProcessor::class, $processor);
+
+        $raw = $this->encodePayload([
+            'type' => 'payment_intent.succeeded',
+            'data' => [
+                'object' => [
+                    'metadata' => ['order_no' => 'ord_missing_event'],
+                ],
+            ],
+        ]);
+
+        $response = $this->call(
+            'POST',
+            '/api/v0.3/webhooks/payment/stripe',
+            [],
+            [],
+            [],
+            [
+                'CONTENT_TYPE' => 'application/json',
+                'HTTP_ACCEPT' => 'application/json',
+                'HTTP_STRIPE_SIGNATURE' => $this->buildStripeSignatureHeader('whsec_sec002_missing_event', $raw),
+            ],
+            $raw
+        );
+
+        $response->assertStatus(400);
+        $response->assertJsonPath('error_code', 'MISSING_EVENT_ID');
+    }
+
+    public function test_processor_throwable_returns_500(): void
+    {
+        config([
+            'services.stripe.webhook_secret' => 'whsec_sec002_500',
+            'services.stripe.webhook_tolerance_seconds' => 300,
+        ]);
+
+        $processor = Mockery::mock(PaymentWebhookProcessor::class);
+        $processor->shouldReceive('handle')
+            ->once()
+            ->andThrow(new \RuntimeException('boom'));
+        $this->app->instance(PaymentWebhookProcessor::class, $processor);
+
+        $raw = $this->encodePayload([
+            'id' => 'evt_processor_throws',
+            'type' => 'payment_intent.succeeded',
+            'data' => [
+                'object' => [
+                    'id' => 'pi_processor_throws',
+                    'metadata' => ['order_no' => 'ord_processor_throws'],
+                ],
+            ],
+        ]);
+
+        $response = $this->call(
+            'POST',
+            '/api/v0.3/webhooks/payment/stripe',
+            [],
+            [],
+            [],
+            [
+                'CONTENT_TYPE' => 'application/json',
+                'HTTP_ACCEPT' => 'application/json',
+                'HTTP_STRIPE_SIGNATURE' => $this->buildStripeSignatureHeader('whsec_sec002_500', $raw),
+            ],
+            $raw
+        );
+
+        $response->assertStatus(500);
+        $response->assertJsonPath('error_code', 'WEBHOOK_INTERNAL_ERROR');
+    }
+
+    public function test_valid_billing_signature_returns_200_and_writes_or_hits_idempotency(): void
+    {
+        (new Pr19CommerceSeeder())->run();
+
+        config([
+            'services.billing.webhook_secret' => 'billing_secret_sec002',
+            'services.billing.webhook_tolerance_seconds' => 300,
+            'services.billing.allow_legacy_signature' => false,
+        ]);
+
+        $orderNo = 'ord_sec002_webhook_1';
+        DB::table('orders')->insert([
+            'id' => (string) Str::uuid(),
+            'order_no' => $orderNo,
+            'org_id' => 0,
+            'user_id' => null,
+            'anon_id' => null,
+            'sku' => 'MBTI_CREDIT',
+            'quantity' => 1,
+            'target_attempt_id' => null,
+            'amount_cents' => 4990,
+            'currency' => 'USD',
+            'status' => 'created',
+            'provider' => 'billing',
+            'external_trade_no' => null,
+            'paid_at' => null,
+            'created_at' => now(),
+            'updated_at' => now(),
+            'amount_total' => 4990,
+            'amount_refunded' => 0,
+            'item_sku' => 'MBTI_CREDIT',
+            'provider_order_id' => null,
+            'device_id' => null,
+            'request_id' => null,
+            'created_ip' => null,
+            'fulfilled_at' => null,
+            'refunded_at' => null,
+        ]);
+
+        $payload = [
+            'provider_event_id' => 'evt_sec002_bill_1',
+            'order_no' => $orderNo,
+            'amount_cents' => 4990,
+            'currency' => 'USD',
+        ];
+        $raw = $this->encodePayload($payload);
+
+        $first = $this->postSignedBilling($raw, 'billing_secret_sec002');
+        $first->assertStatus(200);
+        $first->assertJsonPath('ok', true);
+
+        $second = $this->postSignedBilling($raw, 'billing_secret_sec002');
+        $second->assertStatus(200);
+        $second->assertJsonPath('ok', true);
+
+        $this->assertSame(1, DB::table('payment_events')
+            ->where('provider', 'billing')
+            ->where('provider_event_id', 'evt_sec002_bill_1')
+            ->count());
+    }
+
+    private function postSignedBilling(string $raw, string $secret): TestResponse
+    {
+        $ts = time();
+        $sig = hash_hmac('sha256', "{$ts}.{$raw}", $secret);
+
+        return $this->call(
+            'POST',
+            '/api/v0.3/webhooks/payment/billing',
+            [],
+            [],
+            [],
+            [
+                'CONTENT_TYPE' => 'application/json',
+                'HTTP_ACCEPT' => 'application/json',
+                'HTTP_X_WEBHOOK_TIMESTAMP' => (string) $ts,
+                'HTTP_X_WEBHOOK_SIGNATURE' => $sig,
+            ],
+            $raw
+        );
+    }
+
+    private function buildStripeSignatureHeader(string $secret, string $raw): string
+    {
+        $ts = time();
+        $sig = hash_hmac('sha256', "{$ts}.{$raw}", $secret);
+
+        return "t={$ts},v1={$sig}";
+    }
+
+    private function encodePayload(array $payload): string
+    {
+        $raw = json_encode($payload, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES);
+        if (!is_string($raw)) {
+            self::fail('json_encode payload failed.');
+        }
+
+        return $raw;
+    }
+}

--- a/backend/tests/Feature/V0_3/PaymentWebhookFailSafeTest.php
+++ b/backend/tests/Feature/V0_3/PaymentWebhookFailSafeTest.php
@@ -51,7 +51,7 @@ class PaymentWebhookFailSafeTest extends TestCase
         $response->assertStatus(400);
         $response->assertJson([
             'ok' => false,
-            'error_code' => 'INVALID_PAYLOAD',
+            'error_code' => 'INVALID_JSON',
         ]);
     }
 }


### PR DESCRIPTION
## Summary
- Harden `POST /api/v0.3/webhooks/payment/{provider}` controller path for SEC-002.
- Enforce explicit webhook gateway signature check in controller before processor dispatch.
- Extract idempotency anchor `event_id`/`provider_event_id` from normalized payload and reject missing event id.
- Resolve `org_id`/`user_id`/`anon_id` from `orders.order_no` and pass them into `PaymentWebhookProcessor`.
- Standardize invalid JSON contract to `400 INVALID_JSON` and preserve `500 WEBHOOK_INTERNAL_ERROR` on processor exceptions.

## Behavior Contract
- Signature invalid => `400 INVALID_SIGNATURE`
- JSON invalid => `400 INVALID_JSON`
- Missing event id => `400 MISSING_EVENT_ID`
- Processor returns normally (including duplicate) => `200`
- Processor throws => `500 WEBHOOK_INTERNAL_ERROR`

## Changed Files
- `backend/app/Http/Controllers/API/V0_3/Webhooks/PaymentWebhookController.php`
- `backend/app/Services/Commerce/PaymentGateway/StripeGateway.php`
- `backend/tests/Feature/V0_3/PaymentWebhookFailSafeTest.php`
- `backend/tests/Feature/V0_3/PaymentWebhookControllerTest.php` (new)

## Verification
- `php artisan route:list | rg "v0.3.webhooks.payment|webhooks/payment"`
- `php artisan migrate`
- `php -l app/Http/Middleware/FmTokenAuth.php`
- `php artisan test --filter=PaymentWebhookControllerTest --colors=never`
- `php artisan test --filter=PaymentWebhookFailSafeTest --colors=never`
- `php artisan test --filter=BillingWebhookSignatureTest --colors=never`
- `php artisan test --colors=never`
- `bash backend/scripts/ci_verify_mbti.sh`
