### PR TITLE
Fixes FER2-31: one-click DSAR async closure with retries and audit-DLQ

### DIFF
--- a/backend/app/Http/Controllers/API/V0_3/ComplianceDsarController.php
+++ b/backend/app/Http/Controllers/API/V0_3/ComplianceDsarController.php
@@ -42,33 +42,82 @@ final class ComplianceDsarController extends Controller
             'reason' => ['nullable', 'string', 'max:255'],
         ]);
 
-        $requestId = (string) Str::uuid();
-        $now = now();
+        $orgId = $context['org_id'];
+        $actorUserId = $context['actor_user_id'];
+        $subjectUserId = (int) $payload['subject_user_id'];
+        $mode = (string) ($payload['mode'] ?? 'hybrid_anonymize');
+        $reason = isset($payload['reason']) ? trim((string) $payload['reason']) : null;
+        $initialPayload = [
+            'ip' => $request->ip(),
+            'user_agent' => (string) $request->userAgent(),
+        ];
 
-        DB::table('dsar_requests')->insert([
-            'id' => $requestId,
-            'org_id' => $context['org_id'],
-            'subject_user_id' => (int) $payload['subject_user_id'],
-            'requested_by_user_id' => $context['actor_user_id'],
-            'executed_by_user_id' => null,
-            'mode' => (string) ($payload['mode'] ?? 'hybrid_anonymize'),
-            'status' => 'pending',
-            'reason' => isset($payload['reason']) ? trim((string) $payload['reason']) : null,
-            'payload_json' => json_encode([
-                'ip' => $request->ip(),
-                'user_agent' => (string) $request->userAgent(),
-            ], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES),
-            'result_json' => null,
-            'requested_at' => $now,
-            'executed_at' => null,
-            'created_at' => $now,
-            'updated_at' => $now,
-        ]);
+        $lock = DB::transaction(function () use ($orgId, $actorUserId, $subjectUserId, $mode, $reason, $initialPayload): array {
+            $active = DB::table('dsar_requests')
+                ->where('org_id', $orgId)
+                ->where('subject_user_id', $subjectUserId)
+                ->where('mode', $mode)
+                ->whereIn('status', ['pending', 'running'])
+                ->orderByDesc('created_at')
+                ->orderByDesc('id')
+                ->lockForUpdate()
+                ->first();
+
+            if ($active === null) {
+                $requestId = (string) Str::uuid();
+                $now = now();
+                DB::table('dsar_requests')->insert([
+                    'id' => $requestId,
+                    'org_id' => $orgId,
+                    'subject_user_id' => $subjectUserId,
+                    'requested_by_user_id' => $actorUserId,
+                    'executed_by_user_id' => null,
+                    'mode' => $mode,
+                    'status' => 'pending',
+                    'reason' => $reason,
+                    'payload_json' => json_encode($initialPayload, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES),
+                    'result_json' => null,
+                    'requested_at' => $now,
+                    'executed_at' => null,
+                    'created_at' => $now,
+                    'updated_at' => $now,
+                ]);
+            } else {
+                $requestId = trim((string) ($active->id ?? ''));
+            }
+
+            return $this->lockExecutionState($requestId, $orgId, $actorUserId, true);
+        });
+
+        if (($lock['state'] ?? '') === 'missing') {
+            return $this->requestNotFound();
+        }
+
+        $requestId = (string) ($lock['request_id'] ?? '');
+        $status = (string) ($lock['status'] ?? 'running');
+        $taskId = (string) ($lock['task_id'] ?? '');
+        $referenceId = (string) ($lock['reference_id'] ?? '');
+
+        if (($lock['state'] ?? '') === 'dispatch') {
+            ExecuteDsarRequestJob::dispatch(
+                $requestId,
+                $orgId,
+                $actorUserId,
+                $taskId,
+                $referenceId
+            )->afterCommit();
+        }
 
         return response()->json([
             'ok' => true,
             'request_id' => $requestId,
-            'status' => 'pending',
+            'status' => $status,
+            'meta' => [
+                'execution' => [
+                    'task_id' => $taskId !== '' ? $taskId : null,
+                    'job_reference' => $referenceId !== '' ? $referenceId : null,
+                ],
+            ],
         ], 202);
     }
 
