### PR TITLE
feat(storage): three-phase storage governance rollout

### DIFF
--- a/backend/app/Console/Commands/StorageInventory.php
+++ b/backend/app/Console/Commands/StorageInventory.php
@@ -1,0 +1,150 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Console\Commands;
+
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+final class StorageInventory extends Command
+{
+    protected $signature = 'storage:inventory {--json : JSON output}';
+
+    protected $description = 'Inventory storage usage by scope (files/bytes/mtime/top dirs).';
+
+    public function handle(): int
+    {
+        $rows = [
+            $this->collectScope('reports', storage_path('app/private/reports')),
+            $this->collectScope('artifacts', storage_path('app/private/artifacts')),
+            $this->collectScope('content_releases', storage_path('app/private/content_releases')),
+            $this->collectScope('packs_v2', storage_path('app/private/packs_v2')),
+            $this->collectScope('content_packs_v2', storage_path('app/content_packs_v2')),
+            $this->collectScope('logs', storage_path('logs')),
+        ];
+
+        if ((bool) $this->option('json')) {
+            $this->line((string) json_encode($rows, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES));
+        } else {
+            $display = array_map(static function (array $row): array {
+                return [
+                    'scope' => (string) $row['scope'],
+                    'files' => (int) $row['files'],
+                    'bytes' => (int) $row['bytes'],
+                    'oldest_mtime' => (string) $row['oldest_mtime'],
+                    'newest_mtime' => (string) $row['newest_mtime'],
+                    'top_dirs' => (string) json_encode($row['top_dirs'], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES),
+                ];
+            }, $rows);
+
+            $this->table(['scope', 'files', 'bytes', 'oldest_mtime', 'newest_mtime', 'top_dirs'], $display);
+        }
+
+        $this->recordAudit($rows);
+
+        return self::SUCCESS;
+    }
+
+    /**
+     * @return array{
+     *   scope:string,
+     *   files:int,
+     *   bytes:int,
+     *   oldest_mtime:?string,
+     *   newest_mtime:?string,
+     *   top_dirs:array<string,int>
+     * }
+     */
+    private function collectScope(string $scope, string $root): array
+    {
+        if (! is_dir($root)) {
+            return [
+                'scope' => $scope,
+                'files' => 0,
+                'bytes' => 0,
+                'oldest_mtime' => null,
+                'newest_mtime' => null,
+                'top_dirs' => [],
+            ];
+        }
+
+        $files = 0;
+        $bytes = 0;
+        $oldest = null;
+        $newest = null;
+        $topDirs = [];
+
+        $iterator = new \RecursiveIteratorIterator(
+            new \RecursiveDirectoryIterator($root, \FilesystemIterator::SKIP_DOTS)
+        );
+
+        foreach ($iterator as $file) {
+            if (! $file instanceof \SplFileInfo || ! $file->isFile()) {
+                continue;
+            }
+
+            $files++;
+            $size = max(0, (int) ($file->getSize() ?: 0));
+            $bytes += $size;
+
+            $mtime = (int) ($file->getMTime() ?: 0);
+            if ($oldest === null || $mtime < $oldest) {
+                $oldest = $mtime;
+            }
+            if ($newest === null || $mtime > $newest) {
+                $newest = $mtime;
+            }
+
+            $fullPath = str_replace('\\', '/', $file->getPathname());
+            $rootNorm = rtrim(str_replace('\\', '/', $root), '/').'/';
+            $relative = str_starts_with($fullPath, $rootNorm)
+                ? substr($fullPath, strlen($rootNorm))
+                : basename($fullPath);
+            $relative = ltrim((string) $relative, '/');
+            $first = explode('/', $relative)[0] ?? '.';
+            $first = trim((string) $first) !== '' ? (string) $first : '.';
+            $topDirs[$first] = (int) (($topDirs[$first] ?? 0) + 1);
+        }
+
+        arsort($topDirs);
+        $topDirs = array_slice($topDirs, 0, 5, true);
+
+        return [
+            'scope' => $scope,
+            'files' => $files,
+            'bytes' => $bytes,
+            'oldest_mtime' => $oldest !== null ? date(DATE_ATOM, $oldest) : null,
+            'newest_mtime' => $newest !== null ? date(DATE_ATOM, $newest) : null,
+            'top_dirs' => $topDirs,
+        ];
+    }
+
+    /**
+     * @param  list<array<string,mixed>>  $rows
+     */
+    private function recordAudit(array $rows): void
+    {
+        if (! Schema::hasTable('audit_logs')) {
+            return;
+        }
+
+        DB::table('audit_logs')->insert([
+            'org_id' => 0,
+            'actor_admin_id' => null,
+            'action' => 'storage_inventory',
+            'target_type' => 'storage',
+            'target_id' => 'inventory',
+            'meta_json' => json_encode([
+                'scopes' => $rows,
+            ], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES),
+            'ip' => null,
+            'user_agent' => 'cli/storage_inventory',
+            'request_id' => null,
+            'reason' => 'scheduled_or_manual',
+            'result' => 'success',
+            'created_at' => now(),
+        ]);
+    }
+}

--- a/backend/app/Console/Commands/StorageMigrateLegacyArtifacts.php
+++ b/backend/app/Console/Commands/StorageMigrateLegacyArtifacts.php
@@ -1,0 +1,336 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Console\Commands;
+
+use App\Services\Storage\ArtifactStore;
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\File;
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Support\Facades\Storage;
+
+final class StorageMigrateLegacyArtifacts extends Command
+{
+    protected $signature = 'storage:migrate-legacy-artifacts
+    {--dry-run : Plan only}
+    {--execute : Execute copy plan}
+    {--plan= : Existing plan path for execute mode}
+    {--limit=0 : Max files to process}';
+
+    protected $description = 'Migrate legacy report/pdf artifacts to canonical artifacts path (copy-only).';
+
+    public function __construct(
+        private readonly ArtifactStore $artifactStore,
+    ) {
+        parent::__construct();
+    }
+
+    public function handle(): int
+    {
+        $dryRun = (bool) $this->option('dry-run');
+        $execute = (bool) $this->option('execute');
+        $limit = max(0, (int) $this->option('limit'));
+
+        if (($dryRun && $execute) || (! $dryRun && ! $execute)) {
+            $this->error('exactly one of --dry-run or --execute is required.');
+
+            return self::FAILURE;
+        }
+
+        if ($dryRun) {
+            return $this->dryRun($limit);
+        }
+
+        return $this->executePlan();
+    }
+
+    private function dryRun(int $limit): int
+    {
+        $entries = $this->collectEntries($limit);
+        $totalBytes = 0;
+        $files = [];
+
+        foreach ($entries as $entry) {
+            $bytes = max(0, (int) ($entry['bytes'] ?? 0));
+            $files[] = [
+                'source' => (string) ($entry['source'] ?? ''),
+                'target' => (string) ($entry['target'] ?? ''),
+                'scope' => (string) ($entry['scope'] ?? ''),
+                'bytes' => $bytes,
+            ];
+            $totalBytes += $bytes;
+        }
+
+        $plan = [
+            'schema' => 'storage_migrate_legacy_artifacts.v1',
+            'generated_at' => now()->toISOString(),
+            'files' => $files,
+            'summary' => [
+                'files' => count($files),
+                'bytes' => $totalBytes,
+            ],
+        ];
+
+        $planDir = storage_path('app/private/migration_plans');
+        File::ensureDirectoryExists($planDir);
+        $planPath = $planDir.DIRECTORY_SEPARATOR.now()->format('Ymd_His').'_storage_migrate_legacy_artifacts_'
+            .substr(bin2hex(random_bytes(4)), 0, 8).'.json';
+        $encoded = json_encode($plan, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES | JSON_PRETTY_PRINT);
+        if (! is_string($encoded)) {
+            $this->error('failed to encode migration plan json.');
+
+            return self::FAILURE;
+        }
+
+        File::put($planPath, $encoded.PHP_EOL);
+
+        $this->line('status=planned');
+        $this->line('plan='.$planPath);
+        $this->line('files='.count($files));
+        $this->line('bytes='.$totalBytes);
+
+        return self::SUCCESS;
+    }
+
+    private function executePlan(): int
+    {
+        $planOption = trim((string) $this->option('plan'));
+        if ($planOption === '') {
+            $this->error('--plan is required in --execute mode.');
+
+            return self::FAILURE;
+        }
+
+        $planPath = $this->resolvePlanPath($planOption);
+        if (! is_file($planPath)) {
+            $this->error('plan not found: '.$planPath);
+
+            return self::FAILURE;
+        }
+
+        $decoded = json_decode((string) File::get($planPath), true);
+        if (! is_array($decoded)) {
+            $this->error('invalid plan json: '.$planPath);
+
+            return self::FAILURE;
+        }
+
+        if ((string) ($decoded['schema'] ?? '') !== 'storage_migrate_legacy_artifacts.v1') {
+            $this->error('plan schema mismatch.');
+
+            return self::FAILURE;
+        }
+
+        $files = is_array($decoded['files'] ?? null) ? $decoded['files'] : [];
+        $disk = Storage::disk('local');
+
+        $copiedFiles = 0;
+        $copiedBytes = 0;
+        $missingFiles = 0;
+        $skippedFiles = 0;
+        $failedFiles = 0;
+
+        foreach ($files as $entry) {
+            $source = trim((string) (is_array($entry) ? ($entry['source'] ?? '') : ''));
+            $target = trim((string) (is_array($entry) ? ($entry['target'] ?? '') : ''));
+
+            if ($source === '' || $target === '') {
+                $skippedFiles++;
+                continue;
+            }
+
+            if (! $disk->exists($source)) {
+                $missingFiles++;
+                continue;
+            }
+
+            if ($disk->exists($target)) {
+                $skippedFiles++;
+                continue;
+            }
+
+            $content = $disk->get($source);
+            if (! is_string($content) || $content === '') {
+                $failedFiles++;
+                continue;
+            }
+
+            if (! $disk->put($target, $content)) {
+                $failedFiles++;
+                continue;
+            }
+
+            $sha256 = hash('sha256', $content);
+            $bytes = strlen($content);
+            $copiedFiles++;
+            $copiedBytes += $bytes;
+
+            $this->recordAudit($source, $target, $sha256, $bytes);
+        }
+
+        $this->line('status=executed');
+        $this->line('plan='.$planPath);
+        $this->line('copied_files='.$copiedFiles);
+        $this->line('copied_bytes='.$copiedBytes);
+        $this->line('missing_files='.$missingFiles);
+        $this->line('skipped_files='.$skippedFiles);
+        $this->line('failed_files='.$failedFiles);
+
+        return $failedFiles > 0 ? self::FAILURE : self::SUCCESS;
+    }
+
+    /**
+     * @return list<array{source:string,target:string,scope:string,bytes:int}>
+     */
+    private function collectEntries(int $limit): array
+    {
+        $disk = Storage::disk('local');
+        $entries = [];
+
+        foreach ($disk->allFiles('reports') as $relPath) {
+            if (preg_match('#^reports/([^/]+)/report\.json$#', $relPath, $matches) !== 1) {
+                continue;
+            }
+
+            $attemptId = (string) $matches[1];
+            $target = $this->artifactStore->reportCanonicalPath('MBTI', $attemptId);
+            if ($target === $relPath || $disk->exists($target)) {
+                continue;
+            }
+
+            $entries[$relPath] = [
+                'source' => $relPath,
+                'target' => $target,
+                'scope' => 'report',
+                'bytes' => $this->fileSizeFromRelativePath($relPath),
+            ];
+        }
+
+        foreach (['private/reports', 'reports'] as $prefix) {
+            foreach ($disk->allFiles($prefix) as $relPath) {
+                $parsed = $this->parseLegacyPdfPath($relPath);
+                if ($parsed === null) {
+                    continue;
+                }
+
+                $target = $this->artifactStore->pdfCanonicalPath(
+                    (string) $parsed['scale'],
+                    (string) $parsed['attempt'],
+                    (string) $parsed['manifest_hash'],
+                    (string) $parsed['variant']
+                );
+
+                if ($target === $relPath || $disk->exists($target)) {
+                    continue;
+                }
+
+                $entries[$relPath] = [
+                    'source' => $relPath,
+                    'target' => $target,
+                    'scope' => 'pdf',
+                    'bytes' => $this->fileSizeFromRelativePath($relPath),
+                ];
+            }
+        }
+
+        ksort($entries);
+        $items = array_values($entries);
+
+        if ($limit > 0) {
+            $items = array_slice($items, 0, $limit);
+        }
+
+        return $items;
+    }
+
+    /**
+     * @return array{scale:string,attempt:string,manifest_hash:string,variant:string}|null
+     */
+    private function parseLegacyPdfPath(string $relPath): ?array
+    {
+        if (preg_match('#^(?:private/)?reports/([^/]+)/([^/]+)/([^/]+)/report_(free|full)\.pdf$#i', $relPath, $m) === 1) {
+            return [
+                'scale' => (string) $m[1],
+                'attempt' => (string) $m[2],
+                'manifest_hash' => (string) $m[3],
+                'variant' => strtolower((string) $m[4]),
+            ];
+        }
+
+        if (preg_match('#^(?:private/)?reports/([^/]+)/([^/]+)/report_(free|full)\.pdf$#i', $relPath, $m) === 1) {
+            return [
+                'scale' => (string) $m[1],
+                'attempt' => (string) $m[2],
+                'manifest_hash' => 'nohash',
+                'variant' => strtolower((string) $m[3]),
+            ];
+        }
+
+        return null;
+    }
+
+    private function resolvePlanPath(string $planOption): string
+    {
+        if (str_starts_with($planOption, DIRECTORY_SEPARATOR)) {
+            return $planOption;
+        }
+
+        $basePathCandidate = base_path($planOption);
+        if (is_file($basePathCandidate)) {
+            return $basePathCandidate;
+        }
+
+        return storage_path('app/private/'.ltrim($planOption, '/\\'));
+    }
+
+    private function fileSizeFromRelativePath(string $relPath): int
+    {
+        $abs = storage_path('app/private/'.$relPath);
+
+        return is_file($abs) ? max(0, (int) (filesize($abs) ?: 0)) : 0;
+    }
+
+    private function recordAudit(string $source, string $target, string $sha256, int $bytes): void
+    {
+        if (! Schema::hasTable('audit_logs')) {
+            return;
+        }
+
+        $attemptId = $this->extractAttemptId($target);
+
+        DB::table('audit_logs')->insert([
+            'org_id' => 0,
+            'actor_admin_id' => null,
+            'action' => 'storage_migrate_legacy_artifacts',
+            'target_type' => 'attempt',
+            'target_id' => $attemptId,
+            'meta_json' => json_encode([
+                'source' => $source,
+                'target' => $target,
+                'sha256' => $sha256,
+                'bytes' => $bytes,
+            ], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES),
+            'ip' => null,
+            'user_agent' => 'cli/storage_migrate_legacy_artifacts',
+            'request_id' => null,
+            'reason' => 'legacy_artifact_copy',
+            'result' => 'success',
+            'created_at' => now(),
+        ]);
+    }
+
+    private function extractAttemptId(string $target): string
+    {
+        if (preg_match('#^artifacts/reports/[^/]+/([^/]+)/report\.json$#', $target, $m) === 1) {
+            return (string) $m[1];
+        }
+
+        if (preg_match('#^artifacts/pdf/[^/]+/([^/]+)/#', $target, $m) === 1) {
+            return (string) $m[1];
+        }
+
+        return $target;
+    }
+}

