### PR TITLE
refactor(scale-identity): phase-b convergence and ci contract guardrails

### DIFF
--- a/.github/workflows/ci_verify_mbti.yml
+++ b/.github/workflows/ci_verify_mbti.yml
@@ -221,6 +221,8 @@ jobs:
           RUN_EQ_60_GATE: ${{ steps.scale-impact.outputs.run_eq_60_gate }}
           RUN_SDS_NORMS_GATE: ${{ steps.scale-impact.outputs.run_sds_norms_gate }}
           RUN_FULL_SCALE_REGRESSION: ${{ steps.scale-impact.outputs.run_full_scale_regression }}
+          RUN_SCALE_IDENTITY_CONTRACT: ${{ steps.scale-impact.outputs.run_full_scale_regression }}
+          RUN_SCALE_IDENTITY_GATE: ${{ steps.scale-impact.outputs.run_full_scale_regression }}
           SCALE_SCOPE: ${{ steps.scale-impact.outputs.scale_scope }}
           DB_CONNECTION: mysql
           DB_HOST: 127.0.0.1

--- a/backend/app/Console/Commands/Ops/ScaleIdentityModeAudit.php
+++ b/backend/app/Console/Commands/Ops/ScaleIdentityModeAudit.php
@@ -1,0 +1,221 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Console\Commands\Ops;
+
+use Illuminate\Console\Command;
+
+final class ScaleIdentityModeAudit extends Command
+{
+    protected $signature = 'ops:scale-identity-mode-audit
+        {--json=1 : Output JSON payload}
+        {--strict=0 : Exit non-zero when violations exist}';
+
+    protected $description = 'Audit scale identity mode combinations and block invalid rollouts.';
+
+    public function handle(): int
+    {
+        $modes = $this->collectModes();
+        $allowed = $this->allowedValues();
+
+        $violations = [];
+        $warnings = [];
+
+        $this->validateAllowedModes($modes, $allowed, $violations);
+        $this->validateSemanticConstraints($modes, $violations, $warnings);
+
+        $strict = $this->isTruthy($this->option('strict'));
+        $payload = [
+            'ok' => true,
+            'checked_at' => now()->toISOString(),
+            'strict' => $strict,
+            'pass' => count($violations) === 0,
+            'modes' => $modes,
+            'allowed_values' => $allowed,
+            'violations' => $violations,
+            'warnings' => $warnings,
+        ];
+
+        if ($this->isTruthy($this->option('json'))) {
+            $this->line((string) json_encode($payload, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES));
+        } else {
+            $this->line('scale identity mode audit');
+            foreach ($modes as $key => $value) {
+                if (is_bool($value)) {
+                    $value = $value ? 'true' : 'false';
+                }
+                $this->line(sprintf('%s=%s', $key, (string) $value));
+            }
+
+            foreach ($warnings as $warning) {
+                $this->warn(sprintf(
+                    '[warning] %s value=%s hint=%s',
+                    (string) ($warning['key'] ?? ''),
+                    (string) ($warning['value'] ?? ''),
+                    (string) ($warning['hint'] ?? '')
+                ));
+            }
+
+            foreach ($violations as $violation) {
+                $this->error(sprintf(
+                    '[violation] %s value=%s expected=%s reason=%s',
+                    (string) ($violation['key'] ?? ''),
+                    (string) ($violation['value'] ?? ''),
+                    (string) ($violation['expected'] ?? ''),
+                    (string) ($violation['reason'] ?? '')
+                ));
+            }
+        }
+
+        if ($strict && $violations !== []) {
+            return self::FAILURE;
+        }
+
+        return self::SUCCESS;
+    }
+
+    /**
+     * @return array{
+     *   write_mode:string,
+     *   read_mode:string,
+     *   content_path_mode:string,
+     *   content_publish_mode:string,
+     *   api_response_scale_code_mode:string,
+     *   accept_legacy_scale_code:bool,
+     *   allow_demo_scales:bool
+     * }
+     */
+    private function collectModes(): array
+    {
+        return [
+            'write_mode' => strtolower(trim((string) config('scale_identity.write_mode', 'legacy'))),
+            'read_mode' => strtolower(trim((string) config('scale_identity.read_mode', 'legacy'))),
+            'content_path_mode' => strtolower(trim((string) config('scale_identity.content_path_mode', 'legacy'))),
+            'content_publish_mode' => strtolower(trim((string) config('scale_identity.content_publish_mode', 'legacy'))),
+            'api_response_scale_code_mode' => strtolower(trim((string) config('scale_identity.api_response_scale_code_mode', 'legacy'))),
+            'accept_legacy_scale_code' => (bool) config('scale_identity.accept_legacy_scale_code', true),
+            'allow_demo_scales' => (bool) config('scale_identity.allow_demo_scales', true),
+        ];
+    }
+
+    /**
+     * @return array{
+     *   write_mode:list<string>,
+     *   read_mode:list<string>,
+     *   content_path_mode:list<string>,
+     *   content_publish_mode:list<string>,
+     *   api_response_scale_code_mode:list<string>
+     * }
+     */
+    private function allowedValues(): array
+    {
+        return [
+            'write_mode' => ['legacy', 'dual', 'v2'],
+            'read_mode' => ['legacy', 'dual_prefer_old', 'dual_prefer_new', 'v2'],
+            'content_path_mode' => ['legacy', 'dual_prefer_old', 'dual_prefer_new', 'v2'],
+            'content_publish_mode' => ['legacy', 'dual', 'v2'],
+            'api_response_scale_code_mode' => ['legacy', 'dual', 'v2'],
+        ];
+    }
+
+    /**
+     * @param  array<string,mixed>  $modes
+     * @param  array<string,mixed>  $allowed
+     * @param  array<int,array<string,string>>  $violations
+     */
+    private function validateAllowedModes(array $modes, array $allowed, array &$violations): void
+    {
+        foreach ($allowed as $key => $set) {
+            $value = strtolower(trim((string) ($modes[$key] ?? '')));
+            $allowedSet = array_values(array_map(
+                static fn (string $item): string => strtolower(trim($item)),
+                (array) $set
+            ));
+            if (! in_array($value, $allowedSet, true)) {
+                $violations[] = [
+                    'key' => $key,
+                    'value' => $value,
+                    'expected' => implode('|', $allowedSet),
+                    'reason' => 'unsupported mode value',
+                ];
+            }
+        }
+    }
+
+    /**
+     * @param  array{
+     *   write_mode:string,
+     *   read_mode:string,
+     *   content_path_mode:string,
+     *   content_publish_mode:string,
+     *   api_response_scale_code_mode:string,
+     *   accept_legacy_scale_code:bool,
+     *   allow_demo_scales:bool
+     * }  $modes
+     * @param  array<int,array<string,string>>  $violations
+     * @param  array<int,array<string,string>>  $warnings
+     */
+    private function validateSemanticConstraints(array $modes, array &$violations, array &$warnings): void
+    {
+        $writeMode = (string) ($modes['write_mode'] ?? 'legacy');
+        $readMode = (string) ($modes['read_mode'] ?? 'legacy');
+        $contentPathMode = (string) ($modes['content_path_mode'] ?? 'legacy');
+        $contentPublishMode = (string) ($modes['content_publish_mode'] ?? 'legacy');
+        $responseMode = (string) ($modes['api_response_scale_code_mode'] ?? 'legacy');
+        $acceptLegacy = (bool) ($modes['accept_legacy_scale_code'] ?? true);
+
+        if ($readMode === 'v2' && $writeMode === 'legacy') {
+            $violations[] = [
+                'key' => 'read_mode',
+                'value' => $readMode,
+                'expected' => 'write_mode=dual|v2',
+                'reason' => 'v2 read requires dual/v2 write path to avoid stale identity projection',
+            ];
+        }
+
+        if ($readMode === 'v2' && $acceptLegacy) {
+            $violations[] = [
+                'key' => 'accept_legacy_scale_code',
+                'value' => 'true',
+                'expected' => 'false when read_mode=v2',
+                'reason' => 'v2 read mode conflicts with accepting legacy request code as primary input',
+            ];
+        }
+
+        if ($contentPathMode === 'v2' && $contentPublishMode === 'legacy') {
+            $warnings[] = [
+                'key' => 'content_publish_mode',
+                'value' => $contentPublishMode,
+                'hint' => 'consider dual/v2 publish mode when content_path_mode=v2 to reduce fallback dependency',
+            ];
+        }
+
+        if ($contentPathMode === 'legacy' && $contentPublishMode === 'v2') {
+            $warnings[] = [
+                'key' => 'content_path_mode',
+                'value' => $contentPathMode,
+                'hint' => 'legacy content path read with v2 publish may hide fresh v2 packs behind fallback',
+            ];
+        }
+
+        if ($responseMode === 'v2' && $readMode === 'legacy') {
+            $warnings[] = [
+                'key' => 'api_response_scale_code_mode',
+                'value' => $responseMode,
+                'hint' => 'response v2 with read_mode=legacy is allowed but increases config coupling risk',
+            ];
+        }
+    }
+
+    private function isTruthy(mixed $value): bool
+    {
+        if (is_bool($value)) {
+            return $value;
+        }
+
+        $normalized = strtolower(trim((string) $value));
+
+        return in_array($normalized, ['1', 'true', 'yes', 'on'], true);
+    }
+}

--- a/backend/app/Console/Kernel.php
+++ b/backend/app/Console/Kernel.php
@@ -30,8 +30,6 @@ use App\Console\Commands\NormsEq60Import;
 use App\Console\Commands\NormsImport;
 use App\Console\Commands\NormsSdsDriftCheck;
 use App\Console\Commands\NormsSdsRebuild;
-use App\Console\Commands\Ops\ScaleIdentityGate;
-use App\Console\Commands\Ops\ContentPathMirror;
 use App\Console\Commands\Ops\BackfillAssessmentsScaleIdentity;
 use App\Console\Commands\Ops\BackfillAttemptAnswerRowsScaleIdentity;
 use App\Console\Commands\Ops\BackfillAttemptAnswerSetsScaleIdentity;
@@ -42,7 +40,10 @@ use App\Console\Commands\Ops\BackfillPaymentEventsScaleIdentity;
 use App\Console\Commands\Ops\BackfillReportSnapshotsScaleIdentity;
 use App\Console\Commands\Ops\BackfillResultsScaleIdentity;
 use App\Console\Commands\Ops\BackfillSharesScaleIdentity;
+use App\Console\Commands\Ops\ContentPathMirror;
 use App\Console\Commands\Ops\PartitionAttemptAnswerRows;
+use App\Console\Commands\Ops\ScaleIdentityGate;
+use App\Console\Commands\Ops\ScaleIdentityModeAudit;
 use App\Console\Commands\OpsDeployEvent;
 use App\Console\Commands\OpsHealthzSnapshot;
 use App\Console\Commands\Packs2Activate;
@@ -55,9 +56,9 @@ use App\Console\Commands\PaymentsPruneEvents;
 use App\Console\Commands\QualityDailySummary;
 use App\Console\Commands\SdsPsychometricsReport;
 use App\Console\Commands\SeedScaleRegistry;
-use App\Console\Commands\StoragePrune;
-use App\Console\Commands\StorageMigrateLegacyArtifacts;
 use App\Console\Commands\StorageInventory;
+use App\Console\Commands\StorageMigrateLegacyArtifacts;
+use App\Console\Commands\StoragePrune;
 use App\Console\Commands\SyncScaleSlugs;
 use Illuminate\Console\Scheduling\Schedule;
 use Illuminate\Foundation\Console\Kernel as ConsoleKernel;
@@ -119,6 +120,7 @@ class Kernel extends ConsoleKernel
         CiScaleImpact::class,
         ContentPathMirror::class,
         ScaleIdentityGate::class,
+        ScaleIdentityModeAudit::class,
         BackfillAssessmentsScaleIdentity::class,
         BackfillAttemptAnswerRowsScaleIdentity::class,
         BackfillAttemptAnswerSetsScaleIdentity::class,

--- a/backend/app/Services/Assessments/AssessmentService.php
+++ b/backend/app/Services/Assessments/AssessmentService.php
@@ -4,15 +4,17 @@ namespace App\Services\Assessments;
 
 use App\Models\Assessment;
 use App\Models\AssessmentAssignment;