@@ -97,116 +146,12 @@ final class ComplianceDsarController extends Controller
             return $this->orgNotFound();
         }
 
-        $lock = DB::transaction(function () use ($id, $context): array {
-            $row = DB::table('dsar_requests')
-                ->where('id', $id)
-                ->where('org_id', $context['org_id'])
-                ->lockForUpdate()
-                ->first();
-
-            if ($row === null) {
-                return ['state' => 'missing'];
-            }
-
-            $status = trim((string) ($row->status ?? 'pending'));
-            $subjectUserId = (int) ($row->subject_user_id ?? 0);
-            $payload = $this->decodeJson($row->payload_json ?? null) ?? [];
-            $execution = is_array($payload['execution'] ?? null) ? $payload['execution'] : [];
-
-            $referenceId = trim((string) ($execution['reference_id'] ?? ''));
-            if ($referenceId === '') {
-                $referenceId = (string) Str::uuid();
-            }
-
-            $taskId = trim((string) ($execution['task_id'] ?? ''));
-            if ($taskId === '' && SchemaBaseline::hasTable('dsar_request_tasks')) {
-                $existingTaskId = DB::table('dsar_request_tasks')
-                    ->where('request_id', $id)
-                    ->where('domain', 'orchestration')
-                    ->where('action', 'execute')
-                    ->orderByDesc('created_at')
-                    ->value('id');
-                $taskId = is_string($existingTaskId) ? trim($existingTaskId) : '';
-            }
-            if ($taskId === '') {
-                $taskId = (string) Str::uuid();
-            }
-
-            if ($status === 'pending') {
-                if (SchemaBaseline::hasTable('dsar_request_tasks')) {
-                    $existing = DB::table('dsar_request_tasks')
-                        ->where('request_id', $id)
-                        ->where('domain', 'orchestration')
-                        ->where('action', 'execute')
-                        ->orderByDesc('created_at')
-                        ->first();
-
-                    if ($existing === null) {
-                        DB::table('dsar_request_tasks')->insert([
-                            'id' => $taskId,
-                            'request_id' => $id,
-                            'org_id' => $context['org_id'],
-                            'subject_user_id' => $subjectUserId > 0 ? $subjectUserId : null,
-                            'domain' => 'orchestration',
-                            'action' => 'execute',
-                            'status' => 'pending',
-                            'error_code' => null,
-                            'stats_json' => json_encode([
-                                'queued_by_user_id' => $context['actor_user_id'],
-                                'reference_id' => $referenceId,
-                            ], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES),
-                            'started_at' => null,
-                            'finished_at' => null,
-                            'created_at' => now(),
-                            'updated_at' => now(),
-                        ]);
-                    } else {
-                        $taskId = (string) ($existing->id ?? $taskId);
-                    }
-                }
-
-                $payload['execution'] = [
-                    'reference_id' => $referenceId,
-                    'task_id' => $taskId,
-                    'queued_by_user_id' => $context['actor_user_id'],
-                    'queued_at' => now()->toISOString(),
-                ];
-
-                DB::table('dsar_requests')
-                    ->where('id', $id)
-                    ->where('org_id', $context['org_id'])
-                    ->update([
-                        'status' => 'running',
-                        'executed_by_user_id' => $context['actor_user_id'],
-                        'payload_json' => json_encode($payload, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES),
-                        'updated_at' => now(),
-                    ]);
-
-                $this->appendStatusTransitionAudit(
-                    $id,
-                    $context['org_id'],
-                    $subjectUserId,
-                    'pending',
-                    'running',
-                    $referenceId,
-                    $taskId
-                );
-
-                return [
-                    'state' => 'dispatch',
-                    'status' => 'running',
-                    'task_id' => $taskId,
-                    'reference_id' => $referenceId,
-                ];
-            }
-
-            return [
-                'state' => 'existing',
-                'status' => $status !== '' ? $status : 'running',
-                'task_id' => $taskId,
-                'reference_id' => $referenceId,
-            ];
-        });
+        $lock = DB::transaction(fn (): array => $this->lockExecutionState(
+            $id,
+            $context['org_id'],
+            $context['actor_user_id'],
+            true
+        ));
 
         $state = (string) ($lock['state'] ?? '');
         if ($state === 'missing') {
@@ -224,7 +169,7 @@ final class ComplianceDsarController extends Controller
                 $context['actor_user_id'],
                 $taskId,
                 $referenceId
-            );
+            )->afterCommit();
         }
 
         return response()->json([
@@ -233,7 +178,173 @@ final class ComplianceDsarController extends Controller
             'status' => $status,
             'task_id' => $taskId !== '' ? $taskId : null,
             'job_reference' => $referenceId !== '' ? $referenceId : null,
+            'meta' => [
+                'execution' => [
+                    'task_id' => $taskId !== '' ? $taskId : null,
+                    'job_reference' => $referenceId !== '' ? $referenceId : null,
+                ],
+            ],
         ], 202);
