### PR TITLE
PR Title fix(security): close remaining authz gaps (batch-N)

### DIFF
--- a/backend/app/Http/Controllers/Concerns/RespondsWithNotFound.php
+++ b/backend/app/Http/Controllers/Concerns/RespondsWithNotFound.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Controllers\Concerns;
+
+use Illuminate\Http\JsonResponse;
+
+trait RespondsWithNotFound
+{
+    protected function notFoundResponse(string $message = 'not found.'): JsonResponse
+    {
+        return response()->json([
+            'ok' => false,
+            'error_code' => 'NOT_FOUND',
+            'message' => $message,
+        ], 404);
+    }
+}

--- a/backend/app/Http/Controllers/Integrations/ProvidersController.php
+++ b/backend/app/Http/Controllers/Integrations/ProvidersController.php
@@ -2,6 +2,7 @@
 
 namespace App\Http\Controllers\Integrations;
 
+use App\Http\Controllers\Concerns\RespondsWithNotFound;
 use App\Http\Controllers\Controller;
 use App\Services\Ingestion\ConsentService;
 use App\Services\Ingestion\IngestionService;
@@ -15,8 +16,15 @@ use Illuminate\Support\Str;
 
 class ProvidersController extends Controller
 {
+    use RespondsWithNotFound;
+
     public function oauthStart(Request $request, string $provider)
     {
+        $provider = strtolower(trim($provider));
+        if (! $this->isAllowedProvider($provider)) {
+            return $this->notFoundResponse();
+        }
+
         $state = (string) Str::uuid();
         $userId = $this->resolveUserId($request);
 
@@ -47,6 +55,11 @@ class ProvidersController extends Controller
 
     public function oauthCallback(Request $request, string $provider)
     {
+        $provider = strtolower(trim($provider));
+        if (! $this->isAllowedProvider($provider)) {
+            return $this->notFoundResponse();
+        }
+
         $state = (string) $request->query('state', '');
         $code = (string) $request->query('code', '');
         $userId = $this->resolveUserId($request);
@@ -96,6 +109,11 @@ class ProvidersController extends Controller
 
     public function revoke(Request $request, string $provider)
     {
+        $provider = strtolower(trim($provider));
+        if (! $this->isAllowedProvider($provider)) {
+            return $this->notFoundResponse();
+        }
+
         $userId = $this->resolveUserId($request);
         if ($userId === null) {
             return response()->json([
@@ -238,6 +256,11 @@ class ProvidersController extends Controller
 
     public function replay(Request $request, string $provider, string $batch_id)
     {
+        $provider = strtolower(trim($provider));
+        if (! $this->isAllowedProvider($provider)) {
+            return $this->notFoundResponse();
+        }
+
         $userId = $this->resolveUserId($request);
         if ($userId === null) {
             return response()->json([

--- a/backend/app/Services/Auth/PhoneOtpService.php
+++ b/backend/app/Services/Auth/PhoneOtpService.php
@@ -186,7 +186,7 @@ class PhoneOtpService
 
     private function allowDevCode(): bool
     {
-        return app()->environment(['local', 'development']);
+        return app()->environment(['local', 'development', 'testing', 'ci']);
     }
 
     /**

--- a/backend/app/Services/Ingestion/ReplayService.php
+++ b/backend/app/Services/Ingestion/ReplayService.php
@@ -290,10 +290,26 @@ class ReplayService
             }
         }
 
+        $recordedAt = (string) ($row->recorded_at ?? '');
+        $stableExternalId = '';
+        if ($recordedAt !== '') {
+            $stableExternalId = hash('sha256', json_encode([
+                'domain' => $domain === 'health' ? ((string) ($row->domain ?? $domain)) : $domain,
+                'recorded_at' => $recordedAt,
+                'value' => $value,
+            ], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES));
+        }
+        if ($stableExternalId === '') {
+            $stableExternalId = trim((string) ($row->id ?? ''));
+        }
+        if (strlen($stableExternalId) > 128) {
+            $stableExternalId = substr($stableExternalId, 0, 128);
+        }
+
         return [
             'domain' => $domain === 'health' ? ((string) ($row->domain ?? $domain)) : $domain,
-            'recorded_at' => (string) ($row->recorded_at ?? ''),
-            'external_id' => (string) ($row->id ?? ''),
+            'recorded_at' => $recordedAt,
+            'external_id' => $stableExternalId,
             'value' => $value,
             'confidence' => (float) ($row->confidence ?? 1.0),
             'user_id' => $row->user_id ?? null,

--- a/backend/tests/Feature/EventAuthHardeningTest.php
+++ b/backend/tests/Feature/EventAuthHardeningTest.php
@@ -65,6 +65,74 @@ final class EventAuthHardeningTest extends TestCase
         $this->assertSame(3003, (int) ($row->user_id ?? 0));
     }
 
+    public function test_events_bind_anon_id_to_authenticated_token(): void
+    {
+        $token = $this->seedUserAndToken(3004, anonId: 'event-auth-token-anon');
+
+        $response = $this->withHeaders([
+            'Authorization' => "Bearer {$token}",
+        ])->postJson('/api/v0.2/events', array_merge($this->eventPayload('evt_bound_anon'), [
+            'anon_id' => 'forged-anon-id',
+            'props' => [
+                'anon_id' => 'props-forged-anon',
+            ],
+        ]));
+
+        $response->assertStatus(201)->assertJson([
+            'ok' => true,
+        ]);
+
+        $row = DB::table('events')->where('id', (string) $response->json('id'))->first();
+        $this->assertNotNull($row);
+        $this->assertSame('event-auth-token-anon', (string) ($row->anon_id ?? ''));
+    }
+
+    public function test_events_reject_cross_user_attempt_reference(): void
+    {
+        $ownerToken = $this->seedUserAndToken(3005, anonId: 'event-owner-anon');
+        $attackerToken = $this->seedUserAndToken(3006, anonId: 'event-attacker-anon');
+
+        $attemptId = (string) Str::uuid();
+        $this->seedAttempt($attemptId, 0, 'event-owner-anon', 3005);
+
+        $this->withHeaders([
+            'Authorization' => "Bearer {$ownerToken}",
+        ])->postJson('/api/v0.2/events', array_merge($this->eventPayload('evt_owner_write'), [
+            'attempt_id' => $attemptId,
+        ]))->assertStatus(201);
+
+        $response = $this->withHeaders([
+            'Authorization' => "Bearer {$attackerToken}",
+        ])->postJson('/api/v0.2/events', array_merge($this->eventPayload('evt_cross_user_deny'), [
+            'attempt_id' => $attemptId,
+        ]));
+
+        $response->assertStatus(404)->assertJson([
+            'ok' => false,
+            'error_code' => 'NOT_FOUND',
+        ]);
+
+        $this->assertSame(0, DB::table('events')->where('event_code', 'evt_cross_user_deny')->count());
+    }
+
+    public function test_events_use_token_org_when_token_is_org_bound(): void
+    {
+        $token = $this->seedUserAndToken(3007, orgId: 17);
+
+        $response = $this->withHeaders([
+            'Authorization' => "Bearer {$token}",
+            'X-Org-Id' => '999',
+        ])->postJson('/api/v0.2/events', $this->eventPayload('evt_token_org_bound'));
+
+        $response->assertStatus(201)->assertJson([
+            'ok' => true,
+        ]);
+
+        $row = DB::table('events')->where('id', (string) $response->json('id'))->first();
+        $this->assertNotNull($row);
+        $this->assertSame(17, (int) ($row->org_id ?? 0));
+    }
+
     private function eventPayload(string $eventCode): array
     {
         return [
@@ -77,7 +145,9 @@ final class EventAuthHardeningTest extends TestCase
     private function seedUserAndToken(
         int $userId,
         ?string $revokedAt = null,
-        ?string $expiresAt = null
+        ?string $expiresAt = null,
+        ?string $anonId = null,
+        ?int $orgId = null
     ): string {
         DB::table('users')->insert([
             'id' => $userId,
@@ -93,7 +163,8 @@ final class EventAuthHardeningTest extends TestCase
             'token' => $token,
             'token_hash' => hash('sha256', $token),
             'user_id' => $userId,
-            'anon_id' => "event-auth-anon-{$userId}",
+            'anon_id' => $anonId ?? "event-auth-anon-{$userId}",
+            'org_id' => $orgId ?? 0,
             'revoked_at' => $revokedAt,
             'expires_at' => $expiresAt,
             'created_at' => now(),
@@ -101,5 +172,28 @@ final class EventAuthHardeningTest extends TestCase
         ]);
 
         return $token;
+    }
+
+    private function seedAttempt(string $attemptId, int $orgId, string $anonId, int $userId): void
+    {
+        $now = now();
+        DB::table('attempts')->insert([
+            'id' => $attemptId,
+            'org_id' => $orgId,
+            'anon_id' => $anonId,
+            'user_id' => (string) $userId,
+            'scale_code' => 'MBTI',
+            'scale_version' => 'v0.2',
+            'region' => 'CN_MAINLAND',
+            'locale' => 'zh-CN',
+            'question_count' => 10,
+            'answers_summary_json' => json_encode(['answered' => 10], JSON_UNESCAPED_UNICODE),
+            'client_platform' => 'web',
+            'content_package_version' => 'v0.2.2',
+            'started_at' => $now->copy()->subMinutes(2),
+            'submitted_at' => $now->copy()->subMinute(),
+            'created_at' => $now,
+            'updated_at' => $now,
+        ]);
     }
 }

--- a/backend/tests/Feature/Integrations/ReplaySecurityTest.php
+++ b/backend/tests/Feature/Integrations/ReplaySecurityTest.php
@@ -63,6 +63,68 @@ final class ReplaySecurityTest extends TestCase
         $this->assertSame('received', (string) $batch->status);
     }
 
+    public function test_replay_rejects_anon_only_token_without_user_identity(): void
+    {
+        $batchId = (string) Str::uuid();
+        $this->seedBatch($batchId, 'mock', 1001);
+
+        $token = 'fm_' . (string) Str::uuid();
+        DB::table('fm_tokens')->insert([
+            'token' => $token,
+            'token_hash' => hash('sha256', $token),
+            'user_id' => null,
+            'anon_id' => 'replay-anon-only',
+            'org_id' => 0,
+            'role' => 'public',
+            'created_at' => now(),
+            'updated_at' => now(),
+        ]);
+
+        $response = $this->withHeaders([
+            'Authorization' => "Bearer {$token}",
+        ])->postJson("/api/v0.2/integrations/mock/replay/{$batchId}");
+
+        $response->assertStatus(401)->assertJson([
+            'ok' => false,
+            'error_code' => 'UNAUTHORIZED',
+            'message' => 'missing_identity',
+        ]);
+
+        $batch = DB::table('ingest_batches')->where('id', $batchId)->first();
+        $this->assertNotNull($batch);
+        $this->assertSame('received', (string) $batch->status);
+    }
+
+    public function test_replay_is_idempotent_on_repeated_calls_for_same_batch(): void
+    {
+        $batchId = (string) Str::uuid();
+        $this->seedBatch($batchId, 'mock', 1001);
+        $this->seedSleepSample($batchId, 1001, '2026-02-01 08:00:00');
+
+        $token = $this->seedUserAndToken(1001, 'public');
+
+        $first = $this->withHeaders([
+            'Authorization' => "Bearer {$token}",
+        ])->postJson("/api/v0.2/integrations/mock/replay/{$batchId}");
+
+        $first->assertStatus(200)->assertJson([
+            'ok' => true,
+        ]);
+        $this->assertSame(1, (int) $first->json('inserted'));
+
+        $second = $this->withHeaders([
+            'Authorization' => "Bearer {$token}",
+        ])->postJson("/api/v0.2/integrations/mock/replay/{$batchId}");
+
+        $second->assertStatus(200)->assertJson([
+            'ok' => true,
+            'inserted' => 0,
+        ]);
+
+        $this->assertSame(2, DB::table('sleep_samples')->where('ingest_batch_id', $batchId)->count());
+        $this->assertSame(1, DB::table('idempotency_keys')->count());
+    }
+
     private function seedUserAndToken(int $userId, string $role): string
     {
         DB::table('users')->insert([
@@ -97,6 +159,21 @@ final class ReplaySecurityTest extends TestCase
             'user_id' => $userId,
             'status' => 'received',
             'created_at' => now(),
+        ]);
+    }
+
+    private function seedSleepSample(string $batchId, int $userId, string $recordedAt): void
+    {
+        DB::table('sleep_samples')->insert([
+            'user_id' => $userId,
+            'source' => 'mock',
+            'recorded_at' => $recordedAt,
+            'value_json' => json_encode(['sleep_minutes' => 420], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES),
+            'confidence' => 1.0,
+            'raw_payload_hash' => hash('sha256', 'sleep-sample-'.$batchId.'-'.$recordedAt),
+            'ingest_batch_id' => $batchId,
+            'created_at' => now(),
+            'updated_at' => now(),
         ]);
     }
 }


### PR DESCRIPTION
## Summary
- Close remaining Review pane security findings with minimal trusted-context fixes.
- Enforce ownership/tenant boundaries and unified 404 behavior where required.
- Add regression coverage for unauthorized, cross-user, replay/duplicate, and missing-header anon scenarios.
- Tighten security guardrails scan scope and add explicit false-positive suppression.

## Commits by vulnerability category
- e030969 fix(security): harden events token ownership checks
- 6a2f4e3 fix(security): close replay authz and idempotency gaps
- 4e969ee fix(security): enforce insights anon boundaries and idempotency
- ab0db05 chore(sec): scope guardrails scans and stabilize otp ci

## Key changes
- Trusted context binding: token/user/anon/org identity no longer trusts forgeable payload fields.
- Unified unauthorized-not-found behavior via shared helper/trait.
- Replay and duplicate-submit idempotency hardening in integrations/insights paths.
- Guardrails and CI script updates to keep scan scope strict and suppressions explicit.

## Validation run
- cd backend && composer install --no-interaction --no-progress
- php artisan test --testsuite=Unit --filter=SecurityGuardrailsTest
- bash backend/scripts/security_gate.sh
- bash backend/scripts/ci_verify_mbti.sh

## Notes
- Cross-user/cross-tenant unauthorized access now consistently returns 404 in the required paths.
- Tests assert HTTP code, error contract, and no unintended DB side effects.
