### PR TITLE
Fixes FER2-38: add OpenAPI export and CI schema diff gate

### DIFF
--- a/backend/docs/contracts/openapi.snapshot.json
+++ b/backend/docs/contracts/openapi.snapshot.json
@@ -1,0 +1,1668 @@
+{
+    "openapi": "3.0.3",
+    "info": {
+        "title": "fap-api route contract snapshot",
+        "version": "route-list-v1"
+    },
+    "paths": {
+        "/api/healthz": {
+            "get": {
+                "operationId": "healthz",
+                "tags": [
+                    "api:root"
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK"
+                    }
+                },
+                "x-laravel-action": "App\\Http\\Controllers\\HealthzController@show",
+                "x-laravel-middleware": [
+                    "api",
+                    "App\\Http\\Middleware\\HealthzAccessControl",
+                    "Illuminate\\Routing\\Middleware\\ThrottleRequests:api_public"
+                ],
+                "x-laravel-name": "healthz"
+            }
+        },
+        "/api/user": {
+            "get": {
+                "operationId": "get_api_user",
+                "tags": [
+                    "api:root"
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK"
+                    }
+                },
+                "x-laravel-action": "Closure",
+                "x-laravel-middleware": [
+                    "api",
+                    "Illuminate\\Auth\\Middleware\\Authenticate:sanctum"
+                ]
+            }
+        },
+        "/api/v0.2/{any?}": {
+            "delete": {
+                "operationId": "delete_api_v0_2_any_",
+                "tags": [
+                    "api:v0.2"
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK"
+                    }
+                },
+                "x-laravel-action": "Closure",
+                "x-laravel-middleware": [
+                    "api",
+                    "Illuminate\\Routing\\Middleware\\ThrottleRequests:api_public",
+                    "App\\Http\\Middleware\\NormalizeApiErrorContract"
+                ]
+            },
+            "get": {
+                "operationId": "get_api_v0_2_any_",
+                "tags": [
+                    "api:v0.2"
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK"
+                    }
+                },
+                "x-laravel-action": "Closure",
+                "x-laravel-middleware": [
+                    "api",
+                    "Illuminate\\Routing\\Middleware\\ThrottleRequests:api_public",
+                    "App\\Http\\Middleware\\NormalizeApiErrorContract"
+                ]
+            },
+            "options": {
+                "operationId": "options_api_v0_2_any_",
+                "tags": [
+                    "api:v0.2"
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK"
+                    }
+                },
+                "x-laravel-action": "Closure",
+                "x-laravel-middleware": [
+                    "api",
+                    "Illuminate\\Routing\\Middleware\\ThrottleRequests:api_public",
+                    "App\\Http\\Middleware\\NormalizeApiErrorContract"
+                ]
+            },
+            "patch": {
+                "operationId": "patch_api_v0_2_any_",
+                "tags": [
+                    "api:v0.2"
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK"
+                    }
+                },
+                "x-laravel-action": "Closure",
+                "x-laravel-middleware": [
+                    "api",
+                    "Illuminate\\Routing\\Middleware\\ThrottleRequests:api_public",
+                    "App\\Http\\Middleware\\NormalizeApiErrorContract"
+                ]
+            },
+            "post": {
+                "operationId": "post_api_v0_2_any_",
+                "tags": [
+                    "api:v0.2"
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK"
+                    }
+                },
+                "x-laravel-action": "Closure",
+                "x-laravel-middleware": [
+                    "api",
+                    "Illuminate\\Routing\\Middleware\\ThrottleRequests:api_public",
+                    "App\\Http\\Middleware\\NormalizeApiErrorContract"
+                ]
+            },
+            "put": {
+                "operationId": "put_api_v0_2_any_",
+                "tags": [
+                    "api:v0.2"
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK"
+                    }
+                },
+                "x-laravel-action": "Closure",
+                "x-laravel-middleware": [
+                    "api",
+                    "Illuminate\\Routing\\Middleware\\ThrottleRequests:api_public",
+                    "App\\Http\\Middleware\\NormalizeApiErrorContract"
+                ]
+            }
+        },
+        "/api/v0.3/attempts/start": {
+            "post": {
+                "operationId": "post_api_v0_3_attempts_start",
+                "tags": [
+                    "api:v0.3"
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK"
+                    }
+                },
+                "x-laravel-action": "App\\Http\\Controllers\\API\\V0_3\\AttemptWriteController@start",
+                "x-laravel-middleware": [
+                    "api",
+                    "Illuminate\\Routing\\Middleware\\ThrottleRequests:api_public",
+                    "App\\Http\\Middleware\\NormalizeApiErrorContract",
+                    "App\\Http\\Middleware\\ResolveAnonId",
+                    "App\\Http\\Middleware\\ResolveOrgContext",
+                    "Illuminate\\Routing\\Middleware\\ThrottleRequests:api_attempt_submit"
+                ]
+            }
+        },
+        "/api/v0.3/attempts/submit": {
+            "post": {
+                "operationId": "post_api_v0_3_attempts_submit",
+                "tags": [
+                    "api:v0.3"
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK"
+                    }
+                },
+                "x-laravel-action": "App\\Http\\Controllers\\API\\V0_3\\AttemptWriteController@submit",
+                "x-laravel-middleware": [
+                    "api",
+                    "Illuminate\\Routing\\Middleware\\ThrottleRequests:api_public",
+                    "App\\Http\\Middleware\\NormalizeApiErrorContract",
+                    "App\\Http\\Middleware\\ResolveAnonId",
+                    "App\\Http\\Middleware\\ResolveOrgContext",
+                    "Illuminate\\Routing\\Middleware\\ThrottleRequests:api_attempt_submit",
+                    "App\\Http\\Middleware\\FmTokenAuth"
+                ]
+            }
+        },
+        "/api/v0.3/attempts/{attempt_id}/progress": {
+            "get": {
+                "operationId": "get_api_v0_3_attempts_attempt_id_progress",
+                "tags": [
+                    "api:v0.3"
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK"
+                    }
+                },
+                "x-laravel-action": "App\\Http\\Controllers\\API\\V0_3\\AttemptProgressController@show",
+                "x-laravel-middleware": [
+                    "api",
+                    "Illuminate\\Routing\\Middleware\\ThrottleRequests:api_public",
+                    "App\\Http\\Middleware\\NormalizeApiErrorContract",
+                    "App\\Http\\Middleware\\ResolveAnonId",
+                    "App\\Http\\Middleware\\ResolveOrgContext",
+                    "App\\Http\\Middleware\\EnsureUuidRouteParams:attempt_id"
+                ]
+            },
+            "put": {
+                "operationId": "put_api_v0_3_attempts_attempt_id_progress",
+                "tags": [
+                    "api:v0.3"
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK"
+                    }
+                },
+                "x-laravel-action": "App\\Http\\Controllers\\API\\V0_3\\AttemptProgressController@upsert",
+                "x-laravel-middleware": [
+                    "api",
+                    "Illuminate\\Routing\\Middleware\\ThrottleRequests:api_public",
+                    "App\\Http\\Middleware\\NormalizeApiErrorContract",
+                    "App\\Http\\Middleware\\ResolveAnonId",
+                    "App\\Http\\Middleware\\ResolveOrgContext",
+                    "App\\Http\\Middleware\\EnsureUuidRouteParams:attempt_id"
+                ]
+            }
+        },
+        "/api/v0.3/attempts/{attempt_id}/submission": {
+            "get": {
+                "operationId": "api.v0_3.attempts.submission",
+                "tags": [
+                    "api:v0.3"
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK"
+                    }
+                },
+                "x-laravel-action": "App\\Http\\Controllers\\API\\V0_3\\AttemptReadController@submission",
+                "x-laravel-middleware": [
+                    "api",
+                    "Illuminate\\Routing\\Middleware\\ThrottleRequests:api_public",
+                    "App\\Http\\Middleware\\NormalizeApiErrorContract",
+                    "App\\Http\\Middleware\\ResolveAnonId",
+                    "App\\Http\\Middleware\\ResolveOrgContext",
+                    "App\\Http\\Middleware\\EnsureUuidRouteParams:attempt_id"
+                ],
+                "x-laravel-name": "api.v0_3.attempts.submission"
+            }
+        },
+        "/api/v0.3/attempts/{id}": {
+            "get": {
+                "operationId": "api.v0_3.attempts.show",
+                "tags": [
+                    "api:v0.3"
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK"
+                    }
+                },
+                "x-laravel-action": "App\\Http\\Controllers\\API\\V0_3\\AttemptReadController@show",
+                "x-laravel-middleware": [
+                    "api",
+                    "Illuminate\\Routing\\Middleware\\ThrottleRequests:api_public",
+                    "App\\Http\\Middleware\\NormalizeApiErrorContract",
+                    "App\\Http\\Middleware\\ResolveAnonId",
+                    "App\\Http\\Middleware\\ResolveOrgContext",
+                    "App\\Http\\Middleware\\EnsureUuidRouteParams:id"
+                ],
+                "x-laravel-name": "api.v0_3.attempts.show"
+            }
+        },
+        "/api/v0.3/attempts/{id}/report": {
+            "get": {
+                "operationId": "api.v0_3.attempts.report",
+                "tags": [
+                    "api:v0.3"
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK"
+                    }
+                },
+                "x-laravel-action": "App\\Http\\Controllers\\API\\V0_3\\AttemptReadController@report",
+                "x-laravel-middleware": [
+                    "api",
+                    "Illuminate\\Routing\\Middleware\\ThrottleRequests:api_public",
+                    "App\\Http\\Middleware\\NormalizeApiErrorContract",
+                    "App\\Http\\Middleware\\ResolveAnonId",
+                    "App\\Http\\Middleware\\ResolveOrgContext",
+                    "App\\Http\\Middleware\\EnsureUuidRouteParams:id"
+                ],
+                "x-laravel-name": "api.v0_3.attempts.report"
+            }
+        },
+        "/api/v0.3/attempts/{id}/report.pdf": {
+            "get": {
+                "operationId": "api.v0_3.attempts.report_pdf",
+                "tags": [
+                    "api:v0.3"
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK"
+                    }
+                },
+                "x-laravel-action": "App\\Http\\Controllers\\API\\V0_3\\AttemptReadController@reportPdf",
+                "x-laravel-middleware": [
+                    "api",
+                    "Illuminate\\Routing\\Middleware\\ThrottleRequests:api_public",
+                    "App\\Http\\Middleware\\NormalizeApiErrorContract",
+                    "App\\Http\\Middleware\\ResolveAnonId",
+                    "App\\Http\\Middleware\\ResolveOrgContext",
+                    "App\\Http\\Middleware\\EnsureUuidRouteParams:id"
+                ],
+                "x-laravel-name": "api.v0_3.attempts.report_pdf"
+            }
+        },
+        "/api/v0.3/attempts/{id}/result": {
+            "get": {
+                "operationId": "api.v0_3.attempts.result",
+                "tags": [
+                    "api:v0.3"
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK"
+                    }
+                },
+                "x-laravel-action": "App\\Http\\Controllers\\API\\V0_3\\AttemptReadController@result",
+                "x-laravel-middleware": [
+                    "api",
+                    "Illuminate\\Routing\\Middleware\\ThrottleRequests:api_public",
+                    "App\\Http\\Middleware\\NormalizeApiErrorContract",
+                    "App\\Http\\Middleware\\ResolveAnonId",
+                    "App\\Http\\Middleware\\ResolveOrgContext",
+                    "App\\Http\\Middleware\\EnsureUuidRouteParams:id"
+                ],
+                "x-laravel-name": "api.v0_3.attempts.result"
+            }
+        },
+        "/api/v0.3/attempts/{id}/share": {
+            "get": {
+                "operationId": "get_api_v0_3_attempts_id_share",
+                "tags": [
+                    "api:v0.3"
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK"
+                    }
+                },
+                "x-laravel-action": "App\\Http\\Controllers\\API\\V0_3\\ShareController@getShare",
+                "x-laravel-middleware": [
+                    "api",
+                    "Illuminate\\Routing\\Middleware\\ThrottleRequests:api_public",
+                    "App\\Http\\Middleware\\NormalizeApiErrorContract",
+                    "App\\Http\\Middleware\\ResolveAnonId",
+                    "App\\Http\\Middleware\\ResolveOrgContext",
+                    "App\\Http\\Middleware\\FmTokenAuth"
+                ]
+            }
+        },
+        "/api/v0.3/auth/guest": {
+            "post": {
+                "operationId": "post_api_v0_3_auth_guest",
+                "tags": [
+                    "api:v0.3"
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK"
+                    }
+                },
+                "x-laravel-action": "App\\Http\\Controllers\\API\\V0_3\\AuthGuestController",
+                "x-laravel-middleware": [
+                    "api",
+                    "Illuminate\\Routing\\Middleware\\ThrottleRequests:api_public",
+                    "App\\Http\\Middleware\\NormalizeApiErrorContract",
+                    "Illuminate\\Routing\\Middleware\\ThrottleRequests:api_auth",
+                    "App\\Http\\Middleware\\ResolveAnonId"
+                ]
+            }
+        },
+        "/api/v0.3/auth/phone/send_code": {
+            "post": {
+                "operationId": "post_api_v0_3_auth_phone_send_code",
+                "tags": [
+                    "api:v0.3"
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK"
+                    }
+                },
+                "x-laravel-action": "App\\Http\\Controllers\\API\\V0_3\\AuthPhoneController@sendCode",
+                "x-laravel-middleware": [
+                    "api",
+                    "Illuminate\\Routing\\Middleware\\ThrottleRequests:api_public",
+                    "App\\Http\\Middleware\\NormalizeApiErrorContract",
+                    "Illuminate\\Routing\\Middleware\\ThrottleRequests:api_auth"
+                ]
+            }
+        },
+        "/api/v0.3/auth/phone/verify": {
+            "post": {
+                "operationId": "post_api_v0_3_auth_phone_verify",
+                "tags": [
+                    "api:v0.3"
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK"
+                    }
+                },
+                "x-laravel-action": "App\\Http\\Controllers\\API\\V0_3\\AuthPhoneController@verify",
+                "x-laravel-middleware": [
+                    "api",
+                    "Illuminate\\Routing\\Middleware\\ThrottleRequests:api_public",
+                    "App\\Http\\Middleware\\NormalizeApiErrorContract",
+                    "Illuminate\\Routing\\Middleware\\ThrottleRequests:api_auth"
+                ]
+            }
+        },
+        "/api/v0.3/auth/wx_phone": {
+            "post": {
+                "operationId": "post_api_v0_3_auth_wx_phone",
+                "tags": [
+                    "api:v0.3"
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK"
+                    }
+                },
+                "x-laravel-action": "App\\Http\\Controllers\\API\\V0_3\\AuthWxPhoneController",
+                "x-laravel-middleware": [
+                    "api",
+                    "Illuminate\\Routing\\Middleware\\ThrottleRequests:api_public",
+                    "App\\Http\\Middleware\\NormalizeApiErrorContract",
+                    "Illuminate\\Routing\\Middleware\\ThrottleRequests:api_auth"
+                ]
+            }
+        },
+        "/api/v0.3/boot": {
+            "get": {
+                "operationId": "get_api_v0_3_boot",
+                "tags": [
+                    "api:v0.3"
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK"
+                    }
+                },
+                "x-laravel-action": "App\\Http\\Controllers\\API\\V0_3\\BootController@show",
+                "x-laravel-middleware": [
+                    "api",
+                    "Illuminate\\Routing\\Middleware\\ThrottleRequests:api_public",
+                    "App\\Http\\Middleware\\NormalizeApiErrorContract",
+                    "App\\Http\\Middleware\\ResolveAnonId",
+                    "App\\Http\\Middleware\\ResolveOrgContext"
+                ]
+            }
+        },
+        "/api/v0.3/claim/report": {
+            "get": {
+                "operationId": "get_api_v0_3_claim_report",
+                "tags": [
+                    "api:v0.3"
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK"
+                    }
+                },
+                "x-laravel-action": "App\\Http\\Controllers\\API\\V0_3\\ClaimController@report",
+                "x-laravel-middleware": [
+                    "api",
+                    "Illuminate\\Routing\\Middleware\\ThrottleRequests:api_public",
+                    "App\\Http\\Middleware\\NormalizeApiErrorContract"
+                ]
+            }
+        },
+        "/api/v0.3/compliance/dsar/requests": {
+            "post": {
+                "operationId": "post_api_v0_3_compliance_dsar_requests",
+                "tags": [
+                    "api:v0.3"
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK"
+                    }
+                },
+                "x-laravel-action": "App\\Http\\Controllers\\API\\V0_3\\ComplianceDsarController@store",
+                "x-laravel-middleware": [
+                    "api",
+                    "Illuminate\\Routing\\Middleware\\ThrottleRequests:api_public",
+                    "App\\Http\\Middleware\\NormalizeApiErrorContract",
+                    "App\\Http\\Middleware\\FmTokenAuth",
+                    "App\\Http\\Middleware\\ResolveOrgContext",
+                    "Illuminate\\Routing\\Middleware\\ThrottleRequests:api_auth"
+                ]
+            }
+        },
+        "/api/v0.3/compliance/dsar/requests/{id}": {
+            "get": {
+                "operationId": "get_api_v0_3_compliance_dsar_requests_id_",
+                "tags": [
+                    "api:v0.3"
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK"
+                    }
+                },
+                "x-laravel-action": "App\\Http\\Controllers\\API\\V0_3\\ComplianceDsarController@show",
+                "x-laravel-middleware": [
+                    "api",
+                    "Illuminate\\Routing\\Middleware\\ThrottleRequests:api_public",
+                    "App\\Http\\Middleware\\NormalizeApiErrorContract",
+                    "App\\Http\\Middleware\\FmTokenAuth",
+                    "App\\Http\\Middleware\\ResolveOrgContext",
+                    "App\\Http\\Middleware\\EnsureUuidRouteParams:id",
+                    "Illuminate\\Routing\\Middleware\\ThrottleRequests:api_auth"
+                ]
+            }
+        },
+        "/api/v0.3/compliance/dsar/requests/{id}/execute": {
+            "post": {
+                "operationId": "post_api_v0_3_compliance_dsar_requests_id_execute",
+                "tags": [
+                    "api:v0.3"
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK"
+                    }
+                },
+                "x-laravel-action": "App\\Http\\Controllers\\API\\V0_3\\ComplianceDsarController@execute",
+                "x-laravel-middleware": [
+                    "api",
+                    "Illuminate\\Routing\\Middleware\\ThrottleRequests:api_public",
+                    "App\\Http\\Middleware\\NormalizeApiErrorContract",
+                    "App\\Http\\Middleware\\FmTokenAuth",
+                    "App\\Http\\Middleware\\ResolveOrgContext",
+                    "App\\Http\\Middleware\\EnsureUuidRouteParams:id",
+                    "Illuminate\\Routing\\Middleware\\ThrottleRequests:api_auth"
+                ]
+            }
+        },
+        "/api/v0.3/experiments": {
+            "get": {
+                "operationId": "get_api_v0_3_experiments",
+                "tags": [
+                    "api:v0.3"
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK"
+                    }
+                },
+                "x-laravel-action": "App\\Http\\Controllers\\API\\V0_3\\BootController@experiments",
+                "x-laravel-middleware": [
+                    "api",
+                    "Illuminate\\Routing\\Middleware\\ThrottleRequests:api_public",
+                    "App\\Http\\Middleware\\NormalizeApiErrorContract",
+                    "App\\Http\\Middleware\\ResolveAnonId",
+                    "App\\Http\\Middleware\\ResolveOrgContext"
+                ]
+            }
+        },
+        "/api/v0.3/flags": {
+            "get": {
+                "operationId": "get_api_v0_3_flags",
+                "tags": [
+                    "api:v0.3"
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK"
+                    }
+                },
+                "x-laravel-action": "App\\Http\\Controllers\\API\\V0_3\\BootController@flags",
+                "x-laravel-middleware": [
+                    "api",
+                    "Illuminate\\Routing\\Middleware\\ThrottleRequests:api_public",
+                    "App\\Http\\Middleware\\NormalizeApiErrorContract",
+                    "App\\Http\\Middleware\\ResolveAnonId",
+                    "App\\Http\\Middleware\\ResolveOrgContext"
+                ]
+            }
+        },
+        "/api/v0.3/me/attempts": {
+            "get": {
+                "operationId": "get_api_v0_3_me_attempts",
+                "tags": [
+                    "api:v0.3"
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK"
+                    }
+                },
+                "x-laravel-action": "App\\Http\\Controllers\\API\\V0_3\\MeController@attempts",
+                "x-laravel-middleware": [
+                    "api",
+                    "Illuminate\\Routing\\Middleware\\ThrottleRequests:api_public",
+                    "App\\Http\\Middleware\\NormalizeApiErrorContract",
+                    "App\\Http\\Middleware\\FmTokenAuth"
+                ]
+            }
+        },
+        "/api/v0.3/orders": {
+            "post": {
+                "operationId": "post_api_v0_3_orders",
+                "tags": [
+                    "api:v0.3"
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK"
+                    }
+                },
+                "x-laravel-action": "App\\Http\\Controllers\\API\\V0_3\\CommerceController@createOrder",
+                "x-laravel-middleware": [
+                    "api",
+                    "Illuminate\\Routing\\Middleware\\ThrottleRequests:api_public",
+                    "App\\Http\\Middleware\\NormalizeApiErrorContract",
+                    "App\\Http\\Middleware\\ResolveAnonId",
+                    "App\\Http\\Middleware\\ResolveOrgContext",
+                    "App\\Http\\Middleware\\FmTokenAuth"
+                ]
+            }
+        },
+        "/api/v0.3/orders/checkout": {
+            "post": {
+                "operationId": "post_api_v0_3_orders_checkout",
+                "tags": [
+                    "api:v0.3"
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK"
+                    }
+                },
+                "x-laravel-action": "App\\Http\\Controllers\\API\\V0_3\\CommerceController@checkout",
+                "x-laravel-middleware": [
+                    "api",
+                    "Illuminate\\Routing\\Middleware\\ThrottleRequests:api_public",
+                    "App\\Http\\Middleware\\NormalizeApiErrorContract",
+                    "App\\Http\\Middleware\\ResolveAnonId",
+                    "App\\Http\\Middleware\\ResolveOrgContext",
+                    "App\\Http\\Middleware\\FmTokenOptional"
+                ]
+            }
+        },
+        "/api/v0.3/orders/lookup": {
+            "post": {
+                "operationId": "post_api_v0_3_orders_lookup",
+                "tags": [
+                    "api:v0.3"
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK"
+                    }
+                },
+                "x-laravel-action": "App\\Http\\Controllers\\API\\V0_3\\CommerceController@lookup",
+                "x-laravel-middleware": [
+                    "api",
+                    "Illuminate\\Routing\\Middleware\\ThrottleRequests:api_public",
+                    "App\\Http\\Middleware\\NormalizeApiErrorContract",
+                    "App\\Http\\Middleware\\ResolveAnonId",
+                    "App\\Http\\Middleware\\ResolveOrgContext",
+                    "App\\Http\\Middleware\\FmTokenOptional"
+                ]
+            }
+        },
+        "/api/v0.3/orders/stub": {
+            "post": {
+                "operationId": "post_api_v0_3_orders_stub",
+                "tags": [
+                    "api:v0.3"
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK"
+                    }
+                },
+                "x-laravel-action": "Closure",
+                "x-laravel-middleware": [
+                    "api",
+                    "Illuminate\\Routing\\Middleware\\ThrottleRequests:api_public",
+                    "App\\Http\\Middleware\\NormalizeApiErrorContract",
+                    "App\\Http\\Middleware\\ResolveAnonId",
+                    "App\\Http\\Middleware\\ResolveOrgContext"
+                ]
+            }
+        },
+        "/api/v0.3/orders/{order_no}": {
+            "get": {
+                "operationId": "get_api_v0_3_orders_order_no_",
+                "tags": [
+                    "api:v0.3"
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK"
+                    }
+                },
+                "x-laravel-action": "App\\Http\\Controllers\\API\\V0_3\\CommerceController@getOrder",
+                "x-laravel-middleware": [
+                    "api",
+                    "Illuminate\\Routing\\Middleware\\ThrottleRequests:api_public",
+                    "App\\Http\\Middleware\\NormalizeApiErrorContract",
+                    "App\\Http\\Middleware\\ResolveAnonId",
+                    "App\\Http\\Middleware\\ResolveOrgContext",
+                    "App\\Http\\Middleware\\FmTokenOptional"
+                ]
+            }
+        },
+        "/api/v0.3/orders/{order_no}/pay/alipay": {
+            "get": {
+                "operationId": "get_api_v0_3_orders_order_no_pay_alipay",
+                "tags": [
+                    "api:v0.3"
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK"
+                    }
+                },
+                "x-laravel-action": "App\\Http\\Controllers\\API\\V0_3\\CommerceController@launchAlipay",
+                "x-laravel-middleware": [
+                    "api",
+                    "Illuminate\\Routing\\Middleware\\ThrottleRequests:api_public",
+                    "App\\Http\\Middleware\\NormalizeApiErrorContract",
+                    "App\\Http\\Middleware\\ResolveAnonId",
+                    "App\\Http\\Middleware\\ResolveOrgContext",
+                    "App\\Http\\Middleware\\FmTokenOptional"
+                ]
+            }
+        },
+        "/api/v0.3/orders/{order_no}/resend": {
+            "post": {
+                "operationId": "post_api_v0_3_orders_order_no_resend",
+                "tags": [
+                    "api:v0.3"
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK"
+                    }
+                },
+                "x-laravel-action": "App\\Http\\Controllers\\API\\V0_3\\CommerceController@resend",
+                "x-laravel-middleware": [
+                    "api",
+                    "Illuminate\\Routing\\Middleware\\ThrottleRequests:api_public",
+                    "App\\Http\\Middleware\\NormalizeApiErrorContract",
+                    "App\\Http\\Middleware\\ResolveAnonId",
+                    "App\\Http\\Middleware\\ResolveOrgContext",
+                    "App\\Http\\Middleware\\FmTokenOptional"
+                ]
+            }
+        },
+        "/api/v0.3/orders/{provider}": {
+            "post": {
+                "operationId": "post_api_v0_3_orders_provider_",
+                "tags": [
+                    "api:v0.3"
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK"
+                    }
+                },
+                "x-laravel-action": "App\\Http\\Controllers\\API\\V0_3\\CommerceController@createOrder",
+                "x-laravel-middleware": [
+                    "api",
+                    "Illuminate\\Routing\\Middleware\\ThrottleRequests:api_public",
+                    "App\\Http\\Middleware\\NormalizeApiErrorContract",
+                    "App\\Http\\Middleware\\ResolveAnonId",
+                    "App\\Http\\Middleware\\ResolveOrgContext",
+                    "App\\Http\\Middleware\\FmTokenAuth"
+                ]
+            }
+        },
+        "/api/v0.3/orgs": {
+            "post": {
+                "operationId": "post_api_v0_3_orgs",
+                "tags": [
+                    "api:v0.3"
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK"
+                    }
+                },
+                "x-laravel-action": "App\\Http\\Controllers\\API\\V0_3\\OrgsController@store",
+                "x-laravel-middleware": [
+                    "api",
+                    "Illuminate\\Routing\\Middleware\\ThrottleRequests:api_public",
+                    "App\\Http\\Middleware\\NormalizeApiErrorContract",
+                    "App\\Http\\Middleware\\FmTokenAuth",
+                    "App\\Http\\Middleware\\ResolveOrgContext"
+                ]
+            }
+        },
+        "/api/v0.3/orgs/invites/accept": {
+            "post": {
+                "operationId": "post_api_v0_3_orgs_invites_accept",
+                "tags": [
+                    "api:v0.3"
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK"
+                    }
+                },
+                "x-laravel-action": "App\\Http\\Controllers\\API\\V0_3\\OrgInvitesController@accept",
+                "x-laravel-middleware": [
+                    "api",
+                    "Illuminate\\Routing\\Middleware\\ThrottleRequests:api_public",
+                    "App\\Http\\Middleware\\NormalizeApiErrorContract",
+                    "App\\Http\\Middleware\\FmTokenAuth",
+                    "App\\Http\\Middleware\\ResolveOrgContext"
+                ]
+            }
+        },
+        "/api/v0.3/orgs/me": {
+            "get": {
+                "operationId": "get_api_v0_3_orgs_me",
+                "tags": [
+                    "api:v0.3"
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK"
+                    }
+                },
+                "x-laravel-action": "App\\Http\\Controllers\\API\\V0_3\\OrgsController@me",
+                "x-laravel-middleware": [
+                    "api",
+                    "Illuminate\\Routing\\Middleware\\ThrottleRequests:api_public",
+                    "App\\Http\\Middleware\\NormalizeApiErrorContract",
+                    "App\\Http\\Middleware\\FmTokenAuth",
+                    "App\\Http\\Middleware\\ResolveOrgContext"
+                ]
+            }
+        },
+        "/api/v0.3/orgs/{org_id}/big5/audits": {
+            "get": {
+                "operationId": "get_api_v0_3_orgs_org_id_big5_audits",
+                "tags": [
+                    "api:v0.3"
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK"
+                    }
+                },
+                "x-laravel-action": "App\\Http\\Controllers\\API\\V0_3\\BigFiveOpsController@audits",
+                "x-laravel-middleware": [
+                    "api",
+                    "Illuminate\\Routing\\Middleware\\ThrottleRequests:api_public",
+                    "App\\Http\\Middleware\\NormalizeApiErrorContract",
+                    "App\\Http\\Middleware\\FmTokenAuth",
+                    "App\\Http\\Middleware\\ResolveOrgContext",
+                    "App\\Http\\Middleware\\RequireOrgRole:owner,admin"
+                ]
+            }
+        },
+        "/api/v0.3/orgs/{org_id}/big5/audits/{audit_id}": {
+            "get": {
+                "operationId": "get_api_v0_3_orgs_org_id_big5_audits_audit_id_",
+                "tags": [
+                    "api:v0.3"
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK"
+                    }
+                },
+                "x-laravel-action": "App\\Http\\Controllers\\API\\V0_3\\BigFiveOpsController@audit",
+                "x-laravel-middleware": [
+                    "api",
+                    "Illuminate\\Routing\\Middleware\\ThrottleRequests:api_public",
+                    "App\\Http\\Middleware\\NormalizeApiErrorContract",
+                    "App\\Http\\Middleware\\FmTokenAuth",
+                    "App\\Http\\Middleware\\ResolveOrgContext",
+                    "App\\Http\\Middleware\\RequireOrgRole:owner,admin"
+                ]
+            }
+        },
+        "/api/v0.3/orgs/{org_id}/big5/norms/activate": {
+            "post": {
+                "operationId": "post_api_v0_3_orgs_org_id_big5_norms_activate",
+                "tags": [
+                    "api:v0.3"
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK"
+                    }
+                },
+                "x-laravel-action": "App\\Http\\Controllers\\API\\V0_3\\BigFiveOpsController@activateNorms",
+                "x-laravel-middleware": [
+                    "api",
+                    "Illuminate\\Routing\\Middleware\\ThrottleRequests:api_public",
+                    "App\\Http\\Middleware\\NormalizeApiErrorContract",
+                    "App\\Http\\Middleware\\FmTokenAuth",
+                    "App\\Http\\Middleware\\ResolveOrgContext",
+                    "App\\Http\\Middleware\\RequireOrgRole:owner,admin"
+                ]
+            }
+        },
+        "/api/v0.3/orgs/{org_id}/big5/norms/drift-check": {
+            "post": {
+                "operationId": "post_api_v0_3_orgs_org_id_big5_norms_drift_check",
+                "tags": [
+                    "api:v0.3"
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK"
+                    }
+                },
+                "x-laravel-action": "App\\Http\\Controllers\\API\\V0_3\\BigFiveOpsController@driftCheckNorms",
+                "x-laravel-middleware": [
+                    "api",
+                    "Illuminate\\Routing\\Middleware\\ThrottleRequests:api_public",
+                    "App\\Http\\Middleware\\NormalizeApiErrorContract",
+                    "App\\Http\\Middleware\\FmTokenAuth",
+                    "App\\Http\\Middleware\\ResolveOrgContext",
+                    "App\\Http\\Middleware\\RequireOrgRole:owner,admin"
+                ]
+            }
+        },
+        "/api/v0.3/orgs/{org_id}/big5/norms/rebuild": {
+            "post": {
+                "operationId": "post_api_v0_3_orgs_org_id_big5_norms_rebuild",
+                "tags": [
+                    "api:v0.3"
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK"
+                    }
+                },
+                "x-laravel-action": "App\\Http\\Controllers\\API\\V0_3\\BigFiveOpsController@rebuildNorms",
+                "x-laravel-middleware": [
+                    "api",
+                    "Illuminate\\Routing\\Middleware\\ThrottleRequests:api_public",
+                    "App\\Http\\Middleware\\NormalizeApiErrorContract",
+                    "App\\Http\\Middleware\\FmTokenAuth",
+                    "App\\Http\\Middleware\\ResolveOrgContext",
+                    "App\\Http\\Middleware\\RequireOrgRole:owner,admin"
+                ]
+            }
+        },
+        "/api/v0.3/orgs/{org_id}/big5/releases": {
+            "get": {
+                "operationId": "get_api_v0_3_orgs_org_id_big5_releases",
+                "tags": [
+                    "api:v0.3"
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK"
+                    }
+                },
+                "x-laravel-action": "App\\Http\\Controllers\\API\\V0_3\\BigFiveOpsController@releases",
+                "x-laravel-middleware": [
+                    "api",
+                    "Illuminate\\Routing\\Middleware\\ThrottleRequests:api_public",
+                    "App\\Http\\Middleware\\NormalizeApiErrorContract",
+                    "App\\Http\\Middleware\\FmTokenAuth",
+                    "App\\Http\\Middleware\\ResolveOrgContext",
+                    "App\\Http\\Middleware\\RequireOrgRole:owner,admin"
+                ]
+            }
+        },
+        "/api/v0.3/orgs/{org_id}/big5/releases/latest": {
+            "get": {
+                "operationId": "get_api_v0_3_orgs_org_id_big5_releases_latest",
+                "tags": [
+                    "api:v0.3"
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK"
+                    }
+                },
+                "x-laravel-action": "App\\Http\\Controllers\\API\\V0_3\\BigFiveOpsController@latest",
+                "x-laravel-middleware": [
+                    "api",
+                    "Illuminate\\Routing\\Middleware\\ThrottleRequests:api_public",
+                    "App\\Http\\Middleware\\NormalizeApiErrorContract",
+                    "App\\Http\\Middleware\\FmTokenAuth",
+                    "App\\Http\\Middleware\\ResolveOrgContext",
+                    "App\\Http\\Middleware\\RequireOrgRole:owner,admin"
+                ]
+            }
+        },
+        "/api/v0.3/orgs/{org_id}/big5/releases/latest/audits": {
+            "get": {
+                "operationId": "get_api_v0_3_orgs_org_id_big5_releases_latest_audits",
+                "tags": [
+                    "api:v0.3"
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK"
+                    }
+                },
+                "x-laravel-action": "App\\Http\\Controllers\\API\\V0_3\\BigFiveOpsController@latestAudits",
+                "x-laravel-middleware": [
+                    "api",
+                    "Illuminate\\Routing\\Middleware\\ThrottleRequests:api_public",
+                    "App\\Http\\Middleware\\NormalizeApiErrorContract",
+                    "App\\Http\\Middleware\\FmTokenAuth",
+                    "App\\Http\\Middleware\\ResolveOrgContext",
+                    "App\\Http\\Middleware\\RequireOrgRole:owner,admin"
+                ]
+            }
+        },
+        "/api/v0.3/orgs/{org_id}/big5/releases/publish": {
+            "post": {
+                "operationId": "post_api_v0_3_orgs_org_id_big5_releases_publish",
+                "tags": [
+                    "api:v0.3"
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK"
+                    }
+                },
+                "x-laravel-action": "App\\Http\\Controllers\\API\\V0_3\\BigFiveOpsController@publish",
+                "x-laravel-middleware": [
+                    "api",
+                    "Illuminate\\Routing\\Middleware\\ThrottleRequests:api_public",
+                    "App\\Http\\Middleware\\NormalizeApiErrorContract",
+                    "App\\Http\\Middleware\\FmTokenAuth",
+                    "App\\Http\\Middleware\\ResolveOrgContext",
+                    "App\\Http\\Middleware\\RequireOrgRole:owner,admin"
+                ]
+            }
+        },
+        "/api/v0.3/orgs/{org_id}/big5/releases/rollback": {
+            "post": {
+                "operationId": "post_api_v0_3_orgs_org_id_big5_releases_rollback",
+                "tags": [
+                    "api:v0.3"
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK"
+                    }
+                },
+                "x-laravel-action": "App\\Http\\Controllers\\API\\V0_3\\BigFiveOpsController@rollback",
+                "x-laravel-middleware": [
+                    "api",
+                    "Illuminate\\Routing\\Middleware\\ThrottleRequests:api_public",
+                    "App\\Http\\Middleware\\NormalizeApiErrorContract",
+                    "App\\Http\\Middleware\\FmTokenAuth",
+                    "App\\Http\\Middleware\\ResolveOrgContext",
+                    "App\\Http\\Middleware\\RequireOrgRole:owner,admin"
+                ]
+            }
+        },
+        "/api/v0.3/orgs/{org_id}/big5/releases/{release_id}": {
+            "get": {
+                "operationId": "get_api_v0_3_orgs_org_id_big5_releases_release_id_",
+                "tags": [
+                    "api:v0.3"
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK"
+                    }
+                },
+                "x-laravel-action": "App\\Http\\Controllers\\API\\V0_3\\BigFiveOpsController@release",
+                "x-laravel-middleware": [
+                    "api",
+                    "Illuminate\\Routing\\Middleware\\ThrottleRequests:api_public",
+                    "App\\Http\\Middleware\\NormalizeApiErrorContract",
+                    "App\\Http\\Middleware\\FmTokenAuth",
+                    "App\\Http\\Middleware\\ResolveOrgContext",
+                    "App\\Http\\Middleware\\RequireOrgRole:owner,admin"
+                ]
+            }
+        },
+        "/api/v0.3/orgs/{org_id}/invites": {
+            "post": {
+                "operationId": "post_api_v0_3_orgs_org_id_invites",
+                "tags": [
+                    "api:v0.3"
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK"
+                    }
+                },
+                "x-laravel-action": "App\\Http\\Controllers\\API\\V0_3\\OrgInvitesController@store",
+                "x-laravel-middleware": [
+                    "api",
+                    "Illuminate\\Routing\\Middleware\\ThrottleRequests:api_public",
+                    "App\\Http\\Middleware\\NormalizeApiErrorContract",
+                    "App\\Http\\Middleware\\FmTokenAuth",
+                    "App\\Http\\Middleware\\ResolveOrgContext"
+                ]
+            }
+        },
+        "/api/v0.3/orgs/{org_id}/wallets": {
+            "get": {
+                "operationId": "get_api_v0_3_orgs_org_id_wallets",
+                "tags": [
+                    "api:v0.3"
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK"
+                    }
+                },
+                "x-laravel-action": "App\\Http\\Controllers\\API\\V0_3\\OrgWalletController@wallets",
+                "x-laravel-middleware": [
+                    "api",
+                    "Illuminate\\Routing\\Middleware\\ThrottleRequests:api_public",
+                    "App\\Http\\Middleware\\NormalizeApiErrorContract",
+                    "App\\Http\\Middleware\\FmTokenAuth",
+                    "App\\Http\\Middleware\\ResolveOrgContext"
+                ]
+            }
+        },
+        "/api/v0.3/orgs/{org_id}/wallets/{benefit_code}/ledger": {
+            "get": {
+                "operationId": "get_api_v0_3_orgs_org_id_wallets_benefit_code_ledger",
+                "tags": [
+                    "api:v0.3"
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK"
+                    }
+                },
+                "x-laravel-action": "App\\Http\\Controllers\\API\\V0_3\\OrgWalletController@ledger",
+                "x-laravel-middleware": [
+                    "api",
+                    "Illuminate\\Routing\\Middleware\\ThrottleRequests:api_public",
+                    "App\\Http\\Middleware\\NormalizeApiErrorContract",
+                    "App\\Http\\Middleware\\FmTokenAuth",
+                    "App\\Http\\Middleware\\ResolveOrgContext"
+                ]
+            }
+        },
+        "/api/v0.3/scales": {
+            "get": {
+                "operationId": "get_api_v0_3_scales",
+                "tags": [
+                    "api:v0.3"
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK"
+                    }
+                },
+                "x-laravel-action": "App\\Http\\Controllers\\API\\V0_3\\ScalesController@index",
+                "x-laravel-middleware": [
+                    "api",
+                    "Illuminate\\Routing\\Middleware\\ThrottleRequests:api_public",
+                    "App\\Http\\Middleware\\NormalizeApiErrorContract",
+                    "App\\Http\\Middleware\\ResolveAnonId",
+                    "App\\Http\\Middleware\\ResolveOrgContext"
+                ]
+            }
+        },
+        "/api/v0.3/scales/lookup": {
+            "get": {
+                "operationId": "get_api_v0_3_scales_lookup",
+                "tags": [
+                    "api:v0.3"
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK"
+                    }
+                },
+                "x-laravel-action": "App\\Http\\Controllers\\API\\V0_3\\ScalesLookupController@lookup",
+                "x-laravel-middleware": [
+                    "api",
+                    "Illuminate\\Routing\\Middleware\\ThrottleRequests:api_public",
+                    "App\\Http\\Middleware\\NormalizeApiErrorContract",
+                    "App\\Http\\Middleware\\ResolveAnonId",
+                    "App\\Http\\Middleware\\ResolveOrgContext"
+                ]
+            }
+        },
+        "/api/v0.3/scales/sitemap-source": {
+            "get": {
+                "operationId": "get_api_v0_3_scales_sitemap_source",
+                "tags": [
+                    "api:v0.3"
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK"
+                    }
+                },
+                "x-laravel-action": "App\\Http\\Controllers\\API\\V0_3\\ScalesSitemapSourceController@index",
+                "x-laravel-middleware": [
+                    "api",
+                    "Illuminate\\Routing\\Middleware\\ThrottleRequests:api_public",
+                    "App\\Http\\Middleware\\NormalizeApiErrorContract",
+                    "App\\Http\\Middleware\\ResolveAnonId",
+                    "App\\Http\\Middleware\\ResolveOrgContext"
+                ]
+            }
+        },
+        "/api/v0.3/scales/{scale_code}": {
+            "get": {
+                "operationId": "get_api_v0_3_scales_scale_code_",
+                "tags": [
+                    "api:v0.3"
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK"
+                    }
+                },
+                "x-laravel-action": "App\\Http\\Controllers\\API\\V0_3\\ScalesController@show",
+                "x-laravel-middleware": [
+                    "api",
+                    "Illuminate\\Routing\\Middleware\\ThrottleRequests:api_public",
+                    "App\\Http\\Middleware\\NormalizeApiErrorContract",
+                    "App\\Http\\Middleware\\ResolveAnonId",
+                    "App\\Http\\Middleware\\ResolveOrgContext"
+                ]
+            }
+        },
+        "/api/v0.3/scales/{scale_code}/questions": {
+            "get": {
+                "operationId": "get_api_v0_3_scales_scale_code_questions",
+                "tags": [
+                    "api:v0.3"
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK"
+                    }
+                },
+                "x-laravel-action": "App\\Http\\Controllers\\API\\V0_3\\ScalesController@questions",
+                "x-laravel-middleware": [
+                    "api",
+                    "Illuminate\\Routing\\Middleware\\ThrottleRequests:api_public",
+                    "App\\Http\\Middleware\\NormalizeApiErrorContract",
+                    "App\\Http\\Middleware\\ResolveAnonId",
+                    "App\\Http\\Middleware\\ResolveOrgContext"
+                ]
+            }
+        },
+        "/api/v0.3/shares/{id}": {
+            "get": {
+                "operationId": "get_api_v0_3_shares_id_",
+                "tags": [
+                    "api:v0.3"
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK"
+                    }
+                },
+                "x-laravel-action": "App\\Http\\Controllers\\API\\V0_3\\ShareController@getShareView",
+                "x-laravel-middleware": [
+                    "api",
+                    "Illuminate\\Routing\\Middleware\\ThrottleRequests:api_public",
+                    "App\\Http\\Middleware\\NormalizeApiErrorContract",
+                    "App\\Http\\Middleware\\ResolveAnonId",
+                    "App\\Http\\Middleware\\ResolveOrgContext"
+                ]
+            }
+        },
+        "/api/v0.3/shares/{shareId}/click": {
+            "post": {
+                "operationId": "post_api_v0_3_shares_shareid_click",
+                "tags": [
+                    "api:v0.3"
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK"
+                    }
+                },
+                "x-laravel-action": "App\\Http\\Controllers\\API\\V0_3\\ShareController@click",
+                "x-laravel-middleware": [
+                    "api",
+                    "Illuminate\\Routing\\Middleware\\ThrottleRequests:api_public",
+                    "App\\Http\\Middleware\\NormalizeApiErrorContract",
+                    "App\\Http\\Middleware\\ResolveAnonId",
+                    "App\\Http\\Middleware\\ResolveOrgContext",
+                    "App\\Http\\Middleware\\FmTokenOptional",
+                    "App\\Http\\Middleware\\LimitApiPublicPayloadSize"
+                ]
+            }
+        },
+        "/api/v0.3/skus": {
+            "get": {
+                "operationId": "api.v0_3.skus",
+                "tags": [
+                    "api:v0.3"
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK"
+                    }
+                },
+                "x-laravel-action": "App\\Http\\Controllers\\API\\V0_3\\CommerceController@listSkus",
+                "x-laravel-middleware": [
+                    "api",
+                    "Illuminate\\Routing\\Middleware\\ThrottleRequests:api_public",
+                    "App\\Http\\Middleware\\NormalizeApiErrorContract",
+                    "App\\Http\\Middleware\\ResolveAnonId",
+                    "App\\Http\\Middleware\\ResolveOrgContext"
+                ],
+                "x-laravel-name": "api.v0_3.skus"
+            }
+        },
+        "/api/v0.3/webhooks/payment/{provider}": {
+            "post": {
+                "operationId": "api.v0_3.webhooks.payment",
+                "tags": [
+                    "api:v0.3"
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK"
+                    }
+                },
+                "x-laravel-action": "App\\Http\\Controllers\\API\\V0_3\\Webhooks\\PaymentWebhookController@handle",
+                "x-laravel-middleware": [
+                    "api",
+                    "Illuminate\\Routing\\Middleware\\ThrottleRequests:api_public",
+                    "App\\Http\\Middleware\\NormalizeApiErrorContract",
+                    "App\\Http\\Middleware\\LimitWebhookPayloadSize",
+                    "Illuminate\\Routing\\Middleware\\ThrottleRequests:api_webhook"
+                ],
+                "x-laravel-name": "api.v0_3.webhooks.payment"
+            }
+        },
+        "/api/v0.4/boot": {
+            "get": {
+                "operationId": "get_api_v0_4_boot",
+                "tags": [
+                    "api:v0.4"
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK"
+                    }
+                },
+                "x-laravel-action": "App\\Http\\Controllers\\API\\V0_4\\BootController@show",
+                "x-laravel-middleware": [
+                    "api",
+                    "App\\Http\\Middleware\\NormalizeApiErrorContract",
+                    "Illuminate\\Routing\\Middleware\\ThrottleRequests:api_public"
+                ]
+            }
+        },
+        "/api/v0.4/orgs/{org_id}/assessments": {
+            "post": {
+                "operationId": "post_api_v0_4_orgs_org_id_assessments",
+                "tags": [
+                    "api:v0.4"
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK"
+                    }
+                },
+                "x-laravel-action": "App\\Http\\Controllers\\API\\V0_4\\AssessmentController@store",
+                "x-laravel-middleware": [
+                    "api",
+                    "App\\Http\\Middleware\\NormalizeApiErrorContract",
+                    "App\\Http\\Middleware\\FmTokenAuth",
+                    "App\\Http\\Middleware\\RequireOrgRole:owner,admin"
+                ]
+            }
+        },
+        "/api/v0.4/orgs/{org_id}/assessments/{id}/invite": {
+            "post": {
+                "operationId": "post_api_v0_4_orgs_org_id_assessments_id_invite",
+                "tags": [
+                    "api:v0.4"
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK"
+                    }
+                },
+                "x-laravel-action": "App\\Http\\Controllers\\API\\V0_4\\AssessmentController@invite",
+                "x-laravel-middleware": [
+                    "api",
+                    "App\\Http\\Middleware\\NormalizeApiErrorContract",
+                    "App\\Http\\Middleware\\FmTokenAuth",
+                    "App\\Http\\Middleware\\RequireOrgRole:owner,admin"
+                ]
+            }
+        },
+        "/api/v0.4/orgs/{org_id}/assessments/{id}/progress": {
+            "get": {
+                "operationId": "get_api_v0_4_orgs_org_id_assessments_id_progress",
+                "tags": [
+                    "api:v0.4"
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK"
+                    }
+                },
+                "x-laravel-action": "App\\Http\\Controllers\\API\\V0_4\\AssessmentController@progress",
+                "x-laravel-middleware": [
+                    "api",
+                    "App\\Http\\Middleware\\NormalizeApiErrorContract",
+                    "App\\Http\\Middleware\\FmTokenAuth",
+                    "App\\Http\\Middleware\\RequireOrgRole:owner,admin"
+                ]
+            }
+        },
+        "/api/v0.4/orgs/{org_id}/assessments/{id}/summary": {
+            "get": {
+                "operationId": "get_api_v0_4_orgs_org_id_assessments_id_summary",
+                "tags": [
+                    "api:v0.4"
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK"
+                    }
+                },
+                "x-laravel-action": "App\\Http\\Controllers\\API\\V0_4\\AssessmentController@summary",
+                "x-laravel-middleware": [
+                    "api",
+                    "App\\Http\\Middleware\\NormalizeApiErrorContract",
+                    "App\\Http\\Middleware\\FmTokenAuth",
+                    "App\\Http\\Middleware\\RequireOrgRole:owner,admin"
+                ]
+            }
+        },
+        "/api/v0.4/orgs/{org_id}/compliance/rotation/audits": {
+            "get": {
+                "operationId": "get_api_v0_4_orgs_org_id_compliance_rotation_audits",
+                "tags": [
+                    "api:v0.4"
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK"
+                    }
+                },
+                "x-laravel-action": "App\\Http\\Controllers\\API\\V0_4\\RotationAuditController@index",
+                "x-laravel-middleware": [
+                    "api",
+                    "App\\Http\\Middleware\\NormalizeApiErrorContract",
+                    "App\\Http\\Middleware\\FmTokenAuth",
+                    "App\\Http\\Middleware\\RequireOrgRole:owner,admin"
+                ]
+            }
+        },
+        "/api/v0.4/orgs/{org_id}/compliance/rotation/audits/{id}": {
+            "get": {
+                "operationId": "get_api_v0_4_orgs_org_id_compliance_rotation_audits_id_",
+                "tags": [
+                    "api:v0.4"
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK"
+                    }
+                },
+                "x-laravel-action": "App\\Http\\Controllers\\API\\V0_4\\RotationAuditController@show",
+                "x-laravel-middleware": [
+                    "api",
+                    "App\\Http\\Middleware\\NormalizeApiErrorContract",
+                    "App\\Http\\Middleware\\FmTokenAuth",
+                    "App\\Http\\Middleware\\RequireOrgRole:owner,admin",
+                    "App\\Http\\Middleware\\EnsureUuidRouteParams:id"
+                ]
+            }
+        },
+        "/api/v0.4/orgs/{org_id}/experiments/rollouts/{rollout_id}/approve": {
+            "post": {
+                "operationId": "post_api_v0_4_orgs_org_id_experiments_rollouts_rollout_id_approve",
+                "tags": [
+                    "api:v0.4"
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK"
+                    }
+                },
+                "x-laravel-action": "App\\Http\\Controllers\\API\\V0_4\\ExperimentGovernanceController@approve",
+                "x-laravel-middleware": [
+                    "api",
+                    "App\\Http\\Middleware\\NormalizeApiErrorContract",
+                    "App\\Http\\Middleware\\FmTokenAuth",
+                    "App\\Http\\Middleware\\RequireOrgRole:owner,admin",
+                    "App\\Http\\Middleware\\EnsureUuidRouteParams:rollout_id"
+                ]
+            }
+        },
+        "/api/v0.4/orgs/{org_id}/experiments/rollouts/{rollout_id}/guardrails": {
+            "put": {
+                "operationId": "put_api_v0_4_orgs_org_id_experiments_rollouts_rollout_id_guardrails",
+                "tags": [
+                    "api:v0.4"
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK"
+                    }
+                },
+                "x-laravel-action": "App\\Http\\Controllers\\API\\V0_4\\ExperimentGovernanceController@upsertGuardrail",
+                "x-laravel-middleware": [
+                    "api",
+                    "App\\Http\\Middleware\\NormalizeApiErrorContract",
+                    "App\\Http\\Middleware\\FmTokenAuth",
+                    "App\\Http\\Middleware\\RequireOrgRole:owner,admin",
+                    "App\\Http\\Middleware\\EnsureUuidRouteParams:rollout_id"
+                ]
+            }
+        },
+        "/api/v0.4/orgs/{org_id}/experiments/rollouts/{rollout_id}/guardrails/evaluate": {
+            "post": {
+                "operationId": "post_api_v0_4_orgs_org_id_experiments_rollouts_rollout_id_guardrails_evaluate",
+                "tags": [
+                    "api:v0.4"
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK"
+                    }
+                },
+                "x-laravel-action": "App\\Http\\Controllers\\API\\V0_4\\ExperimentGovernanceController@evaluateGuardrails",
+                "x-laravel-middleware": [
+                    "api",
+                    "App\\Http\\Middleware\\NormalizeApiErrorContract",
+                    "App\\Http\\Middleware\\FmTokenAuth",
+                    "App\\Http\\Middleware\\RequireOrgRole:owner,admin",
+                    "App\\Http\\Middleware\\EnsureUuidRouteParams:rollout_id"
+                ]
+            }
+        },
+        "/api/v0.4/orgs/{org_id}/experiments/rollouts/{rollout_id}/pause": {
+            "post": {
+                "operationId": "post_api_v0_4_orgs_org_id_experiments_rollouts_rollout_id_pause",
+                "tags": [
+                    "api:v0.4"
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK"
+                    }
+                },
+                "x-laravel-action": "App\\Http\\Controllers\\API\\V0_4\\ExperimentGovernanceController@pause",
+                "x-laravel-middleware": [
+                    "api",
+                    "App\\Http\\Middleware\\NormalizeApiErrorContract",
+                    "App\\Http\\Middleware\\FmTokenAuth",
+                    "App\\Http\\Middleware\\RequireOrgRole:owner,admin",
+                    "App\\Http\\Middleware\\EnsureUuidRouteParams:rollout_id"
+                ]
+            }
+        },
+        "/api/v0.4/orgs/{org_id}/experiments/rollouts/{rollout_id}/rollback": {
+            "post": {
+                "operationId": "post_api_v0_4_orgs_org_id_experiments_rollouts_rollout_id_rollback",
+                "tags": [
+                    "api:v0.4"
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK"
+                    }
+                },
+                "x-laravel-action": "App\\Http\\Controllers\\API\\V0_4\\ExperimentGovernanceController@rollback",
+                "x-laravel-middleware": [
+                    "api",
+                    "App\\Http\\Middleware\\NormalizeApiErrorContract",
+                    "App\\Http\\Middleware\\FmTokenAuth",
+                    "App\\Http\\Middleware\\RequireOrgRole:owner,admin",
+                    "App\\Http\\Middleware\\EnsureUuidRouteParams:rollout_id"
+                ]
+            }
+        },
+        "/api/v0.4/partners/sessions": {
+            "post": {
+                "operationId": "post_api_v0_4_partners_sessions",
+                "tags": [
+                    "api:v0.4"
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK"
+                    }
+                },
+                "x-laravel-action": "App\\Http\\Controllers\\API\\V0_4\\PartnerController@createSession",
+                "x-laravel-middleware": [
+                    "api",
+                    "App\\Http\\Middleware\\NormalizeApiErrorContract",
+                    "Illuminate\\Routing\\Middleware\\ThrottleRequests:api_public",
+                    "App\\Http\\Middleware\\PartnerApiKeyAuth"
+                ]
+            }
+        },
+        "/api/v0.4/partners/sessions/{attempt_id}/status": {
+            "get": {
+                "operationId": "get_api_v0_4_partners_sessions_attempt_id_status",
+                "tags": [
+                    "api:v0.4"
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK"
+                    }
+                },
+                "x-laravel-action": "App\\Http\\Controllers\\API\\V0_4\\PartnerController@status",
+                "x-laravel-middleware": [
+                    "api",
+                    "App\\Http\\Middleware\\NormalizeApiErrorContract",
+                    "Illuminate\\Routing\\Middleware\\ThrottleRequests:api_public",
+                    "App\\Http\\Middleware\\PartnerApiKeyAuth",
+                    "App\\Http\\Middleware\\EnsureUuidRouteParams:attempt_id"
+                ]
+            }
+        },
+        "/api/v0.4/partners/webhooks/sign": {
+            "post": {
+                "operationId": "post_api_v0_4_partners_webhooks_sign",
+                "tags": [
+                    "api:v0.4"
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK"
+                    }
+                },
+                "x-laravel-action": "App\\Http\\Controllers\\API\\V0_4\\PartnerController@signWebhook",
+                "x-laravel-middleware": [
+                    "api",
+                    "App\\Http\\Middleware\\NormalizeApiErrorContract",
+                    "Illuminate\\Routing\\Middleware\\ThrottleRequests:api_public",
+                    "App\\Http\\Middleware\\PartnerApiKeyAuth"
+                ]
+            }
+        }
+    }
+}

