### PR TITLE
Fixes FER2-29: add configurable external KMS adapter and rotation automation

### DIFF
--- a/backend/app/Console/Commands/Ops/BackfillPiiEncryption.php
+++ b/backend/app/Console/Commands/Ops/BackfillPiiEncryption.php
@@ -13,16 +13,27 @@ class BackfillPiiEncryption extends Command
         {--scope=all : Backfill scope: all|users|email_outbox}
         {--chunk=1000 : Chunk size}
         {--sleep-ms=50 : Pause between chunks in milliseconds}
+        {--rotate-key-version= : Rotate encrypted payloads to target key_version}
+        {--batch= : Rotation audit batch reference}
         {--sync : Run immediately in current process}';
 
     protected $description = 'Backfill encrypted/hash PII tracks for users and email_outbox';
 
     public function handle(): int
     {
+        $rotateKeyVersion = $this->resolveRotateKeyVersion();
+        if ($rotateKeyVersion !== null && ! (bool) $this->option('sync')) {
+            $this->error('--rotate-key-version requires --sync');
+
+            return self::FAILURE;
+        }
+
         $job = new BackfillPiiEncryptionJob(
             scope: trim((string) $this->option('scope')),
             chunk: (int) $this->option('chunk'),
-            sleepMs: (int) $this->option('sleep-ms')
+            sleepMs: (int) $this->option('sleep-ms'),
+            rotateKeyVersion: $rotateKeyVersion,
+            batchRef: $this->resolveBatchRef()
         );
 
         if ((bool) $this->option('sync')) {
@@ -35,11 +46,32 @@ class BackfillPiiEncryption extends Command
         BackfillPiiEncryptionJob::dispatch(
             scope: trim((string) $this->option('scope')),
             chunk: (int) $this->option('chunk'),
-            sleepMs: (int) $this->option('sleep-ms')
+            sleepMs: (int) $this->option('sleep-ms'),
+            rotateKeyVersion: $rotateKeyVersion,
+            batchRef: $this->resolveBatchRef()
         )->onQueue('ops');
 
         $this->info('pii encryption backfill dispatched');
 
         return self::SUCCESS;
+    }
+
+    private function resolveRotateKeyVersion(): ?int
+    {
+        $raw = trim((string) ($this->option('rotate-key-version') ?? ''));
+        if ($raw === '') {
+            return null;
+        }
+
+        $version = (int) $raw;
+
+        return $version > 0 ? $version : null;
+    }
+
+    private function resolveBatchRef(): ?string
+    {
+        $batch = trim((string) ($this->option('batch') ?? ''));
+
+        return $batch !== '' ? $batch : null;
     }
 }

