### PR TITLE
Fixes FER2-16: partition webhook lock key by provider+org+event

### DIFF
--- a/backend/app/Internal/Commerce/PaymentWebhookHandlerCore.php
+++ b/backend/app/Internal/Commerce/PaymentWebhookHandlerCore.php
@@ -35,6 +35,8 @@ class PaymentWebhookHandlerCore
 
     private const DEFAULT_WEBHOOK_LOCK_BLOCK_SECONDS = 5;
 
+    private const DEFAULT_WEBHOOK_LOCK_CONTENTION_BUDGET_MS = 3000;
+
     private const TRANSIENT_DB_RETRY_MAX_ATTEMPTS = 3;
 
     private const TRANSIENT_DB_RETRY_BASE_USLEEP = 100000;
@@ -127,7 +129,8 @@ class PaymentWebhookHandlerCore
         );
         $payloadSummaryJson = $this->encodePayloadSummary($payloadSummary);
         $payloadExcerpt = $this->buildPayloadExcerpt($payloadSummaryJson);
-        $lockKey = "webhook_pay:{$provider}:{$providerEventId}";
+        $normalizedOrgId = max(0, $orgId);
+        $lockKey = $this->buildWebhookLockKey($provider, $normalizedOrgId, $providerEventId);
         $lockTtl = max(1, (int) config(
             'services.payment_webhook.lock_ttl_seconds',
             self::DEFAULT_WEBHOOK_LOCK_TTL_SECONDS
@@ -136,19 +139,26 @@ class PaymentWebhookHandlerCore
             'services.payment_webhook.lock_block_seconds',
             self::DEFAULT_WEBHOOK_LOCK_BLOCK_SECONDS
         ));
+        $contentionBudgetMs = max(1, (int) config(
+            'services.payment_webhook.lock_contention_budget_ms',
+            self::DEFAULT_WEBHOOK_LOCK_CONTENTION_BUDGET_MS
+        ));
         $postCommitOutcome = null;
         $postCommitCtx = null;
