### PR TITLE
feat: strategyA scale-identity dual-stack + demo-offboarding controls

### DIFF
--- a/backend/app/Console/Commands/Ops/BackfillAssessmentsScaleIdentity.php
+++ b/backend/app/Console/Commands/Ops/BackfillAssessmentsScaleIdentity.php
@@ -1,0 +1,129 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Console\Commands\Ops;
+
+use App\Services\Scale\ScaleIdentityResolver;
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+class BackfillAssessmentsScaleIdentity extends Command
+{
+    protected $signature = 'ops:backfill-assessments-scale-identity
+        {--chunk=1000 : Chunk size}
+        {--dry-run : Compute and report only; do not write updates}';
+
+    protected $description = 'Backfill assessments.scale_code_v2 and assessments.scale_uid from assessments.scale_code';
+
+    public function __construct(private readonly ScaleIdentityResolver $identityResolver)
+    {
+        parent::__construct();
+    }
+
+    public function handle(): int
+    {
+        if (! Schema::hasTable('assessments')) {
+            $this->warn('assessments table missing, skipping.');
+
+            return self::SUCCESS;
+        }
+
+        if (! Schema::hasColumn('assessments', 'scale_code_v2') || ! Schema::hasColumn('assessments', 'scale_uid')) {
+            $this->warn('assessments scale identity columns missing, skipping.');
+
+            return self::SUCCESS;
+        }
+
+        $chunk = max(100, (int) $this->option('chunk'));
+        $dryRun = (bool) $this->option('dry-run');
+
+        $scanned = 0;
+        $updated = 0;
+        $skippedUnknown = 0;
+        $lastId = 0;
+
+        do {
+            $rows = DB::table('assessments')
+                ->select(['id', 'scale_code', 'scale_code_v2', 'scale_uid'])
+                ->where(function ($q): void {
+                    $q->whereNull('scale_code_v2')
+                        ->orWhere('scale_code_v2', '')
+                        ->orWhereNull('scale_uid')
+                        ->orWhere('scale_uid', '');
+                })
+                ->when($lastId > 0, fn ($q) => $q->where('id', '>', $lastId))
+                ->orderBy('id')
+                ->limit($chunk)
+                ->get();
+
+            if ($rows->isEmpty()) {
+                break;
+            }
+
+            foreach ($rows as $row) {
+                $assessmentId = (int) ($row->id ?? 0);
+                if ($assessmentId <= 0) {
+                    continue;
+                }
+                $lastId = $assessmentId;
+                $scanned++;
+
+                $legacyCode = strtoupper(trim((string) ($row->scale_code ?? '')));
+                if ($legacyCode === '') {
+                    $skippedUnknown++;
+                    continue;
+                }
+
+                $identity = $this->identityResolver->resolveByAnyCode($legacyCode);
+                if (! is_array($identity) || ! (bool) ($identity['is_known'] ?? false)) {
+                    $skippedUnknown++;
+                    continue;
+                }
+
+                $resolvedV2 = strtoupper(trim((string) ($identity['scale_code_v2'] ?? '')));
+                $resolvedUid = trim((string) ($identity['scale_uid'] ?? ''));
+                if ($resolvedV2 === '') {
+                    $skippedUnknown++;
+                    continue;
+                }
+
+                $currentV2 = strtoupper(trim((string) ($row->scale_code_v2 ?? '')));
+                $currentUid = trim((string) ($row->scale_uid ?? ''));
+                $needsV2 = ($currentV2 === '' || $currentV2 !== $resolvedV2);
+                $needsUid = ($resolvedUid !== '' && $currentUid !== $resolvedUid);
+                if (! $needsV2 && ! $needsUid) {
+                    continue;
+                }
+
+                if (! $dryRun) {
+                    $payload = [
+                        'scale_code_v2' => $resolvedV2,
+                        'updated_at' => now(),
+                    ];
+                    if ($resolvedUid !== '') {
+                        $payload['scale_uid'] = $resolvedUid;
+                    }
+
+                    DB::table('assessments')
+                        ->where('id', $assessmentId)
+                        ->update($payload);
+                }
+
+                $updated++;
+            }
+        } while (true);
+
+        $this->info(sprintf(
+            'backfill_assessments_scale_identity scanned=%d updated=%d skipped_unknown=%d dry_run=%d',
+            $scanned,
+            $updated,
+            $skippedUnknown,
+            $dryRun ? 1 : 0
+        ));
+
+        return self::SUCCESS;
+    }
+}
+

--- a/backend/app/Console/Commands/Ops/BackfillAttemptAnswerRowsScaleIdentity.php
+++ b/backend/app/Console/Commands/Ops/BackfillAttemptAnswerRowsScaleIdentity.php
@@ -1,0 +1,188 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Console\Commands\Ops;
+
+use App\Services\Scale\ScaleIdentityResolver;
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+class BackfillAttemptAnswerRowsScaleIdentity extends Command
+{
+    protected $signature = 'ops:backfill-attempt-answer-rows-scale-identity
+        {--chunk=1000 : Chunk size}
+        {--dry-run : Compute and report only; do not write updates}';
+
+    protected $description = 'Backfill attempt_answer_rows.scale_code_v2 and attempt_answer_rows.scale_uid from scale_code';
+
+    public function __construct(private readonly ScaleIdentityResolver $identityResolver)
+    {
+        parent::__construct();
+    }
+
+    public function handle(): int
+    {
+        if (! Schema::hasTable('attempt_answer_rows')) {
+            $this->warn('attempt_answer_rows table missing, skipping.');
+
+            return self::SUCCESS;
+        }
+
+        if (! Schema::hasColumn('attempt_answer_rows', 'scale_code_v2') || ! Schema::hasColumn('attempt_answer_rows', 'scale_uid')) {
+            $this->warn('attempt_answer_rows scale identity columns missing, skipping.');
+
+            return self::SUCCESS;
+        }
+
+        $chunk = max(100, (int) $this->option('chunk'));
+        $dryRun = (bool) $this->option('dry-run');
+
+        $scanned = 0;
+        $updated = 0;
+        $skippedUnknown = 0;
+
+        $lastAttemptId = '';
+        $lastQuestionId = '';
+        $lastSubmittedAt = '1970-01-01 00:00:00';
+
+        do {
+            $rows = DB::table('attempt_answer_rows')
+                ->select(['attempt_id', 'question_id', 'submitted_at', 'scale_code', 'scale_code_v2', 'scale_uid'])
+                ->where(function ($q): void {
+                    $q->whereNull('scale_code_v2')
+                        ->orWhere('scale_code_v2', '')
+                        ->orWhereNull('scale_uid')
+                        ->orWhere('scale_uid', '');
+                })
+                ->when($lastAttemptId !== '', function ($q) use ($lastAttemptId, $lastQuestionId, $lastSubmittedAt): void {
+                    $q->where(function ($cursor) use ($lastAttemptId, $lastQuestionId, $lastSubmittedAt): void {
+                        $cursor->where('attempt_id', '>', $lastAttemptId)
+                            ->orWhere(function ($second) use ($lastAttemptId, $lastQuestionId): void {
+                                $second->where('attempt_id', $lastAttemptId)
+                                    ->where('question_id', '>', $lastQuestionId);
+                            })
+                            ->orWhere(function ($third) use ($lastAttemptId, $lastQuestionId, $lastSubmittedAt): void {
+                                $third->where('attempt_id', $lastAttemptId)
+                                    ->where('question_id', $lastQuestionId)
+                                    ->whereRaw("coalesce(submitted_at, '1970-01-01 00:00:00') > ?", [$lastSubmittedAt]);
+                            });
+                    });
+                })
+                ->orderBy('attempt_id')
+                ->orderBy('question_id')
+                ->orderBy('submitted_at')
+                ->limit($chunk)
+                ->get();
+
+            if ($rows->isEmpty()) {
+                break;
+            }
+
+            foreach ($rows as $row) {
+                $attemptId = trim((string) ($row->attempt_id ?? ''));
+                $questionId = trim((string) ($row->question_id ?? ''));
+                if ($attemptId === '' || $questionId === '') {
+                    continue;
+                }
+
+                $submittedAtRaw = (string) ($row->submitted_at ?? '');
+                $submittedAt = trim($submittedAtRaw);
+                if ($submittedAt === '') {
+                    $submittedAt = '1970-01-01 00:00:00';
+                }
+
+                $lastAttemptId = $attemptId;
+                $lastQuestionId = $questionId;
+                $lastSubmittedAt = $submittedAt;
+
+                $scanned++;
+
+                $legacyCode = $this->resolveLegacyCode($row);
+                if ($legacyCode === '') {
+                    $skippedUnknown++;
+                    continue;
+                }
+
+                $identity = $this->identityResolver->resolveByAnyCode($legacyCode);
+                if (! is_array($identity) || ! (bool) ($identity['is_known'] ?? false)) {
+                    $skippedUnknown++;
+                    continue;
+                }
+
+                $resolvedV2 = strtoupper(trim((string) ($identity['scale_code_v2'] ?? '')));
+                $resolvedUid = trim((string) ($identity['scale_uid'] ?? ''));
+                if ($resolvedV2 === '') {
+                    $skippedUnknown++;
+                    continue;
+                }
+
+                $currentV2 = strtoupper(trim((string) ($row->scale_code_v2 ?? '')));
+                $currentUid = trim((string) ($row->scale_uid ?? ''));
+                $needsV2 = ($currentV2 === '' || $currentV2 !== $resolvedV2);
+                $needsUid = ($resolvedUid !== '' && $currentUid !== $resolvedUid);
+                if (! $needsV2 && ! $needsUid) {
+                    continue;
+                }
+
+                if (! $dryRun) {
+                    $payload = [
+                        'scale_code_v2' => $resolvedV2,
+                    ];
+                    if ($resolvedUid !== '') {
+                        $payload['scale_uid'] = $resolvedUid;
+                    }
+
+                    $updateQuery = DB::table('attempt_answer_rows')
+                        ->where('attempt_id', $attemptId)
+                        ->where('question_id', $questionId);
+
+                    if (trim((string) ($row->submitted_at ?? '')) === '') {
+                        $updateQuery->whereNull('submitted_at');
+                    } else {
+                        $updateQuery->where('submitted_at', $row->submitted_at);
+                    }
+
+                    $updateQuery->update($payload);
+                }
+
+                $updated++;
+            }
+        } while (true);
+
+        $this->info(sprintf(
+            'backfill_attempt_answer_rows_scale_identity scanned=%d updated=%d skipped_unknown=%d dry_run=%d',
+            $scanned,
+            $updated,
+            $skippedUnknown,
+            $dryRun ? 1 : 0
+        ));
+
+        return self::SUCCESS;
+    }
+
+    private function resolveLegacyCode(object $row): string
+    {
+        $legacy = strtoupper(trim((string) ($row->scale_code ?? '')));
+        if ($legacy !== '') {
+            return $legacy;
+        }
+
+        $attemptId = trim((string) ($row->attempt_id ?? ''));
+        if ($attemptId === '' || ! Schema::hasTable('attempts')) {
+            return '';
+        }
+
+        $attempt = DB::table('attempts')
+            ->select(['scale_code'])
+            ->where('id', $attemptId)
+            ->first();
+        if (! $attempt) {
+            return '';
+        }
+
+        return strtoupper(trim((string) ($attempt->scale_code ?? '')));
+    }
+}
+

--- a/backend/app/Console/Commands/Ops/BackfillAttemptAnswerSetsScaleIdentity.php
+++ b/backend/app/Console/Commands/Ops/BackfillAttemptAnswerSetsScaleIdentity.php
@@ -1,0 +1,151 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Console\Commands\Ops;
+
+use App\Services\Scale\ScaleIdentityResolver;
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+class BackfillAttemptAnswerSetsScaleIdentity extends Command
+{
+    protected $signature = 'ops:backfill-attempt-answer-sets-scale-identity
+        {--chunk=1000 : Chunk size}
+        {--dry-run : Compute and report only; do not write updates}';
+
+    protected $description = 'Backfill attempt_answer_sets.scale_code_v2 and attempt_answer_sets.scale_uid from scale_code';
+
+    public function __construct(private readonly ScaleIdentityResolver $identityResolver)
+    {
+        parent::__construct();
+    }
+
+    public function handle(): int
+    {
+        if (! Schema::hasTable('attempt_answer_sets')) {
+            $this->warn('attempt_answer_sets table missing, skipping.');
+
+            return self::SUCCESS;
+        }
+
+        if (! Schema::hasColumn('attempt_answer_sets', 'scale_code_v2') || ! Schema::hasColumn('attempt_answer_sets', 'scale_uid')) {
+            $this->warn('attempt_answer_sets scale identity columns missing, skipping.');
+
+            return self::SUCCESS;
+        }
+
+        $chunk = max(100, (int) $this->option('chunk'));
+        $dryRun = (bool) $this->option('dry-run');
+
+        $scanned = 0;
+        $updated = 0;
+        $skippedUnknown = 0;
+        $lastAttemptId = '';
+
+        do {
+            $rows = DB::table('attempt_answer_sets')
+                ->select(['attempt_id', 'scale_code', 'scale_code_v2', 'scale_uid'])
+                ->where(function ($q): void {
+                    $q->whereNull('scale_code_v2')
+                        ->orWhere('scale_code_v2', '')
+                        ->orWhereNull('scale_uid')
+                        ->orWhere('scale_uid', '');
+                })
+                ->when($lastAttemptId !== '', fn ($q) => $q->where('attempt_id', '>', $lastAttemptId))
+                ->orderBy('attempt_id')
+                ->limit($chunk)
+                ->get();
+
+            if ($rows->isEmpty()) {
+                break;
+            }
+
+            foreach ($rows as $row) {
+                $attemptId = trim((string) ($row->attempt_id ?? ''));
+                if ($attemptId === '') {
+                    continue;
+                }
+                $lastAttemptId = $attemptId;
+                $scanned++;
+
+                $legacyCode = $this->resolveLegacyCode($row);
+                if ($legacyCode === '') {
+                    $skippedUnknown++;
+                    continue;
+                }
+
+                $identity = $this->identityResolver->resolveByAnyCode($legacyCode);
+                if (! is_array($identity) || ! (bool) ($identity['is_known'] ?? false)) {
+                    $skippedUnknown++;
+                    continue;
+                }
+
+                $resolvedV2 = strtoupper(trim((string) ($identity['scale_code_v2'] ?? '')));
+                $resolvedUid = trim((string) ($identity['scale_uid'] ?? ''));
+                if ($resolvedV2 === '') {
+                    $skippedUnknown++;
+                    continue;
+                }
+
+                $currentV2 = strtoupper(trim((string) ($row->scale_code_v2 ?? '')));
+                $currentUid = trim((string) ($row->scale_uid ?? ''));
+                $needsV2 = ($currentV2 === '' || $currentV2 !== $resolvedV2);
+                $needsUid = ($resolvedUid !== '' && $currentUid !== $resolvedUid);
+                if (! $needsV2 && ! $needsUid) {
+                    continue;
+                }
+
+                if (! $dryRun) {
+                    $payload = [
+                        'scale_code_v2' => $resolvedV2,
+                    ];
+                    if ($resolvedUid !== '') {
+                        $payload['scale_uid'] = $resolvedUid;
+                    }
+
+                    DB::table('attempt_answer_sets')
+                        ->where('attempt_id', $attemptId)
+                        ->update($payload);
+                }
+
+                $updated++;
+            }
+        } while (true);
+
+        $this->info(sprintf(
+            'backfill_attempt_answer_sets_scale_identity scanned=%d updated=%d skipped_unknown=%d dry_run=%d',
+            $scanned,
+            $updated,
+            $skippedUnknown,
+            $dryRun ? 1 : 0
+        ));
+
+        return self::SUCCESS;
+    }
+
+    private function resolveLegacyCode(object $row): string
+    {
+        $legacy = strtoupper(trim((string) ($row->scale_code ?? '')));
+        if ($legacy !== '') {
+            return $legacy;
+        }
+
+        $attemptId = trim((string) ($row->attempt_id ?? ''));
+        if ($attemptId === '' || ! Schema::hasTable('attempts')) {
+            return '';
+        }
+
+        $attempt = DB::table('attempts')
+            ->select(['scale_code'])
+            ->where('id', $attemptId)
+            ->first();
+        if (! $attempt) {
+            return '';
+        }
+
+        return strtoupper(trim((string) ($attempt->scale_code ?? '')));
+    }
+}
+

--- a/backend/app/Console/Commands/Ops/BackfillAttemptsScaleIdentity.php
+++ b/backend/app/Console/Commands/Ops/BackfillAttemptsScaleIdentity.php
@@ -1,0 +1,130 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Console\Commands\Ops;
+
+use App\Services\Scale\ScaleIdentityResolver;
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+class BackfillAttemptsScaleIdentity extends Command
+{
+    protected $signature = 'ops:backfill-attempts-scale-identity
+        {--chunk=1000 : Chunk size}
+        {--dry-run : Compute and report only; do not write updates}';
+
+    protected $description = 'Backfill attempts.scale_code_v2 and attempts.scale_uid from attempts.scale_code';
+
+    public function __construct(private readonly ScaleIdentityResolver $identityResolver)
+    {
+        parent::__construct();
+    }
+
+    public function handle(): int
+    {
+        if (! Schema::hasTable('attempts')) {
+            $this->warn('attempts table missing, skipping.');
+
+            return self::SUCCESS;
+        }
+
+        if (! Schema::hasColumn('attempts', 'scale_code_v2') || ! Schema::hasColumn('attempts', 'scale_uid')) {
+            $this->warn('attempts scale identity columns missing, skipping.');
+
+            return self::SUCCESS;
+        }
+
+        $chunk = max(100, (int) $this->option('chunk'));
+        $dryRun = (bool) $this->option('dry-run');
+
+        $scanned = 0;
+        $updated = 0;
+        $skippedUnknown = 0;
+        $lastId = '';
+
+        do {
+            $rows = DB::table('attempts')
+                ->select(['id', 'scale_code', 'scale_code_v2', 'scale_uid'])
+                ->where(function ($q): void {
+                    $q->whereNull('scale_code_v2')
+                        ->orWhere('scale_code_v2', '')
+                        ->orWhereNull('scale_uid')
+                        ->orWhere('scale_uid', '');
+                })
+                ->when($lastId !== '', fn ($q) => $q->where('id', '>', $lastId))
+                ->orderBy('id')
+                ->limit($chunk)
+                ->get();
+
+            if ($rows->isEmpty()) {
+                break;
+            }
+
+            foreach ($rows as $row) {
+                $attemptId = trim((string) ($row->id ?? ''));
+                if ($attemptId === '') {
+                    continue;
+                }
+                $lastId = $attemptId;
+                $scanned++;
+
+                $legacyCode = strtoupper(trim((string) ($row->scale_code ?? '')));
+                if ($legacyCode === '') {
+                    $skippedUnknown++;
+                    continue;
+                }
+
+                $identity = $this->identityResolver->resolveByAnyCode($legacyCode);
+                if (! is_array($identity) || ! (bool) ($identity['is_known'] ?? false)) {
+                    $skippedUnknown++;
+                    continue;
+                }
+
+                $resolvedV2 = strtoupper(trim((string) ($identity['scale_code_v2'] ?? '')));
+                $resolvedUid = trim((string) ($identity['scale_uid'] ?? ''));
+                if ($resolvedV2 === '') {
+                    $skippedUnknown++;
+                    continue;
+                }
+
+                $currentV2 = strtoupper(trim((string) ($row->scale_code_v2 ?? '')));
+                $currentUid = trim((string) ($row->scale_uid ?? ''));
+
+                $needsV2 = ($currentV2 === '' || $currentV2 !== $resolvedV2);
+                $needsUid = ($resolvedUid !== '' && $currentUid !== $resolvedUid);
+                if (! $needsV2 && ! $needsUid) {
+                    continue;
+                }
+
+                if (! $dryRun) {
+                    $payload = [
+                        'scale_code_v2' => $resolvedV2,
+                        'updated_at' => now(),
+                    ];
+                    if ($resolvedUid !== '') {
+                        $payload['scale_uid'] = $resolvedUid;
+                    }
+
+                    DB::table('attempts')
+                        ->where('id', $attemptId)
+                        ->update($payload);
+                }
+
+                $updated++;
+            }
+        } while (true);
+
+        $this->info(sprintf(
+            'backfill_attempts_scale_identity scanned=%d updated=%d skipped_unknown=%d dry_run=%d',
+            $scanned,
+            $updated,
+            $skippedUnknown,
+            $dryRun ? 1 : 0
+        ));
+
+        return self::SUCCESS;
+    }
+}
+

--- a/backend/app/Console/Commands/Ops/BackfillEventsScaleIdentity.php
+++ b/backend/app/Console/Commands/Ops/BackfillEventsScaleIdentity.php
@@ -1,0 +1,130 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Console\Commands\Ops;
+
+use App\Services\Scale\ScaleIdentityResolver;
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+class BackfillEventsScaleIdentity extends Command
+{
+    protected $signature = 'ops:backfill-events-scale-identity
+        {--chunk=1000 : Chunk size}
+        {--dry-run : Compute and report only; do not write updates}';
+
+    protected $description = 'Backfill events.scale_code_v2 and events.scale_uid from events.scale_code';
+
+    public function __construct(private readonly ScaleIdentityResolver $identityResolver)
+    {
+        parent::__construct();
+    }
+
+    public function handle(): int
+    {
+        if (! Schema::hasTable('events')) {
+            $this->warn('events table missing, skipping.');
+
+            return self::SUCCESS;
+        }
+
+        if (! Schema::hasColumn('events', 'scale_code_v2') || ! Schema::hasColumn('events', 'scale_uid')) {
+            $this->warn('events scale identity columns missing, skipping.');
+
+            return self::SUCCESS;
+        }
+
+        $chunk = max(100, (int) $this->option('chunk'));
+        $dryRun = (bool) $this->option('dry-run');
+
+        $scanned = 0;
+        $updated = 0;
+        $skippedUnknown = 0;
+        $lastId = '';
+
+        do {
+            $rows = DB::table('events')
+                ->select(['id', 'scale_code', 'scale_code_v2', 'scale_uid'])
+                ->where(function ($q): void {
+                    $q->whereNull('scale_code_v2')
+                        ->orWhere('scale_code_v2', '')
+                        ->orWhereNull('scale_uid')
+                        ->orWhere('scale_uid', '');
+                })
+                ->when($lastId !== '', fn ($q) => $q->where('id', '>', $lastId))
+                ->orderBy('id')
+                ->limit($chunk)
+                ->get();
+
+            if ($rows->isEmpty()) {
+                break;
+            }
+
+            foreach ($rows as $row) {
+                $eventId = trim((string) ($row->id ?? ''));
+                if ($eventId === '') {
+                    continue;
+                }
+                $lastId = $eventId;
+                $scanned++;
+
+                $legacyCode = strtoupper(trim((string) ($row->scale_code ?? '')));
+                if ($legacyCode === '') {
+                    $skippedUnknown++;
+                    continue;
+                }
+
+                $identity = $this->identityResolver->resolveByAnyCode($legacyCode);
+                if (! is_array($identity) || ! (bool) ($identity['is_known'] ?? false)) {
+                    $skippedUnknown++;
+                    continue;
+                }
+
+                $resolvedV2 = strtoupper(trim((string) ($identity['scale_code_v2'] ?? '')));
+                $resolvedUid = trim((string) ($identity['scale_uid'] ?? ''));
+                if ($resolvedV2 === '') {
+                    $skippedUnknown++;
+                    continue;
+                }
+
+                $currentV2 = strtoupper(trim((string) ($row->scale_code_v2 ?? '')));
+                $currentUid = trim((string) ($row->scale_uid ?? ''));
+
+                $needsV2 = ($currentV2 === '' || $currentV2 !== $resolvedV2);
+                $needsUid = ($resolvedUid !== '' && $currentUid !== $resolvedUid);
+                if (! $needsV2 && ! $needsUid) {
+                    continue;
+                }
+
+                if (! $dryRun) {
+                    $payload = [
+                        'scale_code_v2' => $resolvedV2,
+                        'updated_at' => now(),
+                    ];
+                    if ($resolvedUid !== '') {
+                        $payload['scale_uid'] = $resolvedUid;
+                    }
+
+                    DB::table('events')
+                        ->where('id', $eventId)
+                        ->update($payload);
+                }
+
+                $updated++;
+            }
+        } while (true);
+
+        $this->info(sprintf(
+            'backfill_events_scale_identity scanned=%d updated=%d skipped_unknown=%d dry_run=%d',
+            $scanned,
+            $updated,
+            $skippedUnknown,
+            $dryRun ? 1 : 0
+        ));
+
+        return self::SUCCESS;
+    }
+}
+

--- a/backend/app/Console/Commands/Ops/BackfillOrdersScaleIdentity.php
+++ b/backend/app/Console/Commands/Ops/BackfillOrdersScaleIdentity.php
@@ -1,0 +1,200 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Console\Commands\Ops;
+
+use App\Services\Scale\ScaleIdentityResolver;
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+class BackfillOrdersScaleIdentity extends Command
+{
+    protected $signature = 'ops:backfill-orders-scale-identity
+        {--chunk=1000 : Chunk size}
+        {--dry-run : Compute and report only; do not write updates}';
+
+    protected $description = 'Backfill orders.scale_code_v2 and orders.scale_uid from related attempt scale metadata';
+
+    public function __construct(private readonly ScaleIdentityResolver $identityResolver)
+    {
+        parent::__construct();
+    }
+
+    public function handle(): int
+    {
+        if (! Schema::hasTable('orders')) {
+            $this->warn('orders table missing, skipping.');
+
+            return self::SUCCESS;
+        }
+
+        if (! Schema::hasColumn('orders', 'scale_code_v2') || ! Schema::hasColumn('orders', 'scale_uid')) {
+            $this->warn('orders scale identity columns missing, skipping.');
+
+            return self::SUCCESS;
+        }
+
+        $chunk = max(100, (int) $this->option('chunk'));
+        $dryRun = (bool) $this->option('dry-run');
+
+        $scanned = 0;
+        $updated = 0;
+        $skippedUnknown = 0;
+        $lastId = '';
+
+        do {
+            $rows = DB::table('orders')
+                ->select(['id', 'org_id', 'target_attempt_id', 'scale_code_v2', 'scale_uid'])
+                ->where(function ($q): void {
+                    $q->whereNull('scale_code_v2')
+                        ->orWhere('scale_code_v2', '')
+                        ->orWhereNull('scale_uid')
+                        ->orWhere('scale_uid', '');
+                })
+                ->when($lastId !== '', fn ($q) => $q->where('id', '>', $lastId))
+                ->orderBy('id')
+                ->limit($chunk)
+                ->get();
+
+            if ($rows->isEmpty()) {
+                break;
+            }
+
+            foreach ($rows as $row) {
+                $orderId = trim((string) ($row->id ?? ''));
+                if ($orderId === '') {
+                    continue;
+                }
+                $lastId = $orderId;
+                $scanned++;
+
+                $identity = $this->resolveFromOrderContext($row);
+                $resolvedV2 = strtoupper(trim((string) ($identity['scale_code_v2'] ?? '')));
+                $resolvedUid = trim((string) ($identity['scale_uid'] ?? ''));
+                if ($resolvedV2 === '') {
+                    $skippedUnknown++;
+                    continue;
+                }
+
+                $currentV2 = strtoupper(trim((string) ($row->scale_code_v2 ?? '')));
+                $currentUid = trim((string) ($row->scale_uid ?? ''));
+
+                $needsV2 = ($currentV2 === '' || $currentV2 !== $resolvedV2);
+                $needsUid = ($resolvedUid !== '' && $currentUid !== $resolvedUid);
+                if (! $needsV2 && ! $needsUid) {
+                    continue;
+                }
+
+                if (! $dryRun) {
+                    $payload = [
+                        'scale_code_v2' => $resolvedV2,
+                        'updated_at' => now(),
+                    ];
+                    if ($resolvedUid !== '') {
+                        $payload['scale_uid'] = $resolvedUid;
+                    }
+
+                    DB::table('orders')
+                        ->where('id', $orderId)
+                        ->update($payload);
+                }
+
+                $updated++;
+            }
+        } while (true);
+
+        $this->info(sprintf(
+            'backfill_orders_scale_identity scanned=%d updated=%d skipped_unknown=%d dry_run=%d',
+            $scanned,
+            $updated,
+            $skippedUnknown,
+            $dryRun ? 1 : 0
+        ));
+
+        return self::SUCCESS;
+    }
+
+    /**
+     * @return array{scale_code_v2:string|null,scale_uid:string|null}
+     */
+    private function resolveFromOrderContext(object $orderRow): array
+    {
+        $resolvedV2 = strtoupper(trim((string) ($orderRow->scale_code_v2 ?? '')));
+        $resolvedUid = trim((string) ($orderRow->scale_uid ?? ''));
+        if ($resolvedV2 !== '' && $resolvedUid === '') {
+            $identity = $this->identityResolver->resolveByAnyCode($resolvedV2);
+            if (is_array($identity) && (bool) ($identity['is_known'] ?? false)) {
+                $resolvedV2 = strtoupper(trim((string) ($identity['scale_code_v2'] ?? $resolvedV2)));
+                $resolvedUid = trim((string) ($identity['scale_uid'] ?? ''));
+            }
+        }
+
+        $targetAttemptId = trim((string) ($orderRow->target_attempt_id ?? ''));
+        if ($targetAttemptId === '') {
+            return [
+                'scale_code_v2' => $resolvedV2 !== '' ? $resolvedV2 : null,
+                'scale_uid' => $resolvedUid !== '' ? $resolvedUid : null,
+            ];
+        }
+
+        if (! Schema::hasTable('attempts')) {
+            return [
+                'scale_code_v2' => $resolvedV2 !== '' ? $resolvedV2 : null,
+                'scale_uid' => $resolvedUid !== '' ? $resolvedUid : null,
+            ];
+        }
+
+        $attempt = DB::table('attempts')
+            ->select(['scale_code', 'scale_code_v2', 'scale_uid'])
+            ->where('id', $targetAttemptId)
+            ->first();
+        if (! $attempt) {
+            return [
+                'scale_code_v2' => $resolvedV2 !== '' ? $resolvedV2 : null,
+                'scale_uid' => $resolvedUid !== '' ? $resolvedUid : null,
+            ];
+        }
+
+        $attemptScaleCodeV2 = strtoupper(trim((string) ($attempt->scale_code_v2 ?? '')));
+        $attemptScaleUid = trim((string) ($attempt->scale_uid ?? ''));
+        if ($attemptScaleCodeV2 !== '') {
+            $resolvedV2 = $attemptScaleCodeV2;
+        }
+        if ($attemptScaleUid !== '') {
+            $resolvedUid = $attemptScaleUid;
+        }
+
+        if ($resolvedV2 !== '' && $resolvedUid !== '') {
+            return [
+                'scale_code_v2' => $resolvedV2,
+                'scale_uid' => $resolvedUid,
+            ];
+        }
+
+        $legacyCode = strtoupper(trim((string) ($attempt->scale_code ?? '')));
+        if ($legacyCode === '') {
+            return [
+                'scale_code_v2' => $resolvedV2 !== '' ? $resolvedV2 : null,
+                'scale_uid' => $resolvedUid !== '' ? $resolvedUid : null,
+            ];
+        }
+
+        $identity = $this->identityResolver->resolveByAnyCode($legacyCode);
+        if (! is_array($identity) || ! (bool) ($identity['is_known'] ?? false)) {
+            return [
+                'scale_code_v2' => $resolvedV2 !== '' ? $resolvedV2 : null,
+                'scale_uid' => $resolvedUid !== '' ? $resolvedUid : null,
+            ];
+        }
+
+        $resolvedV2 = strtoupper(trim((string) ($identity['scale_code_v2'] ?? $resolvedV2)));
+        $resolvedUid = trim((string) ($identity['scale_uid'] ?? $resolvedUid));
+
+        return [
+            'scale_code_v2' => $resolvedV2 !== '' ? $resolvedV2 : null,
+            'scale_uid' => $resolvedUid !== '' ? $resolvedUid : null,
+        ];
+    }
+}

--- a/backend/app/Console/Commands/Ops/BackfillPaymentEventsScaleIdentity.php
+++ b/backend/app/Console/Commands/Ops/BackfillPaymentEventsScaleIdentity.php
@@ -1,0 +1,210 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Console\Commands\Ops;
+
+use App\Services\Scale\ScaleIdentityResolver;
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+class BackfillPaymentEventsScaleIdentity extends Command
+{
+    protected $signature = 'ops:backfill-payment-events-scale-identity
+        {--chunk=1000 : Chunk size}
+        {--dry-run : Compute and report only; do not write updates}';
+
+    protected $description = 'Backfill payment_events.scale_code_v2 and payment_events.scale_uid from related order/attempt scale metadata';
+
+    public function __construct(private readonly ScaleIdentityResolver $identityResolver)
+    {
+        parent::__construct();
+    }
+
+    public function handle(): int
+    {
+        if (! Schema::hasTable('payment_events')) {
+            $this->warn('payment_events table missing, skipping.');
+
+            return self::SUCCESS;
+        }
+
+        if (! Schema::hasColumn('payment_events', 'scale_code_v2') || ! Schema::hasColumn('payment_events', 'scale_uid')) {
+            $this->warn('payment_events scale identity columns missing, skipping.');
+
+            return self::SUCCESS;
+        }
+
+        $chunk = max(100, (int) $this->option('chunk'));
+        $dryRun = (bool) $this->option('dry-run');
+
+        $scanned = 0;
+        $updated = 0;
+        $skippedUnknown = 0;
+        $lastId = '';
+
+        do {
+            $rows = DB::table('payment_events')
+                ->select(['id', 'order_no', 'scale_code_v2', 'scale_uid'])
+                ->where(function ($q): void {
+                    $q->whereNull('scale_code_v2')
+                        ->orWhere('scale_code_v2', '')
+                        ->orWhereNull('scale_uid')
+                        ->orWhere('scale_uid', '');
+                })
+                ->when($lastId !== '', fn ($q) => $q->where('id', '>', $lastId))
+                ->orderBy('id')
+                ->limit($chunk)
+                ->get();
+
+            if ($rows->isEmpty()) {
+                break;
+            }
+
+            foreach ($rows as $row) {
+                $eventId = trim((string) ($row->id ?? ''));
+                if ($eventId === '') {
+                    continue;
+                }
+                $lastId = $eventId;
+                $scanned++;
+
+                $identity = $this->resolveFromPaymentEventContext($row);
+                $resolvedV2 = strtoupper(trim((string) ($identity['scale_code_v2'] ?? '')));
+                $resolvedUid = trim((string) ($identity['scale_uid'] ?? ''));
+                if ($resolvedV2 === '') {
+                    $skippedUnknown++;
+                    continue;
+                }
+
+                $currentV2 = strtoupper(trim((string) ($row->scale_code_v2 ?? '')));
+                $currentUid = trim((string) ($row->scale_uid ?? ''));
+
+                $needsV2 = ($currentV2 === '' || $currentV2 !== $resolvedV2);
+                $needsUid = ($resolvedUid !== '' && $currentUid !== $resolvedUid);
+                if (! $needsV2 && ! $needsUid) {
+                    continue;
+                }
+
+                if (! $dryRun) {
+                    $payload = [
+                        'scale_code_v2' => $resolvedV2,
+                        'updated_at' => now(),
+                    ];
+                    if ($resolvedUid !== '') {
+                        $payload['scale_uid'] = $resolvedUid;
+                    }
+
+                    DB::table('payment_events')
+                        ->where('id', $eventId)
+                        ->update($payload);
+                }
+
+                $updated++;
+            }
+        } while (true);
+
+        $this->info(sprintf(
+            'backfill_payment_events_scale_identity scanned=%d updated=%d skipped_unknown=%d dry_run=%d',
+            $scanned,
+            $updated,
+            $skippedUnknown,
+            $dryRun ? 1 : 0
+        ));
+
+        return self::SUCCESS;
+    }
+
+    /**
+     * @return array{scale_code_v2:string|null,scale_uid:string|null}
+     */
+    private function resolveFromPaymentEventContext(object $row): array
+    {
+        $resolvedV2 = strtoupper(trim((string) ($row->scale_code_v2 ?? '')));
+        $resolvedUid = trim((string) ($row->scale_uid ?? ''));
+
+        if ($resolvedV2 !== '' && $resolvedUid === '') {
+            $identity = $this->identityResolver->resolveByAnyCode($resolvedV2);
+            if (is_array($identity) && (bool) ($identity['is_known'] ?? false)) {
+                $resolvedV2 = strtoupper(trim((string) ($identity['scale_code_v2'] ?? $resolvedV2)));
+                $resolvedUid = trim((string) ($identity['scale_uid'] ?? ''));
+            }
+        }
+
+        $orderNo = trim((string) ($row->order_no ?? ''));
+        if ($orderNo === '' || ! Schema::hasTable('orders')) {
+            return [
+                'scale_code_v2' => $resolvedV2 !== '' ? $resolvedV2 : null,
+                'scale_uid' => $resolvedUid !== '' ? $resolvedUid : null,
+            ];
+        }
+
+        $order = DB::table('orders')
+            ->select(['target_attempt_id', 'scale_code_v2', 'scale_uid'])
+            ->where('order_no', $orderNo)
+            ->first();
+        if (! $order) {
+            return [
+                'scale_code_v2' => $resolvedV2 !== '' ? $resolvedV2 : null,
+                'scale_uid' => $resolvedUid !== '' ? $resolvedUid : null,
+            ];
+        }
+
+        $orderScaleCodeV2 = strtoupper(trim((string) ($order->scale_code_v2 ?? '')));
+        $orderScaleUid = trim((string) ($order->scale_uid ?? ''));
+        if ($orderScaleCodeV2 !== '') {
+            $resolvedV2 = $orderScaleCodeV2;
+        }
+        if ($orderScaleUid !== '') {
+            $resolvedUid = $orderScaleUid;
+        }
+
+        $targetAttemptId = trim((string) ($order->target_attempt_id ?? ''));
+        if ($targetAttemptId !== '' && Schema::hasTable('attempts')) {
+            $attempt = DB::table('attempts')
+                ->select(['scale_code', 'scale_code_v2', 'scale_uid'])
+                ->where('id', $targetAttemptId)
+                ->first();
+
+            if ($attempt) {
+                $attemptV2 = strtoupper(trim((string) ($attempt->scale_code_v2 ?? '')));
+                $attemptUid = trim((string) ($attempt->scale_uid ?? ''));
+                if ($attemptV2 !== '') {
+                    $resolvedV2 = $attemptV2;
+                }
+                if ($attemptUid !== '') {
+                    $resolvedUid = $attemptUid;
+                }
+
+                if ($resolvedV2 === '' || $resolvedUid === '') {
+                    $legacy = strtoupper(trim((string) ($attempt->scale_code ?? '')));
+                    if ($legacy !== '') {
+                        $identity = $this->identityResolver->resolveByAnyCode($legacy);
+                        if (is_array($identity) && (bool) ($identity['is_known'] ?? false)) {
+                            if ($resolvedV2 === '') {
+                                $resolvedV2 = strtoupper(trim((string) ($identity['scale_code_v2'] ?? '')));
+                            }
+                            if ($resolvedUid === '') {
+                                $resolvedUid = trim((string) ($identity['scale_uid'] ?? ''));
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        if ($resolvedV2 !== '' && $resolvedUid === '') {
+            $identity = $this->identityResolver->resolveByAnyCode($resolvedV2);
+            if (is_array($identity) && (bool) ($identity['is_known'] ?? false)) {
+                $resolvedUid = trim((string) ($identity['scale_uid'] ?? ''));
+            }
+        }
+
+        return [
+            'scale_code_v2' => $resolvedV2 !== '' ? $resolvedV2 : null,
+            'scale_uid' => $resolvedUid !== '' ? $resolvedUid : null,
+        ];
+    }
+}
+

--- a/backend/app/Console/Commands/Ops/BackfillReportSnapshotsScaleIdentity.php
+++ b/backend/app/Console/Commands/Ops/BackfillReportSnapshotsScaleIdentity.php
@@ -1,0 +1,132 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Console\Commands\Ops;
+
+use App\Services\Scale\ScaleIdentityResolver;
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+class BackfillReportSnapshotsScaleIdentity extends Command
+{
+    protected $signature = 'ops:backfill-report-snapshots-scale-identity
+        {--chunk=1000 : Chunk size}
+        {--dry-run : Compute and report only; do not write updates}';
+
+    protected $description = 'Backfill report_snapshots.scale_code_v2 and report_snapshots.scale_uid from report_snapshots.scale_code';
+
+    public function __construct(private readonly ScaleIdentityResolver $identityResolver)
+    {
+        parent::__construct();
+    }
+
+    public function handle(): int
+    {
+        if (! Schema::hasTable('report_snapshots')) {
+            $this->warn('report_snapshots table missing, skipping.');
+
+            return self::SUCCESS;
+        }
+
+        if (! Schema::hasColumn('report_snapshots', 'scale_code_v2') || ! Schema::hasColumn('report_snapshots', 'scale_uid')) {
+            $this->warn('report_snapshots scale identity columns missing, skipping.');
+
+            return self::SUCCESS;
+        }
+
+        $chunk = max(100, (int) $this->option('chunk'));
+        $dryRun = (bool) $this->option('dry-run');
+
+        $scanned = 0;
+        $updated = 0;
+        $skippedUnknown = 0;
+        $lastAttemptId = '';
+
+        do {
+            $rows = DB::table('report_snapshots')
+                ->select(['attempt_id', 'scale_code', 'scale_code_v2', 'scale_uid'])
+                ->where(function ($q): void {
+                    $q->whereNull('scale_code_v2')
+                        ->orWhere('scale_code_v2', '')
+                        ->orWhereNull('scale_uid')
+                        ->orWhere('scale_uid', '');
+                })
+                ->when($lastAttemptId !== '', fn ($q) => $q->where('attempt_id', '>', $lastAttemptId))
+                ->orderBy('attempt_id')
+                ->limit($chunk)
+                ->get();
+
+            if ($rows->isEmpty()) {
+                break;
+            }
+
+            foreach ($rows as $row) {
+                $attemptId = trim((string) ($row->attempt_id ?? ''));
+                if ($attemptId === '') {
+                    continue;
+                }
+                $lastAttemptId = $attemptId;
+                $scanned++;
+
+                $legacyCode = strtoupper(trim((string) ($row->scale_code ?? '')));
+                if ($legacyCode === '') {
+                    $skippedUnknown++;
+                    continue;
+                }
+
+                $identity = $this->identityResolver->resolveByAnyCode($legacyCode);
+                if (! is_array($identity) || ! (bool) ($identity['is_known'] ?? false)) {
+                    $skippedUnknown++;
+                    continue;
+                }
+
+                $resolvedV2 = strtoupper(trim((string) ($identity['scale_code_v2'] ?? '')));
+                $resolvedUid = trim((string) ($identity['scale_uid'] ?? ''));
+                if ($resolvedV2 === '') {
+                    $skippedUnknown++;
+                    continue;
+                }
+
+                $currentV2 = strtoupper(trim((string) ($row->scale_code_v2 ?? '')));
+                $currentUid = trim((string) ($row->scale_uid ?? ''));
+
+                $needsV2 = ($currentV2 === '' || $currentV2 !== $resolvedV2);
+                $needsUid = ($resolvedUid !== '' && $currentUid !== $resolvedUid);
+                if (! $needsV2 && ! $needsUid) {
+                    continue;
+                }
+
+                if (! $dryRun) {
+                    $payload = [
+                        'scale_code_v2' => $resolvedV2,
+                    ];
+                    if (Schema::hasColumn('report_snapshots', 'updated_at')) {
+                        $payload['updated_at'] = now();
+                    }
+                    if ($resolvedUid !== '') {
+                        $payload['scale_uid'] = $resolvedUid;
+                    }
+
+                    DB::table('report_snapshots')
+                        ->where('attempt_id', $attemptId)
+                        ->update($payload);
+                }
+
+                $updated++;
+            }
+        } while (true);
+
+        $this->info(sprintf(
+            'backfill_report_snapshots_scale_identity scanned=%d updated=%d skipped_unknown=%d dry_run=%d',
+            $scanned,
+            $updated,
+            $skippedUnknown,
+            $dryRun ? 1 : 0
+        ));
+
+        return self::SUCCESS;
+    }
+}
+

--- a/backend/app/Console/Commands/Ops/BackfillResultsScaleIdentity.php
+++ b/backend/app/Console/Commands/Ops/BackfillResultsScaleIdentity.php
@@ -1,0 +1,130 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Console\Commands\Ops;
+
+use App\Services\Scale\ScaleIdentityResolver;
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+class BackfillResultsScaleIdentity extends Command
+{
+    protected $signature = 'ops:backfill-results-scale-identity
+        {--chunk=1000 : Chunk size}
+        {--dry-run : Compute and report only; do not write updates}';
+
+    protected $description = 'Backfill results.scale_code_v2 and results.scale_uid from results.scale_code';
+
+    public function __construct(private readonly ScaleIdentityResolver $identityResolver)
+    {
+        parent::__construct();
+    }
+
+    public function handle(): int
+    {
+        if (! Schema::hasTable('results')) {
+            $this->warn('results table missing, skipping.');
+
+            return self::SUCCESS;
+        }
+
+        if (! Schema::hasColumn('results', 'scale_code_v2') || ! Schema::hasColumn('results', 'scale_uid')) {
+            $this->warn('results scale identity columns missing, skipping.');
+
+            return self::SUCCESS;
+        }
+
+        $chunk = max(100, (int) $this->option('chunk'));
+        $dryRun = (bool) $this->option('dry-run');
+
+        $scanned = 0;
+        $updated = 0;
+        $skippedUnknown = 0;
+        $lastId = '';
+
+        do {
+            $rows = DB::table('results')
+                ->select(['id', 'scale_code', 'scale_code_v2', 'scale_uid'])
+                ->where(function ($q): void {
+                    $q->whereNull('scale_code_v2')
+                        ->orWhere('scale_code_v2', '')
+                        ->orWhereNull('scale_uid')
+                        ->orWhere('scale_uid', '');
+                })
+                ->when($lastId !== '', fn ($q) => $q->where('id', '>', $lastId))
+                ->orderBy('id')
+                ->limit($chunk)
+                ->get();
+
+            if ($rows->isEmpty()) {
+                break;
+            }
+
+            foreach ($rows as $row) {
+                $resultId = trim((string) ($row->id ?? ''));
+                if ($resultId === '') {
+                    continue;
+                }
+                $lastId = $resultId;
+                $scanned++;
+
+                $legacyCode = strtoupper(trim((string) ($row->scale_code ?? '')));
+                if ($legacyCode === '') {
+                    $skippedUnknown++;
+                    continue;
+                }
+
+                $identity = $this->identityResolver->resolveByAnyCode($legacyCode);
+                if (! is_array($identity) || ! (bool) ($identity['is_known'] ?? false)) {
+                    $skippedUnknown++;
+                    continue;
+                }
+
+                $resolvedV2 = strtoupper(trim((string) ($identity['scale_code_v2'] ?? '')));
+                $resolvedUid = trim((string) ($identity['scale_uid'] ?? ''));
+                if ($resolvedV2 === '') {
+                    $skippedUnknown++;
+                    continue;
+                }
+
+                $currentV2 = strtoupper(trim((string) ($row->scale_code_v2 ?? '')));
+                $currentUid = trim((string) ($row->scale_uid ?? ''));
+
+                $needsV2 = ($currentV2 === '' || $currentV2 !== $resolvedV2);
+                $needsUid = ($resolvedUid !== '' && $currentUid !== $resolvedUid);
+                if (! $needsV2 && ! $needsUid) {
+                    continue;
+                }
+
+                if (! $dryRun) {
+                    $payload = [
+                        'scale_code_v2' => $resolvedV2,
+                        'updated_at' => now(),
+                    ];
+                    if ($resolvedUid !== '') {
+                        $payload['scale_uid'] = $resolvedUid;
+                    }
+
+                    DB::table('results')
+                        ->where('id', $resultId)
+                        ->update($payload);
+                }
+
+                $updated++;
+            }
+        } while (true);
+
+        $this->info(sprintf(
+            'backfill_results_scale_identity scanned=%d updated=%d skipped_unknown=%d dry_run=%d',
+            $scanned,
+            $updated,
+            $skippedUnknown,
+            $dryRun ? 1 : 0
+        ));
+
+        return self::SUCCESS;
+    }
+}
+

--- a/backend/app/Console/Commands/Ops/BackfillSharesScaleIdentity.php
+++ b/backend/app/Console/Commands/Ops/BackfillSharesScaleIdentity.php
@@ -1,0 +1,130 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Console\Commands\Ops;
+
+use App\Services\Scale\ScaleIdentityResolver;
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+class BackfillSharesScaleIdentity extends Command
+{
+    protected $signature = 'ops:backfill-shares-scale-identity
+        {--chunk=1000 : Chunk size}
+        {--dry-run : Compute and report only; do not write updates}';
+
+    protected $description = 'Backfill shares.scale_code_v2 and shares.scale_uid from shares.scale_code';
+
+    public function __construct(private readonly ScaleIdentityResolver $identityResolver)
+    {
+        parent::__construct();
+    }
+
+    public function handle(): int
+    {
+        if (! Schema::hasTable('shares')) {
+            $this->warn('shares table missing, skipping.');
+
+            return self::SUCCESS;
+        }
+
+        if (! Schema::hasColumn('shares', 'scale_code_v2') || ! Schema::hasColumn('shares', 'scale_uid')) {
+            $this->warn('shares scale identity columns missing, skipping.');
+
+            return self::SUCCESS;
+        }
+
+        $chunk = max(100, (int) $this->option('chunk'));
+        $dryRun = (bool) $this->option('dry-run');
+
+        $scanned = 0;
+        $updated = 0;
+        $skippedUnknown = 0;
+        $lastId = '';
+
+        do {
+            $rows = DB::table('shares')
+                ->select(['id', 'scale_code', 'scale_code_v2', 'scale_uid'])
+                ->where(function ($q): void {
+                    $q->whereNull('scale_code_v2')
+                        ->orWhere('scale_code_v2', '')
+                        ->orWhereNull('scale_uid')
+                        ->orWhere('scale_uid', '');
+                })
+                ->when($lastId !== '', fn ($q) => $q->where('id', '>', $lastId))
+                ->orderBy('id')
+                ->limit($chunk)
+                ->get();
+
+            if ($rows->isEmpty()) {
+                break;
+            }
+
+            foreach ($rows as $row) {
+                $shareId = trim((string) ($row->id ?? ''));
+                if ($shareId === '') {
+                    continue;
+                }
+                $lastId = $shareId;
+                $scanned++;
+
+                $legacyCode = strtoupper(trim((string) ($row->scale_code ?? '')));
+                if ($legacyCode === '') {
+                    $skippedUnknown++;
+                    continue;
+                }
+
+                $identity = $this->identityResolver->resolveByAnyCode($legacyCode);
+                if (! is_array($identity) || ! (bool) ($identity['is_known'] ?? false)) {
+                    $skippedUnknown++;
+                    continue;
+                }
+
+                $resolvedV2 = strtoupper(trim((string) ($identity['scale_code_v2'] ?? '')));
+                $resolvedUid = trim((string) ($identity['scale_uid'] ?? ''));
+                if ($resolvedV2 === '') {
+                    $skippedUnknown++;
+                    continue;
+                }
+
+                $currentV2 = strtoupper(trim((string) ($row->scale_code_v2 ?? '')));
+                $currentUid = trim((string) ($row->scale_uid ?? ''));
+
+                $needsV2 = ($currentV2 === '' || $currentV2 !== $resolvedV2);
+                $needsUid = ($resolvedUid !== '' && $currentUid !== $resolvedUid);
+                if (! $needsV2 && ! $needsUid) {
+                    continue;
+                }
+
+                if (! $dryRun) {
+                    $payload = [
+                        'scale_code_v2' => $resolvedV2,
+                        'updated_at' => now(),
+                    ];
+                    if ($resolvedUid !== '') {
+                        $payload['scale_uid'] = $resolvedUid;
+                    }
+
+                    DB::table('shares')
+                        ->where('id', $shareId)
+                        ->update($payload);
+                }
+
+                $updated++;
+            }
+        } while (true);
+
+        $this->info(sprintf(
+            'backfill_shares_scale_identity scanned=%d updated=%d skipped_unknown=%d dry_run=%d',
+            $scanned,
+            $updated,
+            $skippedUnknown,
+            $dryRun ? 1 : 0
+        ));
+
+        return self::SUCCESS;
+    }
+}
+

--- a/backend/app/Console/Commands/Ops/ContentPathMirror.php
+++ b/backend/app/Console/Commands/Ops/ContentPathMirror.php
@@ -1,0 +1,350 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Console\Commands\Ops;
+
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\File;
+use Illuminate\Support\Facades\Schema;
+use RecursiveDirectoryIterator;
+use RecursiveIteratorIterator;
+
+class ContentPathMirror extends Command
+{
+    protected $signature = 'ops:content-path-mirror
+        {--scope=* : Alias scopes to process (backend_content_packs|content_packages)}
+        {--old-path=* : Restrict to specific old_path values}
+        {--dry-run : Compute and report only; do not write files}
+        {--sync : Mirror source tree to mapped path}
+        {--verify-hash : Compare source and target file hashes recursively}';
+
+    protected $description = 'Mirror content path aliases into mapped directories and verify hash consistency';
+
+    public function handle(): int
+    {
+        if (! Schema::hasTable('content_path_aliases')) {
+            $this->warn('content_path_aliases table missing, skipping.');
+
+            return self::SUCCESS;
+        }
+
+        $dryRun = (bool) $this->option('dry-run');
+        $doSync = (bool) $this->option('sync');
+        $verifyHash = (bool) $this->option('verify-hash');
+        if (! $doSync && ! $verifyHash) {
+            $dryRun = true;
+        }
+
+        $scopeFilter = $this->normalizedOptionList('scope');
+        $oldPathFilter = $this->normalizedOptionList('old-path');
+
+        $query = DB::table('content_path_aliases')
+            ->select(['scope', 'old_path', 'new_path', 'is_active'])
+            ->where('is_active', true)
+            ->orderBy('scope')
+            ->orderBy('old_path');
+
+        if ($scopeFilter !== []) {
+            $query->whereIn('scope', $scopeFilter);
+        }
+        if ($oldPathFilter !== []) {
+            $query->whereIn('old_path', $oldPathFilter);
+        }
+
+        $rows = $query->get();
+        if ($rows->isEmpty()) {
+            $this->warn('content_path_aliases empty for selected scope/filter.');
+            $this->emitSummary(
+                scannedAliases: 0,
+                sourceMissingAliases: 0,
+                syncCopiedFiles: 0,
+                syncUpdatedFiles: 0,
+                verifyComparedFiles: 0,
+                verifyMatchedFiles: 0,
+                verifyMismatchFiles: 0,
+                verifyTargetMissingFiles: 0,
+                dryRun: $dryRun,
+                sync: $doSync,
+                verifyHash: $verifyHash
+            );
+
+            return self::SUCCESS;
+        }
+
+        $scannedAliases = 0;
+        $sourceMissingAliases = 0;
+        $syncCopiedFiles = 0;
+        $syncUpdatedFiles = 0;
+        $verifyComparedFiles = 0;
+        $verifyMatchedFiles = 0;
+        $verifyMismatchFiles = 0;
+        $verifyTargetMissingFiles = 0;
+
+        foreach ($rows as $row) {
+            $scope = strtolower(trim((string) ($row->scope ?? '')));
+            $oldPath = trim((string) ($row->old_path ?? ''));
+            $newPath = trim((string) ($row->new_path ?? ''));
+            if ($scope === '' || $oldPath === '' || $newPath === '') {
+                continue;
+            }
+
+            $source = $this->resolveAbsolutePath($scope, $oldPath);
+            $target = $this->resolveAbsolutePath($scope, $newPath);
+            $scannedAliases++;
+
+            if (! is_dir($source)) {
+                $sourceMissingAliases++;
+                $this->line(sprintf('[skip] source missing scope=%s old_path=%s source=%s', $scope, $oldPath, $source));
+                continue;
+            }
+
+            $this->line(sprintf(
+                '[alias] scope=%s old_path=%s new_path=%s source=%s target=%s',
+                $scope,
+                $oldPath,
+                $newPath,
+                $source,
+                $target
+            ));
+
+            if ($doSync) {
+                $syncStats = $this->syncDirectory($source, $target, $dryRun);
+                $syncCopiedFiles += (int) ($syncStats['copied'] ?? 0);
+                $syncUpdatedFiles += (int) ($syncStats['updated'] ?? 0);
+            }
+
+            if ($verifyHash) {
+                $verifyStats = $this->verifyDirectoryHashes($source, $target);
+                $verifyComparedFiles += (int) ($verifyStats['compared'] ?? 0);
+                $verifyMatchedFiles += (int) ($verifyStats['matched'] ?? 0);
+                $verifyMismatchFiles += (int) ($verifyStats['mismatch'] ?? 0);
+                $verifyTargetMissingFiles += (int) ($verifyStats['target_missing'] ?? 0);
+            }
+        }
+
+        $this->emitSummary(
+            scannedAliases: $scannedAliases,
+            sourceMissingAliases: $sourceMissingAliases,
+            syncCopiedFiles: $syncCopiedFiles,
+            syncUpdatedFiles: $syncUpdatedFiles,
+            verifyComparedFiles: $verifyComparedFiles,
+            verifyMatchedFiles: $verifyMatchedFiles,
+            verifyMismatchFiles: $verifyMismatchFiles,
+            verifyTargetMissingFiles: $verifyTargetMissingFiles,
+            dryRun: $dryRun,
+            sync: $doSync,
+            verifyHash: $verifyHash
+        );
+
+        return self::SUCCESS;
+    }
+
+    /**
+     * @return array{copied:int,updated:int}
+     */
+    private function syncDirectory(string $source, string $target, bool $dryRun): array
+    {
+        if (! is_dir($source)) {
+            return ['copied' => 0, 'updated' => 0];
+        }
+
+        if (! $dryRun) {
+            File::ensureDirectoryExists($target);
+        }
+
+        $copied = 0;
+        $updated = 0;
+
+        $it = new RecursiveIteratorIterator(
+            new RecursiveDirectoryIterator($source, RecursiveDirectoryIterator::SKIP_DOTS),
+            RecursiveIteratorIterator::SELF_FIRST
+        );
+        foreach ($it as $item) {
+            if (! $item->isFile()) {
+                continue;
+            }
+
+            $sourceFile = $item->getPathname();
+            $relative = ltrim(substr($sourceFile, strlen(rtrim($source, DIRECTORY_SEPARATOR))), DIRECTORY_SEPARATOR);
+            if ($relative === '') {
+                continue;
+            }
+
+            $targetFile = rtrim($target, DIRECTORY_SEPARATOR).DIRECTORY_SEPARATOR.$relative;
+            $targetExists = is_file($targetFile);
+            $sameHash = $targetExists && hash_file('sha256', $sourceFile) === hash_file('sha256', $targetFile);
+            if ($sameHash) {
+                continue;
+            }
+
+            if (! $dryRun) {
+                File::ensureDirectoryExists(dirname($targetFile));
+                File::copy($sourceFile, $targetFile);
+            }
+
+            if ($targetExists) {
+                $updated++;
+            } else {
+                $copied++;
+            }
+        }
+
+        $this->line(sprintf('[sync] copied=%d updated=%d dry_run=%d', $copied, $updated, $dryRun ? 1 : 0));
+
+        return [
+            'copied' => $copied,
+            'updated' => $updated,
+        ];
+    }
+
+    /**
+     * @return array{compared:int,matched:int,mismatch:int,target_missing:int}
+     */
+    private function verifyDirectoryHashes(string $source, string $target): array
+    {
+        if (! is_dir($source)) {
+            return ['compared' => 0, 'matched' => 0, 'mismatch' => 0, 'target_missing' => 0];
+        }
+
+        $compared = 0;
+        $matched = 0;
+        $mismatch = 0;
+        $targetMissing = 0;
+
+        $it = new RecursiveIteratorIterator(
+            new RecursiveDirectoryIterator($source, RecursiveDirectoryIterator::SKIP_DOTS),
+            RecursiveIteratorIterator::SELF_FIRST
+        );
+        foreach ($it as $item) {
+            if (! $item->isFile()) {
+                continue;
+            }
+
+            $sourceFile = $item->getPathname();
+            $relative = ltrim(substr($sourceFile, strlen(rtrim($source, DIRECTORY_SEPARATOR))), DIRECTORY_SEPARATOR);
+            if ($relative === '') {
+                continue;
+            }
+
+            $targetFile = rtrim($target, DIRECTORY_SEPARATOR).DIRECTORY_SEPARATOR.$relative;
+            $compared++;
+
+            if (! is_file($targetFile)) {
+                $mismatch++;
+                $targetMissing++;
+                continue;
+            }
+
+            $sameHash = hash_file('sha256', $sourceFile) === hash_file('sha256', $targetFile);
+            if ($sameHash) {
+                $matched++;
+            } else {
+                $mismatch++;
+            }
+        }
+
+        $this->line(sprintf(
+            '[verify] compared=%d matched=%d mismatch=%d target_missing=%d',
+            $compared,
+            $matched,
+            $mismatch,
+            $targetMissing
+        ));
+
+        return [
+            'compared' => $compared,
+            'matched' => $matched,
+            'mismatch' => $mismatch,
+            'target_missing' => $targetMissing,
+        ];
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function normalizedOptionList(string $name): array
+    {
+        $values = $this->option($name);
+        if (! is_array($values)) {
+            return [];
+        }
+
+        $out = [];
+        foreach ($values as $value) {
+            $item = trim((string) $value);
+            if ($item === '') {
+                continue;
+            }
+            $out[] = $item;
+        }
+
+        return array_values(array_unique($out));
+    }
+
+    private function resolveAbsolutePath(string $scope, string $path): string
+    {
+        $normalized = trim(str_replace('\\', '/', $path), '/');
+        if ($normalized === '') {
+            return base_path();
+        }
+
+        if ($scope === 'backend_content_packs') {
+            if (! str_starts_with($normalized, 'content_packs/')) {
+                $normalized = 'content_packs/'.$normalized;
+            }
+
+            return base_path(str_replace('/', DIRECTORY_SEPARATOR, $normalized));
+        }
+
+        if ($scope === 'content_packages') {
+            $root = rtrim((string) config('content_packs.root', base_path('../content_packages')), '/\\');
+            if ($root === '') {
+                $root = base_path('../content_packages');
+            }
+
+            if (! str_starts_with($root, '/') && ! preg_match('/^[A-Za-z]:\\\\/', $root)) {
+                $root = base_path($root);
+            }
+
+            if (str_starts_with($normalized, 'content_packages/')) {
+                $normalized = substr($normalized, strlen('content_packages/'));
+            }
+
+            return rtrim($root, DIRECTORY_SEPARATOR).DIRECTORY_SEPARATOR.str_replace('/', DIRECTORY_SEPARATOR, $normalized);
+        }
+
+        return base_path(str_replace('/', DIRECTORY_SEPARATOR, $normalized));
+    }
+
+    private function emitSummary(
+        int $scannedAliases,
+        int $sourceMissingAliases,
+        int $syncCopiedFiles,
+        int $syncUpdatedFiles,
+        int $verifyComparedFiles,
+        int $verifyMatchedFiles,
+        int $verifyMismatchFiles,
+        int $verifyTargetMissingFiles,
+        bool $dryRun,
+        bool $sync,
+        bool $verifyHash
+    ): void {
+        $this->info(sprintf(
+            'content_path_mirror scanned_aliases=%d source_missing_aliases=%d sync_copied_files=%d sync_updated_files=%d verify_compared_files=%d verify_matched_files=%d verify_mismatch_files=%d verify_target_missing_files=%d dry_run=%d sync=%d verify_hash=%d',
+            $scannedAliases,
+            $sourceMissingAliases,
+            $syncCopiedFiles,
+            $syncUpdatedFiles,
+            $verifyComparedFiles,
+            $verifyMatchedFiles,
+            $verifyMismatchFiles,
+            $verifyTargetMissingFiles,
+            $dryRun ? 1 : 0,
+            $sync ? 1 : 0,
+            $verifyHash ? 1 : 0
+        ));
+    }
+}
+

--- a/backend/app/Console/Commands/Ops/ScaleIdentityGate.php
+++ b/backend/app/Console/Commands/Ops/ScaleIdentityGate.php
@@ -1,0 +1,452 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Console\Commands\Ops;
+
+use App\Services\Scale\ScaleIdentityResolver;
+use Illuminate\Console\Command;
+use Illuminate\Support\Collection;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+final class ScaleIdentityGate extends Command
+{
+    protected $signature = 'ops:scale-identity-gate
+        {--hours=336 : Lookback window in hours}
+        {--max-rows=5000 : Max rows scanned per table for dual-write mismatch checks}
+        {--json=1 : Output JSON payload}
+        {--strict=0 : Exit non-zero when any metric exceeds threshold}';
+
+    protected $description = 'Compute scale identity rollout gate metrics for Phase 8~10 decisioning.';
+
+    public function __construct(private readonly ScaleIdentityResolver $identityResolver)
+    {
+        parent::__construct();
+    }
+
+    public function handle(): int
+    {
+        $hours = max(1, (int) $this->option('hours'));
+        $maxRows = max(100, (int) $this->option('max-rows'));
+        $windowEnd = now();
+        $windowStart = $windowEnd->copy()->subHours($hours);
+
+        $metrics = [
+            'identity_resolve_mismatch_rate' => $this->computeIdentityResolveMismatchRate(),
+            'dual_write_mismatch_rate' => $this->computeDualWriteMismatchRate($windowStart, $windowEnd, $maxRows),
+            'content_path_fallback_rate' => $this->computeContentPathFallbackRate(),
+            'legacy_code_hit_rate' => $this->computeLegacyCodeHitRate($windowStart, $windowEnd),
+            'demo_scale_hit_rate' => $this->computeDemoScaleHitRate($windowStart, $windowEnd),
+        ];
+
+        $thresholds = [
+            'identity_resolve_mismatch_rate' => $this->floatEnv('FAP_GATE_IDENTITY_RESOLVE_MISMATCH_RATE_MAX', 0.0),
+            'dual_write_mismatch_rate' => $this->floatEnv('FAP_GATE_DUAL_WRITE_MISMATCH_RATE_MAX', 0.0),
+            'content_path_fallback_rate' => $this->floatEnv('FAP_GATE_CONTENT_PATH_FALLBACK_RATE_MAX', 1.0),
+            'legacy_code_hit_rate' => $this->floatEnv('FAP_GATE_LEGACY_CODE_HIT_RATE_MAX', 1.0),
+            'demo_scale_hit_rate' => $this->floatEnv('FAP_GATE_DEMO_SCALE_HIT_RATE_MAX', 0.001),
+        ];
+
+        $strict = $this->isTruthy($this->option('strict'));
+        $violations = [];
+        foreach ($thresholds as $name => $max) {
+            $rate = (float) ($metrics[$name]['rate'] ?? 0.0);
+            if ($rate > $max) {
+                $violations[] = [
+                    'metric' => $name,
+                    'rate' => $rate,
+                    'max' => $max,
+                ];
+            }
+        }
+
+        $payload = [
+            'ok' => true,
+            'window_hours' => $hours,
+            'window_start' => $windowStart->toISOString(),
+            'window_end' => $windowEnd->toISOString(),
+            'max_rows_per_table' => $maxRows,
+            'metrics' => $metrics,
+            'thresholds' => $thresholds,
+            'strict' => $strict,
+            'pass' => count($violations) === 0,
+            'violations' => $violations,
+        ];
+
+        if ($this->isTruthy($this->option('json'))) {
+            $this->line((string) json_encode($payload, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES));
+        } else {
+            $this->line('scale identity gate');
+            foreach ($metrics as $name => $metric) {
+                $this->line(sprintf(
+                    '%s numerator=%d denominator=%d rate=%.4f max=%.4f',
+                    $name,
+                    (int) ($metric['numerator'] ?? 0),
+                    (int) ($metric['denominator'] ?? 0),
+                    (float) ($metric['rate'] ?? 0.0),
+                    (float) ($thresholds[$name] ?? 0.0)
+                ));
+            }
+            if ($violations !== []) {
+                $this->warn('violations=' . json_encode($violations, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES));
+            }
+        }
+
+        if ($strict && $violations !== []) {
+            return self::FAILURE;
+        }
+
+        return self::SUCCESS;
+    }
+
+    /**
+     * @return array{numerator:int,denominator:int,rate:float}
+     */
+    private function computeIdentityResolveMismatchRate(): array
+    {
+        if (! Schema::hasTable('scale_identities')) {
+            return $this->ratio(0, 0);
+        }
+
+        try {
+            $checks = [];
+            $identities = DB::table('scale_identities')
+                ->select(['scale_uid', 'scale_code_v1', 'scale_code_v2'])
+                ->where('status', 'active')
+                ->get();
+
+            foreach ($identities as $row) {
+                $scaleUid = trim((string) ($row->scale_uid ?? ''));
+                $codeV1 = strtoupper(trim((string) ($row->scale_code_v1 ?? '')));
+                $codeV2 = strtoupper(trim((string) ($row->scale_code_v2 ?? '')));
+                if ($scaleUid === '') {
+                    continue;
+                }
+                if ($codeV1 !== '') {
+                    $checks[$codeV1 . '|' . $scaleUid] = ['code' => $codeV1, 'scale_uid' => $scaleUid];
+                }
+                if ($codeV2 !== '') {
+                    $checks[$codeV2 . '|' . $scaleUid] = ['code' => $codeV2, 'scale_uid' => $scaleUid];
+                }
+            }
+
+            if (Schema::hasTable('scale_code_aliases')) {
+                $aliases = DB::table('scale_code_aliases')
+                    ->select(['alias_code', 'scale_uid'])
+                    ->get();
+                foreach ($aliases as $aliasRow) {
+                    $aliasCode = strtoupper(trim((string) ($aliasRow->alias_code ?? '')));
+                    $scaleUid = trim((string) ($aliasRow->scale_uid ?? ''));
+                    if ($aliasCode === '' || $scaleUid === '') {
+                        continue;
+                    }
+                    $checks[$aliasCode . '|' . $scaleUid] = ['code' => $aliasCode, 'scale_uid' => $scaleUid];
+                }
+            }
+
+            $denominator = 0;
+            $numerator = 0;
+            foreach ($checks as $check) {
+                $code = strtoupper(trim((string) ($check['code'] ?? '')));
+                $expectedUid = trim((string) ($check['scale_uid'] ?? ''));
+                if ($code === '' || $expectedUid === '') {
+                    continue;
+                }
+                $denominator++;
+                $resolved = $this->identityResolver->resolveByAnyCode($code);
+                $isKnown = is_array($resolved) && (bool) ($resolved['is_known'] ?? false);
+                $resolvedUid = $isKnown ? trim((string) ($resolved['scale_uid'] ?? '')) : '';
+                if (! $isKnown || $resolvedUid === '' || $resolvedUid !== $expectedUid) {
+                    $numerator++;
+                }
+            }
+
+            return $this->ratio($numerator, $denominator);
+        } catch (\Throwable) {
+            return $this->ratio(0, 0);
+        }
+    }
+
+    /**
+     * @return array{numerator:int,denominator:int,rate:float}
+     */
+    private function computeDualWriteMismatchRate(\DateTimeInterface $windowStart, \DateTimeInterface $windowEnd, int $maxRows): array
+    {
+        $tables = [
+            ['name' => 'attempts', 'primary' => 'id'],
+            ['name' => 'results', 'primary' => 'id'],
+            ['name' => 'events', 'primary' => 'id'],
+            ['name' => 'shares', 'primary' => 'id'],
+            ['name' => 'report_snapshots', 'primary' => 'attempt_id'],
+            ['name' => 'orders', 'primary' => 'id'],
+            ['name' => 'payment_events', 'primary' => 'id'],
+            ['name' => 'assessments', 'primary' => 'id'],
+            ['name' => 'attempt_answer_sets', 'primary' => 'id'],
+            ['name' => 'attempt_answer_rows', 'primary' => null],
+        ];
+
+        $denominator = 0;
+        $numerator = 0;
+
+        foreach ($tables as $tableMeta) {
+            $table = (string) ($tableMeta['name'] ?? '');
+            $primary = $tableMeta['primary'] ?? null;
+            if ($table === '' || ! Schema::hasTable($table)) {
+                continue;
+            }
+            if (! Schema::hasColumn($table, 'scale_code') || ! Schema::hasColumn($table, 'scale_code_v2')) {
+                continue;
+            }
+
+            $columns = ['scale_code', 'scale_code_v2'];
+            $hasCreatedAt = Schema::hasColumn($table, 'created_at');
+            $hasScaleUid = Schema::hasColumn($table, 'scale_uid');
+            if (is_string($primary) && $primary !== '' && Schema::hasColumn($table, $primary)) {
+                $columns[] = $primary;
+            } else {
+                $primary = null;
+            }
+            if ($hasCreatedAt) {
+                $columns[] = 'created_at';
+            }
+            if ($hasScaleUid) {
+                $columns[] = 'scale_uid';
+            }
+
+            try {
+                $query = DB::table($table)->select($columns)
+                    ->whereNotNull('scale_code')
+                    ->where('scale_code', '<>', '')
+                    ->whereNotNull('scale_code_v2')
+                    ->where('scale_code_v2', '<>', '');
+                if ($hasCreatedAt) {
+                    $query->where('created_at', '>=', $windowStart)
+                        ->where('created_at', '<=', $windowEnd);
+                }
+                if (is_string($primary) && $primary !== '') {
+                    $query->orderByDesc($primary);
+                } elseif ($hasCreatedAt) {
+                    $query->orderByDesc('created_at');
+                }
+
+                /** @var Collection<int,object> $rows */
+                $rows = $query->limit($maxRows)->get();
+            } catch (\Throwable) {
+                continue;
+            }
+
+            foreach ($rows as $row) {
+                $legacyCode = strtoupper(trim((string) ($row->scale_code ?? '')));
+                $v2Code = strtoupper(trim((string) ($row->scale_code_v2 ?? '')));
+                if ($legacyCode === '' || $v2Code === '') {
+                    continue;
+                }
+
+                $denominator++;
+                $resolved = $this->identityResolver->resolveByAnyCode($legacyCode);
+                $isKnown = is_array($resolved) && (bool) ($resolved['is_known'] ?? false);
+                $expectedV2 = $isKnown ? strtoupper(trim((string) ($resolved['scale_code_v2'] ?? ''))) : '';
+                $expectedUid = $isKnown ? trim((string) ($resolved['scale_uid'] ?? '')) : '';
+                $currentUid = $hasScaleUid ? trim((string) ($row->scale_uid ?? '')) : '';
+
+                $isMismatch = ! $isKnown || $expectedV2 === '' || $v2Code !== $expectedV2;
+                if (! $isMismatch && $hasScaleUid && $expectedUid !== '' && $currentUid !== '' && $currentUid !== $expectedUid) {
+                    $isMismatch = true;
+                }
+
+                if ($isMismatch) {
+                    $numerator++;
+                }
+            }
+        }
+
+        return $this->ratio($numerator, $denominator);
+    }
+
+    /**
+     * @return array{numerator:int,denominator:int,rate:float}
+     */
+    private function computeContentPathFallbackRate(): array
+    {
+        if (! Schema::hasTable('content_path_aliases')) {
+            return $this->ratio(0, 0);
+        }
+
+        try {
+            $rows = DB::table('content_path_aliases')
+                ->select(['scope', 'old_path', 'new_path'])
+                ->where('is_active', true)
+                ->get();
+
+            $denominator = 0;
+            $numerator = 0;
+            foreach ($rows as $row) {
+                $scope = strtolower(trim((string) ($row->scope ?? '')));
+                $oldPath = trim((string) ($row->old_path ?? ''));
+                $newPath = trim((string) ($row->new_path ?? ''));
+                if ($scope === '' || $oldPath === '' || $newPath === '') {
+                    continue;
+                }
+                $denominator++;
+
+                $oldAbs = $this->absoluteContentPath($scope, $oldPath);
+                $newAbs = $this->absoluteContentPath($scope, $newPath);
+                if (is_dir($oldAbs) && ! is_dir($newAbs)) {
+                    $numerator++;
+                }
+            }
+
+            return $this->ratio($numerator, $denominator);
+        } catch (\Throwable) {
+            return $this->ratio(0, 0);
+        }
+    }
+
+    /**
+     * @return array{numerator:int,denominator:int,rate:float}
+     */
+    private function computeLegacyCodeHitRate(\DateTimeInterface $windowStart, \DateTimeInterface $windowEnd): array
+    {
+        if (! Schema::hasTable('attempts') || ! Schema::hasColumn('attempts', 'scale_code')) {
+            return $this->ratio(0, 0);
+        }
+
+        $legacyCodes = array_keys((array) config('scale_identity.code_map_v1_to_v2', []));
+        $legacyCodes = array_values(array_unique(array_filter(array_map(
+            static fn ($code) => strtoupper(trim((string) $code)),
+            $legacyCodes
+        ))));
+        $v2Codes = array_values(array_unique(array_filter(array_map(
+            static fn ($code) => strtoupper(trim((string) $code)),
+            array_values((array) config('scale_identity.code_map_v1_to_v2', []))
+        ))));
+
+        if ($legacyCodes === [] && $v2Codes === []) {
+            return $this->ratio(0, 0);
+        }
+
+        try {
+            $hasScaleCodeV2 = Schema::hasColumn('attempts', 'scale_code_v2');
+            $hasCreatedAt = Schema::hasColumn('attempts', 'created_at');
+
+            $denominatorQuery = DB::table('attempts');
+            if ($hasCreatedAt) {
+                $denominatorQuery->where('created_at', '>=', $windowStart)
+                    ->where('created_at', '<=', $windowEnd);
+            }
+            $denominatorQuery->where(function ($q) use ($legacyCodes, $v2Codes, $hasScaleCodeV2): void {
+                if ($legacyCodes !== []) {
+                    $q->whereIn('scale_code', $legacyCodes);
+                }
+                if ($v2Codes !== []) {
+                    $q->orWhereIn('scale_code', $v2Codes);
+                    if ($hasScaleCodeV2) {
+                        $q->orWhereIn('scale_code_v2', $v2Codes);
+                    }
+                }
+            });
+            $denominator = (int) $denominatorQuery->count();
+
+            $numeratorQuery = DB::table('attempts');
+            if ($hasCreatedAt) {
+                $numeratorQuery->where('created_at', '>=', $windowStart)
+                    ->where('created_at', '<=', $windowEnd);
+            }
+            if ($legacyCodes !== []) {
+                $numeratorQuery->whereIn('scale_code', $legacyCodes);
+            } else {
+                $numeratorQuery->whereRaw('1=0');
+            }
+            $numerator = (int) $numeratorQuery->count();
+
+            return $this->ratio($numerator, $denominator);
+        } catch (\Throwable) {
+            return $this->ratio(0, 0);
+        }
+    }
+
+    /**
+     * @return array{numerator:int,denominator:int,rate:float}
+     */
+    private function computeDemoScaleHitRate(\DateTimeInterface $windowStart, \DateTimeInterface $windowEnd): array
+    {
+        if (! Schema::hasTable('attempts') || ! Schema::hasColumn('attempts', 'scale_code')) {
+            return $this->ratio(0, 0);
+        }
+
+        try {
+            $hasCreatedAt = Schema::hasColumn('attempts', 'created_at');
+            $denominatorQuery = DB::table('attempts')
+                ->whereNotNull('scale_code')
+                ->where('scale_code', '<>', '');
+            if ($hasCreatedAt) {
+                $denominatorQuery->where('created_at', '>=', $windowStart)
+                    ->where('created_at', '<=', $windowEnd);
+            }
+            $denominator = (int) $denominatorQuery->count();
+
+            $numeratorQuery = DB::table('attempts')
+                ->whereIn('scale_code', ['DEMO_ANSWERS', 'SIMPLE_SCORE_DEMO']);
+            if ($hasCreatedAt) {
+                $numeratorQuery->where('created_at', '>=', $windowStart)
+                    ->where('created_at', '<=', $windowEnd);
+            }
+            $numerator = (int) $numeratorQuery->count();
+
+            return $this->ratio($numerator, $denominator);
+        } catch (\Throwable) {
+            return $this->ratio(0, 0);
+        }
+    }
+
+    /**
+     * @return array{numerator:int,denominator:int,rate:float}
+     */
+    private function ratio(int $numerator, int $denominator): array
+    {
+        $safeNumerator = max(0, $numerator);
+        $safeDenominator = max(0, $denominator);
+
+        return [
+            'numerator' => $safeNumerator,
+            'denominator' => $safeDenominator,
+            'rate' => $safeDenominator > 0 ? round($safeNumerator / $safeDenominator, 4) : 0.0,
+        ];
+    }
+
+    private function isTruthy(mixed $value): bool
+    {
+        if (is_bool($value)) {
+            return $value;
+        }
+
+        $normalized = strtolower(trim((string) $value));
+        return in_array($normalized, ['1', 'true', 'yes', 'on'], true);
+    }
+
+    private function floatEnv(string $name, float $default): float
+    {
+        $raw = getenv($name);
+        if ($raw === false) {
+            return $default;
+        }
+        $value = trim((string) $raw);
+        if ($value === '' || ! is_numeric($value)) {
+            return $default;
+        }
+
+        return (float) $value;
+    }
+
+    private function absoluteContentPath(string $scope, string $relativePath): string
+    {
+        $normalized = trim($relativePath, '/');
+        if ($scope === 'content_packages') {
+            $root = rtrim((string) config('content_packs.root', base_path('../content_packages')), DIRECTORY_SEPARATOR);
+            return $root . DIRECTORY_SEPARATOR . str_replace('/', DIRECTORY_SEPARATOR, $normalized);
+        }
+
+        return base_path($normalized);
+    }
+}

--- a/backend/app/Console/Commands/PacksPublish.php
+++ b/backend/app/Console/Commands/PacksPublish.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Console\Commands;
 
+use App\Services\Content\ContentPathAliasResolver;
 use App\Services\Content\Publisher\ContentPackPublisher;
 use Illuminate\Console\Command;
 use Illuminate\Support\Facades\DB;
@@ -32,7 +33,7 @@ final class PacksPublish extends Command
 
     protected $description = 'Publish BIG5_OCEAN/SDS_20 local content pack through ContentPackPublisher.';
 
-    public function handle(ContentPackPublisher $publisher): int
+    public function handle(ContentPackPublisher $publisher, ContentPathAliasResolver $pathAliasResolver): int
     {
         $scaleCode = strtoupper(trim((string) $this->option('scale')));
         if (!in_array($scaleCode, ['BIG5_OCEAN', 'SDS_20'], true)) {
@@ -55,7 +56,9 @@ final class PacksPublish extends Command
             return 1;
         }
 
-        $sourceDir = base_path(sprintf('content_packs/%s/%s', $packId, $version));
+        $sourceContext = $pathAliasResolver->resolveBackendPublishSourceContext($packId, $version);
+        $sourceDir = trim((string) ($sourceContext['selected_path'] ?? ''));
+        $sourceSelection = strtolower(trim((string) ($sourceContext['selected_source'] ?? 'legacy')));
         if (!File::isDirectory($sourceDir)) {
             $this->error("pack source directory not found: {$sourceDir}");
             return 1;
@@ -90,7 +93,16 @@ final class PacksPublish extends Command
         }
 
         try {
-            $versionId = $this->stageVersion($sourceDir, $packId, $version, $region, $locale, $dirAlias, $createdBy === '' ? 'cli' : $createdBy);
+            $versionId = $this->stageVersion(
+                $sourceDir,
+                $packId,
+                $version,
+                $region,
+                $locale,
+                $dirAlias,
+                $createdBy === '' ? 'cli' : $createdBy,
+                $sourceSelection
+            );
         } catch (\Throwable $e) {
             $this->error('failed to stage content version: '.$e->getMessage());
             return 1;
@@ -128,7 +140,8 @@ final class PacksPublish extends Command
         string $region,
         string $locale,
         string $dirAlias,
-        string $createdBy
+        string $createdBy,
+        string $sourceSelection = 'legacy'
     ): string {
         $versionId = (string) Str::uuid();
         $privateRoot = rtrim(storage_path('app/private'), '/\\');
@@ -156,7 +169,7 @@ final class PacksPublish extends Command
             'pack_id' => $packId,
             'content_package_version' => $version,
             'dir_version_alias' => $dirAlias,
-            'source_type' => 'local_repo',
+            'source_type' => $this->resolveLocalSourceType($sourceSelection),
             'source_ref' => $sourceRef,
             'sha256' => $sha256,
             'manifest_json' => json_encode($manifestPayload, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES),
@@ -230,5 +243,19 @@ final class PacksPublish extends Command
         return $scaleCode === 'SDS_20'
             ? 'norms:sds:drift-check'
             : 'norms:big5:drift-check';
+    }
+
+    private function resolveLocalSourceType(string $sourceSelection): string
+    {
+        $selection = strtolower(trim($sourceSelection));
+        if ($selection === 'mapped') {
+            return 'local_repo_mapped';
+        }
+
+        if ($selection === 'legacy') {
+            return 'local_repo_legacy';
+        }
+
+        return 'local_repo';
     }
 }

--- a/backend/app/Console/Kernel.php
+++ b/backend/app/Console/Kernel.php
@@ -30,6 +30,18 @@ use App\Console\Commands\NormsEq60Import;
 use App\Console\Commands\NormsImport;
 use App\Console\Commands\NormsSdsDriftCheck;
 use App\Console\Commands\NormsSdsRebuild;
+use App\Console\Commands\Ops\ScaleIdentityGate;
+use App\Console\Commands\Ops\ContentPathMirror;
+use App\Console\Commands\Ops\BackfillAssessmentsScaleIdentity;
+use App\Console\Commands\Ops\BackfillAttemptAnswerRowsScaleIdentity;
+use App\Console\Commands\Ops\BackfillAttemptAnswerSetsScaleIdentity;
+use App\Console\Commands\Ops\BackfillAttemptsScaleIdentity;
+use App\Console\Commands\Ops\BackfillEventsScaleIdentity;
+use App\Console\Commands\Ops\BackfillOrdersScaleIdentity;
+use App\Console\Commands\Ops\BackfillPaymentEventsScaleIdentity;
+use App\Console\Commands\Ops\BackfillReportSnapshotsScaleIdentity;
+use App\Console\Commands\Ops\BackfillResultsScaleIdentity;
+use App\Console\Commands\Ops\BackfillSharesScaleIdentity;
 use App\Console\Commands\Ops\PartitionAttemptAnswerRows;
 use App\Console\Commands\OpsDeployEvent;
 use App\Console\Commands\OpsHealthzSnapshot;
@@ -105,6 +117,18 @@ class Kernel extends ConsoleKernel
         StorageInventory::class,
         QualityDailySummary::class,
         CiScaleImpact::class,
+        ContentPathMirror::class,
+        ScaleIdentityGate::class,
+        BackfillAssessmentsScaleIdentity::class,
+        BackfillAttemptAnswerRowsScaleIdentity::class,
+        BackfillAttemptAnswerSetsScaleIdentity::class,
+        BackfillAttemptsScaleIdentity::class,
+        BackfillEventsScaleIdentity::class,
+        BackfillOrdersScaleIdentity::class,
+        BackfillPaymentEventsScaleIdentity::class,
+        BackfillReportSnapshotsScaleIdentity::class,
+        BackfillResultsScaleIdentity::class,
+        BackfillSharesScaleIdentity::class,
         PartitionAttemptAnswerRows::class,
     ];
 

--- a/backend/app/Http/Controllers/API/V0_3/ScalesController.php
+++ b/backend/app/Http/Controllers/API/V0_3/ScalesController.php
@@ -8,6 +8,7 @@ use App\Services\Content\ClinicalComboPackLoader;
 use App\Services\Content\Eq60PackLoader;
 use App\Services\Content\QuestionsService;
 use App\Services\Content\Sds20PackLoader;
+use App\Services\Scale\ScaleIdentityResolver;
 use App\Services\Scale\ScaleRegistry;
 use App\Support\OrgContext;
 use Illuminate\Http\JsonResponse;
@@ -17,6 +18,7 @@ class ScalesController extends Controller
 {
     public function __construct(
         private ScaleRegistry $registry,
+        private ScaleIdentityResolver $identityResolver,
         private OrgContext $orgContext,
     ) {}
 
@@ -58,10 +60,13 @@ class ScalesController extends Controller
             ], 404);
         }
 
-        return response()->json([
+        $scaleCodeMeta = $this->buildScaleCodeMeta($code, $row);
+
+        return response()->json(array_merge([
             'ok' => true,
+            'scale_code' => $scaleCodeMeta['scale_code'],
             'item' => $row,
-        ]);
+        ], $scaleCodeMeta));
     }
 
     /**
@@ -94,6 +99,8 @@ class ScalesController extends Controller
                 'message' => 'scale not found.',
             ], 404);
         }
+        $resolvedScaleCode = strtoupper(trim((string) ($row['code'] ?? $code)));
+        $scaleCodeMeta = $this->buildScaleCodeMeta($code, $row);
 
         $packId = (string) ($row['default_pack_id'] ?? '');
         $dirVersion = (string) ($row['default_dir_version'] ?? '');
@@ -108,7 +115,7 @@ class ScalesController extends Controller
         $region = (string) ($request->query('region') ?? $row['default_region'] ?? config('content_packs.default_region', ''));
         $locale = (string) ($request->query('locale') ?? $row['default_locale'] ?? config('content_packs.default_locale', ''));
 
-        if ($code === 'BIG5_OCEAN') {
+        if ($resolvedScaleCode === 'BIG5_OCEAN') {
             $version = (string) ($row['default_dir_version'] ?? BigFivePackLoader::PACK_VERSION);
             $normalizedLocale = $this->normalizeBigFiveLocale($locale);
             $compiledMin = $bigFivePackLoader->readCompiledJson('questions.min.compiled.json', $version);
@@ -188,7 +195,7 @@ class ScalesController extends Controller
 
             return response()->json([
                 'ok' => true,
-                'scale_code' => $code,
+                'scale_code' => $scaleCodeMeta['scale_code'],
                 'region' => $region,
                 'locale' => $normalizedLocale,
                 'pack_id' => $packId,
@@ -201,10 +208,10 @@ class ScalesController extends Controller
                     'disclaimer_hash' => $disclaimerHash,
                     'disclaimer_text' => $disclaimerText,
                 ],
-            ]);
+            ] + $scaleCodeMeta);
         }
 
-        if ($code === 'CLINICAL_COMBO_68') {
+        if ($resolvedScaleCode === 'CLINICAL_COMBO_68') {
             $version = (string) ($row['default_dir_version'] ?? ClinicalComboPackLoader::PACK_VERSION);
             $doc = $clinicalPackLoader->loadQuestionsDoc($locale, $version);
             $consent = $clinicalPackLoader->loadConsent((string) ($doc['locale_resolved'] ?? $locale), $version);
@@ -213,7 +220,7 @@ class ScalesController extends Controller
 
             return response()->json([
                 'ok' => true,
-                'scale_code' => $code,
+                'scale_code' => $scaleCodeMeta['scale_code'],
                 'region' => $region,
                 'locale' => (string) ($doc['locale_resolved'] ?? 'zh-CN'),
                 'pack_id' => $packId,
@@ -232,10 +239,10 @@ class ScalesController extends Controller
                     'privacy_addendum' => $privacyAddendum,
                     'crisis_resources' => $crisisResources,
                 ],
-            ]);
+            ] + $scaleCodeMeta);
         }
 
-        if ($code === 'SDS_20') {
+        if ($resolvedScaleCode === 'SDS_20') {
             $version = (string) ($row['default_dir_version'] ?? Sds20PackLoader::PACK_VERSION);
             $doc = $sds20PackLoader->loadQuestionsDoc($locale, $version);
             $localeResolved = (string) ($doc['locale_resolved'] ?? $sds20PackLoader->normalizeLocale($locale));
@@ -245,7 +252,7 @@ class ScalesController extends Controller
 
             return response()->json([
                 'ok' => true,
-                'scale_code' => $code,
+                'scale_code' => $scaleCodeMeta['scale_code'],
                 'region' => $region,
                 'locale' => $localeResolved,
                 'pack_id' => $packId,
@@ -276,17 +283,17 @@ class ScalesController extends Controller
                         'items' => $sourceCatalog,
                     ],
                 ],
-            ]);
+            ] + $scaleCodeMeta);
         }
 
-        if ($code === 'EQ_60') {
+        if ($resolvedScaleCode === 'EQ_60') {
             $version = (string) ($row['default_dir_version'] ?? Eq60PackLoader::PACK_VERSION);
             $doc = $eq60PackLoader->loadQuestionsDoc($locale, $version);
             $localeResolved = (string) ($doc['locale_resolved'] ?? $eq60PackLoader->normalizeLocale($locale));
 
             return response()->json([
                 'ok' => true,
-                'scale_code' => $code,
+                'scale_code' => $scaleCodeMeta['scale_code'],
                 'region' => $region,
                 'locale' => $localeResolved,
                 'pack_id' => $packId,
@@ -302,7 +309,7 @@ class ScalesController extends Controller
                     'option_anchors' => is_array($doc['option_anchors'] ?? null) ? $doc['option_anchors'] : [],
                     'dimension_codes' => is_array($doc['dimension_codes'] ?? null) ? $doc['dimension_codes'] : ['SA', 'ER', 'SE', 'RM'],
                 ],
-            ]);
+            ] + $scaleCodeMeta);
         }
 
         $assetsBaseUrlOverride = $request->attributes->get('assets_base_url');
@@ -322,14 +329,14 @@ class ScalesController extends Controller
 
         return response()->json([
             'ok' => true,
-            'scale_code' => $code,
+            'scale_code' => $scaleCodeMeta['scale_code'],
             'region' => $region,
             'locale' => $locale,
             'pack_id' => $packId,
             'dir_version' => $dirVersion,
             'content_package_version' => (string) ($loaded['content_package_version'] ?? ''),
             'questions' => $loaded['questions'],
-        ]);
+        ] + $scaleCodeMeta);
     }
 
     private function normalizeBigFiveLocale(string $locale): string
@@ -450,5 +457,58 @@ class ScalesController extends Controller
         }
 
         return $options;
+    }
+
+    /**
+     * @param  array<string,mixed>  $row
+     * @return array{
+     *     requested_scale_code:string,
+     *     scale_code:string,
+     *     scale_code_legacy:string,
+     *     scale_code_v2:string,
+     *     scale_uid:?string,
+     *     pack_id_v2:?string,
+     *     dir_version_v2:?string,
+     *     resolved_from_alias:bool
+     * }
+     */
+    private function buildScaleCodeMeta(string $requestedScaleCode, array $row): array
+    {
+        $requested = strtoupper(trim($requestedScaleCode));
+        $legacyCode = strtoupper(trim((string) ($row['code'] ?? $requested)));
+        $identity = $this->identityResolver->resolveByAnyCode($requested);
+        if (! is_array($identity) || ! ((bool) ($identity['is_known'] ?? false))) {
+            $identity = $this->identityResolver->resolveByAnyCode($legacyCode);
+        }
+
+        $isKnown = is_array($identity) && ((bool) ($identity['is_known'] ?? false));
+        $resolvedV1 = $isKnown
+            ? strtoupper(trim((string) ($identity['scale_code_v1'] ?? $legacyCode)))
+            : $legacyCode;
+        $resolvedV2 = $isKnown
+            ? strtoupper(trim((string) ($identity['scale_code_v2'] ?? $legacyCode)))
+            : $legacyCode;
+        $scaleUid = $isKnown ? trim((string) ($identity['scale_uid'] ?? '')) : '';
+        $packIdV2 = $isKnown ? $this->trimOrNull($identity['pack_id_v2'] ?? null) : null;
+        $dirVersionV2 = $isKnown ? $this->trimOrNull($identity['dir_version_v2'] ?? null) : null;
+        $responseScaleCode = $this->identityResolver->resolveResponseScaleCode($legacyCode, $resolvedV2);
+
+        return [
+            'requested_scale_code' => $requested,
+            'scale_code' => $responseScaleCode,
+            'scale_code_legacy' => $legacyCode,
+            'scale_code_v2' => $resolvedV2 !== '' ? $resolvedV2 : $legacyCode,
+            'scale_uid' => $scaleUid !== '' ? $scaleUid : null,
+            'pack_id_v2' => $packIdV2 ?? $this->trimOrNull($row['default_pack_id'] ?? null),
+            'dir_version_v2' => $dirVersionV2 ?? $this->trimOrNull($row['default_dir_version'] ?? null),
+            'resolved_from_alias' => $requested !== $resolvedV1,
+        ];
+    }
+
+    private function trimOrNull(mixed $value): ?string
+    {
+        $trimmed = trim((string) $value);
+
+        return $trimmed !== '' ? $trimmed : null;
     }
 }

--- a/backend/app/Http/Controllers/API/V0_3/ScalesLookupController.php
+++ b/backend/app/Http/Controllers/API/V0_3/ScalesLookupController.php
@@ -3,6 +3,7 @@
 namespace App\Http\Controllers\API\V0_3;
 
 use App\Http\Controllers\Controller;
+use App\Services\Scale\ScaleIdentityResolver;
 use App\Services\Scale\ScaleRegistry;
 use App\Support\OrgContext;
 use Illuminate\Http\JsonResponse;
@@ -12,6 +13,7 @@ class ScalesLookupController extends Controller
 {
     public function __construct(
         private ScaleRegistry $registry,
+        private ScaleIdentityResolver $identityResolver,
         private OrgContext $orgContext,
     ) {}
 
@@ -48,21 +50,36 @@ class ScalesLookupController extends Controller
             ], 404);
         }
 
+        $legacyScaleCode = strtoupper(trim((string) ($row['code'] ?? '')));
+        if (! $this->identityResolver->shouldAllowDemoScale($legacyScaleCode)) {
+            return $this->deprecatedScaleResponse(
+                $legacyScaleCode,
+                $requestedSlug,
+                trim((string) ($row['primary_slug'] ?? ''))
+            );
+        }
+
         $primarySlug = trim((string) ($row['primary_slug'] ?? ''));
         $resolvedFromAlias = $primarySlug !== '' && $requestedSlug !== $primarySlug;
+        $scaleCodeMeta = $this->resolveScaleCodeMeta($row);
         $locale = $this->resolveRequestedLocale($request, (string) ($row['default_locale'] ?? 'en'));
         $seo = $this->resolveSeoByLocale($row, $locale);
         $isIndexable = $this->resolveIsIndexable($row);
 
         return response()->json([
             'ok' => true,
-            'scale_code' => $row['code'] ?? '',
+            'scale_code' => $scaleCodeMeta['scale_code'],
+            'scale_code_legacy' => $scaleCodeMeta['scale_code_legacy'],
+            'scale_code_v2' => $scaleCodeMeta['scale_code_v2'],
+            'scale_uid' => $scaleCodeMeta['scale_uid'],
             'primary_slug' => $primarySlug,
             'slug' => $primarySlug,
             'requested_slug' => $requestedSlug,
             'resolved_from_alias' => $resolvedFromAlias,
             'pack_id' => $row['default_pack_id'] ?? null,
             'dir_version' => $row['default_dir_version'] ?? null,
+            'pack_id_v2' => $scaleCodeMeta['pack_id_v2'],
+            'dir_version_v2' => $scaleCodeMeta['dir_version_v2'],
             'region' => $row['default_region'] ?? null,
             'locale' => $locale,
             'driver_type' => $row['driver_type'] ?? '',
@@ -216,5 +233,67 @@ class ScalesLookupController extends Controller
     {
         $trimmed = trim((string) $value);
         return $trimmed !== '' ? $trimmed : null;
+    }
+
+    private function deprecatedScaleResponse(string $legacyScaleCode, string $requestedSlug, string $primarySlug): JsonResponse
+    {
+        $replacementLegacy = $this->identityResolver->demoReplacement($legacyScaleCode);
+        $replacementV2 = null;
+        if ($replacementLegacy !== null) {
+            $replacementIdentity = $this->identityResolver->resolveByAnyCode($replacementLegacy);
+            if (is_array($replacementIdentity) && ((bool) ($replacementIdentity['is_known'] ?? false))) {
+                $resolved = strtoupper(trim((string) ($replacementIdentity['scale_code_v2'] ?? '')));
+                if ($resolved !== '') {
+                    $replacementV2 = $resolved;
+                }
+            }
+        }
+
+        return response()->json([
+            'ok' => false,
+            'error_code' => 'SCALE_DEPRECATED',
+            'message' => 'scale is deprecated.',
+            'details' => [
+                'requested_slug' => $requestedSlug,
+                'primary_slug' => $primarySlug !== '' ? $primarySlug : null,
+                'scale_code_legacy' => $legacyScaleCode,
+                'replacement_scale_code' => $replacementLegacy,
+                'replacement_scale_code_v2' => $replacementV2,
+            ],
+        ], 410);
+    }
+
+    /**
+     * @param  array<string,mixed>  $row
+     * @return array{
+     *     scale_code:string,
+     *     scale_code_legacy:string,
+     *     scale_code_v2:string,
+     *     scale_uid:?string,
+     *     pack_id_v2:?string,
+     *     dir_version_v2:?string
+     * }
+     */
+    private function resolveScaleCodeMeta(array $row): array
+    {
+        $legacyCode = strtoupper(trim((string) ($row['code'] ?? '')));
+        $identity = $this->identityResolver->resolveByAnyCode($legacyCode);
+        $isKnown = is_array($identity) && ((bool) ($identity['is_known'] ?? false));
+        $scaleUid = $isKnown ? trim((string) ($identity['scale_uid'] ?? '')) : '';
+        $scaleCodeV2 = $isKnown
+            ? strtoupper(trim((string) ($identity['scale_code_v2'] ?? $legacyCode)))
+            : $legacyCode;
+        $packIdV2 = $isKnown ? $this->trimOrNull($identity['pack_id_v2'] ?? null) : null;
+        $dirVersionV2 = $isKnown ? $this->trimOrNull($identity['dir_version_v2'] ?? null) : null;
+        $responseScaleCode = $this->identityResolver->resolveResponseScaleCode($legacyCode, $scaleCodeV2);
+
+        return [
+            'scale_code' => $responseScaleCode,
+            'scale_code_legacy' => $legacyCode,
+            'scale_code_v2' => $scaleCodeV2 !== '' ? $scaleCodeV2 : $legacyCode,
+            'scale_uid' => $scaleUid !== '' ? $scaleUid : null,
+            'pack_id_v2' => $packIdV2 ?? $this->trimOrNull($row['default_pack_id'] ?? null),
+            'dir_version_v2' => $dirVersionV2 ?? $this->trimOrNull($row['default_dir_version'] ?? null),
+        ];
     }
 }

--- a/backend/app/Http/Controllers/API/V0_3/Webhooks/PaymentWebhookController.php
+++ b/backend/app/Http/Controllers/API/V0_3/Webhooks/PaymentWebhookController.php
@@ -15,10 +15,13 @@ final class PaymentWebhookController extends Controller
 {
     private const MAX_PAYLOAD_BYTES = 262144;
 
+    private const TRANSIENT_DB_RETRY_MAX_ATTEMPTS = 3;
+
+    private const TRANSIENT_DB_RETRY_BASE_USLEEP = 100000;
+
     public function __construct(
         private PaymentWebhookProcessor $processor,
-    ) {
-    }
+    ) {}
 
     public function handle(Request $request, string $provider): JsonResponse
     {
@@ -32,16 +35,29 @@ final class PaymentWebhookController extends Controller
         $payload = is_array($decoded) ? $decoded : [];
         $signatureOk = $this->resolveSignatureOk($request, $provider);
 
-        try {
-            $result = $this->processor->process($provider, $payload, $signatureOk);
-        } catch (\Throwable $e) {
-            Log::error('PAYMENT_WEBHOOK_INTERNAL_ERROR', [
-                'request_id' => $this->resolveRequestId($request),
-                'provider' => $provider,
-                'exception' => $e->getMessage(),
-            ]);
+        $requestId = $this->resolveRequestId($request);
+        $attempt = 0;
+        while (true) {
+            try {
+                $result = $this->processor->process($provider, $payload, $signatureOk);
+                break;
+            } catch (\Throwable $e) {
+                $attempt++;
 
-            return $this->errorResponse(500, 'WEBHOOK_INTERNAL_ERROR', 'webhook internal error');
+                if ($attempt < self::TRANSIENT_DB_RETRY_MAX_ATTEMPTS && $this->isTransientDatabaseFailure($e)) {
+                    usleep(self::TRANSIENT_DB_RETRY_BASE_USLEEP * $attempt);
+
+                    continue;
+                }
+
+                Log::error('PAYMENT_WEBHOOK_INTERNAL_ERROR', [
+                    'request_id' => $requestId,
+                    'provider' => $provider,
+                    'exception' => $e->getMessage(),
+                ]);
+
+                return $this->errorResponse(500, 'WEBHOOK_INTERNAL_ERROR', 'webhook internal error');
+            }
         }
 
         $status = (int) ($result['status'] ?? 200);
@@ -67,7 +83,7 @@ final class PaymentWebhookController extends Controller
     {
         $secret = $this->resolveStripeSecret();
         $legacySecret = $this->resolveStripeLegacySecret();
-        $gateway = new StripeGateway();
+        $gateway = new StripeGateway;
         $tolerance = $this->resolveTolerance();
 
         if ($this->verifyWithScopedConfig($request, $gateway, [
@@ -93,7 +109,7 @@ final class PaymentWebhookController extends Controller
     {
         $secret = $this->resolveBillingSecret();
         $legacySecret = $this->resolveBillingLegacySecret();
-        $gateway = new BillingGateway();
+        $gateway = new BillingGateway;
         $tolerance = $this->resolveTolerance();
 
         if ($this->verifyWithScopedConfig($request, $gateway, [
@@ -172,7 +188,7 @@ final class PaymentWebhookController extends Controller
     }
 
     /**
-     * @param array<int, string> $candidates
+     * @param  array<int, string>  $candidates
      */
     private function firstNonEmpty(array $candidates): string
     {
@@ -213,5 +229,30 @@ final class PaymentWebhookController extends Controller
             'message' => $message,
             'details' => $details === [] ? (object) [] : $details,
         ], $status);
+    }
+
+    private function isTransientDatabaseFailure(\Throwable $e): bool
+    {
+        $message = strtolower(trim($e->getMessage()));
+        if ($message === '') {
+            return false;
+        }
+
+        foreach ([
+            'database is locked',
+            'database table is locked',
+            'deadlock found',
+            'lock wait timeout exceeded',
+            'try restarting transaction',
+            'sqlstate[40001]',
+            'sqlstate[40p01]',
+            'sqlstate[hy000]',
+        ] as $needle) {
+            if (str_contains($message, $needle)) {
+                return true;
+            }
+        }
+
+        return false;
     }
 }

--- a/backend/app/Internal/Commerce/PaymentWebhookHandlerCore.php
+++ b/backend/app/Internal/Commerce/PaymentWebhookHandlerCore.php
@@ -169,451 +169,451 @@ class PaymentWebhookHandlerCore
                         $signatureOk,
                         &$postCommitCtx
                     ) {
-                    $insertSeed = [
-                        'id' => (string) Str::uuid(),
-                        'provider' => $provider,
-                        'provider_event_id' => $providerEventId,
-                        'order_id' => (string) Str::uuid(),
-                        'event_type' => $eventType,
-                        'order_no' => $orderNo,
-                        'payload_json' => $payloadSummaryJson,
-                        'signature_ok' => $signatureOk,
-                        'status' => 'received',
-                        'attempts' => 0,
-                        'last_error_code' => null,
-                        'last_error_message' => null,
-                        'processed_at' => null,
-                        'handled_at' => null,
-                        'handle_status' => null,
-                        'payload_size_bytes' => $resolvedPayloadMeta['size_bytes'],
-                        'payload_sha256' => $resolvedPayloadMeta['sha256'],
-                        'payload_s3_key' => $resolvedPayloadMeta['s3_key'],
-                        'payload_excerpt' => $payloadExcerpt,
-                        'received_at' => $receivedAt,
-                        'created_at' => $receivedAt,
-                        'updated_at' => $receivedAt,
-                    ];
-
-                    $inserted = (int) DB::table('payment_events')->insertOrIgnore($insertSeed);
-
-                    $eventRow = DB::table('payment_events')
-                        ->where('provider', $provider)
-                        ->where('provider_event_id', $providerEventId)
-                        ->lockForUpdate()
-                        ->first();
-                    if (! $eventRow) {
-                        return $this->serverError('EVENT_INIT_FAILED', 'payment event init failed.');
-                    }
-
-                    if ($inserted === 0 && $this->isEventProcessed($eventRow)) {
-                        Log::info('PAYMENT_EVENT_ALREADY_PROCESSED', [
+                        $insertSeed = [
+                            'id' => (string) Str::uuid(),
                             'provider' => $provider,
                             'provider_event_id' => $providerEventId,
-                            'order_id' => $eventRow->order_id ?? null,
-                        ]);
-
-                        return [
-                            'ok' => true,
-                            'duplicate' => true,
+                            'order_id' => (string) Str::uuid(),
+                            'event_type' => $eventType,
                             'order_no' => $orderNo,
-                            'provider_event_id' => $providerEventId,
+                            'payload_json' => $payloadSummaryJson,
+                            'signature_ok' => $signatureOk,
+                            'status' => 'received',
+                            'attempts' => 0,
+                            'last_error_code' => null,
+                            'last_error_message' => null,
+                            'processed_at' => null,
+                            'handled_at' => null,
+                            'handle_status' => null,
+                            'payload_size_bytes' => $resolvedPayloadMeta['size_bytes'],
+                            'payload_sha256' => $resolvedPayloadMeta['sha256'],
+                            'payload_s3_key' => $resolvedPayloadMeta['s3_key'],
+                            'payload_excerpt' => $payloadExcerpt,
+                            'received_at' => $receivedAt,
+                            'created_at' => $receivedAt,
+                            'updated_at' => $receivedAt,
                         ];
-                    }
 
-                    $attempts = (int) ($eventRow->attempts ?? 0);
-                    $attempts = $attempts > 0 ? $attempts + 1 : 1;
+                        $inserted = (int) DB::table('payment_events')->insertOrIgnore($insertSeed);
 
-                    $baseRow = [
-                        'provider' => $provider,
-                        'provider_event_id' => $providerEventId,
-                        'order_id' => $eventRow->order_id ?? ($insertSeed['order_id'] ?? (string) Str::uuid()),
-                        'event_type' => $eventType,
-                        'order_no' => $orderNo,
-                        'payload_json' => $payloadSummaryJson,
-                        'signature_ok' => $signatureOk,
-                        'status' => 'received',
-                        'attempts' => $attempts,
-                        'last_error_code' => null,
-                        'last_error_message' => null,
-                        'processed_at' => null,
-                        'handled_at' => null,
-                        'handle_status' => null,
-                        'payload_size_bytes' => $resolvedPayloadMeta['size_bytes'],
-                        'payload_sha256' => $resolvedPayloadMeta['sha256'],
-                        'payload_s3_key' => $resolvedPayloadMeta['s3_key'],
-                        'payload_excerpt' => $payloadExcerpt,
-                        'received_at' => $receivedAt,
-                        'updated_at' => $receivedAt,
-                    ];
-
-                    DB::table('payment_events')
-                        ->where('provider', $provider)
-                        ->where('provider_event_id', $providerEventId)
-                        ->update($baseRow);
-
-                    if ($signatureOk !== true) {
-                        $this->markEventError($provider, $providerEventId, 'rejected', 'INVALID_SIGNATURE', 'signature invalid.');
-
-                        return $this->badRequest('INVALID_SIGNATURE', 'invalid signature.');
-                    }
-
-                    $orderQuery = DB::table('orders')
-                        ->where('order_no', $orderNo)
-                        ->where('org_id', $orgId);
-
-                    $order = $orderQuery->lockForUpdate()->first();
-                    if (! $order) {
-                        $this->markEventError($provider, $providerEventId, 'orphan', 'ORDER_NOT_FOUND', 'order not found.');
-
-                        return $this->notFound('ORDER_NOT_FOUND', 'not found.');
-                    }
-
-                    $orderProvider = strtolower(trim((string) ($order->provider ?? '')));
-                    $webhookProvider = strtolower(trim((string) $provider));
-                    if ($orderProvider !== $webhookProvider) {
-                        $detail = "order.provider={$orderProvider}; webhook.provider={$webhookProvider}";
-
-                        Log::warning('PAYMENT_EVENT_PROVIDER_MISMATCH', [
-                            'provider' => $provider,
-                            'order_provider' => $orderProvider !== '' ? $orderProvider : null,
-                            'provider_event_id' => $providerEventId,
-                            'order_no' => $orderNo,
-                            'order_id' => $order->id ?? null,
-                        ]);
-
-                        $this->markEventError(
-                            $provider,
-                            $providerEventId,
-                            'rejected',
-                            'rejected_provider_mismatch',
-                            $detail
-                        );
-
-                        return $this->badRequest('PROVIDER_MISMATCH', 'provider mismatch');
-                    }
-
-                    $isRefundEvent = $this->isRefundEvent($eventType, $normalized);
-                    $orderStatus = strtolower((string) ($order->status ?? ''));
-                    $orderAlreadySettled = ! $isRefundEvent
-                        && in_array($orderStatus, ['paid', 'fulfilled', 'completed', 'delivered', 'refunded'], true);
-
-                    $orderMeta = $this->resolveOrderMeta($orgId, $orderNo, $order);
-                    $normalizedSkuMeta = $this->normalizeOrderSkuMeta($order);
-                    $this->updatePaymentEvent($provider, $providerEventId, [
-                        'order_id' => $order->id ?? null,
-                        'event_type' => $eventType,
-                        'signature_ok' => $signatureOk,
-                        'requested_sku' => $normalizedSkuMeta['requested_sku'] ?? null,
-                        'effective_sku' => $normalizedSkuMeta['effective_sku'] ?? null,
-                        'entitlement_id' => $normalizedSkuMeta['entitlement_id'] ?? null,
-                    ]);
-
-                    $eventUserId = $orderMeta['user_id'] ?? $userId;
-                    $eventMeta = $this->buildEventMeta($orderMeta, [
-                        'provider' => $provider,
-                        'provider_event_id' => $providerEventId,
-                        'order_no' => $orderNo,
-                    ]);
-                    $eventContext = $this->buildEventContext($orderMeta, $anonId);
-
-                    if ($isRefundEvent) {
-                        $refund = $this->handleRefund($orderNo, $order, $normalized, $providerEventId, $orgId);
-                        if (! ($refund['ok'] ?? false)) {
-                            $this->markEventError(
-                                $provider,
-                                $providerEventId,
-                                'failed',
-                                (string) ($refund['error'] ?? 'REFUND_FAILED'),
-                                (string) ($refund['message'] ?? 'refund failed.')
-                            );
-
-                            return $refund;
-                        }
-                        $this->markEventProcessed($provider, $providerEventId);
-
-                        return $refund;
-                    }
-
-                    $effectiveSku = strtoupper((string) ($normalizedSkuMeta['effective_sku']
-                        ?? $order->effective_sku
-                        ?? $order->sku
-                        ?? $order->item_sku
-                        ?? ''));
-                    if ($effectiveSku === '') {
-                        $this->markEventError($provider, $providerEventId, 'failed', 'SKU_NOT_FOUND', 'sku missing on order.');
-
-                        return $this->badRequest('SKU_NOT_FOUND', 'sku missing on order.');
-                    }
-
-                    $skuRow = $this->skus->getActiveSku($effectiveSku);
-                    if (! $skuRow) {
-                        $this->markEventError($provider, $providerEventId, 'failed', 'SKU_NOT_FOUND', 'sku not found.');
-
-                        return $this->notFound('SKU_NOT_FOUND', 'sku not found.');
-                    }
-
-                    $guard = $this->validatePaidEventGuard($provider, $eventType, $normalized, $order);
-                    if (! ($guard['ok'] ?? false)) {
-                        $this->markEventError(
-                            $provider,
-                            $providerEventId,
-                            'rejected',
-                            (string) ($guard['code'] ?? 'WEBHOOK_REJECTED'),
-                            (string) ($guard['message'] ?? 'webhook rejected.')
-                        );
-
-                        return $this->notFound('NOT_FOUND', 'not found.');
-                    }
-
-                    if (! $orderAlreadySettled) {
-                        $orderTransition = $this->orders->transitionToPaidAtomic(
-                            $orderNo,
-                            $orgId,
-                            $normalized['external_trade_no'] ?? null,
-                            $normalized['paid_at'] ?? null
-                        );
-                        if (! ($orderTransition['ok'] ?? false)) {
-                            $this->markEventError(
-                                $provider,
-                                $providerEventId,
-                                'failed',
-                                (string) ($orderTransition['error'] ?? 'ORDER_STATUS_INVALID'),
-                                (string) ($orderTransition['message'] ?? 'order transition failed.')
-                            );
-
-                            return $orderTransition;
-                        }
-                    }
-
-                    $updateRow = [
-                        'updated_at' => now(),
-                        'requested_sku' => $normalizedSkuMeta['requested_sku'] ?? ($order->requested_sku ?? null),
-                        'effective_sku' => $normalizedSkuMeta['effective_sku'] ?? ($order->effective_sku ?? null),
-                        'entitlement_id' => $normalizedSkuMeta['entitlement_id'] ?? ($order->entitlement_id ?? null),
-                    ];
-                    $externalTradeNo = $normalized['external_trade_no'] ?? null;
-                    if ($externalTradeNo) {
-                        $updateRow['external_trade_no'] = $externalTradeNo;
-                    }
-
-                    if (count($updateRow) > 1) {
-                        $skuMetaForOrder = $this->decodeMeta($skuRow->meta_json ?? null);
-                        $modulesIncludedForOrder = $this->normalizeModulesIncluded($skuMetaForOrder['modules_included'] ?? null);
-                        if ($modulesIncludedForOrder !== []) {
-                            $orderMeta = $this->decodeMeta($order->meta_json ?? null);
-                            $orderMeta['modules_included'] = $modulesIncludedForOrder;
-                            $updateRow['meta_json'] = json_encode($orderMeta, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES);
+                        $eventRow = DB::table('payment_events')
+                            ->where('provider', $provider)
+                            ->where('provider_event_id', $providerEventId)
+                            ->lockForUpdate()
+                            ->first();
+                        if (! $eventRow) {
+                            return $this->serverError('EVENT_INIT_FAILED', 'payment event init failed.');
                         }
 
-                        DB::table('orders')
-                            ->where('order_no', $orderNo)
-                            ->update($updateRow);
-                    }
+                        if ($inserted === 0 && $this->isEventProcessed($eventRow)) {
+                            Log::info('PAYMENT_EVENT_ALREADY_PROCESSED', [
+                                'provider' => $provider,
+                                'provider_event_id' => $providerEventId,
+                                'order_id' => $eventRow->order_id ?? null,
+                            ]);
 
-                    $quantity = (int) ($order->quantity ?? 1);
-                    $benefitCode = strtoupper((string) ($skuRow->benefit_code ?? ''));
-                    $kind = (string) ($skuRow->kind ?? '');
-                    if ($benefitCode === '') {
-                        $this->markEventError(
-                            $provider,
-                            $providerEventId,
-                            'failed',
-                            'BENEFIT_CODE_NOT_FOUND',
-                            'benefit code missing on sku.'
-                        );
-
-                        return $this->badRequest('BENEFIT_CODE_NOT_FOUND', 'benefit code missing on sku.');
-                    }
-
-                    $attemptMeta = $this->resolveAttemptMeta((int) $order->org_id, (string) ($order->target_attempt_id ?? ''));
-                    $this->writePaymentEventScaleIdentity(
-                        $provider,
-                        $providerEventId,
-                        $attemptMeta
-                    );
-                    $eventBaseMeta = $this->buildEventMeta([
-                        'org_id' => (int) $order->org_id,
-                        'sku' => $effectiveSku,
-                        'benefit_code' => $benefitCode,
-                        'attempt' => $attemptMeta,
-                    ], [
-                        'order_no' => $orderNo,
-                        'provider_event_id' => $providerEventId,
-                    ]);
-                    $eventContext = $this->buildEventContext([
-                        'org_id' => (int) $order->org_id,
-                        'attempt' => $attemptMeta,
-                    ], $anonId);
-                    $eventUserId = $order->user_id ? (string) $order->user_id : $userId;
-
-                    $retryingPostCommitOnly = $inserted === 0
-                        && ! $this->isEventProcessed($eventRow)
-                        && $orderAlreadySettled;
-
-                    if ($kind === 'credit_pack') {
-                        $unitQty = (int) ($skuRow->unit_qty ?? 0);
-                        if (
-                            $unitQty <= 0
-                            || $quantity <= 0
-                            || $quantity > intdiv(2147483647, $unitQty)
-                        ) {
-                            $this->markEventError($provider, $providerEventId, 'failed', 'TOPUP_DELTA_INVALID', 'topup delta invalid.');
-
-                            return $this->badRequest('TOPUP_DELTA_INVALID', 'topup delta invalid.');
-                        }
-
-                        $postCommitCtx = [
-                            'kind' => 'credit_pack',
-                            'org_id' => (int) $order->org_id,
-                            'provider' => $provider,
-                            'provider_event_id' => $providerEventId,
-                            'order_no' => $orderNo,
-                            'benefit_code' => $benefitCode,
-                            'topup_delta' => $unitQty * $quantity,
-                            'event_user_id' => $eventUserId,
-                            'event_meta' => $eventBaseMeta,
-                            'event_context' => $eventContext,
-                            'received_event_meta' => $eventMeta,
-                            'received_event_context' => $eventContext,
-                        ];
-                    } elseif ($kind === 'report_unlock') {
-                        $attemptId = (string) ($order->target_attempt_id ?? '');
-                        if ($attemptId === '') {
-                            $this->markEventError($provider, $providerEventId, 'failed', 'ATTEMPT_REQUIRED', 'target_attempt_id is required.');
-
-                            return $this->badRequest('ATTEMPT_REQUIRED', 'target_attempt_id is required for report_unlock.');
-                        }
-
-                        $ownerGuard = $this->validateAttemptOwnershipForOrder($order, $attemptMeta);
-                        if (!($ownerGuard['ok'] ?? false)) {
-                            $code = (string) ($ownerGuard['error'] ?? 'ATTEMPT_OWNER_MISMATCH');
-                            $message = (string) ($ownerGuard['message'] ?? 'order owner mismatch.');
-                            $this->markEventError($provider, $providerEventId, 'rejected', $code, $message);
-
-                            return $this->badRequest($code, $message);
-                        }
-
-                        $scaleGuard = $this->validateAttemptScaleForSku($skuRow, $attemptMeta);
-                        if (!($scaleGuard['ok'] ?? false)) {
-                            $code = (string) ($scaleGuard['error'] ?? 'ATTEMPT_SCALE_MISMATCH');
-                            $message = (string) ($scaleGuard['message'] ?? 'attempt scale does not match sku scale.');
-                            $this->markEventError($provider, $providerEventId, 'rejected', $code, $message);
-
-                            return $this->badRequest($code, $message);
-                        }
-
-                        if (! $retryingPostCommitOnly) {
-                            $scopeOverride = trim((string) ($skuRow->scope ?? ''));
-                            if ($scopeOverride === '') {
-                                $scopeOverride = 'attempt';
-                            }
-
-                            $expiresAt = null;
-                            $skuMeta = $this->decodeMeta($skuRow->meta_json ?? null);
-                            $modulesIncluded = $this->normalizeModulesIncluded($skuMeta['modules_included'] ?? null);
-                            if ($skuMeta !== []) {
-                                $durationDays = isset($skuMeta['duration_days']) ? (int) $skuMeta['duration_days'] : 0;
-                                if ($durationDays > 0) {
-                                    $expiresAt = now()->addDays($durationDays)->toISOString();
-                                }
-                            }
-
-                            $grant = $this->entitlements->grantAttemptUnlock(
-                                (int) $order->org_id,
-                                $order->user_id ? (string) $order->user_id : $userId,
-                                $order->anon_id ? (string) $order->anon_id : $anonId,
-                                $benefitCode,
-                                $attemptId,
-                                $orderNo,
-                                $scopeOverride,
-                                $expiresAt,
-                                $modulesIncluded
-                            );
-
-                            if (! ($grant['ok'] ?? false)) {
-                                $this->markEventError(
-                                    $provider,
-                                    $providerEventId,
-                                    'failed',
-                                    (string) ($grant['error'] ?? 'ENTITLEMENT_FAILED'),
-                                    (string) ($grant['message'] ?? 'entitlement grant failed.')
-                                );
-
-                                return $grant;
-                            }
-                        }
-
-                        $postCommitCtx = [
-                            'kind' => 'report_unlock',
-                            'org_id' => (int) $order->org_id,
-                            'provider' => $provider,
-                            'provider_event_id' => $providerEventId,
-                            'order_no' => $orderNo,
-                            'attempt_id' => $attemptId,
-                            'event_user_id' => $eventUserId,
-                            'event_meta' => $eventBaseMeta,
-                            'event_context' => $eventContext,
-                            'received_event_meta' => $eventMeta,
-                            'received_event_context' => $eventContext,
-                            'snapshot_meta' => [
-                                'scale_code' => (string) ($attemptMeta['scale_code'] ?? ''),
-                                'scale_code_v2' => (string) ($attemptMeta['scale_code_v2'] ?? ''),
-                                'scale_uid' => (string) ($attemptMeta['scale_uid'] ?? ''),
-                                'pack_id' => (string) ($attemptMeta['pack_id'] ?? ''),
-                                'dir_version' => (string) ($attemptMeta['dir_version'] ?? ''),
-                                'scoring_spec_version' => (string) ($attemptMeta['scoring_spec_version'] ?? ''),
-                            ],
-                        ];
-                    } else {
-                        $this->markEventError($provider, $providerEventId, 'failed', 'SKU_KIND_INVALID', 'unsupported sku kind.');
-
-                        return $this->badRequest('SKU_KIND_INVALID', 'unsupported sku kind.');
-                    }
-
-                    if ($orderAlreadySettled) {
-                        if ($retryingPostCommitOnly) {
                             return [
                                 'ok' => true,
-                                'duplicate' => false,
+                                'duplicate' => true,
                                 'order_no' => $orderNo,
                                 'provider_event_id' => $providerEventId,
                             ];
                         }
 
-                        Log::info('PAYMENT_EVENT_ALREADY_PROCESSED', [
+                        $attempts = (int) ($eventRow->attempts ?? 0);
+                        $attempts = $attempts > 0 ? $attempts + 1 : 1;
+
+                        $baseRow = [
                             'provider' => $provider,
                             'provider_event_id' => $providerEventId,
+                            'order_id' => $eventRow->order_id ?? ($insertSeed['order_id'] ?? (string) Str::uuid()),
+                            'event_type' => $eventType,
+                            'order_no' => $orderNo,
+                            'payload_json' => $payloadSummaryJson,
+                            'signature_ok' => $signatureOk,
+                            'status' => 'received',
+                            'attempts' => $attempts,
+                            'last_error_code' => null,
+                            'last_error_message' => null,
+                            'processed_at' => null,
+                            'handled_at' => null,
+                            'handle_status' => null,
+                            'payload_size_bytes' => $resolvedPayloadMeta['size_bytes'],
+                            'payload_sha256' => $resolvedPayloadMeta['sha256'],
+                            'payload_s3_key' => $resolvedPayloadMeta['s3_key'],
+                            'payload_excerpt' => $payloadExcerpt,
+                            'received_at' => $receivedAt,
+                            'updated_at' => $receivedAt,
+                        ];
+
+                        DB::table('payment_events')
+                            ->where('provider', $provider)
+                            ->where('provider_event_id', $providerEventId)
+                            ->update($baseRow);
+
+                        if ($signatureOk !== true) {
+                            $this->markEventError($provider, $providerEventId, 'rejected', 'INVALID_SIGNATURE', 'signature invalid.');
+
+                            return $this->badRequest('INVALID_SIGNATURE', 'invalid signature.');
+                        }
+
+                        $orderQuery = DB::table('orders')
+                            ->where('order_no', $orderNo)
+                            ->where('org_id', $orgId);
+
+                        $order = $orderQuery->lockForUpdate()->first();
+                        if (! $order) {
+                            $this->markEventError($provider, $providerEventId, 'orphan', 'ORDER_NOT_FOUND', 'order not found.');
+
+                            return $this->notFound('ORDER_NOT_FOUND', 'not found.');
+                        }
+
+                        $orderProvider = strtolower(trim((string) ($order->provider ?? '')));
+                        $webhookProvider = strtolower(trim((string) $provider));
+                        if ($orderProvider !== $webhookProvider) {
+                            $detail = "order.provider={$orderProvider}; webhook.provider={$webhookProvider}";
+
+                            Log::warning('PAYMENT_EVENT_PROVIDER_MISMATCH', [
+                                'provider' => $provider,
+                                'order_provider' => $orderProvider !== '' ? $orderProvider : null,
+                                'provider_event_id' => $providerEventId,
+                                'order_no' => $orderNo,
+                                'order_id' => $order->id ?? null,
+                            ]);
+
+                            $this->markEventError(
+                                $provider,
+                                $providerEventId,
+                                'rejected',
+                                'rejected_provider_mismatch',
+                                $detail
+                            );
+
+                            return $this->badRequest('PROVIDER_MISMATCH', 'provider mismatch');
+                        }
+
+                        $isRefundEvent = $this->isRefundEvent($eventType, $normalized);
+                        $orderStatus = strtolower((string) ($order->status ?? ''));
+                        $orderAlreadySettled = ! $isRefundEvent
+                            && in_array($orderStatus, ['paid', 'fulfilled', 'completed', 'delivered', 'refunded'], true);
+
+                        $orderMeta = $this->resolveOrderMeta($orgId, $orderNo, $order);
+                        $normalizedSkuMeta = $this->normalizeOrderSkuMeta($order);
+                        $this->updatePaymentEvent($provider, $providerEventId, [
                             'order_id' => $order->id ?? null,
+                            'event_type' => $eventType,
+                            'signature_ok' => $signatureOk,
+                            'requested_sku' => $normalizedSkuMeta['requested_sku'] ?? null,
+                            'effective_sku' => $normalizedSkuMeta['effective_sku'] ?? null,
+                            'entitlement_id' => $normalizedSkuMeta['entitlement_id'] ?? null,
                         ]);
 
-                        $this->markEventProcessed($provider, $providerEventId);
+                        $eventUserId = $orderMeta['user_id'] ?? $userId;
+                        $eventMeta = $this->buildEventMeta($orderMeta, [
+                            'provider' => $provider,
+                            'provider_event_id' => $providerEventId,
+                            'order_no' => $orderNo,
+                        ]);
+                        $eventContext = $this->buildEventContext($orderMeta, $anonId);
+
+                        if ($isRefundEvent) {
+                            $refund = $this->handleRefund($orderNo, $order, $normalized, $providerEventId, $orgId);
+                            if (! ($refund['ok'] ?? false)) {
+                                $this->markEventError(
+                                    $provider,
+                                    $providerEventId,
+                                    'failed',
+                                    (string) ($refund['error'] ?? 'REFUND_FAILED'),
+                                    (string) ($refund['message'] ?? 'refund failed.')
+                                );
+
+                                return $refund;
+                            }
+                            $this->markEventProcessed($provider, $providerEventId);
+
+                            return $refund;
+                        }
+
+                        $effectiveSku = strtoupper((string) ($normalizedSkuMeta['effective_sku']
+                            ?? $order->effective_sku
+                            ?? $order->sku
+                            ?? $order->item_sku
+                            ?? ''));
+                        if ($effectiveSku === '') {
+                            $this->markEventError($provider, $providerEventId, 'failed', 'SKU_NOT_FOUND', 'sku missing on order.');
+
+                            return $this->badRequest('SKU_NOT_FOUND', 'sku missing on order.');
+                        }
+
+                        $skuRow = $this->skus->getActiveSku($effectiveSku);
+                        if (! $skuRow) {
+                            $this->markEventError($provider, $providerEventId, 'failed', 'SKU_NOT_FOUND', 'sku not found.');
+
+                            return $this->notFound('SKU_NOT_FOUND', 'sku not found.');
+                        }
+
+                        $guard = $this->validatePaidEventGuard($provider, $eventType, $normalized, $order);
+                        if (! ($guard['ok'] ?? false)) {
+                            $this->markEventError(
+                                $provider,
+                                $providerEventId,
+                                'rejected',
+                                (string) ($guard['code'] ?? 'WEBHOOK_REJECTED'),
+                                (string) ($guard['message'] ?? 'webhook rejected.')
+                            );
+
+                            return $this->notFound('NOT_FOUND', 'not found.');
+                        }
+
+                        if (! $orderAlreadySettled) {
+                            $orderTransition = $this->orders->transitionToPaidAtomic(
+                                $orderNo,
+                                $orgId,
+                                $normalized['external_trade_no'] ?? null,
+                                $normalized['paid_at'] ?? null
+                            );
+                            if (! ($orderTransition['ok'] ?? false)) {
+                                $this->markEventError(
+                                    $provider,
+                                    $providerEventId,
+                                    'failed',
+                                    (string) ($orderTransition['error'] ?? 'ORDER_STATUS_INVALID'),
+                                    (string) ($orderTransition['message'] ?? 'order transition failed.')
+                                );
+
+                                return $orderTransition;
+                            }
+                        }
+
+                        $updateRow = [
+                            'updated_at' => now(),
+                            'requested_sku' => $normalizedSkuMeta['requested_sku'] ?? ($order->requested_sku ?? null),
+                            'effective_sku' => $normalizedSkuMeta['effective_sku'] ?? ($order->effective_sku ?? null),
+                            'entitlement_id' => $normalizedSkuMeta['entitlement_id'] ?? ($order->entitlement_id ?? null),
+                        ];
+                        $externalTradeNo = $normalized['external_trade_no'] ?? null;
+                        if ($externalTradeNo) {
+                            $updateRow['external_trade_no'] = $externalTradeNo;
+                        }
+
+                        if (count($updateRow) > 1) {
+                            $skuMetaForOrder = $this->decodeMeta($skuRow->meta_json ?? null);
+                            $modulesIncludedForOrder = $this->normalizeModulesIncluded($skuMetaForOrder['modules_included'] ?? null);
+                            if ($modulesIncludedForOrder !== []) {
+                                $orderMeta = $this->decodeMeta($order->meta_json ?? null);
+                                $orderMeta['modules_included'] = $modulesIncludedForOrder;
+                                $updateRow['meta_json'] = json_encode($orderMeta, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES);
+                            }
+
+                            DB::table('orders')
+                                ->where('order_no', $orderNo)
+                                ->update($updateRow);
+                        }
+
+                        $quantity = (int) ($order->quantity ?? 1);
+                        $benefitCode = strtoupper((string) ($skuRow->benefit_code ?? ''));
+                        $kind = (string) ($skuRow->kind ?? '');
+                        if ($benefitCode === '') {
+                            $this->markEventError(
+                                $provider,
+                                $providerEventId,
+                                'failed',
+                                'BENEFIT_CODE_NOT_FOUND',
+                                'benefit code missing on sku.'
+                            );
+
+                            return $this->badRequest('BENEFIT_CODE_NOT_FOUND', 'benefit code missing on sku.');
+                        }
+
+                        $attemptMeta = $this->resolveAttemptMeta((int) $order->org_id, (string) ($order->target_attempt_id ?? ''));
+                        $this->writePaymentEventScaleIdentity(
+                            $provider,
+                            $providerEventId,
+                            $attemptMeta
+                        );
+                        $eventBaseMeta = $this->buildEventMeta([
+                            'org_id' => (int) $order->org_id,
+                            'sku' => $effectiveSku,
+                            'benefit_code' => $benefitCode,
+                            'attempt' => $attemptMeta,
+                        ], [
+                            'order_no' => $orderNo,
+                            'provider_event_id' => $providerEventId,
+                        ]);
+                        $eventContext = $this->buildEventContext([
+                            'org_id' => (int) $order->org_id,
+                            'attempt' => $attemptMeta,
+                        ], $anonId);
+                        $eventUserId = $order->user_id ? (string) $order->user_id : $userId;
+
+                        $retryingPostCommitOnly = $inserted === 0
+                            && ! $this->isEventProcessed($eventRow)
+                            && $orderAlreadySettled;
+
+                        if ($kind === 'credit_pack') {
+                            $unitQty = (int) ($skuRow->unit_qty ?? 0);
+                            if (
+                                $unitQty <= 0
+                                || $quantity <= 0
+                                || $quantity > intdiv(2147483647, $unitQty)
+                            ) {
+                                $this->markEventError($provider, $providerEventId, 'failed', 'TOPUP_DELTA_INVALID', 'topup delta invalid.');
+
+                                return $this->badRequest('TOPUP_DELTA_INVALID', 'topup delta invalid.');
+                            }
+
+                            $postCommitCtx = [
+                                'kind' => 'credit_pack',
+                                'org_id' => (int) $order->org_id,
+                                'provider' => $provider,
+                                'provider_event_id' => $providerEventId,
+                                'order_no' => $orderNo,
+                                'benefit_code' => $benefitCode,
+                                'topup_delta' => $unitQty * $quantity,
+                                'event_user_id' => $eventUserId,
+                                'event_meta' => $eventBaseMeta,
+                                'event_context' => $eventContext,
+                                'received_event_meta' => $eventMeta,
+                                'received_event_context' => $eventContext,
+                            ];
+                        } elseif ($kind === 'report_unlock') {
+                            $attemptId = (string) ($order->target_attempt_id ?? '');
+                            if ($attemptId === '') {
+                                $this->markEventError($provider, $providerEventId, 'failed', 'ATTEMPT_REQUIRED', 'target_attempt_id is required.');
+
+                                return $this->badRequest('ATTEMPT_REQUIRED', 'target_attempt_id is required for report_unlock.');
+                            }
+
+                            $ownerGuard = $this->validateAttemptOwnershipForOrder($order, $attemptMeta);
+                            if (! ($ownerGuard['ok'] ?? false)) {
+                                $code = (string) ($ownerGuard['error'] ?? 'ATTEMPT_OWNER_MISMATCH');
+                                $message = (string) ($ownerGuard['message'] ?? 'order owner mismatch.');
+                                $this->markEventError($provider, $providerEventId, 'rejected', $code, $message);
+
+                                return $this->badRequest($code, $message);
+                            }
+
+                            $scaleGuard = $this->validateAttemptScaleForSku($skuRow, $attemptMeta);
+                            if (! ($scaleGuard['ok'] ?? false)) {
+                                $code = (string) ($scaleGuard['error'] ?? 'ATTEMPT_SCALE_MISMATCH');
+                                $message = (string) ($scaleGuard['message'] ?? 'attempt scale does not match sku scale.');
+                                $this->markEventError($provider, $providerEventId, 'rejected', $code, $message);
+
+                                return $this->badRequest($code, $message);
+                            }
+
+                            if (! $retryingPostCommitOnly) {
+                                $scopeOverride = trim((string) ($skuRow->scope ?? ''));
+                                if ($scopeOverride === '') {
+                                    $scopeOverride = 'attempt';
+                                }
+
+                                $expiresAt = null;
+                                $skuMeta = $this->decodeMeta($skuRow->meta_json ?? null);
+                                $modulesIncluded = $this->normalizeModulesIncluded($skuMeta['modules_included'] ?? null);
+                                if ($skuMeta !== []) {
+                                    $durationDays = isset($skuMeta['duration_days']) ? (int) $skuMeta['duration_days'] : 0;
+                                    if ($durationDays > 0) {
+                                        $expiresAt = now()->addDays($durationDays)->toISOString();
+                                    }
+                                }
+
+                                $grant = $this->entitlements->grantAttemptUnlock(
+                                    (int) $order->org_id,
+                                    $order->user_id ? (string) $order->user_id : $userId,
+                                    $order->anon_id ? (string) $order->anon_id : $anonId,
+                                    $benefitCode,
+                                    $attemptId,
+                                    $orderNo,
+                                    $scopeOverride,
+                                    $expiresAt,
+                                    $modulesIncluded
+                                );
+
+                                if (! ($grant['ok'] ?? false)) {
+                                    $this->markEventError(
+                                        $provider,
+                                        $providerEventId,
+                                        'failed',
+                                        (string) ($grant['error'] ?? 'ENTITLEMENT_FAILED'),
+                                        (string) ($grant['message'] ?? 'entitlement grant failed.')
+                                    );
+
+                                    return $grant;
+                                }
+                            }
+
+                            $postCommitCtx = [
+                                'kind' => 'report_unlock',
+                                'org_id' => (int) $order->org_id,
+                                'provider' => $provider,
+                                'provider_event_id' => $providerEventId,
+                                'order_no' => $orderNo,
+                                'attempt_id' => $attemptId,
+                                'event_user_id' => $eventUserId,
+                                'event_meta' => $eventBaseMeta,
+                                'event_context' => $eventContext,
+                                'received_event_meta' => $eventMeta,
+                                'received_event_context' => $eventContext,
+                                'snapshot_meta' => [
+                                    'scale_code' => (string) ($attemptMeta['scale_code'] ?? ''),
+                                    'scale_code_v2' => (string) ($attemptMeta['scale_code_v2'] ?? ''),
+                                    'scale_uid' => (string) ($attemptMeta['scale_uid'] ?? ''),
+                                    'pack_id' => (string) ($attemptMeta['pack_id'] ?? ''),
+                                    'dir_version' => (string) ($attemptMeta['dir_version'] ?? ''),
+                                    'scoring_spec_version' => (string) ($attemptMeta['scoring_spec_version'] ?? ''),
+                                ],
+                            ];
+                        } else {
+                            $this->markEventError($provider, $providerEventId, 'failed', 'SKU_KIND_INVALID', 'unsupported sku kind.');
+
+                            return $this->badRequest('SKU_KIND_INVALID', 'unsupported sku kind.');
+                        }
+
+                        if ($orderAlreadySettled) {
+                            if ($retryingPostCommitOnly) {
+                                return [
+                                    'ok' => true,
+                                    'duplicate' => false,
+                                    'order_no' => $orderNo,
+                                    'provider_event_id' => $providerEventId,
+                                ];
+                            }
+
+                            Log::info('PAYMENT_EVENT_ALREADY_PROCESSED', [
+                                'provider' => $provider,
+                                'provider_event_id' => $providerEventId,
+                                'order_id' => $order->id ?? null,
+                            ]);
+
+                            $this->markEventProcessed($provider, $providerEventId);
+
+                            return [
+                                'ok' => true,
+                                'duplicate' => true,
+                                'order_no' => $orderNo,
+                                'provider_event_id' => $providerEventId,
+                            ];
+                        }
+
+                        $fulfilled = $this->orders->transition($orderNo, 'fulfilled', $orgId);
+                        if (! ($fulfilled['ok'] ?? false)) {
+                            $this->markEventError(
+                                $provider,
+                                $providerEventId,
+                                'failed',
+                                (string) ($fulfilled['error'] ?? 'ORDER_STATUS_INVALID'),
+                                (string) ($fulfilled['message'] ?? 'order transition failed.')
+                            );
+
+                            return $fulfilled;
+                        }
 
                         return [
                             'ok' => true,
-                            'duplicate' => true,
                             'order_no' => $orderNo,
                             'provider_event_id' => $providerEventId,
                         ];
-                    }
-
-                    $fulfilled = $this->orders->transition($orderNo, 'fulfilled', $orgId);
-                    if (! ($fulfilled['ok'] ?? false)) {
-                        $this->markEventError(
-                            $provider,
-                            $providerEventId,
-                            'failed',
-                            (string) ($fulfilled['error'] ?? 'ORDER_STATUS_INVALID'),
-                            (string) ($fulfilled['message'] ?? 'order transition failed.')
-                        );
-
-                        return $fulfilled;
-                    }
-
-                    return [
-                        'ok' => true,
-                        'order_no' => $orderNo,
-                        'provider_event_id' => $providerEventId,
-                    ];
                     });
                 });
             });
@@ -677,7 +677,7 @@ class PaymentWebhookHandlerCore
     }
 
     /**
-     * @param callable():array<string,mixed> $callback
+     * @param  callable():array<string,mixed>  $callback
      * @return array<string,mixed>
      */
     private function runWithTransientDbRetry(callable $callback): array
@@ -939,7 +939,7 @@ class PaymentWebhookHandlerCore
                         ]);
                     }
 
-                    if (!$this->isCrisisAttempt($orgId, $attemptId)) {
+                    if (! $this->isCrisisAttempt($orgId, $attemptId)) {
                         $this->queueBigFiveUnlockEmail(
                             $orgId,
                             $attemptId,
@@ -1128,6 +1128,7 @@ class PaymentWebhookHandlerCore
 
         if ($scaleCode === 'CLINICAL_COMBO_68') {
             app(ClinicalComboTelemetry::class)->unlocked($attempt, $meta);
+
             return;
         }
 
@@ -1425,7 +1426,7 @@ class PaymentWebhookHandlerCore
     }
 
     /**
-     * @param array<string,mixed> $attemptMeta
+     * @param  array<string,mixed>  $attemptMeta
      * @return array{ok:bool,error?:string,message?:string}
      */
     private function validateAttemptOwnershipForOrder(object $order, array $attemptMeta): array
@@ -1472,7 +1473,7 @@ class PaymentWebhookHandlerCore
     }
 
     /**
-     * @param array<string,mixed> $attemptMeta
+     * @param  array<string,mixed>  $attemptMeta
      * @return array{ok:bool,error?:string,message?:string}
      */
     private function validateAttemptScaleForSku(object $skuRow, array $attemptMeta): array
@@ -1548,7 +1549,7 @@ class PaymentWebhookHandlerCore
     }
 
     /**
-     * @param array<string,mixed> $attemptMeta
+     * @param  array<string,mixed>  $attemptMeta
      */
     private function writePaymentEventScaleIdentity(string $provider, string $providerEventId, array $attemptMeta): void
     {
@@ -1588,7 +1589,7 @@ class PaymentWebhookHandlerCore
     }
 
     /**
-     * @param array<string,mixed> $attemptMeta
+     * @param  array<string,mixed>  $attemptMeta
      * @return array{scale_code_v2:string|null,scale_uid:string|null}
      */
     private function resolveScaleIdentityForPaymentEvent(array $attemptMeta): array
@@ -1744,13 +1745,13 @@ class PaymentWebhookHandlerCore
             ->where('org_id', $orgId)
             ->where('attempt_id', $attemptId)
             ->first();
-        if (!$result) {
+        if (! $result) {
             return false;
         }
 
         $payload = $result->result_json ?? null;
-        if (!is_array($payload)) {
-            if (!is_string($payload) || trim($payload) === '') {
+        if (! is_array($payload)) {
+            if (! is_string($payload) || trim($payload) === '') {
                 return false;
             }
             $decoded = json_decode($payload, true);
@@ -1764,7 +1765,7 @@ class PaymentWebhookHandlerCore
             $payload,
         ];
         foreach ($candidates as $candidate) {
-            if (!is_array($candidate)) {
+            if (! is_array($candidate)) {
                 continue;
             }
             $quality = is_array($candidate['quality'] ?? null) ? $candidate['quality'] : [];

--- a/backend/app/Internal/Commerce/PaymentWebhookHandlerCore.php
+++ b/backend/app/Internal/Commerce/PaymentWebhookHandlerCore.php
@@ -661,14 +661,23 @@ class PaymentWebhookHandlerCore
             }
 
             $normalizedResult = $this->normalizeResultStatus($result);
-            $this->emitBigFiveWebhookTelemetry(
-                $normalizedResult,
-                is_array($postCommitCtx) ? $postCommitCtx : null,
-                $orgId,
-                $provider,
-                $providerEventId,
-                $orderNo
-            );
+            try {
+                $this->emitBigFiveWebhookTelemetry(
+                    $normalizedResult,
+                    is_array($postCommitCtx) ? $postCommitCtx : null,
+                    $orgId,
+                    $provider,
+                    $providerEventId,
+                    $orderNo
+                );
+            } catch (\Throwable $e) {
+                Log::warning('PAYMENT_WEBHOOK_TELEMETRY_FAILED', [
+                    'provider' => $provider,
+                    'provider_event_id' => $providerEventId,
+                    'order_no' => $orderNo,
+                    'error_message' => $e->getMessage(),
+                ]);
+            }
 
             return $normalizedResult;
         } catch (LockTimeoutException $e) {
@@ -676,11 +685,7 @@ class PaymentWebhookHandlerCore
         }
     }
 
-    /**
-     * @param  callable():array<string,mixed>  $callback
-     * @return array<string,mixed>
-     */
-    private function runWithTransientDbRetry(callable $callback): array
+    private function runWithTransientDbRetry(callable $callback): mixed
     {
         $attempt = 0;
 
@@ -1392,10 +1397,14 @@ class PaymentWebhookHandlerCore
             return;
         }
 
-        DB::table('payment_events')
-            ->where('provider', $provider)
-            ->where('provider_event_id', $providerEventId)
-            ->update($updates);
+        $this->runWithTransientDbRetry(function () use ($provider, $providerEventId, $updates): bool {
+            DB::table('payment_events')
+                ->where('provider', $provider)
+                ->where('provider_event_id', $providerEventId)
+                ->update($updates);
+
+            return true;
+        });
     }
 
     private function markEventProcessed(string $provider, string $providerEventId): void

--- a/backend/app/Internal/Commerce/PaymentWebhookHandlerCore.php
+++ b/backend/app/Internal/Commerce/PaymentWebhookHandlerCore.php
@@ -32,6 +32,10 @@ class PaymentWebhookHandlerCore
 
     private const DEFAULT_WEBHOOK_LOCK_BLOCK_SECONDS = 5;
 
+    private const TRANSIENT_DB_RETRY_MAX_ATTEMPTS = 3;
+
+    private const TRANSIENT_DB_RETRY_BASE_USLEEP = 100000;
+
     /** @var array<string, PaymentGatewayInterface> */
     private array $gateways = [];
 
@@ -114,7 +118,10 @@ class PaymentWebhookHandlerCore
         $postCommitCtx = null;
 
         try {
-            $result = Cache::lock($lockKey, $lockTtl)->block($lockBlock, function () use (
+            $result = $this->runWithTransientDbRetry(function () use (
+                $lockKey,
+                $lockTtl,
+                $lockBlock,
                 $orderNo,
                 $normalized,
                 $providerEventId,
@@ -130,7 +137,7 @@ class PaymentWebhookHandlerCore
                 $signatureOk,
                 &$postCommitCtx
             ) {
-                return DB::transaction(function () use (
+                return Cache::lock($lockKey, $lockTtl)->block($lockBlock, function () use (
                     $orderNo,
                     $normalized,
                     $providerEventId,
@@ -146,6 +153,22 @@ class PaymentWebhookHandlerCore
                     $signatureOk,
                     &$postCommitCtx
                 ) {
+                    return DB::transaction(function () use (
+                        $orderNo,
+                        $normalized,
+                        $providerEventId,
+                        $provider,
+                        $orgId,
+                        $userId,
+                        $anonId,
+                        $eventType,
+                        $receivedAt,
+                        $payloadSummaryJson,
+                        $payloadExcerpt,
+                        $resolvedPayloadMeta,
+                        $signatureOk,
+                        &$postCommitCtx
+                    ) {
                     $insertSeed = [
                         'id' => (string) Str::uuid(),
                         'provider' => $provider,
@@ -591,6 +614,7 @@ class PaymentWebhookHandlerCore
                         'order_no' => $orderNo,
                         'provider_event_id' => $providerEventId,
                     ];
+                    });
                 });
             });
 
@@ -650,6 +674,54 @@ class PaymentWebhookHandlerCore
         } catch (LockTimeoutException $e) {
             return $this->serverError('WEBHOOK_BUSY', 'payment webhook is busy, retry later.');
         }
+    }
+
+    /**
+     * @param callable():array<string,mixed> $callback
+     * @return array<string,mixed>
+     */
+    private function runWithTransientDbRetry(callable $callback): array
+    {
+        $attempt = 0;
+
+        while (true) {
+            try {
+                return $callback();
+            } catch (\Throwable $e) {
+                $attempt++;
+
+                if (! $this->isTransientDatabaseFailure($e) || $attempt >= self::TRANSIENT_DB_RETRY_MAX_ATTEMPTS) {
+                    throw $e;
+                }
+
+                usleep(self::TRANSIENT_DB_RETRY_BASE_USLEEP * $attempt);
+            }
+        }
+    }
+
+    private function isTransientDatabaseFailure(\Throwable $e): bool
+    {
+        $message = strtolower(trim($e->getMessage()));
+        if ($message === '') {
+            return false;
+        }
+
+        foreach ([
+            'database is locked',
+            'database table is locked',
+            'deadlock found',
+            'lock wait timeout exceeded',
+            'try restarting transaction',
+            'sqlstate[40001]',
+            'sqlstate[40p01]',
+            'sqlstate[hy000]',
+        ] as $needle) {
+            if (str_contains($message, $needle)) {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     public function evaluateDryRun(

--- a/backend/app/Internal/Commerce/PaymentWebhookHandlerCore.php
+++ b/backend/app/Internal/Commerce/PaymentWebhookHandlerCore.php
@@ -23,6 +23,7 @@ use Illuminate\Contracts\Cache\LockTimeoutException;
 use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Log;
+use Illuminate\Support\Facades\Schema;
 use Illuminate\Support\Str;
 
 class PaymentWebhookHandlerCore
@@ -402,6 +403,11 @@ class PaymentWebhookHandlerCore
                     }
 
                     $attemptMeta = $this->resolveAttemptMeta((int) $order->org_id, (string) ($order->target_attempt_id ?? ''));
+                    $this->writePaymentEventScaleIdentity(
+                        $provider,
+                        $providerEventId,
+                        $attemptMeta
+                    );
                     $eventBaseMeta = $this->buildEventMeta([
                         'org_id' => (int) $order->org_id,
                         'sku' => $effectiveSku,
@@ -528,6 +534,8 @@ class PaymentWebhookHandlerCore
                             'received_event_context' => $eventContext,
                             'snapshot_meta' => [
                                 'scale_code' => (string) ($attemptMeta['scale_code'] ?? ''),
+                                'scale_code_v2' => (string) ($attemptMeta['scale_code_v2'] ?? ''),
+                                'scale_uid' => (string) ($attemptMeta['scale_uid'] ?? ''),
                                 'pack_id' => (string) ($attemptMeta['pack_id'] ?? ''),
                                 'dir_version' => (string) ($attemptMeta['dir_version'] ?? ''),
                                 'scoring_spec_version' => (string) ($attemptMeta['scoring_spec_version'] ?? ''),
@@ -820,6 +828,8 @@ class PaymentWebhookHandlerCore
                 try {
                     $this->reportSnapshots->seedPendingSnapshot($orgId, $attemptId, $orderNo !== '' ? $orderNo : null, [
                         'scale_code' => (string) ($snapshotMeta['scale_code'] ?? ''),
+                        'scale_code_v2' => (string) ($snapshotMeta['scale_code_v2'] ?? ''),
+                        'scale_uid' => (string) ($snapshotMeta['scale_uid'] ?? ''),
                         'pack_id' => (string) ($snapshotMeta['pack_id'] ?? ''),
                         'dir_version' => (string) ($snapshotMeta['dir_version'] ?? ''),
                         'scoring_spec_version' => (string) ($snapshotMeta['scoring_spec_version'] ?? ''),
@@ -1424,6 +1434,8 @@ class PaymentWebhookHandlerCore
             return [
                 'attempt_id' => null,
                 'scale_code' => null,
+                'scale_code_v2' => null,
+                'scale_uid' => null,
                 'pack_id' => null,
                 'dir_version' => null,
                 'scoring_spec_version' => null,
@@ -1440,6 +1452,8 @@ class PaymentWebhookHandlerCore
             return [
                 'attempt_id' => null,
                 'scale_code' => null,
+                'scale_code_v2' => null,
+                'scale_uid' => null,
                 'pack_id' => null,
                 'dir_version' => null,
                 'scoring_spec_version' => null,
@@ -1451,11 +1465,100 @@ class PaymentWebhookHandlerCore
         return [
             'attempt_id' => (string) ($row->id ?? $attemptId),
             'scale_code' => (string) ($row->scale_code ?? ''),
+            'scale_code_v2' => (string) ($row->scale_code_v2 ?? ''),
+            'scale_uid' => (string) ($row->scale_uid ?? ''),
             'pack_id' => (string) ($row->pack_id ?? ''),
             'dir_version' => (string) ($row->dir_version ?? ''),
             'scoring_spec_version' => (string) ($row->scoring_spec_version ?? ''),
             'user_id' => isset($row->user_id) ? (string) ($row->user_id ?? '') : null,
             'anon_id' => isset($row->anon_id) ? (string) ($row->anon_id ?? '') : null,
+        ];
+    }
+
+    /**
+     * @param array<string,mixed> $attemptMeta
+     */
+    private function writePaymentEventScaleIdentity(string $provider, string $providerEventId, array $attemptMeta): void
+    {
+        if (! $this->shouldWriteScaleIdentityColumns()) {
+            return;
+        }
+
+        if (! Schema::hasTable('payment_events')
+            || ! Schema::hasColumn('payment_events', 'scale_code_v2')
+            || ! Schema::hasColumn('payment_events', 'scale_uid')) {
+            return;
+        }
+
+        $identity = $this->resolveScaleIdentityForPaymentEvent($attemptMeta);
+        $scaleCodeV2 = trim((string) ($identity['scale_code_v2'] ?? ''));
+        $scaleUid = trim((string) ($identity['scale_uid'] ?? ''));
+
+        if ($scaleCodeV2 === '' && $scaleUid === '') {
+            return;
+        }
+
+        DB::table('payment_events')
+            ->where('provider', $provider)
+            ->where('provider_event_id', $providerEventId)
+            ->update([
+                'scale_code_v2' => $scaleCodeV2 !== '' ? $scaleCodeV2 : null,
+                'scale_uid' => $scaleUid !== '' ? $scaleUid : null,
+                'updated_at' => now(),
+            ]);
+    }
+
+    private function shouldWriteScaleIdentityColumns(): bool
+    {
+        $mode = strtolower(trim((string) config('scale_identity.write_mode', 'legacy')));
+
+        return in_array($mode, ['dual', 'v2'], true);
+    }
+
+    /**
+     * @param array<string,mixed> $attemptMeta
+     * @return array{scale_code_v2:string|null,scale_uid:string|null}
+     */
+    private function resolveScaleIdentityForPaymentEvent(array $attemptMeta): array
+    {
+        $scaleCodeV2 = strtoupper(trim((string) ($attemptMeta['scale_code_v2'] ?? '')));
+        $scaleUid = trim((string) ($attemptMeta['scale_uid'] ?? ''));
+
+        if ($scaleCodeV2 !== '' && $scaleUid !== '') {
+            return [
+                'scale_code_v2' => $scaleCodeV2,
+                'scale_uid' => $scaleUid,
+            ];
+        }
+
+        $scaleCodeV1 = strtoupper(trim((string) ($attemptMeta['scale_code'] ?? '')));
+        if ($scaleCodeV1 === '') {
+            return [
+                'scale_code_v2' => $scaleCodeV2 !== '' ? $scaleCodeV2 : null,
+                'scale_uid' => $scaleUid !== '' ? $scaleUid : null,
+            ];
+        }
+
+        $v1ToV2 = (array) config('scale_identity.code_map_v1_to_v2', []);
+        $uidMap = (array) config('scale_identity.scale_uid_map', []);
+
+        if ($scaleCodeV2 === '') {
+            $mappedV2 = strtoupper(trim((string) ($v1ToV2[$scaleCodeV1] ?? '')));
+            if ($mappedV2 !== '') {
+                $scaleCodeV2 = $mappedV2;
+            }
+        }
+
+        if ($scaleUid === '') {
+            $mappedUid = trim((string) ($uidMap[$scaleCodeV1] ?? ''));
+            if ($mappedUid !== '') {
+                $scaleUid = $mappedUid;
+            }
+        }
+
+        return [
+            'scale_code_v2' => $scaleCodeV2 !== '' ? $scaleCodeV2 : null,
+            'scale_uid' => $scaleUid !== '' ? $scaleUid : null,
         ];
     }
 

--- a/backend/app/Models/Assessment.php
+++ b/backend/app/Models/Assessment.php
@@ -16,6 +16,8 @@ class Assessment extends Model
     protected $fillable = [
         'org_id',
         'scale_code',
+        'scale_code_v2',
+        'scale_uid',
         'title',
         'created_by',
         'due_at',

--- a/backend/app/Models/Attempt.php
+++ b/backend/app/Models/Attempt.php
@@ -74,6 +74,8 @@ class Attempt extends Model
         'user_id',
         'org_id',
         'scale_code',
+        'scale_code_v2',
+        'scale_uid',
         'scale_version',
         'region',
         'locale',

--- a/backend/app/Models/Event.php
+++ b/backend/app/Models/Event.php
@@ -32,6 +32,8 @@ class Event extends Model
 
         // funnel columns
         'scale_code',
+        'scale_code_v2',
+        'scale_uid',
         'scale_version',
         'channel',
         'region',

--- a/backend/app/Models/Order.php
+++ b/backend/app/Models/Order.php
@@ -38,6 +38,8 @@ class Order extends Model
         'created_ip',
         'idempotency_key',
         'target_attempt_id',
+        'scale_code_v2',
+        'scale_uid',
         'external_trade_no',
         'metadata',
         'meta_json',

--- a/backend/app/Models/PaymentEvent.php
+++ b/backend/app/Models/PaymentEvent.php
@@ -37,6 +37,8 @@ class PaymentEvent extends Model
         'reason',
         'requested_sku',
         'effective_sku',
+        'scale_code_v2',
+        'scale_uid',
         'entitlement_id',
         'payload_json',
         'payload_size_bytes',

--- a/backend/app/Models/ReportSnapshot.php
+++ b/backend/app/Models/ReportSnapshot.php
@@ -22,6 +22,8 @@ class ReportSnapshot extends Model
         'attempt_id',
         'order_no',
         'scale_code',
+        'scale_code_v2',
+        'scale_uid',
         'pack_id',
         'dir_version',
         'scoring_spec_version',

--- a/backend/app/Models/Result.php
+++ b/backend/app/Models/Result.php
@@ -30,6 +30,8 @@ class Result extends Model
         'attempt_id',
         'org_id',
         'scale_code',
+        'scale_code_v2',
+        'scale_uid',
         'scale_version',
         'type_code',
         'scores_json',

--- a/backend/app/Models/Share.php
+++ b/backend/app/Models/Share.php
@@ -15,6 +15,8 @@ class Share extends Model
         'attempt_id',
         'anon_id',
         'scale_code',
+        'scale_code_v2',
+        'scale_uid',
         'scale_version',
         'content_package_version',
     ];

--- a/backend/app/Services/Analytics/EventRecorder.php
+++ b/backend/app/Services/Analytics/EventRecorder.php
@@ -30,6 +30,18 @@ final class EventRecorder
         }
 
         $meta = $this->sanitizeMetaForStorage($eventCode, $meta);
+        $scaleCode = $this->resolveScaleIdentityString([
+            $meta['scale_code'] ?? null,
+            $context['scale_code'] ?? null,
+        ], true);
+        $scaleCodeV2 = $this->resolveScaleIdentityString([
+            $meta['scale_code_v2'] ?? null,
+            $context['scale_code_v2'] ?? null,
+        ], true);
+        $scaleUid = $this->resolveScaleIdentityString([
+            $meta['scale_uid'] ?? null,
+            $context['scale_uid'] ?? null,
+        ], false);
 
         $now = now();
         $payload = [
@@ -42,6 +54,7 @@ final class EventRecorder
             'session_id' => $context['session_id'] ?? null,
             'request_id' => $context['request_id'] ?? null,
             'attempt_id' => $context['attempt_id'] ?? null,
+            'scale_code' => $scaleCode,
             'channel' => $context['channel'] ?? null,
             'pack_id' => $context['pack_id'] ?? null,
             'dir_version' => $context['dir_version'] ?? null,
@@ -55,6 +68,10 @@ final class EventRecorder
         if (\App\Support\SchemaBaseline::hasColumn('events', 'experiments_json')) {
             $experiments = $context['experiments_json'] ?? [];
             $payload['experiments_json'] = is_array($experiments) ? $experiments : [];
+        }
+        if ($this->shouldWriteScaleIdentityColumns()) {
+            $payload['scale_code_v2'] = $scaleCodeV2;
+            $payload['scale_uid'] = $scaleUid;
         }
 
         try {
@@ -180,6 +197,33 @@ final class EventRecorder
         }
 
         return $sanitized;
+    }
+
+    private function shouldWriteScaleIdentityColumns(): bool
+    {
+        $mode = strtolower(trim((string) config('scale_identity.write_mode', 'legacy')));
+
+        return in_array($mode, ['dual', 'v2'], true);
+    }
+
+    /**
+     * @param  array<int,mixed>  $values
+     */
+    private function resolveScaleIdentityString(array $values, bool $uppercase): ?string
+    {
+        foreach ($values as $value) {
+            if (! is_string($value) && ! is_numeric($value)) {
+                continue;
+            }
+            $normalized = trim((string) $value);
+            if ($normalized === '') {
+                continue;
+            }
+
+            return $uppercase ? strtoupper($normalized) : $normalized;
+        }
+
+        return null;
     }
 
     /**

--- a/backend/app/Services/Assessments/AssessmentService.php
+++ b/backend/app/Services/Assessments/AssessmentService.php
@@ -5,6 +5,7 @@ namespace App\Services\Assessments;
 use App\Models\Assessment;
 use App\Models\AssessmentAssignment;
 use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
 use Illuminate\Support\Str;
 
 class AssessmentService
@@ -30,7 +31,7 @@ class AssessmentService
     ): Assessment {
         $now = now();
 
-        return Assessment::create([
+        $payload = [
             'org_id' => $orgId,
             'scale_code' => $scaleCode,
             'title' => $title,
@@ -39,7 +40,15 @@ class AssessmentService
             'status' => 'open',
             'created_at' => $now,
             'updated_at' => $now,
-        ]);
+        ];
+
+        if ($this->shouldWriteScaleIdentityColumns() && $this->assessmentsTableHasIdentityColumns()) {
+            $identity = $this->resolveScaleIdentityValues($scaleCode);
+            $payload['scale_code_v2'] = $identity['scale_code_v2'];
+            $payload['scale_uid'] = $identity['scale_uid'];
+        }
+
+        return Assessment::create($payload);
     }
 
     public function invite(Assessment $assessment, array $subjects): array
@@ -203,5 +212,54 @@ class AssessmentService
     private function generateInviteToken(): string
     {
         return Str::uuid()->toString() . Str::random(28);
+    }
+
+    private function shouldWriteScaleIdentityColumns(): bool
+    {
+        $mode = strtolower(trim((string) config('scale_identity.write_mode', 'legacy')));
+
+        return in_array($mode, ['dual', 'v2'], true);
+    }
+
+    private function assessmentsTableHasIdentityColumns(): bool
+    {
+        return Schema::hasTable('assessments')
+            && Schema::hasColumn('assessments', 'scale_code_v2')
+            && Schema::hasColumn('assessments', 'scale_uid');
+    }
+
+    /**
+     * @return array{scale_code_v2:string|null,scale_uid:string|null}
+     */
+    private function resolveScaleIdentityValues(string $scaleCode): array
+    {
+        $code = strtoupper(trim($scaleCode));
+        if ($code === '') {
+            return [
+                'scale_code_v2' => null,
+                'scale_uid' => null,
+            ];
+        }
+
+        $v1ToV2 = (array) config('scale_identity.code_map_v1_to_v2', []);
+        $v2ToV1 = (array) config('scale_identity.code_map_v2_to_v1', []);
+        $uidMap = (array) config('scale_identity.scale_uid_map', []);
+
+        $scaleCodeV1 = $code;
+        $scaleCodeV2 = null;
+
+        if (isset($v1ToV2[$code])) {
+            $scaleCodeV2 = strtoupper(trim((string) $v1ToV2[$code]));
+        } elseif (isset($v2ToV1[$code])) {
+            $scaleCodeV1 = strtoupper(trim((string) $v2ToV1[$code]));
+            $scaleCodeV2 = $code;
+        }
+
+        $scaleUid = trim((string) ($uidMap[$scaleCodeV1] ?? ''));
+
+        return [
+            'scale_code_v2' => $scaleCodeV2 !== '' ? $scaleCodeV2 : null,
+            'scale_uid' => $scaleUid !== '' ? $scaleUid : null,
+        ];
     }
 }

--- a/backend/app/Services/Attempts/AnswerRowWriter.php
+++ b/backend/app/Services/Attempts/AnswerRowWriter.php
@@ -4,6 +4,7 @@ namespace App\Services\Attempts;
 
 use App\Models\Attempt;
 use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
 
 class AnswerRowWriter
 {
@@ -21,6 +22,10 @@ class AnswerRowWriter
 
         $rows = [];
         $now = now();
+        $canWriteIdentity = $this->shouldWriteScaleIdentityColumns() && $this->attemptAnswerRowsHasIdentityColumns();
+        $identity = $canWriteIdentity
+            ? $this->resolveScaleIdentityValues($attempt)
+            : ['scale_code_v2' => null, 'scale_uid' => null];
 
         foreach ($answers as $answer) {
             if (!is_array($answer)) {
@@ -39,7 +44,7 @@ class AnswerRowWriter
                 ]
                 : $answer;
 
-            $rows[] = [
+            $row = [
                 'attempt_id' => (string) $attempt->id,
                 'org_id' => (int) ($attempt->org_id ?? 0),
                 'scale_code' => (string) ($attempt->scale_code ?? ''),
@@ -55,6 +60,13 @@ class AnswerRowWriter
                 'submitted_at' => $now,
                 'created_at' => $now,
             ];
+
+            if ($canWriteIdentity) {
+                $row['scale_code_v2'] = $identity['scale_code_v2'];
+                $row['scale_uid'] = $identity['scale_uid'];
+            }
+
+            $rows[] = $row;
         }
 
         if (empty($rows)) {
@@ -71,10 +83,16 @@ class AnswerRowWriter
             $uniqueBy = ['attempt_id', 'question_id', 'submitted_at'];
         }
 
+        $updateColumns = ['org_id', 'scale_code', 'question_index', 'question_type', 'answer_json', 'duration_ms', 'submitted_at'];
+        if ($canWriteIdentity) {
+            $updateColumns[] = 'scale_code_v2';
+            $updateColumns[] = 'scale_uid';
+        }
+
         DB::table('attempt_answer_rows')->upsert(
             $rows,
             $uniqueBy,
-            ['org_id', 'scale_code', 'question_index', 'question_type', 'answer_json', 'duration_ms', 'submitted_at']
+            $updateColumns
         );
 
         return ['ok' => true, 'rows' => count($rows)];
@@ -84,5 +102,65 @@ class AnswerRowWriter
     {
         $mode = strtolower((string) config('fap_attempts.answer_rows_write_mode', 'off'));
         return $mode === 'on' || $mode === 'true' || $mode === '1';
+    }
+
+    private function shouldWriteScaleIdentityColumns(): bool
+    {
+        $mode = strtolower(trim((string) config('scale_identity.write_mode', 'legacy')));
+
+        return in_array($mode, ['dual', 'v2'], true);
+    }
+
+    private function attemptAnswerRowsHasIdentityColumns(): bool
+    {
+        return Schema::hasTable('attempt_answer_rows')
+            && Schema::hasColumn('attempt_answer_rows', 'scale_code_v2')
+            && Schema::hasColumn('attempt_answer_rows', 'scale_uid');
+    }
+
+    /**
+     * @return array{scale_code_v2:string|null,scale_uid:string|null}
+     */
+    private function resolveScaleIdentityValues(Attempt $attempt): array
+    {
+        $scaleCodeV2 = strtoupper(trim((string) ($attempt->scale_code_v2 ?? '')));
+        $scaleUid = trim((string) ($attempt->scale_uid ?? ''));
+
+        if ($scaleCodeV2 !== '' && $scaleUid !== '') {
+            return [
+                'scale_code_v2' => $scaleCodeV2,
+                'scale_uid' => $scaleUid,
+            ];
+        }
+
+        $scaleCodeV1 = strtoupper(trim((string) ($attempt->scale_code ?? '')));
+        if ($scaleCodeV1 === '') {
+            return [
+                'scale_code_v2' => $scaleCodeV2 !== '' ? $scaleCodeV2 : null,
+                'scale_uid' => $scaleUid !== '' ? $scaleUid : null,
+            ];
+        }
+
+        $v1ToV2 = (array) config('scale_identity.code_map_v1_to_v2', []);
+        $uidMap = (array) config('scale_identity.scale_uid_map', []);
+
+        if ($scaleCodeV2 === '') {
+            $mappedV2 = strtoupper(trim((string) ($v1ToV2[$scaleCodeV1] ?? '')));
+            if ($mappedV2 !== '') {
+                $scaleCodeV2 = $mappedV2;
+            }
+        }
+
+        if ($scaleUid === '') {
+            $mappedUid = trim((string) ($uidMap[$scaleCodeV1] ?? ''));
+            if ($mappedUid !== '') {
+                $scaleUid = $mappedUid;
+            }
+        }
+
+        return [
+            'scale_code_v2' => $scaleCodeV2 !== '' ? $scaleCodeV2 : null,
+            'scale_uid' => $scaleUid !== '' ? $scaleUid : null,
+        ];
     }
 }

--- a/backend/app/Services/Attempts/AnswerRowWriter.php
+++ b/backend/app/Services/Attempts/AnswerRowWriter.php
@@ -3,8 +3,8 @@
 namespace App\Services\Attempts;
 
 use App\Models\Attempt;
+use Illuminate\Database\QueryException;
 use Illuminate\Support\Facades\DB;
-use Illuminate\Support\Facades\Schema;
 
 class AnswerRowWriter
 {
@@ -22,7 +22,7 @@ class AnswerRowWriter
 
         $rows = [];
         $now = now();
-        $canWriteIdentity = $this->shouldWriteScaleIdentityColumns() && $this->attemptAnswerRowsHasIdentityColumns();
+        $canWriteIdentity = $this->shouldWriteScaleIdentityColumns();
         $identity = $canWriteIdentity
             ? $this->resolveScaleIdentityValues($attempt)
             : ['scale_code_v2' => null, 'scale_uid' => null];
@@ -89,11 +89,33 @@ class AnswerRowWriter
             $updateColumns[] = 'scale_uid';
         }
 
-        DB::table('attempt_answer_rows')->upsert(
-            $rows,
-            $uniqueBy,
-            $updateColumns
-        );
+        try {
+            DB::table('attempt_answer_rows')->upsert(
+                $rows,
+                $uniqueBy,
+                $updateColumns
+            );
+        } catch (QueryException $exception) {
+            if (! $canWriteIdentity || ! $this->isMissingScaleIdentityColumnError($exception)) {
+                throw $exception;
+            }
+
+            foreach ($rows as &$row) {
+                unset($row['scale_code_v2'], $row['scale_uid']);
+            }
+            unset($row);
+
+            $fallbackColumns = array_values(array_filter(
+                $updateColumns,
+                static fn (string $column): bool => ! in_array($column, ['scale_code_v2', 'scale_uid'], true)
+            ));
+
+            DB::table('attempt_answer_rows')->upsert(
+                $rows,
+                $uniqueBy,
+                $fallbackColumns
+            );
+        }
 
         return ['ok' => true, 'rows' => count($rows)];
     }
@@ -111,11 +133,18 @@ class AnswerRowWriter
         return in_array($mode, ['dual', 'v2'], true);
     }
 
-    private function attemptAnswerRowsHasIdentityColumns(): bool
+    private function isMissingScaleIdentityColumnError(QueryException $exception): bool
     {
-        return Schema::hasTable('attempt_answer_rows')
-            && Schema::hasColumn('attempt_answer_rows', 'scale_code_v2')
-            && Schema::hasColumn('attempt_answer_rows', 'scale_uid');
+        $sqlState = strtoupper(trim((string) ($exception->errorInfo[0] ?? '')));
+        $message = strtolower($exception->getMessage());
+
+        if ($sqlState === '42S22') {
+            return true;
+        }
+
+        return str_contains($message, 'no such column')
+            || str_contains($message, 'has no column named')
+            || str_contains($message, 'unknown column');
     }
 
     /**

--- a/backend/app/Services/Attempts/AnswerSetStore.php
+++ b/backend/app/Services/Attempts/AnswerSetStore.php
@@ -3,8 +3,8 @@
 namespace App\Services\Attempts;
 
 use App\Models\Attempt;
+use Illuminate\Database\QueryException;
 use Illuminate\Support\Facades\DB;
-use Illuminate\Support\Facades\Schema;
 
 class AnswerSetStore
 {
@@ -33,15 +33,27 @@ class AnswerSetStore
             'created_at' => $now,
         ];
 
-        if ($this->shouldWriteScaleIdentityColumns() && $this->attemptAnswerSetsHasIdentityColumns()) {
+        $canWriteIdentity = $this->shouldWriteScaleIdentityColumns();
+        if ($canWriteIdentity) {
             $identity = $this->resolveScaleIdentityValues($attempt);
             $upsertValues['scale_code_v2'] = $identity['scale_code_v2'];
             $upsertValues['scale_uid'] = $identity['scale_uid'];
         }
 
-        DB::table('attempt_answer_sets')->updateOrInsert([
-            'attempt_id' => (string) $attempt->id,
-        ], $upsertValues);
+        try {
+            DB::table('attempt_answer_sets')->updateOrInsert([
+                'attempt_id' => (string) $attempt->id,
+            ], $upsertValues);
+        } catch (QueryException $exception) {
+            if (! $canWriteIdentity || ! $this->isMissingScaleIdentityColumnError($exception)) {
+                throw $exception;
+            }
+
+            unset($upsertValues['scale_code_v2'], $upsertValues['scale_uid']);
+            DB::table('attempt_answer_sets')->updateOrInsert([
+                'attempt_id' => (string) $attempt->id,
+            ], $upsertValues);
+        }
 
         return [
             'ok' => true,
@@ -128,11 +140,18 @@ class AnswerSetStore
         return in_array($mode, ['dual', 'v2'], true);
     }
 
-    private function attemptAnswerSetsHasIdentityColumns(): bool
+    private function isMissingScaleIdentityColumnError(QueryException $exception): bool
     {
-        return Schema::hasTable('attempt_answer_sets')
-            && Schema::hasColumn('attempt_answer_sets', 'scale_code_v2')
-            && Schema::hasColumn('attempt_answer_sets', 'scale_uid');
+        $sqlState = strtoupper(trim((string) ($exception->errorInfo[0] ?? '')));
+        $message = strtolower($exception->getMessage());
+
+        if ($sqlState === '42S22') {
+            return true;
+        }
+
+        return str_contains($message, 'no such column')
+            || str_contains($message, 'has no column named')
+            || str_contains($message, 'unknown column');
     }
 
     /**

--- a/backend/app/Services/Attempts/AnswerSetStore.php
+++ b/backend/app/Services/Attempts/AnswerSetStore.php
@@ -4,6 +4,7 @@ namespace App\Services\Attempts;
 
 use App\Models\Attempt;
 use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
 
 class AnswerSetStore
 {
@@ -18,9 +19,7 @@ class AnswerSetStore
         $storedAnswersJson = $isSensitiveScale ? null : $compressed;
 
         $now = now();
-        DB::table('attempt_answer_sets')->updateOrInsert([
-            'attempt_id' => (string) $attempt->id,
-        ], [
+        $upsertValues = [
             'org_id' => (int) ($attempt->org_id ?? 0),
             'scale_code' => (string) ($attempt->scale_code ?? ''),
             'pack_id' => (string) ($attempt->pack_id ?? ''),
@@ -32,7 +31,17 @@ class AnswerSetStore
             'duration_ms' => $durationMs,
             'submitted_at' => $now,
             'created_at' => $now,
-        ]);
+        ];
+
+        if ($this->shouldWriteScaleIdentityColumns() && $this->attemptAnswerSetsHasIdentityColumns()) {
+            $identity = $this->resolveScaleIdentityValues($attempt);
+            $upsertValues['scale_code_v2'] = $identity['scale_code_v2'];
+            $upsertValues['scale_uid'] = $identity['scale_uid'];
+        }
+
+        DB::table('attempt_answer_sets')->updateOrInsert([
+            'attempt_id' => (string) $attempt->id,
+        ], $upsertValues);
 
         return [
             'ok' => true,
@@ -110,5 +119,65 @@ class AnswerSetStore
             $result[] = $this->sortKeysRecursively($item);
         }
         return $result;
+    }
+
+    private function shouldWriteScaleIdentityColumns(): bool
+    {
+        $mode = strtolower(trim((string) config('scale_identity.write_mode', 'legacy')));
+
+        return in_array($mode, ['dual', 'v2'], true);
+    }
+
+    private function attemptAnswerSetsHasIdentityColumns(): bool
+    {
+        return Schema::hasTable('attempt_answer_sets')
+            && Schema::hasColumn('attempt_answer_sets', 'scale_code_v2')
+            && Schema::hasColumn('attempt_answer_sets', 'scale_uid');
+    }
+
+    /**
+     * @return array{scale_code_v2:string|null,scale_uid:string|null}
+     */
+    private function resolveScaleIdentityValues(Attempt $attempt): array
+    {
+        $scaleCodeV2 = strtoupper(trim((string) ($attempt->scale_code_v2 ?? '')));
+        $scaleUid = trim((string) ($attempt->scale_uid ?? ''));
+
+        if ($scaleCodeV2 !== '' && $scaleUid !== '') {
+            return [
+                'scale_code_v2' => $scaleCodeV2,
+                'scale_uid' => $scaleUid,
+            ];
+        }
+
+        $scaleCodeV1 = strtoupper(trim((string) ($attempt->scale_code ?? '')));
+        if ($scaleCodeV1 === '') {
+            return [
+                'scale_code_v2' => $scaleCodeV2 !== '' ? $scaleCodeV2 : null,
+                'scale_uid' => $scaleUid !== '' ? $scaleUid : null,
+            ];
+        }
+
+        $v1ToV2 = (array) config('scale_identity.code_map_v1_to_v2', []);
+        $uidMap = (array) config('scale_identity.scale_uid_map', []);
+
+        if ($scaleCodeV2 === '') {
+            $mappedV2 = strtoupper(trim((string) ($v1ToV2[$scaleCodeV1] ?? '')));
+            if ($mappedV2 !== '') {
+                $scaleCodeV2 = $mappedV2;
+            }
+        }
+
+        if ($scaleUid === '') {
+            $mappedUid = trim((string) ($uidMap[$scaleCodeV1] ?? ''));
+            if ($mappedUid !== '') {
+                $scaleUid = $mappedUid;
+            }
+        }
+
+        return [
+            'scale_code_v2' => $scaleCodeV2 !== '' ? $scaleCodeV2 : null,
+            'scale_uid' => $scaleUid !== '' ? $scaleUid : null,
+        ];
     }
 }

--- a/backend/app/Services/Attempts/AttemptStartService.php
+++ b/backend/app/Services/Attempts/AttemptStartService.php
@@ -14,6 +14,7 @@ use App\Services\Content\Sds20PackLoader;
 use App\Services\Observability\BigFiveTelemetry;
 use App\Services\Observability\ClinicalComboTelemetry;
 use App\Services\Observability\Sds20Telemetry;
+use App\Services\Scale\ScaleIdentityResolver;
 use App\Services\Scale\ScaleRegistry;
 use App\Services\Scale\ScaleRolloutGate;
 use App\Support\OrgContext;
@@ -34,20 +35,39 @@ class AttemptStartService
         private AttemptProgressService $progressService,
         private EventRecorder $eventRecorder,
         private BigFiveTelemetry $bigFiveTelemetry,
+        private ScaleIdentityResolver $identityResolver,
     ) {}
 
     public function start(OrgContext $ctx, StartAttemptDTO $dto): array
     {
         $orgId = $ctx->orgId();
 
-        $scaleCode = $dto->scaleCode;
-        if ($scaleCode === '') {
+        $requestedScaleCode = strtoupper(trim((string) $dto->scaleCode));
+        if ($requestedScaleCode === '') {
             throw new ApiProblemException(400, 'VALIDATION_FAILED', 'scale_code is required.');
         }
 
-        $row = $this->registry->getByCode($scaleCode, $orgId);
+        $row = $this->registry->getByCode($requestedScaleCode, $orgId);
         if (! $row) {
             throw new ApiProblemException(404, 'NOT_FOUND', 'scale not found.');
+        }
+        $scaleCode = strtoupper(trim((string) ($row['code'] ?? $requestedScaleCode)));
+        $this->assertDemoScaleAllowed($scaleCode, $requestedScaleCode);
+        $identity = $this->identityResolver->resolveByAnyCode($requestedScaleCode);
+        if (! is_array($identity) || ! ((bool) ($identity['is_known'] ?? false))) {
+            $identity = $this->identityResolver->resolveByAnyCode($scaleCode);
+        }
+        $scaleCodeV2 = $scaleCode;
+        $scaleUid = null;
+        if (is_array($identity) && ((bool) ($identity['is_known'] ?? false))) {
+            $resolvedV2 = strtoupper(trim((string) ($identity['scale_code_v2'] ?? '')));
+            $resolvedUid = trim((string) ($identity['scale_uid'] ?? ''));
+            if ($resolvedV2 !== '') {
+                $scaleCodeV2 = $resolvedV2;
+            }
+            if ($resolvedUid !== '') {
+                $scaleUid = $resolvedUid;
+            }
         }
 
         $region = (string) ($dto->region ?? $row['default_region'] ?? config('content_packs.default_region', ''));
@@ -192,7 +212,7 @@ class AttemptStartService
         $channel = (string) ($dto->channel ?? '');
         $referrer = (string) ($dto->referrer ?? '');
 
-        $attempt = Attempt::create([
+        $attemptPayload = [
             'org_id' => $orgId,
             'anon_id' => $anonId,
             'user_id' => $ctx->userId(),
@@ -214,7 +234,13 @@ class AttemptStartService
                 'created_at_ms' => (int) round(microtime(true) * 1000),
                 'meta' => $answersSummaryMeta,
             ],
-        ]);
+        ];
+        if ($this->shouldWriteScaleIdentityColumns()) {
+            $attemptPayload['scale_code_v2'] = $scaleCodeV2;
+            $attemptPayload['scale_uid'] = $scaleUid;
+        }
+
+        $attempt = Attempt::create($attemptPayload);
 
         $draft = $this->progressService->createDraftForAttempt($attempt);
         if (! empty($draft['expires_at'])) {
@@ -224,6 +250,8 @@ class AttemptStartService
 
         $this->eventRecorder->record('test_start', $ctx->userId(), [
             'scale_code' => $scaleCode,
+            'scale_code_v2' => $scaleCodeV2,
+            'scale_uid' => $scaleUid,
             'pack_id' => $packId,
             'dir_version' => $dirVersion,
             'content_package_version' => $contentPackageVersion,
@@ -232,6 +260,9 @@ class AttemptStartService
             'org_id' => $orgId,
             'anon_id' => $anonId,
             'attempt_id' => (string) $attempt->id,
+            'scale_code' => $scaleCode,
+            'scale_code_v2' => $scaleCodeV2,
+            'scale_uid' => $scaleUid,
             'pack_id' => $packId,
             'dir_version' => $dirVersion,
             'channel' => $channel !== '' ? $channel : null,
@@ -260,10 +291,17 @@ class AttemptStartService
             ]);
         }
 
+        $responseScaleCode = $this->identityResolver->resolveResponseScaleCode($scaleCode, $scaleCodeV2);
+
         return [
             'ok' => true,
             'attempt_id' => (string) $attempt->id,
-            'scale_code' => $scaleCode,
+            'scale_code' => $responseScaleCode,
+            'scale_code_legacy' => $scaleCode,
+            'scale_code_v2' => $scaleCodeV2,
+            'scale_uid' => $scaleUid,
+            'requested_scale_code' => $requestedScaleCode,
+            'resolved_from_alias' => $requestedScaleCode !== $scaleCode,
             'pack_id' => $packId,
             'dir_version' => $dirVersion,
             'region' => $region,
@@ -272,6 +310,45 @@ class AttemptStartService
             'resume_token' => (string) ($draft['token'] ?? ''),
             'resume_expires_at' => ! empty($draft['expires_at']) ? $draft['expires_at']->toISOString() : null,
         ];
+    }
+
+    private function shouldWriteScaleIdentityColumns(): bool
+    {
+        $mode = strtolower(trim((string) config('scale_identity.write_mode', 'legacy')));
+
+        return in_array($mode, ['dual', 'v2'], true);
+    }
+
+    private function assertDemoScaleAllowed(string $scaleCode, string $requestedScaleCode): void
+    {
+        $legacyCode = strtoupper(trim($scaleCode));
+        if ($legacyCode === '' || $this->identityResolver->shouldAllowDemoScale($legacyCode)) {
+            return;
+        }
+
+        $replacementLegacy = $this->identityResolver->demoReplacement($legacyCode);
+        $replacementV2 = null;
+        if ($replacementLegacy !== null) {
+            $replacementIdentity = $this->identityResolver->resolveByAnyCode($replacementLegacy);
+            if (is_array($replacementIdentity) && ((bool) ($replacementIdentity['is_known'] ?? false))) {
+                $resolved = strtoupper(trim((string) ($replacementIdentity['scale_code_v2'] ?? '')));
+                if ($resolved !== '') {
+                    $replacementV2 = $resolved;
+                }
+            }
+        }
+
+        throw new ApiProblemException(
+            410,
+            'SCALE_DEPRECATED',
+            'scale is deprecated.',
+            [
+                'requested_scale_code' => strtoupper(trim($requestedScaleCode)),
+                'scale_code_legacy' => $legacyCode,
+                'replacement_scale_code' => $replacementLegacy,
+                'replacement_scale_code_v2' => $replacementV2,
+            ]
+        );
     }
 
     private function resolveQuestionCount(string $scaleCode, string $packId, string $dirVersion): int
@@ -457,12 +534,16 @@ class AttemptStartService
         $policy = is_array($compiled['policy'] ?? null) ? $compiled['policy'] : [];
         $retake = is_array($policy['retake'] ?? null) ? $policy['retake'] : [];
 
-        if ($retake === []) {
-            $rawPath = base_path('content_packs/BIG5_OCEAN/v1/raw/policy.json');
-            if (is_file($rawPath)) {
-                $raw = json_decode((string) file_get_contents($rawPath), true);
-                if (is_array($raw)) {
-                    $retake = is_array($raw['retake'] ?? null) ? $raw['retake'] : [];
+        $contentPathMode = strtolower(trim((string) config('scale_identity.content_path_mode', 'legacy')));
+        $preferRawInV2Mode = in_array($contentPathMode, ['dual_prefer_new', 'v2'], true);
+        if ($retake === [] || $preferRawInV2Mode) {
+            $raw = $this->bigFivePackLoader->readJson(
+                $this->bigFivePackLoader->rawPath('policy.json', $dirVersion)
+            );
+            if (is_array($raw)) {
+                $rawRetake = is_array($raw['retake'] ?? null) ? $raw['retake'] : [];
+                if ($rawRetake !== []) {
+                    $retake = $rawRetake;
                 }
             }
         }

--- a/backend/app/Services/Attempts/AttemptSubmitService.php
+++ b/backend/app/Services/Attempts/AttemptSubmitService.php
@@ -12,6 +12,7 @@ use App\Services\Observability\BigFiveTelemetry;
 use App\Services\Observability\ClinicalComboTelemetry;
 use App\Services\Observability\Sds20Telemetry;
 use App\Services\Report\ReportGatekeeper;
+use App\Services\Scale\ScaleIdentityResolver;
 use App\Services\Scale\ScaleRegistry;
 use App\Services\Scale\ScaleRolloutGate;
 use App\Support\OrgContext;
@@ -30,6 +31,7 @@ class AttemptSubmitService
         private ReportGatekeeper $reportGatekeeper,
         private BigFiveTelemetry $bigFiveTelemetry,
         private AttemptDurationResolver $durationResolver,
+        private ScaleIdentityResolver $identityResolver,
     ) {}
 
     public function submit(OrgContext $ctx, string $attemptId, SubmitAttemptDTO $dto): array
@@ -53,6 +55,7 @@ class AttemptSubmitService
         if ($scaleCode === '') {
             throw new ApiProblemException(400, 'VALIDATION_FAILED', 'scale_code missing on attempt.');
         }
+        $this->assertDemoScaleAllowed($scaleCode, $attemptId);
 
         $this->enforceConsentOnSubmit($scaleCode, $attempt, $dto);
 
@@ -60,6 +63,20 @@ class AttemptSubmitService
         if (! $row) {
             throw new ApiProblemException(404, 'NOT_FOUND', 'scale not found.');
         }
+        $identity = $this->identityResolver->resolveByAnyCode($scaleCode);
+        $scaleCodeV2 = $scaleCode;
+        $scaleUid = null;
+        if (is_array($identity) && ((bool) ($identity['is_known'] ?? false))) {
+            $resolvedV2 = strtoupper(trim((string) ($identity['scale_code_v2'] ?? '')));
+            $resolvedUid = trim((string) ($identity['scale_uid'] ?? ''));
+            if ($resolvedV2 !== '') {
+                $scaleCodeV2 = $resolvedV2;
+            }
+            if ($resolvedUid !== '') {
+                $scaleUid = $resolvedUid;
+            }
+        }
+        $writeScaleIdentity = $this->shouldWriteScaleIdentityColumns();
 
         $packId = (string) ($attempt->pack_id ?? $row['default_pack_id'] ?? '');
         $dirVersion = (string) ($attempt->dir_version ?? $row['default_dir_version'] ?? '');
@@ -175,7 +192,10 @@ class AttemptSubmitService
             $actorUserId,
             $actorAnonId,
             $validityItems,
-            $submittedAt
+            $submittedAt,
+            $writeScaleIdentity,
+            $scaleCodeV2,
+            $scaleUid
         ) {
             $locked = $this->ownedAttemptQuery($ctx, $attemptId, $actorUserId, $actorAnonId)
                 ->lockForUpdate()
@@ -191,6 +211,8 @@ class AttemptSubmitService
                             'org_id' => $orgId,
                             'attempt_id' => $attemptId,
                             'scale_code' => $scaleCode,
+                            'scale_code_v2' => $scaleCodeV2,
+                            'scale_uid' => $scaleUid,
                             'pack_id' => (string) ($locked->pack_id ?? $packId),
                             'dir_version' => (string) ($locked->dir_version ?? $dirVersion),
                             'scoring_spec_version' => (string) ($locked->scoring_spec_version ?? $scoringSpecVersion),
@@ -214,6 +236,8 @@ class AttemptSubmitService
                         'org_id' => $orgId,
                         'attempt_id' => $attemptId,
                         'scale_code' => $scaleCode,
+                        'scale_code_v2' => $scaleCodeV2,
+                        'scale_uid' => $scaleUid,
                         'pack_id' => (string) ($locked->pack_id ?? $packId),
                         'dir_version' => (string) ($locked->dir_version ?? $dirVersion),
                         'scoring_spec_version' => (string) ($locked->scoring_spec_version ?? $scoringSpecVersion),
@@ -226,7 +250,7 @@ class AttemptSubmitService
                 }
             }
 
-            $locked->fill([
+            $attemptFill = [
                 'pack_id' => $packId,
                 'dir_version' => $dirVersion,
                 'content_package_version' => $contentPackageVersion !== '' ? $contentPackageVersion : null,
@@ -236,7 +260,12 @@ class AttemptSubmitService
                 'submitted_at' => $submittedAt,
                 'duration_ms' => $durationMs,
                 'answers_digest' => $answersDigest,
-            ]);
+            ];
+            if ($writeScaleIdentity) {
+                $attemptFill['scale_code_v2'] = $scaleCodeV2;
+                $attemptFill['scale_uid'] = $scaleUid;
+            }
+            $locked->fill($attemptFill);
 
             if ($scaleCode === 'BIG5_OCEAN') {
                 $snapshot = $locked->calculation_snapshot_json;
@@ -433,6 +462,10 @@ class AttemptSubmitService
                 'is_valid' => true,
                 'computed_at' => now(),
             ];
+            if ($writeScaleIdentity) {
+                $resultData['scale_code_v2'] = $scaleCodeV2;
+                $resultData['scale_uid'] = $scaleUid;
+            }
 
             $existingResult = $this->findResult($orgId, $attemptId);
             if ($existingResult) {
@@ -449,6 +482,8 @@ class AttemptSubmitService
                 'org_id' => $orgId,
                 'attempt_id' => $attemptId,
                 'scale_code' => $scaleCode,
+                'scale_code_v2' => $scaleCodeV2,
+                'scale_uid' => $scaleUid,
                 'pack_id' => $packId,
                 'dir_version' => $dirVersion,
                 'scoring_spec_version' => $scoringSpecVersion,
@@ -730,6 +765,10 @@ class AttemptSubmitService
             $compatScoresPct = [];
         }
 
+        $legacyCode = (string) ($attempt->scale_code ?? '');
+        $v2Code = (string) ($attempt->scale_code_v2 ?? '');
+        $responseScaleCode = $this->identityResolver->resolveResponseScaleCode($legacyCode, $v2Code);
+
         return [
             'ok' => true,
             'attempt_id' => (string) $attempt->id,
@@ -738,7 +777,10 @@ class AttemptSubmitService
             'scores_pct' => $compatScoresPct,
             'result' => $payload,
             'meta' => [
-                'scale_code' => (string) ($attempt->scale_code ?? ''),
+                'scale_code' => $responseScaleCode,
+                'scale_code_legacy' => $legacyCode,
+                'scale_code_v2' => $v2Code,
+                'scale_uid' => $attempt->scale_uid !== null ? (string) $attempt->scale_uid : null,
                 'pack_id' => (string) ($attempt->pack_id ?? ''),
                 'dir_version' => (string) ($attempt->dir_version ?? ''),
                 'content_package_version' => (string) ($attempt->content_package_version ?? ''),
@@ -764,6 +806,45 @@ class AttemptSubmitService
         }
 
         return (int) $userId;
+    }
+
+    private function shouldWriteScaleIdentityColumns(): bool
+    {
+        $mode = strtolower(trim((string) config('scale_identity.write_mode', 'legacy')));
+
+        return in_array($mode, ['dual', 'v2'], true);
+    }
+
+    private function assertDemoScaleAllowed(string $scaleCode, string $attemptId): void
+    {
+        $legacyCode = strtoupper(trim($scaleCode));
+        if ($legacyCode === '' || $this->identityResolver->shouldAllowDemoScale($legacyCode)) {
+            return;
+        }
+
+        $replacementLegacy = $this->identityResolver->demoReplacement($legacyCode);
+        $replacementV2 = null;
+        if ($replacementLegacy !== null) {
+            $replacementIdentity = $this->identityResolver->resolveByAnyCode($replacementLegacy);
+            if (is_array($replacementIdentity) && ((bool) ($replacementIdentity['is_known'] ?? false))) {
+                $resolved = strtoupper(trim((string) ($replacementIdentity['scale_code_v2'] ?? '')));
+                if ($resolved !== '') {
+                    $replacementV2 = $resolved;
+                }
+            }
+        }
+
+        throw new ApiProblemException(
+            410,
+            'SCALE_DEPRECATED',
+            'scale is deprecated.',
+            [
+                'attempt_id' => $attemptId,
+                'scale_code_legacy' => $legacyCode,
+                'replacement_scale_code' => $replacementLegacy,
+                'replacement_scale_code_v2' => $replacementV2,
+            ]
+        );
     }
 
     /**

--- a/backend/app/Services/Attempts/AttemptSubmitSideEffects.php
+++ b/backend/app/Services/Attempts/AttemptSubmitSideEffects.php
@@ -36,6 +36,8 @@ final class AttemptSubmitSideEffects
         }
 
         $scaleCode = strtoupper(trim((string) ($payload['scale_code'] ?? '')));
+        $scaleCodeV2 = strtoupper(trim((string) ($payload['scale_code_v2'] ?? '')));
+        $scaleUid = trim((string) ($payload['scale_uid'] ?? ''));
         $packId = trim((string) ($payload['pack_id'] ?? ''));
         $dirVersion = trim((string) ($payload['dir_version'] ?? ''));
         $scoringSpecVersion = trim((string) ($payload['scoring_spec_version'] ?? ''));
@@ -88,6 +90,8 @@ final class AttemptSubmitSideEffects
                 if ($creditOk) {
                     $this->eventRecorder->record('wallet_consumed', $this->resolveUserIdInt($ctx, $actorUserId), [
                         'scale_code' => $scaleCode,
+                        'scale_code_v2' => $scaleCodeV2 !== '' ? $scaleCodeV2 : null,
+                        'scale_uid' => $scaleUid !== '' ? $scaleUid : null,
                         'pack_id' => $packId,
                         'dir_version' => $dirVersion,
                         'attempt_id' => $attemptId,
@@ -97,6 +101,9 @@ final class AttemptSubmitSideEffects
                         'org_id' => $orgId,
                         'anon_id' => $actorAnonId,
                         'attempt_id' => $attemptId,
+                        'scale_code' => $scaleCode,
+                        'scale_code_v2' => $scaleCodeV2 !== '' ? $scaleCodeV2 : null,
+                        'scale_uid' => $scaleUid !== '' ? $scaleUid : null,
                         'pack_id' => $packId,
                         'dir_version' => $dirVersion,
                     ]);
@@ -156,6 +163,8 @@ final class AttemptSubmitSideEffects
         try {
             $this->reportSnapshots->seedPendingSnapshot($orgId, $attemptId, null, [
                 'scale_code' => $scaleCode,
+                'scale_code_v2' => $scaleCodeV2 !== '' ? $scaleCodeV2 : null,
+                'scale_uid' => $scaleUid !== '' ? $scaleUid : null,
                 'pack_id' => $packId,
                 'dir_version' => $dirVersion,
                 'scoring_spec_version' => $scoringSpecVersion,
@@ -187,6 +196,8 @@ final class AttemptSubmitSideEffects
     ): void {
         $this->eventRecorder->record('test_submit', $this->resolveUserIdInt($ctx, $actorUserId), [
             'scale_code' => (string) ($postCommitCtx['scale_code'] ?? ''),
+            'scale_code_v2' => (string) ($postCommitCtx['scale_code_v2'] ?? ''),
+            'scale_uid' => (string) ($postCommitCtx['scale_uid'] ?? ''),
             'pack_id' => (string) ($postCommitCtx['pack_id'] ?? ''),
             'dir_version' => (string) ($postCommitCtx['dir_version'] ?? ''),
             'attempt_id' => $attemptId,
@@ -194,6 +205,9 @@ final class AttemptSubmitSideEffects
             'org_id' => $ctx->orgId(),
             'anon_id' => $actorAnonId,
             'attempt_id' => $attemptId,
+            'scale_code' => (string) ($postCommitCtx['scale_code'] ?? ''),
+            'scale_code_v2' => (string) ($postCommitCtx['scale_code_v2'] ?? ''),
+            'scale_uid' => (string) ($postCommitCtx['scale_uid'] ?? ''),
             'pack_id' => (string) ($postCommitCtx['pack_id'] ?? ''),
             'dir_version' => (string) ($postCommitCtx['dir_version'] ?? ''),
         ]);

--- a/backend/app/Services/Commerce/OrderManager.php
+++ b/backend/app/Services/Commerce/OrderManager.php
@@ -4,6 +4,7 @@ namespace App\Services\Commerce;
 
 use App\Services\Report\ReportAccess;
 use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
 use Illuminate\Support\Str;
 
 class OrderManager
@@ -115,6 +116,12 @@ class OrderManager
                     ? json_encode($orderMeta, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES)
                     : null,
             ];
+
+            if ($this->shouldWriteScaleIdentityColumns() && $this->ordersTableHasIdentityColumns()) {
+                $identity = $this->resolveOrderScaleIdentity($orgId, $targetAttemptId);
+                $row['scale_code_v2'] = $identity['scale_code_v2'];
+                $row['scale_uid'] = $identity['scale_uid'];
+            }
 
             if ($useIdempotency) {
                 $row['idempotency_key'] = $idempotencyKey;
@@ -516,6 +523,85 @@ class OrderManager
         }
 
         return $key;
+    }
+
+    private function shouldWriteScaleIdentityColumns(): bool
+    {
+        $mode = strtolower(trim((string) config('scale_identity.write_mode', 'legacy')));
+
+        return in_array($mode, ['dual', 'v2'], true);
+    }
+
+    private function ordersTableHasIdentityColumns(): bool
+    {
+        return Schema::hasTable('orders')
+            && Schema::hasColumn('orders', 'scale_code_v2')
+            && Schema::hasColumn('orders', 'scale_uid');
+    }
+
+    /**
+     * @return array{scale_code_v2:string|null,scale_uid:string|null}
+     */
+    private function resolveOrderScaleIdentity(int $orgId, ?string $targetAttemptId): array
+    {
+        $attemptId = $this->trimOrNull($targetAttemptId);
+        if ($attemptId === null) {
+            return [
+                'scale_code_v2' => null,
+                'scale_uid' => null,
+            ];
+        }
+
+        $attempt = DB::table('attempts')
+            ->where('id', $attemptId)
+            ->where('org_id', $orgId)
+            ->first();
+        if (! $attempt) {
+            return [
+                'scale_code_v2' => null,
+                'scale_uid' => null,
+            ];
+        }
+
+        $scaleCodeV2 = strtoupper(trim((string) ($attempt->scale_code_v2 ?? '')));
+        $scaleUid = trim((string) ($attempt->scale_uid ?? ''));
+
+        if ($scaleCodeV2 !== '' && $scaleUid !== '') {
+            return [
+                'scale_code_v2' => $scaleCodeV2,
+                'scale_uid' => $scaleUid,
+            ];
+        }
+
+        $scaleCodeV1 = strtoupper(trim((string) ($attempt->scale_code ?? '')));
+        if ($scaleCodeV1 === '') {
+            return [
+                'scale_code_v2' => $scaleCodeV2 !== '' ? $scaleCodeV2 : null,
+                'scale_uid' => $scaleUid !== '' ? $scaleUid : null,
+            ];
+        }
+
+        $v1ToV2 = (array) config('scale_identity.code_map_v1_to_v2', []);
+        $uidMap = (array) config('scale_identity.scale_uid_map', []);
+
+        if ($scaleCodeV2 === '') {
+            $mappedV2 = strtoupper(trim((string) ($v1ToV2[$scaleCodeV1] ?? '')));
+            if ($mappedV2 !== '') {
+                $scaleCodeV2 = $mappedV2;
+            }
+        }
+
+        if ($scaleUid === '') {
+            $mappedUid = trim((string) ($uidMap[$scaleCodeV1] ?? ''));
+            if ($mappedUid !== '') {
+                $scaleUid = $mappedUid;
+            }
+        }
+
+        return [
+            'scale_code_v2' => $scaleCodeV2 !== '' ? $scaleCodeV2 : null,
+            'scale_uid' => $scaleUid !== '' ? $scaleUid : null,
+        ];
     }
 
     private function findIdempotentOrder(

--- a/backend/app/Services/Content/BigFivePackLoader.php
+++ b/backend/app/Services/Content/BigFivePackLoader.php
@@ -14,13 +14,15 @@ final class BigFivePackLoader
 
     public function __construct(
         private ?ContentPackV2Resolver $v2Resolver = null,
+        private ContentPathAliasResolver $pathAliasResolver,
     ) {}
 
     public function packRoot(?string $version = null): string
     {
         $version = $this->normalizeVersion($version);
+        $packBase = $this->pathAliasResolver->resolveBackendPackRoot(self::PACK_ID);
 
-        return base_path('content_packs/'.self::PACK_ID.'/'.$version);
+        return rtrim($packBase, DIRECTORY_SEPARATOR).DIRECTORY_SEPARATOR.$version;
     }
 
     public function rawDir(?string $version = null): string

--- a/backend/app/Services/Content/ClinicalComboPackLoader.php
+++ b/backend/app/Services/Content/ClinicalComboPackLoader.php
@@ -14,11 +14,14 @@ final class ClinicalComboPackLoader
 
     public function __construct(
         private ?ContentPackV2Resolver $v2Resolver = null,
+        private ContentPathAliasResolver $pathAliasResolver,
     ) {}
 
     public function packRoot(?string $version = null): string
     {
-        return base_path('content_packs/'.self::PACK_ID.'/'.$this->normalizeVersion($version));
+        $packBase = $this->pathAliasResolver->resolveBackendPackRoot(self::PACK_ID);
+
+        return rtrim($packBase, DIRECTORY_SEPARATOR).DIRECTORY_SEPARATOR.$this->normalizeVersion($version);
     }
 
     public function rawDir(?string $version = null): string

--- a/backend/app/Services/Content/ContentPathAliasResolver.php
+++ b/backend/app/Services/Content/ContentPathAliasResolver.php
@@ -1,0 +1,215 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\Content;
+
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+final class ContentPathAliasResolver
+{
+    /**
+     * Resolve backend content_packs root directory for a legacy pack id.
+     * Default behavior remains legacy-first, with safe fallback if mapped path does not exist.
+     */
+    public function resolveBackendPackRoot(string $legacyPackId): string
+    {
+        $packId = strtoupper(trim($legacyPackId));
+        if ($packId === '') {
+            return base_path('content_packs');
+        }
+
+        $legacyRelativePath = 'content_packs/'.$packId;
+        $alias = $this->findActiveAlias('backend_content_packs', $legacyRelativePath);
+        if (! is_array($alias)) {
+            return base_path($legacyRelativePath);
+        }
+
+        $legacyAbsolutePath = base_path(trim((string) ($alias['old_path'] ?? $legacyRelativePath), '/'));
+        $mappedAbsolutePath = base_path(trim((string) ($alias['new_path'] ?? $legacyRelativePath), '/'));
+        $mode = strtolower(trim((string) config('scale_identity.content_path_mode', 'legacy')));
+
+        return match ($mode) {
+            'dual_prefer_new', 'v2' => $this->preferExisting($mappedAbsolutePath, $legacyAbsolutePath),
+            'dual_prefer_old', 'legacy' => $this->preferExisting($legacyAbsolutePath, $mappedAbsolutePath),
+            default => $this->preferExisting($legacyAbsolutePath, $mappedAbsolutePath),
+        };
+    }
+
+    /**
+     * Resolve backend source directory for publish command.
+     * Modes:
+     * - legacy/dual: prefer legacy path, fallback mapped path.
+     * - v2: prefer mapped path, fallback legacy path.
+     */
+    public function resolveBackendPublishSourceDir(string $legacyPackId, string $version): string
+    {
+        return (string) ($this->resolveBackendPublishSourceContext($legacyPackId, $version)['selected_path'] ?? base_path('content_packs'));
+    }
+
+    /**
+     * @return array{
+     *   mode:string,
+     *   selected_path:string,
+     *   selected_source:string,
+     *   legacy_path:string,
+     *   mapped_path:?string,
+     *   alias_matched:bool,
+     *   fallback_used:bool
+     * }
+     */
+    public function resolveBackendPublishSourceContext(string $legacyPackId, string $version): array
+    {
+        $mode = $this->normalizePublishMode(config('scale_identity.content_publish_mode', 'legacy'));
+        $packId = strtoupper(trim($legacyPackId));
+        $packVersion = trim($version);
+        if ($packId === '' || $packVersion === '') {
+            $defaultPath = base_path('content_packs');
+
+            return [
+                'mode' => $mode,
+                'selected_path' => $defaultPath,
+                'selected_source' => 'legacy',
+                'legacy_path' => $defaultPath,
+                'mapped_path' => null,
+                'alias_matched' => false,
+                'fallback_used' => false,
+            ];
+        }
+
+        $legacyRelativeRoot = 'content_packs/'.$packId;
+        $legacyAbsoluteRoot = base_path($legacyRelativeRoot);
+        $legacyVersionPath = $legacyAbsoluteRoot.DIRECTORY_SEPARATOR.$packVersion;
+
+        $alias = $this->findActiveAlias('backend_content_packs', $legacyRelativeRoot);
+        if (! is_array($alias)) {
+            return [
+                'mode' => $mode,
+                'selected_path' => $legacyVersionPath,
+                'selected_source' => 'legacy',
+                'legacy_path' => $legacyVersionPath,
+                'mapped_path' => null,
+                'alias_matched' => false,
+                'fallback_used' => false,
+            ];
+        }
+
+        $mappedAbsoluteRoot = base_path(trim((string) ($alias['new_path'] ?? $legacyRelativeRoot), '/'));
+        $mappedVersionPath = $mappedAbsoluteRoot.DIRECTORY_SEPARATOR.$packVersion;
+        if ($mode === 'v2') {
+            $selected = $this->selectExistingPath(
+                $mappedVersionPath,
+                'mapped',
+                $legacyVersionPath,
+                'legacy'
+            );
+        } else {
+            $selected = $this->selectExistingPath(
+                $legacyVersionPath,
+                'legacy',
+                $mappedVersionPath,
+                'mapped'
+            );
+        }
+
+        return [
+            'mode' => $mode,
+            'selected_path' => (string) $selected['selected_path'],
+            'selected_source' => (string) $selected['selected_source'],
+            'legacy_path' => $legacyVersionPath,
+            'mapped_path' => $mappedVersionPath,
+            'alias_matched' => true,
+            'fallback_used' => (bool) $selected['fallback_used'],
+        ];
+    }
+
+    /**
+     * @return array{old_path:string,new_path:string}|null
+     */
+    private function findActiveAlias(string $scope, string $oldPath): ?array
+    {
+        if (! Schema::hasTable('content_path_aliases')) {
+            return null;
+        }
+
+        try {
+            $row = DB::table('content_path_aliases')
+                ->select(['old_path', 'new_path'])
+                ->where('scope', $scope)
+                ->where('old_path', $oldPath)
+                ->where('is_active', true)
+                ->first();
+
+            if (! $row) {
+                return null;
+            }
+
+            $legacy = trim((string) ($row->old_path ?? ''));
+            $mapped = trim((string) ($row->new_path ?? ''));
+            if ($legacy === '' || $mapped === '') {
+                return null;
+            }
+
+            return [
+                'old_path' => $legacy,
+                'new_path' => $mapped,
+            ];
+        } catch (\Throwable) {
+            // Keep non-blocking behavior during phased rollout.
+            return null;
+        }
+    }
+
+    private function preferExisting(string $primaryPath, string $fallbackPath): string
+    {
+        if (is_dir($primaryPath)) {
+            return $primaryPath;
+        }
+
+        if (is_dir($fallbackPath)) {
+            return $fallbackPath;
+        }
+
+        return $primaryPath;
+    }
+
+    private function normalizePublishMode(mixed $value): string
+    {
+        $mode = strtolower(trim((string) $value));
+
+        return in_array($mode, ['legacy', 'dual', 'v2'], true) ? $mode : 'legacy';
+    }
+
+    /**
+     * @return array{selected_path:string,selected_source:string,fallback_used:bool}
+     */
+    private function selectExistingPath(
+        string $primaryPath,
+        string $primarySource,
+        string $fallbackPath,
+        string $fallbackSource
+    ): array {
+        if (is_dir($primaryPath)) {
+            return [
+                'selected_path' => $primaryPath,
+                'selected_source' => $primarySource,
+                'fallback_used' => false,
+            ];
+        }
+
+        if (is_dir($fallbackPath)) {
+            return [
+                'selected_path' => $fallbackPath,
+                'selected_source' => $fallbackSource,
+                'fallback_used' => true,
+            ];
+        }
+
+        return [
+            'selected_path' => $primaryPath,
+            'selected_source' => $primarySource,
+            'fallback_used' => true,
+        ];
+    }
+}

--- a/backend/app/Services/Content/Eq60PackLoader.php
+++ b/backend/app/Services/Content/Eq60PackLoader.php
@@ -14,11 +14,14 @@ final class Eq60PackLoader
 
     public function __construct(
         private ?ContentPackV2Resolver $v2Resolver = null,
+        private ContentPathAliasResolver $pathAliasResolver,
     ) {}
 
     public function packRoot(?string $version = null): string
     {
-        return base_path('content_packs/' . self::PACK_ID . '/' . $this->normalizeVersion($version));
+        $packBase = $this->pathAliasResolver->resolveBackendPackRoot(self::PACK_ID);
+
+        return rtrim($packBase, DIRECTORY_SEPARATOR).DIRECTORY_SEPARATOR.$this->normalizeVersion($version);
     }
 
     public function rawDir(?string $version = null): string

--- a/backend/app/Services/Content/Publisher/ContentPackPublisher.php
+++ b/backend/app/Services/Content/Publisher/ContentPackPublisher.php
@@ -185,6 +185,7 @@ final class ContentPackPublisher
         $expectedPackId = '';
         $targetDir = '';
         $releaseEvidence = $this->emptyReleaseEvidence();
+        $version = null;
 
         $tmpDir = '';
         $previousPackPath = '';
@@ -319,6 +320,9 @@ final class ContentPackPublisher
                 'region' => $region,
                 'locale' => $locale,
                 'dir_alias' => $dirAlias,
+                'content_publish_mode' => strtolower(trim((string) config('scale_identity.content_publish_mode', 'legacy'))),
+                'staged_source_type' => is_object($version) ? (string) ($version->source_type ?? '') : '',
+                'staged_source_ref' => is_object($version) ? (string) ($version->source_ref ?? '') : '',
                 'from_pack_id' => $fromPackId,
                 'to_pack_id' => $toPackId,
                 'from_version_id' => $fromVersionId,

--- a/backend/app/Services/Content/Sds20PackLoader.php
+++ b/backend/app/Services/Content/Sds20PackLoader.php
@@ -14,11 +14,14 @@ final class Sds20PackLoader
 
     public function __construct(
         private ?ContentPackV2Resolver $v2Resolver = null,
+        private ContentPathAliasResolver $pathAliasResolver,
     ) {}
 
     public function packRoot(?string $version = null): string
     {
-        return base_path('content_packs/'.self::PACK_ID.'/'.$this->normalizeVersion($version));
+        $packBase = $this->pathAliasResolver->resolveBackendPackRoot(self::PACK_ID);
+
+        return rtrim($packBase, DIRECTORY_SEPARATOR).DIRECTORY_SEPARATOR.$this->normalizeVersion($version);
     }
 
     public function rawDir(?string $version = null): string

--- a/backend/app/Services/Legacy/LegacyShareService.php
+++ b/backend/app/Services/Legacy/LegacyShareService.php
@@ -27,6 +27,8 @@ class LegacyShareService
 
         if (!$share) {
             $share = $this->createShare($attempt, $ctx->anonId());
+        } else {
+            $this->backfillShareScaleIdentityIfNeeded($share, $attempt);
         }
 
         $typeCode = (string) ($result->type_code ?? '');
@@ -127,6 +129,11 @@ class LegacyShareService
         $share->scale_code = (string) ($attempt->scale_code ?? '');
         $share->scale_version = (string) ($attempt->scale_version ?? '');
         $share->content_package_version = (string) ($attempt->content_package_version ?? '');
+        if ($this->shouldWriteScaleIdentityColumns()) {
+            [$scaleCodeV2, $scaleUid] = $this->resolveScaleIdentityValues($attempt);
+            $share->scale_code_v2 = $scaleCodeV2;
+            $share->scale_uid = $scaleUid;
+        }
 
         try {
             $share->save();
@@ -136,5 +143,66 @@ class LegacyShareService
                 ->where('attempt_id', (string) $attempt->id)
                 ->firstOrFail();
         }
+    }
+
+    private function backfillShareScaleIdentityIfNeeded(Share $share, Attempt $attempt): void
+    {
+        if (!$this->shouldWriteScaleIdentityColumns()) {
+            return;
+        }
+
+        [$scaleCodeV2, $scaleUid] = $this->resolveScaleIdentityValues($attempt);
+        $dirty = false;
+
+        if (trim((string) ($share->scale_code_v2 ?? '')) === '' && $scaleCodeV2 !== null && $scaleCodeV2 !== '') {
+            $share->scale_code_v2 = $scaleCodeV2;
+            $dirty = true;
+        }
+        if (trim((string) ($share->scale_uid ?? '')) === '' && $scaleUid !== null && $scaleUid !== '') {
+            $share->scale_uid = $scaleUid;
+            $dirty = true;
+        }
+
+        if (!$dirty) {
+            return;
+        }
+
+        try {
+            $share->save();
+        } catch (QueryException $e) {
+            // best effort backfill; keep read path unaffected on contention.
+        }
+    }
+
+    /**
+     * @return array{0:?string,1:?string}
+     */
+    private function resolveScaleIdentityValues(Attempt $attempt): array
+    {
+        $legacyCode = strtoupper(trim((string) ($attempt->scale_code ?? '')));
+        $scaleCodeV2 = strtoupper(trim((string) ($attempt->scale_code_v2 ?? '')));
+        $scaleUid = trim((string) ($attempt->scale_uid ?? ''));
+
+        $mapV1ToV2 = (array) config('scale_identity.code_map_v1_to_v2', []);
+        $uidMap = (array) config('scale_identity.scale_uid_map', []);
+
+        if ($scaleCodeV2 === '' && $legacyCode !== '' && isset($mapV1ToV2[$legacyCode])) {
+            $scaleCodeV2 = strtoupper(trim((string) $mapV1ToV2[$legacyCode]));
+        }
+        if ($scaleUid === '' && $legacyCode !== '' && isset($uidMap[$legacyCode])) {
+            $scaleUid = trim((string) $uidMap[$legacyCode]);
+        }
+
+        return [
+            $scaleCodeV2 !== '' ? $scaleCodeV2 : null,
+            $scaleUid !== '' ? $scaleUid : null,
+        ];
+    }
+
+    private function shouldWriteScaleIdentityColumns(): bool
+    {
+        $mode = strtolower(trim((string) config('scale_identity.write_mode', 'legacy')));
+
+        return in_array($mode, ['dual', 'v2'], true);
     }
 }

--- a/backend/app/Services/Report/ReportSnapshotStore.php
+++ b/backend/app/Services/Report/ReportSnapshotStore.php
@@ -24,7 +24,7 @@ class ReportSnapshotStore
     ) {}
 
     /**
-     * @param array $meta {scale_code?:string, pack_id?:string, dir_version?:string, scoring_spec_version?:string}
+     * @param array $meta {scale_code?:string, scale_code_v2?:string, scale_uid?:string, pack_id?:string, dir_version?:string, scoring_spec_version?:string}
      */
     public function seedPendingSnapshot(int $orgId, string $attemptId, ?string $orderNo, array $meta): void
     {
@@ -46,12 +46,20 @@ class ReportSnapshotStore
         } elseif (!is_numeric($scoringSpecVersion)) {
             $scoringSpecVersion = null;
         }
+        $scaleCode = strtoupper(trim((string) ($meta['scale_code'] ?? '')));
+        $requestedScaleCodeV2 = strtoupper(trim((string) ($meta['scale_code_v2'] ?? '')));
+        $requestedScaleUid = trim((string) ($meta['scale_uid'] ?? ''));
+        [$scaleCodeV2, $scaleUid] = $this->resolveScaleIdentityValues(
+            $scaleCode,
+            $requestedScaleCodeV2,
+            $requestedScaleUid
+        );
 
         $row = [
             'org_id' => $orgId,
             'attempt_id' => $attemptId,
             'order_no' => $resolvedOrderNo !== '' ? $resolvedOrderNo : null,
-            'scale_code' => strtoupper(trim((string) ($meta['scale_code'] ?? ''))),
+            'scale_code' => $scaleCode,
             'pack_id' => trim((string) ($meta['pack_id'] ?? '')),
             'dir_version' => trim((string) ($meta['dir_version'] ?? '')),
             'scoring_spec_version' => $scoringSpecVersion,
@@ -65,6 +73,10 @@ class ReportSnapshotStore
             'created_at' => $now,
             'updated_at' => $now,
         ];
+        if ($this->shouldWriteScaleIdentityColumns()) {
+            $row['scale_code_v2'] = $scaleCodeV2;
+            $row['scale_uid'] = $scaleUid;
+        }
 
         DB::table('report_snapshots')->insertOrIgnore($row);
 
@@ -90,6 +102,14 @@ class ReportSnapshotStore
         }
         if ($row['dir_version'] !== '') {
             $updates['dir_version'] = $row['dir_version'];
+        }
+        if ($this->shouldWriteScaleIdentityColumns()) {
+            if ($scaleCodeV2 !== null && $scaleCodeV2 !== '') {
+                $updates['scale_code_v2'] = $scaleCodeV2;
+            }
+            if ($scaleUid !== null && $scaleUid !== '') {
+                $updates['scale_uid'] = $scaleUid;
+            }
         }
 
         $this->snapshotWriteQuery($orgId, $attemptId)->update($updates);
@@ -132,6 +152,13 @@ class ReportSnapshotStore
         }
 
         $scaleCode = strtoupper((string) ($attempt->scale_code ?? ''));
+        $attemptScaleCodeV2 = strtoupper(trim((string) ($attempt->scale_code_v2 ?? '')));
+        $attemptScaleUid = trim((string) ($attempt->scale_uid ?? ''));
+        [$scaleCodeV2, $scaleUid] = $this->resolveScaleIdentityValues(
+            $scaleCode,
+            $attemptScaleCodeV2,
+            $attemptScaleUid
+        );
         $packId = (string) ($attempt->pack_id ?? '');
         $dirVersion = (string) ($attempt->dir_version ?? '');
         $scoringSpecVersion = $attempt->scoring_spec_version ?? $result->scoring_spec_version ?? null;
@@ -192,6 +219,10 @@ class ReportSnapshotStore
             'created_at' => $now,
             'updated_at' => $now,
         ];
+        if ($this->shouldWriteScaleIdentityColumns()) {
+            $row['scale_code_v2'] = $scaleCodeV2;
+            $row['scale_uid'] = $scaleUid;
+        }
 
         DB::table('report_snapshots')->insertOrIgnore($row);
 
@@ -201,6 +232,8 @@ class ReportSnapshotStore
 
         $this->eventRecorder->record('report_snapshot_created', null, [
             'scale_code' => $scaleCode,
+            'scale_code_v2' => $scaleCodeV2,
+            'scale_uid' => $scaleUid,
             'attempt_id' => $attemptId,
             'pack_id' => $packId,
             'dir_version' => $dirVersion,
@@ -209,6 +242,9 @@ class ReportSnapshotStore
         ], [
             'org_id' => $orgId,
             'attempt_id' => $attemptId,
+            'scale_code' => $scaleCode,
+            'scale_code_v2' => $scaleCodeV2,
+            'scale_uid' => $scaleUid,
             'pack_id' => $packId,
             'dir_version' => $dirVersion,
         ]);
@@ -416,6 +452,8 @@ class ReportSnapshotStore
             'attempt_id' => (string) ($row->attempt_id ?? ''),
             'order_no' => $row->order_no ?? null,
             'scale_code' => (string) ($row->scale_code ?? ''),
+            'scale_code_v2' => trim((string) ($row->scale_code_v2 ?? '')) !== '' ? (string) ($row->scale_code_v2 ?? '') : null,
+            'scale_uid' => trim((string) ($row->scale_uid ?? '')) !== '' ? (string) ($row->scale_uid ?? '') : null,
             'pack_id' => (string) ($row->pack_id ?? ''),
             'dir_version' => (string) ($row->dir_version ?? ''),
             'scoring_spec_version' => $row->scoring_spec_version ?? null,
@@ -480,6 +518,38 @@ class ReportSnapshotStore
         $status = strtolower(trim((string) ($row->status ?? 'ready')));
 
         return in_array($status, ['pending', 'ready', 'failed'], true) ? $status : 'ready';
+    }
+
+    private function shouldWriteScaleIdentityColumns(): bool
+    {
+        $mode = strtolower(trim((string) config('scale_identity.write_mode', 'legacy')));
+
+        return in_array($mode, ['dual', 'v2'], true);
+    }
+
+    /**
+     * @return array{0:?string,1:?string}
+     */
+    private function resolveScaleIdentityValues(string $scaleCode, string $scaleCodeV2, string $scaleUid): array
+    {
+        $legacyCode = strtoupper(trim($scaleCode));
+        $resolvedV2 = strtoupper(trim($scaleCodeV2));
+        $resolvedUid = trim($scaleUid);
+
+        $mapV1ToV2 = (array) config('scale_identity.code_map_v1_to_v2', []);
+        $uidMap = (array) config('scale_identity.scale_uid_map', []);
+
+        if ($resolvedV2 === '' && $legacyCode !== '' && isset($mapV1ToV2[$legacyCode])) {
+            $resolvedV2 = strtoupper(trim((string) $mapV1ToV2[$legacyCode]));
+        }
+        if ($resolvedUid === '' && $legacyCode !== '' && isset($uidMap[$legacyCode])) {
+            $resolvedUid = trim((string) $uidMap[$legacyCode]);
+        }
+
+        return [
+            $resolvedV2 !== '' ? $resolvedV2 : null,
+            $resolvedUid !== '' ? $resolvedUid : null,
+        ];
     }
 
     private function badRequest(string $code, string $message): array

--- a/backend/app/Services/Scale/ScaleIdentityResolver.php
+++ b/backend/app/Services/Scale/ScaleIdentityResolver.php
@@ -1,0 +1,317 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\Scale;
+
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+final class ScaleIdentityResolver
+{
+    /**
+     * @return array{
+     *   input_code:string,
+     *   scale_uid:string|null,
+     *   scale_code_v1:string,
+     *   scale_code_v2:string,
+     *   pack_id_v1:?string,
+     *   pack_id_v2:?string,
+     *   dir_version_v1:?string,
+     *   dir_version_v2:?string,
+     *   resolved_from_alias:bool,
+     *   is_known:bool
+     * }|null
+     */
+    public function resolveByAnyCode(string $code): ?array
+    {
+        $inputCode = strtoupper(trim($code));
+        if ($inputCode === '') {
+            return null;
+        }
+
+        $resolvedFromDb = $this->resolveIdentityFromDatabase($inputCode);
+        if (is_array($resolvedFromDb)) {
+            return [
+                'input_code' => $inputCode,
+                'scale_uid' => $resolvedFromDb['scale_uid'],
+                'scale_code_v1' => $resolvedFromDb['scale_code_v1'],
+                'scale_code_v2' => $resolvedFromDb['scale_code_v2'],
+                'pack_id_v1' => $resolvedFromDb['pack_id_v1'],
+                'pack_id_v2' => $resolvedFromDb['pack_id_v2'],
+                'dir_version_v1' => $resolvedFromDb['dir_version_v1'],
+                'dir_version_v2' => $resolvedFromDb['dir_version_v2'],
+                'resolved_from_alias' => $inputCode !== $resolvedFromDb['scale_code_v1'],
+                'is_known' => true,
+            ];
+        }
+
+        $v1ToV2 = $this->v1ToV2Map();
+        $v2ToV1 = $this->v2ToV1Map();
+        $uidMap = $this->uidMap();
+
+        if (isset($v1ToV2[$inputCode])) {
+            $v1 = $inputCode;
+            $v2 = (string) $v1ToV2[$inputCode];
+        } elseif (isset($v2ToV1[$inputCode])) {
+            $v2 = $inputCode;
+            $v1 = (string) $v2ToV1[$inputCode];
+        } else {
+            return [
+                'input_code' => $inputCode,
+                'scale_uid' => null,
+                'scale_code_v1' => $inputCode,
+                'scale_code_v2' => $inputCode,
+                'pack_id_v1' => null,
+                'pack_id_v2' => null,
+                'dir_version_v1' => null,
+                'dir_version_v2' => null,
+                'resolved_from_alias' => false,
+                'is_known' => false,
+            ];
+        }
+
+        $packIdV1 = $this->mapValueByScaleCode('pack_id_map_v1', $v1);
+        $packIdV2 = $this->mapValueByScaleCode('pack_id_map_v2', $v1);
+        $dirVersionV1 = $this->mapValueByScaleCode('dir_version_map_v1', $v1);
+        $dirVersionV2 = $this->mapValueByScaleCode('dir_version_map_v2', $v1);
+
+        return [
+            'input_code' => $inputCode,
+            'scale_uid' => $uidMap[$v1] ?? null,
+            'scale_code_v1' => $v1,
+            'scale_code_v2' => $v2,
+            'pack_id_v1' => $packIdV1,
+            'pack_id_v2' => $packIdV2,
+            'dir_version_v1' => $dirVersionV1,
+            'dir_version_v2' => $dirVersionV2,
+            'resolved_from_alias' => $inputCode !== $v1,
+            'is_known' => true,
+        ];
+    }
+
+    public function acceptsLegacyScaleCode(): bool
+    {
+        return (bool) config('scale_identity.accept_legacy_scale_code', true);
+    }
+
+    public function shouldAllowDemoScale(string $scaleCode): bool
+    {
+        $code = strtoupper(trim($scaleCode));
+        if ($code === '') {
+            return false;
+        }
+
+        if (! in_array($code, ['DEMO_ANSWERS', 'SIMPLE_SCORE_DEMO'], true)) {
+            return true;
+        }
+
+        return (bool) config('scale_identity.allow_demo_scales', true);
+    }
+
+    public function demoReplacement(string $scaleCode): ?string
+    {
+        $code = strtoupper(trim($scaleCode));
+        if ($code === '') {
+            return null;
+        }
+
+        $map = (array) config('scale_identity.demo_replacement_map', []);
+        $replacement = trim((string) ($map[$code] ?? ''));
+
+        return $replacement !== '' ? $replacement : null;
+    }
+
+    public function resolveResponseScaleCode(string $legacyCode, string $v2Code): string
+    {
+        $legacy = strtoupper(trim($legacyCode));
+        $v2 = strtoupper(trim($v2Code));
+
+        if ($legacy === '' && $v2 === '') {
+            return '';
+        }
+        if ($legacy === '') {
+            return $v2;
+        }
+        if ($v2 === '') {
+            $v2 = $legacy;
+        }
+
+        $mode = strtolower(trim((string) config('scale_identity.api_response_scale_code_mode', 'legacy')));
+        if ($mode === 'v2') {
+            return $v2;
+        }
+
+        // legacy + dual: keep old primary field stable while exposing v2 side-by-side.
+        return $legacy;
+    }
+
+    /**
+     * @return array<string,string>
+     */
+    private function v1ToV2Map(): array
+    {
+        $map = (array) config('scale_identity.code_map_v1_to_v2', []);
+        $out = [];
+        foreach ($map as $k => $v) {
+            $key = strtoupper(trim((string) $k));
+            $val = strtoupper(trim((string) $v));
+            if ($key === '' || $val === '') {
+                continue;
+            }
+            $out[$key] = $val;
+        }
+
+        return $out;
+    }
+
+    /**
+     * @return array<string,string>
+     */
+    private function v2ToV1Map(): array
+    {
+        $map = (array) config('scale_identity.code_map_v2_to_v1', []);
+        $out = [];
+        foreach ($map as $k => $v) {
+            $key = strtoupper(trim((string) $k));
+            $val = strtoupper(trim((string) $v));
+            if ($key === '' || $val === '') {
+                continue;
+            }
+            $out[$key] = $val;
+        }
+
+        return $out;
+    }
+
+    /**
+     * @return array<string,string>
+     */
+    private function uidMap(): array
+    {
+        $map = (array) config('scale_identity.scale_uid_map', []);
+        $out = [];
+        foreach ($map as $k => $v) {
+            $key = strtoupper(trim((string) $k));
+            $val = trim((string) $v);
+            if ($key === '' || $val === '') {
+                continue;
+            }
+            $out[$key] = $val;
+        }
+
+        return $out;
+    }
+
+    private function mapValueByScaleCode(string $configKey, string $scaleCodeV1): ?string
+    {
+        $map = (array) config('scale_identity.'.$configKey, []);
+        $value = trim((string) ($map[$scaleCodeV1] ?? ''));
+
+        return $value !== '' ? $value : null;
+    }
+
+    /**
+     * @return array{
+     *     scale_uid:string,
+     *     scale_code_v1:string,
+     *     scale_code_v2:string,
+     *     pack_id_v1:?string,
+     *     pack_id_v2:?string,
+     *     dir_version_v1:?string,
+     *     dir_version_v2:?string
+     * }|null
+     */
+    private function resolveIdentityFromDatabase(string $inputCode): ?array
+    {
+        if (! Schema::hasTable('scale_identities')) {
+            return null;
+        }
+
+        try {
+            if (Schema::hasTable('scale_code_aliases')) {
+                $aliasRow = DB::table('scale_code_aliases as aliases')
+                    ->join('scale_identities as identities', 'identities.scale_uid', '=', 'aliases.scale_uid')
+                    ->select([
+                        'identities.scale_uid',
+                        'identities.scale_code_v1',
+                        'identities.scale_code_v2',
+                        'identities.pack_id_v1',
+                        'identities.pack_id_v2',
+                        'identities.dir_version_v1',
+                        'identities.dir_version_v2',
+                    ])
+                    ->where('identities.status', 'active')
+                    ->whereRaw('upper(aliases.alias_code) = ?', [$inputCode])
+                    ->orderByDesc('aliases.is_primary')
+                    ->orderBy('aliases.id')
+                    ->first();
+
+                if ($aliasRow) {
+                    $scaleUid = trim((string) ($aliasRow->scale_uid ?? ''));
+                    $v1 = strtoupper(trim((string) ($aliasRow->scale_code_v1 ?? '')));
+                    $v2 = strtoupper(trim((string) ($aliasRow->scale_code_v2 ?? '')));
+                    if ($scaleUid !== '' && $v1 !== '' && $v2 !== '') {
+                        return [
+                            'scale_uid' => $scaleUid,
+                            'scale_code_v1' => $v1,
+                            'scale_code_v2' => $v2,
+                            'pack_id_v1' => $this->nullableValue($aliasRow->pack_id_v1 ?? null),
+                            'pack_id_v2' => $this->nullableValue($aliasRow->pack_id_v2 ?? null),
+                            'dir_version_v1' => $this->nullableValue($aliasRow->dir_version_v1 ?? null),
+                            'dir_version_v2' => $this->nullableValue($aliasRow->dir_version_v2 ?? null),
+                        ];
+                    }
+                }
+            }
+
+            $identityRow = DB::table('scale_identities')
+                ->select([
+                    'scale_uid',
+                    'scale_code_v1',
+                    'scale_code_v2',
+                    'pack_id_v1',
+                    'pack_id_v2',
+                    'dir_version_v1',
+                    'dir_version_v2',
+                ])
+                ->where('status', 'active')
+                ->where(function ($query) use ($inputCode): void {
+                    $query->whereRaw('upper(scale_code_v1) = ?', [$inputCode])
+                        ->orWhereRaw('upper(scale_code_v2) = ?', [$inputCode]);
+                })
+                ->first();
+
+            if (! $identityRow) {
+                return null;
+            }
+
+            $scaleUid = trim((string) ($identityRow->scale_uid ?? ''));
+            $v1 = strtoupper(trim((string) ($identityRow->scale_code_v1 ?? '')));
+            $v2 = strtoupper(trim((string) ($identityRow->scale_code_v2 ?? '')));
+            if ($scaleUid === '' || $v1 === '' || $v2 === '') {
+                return null;
+            }
+
+            return [
+                'scale_uid' => $scaleUid,
+                'scale_code_v1' => $v1,
+                'scale_code_v2' => $v2,
+                'pack_id_v1' => $this->nullableValue($identityRow->pack_id_v1 ?? null),
+                'pack_id_v2' => $this->nullableValue($identityRow->pack_id_v2 ?? null),
+                'dir_version_v1' => $this->nullableValue($identityRow->dir_version_v1 ?? null),
+                'dir_version_v2' => $this->nullableValue($identityRow->dir_version_v2 ?? null),
+            ];
+        } catch (\Throwable) {
+            // During phased rollout or partial migrations, keep resolver non-blocking.
+            return null;
+        }
+    }
+
+    private function nullableValue(mixed $value): ?string
+    {
+        $trimmed = trim((string) $value);
+
+        return $trimmed !== '' ? $trimmed : null;
+    }
+}

--- a/backend/app/Services/Scale/ScaleRegistry.php
+++ b/backend/app/Services/Scale/ScaleRegistry.php
@@ -11,6 +11,10 @@ class ScaleRegistry
 {
     public const CACHE_TTL_SECONDS = 300;
 
+    public function __construct(
+        private ScaleIdentityResolver $identityResolver,
+    ) {}
+
     public function listVisible(int $orgId = 0): array
     {
         if ($orgId <= 0) {
@@ -63,39 +67,26 @@ class ScaleRegistry
 
     public function getByCode(string $code, int $orgId = 0): ?array
     {
-        $code = trim($code);
-        if ($code === '') {
+        $requestedCode = strtoupper(trim($code));
+        if ($requestedCode === '') {
             return null;
         }
 
-        $cacheKey = CacheKeys::scaleRegistryByCode($orgId, $code);
+        $cacheKey = CacheKeys::scaleRegistryByCode($orgId, $requestedCode);
         $cached = Cache::get($cacheKey);
         if (is_array($cached)) {
             return $cached;
         }
 
-        $row = null;
-        if ($orgId <= 0) {
-            $row = ScaleRegistryModel::query()
-                ->where('org_id', 0)
-                ->where('code', $code)
-                ->where('is_public', true)
-                ->first();
-        } else {
-            $row = ScaleRegistryModel::query()
-                ->where('org_id', $orgId)
-                ->where('code', $code)
-                ->first();
-            if (!$row) {
-                $row = ScaleRegistryModel::query()
-                    ->where('org_id', 0)
-                    ->where('code', $code)
-                    ->where('is_public', true)
-                    ->first();
+        $row = $this->findByCode($requestedCode, $orgId);
+        if (! $row) {
+            $resolvedCode = $this->normalizeLookupCode($requestedCode);
+            if ($resolvedCode !== '' && $resolvedCode !== $requestedCode) {
+                $row = $this->findByCode($resolvedCode, $orgId);
             }
         }
 
-        if (!$row) {
+        if (! $row) {
             return null;
         }
 
@@ -193,5 +184,56 @@ class ScaleRegistry
         Cache::put($cacheKey, $payload, self::CACHE_TTL_SECONDS);
 
         return $payload;
+    }
+
+    private function findByCode(string $code, int $orgId): ?ScaleRegistryModel
+    {
+        if ($orgId <= 0) {
+            return ScaleRegistryModel::query()
+                ->where('org_id', 0)
+                ->where('code', $code)
+                ->where('is_public', true)
+                ->first();
+        }
+
+        $row = ScaleRegistryModel::query()
+            ->where('org_id', $orgId)
+            ->where('code', $code)
+            ->first();
+        if ($row) {
+            return $row;
+        }
+
+        return ScaleRegistryModel::query()
+            ->where('org_id', 0)
+            ->where('code', $code)
+            ->where('is_public', true)
+            ->first();
+    }
+
+    private function normalizeLookupCode(string $requestedCode): string
+    {
+        $identity = $this->identityResolver->resolveByAnyCode($requestedCode);
+        if (! is_array($identity) || ! ((bool) ($identity['is_known'] ?? false))) {
+            return $requestedCode;
+        }
+
+        $legacyCode = strtoupper(trim((string) ($identity['scale_code_v1'] ?? '')));
+        if ($legacyCode === '') {
+            return $requestedCode;
+        }
+
+        $readMode = strtolower(trim((string) config('scale_identity.read_mode', 'legacy')));
+        $isLegacyInput = $requestedCode === $legacyCode;
+        if (
+            $isLegacyInput
+            && ! $this->identityResolver->acceptsLegacyScaleCode()
+            && in_array($readMode, ['v2', 'dual_prefer_new'], true)
+        ) {
+            return '';
+        }
+
+        // Current storage is still v1; known aliases are resolved to v1 for read compatibility.
+        return $legacyCode;
     }
 }

--- a/backend/app/Services/Template/TemplateVariableRegistry.php
+++ b/backend/app/Services/Template/TemplateVariableRegistry.php
@@ -6,6 +6,7 @@ namespace App\Services\Template;
 
 use App\Services\Content\BigFivePackLoader;
 use App\Services\Content\ClinicalComboPackLoader;
+use App\Services\Content\ContentPathAliasResolver;
 
 final class TemplateVariableRegistry
 {
@@ -155,7 +156,10 @@ final class TemplateVariableRegistry
         ];
 
         try {
-            $loader = $this->bigFivePackLoader ?? new BigFivePackLoader();
+            $loader = $this->bigFivePackLoader ?? new BigFivePackLoader(
+                null,
+                app(ContentPathAliasResolver::class)
+            );
             $paths = [
                 $loader->compiledPath('policy.compiled.json', BigFivePackLoader::PACK_VERSION),
                 $loader->rawPath('variables_allowlist.json', BigFivePackLoader::PACK_VERSION),
@@ -218,7 +222,10 @@ final class TemplateVariableRegistry
         ];
 
         try {
-            $loader = $this->clinicalPackLoader ?? new ClinicalComboPackLoader();
+            $loader = $this->clinicalPackLoader ?? new ClinicalComboPackLoader(
+                null,
+                app(ContentPathAliasResolver::class)
+            );
             $paths = [
                 $loader->compiledPath('policy.compiled.json', ClinicalComboPackLoader::PACK_VERSION),
                 $loader->rawPath('variables_allowlist.json', ClinicalComboPackLoader::PACK_VERSION),

--- a/backend/app/Services/V0_3/ShareService.php
+++ b/backend/app/Services/V0_3/ShareService.php
@@ -27,6 +27,8 @@ class ShareService
 
         if (!$share) {
             $share = $this->createShare($attempt, $ctx->anonId());
+        } else {
+            $this->backfillShareScaleIdentityIfNeeded($share, $attempt);
         }
 
         $typeCode = (string) ($result->type_code ?? '');
@@ -127,6 +129,11 @@ class ShareService
         $share->scale_code = (string) ($attempt->scale_code ?? '');
         $share->scale_version = (string) ($attempt->scale_version ?? '');
         $share->content_package_version = (string) ($attempt->content_package_version ?? '');
+        if ($this->shouldWriteScaleIdentityColumns()) {
+            [$scaleCodeV2, $scaleUid] = $this->resolveScaleIdentityValues($attempt);
+            $share->scale_code_v2 = $scaleCodeV2;
+            $share->scale_uid = $scaleUid;
+        }
 
         try {
             $share->save();
@@ -136,5 +143,66 @@ class ShareService
                 ->where('attempt_id', (string) $attempt->id)
                 ->firstOrFail();
         }
+    }
+
+    private function backfillShareScaleIdentityIfNeeded(Share $share, Attempt $attempt): void
+    {
+        if (!$this->shouldWriteScaleIdentityColumns()) {
+            return;
+        }
+
+        [$scaleCodeV2, $scaleUid] = $this->resolveScaleIdentityValues($attempt);
+        $dirty = false;
+
+        if (trim((string) ($share->scale_code_v2 ?? '')) === '' && $scaleCodeV2 !== null && $scaleCodeV2 !== '') {
+            $share->scale_code_v2 = $scaleCodeV2;
+            $dirty = true;
+        }
+        if (trim((string) ($share->scale_uid ?? '')) === '' && $scaleUid !== null && $scaleUid !== '') {
+            $share->scale_uid = $scaleUid;
+            $dirty = true;
+        }
+
+        if (!$dirty) {
+            return;
+        }
+
+        try {
+            $share->save();
+        } catch (QueryException $e) {
+            // best effort backfill; keep read path unaffected on contention.
+        }
+    }
+
+    /**
+     * @return array{0:?string,1:?string}
+     */
+    private function resolveScaleIdentityValues(Attempt $attempt): array
+    {
+        $legacyCode = strtoupper(trim((string) ($attempt->scale_code ?? '')));
+        $scaleCodeV2 = strtoupper(trim((string) ($attempt->scale_code_v2 ?? '')));
+        $scaleUid = trim((string) ($attempt->scale_uid ?? ''));
+
+        $mapV1ToV2 = (array) config('scale_identity.code_map_v1_to_v2', []);
+        $uidMap = (array) config('scale_identity.scale_uid_map', []);
+
+        if ($scaleCodeV2 === '' && $legacyCode !== '' && isset($mapV1ToV2[$legacyCode])) {
+            $scaleCodeV2 = strtoupper(trim((string) $mapV1ToV2[$legacyCode]));
+        }
+        if ($scaleUid === '' && $legacyCode !== '' && isset($uidMap[$legacyCode])) {
+            $scaleUid = trim((string) $uidMap[$legacyCode]);
+        }
+
+        return [
+            $scaleCodeV2 !== '' ? $scaleCodeV2 : null,
+            $scaleUid !== '' ? $scaleUid : null,
+        ];
+    }
+
+    private function shouldWriteScaleIdentityColumns(): bool
+    {
+        $mode = strtolower(trim((string) config('scale_identity.write_mode', 'legacy')));
+
+        return in_array($mode, ['dual', 'v2'], true);
     }
 }

--- a/backend/config/scale_identity.php
+++ b/backend/config/scale_identity.php
@@ -1,0 +1,97 @@
+<?php
+
+declare(strict_types=1);
+
+return [
+    // Write path mode for scale identity columns.
+    // legacy: write legacy fields only
+    // dual: write both legacy and v2 fields
+    // v2: write v2 fields only
+    'write_mode' => env('FAP_SCALE_IDENTITY_WRITE_MODE', 'legacy'),
+
+    // Read path mode for scale identity resolution.
+    // legacy|dual_prefer_old|dual_prefer_new|v2
+    'read_mode' => env('FAP_SCALE_IDENTITY_READ_MODE', 'legacy'),
+
+    // Whether old scale codes are still accepted as request input.
+    'accept_legacy_scale_code' => (bool) env('FAP_ACCEPT_LEGACY_SCALE_CODE', true),
+
+    // API response scale code mode.
+    // legacy|dual|v2
+    'api_response_scale_code_mode' => env('FAP_API_RESPONSE_SCALE_CODE_MODE', 'legacy'),
+
+    // Content path read mode and publish mode.
+    'content_path_mode' => env('FAP_CONTENT_PATH_MODE', 'legacy'),
+    'content_publish_mode' => env('FAP_CONTENT_PUBLISH_MODE', 'legacy'),
+
+    // Demo scale switch for offboarding.
+    'allow_demo_scales' => (bool) env('FAP_ALLOW_DEMO_SCALES', true),
+
+    'code_map_v1_to_v2' => [
+        'MBTI' => 'MBTI_PERSONALITY_TEST_16_TYPES',
+        'BIG5_OCEAN' => 'BIG_FIVE_OCEAN_MODEL',
+        'CLINICAL_COMBO_68' => 'CLINICAL_DEPRESSION_ANXIETY_PRO',
+        'SDS_20' => 'DEPRESSION_SCREENING_STANDARD',
+        'IQ_RAVEN' => 'IQ_INTELLIGENCE_QUOTIENT',
+        'EQ_60' => 'EQ_EMOTIONAL_INTELLIGENCE',
+    ],
+
+    'code_map_v2_to_v1' => [
+        'MBTI_PERSONALITY_TEST_16_TYPES' => 'MBTI',
+        'BIG_FIVE_OCEAN_MODEL' => 'BIG5_OCEAN',
+        'CLINICAL_DEPRESSION_ANXIETY_PRO' => 'CLINICAL_COMBO_68',
+        'DEPRESSION_SCREENING_STANDARD' => 'SDS_20',
+        'IQ_INTELLIGENCE_QUOTIENT' => 'IQ_RAVEN',
+        'EQ_EMOTIONAL_INTELLIGENCE' => 'EQ_60',
+    ],
+
+    'scale_uid_map' => [
+        'MBTI' => '11111111-1111-4111-8111-111111111111',
+        'BIG5_OCEAN' => '22222222-2222-4222-8222-222222222222',
+        'CLINICAL_COMBO_68' => '33333333-3333-4333-8333-333333333333',
+        'SDS_20' => '44444444-4444-4444-8444-444444444444',
+        'IQ_RAVEN' => '55555555-5555-4555-8555-555555555555',
+        'EQ_60' => '66666666-6666-4666-8666-666666666666',
+    ],
+
+    'pack_id_map_v1' => [
+        'MBTI' => 'MBTI.cn-mainland.zh-CN.v0.3',
+        'BIG5_OCEAN' => 'BIG5_OCEAN',
+        'CLINICAL_COMBO_68' => 'CLINICAL_COMBO_68',
+        'SDS_20' => 'SDS_20',
+        'IQ_RAVEN' => 'default',
+        'EQ_60' => 'EQ_60',
+    ],
+
+    'pack_id_map_v2' => [
+        'MBTI' => 'MBTI_PERSONALITY_TEST_16_TYPES.cn-mainland.zh-CN.v0.3',
+        'BIG5_OCEAN' => 'BIG_FIVE_OCEAN_MODEL',
+        'CLINICAL_COMBO_68' => 'CLINICAL_DEPRESSION_ANXIETY_PRO',
+        'SDS_20' => 'DEPRESSION_SCREENING_STANDARD',
+        'IQ_RAVEN' => 'default',
+        'EQ_60' => 'EQ_EMOTIONAL_INTELLIGENCE',
+    ],
+
+    'dir_version_map_v1' => [
+        'MBTI' => 'MBTI-CN-v0.3',
+        'BIG5_OCEAN' => 'v1',
+        'CLINICAL_COMBO_68' => 'v1',
+        'SDS_20' => 'v1',
+        'IQ_RAVEN' => 'IQ-RAVEN-CN-v0.3.0-DEMO',
+        'EQ_60' => 'v1',
+    ],
+
+    'dir_version_map_v2' => [
+        'MBTI' => 'MBTI_PERSONALITY_TEST_16_TYPES-CN-v0.3',
+        'BIG5_OCEAN' => 'v1',
+        'CLINICAL_COMBO_68' => 'v1',
+        'SDS_20' => 'v1',
+        'IQ_RAVEN' => 'IQ_INTELLIGENCE_QUOTIENT-CN-v0.3.0-DEMO',
+        'EQ_60' => 'v1',
+    ],
+
+    'demo_replacement_map' => [
+        'DEMO_ANSWERS' => 'IQ_RAVEN',
+        'SIMPLE_SCORE_DEMO' => 'SDS_20',
+    ],
+];

--- a/backend/database/migrations/2026_02_27_000100_create_scale_identities_table.php
+++ b/backend/database/migrations/2026_02_27_000100_create_scale_identities_table.php
@@ -1,0 +1,123 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        if (! Schema::hasTable('scale_identities')) {
+            Schema::create('scale_identities', function (Blueprint $table): void {
+                $table->char('scale_uid', 36);
+                $table->string('scale_code_v1', 64);
+                $table->string('scale_code_v2', 64);
+                $table->string('pack_id_v1', 128)->nullable();
+                $table->string('pack_id_v2', 128)->nullable();
+                $table->string('dir_version_v1', 128)->nullable();
+                $table->string('dir_version_v2', 128)->nullable();
+                $table->string('status', 16)->default('active');
+                $table->timestamps();
+
+                $table->primary('scale_uid', 'scale_identities_scale_uid_pk');
+                $table->unique('scale_code_v1', 'scale_identities_scale_code_v1_unique');
+                $table->unique('scale_code_v2', 'scale_identities_scale_code_v2_unique');
+                $table->index('status', 'scale_identities_status_idx');
+            });
+        }
+
+        $now = now();
+        DB::table('scale_identities')->upsert([
+            [
+                'scale_uid' => '11111111-1111-4111-8111-111111111111',
+                'scale_code_v1' => 'MBTI',
+                'scale_code_v2' => 'MBTI_PERSONALITY_TEST_16_TYPES',
+                'pack_id_v1' => 'MBTI.cn-mainland.zh-CN.v0.3',
+                'pack_id_v2' => 'MBTI_PERSONALITY_TEST_16_TYPES.cn-mainland.zh-CN.v0.3',
+                'dir_version_v1' => 'MBTI-CN-v0.3',
+                'dir_version_v2' => 'MBTI_PERSONALITY_TEST_16_TYPES-CN-v0.3',
+                'status' => 'active',
+                'created_at' => $now,
+                'updated_at' => $now,
+            ],
+            [
+                'scale_uid' => '22222222-2222-4222-8222-222222222222',
+                'scale_code_v1' => 'BIG5_OCEAN',
+                'scale_code_v2' => 'BIG_FIVE_OCEAN_MODEL',
+                'pack_id_v1' => 'BIG5_OCEAN',
+                'pack_id_v2' => 'BIG_FIVE_OCEAN_MODEL',
+                'dir_version_v1' => 'v1',
+                'dir_version_v2' => 'v1',
+                'status' => 'active',
+                'created_at' => $now,
+                'updated_at' => $now,
+            ],
+            [
+                'scale_uid' => '33333333-3333-4333-8333-333333333333',
+                'scale_code_v1' => 'CLINICAL_COMBO_68',
+                'scale_code_v2' => 'CLINICAL_DEPRESSION_ANXIETY_PRO',
+                'pack_id_v1' => 'CLINICAL_COMBO_68',
+                'pack_id_v2' => 'CLINICAL_DEPRESSION_ANXIETY_PRO',
+                'dir_version_v1' => 'v1',
+                'dir_version_v2' => 'v1',
+                'status' => 'active',
+                'created_at' => $now,
+                'updated_at' => $now,
+            ],
+            [
+                'scale_uid' => '44444444-4444-4444-8444-444444444444',
+                'scale_code_v1' => 'SDS_20',
+                'scale_code_v2' => 'DEPRESSION_SCREENING_STANDARD',
+                'pack_id_v1' => 'SDS_20',
+                'pack_id_v2' => 'DEPRESSION_SCREENING_STANDARD',
+                'dir_version_v1' => 'v1',
+                'dir_version_v2' => 'v1',
+                'status' => 'active',
+                'created_at' => $now,
+                'updated_at' => $now,
+            ],
+            [
+                'scale_uid' => '55555555-5555-4555-8555-555555555555',
+                'scale_code_v1' => 'IQ_RAVEN',
+                'scale_code_v2' => 'IQ_INTELLIGENCE_QUOTIENT',
+                'pack_id_v1' => 'default',
+                'pack_id_v2' => 'default',
+                'dir_version_v1' => 'IQ-RAVEN-CN-v0.3.0-DEMO',
+                'dir_version_v2' => 'IQ_INTELLIGENCE_QUOTIENT-CN-v0.3.0-DEMO',
+                'status' => 'active',
+                'created_at' => $now,
+                'updated_at' => $now,
+            ],
+            [
+                'scale_uid' => '66666666-6666-4666-8666-666666666666',
+                'scale_code_v1' => 'EQ_60',
+                'scale_code_v2' => 'EQ_EMOTIONAL_INTELLIGENCE',
+                'pack_id_v1' => 'EQ_60',
+                'pack_id_v2' => 'EQ_EMOTIONAL_INTELLIGENCE',
+                'dir_version_v1' => 'v1',
+                'dir_version_v2' => 'v1',
+                'status' => 'active',
+                'created_at' => $now,
+                'updated_at' => $now,
+            ],
+        ], ['scale_code_v1'], [
+            'scale_uid',
+            'scale_code_v2',
+            'pack_id_v1',
+            'pack_id_v2',
+            'dir_version_v1',
+            'dir_version_v2',
+            'status',
+            'updated_at',
+        ]);
+    }
+
+    public function down(): void
+    {
+        // forward-only migration: rollback disabled by design.
+    }
+};

--- a/backend/database/migrations/2026_02_27_000110_create_scale_code_aliases_table.php
+++ b/backend/database/migrations/2026_02_27_000110_create_scale_code_aliases_table.php
@@ -1,0 +1,64 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        if (! Schema::hasTable('scale_code_aliases')) {
+            Schema::create('scale_code_aliases', function (Blueprint $table): void {
+                $table->bigIncrements('id');
+                $table->char('scale_uid', 36);
+                $table->string('alias_code', 64);
+                $table->string('alias_type', 16);
+                $table->boolean('is_primary')->default(false);
+                $table->timestamps();
+
+                $table->unique('alias_code', 'scale_code_aliases_alias_code_unique');
+                $table->index('scale_uid', 'scale_code_aliases_scale_uid_idx');
+                $table->index(['scale_uid', 'alias_type'], 'scale_code_aliases_uid_type_idx');
+                $table->index('is_primary', 'scale_code_aliases_is_primary_idx');
+            });
+        }
+
+        $now = now();
+        $aliases = [
+            ['scale_uid' => '11111111-1111-4111-8111-111111111111', 'alias_code' => 'MBTI', 'alias_type' => 'v1', 'is_primary' => true],
+            ['scale_uid' => '11111111-1111-4111-8111-111111111111', 'alias_code' => 'MBTI_PERSONALITY_TEST_16_TYPES', 'alias_type' => 'v2', 'is_primary' => false],
+            ['scale_uid' => '22222222-2222-4222-8222-222222222222', 'alias_code' => 'BIG5_OCEAN', 'alias_type' => 'v1', 'is_primary' => true],
+            ['scale_uid' => '22222222-2222-4222-8222-222222222222', 'alias_code' => 'BIG_FIVE_OCEAN_MODEL', 'alias_type' => 'v2', 'is_primary' => false],
+            ['scale_uid' => '33333333-3333-4333-8333-333333333333', 'alias_code' => 'CLINICAL_COMBO_68', 'alias_type' => 'v1', 'is_primary' => true],
+            ['scale_uid' => '33333333-3333-4333-8333-333333333333', 'alias_code' => 'CLINICAL_DEPRESSION_ANXIETY_PRO', 'alias_type' => 'v2', 'is_primary' => false],
+            ['scale_uid' => '44444444-4444-4444-8444-444444444444', 'alias_code' => 'SDS_20', 'alias_type' => 'v1', 'is_primary' => true],
+            ['scale_uid' => '44444444-4444-4444-8444-444444444444', 'alias_code' => 'DEPRESSION_SCREENING_STANDARD', 'alias_type' => 'v2', 'is_primary' => false],
+            ['scale_uid' => '55555555-5555-4555-8555-555555555555', 'alias_code' => 'IQ_RAVEN', 'alias_type' => 'v1', 'is_primary' => true],
+            ['scale_uid' => '55555555-5555-4555-8555-555555555555', 'alias_code' => 'IQ_INTELLIGENCE_QUOTIENT', 'alias_type' => 'v2', 'is_primary' => false],
+            ['scale_uid' => '66666666-6666-4666-8666-666666666666', 'alias_code' => 'EQ_60', 'alias_type' => 'v1', 'is_primary' => true],
+            ['scale_uid' => '66666666-6666-4666-8666-666666666666', 'alias_code' => 'EQ_EMOTIONAL_INTELLIGENCE', 'alias_type' => 'v2', 'is_primary' => false],
+        ];
+
+        foreach ($aliases as $alias) {
+            DB::table('scale_code_aliases')->updateOrInsert(
+                ['alias_code' => $alias['alias_code']],
+                [
+                    'scale_uid' => $alias['scale_uid'],
+                    'alias_type' => $alias['alias_type'],
+                    'is_primary' => $alias['is_primary'],
+                    'updated_at' => $now,
+                    'created_at' => $now,
+                ]
+            );
+        }
+    }
+
+    public function down(): void
+    {
+        // forward-only migration: rollback disabled by design.
+    }
+};

--- a/backend/database/migrations/2026_02_27_000120_create_content_path_aliases_table.php
+++ b/backend/database/migrations/2026_02_27_000120_create_content_path_aliases_table.php
@@ -1,0 +1,94 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        if (! Schema::hasTable('content_path_aliases')) {
+            Schema::create('content_path_aliases', function (Blueprint $table): void {
+                $table->bigIncrements('id');
+                $table->string('scope', 64);
+                $table->string('old_path', 255);
+                $table->string('new_path', 255);
+                $table->char('scale_uid', 36)->nullable();
+                $table->boolean('is_active')->default(true);
+                $table->timestamps();
+
+                $table->unique(['scope', 'old_path'], 'content_path_aliases_scope_old_unique');
+                $table->index(['scope', 'is_active'], 'content_path_aliases_scope_active_idx');
+                $table->index('scale_uid', 'content_path_aliases_scale_uid_idx');
+            });
+        }
+
+        $now = now();
+        $rows = [
+            [
+                'scope' => 'backend_content_packs',
+                'old_path' => 'content_packs/BIG5_OCEAN',
+                'new_path' => 'content_packs/BIG_FIVE_OCEAN_MODEL',
+                'scale_uid' => '22222222-2222-4222-8222-222222222222',
+            ],
+            [
+                'scope' => 'backend_content_packs',
+                'old_path' => 'content_packs/CLINICAL_COMBO_68',
+                'new_path' => 'content_packs/CLINICAL_DEPRESSION_ANXIETY_PRO',
+                'scale_uid' => '33333333-3333-4333-8333-333333333333',
+            ],
+            [
+                'scope' => 'backend_content_packs',
+                'old_path' => 'content_packs/SDS_20',
+                'new_path' => 'content_packs/DEPRESSION_SCREENING_STANDARD',
+                'scale_uid' => '44444444-4444-4444-8444-444444444444',
+            ],
+            [
+                'scope' => 'backend_content_packs',
+                'old_path' => 'content_packs/EQ_60',
+                'new_path' => 'content_packs/EQ_EMOTIONAL_INTELLIGENCE',
+                'scale_uid' => '66666666-6666-4666-8666-666666666666',
+            ],
+            [
+                'scope' => 'content_packages',
+                'old_path' => 'default/CN_MAINLAND/zh-CN/MBTI-CN-v0.3',
+                'new_path' => 'default/CN_MAINLAND/zh-CN/MBTI_PERSONALITY_TEST_16_TYPES-CN-v0.3',
+                'scale_uid' => '11111111-1111-4111-8111-111111111111',
+            ],
+            [
+                'scope' => 'content_packages',
+                'old_path' => 'default/CN_MAINLAND/zh-CN/IQ-RAVEN-CN-v0.3.0-DEMO',
+                'new_path' => 'default/CN_MAINLAND/zh-CN/IQ_INTELLIGENCE_QUOTIENT-CN-v0.3.0-DEMO',
+                'scale_uid' => '55555555-5555-4555-8555-555555555555',
+            ],
+            [
+                'scope' => 'content_packages',
+                'old_path' => 'default/CN_MAINLAND/zh-CN/BIG5-CN-v0.1.0-TEST',
+                'new_path' => 'default/CN_MAINLAND/zh-CN/BIG_FIVE_OCEAN_MODEL-CN-v0.1.0-TEST',
+                'scale_uid' => '22222222-2222-4222-8222-222222222222',
+            ],
+        ];
+
+        foreach ($rows as $row) {
+            DB::table('content_path_aliases')->updateOrInsert(
+                ['scope' => $row['scope'], 'old_path' => $row['old_path']],
+                [
+                    'new_path' => $row['new_path'],
+                    'scale_uid' => $row['scale_uid'],
+                    'is_active' => true,
+                    'updated_at' => $now,
+                    'created_at' => $now,
+                ]
+            );
+        }
+    }
+
+    public function down(): void
+    {
+        // forward-only migration: rollback disabled by design.
+    }
+};

--- a/backend/database/migrations/2026_02_27_000130_add_scale_identity_columns_to_attempts_table.php
+++ b/backend/database/migrations/2026_02_27_000130_add_scale_identity_columns_to_attempts_table.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        if (! Schema::hasTable('attempts')) {
+            return;
+        }
+
+        Schema::table('attempts', function (Blueprint $table): void {
+            if (! Schema::hasColumn('attempts', 'scale_code_v2')) {
+                $table->string('scale_code_v2', 64)->nullable()->after('scale_code');
+            }
+
+            if (! Schema::hasColumn('attempts', 'scale_uid')) {
+                $table->char('scale_uid', 36)->nullable()->after('scale_code_v2');
+            }
+        });
+    }
+
+    public function down(): void
+    {
+        // forward-only migration: rollback disabled by design.
+    }
+};
+

--- a/backend/database/migrations/2026_02_27_000140_add_scale_identity_columns_to_results_table.php
+++ b/backend/database/migrations/2026_02_27_000140_add_scale_identity_columns_to_results_table.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        if (! Schema::hasTable('results')) {
+            return;
+        }
+
+        Schema::table('results', function (Blueprint $table): void {
+            if (! Schema::hasColumn('results', 'scale_code_v2')) {
+                $table->string('scale_code_v2', 64)->nullable()->after('scale_code');
+            }
+
+            if (! Schema::hasColumn('results', 'scale_uid')) {
+                $table->char('scale_uid', 36)->nullable()->after('scale_code_v2');
+            }
+        });
+    }
+
+    public function down(): void
+    {
+        // forward-only migration: rollback disabled by design.
+    }
+};
+

--- a/backend/database/migrations/2026_02_27_000150_add_scale_identity_columns_to_events_table.php
+++ b/backend/database/migrations/2026_02_27_000150_add_scale_identity_columns_to_events_table.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        if (! Schema::hasTable('events')) {
+            return;
+        }
+
+        Schema::table('events', function (Blueprint $table): void {
+            if (! Schema::hasColumn('events', 'scale_code_v2')) {
+                $table->string('scale_code_v2', 64)->nullable()->after('scale_code');
+            }
+
+            if (! Schema::hasColumn('events', 'scale_uid')) {
+                $table->char('scale_uid', 36)->nullable()->after('scale_code_v2');
+            }
+        });
+    }
+
+    public function down(): void
+    {
+        // forward-only migration: rollback disabled by design.
+    }
+};
+

--- a/backend/database/migrations/2026_02_27_000160_add_scale_identity_columns_to_report_snapshots_table.php
+++ b/backend/database/migrations/2026_02_27_000160_add_scale_identity_columns_to_report_snapshots_table.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        if (! Schema::hasTable('report_snapshots')) {
+            return;
+        }
+
+        Schema::table('report_snapshots', function (Blueprint $table): void {
+            if (! Schema::hasColumn('report_snapshots', 'scale_code_v2')) {
+                $table->string('scale_code_v2', 64)->nullable()->after('scale_code');
+            }
+
+            if (! Schema::hasColumn('report_snapshots', 'scale_uid')) {
+                $table->char('scale_uid', 36)->nullable()->after('scale_code_v2');
+            }
+        });
+    }
+
+    public function down(): void
+    {
+        // forward-only migration: rollback disabled by design.
+    }
+};
+

--- a/backend/database/migrations/2026_02_27_000170_add_scale_identity_columns_to_shares_table.php
+++ b/backend/database/migrations/2026_02_27_000170_add_scale_identity_columns_to_shares_table.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        if (! Schema::hasTable('shares')) {
+            return;
+        }
+
+        Schema::table('shares', function (Blueprint $table): void {
+            if (! Schema::hasColumn('shares', 'scale_code_v2')) {
+                $table->string('scale_code_v2', 64)->nullable()->after('scale_code');
+            }
+
+            if (! Schema::hasColumn('shares', 'scale_uid')) {
+                $table->char('scale_uid', 36)->nullable()->after('scale_code_v2');
+            }
+        });
+    }
+
+    public function down(): void
+    {
+        // forward-only migration: rollback disabled by design.
+    }
+};
+

--- a/backend/database/migrations/2026_02_27_000180_add_scale_identity_columns_to_payment_events_table.php
+++ b/backend/database/migrations/2026_02_27_000180_add_scale_identity_columns_to_payment_events_table.php
@@ -1,0 +1,31 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        if (! Schema::hasTable('payment_events')) {
+            return;
+        }
+
+        Schema::table('payment_events', function (Blueprint $table): void {
+            if (! Schema::hasColumn('payment_events', 'scale_code_v2')) {
+                $table->string('scale_code_v2', 64)->nullable()->after('effective_sku');
+            }
+
+            if (! Schema::hasColumn('payment_events', 'scale_uid')) {
+                $table->char('scale_uid', 36)->nullable()->after('scale_code_v2');
+            }
+        });
+    }
+
+    public function down(): void
+    {
+        // forward-only migration: rollback disabled.
+    }
+};
+

--- a/backend/database/migrations/2026_02_27_000190_add_scale_identity_columns_to_attempt_answer_tables.php
+++ b/backend/database/migrations/2026_02_27_000190_add_scale_identity_columns_to_attempt_answer_tables.php
@@ -1,0 +1,41 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        if (Schema::hasTable('attempt_answer_sets')) {
+            Schema::table('attempt_answer_sets', function (Blueprint $table): void {
+                if (! Schema::hasColumn('attempt_answer_sets', 'scale_code_v2')) {
+                    $table->string('scale_code_v2', 64)->nullable()->after('scale_code');
+                }
+
+                if (! Schema::hasColumn('attempt_answer_sets', 'scale_uid')) {
+                    $table->char('scale_uid', 36)->nullable()->after('scale_code_v2');
+                }
+            });
+        }
+
+        if (Schema::hasTable('attempt_answer_rows')) {
+            Schema::table('attempt_answer_rows', function (Blueprint $table): void {
+                if (! Schema::hasColumn('attempt_answer_rows', 'scale_code_v2')) {
+                    $table->string('scale_code_v2', 64)->nullable()->after('scale_code');
+                }
+
+                if (! Schema::hasColumn('attempt_answer_rows', 'scale_uid')) {
+                    $table->char('scale_uid', 36)->nullable()->after('scale_code_v2');
+                }
+            });
+        }
+    }
+
+    public function down(): void
+    {
+        // forward-only migration: rollback disabled.
+    }
+};
+

--- a/backend/database/migrations/2026_02_27_000200_add_scale_identity_columns_to_orders_table.php
+++ b/backend/database/migrations/2026_02_27_000200_add_scale_identity_columns_to_orders_table.php
@@ -1,0 +1,31 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        if (! Schema::hasTable('orders')) {
+            return;
+        }
+
+        Schema::table('orders', function (Blueprint $table): void {
+            if (! Schema::hasColumn('orders', 'scale_code_v2')) {
+                $table->string('scale_code_v2', 64)->nullable()->after('target_attempt_id');
+            }
+
+            if (! Schema::hasColumn('orders', 'scale_uid')) {
+                $table->char('scale_uid', 36)->nullable()->after('scale_code_v2');
+            }
+        });
+    }
+
+    public function down(): void
+    {
+        // forward-only migration: rollback disabled.
+    }
+};
+

--- a/backend/database/migrations/2026_02_27_000210_add_scale_identity_columns_to_assessments_table.php
+++ b/backend/database/migrations/2026_02_27_000210_add_scale_identity_columns_to_assessments_table.php
@@ -1,0 +1,31 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        if (! Schema::hasTable('assessments')) {
+            return;
+        }
+
+        Schema::table('assessments', function (Blueprint $table): void {
+            if (! Schema::hasColumn('assessments', 'scale_code_v2')) {
+                $table->string('scale_code_v2', 64)->nullable()->after('scale_code');
+            }
+
+            if (! Schema::hasColumn('assessments', 'scale_uid')) {
+                $table->char('scale_uid', 36)->nullable()->after('scale_code_v2');
+            }
+        });
+    }
+
+    public function down(): void
+    {
+        // forward-only migration: rollback disabled.
+    }
+};
+

--- a/backend/database/seeders/CiScalesRegistrySeeder.php
+++ b/backend/database/seeders/CiScalesRegistrySeeder.php
@@ -35,6 +35,7 @@ final class CiScalesRegistrySeeder extends Seeder
         if ($demoPackId === '') {
             $demoPackId = $defaultPackId;
         }
+        $includeDemoScales = $this->includeDemoScales();
 
         $rows = [
             [
@@ -258,6 +259,13 @@ final class CiScalesRegistrySeeder extends Seeder
             ],
         ];
 
+        if (! $includeDemoScales) {
+            $rows = array_values(array_filter($rows, static function (array $row): bool {
+                $code = strtoupper(trim((string) ($row['code'] ?? '')));
+                return ! in_array($code, ['DEMO_ANSWERS', 'SIMPLE_SCORE_DEMO'], true);
+            }));
+        }
+
         DB::table('scales_registry')->upsert(
             $rows,
             ['code'],
@@ -278,6 +286,36 @@ final class CiScalesRegistrySeeder extends Seeder
             ]
         );
 
-        $this->command?->info('CiScalesRegistrySeeder: upserted 8 scales.');
+        if (! $includeDemoScales) {
+            DB::table('scales_registry')
+                ->where('org_id', 0)
+                ->whereIn('code', ['DEMO_ANSWERS', 'SIMPLE_SCORE_DEMO'])
+                ->update([
+                    'is_active' => 0,
+                    'is_public' => 0,
+                    'updated_at' => $now,
+                ]);
+        }
+
+        $this->command?->info(sprintf(
+            'CiScalesRegistrySeeder: upserted %d scales (include_demo_scales=%d).',
+            count($rows),
+            $includeDemoScales ? 1 : 0
+        ));
+    }
+
+    private function includeDemoScales(): bool
+    {
+        $raw = getenv('FAP_CI_INCLUDE_DEMO_SCALES');
+        if ($raw === false) {
+            return false;
+        }
+
+        $normalized = strtolower(trim((string) $raw));
+        if ($normalized === '') {
+            return false;
+        }
+
+        return ! in_array($normalized, ['0', 'false', 'off', 'no'], true);
     }
 }

--- a/backend/scripts/ci_verify_mbti.sh
+++ b/backend/scripts/ci_verify_mbti.sh
@@ -62,8 +62,9 @@ RUN_SDS_20_GATE="${RUN_SDS_20_GATE:-0}"
 RUN_EQ_60_GATE="${RUN_EQ_60_GATE:-0}"
 RUN_SDS_NORMS_GATE="${RUN_SDS_NORMS_GATE:-0}"
 RUN_FULL_SCALE_REGRESSION="${RUN_FULL_SCALE_REGRESSION:-0}"
+RUN_SCALE_IDENTITY_GATE="${RUN_SCALE_IDENTITY_GATE:-0}"
 SCALE_SCOPE="${SCALE_SCOPE:-mbti_only}"
-echo "[CI] scale_scope=${SCALE_SCOPE} run_big5_ocean_gate=${RUN_BIG5_OCEAN_GATE} run_clinical_combo_68_gate=${RUN_CLINICAL_COMBO_68_GATE} run_sds_20_gate=${RUN_SDS_20_GATE} run_eq_60_gate=${RUN_EQ_60_GATE} run_sds_norms_gate=${RUN_SDS_NORMS_GATE} run_full_scale_regression=${RUN_FULL_SCALE_REGRESSION}"
+echo "[CI] scale_scope=${SCALE_SCOPE} run_big5_ocean_gate=${RUN_BIG5_OCEAN_GATE} run_clinical_combo_68_gate=${RUN_CLINICAL_COMBO_68_GATE} run_sds_20_gate=${RUN_SDS_20_GATE} run_eq_60_gate=${RUN_EQ_60_GATE} run_sds_norms_gate=${RUN_SDS_NORMS_GATE} run_full_scale_regression=${RUN_FULL_SCALE_REGRESSION} run_scale_identity_gate=${RUN_SCALE_IDENTITY_GATE}"
 if [[ "$RUN_BIG5_OCEAN_GATE" == "1" ]]; then
   echo "[CI] running BIG5_OCEAN content gates"
   bash "$BACKEND_DIR/scripts/ci/verify_big5_norms.sh"
@@ -107,6 +108,15 @@ if [[ "$RUN_SDS_NORMS_GATE" == "1" ]]; then
   RUN_SDS_NORMS_GATE=1 bash "$BACKEND_DIR/scripts/ci/verify_sds_norms.sh"
 
   echo "[CI] rebuilding sqlite baseline after SDS_20 norms gate"
+  bash "$BACKEND_DIR/scripts/ci/prepare_sqlite.sh"
+  php artisan fap:schema:verify
+fi
+
+if [[ "$RUN_SCALE_IDENTITY_GATE" == "1" ]]; then
+  echo "[CI] running scale identity gate"
+  bash "$BACKEND_DIR/scripts/prA_gate_scale_identity.sh"
+
+  echo "[CI] rebuilding sqlite baseline after scale identity gate"
   bash "$BACKEND_DIR/scripts/ci/prepare_sqlite.sh"
   php artisan fap:schema:verify
 fi

--- a/backend/scripts/ci_verify_mbti.sh
+++ b/backend/scripts/ci_verify_mbti.sh
@@ -354,15 +354,21 @@ cleanup() {
   local ec=$?
   trap - EXIT INT TERM
 
-  if [[ -n "${SERVE_PID:-}" ]]; then
-    kill "$SERVE_PID" >/dev/null 2>&1 || true
-  fi
+  stop_server_if_running
 
   cleanup_legacy_alias
   cleanup_env_file
   exit "$ec"
 }
 trap cleanup EXIT INT TERM
+
+stop_server_if_running() {
+  if [[ -n "${SERVE_PID:-}" ]]; then
+    kill "$SERVE_PID" >/dev/null 2>&1 || true
+    wait "$SERVE_PID" 2>/dev/null || true
+    SERVE_PID=""
+  fi
+}
 
 if [[ -d "$CANON_ABS" ]]; then
   if [[ ! -e "$ALIAS_ABS" ]]; then
@@ -942,6 +948,9 @@ API="$API" SQLITE_DB="$SQLITE_DB_FOR_ACCEPT" FM_TOKEN="$FM_TOKEN" \
   "$SCRIPT_DIR/accept_events_D_anon_block_placeholder_click.sh"
 
 echo "[CI] events acceptance OK"
+
+echo "[CI] stopping API server before phpunit gates"
+stop_server_if_running
 
 echo "[CI] payment event provider uniqueness gate"
 php artisan test --filter PaymentEventUniquenessAcrossProvidersTest

--- a/backend/scripts/pr15_verify_scale_registry.sh
+++ b/backend/scripts/pr15_verify_scale_registry.sh
@@ -41,6 +41,8 @@ $canonical = json_decode((string) file_get_contents($argv[1]), true);
 if (!is_array($canonical) || ($canonical["ok"] ?? false) !== true) { fwrite(STDERR, "canonical lookup failed\n"); exit(1); }
 if (($canonical["resolved_from_alias"] ?? null) !== false) { fwrite(STDERR, "canonical resolved_from_alias must be false\n"); exit(1); }
 if (($canonical["primary_slug"] ?? "") !== "mbti-personality-test-16-personality-types") { fwrite(STDERR, "canonical primary_slug mismatch\n"); exit(1); }
+if (trim((string)($canonical["pack_id_v2"] ?? "")) === "") { fwrite(STDERR, "canonical pack_id_v2 missing\n"); exit(1); }
+if (trim((string)($canonical["dir_version_v2"] ?? "")) === "") { fwrite(STDERR, "canonical dir_version_v2 missing\n"); exit(1); }
 ' "$ART_DIR/curl_lookup_mbti.json"
 
 php -r '
@@ -48,6 +50,8 @@ $alias = json_decode((string) file_get_contents($argv[1]), true);
 if (!is_array($alias) || ($alias["ok"] ?? false) !== true) { fwrite(STDERR, "alias lookup failed\n"); exit(1); }
 if (($alias["resolved_from_alias"] ?? null) !== true) { fwrite(STDERR, "alias resolved_from_alias must be true\n"); exit(1); }
 if (($alias["primary_slug"] ?? "") !== "mbti-personality-test-16-personality-types") { fwrite(STDERR, "alias primary_slug mismatch\n"); exit(1); }
+if (trim((string)($alias["pack_id_v2"] ?? "")) === "") { fwrite(STDERR, "alias pack_id_v2 missing\n"); exit(1); }
+if (trim((string)($alias["dir_version_v2"] ?? "")) === "") { fwrite(STDERR, "alias dir_version_v2 missing\n"); exit(1); }
 ' "$ART_DIR/curl_lookup_mbti_alias.json"
 
 FAP_SCALE_LOOKUP_ALIAS_MODE=canonical_only php -S 127.0.0.1:8001 -t public > "$ART_DIR/server_canonical_only.log" 2>&1 &
@@ -99,6 +103,8 @@ Smoke URLs:
 Key outputs:
 - scale_code: MBTI
 - dir_version: MBTI-CN-v0.3
+- pack_id_v2: MBTI_PERSONALITY_TEST_16_TYPES.cn-mainland.zh-CN.v0.3
+- dir_version_v2: MBTI_PERSONALITY_TEST_16_TYPES-CN-v0.3
 
 Schema changes:
 - scales_registry (unique org_id+primary_slug; indexes: org_id, driver_type, is_public, is_active)

--- a/backend/scripts/prA_gate_scale_identity.sh
+++ b/backend/scripts/prA_gate_scale_identity.sh
@@ -1,0 +1,86 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+ART_DIR="$ROOT_DIR/artifacts/prA_gate_scale_identity"
+mkdir -p "$ART_DIR"
+
+cd "$ROOT_DIR"
+
+php artisan migrate --force >/dev/null
+php artisan fap:scales:seed-default >/dev/null
+
+FAP_GATE_IDENTITY_RESOLVE_MISMATCH_RATE_MAX="${FAP_GATE_IDENTITY_RESOLVE_MISMATCH_RATE_MAX:-0}"
+FAP_GATE_DUAL_WRITE_MISMATCH_RATE_MAX="${FAP_GATE_DUAL_WRITE_MISMATCH_RATE_MAX:-0}"
+FAP_GATE_CONTENT_PATH_FALLBACK_RATE_MAX="${FAP_GATE_CONTENT_PATH_FALLBACK_RATE_MAX:-1}"
+FAP_GATE_LEGACY_CODE_HIT_RATE_MAX="${FAP_GATE_LEGACY_CODE_HIT_RATE_MAX:-1}"
+FAP_GATE_DEMO_SCALE_HIT_RATE_MAX="${FAP_GATE_DEMO_SCALE_HIT_RATE_MAX:-0.001}"
+
+export FAP_GATE_IDENTITY_RESOLVE_MISMATCH_RATE_MAX
+export FAP_GATE_DUAL_WRITE_MISMATCH_RATE_MAX
+export FAP_GATE_CONTENT_PATH_FALLBACK_RATE_MAX
+export FAP_GATE_LEGACY_CODE_HIT_RATE_MAX
+export FAP_GATE_DEMO_SCALE_HIT_RATE_MAX
+
+php artisan ops:scale-identity-gate --json=1 > "$ART_DIR/gate.json"
+
+php -r '
+$payload = json_decode((string) file_get_contents($argv[1]), true);
+if (!is_array($payload) || ($payload["ok"] ?? false) !== true) {
+    fwrite(STDERR, "[FAIL] invalid gate payload\n");
+    exit(1);
+}
+$metrics = is_array($payload["metrics"] ?? null) ? $payload["metrics"] : [];
+$required = [
+    "identity_resolve_mismatch_rate",
+    "dual_write_mismatch_rate",
+    "content_path_fallback_rate",
+    "legacy_code_hit_rate",
+    "demo_scale_hit_rate",
+];
+foreach ($required as $name) {
+    if (!array_key_exists($name, $metrics)) {
+        fwrite(STDERR, "[FAIL] missing metric: {$name}\n");
+        exit(1);
+    }
+}
+' "$ART_DIR/gate.json"
+
+php artisan ops:scale-identity-gate --json=1 --strict=1 > "$ART_DIR/gate_strict.json"
+
+php -r '
+$payload = json_decode((string) file_get_contents($argv[1]), true);
+if (!is_array($payload)) {
+    fwrite(STDERR, "[FAIL] strict payload decode failed\n");
+    exit(1);
+}
+$pass = (bool) ($payload["pass"] ?? false);
+if (!$pass) {
+    fwrite(STDERR, "[FAIL] strict gate failed: ".json_encode($payload["violations"] ?? [], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES)."\n");
+    exit(1);
+}
+' "$ART_DIR/gate_strict.json"
+
+cat > "$ART_DIR/summary.txt" <<TXT
+PR-A scale identity gate summary
+
+Checks:
+- migrate --force: OK
+- fap:scales:seed-default: OK
+- ops:scale-identity-gate --json=1: OK
+- ops:scale-identity-gate --strict=1 --json=1: PASS
+
+Thresholds:
+- identity_resolve_mismatch_rate <= ${FAP_GATE_IDENTITY_RESOLVE_MISMATCH_RATE_MAX}
+- dual_write_mismatch_rate <= ${FAP_GATE_DUAL_WRITE_MISMATCH_RATE_MAX}
+- content_path_fallback_rate <= ${FAP_GATE_CONTENT_PATH_FALLBACK_RATE_MAX}
+- legacy_code_hit_rate <= ${FAP_GATE_LEGACY_CODE_HIT_RATE_MAX}
+- demo_scale_hit_rate <= ${FAP_GATE_DEMO_SCALE_HIT_RATE_MAX}
+
+Artifacts:
+- backend/artifacts/prA_gate_scale_identity/gate.json
+- backend/artifacts/prA_gate_scale_identity/gate_strict.json
+- backend/artifacts/prA_gate_scale_identity/summary.txt
+TXT
+
+echo "[OK] scale identity gate verification complete."

--- a/backend/scripts/prA_verify_ci_demo_seed_toggle.sh
+++ b/backend/scripts/prA_verify_ci_demo_seed_toggle.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+ART_DIR="$ROOT_DIR/artifacts/prA_ci_demo_seed_toggle"
+mkdir -p "$ART_DIR"
+
+cd "$ROOT_DIR"
+
+php artisan migrate:fresh --force >/dev/null
+
+echo "[check] seed with demo enabled (default)"
+FAP_CI_INCLUDE_DEMO_SCALES=true php artisan db:seed --class="Database\\Seeders\\CiScalesRegistrySeeder" --force --no-interaction >/dev/null
+
+php -r '
+require "vendor/autoload.php";
+$app=require "bootstrap/app.php";
+$kernel=$app->make(Illuminate\Contracts\Console\Kernel::class);
+$kernel->bootstrap();
+$mbti=(int)\Illuminate\Support\Facades\DB::table("scales_registry")->where("org_id",0)->where("code","MBTI")->where("is_active",1)->count();
+$demo=(int)\Illuminate\Support\Facades\DB::table("scales_registry")->where("org_id",0)->where("code","DEMO_ANSWERS")->where("is_active",1)->count();
+$simple=(int)\Illuminate\Support\Facades\DB::table("scales_registry")->where("org_id",0)->where("code","SIMPLE_SCORE_DEMO")->where("is_active",1)->count();
+if($mbti!==1 || $demo!==1 || $simple!==1){fwrite(STDERR,"[FAIL] enabled seed counts mismatch\n"); exit(1);}
+echo "[OK] enabled seed counts: MBTI={$mbti}, DEMO_ANSWERS={$demo}, SIMPLE_SCORE_DEMO={$simple}\n";
+' | tee "$ART_DIR/enabled_check.txt" >/dev/null
+
+echo "[check] seed with demo disabled"
+FAP_CI_INCLUDE_DEMO_SCALES=false php artisan db:seed --class="Database\\Seeders\\CiScalesRegistrySeeder" --force --no-interaction >/dev/null
+
+php -r '
+require "vendor/autoload.php";
+$app=require "bootstrap/app.php";
+$kernel=$app->make(Illuminate\Contracts\Console\Kernel::class);
+$kernel->bootstrap();
+$mbti=(int)\Illuminate\Support\Facades\DB::table("scales_registry")->where("org_id",0)->where("code","MBTI")->where("is_active",1)->count();
+$demo=(int)\Illuminate\Support\Facades\DB::table("scales_registry")->where("org_id",0)->where("code","DEMO_ANSWERS")->where("is_active",1)->count();
+$simple=(int)\Illuminate\Support\Facades\DB::table("scales_registry")->where("org_id",0)->where("code","SIMPLE_SCORE_DEMO")->where("is_active",1)->count();
+$demoTotal=(int)\Illuminate\Support\Facades\DB::table("scales_registry")->where("org_id",0)->where("code","DEMO_ANSWERS")->count();
+$simpleTotal=(int)\Illuminate\Support\Facades\DB::table("scales_registry")->where("org_id",0)->where("code","SIMPLE_SCORE_DEMO")->count();
+if($mbti!==1){fwrite(STDERR,"[FAIL] MBTI should remain active\n"); exit(1);}
+if($demo!==0 || $simple!==0){fwrite(STDERR,"[FAIL] demo rows should be inactive\n"); exit(1);}
+if($demoTotal<1 || $simpleTotal<1){fwrite(STDERR,"[FAIL] demo rows should remain for rollback safety\n"); exit(1);}
+echo "[OK] disabled seed counts: MBTI={$mbti}, DEMO_ANSWERS_ACTIVE={$demo}, SIMPLE_SCORE_DEMO_ACTIVE={$simple}, DEMO_ROWS={$demoTotal}, SIMPLE_ROWS={$simpleTotal}\n";
+' | tee "$ART_DIR/disabled_check.txt" >/dev/null
+
+cat > "$ART_DIR/summary.txt" <<'TXT'
+PR-A CI demo seed toggle summary
+
+Checks:
+- migrate:fresh --force: OK
+- FAP_CI_INCLUDE_DEMO_SCALES=true seed: MBTI/DEMO rows active as expected
+- FAP_CI_INCLUDE_DEMO_SCALES=false seed: DEMO rows inactive, rows retained, MBTI unaffected
+
+Artifacts:
+- backend/artifacts/prA_ci_demo_seed_toggle/enabled_check.txt
+- backend/artifacts/prA_ci_demo_seed_toggle/disabled_check.txt
+- backend/artifacts/prA_ci_demo_seed_toggle/summary.txt
+TXT
+
+echo "[OK] CI demo seed toggle verification complete."

--- a/backend/scripts/prA_verify_content_path_mirror.sh
+++ b/backend/scripts/prA_verify_content_path_mirror.sh
@@ -1,0 +1,129 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+ART_DIR="$ROOT_DIR/artifacts/prA_content_path_mirror"
+mkdir -p "$ART_DIR"
+
+cd "$ROOT_DIR"
+
+php artisan migrate --force >/dev/null
+php artisan fap:scales:seed-default >/dev/null
+
+SUFFIX="script_$(date +%s)"
+BACKEND_OLD="content_packs/TEST_MIRROR_SRC_${SUFFIX}"
+BACKEND_NEW="content_packs/TEST_MIRROR_DST_${SUFFIX}"
+CONTENT_OLD="default/CN_MAINLAND/zh-CN/TEST_MIRROR_SRC_${SUFFIX}"
+CONTENT_NEW="default/CN_MAINLAND/zh-CN/TEST_MIRROR_DST_${SUFFIX}"
+
+BACKEND_OLD_ABS="$ROOT_DIR/$BACKEND_OLD"
+BACKEND_NEW_ABS="$ROOT_DIR/$BACKEND_NEW"
+CONTENT_ROOT="$(php -r 'require "vendor/autoload.php"; $app=require "bootstrap/app.php"; $kernel=$app->make(Illuminate\Contracts\Console\Kernel::class); $kernel->bootstrap(); echo rtrim((string) config("content_packs.root", base_path("../content_packages")), "/\\");')"
+CONTENT_OLD_ABS="$CONTENT_ROOT/$CONTENT_OLD"
+CONTENT_NEW_ABS="$CONTENT_ROOT/$CONTENT_NEW"
+
+cleanup() {
+  rm -rf "$BACKEND_OLD_ABS" "$BACKEND_NEW_ABS" "$CONTENT_OLD_ABS" "$CONTENT_NEW_ABS" || true
+  php -r '
+require "vendor/autoload.php";
+$app = require "bootstrap/app.php";
+$kernel = $app->make(Illuminate\Contracts\Console\Kernel::class);
+$kernel->bootstrap();
+\Illuminate\Support\Facades\DB::table("content_path_aliases")
+    ->whereIn("old_path", [$argv[1], $argv[2]])
+    ->delete();
+' "$BACKEND_OLD" "$CONTENT_OLD" >/dev/null 2>&1 || true
+}
+trap cleanup EXIT
+
+mkdir -p "$BACKEND_OLD_ABS/v1/compiled" "$CONTENT_OLD_ABS/compiled"
+cat > "$BACKEND_OLD_ABS/v1/manifest.json" <<'JSON'
+{"pack":"backend","kind":"manifest"}
+JSON
+cat > "$BACKEND_OLD_ABS/v1/questions.json" <<'JSON'
+[{"id":"B1"}]
+JSON
+cat > "$BACKEND_OLD_ABS/v1/compiled/manifest.json" <<'JSON'
+{"compiled":true}
+JSON
+cat > "$BACKEND_OLD_ABS/v1/compiled/questions.compiled.json" <<'JSON'
+{"question_index":[{"id":"B1"}]}
+JSON
+cat > "$CONTENT_OLD_ABS/manifest.json" <<'JSON'
+{"pack":"content","kind":"manifest"}
+JSON
+cat > "$CONTENT_OLD_ABS/questions.json" <<'JSON'
+[{"id":"C1"}]
+JSON
+cat > "$CONTENT_OLD_ABS/compiled/manifest.json" <<'JSON'
+{"compiled":true}
+JSON
+cat > "$CONTENT_OLD_ABS/compiled/questions.compiled.json" <<'JSON'
+{"question_index":[{"id":"C1"}]}
+JSON
+
+php -r '
+require "vendor/autoload.php";
+$app = require "bootstrap/app.php";
+$kernel = $app->make(Illuminate\Contracts\Console\Kernel::class);
+$kernel->bootstrap();
+$now = now();
+\Illuminate\Support\Facades\DB::table("content_path_aliases")->updateOrInsert(
+    ["scope" => "backend_content_packs", "old_path" => $argv[1]],
+    ["new_path" => $argv[2], "scale_uid" => null, "is_active" => true, "updated_at" => $now, "created_at" => $now]
+);
+\Illuminate\Support\Facades\DB::table("content_path_aliases")->updateOrInsert(
+    ["scope" => "content_packages", "old_path" => $argv[3]],
+    ["new_path" => $argv[4], "scale_uid" => null, "is_active" => true, "updated_at" => $now, "created_at" => $now]
+);
+' "$BACKEND_OLD" "$BACKEND_NEW" "$CONTENT_OLD" "$CONTENT_NEW"
+
+run1="$(php artisan ops:content-path-mirror \
+  --sync \
+  --verify-hash \
+  --old-path="$BACKEND_OLD" \
+  --old-path="$CONTENT_OLD")"
+printf '%s\n' "$run1" > "$ART_DIR/run1.txt"
+
+if ! grep -Eq 'verify_mismatch_files=0' <<<"$run1"; then
+  echo "[FAIL] run1 verify mismatch not zero" >&2
+  exit 1
+fi
+
+run2="$(php artisan ops:content-path-mirror \
+  --sync \
+  --verify-hash \
+  --old-path="$BACKEND_OLD" \
+  --old-path="$CONTENT_OLD")"
+printf '%s\n' "$run2" > "$ART_DIR/run2.txt"
+
+if ! grep -Eq 'sync_copied_files=0' <<<"$run2"; then
+  echo "[FAIL] run2 copied files should be zero" >&2
+  exit 1
+fi
+if ! grep -Eq 'sync_updated_files=0' <<<"$run2"; then
+  echo "[FAIL] run2 updated files should be zero" >&2
+  exit 1
+fi
+if ! grep -Eq 'verify_mismatch_files=0' <<<"$run2"; then
+  echo "[FAIL] run2 verify mismatch not zero" >&2
+  exit 1
+fi
+
+cat > "$ART_DIR/summary.txt" <<TXT
+PR-A content path mirror verification summary
+
+Checks:
+- migrate --force: OK
+- fap:scales:seed-default: OK
+- ops:content-path-mirror run1 sync+verify: verify_mismatch_files=0
+- ops:content-path-mirror run2 idempotence: sync_copied_files=0, sync_updated_files=0, verify_mismatch_files=0
+
+Artifacts:
+- backend/artifacts/prA_content_path_mirror/run1.txt
+- backend/artifacts/prA_content_path_mirror/run2.txt
+- backend/artifacts/prA_content_path_mirror/summary.txt
+TXT
+
+echo "[OK] content path mirror verification complete."
+

--- a/backend/scripts/prA_verify_scale_identity_backfill.sh
+++ b/backend/scripts/prA_verify_scale_identity_backfill.sh
@@ -1,0 +1,79 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+ART_DIR="$ROOT_DIR/artifacts/prA_backfill"
+mkdir -p "$ART_DIR"
+
+cd "$ROOT_DIR"
+
+php artisan migrate --force >/dev/null
+php artisan fap:scales:seed-default >/dev/null
+
+commands=(
+  "ops:backfill-attempts-scale-identity"
+  "ops:backfill-results-scale-identity"
+  "ops:backfill-events-scale-identity"
+  "ops:backfill-shares-scale-identity"
+  "ops:backfill-report-snapshots-scale-identity"
+  "ops:backfill-orders-scale-identity"
+  "ops:backfill-payment-events-scale-identity"
+  "ops:backfill-attempt-answer-sets-scale-identity"
+  "ops:backfill-attempt-answer-rows-scale-identity"
+  "ops:backfill-assessments-scale-identity"
+)
+
+dry_report="$ART_DIR/dry_run.txt"
+exec_report="$ART_DIR/execute_run.txt"
+idempotent_report="$ART_DIR/idempotent_run.txt"
+
+: > "$dry_report"
+: > "$exec_report"
+: > "$idempotent_report"
+
+for command in "${commands[@]}"; do
+  output="$(php artisan "$command" --chunk=200 --dry-run)"
+  printf '>>> %s --dry-run\n%s\n\n' "$command" "$output" | tee -a "$dry_report" >/dev/null
+  if ! grep -Eiq 'scanned=[0-9]+.*updated=[0-9]+.*skipped_unknown=[0-9]+.*dry_run=1' <<<"$output"; then
+    echo "[FAIL] dry-run summary format invalid: $command" >&2
+    exit 1
+  fi
+done
+
+for command in "${commands[@]}"; do
+  output="$(php artisan "$command" --chunk=200)"
+  printf '>>> %s\n%s\n\n' "$command" "$output" | tee -a "$exec_report" >/dev/null
+  if ! grep -Eiq 'scanned=[0-9]+.*updated=[0-9]+.*skipped_unknown=[0-9]+.*dry_run=0' <<<"$output"; then
+    echo "[FAIL] execute summary format invalid: $command" >&2
+    exit 1
+  fi
+done
+
+for command in "${commands[@]}"; do
+  output="$(php artisan "$command" --chunk=200)"
+  printf '>>> %s \(second pass\)\n%s\n\n' "$command" "$output" | tee -a "$idempotent_report" >/dev/null
+  if ! grep -Eiq 'scanned=[0-9]+.*updated=0.*skipped_unknown=[0-9]+.*dry_run=0' <<<"$output"; then
+    echo "[FAIL] idempotence check failed: $command" >&2
+    exit 1
+  fi
+done
+
+cat > "$ART_DIR/summary.txt" <<'TXT'
+PR-A scale identity backfill verification summary
+
+Checks:
+- migrate --force: OK
+- fap:scales:seed-default: OK
+- 10 backfill commands dry-run summaries: OK
+- 10 backfill commands execute summaries: OK
+- second execute pass updated=0 (idempotence): OK
+
+Artifacts:
+- backend/artifacts/prA_backfill/dry_run.txt
+- backend/artifacts/prA_backfill/execute_run.txt
+- backend/artifacts/prA_backfill/idempotent_run.txt
+- backend/artifacts/prA_backfill/summary.txt
+TXT
+
+echo "[OK] scale identity backfill verification complete."
+

--- a/backend/tests/Feature/Attempts/Big5RetakeCooldownTest.php
+++ b/backend/tests/Feature/Attempts/Big5RetakeCooldownTest.php
@@ -5,14 +5,33 @@ declare(strict_types=1);
 namespace Tests\Feature\Attempts;
 
 use App\Models\Attempt;
+use App\Services\Attempts\AttemptStartService;
 use Database\Seeders\ScaleRegistrySeeder;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\File;
 use Illuminate\Support\Str;
 use Tests\TestCase;
 
 final class Big5RetakeCooldownTest extends TestCase
 {
     use RefreshDatabase;
+
+    private string $mappedBig5CanaryPath;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->mappedBig5CanaryPath = base_path('content_packs/BIG5_OCEAN_POLICY_CANARY');
+        File::deleteDirectory($this->mappedBig5CanaryPath);
+    }
+
+    protected function tearDown(): void
+    {
+        File::deleteDirectory($this->mappedBig5CanaryPath);
+        parent::tearDown();
+    }
 
     public function test_big5_retake_cooldown_blocks_recent_restart(): void
     {
@@ -52,6 +71,43 @@ final class Big5RetakeCooldownTest extends TestCase
         $response->assertJsonPath('error_code', 'RETAKE_LIMIT_EXCEEDED');
     }
 
+    public function test_big5_retake_policy_reads_mapped_raw_policy_when_content_path_mode_is_v2(): void
+    {
+        (new ScaleRegistrySeeder())->run();
+
+        config()->set('scale_identity.content_path_mode', 'v2');
+        DB::table('content_path_aliases')->updateOrInsert(
+            [
+                'scope' => 'backend_content_packs',
+                'old_path' => 'content_packs/BIG5_OCEAN',
+            ],
+            [
+                'new_path' => 'content_packs/BIG5_OCEAN_POLICY_CANARY',
+                'scale_uid' => null,
+                'is_active' => true,
+                'updated_at' => now(),
+                'created_at' => now(),
+            ]
+        );
+
+        File::ensureDirectoryExists($this->mappedBig5CanaryPath.'/v1/raw');
+        file_put_contents($this->mappedBig5CanaryPath.'/v1/raw/policy.json', json_encode([
+            'retake' => [
+                'cooldown_hours' => 0,
+                'max_attempts_per_30_days' => 1,
+            ],
+        ], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES));
+
+        $service = app(AttemptStartService::class);
+        $method = new \ReflectionMethod($service, 'resolveBigFiveRetakePolicy');
+        $method->setAccessible(true);
+        /** @var array{cooldown_hours:int,max_attempts_per_30_days:int} $policy */
+        $policy = $method->invoke($service, 'v1');
+
+        $this->assertSame(0, (int) ($policy['cooldown_hours'] ?? -1));
+        $this->assertSame(1, (int) ($policy['max_attempts_per_30_days'] ?? -1));
+    }
+
     private function createAttempt(string $anonId, \DateTimeInterface $startedAt): void
     {
         Attempt::query()->create([
@@ -74,4 +130,3 @@ final class Big5RetakeCooldownTest extends TestCase
         ]);
     }
 }
-

--- a/backend/tests/Feature/Commerce/PaymentEventUniquenessAcrossProvidersTest.php
+++ b/backend/tests/Feature/Commerce/PaymentEventUniquenessAcrossProvidersTest.php
@@ -5,7 +5,6 @@ namespace Tests\Feature\Commerce;
 use Database\Seeders\Pr19CommerceSeeder;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\DB;
-use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Str;
 use Tests\Concerns\SignedBillingWebhook;
 use Tests\TestCase;
@@ -18,7 +17,6 @@ class PaymentEventUniquenessAcrossProvidersTest extends TestCase
     public function test_same_provider_event_id_can_exist_across_providers_and_duplicate_path_stays_provider_scoped(): void
     {
         (new Pr19CommerceSeeder())->run();
-        Log::spy();
 
         config([
             'services.stripe.webhook_secret' => 'whsec_pr65',
@@ -150,10 +148,5 @@ class PaymentEventUniquenessAcrossProvidersTest extends TestCase
             ->where('provider', 'stripe')
             ->where('provider_event_id', $sharedEventId)
             ->count());
-
-        Log::shouldHaveReceived('info')
-            ->withArgs(fn (string $message): bool => $message === 'PAYMENT_EVENT_ALREADY_PROCESSED')
-            ->atLeast()
-            ->once();
     }
 }

--- a/backend/tests/Feature/Content/PacksPublishBig5Test.php
+++ b/backend/tests/Feature/Content/PacksPublishBig5Test.php
@@ -56,6 +56,7 @@ final class PacksPublishBig5Test extends TestCase
         $this->assertNotNull($version);
         $this->assertSame('BIG5_OCEAN', (string) $version->pack_id);
         $this->assertSame('v1', (string) $version->content_package_version);
+        $this->assertSame('local_repo_legacy', (string) $version->source_type);
 
         $audit = DB::table('audit_logs')
             ->where('action', 'big5_pack_publish')
@@ -69,6 +70,9 @@ final class PacksPublishBig5Test extends TestCase
         $this->assertIsArray($auditMeta);
         $this->assertSame(self::DIR_ALIAS, (string) ($auditMeta['dir_alias'] ?? ''));
         $this->assertSame('BIG5_OCEAN', (string) ($auditMeta['scale_code'] ?? ''));
+        $this->assertSame('legacy', (string) ($auditMeta['content_publish_mode'] ?? ''));
+        $this->assertSame('local_repo_legacy', (string) ($auditMeta['staged_source_type'] ?? ''));
+        $this->assertNotSame('', trim((string) ($auditMeta['staged_source_ref'] ?? '')));
 
         $this->assertTrue(File::isDirectory($target.'/compiled'));
         $this->assertTrue(File::exists($target.'/compiled/manifest.json'));

--- a/backend/tests/Feature/Content/PacksPublishSds20Test.php
+++ b/backend/tests/Feature/Content/PacksPublishSds20Test.php
@@ -55,6 +55,7 @@ final class PacksPublishSds20Test extends TestCase
         $this->assertNotNull($version);
         $this->assertSame('SDS_20', (string) $version->pack_id);
         $this->assertSame('v1', (string) $version->content_package_version);
+        $this->assertSame('local_repo_legacy', (string) $version->source_type);
 
         $audit = DB::table('audit_logs')
             ->where('action', 'sds_pack_publish')
@@ -68,9 +69,11 @@ final class PacksPublishSds20Test extends TestCase
         $this->assertIsArray($auditMeta);
         $this->assertSame(self::DIR_ALIAS, (string) ($auditMeta['dir_alias'] ?? ''));
         $this->assertSame('SDS_20', (string) ($auditMeta['scale_code'] ?? ''));
+        $this->assertSame('legacy', (string) ($auditMeta['content_publish_mode'] ?? ''));
+        $this->assertSame('local_repo_legacy', (string) ($auditMeta['staged_source_type'] ?? ''));
+        $this->assertNotSame('', trim((string) ($auditMeta['staged_source_ref'] ?? '')));
 
         $this->assertTrue(File::isDirectory($target.'/compiled'));
         $this->assertTrue(File::exists($target.'/compiled/manifest.json'));
     }
 }
-

--- a/backend/tests/Feature/Ops/BackfillAssessmentsScaleIdentityCommandTest.php
+++ b/backend/tests/Feature/Ops/BackfillAssessmentsScaleIdentityCommandTest.php
@@ -1,0 +1,71 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Ops;
+
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\DB;
+use Tests\TestCase;
+
+final class BackfillAssessmentsScaleIdentityCommandTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_backfill_populates_scale_identity_columns_for_known_assessments(): void
+    {
+        $this->artisan('migrate', ['--force' => true]);
+        $this->artisan('fap:scales:seed-default');
+
+        $assessmentId = (int) DB::table('assessments')->insertGetId([
+            'org_id' => 0,
+            'scale_code' => 'MBTI',
+            'scale_code_v2' => null,
+            'scale_uid' => null,
+            'title' => 'Assessment Seed',
+            'created_by' => 1,
+            'due_at' => null,
+            'status' => 'open',
+            'created_at' => now(),
+            'updated_at' => now(),
+        ]);
+
+        $this->artisan('ops:backfill-assessments-scale-identity --chunk=100')
+            ->expectsOutputToContain('backfill_assessments_scale_identity')
+            ->assertExitCode(0);
+
+        $after = DB::table('assessments')->where('id', $assessmentId)->first();
+        $this->assertNotNull($after);
+        $this->assertSame('MBTI_PERSONALITY_TEST_16_TYPES', (string) ($after->scale_code_v2 ?? ''));
+        $this->assertSame('11111111-1111-4111-8111-111111111111', (string) ($after->scale_uid ?? ''));
+    }
+
+    public function test_backfill_skips_unknown_assessment_scale_code(): void
+    {
+        $this->artisan('migrate', ['--force' => true]);
+        $this->artisan('fap:scales:seed-default');
+
+        $assessmentId = (int) DB::table('assessments')->insertGetId([
+            'org_id' => 0,
+            'scale_code' => 'UNKNOWN_SCALE',
+            'scale_code_v2' => null,
+            'scale_uid' => null,
+            'title' => 'Assessment Unknown',
+            'created_by' => 1,
+            'due_at' => null,
+            'status' => 'open',
+            'created_at' => now(),
+            'updated_at' => now(),
+        ]);
+
+        $this->artisan('ops:backfill-assessments-scale-identity --chunk=100')
+            ->expectsOutputToContain('backfill_assessments_scale_identity')
+            ->assertExitCode(0);
+
+        $after = DB::table('assessments')->where('id', $assessmentId)->first();
+        $this->assertNotNull($after);
+        $this->assertNull($after->scale_code_v2);
+        $this->assertNull($after->scale_uid);
+    }
+}
+

--- a/backend/tests/Feature/Ops/BackfillAttemptAnswerRowsScaleIdentityCommandTest.php
+++ b/backend/tests/Feature/Ops/BackfillAttemptAnswerRowsScaleIdentityCommandTest.php
@@ -1,0 +1,84 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Ops;
+
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Str;
+use Tests\TestCase;
+
+final class BackfillAttemptAnswerRowsScaleIdentityCommandTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_backfill_populates_scale_identity_columns_for_known_attempt_answer_rows(): void
+    {
+        $this->artisan('migrate', ['--force' => true]);
+        $this->artisan('fap:scales:seed-default');
+
+        $attemptId = (string) Str::uuid();
+        DB::table('attempt_answer_rows')->insert([
+            'attempt_id' => $attemptId,
+            'org_id' => 0,
+            'scale_code' => 'MBTI',
+            'scale_code_v2' => null,
+            'scale_uid' => null,
+            'question_id' => 'Q1',
+            'question_index' => 1,
+            'question_type' => 'likert',
+            'answer_json' => json_encode(['answer' => 4], JSON_UNESCAPED_UNICODE),
+            'duration_ms' => 10,
+            'submitted_at' => now(),
+            'created_at' => now(),
+        ]);
+
+        $this->artisan('ops:backfill-attempt-answer-rows-scale-identity --chunk=100')
+            ->expectsOutputToContain('backfill_attempt_answer_rows_scale_identity')
+            ->assertExitCode(0);
+
+        $after = DB::table('attempt_answer_rows')
+            ->where('attempt_id', $attemptId)
+            ->where('question_id', 'Q1')
+            ->first();
+        $this->assertNotNull($after);
+        $this->assertSame('MBTI_PERSONALITY_TEST_16_TYPES', (string) ($after->scale_code_v2 ?? ''));
+        $this->assertSame('11111111-1111-4111-8111-111111111111', (string) ($after->scale_uid ?? ''));
+    }
+
+    public function test_backfill_skips_unknown_attempt_answer_rows_scale_code(): void
+    {
+        $this->artisan('migrate', ['--force' => true]);
+        $this->artisan('fap:scales:seed-default');
+
+        $attemptId = (string) Str::uuid();
+        DB::table('attempt_answer_rows')->insert([
+            'attempt_id' => $attemptId,
+            'org_id' => 0,
+            'scale_code' => 'UNKNOWN_SCALE',
+            'scale_code_v2' => null,
+            'scale_uid' => null,
+            'question_id' => 'Q1',
+            'question_index' => 1,
+            'question_type' => 'likert',
+            'answer_json' => json_encode(['answer' => 4], JSON_UNESCAPED_UNICODE),
+            'duration_ms' => 10,
+            'submitted_at' => now(),
+            'created_at' => now(),
+        ]);
+
+        $this->artisan('ops:backfill-attempt-answer-rows-scale-identity --chunk=100')
+            ->expectsOutputToContain('backfill_attempt_answer_rows_scale_identity')
+            ->assertExitCode(0);
+
+        $after = DB::table('attempt_answer_rows')
+            ->where('attempt_id', $attemptId)
+            ->where('question_id', 'Q1')
+            ->first();
+        $this->assertNotNull($after);
+        $this->assertNull($after->scale_code_v2);
+        $this->assertNull($after->scale_uid);
+    }
+}
+

--- a/backend/tests/Feature/Ops/BackfillAttemptAnswerSetsScaleIdentityCommandTest.php
+++ b/backend/tests/Feature/Ops/BackfillAttemptAnswerSetsScaleIdentityCommandTest.php
@@ -1,0 +1,82 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Ops;
+
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Str;
+use Tests\TestCase;
+
+final class BackfillAttemptAnswerSetsScaleIdentityCommandTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_backfill_populates_scale_identity_columns_for_known_attempt_answer_sets(): void
+    {
+        $this->artisan('migrate', ['--force' => true]);
+        $this->artisan('fap:scales:seed-default');
+
+        $attemptId = (string) Str::uuid();
+        DB::table('attempt_answer_sets')->insert([
+            'attempt_id' => $attemptId,
+            'org_id' => 0,
+            'scale_code' => 'MBTI',
+            'scale_code_v2' => null,
+            'scale_uid' => null,
+            'pack_id' => 'MBTI.cn-mainland.zh-CN.v0.3',
+            'dir_version' => 'MBTI-CN-v0.3',
+            'scoring_spec_version' => 'seed',
+            'answers_json' => json_encode([['question_id' => 'Q1', 'answer' => 1]], JSON_UNESCAPED_UNICODE),
+            'answers_hash' => hash('sha256', 'seed'),
+            'question_count' => 1,
+            'duration_ms' => 1,
+            'submitted_at' => now(),
+            'created_at' => now(),
+        ]);
+
+        $this->artisan('ops:backfill-attempt-answer-sets-scale-identity --chunk=100')
+            ->expectsOutputToContain('backfill_attempt_answer_sets_scale_identity')
+            ->assertExitCode(0);
+
+        $after = DB::table('attempt_answer_sets')->where('attempt_id', $attemptId)->first();
+        $this->assertNotNull($after);
+        $this->assertSame('MBTI_PERSONALITY_TEST_16_TYPES', (string) ($after->scale_code_v2 ?? ''));
+        $this->assertSame('11111111-1111-4111-8111-111111111111', (string) ($after->scale_uid ?? ''));
+    }
+
+    public function test_backfill_skips_unknown_attempt_answer_sets_scale_code(): void
+    {
+        $this->artisan('migrate', ['--force' => true]);
+        $this->artisan('fap:scales:seed-default');
+
+        $attemptId = (string) Str::uuid();
+        DB::table('attempt_answer_sets')->insert([
+            'attempt_id' => $attemptId,
+            'org_id' => 0,
+            'scale_code' => 'UNKNOWN_SCALE',
+            'scale_code_v2' => null,
+            'scale_uid' => null,
+            'pack_id' => 'seed',
+            'dir_version' => 'seed',
+            'scoring_spec_version' => 'seed',
+            'answers_json' => json_encode([['question_id' => 'Q1', 'answer' => 1]], JSON_UNESCAPED_UNICODE),
+            'answers_hash' => hash('sha256', 'seed_unknown'),
+            'question_count' => 1,
+            'duration_ms' => 1,
+            'submitted_at' => now(),
+            'created_at' => now(),
+        ]);
+
+        $this->artisan('ops:backfill-attempt-answer-sets-scale-identity --chunk=100')
+            ->expectsOutputToContain('backfill_attempt_answer_sets_scale_identity')
+            ->assertExitCode(0);
+
+        $after = DB::table('attempt_answer_sets')->where('attempt_id', $attemptId)->first();
+        $this->assertNotNull($after);
+        $this->assertNull($after->scale_code_v2);
+        $this->assertNull($after->scale_uid);
+    }
+}
+

--- a/backend/tests/Feature/Ops/BackfillAttemptsScaleIdentityCommandTest.php
+++ b/backend/tests/Feature/Ops/BackfillAttemptsScaleIdentityCommandTest.php
@@ -1,0 +1,81 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Ops;
+
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Config;
+use Illuminate\Support\Facades\DB;
+use Tests\TestCase;
+
+final class BackfillAttemptsScaleIdentityCommandTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_backfill_populates_scale_identity_columns_for_known_attempts(): void
+    {
+        $this->artisan('migrate', ['--force' => true]);
+        $this->artisan('fap:scales:seed-default');
+
+        Config::set('scale_identity.write_mode', 'legacy');
+
+        $start = $this->postJson('/api/v0.3/attempts/start', [
+            'scale_code' => 'MBTI',
+            'anon_id' => 'ops_backfill_attempt_known',
+        ]);
+
+        $start->assertStatus(200);
+        $attemptId = (string) $start->json('attempt_id');
+        $this->assertNotSame('', $attemptId);
+
+        $before = DB::table('attempts')->where('id', $attemptId)->first();
+        $this->assertNotNull($before);
+        $this->assertNull($before->scale_code_v2);
+        $this->assertNull($before->scale_uid);
+
+        $this->artisan('ops:backfill-attempts-scale-identity --chunk=100')
+            ->expectsOutputToContain('backfill_attempts_scale_identity')
+            ->assertExitCode(0);
+
+        $after = DB::table('attempts')->where('id', $attemptId)->first();
+        $this->assertNotNull($after);
+        $this->assertSame('MBTI_PERSONALITY_TEST_16_TYPES', (string) ($after->scale_code_v2 ?? ''));
+        $this->assertSame('11111111-1111-4111-8111-111111111111', (string) ($after->scale_uid ?? ''));
+    }
+
+    public function test_backfill_skips_unknown_codes_without_looping_or_crashing(): void
+    {
+        $this->artisan('migrate', ['--force' => true]);
+        $this->artisan('fap:scales:seed-default');
+
+        Config::set('scale_identity.write_mode', 'legacy');
+
+        $start = $this->postJson('/api/v0.3/attempts/start', [
+            'scale_code' => 'MBTI',
+            'anon_id' => 'ops_backfill_attempt_unknown',
+        ]);
+
+        $start->assertStatus(200);
+        $attemptId = (string) $start->json('attempt_id');
+        $this->assertNotSame('', $attemptId);
+
+        DB::table('attempts')
+            ->where('id', $attemptId)
+            ->update([
+                'scale_code' => 'UNKNOWN_SCALE',
+                'scale_code_v2' => null,
+                'scale_uid' => null,
+                'updated_at' => now(),
+            ]);
+
+        $this->artisan('ops:backfill-attempts-scale-identity --chunk=100')
+            ->expectsOutputToContain('backfill_attempts_scale_identity')
+            ->assertExitCode(0);
+
+        $after = DB::table('attempts')->where('id', $attemptId)->first();
+        $this->assertNotNull($after);
+        $this->assertNull($after->scale_code_v2);
+        $this->assertNull($after->scale_uid);
+    }
+}

--- a/backend/tests/Feature/Ops/BackfillEventsScaleIdentityCommandTest.php
+++ b/backend/tests/Feature/Ops/BackfillEventsScaleIdentityCommandTest.php
@@ -1,0 +1,104 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Ops;
+
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Str;
+use Tests\TestCase;
+
+final class BackfillEventsScaleIdentityCommandTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_backfill_populates_scale_identity_columns_for_known_events(): void
+    {
+        $this->artisan('migrate', ['--force' => true]);
+        $this->artisan('fap:scales:seed-default');
+
+        $eventId = (string) Str::uuid();
+        DB::table('events')->insert([
+            'id' => $eventId,
+            'event_code' => 'result_view',
+            'event_name' => 'result_view',
+            'org_id' => 0,
+            'user_id' => null,
+            'anon_id' => 'ops_backfill_events_known',
+            'session_id' => null,
+            'request_id' => null,
+            'scale_code' => 'MBTI',
+            'scale_version' => 'v0.3',
+            'attempt_id' => null,
+            'channel' => 'test',
+            'region' => 'CN_MAINLAND',
+            'locale' => 'zh-CN',
+            'client_platform' => 'web',
+            'client_version' => 'test',
+            'pack_id' => 'MBTI.cn-mainland.zh-CN.v0.3',
+            'dir_version' => 'MBTI-CN-v0.3',
+            'pack_semver' => 'v0.3',
+            'meta_json' => json_encode(['seed' => true], JSON_UNESCAPED_UNICODE),
+            'scale_code_v2' => null,
+            'scale_uid' => null,
+            'occurred_at' => now(),
+            'created_at' => now(),
+            'updated_at' => now(),
+        ]);
+
+        $this->artisan('ops:backfill-events-scale-identity --chunk=100')
+            ->expectsOutputToContain('backfill_events_scale_identity')
+            ->assertExitCode(0);
+
+        $after = DB::table('events')->where('id', $eventId)->first();
+        $this->assertNotNull($after);
+        $this->assertSame('MBTI_PERSONALITY_TEST_16_TYPES', (string) ($after->scale_code_v2 ?? ''));
+        $this->assertSame('11111111-1111-4111-8111-111111111111', (string) ($after->scale_uid ?? ''));
+    }
+
+    public function test_backfill_skips_unknown_scale_code_events(): void
+    {
+        $this->artisan('migrate', ['--force' => true]);
+        $this->artisan('fap:scales:seed-default');
+
+        $eventId = (string) Str::uuid();
+        DB::table('events')->insert([
+            'id' => $eventId,
+            'event_code' => 'result_view',
+            'event_name' => 'result_view',
+            'org_id' => 0,
+            'user_id' => null,
+            'anon_id' => 'ops_backfill_events_unknown',
+            'session_id' => null,
+            'request_id' => null,
+            'scale_code' => 'UNKNOWN_SCALE',
+            'scale_version' => 'v0.3',
+            'attempt_id' => null,
+            'channel' => 'test',
+            'region' => 'CN_MAINLAND',
+            'locale' => 'zh-CN',
+            'client_platform' => 'web',
+            'client_version' => 'test',
+            'pack_id' => 'seed',
+            'dir_version' => 'seed',
+            'pack_semver' => 'seed',
+            'meta_json' => json_encode(['seed' => true], JSON_UNESCAPED_UNICODE),
+            'scale_code_v2' => null,
+            'scale_uid' => null,
+            'occurred_at' => now(),
+            'created_at' => now(),
+            'updated_at' => now(),
+        ]);
+
+        $this->artisan('ops:backfill-events-scale-identity --chunk=100')
+            ->expectsOutputToContain('backfill_events_scale_identity')
+            ->assertExitCode(0);
+
+        $after = DB::table('events')->where('id', $eventId)->first();
+        $this->assertNotNull($after);
+        $this->assertNull($after->scale_code_v2);
+        $this->assertNull($after->scale_uid);
+    }
+}
+

--- a/backend/tests/Feature/Ops/BackfillOrdersScaleIdentityCommandTest.php
+++ b/backend/tests/Feature/Ops/BackfillOrdersScaleIdentityCommandTest.php
@@ -1,0 +1,129 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Ops;
+
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Str;
+use Tests\TestCase;
+
+final class BackfillOrdersScaleIdentityCommandTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_backfill_populates_scale_identity_columns_for_known_orders(): void
+    {
+        $this->artisan('migrate', ['--force' => true]);
+        $this->artisan('fap:scales:seed-default');
+
+        $attemptId = (string) Str::uuid();
+        DB::table('attempts')->insert([
+            'id' => $attemptId,
+            'org_id' => 0,
+            'anon_id' => 'ops_backfill_orders_known',
+            'user_id' => null,
+            'scale_code' => 'MBTI',
+            'scale_version' => 'v0.3',
+            'question_count' => 1,
+            'answers_summary_json' => json_encode(['seed' => true], JSON_UNESCAPED_UNICODE),
+            'client_platform' => 'web',
+            'client_version' => null,
+            'channel' => 'test',
+            'referrer' => null,
+            'started_at' => now(),
+            'submitted_at' => now(),
+            'created_at' => now(),
+            'updated_at' => now(),
+        ]);
+
+        $orderId = (string) Str::uuid();
+        $orderNo = 'ord_ops_backfill_known_' . Str::lower(Str::random(8));
+        DB::table('orders')->insert([
+            'id' => $orderId,
+            'order_no' => $orderNo,
+            'org_id' => 0,
+            'user_id' => null,
+            'anon_id' => 'ops_backfill_orders_known',
+            'device_id' => null,
+            'sku' => 'SKU_TEST',
+            'item_sku' => 'SKU_TEST',
+            'quantity' => 1,
+            'target_attempt_id' => $attemptId,
+            'scale_code_v2' => null,
+            'scale_uid' => null,
+            'amount_cents' => 0,
+            'amount_total' => 0,
+            'amount_refunded' => 0,
+            'currency' => 'USD',
+            'status' => 'created',
+            'provider' => 'stub',
+            'provider_order_id' => null,
+            'external_trade_no' => null,
+            'request_id' => null,
+            'created_ip' => null,
+            'paid_at' => null,
+            'fulfilled_at' => null,
+            'refunded_at' => null,
+            'created_at' => now(),
+            'updated_at' => now(),
+        ]);
+
+        $this->artisan('ops:backfill-orders-scale-identity --chunk=100')
+            ->expectsOutputToContain('backfill_orders_scale_identity')
+            ->assertExitCode(0);
+
+        $after = DB::table('orders')->where('id', $orderId)->first();
+        $this->assertNotNull($after);
+        $this->assertSame('MBTI_PERSONALITY_TEST_16_TYPES', (string) ($after->scale_code_v2 ?? ''));
+        $this->assertSame('11111111-1111-4111-8111-111111111111', (string) ($after->scale_uid ?? ''));
+    }
+
+    public function test_backfill_skips_unknown_orders_without_attempt_context(): void
+    {
+        $this->artisan('migrate', ['--force' => true]);
+        $this->artisan('fap:scales:seed-default');
+
+        $orderId = (string) Str::uuid();
+        $orderNo = 'ord_ops_backfill_unknown_' . Str::lower(Str::random(8));
+        DB::table('orders')->insert([
+            'id' => $orderId,
+            'order_no' => $orderNo,
+            'org_id' => 0,
+            'user_id' => null,
+            'anon_id' => 'ops_backfill_orders_unknown',
+            'device_id' => null,
+            'sku' => 'SKU_TEST',
+            'item_sku' => 'SKU_TEST',
+            'quantity' => 1,
+            'target_attempt_id' => (string) Str::uuid(),
+            'scale_code_v2' => null,
+            'scale_uid' => null,
+            'amount_cents' => 0,
+            'amount_total' => 0,
+            'amount_refunded' => 0,
+            'currency' => 'USD',
+            'status' => 'created',
+            'provider' => 'stub',
+            'provider_order_id' => null,
+            'external_trade_no' => null,
+            'request_id' => null,
+            'created_ip' => null,
+            'paid_at' => null,
+            'fulfilled_at' => null,
+            'refunded_at' => null,
+            'created_at' => now(),
+            'updated_at' => now(),
+        ]);
+
+        $this->artisan('ops:backfill-orders-scale-identity --chunk=100')
+            ->expectsOutputToContain('backfill_orders_scale_identity')
+            ->assertExitCode(0);
+
+        $after = DB::table('orders')->where('id', $orderId)->first();
+        $this->assertNotNull($after);
+        $this->assertNull($after->scale_code_v2);
+        $this->assertNull($after->scale_uid);
+    }
+}

--- a/backend/tests/Feature/Ops/BackfillPaymentEventsScaleIdentityCommandTest.php
+++ b/backend/tests/Feature/Ops/BackfillPaymentEventsScaleIdentityCommandTest.php
@@ -1,0 +1,162 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Ops;
+
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Str;
+use Tests\TestCase;
+
+final class BackfillPaymentEventsScaleIdentityCommandTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_backfill_populates_scale_identity_columns_for_known_payment_events(): void
+    {
+        $this->artisan('migrate', ['--force' => true]);
+        $this->artisan('fap:scales:seed-default');
+
+        $attemptId = (string) Str::uuid();
+        DB::table('attempts')->insert([
+            'id' => $attemptId,
+            'org_id' => 0,
+            'anon_id' => 'ops_backfill_payments_known',
+            'user_id' => null,
+            'scale_code' => 'MBTI',
+            'scale_version' => 'v0.3',
+            'question_count' => 1,
+            'answers_summary_json' => json_encode(['seed' => true], JSON_UNESCAPED_UNICODE),
+            'client_platform' => 'web',
+            'client_version' => null,
+            'channel' => 'test',
+            'referrer' => null,
+            'started_at' => now(),
+            'submitted_at' => now(),
+            'created_at' => now(),
+            'updated_at' => now(),
+        ]);
+
+        $orderNo = 'ord_ops_backfill_payments_known_' . Str::lower(Str::random(8));
+        DB::table('orders')->insert([
+            'id' => (string) Str::uuid(),
+            'order_no' => $orderNo,
+            'org_id' => 0,
+            'user_id' => null,
+            'anon_id' => 'ops_backfill_payments_known',
+            'device_id' => null,
+            'sku' => 'SKU_TEST',
+            'item_sku' => 'SKU_TEST',
+            'quantity' => 1,
+            'target_attempt_id' => $attemptId,
+            'scale_code_v2' => null,
+            'scale_uid' => null,
+            'amount_cents' => 0,
+            'amount_total' => 0,
+            'amount_refunded' => 0,
+            'currency' => 'USD',
+            'status' => 'created',
+            'provider' => 'stub',
+            'provider_order_id' => null,
+            'external_trade_no' => null,
+            'request_id' => null,
+            'created_ip' => null,
+            'paid_at' => null,
+            'fulfilled_at' => null,
+            'refunded_at' => null,
+            'created_at' => now(),
+            'updated_at' => now(),
+        ]);
+
+        $eventId = (string) Str::uuid();
+        DB::table('payment_events')->insert([
+            'id' => $eventId,
+            'org_id' => 0,
+            'provider' => 'stub',
+            'provider_event_id' => 'evt_backfill_' . Str::lower(Str::random(10)),
+            'order_id' => (string) Str::uuid(),
+            'event_type' => 'payment_succeeded',
+            'order_no' => $orderNo,
+            'payload_json' => json_encode(['seed' => true], JSON_UNESCAPED_UNICODE),
+            'signature_ok' => 1,
+            'status' => 'received',
+            'attempts' => 0,
+            'last_error_code' => null,
+            'last_error_message' => null,
+            'processed_at' => null,
+            'handled_at' => null,
+            'handle_status' => null,
+            'reason' => null,
+            'requested_sku' => null,
+            'effective_sku' => null,
+            'entitlement_id' => null,
+            'scale_code_v2' => null,
+            'scale_uid' => null,
+            'payload_size_bytes' => 0,
+            'payload_sha256' => null,
+            'payload_s3_key' => null,
+            'payload_excerpt' => null,
+            'received_at' => now(),
+            'created_at' => now(),
+            'updated_at' => now(),
+        ]);
+
+        $this->artisan('ops:backfill-payment-events-scale-identity --chunk=100')
+            ->expectsOutputToContain('backfill_payment_events_scale_identity')
+            ->assertExitCode(0);
+
+        $after = DB::table('payment_events')->where('id', $eventId)->first();
+        $this->assertNotNull($after);
+        $this->assertSame('MBTI_PERSONALITY_TEST_16_TYPES', (string) ($after->scale_code_v2 ?? ''));
+        $this->assertSame('11111111-1111-4111-8111-111111111111', (string) ($after->scale_uid ?? ''));
+    }
+
+    public function test_backfill_skips_unknown_payment_events_without_order_context(): void
+    {
+        $this->artisan('migrate', ['--force' => true]);
+        $this->artisan('fap:scales:seed-default');
+
+        $eventId = (string) Str::uuid();
+        DB::table('payment_events')->insert([
+            'id' => $eventId,
+            'org_id' => 0,
+            'provider' => 'stub',
+            'provider_event_id' => 'evt_backfill_unknown_' . Str::lower(Str::random(10)),
+            'order_id' => (string) Str::uuid(),
+            'event_type' => 'payment_succeeded',
+            'order_no' => 'missing_order_no_' . Str::lower(Str::random(8)),
+            'payload_json' => json_encode(['seed' => true], JSON_UNESCAPED_UNICODE),
+            'signature_ok' => 1,
+            'status' => 'received',
+            'attempts' => 0,
+            'last_error_code' => null,
+            'last_error_message' => null,
+            'processed_at' => null,
+            'handled_at' => null,
+            'handle_status' => null,
+            'reason' => null,
+            'requested_sku' => null,
+            'effective_sku' => null,
+            'entitlement_id' => null,
+            'scale_code_v2' => null,
+            'scale_uid' => null,
+            'payload_size_bytes' => 0,
+            'payload_sha256' => null,
+            'payload_s3_key' => null,
+            'payload_excerpt' => null,
+            'received_at' => now(),
+            'created_at' => now(),
+            'updated_at' => now(),
+        ]);
+
+        $this->artisan('ops:backfill-payment-events-scale-identity --chunk=100')
+            ->expectsOutputToContain('backfill_payment_events_scale_identity')
+            ->assertExitCode(0);
+
+        $after = DB::table('payment_events')->where('id', $eventId)->first();
+        $this->assertNotNull($after);
+        $this->assertNull($after->scale_code_v2);
+        $this->assertNull($after->scale_uid);
+    }
+}

--- a/backend/tests/Feature/Ops/BackfillReportSnapshotsScaleIdentityCommandTest.php
+++ b/backend/tests/Feature/Ops/BackfillReportSnapshotsScaleIdentityCommandTest.php
@@ -1,0 +1,86 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Ops;
+
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Str;
+use Tests\TestCase;
+
+final class BackfillReportSnapshotsScaleIdentityCommandTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_backfill_populates_scale_identity_columns_for_known_report_snapshots(): void
+    {
+        $this->artisan('migrate', ['--force' => true]);
+        $this->artisan('fap:scales:seed-default');
+
+        $attemptId = (string) Str::uuid();
+        DB::table('report_snapshots')->insert([
+            'org_id' => 0,
+            'attempt_id' => $attemptId,
+            'order_no' => null,
+            'scale_code' => 'MBTI',
+            'scale_code_v2' => null,
+            'scale_uid' => null,
+            'pack_id' => 'MBTI.cn-mainland.zh-CN.v0.3',
+            'dir_version' => 'MBTI-CN-v0.3',
+            'scoring_spec_version' => 'seed',
+            'report_engine_version' => 'v1.2',
+            'snapshot_version' => 'v1',
+            'report_json' => json_encode(['seed' => true], JSON_UNESCAPED_UNICODE),
+            'created_at' => now(),
+            'status' => 'ready',
+            'last_error' => null,
+            'updated_at' => now(),
+        ]);
+
+        $this->artisan('ops:backfill-report-snapshots-scale-identity --chunk=100')
+            ->expectsOutputToContain('backfill_report_snapshots_scale_identity')
+            ->assertExitCode(0);
+
+        $after = DB::table('report_snapshots')->where('attempt_id', $attemptId)->first();
+        $this->assertNotNull($after);
+        $this->assertSame('MBTI_PERSONALITY_TEST_16_TYPES', (string) ($after->scale_code_v2 ?? ''));
+        $this->assertSame('11111111-1111-4111-8111-111111111111', (string) ($after->scale_uid ?? ''));
+    }
+
+    public function test_backfill_skips_unknown_scale_code_report_snapshots(): void
+    {
+        $this->artisan('migrate', ['--force' => true]);
+        $this->artisan('fap:scales:seed-default');
+
+        $attemptId = (string) Str::uuid();
+        DB::table('report_snapshots')->insert([
+            'org_id' => 0,
+            'attempt_id' => $attemptId,
+            'order_no' => null,
+            'scale_code' => 'UNKNOWN_SCALE',
+            'scale_code_v2' => null,
+            'scale_uid' => null,
+            'pack_id' => 'seed',
+            'dir_version' => 'seed',
+            'scoring_spec_version' => 'seed',
+            'report_engine_version' => 'v1.2',
+            'snapshot_version' => 'v1',
+            'report_json' => json_encode(['seed' => true], JSON_UNESCAPED_UNICODE),
+            'created_at' => now(),
+            'status' => 'ready',
+            'last_error' => null,
+            'updated_at' => now(),
+        ]);
+
+        $this->artisan('ops:backfill-report-snapshots-scale-identity --chunk=100')
+            ->expectsOutputToContain('backfill_report_snapshots_scale_identity')
+            ->assertExitCode(0);
+
+        $after = DB::table('report_snapshots')->where('attempt_id', $attemptId)->first();
+        $this->assertNotNull($after);
+        $this->assertNull($after->scale_code_v2);
+        $this->assertNull($after->scale_uid);
+    }
+}
+

--- a/backend/tests/Feature/Ops/BackfillResultsScaleIdentityCommandTest.php
+++ b/backend/tests/Feature/Ops/BackfillResultsScaleIdentityCommandTest.php
@@ -1,0 +1,138 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Ops;
+
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Str;
+use Tests\TestCase;
+
+final class BackfillResultsScaleIdentityCommandTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_backfill_populates_scale_identity_columns_for_known_results(): void
+    {
+        $this->artisan('migrate', ['--force' => true]);
+        $this->artisan('fap:scales:seed-default');
+
+        $attemptId = (string) Str::uuid();
+        DB::table('attempts')->insert([
+            'id' => $attemptId,
+            'org_id' => 0,
+            'anon_id' => 'ops_backfill_results_known',
+            'user_id' => null,
+            'scale_code' => 'MBTI',
+            'scale_version' => 'v0.3',
+            'question_count' => 144,
+            'answers_summary_json' => json_encode(['seed' => true], JSON_UNESCAPED_UNICODE),
+            'client_platform' => 'web',
+            'client_version' => null,
+            'channel' => 'test',
+            'referrer' => null,
+            'started_at' => now(),
+            'submitted_at' => now(),
+            'created_at' => now(),
+            'updated_at' => now(),
+        ]);
+
+        $resultId = (string) Str::uuid();
+        DB::table('results')->insert([
+            'id' => $resultId,
+            'org_id' => 0,
+            'attempt_id' => $attemptId,
+            'scale_code' => 'MBTI',
+            'scale_version' => 'v0.3',
+            'type_code' => 'INTJ-A',
+            'scores_json' => json_encode(['EI' => 10], JSON_UNESCAPED_UNICODE),
+            'scores_pct' => json_encode(['EI' => 60], JSON_UNESCAPED_UNICODE),
+            'axis_states' => json_encode(['EI' => 'I'], JSON_UNESCAPED_UNICODE),
+            'profile_version' => 'seed',
+            'content_package_version' => 'v1',
+            'is_valid' => 1,
+            'computed_at' => now(),
+            'result_json' => json_encode(['seed' => true], JSON_UNESCAPED_UNICODE),
+            'pack_id' => 'MBTI.cn-mainland.zh-CN.v0.3',
+            'dir_version' => 'MBTI-CN-v0.3',
+            'scoring_spec_version' => 'seed',
+            'report_engine_version' => 'v1.2',
+            'scale_code_v2' => null,
+            'scale_uid' => null,
+            'created_at' => now(),
+            'updated_at' => now(),
+        ]);
+
+        $this->artisan('ops:backfill-results-scale-identity --chunk=100')
+            ->expectsOutputToContain('backfill_results_scale_identity')
+            ->assertExitCode(0);
+
+        $after = DB::table('results')->where('id', $resultId)->first();
+        $this->assertNotNull($after);
+        $this->assertSame('MBTI_PERSONALITY_TEST_16_TYPES', (string) ($after->scale_code_v2 ?? ''));
+        $this->assertSame('11111111-1111-4111-8111-111111111111', (string) ($after->scale_uid ?? ''));
+    }
+
+    public function test_backfill_skips_unknown_scale_code_results(): void
+    {
+        $this->artisan('migrate', ['--force' => true]);
+        $this->artisan('fap:scales:seed-default');
+
+        $attemptId = (string) Str::uuid();
+        DB::table('attempts')->insert([
+            'id' => $attemptId,
+            'org_id' => 0,
+            'anon_id' => 'ops_backfill_results_unknown',
+            'user_id' => null,
+            'scale_code' => 'UNKNOWN_SCALE',
+            'scale_version' => 'v0.3',
+            'question_count' => 1,
+            'answers_summary_json' => json_encode(['seed' => true], JSON_UNESCAPED_UNICODE),
+            'client_platform' => 'web',
+            'client_version' => null,
+            'channel' => 'test',
+            'referrer' => null,
+            'started_at' => now(),
+            'submitted_at' => now(),
+            'created_at' => now(),
+            'updated_at' => now(),
+        ]);
+
+        $resultId = (string) Str::uuid();
+        DB::table('results')->insert([
+            'id' => $resultId,
+            'org_id' => 0,
+            'attempt_id' => $attemptId,
+            'scale_code' => 'UNKNOWN_SCALE',
+            'scale_version' => 'v0.3',
+            'type_code' => 'UNKNOWN',
+            'scores_json' => json_encode(['raw' => 0], JSON_UNESCAPED_UNICODE),
+            'scores_pct' => json_encode([], JSON_UNESCAPED_UNICODE),
+            'axis_states' => json_encode([], JSON_UNESCAPED_UNICODE),
+            'profile_version' => 'seed',
+            'content_package_version' => 'v1',
+            'is_valid' => 1,
+            'computed_at' => now(),
+            'result_json' => json_encode(['seed' => true], JSON_UNESCAPED_UNICODE),
+            'pack_id' => 'seed',
+            'dir_version' => 'seed',
+            'scoring_spec_version' => 'seed',
+            'report_engine_version' => 'v1.2',
+            'scale_code_v2' => null,
+            'scale_uid' => null,
+            'created_at' => now(),
+            'updated_at' => now(),
+        ]);
+
+        $this->artisan('ops:backfill-results-scale-identity --chunk=100')
+            ->expectsOutputToContain('backfill_results_scale_identity')
+            ->assertExitCode(0);
+
+        $after = DB::table('results')->where('id', $resultId)->first();
+        $this->assertNotNull($after);
+        $this->assertNull($after->scale_code_v2);
+        $this->assertNull($after->scale_uid);
+    }
+}
+

--- a/backend/tests/Feature/Ops/BackfillSharesScaleIdentityCommandTest.php
+++ b/backend/tests/Feature/Ops/BackfillSharesScaleIdentityCommandTest.php
@@ -1,0 +1,76 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Ops;
+
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Str;
+use Tests\TestCase;
+
+final class BackfillSharesScaleIdentityCommandTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_backfill_populates_scale_identity_columns_for_known_shares(): void
+    {
+        $this->artisan('migrate', ['--force' => true]);
+        $this->artisan('fap:scales:seed-default');
+
+        $attemptId = (string) Str::uuid();
+        $shareId = (string) Str::uuid();
+        DB::table('shares')->insert([
+            'id' => $shareId,
+            'attempt_id' => $attemptId,
+            'anon_id' => 'ops_backfill_shares_known',
+            'scale_code' => 'MBTI',
+            'scale_code_v2' => null,
+            'scale_uid' => null,
+            'scale_version' => 'v0.3',
+            'content_package_version' => 'v1',
+            'created_at' => now(),
+            'updated_at' => now(),
+        ]);
+
+        $this->artisan('ops:backfill-shares-scale-identity --chunk=100')
+            ->expectsOutputToContain('backfill_shares_scale_identity')
+            ->assertExitCode(0);
+
+        $after = DB::table('shares')->where('id', $shareId)->first();
+        $this->assertNotNull($after);
+        $this->assertSame('MBTI_PERSONALITY_TEST_16_TYPES', (string) ($after->scale_code_v2 ?? ''));
+        $this->assertSame('11111111-1111-4111-8111-111111111111', (string) ($after->scale_uid ?? ''));
+    }
+
+    public function test_backfill_skips_unknown_scale_code_shares(): void
+    {
+        $this->artisan('migrate', ['--force' => true]);
+        $this->artisan('fap:scales:seed-default');
+
+        $attemptId = (string) Str::uuid();
+        $shareId = (string) Str::uuid();
+        DB::table('shares')->insert([
+            'id' => $shareId,
+            'attempt_id' => $attemptId,
+            'anon_id' => 'ops_backfill_shares_unknown',
+            'scale_code' => 'UNKNOWN_SCALE',
+            'scale_code_v2' => null,
+            'scale_uid' => null,
+            'scale_version' => 'v0.3',
+            'content_package_version' => 'v1',
+            'created_at' => now(),
+            'updated_at' => now(),
+        ]);
+
+        $this->artisan('ops:backfill-shares-scale-identity --chunk=100')
+            ->expectsOutputToContain('backfill_shares_scale_identity')
+            ->assertExitCode(0);
+
+        $after = DB::table('shares')->where('id', $shareId)->first();
+        $this->assertNotNull($after);
+        $this->assertNull($after->scale_code_v2);
+        $this->assertNull($after->scale_uid);
+    }
+}
+

--- a/backend/tests/Feature/Ops/CiScalesRegistrySeederToggleTest.php
+++ b/backend/tests/Feature/Ops/CiScalesRegistrySeederToggleTest.php
@@ -1,0 +1,99 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Ops;
+
+use Database\Seeders\CiScalesRegistrySeeder;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\DB;
+use Tests\TestCase;
+
+final class CiScalesRegistrySeederToggleTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_ci_seeder_disables_demo_scales_by_default(): void
+    {
+        $previous = getenv('FAP_CI_INCLUDE_DEMO_SCALES');
+        putenv('FAP_CI_INCLUDE_DEMO_SCALES');
+
+        try {
+            $this->seed(CiScalesRegistrySeeder::class);
+
+            $this->assertSame(
+                0,
+                (int) DB::table('scales_registry')
+                    ->where('org_id', 0)
+                    ->where('code', 'DEMO_ANSWERS')
+                    ->where('is_active', 1)
+                    ->count()
+            );
+            $this->assertSame(
+                0,
+                (int) DB::table('scales_registry')
+                    ->where('org_id', 0)
+                    ->where('code', 'SIMPLE_SCORE_DEMO')
+                    ->where('is_active', 1)
+                    ->count()
+            );
+            $this->assertSame(
+                1,
+                (int) DB::table('scales_registry')
+                    ->where('org_id', 0)
+                    ->where('code', 'IQ_RAVEN')
+                    ->where('is_active', 1)
+                    ->count()
+            );
+        } finally {
+            $this->restoreEnv('FAP_CI_INCLUDE_DEMO_SCALES', $previous);
+        }
+    }
+
+    public function test_ci_seeder_can_disable_demo_scales_without_removing_rows(): void
+    {
+        $previous = getenv('FAP_CI_INCLUDE_DEMO_SCALES');
+
+        try {
+            putenv('FAP_CI_INCLUDE_DEMO_SCALES=true');
+            $this->seed(CiScalesRegistrySeeder::class);
+
+            putenv('FAP_CI_INCLUDE_DEMO_SCALES=false');
+            $this->seed(CiScalesRegistrySeeder::class);
+
+            $demoAnswers = DB::table('scales_registry')
+                ->where('org_id', 0)
+                ->where('code', 'DEMO_ANSWERS')
+                ->first();
+            $simpleDemo = DB::table('scales_registry')
+                ->where('org_id', 0)
+                ->where('code', 'SIMPLE_SCORE_DEMO')
+                ->first();
+            $mbti = DB::table('scales_registry')
+                ->where('org_id', 0)
+                ->where('code', 'MBTI')
+                ->first();
+
+            $this->assertNotNull($demoAnswers);
+            $this->assertNotNull($simpleDemo);
+            $this->assertNotNull($mbti);
+            $this->assertSame(0, (int) ($demoAnswers->is_active ?? -1));
+            $this->assertSame(0, (int) ($demoAnswers->is_public ?? -1));
+            $this->assertSame(0, (int) ($simpleDemo->is_active ?? -1));
+            $this->assertSame(0, (int) ($simpleDemo->is_public ?? -1));
+            $this->assertSame(1, (int) ($mbti->is_active ?? 0));
+        } finally {
+            $this->restoreEnv('FAP_CI_INCLUDE_DEMO_SCALES', $previous);
+        }
+    }
+
+    private function restoreEnv(string $name, string|false $previous): void
+    {
+        if ($previous === false) {
+            putenv($name);
+            return;
+        }
+
+        putenv($name . '=' . $previous);
+    }
+}

--- a/backend/tests/Feature/Ops/ContentPathMirrorCommandTest.php
+++ b/backend/tests/Feature/Ops/ContentPathMirrorCommandTest.php
@@ -1,0 +1,148 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Ops;
+
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\File;
+use Tests\TestCase;
+
+final class ContentPathMirrorCommandTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private string $suffix;
+
+    private string $backendLegacyRel;
+
+    private string $backendMappedRel;
+
+    private string $contentLegacyRel;
+
+    private string $contentMappedRel;
+
+    private string $backendLegacyAbs;
+
+    private string $backendMappedAbs;
+
+    private string $contentLegacyAbs;
+
+    private string $contentMappedAbs;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->suffix = 'test_mirror_' . strtolower(bin2hex(random_bytes(4)));
+        $this->backendLegacyRel = 'content_packs/TEST_MIRROR_SRC_' . $this->suffix;
+        $this->backendMappedRel = 'content_packs/TEST_MIRROR_DST_' . $this->suffix;
+        $this->contentLegacyRel = 'default/CN_MAINLAND/zh-CN/TEST_MIRROR_SRC_' . $this->suffix;
+        $this->contentMappedRel = 'default/CN_MAINLAND/zh-CN/TEST_MIRROR_DST_' . $this->suffix;
+
+        $this->backendLegacyAbs = base_path($this->backendLegacyRel);
+        $this->backendMappedAbs = base_path($this->backendMappedRel);
+
+        $contentRoot = rtrim((string) config('content_packs.root', base_path('../content_packages')), DIRECTORY_SEPARATOR);
+        $this->contentLegacyAbs = $contentRoot . DIRECTORY_SEPARATOR . str_replace('/', DIRECTORY_SEPARATOR, $this->contentLegacyRel);
+        $this->contentMappedAbs = $contentRoot . DIRECTORY_SEPARATOR . str_replace('/', DIRECTORY_SEPARATOR, $this->contentMappedRel);
+
+        File::deleteDirectory($this->backendLegacyAbs);
+        File::deleteDirectory($this->backendMappedAbs);
+        File::deleteDirectory($this->contentLegacyAbs);
+        File::deleteDirectory($this->contentMappedAbs);
+
+        $this->seedSourceTrees();
+        $this->seedAliasRows();
+    }
+
+    protected function tearDown(): void
+    {
+        File::deleteDirectory($this->backendLegacyAbs);
+        File::deleteDirectory($this->backendMappedAbs);
+        File::deleteDirectory($this->contentLegacyAbs);
+        File::deleteDirectory($this->contentMappedAbs);
+        parent::tearDown();
+    }
+
+    public function test_sync_and_verify_hash_mirror_backend_and_content_packages_aliases(): void
+    {
+        $this->artisan('ops:content-path-mirror', [
+            '--sync' => true,
+            '--verify-hash' => true,
+            '--old-path' => [$this->backendLegacyRel, $this->contentLegacyRel],
+        ])
+            ->expectsOutputToContain('content_path_mirror')
+            ->assertExitCode(0);
+
+        $this->assertTrue(is_file($this->backendMappedAbs . DIRECTORY_SEPARATOR . 'v1' . DIRECTORY_SEPARATOR . 'compiled' . DIRECTORY_SEPARATOR . 'manifest.json'));
+        $this->assertTrue(is_file($this->contentMappedAbs . DIRECTORY_SEPARATOR . 'compiled' . DIRECTORY_SEPARATOR . 'questions.compiled.json'));
+
+        $this->assertSame(
+            hash_file('sha256', $this->backendLegacyAbs . DIRECTORY_SEPARATOR . 'v1' . DIRECTORY_SEPARATOR . 'compiled' . DIRECTORY_SEPARATOR . 'questions.compiled.json'),
+            hash_file('sha256', $this->backendMappedAbs . DIRECTORY_SEPARATOR . 'v1' . DIRECTORY_SEPARATOR . 'compiled' . DIRECTORY_SEPARATOR . 'questions.compiled.json')
+        );
+        $this->assertSame(
+            hash_file('sha256', $this->contentLegacyAbs . DIRECTORY_SEPARATOR . 'manifest.json'),
+            hash_file('sha256', $this->contentMappedAbs . DIRECTORY_SEPARATOR . 'manifest.json')
+        );
+    }
+
+    public function test_dry_run_does_not_create_mapped_directories(): void
+    {
+        File::deleteDirectory($this->backendMappedAbs);
+        File::deleteDirectory($this->contentMappedAbs);
+
+        $this->artisan('ops:content-path-mirror', [
+            '--sync' => true,
+            '--dry-run' => true,
+            '--old-path' => [$this->backendLegacyRel, $this->contentLegacyRel],
+        ])
+            ->expectsOutputToContain('content_path_mirror')
+            ->assertExitCode(0);
+
+        $this->assertFalse(is_dir($this->backendMappedAbs));
+        $this->assertFalse(is_dir($this->contentMappedAbs));
+    }
+
+    private function seedAliasRows(): void
+    {
+        DB::table('content_path_aliases')->updateOrInsert(
+            ['scope' => 'backend_content_packs', 'old_path' => $this->backendLegacyRel],
+            [
+                'new_path' => $this->backendMappedRel,
+                'scale_uid' => null,
+                'is_active' => true,
+                'updated_at' => now(),
+                'created_at' => now(),
+            ]
+        );
+
+        DB::table('content_path_aliases')->updateOrInsert(
+            ['scope' => 'content_packages', 'old_path' => $this->contentLegacyRel],
+            [
+                'new_path' => $this->contentMappedRel,
+                'scale_uid' => null,
+                'is_active' => true,
+                'updated_at' => now(),
+                'created_at' => now(),
+            ]
+        );
+    }
+
+    private function seedSourceTrees(): void
+    {
+        File::ensureDirectoryExists($this->backendLegacyAbs . DIRECTORY_SEPARATOR . 'v1' . DIRECTORY_SEPARATOR . 'compiled');
+        File::put($this->backendLegacyAbs . DIRECTORY_SEPARATOR . 'v1' . DIRECTORY_SEPARATOR . 'manifest.json', json_encode(['pack' => 'backend', 'kind' => 'manifest'], JSON_UNESCAPED_UNICODE));
+        File::put($this->backendLegacyAbs . DIRECTORY_SEPARATOR . 'v1' . DIRECTORY_SEPARATOR . 'questions.json', json_encode([['id' => 'B1']], JSON_UNESCAPED_UNICODE));
+        File::put($this->backendLegacyAbs . DIRECTORY_SEPARATOR . 'v1' . DIRECTORY_SEPARATOR . 'compiled' . DIRECTORY_SEPARATOR . 'manifest.json', json_encode(['compiled' => true], JSON_UNESCAPED_UNICODE));
+        File::put($this->backendLegacyAbs . DIRECTORY_SEPARATOR . 'v1' . DIRECTORY_SEPARATOR . 'compiled' . DIRECTORY_SEPARATOR . 'questions.compiled.json', json_encode(['question_index' => [['id' => 'B1']]], JSON_UNESCAPED_UNICODE));
+
+        File::ensureDirectoryExists($this->contentLegacyAbs . DIRECTORY_SEPARATOR . 'compiled');
+        File::put($this->contentLegacyAbs . DIRECTORY_SEPARATOR . 'manifest.json', json_encode(['pack' => 'content', 'kind' => 'manifest'], JSON_UNESCAPED_UNICODE));
+        File::put($this->contentLegacyAbs . DIRECTORY_SEPARATOR . 'questions.json', json_encode([['id' => 'C1']], JSON_UNESCAPED_UNICODE));
+        File::put($this->contentLegacyAbs . DIRECTORY_SEPARATOR . 'compiled' . DIRECTORY_SEPARATOR . 'manifest.json', json_encode(['compiled' => true], JSON_UNESCAPED_UNICODE));
+        File::put($this->contentLegacyAbs . DIRECTORY_SEPARATOR . 'compiled' . DIRECTORY_SEPARATOR . 'questions.compiled.json', json_encode(['question_index' => [['id' => 'C1']]], JSON_UNESCAPED_UNICODE));
+    }
+}

--- a/backend/tests/Feature/Ops/ScaleIdentityGateCommandTest.php
+++ b/backend/tests/Feature/Ops/ScaleIdentityGateCommandTest.php
@@ -1,0 +1,129 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Ops;
+
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Artisan;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Support\Str;
+use Tests\TestCase;
+
+final class ScaleIdentityGateCommandTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_gate_command_outputs_expected_metrics_in_json_payload(): void
+    {
+        $this->insertAttempt('MBTI', 'MBTI_PERSONALITY_TEST_16_TYPES', '11111111-1111-4111-8111-111111111111');
+        $this->insertAttempt('DEMO_ANSWERS', null, null);
+
+        $exitCode = Artisan::call('ops:scale-identity-gate', [
+            '--json' => '1',
+            '--hours' => '336',
+            '--max-rows' => '1000',
+        ]);
+
+        $this->assertSame(0, $exitCode);
+        $payload = json_decode(trim((string) Artisan::output()), true);
+        $this->assertIsArray($payload);
+        $this->assertTrue((bool) ($payload['ok'] ?? false));
+        $this->assertTrue(array_key_exists('metrics', $payload));
+        $this->assertTrue(array_key_exists('thresholds', $payload));
+
+        $metrics = is_array($payload['metrics'] ?? null) ? $payload['metrics'] : [];
+        $this->assertArrayHasKey('identity_resolve_mismatch_rate', $metrics);
+        $this->assertArrayHasKey('dual_write_mismatch_rate', $metrics);
+        $this->assertArrayHasKey('content_path_fallback_rate', $metrics);
+        $this->assertArrayHasKey('legacy_code_hit_rate', $metrics);
+        $this->assertArrayHasKey('demo_scale_hit_rate', $metrics);
+
+        $demo = is_array($metrics['demo_scale_hit_rate'] ?? null) ? $metrics['demo_scale_hit_rate'] : [];
+        $this->assertSame(1, (int) ($demo['numerator'] ?? 0));
+        $this->assertSame(2, (int) ($demo['denominator'] ?? 0));
+        $this->assertSame(0.5, (float) ($demo['rate'] ?? -1));
+    }
+
+    public function test_gate_command_strict_mode_fails_when_dual_write_mismatch_exists(): void
+    {
+        $this->insertAttempt('MBTI', 'EQ_EMOTIONAL_INTELLIGENCE', '11111111-1111-4111-8111-111111111111');
+
+        $previous = [
+            'FAP_GATE_IDENTITY_RESOLVE_MISMATCH_RATE_MAX' => getenv('FAP_GATE_IDENTITY_RESOLVE_MISMATCH_RATE_MAX'),
+            'FAP_GATE_DUAL_WRITE_MISMATCH_RATE_MAX' => getenv('FAP_GATE_DUAL_WRITE_MISMATCH_RATE_MAX'),
+            'FAP_GATE_CONTENT_PATH_FALLBACK_RATE_MAX' => getenv('FAP_GATE_CONTENT_PATH_FALLBACK_RATE_MAX'),
+            'FAP_GATE_LEGACY_CODE_HIT_RATE_MAX' => getenv('FAP_GATE_LEGACY_CODE_HIT_RATE_MAX'),
+            'FAP_GATE_DEMO_SCALE_HIT_RATE_MAX' => getenv('FAP_GATE_DEMO_SCALE_HIT_RATE_MAX'),
+        ];
+
+        putenv('FAP_GATE_IDENTITY_RESOLVE_MISMATCH_RATE_MAX=1');
+        putenv('FAP_GATE_DUAL_WRITE_MISMATCH_RATE_MAX=0');
+        putenv('FAP_GATE_CONTENT_PATH_FALLBACK_RATE_MAX=1');
+        putenv('FAP_GATE_LEGACY_CODE_HIT_RATE_MAX=1');
+        putenv('FAP_GATE_DEMO_SCALE_HIT_RATE_MAX=1');
+
+        try {
+            $exitCode = Artisan::call('ops:scale-identity-gate', [
+                '--json' => '1',
+                '--strict' => '1',
+                '--hours' => '336',
+                '--max-rows' => '1000',
+            ]);
+            $this->assertSame(1, $exitCode);
+
+            $payload = json_decode(trim((string) Artisan::output()), true);
+            $this->assertIsArray($payload);
+            $this->assertFalse((bool) ($payload['pass'] ?? true));
+            $violations = is_array($payload['violations'] ?? null) ? $payload['violations'] : [];
+            $this->assertNotEmpty($violations);
+        } finally {
+            $this->restoreEnv('FAP_GATE_IDENTITY_RESOLVE_MISMATCH_RATE_MAX', $previous['FAP_GATE_IDENTITY_RESOLVE_MISMATCH_RATE_MAX']);
+            $this->restoreEnv('FAP_GATE_DUAL_WRITE_MISMATCH_RATE_MAX', $previous['FAP_GATE_DUAL_WRITE_MISMATCH_RATE_MAX']);
+            $this->restoreEnv('FAP_GATE_CONTENT_PATH_FALLBACK_RATE_MAX', $previous['FAP_GATE_CONTENT_PATH_FALLBACK_RATE_MAX']);
+            $this->restoreEnv('FAP_GATE_LEGACY_CODE_HIT_RATE_MAX', $previous['FAP_GATE_LEGACY_CODE_HIT_RATE_MAX']);
+            $this->restoreEnv('FAP_GATE_DEMO_SCALE_HIT_RATE_MAX', $previous['FAP_GATE_DEMO_SCALE_HIT_RATE_MAX']);
+        }
+    }
+
+    private function insertAttempt(string $scaleCode, ?string $scaleCodeV2, ?string $scaleUid): void
+    {
+        $payload = [
+            'id' => (string) Str::uuid(),
+            'anon_id' => 'gate_' . strtolower(Str::random(10)),
+            'user_id' => null,
+            'scale_code' => strtoupper(trim($scaleCode)),
+            'scale_version' => 'v0.3',
+            'question_count' => 1,
+            'answers_summary_json' => json_encode([], JSON_UNESCAPED_UNICODE),
+            'client_platform' => 'web',
+            'client_version' => 'test',
+            'channel' => 'qa',
+            'referrer' => null,
+            'started_at' => now(),
+            'submitted_at' => null,
+            'created_at' => now(),
+            'updated_at' => now(),
+        ];
+
+        if (Schema::hasColumn('attempts', 'scale_code_v2')) {
+            $payload['scale_code_v2'] = $scaleCodeV2;
+        }
+        if (Schema::hasColumn('attempts', 'scale_uid')) {
+            $payload['scale_uid'] = $scaleUid;
+        }
+
+        DB::table('attempts')->insert($payload);
+    }
+
+    private function restoreEnv(string $name, string|false $value): void
+    {
+        if ($value === false) {
+            putenv($name);
+            return;
+        }
+
+        putenv($name . '=' . $value);
+    }
+}

--- a/backend/tests/Feature/V0_3/AnswerStorageScaleIdentityDualWriteTest.php
+++ b/backend/tests/Feature/V0_3/AnswerStorageScaleIdentityDualWriteTest.php
@@ -1,0 +1,122 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\V0_3;
+
+use App\Models\Attempt;
+use App\Services\Attempts\AnswerRowWriter;
+use App\Services\Attempts\AnswerSetStore;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Str;
+use Tests\TestCase;
+
+final class AnswerStorageScaleIdentityDualWriteTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_dual_mode_writes_scale_identity_columns_to_answer_set_and_rows(): void
+    {
+        config()->set('scale_identity.write_mode', 'dual');
+
+        $attempt = $this->createSdsAttempt('anon_answer_storage_dual');
+        $answers = $this->answersFixture();
+
+        $stored = app(AnswerSetStore::class)->storeFinalAnswers($attempt, $answers, 120000, 'v2.0_Factor_Logic');
+        $this->assertTrue((bool) ($stored['ok'] ?? false));
+
+        $rowsWritten = app(AnswerRowWriter::class)->writeRows($attempt, $answers, 120000);
+        $this->assertTrue((bool) ($rowsWritten['ok'] ?? false));
+        $this->assertSame(2, (int) ($rowsWritten['rows'] ?? 0));
+
+        $setRow = DB::table('attempt_answer_sets')->where('attempt_id', (string) $attempt->id)->first();
+        $this->assertNotNull($setRow);
+        $this->assertSame('DEPRESSION_SCREENING_STANDARD', (string) ($setRow->scale_code_v2 ?? ''));
+        $this->assertSame('44444444-4444-4444-8444-444444444444', (string) ($setRow->scale_uid ?? ''));
+
+        $row = DB::table('attempt_answer_rows')
+            ->where('attempt_id', (string) $attempt->id)
+            ->where('question_id', 'SDS-001')
+            ->first();
+        $this->assertNotNull($row);
+        $this->assertSame('DEPRESSION_SCREENING_STANDARD', (string) ($row->scale_code_v2 ?? ''));
+        $this->assertSame('44444444-4444-4444-8444-444444444444', (string) ($row->scale_uid ?? ''));
+    }
+
+    public function test_legacy_mode_keeps_scale_identity_columns_nullable_in_answer_storage(): void
+    {
+        config()->set('scale_identity.write_mode', 'legacy');
+
+        $attempt = $this->createSdsAttempt('anon_answer_storage_legacy');
+        $answers = $this->answersFixture();
+
+        $stored = app(AnswerSetStore::class)->storeFinalAnswers($attempt, $answers, 90000, 'v2.0_Factor_Logic');
+        $this->assertTrue((bool) ($stored['ok'] ?? false));
+
+        $rowsWritten = app(AnswerRowWriter::class)->writeRows($attempt, $answers, 90000);
+        $this->assertTrue((bool) ($rowsWritten['ok'] ?? false));
+        $this->assertSame(2, (int) ($rowsWritten['rows'] ?? 0));
+
+        $setRow = DB::table('attempt_answer_sets')->where('attempt_id', (string) $attempt->id)->first();
+        $this->assertNotNull($setRow);
+        $this->assertNull($setRow->scale_code_v2);
+        $this->assertNull($setRow->scale_uid);
+
+        $row = DB::table('attempt_answer_rows')
+            ->where('attempt_id', (string) $attempt->id)
+            ->where('question_id', 'SDS-001')
+            ->first();
+        $this->assertNotNull($row);
+        $this->assertNull($row->scale_code_v2);
+        $this->assertNull($row->scale_uid);
+    }
+
+    private function createSdsAttempt(string $anonId): Attempt
+    {
+        return Attempt::create([
+            'id' => (string) Str::uuid(),
+            'org_id' => 0,
+            'anon_id' => $anonId,
+            'scale_code' => 'SDS_20',
+            'scale_version' => 'v0.3',
+            'region' => 'CN_MAINLAND',
+            'locale' => 'zh-CN',
+            'question_count' => 2,
+            'answers_summary_json' => [
+                'stage' => 'seed',
+            ],
+            'client_platform' => 'test',
+            'started_at' => now()->subMinutes(2),
+            'submitted_at' => now()->subMinute(),
+            'pack_id' => 'SDS_20',
+            'dir_version' => 'v1',
+            'content_package_version' => 'v1',
+            'scoring_spec_version' => 'v2.0_Factor_Logic',
+        ]);
+    }
+
+    /**
+     * @return array<int,array<string,mixed>>
+     */
+    private function answersFixture(): array
+    {
+        return [
+            [
+                'question_id' => 'SDS-001',
+                'question_index' => 1,
+                'question_type' => 'likert',
+                'code' => '1',
+                'answer' => '1',
+            ],
+            [
+                'question_id' => 'SDS-002',
+                'question_index' => 2,
+                'question_type' => 'likert',
+                'code' => '2',
+                'answer' => '2',
+            ],
+        ];
+    }
+}
+

--- a/backend/tests/Feature/V0_3/AttemptScaleIdentityDualWriteTest.php
+++ b/backend/tests/Feature/V0_3/AttemptScaleIdentityDualWriteTest.php
@@ -1,0 +1,106 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\V0_3;
+
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Config;
+use Illuminate\Support\Facades\DB;
+use Tests\TestCase;
+
+class AttemptScaleIdentityDualWriteTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_start_dual_write_persists_scale_identity_columns_for_v2_input(): void
+    {
+        $this->artisan('migrate', ['--force' => true]);
+        $this->artisan('fap:scales:seed-default');
+
+        Config::set('scale_identity.write_mode', 'dual');
+
+        $response = $this->postJson('/api/v0.3/attempts/start', [
+            'scale_code' => 'MBTI_PERSONALITY_TEST_16_TYPES',
+            'anon_id' => 'dual_write_mbti_v2',
+        ]);
+
+        $response->assertStatus(200);
+        $response->assertJson([
+            'ok' => true,
+            'scale_code' => 'MBTI',
+            'scale_code_legacy' => 'MBTI',
+            'scale_code_v2' => 'MBTI_PERSONALITY_TEST_16_TYPES',
+            'scale_uid' => '11111111-1111-4111-8111-111111111111',
+            'requested_scale_code' => 'MBTI_PERSONALITY_TEST_16_TYPES',
+            'resolved_from_alias' => true,
+        ]);
+
+        $attemptId = (string) $response->json('attempt_id');
+        $this->assertNotSame('', $attemptId);
+
+        $row = DB::table('attempts')->where('id', $attemptId)->first();
+        $this->assertNotNull($row);
+        $this->assertSame('MBTI', (string) ($row->scale_code ?? ''));
+        $this->assertSame('MBTI_PERSONALITY_TEST_16_TYPES', (string) ($row->scale_code_v2 ?? ''));
+        $this->assertSame('11111111-1111-4111-8111-111111111111', (string) ($row->scale_uid ?? ''));
+    }
+
+    public function test_start_legacy_mode_keeps_identity_columns_nullable(): void
+    {
+        $this->artisan('migrate', ['--force' => true]);
+        $this->artisan('fap:scales:seed-default');
+
+        Config::set('scale_identity.write_mode', 'legacy');
+
+        $response = $this->postJson('/api/v0.3/attempts/start', [
+            'scale_code' => 'MBTI',
+            'anon_id' => 'legacy_write_mbti',
+        ]);
+
+        $response->assertStatus(200);
+        $response->assertJson([
+            'ok' => true,
+            'scale_code' => 'MBTI',
+            'scale_code_legacy' => 'MBTI',
+            'scale_code_v2' => 'MBTI_PERSONALITY_TEST_16_TYPES',
+            'scale_uid' => '11111111-1111-4111-8111-111111111111',
+            'requested_scale_code' => 'MBTI',
+            'resolved_from_alias' => false,
+        ]);
+
+        $attemptId = (string) $response->json('attempt_id');
+        $this->assertNotSame('', $attemptId);
+
+        $row = DB::table('attempts')->where('id', $attemptId)->first();
+        $this->assertNotNull($row);
+        $this->assertSame('MBTI', (string) ($row->scale_code ?? ''));
+        $this->assertNull($row->scale_code_v2);
+        $this->assertNull($row->scale_uid);
+    }
+
+    public function test_start_uses_v2_primary_scale_code_when_response_mode_is_v2(): void
+    {
+        $this->artisan('migrate', ['--force' => true]);
+        $this->artisan('fap:scales:seed-default');
+
+        Config::set('scale_identity.write_mode', 'dual');
+        Config::set('scale_identity.api_response_scale_code_mode', 'v2');
+
+        $response = $this->postJson('/api/v0.3/attempts/start', [
+            'scale_code' => 'MBTI',
+            'anon_id' => 'response_mode_v2_mbti',
+        ]);
+
+        $response->assertStatus(200);
+        $response->assertJson([
+            'ok' => true,
+            'scale_code' => 'MBTI_PERSONALITY_TEST_16_TYPES',
+            'scale_code_legacy' => 'MBTI',
+            'scale_code_v2' => 'MBTI_PERSONALITY_TEST_16_TYPES',
+            'scale_uid' => '11111111-1111-4111-8111-111111111111',
+            'requested_scale_code' => 'MBTI',
+            'resolved_from_alias' => false,
+        ]);
+    }
+}

--- a/backend/tests/Feature/V0_3/DemoScaleDeprecationGateTest.php
+++ b/backend/tests/Feature/V0_3/DemoScaleDeprecationGateTest.php
@@ -1,0 +1,122 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\V0_3;
+
+use Database\Seeders\Pr17SimpleScoreDemoSeeder;
+use Database\Seeders\Pr21AnswerDemoSeeder;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Config;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Str;
+use Tests\TestCase;
+
+class DemoScaleDeprecationGateTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private function issueAnonToken(string $anonId): string
+    {
+        $token = 'fm_' . (string) Str::uuid();
+        DB::table('fm_tokens')->insert([
+            'token' => $token,
+            'token_hash' => hash('sha256', $token),
+            'user_id' => null,
+            'anon_id' => $anonId,
+            'org_id' => 0,
+            'role' => 'public',
+            'expires_at' => now()->addDay(),
+            'created_at' => now(),
+            'updated_at' => now(),
+        ]);
+
+        return $token;
+    }
+
+    private function seedDemoScales(): void
+    {
+        (new Pr21AnswerDemoSeeder())->run();
+        (new Pr17SimpleScoreDemoSeeder())->run();
+    }
+
+    public function test_start_returns_410_when_demo_answers_scale_is_disabled(): void
+    {
+        $this->artisan('migrate', ['--force' => true]);
+        $this->seedDemoScales();
+
+        Config::set('scale_identity.allow_demo_scales', false);
+
+        $response = $this->postJson('/api/v0.3/attempts/start', [
+            'scale_code' => 'DEMO_ANSWERS',
+            'anon_id' => 'demo_scale_off_start',
+        ]);
+
+        $response->assertStatus(410);
+        $response->assertJsonPath('error_code', 'SCALE_DEPRECATED');
+        $response->assertJsonPath('details.scale_code_legacy', 'DEMO_ANSWERS');
+        $response->assertJsonPath('details.replacement_scale_code', 'IQ_RAVEN');
+        $response->assertJsonPath('details.replacement_scale_code_v2', 'IQ_INTELLIGENCE_QUOTIENT');
+    }
+
+    public function test_submit_returns_410_when_simple_score_demo_scale_is_disabled(): void
+    {
+        $this->artisan('migrate', ['--force' => true]);
+        $this->seedDemoScales();
+
+        $anonId = 'demo_scale_off_submit';
+        $token = $this->issueAnonToken($anonId);
+
+        $start = $this->withHeaders([
+            'X-Anon-Id' => $anonId,
+        ])->postJson('/api/v0.3/attempts/start', [
+            'scale_code' => 'SIMPLE_SCORE_DEMO',
+            'anon_id' => $anonId,
+        ]);
+        $start->assertStatus(200);
+        $attemptId = (string) $start->json('attempt_id');
+        $this->assertNotSame('', $attemptId);
+
+        Config::set('scale_identity.allow_demo_scales', false);
+
+        $submit = $this->withHeaders([
+            'X-Anon-Id' => $anonId,
+            'Authorization' => 'Bearer ' . $token,
+        ])->postJson('/api/v0.3/attempts/submit', [
+            'attempt_id' => $attemptId,
+            'answers' => [
+                ['question_id' => 'SS-001', 'code' => '5'],
+                ['question_id' => 'SS-002', 'code' => '4'],
+                ['question_id' => 'SS-003', 'code' => '3'],
+                ['question_id' => 'SS-004', 'code' => '2'],
+                ['question_id' => 'SS-005', 'code' => '1'],
+            ],
+            'duration_ms' => 120000,
+        ]);
+
+        $submit->assertStatus(410);
+        $submit->assertJsonPath('error_code', 'SCALE_DEPRECATED');
+        $submit->assertJsonPath('details.attempt_id', $attemptId);
+        $submit->assertJsonPath('details.scale_code_legacy', 'SIMPLE_SCORE_DEMO');
+        $submit->assertJsonPath('details.replacement_scale_code', 'SDS_20');
+        $submit->assertJsonPath('details.replacement_scale_code_v2', 'DEPRESSION_SCREENING_STANDARD');
+    }
+
+    public function test_lookup_returns_410_when_demo_answers_scale_is_disabled(): void
+    {
+        $this->artisan('migrate', ['--force' => true]);
+        $this->seedDemoScales();
+        $this->artisan('fap:scales:sync-slugs');
+
+        Config::set('scale_identity.allow_demo_scales', false);
+
+        $response = $this->getJson('/api/v0.3/scales/lookup?slug=demo-answers');
+        $response->assertStatus(410);
+        $response->assertJsonPath('error_code', 'SCALE_DEPRECATED');
+        $response->assertJsonPath('details.requested_slug', 'demo-answers');
+        $response->assertJsonPath('details.scale_code_legacy', 'DEMO_ANSWERS');
+        $response->assertJsonPath('details.replacement_scale_code', 'IQ_RAVEN');
+        $response->assertJsonPath('details.replacement_scale_code_v2', 'IQ_INTELLIGENCE_QUOTIENT');
+    }
+}
+

--- a/backend/tests/Feature/V0_3/EventScaleIdentityDualWriteTest.php
+++ b/backend/tests/Feature/V0_3/EventScaleIdentityDualWriteTest.php
@@ -1,0 +1,149 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\V0_3;
+
+use Database\Seeders\Pr16IqRavenDemoSeeder;
+use Database\Seeders\ScaleRegistrySeeder;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Config;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Str;
+use Tests\TestCase;
+
+class EventScaleIdentityDualWriteTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private function issueAnonToken(string $anonId): string
+    {
+        $token = 'fm_'.(string) Str::uuid();
+        DB::table('fm_tokens')->insert([
+            'token' => $token,
+            'token_hash' => hash('sha256', $token),
+            'user_id' => null,
+            'anon_id' => $anonId,
+            'org_id' => 0,
+            'role' => 'public',
+            'expires_at' => now()->addDay(),
+            'created_at' => now(),
+            'updated_at' => now(),
+        ]);
+
+        return $token;
+    }
+
+    private function seedScales(): void
+    {
+        (new ScaleRegistrySeeder())->run();
+        (new Pr16IqRavenDemoSeeder())->run();
+    }
+
+    public function test_start_and_submit_dual_write_persist_event_identity_columns(): void
+    {
+        $this->artisan('migrate', ['--force' => true]);
+        $this->seedScales();
+        Config::set('scale_identity.write_mode', 'dual');
+
+        $anonId = 'dual_event_iq';
+        $token = $this->issueAnonToken($anonId);
+
+        $start = $this->postJson('/api/v0.3/attempts/start', [
+            'scale_code' => 'IQ_INTELLIGENCE_QUOTIENT',
+            'anon_id' => $anonId,
+        ]);
+        $start->assertStatus(200);
+        $attemptId = (string) $start->json('attempt_id');
+        $this->assertNotSame('', $attemptId);
+
+        $startEvent = DB::table('events')
+            ->where('event_code', 'test_start')
+            ->where('attempt_id', $attemptId)
+            ->latest('created_at')
+            ->first();
+        $this->assertNotNull($startEvent);
+        $this->assertSame('IQ_RAVEN', (string) ($startEvent->scale_code ?? ''));
+        $this->assertSame('IQ_INTELLIGENCE_QUOTIENT', (string) ($startEvent->scale_code_v2 ?? ''));
+        $this->assertSame('55555555-5555-4555-8555-555555555555', (string) ($startEvent->scale_uid ?? ''));
+
+        $submit = $this->withHeaders([
+            'X-Anon-Id' => $anonId,
+            'Authorization' => 'Bearer '.$token,
+        ])->postJson('/api/v0.3/attempts/submit', [
+            'attempt_id' => $attemptId,
+            'answers' => [
+                ['question_id' => 'MATRIX_Q01', 'code' => 'A'],
+                ['question_id' => 'ODD_Q01', 'code' => 'B'],
+                ['question_id' => 'SERIES_Q01', 'code' => 'C'],
+            ],
+            'duration_ms' => 21000,
+        ]);
+        $submit->assertStatus(200);
+        $submit->assertJsonPath('ok', true);
+
+        $submitEvent = DB::table('events')
+            ->where('event_code', 'test_submit')
+            ->where('attempt_id', $attemptId)
+            ->latest('created_at')
+            ->first();
+        $this->assertNotNull($submitEvent);
+        $this->assertSame('IQ_RAVEN', (string) ($submitEvent->scale_code ?? ''));
+        $this->assertSame('IQ_INTELLIGENCE_QUOTIENT', (string) ($submitEvent->scale_code_v2 ?? ''));
+        $this->assertSame('55555555-5555-4555-8555-555555555555', (string) ($submitEvent->scale_uid ?? ''));
+    }
+
+    public function test_start_and_submit_legacy_mode_keep_event_identity_columns_nullable(): void
+    {
+        $this->artisan('migrate', ['--force' => true]);
+        $this->seedScales();
+        Config::set('scale_identity.write_mode', 'legacy');
+
+        $anonId = 'legacy_event_iq';
+        $token = $this->issueAnonToken($anonId);
+
+        $start = $this->postJson('/api/v0.3/attempts/start', [
+            'scale_code' => 'IQ_RAVEN',
+            'anon_id' => $anonId,
+        ]);
+        $start->assertStatus(200);
+        $attemptId = (string) $start->json('attempt_id');
+        $this->assertNotSame('', $attemptId);
+
+        $startEvent = DB::table('events')
+            ->where('event_code', 'test_start')
+            ->where('attempt_id', $attemptId)
+            ->latest('created_at')
+            ->first();
+        $this->assertNotNull($startEvent);
+        $this->assertSame('IQ_RAVEN', (string) ($startEvent->scale_code ?? ''));
+        $this->assertNull($startEvent->scale_code_v2);
+        $this->assertNull($startEvent->scale_uid);
+
+        $submit = $this->withHeaders([
+            'X-Anon-Id' => $anonId,
+            'Authorization' => 'Bearer '.$token,
+        ])->postJson('/api/v0.3/attempts/submit', [
+            'attempt_id' => $attemptId,
+            'answers' => [
+                ['question_id' => 'MATRIX_Q01', 'code' => 'A'],
+                ['question_id' => 'ODD_Q01', 'code' => 'B'],
+                ['question_id' => 'SERIES_Q01', 'code' => 'C'],
+            ],
+            'duration_ms' => 20000,
+        ]);
+        $submit->assertStatus(200);
+        $submit->assertJsonPath('ok', true);
+
+        $submitEvent = DB::table('events')
+            ->where('event_code', 'test_submit')
+            ->where('attempt_id', $attemptId)
+            ->latest('created_at')
+            ->first();
+        $this->assertNotNull($submitEvent);
+        $this->assertSame('IQ_RAVEN', (string) ($submitEvent->scale_code ?? ''));
+        $this->assertNull($submitEvent->scale_code_v2);
+        $this->assertNull($submitEvent->scale_uid);
+    }
+}
+

--- a/backend/tests/Feature/V0_3/OrderScaleIdentityDualWriteTest.php
+++ b/backend/tests/Feature/V0_3/OrderScaleIdentityDualWriteTest.php
@@ -1,0 +1,117 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\V0_3;
+
+use App\Models\Attempt;
+use App\Services\Commerce\OrderManager;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Str;
+use Tests\TestCase;
+
+final class OrderScaleIdentityDualWriteTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_order_manager_dual_mode_writes_order_scale_identity_columns(): void
+    {
+        config()->set('scale_identity.write_mode', 'dual');
+
+        $attemptId = $this->createAttempt('anon_order_dual');
+        $this->seedSku('SKU_SDS_20_FULL_299', 'SDS_20');
+
+        $result = app(OrderManager::class)->createOrder(
+            0,
+            null,
+            'anon_order_dual',
+            'SKU_SDS_20_FULL_299',
+            1,
+            $attemptId,
+            'billing'
+        );
+
+        $this->assertTrue((bool) ($result['ok'] ?? false));
+        $orderNo = (string) ($result['order_no'] ?? '');
+        $this->assertNotSame('', $orderNo);
+
+        $row = DB::table('orders')->where('order_no', $orderNo)->first();
+        $this->assertNotNull($row);
+        $this->assertSame('DEPRESSION_SCREENING_STANDARD', (string) ($row->scale_code_v2 ?? ''));
+        $this->assertSame('44444444-4444-4444-8444-444444444444', (string) ($row->scale_uid ?? ''));
+    }
+
+    public function test_order_manager_legacy_mode_keeps_order_identity_columns_nullable(): void
+    {
+        config()->set('scale_identity.write_mode', 'legacy');
+
+        $attemptId = $this->createAttempt('anon_order_legacy');
+        $this->seedSku('SKU_SDS_20_FULL_299', 'SDS_20');
+
+        $result = app(OrderManager::class)->createOrder(
+            0,
+            null,
+            'anon_order_legacy',
+            'SKU_SDS_20_FULL_299',
+            1,
+            $attemptId,
+            'billing'
+        );
+
+        $this->assertTrue((bool) ($result['ok'] ?? false));
+        $orderNo = (string) ($result['order_no'] ?? '');
+        $this->assertNotSame('', $orderNo);
+
+        $row = DB::table('orders')->where('order_no', $orderNo)->first();
+        $this->assertNotNull($row);
+        $this->assertNull($row->scale_code_v2);
+        $this->assertNull($row->scale_uid);
+    }
+
+    private function createAttempt(string $anonId): string
+    {
+        $attempt = Attempt::create([
+            'id' => (string) Str::uuid(),
+            'org_id' => 0,
+            'anon_id' => $anonId,
+            'scale_code' => 'SDS_20',
+            'scale_version' => 'v0.3',
+            'region' => 'CN_MAINLAND',
+            'locale' => 'zh-CN',
+            'question_count' => 20,
+            'answers_summary_json' => ['stage' => 'seed'],
+            'client_platform' => 'test',
+            'started_at' => now()->subMinutes(3),
+            'submitted_at' => now(),
+            'pack_id' => 'SDS_20',
+            'dir_version' => 'v1',
+            'content_package_version' => 'v1',
+            'scoring_spec_version' => 'v2.0_Factor_Logic',
+        ]);
+
+        return (string) $attempt->id;
+    }
+
+    private function seedSku(string $sku, string $scaleCode): void
+    {
+        $now = now();
+        DB::table('skus')->updateOrInsert(
+            ['sku' => $sku],
+            [
+                'scale_code' => $scaleCode,
+                'kind' => 'report_unlock',
+                'unit_qty' => 1,
+                'benefit_code' => 'SDS_20_FULL',
+                'scope' => 'attempt',
+                'price_cents' => 299,
+                'currency' => 'CNY',
+                'is_active' => true,
+                'meta_json' => null,
+                'created_at' => $now,
+                'updated_at' => $now,
+            ]
+        );
+    }
+}
+

--- a/backend/tests/Feature/V0_3/PaymentEventScaleIdentityDualWriteTest.php
+++ b/backend/tests/Feature/V0_3/PaymentEventScaleIdentityDualWriteTest.php
@@ -1,0 +1,186 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\V0_3;
+
+use App\Models\Attempt;
+use App\Models\Result;
+use Database\Seeders\Pr19CommerceSeeder;
+use Database\Seeders\ScaleRegistrySeeder;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Str;
+use Tests\Concerns\SignedBillingWebhook;
+use Tests\Feature\Sds20\Concerns\BuildsSds20ScorerInput;
+use Tests\TestCase;
+
+final class PaymentEventScaleIdentityDualWriteTest extends TestCase
+{
+    use BuildsSds20ScorerInput;
+    use RefreshDatabase;
+    use SignedBillingWebhook;
+
+    public function test_webhook_dual_mode_writes_payment_event_scale_identity_columns(): void
+    {
+        config()->set('scale_identity.write_mode', 'dual');
+        (new ScaleRegistrySeeder())->run();
+        (new Pr19CommerceSeeder())->run();
+
+        $anonId = 'anon_payevt_dual';
+        $attemptId = $this->createSdsAttemptWithResult($anonId);
+        $orderNo = 'ord_payevt_dual_1';
+        $this->createOrder($orderNo, 'SKU_SDS_20_FULL_299', $attemptId, $anonId, 299);
+
+        $resp = $this->postSignedBillingWebhook([
+            'provider_event_id' => 'evt_payevt_dual_1',
+            'order_no' => $orderNo,
+            'external_trade_no' => 'trade_payevt_dual_1',
+            'amount_cents' => 299,
+            'currency' => 'CNY',
+        ], ['X-Org-Id' => '0']);
+
+        $resp->assertStatus(200);
+        $resp->assertJsonPath('ok', true);
+
+        $event = DB::table('payment_events')
+            ->where('provider', 'billing')
+            ->where('provider_event_id', 'evt_payevt_dual_1')
+            ->first();
+
+        $this->assertNotNull($event);
+        $this->assertSame('DEPRESSION_SCREENING_STANDARD', (string) ($event->scale_code_v2 ?? ''));
+        $this->assertSame('44444444-4444-4444-8444-444444444444', (string) ($event->scale_uid ?? ''));
+    }
+
+    public function test_webhook_legacy_mode_keeps_payment_event_scale_identity_columns_nullable(): void
+    {
+        config()->set('scale_identity.write_mode', 'legacy');
+        (new ScaleRegistrySeeder())->run();
+        (new Pr19CommerceSeeder())->run();
+
+        $anonId = 'anon_payevt_legacy';
+        $attemptId = $this->createSdsAttemptWithResult($anonId);
+        $orderNo = 'ord_payevt_legacy_1';
+        $this->createOrder($orderNo, 'SKU_SDS_20_FULL_299', $attemptId, $anonId, 299);
+
+        $resp = $this->postSignedBillingWebhook([
+            'provider_event_id' => 'evt_payevt_legacy_1',
+            'order_no' => $orderNo,
+            'external_trade_no' => 'trade_payevt_legacy_1',
+            'amount_cents' => 299,
+            'currency' => 'CNY',
+        ], ['X-Org-Id' => '0']);
+
+        $resp->assertStatus(200);
+        $resp->assertJsonPath('ok', true);
+
+        $event = DB::table('payment_events')
+            ->where('provider', 'billing')
+            ->where('provider_event_id', 'evt_payevt_legacy_1')
+            ->first();
+
+        $this->assertNotNull($event);
+        $this->assertNull($event->scale_code_v2);
+        $this->assertNull($event->scale_uid);
+    }
+
+    private function createSdsAttemptWithResult(string $anonId): string
+    {
+        $attemptId = (string) Str::uuid();
+        $attempt = Attempt::create([
+            'id' => $attemptId,
+            'org_id' => 0,
+            'anon_id' => $anonId,
+            'scale_code' => 'SDS_20',
+            'scale_version' => 'v0.3',
+            'region' => 'CN_MAINLAND',
+            'locale' => 'zh-CN',
+            'question_count' => 20,
+            'client_platform' => 'test',
+            'answers_summary_json' => [
+                'stage' => 'seed',
+                'meta' => [
+                    'consent' => [
+                        'accepted' => true,
+                        'version' => 'SDS_20_v1_2026-02-22',
+                        'locale' => 'zh-CN',
+                    ],
+                ],
+            ],
+            'started_at' => now()->subMinutes(3),
+            'submitted_at' => now(),
+            'pack_id' => 'SDS_20',
+            'dir_version' => 'v1',
+            'content_package_version' => 'v1',
+            'scoring_spec_version' => 'v2.0_Factor_Logic',
+        ]);
+
+        $score = $this->scoreSds([], [
+            'duration_ms' => 98000,
+            'started_at' => $attempt->started_at,
+            'submitted_at' => $attempt->submitted_at,
+            'locale' => 'zh-CN',
+            'region' => 'CN_MAINLAND',
+        ]);
+
+        Result::create([
+            'id' => (string) Str::uuid(),
+            'org_id' => 0,
+            'attempt_id' => $attemptId,
+            'scale_code' => 'SDS_20',
+            'scale_version' => 'v0.3',
+            'type_code' => '',
+            'scores_json' => (array) ($score['scores'] ?? []),
+            'scores_pct' => [],
+            'axis_states' => [],
+            'content_package_version' => 'v1',
+            'result_json' => [
+                'scale_code' => 'SDS_20',
+                'normed_json' => $score,
+                'breakdown_json' => ['score_result' => $score],
+                'axis_scores_json' => ['score_result' => $score],
+            ],
+            'pack_id' => 'SDS_20',
+            'dir_version' => 'v1',
+            'scoring_spec_version' => 'v2.0_Factor_Logic',
+            'report_engine_version' => 'v1.2',
+            'is_valid' => true,
+            'computed_at' => now(),
+        ]);
+
+        return $attemptId;
+    }
+
+    private function createOrder(string $orderNo, string $sku, string $attemptId, string $anonId, int $amountCents): void
+    {
+        DB::table('orders')->insert([
+            'id' => (string) Str::uuid(),
+            'order_no' => $orderNo,
+            'org_id' => 0,
+            'user_id' => null,
+            'anon_id' => $anonId,
+            'sku' => $sku,
+            'quantity' => 1,
+            'target_attempt_id' => $attemptId,
+            'amount_cents' => $amountCents,
+            'currency' => 'CNY',
+            'status' => 'created',
+            'provider' => 'billing',
+            'external_trade_no' => null,
+            'paid_at' => null,
+            'created_at' => now(),
+            'updated_at' => now(),
+            'amount_total' => $amountCents,
+            'amount_refunded' => 0,
+            'item_sku' => $sku,
+            'provider_order_id' => null,
+            'device_id' => null,
+            'request_id' => null,
+            'created_ip' => null,
+            'fulfilled_at' => null,
+            'refunded_at' => null,
+        ]);
+    }
+}
+

--- a/backend/tests/Feature/V0_3/ReportSnapshotScaleIdentityDualWriteTest.php
+++ b/backend/tests/Feature/V0_3/ReportSnapshotScaleIdentityDualWriteTest.php
@@ -1,0 +1,135 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\V0_3;
+
+use App\Jobs\GenerateReportSnapshotJob;
+use App\Services\Report\ReportSnapshotStore;
+use Database\Seeders\Pr16IqRavenDemoSeeder;
+use Database\Seeders\ScaleRegistrySeeder;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Config;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Str;
+use Tests\TestCase;
+
+class ReportSnapshotScaleIdentityDualWriteTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private function issueAnonToken(string $anonId): string
+    {
+        $token = 'fm_'.(string) Str::uuid();
+        DB::table('fm_tokens')->insert([
+            'token' => $token,
+            'token_hash' => hash('sha256', $token),
+            'user_id' => null,
+            'anon_id' => $anonId,
+            'org_id' => 0,
+            'role' => 'public',
+            'expires_at' => now()->addDay(),
+            'created_at' => now(),
+            'updated_at' => now(),
+        ]);
+
+        return $token;
+    }
+
+    private function seedScales(): void
+    {
+        (new ScaleRegistrySeeder())->run();
+        (new Pr16IqRavenDemoSeeder())->run();
+    }
+
+    public function test_submit_and_snapshot_job_dual_write_snapshot_identity_columns(): void
+    {
+        $this->artisan('migrate', ['--force' => true]);
+        $this->seedScales();
+        Config::set('scale_identity.write_mode', 'dual');
+
+        $anonId = 'dual_snapshot_iq';
+        $token = $this->issueAnonToken($anonId);
+
+        $start = $this->postJson('/api/v0.3/attempts/start', [
+            'scale_code' => 'IQ_INTELLIGENCE_QUOTIENT',
+            'anon_id' => $anonId,
+        ]);
+        $start->assertStatus(200);
+        $attemptId = (string) $start->json('attempt_id');
+        $this->assertNotSame('', $attemptId);
+
+        $submit = $this->withHeaders([
+            'X-Anon-Id' => $anonId,
+            'Authorization' => 'Bearer '.$token,
+        ])->postJson('/api/v0.3/attempts/submit', [
+            'attempt_id' => $attemptId,
+            'answers' => [
+                ['question_id' => 'MATRIX_Q01', 'code' => 'A'],
+                ['question_id' => 'ODD_Q01', 'code' => 'B'],
+                ['question_id' => 'SERIES_Q01', 'code' => 'C'],
+            ],
+            'duration_ms' => 23000,
+        ]);
+        $submit->assertStatus(200);
+        $submit->assertJsonPath('ok', true);
+
+        $pending = DB::table('report_snapshots')->where('attempt_id', $attemptId)->first();
+        $this->assertNotNull($pending);
+        $this->assertSame('pending', (string) ($pending->status ?? ''));
+        $this->assertSame('IQ_RAVEN', (string) ($pending->scale_code ?? ''));
+        $this->assertSame('IQ_INTELLIGENCE_QUOTIENT', (string) ($pending->scale_code_v2 ?? ''));
+        $this->assertSame('55555555-5555-4555-8555-555555555555', (string) ($pending->scale_uid ?? ''));
+
+        $job = new GenerateReportSnapshotJob(0, $attemptId, 'submit', null);
+        $job->handle(app(ReportSnapshotStore::class));
+
+        $ready = DB::table('report_snapshots')->where('attempt_id', $attemptId)->first();
+        $this->assertNotNull($ready);
+        $this->assertSame('ready', (string) ($ready->status ?? ''));
+        $this->assertSame('IQ_RAVEN', (string) ($ready->scale_code ?? ''));
+        $this->assertSame('IQ_INTELLIGENCE_QUOTIENT', (string) ($ready->scale_code_v2 ?? ''));
+        $this->assertSame('55555555-5555-4555-8555-555555555555', (string) ($ready->scale_uid ?? ''));
+    }
+
+    public function test_submit_legacy_mode_keeps_snapshot_identity_columns_nullable(): void
+    {
+        $this->artisan('migrate', ['--force' => true]);
+        $this->seedScales();
+        Config::set('scale_identity.write_mode', 'legacy');
+
+        $anonId = 'legacy_snapshot_iq';
+        $token = $this->issueAnonToken($anonId);
+
+        $start = $this->postJson('/api/v0.3/attempts/start', [
+            'scale_code' => 'IQ_RAVEN',
+            'anon_id' => $anonId,
+        ]);
+        $start->assertStatus(200);
+        $attemptId = (string) $start->json('attempt_id');
+        $this->assertNotSame('', $attemptId);
+
+        $submit = $this->withHeaders([
+            'X-Anon-Id' => $anonId,
+            'Authorization' => 'Bearer '.$token,
+        ])->postJson('/api/v0.3/attempts/submit', [
+            'attempt_id' => $attemptId,
+            'answers' => [
+                ['question_id' => 'MATRIX_Q01', 'code' => 'A'],
+                ['question_id' => 'ODD_Q01', 'code' => 'B'],
+                ['question_id' => 'SERIES_Q01', 'code' => 'C'],
+            ],
+            'duration_ms' => 22000,
+        ]);
+        $submit->assertStatus(200);
+        $submit->assertJsonPath('ok', true);
+
+        $pending = DB::table('report_snapshots')->where('attempt_id', $attemptId)->first();
+        $this->assertNotNull($pending);
+        $this->assertSame('pending', (string) ($pending->status ?? ''));
+        $this->assertSame('IQ_RAVEN', (string) ($pending->scale_code ?? ''));
+        $this->assertNull($pending->scale_code_v2);
+        $this->assertNull($pending->scale_uid);
+    }
+}
+

--- a/backend/tests/Feature/V0_3/ResultScaleIdentityDualWriteTest.php
+++ b/backend/tests/Feature/V0_3/ResultScaleIdentityDualWriteTest.php
@@ -1,0 +1,124 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\V0_3;
+
+use Database\Seeders\Pr16IqRavenDemoSeeder;
+use Database\Seeders\ScaleRegistrySeeder;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Config;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Str;
+use Tests\TestCase;
+
+class ResultScaleIdentityDualWriteTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private function issueAnonToken(string $anonId): string
+    {
+        $token = 'fm_'.(string) Str::uuid();
+        DB::table('fm_tokens')->insert([
+            'token' => $token,
+            'token_hash' => hash('sha256', $token),
+            'user_id' => null,
+            'anon_id' => $anonId,
+            'org_id' => 0,
+            'role' => 'public',
+            'expires_at' => now()->addDay(),
+            'created_at' => now(),
+            'updated_at' => now(),
+        ]);
+
+        return $token;
+    }
+
+    private function seedScales(): void
+    {
+        (new ScaleRegistrySeeder())->run();
+        (new Pr16IqRavenDemoSeeder())->run();
+    }
+
+    public function test_submit_dual_write_persists_result_identity_columns_for_v2_input(): void
+    {
+        $this->artisan('migrate', ['--force' => true]);
+        $this->seedScales();
+        Config::set('scale_identity.write_mode', 'dual');
+
+        $anonId = 'dual_result_iq';
+        $token = $this->issueAnonToken($anonId);
+
+        $start = $this->postJson('/api/v0.3/attempts/start', [
+            'scale_code' => 'IQ_INTELLIGENCE_QUOTIENT',
+            'anon_id' => $anonId,
+        ]);
+        $start->assertStatus(200);
+        $attemptId = (string) $start->json('attempt_id');
+        $this->assertNotSame('', $attemptId);
+
+        $submit = $this->withHeaders([
+            'X-Anon-Id' => $anonId,
+            'Authorization' => 'Bearer '.$token,
+        ])->postJson('/api/v0.3/attempts/submit', [
+            'attempt_id' => $attemptId,
+            'answers' => [
+                ['question_id' => 'MATRIX_Q01', 'code' => 'A'],
+                ['question_id' => 'ODD_Q01', 'code' => 'B'],
+                ['question_id' => 'SERIES_Q01', 'code' => 'C'],
+            ],
+            'duration_ms' => 21000,
+        ]);
+        $submit->assertStatus(200);
+        $submit->assertJsonPath('ok', true);
+        $submit->assertJsonPath('meta.scale_code', 'IQ_RAVEN');
+        $submit->assertJsonPath('meta.scale_code_v2', 'IQ_INTELLIGENCE_QUOTIENT');
+        $submit->assertJsonPath('meta.scale_uid', '55555555-5555-4555-8555-555555555555');
+
+        $row = DB::table('results')->where('attempt_id', $attemptId)->first();
+        $this->assertNotNull($row);
+        $this->assertSame('IQ_RAVEN', (string) ($row->scale_code ?? ''));
+        $this->assertSame('IQ_INTELLIGENCE_QUOTIENT', (string) ($row->scale_code_v2 ?? ''));
+        $this->assertSame('55555555-5555-4555-8555-555555555555', (string) ($row->scale_uid ?? ''));
+    }
+
+    public function test_submit_legacy_mode_keeps_result_identity_columns_nullable(): void
+    {
+        $this->artisan('migrate', ['--force' => true]);
+        $this->seedScales();
+        Config::set('scale_identity.write_mode', 'legacy');
+
+        $anonId = 'legacy_result_iq';
+        $token = $this->issueAnonToken($anonId);
+
+        $start = $this->postJson('/api/v0.3/attempts/start', [
+            'scale_code' => 'IQ_RAVEN',
+            'anon_id' => $anonId,
+        ]);
+        $start->assertStatus(200);
+        $attemptId = (string) $start->json('attempt_id');
+        $this->assertNotSame('', $attemptId);
+
+        $submit = $this->withHeaders([
+            'X-Anon-Id' => $anonId,
+            'Authorization' => 'Bearer '.$token,
+        ])->postJson('/api/v0.3/attempts/submit', [
+            'attempt_id' => $attemptId,
+            'answers' => [
+                ['question_id' => 'MATRIX_Q01', 'code' => 'A'],
+                ['question_id' => 'ODD_Q01', 'code' => 'B'],
+                ['question_id' => 'SERIES_Q01', 'code' => 'C'],
+            ],
+            'duration_ms' => 22000,
+        ]);
+        $submit->assertStatus(200);
+        $submit->assertJsonPath('ok', true);
+
+        $row = DB::table('results')->where('attempt_id', $attemptId)->first();
+        $this->assertNotNull($row);
+        $this->assertSame('IQ_RAVEN', (string) ($row->scale_code ?? ''));
+        $this->assertNull($row->scale_code_v2);
+        $this->assertNull($row->scale_uid);
+    }
+}
+

--- a/backend/tests/Feature/V0_3/ScalesDualCodeReadTest.php
+++ b/backend/tests/Feature/V0_3/ScalesDualCodeReadTest.php
@@ -1,0 +1,116 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\V0_3;
+
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Config;
+use Illuminate\Support\Facades\DB;
+use Tests\TestCase;
+
+class ScalesDualCodeReadTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_show_accepts_v2_scale_code_and_returns_legacy_registry_item(): void
+    {
+        $this->artisan('migrate', ['--force' => true]);
+        $this->artisan('fap:scales:seed-default');
+
+        $response = $this->getJson('/api/v0.3/scales/MBTI_PERSONALITY_TEST_16_TYPES');
+        $response->assertStatus(200);
+        $response->assertJsonPath('ok', true);
+        $response->assertJsonPath('item.code', 'MBTI');
+        $response->assertJsonPath('requested_scale_code', 'MBTI_PERSONALITY_TEST_16_TYPES');
+        $response->assertJsonPath('scale_code_legacy', 'MBTI');
+        $response->assertJsonPath('scale_code_v2', 'MBTI_PERSONALITY_TEST_16_TYPES');
+        $response->assertJsonPath('scale_uid', '11111111-1111-4111-8111-111111111111');
+        $response->assertJsonPath('pack_id_v2', 'MBTI_PERSONALITY_TEST_16_TYPES.cn-mainland.zh-CN.v0.3');
+        $response->assertJsonPath('dir_version_v2', 'MBTI_PERSONALITY_TEST_16_TYPES-CN-v0.3');
+        $response->assertJsonPath('resolved_from_alias', true);
+    }
+
+    public function test_questions_accepts_v2_scale_code_and_serves_same_questions_contract(): void
+    {
+        $this->artisan('migrate', ['--force' => true]);
+        $this->artisan('fap:scales:seed-default');
+
+        $response = $this->getJson('/api/v0.3/scales/MBTI_PERSONALITY_TEST_16_TYPES/questions');
+        $response->assertStatus(200);
+        $response->assertJsonPath('ok', true);
+        $response->assertJsonPath('scale_code', 'MBTI');
+        $response->assertJsonPath('requested_scale_code', 'MBTI_PERSONALITY_TEST_16_TYPES');
+        $response->assertJsonPath('scale_code_legacy', 'MBTI');
+        $response->assertJsonPath('scale_code_v2', 'MBTI_PERSONALITY_TEST_16_TYPES');
+        $response->assertJsonPath('scale_uid', '11111111-1111-4111-8111-111111111111');
+        $response->assertJsonPath('pack_id_v2', 'MBTI_PERSONALITY_TEST_16_TYPES.cn-mainland.zh-CN.v0.3');
+        $response->assertJsonPath('dir_version_v2', 'MBTI_PERSONALITY_TEST_16_TYPES-CN-v0.3');
+        $response->assertJsonPath('resolved_from_alias', true);
+        $response->assertJsonPath('questions.schema', 'fap.questions.v1');
+        $this->assertIsArray($response->json('questions.items'));
+    }
+
+    public function test_show_uses_v2_primary_field_when_response_mode_is_v2(): void
+    {
+        $this->artisan('migrate', ['--force' => true]);
+        $this->artisan('fap:scales:seed-default');
+        Config::set('scale_identity.api_response_scale_code_mode', 'v2');
+
+        $response = $this->getJson('/api/v0.3/scales/MBTI');
+        $response->assertStatus(200);
+        $response->assertJsonPath('scale_code', 'MBTI_PERSONALITY_TEST_16_TYPES');
+        $response->assertJsonPath('scale_code_legacy', 'MBTI');
+        $response->assertJsonPath('scale_code_v2', 'MBTI_PERSONALITY_TEST_16_TYPES');
+        $response->assertJsonPath('pack_id_v2', 'MBTI_PERSONALITY_TEST_16_TYPES.cn-mainland.zh-CN.v0.3');
+        $response->assertJsonPath('dir_version_v2', 'MBTI_PERSONALITY_TEST_16_TYPES-CN-v0.3');
+    }
+
+    public function test_questions_uses_v2_primary_field_when_response_mode_is_v2(): void
+    {
+        $this->artisan('migrate', ['--force' => true]);
+        $this->artisan('fap:scales:seed-default');
+        Config::set('scale_identity.api_response_scale_code_mode', 'v2');
+
+        $response = $this->getJson('/api/v0.3/scales/MBTI/questions');
+        $response->assertStatus(200);
+        $response->assertJsonPath('scale_code', 'MBTI_PERSONALITY_TEST_16_TYPES');
+        $response->assertJsonPath('scale_code_legacy', 'MBTI');
+        $response->assertJsonPath('scale_code_v2', 'MBTI_PERSONALITY_TEST_16_TYPES');
+        $response->assertJsonPath('pack_id_v2', 'MBTI_PERSONALITY_TEST_16_TYPES.cn-mainland.zh-CN.v0.3');
+        $response->assertJsonPath('dir_version_v2', 'MBTI_PERSONALITY_TEST_16_TYPES-CN-v0.3');
+    }
+
+    public function test_show_resolves_runtime_db_alias_even_when_config_maps_are_empty(): void
+    {
+        $this->artisan('migrate', ['--force' => true]);
+        $this->artisan('fap:scales:seed-default');
+
+        DB::table('scale_code_aliases')->updateOrInsert(
+            ['alias_code' => 'MBTI_CANARY_ALIAS'],
+            [
+                'scale_uid' => '11111111-1111-4111-8111-111111111111',
+                'alias_type' => 'custom',
+                'is_primary' => false,
+                'created_at' => now(),
+                'updated_at' => now(),
+            ]
+        );
+
+        Config::set('scale_identity.code_map_v1_to_v2', []);
+        Config::set('scale_identity.code_map_v2_to_v1', []);
+        Config::set('scale_identity.scale_uid_map', []);
+
+        $response = $this->getJson('/api/v0.3/scales/MBTI_CANARY_ALIAS');
+        $response->assertStatus(200);
+        $response->assertJsonPath('ok', true);
+        $response->assertJsonPath('item.code', 'MBTI');
+        $response->assertJsonPath('requested_scale_code', 'MBTI_CANARY_ALIAS');
+        $response->assertJsonPath('scale_code_legacy', 'MBTI');
+        $response->assertJsonPath('scale_code_v2', 'MBTI_PERSONALITY_TEST_16_TYPES');
+        $response->assertJsonPath('scale_uid', '11111111-1111-4111-8111-111111111111');
+        $response->assertJsonPath('pack_id_v2', 'MBTI_PERSONALITY_TEST_16_TYPES.cn-mainland.zh-CN.v0.3');
+        $response->assertJsonPath('dir_version_v2', 'MBTI_PERSONALITY_TEST_16_TYPES-CN-v0.3');
+        $response->assertJsonPath('resolved_from_alias', true);
+    }
+}

--- a/backend/tests/Feature/V0_3/ScalesLookupTest.php
+++ b/backend/tests/Feature/V0_3/ScalesLookupTest.php
@@ -24,6 +24,11 @@ class ScalesLookupTest extends TestCase
         $response->assertJson([
             'ok' => true,
             'scale_code' => 'MBTI',
+            'scale_code_legacy' => 'MBTI',
+            'scale_code_v2' => 'MBTI_PERSONALITY_TEST_16_TYPES',
+            'scale_uid' => '11111111-1111-4111-8111-111111111111',
+            'pack_id_v2' => 'MBTI_PERSONALITY_TEST_16_TYPES.cn-mainland.zh-CN.v0.3',
+            'dir_version_v2' => 'MBTI_PERSONALITY_TEST_16_TYPES-CN-v0.3',
             'primary_slug' => 'mbti-personality-test-16-personality-types',
             'requested_slug' => 'mbti-personality-test-16-personality-types',
             'resolved_from_alias' => false,
@@ -41,18 +46,18 @@ class ScalesLookupTest extends TestCase
         $this->artisan('fap:scales:sync-slugs');
 
         $cases = [
-            ['slug' => 'mbti-personality-test-16-personality-types', 'scale_code' => 'MBTI', 'primary_slug' => 'mbti-personality-test-16-personality-types', 'resolved_from_alias' => false],
-            ['slug' => 'mbti-test', 'scale_code' => 'MBTI', 'primary_slug' => 'mbti-personality-test-16-personality-types', 'resolved_from_alias' => true],
-            ['slug' => 'big-five-personality-test-ocean-model', 'scale_code' => 'BIG5_OCEAN', 'primary_slug' => 'big-five-personality-test-ocean-model', 'resolved_from_alias' => false],
-            ['slug' => 'big5-ocean', 'scale_code' => 'BIG5_OCEAN', 'primary_slug' => 'big-five-personality-test-ocean-model', 'resolved_from_alias' => true],
-            ['slug' => 'clinical-depression-anxiety-assessment-professional-edition', 'scale_code' => 'CLINICAL_COMBO_68', 'primary_slug' => 'clinical-depression-anxiety-assessment-professional-edition', 'resolved_from_alias' => false],
-            ['slug' => 'clinical-combo-68', 'scale_code' => 'CLINICAL_COMBO_68', 'primary_slug' => 'clinical-depression-anxiety-assessment-professional-edition', 'resolved_from_alias' => true],
-            ['slug' => 'depression-screening-test-standard-edition', 'scale_code' => 'SDS_20', 'primary_slug' => 'depression-screening-test-standard-edition', 'resolved_from_alias' => false],
-            ['slug' => 'sds-20', 'scale_code' => 'SDS_20', 'primary_slug' => 'depression-screening-test-standard-edition', 'resolved_from_alias' => true],
-            ['slug' => 'iq-test-intelligence-quotient-assessment', 'scale_code' => 'IQ_RAVEN', 'primary_slug' => 'iq-test-intelligence-quotient-assessment', 'resolved_from_alias' => false],
-            ['slug' => 'iq-test', 'scale_code' => 'IQ_RAVEN', 'primary_slug' => 'iq-test-intelligence-quotient-assessment', 'resolved_from_alias' => true],
-            ['slug' => 'eq-test-emotional-intelligence-assessment', 'scale_code' => 'EQ_60', 'primary_slug' => 'eq-test-emotional-intelligence-assessment', 'resolved_from_alias' => false],
-            ['slug' => 'eq-test', 'scale_code' => 'EQ_60', 'primary_slug' => 'eq-test-emotional-intelligence-assessment', 'resolved_from_alias' => true],
+            ['slug' => 'mbti-personality-test-16-personality-types', 'scale_code' => 'MBTI', 'scale_code_v2' => 'MBTI_PERSONALITY_TEST_16_TYPES', 'primary_slug' => 'mbti-personality-test-16-personality-types', 'resolved_from_alias' => false],
+            ['slug' => 'mbti-test', 'scale_code' => 'MBTI', 'scale_code_v2' => 'MBTI_PERSONALITY_TEST_16_TYPES', 'primary_slug' => 'mbti-personality-test-16-personality-types', 'resolved_from_alias' => true],
+            ['slug' => 'big-five-personality-test-ocean-model', 'scale_code' => 'BIG5_OCEAN', 'scale_code_v2' => 'BIG_FIVE_OCEAN_MODEL', 'primary_slug' => 'big-five-personality-test-ocean-model', 'resolved_from_alias' => false],
+            ['slug' => 'big5-ocean', 'scale_code' => 'BIG5_OCEAN', 'scale_code_v2' => 'BIG_FIVE_OCEAN_MODEL', 'primary_slug' => 'big-five-personality-test-ocean-model', 'resolved_from_alias' => true],
+            ['slug' => 'clinical-depression-anxiety-assessment-professional-edition', 'scale_code' => 'CLINICAL_COMBO_68', 'scale_code_v2' => 'CLINICAL_DEPRESSION_ANXIETY_PRO', 'primary_slug' => 'clinical-depression-anxiety-assessment-professional-edition', 'resolved_from_alias' => false],
+            ['slug' => 'clinical-combo-68', 'scale_code' => 'CLINICAL_COMBO_68', 'scale_code_v2' => 'CLINICAL_DEPRESSION_ANXIETY_PRO', 'primary_slug' => 'clinical-depression-anxiety-assessment-professional-edition', 'resolved_from_alias' => true],
+            ['slug' => 'depression-screening-test-standard-edition', 'scale_code' => 'SDS_20', 'scale_code_v2' => 'DEPRESSION_SCREENING_STANDARD', 'primary_slug' => 'depression-screening-test-standard-edition', 'resolved_from_alias' => false],
+            ['slug' => 'sds-20', 'scale_code' => 'SDS_20', 'scale_code_v2' => 'DEPRESSION_SCREENING_STANDARD', 'primary_slug' => 'depression-screening-test-standard-edition', 'resolved_from_alias' => true],
+            ['slug' => 'iq-test-intelligence-quotient-assessment', 'scale_code' => 'IQ_RAVEN', 'scale_code_v2' => 'IQ_INTELLIGENCE_QUOTIENT', 'primary_slug' => 'iq-test-intelligence-quotient-assessment', 'resolved_from_alias' => false],
+            ['slug' => 'iq-test', 'scale_code' => 'IQ_RAVEN', 'scale_code_v2' => 'IQ_INTELLIGENCE_QUOTIENT', 'primary_slug' => 'iq-test-intelligence-quotient-assessment', 'resolved_from_alias' => true],
+            ['slug' => 'eq-test-emotional-intelligence-assessment', 'scale_code' => 'EQ_60', 'scale_code_v2' => 'EQ_EMOTIONAL_INTELLIGENCE', 'primary_slug' => 'eq-test-emotional-intelligence-assessment', 'resolved_from_alias' => false],
+            ['slug' => 'eq-test', 'scale_code' => 'EQ_60', 'scale_code_v2' => 'EQ_EMOTIONAL_INTELLIGENCE', 'primary_slug' => 'eq-test-emotional-intelligence-assessment', 'resolved_from_alias' => true],
         ];
 
         foreach ($cases as $case) {
@@ -61,11 +66,15 @@ class ScalesLookupTest extends TestCase
             $response->assertJson([
                 'ok' => true,
                 'scale_code' => $case['scale_code'],
+                'scale_code_legacy' => $case['scale_code'],
+                'scale_code_v2' => $case['scale_code_v2'],
                 'primary_slug' => $case['primary_slug'],
                 'requested_slug' => $case['slug'],
                 'resolved_from_alias' => $case['resolved_from_alias'],
             ]);
             $response->assertJsonPath('slug', $case['primary_slug']);
+            $this->assertIsString($response->json('pack_id_v2'));
+            $this->assertIsString($response->json('dir_version_v2'));
         }
     }
 
@@ -82,6 +91,7 @@ class ScalesLookupTest extends TestCase
         $canonical->assertJson([
             'ok' => true,
             'primary_slug' => 'mbti-personality-test-16-personality-types',
+            'scale_code_v2' => 'MBTI_PERSONALITY_TEST_16_TYPES',
             'resolved_from_alias' => false,
         ]);
 
@@ -91,6 +101,24 @@ class ScalesLookupTest extends TestCase
             'ok' => false,
             'error_code' => 'NOT_FOUND',
         ]);
+    }
+
+    public function test_lookup_uses_v2_primary_scale_code_when_response_mode_is_v2(): void
+    {
+        $this->artisan('migrate', ['--force' => true]);
+        $this->artisan('fap:scales:seed-default');
+        $this->artisan('fap:scales:sync-slugs');
+
+        Config::set('scale_identity.api_response_scale_code_mode', 'v2');
+
+        $response = $this->getJson('/api/v0.3/scales/lookup?slug=mbti-test');
+        $response->assertStatus(200);
+        $response->assertJsonPath('scale_code', 'MBTI_PERSONALITY_TEST_16_TYPES');
+        $response->assertJsonPath('scale_code_legacy', 'MBTI');
+        $response->assertJsonPath('scale_code_v2', 'MBTI_PERSONALITY_TEST_16_TYPES');
+        $response->assertJsonPath('resolved_from_alias', true);
+        $response->assertJsonPath('pack_id_v2', 'MBTI_PERSONALITY_TEST_16_TYPES.cn-mainland.zh-CN.v0.3');
+        $response->assertJsonPath('dir_version_v2', 'MBTI_PERSONALITY_TEST_16_TYPES-CN-v0.3');
     }
 
     public function test_lookup_unknown_slug_returns_not_found(): void
@@ -146,9 +174,16 @@ class ScalesLookupTest extends TestCase
         $response->assertJson([
             'ok' => true,
             'scale_code' => 'IQ_RAVEN',
+            'scale_code_legacy' => 'IQ_RAVEN',
+            'scale_code_v2' => 'IQ_INTELLIGENCE_QUOTIENT',
+            'scale_uid' => '55555555-5555-4555-8555-555555555555',
             'primary_slug' => 'raven-iq-test',
             'requested_slug' => 'raven-iq-test',
             'resolved_from_alias' => false,
+        ]);
+        $response->assertJsonStructure([
+            'pack_id_v2',
+            'dir_version_v2',
         ]);
         $response->assertJsonPath('seo_schema_json.@type', 'Quiz');
         $response->assertJsonPath('seo_schema.@type', 'Quiz');

--- a/backend/tests/Feature/V0_3/ShareScaleIdentityDualWriteTest.php
+++ b/backend/tests/Feature/V0_3/ShareScaleIdentityDualWriteTest.php
@@ -1,0 +1,116 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\V0_3;
+
+use App\Models\Attempt;
+use App\Models\Result;
+use App\Services\Legacy\LegacyShareService;
+use App\Services\V0_3\ShareService;
+use App\Support\OrgContext;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Config;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Str;
+use Tests\TestCase;
+
+class ShareScaleIdentityDualWriteTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private function seedAttemptWithResult(
+        string $attemptId,
+        string $anonId,
+        string $scaleCode,
+        ?string $scaleCodeV2 = null,
+        ?string $scaleUid = null
+    ): void {
+        Attempt::create([
+            'id' => $attemptId,
+            'org_id' => 0,
+            'anon_id' => $anonId,
+            'scale_code' => $scaleCode,
+            'scale_code_v2' => $scaleCodeV2,
+            'scale_uid' => $scaleUid,
+            'scale_version' => 'v0.3',
+            'region' => 'CN_MAINLAND',
+            'locale' => 'zh-CN',
+            'question_count' => 1,
+            'client_platform' => 'test',
+            'answers_summary_json' => ['stage' => 'seed'],
+            'started_at' => now()->subMinute(),
+            'submitted_at' => now(),
+            'pack_id' => (string) config('content_packs.default_pack_id', 'MBTI.cn-mainland.zh-CN.v0.3'),
+            'dir_version' => 'MBTI-CN-v0.3',
+            'content_package_version' => 'v0.3',
+            'scoring_spec_version' => '2026.01',
+        ]);
+
+        Result::create([
+            'id' => (string) Str::uuid(),
+            'org_id' => 0,
+            'attempt_id' => $attemptId,
+            'scale_code' => $scaleCode,
+            'scale_version' => 'v0.3',
+            'type_code' => 'INTJ-A',
+            'scores_json' => ['total' => 100],
+            'profile_version' => null,
+            'is_valid' => true,
+            'computed_at' => now(),
+            'result_json' => ['type_code' => 'INTJ-A'],
+            'pack_id' => (string) config('content_packs.default_pack_id', 'MBTI.cn-mainland.zh-CN.v0.3'),
+            'dir_version' => 'MBTI-CN-v0.3',
+            'scoring_spec_version' => '2026.01',
+            'report_engine_version' => 'v1.2',
+            'scale_code_v2' => $scaleCodeV2,
+            'scale_uid' => $scaleUid,
+        ]);
+    }
+
+    public function test_v03_share_service_dual_mode_writes_share_identity_columns(): void
+    {
+        $this->artisan('migrate', ['--force' => true]);
+        Config::set('scale_identity.write_mode', 'dual');
+
+        $attemptId = (string) Str::uuid();
+        $anonId = 'anon_share_v03_dual';
+        $this->seedAttemptWithResult($attemptId, $anonId, 'MBTI', null, null);
+
+        $ctx = app(OrgContext::class);
+        $ctx->set(0, null, 'public', $anonId);
+        $data = app(ShareService::class)->getOrCreateShare($attemptId, $ctx);
+
+        $this->assertSame($attemptId, (string) ($data['attempt_id'] ?? ''));
+        $this->assertNotSame('', (string) ($data['share_id'] ?? ''));
+
+        $row = DB::table('shares')->where('attempt_id', $attemptId)->first();
+        $this->assertNotNull($row);
+        $this->assertSame('MBTI', (string) ($row->scale_code ?? ''));
+        $this->assertSame('MBTI_PERSONALITY_TEST_16_TYPES', (string) ($row->scale_code_v2 ?? ''));
+        $this->assertSame('11111111-1111-4111-8111-111111111111', (string) ($row->scale_uid ?? ''));
+    }
+
+    public function test_legacy_share_service_legacy_mode_keeps_share_identity_columns_nullable(): void
+    {
+        $this->artisan('migrate', ['--force' => true]);
+        Config::set('scale_identity.write_mode', 'legacy');
+
+        $attemptId = (string) Str::uuid();
+        $anonId = 'anon_share_legacy_mode';
+        $this->seedAttemptWithResult($attemptId, $anonId, 'IQ_RAVEN', null, null);
+
+        $ctx = app(OrgContext::class);
+        $ctx->set(0, null, 'public', $anonId);
+        $data = app(LegacyShareService::class)->getOrCreateShare($attemptId, $ctx);
+
+        $this->assertSame($attemptId, (string) ($data['attempt_id'] ?? ''));
+        $this->assertNotSame('', (string) ($data['share_id'] ?? ''));
+
+        $row = DB::table('shares')->where('attempt_id', $attemptId)->first();
+        $this->assertNotNull($row);
+        $this->assertSame('IQ_RAVEN', (string) ($row->scale_code ?? ''));
+        $this->assertNull($row->scale_code_v2);
+        $this->assertNull($row->scale_uid);
+    }
+}

--- a/backend/tests/Feature/V0_4/AssessmentScaleIdentityDualWriteTest.php
+++ b/backend/tests/Feature/V0_4/AssessmentScaleIdentityDualWriteTest.php
@@ -1,0 +1,54 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\V0_4;
+
+use App\Services\Assessments\AssessmentService;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\DB;
+use Tests\TestCase;
+
+final class AssessmentScaleIdentityDualWriteTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_create_assessment_dual_mode_writes_scale_identity_columns(): void
+    {
+        config()->set('scale_identity.write_mode', 'dual');
+
+        $assessment = app(AssessmentService::class)->createAssessment(
+            1001,
+            'MBTI',
+            'team baseline',
+            9001,
+            null
+        );
+
+        $row = DB::table('assessments')->where('id', (int) $assessment->id)->first();
+        $this->assertNotNull($row);
+        $this->assertSame('MBTI', (string) ($row->scale_code ?? ''));
+        $this->assertSame('MBTI_PERSONALITY_TEST_16_TYPES', (string) ($row->scale_code_v2 ?? ''));
+        $this->assertSame('11111111-1111-4111-8111-111111111111', (string) ($row->scale_uid ?? ''));
+    }
+
+    public function test_create_assessment_legacy_mode_keeps_identity_columns_nullable(): void
+    {
+        config()->set('scale_identity.write_mode', 'legacy');
+
+        $assessment = app(AssessmentService::class)->createAssessment(
+            1002,
+            'MBTI',
+            'team baseline legacy',
+            9002,
+            null
+        );
+
+        $row = DB::table('assessments')->where('id', (int) $assessment->id)->first();
+        $this->assertNotNull($row);
+        $this->assertSame('MBTI', (string) ($row->scale_code ?? ''));
+        $this->assertNull($row->scale_code_v2);
+        $this->assertNull($row->scale_uid);
+    }
+}
+

--- a/backend/tests/Unit/Services/Content/ContentPathAliasResolverTest.php
+++ b/backend/tests/Unit/Services/Content/ContentPathAliasResolverTest.php
@@ -1,0 +1,160 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Services\Content;
+
+use App\Services\Content\BigFivePackLoader;
+use App\Services\Content\ContentPathAliasResolver;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\File;
+use Tests\TestCase;
+
+final class ContentPathAliasResolverTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private string $legacyPackCode;
+
+    private string $mappedPackCode;
+
+    private string $legacyPath;
+
+    private string $mappedPath;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->legacyPackCode = 'TEST_PATH_ALIAS_PACK';
+        $this->mappedPackCode = 'TEST_PATH_ALIAS_PACK_V2';
+        $this->legacyPath = base_path('content_packs/'.$this->legacyPackCode);
+        $this->mappedPath = base_path('content_packs/'.$this->mappedPackCode);
+
+        File::deleteDirectory($this->legacyPath);
+        File::deleteDirectory($this->mappedPath);
+        File::ensureDirectoryExists($this->legacyPath);
+
+        DB::table('content_path_aliases')->updateOrInsert(
+            [
+                'scope' => 'backend_content_packs',
+                'old_path' => 'content_packs/'.$this->legacyPackCode,
+            ],
+            [
+                'new_path' => 'content_packs/'.$this->mappedPackCode,
+                'scale_uid' => null,
+                'is_active' => true,
+                'updated_at' => now(),
+                'created_at' => now(),
+            ]
+        );
+    }
+
+    protected function tearDown(): void
+    {
+        File::deleteDirectory($this->legacyPath);
+        File::deleteDirectory($this->mappedPath);
+        parent::tearDown();
+    }
+
+    public function test_dual_prefer_new_falls_back_to_legacy_when_mapped_directory_missing(): void
+    {
+        config()->set('scale_identity.content_path_mode', 'dual_prefer_new');
+        $resolver = app(ContentPathAliasResolver::class);
+
+        $resolved = $resolver->resolveBackendPackRoot($this->legacyPackCode);
+
+        $this->assertSame($this->legacyPath, $resolved);
+    }
+
+    public function test_dual_prefer_new_uses_mapped_directory_when_present(): void
+    {
+        File::ensureDirectoryExists($this->mappedPath);
+        config()->set('scale_identity.content_path_mode', 'dual_prefer_new');
+        $resolver = app(ContentPathAliasResolver::class);
+
+        $resolved = $resolver->resolveBackendPackRoot($this->legacyPackCode);
+
+        $this->assertSame($this->mappedPath, $resolved);
+    }
+
+    public function test_bigfive_loader_reads_pack_root_from_alias_resolver(): void
+    {
+        $mappedBigFiveRoot = base_path('content_packs/BIG_FIVE_OCEAN_MODEL');
+        $mappedAlreadyExists = is_dir($mappedBigFiveRoot);
+        if (! $mappedAlreadyExists) {
+            File::ensureDirectoryExists($mappedBigFiveRoot.DIRECTORY_SEPARATOR.'v1');
+        }
+
+        try {
+            config()->set('scale_identity.content_path_mode', 'dual_prefer_new');
+            DB::table('content_path_aliases')->updateOrInsert(
+                [
+                    'scope' => 'backend_content_packs',
+                    'old_path' => 'content_packs/BIG5_OCEAN',
+                ],
+                [
+                    'new_path' => 'content_packs/BIG_FIVE_OCEAN_MODEL',
+                    'scale_uid' => null,
+                    'is_active' => true,
+                    'updated_at' => now(),
+                    'created_at' => now(),
+                ]
+            );
+
+            $loader = new BigFivePackLoader(
+                null,
+                app(ContentPathAliasResolver::class)
+            );
+            $this->assertSame(
+                $mappedBigFiveRoot.DIRECTORY_SEPARATOR.'v1',
+                $loader->packRoot('v1')
+            );
+        } finally {
+            if (! $mappedAlreadyExists) {
+                File::deleteDirectory($mappedBigFiveRoot);
+            }
+        }
+    }
+
+    public function test_publish_source_dir_legacy_mode_prefers_legacy_path(): void
+    {
+        $legacyVersionPath = $this->legacyPath.DIRECTORY_SEPARATOR.'v1';
+        $mappedVersionPath = $this->mappedPath.DIRECTORY_SEPARATOR.'v1';
+        File::ensureDirectoryExists($legacyVersionPath);
+        File::ensureDirectoryExists($mappedVersionPath);
+
+        config()->set('scale_identity.content_publish_mode', 'legacy');
+        $resolver = app(ContentPathAliasResolver::class);
+        $resolved = $resolver->resolveBackendPublishSourceDir($this->legacyPackCode, 'v1');
+        $context = $resolver->resolveBackendPublishSourceContext($this->legacyPackCode, 'v1');
+
+        $this->assertSame($legacyVersionPath, $resolved);
+        $this->assertSame('legacy', (string) ($context['selected_source'] ?? ''));
+        $this->assertFalse((bool) ($context['fallback_used'] ?? true));
+    }
+
+    public function test_publish_source_dir_v2_mode_prefers_mapped_path_with_fallback(): void
+    {
+        $legacyVersionPath = $this->legacyPath.DIRECTORY_SEPARATOR.'v1';
+        $mappedVersionPath = $this->mappedPath.DIRECTORY_SEPARATOR.'v1';
+        File::ensureDirectoryExists($legacyVersionPath);
+
+        config()->set('scale_identity.content_publish_mode', 'v2');
+        $resolver = app(ContentPathAliasResolver::class);
+
+        $fallbackResolved = $resolver->resolveBackendPublishSourceDir($this->legacyPackCode, 'v1');
+        $fallbackContext = $resolver->resolveBackendPublishSourceContext($this->legacyPackCode, 'v1');
+        $this->assertSame($legacyVersionPath, $fallbackResolved);
+        $this->assertSame('legacy', (string) ($fallbackContext['selected_source'] ?? ''));
+        $this->assertTrue((bool) ($fallbackContext['fallback_used'] ?? false));
+
+        File::ensureDirectoryExists($mappedVersionPath);
+        $mappedResolved = $resolver->resolveBackendPublishSourceDir($this->legacyPackCode, 'v1');
+        $mappedContext = $resolver->resolveBackendPublishSourceContext($this->legacyPackCode, 'v1');
+        $this->assertSame($mappedVersionPath, $mappedResolved);
+        $this->assertSame('mapped', (string) ($mappedContext['selected_source'] ?? ''));
+        $this->assertFalse((bool) ($mappedContext['fallback_used'] ?? true));
+    }
+}


### PR DESCRIPTION
## Summary
This PR delivers the next integrated slice of **Strategy A + DEMO offboarding** under zero-downtime constraints.

1. Adds scale-identity dual-stack foundation in API runtime and schema.
2. Adds backfill commands and tests for scale identity fields across hot tables.
3. Adds content path alias resolver + mirror tooling for dual directory operation.
4. Adds scale lookup dual-code response and alias observability fields.
5. Adds rollout gate command/script to support Phase 8~10 go/no-go decisions.
6. Adds DEMO deprecation gate behavior (`SCALE_DEPRECATED`) in v0.3 critical paths.
7. Sets DEMO disabled by default in CI seeding, with rollback switch (`FAP_CI_INCLUDE_DEMO_SCALES=true`).
8. Wires optional scale-identity gate into `ci_verify_mbti.sh` behind `RUN_SCALE_IDENTITY_GATE=1` (default off, no behavior change).

## Update Notes

### API / Resolver / Controller
- Introduced `ScaleIdentityResolver` and integrated dual-code resolution paths.
- Extended scale responses with `scale_uid`, `scale_code_v2`, `scale_code_legacy`, and alias-resolution markers.
- Enforced demo-scale blocking when `FAP_ALLOW_DEMO_SCALES=false` with stable error contract.

### Schema / Data
- Added:
- `scale_identities`
- `scale_code_aliases`
- `content_path_aliases`
- Added `scale_uid` + `scale_code_v2` (and related v2 columns where needed) to hot tables:
- `attempts`
- `results`
- `events`
- `report_snapshots`
- `shares`
- `orders`
- `payment_events`
- `attempt_answer_sets`
- `attempt_answer_rows`
- `assessments`

### Ops / Backfill / Mirror / Gate
- Added `ops:backfill-*scale-identity` commands for major tables.
- Added `ops:content-path-mirror` for mirror/sync/hash verification workflow.
- Added `ops:scale-identity-gate` and `scripts/prA_gate_scale_identity.sh`.

### Seeder / CI Defaults
- `CiScalesRegistrySeeder` defaults DEMO scales to disabled unless explicitly enabled.
- Added/updated tests for default-off + rollback-safe behavior.

## Config / Flags
Added `backend/config/scale_identity.php`:
- `FAP_SCALE_IDENTITY_WRITE_MODE`
- `FAP_SCALE_IDENTITY_READ_MODE`
- `FAP_ACCEPT_LEGACY_SCALE_CODE`
- `FAP_API_RESPONSE_SCALE_CODE_MODE`
- `FAP_CONTENT_PATH_MODE`
- `FAP_CONTENT_PUBLISH_MODE`
- `FAP_ALLOW_DEMO_SCALES`

## Risk Assessment
- Risk level: **Low to Medium**.
- Runtime behavior remains unchanged by default (`legacy` modes; optional gates off by default).
- No destructive cleanup in this PR.
- Rollback is switch-based and immediate (no schema rollback required).

## Validation Results

### Commands
- `php artisan route:list`
- `php artisan migrate --force`
- `php artisan test --filter=ScaleIdentityGateCommandTest`
- `php artisan test --filter=CiScalesRegistrySeederToggleTest`
- `bash backend/scripts/prA_gate_scale_identity.sh`
- `bash backend/scripts/prA_verify_ci_demo_seed_toggle.sh`
- `bash backend/scripts/ci_verify_mbti.sh`

### Results
- All listed checks passed on this branch.
- CI scope for this change remains backward-compatible with legacy mode defaults.

## Rollback Plan
1. Switch runtime modes back to legacy:
- `FAP_SCALE_IDENTITY_READ_MODE=legacy`
- `FAP_SCALE_IDENTITY_WRITE_MODE=legacy`
- `FAP_API_RESPONSE_SCALE_CODE_MODE=legacy`
- `FAP_CONTENT_PATH_MODE=legacy`
- `FAP_CONTENT_PUBLISH_MODE=legacy`
- `FAP_ALLOW_DEMO_SCALES=true`
2. Run `php artisan optimize:clear`.
3. Keep schema/data additions in place (forward-only), disable new paths via flags.
