### PR TITLE
feat(sec): close env leakage, tenant isolation gaps, empty-catch observability, and API contract normalization

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,12 @@
 如果你只做一件事：  
 **先按 Stage 1 的规范把接口/术语/事件口径对齐，再按 Stage 2 跑通“测评→报告→分享→增长”的闭环。**
 
+## Release Packaging Policy
+
+- 发布产物只允许来自 `git archive`（例如 `bash scripts/package_release.sh`）或 CI 产物。
+- 禁止直接压缩本地工作目录（例如 Finder/Explorer 手工 zip 工作区）。
+- 原因：工作区可能包含未跟踪文件（如 `backend/.env`），会造成密钥泄露与误部署风险。
+
 ---
 
 ## 1. 当前阶段（Stage 2 · Skeleton-level）

--- a/backend/app/Http/Controllers/API/V0_2/MeController.php
+++ b/backend/app/Http/Controllers/API/V0_2/MeController.php
@@ -8,6 +8,7 @@ use App\Http\Requests\V0_2\BindEmailRequest;
 use App\Models\Attempt;
 use App\Services\Abuse\RateLimiter;
 use App\Services\Audit\LookupEventLogger;
+use App\Support\ApiPagination;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\DB;
@@ -82,17 +83,16 @@ class MeController extends Controller
             $items[] = $this->presentAttempt($a);
         }
 
+        $p->setCollection(collect($items));
+        $pagination = ApiPagination::fromLengthAwarePaginator($p);
+
         return response()->json([
             'ok' => true,
             'user_id' => $userId ?? '',
             'anon_id' => $anonId ?? '',
-            'items' => $items,
-            'pagination' => [
-                'page' => $p->currentPage(),
-                'per_page' => $p->perPage(),
-                'total' => $p->total(),
-                'last_page' => $p->lastPage(),
-            ],
+            'items' => $pagination['items'],
+            'meta' => $pagination['meta'],
+            'links' => $pagination['links'],
         ]);
     }
 

--- a/backend/app/Http/Controllers/API/V0_2/ShareController.php
+++ b/backend/app/Http/Controllers/API/V0_2/ShareController.php
@@ -435,7 +435,15 @@ $event->anon_id = ($clickAnonId !== null && $clickAnonId !== '') ? $clickAnonId 
                 'updated_at' => Carbon::now(),
             ]);
         } catch (\Throwable $e) {
-            // Keep endpoint non-blocking for legacy compatibility.
+            $requestId = trim((string) request()->header('X-Request-Id', request()->header('X-Request-ID', '')));
+
+            Log::warning('SHARE_LEGACY_EVENT_CREATE_FAILED', [
+                'event_code' => $eventCode,
+                'attempt_id' => $attemptId,
+                'org_id' => $orgId,
+                'request_id' => $requestId !== '' ? $requestId : null,
+                'exception' => $e,
+            ]);
         }
     }
 

--- a/backend/app/Http/Middleware/NormalizeApiErrorContract.php
+++ b/backend/app/Http/Middleware/NormalizeApiErrorContract.php
@@ -74,11 +74,15 @@ final class NormalizeApiErrorContract
             return true;
         }
 
+        if ($this->hasLegacyError($payload)) {
+            return true;
+        }
+
         if ($status < 400) {
             return false;
         }
 
-        return $this->hasErrorCode($payload) || $this->hasLegacyError($payload) || $this->hasMessage($payload);
+        return $this->hasErrorCode($payload) || $this->hasMessage($payload);
     }
 
     private function hasErrorCode(array $payload): bool

--- a/backend/app/Http/Middleware/VerifyIntegrationSignature.php
+++ b/backend/app/Http/Middleware/VerifyIntegrationSignature.php
@@ -5,6 +5,7 @@ namespace App\Http\Middleware;
 use Closure;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Facades\Log;
 use Symfony\Component\HttpFoundation\Response;
 
 class VerifyIntegrationSignature
@@ -75,7 +76,13 @@ class VerifyIntegrationSignature
                 }
             }
         } catch (\Throwable $e) {
-            // no-op: guard missing / not available
+            $request = request();
+            $requestId = trim((string) $request->header('X-Request-Id', $request->header('X-Request-ID', '')));
+
+            Log::debug('VERIFY_INTEGRATION_SIGNATURE_GUARD_RESOLVE_FAILED', [
+                'request_id' => $requestId !== '' ? $requestId : null,
+                'exception' => $e,
+            ]);
         }
 
         return null;

--- a/backend/app/Services/Analytics/EventRecorder.php
+++ b/backend/app/Services/Analytics/EventRecorder.php
@@ -5,6 +5,7 @@ namespace App\Services\Analytics;
 use App\Models\Event;
 use App\Services\Experiments\ExperimentAssigner;
 use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Facades\Schema;
 use Illuminate\Support\Str;
 
