### PR TITLE
Fixes FER2-36: add DSAR replay and SLA ops closure

### DIFF
--- a/backend/app/Console/Commands/Ops/DsarRequeue.php
+++ b/backend/app/Console/Commands/Ops/DsarRequeue.php
@@ -1,0 +1,323 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Console\Commands\Ops;
+
+use App\Jobs\ExecuteDsarRequestJob;
+use App\Support\SchemaBaseline;
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Str;
+
+final class DsarRequeue extends Command
+{
+    protected $signature = 'ops:dsar-requeue
+        {--org-id= : Org id}
+        {--request-id= : DSAR request id}
+        {--actor-user-id= : Actor user id}
+        {--reason=manual_requeue : Replay reason}
+        {--json=1 : Output JSON payload}';
+
+    protected $description = 'Replay a failed DSAR request with idempotent no-duplicate semantics.';
+
+    public function handle(): int
+    {
+        $orgId = $this->positiveInt($this->option('org-id'));
+        $actorUserId = $this->positiveInt($this->option('actor-user-id'));
+        $requestId = trim((string) ($this->option('request-id') ?? ''));
+        $reason = trim((string) ($this->option('reason') ?? 'manual_requeue'));
+        if ($reason === '') {
+            $reason = 'manual_requeue';
+        }
+
+        if ($orgId <= 0 || $actorUserId <= 0 || $requestId === '') {
+            $payload = [
+                'ok' => false,
+                'state' => 'invalid',
+                'request_id' => $requestId !== '' ? $requestId : null,
+                'status' => null,
+                'task_id' => null,
+                'job_reference' => null,
+                'reason' => $reason,
+                'error_code' => 'INVALID_ARGUMENTS',
+            ];
+
+            return $this->outputPayload($payload, self::FAILURE);
+        }
+
+        $result = DB::transaction(function () use ($orgId, $requestId, $actorUserId, $reason): array {
+            return $this->requeueWithinTransaction($orgId, $requestId, $actorUserId, $reason);
+        });
+
+        if (($result['state'] ?? '') === 'dispatch') {
+            ExecuteDsarRequestJob::dispatch(
+                (string) $result['request_id'],
+                $orgId,
+                $actorUserId,
+                (string) $result['task_id'],
+                (string) $result['job_reference']
+            )->afterCommit();
+        }
+
+        $payload = [
+            'ok' => ($result['state'] ?? '') !== 'missing',
+            'state' => (string) ($result['state'] ?? 'missing'),
+            'request_id' => (string) ($result['request_id'] ?? $requestId),
+            'status' => (string) ($result['status'] ?? ''),
+            'task_id' => $result['task_id'] ?? null,
+            'job_reference' => $result['job_reference'] ?? null,
+            'reason' => $reason,
+        ];
+
+        $exitCode = ($result['state'] ?? '') === 'missing' ? self::FAILURE : self::SUCCESS;
+
+        return $this->outputPayload($payload, $exitCode);
+    }
+
+    /**
+     * @return array{
+     *   state:string,
+     *   request_id?:string,
+     *   status?:string,
+     *   task_id?:string,
+     *   job_reference?:string
+     * }
+     */
+    private function requeueWithinTransaction(int $orgId, string $requestId, int $actorUserId, string $reason): array
+    {
+        if (! SchemaBaseline::hasTable('dsar_requests')) {
+            return ['state' => 'missing'];
+        }
+
+        $row = DB::table('dsar_requests')
+            ->where('id', $requestId)
+            ->where('org_id', $orgId)
+            ->lockForUpdate()
+            ->first();
+
+        if ($row === null) {
+            return ['state' => 'missing'];
+        }
+
+        $status = trim((string) ($row->status ?? 'pending'));
+        if ($status === '') {
+            $status = 'pending';
+        }
+
+        $payload = $this->decodeJson($row->payload_json ?? null) ?? [];
+        $execution = is_array($payload['execution'] ?? null) ? $payload['execution'] : [];
+        $existingTaskId = trim((string) ($execution['task_id'] ?? ''));
+        $existingReferenceId = trim((string) ($execution['reference_id'] ?? ''));
+
+        $this->appendAudit(
+            requestId: (string) ($row->id ?? ''),
+            orgId: (int) ($row->org_id ?? 0),
+            subjectUserId: $this->nullablePositiveInt($row->subject_user_id ?? null),
+            eventType: 'requeue_requested',
+            level: 'info',
+            message: 'dsar replay requested',
+            context: [
+                'previous_status' => $status,
+                'reason' => $reason,
+                'actor_user_id' => $actorUserId,
+                'task_id' => $existingTaskId !== '' ? $existingTaskId : null,
+                'reference_id' => $existingReferenceId !== '' ? $existingReferenceId : null,
+            ]
+        );
+
+        if ($status !== 'failed') {
+            return [
+                'state' => 'noop',
+                'request_id' => (string) ($row->id ?? $requestId),
+                'status' => $status,
+                'task_id' => $existingTaskId !== '' ? $existingTaskId : null,
+                'job_reference' => $existingReferenceId !== '' ? $existingReferenceId : null,
+            ];
+        }
+
+        $now = now();
+        $taskId = (string) Str::uuid();
+        $referenceId = (string) Str::uuid();
+        $requeueCount = max(0, (int) ($execution['requeue_count'] ?? 0)) + 1;
+
+        $payload['execution'] = [
+            'task_id' => $taskId,
+            'reference_id' => $referenceId,
+            'queued_by_user_id' => $actorUserId,
+            'queued_at' => $now->toISOString(),
+            'requeue_count' => $requeueCount,
+            'requeue_reason' => $reason,
+            'requeue_requested_at' => $now->toISOString(),
+            'requeue_requested_by_user_id' => $actorUserId,
+        ];
+
+        DB::table('dsar_requests')
+            ->where('id', $requestId)
+            ->where('org_id', $orgId)
+            ->update([
+                'status' => 'running',
+                'executed_by_user_id' => $actorUserId,
+                'result_json' => null,
+                'payload_json' => json_encode($payload, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES),
+                'updated_at' => $now,
+            ]);
+
+        if (SchemaBaseline::hasTable('dsar_request_tasks')) {
+            DB::table('dsar_request_tasks')->insert([
+                'id' => $taskId,
+                'request_id' => $requestId,
+                'org_id' => $orgId,
+                'subject_user_id' => $this->nullablePositiveInt($row->subject_user_id ?? null),
+                'domain' => 'orchestration',
+                'action' => 'execute',
+                'status' => 'pending',
+                'error_code' => null,
+                'stats_json' => json_encode([
+                    'queued_by_user_id' => $actorUserId,
+                    'reference_id' => $referenceId,
+                    'requeue' => true,
+                    'requeue_count' => $requeueCount,
+                    'requeue_reason' => $reason,
+                ], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES),
+                'started_at' => null,
+                'finished_at' => null,
+                'created_at' => $now,
+                'updated_at' => $now,
+            ]);
+        }
+
+        $this->appendAudit(
+            requestId: (string) ($row->id ?? ''),
+            orgId: (int) ($row->org_id ?? 0),
+            subjectUserId: $this->nullablePositiveInt($row->subject_user_id ?? null),
+            eventType: 'dsar_status_transition',
+            level: 'info',
+            message: 'dsar request transitioned from failed to running',
+            context: [
+                'from' => 'failed',
+                'to' => 'running',
+                'task_id' => $taskId,
+                'reference_id' => $referenceId,
+            ]
+        );
+
+        $this->appendAudit(
+            requestId: (string) ($row->id ?? ''),
+            orgId: (int) ($row->org_id ?? 0),
+            subjectUserId: $this->nullablePositiveInt($row->subject_user_id ?? null),
+            eventType: 'requeue_started',
+            level: 'info',
+            message: 'dsar replay dispatched',
+            context: [
+                'task_id' => $taskId,
+                'reference_id' => $referenceId,
+                'requeue_count' => $requeueCount,
+                'reason' => $reason,
+            ]
+        );
+
+        return [
+            'state' => 'dispatch',
+            'request_id' => (string) ($row->id ?? $requestId),
+            'status' => 'running',
+            'task_id' => $taskId,
+            'job_reference' => $referenceId,
+        ];
+    }
+
+    /**
+     * @param  array<string,mixed>  $context
+     */
+    private function appendAudit(
+        string $requestId,
+        int $orgId,
+        ?int $subjectUserId,
+        string $eventType,
+        string $level,
+        string $message,
+        array $context
+    ): void {
+        if (! SchemaBaseline::hasTable('dsar_audit_logs')) {
+            return;
+        }
+
+        $now = now();
+        DB::table('dsar_audit_logs')->insert([
+            'request_id' => $requestId,
+            'org_id' => $orgId,
+            'subject_user_id' => $subjectUserId,
+            'event_type' => $eventType,
+            'level' => $level,
+            'message' => $message,
+            'context_json' => json_encode($context, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES),
+            'occurred_at' => $now,
+            'created_at' => $now,
+            'updated_at' => $now,
+        ]);
+    }
+
+    /**
+     * @return array<string,mixed>|null
+     */
+    private function decodeJson(mixed $value): ?array
+    {
+        if (is_array($value)) {
+            return $value;
+        }
+        if (! is_string($value) || trim($value) === '') {
+            return null;
+        }
+
+        $decoded = json_decode($value, true);
+
+        return is_array($decoded) ? $decoded : null;
+    }
+
+    private function nullablePositiveInt(mixed $value): ?int
+    {
+        $value = trim((string) $value);
+        if ($value === '' || preg_match('/^\d+$/', $value) !== 1) {
+            return null;
+        }
+
+        $int = (int) $value;
+
+        return $int > 0 ? $int : null;
+    }
+
+    private function positiveInt(mixed $value): int
+    {
+        return $this->nullablePositiveInt($value) ?? 0;
+    }
+
+    private function outputPayload(array $payload, int $exitCode): int
+    {
+        if ($this->isTruthy($this->option('json'))) {
+            $this->line((string) json_encode($payload, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES));
+        } else {
+            $this->line(sprintf(
+                'state=%s request_id=%s status=%s task_id=%s job_reference=%s reason=%s',
+                (string) ($payload['state'] ?? ''),
+                (string) ($payload['request_id'] ?? ''),
+                (string) ($payload['status'] ?? ''),
+                (string) ($payload['task_id'] ?? ''),
+                (string) ($payload['job_reference'] ?? ''),
+                (string) ($payload['reason'] ?? '')
+            ));
+        }
+
+        return $exitCode;
+    }
+
+    private function isTruthy(mixed $value): bool
+    {
+        if (is_bool($value)) {
+            return $value;
+        }
+
+        $normalized = strtolower(trim((string) $value));
+
+        return in_array($normalized, ['1', 'true', 'yes', 'on'], true);
+    }
+}

