### PR TITLE
feat(sre): SRE-A-013/026/020/030 hardening batch

### DIFF
--- a/backend/app/Console/Commands/Ops/PartitionAttemptAnswerRows.php
+++ b/backend/app/Console/Commands/Ops/PartitionAttemptAnswerRows.php
@@ -1,0 +1,161 @@
+<?php
+
+namespace App\Console\Commands\Ops;
+
+use Carbon\Carbon;
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+class PartitionAttemptAnswerRows extends Command
+{
+    private const TABLE = 'attempt_answer_rows';
+
+    protected $signature = 'ops:partition-attempt-answer-rows
+        {--months=12 : Number of future monthly partitions}
+        {--dry-run : Print SQL without executing}
+        {--execute : Execute ALTER TABLE explicitly}';
+
+    protected $description = 'Apply MySQL monthly RANGE partitions for attempt_answer_rows in maintenance windows';
+
+    public function handle(): int
+    {
+        $driver = DB::connection()->getDriverName();
+        if ($driver !== 'mysql') {
+            $this->info('skip: current driver is not mysql');
+            return self::SUCCESS;
+        }
+
+        if (!Schema::hasTable(self::TABLE)) {
+            $this->error('table missing: ' . self::TABLE);
+            return self::FAILURE;
+        }
+
+        if ($this->hasAnyPartition()) {
+            $this->info('already partitioned: ' . self::TABLE);
+            return self::SUCCESS;
+        }
+
+        $months = (int) $this->option('months');
+        if ($months <= 0) {
+            $this->error('--months must be greater than 0');
+            return self::FAILURE;
+        }
+
+        $constraintError = $this->partitionConstraintError();
+        if ($constraintError !== null) {
+            $this->error($constraintError);
+            return self::FAILURE;
+        }
+
+        $sql = $this->buildPartitionSql($months);
+        $this->line('SQL:');
+        $this->line($sql);
+
+        $shouldExecute = (bool) $this->option('execute');
+        if (!$shouldExecute) {
+            $this->info('dry-run mode (pass --execute to apply DDL)');
+            return self::SUCCESS;
+        }
+
+        $startedAt = microtime(true);
+        DB::statement($sql);
+        $elapsedMs = (int) round((microtime(true) - $startedAt) * 1000);
+
+        $this->info('partition DDL executed successfully. elapsed_ms=' . $elapsedMs);
+
+        return self::SUCCESS;
+    }
+
+    private function hasAnyPartition(): bool
+    {
+        $database = DB::getDatabaseName();
+        if (!is_string($database) || $database === '') {
+            return false;
+        }
+
+        $row = DB::selectOne(
+            'SELECT partition_name
+             FROM information_schema.partitions
+             WHERE table_schema = ?
+               AND table_name = ?
+               AND partition_name IS NOT NULL
+             LIMIT 1',
+            [$database, self::TABLE]
+        );
+
+        return $row !== null;
+    }
+
+    private function partitionConstraintError(): ?string
+    {
+        $database = DB::getDatabaseName();
+        if (!is_string($database) || $database === '') {
+            return 'cannot resolve current database name';
+        }
+
+        $column = DB::selectOne(
+            'SELECT is_nullable
+             FROM information_schema.columns
+             WHERE table_schema = ?
+               AND table_name = ?
+               AND column_name = ?
+             LIMIT 1',
+            [$database, self::TABLE, 'submitted_at']
+        );
+
+        if ($column === null) {
+            return 'constraint failed: submitted_at column not found';
+        }
+
+        $isNullable = strtoupper((string) ($column->is_nullable ?? $column->IS_NULLABLE ?? 'YES'));
+        if ($isNullable !== 'NO') {
+            return 'constraint failed: submitted_at must be NOT NULL for partitioning';
+        }
+
+        $pkRows = DB::select(
+            'SELECT column_name
+             FROM information_schema.key_column_usage
+             WHERE table_schema = ?
+               AND table_name = ?
+               AND constraint_name = ?
+             ORDER BY ordinal_position',
+            [$database, self::TABLE, 'PRIMARY']
+        );
+
+        $pkColumns = array_map(
+            static fn (object $row): string => (string) ($row->column_name ?? $row->COLUMN_NAME ?? ''),
+            $pkRows
+        );
+
+        if (!in_array('submitted_at', $pkColumns, true)) {
+            return 'constraint failed: PRIMARY KEY must include submitted_at';
+        }
+
+        return null;
+    }
+
+    private function buildPartitionSql(int $months): string
+    {
+        $cursor = Carbon::now()->startOfMonth();
+        $parts = [];
+
+        for ($i = 0; $i < $months; $i++) {
+            $next = (clone $cursor)->addMonth();
+            $name = 'p' . $cursor->format('Ym');
+            $parts[] = sprintf(
+                "PARTITION %s VALUES LESS THAN ('%s 00:00:00')",
+                $name,
+                $next->format('Y-m-d')
+            );
+            $cursor = $next;
+        }
+
+        $parts[] = 'PARTITION pmax VALUES LESS THAN (MAXVALUE)';
+
+        return 'ALTER TABLE ' . self::TABLE
+            . ' PARTITION BY RANGE COLUMNS(submitted_at) ('
+            . implode(', ', $parts)
+            . ')';
+    }
+}

--- a/backend/app/Console/Kernel.php
+++ b/backend/app/Console/Kernel.php
@@ -19,6 +19,7 @@ use App\Console\Commands\ArchiveColdData;
 use App\Console\Commands\PaymentsPruneEvents;
 use App\Console\Commands\SeedScaleRegistry;
 use App\Console\Commands\SyncScaleSlugs;
+use App\Console\Commands\Ops\PartitionAttemptAnswerRows;
 
 class Kernel extends ConsoleKernel
 {
@@ -45,6 +46,7 @@ class Kernel extends ConsoleKernel
         PaymentsPruneEvents::class,
         SeedScaleRegistry::class,
         SyncScaleSlugs::class,
+        PartitionAttemptAnswerRows::class,
     ];
 
     /**

--- a/backend/database/migrations/0001_01_01_000000_create_users_table.php
+++ b/backend/database/migrations/0001_01_01_000000_create_users_table.php
@@ -42,8 +42,7 @@ return new class extends Migration
      */
     public function down(): void
     {
-        Schema::dropIfExists('users');
-        Schema::dropIfExists('password_reset_tokens');
-        Schema::dropIfExists('sessions');
+        // forward-only migration: rollback disabled to prevent data loss in production.
+        // Irreversible operation: schema/data rollback handled via forward fix migrations.
     }
 };

--- a/backend/database/migrations/0001_01_01_000001_create_cache_table.php
+++ b/backend/database/migrations/0001_01_01_000001_create_cache_table.php
@@ -29,7 +29,7 @@ return new class extends Migration
      */
     public function down(): void
     {
-        Schema::dropIfExists('cache');
-        Schema::dropIfExists('cache_locks');
+        // forward-only migration: rollback disabled to prevent data loss in production.
+        // Irreversible operation: schema/data rollback handled via forward fix migrations.
     }
 };

--- a/backend/database/migrations/0001_01_01_000002_create_jobs_table.php
+++ b/backend/database/migrations/0001_01_01_000002_create_jobs_table.php
@@ -50,8 +50,7 @@ return new class extends Migration
      */
     public function down(): void
     {
-        Schema::dropIfExists('jobs');
-        Schema::dropIfExists('job_batches');
-        Schema::dropIfExists('failed_jobs');
+        // forward-only migration: rollback disabled to prevent data loss in production.
+        // Irreversible operation: schema/data rollback handled via forward fix migrations.
     }
 };

--- a/backend/database/migrations/2025_12_13_231207_create_results_table.php
+++ b/backend/database/migrations/2025_12_13_231207_create_results_table.php
@@ -47,7 +47,7 @@ return new class extends Migration
      */
     public function down(): void
     {
-        // Safety: Down is a no-op to prevent accidental data loss.
-        // Schema::dropIfExists('results');
+        // forward-only migration: rollback disabled to prevent data loss in production.
+        // Irreversible operation: schema/data rollback handled via forward fix migrations.
     }
 };

--- a/backend/database/migrations/2025_12_14_084436_create_attempts_table.php
+++ b/backend/database/migrations/2025_12_14_084436_create_attempts_table.php
@@ -51,7 +51,7 @@ return new class extends Migration
      */
     public function down(): void
     {
-        // Safety: Down is a no-op to prevent accidental data loss.
-        // Schema::dropIfExists('attempts');
+        // forward-only migration: rollback disabled to prevent data loss in production.
+        // Irreversible operation: schema/data rollback handled via forward fix migrations.
     }
 };

--- a/backend/database/migrations/2025_12_14_091106_create_events_table.php
+++ b/backend/database/migrations/2025_12_14_091106_create_events_table.php
@@ -45,7 +45,7 @@ return new class extends Migration
 
     public function down(): void
     {
-        // Safety: Down is a no-op to prevent accidental data loss.
-        // Schema::dropIfExists('events');
+        // forward-only migration: rollback disabled to prevent data loss in production.
+        // Irreversible operation: schema/data rollback handled via forward fix migrations.
     }
 };

--- a/backend/database/migrations/2025_12_15_165419_add_v021_fields_to_results_table.php
+++ b/backend/database/migrations/2025_12_15_165419_add_v021_fields_to_results_table.php
@@ -17,8 +17,7 @@ return new class extends Migration {
 
     public function down(): void
     {
-        Schema::table('results', function (Blueprint $table) {
-            $table->dropColumn(['scores_pct', 'axis_states', 'content_package_version']);
-        });
+        // forward-only migration: rollback disabled to prevent data loss in production.
+        // Irreversible operation: schema/data rollback handled via forward fix migrations.
     }
 };

--- a/backend/database/migrations/2025_12_15_171546_create_shares_table.php
+++ b/backend/database/migrations/2025_12_15_171546_create_shares_table.php
@@ -25,7 +25,7 @@ return new class extends Migration {
 
     public function down(): void
     {
-        // Safety: Down is a no-op to prevent accidental data loss.
-        // Schema::dropIfExists('shares');
+        // forward-only migration: rollback disabled to prevent data loss in production.
+        // Irreversible operation: schema/data rollback handled via forward fix migrations.
     }
 };

--- a/backend/database/migrations/2025_12_17_165938_create_events_table.php
+++ b/backend/database/migrations/2025_12_17_165938_create_events_table.php
@@ -48,7 +48,7 @@ return new class extends Migration
 
     public function down(): void
     {
-        // Prevent accidental data loss. This table might have existed before.
-        // This migration is guarded by Schema::hasTable(...) in up(), so rollback must never drop the table.
+        // forward-only migration: rollback disabled to prevent data loss in production.
+        // Irreversible operation: schema/data rollback handled via forward fix migrations.
     }
 };

--- a/backend/database/migrations/2025_12_21_101327_add_answers_fields_to_attempts_table.php
+++ b/backend/database/migrations/2025_12_21_101327_add_answers_fields_to_attempts_table.php
@@ -25,18 +25,7 @@ return new class extends Migration
 
     public function down(): void
     {
-        Schema::table('attempts', function (Blueprint $table) {
-            if (Schema::hasColumn('attempts', 'answers_storage_path')) {
-                $table->dropColumn('answers_storage_path');
-            }
-
-            if (Schema::hasColumn('attempts', 'answers_hash')) {
-                $table->dropColumn('answers_hash');
-            }
-
-            if (Schema::hasColumn('attempts', 'answers_json')) {
-                $table->dropColumn('answers_json');
-            }
-        });
+        // forward-only migration: rollback disabled to prevent data loss in production.
+        // Irreversible operation: schema/data rollback handled via forward fix migrations.
     }
 };

--- a/backend/database/migrations/2025_12_28_064425_add_region_locale_to_attempts_table.php
+++ b/backend/database/migrations/2025_12_28_064425_add_region_locale_to_attempts_table.php
@@ -22,9 +22,7 @@ return new class extends Migration
 
 public function down(): void
 {
-    Schema::table('attempts', function (Blueprint $table) {
-        $table->dropIndex('attempts_scale_region_locale_idx');
-        $table->dropColumn(['region', 'locale']);
-    });
-}
+        // forward-only migration: rollback disabled to prevent data loss in production.
+        // Irreversible operation: schema/data rollback handled via forward fix migrations.
+    }
 };

