### PR TITLE
fix(ci): sync #377 composer-validate order into main

### DIFF
--- a/.github/workflows/supply-chain-audit.yml
+++ b/.github/workflows/supply-chain-audit.yml
@@ -24,13 +24,13 @@ jobs:
           coverage: none
           tools: composer:v2
 
-      - name: Composer install (backend)
-        working-directory: backend
-        run: composer install --no-interaction --prefer-dist --no-progress
-
       - name: Composer validate (backend)
         working-directory: backend
         run: composer validate --strict
+
+      - name: Composer install (backend)
+        working-directory: backend
+        run: composer install --no-interaction --prefer-dist --no-progress
 
       - name: Composer audit (backend)
         working-directory: backend


### PR DESCRIPTION
## Summary

Sync the #377 CI fix into `main` by adding the workflow ordering fix in supply-chain audit:

- Ensure `composer validate --strict` is explicitly present for workflows with `composer install`
- Keep `composer audit --no-interaction` gate
- Align with `ci-pr56-workflow-composer-php84` guard expectations

## Change

- `/Users/rainie/Desktop/GitHub/fap-api/.github/workflows/supply-chain-audit.yml`
  - reorder steps to run:
    1. `composer validate --strict`
    2. `composer install --no-interaction --prefer-dist --no-progress`
    3. `composer audit --no-interaction`

## Verification

- Local guard passed:

```bash
for wf in $(grep -R -l -E 'shivammathur/setup-php@v2' .github/workflows); do
  grep -E "^[[:space:]]*php-version:[[:space:]]*['\"]?8\\.4" "${wf}" >/dev/null
done
for wf in $(grep -R -l -E 'composer[[:space:]]+install' .github/workflows); do
  grep -E 'composer[[:space:]]+validate[[:space:]]+--strict' "${wf}" >/dev/null
  grep -E 'composer[[:space:]]+audit[[:space:]]+--no-interaction' "${wf}" >/dev/null
done
