### PR TITLE
Fixes FER2-41: harden external KMS adapter contract and observability

### DIFF
--- a/backend/app/Providers/AppServiceProvider.php
+++ b/backend/app/Providers/AppServiceProvider.php
@@ -56,12 +56,18 @@ class AppServiceProvider extends ServiceProvider
     public function register(): void
     {
         $this->app->singleton(PiiEnvelopeAdapter::class, function ($app) {
-            $adapter = strtolower(trim((string) config('services.pii.adapter', 'local')));
+            $adapterRaw = strtolower(trim((string) config('services.pii.adapter', 'local')));
+            $adapter = match ($adapterRaw) {
+                'external-kms', 'kms' => 'external_kms',
+                default => $adapterRaw,
+            };
 
             return match ($adapter) {
                 'local' => $app->make(LocalPiiEnvelopeAdapter::class),
                 'external_kms' => $app->make(ExternalKmsPiiEnvelopeAdapter::class),
-                default => throw new RuntimeException("Unsupported services.pii.adapter [{$adapter}]"),
+                default => throw new RuntimeException(
+                    "Unsupported services.pii.adapter [{$adapter}] (allowed: local, external_kms)"
+                ),
             };
         });
 

--- a/backend/app/Support/Security/ExternalKmsContractException.php
+++ b/backend/app/Support/Security/ExternalKmsContractException.php
@@ -10,7 +10,10 @@ final class ExternalKmsContractException extends RuntimeException
 {
     public function __construct(
         private readonly string $errorCode,
-        string $message
+        string $message,
+        private readonly bool $retryable,
+        private readonly string $category,
+        private readonly string $operation
     ) {
         parent::__construct($message);
     }
@@ -18,5 +21,20 @@ final class ExternalKmsContractException extends RuntimeException
     public function errorCode(): string
     {
         return $this->errorCode;
+    }
+
+    public function isRetryable(): bool
+    {
+        return $this->retryable;
+    }
+
+    public function category(): string
+    {
+        return $this->category;
+    }
+
+    public function operation(): string
+    {
+        return $this->operation;
     }
 }

--- a/backend/app/Support/Security/ExternalKmsPiiEnvelopeAdapter.php
+++ b/backend/app/Support/Security/ExternalKmsPiiEnvelopeAdapter.php
@@ -25,40 +25,102 @@ final class ExternalKmsPiiEnvelopeAdapter implements PiiEnvelopeAdapter
 
     private function runWithContract(string $operation, callable $localOp): mixed
     {
-        try {
-            $this->simulateExternalDependency($operation);
+        $maxRetries = max(0, (int) config('services.pii.external_kms.max_retries', 2));
+        $retryBackoffMs = max(0, (int) config('services.pii.external_kms.retry_backoff_ms', 50));
+        $attempt = 0;
 
-            return $localOp();
-        } catch (ExternalKmsContractException $e) {
-            if ($this->allowLocalFallback()) {
-                Log::warning('external_kms_fallback_to_local', [
-                    'operation' => $operation,
-                    'error_code' => $e->errorCode(),
-                ]);
+        while (true) {
+            $attempt++;
 
-                return $localOp();
+            try {
+                $this->simulateExternalDependency($operation, $attempt);
+                $result = $localOp();
+
+                if ($attempt > 1) {
+                    Log::info('external_kms_retry_succeeded', [
+                        'operation' => $operation,
+                        'attempt' => $attempt,
+                        'max_retries' => $maxRetries,
+                        'fallback_used' => false,
+                    ]);
+                }
+
+                return $result;
+            } catch (ExternalKmsContractException $e) {
+                if ($e->isRetryable() && $attempt <= $maxRetries) {
+                    Log::warning('external_kms_retryable_failure', [
+                        'operation' => $operation,
+                        'error_code' => $e->errorCode(),
+                        'category' => $e->category(),
+                        'retryable' => $e->isRetryable(),
+                        'attempt' => $attempt,
+                        'max_retries' => $maxRetries,
+                        'fallback_used' => false,
+                    ]);
+
+                    if ($retryBackoffMs > 0) {
+                        usleep($retryBackoffMs * 1000);
+                    }
+                    continue;
+                }
+
+                if ($e->isRetryable() && $this->allowLocalFallback()) {
+                    Log::warning('external_kms_fallback_to_local', [
+                        'operation' => $operation,
+                        'error_code' => $e->errorCode(),
+                        'category' => $e->category(),
+                        'retryable' => $e->isRetryable(),
+                        'attempt' => $attempt,
+                        'max_retries' => $maxRetries,
+                        'fallback_used' => true,
+                    ]);
+
+                    return $localOp();
+                }
+
+                throw $e;
             }
-
-            throw $e;
         }
     }
 
-    private function simulateExternalDependency(string $operation): void
+    private function simulateExternalDependency(string $operation, int $attempt): void
     {
-        $simulate = strtolower(trim((string) config('services.pii.external_kms.simulate', 'none')));
+        $simulateRaw = strtolower(trim((string) config('services.pii.external_kms.simulate', 'none')));
+        $simulate = match ($simulateRaw) {
+            'timeout_once' => $attempt === 1 ? 'timeout' : 'none',
+            'retryable_once' => $attempt === 1 ? 'retryable' : 'none',
+            'failure' => 'retryable',
+            default => $simulateRaw,
+        };
         $timeoutMs = max(1, (int) config('services.pii.external_kms.timeout_ms', 800));
 
         if ($simulate === 'timeout') {
             throw new ExternalKmsContractException(
                 'EXTERNAL_KMS_TIMEOUT',
-                "external kms {$operation} timeout after {$timeoutMs}ms"
+                "external kms {$operation} timeout after {$timeoutMs}ms",
+                true,
+                'timeout',
+                $operation
             );
         }
 
-        if ($simulate === 'failure') {
+        if ($simulate === 'retryable') {
             throw new ExternalKmsContractException(
-                'EXTERNAL_KMS_FAILED',
-                "external kms {$operation} dependency failure"
+                'EXTERNAL_KMS_RETRYABLE',
+                "external kms {$operation} transient dependency failure",
+                true,
+                'retryable',
+                $operation
+            );
+        }
+
+        if ($simulate === 'non_retryable') {
+            throw new ExternalKmsContractException(
+                'EXTERNAL_KMS_NON_RETRYABLE',
+                "external kms {$operation} non-retryable dependency failure",
+                false,
+                'non_retryable',
+                $operation
             );
         }
     }

--- a/backend/config/services.php
+++ b/backend/config/services.php
@@ -147,6 +147,9 @@ return [
             'timeout_ms' => (int) env('PII_EXTERNAL_KMS_TIMEOUT_MS', 800),
             'dry_run' => (bool) env('PII_EXTERNAL_KMS_DRY_RUN', false),
             'fallback_to_local' => (bool) env('PII_EXTERNAL_KMS_FALLBACK_TO_LOCAL', false),
+            'max_retries' => (int) env('PII_EXTERNAL_KMS_MAX_RETRIES', 2),
+            'retry_backoff_ms' => (int) env('PII_EXTERNAL_KMS_RETRY_BACKOFF_MS', 50),
+            // allowed values: none|timeout|retryable|non_retryable|timeout_once|retryable_once
             'simulate' => env('PII_EXTERNAL_KMS_SIMULATE', 'none'),
         ],
     ],

--- a/backend/tests/Feature/V0_3/PiiCipherEnvelopeTest.php
+++ b/backend/tests/Feature/V0_3/PiiCipherEnvelopeTest.php
@@ -93,6 +93,7 @@ final class PiiCipherEnvelopeTest extends TestCase
         config()->set('services.pii.external_kms.simulate', 'timeout');
         config()->set('services.pii.external_kms.dry_run', false);
         config()->set('services.pii.external_kms.fallback_to_local', false);
+        config()->set('services.pii.external_kms.max_retries', 0);
         $this->app->forgetInstance(PiiEnvelopeAdapter::class);
         $this->app->forgetInstance(PiiCipher::class);
 
@@ -101,6 +102,76 @@ final class PiiCipherEnvelopeTest extends TestCase
             self::fail('Expected ExternalKmsContractException to be thrown.');
         } catch (ExternalKmsContractException $e) {
             $this->assertSame('EXTERNAL_KMS_TIMEOUT', $e->errorCode());
+            $this->assertTrue($e->isRetryable());
+            $this->assertSame('timeout', $e->category());
+            $this->assertSame('encrypt', $e->operation());
+        }
+    }
+
+    public function test_external_kms_retryable_error_retries_then_succeeds(): void
+    {
+        config()->set('services.pii.adapter', 'external_kms');
+        config()->set('services.pii.external_kms.simulate', 'timeout_once');
+        config()->set('services.pii.external_kms.dry_run', false);
+        config()->set('services.pii.external_kms.fallback_to_local', false);
+        config()->set('services.pii.external_kms.max_retries', 1);
+        config()->set('services.pii.external_kms.retry_backoff_ms', 1);
+        $this->app->forgetInstance(PiiEnvelopeAdapter::class);
+        $this->app->forgetInstance(PiiCipher::class);
+
+        $plaintext = 'retry.once.success@example.com';
+        $cipher = (string) app(PiiCipher::class)->encrypt($plaintext);
+        $this->assertNotSame('', trim($cipher));
+        $this->assertSame($plaintext, app(PiiCipher::class)->decrypt($cipher));
+    }
+
+    public function test_external_kms_retryable_exhausted_can_fallback_when_enabled(): void
+    {
+        $plaintext = 'retryable.fallback@example.com';
+
+        config()->set('services.pii.adapter', 'external_kms');
+        config()->set('services.pii.external_kms.simulate', 'retryable');
+        config()->set('services.pii.external_kms.dry_run', false);
+        config()->set('services.pii.external_kms.fallback_to_local', true);
+        config()->set('services.pii.external_kms.max_retries', 1);
+        config()->set('services.pii.external_kms.retry_backoff_ms', 1);
+        $this->app->forgetInstance(PiiEnvelopeAdapter::class);
+        $this->app->forgetInstance(PiiCipher::class);
+        /** @var PiiCipher $external */
+        $external = app(PiiCipher::class);
+        $ciphertext = (string) $external->encrypt($plaintext);
+        $this->assertSame($plaintext, $external->decrypt($ciphertext));
+
+        config()->set('services.pii.adapter', 'local');
+        config()->set('services.pii.external_kms.simulate', 'none');
+        config()->set('services.pii.external_kms.fallback_to_local', false);
+        config()->set('services.pii.external_kms.max_retries', 0);
+        $this->app->forgetInstance(PiiEnvelopeAdapter::class);
+        $this->app->forgetInstance(PiiCipher::class);
+        /** @var PiiCipher $local */
+        $local = app(PiiCipher::class);
+        $this->assertSame($plaintext, $local->decrypt($ciphertext));
+    }
+
+    public function test_external_kms_non_retryable_is_fail_closed_even_with_fallback_enabled(): void
+    {
+        config()->set('services.pii.adapter', 'external_kms');
+        config()->set('services.pii.external_kms.simulate', 'non_retryable');
+        config()->set('services.pii.external_kms.dry_run', true);
+        config()->set('services.pii.external_kms.fallback_to_local', true);
+        config()->set('services.pii.external_kms.max_retries', 2);
+        config()->set('services.pii.external_kms.retry_backoff_ms', 1);
+        $this->app->forgetInstance(PiiEnvelopeAdapter::class);
+        $this->app->forgetInstance(PiiCipher::class);
+
+        try {
+            app(PiiCipher::class)->encrypt('non.retryable.fail.closed@example.com');
+            self::fail('Expected ExternalKmsContractException to be thrown.');
+        } catch (ExternalKmsContractException $e) {
+            $this->assertSame('EXTERNAL_KMS_NON_RETRYABLE', $e->errorCode());
+            $this->assertFalse($e->isRetryable());
+            $this->assertSame('non_retryable', $e->category());
+            $this->assertSame('encrypt', $e->operation());
         }
     }
 
@@ -119,9 +190,11 @@ final class PiiCipherEnvelopeTest extends TestCase
         $localCiphertext = (string) $local->encrypt($plaintext);
 
         config()->set('services.pii.adapter', 'external_kms');
-        config()->set('services.pii.external_kms.simulate', 'failure');
+        config()->set('services.pii.external_kms.simulate', 'retryable');
         config()->set('services.pii.external_kms.dry_run', true);
         config()->set('services.pii.external_kms.fallback_to_local', false);
+        config()->set('services.pii.external_kms.max_retries', 1);
+        config()->set('services.pii.external_kms.retry_backoff_ms', 1);
         $this->app->forgetInstance(PiiEnvelopeAdapter::class);
         $this->app->forgetInstance(PiiCipher::class);
         /** @var PiiCipher $externalDryRun */

--- a/backend/tests/Feature/V0_3/PiiCipherRotationAutomationTest.php
+++ b/backend/tests/Feature/V0_3/PiiCipherRotationAutomationTest.php
@@ -123,5 +123,83 @@ final class PiiCipherRotationAutomationTest extends TestCase
             $this->assertSame('noop', (string) ($noopAudit->result ?? ''));
         }
     }