--- a/backend/database/migrations/2026_01_17_040640_add_ticket_code_to_attempts_table.php
+++ b/backend/database/migrations/2026_01_17_040640_add_ticket_code_to_attempts_table.php
@@ -22,9 +22,7 @@ return new class extends Migration
 
     public function down(): void
     {
-        Schema::table('attempts', function (Blueprint $table) {
-            $table->dropUnique('attempts_ticket_code_unique');
-            $table->dropColumn('ticket_code');
-        });
+        // forward-only migration: rollback disabled to prevent data loss in production.
+        // Irreversible operation: schema/data rollback handled via forward fix migrations.
     }
 };

--- a/backend/database/migrations/2026_01_17_164755_add_result_json_to_attempts_table.php
+++ b/backend/database/migrations/2026_01_17_164755_add_result_json_to_attempts_table.php
@@ -38,13 +38,7 @@ return new class extends Migration
 
     public function down(): void
     {
-        Schema::table('attempts', function (Blueprint $table) {
-            if (Schema::hasColumn('attempts', 'type_code')) {
-                $table->dropColumn('type_code');
-            }
-            if (Schema::hasColumn('attempts', 'result_json')) {
-                $table->dropColumn('result_json');
-            }
-        });
+        // forward-only migration: rollback disabled to prevent data loss in production.
+        // Irreversible operation: schema/data rollback handled via forward fix migrations.
     }
 };

--- a/backend/database/migrations/2026_01_18_134019_create_fm_tokens_table.php
+++ b/backend/database/migrations/2026_01_18_134019_create_fm_tokens_table.php
@@ -18,7 +18,7 @@ return new class extends Migration
 
     public function down(): void
     {
-        // Safety: Down is a no-op to prevent accidental data loss.
-        // Schema::dropIfExists('fm_tokens');
+        // forward-only migration: rollback disabled to prevent data loss in production.
+        // Irreversible operation: schema/data rollback handled via forward fix migrations.
     }
 };

--- a/backend/database/migrations/2026_01_18_999999_add_share_id_to_events_table.php
+++ b/backend/database/migrations/2026_01_18_999999_add_share_id_to_events_table.php
@@ -20,33 +20,7 @@ return new class extends Migration
 
     public function down(): void
     {
-        if (!Schema::hasTable('events') || !Schema::hasColumn('events', 'share_id')) {
-            return;
-        }
-
-        $tableName = 'events';
-        $indexName = 'events_share_id_index';
-        $driver = Schema::getConnection()->getDriverName();
-
-        if (SchemaIndex::indexExists($tableName, $indexName)) {
-            try {
-                Schema::table($tableName, function (Blueprint $table): void {
-                    $table->dropIndex('events_share_id_index');
-                });
-                SchemaIndex::logIndexAction('drop_index', $tableName, $indexName, $driver, ['phase' => 'down']);
-            } catch (\Throwable $e) {
-                if (SchemaIndex::isMissingIndexException($e, $indexName)) {
-                    SchemaIndex::logIndexAction('drop_index_skip_missing', $tableName, $indexName, $driver, ['phase' => 'down']);
-                } else {
-                    throw $e;
-                }
-            }
-        } else {
-            SchemaIndex::logIndexAction('drop_index_skip_absent', $tableName, $indexName, $driver, ['phase' => 'down']);
-        }
-
-        Schema::table($tableName, function (Blueprint $table): void {
-            $table->dropColumn('share_id');
-        });
+        // forward-only migration: rollback disabled to prevent data loss in production.
+        // Irreversible operation: schema/data rollback handled via forward fix migrations.
     }
 };

--- a/backend/database/migrations/2026_01_19_111914_add_phone_fields_to_users_table.php
+++ b/backend/database/migrations/2026_01_19_111914_add_phone_fields_to_users_table.php
@@ -20,13 +20,7 @@ return new class extends Migration
 
     public function down(): void
     {
-        Schema::table('users', function (Blueprint $table) {
-            if (Schema::hasColumn('users', 'phone_verified_at')) {
-                $table->dropColumn('phone_verified_at');
-            }
-            if (Schema::hasColumn('users', 'phone_e164')) {
-                $table->dropColumn('phone_e164');
-            }
-        });
+        // forward-only migration: rollback disabled to prevent data loss in production.
+        // Irreversible operation: schema/data rollback handled via forward fix migrations.
     }
 };

--- a/backend/database/migrations/2026_01_19_111915_add_user_id_to_attempts_table.php
+++ b/backend/database/migrations/2026_01_19_111915_add_user_id_to_attempts_table.php
@@ -17,10 +17,7 @@ return new class extends Migration
 
     public function down(): void
     {
-        Schema::table('attempts', function (Blueprint $table) {
-            if (Schema::hasColumn('attempts', 'user_id')) {
-                $table->dropColumn('user_id');
-            }
-        });
+        // forward-only migration: rollback disabled to prevent data loss in production.
+        // Irreversible operation: schema/data rollback handled via forward fix migrations.
     }
 };

--- a/backend/database/migrations/2026_01_19_170606_add_email_fields_to_users_table.php
+++ b/backend/database/migrations/2026_01_19_170606_add_email_fields_to_users_table.php
@@ -20,13 +20,7 @@ return new class extends Migration
 
     public function down(): void
     {
-        Schema::table('users', function (Blueprint $table) {
-            if (Schema::hasColumn('users', 'email_verified_at')) {
-                $table->dropColumn('email_verified_at');
-            }
-            if (Schema::hasColumn('users', 'email')) {
-                $table->dropColumn('email');
-            }
-        });
+        // forward-only migration: rollback disabled to prevent data loss in production.
+        // Irreversible operation: schema/data rollback handled via forward fix migrations.
     }
 };

--- a/backend/database/migrations/2026_01_19_170607_create_email_outbox_table.php
+++ b/backend/database/migrations/2026_01_19_170607_create_email_outbox_table.php
@@ -100,7 +100,7 @@ return new class extends Migration
 
     public function down(): void
     {
-        // Prevent accidental data loss. This table might have existed before.
-        // This migration is guarded by Schema::hasTable(...) in up(), so rollback must never drop the table.
+        // forward-only migration: rollback disabled to prevent data loss in production.
+        // Irreversible operation: schema/data rollback handled via forward fix migrations.
     }
 };

--- a/backend/database/migrations/2026_01_19_180001_create_identities_table.php
+++ b/backend/database/migrations/2026_01_19_180001_create_identities_table.php
@@ -50,7 +50,7 @@ return new class extends Migration
 
     public function down(): void
     {
-        // Prevent accidental data loss. This table might have existed before.
-        // This migration is guarded by Schema::hasTable(...) in up(), so rollback must never drop the table.
+        // forward-only migration: rollback disabled to prevent data loss in production.
+        // Irreversible operation: schema/data rollback handled via forward fix migrations.
     }
 };

--- a/backend/database/migrations/2026_01_20_090001_add_attempt_id_to_email_outbox_table.php
+++ b/backend/database/migrations/2026_01_20_090001_add_attempt_id_to_email_outbox_table.php
@@ -21,14 +21,7 @@ return new class extends Migration
 
     public function down(): void
     {
-        if (!Schema::hasTable('email_outbox')) {
-            return;
-        }
-
-        Schema::table('email_outbox', function (Blueprint $table) {
-            if (Schema::hasColumn('email_outbox', 'attempt_id')) {
-                $table->dropColumn('attempt_id');
-            }
-        });
+        // forward-only migration: rollback disabled to prevent data loss in production.
+        // Irreversible operation: schema/data rollback handled via forward fix migrations.
     }
 };

--- a/backend/database/migrations/2026_01_20_090002_create_lookup_events_table.php
+++ b/backend/database/migrations/2026_01_20_090002_create_lookup_events_table.php
@@ -52,7 +52,7 @@ return new class extends Migration
 
     public function down(): void
     {
-        // Prevent accidental data loss. This table might have existed before.
-        // This migration is guarded by Schema::hasTable(...) in up(), so rollback must never drop the table.
+        // forward-only migration: rollback disabled to prevent data loss in production.
+        // Irreversible operation: schema/data rollback handled via forward fix migrations.
     }
 };

--- a/backend/database/migrations/2026_01_21_090000_create_norms_tables.php
+++ b/backend/database/migrations/2026_01_21_090000_create_norms_tables.php
@@ -99,7 +99,7 @@ return new class extends Migration
 
     public function down(): void
     {
-        // Prevent accidental data loss. This table might have existed before.
-        // This migration is guarded by Schema::hasTable(...) in up(), so rollback must never drop the table.
+        // forward-only migration: rollback disabled to prevent data loss in production.
+        // Irreversible operation: schema/data rollback handled via forward fix migrations.
     }
 };

--- a/backend/database/migrations/2026_01_22_000001_create_validity_feedbacks_table.php
+++ b/backend/database/migrations/2026_01_22_000001_create_validity_feedbacks_table.php
@@ -89,7 +89,7 @@ return new class extends Migration
 
     public function down(): void
     {
-        // Prevent accidental data loss. This table might have existed before.
-        // This migration is guarded by Schema::hasTable(...) in up(), so rollback must never drop the table.
+        // forward-only migration: rollback disabled to prevent data loss in production.
+        // Irreversible operation: schema/data rollback handled via forward fix migrations.
     }
 };

--- a/backend/database/migrations/2026_01_22_090010_create_orders_table.php
+++ b/backend/database/migrations/2026_01_22_090010_create_orders_table.php
@@ -91,7 +91,7 @@ return new class extends Migration
 
     public function down(): void
     {
-        // Prevent accidental data loss. This table might have existed before.
-        // This migration is guarded by Schema::hasTable(...) in up(), so rollback must never drop the table.
+        // forward-only migration: rollback disabled to prevent data loss in production.
+        // Irreversible operation: schema/data rollback handled via forward fix migrations.
     }
 };

--- a/backend/database/migrations/2026_01_22_090020_create_benefit_grants_table.php
+++ b/backend/database/migrations/2026_01_22_090020_create_benefit_grants_table.php
@@ -67,7 +67,7 @@ return new class extends Migration
 
     public function down(): void
     {
-        // Prevent accidental data loss. This table might have existed before.
-        // This migration is guarded by Schema::hasTable(...) in up(), so rollback must never drop the table.
+        // forward-only migration: rollback disabled to prevent data loss in production.
+        // Irreversible operation: schema/data rollback handled via forward fix migrations.
     }
 };

--- a/backend/database/migrations/2026_01_22_090030_create_payment_events_table.php
+++ b/backend/database/migrations/2026_01_22_090030_create_payment_events_table.php
@@ -78,7 +78,7 @@ return new class extends Migration
 
     public function down(): void
     {
-        // Prevent accidental data loss. This table might have existed before.
-        // This migration is guarded by Schema::hasTable(...) in up(), so rollback must never drop the table.
+        // forward-only migration: rollback disabled to prevent data loss in production.
+        // Irreversible operation: schema/data rollback handled via forward fix migrations.
     }
 };

--- a/backend/database/migrations/2026_01_24_162556_add_user_id_to_fm_tokens_table.php
+++ b/backend/database/migrations/2026_01_24_162556_add_user_id_to_fm_tokens_table.php
@@ -14,9 +14,7 @@ return new class extends Migration {
 
     public function down(): void
     {
-        Schema::table('fm_tokens', function (Blueprint $table) {
-            $table->dropIndex(['user_id']);
-            $table->dropColumn('user_id');
-        });
+        // forward-only migration: rollback disabled to prevent data loss in production.
+        // Irreversible operation: schema/data rollback handled via forward fix migrations.
     }
 };

--- a/backend/database/migrations/2026_01_26_090000_create_report_jobs_table.php
+++ b/backend/database/migrations/2026_01_26_090000_create_report_jobs_table.php
@@ -27,6 +27,7 @@ return new class extends Migration
 
     public function down(): void
     {
-        Schema::dropIfExists('report_jobs');
+        // forward-only migration: rollback disabled to prevent data loss in production.
+        // Irreversible operation: schema/data rollback handled via forward fix migrations.
     }
 };

--- a/backend/database/migrations/2026_01_26_110000_create_content_pack_versions_table.php
+++ b/backend/database/migrations/2026_01_26_110000_create_content_pack_versions_table.php
@@ -36,6 +36,7 @@ return new class extends Migration
      */
     public function down(): void
     {
-        Schema::dropIfExists('content_pack_versions');
+        // forward-only migration: rollback disabled to prevent data loss in production.
+        // Irreversible operation: schema/data rollback handled via forward fix migrations.
     }
 };