--- a/backend/scripts/ci_verify_mbti.sh
+++ b/backend/scripts/ci_verify_mbti.sh
@@ -66,6 +66,8 @@ RUN_SCALE_IDENTITY_GATE="${RUN_SCALE_IDENTITY_GATE:-0}"
 RUN_SCALE_IDENTITY_CONTRACT="${RUN_SCALE_IDENTITY_CONTRACT:-0}"
 RUN_PARTNER_API_SMOKE="${RUN_PARTNER_API_SMOKE:-1}"
 RUN_EXPERIMENT_GOVERNANCE_GATE="${RUN_EXPERIMENT_GOVERNANCE_GATE:-0}"
+RUN_OPENAPI_DIFF_GATE="${RUN_OPENAPI_DIFF_GATE:-1}"
+OPENAPI_DIFF_ALLOW_DRIFT="${OPENAPI_DIFF_ALLOW_DRIFT:-0}"
 if [[ "$RUN_FULL_SCALE_REGRESSION" == "1" && "$RUN_SCALE_IDENTITY_CONTRACT" != "1" ]]; then
   RUN_SCALE_IDENTITY_CONTRACT="1"
 fi
@@ -102,7 +104,7 @@ restore_hard_cutover_env() {
   if [[ "$PREV_FAP_CONTENT_PUBLISH_MODE" == "__UNSET__" ]]; then unset FAP_CONTENT_PUBLISH_MODE; else export FAP_CONTENT_PUBLISH_MODE="$PREV_FAP_CONTENT_PUBLISH_MODE"; fi
 }
 SCALE_SCOPE="${SCALE_SCOPE:-mbti_only}"
