### PR TITLE
Fixes FER2-34: decompose AttemptSubmit pipeline into services with golden contract

### DIFF
--- a/backend/app/Services/Attempts/AttemptSubmitCanonicalizeService.php
+++ b/backend/app/Services/Attempts/AttemptSubmitCanonicalizeService.php
@@ -1,0 +1,84 @@
+<?php
+
+namespace App\Services\Attempts;
+
+use App\Exceptions\Api\ApiProblemException;
+use App\Models\Attempt;
+
+class AttemptSubmitCanonicalizeService
+{
+    public function __construct(private AttemptSubmitService $core)
+    {
+    }
+
+    public function handle(array $guarded): array
+    {
+        /** @var Attempt $attempt */
+        $attempt = $guarded['attempt'];
+        $answers = (array) ($guarded['answers'] ?? []);
+        $scaleCode = (string) ($guarded['scale_code'] ?? '');
+        $packId = (string) ($guarded['pack_id'] ?? '');
+        $dirVersion = (string) ($guarded['dir_version'] ?? '');
+        $durationMs = (int) ($guarded['duration_ms'] ?? 0);
+        $orgId = (int) ($guarded['org_id'] ?? 0);
+        $actorAnonId = $guarded['actor_anon_id'] ?? null;
+        if ($actorAnonId !== null) {
+            $actorAnonId = (string) $actorAnonId;
+        }
+
+        $actorUserId = $guarded['actor_user_id'] ?? null;
+        if ($actorUserId !== null) {
+            $actorUserId = (string) $actorUserId;
+        }
+        $attemptId = (string) ($guarded['attempt_id'] ?? '');
+        $validityItems = (array) ($guarded['validity_items'] ?? []);
+        $region = (string) ($guarded['region'] ?? '');
+        $locale = (string) ($guarded['locale'] ?? '');
+
+        $draftAnswers = $this->core->progressService()->loadDraftAnswers($attempt);
+        $mergedAnswers = $this->core->mergeAnswersForSubmit($answers, $draftAnswers);
+        if (empty($mergedAnswers)) {
+            throw new ApiProblemException(422, 'VALIDATION_FAILED', 'answers required.');
+        }
+
+        $answersDigest = $this->core->computeAnswersDigest($mergedAnswers, $scaleCode, $packId, $dirVersion);
+
+        $attemptSummary = is_array($attempt->answers_summary_json ?? null) ? $attempt->answers_summary_json : [];
+        $attemptMeta = is_array($attemptSummary['meta'] ?? null) ? $attemptSummary['meta'] : [];
+        $packReleaseManifestHash = trim((string) ($attemptMeta['pack_release_manifest_hash'] ?? ''));
+        $policyHash = trim((string) ($attemptMeta['policy_hash'] ?? ''));
+        $engineVersion = trim((string) ($attemptMeta['engine_version'] ?? ''));
+        $submittedAt = now();
+        $serverDurationSeconds = $this->core->durationResolver()->resolveServerSecondsFromValues($attempt->started_at, $submittedAt);
+        $experiments = $this->core->resolveScoreExperiments($orgId, $actorAnonId, $actorUserId);
+
+        $scoreContext = [
+            'duration_ms' => $durationMs,
+            'started_at' => $attempt->started_at,
+            'submitted_at' => $submittedAt,
+            'server_duration_seconds' => $serverDurationSeconds,
+            'region' => $region,
+            'locale' => $locale,
+            'org_id' => $orgId,
+            'pack_id' => $packId,
+            'dir_version' => $dirVersion,
+            'attempt_id' => $attemptId,
+            'anon_id' => $actorAnonId,
+            'user_id' => $actorUserId,
+            'validity_items' => $validityItems,
+            'content_manifest_hash' => $packReleaseManifestHash,
+            'policy_hash' => $policyHash,
+            'engine_version' => $engineVersion,
+            'experiments_json' => $experiments,
+        ];
+
+        return array_merge($guarded, [
+            'merged_answers' => $mergedAnswers,
+            'answers_digest' => $answersDigest,
+            'submitted_at' => $submittedAt,
+            'server_duration_seconds' => $serverDurationSeconds,
+            'experiments' => $experiments,
+            'score_context' => $scoreContext,
+        ]);
+    }
+}

--- a/backend/app/Services/Attempts/AttemptSubmitGuardService.php
+++ b/backend/app/Services/Attempts/AttemptSubmitGuardService.php
@@ -1,0 +1,90 @@
+<?php
+
+namespace App\Services\Attempts;
+
+use App\DTO\Attempts\SubmitAttemptDTO;
+use App\Exceptions\Api\ApiProblemException;
+use App\Support\OrgContext;
+use App\Services\Scale\ScaleRolloutGate;
+
+class AttemptSubmitGuardService
+{
+    public function __construct(private AttemptSubmitService $core)
+    {
+    }
+
+    public function handle(OrgContext $ctx, string $attemptId, SubmitAttemptDTO $dto): array
+    {
+        $attemptId = trim($attemptId);
+        if ($attemptId === '') {
+            throw new ApiProblemException(400, 'VALIDATION_FAILED', 'attempt_id is required.');
+        }
+
+        $answers = $dto->answers;
+        $validityItems = $dto->validityItems;
+        $durationMs = $dto->durationMs;
+        $inviteToken = $dto->inviteToken;
+        $actorUserId = $this->core->resolveUserId($ctx, $dto->userId);
+        $actorAnonId = $this->core->resolveAnonId($ctx, $dto->anonId);
+
+        $orgId = $ctx->orgId();
+        $attempt = $this->core->ownedAttemptQuery($ctx, $attemptId, $actorUserId, $actorAnonId)->firstOrFail();
+
+        $scaleCode = strtoupper((string) ($attempt->scale_code ?? ''));
+        if ($scaleCode === '') {
+            throw new ApiProblemException(400, 'VALIDATION_FAILED', 'scale_code missing on attempt.');
+        }
+        $this->core->assertDemoScaleAllowed($scaleCode, $attemptId);
+
+        $this->core->enforceConsentOnSubmit($scaleCode, $attempt, $dto);
+
+        $row = $this->core->registry()->getByCode($scaleCode, $orgId);
+        if (! $row) {
+            throw new ApiProblemException(404, 'NOT_FOUND', 'scale not found.');
+        }
+        $projectedIdentity = $this->core->identityWriteProjector()->projectFromCodes(
+            $scaleCode,
+            (string) ($attempt->scale_code_v2 ?? ''),
+            (string) ($attempt->scale_uid ?? '')
+        );
+        $scaleCodeV2 = strtoupper(trim((string) ($projectedIdentity['scale_code_v2'] ?? $scaleCode)));
+        if ($scaleCodeV2 === '') {
+            $scaleCodeV2 = $scaleCode;
+        }
+        $scaleUid = $projectedIdentity['scale_uid'] ?? null;
+        $writeScaleIdentity = $this->core->runtimePolicy()->shouldWriteScaleIdentityColumns();
+
+        $packId = (string) ($attempt->pack_id ?? $row['default_pack_id'] ?? '');
+        $dirVersion = (string) ($attempt->dir_version ?? $row['default_dir_version'] ?? '');
+        if ($packId === '' || $dirVersion === '') {
+            throw new ApiProblemException(500, 'CONTENT_PACK_ERROR', 'scale pack not configured.');
+        }
+
+        $region = (string) ($attempt->region ?? $row['default_region'] ?? config('content_packs.default_region', ''));
+        $locale = (string) ($attempt->locale ?? $row['default_locale'] ?? config('content_packs.default_locale', ''));
+
+        ScaleRolloutGate::assertEnabled($scaleCode, $row, $region, $attemptId);
+
+        return [
+            'attempt_id' => $attemptId,
+            'dto' => $dto,
+            'answers' => $answers,
+            'validity_items' => $validityItems,
+            'duration_ms' => $durationMs,
+            'invite_token' => $inviteToken,
+            'actor_user_id' => $actorUserId,
+            'actor_anon_id' => $actorAnonId,
+            'org_id' => $orgId,
+            'attempt' => $attempt,
+            'scale_code' => $scaleCode,
+            'registry_row' => $row,
+            'scale_code_v2' => $scaleCodeV2,
+            'scale_uid' => $scaleUid,
+            'write_scale_identity' => $writeScaleIdentity,
+            'pack_id' => $packId,
+            'dir_version' => $dirVersion,
+            'region' => $region,
+            'locale' => $locale,
+        ];
+    }
+}

