### PR TITLE
fix(release): enforce stop-ship release hygiene gate

### DIFF
--- a/.github/workflows/release-hygiene-gate.yml
+++ b/.github/workflows/release-hygiene-gate.yml
@@ -1,16 +1,16 @@
-name: Release Artifact
+name: release-hygiene-gate
 
 on:
-  workflow_dispatch:
+  pull_request:
+    branches: ["main"]
   push:
     branches: ["main"]
-    tags: ["v*", "release-*"]
 
 permissions:
   contents: read
 
 jobs:
-  release-artifact:
+  release-hygiene-gate:
     runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:
@@ -20,7 +20,14 @@ jobs:
       - name: Build release package
         run: bash scripts/release_pack.sh
 
-      - name: Audit smoke evidence
+      - name: Unzip package to fixed audit path
+        run: |
+          set -euo pipefail
+          rm -rf ./_audit/fap-api-0212-5
+          mkdir -p ./_audit/fap-api-0212-5
+          unzip -q dist/fap-api-release.zip -d ./_audit/fap-api-0212-5
+
+      - name: Print audit evidence
         run: |
           set -euo pipefail
           mkdir -p ./_audit
@@ -29,10 +36,11 @@ jobs:
       - name: Enforce release hygiene gate
         run: bash scripts/release_hygiene_gate.sh ./_audit/fap-api-0212-5/
 
-      - name: Upload trusted artifact
+      - name: Upload release package and audit log
+        if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: fap-api-release
+          name: release-hygiene-evidence
           path: |
             dist/fap-api-release.zip
             _audit/audit_smoke.log

--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,12 @@ backend/storage/logs/
 backend/storage/framework/
 backend/storage/app/private/reports/
 backend/storage/app/archives/
+
+# SEC/SRE-000 release package hygiene
+dist/
+_audit/
+.release_staging/
+.env
+.env.*
+**/.DS_Store
+**/__MACOSX/

--- a/Makefile
+++ b/Makefile
@@ -28,15 +28,16 @@ selfcheck-mysql:
 .PHONY: release release\:source-clean release\:verify
 
 release\:source-clean:
-	bash scripts/release/export_source_clean.sh
+	bash scripts/release_pack.sh
 
 release\:verify:
-	bash scripts/release/verify_source_zip_clean.sh dist/source_clean.zip
+	bash scripts/audit_smoke.sh dist/fap-api-release.zip
+	bash scripts/release_hygiene_gate.sh ./_audit/fap-api-0212-5/
 
 release:
 	@$(MAKE) release:source-clean
 	@$(MAKE) release:verify
-	@echo "[release] artifact=dist/source_clean.zip"
+	@echo "[release] artifact=dist/fap-api-release.zip"
 	@echo "[release] commit_sha=$$(git rev-parse --short=12 HEAD)"
 	@echo "[release] generated_at_utc=$$(date -u +%Y-%m-%dT%H:%M:%SZ)"
 	@echo "[release] build_host=$$(uname -srm)"