--- a/backend/database/migrations/2026_01_26_110100_create_content_pack_releases_table.php
+++ b/backend/database/migrations/2026_01_26_110100_create_content_pack_releases_table.php
@@ -37,6 +37,7 @@ return new class extends Migration
      */
     public function down(): void
     {
-        Schema::dropIfExists('content_pack_releases');
+        // forward-only migration: rollback disabled to prevent data loss in production.
+        // Irreversible operation: schema/data rollback handled via forward fix migrations.
     }
 };

--- a/backend/database/migrations/2026_01_27_210000_pr9_add_observability_columns_to_events.php
+++ b/backend/database/migrations/2026_01_27_210000_pr9_add_observability_columns_to_events.php
@@ -99,62 +99,8 @@ return new class extends Migration
 
     public function down(): void
     {
-        $this->dropIndexIfExists('events', 'idx_events_event_time');
-        $this->dropIndexIfExists('events', 'idx_events_attempt');
-        $this->dropIndexIfExists('events', 'idx_events_share');
-        $this->dropIndexIfExists('events', 'idx_events_question');
-        $this->dropIndexIfExists('events', 'idx_events_pack');
-
-        Schema::table('events', function (Blueprint $table): void {
-            if (Schema::hasColumn('events', 'session_id')) {
-                $table->dropColumn('session_id');
-            }
-            if (Schema::hasColumn('events', 'request_id')) {
-                $table->dropColumn('request_id');
-            }
-            if (Schema::hasColumn('events', 'question_id')) {
-                $table->dropColumn('question_id');
-            }
-            if (Schema::hasColumn('events', 'question_index')) {
-                $table->dropColumn('question_index');
-            }
-            if (Schema::hasColumn('events', 'duration_ms')) {
-                $table->dropColumn('duration_ms');
-            }
-            if (Schema::hasColumn('events', 'is_dropoff')) {
-                $table->dropColumn('is_dropoff');
-            }
-            if (Schema::hasColumn('events', 'pack_id')) {
-                $table->dropColumn('pack_id');
-            }
-            if (Schema::hasColumn('events', 'dir_version')) {
-                $table->dropColumn('dir_version');
-            }
-            if (Schema::hasColumn('events', 'pack_semver')) {
-                $table->dropColumn('pack_semver');
-            }
-            if (Schema::hasColumn('events', 'utm_source')) {
-                $table->dropColumn('utm_source');
-            }
-            if (Schema::hasColumn('events', 'utm_medium')) {
-                $table->dropColumn('utm_medium');
-            }
-            if (Schema::hasColumn('events', 'utm_campaign')) {
-                $table->dropColumn('utm_campaign');
-            }
-            if (Schema::hasColumn('events', 'referrer')) {
-                $table->dropColumn('referrer');
-            }
-            if (Schema::hasColumn('events', 'share_channel')) {
-                $table->dropColumn('share_channel');
-            }
-            if (Schema::hasColumn('events', 'share_click_id')) {
-                $table->dropColumn('share_click_id');
-            }
-            if (Schema::hasColumn('events', 'event_name')) {
-                $table->dropColumn('event_name');
-            }
-        });
+        // forward-only migration: rollback disabled to prevent data loss in production.
+        // Irreversible operation: schema/data rollback handled via forward fix migrations.
     }
 
     private function ensureIndex(string $tableName, array $columns, string $indexName): void

--- a/backend/database/migrations/2026_01_27_210100_create_ops_deploy_events.php
+++ b/backend/database/migrations/2026_01_27_210100_create_ops_deploy_events.php
@@ -67,7 +67,7 @@ return new class extends Migration
 
     public function down(): void
     {
-        // Prevent accidental data loss. This table might have existed before.
-        // This migration is guarded by Schema::hasTable(...) in up(), so rollback must never drop the table.
+        // forward-only migration: rollback disabled to prevent data loss in production.
+        // Irreversible operation: schema/data rollback handled via forward fix migrations.
     }
 };

--- a/backend/database/migrations/2026_01_27_210200_create_ops_healthz_snapshots.php
+++ b/backend/database/migrations/2026_01_27_210200_create_ops_healthz_snapshots.php
@@ -77,7 +77,7 @@ return new class extends Migration
 
     public function down(): void
     {
-        // Prevent accidental data loss. This table might have existed before.
-        // This migration is guarded by Schema::hasTable(...) in up(), so rollback must never drop the table.
+        // forward-only migration: rollback disabled to prevent data loss in production.
+        // Irreversible operation: schema/data rollback handled via forward fix migrations.
     }
 };

--- a/backend/database/migrations/2026_01_27_210300_create_views_pr9.php
+++ b/backend/database/migrations/2026_01_27_210300_create_views_pr9.php
@@ -30,19 +30,7 @@ return new class extends Migration
 
     public function down(): void
     {
-        if (config('database.default') === 'sqlite') {
-            return;
-        }
-
-        $viewDir = base_path('tools/sql/views');
-        if (!is_dir($viewDir)) {
-            $viewDir = base_path('../tools/sql/views');
-        }
-        $files = glob($viewDir . '/v_*.sql') ?: [];
-
-        foreach ($files as $file) {
-            $viewName = pathinfo($file, PATHINFO_FILENAME);
-            DB::unprepared("DROP VIEW IF EXISTS {$viewName}");
-        }
+        // forward-only migration: rollback disabled to prevent data loss in production.
+        // Irreversible operation: schema/data rollback handled via forward fix migrations.
     }
 };

--- a/backend/database/migrations/2026_01_27_210350_refresh_views_pr9.php
+++ b/backend/database/migrations/2026_01_27_210350_refresh_views_pr9.php
@@ -29,6 +29,7 @@ return new class extends Migration
 
     public function down(): void
     {
-        // no-op (views are managed by create_views_pr9 migration)
+        // forward-only migration: rollback disabled to prevent data loss in production.
+        // Irreversible operation: schema/data rollback handled via forward fix migrations.
     }
 };

--- a/backend/database/migrations/2026_01_28_090000_create_admin_users_table.php
+++ b/backend/database/migrations/2026_01_28_090000_create_admin_users_table.php
@@ -62,8 +62,8 @@ return new class extends Migration
 
     public function down(): void
     {
-        // Prevent accidental data loss. This table might have existed before.
-        // This migration is guarded by Schema::hasTable(...) in up(), so rollback must never drop the table.
+        // forward-only migration: rollback disabled to prevent data loss in production.
+        // Irreversible operation: schema/data rollback handled via forward fix migrations.
     }
 
     private function ensureUniqueIndex(string $tableName, array $columns, string $indexName, array $alternateNames = []): void

--- a/backend/database/migrations/2026_01_28_090010_create_roles_table.php
+++ b/backend/database/migrations/2026_01_28_090010_create_roles_table.php
@@ -46,8 +46,8 @@ return new class extends Migration
 
     public function down(): void
     {
-        // Prevent accidental data loss. This table might have existed before.
-        // This migration is guarded by Schema::hasTable(...) in up(), so rollback must never drop the table.
+        // forward-only migration: rollback disabled to prevent data loss in production.
+        // Irreversible operation: schema/data rollback handled via forward fix migrations.
     }
 
     private function ensureUniqueIndex(string $tableName, array $columns, string $indexName, array $alternateNames = []): void

--- a/backend/database/migrations/2026_01_28_090020_create_permissions_table.php
+++ b/backend/database/migrations/2026_01_28_090020_create_permissions_table.php
@@ -46,8 +46,8 @@ return new class extends Migration
 
     public function down(): void
     {
-        // Prevent accidental data loss. This table might have existed before.
-        // This migration is guarded by Schema::hasTable(...) in up(), so rollback must never drop the table.
+        // forward-only migration: rollback disabled to prevent data loss in production.
+        // Irreversible operation: schema/data rollback handled via forward fix migrations.
     }
 
     private function ensureUniqueIndex(string $tableName, array $columns, string $indexName, array $alternateNames = []): void

--- a/backend/database/migrations/2026_01_28_090030_create_role_user_table.php
+++ b/backend/database/migrations/2026_01_28_090030_create_role_user_table.php
@@ -44,8 +44,8 @@ return new class extends Migration
 
     public function down(): void
     {
-        // Prevent accidental data loss. This table might have existed before.
-        // This migration is guarded by Schema::hasTable(...) in up(), so rollback must never drop the table.
+        // forward-only migration: rollback disabled to prevent data loss in production.
+        // Irreversible operation: schema/data rollback handled via forward fix migrations.
     }
 
     private function ensureUniqueIndex(string $tableName, array $columns, string $indexName): void

--- a/backend/database/migrations/2026_01_28_090040_create_permission_role_table.php
+++ b/backend/database/migrations/2026_01_28_090040_create_permission_role_table.php
@@ -44,8 +44,8 @@ return new class extends Migration
 
     public function down(): void
     {
-        // Prevent accidental data loss. This table might have existed before.
-        // This migration is guarded by Schema::hasTable(...) in up(), so rollback must never drop the table.
+        // forward-only migration: rollback disabled to prevent data loss in production.
+        // Irreversible operation: schema/data rollback handled via forward fix migrations.
     }
 
     private function ensureUniqueIndex(string $tableName, array $columns, string $indexName): void

--- a/backend/database/migrations/2026_01_28_090050_create_audit_logs_table.php
+++ b/backend/database/migrations/2026_01_28_090050_create_audit_logs_table.php
@@ -66,8 +66,8 @@ return new class extends Migration
 
     public function down(): void
     {
-        // Prevent accidental data loss. This table might have existed before.
-        // This migration is guarded by Schema::hasTable(...) in up(), so rollback must never drop the table.
+        // forward-only migration: rollback disabled to prevent data loss in production.
+        // Irreversible operation: schema/data rollback handled via forward fix migrations.
     }
 
     private function ensureIndex(string $tableName, array $columns, string $indexName): void

--- a/backend/database/migrations/2026_01_28_110000_add_psychometrics_snapshot_to_attempts.php
+++ b/backend/database/migrations/2026_01_28_110000_add_psychometrics_snapshot_to_attempts.php
@@ -48,34 +48,8 @@ return new class extends Migration
 
     public function down(): void
     {
-        if (!Schema::hasTable('attempts')) {
-            return;
-        }
-
-        $indexName = 'attempts_pack_norm_idx';
-        if ($this->indexExists('attempts', $indexName)) {
-            Schema::table('attempts', function (Blueprint $table) use ($indexName) {
-                $table->dropIndex($indexName);
-            });
-        }
-
-        Schema::table('attempts', function (Blueprint $table) {
-            if (Schema::hasColumn('attempts', 'calculation_snapshot_json')) {
-                $table->dropColumn('calculation_snapshot_json');
-            }
-            if (Schema::hasColumn('attempts', 'norm_version')) {
-                $table->dropColumn('norm_version');
-            }
-            if (Schema::hasColumn('attempts', 'scoring_spec_version')) {
-                $table->dropColumn('scoring_spec_version');
-            }
-            if (Schema::hasColumn('attempts', 'dir_version')) {
-                $table->dropColumn('dir_version');
-            }
-            if (Schema::hasColumn('attempts', 'pack_id')) {
-                $table->dropColumn('pack_id');
-            }
-        });
+        // forward-only migration: rollback disabled to prevent data loss in production.
+        // Irreversible operation: schema/data rollback handled via forward fix migrations.
     }
 
     private function indexExists(string $table, string $indexName): bool

--- a/backend/database/migrations/2026_01_28_110100_create_scale_norms_versions_table.php
+++ b/backend/database/migrations/2026_01_28_110100_create_scale_norms_versions_table.php
@@ -103,8 +103,8 @@ return new class extends Migration
 
     public function down(): void
     {
-        // Prevent accidental data loss. This table might have existed before.
-        // This migration is guarded by Schema::hasTable(...) in up(), so rollback must never drop the table.
+        // forward-only migration: rollback disabled to prevent data loss in production.
+        // Irreversible operation: schema/data rollback handled via forward fix migrations.
     }
 
     private function indexExists(string $table, string $indexName): bool

