### PR TITLE
fix(security): harden validation, idor responses, and fix mysql selfcheck ownership 500

### DIFF
--- a/backend/app/Http/Controllers/API/V0_2/InsightsController.php
+++ b/backend/app/Http/Controllers/API/V0_2/InsightsController.php
@@ -234,29 +234,15 @@ class InsightsController extends Controller
             return null;
         }
 
-        return DB::table('ai_insights')
-            ->where('id', $id)
-            ->where(function ($q) use ($userId, $anonId): void {
-                $applied = false;
+        $query = DB::table('ai_insights')->where('id', $id);
+        if ($userId !== '') {
+            return $query
+                ->where('user_id', $userId)
+                ->first();
+        }
 
-                if ($userId !== '') {
-                    $q->where('user_id', $userId);
-                    $applied = true;
-                }
-
-                if ($anonId !== '') {
-                    if ($applied) {
-                        $q->orWhere('anon_id', $anonId);
-                    } else {
-                        $q->where('anon_id', $anonId);
-                        $applied = true;
-                    }
-                }
-
-                if (!$applied) {
-                    $q->whereRaw('1=0');
-                }
-            })
+        return $query
+            ->where('anon_id', $anonId)
             ->first();
     }
 


### PR DESCRIPTION
## Summary

This PR bundles a security hardening pass and a MySQL-specific fix for the failing test:

- `Tests\Feature\HighIdorOwnership404Test::test_anon_b_cannot_post_feedback_to_anon_a_attempt`

### Included fixes

1. Mass-assignment / validation / tampering hardening
- quantity upper bounds
- amount/credit overflow guards
- non-negative price checks
- webhook topup delta guardrails

2. Unauthorized side-channel hardening
- ownership-mismatch style responses aligned to `404/NOT_FOUND` where applicable
- removed resource-existence leaks via `403` in targeted flows

3. Error leakage and sensitive logging hardening
- removed raw exception message echoes in API responses
- expanded redaction coverage for sensitive log keys

4. MySQL selfcheck failure fix (this unblocks the reported CI failure)
- In `/backend/app/Http/Controllers/API/V0_2/ValidityFeedbackController.php`:
  - replaced `SchemaBaseline::hasColumn` checks with real `Schema::hasColumn` for `identities`/`attempts`
  - added `QueryException` fallback in ownership checks
- Reason:
  - `SchemaBaseline` can report optional columns as present when table-specific required columns are not declared.
  - On MySQL, querying non-existent `identities.attempt_id/anon_id` caused 500 instead of expected 404.

## Files touched (high level)

- `/backend/app/Http/Controllers/API/V0_2/ValidityFeedbackController.php`
- plus security hardening files in controllers/services/requests/redactor/tests

## Verification

- `php artisan route:list` ✅
- `php artisan migrate` ⚠️ blocked by production safeguard in local env
- `php artisan migrate --force` ⚠️ local MySQL credential mismatch in this workstation
- `php artisan test --filter='(HighIdorOwnership404Test|InsightsAnonHeaderAuthTest)'` ✅
- `bash backend/scripts/ci_verify_mbti.sh` ✅

Additional note:
- `phpunit.mysql.xml` cannot be fully executed in this local environment due local MySQL access (`root@localhost` denied), but the code path that caused the reported MySQL 500 has been directly fixed.