--- a/backend/app/Services/Attempts/AttemptSubmitPostCommitService.php
+++ b/backend/app/Services/Attempts/AttemptSubmitPostCommitService.php
@@ -1,0 +1,124 @@
+<?php
+
+namespace App\Services\Attempts;
+
+use App\Jobs\GenerateReportSnapshotJob;
+use App\Models\Attempt;
+use App\Services\Observability\ClinicalComboTelemetry;
+use App\Services\Observability\Sds20Telemetry;
+use App\Support\OrgContext;
+
+class AttemptSubmitPostCommitService
+{
+    public function __construct(private AttemptSubmitService $core)
+    {
+    }
+
+    public function handle(OrgContext $ctx, array $canonicalized, array $scored, array $tx): array
+    {
+        /** @var Attempt $attempt */
+        $attempt = $canonicalized['attempt'];
+        $attemptId = (string) ($canonicalized['attempt_id'] ?? '');
+        $orgId = (int) ($canonicalized['org_id'] ?? 0);
+        $scaleCode = (string) ($canonicalized['scale_code'] ?? '');
+        $locale = (string) ($canonicalized['locale'] ?? '');
+        $region = (string) ($canonicalized['region'] ?? '');
+        $dirVersion = (string) ($canonicalized['dir_version'] ?? '');
+        $actorUserId = $canonicalized['actor_user_id'] ?? null;
+        if ($actorUserId !== null) {
+            $actorUserId = (string) $actorUserId;
+        }
+
+        $actorAnonId = $canonicalized['actor_anon_id'] ?? null;
+        if ($actorAnonId !== null) {
+            $actorAnonId = (string) $actorAnonId;
+        }
+        $scoringSpecVersion = (string) ($scored['scoring_spec_version'] ?? '');
+        $responsePayload = is_array($tx['response_payload'] ?? null) ? $tx['response_payload'] : [];
+        $postCommitCtx = is_array($tx['post_commit_ctx'] ?? null) ? $tx['post_commit_ctx'] : null;
+
+        $snapshotJobCtx = null;
+        if (($responsePayload['ok'] ?? false) === true && is_array($postCommitCtx)) {
+            $snapshotJobCtx = $this->core->sideEffects()->runAfterSubmit($ctx, $postCommitCtx, $actorUserId, $actorAnonId);
+        }
+
+        if (is_array($snapshotJobCtx)) {
+            GenerateReportSnapshotJob::dispatch(
+                (int) $snapshotJobCtx['org_id'],
+                (string) $snapshotJobCtx['attempt_id'],
+                (string) $snapshotJobCtx['trigger_source'],
+                $snapshotJobCtx['order_no'] !== null ? (string) $snapshotJobCtx['order_no'] : null,
+            )->afterCommit();
+        }
+
+        if (($responsePayload['ok'] ?? false) === true) {
+            $this->core->progressService()->clearProgress($attemptId);
+            $this->core->sideEffects()->recordSubmitEvent(
+                $ctx,
+                $attemptId,
+                $actorUserId,
+                $actorAnonId,
+                is_array($postCommitCtx) ? $postCommitCtx : []
+            );
+        }
+
+        $this->core->sideEffects()->appendReportPayload($ctx, $attemptId, $actorUserId, $actorAnonId, $responsePayload);
+
+        if (($responsePayload['ok'] ?? false) === true && $scaleCode === 'BIG5_OCEAN') {
+            $reportPayload = is_array($responsePayload['report'] ?? null) ? $responsePayload['report'] : [];
+            $scorePayload = is_array($responsePayload['result'] ?? null) ? $responsePayload['result'] : [];
+            $normsPayload = is_array($scorePayload['norms'] ?? null) ? $scorePayload['norms'] : [];
+            $qualityPayload = is_array($scorePayload['quality'] ?? null) ? $scorePayload['quality'] : [];
+
+            $this->core->bigFiveTelemetry()->recordAttemptSubmitted(
+                $orgId,
+                $this->core->numericUserId($actorUserId),
+                $actorAnonId,
+                $attemptId,
+                $locale,
+                $region,
+                (string) ($normsPayload['status'] ?? 'MISSING'),
+                (string) ($normsPayload['group_id'] ?? ''),
+                (string) ($qualityPayload['level'] ?? 'D'),
+                (string) ($reportPayload['variant'] ?? 'free'),
+                (bool) ($reportPayload['locked'] ?? true),
+                (bool) ($responsePayload['idempotent'] ?? false),
+                $dirVersion,
+                null,
+                (string) ($normsPayload['norms_version'] ?? '')
+            );
+        }
+
+        if (($responsePayload['ok'] ?? false) === true && in_array($scaleCode, ['CLINICAL_COMBO_68', 'SDS_20'], true)) {
+            $reportPayload = is_array($responsePayload['report'] ?? null) ? $responsePayload['report'] : [];
+            $scorePayload = is_array($responsePayload['result'] ?? null) ? $responsePayload['result'] : [];
+            $qualityPayload = is_array($scorePayload['quality'] ?? null)
+                ? $scorePayload['quality']
+                : (is_array(data_get($scorePayload, 'normed_json.quality')) ? data_get($scorePayload, 'normed_json.quality') : []);
+            $crisisReasons = array_values(array_filter(array_map('strval', (array) ($qualityPayload['crisis_reasons'] ?? []))));
+
+            $telemetry = $scaleCode === 'CLINICAL_COMBO_68'
+                ? app(ClinicalComboTelemetry::class)
+                : app(Sds20Telemetry::class);
+
+            $telemetry->attemptSubmitted($attempt, [
+                'quality_level' => strtoupper(trim((string) ($qualityPayload['level'] ?? 'D'))),
+                'variant' => strtolower(trim((string) ($reportPayload['variant'] ?? 'free'))),
+                'locked' => (bool) ($reportPayload['locked'] ?? true),
+                'idempotent' => (bool) ($responsePayload['idempotent'] ?? false),
+                'scoring_spec_version' => $scoringSpecVersion,
+            ]);
+
+            $telemetry->attemptScored($attempt, $scorePayload);
+
+            if ((bool) ($qualityPayload['crisis_alert'] ?? false) === true) {
+                $telemetry->crisisTriggered($attempt, [
+                    'quality_level' => strtoupper(trim((string) ($qualityPayload['level'] ?? 'D'))),
+                    'crisis_reasons' => $crisisReasons,
+                ]);
+            }
+        }
+
+        return $responsePayload;
+    }
+}

--- a/backend/app/Services/Attempts/AttemptSubmitScoreService.php
+++ b/backend/app/Services/Attempts/AttemptSubmitScoreService.php
@@ -1,0 +1,77 @@
+<?php
+
+namespace App\Services\Attempts;
+
+use App\Exceptions\Api\ApiProblemException;
+
+class AttemptSubmitScoreService
+{
+    public function __construct(private AttemptSubmitService $core)
+    {
+    }
+
+    public function handle(array $canonicalized): array
+    {
+        $scaleCode = (string) ($canonicalized['scale_code'] ?? '');
+        $orgId = (int) ($canonicalized['org_id'] ?? 0);
+        $packId = (string) ($canonicalized['pack_id'] ?? '');
+        $dirVersion = (string) ($canonicalized['dir_version'] ?? '');
+        $mergedAnswers = (array) ($canonicalized['merged_answers'] ?? []);
+        $scoreContext = (array) ($canonicalized['score_context'] ?? []);
+        $registryRow = (array) ($canonicalized['registry_row'] ?? []);
+
+        $scored = $this->core->assessmentRunner()->run(
+            $scaleCode,
+            $orgId,
+            $packId,
+            $dirVersion,
+            $mergedAnswers,
+            $scoreContext
+        );
+        if (! ($scored['ok'] ?? false)) {
+            $errorCode = strtoupper(trim((string) ($scored['error'] ?? 'SCORING_FAILED')));
+            if ($errorCode === '') {
+                $errorCode = 'SCORING_FAILED';
+            }
+            $status = match ($errorCode) {
+                'SCORING_INPUT_INVALID' => 422,
+                'SCALE_NOT_FOUND' => 404,
+                default => 500,
+            };
+
+            throw new ApiProblemException($status, $errorCode, (string) ($scored['message'] ?? 'scoring failed.'));
+        }
+
+        $scoreResult = $scored['result'];
+        $contentPackageVersion = (string) ($scored['pack']['content_package_version'] ?? '');
+        $scoringSpecVersion = (string) ($scored['scoring_spec_version'] ?? '');
+        $modelSelection = is_array($scored['model_selection'] ?? null)
+            ? $scored['model_selection']
+            : [];
+
+        $commercial = $registryRow['commercial_json'] ?? null;
+        if (is_string($commercial)) {
+            $decoded = json_decode($commercial, true);
+            $commercial = is_array($decoded) ? $decoded : null;
+        }
+
+        $creditBenefitCode = '';
+        if (is_array($commercial)) {
+            $creditBenefitCode = strtoupper(trim((string) ($commercial['credit_benefit_code'] ?? '')));
+        }
+
+        $entitlementBenefitCode = strtoupper(trim((string) ($commercial['report_benefit_code'] ?? '')));
+        if ($entitlementBenefitCode === '') {
+            $entitlementBenefitCode = $creditBenefitCode;
+        }
+
+        return [
+            'score_result' => $scoreResult,
+            'content_package_version' => $contentPackageVersion,
+            'scoring_spec_version' => $scoringSpecVersion,
+            'model_selection' => $modelSelection,
+            'credit_benefit_code' => $creditBenefitCode,
+            'entitlement_benefit_code' => $entitlementBenefitCode,
+        ];
+    }
+}

--- a/backend/app/Services/Attempts/AttemptSubmitService.php
+++ b/backend/app/Services/Attempts/AttemptSubmitService.php
@@ -4,28 +4,37 @@ namespace App\Services\Attempts;
 
 use App\DTO\Attempts\SubmitAttemptDTO;
 use App\Exceptions\Api\ApiProblemException;
-use App\Jobs\GenerateReportSnapshotJob;
 use App\Models\Attempt;
 use App\Models\Result;
 use App\Services\Assessment\AssessmentRunner;
+use App\Services\Attempts\AttemptSubmitCanonicalizeService;
+use App\Services\Attempts\AttemptSubmitGuardService;
+use App\Services\Attempts\AttemptSubmitPostCommitService;
+use App\Services\Attempts\AttemptSubmitScoreService;
+use App\Services\Attempts\AttemptSubmitTxService;
 use App\Services\Experiments\ExperimentAssigner;
 use App\Services\Observability\BigFiveTelemetry;
-use App\Services\Observability\ClinicalComboTelemetry;
-use App\Services\Observability\Sds20Telemetry;
 use App\Services\Report\ReportGatekeeper;
 use App\Services\Scale\ScaleCodeResponseProjector;
 use App\Services\Scale\ScaleIdentityResolver;
 use App\Services\Scale\ScaleIdentityRuntimePolicy;
 use App\Services\Scale\ScaleIdentityWriteProjector;
 use App\Services\Scale\ScaleRegistry;
-use App\Services\Scale\ScaleRolloutGate;
 use App\Support\OrgContext;
 use Illuminate\Database\Eloquent\Builder;
-use Illuminate\Support\Facades\DB;
-use Illuminate\Support\Str;
 
 class AttemptSubmitService
 {
+    private AttemptSubmitGuardService $guardStage;
+
+    private AttemptSubmitCanonicalizeService $canonicalizeStage;
+
+    private AttemptSubmitScoreService $scoreStage;
+
+    private AttemptSubmitTxService $txStage;
+
+    private AttemptSubmitPostCommitService $postCommitStage;
+
     public function __construct(
         private ScaleRegistry $registry,
         private AttemptProgressService $progressService,
@@ -35,756 +44,65 @@ class AttemptSubmitService
         private ReportGatekeeper $reportGatekeeper,
         private AttemptDurationResolver $durationResolver,
         private ScaleIdentityResolver $identityResolver,
-    ) {}
+    ) {
+        $this->guardStage = new AttemptSubmitGuardService($this);
+        $this->canonicalizeStage = new AttemptSubmitCanonicalizeService($this);
+        $this->scoreStage = new AttemptSubmitScoreService($this);
+        $this->txStage = new AttemptSubmitTxService($this);
+        $this->postCommitStage = new AttemptSubmitPostCommitService($this);
+    }
 
     public function submit(OrgContext $ctx, string $attemptId, SubmitAttemptDTO $dto): array
     {
-        $guarded = $this->stageGuard($ctx, $attemptId, $dto);
-        $canonicalized = $this->stageCanonicalize($guarded);
-        $scored = $this->stageScore($canonicalized);
-        $tx = $this->stageTx($ctx, $canonicalized, $scored);
+        $guarded = $this->guardStage->handle($ctx, $attemptId, $dto);
+        $canonicalized = $this->canonicalizeStage->handle($guarded);
+        $scored = $this->scoreStage->handle($canonicalized);
+        $tx = $this->txStage->handle($ctx, $canonicalized, $scored);
 
-        return $this->stagePostCommit($ctx, $canonicalized, $scored, $tx);
+        return $this->postCommitStage->handle($ctx, $canonicalized, $scored, $tx);
     }
 
