### PR TITLE
docs(research): 新增 2026-02-25 双仓库深度研究报告包

### DIFF
--- a/research/deep-research-2026-02-25/FAP_双仓库深度研究主报告_2026-02-25.md
+++ b/research/deep-research-2026-02-25/FAP_双仓库深度研究主报告_2026-02-25.md
@@ -870,7 +870,7 @@ curl -X PUT "http://127.0.0.1:1827/api/v0.3/attempts/{attempt_id}/progress" \
 ```bash
 curl -X POST "http://127.0.0.1:1827/api/v0.3/attempts/submit" \
   -H "Content-Type: application/json" \
-  -H "Authorization: Bearer fm_xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx" \
+  -H "Authorization: Bearer <FM_TOKEN>" \
   -H "X-Anon-Id: anon_demo_001" \
   -d '{
     "attempt_id": "{attempt_id}",
@@ -886,7 +886,7 @@ curl -X POST "http://127.0.0.1:1827/api/v0.3/attempts/submit" \
 
 ```bash
 curl "http://127.0.0.1:1827/api/v0.3/attempts/{attempt_id}/report" \
-  -H "Authorization: Bearer fm_xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx" \
+  -H "Authorization: Bearer <FM_TOKEN>" \
   -H "X-Anon-Id: anon_demo_001"
 ```
 
@@ -895,7 +895,7 @@ curl "http://127.0.0.1:1827/api/v0.3/attempts/{attempt_id}/report" \
 ```bash
 curl -X POST "http://127.0.0.1:1827/api/v0.3/orders/checkout" \
   -H "Content-Type: application/json" \
-  -H "Authorization: Bearer fm_xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx" \
+  -H "Authorization: Bearer <FM_TOKEN>" \
   -H "Idempotency-Key: chk_{attempt_id}_big5" \
   -H "X-Anon-Id: anon_demo_001" \
   -d '{"attempt_id":"{attempt_id}","sku":"BIG5_UNLOCK"}'