--- a/README_DEPLOY.md
+++ b/README_DEPLOY.md
@@ -1,0 +1,67 @@
+# README_DEPLOY
+
+## 1) 唯一交付包
+
+唯一允许产物：`dist/fap-api-release.zip`
+
+生成命令：
+
+```bash
+bash scripts/release_pack.sh
+```
+
+审计命令：
+
+```bash
+bash scripts/audit_smoke.sh dist/fap-api-release.zip
+bash scripts/release_hygiene_gate.sh ./_audit/fap-api-0212-5/
+```
+
+## 2) 交付包内容边界
+
+交付包根目录固定为：
+
+- `backend/`
+- `scripts/`
+- `docs/`
+- `README_DEPLOY.md`
+
+不包含：
+
+- `.env/.env.*`（`backend/.env.example` 允许）
+- `.git/`
+- `vendor/`
+- `node_modules/`
+- `backend/storage/logs/`
+- `backend/artifacts/`
+- `*.sqlite*`
+- `backend/storage/app/private/reports/`
+- `__MACOSX/`
+- `.DS_Store`
+
+## 3) 部署最短路径（不依赖本地 .env，不打包 vendor）
+
+```bash
+unzip -q dist/fap-api-release.zip -d /opt/fap-api-release
+cd /opt/fap-api-release/backend
+
+cp .env.example .env
+# 通过密钥系统注入生产变量（禁止提交真实密钥）
+# 例如：DB_*, APP_KEY, STRIPE_WEBHOOK_SECRET, FAP_ADMIN_TOKEN ...
+
+composer install --no-dev --optimize-autoloader
+php artisan migrate --force
+php artisan config:cache
+php artisan route:cache
+```
+
+说明：
+
+- 交付包不含 `vendor`，必须在部署环境执行 `composer install`。
+- 交付包不依赖本地开发机 `.env`。
+
+## 4) 回滚
+
+1. 使用上一个可用 `fap-api-release.zip`。
+2. 解压后按同样部署步骤执行。
+3. 通过包内 `docs/release/RELEASE_MANIFEST.json` 核对 `commit_sha` 与构建时间。