@@ -50,7 +51,13 @@ final class EventRecorder
         try {
             Event::create($payload);
         } catch (\Throwable $e) {
-            // best-effort
+            Log::warning('EVENT_RECORDER_WRITE_FAILED', [
+                'event_code' => $eventCode,
+                'org_id' => (int) ($payload['org_id'] ?? 0),
+                'request_id' => $payload['request_id'] ?? null,
+                'user_id' => $userId,
+                'exception' => $e,
+            ]);
         }
     }
 

--- a/backend/app/Services/Content/ContentPacksIndex.php
+++ b/backend/app/Services/Content/ContentPacksIndex.php
@@ -7,6 +7,7 @@ namespace App\Services\Content;
 use App\Support\CacheKeys;
 use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\File;
+use Illuminate\Support\Facades\Log;
 
 final class ContentPacksIndex
 {
@@ -73,7 +74,12 @@ final class ContentPacksIndex
             try {
                 Cache::store()->put($cacheKey, $index, self::CACHE_TTL_SECONDS);
             } catch (\Throwable $e2) {
-                // ignore cache write failure
+                Log::warning('CONTENT_PACKS_INDEX_CACHE_WRITE_FAILED', [
+                    'cache_key' => $cacheKey,
+                    'store' => 'default',
+                    'ttl' => self::CACHE_TTL_SECONDS,
+                    'exception' => $e2,
+                ]);
             }
         }
 

--- a/backend/app/Services/Content/ContentStore.php
+++ b/backend/app/Services/Content/ContentStore.php
@@ -162,7 +162,12 @@ final class ContentStore
                 try {
                     Cache::store()->put($cacheKey, $json, self::HOT_CACHE_TTL_SECONDS);
                 } catch (\Throwable $e2) {
-                    // ignore cache write failure
+                    Log::warning('CONTENT_STORE_CACHE_WRITE_FAILED', [
+                        'cache_key' => $cacheKey,
+                        'store' => 'default',
+                        'ttl' => self::HOT_CACHE_TTL_SECONDS,
+                        'exception' => $e2,
+                    ]);
                 }
             }
 

--- a/backend/app/Services/Content/Publisher/ContentPackPublisher.php
+++ b/backend/app/Services/Content/Publisher/ContentPackPublisher.php
@@ -9,6 +9,7 @@ use Illuminate\Support\Facades\Artisan;
 use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\File;
+use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Str;
 use RuntimeException;
 use ZipArchive;
@@ -623,25 +624,39 @@ final class ContentPackPublisher
         try {
             Artisan::call('cache:clear');
         } catch (\Throwable $e) {
-            // ignore cache clear failures
+            Log::warning('CONTENT_PACK_PUBLISHER_CACHE_CLEAR_FAILED', [
+                'action' => 'cache:clear',
+                'exception' => $e,
+            ]);
         }
 
         try {
             Cache::store('hot_redis')->flush();
         } catch (\Throwable $e) {
-            // ignore hot_redis failures
+            Log::warning('CONTENT_PACK_PUBLISHER_CACHE_CLEAR_FAILED', [
+                'action' => 'hot_redis.flush',
+                'exception' => $e,
+            ]);
         }
 
         try {
             Cache::forget(CacheKeys::packsIndex());
         } catch (\Throwable $e) {
-            // ignore cache forget failures
+            Log::warning('CONTENT_PACK_PUBLISHER_CACHE_CLEAR_FAILED', [
+                'action' => 'default.forget',
+                'cache_key' => CacheKeys::packsIndex(),
+                'exception' => $e,
+            ]);
         }
 
         try {
             Cache::store('hot_redis')->forget(CacheKeys::packsIndex());
         } catch (\Throwable $e) {
-            // ignore hot_redis failures
+            Log::warning('CONTENT_PACK_PUBLISHER_CACHE_CLEAR_FAILED', [
+                'action' => 'hot_redis.forget',
+                'cache_key' => CacheKeys::packsIndex(),
+                'exception' => $e,
+            ]);
         }
     }
 

--- a/backend/app/Services/Content/Publisher/ContentProbeService.php
+++ b/backend/app/Services/Content/Publisher/ContentProbeService.php
@@ -3,6 +3,7 @@
 namespace App\Services\Content\Publisher;
 
 use App\Support\Http\ResilientClient;