--- a/backend/app/Console/Commands/StoragePrune.php
+++ b/backend/app/Console/Commands/StoragePrune.php
@@ -4,32 +4,59 @@ declare(strict_types=1);
 
 namespace App\Console\Commands;
 
+use App\Services\Storage\ArtifactStore;
 use Illuminate\Console\Command;
+use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\File;
+use Illuminate\Support\Facades\Schema;
 use Illuminate\Support\Facades\Storage;
 
 final class StoragePrune extends Command
 {
     private const SCOPE_REPORTS_BACKUPS = 'reports_backups';
+    private const SCOPE_CONTENT_RELEASES = 'content_releases_retention';
+    private const SCOPE_LEGACY_PRIVATE_PRIVATE = 'legacy_private_private_cleanup';
+
+    private const STRATEGY_STRICT = 'strict';
+    private const STRATEGY_BROAD = 'broad';
 
     /** @var list<string> */
     private const SUPPORTED_SCOPES = [
         self::SCOPE_REPORTS_BACKUPS,
+        self::SCOPE_CONTENT_RELEASES,
+        self::SCOPE_LEGACY_PRIVATE_PRIVATE,
+    ];
+
+    /** @var list<string> */
+    private const SUPPORTED_STRATEGIES = [
+        self::STRATEGY_STRICT,
+        self::STRATEGY_BROAD,
     ];
 
     protected $signature = 'storage:prune
         {--dry-run : Generate prune plan only}
         {--execute : Execute prune plan}
         {--scope=reports_backups : Prune scope}
+        {--strategy=strict : reports_backups strategy(strict|broad)}
         {--plan= : Plan json path for execute mode}';
 
     protected $description = 'Generate/execute storage prune plans.';
+
+    public function __construct(
+        private readonly ArtifactStore $artifactStore,
+    ) {
+        parent::__construct();
+    }
 
     public function handle(): int
     {
         $dryRun = (bool) $this->option('dry-run');
         $execute = (bool) $this->option('execute');
         $scope = strtolower(trim((string) $this->option('scope')));
+        $strategy = strtolower(trim((string) $this->option('strategy')));
+        if ($strategy === '') {
+            $strategy = self::STRATEGY_STRICT;
+        }
 
         if (! in_array($scope, self::SUPPORTED_SCOPES, true)) {
             $this->error('unsupported --scope: '.$scope);
@@ -43,17 +70,31 @@ final class StoragePrune extends Command
             return self::FAILURE;
         }
 
-        if ($dryRun) {
-            return $this->dryRun($scope);
+        if ($scope === self::SCOPE_REPORTS_BACKUPS && ! in_array($strategy, self::SUPPORTED_STRATEGIES, true)) {
+            $this->error('unsupported --strategy for reports_backups: '.$strategy);
+
+            return self::FAILURE;
         }
 
-        return $this->executePlan($scope);
+        if ($scope === self::SCOPE_REPORTS_BACKUPS && $strategy === self::STRATEGY_BROAD && $execute) {
+            $this->error('reports_backups strategy=broad is dry-run only in phased rollout.');
+
+            return self::FAILURE;
+        }
+
+        if ($dryRun) {
+            return $this->dryRun($scope, $strategy);
+        }
+
+        return $this->executePlan($scope, $strategy);
     }
 
-    private function dryRun(string $scope): int
+    private function dryRun(string $scope, string $strategy): int
     {
         $entries = match ($scope) {
-            self::SCOPE_REPORTS_BACKUPS => $this->collectReportBackupEntries(),
+            self::SCOPE_REPORTS_BACKUPS => $this->collectReportBackupEntries($strategy),
+            self::SCOPE_CONTENT_RELEASES => $this->collectContentReleasesRetentionEntries(),
+            self::SCOPE_LEGACY_PRIVATE_PRIVATE => $this->collectLegacyPrivatePrivateEntries(),
             default => [],
         };
 
@@ -66,16 +107,24 @@ final class StoragePrune extends Command
             }
 
             $bytes = max(0, (int) ($entry['bytes'] ?? 0));
-            $paths[] = [
+            $item = [
                 'path' => $path,
                 'bytes' => $bytes,
             ];
+
+            $canonical = trim((string) ($entry['canonical'] ?? ''));
+            if ($canonical !== '') {
+                $item['canonical'] = $canonical;
+            }
+
+            $paths[] = $item;
             $totalBytes += $bytes;
         }
 
         $plan = [
-            'schema' => 'storage_prune_plan.v1',
+            'schema' => 'storage_prune_plan.v2',
             'scope' => $scope,
+            'strategy' => $scope === self::SCOPE_REPORTS_BACKUPS ? $strategy : null,
             'generated_at' => now()->toISOString(),
             'files' => $paths,
             'summary' => [
@@ -101,6 +150,9 @@ final class StoragePrune extends Command
 
         $this->line('status=planned');
         $this->line('scope='.$scope);
+        if ($scope === self::SCOPE_REPORTS_BACKUPS) {
+            $this->line('strategy='.$strategy);
+        }
         $this->line('plan='.$planPath);
         $this->line('files='.count($paths));
         $this->line('bytes='.$totalBytes);
@@ -108,7 +160,7 @@ final class StoragePrune extends Command
         return self::SUCCESS;
     }
 
-    private function executePlan(string $scope): int
+    private function executePlan(string $scope, string $strategy): int
     {
         $planOption = trim((string) $this->option('plan'));
         if ($planOption === '') {
@@ -131,11 +183,37 @@ final class StoragePrune extends Command
             return self::FAILURE;
         }
 
+        $planSchema = trim((string) ($decoded['schema'] ?? ''));
+        if (! in_array($planSchema, ['storage_prune_plan.v1', 'storage_prune_plan.v2'], true)) {
+            $this->error('unsupported plan schema: '.$planSchema);
+
+            return self::FAILURE;
+        }
+
         $planScope = strtolower(trim((string) ($decoded['scope'] ?? '')));
         if ($planScope !== $scope) {
             $this->error('plan scope mismatch: plan='.$planScope.' cli='.$scope);
 
             return self::FAILURE;
+        }
+
+        $planStrategy = strtolower(trim((string) ($decoded['strategy'] ?? self::STRATEGY_STRICT)));
+        if ($scope === self::SCOPE_REPORTS_BACKUPS) {
+            if (! in_array($planStrategy, self::SUPPORTED_STRATEGIES, true)) {
+                $this->error('unsupported plan strategy: '.$planStrategy);
+
+                return self::FAILURE;
+            }
+            if ($planStrategy !== $strategy) {
+                $this->error('plan strategy mismatch: plan='.$planStrategy.' cli='.$strategy);
+
+                return self::FAILURE;
+            }
+            if ($strategy === self::STRATEGY_BROAD) {
+                $this->error('reports_backups strategy=broad is dry-run only in phased rollout.');
+
+                return self::FAILURE;
+            }
         }
 
         $files = is_array($decoded['files'] ?? null) ? $decoded['files'] : [];
@@ -152,7 +230,14 @@ final class StoragePrune extends Command
                 continue;
             }
 
-            if (! $this->isPrunablePathForScope($scope, $relPath)) {
+            $canonical = trim((string) (is_array($fileEntry) ? ($fileEntry['canonical'] ?? '') : ''));
+
+            if (! $this->isPrunablePathForScope($scope, $relPath, $strategy)) {
+                $skippedFiles++;
+                continue;
+            }
+
+            if ($scope === self::SCOPE_LEGACY_PRIVATE_PRIVATE && $canonical !== '' && ! $disk->exists($canonical)) {
                 $skippedFiles++;
                 continue;
             }
@@ -174,13 +259,22 @@ final class StoragePrune extends Command
             $deletedBytes += max(0, $bytes);
         }
 
+        if ($scope === self::SCOPE_LEGACY_PRIVATE_PRIVATE) {
+            $this->cleanupEmptyDirectories(storage_path('app/private/private'));
+        }
+
         $this->line('status=executed');
         $this->line('scope='.$scope);
+        if ($scope === self::SCOPE_REPORTS_BACKUPS) {
+            $this->line('strategy='.$strategy);
+        }
         $this->line('plan='.$planPath);
         $this->line('deleted_files='.$deletedFiles);
         $this->line('deleted_bytes='.$deletedBytes);
         $this->line('missing_files='.$missingFiles);
         $this->line('skipped_files='.$skippedFiles);
+
+        $this->recordAudit($scope, $strategy, $deletedFiles, $deletedBytes, $missingFiles, $skippedFiles, $planPath);
 
         return self::SUCCESS;
     }
@@ -188,7 +282,7 @@ final class StoragePrune extends Command
     /**
      * @return list<array{path:string,bytes:int}>
      */
-    private function collectReportBackupEntries(): array
+    private function collectReportBackupEntries(string $strategy): array
     {
         $root = storage_path('app/private/reports');
         if (! is_dir($root)) {
@@ -212,13 +306,139 @@ final class StoragePrune extends Command
             }
 
             $relPath = str_replace('\\', '/', substr($fullPath, strlen($prefix)));
-            if (! $this->isReportTimestampBackupPath($relPath)) {
+            $matches = $strategy === self::STRATEGY_STRICT
+                ? $this->isReportTimestampBackupPathStrict($relPath)
+                : $this->isReportTimestampBackupPathBroad($relPath);
+
+            if (! $matches) {
                 continue;
             }
 
             $items[] = [
                 'path' => $relPath,
                 'bytes' => max(0, (int) ($file->getSize() ?: 0)),
+            ];
+        }
+
+        usort($items, static fn (array $a, array $b): int => strcmp($a['path'], $b['path']));
+
+        return $items;
+    }
+
+    /**
+     * @return list<array{path:string,bytes:int}>
+     */
+    private function collectContentReleasesRetentionEntries(): array
+    {
+        $root = storage_path('app/private/content_releases');
+        if (! is_dir($root)) {
+            return [];
+        }
+
+        $keepLastN = max(0, (int) config('storage_retention.content_releases.keep_last_n', 20));
+        $keepDays = max(0, (int) config('storage_retention.content_releases.keep_days', 180));
+        $threshold = now()->subDays($keepDays)->getTimestamp();
+
+        $releaseDirs = [];
+        foreach (new \DirectoryIterator($root) as $item) {
+            if (! $item->isDir() || $item->isDot()) {
+                continue;
+            }
+
+            $dirPath = $item->getPathname();
+            $releaseDirs[] = [
+                'name' => $item->getFilename(),
+                'path' => $dirPath,
+                'mtime' => (int) (@filemtime($dirPath) ?: 0),
+            ];
+        }
+
+        usort($releaseDirs, static fn (array $a, array $b): int => $b['mtime'] <=> $a['mtime']);
+
+        $items = [];
+        foreach ($releaseDirs as $index => $dir) {
+            $isProtectedByCount = $index < $keepLastN;
+            $isProtectedByAge = ((int) $dir['mtime']) >= $threshold;
+            if ($isProtectedByCount || $isProtectedByAge) {
+                continue;
+            }
+
+            $iterator = new \RecursiveIteratorIterator(
+                new \RecursiveDirectoryIterator((string) $dir['path'], \FilesystemIterator::SKIP_DOTS)
+            );
+            foreach ($iterator as $file) {
+                if (! $file instanceof \SplFileInfo || ! $file->isFile()) {
+                    continue;
+                }
+
+                $fullPath = $file->getPathname();
+                $prefix = rtrim(storage_path('app/private'), DIRECTORY_SEPARATOR).DIRECTORY_SEPARATOR;
+                if (! str_starts_with($fullPath, $prefix)) {
+                    continue;
+                }
+
+                $relPath = str_replace('\\', '/', substr($fullPath, strlen($prefix)));
+                $items[] = [
+                    'path' => $relPath,
+                    'bytes' => max(0, (int) ($file->getSize() ?: 0)),
+                ];
+            }
+        }
+
+        usort($items, static fn (array $a, array $b): int => strcmp($a['path'], $b['path']));
+
+        return $items;
+    }
+
+    /**
+     * @return list<array{path:string,bytes:int,canonical:string}>
+     */
+    private function collectLegacyPrivatePrivateEntries(): array
+    {
+        $root = storage_path('app/private/private');
+        if (! is_dir($root)) {
+            return [];
+        }
+
+        $items = [];
+        $disk = Storage::disk('local');
+        $iterator = new \RecursiveIteratorIterator(
+            new \RecursiveDirectoryIterator($root, \FilesystemIterator::SKIP_DOTS)
+        );
+
+        foreach ($iterator as $file) {
+            if (! $file instanceof \SplFileInfo || ! $file->isFile()) {
+                continue;
+            }
+
+            $fullPath = $file->getPathname();
+            $prefix = rtrim(storage_path('app/private'), DIRECTORY_SEPARATOR).DIRECTORY_SEPARATOR;
+            if (! str_starts_with($fullPath, $prefix)) {
+                continue;
+            }
+
+            $relPath = str_replace('\\', '/', substr($fullPath, strlen($prefix)));
+            if (! str_starts_with($relPath, 'private/')) {
+                continue;
+            }
+
+            $candidates = $this->legacyCanonicalCandidates($relPath);
+            $canonical = '';
+            foreach ($candidates as $candidate) {
+                if ($candidate !== '' && $disk->exists($candidate)) {
+                    $canonical = $candidate;
+                    break;
+                }
+            }
+
+            if ($canonical === '') {
+                continue;
+            }
+
+            $items[] = [
+                'path' => $relPath,
+                'bytes' => max(0, (int) ($file->getSize() ?: 0)),
+                'canonical' => $canonical,
             ];
         }
 
@@ -241,16 +461,138 @@ final class StoragePrune extends Command
         return storage_path('app/private/'.ltrim($planOption, '/\\'));
     }
 
-    private function isPrunablePathForScope(string $scope, string $relPath): bool
+    private function isPrunablePathForScope(string $scope, string $relPath, string $strategy): bool
     {
         return match ($scope) {
-            self::SCOPE_REPORTS_BACKUPS => $this->isReportTimestampBackupPath($relPath),
+            self::SCOPE_REPORTS_BACKUPS => $strategy === self::STRATEGY_STRICT
+                ? $this->isReportTimestampBackupPathStrict($relPath)
+                : $this->isReportTimestampBackupPathBroad($relPath),
+            self::SCOPE_CONTENT_RELEASES => str_starts_with($relPath, 'content_releases/'),
+            self::SCOPE_LEGACY_PRIVATE_PRIVATE => str_starts_with($relPath, 'private/'),
             default => false,
         };
     }
 
-    private function isReportTimestampBackupPath(string $relPath): bool
+    private function isReportTimestampBackupPathStrict(string $relPath): bool
     {
         return preg_match('#^reports/[^/]+/report\.\d{8}_\d{6}\.json$#', $relPath) === 1;
+    }
+
+    private function isReportTimestampBackupPathBroad(string $relPath): bool
+    {
+        if (preg_match('#^reports/[^/]+/(report|report_snapshot)\.json$#', $relPath) === 1) {
+            return false;
+        }
+
+        return preg_match('#^reports/[^/]+/(report|report_snapshot)\..+\.json$#', $relPath) === 1;
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function legacyCanonicalCandidates(string $legacyPath): array
+    {
+        $candidates = [];
+
+        $stripped = substr($legacyPath, strlen('private/'));
+        if (is_string($stripped) && $stripped !== '') {
+            $candidates[] = $stripped;
+        }
+
+        if (preg_match('#^private/reports/([^/]+)/([^/]+)/([^/]+)/report_(free|full)\.pdf$#i', $legacyPath, $m) === 1) {
+            $candidates[] = $this->artifactStore->pdfCanonicalPath(
+                (string) $m[1],
+                (string) $m[2],
+                (string) $m[3],
+                (string) $m[4]
+            );
+        } elseif (preg_match('#^private/reports/([^/]+)/([^/]+)/report_(free|full)\.pdf$#i', $legacyPath, $m) === 1) {
+            $candidates[] = $this->artifactStore->pdfCanonicalPath(
+                (string) $m[1],
+                (string) $m[2],
+                'nohash',
+                (string) $m[3]
+            );
+        }
+
+        if (preg_match('#^private/reports/([^/]+)/report\.json$#', $legacyPath, $m) === 1) {
+            $candidates[] = $this->artifactStore->reportCanonicalPath('MBTI', (string) $m[1]);
+        } elseif (preg_match('#^private/reports/([^/]+)/([^/]+)/report\.json$#', $legacyPath, $m) === 1) {
+            $candidates[] = $this->artifactStore->reportCanonicalPath((string) $m[1], (string) $m[2]);
+        }
+
+        $candidates = array_values(array_unique(array_filter($candidates, static fn (string $path): bool => $path !== '')));
+
+        return $candidates;
+    }
+
+    private function cleanupEmptyDirectories(string $root): void
+    {
+        if (! is_dir($root)) {
+            return;
+        }
+
+        $iterator = new \RecursiveIteratorIterator(
+            new \RecursiveDirectoryIterator($root, \FilesystemIterator::SKIP_DOTS),
+            \RecursiveIteratorIterator::CHILD_FIRST
+        );
+
+        foreach ($iterator as $item) {
+            if (! $item instanceof \SplFileInfo || ! $item->isDir()) {
+                continue;
+            }
+
+            $dir = $item->getPathname();
+            $children = @scandir($dir);
+            if ($children === false) {
+                continue;
+            }
+
+            if (count($children) === 2) {
+                @rmdir($dir);
+            }
+        }
+
+        $children = @scandir($root);
+        if (is_array($children) && count($children) === 2) {
+            @rmdir($root);
+        }
+    }
+
+    private function recordAudit(
+        string $scope,
+        string $strategy,
+        int $deletedFiles,
+        int $deletedBytes,
+        int $missingFiles,
+        int $skippedFiles,
+        string $planPath
+    ): void {
+        if (! Schema::hasTable('audit_logs')) {
+            return;
+        }
+
+        DB::table('audit_logs')->insert([
+            'org_id' => 0,
+            'actor_admin_id' => null,
+            'action' => 'storage_prune',
+            'target_type' => 'storage',
+            'target_id' => $scope,
+            'meta_json' => json_encode([
+                'scope' => $scope,
+                'strategy' => $scope === self::SCOPE_REPORTS_BACKUPS ? $strategy : null,
+                'deleted_files_count' => $deletedFiles,
+                'deleted_bytes' => $deletedBytes,
+                'missing_files' => $missingFiles,
+                'skipped_files' => $skippedFiles,
+                'plan' => $planPath,
+            ], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES),
+            'ip' => null,
+            'user_agent' => 'cli/storage_prune',
+            'request_id' => null,
+            'reason' => 'retention_policy',
+            'result' => 'success',
+            'created_at' => now(),
+        ]);
     }
 }

--- a/backend/app/Console/Kernel.php
+++ b/backend/app/Console/Kernel.php
@@ -40,6 +40,8 @@ use App\Console\Commands\QualityDailySummary;
 use App\Console\Commands\SdsPsychometricsReport;
 use App\Console\Commands\SeedScaleRegistry;
 use App\Console\Commands\StoragePrune;
+use App\Console\Commands\StorageMigrateLegacyArtifacts;
+use App\Console\Commands\StorageInventory;
 use App\Console\Commands\SyncScaleSlugs;
 use Illuminate\Console\Scheduling\Schedule;
 use Illuminate\Foundation\Console\Kernel as ConsoleKernel;
@@ -91,6 +93,8 @@ class Kernel extends ConsoleKernel
         Packs2Rollback::class,
         Packs2List::class,
         StoragePrune::class,
+        StorageMigrateLegacyArtifacts::class,
+        StorageInventory::class,
         QualityDailySummary::class,
         CiScaleImpact::class,
         PartitionAttemptAnswerRows::class,
@@ -104,6 +108,10 @@ class Kernel extends ConsoleKernel
         // 示例（需要就开）：
         // $schedule->command('fap:self-check')->dailyAt('03:10');
         // $schedule->command('fap:validate-report --attempt=...')->hourly();
+        $schedule->command('storage:prune --execute --scope=reports_backups --strategy=strict')->dailyAt('03:10')->withoutOverlapping();
+        $schedule->command('storage:prune --execute --scope=content_releases_retention')->dailyAt('03:20')->withoutOverlapping();
+        $schedule->command('storage:prune --execute --scope=legacy_private_private_cleanup')->dailyAt('03:30')->withoutOverlapping();
+        $schedule->command('storage:inventory --json')->weeklyOn(1, '04:10')->withoutOverlapping();
         $schedule->command('payments:prune-events --days=90')->dailyAt('03:00')->withoutOverlapping();
         $schedule->command('quality:daily-summary')->dailyAt('03:20')->withoutOverlapping();
         $schedule->command('sds:psychometrics --window=last_7_days')->weeklyOn(1, '04:10')->withoutOverlapping();

--- a/backend/app/Jobs/GenerateReportJob.php
+++ b/backend/app/Jobs/GenerateReportJob.php
@@ -6,13 +6,13 @@ use App\Models\Attempt;
 use App\Models\ReportJob;
 use App\Models\Result;
 use App\Services\Report\ReportComposer;
+use App\Services\Storage\ArtifactStore;
 use Illuminate\Bus\Queueable;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Foundation\Bus\Dispatchable;
 use Illuminate\Queue\InteractsWithQueue;
 use Illuminate\Queue\SerializesModels;
 use Illuminate\Support\Facades\Log;
-use Illuminate\Support\Facades\Storage;
 use Illuminate\Support\Str;
 
 class GenerateReportJob implements ShouldQueue
@@ -89,7 +89,7 @@ class GenerateReportJob implements ShouldQueue
             $job->report_json = $reportPayload;
             $job->save();
 
-            $this->persistReportJson($attemptId, $reportPayload);
+            $this->persistReportJson((string) ($attempt->scale_code ?? 'MBTI'), $attemptId, $reportPayload);
         } catch (\Throwable $e) {
             $job->status = 'failed';
             $job->failed_at = now();
@@ -107,42 +107,22 @@ class GenerateReportJob implements ShouldQueue
         }
     }
 
