### PR TITLE
fix(security): harden IDOR isolation and webhook idempotency

### DIFF
--- a/backend/app/Http/Controllers/API/V0_2/ValidityFeedbackController.php
+++ b/backend/app/Http/Controllers/API/V0_2/ValidityFeedbackController.php
@@ -9,7 +9,6 @@ use Illuminate\Database\QueryException;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\DB;
-use Illuminate\Support\Facades\Schema;
 use Illuminate\Support\Facades\Storage;
 
 class ValidityFeedbackController extends Controller
@@ -38,33 +37,21 @@ class ValidityFeedbackController extends Controller
         ]);
 
         $orgId = $this->resolveOrgId($request);
+        $fmUserId = $this->normalizeId($request->attributes->get('fm_user_id') ?? $request->attributes->get('user_id'));
+        $anonId = $this->normalizeId($request->attributes->get('fm_anon_id') ?? $request->attributes->get('anon_id'));
+
+        $attemptQuery = Attempt::where('id', $attemptId)
+            ->where('org_id', $orgId);
+        $this->applyAttemptOwnershipScope($attemptQuery, $fmUserId, $anonId);
 
         /** @var Attempt|null $attempt */
-        $attempt = Attempt::where('id', $attemptId)
-            ->where('org_id', $orgId)
-            ->first();
+        $attempt = $attemptQuery->first();
         if (!$attempt) {
             return response()->json([
                 'ok' => false,
                 'error_code' => 'NOT_FOUND',
                 'message' => 'attempt not found.',
             ], 404);
-        }
-
-        $fmUserId = $this->normalizeId($request->attributes->get('fm_user_id'));
-        $anonId = $this->normalizeId($request->attributes->get('anon_id'));
-
-        if ($fmUserId !== null && \App\Support\SchemaBaseline::hasColumn('attempts', 'user_id')) {
-            if ((string) ($attempt->user_id ?? '') !== $fmUserId) {
-                return $this->forbiddenResponse();
-            }
-        } else {
-            if ($anonId === null) {
-                return $this->forbiddenResponse();
-            }
-            if (!$this->checkAnonOwnership($attemptId, $anonId)) {
-                return $this->forbiddenResponse();
-            }
         }
 
         $createdAt = now();
@@ -144,15 +131,6 @@ class ValidityFeedbackController extends Controller
         ], 200);
     }
 
-    private function forbiddenResponse(): JsonResponse
-    {
-        return response()->json([
-            'ok' => false,
-            'error_code' => 'FORBIDDEN',
-            'message' => 'forbidden.',
-        ], 403);
-    }
-
     private function normalizeId(mixed $value): ?string
     {
         if (!is_string($value)) {
@@ -160,6 +138,44 @@ class ValidityFeedbackController extends Controller
         }
         $value = trim($value);
         return $value !== '' ? $value : null;
+    }
+
+    private function applyAttemptOwnershipScope(
+        \Illuminate\Database\Eloquent\Builder $query,
+        ?string $userId,
+        ?string $anonId
+    ): void {
+        $uid = trim((string) ($userId ?? ''));
+        $aid = trim((string) ($anonId ?? ''));
+        $hasUser = \App\Support\SchemaBaseline::hasColumn('attempts', 'user_id');
+        $hasAnon = \App\Support\SchemaBaseline::hasColumn('attempts', 'anon_id');
+
+        if (($uid === '' || !$hasUser) && ($aid === '' || !$hasAnon)) {
+            $query->whereRaw('1=0');
+            return;
+        }
+
+        $query->where(function ($q) use ($uid, $aid, $hasUser, $hasAnon): void {
+            $applied = false;
+
+            if ($uid !== '' && $hasUser) {
+                $q->where('user_id', $uid);
+                $applied = true;
+            }
+
+            if ($aid !== '' && $hasAnon) {
+                if ($applied) {
+                    $q->orWhere('anon_id', $aid);
+                } else {
+                    $q->where('anon_id', $aid);
+                    $applied = true;
+                }
+            }
+
+            if (!$applied) {
+                $q->whereRaw('1=0');
+            }
+        });
     }
 
     private function normalizeReasonTags(array $tags): array