--- a/backend/database/migrations/2026_01_28_110200_create_attempt_quality_table.php
+++ b/backend/database/migrations/2026_01_28_110200_create_attempt_quality_table.php
@@ -62,8 +62,8 @@ return new class extends Migration
 
     public function down(): void
     {
-        // Prevent accidental data loss. This table might have existed before.
-        // This migration is guarded by Schema::hasTable(...) in up(), so rollback must never drop the table.
+        // forward-only migration: rollback disabled to prevent data loss in production.
+        // Irreversible operation: schema/data rollback handled via forward fix migrations.
     }
 
     private function indexExists(string $table, string $indexName): bool

--- a/backend/database/migrations/2026_01_28_120000_create_ai_insights_table.php
+++ b/backend/database/migrations/2026_01_28_120000_create_ai_insights_table.php
@@ -131,7 +131,7 @@ return new class extends Migration
 
     public function down(): void
     {
-        // Safety: Down is a no-op to prevent accidental data loss.
-        // Schema::drop('ai_insights');
+        // forward-only migration: rollback disabled to prevent data loss in production.
+        // Irreversible operation: schema/data rollback handled via forward fix migrations.
     }
 };

--- a/backend/database/migrations/2026_01_28_120100_create_ai_insight_feedback_table.php
+++ b/backend/database/migrations/2026_01_28_120100_create_ai_insight_feedback_table.php
@@ -55,7 +55,7 @@ return new class extends Migration
 
     public function down(): void
     {
-        // Safety: Down is a no-op to prevent accidental data loss.
-        // Schema::drop('ai_insight_feedback');
+        // forward-only migration: rollback disabled to prevent data loss in production.
+        // Irreversible operation: schema/data rollback handled via forward fix migrations.
     }
 };

--- a/backend/database/migrations/2026_01_28_130000_create_integrations_tables.php
+++ b/backend/database/migrations/2026_01_28_130000_create_integrations_tables.php
@@ -82,8 +82,8 @@ return new class extends Migration
 
     public function down(): void
     {
-        // Prevent accidental data loss. This table might have existed before.
-        // This migration is guarded by Schema::hasTable(...) in up(), so rollback must never drop the table.
+        // forward-only migration: rollback disabled to prevent data loss in production.
+        // Irreversible operation: schema/data rollback handled via forward fix migrations.
     }
 
     private function indexExists(string $table, string $indexName): bool

--- a/backend/database/migrations/2026_01_28_130100_create_ingest_batches_table.php
+++ b/backend/database/migrations/2026_01_28_130100_create_ingest_batches_table.php
@@ -67,8 +67,8 @@ return new class extends Migration
 
     public function down(): void
     {
-        // Prevent accidental data loss. This table might have existed before.
-        // This migration is guarded by Schema::hasTable(...) in up(), so rollback must never drop the table.
+        // forward-only migration: rollback disabled to prevent data loss in production.
+        // Irreversible operation: schema/data rollback handled via forward fix migrations.
     }
 
     private function indexExists(string $table, string $indexName): bool

--- a/backend/database/migrations/2026_01_28_130200_create_sleep_samples_table.php
+++ b/backend/database/migrations/2026_01_28_130200_create_sleep_samples_table.php
@@ -82,8 +82,8 @@ return new class extends Migration
 
     public function down(): void
     {
-        // Prevent accidental data loss. This table might have existed before.
-        // This migration is guarded by Schema::hasTable(...) in up(), so rollback must never drop the table.
+        // forward-only migration: rollback disabled to prevent data loss in production.
+        // Irreversible operation: schema/data rollback handled via forward fix migrations.
     }
 
     private function indexExists(string $table, string $indexName): bool

--- a/backend/database/migrations/2026_01_28_130300_create_health_samples_table.php
+++ b/backend/database/migrations/2026_01_28_130300_create_health_samples_table.php
@@ -86,8 +86,8 @@ return new class extends Migration
 
     public function down(): void
     {
-        // Prevent accidental data loss. This table might have existed before.
-        // This migration is guarded by Schema::hasTable(...) in up(), so rollback must never drop the table.
+        // forward-only migration: rollback disabled to prevent data loss in production.
+        // Irreversible operation: schema/data rollback handled via forward fix migrations.
     }
 
     private function indexExists(string $table, string $indexName): bool

--- a/backend/database/migrations/2026_01_28_130400_create_screen_time_samples_table.php
+++ b/backend/database/migrations/2026_01_28_130400_create_screen_time_samples_table.php
@@ -82,8 +82,8 @@ return new class extends Migration
 
     public function down(): void
     {
-        // Prevent accidental data loss. This table might have existed before.
-        // This migration is guarded by Schema::hasTable(...) in up(), so rollback must never drop the table.
+        // forward-only migration: rollback disabled to prevent data loss in production.
+        // Irreversible operation: schema/data rollback handled via forward fix migrations.
     }
 
     private function indexExists(string $table, string $indexName): bool

--- a/backend/database/migrations/2026_01_28_130500_create_idempotency_keys_table.php
+++ b/backend/database/migrations/2026_01_28_130500_create_idempotency_keys_table.php
@@ -88,8 +88,8 @@ return new class extends Migration
 
     public function down(): void
     {
-        // Prevent accidental data loss. This table might have existed before.
-        // This migration is guarded by Schema::hasTable(...) in up(), so rollback must never drop the table.
+        // forward-only migration: rollback disabled to prevent data loss in production.
+        // Irreversible operation: schema/data rollback handled via forward fix migrations.
     }
 
     private function indexExists(string $table, string $indexName): bool

--- a/backend/database/migrations/2026_01_28_140000_create_user_agent_settings.php
+++ b/backend/database/migrations/2026_01_28_140000_create_user_agent_settings.php
@@ -95,8 +95,8 @@ return new class extends Migration
 
     public function down(): void
     {
-        // Prevent accidental data loss. This table might have existed before.
-        // This migration is guarded by Schema::hasTable(...) in up(), so rollback must never drop the table.
+        // forward-only migration: rollback disabled to prevent data loss in production.
+        // Irreversible operation: schema/data rollback handled via forward fix migrations.
     }
 
     private function indexExists(string $table, string $indexName): bool

--- a/backend/database/migrations/2026_01_28_140100_create_memories_table.php
+++ b/backend/database/migrations/2026_01_28_140100_create_memories_table.php
@@ -140,8 +140,8 @@ return new class extends Migration
 
     public function down(): void
     {
-        // Prevent accidental data loss. This table might have existed before.
-        // This migration is guarded by Schema::hasTable(...) in up(), so rollback must never drop the table.
+        // forward-only migration: rollback disabled to prevent data loss in production.
+        // Irreversible operation: schema/data rollback handled via forward fix migrations.
     }
 
     private function indexExists(string $table, string $indexName): bool

--- a/backend/database/migrations/2026_01_28_140200_create_embeddings_index.php
+++ b/backend/database/migrations/2026_01_28_140200_create_embeddings_index.php
@@ -112,8 +112,8 @@ return new class extends Migration
 
     public function down(): void
     {
-        // Prevent accidental data loss. This table might have existed before.
-        // This migration is guarded by Schema::hasTable(...) in up(), so rollback must never drop the table.
+        // forward-only migration: rollback disabled to prevent data loss in production.
+        // Irreversible operation: schema/data rollback handled via forward fix migrations.
     }
 
     private function indexExists(string $table, string $indexName): bool

--- a/backend/database/migrations/2026_01_28_140300_create_embeddings_table.php
+++ b/backend/database/migrations/2026_01_28_140300_create_embeddings_table.php
@@ -117,8 +117,8 @@ return new class extends Migration
 
     public function down(): void
     {
-        // Prevent accidental data loss. This table might have existed before.
-        // This migration is guarded by Schema::hasTable(...) in up(), so rollback must never drop the table.
+        // forward-only migration: rollback disabled to prevent data loss in production.
+        // Irreversible operation: schema/data rollback handled via forward fix migrations.
     }
 
     private function indexExists(string $table, string $indexName): bool

--- a/backend/database/migrations/2026_01_28_140400_create_agent_triggers.php
+++ b/backend/database/migrations/2026_01_28_140400_create_agent_triggers.php
@@ -105,8 +105,8 @@ return new class extends Migration
 
     public function down(): void
     {
-        // Prevent accidental data loss. This table might have existed before.
-        // This migration is guarded by Schema::hasTable(...) in up(), so rollback must never drop the table.
+        // forward-only migration: rollback disabled to prevent data loss in production.
+        // Irreversible operation: schema/data rollback handled via forward fix migrations.
     }
 
     private function indexExists(string $table, string $indexName): bool

--- a/backend/database/migrations/2026_01_28_140500_create_agent_decisions.php
+++ b/backend/database/migrations/2026_01_28_140500_create_agent_decisions.php
@@ -99,8 +99,8 @@ return new class extends Migration
 
     public function down(): void
     {
-        // Prevent accidental data loss. This table might have existed before.
-        // This migration is guarded by Schema::hasTable(...) in up(), so rollback must never drop the table.
+        // forward-only migration: rollback disabled to prevent data loss in production.
+        // Irreversible operation: schema/data rollback handled via forward fix migrations.
     }
 
     private function indexExists(string $table, string $indexName): bool

--- a/backend/database/migrations/2026_01_28_140600_create_agent_messages.php
+++ b/backend/database/migrations/2026_01_28_140600_create_agent_messages.php
@@ -148,8 +148,8 @@ return new class extends Migration
 
     public function down(): void
     {
-        // Prevent accidental data loss. This table might have existed before.
-        // This migration is guarded by Schema::hasTable(...) in up(), so rollback must never drop the table.
+        // forward-only migration: rollback disabled to prevent data loss in production.
+        // Irreversible operation: schema/data rollback handled via forward fix migrations.
     }
 
     private function indexExists(string $table, string $indexName): bool

--- a/backend/database/migrations/2026_01_28_140700_create_agent_feedback.php
+++ b/backend/database/migrations/2026_01_28_140700_create_agent_feedback.php
@@ -76,8 +76,8 @@ return new class extends Migration
 
     public function down(): void
     {
-        // Prevent accidental data loss. This table might have existed before.
-        // This migration is guarded by Schema::hasTable(...) in up(), so rollback must never drop the table.
+        // forward-only migration: rollback disabled to prevent data loss in production.
+        // Irreversible operation: schema/data rollback handled via forward fix migrations.
     }
 
     private function indexExists(string $table, string $indexName): bool

--- a/backend/database/migrations/2026_01_29_000001_create_organizations_table.php
+++ b/backend/database/migrations/2026_01_29_000001_create_organizations_table.php
@@ -50,7 +50,7 @@ return new class extends Migration
 
     public function down(): void
     {
-        // Prevent accidental data loss. This table might have existed before.
-        // This migration is guarded by Schema::hasTable(...) in up(), so rollback must never drop the table.
+        // forward-only migration: rollback disabled to prevent data loss in production.
+        // Irreversible operation: schema/data rollback handled via forward fix migrations.
     }
 };

--- a/backend/database/migrations/2026_01_29_000002_create_organization_members_table.php
+++ b/backend/database/migrations/2026_01_29_000002_create_organization_members_table.php
@@ -75,7 +75,7 @@ return new class extends Migration
 
     public function down(): void
     {
-        // Prevent accidental data loss. This table might have existed before.
-        // This migration is guarded by Schema::hasTable(...) in up(), so rollback must never drop the table.
+        // forward-only migration: rollback disabled to prevent data loss in production.
+        // Irreversible operation: schema/data rollback handled via forward fix migrations.
     }
 };

--- a/backend/database/migrations/2026_01_29_000003_create_organization_invites_table.php
+++ b/backend/database/migrations/2026_01_29_000003_create_organization_invites_table.php
@@ -77,7 +77,7 @@ return new class extends Migration
 
     public function down(): void
     {
-        // Prevent accidental data loss. This table might have existed before.
-        // This migration is guarded by Schema::hasTable(...) in up(), so rollback must never drop the table.
+        // forward-only migration: rollback disabled to prevent data loss in production.
+        // Irreversible operation: schema/data rollback handled via forward fix migrations.
     }
 };

