### PR TITLE
Fixes FER2-12: treat unknown snapshot status as error

### DIFF
--- a/backend/app/Services/Report/ReportGatekeeper.php
+++ b/backend/app/Services/Report/ReportGatekeeper.php
@@ -206,7 +206,7 @@ class ReportGatekeeper
             }
 
             if ($snapshotRow) {
-                $snapshotStatus = strtolower(trim((string) ($snapshotRow->status ?? 'ready')));
+                $snapshotStatus = strtolower(trim((string) ($snapshotRow->status ?? '')));
                 if ($snapshotStatus === 'pending') {
                     return $this->responsePayload(
                         $locked,
@@ -240,6 +240,38 @@ class ReportGatekeeper
                             'generating' => false,
                             'snapshot_error' => true,
                             'retry_after_seconds' => self::SNAPSHOT_RETRY_AFTER_SECONDS,
+                        ],
+                        $modulesAllowed,
+                        $modulesOffered,
+                        $modulesPreview,
+                        $normsPayload,
+                        $qualityPayload
+                    );
+                }
+
+                if ($snapshotStatus !== 'ready') {
+                    Log::warning('[REPORT] snapshot_status_unknown', [
+                        'org_id' => $orgId,
+                        'attempt_id' => $attemptId,
+                        'status' => $snapshotStatus !== '' ? $snapshotStatus : null,
+                        'strict_mode' => $snapshotStrictMode,
+                        'variant' => $variant,
+                        'source' => 'report_gatekeeper',
+                    ]);
+
+                    return $this->responsePayload(
+                        $locked,
+                        $reportAccessLevel,
+                        $variant,
+                        $viewPolicy,
+                        [],
+                        $paywall,
+                        [
+                            'generating' => false,
+                            'snapshot_error' => true,
+                            'retry_after_seconds' => self::SNAPSHOT_RETRY_AFTER_SECONDS,
+                            'snapshot_status' => $snapshotStatus !== '' ? $snapshotStatus : null,
+                            'snapshot_status_unknown' => true,
                         ],
                         $modulesAllowed,
                         $modulesOffered,
@@ -426,7 +458,6 @@ class ReportGatekeeper
     {
         return in_array($role, ['member', 'viewer'], true);
     }
-
 
     private function upsertSnapshotVariants(
         int $orgId,

--- a/backend/app/Services/Report/ReportSnapshotStore.php
+++ b/backend/app/Services/Report/ReportSnapshotStore.php
@@ -8,6 +8,7 @@ use App\Services\Analytics\EventRecorder;
 use App\Services\Assessment\GenericReportBuilder;
 use App\Services\Scale\ScaleIdentityWriteProjector;
 use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Log;
 
 class ReportSnapshotStore
 {
@@ -518,9 +519,19 @@ class ReportSnapshotStore
 
     private function snapshotStatus(?object $row): string
     {
-        $status = strtolower(trim((string) ($row->status ?? 'ready')));
+        $status = strtolower(trim((string) ($row->status ?? '')));
+        if (in_array($status, ['pending', 'ready', 'failed'], true)) {
+            return $status;
+        }
 
-        return in_array($status, ['pending', 'ready', 'failed'], true) ? $status : 'ready';
+        Log::warning('[REPORT] snapshot_status_unknown', [
+            'org_id' => (int) ($row->org_id ?? 0),
+            'attempt_id' => (string) ($row->attempt_id ?? ''),
+            'status' => $status !== '' ? $status : null,
+            'source' => 'report_snapshot_store',
+        ]);
+
+        return 'failed';
     }
 
     private function shouldWriteScaleIdentityColumns(): bool

--- a/backend/tests/Feature/Report/ReportSnapshotStrictModeTest.php
+++ b/backend/tests/Feature/Report/ReportSnapshotStrictModeTest.php
@@ -11,6 +11,7 @@ use Database\Seeders\Pr19CommerceSeeder;
 use Database\Seeders\ScaleRegistrySeeder;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Facades\Queue;
 use Illuminate\Support\Str;
 use Tests\TestCase;
@@ -21,8 +22,8 @@ final class ReportSnapshotStrictModeTest extends TestCase
 
     private function seedScales(): void
     {
-        (new ScaleRegistrySeeder())->run();
-        (new Pr19CommerceSeeder())->run();
+        (new ScaleRegistrySeeder)->run();
+        (new Pr19CommerceSeeder)->run();
     }
 
     private function issueAnonToken(string $anonId): string
@@ -133,5 +134,59 @@ final class ReportSnapshotStrictModeTest extends TestCase
                 && $job->attemptId === $attemptId
                 && $job->triggerSource === 'report_api';
         });
+    }
+
+    public function test_unknown_snapshot_status_returns_snapshot_error_and_observability_signal(): void
+    {
+        config()->set('fap.features.report_snapshot_strict_v2', true);
+        $this->seedScales();
+
+        $anonId = 'anon_report_snapshot_unknown';
+        $attemptId = $this->createAttemptWithResult($anonId);
+        $token = $this->issueAnonToken($anonId);
+
+        DB::table('report_snapshots')->insert([
+            'org_id' => 0,
+            'attempt_id' => $attemptId,
+            'order_no' => null,
+            'scale_code' => 'MBTI',
+            'pack_id' => (string) config('content_packs.default_pack_id', 'MBTI.cn-mainland.zh-CN.v0.3'),
+            'dir_version' => (string) config('content_packs.default_dir_version', 'MBTI-CN-v0.3'),
+            'scoring_spec_version' => '2026.01',
+            'report_engine_version' => 'v1.2',
+            'snapshot_version' => 'v1',
+            'report_json' => '{}',
+            'report_free_json' => '{}',
+            'report_full_json' => '{}',
+            'status' => 'mystery',
+            'last_error' => null,
+            'created_at' => now(),
+            'updated_at' => now(),
+        ]);
+
+        Log::spy();
+
+        $response = $this->withHeaders([
+            'Authorization' => 'Bearer '.$token,
+        ])->getJson('/api/v0.3/attempts/'.$attemptId.'/report');
+
+        $response->assertStatus(200);
+        $response->assertJson([
+            'ok' => true,
+            'generating' => false,
+            'snapshot_error' => true,
+        ]);
+        $this->assertSame([], (array) $response->json('report'));
+        $this->assertSame('mystery', (string) $response->json('meta.snapshot_status'));
+        $this->assertTrue((bool) $response->json('meta.snapshot_status_unknown'));
+
+        Log::shouldHaveReceived('warning')
+            ->withArgs(function (string $message, array $context) use ($attemptId): bool {
+                return $message === '[REPORT] snapshot_status_unknown'
+                    && (int) ($context['org_id'] ?? -1) === 0
+                    && (string) ($context['attempt_id'] ?? '') === $attemptId
+                    && (string) ($context['status'] ?? '') === 'mystery'
+                    && (string) ($context['source'] ?? '') === 'report_gatekeeper';
+            });
     }
 }


### PR DESCRIPTION
Fixes FER2-12

## Summary
- treat unknown `report_snapshots.status` as error instead of ready in `ReportSnapshotStore`
- add explicit unknown-status guard in `ReportGatekeeper` read path to return `snapshot_error=true`
- emit observability signals for unknown snapshot status via warning logs and response `meta` fields (`snapshot_status`, `snapshot_status_unknown`)
- add strict-mode regression test for unknown snapshot status

## Verification
- php artisan test --filter=ReportSnapshotStrictModeTest
- php artisan route:list
- php artisan migrate --force
- bash scripts/ci_verify_mbti.sh


Note: Unknown report_snapshots.status is now treated as snapshot_error (observability via [REPORT] snapshot_status_unknown). This prevents unknown/dirty states from being served as ready.