### PR TITLE
api(v0.3): add ResolveAnonId(client_anon_id) and unify boot/start anon intake

### DIFF
--- a/backend/app/Http/Controllers/API/V0_3/AttemptWriteController.php
+++ b/backend/app/Http/Controllers/API/V0_3/AttemptWriteController.php
@@ -27,7 +27,7 @@ class AttemptWriteController extends Controller
     {
         $payload = $request->validated();
 
-        $anonId = trim((string) ($payload['anon_id'] ?? $request->header('X-Anon-Id') ?? ''));
+        $anonId = trim((string) ($request->attributes->get('client_anon_id') ?? $payload['anon_id'] ?? ''));
         if ($anonId !== '') {
             $payload['anon_id'] = $anonId;
         }

--- a/backend/app/Http/Controllers/API/V0_3/BootController.php
+++ b/backend/app/Http/Controllers/API/V0_3/BootController.php
@@ -79,8 +79,8 @@ class BootController extends Controller
         $candidates = [
             $request->attributes->get('anon_id'),
             $request->attributes->get('fm_anon_id'),
+            $request->attributes->get('client_anon_id'),
             $request->query('anon_id'),
-            $request->header('X-Anon-Id'),
         ];
 
         foreach ($candidates as $candidate) {

--- a/backend/app/Http/Middleware/ResolveAnonId.php
+++ b/backend/app/Http/Middleware/ResolveAnonId.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Middleware;
+
+use Closure;
+use Illuminate\Http\Request;
+use Symfony\Component\HttpFoundation\Response;
+
+class ResolveAnonId
+{
+    public function handle(Request $request, Closure $next): Response
+    {
+        $headerAnonId = $this->normalize($request->header('X-Anon-Id'));
+        $cookieAnonId = $this->normalize($request->cookie('fap_anonymous_id_v1'));
+
+        $resolved = $headerAnonId ?? $cookieAnonId;
+        if ($resolved !== null) {
+            // Keep transport-level anon identity isolated from auth-bound anon_id.
+            $request->attributes->set('client_anon_id', $resolved);
+        }
+
+        return $next($request);
+    }
+
+    private function normalize(mixed $value): ?string
+    {
+        if (!is_string($value) && !is_numeric($value)) {
+            return null;
+        }
+
+        $trimmed = trim((string) $value);
+        if ($trimmed === '' || strlen($trimmed) > 128) {
+            return null;
+        }
+
+        $lower = mb_strtolower($trimmed, 'UTF-8');
+        foreach (['todo', 'placeholder', 'fixme', 'tbd', '填这里'] as $bad) {
+            if (mb_strpos($lower, $bad) !== false) {
+                return null;
+            }
+        }
+
+        return $trimmed;
+    }
+}

--- a/backend/routes/api.php
+++ b/backend/routes/api.php
@@ -317,7 +317,7 @@ Route::prefix("v0.3")->middleware([
         ->middleware([LimitWebhookPayloadSize::class, 'throttle:api_webhook'])
         ->name('api.v0_3.webhooks.payment');
 
-    Route::middleware(ResolveOrgContext::class)->group(function () use ($payProviders) {
+    Route::middleware([\App\Http\Middleware\ResolveAnonId::class, ResolveOrgContext::class])->group(function () use ($payProviders) {
         // 0) Boot (flags + experiments)
         Route::get("/boot", [BootV0_3Controller::class, "show"]);
         Route::get("/flags", [BootV0_3Controller::class, "flags"]);

--- a/backend/tests/Feature/V0_3/ResolveAnonIdMiddlewareTest.php
+++ b/backend/tests/Feature/V0_3/ResolveAnonIdMiddlewareTest.php
@@ -1,0 +1,60 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\V0_3;
+
+use App\Models\Attempt;
+use Database\Seeders\Pr17SimpleScoreDemoSeeder;
+use Database\Seeders\ScaleRegistrySeeder;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+final class ResolveAnonIdMiddlewareTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_boot_prefers_header_over_cookie_for_client_anon_id(): void
+    {
+        $response = $this->withHeader('X-Anon-Id', 'anon_header_1')
+            ->withCookie('fap_anonymous_id_v1', 'anon_cookie_1')
+            ->getJson('/api/v0.3/boot');
+
+        $response->assertStatus(200)
+            ->assertJsonPath('ok', true)
+            ->assertJsonPath('anon_id', 'anon_header_1');
+    }
+
+    public function test_boot_uses_cookie_when_header_missing(): void
+    {
+        $response = $this->call(
+            'GET',
+            '/api/v0.3/boot',
+            [],
+            ['fap_anonymous_id_v1' => 'anon_cookie_only']
+        );
+
+        $response->assertStatus(200)
+            ->assertJsonPath('ok', true)
+            ->assertJsonPath('anon_id', 'anon_cookie_only');
+    }
+
+    public function test_attempt_start_prefers_client_anon_id_over_payload_anon_id(): void
+    {
+        (new ScaleRegistrySeeder())->run();
+        (new Pr17SimpleScoreDemoSeeder())->run();
+
+        $response = $this->withHeader('X-Anon-Id', 'anon_header_start')
+            ->postJson('/api/v0.3/attempts/start', [
+                'scale_code' => 'SIMPLE_SCORE_DEMO',
+                'anon_id' => 'anon_payload_start',
+            ]);
+
+        $response->assertStatus(200)->assertJsonPath('ok', true);
+        $attemptId = (string) $response->json('attempt_id');
+        $this->assertNotSame('', $attemptId);
+
+        $attempt = Attempt::query()->findOrFail($attemptId);
+        $this->assertSame('anon_header_start', (string) $attempt->anon_id);
+    }
+}


### PR DESCRIPTION
## Summary
- Add `ResolveAnonId` middleware to parse anonymous identity from transport layer only:
  - `X-Anon-Id` header
  - `fap_anonymous_id_v1` cookie
- Store only `request.attributes.client_anon_id` (do not overwrite `anon_id` / `fm_anon_id`).
- Wire middleware into v0.3 route group before `ResolveOrgContext`.
- Update v0.3 Boot anon resolver priority:
  - token-bound anon (`anon_id` / `fm_anon_id`) > `client_anon_id` > `query anon_id` > generated uuid.
- Update v0.3 attempt start to prefer `client_anon_id` over payload anon id.
- Add feature tests for header-vs-cookie precedence and start flow behavior.

## Why
- Keep ownership/security boundary unchanged (token-bound anon remains authoritative).
- Improve transport-level anon consistency for boot/start and migration period support.

## Tests
- `php artisan route:list`
- `php artisan migrate --force`
- `php -l app/Http/Middleware/FmTokenAuth.php`
- `php artisan test --filter="ResolveAnonIdMiddlewareTest|ExperimentStickyAssignmentTest|AttemptOwnershipTraitTest|HighIdorOwnership404Test"`
- `bash backend/scripts/ci_verify_mbti.sh`
