### PR TITLE
feat(storage): stop bleed with prune plan and artifact hygiene guards

### DIFF
--- a/.clocignore
+++ b/.clocignore
@@ -1,0 +1,4 @@
+backend/storage/**
+backend/artifacts/**
+dist/**
+_audit/**

--- a/.gitignore
+++ b/.gitignore
@@ -36,6 +36,9 @@ backend/database/*.sqlite
 backend/storage/logs/
 backend/storage/framework/
 backend/storage/app/private/reports/
+backend/storage/app/private/artifacts/
+backend/storage/app/private/packs_v2/
+backend/storage/app/private/prune_plans/
 backend/storage/app/archives/
 
 # SEC/SRE-000 release package hygiene

--- a/backend/.gitignore
+++ b/backend/.gitignore
@@ -29,6 +29,9 @@ Thumbs.db
 /storage/framework/cache/*
 /storage/framework/views/*
 /storage/app/private/reports/*
+/storage/app/private/artifacts/*
+/storage/app/private/packs_v2/*
+/storage/app/private/prune_plans/*
 /storage/app/archives/*
 !/storage/logs/.gitkeep
 !/storage/framework/sessions/.gitkeep

--- a/backend/app/Console/Commands/StoragePrune.php
+++ b/backend/app/Console/Commands/StoragePrune.php
@@ -1,0 +1,256 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Console\Commands;
+
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\File;
+use Illuminate\Support\Facades\Storage;
+
+final class StoragePrune extends Command
+{
+    private const SCOPE_REPORTS_BACKUPS = 'reports_backups';
+
+    /** @var list<string> */
+    private const SUPPORTED_SCOPES = [
+        self::SCOPE_REPORTS_BACKUPS,
+    ];
+
+    protected $signature = 'storage:prune
+        {--dry-run : Generate prune plan only}
+        {--execute : Execute prune plan}
+        {--scope=reports_backups : Prune scope}
+        {--plan= : Plan json path for execute mode}';
+
+    protected $description = 'Generate/execute storage prune plans.';
+
+    public function handle(): int
+    {
+        $dryRun = (bool) $this->option('dry-run');
+        $execute = (bool) $this->option('execute');
+        $scope = strtolower(trim((string) $this->option('scope')));
+
+        if (! in_array($scope, self::SUPPORTED_SCOPES, true)) {
+            $this->error('unsupported --scope: '.$scope);
+
+            return self::FAILURE;
+        }
+
+        if (($dryRun && $execute) || (! $dryRun && ! $execute)) {
+            $this->error('exactly one of --dry-run or --execute is required.');
+
+            return self::FAILURE;
+        }
+
+        if ($dryRun) {
+            return $this->dryRun($scope);
+        }
+
+        return $this->executePlan($scope);
+    }
+
+    private function dryRun(string $scope): int
+    {
+        $entries = match ($scope) {
+            self::SCOPE_REPORTS_BACKUPS => $this->collectReportBackupEntries(),
+            default => [],
+        };
+
+        $totalBytes = 0;
+        $paths = [];
+        foreach ($entries as $entry) {
+            $path = trim((string) ($entry['path'] ?? ''));
+            if ($path === '') {
+                continue;
+            }
+
+            $bytes = max(0, (int) ($entry['bytes'] ?? 0));
+            $paths[] = [
+                'path' => $path,
+                'bytes' => $bytes,
+            ];
+            $totalBytes += $bytes;
+        }
+
+        $plan = [
+            'schema' => 'storage_prune_plan.v1',
+            'scope' => $scope,
+            'generated_at' => now()->toISOString(),
+            'files' => $paths,
+            'summary' => [
+                'files' => count($paths),
+                'bytes' => $totalBytes,
+            ],
+        ];
+
+        $planDir = storage_path('app/private/prune_plans');
+        File::ensureDirectoryExists($planDir);
+
+        $planName = now()->format('Ymd_His').'_'.$scope.'_'.substr(bin2hex(random_bytes(4)), 0, 8).'.json';
+        $planPath = $planDir.DIRECTORY_SEPARATOR.$planName;
+        $encoded = json_encode($plan, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES | JSON_PRETTY_PRINT);
+
+        if (! is_string($encoded)) {
+            $this->error('failed to encode prune plan json.');
+
+            return self::FAILURE;
+        }
+
+        File::put($planPath, $encoded.PHP_EOL);
+
+        $this->line('status=planned');
+        $this->line('scope='.$scope);
+        $this->line('plan='.$planPath);
+        $this->line('files='.count($paths));
+        $this->line('bytes='.$totalBytes);
+
+        return self::SUCCESS;
+    }
+
+    private function executePlan(string $scope): int
+    {
+        $planOption = trim((string) $this->option('plan'));
+        if ($planOption === '') {
+            $this->error('--plan is required in --execute mode.');
+
+            return self::FAILURE;
+        }
+
+        $planPath = $this->resolvePlanPath($planOption);
+        if (! is_file($planPath)) {
+            $this->error('plan not found: '.$planPath);
+
+            return self::FAILURE;
+        }
+
+        $decoded = json_decode((string) File::get($planPath), true);
+        if (! is_array($decoded)) {
+            $this->error('invalid plan json: '.$planPath);
+
+            return self::FAILURE;
+        }
+
+        $planScope = strtolower(trim((string) ($decoded['scope'] ?? '')));
+        if ($planScope !== $scope) {
+            $this->error('plan scope mismatch: plan='.$planScope.' cli='.$scope);
+
+            return self::FAILURE;
+        }
+
+        $files = is_array($decoded['files'] ?? null) ? $decoded['files'] : [];
+        $disk = Storage::disk('local');
+
+        $deletedFiles = 0;
+        $deletedBytes = 0;
+        $missingFiles = 0;
+        $skippedFiles = 0;
+
+        foreach ($files as $fileEntry) {
+            $relPath = trim((string) (is_array($fileEntry) ? ($fileEntry['path'] ?? '') : $fileEntry));
+            if ($relPath === '') {
+                continue;
+            }
+
+            if (! $this->isPrunablePathForScope($scope, $relPath)) {
+                $skippedFiles++;
+                continue;
+            }
+
+            if (! $disk->exists($relPath)) {
+                $missingFiles++;
+                continue;
+            }
+
+            $absPath = storage_path('app/private/'.$relPath);
+            $bytes = is_file($absPath) ? (int) (filesize($absPath) ?: 0) : 0;
+            if (! $disk->delete($relPath)) {
+                $this->error('delete failed: '.$relPath);
+
+                return self::FAILURE;
+            }
+
+            $deletedFiles++;
+            $deletedBytes += max(0, $bytes);
+        }
+
+        $this->line('status=executed');
+        $this->line('scope='.$scope);
+        $this->line('plan='.$planPath);
+        $this->line('deleted_files='.$deletedFiles);
+        $this->line('deleted_bytes='.$deletedBytes);
+        $this->line('missing_files='.$missingFiles);
+        $this->line('skipped_files='.$skippedFiles);
+
+        return self::SUCCESS;
+    }
+
+    /**
+     * @return list<array{path:string,bytes:int}>
+     */
+    private function collectReportBackupEntries(): array
+    {
+        $root = storage_path('app/private/reports');
+        if (! is_dir($root)) {
+            return [];
+        }
+
+        $items = [];
+        $iterator = new \RecursiveIteratorIterator(
+            new \RecursiveDirectoryIterator($root, \FilesystemIterator::SKIP_DOTS)
+        );
+
+        foreach ($iterator as $file) {
+            if (! $file instanceof \SplFileInfo || ! $file->isFile()) {
+                continue;
+            }
+
+            $fullPath = $file->getPathname();
+            $prefix = rtrim(storage_path('app/private'), DIRECTORY_SEPARATOR).DIRECTORY_SEPARATOR;
+            if (! str_starts_with($fullPath, $prefix)) {
+                continue;
+            }
+
+            $relPath = str_replace('\\', '/', substr($fullPath, strlen($prefix)));
+            if (! $this->isReportTimestampBackupPath($relPath)) {
+                continue;
+            }
+
+            $items[] = [
+                'path' => $relPath,
+                'bytes' => max(0, (int) ($file->getSize() ?: 0)),
+            ];
+        }
+
+        usort($items, static fn (array $a, array $b): int => strcmp($a['path'], $b['path']));
+
+        return $items;
+    }
+
+    private function resolvePlanPath(string $planOption): string
+    {
+        if (str_starts_with($planOption, DIRECTORY_SEPARATOR)) {
+            return $planOption;
+        }
+
+        $basePathCandidate = base_path($planOption);
+        if (is_file($basePathCandidate)) {
+            return $basePathCandidate;
+        }
+
+        return storage_path('app/private/'.ltrim($planOption, '/\\'));
+    }
+
+    private function isPrunablePathForScope(string $scope, string $relPath): bool
+    {
+        return match ($scope) {
+            self::SCOPE_REPORTS_BACKUPS => $this->isReportTimestampBackupPath($relPath),
+            default => false,
+        };
+    }
+
+    private function isReportTimestampBackupPath(string $relPath): bool
+    {
+        return preg_match('#^reports/[^/]+/report\.\d{8}_\d{6}\.json$#', $relPath) === 1;
+    }
+}

