### PR TITLE
fix(sec-003): unify v0.3 attempt ownership trait

### DIFF
--- a/backend/app/Http/Controllers/API/V0_3/Concerns/ResolvesAttemptOwnership.php
+++ b/backend/app/Http/Controllers/API/V0_3/Concerns/ResolvesAttemptOwnership.php
@@ -6,110 +6,181 @@ use App\Models\Attempt;
 use App\Support\OrgContext;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Http\Request;
+use Illuminate\Support\Facades\DB;
 
 trait ResolvesAttemptOwnership
 {
-    protected function resolveUserId(Request $request): ?string
+    /**
+     * @return array{userId:?string, anonId:?string}
+     */
+    protected function resolveViewerIdentity(Request $request): array
     {
-        $orgContext = app(OrgContext::class);
+        $ctx = app(OrgContext::class);
 
-        $candidates = [
-            $orgContext->userId(),
-            $request->attributes->get('fm_user_id'),
-            $request->attributes->get('user_id'),
+        $userId = $this->normalizeUserId(auth()->id());
+        if ($userId === null) {
+            $userId = $this->normalizeUserId(
+                $request->attributes->get('fm_user_id')
+                    ?? $request->attributes->get('user_id')
+                    ?? $ctx->userId()
+            );
+        }
+
+        $anonId = $this->normalizeAnonId(
+            $request->header('X-Anon-Id')
+                ?? $request->header('X-Fm-Anon-Id')
+        );
+
+        if ($anonId === null) {
+            $anonId = $this->normalizeAnonId(
+                $request->attributes->get('anon_id')
+                    ?? $request->attributes->get('fm_anon_id')
+                    ?? $ctx->anonId()
+            );
+        }
+
+        return [
+            'userId' => $userId,
+            'anonId' => $anonId,
         ];
+    }
 
-        foreach ($candidates as $candidate) {
-            if (is_string($candidate) || is_numeric($candidate)) {
-                $value = trim((string) $candidate);
-                if ($value !== '' && preg_match('/^\d+$/', $value)) {
-                    return $value;
-                }
+    protected function orgIdFromContext(): int
+    {
+        $req = request();
+        if ($req instanceof Request) {
+            $attrOrgId = $req->attributes->get('org_id');
+            if (is_numeric($attrOrgId)) {
+                return (int) $attrOrgId;
+            }
+
+            $fmOrgId = $req->attributes->get('fm_org_id');
+            if (is_numeric($fmOrgId)) {
+                return (int) $fmOrgId;
             }
         }
 
-        return null;
+        return (int) app(OrgContext::class)->orgId();
+    }
+
+    /**
+     * Legacy usage:
+     * - ownedAttemptQuery($attemptId)
+     *
+     * New usage:
+     * - ownedAttemptQuery($orgId, $userId, $anonId)
+     */
+    protected function ownedAttemptQuery(int|string $orgIdOrAttemptId, ?string $userId = null, ?string $anonId = null): Builder
+    {
+        if (is_string($orgIdOrAttemptId) && func_num_args() === 1) {
+            $req = request();
+            if (!$req instanceof Request) {
+                return $this->denyAll(Attempt::query());
+            }
+
+            $identity = $this->resolveViewerIdentity($req);
+            $orgId = $this->orgIdFromContext();
+
+            return $this->buildOwnedAttemptQuery($orgId, $identity['userId'], $identity['anonId'])
+                ->where('id', $orgIdOrAttemptId);
+        }
+
+        return $this->buildOwnedAttemptQuery((int) $orgIdOrAttemptId, $userId, $anonId);
+    }
+
+    protected function resolveAttemptOr404(Request $request, string $attemptId): Attempt
+    {
+        $identity = $this->resolveViewerIdentity($request);
+
+        $attempt = $this->ownedAttemptQuery(
+            $this->orgIdFromContext(),
+            $identity['userId'],
+            $identity['anonId']
+        )->where('id', $attemptId)->first();
+
+        if (!$attempt instanceof Attempt) {
+            abort(404);
+        }
+
+        return $attempt;
+    }
+
+    protected function resolveUserId(Request $request): ?string
+    {
+        return $this->resolveViewerIdentity($request)['userId'];
     }
 
     protected function resolveAnonId(Request $request): ?string
     {
-        $orgContext = app(OrgContext::class);
-
-        $candidates = [
-            $orgContext->anonId(),
-            $request->attributes->get('anon_id'),
-            $request->attributes->get('fm_anon_id'),
-            $request->query('anon_id'),
-            $request->header('X-Anon-Id'),
-            $request->header('X-Fm-Anon-Id'),
-        ];
-
-        foreach ($candidates as $candidate) {
-            if (is_string($candidate) || is_numeric($candidate)) {
-                $value = trim((string) $candidate);
-                if ($value !== '') {
-                    return $value;
-                }
-            }
-        }
-
-        return null;
+        return $this->resolveViewerIdentity($request)['anonId'];
     }
 
-    protected function ownedAttemptQuery(string $attemptId): Builder
+    private function buildOwnedAttemptQuery(int $orgId, ?string $userId, ?string $anonId): Builder
     {
-        $orgContext = app(OrgContext::class);
+        $query = Attempt::query()->where('org_id', $orgId);
 
-        $query = Attempt::query()
-            ->where('id', $attemptId)
-            ->where('org_id', $orgContext->orgId());
+        $normalizedUserId = $this->normalizeUserId($userId);
+        $normalizedAnonId = $this->normalizeAnonId($anonId);
 
-        $role = (string) ($orgContext->role() ?? '');
+        $role = (string) (app(OrgContext::class)->role() ?? '');
         if (in_array($role, ['owner', 'admin'], true)) {
             return $query;
         }
 
-        $request = request();
-        $userId = null;
-        $anonId = null;
-
-        if ($request instanceof Request) {
-            $userId = $this->resolveUserId($request);
-            $anonId = $this->resolveAnonId($request);
-        } else {
-            $ctxUserId = $orgContext->userId();
-            if ($ctxUserId !== null) {
-                $candidate = trim((string) $ctxUserId);
-                $userId = $candidate !== '' ? $candidate : null;
-            }
-
-            $ctxAnonId = $orgContext->anonId();
-            if (is_string($ctxAnonId)) {
-                $candidate = trim($ctxAnonId);
-                $anonId = $candidate !== '' ? $candidate : null;
-            }
+        if ($normalizedUserId === null && $normalizedAnonId === null) {
+            return $this->denyAll($query);
         }
 
-        if (in_array($role, ['member', 'viewer'], true)) {
-            if ($userId !== null) {
-                return $query->where('user_id', $userId);
+        return $query->where(function (Builder $owned) use ($normalizedUserId, $normalizedAnonId): void {
+            $applied = false;
+
+            if ($normalizedUserId !== null) {
+                $owned->where('user_id', $normalizedUserId);
+                $applied = true;
             }
 
-            if ($anonId !== null) {
-                return $query->where('anon_id', $anonId);
+            if ($normalizedAnonId !== null) {
+                if ($applied) {
+                    $owned->orWhere('anon_id', $normalizedAnonId);
+                } else {
+                    $owned->where('anon_id', $normalizedAnonId);
+                    $applied = true;
+                }
             }
 
-            return $query->whereRaw('1=0');
+            if (!$applied) {
+                $owned->where(DB::raw('1'), '=', 0);
+            }
+        });
+    }
+
+    private function denyAll(Builder $query): Builder
+    {
+        return $query->where(DB::raw('1'), '=', 0);
+    }
+
+    private function normalizeUserId(mixed $candidate): ?string
+    {
+        if (!is_string($candidate) && !is_numeric($candidate)) {
+            return null;
         }
 
-        if ($userId !== null) {
-            return $query->where('user_id', $userId);
+        $value = trim((string) $candidate);
+        if ($value === '' || !preg_match('/^\d+$/', $value)) {
+            return null;
         }
 
-        if ($anonId !== null) {
-            return $query->where('anon_id', $anonId);
+        return $value;
+    }
+
+    private function normalizeAnonId(mixed $candidate): ?string
+    {
+        if (!is_string($candidate) && !is_numeric($candidate)) {
+            return null;
         }
 
-        return $query->whereRaw('1=0');
+        $value = trim((string) $candidate);
+
+        return $value === '' ? null : $value;
     }
 }

--- a/backend/tests/Feature/V0_3/AttemptOwnershipTraitTest.php
+++ b/backend/tests/Feature/V0_3/AttemptOwnershipTraitTest.php
@@ -1,0 +1,125 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\V0_3;
+
+use App\Models\Attempt;
+use App\Models\Result;
+use Database\Seeders\ScaleRegistrySeeder;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Str;
+use Tests\TestCase;
+
+final class AttemptOwnershipTraitTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private function seedScales(): void
+    {
+        (new ScaleRegistrySeeder())->run();
+    }
+
+    private function seedAttemptAndResult(string $anonId): string
+    {
+        $attemptId = (string) Str::uuid();
+
+        Attempt::create([
+            'id' => $attemptId,
+            'org_id' => 0,
+            'anon_id' => $anonId,
+            'scale_code' => 'MBTI',
+            'scale_version' => 'v0.3',
+            'region' => 'CN_MAINLAND',
+            'locale' => 'zh-CN',
+            'question_count' => 144,
+            'client_platform' => 'test',
+            'answers_summary_json' => ['stage' => 'seed'],
+            'started_at' => now(),
+            'submitted_at' => now(),
+            'pack_id' => (string) config('content_packs.default_pack_id'),
+            'dir_version' => 'MBTI-CN-v0.2.1-TEST',
+            'content_package_version' => 'v0.2.1-TEST',
+            'scoring_spec_version' => '2026.01',
+        ]);
+
+        Result::create([
+            'id' => (string) Str::uuid(),
+            'org_id' => 0,
+            'attempt_id' => $attemptId,
+            'scale_code' => 'MBTI',
+            'scale_version' => 'v0.3',
+            'type_code' => 'INTJ-A',
+            'scores_json' => [
+                'EI' => ['a' => 10, 'b' => 10, 'sum' => 0, 'total' => 20],
+                'SN' => ['a' => 10, 'b' => 10, 'sum' => 0, 'total' => 20],
+                'TF' => ['a' => 10, 'b' => 10, 'sum' => 0, 'total' => 20],
+                'JP' => ['a' => 10, 'b' => 10, 'sum' => 0, 'total' => 20],
+                'AT' => ['a' => 10, 'b' => 10, 'sum' => 0, 'total' => 20],
+            ],
+            'scores_pct' => [
+                'EI' => 50,
+                'SN' => 50,
+                'TF' => 50,
+                'JP' => 50,
+                'AT' => 50,
+            ],
+            'axis_states' => [
+                'EI' => 'clear',
+                'SN' => 'clear',
+                'TF' => 'clear',
+                'JP' => 'clear',
+                'AT' => 'clear',
+            ],
+            'content_package_version' => 'v0.2.1-TEST',
+            'result_json' => [
+                'type_code' => 'INTJ-A',
+                'scores_json' => [
+                    'EI' => ['a' => 10, 'b' => 10, 'sum' => 0, 'total' => 20],
+                ],
+            ],
+            'pack_id' => (string) config('content_packs.default_pack_id'),
+            'dir_version' => 'MBTI-CN-v0.2.1-TEST',
+            'scoring_spec_version' => '2026.01',
+            'report_engine_version' => 'v1.2',
+            'is_valid' => true,
+            'computed_at' => now(),
+        ]);
+
+        return $attemptId;
+    }
+
+    public function test_report_returns_404_without_auth_and_anon_header(): void
+    {
+        $this->seedScales();
+        $attemptId = $this->seedAttemptAndResult('sec003-owner-anon');
+
+        $this->getJson("/api/v0.3/attempts/{$attemptId}/report")
+            ->assertStatus(404);
+    }
+
+    public function test_report_returns_404_when_anon_header_mismatch(): void
+    {
+        $this->seedScales();
+        $attemptId = $this->seedAttemptAndResult('sec003-owner-anon');
+
+        $this->withHeader('X-Anon-Id', 'sec003-other-anon')
+            ->getJson("/api/v0.3/attempts/{$attemptId}/report")
+            ->assertStatus(404);
+    }
+
+    public function test_report_with_matching_anon_header_never_500(): void
+    {
+        $this->seedScales();
+        $attemptId = $this->seedAttemptAndResult('sec003-owner-anon');
+
+        $response = $this->withHeader('X-Anon-Id', 'sec003-owner-anon')
+            ->getJson("/api/v0.3/attempts/{$attemptId}/report");
+
+        $this->assertContains($response->status(), [200, 402]);
+
+        if ($response->status() === 200) {
+            $this->assertIsBool($response->json('locked'));
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- restore and standardize `ResolvesAttemptOwnership` APIs for v0.3 attempts read path
- keep owner/admin privileged read semantics while enforcing owner/anon+org scoping
- add regression tests to lock 404 for missing/wrong identity and non-500 for matched anon

## Changes
- replace `/Users/rainie/Desktop/GitHub/fap-api/backend/app/Http/Controllers/API/V0_3/Concerns/ResolvesAttemptOwnership.php`
  - add `resolveViewerIdentity(Request): array{userId:?string, anonId:?string}`
  - add `orgIdFromContext(): int`
  - add `resolveAttemptOr404(Request, string): Attempt`
  - support both `ownedAttemptQuery($attemptId)` and `ownedAttemptQuery($orgId, $userId, $anonId)`
  - keep `resolveUserId/resolveAnonId` wrappers for backwards compatibility
- add `/Users/rainie/Desktop/GitHub/fap-api/backend/tests/Feature/V0_3/AttemptOwnershipTraitTest.php`
  - no auth + no anon header => 404
  - anon mismatch => 404
  - anon match => 200 or 402, never 500

## Verification
- `cd /Users/rainie/Desktop/GitHub/fap-api/backend && php artisan route:list`
- `cd /Users/rainie/Desktop/GitHub/fap-api/backend && php artisan migrate`
- `cd /Users/rainie/Desktop/GitHub/fap-api/backend && php -l app/Http/Middleware/FmTokenAuth.php`
- `cd /Users/rainie/Desktop/GitHub/fap-api/backend && php artisan test --filter=AttemptOwnershipTraitTest`
- `cd /Users/rainie/Desktop/GitHub/fap-api/backend && php artisan test --filter=AttemptOwnershipAnd404Test`
- `cd /Users/rainie/Desktop/GitHub/fap-api && bash backend/scripts/ci_verify_mbti.sh`
- `cd /Users/rainie/Desktop/GitHub/fap-api/backend && php artisan test`

## Acceptance Mapping
- trait exists and is wired for v0.3 attempt read ownership resolution
- no fatal/500 on trait dependency path
- unauthenticated or wrong identity paths return stable 404
- full test suite green