### PR TITLE
Fixes FER2-26: async orchestration for DSAR execution

### DIFF
--- a/backend/app/Http/Controllers/API/V0_3/ComplianceDsarController.php
+++ b/backend/app/Http/Controllers/API/V0_3/ComplianceDsarController.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace App\Http\Controllers\API\V0_3;
 
 use App\Http\Controllers\Controller;
-use App\Services\Attempts\UserDataLifecycleService;
+use App\Jobs\ExecuteDsarRequestJob;
 use App\Support\SchemaBaseline;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
@@ -20,10 +20,6 @@ final class ComplianceDsarController extends Controller
 
     /** @var array<int,string> */
     private const ALLOWED_ROLES = ['owner', 'admin'];
-
-    public function __construct(
-        private readonly UserDataLifecycleService $userDataLifecycleService,
-    ) {}
 
     public function store(Request $request): JsonResponse
     {
@@ -113,88 +109,131 @@ final class ComplianceDsarController extends Controller
             }
 
             $status = trim((string) ($row->status ?? 'pending'));
-            if ($status === 'running') {
-                return ['state' => 'running', 'row' => $row];
-            }
-            if ($status === 'done') {
-                return ['state' => 'done', 'row' => $row];
+            $subjectUserId = (int) ($row->subject_user_id ?? 0);
+            $payload = $this->decodeJson($row->payload_json ?? null) ?? [];
+            $execution = is_array($payload['execution'] ?? null) ? $payload['execution'] : [];
+
+            $referenceId = trim((string) ($execution['reference_id'] ?? ''));
+            if ($referenceId === '') {
+                $referenceId = (string) Str::uuid();
             }
 
-            DB::table('dsar_requests')
-                ->where('id', $id)
-                ->where('org_id', $context['org_id'])
-                ->update([
+            $taskId = trim((string) ($execution['task_id'] ?? ''));
+            if ($taskId === '' && SchemaBaseline::hasTable('dsar_request_tasks')) {
+                $existingTaskId = DB::table('dsar_request_tasks')
+                    ->where('request_id', $id)
+                    ->where('domain', 'orchestration')
+                    ->where('action', 'execute')
+                    ->orderByDesc('created_at')
+                    ->value('id');
+                $taskId = is_string($existingTaskId) ? trim($existingTaskId) : '';
+            }
+            if ($taskId === '') {
+                $taskId = (string) Str::uuid();
+            }
+
+            if ($status === 'pending') {
+                if (SchemaBaseline::hasTable('dsar_request_tasks')) {
+                    $existing = DB::table('dsar_request_tasks')
+                        ->where('request_id', $id)
+                        ->where('domain', 'orchestration')
+                        ->where('action', 'execute')
+                        ->orderByDesc('created_at')
+                        ->first();
+
+                    if ($existing === null) {
+                        DB::table('dsar_request_tasks')->insert([
+                            'id' => $taskId,
+                            'request_id' => $id,
+                            'org_id' => $context['org_id'],
+                            'subject_user_id' => $subjectUserId > 0 ? $subjectUserId : null,
+                            'domain' => 'orchestration',
+                            'action' => 'execute',
+                            'status' => 'pending',
+                            'error_code' => null,
+                            'stats_json' => json_encode([
+                                'queued_by_user_id' => $context['actor_user_id'],
+                                'reference_id' => $referenceId,
+                            ], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES),
+                            'started_at' => null,
+                            'finished_at' => null,
+                            'created_at' => now(),
+                            'updated_at' => now(),
+                        ]);
+                    } else {
+                        $taskId = (string) ($existing->id ?? $taskId);
+                    }
+                }
+
+                $payload['execution'] = [
+                    'reference_id' => $referenceId,
+                    'task_id' => $taskId,
+                    'queued_by_user_id' => $context['actor_user_id'],
+                    'queued_at' => now()->toISOString(),
+                ];
+
+                DB::table('dsar_requests')
+                    ->where('id', $id)
+                    ->where('org_id', $context['org_id'])
+                    ->update([
+                        'status' => 'running',
+                        'executed_by_user_id' => $context['actor_user_id'],
+                        'payload_json' => json_encode($payload, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES),
+                        'updated_at' => now(),
+                    ]);
+
+                $this->appendStatusTransitionAudit(
+                    $id,
+                    $context['org_id'],
+                    $subjectUserId,
+                    'pending',
+                    'running',
+                    $referenceId,
+                    $taskId
+                );
+
+                return [
+                    'state' => 'dispatch',
                     'status' => 'running',
-                    'executed_by_user_id' => $context['actor_user_id'],
-                    'updated_at' => now(),
-                ]);
+                    'task_id' => $taskId,
+                    'reference_id' => $referenceId,
+                ];
+            }
 
-            $fresh = DB::table('dsar_requests')
-                ->where('id', $id)
-                ->where('org_id', $context['org_id'])
-                ->first();
-
-            return ['state' => 'ready', 'row' => $fresh];
+            return [
+                'state' => 'existing',
+                'status' => $status !== '' ? $status : 'running',
+                'task_id' => $taskId,
+                'reference_id' => $referenceId,
+            ];
         });
 
         $state = (string) ($lock['state'] ?? '');
         if ($state === 'missing') {
             return $this->requestNotFound();
         }
