### PR TITLE
Fixes FER2-20: add conversion KPI evaluator and governance bridge

### DIFF
--- a/backend/app/Console/Commands/Ops/ExperimentGuardrailsEvaluate.php
+++ b/backend/app/Console/Commands/Ops/ExperimentGuardrailsEvaluate.php
@@ -1,0 +1,148 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Console\Commands\Ops;
+
+use App\Services\Experiments\ExperimentKpiEvaluator;
+use Illuminate\Console\Command;
+
+final class ExperimentGuardrailsEvaluate extends Command
+{
+    protected $signature = 'ops:experiment-guardrails-evaluate
+        {--org-id= : Org id to evaluate}
+        {--rollout-id= : Optional rollout id; when omitted, evaluate all active rollouts in org}
+        {--window-minutes=60 : KPI lookback window in minutes}
+        {--actor-user-id= : Optional actor user id written into audits}
+        {--reason= : Optional reason message}
+        {--strict=0 : Exit non-zero when any rollout is auto rolled back}
+        {--json=1 : Output JSON payload}';
+
+    protected $description = 'Evaluate experiment guardrails with DB KPI metrics and auto rollback bridge.';
+
+    public function __construct(private readonly ExperimentKpiEvaluator $kpiEvaluator)
+    {
+        parent::__construct();
+    }
+
+    public function handle(): int
+    {
+        $orgId = $this->parseOrgId($this->option('org-id'));
+        if ($orgId <= 0) {
+            $this->error('invalid --org-id, expected positive integer');
+
+            return self::FAILURE;
+        }
+
+        $windowMinutes = max(1, (int) $this->option('window-minutes'));
+        $actorUserId = $this->parseOptionalInt($this->option('actor-user-id'));
+        $reason = $this->normalizeString($this->option('reason'));
+        $rolloutId = $this->normalizeString($this->option('rollout-id'));
+
+        $results = [];
+
+        try {
+            if ($rolloutId !== null) {
+                $evaluated = $this->kpiEvaluator->evaluateRollout(
+                    $orgId,
+                    $rolloutId,
+                    $actorUserId,
+                    $windowMinutes,
+                    $reason
+                );
+
+                if ($evaluated === null) {
+                    $this->error('rollout not found or governance tables not ready');
+
+                    return self::FAILURE;
+                }
+
+                $results[] = $evaluated;
+            } else {
+                $results = $this->kpiEvaluator->evaluateActiveRollouts(
+                    $orgId,
+                    $actorUserId,
+                    $windowMinutes,
+                    $reason
+                );
+            }
+        } catch (\RuntimeException $e) {
+            $this->error($e->getMessage());
+
+            return self::FAILURE;
+        }
+
+        $rolledBackCount = 0;
+        foreach ($results as $result) {
+            if ((bool) ($result['rolled_back'] ?? false)) {
+                $rolledBackCount++;
+            }
+        }
+
+        $payload = [
+            'ok' => true,
+            'org_id' => $orgId,
+            'window_minutes' => $windowMinutes,
+            'evaluated_count' => count($results),
+            'rolled_back_count' => $rolledBackCount,
+            'results' => $results,
+        ];
+
+        if ($this->isTruthy($this->option('json'))) {
+            $this->line((string) json_encode($payload, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES));
+        } else {
+            $this->info('experiment_guardrails_evaluate');
+            $this->line(sprintf(
+                'org_id=%d window_minutes=%d evaluated=%d rolled_back=%d',
+                $orgId,
+                $windowMinutes,
+                count($results),
+                $rolledBackCount
+            ));
+        }
+
+        if ($this->isTruthy($this->option('strict')) && $rolledBackCount > 0) {
+            return self::FAILURE;
+        }
+
+        return self::SUCCESS;
+    }
+
+    private function parseOrgId(mixed $value): int
+    {
+        $normalized = trim((string) $value);
+        if ($normalized === '' || preg_match('/^\d+$/', $normalized) !== 1) {
+            return 0;
+        }
+
+        return (int) $normalized;
+    }
+
+    private function parseOptionalInt(mixed $value): ?int
+    {
+        $normalized = trim((string) $value);
+        if ($normalized === '' || preg_match('/^\d+$/', $normalized) !== 1) {
+            return null;
+        }
+
+        return (int) $normalized;
+    }
+
+    private function normalizeString(mixed $value): ?string
+    {
+        $normalized = trim((string) $value);
+
+        return $normalized !== '' ? $normalized : null;
+    }
+
+    private function isTruthy(mixed $value): bool
+    {
+        if (is_bool($value)) {
+            return $value;
+        }
+
+        $normalized = strtolower(trim((string) $value));
+
+        return in_array($normalized, ['1', 'true', 'yes', 'on'], true);
+    }
+}

