### PR TITLE
test(sre): add migration hot table + migration purity CI gates

### DIFF
--- a/backend/tests/Sre/MigrationHotTableNotNullGateTest.php
+++ b/backend/tests/Sre/MigrationHotTableNotNullGateTest.php
@@ -1,0 +1,279 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Sre;
+
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+final class MigrationHotTableNotNullGateTest extends TestCase
+{
+    /**
+     * @var list<string>
+     */
+    private const HOT_TABLES = [
+        'attempts',
+        'results',
+        'orders',
+        'payment_events',
+        'benefit_grants',
+        'report_snapshots',
+        'attempt_answer_rows',
+        'organization_members',
+    ];
+
+    /**
+     * @var list<string>
+     */
+    private const COLUMN_METHODS = [
+        'biginteger',
+        'binary',
+        'boolean',
+        'char',
+        'date',
+        'datetime',
+        'datetimetz',
+        'decimal',
+        'double',
+        'enum',
+        'float',
+        'integer',
+        'ipaddress',
+        'json',
+        'jsonb',
+        'longtext',
+        'macaddress',
+        'mediuminteger',
+        'mediumtext',
+        'set',
+        'smallinteger',
+        'softdeletes',
+        'softdeletestz',
+        'string',
+        'text',
+        'time',
+        'timetz',
+        'timestamp',
+        'timestamptz',
+        'tinyinteger',
+        'ulid',
+        'unsignedbiginteger',
+        'unsignedinteger',
+        'unsignedmediuminteger',
+        'unsignedsmallinteger',
+        'unsignedtinyinteger',
+        'uuid',
+        'year',
+    ];
+
+    private const LOOKAHEAD_LINES = 6;
+
+    #[Test]
+    public function added_columns_on_hot_tables_must_define_nullable_or_default(): void
+    {
+        $violations = [];
+
+        foreach ($this->migrationFiles() as $filePath) {
+            if (str_contains(basename($filePath), 'create_')) {
+                continue;
+            }
+
+            $source = file_get_contents($filePath);
+            $this->assertIsString($source, 'unable to read migration file: ' . $filePath);
+
+            $violations = array_merge($violations, $this->collectViolations($filePath, $source));
+        }
+
+        $this->assertSame(
+            [],
+            $violations,
+            "hot table nullable/default gate violations:\n" . implode("\n", $violations)
+        );
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function collectViolations(string $filePath, string $source): array
+    {
+        $constTables = $this->constantTableMap($source);
+        $lines = preg_split('/\R/', $source);
+        if (!is_array($lines)) {
+            return [];
+        }
+
+        $violations = [];
+        $inHotBlock = false;
+        $currentTable = '';
+        $braceDepth = 0;
+        $lineCount = count($lines);
+
+        for ($i = 0; $i < $lineCount; $i++) {
+            $line = $lines[$i];
+
+            if (!$inHotBlock) {
+                [$tableName, $signatureEndLine, $signatureSource] = $this->detectBlockStart($lines, $i, $constTables);
+                if ($tableName === null || $signatureSource === null) {
+                    continue;
+                }
+
+                $inHotBlock = true;
+                $currentTable = $tableName;
+                $braceDepth = substr_count($signatureSource, '{') - substr_count($signatureSource, '}');
+                $i = $signatureEndLine;
+                continue;
+            }
+
+            if ($this->isColumnDeclarationLine($line)) {
+                $statement = $this->statementSnippet($lines, $i);
+                $hasNullable = preg_match('/->nullable\s*\(\s*\)/i', $statement) === 1;
+                $hasDefault = preg_match('/->default\s*\(/i', $statement) === 1;
+                $hasPrimary = preg_match('/->primary\s*\(/i', $statement) === 1;
+                $hasNullableFalse = preg_match('/->nullable\s*\(\s*false\s*\)/i', $statement) === 1;
+                $hasDefaultNull = preg_match('/->default\s*\(\s*null\s*\)/i', $statement) === 1;
+
+                if (!$hasPrimary && ((!$hasNullable && !$hasDefault) || $hasNullableFalse || $hasDefaultNull)) {
+                    $violations[] = sprintf(
+                        'file=%s table=%s line=%d snippet=%s',
+                        basename($filePath),
+                        $currentTable,
+                        $i + 1,
+                        $this->truncateSnippet($statement)
+                    );
+                }
+            }
+
+            $braceDepth += substr_count($line, '{') - substr_count($line, '}');
+            if ($braceDepth <= 0) {
+                $inHotBlock = false;
+                $currentTable = '';
+                $braceDepth = 0;
+            }
+        }
+
+        return $violations;
+    }
+
+    /**
+     * @param array<int, string> $lines
+     * @param array<string, string> $constTables
+     * @return array{0: ?string, 1: int, 2: ?string}
+     */
+    private function detectBlockStart(array $lines, int $startLine, array $constTables): array
+    {
+        $lineCount = count($lines);
+        $endLine = $startLine;
+        $signature = $lines[$startLine];
+
+        while (
+            $endLine + 1 < $lineCount
+            && !str_contains($signature, '{')
+            && ($endLine - $startLine + 1) < self::LOOKAHEAD_LINES
+        ) {
+            $endLine++;
+            $signature .= "\n" . $lines[$endLine];
+        }
+
+        $tableName = null;
+
+        if (preg_match(
+            '/Schema::table\s*\(\s*[\'"]([A-Za-z0-9_]+)[\'"]\s*,\s*(?:static\s+)?function\s*\([^)]*\)\s*(?:use\s*\([^)]*\)\s*)?(?::\s*void\s*)?\s*\{/',
+            $signature,
+            $matches
+        ) === 1) {
+            $tableName = strtolower($matches[1]);
+        } elseif (preg_match(
+            '/Schema::table\s*\(\s*self::([A-Z_][A-Z0-9_]*)\s*,\s*(?:static\s+)?function\s*\([^)]*\)\s*(?:use\s*\([^)]*\)\s*)?(?::\s*void\s*)?\s*\{/',
+            $signature,
+            $matches
+        ) === 1) {
+            $constName = $matches[1];
+            $tableName = $constTables[$constName] ?? null;
+        }
+
+        if ($tableName === null || !in_array($tableName, self::HOT_TABLES, true)) {
+            return [null, $startLine, null];
+        }
+
+        return [$tableName, $endLine, $signature];
+    }
+
+    /**
+     * @param array<int, string> $lines
+     */
+    private function statementSnippet(array $lines, int $startLine): string
+    {
+        $lineCount = count($lines);
+        $endLine = min($lineCount - 1, $startLine + self::LOOKAHEAD_LINES - 1);
+        $parts = [];
+
+        for ($i = $startLine; $i <= $endLine; $i++) {
+            $parts[] = trim($lines[$i]);
+            if (str_contains($lines[$i], ';')) {
+                break;
+            }
+        }
+
+        return preg_replace('/\s+/', ' ', trim(implode(' ', $parts))) ?? '';
+    }
+
+    private function isColumnDeclarationLine(string $line): bool
+    {
+        if (preg_match('/\$table->([A-Za-z_][A-Za-z0-9_]*)\s*\(/', $line, $matches) !== 1) {
+            return false;
+        }
+
+        $method = strtolower($matches[1]);
+
+        return in_array($method, self::COLUMN_METHODS, true);
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    private function constantTableMap(string $source): array
+    {
+        $constTables = [];
+
+        if (preg_match_all(
+            '/const\s+([A-Z_][A-Z0-9_]*)\s*=\s*[\'"]([a-z0-9_]+)[\'"]/i',
+            $source,
+            $matches,
+            PREG_SET_ORDER
+        ) !== 1 && empty($matches)) {
+            return $constTables;
+        }
+
+        foreach ($matches as $match) {
+            $constTables[$match[1]] = strtolower($match[2]);
+        }
+
+        return $constTables;
+    }
+
+    private function truncateSnippet(string $snippet): string
+    {
+        if (strlen($snippet) <= 220) {
+            return $snippet;
+        }
+
+        return substr($snippet, 0, 217) . '...';
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function migrationFiles(): array
+    {
+        $files = glob(base_path('database/migrations/*.php'));
+
+        if (!is_array($files)) {
+            return [];
+        }
+
+        sort($files);
+
+        return array_values($files);
+    }
+}

--- a/backend/tests/Sre/MigrationPurityGateTest.php
+++ b/backend/tests/Sre/MigrationPurityGateTest.php
@@ -1,0 +1,278 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Sre;
+
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+final class MigrationPurityGateTest extends TestCase
+{
+    /**
+     * @var list<array{keyword: string, regex: string}>
+     */
+    private const FORBIDDEN_PATTERNS = [
+        ['keyword' => 'DB::table(', 'regex' => '/\bDB::table\s*\(/'],
+        ['keyword' => '->update(', 'regex' => '/->update\s*\(/'],
+        ['keyword' => '->insert(', 'regex' => '/->insert\s*\(/'],
+        ['keyword' => '->delete(', 'regex' => '/->delete\s*\(/'],
+        ['keyword' => 'upsert(', 'regex' => '/\bupsert\s*\(/'],
+        ['keyword' => 'insertOrIgnore(', 'regex' => '/\binsertOrIgnore\s*\(/'],
+        ['keyword' => 'truncate(', 'regex' => '/\btruncate\s*\(/'],
+        ['keyword' => 'DB::statement(', 'regex' => '/\bDB::statement\s*\(/'],
+        ['keyword' => 'DB::select(', 'regex' => '/\bDB::select\s*\(/'],
+        ['keyword' => 'groupBy(', 'regex' => '/\bgroupBy\s*\(/'],
+        ['keyword' => 'having(', 'regex' => '/\bhaving\s*\(/'],
+        ['keyword' => 'join(', 'regex' => '/\bjoin\s*\(/'],
+        ['keyword' => 'cursor()', 'regex' => '/\bcursor\s*\(/'],
+        ['keyword' => 'chunkById(', 'regex' => '/\bchunkById\s*\(/'],
+        ['keyword' => '::query()', 'regex' => '/::query\s*\(/'],
+        ['keyword' => '::where(', 'regex' => '/::where\s*\(/'],
+        ['keyword' => 'Model::', 'regex' => '/\bModel::/'],
+        ['keyword' => 'use App\\Models\\', 'regex' => '/^\s*use\s+App\\\\Models\\\\/'],
+        ['keyword' => 'App\\Models\\', 'regex' => '/\bApp\\\\Models\\\\/'],
+        ['keyword' => 'new App\\Models\\...(', 'regex' => '/\bnew\s+\\\\?App\\\\Models\\\\[A-Za-z_][A-Za-z0-9_]*\s*\(/'],
+    ];
+
+    /**
+     * @var list<string>
+     */
+    private const DB_GUARD_ALLOWLIST = [
+        '/\bSHOW\s+INDEX\b/i',
+        '/\binformation_schema\b/i',
+        '/\bpg_indexes\b/i',
+        '/\bPRAGMA\s+index_list\s*\(/i',
+        '/\bDB::raw\s*\(/i',
+    ];
+
+    private const LOOKAHEAD_LINES = 6;
+
+    #[Test]
+    public function migrations_must_remain_schema_only_and_not_contain_data_backfills(): void
+    {
+        $violations = [];
+        $seen = [];
+
+        foreach ($this->migrationFiles() as $filePath) {
+            $source = file_get_contents($filePath);
+            $this->assertIsString($source, 'unable to read migration file: ' . $filePath);
+
+            $cleanSource = $this->stripCommentsPreservingLineNumbers($source);
+            $lines = preg_split('/\R/', $cleanSource);
+            if (!is_array($lines)) {
+                continue;
+            }
+
+            $modelAliases = $this->modelAliases($lines);
+            $violations = array_merge(
+                $violations,
+                $this->collectForbiddenPatternViolations($filePath, $lines, $seen)
+            );
+            $violations = array_merge(
+                $violations,
+                $this->collectModelAliasViolations($filePath, $lines, $modelAliases, $seen)
+            );
+        }
+
+        $this->assertSame(
+            [],
+            $violations,
+            "migration purity gate violations:\n" . implode("\n", $violations)
+        );
+    }
+
+    /**
+     * @param array<int, string> $lines
+     * @param array<string, bool> $seen
+     * @return list<string>
+     */
+    private function collectForbiddenPatternViolations(string $filePath, array $lines, array &$seen): array
+    {
+        $violations = [];
+
+        foreach ($lines as $lineIndex => $line) {
+            foreach (self::FORBIDDEN_PATTERNS as $rule) {
+                if (preg_match($rule['regex'], $line) !== 1) {
+                    continue;
+                }
+
+                $snippet = $this->statementSnippet($lines, $lineIndex);
+                if ($this->isAllowlisted($rule['keyword'], $snippet)) {
+                    continue;
+                }
+
+                $violationKey = sprintf('%s|%d|%s', $filePath, $lineIndex + 1, $rule['keyword']);
+                if (isset($seen[$violationKey])) {
+                    continue;
+                }
+                $seen[$violationKey] = true;
+
+                $violations[] = sprintf(
+                    'file=%s line=%d keyword=%s snippet=%s',
+                    basename($filePath),
+                    $lineIndex + 1,
+                    $rule['keyword'],
+                    $this->truncateSnippet($snippet)
+                );
+            }
+        }
+
+        return $violations;
+    }
+
+    /**
+     * @param array<int, string> $lines
+     * @param list<string> $modelAliases
+     * @param array<string, bool> $seen
+     * @return list<string>
+     */
+    private function collectModelAliasViolations(
+        string $filePath,
+        array $lines,
+        array $modelAliases,
+        array &$seen
+    ): array {
+        if ($modelAliases === []) {
+            return [];
+        }
+
+        $violations = [];
+
+        foreach ($lines as $lineIndex => $line) {
+            foreach ($modelAliases as $alias) {
+                $quoted = preg_quote($alias, '/');
+                $isNewModel = preg_match('/\bnew\s+' . $quoted . '\s*\(/', $line) === 1;
+                $isStaticModelCall = preg_match('/\b' . $quoted . '::/', $line) === 1;
+
+                if (!$isNewModel && !$isStaticModelCall) {
+                    continue;
+                }
+
+                $keyword = $isNewModel ? "new {$alias}(" : "{$alias}::";
+                $violationKey = sprintf('%s|%d|%s', $filePath, $lineIndex + 1, $keyword);
+                if (isset($seen[$violationKey])) {
+                    continue;
+                }
+                $seen[$violationKey] = true;
+
+                $violations[] = sprintf(
+                    'file=%s line=%d keyword=%s snippet=%s',
+                    basename($filePath),
+                    $lineIndex + 1,
+                    $keyword,
+                    $this->truncateSnippet($this->statementSnippet($lines, $lineIndex))
+                );
+            }
+        }
+
+        return $violations;
+    }
+
+    /**
+     * @param array<int, string> $lines
+     * @return list<string>
+     */
+    private function modelAliases(array $lines): array
+    {
+        $aliases = [];
+
+        foreach ($lines as $line) {
+            if (preg_match(
+                '/^\s*use\s+App\\\\Models\\\\([A-Za-z_][A-Za-z0-9_]*)(?:\s+as\s+([A-Za-z_][A-Za-z0-9_]*))?\s*;/',
+                $line,
+                $matches
+            ) !== 1) {
+                continue;
+            }
+
+            $aliases[] = $matches[2] !== '' ? $matches[2] : $matches[1];
+        }
+
+        return array_values(array_unique($aliases));
+    }
+
+    private function isAllowlisted(string $keyword, string $snippet): bool
+    {
+        if (!in_array($keyword, ['DB::select(', 'DB::statement('], true)) {
+            return false;
+        }
+
+        foreach (self::DB_GUARD_ALLOWLIST as $allowPattern) {
+            if (preg_match($allowPattern, $snippet) === 1) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * @param array<int, string> $lines
+     */
+    private function statementSnippet(array $lines, int $startLine): string
+    {
+        $lineCount = count($lines);
+        $endLine = min($lineCount - 1, $startLine + self::LOOKAHEAD_LINES - 1);
+        $parts = [];
+
+        for ($i = $startLine; $i <= $endLine; $i++) {
+            $parts[] = trim($lines[$i]);
+            if (str_contains($lines[$i], ';')) {
+                break;
+            }
+        }
+
+        return preg_replace('/\s+/', ' ', trim(implode(' ', $parts))) ?? '';
+    }
+
+    private function stripCommentsPreservingLineNumbers(string $source): string
+    {
+        $tokens = token_get_all($source);
+        $clean = '';
+
+        foreach ($tokens as $token) {
+            if (is_string($token)) {
+                $clean .= $token;
+                continue;
+            }
+
+            $tokenId = $token[0];
+            $tokenText = $token[1];
+
+            if ($tokenId === T_COMMENT || $tokenId === T_DOC_COMMENT) {
+                $clean .= str_repeat("\n", substr_count($tokenText, "\n"));
+                continue;
+            }
+
+            $clean .= $tokenText;
+        }
+
+        return $clean;
+    }
+
+    private function truncateSnippet(string $snippet): string
+    {
+        if (strlen($snippet) <= 220) {
+            return $snippet;
+        }
+
+        return substr($snippet, 0, 217) . '...';
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function migrationFiles(): array
+    {
+        $files = glob(base_path('database/migrations/*.php'));
+
+        if (!is_array($files)) {
+            return [];
+        }
+
+        sort($files);
+
+        return array_values($files);
+    }
+}


### PR DESCRIPTION


## Summary
- add `MigrationHotTableNotNullGateTest` as CI gate for hot-table `Schema::table(...)` column additions
- enforce hot-table additions to include `->nullable()` or `->default(...)`
- block pseudo-protections `->nullable(false)` and `->default(null)`
- skip legacy `create_*` migrations and exempt `->primary()` chains for baseline compatibility
- add `MigrationPurityGateTest` as CI gate to keep migrations schema-only
- block migration data backfill / large scan / model usage patterns
- add allowlist for index/introspection guard queries (`SHOW INDEX`, `information_schema`, `pg_indexes`, `PRAGMA index_list`, `DB::raw`)

## Changed Files
- added `/Users/rainie/Desktop/GitHub/fap-api/backend/tests/Sre/MigrationHotTableNotNullGateTest.php`
- added `/Users/rainie/Desktop/GitHub/fap-api/backend/tests/Sre/MigrationPurityGateTest.php`

## Verification
- `cd /Users/rainie/Desktop/GitHub/fap-api/backend && php artisan route:list`
- `cd /Users/rainie/Desktop/GitHub/fap-api/backend && php artisan migrate`
- `cd /Users/rainie/Desktop/GitHub/fap-api/backend && php -l app/Http/Middleware/FmTokenAuth.php`
- `cd /Users/rainie/Desktop/GitHub/fap-api/backend && curl -i http://127.0.0.1:8000/api/v0.2/health`
- `cd /Users/rainie/Desktop/GitHub/fap-api/backend && curl -i http://127.0.0.1:8000/api/healthz`
- `cd /Users/rainie/Desktop/GitHub/fap-api/backend && php artisan test --filter MigrationHotTableNotNullGateTest`
- `cd /Users/rainie/Desktop/GitHub/fap-api/backend && php artisan test --filter MigrationPurityGateTest`
- `cd /Users/rainie/Desktop/GitHub/fap-api/backend && php artisan test`
- `cd /Users/rainie/Desktop/GitHub/fap-api/backend && bash scripts/ci_verify_mbti.sh`