--- a/backend/app/Console/Kernel.php
+++ b/backend/app/Console/Kernel.php
@@ -39,6 +39,7 @@ use App\Console\Commands\PaymentsPruneEvents;
 use App\Console\Commands\QualityDailySummary;
 use App\Console\Commands\SdsPsychometricsReport;
 use App\Console\Commands\SeedScaleRegistry;
+use App\Console\Commands\StoragePrune;
 use App\Console\Commands\SyncScaleSlugs;
 use Illuminate\Console\Scheduling\Schedule;
 use Illuminate\Foundation\Console\Kernel as ConsoleKernel;
@@ -89,6 +90,7 @@ class Kernel extends ConsoleKernel
         Packs2Activate::class,
         Packs2Rollback::class,
         Packs2List::class,
+        StoragePrune::class,
         QualityDailySummary::class,
         CiScaleImpact::class,
         PartitionAttemptAnswerRows::class,

--- a/backend/scripts/release_pack.sh
+++ b/backend/scripts/release_pack.sh
@@ -68,7 +68,10 @@ rm -rf "${STAGING_DIR}/.git" \
        "${STAGING_DIR}/backend/node_modules" \
        "${STAGING_DIR}/backend/storage/logs" \
        "${STAGING_DIR}/backend/artifacts" \
