### PR TITLE
fix(security): full audit and remediation for fap-api

### DIFF
--- a/backend/app/Http/Controllers/API/V0_3/Concerns/ResolvesAttemptOwnership.php
+++ b/backend/app/Http/Controllers/API/V0_3/Concerns/ResolvesAttemptOwnership.php
@@ -40,7 +40,7 @@ trait ResolvesAttemptOwnership
         ];
 
         foreach ($candidates as $candidate) {
-            $normalized = $this->normalizeString($candidate);
+            $normalized = $this->normalizeNumericString($candidate);
             if ($normalized !== null) {
                 return $normalized;
             }
@@ -54,8 +54,6 @@ trait ResolvesAttemptOwnership
         $candidates = [
             $request->attributes->get('anon_id'),
             $request->attributes->get('fm_anon_id'),
-            $request->header('X-Anon-Id'),
-            $request->header('X-Fm-Anon-Id'),
             app(OrgContext::class)->anonId(),
         ];
 
@@ -67,6 +65,20 @@ trait ResolvesAttemptOwnership
         }
 
         return null;
+    }
+
+    private function normalizeNumericString(mixed $candidate): ?string
+    {
+        if (!is_string($candidate) && !is_numeric($candidate)) {
+            return null;
+        }
+
+        $value = trim((string) $candidate);
+        if ($value === '' || preg_match('/^\d+$/', $value) !== 1) {
+            return null;
+        }
+
+        return $value;
     }
 
     private function normalizeString(mixed $candidate): ?string