--- a/research/deep-research-2026-02-25/FAP_双仓库深度研究主报告_2026-02-25.md
+++ b/research/deep-research-2026-02-25/FAP_双仓库深度研究主报告_2026-02-25.md
@@ -1,0 +1,1940 @@
+# FAP 双仓库深度研究主报告（超深版）
+
+- 报告版本：v2.0（扩写版）
+- 研究日期：2026-02-25（UTC+8）
+- 研究对象：`/Users/rainie/Desktop/GitHub/fap-api` + `/Users/rainie/Desktop/GitHub/fap-web`
+- 对标对象：Truity、16Personalities、123test
+- 报告定位：长期稳定运营级（产品 + 工程 + 商业化 + 合规 + 增长）深度诊断与执行路线图
+- 证据体系：P0（代码/脚本/命令/测试）> P1（仓库文档）> P2（外部公开资料）
+
+---
+
+## 0. 结论先行（给管理层与负责人先看）
+
+### 0.1 一句话判断
+
+FAP 当前已经不是“能跑起来”的测评项目，而是接近“可长期运营”的平台雏形：在身份注入、组织隔离、作答幂等、支付幂等、报告快照异步化、CI 主链门禁上具备明显工程化优势；真正的核心差距不在功能可用性，而在“规模化运营资产沉淀速度”与“契约治理系统化程度”。
+
+### 0.2 经营视角判断
+
+1. 从业务闭环看：`landing/test -> take -> submit -> result -> pay -> unlock -> report/pdf/share -> resend/lookup` 已形成闭环，且有真实验收脚本覆盖。
+2. 从营收可靠性看：支付 Webhook 已实现“锁 + 事务 + 去重 + 状态机 + 后置履约 + 异步快照”链式防护，具备抗重复投递与抗乱序的基础能力。
+3. 从技术债风险看：系统并非“代码少、能力弱”，而是“能力强、复杂度高”，复杂度主要集中在 `AttemptSubmitService`、`PaymentWebhookHandlerCore`、`ReportGatekeeper`、`SelfCheckContentEngineCore` 等超大文件与多代兼容路径并存。
+4. 从战略短板看：公开方法学、品牌信任资产、SEO 工厂化、B2B 产品化、合规叙事外化，仍明显落后于 Truity / 16Personalities / 123test 的长期运营层级。
+
+### 0.3 综合评分（100）
+
+| 维度 | 权重 | 得分 | 核心判断 |
+|---|---:|---:|---|
+| 产品闭环与转化设计 | 20 | 16 | 闭环完整，跨量表一致性与漏斗精细化仍需增强 |
+| 量表/内容与解释系统 | 20 | 17 | 内容包机制成熟，公开方法学资产不足 |
+| 商业化与支付履约 | 15 | 13 | 幂等与履约较强，支付体验产品化可再提升 |
+| 工程可靠性与可扩展性 | 20 | 18 | CI 主链扎实，复杂度与耦合需要持续治理 |
+| 安全与合规 | 15 | 12 | 安全边界较好，外部合规页面/制度化仍有缺口 |
+| 增长/SEO/留存运营 | 10 | 7 | 基建具备，规模化增长资产沉淀不足 |
+| **总分** | **100** | **83** | **稳定运营雏形，距头部仍有 1~2 个阶段** |
+
+### 0.4 关键建议总纲（执行导向）
+
+1. 把“契约治理”提升到第一优先级：错误包统一、状态协议统一、shared schema 生成类型、route spec 自动导出。
+2. 把“支付后履约可观测”提升到 SLO 级：checkout->paid->unlock->snapshot_ready 全链路可追踪、可报警、可复盘。
+3. 把“复杂度治理”作为 180 天主线工程：拆分 webhook / submit 超大服务，建立边界测试与行为等价护栏。
+4. 把“信任资产公开化”作为增长战略的先导：方法学页、限制声明、隐私与用途边界、可访问性声明、版本日志公开。
+5. 把“增长工程化”从一次性动作升级为流水线：模板化 SEO、结构化数据、内容节奏、漏斗实验、留存触达。
+
+---
+
+## 1. 研究目标、边界与方法
+
+### 1.1 研究目标
+
+本次研究不是代码审美评审，也不是简单列问题，而是回答以下经营与工程联合问题：
+
+1. 当前双仓库是否具备“长期稳定运营能力”。
+2. 现有体系与 Truity/16Personalities/123test 的差距本质是什么。
+3. 哪些改造项最具 ROI，如何按 90/180 天落地，如何验证是否真的提升。
+
+### 1.2 研究边界
+
+1. `fap-api/backend/*`：路由、中间件、控制器、服务、迁移、脚本、测试、配置、文档。
+2. `fap-web/*`：页面路由、take/result/orders 主链、API 客户端、埋点、同意机制、发布脚本、测试。
+3. 外部对标采用公开页面，不包含私有经营数据。
+
+### 1.3 证据与结论规则
+
+1. 高风险结论必须至少两条独立证据。
+2. 涉及稳定性/安全/营收链路的结论必须可复现实验或命令。
+3. 外部证据全部标注抓取日期（2026-02-25）。
+4. 结论权重：P0 > P1 > P2；P2 仅作映射，不替代本地代码事实。
+
+### 1.4 本轮关键命令实跑摘要（P0）
+
+1. `php artisan route:list`：共 122 条路由，`/api/v0.3` 主业务，`/api/v0.4` 组织评估扩展，`/api/v0.2` 统一 410 退役兜底。
+2. `php artisan migrate`：`Nothing to migrate`，当前迁移状态一致。
+3. `bash scripts/ci_verify_mbti.sh`：完整通过（退出码 0），包含 DB 初始化、内容门禁、MBTI E2E、事件验收、迁移安全、webhook/attempt 回归门禁。
+4. `pnpm test:contract`（fap-web）：12 tests 通过。
+5. `pnpm test:a11y`（fap-web）：5 tests 通过。
+
+---
+
+## 2. 双仓库总体架构与协作模型
+
+### 2.1 协作边界
+
+根据 web 仓库文档，当前架构明确采用“前后端职责切分”模型：
+
+1. `fap-web` 负责 SEO 页面渲染、内容展示、运营体验、路由编排、埋点采集入口。
+2. `fap-api` 负责测评业务权威判定：出题、提交、评分、报告生成、支付履约、权益发放、事件入库。
+3. 协作契约主干为 `/api/v0.3/*`。
+
+这种切分是正确方向。风险点不在边界定义，而在“边界是否持续同步”：只要 API 契约与前端类型漂移，长期成本会指数化上升。
+
+### 2.2 规模指标（2026-02-25 实测）
+
+#### fap-api
+
+1. `backend` 代码体量显著，服务域广：Assessment/Attempts/Commerce/Content/Report/Rules/Overrides 等并存。
+2. migrations：147 个，说明演进频繁且长期维护。
+3. 测试：285 个 php 测试文件，Feature 覆盖明显高于 Unit，符合业务平台项目特征。
+4. 核心脚本：`ci_verify_mbti.sh`、`verify_mbti.sh`、`security_gate.sh`、大量 `prXX_verify` 验收脚本。
+
+#### fap-web
+
+1. `app` 页面与 `lib` 客户端并重，属于“运营站 + 应用站”混合形态。
+2. tests 分层：`e2e` + `contracts` + `a11y`。
+3. 前端大文件主要集中在 take/result 交互页和 API 契约文件，符合产品现状。
+
+### 2.3 架构成熟度判断
+
+成熟度不是由“是否微服务”决定，而由“关键风险是否可控”决定。以该标准评估，FAP 当前成熟度体现在：
+
+1. 关键写入链路（submit/webhook）具备幂等与锁保护。
+2. 关键读链路（report）具备门禁与异步快照状态机。
+3. 关键运维链路具备 CI 主链与脚本化验收。
+4. 关键产品链路具备前端降级与恢复策略。
+
+不足在于：治理层（契约统一、复杂度拆分、公开信任资产）仍偏“项目驱动”，尚未完全制度化。
+
+---
+
+## 3. fap-api 深度解剖
+
+## 3.1 路由与版本治理
+
+`backend/routes/api.php` 是系统事实入口，呈现出三层版本策略：
+
+1. `v0.2`：统一 `410 API_VERSION_DEPRECATED`。
+2. `v0.3`：当前主业务域（attempts/orders/scales/shares/orgs/webhooks）。
+3. `v0.4`：组织评估场景扩展（assessments）。
+
+关键观察：
+
+1. Webhook 被明确作为“公共入口”独立于 token/org context，避免误耦合导致支付回调不可达。
+2. submit 路由强制走 `FmTokenAuth`，而 start/progress 在匿名链路可运行，符合漏斗设计。
+3. org 管理能力放在 token+org context+role middleware 下，隔离策略明确。
+
+风险与建议：
+
+1. 路由定义清晰，但文档容易漂移；应强制 route spec 自动导出并 CI diff。
+2. v0.3/v0.4 并行时，需要统一错误包与 request_id 约束，降低跨版本前端分支复杂度。
+
+## 3.2 鉴权与上下文注入
+
+### 3.2.1 FmTokenAuth 的安全增益
+
+当前实现并非仅验证 token 字符串，而是执行完整注入链：
+
+1. Bearer 格式 + `fm_uuid` 正则校验。
+2. `token_hash` 查询优先，兼容 legacy `token` 并自动回填 hash。
+3. revoked/expired 拒绝。
+4. 注入 `fm_user_id` 和 `user_id`。
+5. 注入后执行 `assertInjectedUserIdentity` 防回归。
+6. 注入 `org_id/org_role/anon_id` 并绑定 `OrgContext`。
+
+这条链路的工程价值在于：
+
+1. 将“身份真相”从业务层上移到中间件层。
+2. 把“错误身份”尽早拒绝，防止业务层出现隐式绕过。
+3. 注入后一致性断言可有效阻断历史回归。
+
+### 3.2.2 Optional Token 的产品价值
+
+`FmTokenOptional` 允许匿名请求继续执行，但若带 token 则增强上下文，这对以下页面至关重要：
+
+1. share 访问与点击上报。
+2. 弱登录状态下的内容页行为统计。
+3. 多来源流量下的渐进身份绑定。
+
+### 3.2.3 ResolveOrgContext 的组织隔离价值
+
+`ResolveOrgContext` 把 header/query/token/attr 的 org 解析统一化，关键好处：
+
+1. 组织隔离逻辑集中，不分散到每个 controller。
+2. 成员角色从 membership service 获取，避免前端自报角色。
+3. admin/system 与 public/member 路径分离，便于做最小权限。
+
+## 3.3 Attempt 生命周期（start/progress/submit）
+
+### 3.3.1 Start：把业务风险前置
+
+`AttemptStartService` 实际承担风控入口而非“建记录”动作：
+
+1. rollout gate：支持按量表开关与灰度。
+2. Big5 retake policy：冷却 + 30 天次数限制。
+3. CLINICAL/SDS consent 版本哈希校验。
+4. 解析 question_count、pack version、manifest hash 写入快照。
+5. 自动创建 draft token（恢复能力）。
+6. 记录事件与 telemetry。
+
+这意味着“是否允许开始测评”已是运营策略控制点。
+
+### 3.3.2 Progress：弱网与恢复设计
+
+`AttemptProgressService` 体现了移动端友好度：
+
+1. `attempt_drafts` + cache 双存储。
+2. `seq` 防乱序。
+3. owner/resume token 双重访问控制。
+4. 过期返回 410 `RESUME_EXPIRED`。
+
+建议：对 progress 还可补“冲突可视化指标”，例如 `seq_out_of_order_rate`。
+
+### 3.3.3 Submit：核心复杂链路
+
+`AttemptSubmitService` 当前是高风险复杂点，同时也是能力中枢：
+
+1. ownership query + org scope。
+2. consent on submit 二次校验（临床/抑郁量表）。
+3. merge draft + request answers。
+4. digest 幂等冲突处理：相同 digest 幂等、不同 digest 409。
+5. transaction + `lockForUpdate`。
+6. 评分、version snapshot、quality/norm snapshot 写入。
+7. post-commit side effects。
+8. `GenerateReportSnapshotJob->afterCommit()`。
+
+评估：该服务将业务正确性托底做得较强，但维护成本偏高，建议 180 天内拆分成：
+
+1. `SubmitOwnershipGuard`
+2. `SubmitInputCanonicalizer`
+3. `SubmitScoringOrchestrator`
+4. `SubmitPersistenceTx`
+5. `SubmitPostCommitDispatcher`
+
+并以“行为等价测试 + contract golden”保障拆分安全。
+
+## 3.4 报告门禁与异步快照
+
+### 3.4.1 Gatekeeper 的平台价值
+
+`ReportGatekeeper` 统一控制：
+
+1. entitlement 判断。
+2. `locked/free/full` 变体。
+3. modules_allowed/offered/preview。
+4. crisis 情况下 offers 清空（避免不当商业化）。
+5. snapshot pending/failed/ready 状态转译给前端。
+
+### 3.4.2 Snapshot 状态机
+
+`ReportSnapshotStore` + `GenerateReportSnapshotJob` 实现：
+
+1. `seed_pending`：支付后立即可见“生成中”状态。
+2. `ready`：完整快照可读。
+3. `failed`：保留 `last_error` + backoff 重试。
+
+设计收益：
+
+1. submit 和 webhook 写链路低延迟化。
+2. report 读取链路更稳定。
+3. 可用显式状态做前端友好提示。
+
+建议增强：
+
+1. 对外返回 `schema_version`、`generated_at`，强化前端缓存与兼容。
+2. 给 `retry_after_seconds` 加统一语义约束文档。
+
+## 3.5 商业化与支付履约
+
+### 3.5.1 订单层
+
+`OrderManager` 已具备：
+
+1. provider scoped idempotency。
+2. order status transition 原子化。
+3. ownership read 防越权。
+4. paid/fulfilled/refund 状态语义。
+
+### 3.5.2 Webhook 层
+
+`PaymentWebhookHandlerCore` 关键防护较完整：
+
+1. `Cache::lock` 控并发。
+2. 事务内 `insertOrIgnore` 事件去重。
+3. `provider + provider_event_id` 唯一处理。
+4. signature guard。
+5. provider mismatch 拒绝。
+6. paid/refund 路径分流。
+7. report_unlock 时 owner/scale 校验后发放权益。
+8. post-commit 事件、钱包、快照、PDF、通知。
+
+风险与改造重点：
+
+1. 文件超大，变更回归成本高。
+2. 推荐按 `precheck -> order transition -> entitlement -> post-commit` 拆层。
+3. 强化“重放仿真测试集”，覆盖乱序/重复/签名失败/跨 provider 冲突。
+
+## 3.6 数据层与迁移演进
+
+147 条迁移显示系统高速演化，优点是持续迭代，风险是迁移治理复杂。当前优点：
+
+1. migration safety tests 较完善。
+2. 具备 schema baseline verify。
+3. 关键表索引与约束在持续补齐。
+
+建议：
+
+1. 建立迁移冷热分级与窗口制度。
+2. 热表变更必须附性能回归证据。
+3. 迁移审计看板化（失败率、回滚耗时、热点表冲击）。
+
+## 3.7 测试与脚本体系
+
+从仓库事实看，fap-api 并非“单测驱动”，而是“验收脚本 + feature 回归 + SRE gate”混合体系：
+
+1. `ci_verify_mbti.sh` 作为主链。
+2. `verify_mbti.sh` 作为链路验收。
+3. payment/attempt/migration/security 多专项 gate。
+4. test 目录覆盖 commerce/content/v0_3/v0_4/psychometrics。
+
+优点：贴近业务真实风险；不足：脚本数量多、认知成本高。建议做脚本分层索引与统一入口。
+
+---
+
+## 4. fap-web 深度解剖
+
+## 4.1 路由、中间件、noindex 策略
+
+### 4.1.1 敏感页保护
+
+`middleware.ts` 与 `next.config.mjs` 双重 noindex：
+
+1. `/result`、`/orders`、`/share`、`/api`、`/og`、take 页均打 noindex。
+2. 静态资源路径被排除，避免副作用。
+
+这对长期 SEO 质量与隐私保护都非常关键。
+
+### 4.1.2 匿名身份连续性
+
+中间件将 `x-anon-id` 与 cookie 协调，显著提升：
+
+1. 跨页面漏斗连续性。
+2. 匿名到登录转换的可追踪性。
+3. 后端 ownership 判定成功率。
+
+## 4.2 API 客户端与错误模型
+
+`lib/api-client.ts` 的优点：
+
+1. timeout + AbortController。
+2. locale 自动注入。
+3. token 自动注入。
+4. ApiError 结构化（status/errorCode/message/details/requestId）。
+
+建议：
+
+1. 与 API 错误 contract 完全对齐到 `code/message/details/request_id` 统一字段名。
+2. 将 fallback error code 映射抽成共享常量，避免页面间偏差。
+
+## 4.3 v0_3 契约层
+
+`lib/api/v0_3.ts` 集中定义了 questions/start/submit/report/order/share 等类型与调用，属于“契约聚合层”。
+
+优势：
+
+1. 前端主链基本经过统一调用层。
+2. `Idempotency-Key` 已在 checkout 入口支持。
+
+不足：
+
+1. 类型仍主要手写，易与后端漂移。
+2. 报告状态字段在多页面消费时存在命名差异风险。
+
+建议：
+
+1. 从 OpenAPI/JSON Schema 生成 TS 类型。
+2. 把 `pending/ready/failed/retry_after_seconds` 语义固化成单一枚举。
+
+## 4.4 Take 页面工程质量
+
+### 4.4.1 Big5TakeClient
+
+能力点：
+
+1. rollout 前置 gate。
+2. 问题加载失败分类上报。
+3. start 重试、429 处理。
+4. submit 前缺题拦截。
+5. submit 超时可重试。
+6. 分阶段 loading overlay + 埋点。
+
+这说明前端不是“提交按钮 + API 请求”粗糙实现，而是对弱网、异常和反馈节奏有细化设计。
+
+### 4.4.2 ClinicalTakeClient
+
+能力点：
+
+1. consent snapshot 必须存在才能提交。
+2. submit 成功后 session cache。
+3. submit/start 错误分类上报 + Sentry。
+4. submit overlay 相位埋点。
+
+## 4.5 Result/Order 页面稳定性
+
+### 4.5.1 ResultClient
+
+1. `generating` 轮询与退避。
+2. 报告加载失败上报与捕获。
+3. checkout 入口带 idempotency key。
+4. unlock 成功埋点与本地恢复。
+5. 临床量表与一般量表分流渲染。
+
+### 4.5.2 OrdersClient
+
+1. backoff 轮询数组 + 总超时。
+2. `paid` 自动跳转 result。
+3. 失败/取消/退款分支明确。
+4. 手动刷新与客服兜底。
+
+## 4.6 Tracking 与 Consent 边界
+
+`tracking/events.ts` + `/api/track` + `consent/store.ts` 组合具备以下优点：
+
+1. event whitelist 控字段。
+2. forbidden fragments 防敏感字段泄漏。
+3. payload 大小限制与 eventName 校验。
+4. consent 三态（unknown/granted/denied）本地持久化。
+
+建议：
+
+1. `denied` 时做更严格的“静默模式审计”，保证无旁路上报。
+2. 将事件 schema lint 纳入 pre-merge gate。
+
+## 4.7 发布治理
+
+`release_gate.sh` + checklist + rollback smoke 构成制度化发布能力：
+
+1. 禁止敏感文件/构建产物入库。
+2. 发布前必须 contract + e2e + UAT。
+3. 要求 10 分钟回滚演练。
+
+这是“长期运营稳定性”的关键特征，明显优于多数中小测评站点。
+
+---
+
+## 5. 端到端链路与状态机
+
+## 5.1 尝试生命周期状态机
+
+```mermaid
+stateDiagram-v2
+    [*] --> START_REQUESTED
+    START_REQUESTED --> STARTED: start ok
+    STARTED --> DRAFTING: progress upsert
+    DRAFTING --> DRAFTING: seq monotonic
+    DRAFTING --> SUBMITTING: submit
+    SUBMITTING --> SUBMITTED: tx commit
+    SUBMITTED --> SNAPSHOT_PENDING: seed pending
+    SNAPSHOT_PENDING --> SNAPSHOT_READY: async job success
+    SNAPSHOT_PENDING --> SNAPSHOT_FAILED: async job failed
+```
+
+关键防护点：
+
+1. `seq` 防乱序。
+2. submit digest 幂等。
+3. snapshot 异步化。
+4. report gatekeeper 对 pending/failed 的可解释状态反馈。
+
+## 5.2 支付履约状态机
+
+```mermaid
+stateDiagram-v2
+    [*] --> ORDER_CREATED
+    ORDER_CREATED --> ORDER_PAID: webhook success
+    ORDER_PAID --> ORDER_FULFILLED: entitlement/wallet ok
+    ORDER_PAID --> POST_COMMIT_FAILED: side effects fail
+    ORDER_FULFILLED --> SNAPSHOT_PENDING: report unlock
+    SNAPSHOT_PENDING --> SNAPSHOT_READY: snapshot job ok
+```
+
+关键风险点：
+
+1. `ORDER_PAID` 到 `SNAPSHOT_READY` 的时间窗口（用户感知最敏感）。
+2. post-commit 失败处理与补偿机制。
+
+建议 SLO：
+
+1. `checkout_success -> paid` p95。
+2. `paid -> unlock` p95。
+3. `unlock -> snapshot_ready` p95。
+
+## 5.3 前端体验状态机
+
+```mermaid
+stateDiagram-v2
+    [*] --> TAKE_LOADING
+    TAKE_LOADING --> TAKE_READY
+    TAKE_READY --> TAKE_SUBMITTING
+    TAKE_SUBMITTING --> RESULT_GENERATING
+    RESULT_GENERATING --> RESULT_READY
+    RESULT_READY --> PAYWALL_LOCKED
+    PAYWALL_LOCKED --> CHECKOUT
+    CHECKOUT --> ORDER_PENDING
+    ORDER_PENDING --> ORDER_PAID
+    ORDER_PAID --> RESULT_READY_FULL
+```
+
+建议：以状态机为中心统一文案、埋点和错误码映射，减少页面间行为漂移。
+
+---
+
+## 6. 内容包、量表引擎与报告体系
+
+## 6.1 内容包机制
+
+FAP 的核心竞争力之一是内容包（pack）机制，它将：
+
+1. 题目。
+2. 规则。
+3. 报告模板。
+4. 常模/质量策略。
+5. SEO/landing 元信息。
+
+统一纳入可版本化资产。
+
+这使系统具备“多量表扩展”能力，而非仅 MBTI 单点实现。
+
+## 6.2 常模与质量
+
+从 Big5/SDS/EQ/Clinical 代码与测试可见，系统已经建立：
+
+1. norm version snapshot。
+2. quality level 输出。
+3. crisis alert 与商业化隔离。
+
+下一步建议：
+
+1. 对外公开方法页：版本、样本、限制、更新日志。
+2. 对内固化 psychometrics gate：上线前必须通过质量阈值。
+
+## 6.3 报告生成
+
+报告体系具备以下特性：
+
+1. variant（free/full）分层。
+2. modules 级别可控。
+3. snapshot 缓存与异步生成。
+4. PDF 交付链路。
+
+建议增强：
+
+1. `report schema_version` 强约束。
+2. 生成时间与来源可追踪字段。
+3. 解释文案版本号与效果反馈闭环。
+
+---
+
+## 7. 商业化能力评估
+
+## 7.1 优势
+
+1. 幂等化设计深入订单和 webhook 主链。
+2. 订单 ownership 防越权。
+3. entitlement 发放前做 owner 与量表匹配校验。
+4. 退款反向处理链路存在测试覆盖。
+
+## 7.2 关键短板
+
+1. `Idempotency-Key` 未完全强制，仍存在边界重复请求风险。
+2. 支付完成后用户感知路径（pending->ready）仍有优化空间。
+3. 企业化商业能力尚未产品化（sandbox、developer docs、团队版方案）。
+
+## 7.3 经营级建议
+
+1. 必要强制：订单/checkout 必带 idempotency key。
+2. 可观测优先：建立支付履约漏斗看板与阈值告警。
+3. 转化提升：减少支付后等待焦虑（状态解释 + 主动通知 + 恢复入口）。
+
+---
+
+## 8. 稳定性、安全、合规与风控
+
+## 8.1 稳定性
+
+稳定性基础已较扎实：
+
+1. healthz + 依赖状态。
+2. queue runbook。
+3. rollback smoke runbook。
+4. CI 主链覆盖关键风险点。
+
+建议增加：
+
+1. SLO 明确化与错误预算制度。
+2. 统一 incident 分级与复盘模板。
+
+## 8.2 安全
+
+现状优势：
+
+1. token 注入防回归。
+2. org isolation 中间件。
+3. webhook signature + provider mismatch guard。
+4. tracking 白名单 + payload 限制。
+
+高风险项：
+
+1. 巨型服务改动导致非预期权限/状态回归。
+2. 事件字段扩展时的敏感信息泄露风险。
+
+## 8.3 合规
+
+当前代码侧已体现“临床场景谨慎商业化”意识，但外部合规资产仍需强化：
+
+1. 非医疗、非招聘、非诊断边界声明需要网站公开统一。
+2. 数据生命周期与删除请求应可审计化。
+3. 可访问性声明建议补齐。
+
+---
+
+## 9. 可观测性、CI/CD 与运维机制
+
+## 9.1 可观测性
+
+API 文档已有 healthz、延迟、错误率、队列指标建议阈值。建议进一步经营化：
+
+1. 业务指标和技术指标同屏。
+2. 以 attempt/order 为主键串联日志、事件、告警。
+3. 发布版本标记自动注入观测系统。
+
+## 9.2 CI/CD
+
+FAP 目前 CI 更像“业务回归流水线”而不仅是 lint/test：
+
+1. 内容自检。
+2. MBTI 主链验收。
+3. 事件验收脚本。
+4. migration safety。
+5. webhook/attempt regression。
+
+建议：
+
+1. fast/slow 两级 pipeline，降低 PR 等待。
+2. 对 flaky case 建立隔离清单与治理目标。
+
+## 9.3 运维
+
+已有 go-live checklist、queue runbook、rollback drill，说明团队已进入制度化运营阶段。下一步建议：
+
+1. 建立值班轮值与月度演练 KPI。
+2. 把“演练记录”纳入发布门禁证据。
+
+---
+
+## 10. 对标研究（Truity / 16Personalities / 123test）
+
+> 抓取日期：2026-02-25（官方公开页面）
+
+## 10.1 Truity
+
+公开信号（官方页面）显示其长期运营特征：
+
+1. TypeFinder 明确题量与耗时（约 130 题、约 15 分钟）。
+2. 免费基础结果 + 付费深度报告的经典双层商业模型。
+3. About 页面公开长期用户规模（百万级）。
+4. 提供技术文档页面，公开方法与可靠性口径。
+5. 提供 API 兴趣入口，体现 B2B 产品化意图。
+
+对 FAP 启发：
+
+1. 不只是“有报告”，而是“有公开可信方法学”。
+2. 不只是“能卖”，而是“商业化规则与科学解释并存”。
+
+## 10.2 16Personalities
+
+公开信号：
+
+1. 语言与地区覆盖广，全球化资产明显。
+2. 条款中有用途边界（非医疗、非招聘决策）表达。
+3. 隐私与可访问性政策结构完整。
+4. 产品形态涵盖个人与团队方向。
+
+对 FAP 启发：
+
+1. 国际化不仅是翻译，而是政策、可访问性、用户边界的系统工程。
+2. “信任页面”本身就是增长资产。
+
+## 10.3 123test
+
+公开信号：
+
+1. 长期运营历史（早期成立 + 高完成量级）。
+2. 多测评矩阵与免费入口。
+3. 明确 B2B 能力（API/Online Assessment/White Label）。
+4. 对测试边界与免责声明表达明确。
+
+对 FAP 启发：
+
+1. 规模化收入往往来自 B2C + B2B 双轮。
+2. 多量表矩阵和稳定分发体系是持续增长关键。
+
+## 10.4 对标差距总结
+
+FAP 与头部差距的本质不是技术底盘，而是运营资产与公开信任系统：
+
+1. 公开方法学资产不足。
+2. 合规/用途边界页面体系不足。
+3. SEO 与内容分发工厂化不足。
+4. B2B 产品化与开发者入口不足。
+
+---
+
+## 11. 差距矩阵（能力-风险-投入-收益）
+
+| 差距项 | 当前状态 | 风险等级 | 投入 | 收益 | 优先级 |
+|---|---|---:|---:|---:|---:|
+| API 错误包统一 | 局部统一 | 高 | 中 | 高 | P0 |
+| 报告状态协议统一 | 前后端仍有差异 | 高 | 中 | 高 | P0 |
+| checkout 强制幂等键 | 部分入口支持 | 高 | 低 | 高 | P0 |
+| Webhook 核心拆分 | 巨型核心类 | 高 | 中高 | 高 | P0 |
+| Submit 服务拆分 | 巨型服务 | 高 | 中高 | 高 | P0 |
+| route spec 自动导出 | 缺系统化 | 中 | 低 | 高 | P1 |
+| shared schema codegen | 缺 | 中 | 中 | 高 | P1 |
+| 支付履约可观测看板 | 局部 | 中 | 中 | 高 | P1 |
+| 方法学公开中心 | 缺 | 中 | 中 | 高 | P1 |
+| 合规公开页面体系 | 部分 | 高 | 中 | 高 | P1 |
+| SEO 工厂化模板 | 部分文档 | 中 | 中 | 中高 | P1 |
+| B2B API 产品化 | 弱 | 中 | 中高 | 高 | P2 |
+
+---
+
+## 12. 改进清单（30+ 可执行项）
+
+### 12.1 契约与类型（10 项）
+
+1. 统一 API 错误包字段：`code/message/details/request_id`。
+2. 对 `/api/v0.3` 全路由执行错误包一致性测试。
+3. 报告状态字段统一：`pending/ready/failed/retry_after_seconds`。
+4. 报告响应增加 `schema_version`。
+5. 报告响应增加 `generated_at`。
+6. orders/checkout 强制 `Idempotency-Key`。
+7. webhook 事件标准字段统一：`provider_event_id/order_id/status/processed_at`。
+8. route spec 自动导出并纳入 CI。
+9. 从 schema 生成 TS 类型替换手写关键类型。
+10. 前后端状态枚举单源化。
+
+### 12.2 核心链路可靠性（8 项）
+
+11. 拆分 `PaymentWebhookHandlerCore`。
+12. 拆分 `AttemptSubmitService`。
+13. 增加 webhook 重放/乱序仿真集。
+14. 增加 submit 幂等冲突行为 golden tests。
+15. 建立 `unlock->snapshot_ready` SLO 告警。
+16. 把 post-commit failure 纳入重试补偿队列。
+17. 把 snapshot failed 的用户提示标准化。
+18. 加强 queue backlog 指标告警。
+
+### 12.3 安全与合规（7 项）
+
+19. tracking schema lint 阻断敏感字段。
+20. 合规页面统一（用途边界/非医疗/非招聘）。
+21. 数据删除请求全链路审计化。
+22. 建立季度隐私与安全审计节奏。
+23. 组织权限回归测试扩大到新增 API。
+24. 统一 request_id 透传规范。
+25. 可访问性声明页面上线并验收。
+
+### 12.4 增长与运营（7 项）
+
+26. 结构化数据模板化注入。
+27. landing canonical/noindex 规则 CI 检测。
+28. 漏斗看板（questions/start/submit/report/checkout/paid）。
+29. 支付后恢复路径优化（邮件+订单页+结果页联动）。
+30. 方法学公开中心上线。
+31. 量表版本日志公开。
+32. B2B landing + API sandbox + 询盘流程。
+
+### 12.5 组织与流程（4 项）
+
+33. 跨域 owner 机制（API/Web/Commerce/SRE）。
+34. 月度回滚演练 KPI 化。
+35. incident 复盘模板标准化。
+36. 技术债账本 + 里程碑关闭机制。
+
+---
+
+## 13. 90/180 天路线图（摘要版）
+
+### 13.1 90 天（稳态与契约）
+
+目标：减少线上不确定性和联调摩擦。
+
+1. 完成契约统一与 route spec gate。
+2. 强制关键幂等键。
+3. 上线支付履约链路看板。
+4. 完成 webhook/submit 拆分第一阶段。
+5. 发布最小合规公开页面。
+
+### 13.2 180 天（增长与平台化）
+
+目标：建立规模化增长与对外能力。
+
+1. 方法学公开中心 + 版本日志。
+2. SEO 工厂化 + 结构化数据流水线。
+3. B2B landing + sandbox + 询盘闭环。
+4. 国际化合规清单化。
+5. 经营看板（业务+技术）统一。
+
+---
+
+## 14. KPI 与验收标准
+
+## 14.1 技术 KPI
+
+1. submit 失败率（按状态组）。
+2. report generating 超时率。
+3. unlock->snapshot_ready p95。
+4. webhook 重复事件处理时延 p95。
+5. 契约漂移缺陷/月。
+6. CI 平均耗时与 flaky 率。
+
+## 14.2 业务 KPI
+
+1. 免费->付费转化。
+2. 订单完成率。
+3. 支付后流失率。
+4. 自然流量（非品牌）增长。
+5. 结果页二次访问与分享率。
+
+## 14.3 验收命令（最小集）
+
+```bash
+cd /Users/rainie/Desktop/GitHub/fap-api/backend
+php artisan route:list
+php artisan migrate
+bash scripts/ci_verify_mbti.sh
+
+cd /Users/rainie/Desktop/GitHub/fap-web
+pnpm test:contract
+pnpm test:a11y
+```
+
+## 14.4 关键 curl 场景（可直接复现）
+
+### 尝试开始
+
+```bash
+curl -X POST "http://127.0.0.1:1827/api/v0.3/attempts/start" \
+  -H "Content-Type: application/json" \
+  -H "X-FAP-Locale: zh-CN" \
+  -H "X-Anon-Id: anon_demo_001" \
+  -d '{
+    "scale_code": "BIG5_OCEAN",
+    "region": "CN_MAINLAND",
+    "locale": "zh-CN",
+    "client_platform": "web",
+    "client_version": "report-v2",
+    "channel": "web"
+  }'
+```
+
+### 进度保存
+
+```bash
+curl -X PUT "http://127.0.0.1:1827/api/v0.3/attempts/{attempt_id}/progress" \
+  -H "Content-Type: application/json" \
+  -H "X-Anon-Id: anon_demo_001" \
+  -d '{
+    "seq": 1,
+    "cursor": "q_10",
+    "duration_ms": 120000,
+    "answers": [
+      {"question_id":"Q1","code":"A"},
+      {"question_id":"Q2","code":"C"}
+    ]
+  }'
+```
+
+### 提交作答
+
+```bash
+curl -X POST "http://127.0.0.1:1827/api/v0.3/attempts/submit" \
+  -H "Content-Type: application/json" \
+  -H "Authorization: Bearer fm_xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx" \
+  -H "X-Anon-Id: anon_demo_001" \
+  -d '{
+    "attempt_id": "{attempt_id}",
+    "duration_ms": 300000,
+    "answers": [
+      {"question_id":"Q1","code":"A"},
+      {"question_id":"Q2","code":"C"}
+    ]
+  }'
+```
+
+### 获取报告
+
+```bash
+curl "http://127.0.0.1:1827/api/v0.3/attempts/{attempt_id}/report" \
+  -H "Authorization: Bearer fm_xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx" \
+  -H "X-Anon-Id: anon_demo_001"
+```
+
+### 创建订单与查单
+
+```bash
+curl -X POST "http://127.0.0.1:1827/api/v0.3/orders/checkout" \
+  -H "Content-Type: application/json" \
+  -H "Authorization: Bearer fm_xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx" \
+  -H "Idempotency-Key: chk_{attempt_id}_big5" \
+  -H "X-Anon-Id: anon_demo_001" \
+  -d '{"attempt_id":"{attempt_id}","sku":"BIG5_UNLOCK"}'
+
+curl "http://127.0.0.1:1827/api/v0.3/orders/{order_no}" \
+  -H "X-Anon-Id: anon_demo_001"
+```
+
+### Webhook 重放幂等验证
+
+```bash
+curl -X POST "http://127.0.0.1:1827/api/v0.3/webhooks/payment/stripe" \
+  -H "Content-Type: application/json" \
+  -d '{"provider_event_id":"evt_demo_001","order_no":"ord_demo_001","event_type":"payment_succeeded"}'
+
+# 重放同一 provider_event_id
+curl -X POST "http://127.0.0.1:1827/api/v0.3/webhooks/payment/stripe" \
+  -H "Content-Type: application/json" \
+  -d '{"provider_event_id":"evt_demo_001","order_no":"ord_demo_001","event_type":"payment_succeeded"}'
+```
+
+---
+
+## 15. 关键风险总览（摘要）
+
+> 详版见《风险登记册》独立文件。
+
+1. 契约漂移风险：多版本与手写类型并存。
+2. 超大服务风险：webhook/submit 复杂度高。
+3. 履约感知风险：支付后 ready 延迟影响体验。
+4. 合规叙事风险：外部边界说明不够体系化。
+5. 增长资产风险：SEO 与方法学公开不足。
+
+---
+
+## 16. 最终判断
+
+1. FAP 具备进入长期运营阶段的工程底盘。
+2. 当前主要矛盾已从“功能可用”转向“治理与规模化”。
+3. 若按本报告路线执行，6 个月内可显著缩小与头部平台在运营成熟度上的差距。
+4. 若不做治理，复杂度将成为未来增长与稳定性的主要阻力。
+
+---
+
+## 17. 外部参考链接（抓取日期：2026-02-25）
+
+### Truity
+
+1. https://www.truity.com/test/type-finder-personality-test-new
+2. https://www.truity.com/about-us
+3. https://www.truity.com/page/technical-documentation
+4. https://www.truity.com/test-api
+5. https://www.truity.com/privacy-policy
+
+### 16Personalities
+
+1. https://www.16personalities.com/free-personality-test
+2. https://www.16personalities.com/country-profiles
+3. https://www.16personalities.com/terms
+4. https://www.16personalities.com/terms/privacy
+5. https://www.16personalities.com/accessibility-statement
+
+### 123test
+
+1. https://www.123test.com/about/
+2. https://www.123test.com/personality-test/
+3. https://www.123test.com/using-our-tests/
+4. https://www.123test.com/disclaimer/
+
+
+---
+
+## 18. 附录A：API 路由全量盘点（122 条，P0）
+
+以下清单用于契约治理与回归基线，来源：`php artisan route:list --json`。
+
+| Method | URI | Name | Action |
+|---|---|---|---|
+|GET|HEAD|/||Closure|
+|GET|HEAD|POST|PUT|PATCH|DELETE|OPTIONS|admin||Illuminate\Routing\RedirectController|
+|GET|HEAD|admin/{path}||Closure|
+|GET|HEAD|api/healthz|healthz|App\Http\Controllers\HealthzController@show|
+|GET|HEAD|api/user||Closure|
+|GET|HEAD|POST|PUT|PATCH|DELETE|OPTIONS|api/v0.2/{any?}||Closure|
+|POST|api/v0.3/attempts/start||App\Http\Controllers\API\V0_3\AttemptWriteController@start|
+|POST|api/v0.3/attempts/submit||App\Http\Controllers\API\V0_3\AttemptWriteController@submit|
+|PUT|api/v0.3/attempts/{attempt_id}/progress||App\Http\Controllers\API\V0_3\AttemptProgressController@upsert|
+|GET|HEAD|api/v0.3/attempts/{attempt_id}/progress||App\Http\Controllers\API\V0_3\AttemptProgressController@show|
+|GET|HEAD|api/v0.3/attempts/{id}|api.v0_3.attempts.show|App\Http\Controllers\API\V0_3\AttemptReadController@show|
+|GET|HEAD|api/v0.3/attempts/{id}/report|api.v0_3.attempts.report|App\Http\Controllers\API\V0_3\AttemptReadController@report|
+|GET|HEAD|api/v0.3/attempts/{id}/report.pdf|api.v0_3.attempts.report_pdf|App\Http\Controllers\API\V0_3\AttemptReadController@reportPdf|
+|GET|HEAD|api/v0.3/attempts/{id}/result|api.v0_3.attempts.result|App\Http\Controllers\API\V0_3\AttemptReadController@result|
+|GET|HEAD|api/v0.3/attempts/{id}/share||App\Http\Controllers\API\V0_3\ShareController@getShare|
+|POST|api/v0.3/auth/phone/send_code||App\Http\Controllers\API\V0_3\AuthPhoneController@sendCode|
+|POST|api/v0.3/auth/phone/verify||App\Http\Controllers\API\V0_3\AuthPhoneController@verify|
+|POST|api/v0.3/auth/wx_phone||App\Http\Controllers\API\V0_3\AuthWxPhoneController|
+|GET|HEAD|api/v0.3/boot||App\Http\Controllers\API\V0_3\BootController@show|
+|GET|HEAD|api/v0.3/claim/report||App\Http\Controllers\API\V0_3\ClaimController@report|
+|GET|HEAD|api/v0.3/experiments||App\Http\Controllers\API\V0_3\BootController@experiments|
+|GET|HEAD|api/v0.3/flags||App\Http\Controllers\API\V0_3\BootController@flags|
+|GET|HEAD|api/v0.3/me/attempts||App\Http\Controllers\API\V0_3\MeController@attempts|
+|POST|api/v0.3/orders||App\Http\Controllers\API\V0_3\CommerceController@createOrder|
+|POST|api/v0.3/orders/checkout||App\Http\Controllers\API\V0_3\CommerceController@checkout|
+|POST|api/v0.3/orders/lookup||App\Http\Controllers\API\V0_3\CommerceController@lookup|
+|POST|api/v0.3/orders/stub||Closure|
+|GET|HEAD|api/v0.3/orders/{order_no}||App\Http\Controllers\API\V0_3\CommerceController@getOrder|
+|POST|api/v0.3/orders/{order_no}/resend||App\Http\Controllers\API\V0_3\CommerceController@resend|
+|POST|api/v0.3/orders/{provider}||App\Http\Controllers\API\V0_3\CommerceController@createOrder|
+|POST|api/v0.3/orgs||App\Http\Controllers\API\V0_3\OrgsController@store|
+|POST|api/v0.3/orgs/invites/accept||App\Http\Controllers\API\V0_3\OrgInvitesController@accept|
+|GET|HEAD|api/v0.3/orgs/me||App\Http\Controllers\API\V0_3\OrgsController@me|
+|GET|HEAD|api/v0.3/orgs/{org_id}/big5/audits||App\Http\Controllers\API\V0_3\BigFiveOpsController@audits|
+|GET|HEAD|api/v0.3/orgs/{org_id}/big5/audits/{audit_id}||App\Http\Controllers\API\V0_3\BigFiveOpsController@audit|
+|POST|api/v0.3/orgs/{org_id}/big5/norms/activate||App\Http\Controllers\API\V0_3\BigFiveOpsController@activateNorms|
+|POST|api/v0.3/orgs/{org_id}/big5/norms/drift-check||App\Http\Controllers\API\V0_3\BigFiveOpsController@driftCheckNorms|
+|POST|api/v0.3/orgs/{org_id}/big5/norms/rebuild||App\Http\Controllers\API\V0_3\BigFiveOpsController@rebuildNorms|
+|GET|HEAD|api/v0.3/orgs/{org_id}/big5/releases||App\Http\Controllers\API\V0_3\BigFiveOpsController@releases|
+|GET|HEAD|api/v0.3/orgs/{org_id}/big5/releases/latest||App\Http\Controllers\API\V0_3\BigFiveOpsController@latest|
+|GET|HEAD|api/v0.3/orgs/{org_id}/big5/releases/latest/audits||App\Http\Controllers\API\V0_3\BigFiveOpsController@latestAudits|
+|POST|api/v0.3/orgs/{org_id}/big5/releases/publish||App\Http\Controllers\API\V0_3\BigFiveOpsController@publish|
+|POST|api/v0.3/orgs/{org_id}/big5/releases/rollback||App\Http\Controllers\API\V0_3\BigFiveOpsController@rollback|
+|GET|HEAD|api/v0.3/orgs/{org_id}/big5/releases/{release_id}||App\Http\Controllers\API\V0_3\BigFiveOpsController@release|
+|POST|api/v0.3/orgs/{org_id}/invites||App\Http\Controllers\API\V0_3\OrgInvitesController@store|
+|GET|HEAD|api/v0.3/orgs/{org_id}/wallets||App\Http\Controllers\API\V0_3\OrgWalletController@wallets|
+|GET|HEAD|api/v0.3/orgs/{org_id}/wallets/{benefit_code}/ledger||App\Http\Controllers\API\V0_3\OrgWalletController@ledger|
+|GET|HEAD|api/v0.3/scales||App\Http\Controllers\API\V0_3\ScalesController@index|
+|GET|HEAD|api/v0.3/scales/lookup||App\Http\Controllers\API\V0_3\ScalesLookupController@lookup|
+|GET|HEAD|api/v0.3/scales/sitemap-source||App\Http\Controllers\API\V0_3\ScalesSitemapSourceController@index|
+|GET|HEAD|api/v0.3/scales/{scale_code}||App\Http\Controllers\API\V0_3\ScalesController@show|
+|GET|HEAD|api/v0.3/scales/{scale_code}/questions||App\Http\Controllers\API\V0_3\ScalesController@questions|
+|GET|HEAD|api/v0.3/shares/{id}||App\Http\Controllers\API\V0_3\ShareController@getShareView|
+|POST|api/v0.3/shares/{shareId}/click||App\Http\Controllers\API\V0_3\ShareController@click|
+|GET|HEAD|api/v0.3/skus|api.v0_3.skus|App\Http\Controllers\API\V0_3\CommerceController@listSkus|
+|POST|api/v0.3/webhooks/payment/{provider}|api.v0_3.webhooks.payment|App\Http\Controllers\API\V0_3\Webhooks\PaymentWebhookController@handle|
+|GET|HEAD|api/v0.4/boot||App\Http\Controllers\API\V0_4\BootController@show|
+|POST|api/v0.4/orgs/{org_id}/assessments||App\Http\Controllers\API\V0_4\AssessmentController@store|
+|POST|api/v0.4/orgs/{org_id}/assessments/{id}/invite||App\Http\Controllers\API\V0_4\AssessmentController@invite|
+|GET|HEAD|api/v0.4/orgs/{org_id}/assessments/{id}/progress||App\Http\Controllers\API\V0_4\AssessmentController@progress|
+|GET|HEAD|api/v0.4/orgs/{org_id}/assessments/{id}/summary||App\Http\Controllers\API\V0_4\AssessmentController@summary|
+|GET|HEAD|filament/exports/{export}/download|filament.exports.download|Filament\Actions\Exports\Http\Controllers\DownloadExport|
+|GET|HEAD|filament/imports/{import}/failed-rows/download|filament.imports.failed-rows.download|Filament\Actions\Imports\Http\Controllers\DownloadImportFailureCsv|
+|GET|HEAD|livewire/livewire.js||Livewire\Mechanisms\FrontendAssets\FrontendAssets@returnJavaScriptAsFile|
+|GET|HEAD|livewire/livewire.min.js.map||Livewire\Mechanisms\FrontendAssets\FrontendAssets@maps|
+|GET|HEAD|livewire/preview-file/{filename}|livewire.preview-file|Livewire\Features\SupportFileUploads\FilePreviewController@handle|
+|POST|livewire/update|livewire.update|Livewire\Mechanisms\HandleRequests\HandleRequests@handleUpdate|
+|POST|livewire/upload-file|livewire.upload-file|Livewire\Features\SupportFileUploads\FileUploadController@handle|
+|GET|HEAD|ops|filament.ops.pages.dashboard|App\Filament\Ops\Pages\OpsDashboard|
+|GET|HEAD|ops/admin-approvals|filament.ops.resources.admin-approvals.index|App\Filament\Ops\Resources\AdminApprovalResource\Pages\ListAdminApprovals|
+|GET|HEAD|ops/admin-approvals/{record}|filament.ops.resources.admin-approvals.view|App\Filament\Ops\Resources\AdminApprovalResource\Pages\ViewAdminApproval|
+|GET|HEAD|ops/admin-users|filament.ops.resources.admin-users.index|App\Filament\Ops\Resources\AdminUserResource\Pages\ListAdminUsers|
+|GET|HEAD|ops/admin-users/create|filament.ops.resources.admin-users.create|App\Filament\Ops\Resources\AdminUserResource\Pages\CreateAdminUser|
+|GET|HEAD|ops/admin-users/{record}/edit|filament.ops.resources.admin-users.edit|App\Filament\Ops\Resources\AdminUserResource\Pages\EditAdminUser|
+|GET|HEAD|ops/audit-logs|filament.ops.resources.audit-logs.index|App\Filament\Ops\Resources\AuditLogResource\Pages\ListAuditLogs|
+|GET|HEAD|ops/benefit-grants|filament.ops.resources.benefit-grants.index|App\Filament\Ops\Resources\BenefitGrantResource\Pages\ListBenefitGrants|
+|GET|HEAD|ops/benefit-grants/{record}|filament.ops.resources.benefit-grants.view|App\Filament\Ops\Resources\BenefitGrantResource\Pages\ViewBenefitGrant|
+|GET|HEAD|ops/content-pack-releases|filament.ops.resources.content-pack-releases.index|App\Filament\Ops\Resources\ContentPackReleaseResource\Pages\ListContentPackReleases|
+|GET|HEAD|ops/content-pack-releases/{record}|filament.ops.resources.content-pack-releases.view|App\Filament\Ops\Resources\ContentPackReleaseResource\Pages\ViewContentPackRelease|
+|GET|HEAD|ops/content-pack-versions|filament.ops.resources.content-pack-versions.index|App\Filament\Ops\Resources\ContentPackVersionResource\Pages\ListContentPackVersions|
+|GET|HEAD|ops/content-pack-versions/create|filament.ops.resources.content-pack-versions.create|App\Filament\Ops\Resources\ContentPackVersionResource\Pages\CreateContentPackVersion|
+|GET|HEAD|ops/content-pack-versions/{record}/edit|filament.ops.resources.content-pack-versions.edit|App\Filament\Ops\Resources\ContentPackVersionResource\Pages\EditContentPackVersion|
+|GET|HEAD|ops/content-releases|filament.ops.resources.content-releases.index|App\Filament\Ops\Resources\ContentPackReleaseResource\Pages\ListContentPackReleases|
+|GET|HEAD|ops/content-releases/{record}|filament.ops.resources.content-releases.view|App\Filament\Ops\Resources\ContentPackReleaseResource\Pages\ViewContentPackRelease|
+|GET|HEAD|ops/delivery-tools|filament.ops.pages.delivery-tools|App\Filament\Ops\Pages\DeliveryTools|
+|GET|HEAD|ops/deploys|filament.ops.resources.deploys.index|App\Filament\Ops\Resources\DeployResource\Pages\ListDeployEvents|
+|GET|HEAD|ops/global-search|filament.ops.pages.global-search|App\Filament\Ops\Pages\GlobalSearchPage|
+|GET|HEAD|ops/go-live-gate|filament.ops.pages.go-live-gate|App\Filament\Ops\Pages\GoLiveGatePage|
+|GET|HEAD|ops/health-checks|filament.ops.pages.health-checks|App\Filament\Ops\Pages\HealthChecks|
+|GET|HEAD|ops/login|filament.ops.auth.login|Filament\Pages\Auth\Login|
+|POST|ops/logout|filament.ops.auth.logout|Filament\Http\Controllers\Auth\LogoutController|
+|GET|HEAD|ops/order-lookup|filament.ops.pages.order-lookup|App\Filament\Ops\Pages\OrderLookup|
+|GET|HEAD|ops/orders|filament.ops.resources.orders.index|App\Filament\Ops\Resources\OrderResource\Pages\ListOrders|
+|GET|HEAD|ops/orders/{record}|filament.ops.resources.orders.view|App\Filament\Ops\Resources\OrderResource\Pages\ViewOrder|
+|GET|HEAD|ops/organizations|filament.ops.resources.organizations.index|App\Filament\Ops\Resources\OrganizationResource\Pages\ListOrganizations|
+|GET|HEAD|ops/organizations-import|filament.ops.pages.organizations-import|App\Filament\Ops\Pages\OrganizationsImportPage|
+|GET|HEAD|ops/organizations/create|filament.ops.resources.organizations.create|App\Filament\Ops\Resources\OrganizationResource\Pages\CreateOrganization|
+|GET|HEAD|ops/organizations/{record}/edit|filament.ops.resources.organizations.edit|App\Filament\Ops\Resources\OrganizationResource\Pages\EditOrganization|
+|GET|HEAD|ops/payment-events|filament.ops.resources.payment-events.index|App\Filament\Ops\Resources\PaymentEventResource\Pages\ListPaymentEvents|
+|GET|HEAD|ops/payment-events/{record}|filament.ops.resources.payment-events.view|App\Filament\Ops\Resources\PaymentEventResource\Pages\ViewPaymentEvent|
+|GET|HEAD|ops/permissions|filament.ops.resources.permissions.index|App\Filament\Ops\Resources\PermissionResource\Pages\ListPermissions|
+|GET|HEAD|ops/permissions/create|filament.ops.resources.permissions.create|App\Filament\Ops\Resources\PermissionResource\Pages\CreatePermission|
+|GET|HEAD|ops/permissions/{record}/edit|filament.ops.resources.permissions.edit|App\Filament\Ops\Resources\PermissionResource\Pages\EditPermission|
+|GET|HEAD|ops/queue-monitor|filament.ops.pages.queue-monitor|App\Filament\Ops\Pages\QueueMonitor|
+|GET|HEAD|ops/roles|filament.ops.resources.roles.index|App\Filament\Ops\Resources\RoleResource\Pages\ListRoles|
+|GET|HEAD|ops/roles/create|filament.ops.resources.roles.create|App\Filament\Ops\Resources\RoleResource\Pages\CreateRole|
+|GET|HEAD|ops/roles/{record}/edit|filament.ops.resources.roles.edit|App\Filament\Ops\Resources\RoleResource\Pages\EditRole|
+|GET|HEAD|ops/scale-registries|filament.ops.resources.scale-registries.index|App\Filament\Ops\Resources\ScaleRegistryResource\Pages\ListScaleRegistries|
+|GET|HEAD|ops/scale-registries/create|filament.ops.resources.scale-registries.create|App\Filament\Ops\Resources\ScaleRegistryResource\Pages\CreateScaleRegistry|
+|GET|HEAD|ops/scale-registries/{record}/edit|filament.ops.resources.scale-registries.edit|App\Filament\Ops\Resources\ScaleRegistryResource\Pages\EditScaleRegistry|
+|GET|HEAD|ops/scale-slugs|filament.ops.resources.scale-slugs.index|App\Filament\Ops\Resources\ScaleSlugResource\Pages\ListScaleSlugs|
+|GET|HEAD|ops/scale-slugs/create|filament.ops.resources.scale-slugs.create|App\Filament\Ops\Resources\ScaleSlugResource\Pages\CreateScaleSlug|
+|GET|HEAD|ops/scale-slugs/{record}/edit|filament.ops.resources.scale-slugs.edit|App\Filament\Ops\Resources\ScaleSlugResource\Pages\EditScaleSlug|
+|GET|HEAD|ops/secure-link|filament.ops.pages.secure-link|App\Filament\Ops\Pages\SecureLink|
+|GET|HEAD|ops/select-org|filament.ops.pages.select-org|App\Filament\Ops\Pages\SelectOrgPage|
+|GET|HEAD|ops/skus|filament.ops.resources.skus.index|App\Filament\Ops\Resources\SkuResource\Pages\ListSkus|
+|GET|HEAD|ops/two-factor-challenge|filament.ops.pages.two-factor-challenge|App\Filament\Ops\Pages\TwoFactorChallenge|
+|GET|HEAD|ops/webhook-monitor|filament.ops.pages.webhook-monitor|App\Filament\Ops\Pages\WebhookMonitor|
+|GET|HEAD|sitemap.xml||App\Http\Controllers\SitemapController@index|
+|GET|HEAD|storage/{path}|storage.local|Closure|
+|GET|HEAD|tenant||Closure|
+|GET|HEAD|up||Closure|
+
+### 18.1 路由统计摘要
+
+```text
+total_routes=122
+method=GET|HEAD, count=93
+method=GET|HEAD|POST|PUT|PATCH|DELETE|OPTIONS, count=2
+method=POST, count=26
+method=PUT, count=1
+```
+
+### 18.2 v0.3 / v0.4 / v0.2 明细（关键演进证据）
+
+```text
+[v0.3]
+POST	api/v0.3/attempts/start	App\Http\Controllers\API\V0_3\AttemptWriteController@start
+POST	api/v0.3/attempts/submit	App\Http\Controllers\API\V0_3\AttemptWriteController@submit
+PUT	api/v0.3/attempts/{attempt_id}/progress	App\Http\Controllers\API\V0_3\AttemptProgressController@upsert
+GET|HEAD	api/v0.3/attempts/{attempt_id}/progress	App\Http\Controllers\API\V0_3\AttemptProgressController@show
+GET|HEAD	api/v0.3/attempts/{id}	App\Http\Controllers\API\V0_3\AttemptReadController@show
+GET|HEAD	api/v0.3/attempts/{id}/report	App\Http\Controllers\API\V0_3\AttemptReadController@report
+GET|HEAD	api/v0.3/attempts/{id}/report.pdf	App\Http\Controllers\API\V0_3\AttemptReadController@reportPdf
+GET|HEAD	api/v0.3/attempts/{id}/result	App\Http\Controllers\API\V0_3\AttemptReadController@result
+GET|HEAD	api/v0.3/attempts/{id}/share	App\Http\Controllers\API\V0_3\ShareController@getShare
+POST	api/v0.3/auth/phone/send_code	App\Http\Controllers\API\V0_3\AuthPhoneController@sendCode
+POST	api/v0.3/auth/phone/verify	App\Http\Controllers\API\V0_3\AuthPhoneController@verify
+POST	api/v0.3/auth/wx_phone	App\Http\Controllers\API\V0_3\AuthWxPhoneController
+GET|HEAD	api/v0.3/boot	App\Http\Controllers\API\V0_3\BootController@show
+GET|HEAD	api/v0.3/claim/report	App\Http\Controllers\API\V0_3\ClaimController@report
+GET|HEAD	api/v0.3/experiments	App\Http\Controllers\API\V0_3\BootController@experiments
+GET|HEAD	api/v0.3/flags	App\Http\Controllers\API\V0_3\BootController@flags
+GET|HEAD	api/v0.3/me/attempts	App\Http\Controllers\API\V0_3\MeController@attempts
+POST	api/v0.3/orders	App\Http\Controllers\API\V0_3\CommerceController@createOrder
+POST	api/v0.3/orders/checkout	App\Http\Controllers\API\V0_3\CommerceController@checkout
+POST	api/v0.3/orders/lookup	App\Http\Controllers\API\V0_3\CommerceController@lookup
+POST	api/v0.3/orders/stub	Closure
+GET|HEAD	api/v0.3/orders/{order_no}	App\Http\Controllers\API\V0_3\CommerceController@getOrder
+POST	api/v0.3/orders/{order_no}/resend	App\Http\Controllers\API\V0_3\CommerceController@resend
+POST	api/v0.3/orders/{provider}	App\Http\Controllers\API\V0_3\CommerceController@createOrder
+POST	api/v0.3/orgs	App\Http\Controllers\API\V0_3\OrgsController@store
+POST	api/v0.3/orgs/invites/accept	App\Http\Controllers\API\V0_3\OrgInvitesController@accept
+GET|HEAD	api/v0.3/orgs/me	App\Http\Controllers\API\V0_3\OrgsController@me
+GET|HEAD	api/v0.3/orgs/{org_id}/big5/audits	App\Http\Controllers\API\V0_3\BigFiveOpsController@audits
+GET|HEAD	api/v0.3/orgs/{org_id}/big5/audits/{audit_id}	App\Http\Controllers\API\V0_3\BigFiveOpsController@audit
+POST	api/v0.3/orgs/{org_id}/big5/norms/activate	App\Http\Controllers\API\V0_3\BigFiveOpsController@activateNorms
+POST	api/v0.3/orgs/{org_id}/big5/norms/drift-check	App\Http\Controllers\API\V0_3\BigFiveOpsController@driftCheckNorms
+POST	api/v0.3/orgs/{org_id}/big5/norms/rebuild	App\Http\Controllers\API\V0_3\BigFiveOpsController@rebuildNorms
+GET|HEAD	api/v0.3/orgs/{org_id}/big5/releases	App\Http\Controllers\API\V0_3\BigFiveOpsController@releases
+GET|HEAD	api/v0.3/orgs/{org_id}/big5/releases/latest	App\Http\Controllers\API\V0_3\BigFiveOpsController@latest
+GET|HEAD	api/v0.3/orgs/{org_id}/big5/releases/latest/audits	App\Http\Controllers\API\V0_3\BigFiveOpsController@latestAudits
+POST	api/v0.3/orgs/{org_id}/big5/releases/publish	App\Http\Controllers\API\V0_3\BigFiveOpsController@publish
+POST	api/v0.3/orgs/{org_id}/big5/releases/rollback	App\Http\Controllers\API\V0_3\BigFiveOpsController@rollback
+GET|HEAD	api/v0.3/orgs/{org_id}/big5/releases/{release_id}	App\Http\Controllers\API\V0_3\BigFiveOpsController@release
+POST	api/v0.3/orgs/{org_id}/invites	App\Http\Controllers\API\V0_3\OrgInvitesController@store
+GET|HEAD	api/v0.3/orgs/{org_id}/wallets	App\Http\Controllers\API\V0_3\OrgWalletController@wallets
+GET|HEAD	api/v0.3/orgs/{org_id}/wallets/{benefit_code}/ledger	App\Http\Controllers\API\V0_3\OrgWalletController@ledger
+GET|HEAD	api/v0.3/scales	App\Http\Controllers\API\V0_3\ScalesController@index
+GET|HEAD	api/v0.3/scales/lookup	App\Http\Controllers\API\V0_3\ScalesLookupController@lookup
+GET|HEAD	api/v0.3/scales/sitemap-source	App\Http\Controllers\API\V0_3\ScalesSitemapSourceController@index
+GET|HEAD	api/v0.3/scales/{scale_code}	App\Http\Controllers\API\V0_3\ScalesController@show
+GET|HEAD	api/v0.3/scales/{scale_code}/questions	App\Http\Controllers\API\V0_3\ScalesController@questions
+GET|HEAD	api/v0.3/shares/{id}	App\Http\Controllers\API\V0_3\ShareController@getShareView
+POST	api/v0.3/shares/{shareId}/click	App\Http\Controllers\API\V0_3\ShareController@click
+GET|HEAD	api/v0.3/skus	App\Http\Controllers\API\V0_3\CommerceController@listSkus
+POST	api/v0.3/webhooks/payment/{provider}	App\Http\Controllers\API\V0_3\Webhooks\PaymentWebhookController@handle
+
+[v0.4]
+GET|HEAD	api/v0.4/boot	App\Http\Controllers\API\V0_4\BootController@show
+POST	api/v0.4/orgs/{org_id}/assessments	App\Http\Controllers\API\V0_4\AssessmentController@store
+POST	api/v0.4/orgs/{org_id}/assessments/{id}/invite	App\Http\Controllers\API\V0_4\AssessmentController@invite
+GET|HEAD	api/v0.4/orgs/{org_id}/assessments/{id}/progress	App\Http\Controllers\API\V0_4\AssessmentController@progress
+GET|HEAD	api/v0.4/orgs/{org_id}/assessments/{id}/summary	App\Http\Controllers\API\V0_4\AssessmentController@summary
+
+[v0.2]
+GET|HEAD|POST|PUT|PATCH|DELETE|OPTIONS	api/v0.2/{any?}	Closure
+```
+
+## 19. 附录B：迁移与测试资产清单（P0）
+
+### 19.1 fap-api 迁移清单（147）
+
+```text
+count=     147 /tmp/fap_api_migrations_list.txt
+database/migrations/0001_01_01_000000_create_users_table.php
+database/migrations/0001_01_01_000001_create_cache_table.php
+database/migrations/0001_01_01_000002_create_jobs_table.php
+database/migrations/2025_12_13_231207_create_results_table.php
+database/migrations/2025_12_14_084436_create_attempts_table.php
+database/migrations/2025_12_14_091106_create_events_table.php
+database/migrations/2025_12_15_165419_add_v021_fields_to_results_table.php
+database/migrations/2025_12_15_171546_create_shares_table.php
+database/migrations/2025_12_17_165938_create_events_table.php
+database/migrations/2025_12_21_101327_add_answers_fields_to_attempts_table.php
+database/migrations/2025_12_28_064425_add_region_locale_to_attempts_table.php
+database/migrations/2026_01_17_040640_add_ticket_code_to_attempts_table.php
+database/migrations/2026_01_17_164755_add_result_json_to_attempts_table.php
+database/migrations/2026_01_18_134019_create_fm_tokens_table.php
+database/migrations/2026_01_18_999999_add_share_id_to_events_table.php
+database/migrations/2026_01_19_111914_add_phone_fields_to_users_table.php
+database/migrations/2026_01_19_111915_add_user_id_to_attempts_table.php
+database/migrations/2026_01_19_170606_add_email_fields_to_users_table.php
+database/migrations/2026_01_19_170607_create_email_outbox_table.php
+database/migrations/2026_01_19_180001_create_identities_table.php
+database/migrations/2026_01_20_090001_add_attempt_id_to_email_outbox_table.php
+database/migrations/2026_01_20_090002_create_lookup_events_table.php
+database/migrations/2026_01_21_090000_create_norms_tables.php
+database/migrations/2026_01_22_000001_create_validity_feedbacks_table.php
+database/migrations/2026_01_22_090010_create_orders_table.php
+database/migrations/2026_01_22_090020_create_benefit_grants_table.php
+database/migrations/2026_01_22_090030_create_payment_events_table.php
+database/migrations/2026_01_24_162556_add_user_id_to_fm_tokens_table.php
+database/migrations/2026_01_26_090000_create_report_jobs_table.php
+database/migrations/2026_01_26_110000_create_content_pack_versions_table.php
+database/migrations/2026_01_26_110100_create_content_pack_releases_table.php
+database/migrations/2026_01_27_210000_pr9_add_observability_columns_to_events.php
+database/migrations/2026_01_27_210100_create_ops_deploy_events.php
+database/migrations/2026_01_27_210200_create_ops_healthz_snapshots.php
+database/migrations/2026_01_27_210300_create_views_pr9.php
+database/migrations/2026_01_27_210350_refresh_views_pr9.php
+database/migrations/2026_01_28_090000_create_admin_users_table.php
+database/migrations/2026_01_28_090010_create_roles_table.php
+database/migrations/2026_01_28_090020_create_permissions_table.php
+database/migrations/2026_01_28_090030_create_role_user_table.php
+database/migrations/2026_01_28_090040_create_permission_role_table.php
+database/migrations/2026_01_28_090050_create_audit_logs_table.php
+database/migrations/2026_01_28_110000_add_psychometrics_snapshot_to_attempts.php
+database/migrations/2026_01_28_110100_create_scale_norms_versions_table.php
+database/migrations/2026_01_28_110200_create_attempt_quality_table.php
+database/migrations/2026_01_28_120000_create_ai_insights_table.php
+database/migrations/2026_01_28_120100_create_ai_insight_feedback_table.php
+database/migrations/2026_01_28_130000_create_integrations_tables.php
+database/migrations/2026_01_28_130100_create_ingest_batches_table.php
+database/migrations/2026_01_28_130200_create_sleep_samples_table.php
+database/migrations/2026_01_28_130300_create_health_samples_table.php
+database/migrations/2026_01_28_130400_create_screen_time_samples_table.php
+database/migrations/2026_01_28_130500_create_idempotency_keys_table.php
+database/migrations/2026_01_28_140000_create_user_agent_settings.php
+database/migrations/2026_01_28_140100_create_memories_table.php
+database/migrations/2026_01_28_140200_create_embeddings_index.php
+database/migrations/2026_01_28_140300_create_embeddings_table.php
+database/migrations/2026_01_28_140400_create_agent_triggers.php
+database/migrations/2026_01_28_140500_create_agent_decisions.php
+database/migrations/2026_01_28_140600_create_agent_messages.php
+database/migrations/2026_01_28_140700_create_agent_feedback.php
+database/migrations/2026_01_29_000001_create_organizations_table.php
+database/migrations/2026_01_29_000002_create_organization_members_table.php
+database/migrations/2026_01_29_000003_create_organization_invites_table.php
+database/migrations/2026_01_29_000004_add_org_id_to_attempts_results_events_report_jobs.php
+database/migrations/2026_01_29_090000_create_scales_registry_table.php
+database/migrations/2026_01_29_090010_create_scale_slugs_table.php
+database/migrations/2026_01_29_120000_v03_attempts_results_fields.php
+database/migrations/2026_01_29_140000_create_report_snapshots_table.php
+database/migrations/2026_01_29_200000_create_skus_table.php
+database/migrations/2026_01_29_200010_create_orders_table.php
+database/migrations/2026_01_29_200020_create_payment_events_table.php
+database/migrations/2026_01_29_200030_create_benefit_wallets_table.php
+database/migrations/2026_01_29_200040_create_benefit_wallet_ledgers_table.php
+database/migrations/2026_01_29_200050_create_benefit_consumptions_table.php
+database/migrations/2026_01_29_200060_create_benefit_grants_table.php
+database/migrations/2026_01_30_120001_create_feature_flags_table.php
+database/migrations/2026_01_30_120002_create_experiment_assignments_table.php
+database/migrations/2026_01_30_120003_add_experiments_json_to_events_table.php
+database/migrations/2026_01_30_120100_create_attempt_drafts_table.php
+database/migrations/2026_01_30_120110_create_attempt_answer_sets_table.php
+database/migrations/2026_01_30_120120_create_attempt_answer_rows_table.php
+database/migrations/2026_01_30_120130_create_archive_audits_table.php
+database/migrations/2026_01_30_120140_add_resume_expires_at_to_attempts_table.php
+database/migrations/2026_01_31_090000_create_assessments_table.php
+database/migrations/2026_01_31_090010_create_assessment_assignments_table.php
+database/migrations/2026_01_31_090020_expand_organization_members_role.php
+database/migrations/2026_02_02_090000_add_sku_fields_to_orders_payment_events.php
+database/migrations/2026_02_04_090000_add_idempotency_refunds_to_orders_benefit_grants.php
+database/migrations/2026_02_05_090000_add_assessment_driver_to_scales_registry_table.php
+database/migrations/2026_02_05_090000_add_processing_fields_to_payment_events_table.php
+database/migrations/2026_02_05_090010_add_unique_index_to_skus_table.php
+database/migrations/2026_02_07_180000_add_webhook_hardening_fields_to_integrations_table.php
+database/migrations/2026_02_07_190000_scope_order_idempotency_key_by_provider.php
+database/migrations/2026_02_08_000001_add_provider_composite_unique_to_payment_events.php
+database/migrations/2026_02_08_030000_create_queue_dlq_replays_table.php
+database/migrations/2026_02_08_040000_create_migration_index_audits_table.php
+database/migrations/2026_02_08_050000_scope_payment_event_uniqueness_by_provider.php
+database/migrations/2026_02_08_060000_make_failed_jobs_uuid_nullable.php
+database/migrations/2026_02_10_090000_add_reason_to_payment_events_table.php
+database/migrations/2026_02_10_120000_add_payload_forensics_columns_to_payment_events_table.php
+database/migrations/2026_02_10_140000_create_integration_user_bindings_table.php
+database/migrations/2026_02_10_140100_add_auth_audit_fields_to_ingest_batches_table.php
+database/migrations/2026_02_10_150000_add_status_and_last_error_to_report_snapshots.php
+database/migrations/2026_02_10_160000_create_migration_backfills_table.php
+database/migrations/2026_02_10_160100_add_idx_idempo_payload.php
+database/migrations/2026_02_10_160200_add_benefit_grants_composite_indexes.php
+database/migrations/2026_02_10_160300_add_payment_events_status_time_index.php
+database/migrations/2026_02_10_999999_add_business_indexes.php
+database/migrations/2026_02_11_090100_add_idx_idempotency_keys_provider_recorded_hash.php
+database/migrations/2026_02_11_100200_add_org_id_to_audit_logs_table.php
+database/migrations/2026_02_11_120300_add_payload_digest_to_payment_events.php
+database/migrations/2026_02_12_000000_add_replay_indexes.php
+database/migrations/2026_02_12_000001_converge_hotpath_schema.php
+database/migrations/2026_02_12_000010_converge_fm_tokens_schema.php
+database/migrations/2026_02_12_000011_converge_integrations_schema.php
+database/migrations/2026_02_12_000012_converge_attempts_hot_columns.php
+database/migrations/2026_02_12_010000_add_run_id_to_idempotency_keys.php
+database/migrations/2026_02_13_000001_converge_core_schema_baseline.php
+database/migrations/2026_02_13_020000_add_identity_unique_to_idempotency_keys.php
+database/migrations/2026_02_14_235000_add_is_active_to_organization_members_table.php
+database/migrations/2026_02_15_000100_add_org_id_to_payment_events_table.php
+database/migrations/2026_02_15_000200_add_order_no_to_benefit_grants_table.php
+database/migrations/2026_02_15_000300_create_admin_approvals_table.php
+database/migrations/2026_02_15_000400_add_probe_fields_to_content_pack_releases_table.php
+database/migrations/2026_02_15_100500_expand_organizations_operable_fields.php
+database/migrations/2026_02_15_100600_create_admin_user_totp_tables.php
+database/migrations/2026_02_15_100700_add_reason_result_to_audit_logs.php
+database/migrations/2026_02_15_100800_add_ops_global_search_indexes.php
+database/migrations/2026_02_15_100900_create_payment_reconcile_snapshots_table.php
+database/migrations/2026_02_15_101000_create_data_lifecycle_requests_table.php
+database/migrations/2026_02_15_135009_add_preferred_locale_to_admin_users_table.php
+database/migrations/2026_02_15_160000_add_i18n_seo_content_fields_to_scales_registry.php
+database/migrations/2026_02_15_160100_add_i18n_template_fields_to_email_outbox.php
+database/migrations/2026_02_16_000100_add_report_free_full_json_to_report_snapshots.php
+database/migrations/2026_02_16_000200_add_meta_json_to_orders_and_benefit_grants.php
+database/migrations/2026_02_22_000100_create_norm_sources_table.php
+database/migrations/2026_02_22_000110_alter_scale_norms_versions_add_group_fields.php
+database/migrations/2026_02_22_000120_create_scale_norm_stats_table.php
+database/migrations/2026_02_22_001000_alter_content_pack_releases_add_hash_evidence.php
+database/migrations/2026_02_23_000100_create_big5_psychometrics_reports_table.php
+database/migrations/2026_02_23_000100_create_content_pack_activations_table.php
+database/migrations/2026_02_23_000101_add_packs2_columns_to_content_pack_releases_table.php
+database/migrations/2026_02_23_000200_create_scale_quality_daily_stats_table.php
+database/migrations/2026_02_24_000100_create_norms_build_artifacts_table.php
+database/migrations/2026_02_24_000200_create_eq60_psychometrics_reports_table.php
+database/migrations/2026_02_26_000100_create_sds_psychometrics_reports_table.php
+```
+
+### 19.2 fap-api 测试清单（285）
+
+```text
+count=     285 /tmp/fap_api_tests_list.txt
+tests/Architecture/AttemptSubmitServiceConstructorLimitTest.php
+tests/Architecture/NoEnvUsageOutsideConfigTest.php
+tests/Architecture/NoFailOpenThrowableCatchTest.php
+tests/Architecture/NoRuntimeSchemaIntrospectionTest.php
+tests/Concerns/SignedBillingWebhook.php
+tests/Feature/Admin/AuditLogOrgScopeTest.php
+tests/Feature/Api/ValidationErrorContractTest.php
+tests/Feature/ApiErrorContractMiddlewareTest.php
+tests/Feature/ApiExceptionRendererTest.php
+tests/Feature/ApiValidationErrorContractTest.php
+tests/Feature/AppServiceProviderContentStoreIsolationTest.php
+tests/Feature/Approvals/ApprovalFlowTest.php
+tests/Feature/Architecture/MiddlewareNoThrowableReturnTrueTest.php
+tests/Feature/Architecture/NoErrorKeyInApiResponsesTest.php
+tests/Feature/Architecture/NoRuntimeSchemaProbingInHotPathTest.php
+tests/Feature/Architecture/ServiceLayerBoundaryTest.php
+tests/Feature/Architecture/V0_3TraitReferenceTest.php
+tests/Feature/AssetCollectorOrgIsolationTest.php
+tests/Feature/Attempts/Big5RetakeCooldownTest.php
+tests/Feature/Attempts/BigFiveAttemptStartMinCompiledPathTest.php
+tests/Feature/Attempts/BigFiveHistoryCompareTest.php
+tests/Feature/ClinicalCombo68/ClinicalComboBlockSelectionEngineTest.php
+tests/Feature/ClinicalCombo68/ClinicalComboConsentGateTest.php
+tests/Feature/ClinicalCombo68/ClinicalComboConsentStartHashTest.php
+tests/Feature/ClinicalCombo68/ClinicalComboConsentSubmitTest.php
+tests/Feature/ClinicalCombo68/ClinicalComboCrisisGateTest.php
+tests/Feature/ClinicalCombo68/ClinicalComboCrisisStopsUpsellTest.php
+tests/Feature/ClinicalCombo68/ClinicalComboDataDeletionFlowTest.php
+tests/Feature/ClinicalCombo68/ClinicalComboDataRedactionTest.php
+tests/Feature/ClinicalCombo68/ClinicalComboGoldenCasesTest.php
+tests/Feature/ClinicalCombo68/ClinicalComboLayoutSatisfiabilityTest.php
+tests/Feature/ClinicalCombo68/ClinicalComboMaskedDepressionTest.php
+tests/Feature/ClinicalCombo68/ClinicalComboOptionSetMappingTest.php
+tests/Feature/ClinicalCombo68/ClinicalComboQuestionsApiTest.php
+tests/Feature/ClinicalCombo68/ClinicalComboQuestionsLocaleSplitTest.php
+tests/Feature/ClinicalCombo68/ClinicalComboQuestionsMetaComplianceTest.php
+tests/Feature/ClinicalCombo68/ClinicalComboReportLocaleTest.php
+tests/Feature/ClinicalCombo68/ClinicalComboReportPaywallTest.php
+tests/Feature/ClinicalCombo68/ClinicalComboReverseScoringTest.php
+tests/Feature/ClinicalCombo68/ClinicalComboScoreSmokeTest.php
+tests/Feature/ClinicalCombo68/ClinicalComboServerTimeQualityTest.php
+tests/Feature/ClinicalCombo68/Concerns/BuildsClinicalComboScorerInput.php
+tests/Feature/Commerce/BigFiveModulesUnlockFlowTest.php
+tests/Feature/Commerce/BigFiveUnlockDeliveryPipelineTest.php
+tests/Feature/Commerce/BigFiveWebhookIdempotencyTest.php
+tests/Feature/Commerce/ClinicalCombo68UnlockFlowTest.php
+tests/Feature/Commerce/ClinicalCombo68WebhookIdempotencyTest.php
+tests/Feature/Commerce/CommerceReconcileCommandTest.php
+tests/Feature/Commerce/Eq60UnlockFlowTest.php
+tests/Feature/Commerce/Eq60WebhookIdempotencyTest.php
+tests/Feature/Commerce/ManualGrantCreatesAuditTrailTest.php
+tests/Feature/Commerce/ModuleEntitlementGrantTest.php
+tests/Feature/Commerce/OfferModulesContractTest.php
+tests/Feature/Commerce/OrderPricingTest.php
+tests/Feature/Commerce/PaymentEventUniquenessAcrossProvidersTest.php
+tests/Feature/Commerce/PaymentWebhookIdempotencyTest.php
+tests/Feature/Commerce/PaymentWebhookProcessorAtomicityTest.php
+tests/Feature/Commerce/PaymentWebhookProcessorLockKeyTest.php
+tests/Feature/Commerce/PaymentWebhookStripeSignatureTest.php
+tests/Feature/Commerce/PaymentWebhookTrustBoundaryTest.php
+tests/Feature/Commerce/RefundRevokesEntitlementTest.php
+tests/Feature/Commerce/Sds20UnlockFlowTest.php
+tests/Feature/Commerce/Sds20WebhookIdempotencyTest.php
+tests/Feature/Commerce/Webhook/PaymentWebhookProcessorContractTest.php
+tests/Feature/Commerce/WebhookIdempotencyStillHoldsAfterReprocessTest.php
+tests/Feature/Compliance/Big5DisclaimerAcceptanceTest.php
+tests/Feature/Compliance/BigFiveDataDeletionCommandTest.php
+tests/Feature/Compliance/BigFiveDataDeletionFlowTest.php
+tests/Feature/Console/TenantIsolationTest.php
+tests/Feature/Content/Big5ComplianceLintTest.php
+tests/Feature/Content/Big5DurationSpoofDoesNotChangeQualityTest.php
+tests/Feature/Content/BigFiveDisclaimerContractTest.php
+tests/Feature/Content/BigFiveGoldenCasesTest.php
+tests/Feature/Content/BigFiveNormResolverBandsTest.php
+tests/Feature/Content/BigFiveNormResolverTest.php
+tests/Feature/Content/BigFiveNormsCoverageGateTest.php
+tests/Feature/Content/BigFivePackIntegrityTest.php
+tests/Feature/Content/BigFivePaywallFlagModesTest.php
+tests/Feature/Content/BigFiveQuestionsCompiledDeterminismTest.php
+tests/Feature/Content/BigFiveQuestionsCompiledSizeBudgetTest.php
+tests/Feature/Content/BigFiveQuestionsLocaleSplitTest.php
+tests/Feature/Content/BigFiveQuestionsMinCompiledContractTest.php
+tests/Feature/Content/BigFiveQuestionsMinCompiledEvidenceContractTest.php
+tests/Feature/Content/BigFiveQuestionsMinReadPathTest.php
+tests/Feature/Content/BigFiveReportBlocksContractTest.php
+tests/Feature/Content/BigFiveReportCoverageMatrixTest.php
+tests/Feature/Content/BigFiveRolloutGateTest.php
+tests/Feature/Content/BigFiveValidityItemsTest.php
+tests/Feature/Content/ContentPackCoverageMatrixTest.php
+tests/Feature/Content/ContentPackLintTest.php
+tests/Feature/Content/ContentStoreContractTest.php
+tests/Feature/Content/Eq60ContentGateTest.php
+tests/Feature/Content/Eq60GoldenCasesTest.php
+tests/Feature/Content/Packs2DualWritePublishTest.php
+tests/Feature/Content/PacksPublishBig5Test.php
+tests/Feature/Content/PacksPublishSds20Test.php
+tests/Feature/Content/PacksRollbackBig5Test.php
+tests/Feature/Content/TemplateLintInPackTest.php
+tests/Feature/DeprecatedApiVersionContractTest.php
+tests/Feature/ErrorContractConsistencyTest.php
+tests/Feature/ExampleTest.php
+tests/Feature/FmTokenOptionalAuthMiddlewareTest.php
+tests/Feature/FmTokenOrgOverrideIsolationTest.php
+tests/Feature/HealthzExposureTest.php
+tests/Feature/HealthzRateLimitTest.php
+tests/Feature/HighIdorOwnership404Test.php
+tests/Feature/HighlightBuilderBlindspotIdTemplatesDocTest.php
+tests/Feature/HighlightBuilderBuildFromStoreTest.php
+tests/Feature/LegacyMbti/ReportPayloadGoldenMasterTest.php
+tests/Feature/Migrations/EventsGuardedCreateRollbackDoesNotDropTableTest.php
+tests/Feature/Migrations/MigrationsNoGuardedDropRollbackTest.php
+tests/Feature/Migrations/MigrationsNoSilentCatchTest.php
+tests/Feature/NoEmptyThrowableCatchTest.php
+tests/Feature/Observability/BigFiveMetricsContractTest.php
+tests/Feature/Observability/BigFiveTelemetrySummaryCommandTest.php
+tests/Feature/Observability/BigFiveTelemetryTest.php
+tests/Feature/Observability/ClinicalSdsTelemetryContractTest.php
+tests/Feature/Observability/EventRecorderBig5RedactionTest.php
+tests/Feature/Ops/BigFiveOpsReleaseFlowTest.php
+tests/Feature/Ops/BigFiveOpsReleasesEndpointTest.php
+tests/Feature/Ops/BigFiveOpsWriteEndpointsTest.php
+tests/Feature/Ops/CurrentOrgSwitcherComponentTest.php
+tests/Feature/Ops/LocaleSwitcherComponentTest.php
+tests/Feature/Ops/SetOpsLocaleMiddlewareTest.php
+tests/Feature/PaginationContractTest.php
+tests/Feature/PaymentWebhookControllerTest.php
+tests/Feature/Payments/StubProviderDisabledTest.php
+tests/Feature/Payments/WebhookPayloadSizeLimitTest.php
+tests/Feature/Payments/WebhookProviderMismatchTest.php
+tests/Feature/Performance/Big5PerfBudgetTest.php
+tests/Feature/Psychometrics/Big5BootstrapBuildTest.php
+tests/Feature/Psychometrics/Big5NormsDriftCheckTest.php
+tests/Feature/Psychometrics/Big5NormsRebuildCommandTest.php
+tests/Feature/Psychometrics/Big5NormsRebuildDedupTest.php
+tests/Feature/Psychometrics/Big5PsychometricsReportCommandTest.php
+tests/Feature/Psychometrics/Big5RebuildFilterValidityTest.php
+tests/Feature/Psychometrics/Big5RollingNormsCommandTest.php
+tests/Feature/Psychometrics/Eq60NormsDriftCheckTest.php
+tests/Feature/Psychometrics/Eq60NormsImportTest.php
+tests/Feature/Psychometrics/Eq60PsychometricsReportTest.php
+tests/Feature/Psychometrics/SdsNormsDriftCheckTest.php
+tests/Feature/Psychometrics/SdsNormsRebuildCommandTest.php
+tests/Feature/Psychometrics/SdsPsychometricsReportCommandTest.php
+tests/Feature/Report/BigFivePdfDeliveryTest.php
+tests/Feature/Report/Eq60PdfDeliveryTest.php
+tests/Feature/Report/Eq60ReportPaywallTest.php
+tests/Feature/Report/GenerateBigFiveReportPdfJobTest.php
+tests/Feature/Report/ModulesGateReportTest.php
+tests/Feature/Report/ReportLockedVariantLeakTest.php
+tests/Feature/Report/ReportPdfCrossScaleDeliveryTest.php
+tests/Feature/Report/ReportVariantGenerationTest.php
+tests/Feature/ReportComposerTenantIsolationTest.php
+tests/Feature/ReportGatekeeperIdentityBoundaryTest.php
+tests/Feature/SEO/SitemapGeneratorTest.php
+tests/Feature/SEO/SitemapXmlTest.php
+tests/Feature/SRE/TransactionSlimmingTest.php
+tests/Feature/Sds20/Concerns/BuildsSds20ScorerInput.php
+tests/Feature/Sds20/Sds20ConsentRequiredTest.php
+tests/Feature/Sds20/Sds20CrisisGateTest.php
+tests/Feature/Sds20/Sds20CrisisStopsUpsellTest.php
+tests/Feature/Sds20/Sds20DataRedactionTest.php
+tests/Feature/Sds20/Sds20DtoDeterminismTest.php
+tests/Feature/Sds20/Sds20DurationSpoofDoesNotChangeQualityTest.php
+tests/Feature/Sds20/Sds20FactorScoringTest.php
+tests/Feature/Sds20/Sds20GoldenCasesTest.php
+tests/Feature/Sds20/Sds20MaskLogicGateTest.php
+tests/Feature/Sds20/Sds20PercentileNormsTest.php
+tests/Feature/Sds20/Sds20QualityGateTest.php
+tests/Feature/Sds20/Sds20QuestionsApiTest.php
+tests/Feature/Sds20/Sds20ReportLocaleTest.php
+tests/Feature/Sds20/Sds20ReportPaywallTest.php
+tests/Feature/Sds20/Sds20ReverseScoringTest.php
+tests/Feature/Sds20/Sds20ScoreSmokeTest.php
+tests/Feature/Sds20/Sds20SomaticMaskGateTest.php
+tests/Feature/Sds20/Sds20SubmitConsentGateTest.php
+tests/Feature/SelfCheck/SelfCheckContractTest.php
+tests/Feature/Storage/ArtifactStoreReadCompatibilityTest.php
+tests/Feature/Storage/ReportPersistenceStopsTimestampBackupsTest.php
+tests/Feature/Storage/StorageInventoryCommandTest.php
+tests/Feature/Storage/StorageMigrateLegacyArtifactsCommandTest.php
+tests/Feature/Storage/StoragePruneDoesNotDeleteCanonicalTest.php
+tests/Feature/Storage/StoragePruneReleaseRetentionTest.php
+tests/Feature/UuidRouteParamsMiddlewareTest.php
+tests/Feature/V0_3/ArchiveColdDataCommandTest.php
+tests/Feature/V0_3/AssetsBaseUrlFromCdnMapTest.php
+tests/Feature/V0_3/AttemptContentPackErrorTest.php
+tests/Feature/V0_3/AttemptControllerSplitSmokeTest.php
+tests/Feature/V0_3/AttemptMemberViewerOwnershipTest.php
+tests/Feature/V0_3/AttemptOwnershipAnd404Test.php
+tests/Feature/V0_3/AttemptOwnershipTraitTest.php
+tests/Feature/V0_3/AttemptProgressFlowTest.php
+tests/Feature/V0_3/AttemptReportPaymentUnlockFlowTest.php
+tests/Feature/V0_3/AttemptSubmitAuthTest.php
+tests/Feature/V0_3/AttemptSubmitIdempotencyTest.php
+tests/Feature/V0_3/AttemptSubmitRefactorParityTest.php
+tests/Feature/V0_3/AttemptWriteSlimControllerTest.php
+tests/Feature/V0_3/AttemptsStartSubmitTest.php
+tests/Feature/V0_3/BillingWebhookMisconfiguredSecretTest.php
+tests/Feature/V0_3/BillingWebhookReplayToleranceTest.php
+tests/Feature/V0_3/BillingWebhookSignatureTest.php
+tests/Feature/V0_3/CommerceOrderIdempotencyTest.php
+tests/Feature/V0_3/CommerceOrderReadFallbackTest.php
+tests/Feature/V0_3/CommerceOrgIdWriteIsolationTest.php
+tests/Feature/V0_3/CommerceRefundWebhookTest.php
+tests/Feature/V0_3/CommerceWalletConsumeOnSubmitTest.php
+tests/Feature/V0_3/CommerceWebhookIdempotencyTest.php
+tests/Feature/V0_3/CreditsConsumeOnAttemptSubmitTest.php
+tests/Feature/V0_3/Eq60HistoryListTest.php
+tests/Feature/V0_3/Eq60StartSubmitTest.php
+tests/Feature/V0_3/Eq60SubmitQualityContractTest.php
+tests/Feature/V0_3/EventExperimentsJsonTest.php
+tests/Feature/V0_3/ExperimentStickyAssignmentTest.php
+tests/Feature/V0_3/OrgContextMiddlewareTest.php
+tests/Feature/V0_3/OrgInvitesFlowTest.php
+tests/Feature/V0_3/OrgIsolationAttemptsTest.php
+tests/Feature/V0_3/PaymentWebhookControllerTest.php
+tests/Feature/V0_3/PaymentWebhookFailSafeTest.php
+tests/Feature/V0_3/PaymentWebhookPayloadLimitTest.php
+tests/Feature/V0_3/PaymentWebhookRouteWiringTest.php
+tests/Feature/V0_3/ReportDirVersionTruthTest.php
+tests/Feature/V0_3/ReportErrorContractTest.php
+tests/Feature/V0_3/ReportPaywallTeaserTest.php
+tests/Feature/V0_3/ReportQueryFootprintTest.php
+tests/Feature/V0_3/ReportSnapshotB2BTest.php
+tests/Feature/V0_3/ReportSnapshotB2CTest.php
+tests/Feature/V0_3/ResolveAnonIdMiddlewareTest.php
+tests/Feature/V0_3/ScalesListTest.php
+tests/Feature/V0_3/ScalesLookupTest.php
+tests/Feature/V0_3/WebhookPayloadSizeLimitTest.php
+tests/Feature/V0_3/WebhookStatusPropagationTest.php
+tests/Feature/V0_4/AssessmentsProgressSummaryTest.php
+tests/Feature/V0_4/AssessmentsRbacIsolationTest.php
+tests/Feature/V0_4/BootTest.php
+tests/Feature/ViewCompiledPathTest.php
+tests/Sre/MigrationHotTableNotNullGateTest.php
+tests/Sre/MigrationPurityGateTest.php
+tests/Sre/MigrationSafetyTest.php
+tests/TestCase.php
+tests/Unit/API/V0_3/Webhooks/PaymentWebhookStripeSignatureTest.php
+tests/Unit/Analytics/Big5EventSchemaValidationTest.php
+tests/Unit/Assessment/BigFiveDriverMinCompiledPathTest.php
+tests/Unit/Assessment/BigFiveDriverNormsSnapshotTest.php
+tests/Unit/Assessment/Eq60DriverScoringTest.php
+tests/Unit/Assessment/Eq60ScorerCrossInsightTest.php
+tests/Unit/Assessment/Eq60ScorerValidityTest.php
+tests/Unit/Assessment/GenericScoringDriverTest.php
+tests/Unit/Ci/ScaleImpactResolverTest.php
+tests/Unit/Commerce/PaymentEventsProviderScopeGuardTest.php
+tests/Unit/Commerce/PaymentWebhookLockBusyTest.php
+tests/Unit/Content/ContentPackV2ResolverPathFallbackTest.php
+tests/Unit/ExampleTest.php
+tests/Unit/Http/PaymentWebhookStripeSignatureTest.php
+tests/Unit/Legacy/Mbti/LegacyMbtiPackRepositoryTest.php
+tests/Unit/Legacy/Mbti/LegacyMbtiReportAssetRepositoryTest.php
+tests/Unit/Legacy/Mbti/LegacyMbtiReportPayloadBuilderTest.php
+tests/Unit/Logging/RedactProcessorTest.php
+tests/Unit/Migrations/CreateMigrationsMustConvergeTest.php
+tests/Unit/Migrations/GuardedCreateMigrationsNoDropTest.php
+tests/Unit/Migrations/MigrationNoSilentCatchTest.php
+tests/Unit/Migrations/MigrationProtectedTablesNoDropTest.php
+tests/Unit/Migrations/MigrationRollbackSafetyTest.php
+tests/Unit/Migrations/MigrationSafetyTest.php
+tests/Unit/Psychometrics/Big5/Big5StandardizerTest.php
+tests/Unit/Psychometrics/Big5/NormGroupResolverTest.php
+tests/Unit/Psychometrics/GenericLikertDriverTest.php
+tests/Unit/Report/Composer/ReportOverridesMergerTest.php
+tests/Unit/Report/Composer/ReportPackChainLoaderTest.php
+tests/Unit/Security/SecurityGuardrailsTest.php
+tests/Unit/SelfCheck/ManifestContractCheckTest.php
+tests/Unit/SelfCheck/SelfCheckRunnerOrderTest.php
+tests/Unit/Services/Analytics/EventPayloadLimiterTest.php
+tests/Unit/Services/Assessment/Drivers/GenericLikertDriverReverseAndWeightTest.php
+tests/Unit/Services/Assessment/Drivers/GenericLikertDriverTest.php
+tests/Unit/Services/Assessment/GenericLikertDriverTest.php
+tests/Unit/Services/Commerce/PaymentWebhookProcessorLockTest.php
+tests/Unit/Services/Content/ContentPacksIndexManifestConsistencyTest.php
+tests/Unit/Services/ContentLoaderMtimeCacheTest.php
+tests/Unit/Services/ContentLoaderServiceMtimeTest.php
+tests/Unit/Services/ContentPackResolverCacheTest.php
+tests/Unit/Support/Database/SchemaIndexTest.php
+tests/Unit/Support/Rbac/RbacServiceTest.php
+tests/Unit/Support/SensitiveDataRedactorTest.php
+tests/Unit/TagBuilderTest.php
+tests/Unit/Template/BigFiveTemplateWhitelistTest.php
+tests/Unit/Template/TemplateEngineTest.php
+```
+
+### 19.3 fap-web 测试清单（25）
+
+```text
+count=      25 /tmp/fap_web_tests_list.txt
+tests/a11y/adaptive-option-group.a11y.test.tsx
+tests/a11y/data-glyph.a11y.test.tsx
+tests/a11y/likert.a11y.test.tsx
+tests/contracts/big5.contract.test.ts
+tests/contracts/clinical.contract.test.ts
+tests/contracts/quiz-ux-flags.contract.test.ts
+tests/contracts/tracking-whitelist.contract.test.ts
+tests/e2e/big5-flow.spec.ts
+tests/e2e/big5-negative.spec.ts
+tests/e2e/clinical-combo-flow.spec.ts
+tests/e2e/helpers/quiz-flow.ts
+tests/e2e/home-visual.spec.ts
+tests/e2e/mbti-regression.spec.ts
+tests/e2e/navigation-shell.spec.ts
+tests/e2e/result-loading.spec.ts
+tests/e2e/sds-flow.spec.ts
+tests/e2e/seo-og.spec.ts
+tests/e2e/test-detail.spec.ts
+tests/e2e/tests-list.spec.ts
+tests/e2e/uat-matrix.spec.ts
+tests/e2e/visual/home.visual.spec.ts
+tests/e2e/visual/support.visual.spec.ts
+tests/e2e/visual/test-detail.visual.spec.ts
+tests/e2e/visual/tests-list.visual.spec.ts
+tests/e2e/visual/visual-helpers.ts
+```
+
+### 19.4 fap-web app 页面清单（52）
+
+```text
+count=      52 /tmp/fap_web_app_files.txt
+app/(localized)/[locale]/(app)/.DS_Store
+app/(localized)/[locale]/(app)/history/big5/Big5HistoryClient.tsx
+app/(localized)/[locale]/(app)/history/big5/compare/Big5CompareClient.tsx
+app/(localized)/[locale]/(app)/history/big5/compare/page.tsx
+app/(localized)/[locale]/(app)/history/big5/page.tsx
+app/(localized)/[locale]/(app)/layout.tsx
+app/(localized)/[locale]/(app)/quiz/[slug]/page.tsx
+app/(localized)/[locale]/(app)/result/[id]/ResultClient.tsx
+app/(localized)/[locale]/(app)/result/[id]/page.tsx
+app/(localized)/[locale]/articles/[slug]/page.tsx
+app/(localized)/[locale]/articles/page.tsx
+app/(localized)/[locale]/attempts/[attemptId]/report/page.tsx
+app/(localized)/[locale]/blog/[slug]/page.tsx
+app/(localized)/[locale]/blog/page.tsx
+app/(localized)/[locale]/business/page.tsx
+app/(localized)/[locale]/help/page.tsx
+app/(localized)/[locale]/layout.tsx
+app/(localized)/[locale]/orders/.DS_Store
+app/(localized)/[locale]/orders/[orderNo]/OrdersClient.tsx
+app/(localized)/[locale]/orders/[orderNo]/page.tsx
+app/(localized)/[locale]/orders/lookup/page.tsx
+app/(localized)/[locale]/page.tsx
+app/(localized)/[locale]/payment/stripe/cancel/page.tsx
+app/(localized)/[locale]/payment/stripe/success/page.tsx
+app/(localized)/[locale]/privacy/page.tsx
+app/(localized)/[locale]/professions/[code]/page.tsx
+app/(localized)/[locale]/professions/page.tsx
+app/(localized)/[locale]/refund/page.tsx
+app/(localized)/[locale]/share/[id]/ShareClient.tsx
+app/(localized)/[locale]/share/[id]/page.tsx
+app/(localized)/[locale]/support/page.tsx
+app/(localized)/[locale]/terms/page.tsx
+app/(localized)/[locale]/test/[slug]/page.tsx
+app/(localized)/[locale]/test/[slug]/take/page.tsx
+app/(localized)/[locale]/test/page.tsx
+app/(localized)/[locale]/tests/[slug]/page.tsx
+app/(localized)/[locale]/tests/[slug]/take/Big5TakeClient.tsx
+app/(localized)/[locale]/tests/[slug]/take/ClinicalTakeClient.tsx
+app/(localized)/[locale]/tests/[slug]/take/QuizTakeClient.tsx
+app/(localized)/[locale]/tests/[slug]/take/page.tsx
+app/(localized)/[locale]/tests/page.tsx
+app/(localized)/[locale]/types/[code]/page.tsx
+app/(localized)/[locale]/types/page.tsx
+app/(root)/layout.tsx
+app/(root)/page.tsx
+app/.DS_Store
+app/api/track/route.ts
+app/favicon.ico
+app/global-error.tsx
+app/globals.css
+app/og/[slug]/route.tsx
+app/providers.tsx
+```
+
+## 20. 附录C：热点文件、复杂度与演进压力（P0）
+
+### 20.1 fap-api 热点文件（按行数）
+
+```text
+    3185 app/Internal/SelfCheck/SelfCheckContentEngineCore.php
+    2412 app/Internal/Legacy/Mbti/Report/LegacyMbtiReportPayloadBuilderV2Core.php
+    1917 app/Internal/Commerce/PaymentWebhookHandlerCore.php
+    1561 app/Services/Overrides/ReportOverridesApplier.php
+    1331 app/Internal/Content/ContentStoreV2Core.php
+    1237 app/Services/Content/Publisher/ContentPackPublisher.php
+    1148 app/Services/Rules/RuleEngine.php
+    1110 app/Services/Content/BigFiveContentLintService.php
+    1002 app/Services/Report/ReportGatekeeper.php
+     969 app/Http/Controllers/API/V0_3/BigFiveOpsController.php
+     958 app/Services/Content/Eq60ContentLintService.php
+     955 app/Services/Legacy/Mbti/Attempt/LegacyMbtiAttemptLifecycleService.php
+     942 app/Services/Content/ClinicalComboContentLintService.php
+     936 app/Services/Assessment/Scorers/Eq60ScorerV1NormedValidity.php
+     933 app/Services/Report/BigFiveReportComposer.php
+     869 app/Services/Content/Eq60ContentCompileService.php
+     856 app/Services/Attempts/AttemptSubmitService.php
+     796 app/Services/Content/ClinicalComboPackLoader.php
+     756 app/Services/Assessment/Scorers/BigFiveScorerV3.php
+     755 app/Services/Content/BigFiveContentCompileService.php
+     733 app/Services/Report/Eq60ReportComposer.php
+     731 app/Services/Report/HighlightsGenerator.php
+     730 app/Services/Report/HighlightBuilder.php
+     637 app/Services/Legacy/LegacyReportService.php
+     609 app/Services/Score/MbtiAttemptScorer.php
+     598 app/Console/Commands/StoragePrune.php
+     597 app/Services/Assessment/Scorers/Sds20ScorerV2FactorLogic.php
+     581 app/Services/RuleEngine/ReportRuleEngine.php
+     570 app/Console/Commands/NormsBig5BootstrapBuild.php
+     568 app/Http/Controllers/LookupController.php
+     555 app/Console/Commands/NormsImport.php
+     546 app/Services/Assessment/Scorers/ClinicalCombo68ScorerV1.php
+     538 app/Services/Commerce/OrderManager.php
+     526 app/Services/V0_3/ShareFlowService.php
+     526 app/Services/Legacy/LegacyShareFlowService.php
+     523 app/Services/Payments/PaymentService.php
+     512 app/Services/Report/ReportSnapshotStore.php
+     509 app/Services/Assessment/Drivers/GenericScoringDriver.php
+     482 app/Services/Attempts/AttemptStartService.php
+     480 app/Console/Commands/NormsBig5Rebuild.php
+     465 app/Providers/AppServiceProvider.php
+```
+
+### 20.2 fap-web 热点文件（按行数）
+
+```text
+   16192 total
+    1007 app/(localized)/[locale]/tests/[slug]/take/Big5TakeClient.tsx
+     969 components/clinical/report/ClinicalReportClient.tsx
+     841 lib/api/v0_3.ts
+     822 app/(localized)/[locale]/tests/[slug]/take/ClinicalTakeClient.tsx
+     661 app/(localized)/[locale]/(app)/result/[id]/ResultClient.tsx
+     632 app/(localized)/[locale]/tests/[slug]/take/QuizTakeClient.tsx
+     420 app/(localized)/[locale]/tests/[slug]/page.tsx
+     300 app/(localized)/[locale]/orders/[orderNo]/OrdersClient.tsx
+     295 app/(localized)/[locale]/(app)/history/big5/compare/Big5CompareClient.tsx
+     286 components/clinical/report/CrisisOverlay.tsx
+     267 lib/quiz/store.tsx
+     222 components/quiz/matrix/MatrixQuestionTable.tsx
+     203 lib/rollout/scaleRollout.ts
+     201 lib/i18n/locales/en.ts
+     200 lib/i18n/locales/zh.ts
+     192 components/report/LockedInsightTeaser.tsx
+     188 lib/big5/api.ts
+     185 lib/big5/contracts/schemas.ts
+     171 components/big5/report/BlockRenderer.tsx
+     166 lib/clinical/contracts/schemas.ts
+     164 lib/clinical/attemptStore.ts
+     163 lib/api-client.ts
+     161 lib/i18n/types.ts
+     161 lib/clinical/api.ts
+     161 app/(localized)/[locale]/(app)/history/big5/Big5HistoryClient.tsx
+     158 lib/anon.ts
+     157 components/assessment-cards/DataGlyph.tsx
+     153 components/clinical/report/SdsFactorPanel.tsx
+     151 lib/tracking/events.ts
+     148 components/marketing/HighlightedTestsSection.tsx
+     136 components/layout/SiteHeader.tsx
+     135 components/quiz/immersive/AdaptiveOptionGroup.tsx
+     135 app/(localized)/[locale]/tests/[slug]/take/page.tsx
+     133 lib/big5/attemptStore.ts
+     126 components/business/TestCard.tsx
+     125 components/quiz/immersive/useAutoAdvanceFlow.ts
+     117 app/(localized)/[locale]/share/[id]/ShareClient.tsx
+     115 components/big5/quiz/LikertScale.tsx
+     112 components/commerce/UnlockCTA.tsx
+     105 components/support/OrderLookupForm.tsx
+     105 app/(localized)/[locale]/privacy/page.tsx
+```
+
+### 20.3 最近变更热点（提交次数）
+
+```text
+ 113 backend/routes/api.php
+  68 backend/app/Http/Controllers/MbtiController.php
+  44 backend/.env.example
+  44 .github/workflows/selfcheck.yml
+  39 backend/scripts/ci_verify_mbti.sh
+  32 backend/app/Http/Middleware/FmTokenAuth.php
+  31 .github/workflows/ci_verify_mbti.yml
+  29 backend/app/Services/Commerce/PaymentWebhookProcessor.php
+  29 backend/app/Http/Controllers/API/V0_3/Webhooks/PaymentWebhookController.php
+  27 backend/app/Http/Controllers/API/V0_2/ShareController.php
+  27 backend/app/Console/Kernel.php
+  25 deploy.php
+  25 backend/config/fap.php
+  25 backend/app/Console/Commands/FapSelfCheck.php
+  22 backend/database/seeders/ScaleRegistrySeeder.php
+  22 backend/app/Services/Report/ReportGatekeeper.php
+  21 backend/database/seeders/CiScalesRegistrySeeder.php
+  21 backend/app/Providers/AppServiceProvider.php
+  21 backend/app/Http/Controllers/EventController.php
+  20 backend/app/Services/Report/ReportComposer.php
+  19 content_packages/default/CN_MAINLAND/zh-CN/MBTI-CN-v0.2.1-TEST/report_recommended_reads.json
+  19 backend/.gitignore
+  18 backend/app/Services/Attempts/AttemptSubmitService.php
+  18 .gitignore
+  17 backend/app/Http/Controllers/API/V0_3/CommerceController.php
+  16 backend/app/Services/Attempts/AttemptStartService.php
+  15 backend/scripts/verify_mbti.sh
+  15 backend/bootstrap/app.php
+  14 backend/scripts/pr20_verify_report_paywall.sh
+  14 backend/content_packs/BIG5_OCEAN/v1/compiled/questions.compiled.json
+  14 backend/content_packs/BIG5_OCEAN/v1/compiled/policy.compiled.json
+  14 backend/content_packs/BIG5_OCEAN/v1/compiled/norms.compiled.json
+  14 backend/content_packs/BIG5_OCEAN/v1/compiled/manifest.json
+  14 backend/content_packs/BIG5_OCEAN/v1/compiled/landing.compiled.json
+  14 backend/content_packs/BIG5_OCEAN/v1/compiled/golden_cases.compiled.json
+  14 backend/content_packs/BIG5_OCEAN/v1/compiled/facet_index.json
+  14 backend/content_packs/BIG5_OCEAN/v1/compiled/domain_index.json
+  14 backend/content_packs/BIG5_OCEAN/v1/compiled/copy.compiled.json
+  14 backend/app/Support/ApiExceptionRenderer.php
+  14 backend/app/Services/Report/SectionCardGenerator.php
+---
+  11 package.json
+   9 lib/api/v0_3.ts
+   9 app/(localized)/[locale]/tests/[slug]/take/QuizTakeClient.tsx
+   8 tests/e2e/visual/home.visual.spec.ts-snapshots/home-en-chromium-linux.png
+   8 tests/e2e/visual/home.visual.spec.ts-snapshots/home-en-chromium-darwin.png
+   8 lib/i18n/types.ts
+   8 lib/i18n/locales/zh.ts
+   8 lib/i18n/locales/en.ts
+   8 app/test/[slug]/page.tsx
+   8 app/(localized)/[locale]/tests/[slug]/take/Big5TakeClient.tsx
+   8 app/(localized)/[locale]/(app)/result/[id]/ResultClient.tsx
+   7 velite.config.ts
+   7 tests/e2e/mbti-regression.spec.ts
+   7 pnpm-lock.yaml
+   7 components/layout/SiteFooter.tsx
+   7 app/tests/[slug]/page.tsx
+   7 app/test/[slug]/take/page.tsx
+   7 app/layout.tsx
+   7 app/(localized)/[locale]/tests/[slug]/take/page.tsx
+   7 app/(localized)/[locale]/tests/[slug]/page.tsx
+   7 app/(localized)/[locale]/page.tsx
+   7 README.md
+   6 tests/e2e/visual/tests-list.visual.spec.ts-snapshots/tests-list-en-chromium-linux.png
+   6 tests/e2e/sds-flow.spec.ts
+   6 tests/e2e/clinical-combo-flow.spec.ts
+   6 tests/e2e/big5-flow.spec.ts
+   6 lib/tracking/events.ts
+   6 lib/content.ts
+   6 content/tests/personality-mbti-test.mdx
+   6 components/layout/SiteHeader.tsx
+   6 components/business/TestCard.tsx
+   6 app/robots.ts
+   6 app/globals.css
+   6 app/(localized)/[locale]/tests/[slug]/take/ClinicalTakeClient.tsx
+   6 .github/workflows/ci.yml
+   6 .env.example
+   5 tests/e2e/visual/tests-list.visual.spec.ts-snapshots/tests-list-en-chromium-darwin.png
+   5 tests/e2e/uat-matrix.spec.ts
+   5 tests/e2e/big5-negative.spec.ts
+   5 next.config.mjs
+```
+
+## 21. 附录D：实跑证据原文摘录（P0）
+
+### 21.1 `php artisan migrate`
+
+```text
+
+   INFO  Nothing to migrate.  
+
+```
+
+### 21.2 `pnpm test:contract` 与 `pnpm test:a11y`（fap-web）
+
+```text
+ WARN  Unsupported engine: wanted: {"node":">=20 <21"} (current: {"node":"v24.11.1","pnpm":"10.28.1"})
+
+> fap-web@0.1.0 test:contract /Users/rainie/Desktop/GitHub/fap-web
+> vitest run tests/contracts -- --runInBand
+
+
+ RUN  v3.2.4 /Users/rainie/Desktop/GitHub/fap-web
+
+ ✓ tests/contracts/quiz-ux-flags.contract.test.ts (2 tests) 2ms
+ ✓ tests/contracts/tracking-whitelist.contract.test.ts (1 test) 2ms
+ ✓ tests/contracts/big5.contract.test.ts (5 tests) 6ms
+ ✓ tests/contracts/clinical.contract.test.ts (4 tests) 7ms
+
+ Test Files  4 passed (4)
+      Tests  12 passed (12)
+   Start at  08:45:46
+   Duration  828ms (transform 121ms, setup 333ms, collect 204ms, tests 17ms, environment 1.75s, prepare 245ms)
+
+ WARN  Unsupported engine: wanted: {"node":">=20 <21"} (current: {"node":"v24.11.1","pnpm":"10.28.1"})
+
+> fap-web@0.1.0 test:a11y /Users/rainie/Desktop/GitHub/fap-web
+> vitest run tests/a11y -- --runInBand
+
+
+ RUN  v3.2.4 /Users/rainie/Desktop/GitHub/fap-web
+
+ ✓ tests/a11y/adaptive-option-group.a11y.test.tsx (2 tests) 76ms
+ ✓ tests/a11y/likert.a11y.test.tsx (1 test) 83ms
+ ✓ tests/a11y/data-glyph.a11y.test.tsx (2 tests) 90ms
+
+ Test Files  3 passed (3)
+      Tests  5 passed (5)
+   Start at  08:45:47
+   Duration  899ms (transform 106ms, setup 153ms, collect 597ms, tests 249ms, environment 864ms, prepare 208ms)
+
+```

