### PR TITLE
feat(storage): migrate report/pdf artifacts to canonical paths with fallback

### DIFF
--- a/backend/app/Console/Commands/StorageMigrateLegacyArtifacts.php
+++ b/backend/app/Console/Commands/StorageMigrateLegacyArtifacts.php
@@ -1,0 +1,390 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Console\Commands;
+
+use App\Models\Attempt;
+use App\Services\Storage\ArtifactStore;
+use App\Support\SchemaBaseline;
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Storage;
+
+final class StorageMigrateLegacyArtifacts extends Command
+{
+    protected $signature = 'storage:migrate-legacy-artifacts
+        {--dry-run : Plan migration only}
+        {--execute : Execute migration copy}';
+
+    protected $description = 'Migrate legacy report/pdf artifacts into artifacts/* paths (copy only).';
+
+    /** @var array<string,string> */
+    private array $attemptScaleCache = [];
+
+    public function __construct(
+        private readonly ArtifactStore $artifactStore
+    ) {
+        parent::__construct();
+    }
+
+    public function handle(): int
+    {
+        $dryRun = (bool) $this->option('dry-run');
+        $execute = (bool) $this->option('execute');
+
+        if (($dryRun && $execute) || (! $dryRun && ! $execute)) {
+            $this->error('exactly one of --dry-run or --execute is required.');
+
+            return self::FAILURE;
+        }
+
+        $operations = $this->collectOperations();
+        if ($dryRun) {
+            $this->line('status=planned');
+            $this->line('operations='.count($operations));
+            $this->line('report_json_ops='.$this->countOperationsByKind($operations, 'report_json'));
+            $this->line('pdf_ops='.$this->countOperationsByKind($operations, 'pdf'));
+
+            return self::SUCCESS;
+        }
+
+        return $this->executeOperations($operations);
+    }
+
+    /**
+     * @return list<array{kind:string,source:string,target:string,attempt_id:string,scale_code:string,manifest_hash:string,variant:string}>
+     */
+    private function collectOperations(): array
+    {
+        $operations = array_merge(
+            $this->collectReportJsonOperations(),
+            $this->collectPdfOperations()
+        );
+
+        usort(
+            $operations,
+            static fn (array $a, array $b): int => strcmp($a['source'].'|'.$a['target'], $b['source'].'|'.$b['target'])
+        );
+
+        return $operations;
+    }
+
+    /**
+     * @return list<array{kind:string,source:string,target:string,attempt_id:string,scale_code:string,manifest_hash:string,variant:string}>
+     */
+    private function collectReportJsonOperations(): array
+    {
+        $operations = [];
+        $seen = [];
+
+        foreach ($this->legacyReportsFiles() as $path) {
+            if (! str_ends_with($path, '/report.json')) {
+                continue;
+            }
+
+            $attemptId = null;
+            $scaleHint = null;
+
+            if (preg_match('#^(?:private/)?reports/([^/]+)/report\.json$#', $path, $m) === 1) {
+                $attemptId = (string) ($m[1] ?? '');
+            } elseif (preg_match('#^(?:private/)?reports/([^/]+)/([^/]+)/report\.json$#', $path, $m) === 1) {
+                $scaleHint = (string) ($m[1] ?? '');
+                $attemptId = (string) ($m[2] ?? '');
+            }
+
+            $attemptId = trim((string) $attemptId);
+            if ($attemptId === '') {
+                continue;
+            }
+
+            $scaleCode = $this->resolveScaleCode($attemptId, $scaleHint);
+            $target = $this->artifactStore->reportJsonPath($scaleCode, $attemptId);
+            if ($target === $path) {
+                continue;
+            }
+
+            $dedupeKey = $path.'|'.$target;
+            if (isset($seen[$dedupeKey])) {
+                continue;
+            }
+            $seen[$dedupeKey] = true;
+
+            $operations[] = [
+                'kind' => 'report_json',
+                'source' => $path,
+                'target' => $target,
+                'attempt_id' => $attemptId,
+                'scale_code' => $scaleCode,
+                'manifest_hash' => 'nohash',
+                'variant' => 'free',
+            ];
+        }
+
+        return $operations;
+    }
+
+    /**
+     * @return list<array{kind:string,source:string,target:string,attempt_id:string,scale_code:string,manifest_hash:string,variant:string}>
+     */
+    private function collectPdfOperations(): array
+    {
+        $operations = [];
+        $seen = [];
+
+        foreach ($this->legacyReportsFiles() as $path) {
+            if (! str_ends_with($path, '.pdf')) {
+                continue;
+            }
+
+            $attemptId = '';
+            $manifestHash = 'nohash';
+            $variant = 'free';
+            $scaleHint = null;
+
+            if (preg_match('#^(?:private/)?reports/([^/]+)/([^/]+)/([^/]+)/report_(free|full)\.pdf$#i', $path, $m) === 1) {
+                $scaleHint = (string) ($m[1] ?? '');
+                $attemptId = (string) ($m[2] ?? '');
+                $manifestHash = (string) ($m[3] ?? 'nohash');
+                $variant = strtolower((string) ($m[4] ?? 'free'));
+            } elseif (preg_match('#^(?:private/)?reports/big5/([^/]+)/report_(free|full)\.pdf$#i', $path, $m) === 1) {
+                $scaleHint = 'BIG5_OCEAN';
+                $attemptId = (string) ($m[1] ?? '');
+                $manifestHash = 'nohash';
+                $variant = strtolower((string) ($m[2] ?? 'free'));
+            } else {
+                continue;
+            }
+
+            $attemptId = trim($attemptId);
+            if ($attemptId === '') {
+                continue;
+            }
+
+            $variant = in_array($variant, ['free', 'full'], true) ? $variant : 'free';
+            $scaleCode = $this->resolveScaleCode($attemptId, $scaleHint);
+            $target = $this->artifactStore->pdfPath($scaleCode, $attemptId, $manifestHash, $variant);
+            if ($target === $path) {
+                continue;
+            }
+
+            $dedupeKey = $path.'|'.$target;
+            if (isset($seen[$dedupeKey])) {
+                continue;
+            }
+            $seen[$dedupeKey] = true;
+
+            $operations[] = [
+                'kind' => 'pdf',
+                'source' => $path,
+                'target' => $target,
+                'attempt_id' => $attemptId,
+                'scale_code' => $scaleCode,
+                'manifest_hash' => trim($manifestHash) !== '' ? trim($manifestHash) : 'nohash',
+                'variant' => $variant,
+            ];
+        }
+
+        return $operations;
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function legacyReportsFiles(): array
+    {
+        $disk = Storage::disk('local');
+        $files = [];
+
+        foreach (['reports', 'private/reports'] as $dir) {
+            if (! $disk->exists($dir)) {
+                continue;
+            }
+
+            foreach ($disk->allFiles($dir) as $path) {
+                $path = str_replace('\\', '/', trim((string) $path));
+                if ($path !== '') {
+                    $files[] = $path;
+                }
+            }
+        }
+
+        $files = array_values(array_unique($files));
+        sort($files);
+
+        return $files;
+    }
+
+    /**
+     * @param  list<array{kind:string,source:string,target:string,attempt_id:string,scale_code:string,manifest_hash:string,variant:string}>  $operations
+     */
+    private function executeOperations(array $operations): int
+    {
+        $disk = Storage::disk('local');
+
+        $copied = 0;
+        $copiedBytes = 0;
+        $skippedExisting = 0;
+        $missingSource = 0;
+        $failed = 0;
+
+        foreach ($operations as $operation) {
+            $source = $operation['source'];
+            $target = $operation['target'];
+
+            if (! $disk->exists($source)) {
+                $missingSource++;
+                continue;
+            }
+
+            $sourceBytes = $disk->get($source);
+            if (! is_string($sourceBytes) || $sourceBytes === '') {
+                $failed++;
+                $this->warn('skip unreadable source: '.$source);
+                continue;
+            }
+
+            $copiedNow = false;
+            if (! $disk->exists($target)) {
+                $targetDir = trim((string) dirname($target), './');
+                if ($targetDir !== '' && $targetDir !== '.') {
+                    $disk->makeDirectory($targetDir);
+                }
+
+                if (! $disk->copy($source, $target)) {
+                    $disk->put($target, $sourceBytes);
+                }
+
+                if (! $disk->exists($target)) {
+                    $failed++;
+                    $this->warn('copy failed: '.$source.' -> '.$target);
+                    continue;
+                }
+
+                $copiedNow = true;
+                $copied++;
+                $copiedBytes += strlen($sourceBytes);
+            } else {
+                $skippedExisting++;
+            }
+
+            $targetBytes = $disk->get($target);
+            $sha256 = is_string($targetBytes) ? hash('sha256', $targetBytes) : hash('sha256', $sourceBytes);
+            $this->writeAuditLog($operation, $sha256, $copiedNow);
+        }
+
+        $this->line('status=executed');
+        $this->line('operations='.count($operations));
+        $this->line('copied='.$copied);
+        $this->line('copied_bytes='.$copiedBytes);
+        $this->line('skipped_existing='.$skippedExisting);
+        $this->line('missing_source='.$missingSource);
+        $this->line('failed='.$failed);
+
+        return $failed > 0 ? self::FAILURE : self::SUCCESS;
+    }
+
+    /**
+     * @param  array{kind:string,source:string,target:string,attempt_id:string,scale_code:string,manifest_hash:string,variant:string}  $operation
+     */
+    private function writeAuditLog(array $operation, string $sha256, bool $copiedNow): void
+    {
+        if (! SchemaBaseline::hasTable('audit_logs')) {
+            return;
+        }
+
+        $meta = [
+            'kind' => (string) ($operation['kind'] ?? ''),
+            'source_path' => (string) ($operation['source'] ?? ''),
+            'target_path' => (string) ($operation['target'] ?? ''),
+            'scale_code' => (string) ($operation['scale_code'] ?? ''),
+            'manifest_hash' => (string) ($operation['manifest_hash'] ?? ''),
+            'variant' => (string) ($operation['variant'] ?? ''),
+            'copied' => $copiedNow,
+            'sha256' => $sha256,
+        ];
+        $metaJson = json_encode($meta, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES);
+        if (! is_string($metaJson)) {
+            $metaJson = '{}';
+        }
+
+        $row = [
+            'action' => 'storage_artifact_migrate',
+            'target_type' => 'attempt',
+            'target_id' => (string) ($operation['attempt_id'] ?? ''),
+            'meta_json' => $metaJson,
+            'created_at' => now(),
+        ];
+
+        if (SchemaBaseline::hasColumn('audit_logs', 'org_id')) {
+            $row['org_id'] = 0;
+        }
+        if (SchemaBaseline::hasColumn('audit_logs', 'actor_admin_id')) {
+            $row['actor_admin_id'] = null;
+        }
+        if (SchemaBaseline::hasColumn('audit_logs', 'ip')) {
+            $row['ip'] = '127.0.0.1';
+        }
+        if (SchemaBaseline::hasColumn('audit_logs', 'user_agent')) {
+            $row['user_agent'] = 'artisan';
+        }
+        if (SchemaBaseline::hasColumn('audit_logs', 'request_id')) {
+            $row['request_id'] = 'storage:migrate-legacy-artifacts';
+        }
+        if (SchemaBaseline::hasColumn('audit_logs', 'reason')) {
+            $row['reason'] = 'storage_governance_migrate';
+        }
+        if (SchemaBaseline::hasColumn('audit_logs', 'result')) {
+            $row['result'] = $copiedNow ? 'success' : 'skipped';
+        }
+
+        DB::table('audit_logs')->insert($row);
+    }
+
+    private function resolveScaleCode(string $attemptId, ?string $hint = null): string
+    {
+        $attemptId = trim($attemptId);
+        if ($attemptId !== '' && isset($this->attemptScaleCache[$attemptId])) {
+            return $this->attemptScaleCache[$attemptId];
+        }
+
+        $scaleCode = '';
+        if ($attemptId !== '' && SchemaBaseline::hasTable('attempts')) {
+            $scaleCode = trim((string) (Attempt::query()->where('id', $attemptId)->value('scale_code') ?? ''));
+        }
+
+        if ($scaleCode === '') {
+            $hint = trim((string) $hint);
+            if (strcasecmp($hint, 'big5') === 0) {
+                $hint = 'BIG5_OCEAN';
+            }
+
+            $scaleCode = $hint;
+        }
+
+        if ($scaleCode === '') {
+            $scaleCode = 'MBTI';
+        }
+
+        if ($attemptId !== '') {
+            $this->attemptScaleCache[$attemptId] = $scaleCode;
+        }
+
+        return $scaleCode;
+    }
+
+    /**
+     * @param  list<array{kind:string,source:string,target:string,attempt_id:string,scale_code:string,manifest_hash:string,variant:string}>  $operations
+     */
+    private function countOperationsByKind(array $operations, string $kind): int
+    {
+        $count = 0;
+        foreach ($operations as $operation) {
+            if (($operation['kind'] ?? '') === $kind) {
+                $count++;
+            }
+        }
+
+        return $count;
+    }
+}

--- a/backend/app/Console/Kernel.php
+++ b/backend/app/Console/Kernel.php
@@ -39,6 +39,7 @@ use App\Console\Commands\PaymentsPruneEvents;
 use App\Console\Commands\QualityDailySummary;
 use App\Console\Commands\SdsPsychometricsReport;
 use App\Console\Commands\SeedScaleRegistry;
+use App\Console\Commands\StorageMigrateLegacyArtifacts;
 use App\Console\Commands\StoragePrune;
 use App\Console\Commands\SyncScaleSlugs;
 use Illuminate\Console\Scheduling\Schedule;
@@ -91,6 +92,7 @@ class Kernel extends ConsoleKernel
         Packs2Rollback::class,
         Packs2List::class,
         StoragePrune::class,
+        StorageMigrateLegacyArtifacts::class,
         QualityDailySummary::class,
         CiScaleImpact::class,
         PartitionAttemptAnswerRows::class,

--- a/backend/app/Jobs/GenerateReportJob.php
+++ b/backend/app/Jobs/GenerateReportJob.php
@@ -6,13 +6,13 @@ use App\Models\Attempt;
 use App\Models\ReportJob;
 use App\Models\Result;
 use App\Services\Report\ReportComposer;
+use App\Services\Storage\ArtifactStore;
 use Illuminate\Bus\Queueable;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Foundation\Bus\Dispatchable;
 use Illuminate\Queue\InteractsWithQueue;
 use Illuminate\Queue\SerializesModels;
 use Illuminate\Support\Facades\Log;
-use Illuminate\Support\Facades\Storage;
 use Illuminate\Support\Str;
 
 class GenerateReportJob implements ShouldQueue
@@ -28,10 +28,11 @@ class GenerateReportJob implements ShouldQueue
         $this->jobId = $jobId;
     }
 
