### PR TITLE
Fixes FER2-21: add PII key_version schema and compatible writes

### DIFF
--- a/backend/app/Http/Controllers/API/V0_3/AuthPhoneController.php
+++ b/backend/app/Http/Controllers/API/V0_3/AuthPhoneController.php
@@ -281,6 +281,7 @@ class AuthPhoneController extends Controller
         $phoneCol = $hasPhoneE164 ? 'phone_e164' : ($hasPhone ? 'phone' : null);
         $phoneHash = $pii->phoneHash($phoneE164);
         $phoneEnc = $pii->encrypt($phoneE164);
+        $keyVersion = $pii->currentKeyVersion();
 
         $query = DB::table('users');
         if ($hasPhoneHash) {
@@ -315,6 +316,9 @@ class AuthPhoneController extends Controller
         }
         if ($hasPhoneEnc) {
             $insert['phone_e164_enc'] = $phoneEnc;
+        }
+        if (\App\Support\SchemaBaseline::hasColumn('users', 'key_version')) {
+            $insert['key_version'] = $keyVersion;
         }
 
         if ($anonId && \App\Support\SchemaBaseline::hasColumn('users', 'anon_id')) {

--- a/backend/app/Jobs/Ops/BackfillPiiEncryptionJob.php
+++ b/backend/app/Jobs/Ops/BackfillPiiEncryptionJob.php
@@ -90,13 +90,14 @@ class BackfillPiiEncryptionJob implements ShouldQueue
         $hasEmailEnc = Schema::hasColumn('users', 'email_enc');
         $hasPhoneHash = Schema::hasColumn('users', 'phone_e164_hash');
         $hasPhoneEnc = Schema::hasColumn('users', 'phone_e164_enc');
+        $hasKeyVersion = Schema::hasColumn('users', 'key_version');
         $hasMigratedAt = Schema::hasColumn('users', 'pii_migrated_at');
 
         if (! $hasEmailHash && ! $hasEmailEnc && ! $hasPhoneHash && ! $hasPhoneEnc) {
             return ['scanned' => 0, 'updated' => 0, 'chunks' => 0, 'last_id' => 0];
         }
 
-        [$lastId] = $this->loadState('pii_backfill_users_v1');
+        [$lastId] = $this->loadState('pii_backfill_users_v2');
         $nextId = max(0, (int) $lastId);
 
         $scanned = 0;
@@ -116,9 +117,14 @@ class BackfillPiiEncryptionJob implements ShouldQueue
         if ($hasPhoneEnc) {
             $select[] = 'phone_e164_enc';
         }
+        if ($hasKeyVersion) {
+            $select[] = 'key_version';
+        }
         if ($hasMigratedAt) {
             $select[] = 'pii_migrated_at';
         }
+
+        $keyVersion = $cipher->currentKeyVersion();
 
         do {
             $rows = DB::table('users')
@@ -161,6 +167,18 @@ class BackfillPiiEncryptionJob implements ShouldQueue
                     }
                 }
 
+                if ($hasKeyVersion && $this->isMissingKeyVersion($row->key_version ?? null)) {
+                    $hasAnyPii =
+                        ($hasEmailHash && ! $this->isBlank($updates['email_hash'] ?? ($row->email_hash ?? null)))
+                        || ($hasEmailEnc && ! $this->isBlank($updates['email_enc'] ?? ($row->email_enc ?? null)))
+                        || ($hasPhoneHash && ! $this->isBlank($updates['phone_e164_hash'] ?? ($row->phone_e164_hash ?? null)))
+                        || ($hasPhoneEnc && ! $this->isBlank($updates['phone_e164_enc'] ?? ($row->phone_e164_enc ?? null)));
+
+                    if ($hasAnyPii) {
+                        $updates['key_version'] = $keyVersion;
+                    }
+                }
+
                 if ($hasMigratedAt && $row->pii_migrated_at === null) {
                     $emailHash = (string) ($updates['email_hash'] ?? ($row->email_hash ?? ''));
                     $emailEnc = (string) ($updates['email_enc'] ?? ($row->email_enc ?? ''));
@@ -189,7 +207,7 @@ class BackfillPiiEncryptionJob implements ShouldQueue
             }
 
             $chunks++;