-    /**
-     * @return array<string,mixed>
-     */
-    private function stageGuard(OrgContext $ctx, string $attemptId, SubmitAttemptDTO $dto): array
+    public function registry(): ScaleRegistry
     {
-        $attemptId = trim($attemptId);
-        if ($attemptId === '') {
-            throw new ApiProblemException(400, 'VALIDATION_FAILED', 'attempt_id is required.');
-        }
-
-        $answers = $dto->answers;
-        $validityItems = $dto->validityItems;
-        $durationMs = $dto->durationMs;
-        $inviteToken = $dto->inviteToken;
-        $actorUserId = $this->resolveUserId($ctx, $dto->userId);
-        $actorAnonId = $this->resolveAnonId($ctx, $dto->anonId);
-
-        $orgId = $ctx->orgId();
-        $attempt = $this->ownedAttemptQuery($ctx, $attemptId, $actorUserId, $actorAnonId)->firstOrFail();
-
-        $scaleCode = strtoupper((string) ($attempt->scale_code ?? ''));
-        if ($scaleCode === '') {
-            throw new ApiProblemException(400, 'VALIDATION_FAILED', 'scale_code missing on attempt.');
-        }
-        $this->assertDemoScaleAllowed($scaleCode, $attemptId);
-
-        $this->enforceConsentOnSubmit($scaleCode, $attempt, $dto);
-
-        $row = $this->registry->getByCode($scaleCode, $orgId);
-        if (! $row) {
-            throw new ApiProblemException(404, 'NOT_FOUND', 'scale not found.');
-        }
-        $projectedIdentity = $this->identityWriteProjector()->projectFromCodes(
-            $scaleCode,
-            (string) ($attempt->scale_code_v2 ?? ''),
-            (string) ($attempt->scale_uid ?? '')
-        );
-        $scaleCodeV2 = strtoupper(trim((string) ($projectedIdentity['scale_code_v2'] ?? $scaleCode)));
-        if ($scaleCodeV2 === '') {
-            $scaleCodeV2 = $scaleCode;
-        }
-        $scaleUid = $projectedIdentity['scale_uid'] ?? null;
-        $writeScaleIdentity = $this->runtimePolicy()->shouldWriteScaleIdentityColumns();
-
-        $packId = (string) ($attempt->pack_id ?? $row['default_pack_id'] ?? '');
-        $dirVersion = (string) ($attempt->dir_version ?? $row['default_dir_version'] ?? '');
-        if ($packId === '' || $dirVersion === '') {
-            throw new ApiProblemException(500, 'CONTENT_PACK_ERROR', 'scale pack not configured.');
-        }
-
-        $region = (string) ($attempt->region ?? $row['default_region'] ?? config('content_packs.default_region', ''));
-        $locale = (string) ($attempt->locale ?? $row['default_locale'] ?? config('content_packs.default_locale', ''));
-
-        ScaleRolloutGate::assertEnabled($scaleCode, $row, $region, $attemptId);
-
-        return [
-            'attempt_id' => $attemptId,
-            'dto' => $dto,
-            'answers' => $answers,
-            'validity_items' => $validityItems,
-            'duration_ms' => $durationMs,
-            'invite_token' => $inviteToken,
-            'actor_user_id' => $actorUserId,
-            'actor_anon_id' => $actorAnonId,
-            'org_id' => $orgId,
-            'attempt' => $attempt,
-            'scale_code' => $scaleCode,
-            'registry_row' => $row,
-            'scale_code_v2' => $scaleCodeV2,
-            'scale_uid' => $scaleUid,
-            'write_scale_identity' => $writeScaleIdentity,
-            'pack_id' => $packId,
-            'dir_version' => $dirVersion,
-            'region' => $region,
-            'locale' => $locale,
-        ];
+        return $this->registry;
     }
 
-    /**
-     * @param  array<string,mixed>  $guarded
-     * @return array<string,mixed>
-     */
-    private function stageCanonicalize(array $guarded): array
+    public function progressService(): AttemptProgressService
     {
-        /** @var Attempt $attempt */
-        $attempt = $guarded['attempt'];
-        $answers = (array) ($guarded['answers'] ?? []);
-        $scaleCode = (string) ($guarded['scale_code'] ?? '');
-        $packId = (string) ($guarded['pack_id'] ?? '');
-        $dirVersion = (string) ($guarded['dir_version'] ?? '');
-        $durationMs = (int) ($guarded['duration_ms'] ?? 0);
-        $orgId = (int) ($guarded['org_id'] ?? 0);
-        $actorAnonId = $guarded['actor_anon_id'] ?? null;
-        if ($actorAnonId !== null) {
-            $actorAnonId = (string) $actorAnonId;
-        }
-
-        $actorUserId = $guarded['actor_user_id'] ?? null;
-        if ($actorUserId !== null) {
-            $actorUserId = (string) $actorUserId;
-        }
-        $attemptId = (string) ($guarded['attempt_id'] ?? '');
-        $validityItems = (array) ($guarded['validity_items'] ?? []);
-        $region = (string) ($guarded['region'] ?? '');
-        $locale = (string) ($guarded['locale'] ?? '');
-
-        $draftAnswers = $this->progressService->loadDraftAnswers($attempt);
-        $mergedAnswers = $this->mergeAnswersForSubmit($answers, $draftAnswers);
-        if (empty($mergedAnswers)) {
-            throw new ApiProblemException(422, 'VALIDATION_FAILED', 'answers required.');
-        }
-
-        $answersDigest = $this->computeAnswersDigest($mergedAnswers, $scaleCode, $packId, $dirVersion);
-
-        $attemptSummary = is_array($attempt->answers_summary_json ?? null) ? $attempt->answers_summary_json : [];
-        $attemptMeta = is_array($attemptSummary['meta'] ?? null) ? $attemptSummary['meta'] : [];
-        $packReleaseManifestHash = trim((string) ($attemptMeta['pack_release_manifest_hash'] ?? ''));
-        $policyHash = trim((string) ($attemptMeta['policy_hash'] ?? ''));
-        $engineVersion = trim((string) ($attemptMeta['engine_version'] ?? ''));
-        $submittedAt = now();
-        $serverDurationSeconds = $this->durationResolver->resolveServerSecondsFromValues($attempt->started_at, $submittedAt);
-        $experiments = $this->resolveScoreExperiments($orgId, $actorAnonId, $actorUserId);
-
-        $scoreContext = [
-            'duration_ms' => $durationMs,
-            'started_at' => $attempt->started_at,
-            'submitted_at' => $submittedAt,
-            'server_duration_seconds' => $serverDurationSeconds,
-            'region' => $region,
-            'locale' => $locale,
-            'org_id' => $orgId,
-            'pack_id' => $packId,
-            'dir_version' => $dirVersion,
-            'attempt_id' => $attemptId,
-            'anon_id' => $actorAnonId,
-            'user_id' => $actorUserId,
-            'validity_items' => $validityItems,
-            'content_manifest_hash' => $packReleaseManifestHash,
-            'policy_hash' => $policyHash,
-            'engine_version' => $engineVersion,
-            'experiments_json' => $experiments,
-        ];
-
-        return array_merge($guarded, [
-            'merged_answers' => $mergedAnswers,
-            'answers_digest' => $answersDigest,
-            'submitted_at' => $submittedAt,
-            'server_duration_seconds' => $serverDurationSeconds,
-            'experiments' => $experiments,
-            'score_context' => $scoreContext,
-        ]);
+        return $this->progressService;
     }
 
-    /**
-     * @param  array<string,mixed>  $canonicalized
-     * @return array<string,mixed>
-     */
-    private function stageScore(array $canonicalized): array
+    public function answerPersistence(): AttemptAnswerPersistence
     {
-        $scaleCode = (string) ($canonicalized['scale_code'] ?? '');
-        $orgId = (int) ($canonicalized['org_id'] ?? 0);
-        $packId = (string) ($canonicalized['pack_id'] ?? '');
-        $dirVersion = (string) ($canonicalized['dir_version'] ?? '');
-        $mergedAnswers = (array) ($canonicalized['merged_answers'] ?? []);
-        $scoreContext = (array) ($canonicalized['score_context'] ?? []);
-        $registryRow = (array) ($canonicalized['registry_row'] ?? []);
-
-        $scored = $this->assessmentRunner->run(
-            $scaleCode,
-            $orgId,
-            $packId,
-            $dirVersion,
-            $mergedAnswers,
-            $scoreContext
-        );
-        if (! ($scored['ok'] ?? false)) {
-            $errorCode = strtoupper(trim((string) ($scored['error'] ?? 'SCORING_FAILED')));
-            if ($errorCode === '') {
-                $errorCode = 'SCORING_FAILED';
-            }
-            $status = match ($errorCode) {
-                'SCORING_INPUT_INVALID' => 422,
-                'SCALE_NOT_FOUND' => 404,
-                default => 500,
-            };
-
-            throw new ApiProblemException($status, $errorCode, (string) ($scored['message'] ?? 'scoring failed.'));
-        }
-
-        $scoreResult = $scored['result'];
-        $contentPackageVersion = (string) ($scored['pack']['content_package_version'] ?? '');
-        $scoringSpecVersion = (string) ($scored['scoring_spec_version'] ?? '');
-        $modelSelection = is_array($scored['model_selection'] ?? null)
-            ? $scored['model_selection']
-            : [];
-
-        $commercial = $registryRow['commercial_json'] ?? null;
-        if (is_string($commercial)) {
-            $decoded = json_decode($commercial, true);
-            $commercial = is_array($decoded) ? $decoded : null;
-        }
-
-        $creditBenefitCode = '';
-        if (is_array($commercial)) {
-            $creditBenefitCode = strtoupper(trim((string) ($commercial['credit_benefit_code'] ?? '')));
-        }
-
-        $entitlementBenefitCode = strtoupper(trim((string) ($commercial['report_benefit_code'] ?? '')));
-        if ($entitlementBenefitCode === '') {
-            $entitlementBenefitCode = $creditBenefitCode;
-        }
-
-        return [
-            'score_result' => $scoreResult,
-            'content_package_version' => $contentPackageVersion,
-            'scoring_spec_version' => $scoringSpecVersion,
-            'model_selection' => $modelSelection,
-            'credit_benefit_code' => $creditBenefitCode,
-            'entitlement_benefit_code' => $entitlementBenefitCode,
-        ];
+        return $this->answerPersistence;
     }
 