+        $lockWaitStartedAt = microtime(true);
 
         try {
             $result = $this->runWithTransientDbRetry(function () use (
                 $lockKey,
                 $lockTtl,
                 $lockBlock,
+                $contentionBudgetMs,
                 $orderNo,
                 $normalized,
                 $providerEventId,
                 $provider,
                 $orgId,
+                $normalizedOrgId,
                 $userId,
                 $anonId,
                 $eventType,
@@ -157,14 +167,18 @@ class PaymentWebhookHandlerCore
                 $payloadExcerpt,
                 $resolvedPayloadMeta,
                 $signatureOk,
+                &$lockWaitStartedAt,
                 &$postCommitCtx
             ) {
+                $lockWaitStartedAt = microtime(true);
+
                 return Cache::lock($lockKey, $lockTtl)->block($lockBlock, function () use (
                     $orderNo,
                     $normalized,
                     $providerEventId,
                     $provider,
                     $orgId,
+                    $normalizedOrgId,
                     $userId,
                     $anonId,
                     $eventType,
@@ -173,8 +187,24 @@ class PaymentWebhookHandlerCore
                     $payloadExcerpt,
                     $resolvedPayloadMeta,
                     $signatureOk,
+                    $lockBlock,
+                    $contentionBudgetMs,
+                    $lockKey,
+                    &$lockWaitStartedAt,
                     &$postCommitCtx
                 ) {
+                    $lockWaitMs = $this->resolveLockWaitMs($lockWaitStartedAt);
+                    $this->observeWebhookLockWait(
+                        $provider,
+                        $normalizedOrgId,
+                        $providerEventId,
+                        $lockKey,
+                        $lockWaitMs,
+                        $lockBlock,
+                        $contentionBudgetMs,
+                        false
+                    );
+
                     return DB::transaction(function () use (
                         $orderNo,
                         $normalized,
@@ -712,6 +742,17 @@ class PaymentWebhookHandlerCore
 
             return $normalizedResult;
         } catch (LockTimeoutException $e) {
+            $this->observeWebhookLockWait(
+                $provider,
+                $normalizedOrgId,
+                $providerEventId,
+                $lockKey,
+                $this->resolveLockWaitMs($lockWaitStartedAt),
+                $lockBlock,
+                $contentionBudgetMs,
+                true
+            );
+
             return $this->serverError('WEBHOOK_BUSY', 'payment webhook is busy, retry later.');
         }
     }
@@ -1433,6 +1474,46 @@ class PaymentWebhookHandlerCore
         }
 
         return false;
+    }
+
+    private function buildWebhookLockKey(string $provider, int $orgId, string $providerEventId): string
+    {
+        return 'webhook_pay:'.$provider.':org_'.$orgId.':'.$providerEventId;
+    }
+
+    private function resolveLockWaitMs(float $lockWaitStartedAt): int
+    {
+        return max(0, (int) round((microtime(true) - $lockWaitStartedAt) * 1000));
+    }
+
+    private function observeWebhookLockWait(
+        string $provider,
+        int $orgId,
+        string $providerEventId,
+        string $lockKey,
+        int $lockWaitMs,
+        int $lockBlock,
+        int $contentionBudgetMs,
+        bool $timedOut
+    ): void {
+        $context = [
+            'provider' => $provider,
+            'org_id' => max(0, $orgId),
+            'provider_event_id' => $providerEventId,
+            'lock_key' => $lockKey,
+            'lock_wait_ms' => max(0, $lockWaitMs),
+            'lock_block_seconds' => max(0, $lockBlock),
+            'contention_budget_ms' => max(1, $contentionBudgetMs),
+            'budget_exceeded' => $lockWaitMs >= $contentionBudgetMs,
+        ];
+
+        if ($timedOut) {
+            Log::warning('PAYMENT_WEBHOOK_LOCK_CONTENTION', $context);
+
+            return;
+        }
+
+        Log::info('PAYMENT_WEBHOOK_LOCK_ACQUIRED', $context);
     }
 
     private function updatePaymentEvent(string $provider, string $providerEventId, array $updates): void

--- a/backend/config/services.php
+++ b/backend/config/services.php
@@ -64,6 +64,7 @@ return [
     'payment_webhook' => [
         'lock_ttl_seconds' => (int) env('PAYMENT_WEBHOOK_LOCK_TTL_SECONDS', 10),
         'lock_block_seconds' => (int) env('PAYMENT_WEBHOOK_LOCK_BLOCK_SECONDS', 5),
+        'lock_contention_budget_ms' => (int) env('PAYMENT_WEBHOOK_LOCK_CONTENTION_BUDGET_MS', 3000),
         'success_event_types' => [
             'stripe' => array_values(array_filter(array_map(
                 static fn ($v) => strtolower(trim((string) $v)),

--- a/backend/tests/Feature/Commerce/PaymentWebhookProcessorLockKeyTest.php
+++ b/backend/tests/Feature/Commerce/PaymentWebhookProcessorLockKeyTest.php
@@ -14,6 +14,7 @@ use App\Services\Experiments\ExperimentAssigner;
 use App\Services\Report\ReportSnapshotStore;
 use Illuminate\Contracts\Cache\LockTimeoutException;
 use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Facades\Schema;
 use Mockery;
 use Tests\TestCase;
@@ -26,12 +27,23 @@ final class PaymentWebhookProcessorLockKeyTest extends TestCase
         parent::tearDown();
     }
 
-    public function test_handle_uses_provider_scoped_lock_key_and_configured_timing(): void
+    public function test_handle_uses_provider_org_event_scoped_lock_key_and_logs_contention_budget(): void
     {
         config()->set('services.payment_webhook.lock_ttl_seconds', 10);
         config()->set('services.payment_webhook.lock_block_seconds', 5);
+        config()->set('services.payment_webhook.lock_contention_budget_ms', 2000);
 
         Schema::shouldReceive('hasTable')->andReturn(true);
+        Log::shouldReceive('warning')
+            ->once()
+            ->withArgs(function (string $message, array $context): bool {
+                return $message === 'PAYMENT_WEBHOOK_LOCK_CONTENTION'
+                    && (string) ($context['provider'] ?? '') === 'billing'
+                    && (int) ($context['org_id'] ?? 0) === 23
+                    && (string) ($context['provider_event_id'] ?? '') === 'evt_lock_key'
+                    && (int) ($context['contention_budget_ms'] ?? 0) === 2000
+                    && is_bool($context['budget_exceeded'] ?? null);
+            });
 
         $lock = Mockery::mock();
         $lock
@@ -42,7 +54,7 @@ final class PaymentWebhookProcessorLockKeyTest extends TestCase
 
         Cache::shouldReceive('lock')
             ->once()
-            ->with('webhook_pay:billing:evt_lock_key', 10)
+            ->with('webhook_pay:billing:org_23:evt_lock_key', 10)
             ->andReturn($lock);
 
         $processor = new PaymentWebhookProcessor(
@@ -57,7 +69,7 @@ final class PaymentWebhookProcessorLockKeyTest extends TestCase
         $result = $processor->handle('billing', [
             'provider_event_id' => 'evt_lock_key',
             'order_no' => 'ORD-LOCK-KEY',
-        ]);
+        ], 23);
 
         $this->assertFalse($result['ok']);
         $this->assertSame(500, $result['status']);

--- a/backend/tests/Unit/Commerce/PaymentWebhookLockBusyTest.php
+++ b/backend/tests/Unit/Commerce/PaymentWebhookLockBusyTest.php
@@ -32,7 +32,7 @@ final class PaymentWebhookLockBusyTest extends TestCase
 
         Cache::shouldReceive('lock')
             ->once()
-            ->with('webhook_pay:billing:evt_busy', 10)
+            ->with('webhook_pay:billing:org_0:evt_busy', 10)
             ->andThrow(new LockTimeoutException('lock timeout'));
 
         $processor = new PaymentWebhookProcessor(

--- a/backend/tests/Unit/Services/Commerce/PaymentWebhookProcessorLockTest.php
+++ b/backend/tests/Unit/Services/Commerce/PaymentWebhookProcessorLockTest.php
@@ -40,7 +40,7 @@ final class PaymentWebhookProcessorLockTest extends TestCase
 
         Cache::shouldReceive('lock')
             ->once()
-            ->with('webhook_pay:billing:evt_lock', 10)
+            ->with('webhook_pay:billing:org_0:evt_lock', 10)
             ->andReturn($lock);
 
         $processor = new PaymentWebhookProcessor(


### PR DESCRIPTION
Fixes FER2-16

## 变更目标
仅完成 FER2-16：Payment webhook lock partition and contention budget。

## 本 PR 变更
- 将 webhook 分布式锁 key 从 `webhook_pay:{provider}:{provider_event_id}` 调整为：
  - `webhook_pay:{provider}:org_{org_id}:{provider_event_id}`
- 增加锁争用可观测信号：
  - 获取锁后记录 `PAYMENT_WEBHOOK_LOCK_ACQUIRED`（含 `lock_wait_ms`）
  - 锁超时记录 `PAYMENT_WEBHOOK_LOCK_CONTENTION`
- 增加“争用预算”阈值配置：
  - `services.payment_webhook.lock_contention_budget_ms`
  - 默认值 `3000ms`
  - 日志中输出 `contention_budget_ms`、`budget_exceeded`

## 明确不变
- 不改签名校验协议
- 不改订单状态机语义
- 不做顺手重构
- 幂等与副作用保持不变（同一事件重放不重复发权益、不重复 seed snapshot、不重复推进订单状态）

## 变更文件
- `backend/app/Internal/Commerce/PaymentWebhookHandlerCore.php`
- `backend/config/services.php`
- `backend/tests/Feature/Commerce/PaymentWebhookProcessorLockKeyTest.php`
- `backend/tests/Unit/Commerce/PaymentWebhookLockBusyTest.php`
- `backend/tests/Unit/Services/Commerce/PaymentWebhookProcessorLockTest.php`

## 验证
- `php artisan route:list`
- `php artisan migrate --force`
- `php artisan test --filter "PaymentWebhookProcessorLockKeyTest|PaymentWebhookProcessorLockTest|PaymentWebhookLockBusyTest"`
- `php artisan test --filter PaymentWebhookProcessorContractTest`
- `php artisan test --filter "ReportSnapshotB2BTest|ReportSnapshotB2CTest|CommerceWalletConsumeOnSubmitTest"`
- `bash backend/scripts/ci_verify_mbti.sh` ✅ 全绿

## curl 示例（重放幂等）
```bash
curl -i -X POST "http://127.0.0.1:8000/api/v0.3/webhooks/payment/billing" \
  -H "Content-Type: application/json" \
  -H "X-Billing-Timestamp: <ts>" \
  -H "X-Billing-Signature: <sig>" \
  --data '{"provider_event_id":"evt_fer2_16_replay_1","order_no":"ord_fer2_16_1","event_type":"payment_succeeded","amount_cents":4990,"currency":"USD"}'
