### PR TITLE
Fixes FER2-10: webhook reject returns 2xx ack

### DIFF
--- a/backend/app/Internal/Commerce/PaymentWebhookHandlerCore.php
+++ b/backend/app/Internal/Commerce/PaymentWebhookHandlerCore.php
@@ -204,6 +204,7 @@ class PaymentWebhookHandlerCore
                             'attempts' => 0,
                             'last_error_code' => null,
                             'last_error_message' => null,
+                            'reason' => null,
                             'processed_at' => null,
                             'handled_at' => null,
                             'handle_status' => null,
@@ -257,6 +258,7 @@ class PaymentWebhookHandlerCore
                             'attempts' => $attempts,
                             'last_error_code' => null,
                             'last_error_message' => null,
+                            'reason' => null,
                             'processed_at' => null,
                             'handled_at' => null,
                             'handle_status' => null,
@@ -287,7 +289,7 @@ class PaymentWebhookHandlerCore
                         if (! $order) {
                             $this->markEventError($provider, $providerEventId, 'orphan', 'ORDER_NOT_FOUND', 'order not found.');
 
-                            return $this->notFound('ORDER_NOT_FOUND', 'not found.');
+                            return $this->semanticReject('ORDER_NOT_FOUND', 'order not found.');
                         }
 
                         $orderProvider = strtolower(trim((string) ($order->provider ?? '')));
@@ -311,7 +313,7 @@ class PaymentWebhookHandlerCore
                                 $detail
                             );
 
-                            return $this->badRequest('PROVIDER_MISMATCH', 'provider mismatch');
+                            return $this->semanticReject('PROVIDER_MISMATCH', 'provider mismatch');
                         }
 
                         $isRefundEvent = $this->isRefundEvent($eventType, $normalized);
@@ -364,27 +366,29 @@ class PaymentWebhookHandlerCore
                         if ($effectiveSku === '') {
                             $this->markEventError($provider, $providerEventId, 'failed', 'SKU_NOT_FOUND', 'sku missing on order.');
 
-                            return $this->badRequest('SKU_NOT_FOUND', 'sku missing on order.');
+                            return $this->semanticReject('SKU_NOT_FOUND', 'sku missing on order.');
                         }
 
                         $skuRow = $this->skus->getActiveSku($effectiveSku, null, (int) ($order->org_id ?? $orgId));
                         if (! $skuRow) {
                             $this->markEventError($provider, $providerEventId, 'failed', 'SKU_NOT_FOUND', 'sku not found.');
 
-                            return $this->notFound('SKU_NOT_FOUND', 'sku not found.');
+                            return $this->semanticReject('SKU_NOT_FOUND', 'sku not found.');
                         }
 
                         $guard = $this->validatePaidEventGuard($provider, $eventType, $normalized, $order);
                         if (! ($guard['ok'] ?? false)) {
+                            $guardCode = (string) ($guard['code'] ?? 'WEBHOOK_REJECTED');
+                            $guardMessage = (string) ($guard['message'] ?? 'webhook rejected.');
                             $this->markEventError(
                                 $provider,
                                 $providerEventId,
                                 'rejected',
-                                (string) ($guard['code'] ?? 'WEBHOOK_REJECTED'),
-                                (string) ($guard['message'] ?? 'webhook rejected.')
+                                $guardCode,
+                                $guardMessage
                             );
 
-                            return $this->notFound('NOT_FOUND', 'not found.');
+                            return $this->semanticReject($guardCode, $guardMessage);
                         }
 
                         if (! $orderAlreadySettled) {
@@ -444,7 +448,7 @@ class PaymentWebhookHandlerCore
                                 'benefit code missing on sku.'
                             );
 
-                            return $this->badRequest('BENEFIT_CODE_NOT_FOUND', 'benefit code missing on sku.');
+                            return $this->semanticReject('BENEFIT_CODE_NOT_FOUND', 'benefit code missing on sku.');
                         }
 
                         $attemptMeta = $this->resolveAttemptMeta((int) $order->org_id, (string) ($order->target_attempt_id ?? ''));