-    /**
-     * @param  array<string,mixed>  $canonicalized
-     * @param  array<string,mixed>  $scored
-     * @return array<string,mixed>
-     */
-    private function stageTx(OrgContext $ctx, array $canonicalized, array $scored): array
+    public function assessmentRunner(): AssessmentRunner
     {
-        $attemptId = (string) ($canonicalized['attempt_id'] ?? '');
-        $mergedAnswers = (array) ($canonicalized['merged_answers'] ?? []);
-        $answersDigest = (string) ($canonicalized['answers_digest'] ?? '');
-        $durationMs = (int) ($canonicalized['duration_ms'] ?? 0);
-        $orgId = (int) ($canonicalized['org_id'] ?? 0);
-        $scaleCode = (string) ($canonicalized['scale_code'] ?? '');
-        $packId = (string) ($canonicalized['pack_id'] ?? '');
-        $dirVersion = (string) ($canonicalized['dir_version'] ?? '');
-        $region = (string) ($canonicalized['region'] ?? '');
-        $locale = (string) ($canonicalized['locale'] ?? '');
-        $inviteToken = (string) ($canonicalized['invite_token'] ?? '');
-        $actorUserId = $canonicalized['actor_user_id'] ?? null;
-        if ($actorUserId !== null) {
-            $actorUserId = (string) $actorUserId;
-        }
-
-        $actorAnonId = $canonicalized['actor_anon_id'] ?? null;
-        if ($actorAnonId !== null) {
-            $actorAnonId = (string) $actorAnonId;
-        }
-        $validityItems = (array) ($canonicalized['validity_items'] ?? []);
-        $submittedAt = $canonicalized['submitted_at'] ?? now();
-        $writeScaleIdentity = (bool) ($canonicalized['write_scale_identity'] ?? false);
-        $scaleCodeV2 = (string) ($canonicalized['scale_code_v2'] ?? '');
-        $scaleUid = $canonicalized['scale_uid'] ?? null;
-
-        $scoreResult = $scored['score_result'];
-        $contentPackageVersion = (string) ($scored['content_package_version'] ?? '');
-        $scoringSpecVersion = (string) ($scored['scoring_spec_version'] ?? '');
-        $modelSelection = is_array($scored['model_selection'] ?? null)
-            ? $scored['model_selection']
-            : [];
-        $creditBenefitCode = (string) ($scored['credit_benefit_code'] ?? '');
-        $entitlementBenefitCode = (string) ($scored['entitlement_benefit_code'] ?? '');
-        $experiments = is_array($canonicalized['experiments'] ?? null) ? $canonicalized['experiments'] : [];
-
-        $responsePayload = null;
-        $postCommitCtx = null;
-
-        DB::transaction(function () use (
-            $ctx,
-            &$responsePayload,
-            &$postCommitCtx,
-            $attemptId,
-            $mergedAnswers,
-            $answersDigest,
-            $durationMs,
-            $orgId,
-            $scaleCode,
-            $packId,
-            $dirVersion,
-            $region,
-            $locale,
-            $inviteToken,
-            $creditBenefitCode,
-            $entitlementBenefitCode,
-            $scoreResult,
-            $contentPackageVersion,
-            $scoringSpecVersion,
-            $modelSelection,
-            $experiments,
-            $actorUserId,
-            $actorAnonId,
-            $validityItems,
-            $submittedAt,
-            $writeScaleIdentity,
-            $scaleCodeV2,
-            $scaleUid
-        ) {
-            $locked = $this->ownedAttemptQuery($ctx, $attemptId, $actorUserId, $actorAnonId)
-                ->lockForUpdate()
-                ->firstOrFail();
-
-            $existingDigest = trim((string) ($locked->answers_digest ?? ''));
-            if ($locked->submitted_at && $existingDigest !== '') {
-                if ($existingDigest === $answersDigest) {
-                    $existingResult = $this->findResult($orgId, $attemptId);
-                    if ($existingResult) {
-                        $responsePayload = $this->buildSubmitPayload($locked, $existingResult, false);
-                        $postCommitCtx = [
-                            'org_id' => $orgId,
-                            'attempt_id' => $attemptId,
-                            'scale_code' => $scaleCode,
-                            'scale_code_v2' => $scaleCodeV2,
-                            'scale_uid' => $scaleUid,
-                            'pack_id' => (string) ($locked->pack_id ?? $packId),
-                            'dir_version' => (string) ($locked->dir_version ?? $dirVersion),
-                            'scoring_spec_version' => (string) ($locked->scoring_spec_version ?? $scoringSpecVersion),
-                            'invite_token' => $inviteToken,
-                            'credit_benefit_code' => $creditBenefitCode,
-                            'entitlement_benefit_code' => $entitlementBenefitCode,
-                        ];
-
-                        return;
-                    }
-                }
-
-                throw new ApiProblemException(409, 'CONFLICT', 'attempt already submitted with different answers.');
-            }
-
-            if ($locked->submitted_at && $existingDigest === '') {
-                $existingResult = $this->findResult($orgId, $attemptId);
-                if ($existingResult) {
-                    $responsePayload = $this->buildSubmitPayload($locked, $existingResult, false);
-                    $postCommitCtx = [
-                        'org_id' => $orgId,
-                        'attempt_id' => $attemptId,
-                        'scale_code' => $scaleCode,
-                        'scale_code_v2' => $scaleCodeV2,
-                        'scale_uid' => $scaleUid,
-                        'pack_id' => (string) ($locked->pack_id ?? $packId),
-                        'dir_version' => (string) ($locked->dir_version ?? $dirVersion),
-                        'scoring_spec_version' => (string) ($locked->scoring_spec_version ?? $scoringSpecVersion),
-                        'invite_token' => $inviteToken,
-                        'credit_benefit_code' => $creditBenefitCode,
-                        'entitlement_benefit_code' => $entitlementBenefitCode,
-                    ];
-
-                    return;
-                }
-            }
-
-            $attemptFill = [
-                'pack_id' => $packId,
-                'dir_version' => $dirVersion,
-                'content_package_version' => $contentPackageVersion !== '' ? $contentPackageVersion : null,
-                'scoring_spec_version' => $scoringSpecVersion !== '' ? $scoringSpecVersion : null,
-                'region' => $region,
-                'locale' => $locale,
-                'submitted_at' => $submittedAt,
-                'duration_ms' => $durationMs,
-                'answers_digest' => $answersDigest,
-            ];
-            if ($writeScaleIdentity) {
-                $attemptFill['scale_code_v2'] = $scaleCodeV2;
-                $attemptFill['scale_uid'] = $scaleUid;
-            }
-            $locked->fill($attemptFill);
-
-            if ($scaleCode === 'BIG5_OCEAN') {
-                $snapshot = $locked->calculation_snapshot_json;
-                if (! is_array($snapshot)) {
-                    $snapshot = [];
-                }
-                $snapshot['validity_items'] = $validityItems;
-                $locked->calculation_snapshot_json = $snapshot;
-            }
-
-            if ($scaleCode === 'BIG5_OCEAN' && is_array($scoreResult->normedJson ?? null)) {
-                $normed = (array) $scoreResult->normedJson;
-                $normsNode = is_array($normed['norms'] ?? null) ? $normed['norms'] : [];
-
-                $normsVersion = trim((string) ($normsNode['norms_version'] ?? ($normed['norms_version'] ?? '')));
-                $groupId = trim((string) ($normsNode['group_id'] ?? ($normed['group_id'] ?? '')));
-                $sourceId = trim((string) ($normsNode['source_id'] ?? ($normed['source_id'] ?? '')));
-                $status = strtoupper(trim((string) ($normsNode['status'] ?? ($normed['status'] ?? 'MISSING'))));
-                if (! in_array($status, ['CALIBRATED', 'PROVISIONAL', 'MISSING'], true)) {
-                    $status = 'MISSING';
-                }
-
-                if ($normsVersion !== '') {
-                    $locked->norm_version = $normsVersion;
-                }
-
-                $snapshot = $locked->calculation_snapshot_json;
-                if (! is_array($snapshot)) {
-                    $snapshot = [];
-                }
-
-                $snapshot['norms'] = [
-                    'norms_version' => $normsVersion,
-                    'group_id' => $groupId,
-                    'source_id' => $sourceId,
-                    'status' => $status,
-                ];
-                $snapshot['spec_version'] = (string) ($normed['spec_version'] ?? ($snapshot['spec_version'] ?? ''));
-                $snapshot['item_bank_version'] = (string) ($normed['item_bank_version'] ?? ($snapshot['item_bank_version'] ?? ''));
-                $snapshot['engine_version'] = (string) ($normed['engine_version'] ?? ($snapshot['engine_version'] ?? ''));
-                $locked->calculation_snapshot_json = $snapshot;
-            }
-
-            if ($scaleCode === 'CLINICAL_COMBO_68' && is_array($scoreResult->normedJson ?? null)) {
-                $normed = (array) $scoreResult->normedJson;
-                $versionSnapshot = is_array($normed['version_snapshot'] ?? null)
-                    ? $normed['version_snapshot']
-                    : [];
-
-                $snapshot = $locked->calculation_snapshot_json;
-                if (! is_array($snapshot)) {
-                    $snapshot = [];
-                }
-
-                $snapshot['clinical_combo_68'] = [
-                    'pack_id' => (string) ($versionSnapshot['pack_id'] ?? $packId),
-                    'pack_version' => (string) ($versionSnapshot['pack_version'] ?? $dirVersion),
-                    'policy_version' => (string) ($versionSnapshot['policy_version'] ?? ''),
-                    'engine_version' => (string) ($versionSnapshot['engine_version'] ?? data_get($normed, 'engine_version', 'v1.0_2026')),
-                    'scoring_spec_version' => (string) ($versionSnapshot['scoring_spec_version'] ?? $scoringSpecVersion),
-                    'content_manifest_hash' => (string) ($versionSnapshot['content_manifest_hash'] ?? ''),
-                ];
-                $snapshot['quality'] = is_array($normed['quality'] ?? null) ? $normed['quality'] : [];
-                $locked->calculation_snapshot_json = $snapshot;
-
-                $locked->answers_summary_json = $this->buildClinicalAnswersSummary($mergedAnswers, $normed, $durationMs);
-            }
-
-            if ($scaleCode === 'SDS_20' && is_array($scoreResult->normedJson ?? null)) {
-                $normed = (array) $scoreResult->normedJson;
-                $versionSnapshot = is_array($normed['version_snapshot'] ?? null)
-                    ? $normed['version_snapshot']
-                    : [];
-                $normsNode = is_array($normed['norms'] ?? null) ? $normed['norms'] : [];
-
-                $snapshot = $locked->calculation_snapshot_json;
-                if (! is_array($snapshot)) {
-                    $snapshot = [];
-                }
-
-                $normsVersion = trim((string) ($normsNode['norms_version'] ?? ''));
-                if ($normsVersion !== '') {
-                    $locked->norm_version = $normsVersion;
-                }
-
-                $snapshot['sds_20'] = [
-                    'pack_id' => (string) ($versionSnapshot['pack_id'] ?? $packId),
-                    'pack_version' => (string) ($versionSnapshot['pack_version'] ?? $dirVersion),
-                    'policy_version' => (string) ($versionSnapshot['policy_version'] ?? ''),
-                    'policy_hash' => (string) ($versionSnapshot['policy_hash'] ?? ''),
-                    'engine_version' => (string) ($versionSnapshot['engine_version'] ?? data_get($normed, 'engine_version', 'v2.0_Factor_Logic')),
-                    'scoring_spec_version' => (string) ($versionSnapshot['scoring_spec_version'] ?? $scoringSpecVersion),
-                    'content_manifest_hash' => (string) ($versionSnapshot['content_manifest_hash'] ?? ''),
-                    'norms' => [
-                        'status' => strtoupper(trim((string) ($normsNode['status'] ?? 'MISSING'))),
-                        'group_id' => (string) ($normsNode['group_id'] ?? ''),
-                        'norms_version' => $normsVersion,
-                        'source_id' => (string) ($normsNode['source_id'] ?? ''),
-                    ],
-                ];
-                $snapshot['quality'] = is_array($normed['quality'] ?? null) ? $normed['quality'] : ($snapshot['quality'] ?? []);
-                $locked->calculation_snapshot_json = $snapshot;
-            }
-
-            if ($scaleCode === 'EQ_60' && is_array($scoreResult->normedJson ?? null)) {
-                $normed = (array) $scoreResult->normedJson;
-                $versionSnapshot = is_array($normed['version_snapshot'] ?? null)
-                    ? $normed['version_snapshot']
-                    : [];
-                $normsNode = is_array($normed['norms'] ?? null) ? $normed['norms'] : [];
-                $qualityNode = is_array($normed['quality'] ?? null) ? $normed['quality'] : [];
-
-                $snapshot = $locked->calculation_snapshot_json;
-                if (! is_array($snapshot)) {
-                    $snapshot = [];
-                }
-
-                $normsVersion = trim((string) ($normsNode['version'] ?? ''));
-                if ($normsVersion !== '') {
-                    $locked->norm_version = $normsVersion;
-                }
-
-                $snapshot['eq_60'] = [
-                    'pack_id' => (string) ($versionSnapshot['pack_id'] ?? $packId),
-                    'pack_version' => (string) ($versionSnapshot['pack_version'] ?? $dirVersion),
-                    'policy_version' => (string) ($versionSnapshot['policy_version'] ?? ''),
-                    'policy_hash' => (string) ($versionSnapshot['policy_hash'] ?? ''),
-                    'engine_version' => (string) ($versionSnapshot['engine_version'] ?? data_get($normed, 'engine_version', 'v1.0_normed_validity')),
-                    'scoring_spec_version' => (string) ($versionSnapshot['scoring_spec_version'] ?? $scoringSpecVersion),
-                    'content_manifest_hash' => (string) ($versionSnapshot['content_manifest_hash'] ?? ''),
-                    'norms' => [
-                        'status' => strtoupper(trim((string) ($normsNode['status'] ?? 'PROVISIONAL'))),
-                        'group' => (string) ($normsNode['group'] ?? ''),
-                        'version' => $normsVersion,
-                    ],
-                    'quality' => [
-                        'level' => strtoupper(trim((string) ($qualityNode['level'] ?? 'A'))),
-                        'flags' => array_values(array_filter(array_map('strval', (array) ($qualityNode['flags'] ?? [])))),
-                    ],
-                ];
-                $snapshot['quality'] = $qualityNode !== [] ? $qualityNode : ($snapshot['quality'] ?? []);
-                $locked->calculation_snapshot_json = $snapshot;
-            }
-
-            if ($locked->started_at === null) {
-                $locked->started_at = now();
-            }
-            $locked->save();
-
-            $this->answerPersistence->persist($locked, $mergedAnswers, $durationMs, $scoringSpecVersion);
-
-            $axisScores = is_array($scoreResult->axisScoresJson ?? null)
-                ? $scoreResult->axisScoresJson
-                : [];
-
-            $scoresJson = $axisScores['scores_json'] ?? null;
-            if (! is_array($scoresJson)) {
-                $scoresJson = is_array($scoreResult->breakdownJson) ? $scoreResult->breakdownJson : [];
-            }
-
-            $scoresPct = $axisScores['scores_pct'] ?? null;
-            $axisStates = $axisScores['axis_states'] ?? null;
-
-            $resultJson = $scoreResult->toArray();
-            if (in_array($scaleCode, ['BIG5_OCEAN', 'SDS_20', 'EQ_60'], true) && is_array($resultJson['normed_json'] ?? null)) {
-                $resultJson = array_merge($resultJson, $resultJson['normed_json']);
-            }
-            if (is_array($resultJson['quality'] ?? null)) {
-                $resultJson['quality']['client_duration_ms'] = $durationMs;
-            }
-            $responseCodes = $this->responseProjector()->project(
-                $scaleCode,
-                $scaleCodeV2,
-                $scaleUid
-            );
-            $resultJson['scale_code'] = $responseCodes['scale_code'];
-            $resultJson['scale_code_legacy'] = $responseCodes['scale_code_legacy'];
-            $resultJson['scale_code_v2'] = $responseCodes['scale_code_v2'];
-            $resultJson['scale_uid'] = $responseCodes['scale_uid'];
-            $resultJson['pack_id'] = $packId;
-            $resultJson['dir_version'] = $dirVersion;
-            $resultJson['content_package_version'] = $contentPackageVersion;
-            $resultJson['scoring_spec_version'] = $scoringSpecVersion;
-            if ($modelSelection !== []) {
-                $resultJson['model_selection'] = $modelSelection;
-            }
-            if ($experiments !== []) {
-                $resultJson['experiments_json'] = $experiments;
-            }
-            $resultJson['computed_at'] = now()->toISOString();
-
-            $resultData = [
-                'org_id' => $orgId,
-                'attempt_id' => $attemptId,
-                'scale_code' => $scaleCode,
-                'scale_version' => (string) ($locked->scale_version ?? 'v0.3'),
-                'type_code' => (string) ($scoreResult->typeCode ?? ''),
-                'scores_json' => $scoresJson,
-                'scores_pct' => is_array($scoresPct) ? $scoresPct : null,
-                'axis_states' => is_array($axisStates) ? $axisStates : null,
-                'profile_version' => null,
-                'content_package_version' => $contentPackageVersion !== '' ? $contentPackageVersion : null,
-                'result_json' => $resultJson,
-                'pack_id' => $packId,
-                'dir_version' => $dirVersion,
-                'scoring_spec_version' => $scoringSpecVersion !== '' ? $scoringSpecVersion : null,
-                'report_engine_version' => 'v1.2',
-                'is_valid' => true,
-                'computed_at' => now(),
-            ];
-            if ($writeScaleIdentity) {
-                $resultData['scale_code_v2'] = $scaleCodeV2;
-                $resultData['scale_uid'] = $scaleUid;
-            }
-
-            $existingResult = $this->findResult($orgId, $attemptId);
-            if ($existingResult) {
-                $existingResult->fill($resultData);
-                $existingResult->save();
-                $result = $existingResult;
-            } else {
-                $resultData['id'] = (string) Str::uuid();
-                $result = Result::create($resultData);
-            }
-
-            $responsePayload = $this->buildSubmitPayload($locked, $result, true);
-            $postCommitCtx = [
-                'org_id' => $orgId,
-                'attempt_id' => $attemptId,
-                'scale_code' => $scaleCode,
-                'scale_code_v2' => $scaleCodeV2,
-                'scale_uid' => $scaleUid,
-                'pack_id' => $packId,
-                'dir_version' => $dirVersion,
-                'scoring_spec_version' => $scoringSpecVersion,
-                'invite_token' => $inviteToken,
-                'credit_benefit_code' => $creditBenefitCode,
-                'entitlement_benefit_code' => $entitlementBenefitCode,
-            ];
-        });
-
-        if (! is_array($responsePayload)) {
-            throw new ApiProblemException(500, 'INTERNAL_ERROR', 'unexpected submit state.');
-        }
-
-        return [
-            'response_payload' => $responsePayload,
-            'post_commit_ctx' => $postCommitCtx,
-        ];
+        return $this->assessmentRunner;
     }
 
