### PR TITLE
docs(biz): rewrite Phase C core logic specs from service truth

### DIFF
--- a/docs/04-stage2/mbti-report-engine-v1.2.md
+++ b/docs/04-stage2/mbti-report-engine-v1.2.md
@@ -1,91 +1,145 @@
 > Status: Active
-> Owner: liufuwei
-> Last Updated: 2025-12-16
-> Version: MBTI Report Engine v1.2
-> Related Docs:
-> - docs/04-stage2/README.md
-> - docs/04-stage2/mbti-content-package-spec.md
-> - docs/04-stage2/mbti-content-schema.md
-> - docs/03-stage1/api-v0.2-spec.md
+> Last Updated: 2026-02-18
+> Version: Fermat Report Engine v2.0
+> Truth Sources:
+> - app/Services/Report/ReportComposer.php
+> - app/Services/Report/Composer/ReportPayloadAssembler*.php
+> - app/Services/Content/ContentStore.php
+> - app/Services/RuleEngine/ReportRuleEngine.php
+> - app/Services/Report/ReportGatekeeper.php
+> - app/Services/Report/ReportAccess.php
 
-# MBTI 动态报告引擎 v1.2（FAP Content Engine）
-对齐：连续光谱 + 分层叙事 + 卡片矩阵 + 弱特质处理 + 内容图谱承接
+# Fermat 报告生成引擎 v2.0（Assembler / Composer / Gatekeeper）
 
-## 1. 一句话定义
-32 型只写“静态骨架”，差异化主要靠：
-AxisDynamics（轴强度卡片库） + LayerProfiles（分层标签卡片） + AssemblyPolicy（拼装策略）补齐。
-前端 UI 稳定，运营可调阈值/策略，内容可版本化发布。
+## 1. 真理边界与职责切分
+- `AttemptReadController@report` 是 HTTP 入口，负责组织上下文、身份提取、事件打点与响应封装。
+- `ReportGatekeeper` 是访问控制与报告变体决策层，决定 `locked`、`variant`、`modules_*` 与 snapshot 读写策略。
+- `ReportComposer` 是组合门面层，负责把 `Attempt + Result + ctx` 转成可渲染报告，内部委托 `ReportPayloadAssembler`。
+- `ReportPayloadAssembler` 是“报告工厂”核心，完成内容加载、规则筛选、卡片装配、覆盖层合并与最终 payload 归档。
+- `ContentStore` 是内容读取门面，按 `features.content_store_v2` 委托 `ContentStoreV2`，对上游保持稳定 API。
+- `ReportRuleEngine` + `SectionAssembler` 是规则与结构收敛层，确保卡片/高亮/分区输出满足 policy。
 
-## 2. 输入与输出边界
-### 输入（来自测评引擎）
-- type_code：如 ENFJ-A
-- scores：五轴百分比（EI/SN/TF/JP/AT）
-- region / locale（默认 CN_MAINLAND / zh-CN）
-- profile_version（内容包版本指针）
+## 2. 运行时流水线（AttemptReadController -> Gatekeeper -> Composer -> Assembler）
+1. `GET /api/v0.3/attempts/{id}/report` 进入 `AttemptReadController@report`。
+2. 控制器先用 `ownedAttemptQuery` 和 `Result` 查询做资源存在性校验。
+3. 控制器调用 `ReportGatekeeper::resolve(orgId, attemptId, userId, anonId, role)`。
+4. Gatekeeper 计算 `hasFullAccess`、`modules_allowed`、`modules_offered`，确定 `variant=free|full`。
+5. 若满足 snapshot 条件则优先读取 `report_snapshots`；否则进入在线组装。
+6. 在线组装时调用 `ReportComposer::composeVariant()`。
+7. `ReportComposer` 组装 `ReportComposeContext`，执行 `ReportPayloadAssembler::assemble()`。
+8. Assembler 产出 `report` 后，`TemplateEngine` 渲染模板文本；若 `persist=true`，再由 `ReportPersistence` 落盘副本。
+9. Gatekeeper 返回标准 payload：`ok/locked/access_level/variant/offers/modules_*/view_policy/meta/report`。
 