--- a/scripts/audit_smoke.sh
+++ b/scripts/audit_smoke.sh
@@ -1,0 +1,128 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(git rev-parse --show-toplevel)"
+AUDIT_ROOT_REL="./_audit/fap-api-0212-5"
+AUDIT_ROOT_ABS="${ROOT}/_audit/fap-api-0212-5"
+
+usage() {
+  cat <<'USAGE'
+Usage:
+  bash scripts/audit_smoke.sh dist/fap-api-release.zip
+  bash scripts/audit_smoke.sh ./_audit/fap-api-0212-5/
+USAGE
+}
+
+to_audit_rel() {
+  local abs="$1"
+  local rel="${abs#${AUDIT_ROOT_ABS}/}"
+  if [[ "$abs" == "$AUDIT_ROOT_ABS" ]]; then
+    echo "${AUDIT_ROOT_REL}/"
+  else
+    echo "${AUDIT_ROOT_REL}/${rel}"
+  fi
+}
+
+prepare_from_zip() {
+  local zip_path="$1"
+  [[ -f "$zip_path" ]] || { echo "[FAIL] zip not found: $zip_path" >&2; exit 1; }
+
+  rm -rf "$AUDIT_ROOT_ABS"
+  mkdir -p "$AUDIT_ROOT_ABS"
+  unzip -q "$zip_path" -d "$AUDIT_ROOT_ABS"
+}
+
+prepare_from_dir() {
+  local src_dir="$1"
+  [[ -d "$src_dir" ]] || { echo "[FAIL] dir not found: $src_dir" >&2; exit 1; }
+
+  local src_abs
+  src_abs="$(cd "$src_dir" && pwd)"
+
+  if [[ "$src_abs" == "$AUDIT_ROOT_ABS" ]]; then
+    return
+  fi
+
+  rm -rf "$AUDIT_ROOT_ABS"
+  mkdir -p "$AUDIT_ROOT_ABS"
+  cp -a "${src_abs}/." "$AUDIT_ROOT_ABS/"
+}
+
+INPUT="${1:-}"
+[[ -n "$INPUT" ]] || { usage; exit 2; }
+
+if [[ -f "$INPUT" ]]; then
+  prepare_from_zip "$INPUT"
+elif [[ -d "$INPUT" ]]; then
+  prepare_from_dir "$INPUT"
+else
+  echo "[FAIL] input not found: $INPUT" >&2
+  usage
+  exit 2
+fi
+
+echo "[AUDIT] root=${AUDIT_ROOT_REL}/"
+
+# 证据 1：目录存在 + api.php 存在
+if [[ -f "${AUDIT_ROOT_ABS}/backend/routes/api.php" ]]; then
+  echo "[EVIDENCE-1] EXISTS path=${AUDIT_ROOT_REL}/backend/routes/api.php"
+else
+  echo "[EVIDENCE-1] MISSING path=${AUDIT_ROOT_REL}/backend/routes/api.php"
+fi
+
+# 证据 2：核心目录存在性
+for p in backend/app backend/routes backend/config backend/database/migrations; do
+  if [[ -e "${AUDIT_ROOT_ABS}/${p}" ]]; then
+    echo "[EVIDENCE-2] EXISTS path=${AUDIT_ROOT_REL}/${p}"
+  else
+    echo "[EVIDENCE-2] MISSING path=${AUDIT_ROOT_REL}/${p}"
+  fi
+done
+
+# 证据 3：敏感/污染命中列表
+HITS_FILE="$(mktemp)"
+trap 'rm -f "$HITS_FILE"' EXIT
+
+while IFS= read -r hit; do
+  [[ -n "$hit" ]] && echo "$hit" >> "$HITS_FILE"
+done < <(find "$AUDIT_ROOT_ABS" -type f \( -name '.env' -o -name '.env.*' \) ! -name '.env.example' -print)
+
+while IFS= read -r hit; do
+  [[ -n "$hit" ]] && echo "$hit" >> "$HITS_FILE"
+done < <(find "$AUDIT_ROOT_ABS" -type d -name '.git' -print)
+
+for p in \
+  "${AUDIT_ROOT_ABS}/vendor" \
+  "${AUDIT_ROOT_ABS}/backend/vendor" \
+  "${AUDIT_ROOT_ABS}/node_modules" \
+  "${AUDIT_ROOT_ABS}/backend/node_modules" \
+  "${AUDIT_ROOT_ABS}/backend/storage/logs" \
+  "${AUDIT_ROOT_ABS}/storage/logs" \
+  "${AUDIT_ROOT_ABS}/backend/artifacts" \
+  "${AUDIT_ROOT_ABS}/artifacts"
+do
+  [[ -e "$p" ]] && echo "$p" >> "$HITS_FILE"
+done
+
+while IFS= read -r hit; do
+  [[ -n "$hit" ]] && echo "$hit" >> "$HITS_FILE"
+done < <(find "$AUDIT_ROOT_ABS" -type f -name '*.sqlite*' -print)
+
+while IFS= read -r hit; do
+  [[ -n "$hit" ]] && echo "$hit" >> "$HITS_FILE"
+done < <(find "$AUDIT_ROOT_ABS" -type d -name '__MACOSX' -print)
+
+while IFS= read -r hit; do
+  [[ -n "$hit" ]] && echo "$hit" >> "$HITS_FILE"
+done < <(find "$AUDIT_ROOT_ABS" -type f -name '.DS_Store' -print)
+
+if [[ -s "$HITS_FILE" ]]; then
+  sort -u "$HITS_FILE" -o "$HITS_FILE"
+  COUNT="$(wc -l < "$HITS_FILE" | tr -d ' ')"
+  echo "[EVIDENCE-3] HIT_COUNT=${COUNT}"
+  while IFS= read -r hit; do
+    echo "[EVIDENCE-3] HIT path=$(to_audit_rel "$hit")"
+  done < "$HITS_FILE"
+else
+  echo "[EVIDENCE-3] HIT_COUNT=0"
+fi

--- a/scripts/package_release.sh
+++ b/scripts/package_release.sh
@@ -4,8 +4,6 @@ set -euo pipefail
 ROOT="$(git rev-parse --show-toplevel)"
 cd "$ROOT"
 
-echo "[deprecated] scripts/package_release.sh delegates to SEC-001 flow"
-bash scripts/security/assert_no_tracked_sensitive_files.sh
-bash scripts/release/export_source_zip.sh
-bash scripts/release/verify_source_zip_clean.sh dist/fap-api-source.zip
-echo "[package_release] dist/fap-api-source.zip"
+echo "[compat] scripts/package_release.sh delegates to scripts/release_pack.sh"
+bash scripts/release_pack.sh
+echo "[package_release] dist/fap-api-release.zip"

