### PR TITLE
fix(sre): harden auth/event/cache hot paths

### DIFF
--- a/backend/app/Console/Commands/Ops/BackfillEventsShareId.php
+++ b/backend/app/Console/Commands/Ops/BackfillEventsShareId.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Console\Commands\Ops;
+
+use App\Jobs\Ops\BackfillEventsShareIdJob;
+use Illuminate\Console\Command;
+
+class BackfillEventsShareId extends Command
+{
+    protected $signature = 'ops:backfill-events-share-id
+        {--sync : Run immediately in current process}';
+
+    protected $description = 'Backfill events.share_id from legacy meta_json payload';
+
+    public function handle(): int
+    {
+        if ((bool) $this->option('sync')) {
+            (new BackfillEventsShareIdJob())->handle();
+            $this->info('events share_id backfill completed (sync)');
+
+            return self::SUCCESS;
+        }
+
+        BackfillEventsShareIdJob::dispatch()->onQueue('ops');
+        $this->info('events share_id backfill dispatched');
+
+        return self::SUCCESS;
+    }
+}

--- a/backend/app/Console/Commands/Ops/BackfillFmTokenHash.php
+++ b/backend/app/Console/Commands/Ops/BackfillFmTokenHash.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Console\Commands\Ops;
+
+use App\Jobs\Ops\BackfillFmTokenHashJob;
+use Illuminate\Console\Command;
+
+class BackfillFmTokenHash extends Command
+{
+    protected $signature = 'ops:backfill-fm-token-hash
+        {--sync : Run immediately in current process}';
+
+    protected $description = 'Backfill fm_tokens.token_hash in throttled batches';
+
+    public function handle(): int
+    {
+        if ((bool) $this->option('sync')) {
+            (new BackfillFmTokenHashJob())->handle();
+            $this->info('fm token hash backfill completed (sync)');
+            return self::SUCCESS;
+        }
+
+        BackfillFmTokenHashJob::dispatch()->onQueue('ops');
+        $this->info('fm token hash backfill dispatched');
+
+        return self::SUCCESS;
+    }
+}

--- a/backend/app/Http/Controllers/EventController.php
+++ b/backend/app/Http/Controllers/EventController.php
@@ -6,11 +6,11 @@ use App\Models\Event;
 use App\Services\Analytics\EventPayloadLimiter;
 use App\Services\Experiments\ExperimentAssigner;
 use App\Services\Analytics\EventNormalizer;
+use App\Support\Database\SchemaCache;
 use Illuminate\Http\Request;
 use Illuminate\Support\Carbon;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Log;
-use Illuminate\Support\Facades\Schema;
 use Illuminate\Support\Str;
 
 class EventController extends Controller
@@ -41,7 +41,7 @@ class EventController extends Controller
             return $token;
         }
 
