### PR TITLE
fix(sec-002): propagate v0.3 payment webhook status codes

### DIFF
--- a/backend/app/Http/Controllers/API/V0_3/Webhooks/PaymentWebhookController.php
+++ b/backend/app/Http/Controllers/API/V0_3/Webhooks/PaymentWebhookController.php
@@ -85,7 +85,15 @@ final class PaymentWebhookController extends Controller
             return $this->errorResponse(500, 'WEBHOOK_INTERNAL_ERROR', 'webhook internal error');
         }
 
-        return response()->json($result, 200);
+        $status = 200;
+        if (is_array($result) && array_key_exists('status', $result)) {
+            $candidate = (int) $result['status'];
+            if ($candidate >= 100 && $candidate <= 599) {
+                $status = $candidate;
+            }
+        }
+
+        return response()->json($result, $status);
     }
 
     private function resolveGateway(string $provider): ?PaymentGatewayInterface

--- a/backend/tests/Feature/Commerce/PaymentWebhookIdempotencyTest.php
+++ b/backend/tests/Feature/Commerce/PaymentWebhookIdempotencyTest.php
@@ -161,7 +161,7 @@ class PaymentWebhookIdempotencyTest extends TestCase
         $first = $this->postSignedBillingWebhook($payload, [
             'X-Org-Id' => '0',
         ]);
-        $first->assertStatus(200);
+        $first->assertStatus(500);
         $first->assertJson([
             'ok' => false,
             'error_code' => 'ORDER_NOT_FOUND',

--- a/backend/tests/Feature/Payments/WebhookProviderMismatchTest.php
+++ b/backend/tests/Feature/Payments/WebhookProviderMismatchTest.php
@@ -56,7 +56,7 @@ class WebhookProviderMismatchTest extends TestCase
             'X-Org-Id' => '0',
         ]);
 