--- a/scripts/release_hygiene_gate.sh
+++ b/scripts/release_hygiene_gate.sh
@@ -1,0 +1,95 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+TARGET_RAW="${1:-./_audit/fap-api-0212-5/}"
+[[ -d "$TARGET_RAW" ]] || { echo "[FAIL] reason=target_not_found path=${TARGET_RAW}" >&2; exit 1; }
+
+TARGET="$(cd "$TARGET_RAW" && pwd)"
+FAIL_COUNT=0
+
+fail() {
+  local reason="$1"
+  local path="$2"
+  echo "[FAIL] reason=${reason} path=${path}"
+  FAIL_COUNT=$((FAIL_COUNT + 1))
+}
+
+to_rel() {
+  local abs="$1"
+  local rel="${abs#${TARGET}/}"
+  if [[ "$abs" == "$TARGET" ]]; then
+    echo "./"
+  else
+    echo "./${rel}"
+  fi
+}
+
+# 必须存在
+[[ -f "${TARGET}/backend/routes/api.php" ]] || fail "missing_required" "./backend/routes/api.php"
+[[ -d "${TARGET}/backend/app" ]] || fail "missing_required" "./backend/app"
+[[ -d "${TARGET}/backend/config" ]] || fail "missing_required" "./backend/config"
+[[ -d "${TARGET}/backend/database/migrations" ]] || fail "missing_required" "./backend/database/migrations"
+
+# 根结构严格唯一：backend/ + scripts/ + docs/ + README_DEPLOY.md
+for req in backend scripts docs; do
+  [[ -d "${TARGET}/${req}" ]] || fail "missing_required_root_dir" "./${req}"
+done
+[[ -f "${TARGET}/README_DEPLOY.md" ]] || fail "missing_required_root_file" "./README_DEPLOY.md"
+
+while IFS= read -r entry; do
+  base="$(basename "$entry")"
+  case "$base" in
+    backend|scripts|docs|README_DEPLOY.md) ;;
+    *) fail "unexpected_root_entry" "./${base}" ;;
+  esac
+done < <(find "$TARGET" -mindepth 1 -maxdepth 1 -print)
+
+# 必须不存在：.env / .env.*（允许 .env.example）
+while IFS= read -r -d '' hit; do
+  fail "forbidden_env_file" "$(to_rel "$hit")"
+done < <(find "$TARGET" -type f \( -name '.env' -o -name '.env.*' \) ! -name '.env.example' -print0)
+
+# 必须不存在：.git
+while IFS= read -r -d '' hit; do
+  fail "forbidden_git_dir" "$(to_rel "$hit")"
+done < <(find "$TARGET" -type d -name '.git' -print0)
+
+# 必须不存在：vendor / node_modules
+for p in \
+  "${TARGET}/vendor" \
+  "${TARGET}/backend/vendor" \
+  "${TARGET}/node_modules" \
+  "${TARGET}/backend/node_modules"
+do
+  [[ -e "$p" ]] && fail "forbidden_dependency_dir" "$(to_rel "$p")"
+done
+
+# 必须不存在：runtime/产物目录
+for p in \
+  "${TARGET}/backend/storage/logs" \
+  "${TARGET}/backend/artifacts" \
+  "${TARGET}/backend/storage/app/private/reports" \
+  "${TARGET}/backend/storage/app/archives"
+do
+  [[ -e "$p" ]] && fail "forbidden_runtime_dir" "$(to_rel "$p")"
+done
+
+# 必须不存在：sqlite
+while IFS= read -r -d '' hit; do
+  fail "forbidden_sqlite_file" "$(to_rel "$hit")"
+done < <(find "$TARGET" -type f -name '*.sqlite*' -print0)
+
+# 必须不存在：macOS 污染
+while IFS= read -r -d '' hit; do
+  fail "forbidden_macosx_dir" "$(to_rel "$hit")"
+done < <(find "$TARGET" -type d -name '__MACOSX' -print0)
+
+while IFS= read -r -d '' hit; do
+  fail "forbidden_ds_store" "$(to_rel "$hit")"
+done < <(find "$TARGET" -type f -name '.DS_Store' -print0)
+
+if [[ "$FAIL_COUNT" -gt 0 ]]; then
+  exit 1
+fi
+
+echo "[OK] release hygiene gate passed"