-        if (!Schema::hasTable('fm_tokens') || !Schema::hasColumn('fm_tokens', 'token')) {
+        if (!SchemaCache::hasTable('fm_tokens') || !SchemaCache::hasColumn('fm_tokens', 'token')) {
             abort(response()->json([
                 'ok' => false,
                 'error' => 'unauthorized',
@@ -172,7 +172,7 @@ class EventController extends Controller
             ? Carbon::parse($data['occurred_at'])
             : now());
 
-        if (Schema::hasColumn('events', 'experiments_json')) {
+        if (SchemaCache::hasColumn('events', 'experiments_json')) {
             $orgId = $this->resolveOrgId($request);
             $anonId = $columns['anon_id'] ?? $data['anon_id'] ?? null;
             $anonId = is_string($anonId) || is_numeric($anonId) ? trim((string) $anonId) : null;

--- a/backend/app/Jobs/Ops/BackfillEventsShareIdJob.php
+++ b/backend/app/Jobs/Ops/BackfillEventsShareIdJob.php
@@ -1,0 +1,111 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Jobs\Ops;
+
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Bus\Dispatchable;
+use Illuminate\Queue\InteractsWithQueue;
+use Illuminate\Queue\SerializesModels;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Log;
+
+class BackfillEventsShareIdJob implements ShouldQueue
+{
+    use Dispatchable, InteractsWithQueue, Queueable, SerializesModels;
+
+    public int $tries = 3;
+    public array $backoff = [5, 10, 20];
+    public int $timeout = 120;
+
+    private const BATCH_SIZE = 1000;
+
+    public function handle(): void
+    {
+        $startedAt = microtime(true);
+        $processed = 0;
+        $backfilled = 0;
+        $batches = 0;
+        $rows = [];
+
+        Log::info('[events_share_id_backfill] start');
+
+        $cursor = DB::table('events')
+            ->select(['id', 'meta_json'])
+            ->whereNull('share_id')
+            ->whereIn('event_code', ['share_generate', 'share_view', 'share_click'])
+            ->orderBy('id')
+            ->cursor();
+
+        foreach ($cursor as $event) {
+            $processed++;
+
+            $shareId = $this->extractShareId($event->meta_json ?? null);
+            if ($shareId === null) {
+                continue;
+            }
+
+            $rows[] = [
+                'id' => (string) ($event->id ?? ''),
+                'share_id' => $shareId,
+                'updated_at' => now(),
+            ];
+
+            if (count($rows) < self::BATCH_SIZE) {
+                continue;
+            }
+
+            $backfilled += $this->flush($rows);
+            $rows = [];
+            $batches++;
+            usleep(50000);
+        }
+
+        if ($rows !== []) {
+            $backfilled += $this->flush($rows);
+            $batches++;
+        }
+
+        Log::info('[events_share_id_backfill] done', [
+            'processed' => $processed,
+            'backfilled' => $backfilled,
+            'batches' => $batches,
+            'elapsed_ms' => (int) ((microtime(true) - $startedAt) * 1000),
+        ]);
+    }
+
+    /**
+     * @param array<int, array{id:string,share_id:string,updated_at:mixed}> $rows
+     */
+    private function flush(array $rows): int
+    {
+        DB::table('events')->upsert($rows, ['id'], ['share_id', 'updated_at']);
+
+        return count($rows);
+    }
+
+    private function extractShareId(mixed $meta): ?string
+    {
+        $payload = [];
+
+        if (is_array($meta)) {
+            $payload = $meta;
+        } elseif (is_object($meta)) {
+            $payload = (array) $meta;
+        } elseif (is_string($meta) && trim($meta) !== '') {
+            $decoded = json_decode($meta, true);
+            if (is_array($decoded)) {
+                $payload = $decoded;
+            }
+        }
+
+        $shareId = trim((string) ($payload['share_id'] ?? ''));
+        if ($shareId === '' || strlen($shareId) > 64) {
+            return null;
+        }
+
+        return $shareId;
+    }
+}

--- a/backend/app/Jobs/Ops/BackfillFmTokenHashJob.php
+++ b/backend/app/Jobs/Ops/BackfillFmTokenHashJob.php
@@ -1,0 +1,84 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Jobs\Ops;
+
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Bus\Dispatchable;
+use Illuminate\Queue\InteractsWithQueue;
+use Illuminate\Queue\SerializesModels;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Log;
+
+class BackfillFmTokenHashJob implements ShouldQueue
+{
+    use Dispatchable, InteractsWithQueue, Queueable, SerializesModels;
+
+    public int $tries = 3;
+    public array $backoff = [5, 10, 20];
+    public int $timeout = 120;
+
+    private const BATCH_SIZE = 1000;
+
+    public function handle(): void
+    {
+        $startedAt = microtime(true);
+        $processed = 0;
+        $batches = 0;
+        $rows = [];
+
+        Log::info('[fm_token_hash_backfill] start');
+
+        $cursor = DB::table('fm_tokens')
+            ->select('token')
+            ->where(function ($query): void {
+                $query->whereNull('token_hash')->orWhere('token_hash', '');
+            })
+            ->orderBy('token')
+            ->cursor();
+
+        foreach ($cursor as $row) {
+            $token = trim((string) ($row->token ?? ''));
+            if ($token === '') {
+                continue;
+            }
+
+            $rows[] = [
+                'token' => $token,
+                'token_hash' => hash('sha256', $token),
+                'updated_at' => now(),
+            ];
+            $processed++;
+
+            if (count($rows) < self::BATCH_SIZE) {
+                continue;
+            }
+
+            $this->flush($rows);
+            $rows = [];
+            $batches++;
+            usleep(50000);
+        }
+
+        if ($rows !== []) {
+            $this->flush($rows);
+            $batches++;
+        }
+
+        Log::info('[fm_token_hash_backfill] done', [
+            'processed' => $processed,
+            'batches' => $batches,
+            'elapsed_ms' => (int) ((microtime(true) - $startedAt) * 1000),
+        ]);
+    }
+
+    /**
+     * @param array<int, array<string, mixed>> $rows
+     */
+    private function flush(array $rows): void
+    {
+        DB::table('fm_tokens')->upsert($rows, ['token'], ['token_hash', 'updated_at']);
+    }
+}

--- a/backend/app/Jobs/Ops/TouchFmTokenLastUsedAtJob.php
+++ b/backend/app/Jobs/Ops/TouchFmTokenLastUsedAtJob.php
@@ -1,0 +1,53 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Jobs\Ops;
+
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldBeUnique;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Bus\Dispatchable;
+use Illuminate\Queue\InteractsWithQueue;
+use Illuminate\Queue\SerializesModels;
+use Illuminate\Support\Facades\DB;
+
+class TouchFmTokenLastUsedAtJob implements ShouldQueue, ShouldBeUnique
+{
+    use Dispatchable, InteractsWithQueue, Queueable, SerializesModels;
+
+    public int $tries = 3;
+    public array $backoff = [5, 10, 20];
+    public int $timeout = 30;
+    public int $uniqueFor = 300;
+
+    public function __construct(public string $tokenHash)
+    {
+    }
+
+    public function uniqueId(): string
+    {
+        return 'fm_token_touch:' . $this->tokenHash;
+    }
+
+    public function handle(): void
+    {
+        $tokenHash = trim($this->tokenHash);
+        if ($tokenHash === '') {
+            return;
+        }
+
+        $threshold = now()->subMinutes(5);
+
+        DB::table('fm_tokens')
+            ->where('token_hash', $tokenHash)
+            ->where(function ($query) use ($threshold): void {
+                $query->whereNull('last_used_at')->orWhere('last_used_at', '<', $threshold);
+            })
+            ->update([
+                'last_used_at' => now(),
+                'updated_at' => now(),
+            ]);
+    }
+}
+

--- a/backend/app/Services/Content/V2/Cache/ContentCacheAdapter.php
+++ b/backend/app/Services/Content/V2/Cache/ContentCacheAdapter.php
@@ -6,28 +6,119 @@ namespace App\Services\Content\V2\Cache;
 
 use App\Services\Content\V2\Contracts\CacheAdapterInterface;
 use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Facades\Log;
+use Throwable;
 
 final class ContentCacheAdapter implements CacheAdapterInterface
 {
+    private static int $hotRedisDisabledUntil = 0;
+
+    /**
+     * @var array<string, int>
+     */
+    private static array $lastFailureLogAt = [];
+
     public function __construct(private readonly string $store = 'hot_redis')
     {
     }
 
     public function get(string $key): mixed
     {
+        if ($this->canUseConfiguredStore()) {
+            try {
+                return Cache::store($this->store)->get($key);
+            } catch (Throwable $e) {
+                $this->tripHotRedisBreaker();
+                $this->logCacheFailure('get@' . $this->store, $key, $e);
+            }
+        }
+
         try {
-            return Cache::store($this->store)->get($key);
-        } catch (\Throwable) {
             return Cache::store()->get($key);
+        } catch (Throwable $e) {
+            $this->logCacheFailure('get@default', $key, $e);
+
+            return null;
         }
     }
 
-    public function put(string $key, mixed $value, int $ttlSeconds): void
+    public function put(string $key, mixed $value, int $ttlSeconds): bool
     {
-        try {
-            Cache::store($this->store)->put($key, $value, $ttlSeconds);
-        } catch (\Throwable) {
-            Cache::store()->put($key, $value, $ttlSeconds);
+        if ($this->canUseConfiguredStore()) {
+            try {
+                return (bool) Cache::store($this->store)->put($key, $value, $ttlSeconds);
+            } catch (Throwable $e) {
+                $this->tripHotRedisBreaker();
+                $this->logCacheFailure('put@' . $this->store, $key, $e);
+            }
         }
+
+        try {
+            return (bool) Cache::store()->put($key, $value, $ttlSeconds);
+        } catch (Throwable $e) {
+            $this->logCacheFailure('put@default', $key, $e);
+
+            return false;
+        }
+    }
+
+    public function forget(string $key): bool
+    {
+        if ($this->canUseConfiguredStore()) {
+            try {
+                return (bool) Cache::store($this->store)->forget($key);
+            } catch (Throwable $e) {
+                $this->tripHotRedisBreaker();
+                $this->logCacheFailure('forget@' . $this->store, $key, $e);
+            }
+        }
+
+        try {
+            return (bool) Cache::store()->forget($key);
+        } catch (Throwable $e) {
+            $this->logCacheFailure('forget@default', $key, $e);
+
+            return false;
+        }
+    }
+
+    private function canUseConfiguredStore(): bool
+    {
+        if ($this->store !== 'hot_redis') {
+            return true;
+        }
+
+        return time() >= self::$hotRedisDisabledUntil;
+    }
+
+    private function tripHotRedisBreaker(): void
+    {
+        if ($this->store === 'hot_redis') {
+            self::$hotRedisDisabledUntil = time() + 60;
+        }
+    }
+
+    private function logCacheFailure(string $op, string $key, Throwable $e): void
+    {
+        $parts = explode('@', $op, 2);
+        $operation = $parts[0] ?? $op;
+        $store = $parts[1] ?? $this->store;
+        $bucket = $operation . '@' . $store;
+        $now = time();
+
+        $lastLoggedAt = self::$lastFailureLogAt[$bucket] ?? 0;
+        if (($now - $lastLoggedAt) < 60) {
+            return;
+        }
+        self::$lastFailureLogAt[$bucket] = $now;
+
+        Log::warning('content_cache_adapter_failed', [
+            'op' => $operation,
+            'key' => $key,
+            'store' => $store,
+            'exception' => $e::class,
+            'message' => $e->getMessage(),
+            'hot_redis_disabled_until' => self::$hotRedisDisabledUntil > 0 ? self::$hotRedisDisabledUntil : null,
+        ]);
     }
 }

--- a/backend/app/Services/Content/V2/Contracts/CacheAdapterInterface.php
+++ b/backend/app/Services/Content/V2/Contracts/CacheAdapterInterface.php
@@ -8,5 +8,7 @@ interface CacheAdapterInterface
 {
     public function get(string $key): mixed;
 
-    public function put(string $key, mixed $value, int $ttlSeconds): void;
+    public function put(string $key, mixed $value, int $ttlSeconds): bool;
+
+    public function forget(string $key): bool;
 }

--- a/backend/app/Support/Database/SchemaCache.php
+++ b/backend/app/Support/Database/SchemaCache.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Support\Database;
+
+use Illuminate\Support\Facades\Schema;
+
+final class SchemaCache
+{
+    /**
+     * @var array<string, bool>
+     */
+    private static array $tableCache = [];
+
+    /**
+     * @var array<string, bool>
+     */
+    private static array $columnCache = [];
+
+    public static function hasTable(string $table): bool
+    {
+        if (!array_key_exists($table, self::$tableCache)) {
+            self::$tableCache[$table] = Schema::hasTable($table);
+        }
+
+        return self::$tableCache[$table];
+    }
+
+    public static function hasColumn(string $table, string $column): bool
+    {
+        $key = $table . '.' . $column;
+        if (!array_key_exists($key, self::$columnCache)) {
+            self::$columnCache[$key] = Schema::hasColumn($table, $column);
+        }
+
+        return self::$columnCache[$key];
+    }
+
+    public static function clear(): void
+    {
+        self::$tableCache = [];
+        self::$columnCache = [];
+    }
+}
+

--- a/backend/database/migrations/2026_02_12_000010_converge_fm_tokens_schema.php
+++ b/backend/database/migrations/2026_02_12_000010_converge_fm_tokens_schema.php
@@ -57,23 +57,6 @@ return new class extends Migration
             }
         });
 
-        $rows = DB::table('fm_tokens')->select('token', 'token_hash')->get();
-        foreach ($rows as $row) {
-            $token = trim((string) ($row->token ?? ''));
-            if ($token === '') {
-                continue;
-            }
-            $tokenHash = hash('sha256', $token);
-            $current = trim((string) ($row->token_hash ?? ''));
-            if ($current === $tokenHash) {
-                continue;
-            }
-
-            DB::table('fm_tokens')->where('token', $token)->update([
-                'token_hash' => $tokenHash,
-            ]);
-        }
-
         if (!$this->indexExists('fm_tokens', 'fm_tokens_token_hash_unique')) {
             Schema::table('fm_tokens', function (Blueprint $table): void {
                 $table->unique(['token_hash'], 'fm_tokens_token_hash_unique');

--- a/backend/tests/Feature/Architecture/MiddlewareNoThrowableReturnTrueTest.php
+++ b/backend/tests/Feature/Architecture/MiddlewareNoThrowableReturnTrueTest.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Architecture;
+
+use RecursiveDirectoryIterator;
+use RecursiveIteratorIterator;
+use SplFileInfo;
+use Tests\TestCase;
+
+final class MiddlewareNoThrowableReturnTrueTest extends TestCase
+{
+    public function test_middleware_does_not_return_true_from_throwable_catch(): void
+    {
+        $root = app_path('Http/Middleware');
+        $offenders = [];
+
+        $iterator = new RecursiveIteratorIterator(
+            new RecursiveDirectoryIterator($root, RecursiveDirectoryIterator::SKIP_DOTS)
+        );
+
+        /** @var SplFileInfo $file */
+        foreach ($iterator as $file) {
+            if (!$file->isFile() || strtolower($file->getExtension()) !== 'php') {
+                continue;
+            }
+
+            $path = $file->getPathname();
+            $source = file_get_contents($path);
+            if (!is_string($source)) {
+                continue;
+            }
+
+            if (preg_match('/catch\\s*\\(\\s*\\\\?Throwable(?:\\s+\\$[A-Za-z_][A-Za-z0-9_]*)?\\s*\\)\\s*\\{[^{}]*return\\s+true\\s*;/s', $source) === 1) {
+                $offenders[] = ltrim(str_replace(base_path(), '', $path), DIRECTORY_SEPARATOR);
+            }
+        }
+
+        sort($offenders);
+
+        $this->assertSame([], $offenders, 'Throwable catch blocks must not return true in middleware.');
+    }
+}
+

--- a/backend/tests/Feature/V0_2/FmTokenLegacyHashFallbackTest.php
+++ b/backend/tests/Feature/V0_2/FmTokenLegacyHashFallbackTest.php
@@ -1,0 +1,55 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\V0_2;
+
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Str;
+use Tests\TestCase;
+
+final class FmTokenLegacyHashFallbackTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_legacy_row_without_token_hash_is_accepted_and_self_healed(): void
+    {
+        $userId = (int) DB::table('users')->insertGetId([
+            'name' => 'Legacy User',
+            'email' => 'legacy-hash@example.com',
+            'password' => bcrypt('secret'),
+            'created_at' => now(),
+            'updated_at' => now(),
+        ]);
+
+        $token = 'fm_' . (string) Str::uuid();
+
+        DB::table('fm_tokens')->insert([
+            'token' => $token,
+            'token_hash' => null,
+            'user_id' => $userId,
+            'anon_id' => 'legacy_anon',
+            'org_id' => 0,
+            'role' => 'public',
+            'expires_at' => now()->addDays(30),
+            'revoked_at' => null,
+            'meta_json' => null,
+            'last_used_at' => null,
+            'created_at' => now(),
+            'updated_at' => now(),
+        ]);
+
+        $response = $this->withHeader('Authorization', 'Bearer ' . $token)
+            ->getJson('/api/v0.2/me/profile');
+
+        $response->assertStatus(200);
+        $response->assertJsonPath('ok', true);
+        $response->assertJsonPath('user_id', (string) $userId);
+
+        $this->assertSame(
+            hash('sha256', $token),
+            DB::table('fm_tokens')->where('token', $token)->value('token_hash')
+        );
+    }
+}

--- a/backend/tests/Feature/V0_2/ShareClickPayloadLimitTest.php
+++ b/backend/tests/Feature/V0_2/ShareClickPayloadLimitTest.php
@@ -183,6 +183,7 @@ final class ShareClickPayloadLimitTest extends TestCase
             'org_id' => $orgId,
             'anon_id' => $anonId,
             'attempt_id' => $attemptId,
+            'share_id' => $shareId,
             'meta_json' => json_encode([
                 'share_id' => $shareId,
                 'attempt_id' => $attemptId,

--- a/backend/tests/Feature/V0_2/ShareClickSecurityTest.php
+++ b/backend/tests/Feature/V0_2/ShareClickSecurityTest.php
@@ -179,6 +179,7 @@ final class ShareClickSecurityTest extends TestCase
             'org_id' => $orgId,
             'anon_id' => $anonId,
             'attempt_id' => $attemptId,
+            'share_id' => $shareId,
             'meta_json' => json_encode([
                 'share_id' => $shareId,
                 'attempt_id' => $attemptId,


### PR DESCRIPTION
## Summary
This PR completes six SRE hardening tasks in one batch:

1. **SRE-A-012** (`fm_tokens` migration + auth compatibility)
   - Removed in-migration full-table backfill from `2026_02_12_000010_converge_fm_tokens_schema.php`.
   - Added async, throttled backfill job/command:
     - `ops:backfill-fm-token-hash`
     - `App\Jobs\Ops\BackfillFmTokenHashJob`
   - Added legacy token fallback (`token_hash` -> `token`) and one-time self-heal in:
     - `FmTokenService`
     - `FmTokenAuth`
     - `FmTokenOptional`
   - Added regression test for legacy `token_hash = NULL` compatibility.

2. **SRE-P-001** (`last_used_at` write amplification)
   - Removed synchronous `last_used_at` writes from request path.
   - Added deduplicated async touch job:
     - `App\Jobs\Ops\TouchFmTokenLastUsedAtJob` (`ShouldBeUnique`, 5m dedupe window)
   - Updated `ResolveOrgContext` to cache token payload in request attributes and avoid repeated `validateToken()` calls.

3. **SRE-A-021** (`events.meta_json->share_id` bypassing index)
   - Replaced JSON-path share lookup with indexed `events.share_id` lookup.
   - Ensured share event writes include `share_id` (and channel/platform fields).
   - Added async legacy backfill job/command:
     - `ops:backfill-events-share-id`
     - `App\Jobs\Ops\BackfillEventsShareIdJob`

4. **SRE-A-022** (schema introspection on hot write path)
   - Added process-level schema cache helper: `App\Support\Database\SchemaCache`.
   - Replaced hot-path `Schema::hasTable/hasColumn` calls in `EventController` with `SchemaCache`.

5. **SRE-E-010** (auth helper swallows exception and returns true)
   - `FmTokenAuth::userExists()` now logs structured error context and returns `false` on exception (fail-closed).
   - Added regression architecture test to prevent `catch(Throwable){ return true; }` pattern in middleware.

6. **SRE-E-011** (cache adapter silent failures)
   - Added rate-limited cache failure logging in `ContentCacheAdapter`.
   - Added hot redis circuit breaker (60s disable window after hot-store failure).
   - Kept graceful fallback semantics:
     - `get()` returns `null` on total cache failure
     - `put()` / `forget()` return `false` on total cache failure

## Files Changed
### Added
- `backend/app/Jobs/Ops/BackfillFmTokenHashJob.php`
- `backend/app/Console/Commands/Ops/BackfillFmTokenHash.php`
- `backend/app/Jobs/Ops/TouchFmTokenLastUsedAtJob.php`
- `backend/app/Jobs/Ops/BackfillEventsShareIdJob.php`
- `backend/app/Console/Commands/Ops/BackfillEventsShareId.php`
- `backend/app/Support/Database/SchemaCache.php`
- `backend/tests/Feature/V0_2/FmTokenLegacyHashFallbackTest.php`
- `backend/tests/Feature/Architecture/MiddlewareNoThrowableReturnTrueTest.php`

### Modified
- `backend/database/migrations/2026_02_12_000010_converge_fm_tokens_schema.php`
- `backend/database/migrations/2026_02_12_000011_converge_integrations_schema.php`
- `backend/app/Services/Auth/FmTokenService.php`
- `backend/app/Http/Middleware/FmTokenAuth.php`
- `backend/app/Http/Middleware/FmTokenOptional.php`
- `backend/app/Http/Middleware/ResolveOrgContext.php`
- `backend/app/Services/Legacy/LegacyShareFlowService.php`
- `backend/app/Http/Controllers/EventController.php`
- `backend/app/Services/Content/V2/Cache/ContentCacheAdapter.php`
- `backend/app/Services/Content/V2/Contracts/CacheAdapterInterface.php`
- `backend/tests/Feature/V0_2/ShareClickSecurityTest.php`
- `backend/tests/Feature/V0_2/ShareClickPayloadLimitTest.php`

## Validation Run
- `cd backend && php artisan route:list`
- `cd backend && DB_CONNECTION=sqlite DB_DATABASE=/tmp/fap-ci.sqlite php artisan migrate --force`
- `cd backend && php artisan list | rg "ops:backfill-fm-token-hash|ops:backfill-events-share-id"`
- `cd backend && DB_CONNECTION=sqlite DB_DATABASE=/tmp/fap-test-fm-legacy.sqlite php artisan test --filter FmTokenLegacyHashFallbackTest`
- `cd backend && DB_CONNECTION=sqlite DB_DATABASE=/tmp/fap-test-middleware-gate.sqlite php artisan test --filter MiddlewareNoThrowableReturnTrueTest`
- `bash backend/scripts/ci_verify_mbti.sh`

All commands above passed in this branch.