@@ -481,7 +485,7 @@ class PaymentWebhookHandlerCore
                             ) {
                                 $this->markEventError($provider, $providerEventId, 'failed', 'TOPUP_DELTA_INVALID', 'topup delta invalid.');
 
-                                return $this->badRequest('TOPUP_DELTA_INVALID', 'topup delta invalid.');
+                                return $this->semanticReject('TOPUP_DELTA_INVALID', 'topup delta invalid.');
                             }
 
                             $postCommitCtx = [
@@ -503,7 +507,7 @@ class PaymentWebhookHandlerCore
                             if ($attemptId === '') {
                                 $this->markEventError($provider, $providerEventId, 'failed', 'ATTEMPT_REQUIRED', 'target_attempt_id is required.');
 
-                                return $this->badRequest('ATTEMPT_REQUIRED', 'target_attempt_id is required for report_unlock.');
+                                return $this->semanticReject('ATTEMPT_REQUIRED', 'target_attempt_id is required for report_unlock.');
                             }
 
                             $ownerGuard = $this->validateAttemptOwnershipForOrder($order, $attemptMeta);
@@ -512,7 +516,7 @@ class PaymentWebhookHandlerCore
                                 $message = (string) ($ownerGuard['message'] ?? 'order owner mismatch.');
                                 $this->markEventError($provider, $providerEventId, 'rejected', $code, $message);
 
-                                return $this->badRequest($code, $message);
+                                return $this->semanticReject($code, $message);
                             }
 
                             $scaleGuard = $this->validateAttemptScaleForSku($skuRow, $attemptMeta);
@@ -521,7 +525,7 @@ class PaymentWebhookHandlerCore
                                 $message = (string) ($scaleGuard['message'] ?? 'attempt scale does not match sku scale.');
                                 $this->markEventError($provider, $providerEventId, 'rejected', $code, $message);
 
-                                return $this->badRequest($code, $message);
+                                return $this->semanticReject($code, $message);
                             }
 
                             if (! $retryingPostCommitOnly) {
@@ -589,7 +593,7 @@ class PaymentWebhookHandlerCore
                         } else {
                             $this->markEventError($provider, $providerEventId, 'failed', 'SKU_KIND_INVALID', 'unsupported sku kind.');
 
-                            return $this->badRequest('SKU_KIND_INVALID', 'unsupported sku kind.');
+                            return $this->semanticReject('SKU_KIND_INVALID', 'unsupported sku kind.');
                         }
 
                         if ($orderAlreadySettled) {
@@ -1452,6 +1456,7 @@ class PaymentWebhookHandlerCore
             'handle_status' => 'processed',
             'last_error_code' => null,
             'last_error_message' => null,
+            'reason' => null,
             'updated_at' => $now,
         ]);
     }
@@ -1459,13 +1464,26 @@ class PaymentWebhookHandlerCore
     private function markEventError(string $provider, string $providerEventId, string $status, string $code, string $message): void
     {
         $now = now();
+        $normalizedCode = substr($this->normalizeErrorCode($code), 0, 64);
         $this->updatePaymentEvent($provider, $providerEventId, [
             'status' => $status,
             'handled_at' => $now,
             'handle_status' => $status,
             'last_error_code' => $code,
             'last_error_message' => $message,
+            'reason' => $normalizedCode,
             'updated_at' => $now,
+        ]);
+    }
+
+    private function semanticReject(string $code, string $message): array
+    {
+        $normalizedCode = $this->normalizeErrorCode($code);
+
+        return $this->errorResult(200, $normalizedCode, $message, null, [
+            'acknowledged' => true,
+            'rejected' => true,
+            'reject_reason' => $normalizedCode,
         ]);
     }
 