-说明：测评引擎负责算分；报告引擎不关心题目细节。
+## 3. ContentStore 取数链（ContentPackResolver + fallback chain）
+- Assembler 入口在 `ReportPayloadAssemblerComposeEntryTrait::composeInternal()`。
+- 先从 DB 重读 attempt/result，按 `org_id + attempt_id` 固定作用域。
+- 通过 `ContentPackResolver::resolve(scaleCode, region, locale, contentPackageVersion, dirVersion)` 获取 `ResolvedPack`。
+- `toContentPackChain()` 把主包与 fallback 包转换为 `ContentPack[]`，形成有序链。
+- `new ContentStore($chain, $ctx, $contentPackageDir)` 建立读取门面。
+- 读取素材包含：
+  - highlights 模板与规则（`loadHighlights`, `loadSelectRules`）
+  - cards/section policies（`loadCards*`, `loadSectionPolicies`）
+  - overrides/report rules（`loadOverrides`, `loadReportOverrides`）
+  - reads（`loadReads`）
+- `ReportPayloadAssemblerPackDocsTrait` 提供 pack-chain 级 JSON 装载，并在必要时走 legacy loader 兜底。
 
-### 输出（给前端）
-稳定 Report JSON（前端只渲染，不做规则判断）：
-- profile（TypeProfile 静态骨架）
-- scores（五轴 percent + side + state）
-- highlights[]（Top-2 强度轴卡片）
-- borderline_note（最弱轴 <55 的“灵活/双栖提示”）
-- sections.*.cards[]（按规则分发）
-- layers.role/strategy/identity（分层叙事卡）
-- recommended_reads[]（内容图谱推荐，M3 上线）
+## 4. RuleEngine/SectionAssembler 装配阶段（highlights/cards/sections）
+- `TagBuilder` 基于 `scores + type_code + role/strategy` 产出上下文 tags。
+- `SectionCardGenerator` 按 section (`traits/career/growth/relationships`) 选卡，并注入 module 访问信息。
+- `ReportRuleEngine::apply()` 对 `highlights` 与各 section cards 执行 keep/drop 规则。
+- `HighlightBuilder` 先 `buildFromTemplatesDoc()` 再 `finalize()`，得到最终 highlights 列表。
+- `ReportOverridesApplier` / `HighlightsOverridesApplier` 合并运营覆盖策略。
+- `SectionAssembler::apply()` 对 section 结构二次收敛，补充 `_meta.sections.*.assembler`。
 
-## 3. 六模型（v1.2 最终形态）
-### 3.1 TypeProfile（32 型静态骨架）
-- 目的：提供类型主叙事，不随百分比变化
-- 约束：避免写死“极度/一定/总是”这类依赖强度的句子，把强弱解释交给 AxisDynamics
+## 5. Gatekeeper 权限与变体语义
+- variant: `free|full`
+- report_access_level: `free|full`
+- modules: `core_free/core_full/career/relationships`
+- SECTION_TO_MODULE: `traits/growth/stress_recovery->core_full`, `career->career`, `relationships->relationships`
 
-### 3.2 TraitScaleConfig（阈值与状态机）
-- 目的：把 percent → state 变成可配置资产（运营可调）
-- 输出：每条轴生成一个 state
-- 推荐状态集合：
-  - very_weak（≈50–54 或 <55）：触发弱特质叙事（灵活/双栖/情境化）
-  - weak（55–59）
-  - moderate（60–69）
-  - clear（70–84）
-  - strong（85–94）
-  - very_strong（95–100）：更“点中但克制”的风险提示
+补充语义（`ReportGatekeeper`）：
+- 访问主体先过 attempt 所有权过滤：`owner/admin` 全量，`member/viewer` 仅 user 维度，public 走 `user_id|anon_id`。
+- `hasFullAccess` 来自 entitlement；即使有 entitlement，也要检查模块是否覆盖 offered modules。
+- `locked=true` 对应 free 变体；`locked=false` 对应 full 变体。
+- 输出统一带：`modules_allowed/modules_offered/modules_preview`，前端可直接渲染模块权限。
 
-### 3.3 AxisDynamics（轴强度卡片库）
-- 目的：把“百分比不同→文案不同”收敛为可复用卡片
-- 索引维度：
-  - axis：EI/SN/TF/JP/AT
-  - side：E/I, S/N, T/F, J/P, A/T
-  - state：very_weak/weak/moderate/clear/strong/very_strong
-  - card_type：explain / behavior / pitfall / action
-  - region/locale + version
+## 6. Snapshot 优先读取策略
+- `shouldUseSnapshot = hasFullAccess && modulesCoverOffered(modulesAllowed, modulesOffered)`。
+- snapshot 状态机：`pending|failed|ready`。
+- `retry_after_seconds: 3`（常量 `SNAPSHOT_RETRY_AFTER_SECONDS`）。
 
