### PR TITLE
chore(ci): align Phase D runtimes and service containers

### DIFF
--- a/.github/workflows/ci_verify_mbti.yml
+++ b/.github/workflows/ci_verify_mbti.yml
@@ -90,7 +90,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: '8.2'
+          php-version: '8.4'
           coverage: none
           tools: composer:v2
           extensions: >
@@ -107,9 +107,9 @@ jobs:
           path: |
             backend/vendor
             ~/.composer/cache/files
-          key: ${{ runner.os }}-php82-${{ hashFiles('backend/composer.lock') }}
+          key: ${{ runner.os }}-php84-${{ hashFiles('backend/composer.lock') }}
           restore-keys: |
-            ${{ runner.os }}-php82-
+            ${{ runner.os }}-php84-
 
       - name: Prepare Laravel cache dirs (for package:discover)
         working-directory: backend

--- a/.github/workflows/ci_verify_mbti.yml
+++ b/.github/workflows/ci_verify_mbti.yml
@@ -27,6 +27,29 @@ jobs:
             FEATURE_PAYMENT_WEBHOOK_V2: "true"
             FEATURE_CONTENT_STORE_V2: "true"
 
+    services:
+      mysql:
+        image: mysql:8.0
+        env:
+          MYSQL_DATABASE: fap_ci
+          MYSQL_ROOT_PASSWORD: root
+        ports:
+          - "3306:3306"
+        options: >-
+          --health-cmd="mysqladmin ping -h 127.0.0.1 -proot"
+          --health-interval=10s
+          --health-timeout=5s
+          --health-retries=12
+      redis:
+        image: redis:6-alpine
+        ports:
+          - "6379:6379"
+        options: >-
+          --health-cmd="redis-cli ping || exit 1"
+          --health-interval=10s
+          --health-timeout=5s
+          --health-retries=12
+
     env:
       APP_ENV: ci
       APP_DEBUG: "true"
@@ -67,11 +90,16 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: '8.4'
+          php-version: '8.2'
           coverage: none
           tools: composer:v2
           extensions: >
-            mbstring, intl, curl, json, openssl, fileinfo, pdo, pdo_sqlite, sqlite3
+            mbstring, intl, curl, json, openssl, fileinfo, pdo, pdo_sqlite, sqlite3, pdo_mysql, redis
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
 
       - name: Cache Composer
         uses: actions/cache@v4
@@ -79,9 +107,9 @@ jobs:
           path: |
             backend/vendor
             ~/.composer/cache/files
-          key: ${{ runner.os }}-php84-${{ hashFiles('backend/composer.lock') }}
+          key: ${{ runner.os }}-php82-${{ hashFiles('backend/composer.lock') }}
           restore-keys: |
-            ${{ runner.os }}-php84-
+            ${{ runner.os }}-php82-
 
       - name: Prepare Laravel cache dirs (for package:discover)
         working-directory: backend
@@ -179,11 +207,19 @@ jobs:
           curl -sS http://127.0.0.1:18000/api/v0.2/content-packs | php -r '$j=json_decode(stream_get_contents(STDIN), true); exit(($j["ok"] ?? false) ? 0 : 1);'
 
       - name: Run ci_verify_mbti
-        working-directory: backend
         env:
           MBTI_CONTENT_PACKAGE: default/CN_MAINLAND/zh-CN/MBTI-CN-v0.2.1-TEST
+          DB_CONNECTION: mysql
+          DB_HOST: 127.0.0.1
+          DB_PORT: 3306
+          DB_DATABASE: fap_ci
+          DB_USERNAME: root
+          DB_PASSWORD: root
+          QUEUE_CONNECTION: redis
+          REDIS_HOST: 127.0.0.1
+          REDIS_PORT: 6379
         run: |
-          bash scripts/ci_verify_mbti.sh
+          bash ./backend/scripts/ci_verify_mbti.sh
 
       - name: Upload verify_mbti artifacts (on failure)
         if: failure()

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -79,7 +79,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: '8.2'
+          php-version: '8.4'
           coverage: none
           tools: composer:v2
           extensions: >

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -27,6 +27,29 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
 
+    services:
+      mysql:
+        image: mysql:8.0
+        env:
+          MYSQL_DATABASE: fap_ci
+          MYSQL_ROOT_PASSWORD: root
+        ports:
+          - "3306:3306"
+        options: >-
+          --health-cmd="mysqladmin ping -h 127.0.0.1 -proot"
+          --health-interval=10s
+          --health-timeout=5s
+          --health-retries=12
+      redis:
+        image: redis:6-alpine
+        ports:
+          - "6379:6379"
+        options: >-
+          --health-cmd="redis-cli ping || exit 1"
+          --health-interval=10s
+          --health-timeout=5s
+          --health-retries=12
+
     # 关键：绑定 GitHub Environment，使 secrets.SSH_PRIVATE_KEY 读取到对应环境的 Environment Secret
     environment:
       name: ${{ github.event_name == 'workflow_dispatch' && inputs.env || 'staging' }}
