### PR TITLE
Fixes FER2-35: harden experiment KPI denominator with full funnel sources

### DIFF
--- a/backend/app/Console/Commands/Ops/ExperimentGuardrailsEvaluate.php
+++ b/backend/app/Console/Commands/Ops/ExperimentGuardrailsEvaluate.php
@@ -99,6 +99,23 @@ final class ExperimentGuardrailsEvaluate extends Command
                 count($results),
                 $rolledBackCount
             ));
+
+            foreach ($results as $index => $result) {
+                $rollout = is_array($result['rollout'] ?? null) ? $result['rollout'] : [];
+                $funnel = is_array($result['funnel'] ?? null) ? $result['funnel'] : [];
+                $stageCounts = is_array($funnel['stage_counts'] ?? null) ? $funnel['stage_counts'] : [];
+                $rolloutLabel = trim((string) ($rollout['id'] ?? '')) ?: 'rollout_'.($index + 1);
+
+                $this->line(sprintf(
+                    '%s start_test=%d submit_attempt=%d checkout_start=%d payment_succeeded=%d report_ready=%d',
+                    $rolloutLabel,
+                    (int) ($stageCounts['start_test'] ?? 0),
+                    (int) ($stageCounts['submit_attempt'] ?? 0),
+                    (int) ($stageCounts['checkout_start'] ?? 0),
+                    (int) ($stageCounts['payment_succeeded'] ?? 0),
+                    (int) ($stageCounts['report_ready'] ?? 0)
+                ));
+            }
         }
 
         if ($this->isTruthy($this->option('strict')) && $rolledBackCount > 0) {

--- a/backend/app/Services/Experiments/ExperimentKpiEvaluator.php
+++ b/backend/app/Services/Experiments/ExperimentKpiEvaluator.php
@@ -4,11 +4,32 @@ declare(strict_types=1);
 
 namespace App\Services\Experiments;
 
+use Illuminate\Support\Carbon;
 use Illuminate\Support\Facades\DB;
 
 final class ExperimentKpiEvaluator
 {
     private const ROLLOUTS_TABLE = 'scoring_model_rollouts';
+
+    private const STAGE_KEYS = [
+        'start_test',
+        'submit_attempt',
+        'checkout_start',
+        'payment_succeeded',
+        'report_ready',
+    ];
+
+    private const METRIC_KEYS = [
+        'conversion_rate',
+        'paid_order_rate',
+        'payment_success_rate',
+        'report_ready_rate',
+        'submission_failed_rate',
+        'start_to_submit_rate',
+        'submit_to_checkout_rate',
+        'checkout_to_payment_rate',
+        'payment_to_report_ready_rate',
+    ];
 
     public function __construct(
         private readonly ExperimentGovernanceService $governanceService,
@@ -21,7 +42,8 @@ final class ExperimentKpiEvaluator
      *     rolled_back:bool,
      *     triggered_count:int,
      *     audit_id:?string,
-     *     metrics:array<string,array{value:float,sample_size:int}>
+     *     metrics:array<string,array{value:float,sample_size:int,source:string}>,
+     *     funnel:array{stage_counts:array<string,int>,stage_sources:array<string,string>}
      * }|null
      */
     public function evaluateRollout(
@@ -36,20 +58,22 @@ final class ExperimentKpiEvaluator
             return null;
         }
 
-        $metrics = $this->buildMetricsForRollout($orgId, $rollout, max(1, $windowMinutes));
+        $metricsPayload = $this->buildMetricsForRollout($orgId, $rollout, max(1, $windowMinutes));
+        $this->assertMetricSchema($metricsPayload['metrics'] ?? []);
 
         $result = $this->governanceService->evaluateGuardrails(
             $orgId,
             (string) $rollout->id,
             $actorUserId,
-            $metrics,
+            $metricsPayload['metrics'],
             $reason
         );
         if ($result === null) {
             return null;
         }
 
-        $result['metrics'] = $metrics;
+        $result['metrics'] = $metricsPayload['metrics'];
+        $result['funnel'] = $metricsPayload['funnel'];
 
         return $result;
     }
@@ -61,7 +85,8 @@ final class ExperimentKpiEvaluator
      *     rolled_back:bool,
      *     triggered_count:int,
      *     audit_id:?string,
-     *     metrics:array<string,array{value:float,sample_size:int}>
+     *     metrics:array<string,array{value:float,sample_size:int,source:string}>,
+     *     funnel:array{stage_counts:array<string,int>,stage_sources:array<string,string>}
      * }>
      */
     public function evaluateActiveRollouts(
@@ -99,217 +124,584 @@ final class ExperimentKpiEvaluator
     }
 
     /**
-     * @return array<string,array{value:float,sample_size:int}>
+     * @return array{
+     *   metrics:array<string,array{value:float,sample_size:int,source:string}>,
+     *   funnel:array{stage_counts:array<string,int>,stage_sources:array<string,string>}
+     * }
      */
     public function buildMetricsForRollout(int $orgId, object $rollout, int $windowMinutes): array
     {
         $windowStart = now()->subMinutes(max(1, $windowMinutes));
-        $exposure = $this->collectExposureAttempts($orgId, $rollout, $windowStart);
+        $attemptRows = $this->collectRolloutAttemptRows($orgId, $rollout, $windowStart);
+        $attemptIds = array_keys($attemptRows);
 
-        $exposureCount = count($exposure['exposure_keys']);
-        $attemptIds = array_keys($exposure['attempt_ids']);
-
-        $orderRows = [];
+        $submitFallback = [];
         if ($attemptIds !== []) {
-            $orderRows = DB::table('orders')
+            $submitRows = DB::table('events')
                 ->where('org_id', $orgId)
-                ->whereIn('target_attempt_id', $attemptIds)
-                ->where(function ($query) use ($windowStart): void {
-                    $query->where('created_at', '>=', $windowStart)
-                        ->orWhere(function ($paidQuery) use ($windowStart): void {
-                            $paidQuery->whereNotNull('paid_at')->where('paid_at', '>=', $windowStart);
-                        });
-                })
-                ->get(['order_no', 'status', 'paid_at', 'target_attempt_id'])
-                ->all();
-        }
-
-        $paidAttemptIds = [];
-        $paidOrderNos = [];
-        $paidOrdersCount = 0;
-        foreach ($orderRows as $orderRow) {
-            $status = strtolower(trim((string) ($orderRow->status ?? '')));
-            $isPaid = in_array($status, ['paid', 'fulfilled', 'completed', 'success', 'succeeded'], true)
-                || $orderRow->paid_at !== null;
-            if (! $isPaid) {
-                continue;
-            }
-
-            $paidOrdersCount++;
-            $targetAttemptId = trim((string) ($orderRow->target_attempt_id ?? ''));
-            if ($targetAttemptId !== '') {
-                $paidAttemptIds[$targetAttemptId] = true;
-            }
-
-            $orderNo = trim((string) ($orderRow->order_no ?? ''));
-            if ($orderNo !== '') {
-                $paidOrderNos[$orderNo] = true;
-            }
-        }
-
-        $paymentRows = [];
-        if ($paidOrderNos !== []) {
-            $paymentRows = DB::table('payment_events')
-                ->where('org_id', $orgId)
-                ->whereIn('order_no', array_keys($paidOrderNos))
-                ->where(function ($query) use ($windowStart): void {
-                    $query->where('created_at', '>=', $windowStart)
-                        ->orWhere(function ($receivedQuery) use ($windowStart): void {
-                            $receivedQuery->whereNotNull('received_at')->where('received_at', '>=', $windowStart);
-                        });
-                })
-                ->get(['status', 'processed_at', 'reason'])
-                ->all();
-        }
-
-        $paymentSuccessCount = 0;
-        foreach ($paymentRows as $paymentRow) {
-            $status = strtolower(trim((string) ($paymentRow->status ?? '')));
-            $reason = strtolower(trim((string) ($paymentRow->reason ?? '')));
-            $isSuccess = in_array($status, ['processed', 'handled', 'success', 'succeeded', 'paid', 'completed', 'ok'], true)
-                || $paymentRow->processed_at !== null
-                || in_array($reason, ['paid', 'success', 'completed'], true);
-            if ($isSuccess) {
-                $paymentSuccessCount++;
-            }
-        }
-
-        $readyAttempts = [];
-        if ($attemptIds !== []) {
-            $snapshotRows = DB::table('report_snapshots')
-                ->where('org_id', $orgId)
+                ->where('event_code', 'test_submit')
                 ->whereIn('attempt_id', $attemptIds)
-                ->where(function ($query) use ($windowStart): void {
-                    $query->where('created_at', '>=', $windowStart)
-                        ->orWhere(function ($updatedQuery) use ($windowStart): void {
-                            $updatedQuery->whereNotNull('updated_at')->where('updated_at', '>=', $windowStart);
-                        });
-                })
-                ->get(['attempt_id', 'status'])
+                ->where('occurred_at', '>=', $windowStart)
+                ->orderBy('occurred_at')
+                ->get(['attempt_id', 'occurred_at'])
                 ->all();
 
-            foreach ($snapshotRows as $snapshotRow) {
-                $attemptId = trim((string) ($snapshotRow->attempt_id ?? ''));
+            foreach ($submitRows as $submitRow) {
+                $attemptId = trim((string) ($submitRow->attempt_id ?? ''));
                 if ($attemptId === '') {
                     continue;
                 }
 
-                $status = strtolower(trim((string) ($snapshotRow->status ?? 'ready')));
-                if (in_array($status, ['ready', 'done', 'generated', 'success', 'completed'], true)) {
-                    $readyAttempts[$attemptId] = true;
+                $submitAt = $this->resolveTimestamp([$submitRow->occurred_at ?? null]);
+                if ($submitAt === null) {
+                    continue;
+                }
+
+                $submitFallback[$attemptId] = $this->minTimestamp($submitFallback[$attemptId] ?? null, $submitAt);
+            }
+        }
+
+        $orderStages = $this->collectOrderStageRows($orgId, $attemptIds, $windowStart);
+        $reportReadyRows = $this->collectReportReadyRows($orgId, $attemptIds, $windowStart);
+
+        $stageCounts = array_fill_keys(self::STAGE_KEYS, 0);
+        foreach ($attemptRows as $attemptId => $attemptRow) {
+            $normalizedTimeline = $this->normalizeStageTimeline([
+                'start_test_at' => $this->resolveTimestamp([
+                    $attemptRow['started_at'] ?? null,
+                    $attemptRow['created_at'] ?? null,
+                ]),
+                'submit_attempt_at' => $this->resolveTimestamp([
+                    $attemptRow['submitted_at'] ?? null,
+                    $submitFallback[$attemptId] ?? null,
+                ]),
+                'checkout_start_at' => $this->resolveTimestamp([
+                    $orderStages[$attemptId]['checkout_start_at'] ?? null,
+                ]),
+                'payment_succeeded_at' => $this->resolveTimestamp([
+                    $orderStages[$attemptId]['payment_succeeded_at'] ?? null,
+                ]),
+                'report_ready_at' => $this->resolveTimestamp([
+                    $reportReadyRows[$attemptId] ?? null,
+                ]),
+            ]);
+
+            foreach (self::STAGE_KEYS as $stageKey) {
+                if (($normalizedTimeline[$stageKey] ?? null) !== null) {
+                    $stageCounts[$stageKey]++;
                 }
             }
         }
 
-        $conversionRate = $this->safeRate(count($paidAttemptIds), $exposureCount);
-        $paidOrderRate = $this->safeRate($paidOrdersCount, count($orderRows));
-        $paymentSuccessRate = $this->safeRate($paymentSuccessCount, count($paymentRows));
-        $reportReadyRate = $this->safeRate(count($readyAttempts), $exposureCount);
-        $submissionFailedRate = $this->safeRate(max(0, $exposureCount - count($readyAttempts)), $exposureCount);
+        $startTestCount = (int) ($stageCounts['start_test'] ?? 0);
+        $submitAttemptCount = (int) ($stageCounts['submit_attempt'] ?? 0);
+        $checkoutStartCount = (int) ($stageCounts['checkout_start'] ?? 0);
+        $paymentSucceededCount = (int) ($stageCounts['payment_succeeded'] ?? 0);
+        $reportReadyCount = (int) ($stageCounts['report_ready'] ?? 0);
 
-        return [
+        $metrics = [
             'conversion_rate' => [
-                'value' => $conversionRate,
-                'sample_size' => $exposureCount,
+                'value' => $this->safeRate($paymentSucceededCount, $startTestCount),
+                'sample_size' => $startTestCount,
+                'source' => 'payment_succeeded/start_test',
             ],
             'paid_order_rate' => [
-                'value' => $paidOrderRate,
-                'sample_size' => count($orderRows),
+                'value' => $this->safeRate($paymentSucceededCount, $checkoutStartCount),
+                'sample_size' => $checkoutStartCount,
+                'source' => 'payment_succeeded/checkout_start',
             ],
             'payment_success_rate' => [
-                'value' => $paymentSuccessRate,
-                'sample_size' => count($paymentRows),
+                'value' => $this->safeRate($paymentSucceededCount, $checkoutStartCount),
+                'sample_size' => $checkoutStartCount,
+                'source' => 'payment_succeeded/checkout_start',
             ],
             'report_ready_rate' => [
-                'value' => $reportReadyRate,
-                'sample_size' => $exposureCount,
+                'value' => $this->safeRate($reportReadyCount, $paymentSucceededCount),
+                'sample_size' => $paymentSucceededCount,
+                'source' => 'report_ready/payment_succeeded',
             ],
             'submission_failed_rate' => [
-                'value' => $submissionFailedRate,
-                'sample_size' => $exposureCount,
+                'value' => $this->safeRate(max(0, $submitAttemptCount - $reportReadyCount), $submitAttemptCount),
+                'sample_size' => $submitAttemptCount,
+                'source' => '(submit_attempt-report_ready)/submit_attempt',
             ],
+            'start_to_submit_rate' => [
+                'value' => $this->safeRate($submitAttemptCount, $startTestCount),
+                'sample_size' => $startTestCount,
+                'source' => 'submit_attempt/start_test',
+            ],
+            'submit_to_checkout_rate' => [
+                'value' => $this->safeRate($checkoutStartCount, $submitAttemptCount),
+                'sample_size' => $submitAttemptCount,
+                'source' => 'checkout_start/submit_attempt',
+            ],
+            'checkout_to_payment_rate' => [
+                'value' => $this->safeRate($paymentSucceededCount, $checkoutStartCount),
+                'sample_size' => $checkoutStartCount,
+                'source' => 'payment_succeeded/checkout_start',
+            ],
+            'payment_to_report_ready_rate' => [
+                'value' => $this->safeRate($reportReadyCount, $paymentSucceededCount),
+                'sample_size' => $paymentSucceededCount,
+                'source' => 'report_ready/payment_succeeded',
+            ],
+        ];
+
+        $funnel = $this->buildFunnelPayload($stageCounts);
+
+        return [
+            'metrics' => $metrics,
+            'funnel' => $funnel,
         ];
     }
 
     /**
-     * @return array{attempt_ids:array<string,bool>,exposure_keys:array<string,bool>}
+     * @return array<string,array<string,mixed>>
      */
-    private function collectExposureAttempts(int $orgId, object $rollout, \DateTimeInterface $windowStart): array
+    private function collectRolloutAttemptRows(int $orgId, object $rollout, \DateTimeInterface $windowStart): array
     {
-        $rows = DB::table('events')
+        $rows = DB::table('attempts')
             ->where('org_id', $orgId)
-            ->whereIn('event_code', ['result_view', 'report_view'])
-            ->where('occurred_at', '>=', $windowStart)
-            ->get(['id', 'attempt_id', 'experiments_json'])
+            ->where(function ($query) use ($windowStart): void {
+                $query->where('started_at', '>=', $windowStart)
+                    ->orWhere(function ($fallbackQuery) use ($windowStart): void {
+                        $fallbackQuery
+                            ->whereNull('started_at')
+                            ->where('created_at', '>=', $windowStart);
+                    });
+            })
+            ->get(['id', 'user_id', 'anon_id', 'started_at', 'submitted_at', 'created_at', 'updated_at'])
             ->all();
 
-        $attemptIds = [];
-        $exposureKeys = [];
+        if ($rows === []) {
+            return [];
+        }
 
+        $experimentKey = trim((string) ($rollout->experiment_key ?? ''));
+        $experimentVariant = trim((string) ($rollout->experiment_variant ?? ''));
+        if ($experimentKey === '') {
+            $attemptRows = [];
+            foreach ($rows as $row) {
+                $attemptId = trim((string) ($row->id ?? ''));
+                if ($attemptId === '') {
+                    continue;
+                }
+
+                $attemptRows[$attemptId] = [
+                    'started_at' => $row->started_at ?? null,
+                    'submitted_at' => $row->submitted_at ?? null,
+                    'created_at' => $row->created_at ?? null,
+                    'updated_at' => $row->updated_at ?? null,
+                ];
+            }
+
+            return $attemptRows;
+        }
+
+        $assignmentMap = $this->buildAttemptAssignmentMap($orgId, $experimentKey, $experimentVariant, $rows);
+        if ($assignmentMap === []) {
+            return [];
+        }
+
+        $attemptRows = [];
         foreach ($rows as $row) {
-            $experiments = $this->decodeJsonRecord($row->experiments_json ?? null);
-            if (! $this->matchesRolloutExperiment($rollout, $experiments)) {
+            $attemptId = trim((string) ($row->id ?? ''));
+            if ($attemptId === '') {
+                continue;
+            }
+
+            $userId = trim((string) ($row->user_id ?? ''));
+            $anonId = trim((string) ($row->anon_id ?? ''));
+            $matched = false;
+
+            if ($userId !== '' && preg_match('/^\d+$/', $userId) === 1 && isset($assignmentMap['user:'.$userId])) {
+                $matched = true;
+            }
+            if (!$matched && $anonId !== '' && isset($assignmentMap['anon:'.$anonId])) {
+                $matched = true;
+            }
+            if (!$matched) {
+                continue;
+            }
+
+            $attemptRows[$attemptId] = [
+                'started_at' => $row->started_at ?? null,
+                'submitted_at' => $row->submitted_at ?? null,
+                'created_at' => $row->created_at ?? null,
+                'updated_at' => $row->updated_at ?? null,
+            ];
+        }
+
+        return $attemptRows;
+    }
+
+    /**
+     * @param  list<object>  $attemptRows
+     * @return array<string,bool>
+     */
+    private function buildAttemptAssignmentMap(
+        int $orgId,
+        string $experimentKey,
+        string $experimentVariant,
+        array $attemptRows
+    ): array {
+        $userIds = [];
+        $anonIds = [];
+
+        foreach ($attemptRows as $attemptRow) {
+            $userId = trim((string) ($attemptRow->user_id ?? ''));
+            if ($userId !== '' && preg_match('/^\d+$/', $userId) === 1) {
+                $userIds[$userId] = true;
+            }
+
+            $anonId = trim((string) ($attemptRow->anon_id ?? ''));
+            if ($anonId !== '') {
+                $anonIds[$anonId] = true;
+            }
+        }
+
+        if ($userIds === [] && $anonIds === []) {
+            return [];
+        }
+
+        $assignmentQuery = DB::table('experiment_assignments')
+            ->where('org_id', $orgId)
+            ->where('experiment_key', $experimentKey)
+            ->where(function ($query) use ($userIds, $anonIds): void {
+                if ($userIds !== []) {
+                    $query->orWhereIn('user_id', array_map('intval', array_keys($userIds)));
+                }
+                if ($anonIds !== []) {
+                    $query->orWhereIn('anon_id', array_keys($anonIds));
+                }
+            });
+
+        if ($experimentVariant !== '') {
+            $assignmentQuery->where('variant', $experimentVariant);
+        }
+
+        $assignments = $assignmentQuery
+            ->get(['user_id', 'anon_id'])
+            ->all();
+
+        $assignmentMap = [];
+        foreach ($assignments as $assignment) {
+            $userId = trim((string) ($assignment->user_id ?? ''));
+            if ($userId !== '' && preg_match('/^\d+$/', $userId) === 1) {
+                $assignmentMap['user:'.$userId] = true;
+            }
+
+            $anonId = trim((string) ($assignment->anon_id ?? ''));
+            if ($anonId !== '') {
+                $assignmentMap['anon:'.$anonId] = true;
+            }
+        }
+
+        return $assignmentMap;
+    }
+
+    /**
+     * @param  array<int,string>  $attemptIds
+     * @return array<string,array{checkout_start_at:?string,payment_succeeded_at:?string}>
+     */
+    private function collectOrderStageRows(int $orgId, array $attemptIds, \DateTimeInterface $windowStart): array
+    {
+        if ($attemptIds === []) {
+            return [];
+        }
+
+        $orderRows = DB::table('orders')
+            ->where('org_id', $orgId)
+            ->whereIn('target_attempt_id', $attemptIds)
+            ->where(function ($query) use ($windowStart): void {
+                $query->where('created_at', '>=', $windowStart)
+                    ->orWhere(function ($paidQuery) use ($windowStart): void {
+                        $paidQuery->whereNotNull('paid_at')->where('paid_at', '>=', $windowStart);
+                    })
+                    ->orWhere('updated_at', '>=', $windowStart);
+            })
+            ->get(['target_attempt_id', 'order_no', 'status', 'created_at', 'paid_at', 'updated_at'])
+            ->all();
+
+        $stageRows = [];
+        $orderToAttempts = [];
+
+        foreach ($orderRows as $orderRow) {
+            $attemptId = trim((string) ($orderRow->target_attempt_id ?? ''));
+            if ($attemptId === '') {
+                continue;
+            }
+
+            $checkoutStartAt = $this->resolveTimestamp([$orderRow->created_at ?? null]);
+            if ($checkoutStartAt !== null) {
+                $stageRows[$attemptId]['checkout_start_at'] = $this->minTimestamp(
+                    $stageRows[$attemptId]['checkout_start_at'] ?? null,
+                    $checkoutStartAt
+                );
+            }
+
+            $orderPaymentSuccessAt = null;
+            if ($orderRow->paid_at !== null) {
+                $orderPaymentSuccessAt = $this->resolveTimestamp([$orderRow->paid_at]);
+            } elseif ($this->isPaidLikeStatus((string) ($orderRow->status ?? ''))) {
+                $orderPaymentSuccessAt = $this->resolveTimestamp([
+                    $orderRow->updated_at ?? null,
+                    $orderRow->created_at ?? null,
+                ]);
+            }
+            if ($orderPaymentSuccessAt !== null) {
+                $stageRows[$attemptId]['payment_succeeded_at'] = $this->minTimestamp(
+                    $stageRows[$attemptId]['payment_succeeded_at'] ?? null,
+                    $orderPaymentSuccessAt
+                );
+            }
+
+            $orderNo = trim((string) ($orderRow->order_no ?? ''));
+            if ($orderNo !== '') {
+                $orderToAttempts[$orderNo][$attemptId] = true;
+            }
+        }
+
+        if ($orderToAttempts === []) {
+            return $stageRows;
+        }
+
+        $paymentRows = DB::table('payment_events')
+            ->where('org_id', $orgId)
+            ->whereIn('order_no', array_keys($orderToAttempts))
+            ->where(function ($query) use ($windowStart): void {
+                $query->where('created_at', '>=', $windowStart)
+                    ->orWhere(function ($receivedQuery) use ($windowStart): void {
+                        $receivedQuery->whereNotNull('received_at')->where('received_at', '>=', $windowStart);
+                    })
+                    ->orWhere(function ($processedQuery) use ($windowStart): void {
+                        $processedQuery->whereNotNull('processed_at')->where('processed_at', '>=', $windowStart);
+                    });
+            })
+            ->get(['order_no', 'status', 'reason', 'processed_at', 'received_at', 'created_at'])
+            ->all();
+
+        foreach ($paymentRows as $paymentRow) {
+            if (! $this->isPaymentSuccessLike($paymentRow)) {
+                continue;
+            }
+
+            $orderNo = trim((string) ($paymentRow->order_no ?? ''));
+            if ($orderNo === '' || ! isset($orderToAttempts[$orderNo])) {
+                continue;
+            }
+
+            $paymentSucceededAt = $this->resolveTimestamp([
+                $paymentRow->processed_at ?? null,
+                $paymentRow->received_at ?? null,
+                $paymentRow->created_at ?? null,
+            ]);
+            if ($paymentSucceededAt === null) {
+                continue;
+            }
+
+            foreach (array_keys($orderToAttempts[$orderNo]) as $attemptId) {
+                $stageRows[$attemptId]['payment_succeeded_at'] = $this->minTimestamp(
+                    $stageRows[$attemptId]['payment_succeeded_at'] ?? null,
+                    $paymentSucceededAt
+                );
+            }
+        }
+
+        return $stageRows;
+    }
+
+    /**
+     * @param  array<int,string>  $attemptIds
+     * @return array<string,string>
+     */
+    private function collectReportReadyRows(int $orgId, array $attemptIds, \DateTimeInterface $windowStart): array
+    {
+        if ($attemptIds === []) {
+            return [];
+        }
+
+        $rows = DB::table('report_snapshots')
+            ->where('org_id', $orgId)
+            ->whereIn('attempt_id', $attemptIds)
+            ->where(function ($query) use ($windowStart): void {
+                $query->where('created_at', '>=', $windowStart)
+                    ->orWhere('updated_at', '>=', $windowStart);
+            })
+            ->get(['attempt_id', 'status', 'updated_at', 'created_at'])
+            ->all();
+
+        $readyRows = [];
+        foreach ($rows as $row) {
+            $status = strtolower(trim((string) ($row->status ?? '')));
+            if (! in_array($status, ['ready', 'done', 'generated', 'success', 'completed'], true)) {
                 continue;
             }
 
             $attemptId = trim((string) ($row->attempt_id ?? ''));
-            if ($attemptId !== '') {
-                $attemptIds[$attemptId] = true;
-                $exposureKeys['attempt:'.$attemptId] = true;
+            if ($attemptId === '') {
                 continue;
             }
 
-            $eventId = trim((string) ($row->id ?? ''));
-            if ($eventId !== '') {
-                $exposureKeys['event:'.$eventId] = true;
+            $reportReadyAt = $this->resolveTimestamp([
+                $row->updated_at ?? null,
+                $row->created_at ?? null,
+            ]);
+            if ($reportReadyAt === null) {
+                continue;
             }
+
+            $readyRows[$attemptId] = $this->minTimestamp($readyRows[$attemptId] ?? null, $reportReadyAt);
+        }
+
+        return $readyRows;
+    }
+
+    /**
+     * @param  array{start_test_at:?string,submit_attempt_at:?string,checkout_start_at:?string,payment_succeeded_at:?string,report_ready_at:?string}  $timeline
+     * @return array{start_test:?string,submit_attempt:?string,checkout_start:?string,payment_succeeded:?string,report_ready:?string}
+     */
+    private function normalizeStageTimeline(array $timeline): array
+    {
+        $startAt = $timeline['start_test_at'] ?? null;
+        $submitAt = $timeline['submit_attempt_at'] ?? null;
+        $checkoutAt = $timeline['checkout_start_at'] ?? null;
+        $paymentAt = $timeline['payment_succeeded_at'] ?? null;
+        $reportAt = $timeline['report_ready_at'] ?? null;
+
+        if ($startAt === null) {
+            return [
+                'start_test' => null,
+                'submit_attempt' => null,
+                'checkout_start' => null,
+                'payment_succeeded' => null,
+                'report_ready' => null,
+            ];
+        }
+
+        if ($submitAt === null || $this->parseTimestamp($submitAt) < $this->parseTimestamp($startAt)) {
+            $submitAt = null;
+            $checkoutAt = null;
+            $paymentAt = null;
+            $reportAt = null;
+        }
+
+        if (
+            $checkoutAt === null
+            || $submitAt === null
+            || $this->parseTimestamp($checkoutAt) < $this->parseTimestamp($submitAt)
+        ) {
+            $checkoutAt = null;
+            $paymentAt = null;
+            $reportAt = null;
+        }
+
+        if (
+            $paymentAt === null
+            || $checkoutAt === null
+            || $this->parseTimestamp($paymentAt) < $this->parseTimestamp($checkoutAt)
+        ) {
+            $paymentAt = null;
+            $reportAt = null;
+        }
+
+        if (
+            $reportAt === null
+            || $paymentAt === null
+            || $this->parseTimestamp($reportAt) < $this->parseTimestamp($paymentAt)
+        ) {
+            $reportAt = null;
         }
 
         return [
-            'attempt_ids' => $attemptIds,
-            'exposure_keys' => $exposureKeys,
+            'start_test' => $startAt,
+            'submit_attempt' => $submitAt,
+            'checkout_start' => $checkoutAt,
+            'payment_succeeded' => $paymentAt,
+            'report_ready' => $reportAt,
         ];
     }
 
     /**
-     * @param  array<string,mixed>  $experiments
+     * @param  array<string,int>  $stageCounts
+     * @return array{stage_counts:array<string,int>,stage_sources:array<string,string>}
      */
-    private function matchesRolloutExperiment(object $rollout, array $experiments): bool
+    private function buildFunnelPayload(array $stageCounts): array
     {
-        $experimentKey = trim((string) ($rollout->experiment_key ?? ''));
-        if ($experimentKey === '') {
-            return true;
-        }
-
-        $variant = trim((string) ($rollout->experiment_variant ?? ''));
-        $assigned = trim((string) ($experiments[$experimentKey] ?? ''));
-        if ($assigned === '') {
-            return false;
-        }
-
-        if ($variant === '') {
-            return true;
-        }
-
-        return $assigned === $variant;
+        return [
+            'stage_counts' => [
+                'start_test' => (int) ($stageCounts['start_test'] ?? 0),
+                'submit_attempt' => (int) ($stageCounts['submit_attempt'] ?? 0),
+                'checkout_start' => (int) ($stageCounts['checkout_start'] ?? 0),
+                'payment_succeeded' => (int) ($stageCounts['payment_succeeded'] ?? 0),
+                'report_ready' => (int) ($stageCounts['report_ready'] ?? 0),
+            ],
+            'stage_sources' => [
+                'start_test' => 'attempts.started_at|attempts.created_at',
+                'submit_attempt' => 'attempts.submitted_at|events(test_submit).occurred_at',
+                'checkout_start' => 'orders.created_at by target_attempt_id',
+                'payment_succeeded' => 'orders.paid_at|orders.status(updated_at)|payment_events(processed_at/received_at)',
+                'report_ready' => 'report_snapshots(status=ready|done|generated|success|completed).updated_at|created_at',
+            ],
+        ];
     }
 
     /**
-     * @return array<string,mixed>
+     * @param  array<string,mixed>  $metrics
      */
-    private function decodeJsonRecord(mixed $raw): array
+    private function assertMetricSchema(array $metrics): void
     {
-        if (is_array($raw)) {
-            return $raw;
+        $actualKeys = array_keys($metrics);
+        sort($actualKeys);
+
+        $expectedKeys = self::METRIC_KEYS;
+        sort($expectedKeys);
+
+        if ($actualKeys !== $expectedKeys) {
+            throw new \RuntimeException('kpi metric schema drift detected: metric keys mismatch.');
         }
 
-        if (! is_string($raw) || trim($raw) === '') {
-            return [];
+        foreach (self::METRIC_KEYS as $metricKey) {
+            $metric = $metrics[$metricKey] ?? null;
+            if (! is_array($metric)) {
+                throw new \RuntimeException('kpi metric schema drift detected: '.$metricKey.' must be object.');
+            }
+
+            if (! array_key_exists('value', $metric) || ! is_numeric($metric['value'])) {
+                throw new \RuntimeException('kpi metric schema drift detected: '.$metricKey.'.value must be numeric.');
+            }
+
+            if (! array_key_exists('sample_size', $metric) || ! is_numeric($metric['sample_size'])) {
+                throw new \RuntimeException('kpi metric schema drift detected: '.$metricKey.'.sample_size must be numeric.');
+            }
+
+            $sampleSize = (int) $metric['sample_size'];
+            if ($sampleSize < 0) {
+                throw new \RuntimeException('kpi metric schema drift detected: '.$metricKey.'.sample_size must be >= 0.');
+            }
+
+            $source = trim((string) ($metric['source'] ?? ''));
+            if ($source === '') {
+                throw new \RuntimeException('kpi metric schema drift detected: '.$metricKey.'.source is required.');
+            }
         }
+    }
 
-        $decoded = json_decode($raw, true);
+    private function isPaidLikeStatus(string $status): bool
+    {
+        $normalized = strtolower(trim($status));
 
-        return is_array($decoded) ? $decoded : [];
+        return in_array($normalized, ['paid', 'fulfilled', 'completed', 'success', 'succeeded'], true);
+    }
+
+    private function isPaymentSuccessLike(object $paymentRow): bool
+    {
+        $status = strtolower(trim((string) ($paymentRow->status ?? '')));
+        $reason = strtolower(trim((string) ($paymentRow->reason ?? '')));
+
+        return in_array($status, ['processed', 'handled', 'success', 'succeeded', 'paid', 'completed', 'ok'], true)
+            || $paymentRow->processed_at !== null
+            || in_array($reason, ['paid', 'success', 'completed'], true);
     }
 
     private function safeRate(int $numerator, int $denominator): float
@@ -319,6 +711,47 @@ final class ExperimentKpiEvaluator
         }
 
         return round($numerator / $denominator, 6);
+    }
+
+    private function minTimestamp(?string $left, ?string $right): ?string
+    {
+        if ($left === null) {
+            return $right;
+        }
+        if ($right === null) {
+            return $left;
+        }
+
+        return $this->parseTimestamp($left) <= $this->parseTimestamp($right) ? $left : $right;
+    }
+
+    /**
+     * @param  array<int,mixed>  $candidates
+     */
+    private function resolveTimestamp(array $candidates): ?string
+    {
+        foreach ($candidates as $candidate) {
+            if ($candidate === null) {
+                continue;
+            }
+
+            try {
+                return Carbon::parse($candidate)->toIso8601String();
+            } catch (\Throwable) {
+                continue;
+            }
+        }
+
+        return null;
+    }
+
+    private function parseTimestamp(string $timestamp): int
+    {
+        try {
+            return Carbon::parse($timestamp)->getTimestamp();
+        } catch (\Throwable) {
+            return PHP_INT_MIN;
+        }
     }
 
     private function findRollout(int $orgId, string $rolloutId): ?object

--- a/backend/tests/Feature/V0_4/ExperimentKpiEvaluatorBridgeTest.php
+++ b/backend/tests/Feature/V0_4/ExperimentKpiEvaluatorBridgeTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Tests\Feature\V0_4;
 
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Carbon;
 use Illuminate\Support\Facades\Artisan;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Str;
@@ -21,7 +22,56 @@ final class ExperimentKpiEvaluatorBridgeTest extends TestCase
         $rolloutId = $this->seedRollout($orgId);
         $this->seedGuardrail($orgId, $rolloutId);
 
-        $this->seedExposureData($orgId, 'PR23_STICKY_BUCKET', 'A', 10, 1, 8);
+        $experimentKey = 'PR23_STICKY_BUCKET';
+        $variant = 'A';
+        $baseTs = now()->subMinutes(30);
+
+        for ($i = 1; $i <= 10; $i++) {
+            $attemptId = 'fer2_kpi_attempt_'.$i;
+            $anonId = 'fer2_kpi_anon_'.$i;
+            $startedAt = (clone $baseTs)->addSeconds($i);
+            $submittedAt = (clone $startedAt)->addMinute();
+
+            $this->insertAttemptWithAssignment(
+                $orgId,
+                $experimentKey,
+                $variant,
+                $attemptId,
+                $anonId,
+                $startedAt,
+                $submittedAt
+            );
+
+            $orderNo = 'FER2KPI'.str_pad((string) $i, 4, '0', STR_PAD_LEFT);
+            $orderId = $this->insertOrderForAttempt(
+                $orgId,
+                $attemptId,
+                $anonId,
+                $orderNo,
+                (clone $submittedAt)->addMinute(),
+                $i === 1 ? (clone $submittedAt)->addMinutes(2) : null,
+                $i === 1 ? 'paid' : 'pending'
+            );
+
+            if ($i === 1) {
+                $this->insertPaymentEvent(
+                    $orgId,
+                    $orderId,
+                    $orderNo,
+                    'evt_fer2_kpi_'.$i,
+                    (clone $submittedAt)->addMinutes(2),
+                    'processed',
+                    null
+                );
+
+                $this->insertReportSnapshot(
+                    $orgId,
+                    $attemptId,
+                    (clone $submittedAt)->addMinutes(3),
+                    'ready'
+                );
+            }
+        }
 
         $exitCode = Artisan::call('ops:experiment-guardrails-evaluate', [
             '--org-id' => (string) $orgId,
@@ -39,10 +89,45 @@ final class ExperimentKpiEvaluatorBridgeTest extends TestCase
 
         $result = is_array($payload['results'][0] ?? null) ? $payload['results'][0] : [];
         $metrics = is_array($result['metrics'] ?? null) ? $result['metrics'] : [];
-        $conversionMetric = is_array($metrics['conversion_rate'] ?? null) ? $metrics['conversion_rate'] : [];
+        $funnel = is_array($result['funnel'] ?? null) ? $result['funnel'] : [];
+        $stageCounts = is_array($funnel['stage_counts'] ?? null) ? $funnel['stage_counts'] : [];
 
+        $expectedMetricKeys = [
+            'conversion_rate',
+            'paid_order_rate',
+            'payment_success_rate',
+            'report_ready_rate',
+            'submission_failed_rate',
+            'start_to_submit_rate',
+            'submit_to_checkout_rate',
+            'checkout_to_payment_rate',
+            'payment_to_report_ready_rate',
+        ];
+        $this->assertEqualsCanonicalizing($expectedMetricKeys, array_keys($metrics));
+
+        foreach ($expectedMetricKeys as $metricKey) {
+            $metric = is_array($metrics[$metricKey] ?? null) ? $metrics[$metricKey] : [];
+            $this->assertArrayHasKey('value', $metric);
+            $this->assertArrayHasKey('sample_size', $metric);
+            $this->assertArrayHasKey('source', $metric);
+            $this->assertIsNumeric($metric['value']);
+            $this->assertIsNumeric($metric['sample_size']);
+            $this->assertNotSame('', trim((string) ($metric['source'] ?? '')));
+        }
+
+        $conversionMetric = is_array($metrics['conversion_rate'] ?? null) ? $metrics['conversion_rate'] : [];
         $this->assertSame(10, (int) ($conversionMetric['sample_size'] ?? 0));
         $this->assertEquals(0.1, (float) ($conversionMetric['value'] ?? -1));
+
+        $this->assertSame(
+            ['start_test', 'submit_attempt', 'checkout_start', 'payment_succeeded', 'report_ready'],
+            array_keys($stageCounts)
+        );
+        $this->assertSame(10, (int) ($stageCounts['start_test'] ?? 0));
+        $this->assertSame(10, (int) ($stageCounts['submit_attempt'] ?? 0));
+        $this->assertSame(10, (int) ($stageCounts['checkout_start'] ?? 0));
+        $this->assertSame(1, (int) ($stageCounts['payment_succeeded'] ?? 0));
+        $this->assertSame(1, (int) ($stageCounts['report_ready'] ?? 0));
         $this->assertTrue((bool) ($result['rolled_back'] ?? false));
 
         $this->assertDatabaseHas('scoring_model_rollouts', [
@@ -57,6 +142,161 @@ final class ExperimentKpiEvaluatorBridgeTest extends TestCase
             'action' => 'auto_rollback',
             'status' => 'triggered',
         ]);
+    }
+
+    public function test_kpi_bridge_missing_submit_event_does_not_count_downstream_stages(): void
+    {
+        $ownerUserId = $this->createUser('fer2_35_missing_submit_owner@fm.test');
+        $orgId = $this->createOrg($ownerUserId, 'FER2 KPI Missing Submit Org');
+        $rolloutId = $this->seedRollout($orgId);
+
+        $experimentKey = 'PR23_STICKY_BUCKET';
+        $variant = 'A';
+        $baseTs = now()->subMinutes(30);
+
+        for ($i = 1; $i <= 3; $i++) {
+            $attemptId = 'fer2_kpi_missing_submit_attempt_'.$i;
+            $anonId = 'fer2_kpi_missing_submit_anon_'.$i;
+            $startedAt = (clone $baseTs)->addSeconds($i);
+
+            $this->insertAttemptWithAssignment(
+                $orgId,
+                $experimentKey,
+                $variant,
+                $attemptId,
+                $anonId,
+                $startedAt,
+                null
+            );
+
+            $orderNo = 'FER2MISS'.str_pad((string) $i, 4, '0', STR_PAD_LEFT);
+            $orderId = $this->insertOrderForAttempt(
+                $orgId,
+                $attemptId,
+                $anonId,
+                $orderNo,
+                (clone $startedAt)->addMinutes(2),
+                (clone $startedAt)->addMinutes(3),
+                'paid'
+            );
+
+            $this->insertPaymentEvent(
+                $orgId,
+                $orderId,
+                $orderNo,
+                'evt_fer2_missing_'.$i,
+                (clone $startedAt)->addMinutes(3),
+                'processed',
+                null
+            );
+
+            $this->insertReportSnapshot(
+                $orgId,
+                $attemptId,
+                (clone $startedAt)->addMinutes(4),
+                'ready'
+            );
+        }
+
+        $exitCode = Artisan::call('ops:experiment-guardrails-evaluate', [
+            '--org-id' => (string) $orgId,
+            '--rollout-id' => $rolloutId,
+            '--window-minutes' => 120,
+            '--json' => 1,
+        ]);
+
+        $this->assertSame(0, $exitCode);
+
+        $payload = json_decode(trim((string) Artisan::output()), true);
+        $this->assertIsArray($payload);
+
+        $result = is_array($payload['results'][0] ?? null) ? $payload['results'][0] : [];
+        $funnel = is_array($result['funnel'] ?? null) ? $result['funnel'] : [];
+        $stageCounts = is_array($funnel['stage_counts'] ?? null) ? $funnel['stage_counts'] : [];
+
+        $this->assertSame(3, (int) ($stageCounts['start_test'] ?? 0));
+        $this->assertSame(0, (int) ($stageCounts['submit_attempt'] ?? 0));
+        $this->assertSame(0, (int) ($stageCounts['checkout_start'] ?? 0));
+        $this->assertSame(0, (int) ($stageCounts['payment_succeeded'] ?? 0));
+        $this->assertSame(0, (int) ($stageCounts['report_ready'] ?? 0));
+    }
+
+    public function test_kpi_bridge_out_of_order_events_are_rejected_by_stage_gating(): void
+    {
+        $ownerUserId = $this->createUser('fer2_35_out_of_order_owner@fm.test');
+        $orgId = $this->createOrg($ownerUserId, 'FER2 KPI Out-of-Order Org');
+        $rolloutId = $this->seedRollout($orgId);
+
+        $experimentKey = 'PR23_STICKY_BUCKET';
+        $variant = 'A';
+        $attemptId = 'fer2_kpi_out_of_order_attempt';
+        $anonId = 'fer2_kpi_out_of_order_anon';
+
+        $startedAt = now()->subMinutes(25);
+        $submittedAt = (clone $startedAt)->addMinute();
+        $checkoutAt = (clone $submittedAt)->addMinutes(2);
+        $paymentAt = (clone $submittedAt)->addMinute();
+        $reportAt = (clone $submittedAt)->addSeconds(90);
+
+        $this->insertAttemptWithAssignment(
+            $orgId,
+            $experimentKey,
+            $variant,
+            $attemptId,
+            $anonId,
+            $startedAt,
+            $submittedAt
+        );
+
+        $orderNo = 'FER2OORD0001';
+        $orderId = $this->insertOrderForAttempt(
+            $orgId,
+            $attemptId,
+            $anonId,
+            $orderNo,
+            $checkoutAt,
+            null,
+            'pending'
+        );
+
+        $this->insertPaymentEvent(
+            $orgId,
+            $orderId,
+            $orderNo,
+            'evt_fer2_oorder_1',
+            $paymentAt,
+            'processed',
+            null
+        );
+
+        $this->insertReportSnapshot(
+            $orgId,
+            $attemptId,
+            $reportAt,
+            'ready'
+        );
+
+        $exitCode = Artisan::call('ops:experiment-guardrails-evaluate', [
+            '--org-id' => (string) $orgId,
+            '--rollout-id' => $rolloutId,
+            '--window-minutes' => 120,
+            '--json' => 1,
+        ]);
+
+        $this->assertSame(0, $exitCode);
+
+        $payload = json_decode(trim((string) Artisan::output()), true);
+        $this->assertIsArray($payload);
+
+        $result = is_array($payload['results'][0] ?? null) ? $payload['results'][0] : [];
+        $funnel = is_array($result['funnel'] ?? null) ? $result['funnel'] : [];
+        $stageCounts = is_array($funnel['stage_counts'] ?? null) ? $funnel['stage_counts'] : [];
+
+        $this->assertSame(1, (int) ($stageCounts['start_test'] ?? 0));
+        $this->assertSame(1, (int) ($stageCounts['submit_attempt'] ?? 0));
+        $this->assertSame(1, (int) ($stageCounts['checkout_start'] ?? 0));
+        $this->assertSame(0, (int) ($stageCounts['payment_succeeded'] ?? 0));
+        $this->assertSame(0, (int) ($stageCounts['report_ready'] ?? 0));
     }
 
     private function createUser(string $email): int
@@ -139,115 +379,134 @@ final class ExperimentKpiEvaluatorBridgeTest extends TestCase
         ]);
     }
 
-    private function seedExposureData(
+    private function insertAttemptWithAssignment(
         int $orgId,
         string $experimentKey,
         string $variant,
-        int $exposureCount,
-        int $paidAttempts,
-        int $readyReports
+        string $attemptId,
+        string $anonId,
+        Carbon $startedAt,
+        ?Carbon $submittedAt
     ): void {
-        $attemptIds = [];
-        $baseTs = now()->subMinutes(10);
+        DB::table('attempts')->insert([
+            'id' => $attemptId,
+            'org_id' => $orgId,
+            'anon_id' => $anonId,
+            'user_id' => null,
+            'scale_code' => 'MBTI',
+            'scale_version' => 'v0.3',
+            'question_count' => 4,
+            'answers_summary_json' => '{}',
+            'client_platform' => 'web',
+            'client_version' => 'test',
+            'channel' => 'organic',
+            'referrer' => null,
+            'pack_id' => 'MBTI.cn-mainland.zh-CN.v0.3',
+            'dir_version' => 'MBTI-CN-v0.3',
+            'content_package_version' => 'v0.3',
+            'scoring_spec_version' => 'mbti_spec_fer2_20',
+            'started_at' => $startedAt,
+            'submitted_at' => $submittedAt,
+            'created_at' => $startedAt,
+            'updated_at' => $submittedAt ?? $startedAt,
+        ]);
 
-        for ($i = 1; $i <= $exposureCount; $i++) {
-            $attemptId = 'fer2_kpi_attempt_'.$i;
-            $attemptIds[] = $attemptId;
+        DB::table('experiment_assignments')->insert([
+            'org_id' => $orgId,
+            'anon_id' => $anonId,
+            'user_id' => null,
+            'experiment_key' => $experimentKey,
+            'variant' => $variant,
+            'assigned_at' => $startedAt,
+            'created_at' => $startedAt,
+            'updated_at' => $startedAt,
+        ]);
+    }
 
-            DB::table('events')->insert([
-                'id' => (string) Str::uuid(),
-                'event_code' => 'result_view',
-                'event_name' => 'result_view',
-                'org_id' => $orgId,
-                'user_id' => null,
-                'anon_id' => 'fer2_kpi_anon_'.$i,
-                'session_id' => null,
-                'request_id' => null,
-                'attempt_id' => $attemptId,
-                'meta_json' => json_encode(['attempt_id' => $attemptId], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES),
-                'experiments_json' => json_encode([$experimentKey => $variant], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES),
-                'occurred_at' => $baseTs,
-                'created_at' => $baseTs,
-                'updated_at' => $baseTs,
-            ]);
-        }
+    private function insertOrderForAttempt(
+        int $orgId,
+        string $attemptId,
+        string $anonId,
+        string $orderNo,
+        Carbon $createdAt,
+        ?Carbon $paidAt,
+        string $status
+    ): string {
+        $orderId = (string) Str::uuid();
 
-        for ($i = 0; $i < $paidAttempts; $i++) {
-            $attemptId = $attemptIds[$i] ?? null;
-            if (! is_string($attemptId) || $attemptId === '') {
-                continue;
-            }
+        DB::table('orders')->insert([
+            'id' => $orderId,
+            'order_no' => $orderNo,
+            'org_id' => $orgId,
+            'user_id' => null,
+            'anon_id' => $anonId,
+            'sku' => 'mbti_report',
+            'item_sku' => 'mbti_report',
+            'quantity' => 1,
+            'target_attempt_id' => $attemptId,
+            'amount_cents' => 999,
+            'amount_total' => 999,
+            'amount_refunded' => 0,
+            'currency' => 'USD',
+            'status' => $status,
+            'provider' => 'stripe',
+            'external_trade_no' => null,
+            'paid_at' => $paidAt,
+            'created_at' => $createdAt,
+            'updated_at' => $paidAt ?? $createdAt,
+        ]);
 
-            $orderNo = 'FER2KPI'.str_pad((string) ($i + 1), 4, '0', STR_PAD_LEFT);
+        return $orderId;
+    }
 
-            $orderId = (string) Str::uuid();
+    private function insertPaymentEvent(
+        int $orgId,
+        string $orderId,
+        string $orderNo,
+        string $providerEventId,
+        Carbon $processedAt,
+        string $status,
+        ?string $reason
+    ): void {
+        DB::table('payment_events')->insert([
+            'id' => (string) Str::uuid(),
+            'org_id' => $orgId,
+            'provider' => 'stripe',
+            'provider_event_id' => $providerEventId,
+            'order_id' => $orderId,
+            'order_no' => $orderNo,
+            'event_type' => 'checkout.paid',
+            'payload_json' => '{}',
+            'signature_ok' => true,
+            'received_at' => $processedAt,
+            'status' => $status,
+            'processed_at' => $processedAt,
+            'attempts' => 1,
+            'last_error_code' => null,
+            'last_error_message' => null,
+            'reason' => $reason,
+            'created_at' => $processedAt,
+            'updated_at' => $processedAt,
+        ]);
+    }
 
-            DB::table('orders')->insert([
-                'id' => $orderId,
-                'order_no' => $orderNo,
-                'org_id' => $orgId,
-                'user_id' => null,
-                'anon_id' => 'fer2_kpi_order_'.$i,
-                'sku' => 'mbti_report',
-                'item_sku' => 'mbti_report',
-                'quantity' => 1,
-                'target_attempt_id' => $attemptId,
-                'amount_cents' => 999,
-                'amount_total' => 999,
-                'amount_refunded' => 0,
-                'currency' => 'USD',
-                'status' => 'paid',
-                'provider' => 'stripe',
-                'external_trade_no' => null,
-                'paid_at' => now()->subMinutes(8),
-                'created_at' => now()->subMinutes(9),
-                'updated_at' => now()->subMinutes(8),
-            ]);
-
-            DB::table('payment_events')->insert([
-                'id' => (string) Str::uuid(),
-                'org_id' => $orgId,
-                'provider' => 'stripe',
-                'provider_event_id' => 'evt_fer2_kpi_'.$i,
-                'order_id' => $orderId,
-                'order_no' => $orderNo,
-                'event_type' => 'checkout.paid',
-                'payload_json' => '{}',
-                'signature_ok' => true,
-                'received_at' => now()->subMinutes(8),
-                'status' => 'processed',
-                'processed_at' => now()->subMinutes(8),
-                'attempts' => 1,
-                'last_error_code' => null,
-                'last_error_message' => null,
-                'reason' => null,
-                'created_at' => now()->subMinutes(8),
-                'updated_at' => now()->subMinutes(8),
-            ]);
-        }
-
-        for ($i = 0; $i < $readyReports; $i++) {
-            $attemptId = $attemptIds[$i] ?? null;
-            if (! is_string($attemptId) || $attemptId === '') {
-                continue;
-            }
-
-            DB::table('report_snapshots')->insert([
-                'org_id' => $orgId,
-                'attempt_id' => $attemptId,
-                'order_no' => null,
-                'scale_code' => 'MBTI',
-                'pack_id' => 'MBTI.cn-mainland.zh-CN.v0.3',
-                'dir_version' => 'MBTI-CN-v0.3',
-                'scoring_spec_version' => 'mbti_spec_fer2_20',
-                'report_engine_version' => 'v1.2',
-                'snapshot_version' => 'v1',
-                'report_json' => '{}',
-                'status' => 'ready',
-                'last_error' => null,
-                'created_at' => now()->subMinutes(7),
-                'updated_at' => now()->subMinutes(7),
-            ]);
-        }
+    private function insertReportSnapshot(int $orgId, string $attemptId, Carbon $updatedAt, string $status): void
+    {
+        DB::table('report_snapshots')->insert([
+            'org_id' => $orgId,
+            'attempt_id' => $attemptId,
+            'order_no' => null,
+            'scale_code' => 'MBTI',
+            'pack_id' => 'MBTI.cn-mainland.zh-CN.v0.3',
+            'dir_version' => 'MBTI-CN-v0.3',
+            'scoring_spec_version' => 'mbti_spec_fer2_20',
+            'report_engine_version' => 'v1.2',
+            'snapshot_version' => 'v1',
+            'report_json' => '{}',
+            'status' => $status,
+            'last_error' => null,
+            'created_at' => $updatedAt,
+            'updated_at' => $updatedAt,
+        ]);
     }
 }


### PR DESCRIPTION
Fixes FER2-35

Summary
- Harden ExperimentKpiEvaluator denominator from late-stage exposure to full-funnel stage gating.
- Add traceable stage sources and KPI schema checks to prevent metric drift.
- Add regression tests for missing-stage and out-of-order-stage false positive/false negative protection.

Verification
- cd backend && php artisan route:list
- cd backend && php artisan migrate
- cd backend && php artisan test --filter AuthGuestToken
- cd backend && php artisan test --filter ExperimentKpi
- cd backend && php artisan test --filter ExperimentGuardrailAutoRollbackTest
- bash backend/scripts/ci_verify_mbti.sh