### PR TITLE
docs(ops): rewrite Phase D deployment and operations runbooks from code truth

### DIFF
--- a/README_DEPLOY.md
+++ b/README_DEPLOY.md
@@ -1,97 +1,196 @@
-# README_DEPLOY
+# Fermat 生产环境部署指南 v2.0
 
-## 1) 唯一交付包
+Status: Active  
+Last Updated: 2026-02-18  
+Truth Source: `backend/composer.json` / `backend/package.json` / `backend/config/queue.php` / `backend/.env.example`
 
-唯一允许产物：`dist/fap-api-release.zip`
+## 1. 真理边界
+本指南只描述当前仓库真实可执行的生产部署路径。
+- 依赖版本以 `composer.json`、`package.json` 为准。
+- 队列运行模型以 `config/queue.php` 与 Jobs 实现为准。
+- 当前仓库 **无** `config/horizon.php`，不使用 Horizon 作为官方基线。
 
-生成命令：
+## 2. 生产环境硬性要求
+- PHP 8.2+（`composer.json` 约束：`^8.2`）
+- MySQL 8.0+
+- Redis 6+
+- Node 20 LTS+（仓库未锁定 engines，按 Vite 7 生产构建建议）
+- Composer 2.x
+- NPM 10+
 
+推荐 PHP 扩展（Laravel 生产常规）：
+- `pdo_mysql`
+- `redis`（phpredis）
+- `mbstring`
+- `openssl`
+- `json`
+- `fileinfo`
+- `tokenizer`
+- `ctype`
+- `xml`
+
+## 3. 部署拓扑（简版）
+- Nginx/Apache（反向代理）
+- PHP-FPM（Laravel 应用）
+- MySQL（主库）
+- Redis（cache + queue lock）
+- Supervisor（驻留 queue workers）
+
+## 4. 配置清单（上线必填）
+以 `backend/.env.example` 为模板，生产必须由密钥系统注入。
+
+### 4.1 基础与数据库
+- `APP_ENV=production`
+- `APP_DEBUG=false`
+- `APP_KEY`
+- `DB_CONNECTION=mysql`
+- `DB_HOST`, `DB_PORT`, `DB_DATABASE`, `DB_USERNAME`, `DB_PASSWORD`
+
+### 4.2 Redis / Cache / Queue
+- `CACHE_STORE=redis`
+- `QUEUE_CONNECTION=redis`（若未覆盖，生产默认也是 redis）
+- `REDIS_HOST`, `REDIS_PORT`, `REDIS_PASSWORD`
+- `REDIS_CACHE_CONNECTION` / `REDIS_QUEUE_CONNECTION`（按集群策略可选）
+
+### 4.3 Webhook Secrets
+- `STRIPE_WEBHOOK_SECRET`
+- `BILLING_WEBHOOK_SECRET`
+- `INTEGRATIONS_WEBHOOK_*_SECRET`
+
+### 4.4 Admin/Auth
+- `FAP_ADMIN_TOKEN`
+- `EVENT_INGEST_TOKEN`
+- `FAP_ADMIN_PANEL_ENABLED=true`
+- `FAP_ADMIN_GUARD=admin`
+
+### 4.5 Object Storage / 内容包
+- `AWS_ACCESS_KEY_ID`
+- `AWS_SECRET_ACCESS_KEY`
+- `AWS_BUCKET`
+- `FAP_PACKS_DRIVER`（local/s3）
+- `FAP_S3_PREFIX`（若 driver=s3）
+
+### 4.6 Mail
+- `MAIL_MAILER`, `MAIL_HOST`, `MAIL_PORT`, `MAIL_USERNAME`, `MAIL_PASSWORD`
+- `MAIL_FROM_ADDRESS`, `MAIL_FROM_NAME`
+
+### 4.7 Ops 安全
+- `OPS_ALLOWED_HOST`
+- `OPS_IP_ALLOWLIST`
+- `OPS_ADMIN_TOTP_ENABLED=true`
+
+> 禁止将真实密钥写入仓库、压缩包或日志。
+
+## 5. 发布步骤（可执行）
 ```bash
-bash scripts/release_pack.sh
-```
+cd /opt/fap-api/backend
 
-审计命令：
+# 1) 拉取代码
+# git pull --ff-only origin <release-branch-or-tag>
 