--- a/backend/tests/Feature/Commerce/BigFiveWebhookIdempotencyTest.php
+++ b/backend/tests/Feature/Commerce/BigFiveWebhookIdempotencyTest.php
@@ -194,8 +194,10 @@ final class BigFiveWebhookIdempotencyTest extends TestCase
         ];
 
         $response = $this->postSignedBillingWebhook($payload, ['X-Org-Id' => '0']);
-        $response->assertStatus(404);
+        $response->assertStatus(200);
         $response->assertJsonPath('error_code', 'SKU_NOT_FOUND');
+        $response->assertJsonPath('rejected', true);
+        $response->assertJsonPath('reject_reason', 'SKU_NOT_FOUND');
 
         $this->assertSame('failed', (string) DB::table('payment_events')
             ->where('provider', 'billing')
@@ -206,6 +208,10 @@ final class BigFiveWebhookIdempotencyTest extends TestCase
             ->where('provider', 'billing')
             ->where('provider_event_id', 'evt_big5_badsku_1')
             ->value('last_error_code'));
+        $this->assertSame('SKU_NOT_FOUND', (string) DB::table('payment_events')
+            ->where('provider', 'billing')
+            ->where('provider_event_id', 'evt_big5_badsku_1')
+            ->value('reason'));
 
         $this->assertSame(0, DB::table('benefit_grants')
             ->where('order_no', $orderNo)

--- a/backend/tests/Feature/Commerce/ClinicalCombo68WebhookIdempotencyTest.php
+++ b/backend/tests/Feature/Commerce/ClinicalCombo68WebhookIdempotencyTest.php
@@ -75,13 +75,19 @@ final class ClinicalCombo68WebhookIdempotencyTest extends TestCase
         ];
 
         $resp = $this->postSignedBillingWebhook($payload, ['X-Org-Id' => '0']);
-        $resp->assertStatus(400);
+        $resp->assertStatus(200);
         $resp->assertJsonPath('error_code', 'ATTEMPT_OWNER_MISMATCH');
+        $resp->assertJsonPath('rejected', true);
+        $resp->assertJsonPath('reject_reason', 'ATTEMPT_OWNER_MISMATCH');
 
         $this->assertSame(0, DB::table('benefit_grants')
             ->where('order_no', $orderNo)
             ->where('attempt_id', $attemptId)
             ->count());
+        $this->assertSame('ATTEMPT_OWNER_MISMATCH', (string) DB::table('payment_events')
+            ->where('provider', 'billing')
+            ->where('provider_event_id', 'evt_cc68_owner_mismatch_1')
+            ->value('reason'));
     }
 
     private function createClinicalAttemptWithResult(string $anonId): string
@@ -178,4 +184,3 @@ final class ClinicalCombo68WebhookIdempotencyTest extends TestCase
         ]);
     }
 }
-

--- a/backend/tests/Feature/Commerce/Eq60WebhookIdempotencyTest.php
+++ b/backend/tests/Feature/Commerce/Eq60WebhookIdempotencyTest.php
@@ -78,8 +78,10 @@ final class Eq60WebhookIdempotencyTest extends TestCase
         ];
 
         $resp = $this->postSignedBillingWebhook($payload, ['X-Org-Id' => '0']);
-        $resp->assertStatus(400);
+        $resp->assertStatus(200);
         $resp->assertJsonPath('error_code', 'ATTEMPT_SCALE_MISMATCH');
+        $resp->assertJsonPath('rejected', true);
+        $resp->assertJsonPath('reject_reason', 'ATTEMPT_SCALE_MISMATCH');
 
         $this->assertSame(0, DB::table('benefit_grants')
             ->where('order_no', $orderNo)
@@ -89,6 +91,10 @@ final class Eq60WebhookIdempotencyTest extends TestCase
             ->where('provider', 'billing')
             ->where('provider_event_id', 'evt_eq_scale_mismatch_1')
             ->value('last_error_code'));