-    private function persistReportJson(string $attemptId, array $reportPayload): void
+    private function persistReportJson(string $scaleCode, string $attemptId, array $reportPayload): void
     {
-        $disk = array_key_exists('private', config('filesystems.disks', []))
-            ? Storage::disk('private')
-            : Storage::disk(config('filesystems.default', 'local'));
-
-        $latestRelPath = "reports/{$attemptId}/report.json";
-
         try {
-            $json = json_encode($reportPayload, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES);
-            if ($json === false) {
-                throw new \RuntimeException('json_encode_failed: ' . json_last_error_msg());
-            }
-
-            if (method_exists($disk, 'makeDirectory')) {
-                $disk->makeDirectory("reports/{$attemptId}");
-            }
-
-            $disk->put($latestRelPath, $json);
-
-            $ts = function_exists('now') ? now()->format('Ymd_His') : date('Ymd_His');
-            $snapRelPath = "reports/{$attemptId}/report.{$ts}.json";
-            $disk->put($snapRelPath, $json);
+            $latestRelPath = app(ArtifactStore::class)
+                ->putReportJson($scaleCode, $attemptId, $reportPayload);
 
             Log::info('[report_job] persisted report.json', [
                 'attempt_id' => $attemptId,
-                'disk' => array_key_exists('private', config('filesystems.disks', []))
-                    ? 'private'
-                    : config('filesystems.default', 'local'),
+                'disk' => 'local',
                 'latest' => $latestRelPath,
-                'snapshot' => $snapRelPath,
+                'snapshot' => null,
             ]);
         } catch (\Throwable $e) {
             Log::warning('[report_job] persist report.json failed', [
                 'attempt_id' => $attemptId,
-                'path' => $latestRelPath,
+                'path' => null,
                 'err' => $e->getMessage(),
             ]);
         }

--- a/backend/app/Services/Content/ContentPackV2Resolver.php
+++ b/backend/app/Services/Content/ContentPackV2Resolver.php
@@ -81,26 +81,51 @@ final class ContentPackV2Resolver
             return null;
         }
 
