### PR TITLE
Fixes FER2-23: add rotation audit trail endpoint and retention policy

### DIFF
--- a/backend/app/Http/Controllers/API/V0_4/RotationAuditController.php
+++ b/backend/app/Http/Controllers/API/V0_4/RotationAuditController.php
@@ -1,0 +1,225 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Controllers\API\V0_4;
+
+use App\Http\Controllers\Controller;
+use App\Support\OrgContext;
+use App\Support\SchemaBaseline;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\DB;
+
+final class RotationAuditController extends Controller
+{
+    public function __construct(
+        private readonly OrgContext $orgContext,
+    ) {}
+
+    public function index(Request $request, string $org_id): JsonResponse
+    {
+        $orgId = $this->resolveOrgId($org_id);
+        if (! $this->isOrgAccessible($orgId)) {
+            return $this->orgNotFound();
+        }
+
+        if (! SchemaBaseline::hasTable('rotation_audits')) {
+            return $this->rotationAuditsNotReady();
+        }
+
+        $payload = $request->validate([
+            'scope' => ['nullable', 'string', 'max:64'],
+            'result' => ['nullable', 'string', 'max:32'],
+            'batch' => ['nullable', 'string', 'max:64'],
+            'key_version' => ['nullable', 'integer', 'min:1', 'max:65535'],
+            'limit' => ['nullable', 'integer', 'min:1', 'max:200'],
+        ]);
+
+        $keepDays = max(1, (int) config('storage_retention.rotation_audits.keep_days', 180));
+        $policy = trim((string) config('storage_retention.rotation_audits.policy', 'ttl'));
+        $cutoffAt = now()->subDays($keepDays);
+        $limit = (int) ($payload['limit'] ?? 50);
+
+        $query = DB::table('rotation_audits')
+            ->where('org_id', $orgId);
+
+        if (SchemaBaseline::hasColumn('rotation_audits', 'created_at')) {
+            $query->where('created_at', '>=', $cutoffAt);
+        }
+
+        $scope = trim((string) ($payload['scope'] ?? ''));
+        if ($scope !== '') {
+            $query->where('scope', $scope);
+        }
+
+        $result = trim((string) ($payload['result'] ?? ''));
+        if ($result !== '') {
+            $query->where('result', $result);
+        }
+
+        $batch = trim((string) ($payload['batch'] ?? ''));
+        if ($batch !== '') {
+            $query->where('batch_ref', $batch);
+        }
+
+        $keyVersion = (int) ($payload['key_version'] ?? 0);
+        if ($keyVersion > 0) {
+            $query->where('key_version', $keyVersion);
+        }
+
+        $rows = $query
+            ->orderByDesc('created_at')
+            ->limit($limit)
+            ->get();
+
+        $items = [];
+        foreach ($rows as $row) {
+            $items[] = $this->mapRow($row);
+        }
+
+        return response()->json([
+            'ok' => true,
+            'retention' => [
+                'policy' => $policy === '' ? 'ttl' : $policy,
+                'keep_days' => $keepDays,
+                'cutoff_at' => $cutoffAt->toIso8601String(),
+            ],
+            'items' => $items,
+        ]);
+    }
+
+    public function show(Request $request, string $org_id, string $id): JsonResponse
+    {
+        $orgId = $this->resolveOrgId($org_id);
+        if (! $this->isOrgAccessible($orgId)) {
+            return $this->orgNotFound();
+        }
+
+        if (! SchemaBaseline::hasTable('rotation_audits')) {
+            return $this->rotationAuditsNotReady();
+        }
+
+        $keepDays = max(1, (int) config('storage_retention.rotation_audits.keep_days', 180));
+        $cutoffAt = now()->subDays($keepDays);
+
+        $query = DB::table('rotation_audits')
+            ->where('org_id', $orgId)
+            ->where('id', $id);
+
+        if (SchemaBaseline::hasColumn('rotation_audits', 'created_at')) {
+            $query->where('created_at', '>=', $cutoffAt);
+        }
+
+        $row = $query->first();
+        if ($row === null) {
+            return response()->json([
+                'ok' => false,
+                'error_code' => 'ROTATION_AUDIT_NOT_FOUND',
+                'message' => 'rotation audit not found.',
+            ], 404);
+        }
+
+        return response()->json([
+            'ok' => true,
+            'audit' => $this->mapRow($row),
+        ]);
+    }
+
+    private function resolveOrgId(string $orgId): int
+    {
+        $orgId = trim($orgId);
+        if ($orgId === '' || preg_match('/^\d+$/', $orgId) !== 1) {
+            return 0;
+        }
+
+        return (int) $orgId;
+    }
+
+    private function isOrgAccessible(int $orgId): bool
+    {
+        return $orgId > 0 && $this->orgContext->orgId() === $orgId;
+    }
+
+    private function orgNotFound(): JsonResponse
+    {
+        return response()->json([
+            'ok' => false,
+            'error_code' => 'ORG_NOT_FOUND',
+            'message' => 'org not found.',
+        ], 404);
+    }
+
+    private function rotationAuditsNotReady(): JsonResponse
+    {
+        return response()->json([
+            'ok' => false,
+            'error_code' => 'ROTATION_AUDIT_NOT_READY',
+            'message' => 'rotation audits table is not ready.',
+        ], 503);
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    private function mapRow(object $row): array
+    {
+        return [
+            'id' => (string) ($row->id ?? ''),
+            'org_id' => (int) ($row->org_id ?? 0),
+            'actor' => $this->nullableString($row->actor ?? null),
+            'actor_user_id' => $this->nullableInt($row->actor_user_id ?? null),
+            'scope' => (string) ($row->scope ?? ''),
+            'key_version' => (int) ($row->key_version ?? 0),
+            'batch' => $this->nullableString($row->batch_ref ?? null),
+            'result' => (string) ($row->result ?? ''),
+            'meta' => $this->decodeJson($row->meta_json ?? null),
+            'created_at' => $this->nullableString($row->created_at ?? null),
+        ];
+    }
+
+    /**
+     * @return array<string,mixed>|null
+     */
+    private function decodeJson(mixed $value): ?array
+    {
+        if (is_array($value)) {
+            return $value;
+        }
+
+        if (! is_string($value)) {
+            return null;
+        }
+
+        $value = trim($value);
+        if ($value === '') {
+            return null;
+        }
+
+        $decoded = json_decode($value, true);
+
+        return is_array($decoded) ? $decoded : null;
+    }
+
+    private function nullableString(mixed $value): ?string
+    {
+        if ($value === null) {
+            return null;
+        }
+
+        $value = trim((string) $value);
+
+        return $value === '' ? null : $value;
+    }
+
+    private function nullableInt(mixed $value): ?int
+    {
+        if ($value === null || $value === '') {
+            return null;
+        }
+
+        $normalized = (int) $value;
+
+        return $normalized > 0 ? $normalized : null;
+    }
+}

--- a/backend/config/storage_retention.php
+++ b/backend/config/storage_retention.php
@@ -12,4 +12,8 @@ return [
     'logs' => [
         'keep_days' => (int) env('STORAGE_RETENTION_LOGS_DAYS', 30),
     ],
+    'rotation_audits' => [
+        'policy' => (string) env('STORAGE_RETENTION_ROTATION_AUDITS_POLICY', 'ttl'),
+        'keep_days' => (int) env('STORAGE_RETENTION_ROTATION_AUDITS_DAYS', 180),
+    ],
 ];

--- a/backend/database/migrations/2026_02_27_180000_create_rotation_audits_table.php
+++ b/backend/database/migrations/2026_02_27_180000_create_rotation_audits_table.php
@@ -1,0 +1,105 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Support\Database\SchemaIndex;
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    private const TABLE = 'rotation_audits';
+
+    public function up(): void
+    {
+        $this->createOrConvergeTable();
+        $this->ensureIndexes();
+    }
+
+    public function down(): void
+    {
+        // forward-only migration: rollback disabled to prevent data loss in production.
+        // Irreversible operation: schema/data rollback handled via forward fix migrations.
+    }
+
+    private function createOrConvergeTable(): void
+    {
+        if (! Schema::hasTable(self::TABLE)) {
+            Schema::create(self::TABLE, function (Blueprint $table): void {
+                $table->uuid('id')->primary();
+                $table->unsignedBigInteger('org_id')->default(0);
+                $table->string('actor', 64)->nullable();
+                $table->unsignedBigInteger('actor_user_id')->nullable();
+                $table->string('scope', 64)->default('pii');
+                $table->unsignedSmallInteger('key_version')->default(1);
+                $table->string('batch_ref', 64)->nullable();
+                $table->string('result', 32)->default('ok');
+                $table->json('meta_json')->nullable();
+                $table->timestamp('created_at')->nullable();
+                $table->timestamp('updated_at')->nullable();
+            });
+
+            return;
+        }
+
+        Schema::table(self::TABLE, function (Blueprint $table): void {
+            if (! Schema::hasColumn(self::TABLE, 'id')) {
+                $table->uuid('id')->nullable();
+            }
+            if (! Schema::hasColumn(self::TABLE, 'org_id')) {
+                $table->unsignedBigInteger('org_id')->default(0);
+            }
+            if (! Schema::hasColumn(self::TABLE, 'actor')) {
+                $table->string('actor', 64)->nullable();
+            }
+            if (! Schema::hasColumn(self::TABLE, 'actor_user_id')) {
+                $table->unsignedBigInteger('actor_user_id')->nullable();
+            }
+            if (! Schema::hasColumn(self::TABLE, 'scope')) {
+                $table->string('scope', 64)->default('pii');
+            }
+            if (! Schema::hasColumn(self::TABLE, 'key_version')) {
+                $table->unsignedSmallInteger('key_version')->default(1);
+            }
+            if (! Schema::hasColumn(self::TABLE, 'batch_ref')) {
+                $table->string('batch_ref', 64)->nullable();
+            }
+            if (! Schema::hasColumn(self::TABLE, 'result')) {
+                $table->string('result', 32)->default('ok');
+            }
+            if (! Schema::hasColumn(self::TABLE, 'meta_json')) {
+                $table->json('meta_json')->nullable();
+            }
+            if (! Schema::hasColumn(self::TABLE, 'created_at')) {
+                $table->timestamp('created_at')->nullable();
+            }
+            if (! Schema::hasColumn(self::TABLE, 'updated_at')) {
+                $table->timestamp('updated_at')->nullable();
+            }
+        });
+    }
+
+    private function ensureIndexes(): void
+    {
+        $this->ensureIndex(['org_id', 'created_at'], 'rotation_audits_org_created_idx');
+        $this->ensureIndex(['org_id', 'scope', 'created_at'], 'rotation_audits_org_scope_created_idx');
+        $this->ensureIndex(['org_id', 'key_version', 'created_at'], 'rotation_audits_org_key_version_created_idx');
+        $this->ensureIndex(['org_id', 'result', 'created_at'], 'rotation_audits_org_result_created_idx');
+        $this->ensureIndex(['batch_ref'], 'rotation_audits_batch_ref_idx');
+    }
+
+    /**
+     * @param  array<int,string>  $columns
+     */
+    private function ensureIndex(array $columns, string $indexName): void
+    {
+        if (! Schema::hasTable(self::TABLE) || SchemaIndex::indexExists(self::TABLE, $indexName)) {
+            return;
+        }
+
+        Schema::table(self::TABLE, function (Blueprint $table) use ($columns, $indexName): void {
+            $table->index($columns, $indexName);
+        });
+    }
+};