+        $this->assertSame('ATTEMPT_SCALE_MISMATCH', (string) DB::table('payment_events')
+            ->where('provider', 'billing')
+            ->where('provider_event_id', 'evt_eq_scale_mismatch_1')
+            ->value('reason'));
     }
 
     private function createEqAttemptWithResult(string $anonId): string
@@ -222,4 +228,3 @@ final class Eq60WebhookIdempotencyTest extends TestCase
         ]);
     }
 }
-

--- a/backend/tests/Feature/Commerce/PaymentWebhookIdempotencyTest.php
+++ b/backend/tests/Feature/Commerce/PaymentWebhookIdempotencyTest.php
@@ -161,15 +161,20 @@ class PaymentWebhookIdempotencyTest extends TestCase
         $first = $this->postSignedBillingWebhook($payload, [
             'X-Org-Id' => '0',
         ]);
-        $first->assertStatus(404);
+        $first->assertStatus(200);
         $first->assertJson([
             'ok' => false,
             'error_code' => 'ORDER_NOT_FOUND',
+            'rejected' => true,
+            'reject_reason' => 'ORDER_NOT_FOUND',
         ]);
 
         $this->assertSame('orphan', (string) DB::table('payment_events')
             ->where('provider_event_id', 'evt_orphan_1')
             ->value('status'));
+        $this->assertSame('ORDER_NOT_FOUND', (string) DB::table('payment_events')
+            ->where('provider_event_id', 'evt_orphan_1')
+            ->value('reason'));
 
         $attemptId = $this->createMbtiAttemptWithResult();
 

--- a/backend/tests/Feature/Commerce/PaymentWebhookTrustBoundaryTest.php
+++ b/backend/tests/Feature/Commerce/PaymentWebhookTrustBoundaryTest.php
@@ -91,12 +91,17 @@ class PaymentWebhookTrustBoundaryTest extends TestCase
         ], 0, null, null, true);
 
         $this->assertFalse($result['ok']);
-        $this->assertSame(404, (int) ($result['status'] ?? 0));
+        $this->assertSame(200, (int) ($result['status'] ?? 0));
+        $this->assertSame('AMOUNT_MISMATCH', (string) ($result['reject_reason'] ?? ''));
         $this->assertSame('created', (string) DB::table('orders')->where('order_no', $orderNo)->value('status'));
         $this->assertSame('AMOUNT_MISMATCH', (string) DB::table('payment_events')
             ->where('provider', 'billing')
             ->where('provider_event_id', 'evt_trust_amt_1')
             ->value('last_error_code'));
+        $this->assertSame('AMOUNT_MISMATCH', (string) DB::table('payment_events')
+            ->where('provider', 'billing')
+            ->where('provider_event_id', 'evt_trust_amt_1')
+            ->value('reason'));
     }
 
     public function test_processor_rejects_event_type_outside_whitelist(): void
@@ -115,11 +120,16 @@ class PaymentWebhookTrustBoundaryTest extends TestCase
         ], 0, null, null, true);
 
         $this->assertFalse($result['ok']);
-        $this->assertSame(404, (int) ($result['status'] ?? 0));
+        $this->assertSame(200, (int) ($result['status'] ?? 0));
+        $this->assertSame('EVENT_TYPE_NOT_ALLOWED', (string) ($result['reject_reason'] ?? ''));
         $this->assertSame('EVENT_TYPE_NOT_ALLOWED', (string) DB::table('payment_events')
             ->where('provider', 'billing')
             ->where('provider_event_id', 'evt_trust_evt_1')
             ->value('last_error_code'));
+        $this->assertSame('EVENT_TYPE_NOT_ALLOWED', (string) DB::table('payment_events')
+            ->where('provider', 'billing')
+            ->where('provider_event_id', 'evt_trust_evt_1')
+            ->value('reason'));
         $this->assertSame('created', (string) DB::table('orders')->where('order_no', $orderNo)->value('status'));
     }
 }

