### PR TITLE
feat(sre-scp-001): enforce supply-chain and release hygiene gates

### DIFF
--- a/.github/workflows/supply-chain-audit.yml
+++ b/.github/workflows/supply-chain-audit.yml
@@ -1,0 +1,61 @@
+name: supply-chain-audit
+
+on:
+  pull_request:
+    branches: ["main"]
+  push:
+    branches: ["main"]
+
+permissions:
+  contents: read
+
+jobs:
+  supply-chain-audit:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup PHP 8.4
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: "8.4"
+          coverage: none
+          tools: composer:v2
+
+      - name: Composer install (backend)
+        working-directory: backend
+        run: composer install --no-interaction --prefer-dist --no-progress
+
+      - name: Composer audit (backend)
+        working-directory: backend
+        run: composer audit --no-interaction
+
+      - name: OSV scan composer.lock
+        run: |
+          set -euo pipefail
+          mkdir -p _audit
+          docker run --rm \
+            -v "${PWD}:/src" \
+            -w /src \
+            ghcr.io/google/osv-scanner:latest \
+            scan -L /src/backend/composer.lock --format json --output /src/_audit/osv-composer-lock.json
+
+          jq -e '.results | length == 0' _audit/osv-composer-lock.json >/dev/null || {
+            echo "[FAIL] osv-scanner found vulnerabilities in backend/composer.lock"
+            jq '.results' _audit/osv-composer-lock.json
+            exit 1
+          }
+
+      - name: Supply chain hard gate
+        run: bash scripts/supply_chain_gate.sh
+
+      - name: Upload supply-chain evidence
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: supply-chain-evidence
+          path: _audit/osv-composer-lock.json
+          if-no-files-found: error
+          retention-days: 7

--- a/.github/workflows/supply-chain-audit.yml
+++ b/.github/workflows/supply-chain-audit.yml
@@ -28,6 +28,10 @@ jobs:
         working-directory: backend
         run: composer install --no-interaction --prefer-dist --no-progress
 
+      - name: Composer validate (backend)
+        working-directory: backend
+        run: composer validate --strict
+
       - name: Composer audit (backend)
         working-directory: backend
         run: composer audit --no-interaction

--- a/README_DEPLOY.md
+++ b/README_DEPLOY.md
@@ -15,6 +15,7 @@ bash scripts/release_pack.sh
 ```bash
 bash scripts/audit_smoke.sh dist/fap-api-release.zip
 bash scripts/release_hygiene_gate.sh ./_audit/fap-api-0212-5/
+bash scripts/supply_chain_gate.sh ./_audit/fap-api-0212-5
 ```
 
 ## 2) 交付包内容边界
@@ -65,3 +66,17 @@ php artisan route:cache
 1. 使用上一个可用 `fap-api-release.zip`。
 2. 解压后按同样部署步骤执行。
 3. 通过包内 `docs/release/RELEASE_MANIFEST.json` 核对 `commit_sha` 与构建时间。
+
+## 5) 验收步骤（标准动作）
+
+```bash
+bash scripts/release_pack.sh
+bash scripts/audit_smoke.sh dist/fap-api-release.zip
+bash scripts/release_hygiene_gate.sh ./_audit/fap-api-0212-5/
+bash scripts/supply_chain_gate.sh ./_audit/fap-api-0212-5
+```
+
+`audit_smoke.sh` 输出必须包含固定标题与三段证据：
+1. `EVIDENCE-1: REQUIRED ENTRY`
+2. `EVIDENCE-2: REQUIRED STRUCTURE`
+3. `EVIDENCE-3: CONTAMINATION HITS`

--- a/docs/SUPPLY_CHAIN.md
+++ b/docs/SUPPLY_CHAIN.md
@@ -1,0 +1,25 @@
+# SUPPLY_CHAIN
+
+## CI 固化命令（阻断模式）
+
+`/Users/rainie/Desktop/GitHub/fap-api/.github/workflows/supply-chain-audit.yml` 固化执行：
+
+1. `cd backend && composer install --no-interaction --prefer-dist --no-progress`
+2. `cd backend && composer audit --no-interaction`
+3. `osv-scanner scan -L backend/composer.lock`
+4. `bash scripts/supply_chain_gate.sh`
+
+任一步骤失败即 job 失败，PR 状态红灯。
+
+## 版本更新策略
+
+1. 每周至少一次执行依赖审计（建议周一）。
+2. 所有依赖升级必须提交更新后的 `backend/composer.lock`。
+3. 升级后必须重新通过 `supply-chain-audit` 与 `release-hygiene-gate`。
+
+## 风险响应流程（audit 红灯）
+
+1. 记录失败证据（Composer/OSV 输出）。
+2. 定位受影响依赖并评估影响范围。
+3. 提交修复（升级/替代/临时抑制并附理由）。
+4. 重新触发 CI，确认两条 gate 全绿后再合并/发布。

