### PR TITLE
Fixes FER2-17: wire v0.4 boot experiments payload

### DIFF
--- a/backend/app/Http/Controllers/API/V0_4/BootController.php
+++ b/backend/app/Http/Controllers/API/V0_4/BootController.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Http\Controllers\API\V0_4;
 
 use App\Http\Controllers\Controller;
+use App\Services\Experiments\ExperimentAssigner;
 use App\Services\Payments\PaymentRouter;
 use App\Support\RegionContext;
 use Illuminate\Http\Request;
@@ -15,6 +16,7 @@ class BootController extends Controller
     public function __construct(
         private RegionContext $regionContext,
         private PaymentRouter $paymentRouter,
+        private ExperimentAssigner $experimentAssigner,
     ) {
     }
 
@@ -26,6 +28,11 @@ class BootController extends Controller
         $region = $this->regionContext->region();
         $locale = $this->regionContext->locale();
         $currency = $this->regionContext->currency();
+        $this->primeOrgContextForPublicBoot($request);
+        $anonId = $this->resolveAnonId($request);
+        $bootExperiments = $anonId !== null
+            ? $this->experimentAssigner->assignActive(0, $anonId, null)
+            : [];
 
         $regionsConfig = config('regions.regions', []);
         $regionConfig = is_array($regionsConfig) ? ($regionsConfig[$region] ?? []) : [];
@@ -48,7 +55,8 @@ class BootController extends Controller
                 'legal_urls' => is_array($regionConfig['legal_urls'] ?? null) ? $regionConfig['legal_urls'] : [],
             ],
             'experiments' => [
-                'boot_experiments' => [],
+                'experiments_json' => $bootExperiments,
+                'boot_experiments' => $bootExperiments,
             ],
             'feature_flags_version' => (string) \App\Support\RuntimeConfig::value('FAP_FEATURE_FLAGS_VERSION', 'v0.4'),
             'policy_versions' => is_array($regionConfig['policy_versions'] ?? null) ? $regionConfig['policy_versions'] : [],
@@ -62,7 +70,7 @@ class BootController extends Controller
         $etag = '"' . sha1($body) . '"';
         $headers = [
             'Cache-Control' => 'public, max-age=300',
-            'Vary' => 'X-Region, Accept-Language, X-FAP-Locale',
+            'Vary' => 'X-Region, Accept-Language, X-FAP-Locale, X-Anon-Id',
             'ETag' => $etag,
             'Content-Type' => 'application/json',
         ];
@@ -115,5 +123,37 @@ class BootController extends Controller
         }
 
         return false;
+    }
+
+    private function resolveAnonId(Request $request): ?string
+    {
+        $candidates = [
+            $request->attributes->get('anon_id'),
+            $request->attributes->get('fm_anon_id'),
+            $request->attributes->get('client_anon_id'),
+            $request->query('anon_id'),
+            $request->header('X-Anon-Id'),
+        ];
+
+        foreach ($candidates as $candidate) {
+            if (!is_string($candidate) && !is_numeric($candidate)) {
+                continue;
+            }
+            $value = trim((string) $candidate);
+            if ($value === '' || strlen($value) > 128) {
+                continue;
+            }
+
+            return $value;
+        }
+
+        return null;
+    }
+
+    private function primeOrgContextForPublicBoot(Request $request): void
+    {
+        $request->attributes->set('org_context_resolved', true);
+        $request->attributes->set('org_id', 0);
+        $request->attributes->set('fm_org_id', 0);
     }
 }

--- a/backend/tests/Feature/V0_4/BootTest.php
+++ b/backend/tests/Feature/V0_4/BootTest.php
@@ -29,7 +29,7 @@ class BootTest extends TestCase
         $this->assertNotSame('', $cache);
         $this->assertStringContainsString('max-age=300', $cache);
         $this->assertStringContainsString('public', $cache);
-        $response->assertHeader('Vary', 'X-Region, Accept-Language, X-FAP-Locale');
+        $response->assertHeader('Vary', 'X-Region, Accept-Language, X-FAP-Locale, X-Anon-Id');
         $this->assertNotEmpty($response->headers->get('ETag'));
     }
 
@@ -55,7 +55,7 @@ class BootTest extends TestCase
         $this->assertNotSame('', $cache);
         $this->assertStringContainsString('max-age=300', $cache);
         $this->assertStringContainsString('public', $cache);
-        $second->assertHeader('Vary', 'X-Region, Accept-Language, X-FAP-Locale');
+        $second->assertHeader('Vary', 'X-Region, Accept-Language, X-FAP-Locale, X-Anon-Id');
     }
 
     public function test_boot_differs_by_region(): void
@@ -103,6 +103,29 @@ class BootTest extends TestCase
 
         $response->assertStatus(200);
         $response->assertJsonPath('locale', 'zh-CN');
-        $response->assertHeader('Vary', 'X-Region, Accept-Language, X-FAP-Locale');
+        $response->assertHeader('Vary', 'X-Region, Accept-Language, X-FAP-Locale, X-Anon-Id');
+    }
+
+    public function test_boot_experiments_are_sticky_for_same_anon_id(): void
+    {
+        $headers = [
+            'X-Region' => 'CN_MAINLAND',
+            'Accept-Language' => 'zh-CN',
+            'X-Anon-Id' => 'fer2_v04_boot_sticky_anon',
+        ];
+
+        $first = $this->getJson('/api/v0.4/boot', $headers);
+        $first->assertStatus(200);
+        $firstVariant = trim((string) $first->json('experiments.boot_experiments.PR23_STICKY_BUCKET'));
+        $this->assertNotSame('', $firstVariant);
+        $this->assertSame(
+            $first->json('experiments.boot_experiments.PR23_STICKY_BUCKET'),
+            $first->json('experiments.experiments_json.PR23_STICKY_BUCKET')
+        );
+
+        $second = $this->getJson('/api/v0.4/boot', $headers);
+        $second->assertStatus(200);
+        $secondVariant = trim((string) $second->json('experiments.boot_experiments.PR23_STICKY_BUCKET'));
+        $this->assertSame($firstVariant, $secondVariant);
     }
 }


### PR DESCRIPTION
Fixes FER2-17

Summary
- Wire v0.4 `/api/v0.4/boot` to return real experiment assignments via `ExperimentAssigner::assignActive()` for stable anon buckets.
- Keep v0.3 behavior untouched and align v0.4 payload fields with experiment contract by returning both `experiments_json` and `boot_experiments`.
- Extend v0.4 boot feature tests to assert sticky assignment for repeated same `X-Anon-Id` requests and updated cache vary header.

Verification
- `cd backend && php artisan test --filter='Tests\\Feature\\V0_4\\BootTest'`
- same anon sticky check via curl on `/api/v0.4/boot` (same `X-Anon-Id` returns same variant)
- `bash backend/scripts/ci_verify_mbti.sh`