--- a/backend/docs/runbooks/secret-rotation.md
+++ b/backend/docs/runbooks/secret-rotation.md
@@ -39,3 +39,13 @@
 - [ ] 所有 workflow 都包含并通过 `bash backend/scripts/cae_gate.sh`。
 - [ ] 受影响密钥全部轮换并完成功能验证。
 - [ ] 形成书面复盘与审计证据（命令输出、CI 链接、发布记录）。
+
+## 6. Rotation Audit 查询与留存
+- 审计查询接口（需 `owner/admin` 且组织隔离）：
+  - `GET /api/v0.4/orgs/{org_id}/compliance/rotation/audits`
+  - `GET /api/v0.4/orgs/{org_id}/compliance/rotation/audits/{id}`
+- 审计字段约定：`actor` / `scope` / `key_version` / `batch` / `result` / `created_at`。
+- 留存策略（TTL）：
+  - `STORAGE_RETENTION_ROTATION_AUDITS_POLICY=ttl`
+  - `STORAGE_RETENTION_ROTATION_AUDITS_DAYS=180`
+- 查询接口会按 TTL 返回窗口内数据，窗口外数据需按归档流程离线检索。

--- a/backend/routes/api.php
+++ b/backend/routes/api.php
@@ -22,6 +22,7 @@ use App\Http\Controllers\API\V0_4\AssessmentController;
 use App\Http\Controllers\API\V0_4\BootController;
 use App\Http\Controllers\API\V0_4\ExperimentGovernanceController;
 use App\Http\Controllers\API\V0_4\PartnerController;