-        if ($state === 'running') {
-            return response()->json([
-                'ok' => true,
-                'request_id' => $id,
-                'status' => 'running',
-            ], 202);
+
+        $status = (string) ($lock['status'] ?? 'running');
+        $taskId = (string) ($lock['task_id'] ?? '');
+        $referenceId = (string) ($lock['reference_id'] ?? '');
+
+        if ($state === 'dispatch') {
+            ExecuteDsarRequestJob::dispatch(
+                $id,
+                $context['org_id'],
+                $context['actor_user_id'],
+                $taskId,
+                $referenceId
+            );
         }
-        if ($state === 'done') {
-            /** @var object $row */
-            $row = $lock['row'];
-
-            return response()->json([
-                'ok' => true,
-                'request' => $this->mapRequestRow($row),
-            ]);
-        }
-
-        /** @var object $row */
-        $row = $lock['row'];
-        $mode = trim((string) ($row->mode ?? 'hybrid_anonymize'));
-        $subjectUserId = (int) ($row->subject_user_id ?? 0);
-
-        $result = $this->userDataLifecycleService->process(
-            $context['org_id'],
-            $subjectUserId,
-            $mode,
-            [
-                'actor_user_id' => $context['actor_user_id'],
-                'request_id' => (string) ($row->id ?? $id),
-                'reason' => (string) ($row->reason ?? 'user_dsar_request'),
-            ]
-        );
-
-        $status = ($result['ok'] ?? false) === true ? 'done' : 'failed';
-        $now = now();
-
-        DB::table('dsar_requests')
-            ->where('id', $id)
-            ->where('org_id', $context['org_id'])
-            ->update([
-                'status' => $status,
-                'result_json' => json_encode($result, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES),
-                'executed_by_user_id' => $context['actor_user_id'],
-                'executed_at' => $now,
-                'updated_at' => $now,
-            ]);
-
-        $updated = $this->findRequestRow($id, $context['org_id']);
 
         return response()->json([
-            'ok' => ($result['ok'] ?? false) === true,
-            'request' => $updated !== null ? $this->mapRequestRow($updated) : null,
-            'result' => $result,
-        ]);
+            'ok' => true,
+            'request_id' => $id,
+            'status' => $status,
+            'task_id' => $taskId !== '' ? $taskId : null,
+            'job_reference' => $referenceId !== '' ? $referenceId : null,
+        ], 202);
     }
 
     /**
@@ -305,5 +344,38 @@ final class ComplianceDsarController extends Controller
             'error_code' => 'DSAR_REQUEST_NOT_FOUND',
             'message' => 'dsar request not found.',
         ], 404);
+    }
+
+    private function appendStatusTransitionAudit(
+        string $requestId,
+        int $orgId,
+        int $subjectUserId,
+        string $from,
+        string $to,
+        string $referenceId,
+        string $taskId
+    ): void {
+        if (! SchemaBaseline::hasTable('dsar_audit_logs')) {
+            return;
+        }
+
+        $now = now();
+        DB::table('dsar_audit_logs')->insert([
+            'request_id' => $requestId,
+            'org_id' => $orgId,
+            'subject_user_id' => $subjectUserId > 0 ? $subjectUserId : null,
+            'event_type' => 'dsar_status_transition',
+            'level' => 'info',
+            'message' => sprintf('dsar request transitioned from %s to %s', $from, $to),
+            'context_json' => json_encode([
+                'from' => $from,
+                'to' => $to,
+                'reference_id' => $referenceId,
+                'task_id' => $taskId,
+            ], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES),
+            'occurred_at' => $now,
+            'created_at' => $now,
+            'updated_at' => $now,
+        ]);
     }
 }

--- a/backend/app/Jobs/ExecuteDsarRequestJob.php
+++ b/backend/app/Jobs/ExecuteDsarRequestJob.php
@@ -1,0 +1,138 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Jobs;
+
+use App\Services\Attempts\UserDataLifecycleService;
+use App\Support\SchemaBaseline;
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Bus\Dispatchable;
+use Illuminate\Queue\InteractsWithQueue;
+use Illuminate\Queue\SerializesModels;
+use Illuminate\Support\Facades\DB;
+
+final class ExecuteDsarRequestJob implements ShouldQueue
+{
+    use Dispatchable, InteractsWithQueue, Queueable, SerializesModels;
+
+    public int $tries = 1;
+
+    public int $timeout = 600;
+
+    public bool $failOnTimeout = true;
+
+    public function __construct(
+        public string $requestId,
+        public int $orgId,
+        public int $actorUserId,
+        public string $taskId,
+        public string $referenceId,
+    ) {
+        $this->onConnection('database');
+        $this->onQueue('compliance');
+    }
+
+    public function handle(UserDataLifecycleService $service): void
+    {
+        $now = now();
+        $requestRow = DB::table('dsar_requests')
+            ->where('id', $this->requestId)
+            ->where('org_id', $this->orgId)
+            ->first();
+
+        if ($requestRow === null) {
+            return;
+        }
+
+        $currentStatus = trim((string) ($requestRow->status ?? 'pending'));
+        if (in_array($currentStatus, ['done', 'failed'], true)) {
+            return;
+        }
+
+        if (SchemaBaseline::hasTable('dsar_request_tasks')) {
+            DB::table('dsar_request_tasks')
+                ->where('id', $this->taskId)
+                ->where('request_id', $this->requestId)
+                ->update([
+                    'status' => 'running',
+                    'started_at' => $now,
+                    'updated_at' => $now,
+                ]);
+        }
+
+        $result = $service->process(
+            $this->orgId,
+            (int) ($requestRow->subject_user_id ?? 0),
+            (string) ($requestRow->mode ?? 'hybrid_anonymize'),
+            [
+                'actor_user_id' => $this->actorUserId,
+                'request_id' => $this->requestId,
+                'reason' => (string) ($requestRow->reason ?? 'user_dsar_request'),
+            ]
+        );
+
+        $finalStatus = ($result['ok'] ?? false) === true ? 'done' : 'failed';
+        $finishedAt = now();
+
+        DB::table('dsar_requests')
+            ->where('id', $this->requestId)
+            ->where('org_id', $this->orgId)
+            ->update([
+                'status' => $finalStatus,
+                'result_json' => json_encode($result, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES),
+                'executed_by_user_id' => $this->actorUserId,
+                'executed_at' => $finishedAt,
+                'updated_at' => $finishedAt,
+            ]);
+
+        if (SchemaBaseline::hasTable('dsar_request_tasks')) {
+            DB::table('dsar_request_tasks')
+                ->where('id', $this->taskId)
+                ->where('request_id', $this->requestId)
+                ->update([
+                    'status' => $finalStatus,
+                    'error_code' => $finalStatus === 'failed' ? 'USER_DSAR_FAILED' : null,
+                    'stats_json' => json_encode([
+                        'result_ok' => ($result['ok'] ?? false) === true,
+                        'counts' => is_array($result['counts'] ?? null) ? $result['counts'] : null,
+                    ], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES),
+                    'finished_at' => $finishedAt,
+                    'updated_at' => $finishedAt,
+                ]);
+        }
+
+        $this->appendAuditTransition($currentStatus, $finalStatus, $result);
+    }
+
+    /**
+     * @param  array<string,mixed>  $result
+     */
+    private function appendAuditTransition(string $from, string $to, array $result): void
+    {
+        if (! SchemaBaseline::hasTable('dsar_audit_logs')) {
+            return;
+        }
+
+        $now = now();
+        DB::table('dsar_audit_logs')->insert([
+            'request_id' => $this->requestId,
+            'org_id' => $this->orgId,
+            'subject_user_id' => null,
+            'event_type' => 'dsar_status_transition',
+            'level' => $to === 'failed' ? 'error' : 'info',
+            'message' => sprintf('dsar request transitioned from %s to %s', $from, $to),
+            'context_json' => json_encode([
+                'from' => $from,
+                'to' => $to,
+                'reference_id' => $this->referenceId,
+                'task_id' => $this->taskId,
+                'result_ok' => ($result['ok'] ?? false) === true,
+            ], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES),
+            'occurred_at' => $now,
+            'created_at' => $now,
+            'updated_at' => $now,
+        ]);
+    }
+}