-            $this->persistState('pii_backfill_users_v1', $nextId, null);
+            $this->persistState('pii_backfill_users_v2', $nextId, null);
             $this->sleepBetweenChunks();
         } while (true);
 
@@ -216,6 +234,7 @@ class BackfillPiiEncryptionJob implements ShouldQueue
         $hasToEmailEnc = Schema::hasColumn('email_outbox', 'to_email_enc');
         $hasPayloadEnc = Schema::hasColumn('email_outbox', 'payload_enc');
         $hasPayloadVersion = Schema::hasColumn('email_outbox', 'payload_schema_version');
+        $hasKeyVersion = Schema::hasColumn('email_outbox', 'key_version');
         $hasToEmail = Schema::hasColumn('email_outbox', 'to_email');
         $hasPayloadJson = Schema::hasColumn('email_outbox', 'payload_json');
 
@@ -223,7 +242,7 @@ class BackfillPiiEncryptionJob implements ShouldQueue
             return ['scanned' => 0, 'updated' => 0, 'chunks' => 0, 'last_cursor' => ''];
         }
 
-        [, $lastCursor] = $this->loadState('pii_backfill_email_outbox_v1');
+        [, $lastCursor] = $this->loadState('pii_backfill_email_outbox_v2');
         $cursor = $lastCursor !== null ? trim($lastCursor) : '';
 
         $scanned = 0;
@@ -255,6 +274,11 @@ class BackfillPiiEncryptionJob implements ShouldQueue
         if ($hasPayloadVersion) {
             $select[] = 'payload_schema_version';
         }
+        if ($hasKeyVersion) {
+            $select[] = 'key_version';
+        }
+
+        $keyVersion = $cipher->currentKeyVersion();
 
         do {
             $query = DB::table('email_outbox')
@@ -316,6 +340,19 @@ class BackfillPiiEncryptionJob implements ShouldQueue
                     $updates['payload_schema_version'] = 'v1-json-enc';
                 }
 
+                if ($hasKeyVersion && $this->isMissingKeyVersion($row->key_version ?? null)) {
+                    $hasAnyPii =
+                        ($hasEmailHash && ! $this->isBlank($updates['email_hash'] ?? ($row->email_hash ?? null)))
+                        || ($hasEmailEnc && ! $this->isBlank($updates['email_enc'] ?? ($row->email_enc ?? null)))
+                        || ($hasToEmailHash && ! $this->isBlank($updates['to_email_hash'] ?? ($row->to_email_hash ?? null)))
+                        || ($hasToEmailEnc && ! $this->isBlank($updates['to_email_enc'] ?? ($row->to_email_enc ?? null)))
+                        || ($hasPayloadEnc && ! $this->isBlank($updates['payload_enc'] ?? ($row->payload_enc ?? null)));
+
+                    if ($hasAnyPii) {
+                        $updates['key_version'] = $keyVersion;
+                    }
+                }
+
                 if ($updates === []) {
                     continue;
                 }
@@ -330,7 +367,7 @@ class BackfillPiiEncryptionJob implements ShouldQueue
             }
 
             $chunks++;
-            $this->persistState('pii_backfill_email_outbox_v1', 0, $cursor);
+            $this->persistState('pii_backfill_email_outbox_v2', 0, $cursor);
             $this->sleepBetweenChunks();
         } while (true);
 