@@ -52,6 +75,20 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.2'
+          coverage: none
+          tools: composer:v2
+          extensions: >
+            mbstring, intl, curl, json, openssl, fileinfo, pdo, pdo_sqlite, sqlite3, pdo_mysql, redis
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
 
       - name: CAE gate (config + artifact safety)
         run: bash backend/scripts/cae_gate.sh
@@ -94,6 +131,22 @@ jobs:
           echo "SSH=$DEPLOY_USER@$DEPLOY_HOST:$DEPLOY_PORT"
           echo "DEPLOY_PATH=$DEPLOY_PATH"
           echo "HEALTHCHECK_URL=$HEALTHCHECK_URL"
+
+      - name: Gate - ci_verify_mbti (Phase D)
+        env:
+          MBTI_CONTENT_PACKAGE: default/CN_MAINLAND/zh-CN/MBTI-CN-v0.2.1-TEST
+          DB_CONNECTION: mysql
+          DB_HOST: 127.0.0.1
+          DB_PORT: 3306
+          DB_DATABASE: fap_ci
+          DB_USERNAME: root
+          DB_PASSWORD: root
+          QUEUE_CONNECTION: redis
+          REDIS_HOST: 127.0.0.1
+          REDIS_PORT: 6379
+        run: |
+          set -euo pipefail
+          bash ./backend/scripts/ci_verify_mbti.sh
 
       - name: Set up SSH
         uses: webfactory/ssh-agent@v0.9.0
@@ -142,6 +195,14 @@ jobs:
         run: |
           set -euo pipefail
           php /tmp/dep.phar deploy "$TARGET" -f deploy.php -vvv --no-interaction
+
+      - name: Restart queue workers (Supervisor)
+        shell: bash
+        run: |
+          set -euo pipefail
+          ssh -o BatchMode=yes -o StrictHostKeyChecking=yes -o ConnectTimeout=10 \
+            -p "$DEPLOY_PORT" "$DEPLOY_USER@$DEPLOY_HOST" \
+            "cd '$DEPLOY_PATH/current' && php artisan queue:restart"
 
       - name: Healthcheck (post deploy)
         shell: bash

--- a/.github/workflows/selfcheck.yml
+++ b/.github/workflows/selfcheck.yml
@@ -80,7 +80,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: '8.2'
+          php-version: '8.4'
           tools: composer:v2
 
       - name: Setup Node
@@ -93,9 +93,9 @@ jobs:
         with:
           path: |
             ~/.composer/cache
-          key: composer-${{ runner.os }}-php82-${{ hashFiles('backend/composer.lock') }}
+          key: composer-${{ runner.os }}-php84-${{ hashFiles('backend/composer.lock') }}
           restore-keys: |
-            composer-${{ runner.os }}-php82-
+            composer-${{ runner.os }}-php84-
 
       - name: Prepare Laravel cache dirs (for package:discover)
         working-directory: backend
@@ -346,7 +346,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: '8.2'
+          php-version: '8.4'
           tools: composer:v2
           extensions: mbstring, dom, xml, curl, pdo_mysql, redis
 

--- a/.github/workflows/selfcheck.yml
+++ b/.github/workflows/selfcheck.yml
@@ -21,6 +21,29 @@ jobs:
       run:
         shell: bash
 
+    services:
+      mysql:
+        image: mysql:8.0
+        env:
+          MYSQL_DATABASE: fap_ci
+          MYSQL_ROOT_PASSWORD: root
+        ports:
+          - "3306:3306"
+        options: >-
+          --health-cmd="mysqladmin ping -h 127.0.0.1 -proot"
+          --health-interval=10s
+          --health-timeout=5s
+          --health-retries=12
+      redis:
+        image: redis:6-alpine
+        ports:
+          - "6379:6379"
+        options: >-
+          --health-cmd="redis-cli ping || exit 1"
+          --health-interval=10s
+          --health-timeout=5s
+          --health-retries=12
+
     env:
       APP_ENV: testing
       APP_DEBUG: "true"
@@ -57,17 +80,22 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: '8.4'
+          php-version: '8.2'
           tools: composer:v2
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
 
       - name: Cache Composer
         uses: actions/cache@v4
         with:
           path: |
             ~/.composer/cache
-          key: composer-${{ runner.os }}-php84-${{ hashFiles('backend/composer.lock') }}
+          key: composer-${{ runner.os }}-php82-${{ hashFiles('backend/composer.lock') }}
           restore-keys: |