+use Illuminate\Support\Facades\Log;
 
 class ContentProbeService
 {
@@ -86,6 +87,11 @@ class ContentProbeService
         try {
             $json = $resp->json();
         } catch (\Throwable $e) {
+            Log::warning('CONTENT_PROBE_JSON_PARSE_FAILED', [
+                'url' => $url,
+                'status' => $status,
+                'exception' => $e,
+            ]);
         }
 
         return [

--- a/backend/app/Services/Queue/QueueDlqService.php
+++ b/backend/app/Services/Queue/QueueDlqService.php
@@ -245,8 +245,12 @@ class QueueDlqService
             foreach (array_unique($candidates) as $candidate) {
                 try {
                     $failer->forget($candidate);
-                } catch (\Throwable) {
-                    // Fallback delete below is authoritative in this service.
+                } catch (\Throwable $e) {
+                    Log::warning('QUEUE_DLQ_FORGET_FAILED', [
+                        'candidate_id' => (string) $candidate,
+                        'failed_job_id' => $failedJobId,
+                        'exception' => $e,
+                    ]);
                 }
             }
         }

--- a/backend/app/Services/Report/HighlightsGenerator.php
+++ b/backend/app/Services/Report/HighlightsGenerator.php
@@ -3,6 +3,7 @@
 namespace App\Services\Report;
 
 use App\Services\Overrides\HighlightsOverridesApplier;
+use Illuminate\Support\Facades\Log;
 
 class HighlightsGenerator
 {
@@ -188,7 +189,11 @@ class HighlightsGenerator
                 $out = $applier->apply($out, $ctx);
             }
         } catch (\Throwable $e) {
-            // swallow: overrides 不可用时不影响主链路
+            Log::warning('HIGHLIGHTS_OVERRIDES_APPLY_FAILED', [
+                'type_code' => $typeCode,
+                'content_package_version' => $contentPackageVersion,
+                'exception' => $e,
+            ]);
         }
 
         return array_slice($out, 0, 8);

--- a/backend/app/Support/ApiPagination.php
+++ b/backend/app/Support/ApiPagination.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Support;
+
+use Illuminate\Pagination\LengthAwarePaginator;
+
+final class ApiPagination
+{
+    /**
+     * @return array{
+     *     items: array<int, mixed>,
+     *     meta: array{current_page:int, per_page:int, total:int, last_page:int},
+     *     links: array{first:?string, last:?string, prev:?string, next:?string}
+     * }
+     */
+    public static function fromLengthAwarePaginator(LengthAwarePaginator $paginator): array
+    {
+        $lastPage = max(1, (int) $paginator->lastPage());
+
+        return [
+            'items' => $paginator->items(),
+            'meta' => [
+                'current_page' => (int) $paginator->currentPage(),
+                'per_page' => (int) $paginator->perPage(),
+                'total' => (int) $paginator->total(),
+                'last_page' => $lastPage,
+            ],
+            'links' => [
+                'first' => $paginator->url(1),
+                'last' => $paginator->url($lastPage),
+                'prev' => $paginator->previousPageUrl(),
+                'next' => $paginator->nextPageUrl(),
+            ],
+        ];
+    }
+}

--- a/backend/docs/runbooks/secret-rotation.md
+++ b/backend/docs/runbooks/secret-rotation.md
@@ -12,10 +12,20 @@
 
 ## 3. 强制轮换清单（必须全部完成）
 - [ ] APP_KEY：在 Secrets Manager 生成新值，更新运行环境后滚动重启；评估并记录对历史加密数据/会话的影响。
-- [ ] Stripe webhook secret / Billing webhook secret：在 Stripe/Billing 控制台重新签发，更新环境变量并验证 webhook 签名通过。
+- [ ] EVENT_INGEST_TOKEN、FAP_ADMIN_TOKEN：全部吊销旧值并替换为新值，确认旧值不可再用。
+- [ ] WEBHOOK_*（含 `STRIPE_WEBHOOK_SECRET`、`BILLING_WEBHOOK_SECRET`、`INTEGRATIONS_WEBHOOK_*_SECRET`）：在各提供方控制台重新签发，更新环境变量并验证签名。
+- [ ] 任意第三方 `*_SECRET` / `*_TOKEN`：逐项吊销旧值并替换为新值（短信、邮件、对象存储、监控、支付扩展等）。
 - [ ] DB 密码：重置应用账号密码，更新连接串并验证读写；旧密码立即失效。
 - [ ] Redis 密码：重置 Redis ACL/密码，更新客户端连接串并验证队列/缓存恢复。
-- [ ] 任意第三方 Token（短信、邮件、对象存储、监控、支付扩展等）：逐项吊销旧 token 并替换为新 token。
+
+### 3.1 APP_KEY 轮换影响面与回滚策略（必须确认）
+- 影响面（事实）：轮换后旧 `session/cookie` 与历史加密载荷（`Crypt::encrypt`、加密 token、加密字段）将无法解密，用户会被迫重新登录。
+- 发布要求：必须在注入新 APP_KEY 后立即重新部署应用，并重启队列/长驻进程，避免新旧 key 混跑。
+- 验证清单：
+  - [ ] 新请求可正常登录、下发 cookie、访问受保护接口。
+  - [ ] 关键写路径（attempt submit/report/share）无异常解密错误。
+  - [ ] 日志中无批量 `DecryptException` 持续告警。
+- 回滚策略：仅允许在受控窗口内回滚到“上一把已知安全 APP_KEY”，并记录回滚开始/结束时间、影响范围与后续再轮换计划。
 
 ## 4. 发布流程收口动作
 - [ ] 先在 staging 注入新密钥并部署，完成 healthcheck 与核心接口冒烟。