--- a/backend/database/migrations/2026_01_29_000004_add_org_id_to_attempts_results_events_report_jobs.php
+++ b/backend/database/migrations/2026_01_29_000004_add_org_id_to_attempts_results_events_report_jobs.php
@@ -82,74 +82,8 @@ return new class extends Migration
 
     public function down(): void
     {
-        if (Schema::hasTable('attempts')) {
-            $indexName = 'attempts_org_id_idx';
-            if ($this->indexExists('attempts', $indexName)) {
-                Schema::table('attempts', function (Blueprint $table) use ($indexName) {
-                    $table->dropIndex($indexName);
-                });
-            }
-            Schema::table('attempts', function (Blueprint $table) {
-                if (Schema::hasColumn('attempts', 'org_id')) {
-                    $table->dropColumn('org_id');
-                }
-            });
-        }
-
-        if (Schema::hasTable('results')) {
-            $uniqueName = 'results_org_id_attempt_id_unique';
-            $legacyUniqueName = 'results_org_attempt_unique';
-            if ($this->indexExists('results', $uniqueName)) {
-                Schema::table('results', function (Blueprint $table) use ($uniqueName) {
-                    $table->dropUnique($uniqueName);
-                });
-            } elseif ($this->indexExists('results', $legacyUniqueName)) {
-                Schema::table('results', function (Blueprint $table) use ($legacyUniqueName) {
-                    $table->dropUnique($legacyUniqueName);
-                });
-            }
-
-            $indexName = 'results_org_id_idx';
-            if ($this->indexExists('results', $indexName)) {
-                Schema::table('results', function (Blueprint $table) use ($indexName) {
-                    $table->dropIndex($indexName);
-                });
-            }
-
-            Schema::table('results', function (Blueprint $table) {
-                if (Schema::hasColumn('results', 'org_id')) {
-                    $table->dropColumn('org_id');
-                }
-            });
-        }
-
-        if (Schema::hasTable('events')) {
-            $indexName = 'events_org_id_idx';
-            if ($this->indexExists('events', $indexName)) {
-                Schema::table('events', function (Blueprint $table) use ($indexName) {
-                    $table->dropIndex($indexName);
-                });
-            }
-            Schema::table('events', function (Blueprint $table) {
-                if (Schema::hasColumn('events', 'org_id')) {
-                    $table->dropColumn('org_id');
-                }
-            });
-        }
-
-        if (Schema::hasTable('report_jobs')) {
-            $indexName = 'report_jobs_org_id_idx';
-            if ($this->indexExists('report_jobs', $indexName)) {
-                Schema::table('report_jobs', function (Blueprint $table) use ($indexName) {
-                    $table->dropIndex($indexName);
-                });
-            }
-            Schema::table('report_jobs', function (Blueprint $table) {
-                if (Schema::hasColumn('report_jobs', 'org_id')) {
-                    $table->dropColumn('org_id');
-                }
-            });
-        }
+        // forward-only migration: rollback disabled to prevent data loss in production.
+        // Irreversible operation: schema/data rollback handled via forward fix migrations.
     }
 
     private function indexExists(string $table, string $indexName): bool

--- a/backend/database/migrations/2026_01_29_090000_create_scales_registry_table.php
+++ b/backend/database/migrations/2026_01_29_090000_create_scales_registry_table.php
@@ -178,8 +178,8 @@ return new class extends Migration
 
     public function down(): void
     {
-        // Safety: Down is a no-op to prevent accidental data loss.
-        // Schema::drop('scales_registry');
+        // forward-only migration: rollback disabled to prevent data loss in production.
+        // Irreversible operation: schema/data rollback handled via forward fix migrations.
     }
 
     private function indexExists(string $table, string $indexName): bool

--- a/backend/database/migrations/2026_01_29_090010_create_scale_slugs_table.php
+++ b/backend/database/migrations/2026_01_29_090010_create_scale_slugs_table.php
@@ -86,8 +86,8 @@ return new class extends Migration
 
     public function down(): void
     {
-        // Safety: Down is a no-op to prevent accidental data loss.
-        // Schema::drop('scale_slugs');
+        // forward-only migration: rollback disabled to prevent data loss in production.
+        // Irreversible operation: schema/data rollback handled via forward fix migrations.
     }
 
     private function indexExists(string $table, string $indexName): bool

--- a/backend/database/migrations/2026_01_29_120000_v03_attempts_results_fields.php
+++ b/backend/database/migrations/2026_01_29_120000_v03_attempts_results_fields.php
@@ -115,78 +115,8 @@ return new class extends Migration
 
     public function down(): void
     {
-        if (Schema::hasTable('attempts')) {
-            $indexName = 'attempts_org_scale_pack_dir_idx';
-            if ($this->indexExists('attempts', $indexName)) {
-                Schema::table('attempts', function (Blueprint $table) use ($indexName) {
-                    $table->dropIndex($indexName);
-                });
-            }
-
-            $indexName = 'attempts_org_anon_idx';
-            if ($this->indexExists('attempts', $indexName)) {
-                Schema::table('attempts', function (Blueprint $table) use ($indexName) {
-                    $table->dropIndex($indexName);
-                });
-            }
-
-            $indexName = 'attempts_org_user_idx';
-            if ($this->indexExists('attempts', $indexName)) {
-                Schema::table('attempts', function (Blueprint $table) use ($indexName) {
-                    $table->dropIndex($indexName);
-                });
-            }
-
-            Schema::table('attempts', function (Blueprint $table) {
-                if (Schema::hasColumn('attempts', 'answers_digest')) {
-                    // Irreversible operation: Column dropped manually if needed (rollback disabled to prevent data loss).
-                }
-                if (Schema::hasColumn('attempts', 'duration_ms')) {
-                    // Irreversible operation: Column dropped manually if needed (rollback disabled to prevent data loss).
-                }
-                if (Schema::hasColumn('attempts', 'content_package_version')) {
-                    // Irreversible operation: Column dropped manually if needed (rollback disabled to prevent data loss).
-                }
-                if (Schema::hasColumn('attempts', 'org_id')) {
-                    // Irreversible operation: Column dropped manually if needed (rollback disabled to prevent data loss).
-                }
-            });
-        }
-
-        if (Schema::hasTable('results')) {
-            $indexName = 'results_org_id_attempt_id_unique';
-            $legacyIndexName = 'results_org_attempt_unique';
-            if ($this->indexExists('results', $indexName)) {
-                Schema::table('results', function (Blueprint $table) use ($indexName) {
-                    $table->dropUnique($indexName);
-                });
-            } elseif ($this->indexExists('results', $legacyIndexName)) {
-                Schema::table('results', function (Blueprint $table) use ($legacyIndexName) {
-                    $table->dropUnique($legacyIndexName);
-                });
-            }
-
-            Schema::table('results', function (Blueprint $table) {
-                if (Schema::hasColumn('results', 'report_engine_version')) {
-                    // Irreversible operation: Column dropped manually if needed (rollback disabled to prevent data loss).
-                }
-                if (Schema::hasColumn('results', 'scoring_spec_version')) {
-                    // Irreversible operation: Column dropped manually if needed (rollback disabled to prevent data loss).
-                }
-                if (Schema::hasColumn('results', 'dir_version')) {
-                    // Irreversible operation: Column dropped manually if needed (rollback disabled to prevent data loss).
-                }
-                if (Schema::hasColumn('results', 'pack_id')) {
-                    // Irreversible operation: Column dropped manually if needed (rollback disabled to prevent data loss).
-                }
-                if (Schema::hasColumn('results', 'result_json')) {
-                    // Irreversible operation: Column dropped manually if needed (rollback disabled to prevent data loss).
-                }
-                if (Schema::hasColumn('results', 'org_id')) {
-                    // Irreversible operation: Column dropped manually if needed (rollback disabled to prevent data loss).
-                }
-            });
-        }
+        // forward-only migration: rollback disabled to prevent data loss in production.
+        // Irreversible operation: schema/data rollback handled via forward fix migrations.
     }
 
     private function indexExists(string $table, string $indexName): bool

--- a/backend/database/migrations/2026_01_29_140000_create_report_snapshots_table.php
+++ b/backend/database/migrations/2026_01_29_140000_create_report_snapshots_table.php
@@ -114,8 +114,8 @@ return new class extends Migration
 
     public function down(): void
     {
-        // Prevent accidental data loss. This table might have existed before.
-        // This migration is guarded by Schema::hasTable(...) in up(), so rollback must never drop the table.
+        // forward-only migration: rollback disabled to prevent data loss in production.
+        // Irreversible operation: schema/data rollback handled via forward fix migrations.
     }
 
     private function indexExists(string $table, string $indexName): bool

--- a/backend/database/migrations/2026_01_29_200000_create_skus_table.php
+++ b/backend/database/migrations/2026_01_29_200000_create_skus_table.php
@@ -91,8 +91,8 @@ return new class extends Migration
 
     public function down(): void
     {
-        // Prevent accidental data loss. This table might have existed before.
-        // This migration is guarded by Schema::hasTable(...) in up(), so rollback must never drop the table.
+        // forward-only migration: rollback disabled to prevent data loss in production.
+        // Irreversible operation: schema/data rollback handled via forward fix migrations.
     }
 
     private function indexExists(string $table, string $indexName): bool

--- a/backend/database/migrations/2026_01_29_200010_create_orders_table.php
+++ b/backend/database/migrations/2026_01_29_200010_create_orders_table.php
@@ -99,8 +99,8 @@ return new class extends Migration
 
     public function down(): void
     {
-        // Prevent accidental data loss. This table might have existed before.
-        // This migration is guarded by Schema::hasTable(...) in up(), so rollback must never drop the table.
+        // forward-only migration: rollback disabled to prevent data loss in production.
+        // Irreversible operation: schema/data rollback handled via forward fix migrations.
     }
 
     private function indexExists(string $table, string $indexName): bool

--- a/backend/database/migrations/2026_01_29_200020_create_payment_events_table.php
+++ b/backend/database/migrations/2026_01_29_200020_create_payment_events_table.php
@@ -53,8 +53,8 @@ return new class extends Migration
 
     public function down(): void
     {
-        // Prevent accidental data loss. This table might have existed before.
-        // This migration is guarded by Schema::hasTable(...) in up(), so rollback must never drop the table.
+        // forward-only migration: rollback disabled to prevent data loss in production.
+        // Irreversible operation: schema/data rollback handled via forward fix migrations.
     }
 
     private function indexExists(string $table, string $indexName): bool

--- a/backend/database/migrations/2026_01_29_200030_create_benefit_wallets_table.php
+++ b/backend/database/migrations/2026_01_29_200030_create_benefit_wallets_table.php
@@ -63,8 +63,8 @@ return new class extends Migration
 
     public function down(): void
     {
-        // Prevent accidental data loss. This table might have existed before.
-        // This migration is guarded by Schema::hasTable(...) in up(), so rollback must never drop the table.
+        // forward-only migration: rollback disabled to prevent data loss in production.
+        // Irreversible operation: schema/data rollback handled via forward fix migrations.
     }
 
     private function indexExists(string $table, string $indexName): bool

--- a/backend/database/migrations/2026_01_29_200040_create_benefit_wallet_ledgers_table.php
+++ b/backend/database/migrations/2026_01_29_200040_create_benefit_wallet_ledgers_table.php
@@ -85,8 +85,8 @@ return new class extends Migration
 
     public function down(): void
     {
-        // Prevent accidental data loss. This table might have existed before.
-        // This migration is guarded by Schema::hasTable(...) in up(), so rollback must never drop the table.
+        // forward-only migration: rollback disabled to prevent data loss in production.
+        // Irreversible operation: schema/data rollback handled via forward fix migrations.
     }
 
     private function indexExists(string $table, string $indexName): bool

--- a/backend/database/migrations/2026_01_29_200050_create_benefit_consumptions_table.php
+++ b/backend/database/migrations/2026_01_29_200050_create_benefit_consumptions_table.php
@@ -75,8 +75,8 @@ return new class extends Migration
 
     public function down(): void
     {
-        // Prevent accidental data loss. This table might have existed before.
-        // This migration is guarded by Schema::hasTable(...) in up(), so rollback must never drop the table.
+        // forward-only migration: rollback disabled to prevent data loss in production.
+        // Irreversible operation: schema/data rollback handled via forward fix migrations.
     }
 
     private function indexExists(string $table, string $indexName): bool

--- a/backend/database/migrations/2026_01_29_200060_create_benefit_grants_table.php
+++ b/backend/database/migrations/2026_01_29_200060_create_benefit_grants_table.php
@@ -78,8 +78,8 @@ return new class extends Migration
 
     public function down(): void
     {
-        // Prevent accidental data loss. This table might have existed before.
-        // This migration is guarded by Schema::hasTable(...) in up(), so rollback must never drop the table.
+        // forward-only migration: rollback disabled to prevent data loss in production.
+        // Irreversible operation: schema/data rollback handled via forward fix migrations.
     }
 
     private function indexExists(string $table, string $indexName): bool