--- a/backend/app/Console/Kernel.php
+++ b/backend/app/Console/Kernel.php
@@ -41,6 +41,7 @@ use App\Console\Commands\Ops\BackfillReportSnapshotsScaleIdentity;
 use App\Console\Commands\Ops\BackfillResultsScaleIdentity;
 use App\Console\Commands\Ops\BackfillSharesScaleIdentity;
 use App\Console\Commands\Ops\ContentPathMirror;
+use App\Console\Commands\Ops\ExperimentGuardrailsEvaluate;
 use App\Console\Commands\Ops\PartitionAttemptAnswerRows;
 use App\Console\Commands\Ops\QueueBacklogProbe;
 use App\Console\Commands\Ops\ScaleIdentityGate;
@@ -134,6 +135,7 @@ class Kernel extends ConsoleKernel
         BackfillSharesScaleIdentity::class,
         PartitionAttemptAnswerRows::class,
         QueueBacklogProbe::class,
+        ExperimentGuardrailsEvaluate::class,
     ];
 
     /**

--- a/backend/app/Services/Experiments/ExperimentKpiEvaluator.php
+++ b/backend/app/Services/Experiments/ExperimentKpiEvaluator.php
@@ -1,0 +1,336 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\Experiments;
+
+use Illuminate\Support\Facades\DB;
+
+final class ExperimentKpiEvaluator
+{
+    private const ROLLOUTS_TABLE = 'scoring_model_rollouts';
+
+    public function __construct(
+        private readonly ExperimentGovernanceService $governanceService,
+    ) {}
+
+    /**
+     * @return array{
+     *     rollout:array<string,mixed>,
+     *     guardrails:list<array<string,mixed>>,
+     *     rolled_back:bool,
+     *     triggered_count:int,
+     *     audit_id:?string,
+     *     metrics:array<string,array{value:float,sample_size:int}>
+     * }|null
+     */
+    public function evaluateRollout(
+        int $orgId,
+        string $rolloutId,
+        ?int $actorUserId,
+        int $windowMinutes = 60,
+        ?string $reason = null
+    ): ?array {
+        $rollout = $this->findRollout($orgId, $rolloutId);
+        if ($rollout === null) {
+            return null;
+        }
+
+        $metrics = $this->buildMetricsForRollout($orgId, $rollout, max(1, $windowMinutes));
+
+        $result = $this->governanceService->evaluateGuardrails(
+            $orgId,
+            (string) $rollout->id,
+            $actorUserId,
+            $metrics,
+            $reason
+        );
+        if ($result === null) {
+            return null;
+        }
+
+        $result['metrics'] = $metrics;
+
+        return $result;
+    }
+
+    /**
+     * @return list<array{
+     *     rollout:array<string,mixed>,
+     *     guardrails:list<array<string,mixed>>,
+     *     rolled_back:bool,
+     *     triggered_count:int,
+     *     audit_id:?string,
+     *     metrics:array<string,array{value:float,sample_size:int}>
+     * }>
+     */
+    public function evaluateActiveRollouts(
+        int $orgId,
+        ?int $actorUserId,
+        int $windowMinutes = 60,
+        ?string $reason = null
+    ): array {
+        if ($orgId <= 0) {
+            return [];
+        }
+
+        $rollouts = DB::table(self::ROLLOUTS_TABLE)
+            ->where('org_id', $orgId)
+            ->where('is_active', true)
+            ->orderBy('priority')
+            ->orderBy('created_at')
+            ->get(['id'])
+            ->all();
+
+        $results = [];
+        foreach ($rollouts as $rollout) {
+            $rolloutId = trim((string) ($rollout->id ?? ''));
+            if ($rolloutId === '') {
+                continue;
+            }
+
+            $evaluated = $this->evaluateRollout($orgId, $rolloutId, $actorUserId, $windowMinutes, $reason);
+            if ($evaluated !== null) {
+                $results[] = $evaluated;
+            }
+        }
+
+        return $results;
+    }
+
+    /**
+     * @return array<string,array{value:float,sample_size:int}>
+     */
+    public function buildMetricsForRollout(int $orgId, object $rollout, int $windowMinutes): array
+    {
+        $windowStart = now()->subMinutes(max(1, $windowMinutes));
+        $exposure = $this->collectExposureAttempts($orgId, $rollout, $windowStart);
+
+        $exposureCount = count($exposure['exposure_keys']);
+        $attemptIds = array_keys($exposure['attempt_ids']);
+
+        $orderRows = [];
+        if ($attemptIds !== []) {
+            $orderRows = DB::table('orders')
+                ->where('org_id', $orgId)
+                ->whereIn('target_attempt_id', $attemptIds)
+                ->where(function ($query) use ($windowStart): void {
+                    $query->where('created_at', '>=', $windowStart)
+                        ->orWhere(function ($paidQuery) use ($windowStart): void {
+                            $paidQuery->whereNotNull('paid_at')->where('paid_at', '>=', $windowStart);
+                        });
+                })
+                ->get(['order_no', 'status', 'paid_at', 'target_attempt_id'])
+                ->all();
+        }
+
+        $paidAttemptIds = [];
+        $paidOrderNos = [];
+        $paidOrdersCount = 0;
+        foreach ($orderRows as $orderRow) {
+            $status = strtolower(trim((string) ($orderRow->status ?? '')));
+            $isPaid = in_array($status, ['paid', 'fulfilled', 'completed', 'success', 'succeeded'], true)
+                || $orderRow->paid_at !== null;
+            if (! $isPaid) {
+                continue;
+            }
+
+            $paidOrdersCount++;
+            $targetAttemptId = trim((string) ($orderRow->target_attempt_id ?? ''));
+            if ($targetAttemptId !== '') {
+                $paidAttemptIds[$targetAttemptId] = true;
+            }
+
+            $orderNo = trim((string) ($orderRow->order_no ?? ''));
+            if ($orderNo !== '') {
+                $paidOrderNos[$orderNo] = true;
+            }
+        }
+
+        $paymentRows = [];
+        if ($paidOrderNos !== []) {
+            $paymentRows = DB::table('payment_events')
+                ->where('org_id', $orgId)
+                ->whereIn('order_no', array_keys($paidOrderNos))
+                ->where(function ($query) use ($windowStart): void {
+                    $query->where('created_at', '>=', $windowStart)
+                        ->orWhere(function ($receivedQuery) use ($windowStart): void {
+                            $receivedQuery->whereNotNull('received_at')->where('received_at', '>=', $windowStart);
+                        });
+                })
+                ->get(['status', 'processed_at', 'reason'])
+                ->all();
+        }
+
+        $paymentSuccessCount = 0;
+        foreach ($paymentRows as $paymentRow) {
+            $status = strtolower(trim((string) ($paymentRow->status ?? '')));
+            $reason = strtolower(trim((string) ($paymentRow->reason ?? '')));
+            $isSuccess = in_array($status, ['processed', 'handled', 'success', 'succeeded', 'paid', 'completed', 'ok'], true)
+                || $paymentRow->processed_at !== null
+                || in_array($reason, ['paid', 'success', 'completed'], true);
+            if ($isSuccess) {
+                $paymentSuccessCount++;
+            }
+        }
+
+        $readyAttempts = [];
+        if ($attemptIds !== []) {
+            $snapshotRows = DB::table('report_snapshots')
+                ->where('org_id', $orgId)
+                ->whereIn('attempt_id', $attemptIds)
+                ->where(function ($query) use ($windowStart): void {
+                    $query->where('created_at', '>=', $windowStart)
+                        ->orWhere(function ($updatedQuery) use ($windowStart): void {
+                            $updatedQuery->whereNotNull('updated_at')->where('updated_at', '>=', $windowStart);
+                        });
+                })
+                ->get(['attempt_id', 'status'])
+                ->all();
+
+            foreach ($snapshotRows as $snapshotRow) {
+                $attemptId = trim((string) ($snapshotRow->attempt_id ?? ''));
+                if ($attemptId === '') {
+                    continue;
+                }
+
+                $status = strtolower(trim((string) ($snapshotRow->status ?? 'ready')));
+                if (in_array($status, ['ready', 'done', 'generated', 'success', 'completed'], true)) {
+                    $readyAttempts[$attemptId] = true;
+                }
+            }
+        }
+
+        $conversionRate = $this->safeRate(count($paidAttemptIds), $exposureCount);
+        $paidOrderRate = $this->safeRate($paidOrdersCount, count($orderRows));
+        $paymentSuccessRate = $this->safeRate($paymentSuccessCount, count($paymentRows));
+        $reportReadyRate = $this->safeRate(count($readyAttempts), $exposureCount);
+        $submissionFailedRate = $this->safeRate(max(0, $exposureCount - count($readyAttempts)), $exposureCount);
+
+        return [
+            'conversion_rate' => [
+                'value' => $conversionRate,
+                'sample_size' => $exposureCount,
+            ],
+            'paid_order_rate' => [
+                'value' => $paidOrderRate,
+                'sample_size' => count($orderRows),
+            ],
+            'payment_success_rate' => [
+                'value' => $paymentSuccessRate,
+                'sample_size' => count($paymentRows),
+            ],
+            'report_ready_rate' => [
+                'value' => $reportReadyRate,
+                'sample_size' => $exposureCount,
+            ],
+            'submission_failed_rate' => [
+                'value' => $submissionFailedRate,
+                'sample_size' => $exposureCount,
+            ],
+        ];
+    }
+
+    /**
+     * @return array{attempt_ids:array<string,bool>,exposure_keys:array<string,bool>}
+     */
+    private function collectExposureAttempts(int $orgId, object $rollout, \DateTimeInterface $windowStart): array
+    {
+        $rows = DB::table('events')
+            ->where('org_id', $orgId)
+            ->whereIn('event_code', ['result_view', 'report_view'])
+            ->where('occurred_at', '>=', $windowStart)
+            ->get(['id', 'attempt_id', 'experiments_json'])
+            ->all();
+
+        $attemptIds = [];
+        $exposureKeys = [];
+
+        foreach ($rows as $row) {
+            $experiments = $this->decodeJsonRecord($row->experiments_json ?? null);
+            if (! $this->matchesRolloutExperiment($rollout, $experiments)) {
+                continue;
+            }
+
+            $attemptId = trim((string) ($row->attempt_id ?? ''));
+            if ($attemptId !== '') {
+                $attemptIds[$attemptId] = true;
+                $exposureKeys['attempt:'.$attemptId] = true;
+                continue;
+            }
+
+            $eventId = trim((string) ($row->id ?? ''));
+            if ($eventId !== '') {
+                $exposureKeys['event:'.$eventId] = true;
+            }
+        }
+
+        return [
+            'attempt_ids' => $attemptIds,
+            'exposure_keys' => $exposureKeys,
+        ];
+    }
+
+    /**
+     * @param  array<string,mixed>  $experiments
+     */
+    private function matchesRolloutExperiment(object $rollout, array $experiments): bool
+    {
+        $experimentKey = trim((string) ($rollout->experiment_key ?? ''));
+        if ($experimentKey === '') {
+            return true;
+        }
+
+        $variant = trim((string) ($rollout->experiment_variant ?? ''));
+        $assigned = trim((string) ($experiments[$experimentKey] ?? ''));
+        if ($assigned === '') {
+            return false;
+        }
+
+        if ($variant === '') {
+            return true;
+        }
+
+        return $assigned === $variant;
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    private function decodeJsonRecord(mixed $raw): array
+    {
+        if (is_array($raw)) {
+            return $raw;
+        }
+
+        if (! is_string($raw) || trim($raw) === '') {
+            return [];
+        }
+
+        $decoded = json_decode($raw, true);
+
+        return is_array($decoded) ? $decoded : [];
+    }
+
+    private function safeRate(int $numerator, int $denominator): float
+    {
+        if ($denominator <= 0) {
+            return 0.0;
+        }
+
+        return round($numerator / $denominator, 6);
+    }
+
+    private function findRollout(int $orgId, string $rolloutId): ?object
+    {
+        $normalizedRolloutId = trim($rolloutId);
+        if ($orgId <= 0 || $normalizedRolloutId === '') {
+            return null;
+        }
+
+        return DB::table(self::ROLLOUTS_TABLE)
+            ->where('org_id', $orgId)
+            ->where('id', $normalizedRolloutId)
+            ->first();
+    }
+}