-```bash
-bash scripts/audit_smoke.sh dist/fap-api-release.zip
-bash scripts/release_hygiene_gate.sh ./_audit/fap-api-0212-5/
-bash scripts/supply_chain_gate.sh ./_audit/fap-api-0212-5
-```
-
-## 2) 交付包内容边界
-
-交付包根目录固定为：
-
-- `backend/`
-- `scripts/`
-- `docs/`
-- `README_DEPLOY.md`
-
-不包含：
-
-- `.env/.env.*`（`backend/.env.example` 允许）
-- `.git/`
-- `vendor/`
-- `node_modules/`
-- `backend/storage/logs/`
-- `backend/artifacts/`
-- `*.sqlite*`
-- `backend/storage/app/private/reports/`
-- `__MACOSX/`
-- `.DS_Store`
-
-## 3) 部署最短路径（不依赖本地 .env，不打包 vendor）
-
-```bash
-unzip -q dist/fap-api-release.zip -d /opt/fap-api-release
-cd /opt/fap-api-release/backend
-
-cp .env.example .env
-# 通过密钥系统注入生产变量（禁止提交真实密钥）
-# 例如：DB_*, APP_KEY, STRIPE_WEBHOOK_SECRET, FAP_ADMIN_TOKEN ...
-
+# 2) 安装后端依赖
 composer install --no-dev --optimize-autoloader
+
+# 3) 构建前端资源（若发布工件不含构建产物）
+npm ci
+npm run build
+
+# 4) 数据库迁移
 php artisan migrate --force
+
+# 5) 缓存与路由缓存
 php artisan config:cache
 php artisan route:cache
+
+# 6) 基线校验
+php artisan fap:schema:verify
 ```
 
-说明：
+## 6. Supervisor 队列守护配置（无 Horizon）
+当前基线：使用 Supervisor 常驻 `queue:work`。至少部署以下两个 program。
 
-- 交付包不含 `vendor`，必须在部署环境执行 `composer install`。
-- 交付包不依赖本地开发机 `.env`。
+### 6.1 必配 program：default/high
+```ini
+[program:fap-queue-default-high]
+directory=/opt/fap-api/backend
+command=/usr/bin/php artisan queue:work redis --queue=high,default --sleep=1 --tries=3 --timeout=120 --max-time=3600
+process_name=%(program_name)s_%(process_num)02d
+numprocs=2
+autostart=true
+autorestart=true
+stopasgroup=true
+killasgroup=true
+user=www-data
+redirect_stderr=true
+stdout_logfile=/var/log/supervisor/fap-queue-default-high.log
+stopwaitsecs=360
+```
 
-## 4) 回滚
+### 6.2 必配 program：reports（报告生成）
+```ini
+[program:fap-queue-reports]
+directory=/opt/fap-api/backend
+command=/usr/bin/php artisan queue:work database --queue=reports --sleep=1 --tries=3 --timeout=180 --max-time=3600
+process_name=%(program_name)s_%(process_num)02d
+numprocs=2
+autostart=true
+autorestart=true
+stopasgroup=true
+killasgroup=true
+user=www-data
+redirect_stderr=true
+stdout_logfile=/var/log/supervisor/fap-queue-reports.log
+stopwaitsecs=360
+```
 
-1. 使用上一个可用 `fap-api-release.zip`。
-2. 解压后按同样部署步骤执行。
-3. 通过包内 `docs/release/RELEASE_MANIFEST.json` 核对 `commit_sha` 与构建时间。
+### 6.3 推荐 program（按业务拆分）
+- `fap-queue-ops` -> `--queue=ops`
+- `fap-queue-commerce` -> `--queue=commerce`
+- `fap-queue-content` -> `--queue=content`
+- `fap-queue-insights` -> `--queue=insights`
 
-## 5) 验收步骤（标准动作）
+> 说明：
+> - 报告相关作业主队列是 `reports`（`GenerateReportSnapshotJob`、legacy `GenerateReportJob`）。
+> - `high/default` 作为通用优先级队列，承接未显式队列任务。
 