+    }
+
+    /**
+     * @return array{
+     *   state:string,
+     *   request_id?:string,
+     *   status?:string,
+     *   task_id?:string,
+     *   reference_id?:string
+     * }
+     */
+    private function lockExecutionState(
+        string $requestId,
+        int $orgId,
+        int $actorUserId,
+        bool $dispatchWhenRunningWithoutExecution
+    ): array {
+        $row = DB::table('dsar_requests')
+            ->where('id', $requestId)
+            ->where('org_id', $orgId)
+            ->lockForUpdate()
+            ->first();
+
+        if ($row === null) {
+            return ['state' => 'missing'];
+        }
+
+        $status = trim((string) ($row->status ?? 'pending'));
+        $subjectUserId = (int) ($row->subject_user_id ?? 0);
+        $payload = $this->decodeJson($row->payload_json ?? null) ?? [];
+        $execution = is_array($payload['execution'] ?? null) ? $payload['execution'] : [];
+
+        $payloadReferenceId = trim((string) ($execution['reference_id'] ?? ''));
+        $payloadTaskId = trim((string) ($execution['task_id'] ?? ''));
+        $executionMissing = $payloadReferenceId === '' || $payloadTaskId === '';
+
+        $referenceId = $payloadReferenceId !== '' ? $payloadReferenceId : (string) Str::uuid();
+        $taskRow = null;
+        if (SchemaBaseline::hasTable('dsar_request_tasks')) {
+            if ($payloadTaskId !== '') {
+                $taskRow = DB::table('dsar_request_tasks')
+                    ->where('id', $payloadTaskId)
+                    ->where('request_id', $requestId)
+                    ->first();
+            }
+            if ($taskRow === null) {
+                $taskRow = DB::table('dsar_request_tasks')
+                    ->where('request_id', $requestId)
+                    ->where('domain', 'orchestration')
+                    ->where('action', 'execute')
+                    ->orderByDesc('created_at')
+                    ->first();
+            }
+        }
+
+        $taskId = $payloadTaskId !== '' ? $payloadTaskId : trim((string) ($taskRow->id ?? ''));
+        if ($taskId === '') {
+            $taskId = (string) Str::uuid();
+        }
+
+        $taskExists = $taskRow !== null;
+        $shouldDispatch = false;
+        $now = now();
+
+        if ($status === 'pending') {
+            if (SchemaBaseline::hasTable('dsar_request_tasks') && ! $taskExists) {
+                $this->createOrchestrationTask($taskId, $requestId, $orgId, $subjectUserId, $actorUserId, $referenceId, $now);
+            }
+
+            $payload['execution'] = [
+                'reference_id' => $referenceId,
+                'task_id' => $taskId,
+                'queued_by_user_id' => $actorUserId,
+                'queued_at' => $now->toISOString(),
+            ];
+
+            DB::table('dsar_requests')
+                ->where('id', $requestId)
+                ->where('org_id', $orgId)
+                ->update([
+                    'status' => 'running',
+                    'executed_by_user_id' => $actorUserId,
+                    'payload_json' => json_encode($payload, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES),
+                    'updated_at' => $now,
+                ]);
+
+            $this->appendStatusTransitionAudit(
+                $requestId,
+                $orgId,
+                $subjectUserId,
+                'pending',
+                'running',
+                $referenceId,
+                $taskId
+            );
+
+            $status = 'running';
+            $shouldDispatch = true;
+        } elseif ($status === 'running' && $executionMissing) {
+            if (SchemaBaseline::hasTable('dsar_request_tasks') && ! $taskExists) {
+                $this->createOrchestrationTask($taskId, $requestId, $orgId, $subjectUserId, $actorUserId, $referenceId, $now);
+                if ($dispatchWhenRunningWithoutExecution) {
+                    $shouldDispatch = true;
+                }
+            } elseif (! SchemaBaseline::hasTable('dsar_request_tasks') && $dispatchWhenRunningWithoutExecution) {
+                $shouldDispatch = true;
+            }
+
+            $payload['execution'] = [
+                'reference_id' => $referenceId,
+                'task_id' => $taskId,
+                'queued_by_user_id' => $actorUserId,
+                'queued_at' => $now->toISOString(),
+            ];
+
+            DB::table('dsar_requests')
+                ->where('id', $requestId)
+                ->where('org_id', $orgId)
+                ->update([
+                    'payload_json' => json_encode($payload, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES),
+                    'updated_at' => $now,
+                ]);
+        }
+
+        return [
+            'state' => $shouldDispatch ? 'dispatch' : 'existing',
+            'request_id' => $requestId,
+            'status' => $status !== '' ? $status : 'running',
+            'task_id' => $taskId,
+            'reference_id' => $referenceId,
+        ];
+    }
+
+    private function createOrchestrationTask(
+        string $taskId,
+        string $requestId,
+        int $orgId,
+        int $subjectUserId,
+        int $actorUserId,
+        string $referenceId,
+        \Illuminate\Support\Carbon $now
+    ): void {
+        DB::table('dsar_request_tasks')->insert([
+            'id' => $taskId,
+            'request_id' => $requestId,
+            'org_id' => $orgId,
+            'subject_user_id' => $subjectUserId > 0 ? $subjectUserId : null,
+            'domain' => 'orchestration',
+            'action' => 'execute',
+            'status' => 'pending',
+            'error_code' => null,
+            'stats_json' => json_encode([
+                'queued_by_user_id' => $actorUserId,
+                'reference_id' => $referenceId,
+            ], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES),
+            'started_at' => null,
+            'finished_at' => null,
+            'created_at' => $now,
+            'updated_at' => $now,
+        ]);
     }
 
     /**

--- a/backend/app/Jobs/ExecuteDsarRequestJob.php
+++ b/backend/app/Jobs/ExecuteDsarRequestJob.php
@@ -12,16 +12,25 @@ use Illuminate\Foundation\Bus\Dispatchable;
 use Illuminate\Queue\InteractsWithQueue;
 use Illuminate\Queue\SerializesModels;
 use Illuminate\Support\Facades\DB;
+use Throwable;
 
 final class ExecuteDsarRequestJob implements ShouldQueue
 {
     use Dispatchable, InteractsWithQueue, Queueable, SerializesModels;
 
-    public int $tries = 1;
+    public int $tries = 3;
 
     public int $timeout = 600;
 
     public bool $failOnTimeout = true;
+
+    /**
+     * @return array<int,int>
+     */
+    public function backoff(): array
+    {
+        return [10, 30, 90];
+    }
 
     public function __construct(
         public string $requestId,
@@ -106,6 +115,98 @@ final class ExecuteDsarRequestJob implements ShouldQueue
         $this->appendAuditTransition($currentStatus, $finalStatus, $result);
     }
 