--- a/backend/tests/Feature/AssetCollectorOrgIsolationTest.php
+++ b/backend/tests/Feature/AssetCollectorOrgIsolationTest.php
@@ -1,0 +1,93 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature;
+
+use App\Models\Attempt;
+use App\Services\Account\AssetCollector;
+use App\Support\OrgContext;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Support\Str;
+use Tests\TestCase;
+
+final class AssetCollectorOrgIsolationTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_append_by_anon_id_updates_only_current_org(): void
+    {
+        $anonId = 'anon_shared';
+
+        $attemptOrg1 = $this->seedAttempt(orgId: 1, anonId: $anonId);
+        $attemptOrg2 = $this->seedAttempt(orgId: 2, anonId: $anonId);
+
+        $orgContext = app(OrgContext::class);
+        $orgContext->set(1, null, 'public');
+        app()->instance(OrgContext::class, $orgContext);
+
+        $result = app(AssetCollector::class)->appendByAnonId('u_1', $anonId);
+
+        $this->assertSame(1, (int) ($result['updated'] ?? 0));
+        $this->assertSame('u_1', (string) Attempt::query()->where('id', $attemptOrg1)->value('user_id'));
+        $this->assertNull(Attempt::query()->where('id', $attemptOrg2)->value('user_id'));
+    }
+
+    public function test_append_by_device_key_hash_updates_only_current_org(): void
+    {
+        if (!Schema::hasColumn('attempts', 'device_key_hash')) {
+            Schema::table('attempts', static function (Blueprint $table): void {
+                $table->string('device_key_hash', 191)->nullable()->index();
+            });
+        }
+
+        $deviceKeyHash = 'dk_shared_hash';
+        $attemptOrg1 = $this->seedAttempt(orgId: 1, anonId: 'anon_org_1');
+        $attemptOrg2 = $this->seedAttempt(orgId: 2, anonId: 'anon_org_2');
+
+        DB::table('attempts')->where('id', $attemptOrg1)->update(['device_key_hash' => $deviceKeyHash]);
+        DB::table('attempts')->where('id', $attemptOrg2)->update(['device_key_hash' => $deviceKeyHash]);
+
+        $orgContext = app(OrgContext::class);
+        $orgContext->set(1, null, 'public');
+        app()->instance(OrgContext::class, $orgContext);
+
+        $result = app(AssetCollector::class)->appendByDeviceKeyHash('u_1', $deviceKeyHash);
+
+        $this->assertSame(1, (int) ($result['updated'] ?? 0));
+        $this->assertSame('u_1', (string) Attempt::query()->where('id', $attemptOrg1)->value('user_id'));
+        $this->assertNull(Attempt::query()->where('id', $attemptOrg2)->value('user_id'));
+    }
+
+    private function seedAttempt(int $orgId, string $anonId): string
+    {
+        $attemptId = (string) Str::uuid();
+
+        Attempt::create([
+            'id' => $attemptId,
+            'org_id' => $orgId,
+            'anon_id' => $anonId,
+            'user_id' => null,
+            'scale_code' => 'MBTI',
+            'scale_version' => 'v0.2',
+            'region' => 'CN_MAINLAND',
+            'locale' => 'zh-CN',
+            'question_count' => 144,
+            'answers_summary_json' => ['seed' => true],
+            'client_platform' => 'test',
+            'client_version' => '1.0.0',
+            'channel' => 'test',
+            'started_at' => now()->subMinute(),
+            'submitted_at' => now(),
+            'pack_id' => (string) config('content_packs.default_pack_id', 'MBTI.cn-mainland.zh-CN.v0.2.2'),
+            'dir_version' => (string) config('content_packs.default_dir_version', 'MBTI-CN-v0.2.2'),
+            'content_package_version' => 'v0.2.2',
+            'scoring_spec_version' => '2026.01',
+        ]);
+
+        return $attemptId;
+    }
+}

