### PR TITLE
feat(api): add v0.3 auth/guest endpoint

### DIFF
--- a/backend/app/Http/Controllers/API/V0_3/AuthGuestController.php
+++ b/backend/app/Http/Controllers/API/V0_3/AuthGuestController.php
@@ -1,0 +1,84 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Controllers\API\V0_3;
+
+use App\Http\Controllers\Controller;
+use App\Services\Auth\FmTokenService;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+use Illuminate\Support\Str;
+
+final class AuthGuestController extends Controller
+{
+    public function __invoke(Request $request, FmTokenService $tokenService): JsonResponse
+    {
+        $payload = $request->validate([
+            'anon_id' => ['nullable', 'string', 'max:128'],
+        ]);
+
+        $anonId = $this->resolveAnonId(
+            $payload['anon_id'] ?? null,
+            $request
+        );
+
+        $issued = $tokenService->issueForUser($anonId, [
+            'provider' => 'guest',
+            'anon_id' => $anonId,
+            'role' => 'public',
+            'org_id' => 0,
+        ]);
+
+        $token = (string) ($issued['token'] ?? '');
+
+        return response()->json([
+            'ok' => true,
+            'fm_token' => $token,
+            'token' => $token,
+            'auth_token' => $token,
+            'expires_at' => $issued['expires_at'] ?? null,
+            'anon_id' => $anonId,
+        ]);
+    }
+
+    private function resolveAnonId(mixed $bodyAnonId, Request $request): string
+    {
+        $fromBody = $this->normalizeAnonId($bodyAnonId);
+        if ($fromBody !== null) {
+            return $fromBody;
+        }
+
+        $fromTransport = $this->normalizeAnonId(
+            $request->attributes->get('client_anon_id')
+                ?? $request->header('X-Anon-Id')
+                ?? $request->cookie('fap_anonymous_id_v1')
+        );
+        if ($fromTransport !== null) {
+            return $fromTransport;
+        }
+
+        return 'anon_' . (string) Str::uuid();
+    }
+
+    private function normalizeAnonId(mixed $candidate): ?string
+    {
+        if (!is_string($candidate) && !is_numeric($candidate)) {
+            return null;
+        }
+
+        $anonId = trim((string) $candidate);
+        if ($anonId === '' || strlen($anonId) > 128) {
+            return null;
+        }
+
+        $lower = mb_strtolower($anonId, 'UTF-8');
+        foreach (['todo', 'placeholder', 'fixme', 'tbd', '填这里'] as $bad) {
+            if (mb_strpos($lower, $bad) !== false) {
+                return null;
+            }
+        }
+
+        return $anonId;
+    }
+}

--- a/backend/routes/api.php
+++ b/backend/routes/api.php
@@ -3,6 +3,7 @@
 use App\Http\Controllers\API\V0_3\AttemptProgressController;
 use App\Http\Controllers\API\V0_3\AttemptReadController;
 use App\Http\Controllers\API\V0_3\AttemptWriteController;
+use App\Http\Controllers\API\V0_3\AuthGuestController as AuthGuestV03Controller;
 use App\Http\Controllers\API\V0_3\AuthPhoneController as AuthPhoneV03Controller;
 use App\Http\Controllers\API\V0_3\AuthWxPhoneController as AuthWxPhoneV03Controller;
 use App\Http\Controllers\API\V0_3\BigFiveOpsController;