-        $normalized = str_replace('\\', '/', $storagePath);
+        $roots = $this->candidateRootsFromStoragePath($storagePath);
+        foreach ($roots as $root) {
+            $compiledDir = is_dir($root.'/compiled') ? $root.'/compiled' : $root;
+            if (is_file($compiledDir.'/manifest.json')) {
+                return $compiledDir;
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function candidateRootsFromStoragePath(string $storagePath): array
+    {
+        $normalized = str_replace('\\', '/', trim($storagePath));
+        if ($normalized === '') {
+            return [];
+        }
+
+        $candidates = [];
         if (str_starts_with($normalized, '/')) {
-            $root = rtrim($normalized, '/');
+            $candidates[] = rtrim($normalized, '/');
         } else {
             $relative = ltrim($normalized, '/');
             if (str_starts_with($relative, 'app/')) {
                 $relative = substr($relative, 4);
             }
-            $root = rtrim(storage_path('app/'.$relative), '/');
+            $relative = ltrim($relative, '/');
+            if ($relative !== '') {
+                $candidates[] = rtrim(storage_path('app/'.$relative), '/');
+            }
+
+            if (str_starts_with($relative, 'private/packs_v2/')) {
+                $mirror = 'content_packs_v2/'.substr($relative, strlen('private/packs_v2/'));
+                $candidates[] = rtrim(storage_path('app/'.$mirror), '/');
+            } elseif (str_starts_with($relative, 'content_packs_v2/')) {
+                $mirror = 'private/packs_v2/'.substr($relative, strlen('content_packs_v2/'));
+                $candidates[] = rtrim(storage_path('app/'.$mirror), '/');
+            }
         }
 
-        $compiledDir = $root;
-        if (is_dir($root.'/compiled')) {
-            $compiledDir = $root.'/compiled';
-        }
+        $candidates = array_values(array_unique(array_filter($candidates, static fn (string $root): bool => $root !== '')));
 
-        if (! is_file($compiledDir.'/manifest.json')) {
-            return null;
-        }
-
-        return $compiledDir;
+        return $candidates;
     }
 }

--- a/backend/app/Services/Content/Publisher/ContentPackV2Publisher.php
+++ b/backend/app/Services/Content/Publisher/ContentPackV2Publisher.php
@@ -52,18 +52,13 @@ final class ContentPackV2Publisher
         $normsVersion = trim((string) ($manifest['norms_version'] ?? data_get($manifest, 'norms.norms_version', '')));
 
         $releaseId = (string) Str::uuid();
-        $storagePath = 'content_packs_v2/'.$packId.'/'.$packVersion.'/'.$releaseId;
-        $targetRoot = storage_path('app/'.$storagePath);
-        $targetCompiledDir = $targetRoot.'/compiled';
+        $primaryStoragePath = 'private/packs_v2/'.$packId.'/'.$packVersion.'/'.$releaseId;
+        $mirrorStoragePath = 'content_packs_v2/'.$packId.'/'.$packVersion.'/'.$releaseId;
 
-        if (File::isDirectory($targetRoot)) {
-            File::deleteDirectory($targetRoot);
-        }
+        $this->copyCompiledToStoragePath($sourceCompiledDir, $primaryStoragePath);
+        $this->copyCompiledToStoragePath($sourceCompiledDir, $mirrorStoragePath);
 
-        File::ensureDirectoryExists(dirname($targetCompiledDir));
-        if (! File::copyDirectory($sourceCompiledDir, $targetCompiledDir)) {
-            throw new RuntimeException('COPY_COMPILED_FAILED');
-        }
+        $storagePath = $primaryStoragePath;
 
         $sourceCommit = trim((string) ($options['source_commit'] ?? ''));
         $createdBy = trim((string) ($options['created_by'] ?? 'packs2'));
@@ -279,5 +274,20 @@ final class ContentPackV2Publisher
         $root = storage_path('app/'.ltrim(str_starts_with($storagePath, 'app/') ? substr($storagePath, 4) : $storagePath, '/'));
 
         return is_file($root.'/compiled/manifest.json') || is_file($root.'/manifest.json');
+    }
+
+    private function copyCompiledToStoragePath(string $sourceCompiledDir, string $storagePath): void
+    {
+        $targetRoot = storage_path('app/'.$storagePath);
+        $targetCompiledDir = $targetRoot.'/compiled';
+
+        if (File::isDirectory($targetRoot)) {
+            File::deleteDirectory($targetRoot);
+        }
+
+        File::ensureDirectoryExists(dirname($targetCompiledDir));
+        if (! File::copyDirectory($sourceCompiledDir, $targetCompiledDir)) {
+            throw new RuntimeException('COPY_COMPILED_FAILED: '.$storagePath);
+        }
     }
 }