--- a/backend/database/migrations/2026_01_30_120001_create_feature_flags_table.php
+++ b/backend/database/migrations/2026_01_30_120001_create_feature_flags_table.php
@@ -52,7 +52,7 @@ return new class extends Migration
 
     public function down(): void
     {
-        // Prevent accidental data loss. This table might have existed before.
-        // This migration is guarded by Schema::hasTable(...) in up(), so rollback must never drop the table.
+        // forward-only migration: rollback disabled to prevent data loss in production.
+        // Irreversible operation: schema/data rollback handled via forward fix migrations.
     }
 };

--- a/backend/database/migrations/2026_01_30_120002_create_experiment_assignments_table.php
+++ b/backend/database/migrations/2026_01_30_120002_create_experiment_assignments_table.php
@@ -87,7 +87,7 @@ return new class extends Migration
 
     public function down(): void
     {
-        // Prevent accidental data loss. This table might have existed before.
-        // This migration is guarded by Schema::hasTable(...) in up(), so rollback must never drop the table.
+        // forward-only migration: rollback disabled to prevent data loss in production.
+        // Irreversible operation: schema/data rollback handled via forward fix migrations.
     }
 };

--- a/backend/database/migrations/2026_01_30_120003_add_experiments_json_to_events_table.php
+++ b/backend/database/migrations/2026_01_30_120003_add_experiments_json_to_events_table.php
@@ -21,14 +21,7 @@ return new class extends Migration
 
     public function down(): void
     {
-        if (!Schema::hasTable('events')) {
-            return;
-        }
-
-        Schema::table('events', function (Blueprint $table) {
-            if (Schema::hasColumn('events', 'experiments_json')) {
-                $table->dropColumn('experiments_json');
-            }
-        });
+        // forward-only migration: rollback disabled to prevent data loss in production.
+        // Irreversible operation: schema/data rollback handled via forward fix migrations.
     }
 };

--- a/backend/database/migrations/2026_01_30_120100_create_attempt_drafts_table.php
+++ b/backend/database/migrations/2026_01_30_120100_create_attempt_drafts_table.php
@@ -96,8 +96,8 @@ return new class extends Migration
 
     public function down(): void
     {
-        // Prevent accidental data loss. This table might have existed before.
-        // This migration is guarded by Schema::hasTable(...) in up(), so rollback must never drop the table.
+        // forward-only migration: rollback disabled to prevent data loss in production.
+        // Irreversible operation: schema/data rollback handled via forward fix migrations.
     }
 
     private function indexExists(string $table, string $indexName): bool

--- a/backend/database/migrations/2026_01_30_120110_create_attempt_answer_sets_table.php
+++ b/backend/database/migrations/2026_01_30_120110_create_attempt_answer_sets_table.php
@@ -107,8 +107,8 @@ return new class extends Migration
 
     public function down(): void
     {
-        // Prevent accidental data loss. This table might have existed before.
-        // This migration is guarded by Schema::hasTable(...) in up(), so rollback must never drop the table.
+        // forward-only migration: rollback disabled to prevent data loss in production.
+        // Irreversible operation: schema/data rollback handled via forward fix migrations.
     }
 
     private function indexExists(string $table, string $indexName): bool

--- a/backend/database/migrations/2026_01_30_120120_create_attempt_answer_rows_table.php
+++ b/backend/database/migrations/2026_01_30_120120_create_attempt_answer_rows_table.php
@@ -153,8 +153,8 @@ return new class extends Migration
 
     public function down(): void
     {
-        // Prevent accidental data loss. This table might have existed before.
-        // This migration is guarded by Schema::hasTable(...) in up(), so rollback must never drop the table.
+        // forward-only migration: rollback disabled to prevent data loss in production.
+        // Irreversible operation: schema/data rollback handled via forward fix migrations.
     }
 
     private function indexExists(string $table, string $indexName): bool

--- a/backend/database/migrations/2026_01_30_120130_create_archive_audits_table.php
+++ b/backend/database/migrations/2026_01_30_120130_create_archive_audits_table.php
@@ -65,8 +65,8 @@ return new class extends Migration
 
     public function down(): void
     {
-        // Prevent accidental data loss. This table might have existed before.
-        // This migration is guarded by Schema::hasTable(...) in up(), so rollback must never drop the table.
+        // forward-only migration: rollback disabled to prevent data loss in production.
+        // Irreversible operation: schema/data rollback handled via forward fix migrations.
     }
 
     private function indexExists(string $table, string $indexName): bool

--- a/backend/database/migrations/2026_01_30_120140_add_resume_expires_at_to_attempts_table.php
+++ b/backend/database/migrations/2026_01_30_120140_add_resume_expires_at_to_attempts_table.php
@@ -28,21 +28,8 @@ return new class extends Migration
 
     public function down(): void
     {
-        if (!Schema::hasTable('attempts')) {
-            return;
-        }
-
-        if ($this->indexExists('attempts', 'attempts_resume_expires_idx')) {
-            Schema::table('attempts', function (Blueprint $table) {
-                $table->dropIndex('attempts_resume_expires_idx');
-            });
-        }
-
-        Schema::table('attempts', function (Blueprint $table) {
-            if (Schema::hasColumn('attempts', 'resume_expires_at')) {
-                $table->dropColumn('resume_expires_at');
-            }
-        });
+        // forward-only migration: rollback disabled to prevent data loss in production.
+        // Irreversible operation: schema/data rollback handled via forward fix migrations.
     }
 
     private function indexExists(string $table, string $indexName): bool

--- a/backend/database/migrations/2026_01_31_090000_create_assessments_table.php
+++ b/backend/database/migrations/2026_01_31_090000_create_assessments_table.php
@@ -76,7 +76,7 @@ return new class extends Migration
 
     public function down(): void
     {
-        // Prevent accidental data loss. This table might have existed before.
-        // This migration is guarded by Schema::hasTable(...) in up(), so rollback must never drop the table.
+        // forward-only migration: rollback disabled to prevent data loss in production.
+        // Irreversible operation: schema/data rollback handled via forward fix migrations.
     }
 };

--- a/backend/database/migrations/2026_01_31_090010_create_assessment_assignments_table.php
+++ b/backend/database/migrations/2026_01_31_090010_create_assessment_assignments_table.php
@@ -100,7 +100,7 @@ return new class extends Migration
 
     public function down(): void
     {
-        // Prevent accidental data loss. This table might have existed before.
-        // This migration is guarded by Schema::hasTable(...) in up(), so rollback must never drop the table.
+        // forward-only migration: rollback disabled to prevent data loss in production.
+        // Irreversible operation: schema/data rollback handled via forward fix migrations.
     }
 };

--- a/backend/database/migrations/2026_01_31_090020_expand_organization_members_role.php
+++ b/backend/database/migrations/2026_01_31_090020_expand_organization_members_role.php
@@ -12,6 +12,7 @@ return new class extends Migration
 
     public function down(): void
     {
-        // no-op (data backfill only)
+        // forward-only migration: rollback disabled to prevent data loss in production.
+        // Irreversible operation: schema/data rollback handled via forward fix migrations.
     }
 };

--- a/backend/database/migrations/2026_02_02_090000_add_sku_fields_to_orders_payment_events.php
+++ b/backend/database/migrations/2026_02_02_090000_add_sku_fields_to_orders_payment_events.php
@@ -39,32 +39,7 @@ return new class extends Migration
 
     public function down(): void
     {
-        if (Schema::hasTable('payment_events')) {
-            Schema::table('payment_events', function (Blueprint $table) {
-                if (Schema::hasColumn('payment_events', 'requested_sku')) {
-                    $table->dropColumn('requested_sku');
-                }
-                if (Schema::hasColumn('payment_events', 'effective_sku')) {
-                    $table->dropColumn('effective_sku');
-                }
-                if (Schema::hasColumn('payment_events', 'entitlement_id')) {
-                    $table->dropColumn('entitlement_id');
-                }
-            });
-        }
-
-        if (Schema::hasTable('orders')) {
-            Schema::table('orders', function (Blueprint $table) {
-                if (Schema::hasColumn('orders', 'requested_sku')) {
-                    $table->dropColumn('requested_sku');
-                }
-                if (Schema::hasColumn('orders', 'effective_sku')) {
-                    $table->dropColumn('effective_sku');
-                }
-                if (Schema::hasColumn('orders', 'entitlement_id')) {
-                    $table->dropColumn('entitlement_id');
-                }
-            });
-        }
+        // forward-only migration: rollback disabled to prevent data loss in production.
+        // Irreversible operation: schema/data rollback handled via forward fix migrations.
     }
 };

--- a/backend/database/migrations/2026_02_04_090000_add_idempotency_refunds_to_orders_benefit_grants.php
+++ b/backend/database/migrations/2026_02_04_090000_add_idempotency_refunds_to_orders_benefit_grants.php
@@ -58,42 +58,8 @@ return new class extends Migration
 
     public function down(): void
     {
-        if (Schema::hasTable('orders')) {
-            if ($this->indexExists('orders', 'orders_org_idempotency_key_unique')) {
-                Schema::table('orders', function (Blueprint $table) {
-                    $table->dropUnique('orders_org_idempotency_key_unique');
-                });
-            }
-
-            Schema::table('orders', function (Blueprint $table) {
-                if (Schema::hasColumn('orders', 'idempotency_key')) {
-                    $table->dropColumn('idempotency_key');
-                }
-                if (Schema::hasColumn('orders', 'refunded_at')) {
-                    $table->dropColumn('refunded_at');
-                }
-                if (Schema::hasColumn('orders', 'refund_amount_cents')) {
-                    $table->dropColumn('refund_amount_cents');
-                }
-                if (Schema::hasColumn('orders', 'refund_reason')) {
-                    $table->dropColumn('refund_reason');
-                }
-            });
-        }
-
-        if (Schema::hasTable('benefit_grants')) {
-            if ($this->indexExists('benefit_grants', 'benefit_grants_org_benefit_attempt_status_idx')) {
-                Schema::table('benefit_grants', function (Blueprint $table) {
-                    $table->dropIndex('benefit_grants_org_benefit_attempt_status_idx');
-                });
-            }
-
-            Schema::table('benefit_grants', function (Blueprint $table) {
-                if (Schema::hasColumn('benefit_grants', 'revoked_at')) {
-                    $table->dropColumn('revoked_at');
-                }
-            });
-        }
+        // forward-only migration: rollback disabled to prevent data loss in production.
+        // Irreversible operation: schema/data rollback handled via forward fix migrations.
     }
 
     private function indexExists(string $table, string $indexName): bool

--- a/backend/database/migrations/2026_02_05_090000_add_assessment_driver_to_scales_registry_table.php
+++ b/backend/database/migrations/2026_02_05_090000_add_assessment_driver_to_scales_registry_table.php
@@ -21,14 +21,7 @@ return new class extends Migration
 
     public function down(): void
     {
-        if (!Schema::hasTable('scales_registry')) {
-            return;
-        }
-
-        if (Schema::hasColumn('scales_registry', 'assessment_driver')) {
-            Schema::table('scales_registry', function (Blueprint $table) {
-                $table->dropColumn('assessment_driver');
-            });
-        }
+        // forward-only migration: rollback disabled to prevent data loss in production.
+        // Irreversible operation: schema/data rollback handled via forward fix migrations.
     }
 };