@@ -416,6 +453,16 @@ class BackfillPiiEncryptionJob implements ShouldQueue
     private function isBlank(mixed $value): bool
     {
         return trim((string) ($value ?? '')) === '';
+    }
+
+    private function isMissingKeyVersion(mixed $value): bool
+    {
+        $normalized = trim((string) ($value ?? ''));
+        if ($normalized === '') {
+            return true;
+        }
+
+        return (int) $normalized <= 0;
     }
 
     private function normalizePayloadJson(mixed $payload): ?string

--- a/backend/app/Services/Email/EmailOutboxService.php
+++ b/backend/app/Services/Email/EmailOutboxService.php
@@ -35,6 +35,7 @@ class EmailOutboxService
 
         $emailHash = $this->piiCipher->emailHash($email);
         $emailEnc = $this->piiCipher->encrypt($email);
+        $keyVersion = $this->piiCipher->currentKeyVersion();
         $maskedEmail = $this->maskedLegacyEmail($emailHash);
 
         $token = 'claim_'.(string) Str::uuid();
@@ -99,6 +100,9 @@ class EmailOutboxService
             if (\App\Support\SchemaBaseline::hasColumn('email_outbox', 'payload_schema_version')) {
                 $update['payload_schema_version'] = 'v1';
             }
+            if (\App\Support\SchemaBaseline::hasColumn('email_outbox', 'key_version')) {
+                $update['key_version'] = $keyVersion;
+            }
             if (\App\Support\SchemaBaseline::hasColumn('email_outbox', 'locale')) {
                 $update['locale'] = $locale;
             }
@@ -160,6 +164,9 @@ class EmailOutboxService
         if (\App\Support\SchemaBaseline::hasColumn('email_outbox', 'payload_schema_version')) {
             $row['payload_schema_version'] = 'v1';
         }
+        if (\App\Support\SchemaBaseline::hasColumn('email_outbox', 'key_version')) {
+            $row['key_version'] = $keyVersion;
+        }
 
         if (\App\Support\SchemaBaseline::hasColumn('email_outbox', 'locale')) {
             $row['locale'] = $locale;
@@ -214,6 +221,7 @@ class EmailOutboxService
 
         $emailHash = $this->piiCipher->emailHash($email);
         $emailEnc = $this->piiCipher->encrypt($email);
+        $keyVersion = $this->piiCipher->currentKeyVersion();
         $maskedEmail = $this->maskedLegacyEmail($emailHash);
 
         $locale = $this->resolveAttemptLocale($attemptId);
@@ -274,6 +282,9 @@ class EmailOutboxService
             if (\App\Support\SchemaBaseline::hasColumn('email_outbox', 'payload_schema_version')) {
                 $update['payload_schema_version'] = 'v1';
             }
+            if (\App\Support\SchemaBaseline::hasColumn('email_outbox', 'key_version')) {
+                $update['key_version'] = $keyVersion;
+            }
             if (\App\Support\SchemaBaseline::hasColumn('email_outbox', 'locale')) {
                 $update['locale'] = $locale;
             }
@@ -328,6 +339,9 @@ class EmailOutboxService
         }
         if (\App\Support\SchemaBaseline::hasColumn('email_outbox', 'payload_schema_version')) {
             $row['payload_schema_version'] = 'v1';
+        }
+        if (\App\Support\SchemaBaseline::hasColumn('email_outbox', 'key_version')) {
+            $row['key_version'] = $keyVersion;
         }
         if (\App\Support\SchemaBaseline::hasColumn('email_outbox', 'locale')) {
             $row['locale'] = $locale;

--- a/backend/app/Services/Legacy/LegacyMeFacadeService.php
+++ b/backend/app/Services/Legacy/LegacyMeFacadeService.php
@@ -13,7 +13,6 @@ use App\Support\PiiCipher;
 use Illuminate\Contracts\Cache\Repository as CacheRepository;
 use Illuminate\Contracts\Mail\Factory as MailFactory;
 use Illuminate\Support\Facades\DB;
-use Illuminate\Support\Facades\Schema;
 use Illuminate\Support\Str;
 use Psr\Log\LoggerInterface;
 
@@ -29,8 +28,7 @@ class LegacyMeFacadeService
         private readonly MailFactory $mailer,
         private readonly CacheRepository $cache,
         private readonly PiiCipher $piiCipher,
-    ) {
-    }
+    ) {}
 
     public function listAttempts(int $pageSize, int $page = 1): array
     {
@@ -57,13 +55,14 @@ class LegacyMeFacadeService
             throw new ApiProblemException(401, 'UNAUTHORIZED', 'Missing or invalid fm_token.');
         }
 
