### PR TITLE
feat(storage): retention lifecycle, inventory/prune schedule, and packs2 path migration

### DIFF
--- a/backend/app/Console/Commands/Packs2MigrateStoragePath.php
+++ b/backend/app/Console/Commands/Packs2MigrateStoragePath.php
@@ -1,0 +1,294 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Console\Commands;
+
+use App\Support\SchemaBaseline;
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\File;
+use Illuminate\Support\Facades\Schema;
+
+final class Packs2MigrateStoragePath extends Command
+{
+    protected $signature = 'packs2:migrate-storage-path
+        {--dry-run : Plan migration only}
+        {--execute : Execute migration and update DB storage_path}';
+
+    protected $description = 'Migrate packs2 storage_path from content_packs_v2/* to private/packs_v2/*.';
+
+    public function handle(): int
+    {
+        $dryRun = (bool) $this->option('dry-run');
+        $execute = (bool) $this->option('execute');
+
+        if (($dryRun && $execute) || (! $dryRun && ! $execute)) {
+            $this->error('exactly one of --dry-run or --execute is required.');
+
+            return self::FAILURE;
+        }
+
+        $operations = $this->collectOperations();
+
+        if ($dryRun) {
+            $this->line('status=planned');
+            $this->line('operations='.count($operations));
+
+            return self::SUCCESS;
+        }
+
+        return $this->executeOperations($operations);
+    }
+
+    /**
+     * @return list<array{release_id:string,source_storage_path:string,target_storage_path:string,source_abs:string,target_abs:string,pack_id:string,pack_version:string,manifest_hash:string}>
+     */
+    private function collectOperations(): array
+    {
+        if (! SchemaBaseline::hasTable('content_pack_releases')) {
+            return [];
+        }
+
+        $rows = DB::table('content_pack_releases')
+            ->whereNotNull('storage_path')
+            ->orderBy('created_at')
+            ->get();
+
+        $operations = [];
+        foreach ($rows as $row) {
+            $releaseId = trim((string) ($row->id ?? ''));
+            $storagePath = trim((string) ($row->storage_path ?? ''));
+            if ($releaseId === '' || $storagePath === '') {
+                continue;
+            }
+
+            $relativeLegacy = $this->legacyRelativePath($storagePath);
+            if ($relativeLegacy === null) {
+                continue;
+            }
+
+            $segments = explode('/', trim($relativeLegacy, '/'));
+            if (count($segments) < 4) {
+                continue;
+            }
+
+            $packId = strtoupper(trim((string) ($row->to_pack_id ?? ($segments[1] ?? ''))));
+            $packVersion = trim((string) (($row->pack_version ?? null) ?: ($row->dir_alias ?? null) ?: ($segments[2] ?? '')));
+            if ($packId === '' || $packVersion === '') {
+                continue;
+            }
+
+            $manifestHash = strtolower(trim((string) ($row->manifest_hash ?? '')));
+            if ($manifestHash === '') {
+                $manifestHash = $releaseId;
+            }
+
+            $targetStoragePath = 'private/packs_v2/'.$packId.'/'.$packVersion.'/'.$manifestHash;
+
+            $operations[] = [
+                'release_id' => $releaseId,
+                'source_storage_path' => $storagePath,
+                'target_storage_path' => $targetStoragePath,
+                'source_abs' => $this->resolveStorageAbsolutePath($storagePath),
+                'target_abs' => storage_path('app/'.$targetStoragePath),
+                'pack_id' => $packId,
+                'pack_version' => $packVersion,
+                'manifest_hash' => $manifestHash,
+            ];
+        }
+
+        return $operations;
+    }
+
+    /**
+     * @param  list<array{release_id:string,source_storage_path:string,target_storage_path:string,source_abs:string,target_abs:string,pack_id:string,pack_version:string,manifest_hash:string}>  $operations
+     */
+    private function executeOperations(array $operations): int
+    {
+        if (! SchemaBaseline::hasTable('content_pack_releases')) {
+            $this->error('content_pack_releases table unavailable.');
+
+            return self::FAILURE;
+        }
+
+        $migrated = 0;
+        $updatedRows = 0;
+        $missingSource = 0;
+        $failed = 0;
+
+        foreach ($operations as $operation) {
+            $sourceAbs = $operation['source_abs'];
+            $targetAbs = $operation['target_abs'];
+
+            $copied = false;
+            if (! is_dir($targetAbs)) {
+                if (! is_dir($sourceAbs)) {
+                    $missingSource++;
+
+                    continue;
+                }
+
+                File::ensureDirectoryExists(dirname($targetAbs));
+                if (! File::copyDirectory($sourceAbs, $targetAbs)) {
+                    $failed++;
+                    $this->warn('copy_failed release_id='.$operation['release_id']);
+
+                    continue;
+                }
+
+                $copied = true;
+            }
+
+            $updated = false;
+            $releaseId = $operation['release_id'];
+            $targetStoragePath = $operation['target_storage_path'];
+
+            $affected = DB::table('content_pack_releases')
+                ->where('id', $releaseId)
+                ->update([
+                    'storage_path' => $targetStoragePath,
+                    'updated_at' => now(),
+                ]);
+
+            if ($affected > 0) {
+                $updated = true;
+                $updatedRows += $affected;
+            }
+
+            $migrated++;
+            $this->writeAuditLog($operation, $copied, $updated, $this->targetManifestSha256($targetAbs));
+        }
+
+        $this->line('status=executed');
+        $this->line('operations='.count($operations));
+        $this->line('migrated='.$migrated);
+        $this->line('updated_rows='.$updatedRows);
+        $this->line('missing_source='.$missingSource);
+        $this->line('failed='.$failed);
+
+        return $failed > 0 ? self::FAILURE : self::SUCCESS;
+    }
+
+    private function targetManifestSha256(string $targetAbs): string
+    {
+        $candidates = [
+            $targetAbs.'/manifest.json',
+            $targetAbs.'/compiled/manifest.json',
+        ];
+
+        foreach ($candidates as $path) {
+            if (is_file($path)) {
+                $hash = hash_file('sha256', $path);
+
+                return is_string($hash) ? $hash : '';
+            }
+        }
+
+        return '';
+    }
+
+    private function resolveStorageAbsolutePath(string $storagePath): string
+    {
+        $normalized = str_replace('\\', '/', trim($storagePath));
+        if ($normalized === '') {
+            return storage_path('app');
+        }
+
+        if (str_starts_with($normalized, '/')) {
+            return rtrim($normalized, '/');
+        }
+
+        $relative = ltrim($normalized, '/');
+        if (str_starts_with($relative, 'app/')) {
+            $relative = substr($relative, 4);
+        }
+
+        return rtrim(storage_path('app/'.$relative), '/');
+    }
+
+    private function legacyRelativePath(string $storagePath): ?string
+    {
+        $normalized = str_replace('\\', '/', trim($storagePath));
+        if ($normalized === '') {
+            return null;
+        }
+
+        if (str_contains($normalized, '/storage/app/content_packs_v2/')) {
+            $parts = explode('/storage/app/', $normalized, 2);
+            $relative = $parts[1] ?? '';
+
+            return str_starts_with($relative, 'content_packs_v2/') ? $relative : null;
+        }
+
+        $relative = ltrim($normalized, '/');
+        if (str_starts_with($relative, 'app/')) {
+            $relative = substr($relative, 4);
+        }
+
+        return str_starts_with($relative, 'content_packs_v2/') ? $relative : null;
+    }
+
+    /**
+     * @param  array{release_id:string,source_storage_path:string,target_storage_path:string,source_abs:string,target_abs:string,pack_id:string,pack_version:string,manifest_hash:string}  $operation
+     */
+    private function writeAuditLog(array $operation, bool $copied, bool $updated, string $sha256): void
+    {
+        if (! Schema::hasTable('audit_logs')) {
+            return;
+        }
+
+        $meta = [
+            'release_id' => $operation['release_id'],
+            'source_storage_path' => $operation['source_storage_path'],
+            'target_storage_path' => $operation['target_storage_path'],
+            'pack_id' => $operation['pack_id'],
+            'pack_version' => $operation['pack_version'],
+            'manifest_hash' => $operation['manifest_hash'],
+            'copied' => $copied,
+            'updated' => $updated,
+            'sha256' => $sha256,
+        ];
+
+        $metaJson = json_encode($meta, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES);
+        if (! is_string($metaJson)) {
+            $metaJson = '{}';
+        }
+
+        $row = [
+            'action' => 'packs2_storage_path_migrate',
+            'target_type' => 'content_pack_release',
+            'target_id' => $operation['release_id'],
+            'meta_json' => $metaJson,
+            'created_at' => now(),
+        ];
+
+        if (SchemaBaseline::hasColumn('audit_logs', 'org_id')) {
+            $row['org_id'] = 0;
+        }
+        if (SchemaBaseline::hasColumn('audit_logs', 'actor_admin_id')) {
+            $row['actor_admin_id'] = null;
+        }
+        if (SchemaBaseline::hasColumn('audit_logs', 'ip')) {
+            $row['ip'] = '127.0.0.1';
+        }
+        if (SchemaBaseline::hasColumn('audit_logs', 'user_agent')) {
+            $row['user_agent'] = 'artisan';
+        }
+        if (SchemaBaseline::hasColumn('audit_logs', 'request_id')) {
+            $row['request_id'] = 'packs2:migrate-storage-path';
+        }
+        if (SchemaBaseline::hasColumn('audit_logs', 'reason')) {
+            $row['reason'] = 'storage_governance_packs2_migrate';
+        }
+        if (SchemaBaseline::hasColumn('audit_logs', 'result')) {
+            $row['result'] = $updated ? 'success' : 'skipped';
+        }
+
+        try {
+            DB::table('audit_logs')->insert($row);
+        } catch (\Throwable) {
+            // keep storage path migration non-blocking when audit persistence is unavailable.
+        }
+    }
+}