--- a/backend/app/Console/Commands/Ops/DsarSlaStats.php
+++ b/backend/app/Console/Commands/Ops/DsarSlaStats.php
@@ -1,0 +1,168 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Console\Commands\Ops;
+
+use App\Support\SchemaBaseline;
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\DB;
+
+final class DsarSlaStats extends Command
+{
+    protected $signature = 'ops:dsar-sla-stats
+        {--org-id= : Org id}
+        {--window-hours=24 : Lookback hours}
+        {--stale-minutes=60 : Pending/running timeout threshold}
+        {--json=1 : Output JSON payload}';
+
+    protected $description = 'Output DSAR SLA ops stats (timeouts, failures, retry exhausted, and replay lifecycle).';
+
+    public function handle(): int
+    {
+        $orgId = $this->positiveInt($this->option('org-id'));
+        $windowHours = max(1, (int) ($this->option('window-hours') ?? 24));
+        $staleMinutes = max(1, (int) ($this->option('stale-minutes') ?? 60));
+
+        if ($orgId <= 0) {
+            $payload = [
+                'ok' => false,
+                'error_code' => 'INVALID_ORG_ID',
+                'org_id' => $orgId,
+            ];
+
+            if ($this->isTruthy($this->option('json'))) {
+                $this->line((string) json_encode($payload, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES));
+            } else {
+                $this->error('invalid --org-id, expected positive integer');
+            }
+
+            return self::FAILURE;
+        }
+
+        $windowStart = now()->subHours($windowHours);
+        $staleCutoff = now()->subMinutes($staleMinutes);
+
+        $stats = [
+            'timeout_count' => $this->countTimeouts($orgId, $staleCutoff),
+            'failed_count' => $this->countFailedRequests($orgId, $windowStart),
+            'retry_exhausted_count' => $this->countRetryExhausted($orgId, $windowStart),
+            'replay_requested_count' => $this->countReplayAudit($orgId, 'requeue_requested', $windowStart),
+            'replay_started_count' => $this->countReplayAudit($orgId, 'requeue_started', $windowStart),
+            'replay_done_count' => $this->countReplayAudit($orgId, 'requeue_done', $windowStart),
+            'replay_failed_count' => $this->countReplayAudit($orgId, 'requeue_failed', $windowStart),
+        ];
+
+        $sources = [
+            'timeout_count' => 'dsar_requests.status in (pending,running) with coalesce(updated_at,requested_at,created_at) <= now-stale_minutes',
+            'failed_count' => 'dsar_requests.status=failed with coalesce(updated_at,executed_at,requested_at,created_at) >= window_start',
+            'retry_exhausted_count' => 'dsar_request_tasks.error_code=USER_DSAR_RETRY_EXHAUSTED with coalesce(updated_at,finished_at,created_at) >= window_start',
+            'replay_requested_count' => 'dsar_audit_logs.event_type=requeue_requested and occurred_at >= window_start',
+            'replay_started_count' => 'dsar_audit_logs.event_type=requeue_started and occurred_at >= window_start',
+            'replay_done_count' => 'dsar_audit_logs.event_type=requeue_done and occurred_at >= window_start',
+            'replay_failed_count' => 'dsar_audit_logs.event_type=requeue_failed and occurred_at >= window_start',
+        ];
+
+        $payload = [
+            'ok' => true,
+            'org_id' => $orgId,
+            'window_hours' => $windowHours,
+            'stale_minutes' => $staleMinutes,
+            'generated_at' => now()->toIso8601String(),
+            'stats' => $stats,
+            'sources' => $sources,
+        ];
+
+        if ($this->isTruthy($this->option('json'))) {
+            $this->line((string) json_encode($payload, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES));
+        } else {
+            $this->line(sprintf(
+                'timeouts=%d failed=%d retry_exhausted=%d replay_requested=%d replay_started=%d replay_done=%d replay_failed=%d',
+                (int) $stats['timeout_count'],
+                (int) $stats['failed_count'],
+                (int) $stats['retry_exhausted_count'],
+                (int) $stats['replay_requested_count'],
+                (int) $stats['replay_started_count'],
+                (int) $stats['replay_done_count'],
+                (int) $stats['replay_failed_count']
+            ));
+        }
+
+        return self::SUCCESS;
+    }
+
+    private function countTimeouts(int $orgId, \DateTimeInterface $staleCutoff): int
+    {
+        if (! SchemaBaseline::hasTable('dsar_requests')) {
+            return 0;
+        }
+
+        return (int) DB::table('dsar_requests')
+            ->where('org_id', $orgId)
+            ->whereIn('status', ['pending', 'running'])
+            ->whereRaw('coalesce(updated_at, requested_at, created_at) <= ?', [$staleCutoff])
+            ->count();
+    }
+
+    private function countFailedRequests(int $orgId, \DateTimeInterface $windowStart): int
+    {
+        if (! SchemaBaseline::hasTable('dsar_requests')) {
+            return 0;
+        }
+
+        return (int) DB::table('dsar_requests')
+            ->where('org_id', $orgId)
+            ->where('status', 'failed')
+            ->whereRaw('coalesce(updated_at, executed_at, requested_at, created_at) >= ?', [$windowStart])
+            ->count();
+    }
+
+    private function countRetryExhausted(int $orgId, \DateTimeInterface $windowStart): int
+    {
+        if (! SchemaBaseline::hasTable('dsar_request_tasks')) {
+            return 0;
+        }
+
+        return (int) DB::table('dsar_request_tasks')
+            ->where('org_id', $orgId)
+            ->where('error_code', 'USER_DSAR_RETRY_EXHAUSTED')
+            ->whereRaw('coalesce(updated_at, finished_at, created_at) >= ?', [$windowStart])
+            ->count();
+    }
+
+    private function countReplayAudit(int $orgId, string $eventType, \DateTimeInterface $windowStart): int
+    {
+        if (! SchemaBaseline::hasTable('dsar_audit_logs')) {
+            return 0;
+        }
+
+        return (int) DB::table('dsar_audit_logs')
+            ->where('org_id', $orgId)
+            ->where('event_type', $eventType)
+            ->whereRaw('coalesce(occurred_at, created_at) >= ?', [$windowStart])
+            ->count();
+    }
+
+    private function positiveInt(mixed $value): int
+    {
+        $raw = trim((string) $value);
+        if ($raw === '' || preg_match('/^\d+$/', $raw) !== 1) {
+            return 0;
+        }
+
+        $int = (int) $raw;
+
+        return $int > 0 ? $int : 0;
+    }
+
+    private function isTruthy(mixed $value): bool
+    {
+        if (is_bool($value)) {
+            return $value;
+        }
+
+        $normalized = strtolower(trim((string) $value));
+
+        return in_array($normalized, ['1', 'true', 'yes', 'on'], true);
+    }
+}