@@ -196,29 +212,6 @@ class ValidityFeedbackController extends Controller
             return (string) mb_substr($clean, 0, 200, 'UTF-8');
         }
         return (string) substr($clean, 0, 200);
-    }
-
-    private function checkAnonOwnership(string $attemptId, string $anonId): bool
-    {
-        if (!\App\Support\SchemaBaseline::hasTable('identities')) {
-            // TODO: identities table missing; allow anon-bound write for now.
-            return true;
-        }
-        if (!\App\Support\SchemaBaseline::hasColumn('identities', 'attempt_id') || !\App\Support\SchemaBaseline::hasColumn('identities', 'anon_id')) {
-            // TODO: identities schema missing attempt_id/anon_id; allow anon-bound write for now.
-            return true;
-        }
-
-        $row = DB::table('identities')
-            ->where('attempt_id', $attemptId)
-            ->first();
-
-        if (!$row) {
-            // TODO: identities row missing for attempt; allow anon-bound write for now.
-            return true;
-        }
-
-        return trim((string) ($row->anon_id ?? '')) === $anonId;
     }
 
     private function resolvePackId(Attempt $attempt): string

--- a/backend/app/Http/Controllers/Concerns/ResolvesOrgId.php
+++ b/backend/app/Http/Controllers/Concerns/ResolvesOrgId.php
@@ -8,6 +8,16 @@ trait ResolvesOrgId
 {
     protected function resolveOrgId(Request $request): int
     {
+        $attrOrgId = $request->attributes->get('org_id');
+        if (is_numeric($attrOrgId)) {
+            return max(0, (int) $attrOrgId);
+        }
+
+        $attrFmOrgId = $request->attributes->get('fm_org_id');
+        if (is_numeric($attrFmOrgId)) {
+            return max(0, (int) $attrFmOrgId);
+        }
+
         $raw = trim((string) $request->header('X-Org-Id', ''));
         if ($raw === '') {
             $raw = trim((string) $request->query('org_id', ''));

--- a/backend/app/Services/Commerce/PaymentGateway/BillingGateway.php
+++ b/backend/app/Services/Commerce/PaymentGateway/BillingGateway.php
@@ -49,13 +49,6 @@ class BillingGateway implements PaymentGatewayInterface
             }
         }
 
-        if ((bool) config('services.billing.allow_legacy_signature', false) === true && $providedSignature !== '') {
-            $legacy = hash_hmac('sha256', $rawBody, $secret);
-            if (hash_equals($legacy, $providedSignature)) {
-                return true;
-            }
-        }
-
         return false;
     }
 

--- a/backend/app/Services/Ingestion/IngestionService.php
+++ b/backend/app/Services/Ingestion/IngestionService.php
@@ -98,7 +98,7 @@ class IngestionService
             $value = $sample['value'] ?? $sample;
             $recordedAtNormalized = IdempotencyKey::normalizeRecordedAt($recordedAt);
             $idKey = IdempotencyKey::build($provider, $externalId !== '' ? $externalId : $recordedAtNormalized, $recordedAtNormalized, $value);
