### PR TITLE
chore(security): harden auth/guest route contract and deploy checks

### DIFF
--- a/.github/workflows/ci_verify_mbti.yml
+++ b/.github/workflows/ci_verify_mbti.yml
@@ -186,6 +186,8 @@ jobs:
           php artisan test --filter OrgContextMiddlewareTest
           php artisan test --filter MeAttemptsAuthContractTest
           php artisan test --filter ApiErrorContractMiddlewareTest
+          php artisan test --filter AuthGuestTokenTest
+          php artisan test --filter AuthGuestRouteWiringTest
 
       - name: Run content pack manifest consistency tests
         working-directory: backend

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -64,6 +64,7 @@ jobs:
       DEPLOY_HOST_PROD: "122.152.221.126"
       DEPLOY_PATH_PROD: "/var/www/fap-api"
       HEALTHCHECK_URL_PROD: "https://fermatmind.com/api/healthz"
+      AUTH_GUEST_CHECK_URL_PROD: "https://fermatmind.com/api/v0.3/auth/guest"
 
       # ====== staging ======
       DEPLOY_USER_STG: "ubuntu"
@@ -71,6 +72,7 @@ jobs:
       DEPLOY_HOST_STG: "49.234.55.28"
       DEPLOY_PATH_STG: "/var/www/fap-api-staging"
       HEALTHCHECK_URL_STG: "https://staging.fermatmind.com/api/healthz"
+      AUTH_GUEST_CHECK_URL_STG: "https://staging.fermatmind.com/api/v0.3/auth/guest"
 
     steps:
       - name: Checkout code
@@ -105,6 +107,7 @@ jobs:
               DEPLOY_PORT="$DEPLOY_PORT_PROD"
               DEPLOY_PATH="$DEPLOY_PATH_PROD"
               HEALTHCHECK_URL="$HEALTHCHECK_URL_PROD"
+              AUTH_GUEST_CHECK_URL="$AUTH_GUEST_CHECK_URL_PROD"
               ;;
             staging)
               DEPLOY_HOST="$DEPLOY_HOST_STG"
@@ -112,6 +115,7 @@ jobs:
               DEPLOY_PORT="$DEPLOY_PORT_STG"
               DEPLOY_PATH="$DEPLOY_PATH_STG"
               HEALTHCHECK_URL="$HEALTHCHECK_URL_STG"
+              AUTH_GUEST_CHECK_URL="$AUTH_GUEST_CHECK_URL_STG"
               ;;
             *)
               echo "invalid TARGET=$TARGET"
@@ -125,12 +129,14 @@ jobs:
             echo "DEPLOY_PORT=$DEPLOY_PORT"
             echo "DEPLOY_PATH=$DEPLOY_PATH"
             echo "HEALTHCHECK_URL=$HEALTHCHECK_URL"
+            echo "AUTH_GUEST_CHECK_URL=$AUTH_GUEST_CHECK_URL"
           } >> "$GITHUB_ENV"
 
           echo "TARGET=$TARGET"
           echo "SSH=$DEPLOY_USER@$DEPLOY_HOST:$DEPLOY_PORT"
           echo "DEPLOY_PATH=$DEPLOY_PATH"
           echo "HEALTHCHECK_URL=$HEALTHCHECK_URL"
+          echo "AUTH_GUEST_CHECK_URL=$AUTH_GUEST_CHECK_URL"
 
       - name: Gate - ci_verify_mbti (Phase D)
         env:
@@ -215,4 +221,19 @@ jobs:
             sleep 3
           done
           echo "Healthcheck failed"
+          exit 1
+
+      - name: Contract check (auth/guest post deploy)
+        shell: bash
+        run: |
+          set -euo pipefail
+          echo "Auth guest contract: $AUTH_GUEST_CHECK_URL"
+          for i in 1 2 3 4 5; do
+            OUT="$(curl -fsS --max-time 10 -X POST "$AUTH_GUEST_CHECK_URL" -H 'Content-Type: application/json' --data '{"anon_id":"deploy_contract_probe"}' || true)"
+            if echo "$OUT" | php -r '$j = json_decode(stream_get_contents(STDIN), true); exit((is_array($j) && (($j["ok"] ?? false) === true) && (($j["anon_id"] ?? "") === "deploy_contract_probe")) ? 0 : 1);'; then
+              exit 0
+            fi
+            sleep 2
+          done
+          echo "Auth guest contract check failed"
           exit 1

--- a/README_DEPLOY.md
+++ b/README_DEPLOY.md
@@ -172,8 +172,9 @@ cd /opt/fap-api/backend
 php artisan route:list
 php artisan migrate
 