--- a/backend/app/Jobs/ExecuteDsarRequestJob.php
+++ b/backend/app/Jobs/ExecuteDsarRequestJob.php
@@ -54,6 +54,7 @@ final class ExecuteDsarRequestJob implements ShouldQueue
         if ($requestRow === null) {
             return;
         }
+        $replayContext = $this->extractReplayContext($requestRow);
 
         $currentStatus = trim((string) ($requestRow->status ?? 'pending'));
         if (in_array($currentStatus, ['done', 'failed'], true)) {
@@ -113,6 +114,21 @@ final class ExecuteDsarRequestJob implements ShouldQueue
         }
 
         $this->appendAuditTransition($currentStatus, $finalStatus, $result);
+        if ($replayContext !== null) {
+            $eventType = $finalStatus === 'done' ? 'requeue_done' : 'requeue_failed';
+            $level = $finalStatus === 'done' ? 'info' : 'error';
+            $this->appendReplayOutcomeAudit($requestRow, $eventType, $level, [
+                'task_id' => $replayContext['task_id'],
+                'reference_id' => $replayContext['reference_id'],
+                'requeue_count' => $replayContext['requeue_count'],
+                'requeue_reason' => $replayContext['requeue_reason'],
+                'requeue_requested_by_user_id' => $replayContext['requeue_requested_by_user_id'],
+                'requeue_requested_at' => $replayContext['requeue_requested_at'],
+                'error_code' => $finalStatus === 'failed'
+                    ? (string) ($result['error'] ?? 'USER_DSAR_FAILED')
+                    : null,
+            ]);
+        }
     }
 
     public function failed(Throwable $exception): void