--- a/backend/app/Console/Commands/Packs2MigrateStoragePath.php
+++ b/backend/app/Console/Commands/Packs2MigrateStoragePath.php
@@ -8,6 +8,7 @@ use App\Support\SchemaBaseline;
 use Illuminate\Console\Command;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\File;
+use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Facades\Schema;
 
 final class Packs2MigrateStoragePath extends Command
@@ -287,8 +288,12 @@ final class Packs2MigrateStoragePath extends Command
 
         try {
             DB::table('audit_logs')->insert($row);
-        } catch (\Throwable) {
-            // keep storage path migration non-blocking when audit persistence is unavailable.
+        } catch (\Throwable $e) {
+            Log::warning('packs2_migrate_audit_log_insert_failed', [
+                'command' => 'packs2:migrate-storage-path',
+                'release_id' => $operation['release_id'] ?? null,
+                'error' => $e->getMessage(),
+            ]);
         }
     }
 }

--- a/backend/app/Console/Commands/StorageInventory.php
+++ b/backend/app/Console/Commands/StorageInventory.php
@@ -1,0 +1,232 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Console\Commands;
+
+use App\Support\SchemaBaseline;
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+final class StorageInventory extends Command
+{
+    protected $signature = 'storage:inventory
+        {--json : Output inventory as json}';
+
+    protected $description = 'Inspect storage usage snapshot and persist audit log.';
+
+    public function handle(): int
+    {
+        $snapshot = $this->buildSnapshot();
+
+        if ((bool) $this->option('json')) {
+            $encoded = json_encode($snapshot, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES);
+            if (! is_string($encoded)) {
+                $this->error('failed_to_encode_inventory_json');
+
+                return self::FAILURE;
+            }
+
+            $this->line($encoded);
+        } else {
+            $rows = [];
+            $scopes = is_array($snapshot['scopes'] ?? null) ? $snapshot['scopes'] : [];
+            foreach ($scopes as $scope => $data) {
+                if (! is_array($data)) {
+                    continue;
+                }
+
+                $rows[] = [
+                    (string) $scope,
+                    (string) ((int) ($data['files_count'] ?? 0)),
+                    (string) ((int) ($data['bytes_total'] ?? 0)),
+                    (string) ($data['oldest_mtime'] ?? ''),
+                    (string) ($data['newest_mtime'] ?? ''),
+                ];
+            }
+
+            $this->table(['scope', 'files_count', 'bytes_total', 'oldest_mtime', 'newest_mtime'], $rows);
+        }
+
+        $this->writeAuditLog($snapshot);
+
+        return self::SUCCESS;
+    }
+
+    /**
+     * @return array{schema:string,generated_at:string,scopes:array<string,array<string,mixed>>}
+     */
+    private function buildSnapshot(): array
+    {
+        $roots = [
+            'artifacts' => storage_path('app/private/artifacts'),
+            'reports' => storage_path('app/private/reports'),
+            'packs_v2' => storage_path('app/private/packs_v2'),
+            'releases' => storage_path('app/private/releases'),
+            'content_releases' => storage_path('app/private/content_releases'),
+            'prune_plans' => storage_path('app/private/prune_plans'),
+            'logs' => storage_path('logs'),
+        ];
+
+        $scopes = [];
+        foreach ($roots as $scope => $root) {
+            $scopes[$scope] = $this->buildDirectoryStats($root);
+        }
+
+        return [
+            'schema' => 'storage_inventory_snapshot.v1',
+            'generated_at' => now()->toISOString(),
+            'scopes' => $scopes,
+        ];
+    }
+
+    /**
+     * @return array{files_count:int,bytes_total:int,oldest_mtime:?string,newest_mtime:?string,top_children:list<array{name:string,files_count:int,bytes_total:int}>}
+     */
+    private function buildDirectoryStats(string $root): array
+    {
+        if (! is_dir($root)) {
+            return [
+                'files_count' => 0,
+                'bytes_total' => 0,
+                'oldest_mtime' => null,
+                'newest_mtime' => null,
+                'top_children' => [],
+            ];
+        }
+
+        $filesCount = 0;
+        $bytesTotal = 0;
+        $oldestTs = null;
+        $newestTs = null;
+
+        /** @var array<string,array{files_count:int,bytes_total:int}> $children */
+        $children = [];
+
+        $iterator = new \RecursiveIteratorIterator(
+            new \RecursiveDirectoryIterator($root, \FilesystemIterator::SKIP_DOTS)
+        );
+
+        foreach ($iterator as $file) {
+            if (! $file instanceof \SplFileInfo || ! $file->isFile()) {
+                continue;
+            }
+
+            $fullPath = $file->getPathname();
+            $relPath = ltrim(str_replace('\\', '/', substr($fullPath, strlen(rtrim($root, DIRECTORY_SEPARATOR)))), '/');
+
+            $bytes = max(0, (int) ($file->getSize() ?: 0));
+            $mtime = max(0, (int) ($file->getMTime() ?: 0));
+
+            $filesCount++;
+            $bytesTotal += $bytes;
+            $oldestTs = $oldestTs === null ? $mtime : min($oldestTs, $mtime);
+            $newestTs = $newestTs === null ? $mtime : max($newestTs, $mtime);
+
+            $child = $this->topChildName($relPath);
+            if (! isset($children[$child])) {
+                $children[$child] = [
+                    'files_count' => 0,
+                    'bytes_total' => 0,
+                ];
+            }
+            $children[$child]['files_count']++;
+            $children[$child]['bytes_total'] += $bytes;
+        }
+
+        $childRows = [];
+        foreach ($children as $name => $stats) {
+            $childRows[] = [
+                'name' => $name,
+                'files_count' => (int) ($stats['files_count'] ?? 0),
+                'bytes_total' => (int) ($stats['bytes_total'] ?? 0),
+            ];
+        }
+
+        usort($childRows, static function (array $a, array $b): int {
+            $bytesCmp = ((int) ($b['bytes_total'] ?? 0)) <=> ((int) ($a['bytes_total'] ?? 0));
+            if ($bytesCmp !== 0) {
+                return $bytesCmp;
+            }
+
+            $filesCmp = ((int) ($b['files_count'] ?? 0)) <=> ((int) ($a['files_count'] ?? 0));
+            if ($filesCmp !== 0) {
+                return $filesCmp;
+            }
+
+            return strcmp((string) ($a['name'] ?? ''), (string) ($b['name'] ?? ''));
+        });
+
+        return [
+            'files_count' => $filesCount,
+            'bytes_total' => $bytesTotal,
+            'oldest_mtime' => $oldestTs !== null ? date(DATE_ATOM, $oldestTs) : null,
+            'newest_mtime' => $newestTs !== null ? date(DATE_ATOM, $newestTs) : null,
+            'top_children' => array_slice($childRows, 0, 5),
+        ];
+    }
+
+    private function topChildName(string $relPath): string
+    {
+        $relPath = trim($relPath);
+        if ($relPath === '') {
+            return '.';
+        }
+
+        $parts = explode('/', $relPath, 2);
+
+        return trim((string) ($parts[0] ?? '.')) ?: '.';
+    }
+
+    /**
+     * @param  array{schema:string,generated_at:string,scopes:array<string,array<string,mixed>>}  $snapshot
+     */
+    private function writeAuditLog(array $snapshot): void
+    {
+        if (! Schema::hasTable('audit_logs')) {
+            return;
+        }
+
+        $metaJson = json_encode($snapshot, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES);
+        if (! is_string($metaJson)) {
+            $metaJson = '{}';
+        }
+
+        $row = [
+            'action' => 'storage_inventory_snapshot',
+            'target_type' => 'storage',
+            'target_id' => null,
+            'meta_json' => $metaJson,
+            'created_at' => now(),
+        ];
+
+        if (SchemaBaseline::hasColumn('audit_logs', 'org_id')) {
+            $row['org_id'] = 0;
+        }
+        if (SchemaBaseline::hasColumn('audit_logs', 'actor_admin_id')) {
+            $row['actor_admin_id'] = null;
+        }
+        if (SchemaBaseline::hasColumn('audit_logs', 'ip')) {
+            $row['ip'] = '127.0.0.1';
+        }
+        if (SchemaBaseline::hasColumn('audit_logs', 'user_agent')) {
+            $row['user_agent'] = 'artisan';
+        }
+        if (SchemaBaseline::hasColumn('audit_logs', 'request_id')) {
+            $row['request_id'] = 'storage:inventory';
+        }
+        if (SchemaBaseline::hasColumn('audit_logs', 'reason')) {
+            $row['reason'] = 'storage_governance_inventory';
+        }
+        if (SchemaBaseline::hasColumn('audit_logs', 'result')) {
+            $row['result'] = 'success';
+        }
+
+        try {
+            DB::table('audit_logs')->insert($row);
+        } catch (\Throwable) {
+            // keep inventory snapshot non-blocking when audit persistence is unavailable.
+        }
+    }
+}