-echo "[CI] scale_scope=${SCALE_SCOPE} run_big5_ocean_gate=${RUN_BIG5_OCEAN_GATE} run_clinical_combo_68_gate=${RUN_CLINICAL_COMBO_68_GATE} run_sds_20_gate=${RUN_SDS_20_GATE} run_eq_60_gate=${RUN_EQ_60_GATE} run_sds_norms_gate=${RUN_SDS_NORMS_GATE} run_full_scale_regression=${RUN_FULL_SCALE_REGRESSION} run_scale_identity_gate=${RUN_SCALE_IDENTITY_GATE} run_scale_identity_contract=${RUN_SCALE_IDENTITY_CONTRACT} run_scale_identity_hard_cutover=${RUN_SCALE_IDENTITY_HARD_CUTOVER} run_partner_api_smoke=${RUN_PARTNER_API_SMOKE} run_experiment_governance_gate=${RUN_EXPERIMENT_GOVERNANCE_GATE}"
+echo "[CI] scale_scope=${SCALE_SCOPE} run_big5_ocean_gate=${RUN_BIG5_OCEAN_GATE} run_clinical_combo_68_gate=${RUN_CLINICAL_COMBO_68_GATE} run_sds_20_gate=${RUN_SDS_20_GATE} run_eq_60_gate=${RUN_EQ_60_GATE} run_sds_norms_gate=${RUN_SDS_NORMS_GATE} run_full_scale_regression=${RUN_FULL_SCALE_REGRESSION} run_scale_identity_gate=${RUN_SCALE_IDENTITY_GATE} run_scale_identity_contract=${RUN_SCALE_IDENTITY_CONTRACT} run_scale_identity_hard_cutover=${RUN_SCALE_IDENTITY_HARD_CUTOVER} run_partner_api_smoke=${RUN_PARTNER_API_SMOKE} run_experiment_governance_gate=${RUN_EXPERIMENT_GOVERNANCE_GATE} run_openapi_diff_gate=${RUN_OPENAPI_DIFF_GATE} openapi_diff_allow_drift=${OPENAPI_DIFF_ALLOW_DRIFT}"
 if [[ "$RUN_BIG5_OCEAN_GATE" == "1" ]]; then
   echo "[CI] running BIG5_OCEAN content gates"
   bash "$BACKEND_DIR/scripts/ci/verify_big5_norms.sh"
