### PR TITLE
docs(ops): add storage cleanup wave3 execution report

### DIFF
--- a/docs/04-ops/storage_cleanup_wave3_report_2026-02-24.md
+++ b/docs/04-ops/storage_cleanup_wave3_report_2026-02-24.md
@@ -1,0 +1,46 @@
+# Storage Cleanup Wave 3 Report (2026-02-24)
+
+## Scope
+- Environment: local development workspace
+- Target: `/Users/rainie/Desktop/GitHub/fap-api/backend/storage`
+- Policy: `local_convergence_2.0`
+- Backup policy: remove `current_pack`, keep `previous_pack`
+
+## Executed Actions
+1. Generated pre-clean snapshot:
+   - `backend/artifacts/storage_cleanup_wave3_before.json`
+2. Deleted plan files:
+   - `backend/storage/app/private/prune_plans/*.json`
+   - `backend/storage/app/private/migration_plans/*.json`
+3. Deleted legacy backup transient copies:
+   - `backend/storage/app/private/content_releases/backups/*/current_pack/**`
+4. Deleted test archive payload:
+   - `backend/storage/app/archives/pr21-test/**`
+5. Deleted empty directories under `backend/storage`
+6. Generated post-clean snapshot:
+   - `backend/artifacts/storage_cleanup_wave3_after.json`
+
+## Before/After Metrics
+- Storage total size: `201M -> 124M` (about `-77M`)
+- Storage files: `3886 -> 2649`
+- `current_pack` directories: `43 -> 0`
+- `previous_pack` directories: `47` (preserved)
+- `prune_plans` json: `10 -> 0`
+- `migration_plans` json: `1 -> 0`
+- `archives/pr21-test` files: `114 -> 0`
+- Empty dirs under storage: `482 -> 0`
+
+## Post-Cleanup Inventory (high level)
+- `backend/storage/app/private/artifacts`: about `22M`
+- `backend/storage/app/private/content_releases`: about `101M`
+- `backend/storage/app/private/content_releases/backups`: about `81M`
+
+## Validation
+- `php artisan route:list` passed (`122` routes)
+- `php artisan migrate` passed (`Nothing to migrate`)
+- `bash backend/scripts/ci_verify_mbti.sh` passed
+
+## Risk Notes
+- Legacy rollback chain still has `previous_pack` evidence.
+- Deleting `current_pack` removes transient rollback-side snapshots only.
+- No source code paths or DB schema were changed.


### PR DESCRIPTION
## Summary
Add a tracked ops report for Storage Cleanup Wave 3 (2026-02-24), documenting executed actions, before/after metrics, validation commands, and risk notes.

## What changed
- Added wave3 execution report:
  - `/Users/rainie/Desktop/GitHub/fap-api/docs/04-ops/storage_cleanup_wave3_report_2026-02-24.md`
- No runtime code changes
- No API contract changes
- No schema changes

## Recorded outcomes
- storage size: `201M -> 124M`
- storage files: `3886 -> 2649`
- `current_pack`: `43 -> 0`
- `previous_pack`: kept (`47`)
- plan json files cleared
- test archive `pr21-test` removed

## Validation
- `php artisan route:list` passed
- `php artisan migrate` passed (`Nothing to migrate`)
- `bash /Users/rainie/Desktop/GitHub/fap-api/backend/scripts/ci_verify_mbti.sh` passed

## Risk
- Keeps legacy rollback evidence in `previous_pack`
- Removes transient `current_pack` only