+    public function failed(Throwable $exception): void
+    {
+        $requestRow = DB::table('dsar_requests')
+            ->where('id', $this->requestId)
+            ->where('org_id', $this->orgId)
+            ->first();
+
+        if ($requestRow === null) {
+            return;
+        }
+
+        $currentStatus = trim((string) ($requestRow->status ?? 'pending'));
+        if (in_array($currentStatus, ['done', 'failed'], true)) {
+            return;
+        }
+
+        $finishedAt = now();
+        $attempts = max(1, (int) $this->attempts());
+        $maxTries = max(1, (int) $this->tries);
+        $connection = trim((string) ($this->connection ?? ''));
+        if ($connection === '') {
+            $connection = trim((string) config('queue.default', 'sync'));
+        }
+        if ($connection === '') {
+            $connection = 'sync';
+        }
+
+        $queue = trim((string) ($this->queue ?? ''));
+        if ($queue === '') {
+            $queue = trim((string) config('queue.connections.'.$connection.'.queue', ''));
+        }
+        if ($queue === '') {
+            $queue = 'default';
+        }
+
+        $exceptionMessage = trim($exception->getMessage());
+        if ($exceptionMessage !== '') {
+            $exceptionMessage = mb_substr($exceptionMessage, 0, 300);
+        }
+
+        $result = [
+            'ok' => false,
+            'error_code' => 'USER_DSAR_RETRY_EXHAUSTED',
+            'message' => 'dsar execution retry exhausted.',
+            'terminal' => [
+                'attempts' => $attempts,
+                'max_tries' => $maxTries,
+                'queue' => $queue,
+                'connection' => $connection,
+                'task_id' => $this->taskId,
+                'reference_id' => $this->referenceId,
+                'exception_class' => class_basename($exception),
+                'exception_message' => $exceptionMessage,
+            ],
+        ];
+
+        DB::table('dsar_requests')
+            ->where('id', $this->requestId)
+            ->where('org_id', $this->orgId)
+            ->update([
+                'status' => 'failed',
+                'result_json' => json_encode($result, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES),
+                'executed_by_user_id' => $this->actorUserId,
+                'executed_at' => $finishedAt,
+                'updated_at' => $finishedAt,
+            ]);
+
+        if (SchemaBaseline::hasTable('dsar_request_tasks')) {
+            DB::table('dsar_request_tasks')
+                ->where('id', $this->taskId)
+                ->where('request_id', $this->requestId)
+                ->update([
+                    'status' => 'failed',
+                    'error_code' => 'USER_DSAR_RETRY_EXHAUSTED',
+                    'stats_json' => json_encode([
+                        'dlq_marked' => true,
+                        'attempts' => $attempts,
+                        'max_tries' => $maxTries,
+                        'queue' => $queue,
+                        'connection' => $connection,
+                        'reference_id' => $this->referenceId,
+                        'task_id' => $this->taskId,
+                    ], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES),
+                    'finished_at' => $finishedAt,
+                    'updated_at' => $finishedAt,
+                ]);
+        }
+
+        $this->appendAuditTransition($currentStatus, 'failed', ['ok' => false]);
+        $this->appendTerminalFailureAudit($requestRow, $result['terminal'], $finishedAt);
+    }
+
     /**
      * @param  array<string,mixed>  $result
      */