-            composer-${{ runner.os }}-php84-
+            composer-${{ runner.os }}-php82-
 
       - name: Prepare Laravel cache dirs (for package:discover)
         working-directory: backend
@@ -290,6 +318,14 @@ jobs:
           --health-interval=10s
           --health-timeout=5s
           --health-retries=12
+      redis:
+        image: redis:6-alpine
+        ports: ["6379:6379"]
+        options: >-
+          --health-cmd="redis-cli ping || exit 1"
+          --health-interval=10s
+          --health-timeout=5s
+          --health-retries=12
 
     env:
       APP_ENV: ci
@@ -310,9 +346,14 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: '8.4'
+          php-version: '8.2'
           tools: composer:v2
-          extensions: mbstring, dom, xml, curl, pdo_mysql
+          extensions: mbstring, dom, xml, curl, pdo_mysql, redis
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
 
       - name: Wait for mysql
         run: |

--- a/backend/docker-compose.yml
+++ b/backend/docker-compose.yml
@@ -1,7 +1,39 @@
 version: "3.8"
 
 services:
+  mysql:
+    image: mysql:8.0
+    container_name: fap-mysql
+    environment:
+      MYSQL_ROOT_PASSWORD: root
+      MYSQL_DATABASE: fap
+      MYSQL_USER: fap
+      MYSQL_PASSWORD: fap
+    ports:
+      - "3306:3306"
+    command: --default-authentication-plugin=mysql_native_password
+    volumes:
+      - mysql-data:/var/lib/mysql
+    healthcheck:
+      test: ["CMD", "mysqladmin", "ping", "-h", "127.0.0.1", "-proot"]
+      interval: 10s
+      timeout: 5s
+      retries: 10
+
   redis:
-    image: redis:7-alpine
+    image: redis:6-alpine
+    container_name: fap-redis
     ports:
       - "6379:6379"
+    command: ["redis-server", "--appendonly", "yes"]
+    volumes:
+      - redis-data:/data
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+      interval: 10s
+      timeout: 3s
+      retries: 10
+
+volumes:
+  mysql-data:
+  redis-data:

--- a/tools/compose/observability.yml
+++ b/tools/compose/observability.yml
@@ -24,5 +24,30 @@ services:
     volumes:
       - metabase-data:/metabase-data
 
+  mysql:
+    profiles: ["phase-d-deps"]
+    image: mysql:8.0
+    environment:
+      MYSQL_ROOT_PASSWORD: root
+      MYSQL_DATABASE: fap_obs
+    ports:
+      - "13306:3306"
+    healthcheck:
+      test: ["CMD", "mysqladmin", "ping", "-h", "127.0.0.1", "-proot"]
+      interval: 10s
+      timeout: 5s
+      retries: 10
+
+  redis:
+    profiles: ["phase-d-deps"]
+    image: redis:6-alpine
+    ports:
+      - "16379:6379"
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+      interval: 10s
+      timeout: 3s
+      retries: 10
+
 volumes:
   metabase-data:


### PR DESCRIPTION
## Summary
- align GitHub Actions runtimes to Phase D baselines (PHP 8.2, Node 20)
- harden workflow service containers with MySQL 8.0 and Redis 6-alpine
- add Phase D gate execution before critical deploy actions
- switch deploy queue restart to Supervisor-compatible `php artisan queue:restart`

## Changed Files
- /Users/rainie/Desktop/GitHub/fap-api/.github/workflows/ci_verify_mbti.yml
- /Users/rainie/Desktop/GitHub/fap-api/.github/workflows/deploy.yml
- /Users/rainie/Desktop/GitHub/fap-api/.github/workflows/selfcheck.yml
- /Users/rainie/Desktop/GitHub/fap-api/backend/docker-compose.yml
- /Users/rainie/Desktop/GitHub/fap-api/tools/compose/observability.yml

## Key Changes
- pin `shivammathur/setup-php` to `php-version: '8.2'`
- pin `actions/setup-node` to `node-version: '20'`
- add and fix multi-line `services` definitions (MySQL + Redis) in core workflows
- inject DB/Redis env when running `./backend/scripts/ci_verify_mbti.sh` in CI/deploy gate
- add deploy post-step: `php artisan queue:restart`
- pin local compose runtime images: MySQL `8.0`, Redis `6-alpine`
- add optional observability deps profile `phase-d-deps` for MySQL/Redis

## Verification
- `php artisan route:list`
- `php artisan migrate --force`
- `curl -sS http://127.0.0.1:18000/api/v0.2/health`
- `curl -sS http://127.0.0.1:18000/api/v0.2/content-packs`
- `bash backend/scripts/ci_verify_mbti.sh`
