### PR TITLE
Fixes FER2-24: define queue lag SLO and strict probe policy

### DIFF
--- a/backend/app/Console/Commands/Ops/QueueBacklogProbe.php
+++ b/backend/app/Console/Commands/Ops/QueueBacklogProbe.php
@@ -9,14 +9,21 @@ use Illuminate\Console\Command;
 
 final class QueueBacklogProbe extends Command
 {
+    private const THRESHOLD_KEYS = [
+        'max_pending',
+        'max_failed',
+        'max_oldest_seconds',
+        'max_timeout_failures',
+    ];
+
     protected $signature = 'ops:queue-backlog-probe
-        {--queues=attempts,reports,commerce : Comma-separated queue names}
-        {--window-minutes=60 : Failure telemetry lookback window in minutes}
-        {--max-pending=200 : Warn threshold for pending jobs per queue}
-        {--max-failed=20 : Warn threshold for failed jobs per queue}
-        {--max-oldest-seconds=300 : Warn threshold for oldest pending job age}
-        {--max-timeout-failures=3 : Warn threshold for timeout-like failed jobs in window}
-        {--strict=0 : Exit non-zero when any queue exceeds threshold}
+        {--queues= : Comma-separated queue names; defaults to ops.queue_backlog_probe.queues}
+        {--window-minutes= : Failure telemetry lookback window in minutes}
+        {--max-pending= : Override pending threshold for all queues}
+        {--max-failed= : Override failed jobs threshold for all queues}
+        {--max-oldest-seconds= : Override oldest pending job age threshold}
+        {--max-timeout-failures= : Override timeout-like failed jobs threshold in window}
+        {--strict= : Exit non-zero when any queue exceeds threshold}
         {--json=1 : Output JSON payload}';
 
     protected $description = 'Queue backlog probe for attempts/reports/commerce capacity governance.';
@@ -28,23 +35,38 @@ final class QueueBacklogProbe extends Command
 
     public function handle(): int
     {
-        $queues = $this->parseQueues((string) $this->option('queues'));
-        $windowMinutes = max(1, (int) $this->option('window-minutes'));
+        $policy = $this->queuePolicy();
 
-        $thresholds = [
-            'max_pending' => max(0, (int) $this->option('max-pending')),
-            'max_failed' => max(0, (int) $this->option('max-failed')),
-            'max_oldest_seconds' => max(0, (int) $this->option('max-oldest-seconds')),
-            'max_timeout_failures' => max(0, (int) $this->option('max-timeout-failures')),
-        ];
+        $queues = $this->parseQueues((string) ($this->option('queues') ?? ''));
+        if ($queues === []) {
+            $queues = $this->normalizeQueueList($policy['queues'] ?? []);
+        }
+        if ($queues === []) {
+            $queues = ['attempts', 'reports', 'commerce'];
+        }
+
+        $windowMinutes = $this->resolveWindowMinutes($policy);
+        $strict = $this->resolveStrict($policy);
+        $thresholdsByQueue = $this->resolveThresholdsByQueue($queues, $policy);
 
         $payload = $this->probeService->probe($queues, $windowMinutes);
         $assessment = $this->assessQueues(
             is_array($payload['queues'] ?? null) ? $payload['queues'] : [],
-            $thresholds
+            $thresholdsByQueue
         );
 
-        $payload['thresholds'] = $thresholds;
+        $payload['thresholds'] = [
+            'by_queue' => $thresholdsByQueue,
+        ];
+        $payload['slo'] = [
+            'strict' => $strict,
+            'alert_policy' => is_array($policy['alert_policy'] ?? null) ? $policy['alert_policy'] : [],
+            'breach_total' => count($assessment['violations']),
+            'breached_queues' => array_values(array_unique(array_map(
+                static fn (array $violation): string => (string) ($violation['queue'] ?? ''),
+                $assessment['violations']
+            ))),
+        ];
         $payload['queues'] = $assessment['queues'];
         $payload['violations'] = $assessment['violations'];
         $payload['pass'] = $assessment['pass'];
@@ -54,16 +76,18 @@ final class QueueBacklogProbe extends Command
         } else {
             $this->info('queue_backlog_probe');
             $this->line(sprintf(
-                'driver=%s connection=%s window_minutes=%d',
+                'driver=%s connection=%s window_minutes=%d strict=%s',
                 (string) ($payload['queue_driver'] ?? ''),
                 (string) ($payload['queue_connection'] ?? ''),
-                (int) ($payload['window_minutes'] ?? 0)
+                (int) ($payload['window_minutes'] ?? 0),
+                $strict ? '1' : '0'
             ));
             foreach ($assessment['queues'] as $queue) {
                 $backlog = is_array($queue['backlog'] ?? null) ? $queue['backlog'] : [];
                 $failures = is_array($queue['failures'] ?? null) ? $queue['failures'] : [];
+                $slo = is_array($queue['slo'] ?? null) ? $queue['slo'] : [];
                 $this->line(sprintf(
-                    '%s status=%s pending=%d reserved=%d delayed=%d oldest_pending_s=%d failed=%d timeout_failed_window=%d',
+                    '%s status=%s pending=%d reserved=%d delayed=%d oldest_pending_s=%d failed=%d timeout_failed_window=%d max_utilization=%.2f',
                     (string) ($queue['queue'] ?? ''),
                     (string) ($queue['status'] ?? 'ok'),
                     (int) ($backlog['pending'] ?? 0),
@@ -71,7 +95,8 @@ final class QueueBacklogProbe extends Command
                     (int) ($backlog['delayed'] ?? 0),
                     (int) ($backlog['oldest_pending_seconds'] ?? 0),
                     (int) ($failures['total'] ?? 0),
-                    (int) ($failures['window_timeout_total'] ?? 0)
+                    (int) ($failures['window_timeout_total'] ?? 0),
+                    (float) ($slo['max_utilization'] ?? 0.0)
                 ));
             }
             if ($assessment['violations'] !== []) {
@@ -79,7 +104,7 @@ final class QueueBacklogProbe extends Command
             }
         }
 
-        if ($this->isTruthy($this->option('strict')) && ! ($assessment['pass'] ?? true)) {
+        if ($strict && ! ($assessment['pass'] ?? true)) {
             return self::FAILURE;
         }
 
@@ -88,14 +113,14 @@ final class QueueBacklogProbe extends Command
 
     /**
      * @param  list<array<string,mixed>>  $queues
-     * @param  array{max_pending:int,max_failed:int,max_oldest_seconds:int,max_timeout_failures:int}  $thresholds
+     * @param  array<string,array{max_pending:int,max_failed:int,max_oldest_seconds:int,max_timeout_failures:int}>  $thresholdsByQueue
      * @return array{
      *     pass:bool,
      *     queues:list<array<string,mixed>>,
      *     violations:list<array{queue:string,metric:string,value:int,threshold:int}>
      * }
      */
-    private function assessQueues(array $queues, array $thresholds): array
+    private function assessQueues(array $queues, array $thresholdsByQueue): array
     {
         $violations = [];
         $assessed = [];
@@ -104,6 +129,7 @@ final class QueueBacklogProbe extends Command
             $backlog = is_array($queue['backlog'] ?? null) ? $queue['backlog'] : [];
             $failures = is_array($queue['failures'] ?? null) ? $queue['failures'] : [];
             $queueName = (string) ($queue['queue'] ?? '');
+            $thresholds = $this->thresholdForQueue($queueName, $thresholdsByQueue);
             $queueViolations = [];
 
             $pending = (int) ($backlog['pending'] ?? 0);
@@ -150,12 +176,23 @@ final class QueueBacklogProbe extends Command
             if ($existingStatus === '') {
                 $existingStatus = 'ok';
             }
-            if ($queueViolations !== []) {
-                $queue['status'] = 'warn';
-            } else {
-                $queue['status'] = $existingStatus;
-            }
+            $queue['status'] = $queueViolations !== [] ? 'warn' : $existingStatus;
             $queue['violations'] = $queueViolations;
+            $queue['thresholds'] = $thresholds;
+            $queue['slo'] = [
+                'status' => $queueViolations !== [] ? 'breach' : 'ok',
+                'pending_utilization' => $this->ratio($pending, $thresholds['max_pending']),
+                'failed_utilization' => $this->ratio($failed, $thresholds['max_failed']),
+                'oldest_pending_utilization' => $this->ratio($oldestPending, $thresholds['max_oldest_seconds']),
+                'timeout_failure_utilization' => $this->ratio($timeoutFailures, $thresholds['max_timeout_failures']),
+                'max_utilization' => max(
+                    $this->ratio($pending, $thresholds['max_pending']),
+                    $this->ratio($failed, $thresholds['max_failed']),
+                    $this->ratio($oldestPending, $thresholds['max_oldest_seconds']),
+                    $this->ratio($timeoutFailures, $thresholds['max_timeout_failures']),
+                ),
+                'breach_count' => count($queueViolations),
+            ];
 
             $violations = array_merge($violations, $queueViolations);
             $assessed[] = $queue;
@@ -186,6 +223,9 @@ final class QueueBacklogProbe extends Command
         return array_keys($dedup);
     }
 
+    /**
+     * @param  mixed  $value
+     */
     private function isTruthy(mixed $value): bool
     {
         if (is_bool($value)) {
@@ -195,5 +235,129 @@ final class QueueBacklogProbe extends Command
         $normalized = strtolower(trim((string) $value));
 
         return in_array($normalized, ['1', 'true', 'yes', 'on'], true);
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    private function queuePolicy(): array
+    {
+        $policy = config('ops.queue_backlog_probe');
+
+        return is_array($policy) ? $policy : [];
+    }
+
+    /**
+     * @param  mixed  $rawQueues
+     * @return list<string>
+     */
+    private function normalizeQueueList(mixed $rawQueues): array
+    {
+        if (! is_array($rawQueues)) {
+            return [];
+        }
+
+        $normalized = [];
+        foreach ($rawQueues as $queue) {
+            $value = strtolower(trim((string) $queue));
+            if ($value === '') {
+                continue;
+            }
+            $normalized[$value] = true;
+        }
+
+        return array_keys($normalized);
+    }
+
+    /**
+     * @param  array<string,mixed>  $policy
+     */
+    private function resolveWindowMinutes(array $policy): int
+    {
+        $option = $this->option('window-minutes');
+        if ($option !== null && trim((string) $option) !== '') {
+            return max(1, (int) $option);
+        }
+
+        return max(1, (int) ($policy['window_minutes'] ?? 60));
+    }
+
+    /**
+     * @param  array<string,mixed>  $policy
+     */
+    private function resolveStrict(array $policy): bool
+    {
+        $option = $this->option('strict');
+        if ($option !== null && trim((string) $option) !== '') {
+            return $this->isTruthy($option);
+        }
+
+        return (bool) ($policy['strict_default'] ?? false);
+    }
+
+    /**
+     * @param  list<string>  $queues
+     * @param  array<string,mixed>  $policy
+     * @return array<string,array{max_pending:int,max_failed:int,max_oldest_seconds:int,max_timeout_failures:int}>
+     */
+    private function resolveThresholdsByQueue(array $queues, array $policy): array
+    {
+        $rawThresholds = $policy['thresholds'] ?? [];
+        $configured = is_array($rawThresholds) ? $rawThresholds : [];
+        $resolved = [];
+
+        foreach ($queues as $queue) {
+            $queueConfig = is_array($configured[$queue] ?? null) ? $configured[$queue] : [];
+
+            $thresholds = [
+                'max_pending' => max(0, (int) ($queueConfig['max_pending'] ?? 200)),
+                'max_failed' => max(0, (int) ($queueConfig['max_failed'] ?? 20)),
+                'max_oldest_seconds' => max(0, (int) ($queueConfig['max_oldest_seconds'] ?? 300)),
+                'max_timeout_failures' => max(0, (int) ($queueConfig['max_timeout_failures'] ?? 3)),
+            ];
+
+            foreach (self::THRESHOLD_KEYS as $key) {
+                $optionName = str_replace('_', '-', $key);
+                $override = $this->option($optionName);
+                if ($override === null || trim((string) $override) === '') {
+                    continue;
+                }
+                $thresholds[$key] = max(0, (int) $override);
+            }
+
+            $resolved[$queue] = $thresholds;
+        }
+
+        return $resolved;
+    }
+
+    /**
+     * @param  array<string,array{max_pending:int,max_failed:int,max_oldest_seconds:int,max_timeout_failures:int}>  $thresholdsByQueue
+     * @return array{max_pending:int,max_failed:int,max_oldest_seconds:int,max_timeout_failures:int}
+     */
+    private function thresholdForQueue(string $queueName, array $thresholdsByQueue): array
+    {
+        $thresholds = $thresholdsByQueue[$queueName] ?? [
+            'max_pending' => 200,
+            'max_failed' => 20,
+            'max_oldest_seconds' => 300,
+            'max_timeout_failures' => 3,
+        ];
+
+        return [
+            'max_pending' => max(0, (int) ($thresholds['max_pending'] ?? 0)),
+            'max_failed' => max(0, (int) ($thresholds['max_failed'] ?? 0)),
+            'max_oldest_seconds' => max(0, (int) ($thresholds['max_oldest_seconds'] ?? 0)),
+            'max_timeout_failures' => max(0, (int) ($thresholds['max_timeout_failures'] ?? 0)),
+        ];
+    }
+
+    private function ratio(int $value, int $threshold): float
+    {
+        if ($threshold <= 0) {
+            return $value > 0 ? 1.0 : 0.0;
+        }
+
+        return round($value / $threshold, 4);
     }
 }

--- a/backend/config/ops.php
+++ b/backend/config/ops.php
@@ -31,4 +31,38 @@ return [
         'admin_login_max_attempts' => (int) env('OPS_ADMIN_LOGIN_MAX_ATTEMPTS', 5),
         'admin_login_decay_seconds' => (int) env('OPS_ADMIN_LOGIN_DECAY_SECONDS', 300),
     ],
+
+    'queue_backlog_probe' => [
+        'queues' => ['attempts', 'reports', 'commerce'],
+        'window_minutes' => (int) env('OPS_QUEUE_BACKLOG_WINDOW_MINUTES', 60),
+        'strict_default' => (bool) env('OPS_QUEUE_BACKLOG_STRICT_DEFAULT', false),
+        'thresholds' => [
+            'attempts' => [
+                'max_pending' => (int) env('OPS_QUEUE_ATTEMPTS_MAX_PENDING', 120),
+                'max_failed' => (int) env('OPS_QUEUE_ATTEMPTS_MAX_FAILED', 15),
+                'max_oldest_seconds' => (int) env('OPS_QUEUE_ATTEMPTS_MAX_OLDEST_SECONDS', 240),
+                'max_timeout_failures' => (int) env('OPS_QUEUE_ATTEMPTS_MAX_TIMEOUT_FAILURES', 3),
+            ],
+            'reports' => [
+                'max_pending' => (int) env('OPS_QUEUE_REPORTS_MAX_PENDING', 60),
+                'max_failed' => (int) env('OPS_QUEUE_REPORTS_MAX_FAILED', 10),
+                'max_oldest_seconds' => (int) env('OPS_QUEUE_REPORTS_MAX_OLDEST_SECONDS', 300),
+                'max_timeout_failures' => (int) env('OPS_QUEUE_REPORTS_MAX_TIMEOUT_FAILURES', 2),
+            ],
+            'commerce' => [
+                'max_pending' => (int) env('OPS_QUEUE_COMMERCE_MAX_PENDING', 40),
+                'max_failed' => (int) env('OPS_QUEUE_COMMERCE_MAX_FAILED', 8),
+                'max_oldest_seconds' => (int) env('OPS_QUEUE_COMMERCE_MAX_OLDEST_SECONDS', 180),
+                'max_timeout_failures' => (int) env('OPS_QUEUE_COMMERCE_MAX_TIMEOUT_FAILURES', 2),
+            ],
+        ],
+        'alert_policy' => [
+            'escalation_chain' => ['ops-oncall', 'backend-oncall', 'payments-oncall'],
+            'quiet_window' => [
+                'timezone' => env('OPS_QUEUE_ALERT_QUIET_TZ', 'Asia/Shanghai'),
+                'start' => env('OPS_QUEUE_ALERT_QUIET_START', '02:00'),
+                'end' => env('OPS_QUEUE_ALERT_QUIET_END', '08:00'),
+            ],
+        ],
+    ],
 ];

--- a/backend/docs/ops/queue-runbook.md
+++ b/backend/docs/ops/queue-runbook.md
@@ -127,11 +127,39 @@ php artisan queue:flush
 - 关注表：`ai_insights`
 - 典型问题：预算/外部 provider 超时导致 failed
 
-## 6. SLO 与告警建议
-- `failed_jobs` 总量 > 0 且持续 5 分钟：warning
-- `jobs(queue=reports)` 积压超过阈值（例如 > 100）且 10 分钟无下降：critical
-- `report_snapshots.status=pending` 超时（例如 > 5 分钟）占比异常：warning
-- `payment_events.handle_status in (failed,reprocess_failed)` 激增：warning
+## 6. SLO 与告警策略（FER2-24）
+`ops:queue-backlog-probe` 默认输出 `attempts/reports/commerce` 三队列 SLO 指标，含：
+- backlog：`pending/reserved/delayed/oldest_pending_seconds`
+- failures：`failed_total/window_timeout_failures`
+- slo：`pending_utilization/failed_utilization/oldest_pending_utilization/timeout_failure_utilization/max_utilization`
+
+默认阈值（可通过 `OPS_QUEUE_*` 环境变量覆盖）：
+
+| Queue | max_pending | max_failed | max_oldest_seconds | max_timeout_failures |
+|---|---:|---:|---:|---:|
+| attempts | 120 | 15 | 240 | 3 |
+| reports | 60 | 10 | 300 | 2 |
+| commerce | 40 | 8 | 180 | 2 |
+
+### 6.1 告警分级
+- Warning：任意队列 `max_utilization > 0.8` 且持续 10 分钟。
+- Critical：任意队列发生 breach（超过阈值）且持续 5 分钟。
+- Recovery：连续 10 分钟无 breach 且 `max_utilization <= 0.6`。
+
+### 6.2 升级链路（escalation chain）
+1. `ops-oncall`（首响）
+2. `backend-oncall`（5 分钟未恢复）
+3. `payments-oncall`（commerce 队列连续 breach > 10 分钟）
+
+### 6.3 静默窗口（quiet window）
+- 时区：`Asia/Shanghai`
+- 窗口：`02:00-08:00`
+- 规则：静默窗口仅抑制 Warning，不抑制 Critical。
+
+### 6.4 CI 阻断模式
+- 非阻断（默认）：`php artisan ops:queue-backlog-probe --json=1 --strict=0`
+- 阻断：`php artisan ops:queue-backlog-probe --json=1 --strict=1`
+- 也可配置默认严格模式：`OPS_QUEUE_BACKLOG_STRICT_DEFAULT=true`
 
 ## 7. 演练清单
 1. 人工制造一条失败任务（测试环境）。

--- a/backend/scripts/ci_verify_mbti.sh
+++ b/backend/scripts/ci_verify_mbti.sh
@@ -1134,9 +1134,16 @@ php vendor/phpunit/phpunit/phpunit --configuration phpunit.xml tests/Feature/V0_
 php vendor/phpunit/phpunit/phpunit --configuration phpunit.xml tests/Feature/Architecture/V0_3TraitReferenceTest.php
 echo "[CI] webhook/attempt regression gates OK"
 
-echo "[CI] queue backlog probe (non-blocking)"
-if php artisan ops:queue-backlog-probe --json=1 --strict=0 >"$QUEUE_BACKLOG_PROBE_LOG" 2>"$QUEUE_BACKLOG_PROBE_ERR_LOG"; then
+QUEUE_BACKLOG_PROBE_STRICT="${QUEUE_BACKLOG_PROBE_STRICT:-0}"
+if [[ "$QUEUE_BACKLOG_PROBE_STRICT" == "1" ]]; then
+  echo "[CI] queue backlog probe (blocking strict=1)"
+  php artisan ops:queue-backlog-probe --json=1 --strict=1 >"$QUEUE_BACKLOG_PROBE_LOG" 2>"$QUEUE_BACKLOG_PROBE_ERR_LOG"
   echo "[CI] queue backlog probe artifact=$QUEUE_BACKLOG_PROBE_LOG"
 else
-  echo "[CI][WARN] queue backlog probe failed (non-blocking), see $QUEUE_BACKLOG_PROBE_ERR_LOG"
+  echo "[CI] queue backlog probe (non-blocking strict=0)"
+  if php artisan ops:queue-backlog-probe --json=1 --strict=0 >"$QUEUE_BACKLOG_PROBE_LOG" 2>"$QUEUE_BACKLOG_PROBE_ERR_LOG"; then
+    echo "[CI] queue backlog probe artifact=$QUEUE_BACKLOG_PROBE_LOG"
+  else
+    echo "[CI][WARN] queue backlog probe failed (non-blocking), see $QUEUE_BACKLOG_PROBE_ERR_LOG"
+  fi
 fi

--- a/backend/tests/Feature/Ops/QueueBacklogProbeCommandTest.php
+++ b/backend/tests/Feature/Ops/QueueBacklogProbeCommandTest.php
@@ -114,6 +114,8 @@ final class QueueBacklogProbeCommandTest extends TestCase
         $this->assertIsArray($payload);
         $this->assertTrue((bool) ($payload['pass'] ?? false));
         $this->assertSame('database', (string) ($payload['queue_driver'] ?? ''));
+        $this->assertIsArray($payload['thresholds']['by_queue'] ?? null);
+        $this->assertIsArray($payload['slo'] ?? null);
 
         $queues = is_array($payload['queues'] ?? null) ? $payload['queues'] : [];
 
@@ -125,10 +127,17 @@ final class QueueBacklogProbeCommandTest extends TestCase
         $this->assertSame(1, (int) ($attempts['failures']['total'] ?? 0));
         $this->assertSame(1, (int) ($attempts['failures']['timeout_total'] ?? 0));
         $this->assertSame(1, (int) ($attempts['attempt_submissions']['states']['pending'] ?? 0));
+        $this->assertSame('ok', (string) ($attempts['slo']['status'] ?? ''));
+        $this->assertGreaterThanOrEqual(0.0, (float) ($attempts['slo']['max_utilization'] ?? -1));
 
         $reports = $this->findQueue($queues, 'reports');
         $this->assertIsArray($reports);
         $this->assertSame(1, (int) ($reports['report_jobs']['states']['running'] ?? 0));
+        $this->assertSame('ok', (string) ($reports['slo']['status'] ?? ''));
+
+        $commerce = $this->findQueue($queues, 'commerce');
+        $this->assertIsArray($commerce);
+        $this->assertSame('ok', (string) ($commerce['slo']['status'] ?? ''));
     }
 
     public function test_strict_mode_returns_failure_when_queue_threshold_is_exceeded(): void
@@ -163,6 +172,43 @@ final class QueueBacklogProbeCommandTest extends TestCase
         $first = is_array($violations[0] ?? null) ? $violations[0] : [];
         $this->assertSame('attempts', (string) ($first['queue'] ?? ''));
         $this->assertSame('pending', (string) ($first['metric'] ?? ''));
+    }
+
+    public function test_command_uses_default_three_queues_and_config_driven_strict_mode(): void
+    {
+        $this->useDatabaseQueueDriver();
+
+        config()->set('ops.queue_backlog_probe.queues', ['attempts', 'reports', 'commerce']);
+        config()->set('ops.queue_backlog_probe.strict_default', true);
+        config()->set('ops.queue_backlog_probe.thresholds.attempts.max_pending', 0);
+        config()->set('ops.queue_backlog_probe.thresholds.reports.max_pending', 999);
+        config()->set('ops.queue_backlog_probe.thresholds.commerce.max_pending', 999);
+
+        $nowTs = now()->timestamp;
+        DB::table('jobs')->insert([
+            'queue' => 'attempts',
+            'payload' => '{"job":"attempt.submit"}',
+            'attempts' => 1,
+            'reserved_at' => null,
+            'available_at' => $nowTs - 30,
+            'created_at' => $nowTs - 30,
+        ]);
+
+        $exitCode = Artisan::call('ops:queue-backlog-probe', [
+            '--json' => 1,
+        ]);
+
+        $this->assertSame(1, $exitCode);
+
+        $payload = json_decode(trim((string) Artisan::output()), true);
+        $this->assertIsArray($payload);
+        $this->assertFalse((bool) ($payload['pass'] ?? true));
+        $this->assertTrue((bool) ($payload['slo']['strict'] ?? false));
+
+        $queues = is_array($payload['queues'] ?? null) ? $payload['queues'] : [];
+        $this->assertNotSame([], $this->findQueue($queues, 'attempts'));
+        $this->assertNotSame([], $this->findQueue($queues, 'reports'));
+        $this->assertNotSame([], $this->findQueue($queues, 'commerce'));
     }
 
     private function useDatabaseQueueDriver(): void


### PR DESCRIPTION
Fixes FER2-24

## Summary
- Extend `ops:queue-backlog-probe` to emit queue-level SLO metrics for `attempts/reports/commerce` and evaluate thresholds per queue.
- Add queue backlog SLO policy in `config/ops.php` (thresholds, strict default, escalation chain, quiet window).
- Add strict-blocking mode toggle support in `backend/scripts/ci_verify_mbti.sh` via `QUEUE_BACKLOG_PROBE_STRICT`.
- Add/extend feature tests for default three-queue output, per-queue thresholds, and strict mode behavior.
- Update queue runbook with threshold table, escalation path, quiet window, and strict CI usage.

## Verification
- php artisan test --filter='QueueBacklogProbeCommandTest'
- php artisan ops:queue-backlog-probe --json=1 --strict=1
- bash backend/scripts/ci_verify_mbti.sh