-curl -i http://127.0.0.1:8000/api/v0.2/health
+curl -i http://127.0.0.1:8000/api/healthz
 curl -i http://127.0.0.1:8000/api/v0.4/boot
+curl -i -X POST http://127.0.0.1:8000/api/v0.3/auth/guest -H 'Content-Type: application/json' -d '{"anon_id":"deploy_contract_probe"}'
 curl -i -X POST http://127.0.0.1:8000/api/v0.3/attempts/start -H 'Content-Type: application/json' -d '{"scale_code":"MBTI"}'
 
 cd /opt/fap-api
@@ -182,7 +183,7 @@ bash backend/scripts/ci_verify_mbti.sh
 
 通过标准：
 - 路由与迁移命令成功。
-- 健康检查接口可达。
+- 健康检查接口可达，且 `/api/v0.3/auth/guest` 合约通过。
 - MBTI CI 验收链路通过。
 
 ## 8. 回滚流程

--- a/backend/scripts/ci_verify_mbti.sh
+++ b/backend/scripts/ci_verify_mbti.sh
@@ -309,12 +309,18 @@ ACCEPT_ORDER_SH="$SCRIPT_DIR/accept_lookup_order.sh"
 ACCEPT_ORDER="${ACCEPT_ORDER:-0}"  # 1=run, 0=skip
 SCALE_IDENTITY_CONTRACT_SH="$BACKEND_DIR/scripts/ci/verify_scale_identity_contract.sh"
 SCALE_IDENTITY_HARD_CUTOVER_SH="$BACKEND_DIR/scripts/ci/verify_scale_identity_hard_cutover.sh"
+AUTH_GUEST_CONTRACT_SH="$BACKEND_DIR/scripts/verify_auth_guest_contract.sh"
 
 if [[ "$ACCEPT_ORDER" == "1" ]]; then
   if [[ ! -f "$ACCEPT_ORDER_SH" ]]; then
     echo "[CI][FAIL] missing: $ACCEPT_ORDER_SH" >&2
     exit 14
   fi
+fi
+
+if [[ ! -x "$AUTH_GUEST_CONTRACT_SH" ]]; then
+  echo "[CI][FAIL] missing or not executable: $AUTH_GUEST_CONTRACT_SH" >&2
+  exit 14
 fi
 
 if [[ "$RUN_SCALE_IDENTITY_HARD_CUTOVER" == "1" ]]; then
@@ -1076,6 +1082,10 @@ php artisan test --filter MigrationRollbackSafetyTest
 php artisan test --filter MigrationsNoSilentCatchTest
 php artisan test --filter MigrationProtectedTablesNoDropTest
 echo "[CI] migration safety gates OK"
+
+echo "[CI] auth guest contract gate"
+bash scripts/verify_auth_guest_contract.sh
+echo "[CI] auth guest contract gate OK"
 
 echo "[CI] order security gate"
 bash scripts/verify_order_security.sh

--- a/backend/scripts/security_gate.sh
+++ b/backend/scripts/security_gate.sh
@@ -25,7 +25,7 @@ trap cleanup EXIT
 
 echo "[SECURITY_GATE] start"
 
-echo "[SECURITY_GATE] check 1/10: critical route auth invariants"
+echo "[SECURITY_GATE] check 1/11: critical route auth invariants"
 php -r '
 $path = getcwd() . "/routes/api.php";
 $source = file_get_contents($path);
@@ -54,7 +54,34 @@ if ($missing !== []) {
 }
 '
 