-### 3.4 LayerProfiles（分层标签卡片）
-- RoleProfile（4 类）
-- StrategyProfile（4 类）
-- IdentityProfile（A/T 2 类，必须优先写全）
-用途：作为“第二个个性化引擎”，增强专业感与叙事颗粒度。
+读取规则：
+- `pending`：返回 `ok=true` 且 `meta.generating=true`，report 为空。
+- `failed`：返回 `ok=true` 且 `meta.snapshot_error=true`，report 为空。
+- `ready`：优先读 `report_full_json`，缺失时回退 `report_json`。
+- 无 snapshot 或不满足条件：在线 compose；若为 full 且满足快照条件，可回写 `report_snapshots` 变体。
 
-### 3.5 AssemblyPolicy（拼装控制台）
-由三部分组成：
-- SelectionPolicy：
-  - top_strength_axes：Top-2 强度轴 → highlights[]
-  - weakest_axis：最弱轴（若 very_weak/<55）→ borderline_note
-  - identity_overlay：A/T → 语气滤镜
-- SectionMapping：把卡片分发到 traits/career/growth/relationships
-- ToneFilter：由 A/T + state 控制语气与风险提示力度
+## 7. Free/Full 响应差异与 paywall 字段
+公共字段（两种变体都有）：
+- `ok`
+- `locked`
+- `access_level`
+- `variant`
+- `upgrade_sku`
+- `upgrade_sku_effective`
+- `offers`
+- `modules_allowed/modules_offered/modules_preview`
+- `view_policy`
+- `meta`
+- `report`
 
-### 3.6 ContentGraph（内容图谱与推荐）
-- 目的：承接留存/增长
-- 输出：recommended_reads[]（3–6 条）
-- 推荐依据：top_strength_axes + role + strategy + identity
+差异点：
+- free 变体：
+  - `locked=true`
+  - `access_level=free`
+  - `modules_allowed` 默认至少含 `core_free`
+  - 非 MBTI 且 locked 时会执行 teaser 模糊化
+- full 变体：
+  - `locked=false`
+  - `access_level=full`
+  - `modules_allowed` 覆盖付费模块
+  - 优先走 snapshot，避免历史结果漂移
 
-## 4. 写作与合规约束（摘要）
-- 不做诊断、不替代专业建议；避免“病理化/医疗化”表述
-- 弱特质（very_weak）要强调情境切换与灵活性，不下绝对结论
-- 极强态（very_strong）风险提示要“克制但具体可执行”
+## 8. 错误与降级路径（RESULT_NOT_FOUND / REPORT_FAILED / TEMPLATE_RENDER_FAILED）
+- `ATTEMPT_NOT_FOUND`：attempt 不存在或权限不匹配。
+- `RESULT_NOT_FOUND`：结果未生成，不进入报告拼装。
+- `SCALE_NOT_FOUND` / `SCALE_REQUIRED`：量表注册信息缺失。
+- `REPORT_FAILED`：composer/assembler 失败或返回非数组报告。
+- `REPORT_TEMPLATE_RENDER_FAILED`：`TemplateEngine` 渲染失败（Composer 显式返回 500）。
+- 快照降级：
+  - `pending`/`failed` 不是 HTTP 错误，而是 `ok=true` 的“生成态/错误态元信息”响应。
 