--- a/backend/app/Console/Commands/StorageInventory.php
+++ b/backend/app/Console/Commands/StorageInventory.php
@@ -7,6 +7,7 @@ namespace App\Console\Commands;
 use App\Support\SchemaBaseline;
 use Illuminate\Console\Command;
 use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Facades\Schema;
 
 final class StorageInventory extends Command
@@ -225,8 +226,11 @@ final class StorageInventory extends Command
 
         try {
             DB::table('audit_logs')->insert($row);
-        } catch (\Throwable) {
-            // keep inventory snapshot non-blocking when audit persistence is unavailable.
+        } catch (\Throwable $e) {
+            Log::warning('storage_inventory_audit_log_insert_failed', [
+                'command' => 'storage:inventory',
+                'error' => $e->getMessage(),
+            ]);
         }
     }
 }

--- a/backend/app/Console/Commands/StoragePrune.php
+++ b/backend/app/Console/Commands/StoragePrune.php
@@ -4,23 +4,37 @@ declare(strict_types=1);
 
 namespace App\Console\Commands;
 
+use App\Support\SchemaBaseline;
 use Illuminate\Console\Command;
+use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\File;
+use Illuminate\Support\Facades\Schema;
 use Illuminate\Support\Facades\Storage;
 
 final class StoragePrune extends Command
 {
+    private const SCOPE_ALL = 'all';
+
     private const SCOPE_REPORTS_BACKUPS = 'reports_backups';
+
+    private const SCOPE_PDF_EXPIRED = 'pdf_expired';
+
+    private const SCOPE_RELEASES_EXPIRED = 'releases_expired';
+
+    private const SCOPE_LOGS_EXPIRED = 'logs_expired';
 
     /** @var list<string> */
     private const SUPPORTED_SCOPES = [
         self::SCOPE_REPORTS_BACKUPS,
+        self::SCOPE_PDF_EXPIRED,
+        self::SCOPE_RELEASES_EXPIRED,
+        self::SCOPE_LOGS_EXPIRED,
     ];
 
     protected $signature = 'storage:prune
         {--dry-run : Generate prune plan only}
         {--execute : Execute prune plan}
-        {--scope=reports_backups : Prune scope}
+        {--scope=all : Prune scope (all|reports_backups|pdf_expired|releases_expired|logs_expired)}
         {--plan= : Plan json path for execute mode}';
 
     protected $description = 'Generate/execute storage prune plans.';
@@ -29,9 +43,9 @@ final class StoragePrune extends Command
     {
         $dryRun = (bool) $this->option('dry-run');
         $execute = (bool) $this->option('execute');
-        $scope = strtolower(trim((string) $this->option('scope')));
+        $scope = $this->normalizeScope((string) $this->option('scope'));
 
-        if (! in_array($scope, self::SUPPORTED_SCOPES, true)) {
+        if (! $this->isSupportedScope($scope, true)) {
             $this->error('unsupported --scope: '.$scope);
 
             return self::FAILURE;
@@ -52,58 +66,20 @@ final class StoragePrune extends Command
 
     private function dryRun(string $scope): int
     {
-        $entries = match ($scope) {
-            self::SCOPE_REPORTS_BACKUPS => $this->collectReportBackupEntries(),
-            default => [],
-        };
-
-        $totalBytes = 0;
-        $paths = [];
-        foreach ($entries as $entry) {
-            $path = trim((string) ($entry['path'] ?? ''));
-            if ($path === '') {
-                continue;
-            }
-
-            $bytes = max(0, (int) ($entry['bytes'] ?? 0));
-            $paths[] = [
-                'path' => $path,
-                'bytes' => $bytes,
-            ];
-            $totalBytes += $bytes;
-        }
-
-        $plan = [
-            'schema' => 'storage_prune_plan.v1',
-            'scope' => $scope,
-            'generated_at' => now()->toISOString(),
-            'files' => $paths,
-            'summary' => [
-                'files' => count($paths),
-                'bytes' => $totalBytes,
-            ],
-        ];
-
-        $planDir = storage_path('app/private/prune_plans');
-        File::ensureDirectoryExists($planDir);
-
-        $planName = now()->format('Ymd_His').'_'.$scope.'_'.substr(bin2hex(random_bytes(4)), 0, 8).'.json';
-        $planPath = $planDir.DIRECTORY_SEPARATOR.$planName;
-        $encoded = json_encode($plan, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES | JSON_PRETTY_PRINT);
-
-        if (! is_string($encoded)) {
+        $entries = $this->collectEntries($scope);
+        $plan = $this->buildPlan($scope, $entries);
+        $planPath = $this->writePlanFile($plan, $scope);
+        if ($planPath === null) {
             $this->error('failed to encode prune plan json.');
 
             return self::FAILURE;
         }
 
-        File::put($planPath, $encoded.PHP_EOL);
-
         $this->line('status=planned');
         $this->line('scope='.$scope);
         $this->line('plan='.$planPath);
-        $this->line('files='.count($paths));
-        $this->line('bytes='.$totalBytes);
+        $this->line('files='.(int) ($plan['summary']['files'] ?? 0));
+        $this->line('bytes='.(int) ($plan['summary']['bytes'] ?? 0));
 
         return self::SUCCESS;
     }
@@ -112,12 +88,20 @@ final class StoragePrune extends Command
     {
         $planOption = trim((string) $this->option('plan'));
         if ($planOption === '') {
-            $this->error('--plan is required in --execute mode.');
+            $entries = $this->collectEntries($scope);
+            $generatedPlan = $this->buildPlan($scope, $entries);
+            $generatedPlanPath = $this->writePlanFile($generatedPlan, $scope);
+            if ($generatedPlanPath === null) {
+                $this->error('failed to generate plan in --execute mode.');
 
-            return self::FAILURE;
+                return self::FAILURE;
+            }
+
+            $planPath = $generatedPlanPath;
+        } else {
+            $planPath = $this->resolvePlanPath($planOption);
         }
 
-        $planPath = $this->resolvePlanPath($planOption);
         if (! is_file($planPath)) {
             $this->error('plan not found: '.$planPath);
 
@@ -131,14 +115,14 @@ final class StoragePrune extends Command
             return self::FAILURE;
         }
 
-        $planScope = strtolower(trim((string) ($decoded['scope'] ?? '')));
-        if ($planScope !== $scope) {
+        $planScope = $this->normalizeScope((string) ($decoded['scope'] ?? ''));
+        if ($scope !== self::SCOPE_ALL && $planScope !== '' && $planScope !== $scope && $planScope !== self::SCOPE_ALL) {
             $this->error('plan scope mismatch: plan='.$planScope.' cli='.$scope);
 
             return self::FAILURE;
         }
 
-        $files = is_array($decoded['files'] ?? null) ? $decoded['files'] : [];
+        $entries = $this->entriesFromPlan($decoded, $planScope);
         $disk = Storage::disk('local');
 
         $deletedFiles = 0;
@@ -146,32 +130,92 @@ final class StoragePrune extends Command
         $missingFiles = 0;
         $skippedFiles = 0;
 
-        foreach ($files as $fileEntry) {
-            $relPath = trim((string) (is_array($fileEntry) ? ($fileEntry['path'] ?? '') : $fileEntry));
-            if ($relPath === '') {
-                continue;
-            }
+        /** @var array<string,array{files:int,bytes:int}> $deletedByScope */
+        $deletedByScope = [];
 
-            if (! $this->isPrunablePathForScope($scope, $relPath)) {
+        foreach ($entries as $entry) {
+            $entryScope = $this->normalizeScope((string) ($entry['scope'] ?? ''));
+            $path = trim((string) ($entry['path'] ?? ''));
+            $mode = strtolower(trim((string) ($entry['mode'] ?? 'local')));
+            if ($path === '' || ! $this->isSupportedScope($entryScope, false)) {
                 $skippedFiles++;
+
                 continue;
             }
 
-            if (! $disk->exists($relPath)) {
+            if ($scope !== self::SCOPE_ALL && $entryScope !== $scope) {
+                $skippedFiles++;
+
+                continue;
+            }
+
+            if (! isset($deletedByScope[$entryScope])) {
+                $deletedByScope[$entryScope] = ['files' => 0, 'bytes' => 0];
+            }
+
+            if ($mode === 'absolute') {
+                if (! $this->isPrunableAbsolutePathForScope($entryScope, $path)) {
+                    $skippedFiles++;
+
+                    continue;
+                }
+
+                if (! is_file($path)) {
+                    $missingFiles++;
+
+                    continue;
+                }
+
+                $bytes = (int) (filesize($path) ?: 0);
+                if (! @unlink($path)) {
+                    $this->error('delete failed: '.$path);
+
+                    return self::FAILURE;
+                }
+
+                $deletedFiles++;
+                $deletedBytes += max(0, $bytes);
+                $deletedByScope[$entryScope]['files']++;
+                $deletedByScope[$entryScope]['bytes'] += max(0, $bytes);
+
+                continue;
+            }
+
+            if (! $this->isPrunablePathForScope($entryScope, $path)) {
+                $skippedFiles++;
+
+                continue;
+            }
+
+            if (! $disk->exists($path)) {
                 $missingFiles++;
+
                 continue;
             }
 
-            $absPath = storage_path('app/private/'.$relPath);
+            $absPath = storage_path('app/private/'.$path);
             $bytes = is_file($absPath) ? (int) (filesize($absPath) ?: 0) : 0;
-            if (! $disk->delete($relPath)) {
-                $this->error('delete failed: '.$relPath);
+            if (! $disk->delete($path)) {
+                $this->error('delete failed: '.$path);
 
                 return self::FAILURE;
             }
 
             $deletedFiles++;
             $deletedBytes += max(0, $bytes);
+            $deletedByScope[$entryScope]['files']++;
+            $deletedByScope[$entryScope]['bytes'] += max(0, $bytes);
+        }
+
+        $auditScopes = $scope === self::SCOPE_ALL ? self::SUPPORTED_SCOPES : [$scope];
+        foreach ($auditScopes as $auditScope) {
+            $scopeSummary = $deletedByScope[$auditScope] ?? ['files' => 0, 'bytes' => 0];
+            $this->writeAuditLog(
+                $auditScope,
+                (int) ($scopeSummary['files'] ?? 0),
+                (int) ($scopeSummary['bytes'] ?? 0),
+                $planPath
+            );
         }
 
         $this->line('status=executed');
@@ -186,16 +230,211 @@ final class StoragePrune extends Command
     }
 
     /**
-     * @return list<array{path:string,bytes:int}>
+     * @return list<array{scope:string,path:string,bytes:int,mode:string}>
+     */
+    private function collectEntries(string $scope): array
+    {
+        $scopes = $scope === self::SCOPE_ALL ? self::SUPPORTED_SCOPES : [$scope];
+
+        $entries = [];
+        foreach ($scopes as $itemScope) {
+            $entries = array_merge($entries, $this->collectEntriesForScope($itemScope));
+        }
+
+        usort($entries, static function (array $a, array $b): int {
+            $scopeCmp = strcmp((string) ($a['scope'] ?? ''), (string) ($b['scope'] ?? ''));
+            if ($scopeCmp !== 0) {
+                return $scopeCmp;
+            }
+
+            return strcmp((string) ($a['path'] ?? ''), (string) ($b['path'] ?? ''));
+        });
+
+        return $entries;
+    }
+
+    /**
+     * @return list<array{scope:string,path:string,bytes:int,mode:string}>
+     */
+    private function collectEntriesForScope(string $scope): array
+    {
+        return match ($scope) {
+            self::SCOPE_REPORTS_BACKUPS => $this->collectReportBackupEntries(),
+            self::SCOPE_PDF_EXPIRED => $this->collectExpiredPdfEntries(),
+            self::SCOPE_RELEASES_EXPIRED => $this->collectExpiredReleaseEntries(),
+            self::SCOPE_LOGS_EXPIRED => $this->collectExpiredLogEntries(),
+            default => [],
+        };
+    }
+
+    /**
+     * @return list<array{scope:string,path:string,bytes:int,mode:string}>
      */
     private function collectReportBackupEntries(): array
     {
-        $root = storage_path('app/private/reports');
+        $entries = [];
+
+        foreach ($this->scanLocalFiles('reports') as $file) {
+            $relPath = (string) ($file['path'] ?? '');
+            if (! $this->isReportTimestampBackupPath($relPath)) {
+                continue;
+            }
+
+            $entries[] = [
+                'scope' => self::SCOPE_REPORTS_BACKUPS,
+                'path' => $relPath,
+                'bytes' => max(0, (int) ($file['bytes'] ?? 0)),
+                'mode' => 'local',
+            ];
+        }
+
+        return $entries;
+    }
+
+    /**
+     * @return list<array{scope:string,path:string,bytes:int,mode:string}>
+     */
+    private function collectExpiredPdfEntries(): array
+    {
+        $entries = [];
+        $freeKeepDays = max(0, (int) config('storage_retention.pdf.keep_days_free', 30));
+        $paidKeepDays = max(0, (int) config('storage_retention.pdf.keep_days_paid', 365));
+
+        $freeCutoff = now()->subDays($freeKeepDays)->getTimestamp();
+        $paidCutoff = now()->subDays($paidKeepDays)->getTimestamp();
+
+        foreach ($this->scanLocalFiles('artifacts/pdf') as $file) {
+            $relPath = (string) ($file['path'] ?? '');
+            $mtime = max(0, (int) ($file['mtime'] ?? 0));
+
+            if (preg_match('#^artifacts/pdf/[^/]+/[^/]+/[^/]+/report_(free|full)\.pdf$#i', $relPath, $m) !== 1) {
+                continue;
+            }
+
+            $variant = strtolower((string) ($m[1] ?? 'free'));
+            $cutoff = $variant === 'full' ? $paidCutoff : $freeCutoff;
+            if ($mtime > $cutoff) {
+                continue;
+            }
+
+            $entries[] = [
+                'scope' => self::SCOPE_PDF_EXPIRED,
+                'path' => $relPath,
+                'bytes' => max(0, (int) ($file['bytes'] ?? 0)),
+                'mode' => 'local',
+            ];
+        }
+
+        return $entries;
+    }
+
+    /**
+     * @return list<array{scope:string,path:string,bytes:int,mode:string}>
+     */
+    private function collectExpiredReleaseEntries(): array
+    {
+        $keepDays = max(0, (int) config('storage_retention.releases.keep_days', 180));
+        $keepLastN = max(0, (int) config('storage_retention.releases.keep_last_n', 20));
+        $cutoff = now()->subDays($keepDays)->getTimestamp();
+
+        /** @var list<array{path:string,bytes:int,mtime:int,release_key:?string,parent_key:?string}> $records */
+        $records = [];
+        foreach (['releases', 'content_releases'] as $root) {
+            foreach ($this->scanLocalFiles($root) as $file) {
+                $path = (string) ($file['path'] ?? '');
+                if ($path === '' || str_ends_with($path, '/.gitkeep')) {
+                    continue;
+                }
+
+                $keys = $this->resolveReleaseKeys($path);
+
+                $records[] = [
+                    'path' => $path,
+                    'bytes' => max(0, (int) ($file['bytes'] ?? 0)),
+                    'mtime' => max(0, (int) ($file['mtime'] ?? 0)),
+                    'release_key' => $keys['release_key'],
+                    'parent_key' => $keys['parent_key'],
+                ];
+            }
+        }
+
+        /** @var array<string,int> $releaseLatest */
+        $releaseLatest = [];
+        /** @var array<string,string> $releaseParent */
+        $releaseParent = [];
+        foreach ($records as $record) {
+            $releaseKey = $record['release_key'];
+            $parentKey = $record['parent_key'];
+            if ($releaseKey === null) {
+                continue;
+            }
+
+            $releaseLatest[$releaseKey] = isset($releaseLatest[$releaseKey])
+                ? max($releaseLatest[$releaseKey], $record['mtime'])
+                : $record['mtime'];
+
+            $releaseParent[$releaseKey] = $parentKey ?? '_';
+        }
+
+        /** @var array<string,array<string,int>> $grouped */
+        $grouped = [];
+        foreach ($releaseLatest as $releaseKey => $mtime) {
+            $parent = $releaseParent[$releaseKey] ?? '_';
+            if (! isset($grouped[$parent])) {
+                $grouped[$parent] = [];
+            }
+            $grouped[$parent][$releaseKey] = $mtime;
+        }
+
+        /** @var array<string,bool> $protectedReleaseKeys */
+        $protectedReleaseKeys = [];
+        foreach ($grouped as $items) {
+            arsort($items, SORT_NUMERIC);
+            $index = 0;
+            foreach ($items as $releaseKey => $_mtime) {
+                if ($index < $keepLastN) {
+                    $protectedReleaseKeys[$releaseKey] = true;
+                }
+                $index++;
+            }
+        }
+
+        $entries = [];
+        foreach ($records as $record) {
+            if ($record['mtime'] > $cutoff) {
+                continue;
+            }
+
+            $releaseKey = $record['release_key'];
+            if ($releaseKey !== null && isset($protectedReleaseKeys[$releaseKey])) {
+                continue;
+            }
+
+            $entries[] = [
+                'scope' => self::SCOPE_RELEASES_EXPIRED,
+                'path' => $record['path'],
+                'bytes' => $record['bytes'],
+                'mode' => 'local',
+            ];
+        }
+
+        return $entries;
+    }
+
+    /**
+     * @return list<array{scope:string,path:string,bytes:int,mode:string}>
+     */
+    private function collectExpiredLogEntries(): array
+    {
+        $root = storage_path('logs');
         if (! is_dir($root)) {
             return [];
         }
 
-        $items = [];
+        $keepDays = max(0, (int) config('storage_retention.logs.keep_days', 30));
+        $cutoff = now()->subDays($keepDays)->getTimestamp();
+
+        $entries = [];
         $iterator = new \RecursiveIteratorIterator(
             new \RecursiveDirectoryIterator($root, \FilesystemIterator::SKIP_DOTS)
         );
@@ -206,25 +445,228 @@ final class StoragePrune extends Command
             }
 
             $fullPath = $file->getPathname();
-            $prefix = rtrim(storage_path('app/private'), DIRECTORY_SEPARATOR).DIRECTORY_SEPARATOR;
-            if (! str_starts_with($fullPath, $prefix)) {
+            if (str_ends_with($fullPath, DIRECTORY_SEPARATOR.'.gitkeep')) {
                 continue;
             }
 
-            $relPath = str_replace('\\', '/', substr($fullPath, strlen($prefix)));
-            if (! $this->isReportTimestampBackupPath($relPath)) {
+            $mtime = max(0, (int) ($file->getMTime() ?: 0));
+            if ($mtime > $cutoff) {
                 continue;
             }
 
-            $items[] = [
-                'path' => $relPath,
+            $entries[] = [
+                'scope' => self::SCOPE_LOGS_EXPIRED,
+                'path' => $fullPath,
                 'bytes' => max(0, (int) ($file->getSize() ?: 0)),
+                'mode' => 'absolute',
             ];
         }
 
-        usort($items, static fn (array $a, array $b): int => strcmp($a['path'], $b['path']));
+        return $entries;
+    }
 
-        return $items;
+    /**
+     * @return array{release_key:?string,parent_key:?string}
+     */
+    private function resolveReleaseKeys(string $path): array
+    {
+        if (preg_match('#^releases/([^/]+)/([^/]+)(?:/|$)#', $path, $m) === 1) {
+            return [
+                'release_key' => 'releases/'.$m[1].'/'.$m[2],
+                'parent_key' => 'releases/'.$m[1],
+            ];
+        }
+
+        if (preg_match('#^content_releases/backups/([^/]+)(?:/|$)#', $path, $m) === 1) {
+            return [
+                'release_key' => 'content_releases/backups/'.$m[1],
+                'parent_key' => 'content_releases/backups',
+            ];
+        }
+
+        if (preg_match('#^content_releases/([^/]+)/([^/]+)(?:/|$)#', $path, $m) === 1) {
+            return [
+                'release_key' => 'content_releases/'.$m[1].'/'.$m[2],
+                'parent_key' => 'content_releases/'.$m[1],
+            ];
+        }
+
+        return [
+            'release_key' => null,
+            'parent_key' => null,
+        ];
+    }
+
+    /**
+     * @return list<array{path:string,bytes:int,mtime:int}>
+     */
+    private function scanLocalFiles(string $relativeRoot): array
+    {
+        $relativeRoot = trim(str_replace('\\', '/', $relativeRoot), '/');
+        if ($relativeRoot === '') {
+            return [];
+        }
+
+        $root = storage_path('app/private/'.$relativeRoot);
+        if (! is_dir($root)) {
+            return [];
+        }
+
+        $entries = [];
+        $iterator = new \RecursiveIteratorIterator(
+            new \RecursiveDirectoryIterator($root, \FilesystemIterator::SKIP_DOTS)
+        );
+
+        $privateRoot = rtrim(storage_path('app/private'), DIRECTORY_SEPARATOR).DIRECTORY_SEPARATOR;
+
+        foreach ($iterator as $file) {
+            if (! $file instanceof \SplFileInfo || ! $file->isFile()) {
+                continue;
+            }
+
+            $fullPath = $file->getPathname();
+            if (! str_starts_with($fullPath, $privateRoot)) {
+                continue;
+            }
+
+            $relPath = str_replace('\\', '/', substr($fullPath, strlen($privateRoot)));
+            $entries[] = [
+                'path' => $relPath,
+                'bytes' => max(0, (int) ($file->getSize() ?: 0)),
+                'mtime' => max(0, (int) ($file->getMTime() ?: 0)),
+            ];
+        }
+
+        return $entries;
+    }
+
+    /**
+     * @param  array<string,mixed>  $decoded
+     * @return list<array{scope:string,path:string,bytes:int,mode:string}>
+     */
+    private function entriesFromPlan(array $decoded, string $planScope): array
+    {
+        $entries = [];
+
+        if (is_array($decoded['entries'] ?? null)) {
+            foreach ($decoded['entries'] as $entry) {
+                if (! is_array($entry)) {
+                    continue;
+                }
+
+                $scope = $this->normalizeScope((string) ($entry['scope'] ?? $planScope));
+                $path = trim((string) ($entry['path'] ?? ''));
+                $bytes = max(0, (int) ($entry['bytes'] ?? 0));
+                $mode = strtolower(trim((string) ($entry['mode'] ?? 'local')));
+                if ($path === '' || $mode === '') {
+                    continue;
+                }
+
+                $entries[] = [
+                    'scope' => $scope,
+                    'path' => $path,
+                    'bytes' => $bytes,
+                    'mode' => $mode,
+                ];
+            }
+
+            return $entries;
+        }
+
+        if (! is_array($decoded['files'] ?? null)) {
+            return [];
+        }
+
+        $fallbackScope = $this->isSupportedScope($planScope, true) ? $planScope : self::SCOPE_REPORTS_BACKUPS;
+        foreach ($decoded['files'] as $fileEntry) {
+            $path = trim((string) (is_array($fileEntry) ? ($fileEntry['path'] ?? '') : $fileEntry));
+            if ($path === '') {
+                continue;
+            }
+
+            $bytes = max(0, (int) (is_array($fileEntry) ? ($fileEntry['bytes'] ?? 0) : 0));
+            $entries[] = [
+                'scope' => $fallbackScope,
+                'path' => $path,
+                'bytes' => $bytes,
+                'mode' => 'local',
+            ];
+        }
+
+        return $entries;
+    }
+
+    /**
+     * @param  list<array{scope:string,path:string,bytes:int,mode:string}>  $entries
+     * @return array{
+     *     schema:string,
+     *     scope:string,
+     *     generated_at:string,
+     *     entries:list<array{scope:string,path:string,bytes:int,mode:string}>,
+     *     summary:array{files:int,bytes:int,scopes:array<string,array{files:int,bytes:int}>}
+     * }
+     */
+    private function buildPlan(string $scope, array $entries): array
+    {
+        /** @var array<string,array{files:int,bytes:int}> $summaryByScope */
+        $summaryByScope = [];
+        $totalBytes = 0;
+
+        foreach ($entries as $entry) {
+            $entryScope = (string) ($entry['scope'] ?? '');
+            $bytes = max(0, (int) ($entry['bytes'] ?? 0));
+
+            if (! isset($summaryByScope[$entryScope])) {
+                $summaryByScope[$entryScope] = [
+                    'files' => 0,
+                    'bytes' => 0,
+                ];
+            }
+
+            $summaryByScope[$entryScope]['files']++;
+            $summaryByScope[$entryScope]['bytes'] += $bytes;
+            $totalBytes += $bytes;
+        }
+
+        return [
+            'schema' => 'storage_prune_plan.v2',
+            'scope' => $scope,
+            'generated_at' => now()->toISOString(),
+            'entries' => $entries,
+            'summary' => [
+                'files' => count($entries),
+                'bytes' => $totalBytes,
+                'scopes' => $summaryByScope,
+            ],
+        ];
+    }
+
+    /**
+     * @param  array{
+     *     schema:string,
+     *     scope:string,
+     *     generated_at:string,
+     *     entries:list<array{scope:string,path:string,bytes:int,mode:string}>,
+     *     summary:array{files:int,bytes:int,scopes:array<string,array{files:int,bytes:int}>}
+     * }  $plan
+     */
+    private function writePlanFile(array $plan, string $scope): ?string
+    {
+        $planDir = storage_path('app/private/prune_plans');
+        File::ensureDirectoryExists($planDir);
+
+        $random = bin2hex(random_bytes(4));
+        $planName = now()->format('Ymd_His').'_'.$scope.'_'.substr($random, 0, 8).'.json';
+        $planPath = $planDir.DIRECTORY_SEPARATOR.$planName;
+
+        $encoded = json_encode($plan, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES | JSON_PRETTY_PRINT);
+        if (! is_string($encoded)) {
+            return null;
+        }
+
+        File::put($planPath, $encoded.PHP_EOL);
+
+        return $planPath;
     }
 
     private function resolvePlanPath(string $planOption): string
@@ -245,12 +687,101 @@ final class StoragePrune extends Command
     {
         return match ($scope) {
             self::SCOPE_REPORTS_BACKUPS => $this->isReportTimestampBackupPath($relPath),
+            self::SCOPE_PDF_EXPIRED => preg_match('#^artifacts/pdf/[^/]+/[^/]+/[^/]+/report_(free|full)\.pdf$#i', $relPath) === 1,
+            self::SCOPE_RELEASES_EXPIRED => (
+                str_starts_with($relPath, 'releases/')
+                || str_starts_with($relPath, 'content_releases/')
+            ) && ! str_ends_with($relPath, '/.gitkeep'),
             default => false,
         };
+    }
+
+    private function isPrunableAbsolutePathForScope(string $scope, string $path): bool
+    {
+        if ($scope !== self::SCOPE_LOGS_EXPIRED) {
+            return false;
+        }
+
+        $logsRoot = rtrim(storage_path('logs'), DIRECTORY_SEPARATOR).DIRECTORY_SEPARATOR;
+
+        return str_starts_with($path, $logsRoot)
+            && is_file($path)
+            && ! str_ends_with($path, DIRECTORY_SEPARATOR.'.gitkeep');
     }
 
     private function isReportTimestampBackupPath(string $relPath): bool
     {
         return preg_match('#^reports/[^/]+/report\.\d{8}_\d{6}\.json$#', $relPath) === 1;
+    }
+
+    private function normalizeScope(string $scope): string
+    {
+        $scope = strtolower(trim($scope));
+
+        return $scope !== '' ? $scope : self::SCOPE_ALL;
+    }
+
+    private function isSupportedScope(string $scope, bool $allowAll): bool
+    {
+        if ($allowAll && $scope === self::SCOPE_ALL) {
+            return true;
+        }
+
+        return in_array($scope, self::SUPPORTED_SCOPES, true);
+    }
+
+    private function writeAuditLog(string $scope, int $deletedFiles, int $deletedBytes, string $planPath): void
+    {
+        if (! Schema::hasTable('audit_logs')) {
+            return;
+        }
+
+        $meta = [
+            'scope' => $scope,
+            'deleted_files_count' => max(0, $deletedFiles),
+            'deleted_bytes' => max(0, $deletedBytes),
+            'plan_path' => $planPath,
+        ];
+
+        $metaJson = json_encode($meta, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES);
+        if (! is_string($metaJson)) {
+            $metaJson = '{}';
+        }
+
+        $row = [
+            'action' => 'storage_prune',
+            'target_type' => 'storage',
+            'target_id' => null,
+            'meta_json' => $metaJson,
+            'created_at' => now(),
+        ];
+
+        if (SchemaBaseline::hasColumn('audit_logs', 'org_id')) {
+            $row['org_id'] = 0;
+        }
+        if (SchemaBaseline::hasColumn('audit_logs', 'actor_admin_id')) {
+            $row['actor_admin_id'] = null;
+        }
+        if (SchemaBaseline::hasColumn('audit_logs', 'ip')) {
+            $row['ip'] = '127.0.0.1';
+        }
+        if (SchemaBaseline::hasColumn('audit_logs', 'user_agent')) {
+            $row['user_agent'] = 'artisan';
+        }
+        if (SchemaBaseline::hasColumn('audit_logs', 'request_id')) {
+            $row['request_id'] = 'storage:prune';
+        }
+        if (SchemaBaseline::hasColumn('audit_logs', 'reason')) {
+            $row['reason'] = 'storage_governance_prune';
+        }
+        if (SchemaBaseline::hasColumn('audit_logs', 'result')) {
+            $row['result'] = 'success';
+        }
+
+        try {
+            DB::table('audit_logs')->insert($row);
+        } catch (\Throwable) {
+            // keep prune flow non-blocking when audit table shape is unavailable in test/runtime.
+        }
     }
 }

--- a/backend/app/Console/Commands/StoragePrune.php
+++ b/backend/app/Console/Commands/StoragePrune.php
@@ -8,6 +8,7 @@ use App\Support\SchemaBaseline;
 use Illuminate\Console\Command;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\File;
+use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Facades\Schema;
 use Illuminate\Support\Facades\Storage;
 
@@ -780,8 +781,13 @@ final class StoragePrune extends Command
 
         try {
             DB::table('audit_logs')->insert($row);
-        } catch (\Throwable) {
-            // keep prune flow non-blocking when audit table shape is unavailable in test/runtime.
+        } catch (\Throwable $e) {
+            Log::warning('storage_prune_audit_log_insert_failed', [
+                'command' => 'storage:prune',
+                'scope' => $scope,
+                'plan_path' => $planPath,
+                'error' => $e->getMessage(),
+            ]);
         }
     }
 }

--- a/backend/app/Console/Kernel.php
+++ b/backend/app/Console/Kernel.php
@@ -31,6 +31,7 @@ use App\Console\Commands\OpsDeployEvent;
 use App\Console\Commands\OpsHealthzSnapshot;
 use App\Console\Commands\Packs2Activate;
 use App\Console\Commands\Packs2List;
+use App\Console\Commands\Packs2MigrateStoragePath;
 use App\Console\Commands\Packs2Publish;
 use App\Console\Commands\Packs2Rollback;
 use App\Console\Commands\PacksPublish;
@@ -39,6 +40,7 @@ use App\Console\Commands\PaymentsPruneEvents;
 use App\Console\Commands\QualityDailySummary;
 use App\Console\Commands\SdsPsychometricsReport;
 use App\Console\Commands\SeedScaleRegistry;
+use App\Console\Commands\StorageInventory;
 use App\Console\Commands\StorageMigrateLegacyArtifacts;
 use App\Console\Commands\StoragePrune;
 use App\Console\Commands\SyncScaleSlugs;
@@ -91,7 +93,9 @@ class Kernel extends ConsoleKernel
         Packs2Activate::class,
         Packs2Rollback::class,
         Packs2List::class,
+        Packs2MigrateStoragePath::class,
         StoragePrune::class,
+        StorageInventory::class,
         StorageMigrateLegacyArtifacts::class,
         QualityDailySummary::class,
         CiScaleImpact::class,
@@ -107,7 +111,9 @@ class Kernel extends ConsoleKernel
         // $schedule->command('fap:self-check')->dailyAt('03:10');
         // $schedule->command('fap:validate-report --attempt=...')->hourly();
         $schedule->command('payments:prune-events --days=90')->dailyAt('03:00')->withoutOverlapping();
+        $schedule->command('storage:prune --execute')->dailyAt('03:10')->withoutOverlapping();
         $schedule->command('quality:daily-summary')->dailyAt('03:20')->withoutOverlapping();
+        $schedule->command('storage:inventory --json')->weeklyOn(1, '04:10')->withoutOverlapping();
         $schedule->command('sds:psychometrics --window=last_7_days')->weeklyOn(1, '04:10')->withoutOverlapping();
         $schedule->command('norms:big5:roll --window_days=365')->monthlyOn(1, '04:30')->withoutOverlapping();
         $schedule->command('norms:big5:monthly-drift-check')->monthlyOn(1, '04:50')->withoutOverlapping();

--- a/backend/app/Services/Content/ContentPackV2Resolver.php
+++ b/backend/app/Services/Content/ContentPackV2Resolver.php
@@ -81,26 +81,80 @@ final class ContentPackV2Resolver
             return null;
         }
 
-        $normalized = str_replace('\\', '/', $storagePath);
-        if (str_starts_with($normalized, '/')) {
-            $root = rtrim($normalized, '/');
-        } else {
-            $relative = ltrim($normalized, '/');
-            if (str_starts_with($relative, 'app/')) {
-                $relative = substr($relative, 4);
+        $roots = [$this->resolveStorageRoot($storagePath)];
+        foreach ($this->legacyFallbackRoots($release, $storagePath) as $legacyRoot) {
+            $roots[] = $legacyRoot;
+        }
+
+        $roots = array_values(array_unique(array_filter($roots, static fn (string $root): bool => $root !== '')));
+        foreach ($roots as $root) {
+            $compiledDir = $root;
+            if (is_dir($root.'/compiled')) {
+                $compiledDir = $root.'/compiled';
             }
-            $root = rtrim(storage_path('app/'.$relative), '/');
+
+            if (is_file($compiledDir.'/manifest.json')) {
+                return $compiledDir;
+            }
         }
 
-        $compiledDir = $root;
-        if (is_dir($root.'/compiled')) {
-            $compiledDir = $root.'/compiled';
+        return null;
+    }
+
+    private function resolveStorageRoot(string $storagePath): string
+    {
+        $normalized = str_replace('\\', '/', trim($storagePath));
+        if ($normalized === '') {
+            return '';
         }
 
-        if (! is_file($compiledDir.'/manifest.json')) {
-            return null;
+        if (str_starts_with($normalized, '/')) {
+            return rtrim($normalized, '/');
         }
 
-        return $compiledDir;
+        $relative = ltrim($normalized, '/');
+        if (str_starts_with($relative, 'app/')) {
+            $relative = substr($relative, 4);
+        }
+
+        return rtrim(storage_path('app/'.$relative), '/');
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function legacyFallbackRoots(object $release, string $storagePath): array
+    {
+        $normalizedStoragePath = str_replace('\\', '/', trim($storagePath));
+        $isNewPath = str_contains($normalizedStoragePath, 'private/packs_v2/');
+        if (! $isNewPath) {
+            return [];
+        }
+
+        $packId = strtoupper(trim((string) ($release->to_pack_id ?? '')));
+        $packVersion = trim((string) ($release->pack_version ?? $release->dir_alias ?? ''));
+        if ($packId === '' || $packVersion === '') {
+            return [];
+        }
+
+        $releaseId = trim((string) ($release->id ?? ''));
+        $manifestHash = strtolower(trim((string) ($release->manifest_hash ?? '')));
+
+        $candidates = [];
+        if ($manifestHash !== '') {
+            $candidates[] = storage_path('app/content_packs_v2/'.$packId.'/'.$packVersion.'/'.$manifestHash);
+        }
+        if ($releaseId !== '') {
+            $candidates[] = storage_path('app/content_packs_v2/'.$packId.'/'.$packVersion.'/'.$releaseId);
+        }
+
+        if (preg_match('#private/packs_v2/[^/]+/[^/]+/([^/]+)$#', trim($normalizedStoragePath, '/'), $m) === 1) {
+            $storageLeaf = trim((string) ($m[1] ?? ''));
+            if ($storageLeaf !== '') {
+                $candidates[] = storage_path('app/content_packs_v2/'.$packId.'/'.$packVersion.'/'.$storageLeaf);
+            }
+        }
+
+        return array_values(array_unique($candidates));
     }
 }

--- a/backend/app/Services/Content/Publisher/ContentPackV2Publisher.php
+++ b/backend/app/Services/Content/Publisher/ContentPackV2Publisher.php
@@ -52,16 +52,16 @@ final class ContentPackV2Publisher
         $normsVersion = trim((string) ($manifest['norms_version'] ?? data_get($manifest, 'norms.norms_version', '')));
 
         $releaseId = (string) Str::uuid();
-        $storagePath = 'content_packs_v2/'.$packId.'/'.$packVersion.'/'.$releaseId;
+        $pathHash = $manifestHash !== '' ? $manifestHash : $releaseId;
+        $storagePath = 'private/packs_v2/'.$packId.'/'.$packVersion.'/'.$pathHash;
         $targetRoot = storage_path('app/'.$storagePath);
-        $targetCompiledDir = $targetRoot.'/compiled';
 
         if (File::isDirectory($targetRoot)) {
             File::deleteDirectory($targetRoot);
         }
 
-        File::ensureDirectoryExists(dirname($targetCompiledDir));
-        if (! File::copyDirectory($sourceCompiledDir, $targetCompiledDir)) {
+        File::ensureDirectoryExists(dirname($targetRoot));
+        if (! File::copyDirectory($sourceCompiledDir, $targetRoot)) {
             throw new RuntimeException('COPY_COMPILED_FAILED');
         }
 

--- a/backend/bootstrap/app.php
+++ b/backend/bootstrap/app.php
@@ -34,7 +34,9 @@ return Application::configure(basePath: dirname(__DIR__))
     ])
     ->withSchedule(function (Schedule $schedule): void {
         $schedule->command('payments:prune-events --days=90')->dailyAt('03:00')->withoutOverlapping();
+        $schedule->command('storage:prune --execute')->dailyAt('03:10')->withoutOverlapping();
         $schedule->command('quality:daily-summary')->dailyAt('03:20')->withoutOverlapping();
+        $schedule->command('storage:inventory --json')->weeklyOn(1, '04:10')->withoutOverlapping();
         $schedule->command('sds:psychometrics --window=last_7_days')->weeklyOn(1, '04:10')->withoutOverlapping();
         $schedule->command('norms:big5:roll --window_days=365')->monthlyOn(1, '04:30')->withoutOverlapping();
         $schedule->command('norms:big5:monthly-drift-check')->monthlyOn(1, '04:50')->withoutOverlapping();

--- a/backend/config/storage_retention.php
+++ b/backend/config/storage_retention.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+return [
+    'reports' => [
+        'keep_days' => (int) env('STORAGE_RETENTION_REPORTS_KEEP_DAYS', 365),
+        'keep_timestamp_backups' => (int) env('STORAGE_RETENTION_REPORTS_KEEP_TIMESTAMP_BACKUPS', 0),
+    ],
+
+    'pdf' => [
+        'keep_days_paid' => (int) env('STORAGE_RETENTION_PDF_KEEP_DAYS_PAID', 365),
+        'keep_days_free' => (int) env('STORAGE_RETENTION_PDF_KEEP_DAYS_FREE', 30),
+    ],
+
+    'releases' => [
+        'keep_last_n' => (int) env('STORAGE_RETENTION_RELEASES_KEEP_LAST_N', 20),
+        'keep_days' => (int) env('STORAGE_RETENTION_RELEASES_KEEP_DAYS', 180),
+    ],
+
+    'logs' => [
+        'keep_days' => (int) env('STORAGE_RETENTION_LOGS_KEEP_DAYS', 30),
+    ],
+
+    'compatibility' => [
+        'keep_legacy_paths_days' => (int) env('STORAGE_RETENTION_KEEP_LEGACY_PATHS_DAYS', 90),
+    ],
+];

--- a/backend/tests/Feature/Content/Packs2MigrateStoragePathCommandTest.php
+++ b/backend/tests/Feature/Content/Packs2MigrateStoragePathCommandTest.php
@@ -1,0 +1,143 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Content;
+
+use App\Services\Content\ContentPackV2Resolver;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\File;
+use Illuminate\Support\Str;
+use Tests\TestCase;
+
+final class Packs2MigrateStoragePathCommandTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private string $releaseId;
+
+    private string $manifestHash;
+
+    private string $oldStoragePath;
+
+    private string $newStoragePath;
+
+    private string $oldCompiledDir;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->releaseId = (string) Str::uuid();
+        $this->manifestHash = 'hash_'.substr(str_replace('-', '', (string) Str::uuid()), 0, 16);
+        $this->oldStoragePath = 'content_packs_v2/BIG5_OCEAN/v1/'.$this->releaseId;
+        $this->newStoragePath = 'private/packs_v2/BIG5_OCEAN/v1/'.$this->manifestHash;
+        $this->oldCompiledDir = storage_path('app/'.$this->oldStoragePath.'/compiled');
+
+        File::ensureDirectoryExists($this->oldCompiledDir);
+        File::put(
+            $this->oldCompiledDir.'/manifest.json',
+            json_encode([
+                'pack_id' => 'BIG5_OCEAN',
+                'version' => 'v1',
+                'compiled_hash' => $this->manifestHash,
+            ], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES)
+        );
+        File::put(
+            $this->oldCompiledDir.'/questions.compiled.json',
+            json_encode([
+                'question_index' => [],
+            ], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES)
+        );
+
+        DB::table('content_pack_releases')->insert([
+            'id' => $this->releaseId,
+            'action' => 'packs2_publish',
+            'region' => 'GLOBAL',
+            'locale' => 'global',
+            'dir_alias' => 'v1',
+            'from_version_id' => null,
+            'to_version_id' => null,
+            'from_pack_id' => null,
+            'to_pack_id' => 'BIG5_OCEAN',
+            'status' => 'success',
+            'message' => 'seed release',
+            'created_by' => 'test',
+            'manifest_hash' => $this->manifestHash,
+            'compiled_hash' => $this->manifestHash,
+            'content_hash' => $this->manifestHash,
+            'norms_version' => 'v1',
+            'git_sha' => null,
+            'pack_version' => 'v1',
+            'manifest_json' => json_encode(['compiled_hash' => $this->manifestHash], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES),
+            'storage_path' => $this->oldStoragePath,
+            'source_commit' => null,
+            'created_at' => now(),
+            'updated_at' => now(),
+        ]);
+    }
+
+    protected function tearDown(): void
+    {
+        $dirs = [
+            storage_path('app/'.$this->oldStoragePath),
+            storage_path('app/'.$this->newStoragePath),
+        ];
+
+        foreach ($dirs as $dir) {
+            if (is_dir($dir)) {
+                File::deleteDirectory($dir);
+            }
+        }
+
+        parent::tearDown();
+    }
+
+    public function test_migrate_storage_path_updates_release_and_resolver_reads_with_legacy_fallback(): void
+    {
+        $this->artisan('packs2:migrate-storage-path --dry-run')
+            ->assertExitCode(0);
+
+        $this->assertSame(
+            $this->oldStoragePath,
+            (string) DB::table('content_pack_releases')->where('id', $this->releaseId)->value('storage_path')
+        );
+
+        $this->artisan('packs2:migrate-storage-path --execute')
+            ->assertExitCode(0);
+
+        $this->assertSame(
+            $this->newStoragePath,
+            (string) DB::table('content_pack_releases')->where('id', $this->releaseId)->value('storage_path')
+        );
+        $this->assertFileExists(storage_path('app/'.$this->newStoragePath.'/compiled/manifest.json'));
+
+        $auditCount = DB::table('audit_logs')
+            ->where('action', 'packs2_storage_path_migrate')
+            ->where('target_id', $this->releaseId)
+            ->count();
+        $this->assertGreaterThanOrEqual(1, $auditCount);
+
+        DB::table('content_pack_activations')->insert([
+            'pack_id' => 'BIG5_OCEAN',
+            'pack_version' => 'v1',
+            'release_id' => $this->releaseId,
+            'activated_at' => now(),
+            'created_at' => now(),
+            'updated_at' => now(),
+        ]);
+
+        /** @var ContentPackV2Resolver $resolver */
+        $resolver = app(ContentPackV2Resolver::class);
+        $compiledPath = $resolver->resolveActiveCompiledPath('BIG5_OCEAN', 'v1');
+        $this->assertSame(storage_path('app/'.$this->newStoragePath.'/compiled'), $compiledPath);
+        $this->assertFileExists((string) $compiledPath.'/manifest.json');
+
+        File::deleteDirectory(storage_path('app/'.$this->newStoragePath));
+
+        $fallbackPath = $resolver->resolveActiveCompiledPath('BIG5_OCEAN', 'v1');
+        $this->assertSame($this->oldCompiledDir, $fallbackPath);
+        $this->assertFileExists((string) $fallbackPath.'/manifest.json');
+    }
+}

--- a/backend/tests/Feature/Storage/StorageInventoryCommandTest.php
+++ b/backend/tests/Feature/Storage/StorageInventoryCommandTest.php
@@ -1,0 +1,131 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Storage;
+
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Artisan;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\File;
+use Illuminate\Support\Str;
+use Tests\TestCase;
+
+final class StorageInventoryCommandTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private string $marker;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->marker = str_replace('-', '', strtolower((string) Str::uuid()));
+
+        $reportPath = storage_path('app/private/artifacts/reports/INVENTORY_TEST/'.$this->marker.'/report.json');
+        File::ensureDirectoryExists(dirname($reportPath));
+        File::put($reportPath, json_encode(['ok' => true], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES));
+
+        $packManifestPath = storage_path('app/private/packs_v2/INVENTORY_TEST/v1/'.$this->marker.'/manifest.json');
+        File::ensureDirectoryExists(dirname($packManifestPath));
+        File::put($packManifestPath, json_encode(['compiled_hash' => $this->marker], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES));
+
+        $logPath = storage_path('logs/'.$this->marker.'.log');
+        File::ensureDirectoryExists(dirname($logPath));
+        File::put($logPath, 'inventory test');
+    }
+
+    protected function tearDown(): void
+    {
+        $paths = [
+            storage_path('app/private/artifacts/reports/INVENTORY_TEST/'.$this->marker),
+            storage_path('app/private/packs_v2/INVENTORY_TEST/v1/'.$this->marker),
+        ];
+
+        foreach ($paths as $path) {
+            if (is_dir($path)) {
+                File::deleteDirectory($path);
+            }
+        }
+
+        $logPath = storage_path('logs/'.$this->marker.'.log');
+        if (is_file($logPath)) {
+            @unlink($logPath);
+        }
+
+        parent::tearDown();
+    }
+
+    public function test_inventory_outputs_complete_non_negative_stats_and_writes_audit(): void
+    {
+        $exitCode = Artisan::call('storage:inventory', ['--json' => 1]);
+        $this->assertSame(0, $exitCode);
+
+        $payload = $this->decodeLastJsonLine(Artisan::output());
+        $this->assertIsArray($payload);
+        $this->assertSame('storage_inventory_snapshot.v1', (string) ($payload['schema'] ?? ''));
+
+        $scopes = is_array($payload['scopes'] ?? null) ? $payload['scopes'] : [];
+        $requiredScopes = ['artifacts', 'reports', 'packs_v2', 'releases', 'content_releases', 'prune_plans', 'logs'];
+
+        foreach ($requiredScopes as $scope) {
+            $this->assertArrayHasKey($scope, $scopes);
+            $stats = is_array($scopes[$scope] ?? null) ? $scopes[$scope] : [];
+
+            $this->assertArrayHasKey('files_count', $stats);
+            $this->assertArrayHasKey('bytes_total', $stats);
+            $this->assertArrayHasKey('oldest_mtime', $stats);
+            $this->assertArrayHasKey('newest_mtime', $stats);
+            $this->assertArrayHasKey('top_children', $stats);
+
+            $this->assertGreaterThanOrEqual(0, (int) ($stats['files_count'] ?? -1));
+            $this->assertGreaterThanOrEqual(0, (int) ($stats['bytes_total'] ?? -1));
+
+            $topChildren = is_array($stats['top_children'] ?? null) ? $stats['top_children'] : [];
+            foreach ($topChildren as $child) {
+                $this->assertIsArray($child);
+                $this->assertArrayHasKey('name', $child);
+                $this->assertArrayHasKey('files_count', $child);
+                $this->assertArrayHasKey('bytes_total', $child);
+                $this->assertGreaterThanOrEqual(0, (int) ($child['files_count'] ?? -1));
+                $this->assertGreaterThanOrEqual(0, (int) ($child['bytes_total'] ?? -1));
+            }
+        }
+
+        $audit = DB::table('audit_logs')
+            ->where('action', 'storage_inventory_snapshot')
+            ->orderByDesc('id')
+            ->first();
+
+        $this->assertNotNull($audit);
+        $meta = json_decode((string) ($audit->meta_json ?? '{}'), true);
+        $this->assertIsArray($meta);
+        $this->assertSame('storage_inventory_snapshot.v1', (string) ($meta['schema'] ?? ''));
+    }
+
+    /**
+     * @return array<string,mixed>|null
+     */
+    private function decodeLastJsonLine(string $output): ?array
+    {
+        $lines = preg_split('/\R/', trim($output));
+        if (! is_array($lines)) {
+            return null;
+        }
+
+        for ($i = count($lines) - 1; $i >= 0; $i--) {
+            $line = trim((string) ($lines[$i] ?? ''));
+            if ($line === '') {
+                continue;
+            }
+
+            $decoded = json_decode($line, true);
+            if (is_array($decoded)) {
+                return $decoded;
+            }
+        }
+
+        return null;
+    }
+}

--- a/backend/tests/Feature/Storage/StoragePrunePlanWorkflowTest.php
+++ b/backend/tests/Feature/Storage/StoragePrunePlanWorkflowTest.php
@@ -1,0 +1,105 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Storage;
+
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\File;
+use Illuminate\Support\Str;
+use Tests\TestCase;
+
+final class StoragePrunePlanWorkflowTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private string $attemptId;
+
+    private string $attemptDir;
+
+    private string $planPath;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->attemptId = (string) Str::uuid();
+        $this->attemptDir = storage_path('app/private/reports/'.$this->attemptId);
+        $this->planPath = storage_path('app/private/prune_plans/storage_prune_plan_workflow_'.$this->attemptId.'.json');
+
+        File::ensureDirectoryExists($this->attemptDir);
+        File::ensureDirectoryExists(dirname($this->planPath));
+
+        File::put($this->attemptDir.'/report.json', json_encode(['ok' => true], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES));
+        File::put($this->attemptDir.'/report.20260101_010101.json', json_encode(['stale' => true], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES));
+        File::put($this->attemptDir.'/report.20260101_010102.json', json_encode(['stale' => true], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES));
+
+        $plan = [
+            'schema' => 'storage_prune_plan.v2',
+            'scope' => 'reports_backups',
+            'generated_at' => now()->toISOString(),
+            'entries' => [
+                [
+                    'scope' => 'reports_backups',
+                    'path' => 'reports/'.$this->attemptId.'/report.20260101_010101.json',
+                    'bytes' => 0,
+                    'mode' => 'local',
+                ],
+            ],
+            'summary' => [
+                'files' => 1,
+                'bytes' => 0,
+                'scopes' => [
+                    'reports_backups' => [
+                        'files' => 1,
+                        'bytes' => 0,
+                    ],
+                ],
+            ],
+        ];
+
+        File::put(
+            $this->planPath,
+            (string) json_encode($plan, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES | JSON_PRETTY_PRINT)
+        );
+    }
+
+    protected function tearDown(): void
+    {
+        if (is_dir($this->attemptDir)) {
+            File::deleteDirectory($this->attemptDir);
+        }
+
+        if (is_file($this->planPath)) {
+            @unlink($this->planPath);
+        }
+
+        parent::tearDown();
+    }
+
+    public function test_execute_consumes_plan_only_without_rescanning_scope(): void
+    {
+        $this->assertFileExists($this->attemptDir.'/report.json');
+        $this->assertFileExists($this->attemptDir.'/report.20260101_010101.json');
+        $this->assertFileExists($this->attemptDir.'/report.20260101_010102.json');
+
+        $this->artisan('storage:prune --execute --scope=reports_backups --plan='.$this->planPath)
+            ->assertExitCode(0);
+
+        $this->assertFileExists($this->attemptDir.'/report.json');
+        $this->assertFileDoesNotExist($this->attemptDir.'/report.20260101_010101.json');
+        $this->assertFileExists($this->attemptDir.'/report.20260101_010102.json');
+
+        $audit = DB::table('audit_logs')
+            ->where('action', 'storage_prune')
+            ->orderByDesc('id')
+            ->first();
+
+        $this->assertNotNull($audit);
+        $meta = json_decode((string) ($audit->meta_json ?? '{}'), true);
+        $this->assertIsArray($meta);
+        $this->assertSame('reports_backups', (string) ($meta['scope'] ?? ''));
+        $this->assertSame(1, (int) ($meta['deleted_files_count'] ?? -1));
+    }
+}


### PR DESCRIPTION
## Summary
- Add retention lifecycle config (`storage_retention`) and inventory command (`storage:inventory`).
- Extend prune scopes (`reports_backups`, `pdf_expired`, `releases_expired`, `logs_expired`) with plan-driven execution and audit.
- Add scheduler entries for daily prune and weekly inventory snapshot.
- Migrate packs2 storage path to `private/packs_v2/...` and add migration command (`packs2:migrate-storage-path`) plus resolver compatibility fallback.

## Scope
- Long-term storage governance + packs2 path migration, no route contract change.

## Verification
- `php artisan route:list`
- `php artisan migrate`
- `php artisan storage:inventory --json`
- `php artisan storage:prune --dry-run`
- `php artisan storage:prune --execute --plan=<latest_plan>`
- `php artisan packs2:migrate-storage-path --dry-run`
- `php artisan packs2:migrate-storage-path --execute`
- `php artisan test --filter=StorageInventoryCommandTest`
- `php artisan test --filter=StoragePrunePlanWorkflowTest`
- `php artisan test --filter=Packs2MigrateStoragePathCommandTest`
- `bash /Users/rainie/Desktop/GitHub/fap-api/backend/scripts/ci_verify_mbti.sh`

## Risk & Rollback
- Medium risk: packs2 storage path transition handled by compatibility fallback.
- Rollback: revert publisher/resolver path strategy and disable migration command execution.
EOF