-echo "[SECURITY_GATE] check 2/10: no request->all() mass assignment sinks"
+echo "[SECURITY_GATE] check 2/11: v0.3 auth guest route contract"
+php -r '
+$path = getcwd() . "/routes/api.php";
+$source = file_get_contents($path);
+if (!is_string($source)) {
+    fwrite(STDERR, "[SECURITY_GATE][FAIL] unable to read {$path}\n");
+    exit(1);
+}
+
+$checks = [
+    "v0.3 auth middleware group" => "/Route::middleware\\(\\s*[\\x27\\x22]throttle:api_auth[\\x27\\x22]\\s*\\)\\s*->\\s*group\\s*\\(\\s*function\\s*\\(\\s*\\)\\s*\\{/s",
+    "v0.3 auth guest route" => "/Route::post\\(\\s*[\\x27\\x22]\\/auth\\/guest[\\x27\\x22]\\s*,\\s*AuthGuestV03Controller::class\\s*\\)\\s*->\\s*middleware\\(\\s*\\\\App\\\\Http\\\\Middleware\\\\ResolveAnonId::class\\s*\\)\\s*;/s",
+];
+
+$missing = [];
+foreach ($checks as $name => $regex) {
+    if (preg_match($regex, $source) !== 1) {
+        $missing[] = $name;
+    }
+}
+
+if ($missing !== []) {
+    fwrite(STDERR, "[SECURITY_GATE][FAIL] missing auth guest route invariants: " . implode(", ", $missing) . "\n");
+    exit(1);
+}
+'
+
+echo "[SECURITY_GATE] check 3/11: no request->all() mass assignment sinks"
 php -r '
 $roots = [
     getcwd() . "/routes",
@@ -145,7 +172,7 @@ if ($violations !== []) {
 }
 '
 
-echo "[SECURITY_GATE] check 3/10: ownership 404 contract (no 403 leaks)"
+echo "[SECURITY_GATE] check 4/11: ownership 404 contract (no 403 leaks)"
 php -r '
 $paths = [
     "app/Http/Controllers/API/V0_3/AttemptReadController.php",
@@ -228,7 +255,7 @@ if ($violations !== []) {
 }
 '
 
-echo "[SECURITY_GATE] check 4/10: v0.3 attempt ownership resolver must not trust anon headers"
+echo "[SECURITY_GATE] check 5/11: v0.3 attempt ownership resolver must not trust anon headers"
 php -r '
 $path = getcwd() . "/app/Http/Controllers/API/V0_3/Concerns/ResolvesAttemptOwnership.php";
 $source = file_get_contents($path);
@@ -250,7 +277,7 @@ foreach ($forbidden as $regex) {
 }
 '
 
-echo "[SECURITY_GATE] check 5/10: org context can hydrate anon identity from token payload"
+echo "[SECURITY_GATE] check 6/11: org context can hydrate anon identity from token payload"
 php -r '
 $path = getcwd() . "/app/Http/Middleware/ResolveOrgContext.php";
 $source = file_get_contents($path);
@@ -278,7 +305,7 @@ if ($missing !== []) {
 }
 '
 
-echo "[SECURITY_GATE] check 6/10: webhook signature verifier has no testing/local fail-open"
+echo "[SECURITY_GATE] check 7/11: webhook signature verifier has no testing/local fail-open"
 php -r '
 $path = getcwd() . "/app/Http/Controllers/Webhooks/HandleProviderWebhook.php";
 $source = file_get_contents($path);
@@ -298,7 +325,7 @@ if (preg_match("/allow_unsigned_without_secret/", $source) !== 1) {
 }
 '
 
-echo "[SECURITY_GATE] check 7/10: fm token middlewares enforce revoked/expired checks"
+echo "[SECURITY_GATE] check 8/11: fm token middlewares enforce revoked/expired checks"
 php -r '
 $paths = [
     "app/Http/Middleware/FmTokenAuth.php",
@@ -329,7 +356,7 @@ if ($missing !== []) {
 }
 '
 
-echo "[SECURITY_GATE] check 8/10: content pack API errors must not leak internal reason"
+echo "[SECURITY_GATE] check 9/11: content pack API errors must not leak internal reason"
 php -r '
 $path = getcwd() . "/app/Support/ApiExceptionRenderer.php";
 $source = file_get_contents($path);
@@ -349,7 +376,7 @@ if (preg_match("/[\\x27\\x22]reason[\\x27\\x22]\\s*=>/", $source) === 1) {
 }
 '
 
-echo "[SECURITY_GATE] check 9/10: v0.2 must stay on deprecated 410 contract"
+echo "[SECURITY_GATE] check 10/11: v0.2 must stay on deprecated 410 contract"
 php -r '
 $path = getcwd() . "/routes/api.php";
 $source = file_get_contents($path);
@@ -359,7 +386,7 @@ if (!is_string($source)) {
 }
 
 $checks = [
-    "v0.2 retired prefix" => "/Route::prefix\\(\\s*\\x22v0\\.2\\x22\\s*\\)/",
+    "v0.2 retired prefix" => "/Route::prefix\\(\\s*[\\x27\\x22]v0\\.2[\\x27\\x22]\\s*\\)/",
     "v0.2 deprecated error code" => "/[\\x27\\x22]error_code[\\x27\\x22]\\s*=>\\s*[\\x27\\x22]API_VERSION_DEPRECATED[\\x27\\x22]/",
     "v0.2 deprecated 410 status" => "/\\],\\s*410\\s*\\)/",
 ];
@@ -377,7 +404,7 @@ if ($missing !== []) {
 }
 '
 
-echo "[SECURITY_GATE] check 10/10: unit guard test"
+echo "[SECURITY_GATE] check 11/11: unit guard test"
 php artisan test --testsuite=Unit --filter=SecurityGuardrailsTest
 
 echo "[SECURITY_GATE] PASS"

--- a/backend/scripts/verify_auth_guest_contract.sh
+++ b/backend/scripts/verify_auth_guest_contract.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "${ROOT_DIR}"
+
+echo "[AUTH_GUEST_CONTRACT] verify route + middleware invariants"
+php -r '
+require __DIR__ . "/vendor/autoload.php";
+$app = require __DIR__ . "/bootstrap/app.php";
+$kernel = $app->make(Illuminate\Contracts\Console\Kernel::class);
+$kernel->bootstrap();
+
+$routes = app("router")->getRoutes();
+$route = $routes->match(Illuminate\Http\Request::create("/api/v0.3/auth/guest", "POST"));
+if (!$route) {
+    fwrite(STDERR, "[AUTH_GUEST_CONTRACT][FAIL] route not found\n");
+    exit(1);
+}
+
+$middlewares = $route->gatherMiddleware();
+$required = ["throttle:api_auth", "App\\Http\\Middleware\\ResolveAnonId"];
+$missing = [];
+foreach ($required as $item) {
+    if (!in_array($item, $middlewares, true)) {
+        $missing[] = $item;
+    }
+}
+
+if ($missing !== []) {
+    fwrite(STDERR, "[AUTH_GUEST_CONTRACT][FAIL] missing middleware: " . implode(", ", $missing) . "\n");
+    exit(1);
+}
+'
+
+echo "[AUTH_GUEST_CONTRACT] phpunit contract tests"
+php artisan test --filter AuthGuestTokenTest
+php artisan test --filter AuthGuestRouteWiringTest
+
+echo "[AUTH_GUEST_CONTRACT] PASS"

--- a/backend/tests/Feature/V0_3/AuthGuestRouteWiringTest.php
+++ b/backend/tests/Feature/V0_3/AuthGuestRouteWiringTest.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\V0_3;
+
+use App\Http\Controllers\API\V0_3\AuthGuestController;
+use App\Http\Middleware\ResolveAnonId;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Http\Request;
+use Tests\TestCase;
+
+final class AuthGuestRouteWiringTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_auth_guest_route_is_public_and_has_expected_middlewares(): void
+    {
+        $route = app('router')->getRoutes()->match(Request::create('/api/v0.3/auth/guest', 'POST'));
+        $this->assertNotNull($route);
+        $this->assertStringContainsString(AuthGuestController::class, $route->getActionName());
+
+        $middlewares = $route->gatherMiddleware();
+        $this->assertContains('throttle:api_auth', $middlewares);
+        $this->assertContains(ResolveAnonId::class, $middlewares);
+
+        $joined = implode(',', $middlewares);
+        $this->assertStringNotContainsString('FmTokenAuth', $joined);
+
+        $response = $this->postJson('/api/v0.3/auth/guest', [
+            'anon_id' => 'anon_guest_route_wiring_001',
+        ]);
+
+        $response->assertStatus(200)->assertJson([
+            'ok' => true,
+            'anon_id' => 'anon_guest_route_wiring_001',
+        ]);
+    }
+}
+

--- a/backend/tests/Unit/Security/SecurityGuardrailsTest.php
+++ b/backend/tests/Unit/Security/SecurityGuardrailsTest.php
@@ -284,6 +284,21 @@ final class SecurityGuardrailsTest extends TestCase
         $this->assertDoesNotMatchRegularExpression('/[\'"]reason[\'"]\s*=>/', $source);
     }
 
+    public function test_v03_auth_guest_route_wiring_and_middleware_contract(): void
+    {
+        $source = file_get_contents(base_path('routes/api.php'));
+        $this->assertIsString($source);
+
+        $this->assertMatchesRegularExpression(
+            '/Route::middleware\(\s*[\'"]throttle:api_auth[\'"]\s*\)\s*->\s*group\s*\(\s*function\s*\(\s*\)\s*\{/s',
+            $source
+        );
+        $this->assertMatchesRegularExpression(
+            '/Route::post\(\s*[\'"]\/auth\/guest[\'"]\s*,\s*AuthGuestV03Controller::class\s*\)\s*->\s*middleware\(\s*\\\\App\\\\Http\\\\Middleware\\\\ResolveAnonId::class\s*\)\s*;/s',
+            $source
+        );
+    }
+
     public function test_v02_routes_use_deprecated_410_contract(): void
     {
         $source = file_get_contents(base_path('routes/api.php'));

--- a/deploy.php
+++ b/deploy.php
@@ -203,7 +203,17 @@ task('ensure:phpredis', function () {
  */
 task('healthcheck:public', function () {
     $host = get('healthcheck_host');
-    $cmd  = "curl -fsS --resolve {$host}:443:127.0.0.1 https://{$host}/api/v0.2/healthz | jq -e '.ok==true'";
+    $cmd  = "curl -fsS --resolve {$host}:443:127.0.0.1 https://{$host}/api/healthz | jq -e '.ok==true'";
+    run($cmd);
+});
+
+task('healthcheck:auth-guest-contract', function () {
+    $host = get('healthcheck_host');
+    $payload = escapeshellarg((string) json_encode([
+        'anon_id' => 'deploy_contract_probe',
+    ], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES));
+
+    $cmd = "curl -fsS --resolve {$host}:443:127.0.0.1 -H 'Content-Type: application/json' -X POST https://{$host}/api/v0.3/auth/guest --data {$payload} | jq -e '.ok==true and .anon_id==\"deploy_contract_probe\"'";
     run($cmd);
 });
 
@@ -232,6 +242,6 @@ after('deploy:shared', 'ensure:healthz-deps');
 after('deploy:symlink', 'reload:php-fpm');
 after('deploy:symlink', 'reload:nginx');
 after('deploy:symlink', 'healthcheck:public');
+after('deploy:symlink', 'healthcheck:auth-guest-contract');
 
 after('deploy:failed', 'deploy:unlock');
-


### PR DESCRIPTION
## Summary
This PR completes the anti-regression hardening for the `v0.3 auth/guest` entrypoint and closes the remaining guard gaps:
- add route/middleware contract assertions for `/api/v0.3/auth/guest`
- wire auth/guest checks into security gate + CI verify chain
- add deploy-time post-check for auth/guest contract
- fix deploy public health check path from deprecated `/api/v0.2/healthz` to `/api/healthz`

## Changes
1. Security and unit guardrails
- `backend/scripts/security_gate.sh`
  - add `check 2/11` for `throttle:api_auth` group + `/auth/guest` + `ResolveAnonId`
  - update check numbering to `1/11 ... 11/11`
  - make v0.2 prefix regex quote-style tolerant (`'` or `"`)
- `backend/tests/Unit/Security/SecurityGuardrailsTest.php`
  - add `test_v03_auth_guest_route_wiring_and_middleware_contract`

2. Feature and script contract coverage
- add `backend/tests/Feature/V0_3/AuthGuestRouteWiringTest.php`
  - verify route resolves to `AuthGuestController`
  - verify middleware contains `throttle:api_auth` and `ResolveAnonId`
  - verify no auth middleware requirement leak (`FmTokenAuth` absent)
  - verify endpoint returns `ok=true` contract
- add `backend/scripts/verify_auth_guest_contract.sh`
  - runtime route+middleware invariant check
  - run `AuthGuestTokenTest` + `AuthGuestRouteWiringTest`
- `backend/scripts/ci_verify_mbti.sh`
  - require executable `verify_auth_guest_contract.sh`
  - run auth/guest contract gate before order security gate

3. CI and deploy hardening
- `.github/workflows/ci_verify_mbti.yml`
  - add `AuthGuestTokenTest`
  - add `AuthGuestRouteWiringTest`
- `deploy.php`
  - healthcheck path: `/api/v0.2/healthz` -> `/api/healthz`
  - add `healthcheck:auth-guest-contract` task
  - run `healthcheck:auth-guest-contract` after symlink
- `.github/workflows/deploy.yml`
  - add envs for auth/guest post-deploy check URLs
  - add `Contract check (auth/guest post deploy)` step
- `README_DEPLOY.md`
  - update post-deploy checklist with `/api/healthz` and `/api/v0.3/auth/guest` probe

## Validation
Executed locally:
- `php artisan test --testsuite=Unit --filter=SecurityGuardrailsTest`
- `php artisan test --filter=AuthGuestTokenTest`
- `php artisan test --filter=AuthGuestRouteWiringTest`
- `bash backend/scripts/security_gate.sh`
- `bash backend/scripts/verify_auth_guest_contract.sh`

All passed.

## Notes
- Existing unrelated dirty files under `backend/content_packs/EQ_60/v1/compiled/*` were intentionally not included in this PR.