@@ -74,6 +75,9 @@ Route::prefix('v0.3')->middleware([
         ->name('api.v0_3.webhooks.payment');
 
     Route::middleware('throttle:api_auth')->group(function () {
+        Route::post('/auth/guest', AuthGuestV03Controller::class)
+            ->middleware(\App\Http\Middleware\ResolveAnonId::class);
+
         if (app()->environment(['local', 'testing', 'ci'])) {
             Route::post('/auth/wx_phone', AuthWxPhoneV03Controller::class);
         } else {

--- a/backend/tests/Feature/V0_3/AuthGuestTokenTest.php
+++ b/backend/tests/Feature/V0_3/AuthGuestTokenTest.php
@@ -1,0 +1,81 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\V0_3;
+
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\DB;
+use Tests\TestCase;
+
+final class AuthGuestTokenTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_guest_token_can_be_issued_with_body_anon_id(): void
+    {
+        $anonId = 'anon_guest_body_001';
+
+        $response = $this->postJson('/api/v0.3/auth/guest', [
+            'anon_id' => $anonId,
+        ]);
+
+        $response->assertStatus(200)->assertJson([
+            'ok' => true,
+            'anon_id' => $anonId,
+        ]);
+
+        $token = (string) $response->json('fm_token');
+        $this->assertMatchesRegularExpression('/^fm_[0-9a-fA-F-]{36}$/', $token);
+        $this->assertSame($token, (string) $response->json('token'));
+        $this->assertSame($token, (string) $response->json('auth_token'));
+
+        $row = DB::table('fm_tokens')
+            ->where('token_hash', hash('sha256', $token))
+            ->first();
+        $this->assertNotNull($row);
+        $this->assertSame($anonId, (string) ($row->anon_id ?? ''));
+    }
+
+    public function test_guest_token_uses_transport_anon_id_when_body_is_missing(): void
+    {
+        $anonId = 'anon_guest_header_001';
+
+        $response = $this->withHeaders([
+            'X-Anon-Id' => $anonId,
+        ])->postJson('/api/v0.3/auth/guest', []);
+
+        $response->assertStatus(200)->assertJson([
+            'ok' => true,
+            'anon_id' => $anonId,
+        ]);
+    }
+
+    public function test_guest_token_generates_anon_id_when_missing(): void
+    {
+        $response = $this->postJson('/api/v0.3/auth/guest', []);
+        $response->assertStatus(200)->assertJson([
+            'ok' => true,
+        ]);
+
+        $anonId = (string) $response->json('anon_id');
+        $this->assertNotSame('', $anonId);
+        $this->assertMatchesRegularExpression('/^anon_[0-9a-fA-F-]{36}$/', $anonId);
+    }
+
+    public function test_guest_token_rejects_invalid_anon_id_payload(): void
+    {
+        $response = $this->postJson('/api/v0.3/auth/guest', [
+            'anon_id' => str_repeat('a', 129),
+        ]);
+
+        $response->assertStatus(422);
+        $response->assertJsonStructure([
+            'ok',
+            'error_code',
+            'message',
+            'details',
+            'request_id',
+        ]);
+    }
+}

--- a/backend/tests/Unit/Security/SecurityGuardrailsTest.php
+++ b/backend/tests/Unit/Security/SecurityGuardrailsTest.php
@@ -18,6 +18,7 @@ final class SecurityGuardrailsTest extends TestCase
     private const EXPLICIT_PUBLIC_MUTATING_ROUTES = [
         '/api/v0.2/{any?}',
         '/api/v0.3/webhooks/payment/{provider}',
+        '/api/v0.3/auth/guest',
         '/api/v0.3/auth/wx_phone',
         '/api/v0.3/auth/phone/send_code',
         '/api/v0.3/auth/phone/verify',


### PR DESCRIPTION
## Summary
- add public endpoint `POST /api/v0.3/auth/guest` under `throttle:api_auth`
- resolve `anon_id` priority as: request body -> transport anon id -> generated fallback
- issue public token via existing FM token service and return compatibility fields: `fm_token`, `token`, `auth_token`, `expires_at`, `anon_id`
- include `/api/v0.3/auth/guest` in explicit public mutating route allowlist guardrail

## Validation
- `php artisan test tests/Feature/V0_3/AuthGuestTokenTest.php tests/Unit/Security/SecurityGuardrailsTest.php --colors=never`