--- a/backend/app/Http/Controllers/Webhooks/HandleProviderWebhook.php
+++ b/backend/app/Http/Controllers/Webhooks/HandleProviderWebhook.php
@@ -102,7 +102,7 @@ class HandleProviderWebhook extends Controller
 
         if ($secret === '') {
             $allowUnsigned = (bool) config('services.integrations.allow_unsigned_without_secret', false);
-            if ($allowUnsigned || app()->environment(['local', 'testing', 'ci'])) {
+            if ($allowUnsigned) {
                 return ['ok' => true, 'timestamp' => $timestamp];
             }
 

--- a/backend/app/Http/Middleware/ResolveOrgContext.php
+++ b/backend/app/Http/Middleware/ResolveOrgContext.php
@@ -29,6 +29,13 @@ class ResolveOrgContext
 
         $userId = $this->resolveUserId($request);
         $anonId = $this->resolveAnonId($request);
+        if ($anonId === null) {
+            $anonId = $this->resolveAnonIdFromToken($request);
+            if ($anonId !== null) {
+                $request->attributes->set('anon_id', $anonId);
+                $request->attributes->set('fm_anon_id', $anonId);
+            }
+        }
         $role = null;
 
         if ($orgId > 0) {
@@ -153,6 +160,21 @@ class ResolveOrgContext
         $role = trim((string) ($payload['role'] ?? ''));
 
         return $role !== '' ? $role : null;
+    }
+
+    private function resolveAnonIdFromToken(Request $request): ?string
+    {
+        $payload = $this->resolveFmTokenPayload($request);
+        if (!($payload['ok'] ?? false)) {
+            return null;
+        }
+
+        $anonId = trim((string) ($payload['anon_id'] ?? ''));
+        if ($anonId === '') {
+            return null;
+        }
+
+        return strlen($anonId) <= 128 ? $anonId : null;
     }
 
     /**

--- a/backend/app/Support/ApiExceptionRenderer.php
+++ b/backend/app/Support/ApiExceptionRenderer.php
@@ -55,17 +55,11 @@ final class ApiExceptionRenderer
         }
 
         if ($e instanceof \RuntimeException && trim($e->getMessage()) === 'CONTENT_PACK_ERROR') {
-            $reason = trim((string) ($e->getPrevious()?->getMessage() ?? ''));
-            $payload = [];
-            if ($reason !== '') {
-                $payload['details'] = ['reason' => $reason];
-            }
-
             return self::errorResponse(
                 500,
                 'CONTENT_PACK_ERROR',
                 'content pack resolve failed.',
-                (array) ($payload['details'] ?? []),
+                [],
                 $requestId
             );
         }

--- a/backend/scripts/pr17_verify_assessment_engine.sh
+++ b/backend/scripts/pr17_verify_assessment_engine.sh
@@ -227,12 +227,14 @@ simple_final="$(json_get "$simple_submit" "result.final_score" || true)"
 echo "[PR17] simple_score_demo result" | tee -a "$LOG_FILE"
 http_code=$(curl -sS -L -o "$simple_result" -w "%{http_code}" \
   -H "X-Anon-Id: ${SIMPLE_ANON_ID}" \
+  -H "Authorization: Bearer ${simple_token}" \
   "$API/api/v0.3/attempts/$simple_attempt_id/result" || true)
 [[ "$http_code" == "200" ]] || fail "simple result failed (http=$http_code)"
 
 echo "[PR17] simple_score_demo report" | tee -a "$LOG_FILE"
 http_code=$(curl -sS -L -o "$simple_report" -w "%{http_code}" \
   -H "X-Anon-Id: ${SIMPLE_ANON_ID}" \
+  -H "Authorization: Bearer ${simple_token}" \
   "$API/api/v0.3/attempts/$simple_attempt_id/report" || true)
 [[ "$http_code" == "200" ]] || fail "simple report failed (http=$http_code)"
 
@@ -286,12 +288,14 @@ raven_final="$(json_get "$raven_submit" "result.final_score" || true)"
 echo "[PR17] iq_raven result" | tee -a "$LOG_FILE"
 http_code=$(curl -sS -L -o "$raven_result" -w "%{http_code}" \
   -H "X-Anon-Id: ${RAVEN_ANON_ID}" \
+  -H "Authorization: Bearer ${raven_token}" \
   "$API/api/v0.3/attempts/$raven_attempt_id/result" || true)
 [[ "$http_code" == "200" ]] || fail "raven result failed (http=$http_code)"
 
 echo "[PR17] iq_raven report" | tee -a "$LOG_FILE"
 http_code=$(curl -sS -L -o "$raven_report" -w "%{http_code}" \
   -H "X-Anon-Id: ${RAVEN_ANON_ID}" \
+  -H "Authorization: Bearer ${raven_token}" \
   "$API/api/v0.3/attempts/$raven_attempt_id/report" || true)
 [[ "$http_code" == "200" ]] || fail "raven report failed (http=$http_code)"
 

--- a/backend/scripts/pr20_verify_report_paywall.sh
+++ b/backend/scripts/pr20_verify_report_paywall.sh
@@ -304,7 +304,7 @@ if [ "${http_code:-000}" != "200" ]; then
 fi
 
 # 未购 report
-curl_json GET "$API/api/v0.3/attempts/${attempt_id}/report" "" "$ART_DIR/curl_report_unpaid.json" "" || fail "fetch unpaid report failed"
+curl_json GET "$API/api/v0.3/attempts/${attempt_id}/report" "" "$ART_DIR/curl_report_unpaid.json" "$ANON_TOKEN" || fail "fetch unpaid report failed"
 
 # ------------------------
 # order + webhook -> entitlement + snapshot
@@ -345,12 +345,12 @@ http_code="$(post_billing_webhook "$WEBHOOK_PAYLOAD" "$ART_DIR/curl_webhook.json
 [ "${http_code:-000}" = "200" ] || fail "webhook failed (http=${http_code:-000})"
 
 # 已购 report（读 snapshot）
-curl_json GET "$API/api/v0.3/attempts/${attempt_id}/report" "" "$ART_DIR/curl_report_paid.json" "" || fail "fetch paid report failed"
+curl_json GET "$API/api/v0.3/attempts/${attempt_id}/report" "" "$ART_DIR/curl_report_paid.json" "$ANON_TOKEN" || fail "fetch paid report failed"
 
 # paid report must remain identical after registry update (snapshot)
 php artisan tinker --execute="\\Illuminate\\Support\\Facades\\DB::table('scales_registry')->where('org_id',0)->where('code','MBTI')->update(['default_dir_version'=>'MBTI-CN-v0.2.1-NOTEXIST','updated_at'=>now()]);" >/dev/null
 
-curl_json GET "$API/api/v0.3/attempts/${attempt_id}/report" "" "$ART_DIR/curl_report_paid_after_update.json" "" || fail "fetch paid report after update failed"
+curl_json GET "$API/api/v0.3/attempts/${attempt_id}/report" "" "$ART_DIR/curl_report_paid_after_update.json" "$ANON_TOKEN" || fail "fetch paid report after update failed"
 
 diff_result="diff=0"
 if ! diff -q "$ART_DIR/curl_report_paid.json" "$ART_DIR/curl_report_paid_after_update.json" >/dev/null 2>&1; then

--- a/backend/tests/Feature/FmTokenOptionalAuthMiddlewareTest.php
+++ b/backend/tests/Feature/FmTokenOptionalAuthMiddlewareTest.php
@@ -1,0 +1,65 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature;
+
+use App\Http\Middleware\FmTokenOptionalAuth;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Str;
+use Tests\TestCase;
+
+final class FmTokenOptionalAuthMiddlewareTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_revoked_token_is_rejected(): void
+    {
+        $token = 'fm_'.(string) Str::uuid();
+        DB::table('fm_tokens')->insert([
+            'token' => $token,
+            'token_hash' => hash('sha256', $token),
+            'user_id' => '9001',
+            'anon_id' => 'anon-9001',
+            'org_id' => 0,
+            'role' => 'public',
+            'revoked_at' => now()->subMinute(),
+            'expires_at' => now()->addDay(),
+            'created_at' => now(),
+            'updated_at' => now(),
+        ]);
+
+        $request = Request::create('/_security/optional-auth', 'GET');
+        $request->headers->set('Authorization', "Bearer {$token}");
+
+        $response = (new FmTokenOptionalAuth())->handle($request, static fn () => response()->json(['ok' => true]));
+
+        $this->assertSame(401, $response->getStatusCode());
+    }
+
+    public function test_expired_token_is_rejected(): void
+    {
+        $token = 'fm_'.(string) Str::uuid();
+        DB::table('fm_tokens')->insert([
+            'token' => $token,
+            'token_hash' => hash('sha256', $token),
+            'user_id' => '9002',
+            'anon_id' => 'anon-9002',
+            'org_id' => 0,
+            'role' => 'public',
+            'revoked_at' => null,
+            'expires_at' => now()->subMinute(),
+            'created_at' => now(),
+            'updated_at' => now(),
+        ]);
+
+        $request = Request::create('/_security/optional-auth', 'GET');
+        $request->headers->set('Authorization', "Bearer {$token}");
+
+        $response = (new FmTokenOptionalAuth())->handle($request, static fn () => response()->json(['ok' => true]));
+
+        $this->assertSame(401, $response->getStatusCode());
+    }
+}

--- a/backend/tests/Feature/HighIdorOwnership404Test.php
+++ b/backend/tests/Feature/HighIdorOwnership404Test.php
@@ -196,6 +196,20 @@ class HighIdorOwnership404Test extends TestCase
             ->assertStatus(404);
     }
 
+    public function test_header_only_anon_identity_cannot_read_v03_attempt_without_token_binding(): void
+    {
+        $this->seedScales();
+        $attemptId = $this->createSubmittedAttemptForAnonA();
+
+        $this->withHeaders(['X-Anon-Id' => self::ANON_A])
+            ->getJson("/api/v0.3/attempts/{$attemptId}/result")
+            ->assertStatus(404);
+
+        $this->withHeaders(['X-Anon-Id' => self::ANON_A])
+            ->getJson("/api/v0.3/attempts/{$attemptId}/report")
+            ->assertStatus(404);
+    }
+
     public function test_anon_b_cannot_get_anon_a_order(): void
     {
         $orderNo = 'ord_pr60_' . Str::lower(Str::random(10));

--- a/backend/tests/Feature/V0_3/AttemptContentPackErrorTest.php
+++ b/backend/tests/Feature/V0_3/AttemptContentPackErrorTest.php
@@ -39,6 +39,7 @@ final class AttemptContentPackErrorTest extends TestCase
 
         $response->assertStatus(500);
         $response->assertJsonPath('error_code', 'CONTENT_PACK_ERROR');
+        $response->assertJsonMissingPath('details.reason');
 
         Log::shouldHaveReceived('error')
             ->atLeast()

--- a/backend/tests/Feature/V0_3/AttemptsStartSubmitTest.php
+++ b/backend/tests/Feature/V0_3/AttemptsStartSubmitTest.php
@@ -84,6 +84,7 @@ class AttemptsStartSubmitTest extends TestCase
 
         $result = $this->withHeaders([
             'X-Anon-Id' => $anonId,
+            'Authorization' => 'Bearer ' . $anonToken,
         ])->getJson("/api/v0.3/attempts/{$attemptId}/result");
         $result->assertStatus(200);
         $this->assertSame(15, (int) $result->json('result.raw_score'));
@@ -140,6 +141,7 @@ class AttemptsStartSubmitTest extends TestCase
     public function test_mbti_report_locked_true_without_entitlement(): void
     {
         $this->seedScales();
+        $anonToken = $this->issueAnonToken('anon_test');
         $attemptId = (string) Str::uuid();
         \App\Models\Attempt::create([
             'id' => $attemptId,
@@ -220,6 +222,7 @@ class AttemptsStartSubmitTest extends TestCase
 
         $resultResp = $this->withHeaders([
             'X-Anon-Id' => 'anon_test',
+            'Authorization' => 'Bearer ' . $anonToken,
         ])->getJson("/api/v0.3/attempts/{$attemptId}/result");
 
         $resultResp->assertStatus(200);
@@ -230,6 +233,7 @@ class AttemptsStartSubmitTest extends TestCase
 
         $report = $this->withHeaders([
             'X-Anon-Id' => 'anon_test',
+            'Authorization' => 'Bearer ' . $anonToken,
         ])->getJson("/api/v0.3/attempts/{$attemptId}/report");
         $report->assertStatus(200);
         $report->assertJson([


### PR DESCRIPTION
PR Body
## Summary
This PR delivers a full security remediation pass for `fap-api` based on the recent end-to-end audit across API routes, middleware, services, runtime error contract, and guardrail automation.

### Audit Scope
- Code surface: controllers, services, routes, middleware, security middleware.
- Dependency surface: Composer lockfiles (`/composer.lock`, `/backend/composer.lock`).
- Runtime surface: token lifecycle checks, webhook signature trust model, ownership resolution boundary, error contract leakage.

## Major Fixes
1. Prevented public overwrite of existing v0.2 attempts (`LegacyMbtiAttemptLifecycleService`).
2. Removed webhook env fail-open unsigned bypass (`HandleProviderWebhook`).
3. Hardened optional token validation with token_hash + revoked/expired checks (`FmTokenOptionalAuth`).
4. Removed v0.3 anon header trust for ownership; hydrate anon from validated token (`ResolvesAttemptOwnership`, `ResolveOrgContext`).
5. Removed content-pack internal reason leakage in API response (`ApiExceptionRenderer`).
6. Expanded security automation checks (`security_gate.sh`) and unit guardrails (`SecurityGuardrailsTest`).

## Regression Tests
- Added `FmTokenOptionalAuthMiddlewareTest` (revoked/expired token rejection).
- Added webhook unsigned-without-secret rejection test.
- Added non-leak assertion for content pack error details.
- Added header-only anon identity denial test for v0.3 attempt reads.
- Updated v0.3 read/report tests to token-bound identity.

## Dependency Audit Result
- Root `composer audit`: `No packages - skipping audit.`
- Backend `composer audit --format=json`: `advisories: []`, `abandoned: []`
- No `package-lock.json` / `pnpm-lock.yaml` / `yarn.lock` found (npm/pnpm/yarn audit not applicable).

## Verification
- `cd backend && composer install --no-interaction --no-progress`
- `cd backend && php artisan test --testsuite=Unit --filter=SecurityGuardrailsTest`
- `bash backend/scripts/security_gate.sh`
- `cd backend && php artisan route:list --json`