-    public function handle(ReportComposer $composer): void
+    public function handle(ReportComposer $composer, ?ArtifactStore $artifactStore = null): void
     {
         $attempt = Attempt::query()->where('id', $this->attemptId)->firstOrFail();
         $attemptId = (string) $attempt->id;
+        $scaleCode = (string) ($attempt->scale_code ?? 'MBTI');
         $orgId = (int) ($attempt->org_id ?? 0);
 
         $result = Result::query()
@@ -89,7 +90,12 @@ class GenerateReportJob implements ShouldQueue
             $job->report_json = $reportPayload;
             $job->save();
 
-            $this->persistReportJson($attemptId, $reportPayload);
+            $this->persistReportJson(
+                $artifactStore ?? app(ArtifactStore::class),
+                $scaleCode,
+                $attemptId,
+                $reportPayload
+            );
         } catch (\Throwable $e) {
             $job->status = 'failed';
             $job->failed_at = now();
@@ -107,40 +113,26 @@ class GenerateReportJob implements ShouldQueue
         }
     }
 
-    private function persistReportJson(string $attemptId, array $reportPayload): void
-    {
-        $disk = array_key_exists('private', config('filesystems.disks', []))
-            ? Storage::disk('private')
-            : Storage::disk(config('filesystems.default', 'local'));
-
-        $latestRelPath = "reports/{$attemptId}/report.json";
+    private function persistReportJson(
+        ArtifactStore $artifactStore,
+        string $scaleCode,
+        string $attemptId,
+        array $reportPayload
+    ): void {
+        $latestRelPath = $artifactStore->reportJsonPath($scaleCode, $attemptId);
 
         try {
-            $json = json_encode($reportPayload, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES);
-            if ($json === false) {
-                throw new \RuntimeException('json_encode_failed: ' . json_last_error_msg());
-            }
-
-            if (method_exists($disk, 'makeDirectory')) {
-                $disk->makeDirectory("reports/{$attemptId}");
-            }
-
-            $disk->put($latestRelPath, $json);
-
-            $ts = function_exists('now') ? now()->format('Ymd_His') : date('Ymd_His');
-            $snapRelPath = "reports/{$attemptId}/report.{$ts}.json";
-            $disk->put($snapRelPath, $json);
+            $artifactStore->putReportJson($scaleCode, $attemptId, $reportPayload);
 
             Log::info('[report_job] persisted report.json', [
+                'scale_code' => $scaleCode,
                 'attempt_id' => $attemptId,
-                'disk' => array_key_exists('private', config('filesystems.disks', []))
-                    ? 'private'
-                    : config('filesystems.default', 'local'),
+                'disk' => 'local',
                 'latest' => $latestRelPath,
-                'snapshot' => $snapRelPath,
             ]);
         } catch (\Throwable $e) {
             Log::warning('[report_job] persist report.json failed', [
+                'scale_code' => $scaleCode,
                 'attempt_id' => $attemptId,
                 'path' => $latestRelPath,
                 'err' => $e->getMessage(),

--- a/backend/app/Services/Legacy/LegacyReportService.php
+++ b/backend/app/Services/Legacy/LegacyReportService.php
@@ -9,6 +9,7 @@ use App\Models\Attempt;
 use App\Models\ReportJob;
 use App\Models\Result;
 use App\Services\Commerce\EntitlementManager;
+use App\Services\Storage\ArtifactStore;
 use App\Support\OrgContext;
 use App\Support\WritesEvents;
 use Illuminate\Database\Eloquent\ModelNotFoundException;
@@ -16,7 +17,6 @@ use Illuminate\Http\Request;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Facades\Schema;
-use Illuminate\Support\Facades\Storage;
 use Illuminate\Support\Str;
 use Throwable;
 
@@ -25,7 +25,8 @@ class LegacyReportService
     use WritesEvents;
 
     public function __construct(
-        private OrgContext $orgContext
+        private OrgContext $orgContext,
+        private ArtifactStore $artifactStore
     ) {
     }
 
@@ -371,23 +372,19 @@ class LegacyReportService
             : null;
 
         if (!is_array($reportPayload)) {
-            $disk = array_key_exists('private', config('filesystems.disks', []))
-                ? Storage::disk('private')
-                : Storage::disk(config('filesystems.default', 'local'));
-            $latestRelPath = "reports/{$attemptId}/report.json";
+            $scaleCode = (string) ($attempt->scale_code ?? $result->scale_code ?? 'MBTI');
+            $latestRelPath = $this->artifactStore->reportJsonPath($scaleCode, $attemptId);
 
             try {
-                if ($disk->exists($latestRelPath)) {
-                    $cachedJson = $disk->get($latestRelPath);
-                    $cached = json_decode($cachedJson, true);
-                    if (is_array($cached)) {
-                        $reportPayload = $cached;
-                    }
+                $cached = $this->artifactStore->getReportJson($scaleCode, $attemptId);
+                if (is_array($cached)) {
+                    $reportPayload = $cached;
                 }
             } catch (Throwable $e) {
                 Log::error('LEGACY_REPORT_CACHE_READ_FAILED', [
                     'attempt_id' => $attemptId,
                     'request_id' => $this->requestId($request),
+                    'scale_code' => $scaleCode,
                     'path' => $latestRelPath,
                     'message' => $e->getMessage(),
                 ]);

--- a/backend/app/Services/Report/Composer/ReportPersistence.php
+++ b/backend/app/Services/Report/Composer/ReportPersistence.php
@@ -4,49 +4,33 @@ declare(strict_types=1);
 
 namespace App\Services\Report\Composer;
 
+use App\Services\Storage\ArtifactStore;
 use Illuminate\Support\Facades\Log;
-use Illuminate\Support\Facades\Storage;
 
 class ReportPersistence
 {
-    public function persist(string $attemptId, array $payload): void
+    public function __construct(
+        private readonly ArtifactStore $artifactStore
+    ) {
+    }
+
+    public function persist(string $scaleCode, string $attemptId, array $payload): void
     {
         try {
-            $disk = Storage::disk('local');
-            $baseDir = "reports/{$attemptId}";
-            $disk->makeDirectory($baseDir);
-
-            $json = json_encode(
-                $payload,
-                JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES | JSON_PRETTY_PRINT
-            );
-
-            if ($json === false) {
-                Log::warning('[REPORT] persist_report_json_encode_failed', [
-                    'attempt_id' => $attemptId,
-                    'json_error' => json_last_error_msg(),
-                ]);
-                return;
-            }
-
-            $pathLatest = "{$baseDir}/report.json";
-            $disk->put($pathLatest, $json);
-
-            $ts = now()->format('Ymd_His');
-            $pathSnapshot = "{$baseDir}/report.{$ts}.json";
-            $disk->put($pathSnapshot, $json);
+            $this->artifactStore->putReportJson($scaleCode, $attemptId, $payload);
+            $pathLatest = $this->artifactStore->reportJsonPath($scaleCode, $attemptId);
 
             Log::info('[REPORT] persisted', [
+                'scale_code' => $scaleCode,
                 'attempt_id' => $attemptId,
                 'disk' => 'local',
                 'root' => (string) config('filesystems.disks.local.root'),
                 'latest' => $pathLatest,
-                'snapshot' => $pathSnapshot,
-                'latest_exists' => $disk->exists($pathLatest),
-                'latest_abs' => method_exists($disk, 'path') ? $disk->path($pathLatest) : null,
+                'latest_exists' => true,
             ]);
         } catch (\Throwable $e) {
             Log::warning('[REPORT] persist_report_failed', [
+                'scale_code' => $scaleCode,
                 'attempt_id' => $attemptId,
                 'error' => $e->getMessage(),
             ]);

--- a/backend/app/Services/Report/Pdf/ReportPdfArtifactStore.php
+++ b/backend/app/Services/Report/Pdf/ReportPdfArtifactStore.php
@@ -4,34 +4,19 @@ declare(strict_types=1);
 
 namespace App\Services\Report\Pdf;
 
+use App\Services\Storage\ArtifactStore;
 use Illuminate\Support\Facades\Storage;
 
 final class ReportPdfArtifactStore
 {
+    public function __construct(
+        private readonly ArtifactStore $artifactStore
+    ) {
+    }
+
     public function path(string $scaleCode, string $attemptId, string $manifestHash, string $variant): string
     {
-        $scale = strtoupper(trim($scaleCode));
-        if ($scale === '') {
-            $scale = 'UNKNOWN';
-        }
-        $scale = preg_replace('/[^A-Z0-9_]/', '_', $scale) ?? 'UNKNOWN';
-
-        $attempt = trim($attemptId);
-        if ($attempt === '') {
-            $attempt = 'unknown_attempt';
-        }
-        $attempt = preg_replace('/[^a-zA-Z0-9\\-_]/', '_', $attempt) ?? 'unknown_attempt';
-
-        $hash = trim($manifestHash) !== '' ? trim($manifestHash) : 'nohash';
-        $hash = preg_replace('/[^a-zA-Z0-9\\-_\\.]/', '', $hash) ?? 'nohash';
-        if ($hash === '') {
-            $hash = 'nohash';
-        }
-
-        $variant = strtolower(trim($variant));
-        $variant = in_array($variant, ['free', 'full'], true) ? $variant : 'free';
-
-        return "private/reports/{$scale}/{$attempt}/{$hash}/report_{$variant}.pdf";
+        return $this->artifactStore->pdfPath($scaleCode, $attemptId, $manifestHash, $variant);
     }
 
     public function exists(string $path): bool
@@ -48,6 +33,19 @@ final class ReportPdfArtifactStore
     {
         $disk = Storage::disk('local');
         if (! $disk->exists($path)) {
+            if (preg_match('#^artifacts/pdf/([^/]+)/([^/]+)/([^/]+)/report_(free|full)\\.pdf$#i', $path, $m) === 1) {
+                $fallback = $this->artifactStore->getPdf(
+                    (string) ($m[1] ?? ''),
+                    (string) ($m[2] ?? ''),
+                    (string) ($m[3] ?? ''),
+                    (string) ($m[4] ?? 'free')
+                );
+
+                if (is_array($fallback) && is_string($fallback['binary'] ?? null)) {
+                    return $fallback['binary'];
+                }
+            }
+
             return null;
         }
 

--- a/backend/app/Services/Report/ReportComposer.php
+++ b/backend/app/Services/Report/ReportComposer.php
@@ -75,7 +75,7 @@ class ReportComposer
             && is_array($payload['report'] ?? null)
         ) {
             $attemptId = (string) ($payload['attempt_id'] ?? $composeContext->attemptId);
-            $this->persistence->persist($attemptId, $payload['report']);
+            $this->persistence->persist((string) ($attempt->scale_code ?? 'MBTI'), $attemptId, $payload['report']);
         }
 
         return $payload;

--- a/backend/app/Services/Storage/ArtifactStore.php
+++ b/backend/app/Services/Storage/ArtifactStore.php
@@ -1,0 +1,244 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\Storage;
+
+use Illuminate\Support\Facades\Storage;
+
+final class ArtifactStore
+{
+    public function putReportJson(string $scaleCode, string $attemptId, array $payload): void
+    {
+        $json = json_encode(
+            $payload,
+            JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES | JSON_PRETTY_PRINT
+        );
+
+        if (! is_string($json)) {
+            throw new \RuntimeException('report_json_encode_failed: '.json_last_error_msg());
+        }
+
+        Storage::disk('local')->put($this->reportJsonPath($scaleCode, $attemptId), $json);
+    }
+
+    public function getReportJson(string $scaleCode, string $attemptId): ?array
+    {
+        foreach ($this->reportJsonCandidatePaths($scaleCode, $attemptId) as $path) {
+            $decoded = $this->readJson($path);
+            if (is_array($decoded)) {
+                return $decoded;
+            }
+        }
+
+        return null;
+    }
+
+    public function putPdf(
+        string $scaleCode,
+        string $attemptId,
+        string $manifestHash,
+        string $variant,
+        string $bytes
+    ): string {
+        $path = $this->pdfPath($scaleCode, $attemptId, $manifestHash, $variant);
+        Storage::disk('local')->put($path, $bytes);
+
+        return $path;
+    }
+
+    /**
+     * @return array{path:string,binary:string}|null
+     */
+    public function getPdf(
+        string $scaleCode,
+        string $attemptId,
+        string $manifestHash,
+        string $variant
+    ): ?array {
+        foreach ($this->pdfCandidatePaths($scaleCode, $attemptId, $manifestHash, $variant) as $path) {
+            $contents = $this->readBinary($path);
+            if ($contents !== null) {
+                return [
+                    'path' => $path,
+                    'binary' => $contents,
+                ];
+            }
+        }
+
+        return null;
+    }
+
+    public function reportJsonPath(string $scaleCode, string $attemptId): string
+    {
+        return sprintf(
+            'artifacts/reports/%s/%s/report.json',
+            $this->normalizeScaleCode($scaleCode),
+            $this->normalizeAttemptId($attemptId)
+        );
+    }
+
+    public function pdfPath(string $scaleCode, string $attemptId, string $manifestHash, string $variant): string
+    {
+        return sprintf(
+            'artifacts/pdf/%s/%s/%s/report_%s.pdf',
+            $this->normalizeScaleCode($scaleCode),
+            $this->normalizeAttemptId($attemptId),
+            $this->normalizeManifestHash($manifestHash),
+            $this->normalizeVariant($variant)
+        );
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function reportJsonCandidatePaths(string $scaleCode, string $attemptId): array
+    {
+        $attempt = $this->normalizeAttemptId($attemptId);
+        $paths = [
+            $this->reportJsonPath($scaleCode, $attemptId),
+            "reports/{$attempt}/report.json",
+            "private/reports/{$attempt}/report.json",
+        ];
+
+        foreach ($this->scaleCandidates($scaleCode) as $scale) {
+            $paths[] = "reports/{$scale}/{$attempt}/report.json";
+            $paths[] = "private/reports/{$scale}/{$attempt}/report.json";
+        }
+
+        return $this->uniquePaths($paths);
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function pdfCandidatePaths(
+        string $scaleCode,
+        string $attemptId,
+        string $manifestHash,
+        string $variant
+    ): array {
+        $attempt = $this->normalizeAttemptId($attemptId);
+        $hash = $this->normalizeManifestHash($manifestHash);
+        $normalizedVariant = $this->normalizeVariant($variant);
+
+        $paths = [
+            $this->pdfPath($scaleCode, $attemptId, $manifestHash, $variant),
+            "private/reports/big5/{$attempt}/report_{$normalizedVariant}.pdf",
+            "reports/big5/{$attempt}/report_{$normalizedVariant}.pdf",
+        ];
+
+        foreach ($this->scaleCandidates($scaleCode) as $scale) {
+            $paths[] = "private/reports/{$scale}/{$attempt}/{$hash}/report_{$normalizedVariant}.pdf";
+            $paths[] = "reports/{$scale}/{$attempt}/{$hash}/report_{$normalizedVariant}.pdf";
+        }
+
+        return $this->uniquePaths($paths);
+    }
+
+    private function readJson(string $path): ?array
+    {
+        $contents = $this->readBinary($path);
+        if ($contents === null || trim($contents) === '') {
+            return null;
+        }
+
+        $decoded = json_decode($contents, true);
+
+        return is_array($decoded) ? $decoded : null;
+    }
+
+    private function readBinary(string $path): ?string
+    {
+        $disk = Storage::disk('local');
+        if (! $disk->exists($path)) {
+            return null;
+        }
+
+        $contents = $disk->get($path);
+
+        return is_string($contents) && $contents !== '' ? $contents : null;
+    }
+
+    private function normalizeScaleCode(string $scaleCode): string
+    {
+        $scale = strtoupper(trim($scaleCode));
+        if ($scale === '') {
+            $scale = 'UNKNOWN';
+        }
+
+        $scale = preg_replace('/[^A-Z0-9_]/', '_', $scale) ?? 'UNKNOWN';
+
+        return $scale !== '' ? $scale : 'UNKNOWN';
+    }
+
+    private function normalizeAttemptId(string $attemptId): string
+    {
+        $attempt = trim($attemptId);
+        if ($attempt === '') {
+            $attempt = 'unknown_attempt';
+        }
+
+        $attempt = preg_replace('/[^a-zA-Z0-9\-_]/', '_', $attempt) ?? 'unknown_attempt';
+
+        return $attempt !== '' ? $attempt : 'unknown_attempt';
+    }
+
+    private function normalizeManifestHash(string $manifestHash): string
+    {
+        $hash = trim($manifestHash);
+        if ($hash === '') {
+            $hash = 'nohash';
+        }
+
+        $hash = preg_replace('/[^a-zA-Z0-9\-_\.]/', '', $hash) ?? 'nohash';
+
+        return $hash !== '' ? $hash : 'nohash';
+    }
+
+    private function normalizeVariant(string $variant): string
+    {
+        $normalized = strtolower(trim($variant));
+
+        return in_array($normalized, ['free', 'full'], true) ? $normalized : 'free';
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function scaleCandidates(string $scaleCode): array
+    {
+        $raw = trim($scaleCode);
+        $normalized = $this->normalizeScaleCode($raw);
+        $rawSanitized = preg_replace('/[^a-zA-Z0-9_]/', '_', $raw) ?? '';
+
+        return $this->uniquePaths([
+            $normalized,
+            $rawSanitized,
+            strtoupper($rawSanitized),
+            strtolower($rawSanitized),
+        ]);
+    }
+
+    /**
+     * @param  list<string>  $paths
+     * @return list<string>
+     */
+    private function uniquePaths(array $paths): array
+    {
+        $seen = [];
+        $unique = [];
+
+        foreach ($paths as $path) {
+            $path = trim((string) $path);
+            if ($path === '' || isset($seen[$path])) {
+                continue;
+            }
+
+            $seen[$path] = true;
+            $unique[] = $path;
+        }
+
+        return $unique;
+    }
+}

--- a/backend/tests/Feature/Report/ReportPdfCrossScaleDeliveryTest.php
+++ b/backend/tests/Feature/Report/ReportPdfCrossScaleDeliveryTest.php
@@ -8,6 +8,7 @@ use App\Services\Assessment\Scorers\ClinicalCombo68ScorerV1;
 use App\Services\Assessment\Scorers\Sds20ScorerV2FactorLogic;
 use App\Services\Content\ClinicalComboPackLoader;
 use App\Services\Content\Sds20PackLoader;
+use App\Services\Report\Pdf\ReportPdfDocumentService;
 use App\Models\Attempt;
 use App\Models\Result;
 use Database\Seeders\ScaleRegistrySeeder;
@@ -51,8 +52,8 @@ final class ReportPdfCrossScaleDeliveryTest extends TestCase
         $sdsPdf->assertHeader('Content-Type', 'application/pdf');
         $sdsPdf->assertHeader('X-Report-Scale', 'SDS_20');
 
-        $clinicalFilesFirst = Storage::disk('local')->allFiles('private/reports/CLINICAL_COMBO_68/'.$clinicalAttemptId);
-        $sdsFilesFirst = Storage::disk('local')->allFiles('private/reports/SDS_20/'.$sdsAttemptId);
+        $clinicalFilesFirst = Storage::disk('local')->allFiles('artifacts/pdf/CLINICAL_COMBO_68/'.$clinicalAttemptId);
+        $sdsFilesFirst = Storage::disk('local')->allFiles('artifacts/pdf/SDS_20/'.$sdsAttemptId);
         $this->assertCount(1, $clinicalFilesFirst);
         $this->assertCount(1, $sdsFilesFirst);
         $this->assertStringContainsString('/report_free.pdf', $clinicalFilesFirst[0]);
@@ -64,8 +65,32 @@ final class ReportPdfCrossScaleDeliveryTest extends TestCase
         ])->get('/api/v0.3/attempts/'.$clinicalAttemptId.'/report.pdf');
         $clinicalPdfAgain->assertStatus(200);
 
-        $clinicalFilesSecond = Storage::disk('local')->allFiles('private/reports/CLINICAL_COMBO_68/'.$clinicalAttemptId);
+        $clinicalFilesSecond = Storage::disk('local')->allFiles('artifacts/pdf/CLINICAL_COMBO_68/'.$clinicalAttemptId);
         $this->assertSame($clinicalFilesFirst, $clinicalFilesSecond);
+
+        /** @var Attempt|null $clinicalAttempt */
+        $clinicalAttempt = Attempt::query()->find($clinicalAttemptId);
+        /** @var Result|null $clinicalResult */
+        $clinicalResult = Result::query()->where('attempt_id', $clinicalAttemptId)->where('org_id', 0)->first();
+        $this->assertNotNull($clinicalAttempt);
+        $this->assertNotNull($clinicalResult);
+
+        /** @var ReportPdfDocumentService $pdfService */
+        $pdfService = app(ReportPdfDocumentService::class);
+        $manifestHash = $pdfService->resolveManifestHash($clinicalAttempt, $clinicalResult);
+        $newPdfPath = $pdfService->resolveArtifactPath($clinicalAttempt, 'free', $clinicalResult);
+        Storage::disk('local')->delete($newPdfPath);
+
+        $legacyPdfPath = sprintf(
+            'private/reports/CLINICAL_COMBO_68/%s/%s/report_free.pdf',
+            $clinicalAttemptId,
+            $manifestHash
+        );
+        $legacyBytes = '%PDF-legacy-fallback%';
+        Storage::disk('local')->put($legacyPdfPath, $legacyBytes);
+
+        $fallbackRead = $pdfService->readArtifact($clinicalAttempt, 'free', $clinicalResult);
+        $this->assertSame($legacyBytes, $fallbackRead);
     }
 
     private function createClinicalAttemptWithResult(string $anonId): string

--- a/backend/tests/Feature/Storage/ArtifactStoreReadCompatibilityTest.php
+++ b/backend/tests/Feature/Storage/ArtifactStoreReadCompatibilityTest.php
@@ -1,0 +1,69 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Storage;
+
+use App\Services\Storage\ArtifactStore;
+use Illuminate\Support\Facades\File;
+use Illuminate\Support\Str;
+use Tests\TestCase;
+
+final class ArtifactStoreReadCompatibilityTest extends TestCase
+{
+    /** @var list<string> */
+    private array $cleanupDirs = [];
+
+    protected function tearDown(): void
+    {
+        foreach ($this->cleanupDirs as $dir) {
+            if (is_dir($dir)) {
+                File::deleteDirectory($dir);
+            }
+        }
+
+        parent::tearDown();
+    }
+
+    public function test_get_report_json_reads_legacy_reports_path(): void
+    {
+        $attemptId = (string) Str::uuid();
+        $legacyDir = storage_path('app/private/reports/'.$attemptId);
+        $this->cleanupDirs[] = $legacyDir;
+
+        File::ensureDirectoryExists($legacyDir);
+        File::put($legacyDir.'/report.json', json_encode([
+            'ok' => true,
+            'source' => 'legacy_reports',
+        ], JSON_UNESCAPED_UNICODE));
+
+        /** @var ArtifactStore $store */
+        $store = app(ArtifactStore::class);
+        $payload = $store->getReportJson('MBTI', $attemptId);
+
+        $this->assertIsArray($payload);
+        $this->assertTrue((bool) ($payload['ok'] ?? false));
+        $this->assertSame('legacy_reports', (string) ($payload['source'] ?? ''));
+    }
+
+    public function test_get_pdf_reads_legacy_private_reports_path(): void
+    {
+        $attemptId = (string) Str::uuid();
+        $legacyDir = storage_path('app/private/private/reports/BIG5_OCEAN/'.$attemptId.'/hash_v1');
+        $this->cleanupDirs[] = storage_path('app/private/private/reports/BIG5_OCEAN/'.$attemptId);
+
+        File::ensureDirectoryExists($legacyDir);
+        File::put($legacyDir.'/report_free.pdf', '%PDF legacy artifact bytes%');
+
+        /** @var ArtifactStore $store */
+        $store = app(ArtifactStore::class);
+        $pdf = $store->getPdf('BIG5_OCEAN', $attemptId, 'hash_v1', 'free');
+
+        $this->assertIsArray($pdf);
+        $this->assertSame(
+            'private/reports/BIG5_OCEAN/'.$attemptId.'/hash_v1/report_free.pdf',
+            (string) ($pdf['path'] ?? '')
+        );
+        $this->assertSame('%PDF legacy artifact bytes%', (string) ($pdf['binary'] ?? ''));
+    }
+}

--- a/backend/tests/Feature/Storage/StorageMigrateLegacyArtifactsCommandTest.php
+++ b/backend/tests/Feature/Storage/StorageMigrateLegacyArtifactsCommandTest.php
@@ -1,0 +1,114 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Storage;
+
+use App\Models\Attempt;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\File;
+use Illuminate\Support\Str;
+use Tests\TestCase;
+
+final class StorageMigrateLegacyArtifactsCommandTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private string $attemptId;
+
+    private string $legacyReportPath;
+
+    private string $legacyPdfPath;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->attemptId = (string) Str::uuid();
+
+        Attempt::create([
+            'id' => $this->attemptId,
+            'org_id' => 0,
+            'anon_id' => 'anon_storage_migrate_test',
+            'scale_code' => 'BIG5_OCEAN',
+            'scale_version' => 'v0.3',
+            'region' => 'CN_MAINLAND',
+            'locale' => 'zh-CN',
+            'question_count' => 120,
+            'client_platform' => 'test',
+            'answers_summary_json' => ['stage' => 'seed'],
+            'started_at' => now()->subMinute(),
+            'submitted_at' => now(),
+            'pack_id' => 'BIG5_OCEAN',
+            'dir_version' => 'v1',
+            'content_package_version' => 'v1',
+            'scoring_spec_version' => 'v1',
+        ]);
+
+        $legacyReportDir = storage_path('app/private/reports/'.$this->attemptId);
+        File::ensureDirectoryExists($legacyReportDir);
+        $this->legacyReportPath = $legacyReportDir.'/report.json';
+        File::put($this->legacyReportPath, json_encode([
+            'ok' => true,
+            'report_id' => $this->attemptId,
+        ], JSON_UNESCAPED_UNICODE));
+
+        $legacyPdfDir = storage_path('app/private/private/reports/BIG5_OCEAN/'.$this->attemptId.'/hash_v1');
+        File::ensureDirectoryExists($legacyPdfDir);
+        $this->legacyPdfPath = $legacyPdfDir.'/report_free.pdf';
+        File::put($this->legacyPdfPath, '%PDF legacy migrate source%');
+    }
+
+    protected function tearDown(): void
+    {
+        $reportDir = storage_path('app/private/reports/'.$this->attemptId);
+        if (is_dir($reportDir)) {
+            File::deleteDirectory($reportDir);
+        }
+
+        $legacyPdfRoot = storage_path('app/private/private/reports/BIG5_OCEAN/'.$this->attemptId);
+        if (is_dir($legacyPdfRoot)) {
+            File::deleteDirectory($legacyPdfRoot);
+        }
+
+        $newReportRoot = storage_path('app/private/artifacts/reports/BIG5_OCEAN/'.$this->attemptId);
+        if (is_dir($newReportRoot)) {
+            File::deleteDirectory($newReportRoot);
+        }
+
+        $newPdfRoot = storage_path('app/private/artifacts/pdf/BIG5_OCEAN/'.$this->attemptId);
+        if (is_dir($newPdfRoot)) {
+            File::deleteDirectory($newPdfRoot);
+        }
+
+        parent::tearDown();
+    }
+
+    public function test_migrate_command_dry_run_and_execute_with_audit(): void
+    {
+        $newReportPath = storage_path('app/private/artifacts/reports/BIG5_OCEAN/'.$this->attemptId.'/report.json');
+        $newPdfPath = storage_path('app/private/artifacts/pdf/BIG5_OCEAN/'.$this->attemptId.'/hash_v1/report_free.pdf');
+
+        $this->artisan('storage:migrate-legacy-artifacts --dry-run')
+            ->assertExitCode(0);
+
+        $this->assertFileDoesNotExist($newReportPath);
+        $this->assertFileDoesNotExist($newPdfPath);
+
+        $this->artisan('storage:migrate-legacy-artifacts --execute')
+            ->assertExitCode(0);
+
+        $this->assertFileExists($this->legacyReportPath);
+        $this->assertFileExists($this->legacyPdfPath);
+        $this->assertFileExists($newReportPath);
+        $this->assertFileExists($newPdfPath);
+
+        $auditCount = DB::table('audit_logs')
+            ->where('action', 'storage_artifact_migrate')
+            ->where('target_id', $this->attemptId)
+            ->count();
+
+        $this->assertGreaterThanOrEqual(2, $auditCount);
+    }
+}


### PR DESCRIPTION
## Summary
- Introduce `ArtifactStore` as canonical storage adapter for report JSON/PDF.
- Switch report/pdf write paths to canonical artifact paths.
- Add legacy read fallback and one-time migration command (`storage:migrate-legacy-artifacts`) with dry-run/execute.

## Scope
- Internal storage path governance only; external API behavior unchanged.

## Verification
- `php artisan route:list`
- `php artisan migrate`
- `php artisan storage:migrate-legacy-artifacts --dry-run`
- `php artisan storage:migrate-legacy-artifacts --execute`
- `php artisan test --filter=ArtifactStoreReadCompatibilityTest`
- `php artisan test --filter=StorageMigrateLegacyArtifactsCommandTest`
- `php artisan test --filter=ReportPdfCrossScaleDeliveryTest`
- `bash /Users/rainie/Desktop/GitHub/fap-api/backend/scripts/ci_verify_mbti.sh`

## Risk & Rollback
- Medium-low risk: read path is backward compatible by design.
- Rollback: keep legacy resolver path active and revert branch.
EOF