+### 6.4 生效命令
 ```bash
-bash scripts/release_pack.sh
-bash scripts/audit_smoke.sh dist/fap-api-release.zip
-bash scripts/release_hygiene_gate.sh ./_audit/fap-api-0212-5/
-bash scripts/supply_chain_gate.sh ./_audit/fap-api-0212-5
+sudo supervisorctl reread
+sudo supervisorctl update
+sudo supervisorctl restart fap-queue-default-high:*
+sudo supervisorctl restart fap-queue-reports:*
+# 可选
+sudo supervisorctl restart fap-queue-ops:*
+sudo supervisorctl restart fap-queue-commerce:*
+sudo supervisorctl restart fap-queue-content:*
+sudo supervisorctl restart fap-queue-insights:*
 ```
 
-`audit_smoke.sh` 输出必须包含固定标题与三段证据：
-1. `EVIDENCE-1: REQUIRED ENTRY`
-2. `EVIDENCE-2: REQUIRED STRUCTURE`
-3. `EVIDENCE-3: CONTAMINATION HITS`
-
-## 6) 内容包闸门命令
-
-上线前必须执行：
-
+## 7. 发布后验收
 ```bash
-cd backend
-php artisan content:lint --all
-php artisan content:compile --all
+cd /opt/fap-api/backend
+php artisan route:list
+php artisan migrate
+
+curl -i http://127.0.0.1:8000/api/v0.2/health
+curl -i http://127.0.0.1:8000/api/v0.4/boot
+curl -i -X POST http://127.0.0.1:8000/api/v0.3/attempts/start -H 'Content-Type: application/json' -d '{"scale_code":"MBTI"}'
+
+cd /opt/fap-api
+bash backend/scripts/ci_verify_mbti.sh
 ```
 
-失败解释：
+通过标准：
+- 路由与迁移命令成功。
+- 健康检查接口可达。
+- MBTI CI 验收链路通过。
 
-- `content:lint` 失败：存在 JSON 结构错误、缺少必填字段、`access_level` 非法值、section 不在 policies、或模板变量不在白名单。
-- `content:compile` 失败：通常由 lint 未通过导致，或编译产物写入失败。修复后重跑可覆盖生成 `compiled/*` 文件。
+## 8. 回滚流程
+1. 切换到上一个可用发布版本（代码/工件）。
+2. 执行依赖安装与缓存重建（同部署步骤）。
+3. 迁移策略：本仓库以 forward-only 迁移为主，回滚优先采用“新修复迁移”而非 destructive rollback。
+4. 队列处理顺序：
+   - 先 `supervisorctl stop fap-queue-*`（或逐组停）
+   - 完成代码切换/配置恢复
+   - 再按 `reports -> default/high -> 其他队列` 顺序启动
+5. 验收通过后恢复流量。