--- a/docs/release/RELEASE_POLICY.md
+++ b/docs/release/RELEASE_POLICY.md
@@ -1,0 +1,28 @@
+# RELEASE_POLICY
+
+## 最小可审计交付目录集（必须包含）
+
+1. `backend/routes/api.php`
+2. `backend/app`
+3. `backend/config`
+4. `backend/database/migrations`
+5. `backend/composer.json`
+6. `backend/composer.lock`
+7. `scripts`
+8. `docs`
+9. `README_DEPLOY.md`
+
+## 黑名单（必须不包含）与原因
+
+1. `.env/.env.*`（排除 `.env.example`）：敏感信息泄露风险。
+2. `.git`：源码历史泄露与体积污染。
+3. `vendor`/`node_modules`：体积污染与不可控供应链复制。
+4. `backend/storage/logs`、`backend/artifacts`、`backend/storage/app/private/reports`、`backend/storage/app/archives`：运行时污染物，不可审计交付。
+5. `*.sqlite*`：环境数据泄露风险。
+6. `__MACOSX`、`.DS_Store`：非业务污染物。
+
+## 验收动作（必做）
+
+1. `bash scripts/audit_smoke.sh dist/fap-api-release.zip`
+2. `bash scripts/release_hygiene_gate.sh ./_audit/fap-api-0212-5/`
+3. `bash scripts/supply_chain_gate.sh ./_audit/fap-api-0212-5`

--- a/scripts/audit_smoke.sh
+++ b/scripts/audit_smoke.sh
@@ -61,16 +61,17 @@ else
   exit 2
 fi
 
+echo "========== AUDIT SMOKE REPORT =========="
 echo "[AUDIT] root=${AUDIT_ROOT_REL}/"
 
-# 证据 1：目录存在 + api.php 存在
+echo "========== EVIDENCE-1: REQUIRED ENTRY =========="
 if [[ -f "${AUDIT_ROOT_ABS}/backend/routes/api.php" ]]; then
   echo "[EVIDENCE-1] EXISTS path=${AUDIT_ROOT_REL}/backend/routes/api.php"
 else
   echo "[EVIDENCE-1] MISSING path=${AUDIT_ROOT_REL}/backend/routes/api.php"
 fi
 
-# 证据 2：核心目录存在性
+echo "========== EVIDENCE-2: REQUIRED STRUCTURE =========="
 for p in backend/app backend/routes backend/config backend/database/migrations; do
   if [[ -e "${AUDIT_ROOT_ABS}/${p}" ]]; then
     echo "[EVIDENCE-2] EXISTS path=${AUDIT_ROOT_REL}/${p}"
@@ -79,7 +80,7 @@ for p in backend/app backend/routes backend/config backend/database/migrations; 
   fi
 done
 
-# 证据 3：敏感/污染命中列表
+echo "========== EVIDENCE-3: CONTAMINATION HITS =========="
 HITS_FILE="$(mktemp)"
 trap 'rm -f "$HITS_FILE"' EXIT
 