--- a/backend/database/migrations/2026_02_05_090000_add_processing_fields_to_payment_events_table.php
+++ b/backend/database/migrations/2026_02_05_090000_add_processing_fields_to_payment_events_table.php
@@ -49,39 +49,8 @@ return new class extends Migration
 
     public function down(): void
     {
-        if (!Schema::hasTable('payment_events')) {
-            return;
-        }
-
-        if ($this->indexExists('payment_events', 'payment_events_provider_order_idx')) {
-            Schema::table('payment_events', function (Blueprint $table) {
-                $table->dropIndex('payment_events_provider_order_idx');
-            });
-        }
-
-        if ($this->indexExists('payment_events', 'payment_events_status_idx')) {
-            Schema::table('payment_events', function (Blueprint $table) {
-                $table->dropIndex('payment_events_status_idx');
-            });
-        }
-
-        Schema::table('payment_events', function (Blueprint $table) {
-            if (Schema::hasColumn('payment_events', 'status')) {
-                $table->dropColumn('status');
-            }
-            if (Schema::hasColumn('payment_events', 'processed_at')) {
-                $table->dropColumn('processed_at');
-            }
-            if (Schema::hasColumn('payment_events', 'attempts')) {
-                $table->dropColumn('attempts');
-            }
-            if (Schema::hasColumn('payment_events', 'last_error_code')) {
-                $table->dropColumn('last_error_code');
-            }
-            if (Schema::hasColumn('payment_events', 'last_error_message')) {
-                $table->dropColumn('last_error_message');
-            }
-        });
+        // forward-only migration: rollback disabled to prevent data loss in production.
+        // Irreversible operation: schema/data rollback handled via forward fix migrations.
     }
 
     private function indexExists(string $table, string $indexName): bool

--- a/backend/database/migrations/2026_02_05_090010_add_unique_index_to_skus_table.php
+++ b/backend/database/migrations/2026_02_05_090010_add_unique_index_to_skus_table.php
@@ -22,15 +22,8 @@ return new class extends Migration
 
     public function down(): void
     {
-        if (!Schema::hasTable('skus')) {
-            return;
-        }
-
-        if ($this->indexExists('skus', 'skus_sku_unique')) {
-            Schema::table('skus', function (Blueprint $table) {
-                $table->dropUnique('skus_sku_unique');
-            });
-        }
+        // forward-only migration: rollback disabled to prevent data loss in production.
+        // Irreversible operation: schema/data rollback handled via forward fix migrations.
     }
 
     private function indexExists(string $table, string $indexName): bool

--- a/backend/database/migrations/2026_02_07_180000_add_webhook_hardening_fields_to_integrations_table.php
+++ b/backend/database/migrations/2026_02_07_180000_add_webhook_hardening_fields_to_integrations_table.php
@@ -38,27 +38,8 @@ return new class extends Migration
 
     public function down(): void
     {
-        if (!Schema::hasTable('integrations')) {
-            return;
-        }
-
-        if ($this->indexExists('integrations', 'integrations_provider_external_user_idx')) {
-            Schema::table('integrations', function (Blueprint $table) {
-                $table->dropIndex('integrations_provider_external_user_idx');
-            });
-        }
-
-        Schema::table('integrations', function (Blueprint $table) {
-            if (Schema::hasColumn('integrations', 'webhook_last_event_id')) {
-                $table->dropColumn('webhook_last_event_id');
-            }
-            if (Schema::hasColumn('integrations', 'webhook_last_timestamp')) {
-                $table->dropColumn('webhook_last_timestamp');
-            }
-            if (Schema::hasColumn('integrations', 'webhook_last_received_at')) {
-                $table->dropColumn('webhook_last_received_at');
-            }
-        });
+        // forward-only migration: rollback disabled to prevent data loss in production.
+        // Irreversible operation: schema/data rollback handled via forward fix migrations.
     }
 
     private function indexExists(string $table, string $indexName): bool

--- a/backend/database/migrations/2026_02_07_190000_scope_order_idempotency_key_by_provider.php
+++ b/backend/database/migrations/2026_02_07_190000_scope_order_idempotency_key_by_provider.php
@@ -39,27 +39,8 @@ return new class extends Migration
 
     public function down(): void
     {
-        if (!Schema::hasTable('orders')) {
-            return;
-        }
-
-        if ($this->indexExists('orders', self::NEW_UNIQUE)) {
-            Schema::table('orders', function (Blueprint $table) {
-                $table->dropUnique(self::NEW_UNIQUE);
-            });
-        }
-
-        if (!Schema::hasColumn('orders', 'org_id') || !Schema::hasColumn('orders', 'idempotency_key')) {
-            return;
-        }
-
-        if ($this->indexExists('orders', self::OLD_UNIQUE)) {
-            return;
-        }
-
-        Schema::table('orders', function (Blueprint $table) {
-            $table->unique(['org_id', 'idempotency_key'], self::OLD_UNIQUE);
-        });
+        // forward-only migration: rollback disabled to prevent data loss in production.
+        // Irreversible operation: schema/data rollback handled via forward fix migrations.
     }
 
     private function indexExists(string $table, string $indexName): bool

--- a/backend/database/migrations/2026_02_08_000001_add_provider_composite_unique_to_payment_events.php
+++ b/backend/database/migrations/2026_02_08_000001_add_provider_composite_unique_to_payment_events.php
@@ -49,24 +49,7 @@ return new class extends Migration
 
     public function down(): void
     {
-        if (!Schema::hasTable(self::TABLE)) {
-            return;
-        }
-
-        if (!Schema::hasColumn(self::TABLE, 'provider_event_id')) {
-            return;
-        }
-
-        if (SchemaIndex::indexExists(self::TABLE, self::NEW_UNIQUE)) {
-            Schema::table(self::TABLE, function (Blueprint $table) {
-                $table->dropUnique(self::NEW_UNIQUE);
-            });
-        }
-
-        if (!SchemaIndex::indexExists(self::TABLE, self::OLD_UNIQUE)) {
-            Schema::table(self::TABLE, function (Blueprint $table) {
-                $table->unique('provider_event_id', self::OLD_UNIQUE);
-            });
-        }
+        // forward-only migration: rollback disabled to prevent data loss in production.
+        // Irreversible operation: schema/data rollback handled via forward fix migrations.
     }
 };

--- a/backend/database/migrations/2026_02_08_030000_create_queue_dlq_replays_table.php
+++ b/backend/database/migrations/2026_02_08_030000_create_queue_dlq_replays_table.php
@@ -28,6 +28,7 @@ return new class extends Migration
 
     public function down(): void
     {
-        Schema::dropIfExists('queue_dlq_replays');
+        // forward-only migration: rollback disabled to prevent data loss in production.
+        // Irreversible operation: schema/data rollback handled via forward fix migrations.
     }
 };