--- a/scripts/release_pack.sh
+++ b/scripts/release_pack.sh
@@ -1,0 +1,108 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+RELEASE_PACK_VERSION=1
+
+ROOT="$(git rev-parse --show-toplevel)"
+STAGING_DIR="${ROOT}/.release_staging"
+DIST_DIR="${ROOT}/dist"
+OUT_ZIP="${DIST_DIR}/fap-api-release.zip"
+MANIFEST_DIR="${STAGING_DIR}/docs/release"
+MANIFEST_FILE="${MANIFEST_DIR}/RELEASE_MANIFEST.json"
+
+fail() {
+  echo "[FAIL] $*" >&2
+  exit 1
+}
+
+need_cmd() {
+  command -v "$1" >/dev/null 2>&1 || fail "missing command: $1"
+}
+
+need_cmd git
+need_cmd zip
+need_cmd unzip
+need_cmd find
+
+cd "$ROOT"
+
+# 强入口存在性校验（硬失败）
+[[ -f "${ROOT}/backend/routes/api.php" ]] || fail "required entry missing: backend/routes/api.php"
+
+# 白名单来源必须存在（禁止静默跳过）
+for src in backend scripts docs README_DEPLOY.md backend/.env.example; do
+  [[ -e "${ROOT}/${src}" ]] || fail "whitelist source missing: ${src}"
+done
+
+rm -rf "$STAGING_DIR"
+mkdir -p "$STAGING_DIR" "$DIST_DIR"
+
+# 白名单复制
+cp -a "${ROOT}/backend" "$STAGING_DIR/backend"
+cp -a "${ROOT}/scripts" "$STAGING_DIR/scripts"
+cp -a "${ROOT}/docs" "$STAGING_DIR/docs"
+cp -a "${ROOT}/README_DEPLOY.md" "$STAGING_DIR/README_DEPLOY.md"
+
+# 黑名单二次清扫（允许 .env.example）
+while IFS= read -r -d '' f; do
+  base="$(basename "$f")"
+  [[ "$base" == ".env.example" ]] && continue
+  rm -f "$f"
+done < <(find "$STAGING_DIR" -type f \( -name '.env' -o -name '.env.*' \) -print0)
+
+rm -rf "$STAGING_DIR/.git" "$STAGING_DIR/vendor" "$STAGING_DIR/node_modules"
+rm -rf "$STAGING_DIR/backend/vendor" "$STAGING_DIR/backend/node_modules"
+rm -rf "$STAGING_DIR/backend/storage/logs" "$STAGING_DIR/backend/artifacts"
+rm -rf "$STAGING_DIR/backend/storage/app/private/reports" "$STAGING_DIR/backend/storage/app/archives"
+
+find "$STAGING_DIR" -type f -name '*.sqlite*' -delete
+find "$STAGING_DIR" -type f -name '.DS_Store' -delete
+find "$STAGING_DIR" -type d -name '__MACOSX' -prune -exec rm -rf {} +
+
+# 根目录结构固定校验
+for d in backend scripts docs; do
+  [[ -d "${STAGING_DIR}/${d}" ]] || fail "missing root dir in staging: ${d}"
+done
+[[ -f "${STAGING_DIR}/README_DEPLOY.md" ]] || fail "missing root file in staging: README_DEPLOY.md"
+
+while IFS= read -r entry; do
+  base="$(basename "$entry")"
+  case "$base" in
+    backend|scripts|docs|README_DEPLOY.md) ;;
+    *) fail "unexpected root entry in staging: ${base}" ;;
+  esac
+done < <(find "$STAGING_DIR" -mindepth 1 -maxdepth 1 -print)
+
+# 关键文件存在性校验
+for rf in backend/routes/api.php backend/composer.lock backend/.env.example; do
+  [[ -f "${STAGING_DIR}/${rf}" ]] || fail "required file missing in staging: ${rf}"
+done
+
+# 产物可追溯 manifest
+mkdir -p "$MANIFEST_DIR"
+COMMIT_SHA="$(git -C "$ROOT" rev-parse HEAD)"
+BUILD_TIME_UTC="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+
+cat > "$MANIFEST_FILE" <<MANIFEST
+{
+  "release_pack_version": ${RELEASE_PACK_VERSION},
+  "commit_sha": "${COMMIT_SHA}",
+  "build_time_utc": "${BUILD_TIME_UTC}",
+  "required_files": [
+    { "path": "backend/routes/api.php", "exists": true },
+    { "path": "backend/composer.lock", "exists": true },
+    { "path": "backend/.env.example", "exists": true }
+  ]
+}
+MANIFEST
+
+rm -f "$OUT_ZIP"
+(
+  cd "$STAGING_DIR"
+  zip -qr "$OUT_ZIP" .
+)
+
+rm -rf "$STAGING_DIR"
+
+echo "[OK] release package generated: dist/fap-api-release.zip"
+echo "[OK] manifest embedded at: docs/release/RELEASE_MANIFEST.json"