--- a/backend/tests/Feature/NoEmptyThrowableCatchTest.php
+++ b/backend/tests/Feature/NoEmptyThrowableCatchTest.php
@@ -1,0 +1,189 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature;
+
+use PHPUnit\Framework\Attributes\Test;
+use RecursiveDirectoryIterator;
+use RecursiveIteratorIterator;
+use SplFileInfo;
+use Tests\TestCase;
+
+final class NoEmptyThrowableCatchTest extends TestCase
+{
+    #[Test]
+    public function app_php_files_do_not_contain_empty_throwable_catch_blocks(): void
+    {
+        $offenders = [];
+
+        foreach ($this->appPhpFiles() as $filePath) {
+            $source = (string) file_get_contents($filePath);
+            $relativePath = ltrim(str_replace(base_path(), '', $filePath), DIRECTORY_SEPARATOR);
+
+            foreach ($this->extractCatchBlocks($source) as $block) {
+                if (! $this->isThrowableCatchSignature($block['signature'])) {
+                    continue;
+                }
+
+                $bodyWithoutComments = trim($this->stripComments($block['body']));
+                if ($bodyWithoutComments !== '') {
+                    continue;
+                }
+
+                $offenders[] = "{$relativePath}:{$block['line']}";
+            }
+        }
+
+        if ($offenders !== []) {
+            sort($offenders);
+
+            self::fail(
+                "Empty Throwable catch blocks found:\n".implode("\n", $offenders)
+            );
+        }
+
+        self::assertTrue(true);
+    }
+
+    /**
+     * @return array<int, string>
+     */
+    private function appPhpFiles(): array
+    {
+        $root = base_path('app');
+        $files = [];
+
+        $iterator = new RecursiveIteratorIterator(new RecursiveDirectoryIterator($root));
+        /** @var SplFileInfo $file */
+        foreach ($iterator as $file) {
+            if (! $file->isFile()) {
+                continue;
+            }
+
+            if (strtolower($file->getExtension()) !== 'php') {
+                continue;
+            }
+
+            $files[] = $file->getPathname();
+        }
+
+        sort($files);
+
+        return $files;
+    }
+
+    /**
+     * @return array<int, array{signature:string, body:string, line:int}>
+     */
+    private function extractCatchBlocks(string $source): array
+    {
+        $tokens = token_get_all($source);
+        $blocks = [];
+        $count = count($tokens);
+
+        for ($i = 0; $i < $count; $i++) {
+            $token = $tokens[$i];
+            if (! is_array($token) || $token[0] !== T_CATCH) {
+                continue;
+            }
+
+            $line = (int) $token[2];
+
+            while ($i < $count && $this->tokenText($tokens[$i]) !== '(') {
+                $i++;
+            }
+            if ($i >= $count || $this->tokenText($tokens[$i]) !== '(') {
+                continue;
+            }
+
+            $signature = '(';
+            $parenDepth = 1;
+            $i++;
+            for (; $i < $count; $i++) {
+                $text = $this->tokenText($tokens[$i]);
+                $signature .= $text;
+
+                if ($text === '(') {
+                    $parenDepth++;
+                } elseif ($text === ')') {
+                    $parenDepth--;
+                    if ($parenDepth === 0) {
+                        break;
+                    }
+                }
+            }
+
+            while ($i < $count && $this->tokenText($tokens[$i]) !== '{') {
+                $i++;
+            }
+            if ($i >= $count || $this->tokenText($tokens[$i]) !== '{') {
+                continue;
+            }
+
+            $body = '';
+            $braceDepth = 1;
+            $i++;
+            for (; $i < $count; $i++) {
+                $text = $this->tokenText($tokens[$i]);
+
+                if ($text === '{') {
+                    $braceDepth++;
+                    $body .= $text;
+
+                    continue;
+                }
+
+                if ($text === '}') {
+                    $braceDepth--;
+                    if ($braceDepth === 0) {
+                        break;
+                    }
+                    $body .= $text;
+
+                    continue;
+                }
+
+                $body .= $text;
+            }
+
+            $blocks[] = [
+                'signature' => $signature,
+                'body' => $body,
+                'line' => $line,
+            ];
+        }
+
+        return $blocks;
+    }
+
+    private function isThrowableCatchSignature(string $signature): bool
+    {
+        $normalized = preg_replace('/\s+/', '', $signature);
+        if (! is_string($normalized)) {
+            return false;
+        }
+
+        return preg_match('/^\(\\\\?Throwable(?:\\$[A-Za-z_][A-Za-z0-9_]*)?\)$/', $normalized) === 1;
+    }
+
+    /**
+     * @param  string|array{int, string, int}  $token
+     */
+    private function tokenText(string|array $token): string
+    {
+        if (is_string($token)) {
+            return $token;
+        }
+
+        return $token[1];
+    }
+
+    private function stripComments(string $source): string
+    {
+        $withoutBlock = preg_replace('/\/\*.*?\*\//s', '', $source);
+        $withoutLine = preg_replace('/\/\/[^\n]*|#[^\n]*/', '', (string) $withoutBlock);
+
+        return (string) $withoutLine;
+    }
+}

