### PR TITLE
Fixes FER2-18: add DB experiment registry with active window

### DIFF
--- a/backend/app/Services/Experiments/ExperimentAssigner.php
+++ b/backend/app/Services/Experiments/ExperimentAssigner.php
@@ -18,23 +18,12 @@ class ExperimentAssigner
 
     public function assignActive(int $orgId, ?string $anonId, ?int $userId): array
     {
-        $configs = config('fap_experiments.experiments', []);
-        if (!is_array($configs)) {
-            return [];
+        $activeRegistry = $this->activeExperimentsFromRegistry($orgId);
+        if ($activeRegistry !== []) {
+            return $this->assignMany($activeRegistry, $orgId, $anonId, $userId);
         }
 
-        $active = [];
-        foreach ($configs as $key => $config) {
-            if (!is_array($config)) {
-                continue;
-            }
-            if (!($config['is_active'] ?? false)) {
-                continue;
-            }
-            $active[$key] = $config;
-        }
-
-        return $this->assignMany($active, $orgId, $anonId, $userId);
+        return $this->assignMany($this->activeExperimentsFromConfig(), $orgId, $anonId, $userId);
     }
 
     public function assignMany(array $experiments, int $orgId, ?string $anonId, ?int $userId): array
@@ -137,6 +126,98 @@ class ExperimentAssigner
         }
 
         return $variant;
+    }
+
+    private function activeExperimentsFromRegistry(int $orgId): array
+    {
+        if (!\App\Support\SchemaBaseline::hasTable('experiments_registry')) {
+            return [];
+        }
+
+        $now = now();
+        $rows = DB::table('experiments_registry')
+            ->where('org_id', $orgId)
+            ->where('is_active', true)
+            ->where(function ($query) use ($now): void {
+                $query->whereNull('active_from')->orWhere('active_from', '<=', $now);
+            })
+            ->where(function ($query) use ($now): void {
+                $query->whereNull('active_to')->orWhere('active_to', '>', $now);
+            })
+            ->orderByDesc('active_from')
+            ->orderBy('experiment_key')
+            ->get(['experiment_key', 'variants_json']);
+
+        $active = [];
+        foreach ($rows as $row) {
+            $experimentKey = trim((string) ($row->experiment_key ?? ''));
+            if ($experimentKey === '') {
+                continue;
+            }
+
+            $variants = $this->normalizeVariantWeights($row->variants_json ?? null);
+            if ($variants === []) {
+                continue;
+            }
+
+            $active[$experimentKey] = [
+                'variants' => $variants,
+            ];
+        }
+
+        return $active;
+    }
+
+    private function activeExperimentsFromConfig(): array
+    {
+        $configs = config('fap_experiments.experiments', []);
+        if (!is_array($configs)) {
+            return [];
+        }
+
+        $active = [];
+        foreach ($configs as $key => $config) {
+            if (!is_array($config)) {
+                continue;
+            }
+            if (!($config['is_active'] ?? false)) {
+                continue;
+            }
+            $active[$key] = $config;
+        }
+
+        return $active;
+    }
+
+    private function normalizeVariantWeights(mixed $payload): array
+    {
+        if (is_string($payload) && $payload !== '') {
+            $decoded = json_decode($payload, true);
+            if (is_array($decoded)) {
+                $payload = $decoded;
+            }
+        }
+
+        if (!is_array($payload)) {
+            return [];
+        }
+
+        $normalized = [];
+        foreach ($payload as $variant => $weight) {
+            $variantKey = trim((string) $variant);
+            if ($variantKey === '' || !is_numeric($weight)) {
+                continue;
+            }
+
+            $normalizedWeight = (int) round((float) $weight);
+            if ($normalizedWeight <= 0) {
+                continue;
+            }
+
+            $normalized[$variantKey] = $normalizedWeight;
+        }
+
+        return $normalized;
     }
 
     private function findExisting(string $experimentKey, int $orgId, ?int $userId, string $anonId): ?ExperimentAssignment