--- a/backend/app/Services/Legacy/LegacyReportService.php
+++ b/backend/app/Services/Legacy/LegacyReportService.php
@@ -9,6 +9,7 @@ use App\Models\Attempt;
 use App\Models\ReportJob;
 use App\Models\Result;
 use App\Services\Commerce\EntitlementManager;
+use App\Services\Storage\ArtifactStore;
 use App\Support\OrgContext;
 use App\Support\WritesEvents;
 use Illuminate\Database\Eloquent\ModelNotFoundException;
@@ -16,7 +17,6 @@ use Illuminate\Http\Request;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Facades\Schema;
-use Illuminate\Support\Facades\Storage;
 use Illuminate\Support\Str;
 use Throwable;
 
@@ -25,7 +25,8 @@ class LegacyReportService
     use WritesEvents;
 
     public function __construct(
-        private OrgContext $orgContext
+        private OrgContext $orgContext,
+        private readonly ArtifactStore $artifactStore,
     ) {
     }
 
@@ -371,24 +372,19 @@ class LegacyReportService
             : null;
 
         if (!is_array($reportPayload)) {
-            $disk = array_key_exists('private', config('filesystems.disks', []))
-                ? Storage::disk('private')
-                : Storage::disk(config('filesystems.default', 'local'));
-            $latestRelPath = "reports/{$attemptId}/report.json";
+            $scaleCode = (string) (
+                $result?->scale_code
+                ?? $attempt->scale_code
+                ?? data_get($attempt->result_json, 'scale_code', 'MBTI')
+            );
 
             try {
-                if ($disk->exists($latestRelPath)) {
-                    $cachedJson = $disk->get($latestRelPath);
-                    $cached = json_decode($cachedJson, true);
-                    if (is_array($cached)) {
-                        $reportPayload = $cached;
-                    }
-                }
+                $reportPayload = $this->artifactStore->getReportJson($scaleCode, $attemptId);
             } catch (Throwable $e) {
                 Log::error('LEGACY_REPORT_CACHE_READ_FAILED', [
                     'attempt_id' => $attemptId,
                     'request_id' => $this->requestId($request),
-                    'path' => $latestRelPath,
+                    'path' => $this->artifactStore->reportCanonicalPath($scaleCode, $attemptId),
                     'message' => $e->getMessage(),
                 ]);
 

--- a/backend/app/Services/Report/Composer/ReportPersistence.php
+++ b/backend/app/Services/Report/Composer/ReportPersistence.php
@@ -4,46 +4,29 @@ declare(strict_types=1);
 
 namespace App\Services\Report\Composer;
 
+use App\Services\Storage\ArtifactStore;
 use Illuminate\Support\Facades\Log;
-use Illuminate\Support\Facades\Storage;
 
 class ReportPersistence
 {
+    public function __construct(
+        private readonly ArtifactStore $artifactStore,
+    ) {
+    }
+
     public function persist(string $attemptId, array $payload): void
     {
         try {
-            $disk = Storage::disk('local');
-            $baseDir = "reports/{$attemptId}";
-            $disk->makeDirectory($baseDir);
-
-            $json = json_encode(
-                $payload,
-                JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES | JSON_PRETTY_PRINT
-            );
-
-            if ($json === false) {
-                Log::warning('[REPORT] persist_report_json_encode_failed', [
-                    'attempt_id' => $attemptId,
-                    'json_error' => json_last_error_msg(),
-                ]);
-                return;
-            }
-
-            $pathLatest = "{$baseDir}/report.json";
-            $disk->put($pathLatest, $json);
-
-            $ts = now()->format('Ymd_His');
-            $pathSnapshot = "{$baseDir}/report.{$ts}.json";
-            $disk->put($pathSnapshot, $json);
+            $pathLatest = $this->artifactStore->putReportJson('MBTI', $attemptId, $payload);
 
             Log::info('[REPORT] persisted', [
                 'attempt_id' => $attemptId,
                 'disk' => 'local',
                 'root' => (string) config('filesystems.disks.local.root'),
                 'latest' => $pathLatest,
-                'snapshot' => $pathSnapshot,
-                'latest_exists' => $disk->exists($pathLatest),
-                'latest_abs' => method_exists($disk, 'path') ? $disk->path($pathLatest) : null,
+                'snapshot' => null,
+                'latest_exists' => $this->artifactStore->exists($pathLatest),
+                'latest_abs' => storage_path('app/private/'.$pathLatest),
             ]);
         } catch (\Throwable $e) {
             Log::warning('[REPORT] persist_report_failed', [

--- a/backend/app/Services/Report/Pdf/ReportPdfArtifactStore.php
+++ b/backend/app/Services/Report/Pdf/ReportPdfArtifactStore.php
@@ -4,55 +4,47 @@ declare(strict_types=1);
 
 namespace App\Services\Report\Pdf;
 
-use Illuminate\Support\Facades\Storage;
+use App\Services\Storage\ArtifactStore;
 
 final class ReportPdfArtifactStore
 {
+    public function __construct(
+        private readonly ArtifactStore $artifactStore,
+    ) {}
+
     public function path(string $scaleCode, string $attemptId, string $manifestHash, string $variant): string
     {
-        $scale = strtoupper(trim($scaleCode));
-        if ($scale === '') {
-            $scale = 'UNKNOWN';
-        }
-        $scale = preg_replace('/[^A-Z0-9_]/', '_', $scale) ?? 'UNKNOWN';
+        return $this->artifactStore->pdfCanonicalPath($scaleCode, $attemptId, $manifestHash, $variant);
+    }
 
-        $attempt = trim($attemptId);
-        if ($attempt === '') {
-            $attempt = 'unknown_attempt';
-        }
-        $attempt = preg_replace('/[^a-zA-Z0-9\\-_]/', '_', $attempt) ?? 'unknown_attempt';
-
-        $hash = trim($manifestHash) !== '' ? trim($manifestHash) : 'nohash';
-        $hash = preg_replace('/[^a-zA-Z0-9\\-_\\.]/', '', $hash) ?? 'nohash';
-        if ($hash === '') {
-            $hash = 'nohash';
-        }
-
-        $variant = strtolower(trim($variant));
-        $variant = in_array($variant, ['free', 'full'], true) ? $variant : 'free';
-
-        return "private/reports/{$scale}/{$attempt}/{$hash}/report_{$variant}.pdf";
+    /**
+     * @return list<string>
+     */
+    public function legacyPaths(string $scaleCode, string $attemptId, string $manifestHash, string $variant): array
+    {
+        return $this->artifactStore->pdfLegacyPaths($scaleCode, $attemptId, $manifestHash, $variant);
     }
 
     public function exists(string $path): bool
     {
-        return Storage::disk('local')->exists($path);
+        return $this->artifactStore->exists($path);
     }
 
     public function put(string $path, string $bytes): void
     {
-        Storage::disk('local')->put($path, $bytes);
+        $this->artifactStore->putPdf($path, $bytes);
     }
 
     public function get(string $path): ?string
     {
-        $disk = Storage::disk('local');
-        if (! $disk->exists($path)) {
-            return null;
-        }
+        return $this->artifactStore->get($path);
+    }
 
-        $contents = $disk->get($path);
-
-        return is_string($contents) && $contents !== '' ? $contents : null;
+    /**
+     * @param  list<string>  $paths
+     */
+    public function getFirst(array $paths): ?string
+    {
+        return $this->artifactStore->getFirstFile($paths);
     }
 }

--- a/backend/app/Services/Report/Pdf/ReportPdfDocumentService.php
+++ b/backend/app/Services/Report/Pdf/ReportPdfDocumentService.php
@@ -39,9 +39,32 @@ final class ReportPdfDocumentService
 
     public function readArtifact(Attempt $attempt, string $variant, ?Result $result = null): ?string
     {
-        $path = $this->resolveArtifactPath($attempt, $variant, $result);
+        $variant = $this->normalizeVariant($variant);
+        $manifestHash = $this->resolveManifestHash($attempt, $result);
+        $path = $this->artifactStore->path(
+            (string) ($attempt->scale_code ?? 'UNKNOWN'),
+            (string) $attempt->id,
+            $manifestHash,
+            $variant
+        );
+        $candidates = array_merge([
+            $path,
+        ], $this->artifactStore->legacyPaths(
+            (string) ($attempt->scale_code ?? 'UNKNOWN'),
+            (string) $attempt->id,
+            $manifestHash,
+            $variant
+        ));
+        $cached = $this->artifactStore->getFirst($candidates);
+        if (is_string($cached) && $cached !== '') {
+            if (! $this->artifactStore->exists($path)) {
+                $this->artifactStore->put($path, $cached);
+            }
 
-        return $this->artifactStore->get($path);
+            return $cached;
+        }
+
+        return null;
     }
 
     /**
@@ -59,9 +82,20 @@ final class ReportPdfDocumentService
             $manifestHash,
             $variant
         );
-
-        $cached = $this->artifactStore->get($path);
+        $candidates = array_merge([
+            $path,
+        ], $this->artifactStore->legacyPaths(
+            (string) ($attempt->scale_code ?? 'UNKNOWN'),
+            (string) $attempt->id,
+            $manifestHash,
+            $variant
+        ));
+        $cached = $this->artifactStore->getFirst($candidates);
         if (is_string($cached) && $cached !== '') {
+            if (! $this->artifactStore->exists($path)) {
+                $this->artifactStore->put($path, $cached);
+            }
+
             return [
                 'binary' => $cached,
                 'storage_path' => $path,

--- a/backend/app/Services/Storage/ArtifactStore.php
+++ b/backend/app/Services/Storage/ArtifactStore.php
@@ -1,0 +1,190 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\Storage;
+
+use Illuminate\Support\Facades\Storage;
+
+final class ArtifactStore
+{
+    public function reportCanonicalPath(string $scaleCode, string $attemptId): string
+    {
+        $scale = $this->sanitizeScaleCode($scaleCode);
+        $attempt = $this->sanitizeAttemptId($attemptId);
+
+        return "artifacts/reports/{$scale}/{$attempt}/report.json";
+    }
+
+    /**
+     * @return list<string>
+     */
+    public function reportLegacyPaths(string $scaleCode, string $attemptId): array
+    {
+        $scale = $this->sanitizeScaleCode($scaleCode);
+        $attempt = $this->sanitizeAttemptId($attemptId);
+
+        return [
+            "reports/{$attempt}/report.json",
+            "private/reports/{$attempt}/report.json",
+            "reports/{$scale}/{$attempt}/report.json",
+            "private/reports/{$scale}/{$attempt}/report.json",
+        ];
+    }
+
+    /**
+     * @param  array<string,mixed>  $payload
+     */
+    public function putReportJson(string $scaleCode, string $attemptId, array $payload): string
+    {
+        $path = $this->reportCanonicalPath($scaleCode, $attemptId);
+        $json = json_encode(
+            $payload,
+            JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES | JSON_PRETTY_PRINT
+        );
+
+        if (! is_string($json)) {
+            throw new \RuntimeException('REPORT_JSON_ENCODE_FAILED: '.json_last_error_msg());
+        }
+
+        Storage::disk('local')->put($path, $json);
+
+        return $path;
+    }
+
+    /**
+     * @return array<string,mixed>|null
+     */
+    public function getReportJson(string $scaleCode, string $attemptId): ?array
+    {
+        $paths = array_merge(
+            [$this->reportCanonicalPath($scaleCode, $attemptId)],
+            $this->reportLegacyPaths($scaleCode, $attemptId)
+        );
+
+        foreach ($paths as $path) {
+            $raw = $this->get($path);
+            if (! is_string($raw) || $raw === '') {
+                continue;
+            }
+
+            $decoded = json_decode($raw, true);
+            if (is_array($decoded)) {
+                return $decoded;
+            }
+        }
+
+        return null;
+    }
+
+    public function pdfCanonicalPath(string $scaleCode, string $attemptId, string $manifestHash, string $variant): string
+    {
+        $scale = $this->sanitizeScaleCode($scaleCode);
+        $attempt = $this->sanitizeAttemptId($attemptId);
+        $hash = $this->sanitizeManifestHash($manifestHash);
+        $variant = $this->normalizeVariant($variant);
+
+        return "artifacts/pdf/{$scale}/{$attempt}/{$hash}/report_{$variant}.pdf";
+    }
+
+    /**
+     * @return list<string>
+     */
+    public function pdfLegacyPaths(string $scaleCode, string $attemptId, string $manifestHash, string $variant): array
+    {
+        $scale = $this->sanitizeScaleCode($scaleCode);
+        $attempt = $this->sanitizeAttemptId($attemptId);
+        $hash = $this->sanitizeManifestHash($manifestHash);
+        $variant = $this->normalizeVariant($variant);
+
+        return [
+            "private/reports/{$scale}/{$attempt}/{$hash}/report_{$variant}.pdf",
+            "private/reports/{$scale}/{$attempt}/report_{$variant}.pdf",
+            "reports/{$scale}/{$attempt}/{$hash}/report_{$variant}.pdf",
+            "reports/{$scale}/{$attempt}/report_{$variant}.pdf",
+            "private/reports/big5/{$attempt}/report_{$variant}.pdf",
+            "reports/big5/{$attempt}/report_{$variant}.pdf",
+        ];
+    }
+
+    public function putPdf(string $path, string $bytes): void
+    {
+        Storage::disk('local')->put($path, $bytes);
+    }
+
+    /**
+     * @param  list<string>  $paths
+     */
+    public function getFirstFile(array $paths): ?string
+    {
+        foreach ($paths as $path) {
+            $content = $this->get($path);
+            if (is_string($content) && $content !== '') {
+                return $content;
+            }
+        }
+
+        return null;
+    }
+
+    public function exists(string $path): bool
+    {
+        return Storage::disk('local')->exists($path);
+    }
+
+    public function put(string $path, string $content): void
+    {
+        Storage::disk('local')->put($path, $content);
+    }
+
+    public function get(string $path): ?string
+    {
+        $disk = Storage::disk('local');
+        if (! $disk->exists($path)) {
+            return null;
+        }
+
+        $contents = $disk->get($path);
+
+        return is_string($contents) && $contents !== '' ? $contents : null;
+    }
+
+    private function sanitizeScaleCode(string $scaleCode): string
+    {
+        $scale = strtoupper(trim($scaleCode));
+        if ($scale === '') {
+            $scale = 'UNKNOWN';
+        }
+
+        return preg_replace('/[^A-Z0-9_]/', '_', $scale) ?? 'UNKNOWN';
+    }
+
+    private function sanitizeAttemptId(string $attemptId): string
+    {
+        $attempt = trim($attemptId);
+        if ($attempt === '') {
+            $attempt = 'unknown_attempt';
+        }
+
+        return preg_replace('/[^a-zA-Z0-9\\-_]/', '_', $attempt) ?? 'unknown_attempt';
+    }
+
+    private function sanitizeManifestHash(string $manifestHash): string
+    {
+        $hash = trim($manifestHash);
+        if ($hash === '') {
+            $hash = 'nohash';
+        }
+
+        $hash = preg_replace('/[^a-zA-Z0-9\\-_\\.]/', '', $hash) ?? 'nohash';
+
+        return $hash !== '' ? $hash : 'nohash';
+    }
+
+    private function normalizeVariant(string $variant): string
+    {
+        $variant = strtolower(trim($variant));
+
+        return in_array($variant, ['free', 'full'], true) ? $variant : 'free';
+    }
+}

--- a/backend/bootstrap/app.php
+++ b/backend/bootstrap/app.php
@@ -33,6 +33,10 @@ return Application::configure(basePath: dirname(__DIR__))
         \App\Console\Commands\FapResolvePack::class,
     ])
     ->withSchedule(function (Schedule $schedule): void {
+        $schedule->command('storage:prune --execute --scope=reports_backups --strategy=strict')->dailyAt('03:10')->withoutOverlapping();
+        $schedule->command('storage:prune --execute --scope=content_releases_retention')->dailyAt('03:20')->withoutOverlapping();
+        $schedule->command('storage:prune --execute --scope=legacy_private_private_cleanup')->dailyAt('03:30')->withoutOverlapping();
+        $schedule->command('storage:inventory --json')->weeklyOn(1, '04:10')->withoutOverlapping();
         $schedule->command('payments:prune-events --days=90')->dailyAt('03:00')->withoutOverlapping();
         $schedule->command('quality:daily-summary')->dailyAt('03:20')->withoutOverlapping();
         $schedule->command('sds:psychometrics --window=last_7_days')->weeklyOn(1, '04:10')->withoutOverlapping();

--- a/backend/config/storage_retention.php
+++ b/backend/config/storage_retention.php
@@ -1,0 +1,15 @@
+<?php
+
+return [
+    'reports' => [
+        'keep_days' => (int) env('STORAGE_RETENTION_REPORTS_DAYS', 365),
+        'keep_timestamp_backups' => (int) env('STORAGE_RETENTION_REPORT_TS_KEEP', 0),
+    ],
+    'content_releases' => [
+        'keep_last_n' => (int) env('STORAGE_RETENTION_RELEASES_KEEP_LAST', 20),
+        'keep_days' => (int) env('STORAGE_RETENTION_RELEASES_DAYS', 180),
+    ],
+    'logs' => [
+        'keep_days' => (int) env('STORAGE_RETENTION_LOGS_DAYS', 30),
+    ],
+];

--- a/backend/scripts/release_pack.sh
+++ b/backend/scripts/release_pack.sh
@@ -71,6 +71,7 @@ rm -rf "${STAGING_DIR}/.git" \
        "${STAGING_DIR}/backend/storage/app/private/reports" \
        "${STAGING_DIR}/backend/storage/app/private/artifacts" \
        "${STAGING_DIR}/backend/storage/app/private/packs_v2" \
+       "${STAGING_DIR}/backend/storage/app/content_packs_v2" \
        "${STAGING_DIR}/backend/storage/app/private/prune_plans"
 
 find "${STAGING_DIR}" -type f -name '*.sqlite*' -delete
@@ -89,6 +90,7 @@ find "${STAGING_DIR}" -type f -name '*.sqlite*' -print >> "$HITS_FILE"
 find "${STAGING_DIR}" -type d -path '*/storage/app/private/reports' -print >> "$HITS_FILE"
 find "${STAGING_DIR}" -type d -path '*/storage/app/private/artifacts' -print >> "$HITS_FILE"
 find "${STAGING_DIR}" -type d -path '*/storage/app/private/packs_v2' -print >> "$HITS_FILE"
+find "${STAGING_DIR}" -type d -path '*/storage/app/content_packs_v2' -print >> "$HITS_FILE"
 find "${STAGING_DIR}" -type d -path '*/storage/app/private/prune_plans' -print >> "$HITS_FILE"
 
 if [[ -s "$HITS_FILE" ]]; then

--- a/backend/tests/Feature/Content/Packs2DualWritePublishTest.php
+++ b/backend/tests/Feature/Content/Packs2DualWritePublishTest.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Content;
+
+use App\Services\Content\Publisher\ContentPackV2Publisher;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\File;
+use Tests\TestCase;
+
+final class Packs2DualWritePublishTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_publish_compiled_dual_writes_to_private_and_mirror_paths(): void
+    {
+        $this->artisan('content:compile --pack=BIG5_OCEAN --pack-version=v1')->assertExitCode(0);
+
+        /** @var ContentPackV2Publisher $publisher */
+        $publisher = app(ContentPackV2Publisher::class);
+        $release = $publisher->publishCompiled('BIG5_OCEAN', 'v1', [
+            'created_by' => 'test',
+        ]);
+
+        $releaseId = (string) ($release['id'] ?? '');
+        $this->assertNotSame('', $releaseId);
+
+        $primaryPath = 'private/packs_v2/BIG5_OCEAN/v1/'.$releaseId;
+        $mirrorPath = 'content_packs_v2/BIG5_OCEAN/v1/'.$releaseId;
+
+        $this->assertSame($primaryPath, (string) ($release['storage_path'] ?? ''));
+        $this->assertFileExists(storage_path('app/'.$primaryPath.'/compiled/manifest.json'));
+        $this->assertFileExists(storage_path('app/'.$mirrorPath.'/compiled/manifest.json'));
+
+        $storedPath = (string) DB::table('content_pack_releases')
+            ->where('id', $releaseId)
+            ->value('storage_path');
+        $this->assertSame($primaryPath, $storedPath);
+
+        File::deleteDirectory(storage_path('app/'.$primaryPath));
+        File::deleteDirectory(storage_path('app/'.$mirrorPath));
+    }
+}

--- a/backend/tests/Feature/Report/ReportPdfCrossScaleDeliveryTest.php
+++ b/backend/tests/Feature/Report/ReportPdfCrossScaleDeliveryTest.php
@@ -51,8 +51,8 @@ final class ReportPdfCrossScaleDeliveryTest extends TestCase
         $sdsPdf->assertHeader('Content-Type', 'application/pdf');
         $sdsPdf->assertHeader('X-Report-Scale', 'SDS_20');
 
-        $clinicalFilesFirst = Storage::disk('local')->allFiles('private/reports/CLINICAL_COMBO_68/'.$clinicalAttemptId);
-        $sdsFilesFirst = Storage::disk('local')->allFiles('private/reports/SDS_20/'.$sdsAttemptId);
+        $clinicalFilesFirst = Storage::disk('local')->allFiles('artifacts/pdf/CLINICAL_COMBO_68/'.$clinicalAttemptId);
+        $sdsFilesFirst = Storage::disk('local')->allFiles('artifacts/pdf/SDS_20/'.$sdsAttemptId);
         $this->assertCount(1, $clinicalFilesFirst);
         $this->assertCount(1, $sdsFilesFirst);
         $this->assertStringContainsString('/report_free.pdf', $clinicalFilesFirst[0]);
@@ -64,7 +64,7 @@ final class ReportPdfCrossScaleDeliveryTest extends TestCase
         ])->get('/api/v0.3/attempts/'.$clinicalAttemptId.'/report.pdf');
         $clinicalPdfAgain->assertStatus(200);
 
-        $clinicalFilesSecond = Storage::disk('local')->allFiles('private/reports/CLINICAL_COMBO_68/'.$clinicalAttemptId);
+        $clinicalFilesSecond = Storage::disk('local')->allFiles('artifacts/pdf/CLINICAL_COMBO_68/'.$clinicalAttemptId);
         $this->assertSame($clinicalFilesFirst, $clinicalFilesSecond);
     }
 

--- a/backend/tests/Feature/Storage/ArtifactStoreReadCompatibilityTest.php
+++ b/backend/tests/Feature/Storage/ArtifactStoreReadCompatibilityTest.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Storage;
+
+use App\Services\Storage\ArtifactStore;
+use Illuminate\Support\Facades\File;
+use Illuminate\Support\Facades\Storage;
+use Illuminate\Support\Str;
+use Tests\TestCase;
+
+final class ArtifactStoreReadCompatibilityTest extends TestCase
+{
+    public function test_reads_legacy_report_json_via_fallback_paths(): void
+    {
+        $attemptId = (string) Str::uuid();
+        $legacyPath = storage_path('app/private/reports/'.$attemptId.'/report.json');
+        File::ensureDirectoryExists(dirname($legacyPath));
+        File::put($legacyPath, json_encode(['ok' => true, 'attempt_id' => $attemptId], JSON_UNESCAPED_UNICODE));
+
+        /** @var ArtifactStore $store */
+        $store = app(ArtifactStore::class);
+        $report = $store->getReportJson('MBTI', $attemptId);
+
+        $this->assertIsArray($report);
+        $this->assertSame($attemptId, (string) ($report['attempt_id'] ?? ''));
+
+        File::deleteDirectory(storage_path('app/private/reports/'.$attemptId));
+    }
+
+    public function test_reads_legacy_private_private_pdf_via_fallback_candidates(): void
+    {
+        $attemptId = (string) Str::uuid();
+        $scaleCode = 'BIG5_OCEAN';
+        $manifestHash = 'legacyhash123';
+        $legacyPath = "private/reports/{$scaleCode}/{$attemptId}/{$manifestHash}/report_free.pdf";
+        $legacyPdf = '%PDF-1.4 legacy fallback';
+        Storage::disk('local')->put($legacyPath, $legacyPdf);
+
+        /** @var ArtifactStore $store */
+        $store = app(ArtifactStore::class);
+        $canonical = $store->pdfCanonicalPath($scaleCode, $attemptId, $manifestHash, 'free');
+        $candidates = array_merge([$canonical], $store->pdfLegacyPaths($scaleCode, $attemptId, $manifestHash, 'free'));
+        $resolved = $store->getFirstFile($candidates);
+
+        $this->assertSame($legacyPdf, $resolved);
+
+        Storage::disk('local')->deleteDirectory("private/reports/{$scaleCode}/{$attemptId}");
+        Storage::disk('local')->deleteDirectory("artifacts/pdf/{$scaleCode}/{$attemptId}");
+    }
+}

--- a/backend/tests/Feature/Storage/ReportPersistenceStopsTimestampBackupsTest.php
+++ b/backend/tests/Feature/Storage/ReportPersistenceStopsTimestampBackupsTest.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Storage;
+
+use App\Services\Report\Composer\ReportPersistence;
+use Illuminate\Support\Facades\File;
+use Illuminate\Support\Str;
+use Tests\TestCase;
+
+final class ReportPersistenceStopsTimestampBackupsTest extends TestCase
+{
+    public function test_persist_only_writes_canonical_report_json(): void
+    {
+        $attemptId = (string) Str::uuid();
+        $legacyDir = storage_path('app/private/reports/'.$attemptId);
+        $canonicalDir = storage_path('app/private/artifacts/reports/MBTI/'.$attemptId);
+        File::ensureDirectoryExists($legacyDir);
+
+        app(ReportPersistence::class)->persist($attemptId, ['ok' => true]);
+
+        $this->assertFileExists($canonicalDir.'/report.json');
+        $this->assertFileDoesNotExist($legacyDir.'/report.json');
+        $this->assertSame([], glob($legacyDir.'/report.*.json') ?: []);
+
+        File::deleteDirectory($legacyDir);
+        File::deleteDirectory($canonicalDir);
+    }
+}

--- a/backend/tests/Feature/Storage/StorageInventoryCommandTest.php
+++ b/backend/tests/Feature/Storage/StorageInventoryCommandTest.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Storage;
+
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Artisan;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Storage;
+use Illuminate\Support\Str;
+use Tests\TestCase;
+
+final class StorageInventoryCommandTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_inventory_outputs_json_fields_and_writes_audit_log(): void
+    {
+        $attemptId = (string) Str::uuid();
+        Storage::disk('local')->put("artifacts/reports/MBTI/{$attemptId}/report.json", '{"ok":true}');
+        Storage::disk('local')->put("artifacts/pdf/MBTI/{$attemptId}/nohash/report_free.pdf", '%PDF-1.4');
+        Storage::disk('local')->put('content_releases/test-release/source_pack/compiled/manifest.json', '{"ok":true}');
+
+        $this->assertSame(0, Artisan::call('storage:inventory', [
+            '--json' => true,
+        ]));
+        $output = (string) Artisan::output();
+        $this->assertStringContainsString('"scope":"reports"', $output);
+        $this->assertStringContainsString('"scope":"artifacts"', $output);
+        $this->assertStringContainsString('"scope":"content_releases"', $output);
+        $this->assertStringContainsString('"files"', $output);
+        $this->assertStringContainsString('"bytes"', $output);
+        $this->assertStringContainsString('"oldest_mtime"', $output);
+        $this->assertStringContainsString('"newest_mtime"', $output);
+        $this->assertStringContainsString('"top_dirs"', $output);
+
+        $this->assertTrue(
+            DB::table('audit_logs')->where('action', 'storage_inventory')->exists(),
+            'expected storage_inventory audit log'
+        );
+
+        Storage::disk('local')->deleteDirectory("artifacts/reports/MBTI/{$attemptId}");
+        Storage::disk('local')->deleteDirectory("artifacts/pdf/MBTI/{$attemptId}");
+        Storage::disk('local')->deleteDirectory('content_releases/test-release');
+    }
+}

--- a/backend/tests/Feature/Storage/StorageMigrateLegacyArtifactsCommandTest.php
+++ b/backend/tests/Feature/Storage/StorageMigrateLegacyArtifactsCommandTest.php
@@ -1,0 +1,85 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Storage;
+
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\File;
+use Illuminate\Support\Facades\Storage;
+use Illuminate\Support\Str;
+use Tests\TestCase;
+
+final class StorageMigrateLegacyArtifactsCommandTest extends TestCase
+{
+    use RefreshDatabase;
+
+    /** @var list<string> */
+    private array $preExistingPlans = [];
+
+    private string $attemptId;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->attemptId = (string) Str::uuid();
+        File::ensureDirectoryExists(storage_path('app/private/migration_plans'));
+        $this->preExistingPlans = glob(storage_path('app/private/migration_plans/*.json')) ?: [];
+
+        Storage::disk('local')->put("reports/{$this->attemptId}/report.json", json_encode([
+            'ok' => true,
+            'attempt_id' => $this->attemptId,
+        ], JSON_UNESCAPED_UNICODE));
+        Storage::disk('local')->put("private/reports/BIG5_OCEAN/{$this->attemptId}/legacyhash/report_free.pdf", '%PDF-1.4 legacy');
+    }
+
+    protected function tearDown(): void
+    {
+        Storage::disk('local')->deleteDirectory('reports/'.$this->attemptId);
+        Storage::disk('local')->deleteDirectory('private/reports/BIG5_OCEAN/'.$this->attemptId);
+        Storage::disk('local')->deleteDirectory('artifacts/reports/MBTI/'.$this->attemptId);
+        Storage::disk('local')->deleteDirectory('artifacts/pdf/BIG5_OCEAN/'.$this->attemptId);
+
+        $currentPlans = glob(storage_path('app/private/migration_plans/*.json')) ?: [];
+        $newPlans = array_diff($currentPlans, $this->preExistingPlans);
+        foreach ($newPlans as $planPath) {
+            if (is_file($planPath)) {
+                @unlink($planPath);
+            }
+        }
+
+        parent::tearDown();
+    }
+
+    public function test_dry_run_and_execute_copy_legacy_artifacts_to_canonical_paths(): void
+    {
+        $this->artisan('storage:migrate-legacy-artifacts --dry-run')->assertExitCode(0);
+
+        $currentPlans = glob(storage_path('app/private/migration_plans/*.json')) ?: [];
+        $newPlans = array_values(array_diff($currentPlans, $this->preExistingPlans));
+        $this->assertNotSame([], $newPlans, 'expected one migration plan.');
+        usort($newPlans, static fn (string $a, string $b): int => filemtime($a) <=> filemtime($b));
+        $latestPlan = (string) end($newPlans);
+        $this->assertFileExists($latestPlan);
+
+        $plan = json_decode((string) file_get_contents($latestPlan), true);
+        $this->assertIsArray($plan);
+        $this->assertSame('storage_migrate_legacy_artifacts.v1', (string) ($plan['schema'] ?? ''));
+
+        $this->artisan('storage:migrate-legacy-artifacts --execute --plan='.$latestPlan)->assertExitCode(0);
+
+        $this->assertTrue(Storage::disk('local')->exists("artifacts/reports/MBTI/{$this->attemptId}/report.json"));
+        $this->assertTrue(Storage::disk('local')->exists("artifacts/pdf/BIG5_OCEAN/{$this->attemptId}/legacyhash/report_free.pdf"));
+
+        // migrate command is copy-only during compatibility window.
+        $this->assertTrue(Storage::disk('local')->exists("reports/{$this->attemptId}/report.json"));
+        $this->assertTrue(Storage::disk('local')->exists("private/reports/BIG5_OCEAN/{$this->attemptId}/legacyhash/report_free.pdf"));
+
+        $auditCount = DB::table('audit_logs')
+            ->where('action', 'storage_migrate_legacy_artifacts')
+            ->count();
+        $this->assertGreaterThanOrEqual(1, $auditCount);
+    }
+}

