### PR TITLE
chore(sec): harden release artifact guards and gate webhook/attempt regressions

### DIFF
--- a/backend/scripts/ci_verify_mbti.sh
+++ b/backend/scripts/ci_verify_mbti.sh
@@ -862,3 +862,10 @@ php artisan test --filter MigrationRollbackSafetyTest
 php artisan test --filter MigrationsNoSilentCatchTest
 php artisan test --filter MigrationProtectedTablesNoDropTest
 echo "[CI] migration safety gates OK"
+
+echo "[CI] webhook/attempt regression gates"
+php vendor/phpunit/phpunit/phpunit --configuration phpunit.xml tests/Feature/V0_3/PaymentWebhookControllerTest.php
+php vendor/phpunit/phpunit/phpunit --configuration phpunit.xml tests/Feature/V0_3/AttemptOwnershipAnd404Test.php
+php vendor/phpunit/phpunit/phpunit --configuration phpunit.xml tests/Feature/V0_3/PaymentWebhookRouteWiringTest.php
+php vendor/phpunit/phpunit/phpunit --configuration phpunit.xml tests/Feature/Architecture/V0_3TraitReferenceTest.php
+echo "[CI] webhook/attempt regression gates OK"

--- a/scripts/release/verify_source_zip_clean.sh
+++ b/scripts/release/verify_source_zip_clean.sh
@@ -21,6 +21,19 @@ PATTERN_PATH='(^fap-api/\.git/|^fap-api/backend/\.env($|[./])|^fap-api/\.env($|[
 HITS_PATH="$(echo "$LIST_FILTERED" | grep -E "$PATTERN_PATH" || true)"
 [ -z "$HITS_PATH" ] || { echo "[verify][FAIL] forbidden paths found:"; echo "$HITS_PATH"; exit 1; }
 
+# 1.5) 关键运行文件必须存在（防止 controller/trait 在发布包中缺失）
+REQUIRED_FILES=(
+  "fap-api/backend/routes/api.php"
+  "fap-api/backend/app/Http/Controllers/API/V0_3/Webhooks/PaymentWebhookController.php"
+  "fap-api/backend/app/Http/Controllers/API/V0_3/Concerns/ResolvesAttemptOwnership.php"
+)
+for rf in "${REQUIRED_FILES[@]}"; do
+  echo "$LIST" | grep -Fx "$rf" >/dev/null || {
+    echo "[verify][FAIL] required file missing: $rf"
+    exit 1
+  }
+done
+
 # 2) 内容敏感模式（命中直接失败；扫描常见文本类型）
 # 仅扫描体量可控的文本文件扩展名，避免二进制与超大文件拖慢校验
 SCAN_FILES="$(echo "$LIST_FILTERED" | grep -E '\.(env|php|json|yml|yaml|md|txt|sh)$' || true)"


### PR DESCRIPTION
## Summary
This PR hardens SEC-001/002/003 safety gates without changing API behavior.

1. Strengthen release/repo artifact hygiene checks:
- Block tracked/runtime artifacts under `backend/artifacts`, `backend/storage/app/archives`, and `backend/database/*.sqlite`.
- Keep `.gitkeep` placeholder requirements strict for runtime storage directories.
- Extend artifact-mode denylist and sqlite scan in delivery checks.

2. Enforce required runtime files in source zip:
- `backend/routes/api.php`
- `backend/app/Http/Controllers/API/V0_3/Webhooks/PaymentWebhookController.php`
- `backend/app/Http/Controllers/API/V0_3/Concerns/ResolvesAttemptOwnership.php`

3. Harden release integrity guard:
- Ensure `route:list` resolves controllers.
- Ensure critical v0.3 class/trait autoloadability.
- Ensure `git archive` includes critical route/controller/trait files and content manifest.

4. Add CI regression gates to `backend/scripts/ci_verify_mbti.sh`:
- `PaymentWebhookControllerTest`
- `AttemptOwnershipAnd404Test`
- `PaymentWebhookRouteWiringTest`
- `V0_3TraitReferenceTest`

## Scope / Non-goals
- No HTTP contract or route behavior changes.
- No migration logic changes.
- No controller/service business logic changes.
- Scripts/CI-only hardening.

## Changed Files
- `scripts/security/assert_artifact_clean.sh`
- `scripts/release/verify_source_zip_clean.sh`
- `backend/scripts/guard_release_integrity.sh`
- `backend/scripts/ci_verify_mbti.sh`

## Verification
Executed and passed:

- `php artisan route:list | rg "api/v0.3/webhooks/payment|api/v0.3/attempts/\{id\}"`
- `DB_CONNECTION=sqlite DB_DATABASE=/tmp/fap-sec.sqlite php artisan migrate --pretend --force`
- `rg -n "DB::table\('fm_tokens'\)|fm_user_id" backend/app/Http/Middleware/FmTokenAuth.php`
- `php -r "require 'vendor/autoload.php'; exit((class_exists('App\\\\Http\\\\Controllers\\\\API\\\\V0_3\\\\Webhooks\\\\PaymentWebhookController') && trait_exists('App\\\\Http\\\\Controllers\\\\API\\\\V0_3\\\\Concerns\\\\ResolvesAttemptOwnership'))?0:1);"`
- `bash scripts/security/assert_artifact_clean.sh --mode repo --target /Users/rainie/Desktop/GitHub/fap-api`
- `bash scripts/release/export_source_zip.sh`
- `bash scripts/release/verify_source_zip_clean.sh dist/fap-api-source.zip`
- `bash backend/scripts/guard_release_integrity.sh`
- `bash backend/scripts/ci_verify_mbti.sh`

## Commits
- `8eb0f19` chore(sec): harden release artifact integrity guards
- `ea43b34` test(sec): gate webhook and attempt regressions in ci verify