@@ -125,6 +141,7 @@ final class ExecuteDsarRequestJob implements ShouldQueue
         if ($requestRow === null) {
             return;
         }
+        $replayContext = $this->extractReplayContext($requestRow);
 
         $currentStatus = trim((string) ($requestRow->status ?? 'pending'));
         if (in_array($currentStatus, ['done', 'failed'], true)) {
@@ -205,6 +222,19 @@ final class ExecuteDsarRequestJob implements ShouldQueue
 
         $this->appendAuditTransition($currentStatus, 'failed', ['ok' => false]);
         $this->appendTerminalFailureAudit($requestRow, $result['terminal'], $finishedAt);
+        if ($replayContext !== null) {
+            $this->appendReplayOutcomeAudit($requestRow, 'requeue_failed', 'error', [
+                'task_id' => $replayContext['task_id'],
+                'reference_id' => $replayContext['reference_id'],
+                'requeue_count' => $replayContext['requeue_count'],
+                'requeue_reason' => $replayContext['requeue_reason'],
+                'requeue_requested_by_user_id' => $replayContext['requeue_requested_by_user_id'],
+                'requeue_requested_at' => $replayContext['requeue_requested_at'],
+                'error_code' => 'USER_DSAR_RETRY_EXHAUSTED',
+                'attempts' => $attempts,
+                'max_tries' => $maxTries,
+            ]);
+        }
     }
 
     /**
@@ -278,5 +308,110 @@ final class ExecuteDsarRequestJob implements ShouldQueue
             'created_at' => $now,
             'updated_at' => $now,
         ]);
+    }
+
+    /**
+     * @return array{
+     *   task_id:string,
+     *   reference_id:string,
+     *   requeue_count:int,
+     *   requeue_reason:?string,
+     *   requeue_requested_by_user_id:?int,
+     *   requeue_requested_at:?string
+     * }|null
+     */
+    private function extractReplayContext(object $requestRow): ?array
+    {
+        $payload = $this->decodeJson($requestRow->payload_json ?? null);
+        if ($payload === null) {
+            return null;
+        }
+
+        $execution = is_array($payload['execution'] ?? null) ? $payload['execution'] : [];
+        $requeueCount = max(0, (int) ($execution['requeue_count'] ?? 0));
+        if ($requeueCount <= 0) {
+            return null;
+        }
+
+        $taskId = trim((string) ($execution['task_id'] ?? $this->taskId));
+        $referenceId = trim((string) ($execution['reference_id'] ?? $this->referenceId));
+        if ($taskId === '' || $referenceId === '') {
+            return null;
+        }
+
+        $requeueReason = trim((string) ($execution['requeue_reason'] ?? ''));
+        if ($requeueReason === '') {
+            $requeueReason = null;
+        }
+
+        $requestedByRaw = trim((string) ($execution['requeue_requested_by_user_id'] ?? ''));
+        $requestedBy = null;
+        if ($requestedByRaw !== '' && preg_match('/^\d+$/', $requestedByRaw) === 1) {
+            $requestedByInt = (int) $requestedByRaw;
+            if ($requestedByInt > 0) {
+                $requestedBy = $requestedByInt;
+            }
+        }
+
+        $requestedAt = trim((string) ($execution['requeue_requested_at'] ?? ''));
+        if ($requestedAt === '') {
+            $requestedAt = null;
+        }
+
+        return [
+            'task_id' => $taskId,
+            'reference_id' => $referenceId,
+            'requeue_count' => $requeueCount,
+            'requeue_reason' => $requeueReason,
+            'requeue_requested_by_user_id' => $requestedBy,
+            'requeue_requested_at' => $requestedAt,
+        ];
+    }
+
+    /**
+     * @param  array<string,mixed>  $context
+     */
+    private function appendReplayOutcomeAudit(
+        object $requestRow,
+        string $eventType,
+        string $level,
+        array $context
+    ): void {
+        if (! SchemaBaseline::hasTable('dsar_audit_logs')) {
+            return;
+        }
+
+        $now = now();
+        DB::table('dsar_audit_logs')->insert([
+            'request_id' => $this->requestId,
+            'org_id' => $this->orgId,
+            'subject_user_id' => (int) ($requestRow->subject_user_id ?? 0) ?: null,
+            'event_type' => $eventType,
+            'level' => $level,
+            'message' => $eventType === 'requeue_done'
+                ? 'dsar replay completed successfully.'
+                : 'dsar replay finished with failure.',
+            'context_json' => json_encode($context, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES),
+            'occurred_at' => $now,
+            'created_at' => $now,
+            'updated_at' => $now,
+        ]);
+    }
+
+    /**
+     * @return array<string,mixed>|null
+     */
+    private function decodeJson(mixed $value): ?array
+    {
+        if (is_array($value)) {
+            return $value;
+        }
+        if (! is_string($value) || trim($value) === '') {
+            return null;
+        }
+
+        $decoded = json_decode($value, true);
+
+        return is_array($decoded) ? $decoded : null;
     }
 }