--- a/backend/tests/Feature/Storage/StoragePruneReleaseRetentionTest.php
+++ b/backend/tests/Feature/Storage/StoragePruneReleaseRetentionTest.php
@@ -1,0 +1,81 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Storage;
+
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\File;
+use Illuminate\Support\Facades\Storage;
+use Tests\TestCase;
+
+final class StoragePruneReleaseRetentionTest extends TestCase
+{
+    use RefreshDatabase;
+
+    /** @var list<string> */
+    private array $preExistingPlans = [];
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        File::ensureDirectoryExists(storage_path('app/private/prune_plans'));
+        $this->preExistingPlans = glob(storage_path('app/private/prune_plans/*.json')) ?: [];
+    }
+
+    protected function tearDown(): void
+    {
+        Storage::disk('local')->deleteDirectory('content_releases/release_new');
+        Storage::disk('local')->deleteDirectory('content_releases/release_old');
+
+        $currentPlans = glob(storage_path('app/private/prune_plans/*.json')) ?: [];
+        $newPlans = array_diff($currentPlans, $this->preExistingPlans);
+        foreach ($newPlans as $planPath) {
+            if (is_file($planPath)) {
+                @unlink($planPath);
+            }
+        }
+
+        parent::tearDown();
+    }
+
+    public function test_content_releases_retention_prunes_old_releases_with_plan_and_audit(): void
+    {
+        config()->set('storage_retention.content_releases.keep_last_n', 1);
+        config()->set('storage_retention.content_releases.keep_days', 180);
+
+        Storage::disk('local')->put('content_releases/release_new/source_pack/compiled/manifest.json', '{"new":true}');
+        Storage::disk('local')->put('content_releases/release_old/source_pack/compiled/manifest.json', '{"old":true}');
+
+        $newDir = storage_path('app/private/content_releases/release_new');
+        $oldDir = storage_path('app/private/content_releases/release_old');
+        $oldTs = now()->subDays(240)->getTimestamp();
+        $newTs = now()->subDays(1)->getTimestamp();
+        @touch($oldDir, $oldTs);
+        @touch($newDir, $newTs);
+
+        $this->artisan('storage:prune --dry-run --scope=content_releases_retention')
+            ->assertExitCode(0);
+
+        $currentPlans = glob(storage_path('app/private/prune_plans/*.json')) ?: [];
+        $newPlans = array_values(array_diff($currentPlans, $this->preExistingPlans));
+        $this->assertNotSame([], $newPlans, 'expected at least one generated prune plan.');
+        usort($newPlans, static fn (string $a, string $b): int => filemtime($a) <=> filemtime($b));
+        $latestPlan = (string) end($newPlans);
+        $this->assertFileExists($latestPlan);
+
+        $this->artisan('storage:prune --execute --scope=content_releases_retention --plan='.$latestPlan)
+            ->assertExitCode(0);
+
+        $this->assertTrue(Storage::disk('local')->exists('content_releases/release_new/source_pack/compiled/manifest.json'));
+        $this->assertFalse(Storage::disk('local')->exists('content_releases/release_old/source_pack/compiled/manifest.json'));
+
+        $audit = DB::table('audit_logs')
+            ->where('action', 'storage_prune')
+            ->where('target_id', 'content_releases_retention')
+            ->exists();
+        $this->assertTrue($audit, 'expected storage_prune audit log for content_releases_retention');
+    }
+}