--- a/backend/tests/Feature/Compliance/DsarRequestApiTest.php
+++ b/backend/tests/Feature/Compliance/DsarRequestApiTest.php
@@ -4,9 +4,11 @@ declare(strict_types=1);
 
 namespace Tests\Feature\Compliance;
 
+use App\Jobs\ExecuteDsarRequestJob;
 use App\Services\Auth\FmTokenService;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Queue;
 use Illuminate\Support\Str;
 use Tests\TestCase;
 
@@ -16,6 +18,8 @@ final class DsarRequestApiTest extends TestCase
 
     public function test_owner_can_create_and_execute_user_dsar_request(): void
     {
+        Queue::fake();
+
         $orgId = 701;
         $ownerUserId = 70101;
         $subjectUserId = 70102;
@@ -58,9 +62,65 @@ final class DsarRequestApiTest extends TestCase
         $execute = $this->withHeaders($headers)
             ->postJson('/api/v0.3/compliance/dsar/requests/'.$requestId.'/execute');
 
-        $execute->assertStatus(200)
+        $execute->assertStatus(202)
+            ->assertJsonPath('ok', true)
+            ->assertJsonPath('request_id', $requestId)
+            ->assertJsonPath('status', 'running');
+        $taskId = (string) $execute->json('task_id');
+        $referenceId = (string) $execute->json('job_reference');
+        $this->assertNotSame('', $taskId);
+        $this->assertNotSame('', $referenceId);
+
+        Queue::assertPushed(ExecuteDsarRequestJob::class, function (ExecuteDsarRequestJob $job) use (
+            $requestId,
+            $orgId,
+            $ownerUserId,
+            $taskId,
+            $referenceId
+        ): bool {
+            return $job->requestId === $requestId
+                && $job->orgId === $orgId
+                && $job->actorUserId === $ownerUserId
+                && $job->taskId === $taskId
+                && $job->referenceId === $referenceId;
+        });
+
+        $this->withHeaders($headers)
+            ->getJson('/api/v0.3/compliance/dsar/requests/'.$requestId)
+            ->assertStatus(200)
+            ->assertJsonPath('ok', true)
+            ->assertJsonPath('request.status', 'running');
+
+        $executeReplay = $this->withHeaders($headers)
+            ->postJson('/api/v0.3/compliance/dsar/requests/'.$requestId.'/execute');
+
+        $executeReplay->assertStatus(202)
+            ->assertJsonPath('ok', true)
+            ->assertJsonPath('request_id', $requestId)
+            ->assertJsonPath('status', 'running')
+            ->assertJsonPath('task_id', $taskId)
+            ->assertJsonPath('job_reference', $referenceId);
+        Queue::assertPushed(ExecuteDsarRequestJob::class, 1);
+
+        $job = new ExecuteDsarRequestJob($requestId, $orgId, $ownerUserId, $taskId, $referenceId);
+        $job->handle(app(\App\Services\Attempts\UserDataLifecycleService::class));
+
+        $this->withHeaders($headers)
+            ->getJson('/api/v0.3/compliance/dsar/requests/'.$requestId)
+            ->assertStatus(200)
             ->assertJsonPath('ok', true)
             ->assertJsonPath('request.status', 'done');
+
+        $executeAfterDone = $this->withHeaders($headers)
+            ->postJson('/api/v0.3/compliance/dsar/requests/'.$requestId.'/execute');
+
+        $executeAfterDone->assertStatus(202)
+            ->assertJsonPath('ok', true)
+            ->assertJsonPath('request_id', $requestId)
+            ->assertJsonPath('status', 'done')
+            ->assertJsonPath('task_id', $taskId)
+            ->assertJsonPath('job_reference', $referenceId);
+        Queue::assertPushed(ExecuteDsarRequestJob::class, 1);
 
         $subjectTokenRow = DB::table('auth_tokens')
             ->where('token_hash', hash('sha256', $subjectToken))
@@ -134,6 +194,27 @@ final class DsarRequestApiTest extends TestCase
             ->orderByDesc('id')
             ->first();
         $this->assertNotNull($auditRow);
+
+        $statusTransitions = DB::table('dsar_audit_logs')
+            ->where('request_id', $requestId)
+            ->where('event_type', 'dsar_status_transition')
+            ->orderBy('id')
+            ->get();
+        $this->assertCount(2, $statusTransitions);
+
+        $firstTransition = $statusTransitions->first();
+        $firstContext = $this->decodeAuditContext($firstTransition?->context_json ?? null);
+        $this->assertSame('pending', (string) ($firstContext['from'] ?? ''));
+        $this->assertSame('running', (string) ($firstContext['to'] ?? ''));
+        $this->assertSame($taskId, (string) ($firstContext['task_id'] ?? ''));
+        $this->assertSame($referenceId, (string) ($firstContext['reference_id'] ?? ''));
+
+        $lastTransition = $statusTransitions->last();
+        $lastContext = $this->decodeAuditContext($lastTransition?->context_json ?? null);
+        $this->assertSame('running', (string) ($lastContext['from'] ?? ''));
+        $this->assertSame('done', (string) ($lastContext['to'] ?? ''));
+        $this->assertSame($taskId, (string) ($lastContext['task_id'] ?? ''));
+        $this->assertSame($referenceId, (string) ($lastContext['reference_id'] ?? ''));
 
         $lifecycleAudit = DB::table('data_lifecycle_requests')
             ->where('request_type', 'user_dsar')
@@ -310,5 +391,22 @@ final class DsarRequestApiTest extends TestCase
         ]);
 
         return $orderNo;
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    private function decodeAuditContext(mixed $value): array
+    {
+        if (is_array($value)) {
+            return $value;
+        }
+        if (! is_string($value) || $value === '') {
+            return [];
+        }
+
+        $decoded = json_decode($value, true);
+
+        return is_array($decoded) ? $decoded : [];
     }
 }


### PR DESCRIPTION
Fixes FER2-26

## Summary
- switch `POST /api/v0.3/compliance/dsar/requests/{id}/execute` to async orchestration contract and always return `202 Accepted` with `task_id` and `job_reference`
- add `ExecuteDsarRequestJob` to process DSAR lifecycle asynchronously with task status updates (`pending -> running -> done/failed`) and status transition audit logs
- make execute idempotent by reusing existing orchestration metadata/task when request is already running or terminal
- update DSAR API feature test to cover queue dispatch, idempotent re-execute behavior, status progression visibility, and transition audit contract

## Verification
- `php artisan test --filter='DsarRequestApiTest'`
- `bash backend/scripts/ci_verify_mbti.sh`