-        if (!\App\Support\SchemaBaseline::hasTable('users') || !\App\Support\SchemaBaseline::hasColumn('users', 'email')) {
+        if (! \App\Support\SchemaBaseline::hasTable('users') || ! \App\Support\SchemaBaseline::hasColumn('users', 'email')) {
             throw new ApiProblemException(500, 'INVALID_SCHEMA', 'users.email column not found.');
         }
 
         $pk = \App\Support\SchemaBaseline::hasColumn('users', 'uid') ? 'uid' : 'id';
         $emailHash = $this->piiCipher->emailHash($email);
         $emailEnc = $this->piiCipher->encrypt($email);
+        $keyVersion = $this->piiCipher->currentKeyVersion();
 
         $existsQuery = DB::table('users')->where($pk, '!=', (string) $userId);
         if (\App\Support\SchemaBaseline::hasColumn('users', 'email_hash')) {
@@ -87,6 +86,9 @@ class LegacyMeFacadeService
         }
         if (\App\Support\SchemaBaseline::hasColumn('users', 'email_enc')) {
             $update['email_enc'] = $emailEnc;
+        }
+        if (\App\Support\SchemaBaseline::hasColumn('users', 'key_version')) {
+            $update['key_version'] = $keyVersion;
         }
         if (\App\Support\SchemaBaseline::hasColumn('users', 'email_verified_at')) {
             $update['email_verified_at'] = now();
@@ -120,7 +122,7 @@ class LegacyMeFacadeService
             ]
         );
 