-## 5. 与 Stage 2 里程碑对齐
-- M1：TypeProfile + TraitScaleConfig（能算 state）+ Report 基础输出
-- M2：AxisDynamics（先 Explain+Action）+ IdentityProfile 完整 + highlights[]
-- M3：Role/Strategy + borderline_note + ContentGraph 推荐 + 运营实验迭代阈值/策略
+## 9. Mermaid 时序图（必须）
+```mermaid
+sequenceDiagram
+    autonumber
+    participant C as Client
+    participant ARC as AttemptReadController
+    participant RG as ReportGatekeeper
+    participant ENT as EntitlementManager
+    participant RS as report_snapshots
+    participant RC as ReportComposer
+    participant RPA as ReportPayloadAssembler
+    participant CS as ContentStore
+    participant RRE as ReportRuleEngine
+
+    C->>ARC: GET /api/v0.3/attempts/{id}/report
+    ARC->>RG: resolve(org, attempt, user/anon, role)
+    RG->>ENT: hasFullAccess + allowed modules
+    RG->>RS: query by (org_id, attempt_id)
+    alt snapshot ready
+        RS-->>RG: report_full_json/report_json
+        RG-->>ARC: payload(locked=false, variant=full)
+    else snapshot pending/failed
+        RG-->>ARC: payload(meta.generating/snapshot_error)
+    else build online report
+        RG->>RC: composeVariant(attempt, variant, ctx, result)
+        RC->>RPA: assemble(context)
+        RPA->>CS: load highlights/cards/reads/overrides
+        RPA->>RRE: apply rules (highlights/cards)
+        RPA-->>RC: report payload
+        RC-->>RG: composed report
+        RG-->>ARC: payload(locked free/full)
+    end
+    ARC-->>C: JSON response
+```

--- a/docs/assessment/assessment-engine-v0.3.md
+++ b/docs/assessment/assessment-engine-v0.3.md
@@ -1,105 +1,131 @@
-# Assessment Engine v0.3
+# Assessment Engine v0.3（Attempts / Results Code Truth）
 
-Date: 2026-01-29
+## 1. 真理源（Controller + Request + Service + Migration）
+- 路由：`backend/routes/api.php` (`/api/v0.3/attempts/*`)
+- 控制器：
+  - `app/Http/Controllers/API/V0_3/AttemptWriteController.php`
+  - `app/Http/Controllers/API/V0_3/AttemptReadController.php`
+  - `app/Http/Controllers/API/V0_3/AttemptProgressController.php`
+- 请求校验：
+  - `app/Http/Requests/V0_3/StartAttemptRequest.php`
+  - `app/Http/Requests/V0_3/SubmitAttemptRequest.php`
+- 服务：
+  - `app/Services/Attempts/AttemptStartService.php`
+  - `app/Services/Attempts/AttemptSubmitService.php`
+  - `app/Services/Attempts/AttemptProgressService.php`
+  - `app/Services/Assessment/AssessmentRunner.php`
+  - `app/Services/Attempts/AttemptSubmitSideEffects.php`
+- 迁移：attempts/results/attempt_drafts/attempt_answer_sets/attempt_answer_rows 相关 migration 集合。
 
-## 目标与边界
-- 目标：引入统一 AssessmentEngine + Drivers，实现 v0.3 attempts start/submit/result/report 主链路；新增量表仅需 content pack + scales_registry 即可跑通评分与报告。
-- 非目标：不改 v0.2 主链路；不接入付费锁（PR20）；不引入 answer_sets 存储（PR21）。
+## 2. 接口与鉴权
+- `POST /api/v0.3/attempts/start` (Public)
+- `POST /api/v0.3/attempts/submit` (FmTokenAuth)
+- `PUT/GET /api/v0.3/attempts/{attempt_id}/progress`
+- `GET /api/v0.3/attempts/{id}/result`
+- `GET /api/v0.3/attempts/{id}/report`
 
-## Attempts 生命周期（v0.3）
-1) `POST /api/v0.3/attempts/start`
-   - 输入：`scale_code`（可选 `region/locale/anon_id/client_*`）
-   - 行为：创建 attempts，写入 `started_at`、`pack_id/dir_version`、`question_count`；`scale_version` 固定 `v0.3`。
-   - 输出：`attempt_id + scale_code + pack_id + dir_version`。
+鉴权补充：
+- `start` 在 `ResolveAnonId + ResolveOrgContext` 下可匿名启动 attempt。
+- `submit` 强制 `FmTokenAuth`，并把 `fm_user_id/fm_anon_id` 注入 DTO。
+- `progress` 不强制 FmToken，但要求 `X-Resume-Token` 或可解析 user 身份，否则直接 404。
+- `result/report` 通过 attempt ownership 约束，跨主体访问统一 not found。
 