--- a/backend/tests/Unit/Content/ContentPackV2ResolverPathFallbackTest.php
+++ b/backend/tests/Unit/Content/ContentPackV2ResolverPathFallbackTest.php
@@ -1,0 +1,66 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Content;
+
+use App\Services\Content\ContentPackV2Resolver;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\File;
+use Illuminate\Support\Str;
+use Tests\TestCase;
+
+final class ContentPackV2ResolverPathFallbackTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_resolver_falls_back_to_mirror_path_when_primary_missing(): void
+    {
+        $releaseId = (string) Str::uuid();
+        $manifestHash = 'resolver_fallback_hash';
+        $primaryStoragePath = 'private/packs_v2/BIG5_OCEAN/v1/'.$releaseId;
+        $mirrorStoragePath = 'content_packs_v2/BIG5_OCEAN/v1/'.$releaseId;
+
+        DB::table('content_pack_releases')->insert([
+            'id' => $releaseId,
+            'action' => 'packs2_publish',
+            'region' => 'GLOBAL',
+            'locale' => 'global',
+            'dir_alias' => 'v1',
+            'from_version_id' => null,
+            'to_version_id' => null,
+            'from_pack_id' => null,
+            'to_pack_id' => 'BIG5_OCEAN',
+            'status' => 'success',
+            'message' => 'test',
+            'created_by' => 'test',
+            'manifest_hash' => $manifestHash,
+            'compiled_hash' => $manifestHash,
+            'content_hash' => null,
+            'norms_version' => null,
+            'git_sha' => null,
+            'pack_version' => 'v1',
+            'manifest_json' => json_encode(['compiled_hash' => $manifestHash], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES),
+            'storage_path' => $primaryStoragePath,
+            'source_commit' => null,
+            'created_at' => now(),
+            'updated_at' => now(),
+        ]);
+
+        $mirrorCompiledDir = storage_path('app/'.$mirrorStoragePath.'/compiled');
+        File::ensureDirectoryExists($mirrorCompiledDir);
+        File::put($mirrorCompiledDir.'/manifest.json', json_encode([
+            'compiled_hash' => $manifestHash,
+        ], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES));
+
+        /** @var ContentPackV2Resolver $resolver */
+        $resolver = app(ContentPackV2Resolver::class);
+        $resolved = $resolver->resolveCompiledPathByManifestHash('BIG5_OCEAN', 'v1', $manifestHash);
+
+        $this->assertSame($mirrorCompiledDir, $resolved);
+
+        File::deleteDirectory(storage_path('app/private/packs_v2/BIG5_OCEAN/v1/'.$releaseId));
+        File::deleteDirectory(storage_path('app/content_packs_v2/BIG5_OCEAN/v1/'.$releaseId));
+    }
+}