--- a/backend/tests/Feature/PaginationContractTest.php
+++ b/backend/tests/Feature/PaginationContractTest.php
@@ -1,0 +1,116 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature;
+
+use App\Models\Attempt;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Str;
+use Tests\TestCase;
+
+final class PaginationContractTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_me_attempts_returns_items_meta_links_and_no_legacy_pagination_field(): void
+    {
+        $userId = 8401;
+        $anonId = 'anon_pagination_contract';
+
+        $this->seedUser($userId);
+        $token = $this->seedFmToken($anonId, $userId);
+        $attemptId = $this->seedAttempt(0, $anonId, (string) $userId);
+
+        $response = $this->withHeaders([
+            'Authorization' => "Bearer {$token}",
+        ])->getJson('/api/v0.2/me/attempts');
+
+        $response->assertStatus(200);
+        $response->assertJsonPath('ok', true);
+        $response->assertJsonMissingPath('pagination');
+
+        $payload = (array) $response->json();
+        $this->assertArrayHasKey('items', $payload);
+        $this->assertArrayHasKey('meta', $payload);
+        $this->assertArrayHasKey('links', $payload);
+        $this->assertIsArray($payload['items']);
+        $this->assertIsArray($payload['meta']);
+        $this->assertIsArray($payload['links']);
+
+        $this->assertArrayHasKey('current_page', $payload['meta']);
+        $this->assertArrayHasKey('per_page', $payload['meta']);
+        $this->assertArrayHasKey('total', $payload['meta']);
+        $this->assertArrayHasKey('last_page', $payload['meta']);
+
+        $this->assertArrayHasKey('first', $payload['links']);
+        $this->assertArrayHasKey('last', $payload['links']);
+        $this->assertArrayHasKey('prev', $payload['links']);
+        $this->assertArrayHasKey('next', $payload['links']);
+
+        $firstAttemptId = (string) (($payload['items'][0]['attempt_id'] ?? ''));
+        $this->assertSame($attemptId, $firstAttemptId);
+    }
+
+    private function seedAttempt(int $orgId, string $anonId, string $userId): string
+    {
+        $attemptId = (string) Str::uuid();
+
+        Attempt::create([
+            'id' => $attemptId,
+            'org_id' => $orgId,
+            'anon_id' => $anonId,
+            'user_id' => $userId,
+            'scale_code' => 'MBTI',
+            'scale_version' => 'v0.2',
+            'region' => 'CN_MAINLAND',
+            'locale' => 'zh-CN',
+            'question_count' => 144,
+            'answers_summary_json' => ['seed' => true],
+            'client_platform' => 'test',
+            'client_version' => '1.0.0',
+            'channel' => 'test',
+            'started_at' => now()->subMinutes(2),
+            'submitted_at' => now()->subMinute(),
+            'pack_id' => (string) config('content_packs.default_pack_id'),
+            'dir_version' => (string) config('content_packs.default_dir_version'),
+            'content_package_version' => 'v0.2.2',
+            'scoring_spec_version' => '2026.01',
+            'calculation_snapshot_json' => [
+                'stats' => ['score' => 42],
+                'norm' => ['version' => 'test'],
+            ],
+        ]);
+
+        return $attemptId;
+    }
+
+    private function seedUser(int $id): void
+    {
+        DB::table('users')->insert([
+            'id' => $id,
+            'name' => "user_{$id}",
+            'email' => "user_{$id}@example.test",
+            'password' => bcrypt('secret'),
+            'created_at' => now(),
+            'updated_at' => now(),
+        ]);
+    }
+
+    private function seedFmToken(string $anonId, int $userId): string
+    {
+        $token = 'fm_' . (string) Str::uuid();
+
+        DB::table('fm_tokens')->insert([
+            'token' => $token,
+            'anon_id' => $anonId,
+            'user_id' => $userId,
+            'expires_at' => now()->addHour(),
+            'created_at' => now(),
+            'updated_at' => now(),
+        ]);
+
+        return $token;
+    }
+}

--- a/backend/tests/Feature/V0_2/AttemptOrgIsolationTest.php
+++ b/backend/tests/Feature/V0_2/AttemptOrgIsolationTest.php
@@ -46,6 +46,23 @@ final class AttemptOrgIsolationTest extends TestCase
 
         $resp->assertStatus(200);
         $resp->assertJsonPath('ok', true);
+        $resp->assertJsonMissingPath('pagination');
+
+        $payload = (array) $resp->json();
+        $this->assertArrayHasKey('meta', $payload);
+        $this->assertArrayHasKey('links', $payload);
+        $this->assertIsArray($payload['meta']);
+        $this->assertIsArray($payload['links']);
+
+        $this->assertArrayHasKey('current_page', $payload['meta']);
+        $this->assertArrayHasKey('per_page', $payload['meta']);
+        $this->assertArrayHasKey('total', $payload['meta']);
+        $this->assertArrayHasKey('last_page', $payload['meta']);
+
+        $this->assertArrayHasKey('first', $payload['links']);
+        $this->assertArrayHasKey('last', $payload['links']);
+        $this->assertArrayHasKey('prev', $payload['links']);
+        $this->assertArrayHasKey('next', $payload['links']);
 
         $ids = array_map(static fn (array $row): string => (string) ($row['attempt_id'] ?? ''), (array) $resp->json('items', []));
 