-        $response->assertStatus(200);
+        $response->assertStatus(400);
         $response->assertJson([
             'ok' => false,
             'error_code' => 'PROVIDER_MISMATCH',

--- a/backend/tests/Feature/V0_3/WebhookStatusPropagationTest.php
+++ b/backend/tests/Feature/V0_3/WebhookStatusPropagationTest.php
@@ -1,0 +1,137 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\V0_3;
+
+use App\Services\Commerce\PaymentWebhookProcessor;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Mockery;
+use Mockery\Adapter\Phpunit\MockeryPHPUnitIntegration;
+use PHPUnit\Framework\Attributes\DataProvider;
+use Tests\TestCase;
+
+final class WebhookStatusPropagationTest extends TestCase
+{
+    use RefreshDatabase;
+    use MockeryPHPUnitIntegration;
+
+    #[DataProvider('errorStatuses')]
+    public function test_controller_uses_processor_status_for_error_responses(int $status): void
+    {
+        config([
+            'services.stripe.webhook_secret' => 'whsec_sec002_status_propagation',
+            'services.stripe.webhook_tolerance_seconds' => 300,
+        ]);
+
+        $processor = Mockery::mock(PaymentWebhookProcessor::class);
+        $processor->shouldReceive('handle')
+            ->once()
+            ->andReturn([
+                'ok' => false,
+                'error' => 'X',
+                'status' => $status,
+            ]);
+        $this->app->instance(PaymentWebhookProcessor::class, $processor);
+
+        $raw = $this->encodePayload([
+            'id' => "evt_status_{$status}",
+            'type' => 'payment_intent.succeeded',
+            'data' => [
+                'object' => [
+                    'id' => "pi_status_{$status}",
+                    'metadata' => ['order_no' => "ord_status_{$status}"],
+                ],
+            ],
+        ]);
+
+        $response = $this->call(
+            'POST',
+            '/api/v0.3/webhooks/payment/stripe',
+            [],
+            [],
+            [],
+            [
+                'CONTENT_TYPE' => 'application/json',
+                'HTTP_ACCEPT' => 'application/json',
+                'HTTP_STRIPE_SIGNATURE' => $this->buildStripeSignatureHeader('whsec_sec002_status_propagation', $raw),
+            ],
+            $raw
+        );
+
+        $response->assertStatus($status);
+    }
+
+    public static function errorStatuses(): array
+    {
+        return [
+            [400],
+            [404],
+            [413],
+            [500],
+        ];
+    }
+
+    public function test_controller_falls_back_to_200_when_processor_status_is_out_of_range(): void
+    {
+        config([
+            'services.stripe.webhook_secret' => 'whsec_sec002_status_fallback',
+            'services.stripe.webhook_tolerance_seconds' => 300,
+        ]);
+
+        $processor = Mockery::mock(PaymentWebhookProcessor::class);
+        $processor->shouldReceive('handle')
+            ->once()
+            ->andReturn([
+                'ok' => false,
+                'error' => 'X',
+                'status' => 700,
+            ]);
+        $this->app->instance(PaymentWebhookProcessor::class, $processor);
+
+        $raw = $this->encodePayload([
+            'id' => 'evt_status_out_of_range',
+            'type' => 'payment_intent.succeeded',
+            'data' => [
+                'object' => [
+                    'id' => 'pi_status_out_of_range',
+                    'metadata' => ['order_no' => 'ord_status_out_of_range'],
+                ],
+            ],
+        ]);
+
+        $response = $this->call(
+            'POST',
+            '/api/v0.3/webhooks/payment/stripe',
+            [],
+            [],
+            [],
+            [
+                'CONTENT_TYPE' => 'application/json',
+                'HTTP_ACCEPT' => 'application/json',
+                'HTTP_STRIPE_SIGNATURE' => $this->buildStripeSignatureHeader('whsec_sec002_status_fallback', $raw),
+            ],
+            $raw
+        );
+
+        $response->assertStatus(200);
+    }
+
+    private function buildStripeSignatureHeader(string $secret, string $raw): string
+    {
+        $ts = time();
+        $sig = hash_hmac('sha256', "{$ts}.{$raw}", $secret);
+
+        return "t={$ts},v1={$sig}";
+    }
+
+    private function encodePayload(array $payload): string
+    {
+        $raw = json_encode($payload, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES);
+        if (!is_string($raw)) {
+            self::fail('json_encode payload failed.');
+        }
+
+        return $raw;
+    }
+}


### PR DESCRIPTION
## Summary
- fix `PaymentWebhookController` to return the HTTP status from processor result instead of hardcoded `200`
- harden `PaymentWebhookProcessor` result contract by normalizing/ensuring `status`
- add regression feature test for status propagation (`400/404/413/500`) and out-of-range fallback (`200`)
- update existing webhook behavior assertions (`provider mismatch`, `orphan order-not-found`) to match new status semantics

## Changes
- `backend/app/Http/Controllers/API/V0_3/Webhooks/PaymentWebhookController.php`
  - replace `response()->json($result, 200)` with validated status propagation (`100..599`, fallback `200`)
- `backend/app/Services/Commerce/PaymentWebhookProcessor.php`
  - return normalized result from `handle()`
  - add `normalizeResultStatus()` helper
  - add `status => 500` to `tableMissing()`
  - add `status => 400` to `badRequest()`
- `backend/tests/Feature/V0_3/WebhookStatusPropagationTest.php` (new)
  - asserts controller propagates processor error statuses
  - asserts out-of-range status falls back to `200`
- `backend/tests/Feature/Payments/WebhookProviderMismatchTest.php`
  - expect `400` instead of `200`
- `backend/tests/Feature/Commerce/PaymentWebhookIdempotencyTest.php`
  - expect first orphan-order callback as `500` (`ORDER_NOT_FOUND`)

## Verification
- `php artisan route:list | rg "v0\.3\.webhooks\.payment|webhooks/payment"`
- `php artisan migrate --force`
- `rg --line-number "DB::table\('fm_tokens'\)|fm_user_id" app/Http/Middleware/FmTokenAuth.php`
- `php artisan test tests/Feature/V0_3/WebhookStatusPropagationTest.php`
- `php artisan test tests/Feature/Payments/WebhookProviderMismatchTest.php`
- `php artisan test tests/Feature/V0_3/PaymentWebhookControllerTest.php`
- `php artisan test`
- `bash backend/scripts/ci_verify_mbti.sh`

## Risk
- webhook consumers now receive non-200 status on processor failures, which is intended to re-enable gateway retries and prevent stuck order progression.
