### PR TITLE
fix(ops): restore current org switcher and remove env usage

### DIFF
--- a/backend/app/Console/Commands/FapEmailOutboxSend.php
+++ b/backend/app/Console/Commands/FapEmailOutboxSend.php
@@ -322,14 +322,14 @@ class FapEmailOutboxSend extends Command
     {
         $appUrl = rtrim((string) config('app.url', 'http://localhost'), '/');
         $global = [
-            'terms' => trim((string) env('FAP_GLOBAL_TERMS_URL', $appUrl . '/terms')),
-            'privacy' => trim((string) env('FAP_GLOBAL_PRIVACY_URL', $appUrl . '/privacy')),
-            'refund' => trim((string) env('FAP_GLOBAL_REFUND_URL', $appUrl . '/refund')),
+            'terms' => trim((string) config('regions.regions.US.legal_urls.terms', $appUrl . '/terms')),
+            'privacy' => trim((string) config('regions.regions.US.legal_urls.privacy', $appUrl . '/privacy')),
+            'refund' => trim((string) config('regions.regions.US.legal_urls.refund', $appUrl . '/refund')),
         ];
         $cn = [
-            'terms' => trim((string) env('FAP_CN_TERMS_URL', $appUrl . '/zh/terms')),
-            'privacy' => trim((string) env('FAP_CN_PRIVACY_URL', $appUrl . '/zh/privacy')),
-            'refund' => trim((string) env('FAP_CN_REFUND_URL', $appUrl . '/zh/refund')),
+            'terms' => trim((string) config('regions.regions.CN_MAINLAND.legal_urls.terms', $appUrl . '/zh/terms')),
+            'privacy' => trim((string) config('regions.regions.CN_MAINLAND.legal_urls.privacy', $appUrl . '/zh/privacy')),
+            'refund' => trim((string) config('regions.regions.CN_MAINLAND.legal_urls.refund', $appUrl . '/zh/refund')),
         ];
 
         $target = $this->languageFromLocale($locale) === 'zh' ? $cn : $global;
@@ -342,7 +342,7 @@ class FapEmailOutboxSend extends Command
 
     private function resolveSupportEmail(): string
     {
-        $support = trim((string) env('FAP_SUPPORT_EMAIL', env('SUPPORT_EMAIL', '')));
+        $support = trim((string) config('fap.support_email', ''));
         if ($support !== '') {
             return $support;
         }

--- a/backend/app/Filament/Ops/Pages/SelectOrgPage.php
+++ b/backend/app/Filament/Ops/Pages/SelectOrgPage.php
@@ -8,6 +8,7 @@ use App\Support\Rbac\PermissionNames;
 use Filament\Notifications\Notification;
 use Filament\Pages\Page;
 use Illuminate\Http\RedirectResponse;
+use Illuminate\Support\Facades\Cookie;
 use Illuminate\Support\Facades\DB;
 
 class SelectOrgPage extends Page
@@ -67,6 +68,17 @@ class SelectOrgPage extends Page
         }
 
         session(['ops_org_id' => $orgId]);
+        Cookie::queue(cookie(
+            name: 'ops_org_id',
+            value: (string) $orgId,
+            minutes: 60 * 24 * 30,
+            path: '/ops',
+            domain: null,
+            secure: (bool) config('session.secure'),
+            httpOnly: true,
+            raw: false,
+            sameSite: 'lax',
+        ));
 
         Notification::make()
             ->title('Organization selected')

--- a/backend/app/Livewire/Filament/Ops/Livewire/CurrentOrgSwitcher.php
+++ b/backend/app/Livewire/Filament/Ops/Livewire/CurrentOrgSwitcher.php
@@ -1,0 +1,88 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Livewire\Filament\Ops\Livewire;
+
+use Illuminate\Contracts\View\View;
+use Illuminate\Support\Facades\Cookie;
+use Illuminate\Support\Facades\DB;
+use Livewire\Component;
+
+final class CurrentOrgSwitcher extends Component
+{
+    public ?int $orgId = null;
+
+    public string $orgName = '未选择企业';
+
+    public function mount(): void
+    {
+        $this->orgId = $this->resolveOrgId();
+
+        if ($this->orgId === null) {
+            return;
+        }
+
+        $row = DB::table('organizations')
+            ->select(['id', 'name'])
+            ->where('id', $this->orgId)
+            ->first();
+
+        if ($row !== null) {
+            $this->orgName = (string) $row->name;
+
+            return;
+        }
+
+        // org_id points to a missing organization; clear to avoid a bad loop.
+        $this->clearOrgSelection();
+        $this->orgId = null;
+        $this->orgName = '未选择企业';
+    }
+
+    public function goSelectOrg(): mixed
+    {
+        $this->clearOrgSelection();
+
+        return redirect()->to('/ops/select-org');
+    }
+
+    private function clearOrgSelection(): void
+    {
+        session()->forget('ops_org_id');
+
+        Cookie::queue(Cookie::forget('ops_org_id', '/ops'));
+        Cookie::queue(Cookie::forget('ops_org_id', '/'));
+    }
+
+    private function resolveOrgId(): ?int
+    {
+        $attr = request()->attributes->get('org_id');
+        if (is_numeric($attr)) {
+            $n = (int) $attr;
+
+            return $n > 0 ? $n : null;
+        }
+
+        $sess = session('ops_org_id');
+        if (is_numeric($sess)) {
+            $n = (int) $sess;
+
+            return $n > 0 ? $n : null;
+        }
+
+        $cookie = request()->cookie('ops_org_id');
+        if (is_numeric($cookie)) {
+            $n = (int) $cookie;
+
+            return $n > 0 ? $n : null;
+        }
+
+        return null;
+    }
+
+    public function render(): View
+    {
+        return view('livewire.filament.ops.livewire.current-org-switcher');
+    }
+}

--- a/backend/app/Providers/AppServiceProvider.php
+++ b/backend/app/Providers/AppServiceProvider.php
@@ -2,6 +2,7 @@
 
 namespace App\Providers;
 
+use App\Livewire\Filament\Ops\Livewire\CurrentOrgSwitcher;
 use App\Models\AdminApproval;
 use App\Models\Attempt;
 use App\Models\BenefitGrant;
@@ -36,6 +37,7 @@ use Illuminate\Support\Facades\Event;
 use Illuminate\Support\Facades\RateLimiter;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\ServiceProvider;
+use Livewire\Livewire;
 use Monolog\LogRecord;
 use RuntimeException;
 
@@ -271,6 +273,7 @@ class AppServiceProvider extends ServiceProvider
         Gate::policy(Share::class, SharePolicy::class);
         Gate::policy(ScaleRegistry::class, ScaleRegistryPolicy::class);
         Gate::policy(ScaleSlug::class, ScaleSlugPolicy::class);
+        Livewire::component('filament.ops.livewire.current-org-switcher', CurrentOrgSwitcher::class);
 
         if ($this->app->runningInConsole() && $this->app->environment('production')) {
             $argv = $_SERVER['argv'] ?? [];

--- a/backend/config/fap.php
+++ b/backend/config/fap.php
@@ -7,6 +7,7 @@ return [
     // Content packages
     'content_package_version' => env('FAP_CONTENT_PACKAGE_VERSION', 'MBTI-CN-v0.2.2'),
     'content_packages_dir' => env('FAP_CONTENT_PACKAGES_DIR', null),
+    'support_email' => env('FAP_SUPPORT_EMAIL', env('SUPPORT_EMAIL', '')),
 
     // Profile / scoring
     'profile_version' => env('FAP_PROFILE_VERSION', 'mbti32-v2.5'),

--- a/backend/resources/views/livewire/filament/ops/livewire/current-org-switcher.blade.php
+++ b/backend/resources/views/livewire/filament/ops/livewire/current-org-switcher.blade.php
@@ -1,0 +1,17 @@
+<div class="flex items-center gap-x-2">
+    <span class="text-sm text-gray-600 dark:text-gray-300">
+        当前企业：
+        <span class="font-medium text-gray-900 dark:text-gray-100">
+            {{ $orgName }}
+        </span>
+    </span>
+
+    <x-filament::button
+        type="button"
+        size="sm"
+        color="gray"
+        wire:click="goSelectOrg"
+    >
+        {{ $orgId ? '切换企业' : '选择企业' }}
+    </x-filament::button>
+</div>

--- a/backend/tests/Feature/Ops/CurrentOrgSwitcherComponentTest.php
+++ b/backend/tests/Feature/Ops/CurrentOrgSwitcherComponentTest.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Ops;
+
+use App\Livewire\Filament\Ops\Livewire\CurrentOrgSwitcher;
+use Livewire\Livewire;
+use Tests\TestCase;
+
+final class CurrentOrgSwitcherComponentTest extends TestCase
+{
+    public function test_current_org_switcher_component_can_boot(): void
+    {
+        Livewire::test(CurrentOrgSwitcher::class)->assertOk();
+        Livewire::test('filament.ops.livewire.current-org-switcher')->assertOk();
+    }
+}


### PR DESCRIPTION
## Summary
- restore `/ops` topbar org switcher Livewire wiring using alias `filament.ops.livewire.current-org-switcher`
- add `CurrentOrgSwitcher` component under `App\Livewire\Filament\Ops\Livewire` and its Blade view
- register alias in `AppServiceProvider` to avoid `ComponentNotFoundException`
- add `CurrentOrgSwitcherComponentTest` to gate both class-based and alias-based Livewire boot
- persist `ops_org_id` to cookie in `SelectOrgPage` (session + cookie) for cross-request stability
- remove direct `env()/getenv()` usage from `FapEmailOutboxSend` to satisfy architecture guard
  - switch legal URL resolution to `config('regions...')`
  - add `config('fap.support_email')` and use it in outbox sender

## Why
`/ops` returned 500 due to unresolved Livewire component alias.  
Full test also had architecture failure (`NoEnvUsageOutsideConfigTest`) caused by `env()` in app code.

## Verification
- `cd /Users/rainie/Desktop/GitHub/fap-api/backend && php artisan route:list`
- `cd /Users/rainie/Desktop/GitHub/fap-api/backend && php artisan migrate`
- `cd /Users/rainie/Desktop/GitHub/fap-api/backend && php artisan test --filter CurrentOrgSwitcherComponentTest`
- `cd /Users/rainie/Desktop/GitHub/fap-api/backend && php artisan test --filter NoEnvUsageOutsideConfigTest`
- `cd /Users/rainie/Desktop/GitHub/fap-api/backend && php artisan test`
- `cd /Users/rainie/Desktop/GitHub/fap-api/backend && php artisan tinker --execute='try { app("livewire")->new("filament.ops.livewire.current-org-switcher"); echo "OK"; } catch (\Throwable $e) { echo get_class($e).":".$e->getMessage(); }'`
- `cd /Users/rainie/Desktop/GitHub/fap-api/backend && curl -i http://127.0.0.1:18010/ops`
- `cd /Users/rainie/Desktop/GitHub/fap-api/backend && curl -i http://127.0.0.1:18010/ops/select-org`
- `cd /Users/rainie/Desktop/GitHub/fap-api && bash backend/scripts/ci_verify_mbti.sh`

## Notes
- `/ops` and `/ops/select-org` return 302-to-login when unauthenticated, no 500.
- no route/migration/FmTokenAuth behavior changes.