--- a/research/deep-research-2026-02-25/证据索引附录_2026-02-25.md
+++ b/research/deep-research-2026-02-25/证据索引附录_2026-02-25.md
@@ -1,0 +1,1397 @@
+# 证据索引附录（超深版 / Evidence Index v2）
+
+- 文档日期：2026-02-25（UTC+8）
+- 对应主报告：`FAP_双仓库深度研究主报告_2026-02-25.md`
+- 证据范围：`fap-api` + `fap-web` + 外部公开对标资料
+- 证据等级：P0 > P1 > P2
+- 证据编号格式：`E-API-*`、`E-WEB-*`、`E-RUN-*`、`E-BM-*`、`E-INV-*`
+
+---
+
+## 1. 证据使用规范
+
+1. 高风险结论必须至少 2 条独立证据（至少 1 条 P0）。
+2. 涉及支付、权限、合规边界、报告生成状态机的结论必须有复现命令。
+3. 外部证据仅使用官方公开页面，全部标注抓取日期（2026-02-25）。
+4. 本附录用于审计和复盘，不替代设计文档；当文档与代码冲突时，以 P0 为准。
+
+---
+
+## 2. 结论-证据映射总表（高价值结论）
+
+| 结论ID | 结论摘要 | 证据编号 | 证据级别 |
+|---|---|---|---|
+| C-001 | API 已实现版本化退役策略（v0.2->410） | E-API-001, E-API-002, E-RUN-001 | P0 |
+| C-002 | v0.3 是主业务面，v0.4 为组织评估扩展 | E-API-003, E-API-004, E-API-005 | P0 |
+| C-003 | token 身份注入具备回归防护 | E-API-010, E-API-011, E-API-012 | P0 |
+| C-004 | org 上下文统一解析避免多点分叉 | E-API-013, E-API-014 | P0 |
+| C-005 | attempt start 具备风控与 consent 入口控制 | E-API-020, E-API-021, E-API-022 | P0 |
+| C-006 | progress 具备恢复能力与 seq 防乱序 | E-API-023, E-API-024 | P0 |
+| C-007 | submit 具备幂等 digest + tx 锁保护 | E-API-025, E-API-026, E-API-027 | P0 |
+| C-008 | 报告生成采用门禁 + 异步快照状态机 | E-API-030, E-API-031, E-API-032, E-API-033 | P0 |
+| C-009 | 商业化链路具备幂等履约防重放能力 | E-API-040, E-API-041, E-API-042, E-API-043 | P0 |
+| C-010 | webhook 已做 provider+event 去重与并发锁 | E-API-044, E-API-045, E-API-046 | P0 |
+| C-011 | web 侧敏感页 noindex 策略完善 | E-WEB-001, E-WEB-002, E-WEB-003 | P0 |
+| C-012 | web API 客户端错误模型结构化 | E-WEB-004, E-WEB-005, E-WEB-006 | P0 |
+| C-013 | take/result/orders 链路有重试和恢复策略 | E-WEB-010, E-WEB-011, E-WEB-012, E-WEB-013 | P0 |
+| C-014 | tracking 有白名单与敏感字段约束 | E-WEB-014, E-WEB-015, E-WEB-016 | P0 |
+| C-015 | 发布治理已制度化（gate/checklist/rollback） | E-WEB-017, E-WEB-018, E-WEB-019 | P1+P0 |
+| C-016 | MBTI CI 主链可实跑通过 | E-RUN-003 | P0 |
+| C-017 | 迁移基线一致且可验证 | E-RUN-002, E-RUN-007 | P0 |
+| C-018 | Truity/16P/123test 在信任资产上更成熟 | E-BM-001~E-BM-017 | P2 |
+| C-019 | FAP 最大风险是复杂度与契约漂移，而非功能缺失 | E-INV-010, E-INV-011, E-INV-012 | P0 |
+| C-020 | 双仓库具备长期运营雏形但缺规模化运营资产 | C-001~C-019 汇总 | 综合 |
+
+---
+
+## 3. fap-api 核心证据卡片（P0）
+
+### 3.1 路由与版本策略
+
+| 编号 | 断言 | 证据位置 | 复现方式 | 影响面 |
+|---|---|---|---|---|
+| E-API-001 | v0.2 退役并统一 410 | `backend/routes/api.php:46-57` | `php artisan route:list` + 访问 `/api/v0.2/*` | 历史客户端兼容与风险收敛 |
+| E-API-002 | v0.3 主业务入口 | `backend/routes/api.php:59-202` | `php artisan route:list --json` 过滤 `api/v0.3` | 新业务迭代主战场 |
+| E-API-003 | webhook 为公共入口，避免 token 依赖 | `backend/routes/api.php:68-74` | 直接 POST webhook 路径 | 支付可用性 |
+| E-API-004 | attempts 主链齐全（start/submit/progress/report） | `backend/routes/api.php:107-131` | 路由过滤 + curl | 用户主漏斗 |
+| E-API-005 | commerce 主链齐全 | `backend/routes/api.php:133-156` | 路由过滤 + curl | 营收链路 |
+| E-API-006 | 组织评估扩展在 v0.4 | `backend/routes/api.php:204-217` | 路由过滤 `api/v0.4` | B2B 扩展 |
+| E-API-007 | healthz 独立路由并受访问控制 | `backend/routes/api.php:42-44` | `GET /api/healthz` | 运维可观测性 |
+
+### 3.2 鉴权、身份、组织上下文
+
+| 编号 | 断言 | 证据位置 | 复现方式 | 风险控制价值 |
+|---|---|---|---|---|
+| E-API-010 | FmTokenAuth 解析 Bearer 并做格式校验 | `FmTokenAuth.php:20-29` | 构造非法 token 请求 | 拦截伪造 token |
+| E-API-011 | token_hash 优先，兼容 legacy token 回填 hash | `FmTokenAuth.php:45-68` | 查 DB 与日志 | 平滑升级 |
+| E-API-012 | revoked/expired 拒绝 | `FmTokenAuth.php:74-83` | 构造过期 token | 身份时效控制 |
+| E-API-013 | 注入 `fm_user_id` 与 `user_id` | `FmTokenAuth.php:85-111` | 中间件链路请求 | 统一身份事实 |
+| E-API-014 | 注入后一致性断言 | `FmTokenAuth.php:273-298` | 回归测试 | 防止注入漂移 |
+| E-API-015 | 绑定 org_id/org_role/anon_id 与 OrgContext | `FmTokenAuth.php:119-143` | 读取请求 attr | 组织隔离基础 |
+| E-API-016 | unauthorized 响应包含 request_id | `FmTokenAuth.php:321-347` | 无 token 请求 | 可追踪错误 |
+| E-API-017 | FmTokenOptional 不阻断请求 | `FmTokenOptional.php:28-41` | 无 token 访问 share | 匿名友好 |
+| E-API-018 | Optional token 下仍可注入上下文 | `FmTokenOptional.php:98-123` | 带 token 访问 share | 渐进身份 |
+| E-API-019 | ResolveOrgContext 统一解析 org 来源 | `ResolveOrgContext.php:83-111` | header/query/token 组合验证 | 组织上下文统一 |
+| E-API-020 | ResolveOrgContext 可从 token 回填 anon_id | `ResolveOrgContext.php:31-37,165-178` | token-only 请求 | 归属一致性 |
+
+### 3.3 Attempt 生命周期
+
+| 编号 | 断言 | 证据位置 | 复现方式 | 业务意义 |
+|---|---|---|---|---|
+| E-API-021 | start 调用 ScaleRolloutGate | `AttemptStartService.php:61` | 关闭某量表开关后 start | 灰度与关停能力 |
+| E-API-022 | Big5 retake policy（冷却+次数） | `AttemptStartService.php:63-73` | 连续 start 验证 | 防滥用 |
+| E-API-023 | Clinical consent 版本哈希强校验 | `AttemptStartService.php:85-115` | 提交错误 hash | 临床合规边界 |
+| E-API-024 | SDS consent/disclaimer 写入 meta | `AttemptStartService.php:117-155` | start 响应与 DB 校验 | 证据留痕 |
+| E-API-025 | start 创建 draft/resume token | `AttemptStartService.php:219-274` | start 返回字段核对 | 中断恢复 |
+| E-API-026 | progress 检查过期并返回 410 | `AttemptProgressService.php:55-63` | 过期 token 读取 | 生命周期清晰 |
+| E-API-027 | progress owner 校验防越权 | `AttemptProgressService.php:65-81,163-179` | 换 anon/user 重放 | 防 IDOR |
+| E-API-028 | progress seq 防乱序（409） | `AttemptProgressService.php:83-96` | 逆序提交 seq | 防并发覆盖 |
+| E-API-029 | progress DB+Cache 双层 | `AttemptProgressService.php:217-281` | 压测/缓存故障 | 韧性 |
+| E-API-030 | submit 合并 draft+request answers | `AttemptSubmitService.php:75-79,677-706` | 先 progress 后 submit | 数据完整性 |
+| E-API-031 | submit digest 幂等语义 | `AttemptSubmitService.php:184-207,669-675` | 同/异 digest 重放 | 幂等与冲突可判 |
+| E-API-032 | submit tx + lockForUpdate | `AttemptSubmitService.php:155-183` | 并发提交模拟 | 写入一致性 |
+| E-API-033 | submit afterCommit 触发 snapshot job | `AttemptSubmitService.php:470-477` | 提交后观察 job | 低延迟异步化 |
+| E-API-034 | submit 返回 `idempotent` 标志 | `AttemptSubmitService.php:733-749` | 重放 submit | 客户端可判重 |
+
+### 3.4 报告门禁与快照
+
+| 编号 | 断言 | 证据位置 | 复现方式 | 价值 |
+|---|---|---|---|---|
+| E-API-040 | gatekeeper 统一 access 判定 | `ReportGatekeeper.php:43-94` | report 接口对比 paid/unpaid | 单点门禁 |
+| E-API-041 | gatekeeper 管理 modules allowed/offered | `ReportGatekeeper.php:148-199` | paid/unpaid 比较 payload | 模块级商业化 |
+| E-API-042 | crisis 场景移除 offers | `ReportGatekeeper.php:205-214` | 触发 crisis 报告 | 伦理安全 |
+| E-API-043 | snapshot pending->generating | `ReportGatekeeper.php:229-250` | 刚支付后拉 report | 用户可解释等待 |
+| E-API-044 | snapshot failed->snapshot_error | `ReportGatekeeper.php:252-271` | 人工注入 failed | 可恢复诊断 |
+| E-API-045 | snapshot ready 读 full/free json | `ReportGatekeeper.php:273-291` | 状态 ready 读取 | 性能与稳定 |
+| E-API-046 | seed pending snapshot | `ReportSnapshotStore.php:29-96` | unlock 后检查 row | 状态机起点 |
+| E-API-047 | create snapshot 写 ready | `ReportSnapshotStore.php:175-201` | 执行 job 后检查 row | 状态机闭环 |
+| E-API-048 | snapshot create 记录事件 | `ReportSnapshotStore.php:202-214` | events 表检查 | 可审计 |
+| E-API-049 | snapshot job tries/backoff | `GenerateReportSnapshotJob.php:20-23` | 失败重试观测 | 抖动容错 |
+| E-API-050 | snapshot job 失败写 last_error | `GenerateReportSnapshotJob.php:71-85` | 人工 throw 异常 | 定位可用 |
+
+### 3.5 订单、支付、Webhook
+
+| 编号 | 断言 | 证据位置 | 复现方式 | 风险控制 |
+|---|---|---|---|---|
+| E-API-060 | 订单支持 provider scoped idempotency | `OrderManager.php:66-160` | 重复 key 下单 | 防重复订单 |
+| E-API-061 | 订单 ownership 校验 | `OrderManager.php:187-219` | 非 owner 查单 | 防越权 |
+| E-API-062 | paid 转移原子化 | `OrderManager.php:222-303` | 并发支付模拟 | 一致性 |
+| E-API-063 | webhook lock + tx + dedupe | `PaymentWebhookHandlerCore.php:103-197` | 并发重放 provider_event_id | 防重入 |
+| E-API-064 | signature invalid 拒绝 | `PaymentWebhookHandlerCore.php:230-234` | 错签名请求 | 安全边界 |
+| E-API-065 | provider mismatch 拒绝 | `PaymentWebhookHandlerCore.php:247-269` | provider 不匹配 | 防跨通道污染 |
+| E-API-066 | validate paid event guard | `PaymentWebhookHandlerCore.php:331-342` | 非白名单 event_type | 防异常事件 |
+| E-API-067 | report_unlock 必须校验 attempt/owner/scale | `PaymentWebhookHandlerCore.php:450-474` | 构造 mismatch | 防错解锁 |
+| E-API-068 | entitlement grant 后 seed snapshot | `PaymentWebhookHandlerCore.php:492-535,821-833` | 成功支付后检查快照 | 履约完整性 |
+| E-API-069 | post-commit 失败可标记错误状态 | `PaymentWebhookHandlerCore.php:589-605` | 人为触发失败 | 故障可追踪 |
+| E-API-070 | webhook dry-run 评估函数 | `PaymentWebhookHandlerCore.php:647-701` | 调用 dry-run | 上线前验收 |
+
+### 3.6 配置、门禁与脚本
+
+| 编号 | 断言 | 证据位置 | 复现方式 | 价值 |
+|---|---|---|---|---|
+| E-API-080 | schema_baseline 定义 required tables/columns | `config/fap.php:34-188` | `php artisan fap:schema:verify` | 迁移安全 |
+| E-API-081 | rate_limits 配置集中 | `config/fap.php:224-230` | 配置检查 | 抗流量冲击 |
+| E-API-082 | ci_verify 强制 deterministic env | `scripts/ci_verify_mbti.sh:4-34` | 查看脚本开头 | CI 稳定性 |
+| E-API-083 | ci_verify 支持按量表 gate | `scripts/ci_verify_mbti.sh:59-113` | 设置 env 运行 | 分层回归 |
+| E-API-084 | ci_verify 含 MBTI E2E + 事件验收 + migration gate | `scripts/ci_verify_mbti.sh` 全链路 | 执行脚本 | 主链托底 |
+| E-API-085 | verify_mbti 提供 HTTP E2E 验证 | `scripts/verify_mbti.sh:15-127` | 执行脚本 | 对外链路可验证 |
+| E-API-086 | security_gate 检查路由鉴权与 mass assignment | `scripts/security_gate.sh:28-146` | 执行脚本 | 发布前安全门禁 |
+
+---
+
+## 4. fap-web 核心证据卡片（P0）
+
+### 4.1 中间件与站点策略
+
+| 编号 | 断言 | 证据位置 | 复现方式 | 价值 |
+|---|---|---|---|---|
+| E-WEB-001 | 中间件维护 anon cookie/header 一致性 | `middleware.ts:47-71` | 请求链路查看头 | 漏斗连续性 |
+| E-WEB-002 | 敏感路径 noindex | `middleware.ts:9-20,73-75` | 访问 result/orders/share | 隐私与SEO防污染 |
+| E-WEB-003 | next headers 对敏感路径二次兜底 | `next.config.mjs:26-53` | curl 响应头 | 稳定策略 |
+| E-WEB-004 | `/api/v0.3` rewrite 到后端 | `next.config.mjs:89-99` | 本地代理请求 | 部署简化 |
+
+### 4.2 API 客户端与契约层
+
+| 编号 | 断言 | 证据位置 | 复现方式 | 价值 |
+|---|---|---|---|---|
+| E-WEB-010 | request timeout + abort | `lib/api-client.ts:63-103` | 人工超时请求 | 体验韧性 |
+| E-WEB-011 | 自动注入 locale/auth | `lib/api-client.ts:72-83` | 查看请求头 | 一致上下文 |
+| E-WEB-012 | ApiError 结构化 | `lib/api-client.ts:105-152` | 触发 4xx/5xx | 统一错误处理 |
+| E-WEB-013 | v0_3 定义 report/order 等核心类型 | `lib/api/v0_3.ts:185-248` | 静态审查 | 契约集中化 |
+| E-WEB-014 | checkout 传 idempotency key | `lib/api/v0_3.ts:695-729` | 抓包 | 防重复支付 |
+| E-WEB-015 | order status 归一化 | `lib/api/v0_3.ts:397-411,731-746` | 多状态模拟 | 页面状态一致 |
+
+### 4.3 take/result/orders 关键链路
+
+| 编号 | 断言 | 证据位置 | 复现方式 | 价值 |
+|---|---|---|---|---|
+| E-WEB-020 | Big5 take rollout gate | `Big5TakeClient.tsx:271-308` | 关闭能力开关 | 避免误放量 |
+| E-WEB-021 | questions load failure 分类上报 | `Big5TakeClient.tsx:380-392` | 模拟 5xx | 可观测性 |
+| E-WEB-022 | start 重试 + 429 处理 | `Big5TakeClient.tsx:433-494` | 压测/限流 | 用户恢复 |
+| E-WEB-023 | submit 缺题拦截 + 错误分类 | `Big5TakeClient.tsx:545-624` | 缺题提交 | 数据质量 |
+| E-WEB-024 | submit overlay 分阶段埋点 | `Big5TakeClient.tsx:649-684` | 提交观察事件 | 感知优化 |
+| E-WEB-025 | Clinical consent snapshot 缺失阻断提交 | `ClinicalTakeClient.tsx:409-418` | 清空 consent 数据 | 合规边界 |
+| E-WEB-026 | Clinical submit 失败捕获 + Sentry | `ClinicalTakeClient.tsx:468-487` | 模拟失败 | 排障效率 |
+| E-WEB-027 | Result 页 generating 轮询与 retry | `ResultClient.tsx:301-307` | report pending 场景 | 等待可解释 |
+| E-WEB-028 | Result 页 report_load_failure 事件 | `ResultClient.tsx:317-325` | 拉取失败 | 线上定位 |
+| E-WEB-029 | Result 支付入口 idempotency key | `ResultClient.tsx:470-482` | 触发 checkout | 防重复下单 |
+| E-WEB-030 | Orders 页 backoff 轮询 + timeout | `OrdersClient.tsx:18-20,62-72,167-175` | pending 长时间场景 | 可恢复性 |
+| E-WEB-031 | Orders paid 自动跳转 result | `OrdersClient.tsx:96-130` | 支付成功后回跳 | 转化稳定 |
+
+### 4.4 tracking、consent、发布治理
+
+| 编号 | 断言 | 证据位置 | 复现方式 | 价值 |
+|---|---|---|---|---|
+| E-WEB-040 | 事件白名单按 event_name 控字段 | `lib/tracking/events.ts:74-115` | 发送超字段 | 数据最小化 |
+| E-WEB-041 | forbidden 字段片段拦截 | `lib/tracking/events.ts:117-150` | 注入 email/token 字段 | 防敏感泄漏 |
+| E-WEB-042 | /api/track payload 大小限制 | `app/api/track/route.ts:8,27-31` | >8KB 请求 | 滥用防护 |
+| E-WEB-043 | /api/track 校验 eventName | `app/api/track/route.ts:38-41` | 非法事件名 | 数据质量 |
+| E-WEB-044 | consent 三态持久化 | `lib/consent/store.ts:1-65` | 本地存取 | 隐私控制 |
+| E-WEB-045 | logger redaction | `lib/observability/logger.ts:1-47` | 输出敏感对象 | 安全日志 |
+| E-WEB-046 | sentry captureError 附 route/scale/stage | `lib/observability/sentry.ts:33-59` | 抛错事件 | 排障加速 |
+| E-WEB-047 | release gate 禁止敏感/构建文件入库 | `scripts/release_gate.sh:20-114` | 执行脚本 | 发布卫生 |
+| E-WEB-048 | rollback smoke 校验 questions->submit->report | `scripts/rollback_smoke.sh:42-128` | 执行脚本 | 回滚可用性 |
+
+---
+
+## 5. 实跑证据（P0）
+
+### 5.1 API 命令
+
+| 编号 | 命令 | 结果 |
+|---|---|---|
+| E-RUN-001 | `php artisan route:list` | 显示 122 routes |
+| E-RUN-002 | `php artisan migrate` | Nothing to migrate |
+| E-RUN-003 | `bash scripts/ci_verify_mbti.sh` | 全链路通过，退出 0 |
+| E-RUN-004 | `php artisan route:list --json` | 生成可审计路由清单 |
+
+### 5.2 Web 命令
+
+| 编号 | 命令 | 结果 |
+|---|---|---|
+| E-RUN-010 | `pnpm test:contract` | 4 files / 12 tests 通过 |
+| E-RUN-011 | `pnpm test:a11y` | 3 files / 5 tests 通过 |
+
+---
+
+## 6. 仓库文档证据（P1）
+
+| 编号 | 主题 | 证据位置 | 备注 |
+|---|---|---|---|
+| E-DOC-001 | Web/API 边界 | `fap-web/docs/architecture/web-boundary.md` | 职责划分清晰 |
+| E-DOC-002 | Production launch checklist | `fap-web/docs/release/production-launch-checklist.md` | 发布门禁制度化 |
+| E-DOC-003 | Rollback drill | `fap-web/docs/release/rollback-drill.md` | 10 分钟恢复目标 |
+| E-DOC-004 | Queue runbook | `fap-api/docs/04-ops/queue-runbook.md` | queue 运行策略 |
+| E-DOC-005 | Observability | `fap-api/docs/04-ops/observability.md` | 指标阈值建议 |
+| E-DOC-006 | Go-live gate | `fap-api/docs/04-ops/go-live-gate-checklist.md` | Stop-ship 标准 |
+| E-DOC-007 | webhook idempotency | `fap-api/docs/payments/webhook-idempotency.md` | 回调幂等准则 |
+| E-DOC-008 | SEO url strategy | `fap-web/docs/seo/url-strategy.md` | canonical/noindex 规范 |
+| E-DOC-009 | structured data spec | `fap-web/docs/seo/structured-data-spec.md` | GEO/SEO 数据规范 |
+| E-DOC-010 | landing meta spec | `fap-web/docs/seo/landing-meta-spec.md` | 内容资产化规范 |
+
+---
+
+## 7. 外部对标证据（P2，抓取日期：2026-02-25）
+
+| 编号 | 对标对象 | 观察点 | 来源 |
+|---|---|---|---|
+| E-BM-001 | Truity | TypeFinder 标注约 130 questions / 15 mins | https://www.truity.com/test/type-finder-personality-test-new |
+| E-BM-002 | Truity | 免费基础结果 + 付费完整版 | https://www.truity.com/test/type-finder-personality-test-new |
+| E-BM-003 | Truity | About 页面展示长期用户规模（百万级） | https://www.truity.com/about-us |
+| E-BM-004 | Truity | 技术文档公开方法学与可靠性口径 | https://www.truity.com/page/technical-documentation |
+| E-BM-005 | Truity | 提供 Test API 入口（B2B 信号） | https://www.truity.com/test-api |
+| E-BM-006 | Truity | 隐私政策含 CCPA/GPC 相关说明 | https://www.truity.com/privacy-policy |
+| E-BM-007 | 16Personalities | free personality test 主入口与产品导航 | https://www.16personalities.com/free-personality-test |
+| E-BM-008 | 16Personalities | country profiles 与全球化语言覆盖信号 | https://www.16personalities.com/country-profiles |
+| E-BM-009 | 16Personalities | Terms 声明用途边界（非医疗/非招聘） | https://www.16personalities.com/terms |
+| E-BM-010 | 16Personalities | Privacy 声明数据处理与不出售个人数据口径 | https://www.16personalities.com/terms/privacy |
+| E-BM-011 | 16Personalities | Accessibility statement（WCAG/EN 标准） | https://www.16personalities.com/accessibility-statement |
+| E-BM-012 | 123test | About 页面披露历史与规模信号 | https://www.123test.com/about/ |
+| E-BM-013 | 123test | Personality test 标注题量与时长 | https://www.123test.com/personality-test/ |
+| E-BM-014 | 123test | Using our tests 提供 API/white label | https://www.123test.com/using-our-tests/ |
+| E-BM-015 | 123test | Disclaimer 明确非医疗诊断替代 | https://www.123test.com/disclaimer/ |
+
+---
+
+## 8. 证据完整性说明
+
+1. 本附录已覆盖：路由、身份、attempt、报告、支付、前端主链、tracking、发布、文档、外部对标。
+2. 可追溯性要求：每条高风险结论均可回链到至少一个 P0 编号。
+3. 若后续新增结论，请追加 `E-*` 编号，不覆盖既有编号。
+
+
+---
+
+## 9. 全量证据底稿（可审计原始清单）
+
+### 9.1 API 全量路由（122）
+
+| Method | URI | Name | Action |
+|---|---|---|---|
+|GET|HEAD|/||Closure|
+|GET|HEAD|POST|PUT|PATCH|DELETE|OPTIONS|admin||Illuminate\Routing\RedirectController|
+|GET|HEAD|admin/{path}||Closure|
+|GET|HEAD|api/healthz|healthz|App\Http\Controllers\HealthzController@show|
+|GET|HEAD|api/user||Closure|
+|GET|HEAD|POST|PUT|PATCH|DELETE|OPTIONS|api/v0.2/{any?}||Closure|
+|POST|api/v0.3/attempts/start||App\Http\Controllers\API\V0_3\AttemptWriteController@start|
+|POST|api/v0.3/attempts/submit||App\Http\Controllers\API\V0_3\AttemptWriteController@submit|
+|PUT|api/v0.3/attempts/{attempt_id}/progress||App\Http\Controllers\API\V0_3\AttemptProgressController@upsert|
+|GET|HEAD|api/v0.3/attempts/{attempt_id}/progress||App\Http\Controllers\API\V0_3\AttemptProgressController@show|
+|GET|HEAD|api/v0.3/attempts/{id}|api.v0_3.attempts.show|App\Http\Controllers\API\V0_3\AttemptReadController@show|
+|GET|HEAD|api/v0.3/attempts/{id}/report|api.v0_3.attempts.report|App\Http\Controllers\API\V0_3\AttemptReadController@report|
+|GET|HEAD|api/v0.3/attempts/{id}/report.pdf|api.v0_3.attempts.report_pdf|App\Http\Controllers\API\V0_3\AttemptReadController@reportPdf|
+|GET|HEAD|api/v0.3/attempts/{id}/result|api.v0_3.attempts.result|App\Http\Controllers\API\V0_3\AttemptReadController@result|
+|GET|HEAD|api/v0.3/attempts/{id}/share||App\Http\Controllers\API\V0_3\ShareController@getShare|
+|POST|api/v0.3/auth/phone/send_code||App\Http\Controllers\API\V0_3\AuthPhoneController@sendCode|
+|POST|api/v0.3/auth/phone/verify||App\Http\Controllers\API\V0_3\AuthPhoneController@verify|
+|POST|api/v0.3/auth/wx_phone||App\Http\Controllers\API\V0_3\AuthWxPhoneController|
+|GET|HEAD|api/v0.3/boot||App\Http\Controllers\API\V0_3\BootController@show|
+|GET|HEAD|api/v0.3/claim/report||App\Http\Controllers\API\V0_3\ClaimController@report|
+|GET|HEAD|api/v0.3/experiments||App\Http\Controllers\API\V0_3\BootController@experiments|
+|GET|HEAD|api/v0.3/flags||App\Http\Controllers\API\V0_3\BootController@flags|
+|GET|HEAD|api/v0.3/me/attempts||App\Http\Controllers\API\V0_3\MeController@attempts|
+|POST|api/v0.3/orders||App\Http\Controllers\API\V0_3\CommerceController@createOrder|
+|POST|api/v0.3/orders/checkout||App\Http\Controllers\API\V0_3\CommerceController@checkout|
+|POST|api/v0.3/orders/lookup||App\Http\Controllers\API\V0_3\CommerceController@lookup|
+|POST|api/v0.3/orders/stub||Closure|
+|GET|HEAD|api/v0.3/orders/{order_no}||App\Http\Controllers\API\V0_3\CommerceController@getOrder|
+|POST|api/v0.3/orders/{order_no}/resend||App\Http\Controllers\API\V0_3\CommerceController@resend|
+|POST|api/v0.3/orders/{provider}||App\Http\Controllers\API\V0_3\CommerceController@createOrder|
+|POST|api/v0.3/orgs||App\Http\Controllers\API\V0_3\OrgsController@store|
+|POST|api/v0.3/orgs/invites/accept||App\Http\Controllers\API\V0_3\OrgInvitesController@accept|
+|GET|HEAD|api/v0.3/orgs/me||App\Http\Controllers\API\V0_3\OrgsController@me|
+|GET|HEAD|api/v0.3/orgs/{org_id}/big5/audits||App\Http\Controllers\API\V0_3\BigFiveOpsController@audits|
+|GET|HEAD|api/v0.3/orgs/{org_id}/big5/audits/{audit_id}||App\Http\Controllers\API\V0_3\BigFiveOpsController@audit|
+|POST|api/v0.3/orgs/{org_id}/big5/norms/activate||App\Http\Controllers\API\V0_3\BigFiveOpsController@activateNorms|
+|POST|api/v0.3/orgs/{org_id}/big5/norms/drift-check||App\Http\Controllers\API\V0_3\BigFiveOpsController@driftCheckNorms|
+|POST|api/v0.3/orgs/{org_id}/big5/norms/rebuild||App\Http\Controllers\API\V0_3\BigFiveOpsController@rebuildNorms|
+|GET|HEAD|api/v0.3/orgs/{org_id}/big5/releases||App\Http\Controllers\API\V0_3\BigFiveOpsController@releases|
+|GET|HEAD|api/v0.3/orgs/{org_id}/big5/releases/latest||App\Http\Controllers\API\V0_3\BigFiveOpsController@latest|
+|GET|HEAD|api/v0.3/orgs/{org_id}/big5/releases/latest/audits||App\Http\Controllers\API\V0_3\BigFiveOpsController@latestAudits|
+|POST|api/v0.3/orgs/{org_id}/big5/releases/publish||App\Http\Controllers\API\V0_3\BigFiveOpsController@publish|
+|POST|api/v0.3/orgs/{org_id}/big5/releases/rollback||App\Http\Controllers\API\V0_3\BigFiveOpsController@rollback|
+|GET|HEAD|api/v0.3/orgs/{org_id}/big5/releases/{release_id}||App\Http\Controllers\API\V0_3\BigFiveOpsController@release|
+|POST|api/v0.3/orgs/{org_id}/invites||App\Http\Controllers\API\V0_3\OrgInvitesController@store|
+|GET|HEAD|api/v0.3/orgs/{org_id}/wallets||App\Http\Controllers\API\V0_3\OrgWalletController@wallets|
+|GET|HEAD|api/v0.3/orgs/{org_id}/wallets/{benefit_code}/ledger||App\Http\Controllers\API\V0_3\OrgWalletController@ledger|
+|GET|HEAD|api/v0.3/scales||App\Http\Controllers\API\V0_3\ScalesController@index|
+|GET|HEAD|api/v0.3/scales/lookup||App\Http\Controllers\API\V0_3\ScalesLookupController@lookup|
+|GET|HEAD|api/v0.3/scales/sitemap-source||App\Http\Controllers\API\V0_3\ScalesSitemapSourceController@index|
+|GET|HEAD|api/v0.3/scales/{scale_code}||App\Http\Controllers\API\V0_3\ScalesController@show|
+|GET|HEAD|api/v0.3/scales/{scale_code}/questions||App\Http\Controllers\API\V0_3\ScalesController@questions|
+|GET|HEAD|api/v0.3/shares/{id}||App\Http\Controllers\API\V0_3\ShareController@getShareView|
+|POST|api/v0.3/shares/{shareId}/click||App\Http\Controllers\API\V0_3\ShareController@click|
+|GET|HEAD|api/v0.3/skus|api.v0_3.skus|App\Http\Controllers\API\V0_3\CommerceController@listSkus|
+|POST|api/v0.3/webhooks/payment/{provider}|api.v0_3.webhooks.payment|App\Http\Controllers\API\V0_3\Webhooks\PaymentWebhookController@handle|
+|GET|HEAD|api/v0.4/boot||App\Http\Controllers\API\V0_4\BootController@show|
+|POST|api/v0.4/orgs/{org_id}/assessments||App\Http\Controllers\API\V0_4\AssessmentController@store|
+|POST|api/v0.4/orgs/{org_id}/assessments/{id}/invite||App\Http\Controllers\API\V0_4\AssessmentController@invite|
+|GET|HEAD|api/v0.4/orgs/{org_id}/assessments/{id}/progress||App\Http\Controllers\API\V0_4\AssessmentController@progress|
+|GET|HEAD|api/v0.4/orgs/{org_id}/assessments/{id}/summary||App\Http\Controllers\API\V0_4\AssessmentController@summary|
+|GET|HEAD|filament/exports/{export}/download|filament.exports.download|Filament\Actions\Exports\Http\Controllers\DownloadExport|
+|GET|HEAD|filament/imports/{import}/failed-rows/download|filament.imports.failed-rows.download|Filament\Actions\Imports\Http\Controllers\DownloadImportFailureCsv|
+|GET|HEAD|livewire/livewire.js||Livewire\Mechanisms\FrontendAssets\FrontendAssets@returnJavaScriptAsFile|
+|GET|HEAD|livewire/livewire.min.js.map||Livewire\Mechanisms\FrontendAssets\FrontendAssets@maps|
+|GET|HEAD|livewire/preview-file/{filename}|livewire.preview-file|Livewire\Features\SupportFileUploads\FilePreviewController@handle|
+|POST|livewire/update|livewire.update|Livewire\Mechanisms\HandleRequests\HandleRequests@handleUpdate|
+|POST|livewire/upload-file|livewire.upload-file|Livewire\Features\SupportFileUploads\FileUploadController@handle|
+|GET|HEAD|ops|filament.ops.pages.dashboard|App\Filament\Ops\Pages\OpsDashboard|
+|GET|HEAD|ops/admin-approvals|filament.ops.resources.admin-approvals.index|App\Filament\Ops\Resources\AdminApprovalResource\Pages\ListAdminApprovals|
+|GET|HEAD|ops/admin-approvals/{record}|filament.ops.resources.admin-approvals.view|App\Filament\Ops\Resources\AdminApprovalResource\Pages\ViewAdminApproval|
+|GET|HEAD|ops/admin-users|filament.ops.resources.admin-users.index|App\Filament\Ops\Resources\AdminUserResource\Pages\ListAdminUsers|
+|GET|HEAD|ops/admin-users/create|filament.ops.resources.admin-users.create|App\Filament\Ops\Resources\AdminUserResource\Pages\CreateAdminUser|
+|GET|HEAD|ops/admin-users/{record}/edit|filament.ops.resources.admin-users.edit|App\Filament\Ops\Resources\AdminUserResource\Pages\EditAdminUser|
+|GET|HEAD|ops/audit-logs|filament.ops.resources.audit-logs.index|App\Filament\Ops\Resources\AuditLogResource\Pages\ListAuditLogs|
+|GET|HEAD|ops/benefit-grants|filament.ops.resources.benefit-grants.index|App\Filament\Ops\Resources\BenefitGrantResource\Pages\ListBenefitGrants|
+|GET|HEAD|ops/benefit-grants/{record}|filament.ops.resources.benefit-grants.view|App\Filament\Ops\Resources\BenefitGrantResource\Pages\ViewBenefitGrant|
+|GET|HEAD|ops/content-pack-releases|filament.ops.resources.content-pack-releases.index|App\Filament\Ops\Resources\ContentPackReleaseResource\Pages\ListContentPackReleases|
+|GET|HEAD|ops/content-pack-releases/{record}|filament.ops.resources.content-pack-releases.view|App\Filament\Ops\Resources\ContentPackReleaseResource\Pages\ViewContentPackRelease|
+|GET|HEAD|ops/content-pack-versions|filament.ops.resources.content-pack-versions.index|App\Filament\Ops\Resources\ContentPackVersionResource\Pages\ListContentPackVersions|
+|GET|HEAD|ops/content-pack-versions/create|filament.ops.resources.content-pack-versions.create|App\Filament\Ops\Resources\ContentPackVersionResource\Pages\CreateContentPackVersion|
+|GET|HEAD|ops/content-pack-versions/{record}/edit|filament.ops.resources.content-pack-versions.edit|App\Filament\Ops\Resources\ContentPackVersionResource\Pages\EditContentPackVersion|
+|GET|HEAD|ops/content-releases|filament.ops.resources.content-releases.index|App\Filament\Ops\Resources\ContentPackReleaseResource\Pages\ListContentPackReleases|
+|GET|HEAD|ops/content-releases/{record}|filament.ops.resources.content-releases.view|App\Filament\Ops\Resources\ContentPackReleaseResource\Pages\ViewContentPackRelease|
+|GET|HEAD|ops/delivery-tools|filament.ops.pages.delivery-tools|App\Filament\Ops\Pages\DeliveryTools|
+|GET|HEAD|ops/deploys|filament.ops.resources.deploys.index|App\Filament\Ops\Resources\DeployResource\Pages\ListDeployEvents|
+|GET|HEAD|ops/global-search|filament.ops.pages.global-search|App\Filament\Ops\Pages\GlobalSearchPage|
+|GET|HEAD|ops/go-live-gate|filament.ops.pages.go-live-gate|App\Filament\Ops\Pages\GoLiveGatePage|
+|GET|HEAD|ops/health-checks|filament.ops.pages.health-checks|App\Filament\Ops\Pages\HealthChecks|
+|GET|HEAD|ops/login|filament.ops.auth.login|Filament\Pages\Auth\Login|
+|POST|ops/logout|filament.ops.auth.logout|Filament\Http\Controllers\Auth\LogoutController|
+|GET|HEAD|ops/order-lookup|filament.ops.pages.order-lookup|App\Filament\Ops\Pages\OrderLookup|
+|GET|HEAD|ops/orders|filament.ops.resources.orders.index|App\Filament\Ops\Resources\OrderResource\Pages\ListOrders|
+|GET|HEAD|ops/orders/{record}|filament.ops.resources.orders.view|App\Filament\Ops\Resources\OrderResource\Pages\ViewOrder|
+|GET|HEAD|ops/organizations|filament.ops.resources.organizations.index|App\Filament\Ops\Resources\OrganizationResource\Pages\ListOrganizations|
+|GET|HEAD|ops/organizations-import|filament.ops.pages.organizations-import|App\Filament\Ops\Pages\OrganizationsImportPage|
+|GET|HEAD|ops/organizations/create|filament.ops.resources.organizations.create|App\Filament\Ops\Resources\OrganizationResource\Pages\CreateOrganization|
+|GET|HEAD|ops/organizations/{record}/edit|filament.ops.resources.organizations.edit|App\Filament\Ops\Resources\OrganizationResource\Pages\EditOrganization|
+|GET|HEAD|ops/payment-events|filament.ops.resources.payment-events.index|App\Filament\Ops\Resources\PaymentEventResource\Pages\ListPaymentEvents|
+|GET|HEAD|ops/payment-events/{record}|filament.ops.resources.payment-events.view|App\Filament\Ops\Resources\PaymentEventResource\Pages\ViewPaymentEvent|
+|GET|HEAD|ops/permissions|filament.ops.resources.permissions.index|App\Filament\Ops\Resources\PermissionResource\Pages\ListPermissions|
+|GET|HEAD|ops/permissions/create|filament.ops.resources.permissions.create|App\Filament\Ops\Resources\PermissionResource\Pages\CreatePermission|
+|GET|HEAD|ops/permissions/{record}/edit|filament.ops.resources.permissions.edit|App\Filament\Ops\Resources\PermissionResource\Pages\EditPermission|
+|GET|HEAD|ops/queue-monitor|filament.ops.pages.queue-monitor|App\Filament\Ops\Pages\QueueMonitor|
+|GET|HEAD|ops/roles|filament.ops.resources.roles.index|App\Filament\Ops\Resources\RoleResource\Pages\ListRoles|
+|GET|HEAD|ops/roles/create|filament.ops.resources.roles.create|App\Filament\Ops\Resources\RoleResource\Pages\CreateRole|
+|GET|HEAD|ops/roles/{record}/edit|filament.ops.resources.roles.edit|App\Filament\Ops\Resources\RoleResource\Pages\EditRole|
+|GET|HEAD|ops/scale-registries|filament.ops.resources.scale-registries.index|App\Filament\Ops\Resources\ScaleRegistryResource\Pages\ListScaleRegistries|
+|GET|HEAD|ops/scale-registries/create|filament.ops.resources.scale-registries.create|App\Filament\Ops\Resources\ScaleRegistryResource\Pages\CreateScaleRegistry|
+|GET|HEAD|ops/scale-registries/{record}/edit|filament.ops.resources.scale-registries.edit|App\Filament\Ops\Resources\ScaleRegistryResource\Pages\EditScaleRegistry|
+|GET|HEAD|ops/scale-slugs|filament.ops.resources.scale-slugs.index|App\Filament\Ops\Resources\ScaleSlugResource\Pages\ListScaleSlugs|
+|GET|HEAD|ops/scale-slugs/create|filament.ops.resources.scale-slugs.create|App\Filament\Ops\Resources\ScaleSlugResource\Pages\CreateScaleSlug|
+|GET|HEAD|ops/scale-slugs/{record}/edit|filament.ops.resources.scale-slugs.edit|App\Filament\Ops\Resources\ScaleSlugResource\Pages\EditScaleSlug|
+|GET|HEAD|ops/secure-link|filament.ops.pages.secure-link|App\Filament\Ops\Pages\SecureLink|
+|GET|HEAD|ops/select-org|filament.ops.pages.select-org|App\Filament\Ops\Pages\SelectOrgPage|
+|GET|HEAD|ops/skus|filament.ops.resources.skus.index|App\Filament\Ops\Resources\SkuResource\Pages\ListSkus|
+|GET|HEAD|ops/two-factor-challenge|filament.ops.pages.two-factor-challenge|App\Filament\Ops\Pages\TwoFactorChallenge|
+|GET|HEAD|ops/webhook-monitor|filament.ops.pages.webhook-monitor|App\Filament\Ops\Pages\WebhookMonitor|
+|GET|HEAD|sitemap.xml||App\Http\Controllers\SitemapController@index|
+|GET|HEAD|storage/{path}|storage.local|Closure|
+|GET|HEAD|tenant||Closure|
+|GET|HEAD|up||Closure|
+
+### 9.2 fap-api 迁移全量清单（147）
+
+```text
+database/migrations/0001_01_01_000000_create_users_table.php
+database/migrations/0001_01_01_000001_create_cache_table.php
+database/migrations/0001_01_01_000002_create_jobs_table.php
+database/migrations/2025_12_13_231207_create_results_table.php
+database/migrations/2025_12_14_084436_create_attempts_table.php
+database/migrations/2025_12_14_091106_create_events_table.php
+database/migrations/2025_12_15_165419_add_v021_fields_to_results_table.php
+database/migrations/2025_12_15_171546_create_shares_table.php
+database/migrations/2025_12_17_165938_create_events_table.php
+database/migrations/2025_12_21_101327_add_answers_fields_to_attempts_table.php
+database/migrations/2025_12_28_064425_add_region_locale_to_attempts_table.php
+database/migrations/2026_01_17_040640_add_ticket_code_to_attempts_table.php
+database/migrations/2026_01_17_164755_add_result_json_to_attempts_table.php
+database/migrations/2026_01_18_134019_create_fm_tokens_table.php
+database/migrations/2026_01_18_999999_add_share_id_to_events_table.php
+database/migrations/2026_01_19_111914_add_phone_fields_to_users_table.php
+database/migrations/2026_01_19_111915_add_user_id_to_attempts_table.php
+database/migrations/2026_01_19_170606_add_email_fields_to_users_table.php
+database/migrations/2026_01_19_170607_create_email_outbox_table.php
+database/migrations/2026_01_19_180001_create_identities_table.php
+database/migrations/2026_01_20_090001_add_attempt_id_to_email_outbox_table.php
+database/migrations/2026_01_20_090002_create_lookup_events_table.php
+database/migrations/2026_01_21_090000_create_norms_tables.php
+database/migrations/2026_01_22_000001_create_validity_feedbacks_table.php
+database/migrations/2026_01_22_090010_create_orders_table.php
+database/migrations/2026_01_22_090020_create_benefit_grants_table.php
+database/migrations/2026_01_22_090030_create_payment_events_table.php
+database/migrations/2026_01_24_162556_add_user_id_to_fm_tokens_table.php
+database/migrations/2026_01_26_090000_create_report_jobs_table.php
+database/migrations/2026_01_26_110000_create_content_pack_versions_table.php
+database/migrations/2026_01_26_110100_create_content_pack_releases_table.php
+database/migrations/2026_01_27_210000_pr9_add_observability_columns_to_events.php
+database/migrations/2026_01_27_210100_create_ops_deploy_events.php
+database/migrations/2026_01_27_210200_create_ops_healthz_snapshots.php
+database/migrations/2026_01_27_210300_create_views_pr9.php
+database/migrations/2026_01_27_210350_refresh_views_pr9.php
+database/migrations/2026_01_28_090000_create_admin_users_table.php
+database/migrations/2026_01_28_090010_create_roles_table.php
+database/migrations/2026_01_28_090020_create_permissions_table.php
+database/migrations/2026_01_28_090030_create_role_user_table.php
+database/migrations/2026_01_28_090040_create_permission_role_table.php
+database/migrations/2026_01_28_090050_create_audit_logs_table.php
+database/migrations/2026_01_28_110000_add_psychometrics_snapshot_to_attempts.php
+database/migrations/2026_01_28_110100_create_scale_norms_versions_table.php
+database/migrations/2026_01_28_110200_create_attempt_quality_table.php
+database/migrations/2026_01_28_120000_create_ai_insights_table.php
+database/migrations/2026_01_28_120100_create_ai_insight_feedback_table.php
+database/migrations/2026_01_28_130000_create_integrations_tables.php
+database/migrations/2026_01_28_130100_create_ingest_batches_table.php
+database/migrations/2026_01_28_130200_create_sleep_samples_table.php
+database/migrations/2026_01_28_130300_create_health_samples_table.php
+database/migrations/2026_01_28_130400_create_screen_time_samples_table.php
+database/migrations/2026_01_28_130500_create_idempotency_keys_table.php
+database/migrations/2026_01_28_140000_create_user_agent_settings.php
+database/migrations/2026_01_28_140100_create_memories_table.php
+database/migrations/2026_01_28_140200_create_embeddings_index.php
+database/migrations/2026_01_28_140300_create_embeddings_table.php
+database/migrations/2026_01_28_140400_create_agent_triggers.php
+database/migrations/2026_01_28_140500_create_agent_decisions.php
+database/migrations/2026_01_28_140600_create_agent_messages.php
+database/migrations/2026_01_28_140700_create_agent_feedback.php
+database/migrations/2026_01_29_000001_create_organizations_table.php
+database/migrations/2026_01_29_000002_create_organization_members_table.php
+database/migrations/2026_01_29_000003_create_organization_invites_table.php
+database/migrations/2026_01_29_000004_add_org_id_to_attempts_results_events_report_jobs.php
+database/migrations/2026_01_29_090000_create_scales_registry_table.php
+database/migrations/2026_01_29_090010_create_scale_slugs_table.php
+database/migrations/2026_01_29_120000_v03_attempts_results_fields.php
+database/migrations/2026_01_29_140000_create_report_snapshots_table.php
+database/migrations/2026_01_29_200000_create_skus_table.php
+database/migrations/2026_01_29_200010_create_orders_table.php
+database/migrations/2026_01_29_200020_create_payment_events_table.php
+database/migrations/2026_01_29_200030_create_benefit_wallets_table.php
+database/migrations/2026_01_29_200040_create_benefit_wallet_ledgers_table.php
+database/migrations/2026_01_29_200050_create_benefit_consumptions_table.php
+database/migrations/2026_01_29_200060_create_benefit_grants_table.php
+database/migrations/2026_01_30_120001_create_feature_flags_table.php
+database/migrations/2026_01_30_120002_create_experiment_assignments_table.php
+database/migrations/2026_01_30_120003_add_experiments_json_to_events_table.php
+database/migrations/2026_01_30_120100_create_attempt_drafts_table.php
+database/migrations/2026_01_30_120110_create_attempt_answer_sets_table.php
+database/migrations/2026_01_30_120120_create_attempt_answer_rows_table.php
+database/migrations/2026_01_30_120130_create_archive_audits_table.php
+database/migrations/2026_01_30_120140_add_resume_expires_at_to_attempts_table.php
+database/migrations/2026_01_31_090000_create_assessments_table.php
+database/migrations/2026_01_31_090010_create_assessment_assignments_table.php
+database/migrations/2026_01_31_090020_expand_organization_members_role.php
+database/migrations/2026_02_02_090000_add_sku_fields_to_orders_payment_events.php
+database/migrations/2026_02_04_090000_add_idempotency_refunds_to_orders_benefit_grants.php
+database/migrations/2026_02_05_090000_add_assessment_driver_to_scales_registry_table.php
+database/migrations/2026_02_05_090000_add_processing_fields_to_payment_events_table.php
+database/migrations/2026_02_05_090010_add_unique_index_to_skus_table.php
+database/migrations/2026_02_07_180000_add_webhook_hardening_fields_to_integrations_table.php
+database/migrations/2026_02_07_190000_scope_order_idempotency_key_by_provider.php
+database/migrations/2026_02_08_000001_add_provider_composite_unique_to_payment_events.php
+database/migrations/2026_02_08_030000_create_queue_dlq_replays_table.php
+database/migrations/2026_02_08_040000_create_migration_index_audits_table.php
+database/migrations/2026_02_08_050000_scope_payment_event_uniqueness_by_provider.php
+database/migrations/2026_02_08_060000_make_failed_jobs_uuid_nullable.php
+database/migrations/2026_02_10_090000_add_reason_to_payment_events_table.php
+database/migrations/2026_02_10_120000_add_payload_forensics_columns_to_payment_events_table.php
+database/migrations/2026_02_10_140000_create_integration_user_bindings_table.php
+database/migrations/2026_02_10_140100_add_auth_audit_fields_to_ingest_batches_table.php
+database/migrations/2026_02_10_150000_add_status_and_last_error_to_report_snapshots.php
+database/migrations/2026_02_10_160000_create_migration_backfills_table.php
+database/migrations/2026_02_10_160100_add_idx_idempo_payload.php
+database/migrations/2026_02_10_160200_add_benefit_grants_composite_indexes.php
+database/migrations/2026_02_10_160300_add_payment_events_status_time_index.php
+database/migrations/2026_02_10_999999_add_business_indexes.php
+database/migrations/2026_02_11_090100_add_idx_idempotency_keys_provider_recorded_hash.php
+database/migrations/2026_02_11_100200_add_org_id_to_audit_logs_table.php
+database/migrations/2026_02_11_120300_add_payload_digest_to_payment_events.php
+database/migrations/2026_02_12_000000_add_replay_indexes.php
+database/migrations/2026_02_12_000001_converge_hotpath_schema.php
+database/migrations/2026_02_12_000010_converge_fm_tokens_schema.php
+database/migrations/2026_02_12_000011_converge_integrations_schema.php
+database/migrations/2026_02_12_000012_converge_attempts_hot_columns.php
+database/migrations/2026_02_12_010000_add_run_id_to_idempotency_keys.php
+database/migrations/2026_02_13_000001_converge_core_schema_baseline.php
+database/migrations/2026_02_13_020000_add_identity_unique_to_idempotency_keys.php
+database/migrations/2026_02_14_235000_add_is_active_to_organization_members_table.php
+database/migrations/2026_02_15_000100_add_org_id_to_payment_events_table.php
+database/migrations/2026_02_15_000200_add_order_no_to_benefit_grants_table.php
+database/migrations/2026_02_15_000300_create_admin_approvals_table.php
+database/migrations/2026_02_15_000400_add_probe_fields_to_content_pack_releases_table.php
+database/migrations/2026_02_15_100500_expand_organizations_operable_fields.php
+database/migrations/2026_02_15_100600_create_admin_user_totp_tables.php
+database/migrations/2026_02_15_100700_add_reason_result_to_audit_logs.php
+database/migrations/2026_02_15_100800_add_ops_global_search_indexes.php
+database/migrations/2026_02_15_100900_create_payment_reconcile_snapshots_table.php
+database/migrations/2026_02_15_101000_create_data_lifecycle_requests_table.php
+database/migrations/2026_02_15_135009_add_preferred_locale_to_admin_users_table.php
+database/migrations/2026_02_15_160000_add_i18n_seo_content_fields_to_scales_registry.php
+database/migrations/2026_02_15_160100_add_i18n_template_fields_to_email_outbox.php
+database/migrations/2026_02_16_000100_add_report_free_full_json_to_report_snapshots.php
+database/migrations/2026_02_16_000200_add_meta_json_to_orders_and_benefit_grants.php
+database/migrations/2026_02_22_000100_create_norm_sources_table.php
+database/migrations/2026_02_22_000110_alter_scale_norms_versions_add_group_fields.php
+database/migrations/2026_02_22_000120_create_scale_norm_stats_table.php
+database/migrations/2026_02_22_001000_alter_content_pack_releases_add_hash_evidence.php
+database/migrations/2026_02_23_000100_create_big5_psychometrics_reports_table.php
+database/migrations/2026_02_23_000100_create_content_pack_activations_table.php
+database/migrations/2026_02_23_000101_add_packs2_columns_to_content_pack_releases_table.php
+database/migrations/2026_02_23_000200_create_scale_quality_daily_stats_table.php
+database/migrations/2026_02_24_000100_create_norms_build_artifacts_table.php
+database/migrations/2026_02_24_000200_create_eq60_psychometrics_reports_table.php
+database/migrations/2026_02_26_000100_create_sds_psychometrics_reports_table.php
+```
+
+### 9.3 fap-api 测试全量清单（285）
+
+```text
+tests/Architecture/AttemptSubmitServiceConstructorLimitTest.php
+tests/Architecture/NoEnvUsageOutsideConfigTest.php
+tests/Architecture/NoFailOpenThrowableCatchTest.php
+tests/Architecture/NoRuntimeSchemaIntrospectionTest.php
+tests/Concerns/SignedBillingWebhook.php
+tests/Feature/Admin/AuditLogOrgScopeTest.php
+tests/Feature/Api/ValidationErrorContractTest.php
+tests/Feature/ApiErrorContractMiddlewareTest.php
+tests/Feature/ApiExceptionRendererTest.php
+tests/Feature/ApiValidationErrorContractTest.php
+tests/Feature/AppServiceProviderContentStoreIsolationTest.php
+tests/Feature/Approvals/ApprovalFlowTest.php
+tests/Feature/Architecture/MiddlewareNoThrowableReturnTrueTest.php
+tests/Feature/Architecture/NoErrorKeyInApiResponsesTest.php
+tests/Feature/Architecture/NoRuntimeSchemaProbingInHotPathTest.php
+tests/Feature/Architecture/ServiceLayerBoundaryTest.php
+tests/Feature/Architecture/V0_3TraitReferenceTest.php
+tests/Feature/AssetCollectorOrgIsolationTest.php
+tests/Feature/Attempts/Big5RetakeCooldownTest.php
+tests/Feature/Attempts/BigFiveAttemptStartMinCompiledPathTest.php
+tests/Feature/Attempts/BigFiveHistoryCompareTest.php
+tests/Feature/ClinicalCombo68/ClinicalComboBlockSelectionEngineTest.php
+tests/Feature/ClinicalCombo68/ClinicalComboConsentGateTest.php
+tests/Feature/ClinicalCombo68/ClinicalComboConsentStartHashTest.php
+tests/Feature/ClinicalCombo68/ClinicalComboConsentSubmitTest.php
+tests/Feature/ClinicalCombo68/ClinicalComboCrisisGateTest.php
+tests/Feature/ClinicalCombo68/ClinicalComboCrisisStopsUpsellTest.php
+tests/Feature/ClinicalCombo68/ClinicalComboDataDeletionFlowTest.php
+tests/Feature/ClinicalCombo68/ClinicalComboDataRedactionTest.php
+tests/Feature/ClinicalCombo68/ClinicalComboGoldenCasesTest.php
+tests/Feature/ClinicalCombo68/ClinicalComboLayoutSatisfiabilityTest.php
+tests/Feature/ClinicalCombo68/ClinicalComboMaskedDepressionTest.php
+tests/Feature/ClinicalCombo68/ClinicalComboOptionSetMappingTest.php
+tests/Feature/ClinicalCombo68/ClinicalComboQuestionsApiTest.php
+tests/Feature/ClinicalCombo68/ClinicalComboQuestionsLocaleSplitTest.php
+tests/Feature/ClinicalCombo68/ClinicalComboQuestionsMetaComplianceTest.php
+tests/Feature/ClinicalCombo68/ClinicalComboReportLocaleTest.php
+tests/Feature/ClinicalCombo68/ClinicalComboReportPaywallTest.php
+tests/Feature/ClinicalCombo68/ClinicalComboReverseScoringTest.php
+tests/Feature/ClinicalCombo68/ClinicalComboScoreSmokeTest.php
+tests/Feature/ClinicalCombo68/ClinicalComboServerTimeQualityTest.php
+tests/Feature/ClinicalCombo68/Concerns/BuildsClinicalComboScorerInput.php
+tests/Feature/Commerce/BigFiveModulesUnlockFlowTest.php
+tests/Feature/Commerce/BigFiveUnlockDeliveryPipelineTest.php
+tests/Feature/Commerce/BigFiveWebhookIdempotencyTest.php
+tests/Feature/Commerce/ClinicalCombo68UnlockFlowTest.php
+tests/Feature/Commerce/ClinicalCombo68WebhookIdempotencyTest.php
+tests/Feature/Commerce/CommerceReconcileCommandTest.php
+tests/Feature/Commerce/Eq60UnlockFlowTest.php
+tests/Feature/Commerce/Eq60WebhookIdempotencyTest.php
+tests/Feature/Commerce/ManualGrantCreatesAuditTrailTest.php
+tests/Feature/Commerce/ModuleEntitlementGrantTest.php
+tests/Feature/Commerce/OfferModulesContractTest.php
+tests/Feature/Commerce/OrderPricingTest.php
+tests/Feature/Commerce/PaymentEventUniquenessAcrossProvidersTest.php
+tests/Feature/Commerce/PaymentWebhookIdempotencyTest.php
+tests/Feature/Commerce/PaymentWebhookProcessorAtomicityTest.php
+tests/Feature/Commerce/PaymentWebhookProcessorLockKeyTest.php
+tests/Feature/Commerce/PaymentWebhookStripeSignatureTest.php
+tests/Feature/Commerce/PaymentWebhookTrustBoundaryTest.php
+tests/Feature/Commerce/RefundRevokesEntitlementTest.php
+tests/Feature/Commerce/Sds20UnlockFlowTest.php
+tests/Feature/Commerce/Sds20WebhookIdempotencyTest.php
+tests/Feature/Commerce/Webhook/PaymentWebhookProcessorContractTest.php
+tests/Feature/Commerce/WebhookIdempotencyStillHoldsAfterReprocessTest.php
+tests/Feature/Compliance/Big5DisclaimerAcceptanceTest.php
+tests/Feature/Compliance/BigFiveDataDeletionCommandTest.php
+tests/Feature/Compliance/BigFiveDataDeletionFlowTest.php
+tests/Feature/Console/TenantIsolationTest.php
+tests/Feature/Content/Big5ComplianceLintTest.php
+tests/Feature/Content/Big5DurationSpoofDoesNotChangeQualityTest.php
+tests/Feature/Content/BigFiveDisclaimerContractTest.php
+tests/Feature/Content/BigFiveGoldenCasesTest.php
+tests/Feature/Content/BigFiveNormResolverBandsTest.php
+tests/Feature/Content/BigFiveNormResolverTest.php
+tests/Feature/Content/BigFiveNormsCoverageGateTest.php
+tests/Feature/Content/BigFivePackIntegrityTest.php
+tests/Feature/Content/BigFivePaywallFlagModesTest.php
+tests/Feature/Content/BigFiveQuestionsCompiledDeterminismTest.php
+tests/Feature/Content/BigFiveQuestionsCompiledSizeBudgetTest.php
+tests/Feature/Content/BigFiveQuestionsLocaleSplitTest.php
+tests/Feature/Content/BigFiveQuestionsMinCompiledContractTest.php
+tests/Feature/Content/BigFiveQuestionsMinCompiledEvidenceContractTest.php
+tests/Feature/Content/BigFiveQuestionsMinReadPathTest.php
+tests/Feature/Content/BigFiveReportBlocksContractTest.php
+tests/Feature/Content/BigFiveReportCoverageMatrixTest.php
+tests/Feature/Content/BigFiveRolloutGateTest.php
+tests/Feature/Content/BigFiveValidityItemsTest.php
+tests/Feature/Content/ContentPackCoverageMatrixTest.php
+tests/Feature/Content/ContentPackLintTest.php
+tests/Feature/Content/ContentStoreContractTest.php
+tests/Feature/Content/Eq60ContentGateTest.php
+tests/Feature/Content/Eq60GoldenCasesTest.php
+tests/Feature/Content/Packs2DualWritePublishTest.php
+tests/Feature/Content/PacksPublishBig5Test.php
+tests/Feature/Content/PacksPublishSds20Test.php
+tests/Feature/Content/PacksRollbackBig5Test.php
+tests/Feature/Content/TemplateLintInPackTest.php
+tests/Feature/DeprecatedApiVersionContractTest.php
+tests/Feature/ErrorContractConsistencyTest.php
+tests/Feature/ExampleTest.php
+tests/Feature/FmTokenOptionalAuthMiddlewareTest.php
+tests/Feature/FmTokenOrgOverrideIsolationTest.php
+tests/Feature/HealthzExposureTest.php
+tests/Feature/HealthzRateLimitTest.php
+tests/Feature/HighIdorOwnership404Test.php
+tests/Feature/HighlightBuilderBlindspotIdTemplatesDocTest.php
+tests/Feature/HighlightBuilderBuildFromStoreTest.php
+tests/Feature/LegacyMbti/ReportPayloadGoldenMasterTest.php
+tests/Feature/Migrations/EventsGuardedCreateRollbackDoesNotDropTableTest.php
+tests/Feature/Migrations/MigrationsNoGuardedDropRollbackTest.php
+tests/Feature/Migrations/MigrationsNoSilentCatchTest.php
+tests/Feature/NoEmptyThrowableCatchTest.php
+tests/Feature/Observability/BigFiveMetricsContractTest.php
+tests/Feature/Observability/BigFiveTelemetrySummaryCommandTest.php
+tests/Feature/Observability/BigFiveTelemetryTest.php
+tests/Feature/Observability/ClinicalSdsTelemetryContractTest.php
+tests/Feature/Observability/EventRecorderBig5RedactionTest.php
+tests/Feature/Ops/BigFiveOpsReleaseFlowTest.php
+tests/Feature/Ops/BigFiveOpsReleasesEndpointTest.php
+tests/Feature/Ops/BigFiveOpsWriteEndpointsTest.php
+tests/Feature/Ops/CurrentOrgSwitcherComponentTest.php
+tests/Feature/Ops/LocaleSwitcherComponentTest.php
+tests/Feature/Ops/SetOpsLocaleMiddlewareTest.php
+tests/Feature/PaginationContractTest.php
+tests/Feature/PaymentWebhookControllerTest.php
+tests/Feature/Payments/StubProviderDisabledTest.php
+tests/Feature/Payments/WebhookPayloadSizeLimitTest.php
+tests/Feature/Payments/WebhookProviderMismatchTest.php
+tests/Feature/Performance/Big5PerfBudgetTest.php
+tests/Feature/Psychometrics/Big5BootstrapBuildTest.php
+tests/Feature/Psychometrics/Big5NormsDriftCheckTest.php
+tests/Feature/Psychometrics/Big5NormsRebuildCommandTest.php
+tests/Feature/Psychometrics/Big5NormsRebuildDedupTest.php
+tests/Feature/Psychometrics/Big5PsychometricsReportCommandTest.php
+tests/Feature/Psychometrics/Big5RebuildFilterValidityTest.php
+tests/Feature/Psychometrics/Big5RollingNormsCommandTest.php
+tests/Feature/Psychometrics/Eq60NormsDriftCheckTest.php
+tests/Feature/Psychometrics/Eq60NormsImportTest.php
+tests/Feature/Psychometrics/Eq60PsychometricsReportTest.php
+tests/Feature/Psychometrics/SdsNormsDriftCheckTest.php
+tests/Feature/Psychometrics/SdsNormsRebuildCommandTest.php
+tests/Feature/Psychometrics/SdsPsychometricsReportCommandTest.php
+tests/Feature/Report/BigFivePdfDeliveryTest.php
+tests/Feature/Report/Eq60PdfDeliveryTest.php
+tests/Feature/Report/Eq60ReportPaywallTest.php
+tests/Feature/Report/GenerateBigFiveReportPdfJobTest.php
+tests/Feature/Report/ModulesGateReportTest.php
+tests/Feature/Report/ReportLockedVariantLeakTest.php
+tests/Feature/Report/ReportPdfCrossScaleDeliveryTest.php
+tests/Feature/Report/ReportVariantGenerationTest.php
+tests/Feature/ReportComposerTenantIsolationTest.php
+tests/Feature/ReportGatekeeperIdentityBoundaryTest.php
+tests/Feature/SEO/SitemapGeneratorTest.php
+tests/Feature/SEO/SitemapXmlTest.php
+tests/Feature/SRE/TransactionSlimmingTest.php
+tests/Feature/Sds20/Concerns/BuildsSds20ScorerInput.php
+tests/Feature/Sds20/Sds20ConsentRequiredTest.php
+tests/Feature/Sds20/Sds20CrisisGateTest.php
+tests/Feature/Sds20/Sds20CrisisStopsUpsellTest.php
+tests/Feature/Sds20/Sds20DataRedactionTest.php
+tests/Feature/Sds20/Sds20DtoDeterminismTest.php
+tests/Feature/Sds20/Sds20DurationSpoofDoesNotChangeQualityTest.php
+tests/Feature/Sds20/Sds20FactorScoringTest.php
+tests/Feature/Sds20/Sds20GoldenCasesTest.php
+tests/Feature/Sds20/Sds20MaskLogicGateTest.php
+tests/Feature/Sds20/Sds20PercentileNormsTest.php
+tests/Feature/Sds20/Sds20QualityGateTest.php
+tests/Feature/Sds20/Sds20QuestionsApiTest.php
+tests/Feature/Sds20/Sds20ReportLocaleTest.php
+tests/Feature/Sds20/Sds20ReportPaywallTest.php
+tests/Feature/Sds20/Sds20ReverseScoringTest.php
+tests/Feature/Sds20/Sds20ScoreSmokeTest.php
+tests/Feature/Sds20/Sds20SomaticMaskGateTest.php
+tests/Feature/Sds20/Sds20SubmitConsentGateTest.php
+tests/Feature/SelfCheck/SelfCheckContractTest.php
+tests/Feature/Storage/ArtifactStoreReadCompatibilityTest.php
+tests/Feature/Storage/ReportPersistenceStopsTimestampBackupsTest.php
+tests/Feature/Storage/StorageInventoryCommandTest.php
+tests/Feature/Storage/StorageMigrateLegacyArtifactsCommandTest.php
+tests/Feature/Storage/StoragePruneDoesNotDeleteCanonicalTest.php
+tests/Feature/Storage/StoragePruneReleaseRetentionTest.php
+tests/Feature/UuidRouteParamsMiddlewareTest.php
+tests/Feature/V0_3/ArchiveColdDataCommandTest.php
+tests/Feature/V0_3/AssetsBaseUrlFromCdnMapTest.php
+tests/Feature/V0_3/AttemptContentPackErrorTest.php
+tests/Feature/V0_3/AttemptControllerSplitSmokeTest.php
+tests/Feature/V0_3/AttemptMemberViewerOwnershipTest.php
+tests/Feature/V0_3/AttemptOwnershipAnd404Test.php
+tests/Feature/V0_3/AttemptOwnershipTraitTest.php
+tests/Feature/V0_3/AttemptProgressFlowTest.php
+tests/Feature/V0_3/AttemptReportPaymentUnlockFlowTest.php
+tests/Feature/V0_3/AttemptSubmitAuthTest.php
+tests/Feature/V0_3/AttemptSubmitIdempotencyTest.php
+tests/Feature/V0_3/AttemptSubmitRefactorParityTest.php
+tests/Feature/V0_3/AttemptWriteSlimControllerTest.php
+tests/Feature/V0_3/AttemptsStartSubmitTest.php
+tests/Feature/V0_3/BillingWebhookMisconfiguredSecretTest.php
+tests/Feature/V0_3/BillingWebhookReplayToleranceTest.php
+tests/Feature/V0_3/BillingWebhookSignatureTest.php
+tests/Feature/V0_3/CommerceOrderIdempotencyTest.php
+tests/Feature/V0_3/CommerceOrderReadFallbackTest.php
+tests/Feature/V0_3/CommerceOrgIdWriteIsolationTest.php
+tests/Feature/V0_3/CommerceRefundWebhookTest.php
+tests/Feature/V0_3/CommerceWalletConsumeOnSubmitTest.php
+tests/Feature/V0_3/CommerceWebhookIdempotencyTest.php
+tests/Feature/V0_3/CreditsConsumeOnAttemptSubmitTest.php
+tests/Feature/V0_3/Eq60HistoryListTest.php
+tests/Feature/V0_3/Eq60StartSubmitTest.php
+tests/Feature/V0_3/Eq60SubmitQualityContractTest.php
+tests/Feature/V0_3/EventExperimentsJsonTest.php
+tests/Feature/V0_3/ExperimentStickyAssignmentTest.php
+tests/Feature/V0_3/OrgContextMiddlewareTest.php
+tests/Feature/V0_3/OrgInvitesFlowTest.php
+tests/Feature/V0_3/OrgIsolationAttemptsTest.php
+tests/Feature/V0_3/PaymentWebhookControllerTest.php
+tests/Feature/V0_3/PaymentWebhookFailSafeTest.php
+tests/Feature/V0_3/PaymentWebhookPayloadLimitTest.php
+tests/Feature/V0_3/PaymentWebhookRouteWiringTest.php
+tests/Feature/V0_3/ReportDirVersionTruthTest.php
+tests/Feature/V0_3/ReportErrorContractTest.php
+tests/Feature/V0_3/ReportPaywallTeaserTest.php
+tests/Feature/V0_3/ReportQueryFootprintTest.php
+tests/Feature/V0_3/ReportSnapshotB2BTest.php
+tests/Feature/V0_3/ReportSnapshotB2CTest.php
+tests/Feature/V0_3/ResolveAnonIdMiddlewareTest.php
+tests/Feature/V0_3/ScalesListTest.php
+tests/Feature/V0_3/ScalesLookupTest.php
+tests/Feature/V0_3/WebhookPayloadSizeLimitTest.php
+tests/Feature/V0_3/WebhookStatusPropagationTest.php
+tests/Feature/V0_4/AssessmentsProgressSummaryTest.php
+tests/Feature/V0_4/AssessmentsRbacIsolationTest.php
+tests/Feature/V0_4/BootTest.php
+tests/Feature/ViewCompiledPathTest.php
+tests/Sre/MigrationHotTableNotNullGateTest.php
+tests/Sre/MigrationPurityGateTest.php
+tests/Sre/MigrationSafetyTest.php
+tests/TestCase.php
+tests/Unit/API/V0_3/Webhooks/PaymentWebhookStripeSignatureTest.php
+tests/Unit/Analytics/Big5EventSchemaValidationTest.php
+tests/Unit/Assessment/BigFiveDriverMinCompiledPathTest.php
+tests/Unit/Assessment/BigFiveDriverNormsSnapshotTest.php
+tests/Unit/Assessment/Eq60DriverScoringTest.php
+tests/Unit/Assessment/Eq60ScorerCrossInsightTest.php
+tests/Unit/Assessment/Eq60ScorerValidityTest.php
+tests/Unit/Assessment/GenericScoringDriverTest.php
+tests/Unit/Ci/ScaleImpactResolverTest.php
+tests/Unit/Commerce/PaymentEventsProviderScopeGuardTest.php
+tests/Unit/Commerce/PaymentWebhookLockBusyTest.php
+tests/Unit/Content/ContentPackV2ResolverPathFallbackTest.php
+tests/Unit/ExampleTest.php
+tests/Unit/Http/PaymentWebhookStripeSignatureTest.php
+tests/Unit/Legacy/Mbti/LegacyMbtiPackRepositoryTest.php
+tests/Unit/Legacy/Mbti/LegacyMbtiReportAssetRepositoryTest.php
+tests/Unit/Legacy/Mbti/LegacyMbtiReportPayloadBuilderTest.php
+tests/Unit/Logging/RedactProcessorTest.php
+tests/Unit/Migrations/CreateMigrationsMustConvergeTest.php
+tests/Unit/Migrations/GuardedCreateMigrationsNoDropTest.php
+tests/Unit/Migrations/MigrationNoSilentCatchTest.php
+tests/Unit/Migrations/MigrationProtectedTablesNoDropTest.php
+tests/Unit/Migrations/MigrationRollbackSafetyTest.php
+tests/Unit/Migrations/MigrationSafetyTest.php
+tests/Unit/Psychometrics/Big5/Big5StandardizerTest.php
+tests/Unit/Psychometrics/Big5/NormGroupResolverTest.php
+tests/Unit/Psychometrics/GenericLikertDriverTest.php
+tests/Unit/Report/Composer/ReportOverridesMergerTest.php
+tests/Unit/Report/Composer/ReportPackChainLoaderTest.php
+tests/Unit/Security/SecurityGuardrailsTest.php
+tests/Unit/SelfCheck/ManifestContractCheckTest.php
+tests/Unit/SelfCheck/SelfCheckRunnerOrderTest.php
+tests/Unit/Services/Analytics/EventPayloadLimiterTest.php
+tests/Unit/Services/Assessment/Drivers/GenericLikertDriverReverseAndWeightTest.php
+tests/Unit/Services/Assessment/Drivers/GenericLikertDriverTest.php
+tests/Unit/Services/Assessment/GenericLikertDriverTest.php
+tests/Unit/Services/Commerce/PaymentWebhookProcessorLockTest.php
+tests/Unit/Services/Content/ContentPacksIndexManifestConsistencyTest.php
+tests/Unit/Services/ContentLoaderMtimeCacheTest.php
+tests/Unit/Services/ContentLoaderServiceMtimeTest.php
+tests/Unit/Services/ContentPackResolverCacheTest.php
+tests/Unit/Support/Database/SchemaIndexTest.php
+tests/Unit/Support/Rbac/RbacServiceTest.php
+tests/Unit/Support/SensitiveDataRedactorTest.php
+tests/Unit/TagBuilderTest.php
+tests/Unit/Template/BigFiveTemplateWhitelistTest.php
+tests/Unit/Template/TemplateEngineTest.php
+```
+
+### 9.4 fap-web 测试全量清单（25）
+
+```text
+tests/a11y/adaptive-option-group.a11y.test.tsx
+tests/a11y/data-glyph.a11y.test.tsx
+tests/a11y/likert.a11y.test.tsx
+tests/contracts/big5.contract.test.ts
+tests/contracts/clinical.contract.test.ts
+tests/contracts/quiz-ux-flags.contract.test.ts
+tests/contracts/tracking-whitelist.contract.test.ts
+tests/e2e/big5-flow.spec.ts
+tests/e2e/big5-negative.spec.ts
+tests/e2e/clinical-combo-flow.spec.ts
+tests/e2e/helpers/quiz-flow.ts
+tests/e2e/home-visual.spec.ts
+tests/e2e/mbti-regression.spec.ts
+tests/e2e/navigation-shell.spec.ts
+tests/e2e/result-loading.spec.ts
+tests/e2e/sds-flow.spec.ts
+tests/e2e/seo-og.spec.ts
+tests/e2e/test-detail.spec.ts
+tests/e2e/tests-list.spec.ts
+tests/e2e/uat-matrix.spec.ts
+tests/e2e/visual/home.visual.spec.ts
+tests/e2e/visual/support.visual.spec.ts
+tests/e2e/visual/test-detail.visual.spec.ts
+tests/e2e/visual/tests-list.visual.spec.ts
+tests/e2e/visual/visual-helpers.ts
+```
+
+### 9.5 fap-web app 页面全量清单（52）
+
+```text
+app/(localized)/[locale]/(app)/.DS_Store
+app/(localized)/[locale]/(app)/history/big5/Big5HistoryClient.tsx
+app/(localized)/[locale]/(app)/history/big5/compare/Big5CompareClient.tsx
+app/(localized)/[locale]/(app)/history/big5/compare/page.tsx
+app/(localized)/[locale]/(app)/history/big5/page.tsx
+app/(localized)/[locale]/(app)/layout.tsx
+app/(localized)/[locale]/(app)/quiz/[slug]/page.tsx
+app/(localized)/[locale]/(app)/result/[id]/ResultClient.tsx
+app/(localized)/[locale]/(app)/result/[id]/page.tsx
+app/(localized)/[locale]/articles/[slug]/page.tsx
+app/(localized)/[locale]/articles/page.tsx
+app/(localized)/[locale]/attempts/[attemptId]/report/page.tsx
+app/(localized)/[locale]/blog/[slug]/page.tsx
+app/(localized)/[locale]/blog/page.tsx
+app/(localized)/[locale]/business/page.tsx
+app/(localized)/[locale]/help/page.tsx
+app/(localized)/[locale]/layout.tsx
+app/(localized)/[locale]/orders/.DS_Store
+app/(localized)/[locale]/orders/[orderNo]/OrdersClient.tsx
+app/(localized)/[locale]/orders/[orderNo]/page.tsx
+app/(localized)/[locale]/orders/lookup/page.tsx
+app/(localized)/[locale]/page.tsx
+app/(localized)/[locale]/payment/stripe/cancel/page.tsx
+app/(localized)/[locale]/payment/stripe/success/page.tsx
+app/(localized)/[locale]/privacy/page.tsx
+app/(localized)/[locale]/professions/[code]/page.tsx
+app/(localized)/[locale]/professions/page.tsx
+app/(localized)/[locale]/refund/page.tsx
+app/(localized)/[locale]/share/[id]/ShareClient.tsx
+app/(localized)/[locale]/share/[id]/page.tsx
+app/(localized)/[locale]/support/page.tsx
+app/(localized)/[locale]/terms/page.tsx
+app/(localized)/[locale]/test/[slug]/page.tsx
+app/(localized)/[locale]/test/[slug]/take/page.tsx
+app/(localized)/[locale]/test/page.tsx
+app/(localized)/[locale]/tests/[slug]/page.tsx
+app/(localized)/[locale]/tests/[slug]/take/Big5TakeClient.tsx
+app/(localized)/[locale]/tests/[slug]/take/ClinicalTakeClient.tsx
+app/(localized)/[locale]/tests/[slug]/take/QuizTakeClient.tsx
+app/(localized)/[locale]/tests/[slug]/take/page.tsx
+app/(localized)/[locale]/tests/page.tsx
+app/(localized)/[locale]/types/[code]/page.tsx
+app/(localized)/[locale]/types/page.tsx
+app/(root)/layout.tsx
+app/(root)/page.tsx
+app/.DS_Store
+app/api/track/route.ts
+app/favicon.ico
+app/global-error.tsx
+app/globals.css
+app/og/[slug]/route.tsx
+app/providers.tsx
+```
+
+### 9.6 fap-api backend/scripts 清单（运行治理资产）
+
+```text
+accept_abuse_audit.sh
+accept_auth_phone.sh
+accept_email_claim.sh
+accept_email_outbox_dedup.sh
+accept_events_C.sh
+accept_events_D_anon.sh
+accept_events_D_anon_block_placeholder_click.sh
+accept_events_D_click_anon_override.sh
+accept_events_E_share_meta.sh
+accept_events_F_result_view_meta.sh
+accept_events_G_report_view_meta.sh
+accept_events_H_share_view_meta.sh
+accept_identities_bind.sh
+accept_lookup_order.sh
+accept_overrides_D.sh
+ai_baseline_diff.sh
+ai_quality_gates.sh
+artifacts
+assert_report.py
+cae_gate.sh
+check_content_packages.sh
+ci
+ci_selfcheck_packs.sh
+ci_smoke_v0_3.sh
+ci_verify_mbti.sh
+ci_verify_scales.sh
+cleanup_bad_anon_id.sh
+go_live_gate.sh
+guard_release_integrity.sh
+guard_v03_alignment.sh
+iq
+loadtest
+mvp_check.sh
+norms
+ops_bootstrap_first_org.sh
+payments_anomalies.sh
+payments_reconcile_daily.sh
+pr10_verify_admin.sh
+pr11_verify_psychometrics.sh
+pr12_verify_ai_insights.sh
+pr13_verify_ingestion.sh
+pr14_verify_agent_memory.sh
+pr15_verify_scale_registry.sh
+pr16_verify_assets.sh
+pr17_verify_assessment_engine.sh
+pr18_verify_org_isolation.sh
+pr19_verify_commerce_v2.sh
+pr20_verify_report_paywall.sh
+pr215_accept.sh
+pr215_verify.sh
+pr217_accept.sh
+pr217_verify.sh
+pr21_accept.sh
+pr21_verify_answer_storage.sh
+pr22_accept.sh
+pr22_verify_boot_v0_4.sh
+pr23_accept.sh
+pr23_verify.sh
+pr24_accept.sh
+pr24_verify_sitemap.sh
+pr25_accept.sh
+pr25_verify.sh
+pr26_accept.sh
+pr26_verify.sh
+pr27_accept.sh
+pr27_verify.sh
+pr28_accept.sh
+pr28_verify.sh
+pr29_accept.sh
+pr29_verify.sh
+pr30_accept.sh
+pr30_verify.sh
+pr32_accept.sh
+pr32_verify.sh
+pr33_accept.sh
+pr33_verify.sh
+pr34_accept.sh
+pr34_verify.sh
+pr35_accept.sh
+pr35_verify.sh
+pr36_accept.sh
+pr36_verify.sh
+pr37_accept.sh
+pr37_verify.sh
+pr38_accept.sh
+pr38_verify.sh
+pr39_accept.sh
+pr39_verify.sh
+pr40_accept.sh
+pr40_verify.sh
+pr41_accept.sh
+pr41_verify.sh
+pr42_accept.sh
+pr42_verify.sh
+pr43_accept.sh
+pr43_verify.sh
+pr44_accept.sh
+pr44_verify.sh
+pr45_accept.sh
+pr45_verify.sh
+pr47_accept.sh
+pr47_verify.sh
+pr48_accept.sh
+pr48_verify.sh
+pr49_accept.sh
+pr49_verify.sh
+pr50_accept.sh
+pr50_verify.sh
+pr51_accept.sh
+pr51_verify.sh
+pr52_accept.sh
+pr52_verify.sh
+pr53_accept.sh
+pr53_verify.sh
+pr54_accept.sh
+pr54_verify.sh
+pr55_accept.sh
+pr55_verify.sh
+pr56_accept.sh
+pr56_verify.sh
+pr57_accept.sh
+pr57_verify.sh
+pr58_accept.sh
+pr58_verify.sh
+pr60_accept.sh
+pr60_verify.sh
+pr61_accept.sh
+pr61_verify.sh
+pr62_accept.sh
+pr62_verify.sh
+pr63_accept.sh
+pr63_verify.sh
+pr64_accept.sh
+pr64_verify.sh
+pr65_accept.sh
+pr65_verify.sh
+pr66_accept.sh
+pr66_verify.sh
+pr67_accept.sh
+pr67_verify.sh
+pr68_accept.sh
+pr68_verify.sh
+pr69_accept.sh
+pr69_verify.sh
+pr9_verify_views.sh
+pre_commit_env_guard.sh
+release_pack.sh
+sanitize_artifacts.sh
+security_gate.sh
+selfcheck.sh
+smoke-v0.3.sh
+smoke-v0.3.strict.sh
+validate_mbti_pack_v022.php
+verify_contentstore_hot_reload.sh
+verify_mbti.sh
+verify_mbti_assert.sh
+verify_pack_fallback.sh
+verify_store_hot_reload_highlights.sh
+verify_store_hot_reload_overrides.sh
+verify_store_hot_reload_reads.sh
+whitepaper_build.sh
+```
+
+### 9.7 fap-web scripts 清单（发布治理资产）
+
+```text
+release_evidence.sh
+release_gate.sh
+rollback_smoke.sh
+run_uat_matrix.sh
+upload-next-static-to-cos.mjs
+```
+
+### 9.8 热点文件（复杂度压强证据）
+
+#### 9.8.1 fap-api app 热点
+
+```text
+    3185 app/Internal/SelfCheck/SelfCheckContentEngineCore.php
+    2412 app/Internal/Legacy/Mbti/Report/LegacyMbtiReportPayloadBuilderV2Core.php
+    1917 app/Internal/Commerce/PaymentWebhookHandlerCore.php
+    1561 app/Services/Overrides/ReportOverridesApplier.php
+    1331 app/Internal/Content/ContentStoreV2Core.php
+    1237 app/Services/Content/Publisher/ContentPackPublisher.php
+    1148 app/Services/Rules/RuleEngine.php
+    1110 app/Services/Content/BigFiveContentLintService.php
+    1002 app/Services/Report/ReportGatekeeper.php
+     969 app/Http/Controllers/API/V0_3/BigFiveOpsController.php
+     958 app/Services/Content/Eq60ContentLintService.php
+     955 app/Services/Legacy/Mbti/Attempt/LegacyMbtiAttemptLifecycleService.php
+     942 app/Services/Content/ClinicalComboContentLintService.php
+     936 app/Services/Assessment/Scorers/Eq60ScorerV1NormedValidity.php
+     933 app/Services/Report/BigFiveReportComposer.php
+     869 app/Services/Content/Eq60ContentCompileService.php
+     856 app/Services/Attempts/AttemptSubmitService.php
+     796 app/Services/Content/ClinicalComboPackLoader.php
+     756 app/Services/Assessment/Scorers/BigFiveScorerV3.php
+     755 app/Services/Content/BigFiveContentCompileService.php
+     733 app/Services/Report/Eq60ReportComposer.php
+     731 app/Services/Report/HighlightsGenerator.php
+     730 app/Services/Report/HighlightBuilder.php
+     637 app/Services/Legacy/LegacyReportService.php
+     609 app/Services/Score/MbtiAttemptScorer.php
+     598 app/Console/Commands/StoragePrune.php
+     597 app/Services/Assessment/Scorers/Sds20ScorerV2FactorLogic.php
+     581 app/Services/RuleEngine/ReportRuleEngine.php
+     570 app/Console/Commands/NormsBig5BootstrapBuild.php
+     568 app/Http/Controllers/LookupController.php
+     555 app/Console/Commands/NormsImport.php
+     546 app/Services/Assessment/Scorers/ClinicalCombo68ScorerV1.php
+     538 app/Services/Commerce/OrderManager.php
+     526 app/Services/V0_3/ShareFlowService.php
+     526 app/Services/Legacy/LegacyShareFlowService.php
+     523 app/Services/Payments/PaymentService.php
+     512 app/Services/Report/ReportSnapshotStore.php
+     509 app/Services/Assessment/Drivers/GenericScoringDriver.php
+     482 app/Services/Attempts/AttemptStartService.php
+     480 app/Console/Commands/NormsBig5Rebuild.php
+     465 app/Providers/AppServiceProvider.php
+     463 app/Services/Overrides/HighlightsOverridesApplier.php
+     454 app/Http/Controllers/API/V0_3/ScalesController.php
+     452 app/Console/Commands/Big5PsychometricsReport.php
+     446 app/Services/Ci/ScaleImpactResolver.php
+     442 app/Services/Report/SectionCardGenerator.php
+     440 app/Services/Report/ClinicalCombo68ReportComposer.php
+     437 app/Services/Content/ContentPacksIndex.php
+     433 app/Services/Report/Composer/ReportPayloadAssemblerContentGraphTrait.php
+     432 app/Services/Content/Sds20ContentLintService.php
+     429 app/Services/Attempts/AttemptProgressService.php
+     424 app/Http/Controllers/API/V0_3/CommerceController.php
+     423 app/Console/Commands/NormsEq60Import.php
+     422 app/Console/Commands/Eq60PsychometricsReport.php
+     418 app/Services/Assessment/Drivers/GenericLikertDriver.php
+     417 app/Services/Email/EmailOutboxService.php
+     405 app/Services/Commerce/EntitlementManager.php
+     405 app/Services/Approvals/ApprovalExecutor.php
+     404 app/Console/Commands/NormsSdsRebuild.php
+     398 app/Console/Commands/MetricsWeeklyValidity.php
+     396 app/Services/Content/Eq60PackLoader.php
+```
+
+#### 9.8.2 fap-web app/lib/components 热点
+
+```text
+   16192 total
+    1007 app/(localized)/[locale]/tests/[slug]/take/Big5TakeClient.tsx
+     969 components/clinical/report/ClinicalReportClient.tsx
+     841 lib/api/v0_3.ts
+     822 app/(localized)/[locale]/tests/[slug]/take/ClinicalTakeClient.tsx
+     661 app/(localized)/[locale]/(app)/result/[id]/ResultClient.tsx
+     632 app/(localized)/[locale]/tests/[slug]/take/QuizTakeClient.tsx
+     420 app/(localized)/[locale]/tests/[slug]/page.tsx
+     300 app/(localized)/[locale]/orders/[orderNo]/OrdersClient.tsx
+     295 app/(localized)/[locale]/(app)/history/big5/compare/Big5CompareClient.tsx
+     286 components/clinical/report/CrisisOverlay.tsx
+     267 lib/quiz/store.tsx
+     222 components/quiz/matrix/MatrixQuestionTable.tsx
+     203 lib/rollout/scaleRollout.ts
+     201 lib/i18n/locales/en.ts
+     200 lib/i18n/locales/zh.ts
+     192 components/report/LockedInsightTeaser.tsx
+     188 lib/big5/api.ts
+     185 lib/big5/contracts/schemas.ts
+     171 components/big5/report/BlockRenderer.tsx
+     166 lib/clinical/contracts/schemas.ts
+     164 lib/clinical/attemptStore.ts
+     163 lib/api-client.ts
+     161 lib/i18n/types.ts
+     161 lib/clinical/api.ts
+     161 app/(localized)/[locale]/(app)/history/big5/Big5HistoryClient.tsx
+     158 lib/anon.ts
+     157 components/assessment-cards/DataGlyph.tsx
+     153 components/clinical/report/SdsFactorPanel.tsx
+     151 lib/tracking/events.ts
+     148 components/marketing/HighlightedTestsSection.tsx
+     136 components/layout/SiteHeader.tsx
+     135 components/quiz/immersive/AdaptiveOptionGroup.tsx
+     135 app/(localized)/[locale]/tests/[slug]/take/page.tsx
+     133 lib/big5/attemptStore.ts
+     126 components/business/TestCard.tsx
+     125 components/quiz/immersive/useAutoAdvanceFlow.ts
+     117 app/(localized)/[locale]/share/[id]/ShareClient.tsx
+     115 components/big5/quiz/LikertScale.tsx
+     112 components/commerce/UnlockCTA.tsx
+     105 components/support/OrderLookupForm.tsx
+     105 app/(localized)/[locale]/privacy/page.tsx
+     104 components/layout/SiteFooter.tsx
+     104 app/og/[slug]/route.tsx
+     103 app/api/track/route.ts
+      97 components/marketing/HeroAnimatedVisual.tsx
+      94 app/(localized)/[locale]/business/page.tsx
+      92 app/(localized)/[locale]/tests/page.tsx
+      92 app/(localized)/[locale]/terms/page.tsx
+      92 app/(localized)/[locale]/refund/page.tsx
+      92 app/(localized)/[locale]/professions/[code]/page.tsx
+      92 app/(localized)/[locale]/layout.tsx
+      92 app/(localized)/[locale]/help/page.tsx
+      89 components/big5/quiz/QuestionNavigator.tsx
+      88 lib/marketing/socialProof.ts
+      88 lib/content.ts
+      86 app/providers.tsx
+      86 app/(localized)/[locale]/articles/[slug]/page.tsx
+      83 components/quiz/immersive/ImmersiveTakeLayout.tsx
+      83 components/business/QuestionRenderer.tsx
+      81 lib/clinical/errors.ts
+      78 app/(localized)/[locale]/articles/page.tsx
+```
+
+### 9.9 实跑证据（摘要）
+
+#### 9.9.1 route:list 统计
+
+```text
+total_routes=122
+method=GET|HEAD,count=93
+method=GET|HEAD|POST|PUT|PATCH|DELETE|OPTIONS,count=2
+method=POST,count=26
+method=PUT,count=1
+```
+
+#### 9.9.2 migrate
+
+```text
+
+   INFO  Nothing to migrate.  
+
+```
+
+#### 9.9.3 ci_verify_mbti 末尾关键信号
+
+```text
+exit_code=0 (已在 2026-02-25 实跑通过)
+关键阶段: self-check -> verify_mbti -> events acceptance -> migration safety -> webhook regression
+```
+
+#### 9.9.4 web contract + a11y
+
+```text
+pnpm test:contract => 12 passed
+pnpm test:a11y => 5 passed
+```
+
+### 9.10 结构性分布统计
+
+```text
+[fap-api service domains]
+  37 Content
+  33 Report
+  26 SelfCheck
+  23 Legacy
+  23 Commerce
+  20 Assessment
+  10 Attempts
+   9 Psychometrics
+   9 Agent
+   6 V0_3
+   5 Memory
+   5 AI
+   4 VectorStore
+   4 Template
+   4 Org
+   4 Observability
+   4 Ingestion
+   4 Auth
+   4 Analytics
+   3 Scale
+   2 SEO
+   2 Rules
+   2 Payments
+   2 Overrides
+   2 Ops
+   2 Audit
+   2 Assessments
+   1 Storage
+   1 Score
+   1 RuleEngine
+   1 Queue
+   1 Flags
+   1 Experiments
+   1 Events
+   1 Email
+   1 Database
+   1 ContentPackage.php
+   1 ContentPackResolver.php
+   1 Ci
+   1 Assets
+   1 Approvals
+   1 Account
+   1 Abuse
+
+[fap-api tests by domain]
+  47 Feature/V0_3
+  29 Feature/Content
+  23 Feature/Commerce
+  21 Feature/ClinicalCombo68
+  19 Feature/Sds20
+  13 Feature/Psychometrics
+   9 Unit/Services
+   8 Feature/Report
+   6 Unit/Migrations
+   6 Unit/Assessment
+   6 Feature/Storage
+   6 Feature/Ops
+   5 Feature/Observability
+   5 Feature/Architecture
+   3 Unit/Support
+   3 Unit/Psychometrics
+   3 Unit/Legacy
+   3 Feature/V0_4
+   3 Feature/Payments
+   3 Feature/Migrations
+   3 Feature/Compliance
+   3 Feature/Attempts
+   2 Unit/Template
+   2 Unit/SelfCheck
+   2 Unit/Report
+   2 Unit/Commerce
+   2 Feature/SEO
+   1 Unit/TagBuilderTest.php
+   1 Unit/Security
+   1 Unit/Logging
+   1 Unit/Http
+   1 Unit/ExampleTest.php
+   1 Unit/Content
+   1 Unit/Ci
+   1 Unit/Analytics
+   1 Unit/API
+   1 TestCase.php/
+   1 Sre/MigrationSafetyTest.php
+   1 Sre/MigrationPurityGateTest.php
+   1 Sre/MigrationHotTableNotNullGateTest.php
+   1 Feature/ViewCompiledPathTest.php
+   1 Feature/UuidRouteParamsMiddlewareTest.php
+   1 Feature/SelfCheck
+   1 Feature/SRE
+   1 Feature/ReportGatekeeperIdentityBoundaryTest.php
+   1 Feature/ReportComposerTenantIsolationTest.php
+   1 Feature/Performance
+   1 Feature/PaymentWebhookControllerTest.php
+   1 Feature/PaginationContractTest.php
+   1 Feature/NoEmptyThrowableCatchTest.php
+   1 Feature/LegacyMbti
+   1 Feature/HighlightBuilderBuildFromStoreTest.php
+   1 Feature/HighlightBuilderBlindspotIdTemplatesDocTest.php
+   1 Feature/HighIdorOwnership404Test.php
+   1 Feature/HealthzRateLimitTest.php
+   1 Feature/HealthzExposureTest.php
+   1 Feature/FmTokenOrgOverrideIsolationTest.php
+   1 Feature/FmTokenOptionalAuthMiddlewareTest.php
+   1 Feature/ExampleTest.php
+   1 Feature/ErrorContractConsistencyTest.php
+   1 Feature/DeprecatedApiVersionContractTest.php
+   1 Feature/Console
+   1 Feature/AssetCollectorOrgIsolationTest.php
+   1 Feature/Approvals
+   1 Feature/AppServiceProviderContentStoreIsolationTest.php
+   1 Feature/ApiValidationErrorContractTest.php
+   1 Feature/ApiExceptionRendererTest.php
+   1 Feature/ApiErrorContractMiddlewareTest.php
+   1 Feature/Api
+   1 Feature/Admin
+   1 Concerns/SignedBillingWebhook.php
+   1 Architecture/NoRuntimeSchemaIntrospectionTest.php
+   1 Architecture/NoFailOpenThrowableCatchTest.php
+   1 Architecture/NoEnvUsageOutsideConfigTest.php
+   1 Architecture/AttemptSubmitServiceConstructorLimitTest.php
+
+[fap-web tests by type]
+  18 tests/e2e
+   4 tests/contracts
+   3 tests/a11y
+```