@@ -129,6 +230,49 @@ final class ExecuteDsarRequestJob implements ShouldQueue
                 'reference_id' => $this->referenceId,
                 'task_id' => $this->taskId,
                 'result_ok' => ($result['ok'] ?? false) === true,
+            ], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES),
+            'occurred_at' => $now,
+            'created_at' => $now,
+            'updated_at' => $now,
+        ]);
+    }
+
+    /**
+     * @param  object  $requestRow
+     * @param  array{
+     *   attempts:int,
+     *   max_tries:int,
+     *   queue:string,
+     *   connection:string,
+     *   task_id:string,
+     *   reference_id:string,
+     *   exception_class:string,
+     *   exception_message:string
+     * }  $terminal
+     */
+    private function appendTerminalFailureAudit(object $requestRow, array $terminal, \Illuminate\Support\Carbon $now): void
+    {
+        if (! SchemaBaseline::hasTable('dsar_audit_logs')) {
+            return;
+        }
+
+        DB::table('dsar_audit_logs')->insert([
+            'request_id' => $this->requestId,
+            'org_id' => $this->orgId,
+            'subject_user_id' => (int) ($requestRow->subject_user_id ?? 0) ?: null,
+            'event_type' => 'dsar_job_failed_terminal',
+            'level' => 'error',
+            'message' => 'dsar execution failed after retries exhausted.',
+            'context_json' => json_encode([
+                'error_code' => 'USER_DSAR_RETRY_EXHAUSTED',
+                'attempts' => $terminal['attempts'],
+                'max_tries' => $terminal['max_tries'],
+                'queue' => $terminal['queue'],
+                'connection' => $terminal['connection'],
+                'task_id' => $terminal['task_id'],
+                'reference_id' => $terminal['reference_id'],
+                'exception_class' => $terminal['exception_class'],
+                'exception_message' => $terminal['exception_message'],
             ], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES),
             'occurred_at' => $now,
             'created_at' => $now,

--- a/backend/tests/Feature/Compliance/DsarRequestApiTest.php
+++ b/backend/tests/Feature/Compliance/DsarRequestApiTest.php
@@ -49,25 +49,11 @@ final class DsarRequestApiTest extends TestCase
 
         $create->assertStatus(202)
             ->assertJsonPath('ok', true)
-            ->assertJsonPath('status', 'pending');
-        $requestId = (string) $create->json('request_id');
-        $this->assertNotSame('', $requestId);
-
-        $this->withHeaders($headers)
-            ->getJson('/api/v0.3/compliance/dsar/requests/'.$requestId)
-            ->assertStatus(200)
-            ->assertJsonPath('ok', true)
-            ->assertJsonPath('request.status', 'pending');
-
-        $execute = $this->withHeaders($headers)
-            ->postJson('/api/v0.3/compliance/dsar/requests/'.$requestId.'/execute');
-
-        $execute->assertStatus(202)
-            ->assertJsonPath('ok', true)
-            ->assertJsonPath('request_id', $requestId)
             ->assertJsonPath('status', 'running');
-        $taskId = (string) $execute->json('task_id');
-        $referenceId = (string) $execute->json('job_reference');
+        $requestId = (string) $create->json('request_id');
+        $taskId = (string) $create->json('meta.execution.task_id');
+        $referenceId = (string) $create->json('meta.execution.job_reference');
+        $this->assertNotSame('', $requestId);
         $this->assertNotSame('', $taskId);
         $this->assertNotSame('', $referenceId);
 
@@ -85,6 +71,39 @@ final class DsarRequestApiTest extends TestCase
                 && $job->referenceId === $referenceId;
         });
 
+        $createReplay = $this->withHeaders($headers)->postJson('/api/v0.3/compliance/dsar/requests', [
+            'subject_user_id' => $subjectUserId,
+            'mode' => 'hybrid_anonymize',
+            'reason' => 'subject requested erase',
+        ]);
+
+        $createReplay->assertStatus(202)
+            ->assertJsonPath('ok', true)
+            ->assertJsonPath('request_id', $requestId)
+            ->assertJsonPath('status', 'running')
+            ->assertJsonPath('meta.execution.task_id', $taskId)
+            ->assertJsonPath('meta.execution.job_reference', $referenceId);
+        Queue::assertPushed(ExecuteDsarRequestJob::class, 1);
+
+        $this->withHeaders($headers)
+            ->getJson('/api/v0.3/compliance/dsar/requests/'.$requestId)
+            ->assertStatus(200)
+            ->assertJsonPath('ok', true)
+            ->assertJsonPath('request.status', 'running');
+
+        $execute = $this->withHeaders($headers)
+            ->postJson('/api/v0.3/compliance/dsar/requests/'.$requestId.'/execute');
+
+        $execute->assertStatus(202)
+            ->assertJsonPath('ok', true)
+            ->assertJsonPath('request_id', $requestId)
+            ->assertJsonPath('status', 'running')
+            ->assertJsonPath('task_id', $taskId)
+            ->assertJsonPath('job_reference', $referenceId)
+            ->assertJsonPath('meta.execution.task_id', $taskId)
+            ->assertJsonPath('meta.execution.job_reference', $referenceId);
+        Queue::assertPushed(ExecuteDsarRequestJob::class, 1);
+
         $this->withHeaders($headers)
             ->getJson('/api/v0.3/compliance/dsar/requests/'.$requestId)
             ->assertStatus(200)
@@ -99,7 +118,9 @@ final class DsarRequestApiTest extends TestCase
             ->assertJsonPath('request_id', $requestId)
             ->assertJsonPath('status', 'running')
             ->assertJsonPath('task_id', $taskId)
-            ->assertJsonPath('job_reference', $referenceId);
+            ->assertJsonPath('job_reference', $referenceId)
+            ->assertJsonPath('meta.execution.task_id', $taskId)
+            ->assertJsonPath('meta.execution.job_reference', $referenceId);
         Queue::assertPushed(ExecuteDsarRequestJob::class, 1);
 
         $job = new ExecuteDsarRequestJob($requestId, $orgId, $ownerUserId, $taskId, $referenceId);
@@ -119,7 +140,9 @@ final class DsarRequestApiTest extends TestCase
             ->assertJsonPath('request_id', $requestId)
             ->assertJsonPath('status', 'done')
             ->assertJsonPath('task_id', $taskId)
-            ->assertJsonPath('job_reference', $referenceId);
+            ->assertJsonPath('job_reference', $referenceId)
+            ->assertJsonPath('meta.execution.task_id', $taskId)
+            ->assertJsonPath('meta.execution.job_reference', $referenceId);
         Queue::assertPushed(ExecuteDsarRequestJob::class, 1);
 
         $subjectTokenRow = DB::table('auth_tokens')
@@ -224,6 +247,99 @@ final class DsarRequestApiTest extends TestCase
         $this->assertNotNull($lifecycleAudit);
 
         $this->assertNotEmpty($ownerToken);
+    }
+
+    public function test_execute_job_failed_marks_terminal_audit_dlq_state(): void
+    {
+        $orgId = 702;
+        $ownerUserId = 70201;
+        $subjectUserId = 70202;
+        $requestId = (string) Str::uuid();
+        $taskId = (string) Str::uuid();
+        $referenceId = (string) Str::uuid();
+
+        $this->seedUser($ownerUserId, "owner_{$ownerUserId}@example.test", '+8613900007101');
+        $this->seedUser($subjectUserId, "subject_{$subjectUserId}@example.test", '+8613900007102');
+        $this->seedOrgWithOwnerMembership($orgId, $ownerUserId);
+
+        DB::table('dsar_requests')->insert([
+            'id' => $requestId,
+            'org_id' => $orgId,
+            'subject_user_id' => $subjectUserId,
+            'requested_by_user_id' => $ownerUserId,
+            'executed_by_user_id' => $ownerUserId,
+            'mode' => 'hybrid_anonymize',
+            'status' => 'running',
+            'reason' => 'retry exhaustion case',
+            'payload_json' => json_encode([
+                'execution' => [
+                    'task_id' => $taskId,
+                    'reference_id' => $referenceId,
+                ],
+            ], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES),
+            'result_json' => null,
+            'requested_at' => now()->subMinute(),
+            'executed_at' => null,
+            'created_at' => now()->subMinute(),
+            'updated_at' => now()->subMinute(),
+        ]);
+
+        DB::table('dsar_request_tasks')->insert([
+            'id' => $taskId,
+            'request_id' => $requestId,
+            'org_id' => $orgId,
+            'subject_user_id' => $subjectUserId,
+            'domain' => 'orchestration',
+            'action' => 'execute',
+            'status' => 'running',
+            'error_code' => null,
+            'stats_json' => null,
+            'started_at' => now()->subMinute(),
+            'finished_at' => null,
+            'created_at' => now()->subMinute(),
+            'updated_at' => now()->subMinute(),
+        ]);
+
+        $job = new ExecuteDsarRequestJob($requestId, $orgId, $ownerUserId, $taskId, $referenceId);
+        $job->failed(new \RuntimeException('simulated terminal failure'));
+
+        $requestRow = DB::table('dsar_requests')->where('id', $requestId)->first();
+        $this->assertNotNull($requestRow);
+        $this->assertSame('failed', (string) ($requestRow->status ?? ''));
+        $requestResult = $this->decodeAuditContext($requestRow->result_json ?? null);
+        $this->assertSame('USER_DSAR_RETRY_EXHAUSTED', (string) ($requestResult['error_code'] ?? ''));
+
+        $taskRow = DB::table('dsar_request_tasks')->where('id', $taskId)->first();
+        $this->assertNotNull($taskRow);
+        $this->assertSame('failed', (string) ($taskRow->status ?? ''));
+        $this->assertSame('USER_DSAR_RETRY_EXHAUSTED', (string) ($taskRow->error_code ?? ''));
+        $taskStats = $this->decodeAuditContext($taskRow->stats_json ?? null);
+        $this->assertTrue((bool) ($taskStats['dlq_marked'] ?? false));
+        $this->assertSame(3, (int) ($taskStats['max_tries'] ?? 0));
+        $this->assertSame('compliance', (string) ($taskStats['queue'] ?? ''));
+        $this->assertNotSame('', (string) ($taskStats['connection'] ?? ''));
+
+        $statusTransitionAudit = DB::table('dsar_audit_logs')
+            ->where('request_id', $requestId)
+            ->where('event_type', 'dsar_status_transition')
+            ->orderByDesc('id')
+            ->first();
+        $this->assertNotNull($statusTransitionAudit);
+        $statusTransitionContext = $this->decodeAuditContext($statusTransitionAudit->context_json ?? null);
+        $this->assertSame('running', (string) ($statusTransitionContext['from'] ?? ''));
+        $this->assertSame('failed', (string) ($statusTransitionContext['to'] ?? ''));
+
+        $terminalAudit = DB::table('dsar_audit_logs')
+            ->where('request_id', $requestId)
+            ->where('event_type', 'dsar_job_failed_terminal')
+            ->orderByDesc('id')
+            ->first();
+        $this->assertNotNull($terminalAudit);
+        $terminalContext = $this->decodeAuditContext($terminalAudit->context_json ?? null);
+        $this->assertSame('USER_DSAR_RETRY_EXHAUSTED', (string) ($terminalContext['error_code'] ?? ''));
+        $this->assertSame($taskId, (string) ($terminalContext['task_id'] ?? ''));
+        $this->assertSame($referenceId, (string) ($terminalContext['reference_id'] ?? ''));
+        $this->assertSame('RuntimeException', (string) ($terminalContext['exception_class'] ?? ''));
     }
 
     private function seedUser(int $userId, string $email, string $phoneE164): void


### PR DESCRIPTION
Fixes FER2-31

## Summary
- Upgrade DSAR store flow to one-click async execution: `store` now reuses active `(org_id, subject_user_id, mode)` requests in `pending/running`, prepares execution metadata, and dispatches only when needed.
- Keep `/execute` endpoint for backward compatibility while enforcing idempotent replay: existing execution metadata in non-pending states no longer causes duplicate dispatch.
- Add `meta.execution` (`task_id`, `job_reference`) to `store` and `execute` responses without breaking existing top-level contract fields.
- Add retry policy to `ExecuteDsarRequestJob` (`tries=3`, `backoff=[10,30,90]`).
- Add terminal failure handling as audit-DLQ: on retry exhaustion, mark `dsar_requests` / `dsar_request_tasks` as `failed`, and write `dsar_status_transition` plus `dsar_job_failed_terminal` audit events with structured failure context.
- Expand DSAR API test coverage for one-click dispatch, active-request idempotency, execute compatibility, and terminal failure archiving.

## Verification
- `cd backend && php artisan test --filter Dsar`
- `bash backend/scripts/ci_verify_mbti.sh`