-    /**
-     * @param  array<string,mixed>  $canonicalized
-     * @param  array<string,mixed>  $scored
-     * @param  array<string,mixed>  $tx
-     * @return array<string,mixed>
-     */
-    private function stagePostCommit(OrgContext $ctx, array $canonicalized, array $scored, array $tx): array
+    public function sideEffects(): AttemptSubmitSideEffects
     {
-        /** @var Attempt $attempt */
-        $attempt = $canonicalized['attempt'];
-        $attemptId = (string) ($canonicalized['attempt_id'] ?? '');
-        $orgId = (int) ($canonicalized['org_id'] ?? 0);
-        $scaleCode = (string) ($canonicalized['scale_code'] ?? '');
-        $locale = (string) ($canonicalized['locale'] ?? '');
-        $region = (string) ($canonicalized['region'] ?? '');
-        $dirVersion = (string) ($canonicalized['dir_version'] ?? '');
-        $actorUserId = $canonicalized['actor_user_id'] ?? null;
-        if ($actorUserId !== null) {
-            $actorUserId = (string) $actorUserId;
-        }
-
-        $actorAnonId = $canonicalized['actor_anon_id'] ?? null;
-        if ($actorAnonId !== null) {
-            $actorAnonId = (string) $actorAnonId;
-        }
-        $scoringSpecVersion = (string) ($scored['scoring_spec_version'] ?? '');
-        $responsePayload = is_array($tx['response_payload'] ?? null) ? $tx['response_payload'] : [];
-        $postCommitCtx = is_array($tx['post_commit_ctx'] ?? null) ? $tx['post_commit_ctx'] : null;
-
-        $snapshotJobCtx = null;
-        if (($responsePayload['ok'] ?? false) === true && is_array($postCommitCtx)) {
-            $snapshotJobCtx = $this->sideEffects->runAfterSubmit($ctx, $postCommitCtx, $actorUserId, $actorAnonId);
-        }
-
-        if (is_array($snapshotJobCtx)) {
-            GenerateReportSnapshotJob::dispatch(
-                (int) $snapshotJobCtx['org_id'],
-                (string) $snapshotJobCtx['attempt_id'],
-                (string) $snapshotJobCtx['trigger_source'],
-                $snapshotJobCtx['order_no'] !== null ? (string) $snapshotJobCtx['order_no'] : null,
-            )->afterCommit();
-        }
-
-        if (($responsePayload['ok'] ?? false) === true) {
-            $this->progressService->clearProgress($attemptId);
-            $this->sideEffects->recordSubmitEvent(
-                $ctx,
-                $attemptId,
-                $actorUserId,
-                $actorAnonId,
-                is_array($postCommitCtx) ? $postCommitCtx : []
-            );
-        }
-
-        $this->sideEffects->appendReportPayload($ctx, $attemptId, $actorUserId, $actorAnonId, $responsePayload);
-
-        if (($responsePayload['ok'] ?? false) === true && $scaleCode === 'BIG5_OCEAN') {
-            $reportPayload = is_array($responsePayload['report'] ?? null) ? $responsePayload['report'] : [];
-            $scorePayload = is_array($responsePayload['result'] ?? null) ? $responsePayload['result'] : [];
-            $normsPayload = is_array($scorePayload['norms'] ?? null) ? $scorePayload['norms'] : [];
-            $qualityPayload = is_array($scorePayload['quality'] ?? null) ? $scorePayload['quality'] : [];
-
-            $this->bigFiveTelemetry()->recordAttemptSubmitted(
-                $orgId,
-                $this->numericUserId($actorUserId),
-                $actorAnonId,
-                $attemptId,
-                $locale,
-                $region,
-                (string) ($normsPayload['status'] ?? 'MISSING'),
-                (string) ($normsPayload['group_id'] ?? ''),
-                (string) ($qualityPayload['level'] ?? 'D'),
-                (string) ($reportPayload['variant'] ?? 'free'),
-                (bool) ($reportPayload['locked'] ?? true),
-                (bool) ($responsePayload['idempotent'] ?? false),
-                $dirVersion,
-                null,
-                (string) ($normsPayload['norms_version'] ?? '')
-            );
-        }
-
-        if (($responsePayload['ok'] ?? false) === true && in_array($scaleCode, ['CLINICAL_COMBO_68', 'SDS_20'], true)) {
-            $reportPayload = is_array($responsePayload['report'] ?? null) ? $responsePayload['report'] : [];
-            $scorePayload = is_array($responsePayload['result'] ?? null) ? $responsePayload['result'] : [];
-            $qualityPayload = is_array($scorePayload['quality'] ?? null)
-                ? $scorePayload['quality']
-                : (is_array(data_get($scorePayload, 'normed_json.quality')) ? data_get($scorePayload, 'normed_json.quality') : []);
-            $crisisReasons = array_values(array_filter(array_map('strval', (array) ($qualityPayload['crisis_reasons'] ?? []))));
-
-            $telemetry = $scaleCode === 'CLINICAL_COMBO_68'
-                ? app(ClinicalComboTelemetry::class)
-                : app(Sds20Telemetry::class);
-
-            $telemetry->attemptSubmitted($attempt, [
-                'quality_level' => strtoupper(trim((string) ($qualityPayload['level'] ?? 'D'))),
-                'variant' => strtolower(trim((string) ($reportPayload['variant'] ?? 'free'))),
-                'locked' => (bool) ($reportPayload['locked'] ?? true),
-                'idempotent' => (bool) ($responsePayload['idempotent'] ?? false),
-                'scoring_spec_version' => $scoringSpecVersion,
-            ]);
-
-            $telemetry->attemptScored($attempt, $scorePayload);
-
-            if ((bool) ($qualityPayload['crisis_alert'] ?? false) === true) {
-                $telemetry->crisisTriggered($attempt, [
-                    'quality_level' => strtoupper(trim((string) ($qualityPayload['level'] ?? 'D'))),
-                    'crisis_reasons' => $crisisReasons,
-                ]);
-            }
-        }
-
-        return $responsePayload;
+        return $this->sideEffects;
     }
 
