### PR TITLE
Fixes FER2-13: make new ContentPackResolver resolvable and align config root

### DIFF
--- a/backend/app/Services/Content/ContentPackResolver.php
+++ b/backend/app/Services/Content/ContentPackResolver.php
@@ -7,17 +7,16 @@ use RuntimeException;
 
 class ContentPackResolver
 {
-    public function __construct(
-        private readonly string $packsRoot,
-    ) {}
+    private readonly string $packsRoot;
+
+    public function __construct(?string $packsRoot = null)
+    {
+        $this->packsRoot = self::resolvePacksRoot($packsRoot);
+    }
 
     public static function make(): self
     {
-        $root = config('content.packs_root');
-        if (!is_string($root) || trim($root) === '') {
-            throw new RuntimeException("Missing config: content.packs_root");
-        }
-        return new self($root);
+        return new self(self::resolvePacksRoot());
     }
 
     /**
@@ -242,5 +241,25 @@ class ContentPackResolver
     {
         if ($a === []) return false;
         return array_keys($a) !== range(0, count($a) - 1);
+    }
+
+    private static function resolvePacksRoot(?string $packsRoot = null): string
+    {
+        $root = is_string($packsRoot) ? trim($packsRoot) : '';
+        if ($root !== '') {
+            return $root;
+        }
+
+        $root = trim((string) config('content_packs.root', ''));
+        if ($root === '') {
+            // Backward-compat key. content_packs.root remains the single source of truth.
+            $root = trim((string) config('content.packs_root', ''));
+        }
+
+        if ($root === '') {
+            throw new RuntimeException("Missing config: content_packs.root");
+        }
+
+        return $root;
     }
 }

--- a/backend/tests/Unit/Services/ContentPackResolverParityTest.php
+++ b/backend/tests/Unit/Services/ContentPackResolverParityTest.php
@@ -1,0 +1,109 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Services;
+
+use App\Services\Content\ContentPackResolver as NewContentPackResolver;
+use App\Services\ContentPackResolver as LegacyContentPackResolver;
+use Illuminate\Support\Facades\File;
+use Tests\TestCase;
+
+final class ContentPackResolverParityTest extends TestCase
+{
+    public function test_container_can_resolve_legacy_and_new_resolvers(): void
+    {
+        $ctx = $this->bootstrapDefaultPackConfig();
+
+        $this->app->forgetInstance(LegacyContentPackResolver::class);
+        $this->app->forgetInstance(NewContentPackResolver::class);
+
+        $legacy = app()->make(LegacyContentPackResolver::class);
+        $new = app()->make(NewContentPackResolver::class);
+
+        $this->assertInstanceOf(LegacyContentPackResolver::class, $legacy);
+        $this->assertInstanceOf(NewContentPackResolver::class, $new);
+        $this->assertNotSame('', $ctx['pack_id']);
+    }
+
+    public function test_legacy_and_new_resolver_match_default_pack_identity(): void
+    {
+        $ctx = $this->bootstrapDefaultPackConfig();
+
+        $this->app->forgetInstance(LegacyContentPackResolver::class);
+        $this->app->forgetInstance(NewContentPackResolver::class);
+
+        /** @var LegacyContentPackResolver $legacy */
+        $legacy = app()->make(LegacyContentPackResolver::class);
+        /** @var NewContentPackResolver $new */
+        $new = app()->make(NewContentPackResolver::class);
+
+        $legacyResolved = $legacy->resolve(
+            'default',
+            $ctx['region'],
+            $ctx['locale'],
+            $ctx['dir_version']
+        );
+        $newResolved = $new->resolve(
+            'default',
+            $ctx['region'],
+            $ctx['locale'],
+            $ctx['dir_version']
+        );
+
+        $this->assertSame((string) $legacyResolved->packId, $newResolved->packId());
+        $this->assertSame(
+            basename((string) $legacyResolved->baseDir),
+            basename($newResolved->basePath())
+        );
+        $this->assertSame(
+            (string) ($legacyResolved->manifest['content_package_version'] ?? ''),
+            $newResolved->version()
+        );
+    }
+
+    /**
+     * @return array{root:string,region:string,locale:string,dir_version:string,pack_id:string}
+     */
+    private function bootstrapDefaultPackConfig(): array
+    {
+        $root = (string) config('content_packs.root', base_path('../content_packages'));
+        if (!is_dir($root)) {
+            $root = base_path('../content_packages');
+        }
+
+        $region = (string) config('content_packs.default_region', 'CN_MAINLAND');
+        $locale = (string) config('content_packs.default_locale', 'zh-CN');
+        $dirVersion = (string) config('content_packs.default_dir_version', 'MBTI-CN-v0.3');
+
+        $manifestPath = $root
+            . DIRECTORY_SEPARATOR . 'default'
+            . DIRECTORY_SEPARATOR . $region
+            . DIRECTORY_SEPARATOR . $locale
+            . DIRECTORY_SEPARATOR . $dirVersion
+            . DIRECTORY_SEPARATOR . 'manifest.json';
+
+        $this->assertTrue(File::exists($manifestPath), "default pack manifest missing: {$manifestPath}");
+        $manifest = json_decode((string) file_get_contents($manifestPath), true);
+        $this->assertIsArray($manifest);
+
+        $packId = trim((string) ($manifest['pack_id'] ?? ''));
+        $this->assertNotSame('', $packId, "manifest missing pack_id: {$manifestPath}");
+
+        config()->set('content_packs.root', $root);
+        config()->set('content.packs_root', $root); // compat key for legacy tests
+        config()->set('content_packs.driver', 'local');
+        config()->set('content_packs.default_region', $region);
+        config()->set('content_packs.default_locale', $locale);
+        config()->set('content_packs.default_dir_version', $dirVersion);
+        config()->set('content_packs.default_pack_id', $packId);
+
+        return [
+            'root' => $root,
+            'region' => $region,
+            'locale' => $locale,
+            'dir_version' => $dirVersion,
+            'pack_id' => $packId,
+        ];
+    }
+}


### PR DESCRIPTION
Fixes FER2-13

Summary
- Make `App\Services\Content\ContentPackResolver` container-resolvable by removing required scalar constructor injection.
- Align packs root resolution to `content_packs.root` as primary source, with `content.packs_root` as backward-compatible fallback only.
- Keep legacy resolver as default runtime behavior; no business-chain callsite changes.
- Add regression tests to verify both resolvers are resolvable and resolve consistent default pack identity.

Verification
- php artisan test tests/Unit/Services/ContentPackResolverParityTest.php
- php artisan test tests/Unit/Services/ContentPackResolverCacheTest.php
- php artisan route:list
- php artisan migrate
- bash backend/scripts/ci_verify_mbti.sh
