### PR TITLE
Fixes FER2-30: stage AttemptSubmit pipeline without behavior change

### DIFF
--- a/backend/app/Services/Attempts/AttemptSubmitService.php
+++ b/backend/app/Services/Attempts/AttemptSubmitService.php
@@ -39,6 +39,19 @@ class AttemptSubmitService
 
     public function submit(OrgContext $ctx, string $attemptId, SubmitAttemptDTO $dto): array
     {
+        $guarded = $this->stageGuard($ctx, $attemptId, $dto);
+        $canonicalized = $this->stageCanonicalize($guarded);
+        $scored = $this->stageScore($canonicalized);
+        $tx = $this->stageTx($ctx, $canonicalized, $scored);
+
+        return $this->stagePostCommit($ctx, $canonicalized, $scored, $tx);
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    private function stageGuard(OrgContext $ctx, string $attemptId, SubmitAttemptDTO $dto): array
+    {
         $attemptId = trim($attemptId);
         if ($attemptId === '') {
             throw new ApiProblemException(400, 'VALIDATION_FAILED', 'attempt_id is required.');
@@ -89,6 +102,57 @@ class AttemptSubmitService
 
         ScaleRolloutGate::assertEnabled($scaleCode, $row, $region, $attemptId);
 
+        return [
+            'attempt_id' => $attemptId,
+            'dto' => $dto,
+            'answers' => $answers,
+            'validity_items' => $validityItems,
+            'duration_ms' => $durationMs,
+            'invite_token' => $inviteToken,
+            'actor_user_id' => $actorUserId,
+            'actor_anon_id' => $actorAnonId,
+            'org_id' => $orgId,
+            'attempt' => $attempt,
+            'scale_code' => $scaleCode,
+            'registry_row' => $row,
+            'scale_code_v2' => $scaleCodeV2,
+            'scale_uid' => $scaleUid,
+            'write_scale_identity' => $writeScaleIdentity,
+            'pack_id' => $packId,
+            'dir_version' => $dirVersion,
+            'region' => $region,
+            'locale' => $locale,
+        ];
+    }
+
+    /**
+     * @param  array<string,mixed>  $guarded
+     * @return array<string,mixed>
+     */
+    private function stageCanonicalize(array $guarded): array
+    {
+        /** @var Attempt $attempt */
+        $attempt = $guarded['attempt'];
+        $answers = (array) ($guarded['answers'] ?? []);
+        $scaleCode = (string) ($guarded['scale_code'] ?? '');
+        $packId = (string) ($guarded['pack_id'] ?? '');
+        $dirVersion = (string) ($guarded['dir_version'] ?? '');
+        $durationMs = (int) ($guarded['duration_ms'] ?? 0);
+        $orgId = (int) ($guarded['org_id'] ?? 0);
+        $actorAnonId = $guarded['actor_anon_id'] ?? null;
+        if ($actorAnonId !== null) {
+            $actorAnonId = (string) $actorAnonId;
+        }
+
+        $actorUserId = $guarded['actor_user_id'] ?? null;
+        if ($actorUserId !== null) {
+            $actorUserId = (string) $actorUserId;
+        }
+        $attemptId = (string) ($guarded['attempt_id'] ?? '');
+        $validityItems = (array) ($guarded['validity_items'] ?? []);
+        $region = (string) ($guarded['region'] ?? '');
+        $locale = (string) ($guarded['locale'] ?? '');
+
         $draftAnswers = $this->progressService->loadDraftAnswers($attempt);
         $mergedAnswers = $this->mergeAnswersForSubmit($answers, $draftAnswers);
         if (empty($mergedAnswers)) {
@@ -126,6 +190,30 @@ class AttemptSubmitService
             'experiments_json' => $experiments,
         ];
 
+        return array_merge($guarded, [
+            'merged_answers' => $mergedAnswers,
+            'answers_digest' => $answersDigest,
+            'submitted_at' => $submittedAt,
+            'server_duration_seconds' => $serverDurationSeconds,
+            'experiments' => $experiments,
+            'score_context' => $scoreContext,
+        ]);
+    }
+
+    /**
+     * @param  array<string,mixed>  $canonicalized
+     * @return array<string,mixed>
+     */
+    private function stageScore(array $canonicalized): array
+    {
+        $scaleCode = (string) ($canonicalized['scale_code'] ?? '');
+        $orgId = (int) ($canonicalized['org_id'] ?? 0);
+        $packId = (string) ($canonicalized['pack_id'] ?? '');
+        $dirVersion = (string) ($canonicalized['dir_version'] ?? '');
+        $mergedAnswers = (array) ($canonicalized['merged_answers'] ?? []);
+        $scoreContext = (array) ($canonicalized['score_context'] ?? []);
+        $registryRow = (array) ($canonicalized['registry_row'] ?? []);
+
         $scored = $this->assessmentRunner->run(
             $scaleCode,
             $orgId,
@@ -155,7 +243,7 @@ class AttemptSubmitService
             ? $scored['model_selection']
             : [];
 
-        $commercial = $row['commercial_json'] ?? null;
+        $commercial = $registryRow['commercial_json'] ?? null;
         if (is_string($commercial)) {
             $decoded = json_decode($commercial, true);
             $commercial = is_array($decoded) ? $decoded : null;
@@ -170,6 +258,59 @@ class AttemptSubmitService
         if ($entitlementBenefitCode === '') {
             $entitlementBenefitCode = $creditBenefitCode;
         }
+
+        return [
+            'score_result' => $scoreResult,
+            'content_package_version' => $contentPackageVersion,
+            'scoring_spec_version' => $scoringSpecVersion,
+            'model_selection' => $modelSelection,
+            'credit_benefit_code' => $creditBenefitCode,
+            'entitlement_benefit_code' => $entitlementBenefitCode,
+        ];
+    }
+
+    /**
+     * @param  array<string,mixed>  $canonicalized
+     * @param  array<string,mixed>  $scored
+     * @return array<string,mixed>
+     */
+    private function stageTx(OrgContext $ctx, array $canonicalized, array $scored): array
+    {
+        $attemptId = (string) ($canonicalized['attempt_id'] ?? '');
+        $mergedAnswers = (array) ($canonicalized['merged_answers'] ?? []);
+        $answersDigest = (string) ($canonicalized['answers_digest'] ?? '');
+        $durationMs = (int) ($canonicalized['duration_ms'] ?? 0);
+        $orgId = (int) ($canonicalized['org_id'] ?? 0);
+        $scaleCode = (string) ($canonicalized['scale_code'] ?? '');
+        $packId = (string) ($canonicalized['pack_id'] ?? '');
+        $dirVersion = (string) ($canonicalized['dir_version'] ?? '');
+        $region = (string) ($canonicalized['region'] ?? '');
+        $locale = (string) ($canonicalized['locale'] ?? '');
+        $inviteToken = (string) ($canonicalized['invite_token'] ?? '');
+        $actorUserId = $canonicalized['actor_user_id'] ?? null;
+        if ($actorUserId !== null) {
+            $actorUserId = (string) $actorUserId;
+        }
+
+        $actorAnonId = $canonicalized['actor_anon_id'] ?? null;
+        if ($actorAnonId !== null) {
+            $actorAnonId = (string) $actorAnonId;
+        }
+        $validityItems = (array) ($canonicalized['validity_items'] ?? []);
+        $submittedAt = $canonicalized['submitted_at'] ?? now();
+        $writeScaleIdentity = (bool) ($canonicalized['write_scale_identity'] ?? false);
+        $scaleCodeV2 = (string) ($canonicalized['scale_code_v2'] ?? '');
+        $scaleUid = $canonicalized['scale_uid'] ?? null;
+
+        $scoreResult = $scored['score_result'];
+        $contentPackageVersion = (string) ($scored['content_package_version'] ?? '');
+        $scoringSpecVersion = (string) ($scored['scoring_spec_version'] ?? '');
+        $modelSelection = is_array($scored['model_selection'] ?? null)
+            ? $scored['model_selection']
+            : [];
+        $creditBenefitCode = (string) ($scored['credit_benefit_code'] ?? '');
+        $entitlementBenefitCode = (string) ($scored['entitlement_benefit_code'] ?? '');
+        $experiments = is_array($canonicalized['experiments'] ?? null) ? $canonicalized['experiments'] : [];
 
         $responsePayload = null;
         $postCommitCtx = null;
@@ -517,6 +658,41 @@ class AttemptSubmitService
         if (! is_array($responsePayload)) {
             throw new ApiProblemException(500, 'INTERNAL_ERROR', 'unexpected submit state.');
         }
+
+        return [
+            'response_payload' => $responsePayload,
+            'post_commit_ctx' => $postCommitCtx,
+        ];
+    }
+
+    /**
+     * @param  array<string,mixed>  $canonicalized
+     * @param  array<string,mixed>  $scored
+     * @param  array<string,mixed>  $tx
+     * @return array<string,mixed>
+     */
+    private function stagePostCommit(OrgContext $ctx, array $canonicalized, array $scored, array $tx): array
+    {
+        /** @var Attempt $attempt */
+        $attempt = $canonicalized['attempt'];
+        $attemptId = (string) ($canonicalized['attempt_id'] ?? '');
+        $orgId = (int) ($canonicalized['org_id'] ?? 0);
+        $scaleCode = (string) ($canonicalized['scale_code'] ?? '');
+        $locale = (string) ($canonicalized['locale'] ?? '');
+        $region = (string) ($canonicalized['region'] ?? '');
+        $dirVersion = (string) ($canonicalized['dir_version'] ?? '');
+        $actorUserId = $canonicalized['actor_user_id'] ?? null;
+        if ($actorUserId !== null) {
+            $actorUserId = (string) $actorUserId;
+        }
+
+        $actorAnonId = $canonicalized['actor_anon_id'] ?? null;
+        if ($actorAnonId !== null) {
+            $actorAnonId = (string) $actorAnonId;
+        }
+        $scoringSpecVersion = (string) ($scored['scoring_spec_version'] ?? '');
+        $responsePayload = is_array($tx['response_payload'] ?? null) ? $tx['response_payload'] : [];
+        $postCommitCtx = is_array($tx['post_commit_ctx'] ?? null) ? $tx['post_commit_ctx'] : null;
 
         $snapshotJobCtx = null;
         if (($responsePayload['ok'] ?? false) === true && is_array($postCommitCtx)) {

--- a/backend/tests/Feature/V0_3/AttemptSubmitRefactorParityTest.php
+++ b/backend/tests/Feature/V0_3/AttemptSubmitRefactorParityTest.php
@@ -35,14 +35,36 @@ final class AttemptSubmitRefactorParityTest extends TestCase
         return $token;
     }
 
-    public function test_submit_flow_keeps_result_and_attempt_state_consistent(): void
+    /**
+     * @return array<int, array{question_id:string,code:string}>
+     */
+    private function baseAnswers(): array
     {
-        (new ScaleRegistrySeeder())->run();
-        (new Pr17SimpleScoreDemoSeeder())->run();
+        return [
+            ['question_id' => 'SS-001', 'code' => '5'],
+            ['question_id' => 'SS-002', 'code' => '4'],
+            ['question_id' => 'SS-003', 'code' => '3'],
+            ['question_id' => 'SS-004', 'code' => '2'],
+            ['question_id' => 'SS-005', 'code' => '1'],
+        ];
+    }
 
-        $anonId = 'refactor-parity-anon';
-        $anonToken = $this->issueAnonToken($anonId);
+    /**
+     * @return array<int, array{question_id:string,code:string}>
+     */
+    private function differentDigestAnswers(): array
+    {
+        return [
+            ['question_id' => 'SS-001', 'code' => '1'],
+            ['question_id' => 'SS-002', 'code' => '4'],
+            ['question_id' => 'SS-003', 'code' => '3'],
+            ['question_id' => 'SS-004', 'code' => '2'],
+            ['question_id' => 'SS-005', 'code' => '1'],
+        ];
+    }
 
+    private function startAttempt(string $anonId): string
+    {
         $start = $this->withHeaders(['X-Anon-Id' => $anonId])->postJson('/api/v0.3/attempts/start', [
             'scale_code' => 'SIMPLE_SCORE_DEMO',
             'anon_id' => $anonId,
@@ -52,26 +74,106 @@ final class AttemptSubmitRefactorParityTest extends TestCase
         $attemptId = (string) $start->json('attempt_id');
         $this->assertNotSame('', $attemptId);
 
-        $submit = $this->withHeaders([
+        return $attemptId;
+    }
+
+    /**
+     * @param array<int, array{question_id:string,code:string}> $answers
+     * @return array<string,mixed>
+     */
+    private function submitPayload(string $anonId, string $anonToken, string $attemptId, array $answers): array
+    {
+        $response = $this->withHeaders([
             'X-Anon-Id' => $anonId,
             'Authorization' => 'Bearer ' . $anonToken,
         ])->postJson('/api/v0.3/attempts/submit', [
             'attempt_id' => $attemptId,
-            'answers' => [
-                ['question_id' => 'SS-001', 'code' => '5'],
-                ['question_id' => 'SS-002', 'code' => '4'],
-                ['question_id' => 'SS-003', 'code' => '3'],
-                ['question_id' => 'SS-004', 'code' => '2'],
-                ['question_id' => 'SS-005', 'code' => '1'],
-            ],
+            'answers' => $answers,
             'duration_ms' => 120000,
         ]);
 
-        $submit->assertStatus(200);
-        $submit->assertJson([
-            'ok' => true,
-            'attempt_id' => $attemptId,
-        ]);
+        return [
+            'status' => $response->status(),
+            'json' => $response->json(),
+        ];
+    }
+
+    /**
+     * @param array<string,mixed> $first
+     * @param array<string,mixed> $replay
+     */
+    private function assertStableContract(array $first, array $replay): void
+    {
+        $this->assertSame($first['ok'] ?? null, $replay['ok'] ?? null);
+        $this->assertSame($first['attempt_id'] ?? null, $replay['attempt_id'] ?? null);
+        $this->assertSame($first['type_code'] ?? null, $replay['type_code'] ?? null);
+        $this->assertSame(
+            $this->normalizeAssocOrder($first['scores'] ?? null),
+            $this->normalizeAssocOrder($replay['scores'] ?? null)
+        );
+        $this->assertSame(
+            $this->normalizeAssocOrder($first['scores_pct'] ?? null),
+            $this->normalizeAssocOrder($replay['scores_pct'] ?? null)
+        );
+
+        $stablePaths = [
+            'result.pack_id',
+            'result.dir_version',
+            'result.content_package_version',
+            'result.scoring_spec_version',
+            'result.type_code',
+            'result.scale_code',
+            'result.scale_code_legacy',
+            'result.scale_code_v2',
+            'result.scale_uid',
+        ];
+
+        foreach ($stablePaths as $path) {
+            $this->assertSame(data_get($first, $path), data_get($replay, $path), 'mismatch on path: ' . $path);
+        }
+    }
+
+    private function normalizeAssocOrder(mixed $value): mixed
+    {
+        if (! is_array($value)) {
+            return $value;
+        }
+
+        if (array_is_list($value)) {
+            return array_map(fn ($item) => $this->normalizeAssocOrder($item), $value);
+        }
+
+        $normalized = [];
+        $keys = array_keys($value);
+        sort($keys);
+
+        foreach ($keys as $key) {
+            $normalized[$key] = $this->normalizeAssocOrder($value[$key]);
+        }
+
+        return $normalized;
+    }
+
+    public function test_same_digest_replay_keeps_submit_contract_stable(): void
+    {
+        (new ScaleRegistrySeeder())->run();
+        (new Pr17SimpleScoreDemoSeeder())->run();
+
+        $anonId = 'refactor-parity-anon';
+        $anonToken = $this->issueAnonToken($anonId);
+        $attemptId = $this->startAttempt($anonId);
+
+        $first = $this->submitPayload($anonId, $anonToken, $attemptId, $this->baseAnswers());
+        $this->assertSame(200, $first['status']);
+        $this->assertTrue((bool) data_get($first, 'json.ok', false));
+        $this->assertFalse((bool) data_get($first, 'json.idempotent', true));
+
+        $replay = $this->submitPayload($anonId, $anonToken, $attemptId, $this->baseAnswers());
+        $this->assertSame(200, $replay['status']);
+        $this->assertTrue((bool) data_get($replay, 'json.ok', false));
+        $this->assertTrue((bool) data_get($replay, 'json.idempotent', false));
+
+        $this->assertStableContract((array) $first['json'], (array) $replay['json']);
 
         $attempt = Attempt::query()->where('id', $attemptId)->first();
         $result = Result::query()->where('attempt_id', $attemptId)->first();
@@ -79,7 +181,26 @@ final class AttemptSubmitRefactorParityTest extends TestCase
         $this->assertNotNull($attempt);
         $this->assertNotNull($attempt?->submitted_at);
         $this->assertNotNull($result);
-        $this->assertSame($attemptId, (string) $result?->attempt_id);
-        $this->assertIsArray($submit->json('report'));
+        $this->assertSame(1, Result::query()->where('attempt_id', $attemptId)->count());
+        $this->assertSame(1, DB::table('attempt_answer_sets')->where('attempt_id', $attemptId)->count());
+        $this->assertNotSame('', trim((string) ($attempt?->answers_digest ?? '')));
+    }
+
+    public function test_different_digest_replay_returns_409_conflict(): void
+    {
+        (new ScaleRegistrySeeder())->run();
+        (new Pr17SimpleScoreDemoSeeder())->run();
+
+        $anonId = 'refactor-parity-conflict';
+        $anonToken = $this->issueAnonToken($anonId);
+        $attemptId = $this->startAttempt($anonId);
+
+        $first = $this->submitPayload($anonId, $anonToken, $attemptId, $this->baseAnswers());
+        $this->assertSame(200, $first['status']);
+
+        $conflict = $this->submitPayload($anonId, $anonToken, $attemptId, $this->differentDigestAnswers());
+        $this->assertSame(409, $conflict['status']);
+        $this->assertFalse((bool) data_get($conflict, 'json.ok', true));
+        $this->assertSame('CONFLICT', (string) data_get($conflict, 'json.error_code', ''));
     }
 }


### PR DESCRIPTION
Fixes FER2-30

## Summary
- Refactored `AttemptSubmitService::submit` into a 5-stage pipeline (`Guard -> Canonicalize -> Score -> Tx -> PostCommit`) with `submit()` as an orchestrator only.
- Kept submit semantics unchanged for conflict/idempotent replay handling, DB writes, events, and post-commit dispatch behavior.
- Expanded `AttemptSubmitRefactorParityTest` to cover same-digest replay parity and different-digest 409 conflict contract with stable key-field assertions.

## Verification
- php artisan route:list
- php artisan migrate
- php artisan test --filter AttemptSubmitRefactorParityTest
- php artisan test --filter AttemptSubmitIdempotencyTest
- php artisan test --filter TransactionSlimmingTest
- bash backend/scripts/ci_verify_mbti.sh