+use App\Http\Controllers\API\V0_4\RotationAuditController;
 use App\Http\Controllers\HealthzController;
 use App\Http\Middleware\HealthzAccessControl;
 use App\Http\Middleware\LimitWebhookPayloadSize;
@@ -48,7 +49,7 @@ Route::middleware([HealthzAccessControl::class, 'throttle:api_public'])
     ->get('/healthz', [HealthzController::class, 'show'])
     ->name('healthz');
 
-Route::prefix("v0.2")->middleware([
+Route::prefix('v0.2')->middleware([
     'throttle:api_public',
     NormalizeApiErrorContract::class,
 ])->group(function () {
@@ -131,7 +132,7 @@ Route::prefix('v0.3')->middleware([
         // 2) Attempts lifecycle
         Route::middleware('throttle:api_attempt_submit')->group(function () {
             Route::post('/attempts/start', [AttemptWriteController::class, 'start']);
-            Route::post("/attempts/submit", [AttemptWriteController::class, "submit"])
+            Route::post('/attempts/submit', [AttemptWriteController::class, 'submit'])
                 ->middleware(\App\Http\Middleware\FmTokenAuth::class);
         });
         Route::put('/attempts/{attempt_id}/progress', [AttemptProgressController::class, 'upsert'])
@@ -274,6 +275,14 @@ Route::prefix('v0.4')->middleware(NormalizeApiErrorContract::class)->group(funct
             ExperimentGovernanceController::class,
             'evaluateGuardrails',
         ])->middleware('uuid:rollout_id');
+        Route::get('/orgs/{org_id}/compliance/rotation/audits', [
+            RotationAuditController::class,
+            'index',
+        ]);
+        Route::get('/orgs/{org_id}/compliance/rotation/audits/{id}', [
+            RotationAuditController::class,
+            'show',
+        ])->middleware('uuid:id');
 
         Route::post('/orgs/{org_id}/assessments', [AssessmentController::class, 'store']);
         Route::post('/orgs/{org_id}/assessments/{id}/invite', [AssessmentController::class, 'invite']);

--- a/backend/routes/api.php
+++ b/backend/routes/api.php
@@ -49,7 +49,7 @@ Route::middleware([HealthzAccessControl::class, 'throttle:api_public'])
     ->get('/healthz', [HealthzController::class, 'show'])
     ->name('healthz');
 
-Route::prefix('v0.2')->middleware([
+Route::prefix("v0.2")->middleware([
     'throttle:api_public',
     NormalizeApiErrorContract::class,
 ])->group(function () {
@@ -132,7 +132,7 @@ Route::prefix('v0.3')->middleware([
         // 2) Attempts lifecycle
         Route::middleware('throttle:api_attempt_submit')->group(function () {
             Route::post('/attempts/start', [AttemptWriteController::class, 'start']);
-            Route::post('/attempts/submit', [AttemptWriteController::class, 'submit'])
+            Route::post("/attempts/submit", [AttemptWriteController::class, "submit"])
                 ->middleware(\App\Http\Middleware\FmTokenAuth::class);
         });
         Route::put('/attempts/{attempt_id}/progress', [AttemptProgressController::class, 'upsert'])

--- a/backend/scripts/security_gate.sh
+++ b/backend/scripts/security_gate.sh
@@ -35,9 +35,9 @@ if (!is_string($source)) {
 }
 
 $checks = [
-    "v0.2 retired_prefix" => "/Route::prefix\\(\\s*\"v0\\.2\"\\s*\\)/s",
+    "v0.2 retired_prefix" => "/Route::prefix\\(\\s*[\\x27\\x22]v0\\.2[\\x27\\x22]\\s*\\)/s",
     "v0.2 retired_any_route" => "/Route::any\\(\\s*[\\x27\\x22]\\/\\{any\\?\\}[\\x27\\x22]\\s*,\\s*static\\s+function\\s*\\(\\s*\\)\\s*\\{/s",
-    "v0.3 attempts_submit_auth" => "/Route::post\\(\\s*\"\\/attempts\\/submit\"\\s*,\\s*\\[\\s*AttemptWriteController::class\\s*,\\s*\"submit\"\\s*\\]\\s*\\)\\s*->middleware\\(\\s*\\\\App\\\\Http\\\\Middleware\\\\FmTokenAuth::class\\s*\\)\\s*;/s",
+    "v0.3 attempts_submit_auth" => "/Route::post\\(\\s*[\\x27\\x22]\\/attempts\\/submit[\\x27\\x22]\\s*,\\s*\\[\\s*AttemptWriteController::class\\s*,\\s*[\\x27\\x22]submit[\\x27\\x22]\\s*\\]\\s*\\)\\s*->middleware\\(\\s*\\\\App\\\\Http\\\\Middleware\\\\FmTokenAuth::class\\s*\\)\\s*;/s",
     "v0.3 auth_plus_ctx_group" => "/Route::middleware\\(\\s*\\[\\s*\\\\App\\\\Http\\\\Middleware\\\\FmTokenAuth::class\\s*,\\s*ResolveO[r]gContext::class\\s*\\]\\s*\\)\\s*->\\s*group\\s*\\(/s",
 ];
 

--- a/backend/tests/Feature/V0_4/RotationAuditEndpointTest.php
+++ b/backend/tests/Feature/V0_4/RotationAuditEndpointTest.php
@@ -1,0 +1,143 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\V0_4;
+
+use App\Services\Auth\FmTokenService;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Str;
+use Tests\TestCase;
+
+final class RotationAuditEndpointTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_owner_admin_can_query_rotation_audits_with_retention_window(): void
+    {
+        $adminId = $this->createUser('rotation_admin@fm.test');
+        $orgId = $this->createOrgWithRole($adminId, 'admin');
+        $token = $this->issueToken($adminId);
+
+        $activeAuditId = (string) Str::uuid();
+        DB::table('rotation_audits')->insert([
+            'id' => $activeAuditId,
+            'org_id' => $orgId,
+            'actor' => 'ops_bot',
+            'actor_user_id' => $adminId,
+            'scope' => 'pii',
+            'key_version' => 2,
+            'batch_ref' => 'batch_2026_02_27',
+            'result' => 'success',
+            'meta_json' => json_encode(['records' => 120], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES),
+            'created_at' => now()->subDay(),
+            'updated_at' => now()->subDay(),
+        ]);
+
+        DB::table('rotation_audits')->insert([
+            'id' => (string) Str::uuid(),
+            'org_id' => $orgId,
+            'actor' => 'ops_bot',
+            'actor_user_id' => $adminId,
+            'scope' => 'pii',
+            'key_version' => 1,
+            'batch_ref' => 'batch_2025_01_01',
+            'result' => 'success',
+            'meta_json' => json_encode(['records' => 10], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES),
+            'created_at' => now()->subDays(400),
+            'updated_at' => now()->subDays(400),
+        ]);
+
+        $list = $this->withHeaders([
+            'Authorization' => 'Bearer '.$token,
+        ])->getJson("/api/v0.4/orgs/{$orgId}/compliance/rotation/audits?scope=pii&limit=10");
+
+        $list->assertStatus(200);
+        $list->assertJsonPath('ok', true);
+        $list->assertJsonPath('retention.policy', 'ttl');
+        $list->assertJsonPath('retention.keep_days', 180);
+        $list->assertJsonCount(1, 'items');
+        $list->assertJsonPath('items.0.id', $activeAuditId);
+        $list->assertJsonPath('items.0.scope', 'pii');
+        $list->assertJsonPath('items.0.key_version', 2);
+        $list->assertJsonPath('items.0.batch', 'batch_2026_02_27');
+        $list->assertJsonPath('items.0.result', 'success');
+        $list->assertJsonPath('items.0.meta.records', 120);
+
+        $show = $this->withHeaders([
+            'Authorization' => 'Bearer '.$token,
+        ])->getJson("/api/v0.4/orgs/{$orgId}/compliance/rotation/audits/{$activeAuditId}");
+
+        $show->assertStatus(200);
+        $show->assertJsonPath('ok', true);
+        $show->assertJsonPath('audit.id', $activeAuditId);
+    }
+
+    public function test_non_admin_role_cannot_query_rotation_audits(): void
+    {
+        $memberId = $this->createUser('rotation_member@fm.test');
+        $orgId = $this->createOrgWithRole($memberId, 'member');
+        $token = $this->issueToken($memberId);
+
+        DB::table('rotation_audits')->insert([
+            'id' => (string) Str::uuid(),
+            'org_id' => $orgId,
+            'actor' => 'ops_bot',
+            'actor_user_id' => $memberId,
+            'scope' => 'pii',
+            'key_version' => 2,
+            'batch_ref' => 'batch_2026_02_27',
+            'result' => 'success',
+            'meta_json' => null,
+            'created_at' => now(),
+            'updated_at' => now(),
+        ]);
+
+        $response = $this->withHeaders([
+            'Authorization' => 'Bearer '.$token,
+        ])->getJson("/api/v0.4/orgs/{$orgId}/compliance/rotation/audits");
+
+        $response->assertStatus(404);
+        $response->assertJsonPath('error_code', 'ORG_NOT_FOUND');
+    }
+
+    private function createUser(string $email): int
+    {
+        return (int) DB::table('users')->insertGetId([
+            'name' => $email,
+            'email' => $email,
+            'password' => bcrypt('secret'),
+            'created_at' => now(),
+            'updated_at' => now(),
+        ]);
+    }
+
+    private function createOrgWithRole(int $userId, string $role): int
+    {
+        $orgId = (int) DB::table('organizations')->insertGetId([
+            'name' => 'Rotation Org '.$role,
+            'owner_user_id' => $userId,
+            'created_at' => now(),
+            'updated_at' => now(),
+        ]);
+
+        DB::table('organization_members')->insert([
+            'org_id' => $orgId,
+            'user_id' => $userId,
+            'role' => $role,
+            'joined_at' => now(),
+            'created_at' => now(),
+            'updated_at' => now(),
+        ]);
+
+        return $orgId;
+    }
+
+    private function issueToken(int $userId): string
+    {
+        $issued = app(FmTokenService::class)->issueForUser((string) $userId);
+
+        return (string) ($issued['token'] ?? '');
+    }
+}

--- a/backend/tests/Unit/Security/SecurityGuardrailsTest.php
+++ b/backend/tests/Unit/Security/SecurityGuardrailsTest.php
@@ -289,7 +289,7 @@ final class SecurityGuardrailsTest extends TestCase
         $source = file_get_contents(base_path('routes/api.php'));
         $this->assertIsString($source);
 
-        $this->assertMatchesRegularExpression('/Route::prefix\(\s*"v0\.2"\s*\)/', $source);
+        $this->assertMatchesRegularExpression('/Route::prefix\(\s*[\'"]v0\.2[\'"]\s*\)/', $source);
         $this->assertMatchesRegularExpression('/[\'"]error_code[\'"]\s*=>\s*[\'"]API_VERSION_DEPRECATED[\'"]/', $source);
         $this->assertMatchesRegularExpression('/\],\s*410\s*\)/', $source);
     }


### PR DESCRIPTION
Fixes FER2-23

Summary
- add forward-only `rotation_audits` schema with required audit fields (`actor`, `scope`, `key_version`, `batch_ref`, `result`, timestamps) and query indexes
- add restricted query endpoints under v0.4 org admin/owner scope:
  - `GET /api/v0.4/orgs/{org_id}/compliance/rotation/audits`
  - `GET /api/v0.4/orgs/{org_id}/compliance/rotation/audits/{id}`
- enforce retention window in query path via configurable TTL policy (`storage_retention.rotation_audits`)
- document rotation-audit query + retention env vars in secret-rotation runbook
- add endpoint coverage for authorized query, retention filtering, and role-based denial

Verification
- php artisan route:list --path=rotation
- php artisan test --filter='RotationAuditEndpointTest'
- bash backend/scripts/ci_verify_mbti.sh