--- a/backend/database/migrations/2026_02_27_160000_create_experiments_registry_table.php
+++ b/backend/database/migrations/2026_02_27_160000_create_experiments_registry_table.php
@@ -1,0 +1,135 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Support\Database\SchemaIndex;
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    private const TABLE = 'experiments_registry';
+
+    public function up(): void
+    {
+        $this->createOrConvergeRegistryTable();
+        $this->ensureIndexes();
+    }
+
+    public function down(): void
+    {
+        // forward-only migration: rollback disabled to prevent data loss in production.
+        // Irreversible operation: schema/data rollback handled via forward fix migrations.
+    }
+
+    private function createOrConvergeRegistryTable(): void
+    {
+        if (! Schema::hasTable(self::TABLE)) {
+            Schema::create(self::TABLE, function (Blueprint $table): void {
+                $table->bigIncrements('id');
+                $table->unsignedBigInteger('org_id')->default(0);
+                $table->string('experiment_key', 64);
+                $table->string('stage', 32)->default('prod');
+                $table->string('version', 32)->default('v1');
+                $table->json('variants_json');
+                $table->boolean('is_active')->default(true);
+                $table->timestamp('active_from')->nullable();
+                $table->timestamp('active_to')->nullable();
+                $table->unsignedBigInteger('created_by')->nullable();
+                $table->unsignedBigInteger('updated_by')->nullable();
+                $table->timestamp('created_at')->nullable();
+                $table->timestamp('updated_at')->nullable();
+            });
+
+            return;
+        }
+
+        Schema::table(self::TABLE, function (Blueprint $table): void {
+            if (! Schema::hasColumn(self::TABLE, 'org_id')) {
+                $table->unsignedBigInteger('org_id')->default(0);
+            }
+            if (! Schema::hasColumn(self::TABLE, 'experiment_key')) {
+                $table->string('experiment_key', 64)->nullable();
+            }
+            if (! Schema::hasColumn(self::TABLE, 'stage')) {
+                $table->string('stage', 32)->default('prod');
+            }
+            if (! Schema::hasColumn(self::TABLE, 'version')) {
+                $table->string('version', 32)->default('v1');
+            }
+            if (! Schema::hasColumn(self::TABLE, 'variants_json')) {
+                $table->json('variants_json')->nullable();
+            }
+            if (! Schema::hasColumn(self::TABLE, 'is_active')) {
+                $table->boolean('is_active')->default(true);
+            }
+            if (! Schema::hasColumn(self::TABLE, 'active_from')) {
+                $table->timestamp('active_from')->nullable();
+            }
+            if (! Schema::hasColumn(self::TABLE, 'active_to')) {
+                $table->timestamp('active_to')->nullable();
+            }
+            if (! Schema::hasColumn(self::TABLE, 'created_by')) {
+                $table->unsignedBigInteger('created_by')->nullable();
+            }
+            if (! Schema::hasColumn(self::TABLE, 'updated_by')) {
+                $table->unsignedBigInteger('updated_by')->nullable();
+            }
+            if (! Schema::hasColumn(self::TABLE, 'created_at')) {
+                $table->timestamp('created_at')->nullable();
+            }
+            if (! Schema::hasColumn(self::TABLE, 'updated_at')) {
+                $table->timestamp('updated_at')->nullable();
+            }
+        });
+    }
+
+    private function ensureIndexes(): void
+    {
+        $this->ensureUnique(
+            self::TABLE,
+            ['org_id', 'experiment_key', 'stage', 'version'],
+            'exp_registry_org_key_stage_version_uq'
+        );
+        $this->ensureIndex(
+            self::TABLE,
+            ['org_id', 'is_active', 'active_from', 'active_to'],
+            'exp_registry_org_active_window_idx'
+        );
+        $this->ensureIndex(
+            self::TABLE,
+            ['org_id', 'experiment_key', 'is_active'],
+            'exp_registry_org_key_active_idx'
+        );
+    }
+
+    /**
+     * @param  array<int,string>  $columns
+     */
+    private function ensureIndex(string $tableName, array $columns, string $indexName): void
+    {
+        if (! Schema::hasTable($tableName) || SchemaIndex::indexExists($tableName, $indexName)) {
+            return;
+        }
+
+        Schema::table($tableName, function (Blueprint $table) use ($columns, $indexName): void {
+            $table->index($columns, $indexName);
+        });
+    }
+
+    /**
+     * @param  array<int,string>  $columns
+     */
+    private function ensureUnique(string $tableName, array $columns, string $indexName): void
+    {
+        if (! Schema::hasTable($tableName) || SchemaIndex::indexExists($tableName, $indexName)) {
+            return;
+        }
+
+        Schema::table($tableName, function (Blueprint $table) use ($columns, $indexName): void {
+            $table->unique($columns, $indexName);
+        });
+    }
+};
+