--- a/backend/tests/Feature/Commerce/Sds20WebhookIdempotencyTest.php
+++ b/backend/tests/Feature/Commerce/Sds20WebhookIdempotencyTest.php
@@ -77,8 +77,10 @@ final class Sds20WebhookIdempotencyTest extends TestCase
         ];
 
         $resp = $this->postSignedBillingWebhook($payload, ['X-Org-Id' => '0']);
-        $resp->assertStatus(400);
+        $resp->assertStatus(200);
         $resp->assertJsonPath('error_code', 'ATTEMPT_SCALE_MISMATCH');
+        $resp->assertJsonPath('rejected', true);
+        $resp->assertJsonPath('reject_reason', 'ATTEMPT_SCALE_MISMATCH');
 
         $this->assertSame(0, DB::table('benefit_grants')
             ->where('order_no', $orderNo)
@@ -89,6 +91,10 @@ final class Sds20WebhookIdempotencyTest extends TestCase
             ->where('provider', 'billing')
             ->where('provider_event_id', 'evt_sds_scale_mismatch_1')
             ->value('last_error_code'));
+        $this->assertSame('ATTEMPT_SCALE_MISMATCH', (string) DB::table('payment_events')
+            ->where('provider', 'billing')
+            ->where('provider_event_id', 'evt_sds_scale_mismatch_1')
+            ->value('reason'));
     }
 
     private function createSdsAttemptWithResult(string $anonId): string

--- a/backend/tests/Feature/Commerce/Webhook/PaymentWebhookProcessorContractTest.php
+++ b/backend/tests/Feature/Commerce/Webhook/PaymentWebhookProcessorContractTest.php
@@ -134,9 +134,11 @@ final class PaymentWebhookProcessorContractTest extends TestCase
             'event_type' => 'payment_succeeded',
         ]);
 
-        $res->assertStatus(400)->assertJson([
+        $res->assertStatus(200)->assertJson([
             'ok' => false,
             'error_code' => 'PROVIDER_MISMATCH',
+            'rejected' => true,
+            'reject_reason' => 'PROVIDER_MISMATCH',
         ]);
 
         $this->assertSame('created', (string) DB::table('orders')->where('order_no', $orderNo)->value('status'));
@@ -144,6 +146,10 @@ final class PaymentWebhookProcessorContractTest extends TestCase
             ->where('provider', 'billing')
             ->where('provider_event_id', 'evt_contract_provider_mismatch_1')
             ->value('last_error_code'));
+        $this->assertSame('REJECTED_PROVIDER_MISMATCH', (string) DB::table('payment_events')
+            ->where('provider', 'billing')
+            ->where('provider_event_id', 'evt_contract_provider_mismatch_1')
+            ->value('reason'));
         $this->assertSame(0, DB::table('benefit_grants')->count());
     }
 
@@ -190,11 +196,16 @@ final class PaymentWebhookProcessorContractTest extends TestCase
         ], 0, null, null, true);
 
         $this->assertFalse((bool) ($amountMismatch['ok'] ?? true));
-        $this->assertSame(404, (int) ($amountMismatch['status'] ?? 0));
+        $this->assertSame(200, (int) ($amountMismatch['status'] ?? 0));
+        $this->assertSame('AMOUNT_MISMATCH', (string) ($amountMismatch['reject_reason'] ?? ''));
         $this->assertSame('AMOUNT_MISMATCH', (string) DB::table('payment_events')
             ->where('provider', 'billing')
             ->where('provider_event_id', 'evt_contract_amount_mismatch_1')
             ->value('last_error_code'));
+        $this->assertSame('AMOUNT_MISMATCH', (string) DB::table('payment_events')
+            ->where('provider', 'billing')
+            ->where('provider_event_id', 'evt_contract_amount_mismatch_1')
+            ->value('reason'));
 
         $currencyMismatch = $processor->handle('billing', [
             'provider_event_id' => 'evt_contract_currency_mismatch_1',
@@ -205,11 +216,16 @@ final class PaymentWebhookProcessorContractTest extends TestCase
         ], 0, null, null, true);
 
         $this->assertFalse((bool) ($currencyMismatch['ok'] ?? true));