-       "${STAGING_DIR}/backend/storage/app/private/reports"
+       "${STAGING_DIR}/backend/storage/app/private/reports" \
+       "${STAGING_DIR}/backend/storage/app/private/artifacts" \
+       "${STAGING_DIR}/backend/storage/app/private/packs_v2" \
+       "${STAGING_DIR}/backend/storage/app/private/prune_plans"
 
 find "${STAGING_DIR}" -type f -name '*.sqlite*' -delete
 
@@ -84,6 +87,9 @@ find "${STAGING_DIR}" -type d -path '*/storage/logs' -print >> "$HITS_FILE"
 find "${STAGING_DIR}" -type d -name 'artifacts' -print >> "$HITS_FILE"
 find "${STAGING_DIR}" -type f -name '*.sqlite*' -print >> "$HITS_FILE"
 find "${STAGING_DIR}" -type d -path '*/storage/app/private/reports' -print >> "$HITS_FILE"
+find "${STAGING_DIR}" -type d -path '*/storage/app/private/artifacts' -print >> "$HITS_FILE"
+find "${STAGING_DIR}" -type d -path '*/storage/app/private/packs_v2' -print >> "$HITS_FILE"
+find "${STAGING_DIR}" -type d -path '*/storage/app/private/prune_plans' -print >> "$HITS_FILE"
 
 if [[ -s "$HITS_FILE" ]]; then
   echo "[FAIL] blacklist violations found:" >&2

--- a/backend/tests/Feature/Storage/StoragePruneDoesNotDeleteCanonicalTest.php
+++ b/backend/tests/Feature/Storage/StoragePruneDoesNotDeleteCanonicalTest.php
@@ -1,0 +1,75 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Storage;
+
+use Illuminate\Support\Facades\File;
+use Illuminate\Support\Str;
+use Tests\TestCase;
+
+final class StoragePruneDoesNotDeleteCanonicalTest extends TestCase
+{
+    private string $attemptId;
+
+    private string $attemptDir;
+
+    /** @var list<string> */
+    private array $preExistingPlans = [];
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->attemptId = (string) Str::uuid();
+        $this->attemptDir = storage_path('app/private/reports/'.$this->attemptId);
+
+        File::ensureDirectoryExists($this->attemptDir);
+        File::ensureDirectoryExists(storage_path('app/private/prune_plans'));
+
+        File::put($this->attemptDir.'/report.json', json_encode(['ok' => true], JSON_UNESCAPED_UNICODE));
+        File::put($this->attemptDir.'/report.20260222_123456.json', json_encode(['ok' => true], JSON_UNESCAPED_UNICODE));
+        File::put($this->attemptDir.'/report.20260222.json', json_encode(['ok' => true], JSON_UNESCAPED_UNICODE));
+
+        $this->preExistingPlans = glob(storage_path('app/private/prune_plans/*.json')) ?: [];
+    }
+
+    protected function tearDown(): void
+    {
+        if (is_dir($this->attemptDir)) {
+            File::deleteDirectory($this->attemptDir);
+        }
+
+        $currentPlans = glob(storage_path('app/private/prune_plans/*.json')) ?: [];
+        $newPlans = array_diff($currentPlans, $this->preExistingPlans);
+        foreach ($newPlans as $planPath) {
+            if (is_file($planPath)) {
+                @unlink($planPath);
+            }
+        }
+
+        parent::tearDown();
+    }
+
+    public function test_prune_removes_timestamp_backup_and_keeps_canonical_report(): void
+    {
+        $this->artisan('storage:prune --dry-run --scope=reports_backups')
+            ->assertExitCode(0);
+
+        $currentPlans = glob(storage_path('app/private/prune_plans/*.json')) ?: [];
+        $newPlans = array_values(array_diff($currentPlans, $this->preExistingPlans));
+
+        $this->assertNotSame([], $newPlans, 'expected at least one generated prune plan.');
+        usort($newPlans, static fn (string $a, string $b): int => filemtime($a) <=> filemtime($b));
+        $latestPlan = end($newPlans);
+        $this->assertIsString($latestPlan);
+        $this->assertTrue(is_file($latestPlan));
+
+        $this->artisan('storage:prune --execute --scope=reports_backups --plan='.$latestPlan)
+            ->assertExitCode(0);
+
+        $this->assertFileExists($this->attemptDir.'/report.json');
+        $this->assertFileDoesNotExist($this->attemptDir.'/report.20260222_123456.json');
+        $this->assertFileExists($this->attemptDir.'/report.20260222.json');
+    }
+}

