### PR TITLE
fix(ops): scope Filament login response override to ops panel

### DIFF
--- a/backend/app/Http/Middleware/BindOpsLoginResponse.php
+++ b/backend/app/Http/Middleware/BindOpsLoginResponse.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Middleware;
+
+use App\Http\Responses\Auth\OpsLoginResponse;
+use Closure;
+use Filament\Http\Responses\Auth\Contracts\LoginResponse as FilamentLoginResponse;
+use Illuminate\Contracts\Container\Container;
+use Illuminate\Http\Request;
+use Symfony\Component\HttpFoundation\Response;
+
+class BindOpsLoginResponse
+{
+    public function __construct(private readonly Container $app)
+    {
+    }
+
+    public function handle(Request $request, Closure $next): Response
+    {
+        if (interface_exists(FilamentLoginResponse::class)) {
+            $this->app->bind(FilamentLoginResponse::class, OpsLoginResponse::class);
+        }
+
+        return $next($request);
+    }
+}

--- a/backend/app/Http/Responses/Auth/OpsLoginResponse.php
+++ b/backend/app/Http/Responses/Auth/OpsLoginResponse.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Http\Responses\Auth;
 
+use Filament\Facades\Filament;
 use Filament\Http\Responses\Auth\Contracts\LoginResponse as LoginResponseContract;
 use Illuminate\Http\RedirectResponse;
 use Livewire\Features\SupportRedirects\Redirector;
@@ -12,6 +13,10 @@ class OpsLoginResponse implements LoginResponseContract
 {
     public function toResponse($request): RedirectResponse | Redirector
     {
+        if (Filament::getCurrentPanel()?->getId() !== 'ops') {
+            return redirect()->intended(Filament::getCurrentPanel()?->getUrl() ?? Filament::getUrl());
+        }
+
         $request->session()->forget('ops_admin_totp_verified_user_id');
 
         $guard = (string) config('admin.guard', 'admin');

--- a/backend/app/Providers/AppServiceProvider.php
+++ b/backend/app/Providers/AppServiceProvider.php
@@ -2,7 +2,6 @@
 
 namespace App\Providers;
 
-use App\Http\Responses\Auth\OpsLoginResponse;
 use App\Models\AdminApproval;
 use App\Models\Attempt;
 use App\Models\BenefitGrant;
@@ -27,7 +26,6 @@ use App\Services\Content\ContentStore;
 use App\Services\ContentPackResolver;
 use App\Support\OrgContext;
 use App\Support\SensitiveDataRedactor;
-use Filament\Http\Responses\Auth\Contracts\LoginResponse as FilamentLoginResponse;
 use Illuminate\Auth\Events\Failed;
 use Illuminate\Auth\Events\Login;
 use Illuminate\Cache\RateLimiting\Limit;
@@ -257,9 +255,6 @@ class AppServiceProvider extends ServiceProvider
             return new ContentStore($chain, [], $legacyDir);
         });
 
-        if (interface_exists(FilamentLoginResponse::class)) {
-            $this->app->bind(FilamentLoginResponse::class, OpsLoginResponse::class);
-        }
     }
 
     /**

--- a/backend/app/Providers/Filament/AdminPanelProvider.php
+++ b/backend/app/Providers/Filament/AdminPanelProvider.php
@@ -3,6 +3,7 @@
 namespace App\Providers\Filament;
 
 use App\Filament\Ops\Pages\OpsDashboard;
+use App\Http\Middleware\BindOpsLoginResponse;
 use App\Http\Middleware\EnsureAdminTotpVerified;
 use App\Http\Middleware\OpsAccessControl;
 use App\Http\Middleware\RequireOpsOrgSelected;
@@ -44,6 +45,7 @@ class AdminPanelProvider extends PanelProvider
                 ShareErrorsFromSession::class,
                 VerifyCsrfToken::class,
                 SubstituteBindings::class,
+                BindOpsLoginResponse::class,
                 SetOpsRequestContext::class,
                 ResolveOrgContext::class,
                 EnsureAdminTotpVerified::class,


### PR DESCRIPTION
## Summary
Sync minimal #385 vulnerability fix to main in an isolated PR.

## Changes
- Add middleware-scoped Filament login response binding for ops panel only.
- Remove global Filament login response binding from AppServiceProvider.
- Add non-ops panel fallback in OpsLoginResponse.

## Files
- backend/app/Http/Middleware/BindOpsLoginResponse.php
- backend/app/Providers/Filament/AdminPanelProvider.php
- backend/app/Providers/AppServiceProvider.php
- backend/app/Http/Responses/Auth/OpsLoginResponse.php

## Verification
- php backend/artisan route:list
- php backend/artisan migrate
- bash backend/scripts/ci_verify_mbti.sh