--- a/backend/tests/Feature/V0_3/ExperimentRegistryActiveWindowTest.php
+++ b/backend/tests/Feature/V0_3/ExperimentRegistryActiveWindowTest.php
@@ -1,0 +1,90 @@
+<?php
+
+namespace Tests\Feature\V0_3;
+
+use App\Services\Experiments\ExperimentAssigner;
+use App\Support\StableBucket;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+use Tests\TestCase;
+
+class ExperimentRegistryActiveWindowTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_assign_active_prefers_registry_within_active_window(): void
+    {
+        $this->assertTrue(Schema::hasColumns('experiments_registry', [
+            'active_from',
+            'active_to',
+            'created_by',
+            'updated_by',
+        ]));
+
+        $now = now();
+        DB::table('experiments_registry')->insert([
+            'org_id' => 0,
+            'experiment_key' => 'PR23_STICKY_BUCKET',
+            'stage' => 'prod',
+            'version' => '2026-02-27',
+            'variants_json' => json_encode(['B' => 100], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES),
+            'is_active' => true,
+            'active_from' => $now->copy()->subMinute(),
+            'active_to' => $now->copy()->addMinutes(10),
+            'created_by' => 9001,
+            'updated_by' => 9001,
+            'created_at' => $now,
+            'updated_at' => $now,
+        ]);
+
+        $anonId = 'fer2_registry_window_anon';
+        $assignments = app(ExperimentAssigner::class)->assignActive(0, $anonId, null);
+
+        $this->assertSame('B', $assignments['PR23_STICKY_BUCKET'] ?? null);
+        $this->assertDatabaseHas('experiment_assignments', [
+            'org_id' => 0,
+            'anon_id' => $anonId,
+            'experiment_key' => 'PR23_STICKY_BUCKET',
+            'variant' => 'B',
+        ]);
+    }
+
+    public function test_assign_active_falls_back_to_config_when_registry_row_is_outside_window(): void
+    {
+        $now = now();
+        DB::table('experiments_registry')->insert([
+            'org_id' => 0,
+            'experiment_key' => 'PR23_STICKY_BUCKET',
+            'stage' => 'prod',
+            'version' => '2026-02-26',
+            'variants_json' => json_encode(['B' => 100], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES),
+            'is_active' => true,
+            'active_from' => $now->copy()->subMinutes(20),
+            'active_to' => $now->copy()->subMinute(),
+            'created_by' => 9001,
+            'updated_by' => 9001,
+            'created_at' => $now,
+            'updated_at' => $now,
+        ]);
+
+        $anonId = 'fer2_registry_fallback_anon';
+        $assignments = app(ExperimentAssigner::class)->assignActive(0, $anonId, null);
+
+        $this->assertArrayHasKey('PR23_STICKY_BUCKET', $assignments);
+        $this->assertSame(
+            $this->expectedConfigVariant($anonId, 0),
+            $assignments['PR23_STICKY_BUCKET']
+        );
+    }
+
+    private function expectedConfigVariant(string $anonId, int $orgId): string
+    {
+        $salt = (string) config('fap_experiments.salt', '');
+        $subjectKey = 'anon:' . $anonId;
+        $bucket = StableBucket::bucket($subjectKey . '|' . $orgId . '|PR23_STICKY_BUCKET|' . $salt, 100);
+
+        return $bucket < 50 ? 'A' : 'B';
+    }
+}
+


### PR DESCRIPTION
Fixes FER2-18

Summary
- Add `experiments_registry` table with active window fields (`active_from` / `active_to`) and audit fields (`created_by` / `updated_by`) plus supporting indexes.
- Update `ExperimentAssigner::assignActive()` to prioritize active experiments from DB registry and keep config-driven experiments as fallback when no active DB rows exist.
- Add `ExperimentRegistryActiveWindowTest` to verify both DB-hit behavior within active window and config fallback when registry rows are inactive/expired.

Verification
- `cd backend && php artisan migrate --force`
- `cd backend && php artisan test --filter='ExperimentRegistryActiveWindowTest'`
- `bash backend/scripts/ci_verify_mbti.sh`