--- a/backend/database/migrations/2026_02_08_040000_create_migration_index_audits_table.php
+++ b/backend/database/migrations/2026_02_08_040000_create_migration_index_audits_table.php
@@ -77,8 +77,8 @@ return new class extends Migration
 
     public function down(): void
     {
-        // Safety: Down is a no-op to prevent accidental data loss.
-        // Schema::drop(self::TABLE);
+        // forward-only migration: rollback disabled to prevent data loss in production.
+        // Irreversible operation: schema/data rollback handled via forward fix migrations.
     }
 
     /**

--- a/backend/database/migrations/2026_02_08_050000_scope_payment_event_uniqueness_by_provider.php
+++ b/backend/database/migrations/2026_02_08_050000_scope_payment_event_uniqueness_by_provider.php
@@ -14,7 +14,7 @@ return new class extends Migration
 
     public function down(): void
     {
-        // Intentionally no-op: rollback behavior is owned by 2026_02_08_000001 migration.
-        return;
+        // forward-only migration: rollback disabled to prevent data loss in production.
+        // Irreversible operation: schema/data rollback handled via forward fix migrations.
     }
 };

--- a/backend/database/migrations/2026_02_08_060000_make_failed_jobs_uuid_nullable.php
+++ b/backend/database/migrations/2026_02_08_060000_make_failed_jobs_uuid_nullable.php
@@ -21,6 +21,7 @@ return new class extends Migration
 
     public function down(): void
     {
-        // no-op: reverting to NOT NULL can break on existing NULL rows
+        // forward-only migration: rollback disabled to prevent data loss in production.
+        // Irreversible operation: schema/data rollback handled via forward fix migrations.
     }
 };

--- a/backend/database/migrations/2026_02_10_090000_add_reason_to_payment_events_table.php
+++ b/backend/database/migrations/2026_02_10_090000_add_reason_to_payment_events_table.php
@@ -21,16 +21,7 @@ return new class extends Migration
 
     public function down(): void
     {
-        if (!Schema::hasTable('payment_events')) {
-            return;
-        }
-
-        if (!Schema::hasColumn('payment_events', 'reason')) {
-            return;
-        }
-
-        Schema::table('payment_events', function (Blueprint $table) {
-            $table->dropColumn('reason');
-        });
+        // forward-only migration: rollback disabled to prevent data loss in production.
+        // Irreversible operation: schema/data rollback handled via forward fix migrations.
     }
 };

--- a/backend/database/migrations/2026_02_10_120000_add_payload_forensics_columns_to_payment_events_table.php
+++ b/backend/database/migrations/2026_02_10_120000_add_payload_forensics_columns_to_payment_events_table.php
@@ -30,23 +30,7 @@ return new class extends Migration
 
     public function down(): void
     {
-        if (!Schema::hasTable('payment_events')) {
-            return;
-        }
-
-        Schema::table('payment_events', function (Blueprint $table) {
-            if (Schema::hasColumn('payment_events', 'payload_size_bytes')) {
-                $table->dropColumn('payload_size_bytes');
-            }
-            if (Schema::hasColumn('payment_events', 'payload_sha256')) {
-                $table->dropColumn('payload_sha256');
-            }
-            if (Schema::hasColumn('payment_events', 'payload_s3_key')) {
-                $table->dropColumn('payload_s3_key');
-            }
-            if (Schema::hasColumn('payment_events', 'payload_excerpt')) {
-                $table->dropColumn('payload_excerpt');
-            }
-        });
+        // forward-only migration: rollback disabled to prevent data loss in production.
+        // Irreversible operation: schema/data rollback handled via forward fix migrations.
     }
 };

--- a/backend/database/migrations/2026_02_10_140000_create_integration_user_bindings_table.php
+++ b/backend/database/migrations/2026_02_10_140000_create_integration_user_bindings_table.php
@@ -22,6 +22,7 @@ return new class extends Migration
 
     public function down(): void
     {
-        Schema::dropIfExists('integration_user_bindings');
+        // forward-only migration: rollback disabled to prevent data loss in production.
+        // Irreversible operation: schema/data rollback handled via forward fix migrations.
     }
 };

--- a/backend/database/migrations/2026_02_10_140100_add_auth_audit_fields_to_ingest_batches_table.php
+++ b/backend/database/migrations/2026_02_10_140100_add_auth_audit_fields_to_ingest_batches_table.php
@@ -30,23 +30,7 @@ return new class extends Migration
 
     public function down(): void
     {
-        if (!Schema::hasTable('ingest_batches')) {
-            return;
-        }
-
-        Schema::table('ingest_batches', function (Blueprint $table) {
-            if (Schema::hasColumn('ingest_batches', 'source_ip')) {
-                $table->dropColumn('source_ip');
-            }
-            if (Schema::hasColumn('ingest_batches', 'signature_ok')) {
-                $table->dropColumn('signature_ok');
-            }
-            if (Schema::hasColumn('ingest_batches', 'auth_mode')) {
-                $table->dropColumn('auth_mode');
-            }
-            if (Schema::hasColumn('ingest_batches', 'actor_user_id')) {
-                $table->dropColumn('actor_user_id');
-            }
-        });
+        // forward-only migration: rollback disabled to prevent data loss in production.
+        // Irreversible operation: schema/data rollback handled via forward fix migrations.
     }
 };

--- a/backend/database/migrations/2026_02_10_150000_add_status_and_last_error_to_report_snapshots.php
+++ b/backend/database/migrations/2026_02_10_150000_add_status_and_last_error_to_report_snapshots.php
@@ -37,29 +37,8 @@ return new class extends Migration
 
     public function down(): void
     {
-        if (!Schema::hasTable('report_snapshots')) {
-            return;
-        }
-
-        if ($this->indexExists(self::STATUS_INDEX)) {
-            Schema::table('report_snapshots', function (Blueprint $table): void {
-                $table->dropIndex(self::STATUS_INDEX);
-            });
-        }
-
-        Schema::table('report_snapshots', function (Blueprint $table): void {
-            if (Schema::hasColumn('report_snapshots', 'updated_at')) {
-                $table->dropColumn('updated_at');
-            }
-
-            if (Schema::hasColumn('report_snapshots', 'last_error')) {
-                $table->dropColumn('last_error');
-            }
-
-            if (Schema::hasColumn('report_snapshots', 'status')) {
-                $table->dropColumn('status');
-            }
-        });
+        // forward-only migration: rollback disabled to prevent data loss in production.
+        // Irreversible operation: schema/data rollback handled via forward fix migrations.
     }
 
     private function indexExists(string $indexName): bool

--- a/backend/database/migrations/2026_02_10_160000_create_migration_backfills_table.php
+++ b/backend/database/migrations/2026_02_10_160000_create_migration_backfills_table.php
@@ -40,6 +40,7 @@ return new class extends Migration
 
     public function down(): void
     {
-        // Safety: no-op.
+        // forward-only migration: rollback disabled to prevent data loss in production.
+        // Irreversible operation: schema/data rollback handled via forward fix migrations.
     }
 };

--- a/backend/database/migrations/2026_02_10_160100_add_idx_idempo_payload.php
+++ b/backend/database/migrations/2026_02_10_160100_add_idx_idempo_payload.php
@@ -31,13 +31,8 @@ return new class extends Migration
 
     public function down(): void
     {
-        if (!Schema::hasTable(self::TABLE) || !SchemaIndex::indexExists(self::TABLE, self::INDEX)) {
-            return;
-        }
-
-        Schema::table(self::TABLE, function (Blueprint $table): void {
-            $table->dropIndex(self::INDEX);
-        });
+        // forward-only migration: rollback disabled to prevent data loss in production.
+        // Irreversible operation: schema/data rollback handled via forward fix migrations.
     }
 
     /**

--- a/backend/database/migrations/2026_02_10_160200_add_benefit_grants_composite_indexes.php
+++ b/backend/database/migrations/2026_02_10_160200_add_benefit_grants_composite_indexes.php
@@ -36,13 +36,8 @@ return new class extends Migration
 
     public function down(): void
     {
-        if (!Schema::hasTable(self::TABLE)) {
-            return;
-        }
-
-        $this->dropIndex(self::IDX_USER);
-        $this->dropIndex(self::IDX_ANON);
-        $this->dropIndex(self::IDX_SCOPE);
+        // forward-only migration: rollback disabled to prevent data loss in production.
+        // Irreversible operation: schema/data rollback handled via forward fix migrations.
     }
 
     /**

--- a/backend/database/migrations/2026_02_10_160300_add_payment_events_status_time_index.php
+++ b/backend/database/migrations/2026_02_10_160300_add_payment_events_status_time_index.php
@@ -29,12 +29,7 @@ return new class extends Migration
 
     public function down(): void
     {
-        if (!Schema::hasTable(self::TABLE) || !SchemaIndex::indexExists(self::TABLE, self::INDEX)) {
-            return;
-        }
-
-        Schema::table(self::TABLE, function (Blueprint $table): void {
-            $table->dropIndex(self::INDEX);
-        });
+        // forward-only migration: rollback disabled to prevent data loss in production.
+        // Irreversible operation: schema/data rollback handled via forward fix migrations.
     }
 };

--- a/backend/database/migrations/2026_02_10_999999_add_business_indexes.php
+++ b/backend/database/migrations/2026_02_10_999999_add_business_indexes.php
@@ -64,25 +64,7 @@ return new class extends Migration
 
     public function down(): void
     {
-        if (Schema::hasTable(self::BENEFIT_GRANTS)
-            && SchemaIndex::indexExists(self::BENEFIT_GRANTS, self::IDX_GRANT_USER)) {
-            Schema::table(self::BENEFIT_GRANTS, function (Blueprint $table): void {
-                $table->dropIndex(self::IDX_GRANT_USER);
-            });
-        }
-
-        if (Schema::hasTable(self::BENEFIT_GRANTS)
-            && SchemaIndex::indexExists(self::BENEFIT_GRANTS, self::IDX_GRANT_ATTEMPT)) {
-            Schema::table(self::BENEFIT_GRANTS, function (Blueprint $table): void {
-                $table->dropIndex(self::IDX_GRANT_ATTEMPT);
-            });
-        }
-
-        if (Schema::hasTable(self::PAYMENT_EVENTS)
-            && SchemaIndex::indexExists(self::PAYMENT_EVENTS, self::IDX_PAYMENT)) {
-            Schema::table(self::PAYMENT_EVENTS, function (Blueprint $table): void {
-                $table->dropIndex(self::IDX_PAYMENT);
-            });
-        }
+        // forward-only migration: rollback disabled to prevent data loss in production.
+        // Irreversible operation: schema/data rollback handled via forward fix migrations.
     }
 };

--- a/backend/database/migrations/2026_02_11_090100_add_idx_idempotency_keys_provider_recorded_hash.php
+++ b/backend/database/migrations/2026_02_11_090100_add_idx_idempotency_keys_provider_recorded_hash.php
@@ -33,13 +33,8 @@ return new class extends Migration
 
     public function down(): void
     {
-        if (!Schema::hasTable(self::TABLE) || !SchemaIndex::indexExists(self::TABLE, self::INDEX)) {
-            return;
-        }
-
-        Schema::table(self::TABLE, function (Blueprint $table): void {
-            $table->dropIndex(self::INDEX);
-        });
+        // forward-only migration: rollback disabled to prevent data loss in production.
+        // Irreversible operation: schema/data rollback handled via forward fix migrations.
     }
 
     /**

--- a/backend/database/migrations/2026_02_11_100200_add_org_id_to_audit_logs_table.php
+++ b/backend/database/migrations/2026_02_11_100200_add_org_id_to_audit_logs_table.php
@@ -25,18 +25,7 @@ return new class extends Migration
 
     public function down(): void
     {
-        if (!Schema::hasTable(self::TABLE) || !Schema::hasColumn(self::TABLE, 'org_id')) {
-            return;
-        }
-
-        if (SchemaIndex::indexExists(self::TABLE, self::INDEX)) {
-            Schema::table(self::TABLE, function (Blueprint $table): void {
-                $table->dropIndex(self::INDEX);
-            });
-        }
-
-        Schema::table(self::TABLE, function (Blueprint $table): void {
-            $table->dropColumn('org_id');
-        });
+        // forward-only migration: rollback disabled to prevent data loss in production.
+        // Irreversible operation: schema/data rollback handled via forward fix migrations.
     }
 };

--- a/backend/database/migrations/2026_02_11_120300_add_payload_digest_to_payment_events.php
+++ b/backend/database/migrations/2026_02_11_120300_add_payload_digest_to_payment_events.php
@@ -38,12 +38,7 @@ return new class extends Migration
 
     public function down(): void
     {
-        if (!Schema::hasTable(self::TABLE) || !SchemaIndex::indexExists(self::TABLE, self::INDEX)) {
-            return;
-        }
-
-        Schema::table(self::TABLE, function (Blueprint $table): void {
-            $table->dropIndex(self::INDEX);
-        });
+        // forward-only migration: rollback disabled to prevent data loss in production.
+        // Irreversible operation: schema/data rollback handled via forward fix migrations.
     }
 };

--- a/backend/database/migrations/2026_02_12_000000_add_replay_indexes.php
+++ b/backend/database/migrations/2026_02_12_000000_add_replay_indexes.php
@@ -18,7 +18,8 @@ return new class extends Migration
 
     public function down(): void
     {
-        // forward-only: do not drop replay indexes on rollback.
+        // forward-only migration: rollback disabled to prevent data loss in production.
+        // Irreversible operation: schema/data rollback handled via forward fix migrations.
     }
 
     private function addReplayIndex(string $table, string $indexName): void

--- a/backend/phpunit.xml
+++ b/backend/phpunit.xml
@@ -11,6 +11,9 @@
         <testsuite name="Feature">
             <directory>tests/Feature</directory>
         </testsuite>
+        <testsuite name="Sre">
+            <directory>tests/Sre</directory>
+        </testsuite>
     </testsuites>
     <source>
         <include>

--- a/backend/tests/Sre/MigrationSafetyTest.php
+++ b/backend/tests/Sre/MigrationSafetyTest.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Sre;
+
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+final class MigrationSafetyTest extends TestCase
+{
+    /**
+     * @var list<string>
+     */
+    private const BLOCKED_PATTERNS = [
+        'dropIfExists(',
+        'dropColumn(',
+        'dropTable(',
+        'renameColumn(',
+    ];
+
+    #[Test]
+    public function migrations_must_not_include_destructive_rollback_statements(): void
+    {
+        $files = glob(base_path('database/migrations/*.php'));
+        if (!is_array($files)) {
+            $this->fail('unable to read migration files');
+        }
+
+        sort($files);
+
+        foreach ($files as $filePath) {
+            $source = file_get_contents($filePath);
+            $this->assertIsString($source, 'unable to read migration file: ' . $filePath);
+
+            foreach (self::BLOCKED_PATTERNS as $pattern) {
+                $this->assertStringNotContainsString(
+                    $pattern,
+                    $source,
+                    sprintf('migration safety violation: file=%s pattern=%s', $filePath, $pattern)
+                );
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary

This PR delivers 4 SRE loops on a single branch, with independent commits per loop:

1. SRE-A-013: move heavy `attempt_answer_rows` partition DDL out of migration into explicit Ops command.
2. SRE-A-026: change memory export from unbounded `get()` to paginated export + optional NDJSON stream download.
3. SRE-A-020: change replay idempotency writes from per-row to per-chunk batch writes using `run_id`, and only insert samples for keys inserted in the current run.
4. SRE-A-030: enforce forward-only migrations (`down()` no-op), block rollback/reset/refresh in production, and add CI guard test.

## Commits

- `b6d3ede` feat(sre-a-013): move attempt partition ddl to ops command
- `c273423` feat(sre-a-026): paginate memory export and add ndjson download
- `bf4e0a6` feat(sre-a-020): batch replay idempotency writes by run
- `9ef53c2` chore(sre-a-030): enforce forward-only migrations and prod rollback guard

## Key Changes

### SRE-A-013
- Removed partition DDL from migration `2026_01_30_120120_create_attempt_answer_rows_table.php`.
- Added Ops command `ops:partition-attempt-answer-rows` with:
  - mysql driver guard
  - table existence guard
  - already-partitioned guard
  - partition constraints validation (`submitted_at` NOT NULL + PK contains `submitted_at`)
  - dry-run default and explicit `--execute` gate
- Explicitly registered command in Console Kernel.

### SRE-A-026
- `GET /api/v0.2/memory/export` now defaults to cursor pagination:
  - `limit` (default 200, max 500)
  - `cursor`
  - response includes `next_cursor` and `truncated`
- Added `download=1` mode:
  - stream download
  - NDJSON (`application/x-ndjson`)
- Removed old unbounded full export path.

### SRE-A-020
- Added migration `2026_02_12_010000_add_run_id_to_idempotency_keys.php`:
  - `run_id` nullable string(36)
  - index `(provider, run_id, external_id)`
- Added `recordFastBatch()` and `pluckInsertedExternalIds()` in IdempotencyStore.
- ReplayService now:
  - generates one `run_id` per replay
  - performs one idempotency batch insert per chunk
  - inserts sample rows only for external IDs inserted in the current `run_id`
  - logs inserted/skipped/chunks per source table.

### SRE-A-030
- Updated all migrations to forward-only rollback style (`down()` no-op).
- Removed destructive rollback keywords from migration files:
  - `dropIfExists(`
  - `dropColumn(`
  - `dropTable(`
  - `renameColumn(`
- Added production safety gate in AppServiceProvider:
  - block `migrate:rollback`, `migrate:reset`, `migrate:refresh` in production by throwing RuntimeException.
- Added CI guard test `Tests\Sre\MigrationSafetyTest`.
- Included `tests/Sre` in phpunit test suites.

## Public API / Behavior Changes

- New artisan command: `ops:partition-attempt-answer-rows`.
- `GET /api/v0.2/memory/export`:
  - now paginated by default
  - returns `next_cursor` and `truncated`
- `GET /api/v0.2/memory/export?download=1`:
  - now NDJSON streaming response.
- Production now blocks rollback-related migrate commands.

## Validation Performed

- `php artisan route:list`
- `php artisan migrate --force`
- `php artisan ops:partition-attempt-answer-rows --dry-run`
- `php artisan ops:partition-attempt-answer-rows --months=12 --execute` (no-op on non-mysql env as expected)
- `APP_ENV=production php artisan migrate:rollback` (fails with rollback-disabled message as expected)
- `php artisan test` (pass; existing one risky test remains)
- `bash backend/scripts/ci_verify_mbti.sh` (pass)

## Notes

- Branch intentionally batches four tickets but keeps one-loop-per-commit granularity.
- Core CI MBTI chain remains green.