--- a/backend/tests/Feature/V0_2/LegacyAttemptCrossOrgIsolationTest.php
+++ b/backend/tests/Feature/V0_2/LegacyAttemptCrossOrgIsolationTest.php
@@ -1,0 +1,155 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\V0_2;
+
+use App\Models\Attempt;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Support\Str;
+use Tests\TestCase;
+
+final class LegacyAttemptCrossOrgIsolationTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_cross_org_attempt_update_returns_404_without_leaking_existence(): void
+    {
+        $user = User::factory()->create();
+        $this->actingAs($user);
+
+        $attemptId = $this->seedAttempt(
+            orgId: 2,
+            anonId: 'anon_org2',
+            userId: (string) $user->id
+        );
+
+        $token = $this->seedFmToken((int) $user->id, 'anon_org0', 0);
+        $answers = $this->buildAnswers();
+
+        $response = $this->withHeaders([
+            'Authorization' => "Bearer {$token}",
+        ])->postJson("/api/v0.2/attempts/{$attemptId}/result", [
+            'anon_id' => 'anon_org2',
+            'scale_code' => 'MBTI',
+            'scale_version' => 'v0.2',
+            'client_platform' => 'test',
+            'client_version' => '1.0.0',
+            'channel' => 'test',
+            'answers' => $answers,
+        ]);
+
+        $response->assertStatus(404);
+        $response->assertJsonPath('ok', false);
+        $response->assertJsonPath('error_code', 'NOT_FOUND');
+        $response->assertJsonMissingPath('error');
+    }
+
+    public function test_same_org_attempt_update_remains_successful_for_org0_compatibility(): void
+    {
+        $user = User::factory()->create();
+        $this->actingAs($user);
+
+        $attemptId = $this->seedAttempt(
+            orgId: 0,
+            anonId: 'anon_org0',
+            userId: (string) $user->id
+        );
+
+        $token = $this->seedFmToken((int) $user->id, 'anon_org0', 0);
+        $answers = $this->buildAnswers();
+
+        $response = $this->withHeaders([
+            'Authorization' => "Bearer {$token}",
+        ])->postJson("/api/v0.2/attempts/{$attemptId}/result", [
+            'anon_id' => 'anon_org0',
+            'scale_code' => 'MBTI',
+            'scale_version' => 'v0.2',
+            'client_platform' => 'test',
+            'client_version' => '1.0.0',
+            'channel' => 'test',
+            'answers' => $answers,
+        ]);
+
+        $this->assertContains($response->status(), [200, 201]);
+        $response->assertJsonPath('ok', true);
+    }
+
+    /**
+     * @return array<int, array{question_id:string, code:string}>
+     */
+    private function buildAnswers(): array
+    {
+        $questions = $this->getJson('/api/v0.2/scales/MBTI/questions')
+            ->assertStatus(200)
+            ->assertJsonPath('ok', true)
+            ->json('items', []);
+
+        $this->assertIsArray($questions);
+        $this->assertNotEmpty($questions);
+
+        return array_map(static function ($row): array {
+            $qid = is_array($row) ? (string) ($row['question_id'] ?? '') : '';
+
+            return [
+                'question_id' => $qid,
+                'code' => 'A',
+            ];
+        }, $questions);
+    }
+
+    private function seedAttempt(int $orgId, string $anonId, string $userId): string
+    {
+        $attemptId = (string) Str::uuid();
+
+        Attempt::create([
+            'id' => $attemptId,
+            'org_id' => $orgId,
+            'anon_id' => $anonId,
+            'user_id' => $userId,
+            'scale_code' => 'MBTI',
+            'scale_version' => 'v0.2',
+            'region' => 'CN_MAINLAND',
+            'locale' => 'zh-CN',
+            'question_count' => 144,
+            'answers_summary_json' => ['seed' => true],
+            'client_platform' => 'test',
+            'client_version' => '1.0.0',
+            'channel' => 'test',
+            'started_at' => now()->subMinute(),
+            'submitted_at' => now(),
+            'pack_id' => (string) config('content_packs.default_pack_id', 'MBTI.cn-mainland.zh-CN.v0.2.2'),
+            'dir_version' => (string) config('content_packs.default_dir_version', 'MBTI-CN-v0.2.2'),
+            'content_package_version' => 'v0.2.2',
+            'scoring_spec_version' => '2026.01',
+        ]);
+
+        return $attemptId;
+    }
+
+    private function seedFmToken(int $userId, string $anonId, int $orgId): string
+    {
+        $token = 'fm_'.(string) Str::uuid();
+
+        $row = [
+            'token' => $token,
+            'anon_id' => $anonId,
+            'user_id' => $userId,
+            'expires_at' => now()->addHour(),
+            'created_at' => now(),
+            'updated_at' => now(),
+        ];
+        if (Schema::hasColumn('fm_tokens', 'org_id')) {
+            $row['org_id'] = $orgId;
+        } elseif (Schema::hasColumn('fm_tokens', 'meta_json')) {
+            $row['meta_json'] = json_encode(['org_id' => $orgId], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES);
+        }
+
+        DB::table('fm_tokens')->insert($row);
+
+        return $token;
+    }
+}