-2) `POST /api/v0.3/attempts/submit`
-   - 输入：`attempt_id + answers + duration_ms`
-   - 行为：计算 `answers_digest` 幂等锁；调用 AssessmentEngine 评分；写入 results（UNIQUE(org_id,attempt_id)）。
-   - 输出：`result`（固定字段集）+ `attempt_id`。
+## 3. 请求校验真值
+- StartAttemptRequest rules 全量列出
+  - `scale_code`: `required|string|max:64`
+  - `region`: `nullable|string|max:32`
+  - `locale`: `nullable|string|max:16`
+  - `anon_id`: `nullable|string|max:64`
+  - `client_platform`: `nullable|string|max:32`
+  - `client_version`: `nullable|string|max:32`
+  - `channel`: `nullable|string|max:32`
+  - `referrer`: `nullable|string|max:255`
+  - `meta`: `sometimes|array`
+- SubmitAttemptRequest rules 全量列出
+  - `attempt_id`: `required|string|max:64`
+  - `answers`: `nullable|array`
+  - `answers.*.question_id`: `required_with:answers|string|max:128`
+  - `answers.*.code`: `nullable`
+  - `answers.*.question_type`: `nullable|string|max:32`
+  - `answers.*.question_index`: `nullable|integer|min:0`
+  - `duration_ms`: `required|integer|min:0`
+  - `invite_token`: `nullable|string|max:64`
 
-3) `GET /api/v0.3/attempts/{id}/result`
-   - 读取 `results.result_json` 返回，附带 `pack_id/dir_version/scoring_spec_version`。
+Progress（控制器内联校验）：
+- `seq`: `required|integer|min:0`
+- `cursor`: `nullable|string|max:255`
+- `duration_ms`: `required|integer|min:0`
+- `answers`: `nullable|array`
+- `answers.*.question_id`: `required_with:answers|string|max:128`
+- `answers.*.question_type`: `nullable|string|max:32`
+- `answers.*.question_index`: `nullable|integer|min:0`
+- `answers.*.code`: `nullable|string|max:64`
+- `answers.*.answer`: `nullable|array`
 
-4) `GET /api/v0.3/attempts/{id}/report`
-   - MBTI：复用 ReportComposer v1.2（JSON 结构不漂移）。
-   - 非 MBTI：返回 GenericReportBuilder 的最小报告结构。
-   - 返回固定：`{ ok, locked:false, report, meta:{scale_code, pack_id, dir_version, scoring_spec_version, report_engine_version} }`。
+## 4. Attempts 状态流（基于字段而非 status 枚举）
+该链路不使用 `attempts.status` 枚举，而以关键字段驱动：
+- `started_at`：启动时间，`start` 时写入。
+- `submitted_at`：提交完成时间，`submit` 事务内写入。
+- `answers_digest`：提交幂等指纹，计算公式为 `sha256(scale|pack|dir|canonical_answers_json)`。
 
-## ctx 固定字段
-AssessmentEngine 的 `ctx` 统一注入：
-- `duration_ms`（提交耗时）
-- `started_at`, `submitted_at`
-- `region`, `locale`
-- `org_id`
-- `pack_id`, `dir_version`
-- `scoring_spec_version`
+幂等规则：
+- submitted + same digest => 幂等回放（返回已有 result，`idempotent=true`）
+- submitted + different digest => 409 冲突（`CONFLICT`）
+- submitted + digest 为空且已有 result => 兼容回放（历史数据兜底）
 
-## ScoreResult 固定字段
-- `raw_score`：原始得分
-- `final_score`：最终得分（含 time_bonus）
-- `breakdown_json`：分解明细（**time_bonus 固定写在此**）
-- `type_code`：可空（MBTI 输出）
-- `axis_scores_json`：可空（MBTI 轴向百分比/状态）
-- `normed_json`：可空（IQ 归一化/正确率等）
+## 5. Submit 事务链路
+1. 基于 org + 身份 ownership 获取并 `lockForUpdate` 锁定 attempt。
+2. 读取 draft answers，与本次请求 answers 合并（question_id 维度覆盖）。
+3. 计算 `answers_digest`，执行提交幂等分支判断。
+4. 调用 `AssessmentRunner::run()` 评分。
+5. 更新 attempt：`pack_id/dir_version/content_package_version/scoring_spec_version/submitted_at/duration_ms/answers_digest`。
+6. 持久化答案：
+   - `AnswerSetStore::storeFinalAnswers`
+   - `AnswerRowWriter::writeRows`
+7. upsert results (`org_id + attempt_id` 唯一约束)：
+   - 核心字段：`type_code/scores_json/scores_pct/axis_states/result_json/report_engine_version`
+8. 事务提交后执行 side effects：
+   - 绑定 invite assignment（可选）
+   - 钱包消费/权益发放（按 benefit code）
+   - `seedPendingSnapshot`（trigger submit）
+   - `GenerateReportSnapshotJob::dispatch(...)->afterCommit()`
+9. 清理 progress 草稿并附加 gatekeeper report payload 到 submit 响应。
 