-            $idRecord = $store->record([
+            $idRecord = $store->recordFast([
                 'provider' => $idKey['provider'],
                 'external_id' => $idKey['external_id'],
                 'recorded_at' => $idKey['recorded_at'],

--- a/backend/app/Services/Payments/PaymentService.php
+++ b/backend/app/Services/Payments/PaymentService.php
@@ -71,13 +71,9 @@ class PaymentService
 
     public function markPaid(string $orderId, string $userId, ?string $anonId, array $context = []): array
     {
-        $order = DB::table('orders')->where('id', $orderId)->first();
+        $order = $this->ownedOrderQuery($orderId, $userId, $anonId)->first();
         if (!$order) {
             return $this->notFound('ORDER_NOT_FOUND', 'order not found.');
-        }
-
-        if (!$this->orderBelongsToActor($order, $userId, $anonId)) {
-            return $this->forbidden('ORDER_FORBIDDEN', 'order not owned.');
         }
 
         if (in_array($order->status, ['paid', 'fulfilled'], true)) {
@@ -140,13 +136,9 @@ class PaymentService
 
     public function fulfill(string $orderId, string $userId, ?string $anonId): array
     {
-        $order = DB::table('orders')->where('id', $orderId)->first();
+        $order = $this->ownedOrderQuery($orderId, $userId, $anonId)->first();
         if (!$order) {
             return $this->notFound('ORDER_NOT_FOUND', 'order not found.');
-        }
-
-        if (!$this->orderBelongsToActor($order, $userId, $anonId)) {
-            return $this->forbidden('ORDER_FORBIDDEN', 'order not owned.');
         }
 
         if (!in_array($order->status, ['paid', 'fulfilled'], true)) {
@@ -411,20 +403,39 @@ class PaymentService
             ->where('provider_event_id', $providerEventId);
     }
 
-    private function orderBelongsToActor(object $order, ?string $userId, ?string $anonId): bool
+    private function ownedOrderQuery(string $orderId, ?string $userId, ?string $anonId)
     {
         $userId = $this->trimOrNull($userId);
         $anonId = $this->trimOrNull($anonId);
 
-        if ($userId && isset($order->user_id) && $order->user_id === $userId) {
-            return true;
+        $query = DB::table('orders')->where('id', $orderId);
+        if (!$userId && !$anonId) {
+            return $query->whereRaw('1=0');
         }
 
-        if ($anonId && isset($order->anon_id) && $order->anon_id === $anonId) {
-            return true;
-        }
+        $query->where(function ($q) use ($userId, $anonId): void {
+            $applied = false;
 
-        return false;
+            if ($userId) {
+                $q->where('user_id', $userId);
+                $applied = true;
+            }
+
+            if ($anonId) {
+                if ($applied) {
+                    $q->orWhere('anon_id', $anonId);
+                } else {
+                    $q->where('anon_id', $anonId);
+                    $applied = true;
+                }
+            }
+
+            if (!$applied) {
+                $q->whereRaw('1=0');
+            }
+        });
+
+        return $query;
     }
 
     private function tableMissing(string $table): array
@@ -442,16 +453,6 @@ class PaymentService
         return [
             'ok' => false,
             'status' => 404,
-            'error_code' => $errorCode,
-            'message' => $message,
-        ];
-    }
-
-    private function forbidden(string $errorCode, string $message): array
-    {
-        return [
-            'ok' => false,
-            'status' => 403,
             'error_code' => $errorCode,
             'message' => $message,
         ];

--- a/backend/database/migrations/2026_02_13_020000_add_identity_unique_to_idempotency_keys.php
+++ b/backend/database/migrations/2026_02_13_020000_add_identity_unique_to_idempotency_keys.php
@@ -1,0 +1,82 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Support\Database\SchemaIndex;
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    private const TABLE = 'idempotency_keys';
+    private const INDEX = 'idempotency_keys_identity_unique';
+
+    public function up(): void
+    {
+        if (!Schema::hasTable(self::TABLE)) {
+            return;
+        }
+
+        if (
+            !Schema::hasColumn(self::TABLE, 'provider')
+            || !Schema::hasColumn(self::TABLE, 'external_id')
+            || !Schema::hasColumn(self::TABLE, 'recorded_at')
+        ) {
+            return;
+        }
+
+        $this->collapseIdentityDuplicates();
+
+        if (SchemaIndex::indexExists(self::TABLE, self::INDEX)) {
+            return;
+        }
+
+        Schema::table(self::TABLE, function (Blueprint $table): void {
+            $table->unique(['provider', 'external_id', 'recorded_at'], self::INDEX);
+        });
+    }
+
+    public function down(): void
+    {
+        // forward-only migration: rollback disabled to prevent data loss in production.
+        // Irreversible operation: schema/data rollback handled via forward fix migrations.
+    }
+
+    private function collapseIdentityDuplicates(): void
+    {
+        $groups = DB::table(self::TABLE)
+            ->select([
+                'provider',
+                'external_id',
+                'recorded_at',
+                DB::raw('MIN(id) as keep_id'),
+                DB::raw('COUNT(*) as dup_count'),
+            ])
+            ->groupBy('provider', 'external_id', 'recorded_at')
+            ->havingRaw('COUNT(*) > 1')
+            ->orderBy('provider')
+            ->orderBy('external_id')
+            ->orderBy('recorded_at')
+            ->get();
+
+        foreach ($groups as $group) {
+            $provider = trim((string) ($group->provider ?? ''));
+            $externalId = trim((string) ($group->external_id ?? ''));
+            $recordedAt = $group->recorded_at ?? null;
+            $keepId = (int) ($group->keep_id ?? 0);
+
+            if ($provider === '' || $externalId === '' || $recordedAt === null || $keepId <= 0) {
+                continue;
+            }
+
+            DB::table(self::TABLE)
+                ->where('provider', $provider)
+                ->where('external_id', $externalId)
+                ->where('recorded_at', $recordedAt)
+                ->where('id', '!=', $keepId)
+                ->delete();
+        }
+    }
+};

--- a/backend/routes/api.php
+++ b/backend/routes/api.php
@@ -147,7 +147,6 @@ Route::prefix("v0.2")->middleware([
 
     // 6.5) Lookups
     Route::get("/lookup/ticket/{code}", [LookupController::class, "lookupTicket"]);
-    Route::post("/lookup/order", [LookupController::class, "lookupOrder"]);
 
     // 7) Share click (public)
     // share_id now supports 32-hex legacy ids, so remove uuid middleware.
@@ -272,6 +271,7 @@ Route::prefix("v0.2")->middleware([
         Route::get("/attempts/{id}/share", [ShareController::class, "getShare"]);
 
         Route::post("/attempts/{attempt_id}/feedback", [ValidityFeedbackController::class, "store"]);
+        Route::post("/lookup/order", [LookupController::class, "lookupOrder"]);
         Route::post("/lookup/device", [LookupController::class, "lookupDevice"]);
 
     });

--- a/backend/tests/Feature/ErrorContractConsistencyTest.php
+++ b/backend/tests/Feature/ErrorContractConsistencyTest.php
@@ -47,8 +47,11 @@ final class ErrorContractConsistencyTest extends TestCase
     public function test_lookup_order_disabled_returns_unified_error_contract(): void
     {
         $this->setEnv('LOOKUP_ORDER', '0');
+        $token = $this->seedFmToken('anon_contract_lookup_order');
 
-        $response = $this->postJson('/api/v0.2/lookup/order', [
+        $response = $this->withHeaders([
+            'Authorization' => "Bearer {$token}",
+        ])->postJson('/api/v0.2/lookup/order', [
             'order_no' => 'ord_contract_disabled',
         ]);
 

--- a/backend/tests/Feature/FmTokenOrgOverrideIsolationTest.php
+++ b/backend/tests/Feature/FmTokenOrgOverrideIsolationTest.php
@@ -1,0 +1,109 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature;
+
+use App\Models\Attempt;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Str;
+use Tests\TestCase;
+
+final class FmTokenOrgOverrideIsolationTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_fm_token_org_cannot_be_overridden_by_header_org_id(): void
+    {
+        $userId = 9901;
+        $anonId = 'anon_token_org_override';
+        $this->seedUser($userId);
+        $token = $this->seedFmToken($userId, $anonId, 0);
+
+        $attemptOrg0 = $this->seedAttempt(0, $anonId, (string) $userId);
+        $attemptOrg1 = $this->seedAttempt(1, $anonId, (string) $userId);
+
+        $response = $this->withHeaders([
+            'Authorization' => "Bearer {$token}",
+            'X-Org-Id' => '1',
+        ])->getJson('/api/v0.2/me/attempts');
+
+        $response->assertStatus(200);
+        $response->assertJsonPath('ok', true);
+
+        $items = (array) $response->json('items', []);
+        $ids = array_map(
+            static fn (array $row): string => (string) ($row['attempt_id'] ?? ''),
+            $items
+        );
+
+        $this->assertContains($attemptOrg0, $ids);
+        $this->assertNotContains($attemptOrg1, $ids);
+    }
+
+    private function seedUser(int $id): void
+    {
+        DB::table('users')->insert([
+            'id' => $id,
+            'name' => "user_{$id}",
+            'email' => "user_{$id}@example.test",
+            'password' => bcrypt('secret'),
+            'created_at' => now(),
+            'updated_at' => now(),
+        ]);
+    }
+
+    private function seedFmToken(int $userId, string $anonId, int $orgId): string
+    {
+        $token = 'fm_' . (string) Str::uuid();
+
+        DB::table('fm_tokens')->insert([
+            'token' => $token,
+            'token_hash' => hash('sha256', $token),
+            'user_id' => $userId,
+            'anon_id' => $anonId,
+            'org_id' => $orgId,
+            'role' => 'public',
+            'expires_at' => now()->addHour(),
+            'created_at' => now(),
+            'updated_at' => now(),
+        ]);
+
+        return $token;
+    }
+
+    private function seedAttempt(int $orgId, string $anonId, string $userId): string
+    {
+        $attemptId = (string) Str::uuid();
+
+        Attempt::create([
+            'id' => $attemptId,
+            'ticket_code' => 'FMT-' . strtoupper(substr(str_replace('-', '', (string) Str::uuid()), 0, 8)),
+            'org_id' => $orgId,
+            'anon_id' => $anonId,
+            'user_id' => $userId,
+            'scale_code' => 'MBTI',
+            'scale_version' => 'v0.2',
+            'region' => 'CN_MAINLAND',
+            'locale' => 'zh-CN',
+            'question_count' => 144,
+            'answers_summary_json' => ['seed' => true],
+            'client_platform' => 'test',
+            'client_version' => '1.0.0',
+            'channel' => 'test',
+            'started_at' => now()->subMinutes(2),
+            'submitted_at' => now()->subMinute(),
+            'pack_id' => (string) config('content_packs.default_pack_id'),
+            'dir_version' => (string) config('content_packs.default_dir_version'),
+            'content_package_version' => 'v0.2.2',
+            'scoring_spec_version' => '2026.01',
+            'calculation_snapshot_json' => [
+                'stats' => ['score' => 42],
+                'norm' => ['version' => 'test'],
+            ],
+        ]);
+
+        return $attemptId;
+    }
+}

--- a/backend/tests/Feature/V0_2/InsightsAnonHeaderAuthTest.php
+++ b/backend/tests/Feature/V0_2/InsightsAnonHeaderAuthTest.php
@@ -41,19 +41,19 @@ final class InsightsAnonHeaderAuthTest extends TestCase
         ]);
 
         $this->getJson("/api/v0.2/insights/{$insightId}")
-            ->assertStatus(403)
+            ->assertStatus(404)
             ->assertJson([
                 'ok' => false,
-                'error_code' => 'FORBIDDEN',
+                'error_code' => 'NOT_FOUND',
             ]);
 
         $this->withHeaders([
             'X-FAP-Anon-Id' => 'anon_wrong',
         ])->getJson("/api/v0.2/insights/{$insightId}")
-            ->assertStatus(403)
+            ->assertStatus(404)
             ->assertJson([
                 'ok' => false,
-                'error_code' => 'FORBIDDEN',
+                'error_code' => 'NOT_FOUND',
             ]);
 
         $this->withHeaders([

--- a/backend/tests/Feature/V0_2/PaymentServiceOwnershipScopeTest.php
+++ b/backend/tests/Feature/V0_2/PaymentServiceOwnershipScopeTest.php
@@ -1,0 +1,83 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\V0_2;
+
+use App\Services\Payments\PaymentService;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+use Tests\TestCase;
+
+final class PaymentServiceOwnershipScopeTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_mark_paid_returns_not_found_for_non_owner_actor(): void
+    {
+        $this->seedSku(1990);
+
+        $order = app(PaymentService::class)->createOrder([
+            'user_id' => 'owner_user_1',
+            'item_sku' => 'MBTI_FULL',
+            'currency' => 'USD',
+        ]);
+
+        $orderId = (string) (($order['order']->id ?? '') ?: ($order['order']['id'] ?? ''));
+        $this->assertNotSame('', $orderId);
+
+        $result = app(PaymentService::class)->markPaid($orderId, 'other_user_2', null);
+
+        $this->assertFalse((bool) ($result['ok'] ?? true));
+        $this->assertSame(404, (int) ($result['status'] ?? 0));
+        $this->assertSame('ORDER_NOT_FOUND', (string) ($result['error_code'] ?? ''));
+    }
+
+    public function test_fulfill_returns_not_found_for_non_owner_actor(): void
+    {
+        $this->seedSku(1990);
+
+        $order = app(PaymentService::class)->createOrder([
+            'user_id' => 'owner_user_1',
+            'item_sku' => 'MBTI_FULL',
+            'currency' => 'USD',
+        ]);
+
+        $orderId = (string) (($order['order']->id ?? '') ?: ($order['order']['id'] ?? ''));
+        $this->assertNotSame('', $orderId);
+
+        $result = app(PaymentService::class)->fulfill($orderId, 'other_user_2', null);
+
+        $this->assertFalse((bool) ($result['ok'] ?? true));
+        $this->assertSame(404, (int) ($result['status'] ?? 0));
+        $this->assertSame('ORDER_NOT_FOUND', (string) ($result['error_code'] ?? ''));
+    }
+
+    private function seedSku(int $priceCents): void
+    {
+        $row = [
+            'sku' => 'MBTI_FULL',
+            'scale_code' => 'MBTI',
+            'kind' => 'report_unlock',
+            'unit_qty' => 1,
+            'benefit_code' => 'MBTI_REPORT_FULL',
+            'scope' => 'user',
+            'price_cents' => $priceCents,
+            'currency' => 'USD',
+            'is_active' => 1,
+            'meta_json' => null,
+            'created_at' => now(),
+            'updated_at' => now(),
+        ];
+
+        if (Schema::hasColumn('skus', 'org_id')) {
+            $row['org_id'] = 1;
+        }
+        if (Schema::hasColumn('skus', 'title')) {
+            $row['title'] = 'MBTI Full';
+        }
+
+        DB::table('skus')->updateOrInsert(['sku' => 'MBTI_FULL'], $row);
+    }
+}

--- a/backend/tests/Feature/V0_2/ProviderWebhookIdempotencyTamperTest.php
+++ b/backend/tests/Feature/V0_2/ProviderWebhookIdempotencyTamperTest.php
@@ -1,0 +1,89 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\V0_2;
+
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Testing\TestResponse;
+use Tests\TestCase;
+
+final class ProviderWebhookIdempotencyTamperTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_same_event_identity_with_different_payload_returns_conflict(): void
+    {
+        config([
+            'services.integrations.webhook_tolerance_seconds' => 300,
+            'services.integrations.providers.mock.webhook_secret' => 'mock_secret_tamper',
+        ]);
+
+        $eventId = 'evt_tamper_identity_1';
+        $recordedAt = '2026-02-07T00:00:00Z';
+
+        $first = $this->postSignedMockWebhook([
+            'event_id' => $eventId,
+            'external_user_id' => 'ext_tamper_1',
+            'recorded_at' => $recordedAt,
+            'samples' => [],
+        ], 'mock_secret_tamper');
+        $first->assertStatus(200);
+        $first->assertJsonPath('ok', true);
+
+        $second = $this->postSignedMockWebhook([
+            'event_id' => $eventId,
+            'external_user_id' => 'ext_tamper_1',
+            'recorded_at' => $recordedAt,
+            'samples' => [
+                [
+                    'domain' => 'sleep',
+                    'recorded_at' => '2026-02-06T23:59:00Z',
+                    'value' => ['minutes' => 421],
+                ],
+            ],
+        ], 'mock_secret_tamper');
+
+        $second->assertStatus(409);
+        $second->assertJsonPath('ok', false);
+        $second->assertJsonPath('error_code', 'IDEMPOTENCY_CONFLICT');
+
+        $this->assertSame(1, DB::table('idempotency_keys')
+            ->where('provider', 'mock')
+            ->where('external_id', $eventId)
+            ->count());
+    }
+
+    private function postSignedMockWebhook(array $payload, string $secret): TestResponse
+    {
+        $timestamp = time();
+        $raw = $this->encodePayload($payload);
+        $signature = hash_hmac('sha256', "{$timestamp}.{$raw}", $secret);
+
+        return $this->call(
+            'POST',
+            '/api/v0.2/webhooks/mock',
+            [],
+            [],
+            [],
+            [
+                'CONTENT_TYPE' => 'application/json',
+                'HTTP_ACCEPT' => 'application/json',
+                'HTTP_X_WEBHOOK_TIMESTAMP' => (string) $timestamp,
+                'HTTP_X_WEBHOOK_SIGNATURE' => $signature,
+            ],
+            $raw,
+        );
+    }
+
+    private function encodePayload(array $payload): string
+    {
+        $raw = json_encode($payload, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES);
+        if (!is_string($raw)) {
+            self::fail('json_encode payload failed.');
+        }
+
+        return $raw;
+    }
+}

--- a/backend/tests/Feature/V0_2/ShareSecurityTest.php
+++ b/backend/tests/Feature/V0_2/ShareSecurityTest.php
@@ -27,7 +27,7 @@ final class ShareSecurityTest extends TestCase
         $this->seedScaleRegistry($orgId, 'MBTI');
         $this->seedBenefitGrant($orgId, $attemptId, (string) $userA, $anonA);
 
-        $tokenA = $this->issueTokenForUser($userA);
+        $tokenA = $this->issueTokenForUser($userA, $orgId);
 
         $resp = $this->withHeaders($this->authHeaders($tokenA, $orgId))
             ->getJson('/api/v0.2/attempts/' . $attemptId . '/share');
@@ -48,7 +48,7 @@ final class ShareSecurityTest extends TestCase
         $attemptId = (string) Str::uuid();
         $this->seedAttemptAndResult($attemptId, $orgId, 'anon_b_' . Str::random(8), $userB);
 
-        $tokenA = $this->issueTokenForUser($userA);
+        $tokenA = $this->issueTokenForUser($userA, $orgId);
 
         $resp = $this->withHeaders($this->authHeaders($tokenA, $orgId))
             ->getJson('/api/v0.2/attempts/' . $attemptId . '/share');
@@ -66,7 +66,7 @@ final class ShareSecurityTest extends TestCase
         $attemptIdB = (string) Str::uuid();
         $this->seedAttemptAndResult($attemptIdB, $orgB, 'anon_cross_b_' . Str::random(8), $userB);
 
-        $tokenA = $this->issueTokenForUser($userA);
+        $tokenA = $this->issueTokenForUser($userA, $orgA);
 
         $resp = $this->withHeaders($this->authHeaders($tokenA, $orgA))
             ->getJson('/api/v0.2/attempts/' . $attemptIdB . '/share');
@@ -98,9 +98,11 @@ final class ShareSecurityTest extends TestCase
         ];
     }
 
-    private function issueTokenForUser(int $userId): string
+    private function issueTokenForUser(int $userId, int $orgId = 0): string
     {
-        $issued = app(FmTokenService::class)->issueForUser((string) $userId);
+        $issued = app(FmTokenService::class)->issueForUser((string) $userId, [
+            'org_id' => $orgId,
+        ]);
 
         return (string) ($issued['token'] ?? '');
     }


### PR DESCRIPTION


## Summary
This PR batches security hardening across authorization/IDOR/tenant isolation and payment webhook idempotency/signature validation.

1. Authorization / IDOR / tenant isolation
- Moved `POST /api/v0.2/lookup/order` into `FmTokenAuth`-gated routes.
- Enforced ownership in SQL (not post-check) for:
  - `lookup/device`
  - `lookup/order`
  - `v0.2 attempts/{id}/feedback`
  - `v0.2 insights/{id}` and `v0.2 insights/{id}/feedback`
  - `PaymentService::markPaid` / `PaymentService::fulfill`
- Blocked org override side-channel in token middleware:
  - `X-Org-Id` / query `org_id` can no longer override token-scoped org.
  - resolver now prefers trusted request attributes (`org_id` / `fm_org_id`).
- Unified unauthorized ownership misses to `404` where resource-existence leakage was possible.

2. Webhook signature hardening
- Removed legacy payload-only HMAC fallback in:
  - provider webhook controller (`v0.2 /webhooks/{provider}`)
  - billing gateway verifier
- Kept timestamped signature with tolerance window and constant-time compare.

3. Replay/idempotency/tamper protection
- Added identity unique index migration on idempotency keys:
  - unique `(provider, external_id, recorded_at)`
- Updated idempotency store to identity-first semantics with `insertOrIgnore`.
- Added hash mismatch detection:
  - same identity + different payload hash now returns `409 IDEMPOTENCY_CONFLICT`.
- Switched ingestion path to `recordFast` for safer concurrent behavior.

## Security Findings Addressed
1. Cross-tenant access via org header override on token-auth endpoints.
2. IDOR from unconstrained `lookup/order` and `lookup/device`.
3. Existence side-channel (`403` vs `404`) on insights/feedback ownership checks.
4. Legacy webhook signature fallback allowing replay without timestamp freshness.
5. Missing idempotency identity uniqueness and payload tamper conflict signaling.
6. Ownership checked after fetch in payment service (`markPaid`/`fulfill`) instead of query scope.

## Migrations
- Added: `backend/database/migrations/2026_02_13_020000_add_identity_unique_to_idempotency_keys.php`
  - Collapses duplicate identities before adding unique index.

## Regression Tests Added/Updated
- Added:
  - `backend/tests/Feature/FmTokenOrgOverrideIsolationTest.php`
  - `backend/tests/Feature/V0_2/ProviderWebhookIdempotencyTamperTest.php`
  - `backend/tests/Feature/V0_2/PaymentServiceOwnershipScopeTest.php`
- Updated:
  - `backend/tests/Feature/HighIdorOwnership404Test.php`
  - `backend/tests/Feature/V0_2/AttemptOrgIsolationTest.php`
  - `backend/tests/Feature/V0_2/InsightsAnonHeaderAuthTest.php`
  - `backend/tests/Feature/V0_2/ProviderWebhookSignatureTest.php`
  - `backend/tests/Feature/V0_3/BillingWebhookSignatureTest.php`
  - `backend/tests/Feature/ErrorContractConsistencyTest.php`

## Verification Run
- `php artisan route:list`
- `DB_CONNECTION=sqlite DB_DATABASE=/tmp/fap-audit-migrate.sqlite php artisan migrate --force`
- `php artisan test tests/Feature/FmTokenOrgOverrideIsolationTest.php tests/Feature/V0_2/AttemptOrgIsolationTest.php tests/Feature/V0_2/InsightsAnonHeaderAuthTest.php tests/Feature/ErrorContractConsistencyTest.php tests/Feature/HighIdorOwnership404Test.php tests/Feature/V0_2/ProviderWebhookSignatureTest.php tests/Feature/V0_2/ProviderWebhookIdempotencyTamperTest.php tests/Feature/V0_3/BillingWebhookSignatureTest.php tests/Feature/V0_2/PaymentServiceOwnershipScopeTest.php`
- `bash scripts/ci_verify_mbti.sh`
- curl smoke:
  - `GET /api/v0.2/health` -> 200
  - unauth `POST /api/v0.2/lookup/order` -> 401