--- a/research/deep-research-2026-02-25/路线图执行表_2026-02-25.md
+++ b/research/deep-research-2026-02-25/路线图执行表_2026-02-25.md
@@ -1,0 +1,515 @@
+# 路线图执行表（超深版 / 90天 + 180天）
+
+- 文档日期：2026-02-25
+- 目标：将 FAP 从“稳定运营雏形”升级到“可规模复制运营”
+- 覆盖范围：产品、工程、商业化、合规、增长、组织流程
+- 执行原则：先稳态后扩张；先契约后体验；先可观测后提速
+
+---
+
+## 1. 目标与阶段拆分
+
+### 1.1 90 天阶段目标（稳态治理）
+
+1. 契约漂移可控：前后端协议统一并可自动校验。
+2. 支付履约可观测：checkout->paid->unlock->ready 全链路可追踪。
+3. 高复杂度服务开始拆分：webhook/submit 第一阶段降复杂度。
+4. 合规边界前置：关键页面与声明上线。
+
+### 1.2 180 天阶段目标（增长平台化）
+
+1. 方法学与信任资产公开化。
+2. SEO/GEO 工厂化，形成可复制扩量流水线。
+3. B2B 能力产品化（landing + sandbox + 询盘流程）。
+4. 经营看板统一（业务与技术指标同屏）。
+
+---
+
+## 2. 90 天执行计划（W1-W12）
+
+## 2.1 工作包总览（22 个）
+
+| WP | 工作包 | 周期 | 依赖 | Owner | 交付物 | DoD |
+|---|---|---|---|---|---|---|
+| WP-90-01 | route spec 自动导出 | W1-W2 | 无 | API 平台 | `route-spec.json` + CI diff | 路由变更未更新 spec 时 CI fail |
+| WP-90-02 | API 错误包统一 | W1-W3 | WP-90-01 | API 平台 | error middleware + 文档 | 全接口具备 code/message/details/request_id |
+| WP-90-03 | report 状态协议统一 | W1-W3 | WP-90-02 | API+Web | pending/ready/failed 协议文档 | result/orders 只使用统一状态机 |
+| WP-90-04 | checkout 强制幂等键 | W2-W4 | WP-90-02 | Commerce | key 校验 + 错误码 | 无 key 请求被拒并可观测 |
+| WP-90-05 | webhook 事件字段标准化 | W2-W4 | WP-90-04 | Commerce | provider_event schema | 事件检索可按 provider_event_id 追踪 |
+| WP-90-06 | shared schema codegen（关键链路） | W3-W6 | WP-90-02,03 | API+Web | schema + TS 生成脚本 | take/result/order 关键类型改为生成 |
+| WP-90-07 | submit 服务拆分一期 | W4-W8 | WP-90-06 | Assessment | submit 子模块化 | 行为等价 + 全量回归通过 |
+| WP-90-08 | webhook 服务拆分一期 | W4-W8 | WP-90-04,05 | Commerce | precheck/transition/postcommit 分层 | 主链用例全绿 |
+| WP-90-09 | 支付履约漏斗看板 | W3-W6 | WP-90-05 | Data+SRE | dashboard + alert | 能定位 order_no 全链路状态 |
+| WP-90-10 | unlock->ready SLO 告警 | W4-W7 | WP-90-09 | SRE | SLO + 阈值 | p95 超阈值可告警 |
+| WP-90-11 | tracking schema lint | W4-W7 | 无 | Web+Data | pre-merge lint | forbidden 字段变更被阻断 |
+| WP-90-12 | noindex/canonical CI 校验 | W5-W8 | 无 | Growth+Web | SEO gate 脚本 | 敏感页误收录风险降为 0 |
+| WP-90-13 | 合规声明统一页 v1 | W6-W8 | Legal 评审 | Product+Legal | 非医疗/非招聘/隐私边界页 | 主入口可访问，多语言最小可用 |
+| WP-90-14 | 方法学页模板搭建 | W6-W9 | WP-90-13 | Content | methods template | 每量表可挂载方法说明 |
+| WP-90-15 | CI 分层（fast/slow） | W7-W10 | WP-90-01 | DevEx | pipeline 重构 | 主分支等待时长下降 |
+| WP-90-16 | 回滚演练制度化 | W8-W12 | 无 | SRE | 月度演练记录 | 每月演练一次并产出复盘 |
+| WP-90-17 | 订单恢复路径优化 | W8-W11 | WP-90-09 | Web+Product | orders/result 恢复入口 | pending 超时可恢复路径清晰 |
+| WP-90-18 | 支付后触达（邮件/站内） | W8-W12 | WP-90-17 | Ops+Growth | resend/通知策略 | 支付后迷失率下降 |
+| WP-90-19 | 组织权限回归扩展 | W6-W10 | WP-90-02 | API Security | org isolation test pack | 新接口必须覆盖权限用例 |
+| WP-90-20 | 迁移热表变更门禁 | W7-W11 | 无 | DBA+Platform | migration heat gate | 热表 schema 变更需附性能证据 |
+| WP-90-21 | 指标字典统一 | W9-W12 | WP-90-09 | Data | metric dictionary | 同指标口径唯一化 |
+| WP-90-22 | P0 风险月度复盘机制 | W10-W12 | 无 | Eng Mgmt | 风险例会模板 | P0 风险逾期为 0 |
+
+## 2.2 里程碑
+
+| 里程碑 | 时间 | 必达标准 |
+|---|---|---|
+| M1 | 第 30 天 | route spec + error contract + report 协议统一完成 |
+| M2 | 第 60 天 | checkout 幂等强制 + 支付履约看板上线 |
+| M3 | 第 90 天 | submit/webhook 拆分一期 + 合规边界页上线 |
+
+## 2.3 90天验收命令矩阵
+
+| 场景 | 命令 | 通过标准 |
+|---|---|---|
+| API 路由基线 | `php artisan route:list` | 路由完整且与 spec 同步 |
+| 迁移基线 | `php artisan migrate` | Nothing to migrate 或迁移成功 |
+| MBTI 主链 | `bash scripts/ci_verify_mbti.sh` | exit code 0 |
+| Web 契约 | `pnpm test:contract` | 通过 |
+| Web 可访问性 | `pnpm test:a11y` | 通过 |
+| Webhook 重放 | 同 provider_event 多次投递 | 不重复履约 |
+
+---
+
+## 3. 180 天执行计划（M4-M6）
+
+## 3.1 工作包总览（26 个）
+
+| WP | 工作包 | 月份 | 依赖 | Owner | 交付物 | DoD |
+|---|---|---|---|---|---|---|
+| WP-180-01 | 方法学公开中心 v1 | M4 | WP-90-14 | Content+Product | methods hub | MBTI/BIG5/Clinical/SDS/EQ 全覆盖 |
+| WP-180-02 | 量表版本日志中心 | M4 | WP-180-01 | Content | version changelog | 用户可查看版本变更与影响 |
+| WP-180-03 | SEO 模板工厂化 | M4-M5 | WP-90-12 | Growth+Web | landing 模板流水线 | 新 slug 生成时间显著下降 |
+| WP-180-04 | 结构化数据流水线 | M4-M5 | WP-180-03 | Growth+Web | schema 生成 + 校验 | 富结果覆盖率提升 |
+| WP-180-05 | 内链与内容矩阵策略 | M4-M6 | WP-180-03 | Growth | content graph 规划 | 长尾页面收录率提升 |
+| WP-180-06 | B2B landing + 询盘闭环 | M5 | WP-90-13 | BizOps+Product | teams/API landing | 企业线索有明确入口 |
+| WP-180-07 | API sandbox alpha | M5-M6 | WP-180-06 | API 平台 | sandbox 环境 | 外部可自助验证关键流程 |
+| WP-180-08 | 合作伙伴接入文档 | M5-M6 | WP-180-07 | API+DX | dev docs | 首个外部试点可落地 |
+| WP-180-09 | 价格与权益实验平台 | M5-M6 | WP-90-09 | Growth+Commerce | AB 实验框架 | 实验具备回滚安全闸门 |
+| WP-180-10 | 支付策略优化（本地化） | M5-M6 | WP-90-04 | Commerce | 支付配置策略 | 地区支付成功率提升 |
+| WP-180-11 | 留存触达自动化 | M5-M6 | WP-90-18 | Growth+Ops | lifecycle campaign | 未完成用户召回提升 |
+| WP-180-12 | 报告解释反馈闭环 | M4-M6 | WP-180-01 | Content+Data | feedback pipeline | 文案质量可量化 |
+| WP-180-13 | 国际化治理 v1（语言+法务+a11y） | M4-M6 | WP-90-13 | Product+Legal+Web | i18n governance | 新语种上线可复制 |
+| WP-180-14 | Accessibility 实施与审计 | M4-M5 | 无 | Web | a11y baseline | 关键路径无高危违规 |
+| WP-180-15 | webhook 拆分二期（provider plugin） | M4-M6 | WP-90-08 | Commerce | plugin architecture | 新 provider 接入改动范围可控 |
+| WP-180-16 | submit 拆分二期（pipeline） | M4-M6 | WP-90-07 | Assessment | submit pipeline | 新量表接入成本下降 |
+| WP-180-17 | report schema versioning 完整落地 | M4-M5 | WP-90-03 | API+Web | schema governance | 前端兼容风险下降 |
+| WP-180-18 | 经营化统一看板 | M4-M6 | WP-90-21 | Data+SRE | exec dashboard | 业务技术同屏决策 |
+| WP-180-19 | 季度安全合规审计机制 | M4-M6 | WP-90-13 | Security+Legal | audit SOP | 审计整改闭环率提高 |
+| WP-180-20 | 数据生命周期自动化 | M5-M6 | WP-90-22 | Data | lifecycle engine | 删除请求闭环可审计 |
+| WP-180-21 | 发布证据链自动化归档 | M5 | WP-90-16 | DevEx | release evidence bot | 发布审计成本下降 |
+| WP-180-22 | 组织评估（v0.4）专项回归门禁 | M4-M5 | WP-90-19 | API 平台 | v0.4 regression pack | B2B 线稳定性提升 |
+| WP-180-23 | 内容质量门禁（psychometrics gate） | M4-M6 | WP-180-12 | Content Science | gate pipeline | 新量表上线风险可控 |
+| WP-180-24 | 企业运营 SLA 策略 | M5-M6 | WP-180-06 | BizOps | SLA policy | B2B 承诺可执行 |
+| WP-180-25 | 商业模型复盘机制 | M5-M6 | WP-180-09 | Product+Finance | pricing review cadence | 实验收益可持续 |
+| WP-180-26 | 组织能力建设（owner 机制） | M4-M6 | 无 | Eng Mgmt | domain ownership matrix | 单点风险持续下降 |
+
+## 3.2 里程碑
+
+| 里程碑 | 时间 | 必达标准 |
+|---|---|---|
+| M4 | 第 120 天 | 方法学中心上线 + SEO 模板流水线可用 |
+| M5 | 第 150 天 | B2B landing + sandbox alpha + 经营看板上线 |
+| M6 | 第 180 天 | 增长平台化与审计机制稳定运行 |
+
+---
+
+## 4. RACI 矩阵（关键工作包）
+
+| 工作包 | R（负责） | A（审批） | C（协作） | I（知会） |
+|---|---|---|---|---|
+| 契约统一（WP-90-02/03） | API 平台 | 技术负责人 | Web、QA | Product |
+| 支付履约治理（WP-90-04/05/09/10） | Commerce | 技术负责人 | SRE、Web、Data | Product、客服 |
+| submit/webhook 拆分（WP-90-07/08） | Assessment/Commerce | 架构负责人 | QA、SRE | 全体研发 |
+| 合规公开页（WP-90-13） | Product | Legal | Web、Content | Ops |
+| SEO 工厂化（WP-180-03/04/05） | Growth+Web | Product | Content、Data | BizOps |
+| B2B 产品化（WP-180-06/07/08） | BizOps+API | Product | Legal、DX | Finance |
+| 经营看板（WP-180-18） | Data | COO/CTO | SRE、Growth、Commerce | 全团队 |
+
+---
+
+## 5. 依赖与阻塞管理
+
+## 5.1 外部依赖
+
+1. 法务评审周期（合规声明、条款文本）。
+2. 支付供应商能力差异（事件类型、签名策略、回调时序）。
+3. 监控平台接入权限（Sentry/BI/告警系统）。
+
+## 5.2 内部依赖
+
+1. schema 单源规范先行，否则 codegen 推进受阻。
+2. 指标字典不统一会阻塞经营看板落地。
+3. 组织 owner 不清会导致跨域工作包反复拉扯。
+
+## 5.3 阻塞处理机制
+
+1. 每周固定“跨域阻塞清单”会议，时长 30 分钟。
+2. 阻塞项超过 7 天自动升级到 A 角色。
+3. 关键里程碑前 2 周进入风险清零窗口。
+
+---
+
+## 6. 验收定义（DoD）模板
+
+每个工作包必须满足以下统一 DoD：
+
+1. 功能行为与设计一致。
+2. 至少一个自动化测试新增或更新。
+3. 关键命令可复现通过。
+4. 文档更新与代码同步。
+5. 监控指标或日志可观察。
+
+---
+
+## 7. KPI 目标（基线->90天->180天）
+
+| 指标 | 基线（待测） | 90天目标 | 180天目标 |
+|---|---:|---:|---:|
+| `submit_failure_rate` | TBD | -30% | -50% |
+| `unlock_to_ready_p95` | TBD | -30% | -50% |
+| `duplicate_order_rate` | TBD | -70% | -85% |
+| `contract_drift_defects/month` | TBD | -60% | -85% |
+| `ci_duration_p95` | TBD | -20% | -30% |
+| `non_brand_organic_traffic` | TBD | +15% | +30% |
+| `free_to_paid_conversion` | TBD | +10% | +20% |
+| `b2b_lead_conversion` | TBD | +15% | +35% |
+| `p0_risk_overdue_count` | TBD | 0 | 0 |
+
+---
+
+## 8. 每月交付清单（便于跟踪）
+
+### 月度1（W1-W4）
+
+1. route spec + 错误包统一一期。
+2. checkout 幂等键强制。
+3. report 状态协议初版。
+
+### 月度2（W5-W8）
+
+1. shared schema codegen 首批落地。
+2. submit/webhook 拆分一期。
+3. 支付履约看板上线。
+
+### 月度3（W9-W12）
+
+1. CI 分层优化。
+2. 合规声明页上线。
+3. 回滚演练制度化。
+
+### 月度4-6（M4-M6）
+
+1. 方法学中心 + SEO 工厂化。
+2. B2B 产品化 + sandbox alpha。
+3. 经营看板与审计机制稳定运行。
+
+---
+
+## 9. 关键验收命令与场景
+
+### 9.1 后端最小验收
+
+```bash
+cd /Users/rainie/Desktop/GitHub/fap-api/backend
+php artisan route:list
+php artisan migrate
+bash scripts/ci_verify_mbti.sh
+```
+
+### 9.2 前端最小验收
+
+```bash
+cd /Users/rainie/Desktop/GitHub/fap-web
+pnpm test:contract
+pnpm test:a11y
+```
+
+### 9.3 关键链路场景验收
+
+1. attempts：start -> progress -> submit -> report。
+2. commerce：checkout -> paid webhook -> entitlement -> snapshot ready。
+3. orders：pending -> paid -> result 跳转与超时恢复。
+4. tracking：未同意 consent 时不上报敏感事件。
+
+---
+
+## 10. 资源预算建议
+
+1. API 平台：2 人（契约/类型/route spec）。
+2. Commerce：2 人（支付履约与 webhook 拆分）。
+3. Assessment/Report：2 人（submit/report schema）。
+4. Web/Growth：2 人（状态机统一、SEO 工厂化）。
+5. Data/SRE：1~2 人（看板、告警、演练）。
+6. Product/Legal/Content：按里程碑参与评审与交付。
+
+---
+
+## 11. 路线图成功判断
+
+满足以下条件即可判断本路线图有效：
+
+1. P0 风险无逾期，支付履约相关投诉显著下降。
+2. 契约类缺陷显著下降，跨端联调效率提升。
+3. 支付后等待体验改善，转化率与完成率同步上升。
+4. SEO 与方法学资产开始贡献稳定增量流量。
+5. B2B 线索从“偶发”变为“可持续管理”。
+
+
+---
+
+## 12. 冲刺级执行日历（建议）
+
+### Sprint 1（W1-W2）
+
+1. route spec 自动导出（WP-90-01）。
+2. 错误包统一设计评审（WP-90-02）。
+3. report 状态协议草案（WP-90-03）。
+4. 验收：`route:list` 与 spec 一致性检查上线。
+
+### Sprint 2（W3-W4）
+
+1. checkout 幂等键强制（WP-90-04）。
+2. webhook 字段标准化（WP-90-05）。
+3. shared schema codegen PoC（WP-90-06）。
+4. 验收：重复下单与重放回调场景通过。
+
+### Sprint 3（W5-W6）
+
+1. submit 拆分一期编码（WP-90-07）。
+2. webhook 拆分一期编码（WP-90-08）。
+3. 支付履约看板搭建（WP-90-09）。
+4. 验收：回归测试全绿，关键指标可视化。
+
+### Sprint 4（W7-W8）
+
+1. unlock->ready SLO 告警（WP-90-10）。
+2. tracking lint 与 SEO gate（WP-90-11/12）。
+3. 合规声明页面上线（WP-90-13）。
+4. 验收：敏感字段阻断与 noindex 规则自动检查上线。
+
+### Sprint 5（W9-W10）
+
+1. CI 分层改造（WP-90-15）。
+2. 订单恢复路径优化（WP-90-17）。
+3. 组织权限回归扩展（WP-90-19）。
+4. 验收：CI 时长下降、orders 恢复流程可复现。
+
+### Sprint 6（W11-W12）
+
+1. 回滚演练制度化（WP-90-16）。
+2. 指标字典统一（WP-90-21）。
+3. P0 风险治理例会落地（WP-90-22）。
+4. 验收：路线图 M3 达成。
+
+---
+
+## 13. 质量闸门清单（按阶段）
+
+| 阶段 | Gate 名称 | 触发条件 | 阻断规则 |
+|---|---|---|---|
+| 开发 | Contract Gate | API 字段变更 | 未更新 schema/类型即阻断 |
+| 开发 | Security Gate | 中间件/鉴权改动 | security_gate 失败即阻断 |
+| 合并前 | CI Master Gate | 影响核心链路 | `ci_verify_mbti.sh` 失败即阻断 |
+| 发布前 | Release Gate | Web 发布 | 敏感文件/构建产物存在即阻断 |
+| 发布后 | SLO Gate | 履约链路波动 | 超阈值触发回滚评估 |
+
+---
+
+## 14. 跨团队协作机制
+
+### 14.1 会议节奏
+
+1. 每周一：路线图推进会（30 分钟，聚焦阻塞项）。
+2. 每周三：技术风险会（30 分钟，聚焦 P0/P1）。
+3. 每双周：产品-工程联审（45 分钟，验收结果与下一步）。
+4. 每月：经营复盘会（60 分钟，业务+技术看板同屏）。
+
+### 14.2 决策机制
+
+1. 涉及支付/合规边界的变更必须经过 A 角色审批。
+2. 涉及契约破坏性变更必须给出迁移窗口与兼容策略。
+3. 涉及用户感知明显变化的改动必须提前灰度与回滚预案。
+
+---
+
+## 15. 验收场景模板（可复制到任务卡）
+
+### 场景 A：attempt 主链
+
+1. start 成功，返回 attempt_id。
+2. progress 可多次保存，seq 单调递增。
+3. submit 成功并返回结果。
+4. report 支持 pending->ready 状态变化。
+
+### 场景 B：支付履约主链
+
+1. checkout 创建成功并返回 order。
+2. webhook 首次投递成功推进状态。
+3. 同 provider_event 重放不重复履约。
+4. unlock 后 snapshot 在 SLA 内 ready。
+
+### 场景 C：前端恢复能力
+
+1. result generating 可重试并有文案提示。
+2. orders pending 超时有恢复入口。
+3. 未授权/异常时错误提示一致。
+
+### 场景 D：隐私与埋点
+
+1. 未同意 tracking 时不上报事件。
+2. event payload 不含敏感字段片段。
+3. track API 对非法事件名拒绝。
+
+---
+
+## 16. 成本与收益预估（用于优先级沟通）
+
+| 工作簇 | 成本（人周） | 预期收益 | 风险下降 |
+|---|---:|---|---|
+| 契约治理（WP-90-01~06） | 12~16 | 联调效率提升、回归成本下降 | 高 |
+| 履约治理（WP-90-04~10） | 10~14 | 重复订单与解锁投诉下降 | 高 |
+| 复杂度治理（WP-90-07/08 + 180-15/16） | 16~24 | 变更风险下降、可扩展性提升 | 高 |
+| 合规与信任资产（WP-90-13 + 180-01/02） | 8~12 | 品牌信任与审查通过率提升 | 中高 |
+| 增长平台化（WP-180-03~12） | 18~28 | 自然流量与转化提升 | 中高 |
+| B2B 产品化（WP-180-06~08/24） | 12~18 | 新收入通道建立 | 高 |
+
+---
+
+## 17. 失败预案（Plan-B）
+
+1. 如果 submit/webhook 拆分进度不达标：先冻结新功能，优先完成边界抽离与回归增强。
+2. 如果契约统一受阻：优先收敛“错误包 + 报告状态协议”两个最高收益点。
+3. 如果增长工作与稳定性冲突：以稳定性为第一优先，增长动作改为灰度。
+4. 如果 B2B 产品化延迟：先上线最小询盘闭环与手工接入流程。
+
+---
+
+## 18. 路线图执行完成定义
+
+当以下条件全部满足，可判定本路线图执行成功：
+
+1. 主链命令稳定通过：`route:list`、`migrate`、`ci_verify_mbti.sh`、`test:contract`、`test:a11y`。
+2. P0 风险无逾期，且关键风险至少降级一档。
+3. 支付履约链路 SLO 达标并可持续监控。
+4. 契约漂移缺陷明显下降。
+5. 形成可对外展示的信任资产（方法学、边界声明、可访问性）。
+6. B2B 线索承接能力从 0 到 1。
+
+
+---
+
+## 19. 执行检查清单（逐项打勾）
+
+### 19.1 契约治理检查
+
+- [ ] API 错误包字段统一：`code/message/details/request_id`。
+- [ ] report 状态统一：`pending/ready/failed/retry_after_seconds`。
+- [ ] shared schema 生成类型已替换关键手写类型。
+- [ ] route spec 自动导出并在 CI 阻断漂移。
+
+### 19.2 履约治理检查
+
+- [ ] checkout 强制 idempotency key。
+- [ ] webhook 重放不重复履约。
+- [ ] `unlock->ready` SLO 已配置告警。
+- [ ] 订单页超时与恢复路径可复现。
+
+### 19.3 稳定性与安全检查
+
+- [ ] `ci_verify_mbti.sh` 每日可稳定通过。
+- [ ] security gate 覆盖关键中间件与路由。
+- [ ] tracking forbidden 字段自动阻断。
+- [ ] 回滚演练按月执行并有复盘。
+
+### 19.4 增长与合规检查
+
+- [ ] noindex/canonical 规则自动化校验。
+- [ ] 方法学页面上线并可追踪版本。
+- [ ] 合规边界页面入口可见。
+- [ ] B2B 询盘流程可闭环追踪。
+
+---
+
+## 20. 命令库（交付验收附录）
+
+### 20.1 API 验收命令
+
+```bash
+cd /Users/rainie/Desktop/GitHub/fap-api/backend
+php artisan route:list
+php artisan migrate
+bash scripts/ci_verify_mbti.sh
+```
+
+### 20.2 Web 验收命令
+
+```bash
+cd /Users/rainie/Desktop/GitHub/fap-web
+pnpm test:contract
+pnpm test:a11y
+```
+
+### 20.3 主链 curl 验收模板
+
+```bash
+# 1) start
+curl -X POST "http://127.0.0.1:1827/api/v0.3/attempts/start" \
+  -H "Content-Type: application/json" \
+  -H "X-FAP-Locale: zh-CN" \
+  -H "X-Anon-Id: anon_exec_001" \
+  -d '{"scale_code":"BIG5_OCEAN","region":"CN_MAINLAND","locale":"zh-CN"}'
+
+# 2) progress
+curl -X PUT "http://127.0.0.1:1827/api/v0.3/attempts/{id}/progress" \
+  -H "Content-Type: application/json" \
+  -H "X-Anon-Id: anon_exec_001" \
+  -d '{"seq":1,"answers":[{"question_id":"Q1","code":"A"}]}'
+
+# 3) submit
+curl -X POST "http://127.0.0.1:1827/api/v0.3/attempts/submit" \
+  -H "Content-Type: application/json" \
+  -H "Authorization: Bearer fm_xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx" \
+  -H "X-Anon-Id: anon_exec_001" \
+  -d '{"attempt_id":"{id}","duration_ms":120000,"answers":[{"question_id":"Q1","code":"A"}]}'
+
+# 4) report
+curl "http://127.0.0.1:1827/api/v0.3/attempts/{id}/report" \
+  -H "Authorization: Bearer fm_xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx" \
+  -H "X-Anon-Id: anon_exec_001"
+
+# 5) checkout + order
+curl -X POST "http://127.0.0.1:1827/api/v0.3/orders/checkout" \
+  -H "Content-Type: application/json" \
+  -H "Authorization: Bearer fm_xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx" \
+  -H "Idempotency-Key: route_exec_{id}" \
+  -H "X-Anon-Id: anon_exec_001" \
+  -d '{"attempt_id":"{id}","sku":"BIG5_UNLOCK"}'
+
+curl "http://127.0.0.1:1827/api/v0.3/orders/{order_no}" -H "X-Anon-Id: anon_exec_001"
+```
+
+### 20.4 Webhook 幂等重放模板
+
+```bash
+curl -X POST "http://127.0.0.1:1827/api/v0.3/webhooks/payment/stripe" \
+  -H "Content-Type: application/json" \
+  -d '{"provider_event_id":"evt_exec_001","order_no":"ord_exec_001","event_type":"payment_succeeded"}'
+
+curl -X POST "http://127.0.0.1:1827/api/v0.3/webhooks/payment/stripe" \
+  -H "Content-Type: application/json" \
+  -d '{"provider_event_id":"evt_exec_001","order_no":"ord_exec_001","event_type":"payment_succeeded"}'
+```
+
+---
+
+## 21. 治理成果固化要求
+
+1. 每个里程碑结束后，必须输出“里程碑证据包”：命令输出、回归截图、风险变更记录。
+2. 每个 P0 工作包完成后，必须附“失败注入演练结果”。
+3. 每个外部可见变更（方法学、合规页、B2B）必须有版本记录与回滚说明。
+

