### PR TITLE
fix(security): close P1/P2 authz gaps in replay/events/insights

### DIFF
--- a/backend/app/Http/Controllers/API/V0_2/InsightsController.php
+++ b/backend/app/Http/Controllers/API/V0_2/InsightsController.php
@@ -244,18 +244,8 @@ class InsightsController extends Controller
                 ], 403);
             }
         } elseif ($rowAnonId !== '') {
-            $allowDev = (bool) config('ai.dev_allow_anon_header', true);
             $headerAnon = trim((string) $request->header('X-FAP-Anon-Id', ''));
-            if ($headerAnon === '') {
-                if ($allowDev) {
-                    return null;
-                }
-                return response()->json([
-                    'ok' => false,
-                    'error_code' => 'FORBIDDEN',
-                ], 403);
-            }
-            if ($headerAnon !== $rowAnonId && !$allowDev) {
+            if ($headerAnon === '' || !hash_equals($rowAnonId, $headerAnon)) {
                 return response()->json([
                     'ok' => false,
                     'error_code' => 'FORBIDDEN',

--- a/backend/app/Services/Analytics/EventNormalizer.php
+++ b/backend/app/Services/Analytics/EventNormalizer.php
@@ -34,9 +34,9 @@ class EventNormalizer
             'event_code' => $payload['event_code'] ?? null,
             'occurred_at' => $occurredAt,
             'user_id' => self::toInt(self::firstNonEmpty([
+                $context['user_id'] ?? null,
                 $payload['user_id'] ?? null,
                 $mergedProps['user_id'] ?? null,
-                $context['user_id'] ?? null,
             ])),
             'anon_id' => self::toString(self::firstNonEmpty([
                 $payload['anon_id'] ?? null,

--- a/backend/config/ai.php
+++ b/backend/config/ai.php
@@ -25,5 +25,5 @@ return [
     'redis_prefix' => env('AI_REDIS_PREFIX', 'ai:budget'),
     'queue_name' => env('AI_INSIGHTS_QUEUE', 'insights'),
     'cost_per_1k_tokens_usd' => (float) env('AI_COST_PER_1K_TOKENS_USD', 0.002),
-    'dev_allow_anon_header' => env('AI_DEV_ALLOW_ANON_HEADER', true),
+    'dev_allow_anon_header' => env('AI_DEV_ALLOW_ANON_HEADER', false),
 ];

--- a/backend/routes/api.php
+++ b/backend/routes/api.php
@@ -185,7 +185,8 @@ Route::prefix("v0.2")->middleware([
             Route::post("/revoke", [ProvidersController::class, "revoke"]);
             Route::post("/ingest", [ProvidersController::class, "ingest"])
                 ->middleware(\App\Http\Middleware\IntegrationsIngestAuth::class);
-            Route::post("/replay/{batch_id}", [ProvidersController::class, "replay"]);
+            Route::post("/replay/{batch_id}", [ProvidersController::class, "replay"])
+                ->middleware(\App\Http\Middleware\FmTokenAuth::class);
         });
     });
 

--- a/backend/tests/Feature/EventAuthHardeningTest.php
+++ b/backend/tests/Feature/EventAuthHardeningTest.php
@@ -1,0 +1,105 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature;
+
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Str;
+use Tests\TestCase;
+
+final class EventAuthHardeningTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_events_rejects_revoked_fm_token(): void
+    {
+        $token = $this->seedUserAndToken(3001, revokedAt: now()->subMinute()->toDateTimeString());
+
+        $response = $this->withHeaders([
+            'Authorization' => "Bearer {$token}",
+        ])->postJson('/api/v0.2/events', $this->eventPayload('evt_revoked'));
+
+        $response->assertStatus(401)->assertJson([
+            'ok' => false,
+            'error_code' => 'UNAUTHORIZED',
+        ]);
+        $this->assertSame(0, DB::table('events')->where('event_code', 'evt_revoked')->count());
+    }
+
+    public function test_events_rejects_expired_fm_token(): void
+    {
+        $token = $this->seedUserAndToken(3002, expiresAt: now()->subMinute()->toDateTimeString());
+
+        $response = $this->withHeaders([
+            'Authorization' => "Bearer {$token}",
+        ])->postJson('/api/v0.2/events', $this->eventPayload('evt_expired'));
+
+        $response->assertStatus(401)->assertJson([
+            'ok' => false,
+            'error_code' => 'UNAUTHORIZED',
+        ]);
+        $this->assertSame(0, DB::table('events')->where('event_code', 'evt_expired')->count());
+    }
+
+    public function test_events_bind_user_id_to_authenticated_token(): void
+    {
+        $token = $this->seedUserAndToken(3003);
+
+        $response = $this->withHeaders([
+            'Authorization' => "Bearer {$token}",
+        ])->postJson('/api/v0.2/events', array_merge($this->eventPayload('evt_bound_user'), [
+            'user_id' => 999999,
+            'props' => [
+                'user_id' => 999998,
+            ],
+        ]));
+
+        $response->assertStatus(201)->assertJson([
+            'ok' => true,
+        ]);
+
+        $row = DB::table('events')->where('id', (string) $response->json('id'))->first();
+        $this->assertNotNull($row);
+        $this->assertSame(3003, (int) ($row->user_id ?? 0));
+    }
+
+    private function eventPayload(string $eventCode): array
+    {
+        return [
+            'event_code' => $eventCode,
+            'attempt_id' => (string) Str::uuid(),
+            'anon_id' => 'event-auth-anon',
+        ];
+    }
+
+    private function seedUserAndToken(
+        int $userId,
+        ?string $revokedAt = null,
+        ?string $expiresAt = null
+    ): string {
+        DB::table('users')->insert([
+            'id' => $userId,
+            'name' => "event-auth-user-{$userId}",
+            'email' => "event-auth-user-{$userId}@example.com",
+            'password' => bcrypt('secret'),
+            'created_at' => now(),
+            'updated_at' => now(),
+        ]);
+
+        $token = 'fm_' . (string) Str::uuid();
+        DB::table('fm_tokens')->insert([
+            'token' => $token,
+            'token_hash' => hash('sha256', $token),
+            'user_id' => $userId,
+            'anon_id' => "event-auth-anon-{$userId}",
+            'revoked_at' => $revokedAt,
+            'expires_at' => $expiresAt,
+            'created_at' => now(),
+            'updated_at' => now(),
+        ]);
+
+        return $token;
+    }
+}

--- a/backend/tests/Feature/Integrations/ReplaySecurityTest.php
+++ b/backend/tests/Feature/Integrations/ReplaySecurityTest.php
@@ -1,0 +1,102 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Integrations;
+
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Str;
+use Tests\TestCase;
+
+final class ReplaySecurityTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_replay_requires_fm_token_auth(): void
+    {
+        $batchId = (string) Str::uuid();
+        $this->seedBatch($batchId, 'mock', 1001);
+
+        $response = $this->postJson("/api/v0.2/integrations/mock/replay/{$batchId}");
+
+        $response->assertStatus(401)->assertJson([
+            'ok' => false,
+        ]);
+    }
+
+    public function test_replay_denies_non_owner_without_privileged_role(): void
+    {
+        $batchId = (string) Str::uuid();
+        $this->seedBatch($batchId, 'mock', 1001);
+
+        $token = $this->seedUserAndToken(1002, 'public');
+
+        $response = $this->withHeaders([
+            'Authorization' => "Bearer {$token}",
+        ])->postJson("/api/v0.2/integrations/mock/replay/{$batchId}");
+
+        $response->assertStatus(404)->assertJson([
+            'ok' => false,
+            'error_code' => 'NOT_FOUND',
+        ]);
+    }
+
+    public function test_replay_rejects_provider_mismatch_for_same_batch(): void
+    {
+        $batchId = (string) Str::uuid();
+        $this->seedBatch($batchId, 'mock', 1001);
+
+        $token = $this->seedUserAndToken(1001, 'public');
+
+        $response = $this->withHeaders([
+            'Authorization' => "Bearer {$token}",
+        ])->postJson("/api/v0.2/integrations/google_fit/replay/{$batchId}");
+
+        $response->assertStatus(404)->assertJson([
+            'ok' => false,
+            'error_code' => 'NOT_FOUND',
+        ]);
+
+        $batch = DB::table('ingest_batches')->where('id', $batchId)->first();
+        $this->assertNotNull($batch);
+        $this->assertSame('received', (string) $batch->status);
+    }
+
+    private function seedUserAndToken(int $userId, string $role): string
+    {
+        DB::table('users')->insert([
+            'id' => $userId,
+            'name' => "replay-user-{$userId}",
+            'email' => "replay-user-{$userId}@example.com",
+            'password' => bcrypt('secret'),
+            'created_at' => now(),
+            'updated_at' => now(),
+        ]);
+
+        $token = 'fm_' . (string) Str::uuid();
+        DB::table('fm_tokens')->insert([
+            'token' => $token,
+            'token_hash' => hash('sha256', $token),
+            'user_id' => $userId,
+            'anon_id' => "replay-anon-{$userId}",
+            'org_id' => 0,
+            'role' => $role,
+            'created_at' => now(),
+            'updated_at' => now(),
+        ]);
+
+        return $token;
+    }
+
+    private function seedBatch(string $batchId, string $provider, int $userId): void
+    {
+        DB::table('ingest_batches')->insert([
+            'id' => $batchId,
+            'provider' => $provider,
+            'user_id' => $userId,
+            'status' => 'received',
+            'created_at' => now(),
+        ]);
+    }
+}

--- a/backend/tests/Feature/V0_2/InsightsAnonHeaderAuthTest.php
+++ b/backend/tests/Feature/V0_2/InsightsAnonHeaderAuthTest.php
@@ -1,0 +1,68 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\V0_2;
+
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Str;
+use Tests\TestCase;
+
+final class InsightsAnonHeaderAuthTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_anonymous_insight_requires_matching_anon_header(): void
+    {
+        config()->set('fap.features.insights', true);
+
+        $insightId = (string) Str::uuid();
+        DB::table('ai_insights')->insert([
+            'id' => $insightId,
+            'user_id' => null,
+            'anon_id' => 'anon_insight_owner',
+            'period_type' => 'week',
+            'period_start' => '2026-01-01',
+            'period_end' => '2026-01-07',
+            'input_hash' => hash('sha256', 'insight:' . $insightId),
+            'prompt_version' => 'v1.0.0',
+            'model' => 'mock-model',
+            'provider' => 'mock',
+            'tokens_in' => 0,
+            'tokens_out' => 0,
+            'cost_usd' => 0,
+            'status' => 'succeeded',
+            'output_json' => json_encode(['ok' => true], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES),
+            'evidence_json' => null,
+            'error_code' => null,
+            'created_at' => now(),
+            'updated_at' => now(),
+        ]);
+
+        $this->getJson("/api/v0.2/insights/{$insightId}")
+            ->assertStatus(403)
+            ->assertJson([
+                'ok' => false,
+                'error_code' => 'FORBIDDEN',
+            ]);
+
+        $this->withHeaders([
+            'X-FAP-Anon-Id' => 'anon_wrong',
+        ])->getJson("/api/v0.2/insights/{$insightId}")
+            ->assertStatus(403)
+            ->assertJson([
+                'ok' => false,
+                'error_code' => 'FORBIDDEN',
+            ]);
+
+        $this->withHeaders([
+            'X-FAP-Anon-Id' => 'anon_insight_owner',
+        ])->getJson("/api/v0.2/insights/{$insightId}")
+            ->assertStatus(200)
+            ->assertJson([
+                'ok' => true,
+                'id' => $insightId,
+            ]);
+    }
+}


### PR DESCRIPTION
## Summary
This PR addresses all P1/P2 findings from the latest security review and keeps scope minimal (no unrelated refactor).

## Security Fixes
1. Protect replay endpoint with auth middleware and caller identity requirement.
2. Enforce replay provider consistency with batch provider, plus provider allowlist validation.
3. Add replay authorization check (batch owner or privileged role: `admin|owner|system`).
4. Harden event ingestion token validation by enforcing `revoked_at` and `expires_at`.
5. Bind analytics `user_id` to authenticated token context and ignore forged payload `user_id`.
6. Require `X-FAP-Anon-Id` for anonymous insight access and require exact match.
7. Change `AI_DEV_ALLOW_ANON_HEADER` default to `false`.

## Files Changed
- `/Users/rainie/.codex/worktrees/3a8a/fap-api/backend/routes/api.php`
- `/Users/rainie/.codex/worktrees/3a8a/fap-api/backend/app/Http/Controllers/Integrations/ProvidersController.php`
- `/Users/rainie/.codex/worktrees/3a8a/fap-api/backend/app/Services/Ingestion/ReplayService.php`
- `/Users/rainie/.codex/worktrees/3a8a/fap-api/backend/app/Http/Controllers/EventController.php`
- `/Users/rainie/.codex/worktrees/3a8a/fap-api/backend/app/Services/Analytics/EventNormalizer.php`
- `/Users/rainie/.codex/worktrees/3a8a/fap-api/backend/app/Http/Controllers/API/V0_2/InsightsController.php`
- `/Users/rainie/.codex/worktrees/3a8a/fap-api/backend/config/ai.php`
- `/Users/rainie/.codex/worktrees/3a8a/fap-api/backend/tests/Feature/Integrations/ReplaySecurityTest.php`
- `/Users/rainie/.codex/worktrees/3a8a/fap-api/backend/tests/Feature/EventAuthHardeningTest.php`
- `/Users/rainie/.codex/worktrees/3a8a/fap-api/backend/tests/Feature/V0_2/InsightsAnonHeaderAuthTest.php`

## Validation
- `php artisan route:list` ✅
- `php artisan migrate --force` ✅
- `php artisan test tests/Feature/Integrations/ReplaySecurityTest.php tests/Feature/EventAuthHardeningTest.php tests/Feature/V0_2/InsightsAnonHeaderAuthTest.php` ✅ (7 passed)
- `bash backend/scripts/ci_verify_mbti.sh` ✅

## Risk / Compatibility
1. Replay endpoint now requires FM token auth and valid identity.
2. Replay returns 404 for provider mismatch/unauthorized ownership checks (intended fail-closed behavior).
3. Anonymous insight access now requires explicit anon header ownership proof.

## Review Outcome
No remaining P1 findings in the addressed scope.