--- a/scripts/package_release.sh
+++ b/scripts/package_release.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(git rev-parse --show-toplevel)"
+cd "$ROOT"
+
+OUT="release.zip"
+git archive --format=zip --output "$OUT" HEAD
+
+echo "[package_release] created $ROOT/$OUT"


### PR DESCRIPTION
## Summary
This PR delivers five isolated hardening loops in sequence:
1. remove sensitive env leakage and harden release packaging
2. enforce org-scoped write isolation in `AssetCollector`
3. enforce org-scoped read/write isolation in v0.2 legacy attempt write path
4. remove empty `catch (\Throwable)` in `backend/app` and add regression guard test
5. unify API error normalization contract and pagination envelope

## Changes
### 01) Secret leakage + mis-deploy bomb prevention
- remove workspace `backend/.env` (keep only `backend/.env.example`)
- harden `backend/scripts/ci_verify_mbti.sh`:
  - add `ENV_CREATED` marker
  - create `.env` only when absent
  - unified `cleanup()` + `trap EXIT INT TERM`
  - remove `.env` only when script created it
- add `scripts/package_release.sh` using `git archive` to build `release.zip`
- document release policy in `README.md` (forbid zipping working directory)
- expand APP_KEY rotation impact/runbook in `backend/docs/runbooks/secret-rotation.md`

### 02) Multi-tenant write isolation (`AssetCollector`)
- inject `OrgContext` into `AssetCollector`
- add `org_id` guard and filter in:
  - `appendByAnonId`
  - `appendByDeviceKeyHash`
- if `attempts.org_id` missing, return compatible payload with:
  - `ok=true`, `collected=0`, `updated=0`, `reason=attempts_org_id_column_missing`
- add cross-org isolation tests in `AssetCollectorOrgIsolationTest`

### 03) Multi-tenant read/write isolation (`LegacyMbtiAttemptService`)
- inject `OrgContext`
- add helper queries:
  - `attemptQuery($attemptId)` scoped by `id + org_id`
  - `resultQuery($attemptId)` scoped by `attempt_id + org_id`
- replace bare attempt/result lookups with scoped helpers
- ensure v0.2 write path `POST /api/v0.2/attempts/{id}/result` returns 404 for cross-org access
- ensure report job path validates scoped attempt existence and uses current `orgId()`
- add `LegacyAttemptCrossOrgIsolationTest`:
  - cross-org returns 404 without leaking existence (`error` removed by contract)
  - org=0 compatibility path remains successful

### 04) Observability hardening for swallowed exceptions
- replace 14 empty `catch (\Throwable)` blocks with explicit logging signals (non-blocking semantics retained)
- add `NoEmptyThrowableCatchTest` to fail on new empty Throwable catches in `backend/app`

### 05) API contract unification
- update `NormalizeApiErrorContract::shouldNormalize()`:
  - normalize when `ok === false`
  - normalize whenever legacy `error` exists, regardless of HTTP status (including 200)
- add `App\Support\ApiPagination`
- update `GET /api/v0.2/me/attempts` to return:
  - `items + meta + links`
  - remove legacy `pagination`
- update/add tests:
  - `AttemptOrgIsolationTest` pagination assertions
  - `PaginationContractTest`
  - `ApiErrorContractMiddlewareTest` for `200 + legacy error`

## API Contract Changes
1. `GET /api/v0.2/me/attempts`
- before: `items + pagination`
- after: `items + meta + links`

2. error normalization middleware
- legacy payloads containing `error` are normalized to:
  - `{ ok:false, error_code, message, details, request_id }`
- applies even when status code is `200`

## Validation
- `php artisan test --filter AssetCollectorOrgIsolationTest`
- `php artisan test --filter LegacyAttemptCrossOrgIsolationTest`
- `php artisan test --filter NoEmptyThrowableCatchTest`
- `php artisan test --filter ApiErrorContractMiddlewareTest`
- `php artisan test --filter PaginationContractTest`
- `php artisan test` (with runtime-generated `APP_KEY` env override in this local environment)
- `bash backend/scripts/ci_verify_mbti.sh`
- `bash scripts/package_release.sh` and `unzip -l release.zip | grep -E '(^|/)backend/\.env$'` (no match)

## Notes
- local `bash backend/scripts/cae_gate.sh` still reports pre-existing runtime artifacts (`backend/vendor`, `backend/storage/**`) unrelated to these code changes.
