### PR TITLE
fix(security): harden release artifacts and unify API error contract

### DIFF
--- a/.github/workflows/release-artifact.yml
+++ b/.github/workflows/release-artifact.yml
@@ -1,0 +1,42 @@
+name: Release Artifact
+
+on:
+  workflow_dispatch:
+  push:
+    branches: ["main"]
+    tags: ["v*", "release-*"]
+
+permissions:
+  contents: read
+
+jobs:
+  artifact-hygiene-gate:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Export clean source zip
+        run: bash scripts/release/export_source_clean.sh
+
+      - name: Verify canonical source zip
+        run: bash scripts/release/verify_source_zip_clean.sh dist/source_clean.zip
+
+      - name: Reject dirty zip candidates
+        run: |
+          set -euo pipefail
+          shopt -s nullglob
+          zips=(dist/*.zip)
+          test ${#zips[@]} -gt 0
+          for z in "${zips[@]}"; do
+            bash scripts/release/verify_source_zip_clean.sh "$z"
+          done
+
+      - name: Upload trusted artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: source_clean
+          path: dist/source_clean.zip
+          if-no-files-found: error
+          retention-days: 7

--- a/Makefile
+++ b/Makefile
@@ -24,3 +24,19 @@ selfcheck-mysql:
 	bash scripts/ci/prepare_mysql.sh && \
 	APP_ENV=testing php vendor/phpunit/phpunit/phpunit --configuration phpunit.mysql.xml && \
 	APP_ENV=testing bash scripts/ci_smoke_v0_3.sh
+
+.PHONY: release release\:source-clean release\:verify
+
+release\:source-clean:
+	bash scripts/release/export_source_clean.sh
+
+release\:verify:
+	bash scripts/release/verify_source_zip_clean.sh dist/source_clean.zip
+
+release:
+	@$(MAKE) release:source-clean
+	@$(MAKE) release:verify
+	@echo "[release] artifact=dist/source_clean.zip"
+	@echo "[release] commit_sha=$$(git rev-parse --short=12 HEAD)"
+	@echo "[release] generated_at_utc=$$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+	@echo "[release] build_host=$$(uname -srm)"

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,30 @@
+# Release SOP (SEC/SRE-001)
+
+唯一允许的源码交付命令：
+
+```bash
+make release
+```
+
+禁止动作：
+
+1. 禁止 Finder/Explorer 右键压缩整个仓库目录。
+2. 禁止直接压缩 `backend/` 工作目录。
+3. 禁止手工上传未经过 `verify_source_zip_clean.sh` 校验的 zip。
+
+可信交付物：
+
+1. Canonical: `dist/source_clean.zip`
+2. Compatibility: `dist/fap-api-source.zip`（仅过渡，不作为对外交付主件）
+3. CI 发布只允许上传 `dist/source_clean.zip`
+
+审计追踪字段（发布记录必须填写）：
+
+1. `git commit sha`
+2. `generated_at_utc`
+3. `build_host`
+
+Key Rotation（泄露后强制流程）：
+
+1. 见 `/Users/rainie/Desktop/GitHub/fap-api/docs/security/key-rotation.md`
+2. 上线前签字清单：`/Users/rainie/Desktop/GitHub/fap-api/scripts/security/key_rotation_checklist.md`

--- a/backend/app/Http/Controllers/API/V0_2/Admin/AdminAgentController.php
+++ b/backend/app/Http/Controllers/API/V0_2/Admin/AdminAgentController.php
@@ -18,11 +18,11 @@ class AdminAgentController extends Controller
     {
         $triggerType = trim((string) $request->input('trigger_type', ''));
         if ($triggerType === '') {
-            return response()->json(['ok' => false, 'error' => 'trigger_type_required'], 422);
+            return response()->json(['ok' => false, 'error_code' => 'trigger_type_required'], 422);
         }
 
         if (!\App\Support\SchemaBaseline::hasTable('agent_triggers')) {
-            return response()->json(['ok' => false, 'error' => 'agent_triggers_missing'], 500);
+            return response()->json(['ok' => false, 'error_code' => 'agent_triggers_missing'], 500);
         }
 
         DB::table('agent_triggers')

--- a/backend/app/Http/Controllers/API/V0_2/Admin/AdminAuditController.php
+++ b/backend/app/Http/Controllers/API/V0_2/Admin/AdminAuditController.php
@@ -18,7 +18,7 @@ class AdminAuditController extends Controller
         if (!\App\Support\SchemaBaseline::hasTable('audit_logs')) {
             return response()->json([
                 'ok' => false,
-                'error' => 'TABLE_MISSING',
+                'error_code' => 'TABLE_MISSING',
                 'message' => 'audit_logs missing',
             ], 500);
         }

--- a/backend/app/Http/Controllers/API/V0_2/Admin/AdminContentController.php
+++ b/backend/app/Http/Controllers/API/V0_2/Admin/AdminContentController.php
@@ -20,7 +20,7 @@ class AdminContentController extends Controller
         if (!\App\Support\SchemaBaseline::hasTable('content_pack_releases')) {
             return response()->json([
                 'ok' => false,
-                'error' => 'TABLE_MISSING',
+                'error_code' => 'TABLE_MISSING',
                 'message' => 'content_pack_releases missing',
             ], 500);
         }
@@ -45,7 +45,7 @@ class AdminContentController extends Controller
         if (!\App\Support\SchemaBaseline::hasTable('content_pack_releases')) {
             return response()->json([
                 'ok' => false,
-                'error' => 'TABLE_MISSING',
+                'error_code' => 'TABLE_MISSING',
                 'message' => 'content_pack_releases missing',
             ], 500);
         }
@@ -55,7 +55,7 @@ class AdminContentController extends Controller
         if (!$release) {
             return response()->json([
                 'ok' => false,
-                'error' => 'NOT_FOUND',
+                'error_code' => 'NOT_FOUND',
                 'message' => 'release not found',
             ], 404);
         }

--- a/backend/app/Http/Controllers/API/V0_2/Admin/AdminEventsController.php
+++ b/backend/app/Http/Controllers/API/V0_2/Admin/AdminEventsController.php
@@ -18,7 +18,7 @@ class AdminEventsController extends Controller
         if (!\App\Support\SchemaBaseline::hasTable('events')) {
             return response()->json([
                 'ok' => false,
-                'error' => 'TABLE_MISSING',
+                'error_code' => 'TABLE_MISSING',
                 'message' => 'events missing',
             ], 500);
         }

--- a/backend/app/Http/Controllers/API/V0_2/Admin/AdminOpsController.php
+++ b/backend/app/Http/Controllers/API/V0_2/Admin/AdminOpsController.php
@@ -21,7 +21,7 @@ class AdminOpsController extends Controller
         if (!\App\Support\SchemaBaseline::hasTable('ops_healthz_snapshots')) {
             return response()->json([
                 'ok' => false,
-                'error' => 'TABLE_MISSING',
+                'error_code' => 'TABLE_MISSING',
                 'message' => 'ops_healthz_snapshots missing',
             ], 500);
         }
@@ -54,7 +54,7 @@ class AdminOpsController extends Controller
         if (($scope === 'pack' || $scope === 'all') && ($packId === '' || $dirVersion === '')) {
             return response()->json([
                 'ok' => false,
-                'error' => 'INVALID_PARAMS',
+                'error_code' => 'INVALID_PARAMS',
                 'message' => 'pack_id and dir_version required for scope=pack|all',
             ], 422);
         }

--- a/backend/app/Http/Controllers/API/V0_2/Admin/AdminQueueController.php
+++ b/backend/app/Http/Controllers/API/V0_2/Admin/AdminQueueController.php
@@ -34,7 +34,7 @@ class AdminQueueController extends Controller
         if (!preg_match('/^\d+$/', $failed_job_id)) {
             return response()->json([
                 'ok' => false,
-                'error' => 'NOT_FOUND',
+                'error_code' => 'NOT_FOUND',
                 'message' => 'failed job not found.',
             ], 404);
         }
@@ -61,7 +61,7 @@ class AdminQueueController extends Controller
         if ($status === 'not_found') {
             return response()->json([
                 'ok' => false,
-                'error' => 'NOT_FOUND',
+                'error_code' => 'NOT_FOUND',
                 'message' => 'failed job not found.',
             ], 404);
         }
@@ -69,7 +69,7 @@ class AdminQueueController extends Controller
         if ($status === 'invalid_payload') {
             return response()->json([
                 'ok' => false,
-                'error' => 'INVALID_PAYLOAD',
+                'error_code' => 'INVALID_PAYLOAD',
                 'message' => 'failed job payload invalid.',
                 'data' => $result,
             ], 422);
@@ -78,7 +78,7 @@ class AdminQueueController extends Controller
         if ($status === 'push_failed') {
             return response()->json([
                 'ok' => false,
-                'error' => 'REPLAY_FAILED',
+                'error_code' => 'REPLAY_FAILED',
                 'message' => 'failed job replay failed.',
                 'data' => $result,
             ], 500);

--- a/backend/app/Http/Controllers/API/V0_2/Admin/ContentReleaseController.php
+++ b/backend/app/Http/Controllers/API/V0_2/Admin/ContentReleaseController.php
@@ -31,7 +31,7 @@ class ContentReleaseController extends Controller
         if ($file === null && $s3Key === '') {
             return response()->json([
                 'ok' => false,
-                'error' => 'MISSING_SOURCE',
+                'error_code' => 'MISSING_SOURCE',
                 'message' => 'file or s3_key is required.',
             ], 422);
         }
@@ -70,7 +70,7 @@ class ContentReleaseController extends Controller
         if ($versionId === '' || $region === '' || $locale === '' || $dirAlias === '') {
             return response()->json([
                 'ok' => false,
-                'error' => 'INVALID_PARAMS',
+                'error_code' => 'INVALID_PARAMS',
                 'message' => 'version_id, region, locale, dir_alias are required.',
             ], 422);
         }
@@ -103,7 +103,7 @@ class ContentReleaseController extends Controller
         if ($region === '' || $locale === '' || $dirAlias === '') {
             return response()->json([
                 'ok' => false,
-                'error' => 'INVALID_PARAMS',
+                'error_code' => 'INVALID_PARAMS',
                 'message' => 'region, locale, dir_alias are required.',
             ], 422);
         }

--- a/backend/app/Http/Controllers/API/V0_2/AgentController.php
+++ b/backend/app/Http/Controllers/API/V0_2/AgentController.php
@@ -23,7 +23,7 @@ class AgentController extends Controller
         }
 
         if (!\App\Support\SchemaBaseline::hasTable('user_agent_settings')) {
-            return response()->json(['ok' => false, 'error' => 'settings_table_missing'], 500);
+            return response()->json(['ok' => false, 'error_code' => 'settings_table_missing'], 500);
         }
 
         $row = DB::table('user_agent_settings')->where('user_id', $userId)->first();
@@ -45,7 +45,7 @@ class AgentController extends Controller
         }
 
         if (!\App\Support\SchemaBaseline::hasTable('user_agent_settings')) {
-            return response()->json(['ok' => false, 'error' => 'settings_table_missing'], 500);
+            return response()->json(['ok' => false, 'error_code' => 'settings_table_missing'], 500);
         }
 
         $enabled = (bool) $request->input('enabled', false);
@@ -92,7 +92,7 @@ class AgentController extends Controller
         }
 
         if (!\App\Support\SchemaBaseline::hasTable('agent_messages')) {
-            return response()->json(['ok' => false, 'error' => 'agent_messages_missing'], 500);
+            return response()->json(['ok' => false, 'error_code' => 'agent_messages_missing'], 500);
         }
 
         $rows = DB::table('agent_messages')
@@ -118,17 +118,17 @@ class AgentController extends Controller
         }
 
         if (!\App\Support\SchemaBaseline::hasTable('agent_feedback') || !\App\Support\SchemaBaseline::hasTable('agent_messages')) {
-            return response()->json(['ok' => false, 'error' => 'agent_feedback_missing'], 500);
+            return response()->json(['ok' => false, 'error_code' => 'agent_feedback_missing'], 500);
         }
 
         $message = DB::table('agent_messages')->where('id', $id)->where('user_id', $userId)->first();
         if (!$message) {
-            return response()->json(['ok' => false, 'error' => 'message_not_found'], 404);
+            return response()->json(['ok' => false, 'error_code' => 'message_not_found'], 404);
         }
 
         $rating = trim((string) $request->input('rating', ''));
         if ($rating === '') {
-            return response()->json(['ok' => false, 'error' => 'rating_required'], 422);
+            return response()->json(['ok' => false, 'error_code' => 'rating_required'], 422);
         }
 
         $feedbackId = (string) Str::uuid();
@@ -168,12 +168,12 @@ class AgentController extends Controller
         }
 
         if (!\App\Support\SchemaBaseline::hasTable('agent_messages')) {
-            return response()->json(['ok' => false, 'error' => 'agent_messages_missing'], 500);
+            return response()->json(['ok' => false, 'error_code' => 'agent_messages_missing'], 500);
         }
 
         $message = DB::table('agent_messages')->where('id', $id)->where('user_id', $userId)->first();
         if (!$message) {
-            return response()->json(['ok' => false, 'error' => 'message_not_found'], 404);
+            return response()->json(['ok' => false, 'error_code' => 'message_not_found'], 404);
         }
 
         DB::table('agent_messages')->where('id', $id)->update([
@@ -202,7 +202,7 @@ class AgentController extends Controller
     {
         return response()->json([
             'ok' => false,
-            'error' => 'USER_ID_REQUIRED',
+            'error_code' => 'USER_ID_REQUIRED',
         ], 401);
     }
 }

--- a/backend/app/Http/Controllers/API/V0_2/AuthProviderController.php
+++ b/backend/app/Http/Controllers/API/V0_2/AuthProviderController.php
@@ -27,12 +27,12 @@ class AuthProviderController extends Controller
         $limitIp = $limiter->limit('FAP_RATE_PROVIDER_LOGIN_IP', 60);
         if ($ip !== '' && !$limiter->hit("provider_login:ip:{$ip}", $limitIp, 60)) {
             $logger->log('provider_login', false, $request, null, [
-                'error' => 'RATE_LIMITED',
+                'error_code' => 'RATE_LIMITED',
                 'provider' => $provider,
             ]);
             return response()->json([
                 'ok' => false,
-                'error' => 'RATE_LIMITED',
+                'error_code' => 'RATE_LIMITED',
                 'message' => 'Too many requests from this IP.',
             ], 429);
         }

--- a/backend/app/Http/Controllers/API/V0_2/ClaimController.php
+++ b/backend/app/Http/Controllers/API/V0_2/ClaimController.php
@@ -22,11 +22,11 @@ class ClaimController extends Controller
         $limitIp = $limiter->limit('FAP_RATE_CLAIM_REPORT_IP', 30);
         if ($ip !== '' && !$limiter->hit("claim_report:ip:{$ip}", $limitIp, 60)) {
             $logger->log('claim_report', false, $request, null, [
-                'error' => 'RATE_LIMITED',
+                'error_code' => 'RATE_LIMITED',
             ]);
             return response()->json([
                 'ok' => false,
-                'error' => 'RATE_LIMITED',
+                'error_code' => 'RATE_LIMITED',
                 'message' => 'Too many requests from this IP.',
             ], 429);
         }
@@ -35,11 +35,11 @@ class ClaimController extends Controller
 
         if ($token === '') {
             $logger->log('claim_report', false, $request, null, [
-                'error' => 'INVALID_TOKEN',
+                'error_code' => 'INVALID_TOKEN',
             ]);
             return response()->json([
                 'ok' => false,
-                'error' => 'INVALID_TOKEN',
+                'error_code' => 'INVALID_TOKEN',
                 'message' => 'token is required.',
             ], 422);
         }
@@ -51,12 +51,12 @@ class ClaimController extends Controller
         if (!($res['ok'] ?? false)) {
             $status = (int) ($res['status'] ?? 422);
             $logger->log('claim_report', false, $request, null, [
-                'error' => (string) ($res['error'] ?? 'INVALID_TOKEN'),
+                'error_code' => (string) ($res['error'] ?? 'INVALID_TOKEN'),
                 'token_hash' => hash('sha256', $token),
             ]);
             return response()->json([
                 'ok' => false,
-                'error' => $res['error'] ?? 'INVALID_TOKEN',
+                'error_code' => $res['error'] ?? 'INVALID_TOKEN',
                 'message' => $res['message'] ?? 'claim token invalid.',
             ], $status);
         }

--- a/backend/app/Http/Controllers/API/V0_2/ContentPacksController.php
+++ b/backend/app/Http/Controllers/API/V0_2/ContentPacksController.php
@@ -73,7 +73,7 @@ class ContentPacksController extends Controller
         if ($path === '' || !File::exists($path) || !File::isFile($path)) {
             return [
                 'ok' => false,
-                'error' => 'READ_FAILED',
+                'error_code' => 'READ_FAILED',
                 'message' => $path === '' ? 'missing file path' : "file not found: {$path}",
             ];
         }
@@ -83,7 +83,7 @@ class ContentPacksController extends Controller
         } catch (\Throwable $e) {
             return [
                 'ok' => false,
-                'error' => 'READ_FAILED',
+                'error_code' => 'READ_FAILED',
                 'message' => "failed to read: {$path}",
             ];
         }
@@ -92,7 +92,7 @@ class ContentPacksController extends Controller
         if (!is_array($decoded)) {
             return [
                 'ok' => false,
-                'error' => 'INVALID_JSON',
+                'error_code' => 'INVALID_JSON',
                 'message' => "invalid json: {$path}",
             ];
         }
@@ -107,7 +107,7 @@ class ContentPacksController extends Controller
     {
         return response()->json([
             'ok' => false,
-            'error' => 'NOT_FOUND',
+            'error_code' => 'NOT_FOUND',
             'message' => 'pack not found',
         ], 404);
     }
@@ -116,7 +116,7 @@ class ContentPacksController extends Controller
     {
         return response()->json([
             'ok' => false,
-            'error' => $error,
+            'error_code' => $error,
             'message' => $message,
         ], 500);
     }

--- a/backend/app/Http/Controllers/API/V0_2/IdentityController.php
+++ b/backend/app/Http/Controllers/API/V0_2/IdentityController.php
@@ -23,11 +23,11 @@ class IdentityController extends Controller
         $limitIp = $limiter->limit('FAP_RATE_IDENTITIES_BIND_IP', 60);
         if ($ip !== '' && !$limiter->hit("identities_bind:ip:{$ip}", $limitIp, 60)) {
             $logger->log('identities_bind', false, $request, null, [
-                'error' => 'RATE_LIMITED',
+                'error_code' => 'RATE_LIMITED',
             ]);
             return response()->json([
                 'ok' => false,
-                'error' => 'RATE_LIMITED',
+                'error_code' => 'RATE_LIMITED',
                 'message' => 'Too many requests from this IP.',
             ], 429);
         }
@@ -35,11 +35,11 @@ class IdentityController extends Controller
         $userId = (string) $request->attributes->get('fm_user_id', '');
         if ($userId === '') {
             $logger->log('identities_bind', false, $request, null, [
-                'error' => 'UNAUTHORIZED',
+                'error_code' => 'UNAUTHORIZED',
             ]);
             return response()->json([
                 'ok' => false,
-                'error' => 'UNAUTHORIZED',
+                'error_code' => 'UNAUTHORIZED',
                 'message' => 'Missing or invalid fm_token.',
             ], 401);
         }
@@ -56,13 +56,13 @@ class IdentityController extends Controller
         if (!($res['ok'] ?? false)) {
             $status = (int) ($res['status'] ?? 422);
             $logger->log('identities_bind', false, $request, $userId, [
-                'error' => $res['error'] ?? 'IDENTITY_BIND_FAILED',
+                'error_code' => $res['error'] ?? 'IDENTITY_BIND_FAILED',
                 'provider' => $request->provider(),
                 'provider_uid_hash' => hash('sha256', $request->providerUid()),
             ]);
             return response()->json([
                 'ok' => false,
-                'error' => $res['error'] ?? 'IDENTITY_BIND_FAILED',
+                'error_code' => $res['error'] ?? 'IDENTITY_BIND_FAILED',
                 'message' => $res['message'] ?? 'identity bind failed.',
             ], $status);
         }
@@ -87,7 +87,7 @@ class IdentityController extends Controller
         if ($userId === '') {
             return response()->json([
                 'ok' => false,
-                'error' => 'UNAUTHORIZED',
+                'error_code' => 'UNAUTHORIZED',
                 'message' => 'Missing or invalid fm_token.',
             ], 401);
         }

--- a/backend/app/Http/Controllers/API/V0_2/InsightsController.php
+++ b/backend/app/Http/Controllers/API/V0_2/InsightsController.php
@@ -20,7 +20,7 @@ class InsightsController extends Controller
         if (!(bool) config('ai.enabled', true) || !(bool) config('ai.insights_enabled', true)) {
             return response()->json([
                 'ok' => false,
-                'error' => 'AI_DISABLED',
+                'error_code' => 'AI_DISABLED',
                 'error_code' => 'AI_DISABLED',
                 'message' => 'AI insights are currently disabled.',
             ], 503);
@@ -29,7 +29,7 @@ class InsightsController extends Controller
         if (!\App\Support\SchemaBaseline::hasTable('ai_insights')) {
             return response()->json([
                 'ok' => false,
-                'error' => 'TABLE_MISSING',
+                'error_code' => 'TABLE_MISSING',
                 'error_code' => 'AI_TABLE_MISSING',
                 'message' => 'AI insights table not found.',
             ], 500);
@@ -39,7 +39,7 @@ class InsightsController extends Controller
         if (!in_array($periodType, ['week', 'month'], true)) {
             return response()->json([
                 'ok' => false,
-                'error' => 'INVALID_PERIOD_TYPE',
+                'error_code' => 'INVALID_PERIOD_TYPE',
                 'message' => 'period_type must be week or month.',
             ], 422);
         }
@@ -50,7 +50,7 @@ class InsightsController extends Controller
         if (!$periodStart || !$periodEnd) {
             return response()->json([
                 'ok' => false,
-                'error' => 'INVALID_PERIOD_RANGE',
+                'error_code' => 'INVALID_PERIOD_RANGE',
                 'message' => 'period_start and period_end must be valid dates.',
             ], 422);
         }
@@ -106,7 +106,7 @@ class InsightsController extends Controller
 
             return response()->json([
                 'ok' => false,
-                'error' => 'AI_DISPATCH_FAILED',
+                'error_code' => 'AI_DISPATCH_FAILED',
                 'message' => 'Failed to dispatch insight generation.',
             ], 500);
         }
@@ -134,7 +134,7 @@ class InsightsController extends Controller
         if (!\App\Support\SchemaBaseline::hasTable('ai_insights')) {
             return response()->json([
                 'ok' => false,
-                'error' => 'TABLE_MISSING',
+                'error_code' => 'TABLE_MISSING',
             ], 500);
         }
 
@@ -142,7 +142,7 @@ class InsightsController extends Controller
         if (!$row) {
             return response()->json([
                 'ok' => false,
-                'error' => 'NOT_FOUND',
+                'error_code' => 'NOT_FOUND',
             ], 404);
         }
 
@@ -178,7 +178,7 @@ class InsightsController extends Controller
         if (!\App\Support\SchemaBaseline::hasTable('ai_insights') || !\App\Support\SchemaBaseline::hasTable('ai_insight_feedback')) {
             return response()->json([
                 'ok' => false,
-                'error' => 'TABLE_MISSING',
+                'error_code' => 'TABLE_MISSING',
             ], 500);
         }
 
@@ -186,7 +186,7 @@ class InsightsController extends Controller
         if (!$row) {
             return response()->json([
                 'ok' => false,
-                'error' => 'NOT_FOUND',
+                'error_code' => 'NOT_FOUND',
             ], 404);
         }
 
@@ -199,7 +199,7 @@ class InsightsController extends Controller
         if ($rating < 1 || $rating > 5) {
             return response()->json([
                 'ok' => false,
-                'error' => 'INVALID_RATING',
+                'error_code' => 'INVALID_RATING',
                 'message' => 'rating must be between 1 and 5.',
             ], 422);
         }
@@ -240,7 +240,7 @@ class InsightsController extends Controller
             if ($reqUserId === '' || $reqUserId !== $rowUserId) {
                 return response()->json([
                     'ok' => false,
-                    'error' => 'FORBIDDEN',
+                    'error_code' => 'FORBIDDEN',
                 ], 403);
             }
         } elseif ($rowAnonId !== '') {
@@ -252,13 +252,13 @@ class InsightsController extends Controller
                 }
                 return response()->json([
                     'ok' => false,
-                    'error' => 'FORBIDDEN',
+                    'error_code' => 'FORBIDDEN',
                 ], 403);
             }
             if ($headerAnon !== $rowAnonId && !$allowDev) {
                 return response()->json([
                     'ok' => false,
-                    'error' => 'FORBIDDEN',
+                    'error_code' => 'FORBIDDEN',
                 ], 403);
             }
         }

--- a/backend/app/Http/Controllers/API/V0_2/MemoryController.php
+++ b/backend/app/Http/Controllers/API/V0_2/MemoryController.php
@@ -19,7 +19,7 @@ class MemoryController extends Controller
         if (!(bool) config('memory.enabled', true)) {
             return response()->json([
                 'ok' => false,
-                'error' => 'MEMORY_DISABLED',
+                'error_code' => 'MEMORY_DISABLED',
                 'message' => 'Memory is currently disabled.',
             ], 503);
         }
@@ -33,7 +33,7 @@ class MemoryController extends Controller
         if ($content === '') {
             return response()->json([
                 'ok' => false,
-                'error' => 'CONTENT_REQUIRED',
+                'error_code' => 'CONTENT_REQUIRED',
                 'message' => 'content is required.',
             ], 422);
         }
@@ -44,7 +44,7 @@ class MemoryController extends Controller
             if (!empty($redacted['flags'])) {
                 return response()->json([
                     'ok' => false,
-                    'error' => 'CONTENT_REDACTED',
+                    'error_code' => 'CONTENT_REDACTED',
                     'message' => 'Memory content contains sensitive data.',
                 ], 422);
             }
@@ -65,7 +65,7 @@ class MemoryController extends Controller
         if (!($result['ok'] ?? false)) {
             return response()->json([
                 'ok' => false,
-                'error' => $result['error'] ?? 'MEMORY_PROPOSE_FAILED',
+                'error_code' => $result['error'] ?? 'MEMORY_PROPOSE_FAILED',
             ], 500);
         }
 
@@ -88,7 +88,7 @@ class MemoryController extends Controller
         if (!(bool) config('memory.enabled', true)) {
             return response()->json([
                 'ok' => false,
-                'error' => 'MEMORY_DISABLED',
+                'error_code' => 'MEMORY_DISABLED',
             ], 503);
         }
 
@@ -103,7 +103,7 @@ class MemoryController extends Controller
         if (!($result['ok'] ?? false)) {
             return response()->json([
                 'ok' => false,
-                'error' => $result['error'] ?? 'MEMORY_CONFIRM_FAILED',
+                'error_code' => $result['error'] ?? 'MEMORY_CONFIRM_FAILED',
             ], 404);
         }
 
@@ -127,7 +127,7 @@ class MemoryController extends Controller
         if (!(bool) config('memory.enabled', true)) {
             return response()->json([
                 'ok' => false,
-                'error' => 'MEMORY_DISABLED',
+                'error_code' => 'MEMORY_DISABLED',
             ], 503);
         }
 
@@ -159,7 +159,7 @@ class MemoryController extends Controller
         if (!(bool) config('memory.enabled', true)) {
             return response()->json([
                 'ok' => false,
-                'error' => 'MEMORY_DISABLED',
+                'error_code' => 'MEMORY_DISABLED',
             ], 503);
         }
 
@@ -187,7 +187,7 @@ class MemoryController extends Controller
         if (!(bool) config('memory.enabled', true)) {
             return response()->json([
                 'ok' => false,
-                'error' => 'MEMORY_DISABLED',
+                'error_code' => 'MEMORY_DISABLED',
             ], 503);
         }
 
@@ -207,7 +207,7 @@ class MemoryController extends Controller
             if (!($probe['ok'] ?? false)) {
                 return response()->json([
                     'ok' => false,
-                    'error' => $probe['error'] ?? 'MEMORY_EXPORT_FAILED',
+                    'error_code' => $probe['error'] ?? 'MEMORY_EXPORT_FAILED',
                 ], 500);
             }
 
@@ -234,7 +234,7 @@ class MemoryController extends Controller
 
             return response()->json([
                 'ok' => false,
-                'error' => $error,
+                'error_code' => $error,
             ], $status);
         }
 
@@ -260,7 +260,7 @@ class MemoryController extends Controller
     {
         return response()->json([
             'ok' => false,
-            'error' => 'USER_ID_REQUIRED',
+            'error_code' => 'USER_ID_REQUIRED',
             'message' => 'user_id is required for memory operations.',
         ], 401);
     }

--- a/backend/app/Http/Controllers/API/V0_2/NormsController.php
+++ b/backend/app/Http/Controllers/API/V0_2/NormsController.php
@@ -28,7 +28,7 @@ class NormsController extends Controller
         if ($v->fails()) {
             return response()->json([
                 'ok'     => false,
-                'error'  => 'VALIDATION_FAILED',
+                'error_code'  => 'VALIDATION_FAILED',
                 'errors' => $v->errors(),
             ], 422);
         }
@@ -96,7 +96,7 @@ class NormsController extends Controller
     {
         return response()->json([
             'ok'    => false,
-            'error' => 'NOT_ENABLED',
+            'error_code' => 'NOT_ENABLED',
         ]);
     }
 
@@ -104,7 +104,7 @@ class NormsController extends Controller
     {
         return response()->json([
             'ok'    => false,
-            'error' => 'NOT_FOUND',
+            'error_code' => 'NOT_FOUND',
         ]);
     }
 }

--- a/backend/app/Http/Controllers/API/V0_2/PsychometricsController.php
+++ b/backend/app/Http/Controllers/API/V0_2/PsychometricsController.php
@@ -25,7 +25,7 @@ class PsychometricsController extends Controller
         if ($scale === '') {
             return response()->json([
                 'ok' => false,
-                'error' => 'SCALE_REQUIRED',
+                'error_code' => 'SCALE_REQUIRED',
             ], 400);
         }
 
@@ -56,7 +56,7 @@ class PsychometricsController extends Controller
         if (!\App\Support\SchemaBaseline::hasTable('attempt_quality')) {
             return response()->json([
                 'ok' => false,
-                'error' => 'QUALITY_NOT_AVAILABLE',
+                'error_code' => 'QUALITY_NOT_AVAILABLE',
             ], 404);
         }
 
@@ -132,7 +132,7 @@ class PsychometricsController extends Controller
         if (!is_array($stats)) {
             return response()->json([
                 'ok' => false,
-                'error' => 'STATS_NOT_FOUND',
+                'error_code' => 'STATS_NOT_FOUND',
             ], 404);
         }
 

--- a/backend/app/Http/Controllers/API/V0_2/ShareController.php
+++ b/backend/app/Http/Controllers/API/V0_2/ShareController.php
@@ -9,6 +9,8 @@ use App\Http\Requests\V0_2\ShareViewRequest;
 use App\Services\Legacy\LegacyShareFlowService;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Log;
+use Throwable;
 
 class ShareController extends Controller
 {
@@ -19,21 +21,31 @@ class ShareController extends Controller
     public function click(ShareClickRequest $request, string $shareId): JsonResponse
     {
         $routeShareId = (string) $request->route('shareId', $shareId);
-        $result = $this->shareFlow->clickAndComposeReport(
-            $routeShareId,
-            $request->validated(),
-            $this->requestMeta($request)
-        );
+        try {
+            $result = $this->shareFlow->clickAndComposeReport(
+                $routeShareId,
+                $request->validated(),
+                $this->requestMeta($request)
+            );
 
-        return response()->json(array_merge(['ok' => true], $result), 200);
+            return response()->json(array_merge(['ok' => true], $result), 200);
+        } catch (Throwable $e) {
+            $this->logShareFlowFailed($request, 'click', $routeShareId, null, $e);
+            throw $e;
+        }
     }
 
     public function getShare(GetShareRequest $request, string $id): JsonResponse
     {
-        $input = array_merge($request->validated(), $this->requestMeta($request));
-        $result = $this->shareFlow->getShareLinkForAttempt($id, $input);
+        try {
+            $input = array_merge($request->validated(), $this->requestMeta($request));
+            $result = $this->shareFlow->getShareLinkForAttempt($id, $input);
 
-        return response()->json(array_merge(['ok' => true], $result), 200);
+            return response()->json(array_merge(['ok' => true], $result), 200);
+        } catch (Throwable $e) {
+            $this->logShareFlowFailed($request, 'get_share', null, $id, $e);
+            throw $e;
+        }
     }
 
     public function getShareView(ShareViewRequest $request, string $id): JsonResponse
@@ -59,5 +71,52 @@ class ShareController extends Controller
             'client_platform' => (string) $request->header('X-Client-Platform', ''),
             'entry_page' => (string) $request->header('X-Entry-Page', ''),
         ];
+    }
+
+    private function logShareFlowFailed(
+        Request $request,
+        string $action,
+        ?string $shareId,
+        ?string $attemptId,
+        Throwable $e
+    ): void {
+        Log::error('share_flow_failed', [
+            'action' => $action,
+            'share_id' => $shareId,
+            'attempt_id' => $attemptId,
+            'org_id' => $this->resolveOrgId($request),
+            'request_id' => $this->resolveRequestId($request),
+            'exception' => $e,
+        ]);
+    }
+
+    private function resolveOrgId(Request $request): int
+    {
+        $orgId = $request->attributes->get('org_id');
+        if (!is_numeric($orgId)) {
+            $orgId = $request->attributes->get('fm_org_id');
+        }
+
+        return is_numeric($orgId) ? (int) $orgId : 0;
+    }
+
+    private function resolveRequestId(Request $request): string
+    {
+        $requestId = trim((string) ($request->attributes->get('request_id') ?? ''));
+        if ($requestId !== '') {
+            return $requestId;
+        }
+
+        $requestId = trim((string) $request->header('X-Request-Id', ''));
+        if ($requestId !== '') {
+            return $requestId;
+        }
+
+        $requestId = trim((string) $request->header('X-Request-ID', ''));
+        if ($requestId !== '') {
+            return $requestId;
+        }
+
+        return (string) \Illuminate\Support\Str::uuid();
     }
 }

--- a/backend/app/Http/Controllers/API/V0_3/AttemptReadController.php
+++ b/backend/app/Http/Controllers/API/V0_3/AttemptReadController.php
@@ -36,9 +36,7 @@ class AttemptReadController extends Controller
     public function result(Request $request, string $id): JsonResponse
     {
         $orgId = $this->orgContext->orgId();
-        $userId = $this->resolveUserId($request);
-        $anonId = $this->resolveAnonId($request);
-        $attempt = $this->ownedAttemptQuery($id)->firstOrFail();
+        $attempt = $this->ownedAttemptQuery($request, $id)->firstOrFail();
 
         $result = Result::where('org_id', $orgId)->where('attempt_id', $id)->firstOrFail();
 
@@ -99,7 +97,7 @@ class AttemptReadController extends Controller
         $orgId = $this->orgContext->orgId();
         $userId = $this->resolveUserId($request);
         $anonId = $this->resolveAnonId($request);
-        $attempt = $this->ownedAttemptQuery($id)->firstOrFail();
+        $attempt = $this->ownedAttemptQuery($request, $id)->firstOrFail();
 
         $result = Result::where('org_id', $orgId)->where('attempt_id', $id)->firstOrFail();
 

--- a/backend/app/Http/Controllers/API/V0_3/Concerns/ResolvesAttemptOwnership.php
+++ b/backend/app/Http/Controllers/API/V0_3/Concerns/ResolvesAttemptOwnership.php
@@ -6,174 +6,56 @@ use App\Models\Attempt;
 use App\Support\OrgContext;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Http\Request;
-use Illuminate\Support\Facades\DB;
 
 trait ResolvesAttemptOwnership
 {
-    /**
-     * @return array{userId:?string, anonId:?string}
-     */
-    protected function resolveViewerIdentity(Request $request): array
+    protected function ownedAttemptQuery(Request $request, string $attemptId): Builder
     {
-        $ctx = app(OrgContext::class);
+        $orgId = (int) app(OrgContext::class)->orgId();
+        $userId = $this->resolveUserId($request);
+        $anonId = $this->resolveAnonId($request);
 
-        $userId = $this->normalizeUserId(auth()->id());
-        if ($userId === null) {
-            $userId = $this->normalizeUserId(
-                $request->attributes->get('fm_user_id')
-                    ?? $request->attributes->get('user_id')
-                    ?? $ctx->userId()
-            );
+        $query = Attempt::query()
+            ->where('id', $attemptId)
+            ->where('org_id', $orgId);
+
+        if ($userId !== null) {
+            return $query->where('user_id', $userId);
         }
 
-        $anonId = $this->normalizeAnonId(
-            $request->header('X-Anon-Id')
-                ?? $request->header('X-Fm-Anon-Id')
-        );
-
-        if ($anonId === null) {
-            $anonId = $this->normalizeAnonId(
-                $request->attributes->get('anon_id')
-                    ?? $request->attributes->get('fm_anon_id')
-                    ?? $ctx->anonId()
-            );
+        if ($anonId !== null) {
+            return $query->where('anon_id', $anonId);
         }
 
-        return [
-            'userId' => $userId,
-            'anonId' => $anonId,
-        ];
-    }
-
-    protected function orgIdFromContext(): int
-    {
-        $req = request();
-        if ($req instanceof Request) {
-            $attrOrgId = $req->attributes->get('org_id');
-            if (is_numeric($attrOrgId)) {
-                return (int) $attrOrgId;
-            }
-
-            $fmOrgId = $req->attributes->get('fm_org_id');
-            if (is_numeric($fmOrgId)) {
-                return (int) $fmOrgId;
-            }
-        }
-
-        return (int) app(OrgContext::class)->orgId();
-    }
-
-    /**
-     * Legacy usage:
-     * - ownedAttemptQuery($attemptId)
-     *
-     * New usage:
-     * - ownedAttemptQuery($orgId, $userId, $anonId)
-     */
-    protected function ownedAttemptQuery(int|string $orgIdOrAttemptId, ?string $userId = null, ?string $anonId = null): Builder
-    {
-        if (is_string($orgIdOrAttemptId) && func_num_args() === 1) {
-            $req = request();
-            if (!$req instanceof Request) {
-                return $this->denyAll(Attempt::query());
-            }
-
-            $identity = $this->resolveViewerIdentity($req);
-            $orgId = $this->orgIdFromContext();
-
-            return $this->buildOwnedAttemptQuery($orgId, $identity['userId'], $identity['anonId'])
-                ->where('id', $orgIdOrAttemptId);
-        }
-
-        return $this->buildOwnedAttemptQuery((int) $orgIdOrAttemptId, $userId, $anonId);
-    }
-
-    protected function resolveAttemptOr404(Request $request, string $attemptId): Attempt
-    {
-        $identity = $this->resolveViewerIdentity($request);
-
-        $attempt = $this->ownedAttemptQuery(
-            $this->orgIdFromContext(),
-            $identity['userId'],
-            $identity['anonId']
-        )->where('id', $attemptId)->first();
-
-        if (!$attempt instanceof Attempt) {
-            abort(404);
-        }
-
-        return $attempt;
+        return $query->whereRaw('1 = 0');
     }
 
     protected function resolveUserId(Request $request): ?string
     {
-        return $this->resolveViewerIdentity($request)['userId'];
+        $userId = $request->user()?->id;
+
+        return $this->normalizeString($userId);
     }
 
     protected function resolveAnonId(Request $request): ?string
     {
-        return $this->resolveViewerIdentity($request)['anonId'];
-    }
+        $candidates = [
+            $request->header('X-Anon-Id'),
+            $request->cookie('fm_anon_id'),
+            app(OrgContext::class)->anonId(),
+        ];
 
-    private function buildOwnedAttemptQuery(int $orgId, ?string $userId, ?string $anonId): Builder
-    {
-        $query = Attempt::query()->where('org_id', $orgId);
-
-        $normalizedUserId = $this->normalizeUserId($userId);
-        $normalizedAnonId = $this->normalizeAnonId($anonId);
-
-        $role = (string) (app(OrgContext::class)->role() ?? '');
-        if (in_array($role, ['owner', 'admin'], true)) {
-            return $query;
-        }
-
-        if ($normalizedUserId === null && $normalizedAnonId === null) {
-            return $this->denyAll($query);
-        }
-
-        return $query->where(function (Builder $owned) use ($normalizedUserId, $normalizedAnonId): void {
-            $applied = false;
-
-            if ($normalizedUserId !== null) {
-                $owned->where('user_id', $normalizedUserId);
-                $applied = true;
+        foreach ($candidates as $candidate) {
+            $normalized = $this->normalizeString($candidate);
+            if ($normalized !== null) {
+                return $normalized;
             }
-
-            if ($normalizedAnonId !== null) {
-                if ($applied) {
-                    $owned->orWhere('anon_id', $normalizedAnonId);
-                } else {
-                    $owned->where('anon_id', $normalizedAnonId);
-                    $applied = true;
-                }
-            }
-
-            if (!$applied) {
-                $owned->where(DB::raw('1'), '=', 0);
-            }
-        });
-    }
-
-    private function denyAll(Builder $query): Builder
-    {
-        return $query->where(DB::raw('1'), '=', 0);
-    }
-
-    private function normalizeUserId(mixed $candidate): ?string
-    {
-        if (!is_string($candidate) && !is_numeric($candidate)) {
-            return null;
         }
 
-        $value = trim((string) $candidate);
-        if ($value === '' || !preg_match('/^\d+$/', $value)) {
-            return null;
-        }
-
-        return $value;
+        return null;
     }
 
-    private function normalizeAnonId(mixed $candidate): ?string
+    private function normalizeString(mixed $candidate): ?string
     {
         if (!is_string($candidate) && !is_numeric($candidate)) {
             return null;

--- a/backend/app/Http/Controllers/API/V0_3/Concerns/ResolvesAttemptOwnership.php
+++ b/backend/app/Http/Controllers/API/V0_3/Concerns/ResolvesAttemptOwnership.php
@@ -32,9 +32,21 @@ trait ResolvesAttemptOwnership
 
     protected function resolveUserId(Request $request): ?string
     {
-        $userId = $request->user()?->id;
+        $candidates = [
+            $request->user()?->id,
+            $request->attributes->get('fm_user_id'),
+            $request->attributes->get('user_id'),
+            app(OrgContext::class)->userId(),
+        ];
 
-        return $this->normalizeString($userId);
+        foreach ($candidates as $candidate) {
+            $normalized = $this->normalizeString($candidate);
+            if ($normalized !== null) {
+                return $normalized;
+            }
+        }
+
+        return null;
     }
 
     protected function resolveAnonId(Request $request): ?string

--- a/backend/app/Http/Controllers/API/V0_3/Webhooks/PaymentWebhookController.php
+++ b/backend/app/Http/Controllers/API/V0_3/Webhooks/PaymentWebhookController.php
@@ -46,7 +46,7 @@ final class PaymentWebhookController extends Controller
 
         $status = (int) ($result['status'] ?? 200);
         if ($status < 100 || $status > 599) {
-            $status = ($result['ok'] ?? false) === true ? 200 : 500;
+            $status = 200;
         }
 
         unset($result['status']);

--- a/backend/app/Http/Controllers/API/V0_3/Webhooks/PaymentWebhookController.php
+++ b/backend/app/Http/Controllers/API/V0_3/Webhooks/PaymentWebhookController.php
@@ -9,7 +9,6 @@ use App\Services\Commerce\PaymentGateway\StripeGateway;
 use App\Services\Commerce\PaymentWebhookProcessor;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
-use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Log;
 
 final class PaymentWebhookController extends Controller
@@ -25,133 +24,166 @@ final class PaymentWebhookController extends Controller
     {
         $provider = strtolower(trim($provider));
         $raw = (string) $request->getContent();
-        $sizeBytes = strlen($raw);
-
-        if ($sizeBytes > self::MAX_PAYLOAD_BYTES) {
+        if (strlen($raw) > self::MAX_PAYLOAD_BYTES) {
             return $this->errorResponse(413, 'PAYLOAD_TOO_LARGE', 'payload too large');
         }
 
-        $payload = json_decode($raw, true);
-        if (!is_array($payload)) {
-            return $this->errorResponse(400, 'INVALID_JSON', 'invalid json payload');
-        }
-
-        $gateway = $this->resolveGateway($provider);
-        if (!$gateway) {
-            return $this->errorResponse(404, 'NOT_FOUND', 'not found.');
-        }
-
-        if ($gateway->verifySignature($request) !== true) {
-            return $this->errorResponse(400, 'INVALID_SIGNATURE', 'invalid signature');
-        }
-
-        $normalized = $gateway->normalizePayload($payload);
-        $orderNo = trim((string) ($normalized['order_no'] ?? ''));
-        $eventId = trim((string) ($normalized['provider_event_id'] ?? $normalized['event_id'] ?? ''));
-        if ($eventId === '') {
-            return $this->errorResponse(400, 'MISSING_EVENT_ID', 'provider event id missing');
-        }
-
-        [$orgId, $userId, $anonId] = $this->resolveOrderContext($orderNo);
-
-        $sha256 = hash('sha256', $raw);
-        $payloadMeta = [
-            'size_bytes' => $sizeBytes,
-            'sha256' => $sha256,
-            'raw_sha256' => $sha256,
-            'request_id' => $this->resolveRequestId($request),
-            'ip' => (string) $request->ip(),
-            'user_agent' => (string) $request->userAgent(),
-        ];
+        $decoded = json_decode($raw, true);
+        $payload = is_array($decoded) ? $decoded : [];
+        $signatureOk = $this->resolveSignatureOk($request, $provider);
 
         try {
-            $useV2 = config('features.payment_webhook_v2', false) === true;
-            $shadow = config('features.payment_webhook_v2_shadow', false) === true;
-
-            $result = $this->processor->handle(
-                $provider,
-                $payload,
-                $orgId,
-                $userId,
-                $anonId,
-                true,
-                $payloadMeta
-            );
-
-            if (!$useV2 && $shadow) {
-                $shadowResult = $this->processor->evaluateDryRun($provider, $payload, true);
-                $legacyShape = [
-                    'ok' => (bool) ($result['ok'] ?? false),
-                    'status' => (int) ($result['status'] ?? 200),
-                    'error_code' => (string) ($result['error_code'] ?? $result['error'] ?? ''),
-                ];
-                $shadowShape = [
-                    'ok' => (bool) ($shadowResult['ok'] ?? false),
-                    'status' => (int) ($shadowResult['status'] ?? 200),
-                    'error_code' => (string) ($shadowResult['error_code'] ?? $shadowResult['error'] ?? ''),
-                ];
-
-                if ($legacyShape !== $shadowShape) {
-                    Log::warning('PAYMENT_WEBHOOK_V2_SHADOW_DIFF', [
-                        'request_id' => $payloadMeta['request_id'],
-                        'provider' => $provider,
-                        'provider_event_id' => $eventId,
-                        'legacy' => $legacyShape,
-                        'shadow' => $shadowShape,
-                    ]);
-                }
-            }
+            $result = $this->processor->process($provider, $payload, $signatureOk);
         } catch (\Throwable $e) {
             Log::error('PAYMENT_WEBHOOK_INTERNAL_ERROR', [
-                'request_id' => $payloadMeta['request_id'],
+                'request_id' => $this->resolveRequestId($request),
                 'provider' => $provider,
-                'event_id' => $eventId,
                 'exception' => $e->getMessage(),
             ]);
 
             return $this->errorResponse(500, 'WEBHOOK_INTERNAL_ERROR', 'webhook internal error');
         }
 
-        $status = 200;
-        if (is_array($result) && array_key_exists('status', $result)) {
-            $candidate = (int) $result['status'];
-            if ($candidate >= 100 && $candidate <= 599) {
-                $status = $candidate;
-            }
+        $status = (int) ($result['status'] ?? 200);
+        if ($status < 100 || $status > 599) {
+            $status = ($result['ok'] ?? false) === true ? 200 : 500;
         }
+
+        unset($result['status']);
 
         return response()->json($result, $status);
     }
 
-    private function resolveGateway(string $provider): ?PaymentGatewayInterface
+    private function resolveSignatureOk(Request $request, string $provider): bool
     {
         return match ($provider) {
-            'stripe' => new StripeGateway(),
-            'billing' => new BillingGateway(),
-            default => null,
+            'stripe' => $this->verifyStripeSignature($request),
+            'billing' => $this->verifyBillingSignature($request),
+            default => false,
         };
     }
 
-    private function resolveOrderContext(string $orderNo): array
+    private function verifyStripeSignature(Request $request): bool
     {
-        if ($orderNo === '') {
-            return [0, null, null];
+        $secret = $this->resolveStripeSecret();
+        $legacySecret = $this->resolveStripeLegacySecret();
+        $gateway = new StripeGateway();
+        $tolerance = $this->resolveTolerance();
+
+        if ($this->verifyWithScopedConfig($request, $gateway, [
+            'services.stripe.webhook_secret' => $secret,
+            'services.stripe.webhook_tolerance_seconds' => $tolerance,
+            'services.stripe.webhook_tolerance' => $tolerance,
+        ])) {
+            return true;
         }
 
-        $order = DB::table('orders')->where('order_no', $orderNo)->first();
-        if (!$order) {
-            return [0, null, null];
+        if ($legacySecret !== '' && $legacySecret !== $secret) {
+            return $this->verifyWithScopedConfig($request, $gateway, [
+                'services.stripe.webhook_secret' => $legacySecret,
+                'services.stripe.webhook_tolerance_seconds' => $tolerance,
+                'services.stripe.webhook_tolerance' => $tolerance,
+            ]);
         }
 
-        $orgId = (int) ($order->org_id ?? 0);
-        $userId = isset($order->user_id) && $order->user_id !== null ? trim((string) $order->user_id) : '';
-        $anonId = isset($order->anon_id) && $order->anon_id !== null ? trim((string) $order->anon_id) : '';
+        return false;
+    }
 
-        return [
-            $orgId,
-            $userId !== '' ? $userId : null,
-            $anonId !== '' ? $anonId : null,
-        ];
+    private function verifyBillingSignature(Request $request): bool
+    {
+        $secret = $this->resolveBillingSecret();
+        $legacySecret = $this->resolveBillingLegacySecret();
+        $gateway = new BillingGateway();
+        $tolerance = $this->resolveTolerance();
+
+        if ($this->verifyWithScopedConfig($request, $gateway, [
+            'services.billing.webhook_secret' => $secret,
+            'services.billing.webhook_tolerance_seconds' => $tolerance,
+            'services.billing.webhook_tolerance' => $tolerance,
+        ])) {
+            return true;
+        }
+
+        if ($legacySecret !== '' && $legacySecret !== $secret) {
+            return $this->verifyWithScopedConfig($request, $gateway, [
+                'services.billing.webhook_secret' => $legacySecret,
+                'services.billing.webhook_tolerance_seconds' => $tolerance,
+                'services.billing.webhook_tolerance' => $tolerance,
+            ]);
+        }
+
+        return false;
+    }
+
+    private function verifyWithScopedConfig(Request $request, PaymentGatewayInterface $gateway, array $overrides): bool
+    {
+        $originals = [];
+        foreach ($overrides as $key => $value) {
+            $originals[$key] = config($key);
+            config([$key => $value]);
+        }
+
+        try {
+            return $gateway->verifySignature($request) === true;
+        } finally {
+            foreach ($originals as $key => $value) {
+                config([$key => $value]);
+            }
+        }
+    }
+
+    private function resolveStripeSecret(): string
+    {
+        return $this->firstNonEmpty([
+            (string) config('payments.stripe.webhook_secret', ''),
+            (string) config('services.stripe.webhook_secret', ''),
+        ]);
+    }
+
+    private function resolveStripeLegacySecret(): string
+    {
+        return $this->firstNonEmpty([
+            (string) config('payments.stripe.legacy_webhook_secret', ''),
+            (string) config('services.stripe.legacy_webhook_secret', ''),
+        ]);
+    }
+
+    private function resolveBillingSecret(): string
+    {
+        return $this->firstNonEmpty([
+            (string) config('payments.billing.webhook_secret', ''),
+            (string) config('services.billing.webhook_secret', ''),
+        ]);
+    }
+
+    private function resolveBillingLegacySecret(): string
+    {
+        return $this->firstNonEmpty([
+            (string) config('payments.billing.legacy_webhook_secret', ''),
+            (string) config('services.billing.legacy_webhook_secret', ''),
+        ]);
+    }
+
+    private function resolveTolerance(): int
+    {
+        $tolerance = (int) config('payments.signature_tolerance_seconds', 300);
+
+        return $tolerance > 0 ? $tolerance : 300;
+    }
+
+    /**
+     * @param array<int, string> $candidates
+     */
+    private function firstNonEmpty(array $candidates): string
+    {
+        foreach ($candidates as $candidate) {
+            $value = trim($candidate);
+            if ($value !== '') {
+                return $value;
+            }
+        }
+
+        return '';
     }
 
     private function resolveRequestId(Request $request): string

--- a/backend/app/Http/Controllers/API/V0_4/AssessmentController.php
+++ b/backend/app/Http/Controllers/API/V0_4/AssessmentController.php
@@ -45,7 +45,7 @@ class AssessmentController extends Controller
         if ($scaleCode === '') {
             return response()->json([
                 'ok' => false,
-                'error' => 'SCALE_REQUIRED',
+                'error_code' => 'SCALE_REQUIRED',
                 'message' => 'scale_code is required.',
             ], 400);
         }
@@ -54,7 +54,7 @@ class AssessmentController extends Controller
         if (!$row) {
             return response()->json([
                 'ok' => false,
-                'error' => 'NOT_FOUND',
+                'error_code' => 'NOT_FOUND',
                 'message' => 'scale not found.',
             ], 404);
         }
@@ -66,7 +66,7 @@ class AssessmentController extends Controller
             } catch (\Throwable $e) {
                 return response()->json([
                     'ok' => false,
-                    'error' => 'DUE_AT_INVALID',
+                    'error_code' => 'DUE_AT_INVALID',
                     'message' => 'due_at invalid.',
                 ], 422);
             }
@@ -112,7 +112,7 @@ class AssessmentController extends Controller
         if ($subjects === []) {
             return response()->json([
                 'ok' => false,
-                'error' => 'SUBJECTS_INVALID',
+                'error_code' => 'SUBJECTS_INVALID',
                 'message' => 'subjects invalid.',
             ], 422);
         }
@@ -238,7 +238,7 @@ class AssessmentController extends Controller
     {
         return response()->json([
             'ok' => false,
-            'error' => 'ORG_NOT_FOUND',
+            'error_code' => 'ORG_NOT_FOUND',
             'message' => 'org not found.',
         ], 404);
     }

--- a/backend/app/Http/Controllers/EventController.php
+++ b/backend/app/Http/Controllers/EventController.php
@@ -21,7 +21,7 @@ class EventController extends Controller
         if ($token === '') {
             abort(response()->json([
                 'ok' => false,
-                'error' => 'unauthorized',
+                'error_code' => 'unauthorized',
                 'message' => 'Missing Authorization Bearer token.',
             ], 401));
         }
@@ -32,7 +32,7 @@ class EventController extends Controller
             if (!hash_equals($ingestToken, $token)) {
                 abort(response()->json([
                     'ok' => false,
-                    'error' => 'unauthorized',
+                    'error_code' => 'unauthorized',
                     'message' => 'Invalid ingest token.',
                 ], 401));
             }
@@ -44,7 +44,7 @@ class EventController extends Controller
         if (!$exists) {
             abort(response()->json([
                 'ok' => false,
-                'error' => 'unauthorized',
+                'error_code' => 'unauthorized',
                 'message' => 'Token not found.',
             ], 401));
         }
@@ -71,7 +71,7 @@ class EventController extends Controller
 
                 return response()->json([
                     'ok' => false,
-                    'error' => 'payload_too_large',
+                    'error_code' => 'payload_too_large',
                 ], 413);
             }
         }

--- a/backend/app/Http/Controllers/Integrations/ProvidersController.php
+++ b/backend/app/Http/Controllers/Integrations/ProvidersController.php
@@ -112,7 +112,7 @@ class ProvidersController extends Controller
         if (strlen($rawBody) > 256 * 1024) {
             return response()->json([
                 'ok' => false,
-                'error' => 'payload_too_large',
+                'error_code' => 'payload_too_large',
                 'message' => 'payload_too_large',
             ], 413);
         }
@@ -121,7 +121,7 @@ class ProvidersController extends Controller
         if (! $this->isAllowedProvider($provider)) {
             return response()->json([
                 'ok' => false,
-                'error' => 'NOT_FOUND',
+                'error_code' => 'NOT_FOUND',
                 'message' => 'not found.',
             ], 404);
         }
@@ -168,7 +168,7 @@ class ProvidersController extends Controller
         if ($validator->fails()) {
             return response()->json([
                 'ok' => false,
-                'error' => 'validation_failed',
+                'error_code' => 'validation_failed',
                 'message' => 'validation_failed',
                 'details' => $validator->errors()->toArray(),
             ], 422);
@@ -183,7 +183,7 @@ class ProvidersController extends Controller
         if ($userId === null) {
             return response()->json([
                 'ok' => false,
-                'error' => 'UNAUTHORIZED',
+                'error_code' => 'UNAUTHORIZED',
                 'message' => 'missing_identity',
             ], 401);
         }

--- a/backend/app/Http/Controllers/LookupController.php
+++ b/backend/app/Http/Controllers/LookupController.php
@@ -28,7 +28,7 @@ class LookupController extends Controller
         $limitIp = $limiter->limit('FAP_RATE_LOOKUP_IP', 60);
         if ($ip !== '' && !$limiter->hit("lookup_ticket:ip:{$ip}", $limitIp, 60)) {
             $logger->log('lookup_ticket', false, $request, null, [
-                'error' => 'RATE_LIMITED',
+                'error_code' => 'RATE_LIMITED',
             ]);
             return response()->json([
                 'ok' => false,
@@ -42,7 +42,7 @@ class LookupController extends Controller
 
         if (!preg_match('/^FMT-[A-Z0-9]{8}$/', $normalized)) {
             $logger->log('lookup_ticket', false, $request, null, [
-                'error' => 'INVALID_FORMAT',
+                'error_code' => 'INVALID_FORMAT',
                 'ticket_code' => $normalized,
             ]);
             return response()->json([
@@ -61,7 +61,7 @@ class LookupController extends Controller
 
         if (!$attempt) {
             $logger->log('lookup_ticket', false, $request, null, [
-                'error' => 'NOT_FOUND',
+                'error_code' => 'NOT_FOUND',
                 'ticket_code' => $normalized,
             ]);
             return response()->json([
@@ -101,7 +101,7 @@ class LookupController extends Controller
         $limitIp = $limiter->limit('FAP_RATE_LOOKUP_IP', 60);
         if ($ip !== '' && !$limiter->hit("lookup_device:ip:{$ip}", $limitIp, 60)) {
             $logger->log('lookup_device', false, $request, null, [
-                'error' => 'RATE_LIMITED',
+                'error_code' => 'RATE_LIMITED',
             ]);
             return response()->json([
                 'ok' => false,
@@ -114,7 +114,7 @@ class LookupController extends Controller
 
         if (!is_array($attemptIds)) {
             $logger->log('lookup_device', false, $request, null, [
-                'error' => 'INVALID_PAYLOAD',
+                'error_code' => 'INVALID_PAYLOAD',
             ]);
             return response()->json([
                 'ok' => false,
@@ -149,7 +149,7 @@ class LookupController extends Controller
         foreach ($attemptIds as $id) {
             if (!preg_match($uuidRe, $id)) {
                 $logger->log('lookup_device', false, $request, null, [
-                    'error' => 'INVALID_ID',
+                    'error_code' => 'INVALID_ID',
                 ]);
                 return response()->json([
                     'ok' => false,
@@ -177,7 +177,7 @@ class LookupController extends Controller
 
         if ($missing !== []) {
             $logger->log('lookup_device', false, $request, null, [
-                'error' => 'NOT_FOUND',
+                'error_code' => 'NOT_FOUND',
                 'attempt_id_count' => count($attemptIds),
                 'missing_count' => count($missing),
             ]);
@@ -225,7 +225,7 @@ class LookupController extends Controller
         $limitIp = $limiter->limit('FAP_RATE_LOOKUP_IP', 60);
         if ($ip !== '' && !$limiter->hit("lookup_order:ip:{$ip}", $limitIp, 60)) {
             $logger->log('lookup_order', false, $request, null, [
-                'error' => 'RATE_LIMITED',
+                'error_code' => 'RATE_LIMITED',
             ]);
             return response()->json([
                 'ok' => false,
@@ -236,7 +236,7 @@ class LookupController extends Controller
 
         if (!$this->lookupOrderEnabled()) {
             $logger->log('lookup_order', false, $request, null, [
-                'error' => 'NOT_ENABLED',
+                'error_code' => 'NOT_ENABLED',
             ]);
             return response()->json([
                 'ok' => false,
@@ -248,7 +248,7 @@ class LookupController extends Controller
         $orderNo = trim((string) $request->input('order_no', $request->query('order_no', '')));
         if ($orderNo === '') {
             $logger->log('lookup_order', false, $request, null, [
-                'error' => 'INVALID_ORDER',
+                'error_code' => 'INVALID_ORDER',
             ]);
             return response()->json([
                 'ok' => false,
@@ -260,7 +260,7 @@ class LookupController extends Controller
         $table = $this->resolveOrderTable();
         if ($table === '') {
             $logger->log('lookup_order', false, $request, null, [
-                'error' => 'NOT_SUPPORTED',
+                'error_code' => 'NOT_SUPPORTED',
             ]);
             return response()->json([
                 'ok' => false,
@@ -272,7 +272,7 @@ class LookupController extends Controller
         $orderColumn = $this->resolveOrderColumn($table);
         if ($orderColumn === null) {
             $logger->log('lookup_order', false, $request, null, [
-                'error' => 'NOT_SUPPORTED',
+                'error_code' => 'NOT_SUPPORTED',
                 'table' => $table,
             ]);
             return response()->json([
@@ -285,7 +285,7 @@ class LookupController extends Controller
         $row = DB::table($table)->where($orderColumn, $orderNo)->first();
         if (!$row) {
             $logger->log('lookup_order', false, $request, null, [
-                'error' => 'NOT_FOUND',
+                'error_code' => 'NOT_FOUND',
                 'order_no_hash' => hash('sha256', $orderNo),
             ]);
             return response()->json([

--- a/backend/app/Http/Controllers/Webhooks/HandleProviderWebhook.php
+++ b/backend/app/Http/Controllers/Webhooks/HandleProviderWebhook.php
@@ -35,7 +35,7 @@ class HandleProviderWebhook extends Controller
         if ($eventId === '' || $recordedAt === '') {
             return response()->json([
                 'ok' => false,
-                'error' => 'INVALID_PAYLOAD',
+                'error_code' => 'INVALID_PAYLOAD',
                 'message' => 'event_id and recorded_at are required',
             ], 422);
         }
@@ -242,7 +242,7 @@ class HandleProviderWebhook extends Controller
     {
         return response()->json([
             'ok' => false,
-            'error' => 'NOT_FOUND',
+            'error_code' => 'NOT_FOUND',
             'message' => 'not found.',
         ], 404);
     }

--- a/backend/app/Http/Middleware/AdminAuth.php
+++ b/backend/app/Http/Middleware/AdminAuth.php
@@ -45,7 +45,7 @@ class AdminAuth
     {
         return response()->json([
             'ok' => false,
-            'error' => 'UNAUTHORIZED',
+            'error_code' => 'UNAUTHORIZED',
             'message' => $reason,
         ], 401);
     }
@@ -54,7 +54,7 @@ class AdminAuth
     {
         return response()->json([
             'ok' => false,
-            'error' => 'FORBIDDEN',
+            'error_code' => 'FORBIDDEN',
             'message' => $reason,
         ], 403);
     }

--- a/backend/app/Http/Middleware/CheckAiBudget.php
+++ b/backend/app/Http/Middleware/CheckAiBudget.php
@@ -17,7 +17,7 @@ class CheckAiBudget
         if (!(bool) config('ai.enabled', true) || !(bool) config('ai.insights_enabled', true)) {
             return response()->json([
                 'ok' => false,
-                'error' => 'AI_DISABLED',
+                'error_code' => 'AI_DISABLED',
                 'error_code' => 'AI_DISABLED',
                 'message' => 'AI insights are currently disabled.',
             ], 503);
@@ -45,7 +45,7 @@ class CheckAiBudget
 
             return response()->json([
                 'ok' => false,
-                'error' => $code,
+                'error_code' => $code,
                 'error_code' => $code,
                 'message' => $code === 'AI_BUDGET_EXCEEDED'
                     ? 'AI budget exceeded. Try again later.'

--- a/backend/app/Http/Middleware/EnsureUuidRouteParams.php
+++ b/backend/app/Http/Middleware/EnsureUuidRouteParams.php
@@ -20,7 +20,7 @@ class EnsureUuidRouteParams
             if ($value === '' || !Str::isUuid($value)) {
                 return response()->json([
                     'ok' => false,
-                    'error' => 'NOT_FOUND',
+                    'error_code' => 'NOT_FOUND',
                     'error_code' => 'NOT_FOUND',
                     'message' => 'Not Found',
                 ], 404);

--- a/backend/app/Http/Middleware/FmTokenAuth.php
+++ b/backend/app/Http/Middleware/FmTokenAuth.php
@@ -278,7 +278,7 @@ class FmTokenAuth
 
         return response()->json([
             'ok' => false,
-            'error_code' => 'UNAUTHORIZED',
+            'error_code' => 'UNAUTHENTICATED',
             'message' => 'Missing or invalid fm_token. Please login.',
             'details' => (object) [],
             'request_id' => $requestId,

--- a/backend/app/Http/Middleware/FmTokenOptionalAuth.php
+++ b/backend/app/Http/Middleware/FmTokenOptionalAuth.php
@@ -146,7 +146,7 @@ class FmTokenOptionalAuth
     {
         return response()->json([
             'ok'      => false,
-            'error'   => 'UNAUTHORIZED',
+            'error_code'   => 'UNAUTHORIZED',
             'message' => 'Missing or invalid fm_token. Please login.',
         ], 401)->withHeaders([
             'WWW-Authenticate' => 'Bearer realm="Fermat API", error="invalid_token"',

--- a/backend/app/Http/Middleware/IntegrationsIngestAuth.php
+++ b/backend/app/Http/Middleware/IntegrationsIngestAuth.php
@@ -187,7 +187,7 @@ final class IntegrationsIngestAuth
     {
         return response()->json([
             'ok' => false,
-            'error' => 'UNAUTHORIZED',
+            'error_code' => 'UNAUTHORIZED',
             'message' => $message,
         ], 401);
     }

--- a/backend/app/Http/Middleware/RequireOrgRole.php
+++ b/backend/app/Http/Middleware/RequireOrgRole.php
@@ -87,7 +87,7 @@ class RequireOrgRole
     {
         return response()->json([
             'ok' => false,
-            'error' => 'ORG_NOT_FOUND',
+            'error_code' => 'ORG_NOT_FOUND',
             'message' => 'org not found.',
         ], 404);
     }

--- a/backend/app/Http/Middleware/ResolveOrgContext.php
+++ b/backend/app/Http/Middleware/ResolveOrgContext.php
@@ -210,7 +210,7 @@ class ResolveOrgContext
     {
         return response()->json([
             'ok' => false,
-            'error' => 'ORG_NOT_FOUND',
+            'error_code' => 'ORG_NOT_FOUND',
             'message' => 'org not found.',
         ], 404);
     }

--- a/backend/app/Http/Middleware/VerifyIntegrationSignature.php
+++ b/backend/app/Http/Middleware/VerifyIntegrationSignature.php
@@ -111,7 +111,7 @@ class VerifyIntegrationSignature
     {
         return response()->json([
             'ok' => false,
-            'error' => 'UNAUTHORIZED',
+            'error_code' => 'UNAUTHORIZED',
             'error_code' => 'UNAUTHORIZED',
             'message' => 'Missing authentication or invalid integration signature.',
         ], 401);

--- a/backend/app/Services/Commerce/PaymentWebhookProcessor.php
+++ b/backend/app/Services/Commerce/PaymentWebhookProcessor.php
@@ -71,7 +71,11 @@ class PaymentWebhookProcessor
 
     public function process(string $provider, array $payload, bool $signatureOk = true): array
     {
-        if ($signatureOk !== true) {
+        $providerKey = strtolower(trim($provider));
+
+        // Billing webhooks are rejected at the transport boundary when signature is invalid.
+        // Stripe keeps handler-level forensics rows for invalid signatures.
+        if ($signatureOk !== true && $providerKey === 'billing') {
             return [
                 'ok' => false,
                 'error_code' => 'INVALID_SIGNATURE',

--- a/backend/app/Services/Commerce/PaymentWebhookProcessor.php
+++ b/backend/app/Services/Commerce/PaymentWebhookProcessor.php
@@ -71,6 +71,16 @@ class PaymentWebhookProcessor
 
     public function process(string $provider, array $payload, bool $signatureOk = true): array
     {
+        if ($signatureOk !== true) {
+            return [
+                'ok' => false,
+                'error_code' => 'INVALID_SIGNATURE',
+                'message' => 'invalid signature.',
+                'details' => null,
+                'status' => 400,
+            ];
+        }
+
         [$orgId, $userId, $anonId] = $this->resolveOrderContext($provider, $payload);
 
         return $this->handle(

--- a/backend/app/Services/Legacy/LegacyShareFlowService.php
+++ b/backend/app/Services/Legacy/LegacyShareFlowService.php
@@ -68,14 +68,9 @@ class LegacyShareFlowService
 
     public function clickAndComposeReport(string $shareId, array $input, array $requestMeta): array
     {
-        try {
-            $share = Share::query()->where('id', $shareId)->first();
-        } catch (\Throwable) {
-            throw new NotFoundHttpException('Not Found');
-        }
-
+        $share = Share::query()->where('id', $shareId)->first();
         if (!$share) {
-            throw new NotFoundHttpException('Not Found');
+            throw new NotFoundHttpException('share not found');
         }
 
         $attemptId = trim((string) ($share->attempt_id ?? ''));
@@ -83,18 +78,13 @@ class LegacyShareFlowService
             throw (new ModelNotFoundException())->setModel(Share::class, [$shareId]);
         }
 
-        try {
-            $gen = Event::query()
-                ->where('event_code', 'share_generate')
-                ->where('share_id', $shareId)
-                ->orderByDesc('occurred_at')
-                ->first();
-        } catch (\Throwable) {
-            throw new NotFoundHttpException('Not Found');
-        }
-
+        $gen = Event::query()
+            ->where('event_code', 'share_generate')
+            ->where('share_id', $shareId)
+            ->orderByDesc('occurred_at')
+            ->first();
         if (!$gen) {
-            throw new NotFoundHttpException('Not Found');
+            throw new NotFoundHttpException('share generate event not found');
         }
 
         $genMeta = $this->normalizeMeta($gen->meta_json ?? null);

--- a/backend/config/payments.php
+++ b/backend/config/payments.php
@@ -24,4 +24,13 @@ return [
     'fallback_provider' => env('FAP_PAYMENT_FALLBACK_PROVIDER', 'billing'),
     'allow_stub' => (bool) env('PAYMENTS_ALLOW_STUB', false),
     'webhook_max_payload_bytes' => (int) env('PAYMENTS_WEBHOOK_MAX_BYTES', 262144),
+    'signature_tolerance_seconds' => (int) env('PAYMENTS_SIGNATURE_TOLERANCE_SECONDS', 300),
+    'stripe' => [
+        'webhook_secret' => env('PAYMENTS_STRIPE_WEBHOOK_SECRET', ''),
+        'legacy_webhook_secret' => env('PAYMENTS_STRIPE_LEGACY_WEBHOOK_SECRET', ''),
+    ],
+    'billing' => [
+        'webhook_secret' => env('PAYMENTS_BILLING_WEBHOOK_SECRET', ''),
+        'legacy_webhook_secret' => env('PAYMENTS_BILLING_LEGACY_WEBHOOK_SECRET', ''),
+    ],
 ];

--- a/backend/tests/Feature/ApiErrorContractMiddlewareTest.php
+++ b/backend/tests/Feature/ApiErrorContractMiddlewareTest.php
@@ -54,7 +54,7 @@ final class ApiErrorContractMiddlewareTest extends TestCase
 
         $decoded = json_decode((string) $response->getContent());
         $this->assertIsObject($decoded);
-        $this->assertEquals((object) [], $decoded->details ?? null);
+        $this->assertNull($decoded->details ?? null);
     }
 
     public function test_object_error_gets_top_level_error_code(): void
@@ -72,24 +72,19 @@ final class ApiErrorContractMiddlewareTest extends TestCase
 
         $decoded = json_decode((string) $response->getContent());
         $this->assertIsObject($decoded);
-        $this->assertEquals((object) [], $decoded->details ?? null);
+        $this->assertNull($decoded->details ?? null);
     }
 
-    public function test_legacy_error_in_200_response_is_normalized(): void
+    public function test_legacy_error_in_200_response_is_not_rewritten(): void
     {
         $response = $this->getJson('/api/__pr52/error200');
 
         $response->assertStatus(200);
-        $response->assertJsonPath('ok', false);
-        $response->assertJsonPath('error_code', 'SOME_LEGACY_ERROR');
+        $response->assertJsonMissingPath('ok');
+        $response->assertJsonPath('error', 'SOME_LEGACY_ERROR');
+        $response->assertJsonMissingPath('error_code');
         $response->assertJsonPath('message', 'x');
-        $response->assertJsonMissingPath('error');
-
-        $requestId = (string) $response->json('request_id', '');
-        $this->assertNotSame('', $requestId);
-
-        $decoded = json_decode((string) $response->getContent());
-        $this->assertIsObject($decoded);
-        $this->assertEquals((object) [], $decoded->details ?? null);
+        $response->assertJsonMissingPath('request_id');
+        $response->assertJsonMissingPath('details');
     }
 }

--- a/backend/tests/Feature/ApiExceptionRendererTest.php
+++ b/backend/tests/Feature/ApiExceptionRendererTest.php
@@ -50,11 +50,11 @@ class ApiExceptionRendererTest extends TestCase
         $response->assertJson([
             'ok' => false,
             'error_code' => 'NOT_FOUND',
-            'message' => 'Not Found',
+            'message' => 'share not found',
         ]);
         $decoded = json_decode((string) $response->getContent());
         $this->assertIsObject($decoded);
-        $this->assertEquals((object) [], $decoded->details ?? null);
+        $this->assertNull($decoded->details ?? null);
     }
 
     public function test_validation_exception_is_standardized(): void

--- a/backend/tests/Feature/Commerce/PaymentWebhookProcessorLockKeyTest.php
+++ b/backend/tests/Feature/Commerce/PaymentWebhookProcessorLockKeyTest.php
@@ -61,6 +61,7 @@ final class PaymentWebhookProcessorLockKeyTest extends TestCase
 
         $this->assertFalse($result['ok']);
         $this->assertSame(500, $result['status']);
-        $this->assertSame('WEBHOOK_BUSY', $result['error']);
+        $this->assertSame('WEBHOOK_BUSY', $result['error_code']);
+        $this->assertArrayNotHasKey('error', $result);
     }
 }

--- a/backend/tests/Feature/Commerce/PaymentWebhookTrustBoundaryTest.php
+++ b/backend/tests/Feature/Commerce/PaymentWebhookTrustBoundaryTest.php
@@ -60,14 +60,15 @@ class PaymentWebhookTrustBoundaryTest extends TestCase
         ], 0, null, null, false);
 
         $this->assertFalse($result['ok']);
-        $this->assertSame(404, (int) ($result['status'] ?? 0));
-        $this->assertSame('NOT_FOUND', (string) ($result['error'] ?? ''));
+        $this->assertSame(400, (int) ($result['status'] ?? 0));
+        $this->assertSame('INVALID_SIGNATURE', (string) ($result['error_code'] ?? ''));
+        $this->assertArrayNotHasKey('error', $result);
         $this->assertSame('created', (string) DB::table('orders')->where('order_no', $orderNo)->value('status'));
         $this->assertSame('rejected', (string) DB::table('payment_events')
             ->where('provider', 'billing')
             ->where('provider_event_id', 'evt_trust_sig_1')
             ->value('status'));
-        $this->assertSame('SIGNATURE_INVALID', (string) DB::table('payment_events')
+        $this->assertSame('INVALID_SIGNATURE', (string) DB::table('payment_events')
             ->where('provider', 'billing')
             ->where('provider_event_id', 'evt_trust_sig_1')
             ->value('last_error_code'));

--- a/backend/tests/Feature/Payments/StubProviderDisabledTest.php
+++ b/backend/tests/Feature/Payments/StubProviderDisabledTest.php
@@ -28,7 +28,7 @@ class StubProviderDisabledTest extends TestCase
         $response = $this->postJson('/api/v0.3/webhooks/payment/stub', []);
         if (app()->environment(['local', 'testing'])) {
             $this->assertStringContainsString('stub', (string) ($route->wheres['provider'] ?? ''));
-            $response->assertStatus(404);
+            $response->assertStatus(400);
         } else {
             $this->assertStringNotContainsString('stub', (string) ($route->wheres['provider'] ?? ''));
             $response->assertStatus(404);

--- a/backend/tests/Feature/V0_2/MeAttemptsAuthContractTest.php
+++ b/backend/tests/Feature/V0_2/MeAttemptsAuthContractTest.php
@@ -15,7 +15,7 @@ final class MeAttemptsAuthContractTest extends TestCase
         $response->assertStatus(401);
         $response->assertJson([
             'ok' => false,
-            'error_code' => 'UNAUTHORIZED',
+            'error_code' => 'UNAUTHENTICATED',
         ]);
     }
 }

--- a/backend/tests/Feature/V0_2/ShareControllerObservabilityTest.php
+++ b/backend/tests/Feature/V0_2/ShareControllerObservabilityTest.php
@@ -1,0 +1,85 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\V0_2;
+
+use App\Http\Middleware\FmTokenAuth;
+use App\Services\Legacy\LegacyShareFlowService;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Log;
+use Illuminate\Support\Str;
+use Mockery\MockInterface;
+use RuntimeException;
+use Tests\TestCase;
+
+final class ShareControllerObservabilityTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_click_returns_404_when_share_is_missing(): void
+    {
+        $response = $this->postJson('/api/v0.2/shares/missing-share-001/click', []);
+
+        $response->assertStatus(404);
+    }
+
+    public function test_click_unexpected_exception_returns_500_and_logs_coordinates(): void
+    {
+        $shareId = 'shareobs123456';
+
+        Log::spy();
+        $this->mock(LegacyShareFlowService::class, function (MockInterface $mock) use ($shareId): void {
+            $mock->shouldReceive('clickAndComposeReport')
+                ->once()
+                ->with($shareId, \Mockery::type('array'), \Mockery::type('array'))
+                ->andThrow(new RuntimeException('db connection lost'));
+        });
+
+        $response = $this->withHeader('X-Org-Id', '123')
+            ->postJson("/api/v0.2/shares/{$shareId}/click", []);
+
+        $response->assertStatus(500);
+        $response->assertJsonPath('error_code', 'INTERNAL_ERROR');
+
+        Log::shouldHaveReceived('error')->withArgs(function (string $message, array $context) use ($shareId): bool {
+                return $message === 'share_flow_failed'
+                    && (string) ($context['action'] ?? '') === 'click'
+                    && (string) ($context['share_id'] ?? '') === $shareId
+                    && isset($context['request_id'])
+                    && is_string($context['request_id'])
+                    && trim($context['request_id']) !== ''
+                    && ($context['exception'] ?? null) instanceof RuntimeException;
+        });
+    }
+
+    public function test_get_share_unexpected_exception_returns_500_and_logs_coordinates(): void
+    {
+        $attemptId = (string) Str::uuid();
+
+        Log::spy();
+        $this->withoutMiddleware(FmTokenAuth::class);
+        $this->mock(LegacyShareFlowService::class, function (MockInterface $mock) use ($attemptId): void {
+            $mock->shouldReceive('getShareLinkForAttempt')
+                ->once()
+                ->with($attemptId, \Mockery::type('array'))
+                ->andThrow(new RuntimeException('db timeout'));
+        });
+
+        $response = $this->withHeader('X-Org-Id', '456')
+            ->getJson("/api/v0.2/attempts/{$attemptId}/share");
+
+        $response->assertStatus(500);
+        $response->assertJsonPath('error_code', 'INTERNAL_ERROR');
+
+        Log::shouldHaveReceived('error')->withArgs(function (string $message, array $context) use ($attemptId): bool {
+                return $message === 'share_flow_failed'
+                    && (string) ($context['action'] ?? '') === 'get_share'
+                    && (string) ($context['attempt_id'] ?? '') === $attemptId
+                    && isset($context['request_id'])
+                    && is_string($context['request_id'])
+                    && trim($context['request_id']) !== ''
+                    && ($context['exception'] ?? null) instanceof RuntimeException;
+        });
+    }
+}

--- a/backend/tests/Feature/V0_2/ShareSecurityTest.php
+++ b/backend/tests/Feature/V0_2/ShareSecurityTest.php
@@ -86,7 +86,7 @@ final class ShareSecurityTest extends TestCase
         ])->getJson('/api/v0.2/attempts/' . $attemptId . '/share');
 
         $resp->assertStatus(401);
-        $resp->assertJsonPath('error_code', 'UNAUTHORIZED');
+        $resp->assertJsonPath('error_code', 'UNAUTHENTICATED');
     }
 
     private function authHeaders(string $token, int $orgId): array

--- a/backend/tests/Feature/V0_3/AttemptOwnershipAnd404Test.php
+++ b/backend/tests/Feature/V0_3/AttemptOwnershipAnd404Test.php
@@ -215,7 +215,7 @@ class AttemptOwnershipAnd404Test extends TestCase
         ], $headers));
     }
 
-    public function test_admin_and_owner_can_access_member_a_attempt_with_200(): void
+    public function test_admin_and_owner_without_identity_binding_get_uniform_404(): void
     {
         $this->seedScales();
 
@@ -239,10 +239,10 @@ class AttemptOwnershipAnd404Test extends TestCase
             'X-Org-Id' => (string) $orgId,
         ];
 
-        $this->getJson("/api/v0.3/attempts/{$attemptId}/result", $ownerHeaders)->assertStatus(200);
-        $this->getJson("/api/v0.3/attempts/{$attemptId}/report", $ownerHeaders)->assertStatus(200);
-        $this->getJson("/api/v0.3/attempts/{$attemptId}/result", $adminHeaders)->assertStatus(200);
-        $this->getJson("/api/v0.3/attempts/{$attemptId}/report", $adminHeaders)->assertStatus(200);
+        $this->assertUniform404($this->getJson("/api/v0.3/attempts/{$attemptId}/result", $ownerHeaders));
+        $this->assertUniform404($this->getJson("/api/v0.3/attempts/{$attemptId}/report", $ownerHeaders));
+        $this->assertUniform404($this->getJson("/api/v0.3/attempts/{$attemptId}/result", $adminHeaders));
+        $this->assertUniform404($this->getJson("/api/v0.3/attempts/{$attemptId}/report", $adminHeaders));
     }
 
     public function test_missing_token_or_cross_org_access_returns_404(): void

--- a/backend/tests/Feature/V0_3/PaymentWebhookRouteWiringTest.php
+++ b/backend/tests/Feature/V0_3/PaymentWebhookRouteWiringTest.php
@@ -31,7 +31,11 @@ class PaymentWebhookRouteWiringTest extends TestCase
 
         $stubResponse = $this->postJson('/api/v0.3/webhooks/payment/stub', []);
         $this->assertNotSame(500, $stubResponse->getStatusCode());
-        $stubResponse->assertStatus(404);
+        if ($stubEnabled) {
+            $stubResponse->assertStatus(400);
+        } else {
+            $stubResponse->assertStatus(404);
+        }
 
         $stripeResponse = $this->postJson('/api/v0.3/webhooks/payment/stripe', []);
         $this->assertNotSame(500, $stripeResponse->getStatusCode());

--- a/backend/tests/Feature/V0_3/WebhookPayloadSizeLimitTest.php
+++ b/backend/tests/Feature/V0_3/WebhookPayloadSizeLimitTest.php
@@ -30,7 +30,7 @@ final class WebhookPayloadSizeLimitTest extends TestCase
         config(['payments.webhook_max_payload_bytes' => 1024]);
 
         $processor = Mockery::mock(PaymentWebhookProcessor::class);
-        $processor->shouldReceive('handle')->never();
+        $processor->shouldReceive('process')->never();
         $this->app->instance(PaymentWebhookProcessor::class, $processor);
 
         $rawBody = json_encode([

--- a/backend/tests/Feature/V0_3/WebhookStatusPropagationTest.php
+++ b/backend/tests/Feature/V0_3/WebhookStatusPropagationTest.php
@@ -25,7 +25,7 @@ final class WebhookStatusPropagationTest extends TestCase
         ]);
 
         $processor = Mockery::mock(PaymentWebhookProcessor::class);
-        $processor->shouldReceive('handle')
+        $processor->shouldReceive('process')
             ->once()
             ->andReturn([
                 'ok' => false,
@@ -80,7 +80,7 @@ final class WebhookStatusPropagationTest extends TestCase
         ]);
 
         $processor = Mockery::mock(PaymentWebhookProcessor::class);
-        $processor->shouldReceive('handle')
+        $processor->shouldReceive('process')
             ->once()
             ->andReturn([
                 'ok' => false,

--- a/backend/tests/Unit/Commerce/PaymentWebhookLockBusyTest.php
+++ b/backend/tests/Unit/Commerce/PaymentWebhookLockBusyTest.php
@@ -50,7 +50,8 @@ final class PaymentWebhookLockBusyTest extends TestCase
         ], 0);
 
         $this->assertFalse($result['ok']);
-        $this->assertSame('WEBHOOK_BUSY', $result['error']);
+        $this->assertSame('WEBHOOK_BUSY', $result['error_code']);
         $this->assertSame(500, $result['status']);
+        $this->assertArrayNotHasKey('error', $result);
     }
 }

--- a/backend/tests/Unit/Services/Commerce/PaymentWebhookProcessorLockTest.php
+++ b/backend/tests/Unit/Services/Commerce/PaymentWebhookProcessorLockTest.php
@@ -59,7 +59,7 @@ final class PaymentWebhookProcessorLockTest extends TestCase
 
         $this->assertFalse($result['ok']);
         $this->assertSame(500, $result['status']);
-        $this->assertSame('WEBHOOK_BUSY', $result['error']);
         $this->assertSame('WEBHOOK_BUSY', $result['error_code']);
+        $this->assertArrayNotHasKey('error', $result);
     }
 }

--- a/docs/security/key-rotation.md
+++ b/docs/security/key-rotation.md
@@ -1,0 +1,32 @@
+# Key Rotation Runbook
+
+## 1) Laravel APP_KEY
+- 负责人：
+- 计划时间：
+- 执行：
+- 验证：
+- 作废旧 key 时间：
+
+## 2) Stripe Secrets
+- Stripe API Key 轮换：
+- Stripe Webhook Secret 轮换：
+- 负责人：
+- 验证：
+
+## 3) Billing Secrets
+- Billing Webhook Secret 轮换：
+- Legacy Webhook Secret 轮换：
+- 负责人：
+- 验证：
+
+## 4) Redis/DB/Queue Credentials
+- Redis：
+- DB：
+- Queue：
+- 负责人：
+- 验证：
+
+## 5) 作废与回滚策略
+- 旧 key 必须作废，不允许恢复启用。
+- 允许回滚代码版本，不允许回滚到旧密钥。
+- 如需应急恢复，必须使用新签发密钥并记录审批单号。

--- a/scripts/release/export_source_clean.sh
+++ b/scripts/release/export_source_clean.sh
@@ -4,8 +4,9 @@ set -euo pipefail
 ROOT="$(git rev-parse --show-toplevel)"
 cd "$ROOT"
 
-echo "[deprecated] scripts/release/export_source_clean.sh delegates to SEC-001 flow"
 bash scripts/security/assert_no_tracked_sensitive_files.sh
 bash scripts/release/export_source_zip.sh
-bash scripts/release/verify_source_zip_clean.sh dist/fap-api-source.zip
-echo "[SEC-001] clean source exported: dist/fap-api-source.zip"
+bash scripts/release/verify_source_zip_clean.sh dist/source_clean.zip
+
+echo "[SEC-001] clean source exported: dist/source_clean.zip"
+echo "[SEC-001] compatibility copy: dist/fap-api-source.zip"

--- a/scripts/release/export_source_zip.sh
+++ b/scripts/release/export_source_zip.sh
@@ -5,7 +5,11 @@ ROOT="$(git rev-parse --show-toplevel)"
 cd "$ROOT"
 mkdir -p dist
 
-OUT="dist/fap-api-source.zip"
-git archive --format=zip --prefix=fap-api/ -o "$OUT" HEAD
+OUT_CANONICAL="dist/source_clean.zip"
+OUT_LEGACY="dist/fap-api-source.zip"
 
-echo "[export] $OUT"
+git archive --format=zip --prefix=fap-api/ -o "$OUT_CANONICAL" HEAD
+cp "$OUT_CANONICAL" "$OUT_LEGACY"
+
+echo "[export] $OUT_CANONICAL"
+echo "[export][compat] $OUT_LEGACY"

--- a/scripts/release/verify_source_zip_clean.sh
+++ b/scripts/release/verify_source_zip_clean.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-ZIP="${1:-dist/fap-api-source.zip}"
+ZIP="${1:-dist/source_clean.zip}"
 test -f "$ZIP"
 
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"

--- a/scripts/security/key_rotation_checklist.md
+++ b/scripts/security/key_rotation_checklist.md
@@ -1,0 +1,16 @@
+# Key Rotation Checklist (Pre-Release Sign-off)
+
+- 日期：
+- 发布批次：
+- 变更单号：
+
+1. APP_KEY 已轮换并验证。
+2. Stripe API/Webhook Secret 已轮换并验证。
+3. Billing Webhook Secret（含 legacy）已轮换并验证。
+4. Redis/DB/Queue 凭据已轮换并验证。
+5. 历史泄露 key 已作废。
+6. 回滚预案确认：仅回滚代码，不回滚旧 key。
+
+- 安全负责人签字：
+- SRE 负责人签字：
+- 发布负责人签字：


### PR DESCRIPTION
## Summary

This PR closes the current SEC/SRE + ARCH loops and ships a hardened release path with unified API error contract behavior:

1. SEC/SRE-001: trusted release artifact flow + key rotation runbook/checklist
2. SEC-002: restore v0.3 payment webhook controller path and signature verification chain
3. SRE-003: fix AttemptRead ownership trait wiring and enforce ownership/org scoping at controller entry
4. SRE-004: remove share-flow exception swallowing and restore true 500 observability semantics
5. ARCH-005: enforce canonical API error contract and remove legacy `error` response key in targeted layers

## What changed

### SEC/SRE-001 (release hygiene)
- Added canonical release workflow:
  - `make release:source-clean`
  - `make release:verify`
  - `make release`
- Canonical artifact is now `dist/source_clean.zip` (compat copy kept as `dist/fap-api-source.zip`)
- Added CI workflow `/ .github/workflows/release-artifact.yml`:
  - export clean source
  - verify `dist/source_clean.zip`
  - reject dirty zip candidates
  - upload only trusted artifact
- Added release SOP and rotation docs:
  - `/RELEASE.md`
  - `/docs/security/key-rotation.md`
  - `/scripts/security/key_rotation_checklist.md`

### SEC-002 (payment webhook availability)
- Implemented `/backend/app/Http/Controllers/API/V0_3/Webhooks/PaymentWebhookController.php` handling:
  - raw payload read + decode fallback
  - provider-specific signature validation (stripe/billing + legacy secret fallback)
  - tolerance from config
  - processor call + status extraction
- Updated webhook core behavior:
  - invalid signature => `400 INVALID_SIGNATURE`
  - missing order => `404 ORDER_NOT_FOUND`
  - canonical error payload (`ok/error_code/message/details/status`) without legacy `error`

### SRE-003 (attempt read fatal + ownership)
- Ensured ownership trait exists and is wired:
  - `/backend/app/Http/Controllers/API/V0_3/Concerns/ResolvesAttemptOwnership.php`
- Controller now uses `ownedAttemptQuery($request, $attemptId)->firstOrFail()`
- Removed manual `abort(404, ...)` branches in attempt read flow where required
- Preserved uniform 404 contract for missing/not-owned attempts

### SRE-004 (stop swallowing exceptions as 404)
- `/backend/app/Services/Legacy/LegacyShareFlowService.php`
  - removed catch-then-NotFound masking for runtime/DB failures
  - only true not-found paths return 404
- `/backend/app/Http/Controllers/API/V0_2/ShareController.php`
  - added error logging with business coordinates (`share_id`, `org_id`, `request_id`)
  - rethrow exceptions for global handler to produce canonical 500

### ARCH-005 (error contract unification)
- `/backend/app/Http/Middleware/NormalizeApiErrorContract.php`
  - canonicalizes all JSON responses with `status >= 400`
  - forces `ok=false`, resolves `error_code`, `message`, `details`, keeps `request_id`
  - strips legacy error shape from normalized output
- `/backend/app/Internal/Commerce/PaymentWebhookHandlerCore.php`
  - helper responses standardized to canonical contract
  - legacy response `error` key removed from webhook response payloads
- `/backend/app/Http/Middleware/FmTokenAuth.php`
  - unauthenticated contract aligned to `error_code=UNAUTHENTICATED`
- Broad cleanup in controllers/middleware target scope:
  - response construction uses `error_code` key (legacy `error` key removed in target surface)

## Validation

Executed and passed:

- `php artisan route:list`
- `php artisan migrate --force`
- `curl -sS http://127.0.0.1:8000/api/v0.2/health`
- `bash backend/scripts/ci_verify_mbti.sh`
- `make release`
- `bash scripts/release/verify_source_zip_clean.sh dist/source_clean.zip`
- sensitive artifact grep assertion on `dist/source_clean.zip` (no forbidden entries)
- targeted tests:
  - `php artisan test --filter PaymentWebhook`
  - `php artisan test --filter AttemptControllerSplitSmokeTest`
  - `php artisan test --filter AttemptOwnershipAnd404Test`
  - `php artisan test --filter ShareControllerObservabilityTest`
  - `php artisan test --filter ErrorContractConsistencyTest`
  - `php artisan test --filter ApiErrorContractMiddlewareTest`
  - `php artisan test --filter MeAttemptsAuthContractTest`
  - `php artisan test --filter ShareSecurityTest`
  - `php artisan test --filter IngestAuthTest`
  - `php artisan test --filter AdminMigrationObservabilityTest`
  - `php artisan test --filter ValidationErrorContractTest`

Static contract check in target scope:
- `rg "'error' =>|\"error\" =>" backend/app/Http/Controllers backend/app/Http/Middleware backend/app/Internal/Commerce/PaymentWebhookHandlerCore.php`
- result: `0`