@@ -1086,6 +1088,26 @@ echo "[CI] migration safety gates OK"
 echo "[CI] auth guest contract gate"
 bash scripts/verify_auth_guest_contract.sh
 echo "[CI] auth guest contract gate OK"
+
+if [[ "$RUN_OPENAPI_DIFF_GATE" == "1" ]]; then
+  echo "[CI] openapi diff gate"
+
+  if [[ "$OPENAPI_DIFF_ALLOW_DRIFT" == "1" ]]; then
+    if bash scripts/export_openapi.sh --check; then
+      echo "[CI] openapi diff snapshot check OK (override mode)"
+    else
+      echo "[CI][WARN] openapi drift detected but OPENAPI_DIFF_ALLOW_DRIFT=1 (non-blocking)"
+    fi
+    OPENAPI_DIFF_ALLOW_DRIFT=1 php artisan test --filter OpenApiDiffTest
+  else
+    bash scripts/export_openapi.sh --check
+    OPENAPI_DIFF_ALLOW_DRIFT=0 php artisan test --filter OpenApiDiffTest
+  fi
+
+  echo "[CI] openapi diff gate OK"
+else
+  echo "[CI] openapi diff gate skipped (RUN_OPENAPI_DIFF_GATE=0)"
+fi
 
 echo "[CI] order security gate"
 bash scripts/verify_order_security.sh

