### PR TITLE
fix(security): harden v0.2/v0.3 write endpoint auth

### DIFF
--- a/backend/app/Http/Controllers/API/V0_2/InsightsController.php
+++ b/backend/app/Http/Controllers/API/V0_2/InsightsController.php
@@ -244,8 +244,16 @@ class InsightsController extends Controller
                 ], 403);
             }
         } elseif ($rowAnonId !== '') {
-            $headerAnon = trim((string) $request->header('X-FAP-Anon-Id', ''));
-            if ($headerAnon === '' || !hash_equals($rowAnonId, $headerAnon)) {
+            $requestAnonId = trim((string) $request->header('X-FAP-Anon-Id', ''));
+            if ($requestAnonId === '') {
+                $requestAnonId = trim((string) (
+                    $request->attributes->get('fm_anon_id')
+                    ?? $request->attributes->get('anon_id')
+                    ?? ''
+                ));
+            }
+
+            if ($requestAnonId === '' || !hash_equals($rowAnonId, $requestAnonId)) {
                 return response()->json([
                     'ok' => false,
                     'error_code' => 'FORBIDDEN',

--- a/backend/app/Services/Ingestion/ConsentService.php
+++ b/backend/app/Services/Ingestion/ConsentService.php
@@ -53,9 +53,20 @@ class ConsentService
 
     public function revoke(?string $userId, string $provider): array
     {
+        $userId = is_string($userId) ? trim($userId) : null;
+        if ($userId === null || $userId === '') {
+            return [
+                'ok' => false,
+                'status' => 401,
+                'error' => 'UNAUTHORIZED',
+                'message' => 'missing_identity',
+            ];
+        }
+
         if (!\App\Support\SchemaBaseline::hasTable('integrations')) {
             return [
                 'ok' => false,
+                'status' => 500,
                 'error' => 'MISSING_TABLE',
                 'message' => 'integrations table not found',
             ];
@@ -73,6 +84,7 @@ class ConsentService
 
         return [
             'ok' => true,
+            'status' => 200,
             'user_id' => $userId !== null ? (int) $userId : null,
             'provider' => $provider,
         ];

--- a/backend/tests/Feature/ApiValidationErrorContractTest.php
+++ b/backend/tests/Feature/ApiValidationErrorContractTest.php
@@ -5,6 +5,8 @@ declare(strict_types=1);
 namespace Tests\Feature;
 
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Str;
 use Tests\TestCase;
 
 final class ApiValidationErrorContractTest extends TestCase
@@ -13,7 +15,9 @@ final class ApiValidationErrorContractTest extends TestCase
 
     public function test_orders_validation_failure_returns_unified_contract(): void
     {
-        $response = $this->postJson('/api/v0.3/orders', []);
+        $response = $this->withHeaders([
+            'Authorization' => 'Bearer ' . $this->issueAnonToken(),
+        ])->postJson('/api/v0.3/orders', []);
 
         $response->assertStatus(422);
         $response->assertJsonPath('ok', false);
@@ -27,5 +31,22 @@ final class ApiValidationErrorContractTest extends TestCase
 
         $requestId = (string) $response->json('request_id', '');
         $this->assertNotSame('', $requestId);
+    }
+
+    private function issueAnonToken(): string
+    {
+        $token = 'fm_' . (string) Str::uuid();
+        DB::table('fm_tokens')->insert([
+            'token' => $token,
+            'token_hash' => hash('sha256', $token),
+            'user_id' => null,
+            'anon_id' => 'contract_anon_' . Str::random(8),
+            'org_id' => 0,
+            'role' => 'public',
+            'created_at' => now(),
+            'updated_at' => now(),
+        ]);
+
+        return $token;
     }
 }

--- a/backend/tests/Feature/Integrations/RevokeSecurityTest.php
+++ b/backend/tests/Feature/Integrations/RevokeSecurityTest.php
@@ -1,0 +1,140 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Integrations;
+
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Str;
+use Tests\TestCase;
+
+final class RevokeSecurityTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_revoke_requires_fm_token_auth(): void
+    {
+        $response = $this->postJson('/api/v0.2/integrations/mock/revoke');
+
+        $response->assertStatus(401)->assertJson([
+            'ok' => false,
+        ]);
+    }
+
+    public function test_revoke_rejects_token_without_bound_user_identity(): void
+    {
+        $token = 'fm_' . (string) Str::uuid();
+        DB::table('fm_tokens')->insert([
+            'token' => $token,
+            'token_hash' => hash('sha256', $token),
+            'user_id' => null,
+            'anon_id' => 'revoke-anon-only',
+            'org_id' => 0,
+            'role' => 'public',
+            'created_at' => now(),
+            'updated_at' => now(),
+        ]);
+
+        $this->seedIntegrationRecord(null, 'mock', 'connected');
+
+        $response = $this->withHeaders([
+            'Authorization' => "Bearer {$token}",
+        ])->postJson('/api/v0.2/integrations/mock/revoke');
+
+        $response->assertStatus(401)->assertJson([
+            'ok' => false,
+            'error_code' => 'UNAUTHORIZED',
+            'message' => 'missing_identity',
+        ]);
+
+        $row = DB::table('integrations')
+            ->whereNull('user_id')
+            ->where('provider', 'mock')
+            ->first();
+
+        $this->assertNotNull($row);
+        $this->assertSame('connected', (string) $row->status);
+        $this->assertNull($row->revoked_at);
+    }
+
+    public function test_revoke_updates_only_authenticated_user_record(): void
+    {
+        $this->seedUser(1001);
+        $this->seedUser(1002);
+
+        $token = 'fm_' . (string) Str::uuid();
+        DB::table('fm_tokens')->insert([
+            'token' => $token,
+            'token_hash' => hash('sha256', $token),
+            'user_id' => 1001,
+            'anon_id' => 'revoke-anon-1001',
+            'org_id' => 0,
+            'role' => 'public',
+            'created_at' => now(),
+            'updated_at' => now(),
+        ]);
+
+        $this->seedIntegrationRecord(1001, 'mock', 'connected');
+        $this->seedIntegrationRecord(1002, 'mock', 'connected');
+
+        $response = $this->withHeaders([
+            'Authorization' => "Bearer {$token}",
+        ])->postJson('/api/v0.2/integrations/mock/revoke');
+
+        $response->assertStatus(200)->assertJson([
+            'ok' => true,
+            'provider' => 'mock',
+            'user_id' => '1001',
+        ]);
+
+        $mine = DB::table('integrations')
+            ->where('user_id', 1001)
+            ->where('provider', 'mock')
+            ->first();
+        $other = DB::table('integrations')
+            ->where('user_id', 1002)
+            ->where('provider', 'mock')
+            ->first();
+
+        $this->assertNotNull($mine);
+        $this->assertSame('revoked', (string) $mine->status);
+        $this->assertNotNull($mine->revoked_at);
+
+        $this->assertNotNull($other);
+        $this->assertSame('connected', (string) $other->status);
+        $this->assertNull($other->revoked_at);
+    }
+
+    private function seedUser(int $userId): void
+    {
+        DB::table('users')->insert([
+            'id' => $userId,
+            'name' => "revoke-user-{$userId}",
+            'email' => "revoke-user-{$userId}@example.com",
+            'password' => bcrypt('secret'),
+            'created_at' => now(),
+            'updated_at' => now(),
+        ]);
+    }
+
+    private function seedIntegrationRecord(?int $userId, string $provider, string $status): void
+    {
+        DB::table('integrations')->insert([
+            'user_id' => $userId,
+            'provider' => $provider,
+            'external_user_id' => $userId !== null ? "ext_{$userId}" : 'ext_null',
+            'status' => $status,
+            'scopes_json' => json_encode(['mock_scope'], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES),
+            'consent_version' => 'v0.1',
+            'connected_at' => now(),
+            'revoked_at' => null,
+            'ingest_key_hash' => hash('sha256', "{$provider}|{$userId}|".Str::uuid()),
+            'webhook_last_event_id' => null,
+            'webhook_last_timestamp' => null,
+            'webhook_last_received_at' => null,
+            'created_at' => now(),
+            'updated_at' => now(),
+        ]);
+    }
+}

--- a/backend/tests/Feature/V0_2/InsightsFeedbackAuthTest.php
+++ b/backend/tests/Feature/V0_2/InsightsFeedbackAuthTest.php
@@ -1,0 +1,106 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\V0_2;
+
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Str;
+use Tests\TestCase;
+
+final class InsightsFeedbackAuthTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_feedback_requires_fm_token(): void
+    {
+        config()->set('fap.features.insights', true);
+
+        $insightId = $this->createAnonymousInsight('anon_feedback_owner');
+
+        $response = $this->withHeaders([
+            'X-FAP-Anon-Id' => 'anon_feedback_owner',
+        ])->postJson("/api/v0.2/insights/{$insightId}/feedback", [
+            'rating' => 4,
+            'reason' => 'helpful',
+            'comment' => 'no token should fail',
+        ]);
+
+        $response->assertStatus(401)
+            ->assertJson([
+                'ok' => false,
+                'error_code' => 'UNAUTHENTICATED',
+            ]);
+    }
+
+    public function test_feedback_accepts_anon_token_identity_without_anon_header(): void
+    {
+        config()->set('fap.features.insights', true);
+
+        $insightId = $this->createAnonymousInsight('anon_feedback_owner');
+        $token = $this->seedAnonToken('anon_feedback_owner');
+
+        $response = $this->withHeaders([
+            'Authorization' => "Bearer {$token}",
+        ])->postJson("/api/v0.2/insights/{$insightId}/feedback", [
+            'rating' => 5,
+            'reason' => 'helpful',
+            'comment' => 'token-backed anon feedback',
+        ]);
+
+        $response->assertStatus(200)
+            ->assertJsonPath('ok', true);
+
+        $this->assertDatabaseHas('ai_insight_feedback', [
+            'insight_id' => $insightId,
+            'rating' => 5,
+            'reason' => 'helpful',
+        ]);
+    }
+
+    private function createAnonymousInsight(string $anonId): string
+    {
+        $insightId = (string) Str::uuid();
+
+        DB::table('ai_insights')->insert([
+            'id' => $insightId,
+            'user_id' => null,
+            'anon_id' => $anonId,
+            'period_type' => 'week',
+            'period_start' => '2026-01-01',
+            'period_end' => '2026-01-07',
+            'input_hash' => hash('sha256', 'feedback:' . $insightId),
+            'prompt_version' => 'v1.0.0',
+            'model' => 'mock-model',
+            'provider' => 'mock',
+            'tokens_in' => 0,
+            'tokens_out' => 0,
+            'cost_usd' => 0,
+            'status' => 'succeeded',
+            'output_json' => null,
+            'evidence_json' => null,
+            'error_code' => null,
+            'created_at' => now(),
+            'updated_at' => now(),
+        ]);
+
+        return $insightId;
+    }
+
+    private function seedAnonToken(string $anonId): string
+    {
+        $token = 'fm_' . (string) Str::uuid();
+
+        DB::table('fm_tokens')->insert([
+            'token' => $token,
+            'token_hash' => hash('sha256', $token),
+            'anon_id' => $anonId,
+            'expires_at' => now()->addHour(),
+            'created_at' => now(),
+            'updated_at' => now(),
+        ]);
+
+        return $token;
+    }
+}

--- a/backend/tests/Feature/V0_2/InsightsGenerateAuthTest.php
+++ b/backend/tests/Feature/V0_2/InsightsGenerateAuthTest.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\V0_2;
+
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+final class InsightsGenerateAuthTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_generate_requires_fm_token(): void
+    {
+        config()->set('fap.features.insights', true);
+        config()->set('ai.enabled', true);
+        config()->set('ai.insights_enabled', true);
+        config()->set('ai.breaker_enabled', false);
+
+        $response = $this->postJson('/api/v0.2/insights/generate', [
+            'period_type' => 'week',
+            'period_start' => '2026-02-01',
+            'period_end' => '2026-02-07',
+            'anon_id' => 'anon_insight_test',
+        ]);
+
+        $response->assertStatus(401)->assertJson([
+            'ok' => false,
+            'error_code' => 'UNAUTHENTICATED',
+        ]);
+    }
+}

--- a/backend/tests/Feature/V0_3/AttemptSubmitAuthTest.php
+++ b/backend/tests/Feature/V0_3/AttemptSubmitAuthTest.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\V0_3;
+
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+final class AttemptSubmitAuthTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_submit_requires_fm_token(): void
+    {
+        $response = $this->postJson('/api/v0.3/attempts/submit', [
+            'attempt_id' => '00000000-0000-0000-0000-000000000000',
+            'answers' => [],
+            'duration_ms' => 1,
+        ]);
+
+        $response->assertStatus(401)->assertJson([
+            'ok' => false,
+            'error_code' => 'UNAUTHENTICATED',
+        ]);
+    }
+}

--- a/backend/tests/Feature/V0_3/AttemptsStartSubmitTest.php
+++ b/backend/tests/Feature/V0_3/AttemptsStartSubmitTest.php
@@ -7,12 +7,31 @@ use Database\Seeders\Pr16IqRavenDemoSeeder;
 use Database\Seeders\Pr17SimpleScoreDemoSeeder;
 use Database\Seeders\ScaleRegistrySeeder;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Str;
 use Tests\TestCase;
 
 class AttemptsStartSubmitTest extends TestCase
 {
     use RefreshDatabase;
+
+    private function issueAnonToken(string $anonId): string
+    {
+        $token = 'fm_' . (string) Str::uuid();
+        DB::table('fm_tokens')->insert([
+            'token' => $token,
+            'token_hash' => hash('sha256', $token),
+            'user_id' => null,
+            'anon_id' => $anonId,
+            'org_id' => 0,
+            'role' => 'public',
+            'expires_at' => now()->addDay(),
+            'created_at' => now(),
+            'updated_at' => now(),
+        ]);
+
+        return $token;
+    }
 
     private function seedScales(): void
     {
@@ -25,6 +44,7 @@ class AttemptsStartSubmitTest extends TestCase
     {
         $this->seedScales();
         $anonId = 'v03_simple_score_owner';
+        $anonToken = $this->issueAnonToken($anonId);
 
         $start = $this->withHeaders([
             'X-Anon-Id' => $anonId,
@@ -46,6 +66,7 @@ class AttemptsStartSubmitTest extends TestCase
 
         $submit = $this->withHeaders([
             'X-Anon-Id' => $anonId,
+            'Authorization' => 'Bearer ' . $anonToken,
         ])->postJson('/api/v0.3/attempts/submit', [
             'attempt_id' => $attemptId,
             'answers' => $answers,
@@ -69,6 +90,7 @@ class AttemptsStartSubmitTest extends TestCase
 
         $dup = $this->withHeaders([
             'X-Anon-Id' => $anonId,
+            'Authorization' => 'Bearer ' . $anonToken,
         ])->postJson('/api/v0.3/attempts/submit', [
             'attempt_id' => $attemptId,
             'answers' => $answers,
@@ -88,6 +110,7 @@ class AttemptsStartSubmitTest extends TestCase
     {
         $this->seedScales();
         $anonId = 'v03_iq_owner';
+        $anonToken = $this->issueAnonToken($anonId);
 
         $start = $this->withHeaders([
             'X-Anon-Id' => $anonId,
@@ -100,6 +123,7 @@ class AttemptsStartSubmitTest extends TestCase
 
         $submit = $this->withHeaders([
             'X-Anon-Id' => $anonId,
+            'Authorization' => 'Bearer ' . $anonToken,
         ])->postJson('/api/v0.3/attempts/submit', [
             'attempt_id' => $attemptId,
             'answers' => [

--- a/backend/tests/Feature/V0_3/CommerceOrgIdWriteIsolationTest.php
+++ b/backend/tests/Feature/V0_3/CommerceOrgIdWriteIsolationTest.php
@@ -5,6 +5,8 @@ declare(strict_types=1);
 namespace Tests\Feature\V0_3;
 
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Str;
 use Tests\TestCase;
 
 final class CommerceOrgIdWriteIsolationTest extends TestCase
@@ -13,7 +15,9 @@ final class CommerceOrgIdWriteIsolationTest extends TestCase
 
     public function test_create_order_rejects_client_tenant_identity_fields(): void
     {
-        $response = $this->postJson('/api/v0.3/orders', [
+        $response = $this->withHeaders([
+            'Authorization' => 'Bearer ' . $this->issueAnonToken(),
+        ])->postJson('/api/v0.3/orders', [
             'sku' => 'MBTI_CREDIT',
             'org_id' => 999,
             'user_id' => 'attacker-user',
@@ -28,5 +32,22 @@ final class CommerceOrgIdWriteIsolationTest extends TestCase
         $this->assertIsArray($response->json('details.org_id'));
         $this->assertIsArray($response->json('details.user_id'));
         $this->assertIsArray($response->json('details.anon_id'));
+    }
+
+    private function issueAnonToken(): string
+    {
+        $token = 'fm_' . (string) Str::uuid();
+        DB::table('fm_tokens')->insert([
+            'token' => $token,
+            'token_hash' => hash('sha256', $token),
+            'user_id' => null,
+            'anon_id' => 'isolation_anon_' . Str::random(8),
+            'org_id' => 0,
+            'role' => 'public',
+            'created_at' => now(),
+            'updated_at' => now(),
+        ]);
+
+        return $token;
     }
 }


### PR DESCRIPTION
## Summary
This PR hardens write-path auth in `/api/v0.2` and `/api/v0.3` based on attack-surface discovery.

### Route hardening
- Add `FmTokenAuth` to `POST /api/v0.2/integrations/{provider}/revoke`.
- Add `FmTokenAuth` to `POST /api/v0.2/insights/generate`.
- Add `FmTokenAuth` to `POST /api/v0.2/insights/{id}/feedback`.
- Add `FmTokenAuth` to `POST /api/v0.3/attempts/submit`.
- Add `FmTokenAuth` to `POST /api/v0.3/orders`.
- Add `FmTokenAuth` to `POST /api/v0.3/orders/{provider}`.

### Controller/service safety tightening
- `ProvidersController@revoke` now rejects missing bound user identity and maps service status/error to HTTP response.
- `ConsentService::revoke` now returns explicit status/error for missing identity and missing table cases.
- `InsightsController::authorizeInsight` now supports anon identity from middleware-injected attributes (`fm_anon_id` / `anon_id`) in addition to header fallback.

### Regression coverage
- Add `RevokeSecurityTest` for revoke auth and ownership isolation.
- Add `InsightsGenerateAuthTest` for generate auth gate.
- Add `InsightsFeedbackAuthTest` for feedback auth gate and anon-token flow.
- Add `AttemptSubmitAuthTest` for submit auth gate.
- Update existing v0.3 order/submit feature tests to include fm token setup where required.

## Changed files
- `backend/routes/api.php`
- `backend/app/Http/Controllers/Integrations/ProvidersController.php`
- `backend/app/Services/Ingestion/ConsentService.php`
- `backend/app/Http/Controllers/API/V0_2/InsightsController.php`
- `backend/tests/Feature/Integrations/RevokeSecurityTest.php`
- `backend/tests/Feature/V0_2/InsightsGenerateAuthTest.php`
- `backend/tests/Feature/V0_2/InsightsFeedbackAuthTest.php`
- `backend/tests/Feature/V0_3/AttemptSubmitAuthTest.php`
- `backend/tests/Feature/ApiValidationErrorContractTest.php`
- `backend/tests/Feature/V0_3/CommerceOrgIdWriteIsolationTest.php`
- `backend/tests/Feature/V0_3/AttemptReportPaymentUnlockFlowTest.php`

## Verification
- `php -l` passed for all changed PHP files.

Could not run in this worktree environment (missing `backend/vendor/autoload.php`):
- `php artisan route:list`
- `php artisan migrate`
- `php artisan test`
- `bash backend/scripts/ci_verify_mbti.sh`