--- a/backend/docs/ops/admin-console.md
+++ b/backend/docs/ops/admin-console.md
@@ -1,0 +1,125 @@
+# Filament 运营控制塔手册
+
+Status: Active  
+Last Updated: 2026-02-18  
+Truth Source: `app/Providers/Filament/*PanelProvider.php` + `app/Filament/Ops/**/*`
+
+## 1. 控制台入口与鉴权
+- `/ops`（Admin Panel，id=`ops`）
+- `/tenant`（Tenant Panel，id=`tenant`）
+
+Admin Panel 关键中间件（真值）：
+- `SetOpsLocale`
+- `SetOpsRequestContext`
+- `ResolveOrgContext`
+- `EnsureAdminTotpVerified`
+- `RequireOpsOrgSelected`
+- `OpsAccessControl`
+
+核心鉴权要点：
+- guard：`config('admin.guard', 'admin')`
+- 启用 TOTP（二次验证）
+- 强制组织上下文选择后才进入大部分操作页面
+
+## 2. 信息架构总览（按分组）
+- Governance
+- Commerce
+- Content
+- Support
+- SRE
+
+## 3. Resources 清单（逐项）
+- `AdminApprovalResource`
+- `AdminUserResource`
+- `AuditLogResource`
+- `BenefitGrantResource`
+- `ContentPackReleaseResource`
+- `ContentPackVersionResource`
+- `DeployResource`
+- `OrderResource`
+- `OrganizationResource`
+- `PaymentEventResource`
+- `PermissionResource`
+- `RoleResource`
+- `ScaleRegistryResource`
+- `ScaleSlugResource`
+- `SkuResource`
+
+## 4. Pages 与 Widgets 清单
+### 4.1 Pages
+- `OpsDashboard`
+- `OrderLookup`
+- `DeliveryTools`
+- `QueueMonitor`
+- `WebhookMonitor`
+- `HealthChecks`
+- `GoLiveGatePage`
+- `SelectOrgPage`
+- `OrganizationsImportPage`
+- `GlobalSearchPage`
+- `SecureLink`
+- `TwoFactorChallenge`
+
+### 4.2 Widgets
+- `CommerceKpiWidget`
+- `WebhookFailureWidget`
+- `QueueFailureWidget`
+- `HealthzStatusWidget`
+- `FunnelWidget`
+
+## 5. 运营能做什么（场景化）
+### 5.1 查单
+- 入口：`OrderLookup`
+- 可按 `order_no / attempt_id / email` 检索
+- 联动查看：订单、支付事件、权益发放、attempt
+
+### 5.2 退款申请
+- 入口：`OrderResource -> Request Refund`
+- 机制：提交审批单（`AdminApproval`），由审批流执行实际动作
+
+### 5.3 重处理支付事件
+- 入口：`PaymentEventResource -> Request Reprocess`
+- 机制：创建 `REPROCESS_EVENT` 审批，再由后台 job 执行
+
+### 5.4 重试审批执行
+- 入口：`AdminApprovalResource -> Retry Execute`
+- 适用：`FAILED` 或 `APPROVED` 但未成功执行的审批
+
+### 5.5 重发/补发报告相关
+- 入口：`DeliveryTools`
+- 机制：发起 `MANUAL_GRANT` 类型审批（含 order/attempt 载荷），由 `AdminApproval` 执行链处理
+
+### 5.6 失败任务重试
+- 入口：`QueueMonitor`
+- 操作：对 `failed_jobs` 单条执行 retry（内部调用 `queue:retry`）
+
+## 6. 权限与审批流
+### 6.1 权限语义（概括）
+- 菜单可见性与操作权限通过 `PermissionNames` 常量集控制。
+- 常见能力边界：
+  - Commerce 读写
+  - Content 读/发布/探针
+  - Governance 审批复核
+  - SRE 监控与故障处置
+
+### 6.2 审批状态流
+`PENDING -> APPROVED/REJECTED -> EXECUTING -> EXECUTED/FAILED`
+
+说明：
+- Approve 后会 `dispatch ExecuteApprovalJob`（queue=`ops`）。
+- 执行失败会落 `FAILED`，可通过 `Retry Execute` 再次触发。
+
+## 7. 故障应急入口（值班顺序）
+1. `OpsDashboard`：先看总体红灯（webhook/queue/health）。
+2. `WebhookMonitor`：确认支付回调是否异常堆积（signature/status/handle_status）。
+3. `QueueMonitor`：确认失败任务、执行 retry。
+4. `OrderLookup`：按用户投诉单号快速定位订单/attempt/权益状态。
+5. `AdminApprovalResource`：排查审批卡点（是否 stuck 在 PENDING/FAILED）。
+6. `AuditLogResource`：追踪谁在什么时候执行了什么动作。
+
+## 8. 值班最小操作清单
+- 查单：`/ops/order-lookup`
+- 看队列失败：`/ops/queue-monitor`
+- 看 webhook 失败：`/ops/webhook-monitor`
+- 审批补偿动作：`/ops/admin-approvals`
+- 触发内容探针：`/ops/content-pack-releases` -> `Run Probe`

