### PR TITLE
feat(remediation): deliver loop01-11 security and reliability closure

### DIFF
--- a/.github/workflows/supply-chain-audit.yml
+++ b/.github/workflows/supply-chain-audit.yml
@@ -5,6 +5,8 @@ on:
     branches: ["main"]
   push:
     branches: ["main"]
+  schedule:
+    - cron: "17 3 * * 1"
 
 permissions:
   contents: read
@@ -54,6 +56,10 @@ jobs:
           echo "::error::composer audit failed after 3 attempts"
           exit 1
 
+      - name: Dependency governance gate (archive + diff + severity policy)
+        working-directory: backend
+        run: bash scripts/pr78_verify.sh
+
       - name: OSV scan composer.lock
         run: |
           set -euo pipefail
@@ -78,6 +84,8 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: supply-chain-evidence
-          path: _audit/osv-composer-lock.json
+          path: |
+            _audit/osv-composer-lock.json
+            backend/artifacts/pr78
           if-no-files-found: error
-          retention-days: 7
+          retention-days: 30

--- a/backend/app/Console/Commands/Big5PsychometricsReport.php
+++ b/backend/app/Console/Commands/Big5PsychometricsReport.php
@@ -43,8 +43,9 @@ class Big5PsychometricsReport extends Command
 
     public function handle(): int
     {
-        if (!Schema::hasTable('big5_psychometrics_reports')) {
+        if (! Schema::hasTable('big5_psychometrics_reports')) {
             $this->error('Missing table big5_psychometrics_reports. Run migrations first.');
+
             return 1;
         }
 
@@ -69,32 +70,55 @@ class Big5PsychometricsReport extends Command
             $query->where('a.region', $region);
         }
 
-        $rows = $query->get();
-        $records = [];
-        foreach ($rows as $row) {
+        $sampleN = 0;
+        $domainStats = $this->initStats(self::DOMAINS);
+        $facetStats = $this->initStats(self::FACETS);
+        $domainTotalStats = $this->initStats(self::DOMAINS);
+        $facetItemTotalCorrStats = $this->initCorrelations(self::FACETS);
+
+        foreach ($query->cursor() as $row) {
             $payload = $this->decodeResultJson($row->result_json ?? null);
             $quality = strtoupper((string) data_get($payload, 'quality.level', ''));
-            if (!in_array($quality, $qualityLevels, true)) {
+            if (! in_array($quality, $qualityLevels, true)) {
                 continue;
             }
 
             $domains = data_get($payload, 'raw_scores.domains_mean');
             $facets = data_get($payload, 'raw_scores.facets_mean');
-            if (!is_array($domains) || !is_array($facets)) {
+            if (! is_array($domains) || ! is_array($facets)) {
                 continue;
             }
 
-            if (!$this->hasCompleteMetrics($domains, $facets)) {
+            if (! $this->hasCompleteMetrics($domains, $facets)) {
                 continue;
             }
 
-            $records[] = [
-                'domains' => $this->pickMetrics($domains, self::DOMAINS),
-                'facets' => $this->pickMetrics($facets, self::FACETS),
-            ];
+            $pickedDomains = $this->pickMetrics($domains, self::DOMAINS);
+            $pickedFacets = $this->pickMetrics($facets, self::FACETS);
+
+            $sampleN++;
+            foreach ($pickedDomains as $domain => $score) {
+                $this->pushStat($domainStats[$domain], (float) $score);
+            }
+            foreach ($pickedFacets as $facet => $score) {
+                $this->pushStat($facetStats[$facet], (float) $score);
+            }
+
+            foreach (self::DOMAIN_TO_FACETS as $domain => $facetsInDomain) {
+                $domainTotal = 0.0;
+                foreach ($facetsInDomain as $facet) {
+                    $domainTotal += (float) $pickedFacets[$facet];
+                }
+
+                $this->pushStat($domainTotalStats[$domain], $domainTotal);
+                foreach ($facetsInDomain as $facet) {
+                    $facetValue = (float) $pickedFacets[$facet];
+                    $sumOthers = $domainTotal - $facetValue;
+                    $this->pushCorrelation($facetItemTotalCorrStats[$facet], $facetValue, $sumOthers);
+                }
+            }
         }
 
-        $sampleN = count($records);
         if ($sampleN < $minSamples) {
             $this->warn(sprintf(
                 'insufficient samples: got=%d required=%d scale=%s locale=%s window=%s',
@@ -104,10 +128,19 @@ class Big5PsychometricsReport extends Command
                 $locale,
                 $window
             ));
+
             return 2;
         }
 
-        $metrics = $this->buildMetrics($records, $windowDays, $qualityLevels);
+        $metrics = $this->buildMetrics(
+            $sampleN,
+            $windowDays,
+            $qualityLevels,
+            $domainStats,
+            $facetStats,
+            $domainTotalStats,
+            $facetItemTotalCorrStats
+        );
         $now = now();
 
         DB::table('big5_psychometrics_reports')->insert([
@@ -160,7 +193,7 @@ class Big5PsychometricsReport extends Command
 
         $levels = [];
         foreach (str_split($normalized) as $char) {
-            if (in_array($char, ['A', 'B', 'C', 'D'], true) && !in_array($char, $levels, true)) {
+            if (in_array($char, ['A', 'B', 'C', 'D'], true) && ! in_array($char, $levels, true)) {
                 $levels[] = $char;
             }
         }
@@ -197,18 +230,18 @@ class Big5PsychometricsReport extends Command
     }
 
     /**
-     * @param array<string,mixed> $domains
-     * @param array<string,mixed> $facets
+     * @param  array<string,mixed>  $domains
+     * @param  array<string,mixed>  $facets
      */
     private function hasCompleteMetrics(array $domains, array $facets): bool
     {
         foreach (self::DOMAINS as $code) {
-            if (!isset($domains[$code]) || !is_numeric($domains[$code])) {
+            if (! isset($domains[$code]) || ! is_numeric($domains[$code])) {
                 return false;
             }
         }
         foreach (self::FACETS as $code) {
-            if (!isset($facets[$code]) || !is_numeric($facets[$code])) {
+            if (! isset($facets[$code]) || ! is_numeric($facets[$code])) {
                 return false;
             }
         }
@@ -217,8 +250,8 @@ class Big5PsychometricsReport extends Command
     }
 
     /**
-     * @param array<string,mixed> $metrics
-     * @param list<string> $codes
+     * @param  array<string,mixed>  $metrics
+     * @param  list<string>  $codes
      * @return array<string,float>
      */
     private function pickMetrics(array $metrics, array $codes): array
@@ -232,203 +265,208 @@ class Big5PsychometricsReport extends Command
     }
 
     /**
-     * @param list<array{domains:array<string,float>,facets:array<string,float>}> $records
-     * @param list<string> $qualityLevels
+     * @param  list<string>  $qualityLevels
+     * @param  array<string,array{n:int,sum:float,sum_sq:float}>  $domainStats
+     * @param  array<string,array{n:int,sum:float,sum_sq:float}>  $facetStats
+     * @param  array<string,array{n:int,sum:float,sum_sq:float}>  $domainTotalStats
+     * @param  array<string,array{n:int,sum_x:float,sum_y:float,sum_x2:float,sum_y2:float,sum_xy:float}>  $facetItemTotalCorrStats
      * @return array<string,mixed>
      */
-    private function buildMetrics(array $records, int $windowDays, array $qualityLevels): array
-    {
-        $domainSeries = [];
-        $facetSeries = [];
+    private function buildMetrics(
+        int $sampleN,
+        int $windowDays,
+        array $qualityLevels,
+        array $domainStats,
+        array $facetStats,
+        array $domainTotalStats,
+        array $facetItemTotalCorrStats
+    ): array {
+        $normalizedDomainStats = [];
         foreach (self::DOMAINS as $domain) {
-            $domainSeries[$domain] = [];
-        }
-        foreach (self::FACETS as $facet) {
-            $facetSeries[$facet] = [];
-        }
-
-        foreach ($records as $row) {
-            foreach (self::DOMAINS as $domain) {
-                $domainSeries[$domain][] = (float) $row['domains'][$domain];
-            }
-            foreach (self::FACETS as $facet) {
-                $facetSeries[$facet][] = (float) $row['facets'][$facet];
-            }
-        }
-
-        $domainStats = [];
-        foreach (self::DOMAINS as $domain) {
-            $series = $domainSeries[$domain];
-            $domainStats[$domain] = [
-                'mean' => round($this->mean($series), 4),
-                'sd' => round($this->populationSd($series), 4),
+            $stat = $domainStats[$domain];
+            $normalizedDomainStats[$domain] = [
+                'mean' => round($this->statMean($stat), 4),
+                'sd' => round($this->statPopulationSd($stat), 4),
             ];
         }
 
-        $facetStats = [];
+        $normalizedFacetStats = [];
         foreach (self::FACETS as $facet) {
-            $series = $facetSeries[$facet];
-            $facetStats[$facet] = [
-                'mean' => round($this->mean($series), 4),
-                'sd' => round($this->populationSd($series), 4),
+            $stat = $facetStats[$facet];
+            $normalizedFacetStats[$facet] = [
+                'mean' => round($this->statMean($stat), 4),
+                'sd' => round($this->statPopulationSd($stat), 4),
             ];
         }
 
         $domainAlpha = [];
         foreach (self::DOMAINS as $domain) {
             $facets = self::DOMAIN_TO_FACETS[$domain];
-            $matrix = [];
-            foreach ($records as $row) {
-                $matrix[] = array_map(static fn (string $f): float => (float) $row['facets'][$f], $facets);
+            $k = count($facets);
+            if ($k <= 1) {
+                $domainAlpha[$domain] = null;
+
+                continue;
             }
-            $domainAlpha[$domain] = $this->cronbachAlpha($matrix);
+
+            $sumItemVariance = 0.0;
+            foreach ($facets as $facet) {
+                $sumItemVariance += $this->statVariance($facetStats[$facet]);
+            }
+
+            $totalVariance = $this->statVariance($domainTotalStats[$domain]);
+            if ($totalVariance <= 0.0) {
+                $domainAlpha[$domain] = null;
+
+                continue;
+            }
+
+            $alpha = ($k / ($k - 1)) * (1.0 - ($sumItemVariance / $totalVariance));
+            $domainAlpha[$domain] = is_finite($alpha) ? round($alpha, 4) : null;
         }
 
         $facetItemTotalCorr = [];
-        foreach (self::DOMAIN_TO_FACETS as $domain => $facets) {
-            foreach ($facets as $facet) {
-                $x = [];
-                $y = [];
-                foreach ($records as $row) {
-                    $facetValue = (float) $row['facets'][$facet];
-                    $sumOthers = 0.0;
-                    foreach ($facets as $f2) {
-                        if ($f2 === $facet) {
-                            continue;
-                        }
-                        $sumOthers += (float) $row['facets'][$f2];
-                    }
-                    $x[] = $facetValue;
-                    $y[] = $sumOthers;
-                }
-                $facetItemTotalCorr[$facet] = $this->correlation($x, $y);
-            }
+        foreach (self::FACETS as $facet) {
+            $facetItemTotalCorr[$facet] = $this->corrFromStat($facetItemTotalCorrStats[$facet]);
         }
 
         $thresholds = (array) config('big5_norms.psychometrics.thresholds', []);
 
         return [
-            'sample_n' => count($records),
+            'sample_n' => $sampleN,
             'window_days' => $windowDays,
             'quality_filter' => $qualityLevels,
             'domain_alpha' => $domainAlpha,
-            'domain_stats' => $domainStats,
-            'facet_stats' => $facetStats,
+            'domain_stats' => $normalizedDomainStats,
+            'facet_stats' => $normalizedFacetStats,
             'facet_item_total_corr' => $facetItemTotalCorr,
             'thresholds' => $thresholds,
         ];
     }
 
     /**
-     * @param list<list<float>> $matrix
+     * @param  list<string>  $codes
+     * @return array<string,array{n:int,sum:float,sum_sq:float}>
      */
-    private function cronbachAlpha(array $matrix): ?float
+    private function initStats(array $codes): array
     {
-        if ($matrix === []) {
-            return null;
-        }
-        $k = count($matrix[0] ?? []);
-        if ($k <= 1) {
-            return null;
+        $stats = [];
+        foreach ($codes as $code) {
+            $stats[$code] = ['n' => 0, 'sum' => 0.0, 'sum_sq' => 0.0];
         }
 
-        $itemVariances = array_fill(0, $k, []);
-        $totalScores = [];
-
-        foreach ($matrix as $row) {
-            if (count($row) !== $k) {
-                return null;
-            }
-            $totalScores[] = array_sum($row);
-            for ($i = 0; $i < $k; $i++) {
-                $itemVariances[$i][] = (float) $row[$i];
-            }
-        }
-
-        $sumItemVariance = 0.0;
-        for ($i = 0; $i < $k; $i++) {
-            $sumItemVariance += $this->populationSd($itemVariances[$i]) ** 2;
-        }
-
-        $totalVariance = $this->populationSd($totalScores) ** 2;
-        if ($totalVariance <= 0.0) {
-            return null;
-        }
-
-        $alpha = ($k / ($k - 1)) * (1.0 - ($sumItemVariance / $totalVariance));
-        if (!is_finite($alpha)) {
-            return null;
-        }
-
-        return round($alpha, 4);
+        return $stats;
     }
 
     /**
-     * @param list<float> $x
-     * @param list<float> $y
+     * @param  list<string>  $codes
+     * @return array<string,array{n:int,sum_x:float,sum_y:float,sum_x2:float,sum_y2:float,sum_xy:float}>
      */
-    private function correlation(array $x, array $y): ?float
+    private function initCorrelations(array $codes): array
     {
-        $n = count($x);
-        if ($n === 0 || $n !== count($y)) {
+        $stats = [];
+        foreach ($codes as $code) {
+            $stats[$code] = [
+                'n' => 0,
+                'sum_x' => 0.0,
+                'sum_y' => 0.0,
+                'sum_x2' => 0.0,
+                'sum_y2' => 0.0,
+                'sum_xy' => 0.0,
+            ];
+        }
+
+        return $stats;
+    }
+
+    /**
+     * @param  array{n:int,sum:float,sum_sq:float}  $stat
+     */
+    private function pushStat(array &$stat, float $value): void
+    {
+        $stat['n']++;
+        $stat['sum'] += $value;
+        $stat['sum_sq'] += $value * $value;
+    }
+
+    /**
+     * @param  array{n:int,sum_x:float,sum_y:float,sum_x2:float,sum_y2:float,sum_xy:float}  $stat
+     */
+    private function pushCorrelation(array &$stat, float $x, float $y): void
+    {
+        $stat['n']++;
+        $stat['sum_x'] += $x;
+        $stat['sum_y'] += $y;
+        $stat['sum_x2'] += $x * $x;
+        $stat['sum_y2'] += $y * $y;
+        $stat['sum_xy'] += $x * $y;
+    }
+
+    /**
+     * @param  array{n:int,sum:float,sum_sq:float}  $stat
+     */
+    private function statMean(array $stat): float
+    {
+        if ($stat['n'] <= 0) {
+            return 0.0;
+        }
+
+        return $stat['sum'] / $stat['n'];
+    }
+
+    /**
+     * @param  array{n:int,sum:float,sum_sq:float}  $stat
+     */
+    private function statPopulationSd(array $stat): float
+    {
+        $variance = $this->statVariance($stat);
+
+        return $variance > 0.0 ? sqrt($variance) : 0.0;
+    }
+
+    /**
+     * @param  array{n:int,sum:float,sum_sq:float}  $stat
+     */
+    private function statVariance(array $stat): float
+    {
+        if ($stat['n'] <= 0) {
+            return 0.0;
+        }
+
+        $mean = $stat['sum'] / $stat['n'];
+        $variance = ($stat['sum_sq'] / $stat['n']) - ($mean * $mean);
+        if ($variance < 0.0 && abs($variance) < 1e-12) {
+            return 0.0;
+        }
+
+        return $variance > 0.0 ? $variance : 0.0;
+    }
+
+    /**
+     * @param  array{n:int,sum_x:float,sum_y:float,sum_x2:float,sum_y2:float,sum_xy:float}  $stat
+     */
+    private function corrFromStat(array $stat): ?float
+    {
+        $n = $stat['n'];
+        if ($n <= 0) {
             return null;
         }
 
-        $meanX = $this->mean($x);
-        $meanY = $this->mean($y);
-        $sumXY = 0.0;
-        $sumXX = 0.0;
-        $sumYY = 0.0;
-
-        for ($i = 0; $i < $n; $i++) {
-            $dx = $x[$i] - $meanX;
-            $dy = $y[$i] - $meanY;
-            $sumXY += $dx * $dy;
-            $sumXX += $dx * $dx;
-            $sumYY += $dy * $dy;
-        }
-
+        $sumX = $stat['sum_x'];
+        $sumY = $stat['sum_y'];
+        $sumXX = $stat['sum_x2'] - (($sumX * $sumX) / $n);
+        $sumYY = $stat['sum_y2'] - (($sumY * $sumY) / $n);
         if ($sumXX <= 0.0 || $sumYY <= 0.0) {
             return null;
         }
 
+        $sumXY = $stat['sum_xy'] - (($sumX * $sumY) / $n);
         $corr = $sumXY / sqrt($sumXX * $sumYY);
-        if (!is_finite($corr)) {
+        if (! is_finite($corr)) {
             return null;
         }
 
         return round($corr, 4);
-    }
-
-    /**
-     * @param list<float> $values
-     */
-    private function mean(array $values): float
-    {
-        if ($values === []) {
-            return 0.0;
-        }
-
-        return array_sum($values) / count($values);
-    }
-
-    /**
-     * @param list<float> $values
-     */
-    private function populationSd(array $values): float
-    {
-        if ($values === []) {
-            return 0.0;
-        }
-
-        $mean = $this->mean($values);
-        $sum = 0.0;
-        foreach ($values as $value) {
-            $d = ((float) $value) - $mean;
-            $sum += $d * $d;
-        }
-
-        return sqrt($sum / count($values));
     }
 
     /**

--- a/backend/app/Console/Commands/SdsPsychometricsReport.php
+++ b/backend/app/Console/Commands/SdsPsychometricsReport.php
@@ -29,7 +29,7 @@ final class SdsPsychometricsReport extends Command
 
     public function handle(): int
     {
-        if (!Schema::hasTable('sds_psychometrics_reports')) {
+        if (! Schema::hasTable('sds_psychometrics_reports')) {
             $this->error('Missing table sds_psychometrics_reports. Run migrations first.');
 
             return 1;
@@ -60,13 +60,15 @@ final class SdsPsychometricsReport extends Command
             $query->where('a.region', $region);
         }
 
-        $rows = $query->get();
-
-        $records = [];
         $totalQualityRecords = 0;
         $qualityCWorseCount = 0;
+        $sampleN = 0;
+        $crisisCount = 0;
+        $bucketCounts = [];
+        $indexStats = ['n' => 0, 'sum' => 0.0, 'sum_sq' => 0.0];
+        $factorStats = $this->initStats(self::FACTORS);
 
-        foreach ($rows as $row) {
+        foreach ($query->cursor() as $row) {
             $payload = $this->decodeResultJson($row->result_json ?? null);
             if ($payload === []) {
                 continue;
@@ -77,15 +79,15 @@ final class SdsPsychometricsReport extends Command
                 ?? data_get($payload, 'normed_json.quality.level')
                 ?? ''
             ));
-            if (!in_array($quality, ['A', 'B', 'C', 'D'], true)) {
+            if (! in_array($quality, ['A', 'B', 'C', 'D'], true)) {
                 continue;
             }
 
             $indexScore = data_get($payload, 'scores.global.index_score');
-            if (!is_numeric($indexScore)) {
+            if (! is_numeric($indexScore)) {
                 $indexScore = data_get($payload, 'normed_json.scores.global.index_score');
             }
-            if (!is_numeric($indexScore)) {
+            if (! is_numeric($indexScore)) {
                 continue;
             }
 
@@ -94,45 +96,44 @@ final class SdsPsychometricsReport extends Command
                 $qualityCWorseCount++;
             }
 
-            if (!in_array($quality, $qualityLevels, true)) {
+            if (! in_array($quality, $qualityLevels, true)) {
                 continue;
             }
+
+            $sampleN++;
+            $this->pushStat($indexStats, (float) $indexScore);
 
             $crisisAlert = (bool) (
                 data_get($payload, 'quality.crisis_alert')
                 ?? data_get($payload, 'normed_json.quality.crisis_alert')
                 ?? false
             );
+            if ($crisisAlert) {
+                $crisisCount++;
+            }
 
             $clinicalLevel = trim((string) (
                 data_get($payload, 'scores.global.clinical_level')
                 ?? data_get($payload, 'normed_json.scores.global.clinical_level')
                 ?? ''
             ));
-            if ($clinicalLevel === '') {
-                $clinicalLevel = 'unknown';
+            $bucket = strtolower($clinicalLevel);
+            if ($bucket === '') {
+                $bucket = 'unknown';
             }
+            $bucketCounts[$bucket] = (int) ($bucketCounts[$bucket] ?? 0) + 1;
 
-            $factorScores = [];
             foreach (self::FACTORS as $factor) {
                 $score = data_get($payload, 'scores.factors.'.$factor.'.score');
-                if (!is_numeric($score)) {
+                if (! is_numeric($score)) {
                     $score = data_get($payload, 'normed_json.scores.factors.'.$factor.'.score');
                 }
                 if (is_numeric($score)) {
-                    $factorScores[$factor] = (float) $score;
+                    $this->pushStat($factorStats[$factor], (float) $score);
                 }
             }
-
-            $records[] = [
-                'index_score' => (float) $indexScore,
-                'crisis_alert' => $crisisAlert,
-                'clinical_level' => $clinicalLevel,
-                'factor_scores' => $factorScores,
-            ];
         }
 
-        $sampleN = count($records);
         if ($sampleN < $minSamples) {
             $this->warn(sprintf(
                 'insufficient samples: got=%d required=%d scale=%s locale=%s window=%s',
@@ -146,7 +147,17 @@ final class SdsPsychometricsReport extends Command
             return 2;
         }
 
-        $metrics = $this->buildMetrics($records, $windowDays, $qualityLevels, $totalQualityRecords, $qualityCWorseCount);
+        $metrics = $this->buildMetrics(
+            $sampleN,
+            $windowDays,
+            $qualityLevels,
+            $totalQualityRecords,
+            $qualityCWorseCount,
+            $indexStats,
+            $crisisCount,
+            $bucketCounts,
+            $factorStats
+        );
         $now = now();
 
         DB::table('sds_psychometrics_reports')->insert([
@@ -226,7 +237,7 @@ final class SdsPsychometricsReport extends Command
         $levels = [];
         foreach ($parts as $part) {
             $candidate = strtoupper(trim((string) $part));
-            if (in_array($candidate, ['A', 'B', 'C', 'D'], true) && !in_array($candidate, $levels, true)) {
+            if (in_array($candidate, ['A', 'B', 'C', 'D'], true) && ! in_array($candidate, $levels, true)) {
                 $levels[] = $candidate;
             }
         }
@@ -268,46 +279,23 @@ final class SdsPsychometricsReport extends Command
     }
 
     /**
+     * @param  list<string>  $qualityLevels
+     * @param  array{n:int,sum:float,sum_sq:float}  $indexStats
+     * @param  array<string,int>  $bucketCounts
+     * @param  array<string,array{n:int,sum:float,sum_sq:float}>  $factorStats
      * @return array<string,mixed>
      */
     private function buildMetrics(
-        array $records,
+        int $sampleN,
         int $windowDays,
         array $qualityLevels,
         int $totalQualityRecords,
-        int $qualityCWorseCount
+        int $qualityCWorseCount,
+        array $indexStats,
+        int $crisisCount,
+        array $bucketCounts,
+        array $factorStats
     ): array {
-        $indexScores = [];
-        $crisisCount = 0;
-        $bucketCounts = [];
-        $factorSeries = [];
-        foreach (self::FACTORS as $factor) {
-            $factorSeries[$factor] = [];
-        }
-
-        foreach ($records as $row) {
-            $index = (float) ($row['index_score'] ?? 0.0);
-            $indexScores[] = $index;
-
-            if ((bool) ($row['crisis_alert'] ?? false)) {
-                $crisisCount++;
-            }
-
-            $bucket = strtolower(trim((string) ($row['clinical_level'] ?? 'unknown')));
-            if ($bucket === '') {
-                $bucket = 'unknown';
-            }
-            $bucketCounts[$bucket] = (int) ($bucketCounts[$bucket] ?? 0) + 1;
-
-            $factorScores = is_array($row['factor_scores'] ?? null) ? $row['factor_scores'] : [];
-            foreach (self::FACTORS as $factor) {
-                if (isset($factorScores[$factor]) && is_numeric($factorScores[$factor])) {
-                    $factorSeries[$factor][] = (float) $factorScores[$factor];
-                }
-            }
-        }
-
-        $sampleN = count($records);
         $distribution = [];
         foreach ($bucketCounts as $bucket => $count) {
             $distribution[$bucket] = [
@@ -319,10 +307,9 @@ final class SdsPsychometricsReport extends Command
 
         $factorSummary = [];
         foreach (self::FACTORS as $factor) {
-            $series = $factorSeries[$factor];
             $factorSummary[$factor] = [
-                'mean' => round($this->mean($series), 4),
-                'sd' => round($this->populationSd($series), 4),
+                'mean' => round($this->statMean($factorStats[$factor]), 4),
+                'sd' => round($this->statPopulationSd($factorStats[$factor]), 4),
             ];
         }
 
@@ -334,8 +321,8 @@ final class SdsPsychometricsReport extends Command
             'sample_n' => $sampleN,
             'window_days' => $windowDays,
             'quality_filter' => array_values($qualityLevels),
-            'index_score_mean' => round($this->mean($indexScores), 4),
-            'index_score_sd' => round($this->populationSd($indexScores), 4),
+            'index_score_mean' => round($this->statMean($indexStats), 4),
+            'index_score_sd' => round($this->statPopulationSd($indexStats), 4),
             'crisis_rate' => $sampleN > 0 ? round($crisisCount / $sampleN, 4) : 0.0,
             'quality_c_or_worse_rate' => $qualityCWorseRate,
             'clinical_bucket_distribution' => $distribution,
@@ -363,33 +350,56 @@ final class SdsPsychometricsReport extends Command
     }
 
     /**
-     * @param list<float> $values
+     * @param  list<string>  $codes
+     * @return array<string,array{n:int,sum:float,sum_sq:float}>
      */
-    private function mean(array $values): float
+    private function initStats(array $codes): array
     {
-        if ($values === []) {
-            return 0.0;
+        $stats = [];
+        foreach ($codes as $code) {
+            $stats[$code] = ['n' => 0, 'sum' => 0.0, 'sum_sq' => 0.0];
         }
 
-        return array_sum($values) / count($values);
+        return $stats;
     }
 
     /**
-     * @param list<float> $values
+     * @param  array{n:int,sum:float,sum_sq:float}  $stat
      */
-    private function populationSd(array $values): float
+    private function pushStat(array &$stat, float $value): void
     {
-        if (count($values) <= 1) {
+        $stat['n']++;
+        $stat['sum'] += $value;
+        $stat['sum_sq'] += $value * $value;
+    }
+
+    /**
+     * @param  array{n:int,sum:float,sum_sq:float}  $stat
+     */
+    private function statMean(array $stat): float
+    {
+        if ($stat['n'] <= 0) {
             return 0.0;
         }
 
-        $mean = $this->mean($values);
-        $acc = 0.0;
-        foreach ($values as $value) {
-            $delta = $value - $mean;
-            $acc += $delta * $delta;
+        return $stat['sum'] / $stat['n'];
+    }
+
+    /**
+     * @param  array{n:int,sum:float,sum_sq:float}  $stat
+     */
+    private function statPopulationSd(array $stat): float
+    {
+        if ($stat['n'] <= 1) {
+            return 0.0;
         }
 
-        return sqrt($acc / count($values));
+        $mean = $stat['sum'] / $stat['n'];
+        $variance = ($stat['sum_sq'] / $stat['n']) - ($mean * $mean);
+        if ($variance < 0.0 && abs($variance) < 1e-12) {
+            return 0.0;
+        }
+
+        return $variance > 0.0 ? sqrt($variance) : 0.0;
     }
 }

--- a/backend/app/DTO/Legacy/LegacyRequestContext.php
+++ b/backend/app/DTO/Legacy/LegacyRequestContext.php
@@ -1,0 +1,281 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\DTO\Legacy;
+
+use App\Support\OrgContext;
+use Illuminate\Http\Request;
+
+final class LegacyRequestContext
+{
+    /**
+     * @param  array<string, string>  $headers
+     * @param  array<string, mixed>  $query
+     * @param  array<string, mixed>  $input
+     * @param  array<string, string>  $attributes
+     */
+    public function __construct(
+        public readonly int $orgId,
+        public readonly ?string $userId,
+        public readonly ?string $anonId,
+        public readonly ?string $requestId,
+        public readonly ?string $sessionId,
+        public readonly array $headers,
+        public readonly array $query,
+        public readonly array $input,
+        public readonly array $attributes,
+    ) {}
+
+    public static function fromRequest(Request $request, OrgContext $orgContext): self
+    {
+        $scopedOrgId = self::normalizeOrgId(
+            $request->attributes->get('org_id')
+                ?? $request->attributes->get('fm_org_id')
+        );
+        if ($scopedOrgId === null) {
+            $scopedOrgId = max(0, (int) $orgContext->orgId());
+        }
+
+        $userId = self::normalizeUserId(
+            $request->attributes->get('fm_user_id')
+                ?? $request->attributes->get('user_id')
+                ?? $request->user()?->id
+        );
+
+        $anonId = self::nullableString(
+            $request->attributes->get('anon_id')
+                ?? $request->attributes->get('fm_anon_id')
+                ?? $request->header('X-Anon-Id')
+                ?? $request->header('X-FAP-Anon-Id')
+                ?? $orgContext->anonId()
+        );
+
+        $requestId = self::nullableString(
+            $request->attributes->get('request_id')
+                ?? $request->header('X-Request-Id')
+                ?? $request->header('X-Request-ID')
+        );
+
+        $sessionId = self::nullableString(
+            $request->attributes->get('session_id')
+                ?? $request->header('X-Session-Id')
+        );
+
+        $headers = [
+            'x-experiment' => self::nullableString($request->header('X-Experiment')),
+            'x-app-version' => self::nullableString($request->header('X-App-Version')),
+            'x-channel' => self::nullableString($request->header('X-Channel')),
+            'x-client-platform' => self::nullableString($request->header('X-Client-Platform')),
+            'x-entry-page' => self::nullableString($request->header('X-Entry-Page')),
+            'x-share-id' => self::nullableString($request->header('X-Share-Id') ?? $request->header('X-Share-ID')),
+            'x-request-id' => self::nullableString($request->header('X-Request-Id') ?? $request->header('X-Request-ID')),
+            'x-session-id' => self::nullableString($request->header('X-Session-Id')),
+        ];
+
+        $attributes = [];
+        foreach ([
+            'org_id',
+            'fm_org_id',
+            'fm_user_id',
+            'user_id',
+            'anon_id',
+            'fm_anon_id',
+            'request_id',
+            'session_id',
+            'channel',
+            'client_platform',
+            'client_version',
+        ] as $key) {
+            $value = self::nullableString($request->attributes->get($key));
+            if ($value !== null) {
+                $attributes[$key] = $value;
+            }
+        }
+
+        $query = $request->query();
+        if (! is_array($query)) {
+            $query = [];
+        }
+
+        $input = $request->all();
+        if (! is_array($input)) {
+            $input = [];
+        }
+
+        return new self(
+            orgId: $scopedOrgId,
+            userId: $userId,
+            anonId: $anonId,
+            requestId: $requestId,
+            sessionId: $sessionId,
+            headers: array_filter($headers, static fn (?string $value): bool => $value !== null),
+            query: $query,
+            input: $input,
+            attributes: $attributes,
+        );
+    }
+
+    public function scopedOrgId(): int
+    {
+        return $this->orgId;
+    }
+
+    public function resolvedUserId(): ?string
+    {
+        return $this->userId;
+    }
+
+    public function resolvedAnonId(): ?string
+    {
+        return $this->anonId;
+    }
+
+    public function resolvedRequestId(): string
+    {
+        return $this->requestId ?? '';
+    }
+
+    public function queryString(string $key, string $default = ''): string
+    {
+        $value = $this->query[$key] ?? null;
+        if (is_string($value) || is_numeric($value)) {
+            $normalized = trim((string) $value);
+
+            return $normalized !== '' ? $normalized : $default;
+        }
+
+        return $default;
+    }
+
+    public function queryFlag(string $key): bool
+    {
+        $value = $this->queryString($key);
+
+        return in_array($value, ['1', 'true', 'TRUE', 'yes', 'YES'], true);
+    }
+
+    public function includeContains(string $needle): bool
+    {
+        $includeRaw = $this->queryString('include');
+        if ($includeRaw === '') {
+            return false;
+        }
+
+        $include = array_values(array_filter(array_map('trim', explode(',', $includeRaw))));
+
+        return in_array($needle, $include, true);
+    }
+
+    public function shareId(): ?string
+    {
+        $shareId = $this->queryString('share_id');
+        if ($shareId !== '') {
+            return $shareId;
+        }
+
+        $headerShareId = $this->headerValue('X-Share-Id') ?? $this->headerValue('X-Share-ID');
+        if ($headerShareId === null) {
+            return null;
+        }
+
+        $normalized = trim($headerShareId);
+
+        return $normalized !== '' ? $normalized : null;
+    }
+
+    public function headerValue(string $name): ?string
+    {
+        $value = $this->headers[strtolower($name)] ?? null;
+        if (! is_string($value)) {
+            return null;
+        }
+
+        $normalized = trim($value);
+
+        return $normalized !== '' ? $normalized : null;
+    }
+
+    /**
+     * @param  array<string, mixed>  $queryOverrides
+     * @param  array<string, mixed>  $inputOverrides
+     */
+    public function toEventRequest(array $queryOverrides = [], array $inputOverrides = []): Request
+    {
+        $query = array_merge($this->query, $queryOverrides);
+        $input = array_merge($this->input, $inputOverrides);
+
+        $server = [];
+        foreach ($this->headers as $name => $value) {
+            if (! is_string($value) || trim($value) === '') {
+                continue;
+            }
+
+            $server['HTTP_'.strtoupper(str_replace('-', '_', $name))] = $value;
+        }
+
+        $request = Request::create('/internal/legacy/events', 'GET', $query, [], [], $server);
+        $request->request->replace($input);
+
+        foreach ($this->attributes as $key => $value) {
+            if ($value === '') {
+                continue;
+            }
+            $request->attributes->set($key, $value);
+        }
+
+        $request->attributes->set('org_id', (string) $this->orgId);
+        $request->attributes->set('fm_org_id', (string) $this->orgId);
+
+        if ($this->userId !== null) {
+            $request->attributes->set('fm_user_id', $this->userId);
+            $request->attributes->set('user_id', $this->userId);
+        }
+
+        if ($this->anonId !== null) {
+            $request->attributes->set('anon_id', $this->anonId);
+            $request->attributes->set('fm_anon_id', $this->anonId);
+        }
+
+        if ($this->requestId !== null) {
+            $request->attributes->set('request_id', $this->requestId);
+        }
+
+        if ($this->sessionId !== null) {
+            $request->attributes->set('session_id', $this->sessionId);
+        }
+
+        return $request;
+    }
+
+    private static function normalizeOrgId(mixed $value): ?int
+    {
+        $normalized = self::nullableString($value);
+        if ($normalized === null || preg_match('/^\d+$/', $normalized) !== 1) {
+            return null;
+        }
+
+        return (int) $normalized;
+    }
+
+    private static function normalizeUserId(mixed $value): ?string
+    {
+        $normalized = self::nullableString($value);
+        if ($normalized === null || preg_match('/^\d+$/', $normalized) !== 1) {
+            return null;
+        }
+
+        return $normalized;
+    }
+
+    private static function nullableString(mixed $value): ?string
+    {
+        if (! is_string($value) && ! is_numeric($value)) {
+            return null;
+        }
+
+        $normalized = trim((string) $value);
+
+        return $normalized !== '' ? $normalized : null;
+    }
+}

--- a/backend/app/Http/Controllers/API/V0_3/BigFiveOpsController.php
+++ b/backend/app/Http/Controllers/API/V0_3/BigFiveOpsController.php
@@ -5,965 +5,103 @@ declare(strict_types=1);
 namespace App\Http\Controllers\API\V0_3;
 
 use App\Http\Controllers\Controller;
+use App\Http\Requests\V0_3\BigFiveOpsRequest;
+use App\Services\Ops\BigFiveOpsActionService;
 use Illuminate\Http\JsonResponse;
-use Illuminate\Http\Request;
-use Illuminate\Support\Facades\Artisan;
-use Illuminate\Support\Facades\DB;
-use Throwable;
 
 final class BigFiveOpsController extends Controller
 {
-    private const BIG5_ACTIONS = [
-        'big5_pack_publish',
-        'big5_pack_rollback',
-    ];
+    public function __construct(
+        private readonly BigFiveOpsActionService $actionService,
+    ) {}
 
-    public function latest(Request $request, int $org_id): JsonResponse
+    public function latest(BigFiveOpsRequest $request, int $org_id): JsonResponse
     {
-        $region = trim((string) $request->query('region', 'CN_MAINLAND'));
-        if ($region === '') {
-            $region = 'CN_MAINLAND';
-        }
-        $locale = trim((string) $request->query('locale', 'zh-CN'));
-        if ($locale === '') {
-            $locale = 'zh-CN';
-        }
-        $action = strtolower(trim((string) $request->query('action', '')));
-        if (! in_array($action, ['publish', 'rollback'], true)) {
-            $action = '';
-        }
+        $result = $this->actionService->latest($org_id, $request->validated());
 
-        $query = DB::table('content_pack_releases')
-            ->where('region', $region)
-            ->where('locale', $locale)
-            ->where(function ($q): void {
-                $q->where('to_pack_id', 'BIG5_OCEAN')
-                    ->orWhere('from_pack_id', 'BIG5_OCEAN');
-            });
-
-        if ($action !== '') {
-            $query->where('action', $action);
-        }
-
-        $row = $query
-            ->orderByDesc('created_at')
-            ->orderByDesc('updated_at')
-            ->first();
-
-        if (! $row) {
-            return response()->json([
-                'ok' => false,
-                'error_code' => 'RELEASE_NOT_FOUND',
-                'message' => 'release not found.',
-            ], 404);
-        }
-
-        return response()->json([
-            'ok' => true,
-            'org_id' => $org_id,
-            'item' => $this->mapReleaseRow($row),
-        ]);
+        return response()->json($result['payload'], $result['status']);
     }
 
-    public function latestAudits(Request $request, int $org_id): JsonResponse
+    public function latestAudits(BigFiveOpsRequest $request, int $org_id): JsonResponse
     {
-        $region = trim((string) $request->query('region', 'CN_MAINLAND'));
-        if ($region === '') {
-            $region = 'CN_MAINLAND';
-        }
-        $locale = trim((string) $request->query('locale', 'zh-CN'));
-        if ($locale === '') {
-            $locale = 'zh-CN';
-        }
-        $releaseAction = strtolower(trim((string) $request->query('release_action', '')));
-        $legacyAction = strtolower(trim((string) $request->query('action', '')));
-        if ($releaseAction === '' && in_array($legacyAction, ['publish', 'rollback'], true)) {
-            $releaseAction = $legacyAction;
-        }
-        if (! in_array($releaseAction, ['publish', 'rollback'], true)) {
-            $releaseAction = '';
-        }
-        $result = strtolower(trim((string) $request->query('result', '')));
-        if (! in_array($result, ['success', 'failed'], true)) {
-            $result = '';
-        }
-        $limit = (int) $request->query('limit', 20);
-        if ($limit < 1) {
-            $limit = 1;
-        }
-        if ($limit > 100) {
-            $limit = 100;
-        }
+        $result = $this->actionService->latestAudits($org_id, $request->validated());
 
-        $query = DB::table('content_pack_releases')
-            ->where('region', $region)
-            ->where('locale', $locale)
-            ->where(function ($q): void {
-                $q->where('to_pack_id', 'BIG5_OCEAN')
-                    ->orWhere('from_pack_id', 'BIG5_OCEAN');
-            });
-
-        if ($releaseAction !== '') {
-            $query->where('action', $releaseAction);
-        }
-
-        $row = $query
-            ->orderByDesc('created_at')
-            ->orderByDesc('updated_at')
-            ->first();
-
-        if (! $row) {
-            return response()->json([
-                'ok' => false,
-                'error_code' => 'RELEASE_NOT_FOUND',
-                'message' => 'release not found.',
-            ], 404);
-        }
-
-        $audits = DB::table('audit_logs')
-            ->whereIn('action', self::BIG5_ACTIONS)
-            ->where('target_id', (string) ($row->id ?? ''))
-            ->when($result !== '', function ($q) use ($result): void {
-                $q->where('result', $result);
-            })
-            ->orderByDesc('id')
-            ->limit($limit)
-            ->get();
-
-        $auditItems = [];
-        foreach ($audits as $audit) {
-            $auditItems[] = $this->mapAuditRow($audit);
-        }
-
-        return response()->json([
-            'ok' => true,
-            'org_id' => $org_id,
-            'item' => $this->mapReleaseRow($row),
-            'count' => count($auditItems),
-            'audits' => $auditItems,
-        ]);
+        return response()->json($result['payload'], $result['status']);
     }
 
-    public function releases(Request $request, int $org_id): JsonResponse
+    public function releases(BigFiveOpsRequest $request, int $org_id): JsonResponse
     {
-        $limit = (int) $request->query('limit', 20);
-        if ($limit < 1) {
-            $limit = 1;
-        }
-        if ($limit > 100) {
-            $limit = 100;
-        }
+        $result = $this->actionService->releases($org_id, $request->validated());
 
-        $region = trim((string) $request->query('region', 'CN_MAINLAND'));
-        if ($region === '') {
-            $region = 'CN_MAINLAND';
-        }
-        $locale = trim((string) $request->query('locale', 'zh-CN'));
-        if ($locale === '') {
-            $locale = 'zh-CN';
-        }
-
-        $action = strtolower(trim((string) $request->query('action', '')));
-        if (! in_array($action, ['publish', 'rollback'], true)) {
-            $action = '';
-        }
-
-        $query = DB::table('content_pack_releases')
-            ->where('region', $region)
-            ->where('locale', $locale)
-            ->where(function ($q): void {
-                $q->where('to_pack_id', 'BIG5_OCEAN')
-                    ->orWhere('from_pack_id', 'BIG5_OCEAN');
-            });
-
-        if ($action !== '') {
-            $query->where('action', $action);
-        }
-
-        $rows = $query
-            ->orderByDesc('created_at')
-            ->orderByDesc('updated_at')
-            ->limit($limit)
-            ->get();
-
-        $items = [];
-        foreach ($rows as $row) {
-            $items[] = $this->mapReleaseRow($row);
-        }
-
-        return response()->json([
-            'ok' => true,
-            'org_id' => $org_id,
-            'count' => count($items),
-            'items' => $items,
-        ]);
+        return response()->json($result['payload'], $result['status']);
     }
 
-    public function audits(Request $request, int $org_id): JsonResponse
+    public function audits(BigFiveOpsRequest $request, int $org_id): JsonResponse
     {
-        $limit = (int) $request->query('limit', 20);
-        if ($limit < 1) {
-            $limit = 1;
-        }
-        if ($limit > 100) {
-            $limit = 100;
-        }
+        $result = $this->actionService->audits($org_id, $request->validated());
 
-        $action = trim((string) $request->query('action', ''));
-        if (! in_array($action, ['big5_pack_publish', 'big5_pack_rollback'], true)) {
-            $action = '';
-        }
-        $result = strtolower(trim((string) $request->query('result', '')));
-        if (! in_array($result, ['success', 'failed'], true)) {
-            $result = '';
-        }
-        $releaseId = trim((string) $request->query('release_id', ''));
-
-        $query = DB::table('audit_logs')
-            ->whereIn('action', self::BIG5_ACTIONS);
-
-        if ($action !== '') {
-            $query->where('action', $action);
-        }
-        if ($result !== '') {
-            $query->where('result', $result);
-        }
-        if ($releaseId !== '') {
-            $query->where('target_id', $releaseId);
-        }
-
-        $rows = $query
-            ->orderByDesc('id')
-            ->limit($limit)
-            ->get();
-
-        $items = [];
-        foreach ($rows as $row) {
-            $items[] = $this->mapAuditRow($row);
-        }
-
-        return response()->json([
-            'ok' => true,
-            'org_id' => $org_id,
-            'count' => count($items),
-            'items' => $items,
-        ]);
+        return response()->json($result['payload'], $result['status']);
     }
 
-    public function audit(Request $request, int $org_id, string $audit_id): JsonResponse
+    public function audit(BigFiveOpsRequest $request, int $org_id, string $audit_id): JsonResponse
     {
-        $audit_id = trim($audit_id);
-        if ($audit_id === '') {
-            return response()->json([
-                'ok' => false,
-                'error_code' => 'AUDIT_NOT_FOUND',
-                'message' => 'audit not found.',
-            ], 404);
-        }
+        $result = $this->actionService->audit($org_id, $audit_id);
 
-        $row = DB::table('audit_logs')
-            ->where('id', $audit_id)
-            ->whereIn('action', self::BIG5_ACTIONS)
-            ->first();
-
-        if (! $row) {
-            return response()->json([
-                'ok' => false,
-                'error_code' => 'AUDIT_NOT_FOUND',
-                'message' => 'audit not found.',
-            ], 404);
-        }
-
-        $release = null;
-        $targetType = (string) ($row->target_type ?? '');
-        $targetId = (string) ($row->target_id ?? '');
-        if ($targetType === 'content_pack_release' && $targetId !== '') {
-            $releaseRow = DB::table('content_pack_releases')
-                ->where('id', $targetId)
-                ->where(function ($q): void {
-                    $q->where('to_pack_id', 'BIG5_OCEAN')
-                        ->orWhere('from_pack_id', 'BIG5_OCEAN');
-                })
-                ->first();
-            if ($releaseRow) {
-                $release = $this->mapReleaseRow($releaseRow);
-            }
-        }
-
-        return response()->json([
-            'ok' => true,
-            'org_id' => $org_id,
-            'item' => $this->mapAuditRow($row),
-            'release' => $release,
-        ]);
+        return response()->json($result['payload'], $result['status']);
     }
 
-    public function release(Request $request, int $org_id, string $release_id): JsonResponse
+    public function release(BigFiveOpsRequest $request, int $org_id, string $release_id): JsonResponse
     {
-        $release_id = trim($release_id);
-        if ($release_id === '') {
-            return response()->json([
-                'ok' => false,
-                'error_code' => 'RELEASE_NOT_FOUND',
-                'message' => 'release not found.',
-            ], 404);
-        }
+        $result = $this->actionService->release($org_id, $release_id);
 
-        $row = DB::table('content_pack_releases')
-            ->where('id', $release_id)
-            ->where(function ($q): void {
-                $q->where('to_pack_id', 'BIG5_OCEAN')
-                    ->orWhere('from_pack_id', 'BIG5_OCEAN');
-            })
-            ->first();
-
-        if (! $row) {
-            return response()->json([
-                'ok' => false,
-                'error_code' => 'RELEASE_NOT_FOUND',
-                'message' => 'release not found.',
-            ], 404);
-        }
-
-        $audits = DB::table('audit_logs')
-            ->whereIn('action', self::BIG5_ACTIONS)
-            ->where('target_id', $release_id)
-            ->orderByDesc('id')
-            ->limit(20)
-            ->get();
-
-        $auditItems = [];
-        foreach ($audits as $audit) {
-            $auditItems[] = $this->mapAuditRow($audit);
-        }
-
-        return response()->json([
-            'ok' => true,
-            'org_id' => $org_id,
-            'item' => $this->mapReleaseRow($row),
-            'audits' => $auditItems,
-        ]);
+        return response()->json($result['payload'], $result['status']);
     }
 
-    public function publish(Request $request, int $org_id): JsonResponse
+    public function publish(BigFiveOpsRequest $request, int $org_id): JsonResponse
     {
-        $region = $this->normalizeRegion((string) $request->input('region', 'CN_MAINLAND'));
-        $locale = $this->normalizeLocale((string) $request->input('locale', 'zh-CN'));
-        $dirAlias = $this->normalizeDirAlias((string) $request->input('dir_alias', 'v1'));
-        $pack = trim((string) $request->input('pack', 'BIG5_OCEAN'));
-        $packVersion = trim((string) $request->input('pack_version', 'v1'));
-        $probe = $this->toBool($request->input('probe', false));
-        $skipDrift = $this->toBool($request->input('skip_drift', true));
-        $baseUrl = trim((string) $request->input('base_url', ''));
+        $result = $this->actionService->publish($org_id, $request->validated(), $this->requestContext($request));
 
-        $startedAt = now();
-        $args = [
-            '--scale' => 'BIG5_OCEAN',
-            '--pack' => $pack === '' ? 'BIG5_OCEAN' : $pack,
-            '--pack-version' => $packVersion === '' ? 'v1' : $packVersion,
-            '--region' => $region,
-            '--locale' => $locale,
-            '--dir_alias' => $dirAlias,
-            '--probe' => $probe ? '1' : '0',
-            '--skip_drift' => $skipDrift ? '1' : '0',
-            '--created_by' => $this->resolveActor($request, $org_id),
-        ];
-        if ($baseUrl !== '') {
-            $args['--base_url'] = $baseUrl;
-        }
-        foreach (['drift_from', 'drift_to', 'drift_group_id', 'drift_threshold_mean', 'drift_threshold_sd'] as $key) {
-            $val = trim((string) $request->input($key, ''));
-            if ($val !== '') {
-                $args['--'.str_replace('_', '-', $key)] = $val;
-            }
-        }
-
-        $exitCode = Artisan::call('packs:publish', $args);
-        $commandOutput = trim(Artisan::output());
-        $releaseId = $this->extractCommandValue($commandOutput, 'release_id');
-        $release = null;
-        if ($releaseId !== '') {
-            $release = DB::table('content_pack_releases')
-                ->where('id', $releaseId)
-                ->first();
-        }
-        if (! $release) {
-            $release = $this->latestRelease('publish', $region, $locale, $dirAlias, $startedAt);
-        }
-        if (! $release) {
-            return response()->json([
-                'ok' => false,
-                'error_code' => 'PUBLISH_RELEASE_NOT_FOUND',
-                'message' => $commandOutput === '' ? 'publish release not found.' : $commandOutput,
-                'org_id' => $org_id,
-                'action' => 'publish',
-                'status' => 'failed',
-                'exit_code' => $exitCode,
-            ], 422);
-        }
-
-        $mapped = $this->mapReleaseRow($release);
-        $status = (string) ($mapped['status'] ?? 'failed');
-        $ok = $exitCode === 0 && $status === 'success';
-
-        return response()->json([
-            'ok' => $ok,
-            'org_id' => $org_id,
-            'action' => 'publish',
-            'status' => $status,
-            'exit_code' => $exitCode,
-            'message' => $commandOutput === '' ? ((string) ($mapped['message'] ?? '')) : $commandOutput,
-            'release' => $mapped,
-        ], $ok ? 200 : 422);
+        return response()->json($result['payload'], $result['status']);
     }
 
-    public function rollback(Request $request, int $org_id): JsonResponse
+    public function rollback(BigFiveOpsRequest $request, int $org_id): JsonResponse
     {
-        $region = $this->normalizeRegion((string) $request->input('region', 'CN_MAINLAND'));
-        $locale = $this->normalizeLocale((string) $request->input('locale', 'zh-CN'));
-        $dirAlias = $this->normalizeDirAlias((string) $request->input('dir_alias', 'v1'));
-        $probe = $this->toBool($request->input('probe', false));
-        $baseUrl = trim((string) $request->input('base_url', ''));
-        $toReleaseId = trim((string) $request->input('to_release_id', ''));
+        $result = $this->actionService->rollback($org_id, $request->validated());
 
-        $startedAt = now();
-        $args = [
-            '--scale' => 'BIG5_OCEAN',
-            '--region' => $region,
-            '--locale' => $locale,
-            '--dir_alias' => $dirAlias,
-            '--probe' => $probe ? '1' : '0',
-        ];
-        if ($baseUrl !== '') {
-            $args['--base_url'] = $baseUrl;
-        }
-        if ($toReleaseId !== '') {
-            $args['--to_release_id'] = $toReleaseId;
-        }
-
-        $exitCode = Artisan::call('packs:rollback', $args);
-        $commandOutput = trim(Artisan::output());
-        $releaseId = $this->extractCommandValue($commandOutput, 'release_id');
-        $release = null;
-        if ($releaseId !== '') {
-            $release = DB::table('content_pack_releases')
-                ->where('id', $releaseId)
-                ->first();
-        }
-        if (! $release) {
-            $release = $this->latestRelease('rollback', $region, $locale, $dirAlias, $startedAt);
-        }
-        if (! $release) {
-            return response()->json([
-                'ok' => false,
-                'error_code' => 'ROLLBACK_RELEASE_NOT_FOUND',
-                'message' => $commandOutput === '' ? 'rollback release not found.' : $commandOutput,
-                'org_id' => $org_id,
-                'action' => 'rollback',
-                'status' => 'failed',
-                'exit_code' => $exitCode,
-            ], 422);
-        }
-
-        $mapped = $this->mapReleaseRow($release);
-        $status = (string) ($mapped['status'] ?? 'failed');
-        $ok = $exitCode === 0 && $status === 'success';
-
-        return response()->json([
-            'ok' => $ok,
-            'org_id' => $org_id,
-            'action' => 'rollback',
-            'status' => $status,
-            'exit_code' => $exitCode,
-            'message' => $commandOutput === '' ? ((string) ($mapped['message'] ?? '')) : $commandOutput,
-            'release' => $mapped,
-        ], $ok ? 200 : 422);
+        return response()->json($result['payload'], $result['status']);
     }
 
-    public function rebuildNorms(Request $request, int $org_id): JsonResponse
+    public function rebuildNorms(BigFiveOpsRequest $request, int $org_id): JsonResponse
     {
-        $locale = $this->normalizeLocale((string) $request->input('locale', 'zh-CN'));
-        $region = $this->normalizeRegion((string) $request->input('region', $locale === 'zh-CN' ? 'CN_MAINLAND' : 'GLOBAL'));
-        $group = trim((string) $request->input('group', 'prod_all_18-60'));
-        if ($group === '') {
-            $group = 'prod_all_18-60';
-        }
-        $groupId = $this->resolveGroupId($locale, $group);
-        $gender = strtoupper(trim((string) $request->input('gender', 'ALL')));
-        if ($gender === '') {
-            $gender = 'ALL';
-        }
-        $ageMin = max(1, (int) $request->input('age_min', 18));
-        $ageMax = max($ageMin, (int) $request->input('age_max', 60));
-        $windowDays = max(1, (int) $request->input('window_days', 365));
-        $minSamples = max(1, (int) $request->input('min_samples', 1000));
-        $onlyQuality = trim((string) $request->input('only_quality', 'AB'));
-        if ($onlyQuality === '') {
-            $onlyQuality = 'AB';
-        }
-        $normsVersion = trim((string) $request->input('norms_version', ''));
-        $activate = $this->toBool($request->input('activate', true));
-        $dryRun = $this->toBool($request->input('dry_run', false));
+        $result = $this->actionService->rebuildNorms($org_id, $request->validated(), $this->requestContext($request));
 
-        $args = [
-            '--locale' => $locale,
-            '--region' => $region,
-            '--group' => $group,
-            '--gender' => $gender,
-            '--age_min' => (string) $ageMin,
-            '--age_max' => (string) $ageMax,
-            '--window_days' => (string) $windowDays,
-            '--min_samples' => (string) $minSamples,
-            '--only_quality' => $onlyQuality,
-            '--activate' => $activate ? '1' : '0',
-            '--dry-run' => $dryRun ? '1' : '0',
-        ];
-        if ($normsVersion !== '') {
-            $args['--norms_version'] = $normsVersion;
-        }
-
-        $exitCode = Artisan::call('norms:big5:rebuild', $args);
-        $commandOutput = trim(Artisan::output());
-        $status = $exitCode === 0 ? 'success' : 'failed';
-        $reason = $status === 'success' ? null : 'REBUILD_FAILED';
-
-        $versionRow = null;
-        if ($status === 'success' && ! $dryRun) {
-            $query = DB::table('scale_norms_versions')
-                ->where('scale_code', 'BIG5_OCEAN')
-                ->where('region', $region)
-                ->where('locale', $locale)
-                ->where('group_id', $groupId);
-            if ($normsVersion !== '') {
-                $query->where('version', $normsVersion);
-            }
-            $versionRow = $query->orderByDesc('created_at')->first();
-        }
-
-        $this->recordOpsAudit(
-            $request,
-            'big5_norms_rebuild',
-            'norms_group',
-            $groupId,
-            $status,
-            $reason,
-            [
-                'org_id' => $org_id,
-                'scale_code' => 'BIG5_OCEAN',
-                'locale' => $locale,
-                'region' => $region,
-                'group_id' => $groupId,
-                'gender' => $gender,
-                'age_min' => $ageMin,
-                'age_max' => $ageMax,
-                'window_days' => $windowDays,
-                'min_samples' => $minSamples,
-                'only_quality' => $onlyQuality,
-                'norms_version' => $normsVersion,
-                'activate' => $activate,
-                'dry_run' => $dryRun,
-                'exit_code' => $exitCode,
-                'output' => $commandOutput,
-            ]
-        );
-
-        return response()->json([
-            'ok' => $status === 'success',
-            'org_id' => $org_id,
-            'action' => 'norms_rebuild',
-            'status' => $status,
-            'exit_code' => $exitCode,
-            'message' => $commandOutput,
-            'item' => $versionRow ? $this->mapNormVersionRow($versionRow) : null,
-        ], $status === 'success' ? 200 : 422);
+        return response()->json($result['payload'], $result['status']);
     }
 
-    public function driftCheckNorms(Request $request, int $org_id): JsonResponse
+    public function driftCheckNorms(BigFiveOpsRequest $request, int $org_id): JsonResponse
     {
-        $from = trim((string) $request->input('from', ''));
-        $to = trim((string) $request->input('to', ''));
-        if ($from === '' || $to === '') {
-            return response()->json([
-                'ok' => false,
-                'error_code' => 'INVALID_ARGUMENT',
-                'message' => 'from and to are required.',
-            ], 422);
-        }
+        $result = $this->actionService->driftCheckNorms($org_id, $request->validated(), $this->requestContext($request));
 
-        $groupId = trim((string) $request->input('group_id', ''));
-        $thresholdMean = trim((string) $request->input('threshold_mean', '0.35'));
-        $thresholdSd = trim((string) $request->input('threshold_sd', '0.35'));
-
-        $args = [
-            '--scale' => 'BIG5_OCEAN',
-            '--from' => $from,
-            '--to' => $to,
-            '--threshold_mean' => $thresholdMean === '' ? '0.35' : $thresholdMean,
-            '--threshold_sd' => $thresholdSd === '' ? '0.35' : $thresholdSd,
-        ];
-        if ($groupId !== '') {
-            $args['--group_id'] = $groupId;
-        }
-
-        $exitCode = Artisan::call('norms:big5:drift-check', $args);
-        $commandOutput = trim(Artisan::output());
-        $status = $exitCode === 0 ? 'success' : 'failed';
-        $reason = $status === 'success' ? null : 'DRIFT_CHECK_FAILED';
-
-        $this->recordOpsAudit(
-            $request,
-            'big5_norms_drift_check',
-            'norms_group',
-            $groupId === '' ? 'all' : $groupId,
-            $status,
-            $reason,
-            [
-                'org_id' => $org_id,
-                'scale_code' => 'BIG5_OCEAN',
-                'from' => $from,
-                'to' => $to,
-                'group_id' => $groupId,
-                'threshold_mean' => (float) ($thresholdMean === '' ? 0.35 : $thresholdMean),
-                'threshold_sd' => (float) ($thresholdSd === '' ? 0.35 : $thresholdSd),
-                'exit_code' => $exitCode,
-                'output' => $commandOutput,
-            ]
-        );
-
-        return response()->json([
-            'ok' => $status === 'success',
-            'org_id' => $org_id,
-            'action' => 'norms_drift_check',
-            'status' => $status,
-            'exit_code' => $exitCode,
-            'message' => $commandOutput,
-        ], $status === 'success' ? 200 : 422);
+        return response()->json($result['payload'], $result['status']);
     }
 
-    public function activateNorms(Request $request, int $org_id): JsonResponse
+    public function activateNorms(BigFiveOpsRequest $request, int $org_id): JsonResponse
     {
-        $groupId = trim((string) $request->input('group_id', ''));
-        $normsVersion = trim((string) $request->input('norms_version', ''));
-        $region = $this->normalizeRegion((string) $request->input('region', 'CN_MAINLAND'));
-        $locale = $this->normalizeLocale((string) $request->input('locale', 'zh-CN'));
+        $result = $this->actionService->activateNorms($org_id, $request->validated(), $this->requestContext($request));
 
-        if ($groupId === '' || $normsVersion === '') {
-            return response()->json([
-                'ok' => false,
-                'error_code' => 'INVALID_ARGUMENT',
-                'message' => 'group_id and norms_version are required.',
-            ], 422);
-        }
-
-        try {
-            $updated = DB::transaction(function () use ($groupId, $normsVersion, $region, $locale): ?object {
-                $target = DB::table('scale_norms_versions')
-                    ->where('scale_code', 'BIG5_OCEAN')
-                    ->where('group_id', $groupId)
-                    ->where('version', $normsVersion)
-                    ->where('region', $region)
-                    ->where('locale', $locale)
-                    ->first();
-                if (! $target) {
-                    return null;
-                }
-
-                DB::table('scale_norms_versions')
-                    ->where('scale_code', 'BIG5_OCEAN')
-                    ->where('group_id', $groupId)
-                    ->update([
-                        'is_active' => 0,
-                        'updated_at' => now(),
-                    ]);
-
-                DB::table('scale_norms_versions')
-                    ->where('id', (string) $target->id)
-                    ->update([
-                        'is_active' => 1,
-                        'updated_at' => now(),
-                    ]);
-
-                return DB::table('scale_norms_versions')
-                    ->where('id', (string) $target->id)
-                    ->first();
-            });
-        } catch (Throwable $e) {
-            $this->recordOpsAudit(
-                $request,
-                'big5_norms_activate',
-                'norms_group',
-                $groupId,
-                'failed',
-                'ACTIVATE_FAILED',
-                [
-                    'org_id' => $org_id,
-                    'scale_code' => 'BIG5_OCEAN',
-                    'group_id' => $groupId,
-                    'norms_version' => $normsVersion,
-                    'region' => $region,
-                    'locale' => $locale,
-                    'error_message' => $e->getMessage(),
-                ]
-            );
-
-            return response()->json([
-                'ok' => false,
-                'error_code' => 'ACTIVATE_FAILED',
-                'message' => $e->getMessage(),
-            ], 500);
-        }
-
-        if (! $updated) {
-            $this->recordOpsAudit(
-                $request,
-                'big5_norms_activate',
-                'norms_group',
-                $groupId,
-                'failed',
-                'NORM_VERSION_NOT_FOUND',
-                [
-                    'org_id' => $org_id,
-                    'scale_code' => 'BIG5_OCEAN',
-                    'group_id' => $groupId,
-                    'norms_version' => $normsVersion,
-                    'region' => $region,
-                    'locale' => $locale,
-                ]
-            );
-
-            return response()->json([
-                'ok' => false,
-                'error_code' => 'NORM_VERSION_NOT_FOUND',
-                'message' => 'norm version not found.',
-            ], 404);
-        }
-
-        $this->recordOpsAudit(
-            $request,
-            'big5_norms_activate',
-            'norms_group',
-            $groupId,
-            'success',
-            null,
-            [
-                'org_id' => $org_id,
-                'scale_code' => 'BIG5_OCEAN',
-                'group_id' => $groupId,
-                'norms_version' => $normsVersion,
-                'region' => $region,
-                'locale' => $locale,
-                'norm_version_id' => (string) ($updated->id ?? ''),
-            ]
-        );
-
-        return response()->json([
-            'ok' => true,
-            'org_id' => $org_id,
-            'action' => 'norms_activate',
-            'status' => 'success',
-            'item' => $this->mapNormVersionRow($updated),
-        ]);
-    }
-
-    private function normalizeRegion(string $region): string
-    {
-        $normalized = strtoupper(trim($region));
-        if ($normalized === '') {
-            return 'CN_MAINLAND';
-        }
-
-        return $normalized;
-    }
-
-    private function normalizeLocale(string $locale): string
-    {
-        $normalized = trim($locale);
-        if ($normalized === '') {
-            return 'zh-CN';
-        }
-
-        return $normalized;
-    }
-
-    private function normalizeDirAlias(string $dirAlias): string
-    {
-        $normalized = trim($dirAlias);
-        if ($normalized === '') {
-            return 'v1';
-        }
-
-        return $normalized;
-    }
-
-    private function resolveActor(Request $request, int $orgId): string
-    {
-        $fmUserId = $request->attributes->get('fm_user_id');
-        $userId = is_numeric($fmUserId) ? (string) (int) $fmUserId : trim((string) $fmUserId);
-        if ($userId === '') {
-            $userId = '0';
-        }
-
-        return "ops_user:{$userId}@org:{$orgId}";
-    }
-
-    private function toBool(mixed $value): bool
-    {
-        if (is_bool($value)) {
-            return $value;
-        }
-        if (is_numeric($value)) {
-            return ((int) $value) === 1;
-        }
-
-        $normalized = strtolower(trim((string) $value));
-
-        return in_array($normalized, ['1', 'true', 'yes', 'on'], true);
-    }
-
-    private function resolveGroupId(string $locale, string $group): string
-    {
-        if (str_starts_with($group, $locale.'_')) {
-            return $group;
-        }
-
-        return $locale.'_'.$group;
-    }
-
-    private function latestRelease(string $action, string $region, string $locale, string $dirAlias, \Carbon\CarbonInterface $startedAt): ?object
-    {
-        return DB::table('content_pack_releases')
-            ->where('action', $action)
-            ->where('region', $region)
-            ->where('locale', $locale)
-            ->where('dir_alias', $dirAlias)
-            ->where(function ($q): void {
-                $q->where('to_pack_id', 'BIG5_OCEAN')
-                    ->orWhere('from_pack_id', 'BIG5_OCEAN');
-            })
-            ->where('created_at', '>=', $startedAt->copy()->subSeconds(2))
-            ->orderByDesc('created_at')
-            ->orderByDesc('updated_at')
-            ->first();
-    }
-
-    private function extractCommandValue(string $output, string $key): string
-    {
-        $needle = $key.'=';
-        foreach (preg_split('/\\r\\n|\\r|\\n/', $output) as $line) {
-            $line = trim((string) $line);
-            if ($line === '' || ! str_starts_with($line, $needle)) {
-                continue;
-            }
-
-            return trim(substr($line, strlen($needle)));
-        }
-
-        return '';
+        return response()->json($result['payload'], $result['status']);
     }
 
     /**
      * @return array<string,mixed>
      */
-    private function mapNormVersionRow(object $row): array
+    private function requestContext(BigFiveOpsRequest $request): array
     {
         return [
-            'id' => (string) ($row->id ?? ''),
-            'scale_code' => (string) ($row->scale_code ?? ''),
-            'region' => (string) ($row->region ?? ''),
-            'locale' => (string) ($row->locale ?? ''),
-            'group_id' => (string) ($row->group_id ?? ''),
-            'norms_version' => (string) ($row->version ?? ''),
-            'status' => (string) ($row->status ?? ''),
-            'is_active' => (bool) ($row->is_active ?? false),
-            'source_id' => (string) ($row->source_id ?? ''),
-            'source_type' => (string) ($row->source_type ?? ''),
-            'published_at' => (string) ($row->published_at ?? ''),
-            'updated_at' => (string) ($row->updated_at ?? ''),
+            'fm_user_id' => $request->attributes->get('fm_user_id'),
+            'ip' => (string) $request->ip(),
+            'user_agent' => (string) $request->userAgent(),
+            'request_id' => (string) $request->headers->get('X-Request-Id', ''),
         ];
-    }
-
-    /**
-     * @param  array<string,mixed>  $meta
-     */
-    private function recordOpsAudit(
-        Request $request,
-        string $action,
-        string $targetType,
-        string $targetId,
-        string $result,
-        ?string $reason,
-        array $meta
-    ): void {
-        DB::table('audit_logs')->insert([
-            'actor_admin_id' => null,
-            'action' => $action,
-            'target_type' => $targetType,
-            'target_id' => $targetId,
-            'meta_json' => json_encode($meta, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES),
-            'ip' => substr((string) $request->ip(), 0, 64),
-            'user_agent' => substr((string) $request->userAgent(), 0, 255),
-            'request_id' => substr((string) $request->headers->get('X-Request-Id', ''), 0, 128),
-            'reason' => $reason,
-            'result' => $result,
-            'created_at' => now(),
-        ]);
-    }
-
-    /**
-     * @return array<string,mixed>
-     */
-    private function mapReleaseRow(object $row): array
-    {
-        return [
-            'release_id' => (string) ($row->id ?? ''),
-            'action' => (string) ($row->action ?? ''),
-            'status' => (string) ($row->status ?? ''),
-            'message' => (string) ($row->message ?? ''),
-            'dir_alias' => (string) ($row->dir_alias ?? ''),
-            'region' => (string) ($row->region ?? ''),
-            'locale' => (string) ($row->locale ?? ''),
-            'from_pack_id' => (string) ($row->from_pack_id ?? ''),
-            'to_pack_id' => (string) ($row->to_pack_id ?? ''),
-            'from_version_id' => (string) ($row->from_version_id ?? ''),
-            'to_version_id' => (string) ($row->to_version_id ?? ''),
-            'created_by' => (string) ($row->created_by ?? ''),
-            'created_at' => (string) ($row->created_at ?? ''),
-            'updated_at' => (string) ($row->updated_at ?? ''),
-            'evidence' => [
-                'manifest_hash' => (string) ($row->manifest_hash ?? ''),
-                'compiled_hash' => (string) ($row->compiled_hash ?? ''),
-                'content_hash' => (string) ($row->content_hash ?? ''),
-                'norms_version' => (string) ($row->norms_version ?? ''),
-                'git_sha' => (string) ($row->git_sha ?? ''),
-            ],
-        ];
-    }
-
-    /**
-     * @return array<string,mixed>
-     */
-    private function mapAuditRow(object $row): array
-    {
-        return [
-            'id' => (int) ($row->id ?? 0),
-            'action' => (string) ($row->action ?? ''),
-            'result' => (string) ($row->result ?? ''),
-            'reason' => (string) ($row->reason ?? ''),
-            'target_type' => (string) ($row->target_type ?? ''),
-            'target_id' => (string) ($row->target_id ?? ''),
-            'request_id' => (string) ($row->request_id ?? ''),
-            'created_at' => (string) ($row->created_at ?? ''),
-            'meta' => $this->decodeJson((string) ($row->meta_json ?? '')),
-        ];
-    }
-
-    /**
-     * @return array<string,mixed>
-     */
-    private function decodeJson(string $json): array
-    {
-        $decoded = json_decode($json, true);
-
-        return is_array($decoded) ? $decoded : [];
     }
 }

--- a/backend/app/Http/Controllers/API/V0_3/CommerceController.php
+++ b/backend/app/Http/Controllers/API/V0_3/CommerceController.php
@@ -51,6 +51,7 @@ class CommerceController extends Controller
         $payload = $request->validate([
             'sku' => ['required', 'string', 'max:64'],
             'quantity' => ['nullable', 'integer', 'min:1', 'max:1000'],
+            'email' => ['nullable', 'string', 'max:320'],
             'target_attempt_id' => ['nullable', 'string', 'max:64'],
             'provider' => ['nullable', 'string', 'max:32'],
             'idempotency_key' => ['nullable', 'string', 'max:128'],
@@ -65,6 +66,10 @@ class CommerceController extends Controller
         $orgId = $this->orgContext->orgId();
         $userId = $this->orgContext->userId();
         $anonId = $this->resolveAnonId($request);
+        $contactEmail = $this->resolveContactEmail($payload, $userId !== null ? (string) $userId : null);
+        if ($userId === null && $contactEmail === null) {
+            abort(422, 'email is required.');
+        }
 
         $provider = $this->resolveProvider($payload, $providerFromRoute);
         if ($provider === '') {
@@ -81,7 +86,8 @@ class CommerceController extends Controller
             (int) ($payload['quantity'] ?? 1),
             $payload['target_attempt_id'] ?? null,
             $provider,
-            $idempotencyKey
+            $idempotencyKey,
+            $contactEmail
         );
 
         if (!($result['ok'] ?? false)) {
@@ -104,7 +110,7 @@ class CommerceController extends Controller
         $orgId = $this->orgContext->orgId();
         $userId = $this->orgContext->userId();
         $anonId = $this->resolveAnonId($request);
-        $result = $this->orders->getOrder($orgId, $userId !== null ? (string) $userId : null, $anonId, $order_no, true);
+        $result = $this->orders->getOrder($orgId, $userId !== null ? (string) $userId : null, $anonId, $order_no, false);
         if (!($result['ok'] ?? false)) {
             $status = $this->mapErrorStatus((string) data_get($result, 'error_code', data_get($result, 'error', '')));
             $message = trim((string) ($result['message'] ?? ''));
@@ -118,14 +124,10 @@ class CommerceController extends Controller
 
         if (!$ownershipVerified) {
             return response()->json([
-                'ok' => true,
-                'ownership_verified' => false,
-                'order_no' => $order->order_no ?? null,
-                'attempt_id' => $order->target_attempt_id ?? null,
-                'status' => $status,
-                'updated_at' => $order->updated_at ?? null,
-                'message' => $message,
-            ]);
+                'ok' => false,
+                'error_code' => 'ORDER_NOT_FOUND',
+                'message' => 'order not found.',
+            ], 404);
         }
 
         return response()->json([
@@ -149,6 +151,7 @@ class CommerceController extends Controller
         $payload = $request->validate([
             'attempt_id' => ['nullable', 'string', 'max:64'],
             'sku' => ['nullable', 'string', 'max:64'],
+            'email' => ['nullable', 'string', 'max:320'],
             'order_no' => ['nullable', 'string', 'max:64'],
             'provider' => ['nullable', 'string', 'max:32'],
             'idempotency_key' => ['nullable', 'string', 'max:128'],
@@ -157,6 +160,10 @@ class CommerceController extends Controller
         $orgId = $this->orgContext->orgId();
         $userId = $this->orgContext->userId();
         $anonId = $this->resolveAnonId($request);
+        $contactEmail = $this->resolveContactEmail($payload, $userId !== null ? (string) $userId : null);
+        if ($userId === null && $contactEmail === null) {
+            abort(422, 'email is required.');
+        }
 
         $existingOrderNo = trim((string) ($payload['order_no'] ?? ''));
         if ($existingOrderNo !== '') {
@@ -202,7 +209,8 @@ class CommerceController extends Controller
             1,
             $attemptId !== '' ? $attemptId : null,
             $provider,
-            $idempotencyKey
+            $idempotencyKey,
+            $contactEmail
         );
 
         if (!($created['ok'] ?? false)) {
@@ -228,18 +236,30 @@ class CommerceController extends Controller
     {
         $payload = $request->validate([
             'order_no' => ['required', 'string', 'max:64'],
-            'email' => ['required', 'string', 'max:320'],
+            'email' => ['nullable', 'string', 'max:320'],
         ]);
 
         $orderNo = trim((string) ($payload['order_no'] ?? ''));
         $orgId = $this->orgContext->orgId();
+        $userId = $this->orgContext->userId();
+        $anonId = $this->resolveAnonId($request);
+        $contactEmailHash = $this->hashContactEmail((string) ($payload['email'] ?? ''));
 
-        $query = DB::table('orders')->where('order_no', $orderNo);
-        if ($orgId > 0) {
-            $query->where('org_id', $orgId);
+        if ($userId === null && $anonId === null && $contactEmailHash === null) {
+            return response()->json([
+                'ok' => false,
+                'error_code' => 'VALIDATION_FAILED',
+                'message' => 'email is required when identity is missing.',
+            ], 422);
         }
 
-        $order = $query->first();
+        $order = $this->orders->findLookupOrder(
+            $orgId,
+            $userId !== null ? (string) $userId : null,
+            $anonId,
+            $orderNo,
+            $contactEmailHash
+        );
         if (!$order) {
             return response()->json([
                 'ok' => false,
@@ -282,6 +302,7 @@ class CommerceController extends Controller
     {
         return match ($code) {
             'SKU_NOT_FOUND', 'ORDER_NOT_FOUND' => 404,
+            'EMAIL_REQUIRED' => 422,
             'TABLE_MISSING' => 500,
             default => 400,
         };
@@ -293,6 +314,7 @@ class CommerceController extends Controller
             $this->orgContext->anonId(),
             $request->attributes->get('anon_id'),
             $request->attributes->get('fm_anon_id'),
+            $request->attributes->get('client_anon_id'),
         ];
 
         foreach ($candidates as $candidate) {
@@ -397,6 +419,47 @@ class CommerceController extends Controller
 
         $sku = trim((string) $sku);
         return $sku !== '' ? strtoupper($sku) : '';
+    }
+
+    private function resolveContactEmail(array $payload, ?string $userId): ?string
+    {
+        $inputEmail = $this->normalizeEmail((string) ($payload['email'] ?? ''));
+        if ($inputEmail !== null) {
+            return $inputEmail;
+        }
+
+        $uid = trim((string) $userId);
+        if ($uid === '' || preg_match('/^\d+$/', $uid) !== 1) {
+            return null;
+        }
+
+        $dbEmail = DB::table('users')->where('id', (int) $uid)->value('email');
+
+        return $this->normalizeEmail((string) ($dbEmail ?? ''));
+    }
+
+    private function hashContactEmail(string $email): ?string
+    {
+        $normalized = $this->normalizeEmail($email);
+        if ($normalized === null) {
+            return null;
+        }
+
+        return hash('sha256', $normalized);
+    }
+
+    private function normalizeEmail(string $email): ?string
+    {
+        $email = mb_strtolower(trim($email), 'UTF-8');
+        if ($email === '') {
+            return null;
+        }
+
+        if (filter_var($email, FILTER_VALIDATE_EMAIL) === false) {
+            return null;
+        }
+
+        return $email;
     }
 
     private function normalizePublicOrderStatus(string $status): string

--- a/backend/app/Http/Controllers/API/V0_3/CommerceController.php
+++ b/backend/app/Http/Controllers/API/V0_3/CommerceController.php
@@ -67,7 +67,7 @@ class CommerceController extends Controller
         $userId = $this->orgContext->userId();
         $anonId = $this->resolveAnonId($request);
         $contactEmail = $this->resolveContactEmail($payload, $userId !== null ? (string) $userId : null);
-        if ($userId === null && $contactEmail === null) {
+        if ($userId === null && $anonId === null && $contactEmail === null) {
             abort(422, 'email is required.');
         }
 
@@ -161,7 +161,7 @@ class CommerceController extends Controller
         $userId = $this->orgContext->userId();
         $anonId = $this->resolveAnonId($request);
         $contactEmail = $this->resolveContactEmail($payload, $userId !== null ? (string) $userId : null);
-        if ($userId === null && $contactEmail === null) {
+        if ($userId === null && $anonId === null && $contactEmail === null) {
             abort(422, 'email is required.');
         }
 

--- a/backend/app/Http/Controllers/MbtiController.php
+++ b/backend/app/Http/Controllers/MbtiController.php
@@ -2,13 +2,20 @@
 
 namespace App\Http\Controllers;
 
+use App\DTO\Legacy\LegacyRequestContext;
+use App\Http\Requests\V0_3\LegacyStartAttemptRequest;
+use App\Http\Requests\V0_3\LegacyStoreAttemptRequest;
 use App\Services\Legacy\LegacyMbtiAttemptService;
+use App\Support\OrgContext;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
 
 class MbtiController extends Controller
 {
-    public function __construct(private LegacyMbtiAttemptService $service) {}
+    public function __construct(
+        private readonly LegacyMbtiAttemptService $service,
+        private readonly OrgContext $orgContext,
+    ) {}
 
     public function health(): JsonResponse
     {
@@ -33,19 +40,35 @@ class MbtiController extends Controller
         return response()->json($payload);
     }
 
-    public function startAttempt(Request $request): JsonResponse
+    public function startAttempt(LegacyStartAttemptRequest $request): JsonResponse
     {
-        return $this->toJson($this->service->startAttempt($request));
+        return $this->toJson(
+            $this->service->startAttempt(
+                $request->validated(),
+                LegacyRequestContext::fromRequest($request, $this->orgContext),
+            )
+        );
     }
 
-    public function storeAttempt(Request $request): JsonResponse
+    public function storeAttempt(LegacyStoreAttemptRequest $request): JsonResponse
     {
-        return $this->toJson($this->service->storeAttempt($request));
+        return $this->toJson(
+            $this->service->storeAttempt(
+                $request->validated(),
+                LegacyRequestContext::fromRequest($request, $this->orgContext),
+            )
+        );
     }
 
-    public function upsertResult(Request $request, string $attemptId): JsonResponse
+    public function upsertResult(LegacyStoreAttemptRequest $request, string $attemptId): JsonResponse
     {
-        return $this->toJson($this->service->upsertResult($request, $attemptId));
+        return $this->toJson(
+            $this->service->upsertResult(
+                $request->validated(),
+                $attemptId,
+                LegacyRequestContext::fromRequest($request, $this->orgContext),
+            )
+        );
     }
 
     private function toJson(array $payload): JsonResponse

--- a/backend/app/Http/Middleware/FmTokenAuth.php
+++ b/backend/app/Http/Middleware/FmTokenAuth.php
@@ -48,26 +48,6 @@ class FmTokenAuth
             ->first();
 
         if (!$row) {
-            $row = DB::table('fm_tokens')
-                ->select($select)
-                ->where('token', $token)
-                ->first();
-
-            if ($row) {
-                $currentHash = trim((string) ($row->token_hash ?? ''));
-                if ($currentHash === '') {
-                    DB::table('fm_tokens')
-                        ->where('token', $token)
-                        ->update([
-                            'token_hash' => $tokenHash,
-                            'updated_at' => now(),
-                        ]);
-                    $row->token_hash = $tokenHash;
-                }
-            }
-        }
-
-        if (!$row) {
             return $this->unauthorizedResponse($request, 'token_not_found');
         }
 
@@ -127,11 +107,7 @@ class FmTokenAuth
         $request->attributes->set('org_id', $orgId);
         $request->attributes->set('org_role', $role);
 
-        $dispatchHash = trim((string) ($row->token_hash ?? ''));
-        if ($dispatchHash === '') {
-            $dispatchHash = $tokenHash;
-        }
-        TouchFmTokenLastUsedAtJob::dispatch($dispatchHash)->onQueue('ops');
+        TouchFmTokenLastUsedAtJob::dispatch($tokenHash)->onQueue('ops');
 
         $ctx = new OrgContext();
         $ctx->set(

--- a/backend/app/Http/Middleware/FmTokenOptional.php
+++ b/backend/app/Http/Middleware/FmTokenOptional.php
@@ -60,26 +60,6 @@ class FmTokenOptional
             ->first();
 
         if (!$row) {
-            $row = DB::table('fm_tokens')
-                ->select($select)
-                ->where('token', $token)
-                ->first();
-
-            if ($row) {
-                $currentHash = trim((string) ($row->token_hash ?? ''));
-                if ($currentHash === '') {
-                    DB::table('fm_tokens')
-                        ->where('token', $token)
-                        ->update([
-                            'token_hash' => $tokenHash,
-                            'updated_at' => now(),
-                        ]);
-                    $row->token_hash = $tokenHash;
-                }
-            }
-        }
-
-        if (!$row) {
             return $next($request);
         }
 

--- a/backend/app/Http/Middleware/FmTokenOptionalAuth.php
+++ b/backend/app/Http/Middleware/FmTokenOptionalAuth.php
@@ -44,7 +44,6 @@ class FmTokenOptionalAuth
         $tokenHash = hash('sha256', $token);
         $select = [
             'token_hash',
-            'token',
             'user_id',
             'anon_id',
             'expires_at',
@@ -55,25 +54,6 @@ class FmTokenOptionalAuth
             ->select($select)
             ->where('token_hash', $tokenHash)
             ->first();
-        if (!$row) {
-            $row = DB::table('fm_tokens')
-                ->select($select)
-                ->where('token', $token)
-                ->first();
-
-            if ($row) {
-                $currentHash = trim((string) ($row->token_hash ?? ''));
-                if ($currentHash === '') {
-                    DB::table('fm_tokens')
-                        ->where('token', $token)
-                        ->update([
-                            'token_hash' => $tokenHash,
-                            'updated_at' => now(),
-                        ]);
-                    $row->token_hash = $tokenHash;
-                }
-            }
-        }
 
         if (!$row) {
             return $this->unauthorizedResponse();

--- a/backend/app/Http/Requests/V0_3/BigFiveOpsRequest.php
+++ b/backend/app/Http/Requests/V0_3/BigFiveOpsRequest.php
@@ -1,0 +1,59 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Requests\V0_3;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+final class BigFiveOpsRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    public function rules(): array
+    {
+        return [
+            'region' => ['sometimes', 'string', 'max:64'],
+            'locale' => ['sometimes', 'string', 'max:32'],
+            'action' => ['sometimes', 'string', 'max:64'],
+            'release_action' => ['sometimes', 'string', 'max:64'],
+            'result' => ['sometimes', 'string', 'max:32'],
+            'release_id' => ['sometimes', 'string', 'max:128'],
+            'limit' => ['sometimes', 'integer', 'min:1', 'max:100'],
+
+            'dir_alias' => ['sometimes', 'string', 'max:128'],
+            'pack' => ['sometimes', 'string', 'max:128'],
+            'pack_version' => ['sometimes', 'string', 'max:128'],
+            'probe' => ['sometimes', 'boolean'],
+            'skip_drift' => ['sometimes', 'boolean'],
+            'base_url' => ['sometimes', 'string', 'max:512'],
+            'to_release_id' => ['sometimes', 'string', 'max:128'],
+
+            'drift_from' => ['sometimes', 'string', 'max:128'],
+            'drift_to' => ['sometimes', 'string', 'max:128'],
+            'drift_group_id' => ['sometimes', 'string', 'max:128'],
+            'drift_threshold_mean' => ['sometimes', 'string', 'max:32'],
+            'drift_threshold_sd' => ['sometimes', 'string', 'max:32'],
+
+            'group' => ['sometimes', 'string', 'max:128'],
+            'group_id' => ['sometimes', 'string', 'max:128'],
+            'gender' => ['sometimes', 'string', 'max:16'],
+            'age_min' => ['sometimes', 'integer', 'min:1'],
+            'age_max' => ['sometimes', 'integer', 'min:1'],
+            'window_days' => ['sometimes', 'integer', 'min:1'],
+            'min_samples' => ['sometimes', 'integer', 'min:1'],
+            'only_quality' => ['sometimes', 'string', 'max:16'],
+            'norms_version' => ['sometimes', 'string', 'max:128'],
+            'activate' => ['sometimes', 'boolean'],
+            'dry_run' => ['sometimes', 'boolean'],
+
+            'from' => ['sometimes', 'string', 'max:128'],
+            'to' => ['sometimes', 'string', 'max:128'],
+            'threshold_mean' => ['sometimes', 'numeric'],
+            'threshold_sd' => ['sometimes', 'numeric'],
+        ];
+    }
+}

--- a/backend/app/Http/Requests/V0_3/LegacyStartAttemptRequest.php
+++ b/backend/app/Http/Requests/V0_3/LegacyStartAttemptRequest.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Requests\V0_3;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class LegacyStartAttemptRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    public function rules(): array
+    {
+        return [
+            'anon_id' => ['required', 'string', 'max:64'],
+            'scale_code' => ['required', 'string', 'in:MBTI'],
+            'scale_version' => ['required', 'string', 'in:v0.3'],
+            'question_count' => ['required', 'integer', 'in:24,93,144'],
+            'client_platform' => ['required', 'string', 'max:32'],
+            'client_version' => ['nullable', 'string', 'max:32'],
+            'channel' => ['nullable', 'string', 'max:32'],
+            'referrer' => ['nullable', 'string', 'max:255'],
+            'meta_json' => ['sometimes', 'array'],
+        ];
+    }
+}

--- a/backend/app/Http/Requests/V0_3/LegacyStoreAttemptRequest.php
+++ b/backend/app/Http/Requests/V0_3/LegacyStoreAttemptRequest.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Requests\V0_3;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class LegacyStoreAttemptRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    public function rules(): array
+    {
+        return [
+            'anon_id' => ['required', 'string', 'max:64'],
+            'scale_code' => ['required', 'string', 'in:MBTI'],
+            'scale_version' => ['required', 'string', 'in:v0.3'],
+            'answers' => ['required', 'array', 'min:1'],
+            'answers.*.question_id' => ['required', 'string'],
+            'answers.*.code' => ['required', 'string', 'in:A,B,C,D,E'],
+            'client_platform' => ['nullable', 'string', 'max:32'],
+            'client_version' => ['nullable', 'string', 'max:32'],
+            'channel' => ['nullable', 'string', 'max:32'],
+            'referrer' => ['nullable', 'string', 'max:255'],
+            'region' => ['nullable', 'string', 'max:32'],
+            'locale' => ['nullable', 'string', 'max:16'],
+            'attempt_id' => ['nullable', 'string', 'max:64'],
+            'demographics' => ['sometimes', 'array'],
+        ];
+    }
+}

--- a/backend/app/Jobs/Commerce/RefundOrderJob.php
+++ b/backend/app/Jobs/Commerce/RefundOrderJob.php
@@ -22,6 +22,10 @@ class RefundOrderJob implements ShouldQueue
 
     public int $tries = 3;
 
+    public int $timeout = 120;
+
+    public bool $failOnTimeout = true;
+
     /** @var array<int,int> */
     public array $backoff = [10, 30, 60];
 
@@ -31,7 +35,7 @@ class RefundOrderJob implements ShouldQueue
         public string $reason,
         public string $correlationId,
     ) {
-        $this->onConnection('database');
+        $this->onConnection('database_commerce');
         $this->onQueue('commerce');
     }
 

--- a/backend/app/Jobs/GenerateReportPdfJob.php
+++ b/backend/app/Jobs/GenerateReportPdfJob.php
@@ -25,6 +25,10 @@ final class GenerateReportPdfJob implements ShouldQueue
 
     public int $tries = 3;
 
+    public int $timeout = 150;
+
+    public bool $failOnTimeout = true;
+
     /** @var array<int, int> */
     public array $backoff = [5, 10, 20];
 
@@ -34,7 +38,7 @@ final class GenerateReportPdfJob implements ShouldQueue
         public string $triggerSource,
         public ?string $orderNo = null,
     ) {
-        $this->onConnection('database');
+        $this->onConnection('database_reports');
         $this->onQueue('reports');
     }
 

--- a/backend/app/Jobs/GenerateReportSnapshotJob.php
+++ b/backend/app/Jobs/GenerateReportSnapshotJob.php
@@ -19,6 +19,10 @@ class GenerateReportSnapshotJob implements ShouldQueue
 
     public int $tries = 3;
 
+    public int $timeout = 150;
+
+    public bool $failOnTimeout = true;
+
     /** @var array<int, int> */
     public array $backoff = [5, 10, 20];
 
@@ -28,7 +32,7 @@ class GenerateReportSnapshotJob implements ShouldQueue
         public string $triggerSource,
         public ?string $orderNo = null,
     ) {
-        $this->onConnection('database');
+        $this->onConnection('database_reports');
         $this->onQueue('reports');
     }
 

--- a/backend/app/Services/Attempts/AttemptStartService.php
+++ b/backend/app/Services/Attempts/AttemptStartService.php
@@ -36,8 +36,6 @@ class AttemptStartService
         private Eq60PackLoader $eq60PackLoader,
         private AttemptRateLimitService $attemptRateLimitService,
         private AttemptProgressService $progressService,
-        private EventRecorder $eventRecorder,
-        private BigFiveTelemetry $bigFiveTelemetry,
     ) {}
 
     public function start(OrgContext $ctx, StartAttemptDTO $dto): array
@@ -250,7 +248,7 @@ class AttemptStartService
             $attempt->save();
         }
 
-        $this->eventRecorder->record('test_start', $ctx->userId(), [
+        $this->eventRecorder()->record('test_start', $ctx->userId(), [
             'scale_code' => $scaleCode,
             'scale_code_v2' => $scaleCodeV2,
             'scale_uid' => $scaleUid,
@@ -271,7 +269,7 @@ class AttemptStartService
         ]);
 
         if (strtoupper($scaleCode) === 'BIG5_OCEAN') {
-            $this->bigFiveTelemetry->recordAttemptStarted(
+            $this->bigFiveTelemetry()->recordAttemptStarted(
                 $orgId,
                 $ctx->userId(),
                 $anonId,
@@ -312,6 +310,16 @@ class AttemptStartService
             'resume_token' => (string) ($draft['token'] ?? ''),
             'resume_expires_at' => ! empty($draft['expires_at']) ? $draft['expires_at']->toISOString() : null,
         ];
+    }
+
+    private function eventRecorder(): EventRecorder
+    {
+        return app(EventRecorder::class);
+    }
+
+    private function bigFiveTelemetry(): BigFiveTelemetry
+    {
+        return app(BigFiveTelemetry::class);
     }
 
     private function runtimePolicy(): ScaleIdentityRuntimePolicy

--- a/backend/app/Services/Attempts/AttemptSubmitService.php
+++ b/backend/app/Services/Attempts/AttemptSubmitService.php
@@ -32,7 +32,6 @@ class AttemptSubmitService
         private AssessmentRunner $assessmentRunner,
         private AttemptSubmitSideEffects $sideEffects,
         private ReportGatekeeper $reportGatekeeper,
-        private BigFiveTelemetry $bigFiveTelemetry,
         private AttemptDurationResolver $durationResolver,
         private ScaleIdentityResolver $identityResolver,
     ) {}
@@ -538,7 +537,7 @@ class AttemptSubmitService
             $normsPayload = is_array($scorePayload['norms'] ?? null) ? $scorePayload['norms'] : [];
             $qualityPayload = is_array($scorePayload['quality'] ?? null) ? $scorePayload['quality'] : [];
 
-            $this->bigFiveTelemetry->recordAttemptSubmitted(
+            $this->bigFiveTelemetry()->recordAttemptSubmitted(
                 $orgId,
                 $this->numericUserId($actorUserId),
                 $actorAnonId,
@@ -588,6 +587,11 @@ class AttemptSubmitService
         }
 
         return $responsePayload;
+    }
+
+    private function bigFiveTelemetry(): BigFiveTelemetry
+    {
+        return app(BigFiveTelemetry::class);
     }
 
     private function enforceConsentOnSubmit(string $scaleCode, Attempt $attempt, SubmitAttemptDTO $dto): void

--- a/backend/app/Services/Auth/FmTokenService.php
+++ b/backend/app/Services/Auth/FmTokenService.php
@@ -24,6 +24,7 @@ class FmTokenService
 
         $token = 'fm_' . (string) Str::uuid();
         $tokenHash = hash('sha256', $token);
+        $tokenStorageKey = $this->tokenStorageKey($tokenHash);
 
         $ttlDays = (int) config('fap.fm_token_ttl_days', 30);
         if ($ttlDays <= 0) {
@@ -60,7 +61,7 @@ class FmTokenService
         }
 
         DB::table('fm_tokens')->insert([
-            'token' => $token,
+            'token' => $tokenStorageKey,
             'token_hash' => $tokenHash,
             'user_id' => $persistedUserId,
             'anon_id' => $anonId,
@@ -97,25 +98,6 @@ class FmTokenService
         $row = DB::table('fm_tokens')
             ->where('token_hash', $tokenHash)
             ->first();
-
-        if (!$row) {
-            $row = DB::table('fm_tokens')
-                ->where('token', $token)
-                ->first();
-
-            if ($row) {
-                $currentHash = trim((string) ($row->token_hash ?? ''));
-                if ($currentHash === '') {
-                    DB::table('fm_tokens')
-                        ->where('token', $token)
-                        ->update([
-                            'token_hash' => $tokenHash,
-                            'updated_at' => now(),
-                        ]);
-                    $row->token_hash = $tokenHash;
-                }
-            }
-        }
 
         if (!$row) {
             return ['ok' => false];
@@ -159,12 +141,7 @@ class FmTokenService
             $anonId = null;
         }
 
-        $dispatchHash = trim((string) ($row->token_hash ?? ''));
-        if ($dispatchHash === '') {
-            $dispatchHash = $tokenHash;
-        }
-
-        TouchFmTokenLastUsedAtJob::dispatch($dispatchHash)->onQueue('ops');
+        TouchFmTokenLastUsedAtJob::dispatch($tokenHash)->onQueue('ops');
 
         return [
             'ok' => true,
@@ -174,5 +151,10 @@ class FmTokenService
             'role' => $role,
             'anon_id' => $anonId,
         ];
+    }
+
+    private function tokenStorageKey(string $tokenHash): string
+    {
+        return 'retired_' . strtolower(trim($tokenHash));
     }
 }

--- a/backend/app/Services/Commerce/OrderManager.php
+++ b/backend/app/Services/Commerce/OrderManager.php
@@ -29,7 +29,8 @@ class OrderManager
         int $quantity,
         ?string $targetAttemptId,
         string $provider,
-        ?string $idempotencyKey = null
+        ?string $idempotencyKey = null,
+        ?string $contactEmail = null
     ): array {
         $requestedSku = $this->skus->normalizeSku($sku);
         if ($requestedSku === '') {
@@ -68,13 +69,20 @@ class OrderManager
             return $this->badRequest('PROVIDER_NOT_SUPPORTED', 'provider not supported.');
         }
 
+        $normalizedUserId = $this->trimOrNull($userId);
+        $normalizedAnonId = $this->trimOrNull($anonId);
+        $contactEmailHash = $this->hashContactEmail($contactEmail);
+        if ($normalizedUserId === null && $contactEmailHash === null) {
+            return $this->badRequest('EMAIL_REQUIRED', 'email is required.');
+        }
+
         $idempotencyKey = $this->normalizeIdempotencyKey($idempotencyKey);
         $useIdempotency = $idempotencyKey !== '';
 
         $createRow = function () use (
             $orgId,
-            $userId,
-            $anonId,
+            $normalizedUserId,
+            $normalizedAnonId,
             $skuToLookup,
             $quantity,
             $targetAttemptId,
@@ -86,7 +94,8 @@ class OrderManager
             $entitlementId,
             $idempotencyKey,
             $useIdempotency,
-            $modulesIncluded
+            $modulesIncluded,
+            $contactEmailHash
         ): array {
             $orderNo = 'ord_'.Str::uuid();
             $now = now();
@@ -100,8 +109,8 @@ class OrderManager
                 'id' => (string) Str::uuid(),
                 'order_no' => $orderNo,
                 'org_id' => $orgId,
-                'user_id' => $this->trimOrNull($userId),
-                'anon_id' => $this->trimOrNull($anonId),
+                'user_id' => $normalizedUserId,
+                'anon_id' => $normalizedAnonId,
                 'sku' => $skuToLookup,
                 'quantity' => $quantity,
                 'target_attempt_id' => $this->trimOrNull($targetAttemptId),
@@ -120,6 +129,9 @@ class OrderManager
                     ? json_encode($orderMeta, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES)
                     : null,
             ];
+            if (Schema::hasColumn('orders', 'contact_email_hash')) {
+                $row['contact_email_hash'] = $contactEmailHash;
+            }
 
             if ($this->shouldWriteScaleIdentityColumns() && $this->ordersTableHasIdentityColumns()) {
                 $identity = $this->resolveOrderScaleIdentity($orgId, $targetAttemptId);
@@ -180,6 +192,47 @@ class OrderManager
             'order_no' => $order->order_no ?? $row['order_no'],
             'order' => $order ?? $row,
         ];
+    }
+
+    public function findLookupOrder(
+        int $orgId,
+        ?string $userId,
+        ?string $anonId,
+        string $orderNo,
+        ?string $contactEmailHash = null
+    ): ?object {
+        $orderNo = trim($orderNo);
+        if ($orderNo === '') {
+            return null;
+        }
+
+        $query = DB::table('orders')
+            ->where('order_no', $orderNo)
+            ->where('org_id', $orgId);
+
+        $uid = $this->trimOrNull($userId);
+        $aid = $this->trimOrNull($anonId);
+        $emailHash = $this->normalizeEmailHash($contactEmailHash);
+        $canMatchByEmailHash = $emailHash !== null && Schema::hasColumn('orders', 'contact_email_hash');
+        if ($uid === null && $aid === null && ! $canMatchByEmailHash) {
+            return null;
+        }
+
+        $query->where(function ($scoped) use ($uid, $aid, $canMatchByEmailHash, $emailHash): void {
+            if ($uid !== null) {
+                $scoped->orWhere('user_id', $uid);
+            }
+
+            if ($aid !== null) {
+                $scoped->orWhere('anon_id', $aid);
+            }
+
+            if ($canMatchByEmailHash && $emailHash !== null) {
+                $scoped->orWhere('contact_email_hash', $emailHash);
+            }
+        });
+
+        return $query->first();
     }
 
     public function getOrder(
@@ -526,6 +579,40 @@ class OrderManager
         }
 
         return $key;
+    }
+
+    private function hashContactEmail(?string $email): ?string
+    {
+        $normalized = $this->normalizeEmail($email);
+        if ($normalized === null) {
+            return null;
+        }
+
+        return hash('sha256', $normalized);
+    }
+
+    private function normalizeEmail(?string $email): ?string
+    {
+        $email = mb_strtolower(trim((string) $email), 'UTF-8');
+        if ($email === '') {
+            return null;
+        }
+
+        if (filter_var($email, FILTER_VALIDATE_EMAIL) === false) {
+            return null;
+        }
+
+        return $email;
+    }
+
+    private function normalizeEmailHash(?string $hash): ?string
+    {
+        $hash = strtolower(trim((string) $hash));
+        if ($hash === '' || preg_match('/^[a-f0-9]{64}$/', $hash) !== 1) {
+            return null;
+        }
+
+        return $hash;
     }
 
     private function shouldWriteScaleIdentityColumns(): bool

--- a/backend/app/Services/Commerce/OrderManager.php
+++ b/backend/app/Services/Commerce/OrderManager.php
@@ -72,7 +72,7 @@ class OrderManager
         $normalizedUserId = $this->trimOrNull($userId);
         $normalizedAnonId = $this->trimOrNull($anonId);
         $contactEmailHash = $this->hashContactEmail($contactEmail);
-        if ($normalizedUserId === null && $contactEmailHash === null) {
+        if ($normalizedUserId === null && $normalizedAnonId === null && $contactEmailHash === null) {
             return $this->badRequest('EMAIL_REQUIRED', 'email is required.');
         }
 

--- a/backend/app/Services/Content/Publisher/ContentPackPublisher.php
+++ b/backend/app/Services/Content/Publisher/ContentPackPublisher.php
@@ -753,10 +753,7 @@ final class ContentPackPublisher
 
     private function resolveGitSha(): ?string
     {
-        $sha = trim((string) env('GITHUB_SHA', ''));
-        if ($sha === '') {
-            $sha = trim((string) env('CI_COMMIT_SHA', ''));
-        }
+        $sha = trim((string) config('app.git_sha', ''));
         if ($sha === '') {
             return null;
         }

--- a/backend/app/Services/Legacy/LegacyMbtiAttemptService.php
+++ b/backend/app/Services/Legacy/LegacyMbtiAttemptService.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Services\Legacy;
 
+use App\DTO\Legacy\LegacyRequestContext;
 use App\Exceptions\Api\ApiProblemException;
 use App\Services\Legacy\Mbti\Attempt\LegacyMbtiAttemptLifecycleService;
 use App\Services\Legacy\Mbti\Content\LegacyMbtiPackRepository;
@@ -11,7 +12,6 @@ use App\Services\Legacy\Mbti\Report\LegacyMbtiReportPayloadBuilder;
 use App\Support\CacheKeys;
 use App\Support\OrgContext;
 use Illuminate\Contracts\Cache\Repository as CacheRepository;
-use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\Log;
 
@@ -178,19 +178,28 @@ class LegacyMbtiAttemptService
         return $payload;
     }
 
-    public function startAttempt(Request $request, ?string $id = null): array
+    /**
+     * @param  array<string, mixed>  $payload
+     */
+    public function startAttempt(array $payload, LegacyRequestContext $context, ?string $id = null): array
     {
-        return $this->attemptLifecycle->startAttempt($request, $id);
+        return $this->attemptLifecycle->startAttempt($payload, $context, $id);
     }
 
-    public function storeAttempt(Request $request): array
+    /**
+     * @param  array<string, mixed>  $payload
+     */
+    public function storeAttempt(array $payload, LegacyRequestContext $context): array
     {
-        return $this->attemptLifecycle->storeAttempt($request);
+        return $this->attemptLifecycle->storeAttempt($payload, $context);
     }
 
-    public function upsertResult(Request $request, string $attemptId): array
+    /**
+     * @param  array<string, mixed>  $payload
+     */
+    public function upsertResult(array $payload, string $attemptId, LegacyRequestContext $context): array
     {
-        return $this->attemptLifecycle->upsertResult($request, $attemptId);
+        return $this->attemptLifecycle->upsertResult($payload, $attemptId, $context);
     }
 
     private function defaultRegion(): string

--- a/backend/app/Services/Legacy/LegacyReportService.php
+++ b/backend/app/Services/Legacy/LegacyReportService.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Services\Legacy;
 
+use App\DTO\Legacy\LegacyRequestContext;
 use App\Jobs\GenerateReportJob;
 use App\Models\Attempt;
 use App\Models\ReportJob;
@@ -13,10 +14,8 @@ use App\Services\Storage\ArtifactStore;
 use App\Support\OrgContext;
 use App\Support\WritesEvents;
 use Illuminate\Database\Eloquent\ModelNotFoundException;
-use Illuminate\Http\Request;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Log;
-use Illuminate\Support\Facades\Schema;
 use Illuminate\Support\Str;
 use Throwable;
 
@@ -27,42 +26,34 @@ class LegacyReportService
     public function __construct(
         private OrgContext $orgContext,
         private readonly ArtifactStore $artifactStore,
-    ) {
-    }
+    ) {}
 
-    public function ownedAttemptOrFail(string $attemptId, Request $request): Attempt
+    public function ownedAttemptOrFail(string $attemptId, LegacyRequestContext $context): Attempt
     {
         $query = Attempt::query()
             ->where('id', $attemptId)
-            ->where('org_id', $this->resolveScopedOrgId($request));
+            ->where('org_id', $this->resolveScopedOrgId($context));
 
-        $userId = $this->resolveUserId($request);
+        $userId = $this->resolveUserId($context);
         if ($userId !== '') {
             return (clone $query)
                 ->where('user_id', $userId)
                 ->firstOrFail();
         }
 
-        $anonId = $this->resolveAnonId($request);
+        $anonId = $this->resolveAnonId($context);
         if ($anonId !== '') {
             return (clone $query)
                 ->where('anon_id', $anonId)
                 ->firstOrFail();
         }
 
-        throw (new ModelNotFoundException())->setModel(Attempt::class, [$attemptId]);
+        throw (new ModelNotFoundException)->setModel(Attempt::class, [$attemptId]);
     }
 
-    private function resolveScopedOrgId(Request $request): int
+    private function resolveScopedOrgId(LegacyRequestContext $context): int
     {
-        $orgAttr = trim((string) ($request->attributes->get('org_id')
-            ?? $request->attributes->get('fm_org_id')
-            ?? ''));
-        if ($orgAttr !== '' && preg_match('/^\d+$/', $orgAttr) === 1) {
-            return (int) $orgAttr;
-        }
-
-        return max(0, (int) $this->orgContext->orgId());
+        return $context->scopedOrgId();
     }
 
     public function getResultPayload(Attempt $attempt): array
@@ -75,8 +66,8 @@ class LegacyReportService
             ->where('attempt_id', $attemptId)
             ->first();
 
-        if (empty($attemptResult) && !$result) {
-            throw (new ModelNotFoundException())->setModel(Result::class, [$attemptId]);
+        if (empty($attemptResult) && ! $result) {
+            throw (new ModelNotFoundException)->setModel(Result::class, [$attemptId]);
         }
 
         $scaleCode = (string) (
@@ -147,30 +138,30 @@ class LegacyReportService
 
         $dims = ['EI', 'SN', 'TF', 'JP', 'AT'];
 
-        if (!is_array($scoresJson)) {
+        if (! is_array($scoresJson)) {
             $scoresJson = [];
         }
-        if (!is_array($scoresPct)) {
+        if (! is_array($scoresPct)) {
             $scoresPct = [];
         }
-        if (!is_array($axisStates)) {
+        if (! is_array($axisStates)) {
             $axisStates = [];
         }
-        if (!is_array($facetScores)) {
+        if (! is_array($facetScores)) {
             $facetScores = [];
         }
-        if (!is_array($pci)) {
+        if (! is_array($pci)) {
             $pci = [];
         }
 
         foreach ($dims as $dim) {
-            if (!array_key_exists($dim, $scoresJson)) {
+            if (! array_key_exists($dim, $scoresJson)) {
                 $scoresJson[$dim] = ['a' => 0, 'b' => 0, 'neutral' => 0, 'sum' => 0, 'total' => 0];
             }
-            if (!array_key_exists($dim, $scoresPct)) {
+            if (! array_key_exists($dim, $scoresPct)) {
                 $scoresPct[$dim] = 50;
             }
-            if (!array_key_exists($dim, $axisStates)) {
+            if (! array_key_exists($dim, $axisStates)) {
                 $axisStates[$dim] = 'moderate';
             }
         }
@@ -193,19 +184,12 @@ class LegacyReportService
         ];
     }
 
-    public function recordResultViewEvents(Request $request, Attempt $attempt, array $payload): void
+    public function recordResultViewEvents(LegacyRequestContext $context, Attempt $attempt, array $payload): void
     {
-        $shareId = trim((string) (
-            $request->query('share_id')
-            ?? $request->header('X-Share-Id')
-            ?? $request->header('X-Share-ID')
-            ?? ''
-        ));
-        if ($shareId === '') {
-            $shareId = null;
-        }
+        $shareId = $context->shareId();
 
-        $funnel = $this->readFunnelMetaFromHeaders($request, $attempt);
+        $funnel = $this->readFunnelMetaFromContext($context, $attempt);
+        $eventRequest = $context->toEventRequest();
 
         $resultViewMeta = $this->mergeEventMeta([
             'type_code' => (string) ($payload['type_code'] ?? ''),
@@ -214,7 +198,7 @@ class LegacyReportService
             'share_id' => $shareId,
         ], $funnel);
 
-        $this->logEvent('result_view', $request, [
+        $this->logEvent('result_view', $eventRequest, [
             'anon_id' => $attempt->anon_id,
             'scale_code' => (string) ($payload['scale_code'] ?? $attempt->scale_code ?? ''),
             'scale_version' => (string) ($payload['scale_version'] ?? $attempt->scale_version ?? ''),
@@ -234,7 +218,7 @@ class LegacyReportService
                 'page' => 'result_page',
             ], $funnel);
 
-            $this->logEvent('share_view', $request, [
+            $this->logEvent('share_view', $eventRequest, [
                 'anon_id' => $attempt->anon_id,
                 'scale_code' => (string) ($payload['scale_code'] ?? $attempt->scale_code ?? ''),
                 'scale_version' => (string) ($payload['scale_version'] ?? $attempt->scale_version ?? ''),
@@ -250,7 +234,7 @@ class LegacyReportService
         }
     }
 
-    public function getReportPayload(Attempt $attempt, Request $request): array
+    public function getReportPayload(Attempt $attempt, LegacyRequestContext $context): array
     {
         $attemptId = (string) $attempt->id;
 
@@ -259,13 +243,13 @@ class LegacyReportService
             ->where('attempt_id', $attemptId)
             ->first();
 
-        if (!$result) {
-            throw (new ModelNotFoundException())->setModel(Result::class, [$attemptId]);
+        if (! $result) {
+            throw (new ModelNotFoundException)->setModel(Result::class, [$attemptId]);
         }
 
-        $userId = $this->resolveUserId($request);
-        $anonId = $this->resolveAnonId($request);
-        $benefitCode = $this->resolveReportBenefitCode($attempt, $request);
+        $userId = $this->resolveUserId($context);
+        $anonId = $this->resolveAnonId($context);
+        $benefitCode = $this->resolveReportBenefitCode($attempt, $context);
 
         $hasFullAccess = app(EntitlementManager::class)->hasFullAccess(
             (int) ($attempt->org_id ?? 0),
@@ -275,7 +259,7 @@ class LegacyReportService
             $benefitCode
         );
 
-        if (!$hasFullAccess) {
+        if (! $hasFullAccess) {
             return [
                 'status' => 402,
                 'body' => [
@@ -286,13 +270,9 @@ class LegacyReportService
             ];
         }
 
-        $shareId = trim((string) ($request->query('share_id') ?? $request->header('X-Share-Id') ?? ''));
-        $includeRaw = (string) $request->query('include', '');
-        $include = array_values(array_filter(array_map('trim', explode(',', $includeRaw))));
-        $includePsychometrics = in_array('psychometrics', $include, true);
-
-        $refreshRaw = (string) $request->query('refresh', '0');
-        $refresh = in_array($refreshRaw, ['1', 'true', 'TRUE', 'yes', 'YES'], true);
+        $shareId = $context->shareId() ?? '';
+        $includePsychometrics = $context->includeContains('psychometrics');
+        $refresh = $context->queryFlag('refresh');
 
         $contentPackageVersion = (string) ($result->content_package_version ?? $this->defaultDirVersion());
         $eventAnonId = trim((string) ($attempt->anon_id ?? $anonId));
@@ -319,7 +299,7 @@ class LegacyReportService
         }
 
         $status = (string) ($reportJob->status ?? 'queued');
-        if (!in_array($status, ['success', 'queued', 'running', 'failed'], true)) {
+        if (! in_array($status, ['success', 'queued', 'running', 'failed'], true)) {
             $status = 'queued';
         }
 
@@ -330,7 +310,7 @@ class LegacyReportService
             while (microtime(true) < $deadline) {
                 usleep(100000);
                 $latest = ReportJob::query()->where('attempt_id', $attemptId)->first();
-                if (!$latest) {
+                if (! $latest) {
                     break;
                 }
 
@@ -371,7 +351,7 @@ class LegacyReportService
             ? $reportJob->report_json
             : null;
 
-        if (!is_array($reportPayload)) {
+        if (! is_array($reportPayload)) {
             $scaleCode = (string) (
                 $result?->scale_code
                 ?? $attempt->scale_code
@@ -383,7 +363,7 @@ class LegacyReportService
             } catch (Throwable $e) {
                 Log::error('LEGACY_REPORT_CACHE_READ_FAILED', [
                     'attempt_id' => $attemptId,
-                    'request_id' => $this->requestId($request),
+                    'request_id' => $this->requestId($context),
                     'path' => $this->artifactStore->reportCanonicalPath($scaleCode, $attemptId),
                     'message' => $e->getMessage(),
                 ]);
@@ -392,7 +372,7 @@ class LegacyReportService
             }
         }
 
-        if (!is_array($reportPayload)) {
+        if (! is_array($reportPayload)) {
             return [
                 'status' => 500,
                 'body' => [
@@ -405,21 +385,22 @@ class LegacyReportService
             ];
         }
 
-        if (!array_key_exists('tags', $reportPayload) || !is_array($reportPayload['tags'])) {
+        if (! array_key_exists('tags', $reportPayload) || ! is_array($reportPayload['tags'])) {
             $reportPayload['tags'] = [];
         }
 
-        $funnel = $this->readFunnelMetaFromHeaders($request, $attempt);
+        $funnel = $this->readFunnelMetaFromContext($context, $attempt);
+        $eventRequest = $context->toEventRequest();
         $reportViewMeta = $this->mergeEventMeta([
             'type_code' => (string) ($result->type_code ?? ''),
             'engine_version' => 'v1.2',
             'content_package_version' => $contentPackageVersion,
             'share_id' => ($shareId !== '' ? $shareId : null),
             'refresh' => $refresh,
-            'cache' => !$refresh,
+            'cache' => ! $refresh,
         ], $funnel);
 
-        $this->logEvent('report_view', $request, [
+        $this->logEvent('report_view', $eventRequest, [
             'anon_id' => $eventAnonId,
             'scale_code' => (string) ($result->scale_code ?? ''),
             'scale_version' => (string) ($result->scale_version ?? ''),
@@ -439,7 +420,7 @@ class LegacyReportService
                 'page' => 'report_page',
             ], $funnel);
 
-            $this->logEvent('share_view', $request, [
+            $this->logEvent('share_view', $eventRequest, [
                 'anon_id' => $eventAnonId,
                 'scale_code' => (string) ($result->scale_code ?? ''),
                 'scale_version' => (string) ($result->scale_version ?? ''),
@@ -474,33 +455,24 @@ class LegacyReportService
         ];
     }
 
-    private function resolveUserId(Request $request): string
+    private function resolveUserId(LegacyRequestContext $context): string
     {
-        $userId = trim((string) ($request->user()?->id ?? ''));
-        if ($userId !== '') {
-            return $userId;
+        return trim((string) ($context->resolvedUserId() ?? ''));
+    }
+
+    private function resolveAnonId(LegacyRequestContext $context): string
+    {
+        $anonId = trim((string) ($context->resolvedAnonId() ?? ''));
+        if ($anonId !== '') {
+            return $anonId;
         }
 
-        return trim((string) ($request->attributes->get('fm_user_id')
-            ?? $request->attributes->get('user_id')
-            ?? ''));
+        return trim((string) ($this->orgContext->anonId() ?? ''));
     }
 
-    private function resolveAnonId(Request $request): string
+    private function resolveReportBenefitCode(Attempt $attempt, LegacyRequestContext $context): string
     {
-        $anonId = trim((string) ($request->attributes->get('anon_id')
-            ?? $request->attributes->get('fm_anon_id')
-            ?? $request->header('X-Anon-Id')
-            ?? $request->header('X-FAP-Anon-Id')
-            ?? $this->orgContext->anonId()
-            ?? ''));
-
-        return $anonId;
-    }
-
-    private function resolveReportBenefitCode(Attempt $attempt, Request $request): string
-    {
-        if (!\App\Support\SchemaBaseline::hasTable('scales_registry')) {
+        if (! \App\Support\SchemaBaseline::hasTable('scales_registry')) {
             return '';
         }
 
@@ -517,14 +489,14 @@ class LegacyReportService
         } catch (Throwable $e) {
             Log::error('LEGACY_REPORT_BENEFIT_RESOLVE_FAILED', [
                 'attempt_id' => (string) $attempt->id,
-                'request_id' => $this->requestId($request),
+                'request_id' => $this->requestId($context),
                 'message' => $e->getMessage(),
             ]);
 
             throw $e;
         }
 
-        if (!$row) {
+        if (! $row) {
             return '';
         }
 
@@ -533,7 +505,7 @@ class LegacyReportService
             $decoded = json_decode($commercial, true);
             $commercial = is_array($decoded) ? $decoded : null;
         }
-        if (!is_array($commercial)) {
+        if (! is_array($commercial)) {
             return '';
         }
 
@@ -549,7 +521,7 @@ class LegacyReportService
     {
         $job = ReportJob::query()->where('attempt_id', $attemptId)->first();
 
-        if (!$job) {
+        if (! $job) {
             $orgId = (int) (Attempt::query()->where('id', $attemptId)->value('org_id') ?? 0);
 
             return ReportJob::create([
@@ -590,13 +562,13 @@ class LegacyReportService
         GenerateReportJob::dispatch($job->attempt_id, $job->id)->onQueue('reports');
     }
 
-    private function readFunnelMetaFromHeaders(Request $request, ?Attempt $attempt = null): array
+    private function readFunnelMetaFromContext(LegacyRequestContext $context, ?Attempt $attempt = null): array
     {
-        $experiment = trim((string) ($request->header('X-Experiment') ?? ''));
-        $version = trim((string) ($request->header('X-App-Version') ?? ''));
-        $channel = trim((string) ($request->header('X-Channel') ?? ($attempt?->channel ?? '')));
-        $clientPlatform = trim((string) ($request->header('X-Client-Platform') ?? ''));
-        $entryPage = trim((string) ($request->header('X-Entry-Page') ?? ''));
+        $experiment = trim((string) ($context->headerValue('X-Experiment') ?? ''));
+        $version = trim((string) ($context->headerValue('X-App-Version') ?? ''));
+        $channel = trim((string) ($context->headerValue('X-Channel') ?? ($attempt?->channel ?? '')));
+        $clientPlatform = trim((string) ($context->headerValue('X-Client-Platform') ?? ''));
+        $entryPage = trim((string) ($context->headerValue('X-Entry-Page') ?? ''));
 
         return [
             'experiment' => ($experiment !== '' ? $experiment : null),
@@ -620,18 +592,8 @@ class LegacyReportService
         );
     }
 
-    private function requestId(Request $request): string
+    private function requestId(LegacyRequestContext $context): string
     {
-        $requestId = trim((string) ($request->attributes->get('request_id') ?? ''));
-        if ($requestId !== '') {
-            return $requestId;
-        }
-
-        $requestId = trim((string) $request->header('X-Request-Id', ''));
-        if ($requestId !== '') {
-            return $requestId;
-        }
-
-        return trim((string) $request->header('X-Request-ID', ''));
+        return $context->resolvedRequestId();
     }
 }

--- a/backend/app/Services/Legacy/LegacyShareFlowService.php
+++ b/backend/app/Services/Legacy/LegacyShareFlowService.php
@@ -1,526 +1,67 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Services\Legacy;
 
-use App\Models\Attempt;
-use App\Models\Event;
-use App\Models\Result;
-use App\Models\Share;
 use App\Services\Analytics\EventPayloadLimiter;
 use App\Services\Commerce\EntitlementManager;
 use App\Services\Report\ReportComposer;
 use App\Services\Scale\ScaleRegistry;
+use App\Services\Share\Adapters\LegacyShareFlowAdapter;
+use App\Services\Share\ShareFlowCoreService;
 use App\Support\OrgContext;
-use Illuminate\Database\Eloquent\ModelNotFoundException;
-use Illuminate\Support\Carbon;
-use Illuminate\Support\Str;
 use Psr\Log\LoggerInterface;
-use Symfony\Component\HttpKernel\Exception\HttpException;
-use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 
 class LegacyShareFlowService
 {
+    private ShareFlowCoreService $core;
+
     public function __construct(
-        private readonly OrgContext $orgContext,
-        private readonly LegacyShareService $legacyShareService,
-        private readonly ReportComposer $reportComposer,
-        private readonly EventPayloadLimiter $eventPayloadLimiter,
-        private readonly ScaleRegistry $scaleRegistry,
-        private readonly EntitlementManager $entitlementManager,
-        private readonly LoggerInterface $logger,
+        OrgContext $orgContext,
+        LegacyShareService $legacyShareService,
+        ReportComposer $reportComposer,
+        EventPayloadLimiter $eventPayloadLimiter,
+        ScaleRegistry $scaleRegistry,
+        EntitlementManager $entitlementManager,
+        LoggerInterface $logger,
     ) {
+        $this->core = new ShareFlowCoreService(
+            $orgContext,
+            new LegacyShareFlowAdapter($legacyShareService),
+            $reportComposer,
+            $eventPayloadLimiter,
+            $scaleRegistry,
+            $entitlementManager,
+            $logger,
+            'SHARE_LEGACY_EVENT_CREATE_FAILED'
+        );
     }
 
+    /**
+     * @param  array<string, mixed>  $input
+     * @return array<string, mixed>
+     */
     public function getShareLinkForAttempt(string $attemptId, array $input): array
     {
-        $attempt = $this->legacyShareService->resolveAttemptForAuth($attemptId, $this->orgContext);
-        $commercial = $this->resolveCommercial($attempt);
-
-        $benefitCode = $commercial['report_benefit_code'];
-        if ($benefitCode === '') {
-            $benefitCode = $commercial['subscription_benefit_code'];
-        }
-
-        $userId = $this->orgContext->userId();
-        $anonId = $this->orgContext->anonId();
-
-        $hasFullAccess = $this->entitlementManager->hasFullAccess(
-            (int) ($attempt->org_id ?? 0),
-            $userId !== null ? (string) $userId : null,
-            $anonId !== null ? (string) $anonId : null,
-            (string) $attempt->id,
-            $benefitCode
-        );
-
-        if (!$hasFullAccess) {
-            throw new HttpException(402, 'PAYMENT_REQUIRED');
-        }
-
-        $data = $this->legacyShareService->getOrCreateShare($attemptId, $this->orgContext);
-        $this->emitLegacyShareEvents($data, $input, $commercial);
-
-        return $data;
+        return $this->core->getShareLinkForAttempt($attemptId, $input);
     }
 
+    /**
+     * @param  array<string, mixed>  $input
+     * @param  array<string, mixed>  $requestMeta
+     * @return array<string, mixed>
+     */
     public function clickAndComposeReport(string $shareId, array $input, array $requestMeta): array
     {
-        $share = Share::withoutGlobalScopes()->where('id', $shareId)->first();
-        if (!$share) {
-            throw new NotFoundHttpException('share not found');
-        }
-
-        $attemptId = trim((string) ($share->attempt_id ?? ''));
-        if ($attemptId === '') {
-            throw (new ModelNotFoundException())->setModel(Share::class, [$shareId]);
-        }
-
-        $gen = Event::withoutGlobalScopes()
-            ->where('event_code', 'share_generate')
-            ->where('share_id', $shareId)
-            ->orderByDesc('occurred_at')
-            ->first();
-        if (!$gen) {
-            throw new NotFoundHttpException('share generate event not found');
-        }
-
-        $genMeta = $this->normalizeMeta($gen->meta_json ?? null);
-
-        $experiment = trim((string) ($requestMeta['experiment'] ?? ($input['experiment'] ?? '')));
-        if ($experiment === '') {
-            $experiment = trim((string) ($genMeta['experiment'] ?? ''));
-        }
-
-        $version = trim((string) ($requestMeta['version'] ?? ($input['version'] ?? '')));
-        if ($version === '') {
-            $version = trim((string) ($genMeta['version'] ?? ''));
-        }
-
-        $channel = trim((string) ($requestMeta['channel'] ?? ($genMeta['channel'] ?? '')));
-        $clientPlatform = trim((string) ($requestMeta['client_platform'] ?? ($genMeta['client_platform'] ?? '')));
-        $entryPage = trim((string) ($requestMeta['entry_page'] ?? ''));
-
-        $typeCode = trim((string) ($genMeta['type_code'] ?? ''));
-        $packVersion = trim((string) ($genMeta['content_package_version'] ?? ''));
-        $engineVersion = trim((string) ($genMeta['engine_version'] ?? ($genMeta['engine'] ?? '')));
-        $profileVersion = trim((string) ($genMeta['profile_version'] ?? ''));
-
-        $meta = is_array($input['meta_json'] ?? null) ? $input['meta_json'] : [];
-
-        if (!isset($meta['share_id'])) {
-            $meta['share_id'] = $shareId;
-        }
-        $meta['attempt_id'] = $attemptId;
-
-        if ($typeCode !== '' && !isset($meta['type_code'])) {
-            $meta['type_code'] = $typeCode;
-        }
-        if ($engineVersion !== '' && !isset($meta['engine_version'])) {
-            $meta['engine_version'] = $engineVersion;
-        }
-        if ($engineVersion !== '' && !isset($meta['engine'])) {
-            $meta['engine'] = $engineVersion;
-        }
-        if ($packVersion !== '' && !isset($meta['content_package_version'])) {
-            $meta['content_package_version'] = $packVersion;
-        }
-        if ($profileVersion !== '' && !isset($meta['profile_version'])) {
-            $meta['profile_version'] = $profileVersion;
-        }
-
-        if ($experiment !== '' && !isset($meta['experiment'])) {
-            $meta['experiment'] = $experiment;
-        }
-        if ($version !== '' && !isset($meta['version'])) {
-            $meta['version'] = $version;
-        }
-
-        if ($channel !== '' && !isset($meta['channel'])) {
-            $meta['channel'] = $channel;
-        }
-        if ($clientPlatform !== '' && !isset($meta['client_platform'])) {
-            $meta['client_platform'] = $clientPlatform;
-        }
-        if ($entryPage !== '' && !isset($meta['entry_page'])) {
-            $meta['entry_page'] = $entryPage;
-        }
-
-        if (!isset($meta['share_generate_event_id'])) {
-            $meta['share_generate_event_id'] = (string) ($gen->id ?? '');
-        }
-        if (!isset($meta['share_generate_occurred_at'])) {
-            $meta['share_generate_occurred_at'] = (string) ($gen->occurred_at ?? '');
-        }
-
-        if (!isset($meta['ua'])) {
-            $meta['ua'] = trim((string) ($requestMeta['ua'] ?? ''));
-        }
-        if (!isset($meta['ip'])) {
-            $meta['ip'] = trim((string) ($requestMeta['ip'] ?? ''));
-        }
-        if (!isset($meta['ref'])) {
-            $meta['ref'] = trim((string) ($requestMeta['referer'] ?? ''));
-        }
-
-        $meta = array_filter($meta, static fn (mixed $v): bool => !($v === null || $v === ''));
-        $meta = $this->eventPayloadLimiter->limit($meta);
-
-        $attempt = Attempt::withoutGlobalScopes()->where('id', $attemptId)->firstOrFail();
-        $this->assertOrgIsolation($attempt);
-
-        $result = Result::withoutGlobalScopes()
-            ->where('org_id', (int) ($attempt->org_id ?? 0))
-            ->where('attempt_id', (string) $attempt->id)
-            ->firstOrFail();
-
-        $event = new Event();
-        $event->id = $this->newUuid();
-        $event->event_code = 'share_click';
-        $event->org_id = (int) ($attempt->org_id ?? 0);
-        $event->attempt_id = (string) $attempt->id;
-        $event->share_id = $shareId;
-        $event->anon_id = $this->resolveClickAnonId($input, $gen);
-        $event->meta_json = $meta;
-        $event->occurred_at = !empty($input['occurred_at'])
-            ? Carbon::parse((string) $input['occurred_at'])
-            : now();
-        $event->save();
-
-        $ctx = [
-            'share_id' => $shareId,
-            'attempt_id' => (string) $attempt->id,
-            'experiment' => $experiment,
-            'version' => $version,
-            'type_code' => $typeCode,
-            'engine' => $engineVersion,
-            'profile_version' => $profileVersion,
-            'content_package_version' => $packVersion,
-            'org_id' => (int) ($attempt->org_id ?? 0),
-        ];
-
-        try {
-            $composed = $this->reportComposer->compose($attempt, $ctx, $result);
-        } catch (\Throwable $e) {
-            $this->logger->error('[share] report compose failed', [
-                'share_id' => $shareId,
-                'attempt_id' => (string) $attempt->id,
-                'org_id' => (int) ($attempt->org_id ?? 0),
-                'exception' => $e::class,
-                'message' => $e->getMessage(),
-            ]);
-            throw $e;
-        }
-
-        $report = is_array($composed['report'] ?? null) ? $composed['report'] : $this->toArray($composed);
-        if (!is_array($report)) {
-            $report = [];
-        }
-
-        if (!isset($report['_meta']) || !is_array($report['_meta'])) {
-            $report['_meta'] = [];
-        }
-
-        $metaFill = [
-            'share_id' => $shareId,
-            'attempt_id' => (string) $attempt->id,
-            'type_code' => $typeCode,
-            'engine' => $engineVersion,
-            'profile_version' => $profileVersion,
-            'content_package_version' => $packVersion,
-            'experiment' => $experiment,
-            'version' => $version,
-            'generated_at' => now()->toISOString(),
-        ];
-
-        foreach ($metaFill as $key => $value) {
-            if ($value === '' || $value === null) {
-                continue;
-            }
-            if (!array_key_exists($key, $report['_meta'])) {
-                $report['_meta'][$key] = $value;
-            }
-        }
-
-        return [
-            'id' => (string) $event->id,
-            'share_id' => $shareId,
-            'attempt_id' => (string) $attempt->id,
-            'report' => $this->filterReport($report),
-        ];
+        return $this->core->clickAndComposeReport($shareId, $input, $requestMeta);
     }
 
+    /**
+     * @return array<string, mixed>
+     */
     public function getShareView(string $shareId): array
     {
-        $data = $this->legacyShareService->getShareView($shareId);
-
-        $attemptId = (string) ($data['attempt_id'] ?? '');
-        if ($attemptId !== '') {
-            $attempt = Attempt::withoutGlobalScopes()->where('id', $attemptId)->firstOrFail();
-            $this->assertOrgIsolation($attempt);
-        }
-
-        return $data;
-    }
-
-    private function emitLegacyShareEvents(array $data, array $input, array $commercial): void
-    {
-        $shareId = trim((string) ($data['share_id'] ?? ''));
-        $attemptId = trim((string) ($data['attempt_id'] ?? ''));
-        if ($shareId === '' || $attemptId === '') {
-            return;
-        }
-
-        $experiment = trim((string) ($input['experiment'] ?? ''));
-        $version = trim((string) ($input['version'] ?? ''));
-        $channel = trim((string) ($input['channel'] ?? ''));
-        $clientPlatform = trim((string) ($input['client_platform'] ?? ''));
-        $entryPage = trim((string) ($input['entry_page'] ?? ''));
-
-        $metaBase = [
-            'share_id' => $shareId,
-            'type_code' => (string) ($data['type_code'] ?? ''),
-            'content_package_version' => (string) ($data['content_package_version'] ?? ''),
-            'engine_version' => 'v1.2',
-            'engine' => 'v1.2',
-            'experiment' => $experiment !== '' ? $experiment : null,
-            'version' => $version !== '' ? $version : null,
-            'channel' => $channel !== '' ? $channel : null,
-            'client_platform' => $clientPlatform !== '' ? $clientPlatform : null,
-            'entry_page' => $entryPage !== '' ? $entryPage : null,
-            'report_benefit_code' => $commercial['report_benefit_code'] !== '' ? $commercial['report_benefit_code'] : null,
-            'subscription_benefit_code' => $commercial['subscription_benefit_code'] !== '' ? $commercial['subscription_benefit_code'] : null,
-            'default_sku' => $commercial['default_sku'] !== '' ? $commercial['default_sku'] : null,
-        ];
-
-        $this->createLegacyEvent('share_generate', $attemptId, (int) ($data['org_id'] ?? 0), $this->orgContext->anonId(), $metaBase + [
-            'generate_type' => 'text',
-        ]);
-
-        $this->createLegacyEvent('share_view', $attemptId, (int) ($data['org_id'] ?? 0), $this->orgContext->anonId(), $metaBase + [
-            'view_type' => 'share_sheet',
-        ]);
-    }
-
-    private function createLegacyEvent(string $eventCode, string $attemptId, int $orgId, ?string $anonId, array $meta): void
-    {
-        try {
-            $shareId = trim((string) ($meta['share_id'] ?? ''));
-            if ($shareId === '' || strlen($shareId) > 64) {
-                $shareId = null;
-            }
-
-            $shareChannel = trim((string) ($meta['share_channel'] ?? ($meta['channel'] ?? '')));
-            if ($shareChannel === '') {
-                $shareChannel = null;
-            }
-
-            $clientPlatform = trim((string) ($meta['client_platform'] ?? ''));
-            if ($clientPlatform === '') {
-                $clientPlatform = null;
-            }
-
-            Event::query()->create([
-                'id' => (string) Str::uuid(),
-                'event_code' => $eventCode,
-                'attempt_id' => $attemptId,
-                'org_id' => $orgId,
-                'anon_id' => $anonId,
-                'channel' => $meta['channel'] ?? null,
-                'client_platform' => $clientPlatform,
-                'share_id' => $shareId,
-                'share_channel' => $shareChannel,
-                'meta_json' => $meta,
-                'occurred_at' => now(),
-                'created_at' => now(),
-                'updated_at' => now(),
-            ]);
-        } catch (\Throwable $e) {
-            $this->logger->warning('SHARE_LEGACY_EVENT_CREATE_FAILED', [
-                'event_code' => $eventCode,
-                'attempt_id' => $attemptId,
-                'org_id' => $orgId,
-                'exception' => $e::class,
-                'message' => $e->getMessage(),
-            ]);
-        }
-    }
-
-    private function resolveCommercial(Attempt $attempt): array
-    {
-        $scaleCode = trim((string) ($attempt->scale_code ?? ''));
-        if ($scaleCode === '') {
-            return [
-                'report_benefit_code' => '',
-                'subscription_benefit_code' => '',
-                'default_sku' => '',
-            ];
-        }
-
-        $row = $this->scaleRegistry->getByCode($scaleCode, (int) ($attempt->org_id ?? 0));
-        if (!is_array($row)) {
-            return [
-                'report_benefit_code' => '',
-                'subscription_benefit_code' => '',
-                'default_sku' => '',
-            ];
-        }
-
-        $commercial = $row['commercial_json'] ?? null;
-        if (is_string($commercial)) {
-            $decoded = json_decode($commercial, true);
-            $commercial = is_array($decoded) ? $decoded : [];
-        }
-        if (!is_array($commercial)) {
-            $commercial = [];
-        }
-
-        $reportBenefitCode = strtoupper(trim((string) ($commercial['report_benefit_code'] ?? '')));
-        if ($reportBenefitCode === '') {
-            $reportBenefitCode = strtoupper(trim((string) ($commercial['credit_benefit_code'] ?? '')));
-        }
-
-        return [
-            'report_benefit_code' => $reportBenefitCode,
-            'subscription_benefit_code' => strtoupper(trim((string) ($commercial['subscription_benefit_code'] ?? ''))),
-            'default_sku' => trim((string) ($commercial['default_sku'] ?? '')),
-        ];
-    }
-
-    private function resolveClickAnonId(array $input, Event $gen): ?string
-    {
-        $badAnon = static function (?string $value): bool {
-            if ($value === null) {
-                return true;
-            }
-
-            $candidate = trim($value);
-            if ($candidate === '') {
-                return true;
-            }
-
-            $lower = mb_strtolower($candidate, 'UTF-8');
-            $blacklist = [
-                'todo',
-                'placeholder',
-                'fixme',
-                'tbd',
-                '把你查到的anon_id填这里',
-                '把你查到的 anon_id 填这里',
-                '填这里',
-            ];
-
-            foreach ($blacklist as $bad) {
-                $needle = mb_strtolower(trim($bad), 'UTF-8');
-                if ($needle !== '' && mb_strpos($lower, $needle) !== false) {
-                    return true;
-                }
-            }
-
-            return false;
-        };
-
-        $fromInput = isset($input['anon_id']) && is_string($input['anon_id'])
-            ? trim((string) $input['anon_id'])
-            : '';
-
-        if ($fromInput !== '' && !$badAnon($fromInput)) {
-            return $fromInput;
-        }
-
-        $fromGen = trim((string) ($gen->anon_id ?? ''));
-        if ($fromGen !== '' && !$badAnon($fromGen)) {
-            return $fromGen;
-        }
-
-        return null;
-    }
-
-    private function assertOrgIsolation(Attempt $attempt): void
-    {
-        $ctxOrgId = max(0, (int) $this->orgContext->orgId());
-        if ($ctxOrgId === 0) {
-            return;
-        }
-
-        if ((int) ($attempt->org_id ?? 0) !== $ctxOrgId) {
-            throw (new ModelNotFoundException())->setModel(Attempt::class, [(string) ($attempt->id ?? '')]);
-        }
-    }
-
-    private function normalizeMeta(mixed $meta): array
-    {
-        if (is_array($meta)) {
-            return $meta;
-        }
-
-        if (is_string($meta)) {
-            $decoded = json_decode($meta, true);
-            if (is_array($decoded)) {
-                return $decoded;
-            }
-        }
-
-        return [];
-    }
-
-    private function filterReport(array $report): array
-    {
-        $allowed = $this->allowedReportKeys();
-        $allowed = array_flip($allowed);
-
-        $output = [];
-        foreach ($report as $key => $value) {
-            if (!isset($allowed[$key])) {
-                continue;
-            }
-
-            if ($key === '_explain' && !$this->shouldExposeExplain()) {
-                continue;
-            }
-
-            $output[$key] = $value;
-        }
-
-        return $output;
-    }
-
-    private function allowedReportKeys(): array
-    {
-        $keys = config('report.share_report_allowed_keys', []);
-        return is_array($keys) ? $keys : [];
-    }
-
-    private function shouldExposeExplain(): bool
-    {
-        if (app()->environment('local', 'development')) {
-            return true;
-        }
-
-        return (bool) config('report.expose_explain', false);
-    }
-
-    private function toArray(mixed $payload): array
-    {
-        if (is_array($payload)) {
-            return $payload;
-        }
-
-        if (is_object($payload)) {
-            if (method_exists($payload, 'toArray')) {
-                $array = $payload->toArray();
-                return is_array($array) ? $array : [];
-            }
-
-            if (method_exists($payload, 'jsonSerialize')) {
-                $array = $payload->jsonSerialize();
-                return is_array($array) ? $array : [];
-            }
-        }
-
-        return [];
-    }
-
-    private function newUuid(): string
-    {
-        return method_exists(Str::class, 'uuid7') ? (string) Str::uuid7() : (string) Str::uuid();
+        return $this->core->getShareView($shareId);
     }
 }

--- a/backend/app/Services/Legacy/Mbti/Attempt/LegacyMbtiAttemptLifecycleService.php
+++ b/backend/app/Services/Legacy/Mbti/Attempt/LegacyMbtiAttemptLifecycleService.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Services\Legacy\Mbti\Attempt;
 
+use App\DTO\Legacy\LegacyRequestContext;
 use App\Exceptions\Api\ApiProblemException;
 use App\Jobs\GenerateReportJob;
 use App\Models\Attempt;
@@ -16,10 +17,8 @@ use App\Services\Psychometrics\QualityChecker;
 use App\Services\Psychometrics\ScoreNormalizer;
 use App\Support\OrgContext;
 use App\Support\WritesEvents;
-use Illuminate\Http\Request;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Log;
-use Illuminate\Support\Facades\Schema;
 use Illuminate\Support\Facades\Storage;
 use Illuminate\Support\Str;
 
@@ -76,25 +75,18 @@ class LegacyMbtiAttemptLifecycleService
         );
     }
 
-    public function startAttempt(Request $request, ?string $id = null): array
+    /**
+     * @param  array<string, mixed>  $payload
+     */
+    public function startAttempt(array $payload, LegacyRequestContext $context, ?string $id = null): array
     {
-        $this->currentRequestId = $this->extractRequestId($request);
+        $this->currentRequestId = $context->resolvedRequestId();
 
         if (is_string($id) && trim($id) !== '') {
-            $request->merge(['attempt_id' => trim($id)]);
+            $payload['attempt_id'] = trim($id);
         }
 
-        $payload = $request->validate([
-            'anon_id' => ['required', 'string', 'max:64'],
-            'scale_code' => ['required', 'string', 'in:MBTI'],
-            'scale_version' => ['required', 'string', 'in:v0.3'],
-            'question_count' => ['required', 'integer', 'in:24,93,144'],
-            'client_platform' => ['required', 'string', 'max:32'],
-            'client_version' => ['nullable', 'string', 'max:32'],
-            'channel' => ['nullable', 'string', 'max:32'],
-            'referrer' => ['nullable', 'string', 'max:255'],
-            'meta_json' => ['sometimes', 'array'],
-        ]);
+        $payload = $this->normalizeStartPayload($payload);
 
         $attempt = Attempt::create([
             'id' => (string) Str::uuid(),
@@ -130,38 +122,16 @@ class LegacyMbtiAttemptLifecycleService
     }
 
     /**
-     * POST /api/v0.3/attempts
-     * ✅ 前端提交：answers[].question_id + answers[].code(A~E)
-     * ✅ 后端用题库 options.score + key_pole + direction 计算 5 轴百分比
+     * @param  array<string, mixed>  $payload
      */
-    public function storeAttempt(Request $request): array
+    public function storeAttempt(array $payload, LegacyRequestContext $context, bool $isResultUpsertRoute = false): array
     {
-        $this->currentRequestId = $this->extractRequestId($request);
-
-        $payload = $request->validate([
-            'anon_id' => ['required', 'string', 'max:64'],
-            'scale_code' => ['required', 'string', 'in:MBTI'],
-            'scale_version' => ['required', 'string', 'in:v0.3'],
-
-            'answers' => ['required', 'array', 'min:1'],
-            'answers.*.question_id' => ['required', 'string'],
-            'answers.*.code' => ['required', 'string', 'in:A,B,C,D,E'],
-
-            // 可选字段
-            'client_platform' => ['nullable', 'string', 'max:32'],
-            'client_version' => ['nullable', 'string', 'max:32'],
-            'channel' => ['nullable', 'string', 'max:32'],
-            'referrer' => ['nullable', 'string', 'max:255'],
-            'region' => ['nullable', 'string', 'max:32'],
-            'locale' => ['nullable', 'string', 'max:16'],
-            'attempt_id' => ['nullable', 'string', 'max:64'],
-            'demographics' => ['sometimes', 'array'],
-        ]);
+        $this->currentRequestId = $context->resolvedRequestId();
+        $payload = $this->normalizeStorePayload($payload);
 
         $attemptId = isset($payload['attempt_id']) && is_string($payload['attempt_id']) && trim($payload['attempt_id']) !== ''
             ? trim($payload['attempt_id'])
             : (string) Str::uuid();
-        $isResultUpsertRoute = trim((string) ($request->route('id') ?? '')) !== '';
 
         Log::info('[attempt_submit] received', [
             'attempt_id' => $attemptId,
@@ -302,8 +272,16 @@ class LegacyMbtiAttemptLifecycleService
 
         $canStoreJson = \App\Support\SchemaBaseline::hasColumn('attempts', 'answers_json');
         $canStorePath = \App\Support\SchemaBaseline::hasColumn('attempts', 'answers_storage_path');
-        $actorUserId = $this->resolveActorUserId($request);
-        $actorAnonId = $this->resolveActorAnonId($request);
+        $actorUserId = $context->resolvedUserId();
+        $actorAnonId = $context->resolvedAnonId();
+        $eventRequest = $context->toEventRequest([], [
+            'anon_id' => $payload['anon_id'],
+            'region' => $payload['region'] ?? null,
+            'locale' => $payload['locale'] ?? null,
+            'channel' => $payload['channel'] ?? null,
+            'client_platform' => $payload['client_platform'] ?? null,
+            'client_version' => $payload['client_version'] ?? null,
+        ]);
 
         if (! $canStoreJson && (! $storeToStorage || ! $canStorePath)) {
             throw new ApiProblemException(
@@ -319,7 +297,7 @@ class LegacyMbtiAttemptLifecycleService
         }
 
         $tx = DB::transaction(function () use (
-            $request,
+            $eventRequest,
             $payload,
             $attemptId,
             $expectedQuestionCount,
@@ -531,7 +509,7 @@ class LegacyMbtiAttemptLifecycleService
             }
 
             // ✅ 4) test_submit event（保持你原逻辑）
-            $this->logEvent('test_submit', $request, [
+            $this->logEvent('test_submit', $eventRequest, [
                 'anon_id' => $payload['anon_id'],
                 'scale_code' => $attempt->scale_code,
                 'scale_version' => $attempt->scale_version,
@@ -592,14 +570,14 @@ class LegacyMbtiAttemptLifecycleService
         ];
     }
 
-    public function upsertResult(\Illuminate\Http\Request $request, string $attemptId)
+    /**
+     * @param  array<string, mixed>  $payload
+     */
+    public function upsertResult(array $payload, string $attemptId, LegacyRequestContext $context): array
     {
-        // 让 /attempts/{id}/result 走你现有的 storeAttempt 逻辑（写 attempts.result_json + results 表）
-        $request->merge([
-            'attempt_id' => $attemptId,
-        ]);
+        $payload['attempt_id'] = $attemptId;
 
-        return $this->storeAttempt($request);
+        return $this->storeAttempt($payload, $context, true);
     }
 
     private function ensureReportJob(string $attemptId, bool $reset = false): ReportJob
@@ -869,46 +847,92 @@ class LegacyMbtiAttemptLifecycleService
         return hash('sha256', json_encode($norm, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES));
     }
 
-    private function resolveActorUserId(Request $request): ?string
+    /**
+     * @param  array<string, mixed>  $payload
+     * @return array<string, mixed>
+     */
+    private function normalizeStartPayload(array $payload): array
     {
-        $candidates = [
-            $request->attributes->get('fm_user_id'),
-            $request->attributes->get('user_id'),
-        ];
+        $anonId = trim((string) ($payload['anon_id'] ?? ''));
+        $scaleCode = trim((string) ($payload['scale_code'] ?? ''));
+        $scaleVersion = trim((string) ($payload['scale_version'] ?? ''));
+        $clientPlatform = trim((string) ($payload['client_platform'] ?? ''));
 
-        foreach ($candidates as $candidate) {
-            if (! is_string($candidate) && ! is_numeric($candidate)) {
-                continue;
-            }
-
-            $value = trim((string) $candidate);
-            if ($value !== '' && preg_match('/^\d+$/', $value) === 1) {
-                return $value;
-            }
+        if ($anonId === '' || $scaleCode === '' || $scaleVersion === '' || $clientPlatform === '') {
+            throw new ApiProblemException(422, 'VALIDATION_FAILED', 'missing required attempt start fields.');
         }
 
-        return null;
+        if ($scaleCode !== 'MBTI' || $scaleVersion !== 'v0.3') {
+            throw new ApiProblemException(422, 'VALIDATION_FAILED', 'invalid scale for legacy MBTI flow.');
+        }
+
+        $payload['anon_id'] = $anonId;
+        $payload['scale_code'] = $scaleCode;
+        $payload['scale_version'] = $scaleVersion;
+        $payload['client_platform'] = $clientPlatform;
+        $payload['question_count'] = (int) ($payload['question_count'] ?? 0);
+        $payload['client_version'] = $this->nullableString($payload['client_version'] ?? null);
+        $payload['channel'] = $this->nullableString($payload['channel'] ?? null);
+        $payload['referrer'] = $this->nullableString($payload['referrer'] ?? null);
+
+        if (! is_array($payload['meta_json'] ?? null)) {
+            $payload['meta_json'] = null;
+        }
+
+        return $payload;
     }
 
-    private function resolveActorAnonId(Request $request): ?string
+    /**
+     * @param  array<string, mixed>  $payload
+     * @return array<string, mixed>
+     */
+    private function normalizeStorePayload(array $payload): array
     {
-        $candidates = [
-            $request->attributes->get('anon_id'),
-            $request->attributes->get('fm_anon_id'),
-        ];
+        $anonId = trim((string) ($payload['anon_id'] ?? ''));
+        $scaleCode = trim((string) ($payload['scale_code'] ?? ''));
+        $scaleVersion = trim((string) ($payload['scale_version'] ?? ''));
 
-        foreach ($candidates as $candidate) {
-            if (! is_string($candidate) && ! is_numeric($candidate)) {
-                continue;
-            }
-
-            $value = trim((string) $candidate);
-            if ($value !== '') {
-                return $value;
-            }
+        if ($anonId === '' || $scaleCode === '' || $scaleVersion === '') {
+            throw new ApiProblemException(422, 'VALIDATION_FAILED', 'missing required attempt submit fields.');
         }
 
-        return null;
+        if ($scaleCode !== 'MBTI' || $scaleVersion !== 'v0.3') {
+            throw new ApiProblemException(422, 'VALIDATION_FAILED', 'invalid scale for legacy MBTI flow.');
+        }
+
+        $answers = $payload['answers'] ?? null;
+        if (! is_array($answers) || count($answers) === 0) {
+            throw new ApiProblemException(422, 'VALIDATION_FAILED', 'answers is required.');
+        }
+
+        $payload['anon_id'] = $anonId;
+        $payload['scale_code'] = $scaleCode;
+        $payload['scale_version'] = $scaleVersion;
+        $payload['answers'] = $answers;
+        $payload['attempt_id'] = $this->nullableString($payload['attempt_id'] ?? null);
+        $payload['client_platform'] = $this->nullableString($payload['client_platform'] ?? null);
+        $payload['client_version'] = $this->nullableString($payload['client_version'] ?? null);
+        $payload['channel'] = $this->nullableString($payload['channel'] ?? null);
+        $payload['referrer'] = $this->nullableString($payload['referrer'] ?? null);
+        $payload['region'] = $this->nullableString($payload['region'] ?? null);
+        $payload['locale'] = $this->nullableString($payload['locale'] ?? null);
+
+        if (! is_array($payload['demographics'] ?? null)) {
+            $payload['demographics'] = null;
+        }
+
+        return $payload;
+    }
+
+    private function nullableString(mixed $value): ?string
+    {
+        if (! is_string($value) && ! is_numeric($value)) {
+            return null;
+        }
+
+        $normalized = trim((string) $value);
+
+        return $normalized !== '' ? $normalized : null;
     }
 
     /**
@@ -936,20 +960,5 @@ class LegacyMbtiAttemptLifecycleService
     private function requestId(): string
     {
         return $this->currentRequestId ?? '';
-    }
-
-    private function extractRequestId(Request $request): string
-    {
-        $requestId = trim((string) ($request->attributes->get('request_id') ?? ''));
-        if ($requestId !== '') {
-            return $requestId;
-        }
-
-        $requestId = trim((string) $request->header('X-Request-Id', ''));
-        if ($requestId !== '') {
-            return $requestId;
-        }
-
-        return trim((string) $request->header('X-Request-ID', ''));
     }
 }

--- a/backend/app/Services/Ops/BigFiveOpsActionService.php
+++ b/backend/app/Services/Ops/BigFiveOpsActionService.php
@@ -1,0 +1,923 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\Ops;
+
+use Throwable;
+
+final class BigFiveOpsActionService
+{
+    /**
+     * @var list<string>
+     */
+    private const BIG5_ACTIONS = [
+        'big5_pack_publish',
+        'big5_pack_rollback',
+    ];
+
+    public function __construct(
+        private readonly BigFiveOpsQueryService $queryService,
+        private readonly BigFiveOpsCommandRunner $commandRunner,
+    ) {}
+
+    /**
+     * @param  array<string,mixed>  $input
+     * @return array{status:int,payload:array<string,mixed>}
+     */
+    public function latest(int $orgId, array $input): array
+    {
+        $region = $this->normalizeRegion((string) ($input['region'] ?? 'CN_MAINLAND'));
+        $locale = $this->normalizeLocale((string) ($input['locale'] ?? 'zh-CN'));
+        $action = $this->normalizeReleaseAction((string) ($input['action'] ?? ''));
+
+        $row = $this->queryService->findLatestRelease($region, $locale, $action);
+        if (! is_object($row)) {
+            return [
+                'status' => 404,
+                'payload' => [
+                    'ok' => false,
+                    'error_code' => 'RELEASE_NOT_FOUND',
+                    'message' => 'release not found.',
+                ],
+            ];
+        }
+
+        return [
+            'status' => 200,
+            'payload' => [
+                'ok' => true,
+                'org_id' => $orgId,
+                'item' => $this->mapReleaseRow($row),
+            ],
+        ];
+    }
+
+    /**
+     * @param  array<string,mixed>  $input
+     * @return array{status:int,payload:array<string,mixed>}
+     */
+    public function latestAudits(int $orgId, array $input): array
+    {
+        $region = $this->normalizeRegion((string) ($input['region'] ?? 'CN_MAINLAND'));
+        $locale = $this->normalizeLocale((string) ($input['locale'] ?? 'zh-CN'));
+        $releaseAction = $this->normalizeReleaseAction((string) ($input['release_action'] ?? ''));
+        if ($releaseAction === '') {
+            $releaseAction = $this->normalizeReleaseAction((string) ($input['action'] ?? ''));
+        }
+        $result = $this->normalizeAuditResult((string) ($input['result'] ?? ''));
+        $limit = $this->normalizeLimit($input['limit'] ?? 20);
+
+        $row = $this->queryService->findLatestRelease($region, $locale, $releaseAction);
+        if (! is_object($row)) {
+            return [
+                'status' => 404,
+                'payload' => [
+                    'ok' => false,
+                    'error_code' => 'RELEASE_NOT_FOUND',
+                    'message' => 'release not found.',
+                ],
+            ];
+        }
+
+        $releaseId = (string) ($row->id ?? '');
+        $audits = $this->queryService->listLatestReleaseAudits($releaseId, $result, $limit);
+        $items = [];
+        foreach ($audits as $audit) {
+            $items[] = $this->mapAuditRow($audit);
+        }
+
+        return [
+            'status' => 200,
+            'payload' => [
+                'ok' => true,
+                'org_id' => $orgId,
+                'item' => $this->mapReleaseRow($row),
+                'count' => count($items),
+                'audits' => $items,
+            ],
+        ];
+    }
+
+    /**
+     * @param  array<string,mixed>  $input
+     * @return array{status:int,payload:array<string,mixed>}
+     */
+    public function releases(int $orgId, array $input): array
+    {
+        $limit = $this->normalizeLimit($input['limit'] ?? 20);
+        $region = $this->normalizeRegion((string) ($input['region'] ?? 'CN_MAINLAND'));
+        $locale = $this->normalizeLocale((string) ($input['locale'] ?? 'zh-CN'));
+        $action = $this->normalizeReleaseAction((string) ($input['action'] ?? ''));
+
+        $rows = $this->queryService->listReleases($region, $locale, $action, $limit);
+        $items = [];
+        foreach ($rows as $row) {
+            $items[] = $this->mapReleaseRow($row);
+        }
+
+        return [
+            'status' => 200,
+            'payload' => [
+                'ok' => true,
+                'org_id' => $orgId,
+                'count' => count($items),
+                'items' => $items,
+            ],
+        ];
+    }
+
+    /**
+     * @param  array<string,mixed>  $input
+     * @return array{status:int,payload:array<string,mixed>}
+     */
+    public function audits(int $orgId, array $input): array
+    {
+        $limit = $this->normalizeLimit($input['limit'] ?? 20);
+        $action = trim((string) ($input['action'] ?? ''));
+        if (! in_array($action, self::BIG5_ACTIONS, true)) {
+            $action = '';
+        }
+        $result = $this->normalizeAuditResult((string) ($input['result'] ?? ''));
+        $releaseId = trim((string) ($input['release_id'] ?? ''));
+
+        $rows = $this->queryService->listAudits($action, $result, $releaseId, $limit);
+        $items = [];
+        foreach ($rows as $row) {
+            $items[] = $this->mapAuditRow($row);
+        }
+
+        return [
+            'status' => 200,
+            'payload' => [
+                'ok' => true,
+                'org_id' => $orgId,
+                'count' => count($items),
+                'items' => $items,
+            ],
+        ];
+    }
+
+    /**
+     * @return array{status:int,payload:array<string,mixed>}
+     */
+    public function audit(int $orgId, string $auditId): array
+    {
+        $auditId = trim($auditId);
+        if ($auditId === '') {
+            return [
+                'status' => 404,
+                'payload' => [
+                    'ok' => false,
+                    'error_code' => 'AUDIT_NOT_FOUND',
+                    'message' => 'audit not found.',
+                ],
+            ];
+        }
+
+        $row = $this->queryService->findAuditById($auditId);
+        if (! is_object($row)) {
+            return [
+                'status' => 404,
+                'payload' => [
+                    'ok' => false,
+                    'error_code' => 'AUDIT_NOT_FOUND',
+                    'message' => 'audit not found.',
+                ],
+            ];
+        }
+
+        $release = null;
+        $targetType = (string) ($row->target_type ?? '');
+        $targetId = (string) ($row->target_id ?? '');
+        if ($targetType === 'content_pack_release' && $targetId !== '') {
+            $releaseRow = $this->queryService->findBig5ReleaseById($targetId);
+            if (is_object($releaseRow)) {
+                $release = $this->mapReleaseRow($releaseRow);
+            }
+        }
+
+        return [
+            'status' => 200,
+            'payload' => [
+                'ok' => true,
+                'org_id' => $orgId,
+                'item' => $this->mapAuditRow($row),
+                'release' => $release,
+            ],
+        ];
+    }
+
+    /**
+     * @return array{status:int,payload:array<string,mixed>}
+     */
+    public function release(int $orgId, string $releaseId): array
+    {
+        $releaseId = trim($releaseId);
+        if ($releaseId === '') {
+            return [
+                'status' => 404,
+                'payload' => [
+                    'ok' => false,
+                    'error_code' => 'RELEASE_NOT_FOUND',
+                    'message' => 'release not found.',
+                ],
+            ];
+        }
+
+        $row = $this->queryService->findBig5ReleaseById($releaseId);
+        if (! is_object($row)) {
+            return [
+                'status' => 404,
+                'payload' => [
+                    'ok' => false,
+                    'error_code' => 'RELEASE_NOT_FOUND',
+                    'message' => 'release not found.',
+                ],
+            ];
+        }
+
+        $audits = $this->queryService->listReleaseAudits($releaseId, 20);
+        $auditItems = [];
+        foreach ($audits as $audit) {
+            $auditItems[] = $this->mapAuditRow($audit);
+        }
+
+        return [
+            'status' => 200,
+            'payload' => [
+                'ok' => true,
+                'org_id' => $orgId,
+                'item' => $this->mapReleaseRow($row),
+                'audits' => $auditItems,
+            ],
+        ];
+    }
+
+    /**
+     * @param  array<string,mixed>  $input
+     * @param  array<string,mixed>  $context
+     * @return array{status:int,payload:array<string,mixed>}
+     */
+    public function publish(int $orgId, array $input, array $context): array
+    {
+        $region = $this->normalizeRegion((string) ($input['region'] ?? 'CN_MAINLAND'));
+        $locale = $this->normalizeLocale((string) ($input['locale'] ?? 'zh-CN'));
+        $dirAlias = $this->normalizeDirAlias((string) ($input['dir_alias'] ?? 'v1'));
+        $pack = trim((string) ($input['pack'] ?? 'BIG5_OCEAN'));
+        $packVersion = trim((string) ($input['pack_version'] ?? 'v1'));
+        $probe = $this->toBool($input['probe'] ?? false);
+        $skipDrift = $this->toBool($input['skip_drift'] ?? true);
+        $baseUrl = trim((string) ($input['base_url'] ?? ''));
+
+        $startedAt = now();
+        $args = [
+            '--scale' => 'BIG5_OCEAN',
+            '--pack' => $pack === '' ? 'BIG5_OCEAN' : $pack,
+            '--pack-version' => $packVersion === '' ? 'v1' : $packVersion,
+            '--region' => $region,
+            '--locale' => $locale,
+            '--dir_alias' => $dirAlias,
+            '--probe' => $probe ? '1' : '0',
+            '--skip_drift' => $skipDrift ? '1' : '0',
+            '--created_by' => $this->resolveActor($context['fm_user_id'] ?? null, $orgId),
+        ];
+        if ($baseUrl !== '') {
+            $args['--base_url'] = $baseUrl;
+        }
+        foreach (['drift_from', 'drift_to', 'drift_group_id', 'drift_threshold_mean', 'drift_threshold_sd'] as $key) {
+            $val = trim((string) ($input[$key] ?? ''));
+            if ($val !== '') {
+                $args['--'.str_replace('_', '-', $key)] = $val;
+            }
+        }
+
+        $command = $this->commandRunner->run('packs:publish', $args);
+        $exitCode = (int) $command['exit_code'];
+        $commandOutput = (string) $command['output'];
+        $releaseId = $this->extractCommandValue($commandOutput, 'release_id');
+        $release = null;
+        if ($releaseId !== '') {
+            $release = $this->queryService->findReleaseById($releaseId);
+        }
+        if (! is_object($release)) {
+            $release = $this->queryService->findBig5ReleaseByActionAndLocale(
+                'publish',
+                $region,
+                $locale,
+                $dirAlias,
+                $startedAt
+            );
+        }
+        if (! is_object($release)) {
+            return [
+                'status' => 422,
+                'payload' => [
+                    'ok' => false,
+                    'error_code' => 'PUBLISH_RELEASE_NOT_FOUND',
+                    'message' => $commandOutput === '' ? 'publish release not found.' : $commandOutput,
+                    'org_id' => $orgId,
+                    'action' => 'publish',
+                    'status' => 'failed',
+                    'exit_code' => $exitCode,
+                ],
+            ];
+        }
+
+        $mapped = $this->mapReleaseRow($release);
+        $status = (string) ($mapped['status'] ?? 'failed');
+        $ok = $exitCode === 0 && $status === 'success';
+
+        return [
+            'status' => $ok ? 200 : 422,
+            'payload' => [
+                'ok' => $ok,
+                'org_id' => $orgId,
+                'action' => 'publish',
+                'status' => $status,
+                'exit_code' => $exitCode,
+                'message' => $commandOutput === '' ? ((string) ($mapped['message'] ?? '')) : $commandOutput,
+                'release' => $mapped,
+            ],
+        ];
+    }
+
+    /**
+     * @param  array<string,mixed>  $input
+     * @return array{status:int,payload:array<string,mixed>}
+     */
+    public function rollback(int $orgId, array $input): array
+    {
+        $region = $this->normalizeRegion((string) ($input['region'] ?? 'CN_MAINLAND'));
+        $locale = $this->normalizeLocale((string) ($input['locale'] ?? 'zh-CN'));
+        $dirAlias = $this->normalizeDirAlias((string) ($input['dir_alias'] ?? 'v1'));
+        $probe = $this->toBool($input['probe'] ?? false);
+        $baseUrl = trim((string) ($input['base_url'] ?? ''));
+        $toReleaseId = trim((string) ($input['to_release_id'] ?? ''));
+
+        $startedAt = now();
+        $args = [
+            '--scale' => 'BIG5_OCEAN',
+            '--region' => $region,
+            '--locale' => $locale,
+            '--dir_alias' => $dirAlias,
+            '--probe' => $probe ? '1' : '0',
+        ];
+        if ($baseUrl !== '') {
+            $args['--base_url'] = $baseUrl;
+        }
+        if ($toReleaseId !== '') {
+            $args['--to_release_id'] = $toReleaseId;
+        }
+
+        $command = $this->commandRunner->run('packs:rollback', $args);
+        $exitCode = (int) $command['exit_code'];
+        $commandOutput = (string) $command['output'];
+        $releaseId = $this->extractCommandValue($commandOutput, 'release_id');
+        $release = null;
+        if ($releaseId !== '') {
+            $release = $this->queryService->findReleaseById($releaseId);
+        }
+        if (! is_object($release)) {
+            $release = $this->queryService->findBig5ReleaseByActionAndLocale(
+                'rollback',
+                $region,
+                $locale,
+                $dirAlias,
+                $startedAt
+            );
+        }
+        if (! is_object($release)) {
+            return [
+                'status' => 422,
+                'payload' => [
+                    'ok' => false,
+                    'error_code' => 'ROLLBACK_RELEASE_NOT_FOUND',
+                    'message' => $commandOutput === '' ? 'rollback release not found.' : $commandOutput,
+                    'org_id' => $orgId,
+                    'action' => 'rollback',
+                    'status' => 'failed',
+                    'exit_code' => $exitCode,
+                ],
+            ];
+        }
+
+        $mapped = $this->mapReleaseRow($release);
+        $status = (string) ($mapped['status'] ?? 'failed');
+        $ok = $exitCode === 0 && $status === 'success';
+
+        return [
+            'status' => $ok ? 200 : 422,
+            'payload' => [
+                'ok' => $ok,
+                'org_id' => $orgId,
+                'action' => 'rollback',
+                'status' => $status,
+                'exit_code' => $exitCode,
+                'message' => $commandOutput === '' ? ((string) ($mapped['message'] ?? '')) : $commandOutput,
+                'release' => $mapped,
+            ],
+        ];
+    }
+
+    /**
+     * @param  array<string,mixed>  $input
+     * @param  array<string,mixed>  $context
+     * @return array{status:int,payload:array<string,mixed>}
+     */
+    public function rebuildNorms(int $orgId, array $input, array $context): array
+    {
+        $locale = $this->normalizeLocale((string) ($input['locale'] ?? 'zh-CN'));
+        $region = $this->normalizeRegion((string) ($input['region'] ?? ($locale === 'zh-CN' ? 'CN_MAINLAND' : 'GLOBAL')));
+        $group = trim((string) ($input['group'] ?? 'prod_all_18-60'));
+        if ($group === '') {
+            $group = 'prod_all_18-60';
+        }
+        $groupId = $this->resolveGroupId($locale, $group);
+        $gender = strtoupper(trim((string) ($input['gender'] ?? 'ALL')));
+        if ($gender === '') {
+            $gender = 'ALL';
+        }
+        $ageMin = max(1, (int) ($input['age_min'] ?? 18));
+        $ageMax = max($ageMin, (int) ($input['age_max'] ?? 60));
+        $windowDays = max(1, (int) ($input['window_days'] ?? 365));
+        $minSamples = max(1, (int) ($input['min_samples'] ?? 1000));
+        $onlyQuality = trim((string) ($input['only_quality'] ?? 'AB'));
+        if ($onlyQuality === '') {
+            $onlyQuality = 'AB';
+        }
+        $normsVersion = trim((string) ($input['norms_version'] ?? ''));
+        $activate = $this->toBool($input['activate'] ?? true);
+        $dryRun = $this->toBool($input['dry_run'] ?? false);
+
+        $args = [
+            '--locale' => $locale,
+            '--region' => $region,
+            '--group' => $group,
+            '--gender' => $gender,
+            '--age_min' => (string) $ageMin,
+            '--age_max' => (string) $ageMax,
+            '--window_days' => (string) $windowDays,
+            '--min_samples' => (string) $minSamples,
+            '--only_quality' => $onlyQuality,
+            '--activate' => $activate ? '1' : '0',
+            '--dry-run' => $dryRun ? '1' : '0',
+        ];
+        if ($normsVersion !== '') {
+            $args['--norms_version'] = $normsVersion;
+        }
+
+        $command = $this->commandRunner->run('norms:big5:rebuild', $args);
+        $exitCode = (int) $command['exit_code'];
+        $commandOutput = (string) $command['output'];
+        $status = $exitCode === 0 ? 'success' : 'failed';
+        $reason = $status === 'success' ? null : 'REBUILD_FAILED';
+
+        $versionRow = null;
+        if ($status === 'success' && ! $dryRun) {
+            $versionRow = $this->queryService->findLatestNormVersion($region, $locale, $groupId, $normsVersion);
+        }
+
+        $this->recordOpsAudit(
+            'big5_norms_rebuild',
+            'norms_group',
+            $groupId,
+            $status,
+            $reason,
+            [
+                'org_id' => $orgId,
+                'scale_code' => 'BIG5_OCEAN',
+                'locale' => $locale,
+                'region' => $region,
+                'group_id' => $groupId,
+                'gender' => $gender,
+                'age_min' => $ageMin,
+                'age_max' => $ageMax,
+                'window_days' => $windowDays,
+                'min_samples' => $minSamples,
+                'only_quality' => $onlyQuality,
+                'norms_version' => $normsVersion,
+                'activate' => $activate,
+                'dry_run' => $dryRun,
+                'exit_code' => $exitCode,
+                'output' => $commandOutput,
+            ],
+            $context
+        );
+
+        return [
+            'status' => $status === 'success' ? 200 : 422,
+            'payload' => [
+                'ok' => $status === 'success',
+                'org_id' => $orgId,
+                'action' => 'norms_rebuild',
+                'status' => $status,
+                'exit_code' => $exitCode,
+                'message' => $commandOutput,
+                'item' => is_object($versionRow) ? $this->mapNormVersionRow($versionRow) : null,
+            ],
+        ];
+    }
+
+    /**
+     * @param  array<string,mixed>  $input
+     * @param  array<string,mixed>  $context
+     * @return array{status:int,payload:array<string,mixed>}
+     */
+    public function driftCheckNorms(int $orgId, array $input, array $context): array
+    {
+        $from = trim((string) ($input['from'] ?? ''));
+        $to = trim((string) ($input['to'] ?? ''));
+        if ($from === '' || $to === '') {
+            return [
+                'status' => 422,
+                'payload' => [
+                    'ok' => false,
+                    'error_code' => 'INVALID_ARGUMENT',
+                    'message' => 'from and to are required.',
+                ],
+            ];
+        }
+
+        $groupId = trim((string) ($input['group_id'] ?? ''));
+        $thresholdMean = trim((string) ($input['threshold_mean'] ?? '0.35'));
+        $thresholdSd = trim((string) ($input['threshold_sd'] ?? '0.35'));
+
+        $args = [
+            '--scale' => 'BIG5_OCEAN',
+            '--from' => $from,
+            '--to' => $to,
+            '--threshold_mean' => $thresholdMean === '' ? '0.35' : $thresholdMean,
+            '--threshold_sd' => $thresholdSd === '' ? '0.35' : $thresholdSd,
+        ];
+        if ($groupId !== '') {
+            $args['--group_id'] = $groupId;
+        }
+
+        $command = $this->commandRunner->run('norms:big5:drift-check', $args);
+        $exitCode = (int) $command['exit_code'];
+        $commandOutput = (string) $command['output'];
+        $status = $exitCode === 0 ? 'success' : 'failed';
+        $reason = $status === 'success' ? null : 'DRIFT_CHECK_FAILED';
+
+        $this->recordOpsAudit(
+            'big5_norms_drift_check',
+            'norms_group',
+            $groupId === '' ? 'all' : $groupId,
+            $status,
+            $reason,
+            [
+                'org_id' => $orgId,
+                'scale_code' => 'BIG5_OCEAN',
+                'from' => $from,
+                'to' => $to,
+                'group_id' => $groupId,
+                'threshold_mean' => (float) ($thresholdMean === '' ? '0.35' : $thresholdMean),
+                'threshold_sd' => (float) ($thresholdSd === '' ? '0.35' : $thresholdSd),
+                'exit_code' => $exitCode,
+                'output' => $commandOutput,
+            ],
+            $context
+        );
+
+        return [
+            'status' => $status === 'success' ? 200 : 422,
+            'payload' => [
+                'ok' => $status === 'success',
+                'org_id' => $orgId,
+                'action' => 'norms_drift_check',
+                'status' => $status,
+                'exit_code' => $exitCode,
+                'message' => $commandOutput,
+            ],
+        ];
+    }
+
+    /**
+     * @param  array<string,mixed>  $input
+     * @param  array<string,mixed>  $context
+     * @return array{status:int,payload:array<string,mixed>}
+     */
+    public function activateNorms(int $orgId, array $input, array $context): array
+    {
+        $groupId = trim((string) ($input['group_id'] ?? ''));
+        $normsVersion = trim((string) ($input['norms_version'] ?? ''));
+        $region = $this->normalizeRegion((string) ($input['region'] ?? 'CN_MAINLAND'));
+        $locale = $this->normalizeLocale((string) ($input['locale'] ?? 'zh-CN'));
+
+        if ($groupId === '' || $normsVersion === '') {
+            return [
+                'status' => 422,
+                'payload' => [
+                    'ok' => false,
+                    'error_code' => 'INVALID_ARGUMENT',
+                    'message' => 'group_id and norms_version are required.',
+                ],
+            ];
+        }
+
+        try {
+            $updated = $this->queryService->activateNormVersion($groupId, $normsVersion, $region, $locale);
+        } catch (Throwable $e) {
+            $this->recordOpsAudit(
+                'big5_norms_activate',
+                'norms_group',
+                $groupId,
+                'failed',
+                'ACTIVATE_FAILED',
+                [
+                    'org_id' => $orgId,
+                    'scale_code' => 'BIG5_OCEAN',
+                    'group_id' => $groupId,
+                    'norms_version' => $normsVersion,
+                    'region' => $region,
+                    'locale' => $locale,
+                    'error_message' => $e->getMessage(),
+                ],
+                $context
+            );
+
+            return [
+                'status' => 500,
+                'payload' => [
+                    'ok' => false,
+                    'error_code' => 'ACTIVATE_FAILED',
+                    'message' => $e->getMessage(),
+                ],
+            ];
+        }
+
+        if (! is_object($updated)) {
+            $this->recordOpsAudit(
+                'big5_norms_activate',
+                'norms_group',
+                $groupId,
+                'failed',
+                'NORM_VERSION_NOT_FOUND',
+                [
+                    'org_id' => $orgId,
+                    'scale_code' => 'BIG5_OCEAN',
+                    'group_id' => $groupId,
+                    'norms_version' => $normsVersion,
+                    'region' => $region,
+                    'locale' => $locale,
+                ],
+                $context
+            );
+
+            return [
+                'status' => 404,
+                'payload' => [
+                    'ok' => false,
+                    'error_code' => 'NORM_VERSION_NOT_FOUND',
+                    'message' => 'norm version not found.',
+                ],
+            ];
+        }
+
+        $this->recordOpsAudit(
+            'big5_norms_activate',
+            'norms_group',
+            $groupId,
+            'success',
+            null,
+            [
+                'org_id' => $orgId,
+                'scale_code' => 'BIG5_OCEAN',
+                'group_id' => $groupId,
+                'norms_version' => $normsVersion,
+                'region' => $region,
+                'locale' => $locale,
+                'norm_version_id' => (string) ($updated->id ?? ''),
+            ],
+            $context
+        );
+
+        return [
+            'status' => 200,
+            'payload' => [
+                'ok' => true,
+                'org_id' => $orgId,
+                'action' => 'norms_activate',
+                'status' => 'success',
+                'item' => $this->mapNormVersionRow($updated),
+            ],
+        ];
+    }
+
+    private function normalizeRegion(string $region): string
+    {
+        $normalized = strtoupper(trim($region));
+        if ($normalized === '') {
+            return 'CN_MAINLAND';
+        }
+
+        return $normalized;
+    }
+
+    private function normalizeLocale(string $locale): string
+    {
+        $normalized = trim($locale);
+        if ($normalized === '') {
+            return 'zh-CN';
+        }
+
+        return $normalized;
+    }
+
+    private function normalizeDirAlias(string $dirAlias): string
+    {
+        $normalized = trim($dirAlias);
+        if ($normalized === '') {
+            return 'v1';
+        }
+
+        return $normalized;
+    }
+
+    private function normalizeReleaseAction(string $action): string
+    {
+        $normalized = strtolower(trim($action));
+        if (! in_array($normalized, ['publish', 'rollback'], true)) {
+            return '';
+        }
+
+        return $normalized;
+    }
+
+    private function normalizeAuditResult(string $result): string
+    {
+        $normalized = strtolower(trim($result));
+        if (! in_array($normalized, ['success', 'failed'], true)) {
+            return '';
+        }
+
+        return $normalized;
+    }
+
+    private function normalizeLimit(mixed $value): int
+    {
+        $limit = (int) $value;
+        if ($limit < 1) {
+            return 1;
+        }
+        if ($limit > 100) {
+            return 100;
+        }
+
+        return $limit;
+    }
+
+    private function resolveActor(mixed $fmUserId, int $orgId): string
+    {
+        $userId = is_numeric($fmUserId) ? (string) (int) $fmUserId : trim((string) $fmUserId);
+        if ($userId === '') {
+            $userId = '0';
+        }
+
+        return "ops_user:{$userId}@org:{$orgId}";
+    }
+
+    private function toBool(mixed $value): bool
+    {
+        if (is_bool($value)) {
+            return $value;
+        }
+        if (is_numeric($value)) {
+            return (int) $value === 1;
+        }
+
+        $normalized = strtolower(trim((string) $value));
+
+        return in_array($normalized, ['1', 'true', 'yes', 'on'], true);
+    }
+
+    private function resolveGroupId(string $locale, string $group): string
+    {
+        if (str_starts_with($group, $locale.'_')) {
+            return $group;
+        }
+
+        return $locale.'_'.$group;
+    }
+
+    private function extractCommandValue(string $output, string $key): string
+    {
+        $needle = $key.'=';
+        foreach (preg_split('/\\r\\n|\\r|\\n/', $output) as $line) {
+            $line = trim((string) $line);
+            if ($line === '' || ! str_starts_with($line, $needle)) {
+                continue;
+            }
+
+            return trim(substr($line, strlen($needle)));
+        }
+
+        return '';
+    }
+
+    /**
+     * @param  array<string,mixed>  $meta
+     * @param  array<string,mixed>  $context
+     */
+    private function recordOpsAudit(
+        string $action,
+        string $targetType,
+        string $targetId,
+        string $result,
+        ?string $reason,
+        array $meta,
+        array $context
+    ): void {
+        $this->queryService->insertAudit(
+            $action,
+            $targetType,
+            $targetId,
+            $result,
+            $reason,
+            $meta,
+            (string) ($context['ip'] ?? ''),
+            (string) ($context['user_agent'] ?? ''),
+            (string) ($context['request_id'] ?? '')
+        );
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    private function mapNormVersionRow(object $row): array
+    {
+        return [
+            'id' => (string) ($row->id ?? ''),
+            'scale_code' => (string) ($row->scale_code ?? ''),
+            'region' => (string) ($row->region ?? ''),
+            'locale' => (string) ($row->locale ?? ''),
+            'group_id' => (string) ($row->group_id ?? ''),
+            'norms_version' => (string) ($row->version ?? ''),
+            'status' => (string) ($row->status ?? ''),
+            'is_active' => (bool) ($row->is_active ?? false),
+            'source_id' => (string) ($row->source_id ?? ''),
+            'source_type' => (string) ($row->source_type ?? ''),
+            'published_at' => (string) ($row->published_at ?? ''),
+            'updated_at' => (string) ($row->updated_at ?? ''),
+        ];
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    private function mapReleaseRow(object $row): array
+    {
+        return [
+            'release_id' => (string) ($row->id ?? ''),
+            'action' => (string) ($row->action ?? ''),
+            'status' => (string) ($row->status ?? ''),
+            'message' => (string) ($row->message ?? ''),
+            'dir_alias' => (string) ($row->dir_alias ?? ''),
+            'region' => (string) ($row->region ?? ''),
+            'locale' => (string) ($row->locale ?? ''),
+            'from_pack_id' => (string) ($row->from_pack_id ?? ''),
+            'to_pack_id' => (string) ($row->to_pack_id ?? ''),
+            'from_version_id' => (string) ($row->from_version_id ?? ''),
+            'to_version_id' => (string) ($row->to_version_id ?? ''),
+            'created_by' => (string) ($row->created_by ?? ''),
+            'created_at' => (string) ($row->created_at ?? ''),
+            'updated_at' => (string) ($row->updated_at ?? ''),
+            'evidence' => [
+                'manifest_hash' => (string) ($row->manifest_hash ?? ''),
+                'compiled_hash' => (string) ($row->compiled_hash ?? ''),
+                'content_hash' => (string) ($row->content_hash ?? ''),
+                'norms_version' => (string) ($row->norms_version ?? ''),
+                'git_sha' => (string) ($row->git_sha ?? ''),
+            ],
+        ];
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    private function mapAuditRow(object $row): array
+    {
+        return [
+            'id' => (int) ($row->id ?? 0),
+            'action' => (string) ($row->action ?? ''),
+            'result' => (string) ($row->result ?? ''),
+            'reason' => (string) ($row->reason ?? ''),
+            'target_type' => (string) ($row->target_type ?? ''),
+            'target_id' => (string) ($row->target_id ?? ''),
+            'request_id' => (string) ($row->request_id ?? ''),
+            'created_at' => (string) ($row->created_at ?? ''),
+            'meta' => $this->decodeJson((string) ($row->meta_json ?? '')),
+        ];
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    private function decodeJson(string $json): array
+    {
+        $decoded = json_decode($json, true);
+
+        return is_array($decoded) ? $decoded : [];
+    }
+}

--- a/backend/app/Services/Ops/BigFiveOpsCommandRunner.php
+++ b/backend/app/Services/Ops/BigFiveOpsCommandRunner.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\Ops;
+
+use Illuminate\Support\Facades\Artisan;
+
+final class BigFiveOpsCommandRunner
+{
+    /**
+     * @param  array<string,scalar>  $args
+     * @return array{exit_code:int,output:string}
+     */
+    public function run(string $command, array $args): array
+    {
+        $exitCode = Artisan::call($command, $args);
+
+        return [
+            'exit_code' => $exitCode,
+            'output' => trim(Artisan::output()),
+        ];
+    }
+}

--- a/backend/app/Services/Ops/BigFiveOpsQueryService.php
+++ b/backend/app/Services/Ops/BigFiveOpsQueryService.php
@@ -1,0 +1,278 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\Ops;
+
+use Carbon\CarbonInterface;
+use Illuminate\Support\Facades\DB;
+
+final class BigFiveOpsQueryService
+{
+    /**
+     * @var list<string>
+     */
+    private const BIG5_ACTIONS = [
+        'big5_pack_publish',
+        'big5_pack_rollback',
+    ];
+
+    public function findLatestRelease(string $region, string $locale, string $action = ''): ?object
+    {
+        $query = DB::table('content_pack_releases')
+            ->where('region', $region)
+            ->where('locale', $locale)
+            ->where(function ($q): void {
+                $q->where('to_pack_id', 'BIG5_OCEAN')
+                    ->orWhere('from_pack_id', 'BIG5_OCEAN');
+            });
+
+        if ($action !== '') {
+            $query->where('action', $action);
+        }
+
+        $row = $query
+            ->orderByDesc('created_at')
+            ->orderByDesc('updated_at')
+            ->first();
+
+        return is_object($row) ? $row : null;
+    }
+
+    /**
+     * @return list<object>
+     */
+    public function listReleases(string $region, string $locale, string $action, int $limit): array
+    {
+        $query = DB::table('content_pack_releases')
+            ->where('region', $region)
+            ->where('locale', $locale)
+            ->where(function ($q): void {
+                $q->where('to_pack_id', 'BIG5_OCEAN')
+                    ->orWhere('from_pack_id', 'BIG5_OCEAN');
+            });
+
+        if ($action !== '') {
+            $query->where('action', $action);
+        }
+
+        $rows = $query
+            ->orderByDesc('created_at')
+            ->orderByDesc('updated_at')
+            ->limit($limit)
+            ->get();
+
+        return $rows->all();
+    }
+
+    /**
+     * @return list<object>
+     */
+    public function listLatestReleaseAudits(string $releaseId, string $result, int $limit): array
+    {
+        $query = DB::table('audit_logs')
+            ->whereIn('action', self::BIG5_ACTIONS)
+            ->where('target_id', $releaseId);
+
+        if ($result !== '') {
+            $query->where('result', $result);
+        }
+
+        $rows = $query
+            ->orderByDesc('id')
+            ->limit($limit)
+            ->get();
+
+        return $rows->all();
+    }
+
+    /**
+     * @return list<object>
+     */
+    public function listAudits(string $action, string $result, string $releaseId, int $limit): array
+    {
+        $query = DB::table('audit_logs')
+            ->whereIn('action', self::BIG5_ACTIONS);
+
+        if ($action !== '') {
+            $query->where('action', $action);
+        }
+        if ($result !== '') {
+            $query->where('result', $result);
+        }
+        if ($releaseId !== '') {
+            $query->where('target_id', $releaseId);
+        }
+
+        $rows = $query
+            ->orderByDesc('id')
+            ->limit($limit)
+            ->get();
+
+        return $rows->all();
+    }
+
+    public function findAuditById(string $auditId): ?object
+    {
+        $row = DB::table('audit_logs')
+            ->where('id', $auditId)
+            ->whereIn('action', self::BIG5_ACTIONS)
+            ->first();
+
+        return is_object($row) ? $row : null;
+    }
+
+    public function findReleaseById(string $releaseId): ?object
+    {
+        $row = DB::table('content_pack_releases')
+            ->where('id', $releaseId)
+            ->first();
+
+        return is_object($row) ? $row : null;
+    }
+
+    public function findBig5ReleaseById(string $releaseId): ?object
+    {
+        $row = DB::table('content_pack_releases')
+            ->where('id', $releaseId)
+            ->where(function ($q): void {
+                $q->where('to_pack_id', 'BIG5_OCEAN')
+                    ->orWhere('from_pack_id', 'BIG5_OCEAN');
+            })
+            ->first();
+
+        return is_object($row) ? $row : null;
+    }
+
+    public function findBig5ReleaseByActionAndLocale(
+        string $action,
+        string $region,
+        string $locale,
+        string $dirAlias,
+        CarbonInterface $startedAt
+    ): ?object {
+        $row = DB::table('content_pack_releases')
+            ->where('action', $action)
+            ->where('region', $region)
+            ->where('locale', $locale)
+            ->where('dir_alias', $dirAlias)
+            ->where(function ($q): void {
+                $q->where('to_pack_id', 'BIG5_OCEAN')
+                    ->orWhere('from_pack_id', 'BIG5_OCEAN');
+            })
+            ->where('created_at', '>=', $startedAt->copy()->subSeconds(2))
+            ->orderByDesc('created_at')
+            ->orderByDesc('updated_at')
+            ->first();
+
+        return is_object($row) ? $row : null;
+    }
+
+    /**
+     * @return list<object>
+     */
+    public function listReleaseAudits(string $releaseId, int $limit = 20): array
+    {
+        $rows = DB::table('audit_logs')
+            ->whereIn('action', self::BIG5_ACTIONS)
+            ->where('target_id', $releaseId)
+            ->orderByDesc('id')
+            ->limit($limit)
+            ->get();
+
+        return $rows->all();
+    }
+
+    public function findLatestNormVersion(
+        string $region,
+        string $locale,
+        string $groupId,
+        string $normsVersion = ''
+    ): ?object {
+        $query = DB::table('scale_norms_versions')
+            ->where('scale_code', 'BIG5_OCEAN')
+            ->where('region', $region)
+            ->where('locale', $locale)
+            ->where('group_id', $groupId);
+
+        if ($normsVersion !== '') {
+            $query->where('version', $normsVersion);
+        }
+
+        $row = $query->orderByDesc('created_at')->first();
+
+        return is_object($row) ? $row : null;
+    }
+
+    public function activateNormVersion(
+        string $groupId,
+        string $normsVersion,
+        string $region,
+        string $locale
+    ): ?object {
+        $updated = DB::transaction(function () use ($groupId, $normsVersion, $region, $locale): ?object {
+            $target = DB::table('scale_norms_versions')
+                ->where('scale_code', 'BIG5_OCEAN')
+                ->where('group_id', $groupId)
+                ->where('version', $normsVersion)
+                ->where('region', $region)
+                ->where('locale', $locale)
+                ->first();
+            if (! is_object($target)) {
+                return null;
+            }
+
+            DB::table('scale_norms_versions')
+                ->where('scale_code', 'BIG5_OCEAN')
+                ->where('group_id', $groupId)
+                ->update([
+                    'is_active' => 0,
+                    'updated_at' => now(),
+                ]);
+
+            DB::table('scale_norms_versions')
+                ->where('id', (string) $target->id)
+                ->update([
+                    'is_active' => 1,
+                    'updated_at' => now(),
+                ]);
+
+            $row = DB::table('scale_norms_versions')
+                ->where('id', (string) $target->id)
+                ->first();
+
+            return is_object($row) ? $row : null;
+        });
+
+        return is_object($updated) ? $updated : null;
+    }
+
+    /**
+     * @param  array<string,mixed>  $meta
+     */
+    public function insertAudit(
+        string $action,
+        string $targetType,
+        string $targetId,
+        string $result,
+        ?string $reason,
+        array $meta,
+        string $ip,
+        string $userAgent,
+        string $requestId
+    ): void {
+        DB::table('audit_logs')->insert([
+            'actor_admin_id' => null,
+            'action' => $action,
+            'target_type' => $targetType,
+            'target_id' => $targetId,
+            'meta_json' => json_encode($meta, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES),
+            'ip' => substr($ip, 0, 64),
+            'user_agent' => substr($userAgent, 0, 255),
+            'request_id' => substr($requestId, 0, 128),
+            'reason' => $reason,
+            'result' => $result,
+            'created_at' => now(),
+        ]);
+    }
+}

--- a/backend/app/Services/Report/ReportComposerRegistry.php
+++ b/backend/app/Services/Report/ReportComposerRegistry.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\Report;
+
+use App\Models\Attempt;
+use App\Models\Result;
+use App\Services\Assessment\GenericReportBuilder;
+
+final class ReportComposerRegistry
+{
+    public function __construct(
+        private readonly ReportComposer $reportComposer,
+        private readonly BigFiveReportComposer $bigFiveReportComposer,
+        private readonly ClinicalCombo68ReportComposer $clinicalCombo68ReportComposer,
+        private readonly Sds20ReportComposer $sds20ReportComposer,
+        private readonly Eq60ReportComposer $eq60ReportComposer,
+        private readonly GenericReportBuilder $genericReportBuilder,
+    ) {}
+
+    /**
+     * @param  array<string,mixed>  $ctx
+     * @return array{ok:bool,report?:array<string,mixed>,error?:string,message?:string,status?:int}
+     */
+    public function composeVariant(
+        string $scaleCode,
+        Attempt $attempt,
+        Result $result,
+        string $variant,
+        array $ctx = []
+    ): array {
+        $scaleCode = strtoupper(trim($scaleCode));
+
+        return match ($scaleCode) {
+            'MBTI' => $this->reportComposer->composeVariant($attempt, $variant, $ctx, $result),
+            'BIG5_OCEAN' => $this->bigFiveReportComposer->composeVariant($attempt, $result, $variant, $ctx),
+            'CLINICAL_COMBO_68' => $this->clinicalCombo68ReportComposer->composeVariant($attempt, $result, $variant, $ctx),
+            'SDS_20' => $this->sds20ReportComposer->composeVariant($attempt, $result, $variant, $ctx),
+            'EQ_60' => $this->eq60ReportComposer->composeVariant($attempt, $result, $variant, $ctx),
+            default => [
+                'ok' => true,
+                'report' => $this->genericReportBuilder->build($attempt, $result),
+            ],
+        };
+    }
+}

--- a/backend/app/Services/Report/ReportGatekeeper.php
+++ b/backend/app/Services/Report/ReportGatekeeper.php
@@ -4,8 +4,6 @@ namespace App\Services\Report;
 
 use App\Models\Attempt;
 use App\Models\Result;
-use App\Services\Analytics\EventRecorder;
-use App\Services\Assessment\GenericReportBuilder;
 use App\Services\Commerce\EntitlementManager;
 use App\Services\Commerce\SkuCatalog;
 use App\Services\Scale\ScaleRegistry;
@@ -30,15 +28,8 @@ class ReportGatekeeper
         private ScaleRegistry $registry,
         private EntitlementManager $entitlements,
         private SkuCatalog $skus,
-        private ReportComposer $reportComposer,
-        private BigFiveReportComposer $bigFiveReportComposer,
-        private ClinicalCombo68ReportComposer $clinicalCombo68ReportComposer,
-        private Sds20ReportComposer $sds20ReportComposer,
-        private Eq60ReportComposer $eq60ReportComposer,
-        private GenericReportBuilder $genericReportBuilder,
-        private EventRecorder $eventRecorder,
-    ) {
-    }
+        private ReportComposerRegistry $composerRegistry,
+    ) {}
 
     public function ensureAccess(
         int $orgId,
@@ -53,12 +44,12 @@ class ReportGatekeeper
         }
 
         $attempt = $this->ownedAttemptQuery($orgId, $attemptId, $userId, $anonId, $role)->first();
-        if (!$attempt) {
+        if (! $attempt) {
             return $this->notFound('ATTEMPT_NOT_FOUND', 'attempt not found.');
         }
 
         $result = Result::where('org_id', $orgId)->where('attempt_id', $attemptId)->first();
-        if (!$result) {
+        if (! $result) {
             return $this->notFound('RESULT_NOT_FOUND', 'result not found.');
         }
 
@@ -68,7 +59,7 @@ class ReportGatekeeper
         }
 
         $registry = $this->registry->getByCode($scaleCode, $orgId);
-        if (!$registry) {
+        if (! $registry) {
             return $this->notFound('SCALE_NOT_FOUND', 'scale not found.');
         }
 
@@ -89,7 +80,7 @@ class ReportGatekeeper
 
         return [
             'ok' => true,
-            'locked' => !$hasAccess,
+            'locked' => ! $hasAccess,
         ];
     }
 
@@ -108,12 +99,12 @@ class ReportGatekeeper
         }
 
         $attempt = $this->ownedAttemptQuery($orgId, $attemptId, $userId, $anonId, $role, $forceSystemAccess)->first();
-        if (!$attempt) {
+        if (! $attempt) {
             return $this->notFound('ATTEMPT_NOT_FOUND', 'attempt not found.');
         }
 
         $result = Result::where('org_id', $orgId)->where('attempt_id', $attemptId)->first();
-        if (!$result) {
+        if (! $result) {
             return $this->notFound('RESULT_NOT_FOUND', 'result not found.');
         }
 
@@ -123,7 +114,7 @@ class ReportGatekeeper
         }
 
         $registry = $this->registry->getByCode($scaleCode, $orgId);
-        if (!$registry) {
+        if (! $registry) {
             return $this->notFound('SCALE_NOT_FOUND', 'scale not found.');
         }
 
@@ -189,7 +180,7 @@ class ReportGatekeeper
                 [$fullModule, $freeModule]
             ));
         }
-        if (!in_array($freeModule, $modulesAllowed, true)) {
+        if (! in_array($freeModule, $modulesAllowed, true)) {
             $modulesAllowed[] = $freeModule;
             $modulesAllowed = ReportAccess::normalizeModules($modulesAllowed);
         }
@@ -220,7 +211,7 @@ class ReportGatekeeper
         $locked = $variant === ReportAccess::VARIANT_FREE;
 
         $shouldUseSnapshot = $hasFullAccess && $this->modulesCoverOffered($modulesAllowed, $modulesOffered);
-        if ($shouldUseSnapshot && !$forceRefresh) {
+        if ($shouldUseSnapshot && ! $forceRefresh) {
             $snapshotRow = DB::table('report_snapshots')
                 ->where('org_id', $orgId)
                 ->where('attempt_id', $attemptId)
@@ -300,18 +291,18 @@ class ReportGatekeeper
             $modulesAllowed,
             $modulesPreview
         );
-        if (!($built['ok'] ?? false)) {
+        if (! ($built['ok'] ?? false)) {
             return $built;
         }
 
         $report = $built['report'] ?? [];
-        if (!is_array($report)) {
+        if (! is_array($report)) {
             return $this->serverError('REPORT_FAILED', 'report generation failed.');
         }
 
         // Non-MBTI reports are still built by GenericReportBuilder. Re-apply teaser
         // masking when locked to avoid exposing full payload to unpaid users.
-        if ($locked && !in_array(strtoupper($scaleCode), ['MBTI', 'BIG5_OCEAN', 'CLINICAL_COMBO_68', 'SDS_20', 'EQ_60'], true)) {
+        if ($locked && ! in_array(strtoupper($scaleCode), ['MBTI', 'BIG5_OCEAN', 'CLINICAL_COMBO_68', 'SDS_20', 'EQ_60'], true)) {
             $report = $this->applyTeaser($report, $viewPolicy);
         }
 
@@ -422,8 +413,12 @@ class ReportGatekeeper
         $policy['blur_others'] = (bool) ($policy['blur_others'] ?? true);
 
         $pct = (float) ($policy['teaser_percent'] ?? self::DEFAULT_VIEW_POLICY['teaser_percent']);
-        if ($pct < 0) $pct = 0;
-        if ($pct > 1) $pct = 1;
+        if ($pct < 0) {
+            $pct = 0;
+        }
+        if ($pct > 1) {
+            $pct = 1;
+        }
         $policy['teaser_percent'] = $pct;
 
         $upgradeSku = trim((string) ($policy['upgrade_sku'] ?? ''));
@@ -438,6 +433,7 @@ class ReportGatekeeper
             $decoded = json_decode($raw, true);
             $raw = is_array($decoded) ? $decoded : null;
         }
+
         return is_array($raw) ? $raw : [];
     }
 
@@ -473,7 +469,7 @@ class ReportGatekeeper
     {
         $offers = [];
         foreach ($items as $item) {
-            if (!is_array($item)) {
+            if (! is_array($item)) {
                 continue;
             }
 
@@ -535,13 +531,13 @@ class ReportGatekeeper
             $decoded = json_decode($raw, true);
             $raw = is_array($decoded) ? $decoded : null;
         }
-        if (!is_array($raw)) {
+        if (! is_array($raw)) {
             return [];
         }
 
         $offers = [];
         foreach ($raw as $item) {
-            if (!is_array($item)) {
+            if (! is_array($item)) {
                 continue;
             }
 
@@ -598,7 +594,7 @@ class ReportGatekeeper
             $decoded = json_decode($raw, true);
             $raw = is_array($decoded) ? $decoded : null;
         }
-        if (!is_array($raw)) {
+        if (! is_array($raw)) {
             return [];
         }
 
@@ -609,7 +605,7 @@ class ReportGatekeeper
     {
         $modules = [];
         foreach ($offers as $offer) {
-            if (!is_array($offer)) {
+            if (! is_array($offer)) {
                 continue;
             }
             $modules = array_merge(
@@ -629,7 +625,7 @@ class ReportGatekeeper
 
         $allowed = array_fill_keys(ReportAccess::normalizeModules($modulesAllowed), true);
         foreach (ReportAccess::normalizeModules($modulesOffered) as $module) {
-            if (!isset($allowed[$module])) {
+            if (! isset($allowed[$module])) {
                 return false;
             }
         }
@@ -700,11 +696,14 @@ class ReportGatekeeper
         string $variant,
         array $modulesAllowed = [],
         array $modulesPreview = []
-    ): array
-    {
+    ): array {
         try {
-            if ($scaleCode === 'MBTI') {
-                $composed = $this->reportComposer->composeVariant($attempt, $variant, [
+            $composed = $this->composerRegistry->composeVariant(
+                $scaleCode,
+                $attempt,
+                $result,
+                $variant,
+                [
                     'org_id' => (int) ($attempt->org_id ?? 0),
                     'variant' => $variant,
                     'report_access_level' => $variant === ReportAccess::VARIANT_FREE
@@ -712,153 +711,18 @@ class ReportGatekeeper
                         : ReportAccess::REPORT_ACCESS_FULL,
                     'modules_allowed' => $modulesAllowed,
                     'modules_preview' => $modulesPreview,
-                ], $result);
-                if (!($composed['ok'] ?? false)) {
-                    return [
-                        'ok' => false,
-                        'error' => (string) ($composed['error'] ?? 'REPORT_FAILED'),
-                        'message' => (string) ($composed['message'] ?? 'report generation failed.'),
-                        'status' => (int) ($composed['status'] ?? 500),
-                    ];
-                }
-
-                $report = $composed['report'] ?? null;
-
-                return is_array($report)
-                    ? ['ok' => true, 'report' => $report]
-                    : [
-                        'ok' => false,
-                        'error' => 'REPORT_FAILED',
-                        'message' => 'report generation failed.',
-                        'status' => 500,
-                    ];
+                ]
+            );
+            if (! ($composed['ok'] ?? false)) {
+                return [
+                    'ok' => false,
+                    'error' => (string) ($composed['error'] ?? 'REPORT_FAILED'),
+                    'message' => (string) ($composed['message'] ?? 'report generation failed.'),
+                    'status' => (int) ($composed['status'] ?? 500),
+                ];
             }
 
-            if ($scaleCode === 'BIG5_OCEAN') {
-                $composed = $this->bigFiveReportComposer->composeVariant($attempt, $result, $variant, [
-                    'org_id' => (int) ($attempt->org_id ?? 0),
-                    'variant' => $variant,
-                    'report_access_level' => $variant === ReportAccess::VARIANT_FREE
-                        ? ReportAccess::REPORT_ACCESS_FREE
-                        : ReportAccess::REPORT_ACCESS_FULL,
-                    'modules_allowed' => $modulesAllowed,
-                    'modules_preview' => $modulesPreview,
-                ]);
-                if (!($composed['ok'] ?? false)) {
-                    return [
-                        'ok' => false,
-                        'error' => (string) ($composed['error'] ?? 'REPORT_FAILED'),
-                        'message' => (string) ($composed['message'] ?? 'report generation failed.'),
-                        'status' => (int) ($composed['status'] ?? 500),
-                    ];
-                }
-
-                $report = $composed['report'] ?? null;
-
-                return is_array($report)
-                    ? ['ok' => true, 'report' => $report]
-                    : [
-                        'ok' => false,
-                        'error' => 'REPORT_FAILED',
-                        'message' => 'report generation failed.',
-                        'status' => 500,
-                    ];
-            }
-
-            if ($scaleCode === 'CLINICAL_COMBO_68') {
-                $composed = $this->clinicalCombo68ReportComposer->composeVariant($attempt, $result, $variant, [
-                    'org_id' => (int) ($attempt->org_id ?? 0),
-                    'variant' => $variant,
-                    'report_access_level' => $variant === ReportAccess::VARIANT_FREE
-                        ? ReportAccess::REPORT_ACCESS_FREE
-                        : ReportAccess::REPORT_ACCESS_FULL,
-                    'modules_allowed' => $modulesAllowed,
-                    'modules_preview' => $modulesPreview,
-                ]);
-                if (!($composed['ok'] ?? false)) {
-                    return [
-                        'ok' => false,
-                        'error' => (string) ($composed['error'] ?? 'REPORT_FAILED'),
-                        'message' => (string) ($composed['message'] ?? 'report generation failed.'),
-                        'status' => (int) ($composed['status'] ?? 500),
-                    ];
-                }
-
-                $report = $composed['report'] ?? null;
-
-                return is_array($report)
-                    ? ['ok' => true, 'report' => $report]
-                    : [
-                        'ok' => false,
-                        'error' => 'REPORT_FAILED',
-                        'message' => 'report generation failed.',
-                        'status' => 500,
-                    ];
-            }
-
-            if ($scaleCode === 'SDS_20') {
-                $composed = $this->sds20ReportComposer->composeVariant($attempt, $result, $variant, [
-                    'org_id' => (int) ($attempt->org_id ?? 0),
-                    'variant' => $variant,
-                    'report_access_level' => $variant === ReportAccess::VARIANT_FREE
-                        ? ReportAccess::REPORT_ACCESS_FREE
-                        : ReportAccess::REPORT_ACCESS_FULL,
-                    'modules_allowed' => $modulesAllowed,
-                    'modules_preview' => $modulesPreview,
-                ]);
-                if (!($composed['ok'] ?? false)) {
-                    return [
-                        'ok' => false,
-                        'error' => (string) ($composed['error'] ?? 'REPORT_FAILED'),
-                        'message' => (string) ($composed['message'] ?? 'report generation failed.'),
-                        'status' => (int) ($composed['status'] ?? 500),
-                    ];
-                }
-
-                $report = $composed['report'] ?? null;
-
-                return is_array($report)
-                    ? ['ok' => true, 'report' => $report]
-                    : [
-                        'ok' => false,
-                        'error' => 'REPORT_FAILED',
-                        'message' => 'report generation failed.',
-                        'status' => 500,
-                    ];
-            }
-
-            if ($scaleCode === 'EQ_60') {
-                $composed = $this->eq60ReportComposer->composeVariant($attempt, $result, $variant, [
-                    'org_id' => (int) ($attempt->org_id ?? 0),
-                    'variant' => $variant,
-                    'report_access_level' => $variant === ReportAccess::VARIANT_FREE
-                        ? ReportAccess::REPORT_ACCESS_FREE
-                        : ReportAccess::REPORT_ACCESS_FULL,
-                    'modules_allowed' => $modulesAllowed,
-                    'modules_preview' => $modulesPreview,
-                ]);
-                if (!($composed['ok'] ?? false)) {
-                    return [
-                        'ok' => false,
-                        'error' => (string) ($composed['error'] ?? 'REPORT_FAILED'),
-                        'message' => (string) ($composed['message'] ?? 'report generation failed.'),
-                        'status' => (int) ($composed['status'] ?? 500),
-                    ];
-                }
-
-                $report = $composed['report'] ?? null;
-
-                return is_array($report)
-                    ? ['ok' => true, 'report' => $report]
-                    : [
-                        'ok' => false,
-                        'error' => 'REPORT_FAILED',
-                        'message' => 'report generation failed.',
-                        'status' => 500,
-                    ];
-            }
-
-            $report = $this->genericReportBuilder->build($attempt, $result);
+            $report = $composed['report'] ?? null;
 
             return is_array($report)
                 ? ['ok' => true, 'report' => $report]
@@ -887,6 +751,7 @@ class ReportGatekeeper
         }
         if (is_string($raw)) {
             $decoded = json_decode($raw, true);
+
             return is_array($decoded) ? $decoded : [];
         }
 
@@ -906,8 +771,7 @@ class ReportGatekeeper
         array $modulesPreview = [],
         array $norms = [],
         array $quality = []
-    ): array
-    {
+    ): array {
         return [
             'ok' => true,
             'locked' => $locked,
@@ -940,7 +804,7 @@ class ReportGatekeeper
         ];
 
         foreach ($candidates as $candidate) {
-            if (!is_array($candidate)) {
+            if (! is_array($candidate)) {
                 continue;
             }
 
@@ -965,7 +829,7 @@ class ReportGatekeeper
     private function numericUserId(?string $userId): ?int
     {
         $userId = $userId !== null ? trim($userId) : '';
-        if ($userId === '' || !preg_match('/^\d+$/', $userId)) {
+        if ($userId === '' || ! preg_match('/^\d+$/', $userId)) {
             return null;
         }
 

--- a/backend/app/Services/Share/Adapters/LegacyShareFlowAdapter.php
+++ b/backend/app/Services/Share/Adapters/LegacyShareFlowAdapter.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\Share\Adapters;
+
+use App\Models\Attempt;
+use App\Services\Legacy\LegacyShareService;
+use App\Services\Share\Contracts\ShareFlowAdapter;
+use App\Support\OrgContext;
+
+final class LegacyShareFlowAdapter implements ShareFlowAdapter
+{
+    public function __construct(private readonly LegacyShareService $legacyShareService) {}
+
+    public function resolveAttemptForAuth(string $attemptId, OrgContext $ctx): Attempt
+    {
+        return $this->legacyShareService->resolveAttemptForAuth($attemptId, $ctx);
+    }
+
+    public function getOrCreateShare(string $attemptId, OrgContext $ctx): array
+    {
+        return $this->legacyShareService->getOrCreateShare($attemptId, $ctx);
+    }
+
+    public function getShareView(string $shareId): array
+    {
+        return $this->legacyShareService->getShareView($shareId);
+    }
+}

--- a/backend/app/Services/Share/Adapters/V03ShareFlowAdapter.php
+++ b/backend/app/Services/Share/Adapters/V03ShareFlowAdapter.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\Share\Adapters;
+
+use App\Models\Attempt;
+use App\Services\Share\Contracts\ShareFlowAdapter;
+use App\Services\V0_3\ShareService;
+use App\Support\OrgContext;
+
+final class V03ShareFlowAdapter implements ShareFlowAdapter
+{
+    public function __construct(private readonly ShareService $shareService) {}
+
+    public function resolveAttemptForAuth(string $attemptId, OrgContext $ctx): Attempt
+    {
+        return $this->shareService->resolveAttemptForAuth($attemptId, $ctx);
+    }
+
+    public function getOrCreateShare(string $attemptId, OrgContext $ctx): array
+    {
+        return $this->shareService->getOrCreateShare($attemptId, $ctx);
+    }
+
+    public function getShareView(string $shareId): array
+    {
+        return $this->shareService->getShareView($shareId);
+    }
+}

--- a/backend/app/Services/Share/Contracts/ShareFlowAdapter.php
+++ b/backend/app/Services/Share/Contracts/ShareFlowAdapter.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\Share\Contracts;
+
+use App\Models\Attempt;
+use App\Support\OrgContext;
+
+interface ShareFlowAdapter
+{
+    public function resolveAttemptForAuth(string $attemptId, OrgContext $ctx): Attempt;
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function getOrCreateShare(string $attemptId, OrgContext $ctx): array;
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function getShareView(string $shareId): array;
+}

--- a/backend/app/Services/Share/ShareFlowCoreService.php
+++ b/backend/app/Services/Share/ShareFlowCoreService.php
@@ -1,0 +1,571 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\Share;
+
+use App\Models\Attempt;
+use App\Models\Event;
+use App\Models\Result;
+use App\Models\Share;
+use App\Services\Analytics\EventPayloadLimiter;
+use App\Services\Commerce\EntitlementManager;
+use App\Services\Report\ReportComposer;
+use App\Services\Scale\ScaleRegistry;
+use App\Services\Share\Contracts\ShareFlowAdapter;
+use App\Support\OrgContext;
+use Illuminate\Database\Eloquent\ModelNotFoundException;
+use Illuminate\Support\Carbon;
+use Illuminate\Support\Str;
+use Psr\Log\LoggerInterface;
+use Symfony\Component\HttpKernel\Exception\HttpException;
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
+
+final class ShareFlowCoreService
+{
+    public function __construct(
+        private readonly OrgContext $orgContext,
+        private readonly ShareFlowAdapter $shareAdapter,
+        private readonly ReportComposer $reportComposer,
+        private readonly EventPayloadLimiter $eventPayloadLimiter,
+        private readonly ScaleRegistry $scaleRegistry,
+        private readonly EntitlementManager $entitlementManager,
+        private readonly LoggerInterface $logger,
+        private readonly string $eventCreateFailureCode = 'SHARE_EVENT_CREATE_FAILED',
+    ) {}
+
+    /**
+     * @param  array<string, mixed>  $input
+     * @return array<string, mixed>
+     */
+    public function getShareLinkForAttempt(string $attemptId, array $input): array
+    {
+        $attempt = $this->shareAdapter->resolveAttemptForAuth($attemptId, $this->orgContext);
+        $commercial = $this->resolveCommercial($attempt);
+
+        $benefitCode = $commercial['report_benefit_code'];
+        if ($benefitCode === '') {
+            $benefitCode = $commercial['subscription_benefit_code'];
+        }
+
+        $userId = $this->orgContext->userId();
+        $anonId = $this->orgContext->anonId();
+
+        $hasFullAccess = $this->entitlementManager->hasFullAccess(
+            (int) ($attempt->org_id ?? 0),
+            $userId !== null ? (string) $userId : null,
+            $anonId !== null ? (string) $anonId : null,
+            (string) $attempt->id,
+            $benefitCode
+        );
+
+        if (! $hasFullAccess) {
+            throw new HttpException(402, 'PAYMENT_REQUIRED');
+        }
+
+        $data = $this->shareAdapter->getOrCreateShare($attemptId, $this->orgContext);
+        $this->emitShareEvents($data, $input, $commercial);
+
+        return $data;
+    }
+
+    /**
+     * @param  array<string, mixed>  $input
+     * @param  array<string, mixed>  $requestMeta
+     * @return array<string, mixed>
+     */
+    public function clickAndComposeReport(string $shareId, array $input, array $requestMeta): array
+    {
+        $share = Share::withoutGlobalScopes()->where('id', $shareId)->first();
+        if (! $share) {
+            throw new NotFoundHttpException('share not found');
+        }
+
+        $attemptId = trim((string) ($share->attempt_id ?? ''));
+        if ($attemptId === '') {
+            throw (new ModelNotFoundException)->setModel(Share::class, [$shareId]);
+        }
+
+        $gen = Event::withoutGlobalScopes()
+            ->where('event_code', 'share_generate')
+            ->where('share_id', $shareId)
+            ->orderByDesc('occurred_at')
+            ->first();
+        if (! $gen) {
+            throw new NotFoundHttpException('share generate event not found');
+        }
+
+        $genMeta = $this->normalizeMeta($gen->meta_json ?? null);
+
+        $experiment = trim((string) ($requestMeta['experiment'] ?? ($input['experiment'] ?? '')));
+        if ($experiment === '') {
+            $experiment = trim((string) ($genMeta['experiment'] ?? ''));
+        }
+
+        $version = trim((string) ($requestMeta['version'] ?? ($input['version'] ?? '')));
+        if ($version === '') {
+            $version = trim((string) ($genMeta['version'] ?? ''));
+        }
+
+        $channel = trim((string) ($requestMeta['channel'] ?? ($genMeta['channel'] ?? '')));
+        $clientPlatform = trim((string) ($requestMeta['client_platform'] ?? ($genMeta['client_platform'] ?? '')));
+        $entryPage = trim((string) ($requestMeta['entry_page'] ?? ''));
+
+        $typeCode = trim((string) ($genMeta['type_code'] ?? ''));
+        $packVersion = trim((string) ($genMeta['content_package_version'] ?? ''));
+        $engineVersion = trim((string) ($genMeta['engine_version'] ?? ($genMeta['engine'] ?? '')));
+        $profileVersion = trim((string) ($genMeta['profile_version'] ?? ''));
+
+        $meta = is_array($input['meta_json'] ?? null) ? $input['meta_json'] : [];
+
+        if (! isset($meta['share_id'])) {
+            $meta['share_id'] = $shareId;
+        }
+        $meta['attempt_id'] = $attemptId;
+
+        if ($typeCode !== '' && ! isset($meta['type_code'])) {
+            $meta['type_code'] = $typeCode;
+        }
+        if ($engineVersion !== '' && ! isset($meta['engine_version'])) {
+            $meta['engine_version'] = $engineVersion;
+        }
+        if ($engineVersion !== '' && ! isset($meta['engine'])) {
+            $meta['engine'] = $engineVersion;
+        }
+        if ($packVersion !== '' && ! isset($meta['content_package_version'])) {
+            $meta['content_package_version'] = $packVersion;
+        }
+        if ($profileVersion !== '' && ! isset($meta['profile_version'])) {
+            $meta['profile_version'] = $profileVersion;
+        }
+
+        if ($experiment !== '' && ! isset($meta['experiment'])) {
+            $meta['experiment'] = $experiment;
+        }
+        if ($version !== '' && ! isset($meta['version'])) {
+            $meta['version'] = $version;
+        }
+
+        if ($channel !== '' && ! isset($meta['channel'])) {
+            $meta['channel'] = $channel;
+        }
+        if ($clientPlatform !== '' && ! isset($meta['client_platform'])) {
+            $meta['client_platform'] = $clientPlatform;
+        }
+        if ($entryPage !== '' && ! isset($meta['entry_page'])) {
+            $meta['entry_page'] = $entryPage;
+        }
+
+        if (! isset($meta['share_generate_event_id'])) {
+            $meta['share_generate_event_id'] = (string) ($gen->id ?? '');
+        }
+        if (! isset($meta['share_generate_occurred_at'])) {
+            $meta['share_generate_occurred_at'] = (string) ($gen->occurred_at ?? '');
+        }
+
+        if (! isset($meta['ua'])) {
+            $meta['ua'] = trim((string) ($requestMeta['ua'] ?? ''));
+        }
+        if (! isset($meta['ip'])) {
+            $meta['ip'] = trim((string) ($requestMeta['ip'] ?? ''));
+        }
+        if (! isset($meta['ref'])) {
+            $meta['ref'] = trim((string) ($requestMeta['referer'] ?? ''));
+        }
+
+        $meta = array_filter($meta, static fn (mixed $v): bool => ! ($v === null || $v === ''));
+        $meta = $this->eventPayloadLimiter->limit($meta);
+
+        $attempt = Attempt::withoutGlobalScopes()->where('id', $attemptId)->firstOrFail();
+        $this->assertOrgIsolation($attempt);
+
+        $result = Result::withoutGlobalScopes()
+            ->where('org_id', (int) ($attempt->org_id ?? 0))
+            ->where('attempt_id', (string) $attempt->id)
+            ->firstOrFail();
+
+        $event = new Event;
+        $event->id = $this->newUuid();
+        $event->event_code = 'share_click';
+        $event->org_id = (int) ($attempt->org_id ?? 0);
+        $event->attempt_id = (string) $attempt->id;
+        $event->share_id = $shareId;
+        $event->anon_id = $this->resolveClickAnonId($input, $gen);
+        $event->meta_json = $meta;
+        $event->occurred_at = ! empty($input['occurred_at'])
+            ? Carbon::parse((string) $input['occurred_at'])
+            : now();
+        $event->save();
+
+        $ctx = [
+            'share_id' => $shareId,
+            'attempt_id' => (string) $attempt->id,
+            'experiment' => $experiment,
+            'version' => $version,
+            'type_code' => $typeCode,
+            'engine' => $engineVersion,
+            'profile_version' => $profileVersion,
+            'content_package_version' => $packVersion,
+            'org_id' => (int) ($attempt->org_id ?? 0),
+        ];
+
+        try {
+            $composed = $this->reportComposer->compose($attempt, $ctx, $result);
+        } catch (\Throwable $e) {
+            $this->logger->error('[share] report compose failed', [
+                'share_id' => $shareId,
+                'attempt_id' => (string) $attempt->id,
+                'org_id' => (int) ($attempt->org_id ?? 0),
+                'exception' => $e::class,
+                'message' => $e->getMessage(),
+            ]);
+            throw $e;
+        }
+
+        $report = is_array($composed['report'] ?? null) ? $composed['report'] : $this->toArray($composed);
+        if (! is_array($report)) {
+            $report = [];
+        }
+
+        if (! isset($report['_meta']) || ! is_array($report['_meta'])) {
+            $report['_meta'] = [];
+        }
+
+        $metaFill = [
+            'share_id' => $shareId,
+            'attempt_id' => (string) $attempt->id,
+            'type_code' => $typeCode,
+            'engine' => $engineVersion,
+            'profile_version' => $profileVersion,
+            'content_package_version' => $packVersion,
+            'experiment' => $experiment,
+            'version' => $version,
+            'generated_at' => now()->toISOString(),
+        ];
+
+        foreach ($metaFill as $key => $value) {
+            if ($value === '' || $value === null) {
+                continue;
+            }
+            if (! array_key_exists($key, $report['_meta'])) {
+                $report['_meta'][$key] = $value;
+            }
+        }
+
+        return [
+            'id' => (string) $event->id,
+            'share_id' => $shareId,
+            'attempt_id' => (string) $attempt->id,
+            'report' => $this->filterReport($report),
+        ];
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function getShareView(string $shareId): array
+    {
+        $data = $this->shareAdapter->getShareView($shareId);
+
+        $attemptId = (string) ($data['attempt_id'] ?? '');
+        if ($attemptId !== '') {
+            $attempt = Attempt::withoutGlobalScopes()->where('id', $attemptId)->firstOrFail();
+            $this->assertOrgIsolation($attempt);
+        }
+
+        return $data;
+    }
+
+    /**
+     * @param  array<string, mixed>  $data
+     * @param  array<string, mixed>  $input
+     * @param  array{report_benefit_code:string,subscription_benefit_code:string,default_sku:string}  $commercial
+     */
+    private function emitShareEvents(array $data, array $input, array $commercial): void
+    {
+        $shareId = trim((string) ($data['share_id'] ?? ''));
+        $attemptId = trim((string) ($data['attempt_id'] ?? ''));
+        if ($shareId === '' || $attemptId === '') {
+            return;
+        }
+
+        $experiment = trim((string) ($input['experiment'] ?? ''));
+        $version = trim((string) ($input['version'] ?? ''));
+        $channel = trim((string) ($input['channel'] ?? ''));
+        $clientPlatform = trim((string) ($input['client_platform'] ?? ''));
+        $entryPage = trim((string) ($input['entry_page'] ?? ''));
+
+        $metaBase = [
+            'share_id' => $shareId,
+            'type_code' => (string) ($data['type_code'] ?? ''),
+            'content_package_version' => (string) ($data['content_package_version'] ?? ''),
+            'engine_version' => 'v1.2',
+            'engine' => 'v1.2',
+            'experiment' => $experiment !== '' ? $experiment : null,
+            'version' => $version !== '' ? $version : null,
+            'channel' => $channel !== '' ? $channel : null,
+            'client_platform' => $clientPlatform !== '' ? $clientPlatform : null,
+            'entry_page' => $entryPage !== '' ? $entryPage : null,
+            'report_benefit_code' => $commercial['report_benefit_code'] !== '' ? $commercial['report_benefit_code'] : null,
+            'subscription_benefit_code' => $commercial['subscription_benefit_code'] !== '' ? $commercial['subscription_benefit_code'] : null,
+            'default_sku' => $commercial['default_sku'] !== '' ? $commercial['default_sku'] : null,
+        ];
+
+        $this->createShareEvent('share_generate', $attemptId, (int) ($data['org_id'] ?? 0), $this->orgContext->anonId(), $metaBase + [
+            'generate_type' => 'text',
+        ]);
+
+        $this->createShareEvent('share_view', $attemptId, (int) ($data['org_id'] ?? 0), $this->orgContext->anonId(), $metaBase + [
+            'view_type' => 'share_sheet',
+        ]);
+    }
+
+    /**
+     * @param  array<string, mixed>  $meta
+     */
+    private function createShareEvent(string $eventCode, string $attemptId, int $orgId, ?string $anonId, array $meta): void
+    {
+        try {
+            $shareId = trim((string) ($meta['share_id'] ?? ''));
+            if ($shareId === '' || strlen($shareId) > 64) {
+                $shareId = null;
+            }
+
+            $shareChannel = trim((string) ($meta['share_channel'] ?? ($meta['channel'] ?? '')));
+            if ($shareChannel === '') {
+                $shareChannel = null;
+            }
+
+            $clientPlatform = trim((string) ($meta['client_platform'] ?? ''));
+            if ($clientPlatform === '') {
+                $clientPlatform = null;
+            }
+
+            Event::query()->create([
+                'id' => (string) Str::uuid(),
+                'event_code' => $eventCode,
+                'attempt_id' => $attemptId,
+                'org_id' => $orgId,
+                'anon_id' => $anonId,
+                'channel' => $meta['channel'] ?? null,
+                'client_platform' => $clientPlatform,
+                'share_id' => $shareId,
+                'share_channel' => $shareChannel,
+                'meta_json' => $meta,
+                'occurred_at' => now(),
+                'created_at' => now(),
+                'updated_at' => now(),
+            ]);
+        } catch (\Throwable $e) {
+            $this->logger->warning($this->eventCreateFailureCode, [
+                'event_code' => $eventCode,
+                'attempt_id' => $attemptId,
+                'org_id' => $orgId,
+                'exception' => $e::class,
+                'message' => $e->getMessage(),
+            ]);
+        }
+    }
+
+    /**
+     * @return array{report_benefit_code:string,subscription_benefit_code:string,default_sku:string}
+     */
+    private function resolveCommercial(Attempt $attempt): array
+    {
+        $scaleCode = trim((string) ($attempt->scale_code ?? ''));
+        if ($scaleCode === '') {
+            return [
+                'report_benefit_code' => '',
+                'subscription_benefit_code' => '',
+                'default_sku' => '',
+            ];
+        }
+
+        $row = $this->scaleRegistry->getByCode($scaleCode, (int) ($attempt->org_id ?? 0));
+        if (! is_array($row)) {
+            return [
+                'report_benefit_code' => '',
+                'subscription_benefit_code' => '',
+                'default_sku' => '',
+            ];
+        }
+
+        $commercial = $row['commercial_json'] ?? null;
+        if (is_string($commercial)) {
+            $decoded = json_decode($commercial, true);
+            $commercial = is_array($decoded) ? $decoded : [];
+        }
+        if (! is_array($commercial)) {
+            $commercial = [];
+        }
+
+        $reportBenefitCode = strtoupper(trim((string) ($commercial['report_benefit_code'] ?? '')));
+        if ($reportBenefitCode === '') {
+            $reportBenefitCode = strtoupper(trim((string) ($commercial['credit_benefit_code'] ?? '')));
+        }
+
+        return [
+            'report_benefit_code' => $reportBenefitCode,
+            'subscription_benefit_code' => strtoupper(trim((string) ($commercial['subscription_benefit_code'] ?? ''))),
+            'default_sku' => trim((string) ($commercial['default_sku'] ?? '')),
+        ];
+    }
+
+    /**
+     * @param  array<string, mixed>  $input
+     */
+    private function resolveClickAnonId(array $input, Event $gen): ?string
+    {
+        $badAnon = static function (?string $value): bool {
+            if ($value === null) {
+                return true;
+            }
+
+            $candidate = trim($value);
+            if ($candidate === '') {
+                return true;
+            }
+
+            $lower = mb_strtolower($candidate, 'UTF-8');
+            $blacklist = [
+                'todo',
+                'placeholder',
+                'fixme',
+                'tbd',
+                '把你查到的anon_id填这里',
+                '把你查到的 anon_id 填这里',
+                '填这里',
+            ];
+
+            foreach ($blacklist as $bad) {
+                $needle = mb_strtolower(trim($bad), 'UTF-8');
+                if ($needle !== '' && mb_strpos($lower, $needle) !== false) {
+                    return true;
+                }
+            }
+
+            return false;
+        };
+
+        $fromInput = isset($input['anon_id']) && is_string($input['anon_id'])
+            ? trim((string) $input['anon_id'])
+            : '';
+
+        if ($fromInput !== '' && ! $badAnon($fromInput)) {
+            return $fromInput;
+        }
+
+        $fromGen = trim((string) ($gen->anon_id ?? ''));
+        if ($fromGen !== '' && ! $badAnon($fromGen)) {
+            return $fromGen;
+        }
+
+        return null;
+    }
+
+    private function assertOrgIsolation(Attempt $attempt): void
+    {
+        $ctxOrgId = max(0, (int) $this->orgContext->orgId());
+        if ($ctxOrgId === 0) {
+            return;
+        }
+
+        if ((int) ($attempt->org_id ?? 0) !== $ctxOrgId) {
+            throw (new ModelNotFoundException)->setModel(Attempt::class, [(string) ($attempt->id ?? '')]);
+        }
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function normalizeMeta(mixed $meta): array
+    {
+        if (is_array($meta)) {
+            return $meta;
+        }
+
+        if (is_string($meta)) {
+            $decoded = json_decode($meta, true);
+            if (is_array($decoded)) {
+                return $decoded;
+            }
+        }
+
+        return [];
+    }
+
+    /**
+     * @param  array<string, mixed>  $report
+     * @return array<string, mixed>
+     */
+    private function filterReport(array $report): array
+    {
+        $allowed = $this->allowedReportKeys();
+        $allowed = array_flip($allowed);
+
+        $output = [];
+        foreach ($report as $key => $value) {
+            if (! isset($allowed[$key])) {
+                continue;
+            }
+
+            if ($key === '_explain' && ! $this->shouldExposeExplain()) {
+                continue;
+            }
+
+            $output[$key] = $value;
+        }
+
+        return $output;
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function allowedReportKeys(): array
+    {
+        $keys = config('report.share_report_allowed_keys', []);
+
+        return is_array($keys) ? $keys : [];
+    }
+
+    private function shouldExposeExplain(): bool
+    {
+        if (app()->environment('local', 'development')) {
+            return true;
+        }
+
+        return (bool) config('report.expose_explain', false);
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function toArray(mixed $payload): array
+    {
+        if (is_array($payload)) {
+            return $payload;
+        }
+
+        if (is_object($payload)) {
+            if (method_exists($payload, 'toArray')) {
+                $array = $payload->toArray();
+
+                return is_array($array) ? $array : [];
+            }
+
+            if (method_exists($payload, 'jsonSerialize')) {
+                $array = $payload->jsonSerialize();
+
+                return is_array($array) ? $array : [];
+            }
+        }
+
+        return [];
+    }
+
+    private function newUuid(): string
+    {
+        return method_exists(Str::class, 'uuid7') ? (string) Str::uuid7() : (string) Str::uuid();
+    }
+}

--- a/backend/app/Services/V0_3/ShareFlowService.php
+++ b/backend/app/Services/V0_3/ShareFlowService.php
@@ -1,526 +1,67 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Services\V0_3;
 
-use App\Models\Attempt;
-use App\Models\Event;
-use App\Models\Result;
-use App\Models\Share;
 use App\Services\Analytics\EventPayloadLimiter;
 use App\Services\Commerce\EntitlementManager;
 use App\Services\Report\ReportComposer;
 use App\Services\Scale\ScaleRegistry;
+use App\Services\Share\Adapters\V03ShareFlowAdapter;
+use App\Services\Share\ShareFlowCoreService;
 use App\Support\OrgContext;
-use Illuminate\Database\Eloquent\ModelNotFoundException;
-use Illuminate\Support\Carbon;
-use Illuminate\Support\Str;
 use Psr\Log\LoggerInterface;
-use Symfony\Component\HttpKernel\Exception\HttpException;
-use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 
 class ShareFlowService
 {
+    private ShareFlowCoreService $core;
+
     public function __construct(
-        private readonly OrgContext $orgContext,
-        private readonly ShareService $shareService,
-        private readonly ReportComposer $reportComposer,
-        private readonly EventPayloadLimiter $eventPayloadLimiter,
-        private readonly ScaleRegistry $scaleRegistry,
-        private readonly EntitlementManager $entitlementManager,
-        private readonly LoggerInterface $logger,
+        OrgContext $orgContext,
+        ShareService $shareService,
+        ReportComposer $reportComposer,
+        EventPayloadLimiter $eventPayloadLimiter,
+        ScaleRegistry $scaleRegistry,
+        EntitlementManager $entitlementManager,
+        LoggerInterface $logger,
     ) {
+        $this->core = new ShareFlowCoreService(
+            $orgContext,
+            new V03ShareFlowAdapter($shareService),
+            $reportComposer,
+            $eventPayloadLimiter,
+            $scaleRegistry,
+            $entitlementManager,
+            $logger,
+            'SHARE_EVENT_CREATE_FAILED'
+        );
     }
 
+    /**
+     * @param  array<string, mixed>  $input
+     * @return array<string, mixed>
+     */
     public function getShareLinkForAttempt(string $attemptId, array $input): array
     {
-        $attempt = $this->shareService->resolveAttemptForAuth($attemptId, $this->orgContext);
-        $commercial = $this->resolveCommercial($attempt);
-
-        $benefitCode = $commercial['report_benefit_code'];
-        if ($benefitCode === '') {
-            $benefitCode = $commercial['subscription_benefit_code'];
-        }
-
-        $userId = $this->orgContext->userId();
-        $anonId = $this->orgContext->anonId();
-
-        $hasFullAccess = $this->entitlementManager->hasFullAccess(
-            (int) ($attempt->org_id ?? 0),
-            $userId !== null ? (string) $userId : null,
-            $anonId !== null ? (string) $anonId : null,
-            (string) $attempt->id,
-            $benefitCode
-        );
-
-        if (!$hasFullAccess) {
-            throw new HttpException(402, 'PAYMENT_REQUIRED');
-        }
-
-        $data = $this->shareService->getOrCreateShare($attemptId, $this->orgContext);
-        $this->emitShareEvents($data, $input, $commercial);
-
-        return $data;
+        return $this->core->getShareLinkForAttempt($attemptId, $input);
     }
 
+    /**
+     * @param  array<string, mixed>  $input
+     * @param  array<string, mixed>  $requestMeta
+     * @return array<string, mixed>
+     */
     public function clickAndComposeReport(string $shareId, array $input, array $requestMeta): array
     {
-        $share = Share::withoutGlobalScopes()->where('id', $shareId)->first();
-        if (!$share) {
-            throw new NotFoundHttpException('share not found');
-        }
-
-        $attemptId = trim((string) ($share->attempt_id ?? ''));
-        if ($attemptId === '') {
-            throw (new ModelNotFoundException())->setModel(Share::class, [$shareId]);
-        }
-
-        $gen = Event::withoutGlobalScopes()
-            ->where('event_code', 'share_generate')
-            ->where('share_id', $shareId)
-            ->orderByDesc('occurred_at')
-            ->first();
-        if (!$gen) {
-            throw new NotFoundHttpException('share generate event not found');
-        }
-
-        $genMeta = $this->normalizeMeta($gen->meta_json ?? null);
-
-        $experiment = trim((string) ($requestMeta['experiment'] ?? ($input['experiment'] ?? '')));
-        if ($experiment === '') {
-            $experiment = trim((string) ($genMeta['experiment'] ?? ''));
-        }
-
-        $version = trim((string) ($requestMeta['version'] ?? ($input['version'] ?? '')));
-        if ($version === '') {
-            $version = trim((string) ($genMeta['version'] ?? ''));
-        }
-
-        $channel = trim((string) ($requestMeta['channel'] ?? ($genMeta['channel'] ?? '')));
-        $clientPlatform = trim((string) ($requestMeta['client_platform'] ?? ($genMeta['client_platform'] ?? '')));
-        $entryPage = trim((string) ($requestMeta['entry_page'] ?? ''));
-
-        $typeCode = trim((string) ($genMeta['type_code'] ?? ''));
-        $packVersion = trim((string) ($genMeta['content_package_version'] ?? ''));
-        $engineVersion = trim((string) ($genMeta['engine_version'] ?? ($genMeta['engine'] ?? '')));
-        $profileVersion = trim((string) ($genMeta['profile_version'] ?? ''));
-
-        $meta = is_array($input['meta_json'] ?? null) ? $input['meta_json'] : [];
-
-        if (!isset($meta['share_id'])) {
-            $meta['share_id'] = $shareId;
-        }
-        $meta['attempt_id'] = $attemptId;
-
-        if ($typeCode !== '' && !isset($meta['type_code'])) {
-            $meta['type_code'] = $typeCode;
-        }
-        if ($engineVersion !== '' && !isset($meta['engine_version'])) {
-            $meta['engine_version'] = $engineVersion;
-        }
-        if ($engineVersion !== '' && !isset($meta['engine'])) {
-            $meta['engine'] = $engineVersion;
-        }
-        if ($packVersion !== '' && !isset($meta['content_package_version'])) {
-            $meta['content_package_version'] = $packVersion;
-        }
-        if ($profileVersion !== '' && !isset($meta['profile_version'])) {
-            $meta['profile_version'] = $profileVersion;
-        }
-
-        if ($experiment !== '' && !isset($meta['experiment'])) {
-            $meta['experiment'] = $experiment;
-        }
-        if ($version !== '' && !isset($meta['version'])) {
-            $meta['version'] = $version;
-        }
-
-        if ($channel !== '' && !isset($meta['channel'])) {
-            $meta['channel'] = $channel;
-        }
-        if ($clientPlatform !== '' && !isset($meta['client_platform'])) {
-            $meta['client_platform'] = $clientPlatform;
-        }
-        if ($entryPage !== '' && !isset($meta['entry_page'])) {
-            $meta['entry_page'] = $entryPage;
-        }
-
-        if (!isset($meta['share_generate_event_id'])) {
-            $meta['share_generate_event_id'] = (string) ($gen->id ?? '');
-        }
-        if (!isset($meta['share_generate_occurred_at'])) {
-            $meta['share_generate_occurred_at'] = (string) ($gen->occurred_at ?? '');
-        }
-
-        if (!isset($meta['ua'])) {
-            $meta['ua'] = trim((string) ($requestMeta['ua'] ?? ''));
-        }
-        if (!isset($meta['ip'])) {
-            $meta['ip'] = trim((string) ($requestMeta['ip'] ?? ''));
-        }
-        if (!isset($meta['ref'])) {
-            $meta['ref'] = trim((string) ($requestMeta['referer'] ?? ''));
-        }
-
-        $meta = array_filter($meta, static fn (mixed $v): bool => !($v === null || $v === ''));
-        $meta = $this->eventPayloadLimiter->limit($meta);
-
-        $attempt = Attempt::withoutGlobalScopes()->where('id', $attemptId)->firstOrFail();
-        $this->assertOrgIsolation($attempt);
-
-        $result = Result::withoutGlobalScopes()
-            ->where('org_id', (int) ($attempt->org_id ?? 0))
-            ->where('attempt_id', (string) $attempt->id)
-            ->firstOrFail();
-
-        $event = new Event();
-        $event->id = $this->newUuid();
-        $event->event_code = 'share_click';
-        $event->org_id = (int) ($attempt->org_id ?? 0);
-        $event->attempt_id = (string) $attempt->id;
-        $event->share_id = $shareId;
-        $event->anon_id = $this->resolveClickAnonId($input, $gen);
-        $event->meta_json = $meta;
-        $event->occurred_at = !empty($input['occurred_at'])
-            ? Carbon::parse((string) $input['occurred_at'])
-            : now();
-        $event->save();
-
-        $ctx = [
-            'share_id' => $shareId,
-            'attempt_id' => (string) $attempt->id,
-            'experiment' => $experiment,
-            'version' => $version,
-            'type_code' => $typeCode,
-            'engine' => $engineVersion,
-            'profile_version' => $profileVersion,
-            'content_package_version' => $packVersion,
-            'org_id' => (int) ($attempt->org_id ?? 0),
-        ];
-
-        try {
-            $composed = $this->reportComposer->compose($attempt, $ctx, $result);
-        } catch (\Throwable $e) {
-            $this->logger->error('[share] report compose failed', [
-                'share_id' => $shareId,
-                'attempt_id' => (string) $attempt->id,
-                'org_id' => (int) ($attempt->org_id ?? 0),
-                'exception' => $e::class,
-                'message' => $e->getMessage(),
-            ]);
-            throw $e;
-        }
-
-        $report = is_array($composed['report'] ?? null) ? $composed['report'] : $this->toArray($composed);
-        if (!is_array($report)) {
-            $report = [];
-        }
-
-        if (!isset($report['_meta']) || !is_array($report['_meta'])) {
-            $report['_meta'] = [];
-        }
-
-        $metaFill = [
-            'share_id' => $shareId,
-            'attempt_id' => (string) $attempt->id,
-            'type_code' => $typeCode,
-            'engine' => $engineVersion,
-            'profile_version' => $profileVersion,
-            'content_package_version' => $packVersion,
-            'experiment' => $experiment,
-            'version' => $version,
-            'generated_at' => now()->toISOString(),
-        ];
-
-        foreach ($metaFill as $key => $value) {
-            if ($value === '' || $value === null) {
-                continue;
-            }
-            if (!array_key_exists($key, $report['_meta'])) {
-                $report['_meta'][$key] = $value;
-            }
-        }
-
-        return [
-            'id' => (string) $event->id,
-            'share_id' => $shareId,
-            'attempt_id' => (string) $attempt->id,
-            'report' => $this->filterReport($report),
-        ];
+        return $this->core->clickAndComposeReport($shareId, $input, $requestMeta);
     }
 
+    /**
+     * @return array<string, mixed>
+     */
     public function getShareView(string $shareId): array
     {
-        $data = $this->shareService->getShareView($shareId);
-
-        $attemptId = (string) ($data['attempt_id'] ?? '');
-        if ($attemptId !== '') {
-            $attempt = Attempt::withoutGlobalScopes()->where('id', $attemptId)->firstOrFail();
-            $this->assertOrgIsolation($attempt);
-        }
-
-        return $data;
-    }
-
-    private function emitShareEvents(array $data, array $input, array $commercial): void
-    {
-        $shareId = trim((string) ($data['share_id'] ?? ''));
-        $attemptId = trim((string) ($data['attempt_id'] ?? ''));
-        if ($shareId === '' || $attemptId === '') {
-            return;
-        }
-
-        $experiment = trim((string) ($input['experiment'] ?? ''));
-        $version = trim((string) ($input['version'] ?? ''));
-        $channel = trim((string) ($input['channel'] ?? ''));
-        $clientPlatform = trim((string) ($input['client_platform'] ?? ''));
-        $entryPage = trim((string) ($input['entry_page'] ?? ''));
-
-        $metaBase = [
-            'share_id' => $shareId,
-            'type_code' => (string) ($data['type_code'] ?? ''),
-            'content_package_version' => (string) ($data['content_package_version'] ?? ''),
-            'engine_version' => 'v1.2',
-            'engine' => 'v1.2',
-            'experiment' => $experiment !== '' ? $experiment : null,
-            'version' => $version !== '' ? $version : null,
-            'channel' => $channel !== '' ? $channel : null,
-            'client_platform' => $clientPlatform !== '' ? $clientPlatform : null,
-            'entry_page' => $entryPage !== '' ? $entryPage : null,
-            'report_benefit_code' => $commercial['report_benefit_code'] !== '' ? $commercial['report_benefit_code'] : null,
-            'subscription_benefit_code' => $commercial['subscription_benefit_code'] !== '' ? $commercial['subscription_benefit_code'] : null,
-            'default_sku' => $commercial['default_sku'] !== '' ? $commercial['default_sku'] : null,
-        ];
-
-        $this->createShareEvent('share_generate', $attemptId, (int) ($data['org_id'] ?? 0), $this->orgContext->anonId(), $metaBase + [
-            'generate_type' => 'text',
-        ]);
-
-        $this->createShareEvent('share_view', $attemptId, (int) ($data['org_id'] ?? 0), $this->orgContext->anonId(), $metaBase + [
-            'view_type' => 'share_sheet',
-        ]);
-    }
-
-    private function createShareEvent(string $eventCode, string $attemptId, int $orgId, ?string $anonId, array $meta): void
-    {
-        try {
-            $shareId = trim((string) ($meta['share_id'] ?? ''));
-            if ($shareId === '' || strlen($shareId) > 64) {
-                $shareId = null;
-            }
-
-            $shareChannel = trim((string) ($meta['share_channel'] ?? ($meta['channel'] ?? '')));
-            if ($shareChannel === '') {
-                $shareChannel = null;
-            }
-
-            $clientPlatform = trim((string) ($meta['client_platform'] ?? ''));
-            if ($clientPlatform === '') {
-                $clientPlatform = null;
-            }
-
-            Event::query()->create([
-                'id' => (string) Str::uuid(),
-                'event_code' => $eventCode,
-                'attempt_id' => $attemptId,
-                'org_id' => $orgId,
-                'anon_id' => $anonId,
-                'channel' => $meta['channel'] ?? null,
-                'client_platform' => $clientPlatform,
-                'share_id' => $shareId,
-                'share_channel' => $shareChannel,
-                'meta_json' => $meta,
-                'occurred_at' => now(),
-                'created_at' => now(),
-                'updated_at' => now(),
-            ]);
-        } catch (\Throwable $e) {
-            $this->logger->warning('SHARE_EVENT_CREATE_FAILED', [
-                'event_code' => $eventCode,
-                'attempt_id' => $attemptId,
-                'org_id' => $orgId,
-                'exception' => $e::class,
-                'message' => $e->getMessage(),
-            ]);
-        }
-    }
-
-    private function resolveCommercial(Attempt $attempt): array
-    {
-        $scaleCode = trim((string) ($attempt->scale_code ?? ''));
-        if ($scaleCode === '') {
-            return [
-                'report_benefit_code' => '',
-                'subscription_benefit_code' => '',
-                'default_sku' => '',
-            ];
-        }
-
-        $row = $this->scaleRegistry->getByCode($scaleCode, (int) ($attempt->org_id ?? 0));
-        if (!is_array($row)) {
-            return [
-                'report_benefit_code' => '',
-                'subscription_benefit_code' => '',
-                'default_sku' => '',
-            ];
-        }
-
-        $commercial = $row['commercial_json'] ?? null;
-        if (is_string($commercial)) {
-            $decoded = json_decode($commercial, true);
-            $commercial = is_array($decoded) ? $decoded : [];
-        }
-        if (!is_array($commercial)) {
-            $commercial = [];
-        }
-
-        $reportBenefitCode = strtoupper(trim((string) ($commercial['report_benefit_code'] ?? '')));
-        if ($reportBenefitCode === '') {
-            $reportBenefitCode = strtoupper(trim((string) ($commercial['credit_benefit_code'] ?? '')));
-        }
-
-        return [
-            'report_benefit_code' => $reportBenefitCode,
-            'subscription_benefit_code' => strtoupper(trim((string) ($commercial['subscription_benefit_code'] ?? ''))),
-            'default_sku' => trim((string) ($commercial['default_sku'] ?? '')),
-        ];
-    }
-
-    private function resolveClickAnonId(array $input, Event $gen): ?string
-    {
-        $badAnon = static function (?string $value): bool {
-            if ($value === null) {
-                return true;
-            }
-
-            $candidate = trim($value);
-            if ($candidate === '') {
-                return true;
-            }
-
-            $lower = mb_strtolower($candidate, 'UTF-8');
-            $blacklist = [
-                'todo',
-                'placeholder',
-                'fixme',
-                'tbd',
-                '把你查到的anon_id填这里',
-                '把你查到的 anon_id 填这里',
-                '填这里',
-            ];
-
-            foreach ($blacklist as $bad) {
-                $needle = mb_strtolower(trim($bad), 'UTF-8');
-                if ($needle !== '' && mb_strpos($lower, $needle) !== false) {
-                    return true;
-                }
-            }
-
-            return false;
-        };
-
-        $fromInput = isset($input['anon_id']) && is_string($input['anon_id'])
-            ? trim((string) $input['anon_id'])
-            : '';
-
-        if ($fromInput !== '' && !$badAnon($fromInput)) {
-            return $fromInput;
-        }
-
-        $fromGen = trim((string) ($gen->anon_id ?? ''));
-        if ($fromGen !== '' && !$badAnon($fromGen)) {
-            return $fromGen;
-        }
-
-        return null;
-    }
-
-    private function assertOrgIsolation(Attempt $attempt): void
-    {
-        $ctxOrgId = max(0, (int) $this->orgContext->orgId());
-        if ($ctxOrgId === 0) {
-            return;
-        }
-
-        if ((int) ($attempt->org_id ?? 0) !== $ctxOrgId) {
-            throw (new ModelNotFoundException())->setModel(Attempt::class, [(string) ($attempt->id ?? '')]);
-        }
-    }
-
-    private function normalizeMeta(mixed $meta): array
-    {
-        if (is_array($meta)) {
-            return $meta;
-        }
-
-        if (is_string($meta)) {
-            $decoded = json_decode($meta, true);
-            if (is_array($decoded)) {
-                return $decoded;
-            }
-        }
-
-        return [];
-    }
-
-    private function filterReport(array $report): array
-    {
-        $allowed = $this->allowedReportKeys();
-        $allowed = array_flip($allowed);
-
-        $output = [];
-        foreach ($report as $key => $value) {
-            if (!isset($allowed[$key])) {
-                continue;
-            }
-
-            if ($key === '_explain' && !$this->shouldExposeExplain()) {
-                continue;
-            }
-
-            $output[$key] = $value;
-        }
-
-        return $output;
-    }
-
-    private function allowedReportKeys(): array
-    {
-        $keys = config('report.share_report_allowed_keys', []);
-        return is_array($keys) ? $keys : [];
-    }
-
-    private function shouldExposeExplain(): bool
-    {
-        if (app()->environment('local', 'development')) {
-            return true;
-        }
-
-        return (bool) config('report.expose_explain', false);
-    }
-
-    private function toArray(mixed $payload): array
-    {
-        if (is_array($payload)) {
-            return $payload;
-        }
-
-        if (is_object($payload)) {
-            if (method_exists($payload, 'toArray')) {
-                $array = $payload->toArray();
-                return is_array($array) ? $array : [];
-            }
-
-            if (method_exists($payload, 'jsonSerialize')) {
-                $array = $payload->jsonSerialize();
-                return is_array($array) ? $array : [];
-            }
-        }
-
-        return [];
-    }
-
-    private function newUuid(): string
-    {
-        return method_exists(Str::class, 'uuid7') ? (string) Str::uuid7() : (string) Str::uuid();
+        return $this->core->getShareView($shareId);
     }
 }

--- a/backend/app/Support/WritesEvents.php
+++ b/backend/app/Support/WritesEvents.php
@@ -4,12 +4,16 @@ namespace App\Support;
 
 use Illuminate\Http\Request;
 use Illuminate\Support\Str;
+use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Log;
+use Illuminate\Support\Facades\Schema;
 use App\Models\Event;
 use App\Services\Analytics\EventNormalizer;
 
 trait WritesEvents
 {
+    private static ?bool $hasShareDedupeLookupColumns = null;
+
     /**
      * Write into events table
      *
@@ -223,19 +227,28 @@ trait WritesEvents
 
             // B) share_generate / share_click dedupe
             if (in_array($eventCode, ['share_generate', 'share_click'], true) && $anonId && $attemptId) {
-                $shareStyle    = $incoming['share_style'] ?? null;
-                $pageSessionId = $incoming['page_session_id'] ?? null;
+                $shareStyle = trim((string) ($incoming['share_style'] ?? ''));
+                $pageSessionId = trim((string) ($incoming['page_session_id'] ?? ''));
 
-                if ($shareStyle && $pageSessionId) {
-                    $dup = Event::query()
+                if ($shareStyle !== '' && $pageSessionId !== '') {
+                    $dupQuery = Event::query()
                         ->where('event_code', $eventCode)
                         ->where('anon_id', $anonId)
-                        ->where('attempt_id', $attemptId)
-                        ->whereRaw("JSON_UNQUOTE(JSON_EXTRACT(meta_json, '$.share_style')) = ?", [$shareStyle])
-                        ->whereRaw("JSON_UNQUOTE(JSON_EXTRACT(meta_json, '$.page_session_id')) = ?", [$pageSessionId])
-                        ->exists();
+                        ->where('attempt_id', $attemptId);
 
-                    if ($dup) return;
+                    if ($this->canUseEventShareDedupeLookupColumns()) {
+                        $dupQuery
+                            ->where('share_style_g', $shareStyle)
+                            ->where('page_session_id_g', $pageSessionId);
+                    } else {
+                        $dupQuery
+                            ->whereRaw("JSON_UNQUOTE(JSON_EXTRACT(meta_json, '$.share_style')) = ?", [$shareStyle])
+                            ->whereRaw("JSON_UNQUOTE(JSON_EXTRACT(meta_json, '$.page_session_id')) = ?", [$pageSessionId]);
+                    }
+
+                    if ($dupQuery->exists()) {
+                        return;
+                    }
                 }
             }
 
@@ -291,5 +304,29 @@ trait WritesEvents
                 'error'      => $e->getMessage(),
             ]);
         }
+    }
+
+    private function canUseEventShareDedupeLookupColumns(): bool
+    {
+        if (self::$hasShareDedupeLookupColumns !== null) {
+            return self::$hasShareDedupeLookupColumns;
+        }
+
+        try {
+            $driver = DB::connection()->getDriverName();
+            if (!in_array($driver, ['mysql', 'sqlite'], true)) {
+                self::$hasShareDedupeLookupColumns = false;
+
+                return false;
+            }
+
+            self::$hasShareDedupeLookupColumns =
+                Schema::hasColumn('events', 'share_style_g')
+                && Schema::hasColumn('events', 'page_session_id_g');
+        } catch (\Throwable) {
+            self::$hasShareDedupeLookupColumns = false;
+        }
+
+        return self::$hasShareDedupeLookupColumns;
     }
 }

--- a/backend/config/app.php
+++ b/backend/config/app.php
@@ -17,6 +17,8 @@ return [
 
     'version' => env('APP_VERSION', 'unknown'),
 
+    'git_sha' => env('GITHUB_SHA', env('CI_COMMIT_SHA', '')),
+
     /*
     |--------------------------------------------------------------------------
     | Application Environment

--- a/backend/config/queue.php
+++ b/backend/config/queue.php
@@ -48,6 +48,24 @@ return [
             'after_commit' => false,
         ],
 
+        'database_reports' => [
+            'driver' => 'database',
+            'connection' => env('DB_QUEUE_REPORTS_CONNECTION', env('DB_QUEUE_CONNECTION')),
+            'table' => env('DB_QUEUE_REPORTS_TABLE', env('DB_QUEUE_TABLE', 'jobs')),
+            'queue' => env('DB_QUEUE_REPORTS', 'reports'),
+            'retry_after' => (int) env('DB_QUEUE_REPORTS_RETRY_AFTER', 300),
+            'after_commit' => false,
+        ],
+
+        'database_commerce' => [
+            'driver' => 'database',
+            'connection' => env('DB_QUEUE_COMMERCE_CONNECTION', env('DB_QUEUE_CONNECTION')),
+            'table' => env('DB_QUEUE_COMMERCE_TABLE', env('DB_QUEUE_TABLE', 'jobs')),
+            'queue' => env('DB_QUEUE_COMMERCE', 'commerce'),
+            'retry_after' => (int) env('DB_QUEUE_COMMERCE_RETRY_AFTER', 300),
+            'after_commit' => false,
+        ],
+
         'beanstalkd' => [
             'driver' => 'beanstalkd',
             'host' => env('BEANSTALKD_QUEUE_HOST', 'localhost'),

--- a/backend/database/migrations/2026_02_08_060000_make_failed_jobs_uuid_nullable.php
+++ b/backend/database/migrations/2026_02_08_060000_make_failed_jobs_uuid_nullable.php
@@ -3,20 +3,37 @@
 declare(strict_types=1);
 
 use Illuminate\Database\Migrations\Migration;
-use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Schema;
 
 return new class extends Migration
 {
     public function up(): void
     {
-        if (!Schema::hasTable('failed_jobs') || !Schema::hasColumn('failed_jobs', 'uuid')) {
+        if (! Schema::hasTable('failed_jobs') || ! Schema::hasColumn('failed_jobs', 'uuid')) {
             return;
         }
 
-        Schema::table('failed_jobs', function (Blueprint $table): void {
-            $table->string('uuid')->nullable()->change();
-        });
+        $driver = Schema::getConnection()->getDriverName();
+
+        if ($driver === 'mysql') {
+            DB::statement('ALTER TABLE `failed_jobs` MODIFY `uuid` VARCHAR(255) NULL');
+
+            return;
+        }
+
+        if ($driver === 'pgsql') {
+            DB::statement('ALTER TABLE failed_jobs ALTER COLUMN uuid DROP NOT NULL');
+
+            return;
+        }
+
+        if ($driver === 'sqlite') {
+            // SQLite does not support ALTER COLUMN to drop NOT NULL safely in-place.
+            return;
+        }
+
+        // Unknown drivers are intentionally no-op to avoid destructive table rebuilds.
     }
 
     public function down(): void

--- a/backend/database/migrations/2026_02_13_000001_converge_core_schema_baseline.php
+++ b/backend/database/migrations/2026_02_13_000001_converge_core_schema_baseline.php
@@ -25,18 +25,18 @@ return new class extends Migration
 
     private function convergeAttempts(): void
     {
-        if (!Schema::hasTable('attempts')) {
+        if (! Schema::hasTable('attempts')) {
             return;
         }
 
         Schema::table('attempts', function (Blueprint $table): void {
-            if (!Schema::hasColumn('attempts', 'org_id')) {
+            if (! Schema::hasColumn('attempts', 'org_id')) {
                 $table->unsignedBigInteger('org_id')->default(0);
             }
-            if (!Schema::hasColumn('attempts', 'user_id')) {
+            if (! Schema::hasColumn('attempts', 'user_id')) {
                 $table->string('user_id', 64)->nullable();
             }
-            if (!Schema::hasColumn('attempts', 'anon_id')) {
+            if (! Schema::hasColumn('attempts', 'anon_id')) {
                 $table->string('anon_id', 64)->nullable();
             }
         });
@@ -44,12 +44,12 @@ return new class extends Migration
 
     private function convergeOrders(): void
     {
-        if (!Schema::hasTable('orders')) {
+        if (! Schema::hasTable('orders')) {
             return;
         }
 
         Schema::table('orders', function (Blueprint $table): void {
-            if (!Schema::hasColumn('orders', 'org_id')) {
+            if (! Schema::hasColumn('orders', 'org_id')) {
                 $table->unsignedBigInteger('org_id')->default(0);
             }
         });
@@ -57,12 +57,12 @@ return new class extends Migration
 
     private function convergePaymentEvents(): void
     {
-        if (!Schema::hasTable('payment_events')) {
+        if (! Schema::hasTable('payment_events')) {
             return;
         }
 
         Schema::table('payment_events', function (Blueprint $table): void {
-            if (!Schema::hasColumn('payment_events', 'provider')) {
+            if (! Schema::hasColumn('payment_events', 'provider')) {
                 $table->string('provider', 32)->default('unknown');
             }
         });
@@ -70,12 +70,12 @@ return new class extends Migration
 
     private function convergeSkus(): void
     {
-        if (!Schema::hasTable('skus')) {
+        if (! Schema::hasTable('skus')) {
             return;
         }
 
         Schema::table('skus', function (Blueprint $table): void {
-            if (!Schema::hasColumn('skus', 'org_id')) {
+            if (! Schema::hasColumn('skus', 'org_id')) {
                 $table->unsignedBigInteger('org_id')->default(1);
             }
         });
@@ -83,12 +83,12 @@ return new class extends Migration
 
     private function convergeReportSnapshots(): void
     {
-        if (!Schema::hasTable('report_snapshots')) {
+        if (! Schema::hasTable('report_snapshots')) {
             return;
         }
 
         Schema::table('report_snapshots', function (Blueprint $table): void {
-            if (!Schema::hasColumn('report_snapshots', 'org_id')) {
+            if (! Schema::hasColumn('report_snapshots', 'org_id')) {
                 $table->unsignedBigInteger('org_id')->default(0);
             }
         });
@@ -96,22 +96,22 @@ return new class extends Migration
 
     private function convergeIdempotencyKeys(): void
     {
-        if (!Schema::hasTable('idempotency_keys')) {
+        if (! Schema::hasTable('idempotency_keys')) {
             return;
         }
 
         Schema::table('idempotency_keys', function (Blueprint $table): void {
-            if (!Schema::hasColumn('idempotency_keys', 'provider')) {
-                $table->string('provider', 64);
+            if (! Schema::hasColumn('idempotency_keys', 'provider')) {
+                $table->string('provider', 64)->nullable();
             }
-            if (!Schema::hasColumn('idempotency_keys', 'external_id')) {
-                $table->string('external_id', 191);
+            if (! Schema::hasColumn('idempotency_keys', 'external_id')) {
+                $table->string('external_id', 191)->nullable();
             }
-            if (!Schema::hasColumn('idempotency_keys', 'recorded_at')) {
-                $table->string('recorded_at', 64);
+            if (! Schema::hasColumn('idempotency_keys', 'recorded_at')) {
+                $table->string('recorded_at', 64)->nullable();
             }
-            if (!Schema::hasColumn('idempotency_keys', 'hash')) {
-                $table->string('hash', 128);
+            if (! Schema::hasColumn('idempotency_keys', 'hash')) {
+                $table->string('hash', 128)->nullable();
             }
         });
     }

--- a/backend/database/migrations/2026_02_27_000220_add_contact_email_hash_to_orders_table.php
+++ b/backend/database/migrations/2026_02_27_000220_add_contact_email_hash_to_orders_table.php
@@ -1,0 +1,80 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    private const LOOKUP_INDEX = 'orders_org_order_contact_email_idx';
+
+    public function up(): void
+    {
+        if (! Schema::hasTable('orders')) {
+            return;
+        }
+
+        Schema::table('orders', function (Blueprint $table): void {
+            if (! Schema::hasColumn('orders', 'contact_email_hash')) {
+                $table->string('contact_email_hash', 64)->nullable();
+            }
+        });
+
+        if (
+            Schema::hasColumn('orders', 'org_id')
+            && Schema::hasColumn('orders', 'order_no')
+            && Schema::hasColumn('orders', 'contact_email_hash')
+            && ! $this->indexExists('orders', self::LOOKUP_INDEX)
+        ) {
+            Schema::table('orders', function (Blueprint $table): void {
+                $table->index(['org_id', 'order_no', 'contact_email_hash'], self::LOOKUP_INDEX);
+            });
+        }
+    }
+
+    public function down(): void
+    {
+        // forward-only migration: rollback disabled to prevent data loss in production.
+        // Irreversible operation: schema/data rollback handled via forward fix migrations.
+    }
+
+    private function indexExists(string $table, string $indexName): bool
+    {
+        $driver = DB::connection()->getDriverName();
+
+        if ($driver === 'sqlite') {
+            $rows = DB::select("PRAGMA index_list('{$table}')");
+            foreach ($rows as $row) {
+                if ((string) ($row->name ?? '') === $indexName) {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
+        if ($driver === 'pgsql') {
+            $rows = DB::select('SELECT indexname FROM pg_indexes WHERE tablename = ?', [$table]);
+            foreach ($rows as $row) {
+                if ((string) ($row->indexname ?? '') === $indexName) {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
+        $database = DB::getDatabaseName();
+        $rows = DB::select(
+            "SELECT 1 FROM information_schema.statistics
+             WHERE table_schema = ? AND table_name = ? AND index_name = ?
+             LIMIT 1",
+            [$database, $table, $indexName]
+        );
+
+        return ! empty($rows);
+    }
+};

--- a/backend/database/migrations/2026_02_27_010000_harden_fm_tokens_hashed_only.php
+++ b/backend/database/migrations/2026_02_27_010000_harden_fm_tokens_hashed_only.php
@@ -1,0 +1,100 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        if (!Schema::hasTable('fm_tokens')) {
+            return;
+        }
+
+        $rows = DB::table('fm_tokens')
+            ->select(['token', 'token_hash'])
+            ->get();
+
+        foreach ($rows as $row) {
+            $token = trim((string) ($row->token ?? ''));
+            $tokenHash = trim((string) ($row->token_hash ?? ''));
+            if ($tokenHash === '' && $token !== '') {
+                $tokenHash = hash('sha256', $token);
+            }
+            if ($tokenHash === '') {
+                continue;
+            }
+
+            $updates = [];
+            if (trim((string) ($row->token_hash ?? '')) === '') {
+                $updates['token_hash'] = $tokenHash;
+            }
+
+            // Retire plaintext token persistence; token_hash becomes the only auth lookup key.
+            if (str_starts_with($token, 'fm_')) {
+                $updates['token'] = 'retired_' . $tokenHash;
+            }
+
+            if ($updates !== []) {
+                $updates['updated_at'] = now();
+
+                DB::table('fm_tokens')
+                    ->where('token', $token)
+                    ->update($updates);
+            }
+        }
+
+        if (!$this->indexExists('fm_tokens', 'fm_tokens_token_hash_unique') && Schema::hasColumn('fm_tokens', 'token_hash')) {
+            Schema::table('fm_tokens', function (Blueprint $table): void {
+                $table->unique(['token_hash'], 'fm_tokens_token_hash_unique');
+            });
+        }
+    }
+
+    public function down(): void
+    {
+        // forward-only migration: rollback disabled to prevent data loss in production.
+        // Irreversible operation: schema/data rollback handled via forward fix migrations.
+    }
+
+    private function indexExists(string $table, string $indexName): bool
+    {
+        $driver = DB::connection()->getDriverName();
+
+        if ($driver === 'sqlite') {
+            $rows = DB::select("PRAGMA index_list('{$table}')");
+            foreach ($rows as $row) {
+                if ((string) ($row->name ?? '') === $indexName) {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
+        if ($driver === 'pgsql') {
+            $rows = DB::select('SELECT indexname FROM pg_indexes WHERE tablename = ?', [$table]);
+            foreach ($rows as $row) {
+                if ((string) ($row->indexname ?? '') === $indexName) {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
+        $db = DB::getDatabaseName();
+        $rows = DB::select(
+            "SELECT 1 FROM information_schema.statistics
+             WHERE table_schema = ? AND table_name = ? AND index_name = ?
+             LIMIT 1",
+            [$db, $table, $indexName]
+        );
+
+        return !empty($rows);
+    }
+};

--- a/backend/database/migrations/2026_02_27_020000_add_events_share_dedupe_generated_columns.php
+++ b/backend/database/migrations/2026_02_27_020000_add_events_share_dedupe_generated_columns.php
@@ -1,0 +1,86 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Support\Database\SchemaIndex;
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    private const TABLE = 'events';
+    private const SHARE_STYLE_COL = 'share_style_g';
+    private const PAGE_SESSION_COL = 'page_session_id_g';
+    private const INDEX = 'idx_events_share_dedupe_lookup';
+
+    public function up(): void
+    {
+        if (!Schema::hasTable(self::TABLE)) {
+            return;
+        }
+
+        $driver = Schema::getConnection()->getDriverName();
+
+        Schema::table(self::TABLE, function (Blueprint $table) use ($driver): void {
+            if (!Schema::hasColumn(self::TABLE, self::SHARE_STYLE_COL)) {
+                if ($driver === 'mysql') {
+                    $table->string(self::SHARE_STYLE_COL, 64)
+                        ->storedAs("json_unquote(json_extract(meta_json, '$.share_style'))");
+                } elseif ($driver === 'sqlite') {
+                    $table->string(self::SHARE_STYLE_COL, 64)
+                        ->storedAs("json_extract(meta_json, '$.share_style')");
+                } else {
+                    $table->string(self::SHARE_STYLE_COL, 64)->nullable();
+                }
+            }
+
+            if (!Schema::hasColumn(self::TABLE, self::PAGE_SESSION_COL)) {
+                if ($driver === 'mysql') {
+                    $table->string(self::PAGE_SESSION_COL, 128)
+                        ->storedAs("json_unquote(json_extract(meta_json, '$.page_session_id'))");
+                } elseif ($driver === 'sqlite') {
+                    $table->string(self::PAGE_SESSION_COL, 128)
+                        ->storedAs("json_extract(meta_json, '$.page_session_id')");
+                } else {
+                    $table->string(self::PAGE_SESSION_COL, 128)->nullable();
+                }
+            }
+        });
+
+        $columnsReady = Schema::hasColumn(self::TABLE, self::SHARE_STYLE_COL)
+            && Schema::hasColumn(self::TABLE, self::PAGE_SESSION_COL);
+
+        if (!$columnsReady) {
+            SchemaIndex::logIndexAction(
+                'create_index_skip_missing_columns',
+                self::TABLE,
+                self::INDEX,
+                $driver,
+                ['phase' => 'up', 'reason' => 'generated-columns-unavailable']
+            );
+
+            return;
+        }
+
+        if (SchemaIndex::indexExists(self::TABLE, self::INDEX)) {
+            SchemaIndex::logIndexAction('create_index_skip_exists', self::TABLE, self::INDEX, $driver, ['phase' => 'up']);
+            return;
+        }
+
+        Schema::table(self::TABLE, function (Blueprint $table): void {
+            $table->index(
+                ['event_code', 'anon_id', 'attempt_id', self::SHARE_STYLE_COL, self::PAGE_SESSION_COL],
+                self::INDEX
+            );
+        });
+
+        SchemaIndex::logIndexAction('create_index', self::TABLE, self::INDEX, $driver, ['phase' => 'up']);
+    }
+
+    public function down(): void
+    {
+        // forward-only migration: rollback disabled to prevent data loss in production.
+        // Irreversible operation: schema/data rollback handled via forward fix migrations.
+    }
+};

--- a/backend/routes/api.php
+++ b/backend/routes/api.php
@@ -132,9 +132,12 @@ Route::prefix('v0.3')->middleware([
         // 3) Commerce v2 (public with org context)
         Route::get('/skus', 'App\\Http\\Controllers\\API\\V0_3\\CommerceController@listSkus')
             ->name('api.v0_3.skus');
-        Route::post('/orders/checkout', 'App\\Http\\Controllers\\API\\V0_3\\CommerceController@checkout');
-        Route::post('/orders/lookup', 'App\\Http\\Controllers\\API\\V0_3\\CommerceController@lookup');
-        Route::post('/orders/{order_no}/resend', 'App\\Http\\Controllers\\API\\V0_3\\CommerceController@resend');
+        Route::post('/orders/checkout', 'App\\Http\\Controllers\\API\\V0_3\\CommerceController@checkout')
+            ->middleware(\App\Http\Middleware\FmTokenOptional::class);
+        Route::post('/orders/lookup', 'App\\Http\\Controllers\\API\\V0_3\\CommerceController@lookup')
+            ->middleware(\App\Http\Middleware\FmTokenOptional::class);
+        Route::post('/orders/{order_no}/resend', 'App\\Http\\Controllers\\API\\V0_3\\CommerceController@resend')
+            ->middleware(\App\Http\Middleware\FmTokenOptional::class);
         Route::post('/orders', 'App\\Http\\Controllers\\API\\V0_3\\CommerceController@createOrder')
             ->middleware(\App\Http\Middleware\FmTokenAuth::class);
         Route::post('/orders/stub', static function (
@@ -152,7 +155,8 @@ Route::prefix('v0.3')->middleware([
         Route::post('/orders/{provider}', 'App\\Http\\Controllers\\API\\V0_3\\CommerceController@createOrder')
             ->middleware(\App\Http\Middleware\FmTokenAuth::class)
             ->whereIn('provider', $payProviders);
-        Route::get('/orders/{order_no}', 'App\\Http\\Controllers\\API\\V0_3\\CommerceController@getOrder');
+        Route::get('/orders/{order_no}', 'App\\Http\\Controllers\\API\\V0_3\\CommerceController@getOrder')
+            ->middleware(\App\Http\Middleware\FmTokenOptional::class);
         Route::get('/shares/{id}', [ShareV03Controller::class, 'getShareView']);
         Route::post('/shares/{shareId}/click', [ShareV03Controller::class, 'click'])
             ->middleware([

--- a/backend/scripts/ci_verify_mbti.sh
+++ b/backend/scripts/ci_verify_mbti.sh
@@ -1063,6 +1063,46 @@ php artisan test --filter MigrationsNoSilentCatchTest
 php artisan test --filter MigrationProtectedTablesNoDropTest
 echo "[CI] migration safety gates OK"
 
+echo "[CI] order security gate"
+bash scripts/verify_order_security.sh
+echo "[CI] order security gate OK"
+
+echo "[CI] psychometrics streaming gate"
+bash scripts/pr70_verify.sh
+echo "[CI] psychometrics streaming gate OK"
+
+echo "[CI] migration static guard gate"
+bash scripts/pr71_verify.sh
+echo "[CI] migration static guard gate OK"
+
+echo "[CI] big5 ops controller layering gate"
+bash scripts/pr72_verify.sh
+echo "[CI] big5 ops controller layering gate OK"
+
+echo "[CI] legacy service request coupling gate"
+bash scripts/pr73_verify.sh
+echo "[CI] legacy service request coupling gate OK"
+
+echo "[CI] constructor injection limit gate"
+bash scripts/pr74_verify.sh
+echo "[CI] constructor injection limit gate OK"
+
+echo "[CI] app env() usage gate"
+bash scripts/pr75_verify.sh
+echo "[CI] app env() usage gate OK"
+
+echo "[CI] events dedupe explain gate"
+bash scripts/pr76_verify.sh
+echo "[CI] events dedupe explain gate OK"
+
+echo "[CI] share flow alignment gate"
+bash scripts/pr77_verify.sh
+echo "[CI] share flow alignment gate OK"
+
+echo "[CI] dependency security gate"
+bash scripts/pr78_verify.sh
+echo "[CI] dependency security gate OK"
+
 if [[ "$RUN_SCALE_IDENTITY_HARD_CUTOVER" == "1" ]]; then
   echo "[CI] hard-cutover phpunit gate"
   php artisan test tests/Feature/Ops/ScaleIdentityHardCutoverCiTest.php

--- a/backend/scripts/pr69_verify.sh
+++ b/backend/scripts/pr69_verify.sh
@@ -27,6 +27,7 @@ fail() {
 echo "[PR69][VERIFY] start"
 
 QUEUE_ASSERT="${ART_DIR}/queue_assertions.txt"
+JOB_TIMEOUT_ASSERT="${ART_DIR}/job_timeout_assertions.txt"
 APP_PROVIDER_ASSERT="${ART_DIR}/app_service_provider_assertions.txt"
 REDACTOR_ASSERT="${ART_DIR}/redactor_assertions.txt"
 ENV_ASSERT="${ART_DIR}/env_assertions.txt"
@@ -49,12 +50,75 @@ foreach (["database", "redis", "beanstalkd"] as $name) {
         $errs[] = "connections.{$name}.retry_after must be 90";
     }
 }
+foreach (["database_reports", "database_commerce"] as $name) {
+    if (!isset($cfg["connections"][$name])) {
+        $errs[] = "connections.{$name} must exist";
+        continue;
+    }
+    $retry = $cfg["connections"][$name]["retry_after"] ?? null;
+    if ($retry !== 300) {
+        $errs[] = "connections.{$name}.retry_after must be 300";
+    }
+}
 if ($errs) {
     fwrite(STDERR, implode(PHP_EOL, $errs) . PHP_EOL);
     exit(1);
 }
 echo "queue_assert=pass" . PHP_EOL;
 ' "${BACKEND_DIR}/vendor/autoload.php" "${BACKEND_DIR}/config/queue.php" > "${QUEUE_ASSERT}" || fail "queue assertions failed"
+
+php -r '
+require $argv[1];
+$cfg = require $argv[2];
+
+$jobs = [
+    [
+        "class" => \App\Jobs\GenerateReportSnapshotJob::class,
+        "args" => [0, "attempt-x", "submit", null],
+        "expected_connection" => "database_reports",
+    ],
+    [
+        "class" => \App\Jobs\GenerateReportPdfJob::class,
+        "args" => [0, "attempt-x", "payment_unlock", "ord-x"],
+        "expected_connection" => "database_reports",
+    ],
+    [
+        "class" => \App\Jobs\Commerce\RefundOrderJob::class,
+        "args" => [0, "ord-x", "test", "corr-x"],
+        "expected_connection" => "database_commerce",
+    ],
+];
+
+$errs = [];
+foreach ($jobs as $spec) {
+    $class = $spec["class"];
+    $job = new $class(...$spec["args"]);
+    $conn = (string) ($job->connection ?? "");
+    if ($conn !== $spec["expected_connection"]) {
+        $errs[] = "{$class} connection must be {$spec["expected_connection"]}, got {$conn}";
+    }
+    $timeout = $job->timeout ?? null;
+    if (!is_int($timeout) || $timeout <= 0) {
+        $errs[] = "{$class} timeout must be positive int";
+        continue;
+    }
+    $retry = (int) ($cfg["connections"][$conn]["retry_after"] ?? 0);
+    if ($retry <= 0) {
+        $errs[] = "{$class} retry_after missing for connection {$conn}";
+    } elseif ($timeout >= $retry) {
+        $errs[] = "{$class} timeout({$timeout}) must be < retry_after({$retry})";
+    }
+    if (($job->failOnTimeout ?? false) !== true) {
+        $errs[] = "{$class} failOnTimeout must be true";
+    }
+}
+
+if ($errs) {
+    fwrite(STDERR, implode(PHP_EOL, $errs) . PHP_EOL);
+    exit(1);
+}
+echo "job_timeout_assert=pass" . PHP_EOL;
+' "${BACKEND_DIR}/vendor/autoload.php" "${BACKEND_DIR}/config/queue.php" > "${JOB_TIMEOUT_ASSERT}" || fail "job timeout assertions failed"
 
 grep -n -E "pushProcessor|SensitiveDataRedactor|context|extra" \
   "${BACKEND_DIR}/app/Providers/AppServiceProvider.php" > "${APP_PROVIDER_ASSERT}" || fail "AppServiceProvider assertions failed"
@@ -75,11 +139,13 @@ done
   grep -n -E "^EVENT_INGEST_TOKEN=$" "${BACKEND_DIR}/.env.example"
 } > "${ENV_ASSERT}" || fail ".env.example assertions failed"
 
-grep -n -E "hash_equals|ingest_token|fm_tokens|Schema::hasTable|DB::table\\('fm_tokens'\\)" \
+grep -n -E "hash_equals|ingest_token|fm_tokens|Schema::hasTable|DB::table\\('fm_tokens'\\)|FmTokenService|validateToken" \
   "${BACKEND_DIR}/app/Http/Controllers/EventController.php" "${BACKEND_DIR}/config/fap.php" > "${EVENT_ASSERT}" || fail "EventController assertions failed"
 grep -q -E "hash_equals" "${BACKEND_DIR}/app/Http/Controllers/EventController.php" || fail "hash_equals missing"
 grep -q -E "config\\('fap\\.events\\.ingest_token'" "${BACKEND_DIR}/app/Http/Controllers/EventController.php" || fail "ingest_token config read missing"
-grep -q -E "DB::table\\('fm_tokens'\\)" "${BACKEND_DIR}/app/Http/Controllers/EventController.php" || fail "fm_tokens DB exists check missing"
+if ! grep -q -E "DB::table\\('fm_tokens'\\)|FmTokenService|validateToken" "${BACKEND_DIR}/app/Http/Controllers/EventController.php"; then
+  fail "fm token validation path missing in EventController"
+fi
 
 ls -1 "${BACKEND_DIR}"/database/migrations/*failed_jobs* > "${MIGRATION_ASSERT}" 2>/dev/null || fail "failed_jobs migration missing"
 

--- a/backend/scripts/pr70_verify.sh
+++ b/backend/scripts/pr70_verify.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+export CI=true
+export FAP_NONINTERACTIVE=1
+export COMPOSER_NO_INTERACTION=1
+export GIT_TERMINAL_PROMPT=0
+export NO_COLOR=1
+export PAGER=cat
+export GIT_PAGER=cat
+export TERM=dumb
+export XDEBUG_MODE=off
+export LANG=en_US.UTF-8
+
+REPO_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+BACKEND_DIR="${REPO_DIR}/backend"
+ART_DIR="${ART_DIR:-${BACKEND_DIR}/artifacts/pr70}"
+
+mkdir -p "${ART_DIR}"
+exec > "${ART_DIR}/verify.log" 2>&1
+
+fail() {
+  echo "[PR70][VERIFY][FAIL] $*"
+  exit 1
+}
+
+echo "[PR70][VERIFY] start"
+
+BIG5_FILE="${BACKEND_DIR}/app/Console/Commands/Big5PsychometricsReport.php"
+SDS_FILE="${BACKEND_DIR}/app/Console/Commands/SdsPsychometricsReport.php"
+STATIC_ASSERT="${ART_DIR}/streaming_assertions.txt"
+
+{
+  grep -n "cursor()" "${BIG5_FILE}"
+  grep -n "cursor()" "${SDS_FILE}"
+} > "${STATIC_ASSERT}" || fail "cursor() assertion failed"
+
+if grep -n "\$query->get()" "${BIG5_FILE}" "${SDS_FILE}" >> "${STATIC_ASSERT}"; then
+  fail "found legacy get() on psychometrics query"
+fi
+
+(
+  cd "${BACKEND_DIR}"
+  php artisan test \
+    tests/Feature/Psychometrics/Big5PsychometricsReportCommandTest.php \
+    tests/Feature/Psychometrics/SdsPsychometricsReportCommandTest.php
+) || fail "psychometrics command tests failed"
+
+echo "verify=pass" > "${ART_DIR}/verify_done.txt"
+echo "[PR70][VERIFY] pass"

--- a/backend/scripts/pr71_verify.sh
+++ b/backend/scripts/pr71_verify.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+export CI=true
+export FAP_NONINTERACTIVE=1
+export COMPOSER_NO_INTERACTION=1
+export GIT_TERMINAL_PROMPT=0
+export NO_COLOR=1
+export PAGER=cat
+export GIT_PAGER=cat
+export TERM=dumb
+export XDEBUG_MODE=off
+export LANG=en_US.UTF-8
+
+REPO_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+BACKEND_DIR="${REPO_DIR}/backend"
+MIG_DIR="${BACKEND_DIR}/database/migrations"
+ART_DIR="${ART_DIR:-${BACKEND_DIR}/artifacts/pr71}"
+
+mkdir -p "${ART_DIR}"
+exec > "${ART_DIR}/verify.log" 2>&1
+
+fail() {
+  echo "[PR71][VERIFY][FAIL] $*"
+  exit 1
+}
+
+echo "[PR71][VERIFY] start"
+
+BLOCKED_OUT="${ART_DIR}/blocked_patterns.txt"
+if rg -n --glob '*.php' "dropIfExists\(|dropColumn\(|dropTable\(|renameColumn\(|->change\(" "${MIG_DIR}" > "${BLOCKED_OUT}"; then
+  fail "blocked migration pattern detected"
+fi
+
+(
+  cd "${BACKEND_DIR}"
+  php artisan test --filter MigrationSafetyTest
+  php artisan test --filter MigrationRollbackSafetyTest
+  php artisan test --filter MigrationsNoSilentCatchTest
+  php artisan test --filter MigrationProtectedTablesNoDropTest
+) || fail "migration safety tests failed"
+
+echo "verify=pass" > "${ART_DIR}/verify_done.txt"
+echo "[PR71][VERIFY] pass"

--- a/backend/scripts/pr72_verify.sh
+++ b/backend/scripts/pr72_verify.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+export CI=true
+export FAP_NONINTERACTIVE=1
+export COMPOSER_NO_INTERACTION=1
+export GIT_TERMINAL_PROMPT=0
+export NO_COLOR=1
+export PAGER=cat
+export GIT_PAGER=cat
+export TERM=dumb
+export XDEBUG_MODE=off
+export LANG=en_US.UTF-8
+
+REPO_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+BACKEND_DIR="${REPO_DIR}/backend"
+ART_DIR="${ART_DIR:-${BACKEND_DIR}/artifacts/pr72}"
+CONTROLLER_FILE="${BACKEND_DIR}/app/Http/Controllers/API/V0_3/BigFiveOpsController.php"
+
+mkdir -p "${ART_DIR}"
+exec > "${ART_DIR}/verify.log" 2>&1
+
+fail() {
+  echo "[PR72][VERIFY][FAIL] $*"
+  exit 1
+}
+
+echo "[PR72][VERIFY] start"
+
+if rg -n "DB::table\(|Artisan::call\(" "${CONTROLLER_FILE}" > "${ART_DIR}/controller_forbidden_calls.txt"; then
+  fail "BigFiveOpsController still contains DB::table or Artisan::call"
+fi
+
+echo "verify=pass" > "${ART_DIR}/verify_done.txt"
+echo "[PR72][VERIFY] pass"

--- a/backend/scripts/pr73_verify.sh
+++ b/backend/scripts/pr73_verify.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+BACKEND_DIR="$(cd "${SCRIPT_DIR}/.." && pwd)"
+ARTIFACT_DIR="${BACKEND_DIR}/artifacts/pr73"
+REPORT_FILE="${ARTIFACT_DIR}/legacy_service_request_coupling.txt"
+
+mkdir -p "${ARTIFACT_DIR}"
+
+TARGETS=(
+  "${BACKEND_DIR}/app/Services/Legacy/LegacyMbtiAttemptService.php"
+  "${BACKEND_DIR}/app/Services/Legacy/LegacyReportService.php"
+  "${BACKEND_DIR}/app/Services/Legacy/Mbti/Attempt/LegacyMbtiAttemptLifecycleService.php"
+)
+
+PATTERN='use Illuminate\\Http\\Request;|\\Illuminate\\Http\\Request|Request \$request'
+
+if rg -n "${PATTERN}" "${TARGETS[@]}" > "${REPORT_FILE}"; then
+  echo "[PR73][FAIL] Legacy service layer still depends on Illuminate\\Http\\Request."
+  echo "[PR73][FAIL] Details: ${REPORT_FILE}"
+  cat "${REPORT_FILE}"
+  exit 1
+fi
+
+echo "[PR73][OK] Legacy services are decoupled from Illuminate\\Http\\Request." | tee "${REPORT_FILE}"

--- a/backend/scripts/pr74_verify.sh
+++ b/backend/scripts/pr74_verify.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+BACKEND_DIR="$(cd "${SCRIPT_DIR}/.." && pwd)"
+ARTIFACT_DIR="${BACKEND_DIR}/artifacts/pr74"
+REPORT_FILE="${ARTIFACT_DIR}/constructor_injection_limit.txt"
+
+mkdir -p "${ARTIFACT_DIR}"
+cd "${BACKEND_DIR}"
+
+php <<'PHP' > "${REPORT_FILE}"
+<?php
+
+declare(strict_types=1);
+
+require getcwd().'/vendor/autoload.php';
+
+$targets = [
+    'App\\Services\\Report\\ReportGatekeeper' => 8,
+    'App\\Services\\Attempts\\AttemptStartService' => 8,
+    'App\\Services\\Attempts\\AttemptSubmitService' => 8,
+];
+
+$violations = [];
+$lines = [];
+
+foreach ($targets as $class => $max) {
+    if (!class_exists($class)) {
+        $violations[] = "{$class}: class_not_found";
+        continue;
+    }
+
+    $reflection = new ReflectionClass($class);
+    $constructor = $reflection->getConstructor();
+    $count = $constructor instanceof ReflectionMethod ? $constructor->getNumberOfParameters() : 0;
+    $lines[] = "{$class}: {$count}";
+
+    if ($count > $max) {
+        $violations[] = "{$class}: {$count} > {$max}";
+    }
+}
+
+foreach ($lines as $line) {
+    echo $line.PHP_EOL;
+}
+
+if ($violations !== []) {
+    echo '--- violations ---'.PHP_EOL;
+    foreach ($violations as $violation) {
+        echo $violation.PHP_EOL;
+    }
+    exit(1);
+}
+PHP
+
+echo "[PR74][OK] constructor injection counts are within limit." | tee -a "${REPORT_FILE}"

--- a/backend/scripts/pr75_verify.sh
+++ b/backend/scripts/pr75_verify.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+BACKEND_DIR="$(cd "${SCRIPT_DIR}/.." && pwd)"
+ARTIFACT_DIR="${BACKEND_DIR}/artifacts/pr75"
+REPORT_FILE="${ARTIFACT_DIR}/service_env_usage.txt"
+
+mkdir -p "${ARTIFACT_DIR}"
+
+if rg -n "\\benv\\(" "${BACKEND_DIR}/app" > "${REPORT_FILE}"; then
+  echo "[PR75][FAIL] env() must not be used in app/ (runtime services/controllers)."
+  echo "[PR75][FAIL] Details: ${REPORT_FILE}"
+  cat "${REPORT_FILE}"
+  exit 1
+fi
+
+echo "[PR75][OK] app/ has no direct env() usage; runtime config is read via config()." | tee "${REPORT_FILE}"

--- a/backend/scripts/pr76_verify.sh
+++ b/backend/scripts/pr76_verify.sh
@@ -1,0 +1,95 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+BACKEND_DIR="$(cd "${SCRIPT_DIR}/.." && pwd)"
+ARTIFACT_DIR="${BACKEND_DIR}/artifacts/pr76"
+REPORT_FILE="${ARTIFACT_DIR}/events_share_dedupe_explain.txt"
+
+mkdir -p "${ARTIFACT_DIR}"
+cd "${BACKEND_DIR}"
+
+php <<'PHP' > "${REPORT_FILE}"
+<?php
+
+declare(strict_types=1);
+
+require getcwd().'/vendor/autoload.php';
+
+$app = require getcwd().'/bootstrap/app.php';
+$kernel = $app->make(Illuminate\Contracts\Console\Kernel::class);
+$kernel->bootstrap();
+
+$table = 'events';
+$indexName = 'idx_events_share_dedupe_lookup';
+$requiredColumns = ['share_style_g', 'page_session_id_g'];
+$sql = 'SELECT 1 FROM events WHERE event_code = ? AND anon_id = ? AND attempt_id = ? AND share_style_g = ? AND page_session_id_g = ? LIMIT 1';
+$bindings = ['share_click', 'anon_probe', 'attempt_probe', 'card', 'session_probe'];
+
+$driver = Illuminate\Support\Facades\DB::connection()->getDriverName();
+echo "driver={$driver}".PHP_EOL;
+
+if (!Illuminate\Support\Facades\Schema::hasTable($table)) {
+    echo '[PR76][FAIL] events table not found.'.PHP_EOL;
+    exit(1);
+}
+
+foreach ($requiredColumns as $column) {
+    if (!Illuminate\Support\Facades\Schema::hasColumn($table, $column)) {
+        echo "[PR76][FAIL] missing column: {$column}".PHP_EOL;
+        exit(1);
+    }
+}
+
+if ($driver === 'mysql') {
+    $rows = Illuminate\Support\Facades\DB::select('EXPLAIN '.$sql, $bindings);
+    $usedKeys = [];
+
+    foreach ($rows as $row) {
+        $payload = (array) $row;
+        echo json_encode($payload, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES).PHP_EOL;
+
+        $key = trim((string) ($payload['key'] ?? $payload['KEY'] ?? ''));
+        if ($key !== '') {
+            $usedKeys[] = $key;
+        }
+    }
+
+    $usedKeys = array_values(array_unique($usedKeys));
+
+    if (!in_array($indexName, $usedKeys, true)) {
+        echo '[PR76][FAIL] mysql explain does not use expected index. keys='.implode(',', $usedKeys).PHP_EOL;
+        exit(1);
+    }
+
+    echo "[PR76][OK] mysql explain uses index {$indexName}.".PHP_EOL;
+    exit(0);
+}
+
+if ($driver === 'sqlite') {
+    $rows = Illuminate\Support\Facades\DB::select('EXPLAIN QUERY PLAN '.$sql, $bindings);
+    $matched = false;
+
+    foreach ($rows as $row) {
+        $payload = (array) $row;
+        echo json_encode($payload, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES).PHP_EOL;
+
+        $detail = strtolower((string) ($payload['detail'] ?? ''));
+        if (str_contains($detail, strtolower($indexName))) {
+            $matched = true;
+        }
+    }
+
+    if (!$matched) {
+        echo '[PR76][FAIL] sqlite query plan does not hit expected index.'.PHP_EOL;
+        exit(1);
+    }
+
+    echo "[PR76][OK] sqlite query plan uses index {$indexName}.".PHP_EOL;
+    exit(0);
+}
+
+echo "[PR76][SKIP] unsupported driver={$driver}.".PHP_EOL;
+PHP
+
+cat "${REPORT_FILE}"

--- a/backend/scripts/pr77_verify.sh
+++ b/backend/scripts/pr77_verify.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+BACKEND_DIR="$(cd "${SCRIPT_DIR}/.." && pwd)"
+ARTIFACT_DIR="${BACKEND_DIR}/artifacts/pr77"
+REPORT_FILE="${ARTIFACT_DIR}/share_flow_alignment.txt"
+
+mkdir -p "${ARTIFACT_DIR}"
+cd "${BACKEND_DIR}"
+
+php artisan test tests/Feature/V0_3/ShareFlowCoreAlignmentTest.php | tee "${REPORT_FILE}"

--- a/backend/scripts/pr78_verify.sh
+++ b/backend/scripts/pr78_verify.sh
@@ -1,0 +1,330 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+export CI="${CI:-true}"
+export FAP_NONINTERACTIVE="${FAP_NONINTERACTIVE:-1}"
+export COMPOSER_NO_INTERACTION=1
+export GIT_TERMINAL_PROMPT=0
+export NO_COLOR=1
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+BACKEND_DIR="$(cd "${SCRIPT_DIR}/.." && pwd)"
+ARTIFACT_ROOT="${ARTIFACT_ROOT:-${BACKEND_DIR}/artifacts/pr78}"
+
+RUN_TS="$(date -u '+%Y%m%dT%H%M%SZ')"
+WEEK_TAG="$(date -u '+%G-W%V')"
+RUN_DIR="${ARTIFACT_ROOT}/runs/${RUN_TS}"
+WEEKLY_DIR="${ARTIFACT_ROOT}/weekly/${WEEK_TAG}"
+LATEST_DIR="${ARTIFACT_ROOT}/latest"
+
+AUDIT_JSON="${RUN_DIR}/composer_audit.json"
+AUDIT_STDERR="${RUN_DIR}/composer_audit.stderr.log"
+NORMALIZED_JSON="${RUN_DIR}/advisories_normalized.json"
+SUMMARY_JSON="${RUN_DIR}/summary.json"
+SUMMARY_TXT="${RUN_DIR}/summary.txt"
+DIFF_JSON="${RUN_DIR}/diff.json"
+DIFF_TXT="${RUN_DIR}/diff.txt"
+PREV_SUMMARY_JSON="${LATEST_DIR}/summary.json"
+
+mkdir -p "${RUN_DIR}" "${WEEKLY_DIR}" "${LATEST_DIR}"
+cd "${BACKEND_DIR}"
+
+fail() {
+  echo "[PR78][VERIFY][FAIL] $*"
+  exit 1
+}
+
+echo "[PR78][VERIFY] start"
+echo "[PR78][VERIFY] run_ts=${RUN_TS} week=${WEEK_TAG}"
+
+AUDIT_EXIT=0
+for attempt in 1 2 3; do
+  set +e
+  composer audit --no-interaction --format=json >"${AUDIT_JSON}" 2>"${AUDIT_STDERR}"
+  AUDIT_EXIT=$?
+  set -e
+
+  if [[ -s "${AUDIT_JSON}" ]]; then
+    break
+  fi
+
+  if [[ "${attempt}" -lt 3 ]]; then
+    echo "[PR78][VERIFY] composer audit produced no JSON (attempt ${attempt}/3), retrying in 5s..."
+    sleep 5
+  fi
+done
+
+if [[ ! -s "${AUDIT_JSON}" ]]; then
+  fail "composer audit did not produce JSON output after retries"
+fi
+
+AUDIT_JSON_PATH="${AUDIT_JSON}" NORMALIZED_JSON_PATH="${NORMALIZED_JSON}" SUMMARY_JSON_PATH="${SUMMARY_JSON}" php <<'PHP'
+<?php
+declare(strict_types=1);
+
+$auditJsonPath = (string) getenv('AUDIT_JSON_PATH');
+$normalizedPath = (string) getenv('NORMALIZED_JSON_PATH');
+$summaryPath = (string) getenv('SUMMARY_JSON_PATH');
+$payload = json_decode((string) file_get_contents($auditJsonPath), true);
+if (!is_array($payload)) {
+    fwrite(STDERR, "[PR78][VERIFY][FAIL] invalid composer audit JSON payload\n");
+    exit(2);
+}
+
+$rawAdvisories = $payload['advisories'] ?? [];
+$normalized = [];
+
+$appendRow = static function (array $row, string $defaultPackage) use (&$normalized): void {
+    $severity = strtolower(trim((string) ($row['severity'] ?? 'unknown')));
+    if ($severity === '') {
+        $severity = 'unknown';
+    }
+
+    $normalized[] = [
+        'package' => (string) ($row['packageName'] ?? $row['package'] ?? $defaultPackage),
+        'advisory_id' => (string) ($row['advisoryId'] ?? $row['advisory_id'] ?? ''),
+        'cve' => (string) ($row['cve'] ?? ''),
+        'title' => (string) ($row['title'] ?? ''),
+        'link' => (string) ($row['link'] ?? ''),
+        'severity' => $severity,
+        'affected_versions' => (string) ($row['affectedVersions'] ?? $row['affected_versions'] ?? ''),
+        'reported_at' => (string) ($row['reportedAt'] ?? $row['reported_at'] ?? ''),
+    ];
+};
+
+if (is_array($rawAdvisories)) {
+    if (array_is_list($rawAdvisories)) {
+        foreach ($rawAdvisories as $row) {
+            if (is_array($row)) {
+                $appendRow($row, 'unknown-package');
+            }
+        }
+    } else {
+        foreach ($rawAdvisories as $package => $rows) {
+            if (!is_array($rows)) {
+                continue;
+            }
+            foreach ($rows as $row) {
+                if (is_array($row)) {
+                    $appendRow($row, (string) $package);
+                }
+            }
+        }
+    }
+}
+
+usort(
+    $normalized,
+    static function (array $a, array $b): int {
+        return [$a['package'], $a['severity'], $a['advisory_id'], $a['cve'], $a['title']]
+            <=> [$b['package'], $b['severity'], $b['advisory_id'], $b['cve'], $b['title']];
+    }
+);
+
+$severityCounts = [
+    'critical' => 0,
+    'high' => 0,
+    'medium' => 0,
+    'low' => 0,
+    'unknown' => 0,
+];
+
+foreach ($normalized as $item) {
+    $sev = $item['severity'];
+    if (!array_key_exists($sev, $severityCounts)) {
+        $sev = 'unknown';
+    }
+    $severityCounts[$sev]++;
+}
+
+$abandoned = $payload['abandoned'] ?? [];
+$abandonedCount = is_array($abandoned) ? count($abandoned) : 0;
+
+$summary = [
+    'generated_at_utc' => gmdate('c'),
+    'total' => count($normalized),
+    'high_or_critical' => $severityCounts['critical'] + $severityCounts['high'],
+    'by_severity' => $severityCounts,
+    'abandoned_count' => $abandonedCount,
+    'advisories' => $normalized,
+];
+
+file_put_contents(
+    $normalizedPath,
+    json_encode($normalized, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE)
+);
+file_put_contents(
+    $summaryPath,
+    json_encode($summary, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE)
+);
+PHP
+
+if [[ -f "${PREV_SUMMARY_JSON}" ]]; then
+  PREV_SUMMARY_PATH="${PREV_SUMMARY_JSON}" CURR_SUMMARY_PATH="${SUMMARY_JSON}" DIFF_JSON_PATH="${DIFF_JSON}" DIFF_TXT_PATH="${DIFF_TXT}" php <<'PHP'
+<?php
+declare(strict_types=1);
+
+$prevPath = (string) getenv('PREV_SUMMARY_PATH');
+$currPath = (string) getenv('CURR_SUMMARY_PATH');
+$diffJsonPath = (string) getenv('DIFF_JSON_PATH');
+$diffTxtPath = (string) getenv('DIFF_TXT_PATH');
+$prev = json_decode((string) file_get_contents($prevPath), true);
+$curr = json_decode((string) file_get_contents($currPath), true);
+
+if (!is_array($prev)) {
+    $prev = ['advisories' => []];
+}
+if (!is_array($curr)) {
+    fwrite(STDERR, "[PR78][VERIFY][FAIL] current summary parse failed\n");
+    exit(2);
+}
+
+$prevList = is_array($prev['advisories'] ?? null) ? $prev['advisories'] : [];
+$currList = is_array($curr['advisories'] ?? null) ? $curr['advisories'] : [];
+
+$toMap = static function (array $rows): array {
+    $map = [];
+    foreach ($rows as $row) {
+        if (!is_array($row)) {
+            continue;
+        }
+        $key = implode('|', [
+            (string) ($row['package'] ?? ''),
+            (string) ($row['advisory_id'] ?? ''),
+            (string) ($row['cve'] ?? ''),
+            (string) ($row['title'] ?? ''),
+        ]);
+        $map[$key] = $row;
+    }
+    return $map;
+};
+
+$prevMap = $toMap($prevList);
+$currMap = $toMap($currList);
+
+$new = [];
+$resolved = [];
+$severityChanged = [];
+
+foreach ($currMap as $k => $row) {
+    if (!array_key_exists($k, $prevMap)) {
+        $new[] = $row;
+        continue;
+    }
+    $prevSeverity = (string) ($prevMap[$k]['severity'] ?? 'unknown');
+    $currSeverity = (string) ($row['severity'] ?? 'unknown');
+    if ($prevSeverity !== $currSeverity) {
+        $severityChanged[] = [
+            'key' => $k,
+            'from' => $prevSeverity,
+            'to' => $currSeverity,
+            'package' => (string) ($row['package'] ?? ''),
+            'advisory_id' => (string) ($row['advisory_id'] ?? ''),
+            'cve' => (string) ($row['cve'] ?? ''),
+            'title' => (string) ($row['title'] ?? ''),
+        ];
+    }
+}
+
+foreach ($prevMap as $k => $row) {
+    if (!array_key_exists($k, $currMap)) {
+        $resolved[] = $row;
+    }
+}
+
+$diff = [
+    'generated_at_utc' => gmdate('c'),
+    'current_total' => (int) ($curr['total'] ?? count($currList)),
+    'previous_total' => (int) ($prev['total'] ?? count($prevList)),
+    'new_count' => count($new),
+    'resolved_count' => count($resolved),
+    'severity_changed_count' => count($severityChanged),
+    'new' => $new,
+    'resolved' => $resolved,
+    'severity_changed' => $severityChanged,
+];
+
+file_put_contents(
+    $diffJsonPath,
+    json_encode($diff, JSON_PRETTY_PRINT | JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES)
+);
+
+$lines = [];
+$lines[] = 'current_total=' . $diff['current_total'];
+$lines[] = 'previous_total=' . $diff['previous_total'];
+$lines[] = 'new=' . $diff['new_count'];
+$lines[] = 'resolved=' . $diff['resolved_count'];
+$lines[] = 'severity_changed=' . $diff['severity_changed_count'];
+if ($diff['new_count'] > 0) {
+    foreach ($new as $row) {
+        $lines[] = 'NEW ' . (string) ($row['package'] ?? '') . '|' . (string) ($row['severity'] ?? '') . '|' . (string) ($row['advisory_id'] ?? '') . '|' . (string) ($row['cve'] ?? '');
+    }
+}
+if ($diff['resolved_count'] > 0) {
+    foreach ($resolved as $row) {
+        $lines[] = 'RESOLVED ' . (string) ($row['package'] ?? '') . '|' . (string) ($row['severity'] ?? '') . '|' . (string) ($row['advisory_id'] ?? '') . '|' . (string) ($row['cve'] ?? '');
+    }
+}
+if ($diff['severity_changed_count'] > 0) {
+    foreach ($severityChanged as $row) {
+        $lines[] = 'CHANGED ' . (string) ($row['package'] ?? '') . '|' . (string) ($row['advisory_id'] ?? '') . '|' . (string) ($row['from'] ?? '') . '->' . (string) ($row['to'] ?? '');
+    }
+}
+
+file_put_contents($diffTxtPath, implode(PHP_EOL, $lines) . PHP_EOL);
+PHP
+else
+  cat > "${DIFF_JSON}" <<'EOF'
+{
+  "generated_at_utc": null,
+  "baseline_initialized": true,
+  "current_total": 0,
+  "previous_total": 0,
+  "new_count": 0,
+  "resolved_count": 0,
+  "severity_changed_count": 0,
+  "new": [],
+  "resolved": [],
+  "severity_changed": []
+}
+EOF
+  cat > "${DIFF_TXT}" <<'EOF'
+baseline_initialized=true
+new=0
+resolved=0
+severity_changed=0
+EOF
+fi
+
+cp "${AUDIT_JSON}" "${WEEKLY_DIR}/composer_audit_${RUN_TS}.json"
+cp "${SUMMARY_JSON}" "${WEEKLY_DIR}/summary_${RUN_TS}.json"
+cp "${DIFF_TXT}" "${WEEKLY_DIR}/diff_${RUN_TS}.txt"
+
+cp "${AUDIT_JSON}" "${LATEST_DIR}/composer_audit.json"
+cp "${SUMMARY_JSON}" "${LATEST_DIR}/summary.json"
+cp "${DIFF_TXT}" "${LATEST_DIR}/diff.txt"
+
+TOTAL_ADVISORIES="$(php -r '$j=json_decode(file_get_contents($argv[1]), true); echo (string) ((int)($j["total"] ?? 0));' "${SUMMARY_JSON}")"
+HIGH_OR_CRITICAL="$(php -r '$j=json_decode(file_get_contents($argv[1]), true); echo (string) ((int)($j["high_or_critical"] ?? 0));' "${SUMMARY_JSON}")"
+ABANDONED_COUNT="$(php -r '$j=json_decode(file_get_contents($argv[1]), true); echo (string) ((int)($j["abandoned_count"] ?? 0));' "${SUMMARY_JSON}")"
+
+{
+  echo "run_ts=${RUN_TS}"
+  echo "week=${WEEK_TAG}"
+  echo "audit_exit_code=${AUDIT_EXIT}"
+  echo "total_advisories=${TOTAL_ADVISORIES}"
+  echo "high_or_critical=${HIGH_OR_CRITICAL}"
+  echo "abandoned_count=${ABANDONED_COUNT}"
+  echo "artifact_run_dir=${RUN_DIR}"
+  echo "artifact_weekly_dir=${WEEKLY_DIR}"
+  echo "artifact_latest_dir=${LATEST_DIR}"
+} > "${SUMMARY_TXT}"
+
+echo "[PR78][VERIFY] total_advisories=${TOTAL_ADVISORIES} high_or_critical=${HIGH_OR_CRITICAL} abandoned=${ABANDONED_COUNT}"
+echo "[PR78][VERIFY] artifacts=${RUN_DIR}"
+
+if [[ "${HIGH_OR_CRITICAL}" -gt 0 ]]; then
+  fail "high/critical advisories detected; release is blocked"
+fi
+
+echo "[PR78][VERIFY] pass"

--- a/backend/scripts/verify_order_security.sh
+++ b/backend/scripts/verify_order_security.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+export CI=true
+export APP_ENV=testing
+export QUEUE_CONNECTION=sync
+export XDEBUG_MODE=off
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "${ROOT_DIR}"
+
+php artisan test --filter=CommerceOrderLookupSecurityTest
+php artisan test --filter=CommerceOrderReadFallbackTest
+php artisan test --filter=HighIdorOwnership404Test

--- a/backend/tests/Feature/HighIdorOwnership404Test.php
+++ b/backend/tests/Feature/HighIdorOwnership404Test.php
@@ -180,7 +180,7 @@ class HighIdorOwnership404Test extends TestCase
             ->assertStatus(404);
     }
 
-    public function test_header_only_order_read_returns_degraded_payload_without_sensitive_fields(): void
+    public function test_header_only_order_read_returns_404(): void
     {
         $orderNo = 'ord_pr60_' . Str::lower(Str::random(10));
         $this->insertOrderForAnonA($orderNo);
@@ -188,15 +188,8 @@ class HighIdorOwnership404Test extends TestCase
         $response = $this->withHeaders(['X-Anon-Id' => self::ANON_B])
             ->getJson("/api/v0.3/orders/{$orderNo}");
 
-        $response->assertStatus(200)
-            ->assertJsonPath('ok', true)
-            ->assertJsonPath('ownership_verified', false)
-            ->assertJsonPath('order_no', $orderNo)
-            ->assertJsonPath('status', 'pending');
-
-        $response->assertJsonMissingPath('order');
-        $response->assertJsonMissingPath('amount_cents');
-        $response->assertJsonMissingPath('currency');
+        $response->assertStatus(404)
+            ->assertJsonPath('error_code', 'NOT_FOUND');
     }
 
 }

--- a/backend/tests/Feature/V0_3/CommerceOrderLookupSecurityTest.php
+++ b/backend/tests/Feature/V0_3/CommerceOrderLookupSecurityTest.php
@@ -10,56 +10,69 @@ use Illuminate\Support\Facades\Schema;
 use Illuminate\Support\Str;
 use Tests\TestCase;
 
-final class CommerceOrderReadFallbackTest extends TestCase
+final class CommerceOrderLookupSecurityTest extends TestCase
 {
     use RefreshDatabase;
 
-    private const ANON_OWNER = 'order_read_owner';
-    private const ANON_ATTACKER = 'order_read_attacker';
+    private const ANON_OWNER = 'lookup_owner';
 
-    public function test_without_identity_returns_404(): void
+    public function test_lookup_requires_email_when_identity_missing(): void
     {
-        $orderNo = 'ord_fallback_' . Str::lower(Str::random(10));
-        $this->insertOrderForOwner($orderNo);
+        $response = $this->postJson('/api/v0.3/orders/lookup', [
+            'order_no' => 'ord_missing_identity',
+        ]);
 
-        $response = $this->getJson('/api/v0.3/orders/' . $orderNo);
-
-        $response->assertStatus(404)
-            ->assertJsonPath('error_code', 'NOT_FOUND');
+        $response->assertStatus(422)
+            ->assertJsonPath('error_code', 'VALIDATION_FAILED');
     }
 
-    public function test_mismatched_token_identity_still_returns_404(): void
+    public function test_lookup_with_wrong_email_is_blinded(): void
     {
-        $orderNo = 'ord_fallback_' . Str::lower(Str::random(10));
-        $this->insertOrderForOwner($orderNo);
+        $orderNo = 'ord_lookup_' . Str::lower(Str::random(8));
+        $this->insertOrderForLookup($orderNo, 'owner@example.com');
 
-        $token = $this->issueAnonToken(self::ANON_ATTACKER);
-        $response = $this->withHeaders([
-            'Authorization' => 'Bearer ' . $token,
-        ])->getJson('/api/v0.3/orders/' . $orderNo);
+        $response = $this->postJson('/api/v0.3/orders/lookup', [
+            'order_no' => $orderNo,
+            'email' => 'attacker@example.com',
+        ]);
 
         $response->assertStatus(404)
-            ->assertJsonPath('error_code', 'NOT_FOUND');
+            ->assertJsonPath('error_code', 'ORDER_NOT_FOUND');
     }
 
-    public function test_matching_token_identity_returns_full_payload(): void
+    public function test_lookup_with_matching_email_hash_returns_status(): void
     {
-        $orderNo = 'ord_fallback_' . Str::lower(Str::random(10));
-        $this->insertOrderForOwner($orderNo);
+        $orderNo = 'ord_lookup_' . Str::lower(Str::random(8));
+        $this->insertOrderForLookup($orderNo, 'owner@example.com');
 
-        $token = $this->issueAnonToken(self::ANON_OWNER);
-        $response = $this->withHeaders([
-            'Authorization' => 'Bearer ' . $token,
-        ])->getJson('/api/v0.3/orders/' . $orderNo);
+        $response = $this->postJson('/api/v0.3/orders/lookup', [
+            'order_no' => $orderNo,
+            'email' => 'owner@example.com',
+        ]);
 
         $response->assertStatus(200)
             ->assertJsonPath('ok', true)
-            ->assertJsonPath('ownership_verified', true)
             ->assertJsonPath('order_no', $orderNo)
-            ->assertJsonPath('status', 'pending')
-            ->assertJsonPath('amount_cents', 1990)
-            ->assertJsonPath('currency', 'USD')
-            ->assertJsonPath('order.anon_id', self::ANON_OWNER);
+            ->assertJsonPath('status', 'pending');
+    }
+
+    public function test_lookup_with_token_owner_works_without_email(): void
+    {
+        $orderNo = 'ord_lookup_' . Str::lower(Str::random(8));
+        $this->insertOrderForLookup($orderNo, 'owner@example.com');
+
+        $token = $this->issueAnonToken(self::ANON_OWNER);
+
+        $response = $this->withHeaders([
+            'Authorization' => 'Bearer ' . $token,
+        ])->postJson('/api/v0.3/orders/lookup', [
+            'order_no' => $orderNo,
+        ]);
+
+        $response->assertStatus(200)
+            ->assertJsonPath('ok', true)
+            ->assertJsonPath('order_no', $orderNo)
+            ->assertJsonPath('status', 'pending');
     }
 
     private function issueAnonToken(string $anonId): string
@@ -81,7 +94,7 @@ final class CommerceOrderReadFallbackTest extends TestCase
         return $token;
     }
 
-    private function insertOrderForOwner(string $orderNo): void
+    private function insertOrderForLookup(string $orderNo, string $email): void
     {
         $now = now();
         $row = [
@@ -103,6 +116,9 @@ final class CommerceOrderReadFallbackTest extends TestCase
             'updated_at' => $now,
         ];
 
+        if (Schema::hasColumn('orders', 'contact_email_hash')) {
+            $row['contact_email_hash'] = hash('sha256', mb_strtolower(trim($email), 'UTF-8'));
+        }
         if (Schema::hasColumn('orders', 'amount_total')) {
             $row['amount_total'] = 1990;
         }

--- a/backend/tests/Feature/V0_3/OrderScaleIdentityDualWriteTest.php
+++ b/backend/tests/Feature/V0_3/OrderScaleIdentityDualWriteTest.php
@@ -29,7 +29,9 @@ final class OrderScaleIdentityDualWriteTest extends TestCase
             'SKU_SDS_20_FULL_299',
             1,
             $attemptId,
-            'billing'
+            'billing',
+            null,
+            'anon_order_dual@example.com'
         );
 
         $this->assertTrue((bool) ($result['ok'] ?? false));
@@ -56,7 +58,9 @@ final class OrderScaleIdentityDualWriteTest extends TestCase
             'SKU_SDS_20_FULL_299',
             1,
             $attemptId,
-            'billing'
+            'billing',
+            null,
+            'anon_order_legacy@example.com'
         );
 
         $this->assertTrue((bool) ($result['ok'] ?? false));
@@ -114,4 +118,3 @@ final class OrderScaleIdentityDualWriteTest extends TestCase
         );
     }
 }
-

--- a/backend/tests/Feature/V0_3/ShareFlowCoreAlignmentTest.php
+++ b/backend/tests/Feature/V0_3/ShareFlowCoreAlignmentTest.php
@@ -1,0 +1,140 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\V0_3;
+
+use App\Models\Attempt;
+use App\Models\Result;
+use App\Services\Commerce\EntitlementManager;
+use App\Services\Legacy\LegacyShareFlowService;
+use App\Services\V0_3\ShareFlowService;
+use App\Support\OrgContext;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Str;
+use Tests\TestCase;
+
+final class ShareFlowCoreAlignmentTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_v03_and_legacy_share_flow_return_aligned_payloads_for_same_input(): void
+    {
+        $orgId = 123;
+        $attemptId = (string) Str::uuid();
+        $anonId = 'anon_share_flow_alignment';
+        $benefitCode = 'MBTI_REPORT_FULL';
+
+        $this->seedScaleRegistry($orgId, $benefitCode);
+        $this->seedAttemptAndResult($orgId, $attemptId, $anonId);
+
+        $ctx = new OrgContext;
+        $ctx->set($orgId, null, 'public', $anonId);
+        app()->instance(OrgContext::class, $ctx);
+
+        app(EntitlementManager::class)->grantAttemptUnlock(
+            $orgId,
+            null,
+            $anonId,
+            $benefitCode,
+            $attemptId,
+            null
+        );
+
+        $input = [
+            'experiment' => 'exp_alignment',
+            'version' => '1.0.0',
+            'channel' => 'miniapp',
+            'client_platform' => 'wechat',
+            'entry_page' => 'result_page',
+        ];
+
+        $v03 = app(ShareFlowService::class)->getShareLinkForAttempt($attemptId, $input);
+        $legacy = app(LegacyShareFlowService::class)->getShareLinkForAttempt($attemptId, $input);
+
+        $this->assertSame((string) ($v03['share_id'] ?? ''), (string) ($legacy['share_id'] ?? ''));
+        $this->assertSame((string) ($v03['share_url'] ?? ''), (string) ($legacy['share_url'] ?? ''));
+        $this->assertSame((string) ($v03['attempt_id'] ?? ''), (string) ($legacy['attempt_id'] ?? ''));
+        $this->assertSame((int) ($v03['org_id'] ?? -1), (int) ($legacy['org_id'] ?? -2));
+        $this->assertSame((string) ($v03['type_code'] ?? ''), (string) ($legacy['type_code'] ?? ''));
+        $this->assertSame((string) ($v03['type_name'] ?? ''), (string) ($legacy['type_name'] ?? ''));
+
+        $shareId = (string) ($v03['share_id'] ?? '');
+        $this->assertNotSame('', $shareId);
+
+        $v03View = app(ShareFlowService::class)->getShareView($shareId);
+        $legacyView = app(LegacyShareFlowService::class)->getShareView($shareId);
+
+        $this->assertSame((string) ($v03View['share_id'] ?? ''), (string) ($legacyView['share_id'] ?? ''));
+        $this->assertSame((string) ($v03View['attempt_id'] ?? ''), (string) ($legacyView['attempt_id'] ?? ''));
+        $this->assertSame((int) ($v03View['org_id'] ?? -1), (int) ($legacyView['org_id'] ?? -2));
+        $this->assertSame((string) ($v03View['type_code'] ?? ''), (string) ($legacyView['type_code'] ?? ''));
+        $this->assertSame((string) ($v03View['type_name'] ?? ''), (string) ($legacyView['type_name'] ?? ''));
+    }
+
+    private function seedScaleRegistry(int $orgId, string $benefitCode): void
+    {
+        $now = now();
+        DB::table('scales_registry')->updateOrInsert(
+            ['code' => 'MBTI'],
+            [
+                'org_id' => $orgId,
+                'primary_slug' => 'mbti',
+                'slugs_json' => json_encode(['mbti'], JSON_UNESCAPED_UNICODE),
+                'driver_type' => 'questionnaire',
+                'default_pack_id' => 'MBTI.cn-mainland.zh-CN.v0.3',
+                'default_region' => 'CN_MAINLAND',
+                'default_locale' => 'zh-CN',
+                'default_dir_version' => 'MBTI-CN-v0.3',
+                'capabilities_json' => json_encode([], JSON_UNESCAPED_UNICODE),
+                'view_policy_json' => json_encode([], JSON_UNESCAPED_UNICODE),
+                'commercial_json' => json_encode(['report_benefit_code' => $benefitCode], JSON_UNESCAPED_UNICODE),
+                'seo_schema_json' => json_encode([], JSON_UNESCAPED_UNICODE),
+                'is_public' => 1,
+                'is_active' => 1,
+                'created_at' => $now,
+                'updated_at' => $now,
+            ]
+        );
+    }
+
+    private function seedAttemptAndResult(int $orgId, string $attemptId, string $anonId): void
+    {
+        Attempt::create([
+            'id' => $attemptId,
+            'org_id' => $orgId,
+            'anon_id' => $anonId,
+            'scale_code' => 'MBTI',
+            'scale_version' => 'v0.3',
+            'region' => 'CN_MAINLAND',
+            'locale' => 'zh-CN',
+            'question_count' => 1,
+            'client_platform' => 'test',
+            'answers_summary_json' => ['stage' => 'seed'],
+            'started_at' => now()->subMinute(),
+            'submitted_at' => now(),
+            'pack_id' => 'MBTI.cn-mainland.zh-CN.v0.3',
+            'dir_version' => 'MBTI-CN-v0.3',
+            'content_package_version' => 'v0.3',
+            'scoring_spec_version' => '2026.01',
+        ]);
+
+        Result::create([
+            'id' => (string) Str::uuid(),
+            'org_id' => $orgId,
+            'attempt_id' => $attemptId,
+            'scale_code' => 'MBTI',
+            'scale_version' => 'v0.3',
+            'type_code' => 'INTJ-A',
+            'scores_json' => ['total' => 100],
+            'is_valid' => true,
+            'computed_at' => now(),
+            'result_json' => ['type_code' => 'INTJ-A'],
+            'pack_id' => 'MBTI.cn-mainland.zh-CN.v0.3',
+            'dir_version' => 'MBTI-CN-v0.3',
+            'scoring_spec_version' => '2026.01',
+            'report_engine_version' => 'v1.2',
+        ]);
+    }
+}

--- a/backend/tests/Sre/MigrationSafetyTest.php
+++ b/backend/tests/Sre/MigrationSafetyTest.php
@@ -17,13 +17,14 @@ final class MigrationSafetyTest extends TestCase
         'dropColumn(',
         'dropTable(',
         'renameColumn(',
+        '->change(',
     ];
 
     #[Test]
     public function migrations_must_not_include_destructive_rollback_statements(): void
     {
         $files = glob(base_path('database/migrations/*.php'));
-        if (!is_array($files)) {
+        if (! is_array($files)) {
             $this->fail('unable to read migration files');
         }
 
@@ -31,7 +32,7 @@ final class MigrationSafetyTest extends TestCase
 
         foreach ($files as $filePath) {
             $source = file_get_contents($filePath);
-            $this->assertIsString($source, 'unable to read migration file: ' . $filePath);
+            $this->assertIsString($source, 'unable to read migration file: '.$filePath);
 
             foreach (self::BLOCKED_PATTERNS as $pattern) {
                 $this->assertStringNotContainsString(


### PR DESCRIPTION
## Summary
This PR delivers the `Loop01 ~ Loop11` remediation sequence as 11 atomic commits, with each loop kept independently verifiable.

## Loop Commit Map
1. `fix(commerce): close order lookup and read ownership gaps`
   - Fixes `/api/v0.3/orders/lookup` ownership proof (`order_no + identity/email-hash`)
   - Removes anonymous order-read leakage path (unauthorized reads return blinded 404)
   - Adds `orders.contact_email_hash` migration + security regression tests
2. `fix(queue): enforce timeout and retry-after isolation`
   - Adds explicit `$timeout` + `$failOnTimeout`
   - Adds `database_reports` / `database_commerce` queue connections and retry-after guards
3. `perf(reports): stream psychometrics aggregation to avoid OOM`
   - Replaces full-load patterns with cursor-based streaming in psychometrics commands
4. `fix(migrations): enforce expand-first schema safety`
   - Makes risky migration changes expand-safe
   - Adds migration static gate script and test guard updates
5. `refactor(ops): slim big5 controller with action/query services`
   - Splits `BigFiveOpsController` responsibilities into request + action/query/command services
6. `refactor(legacy): remove Request coupling via DTO context`
   - Removes `Illuminate\Http\Request` from legacy service signatures
   - Adds DTO context and form requests
7. `refactor(core): split overloaded services to reduce DI fan-in`
   - Reduces constructor fan-in by introducing registry/composition split
8. `refactor(config): move runtime env reads behind config`
   - Removes runtime `env()` use in app service flow and enforces config-driven reads
9. `perf(events): index share dedupe query on generated columns`
   - Adds generated columns + composite index for dedupe lookup and updates query path
10. `refactor(share): unify legacy and v03 share flow core`
    - Extracts shared core and keeps legacy/v0.3 adapters thin
11. `chore(security): gate dependency audit and enforce hashed fm tokens`
    - CI gate for `composer audit`
    - Token validation/storage hardening to hash-driven flow

## Key Files
- Routes: `backend/routes/api.php`
- Commerce security: `backend/app/Http/Controllers/API/V0_3/CommerceController.php`, `backend/app/Services/Commerce/OrderManager.php`
- Queue reliability: `backend/config/queue.php`, `backend/app/Jobs/*`
- Legacy decoupling: `backend/app/Services/Legacy/*`, `backend/app/DTO/Legacy/LegacyRequestContext.php`
- Shareflow unification: `backend/app/Services/Share/*`
- CI gates: `backend/scripts/pr69_verify.sh` ~ `backend/scripts/pr78_verify.sh`, `backend/scripts/ci_verify_mbti.sh`

## Verification
Executed and passing:
- `php artisan route:list --path=api/v0.3/orders -v`
- `DB_CONNECTION=sqlite DB_DATABASE=/tmp/fap-loop-verify.sqlite php artisan migrate --force`
- `bash backend/scripts/verify_order_security.sh`
- `bash backend/scripts/pr69_verify.sh`
- `bash backend/scripts/pr70_verify.sh`
- `bash backend/scripts/pr71_verify.sh`
- `bash backend/scripts/pr72_verify.sh`
- `bash backend/scripts/pr73_verify.sh`
- `bash backend/scripts/pr74_verify.sh`
- `bash backend/scripts/pr75_verify.sh`
- `bash backend/scripts/pr76_verify.sh`
- `bash backend/scripts/pr77_verify.sh`
- `bash backend/scripts/pr78_verify.sh`
- `bash backend/scripts/ci_verify_mbti.sh`

## Risk / Compatibility
- Order lookup/read behavior is intentionally tightened for anti-enumeration.
- Queue worker behavior now depends on explicit timeout contracts (`timeout < retry_after`).
- Token legacy plaintext lookup fallback is removed in favor of hash-only validation.