+use App\Services\Scale\ScaleIdentityWriteProjector;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Schema;
 use Illuminate\Support\Str;
 
 class AssessmentService
 {
-    public function __construct(private AssessmentSummaryService $summaryService)
-    {
-    }
+    public function __construct(
+        private AssessmentSummaryService $summaryService,
+        private ScaleIdentityWriteProjector $identityProjector,
+    ) {}
 
     public function findForOrg(int $orgId, int $assessmentId): ?Assessment
     {
@@ -58,7 +60,7 @@ class AssessmentService
         $now = now();
 
         foreach ($subjects as $subject) {
-            if (!is_array($subject)) {
+            if (! is_array($subject)) {
                 continue;
             }
 
@@ -68,13 +70,13 @@ class AssessmentService
             if ($type === '' || $value === '') {
                 continue;
             }
-            if (!in_array($type, ['user', 'email'], true)) {
+            if (! in_array($type, ['user', 'email'], true)) {
                 continue;
             }
-            if ($type === 'email' && !filter_var($value, FILTER_VALIDATE_EMAIL)) {
+            if ($type === 'email' && ! filter_var($value, FILTER_VALIDATE_EMAIL)) {
                 continue;
             }
-            if ($type === 'user' && !preg_match('/^\d+$/', $value)) {
+            if ($type === 'user' && ! preg_match('/^\d+$/', $value)) {
                 continue;
             }
 
@@ -187,7 +189,7 @@ class AssessmentService
                 ->lockForUpdate()
                 ->first();
 
-            if (!$row) {
+            if (! $row) {
                 return null;
             }
 
@@ -211,7 +213,7 @@ class AssessmentService
 
     private function generateInviteToken(): string
     {
-        return Str::uuid()->toString() . Str::random(28);
+        return Str::uuid()->toString().Str::random(28);
     }
 
     private function shouldWriteScaleIdentityColumns(): bool
@@ -233,33 +235,6 @@ class AssessmentService
      */
     private function resolveScaleIdentityValues(string $scaleCode): array
     {
-        $code = strtoupper(trim($scaleCode));
-        if ($code === '') {
-            return [
-                'scale_code_v2' => null,
-                'scale_uid' => null,
-            ];
-        }
-
-        $v1ToV2 = (array) config('scale_identity.code_map_v1_to_v2', []);
-        $v2ToV1 = (array) config('scale_identity.code_map_v2_to_v1', []);
-        $uidMap = (array) config('scale_identity.scale_uid_map', []);
-
-        $scaleCodeV1 = $code;
-        $scaleCodeV2 = null;
-
-        if (isset($v1ToV2[$code])) {
-            $scaleCodeV2 = strtoupper(trim((string) $v1ToV2[$code]));
-        } elseif (isset($v2ToV1[$code])) {
-            $scaleCodeV1 = strtoupper(trim((string) $v2ToV1[$code]));
-            $scaleCodeV2 = $code;
-        }
-
-        $scaleUid = trim((string) ($uidMap[$scaleCodeV1] ?? ''));
-
-        return [
-            'scale_code_v2' => $scaleCodeV2 !== '' ? $scaleCodeV2 : null,
-            'scale_uid' => $scaleUid !== '' ? $scaleUid : null,
-        ];
+        return $this->identityProjector->projectFromCodes($scaleCode);
     }
 }

--- a/backend/app/Services/Attempts/AnswerRowWriter.php
+++ b/backend/app/Services/Attempts/AnswerRowWriter.php
@@ -3,11 +3,16 @@
 namespace App\Services\Attempts;
 
 use App\Models\Attempt;
+use App\Services\Scale\ScaleIdentityWriteProjector;
 use Illuminate\Database\QueryException;
 use Illuminate\Support\Facades\DB;
 
 class AnswerRowWriter
 {
+    public function __construct(
+        private readonly ScaleIdentityWriteProjector $identityProjector,
+    ) {}
+
     public function writeRows(Attempt $attempt, array $answers, int $durationMs): array
     {
         $scaleCode = strtoupper((string) ($attempt->scale_code ?? ''));
@@ -16,7 +21,7 @@ class AnswerRowWriter
         }
 
         $isSds20 = $scaleCode === 'SDS_20';
-        if (!$this->isEnabled() && !$isSds20) {
+        if (! $this->isEnabled() && ! $isSds20) {
             return ['ok' => true, 'skipped' => true, 'rows' => 0];
         }
 
@@ -24,11 +29,11 @@ class AnswerRowWriter
         $now = now();
         $canWriteIdentity = $this->shouldWriteScaleIdentityColumns();
         $identity = $canWriteIdentity
-            ? $this->resolveScaleIdentityValues($attempt)
+            ? $this->identityProjector->projectFromAttempt($attempt)
             : ['scale_code_v2' => null, 'scale_uid' => null];
 
         foreach ($answers as $answer) {
-            if (!is_array($answer)) {
+            if (! is_array($answer)) {
                 continue;
             }
 
@@ -123,6 +128,7 @@ class AnswerRowWriter
     private function isEnabled(): bool
     {
         $mode = strtolower((string) config('fap_attempts.answer_rows_write_mode', 'off'));
+
         return $mode === 'on' || $mode === 'true' || $mode === '1';
     }
 
@@ -145,51 +151,5 @@ class AnswerRowWriter
         return str_contains($message, 'no such column')
             || str_contains($message, 'has no column named')
             || str_contains($message, 'unknown column');
-    }
-
-    /**
-     * @return array{scale_code_v2:string|null,scale_uid:string|null}
-     */
-    private function resolveScaleIdentityValues(Attempt $attempt): array
-    {
-        $scaleCodeV2 = strtoupper(trim((string) ($attempt->scale_code_v2 ?? '')));
-        $scaleUid = trim((string) ($attempt->scale_uid ?? ''));
-
-        if ($scaleCodeV2 !== '' && $scaleUid !== '') {
-            return [
-                'scale_code_v2' => $scaleCodeV2,
-                'scale_uid' => $scaleUid,
-            ];
-        }
-
-        $scaleCodeV1 = strtoupper(trim((string) ($attempt->scale_code ?? '')));
-        if ($scaleCodeV1 === '') {
-            return [
-                'scale_code_v2' => $scaleCodeV2 !== '' ? $scaleCodeV2 : null,
-                'scale_uid' => $scaleUid !== '' ? $scaleUid : null,
-            ];
-        }
-
-        $v1ToV2 = (array) config('scale_identity.code_map_v1_to_v2', []);
-        $uidMap = (array) config('scale_identity.scale_uid_map', []);
-
-        if ($scaleCodeV2 === '') {
-            $mappedV2 = strtoupper(trim((string) ($v1ToV2[$scaleCodeV1] ?? '')));
-            if ($mappedV2 !== '') {
-                $scaleCodeV2 = $mappedV2;
-            }
-        }
-
-        if ($scaleUid === '') {
-            $mappedUid = trim((string) ($uidMap[$scaleCodeV1] ?? ''));
-            if ($mappedUid !== '') {
-                $scaleUid = $mappedUid;
-            }
-        }
-
-        return [
-            'scale_code_v2' => $scaleCodeV2 !== '' ? $scaleCodeV2 : null,
-            'scale_uid' => $scaleUid !== '' ? $scaleUid : null,
-        ];
     }
 }

--- a/backend/app/Services/Attempts/AnswerSetStore.php
+++ b/backend/app/Services/Attempts/AnswerSetStore.php
@@ -3,11 +3,16 @@
 namespace App\Services\Attempts;
 
 use App\Models\Attempt;
+use App\Services\Scale\ScaleIdentityWriteProjector;
 use Illuminate\Database\QueryException;
 use Illuminate\Support\Facades\DB;
 
 class AnswerSetStore
 {
+    public function __construct(
+        private readonly ScaleIdentityWriteProjector $identityProjector,
+    ) {}
+
     public function storeFinalAnswers(Attempt $attempt, array $answers, int $durationMs, string $scoringSpecVersion): array
     {
         $normalized = $this->canonicalizeAnswers($answers);
@@ -35,7 +40,7 @@ class AnswerSetStore
 
         $canWriteIdentity = $this->shouldWriteScaleIdentityColumns();
         if ($canWriteIdentity) {
-            $identity = $this->resolveScaleIdentityValues($attempt);
+            $identity = $this->identityProjector->projectFromAttempt($attempt);
             $upsertValues['scale_code_v2'] = $identity['scale_code_v2'];
             $upsertValues['scale_uid'] = $identity['scale_uid'];
         }
@@ -152,51 +157,5 @@ class AnswerSetStore
         return str_contains($message, 'no such column')
             || str_contains($message, 'has no column named')
             || str_contains($message, 'unknown column');
-    }
-
-    /**
-     * @return array{scale_code_v2:string|null,scale_uid:string|null}
-     */
-    private function resolveScaleIdentityValues(Attempt $attempt): array
-    {
-        $scaleCodeV2 = strtoupper(trim((string) ($attempt->scale_code_v2 ?? '')));
-        $scaleUid = trim((string) ($attempt->scale_uid ?? ''));
-
-        if ($scaleCodeV2 !== '' && $scaleUid !== '') {
-            return [
-                'scale_code_v2' => $scaleCodeV2,
-                'scale_uid' => $scaleUid,
-            ];
-        }
-
-        $scaleCodeV1 = strtoupper(trim((string) ($attempt->scale_code ?? '')));
-        if ($scaleCodeV1 === '') {
-            return [
-                'scale_code_v2' => $scaleCodeV2 !== '' ? $scaleCodeV2 : null,
-                'scale_uid' => $scaleUid !== '' ? $scaleUid : null,
-            ];
-        }
-
-        $v1ToV2 = (array) config('scale_identity.code_map_v1_to_v2', []);
-        $uidMap = (array) config('scale_identity.scale_uid_map', []);
-
-        if ($scaleCodeV2 === '') {
-            $mappedV2 = strtoupper(trim((string) ($v1ToV2[$scaleCodeV1] ?? '')));
-            if ($mappedV2 !== '') {
-                $scaleCodeV2 = $mappedV2;
-            }
-        }
-
-        if ($scaleUid === '') {
-            $mappedUid = trim((string) ($uidMap[$scaleCodeV1] ?? ''));
-            if ($mappedUid !== '') {
-                $scaleUid = $mappedUid;
-            }
-        }
-
-        return [
-            'scale_code_v2' => $scaleCodeV2 !== '' ? $scaleCodeV2 : null,
-            'scale_uid' => $scaleUid !== '' ? $scaleUid : null,
-        ];
     }
 }

--- a/backend/app/Services/Ci/ScaleImpactResolver.php
+++ b/backend/app/Services/Ci/ScaleImpactResolver.php
@@ -7,9 +7,13 @@ namespace App\Services\Ci;
 final class ScaleImpactResolver
 {
     private const SCALE_MBTI = 'MBTI';
+
     private const SCALE_BIG5 = 'BIG5_OCEAN';
+
     private const SCALE_CLINICAL = 'CLINICAL_COMBO_68';
+
     private const SCALE_SDS = 'SDS_20';
+
     private const SCALE_EQ = 'EQ_60';
 
     /**
@@ -60,6 +64,7 @@ final class ScaleImpactResolver
                 $clinicalChanged = true;
                 $sdsChanged = true;
                 $eqChanged = true;
+
                 continue;
             }
 
@@ -149,7 +154,7 @@ final class ScaleImpactResolver
     }
 
     /**
-     * @param array<int,string> $paths
+     * @param  array<int,string>  $paths
      * @return list<string>
      */
     private function normalizePaths(array $paths): array
@@ -160,7 +165,10 @@ final class ScaleImpactResolver
             if ($value === '') {
                 continue;
             }
-            $value = ltrim($value, './');
+            while (str_starts_with($value, './')) {
+                $value = substr($value, 2);
+            }
+            $value = ltrim($value, '/');
             $out[$value] = true;
         }
 
@@ -294,8 +302,7 @@ final class ScaleImpactResolver
         bool $clinicalChanged,
         bool $sdsChanged,
         bool $eqChanged
-    ): string
-    {
+    ): string {
         if ($runFullScaleRegression) {
             return 'full_regression';
         }
@@ -379,8 +386,7 @@ final class ScaleImpactResolver
         bool $sdsChanged,
         bool $eqChanged,
         bool $sdsNormsChanged
-    ): string
-    {
+    ): string {
         if ($sharedChanged) {
             return 'shared-layer changed: run full cross-scale regression';
         }

--- a/backend/app/Services/Commerce/OrderManager.php
+++ b/backend/app/Services/Commerce/OrderManager.php
@@ -3,6 +3,7 @@
 namespace App\Services\Commerce;
 
 use App\Services\Report\ReportAccess;
+use App\Services\Scale\ScaleIdentityWriteProjector;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Schema;
 use Illuminate\Support\Str;
@@ -10,11 +11,14 @@ use Illuminate\Support\Str;
 class OrderManager
 {
     private const FINAL_STATUSES = ['fulfilled', 'failed', 'canceled', 'refunded'];
+
     private const MAX_ORDER_QUANTITY = 1000;
+
     private const MAX_INT32 = 2147483647;
 
     public function __construct(
         private SkuCatalog $skus,
+        private ScaleIdentityWriteProjector $identityProjector,
     ) {}
 
     public function createOrder(
@@ -43,7 +47,7 @@ class OrderManager
         }
 
         $skuRow = $resolved['sku_row'] ?? null;
-        if (!$skuRow) {
+        if (! $skuRow) {
             return $this->notFound('SKU_NOT_FOUND', 'sku not found.');
         }
 
@@ -60,7 +64,7 @@ class OrderManager
 
         $skuToLookup = $effectiveSku !== '' ? $effectiveSku : $requestedSku;
         $provider = strtolower(trim($provider));
-        if ($provider === '' || !in_array($provider, $this->allowedProviders(), true)) {
+        if ($provider === '' || ! in_array($provider, $this->allowedProviders(), true)) {
             return $this->badRequest('PROVIDER_NOT_SUPPORTED', 'provider not supported.');
         }
 
@@ -84,7 +88,7 @@ class OrderManager
             $useIdempotency,
             $modulesIncluded
         ): array {
-            $orderNo = 'ord_' . Str::uuid();
+            $orderNo = 'ord_'.Str::uuid();
             $now = now();
 
             $orderMeta = [];
@@ -184,8 +188,7 @@ class OrderManager
         ?string $anonId,
         string $orderNo,
         bool $allowAnonymousFallback = false
-    ): array
-    {
+    ): array {
         $orderNo = trim($orderNo);
         if ($orderNo === '') {
             return $this->badRequest('ORDER_REQUIRED', 'order_no is required.');
@@ -196,7 +199,7 @@ class OrderManager
             ->where('org_id', $orgId)
             ->first();
 
-        if (!$order) {
+        if (! $order) {
             return $this->notFound('ORDER_NOT_FOUND', 'order not found.');
         }
 
@@ -207,7 +210,7 @@ class OrderManager
         $ownedByAnon = $aid !== null && $aid === $this->trimOrNull($order->anon_id ?? null);
         $ownershipVerified = $ownedByUser || $ownedByAnon;
 
-        if (!$ownershipVerified && $uid === null && $aid === null && $allowAnonymousFallback) {
+        if (! $ownershipVerified && $uid === null && $aid === null && $allowAnonymousFallback) {
             return [
                 'ok' => true,
                 'order' => $order,
@@ -215,7 +218,7 @@ class OrderManager
             ];
         }
 
-        if (!$ownershipVerified) {
+        if (! $ownershipVerified) {
             return $this->notFound('ORDER_NOT_FOUND', 'order not found.');
         }
 
@@ -242,7 +245,7 @@ class OrderManager
             ->where('org_id', $orgId)
             ->lockForUpdate()
             ->first();
-        if (!$order) {
+        if (! $order) {
             return $this->notFound('ORDER_NOT_FOUND', 'order not found.');
         }
 
@@ -259,7 +262,7 @@ class OrderManager
             ];
         }
 
-        if (!$this->isTransitionAllowed($fromStatus, 'paid')) {
+        if (! $this->isTransitionAllowed($fromStatus, 'paid')) {
             return $this->conflict('ORDER_STATUS_INVALID', 'invalid order status transition.');
         }
 
@@ -285,7 +288,7 @@ class OrderManager
 
         if ($updated === 0) {
             $current = DB::table('orders')->where('order_no', $orderNo)->where('org_id', $orgId)->first();
-            if (!$current) {
+            if (! $current) {
                 return $this->notFound('ORDER_NOT_FOUND', 'order not found.');
             }
             $currentStatus = strtolower((string) ($current->status ?? ''));
@@ -323,7 +326,7 @@ class OrderManager
         }
 
         $order = $query->first();
-        if (!$order) {
+        if (! $order) {
             return $this->notFound('ORDER_NOT_FOUND', 'order not found.');
         }
 
@@ -339,7 +342,7 @@ class OrderManager
             ];
         }
 
-        if (!$this->isTransitionAllowed($fromStatus, $toStatus)) {
+        if (! $this->isTransitionAllowed($fromStatus, $toStatus)) {
             return $this->conflict('ORDER_STATUS_INVALID', 'invalid order status transition.');
         }
 
@@ -369,7 +372,7 @@ class OrderManager
         $updated = $updateQuery->update($updates);
         if ($updated === 0) {
             $current = DB::table('orders')->where('order_no', $orderNo)->first();
-            if (!$current) {
+            if (! $current) {
                 return $this->notFound('ORDER_NOT_FOUND', 'order not found.');
             }
 
@@ -470,7 +473,7 @@ class OrderManager
             $decoded = json_decode($raw, true);
             $raw = is_array($decoded) ? $decoded : null;
         }
-        if (!is_array($raw)) {
+        if (! is_array($raw)) {
             return [];
         }
 
@@ -563,45 +566,11 @@ class OrderManager
             ];
         }
 
-        $scaleCodeV2 = strtoupper(trim((string) ($attempt->scale_code_v2 ?? '')));
-        $scaleUid = trim((string) ($attempt->scale_uid ?? ''));
-
-        if ($scaleCodeV2 !== '' && $scaleUid !== '') {
-            return [
-                'scale_code_v2' => $scaleCodeV2,
-                'scale_uid' => $scaleUid,
-            ];
-        }
-
-        $scaleCodeV1 = strtoupper(trim((string) ($attempt->scale_code ?? '')));
-        if ($scaleCodeV1 === '') {
-            return [
-                'scale_code_v2' => $scaleCodeV2 !== '' ? $scaleCodeV2 : null,
-                'scale_uid' => $scaleUid !== '' ? $scaleUid : null,
-            ];
-        }
-
-        $v1ToV2 = (array) config('scale_identity.code_map_v1_to_v2', []);
-        $uidMap = (array) config('scale_identity.scale_uid_map', []);
-
-        if ($scaleCodeV2 === '') {
-            $mappedV2 = strtoupper(trim((string) ($v1ToV2[$scaleCodeV1] ?? '')));
-            if ($mappedV2 !== '') {
-                $scaleCodeV2 = $mappedV2;
-            }
-        }
-
-        if ($scaleUid === '') {
-            $mappedUid = trim((string) ($uidMap[$scaleCodeV1] ?? ''));
-            if ($mappedUid !== '') {
-                $scaleUid = $mappedUid;
-            }
-        }
-
-        return [
-            'scale_code_v2' => $scaleCodeV2 !== '' ? $scaleCodeV2 : null,
-            'scale_uid' => $scaleUid !== '' ? $scaleUid : null,
-        ];
+        return $this->identityProjector->projectFromCodes(
+            (string) ($attempt->scale_code ?? ''),
+            (string) ($attempt->scale_code_v2 ?? ''),
+            (string) ($attempt->scale_uid ?? '')
+        );
     }
 
     private function findIdempotentOrder(

--- a/backend/app/Services/Legacy/LegacyShareService.php
+++ b/backend/app/Services/Legacy/LegacyShareService.php
@@ -5,6 +5,7 @@ namespace App\Services\Legacy;
 use App\Models\Attempt;
 use App\Models\Result;
 use App\Models\Share;
+use App\Services\Scale\ScaleIdentityWriteProjector;
 use App\Support\OrgContext;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\ModelNotFoundException;
@@ -12,6 +13,10 @@ use Illuminate\Database\QueryException;
 
 class LegacyShareService
 {
+    public function __construct(
+        private readonly ScaleIdentityWriteProjector $identityProjector,
+    ) {}
+
     public function getOrCreateShare(string $attemptId, OrgContext $ctx): array
     {
         $attempt = $this->findAccessibleAttempt($attemptId, $ctx);
@@ -25,7 +30,7 @@ class LegacyShareService
             ->where('attempt_id', $attemptId)
             ->first();
 
-        if (!$share) {
+        if (! $share) {
             $share = $this->createShare($attempt, $ctx->anonId());
         } else {
             $this->backfillShareScaleIdentityIfNeeded($share, $attempt);
@@ -36,7 +41,7 @@ class LegacyShareService
         $typeName = (string) ($resultJson['type_name'] ?? $resultJson['type'] ?? $typeCode);
 
         $shareId = (string) $share->id;
-        $shareUrl = rtrim((string) config('app.frontend_url', 'http://localhost'), '/') . '/share/' . $shareId;
+        $shareUrl = rtrim((string) config('app.frontend_url', 'http://localhost'), '/').'/share/'.$shareId;
 
         return [
             'share_id' => $shareId,
@@ -61,7 +66,7 @@ class LegacyShareService
         $orgId = (int) ($attempt->org_id ?? 0);
         $ctxOrgId = max(0, (int) app(OrgContext::class)->orgId());
         if ($ctxOrgId > 0 && $ctxOrgId !== $orgId) {
-            throw (new ModelNotFoundException())->setModel(Share::class, [$shareId]);
+            throw (new ModelNotFoundException)->setModel(Share::class, [$shareId]);
         }
 
         $result = Result::query()
@@ -94,12 +99,12 @@ class LegacyShareService
             ->where('id', $attemptId)
             ->where('org_id', $ctx->orgId());
 
-        if (!$this->isAdmin($ctx)) {
+        if (! $this->isAdmin($ctx)) {
             $userId = $ctx->userId();
             $anonId = $ctx->anonId();
 
             if ($userId === null && ($anonId === null || $anonId === '')) {
-                throw (new ModelNotFoundException())->setModel(Attempt::class, [$attemptId]);
+                throw (new ModelNotFoundException)->setModel(Attempt::class, [$attemptId]);
             }
 
             $query->where(function (Builder $sub) use ($userId, $anonId): void {
@@ -122,7 +127,7 @@ class LegacyShareService
 
     private function createShare(Attempt $attempt, ?string $anonId): Share
     {
-        $share = new Share();
+        $share = new Share;
         $share->id = bin2hex(random_bytes(16));
         $share->attempt_id = (string) $attempt->id;
         $share->anon_id = $anonId;
@@ -137,6 +142,7 @@ class LegacyShareService
 
         try {
             $share->save();
+
             return $share;
         } catch (QueryException $e) {
             return Share::query()
@@ -147,7 +153,7 @@ class LegacyShareService
 
     private function backfillShareScaleIdentityIfNeeded(Share $share, Attempt $attempt): void
     {
-        if (!$this->shouldWriteScaleIdentityColumns()) {
+        if (! $this->shouldWriteScaleIdentityColumns()) {
             return;
         }
 
@@ -163,7 +169,7 @@ class LegacyShareService
             $dirty = true;
         }
 
-        if (!$dirty) {
+        if (! $dirty) {
             return;
         }
 
@@ -179,23 +185,11 @@ class LegacyShareService
      */
     private function resolveScaleIdentityValues(Attempt $attempt): array
     {
-        $legacyCode = strtoupper(trim((string) ($attempt->scale_code ?? '')));
-        $scaleCodeV2 = strtoupper(trim((string) ($attempt->scale_code_v2 ?? '')));
-        $scaleUid = trim((string) ($attempt->scale_uid ?? ''));
-
-        $mapV1ToV2 = (array) config('scale_identity.code_map_v1_to_v2', []);
-        $uidMap = (array) config('scale_identity.scale_uid_map', []);
-
-        if ($scaleCodeV2 === '' && $legacyCode !== '' && isset($mapV1ToV2[$legacyCode])) {
-            $scaleCodeV2 = strtoupper(trim((string) $mapV1ToV2[$legacyCode]));
-        }
-        if ($scaleUid === '' && $legacyCode !== '' && isset($uidMap[$legacyCode])) {
-            $scaleUid = trim((string) $uidMap[$legacyCode]);
-        }
+        $identity = $this->identityProjector->projectFromAttempt($attempt);
 
         return [
-            $scaleCodeV2 !== '' ? $scaleCodeV2 : null,
-            $scaleUid !== '' ? $scaleUid : null,
+            $identity['scale_code_v2'],
+            $identity['scale_uid'],
         ];
     }
 

--- a/backend/app/Services/Report/ReportSnapshotStore.php
+++ b/backend/app/Services/Report/ReportSnapshotStore.php
@@ -6,11 +6,13 @@ use App\Models\Attempt;
 use App\Models\Result;
 use App\Services\Analytics\EventRecorder;
 use App\Services\Assessment\GenericReportBuilder;
+use App\Services\Scale\ScaleIdentityWriteProjector;
 use Illuminate\Support\Facades\DB;
 
 class ReportSnapshotStore
 {
     private const SNAPSHOT_VERSION = 'v1';
+
     private const REPORT_ENGINE_VERSION = 'v1.2';
 
     public function __construct(
@@ -21,10 +23,11 @@ class ReportSnapshotStore
         private Eq60ReportComposer $eq60ReportComposer,
         private GenericReportBuilder $genericReportBuilder,
         private EventRecorder $eventRecorder,
+        private ScaleIdentityWriteProjector $identityProjector,
     ) {}
 
     /**
-     * @param array $meta {scale_code?:string, scale_code_v2?:string, scale_uid?:string, pack_id?:string, dir_version?:string, scoring_spec_version?:string}
+     * @param  array  $meta  {scale_code?:string, scale_code_v2?:string, scale_uid?:string, pack_id?:string, dir_version?:string, scoring_spec_version?:string}
      */
     public function seedPendingSnapshot(int $orgId, string $attemptId, ?string $orderNo, array $meta): void
     {
@@ -43,7 +46,7 @@ class ReportSnapshotStore
         $scoringSpecVersion = $meta['scoring_spec_version'] ?? null;
         if (is_string($scoringSpecVersion)) {
             $scoringSpecVersion = trim($scoringSpecVersion) !== '' ? trim($scoringSpecVersion) : null;
-        } elseif (!is_numeric($scoringSpecVersion)) {
+        } elseif (! is_numeric($scoringSpecVersion)) {
             $scoringSpecVersion = null;
         }
         $scaleCode = strtoupper(trim((string) ($meta['scale_code'] ?? '')));
@@ -116,7 +119,7 @@ class ReportSnapshotStore
     }
 
     /**
-     * @param array $ctx {org_id:int, attempt_id:string, trigger_source:string, order_no?:string, user_id?:string, anon_id?:string, org_role?:string}
+     * @param  array  $ctx  {org_id:int, attempt_id:string, trigger_source:string, order_no?:string, user_id?:string, anon_id?:string, org_role?:string}
      */
     public function createSnapshotForAttempt(array $ctx): array
     {
@@ -142,12 +145,12 @@ class ReportSnapshotStore
         }
 
         $attempt = $this->ownedAttemptQuery($orgId, $attemptId, $userId, $anonId, $role)->first();
-        if (!$attempt) {
+        if (! $attempt) {
             return $this->notFound('ATTEMPT_NOT_FOUND', 'attempt not found.');
         }
 
         $result = Result::where('org_id', $orgId)->where('attempt_id', $attemptId)->first();
-        if (!$result) {
+        if (! $result) {
             return $this->notFound('RESULT_NOT_FOUND', 'result not found.');
         }
 
@@ -177,7 +180,7 @@ class ReportSnapshotStore
             $modulesFull,
             $modulesPreview
         );
-        if (!is_array($reportFull)) {
+        if (! is_array($reportFull)) {
             return $this->serverError('REPORT_FAILED', 'report generation failed.');
         }
 
@@ -189,7 +192,7 @@ class ReportSnapshotStore
             ReportAccess::defaultModulesAllowedForLocked($scaleCode),
             $modulesPreview
         );
-        if (!is_array($reportFree)) {
+        if (! is_array($reportFree)) {
             return $this->serverError('REPORT_FAILED', 'report generation failed.');
         }
 
@@ -301,7 +304,7 @@ class ReportSnapshotStore
 
     private function normalizeActor(mixed $raw): ?string
     {
-        if (!is_string($raw) && !is_numeric($raw)) {
+        if (! is_string($raw) && ! is_numeric($raw)) {
             return null;
         }
 
@@ -348,8 +351,7 @@ class ReportSnapshotStore
         string $variant,
         array $modulesAllowed = [],
         array $modulesPreview = []
-    ): ?array
-    {
+    ): ?array {
         if ($scaleCode === 'MBTI') {
             $composed = $this->reportComposer->composeVariant($attempt, $variant, [
                 'org_id' => (int) ($attempt->org_id ?? 0),
@@ -360,7 +362,7 @@ class ReportSnapshotStore
                 'modules_allowed' => $modulesAllowed,
                 'modules_preview' => $modulesPreview,
             ], $result);
-            if (!($composed['ok'] ?? false)) {
+            if (! ($composed['ok'] ?? false)) {
                 return null;
             }
             $report = $composed['report'] ?? null;
@@ -378,7 +380,7 @@ class ReportSnapshotStore
                 'modules_allowed' => $modulesAllowed,
                 'modules_preview' => $modulesPreview,
             ]);
-            if (!($composed['ok'] ?? false)) {
+            if (! ($composed['ok'] ?? false)) {
                 return null;
             }
             $report = $composed['report'] ?? null;
@@ -396,7 +398,7 @@ class ReportSnapshotStore
                 'modules_allowed' => $modulesAllowed,
                 'modules_preview' => $modulesPreview,
             ]);
-            if (!($composed['ok'] ?? false)) {
+            if (! ($composed['ok'] ?? false)) {
                 return null;
             }
             $report = $composed['report'] ?? null;
@@ -414,7 +416,7 @@ class ReportSnapshotStore
                 'modules_allowed' => $modulesAllowed,
                 'modules_preview' => $modulesPreview,
             ]);
-            if (!($composed['ok'] ?? false)) {
+            if (! ($composed['ok'] ?? false)) {
                 return null;
             }
             $report = $composed['report'] ?? null;
@@ -432,7 +434,7 @@ class ReportSnapshotStore
                 'modules_allowed' => $modulesAllowed,
                 'modules_preview' => $modulesPreview,
             ]);
-            if (!($composed['ok'] ?? false)) {
+            if (! ($composed['ok'] ?? false)) {
                 return null;
             }
             $report = $composed['report'] ?? null;
@@ -490,6 +492,7 @@ class ReportSnapshotStore
         }
         if (is_string($raw)) {
             $decoded = json_decode($raw, true);
+
             return is_array($decoded) ? $decoded : [];
         }
 
@@ -532,23 +535,11 @@ class ReportSnapshotStore
      */
     private function resolveScaleIdentityValues(string $scaleCode, string $scaleCodeV2, string $scaleUid): array
     {
-        $legacyCode = strtoupper(trim($scaleCode));
-        $resolvedV2 = strtoupper(trim($scaleCodeV2));
-        $resolvedUid = trim($scaleUid);
-
-        $mapV1ToV2 = (array) config('scale_identity.code_map_v1_to_v2', []);
-        $uidMap = (array) config('scale_identity.scale_uid_map', []);
-
-        if ($resolvedV2 === '' && $legacyCode !== '' && isset($mapV1ToV2[$legacyCode])) {
-            $resolvedV2 = strtoupper(trim((string) $mapV1ToV2[$legacyCode]));
-        }
-        if ($resolvedUid === '' && $legacyCode !== '' && isset($uidMap[$legacyCode])) {
-            $resolvedUid = trim((string) $uidMap[$legacyCode]);
-        }
+        $identity = $this->identityProjector->projectFromCodes($scaleCode, $scaleCodeV2, $scaleUid);
 
         return [
-            $resolvedV2 !== '' ? $resolvedV2 : null,
-            $resolvedUid !== '' ? $resolvedUid : null,
+            $identity['scale_code_v2'],
+            $identity['scale_uid'],
         ];
     }
 

--- a/backend/app/Services/Scale/ScaleIdentityWriteProjector.php
+++ b/backend/app/Services/Scale/ScaleIdentityWriteProjector.php
@@ -1,0 +1,133 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\Scale;
+
+use App\Models\Attempt;
+
+final class ScaleIdentityWriteProjector
+{
+    public function __construct(
+        private readonly ScaleIdentityResolver $identityResolver,
+    ) {}
+
+    /**
+     * @return array{scale_code_v2:string|null,scale_uid:string|null}
+     */
+    public function projectFromAttempt(Attempt $attempt): array
+    {
+        return $this->projectFromCodes(
+            (string) ($attempt->scale_code ?? ''),
+            (string) ($attempt->scale_code_v2 ?? ''),
+            (string) ($attempt->scale_uid ?? '')
+        );
+    }
+
+    /**
+     * @return array{scale_code_v2:string|null,scale_uid:string|null}
+     */
+    public function projectFromCodes(string $scaleCodeV1, ?string $scaleCodeV2 = null, ?string $scaleUid = null): array
+    {
+        $legacyCode = strtoupper(trim($scaleCodeV1));
+        $v2Code = strtoupper(trim((string) $scaleCodeV2));
+        $uid = trim((string) $scaleUid);
+
+        if ($v2Code !== '' && $uid !== '') {
+            return [
+                'scale_code_v2' => $v2Code,
+                'scale_uid' => $uid,
+            ];
+        }
+
+        if ($v2Code !== '') {
+            $this->fillFromResolvedIdentity($v2Code, $legacyCode, $v2Code, $uid);
+        }
+
+        if ($legacyCode !== '' && ($v2Code === '' || $uid === '')) {
+            $this->fillFromResolvedIdentity($legacyCode, $legacyCode, $v2Code, $uid);
+        }
+
+        $v1ToV2 = $this->normalizeUpperMap((array) config('scale_identity.code_map_v1_to_v2', []));
+        $v2ToV1 = $this->normalizeUpperMap((array) config('scale_identity.code_map_v2_to_v1', []));
+        $uidMap = $this->normalizeUidMap((array) config('scale_identity.scale_uid_map', []));
+
+        if ($legacyCode === '' && $v2Code !== '' && isset($v2ToV1[$v2Code])) {
+            $legacyCode = $v2ToV1[$v2Code];
+        }
+
+        if ($v2Code === '' && $legacyCode !== '' && isset($v1ToV2[$legacyCode])) {
+            $v2Code = $v1ToV2[$legacyCode];
+        }
+
+        if ($uid === '' && $legacyCode !== '' && isset($uidMap[$legacyCode])) {
+            $uid = $uidMap[$legacyCode];
+        }
+
+        return [
+            'scale_code_v2' => $v2Code !== '' ? $v2Code : null,
+            'scale_uid' => $uid !== '' ? $uid : null,
+        ];
+    }
+
+    private function fillFromResolvedIdentity(string $inputCode, string &$legacyCode, string &$v2Code, string &$uid): void
+    {
+        $resolved = $this->identityResolver->resolveByAnyCode($inputCode);
+        $isKnown = is_array($resolved) && (bool) ($resolved['is_known'] ?? false);
+        if (! $isKnown) {
+            return;
+        }
+
+        $resolvedV1 = strtoupper(trim((string) ($resolved['scale_code_v1'] ?? '')));
+        $resolvedV2 = strtoupper(trim((string) ($resolved['scale_code_v2'] ?? '')));
+        $resolvedUid = trim((string) ($resolved['scale_uid'] ?? ''));
+
+        if ($legacyCode === '' && $resolvedV1 !== '') {
+            $legacyCode = $resolvedV1;
+        }
+        if ($v2Code === '' && $resolvedV2 !== '') {
+            $v2Code = $resolvedV2;
+        }
+        if ($uid === '' && $resolvedUid !== '') {
+            $uid = $resolvedUid;
+        }
+    }
+
+    /**
+     * @param  array<mixed,mixed>  $map
+     * @return array<string,string>
+     */
+    private function normalizeUpperMap(array $map): array
+    {
+        $out = [];
+        foreach ($map as $k => $v) {
+            $key = strtoupper(trim((string) $k));
+            $val = strtoupper(trim((string) $v));
+            if ($key === '' || $val === '') {
+                continue;
+            }
+            $out[$key] = $val;
+        }
+
+        return $out;
+    }
+
+    /**
+     * @param  array<mixed,mixed>  $map
+     * @return array<string,string>
+     */
+    private function normalizeUidMap(array $map): array
+    {
+        $out = [];
+        foreach ($map as $k => $v) {
+            $key = strtoupper(trim((string) $k));
+            $val = trim((string) $v);
+            if ($key === '' || $val === '') {
+                continue;
+            }
+            $out[$key] = $val;
+        }
+
+        return $out;
+    }
+}

--- a/backend/app/Services/V0_3/ShareService.php
+++ b/backend/app/Services/V0_3/ShareService.php
@@ -5,6 +5,7 @@ namespace App\Services\V0_3;
 use App\Models\Attempt;
 use App\Models\Result;
 use App\Models\Share;
+use App\Services\Scale\ScaleIdentityWriteProjector;
 use App\Support\OrgContext;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\ModelNotFoundException;
@@ -12,6 +13,10 @@ use Illuminate\Database\QueryException;
 
 class ShareService
 {
+    public function __construct(
+        private readonly ScaleIdentityWriteProjector $identityProjector,
+    ) {}
+
     public function getOrCreateShare(string $attemptId, OrgContext $ctx): array
     {
         $attempt = $this->findAccessibleAttempt($attemptId, $ctx);
@@ -25,7 +30,7 @@ class ShareService
             ->where('attempt_id', $attemptId)
             ->first();
 
-        if (!$share) {
+        if (! $share) {
             $share = $this->createShare($attempt, $ctx->anonId());
         } else {
             $this->backfillShareScaleIdentityIfNeeded($share, $attempt);
@@ -36,7 +41,7 @@ class ShareService
         $typeName = (string) ($resultJson['type_name'] ?? $resultJson['type'] ?? $typeCode);
 
         $shareId = (string) $share->id;
-        $shareUrl = rtrim((string) config('app.frontend_url', 'http://localhost'), '/') . '/share/' . $shareId;
+        $shareUrl = rtrim((string) config('app.frontend_url', 'http://localhost'), '/').'/share/'.$shareId;
 
         return [
             'share_id' => $shareId,
@@ -61,7 +66,7 @@ class ShareService
         $orgId = (int) ($attempt->org_id ?? 0);
         $ctxOrgId = max(0, (int) app(OrgContext::class)->orgId());
         if ($ctxOrgId > 0 && $ctxOrgId !== $orgId) {
-            throw (new ModelNotFoundException())->setModel(Share::class, [$shareId]);
+            throw (new ModelNotFoundException)->setModel(Share::class, [$shareId]);
         }
 
         $result = Result::query()
@@ -94,12 +99,12 @@ class ShareService
             ->where('id', $attemptId)
             ->where('org_id', $ctx->orgId());
 
-        if (!$this->isAdmin($ctx)) {
+        if (! $this->isAdmin($ctx)) {
             $userId = $ctx->userId();
             $anonId = $ctx->anonId();
 
             if ($userId === null && ($anonId === null || $anonId === '')) {
-                throw (new ModelNotFoundException())->setModel(Attempt::class, [$attemptId]);
+                throw (new ModelNotFoundException)->setModel(Attempt::class, [$attemptId]);
             }
 
             $query->where(function (Builder $sub) use ($userId, $anonId): void {
@@ -122,7 +127,7 @@ class ShareService
 
     private function createShare(Attempt $attempt, ?string $anonId): Share
     {
-        $share = new Share();
+        $share = new Share;
         $share->id = bin2hex(random_bytes(16));
         $share->attempt_id = (string) $attempt->id;
         $share->anon_id = $anonId;
@@ -137,6 +142,7 @@ class ShareService
 
         try {
             $share->save();
+
             return $share;
         } catch (QueryException $e) {
             return Share::query()
@@ -147,7 +153,7 @@ class ShareService
 
     private function backfillShareScaleIdentityIfNeeded(Share $share, Attempt $attempt): void
     {
-        if (!$this->shouldWriteScaleIdentityColumns()) {
+        if (! $this->shouldWriteScaleIdentityColumns()) {
             return;
         }
 
@@ -163,7 +169,7 @@ class ShareService
             $dirty = true;
         }
 
-        if (!$dirty) {
+        if (! $dirty) {
             return;
         }
 
@@ -179,23 +185,11 @@ class ShareService
      */
     private function resolveScaleIdentityValues(Attempt $attempt): array
     {
-        $legacyCode = strtoupper(trim((string) ($attempt->scale_code ?? '')));
-        $scaleCodeV2 = strtoupper(trim((string) ($attempt->scale_code_v2 ?? '')));
-        $scaleUid = trim((string) ($attempt->scale_uid ?? ''));
-
-        $mapV1ToV2 = (array) config('scale_identity.code_map_v1_to_v2', []);
-        $uidMap = (array) config('scale_identity.scale_uid_map', []);
-
-        if ($scaleCodeV2 === '' && $legacyCode !== '' && isset($mapV1ToV2[$legacyCode])) {
-            $scaleCodeV2 = strtoupper(trim((string) $mapV1ToV2[$legacyCode]));
-        }
-        if ($scaleUid === '' && $legacyCode !== '' && isset($uidMap[$legacyCode])) {
-            $scaleUid = trim((string) $uidMap[$legacyCode]);
-        }
+        $identity = $this->identityProjector->projectFromAttempt($attempt);
 
         return [
-            $scaleCodeV2 !== '' ? $scaleCodeV2 : null,
-            $scaleUid !== '' ? $scaleUid : null,
+            $identity['scale_code_v2'],
+            $identity['scale_uid'],
         ];
     }
 

--- a/backend/config/scale_identity.php
+++ b/backend/config/scale_identity.php
@@ -21,8 +21,15 @@ return [
     'api_response_scale_code_mode' => env('FAP_API_RESPONSE_SCALE_CODE_MODE', 'legacy'),
 
     // Content path read mode and publish mode.
+    // content_path_mode: legacy|dual_prefer_old|dual_prefer_new|v2
+    // content_publish_mode: legacy|dual|v2
     'content_path_mode' => env('FAP_CONTENT_PATH_MODE', 'legacy'),
     'content_publish_mode' => env('FAP_CONTENT_PUBLISH_MODE', 'legacy'),
+
+    // Mode semantic guardrails (enforced by ops:scale-identity-mode-audit):
+    // 1) read_mode=v2 requires write_mode in {dual,v2}
+    // 2) read_mode=v2 requires accept_legacy_scale_code=false
+    // 3) Other combinations are allowed but may emit warnings in audit output.
 
     // Demo scale switch for offboarding.
     'allow_demo_scales' => (bool) env('FAP_ALLOW_DEMO_SCALES', true),

--- a/backend/scripts/ci/verify_scale_identity_contract.sh
+++ b/backend/scripts/ci/verify_scale_identity_contract.sh
@@ -1,0 +1,202 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+BACKEND_DIR="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+
+API="${API:-http://127.0.0.1:1827}"
+REGION="${REGION:-CN_MAINLAND}"
+LOCALE="${LOCALE:-zh-CN}"
+
+need_cmd() { command -v "$1" >/dev/null 2>&1 || { echo "[CI][contract][FAIL] missing cmd: $1" >&2; exit 2; }; }
+fail() { echo "[CI][contract][FAIL] $*" >&2; exit 1; }
+
+extract_summary_metric() {
+  local summary="$1"
+  local key="$2"
+  php -r '
+$summary = (string) ($argv[1] ?? "");
+$key = (string) ($argv[2] ?? "");
+$parts = preg_split("/\s+/", trim($summary)) ?: [];
+$map = [];
+foreach ($parts as $part) {
+    if (!is_string($part) || strpos($part, "=") === false) {
+        continue;
+    }
+    [$k, $v] = explode("=", $part, 2);
+    $map[$k] = $v;
+}
+echo (string) ($map[$key] ?? "");
+' "$summary" "$key"
+}
+
+probe_questions_endpoint() {
+  local scale_code="$1"
+  local out_file
+  out_file="$(mktemp)"
+
+  local http_code
+  http_code="$(curl -sS -o "$out_file" -w "%{http_code}" \
+    "$API/api/v0.3/scales/${scale_code}/questions?region=${REGION}&locale=${LOCALE}" || true)"
+
+  if [[ "$http_code" != "200" ]]; then
+    echo "[CI][contract][FAIL] questions probe http=${http_code} scale_code=${scale_code}" >&2
+    echo "---- body (first 1000 bytes) ----" >&2
+    head -c 1000 "$out_file" >&2 || true
+    echo >&2
+    rm -f "$out_file"
+    exit 10
+  fi
+
+  local item_count
+  if ! item_count="$(php -r '
+$path = (string) ($argv[1] ?? "");
+$json = @file_get_contents($path);
+$doc = is_string($json) ? json_decode($json, true) : null;
+if (!is_array($doc) || !($doc["ok"] ?? false)) {
+    fwrite(STDERR, "ok flag is false or payload invalid\n");
+    exit(11);
+}
+$items = $doc["questions"]["items"] ?? null;
+if (!is_array($items)) {
+    fwrite(STDERR, "questions.items missing\n");
+    exit(12);
+}
+echo (string) count($items);
+' "$out_file")"; then
+    echo "[CI][contract][FAIL] invalid questions payload scale_code=${scale_code}" >&2
+    head -c 1000 "$out_file" >&2 || true
+    echo >&2
+    rm -f "$out_file"
+    exit 11
+  fi
+
+  echo "[CI][contract] questions probe ok scale_code=${scale_code} items=${item_count}"
+  rm -f "$out_file"
+}
+
+run_mirror_verify_pass() {
+  local label="$1"
+  local log_file="$2"
+
+  if ! php artisan ops:content-path-mirror --sync --verify-hash >"$log_file" 2>&1; then
+    echo "[CI][contract][FAIL] content-path-mirror failed (${label})" >&2
+    tail -n 200 "$log_file" >&2 || true
+    exit 20
+  fi
+
+  local summary
+  summary="$(grep -E '^content_path_mirror ' "$log_file" | tail -n 1 || true)"
+  if [[ -z "$summary" ]]; then
+    echo "[CI][contract][FAIL] mirror summary missing (${label})" >&2
+    tail -n 200 "$log_file" >&2 || true
+    exit 21
+  fi
+
+  MIRROR_COPIED="$(extract_summary_metric "$summary" "sync_copied_files")"
+  MIRROR_UPDATED="$(extract_summary_metric "$summary" "sync_updated_files")"
+  MIRROR_MISMATCH="$(extract_summary_metric "$summary" "verify_mismatch_files")"
+  MIRROR_TARGET_MISSING="$(extract_summary_metric "$summary" "verify_target_missing_files")"
+
+  [[ -n "$MIRROR_COPIED" ]] || fail "mirror summary missing sync_copied_files (${label})"
+  [[ -n "$MIRROR_UPDATED" ]] || fail "mirror summary missing sync_updated_files (${label})"
+  [[ -n "$MIRROR_MISMATCH" ]] || fail "mirror summary missing verify_mismatch_files (${label})"
+  [[ -n "$MIRROR_TARGET_MISSING" ]] || fail "mirror summary missing verify_target_missing_files (${label})"
+
+  if [[ "$MIRROR_MISMATCH" != "0" ]]; then
+    fail "mirror verify_mismatch_files=${MIRROR_MISMATCH} (${label})"
+  fi
+  if [[ "$MIRROR_TARGET_MISSING" != "0" ]]; then
+    fail "mirror verify_target_missing_files=${MIRROR_TARGET_MISSING} (${label})"
+  fi
+
+  echo "[CI][contract] mirror ${label} copied=${MIRROR_COPIED} updated=${MIRROR_UPDATED} mismatch=${MIRROR_MISMATCH} target_missing=${MIRROR_TARGET_MISSING}"
+}
+
+need_cmd curl
+need_cmd php
+need_cmd grep
+need_cmd tail
+need_cmd mktemp
+
+cd "$BACKEND_DIR"
+
+echo "[CI][contract] six-scale legacy/v2 questions probes API=${API} region=${REGION} locale=${LOCALE}"
+while IFS='|' read -r legacy_code v2_code; do
+  [[ -n "$legacy_code" ]] || continue
+  [[ -n "$v2_code" ]] || continue
+  probe_questions_endpoint "$legacy_code"
+  probe_questions_endpoint "$v2_code"
+done <<'EOF'
+MBTI|MBTI_PERSONALITY_TEST_16_TYPES
+BIG5_OCEAN|BIG_FIVE_OCEAN_MODEL
+CLINICAL_COMBO_68|CLINICAL_DEPRESSION_ANXIETY_PRO
+SDS_20|DEPRESSION_SCREENING_STANDARD
+IQ_RAVEN|IQ_INTELLIGENCE_QUOTIENT
+EQ_60|EQ_EMOTIONAL_INTELLIGENCE
+EOF
+
+echo "[CI][contract] mirror verify pass #1"
+MIRROR_LOG_1="$(mktemp)"
+MIRROR_LOG_2="$(mktemp)"
+run_mirror_verify_pass "first" "$MIRROR_LOG_1"
+FIRST_COPIED="$MIRROR_COPIED"
+FIRST_UPDATED="$MIRROR_UPDATED"
+
+echo "[CI][contract] mirror verify pass #2 (idempotency)"
+run_mirror_verify_pass "second" "$MIRROR_LOG_2"
+SECOND_COPIED="$MIRROR_COPIED"
+SECOND_UPDATED="$MIRROR_UPDATED"
+
+if [[ "$SECOND_COPIED" != "0" || "$SECOND_UPDATED" != "0" ]]; then
+  echo "[CI][contract][FAIL] mirror not idempotent on second pass copied=${SECOND_COPIED} updated=${SECOND_UPDATED}" >&2
+  echo "[CI][contract] first pass copied=${FIRST_COPIED} updated=${FIRST_UPDATED}" >&2
+  exit 22
+fi
+
+rm -f "$MIRROR_LOG_1" "$MIRROR_LOG_2"
+echo "[CI][contract] mirror idempotency passed"
+
+echo "[CI][contract] strict scale identity gate"
+: "${FAP_GATE_IDENTITY_RESOLVE_MISMATCH_RATE_MAX:=0}"
+: "${FAP_GATE_DUAL_WRITE_MISMATCH_RATE_MAX:=0}"
+: "${FAP_GATE_CONTENT_PATH_FALLBACK_RATE_MAX:=0}"
+: "${FAP_GATE_LEGACY_CODE_HIT_RATE_MAX:=1}"
+: "${FAP_GATE_DEMO_SCALE_HIT_RATE_MAX:=1}"
+export FAP_GATE_IDENTITY_RESOLVE_MISMATCH_RATE_MAX
+export FAP_GATE_DUAL_WRITE_MISMATCH_RATE_MAX
+export FAP_GATE_CONTENT_PATH_FALLBACK_RATE_MAX
+export FAP_GATE_LEGACY_CODE_HIT_RATE_MAX
+export FAP_GATE_DEMO_SCALE_HIT_RATE_MAX
+
+set +e
+GATE_OUTPUT="$(php artisan ops:scale-identity-gate --json=1 --strict=1 2>&1)"
+GATE_EXIT=$?
+set -e
+
+if [[ "$GATE_EXIT" -ne 0 ]]; then
+  echo "[CI][contract][FAIL] strict gate command failed exit=${GATE_EXIT}" >&2
+  echo "$GATE_OUTPUT" >&2
+  exit 30
+fi
+
+GATE_JSON="$(printf '%s\n' "$GATE_OUTPUT" | tail -n 1)"
+if ! php -r '
+$json = (string) ($argv[1] ?? "");
+$payload = json_decode($json, true);
+if (!is_array($payload)) {
+    fwrite(STDERR, "invalid gate json\n");
+    exit(31);
+}
+if (!($payload["pass"] ?? false)) {
+    fwrite(STDERR, "gate pass=false\n");
+    exit(32);
+}
+' "$GATE_JSON"; then
+  echo "[CI][contract][FAIL] strict gate payload validation failed" >&2
+  echo "$GATE_OUTPUT" >&2
+  exit 31
+fi
+
+echo "[CI][contract] strict gate passed"
+echo "[CI][contract] scale identity contract verification completed"

--- a/backend/scripts/ci_verify_mbti.sh
+++ b/backend/scripts/ci_verify_mbti.sh
@@ -63,8 +63,12 @@ RUN_EQ_60_GATE="${RUN_EQ_60_GATE:-0}"
 RUN_SDS_NORMS_GATE="${RUN_SDS_NORMS_GATE:-0}"
 RUN_FULL_SCALE_REGRESSION="${RUN_FULL_SCALE_REGRESSION:-0}"
 RUN_SCALE_IDENTITY_GATE="${RUN_SCALE_IDENTITY_GATE:-0}"
+RUN_SCALE_IDENTITY_CONTRACT="${RUN_SCALE_IDENTITY_CONTRACT:-0}"
+if [[ "$RUN_FULL_SCALE_REGRESSION" == "1" && "$RUN_SCALE_IDENTITY_CONTRACT" != "1" ]]; then
+  RUN_SCALE_IDENTITY_CONTRACT="1"
+fi
 SCALE_SCOPE="${SCALE_SCOPE:-mbti_only}"
-echo "[CI] scale_scope=${SCALE_SCOPE} run_big5_ocean_gate=${RUN_BIG5_OCEAN_GATE} run_clinical_combo_68_gate=${RUN_CLINICAL_COMBO_68_GATE} run_sds_20_gate=${RUN_SDS_20_GATE} run_eq_60_gate=${RUN_EQ_60_GATE} run_sds_norms_gate=${RUN_SDS_NORMS_GATE} run_full_scale_regression=${RUN_FULL_SCALE_REGRESSION} run_scale_identity_gate=${RUN_SCALE_IDENTITY_GATE}"
+echo "[CI] scale_scope=${SCALE_SCOPE} run_big5_ocean_gate=${RUN_BIG5_OCEAN_GATE} run_clinical_combo_68_gate=${RUN_CLINICAL_COMBO_68_GATE} run_sds_20_gate=${RUN_SDS_20_GATE} run_eq_60_gate=${RUN_EQ_60_GATE} run_sds_norms_gate=${RUN_SDS_NORMS_GATE} run_full_scale_regression=${RUN_FULL_SCALE_REGRESSION} run_scale_identity_gate=${RUN_SCALE_IDENTITY_GATE} run_scale_identity_contract=${RUN_SCALE_IDENTITY_CONTRACT}"
 if [[ "$RUN_BIG5_OCEAN_GATE" == "1" ]]; then
   echo "[CI] running BIG5_OCEAN content gates"
   bash "$BACKEND_DIR/scripts/ci/verify_big5_norms.sh"
@@ -257,10 +261,18 @@ fi
 # ----------------------------
 ACCEPT_ORDER_SH="$SCRIPT_DIR/accept_lookup_order.sh"
 ACCEPT_ORDER="${ACCEPT_ORDER:-0}"  # 1=run, 0=skip
+SCALE_IDENTITY_CONTRACT_SH="$BACKEND_DIR/scripts/ci/verify_scale_identity_contract.sh"
 
 if [[ "$ACCEPT_ORDER" == "1" ]]; then
   if [[ ! -f "$ACCEPT_ORDER_SH" ]]; then
     echo "[CI][FAIL] missing: $ACCEPT_ORDER_SH" >&2
+    exit 14
+  fi
+fi
+
+if [[ "$RUN_SCALE_IDENTITY_CONTRACT" == "1" ]]; then
+  if [[ ! -x "$SCALE_IDENTITY_CONTRACT_SH" ]]; then
+    echo "[CI][FAIL] missing or not executable: $SCALE_IDENTITY_CONTRACT_SH" >&2
     exit 14
   fi
 fi
@@ -720,6 +732,12 @@ if ! php -r '$j=json_decode(file_get_contents($argv[1]), true); if (!is_array($j
   exit 13
 fi
 echo "[CI] smoke OK"
+
+if [[ "$RUN_SCALE_IDENTITY_CONTRACT" == "1" ]]; then
+  echo "[CI] running scale identity contract gate (full regression)"
+  API="$API" REGION="$REGION" LOCALE="$LOCALE" bash "$SCALE_IDENTITY_CONTRACT_SH"
+  echo "[CI] scale identity contract gate OK"
+fi
 
 # -----------------------------
 # Run E2E verify

--- a/backend/scripts/ci_verify_scales.sh
+++ b/backend/scripts/ci_verify_scales.sh
@@ -8,10 +8,14 @@ RUN_BIG5_OCEAN_GATE="${RUN_BIG5_OCEAN_GATE:-0}"
 RUN_SDS_20_GATE="${RUN_SDS_20_GATE:-0}"
 RUN_SDS_NORMS_GATE="${RUN_SDS_NORMS_GATE:-0}"
 RUN_FULL_SCALE_REGRESSION="${RUN_FULL_SCALE_REGRESSION:-0}"
+RUN_SCALE_IDENTITY_CONTRACT="${RUN_SCALE_IDENTITY_CONTRACT:-$RUN_FULL_SCALE_REGRESSION}"
+RUN_SCALE_IDENTITY_GATE="${RUN_SCALE_IDENTITY_GATE:-$RUN_FULL_SCALE_REGRESSION}"
 SCALE_SCOPE="${SCALE_SCOPE:-mbti_only}"
 
-echo "[CI][scales] scale_scope=${SCALE_SCOPE} run_big5_ocean_gate=${RUN_BIG5_OCEAN_GATE} run_sds_20_gate=${RUN_SDS_20_GATE} run_sds_norms_gate=${RUN_SDS_NORMS_GATE} run_full_scale_regression=${RUN_FULL_SCALE_REGRESSION}"
+echo "[CI][scales] scale_scope=${SCALE_SCOPE} run_big5_ocean_gate=${RUN_BIG5_OCEAN_GATE} run_sds_20_gate=${RUN_SDS_20_GATE} run_sds_norms_gate=${RUN_SDS_NORMS_GATE} run_full_scale_regression=${RUN_FULL_SCALE_REGRESSION} run_scale_identity_contract=${RUN_SCALE_IDENTITY_CONTRACT} run_scale_identity_gate=${RUN_SCALE_IDENTITY_GATE}"
 echo "[CI][scales] running MBTI baseline gate"
+RUN_SCALE_IDENTITY_CONTRACT="${RUN_SCALE_IDENTITY_CONTRACT}" \
+RUN_SCALE_IDENTITY_GATE="${RUN_SCALE_IDENTITY_GATE}" \
 bash "${BACKEND_DIR}/scripts/ci_verify_mbti.sh"
 
 if [[ "${RUN_BIG5_OCEAN_GATE}" != "1" ]]; then

--- a/backend/scripts/prA_gate_scale_identity.sh
+++ b/backend/scripts/prA_gate_scale_identity.sh
@@ -61,6 +61,21 @@ if (!$pass) {
 }
 ' "$ART_DIR/gate_strict.json"
 
+php artisan ops:scale-identity-mode-audit --json=1 --strict=1 > "$ART_DIR/mode_audit_strict.json"
+
+php -r '
+$payload = json_decode((string) file_get_contents($argv[1]), true);
+if (!is_array($payload)) {
+    fwrite(STDERR, "[FAIL] mode audit payload decode failed\n");
+    exit(1);
+}
+$pass = (bool) ($payload["pass"] ?? false);
+if (!$pass) {
+    fwrite(STDERR, "[FAIL] mode audit strict failed: ".json_encode($payload["violations"] ?? [], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES)."\n");
+    exit(1);
+}
+' "$ART_DIR/mode_audit_strict.json"
+
 cat > "$ART_DIR/summary.txt" <<TXT
 PR-A scale identity gate summary
 
@@ -69,6 +84,7 @@ Checks:
 - fap:scales:seed-default: OK
 - ops:scale-identity-gate --json=1: OK
 - ops:scale-identity-gate --strict=1 --json=1: PASS
+- ops:scale-identity-mode-audit --strict=1 --json=1: PASS
 
 Thresholds:
 - identity_resolve_mismatch_rate <= ${FAP_GATE_IDENTITY_RESOLVE_MISMATCH_RATE_MAX}
@@ -80,6 +96,7 @@ Thresholds:
 Artifacts:
 - backend/artifacts/prA_gate_scale_identity/gate.json
 - backend/artifacts/prA_gate_scale_identity/gate_strict.json
+- backend/artifacts/prA_gate_scale_identity/mode_audit_strict.json
 - backend/artifacts/prA_gate_scale_identity/summary.txt
 TXT
 

--- a/backend/tests/Feature/Ops/ScaleIdentityContractCiTest.php
+++ b/backend/tests/Feature/Ops/ScaleIdentityContractCiTest.php
@@ -1,0 +1,98 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Ops;
+
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Artisan;
+use Tests\TestCase;
+
+final class ScaleIdentityContractCiTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_six_scale_questions_accept_legacy_and_v2_codes(): void
+    {
+        $this->artisan('migrate', ['--force' => true]);
+        $this->artisan('fap:scales:seed-default');
+
+        $pairs = [
+            ['legacy' => 'MBTI', 'v2' => 'MBTI_PERSONALITY_TEST_16_TYPES'],
+            ['legacy' => 'BIG5_OCEAN', 'v2' => 'BIG_FIVE_OCEAN_MODEL'],
+            ['legacy' => 'CLINICAL_COMBO_68', 'v2' => 'CLINICAL_DEPRESSION_ANXIETY_PRO'],
+            ['legacy' => 'SDS_20', 'v2' => 'DEPRESSION_SCREENING_STANDARD'],
+            ['legacy' => 'IQ_RAVEN', 'v2' => 'IQ_INTELLIGENCE_QUOTIENT'],
+            ['legacy' => 'EQ_60', 'v2' => 'EQ_EMOTIONAL_INTELLIGENCE'],
+        ];
+
+        foreach ($pairs as $pair) {
+            $legacy = (string) ($pair['legacy'] ?? '');
+            $v2 = (string) ($pair['v2'] ?? '');
+
+            $legacyResponse = $this->getJson('/api/v0.3/scales/'.$legacy.'/questions?region=CN_MAINLAND&locale=zh-CN');
+            $legacyResponse->assertStatus(200);
+            $legacyResponse->assertJsonPath('ok', true);
+            $this->assertIsArray($legacyResponse->json('questions.items'));
+
+            $v2Response = $this->getJson('/api/v0.3/scales/'.$v2.'/questions?region=CN_MAINLAND&locale=zh-CN');
+            $v2Response->assertStatus(200);
+            $v2Response->assertJsonPath('ok', true);
+            $this->assertIsArray($v2Response->json('questions.items'));
+        }
+    }
+
+    public function test_strict_gate_passes_with_contract_thresholds(): void
+    {
+        $this->artisan('migrate', ['--force' => true]);
+        $this->artisan('fap:scales:seed-default');
+
+        $previous = [
+            'FAP_GATE_IDENTITY_RESOLVE_MISMATCH_RATE_MAX' => getenv('FAP_GATE_IDENTITY_RESOLVE_MISMATCH_RATE_MAX'),
+            'FAP_GATE_DUAL_WRITE_MISMATCH_RATE_MAX' => getenv('FAP_GATE_DUAL_WRITE_MISMATCH_RATE_MAX'),
+            'FAP_GATE_CONTENT_PATH_FALLBACK_RATE_MAX' => getenv('FAP_GATE_CONTENT_PATH_FALLBACK_RATE_MAX'),
+            'FAP_GATE_LEGACY_CODE_HIT_RATE_MAX' => getenv('FAP_GATE_LEGACY_CODE_HIT_RATE_MAX'),
+            'FAP_GATE_DEMO_SCALE_HIT_RATE_MAX' => getenv('FAP_GATE_DEMO_SCALE_HIT_RATE_MAX'),
+        ];
+
+        putenv('FAP_GATE_IDENTITY_RESOLVE_MISMATCH_RATE_MAX=0');
+        putenv('FAP_GATE_DUAL_WRITE_MISMATCH_RATE_MAX=0');
+        putenv('FAP_GATE_CONTENT_PATH_FALLBACK_RATE_MAX=0');
+        putenv('FAP_GATE_LEGACY_CODE_HIT_RATE_MAX=1');
+        putenv('FAP_GATE_DEMO_SCALE_HIT_RATE_MAX=1');
+
+        try {
+            $exitCode = Artisan::call('ops:scale-identity-gate', [
+                '--json' => '1',
+                '--strict' => '1',
+                '--hours' => '336',
+                '--max-rows' => '5000',
+            ]);
+
+            $this->assertSame(0, $exitCode);
+
+            $payload = json_decode(trim((string) Artisan::output()), true);
+            $this->assertIsArray($payload);
+            $this->assertTrue((bool) ($payload['ok'] ?? false));
+            $this->assertTrue((bool) ($payload['pass'] ?? false));
+            $this->assertSame([], $payload['violations'] ?? null);
+        } finally {
+            $this->restoreEnv('FAP_GATE_IDENTITY_RESOLVE_MISMATCH_RATE_MAX', $previous['FAP_GATE_IDENTITY_RESOLVE_MISMATCH_RATE_MAX']);
+            $this->restoreEnv('FAP_GATE_DUAL_WRITE_MISMATCH_RATE_MAX', $previous['FAP_GATE_DUAL_WRITE_MISMATCH_RATE_MAX']);
+            $this->restoreEnv('FAP_GATE_CONTENT_PATH_FALLBACK_RATE_MAX', $previous['FAP_GATE_CONTENT_PATH_FALLBACK_RATE_MAX']);
+            $this->restoreEnv('FAP_GATE_LEGACY_CODE_HIT_RATE_MAX', $previous['FAP_GATE_LEGACY_CODE_HIT_RATE_MAX']);
+            $this->restoreEnv('FAP_GATE_DEMO_SCALE_HIT_RATE_MAX', $previous['FAP_GATE_DEMO_SCALE_HIT_RATE_MAX']);
+        }
+    }
+
+    private function restoreEnv(string $name, string|false $value): void
+    {
+        if ($value === false) {
+            putenv($name);
+
+            return;
+        }
+
+        putenv($name.'='.$value);
+    }
+}

--- a/backend/tests/Feature/Ops/ScaleIdentityModeAuditCommandTest.php
+++ b/backend/tests/Feature/Ops/ScaleIdentityModeAuditCommandTest.php
@@ -1,0 +1,79 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Ops;
+
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Artisan;
+use Tests\TestCase;
+
+final class ScaleIdentityModeAuditCommandTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_mode_audit_passes_under_default_legacy_modes(): void
+    {
+        $exitCode = Artisan::call('ops:scale-identity-mode-audit', [
+            '--json' => '1',
+            '--strict' => '1',
+        ]);
+
+        $this->assertSame(0, $exitCode);
+
+        $payload = json_decode(trim((string) Artisan::output()), true);
+        $this->assertIsArray($payload);
+        $this->assertTrue((bool) ($payload['ok'] ?? false));
+        $this->assertTrue((bool) ($payload['pass'] ?? false));
+        $this->assertSame([], $payload['violations'] ?? null);
+    }
+
+    public function test_mode_audit_strict_fails_for_unsupported_mode_value(): void
+    {
+        config()->set('scale_identity.read_mode', 'broken_mode');
+
+        $exitCode = Artisan::call('ops:scale-identity-mode-audit', [
+            '--json' => '1',
+            '--strict' => '1',
+        ]);
+
+        $this->assertSame(1, $exitCode);
+
+        $payload = json_decode(trim((string) Artisan::output()), true);
+        $this->assertIsArray($payload);
+        $this->assertFalse((bool) ($payload['pass'] ?? true));
+
+        $violations = is_array($payload['violations'] ?? null) ? $payload['violations'] : [];
+        $this->assertNotEmpty($violations);
+        $first = is_array($violations[0] ?? null) ? $violations[0] : [];
+        $this->assertSame('read_mode', (string) ($first['key'] ?? ''));
+        $this->assertSame('unsupported mode value', (string) ($first['reason'] ?? ''));
+    }
+
+    public function test_mode_audit_strict_fails_for_v2_read_with_legacy_write_and_legacy_acceptance(): void
+    {
+        config()->set('scale_identity.write_mode', 'legacy');
+        config()->set('scale_identity.read_mode', 'v2');
+        config()->set('scale_identity.accept_legacy_scale_code', true);
+
+        $exitCode = Artisan::call('ops:scale-identity-mode-audit', [
+            '--json' => '1',
+            '--strict' => '1',
+        ]);
+
+        $this->assertSame(1, $exitCode);
+
+        $payload = json_decode(trim((string) Artisan::output()), true);
+        $this->assertIsArray($payload);
+        $this->assertFalse((bool) ($payload['pass'] ?? true));
+
+        $violations = is_array($payload['violations'] ?? null) ? $payload['violations'] : [];
+        $keys = array_values(array_map(
+            static fn (array $item): string => (string) ($item['key'] ?? ''),
+            array_filter($violations, 'is_array')
+        ));
+
+        $this->assertContains('read_mode', $keys);
+        $this->assertContains('accept_legacy_scale_code', $keys);
+    }
+}

--- a/backend/tests/Unit/Ci/ScaleImpactResolverTest.php
+++ b/backend/tests/Unit/Ci/ScaleImpactResolverTest.php
@@ -11,7 +11,7 @@ final class ScaleImpactResolverTest extends TestCase
 {
     public function test_shared_layer_change_triggers_full_regression(): void
     {
-        $resolver = new ScaleImpactResolver();
+        $resolver = new ScaleImpactResolver;
         $result = $resolver->resolve([
             'backend/app/Services/Template/TemplateEngine.php',
         ]);
@@ -24,7 +24,7 @@ final class ScaleImpactResolverTest extends TestCase
 
     public function test_big5_only_change_runs_big5_gate_and_keeps_mbti_smoke(): void
     {
-        $resolver = new ScaleImpactResolver();
+        $resolver = new ScaleImpactResolver;
         $result = $resolver->resolve([
             'backend/content_packs/BIG5_OCEAN/v1/raw/questions_big5_bilingual.csv',
         ]);
@@ -38,7 +38,7 @@ final class ScaleImpactResolverTest extends TestCase
 
     public function test_mbti_only_change_skips_big5_gate(): void
     {
-        $resolver = new ScaleImpactResolver();
+        $resolver = new ScaleImpactResolver;
         $result = $resolver->resolve([
             'content_packages/default/CN_MAINLAND/zh-CN/MBTI-CN-v0.3/questions.json',
         ]);
@@ -51,7 +51,7 @@ final class ScaleImpactResolverTest extends TestCase
 
     public function test_clinical_only_change_runs_clinical_gate_and_keeps_mbti_smoke(): void
     {
-        $resolver = new ScaleImpactResolver();
+        $resolver = new ScaleImpactResolver;
         $result = $resolver->resolve([
             'backend/content_packs/CLINICAL_COMBO_68/v1/raw/policy.json',
         ]);
@@ -65,7 +65,7 @@ final class ScaleImpactResolverTest extends TestCase
 
     public function test_sds_only_change_runs_sds_gate_and_keeps_mbti_smoke(): void
     {
-        $resolver = new ScaleImpactResolver();
+        $resolver = new ScaleImpactResolver;
         $result = $resolver->resolve([
             'backend/content_packs/SDS_20/v1/raw/policy.json',
         ]);
@@ -79,7 +79,7 @@ final class ScaleImpactResolverTest extends TestCase
 
     public function test_sds_norms_change_runs_sds_norms_gate(): void
     {
-        $resolver = new ScaleImpactResolver();
+        $resolver = new ScaleImpactResolver;
         $result = $resolver->resolve([
             'backend/config/sds_norms.php',
         ]);
@@ -92,7 +92,7 @@ final class ScaleImpactResolverTest extends TestCase
 
     public function test_sds_content_change_does_not_force_sds_norms_gate(): void
     {
-        $resolver = new ScaleImpactResolver();
+        $resolver = new ScaleImpactResolver;
         $result = $resolver->resolve([
             'backend/content_packs/SDS_20/v1/raw/policy.json',
         ]);
@@ -104,7 +104,7 @@ final class ScaleImpactResolverTest extends TestCase
 
     public function test_shared_layer_change_enables_sds_gate_too(): void
     {
-        $resolver = new ScaleImpactResolver();
+        $resolver = new ScaleImpactResolver;
         $result = $resolver->resolve([
             'backend/app/Services/Report/ReportGatekeeper.php',
         ]);
@@ -117,7 +117,7 @@ final class ScaleImpactResolverTest extends TestCase
 
     public function test_eq_only_content_change_runs_eq_gate_only(): void
     {
-        $resolver = new ScaleImpactResolver();
+        $resolver = new ScaleImpactResolver;
         $result = $resolver->resolve([
             'backend/content_packs/EQ_60/v1/raw/policy.json',
         ]);
@@ -132,7 +132,7 @@ final class ScaleImpactResolverTest extends TestCase
 
     public function test_eq_compiled_change_runs_eq_gate_only(): void
     {
-        $resolver = new ScaleImpactResolver();
+        $resolver = new ScaleImpactResolver;
         $result = $resolver->resolve([
             'backend/content_packs/EQ_60/v1/compiled/manifest.json',
         ]);
@@ -149,7 +149,7 @@ final class ScaleImpactResolverTest extends TestCase
 
     public function test_eq_specific_class_change_does_not_force_full_regression(): void
     {
-        $resolver = new ScaleImpactResolver();
+        $resolver = new ScaleImpactResolver;
         $result = $resolver->resolve([
             'backend/app/Services/Assessment/Drivers/Eq60Driver.php',
         ]);
@@ -158,5 +158,29 @@ final class ScaleImpactResolverTest extends TestCase
         $this->assertTrue((bool) ($result['eq_60_changed'] ?? false));
         $this->assertTrue((bool) ($result['run_eq_60_gate'] ?? false));
         $this->assertSame('eq60_with_mbti_smoke', (string) ($result['scale_scope'] ?? ''));
+    }
+
+    public function test_ci_verify_mbti_workflow_change_triggers_full_regression(): void
+    {
+        $resolver = new ScaleImpactResolver;
+        $result = $resolver->resolve([
+            '.github/workflows/ci_verify_mbti.yml',
+        ]);
+
+        $this->assertTrue((bool) ($result['shared_changed'] ?? false));
+        $this->assertTrue((bool) ($result['run_full_scale_regression'] ?? false));
+        $this->assertSame('full_regression', (string) ($result['scale_scope'] ?? ''));
+    }
+
+    public function test_ci_contract_script_change_triggers_full_regression(): void
+    {
+        $resolver = new ScaleImpactResolver;
+        $result = $resolver->resolve([
+            'backend/scripts/ci/verify_scale_identity_contract.sh',
+        ]);
+
+        $this->assertTrue((bool) ($result['shared_changed'] ?? false));
+        $this->assertTrue((bool) ($result['run_full_scale_regression'] ?? false));
+        $this->assertSame('full_regression', (string) ($result['scale_scope'] ?? ''));
     }
 }

--- a/backend/tests/Unit/Services/Scale/ScaleIdentityWriteProjectorTest.php
+++ b/backend/tests/Unit/Services/Scale/ScaleIdentityWriteProjectorTest.php
@@ -1,0 +1,118 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Services\Scale;
+
+use App\Models\Attempt;
+use App\Services\Scale\ScaleIdentityWriteProjector;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\DB;
+use Tests\TestCase;
+
+final class ScaleIdentityWriteProjectorTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_projector_keeps_existing_identity_values_when_complete(): void
+    {
+        $attempt = new Attempt([
+            'scale_code' => 'MBTI',
+            'scale_code_v2' => 'mbti_personality_test_16_types',
+            'scale_uid' => '11111111-1111-4111-8111-111111111111',
+        ]);
+
+        $projected = app(ScaleIdentityWriteProjector::class)->projectFromAttempt($attempt);
+
+        $this->assertSame('MBTI_PERSONALITY_TEST_16_TYPES', $projected['scale_code_v2']);
+        $this->assertSame('11111111-1111-4111-8111-111111111111', $projected['scale_uid']);
+    }
+
+    public function test_projector_resolves_identity_from_database_defaults(): void
+    {
+        $attempt = new Attempt([
+            'scale_code' => 'MBTI',
+            'scale_code_v2' => null,
+            'scale_uid' => null,
+        ]);
+
+        $projected = app(ScaleIdentityWriteProjector::class)->projectFromAttempt($attempt);
+
+        $this->assertSame('MBTI_PERSONALITY_TEST_16_TYPES', $projected['scale_code_v2']);
+        $this->assertSame('11111111-1111-4111-8111-111111111111', $projected['scale_uid']);
+    }
+
+    public function test_projector_prefers_database_alias_resolution_even_when_config_maps_are_empty(): void
+    {
+        DB::table('scale_code_aliases')->updateOrInsert(
+            ['alias_code' => 'MBTI_CANARY_ALIAS'],
+            [
+                'scale_uid' => '11111111-1111-4111-8111-111111111111',
+                'alias_type' => 'custom',
+                'is_primary' => false,
+                'updated_at' => now(),
+                'created_at' => now(),
+            ]
+        );
+
+        config()->set('scale_identity.code_map_v1_to_v2', []);
+        config()->set('scale_identity.code_map_v2_to_v1', []);
+        config()->set('scale_identity.scale_uid_map', []);
+
+        $attempt = new Attempt([
+            'scale_code' => 'MBTI_CANARY_ALIAS',
+            'scale_code_v2' => null,
+            'scale_uid' => null,
+        ]);
+
+        $projected = app(ScaleIdentityWriteProjector::class)->projectFromAttempt($attempt);
+
+        $this->assertSame('MBTI_PERSONALITY_TEST_16_TYPES', $projected['scale_code_v2']);
+        $this->assertSame('11111111-1111-4111-8111-111111111111', $projected['scale_uid']);
+    }
+
+    public function test_projector_falls_back_to_config_mapping_for_unknown_code(): void
+    {
+        config()->set('scale_identity.code_map_v1_to_v2', [
+            'TEST_SCALE' => 'TEST_SCALE_V2',
+        ]);
+        config()->set('scale_identity.scale_uid_map', [
+            'TEST_SCALE' => '77777777-7777-4777-8777-777777777777',
+        ]);
+
+        $attempt = new Attempt([
+            'scale_code' => 'TEST_SCALE',
+            'scale_code_v2' => null,
+            'scale_uid' => null,
+        ]);
+
+        $projected = app(ScaleIdentityWriteProjector::class)->projectFromAttempt($attempt);
+
+        $this->assertSame('TEST_SCALE_V2', $projected['scale_code_v2']);
+        $this->assertSame('77777777-7777-4777-8777-777777777777', $projected['scale_uid']);
+    }
+
+    public function test_projector_can_fill_uid_from_v2_to_v1_mapping_when_legacy_code_missing(): void
+    {
+        config()->set('scale_identity.code_map_v1_to_v2', [
+            'TEST_SCALE' => 'TEST_SCALE_V2',
+        ]);
+        config()->set('scale_identity.code_map_v2_to_v1', [
+            'TEST_SCALE_V2' => 'TEST_SCALE',
+        ]);
+        config()->set('scale_identity.scale_uid_map', [
+            'TEST_SCALE' => '88888888-8888-4888-8888-888888888888',
+        ]);
+
+        $attempt = new Attempt([
+            'scale_code' => '',
+            'scale_code_v2' => 'test_scale_v2',
+            'scale_uid' => null,
+        ]);
+
+        $projected = app(ScaleIdentityWriteProjector::class)->projectFromAttempt($attempt);
+
+        $this->assertSame('TEST_SCALE_V2', $projected['scale_code_v2']);
+        $this->assertSame('88888888-8888-4888-8888-888888888888', $projected['scale_uid']);
+    }
+}

--- a/docs/04-ops/scale-identity-v2-zero-risk-closure-2026-02-26.md
+++ b/docs/04-ops/scale-identity-v2-zero-risk-closure-2026-02-26.md
@@ -59,3 +59,26 @@ strict gate 指标（同窗口）：
 - `backend/artifacts/scale_identity_rollout/scale_runtime_storage_audit_20260226_004148.md`
 - `backend/artifacts/scale_identity_rollout/scale_dir_completeness_audit_20260226_003624.md`
 
+## 7) Phase-B 护栏附录（模式语义审计）
+
+为避免“配置值合法但组合语义冲突”的发布风险，Phase-B 增加发布前强校验：
+
+- 命令：`php artisan ops:scale-identity-mode-audit --json=1 --strict=1`
+- 发布门禁脚本：`backend/scripts/prA_gate_scale_identity.sh` 已接入该校验。
+
+当前审计规则（strict 失败条件）：
+
+1. 枚举值非法（任何 mode 超出允许集合）：
+   - `write_mode`: `legacy|dual|v2`
+   - `read_mode`: `legacy|dual_prefer_old|dual_prefer_new|v2`
+   - `content_path_mode`: `legacy|dual_prefer_old|dual_prefer_new|v2`
+   - `content_publish_mode`: `legacy|dual|v2`
+   - `api_response_scale_code_mode`: `legacy|dual|v2`
+2. 语义冲突：
+   - `read_mode=v2` 且 `write_mode=legacy`
+   - `read_mode=v2` 且 `accept_legacy_scale_code=true`
+
+说明：
+
+- 警告项（warnings）用于提示高耦合组合，不直接阻断发布。
+- strict 只在 violations 非空时阻断，保证“可回滚 + 可观测 + 可阻断”。


### PR DESCRIPTION
## Summary
- add `ScaleIdentityWriteProjector` and converge v1/v2 projection logic into one service
- migrate duplicated identity-write code paths to projector across attempts/report/order/assessment/share services
- enforce full six-scale identity contract in CI (`legacy + v2` probes, mirror idempotency, strict gate)
- add `ops:scale-identity-mode-audit` and wire it into release gate script for pre-deploy blocking
- keep external API behavior unchanged (`scale_code` remains legacy-primary; `scale_code_v2` parallel)

## Scope
- No new HTTP routes
- No DB migrations added
- No breaking API schema changes

## Key Changes
### 1) Identity write projection convergence
- Added `backend/app/Services/Scale/ScaleIdentityWriteProjector.php`
- Replaced duplicated projection blocks in:
  - `backend/app/Services/Attempts/AnswerSetStore.php`
  - `backend/app/Services/Attempts/AnswerRowWriter.php`
  - `backend/app/Services/Report/ReportSnapshotStore.php`
  - `backend/app/Services/Commerce/OrderManager.php`
  - `backend/app/Services/Assessments/AssessmentService.php`
  - `backend/app/Services/V0_3/ShareService.php`
  - `backend/app/Services/Legacy/LegacyShareService.php`

### 2) CI full-regression contract closure
- Added `backend/scripts/ci/verify_scale_identity_contract.sh`
- Updated:
  - `backend/scripts/ci_verify_mbti.sh`
  - `backend/scripts/ci_verify_scales.sh`
  - `.github/workflows/ci_verify_mbti.yml`
  - `backend/app/Services/Ci/ScaleImpactResolver.php`
- Added tests:
  - `backend/tests/Feature/Ops/ScaleIdentityContractCiTest.php`
  - `backend/tests/Unit/Ci/ScaleImpactResolverTest.php`

### 3) Mode semantic audit + release guardrails
- Added `backend/app/Console/Commands/Ops/ScaleIdentityModeAudit.php`
- Registered in `backend/app/Console/Kernel.php`
- Added test `backend/tests/Feature/Ops/ScaleIdentityModeAuditCommandTest.php`
- Integrated strict mode-audit into `backend/scripts/prA_gate_scale_identity.sh`
- Clarified mode semantics comments in `backend/config/scale_identity.php` (no default change)
- Updated ops doc appendix:
  - `docs/04-ops/scale-identity-v2-zero-risk-closure-2026-02-26.md`

## Verification
- `cd backend && php artisan route:list`
- `cd backend && php artisan migrate --force`
- `cd backend && php artisan test --filter FmTokenOrgOverrideIsolationTest`
- `cd backend && php artisan test --filter NoFailOpenThrowableCatchTest`
- `cd backend && FAP_GATE_IDENTITY_RESOLVE_MISMATCH_RATE_MAX=0 FAP_GATE_DUAL_WRITE_MISMATCH_RATE_MAX=0 FAP_GATE_CONTENT_PATH_FALLBACK_RATE_MAX=0 FAP_GATE_LEGACY_CODE_HIT_RATE_MAX=1 FAP_GATE_DEMO_SCALE_HIT_RATE_MAX=1 php artisan ops:scale-identity-gate --json=1 --strict=1`
- `cd backend && FAP_PACKS_ROOT=/Users/rainie/Desktop/GitHub/fap-api/content_packages bash scripts/ci/verify_scale_identity_contract.sh`
- `cd backend && FAP_PACKS_ROOT=/Users/rainie/Desktop/GitHub/fap-api/content_packages bash scripts/prA_gate_scale_identity.sh`
- `cd backend && FAP_PACKS_ROOT=/Users/rainie/Desktop/GitHub/fap-api/content_packages bash scripts/ci_verify_mbti.sh`

## Risk / Rollback
- External API contract unchanged
- Rollback by reverting this PR or by runtime mode rollback to legacy profile
- Added release-blocking mode audit to prevent invalid mode combinations