--- a/scripts/release/verify_source_zip_clean.sh
+++ b/scripts/release/verify_source_zip_clean.sh
@@ -17,7 +17,7 @@ LIST="$(unzip -Z1 "$ZIP")"
 LIST_FILTERED="$(echo "$LIST" | grep -vE '^(fap-api/backend/\.env\.example|fap-api/\.env\.example)$' || true)"
 
 # 1) 路径黑名单（命中直接失败）
-PATTERN_PATH='(^fap-api/\.git/|^fap-api/backend/\.env($|[./])|^fap-api/\.env($|[./])|^fap-api/backend/vendor/|^fap-api/vendor/|^fap-api/node_modules/|^fap-api/backend/node_modules/|^fap-api/backend/artifacts/|^fap-api/backend/database/.*\.sqlite$|^fap-api/backend/storage/logs/|^fap-api/backend/storage/framework/|^fap-api/backend/storage/app/private/reports/|^fap-api/backend/storage/app/archives/)'
+PATTERN_PATH='(^fap-api/\.git/|^fap-api/backend/\.env($|[./])|^fap-api/\.env($|[./])|^fap-api/backend/vendor/|^fap-api/vendor/|^fap-api/node_modules/|^fap-api/backend/node_modules/|^fap-api/backend/artifacts/|^fap-api/backend/database/.*\.sqlite$|^fap-api/backend/storage/logs/|^fap-api/backend/storage/framework/|^fap-api/backend/storage/app/private/reports/|^fap-api/backend/storage/app/private/artifacts/|^fap-api/backend/storage/app/private/packs_v2/|^fap-api/backend/storage/app/private/prune_plans/|^fap-api/backend/storage/app/archives/)'
 HITS_PATH="$(echo "$LIST_FILTERED" | grep -E "$PATTERN_PATH" || true)"
 [ -z "$HITS_PATH" ] || { echo "[verify][FAIL] forbidden paths found:"; echo "$HITS_PATH"; exit 1; }
 