--- a/backend/docs/ops/queue-runbook.md
+++ b/backend/docs/ops/queue-runbook.md
@@ -1,0 +1,154 @@
+# Queue Runbook（异步任务运维版）
+
+Status: Active  
+Last Updated: 2026-02-18  
+Truth Source: `config/queue.php`, `app/Jobs/*`, `Phase C snapshot chain`
+
+## 1. 队列架构真值
+- 当前无 Horizon（`config/horizon.php` 不存在）。
+- 队列由 `config/queue.php` 驱动。
+- 生产默认 `QUEUE_CONNECTION=redis`（未显式覆盖时）。
+
+## 1.1 连接/队列映射
+| 任务域 | 连接 | 队列 | 代码锚点 |
+|---|---|---|---|
+| 报告快照生成 | database | reports | `GenerateReportSnapshotJob` |
+| Legacy 报告生成 | runtime dispatch | reports | `GenerateReportJob` |
+| 审批执行 | database | ops | `ExecuteApprovalJob` |
+| 内容探针 | database | content | `RunContentProbeJob` |
+| 商业退款 | database | commerce | `RefundOrderJob` |
+| 支付事件重放 | database | commerce | `ReprocessPaymentEventJob` |
+| AI 洞察 | default + config | insights | `GenerateInsightJob` |
+| 通用任务 | default connection | high/default | 平台保底 worker |
+
+## 2. Worker 驻留规范
+生产建议使用 Supervisor 分组驻留，不使用 horizon。
+
+### 2.1 推荐 Supervisor 样例
+```ini
+[program:fap-queue-default-high]
+directory=/opt/fap-api/backend
+command=/usr/bin/php artisan queue:work redis --queue=high,default --sleep=1 --tries=3 --timeout=120 --max-time=3600
+numprocs=2
+autostart=true
+autorestart=true
+stopasgroup=true
+killasgroup=true
+stdout_logfile=/var/log/supervisor/fap-queue-default-high.log
+stopwaitsecs=360
+
+[program:fap-queue-reports]
+directory=/opt/fap-api/backend
+command=/usr/bin/php artisan queue:work database --queue=reports --sleep=1 --tries=3 --timeout=180 --max-time=3600
+numprocs=2
+autostart=true
+autorestart=true
+stopasgroup=true
+killasgroup=true
+stdout_logfile=/var/log/supervisor/fap-queue-reports.log
+stopwaitsecs=360
+
+[program:fap-queue-ops]
+command=/usr/bin/php artisan queue:work database --queue=ops --sleep=1 --tries=3 --timeout=120 --max-time=3600
+
+[program:fap-queue-commerce]
+command=/usr/bin/php artisan queue:work database --queue=commerce --sleep=1 --tries=3 --timeout=180 --max-time=3600
+
+[program:fap-queue-content]
+command=/usr/bin/php artisan queue:work database --queue=content --sleep=1 --tries=2 --timeout=120 --max-time=3600
+
+[program:fap-queue-insights]
+command=/usr/bin/php artisan queue:work redis --queue=insights --sleep=1 --tries=3 --timeout=180 --max-time=3600
+```
+
+### 2.2 发布后生效
+```bash
+sudo supervisorctl reread
+sudo supervisorctl update
+sudo supervisorctl restart fap-queue-default-high:*
+sudo supervisorctl restart fap-queue-reports:*
+sudo supervisorctl restart fap-queue-ops:*
+sudo supervisorctl restart fap-queue-commerce:*
+sudo supervisorctl restart fap-queue-content:*
+sudo supervisorctl restart fap-queue-insights:*
+```
+
+## 3. 报告生成卡住（重点）
+现象：用户提交后报告长期 loading，或 `report_snapshots.status` 长时间 `pending`。
+
+排查顺序：
+1. 检查 `reports` worker 是否存活。  
+2. 检查 `jobs` 表中 `queue=reports` 是否堆积。  
+3. 检查 `failed_jobs` 最近失败任务（是否为 `GenerateReportSnapshotJob` / `GenerateReportJob`）。  
+4. 检查 `report_snapshots`：
+   - `status` 是否长期 `pending`
+   - `last_error` 是否持续更新
+5. 检查应用日志关键字：
+   - `REPORT_SNAPSHOT_GENERATE_FAILED`
+6. 若 payment 链触发，额外检查 `payment_events.handle_status` 是否 `reprocess_failed/failed`。
+
+## 4. 失败任务重试标准操作
+```bash
+cd /opt/fap-api/backend
+php artisan queue:failed
+php artisan queue:retry <id>
+# 谨慎：批量
+php artisan queue:retry all
+
+# 清理单条失败记录（确认不再需要重试时）
+php artisan queue:forget <id>
+
+# 清空 failed_jobs（高风险，需审批）
+php artisan queue:flush
+```
+
+使用边界：
+- `retry all` 只在根因已修复且已评估幂等性时执行。
+- `queue:flush` 只允许在故障复盘后、经审批执行。
+
+## 5. 按队列故障分诊
+### 5.1 reports（报告快照/legacy report）
+- 关注表：`jobs`, `failed_jobs`, `report_snapshots`, `report_jobs`
+- 典型问题：内容包不可读、result 缺失、snapshot 持续 pending
+
+### 5.2 ops（审批执行）
+- 关注表：`admin_approvals`, `audit_logs`
+- 典型问题：审批 stuck 在 `APPROVED/EXECUTING/FAILED`
+
+### 5.3 commerce（退款/重处理）
+- 关注表：`orders`, `payment_events`, `benefit_grants`
+- 典型问题：`handle_status=reprocess_failed`
+
+### 5.4 content（探针）
+- 关注表：`content_pack_releases`
+- 典型问题：`probe_ok=0`、`probe_json` 显示 health/questions 失败
+
+### 5.5 insights（AI）
+- 关注表：`ai_insights`
+- 典型问题：预算/外部 provider 超时导致 failed
+
+## 6. SLO 与告警建议
+- `failed_jobs` 总量 > 0 且持续 5 分钟：warning
+- `jobs(queue=reports)` 积压超过阈值（例如 > 100）且 10 分钟无下降：critical
+- `report_snapshots.status=pending` 超时（例如 > 5 分钟）占比异常：warning
+- `payment_events.handle_status in (failed,reprocess_failed)` 激增：warning
+
+## 7. 演练清单
+1. 人工制造一条失败任务（测试环境）。
+2. 在 `QueueMonitor` 与 CLI 同步确认失败记录。
+3. 执行 `php artisan queue:retry <id>`。
+4. 验证：
+   - 任务状态变化
+   - 业务状态恢复（例如 snapshot 变为 ready）
+   - 审计日志有对应记录
+5. 记录演练时间、执行人、结论。
+
+## 8. 常用诊断命令
+```bash
+cd /opt/fap-api/backend
+php artisan queue:failed
+php artisan queue:work --once --queue=reports
+php artisan queue:work --once --queue=ops
+php artisan tinker
+# 在 tinker 中可查询 jobs/failed_jobs/report_snapshots/admin_approvals
+```


