### PR TITLE
Fixes FER2-22: add envelope encryption adapter for PII cipher

### DIFF
--- a/backend/app/Contracts/Security/PiiEnvelopeAdapter.php
+++ b/backend/app/Contracts/Security/PiiEnvelopeAdapter.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Contracts\Security;
+
+interface PiiEnvelopeAdapter
+{
+    public function encrypt(string $plaintext): string;
+
+    public function decrypt(string $ciphertext): ?string;
+}

--- a/backend/app/Providers/AppServiceProvider.php
+++ b/backend/app/Providers/AppServiceProvider.php
@@ -2,6 +2,7 @@
 
 namespace App\Providers;
 
+use App\Contracts\Security\PiiEnvelopeAdapter;
 use App\Livewire\Filament\Ops\Livewire\CurrentOrgSwitcher;
 use App\Livewire\Filament\Ops\Livewire\LocaleSwitcher;
 use App\Models\AdminApproval;
@@ -28,6 +29,7 @@ use App\Services\Content\ContentStore;
 use App\Services\ContentPackResolver;
 use App\Support\Logging\RedactProcessor;
 use App\Support\OrgContext;
+use App\Support\Security\LocalPiiEnvelopeAdapter;
 use Illuminate\Auth\Events\Failed;
 use Illuminate\Auth\Events\Login;
 use Illuminate\Cache\RateLimiting\Limit;
