### PR TITLE
Fixes FER2-27: enforce queue SLO strict gate and alert outlet

### DIFF
--- a/backend/app/Console/Commands/Ops/QueueBacklogProbe.php
+++ b/backend/app/Console/Commands/Ops/QueueBacklogProbe.php
@@ -6,6 +6,7 @@ namespace App\Console\Commands\Ops;
 
 use App\Services\Ops\QueueBacklogProbeService;
 use Illuminate\Console\Command;
+use Illuminate\Support\Facades\Log;
 
 final class QueueBacklogProbe extends Command
 {
@@ -70,6 +71,7 @@ final class QueueBacklogProbe extends Command
         $payload['queues'] = $assessment['queues'];
         $payload['violations'] = $assessment['violations'];
         $payload['pass'] = $assessment['pass'];
+        $this->emitBreachAlertOutlet($payload);
 
         if ($this->isTruthy($this->option('json'))) {
             $this->line((string) json_encode($payload, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES));
@@ -109,6 +111,29 @@ final class QueueBacklogProbe extends Command
         }
 
         return self::SUCCESS;
+    }
+
+    /**
+     * @param  array<string,mixed>  $payload
+     */
+    private function emitBreachAlertOutlet(array $payload): void
+    {
+        $violations = is_array($payload['violations'] ?? null) ? $payload['violations'] : [];
+        if ($violations === []) {
+            return;
+        }
+
+        $slo = is_array($payload['slo'] ?? null) ? $payload['slo'] : [];
+        Log::warning('QUEUE_BACKLOG_SLO_BREACH', [
+            'strict' => (bool) ($slo['strict'] ?? false),
+            'pass' => (bool) ($payload['pass'] ?? false),
+            'violations' => $violations,
+            'queues' => is_array($payload['queues'] ?? null) ? $payload['queues'] : [],
+            'thresholds' => is_array($payload['thresholds'] ?? null) ? $payload['thresholds'] : [],
+            'window_minutes' => (int) ($payload['window_minutes'] ?? 0),
+            'queue_driver' => (string) ($payload['queue_driver'] ?? ''),
+            'queue_connection' => (string) ($payload['queue_connection'] ?? ''),
+        ]);
     }
 
     /**

--- a/backend/scripts/ci_verify_mbti.sh
+++ b/backend/scripts/ci_verify_mbti.sh
@@ -1144,14 +1144,14 @@ php vendor/phpunit/phpunit/phpunit --configuration phpunit.xml tests/Feature/V0_
 php vendor/phpunit/phpunit/phpunit --configuration phpunit.xml tests/Feature/Architecture/V0_3TraitReferenceTest.php
 echo "[CI] webhook/attempt regression gates OK"
 
-QUEUE_BACKLOG_PROBE_STRICT="${QUEUE_BACKLOG_PROBE_STRICT:-0}"
+QUEUE_BACKLOG_PROBE_STRICT="${QUEUE_BACKLOG_PROBE_STRICT:-1}"
 if [[ "$QUEUE_BACKLOG_PROBE_STRICT" == "1" ]]; then
   echo "[CI] queue backlog probe (blocking strict=1)"
-  php artisan ops:queue-backlog-probe --json=1 --strict=1 >"$QUEUE_BACKLOG_PROBE_LOG" 2>"$QUEUE_BACKLOG_PROBE_ERR_LOG"
+  php artisan ops:queue-backlog-probe --json=1 --strict="$QUEUE_BACKLOG_PROBE_STRICT" >"$QUEUE_BACKLOG_PROBE_LOG" 2>"$QUEUE_BACKLOG_PROBE_ERR_LOG"
   echo "[CI] queue backlog probe artifact=$QUEUE_BACKLOG_PROBE_LOG"
 else
   echo "[CI] queue backlog probe (non-blocking strict=0)"
-  if php artisan ops:queue-backlog-probe --json=1 --strict=0 >"$QUEUE_BACKLOG_PROBE_LOG" 2>"$QUEUE_BACKLOG_PROBE_ERR_LOG"; then
+  if php artisan ops:queue-backlog-probe --json=1 --strict="$QUEUE_BACKLOG_PROBE_STRICT" >"$QUEUE_BACKLOG_PROBE_LOG" 2>"$QUEUE_BACKLOG_PROBE_ERR_LOG"; then
     echo "[CI] queue backlog probe artifact=$QUEUE_BACKLOG_PROBE_LOG"
   else
     echo "[CI][WARN] queue backlog probe failed (non-blocking), see $QUEUE_BACKLOG_PROBE_ERR_LOG"

--- a/backend/tests/Feature/Ops/QueueBacklogProbeCommandTest.php
+++ b/backend/tests/Feature/Ops/QueueBacklogProbeCommandTest.php
@@ -7,6 +7,7 @@ namespace Tests\Feature\Ops;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\Artisan;
 use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Str;
 use Tests\TestCase;
 
@@ -172,6 +173,83 @@ final class QueueBacklogProbeCommandTest extends TestCase
         $first = is_array($violations[0] ?? null) ? $violations[0] : [];
         $this->assertSame('attempts', (string) ($first['queue'] ?? ''));
         $this->assertSame('pending', (string) ($first['metric'] ?? ''));
+    }
+
+    public function test_strict_override_zero_disables_blocking_even_when_default_is_strict(): void
+    {
+        $this->useDatabaseQueueDriver();
+        config()->set('ops.queue_backlog_probe.strict_default', true);
+
+        $nowTs = now()->timestamp;
+        DB::table('jobs')->insert([
+            'queue' => 'attempts',
+            'payload' => '{"job":"attempt.submit"}',
+            'attempts' => 1,
+            'reserved_at' => null,
+            'available_at' => $nowTs - 60,
+            'created_at' => $nowTs - 60,
+        ]);
+
+        $exitCode = Artisan::call('ops:queue-backlog-probe', [
+            '--json' => 1,
+            '--strict' => 0,
+            '--queues' => 'attempts',
+            '--max-pending' => 0,
+        ]);
+
+        $this->assertSame(0, $exitCode);
+
+        $payload = json_decode(trim((string) Artisan::output()), true);
+        $this->assertIsArray($payload);
+        $this->assertFalse((bool) ($payload['slo']['strict'] ?? true));
+        $this->assertFalse((bool) ($payload['pass'] ?? true));
+    }
+
+    public function test_logs_structured_warning_when_slo_breach_happens(): void
+    {
+        $this->useDatabaseQueueDriver();
+        Log::spy();
+
+        $nowTs = now()->timestamp;
+        DB::table('jobs')->insert([
+            'queue' => 'attempts',
+            'payload' => '{"job":"attempt.submit"}',
+            'attempts' => 1,
+            'reserved_at' => null,
+            'available_at' => $nowTs - 45,
+            'created_at' => $nowTs - 45,
+        ]);
+
+        $exitCode = Artisan::call('ops:queue-backlog-probe', [
+            '--json' => 1,
+            '--strict' => 0,
+            '--queues' => 'attempts',
+            '--max-pending' => 0,
+        ]);
+
+        $this->assertSame(0, $exitCode);
+
+        Log::shouldHaveReceived('warning')
+            ->atLeast()
+            ->once()
+            ->withArgs(function (string $message, array $context): bool {
+                if ($message !== 'QUEUE_BACKLOG_SLO_BREACH') {
+                    return false;
+                }
+
+                foreach (['strict', 'pass', 'violations', 'queues', 'thresholds', 'window_minutes', 'queue_driver'] as $key) {
+                    if (! array_key_exists($key, $context)) {
+                        return false;
+                    }
+                }
+
+                return $context['strict'] === false
+                    && $context['pass'] === false
+                    && is_array($context['violations'])
+                    && $context['violations'] !== []
+                    && is_array($context['queues'])
+                    && is_array($context['thresholds']);
+            });
     }
 
     public function test_command_uses_default_three_queues_and_config_driven_strict_mode(): void


### PR DESCRIPTION
Fixes FER2-27

## Summary
- Set CI queue backlog gate to hard mode by default: `QUEUE_BACKLOG_PROBE_STRICT` now defaults to `1` in `backend/scripts/ci_verify_mbti.sh`.
- Keep explicit override behavior: setting `QUEUE_BACKLOG_PROBE_STRICT=0` keeps queue backlog probe non-blocking in CI.
- Add minimal alert outlet in `ops:queue-backlog-probe`: when SLO breach exists, emit structured log warning `QUEUE_BACKLOG_SLO_BREACH` with strict/pass/violations/queues/thresholds/window/driver context.
- Extend regression tests for queue probe command:
  - strict override with `--strict=0` under strict-default config remains non-blocking
  - breach triggers structured warning outlet with required context fields

## Verification
- `cd backend && php artisan test --filter QueueBacklogProbeCommandTest`
- `cd backend && php artisan ops:queue-backlog-probe --json=1 --strict=1`
- `bash backend/scripts/ci_verify_mbti.sh`