-## scoring_spec.json 最小契约（示例）
-### 1) simple_score
+## 6. Results 写入契约（scores_json/scores_pct/axis_states/result_json）
+- `scores_json`：轴向分数明细（优先来自 `axisScoresJson.scores_json`）。
+- `scores_pct`：百分位/百分比分布。
+- `axis_states`：轴状态（如 moderate/strong）。
+- `result_json`：结构化结果快照（含 `type_code/pack_id/dir_version/content_package_version/scoring_spec_version/computed_at`）。
+- `report_engine_version`：当前提交链写 `v1.2`。
+
+## 7. 错误码与失败模式矩阵
+- Start 阶段：
+  - 400 `VALIDATION_FAILED`：`scale_code` 缺失
+  - 404 `NOT_FOUND`：scale 未注册
+  - 500 `CONTENT_PACK_ERROR`：pack/题库不可用
+- Submit 阶段：
+  - 400 `VALIDATION_FAILED`：attempt_id 缺失/attempt scale 缺失
+  - 404 `NOT_FOUND`：attempt 或 scale 不存在
+  - 422 `VALIDATION_FAILED`：answers 为空
+  - 409 `CONFLICT`：重复提交且 digest 不一致
+  - 500 `SCORING_FAILED` 或 `INTERNAL_ERROR`
+- Progress 阶段：
+  - 404 `DRAFT_NOT_FOUND`
+  - 410 `RESUME_EXPIRED`
+  - 409 `SEQ_OUT_OF_ORDER`
+- Report 附加阶段：
+  - Gatekeeper 异常时 submit 仍返回主结果，但 report 降级为 locked/free 占位。
+
+## 8. Mermaid 状态图（必须）
+```mermaid
+stateDiagram-v2
+    [*] --> Started: POST /attempts/start
+    Started --> Drafting: PUT /attempts/{id}/progress
+    Drafting --> Drafting: PUT /progress (seq increase)
+    Started --> Submitting: POST /attempts/submit
+    Drafting --> Submitting: POST /attempts/submit
+    Submitting --> Submitted: submitted_at set + results upsert
+    Submitted --> Submitted: submit same answers_digest (idempotent replay)
+    Submitted --> Conflict409: submit different answers_digest
+    Conflict409 --> Submitted
 ```