### PR DESCRIPTION
Title:
fix(release): enforce stop-ship release hygiene gate

Body:
## Summary
- Introduce a single release artifact generator: `scripts/release_pack.sh`
  - Fixed output: `dist/fap-api-release.zip`
  - Enforces required entrypoint existence (`backend/routes/api.php`)
  - Uses whitelist copy + blacklist cleanup
  - Removes macOS junk (`.DS_Store`, `__MACOSX`)
  - Embeds traceable manifest at `docs/release/RELEASE_MANIFEST.json`
- Add audit evidence script: `scripts/audit_smoke.sh`
  - Supports zip input and extracted directory input
  - Emits evidence for required backend paths and forbidden contamination hits
  - Normalizes audit output path to `./_audit/fap-api-0212-5/`
- Add hard CI gate script: `scripts/release_hygiene_gate.sh`
  - Fails on missing required paths
  - Fails on forbidden files/dirs (`.env`, `.git`, `vendor`, `node_modules`, `storage/logs`, `artifacts`, `*.sqlite*`, report snapshots, macOS junk)
  - Output format: `[FAIL] reason=... path=...`, success: `[OK] release hygiene gate passed`
- Add CI workflow: `.github/workflows/release-hygiene-gate.yml`
  - Trigger: `pull_request` + `push` on `main`
  - Runs pack -> audit -> gate -> uploads release zip + audit log
- Align existing release entrypoints
  - `scripts/package_release.sh` delegates to `scripts/release_pack.sh`
  - `Makefile` release targets switched to new pack/audit/gate chain
  - `.github/workflows/release-artifact.yml` switched to new release artifact + gate
- Add deployment doc: `README_DEPLOY.md`
- Strengthen ignore rules in `.gitignore` (`dist/`, `_audit/`, `.release_staging/`, `.env*`, `.DS_Store`, `__MACOSX`)

## Validation
- `bash scripts/release_pack.sh`
- `bash scripts/audit_smoke.sh dist/fap-api-release.zip`
- `bash scripts/release_hygiene_gate.sh ./_audit/fap-api-0212-5/`
- `php artisan route:list`
- `DB_CONNECTION=sqlite DB_DATABASE=/tmp/fap-release-gate.sqlite php artisan migrate --force`
- `curl -i http://127.0.0.1:1827/api/healthz`
- `curl -i http://127.0.0.1:1827/api/v0.2/healthz`
- `bash backend/scripts/ci_verify_mbti.sh`
