### PR TITLE
Fixes FER2-40: add server-side rate limiting for key endpoints

### DIFF
--- a/backend/app/Providers/AppServiceProvider.php
+++ b/backend/app/Providers/AppServiceProvider.php
@@ -315,13 +315,46 @@ class AppServiceProvider extends ServiceProvider
 
         $this->registerSlowQueryTelemetry();
 
-        $response = function (string $code, string $message) {
-            return function (Request $request, array $headers) use ($code, $message) {
+        $resolveRequestId = function (Request $request): string {
+            $requestId = trim((string) ($request->attributes->get('request_id') ?? ''));
+            if ($requestId !== '') {
+                return $requestId;
+            }
+
+            $requestId = trim((string) $request->header('X-Request-Id', ''));
+            if ($requestId !== '') {
+                return $requestId;
+            }
+
+            $requestId = trim((string) $request->header('X-Request-ID', ''));
+            if ($requestId !== '') {
+                return $requestId;
+            }
+
+            return (string) \Illuminate\Support\Str::uuid();
+        };
+
+        $scopedRateKey = function (Request $request, string $scope): string {
+            $ip = (string) ($request->ip() ?? 'unknown');
+            $orgId = (int) ($request->attributes->get('org_id', $request->attributes->get('fm_org_id', 0)) ?? 0);
+            $route = (string) (($request->route()?->uri()) ?? $request->path());
+
+            return implode('|', [
+                $scope,
+                'ip:'.$ip,
+                'org:'.max(0, $orgId),
+                'route:'.$route,
+            ]);
+        };
+
+        $response = function (string $code, string $message) use ($resolveRequestId) {
+            return function (Request $request, array $headers) use ($code, $message, $resolveRequestId) {
                 return response()->json([
-                    'error' => [
-                        'code' => $code,
-                        'message' => $message,
-                    ],
+                    'ok' => false,
+                    'error_code' => $code,
+                    'message' => $message,
+                    'details' => null,
+                    'request_id' => $resolveRequestId($request),
                 ], 429)->withHeaders($headers);
             };
         };
@@ -353,7 +386,7 @@ class AppServiceProvider extends ServiceProvider
                 ->response($response('RATE_LIMIT_PUBLIC', 'Too many requests. Please retry later.'));
         });
 