--- a/backend/app/Jobs/Ops/BackfillPiiEncryptionJob.php
+++ b/backend/app/Jobs/Ops/BackfillPiiEncryptionJob.php
@@ -14,6 +14,7 @@ use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Facades\Schema;
+use Illuminate\Support\Str;
 
 class BackfillPiiEncryptionJob implements ShouldQueue
 {
@@ -28,11 +29,15 @@ class BackfillPiiEncryptionJob implements ShouldQueue
     public function __construct(
         public string $scope = 'all',
         public int $chunk = 1000,
-        public int $sleepMs = 50
+        public int $sleepMs = 50,
+        public ?int $rotateKeyVersion = null,
+        public ?string $batchRef = null
     ) {
         $this->scope = $this->normalizeScope($scope) ?? 'all';
         $this->chunk = max(100, $chunk);
         $this->sleepMs = max(0, $sleepMs);
+        $this->rotateKeyVersion = $this->normalizeTargetKeyVersion($rotateKeyVersion);
+        $this->batchRef = $this->normalizeBatchRef($batchRef);
     }
 
     public function handle(): void
@@ -55,20 +60,33 @@ class BackfillPiiEncryptionJob implements ShouldQueue
 
         try {
             $cipher = app(PiiCipher::class);
+            $targetKeyVersion = $this->normalizeTargetKeyVersion($this->rotateKeyVersion);
             $stats = [];
 
             if ($scope === 'all' || $scope === 'users') {
-                $stats['users'] = $this->backfillUsers($cipher);
+                $stats['users'] = $this->backfillUsers($cipher, $targetKeyVersion);
             }
 
             if ($scope === 'all' || $scope === 'email_outbox') {
-                $stats['email_outbox'] = $this->backfillEmailOutbox($cipher);
+                $stats['email_outbox'] = $this->backfillEmailOutbox($cipher, $targetKeyVersion);
+            }
+
+            if ($targetKeyVersion !== null) {
+                $cipher->activateKeyVersion($targetKeyVersion);
+                $affectedCount = $this->resolveRotationAffectedCount($stats);
+                $this->recordRotationAudit(
+                    $targetKeyVersion,
+                    $affectedCount > 0 ? 'ok' : 'noop',
+                    $scope,
+                    $stats
+                );
             }
 
             Log::info('[pii_encryption_backfill] done', [
                 'scope' => $scope,
                 'chunk' => $this->chunk,
                 'sleep_ms' => $this->sleepMs,
+                'rotate_key_version' => $targetKeyVersion,
                 'stats' => $stats,
                 'elapsed_ms' => (int) ((microtime(true) - $startedAt) * 1000),
             ]);
@@ -78,12 +96,12 @@ class BackfillPiiEncryptionJob implements ShouldQueue
     }
 
     /**
-     * @return array{scanned:int,updated:int,chunks:int,last_id:int}
+     * @return array{scanned:int,updated:int,chunks:int,last_id:int,affected_count:int}
      */
-    private function backfillUsers(PiiCipher $cipher): array
+    private function backfillUsers(PiiCipher $cipher, ?int $targetKeyVersion): array
     {
         if (! Schema::hasTable('users')) {
-            return ['scanned' => 0, 'updated' => 0, 'chunks' => 0, 'last_id' => 0];
+            return ['scanned' => 0, 'updated' => 0, 'chunks' => 0, 'last_id' => 0, 'affected_count' => 0];
         }
 
         $hasEmailHash = Schema::hasColumn('users', 'email_hash');
@@ -94,7 +112,7 @@ class BackfillPiiEncryptionJob implements ShouldQueue
         $hasMigratedAt = Schema::hasColumn('users', 'pii_migrated_at');
 
         if (! $hasEmailHash && ! $hasEmailEnc && ! $hasPhoneHash && ! $hasPhoneEnc) {
-            return ['scanned' => 0, 'updated' => 0, 'chunks' => 0, 'last_id' => 0];
+            return ['scanned' => 0, 'updated' => 0, 'chunks' => 0, 'last_id' => 0, 'affected_count' => 0];
         }
 
         [$lastId] = $this->loadState('pii_backfill_users_v2');
@@ -103,6 +121,7 @@ class BackfillPiiEncryptionJob implements ShouldQueue
         $scanned = 0;
         $updated = 0;
         $chunks = 0;
+        $affectedCount = 0;
 
         $select = ['id', 'email', 'phone_e164'];
         if ($hasEmailHash) {
@@ -148,6 +167,7 @@ class BackfillPiiEncryptionJob implements ShouldQueue
                 $updates = [];
                 $email = trim((string) ($row->email ?? ''));
                 $phone = trim((string) ($row->phone_e164 ?? ''));
+                $rotatedThisRow = false;
 
                 if ($email !== '') {
                     if ($hasEmailHash && $this->isBlank($row->email_hash ?? null)) {
@@ -167,7 +187,37 @@ class BackfillPiiEncryptionJob implements ShouldQueue
                     }
                 }
 
-                if ($hasKeyVersion && $this->isMissingKeyVersion($row->key_version ?? null)) {
+                if ($targetKeyVersion !== null && $hasKeyVersion && $this->isOlderKeyVersion($row->key_version ?? null, $targetKeyVersion)) {
+                    if ($hasEmailEnc) {
+                        $emailPlaintext = $this->resolvePlaintextForRotation(
+                            $email,
+                            $updates['email_enc'] ?? ($row->email_enc ?? null),
+                            $cipher
+                        );
+                        if ($emailPlaintext !== null) {
+                            $updates['email_enc'] = $cipher->encryptWithKeyVersion($emailPlaintext, $targetKeyVersion);
+                            $rotatedThisRow = true;
+                        }
+                    }
+
+                    if ($hasPhoneEnc) {
+                        $phonePlaintext = $this->resolvePlaintextForRotation(
+                            $phone,
+                            $updates['phone_e164_enc'] ?? ($row->phone_e164_enc ?? null),
+                            $cipher
+                        );
+                        if ($phonePlaintext !== null) {
+                            $updates['phone_e164_enc'] = $cipher->encryptWithKeyVersion($phonePlaintext, $targetKeyVersion);
+                            $rotatedThisRow = true;
+                        }
+                    }
+
+                    if ($rotatedThisRow) {
+                        $updates['key_version'] = $targetKeyVersion;
+                    }
+                }
+
+                if ($hasKeyVersion && $this->isMissingKeyVersion($row->key_version ?? null) && ! $rotatedThisRow) {
                     $hasAnyPii =
                         ($hasEmailHash && ! $this->isBlank($updates['email_hash'] ?? ($row->email_hash ?? null)))
                         || ($hasEmailEnc && ! $this->isBlank($updates['email_enc'] ?? ($row->email_enc ?? null)))
@@ -204,6 +254,9 @@ class BackfillPiiEncryptionJob implements ShouldQueue
                     ->update($updates);
 
                 $updated++;
+                if ($rotatedThisRow) {
+                    $affectedCount++;
+                }
             }
 
             $chunks++;
@@ -216,16 +269,17 @@ class BackfillPiiEncryptionJob implements ShouldQueue
             'updated' => $updated,
             'chunks' => $chunks,
             'last_id' => $nextId,
+            'affected_count' => $affectedCount,
         ];
     }
 
     /**
-     * @return array{scanned:int,updated:int,chunks:int,last_cursor:string}
+     * @return array{scanned:int,updated:int,chunks:int,last_cursor:string,affected_count:int}
      */
-    private function backfillEmailOutbox(PiiCipher $cipher): array
+    private function backfillEmailOutbox(PiiCipher $cipher, ?int $targetKeyVersion): array
     {
         if (! Schema::hasTable('email_outbox')) {
-            return ['scanned' => 0, 'updated' => 0, 'chunks' => 0, 'last_cursor' => ''];
+            return ['scanned' => 0, 'updated' => 0, 'chunks' => 0, 'last_cursor' => '', 'affected_count' => 0];
         }
 
         $hasEmailHash = Schema::hasColumn('email_outbox', 'email_hash');
@@ -239,7 +293,7 @@ class BackfillPiiEncryptionJob implements ShouldQueue
         $hasPayloadJson = Schema::hasColumn('email_outbox', 'payload_json');
 
         if (! $hasEmailHash && ! $hasEmailEnc && ! $hasToEmailHash && ! $hasToEmailEnc && ! $hasPayloadEnc) {
-            return ['scanned' => 0, 'updated' => 0, 'chunks' => 0, 'last_cursor' => ''];
+            return ['scanned' => 0, 'updated' => 0, 'chunks' => 0, 'last_cursor' => '', 'affected_count' => 0];
         }
 
         [, $lastCursor] = $this->loadState('pii_backfill_email_outbox_v2');
@@ -248,6 +302,7 @@ class BackfillPiiEncryptionJob implements ShouldQueue
         $scanned = 0;
         $updated = 0;
         $chunks = 0;
+        $affectedCount = 0;
 
         $select = ['id', 'email'];
         if ($hasEmailHash) {
@@ -306,6 +361,7 @@ class BackfillPiiEncryptionJob implements ShouldQueue
                 $updates = [];
                 $email = trim((string) ($row->email ?? ''));
                 $toEmail = $hasToEmail ? trim((string) ($row->to_email ?? '')) : '';
+                $rotatedThisRow = false;
 
                 if ($email !== '') {
                     if ($hasEmailHash && $this->isBlank($row->email_hash ?? null)) {
@@ -340,7 +396,52 @@ class BackfillPiiEncryptionJob implements ShouldQueue
                     $updates['payload_schema_version'] = 'v1-json-enc';
                 }
 
-                if ($hasKeyVersion && $this->isMissingKeyVersion($row->key_version ?? null)) {
+                if ($targetKeyVersion !== null && $hasKeyVersion && $this->isOlderKeyVersion($row->key_version ?? null, $targetKeyVersion)) {
+                    if ($hasEmailEnc) {
+                        $emailPlaintext = $this->resolvePlaintextForRotation(
+                            $email,
+                            $updates['email_enc'] ?? ($row->email_enc ?? null),
+                            $cipher
+                        );
+                        if ($emailPlaintext !== null) {
+                            $updates['email_enc'] = $cipher->encryptWithKeyVersion($emailPlaintext, $targetKeyVersion);
+                            $rotatedThisRow = true;
+                        }
+                    }
+
+                    if ($hasToEmailEnc) {
+                        $toEmailPlaintext = $this->resolvePlaintextForRotation(
+                            $toEmail,
+                            $updates['to_email_enc'] ?? ($row->to_email_enc ?? null),
+                            $cipher
+                        );
+                        if ($toEmailPlaintext !== null) {
+                            $updates['to_email_enc'] = $cipher->encryptWithKeyVersion($toEmailPlaintext, $targetKeyVersion);
+                            $rotatedThisRow = true;
+                        }
+                    }
+
+                    if ($hasPayloadEnc) {
+                        $payloadPlaintext = $this->resolvePayloadPlaintextForRotation(
+                            $row->payload_json ?? null,
+                            $updates['payload_enc'] ?? ($row->payload_enc ?? null),
+                            $cipher
+                        );
+                        if ($payloadPlaintext !== null) {
+                            $updates['payload_enc'] = $cipher->encryptWithKeyVersion($payloadPlaintext, $targetKeyVersion);
+                            if ($hasPayloadVersion) {
+                                $updates['payload_schema_version'] = 'v1-json-enc';
+                            }
+                            $rotatedThisRow = true;
+                        }
+                    }
+
+                    if ($rotatedThisRow) {
+                        $updates['key_version'] = $targetKeyVersion;
+                    }
+                }
+
+                if ($hasKeyVersion && $this->isMissingKeyVersion($row->key_version ?? null) && ! $rotatedThisRow) {
                     $hasAnyPii =
                         ($hasEmailHash && ! $this->isBlank($updates['email_hash'] ?? ($row->email_hash ?? null)))
                         || ($hasEmailEnc && ! $this->isBlank($updates['email_enc'] ?? ($row->email_enc ?? null)))
@@ -364,6 +465,9 @@ class BackfillPiiEncryptionJob implements ShouldQueue
                     ->update($updates);
 
                 $updated++;
+                if ($rotatedThisRow) {
+                    $affectedCount++;
+                }
             }
 
             $chunks++;
@@ -376,6 +480,7 @@ class BackfillPiiEncryptionJob implements ShouldQueue
             'updated' => $updated,
             'chunks' => $chunks,
             'last_cursor' => $cursor,
+            'affected_count' => $affectedCount,
         ];
     }
 
@@ -438,6 +543,153 @@ class BackfillPiiEncryptionJob implements ShouldQueue
         }
 
         usleep($this->sleepMs * 1000);
+    }
+
+    /**
+     * @param  array<string,mixed>  $stats
+     */
+    private function resolveRotationAffectedCount(array $stats): int
+    {
+        $affected = 0;
+        foreach (['users', 'email_outbox'] as $scope) {
+            $section = is_array($stats[$scope] ?? null) ? $stats[$scope] : [];
+            $affected += (int) ($section['affected_count'] ?? 0);
+        }
+
+        return max(0, $affected);
+    }
+
+    /**
+     * @param  array<string,mixed>  $stats
+     */
+    private function recordRotationAudit(int $targetKeyVersion, string $result, string $scope, array $stats): void
+    {
+        if (! Schema::hasTable('rotation_audits')) {
+            return;
+        }
+
+        $now = now();
+        $meta = [
+            'scope' => $scope,
+            'chunk' => $this->chunk,
+            'sleep_ms' => $this->sleepMs,
+            'rotate_key_version' => $targetKeyVersion,
+            'affected_count' => $this->resolveRotationAffectedCount($stats),
+            'stats' => $stats,
+        ];
+        $metaJson = json_encode($meta, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES);
+        if (! is_string($metaJson)) {
+            $metaJson = null;
+        }
+
+        $row = [
+            'id' => (string) Str::uuid(),
+        ];
+
+        if (Schema::hasColumn('rotation_audits', 'org_id')) {
+            $row['org_id'] = 0;
+        }
+        if (Schema::hasColumn('rotation_audits', 'actor')) {
+            $row['actor'] = 'ops:backfill-pii-encryption';
+        }
+        if (Schema::hasColumn('rotation_audits', 'actor_user_id')) {
+            $row['actor_user_id'] = null;
+        }
+        if (Schema::hasColumn('rotation_audits', 'scope')) {
+            $row['scope'] = 'pii';
+        }
+        if (Schema::hasColumn('rotation_audits', 'key_version')) {
+            $row['key_version'] = $targetKeyVersion;
+        }
+        if (Schema::hasColumn('rotation_audits', 'batch_ref')) {
+            $row['batch_ref'] = $this->batchRef;
+        }
+        if (Schema::hasColumn('rotation_audits', 'result')) {
+            $row['result'] = substr(trim($result), 0, 32) ?: 'ok';
+        }
+        if (Schema::hasColumn('rotation_audits', 'meta_json')) {
+            $row['meta_json'] = $metaJson;
+        }
+        if (Schema::hasColumn('rotation_audits', 'created_at')) {
+            $row['created_at'] = $now;
+        }
+        if (Schema::hasColumn('rotation_audits', 'updated_at')) {
+            $row['updated_at'] = $now;
+        }
+
+        DB::table('rotation_audits')->insert($row);
+    }
+
+    private function normalizeTargetKeyVersion(?int $version): ?int
+    {
+        if ($version === null) {
+            return null;
+        }
+
+        return $version > 0 ? $version : null;
+    }
+
+    private function normalizeBatchRef(?string $batchRef): ?string
+    {
+        $batchRef = trim((string) ($batchRef ?? ''));
+        if ($batchRef === '') {
+            return null;
+        }
+
+        return substr($batchRef, 0, 64);
+    }
+
+    private function isOlderKeyVersion(mixed $value, int $targetKeyVersion): bool
+    {
+        if ($targetKeyVersion <= 0) {
+            return false;
+        }
+
+        $current = (int) trim((string) ($value ?? ''));
+
+        return $current < $targetKeyVersion;
+    }
+
+    private function resolvePlaintextForRotation(string $plainCandidate, mixed $encryptedCandidate, PiiCipher $cipher): ?string
+    {
+        $plainCandidate = trim($plainCandidate);
+        if ($plainCandidate !== '') {
+            return $plainCandidate;
+        }
+
+        $encryptedCandidate = trim((string) ($encryptedCandidate ?? ''));
+        if ($encryptedCandidate === '') {
+            return null;
+        }
+
+        return $cipher->decrypt($encryptedCandidate);
+    }
+
+    private function resolvePayloadPlaintextForRotation(mixed $payloadJson, mixed $encryptedCandidate, PiiCipher $cipher): ?string
+    {
+        $payload = $this->normalizePayloadJson($payloadJson);
+        if ($payload !== null) {
+            return $payload;
+        }
+
+        $encryptedCandidate = trim((string) ($encryptedCandidate ?? ''));
+        if ($encryptedCandidate === '') {
+            return null;
+        }
+
+        $decrypted = $cipher->decrypt($encryptedCandidate);
+        if ($decrypted === null) {
+            return null;
+        }
+
+        $normalized = $this->normalizePayloadJson($decrypted);
+        if ($normalized !== null) {
+            return $normalized;
+        }
+
+        $decrypted = trim($decrypted);
+
+        return $decrypted !== '' ? $decrypted : null;
     }
 
     private function normalizeScope(string $scope): ?string

--- a/backend/app/Providers/AppServiceProvider.php
+++ b/backend/app/Providers/AppServiceProvider.php
@@ -29,6 +29,7 @@ use App\Services\Content\ContentStore;
 use App\Services\ContentPackResolver;
 use App\Support\Logging\RedactProcessor;
 use App\Support\OrgContext;
+use App\Support\Security\ExternalKmsPiiEnvelopeAdapter;
 use App\Support\Security\LocalPiiEnvelopeAdapter;
 use Illuminate\Auth\Events\Failed;
 use Illuminate\Auth\Events\Login;
@@ -54,7 +55,12 @@ class AppServiceProvider extends ServiceProvider
      */
     public function register(): void
     {
-        $this->app->singleton(PiiEnvelopeAdapter::class, LocalPiiEnvelopeAdapter::class);
+        $this->app->singleton(PiiEnvelopeAdapter::class, function ($app) {
+            return match ((string) config('services.pii.adapter', 'local')) {
+                'external_kms' => $app->make(ExternalKmsPiiEnvelopeAdapter::class),
+                default => $app->make(LocalPiiEnvelopeAdapter::class),
+            };
+        });
 
         // Bind ContentPackResolver so app(ContentPackResolver::class) works everywhere.
         $this->app->singleton(ContentPackResolver::class, function () {

--- a/backend/app/Support/PiiCipher.php
+++ b/backend/app/Support/PiiCipher.php
@@ -84,8 +84,9 @@ final class PiiCipher
         config(['services.pii.key_version' => $version]);
         try {
             Cache::forever($this->activeKeyVersionCacheKey(), $version);
-        } catch (\Throwable) {
+        } catch (\Throwable $cacheError) {
             // Cache persistence is auxiliary; runtime config is the source of truth.
+            report($cacheError);
         }
     }
 

--- a/backend/app/Support/PiiCipher.php
+++ b/backend/app/Support/PiiCipher.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Support;
 
 use App\Contracts\Security\PiiEnvelopeAdapter;
+use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\Crypt;
 
 final class PiiCipher
@@ -48,15 +49,21 @@ final class PiiCipher
 
     public function encrypt(?string $value): ?string
     {
+        return $this->encryptWithKeyVersion($value, $this->currentKeyVersion());
+    }
+
+    public function encryptWithKeyVersion(?string $value, int $version): ?string
+    {
         $normalized = trim((string) $value);
         if ($normalized === '') {
             return null;
         }
 
+        $resolvedVersion = $version > 0 ? $version : $this->currentKeyVersion();
         $envelope = [
             'ciphertext' => $this->envelopeAdapter->encrypt($normalized),
             'key_id' => $this->currentKeyId(),
-            'key_version' => $this->currentKeyVersion(),
+            'key_version' => $resolvedVersion,
             'algo' => $this->currentAlgo(),
         ];
 
@@ -66,6 +73,20 @@ final class PiiCipher
         }
 
         return $encoded;
+    }
+
+    public function activateKeyVersion(int $version): void
+    {
+        if ($version <= 0) {
+            return;
+        }
+
+        config(['services.pii.key_version' => $version]);
+        try {
+            Cache::forever($this->activeKeyVersionCacheKey(), $version);
+        } catch (\Throwable) {
+            // Cache persistence is auxiliary; runtime config is the source of truth.
+        }
     }
 
     public function decrypt(?string $ciphertext): ?string
@@ -126,6 +147,13 @@ final class PiiCipher
         $algo = trim((string) config('services.pii.algo', self::DEFAULT_ALGO));
 
         return $algo !== '' ? $algo : self::DEFAULT_ALGO;
+    }
+
+    private function activeKeyVersionCacheKey(): string
+    {
+        $key = trim((string) config('services.pii.active_key_version_cache_key', 'pii:active_key_version'));
+
+        return $key !== '' ? $key : 'pii:active_key_version';
     }
 
     /**

--- a/backend/app/Support/Security/ExternalKmsPiiEnvelopeAdapter.php
+++ b/backend/app/Support/Security/ExternalKmsPiiEnvelopeAdapter.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Support\Security;
+
+use App\Contracts\Security\PiiEnvelopeAdapter;
+
+/**
+ * External KMS adapter shell.
+ *
+ * This implementation keeps the same ciphertext semantics as local encryption
+ * so we can switch adapters without changing envelope schema/contracts.
+ */
+final class ExternalKmsPiiEnvelopeAdapter implements PiiEnvelopeAdapter
+{
+    public function __construct(
+        private readonly LocalPiiEnvelopeAdapter $localAdapter,
+    ) {}
+
+    public function encrypt(string $plaintext): string
+    {
+        return $this->localAdapter->encrypt($plaintext);
+    }
+
+    public function decrypt(string $ciphertext): ?string
+    {
+        return $this->localAdapter->decrypt($ciphertext);
+    }
+}
+

--- a/backend/tests/Feature/V0_3/PiiCipherEnvelopeTest.php
+++ b/backend/tests/Feature/V0_3/PiiCipherEnvelopeTest.php
@@ -4,6 +4,9 @@ declare(strict_types=1);
 
 namespace Tests\Feature\V0_3;
 
+use App\Contracts\Security\PiiEnvelopeAdapter;
+use App\Support\Security\ExternalKmsPiiEnvelopeAdapter;
+use App\Support\Security\LocalPiiEnvelopeAdapter;
 use App\Support\PiiCipher;
 use Illuminate\Support\Facades\Crypt;
 use Tests\TestCase;
@@ -41,5 +44,45 @@ final class PiiCipherEnvelopeTest extends TestCase
         $legacyCiphertext = Crypt::encryptString($plaintext);
 
         $this->assertSame($plaintext, $pii->decrypt($legacyCiphertext));
+    }
+
+    public function test_adapter_selection_supports_local_and_external_kms(): void
+    {
+        config()->set('services.pii.adapter', 'local');
+        $this->app->forgetInstance(PiiEnvelopeAdapter::class);
+        $this->app->forgetInstance(PiiCipher::class);
+        $this->assertInstanceOf(LocalPiiEnvelopeAdapter::class, app(PiiEnvelopeAdapter::class));
+
+        config()->set('services.pii.adapter', 'external_kms');
+        $this->app->forgetInstance(PiiEnvelopeAdapter::class);
+        $this->app->forgetInstance(PiiCipher::class);
+        $this->assertInstanceOf(ExternalKmsPiiEnvelopeAdapter::class, app(PiiEnvelopeAdapter::class));
+    }
+
+    public function test_cross_adapter_decrypt_compatibility_is_preserved(): void
+    {
+        $plaintext = 'cross.adapter@example.com';
+
+        config()->set('services.pii.adapter', 'local');
+        $this->app->forgetInstance(PiiEnvelopeAdapter::class);
+        $this->app->forgetInstance(PiiCipher::class);
+        /** @var PiiCipher $local */
+        $local = app(PiiCipher::class);
+        $localCiphertext = (string) $local->encrypt($plaintext);
+
+        config()->set('services.pii.adapter', 'external_kms');
+        $this->app->forgetInstance(PiiEnvelopeAdapter::class);
+        $this->app->forgetInstance(PiiCipher::class);
+        /** @var PiiCipher $external */
+        $external = app(PiiCipher::class);
+        $this->assertSame($plaintext, $external->decrypt($localCiphertext));
+        $externalCiphertext = (string) $external->encrypt($plaintext);
+
+        config()->set('services.pii.adapter', 'local');
+        $this->app->forgetInstance(PiiEnvelopeAdapter::class);
+        $this->app->forgetInstance(PiiCipher::class);
+        /** @var PiiCipher $localAgain */
+        $localAgain = app(PiiCipher::class);
+        $this->assertSame($plaintext, $localAgain->decrypt($externalCiphertext));
     }
 }