-        if (!($identity['ok'] ?? false)) {
+        if (! ($identity['ok'] ?? false)) {
             $error = (string) ($identity['error'] ?? 'IDENTITY_BIND_FAILED');
             if ($error === 'IDENTITY_CONFLICT') {
                 throw new ApiProblemException(422, 'EMAIL_IN_USE', 'email already in use.');
@@ -133,7 +135,7 @@ class LegacyMeFacadeService
             throw new ApiProblemException((int) ($identity['status'] ?? 422), 'IDENTITY_BIND_FAILED', (string) ($identity['message'] ?? 'identity bind failed.'));
         }
 
-        $token = 'email_bind_' . (string) Str::uuid();
+        $token = 'email_bind_'.(string) Str::uuid();
         $this->cache->put($this->verifyCacheKey($token), [
             'user_id' => (string) $userId,
             'email' => $email,
@@ -159,7 +161,7 @@ class LegacyMeFacadeService
         $key = $this->verifyCacheKey($token);
         $payload = $this->cache->get($key);
 
-        if (!is_array($payload)) {
+        if (! is_array($payload)) {
             throw new ApiProblemException(422, 'INVALID_TOKEN', 'verification token invalid.');
         }
 
@@ -233,6 +235,6 @@ class LegacyMeFacadeService
 
     private function verifyCacheKey(string $token): string
     {
-        return 'email_binding_verify:' . hash('sha256', $token);
+        return 'email_binding_verify:'.hash('sha256', $token);
     }
 }

--- a/backend/app/Services/V0_3/MeFacadeService.php
+++ b/backend/app/Services/V0_3/MeFacadeService.php
@@ -13,7 +13,6 @@ use App\Support\PiiCipher;
 use Illuminate\Contracts\Cache\Repository as CacheRepository;
 use Illuminate\Contracts\Mail\Factory as MailFactory;
 use Illuminate\Support\Facades\DB;
-use Illuminate\Support\Facades\Schema;
 use Illuminate\Support\Str;
 use Psr\Log\LoggerInterface;
 
@@ -29,8 +28,7 @@ class MeFacadeService
         private readonly MailFactory $mailer,
         private readonly CacheRepository $cache,
         private readonly PiiCipher $piiCipher,
-    ) {
-    }
+    ) {}
 
     public function listAttempts(int $pageSize, int $page = 1, ?string $scaleCode = null): array
     {
@@ -58,13 +56,14 @@ class MeFacadeService
             throw new ApiProblemException(401, 'UNAUTHORIZED', 'Missing or invalid fm_token.');
         }
 
-        if (!\App\Support\SchemaBaseline::hasTable('users') || !\App\Support\SchemaBaseline::hasColumn('users', 'email')) {
+        if (! \App\Support\SchemaBaseline::hasTable('users') || ! \App\Support\SchemaBaseline::hasColumn('users', 'email')) {
             throw new ApiProblemException(500, 'INVALID_SCHEMA', 'users.email column not found.');
         }
 
         $pk = \App\Support\SchemaBaseline::hasColumn('users', 'uid') ? 'uid' : 'id';
         $emailHash = $this->piiCipher->emailHash($email);
         $emailEnc = $this->piiCipher->encrypt($email);
+        $keyVersion = $this->piiCipher->currentKeyVersion();
 
         $existsQuery = DB::table('users')->where($pk, '!=', (string) $userId);
         if (\App\Support\SchemaBaseline::hasColumn('users', 'email_hash')) {
@@ -88,6 +87,9 @@ class MeFacadeService
         }
         if (\App\Support\SchemaBaseline::hasColumn('users', 'email_enc')) {
             $update['email_enc'] = $emailEnc;
+        }
+        if (\App\Support\SchemaBaseline::hasColumn('users', 'key_version')) {
+            $update['key_version'] = $keyVersion;
         }
         if (\App\Support\SchemaBaseline::hasColumn('users', 'email_verified_at')) {
             $update['email_verified_at'] = now();
@@ -121,7 +123,7 @@ class MeFacadeService
             ]
         );
 
-        if (!($identity['ok'] ?? false)) {
+        if (! ($identity['ok'] ?? false)) {
             $error = (string) ($identity['error'] ?? 'IDENTITY_BIND_FAILED');
             if ($error === 'IDENTITY_CONFLICT') {
                 throw new ApiProblemException(422, 'EMAIL_IN_USE', 'email already in use.');
@@ -134,7 +136,7 @@ class MeFacadeService
             throw new ApiProblemException((int) ($identity['status'] ?? 422), 'IDENTITY_BIND_FAILED', (string) ($identity['message'] ?? 'identity bind failed.'));
         }
 
-        $token = 'email_bind_' . (string) Str::uuid();
+        $token = 'email_bind_'.(string) Str::uuid();
         $this->cache->put($this->verifyCacheKey($token), [
             'user_id' => (string) $userId,
             'email' => $email,
@@ -160,7 +162,7 @@ class MeFacadeService
         $key = $this->verifyCacheKey($token);
         $payload = $this->cache->get($key);
 
-        if (!is_array($payload)) {
+        if (! is_array($payload)) {
             throw new ApiProblemException(422, 'INVALID_TOKEN', 'verification token invalid.');
         }
 
@@ -234,6 +236,6 @@ class MeFacadeService
 
     private function verifyCacheKey(string $token): string
     {
-        return 'email_binding_verify:' . hash('sha256', $token);
+        return 'email_binding_verify:'.hash('sha256', $token);
     }
 }

--- a/backend/app/Support/PiiCipher.php
+++ b/backend/app/Support/PiiCipher.php
@@ -10,6 +10,13 @@ final class PiiCipher
 {
     private const PLACEHOLDER_DOMAIN = 'privacy.local';
 
+    public function currentKeyVersion(): int
+    {
+        $version = (int) config('services.pii.key_version', 1);
+
+        return $version > 0 ? $version : 1;
+    }
+
     public function normalizeEmail(string $email): string
     {
         return mb_strtolower(trim($email), 'UTF-8');
@@ -65,13 +72,13 @@ final class PiiCipher
             $prefix = 'unknown';
         }
 
-        return 'redacted+' . $prefix . '@' . self::PLACEHOLDER_DOMAIN;
+        return 'redacted+'.$prefix.'@'.self::PLACEHOLDER_DOMAIN;
     }
 
     private function hash(string $value, string $namespace): string
     {
         $salt = (string) config('app.key', 'fap-key');
 
-        return hash_hmac('sha256', $namespace . '|' . $value, $salt);
+        return hash_hmac('sha256', $namespace.'|'.$value, $salt);
     }
 }

--- a/backend/config/services.php
+++ b/backend/config/services.php
@@ -138,4 +138,8 @@ return [
         ],
     ],
 
+    'pii' => [
+        'key_version' => (int) env('PII_KEY_VERSION', 1),
+    ],
+
 ];

--- a/backend/database/migrations/2026_02_27_170000_add_key_version_to_users_and_email_outbox.php
+++ b/backend/database/migrations/2026_02_27_170000_add_key_version_to_users_and_email_outbox.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        $this->migrateUsers();
+        $this->migrateEmailOutbox();
+    }
+
+    public function down(): void
+    {
+        // forward-only migration: rollback disabled to prevent data loss in production.
+        // Irreversible operation: schema/data rollback handled via forward fix migrations.
+    }
+
+    private function migrateUsers(): void
+    {
+        if (! Schema::hasTable('users')) {
+            return;
+        }
+
+        Schema::table('users', function (Blueprint $table): void {
+            if (! Schema::hasColumn('users', 'key_version')) {
+                $table->unsignedSmallInteger('key_version')->nullable();
+            }
+        });
+    }
+
+    private function migrateEmailOutbox(): void
+    {
+        if (! Schema::hasTable('email_outbox')) {
+            return;
+        }
+
+        Schema::table('email_outbox', function (Blueprint $table): void {
+            if (! Schema::hasColumn('email_outbox', 'key_version')) {
+                $table->unsignedSmallInteger('key_version')->nullable();
+            }
+        });
+    }
+};

--- a/backend/tests/Feature/Ops/BackfillPiiEncryptionCommandTest.php
+++ b/backend/tests/Feature/Ops/BackfillPiiEncryptionCommandTest.php
@@ -7,6 +7,7 @@ namespace Tests\Feature\Ops;
 use App\Support\PiiCipher;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
 use Tests\TestCase;
 
 final class BackfillPiiEncryptionCommandTest extends TestCase
@@ -56,6 +57,9 @@ final class BackfillPiiEncryptionCommandTest extends TestCase
         $this->assertSame($pii->phoneHash('+15551230000'), (string) ($user->phone_e164_hash ?? ''));
         $this->assertSame('Backfill.User@example.com', $pii->decrypt((string) ($user->email_enc ?? '')));
         $this->assertSame('+15551230000', $pii->decrypt((string) ($user->phone_e164_enc ?? '')));
+        if (Schema::hasColumn('users', 'key_version')) {
+            $this->assertSame($pii->currentKeyVersion(), (int) ($user->key_version ?? 0));
+        }
         $this->assertNotNull($user->pii_migrated_at ?? null);
 
         $outbox = DB::table('email_outbox')->where('id', $outboxId)->first();
@@ -65,6 +69,9 @@ final class BackfillPiiEncryptionCommandTest extends TestCase
         $this->assertSame('Backfill.User@example.com', $pii->decrypt((string) ($outbox->email_enc ?? '')));
         $this->assertSame('receiver@example.com', $pii->decrypt((string) ($outbox->to_email_enc ?? '')));
         $this->assertSame('v1-json-enc', (string) ($outbox->payload_schema_version ?? ''));
+        if (Schema::hasColumn('email_outbox', 'key_version')) {
+            $this->assertSame($pii->currentKeyVersion(), (int) ($outbox->key_version ?? 0));
+        }
         $payloadDecoded = $pii->decrypt((string) ($outbox->payload_enc ?? ''));
         $this->assertIsString($payloadDecoded);
         $this->assertTrue(str_contains((string) $payloadDecoded, '"attempt_id":"attempt_demo_1"'));
@@ -81,11 +88,11 @@ final class BackfillPiiEncryptionCommandTest extends TestCase
         $this->assertSame((string) ($outbox->to_email_hash ?? ''), (string) ($outboxAgain->to_email_hash ?? ''));
 
         $keys = DB::table('migration_backfills')
-            ->whereIn('key', ['pii_backfill_users_v1', 'pii_backfill_email_outbox_v1'])
+            ->whereIn('key', ['pii_backfill_users_v2', 'pii_backfill_email_outbox_v2'])
             ->pluck('key')
             ->all();
 
-        $this->assertContains('pii_backfill_users_v1', $keys);
-        $this->assertContains('pii_backfill_email_outbox_v1', $keys);
+        $this->assertContains('pii_backfill_users_v2', $keys);
+        $this->assertContains('pii_backfill_email_outbox_v2', $keys);
     }
 }