-        RateLimiter::for('api_auth', function (Request $request) use ($response, $shouldBypassRateLimits) {
+        RateLimiter::for('api_auth', function (Request $request) use ($response, $shouldBypassRateLimits, $scopedRateKey) {
             if ($shouldBypassRateLimits()) {
                 return Limit::none();
             }
@@ -362,8 +395,34 @@ class AppServiceProvider extends ServiceProvider
             $limit = max(1, $limit);
 
             return Limit::perMinute($limit)
-                ->by('ip:'.$request->ip())
+                ->by($scopedRateKey($request, 'api_auth'))
                 ->response($response('RATE_LIMIT_AUTH', 'Too many auth requests. Please retry later.'));
+        });
+
+        RateLimiter::for('api_order_lookup', function (Request $request) use ($response, $shouldBypassRateLimits, $scopedRateKey) {
+            if ($shouldBypassRateLimits()) {
+                return Limit::none();
+            }
+
+            $limit = (int) config('fap.rate_limits.api_order_lookup_per_minute', 20);
+            $limit = max(1, $limit);
+
+            return Limit::perMinute($limit)
+                ->by($scopedRateKey($request, 'api_order_lookup'))
+                ->response($response('RATE_LIMIT_ORDER_LOOKUP', 'Too many order lookup requests. Please retry later.'));
+        });
+
+        RateLimiter::for('api_track', function (Request $request) use ($response, $shouldBypassRateLimits, $scopedRateKey) {
+            if ($shouldBypassRateLimits()) {
+                return Limit::none();
+            }
+
+            $limit = (int) config('fap.rate_limits.api_track_per_minute', 60);
+            $limit = max(1, $limit);
+
+            return Limit::perMinute($limit)
+                ->by($scopedRateKey($request, 'api_track'))
+                ->response($response('RATE_LIMIT_TRACK', 'Too many tracking requests. Please retry later.'));
         });
 
         RateLimiter::for('api_attempt_submit', function (Request $request) use ($response, $shouldBypassRateLimits) {
@@ -386,7 +445,7 @@ class AppServiceProvider extends ServiceProvider
                 ->response($response('RATE_LIMIT_ATTEMPT_SUBMIT', 'Too many attempt submissions. Please retry later.'));
         });
 
-        RateLimiter::for('api_webhook', function (Request $request) use ($response, $shouldBypassRateLimits) {
+        RateLimiter::for('api_webhook', function (Request $request) use ($response, $shouldBypassRateLimits, $scopedRateKey) {
             if ($shouldBypassRateLimits()) {
                 return Limit::none();
             }
@@ -399,7 +458,8 @@ class AppServiceProvider extends ServiceProvider
                 $provider = (string) $request->route('provider_code', '');
             }
 
-            $key = $provider !== '' ? ('provider:'.$provider) : ('ip:'.$request->ip());
+            $scope = 'api_webhook:'.($provider !== '' ? $provider : 'unknown');
+            $key = $scopedRateKey($request, $scope);
 
             return Limit::perMinute($limit)
                 ->by($key)

--- a/backend/docs/contracts/openapi.snapshot.json
+++ b/backend/docs/contracts/openapi.snapshot.json
@@ -684,7 +684,8 @@
                     "App\\Http\\Middleware\\NormalizeApiErrorContract",
                     "App\\Http\\Middleware\\ResolveAnonId",
                     "App\\Http\\Middleware\\ResolveOrgContext",
-                    "App\\Http\\Middleware\\FmTokenOptional"
+                    "App\\Http\\Middleware\\FmTokenOptional",
+                    "Illuminate\\Routing\\Middleware\\ThrottleRequests:api_order_lookup"
                 ]
             }
         },
@@ -1310,7 +1311,8 @@
                     "App\\Http\\Middleware\\ResolveAnonId",
                     "App\\Http\\Middleware\\ResolveOrgContext",
                     "App\\Http\\Middleware\\FmTokenOptional",
-                    "App\\Http\\Middleware\\LimitApiPublicPayloadSize"
+                    "App\\Http\\Middleware\\LimitApiPublicPayloadSize",
+                    "Illuminate\\Routing\\Middleware\\ThrottleRequests:api_track"
                 ]
             }
         },