--- a/research/deep-research-2026-02-25/路线图执行表_2026-02-25.md
+++ b/research/deep-research-2026-02-25/路线图执行表_2026-02-25.md
@@ -473,19 +473,19 @@ curl -X PUT "http://127.0.0.1:1827/api/v0.3/attempts/{id}/progress" \
 # 3) submit
 curl -X POST "http://127.0.0.1:1827/api/v0.3/attempts/submit" \
   -H "Content-Type: application/json" \
-  -H "Authorization: Bearer fm_xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx" \
+  -H "Authorization: Bearer <FM_TOKEN>" \
   -H "X-Anon-Id: anon_exec_001" \
   -d '{"attempt_id":"{id}","duration_ms":120000,"answers":[{"question_id":"Q1","code":"A"}]}'
 
 # 4) report
 curl "http://127.0.0.1:1827/api/v0.3/attempts/{id}/report" \
-  -H "Authorization: Bearer fm_xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx" \
+  -H "Authorization: Bearer <FM_TOKEN>" \
   -H "X-Anon-Id: anon_exec_001"
 
 # 5) checkout + order
 curl -X POST "http://127.0.0.1:1827/api/v0.3/orders/checkout" \
   -H "Content-Type: application/json" \
-  -H "Authorization: Bearer fm_xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx" \
+  -H "Authorization: Bearer <FM_TOKEN>" \
   -H "Idempotency-Key: route_exec_{id}" \
   -H "X-Anon-Id: anon_exec_001" \
   -d '{"attempt_id":"{id}","sku":"BIG5_UNLOCK"}'