-{
-  "version": "2026.01",
-  "scale_code": "SIMPLE_SCORE_DEMO",
-  "driver_type": "simple_score",
-  "answer_scores": {
-    "SS-001": {"1": 1, "2": 2, "3": 3, "4": 4, "5": 5}
-  },
-  "severity_levels": [
-    {"min": 0, "max": 9, "label": "low"},
-    {"min": 10, "max": 17, "label": "medium"},
-    {"min": 18, "max": 25, "label": "high"}
-  ]
-}
-```
-
-### 2) generic_likert
-```
-{
-  "version": "2026.01",
-  "scale_code": "LIKERT_DEMO",
-  "driver_type": "generic_likert",
-  "options_score_map": {"1": 1, "2": 2, "3": 3, "4": 4, "5": 5},
-  "dimensions": {
-    "stress": {
-      "items": {"Q1": 1, "Q2": 1, "Q3": -1}
-    }
-  }
-}
-```
-
-### 3) iq_test
-```
-{
-  "version": "2026.01",
-  "scale_code": "IQ_RAVEN",
-  "driver_type": "iq_test",
-  "answer_key": {"RAVEN_DEMO_1": "B"},
-  "score": {"correct": 1, "wrong": 0},
-  "time_bonus": {
-    "rules": [
-      {"max_ms": 30000, "bonus": 3},
-      {"max_ms": 60000, "bonus": 2},
-      {"max_ms": 120000, "bonus": 1},
-      {"max_ms": 99999999, "bonus": 0}
-    ]
-  }
-}
-```
-
-## 幂等策略（answers_digest）
-- 提交时将 `answers` 按 `question_id` 排序，仅保留 `question_id + code`，再做 sha256。
-- 已提交且 digest 相同：直接返回已有结果。
-- 已提交且 digest 不同：返回 409（`ATTEMPT_ALREADY_SUBMITTED`）。
-
-## MBTI 报告契约不漂移策略
-- v0.3 MBTI 报告仍使用 `ReportComposer` v1.2。
-- results 必须写入 `scores_pct + axis_states + scores_json` 以保证报告可用。
-- report 响应固定 `locked=false`，付费锁在 PR20 处理。


### PR DESCRIPTION
## 背景
Phase A（API 契约）与 Phase B（数据库/数据流）完成后，本 PR 启动并完成 Phase C：核心业务逻辑文档重写。目标是把业务文档与当前 Service/Manager/Job/Controller 真实实现对齐，清除历史叙述漂移。

## 变更范围（仅文档）
本 PR **不改任何运行时代码**，仅重写以下 4 份核心业务文档：
- `/Users/rainie/Desktop/GitHub/fap-api/docs/04-stage2/mbti-report-engine-v1.2.md`
- `/Users/rainie/Desktop/GitHub/fap-api/docs/assessment/assessment-engine-v0.3.md`
- `/Users/rainie/Desktop/GitHub/fap-api/docs/payments/order-state-machine.md`
- `/Users/rainie/Desktop/GitHub/fap-api/docs/commerce/report-snapshot-v1.md`

## 核心对齐点
### 1) 报告引擎（Assembler / Composer / Gatekeeper）
- 明确运行时主链路：`AttemptReadController -> ReportGatekeeper -> ReportComposer -> ReportPayloadAssembler`
- 明确 `ContentStore + ContentPackResolver + fallback chain` 的真实取数方式
- 补全 `ReportRuleEngine / SectionAssembler` 在 highlights/cards/sections 阶段的职责
- 补全 Gatekeeper 变体语义：`variant`, `access_level`, `modules_allowed/offered/preview`
- 明确 snapshot 优先读策略与 `retry_after_seconds=3` 语义

### 2) Attempts/Results 状态流（v0.3）
- 以字段状态为核心：`started_at / submitted_at / answers_digest`
- 明确 submit 幂等与冲突：
  - same digest -> 幂等回放
  - different digest -> `409 CONFLICT`
- 补全 `StartAttemptRequest` / `SubmitAttemptRequest` 真值规则
- 补全 submit 事务链：合并草稿答案、评分、upsert results、post-commit side effects、seed snapshot、dispatch job

### 3) 订单状态机（OrderManager 真值）
- 迁移矩阵完全按 `OrderManager::isTransitionAllowed()` 重写
- 补全 webhook 推进规则：`refund -> refunded`；非 refund 走 `transitionToPaidAtomic -> fulfilled`
- 明确并发/幂等语义：`lockForUpdate + compare-and-update`
- 历史纠偏：`gifted` 标记为历史态，不属于当前状态机真值

### 4) 报告快照（异步链路）
- 明确双入口：submit 后、payment webhook 后
- 明确 Job 语义：`tries=3`, `backoff=[5,10,20]`, `pending|ready|failed`
- 明确读取链路在 Gatekeeper，pending/failed 的元信息返回语义
- 纠偏 ReportLookup 认知：
  - `/api/v0.2/lookup/*` 仅做定位并返回 `report_api`
  - 真正消费 snapshot 的是 `/api/v0.3/attempts/{id}/report`
  - v0.2 legacy report 仍走 `legacy report_jobs` 链路

## 路由/接口影响
- **No runtime API changes**
- **No DB schema changes**
- 仅文档契约更新与历史表述纠偏

## 验证
已执行：
- `cd backend && php artisan route:list` ✅
- `cd backend && php artisan migrate` ✅（Nothing to migrate）
- `cd /Users/rainie/Desktop/GitHub/fap-api && bash backend/scripts/ci_verify_mbti.sh` ✅（全链路通过）

说明：
- `curl http://127.0.0.1:8000/...` 在本地执行时因 8000 端口未启动服务而连接失败；
- CI 验证脚本内使用独立端口启动服务并完成 E2E 校验，结果通过。

## 风险与不变项
- 风险：低（仅 markdown 文档改造）
- 不变项：路由、控制器、服务、迁移、模型均未修改