--- a/backend/routes/api.php
+++ b/backend/routes/api.php
@@ -163,7 +163,7 @@ Route::prefix('v0.3')->middleware([
         Route::post('/orders/checkout', 'App\\Http\\Controllers\\API\\V0_3\\CommerceController@checkout')
             ->middleware(\App\Http\Middleware\FmTokenOptional::class);
         Route::post('/orders/lookup', 'App\\Http\\Controllers\\API\\V0_3\\CommerceController@lookup')
-            ->middleware(\App\Http\Middleware\FmTokenOptional::class);
+            ->middleware([\App\Http\Middleware\FmTokenOptional::class, 'throttle:api_order_lookup']);
         Route::post('/orders/{order_no}/resend', 'App\\Http\\Controllers\\API\\V0_3\\CommerceController@resend')
             ->middleware(\App\Http\Middleware\FmTokenOptional::class);
         Route::post('/orders', 'App\\Http\\Controllers\\API\\V0_3\\CommerceController@createOrder')
@@ -192,7 +192,7 @@ Route::prefix('v0.3')->middleware([
             ->middleware([
                 \App\Http\Middleware\FmTokenOptional::class,
                 \App\Http\Middleware\LimitApiPublicPayloadSize::class,
-                'throttle:api_public',
+                'throttle:api_track',
             ])
             ->where('shareId', '[A-Za-z0-9_-]{6,128}');
     });

--- a/backend/tests/Feature/V0_3/RateLimitKeyEndpointsTest.php
+++ b/backend/tests/Feature/V0_3/RateLimitKeyEndpointsTest.php
@@ -1,0 +1,164 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\V0_3;
+
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Routing\Route as IlluminateRoute;
+use Tests\TestCase;
+
+final class RateLimitKeyEndpointsTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_route_wiring_contains_expected_throttle_middlewares(): void
+    {
+        $authGuest = $this->findRoute('POST', 'api/v0.3/auth/guest');
+        $this->assertContains('throttle:api_auth', $authGuest->gatherMiddleware());
+
+        $orderLookup = $this->findRoute('POST', 'api/v0.3/orders/lookup');
+        $this->assertContains('throttle:api_order_lookup', $orderLookup->gatherMiddleware());
+
+        $shareClick = $this->findRoute('POST', 'api/v0.3/shares/{shareId}/click');
+        $this->assertContains('throttle:api_track', $shareClick->gatherMiddleware());
+
+        $paymentWebhook = $this->findRoute('POST', 'api/v0.3/webhooks/payment/{provider}');
+        $this->assertContains('throttle:api_webhook', $paymentWebhook->gatherMiddleware());
+    }
+
+    public function test_auth_guest_rate_limit_returns_429_error_contract(): void
+    {
+        $this->configureRateLimitGate([
+            'fap.rate_limits.api_auth_per_minute' => 2,
+        ]);
+
+        $server = ['REMOTE_ADDR' => '198.51.100.40'];
+        $payload = ['anon_id' => 'rate_limit_auth_anon'];
+
+        $this->withServerVariables($server)->postJson('/api/v0.3/auth/guest', $payload)->assertStatus(200);
+        $this->withServerVariables($server)->postJson('/api/v0.3/auth/guest', $payload)->assertStatus(200);
+
+        $response = $this->withServerVariables($server)->postJson('/api/v0.3/auth/guest', $payload);
+        $this->assertRateLimitContract($response->status(), $response->json(), 'RATE_LIMIT_AUTH');
+    }
+
+    public function test_order_lookup_rate_limit_returns_429_error_contract(): void
+    {
+        $this->configureRateLimitGate([
+            'fap.rate_limits.api_order_lookup_per_minute' => 2,
+        ]);
+
+        $server = ['REMOTE_ADDR' => '198.51.100.41'];
+        $payload = [
+            'order_no' => 'ord_rate_limit_lookup_case',
+            'email' => 'lookup@example.com',
+        ];
+
+        $this->withServerVariables($server)->postJson('/api/v0.3/orders/lookup', $payload)->assertStatus(404);
+        $this->withServerVariables($server)->postJson('/api/v0.3/orders/lookup', $payload)->assertStatus(404);
+
+        $response = $this->withServerVariables($server)->postJson('/api/v0.3/orders/lookup', $payload);
+        $this->assertRateLimitContract($response->status(), $response->json(), 'RATE_LIMIT_ORDER_LOOKUP');
+    }
+
+    public function test_share_click_track_rate_limit_returns_429_error_contract(): void
+    {
+        $this->configureRateLimitGate([
+            'fap.rate_limits.api_track_per_minute' => 2,
+        ]);
+
+        $server = ['REMOTE_ADDR' => '198.51.100.42'];
+
+        $first = $this->withServerVariables($server)->postJson('/api/v0.3/shares/abc12345/click', []);
+        $second = $this->withServerVariables($server)->postJson('/api/v0.3/shares/abc12345/click', []);
+
+        $this->assertNotSame(429, $first->status());
+        $this->assertNotSame(429, $second->status());
+
+        $response = $this->withServerVariables($server)->postJson('/api/v0.3/shares/abc12345/click', []);
+        $this->assertRateLimitContract($response->status(), $response->json(), 'RATE_LIMIT_TRACK');
+    }
+
+    public function test_payment_webhook_rate_limit_returns_429_error_contract(): void
+    {
+        $this->configureRateLimitGate([
+            'fap.rate_limits.api_webhook_per_minute' => 2,
+        ]);
+        config([
+            'services.stripe.webhook_secret' => 'whsec_rate_limit_contract',
+            'services.stripe.webhook_tolerance_seconds' => 300,
+        ]);
+
+        $raw = json_encode([
+            'id' => 'evt_rate_limit_case',
+            'type' => 'payment_intent.succeeded',
+            'data' => [
+                'object' => [
+                    'id' => 'pi_rate_limit_case',
+                    'metadata' => ['order_no' => 'ord_rate_limit_case'],
+                ],
+            ],
+        ], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES);
+        $this->assertIsString($raw);
+
+        $server = [
+            'REMOTE_ADDR' => '198.51.100.43',
+            'CONTENT_TYPE' => 'application/json',
+            'HTTP_ACCEPT' => 'application/json',
+            'HTTP_STRIPE_SIGNATURE' => 't=1700000000,v1=invalid',
+        ];
+
+        $first = $this->call('POST', '/api/v0.3/webhooks/payment/stripe', [], [], [], $server, $raw);
+        $second = $this->call('POST', '/api/v0.3/webhooks/payment/stripe', [], [], [], $server, $raw);
+
+        $this->assertSame(400, $first->status());
+        $this->assertSame(400, $second->status());
+
+        $response = $this->call('POST', '/api/v0.3/webhooks/payment/stripe', [], [], [], $server, $raw);
+        $this->assertRateLimitContract($response->status(), $response->json(), 'RATE_LIMIT_WEBHOOK');
+    }
+
+    private function configureRateLimitGate(array $overrides = []): void
+    {
+        config(array_merge([
+            'fap.rate_limits.bypass_in_test_env' => false,
+            'fap.rate_limits.api_auth_per_minute' => 30,
+            'fap.rate_limits.api_order_lookup_per_minute' => 20,
+            'fap.rate_limits.api_track_per_minute' => 60,
+            'fap.rate_limits.api_webhook_per_minute' => 60,
+        ], $overrides));
+    }
+
+    private function assertRateLimitContract(int $status, mixed $json, string $errorCode): void
+    {
+        $this->assertSame(429, $status);
+        $this->assertIsArray($json);
+        $this->assertSame(false, $json['ok'] ?? null);
+        $this->assertSame($errorCode, $json['error_code'] ?? null);
+        $this->assertIsString($json['message'] ?? null);
+        $this->assertNotSame('', trim((string) ($json['message'] ?? '')));
+        $this->assertArrayHasKey('details', $json);
+        $this->assertNull($json['details']);
+        $this->assertIsString($json['request_id'] ?? null);
+        $this->assertNotSame('', trim((string) ($json['request_id'] ?? '')));
+        $this->assertArrayNotHasKey('error', $json);
+    }
+
+    private function findRoute(string $method, string $uri): IlluminateRoute
+    {
+        $routes = app('router')->getRoutes();
+
+        foreach ($routes as $route) {
+            if ($route->uri() !== $uri) {
+                continue;
+            }
+
+            if (in_array(strtoupper($method), $route->methods(), true)) {
+                return $route;
+            }
+        }
+
+        self::fail("Route not found for [{$method}] {$uri}");
+    }
+}


### PR DESCRIPTION
Fixes FER2-40

## Summary
- harden named API limiters with scoped keys (`scope + ip + org + route`) and keep provider-aware webhook scoping
- add dedicated limiters for `orders/lookup` and track endpoint (`shares/{shareId}/click`), and rewire routes to use `throttle:api_order_lookup` / `throttle:api_track`
- unify throttle 429 response payload to top-level structured error contract (`ok/error_code/message/details/request_id`)
- add regression coverage for route wiring and per-endpoint 429 contract behavior
- refresh route contract snapshot to keep OpenAPI diff gate green after middleware wiring changes

## Verification
- `cd /Users/rainie/Desktop/GitHub/fap-api/backend && php artisan test --filter RateLimitKeyEndpointsTest`
- `cd /Users/rainie/Desktop/GitHub/fap-api && bash backend/scripts/ci_verify_mbti.sh`
- `cd /Users/rainie/Desktop/GitHub/fap-api/backend && php artisan route:list --path=api/v0.3`