--- a/scripts/supply_chain_gate.sh
+++ b/scripts/supply_chain_gate.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+TARGET_RAW="${1:-${REPO_ROOT}}"
+
+if [[ ! -d "$TARGET_RAW" ]]; then
+  echo "[FAIL] target_not_found path=${TARGET_RAW}" >&2
+  exit 1
+fi
+
+TARGET="$(cd "$TARGET_RAW" && pwd)"
+COMPOSER_JSON="${TARGET}/backend/composer.json"
+COMPOSER_LOCK="${TARGET}/backend/composer.lock"
+
+fail() {
+  echo "[FAIL] $1" >&2
+  exit 1
+}
+
+command -v jq >/dev/null 2>&1 || fail "missing command: jq"
+
+[[ -f "$COMPOSER_JSON" ]] || fail "missing backend/composer.json"
+[[ -f "$COMPOSER_LOCK" ]] || fail "missing backend/composer.lock"
+
+PACKAGES_LEN="$(jq -r '(.packages // []) | length' "$COMPOSER_LOCK" 2>/dev/null)" || fail "invalid backend/composer.lock"
+
+if [[ "$PACKAGES_LEN" == "0" ]]; then
+  echo "[FAIL] composer.lock packages empty" >&2
+  exit 1
+fi
+
+jq -e 'any((.packages // [])[].name; . == "laravel/framework")' "$COMPOSER_LOCK" >/dev/null 2>&1 || fail "laravel/framework missing in backend/composer.lock"
+
+echo "[OK] supply chain gate passed path=${TARGET}/backend/composer.lock"


### PR DESCRIPTION
## Summary

This PR operationalizes P0/P1 release defense as blocking automation:

1. Add hard supply-chain gate script shared by local + CI.
2. Add CI workflow `supply-chain-audit` to run:
   - `composer install`
   - `composer audit`
   - `osv-scanner` on `backend/composer.lock`
   - `scripts/supply_chain_gate.sh`
3. Enforce release packaging includes Composer manifest/lock and blocks on invalid lockfile.
4. Strengthen release hygiene gate with precheck evidence output + supply-chain recheck.
5. Standardize `audit_smoke.sh` output to fixed heading + 3 evidence sections.
6. Add traceable docs:
   - `/Users/rainie/Desktop/GitHub/fap-api/docs/SUPPLY_CHAIN.md`
   - `/Users/rainie/Desktop/GitHub/fap-api/docs/release/RELEASE_POLICY.md`
   - update `/Users/rainie/Desktop/GitHub/fap-api/README_DEPLOY.md` acceptance steps

## A) Changed Files

### Added
- `/Users/rainie/Desktop/GitHub/fap-api/scripts/supply_chain_gate.sh`
- `/Users/rainie/Desktop/GitHub/fap-api/.github/workflows/supply-chain-audit.yml`
- `/Users/rainie/Desktop/GitHub/fap-api/docs/SUPPLY_CHAIN.md`
- `/Users/rainie/Desktop/GitHub/fap-api/docs/release/RELEASE_POLICY.md`

### Modified
- `/Users/rainie/Desktop/GitHub/fap-api/scripts/release_pack.sh`
- `/Users/rainie/Desktop/GitHub/fap-api/scripts/release_hygiene_gate.sh`
- `/Users/rainie/Desktop/GitHub/fap-api/scripts/audit_smoke.sh`
- `/Users/rainie/Desktop/GitHub/fap-api/README_DEPLOY.md`

## Validation

### Positive checks
- `bash scripts/supply_chain_gate.sh` ✅
- `jq '.packages | length' backend/composer.lock` -> `107` ✅
- `jq -r '.packages[].name' backend/composer.lock | grep -x 'laravel/framework'` ✅
- `bash scripts/release_pack.sh` ✅
- `bash scripts/audit_smoke.sh dist/fap-api-release.zip` ✅
- `bash scripts/release_hygiene_gate.sh ./_audit/fap-api-0212-5/` ✅
- `cd backend && php artisan route:list` ✅
- `cd backend && php artisan migrate` ✅
- `curl -fsS http://127.0.0.1:8000/api/v0.2/healthz` ✅
- `curl -fsS "http://127.0.0.1:8000/api/v0.2/scales/MBTI/questions?region=CN_MAINLAND&locale=zh-CN"` ✅
- `bash backend/scripts/ci_verify_mbti.sh` ✅
- `bash scripts/ci_verify_mbti.sh` ❌ (local env content-packs check behavior; unrelated to this PR scope)

### Negative/Blocking checks
- Tracked `.env` causes `release_pack.sh` to fail ✅
- Injected `backend/storage/logs/` in unpacked artifact causes `release_hygiene_gate.sh` fail with hit path ✅
- Empty `.packages` in lockfile causes `supply_chain_gate.sh` fail with `[FAIL] composer.lock packages empty` ✅

## Notes

- Branch protection should set required checks:
  - `release-hygiene-gate`
  - `supply-chain-audit`