-        $this->assertSame(404, (int) ($currencyMismatch['status'] ?? 0));
+        $this->assertSame(200, (int) ($currencyMismatch['status'] ?? 0));
+        $this->assertSame('CURRENCY_MISMATCH', (string) ($currencyMismatch['reject_reason'] ?? ''));
         $this->assertSame('CURRENCY_MISMATCH', (string) DB::table('payment_events')
             ->where('provider', 'billing')
             ->where('provider_event_id', 'evt_contract_currency_mismatch_1')
             ->value('last_error_code'));
+        $this->assertSame('CURRENCY_MISMATCH', (string) DB::table('payment_events')
+            ->where('provider', 'billing')
+            ->where('provider_event_id', 'evt_contract_currency_mismatch_1')
+            ->value('reason'));
     }
 
     public function test_missing_order_keeps_contract_and_does_not_grant_benefit(): void
@@ -224,9 +240,11 @@ final class PaymentWebhookProcessorContractTest extends TestCase
             'event_type' => 'payment_succeeded',
         ], ['X-Org-Id' => '0']);
 
-        $res->assertStatus(404)->assertJson([
+        $res->assertStatus(200)->assertJson([
             'ok' => false,
             'error_code' => 'ORDER_NOT_FOUND',
+            'rejected' => true,
+            'reject_reason' => 'ORDER_NOT_FOUND',
         ]);
 
         $this->assertSame(0, DB::table('benefit_grants')->count());

--- a/backend/tests/Feature/Payments/WebhookProviderMismatchTest.php
+++ b/backend/tests/Feature/Payments/WebhookProviderMismatchTest.php
@@ -56,11 +56,13 @@ class WebhookProviderMismatchTest extends TestCase
             'X-Org-Id' => '0',
         ]);
 
-        $response->assertStatus(400);
+        $response->assertStatus(200);
         $response->assertJson([
             'ok' => false,
             'error_code' => 'PROVIDER_MISMATCH',
             'message' => 'provider mismatch',
+            'rejected' => true,
+            'reject_reason' => 'PROVIDER_MISMATCH',
         ]);
 
         $this->assertSame('created', (string) DB::table('orders')->where('order_no', $orderNo)->value('status'));
@@ -73,6 +75,10 @@ class WebhookProviderMismatchTest extends TestCase
             ->where('provider', 'billing')
             ->where('provider_event_id', 'evt_provider_mismatch_1')
             ->value('last_error_code'));
+        $this->assertSame('REJECTED_PROVIDER_MISMATCH', (string) DB::table('payment_events')
+            ->where('provider', 'billing')
+            ->where('provider_event_id', 'evt_provider_mismatch_1')
+            ->value('reason'));
         $this->assertSame(0, DB::table('benefit_grants')->count());
         $this->assertSame(0, DB::table('report_snapshots')->count());
     }


### PR DESCRIPTION
Fixes FER2-10

## Summary
- Change semantic webhook rejects to 2xx ACK (status 200) in PaymentWebhookHandlerCore.
- Persist reject reason to payment_events.reason while retaining last_error_code/last_error_message.
- Keep provider_event_id replay idempotent and no duplicate side effects.
- Update webhook tests to assert 2xx semantic reject contract and reject_reason persistence.

## Verification
- php artisan route:list --path=api/v0.3/webhooks/payment
- php artisan migrate --force
- php artisan test --filter "(PaymentWebhookIdempotencyTest|BigFiveWebhookIdempotencyTest|PaymentWebhookTrustBoundaryTest|PaymentWebhookProcessorContractTest|WebhookProviderMismatchTest|ClinicalCombo68WebhookIdempotencyTest|Sds20WebhookIdempotencyTest|Eq60WebhookIdempotencyTest)"
- bash backend/scripts/ci_verify_mbti.sh