--- a/backend/tests/Feature/V0_4/ExperimentKpiEvaluatorBridgeTest.php
+++ b/backend/tests/Feature/V0_4/ExperimentKpiEvaluatorBridgeTest.php
@@ -1,0 +1,253 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\V0_4;
+
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Artisan;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Str;
+use Tests\TestCase;
+
+final class ExperimentKpiEvaluatorBridgeTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_kpi_evaluator_bridge_computes_conversion_rate_and_triggers_auto_rollback(): void
+    {
+        $ownerUserId = $this->createUser('fer2_20_owner@fm.test');
+        $orgId = $this->createOrg($ownerUserId, 'FER2 KPI Org');
+        $rolloutId = $this->seedRollout($orgId);
+        $this->seedGuardrail($orgId, $rolloutId);
+
+        $this->seedExposureData($orgId, 'PR23_STICKY_BUCKET', 'A', 10, 1, 8);
+
+        $exitCode = Artisan::call('ops:experiment-guardrails-evaluate', [
+            '--org-id' => (string) $orgId,
+            '--rollout-id' => $rolloutId,
+            '--window-minutes' => 120,
+            '--json' => 1,
+        ]);
+
+        $this->assertSame(0, $exitCode);
+
+        $payload = json_decode(trim((string) Artisan::output()), true);
+        $this->assertIsArray($payload);
+        $this->assertSame(1, (int) ($payload['evaluated_count'] ?? 0));
+        $this->assertSame(1, (int) ($payload['rolled_back_count'] ?? 0));
+
+        $result = is_array($payload['results'][0] ?? null) ? $payload['results'][0] : [];
+        $metrics = is_array($result['metrics'] ?? null) ? $result['metrics'] : [];
+        $conversionMetric = is_array($metrics['conversion_rate'] ?? null) ? $metrics['conversion_rate'] : [];
+
+        $this->assertSame(10, (int) ($conversionMetric['sample_size'] ?? 0));
+        $this->assertEquals(0.1, (float) ($conversionMetric['value'] ?? -1));
+        $this->assertTrue((bool) ($result['rolled_back'] ?? false));
+
+        $this->assertDatabaseHas('scoring_model_rollouts', [
+            'id' => $rolloutId,
+            'org_id' => $orgId,
+            'is_active' => 0,
+        ]);
+
+        $this->assertDatabaseHas('experiment_rollout_audits', [
+            'org_id' => $orgId,
+            'rollout_id' => $rolloutId,
+            'action' => 'auto_rollback',
+            'status' => 'triggered',
+        ]);
+    }
+
+    private function createUser(string $email): int
+    {
+        return (int) DB::table('users')->insertGetId([
+            'name' => $email,
+            'email' => $email,
+            'password' => bcrypt('secret'),
+            'created_at' => now(),
+            'updated_at' => now(),
+        ]);
+    }
+
+    private function createOrg(int $ownerUserId, string $name): int
+    {
+        return (int) DB::table('organizations')->insertGetId([
+            'name' => $name,
+            'owner_user_id' => $ownerUserId,
+            'created_at' => now(),
+            'updated_at' => now(),
+        ]);
+    }
+
+    private function seedRollout(int $orgId): string
+    {
+        $modelKey = 'fer2_kpi_model_'.Str::lower(Str::random(6));
+
+        DB::table('scoring_models')->insert([
+            'id' => (string) Str::uuid(),
+            'org_id' => $orgId,
+            'scale_code' => 'MBTI',
+            'model_key' => $modelKey,
+            'driver_type' => 'mbti',
+            'scoring_spec_version' => 'mbti_spec_fer2_20',
+            'priority' => 10,
+            'is_active' => true,
+            'config_json' => null,
+            'created_at' => now(),
+            'updated_at' => now(),
+        ]);
+
+        $rolloutId = (string) Str::uuid();
+        DB::table('scoring_model_rollouts')->insert([
+            'id' => $rolloutId,
+            'org_id' => $orgId,
+            'scale_code' => 'MBTI',
+            'model_key' => $modelKey,
+            'experiment_key' => 'PR23_STICKY_BUCKET',
+            'experiment_variant' => 'A',
+            'rollout_percent' => 100,
+            'priority' => 10,
+            'is_active' => true,
+            'starts_at' => now()->subMinutes(20),
+            'ends_at' => null,
+            'created_at' => now(),
+            'updated_at' => now(),
+        ]);
+
+        return $rolloutId;
+    }
+
+    private function seedGuardrail(int $orgId, string $rolloutId): void
+    {
+        DB::table('experiment_guardrails')->insert([
+            'id' => (string) Str::uuid(),
+            'org_id' => $orgId,
+            'rollout_id' => $rolloutId,
+            'experiment_key' => 'PR23_STICKY_BUCKET',
+            'metric_key' => 'conversion_rate',
+            'operator' => 'lte',
+            'threshold' => 0.2,
+            'window_minutes' => 120,
+            'min_sample_size' => 5,
+            'auto_rollback' => true,
+            'is_active' => true,
+            'last_evaluated_at' => null,
+            'last_triggered_at' => null,
+            'created_at' => now(),
+            'updated_at' => now(),
+        ]);
+    }
+
+    private function seedExposureData(
+        int $orgId,
+        string $experimentKey,
+        string $variant,
+        int $exposureCount,
+        int $paidAttempts,
+        int $readyReports
+    ): void {
+        $attemptIds = [];
+        $baseTs = now()->subMinutes(10);
+
+        for ($i = 1; $i <= $exposureCount; $i++) {
+            $attemptId = 'fer2_kpi_attempt_'.$i;
+            $attemptIds[] = $attemptId;
+
+            DB::table('events')->insert([
+                'id' => (string) Str::uuid(),
+                'event_code' => 'result_view',
+                'event_name' => 'result_view',
+                'org_id' => $orgId,
+                'user_id' => null,
+                'anon_id' => 'fer2_kpi_anon_'.$i,
+                'session_id' => null,
+                'request_id' => null,
+                'attempt_id' => $attemptId,
+                'meta_json' => json_encode(['attempt_id' => $attemptId], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES),
+                'experiments_json' => json_encode([$experimentKey => $variant], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES),
+                'occurred_at' => $baseTs,
+                'created_at' => $baseTs,
+                'updated_at' => $baseTs,
+            ]);
+        }
+
+        for ($i = 0; $i < $paidAttempts; $i++) {
+            $attemptId = $attemptIds[$i] ?? null;
+            if (! is_string($attemptId) || $attemptId === '') {
+                continue;
+            }
+
+            $orderNo = 'FER2KPI'.str_pad((string) ($i + 1), 4, '0', STR_PAD_LEFT);
+
+            $orderId = (string) Str::uuid();
+
+            DB::table('orders')->insert([
+                'id' => $orderId,
+                'order_no' => $orderNo,
+                'org_id' => $orgId,
+                'user_id' => null,
+                'anon_id' => 'fer2_kpi_order_'.$i,
+                'sku' => 'mbti_report',
+                'item_sku' => 'mbti_report',
+                'quantity' => 1,
+                'target_attempt_id' => $attemptId,
+                'amount_cents' => 999,
+                'amount_total' => 999,
+                'amount_refunded' => 0,
+                'currency' => 'USD',
+                'status' => 'paid',
+                'provider' => 'stripe',
+                'external_trade_no' => null,
+                'paid_at' => now()->subMinutes(8),
+                'created_at' => now()->subMinutes(9),
+                'updated_at' => now()->subMinutes(8),
+            ]);
+
+            DB::table('payment_events')->insert([
+                'id' => (string) Str::uuid(),
+                'org_id' => $orgId,
+                'provider' => 'stripe',
+                'provider_event_id' => 'evt_fer2_kpi_'.$i,
+                'order_id' => $orderId,
+                'order_no' => $orderNo,
+                'event_type' => 'checkout.paid',
+                'payload_json' => '{}',
+                'signature_ok' => true,
+                'received_at' => now()->subMinutes(8),
+                'status' => 'processed',
+                'processed_at' => now()->subMinutes(8),
+                'attempts' => 1,
+                'last_error_code' => null,
+                'last_error_message' => null,
+                'reason' => null,
+                'created_at' => now()->subMinutes(8),
+                'updated_at' => now()->subMinutes(8),
+            ]);
+        }
+
+        for ($i = 0; $i < $readyReports; $i++) {
+            $attemptId = $attemptIds[$i] ?? null;
+            if (! is_string($attemptId) || $attemptId === '') {
+                continue;
+            }
+
+            DB::table('report_snapshots')->insert([
+                'org_id' => $orgId,
+                'attempt_id' => $attemptId,
+                'order_no' => null,
+                'scale_code' => 'MBTI',
+                'pack_id' => 'MBTI.cn-mainland.zh-CN.v0.3',
+                'dir_version' => 'MBTI-CN-v0.3',
+                'scoring_spec_version' => 'mbti_spec_fer2_20',
+                'report_engine_version' => 'v1.2',
+                'snapshot_version' => 'v1',
+                'report_json' => '{}',
+                'status' => 'ready',
+                'last_error' => null,
+                'created_at' => now()->subMinutes(7),
+                'updated_at' => now()->subMinutes(7),
+            ]);
+        }
+    }
+}


### PR DESCRIPTION
Fixes FER2-20

Summary
- add `ExperimentKpiEvaluator` to aggregate conversion KPI metrics from `events`, `orders`, `payment_events`, and `report_snapshots`
- bridge KPI output directly into `ExperimentGovernanceService::evaluateGuardrails` for automatic pause/rollback decisions
- add `ops:experiment-guardrails-evaluate` command to trigger guardrail evaluation for one rollout or all active rollouts
- register the new command in console kernel and add a feature test covering conversion_rate computation + auto rollback trigger

Verification
- php artisan test --filter='ExperimentKpiEvaluatorBridgeTest'
- php artisan test --filter='ExperimentGuardrailAutoRollbackTest'
- bash backend/scripts/ci_verify_mbti.sh
