### PR TITLE
Fixes FER2-15: decouple attempt submission queue connection

### DIFF
--- a/backend/app/Jobs/ProcessAttemptSubmissionJob.php
+++ b/backend/app/Jobs/ProcessAttemptSubmissionJob.php
@@ -27,8 +27,9 @@ class ProcessAttemptSubmissionJob implements ShouldQueue
     public function __construct(
         public string $submissionId,
     ) {
-        $this->onConnection('database');
-        $this->onQueue('attempts');
+        $connection = config('fap.queue.attempt_connection');
+        $this->onConnection((is_string($connection) && $connection !== '') ? $connection : (string) config('queue.default'));
+        $this->onQueue(config('fap.queue.attempt_queue', 'attempts'));
     }
 
     public function handle(AttemptSubmissionService $service): void
@@ -36,4 +37,3 @@ class ProcessAttemptSubmissionJob implements ShouldQueue
         $service->process($this->submissionId);
     }
 }
-

--- a/backend/config/fap.php
+++ b/backend/config/fap.php
@@ -26,6 +26,11 @@ return [
         'report_snapshot_strict_v2' => (bool) env('FAP_FEATURE_REPORT_SNAPSHOT_STRICT_V2', true),
     ],
 
+    'queue' => [
+        'attempt_connection' => env('FAP_ATTEMPT_QUEUE_CONNECTION', null),
+        'attempt_queue' => env('FAP_ATTEMPT_QUEUE', 'attempts'),
+    ],
+
     'payments' => [
         'enabled' => (bool) env('FAP_PAYMENTS_ENABLED', true),
         'webhooks_enabled' => (bool) env('FAP_PAYMENTS_WEBHOOKS_ENABLED', true),

--- a/backend/tests/Unit/Jobs/ProcessAttemptSubmissionJobTest.php
+++ b/backend/tests/Unit/Jobs/ProcessAttemptSubmissionJobTest.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Jobs;
+
+use App\Jobs\ProcessAttemptSubmissionJob;
+use Tests\TestCase;
+
+final class ProcessAttemptSubmissionJobTest extends TestCase
+{
+    public function test_process_attempt_submission_job_queue_binding_from_config(): void
+    {
+        config()->set('queue.default', 'database');
+        config()->set('fap.queue.attempt_connection', null);
+
+        $defaultJob = new ProcessAttemptSubmissionJob('submission-default');
+        $this->assertSame((string) config('queue.default'), $defaultJob->connection);
+
+        config()->set('fap.queue.attempt_connection', 'redis');
+        $redisJob = new ProcessAttemptSubmissionJob('submission-redis');
+        $this->assertSame('redis', $redisJob->connection);
+
+        config()->set('fap.queue.attempt_queue', 'attempts');
+        $queueJob = new ProcessAttemptSubmissionJob('submission-queue');
+        $this->assertSame('attempts', $queueJob->queue);
+    }
+}


### PR DESCRIPTION
Fixes FER2-15

## Summary
- remove hardcoded onConnection('database') from ProcessAttemptSubmissionJob
- drive attempt job connection and queue from config('fap.queue.*')
- add minimal regression test to verify default fallback and override behavior

## Verification
- cd backend
- php artisan test --filter ProcessAttemptSubmissionJob
- cd ..
- bash backend/scripts/ci_verify_mbti.sh