--- a/backend/scripts/export_openapi.sh
+++ b/backend/scripts/export_openapi.sh
@@ -1,0 +1,155 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+BACKEND_DIR="$(cd "${SCRIPT_DIR}/.." && pwd)"
+REPO_DIR="$(cd "${BACKEND_DIR}/.." && pwd)"
+CALLER_DIR="$(pwd)"
+DEFAULT_OUTPUT="${BACKEND_DIR}/docs/contracts/openapi.snapshot.json"
+
+MODE="write"
+OUTPUT_PATH="${DEFAULT_OUTPUT}"
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --check) MODE="check"; shift ;;
+    --stdout) MODE="stdout"; shift ;;
+    --output)
+      if [[ $# -lt 2 ]]; then
+        echo "[openapi][FAIL] --output requires a path argument" >&2
+        exit 2
+      fi
+      OUTPUT_PATH="$2"
+      shift 2
+      ;;
+    *)
+      echo "[openapi][FAIL] unknown arg: $1" >&2
+      exit 2
+      ;;
+  esac
+done
+
+if [[ "${OUTPUT_PATH}" != /* ]]; then
+  OUTPUT_PATH="${CALLER_DIR}/${OUTPUT_PATH}"
+fi
+
+TMP_RAW="$(mktemp)"
+TMP_CANON="$(mktemp)"
+
+cleanup() {
+  rm -f "$TMP_RAW" "$TMP_CANON"
+}
+
+trap cleanup EXIT
+
+cd "${BACKEND_DIR}"
+APP_ENV="${APP_ENV:-testing}" PAYMENTS_ALLOW_STUB="${PAYMENTS_ALLOW_STUB:-true}" php artisan route:list --json >"${TMP_RAW}"
+
+php -r '
+$rawPath = $argv[1] ?? "";
+$outPath = $argv[2] ?? "";
+$raw = json_decode((string) file_get_contents($rawPath), true);
+if (!is_array($raw)) {
+    fwrite(STDERR, "[openapi][FAIL] invalid route:list json\n");
+    exit(1);
+}
+
+$paths = [];
+foreach ($raw as $row) {
+    if (!is_array($row)) {
+        continue;
+    }
+
+    $uri = trim((string) ($row["uri"] ?? ""));
+    if ($uri === "" || !str_starts_with($uri, "api/")) {
+        continue;
+    }
+
+    $methodRaw = strtoupper(trim((string) ($row["method"] ?? "")));
+    if ($methodRaw === "") {
+        continue;
+    }
+
+    $methods = array_values(array_unique(array_filter(array_map("trim", explode("|", $methodRaw)), fn ($m) => $m !== "")));
+    if (in_array("GET", $methods, true) && in_array("HEAD", $methods, true)) {
+        $methods = array_values(array_filter($methods, fn ($m) => $m !== "HEAD"));
+    }
+    if ($methods === []) {
+        continue;
+    }
+
+    $path = "/" . ltrim($uri, "/");
+    $name = trim((string) ($row["name"] ?? ""));
+    $action = trim((string) ($row["action"] ?? "Closure"));
+    $middleware = array_values(array_map("strval", (array) ($row["middleware"] ?? [])));
+
+    $segments = explode("/", $uri);
+    $version = $segments[1] ?? "root";
+    $tag = preg_match("/^v[0-9]+\\.[0-9]+$/", $version) ? $version : "root";
+
+    foreach ($methods as $method) {
+        $op = strtolower($method);
+        $generatedOperationId = strtolower((string) preg_replace("/[^a-zA-Z0-9]+/", "_", $method . "_" . $uri));
+        $operationId = $name !== "" ? $name : $generatedOperationId;
+        $item = [
+            "operationId" => $operationId,
+            "tags" => ["api:" . $tag],
+            "responses" => ["200" => ["description" => "OK"]],
+            "x-laravel-action" => $action,
+            "x-laravel-middleware" => $middleware,
+        ];
+        if ($name !== "") {
+            $item["x-laravel-name"] = $name;
+        }
+        $paths[$path][$op] = $item;
+    }
+}
+
+ksort($paths);
+foreach ($paths as $p => $ops) {
+    ksort($ops);
+    $paths[$p] = $ops;
+}
+
+$doc = [
+    "openapi" => "3.0.3",
+    "info" => [
+        "title" => "fap-api route contract snapshot",
+        "version" => "route-list-v1",
+    ],
+    "paths" => $paths,
+];
+
+$encoded = json_encode($doc, JSON_PRETTY_PRINT | JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES);
+if (!is_string($encoded)) {
+    fwrite(STDERR, "[openapi][FAIL] encode failed\n");
+    exit(1);
+}
+
+file_put_contents($outPath, $encoded . PHP_EOL);
+' "${TMP_RAW}" "${TMP_CANON}"
+
+if [[ "${MODE}" == "stdout" ]]; then
+  cat "${TMP_CANON}"
+  exit 0
+fi
+
+if [[ "${MODE}" == "check" ]]; then
+  if [[ ! -f "${OUTPUT_PATH}" ]]; then
+    echo "[openapi][FAIL] snapshot missing: ${OUTPUT_PATH}" >&2
+    exit 1
+  fi
+
+  if cmp -s "${OUTPUT_PATH}" "${TMP_CANON}"; then
+    echo "[openapi] snapshot up-to-date"
+    exit 0
+  fi
+
+  echo "[openapi][FAIL] snapshot drift detected: ${OUTPUT_PATH}" >&2
+  git --no-pager -C "${REPO_DIR}" diff --no-index -- "${OUTPUT_PATH}" "${TMP_CANON}" || true
+  exit 1
+fi
+
+mkdir -p "$(dirname "${OUTPUT_PATH}")"
+cp "${TMP_CANON}" "${OUTPUT_PATH}"
+echo "[openapi] snapshot exported: ${OUTPUT_PATH}"

--- a/backend/tests/Feature/OpenApiDiffTest.php
+++ b/backend/tests/Feature/OpenApiDiffTest.php
@@ -1,0 +1,82 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature;
+
+use Tests\TestCase;
+
+final class OpenApiDiffTest extends TestCase
+{
+    public function test_openapi_snapshot_is_synced_when_drift_not_allowed(): void
+    {
+        if (getenv('OPENAPI_DIFF_ALLOW_DRIFT') === '1') {
+            $this->markTestSkipped('OPENAPI_DIFF_ALLOW_DRIFT=1: strict snapshot assertion skipped.');
+        }
+
+        $snapshotPath = base_path('docs/contracts/openapi.snapshot.json');
+        $this->assertFileExists($snapshotPath);
+
+        $expected = (string) file_get_contents($snapshotPath);
+        $actual = $this->exportCurrentSnapshot();
+
+        if (trim($expected) !== trim($actual)) {
+            self::fail("OpenAPI snapshot drift detected.\n".$this->firstMismatchPreview($expected, $actual));
+        }
+
+        self::assertTrue(true);
+    }
+
+    public function test_gate_can_detect_drift_with_simulated_route_change(): void
+    {
+        $expected = $this->exportCurrentSnapshot();
+        $decoded = json_decode($expected, true);
+
+        $this->assertIsArray($decoded);
+        $decoded['paths']['/api/v0.3/__openapi_contract_probe'] = [
+            'get' => [
+                'operationId' => 'simulated_probe',
+                'tags' => ['api:v0.3'],
+                'responses' => ['200' => ['description' => 'OK']],
+                'x-laravel-action' => 'Simulated@probe',
+                'x-laravel-middleware' => ['api'],
+            ],
+        ];
+
+        ksort($decoded['paths']);
+        $mutated = json_encode($decoded, JSON_PRETTY_PRINT | JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES).PHP_EOL;
+
+        $this->assertNotSame(trim($expected), trim((string) $mutated), 'Simulated route drift must change snapshot.');
+    }
+
+    private function exportCurrentSnapshot(): string
+    {
+        $script = base_path('scripts/export_openapi.sh');
+        $cmd = 'bash '.escapeshellarg($script).' --stdout 2>/dev/null';
+        $out = [];
+        $code = 0;
+        exec($cmd, $out, $code);
+        $this->assertSame(0, $code, 'export_openapi.sh --stdout failed.');
+
+        return implode("\n", $out)."\n";
+    }
+
+    private function firstMismatchPreview(string $expected, string $actual): string
+    {
+        $a = preg_split('/\R/', $expected) ?: [];
+        $b = preg_split('/\R/', $actual) ?: [];
+        $max = max(count($a), count($b));
+
+        for ($i = 0; $i < $max; $i++) {
+            $la = $a[$i] ?? '';
+            $lb = $b[$i] ?? '';
+            if ($la !== $lb) {
+                $line = $i + 1;
+
+                return "first mismatch at line {$line}\nEXPECTED: {$la}\nACTUAL:   {$lb}";
+            }
+        }
+
+        return 'content differs but no line mismatch located';
+    }
+}


### PR DESCRIPTION
Fixes FER2-38

Summary
- add `backend/scripts/export_openapi.sh` to export a route-based OpenAPI snapshot from `php artisan route:list --json` for `/api/**` routes only.
- add canonical snapshot file `backend/docs/contracts/openapi.snapshot.json` generated by the export script.
- add `backend/tests/Feature/OpenApiDiffTest.php` to enforce snapshot sync and simulate contract drift detection.
- wire OpenAPI diff gate into `backend/scripts/ci_verify_mbti.sh` with explicit controls:
  - `RUN_OPENAPI_DIFF_GATE` (default `1`)
  - `OPENAPI_DIFF_ALLOW_DRIFT` (default `0`, non-blocking when set to `1`)
- keep business logic unchanged (deployment is contract tooling + CI gate only).

Verification
- `cd /Users/rainie/Desktop/GitHub/fap-api/backend && php artisan route:list`
- `cd /Users/rainie/Desktop/GitHub/fap-api/backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=/tmp/fap-ci.sqlite php artisan migrate --force`
- `cd /Users/rainie/Desktop/GitHub/fap-api/backend && (php artisan serve --host=127.0.0.1 --port=19080 >/tmp/fer2-38-serve.log 2>&1 & SERVE_PID=$!; sleep 2; curl -sS http://127.0.0.1:19080/api/healthz; kill $SERVE_PID >/dev/null 2>&1 || true; wait $SERVE_PID 2>/dev/null || true)`
- `cd /Users/rainie/Desktop/GitHub/fap-api && bash backend/scripts/export_openapi.sh --check`
- `cd /Users/rainie/Desktop/GitHub/fap-api/backend && php artisan test --filter OpenApiDiffTest`
- `cd /Users/rainie/Desktop/GitHub/fap-api && bash backend/scripts/ci_verify_mbti.sh`
