### PR TITLE
fix(console): restore deployable release package and cache-safe panel provider registration

### DIFF
--- a/backend/bootstrap/providers.php
+++ b/backend/bootstrap/providers.php
@@ -1,13 +1,26 @@
 <?php
 
 $filamentAvailable = class_exists(\Filament\PanelProvider::class);
+$configCachePath = __DIR__ . '/cache/config.php';
+$cachedConfig = is_file($configCachePath) ? require $configCachePath : [];
+$cachedConfig = is_array($cachedConfig) ? $cachedConfig : [];
+
+$adminConfig = is_array($cachedConfig['admin'] ?? null)
+    ? $cachedConfig['admin']
+    : require __DIR__ . '/../config/admin.php';
+$tenantConfig = is_array($cachedConfig['tenant'] ?? null)
+    ? $cachedConfig['tenant']
+    : require __DIR__ . '/../config/tenant.php';
+
+$adminPanelEnabled = (bool) ($adminConfig['panel_enabled'] ?? false);
+$tenantPanelEnabled = (bool) ($tenantConfig['panel_enabled'] ?? false);
 
 return array_values(array_filter([
     App\Providers\AppServiceProvider::class,
-    (env('FAP_ADMIN_PANEL_ENABLED', false) && $filamentAvailable)
+    ($adminPanelEnabled && $filamentAvailable)
         ? App\Providers\Filament\AdminPanelProvider::class
         : null,
-    (env('FAP_TENANT_PANEL_ENABLED', false) && $filamentAvailable)
+    ($tenantPanelEnabled && $filamentAvailable)
         ? App\Providers\Filament\TenantPanelProvider::class
         : null,
 ]));

--- a/backend/scripts/release_pack.sh
+++ b/backend/scripts/release_pack.sh
@@ -27,27 +27,20 @@ need_cmd find
 cd "${ROOT}"
 
 WHITELIST_PATHS=(
-  backend/app
-  backend/routes
-  backend/config
-  backend/database/migrations
-  backend/composer.json
-  backend/composer.lock
-  backend/scripts
+  backend
   README_DEPLOY.md
   scripts
   docs
 )
 
 REQUIRED_HEAD_FILES=(
+  backend
+  backend/artisan
+  backend/bootstrap/app.php
+  backend/bootstrap/providers.php
   backend/routes/api.php
-  backend/app
-  backend/routes
-  backend/config
-  backend/database/migrations
   backend/composer.json
   backend/composer.lock
-  backend/scripts
   README_DEPLOY.md
 )
 
@@ -98,7 +91,16 @@ if [[ -s "$HITS_FILE" ]]; then
   exit 1
 fi
 
-[[ -f "${STAGING_DIR}/backend/routes/api.php" ]] || fail "required file missing in package staging: backend/routes/api.php"
+PACKAGE_REQUIRED_FILES=(
+  backend/artisan
+  backend/bootstrap/app.php
+  backend/bootstrap/providers.php
+  backend/routes/api.php
+)
+
+for required in "${PACKAGE_REQUIRED_FILES[@]}"; do
+  [[ -f "${STAGING_DIR}/${required}" ]] || fail "required file missing in package staging: ${required}"
+done
 
 rm -f "${OUT_ZIP}"
 (


### PR DESCRIPTION
## Summary
This PR addresses two high-priority review findings from PR-Console-00 rev:

1. `[P1]` Release package was not deployable because runtime entrypoints (`backend/artisan`, `backend/bootstrap/*`) were excluded.
2. `[P1]` Panel providers were registered via `env()` in bootstrap, which can fail after `php artisan config:cache`.

## Fixes

1. Release package now exports full backend runtime
- Updated `/Users/rainie/Desktop/GitHub/fap-api/backend/scripts/release_pack.sh`:
  - Whitelist changed from backend subset to full `backend`.
  - Added hard checks for required runtime files in staging package:
    - `backend/artisan`
    - `backend/bootstrap/app.php`
    - `backend/bootstrap/providers.php`
    - `backend/routes/api.php`

2. Provider registration now follows cached config instead of direct env
- Updated `/Users/rainie/Desktop/GitHub/fap-api/backend/bootstrap/providers.php`:
  - Read `bootstrap/cache/config.php` first when present.
  - Fallback to `/Users/rainie/Desktop/GitHub/fap-api/backend/config/admin.php` and `/Users/rainie/Desktop/GitHub/fap-api/backend/config/tenant.php` when cache is missing.
  - Use `panel_enabled` from resolved config for provider registration.

## A. Changed Files List
- Added: none
- Modified:
  - `/Users/rainie/Desktop/GitHub/fap-api/backend/bootstrap/providers.php`
  - `/Users/rainie/Desktop/GitHub/fap-api/backend/scripts/release_pack.sh`

## B. Copy-Paste Blocks (Exact Replacement Ranges)

### 1) Replace `/Users/rainie/Desktop/GitHub/fap-api/backend/bootstrap/providers.php:3-25` with:
```php
$filamentAvailable = class_exists(\Filament\PanelProvider::class);
$configCachePath = __DIR__ . '/cache/config.php';
$cachedConfig = is_file($configCachePath) ? require $configCachePath : [];
$cachedConfig = is_array($cachedConfig) ? $cachedConfig : [];

$adminConfig = is_array($cachedConfig['admin'] ?? null)
    ? $cachedConfig['admin']
    : require __DIR__ . '/../config/admin.php';
$tenantConfig = is_array($cachedConfig['tenant'] ?? null)
    ? $cachedConfig['tenant']
    : require __DIR__ . '/../config/tenant.php';

$adminPanelEnabled = (bool) ($adminConfig['panel_enabled'] ?? false);
$tenantPanelEnabled = (bool) ($tenantConfig['panel_enabled'] ?? false);

return array_values(array_filter([
    App\Providers\AppServiceProvider::class,
    ($adminPanelEnabled && $filamentAvailable)
        ? App\Providers\Filament\AdminPanelProvider::class
        : null,
    ($tenantPanelEnabled && $filamentAvailable)
        ? App\Providers\Filament\TenantPanelProvider::class
        : null,
]));
2) Replace release_pack.sh (lines 29-45) with:
WHITELIST_PATHS=(
  backend
  README_DEPLOY.md
  scripts
  docs
)

REQUIRED_HEAD_FILES=(
  backend
  backend/artisan
  backend/bootstrap/app.php
  backend/bootstrap/providers.php
  backend/routes/api.php
  backend/composer.json
  backend/composer.lock
  README_DEPLOY.md
)
3) Replace release_pack.sh (lines 94-103) with:
PACKAGE_REQUIRED_FILES=(
  backend/artisan
  backend/bootstrap/app.php
  backend/bootstrap/providers.php
  backend/routes/api.php
)

for required in "${PACKAGE_REQUIRED_FILES[@]}"; do
  [[ -f "${STAGING_DIR}/${required}" ]] || fail "required file missing in package staging: ${required}"
done
C. Minimal Acceptance Commands
cd /Users/rainie/Desktop/GitHub/fap-api/backend
php artisan route:list
php artisan migrate
curl -i http://127.0.0.1:18080/ops
curl -i http://127.0.0.1:18080/tenant
curl -i http://127.0.0.1:18080/api/v0.2/healthz

cd /Users/rainie/Desktop/GitHub/fap-api
bash backend/scripts/ci_verify_mbti.sh
Verification Notes
php artisan route:list: passed
php artisan migrate: passed (Nothing to migrate)
ci_verify_mbti.sh: passed
release_pack.sh: passed and package contains runtime entrypoints