### PR TITLE
fix(report): reapply teaser masking for locked non-MBTI reports

### DIFF
--- a/backend/app/Services/Report/ReportGatekeeper.php
+++ b/backend/app/Services/Report/ReportGatekeeper.php
@@ -243,6 +243,12 @@ class ReportGatekeeper
             return $this->serverError('REPORT_FAILED', 'report generation failed.');
         }
 
+        // Non-MBTI reports are still built by GenericReportBuilder. Re-apply teaser
+        // masking when locked to avoid exposing full payload to unpaid users.
+        if ($locked && strtoupper($scaleCode) !== 'MBTI') {
+            $report = $this->applyTeaser($report, $viewPolicy);
+        }
+
         if ($shouldUseSnapshot && $variant === ReportAccess::VARIANT_FULL) {
             $reportFreeBuilt = $this->buildReportVariant(
                 $scaleCode,

--- a/backend/tests/Feature/V0_3/AttemptReportPaymentUnlockFlowTest.php
+++ b/backend/tests/Feature/V0_3/AttemptReportPaymentUnlockFlowTest.php
@@ -102,6 +102,9 @@ final class AttemptReportPaymentUnlockFlowTest extends TestCase
         $this->assertIsArray($beforePayload);
         $this->assertArrayNotHasKey('breakdown', $beforePayload);
         $this->assertArrayNotHasKey('answers', $beforePayload);
+        $this->assertSame('[LOCKED]', (string) ($beforePayload['schema_version'] ?? null));
+        $this->assertSame('[LOCKED]', (string) data_get($beforePayload, 'summary.title'));
+        $this->assertNull(data_get($beforePayload, 'summary.final_score'));
 
         $order = $this->withHeaders([
             'X-Anon-Id' => $anonId,


### PR DESCRIPTION
## Summary
This PR fixes a high-priority paywall leak for non-MBTI scales in `GET /api/v0.3/attempts/{id}/report`.

In the R1-R4 refactor, locked responses now return `report` directly from variant generation. MBTI is safe because it uses variant-aware card filtering, but non-MBTI still uses `GenericReportBuilder`, which returns full payload fields. This could expose full non-MBTI report content while `locked=true`.

## Root Cause
`ReportGatekeeper::resolve()` returned `$report` as-is for locked requests.
- MBTI: safe due to variant filtering in report composition
- non-MBTI: unsafe because `GenericReportBuilder` is not variant/paywall-aware

Previously, locked flows were always teaser-masked via `applyTeaser()`.

## Fix
Reapply teaser masking for locked non-MBTI reports in `ReportGatekeeper::resolve()`:
- condition: `if ($locked && strtoupper($scaleCode) !== 'MBTI')`
- action: `$report = $this->applyTeaser($report, $viewPolicy);`

## Tests
Updated `AttemptReportPaymentUnlockFlowTest` (SIMPLE_SCORE_DEMO path) to assert locked masking behavior:
- `schema_version` is masked to `"[LOCKED]"`
- `summary.title` is masked to `"[LOCKED]"`
- `summary.final_score` is masked to `null`

## Files Changed
- `backend/app/Services/Report/ReportGatekeeper.php`
- `backend/tests/Feature/V0_3/AttemptReportPaymentUnlockFlowTest.php`

## Verification
Ran and passed:
- `php artisan route:list | rg "api.v0_3.attempts.report|api.v0_3.skus|api.v0_3.webhooks.payment"`
- `php artisan migrate`
- `php artisan test --filter=test_ingest_with_fm_token_uses_token_user_and_ignores_body_user_id`
- `php artisan test --filter=AttemptReportPaymentUnlockFlowTest`
- `php artisan test --filter=ReportVariantGenerationTest`
- `php artisan test --filter=ReportLockedVariantLeakTest`
- `bash backend/scripts/ci_verify_mbti.sh`