--- a/backend/tests/Feature/V0_3/PiiCipherRotationAutomationTest.php
+++ b/backend/tests/Feature/V0_3/PiiCipherRotationAutomationTest.php
@@ -1,0 +1,127 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\V0_3;
+
+use App\Support\PiiCipher;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+use Tests\TestCase;
+
+final class PiiCipherRotationAutomationTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_rotation_command_reencrypts_to_target_version_and_writes_audit(): void
+    {
+        config()->set('services.pii.adapter', 'local');
+        config()->set('services.pii.key_version', 1);
+
+        /** @var PiiCipher $pii */
+        $pii = app(PiiCipher::class);
+
+        $email = 'rotate.user@example.com';
+        $phone = '+15551239999';
+        $payload = json_encode(['attempt_id' => 'attempt_rotate_1'], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES);
+        $this->assertIsString($payload);
+
+        $userId = DB::table('users')->insertGetId([
+            'name' => 'Rotate User',
+            'email' => $email,
+            'password' => bcrypt('secret-123'),
+            'phone_e164' => $phone,
+            'email_hash' => $pii->emailHash($email),
+            'email_enc' => $pii->encryptWithKeyVersion($email, 1),
+            'phone_e164_hash' => $pii->phoneHash($phone),
+            'phone_e164_enc' => $pii->encryptWithKeyVersion($phone, 1),
+            'key_version' => 1,
+            'created_at' => now(),
+            'updated_at' => now(),
+        ]);
+
+        $outboxId = '22222222-2222-4222-8222-222222222222';
+        DB::table('email_outbox')->insert([
+            'id' => $outboxId,
+            'user_id' => (string) $userId,
+            'email' => $email,
+            'email_hash' => $pii->emailHash($email),
+            'email_enc' => $pii->encryptWithKeyVersion($email, 1),
+            'to_email' => 'receiver@example.com',
+            'to_email_hash' => $pii->emailHash('receiver@example.com'),
+            'to_email_enc' => $pii->encryptWithKeyVersion('receiver@example.com', 1),
+            'template' => 'report_claim',
+            'payload_json' => $payload,
+            'payload_enc' => $pii->encryptWithKeyVersion($payload, 1),
+            'payload_schema_version' => 'v1-json-enc',
+            'key_version' => 1,
+            'claim_token_hash' => hash('sha256', 'rotate-claim-token'),
+            'claim_expires_at' => now()->addDay(),
+            'status' => 'pending',
+            'created_at' => now(),
+            'updated_at' => now(),
+        ]);
+
+        $this->artisan('ops:backfill-pii-encryption', [
+            '--sync' => true,
+            '--scope' => 'all',
+            '--rotate-key-version' => 2,
+            '--batch' => 'batch_rotate_v2',
+        ])->assertExitCode(0);
+
+        $user = DB::table('users')->where('id', $userId)->first();
+        $this->assertNotNull($user);
+        $this->assertSame(2, (int) ($user->key_version ?? 0));
+        $this->assertSame($email, $pii->decrypt((string) ($user->email_enc ?? '')));
+        $this->assertSame($phone, $pii->decrypt((string) ($user->phone_e164_enc ?? '')));
+
+        $outbox = DB::table('email_outbox')->where('id', $outboxId)->first();
+        $this->assertNotNull($outbox);
+        $this->assertSame(2, (int) ($outbox->key_version ?? 0));
+        $this->assertSame($email, $pii->decrypt((string) ($outbox->email_enc ?? '')));
+        $this->assertSame('receiver@example.com', $pii->decrypt((string) ($outbox->to_email_enc ?? '')));
+        $this->assertSame($payload, $pii->decrypt((string) ($outbox->payload_enc ?? '')));
+
+        if (Schema::hasTable('rotation_audits')) {
+            $audit = DB::table('rotation_audits')
+                ->where('scope', 'pii')
+                ->where('batch_ref', 'batch_rotate_v2')
+                ->orderByDesc('created_at')
+                ->first();
+            $this->assertNotNull($audit);
+            $this->assertSame(2, (int) ($audit->key_version ?? 0));
+            $this->assertSame('ok', (string) ($audit->result ?? ''));
+        }
+
+        $this->assertSame(2, app(PiiCipher::class)->currentKeyVersion());
+
+        $emailEncAfterFirst = (string) ($user->email_enc ?? '');
+        $payloadEncAfterFirst = (string) ($outbox->payload_enc ?? '');
+
+        $this->artisan('ops:backfill-pii-encryption', [
+            '--sync' => true,
+            '--scope' => 'all',
+            '--rotate-key-version' => 2,
+            '--batch' => 'batch_rotate_v2_repeat',
+        ])->assertExitCode(0);
+
+        $userAgain = DB::table('users')->where('id', $userId)->first();
+        $outboxAgain = DB::table('email_outbox')->where('id', $outboxId)->first();
+        $this->assertNotNull($userAgain);
+        $this->assertNotNull($outboxAgain);
+        $this->assertSame($emailEncAfterFirst, (string) ($userAgain->email_enc ?? ''));
+        $this->assertSame($payloadEncAfterFirst, (string) ($outboxAgain->payload_enc ?? ''));
+
+        if (Schema::hasTable('rotation_audits')) {
+            $noopAudit = DB::table('rotation_audits')
+                ->where('scope', 'pii')
+                ->where('batch_ref', 'batch_rotate_v2_repeat')
+                ->orderByDesc('created_at')
+                ->first();
+            $this->assertNotNull($noopAudit);
+            $this->assertSame('noop', (string) ($noopAudit->result ?? ''));
+        }
+    }
+}
+


### PR DESCRIPTION
Fixes FER2-29

## Summary
- Add configurable `PiiEnvelopeAdapter` binding in `AppServiceProvider` to support `local` and `external_kms` adapters.
- Add `ExternalKmsPiiEnvelopeAdapter` as a schema-compatible adapter shell delegating to local envelope logic.
- Extend `PiiCipher` with `encryptWithKeyVersion`, `activateKeyVersion`, and keep envelope + legacy decrypt compatibility.
- Extend PII backfill command/job to support `--rotate-key-version` rotation automation, targeted re-encryption, and `rotation_audits` writes.
- Add parity/rotation tests for adapter interoperability and key rotation no-op replay behavior.

## Verification
- `cd backend && php artisan test --filter PiiCipher`
- `cd backend && php artisan test --filter Rotation`
- `bash backend/scripts/ci_verify_mbti.sh`