-}
 
+    public function test_rotation_succeeds_with_external_kms_retryable_fallback_and_keeps_old_ciphertext_readable(): void
+    {
+        config()->set('services.pii.adapter', 'local');
+        config()->set('services.pii.key_version', 1);
+
+        /** @var PiiCipher $pii */
+        $pii = app(PiiCipher::class);
+
+        $email = 'rotate.external.kms@example.com';
+        $phone = '+15550002222';
+        $payload = json_encode(['attempt_id' => 'attempt_rotate_external_1'], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES);
+        $this->assertIsString($payload);
+
+        $userId = DB::table('users')->insertGetId([
+            'name' => 'Rotate External Kms User',
+            'email' => $email,
+            'password' => bcrypt('secret-123'),
+            'phone_e164' => $phone,
+            'email_hash' => $pii->emailHash($email),
+            'email_enc' => $pii->encryptWithKeyVersion($email, 1),
+            'phone_e164_hash' => $pii->phoneHash($phone),
+            'phone_e164_enc' => $pii->encryptWithKeyVersion($phone, 1),
+            'key_version' => 1,
+            'created_at' => now(),
+            'updated_at' => now(),
+        ]);
+
+        $outboxId = '33333333-3333-4333-8333-333333333333';
+        DB::table('email_outbox')->insert([
+            'id' => $outboxId,
+            'user_id' => (string) $userId,
+            'email' => $email,
+            'email_hash' => $pii->emailHash($email),
+            'email_enc' => $pii->encryptWithKeyVersion($email, 1),
+            'to_email' => 'receiver.external@example.com',
+            'to_email_hash' => $pii->emailHash('receiver.external@example.com'),
+            'to_email_enc' => $pii->encryptWithKeyVersion('receiver.external@example.com', 1),
+            'template' => 'report_claim',
+            'payload_json' => $payload,
+            'payload_enc' => $pii->encryptWithKeyVersion($payload, 1),
+            'payload_schema_version' => 'v1-json-enc',
+            'key_version' => 1,
+            'claim_token_hash' => hash('sha256', 'rotate-external-claim-token'),
+            'claim_expires_at' => now()->addDay(),
+            'status' => 'pending',
+            'created_at' => now(),
+            'updated_at' => now(),
+        ]);
+
+        config()->set('services.pii.adapter', 'external_kms');
+        config()->set('services.pii.external_kms.simulate', 'retryable');
+        config()->set('services.pii.external_kms.max_retries', 1);
+        config()->set('services.pii.external_kms.retry_backoff_ms', 1);
+        config()->set('services.pii.external_kms.dry_run', false);
+        config()->set('services.pii.external_kms.fallback_to_local', true);
+
+        $this->artisan('ops:backfill-pii-encryption', [
+            '--sync' => true,
+            '--scope' => 'all',
+            '--rotate-key-version' => 2,
+            '--batch' => 'batch_rotate_external_kms',
+        ])->assertExitCode(0);
+
+        $this->app->forgetInstance(PiiCipher::class);
+        /** @var PiiCipher $cipher */
+        $cipher = app(PiiCipher::class);
+
+        $user = DB::table('users')->where('id', $userId)->first();
+        $this->assertNotNull($user);
+        $this->assertSame(2, (int) ($user->key_version ?? 0));
+        $this->assertSame($email, $cipher->decrypt((string) ($user->email_enc ?? '')));
+        $this->assertSame($phone, $cipher->decrypt((string) ($user->phone_e164_enc ?? '')));
+
+        $outbox = DB::table('email_outbox')->where('id', $outboxId)->first();
+        $this->assertNotNull($outbox);
+        $this->assertSame(2, (int) ($outbox->key_version ?? 0));
+        $this->assertSame($payload, $cipher->decrypt((string) ($outbox->payload_enc ?? '')));
+    }
+}


### PR DESCRIPTION
Fixes FER2-41

## Summary
- harden `external_kms` adapter contract with explicit failure semantics: `timeout`, `retryable`, and `non_retryable`
- add retry budget controls (`max_retries`, `retry_backoff_ms`) and expanded simulation modes (`timeout_once`, `retryable_once`, `non_retryable`) without introducing real cloud SDK dependencies
- enforce fail-closed policy for non-retryable external KMS errors even when fallback flags are enabled
- add structured exception metadata (`errorCode`, `isRetryable`, `category`, `operation`) and observability logs for retry/fallback lifecycle
- extend PII cipher and rotation tests to cover adapter switching, retry success, retry exhaustion with fallback, fail-closed non-retryable path, and rotation compatibility

## Verification
- `cd /Users/rainie/Desktop/GitHub/fap-api/backend && php artisan route:list`
- `cd /Users/rainie/Desktop/GitHub/fap-api/backend && php artisan migrate --force`
- `curl -sS http://127.0.0.1:8000/api/healthz | jq .`
- `cd /Users/rainie/Desktop/GitHub/fap-api/backend && php artisan test --filter PiiCipher`
- `cd /Users/rainie/Desktop/GitHub/fap-api && bash backend/scripts/ci_verify_mbti.sh`