@@ -52,6 +54,8 @@ class AppServiceProvider extends ServiceProvider
      */
     public function register(): void
     {
+        $this->app->singleton(PiiEnvelopeAdapter::class, LocalPiiEnvelopeAdapter::class);
+
         // Bind ContentPackResolver so app(ContentPackResolver::class) works everywhere.
         $this->app->singleton(ContentPackResolver::class, function () {
             return new ContentPackResolver;

--- a/backend/app/Support/PiiCipher.php
+++ b/backend/app/Support/PiiCipher.php
@@ -4,11 +4,20 @@ declare(strict_types=1);
 
 namespace App\Support;
 
+use App\Contracts\Security\PiiEnvelopeAdapter;
 use Illuminate\Support\Facades\Crypt;
 
 final class PiiCipher
 {
     private const PLACEHOLDER_DOMAIN = 'privacy.local';
+
+    private const DEFAULT_KEY_ID = 'local-app-key';
+
+    private const DEFAULT_ALGO = 'laravel-crypt-v1';
+
+    public function __construct(
+        private readonly PiiEnvelopeAdapter $envelopeAdapter,
+    ) {}
 
     public function currentKeyVersion(): int
     {
@@ -44,7 +53,19 @@ final class PiiCipher
             return null;
         }
 
-        return Crypt::encryptString($normalized);
+        $envelope = [
+            'ciphertext' => $this->envelopeAdapter->encrypt($normalized),
+            'key_id' => $this->currentKeyId(),
+            'key_version' => $this->currentKeyVersion(),
+            'algo' => $this->currentAlgo(),
+        ];
+
+        $encoded = json_encode($envelope, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES);
+        if (! is_string($encoded) || trim($encoded) === '') {
+            return (string) $envelope['ciphertext'];
+        }
+
+        return $encoded;
     }
 
     public function decrypt(?string $ciphertext): ?string
@@ -54,9 +75,20 @@ final class PiiCipher
             return null;
         }
 
-        try {
-            $plaintext = Crypt::decryptString($ciphertext);
-        } catch (\Throwable) {
+        $envelope = $this->decodeEnvelope($ciphertext);
+        if ($envelope !== null) {
+            $plaintext = $this->envelopeAdapter->decrypt((string) $envelope['ciphertext']);
+            if ($plaintext === null) {
+                $plaintext = $this->decryptLegacyCiphertext((string) $envelope['ciphertext']);
+            }
+        } else {
+            $plaintext = $this->envelopeAdapter->decrypt($ciphertext);
+            if ($plaintext === null) {
+                $plaintext = $this->decryptLegacyCiphertext($ciphertext);
+            }
+        }
+
+        if ($plaintext === null) {
             return null;
         }
 
@@ -80,5 +112,55 @@ final class PiiCipher
         $salt = (string) config('app.key', 'fap-key');
 
         return hash_hmac('sha256', $namespace.'|'.$value, $salt);
+    }
+
+    private function currentKeyId(): string
+    {
+        $keyId = trim((string) config('services.pii.key_id', self::DEFAULT_KEY_ID));
+
+        return $keyId !== '' ? $keyId : self::DEFAULT_KEY_ID;
+    }
+
+    private function currentAlgo(): string
+    {
+        $algo = trim((string) config('services.pii.algo', self::DEFAULT_ALGO));
+
+        return $algo !== '' ? $algo : self::DEFAULT_ALGO;
+    }
+
+    /**
+     * @return array{ciphertext:string,key_id:string,key_version:int,algo:string}|null
+     */
+    private function decodeEnvelope(string $value): ?array
+    {
+        $decoded = json_decode($value, true);
+        if (! is_array($decoded)) {
+            return null;
+        }
+
+        $ciphertext = trim((string) ($decoded['ciphertext'] ?? ''));
+        $keyId = trim((string) ($decoded['key_id'] ?? ''));
+        $algo = trim((string) ($decoded['algo'] ?? ''));
+        $keyVersion = (int) ($decoded['key_version'] ?? 0);
+
+        if ($ciphertext === '' || $keyId === '' || $algo === '' || $keyVersion <= 0) {
+            return null;
+        }
+
+        return [
+            'ciphertext' => $ciphertext,
+            'key_id' => $keyId,
+            'key_version' => $keyVersion,
+            'algo' => $algo,
+        ];
+    }
+
+    private function decryptLegacyCiphertext(string $ciphertext): ?string
+    {
+        try {
+            return Crypt::decryptString($ciphertext);
+        } catch (\Throwable) {
+            return null;
+        }
     }
 }

--- a/backend/app/Support/Security/LocalPiiEnvelopeAdapter.php
+++ b/backend/app/Support/Security/LocalPiiEnvelopeAdapter.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Support\Security;
+
+use App\Contracts\Security\PiiEnvelopeAdapter;
+use Illuminate\Support\Facades\Crypt;
+
+final class LocalPiiEnvelopeAdapter implements PiiEnvelopeAdapter
+{
+    public function encrypt(string $plaintext): string
+    {
+        return Crypt::encryptString($plaintext);
+    }
+
+    public function decrypt(string $ciphertext): ?string
+    {
+        try {
+            return Crypt::decryptString($ciphertext);
+        } catch (\Throwable) {
+            return null;
+        }
+    }
+}

--- a/backend/config/services.php
+++ b/backend/config/services.php
@@ -140,6 +140,8 @@ return [
 
     'pii' => [
         'key_version' => (int) env('PII_KEY_VERSION', 1),
+        'key_id' => env('PII_KEY_ID', 'local-app-key'),
+        'algo' => env('PII_ENVELOPE_ALGO', 'laravel-crypt-v1'),
     ],
 
 ];

--- a/backend/tests/Feature/V0_3/PiiCipherEnvelopeTest.php
+++ b/backend/tests/Feature/V0_3/PiiCipherEnvelopeTest.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\V0_3;
+
+use App\Support\PiiCipher;
+use Illuminate\Support\Facades\Crypt;
+use Tests\TestCase;
+
+final class PiiCipherEnvelopeTest extends TestCase
+{
+    public function test_encrypt_returns_envelope_and_decrypt_round_trips(): void
+    {
+        /** @var PiiCipher $pii */
+        $pii = app(PiiCipher::class);
+
+        $plaintext = 'envelope.user@example.com';
+        $encrypted = $pii->encrypt($plaintext);
+
+        $this->assertIsString($encrypted);
+        $this->assertNotSame('', trim((string) $encrypted));
+
+        $envelope = json_decode((string) $encrypted, true);
+        $this->assertIsArray($envelope);
+        $this->assertSame($pii->currentKeyVersion(), (int) ($envelope['key_version'] ?? 0));
+        $this->assertSame((string) config('services.pii.key_id', ''), (string) ($envelope['key_id'] ?? ''));
+        $this->assertSame((string) config('services.pii.algo', ''), (string) ($envelope['algo'] ?? ''));
+        $this->assertIsString($envelope['ciphertext'] ?? null);
+        $this->assertNotSame('', trim((string) ($envelope['ciphertext'] ?? '')));
+
+        $this->assertSame($plaintext, $pii->decrypt((string) $encrypted));
+    }
+
+    public function test_decrypt_supports_legacy_ciphertext_format(): void
+    {
+        /** @var PiiCipher $pii */
+        $pii = app(PiiCipher::class);
+
+        $plaintext = 'legacy.user@example.com';
+        $legacyCiphertext = Crypt::encryptString($plaintext);
+
+        $this->assertSame($plaintext, $pii->decrypt($legacyCiphertext));
+    }
+}


### PR DESCRIPTION
Fixes FER2-22

Summary
- introduce envelope adapter contract (`PiiEnvelopeAdapter`) and local implementation (`LocalPiiEnvelopeAdapter`) so PII crypto can abstract away from direct framework crypto calls
- wire adapter binding in service container and upgrade `PiiCipher` to emit envelope payloads with `ciphertext`, `key_id`, `key_version`, `algo`
- keep decrypt backward compatible: supports new envelope payload and legacy raw ciphertext format
- add feature coverage for envelope round-trip and legacy decrypt compatibility (`PiiCipherEnvelopeTest`)

Verification
- php artisan test --filter='PiiCipherEnvelopeTest'
- php artisan test --filter='PiiKeyVersionCompatibilityTest'
- php artisan test --filter='EmailOutboxNoPlaintextPayloadTest'
- bash backend/scripts/ci_verify_mbti.sh