--- a/scripts/security/assert_artifact_clean.sh
+++ b/scripts/security/assert_artifact_clean.sh
@@ -92,6 +92,30 @@ check_repo_mode() {
     done <<< "$hits"
   fi
 
+  hits="$(contains_path '^backend/storage/app/private/artifacts/' "$tracked" | grep -Ev '/\.gitkeep$' || true)"
+  if [[ -n "$hits" ]]; then
+    while IFS= read -r f; do
+      [[ -n "$f" ]] || continue
+      fail "forbidden tracked runtime artifact: $f ; fix: keep only .gitkeep in backend/storage/app/private/artifacts."
+    done <<< "$hits"
+  fi
+
+  hits="$(contains_path '^backend/storage/app/private/packs_v2/' "$tracked" | grep -Ev '/\.gitkeep$' || true)"
+  if [[ -n "$hits" ]]; then
+    while IFS= read -r f; do
+      [[ -n "$f" ]] || continue
+      fail "forbidden tracked runtime artifact: $f ; fix: keep only .gitkeep in backend/storage/app/private/packs_v2."
+    done <<< "$hits"
+  fi
+
+  hits="$(contains_path '^backend/storage/app/private/prune_plans/' "$tracked" | grep -Ev '/\.gitkeep$' || true)"
+  if [[ -n "$hits" ]]; then
+    while IFS= read -r f; do
+      [[ -n "$f" ]] || continue
+      fail "forbidden tracked runtime artifact: $f ; fix: keep only .gitkeep in backend/storage/app/private/prune_plans."
+    done <<< "$hits"
+  fi
+
   hits="$(contains_path '^backend/storage/app/archives/' "$tracked" | grep -Ev '/\.gitkeep$' || true)"
   if [[ -n "$hits" ]]; then
     while IFS= read -r f; do
@@ -151,6 +175,9 @@ check_artifact_mode() {
   check_only_gitkeep_files "backend/storage/logs"
   check_only_gitkeep_files "backend/storage/framework"
   check_only_gitkeep_files "backend/storage/app/private/reports"
+  check_only_gitkeep_files "backend/storage/app/private/artifacts"
+  check_only_gitkeep_files "backend/storage/app/private/packs_v2"
+  check_only_gitkeep_files "backend/storage/app/private/prune_plans"
   check_only_gitkeep_files "backend/storage/app/archives"
 
   for p in \

--- a/scripts/security/assert_no_tracked_sensitive_files.sh
+++ b/scripts/security/assert_no_tracked_sensitive_files.sh
@@ -15,6 +15,15 @@ grep -qE '(^backend/database/.*\.sqlite$)' <<< "$TRACKED" && { echo "[FAIL] trac
 HITS_REPORTS="$(grep -E '^backend/storage/app/private/reports/' <<< "$TRACKED" | grep -vE '^backend/storage/app/private/reports/\.gitkeep$' || true)"
 [ -z "$HITS_REPORTS" ] || { echo "[FAIL] tracked report snapshots found"; echo "$HITS_REPORTS"; exit 1; }
 
+HITS_ARTIFACTS="$(grep -E '^backend/storage/app/private/artifacts/' <<< "$TRACKED" | grep -vE '^backend/storage/app/private/artifacts/\.gitkeep$' || true)"
+[ -z "$HITS_ARTIFACTS" ] || { echo "[FAIL] tracked report/pdf artifacts found"; echo "$HITS_ARTIFACTS"; exit 1; }
+
+HITS_PACKS_V2="$(grep -E '^backend/storage/app/private/packs_v2/' <<< "$TRACKED" | grep -vE '^backend/storage/app/private/packs_v2/\.gitkeep$' || true)"
+[ -z "$HITS_PACKS_V2" ] || { echo "[FAIL] tracked packs_v2 artifacts found"; echo "$HITS_PACKS_V2"; exit 1; }
+
+HITS_PRUNE_PLANS="$(grep -E '^backend/storage/app/private/prune_plans/' <<< "$TRACKED" | grep -vE '^backend/storage/app/private/prune_plans/\.gitkeep$' || true)"
+[ -z "$HITS_PRUNE_PLANS" ] || { echo "[FAIL] tracked prune plans found"; echo "$HITS_PRUNE_PLANS"; exit 1; }
+
 HITS_ARCHIVES="$(grep -E '^backend/storage/app/archives/' <<< "$TRACKED" | grep -vE '^backend/storage/app/archives/\.gitkeep$' || true)"
 [ -z "$HITS_ARCHIVES" ] || { echo "[FAIL] tracked archives found"; echo "$HITS_ARCHIVES"; exit 1; }
 


### PR DESCRIPTION
## Summary
- Add plan-first storage prune flow for report timestamp backups (`--dry-run` plan + `--execute --plan`).
- Keep canonical artifacts safe: never delete `report.json` / `report_snapshot.json`.
- Expand artifact hygiene and packaging guards to include storage artifact directories.

## Scope
- Stop-bleed only; no external API contract change.

## Verification
- `php artisan route:list`
- `php artisan migrate`
- `php artisan storage:prune --dry-run --scope=reports_backups`
- `php artisan storage:prune --execute --scope=reports_backups --plan=<latest_plan>`
- `php artisan test --filter=StoragePruneDoesNotDeleteCanonicalTest`
- `bash /Users/rainie/Desktop/GitHub/fap-api/backend/scripts/ci_verify_mbti.sh`

## Risk & Rollback
- Low risk: deletion only targets timestamp backup patterns.
- Rollback: stop scheduling/invocation and restore from git branch.
EOF