@@ -512,4 +512,3 @@ curl -X POST "http://127.0.0.1:1827/api/v0.3/webhooks/payment/stripe" \
 1. 每个里程碑结束后，必须输出“里程碑证据包”：命令输出、回归截图、风险变更记录。
 2. 每个 P0 工作包完成后，必须附“失败注入演练结果”。
 3. 每个外部可见变更（方法学、合规页、B2B）必须有版本记录与回滚说明。
-

--- a/research/deep-research-2026-02-25/风险登记册_2026-02-25.md
+++ b/research/deep-research-2026-02-25/风险登记册_2026-02-25.md
@@ -1,0 +1,266 @@
+# 风险登记册（超深版 / Risk Register v2）
+
+- 文档日期：2026-02-25
+- 评分方法：`风险分值 = 概率(1-5) × 影响(1-5)`
+- 优先级阈值：`P0 >= 16`，`P1 = 10~15`，`P2 <= 9`
+- 适用范围：`fap-api + fap-web` 双仓库与长期运营链路
+
+---
+
+## 1. 风险分层框架
+
+### 1.1 风险域
+
+1. 平台与架构风险（复杂度、耦合、回归）。
+2. 数据与契约风险（前后端字段、状态机语义漂移）。
+3. 支付与履约风险（订单、webhook、权益发放、解锁体验）。
+4. 稳定性与运维风险（SLO、告警、发布、回滚）。
+5. 安全与合规风险（隐私、边界声明、审计可追踪）。
+6. 增长与商业风险（SEO、留存、B2B 产品化窗口）。
+
+### 1.2 风险处置原则
+
+1. 对主漏斗或营收链路造成中断的风险，默认 P0。
+2. 对用户信任造成持续损害的风险，默认至少 P1。
+3. 能通过制度和自动化预防的风险，优先投入治理而非事后补丁。
+
+---
+
+## 2. 风险组合总表（50 项）
+
+| ID | 风险描述 | 概率 | 影响 | 分值 | 优先级 | 触发信号 | 领先指标 | 缓解策略 | 责任域 |
+|---|---|---:|---:|---:|---|---|---|---|---|
+| R-001 | API 文档与 runtime 路由漂移导致联调错误 | 4 | 3 | 12 | P1 | 新接口联调失败率上升 | route spec diff 数/月 | route 自动导出 + CI 比对 | API 平台 |
+| R-002 | `PaymentWebhookHandlerCore` 复杂度过高导致回归 | 4 | 5 | 20 | P0 | 支付链路 hotfix 频次上升 | webhook 相关缺陷数 | 按策略链拆分 + golden 回归 | Commerce |
+| R-003 | `AttemptSubmitService` 过重导致提交链改动高风险 | 4 | 4 | 16 | P0 | submit 改动引入旁路 bug | submit 缺陷密度 | 分层重构 + 行为等价测试 | Assessment |
+| R-004 | 前后端状态枚举不统一造成页面分支错配 | 4 | 3 | 12 | P1 | 同一错误在不同页表现不一致 | UI 状态异常工单数 | shared schema codegen | API+Web |
+| R-005 | 手写类型长期积累导致契约漂移 | 5 | 3 | 15 | P1 | 字段缺失/多余导致运行时错误 | contract 失败率 | schema 单源生成类型 | API+Web |
+| R-006 | Webhook 重放高峰下锁竞争导致时延放大 | 3 | 5 | 15 | P1 | webhook backlog 增长 | queue lag p95 | 锁粒度优化 + 限流告警 | Commerce+SRE |
+| R-007 | 支付后 snapshot pending 过长触发用户流失 | 3 | 5 | 15 | P1 | 订单页超时投诉增多 | unlock->ready p95 | 状态提示 + SLO + 重试机制 | Report+Web |
+| R-008 | checkout 入口未强制幂等键导致重复订单 | 3 | 5 | 15 | P1 | 同用户短时重复下单 | duplicate_order_rate | 强制 idempotency key | Commerce |
+| R-009 | 组织权限在新增接口实现不一致 | 3 | 5 | 15 | P1 | org 隔离回归失败 | permission test fail rate | ownership middleware 标准化 | API Security |
+| R-010 | tracking 新事件字段带入敏感数据 | 3 | 5 | 15 | P1 | 审计发现 email/token 片段 | forbidden scanner 命中 | schema lint 阻断合并 | Data+Web |
+| R-011 | 临床场景商业化调整不当引发伦理争议 | 2 | 5 | 10 | P1 | crisis 相关负反馈上升 | crisis 页面停留与投诉 | 固化 crisis no-paywall 策略 | Product+Clinical |
+| R-012 | 报告 schema 演进缺版本管理导致前端兼容问题 | 3 | 4 | 12 | P1 | 老版本页面渲染失败 | report parse error rate | schema_version/generation_time | API+Web |
+| R-013 | 迁移数量增长导致变更窗口管理失控 | 3 | 4 | 12 | P1 | 迁移执行时间抖动 | migrate duration p95 | 迁移分层治理与窗口化 | DBA+Platform |
+| R-014 | 热表索引变更影响线上性能 | 2 | 5 | 10 | P1 | DB CPU/锁等待上升 | slow query count | 热表变更性能闸门 | DBA |
+| R-015 | CI 主链持续变长拖慢研发效率 | 4 | 3 | 12 | P1 | PR 等待时长上升 | pipeline duration | fast/slow pipeline 拆分 | DevEx |
+| R-016 | 脚本资产过多且分散，知识内聚不足 | 4 | 3 | 12 | P1 | 新人定位脚本困难 | 问题定位时长 | 脚本目录索引与统一入口 | Platform |
+| R-017 | 关键脚本维护者单点风险 | 3 | 4 | 12 | P1 | 关键人不可用时恢复慢 | MTTR 波动 | 双人 owner + 演练 | Eng Mgmt |
+| R-018 | release gate 未覆盖新增敏感文件模式 | 2 | 4 | 8 | P2 | 意外敏感文件进入仓库 | gate miss count | 扩展 pattern + 定期审计 | Web 平台 |
+| R-019 | rollback drill 频率不足导致真实故障反应慢 | 3 | 4 | 12 | P1 | 回滚耗时超目标 | drill 达标率 | 月度演练制度化 | SRE |
+| R-020 | Sentry 标签不统一影响故障聚类效率 | 3 | 3 | 9 | P2 | 同类错误分散 | unknown-tag ratio | 统一 route/scale/stage tag | Web+API |
+| R-021 | order 状态语义扩展导致历史页面兼容崩溃 | 3 | 3 | 9 | P2 | 新状态显示异常 | status unknown ratio | status enum + fallback 规则 | Web |
+| R-022 | webhook 供应商事件类型变更引发拒收 | 3 | 4 | 12 | P1 | EVENT_TYPE_NOT_ALLOWED 增加 | rejected_event_ratio | 供应商映射版本化 | Commerce |
+| R-023 | 供应商签名策略升级引发误拒绝 | 2 | 5 | 10 | P1 | INVALID_SIGNATURE 激增 | signature_fail_ratio | 双轨签名兼容窗口 | Commerce |
+| R-024 | 订单支付成功但 post-commit 失败未及时补偿 | 3 | 5 | 15 | P1 | paid 与 unlock 断裂 | paid_not_unlocked_count | 补偿队列 + 定时修复任务 | Commerce+SRE |
+| R-025 | snapshot failed 解释不清导致客服压力 | 3 | 3 | 9 | P2 | 用户“支付失败”误判 | snapshot_failed_view_rate | 明确文案 + 重试按钮 | Product+Web |
+| R-026 | 数据删除流程未闭环影响合规审查 | 2 | 5 | 10 | P1 | 合规审查发现缺口 | lifecycle_request_age | 生命周期自动化闭环 | Data+Legal |
+| R-027 | 边界声明分散且不一致引发法律沟通风险 | 3 | 5 | 15 | P1 | 法务反馈需反复解释 | legal_review_cycles | 统一公共声明中心 | Legal+Product |
+| R-028 | 可访问性不足导致国际市场准入受限 | 3 | 3 | 9 | P2 | 无障碍检查失败 | a11y violation count | a11y 基线与声明落地 | Web |
+| R-029 | SEO canonical/noindex 规则在新页漏配 | 4 | 3 | 12 | P1 | 索引到敏感页 | indexed_sensitive_pages | CI SEO rule checker | Growth+Web |
+| R-030 | 结构化数据未模板化导致长尾增长受限 | 4 | 3 | 12 | P1 | 富结果覆盖率低 | schema_coverage | SEO 工厂化模板 | Growth |
+| R-031 | 量表扩展时 psychometrics 门禁不稳定 | 3 | 4 | 12 | P1 | 新量表上线后反馈异常 | first_7d complaint rate | 上线前 psychometric gate | Content Science |
+| R-032 | 解释文本版本化不足导致效果不可评估 | 3 | 3 | 9 | P2 | 文案优化收益不明 | content_experiment_count | 报告块级版本号 | Content |
+| R-033 | 多语言仅翻译未配合法务导致返工 | 3 | 3 | 9 | P2 | 新语种上线延期 | i18n rollback count | i18n+legal checklist | Product |
+| R-034 | B2B 能力未产品化错失企业收入窗口 | 4 | 4 | 16 | P0 | 企业线索无法承接 | b2b lead drop rate | sandbox + docs + team plans | BizOps |
+| R-035 | 支付供应商异常时降级策略不充分 | 3 | 4 | 12 | P1 | 支付可用性突降 | provider_error_rate | provider failover/熔断 | SRE+Commerce |
+| R-036 | 事件数据跨系统 request_id 不一致 | 3 | 3 | 9 | P2 | 排障需要手工对齐 | trace_break_ratio | request_id 端到端透传 | Platform |
+| R-037 | 运营看板缺经营指标联动，决策滞后 | 3 | 4 | 12 | P1 | 周会仅看技术指标 | decision lag | 业务+技术统一看板 | Data |
+| R-038 | 价格实验缺防护导致履约异常 | 2 | 4 | 8 | P2 | 实验版本定价冲突 | experiment_incidents | 实验闸门 + 回滚策略 | Growth+Commerce |
+| R-039 | localStorage 关键状态丢失影响恢复路径 | 3 | 3 | 9 | P2 | 订单/解锁恢复失败 | recovery_fail_count | server-side fallback | Web |
+| R-040 | 匿名ID 与登录绑定边界场景遗漏 | 3 | 4 | 12 | P1 | 历史记录错绑 | link_anon_error_rate | 绑定流程回归增强 | API+Web |
+| R-041 | 结果页轮询策略与后端重试策略不对齐 | 3 | 3 | 9 | P2 | 轮询过度或过慢 | polling_efficiency | 统一 retry_after 语义 | API+Web |
+| R-042 | 报告 PDF 生成失败影响交付可信度 | 2 | 4 | 8 | P2 | 下载失败投诉 | pdf_fail_rate | PDF 队列告警 + 重试 | Report |
+| R-043 | DB/Redis 依赖异常降级不充分 | 2 | 5 | 10 | P1 | healthz 依赖告警持续 | dep_outage_duration | fail-safe 策略演练 | SRE |
+| R-044 | feature flag 生命周期管理不严 | 3 | 3 | 9 | P2 | 历史 flag 堆积 | stale_flag_count | flag 清理制度 | Platform |
+| R-045 | 运营活动流量峰值压垮非热点链路 | 2 | 4 | 8 | P2 | 5xx 突增 | burst_error_ratio | 压测 + 限流演练 | SRE |
+| R-046 | 付费后邮件触达失败导致“未收到报告”工单 | 3 | 3 | 9 | P2 | resend 请求增多 | email_delivery_fail_rate | 邮件通道监控+重投 | Ops |
+| R-047 | 法务页面更新节奏落后产品迭代 | 2 | 4 | 8 | P2 | 页面信息过时 | legal_page_age | 版本发布同步校验 | Legal |
+| R-048 | 代码热点集中导致 reviewer 负载过高 | 4 | 2 | 8 | P2 | 审查瓶颈 | review_cycle_time | 组件拆分+owner扩展 | Eng Mgmt |
+| R-049 | metrics 定义缺统一口径引发汇报偏差 | 3 | 3 | 9 | P2 | 同指标多版本 | metric_definition_conflicts | 指标字典统一 | Data |
+| R-050 | 外部对标学习碎片化，落地动作弱 | 4 | 2 | 8 | P2 | 对标结论无法执行 | benchmark_action_rate | 对标->任务映射制度 | Product |
+
+---
+
+## 3. P0 风险清单（必须优先处理）
+
+> 分值 >= 16
+
+| 风险ID | 核心问题 | 立即动作（2周内） | 30天动作 | 90天动作 |
+|---|---|---|---|---|
+| R-002 | webhook 超大核心复杂度 | 划分责任子模块接口 | 拆出前置校验与履约层 | 完成可插拔 provider 策略 |
+| R-003 | submit 服务超重 | 建立行为基线测试 | 分离 scoring 与持久化 | 完成提交流水线重构 |
+| R-034 | B2B 产品化缺失 | 建立 landing 与询盘入口 | 搭建 sandbox 雏形 | 建立团队版试用闭环 |
+
+---
+
+## 4. 监控指标映射（风险->指标->阈值）
+
+| 指标 | 关联风险 | 建议阈值 | 告警级别 |
+|---|---|---|---|
+| `duplicate_order_rate` | R-008 | >0.3% / 5m | P1 |
+| `unlock_to_snapshot_ready_p95` | R-007,R-024 | >60s / 15m | P1 |
+| `webhook_processed_lag_p95` | R-006,R-035 | >20s / 10m | P1 |
+| `event_forbidden_field_hit` | R-010 | >0 immediate | P0 |
+| `route_spec_drift_count` | R-001 | >0 on main | P1 |
+| `contract_test_fail_rate` | R-004,R-005 | >1% / week | P1 |
+| `indexed_sensitive_pages` | R-029 | >0 immediate | P0 |
+| `ci_duration_p95` | R-015 | >20min | P2 |
+| `migration_failure_rate` | R-013,R-014 | >0.5% / month | P1 |
+| `b2b_lead_drop_rate` | R-034 | >20% / month | P1 |
+
+---
+
+## 5. 风险处置策略库（Playbook）
+
+### 5.1 支付履约中断 Playbook
+
+1. 先看 `payment_events` 状态与 `order` 状态是否一致。
+2. 区分“已 paid 未 unlock”与“unlock 已完成但 snapshot pending”。
+3. 对 post-commit failed 走补偿队列，不允许人工直接改最终状态。
+4. 复盘输出必须包含：触发条件、恢复时长、自动化缺口。
+
+### 5.2 报告生成异常 Playbook
+
+1. 校验 `report_snapshots.status`。
+2. 若 `failed`，读取 `last_error` 并触发重试上限策略。
+3. 前端明确展示 retry_after，避免用户误判“支付失败”。
+4. 建立 `snapshot_failed` 分级：可重试 vs 需人工介入。
+
+### 5.3 契约漂移 Playbook
+
+1. route spec 与 schema 比较失败即阻断主干合并。
+2. 前端 contract test 失败默认高优处理。
+3. 变更必须同时更新：API schema、TS 类型、错误码映射、文档。
+
+---
+
+## 6. 90/180 天风险关闭目标
+
+### 6.1 90 天
+
+1. 关闭 R-002/R-003 第一阶段（可测拆分）。
+2. 把 R-008 从 P1 降到 P2（幂等键强制化）。
+3. 把 R-029 降为 P2（SEO 规则 CI 化）。
+4. 把 R-015 降为 P2（CI 分层优化）。
+
+### 6.2 180 天
+
+1. 把 R-034 从 P0 降到 P1（B2B 产品化成型）。
+2. 把 R-007/R-024 降到 P2（履约链路 SLO 稳定）。
+3. 把 R-027 降到 P2（合规叙事公开化完成）。
+
+---
+
+## 7. 风险复盘模板（执行要求）
+
+每个 P0/P1 事件复盘必须输出：
+
+1. 事件时间线（分钟级）。
+2. 影响范围（用户、订单、报告、渠道）。
+3. 根因分类（代码、配置、流程、外部依赖）。
+4. 临时止损动作与永久修复动作。
+5. 预防措施（自动化门禁或监控指标）。
+6. owner 与完成日期。
+
+---
+
+## 8. 当前结论
+
+1. 当前风险结构以“复杂度与治理”为主，而非基础可用性缺失。
+2. 如果只做功能迭代不做治理，P0 风险会在流量扩大阶段集中暴露。
+3. 若按路线图推进，90 天内可显著降低支付与契约类高风险。
+
+
+---
+
+## 9. 扩展风险库（补充 20 项）
+
+| ID | 风险描述 | 概率 | 影响 | 分值 | 优先级 | 触发信号 | 缓解策略 |
+|---|---|---:|---:|---:|---|---|---|
+| R-051 | 量表间题目 schema 不一致导致客户端兼容分叉 | 3 | 3 | 9 | P2 | 新量表接入时分支增多 | 统一 question schema adapter |
+| R-052 | 运营临时配置未回收导致行为不可预测 | 3 | 3 | 9 | P2 | 临时 flag 长期存在 | flag 生命周期治理 |
+| R-053 | 数据仓库同步延迟导致看板误判 | 3 | 3 | 9 | P2 | 指标延迟超过 SLA | 数据链路延迟监控 |
+| R-054 | result 页文本国际化缺失影响转化 | 3 | 2 | 6 | P2 | 非中文用户跳失升高 | i18n 文案覆盖清单 |
+| R-055 | 内容包发布审批链不足引发错误上线 | 2 | 4 | 8 | P2 | 内容回滚频次增加 | 内容发布审批门禁 |
+| R-056 | QA 用例覆盖偏 MBTI，新增量表覆盖不足 | 3 | 3 | 9 | P2 | 新量表缺陷率偏高 | 量表覆盖配额制度 |
+| R-057 | PDF 生成资源峰值导致队列拥堵 | 2 | 4 | 8 | P2 | PDF queue lag 增长 | PDF 队列独立伸缩 |
+| R-058 | 支付渠道汇率/币种扩展缺策略 | 2 | 3 | 6 | P2 | 新市场上线改造重 | 价格与币种策略模块化 |
+| R-059 | 客服工具缺少技术状态透视能力 | 3 | 3 | 9 | P2 | 一线工单升级比例高 | 客服状态面板 |
+| R-060 | 组织版权限模型扩展时定义不一致 | 3 | 4 | 12 | P1 | v0.4 新角色冲突 | RBAC 模型文档化 |
+| R-061 | 行为埋点过多导致噪声高、信号弱 | 3 | 2 | 6 | P2 | 关键指标波动解释困难 | 事件分层采集策略 |
+| R-062 | 线上故障复盘执行不到位导致同类复发 | 3 | 4 | 12 | P1 | 同类事件重复出现 | 复盘闭环追踪机制 |
+| R-063 | 多仓库版本联动缺规范导致发布错配 | 3 | 4 | 12 | P1 | API/Web 版本不兼容 | 跨仓发布契约门禁 |
+| R-064 | 用户隐私请求响应 SLA 不可量化 | 2 | 4 | 8 | P2 | 合规响应时长不稳 | lifecycle SLA 指标 |
+| R-065 | 事件转发端点故障时降级不清晰 | 3 | 3 | 9 | P2 | `/api/track` 502 增加 | 事件降级缓存与重投 |
+| R-066 | 长尾页面质量波动拉低整站信任 | 3 | 3 | 9 | P2 | 索引页质量评分下降 | 内容质量抽检机制 |
+| R-067 | 匿名会话跨设备断裂影响漏斗归因 | 4 | 2 | 8 | P2 | 归因链断裂率高 | 账号绑定引导优化 |
+| R-068 | 业务指标定义更新未同步历史报表 | 2 | 3 | 6 | P2 | 环比同比误差大 | 指标版本标识 |
+| R-069 | 依赖第三方文档变更未及时跟踪 | 3 | 2 | 6 | P2 | 回调字段突变后异常 | 供应商变更订阅机制 |
+| R-070 | 新人上手周期过长影响迭代速度 | 3 | 2 | 6 | P2 | onboarding 周期拉长 | runbook + 架构地图 |
+
+---
+
+## 10. 风险清零节奏（建议）
+
+1. 每周：更新风险状态（新增、升级、降级、关闭）。
+2. 每双周：P0/P1 逐条评审，确认是否进入阻塞列表。
+3. 每月：输出《风险关闭率与复发率》报告。
+4. 每季度：做一次风险模型校准，修正概率与影响口径。
+
+### 10.1 关闭定义（Closed）
+
+风险项仅在以下条件全部满足时可关闭：
+
+1. 根因修复已发布。
+2. 自动化门禁或监控已建立。
+3. 连续 2 个观察周期未复发。
+4. owner 与 approver 双签。
+
+### 10.2 降级定义（Downgrade）
+
+风险从 P0/P1 降级到 P2 必须满足：
+
+1. 对应指标至少改善 30%。
+2. 关键场景演练至少 2 次通过。
+3. 回归测试覆盖达标。
+
+
+---
+
+## 11. 监控与审计样例（落地执行）
+
+### 11.1 日监控清单
+
+1. `payment_events` 当日重复事件占比。
+2. `orders` 从 `paid` 到 `fulfilled` 的 p95 时延。
+3. `report_snapshots` 中 `status=failed` 占比与趋势。
+4. `attempts` 提交失败与 409 冲突占比。
+5. `track` API 的 4xx/5xx 比例与非法事件名占比。
+
+### 11.2 周审计清单
+
+1. route spec 与生产路由对齐率。
+2. 合规页面版本与产品版本一致性。
+3. 关键风险 owner 的整改完成率。
+4. 回滚演练执行率与达标率。
+
+### 11.3 月度治理清单
+
+1. 关闭风险数 / 新增风险数。
+2. P0/P1 风险平均滞留时长。
+3. 复发风险比例（同类问题复发）。
+4. 预防型改造占比（非事故驱动改造比例）。
+
+### 11.4 建议审计字段
+
+对每个高风险链路事件建议统一记录：
+
+1. `request_id`（跨服务链路追踪）。
+2. `org_id`（组织隔离审计）。
+3. `attempt_id/order_no/provider_event_id`（业务主键）。
+4. `status_before/status_after`（状态机可回放）。
+5. `error_code/error_message`（故障归因）。
+6. `processed_at`（时延分析）。
+


### PR DESCRIPTION
## Summary
新增 2026-02-25 的双仓库深度研究交付文档包，集中放在 `research/deep-research-2026-02-25/` 目录，包含主报告、证据索引、风险登记册、路线图执行表。

## Included Files
- FAP_双仓库深度研究主报告_2026-02-25.md
- 证据索引附录_2026-02-25.md
- 风险登记册_2026-02-25.md
- 路线图执行表_2026-02-25.md

## Impact
- 文档交付变更（docs-only）
- 不涉及运行时代码、数据库结构、接口协议修改

## Notes
- 本 PR 用于沉淀研究成果，便于评审与后续执行跟踪。