### PR DESCRIPTION
## Summary
- Implemented PR-STORAGE-01/02/03 rollout in one branch for storage governance with compatibility safeguards.
- Added canonical artifact storage abstraction and switched report/pdf persistence to canonical paths.
- Added legacy read fallback and copy-only migration command to avoid runtime breakage.
- Expanded storage pruning with scopes/strategy, retention policy config, inventory command, and audit logging.
- Added packs2 dual-write (`private/packs_v2` primary + `content_packs_v2` mirror) and resolver fallback between both roots.
- Updated release packaging blacklist to exclude both packs2 roots.

## Key Changes
- `ArtifactStore` for canonical/legacy report+pdf paths and fallback reads.
- `ReportPersistence` + `GenerateReportJob` write canonical-only report JSON (stop timestamp backup writes).
- `ReportPdfArtifactStore` + `ReportPdfDocumentService` now do canonical-first + legacy fallback + backfill.
- `LegacyReportService` reads report via `ArtifactStore` fallback chain.
- New command: `storage:migrate-legacy-artifacts` (dry-run/execute/plan/limit, copy-only, audit entries).
- New command: `storage:inventory` (scope/files/bytes/mtime/top_dirs + `audit_logs`).
- `storage:prune` now supports:
  - `reports_backups` (strict/broad; broad dry-run only),
  - `content_releases_retention` (`keep_last_n + keep_days`),
  - `legacy_private_private_cleanup` (delete only when canonical exists),
  - execute-mode audit logging.
- Added retention config: `config/storage_retention.php`.
- Added schedule entries for storage prune/inventory (in effective Laravel 11 bootstrap schedule path).
- `ContentPackV2Publisher` dual writes compiled artifacts; DB primary path points to `private/packs_v2/.../<release_id>`.
- `ContentPackV2Resolver` supports path fallback mapping between `private/packs_v2/...` and `content_packs_v2/...`.

## Tests Run
```bash
cd backend
php artisan route:list
php artisan migrate
php artisan test --filter ReportPersistenceStopsTimestampBackupsTest
php artisan test --filter ArtifactStoreReadCompatibilityTest
php artisan test --filter StorageMigrateLegacyArtifactsCommandTest
php artisan test --filter ReportPdfCrossScaleDeliveryTest
php artisan test --filter StorageInventoryCommandTest
php artisan test --filter StoragePruneReleaseRetentionTest
php artisan test --filter Packs2DualWritePublishTest
php artisan test --filter ContentPackV2ResolverPathFallbackTest
php artisan test --filter StoragePruneDoesNotDeleteCanonicalTest
php artisan storage:migrate-legacy-artifacts --dry-run
php artisan storage:inventory --json
php artisan storage:prune --dry-run --scope=reports_backups --strategy=strict
php artisan storage:prune --dry-run --scope=content_releases_retention
php artisan schedule:list
bash scripts/ci_verify_mbti.sh