--- a/backend/tests/Feature/V0_3/PiiKeyVersionCompatibilityTest.php
+++ b/backend/tests/Feature/V0_3/PiiKeyVersionCompatibilityTest.php
@@ -1,0 +1,124 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\V0_3;
+
+use App\Services\Email\EmailOutboxService;
+use App\Support\PiiCipher;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Support\Str;
+use Tests\TestCase;
+
+final class PiiKeyVersionCompatibilityTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_new_pii_writes_include_key_version(): void
+    {
+        $phone = '+86139'.str_pad((string) random_int(0, 99999999), 8, '0', STR_PAD_LEFT);
+
+        $send = $this->postJson('/api/v0.3/auth/phone/send_code', [
+            'phone' => $phone,
+            'consent' => true,
+        ]);
+        $send->assertOk();
+
+        $verify = $this->postJson('/api/v0.3/auth/phone/verify', [
+            'phone' => $phone,
+            'code' => (string) $send->json('dev_code', ''),
+            'consent' => true,
+            'scene' => 'login',
+            'anon_id' => 'pii-key-version-test',
+        ]);
+        $verify->assertOk();
+
+        $this->assertTrue(Schema::hasColumn('users', 'key_version'));
+        $user = DB::table('users')->orderByDesc('id')->first();
+        $this->assertNotNull($user);
+
+        $pii = app(PiiCipher::class);
+        $expectedKeyVersion = $pii->currentKeyVersion();
+        $this->assertSame($expectedKeyVersion, (int) ($user->key_version ?? 0));
+
+        $attemptId = (string) Str::uuid();
+        DB::table('attempts')->insert([
+            'id' => $attemptId,
+            'ticket_code' => 'FMT-'.strtoupper(substr(str_replace('-', '', (string) Str::uuid()), 0, 8)),
+            'org_id' => 0,
+            'anon_id' => 'anon_pii_key_version',
+            'user_id' => null,
+            'scale_code' => 'MBTI',
+            'scale_version' => 'v0.3',
+            'region' => 'CN_MAINLAND',
+            'locale' => 'zh-CN',
+            'question_count' => 144,
+            'answers_summary_json' => json_encode(['seed' => true], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES),
+            'client_platform' => 'test',
+            'client_version' => '1.0.0',
+            'channel' => 'test',
+            'started_at' => now()->subMinute(),
+            'submitted_at' => now(),
+            'pack_id' => (string) config('content_packs.default_pack_id'),
+            'dir_version' => (string) config('content_packs.default_dir_version'),
+            'content_package_version' => 'v0.3',
+            'scoring_spec_version' => '2026.01',
+            'calculation_snapshot_json' => json_encode(['seed' => true], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES),
+            'created_at' => now(),
+            'updated_at' => now(),
+        ]);
+
+        $email = 'buyer+'.random_int(1000, 9999).'@example.com';
+        $queued = app(EmailOutboxService::class)->queueReportClaim((string) ($user->id ?? ''), $email, $attemptId);
+        $this->assertTrue((bool) ($queued['ok'] ?? false));
+
+        $this->assertTrue(Schema::hasColumn('email_outbox', 'key_version'));
+        $outbox = DB::table('email_outbox')
+            ->where('attempt_id', $attemptId)
+            ->where('template', 'report_claim')
+            ->orderByDesc('updated_at')
+            ->first();
+        $this->assertNotNull($outbox);
+        $this->assertSame($expectedKeyVersion, (int) ($outbox->key_version ?? 0));
+    }
+
+    public function test_claim_report_read_path_supports_legacy_null_key_version(): void
+    {
+        $this->assertTrue(Schema::hasColumn('email_outbox', 'key_version'));
+
+        $pii = app(PiiCipher::class);
+        $attemptId = (string) Str::uuid();
+        $token = 'claim_'.(string) Str::uuid();
+        $tokenHash = hash('sha256', $token);
+        $email = 'legacy-key-version@example.com';
+
+        DB::table('email_outbox')->insert([
+            'id' => (string) Str::uuid(),
+            'user_id' => 'legacy-key-version-user',
+            'email' => $pii->legacyEmailPlaceholder($pii->emailHash($email)),
+            'email_hash' => $pii->emailHash($email),
+            'email_enc' => $pii->encrypt($email),
+            'to_email_hash' => $pii->emailHash($email),
+            'to_email_enc' => $pii->encrypt($email),
+            'payload_json' => json_encode(['attempt_id' => $attemptId], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES),
+            'payload_enc' => $pii->encrypt(json_encode([
+                'attempt_id' => $attemptId,
+                'report_url' => "/api/v0.3/attempts/{$attemptId}/report",
+            ], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES)),
+            'payload_schema_version' => 'v1',
+            'key_version' => null,
+            'template' => 'report_claim',
+            'claim_token_hash' => $tokenHash,
+            'claim_expires_at' => now()->addMinutes(15),
+            'status' => 'pending',
+            'created_at' => now(),
+            'updated_at' => now(),
+        ]);
+
+        $claimed = app(EmailOutboxService::class)->claimReport($token);
+        $this->assertTrue((bool) ($claimed['ok'] ?? false));
+        $this->assertSame($attemptId, (string) ($claimed['attempt_id'] ?? ''));
+    }
+}


### PR DESCRIPTION
Fixes FER2-21

Summary
- add forward-only migration to append nullable `key_version` to `users` and `email_outbox`
- add `PiiCipher::currentKeyVersion()` (default from `services.pii.key_version`, fallback `1`) and wire all PII write paths to persist key version
- extend backfill job to fill missing key versions for existing encrypted rows and bump state keys to v2 for re-runs
- add compatibility coverage to ensure null `key_version` legacy rows remain readable and new writes carry key version

Verification
- php artisan migrate --force
- php artisan test --filter='PiiKeyVersionCompatibilityTest'
- php artisan test --filter='BackfillPiiEncryptionCommandTest'
- php artisan test --filter='AuthPhoneNoPlaintextWriteTest'
- php artisan test --filter='EmailOutboxNoPlaintextPayloadTest'
- bash backend/scripts/ci_verify_mbti.sh
