### PR TITLE
Fixes FER2-19: standardize experiment exposure event contract

### DIFF
--- a/backend/app/Services/Analytics/EventRecorder.php
+++ b/backend/app/Services/Analytics/EventRecorder.php
@@ -7,11 +7,15 @@ use App\Services\Experiments\ExperimentAssigner;
 use App\Services\Scale\ScaleIdentityRuntimePolicy;
 use App\Support\SensitiveDataRedactor;
 use Illuminate\Http\Request;
+use Illuminate\Support\Carbon;
+use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Str;
 
 final class EventRecorder
 {
+    private const EXPOSURE_CONTRACT_KEY = '__exposure_contract__';
+
     public function __construct(
         private ExperimentAssigner $experimentAssigner,
         private ?SensitiveDataRedactor $redactor = null,
@@ -67,8 +71,18 @@ final class EventRecorder
         ];
 
         if (\App\Support\SchemaBaseline::hasColumn('events', 'experiments_json')) {
-            $experiments = $context['experiments_json'] ?? [];
-            $payload['experiments_json'] = is_array($experiments) ? $experiments : [];
+            $orgId = is_numeric($payload['org_id'] ?? null) ? (int) $payload['org_id'] : 0;
+            $anonId = is_string($payload['anon_id'] ?? null) || is_numeric($payload['anon_id'] ?? null)
+                ? trim((string) $payload['anon_id'])
+                : '';
+            $payload['experiments_json'] = $this->standardizeExperimentsPayload(
+                $context['experiments_json'] ?? [],
+                [],
+                $orgId,
+                $anonId !== '' ? $anonId : null,
+                $userId,
+                $now
+            );
         }
         if ($this->shouldWriteScaleIdentityColumns()) {
             $payload['scale_code_v2'] = $scaleCodeV2;
@@ -92,12 +106,24 @@ final class EventRecorder
     {
         $context = $this->contextFromRequest($request);
         $bootExperiments = $this->extractBootExperiments($request);
+        $bootContract = $this->extractBootExposureContract($request);
         $assignments = $this->experimentAssigner->assignActive(
             $context['org_id'] ?? 0,
             $context['anon_id'] ?? null,
             $userId,
         );
-        $context['experiments_json'] = $this->experimentAssigner->mergeExperiments($bootExperiments, $assignments);
+        $mergedExperiments = $this->experimentAssigner->mergeExperiments($bootExperiments, $assignments);
+        $context['experiments_json'] = $this->standardizeExperimentsPayload(
+            $mergedExperiments,
+            $bootContract,
+            (int) ($context['org_id'] ?? 0),
+            is_string($context['anon_id'] ?? null) ? (string) $context['anon_id'] : null,
+            $userId,
+            now()
+        );
+        if (in_array($eventCode, ['result_view', 'report_view'], true)) {
+            $meta = $this->appendExposureContractToMeta($meta, $context['experiments_json']);
+        }
         $this->record($eventCode, $userId, $meta, $context);
     }
 
@@ -150,20 +176,446 @@ final class EventRecorder
         return $this->normalizeExperiments($header);
     }
 
+    private function extractBootExposureContract(Request $request): array
+    {
+        $payload = $request->input('experiments_json');
+        $parsed = $this->extractExposureContract($payload);
+        if ($parsed !== []) {
+            return $parsed;
+        }
+
+        $payload = $request->input('boot_experiments');
+        $parsed = $this->extractExposureContract($payload);
+        if ($parsed !== []) {
+            return $parsed;
+        }
+
+        $header = (string) $request->header('X-Experiments-Json', '');
+        $parsed = $this->extractExposureContract($header);
+        if ($parsed !== []) {
+            return $parsed;
+        }
+
+        $header = (string) $request->header('X-Boot-Experiments', '');
+
+        return $this->extractExposureContract($header);
+    }
+
     private function normalizeExperiments($value): array
+    {
+        $decoded = $this->decodeJsonArray($value);
+        if ($decoded === []) {
+            return [];
+        }
+
+        $normalized = [];
+
+        $ingestEntry = function (array $entry) use (&$normalized): void {
+            $experimentKey = trim((string) ($entry['experiment_key'] ?? ''));
+            if ($experimentKey === '' && isset($entry['key'])) {
+                $experimentKey = trim((string) $entry['key']);
+            }
+            if ($experimentKey === '' && isset($entry['name'])) {
+                $experimentKey = trim((string) $entry['name']);
+            }
+
+            $variant = trim((string) ($entry['variant'] ?? ''));
+            if ($experimentKey === '' || $variant === '') {
+                return;
+            }
+
+            $normalized[$experimentKey] = $variant;
+        };
+
+        if (array_is_list($decoded)) {
+            foreach ($decoded as $entry) {
+                if (is_array($entry)) {
+                    $ingestEntry($entry);
+                }
+            }
+
+            return $normalized;
+        }
+
+        $contract = $decoded[self::EXPOSURE_CONTRACT_KEY] ?? null;
+        if (is_array($contract)) {
+            foreach ($contract as $entry) {
+                if (is_array($entry)) {
+                    $ingestEntry($entry);
+                }
+            }
+        }
+
+        foreach ($decoded as $key => $variant) {
+            $experimentKey = trim((string) $key);
+            if ($experimentKey === '' || str_starts_with($experimentKey, '__')) {
+                continue;
+            }
+
+            if (is_string($variant) || is_numeric($variant)) {
+                $variantValue = trim((string) $variant);
+                if ($variantValue !== '') {
+                    $normalized[$experimentKey] = $variantValue;
+                }
+                continue;
+            }
+
+            if (! is_array($variant)) {
+                continue;
+            }
+
+            $variantValue = trim((string) ($variant['variant'] ?? ''));
+            if ($variantValue !== '') {
+                $normalized[$experimentKey] = $variantValue;
+            }
+        }
+
+        return $normalized;
+    }
+
+    /**
+     * @param  array<string,mixed>  $meta
+     * @param  array<string,mixed>  $experimentsPayload
+     * @return array<string,mixed>
+     */
+    private function appendExposureContractToMeta(array $meta, array $experimentsPayload): array
+    {
+        $contract = $this->exposureContractRows($experimentsPayload);
+        if ($contract === []) {
+            return $meta;
+        }
+
+        $meta['experiment_exposure'] = $contract;
+        $primary = $contract[0];
+        foreach (['experiment_key', 'variant', 'version', 'stage', 'assigned_at'] as $field) {
+            $current = trim((string) ($meta[$field] ?? ''));
+            if ($current !== '') {
+                continue;
+            }
+            $value = trim((string) ($primary[$field] ?? ''));
+            if ($value !== '') {
+                $meta[$field] = $value;
+            }
+        }
+
+        return $meta;
+    }
+
+    /**
+     * @param  array<string,mixed>  $bootContract
+     * @return array<string,mixed>
+     */
+    private function standardizeExperimentsPayload(
+        mixed $experiments,
+        array $bootContract,
+        int $orgId,
+        ?string $anonId,
+        ?int $userId,
+        Carbon $fallbackAssignedAt,
+    ): array {
+        $variantMap = $this->normalizeExperiments($experiments);
+        if ($variantMap === []) {
+            return [];
+        }
+
+        $resolvedContract = $this->extractExposureContract($experiments);
+        foreach ($bootContract as $experimentKey => $entry) {
+            if (! is_string($experimentKey) || ! is_array($entry)) {
+                continue;
+            }
+            if (! isset($resolvedContract[$experimentKey]) || ! is_array($resolvedContract[$experimentKey])) {
+                $resolvedContract[$experimentKey] = $entry;
+                continue;
+            }
+            $resolvedContract[$experimentKey] = array_merge($entry, $resolvedContract[$experimentKey]);
+        }
+
+        $metadata = $this->resolveExposureMetadata($orgId, $anonId, $userId, array_keys($variantMap));
+        ksort($variantMap);
+        $entries = [];
+        foreach ($variantMap as $experimentKey => $variant) {
+            $contractEntry = is_array($resolvedContract[$experimentKey] ?? null) ? $resolvedContract[$experimentKey] : [];
+            $meta = is_array($metadata[$experimentKey] ?? null) ? $metadata[$experimentKey] : [];
+            $version = $this->firstNonEmptyString([
+                $contractEntry['version'] ?? null,
+                $meta['version'] ?? null,
+                config('fap_experiments.experiments.' . $experimentKey . '.version'),
+                'v1',
+            ]);
+            $stage = $this->firstNonEmptyString([
+                $contractEntry['stage'] ?? null,
+                $meta['stage'] ?? null,
+                config('fap_experiments.experiments.' . $experimentKey . '.stage'),
+                'prod',
+            ]);
+            $assignedAt = $this->normalizeIsoTimestamp($contractEntry['assigned_at'] ?? null)
+                ?? $this->normalizeIsoTimestamp($meta['assigned_at'] ?? null)
+                ?? $fallbackAssignedAt->toIso8601String();
+
+            $entries[] = [
+                'experiment_key' => $experimentKey,
+                'variant' => $variant,
+                'version' => $version ?? 'v1',
+                'stage' => $stage ?? 'prod',
+                'assigned_at' => $assignedAt,
+            ];
+        }
+
+        $payload = $variantMap;
+        $payload[self::EXPOSURE_CONTRACT_KEY] = $entries;
+
+        return $payload;
+    }
+
+    /**
+     * @param  array<string,mixed>  $payload
+     * @return array<int,array{experiment_key:string,variant:string,version:string,stage:string,assigned_at:string}>
+     */
+    private function exposureContractRows(array $payload): array
+    {
+        $rows = $payload[self::EXPOSURE_CONTRACT_KEY] ?? null;
+        if (! is_array($rows)) {
+            return [];
+        }
+
+        $normalized = [];
+        foreach ($rows as $row) {
+            if (! is_array($row)) {
+                continue;
+            }
+
+            $experimentKey = trim((string) ($row['experiment_key'] ?? ''));
+            $variant = trim((string) ($row['variant'] ?? ''));
+            $version = trim((string) ($row['version'] ?? ''));
+            $stage = trim((string) ($row['stage'] ?? ''));
+            $assignedAt = trim((string) ($row['assigned_at'] ?? ''));
+            if (
+                $experimentKey === ''
+                || $variant === ''
+                || $version === ''
+                || $stage === ''
+                || $assignedAt === ''
+            ) {
+                continue;
+            }
+
+            $normalized[] = [
+                'experiment_key' => $experimentKey,
+                'variant' => $variant,
+                'version' => $version,
+                'stage' => $stage,
+                'assigned_at' => $assignedAt,
+            ];
+        }
+
+        return $normalized;
+    }
+
+    /**
+     * @return array<string,array{version?:string,stage?:string,assigned_at?:string}>
+     */
+    private function extractExposureContract(mixed $value): array
+    {
+        $decoded = $this->decodeJsonArray($value);
+        if ($decoded === []) {
+            return [];
+        }
+
+        $contracts = [];
+        $ingestEntry = function (array $entry, ?string $fallbackKey = null) use (&$contracts): void {
+            $experimentKey = trim((string) ($entry['experiment_key'] ?? $fallbackKey ?? ''));
+            if ($experimentKey === '') {
+                return;
+            }
+
+            $record = [];
+            $version = trim((string) ($entry['version'] ?? ''));
+            if ($version !== '') {
+                $record['version'] = $version;
+            }
+            $stage = trim((string) ($entry['stage'] ?? ''));
+            if ($stage !== '') {
+                $record['stage'] = $stage;
+            }
+            $assignedAt = $this->normalizeIsoTimestamp($entry['assigned_at'] ?? null);
+            if ($assignedAt !== null) {
+                $record['assigned_at'] = $assignedAt;
+            }
+
+            if ($record !== []) {
+                $contracts[$experimentKey] = array_merge($contracts[$experimentKey] ?? [], $record);
+            }
+        };
+
+        if (array_is_list($decoded)) {
+            foreach ($decoded as $entry) {
+                if (is_array($entry)) {
+                    $ingestEntry($entry);
+                }
+            }
+
+            return $contracts;
+        }
+
+        $contractRows = $decoded[self::EXPOSURE_CONTRACT_KEY] ?? null;
+        if (is_array($contractRows)) {
+            foreach ($contractRows as $entry) {
+                if (is_array($entry)) {
+                    $ingestEntry($entry);
+                }
+            }
+        }
+
+        foreach ($decoded as $key => $entry) {
+            if (! is_array($entry)) {
+                continue;
+            }
+            $experimentKey = trim((string) $key);
+            if ($experimentKey === '' || str_starts_with($experimentKey, '__')) {
+                continue;
+            }
+            $ingestEntry($entry, $experimentKey);
+        }
+
+        return $contracts;
+    }
+
+    /**
+     * @param  array<int,string>  $experimentKeys
+     * @return array<string,array{version?:string,stage?:string,assigned_at?:string}>
+     */
+    private function resolveExposureMetadata(int $orgId, ?string $anonId, ?int $userId, array $experimentKeys): array
+    {
+        $experimentKeys = array_values(array_filter(array_map(static function ($value): string {
+            return trim((string) $value);
+        }, $experimentKeys), static function (string $value): bool {
+            return $value !== '';
+        }));
+        if ($experimentKeys === []) {
+            return [];
+        }
+
+        $metadata = [];
+
+        if (\App\Support\SchemaBaseline::hasTable('experiment_assignments')) {
+            $assignmentRows = DB::table('experiment_assignments')
+                ->where('org_id', $orgId)
+                ->whereIn('experiment_key', $experimentKeys)
+                ->when(
+                    $userId !== null || ($anonId !== null && $anonId !== ''),
+                    function ($query) use ($userId, $anonId): void {
+                        $query->where(function ($inner) use ($userId, $anonId): void {
+                            if ($userId !== null) {
+                                $inner->orWhere('user_id', $userId);
+                            }
+                            if ($anonId !== null && $anonId !== '') {
+                                $inner->orWhere('anon_id', $anonId);
+                            }
+                        });
+                    }
+                )
+                ->orderByDesc('assigned_at')
+                ->orderByDesc('id')
+                ->get(['experiment_key', 'user_id', 'anon_id', 'assigned_at']);
+
+            foreach ($assignmentRows as $row) {
+                $experimentKey = trim((string) ($row->experiment_key ?? ''));
+                if ($experimentKey === '' || isset($metadata[$experimentKey]['assigned_at'])) {
+                    continue;
+                }
+
+                $timestamp = $this->normalizeIsoTimestamp($row->assigned_at ?? null);
+                if ($timestamp !== null) {
+                    $metadata[$experimentKey]['assigned_at'] = $timestamp;
+                }
+            }
+        }
+
+        if (\App\Support\SchemaBaseline::hasTable('experiments_registry')) {
+            $now = now();
+            $registryRows = DB::table('experiments_registry')
+                ->where('org_id', $orgId)
+                ->where('is_active', true)
+                ->whereIn('experiment_key', $experimentKeys)
+                ->where(function ($query) use ($now): void {
+                    $query->whereNull('active_from')->orWhere('active_from', '<=', $now);
+                })
+                ->where(function ($query) use ($now): void {
+                    $query->whereNull('active_to')->orWhere('active_to', '>', $now);
+                })
+                ->orderByDesc('active_from')
+                ->orderByDesc('id')
+                ->get(['experiment_key', 'version', 'stage']);
+
+            foreach ($registryRows as $row) {
+                $experimentKey = trim((string) ($row->experiment_key ?? ''));
+                if ($experimentKey === '' || isset($metadata[$experimentKey]['version'])) {
+                    continue;
+                }
+
+                $version = trim((string) ($row->version ?? ''));
+                if ($version !== '') {
+                    $metadata[$experimentKey]['version'] = $version;
+                }
+
+                $stage = trim((string) ($row->stage ?? ''));
+                if ($stage !== '') {
+                    $metadata[$experimentKey]['stage'] = $stage;
+                }
+            }
+        }
+
+        return $metadata;
+    }
+
+    private function decodeJsonArray(mixed $value): array
     {
         if (is_array($value)) {
             return $value;
         }
 
-        if (is_string($value) && $value !== '') {
-            $decoded = json_decode($value, true);
-            if (is_array($decoded)) {
-                return $decoded;
-            }
+        if (! is_string($value) || trim($value) === '') {
+            return [];
+        }
+
+        $decoded = json_decode($value, true);
+        if (is_array($decoded)) {
+            return $decoded;
         }
 
         return [];
+    }
+
+    private function normalizeIsoTimestamp(mixed $value): ?string
+    {
+        if (! is_string($value) && ! is_numeric($value) && ! $value instanceof \DateTimeInterface) {
+            return null;
+        }
+
+        try {
+            return Carbon::parse($value)->toIso8601String();
+        } catch (\Throwable) {
+            return null;
+        }
+    }
+
+    /**
+     * @param  array<int,mixed>  $values
+     */
+    private function firstNonEmptyString(array $values): ?string
+    {
+        foreach ($values as $value) {
+            if (! is_string($value) && ! is_numeric($value)) {
+                continue;
+            }
+
+            $normalized = trim((string) $value);
+            if ($normalized !== '') {
+                return $normalized;
+            }
+        }
+
+        return null;
     }
 
     /**

--- a/backend/tests/Feature/V0_3/ExperimentExposureContractTest.php
+++ b/backend/tests/Feature/V0_3/ExperimentExposureContractTest.php
@@ -41,18 +41,7 @@ class ExperimentExposureContractTest extends TestCase
         ])->getJson("/api/v0.3/attempts/{$attemptId}/report")->assertStatus(200);
 
         foreach (['result_view', 'report_view'] as $eventCode) {
-            $event = DB::table('events')
-                ->where('event_code', $eventCode)
-                ->where('attempt_id', $attemptId)
-                ->orderByDesc('occurred_at')
-                ->first();
-            if (! $event) {
-                $event = DB::table('events')
-                    ->where('event_code', $eventCode)
-                    ->where('meta_json', 'like', '%"attempt_id":"' . $attemptId . '"%')
-                    ->orderByDesc('occurred_at')
-                    ->first();
-            }
+            $event = $this->findLatestEventByAttempt($eventCode, $attemptId);
             $this->assertNotNull($event, 'missing event row: ' . $eventCode);
 
             $experiments = json_decode((string) ($event->experiments_json ?? '{}'), true) ?: [];
@@ -185,5 +174,37 @@ class ExperimentExposureContractTest extends TestCase
         ]);
 
         return $attemptId;
+    }
+
+    private function findLatestEventByAttempt(string $eventCode, string $attemptId): ?object
+    {
+        $query = DB::table('events')
+            ->where('event_code', $eventCode)
+            ->where(function ($inner) use ($attemptId): void {
+                $inner->where('attempt_id', $attemptId);
+
+                $driver = DB::connection()->getDriverName();
+                if ($driver === 'mysql') {
+                    $inner->orWhereRaw(
+                        "JSON_UNQUOTE(JSON_EXTRACT(meta_json, '$.attempt_id')) = ?",
+                        [$attemptId]
+                    );
+
+                    return;
+                }
+
+                if ($driver === 'sqlite') {
+                    $inner->orWhereRaw(
+                        "json_extract(meta_json, '$.attempt_id') = ?",
+                        [$attemptId]
+                    );
+
+                    return;
+                }
+
+                $inner->orWhereRaw('meta_json like ?', ['%"attempt_id":"' . $attemptId . '"%']);
+            });
+
+        return $query->orderByDesc('occurred_at')->first();
     }
 }

--- a/backend/tests/Feature/V0_3/ExperimentExposureContractTest.php
+++ b/backend/tests/Feature/V0_3/ExperimentExposureContractTest.php
@@ -1,0 +1,189 @@
+<?php
+
+namespace Tests\Feature\V0_3;
+
+use App\Models\Attempt;
+use App\Models\Result;
+use Database\Seeders\ScaleRegistrySeeder;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Str;
+use Tests\TestCase;
+
+class ExperimentExposureContractTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_result_and_report_events_include_standardized_exposure_contract(): void
+    {
+        $this->seedScales();
+
+        $anonId = 'fer2_exposure_contract_anon';
+        $anonToken = $this->issueAnonToken($anonId);
+        $attemptId = $this->createMbtiAttemptWithResult($anonId);
+
+        $boot = $this->withHeaders([
+            'X-Anon-Id' => $anonId,
+            'Authorization' => 'Bearer ' . $anonToken,
+        ])->getJson('/api/v0.3/boot');
+        $boot->assertStatus(200);
+        $variant = trim((string) $boot->json('experiments.PR23_STICKY_BUCKET'));
+        $this->assertNotSame('', $variant);
+
+        $this->withHeaders([
+            'X-Anon-Id' => $anonId,
+            'Authorization' => 'Bearer ' . $anonToken,
+        ])->getJson("/api/v0.3/attempts/{$attemptId}/result")->assertStatus(200);
+
+        $this->withHeaders([
+            'X-Anon-Id' => $anonId,
+            'Authorization' => 'Bearer ' . $anonToken,
+        ])->getJson("/api/v0.3/attempts/{$attemptId}/report")->assertStatus(200);
+
+        foreach (['result_view', 'report_view'] as $eventCode) {
+            $event = DB::table('events')
+                ->where('event_code', $eventCode)
+                ->where('attempt_id', $attemptId)
+                ->orderByDesc('occurred_at')
+                ->first();
+            if (! $event) {
+                $event = DB::table('events')
+                    ->where('event_code', $eventCode)
+                    ->where('meta_json', 'like', '%"attempt_id":"' . $attemptId . '"%')
+                    ->orderByDesc('occurred_at')
+                    ->first();
+            }
+            $this->assertNotNull($event, 'missing event row: ' . $eventCode);
+
+            $experiments = json_decode((string) ($event->experiments_json ?? '{}'), true) ?: [];
+            $this->assertSame($variant, (string) ($experiments['PR23_STICKY_BUCKET'] ?? ''));
+
+            $contract = $experiments['__exposure_contract__'][0] ?? null;
+            $this->assertIsArray($contract);
+            $this->assertSame('PR23_STICKY_BUCKET', (string) ($contract['experiment_key'] ?? ''));
+            $this->assertSame($variant, (string) ($contract['variant'] ?? ''));
+            $this->assertNotSame('', trim((string) ($contract['version'] ?? '')));
+            $this->assertNotSame('', trim((string) ($contract['stage'] ?? '')));
+            $this->assertNotSame('', trim((string) ($contract['assigned_at'] ?? '')));
+
+            $meta = json_decode((string) ($event->meta_json ?? '{}'), true) ?: [];
+            $this->assertSame('PR23_STICKY_BUCKET', (string) ($meta['experiment_key'] ?? ''));
+            $this->assertSame($variant, (string) ($meta['variant'] ?? ''));
+            $this->assertNotSame('', trim((string) ($meta['version'] ?? '')));
+            $this->assertNotSame('', trim((string) ($meta['stage'] ?? '')));
+            $this->assertNotSame('', trim((string) ($meta['assigned_at'] ?? '')));
+            $this->assertIsArray($meta['experiment_exposure'] ?? null);
+            $this->assertSame(
+                'PR23_STICKY_BUCKET',
+                (string) (($meta['experiment_exposure'][0]['experiment_key'] ?? ''))
+            );
+        }
+    }
+
+    private function seedScales(): void
+    {
+        (new ScaleRegistrySeeder())->run();
+    }
+
+    private function issueAnonToken(string $anonId): string
+    {
+        $token = 'fm_' . (string) Str::uuid();
+        DB::table('fm_tokens')->insert([
+            'token' => $token,
+            'token_hash' => hash('sha256', $token),
+            'user_id' => null,
+            'anon_id' => $anonId,
+            'org_id' => 0,
+            'role' => 'public',
+            'expires_at' => now()->addDay(),
+            'created_at' => now(),
+            'updated_at' => now(),
+        ]);
+
+        return $token;
+    }
+
+    private function createMbtiAttemptWithResult(string $anonId): string
+    {
+        $attemptId = (string) Str::uuid();
+
+        Attempt::create([
+            'id' => $attemptId,
+            'org_id' => 0,
+            'anon_id' => $anonId,
+            'scale_code' => 'MBTI',
+            'scale_version' => 'v0.3',
+            'region' => 'CN_MAINLAND',
+            'locale' => 'zh-CN',
+            'question_count' => 144,
+            'client_platform' => 'test',
+            'answers_summary_json' => ['stage' => 'seed'],
+            'started_at' => now(),
+            'submitted_at' => now(),
+            'pack_id' => (string) config('content_packs.default_pack_id'),
+            'dir_version' => 'MBTI-CN-v0.3',
+            'content_package_version' => 'v0.3',
+        ]);
+
+        Result::create([
+            'id' => (string) Str::uuid(),
+            'org_id' => 0,
+            'attempt_id' => $attemptId,
+            'scale_code' => 'MBTI',
+            'scale_version' => 'v0.3',
+            'type_code' => 'INTJ-A',
+            'scores_json' => [
+                'EI' => ['a' => 10, 'b' => 10, 'neutral' => 0, 'sum' => 0, 'total' => 20],
+                'SN' => ['a' => 10, 'b' => 10, 'neutral' => 0, 'sum' => 0, 'total' => 20],
+                'TF' => ['a' => 10, 'b' => 10, 'neutral' => 0, 'sum' => 0, 'total' => 20],
+                'JP' => ['a' => 10, 'b' => 10, 'neutral' => 0, 'sum' => 0, 'total' => 20],
+                'AT' => ['a' => 10, 'b' => 10, 'neutral' => 0, 'sum' => 0, 'total' => 20],
+            ],
+            'scores_pct' => [
+                'EI' => 50,
+                'SN' => 50,
+                'TF' => 50,
+                'JP' => 50,
+                'AT' => 50,
+            ],
+            'axis_states' => [
+                'EI' => 'clear',
+                'SN' => 'clear',
+                'TF' => 'clear',
+                'JP' => 'clear',
+                'AT' => 'clear',
+            ],
+            'content_package_version' => 'v0.3',
+            'result_json' => [
+                'raw_score' => 0,
+                'final_score' => 0,
+                'breakdown_json' => [],
+                'type_code' => 'INTJ-A',
+                'axis_scores_json' => [
+                    'scores_pct' => [
+                        'EI' => 50,
+                        'SN' => 50,
+                        'TF' => 50,
+                        'JP' => 50,
+                        'AT' => 50,
+                    ],
+                    'axis_states' => [
+                        'EI' => 'clear',
+                        'SN' => 'clear',
+                        'TF' => 'clear',
+                        'JP' => 'clear',
+                        'AT' => 'clear',
+                    ],
+                ],
+            ],
+            'pack_id' => (string) config('content_packs.default_pack_id'),
+            'dir_version' => 'MBTI-CN-v0.3',
+            'scoring_spec_version' => '2026.01',
+            'report_engine_version' => 'v1.2',
+            'is_valid' => true,
+            'computed_at' => now(),
+        ]);
+
+        return $attemptId;
+    }
+}


### PR DESCRIPTION
Fixes FER2-19

Summary
- Standardize experiment exposure payload in `EventRecorder` by normalizing merged experiments into a compatibility map plus exposure contract rows with fixed fields: `experiment_key`, `variant`, `version`, `stage`, `assigned_at`.
- Ensure `result_view` and `report_view` events always carry exposure contract fields in `meta_json` (`experiment_exposure` and flattened contract fields).
- Add `ExperimentExposureContractTest` to verify both `result_view` and `report_view` persist the contract in `events.experiments_json` and `events.meta_json`.

Verification
- `cd backend && php artisan test --filter='ExperimentExposureContractTest'`
- `cd backend && php artisan test --filter='EventRecorderBig5RedactionTest'`
- `bash backend/scripts/ci_verify_mbti.sh`