--- a/backend/tests/Feature/Compliance/DsarReplayOpsCommandTest.php
+++ b/backend/tests/Feature/Compliance/DsarReplayOpsCommandTest.php
@@ -1,0 +1,578 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Compliance;
+
+use App\Jobs\ExecuteDsarRequestJob;
+use App\Services\Attempts\UserDataLifecycleService;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Artisan;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Queue;
+use Illuminate\Support\Str;
+use Tests\TestCase;
+
+final class DsarReplayOpsCommandTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_requeue_command_replays_failed_request_and_dispatches_job(): void
+    {
+        Queue::fake();
+
+        $orgId = 901;
+        $actorUserId = 90101;
+        $subjectUserId = 90102;
+        $requestId = (string) Str::uuid();
+        $failedTaskId = (string) Str::uuid();
+
+        $this->seedUser($actorUserId, 'owner901@example.test');
+        $this->seedUser($subjectUserId, 'subject901@example.test');
+        $this->seedFailedRequest($requestId, $orgId, $subjectUserId, $actorUserId, $failedTaskId);
+
+        $exitCode = Artisan::call('ops:dsar-requeue', [
+            '--org-id' => (string) $orgId,
+            '--request-id' => $requestId,
+            '--actor-user-id' => (string) $actorUserId,
+            '--reason' => 'manual replay for exhausted request',
+            '--json' => 1,
+        ]);
+
+        $this->assertSame(0, $exitCode);
+
+        $payload = json_decode(trim((string) Artisan::output()), true);
+        $this->assertIsArray($payload);
+        $this->assertTrue((bool) ($payload['ok'] ?? false));
+        $this->assertSame('dispatch', (string) ($payload['state'] ?? ''));
+        $this->assertSame('running', (string) ($payload['status'] ?? ''));
+        $newTaskId = (string) ($payload['task_id'] ?? '');
+        $newReferenceId = (string) ($payload['job_reference'] ?? '');
+        $this->assertNotSame('', $newTaskId);
+        $this->assertNotSame($failedTaskId, $newTaskId);
+        $this->assertNotSame('', $newReferenceId);
+
+        $requestRow = DB::table('dsar_requests')->where('id', $requestId)->first();
+        $this->assertNotNull($requestRow);
+        $this->assertSame('running', (string) ($requestRow->status ?? ''));
+        $this->assertSame($actorUserId, (int) ($requestRow->executed_by_user_id ?? 0));
+        $this->assertNull($requestRow->result_json);
+
+        $requestPayload = $this->decodeJson($requestRow->payload_json ?? null);
+        $execution = is_array($requestPayload['execution'] ?? null) ? $requestPayload['execution'] : [];
+        $this->assertSame($newTaskId, (string) ($execution['task_id'] ?? ''));
+        $this->assertSame($newReferenceId, (string) ($execution['reference_id'] ?? ''));
+        $this->assertSame(1, (int) ($execution['requeue_count'] ?? 0));
+        $this->assertSame('manual replay for exhausted request', (string) ($execution['requeue_reason'] ?? ''));
+
+        $pendingTask = DB::table('dsar_request_tasks')->where('id', $newTaskId)->first();
+        $this->assertNotNull($pendingTask);
+        $this->assertSame('pending', (string) ($pendingTask->status ?? ''));
+        $this->assertSame('orchestration', (string) ($pendingTask->domain ?? ''));
+        $this->assertSame('execute', (string) ($pendingTask->action ?? ''));
+
+        Queue::assertPushed(ExecuteDsarRequestJob::class, function (ExecuteDsarRequestJob $job) use (
+            $requestId,
+            $orgId,
+            $actorUserId,
+            $newTaskId,
+            $newReferenceId
+        ): bool {
+            return $job->requestId === $requestId
+                && $job->orgId === $orgId
+                && $job->actorUserId === $actorUserId
+                && $job->taskId === $newTaskId
+                && $job->referenceId === $newReferenceId;
+        });
+
+        $this->assertDatabaseHas('dsar_audit_logs', [
+            'request_id' => $requestId,
+            'event_type' => 'requeue_requested',
+        ]);
+        $this->assertDatabaseHas('dsar_audit_logs', [
+            'request_id' => $requestId,
+            'event_type' => 'requeue_started',
+        ]);
+        $this->assertDatabaseHas('dsar_audit_logs', [
+            'request_id' => $requestId,
+            'event_type' => 'dsar_status_transition',
+        ]);
+    }
+
+    public function test_requeue_command_is_noop_for_running_request(): void
+    {
+        Queue::fake();
+
+        $orgId = 902;
+        $actorUserId = 90201;
+        $subjectUserId = 90202;
+        $requestId = (string) Str::uuid();
+        $runningTaskId = (string) Str::uuid();
+        $runningReferenceId = (string) Str::uuid();
+
+        $this->seedUser($actorUserId, 'owner902@example.test');
+        $this->seedUser($subjectUserId, 'subject902@example.test');
+
+        DB::table('dsar_requests')->insert([
+            'id' => $requestId,
+            'org_id' => $orgId,
+            'subject_user_id' => $subjectUserId,
+            'requested_by_user_id' => $actorUserId,
+            'executed_by_user_id' => $actorUserId,
+            'mode' => 'hybrid_anonymize',
+            'status' => 'running',
+            'reason' => 'already running',
+            'payload_json' => json_encode([
+                'execution' => [
+                    'task_id' => $runningTaskId,
+                    'reference_id' => $runningReferenceId,
+                ],
+            ], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES),
+            'result_json' => null,
+            'requested_at' => now()->subMinute(),
+            'executed_at' => now()->subMinute(),
+            'created_at' => now()->subMinute(),
+            'updated_at' => now()->subMinute(),
+        ]);
+
+        DB::table('dsar_request_tasks')->insert([
+            'id' => $runningTaskId,
+            'request_id' => $requestId,
+            'org_id' => $orgId,
+            'subject_user_id' => $subjectUserId,
+            'domain' => 'orchestration',
+            'action' => 'execute',
+            'status' => 'running',
+            'error_code' => null,
+            'stats_json' => null,
+            'started_at' => now()->subMinute(),
+            'finished_at' => null,
+            'created_at' => now()->subMinute(),
+            'updated_at' => now()->subMinute(),
+        ]);
+
+        $taskCountBefore = DB::table('dsar_request_tasks')->where('request_id', $requestId)->count();
+
+        $exitCode = Artisan::call('ops:dsar-requeue', [
+            '--org-id' => (string) $orgId,
+            '--request-id' => $requestId,
+            '--actor-user-id' => (string) $actorUserId,
+            '--reason' => 'try replay while running',
+            '--json' => 1,
+        ]);
+
+        $this->assertSame(0, $exitCode);
+
+        $payload = json_decode(trim((string) Artisan::output()), true);
+        $this->assertIsArray($payload);
+        $this->assertSame('noop', (string) ($payload['state'] ?? ''));
+        $this->assertSame('running', (string) ($payload['status'] ?? ''));
+        $this->assertSame($runningTaskId, (string) ($payload['task_id'] ?? ''));
+        $this->assertSame($runningReferenceId, (string) ($payload['job_reference'] ?? ''));
+
+        $taskCountAfter = DB::table('dsar_request_tasks')->where('request_id', $requestId)->count();
+        $this->assertSame($taskCountBefore, $taskCountAfter);
+
+        Queue::assertNothingPushed();
+
+        $this->assertDatabaseHas('dsar_audit_logs', [
+            'request_id' => $requestId,
+            'event_type' => 'requeue_requested',
+        ]);
+        $this->assertDatabaseMissing('dsar_audit_logs', [
+            'request_id' => $requestId,
+            'event_type' => 'requeue_started',
+        ]);
+    }
+
+    public function test_requeue_done_and_failed_audits_are_written_by_job(): void
+    {
+        $orgId = 903;
+        $actorUserId = 90301;
+        $subjectUserId = 90302;
+
+        $this->seedUser($actorUserId, 'owner903@example.test');
+        $this->seedUser($subjectUserId, 'subject903@example.test');
+
+        $doneRequestId = (string) Str::uuid();
+        $doneTaskId = (string) Str::uuid();
+        $doneReferenceId = (string) Str::uuid();
+        $this->seedRunningReplayRequest($doneRequestId, $orgId, $subjectUserId, $actorUserId, $doneTaskId, $doneReferenceId);
+
+        DB::table('dsar_request_tasks')->insert([
+            'id' => $doneTaskId,
+            'request_id' => $doneRequestId,
+            'org_id' => $orgId,
+            'subject_user_id' => $subjectUserId,
+            'domain' => 'orchestration',
+            'action' => 'execute',
+            'status' => 'pending',
+            'error_code' => null,
+            'stats_json' => null,
+            'started_at' => null,
+            'finished_at' => null,
+            'created_at' => now()->subMinute(),
+            'updated_at' => now()->subMinute(),
+        ]);
+
+        /** @var UserDataLifecycleService $service */
+        $service = app(UserDataLifecycleService::class);
+
+        $doneJob = new ExecuteDsarRequestJob($doneRequestId, $orgId, $actorUserId, $doneTaskId, $doneReferenceId);
+        $doneJob->handle($service);
+
+        $this->assertDatabaseHas('dsar_audit_logs', [
+            'request_id' => $doneRequestId,
+            'event_type' => 'requeue_done',
+        ]);
+
+        $failedRequestId = (string) Str::uuid();
+        $failedTaskId = (string) Str::uuid();
+        $failedReferenceId = (string) Str::uuid();
+        $this->seedRunningReplayRequest($failedRequestId, $orgId, $subjectUserId, $actorUserId, $failedTaskId, $failedReferenceId);
+
+        DB::table('dsar_request_tasks')->insert([
+            'id' => $failedTaskId,
+            'request_id' => $failedRequestId,
+            'org_id' => $orgId,
+            'subject_user_id' => $subjectUserId,
+            'domain' => 'orchestration',
+            'action' => 'execute',
+            'status' => 'running',
+            'error_code' => null,
+            'stats_json' => null,
+            'started_at' => now()->subMinute(),
+            'finished_at' => null,
+            'created_at' => now()->subMinute(),
+            'updated_at' => now()->subMinute(),
+        ]);
+
+        $failedJob = new ExecuteDsarRequestJob($failedRequestId, $orgId, $actorUserId, $failedTaskId, $failedReferenceId);
+        $failedJob->failed(new \RuntimeException('terminal fail for replay'));
+
+        $failedAudit = DB::table('dsar_audit_logs')
+            ->where('request_id', $failedRequestId)
+            ->where('event_type', 'requeue_failed')
+            ->orderByDesc('id')
+            ->first();
+
+        $this->assertNotNull($failedAudit);
+        $failedContext = $this->decodeJson($failedAudit->context_json ?? null);
+        $this->assertSame('USER_DSAR_RETRY_EXHAUSTED', (string) ($failedContext['error_code'] ?? ''));
+        $this->assertSame($failedTaskId, (string) ($failedContext['task_id'] ?? ''));
+        $this->assertSame($failedReferenceId, (string) ($failedContext['reference_id'] ?? ''));
+    }
+
+    public function test_sla_stats_command_outputs_timeout_failed_and_replay_counts(): void
+    {
+        $orgId = 904;
+        $windowHours = 24;
+        $staleMinutes = 60;
+
+        $now = now();
+
+        DB::table('dsar_requests')->insert([
+            [
+                'id' => (string) Str::uuid(),
+                'org_id' => $orgId,
+                'subject_user_id' => 90401,
+                'requested_by_user_id' => 90411,
+                'executed_by_user_id' => null,
+                'mode' => 'hybrid_anonymize',
+                'status' => 'pending',
+                'reason' => 'stale pending',
+                'payload_json' => null,
+                'result_json' => null,
+                'requested_at' => $now->copy()->subHours(3),
+                'executed_at' => null,
+                'created_at' => $now->copy()->subHours(3),
+                'updated_at' => $now->copy()->subHours(2),
+            ],
+            [
+                'id' => (string) Str::uuid(),
+                'org_id' => $orgId,
+                'subject_user_id' => 90402,
+                'requested_by_user_id' => 90411,
+                'executed_by_user_id' => null,
+                'mode' => 'hybrid_anonymize',
+                'status' => 'running',
+                'reason' => 'stale running',
+                'payload_json' => null,
+                'result_json' => null,
+                'requested_at' => $now->copy()->subHours(4),
+                'executed_at' => null,
+                'created_at' => $now->copy()->subHours(4),
+                'updated_at' => $now->copy()->subHours(2),
+            ],
+            [
+                'id' => (string) Str::uuid(),
+                'org_id' => $orgId,
+                'subject_user_id' => 90403,
+                'requested_by_user_id' => 90411,
+                'executed_by_user_id' => 90411,
+                'mode' => 'hybrid_anonymize',
+                'status' => 'failed',
+                'reason' => 'recent failed',
+                'payload_json' => null,
+                'result_json' => null,
+                'requested_at' => $now->copy()->subHours(2),
+                'executed_at' => $now->copy()->subHours(2),
+                'created_at' => $now->copy()->subHours(2),
+                'updated_at' => $now->copy()->subHours(2),
+            ],
+            [
+                'id' => (string) Str::uuid(),
+                'org_id' => $orgId,
+                'subject_user_id' => 90404,
+                'requested_by_user_id' => 90411,
+                'executed_by_user_id' => 90411,
+                'mode' => 'hybrid_anonymize',
+                'status' => 'failed',
+                'reason' => 'old failed',
+                'payload_json' => null,
+                'result_json' => null,
+                'requested_at' => $now->copy()->subDays(3),
+                'executed_at' => $now->copy()->subDays(3),
+                'created_at' => $now->copy()->subDays(3),
+                'updated_at' => $now->copy()->subDays(3),
+            ],
+        ]);
+
+        DB::table('dsar_request_tasks')->insert([
+            [
+                'id' => (string) Str::uuid(),
+                'request_id' => (string) Str::uuid(),
+                'org_id' => $orgId,
+                'subject_user_id' => 90403,
+                'domain' => 'orchestration',
+                'action' => 'execute',
+                'status' => 'failed',
+                'error_code' => 'USER_DSAR_RETRY_EXHAUSTED',
+                'stats_json' => null,
+                'started_at' => $now->copy()->subHours(2),
+                'finished_at' => $now->copy()->subHours(2),
+                'created_at' => $now->copy()->subHours(2),
+                'updated_at' => $now->copy()->subHours(2),
+            ],
+            [
+                'id' => (string) Str::uuid(),
+                'request_id' => (string) Str::uuid(),
+                'org_id' => $orgId,
+                'subject_user_id' => 90404,
+                'domain' => 'orchestration',
+                'action' => 'execute',
+                'status' => 'failed',
+                'error_code' => 'USER_DSAR_RETRY_EXHAUSTED',
+                'stats_json' => null,
+                'started_at' => $now->copy()->subDays(3),
+                'finished_at' => $now->copy()->subDays(3),
+                'created_at' => $now->copy()->subDays(3),
+                'updated_at' => $now->copy()->subDays(3),
+            ],
+        ]);
+
+        DB::table('dsar_audit_logs')->insert([
+            [
+                'request_id' => (string) Str::uuid(),
+                'org_id' => $orgId,
+                'subject_user_id' => 90403,
+                'event_type' => 'requeue_requested',
+                'level' => 'info',
+                'message' => 'requested',
+                'context_json' => '{}',
+                'occurred_at' => $now->copy()->subHours(1),
+                'created_at' => $now->copy()->subHours(1),
+                'updated_at' => $now->copy()->subHours(1),
+            ],
+            [
+                'request_id' => (string) Str::uuid(),
+                'org_id' => $orgId,
+                'subject_user_id' => 90403,
+                'event_type' => 'requeue_started',
+                'level' => 'info',
+                'message' => 'started',
+                'context_json' => '{}',
+                'occurred_at' => $now->copy()->subHours(1),
+                'created_at' => $now->copy()->subHours(1),
+                'updated_at' => $now->copy()->subHours(1),
+            ],
+            [
+                'request_id' => (string) Str::uuid(),
+                'org_id' => $orgId,
+                'subject_user_id' => 90403,
+                'event_type' => 'requeue_done',
+                'level' => 'info',
+                'message' => 'done',
+                'context_json' => '{}',
+                'occurred_at' => $now->copy()->subHours(1),
+                'created_at' => $now->copy()->subHours(1),
+                'updated_at' => $now->copy()->subHours(1),
+            ],
+            [
+                'request_id' => (string) Str::uuid(),
+                'org_id' => $orgId,
+                'subject_user_id' => 90403,
+                'event_type' => 'requeue_failed',
+                'level' => 'error',
+                'message' => 'failed',
+                'context_json' => '{}',
+                'occurred_at' => $now->copy()->subHours(1),
+                'created_at' => $now->copy()->subHours(1),
+                'updated_at' => $now->copy()->subHours(1),
+            ],
+            [
+                'request_id' => (string) Str::uuid(),
+                'org_id' => $orgId,
+                'subject_user_id' => 90404,
+                'event_type' => 'requeue_failed',
+                'level' => 'error',
+                'message' => 'old failed',
+                'context_json' => '{}',
+                'occurred_at' => $now->copy()->subDays(3),
+                'created_at' => $now->copy()->subDays(3),
+                'updated_at' => $now->copy()->subDays(3),
+            ],
+        ]);
+
+        $exitCode = Artisan::call('ops:dsar-sla-stats', [
+            '--org-id' => (string) $orgId,
+            '--window-hours' => (string) $windowHours,
+            '--stale-minutes' => (string) $staleMinutes,
+            '--json' => 1,
+        ]);
+
+        $this->assertSame(0, $exitCode);
+
+        $payload = json_decode(trim((string) Artisan::output()), true);
+        $this->assertIsArray($payload);
+        $this->assertTrue((bool) ($payload['ok'] ?? false));
+
+        $stats = is_array($payload['stats'] ?? null) ? $payload['stats'] : [];
+        $this->assertSame(2, (int) ($stats['timeout_count'] ?? -1));
+        $this->assertSame(1, (int) ($stats['failed_count'] ?? -1));
+        $this->assertSame(1, (int) ($stats['retry_exhausted_count'] ?? -1));
+        $this->assertSame(1, (int) ($stats['replay_requested_count'] ?? -1));
+        $this->assertSame(1, (int) ($stats['replay_started_count'] ?? -1));
+        $this->assertSame(1, (int) ($stats['replay_done_count'] ?? -1));
+        $this->assertSame(1, (int) ($stats['replay_failed_count'] ?? -1));
+
+        $sources = is_array($payload['sources'] ?? null) ? $payload['sources'] : [];
+        $this->assertArrayHasKey('timeout_count', $sources);
+        $this->assertArrayHasKey('failed_count', $sources);
+        $this->assertArrayHasKey('retry_exhausted_count', $sources);
+        $this->assertArrayHasKey('replay_failed_count', $sources);
+    }
+
+    private function seedUser(int $id, string $email): void
+    {
+        DB::table('users')->insert([
+            'id' => $id,
+            'name' => $email,
+            'email' => $email,
+            'password' => bcrypt('secret'),
+            'created_at' => now(),
+            'updated_at' => now(),
+        ]);
+    }
+
+    private function seedFailedRequest(
+        string $requestId,
+        int $orgId,
+        int $subjectUserId,
+        int $actorUserId,
+        string $taskId
+    ): void {
+        DB::table('dsar_requests')->insert([
+            'id' => $requestId,
+            'org_id' => $orgId,
+            'subject_user_id' => $subjectUserId,
+            'requested_by_user_id' => $actorUserId,
+            'executed_by_user_id' => $actorUserId,
+            'mode' => 'hybrid_anonymize',
+            'status' => 'failed',
+            'reason' => 'retry exhausted',
+            'payload_json' => json_encode([
+                'execution' => [
+                    'task_id' => $taskId,
+                    'reference_id' => (string) Str::uuid(),
+                ],
+            ], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES),
+            'result_json' => json_encode([
+                'ok' => false,
+                'error_code' => 'USER_DSAR_RETRY_EXHAUSTED',
+            ], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES),
+            'requested_at' => now()->subMinutes(20),
+            'executed_at' => now()->subMinutes(10),
+            'created_at' => now()->subMinutes(20),
+            'updated_at' => now()->subMinutes(10),
+        ]);
+
+        DB::table('dsar_request_tasks')->insert([
+            'id' => $taskId,
+            'request_id' => $requestId,
+            'org_id' => $orgId,
+            'subject_user_id' => $subjectUserId,
+            'domain' => 'orchestration',
+            'action' => 'execute',
+            'status' => 'failed',
+            'error_code' => 'USER_DSAR_RETRY_EXHAUSTED',
+            'stats_json' => null,
+            'started_at' => now()->subMinutes(15),
+            'finished_at' => now()->subMinutes(10),
+            'created_at' => now()->subMinutes(20),
+            'updated_at' => now()->subMinutes(10),
+        ]);
+    }
+
+    private function seedRunningReplayRequest(
+        string $requestId,
+        int $orgId,
+        int $subjectUserId,
+        int $actorUserId,
+        string $taskId,
+        string $referenceId
+    ): void {
+        DB::table('dsar_requests')->insert([
+            'id' => $requestId,
+            'org_id' => $orgId,
+            'subject_user_id' => $subjectUserId,
+            'requested_by_user_id' => $actorUserId,
+            'executed_by_user_id' => $actorUserId,
+            'mode' => 'hybrid_anonymize',
+            'status' => 'running',
+            'reason' => 'replay in progress',
+            'payload_json' => json_encode([
+                'execution' => [
+                    'task_id' => $taskId,
+                    'reference_id' => $referenceId,
+                    'requeue_count' => 1,
+                    'requeue_reason' => 'manual_requeue',
+                    'requeue_requested_by_user_id' => $actorUserId,
+                    'requeue_requested_at' => now()->toIso8601String(),
+                ],
+            ], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES),
+            'result_json' => null,
+            'requested_at' => now()->subMinutes(5),
+            'executed_at' => now()->subMinutes(5),
+            'created_at' => now()->subMinutes(5),
+            'updated_at' => now()->subMinutes(5),
+        ]);
+    }
+
+    /**
+     * @return array<string,mixed>|null
+     */
+    private function decodeJson(mixed $value): ?array
+    {
+        if (is_array($value)) {
+            return $value;
+        }
+        if (! is_string($value) || trim($value) === '') {
+            return null;
+        }
+
+        $decoded = json_decode($value, true);
+
+        return is_array($decoded) ? $decoded : null;
+    }
+}


### PR DESCRIPTION
Fixes FER2-36

Summary
- Add actionable DSAR replay command for failed requests with idempotent no-duplicate semantics.
- Add replay lifecycle audits (requested/started/done/failed) and keep existing DSAR API contracts unchanged.
- Add SLA ops stats command for timeout/failed/replay counters with traceable data sources.

Verification
- cd backend && php artisan route:list
- cd backend && php artisan migrate
- cd backend && php artisan test --filter AuthGuestToken
- cd backend && php artisan test --filter Dsar
- bash backend/scripts/ci_verify_mbti.sh