### PR DESCRIPTION
## 背景
Phase A/B/C 完成后，运维与部署文档仍存在与当前代码实现不一致的问题。  
本 PR 完成 Phase D：以当前配置与实现为真值，重写部署与运维文档，保证值班与故障处置可直接落地。

## 变更清单
- Modified: `/Users/rainie/Desktop/GitHub/fap-api/README_DEPLOY.md`
  - 重写为《Fermat 生产环境部署指南 v2.0》
  - 明确依赖基线：PHP 8.2+ / MySQL 8.0+ / Redis 6+ / Node 20 LTS+
  - 明确当前不使用 Horizon，采用 Supervisor 常驻 worker
  - 提供 default/high、reports 及 ops/commerce/content/insights 的守护示例
- Added: `/Users/rainie/Desktop/GitHub/fap-api/backend/docs/ops/admin-console.md`
  - 新建《Filament 运营控制塔手册》
  - 对齐 `/ops`、`/tenant` 面板，列出实际 Resources / Pages / Widgets
  - 增加查单、退款申请、支付事件重处理、审批重试、队列重试的值班操作路径
- Added: `/Users/rainie/Desktop/GitHub/fap-api/backend/docs/ops/queue-runbook.md`
  - 新建异步队列 runbook（无 Horizon）
  - 对齐 queue 连接与队列分工（reports/ops/commerce/content/insights）
  - 增加报告卡住场景的排障步骤与 `queue:retry` 标准操作

## 代码真值对齐要点
- `backend/composer.json`: PHP `^8.2`, Laravel 12, Filament 3
- `backend/package.json`: Vite 7（未锁 engines）
- `backend/config/queue.php`: 生产默认 redis（未覆盖时）
- `backend/config/horizon.php`: 不存在（当前不走 Horizon）
- Job 队列事实：
  - `GenerateReportSnapshotJob`: database/reports, tries=3, backoff=[5,10,20]
  - `ExecuteApprovalJob`: database/ops
  - `RunContentProbeJob`: database/content
  - `RefundOrderJob` / `ReprocessPaymentEventJob`: database/commerce
  - `GenerateInsightJob`: insights（来自 `config/ai.php`）

## 验证
- `php artisan route:list` ✅
- `php artisan migrate` ✅（Nothing to migrate）
- `bash backend/scripts/ci_verify_mbti.sh` ✅
- `curl` smoke（`127.0.0.1:8000`）在本地未启动 server 时返回连接失败（exit 7）

## 风险与不变项
- No runtime API changes
- No DB schema changes
- No queue behavior changes
- 仅文档层重写与新增