-    private function bigFiveTelemetry(): BigFiveTelemetry
+    public function durationResolver(): AttemptDurationResolver
+    {
+        return $this->durationResolver;
+    }
+
+    public function identityResolver(): ScaleIdentityResolver
+    {
+        return $this->identityResolver;
+    }
+
+    public function bigFiveTelemetry(): BigFiveTelemetry
     {
         return app(BigFiveTelemetry::class);
     }
 
-    private function enforceConsentOnSubmit(string $scaleCode, Attempt $attempt, SubmitAttemptDTO $dto): void
+    public function enforceConsentOnSubmit(string $scaleCode, Attempt $attempt, SubmitAttemptDTO $dto): void
     {
         if (! in_array($scaleCode, ['CLINICAL_COMBO_68', 'SDS_20'], true)) {
             return;
@@ -824,7 +142,7 @@ class AttemptSubmitService
         }
     }
 
-    private function ownedAttemptQuery(
+    public function ownedAttemptQuery(
         OrgContext $ctx,
         string $attemptId,
         ?string $actorUserId,
@@ -865,7 +183,7 @@ class AttemptSubmitService
         return $query->whereRaw('1=0');
     }
 
-    private function resolveUserId(OrgContext $ctx, ?string $actorUserId): ?string
+    public function resolveUserId(OrgContext $ctx, ?string $actorUserId): ?string
     {
         $candidates = [
             $actorUserId,
@@ -884,7 +202,7 @@ class AttemptSubmitService
         return null;
     }
 
-    private function resolveAnonId(OrgContext $ctx, ?string $actorAnonId): ?string
+    public function resolveAnonId(OrgContext $ctx, ?string $actorAnonId): ?string
     {
         $candidates = [
             $actorAnonId,
@@ -903,7 +221,7 @@ class AttemptSubmitService
         return null;
     }
 
-    private function computeAnswersDigest(array $answers, string $scaleCode, string $packId, string $dirVersion): string
+    public function computeAnswersDigest(array $answers, string $scaleCode, string $packId, string $dirVersion): string
     {
         $canonical = $this->answerPersistence->canonicalJson($answers);
         $raw = strtoupper($scaleCode).'|'.$packId.'|'.$dirVersion.'|'.$canonical;
@@ -911,7 +229,7 @@ class AttemptSubmitService
         return hash('sha256', $raw);
     }
 
-    private function mergeAnswersForSubmit(array $requestAnswers, array $draftAnswers): array
+    public function mergeAnswersForSubmit(array $requestAnswers, array $draftAnswers): array
     {
         $map = [];
 
@@ -942,7 +260,7 @@ class AttemptSubmitService
         return array_values($map);
     }
 
-    private function buildSubmitPayload(Attempt $attempt, Result $result, bool $fresh): array
+    public function buildSubmitPayload(Attempt $attempt, Result $result, bool $fresh): array
     {
         $payload = $result->result_json;
         if (! is_array($payload)) {
@@ -999,14 +317,14 @@ class AttemptSubmitService
         ];
     }
 
-    private function findResult(int $orgId, string $attemptId): ?Result
+    public function findResult(int $orgId, string $attemptId): ?Result
     {
         return Result::where('org_id', $orgId)
             ->where('attempt_id', $attemptId)
             ->first();
     }
 
-    private function numericUserId(?string $userId): ?int
+    public function numericUserId(?string $userId): ?int
     {
         $userId = trim((string) $userId);
         if ($userId === '' || ! preg_match('/^\d+$/', $userId)) {
@@ -1019,7 +337,7 @@ class AttemptSubmitService
     /**
      * @return array<string,string>
      */
-    private function resolveScoreExperiments(int $orgId, ?string $actorAnonId, ?string $actorUserId): array
+    public function resolveScoreExperiments(int $orgId, ?string $actorAnonId, ?string $actorUserId): array
     {
         $anonId = trim((string) ($actorAnonId ?? ''));
         if ($anonId === '') {
@@ -1053,7 +371,7 @@ class AttemptSubmitService
         return $normalized;
     }
 
-    private function assertDemoScaleAllowed(string $scaleCode, string $attemptId): void
+    public function assertDemoScaleAllowed(string $scaleCode, string $attemptId): void
     {
         $legacyCode = strtoupper(trim($scaleCode));
         if ($legacyCode === '' || $this->identityResolver->shouldAllowDemoScale($legacyCode)) {
@@ -1085,17 +403,17 @@ class AttemptSubmitService
         );
     }
 
-    private function runtimePolicy(): ScaleIdentityRuntimePolicy
+    public function runtimePolicy(): ScaleIdentityRuntimePolicy
     {
         return app(ScaleIdentityRuntimePolicy::class);
     }
 
-    private function responseProjector(): ScaleCodeResponseProjector
+    public function responseProjector(): ScaleCodeResponseProjector
     {
         return app(ScaleCodeResponseProjector::class);
     }
 
-    private function identityWriteProjector(): ScaleIdentityWriteProjector
+    public function identityWriteProjector(): ScaleIdentityWriteProjector
     {
         return app(ScaleIdentityWriteProjector::class);
     }
@@ -1105,7 +423,7 @@ class AttemptSubmitService
      * @param  array<string,mixed>  $normed
      * @return array<string,mixed>
      */
-    private function buildClinicalAnswersSummary(array $answers, array $normed, int $durationMs): array
+    public function buildClinicalAnswersSummary(array $answers, array $normed, int $durationMs): array
     {
         $counts = [
             'A' => 0,

--- a/backend/app/Services/Attempts/AttemptSubmitTxService.php
+++ b/backend/app/Services/Attempts/AttemptSubmitTxService.php
@@ -1,0 +1,407 @@
+<?php
+
+namespace App\Services\Attempts;
+
+use App\Exceptions\Api\ApiProblemException;
+use App\Models\Result;
+use App\Support\OrgContext;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Str;
+
+class AttemptSubmitTxService
+{
+    public function __construct(private AttemptSubmitService $core)
+    {
+    }
+
+    public function handle(OrgContext $ctx, array $canonicalized, array $scored): array
+    {
+        $attemptId = (string) ($canonicalized['attempt_id'] ?? '');
+        $mergedAnswers = (array) ($canonicalized['merged_answers'] ?? []);
+        $answersDigest = (string) ($canonicalized['answers_digest'] ?? '');
+        $durationMs = (int) ($canonicalized['duration_ms'] ?? 0);
+        $orgId = (int) ($canonicalized['org_id'] ?? 0);
+        $scaleCode = (string) ($canonicalized['scale_code'] ?? '');
+        $packId = (string) ($canonicalized['pack_id'] ?? '');
+        $dirVersion = (string) ($canonicalized['dir_version'] ?? '');
+        $region = (string) ($canonicalized['region'] ?? '');
+        $locale = (string) ($canonicalized['locale'] ?? '');
+        $inviteToken = (string) ($canonicalized['invite_token'] ?? '');
+        $actorUserId = $canonicalized['actor_user_id'] ?? null;
+        if ($actorUserId !== null) {
+            $actorUserId = (string) $actorUserId;
+        }
+
+        $actorAnonId = $canonicalized['actor_anon_id'] ?? null;
+        if ($actorAnonId !== null) {
+            $actorAnonId = (string) $actorAnonId;
+        }
+        $validityItems = (array) ($canonicalized['validity_items'] ?? []);
+        $submittedAt = $canonicalized['submitted_at'] ?? now();
+        $writeScaleIdentity = (bool) ($canonicalized['write_scale_identity'] ?? false);
+        $scaleCodeV2 = (string) ($canonicalized['scale_code_v2'] ?? '');
+        $scaleUid = $canonicalized['scale_uid'] ?? null;
+
+        $scoreResult = $scored['score_result'];
+        $contentPackageVersion = (string) ($scored['content_package_version'] ?? '');
+        $scoringSpecVersion = (string) ($scored['scoring_spec_version'] ?? '');
+        $modelSelection = is_array($scored['model_selection'] ?? null)
+            ? $scored['model_selection']
+            : [];
+        $creditBenefitCode = (string) ($scored['credit_benefit_code'] ?? '');
+        $entitlementBenefitCode = (string) ($scored['entitlement_benefit_code'] ?? '');
+        $experiments = is_array($canonicalized['experiments'] ?? null) ? $canonicalized['experiments'] : [];
+
+        $responsePayload = null;
+        $postCommitCtx = null;
+
+        DB::transaction(function () use (
+            $ctx,
+            &$responsePayload,
+            &$postCommitCtx,
+            $attemptId,
+            $mergedAnswers,
+            $answersDigest,
+            $durationMs,
+            $orgId,
+            $scaleCode,
+            $packId,
+            $dirVersion,
+            $region,
+            $locale,
+            $inviteToken,
+            $creditBenefitCode,
+            $entitlementBenefitCode,
+            $scoreResult,
+            $contentPackageVersion,
+            $scoringSpecVersion,
+            $modelSelection,
+            $experiments,
+            $actorUserId,
+            $actorAnonId,
+            $validityItems,
+            $submittedAt,
+            $writeScaleIdentity,
+            $scaleCodeV2,
+            $scaleUid
+        ) {
+            $locked = $this->core->ownedAttemptQuery($ctx, $attemptId, $actorUserId, $actorAnonId)
+                ->lockForUpdate()
+                ->firstOrFail();
+
+            $existingDigest = trim((string) ($locked->answers_digest ?? ''));
+            if ($locked->submitted_at && $existingDigest !== '') {
+                if ($existingDigest === $answersDigest) {
+                    $existingResult = $this->core->findResult($orgId, $attemptId);
+                    if ($existingResult) {
+                        $responsePayload = $this->core->buildSubmitPayload($locked, $existingResult, false);
+                        $postCommitCtx = [
+                            'org_id' => $orgId,
+                            'attempt_id' => $attemptId,
+                            'scale_code' => $scaleCode,
+                            'scale_code_v2' => $scaleCodeV2,
+                            'scale_uid' => $scaleUid,
+                            'pack_id' => (string) ($locked->pack_id ?? $packId),
+                            'dir_version' => (string) ($locked->dir_version ?? $dirVersion),
+                            'scoring_spec_version' => (string) ($locked->scoring_spec_version ?? $scoringSpecVersion),
+                            'invite_token' => $inviteToken,
+                            'credit_benefit_code' => $creditBenefitCode,
+                            'entitlement_benefit_code' => $entitlementBenefitCode,
+                        ];
+
+                        return;
+                    }
+                }
+
+                throw new ApiProblemException(409, 'CONFLICT', 'attempt already submitted with different answers.');
+            }
+
+            if ($locked->submitted_at && $existingDigest === '') {
+                $existingResult = $this->core->findResult($orgId, $attemptId);
+                if ($existingResult) {
+                    $responsePayload = $this->core->buildSubmitPayload($locked, $existingResult, false);
+                    $postCommitCtx = [
+                        'org_id' => $orgId,
+                        'attempt_id' => $attemptId,
+                        'scale_code' => $scaleCode,
+                        'scale_code_v2' => $scaleCodeV2,
+                        'scale_uid' => $scaleUid,
+                        'pack_id' => (string) ($locked->pack_id ?? $packId),
+                        'dir_version' => (string) ($locked->dir_version ?? $dirVersion),
+                        'scoring_spec_version' => (string) ($locked->scoring_spec_version ?? $scoringSpecVersion),
+                        'invite_token' => $inviteToken,
+                        'credit_benefit_code' => $creditBenefitCode,
+                        'entitlement_benefit_code' => $entitlementBenefitCode,
+                    ];
+
+                    return;
+                }
+            }
+
+            $attemptFill = [
+                'pack_id' => $packId,
+                'dir_version' => $dirVersion,
+                'content_package_version' => $contentPackageVersion !== '' ? $contentPackageVersion : null,
+                'scoring_spec_version' => $scoringSpecVersion !== '' ? $scoringSpecVersion : null,
+                'region' => $region,
+                'locale' => $locale,
+                'submitted_at' => $submittedAt,
+                'duration_ms' => $durationMs,
+                'answers_digest' => $answersDigest,
+            ];
+            if ($writeScaleIdentity) {
+                $attemptFill['scale_code_v2'] = $scaleCodeV2;
+                $attemptFill['scale_uid'] = $scaleUid;
+            }
+            $locked->fill($attemptFill);
+
+            if ($scaleCode === 'BIG5_OCEAN') {
+                $snapshot = $locked->calculation_snapshot_json;
+                if (! is_array($snapshot)) {
+                    $snapshot = [];
+                }
+                $snapshot['validity_items'] = $validityItems;
+                $locked->calculation_snapshot_json = $snapshot;
+            }
+
+            if ($scaleCode === 'BIG5_OCEAN' && is_array($scoreResult->normedJson ?? null)) {
+                $normed = (array) $scoreResult->normedJson;
+                $normsNode = is_array($normed['norms'] ?? null) ? $normed['norms'] : [];
+
+                $normsVersion = trim((string) ($normsNode['norms_version'] ?? ($normed['norms_version'] ?? '')));
+                $groupId = trim((string) ($normsNode['group_id'] ?? ($normed['group_id'] ?? '')));
+                $sourceId = trim((string) ($normsNode['source_id'] ?? ($normed['source_id'] ?? '')));
+                $status = strtoupper(trim((string) ($normsNode['status'] ?? ($normed['status'] ?? 'MISSING'))));
+                if (! in_array($status, ['CALIBRATED', 'PROVISIONAL', 'MISSING'], true)) {
+                    $status = 'MISSING';
+                }
+
+                if ($normsVersion !== '') {
+                    $locked->norm_version = $normsVersion;
+                }
+
+                $snapshot = $locked->calculation_snapshot_json;
+                if (! is_array($snapshot)) {
+                    $snapshot = [];
+                }
+
+                $snapshot['norms'] = [
+                    'norms_version' => $normsVersion,
+                    'group_id' => $groupId,
+                    'source_id' => $sourceId,
+                    'status' => $status,
+                ];
+                $snapshot['spec_version'] = (string) ($normed['spec_version'] ?? ($snapshot['spec_version'] ?? ''));
+                $snapshot['item_bank_version'] = (string) ($normed['item_bank_version'] ?? ($snapshot['item_bank_version'] ?? ''));
+                $snapshot['engine_version'] = (string) ($normed['engine_version'] ?? ($snapshot['engine_version'] ?? ''));
+                $locked->calculation_snapshot_json = $snapshot;
+            }
+
+            if ($scaleCode === 'CLINICAL_COMBO_68' && is_array($scoreResult->normedJson ?? null)) {
+                $normed = (array) $scoreResult->normedJson;
+                $versionSnapshot = is_array($normed['version_snapshot'] ?? null)
+                    ? $normed['version_snapshot']
+                    : [];
+
+                $snapshot = $locked->calculation_snapshot_json;
+                if (! is_array($snapshot)) {
+                    $snapshot = [];
+                }
+
+                $snapshot['clinical_combo_68'] = [
+                    'pack_id' => (string) ($versionSnapshot['pack_id'] ?? $packId),
+                    'pack_version' => (string) ($versionSnapshot['pack_version'] ?? $dirVersion),
+                    'policy_version' => (string) ($versionSnapshot['policy_version'] ?? ''),
+                    'engine_version' => (string) ($versionSnapshot['engine_version'] ?? data_get($normed, 'engine_version', 'v1.0_2026')),
+                    'scoring_spec_version' => (string) ($versionSnapshot['scoring_spec_version'] ?? $scoringSpecVersion),
+                    'content_manifest_hash' => (string) ($versionSnapshot['content_manifest_hash'] ?? ''),
+                ];
+                $snapshot['quality'] = is_array($normed['quality'] ?? null) ? $normed['quality'] : [];
+                $locked->calculation_snapshot_json = $snapshot;
+
+                $locked->answers_summary_json = $this->core->buildClinicalAnswersSummary($mergedAnswers, $normed, $durationMs);
+            }
+
+            if ($scaleCode === 'SDS_20' && is_array($scoreResult->normedJson ?? null)) {
+                $normed = (array) $scoreResult->normedJson;
+                $versionSnapshot = is_array($normed['version_snapshot'] ?? null)
+                    ? $normed['version_snapshot']
+                    : [];
+                $normsNode = is_array($normed['norms'] ?? null) ? $normed['norms'] : [];
+
+                $snapshot = $locked->calculation_snapshot_json;
+                if (! is_array($snapshot)) {
+                    $snapshot = [];
+                }
+
+                $normsVersion = trim((string) ($normsNode['norms_version'] ?? ''));
+                if ($normsVersion !== '') {
+                    $locked->norm_version = $normsVersion;
+                }
+
+                $snapshot['sds_20'] = [
+                    'pack_id' => (string) ($versionSnapshot['pack_id'] ?? $packId),
+                    'pack_version' => (string) ($versionSnapshot['pack_version'] ?? $dirVersion),
+                    'policy_version' => (string) ($versionSnapshot['policy_version'] ?? ''),
+                    'policy_hash' => (string) ($versionSnapshot['policy_hash'] ?? ''),
+                    'engine_version' => (string) ($versionSnapshot['engine_version'] ?? data_get($normed, 'engine_version', 'v2.0_Factor_Logic')),
+                    'scoring_spec_version' => (string) ($versionSnapshot['scoring_spec_version'] ?? $scoringSpecVersion),
+                    'content_manifest_hash' => (string) ($versionSnapshot['content_manifest_hash'] ?? ''),
+                    'norms' => [
+                        'status' => strtoupper(trim((string) ($normsNode['status'] ?? 'MISSING'))),
+                        'group_id' => (string) ($normsNode['group_id'] ?? ''),
+                        'norms_version' => $normsVersion,
+                        'source_id' => (string) ($normsNode['source_id'] ?? ''),
+                    ],
+                ];
+                $snapshot['quality'] = is_array($normed['quality'] ?? null) ? $normed['quality'] : ($snapshot['quality'] ?? []);
+                $locked->calculation_snapshot_json = $snapshot;
+            }
+
+            if ($scaleCode === 'EQ_60' && is_array($scoreResult->normedJson ?? null)) {
+                $normed = (array) $scoreResult->normedJson;
+                $versionSnapshot = is_array($normed['version_snapshot'] ?? null)
+                    ? $normed['version_snapshot']
+                    : [];
+                $normsNode = is_array($normed['norms'] ?? null) ? $normed['norms'] : [];
+                $qualityNode = is_array($normed['quality'] ?? null) ? $normed['quality'] : [];
+
+                $snapshot = $locked->calculation_snapshot_json;
+                if (! is_array($snapshot)) {
+                    $snapshot = [];
+                }
+
+                $normsVersion = trim((string) ($normsNode['version'] ?? ''));
+                if ($normsVersion !== '') {
+                    $locked->norm_version = $normsVersion;
+                }
+
+                $snapshot['eq_60'] = [
+                    'pack_id' => (string) ($versionSnapshot['pack_id'] ?? $packId),
+                    'pack_version' => (string) ($versionSnapshot['pack_version'] ?? $dirVersion),
+                    'policy_version' => (string) ($versionSnapshot['policy_version'] ?? ''),
+                    'policy_hash' => (string) ($versionSnapshot['policy_hash'] ?? ''),
+                    'engine_version' => (string) ($versionSnapshot['engine_version'] ?? data_get($normed, 'engine_version', 'v1.0_normed_validity')),
+                    'scoring_spec_version' => (string) ($versionSnapshot['scoring_spec_version'] ?? $scoringSpecVersion),
+                    'content_manifest_hash' => (string) ($versionSnapshot['content_manifest_hash'] ?? ''),
+                    'norms' => [
+                        'status' => strtoupper(trim((string) ($normsNode['status'] ?? 'PROVISIONAL'))),
+                        'group' => (string) ($normsNode['group'] ?? ''),
+                        'version' => $normsVersion,
+                    ],
+                    'quality' => [
+                        'level' => strtoupper(trim((string) ($qualityNode['level'] ?? 'A'))),
+                        'flags' => array_values(array_filter(array_map('strval', (array) ($qualityNode['flags'] ?? [])))),
+                    ],
+                ];
+                $snapshot['quality'] = $qualityNode !== [] ? $qualityNode : ($snapshot['quality'] ?? []);
+                $locked->calculation_snapshot_json = $snapshot;
+            }
+
+            if ($locked->started_at === null) {
+                $locked->started_at = now();
+            }
+            $locked->save();
+
+            $this->core->answerPersistence()->persist($locked, $mergedAnswers, $durationMs, $scoringSpecVersion);
+
+            $axisScores = is_array($scoreResult->axisScoresJson ?? null)
+                ? $scoreResult->axisScoresJson
+                : [];
+
+            $scoresJson = $axisScores['scores_json'] ?? null;
+            if (! is_array($scoresJson)) {
+                $scoresJson = is_array($scoreResult->breakdownJson) ? $scoreResult->breakdownJson : [];
+            }
+
+            $scoresPct = $axisScores['scores_pct'] ?? null;
+            $axisStates = $axisScores['axis_states'] ?? null;
+
+            $resultJson = $scoreResult->toArray();
+            if (in_array($scaleCode, ['BIG5_OCEAN', 'SDS_20', 'EQ_60'], true) && is_array($resultJson['normed_json'] ?? null)) {
+                $resultJson = array_merge($resultJson, $resultJson['normed_json']);
+            }
+            if (is_array($resultJson['quality'] ?? null)) {
+                $resultJson['quality']['client_duration_ms'] = $durationMs;
+            }
+            $responseCodes = $this->core->responseProjector()->project(
+                $scaleCode,
+                $scaleCodeV2,
+                $scaleUid
+            );
+            $resultJson['scale_code'] = $responseCodes['scale_code'];
+            $resultJson['scale_code_legacy'] = $responseCodes['scale_code_legacy'];
+            $resultJson['scale_code_v2'] = $responseCodes['scale_code_v2'];
+            $resultJson['scale_uid'] = $responseCodes['scale_uid'];
+            $resultJson['pack_id'] = $packId;
+            $resultJson['dir_version'] = $dirVersion;
+            $resultJson['content_package_version'] = $contentPackageVersion;
+            $resultJson['scoring_spec_version'] = $scoringSpecVersion;
+            if ($modelSelection !== []) {
+                $resultJson['model_selection'] = $modelSelection;
+            }
+            if ($experiments !== []) {
+                $resultJson['experiments_json'] = $experiments;
+            }
+            $resultJson['computed_at'] = now()->toISOString();
+
+            $resultData = [
+                'org_id' => $orgId,
+                'attempt_id' => $attemptId,
+                'scale_code' => $scaleCode,
+                'scale_version' => (string) ($locked->scale_version ?? 'v0.3'),
+                'type_code' => (string) ($scoreResult->typeCode ?? ''),
+                'scores_json' => $scoresJson,
+                'scores_pct' => is_array($scoresPct) ? $scoresPct : null,
+                'axis_states' => is_array($axisStates) ? $axisStates : null,
+                'profile_version' => null,
+                'content_package_version' => $contentPackageVersion !== '' ? $contentPackageVersion : null,
+                'result_json' => $resultJson,
+                'pack_id' => $packId,
+                'dir_version' => $dirVersion,
+                'scoring_spec_version' => $scoringSpecVersion !== '' ? $scoringSpecVersion : null,
+                'report_engine_version' => 'v1.2',
+                'is_valid' => true,
+                'computed_at' => now(),
+            ];
+            if ($writeScaleIdentity) {
+                $resultData['scale_code_v2'] = $scaleCodeV2;
+                $resultData['scale_uid'] = $scaleUid;
+            }
+
+            $existingResult = $this->core->findResult($orgId, $attemptId);
+            if ($existingResult) {
+                $existingResult->fill($resultData);
+                $existingResult->save();
+                $result = $existingResult;
+            } else {
+                $resultData['id'] = (string) Str::uuid();
+                $result = Result::create($resultData);
+            }
+
+            $responsePayload = $this->core->buildSubmitPayload($locked, $result, true);
+            $postCommitCtx = [
+                'org_id' => $orgId,
+                'attempt_id' => $attemptId,
+                'scale_code' => $scaleCode,
+                'scale_code_v2' => $scaleCodeV2,
+                'scale_uid' => $scaleUid,
+                'pack_id' => $packId,
+                'dir_version' => $dirVersion,
+                'scoring_spec_version' => $scoringSpecVersion,
+                'invite_token' => $inviteToken,
+                'credit_benefit_code' => $creditBenefitCode,
+                'entitlement_benefit_code' => $entitlementBenefitCode,
+            ];
+        });
+
+        if (! is_array($responsePayload)) {
+            throw new ApiProblemException(500, 'INTERNAL_ERROR', 'unexpected submit state.');
+        }
+
+        return [
+            'response_payload' => $responsePayload,
+            'post_commit_ctx' => $postCommitCtx,
+        ];
+    }
+}

--- a/backend/tests/Feature/V0_3/AttemptSubmitRefactorParityTest.php
+++ b/backend/tests/Feature/V0_3/AttemptSubmitRefactorParityTest.php
@@ -126,6 +126,7 @@ final class AttemptSubmitRefactorParityTest extends TestCase
             'result.scale_code_legacy',
             'result.scale_code_v2',
             'result.scale_uid',
+            'report.locked',
         ];
 
         foreach ($stablePaths as $path) {


### PR DESCRIPTION
Fixes FER2-34

Summary
- Split AttemptSubmitService pipeline into 5 stage services (Guard/Canonicalize/Score/Tx/PostCommit)
- Keep AttemptSubmitService as orchestrator only; preserve idempotency/conflict contract and transaction semantics
- Harden golden contract assertions for replay stability (including report.locked)

Verification
- cd backend && php artisan route:list
- cd backend && php artisan migrate
- cd backend && php artisan test --filter AuthGuestToken
- cd backend && php artisan test --filter AttemptSubmit
- cd backend && php artisan test --filter AttemptSubmissionAsyncFlowTest
- bash backend/scripts/ci_verify_mbti.sh