### PR TITLE
Fixes FER2-42: unify request_id propagation and minimal observability skeleton

### DIFF
--- a/backend/app/Console/Commands/Ops/EvidencePack.php
+++ b/backend/app/Console/Commands/Ops/EvidencePack.php
@@ -9,8 +9,10 @@ use Carbon\CarbonImmutable;
 use Illuminate\Console\Command;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Artisan;
+use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\File;
 use Illuminate\Support\Facades\Http;
+use Illuminate\Support\Facades\Schema;
 
 final class EvidencePack extends Command
 {
@@ -41,6 +43,7 @@ final class EvidencePack extends Command
         $healthzSnapshot = $this->collectHealthzSnapshot((string) $this->option('base-url'));
         $queueBacklogSnapshot = $this->collectQueueBacklogProbeSnapshot($windowMinutes);
         $slowQuerySnapshot = $this->collectSlowQueryTelemetrySnapshot($windowMinutes);
+        $apiSloSnapshot = $this->collectApiSloSnapshot($windowMinutes);
 
         $revisionPayload = [
             'revision' => $revision,
@@ -58,6 +61,7 @@ final class EvidencePack extends Command
                 'healthz_snapshot' => 'healthz_snapshot.json',
                 'queue_backlog_probe' => 'queue_backlog_probe.json',
                 'slow_query_telemetry' => 'slow_query_telemetry.json',
+                'api_slo' => 'api_slo.json',
             ],
         ];
 
@@ -65,6 +69,7 @@ final class EvidencePack extends Command
         $this->writeJson($packDir.'/healthz_snapshot.json', $healthzSnapshot);
         $this->writeJson($packDir.'/queue_backlog_probe.json', $queueBacklogSnapshot);
         $this->writeJson($packDir.'/slow_query_telemetry.json', $slowQuerySnapshot);
+        $this->writeJson($packDir.'/api_slo.json', $apiSloSnapshot);
         $this->writeJson($packDir.'/manifest.json', $manifestPayload);
 
         $this->info($packDir);
@@ -214,6 +219,80 @@ final class EvidencePack extends Command
             'by_connection' => $byConnection,
             'samples' => $samples,
         ];
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    private function collectApiSloSnapshot(int $windowMinutes): array
+    {
+        return [
+            'captured_at' => CarbonImmutable::now('UTC')->toIso8601String(),
+            'window_minutes' => $windowMinutes,
+            'status' => 'UNKNOWN',
+            'metrics' => [
+                'p95_ms' => [
+                    'value' => null,
+                    'status' => 'UNKNOWN',
+                    'reason' => 'apm_not_configured',
+                ],
+                'error_rate' => [
+                    'value' => null,
+                    'status' => 'UNKNOWN',
+                    'reason' => 'apm_not_configured',
+                ],
+            ],
+            'request_id_coverage' => [
+                'events' => $this->collectRequestIdCoverage('events', 'occurred_at', $windowMinutes),
+                'orders' => $this->collectRequestIdCoverage('orders', 'created_at', $windowMinutes),
+                'payment_events' => $this->collectRequestIdCoverage('payment_events', 'received_at', $windowMinutes),
+            ],
+        ];
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    private function collectRequestIdCoverage(string $table, string $timeColumn, int $windowMinutes): array
+    {
+        if (! Schema::hasTable($table) || ! Schema::hasColumn($table, 'request_id') || ! Schema::hasColumn($table, $timeColumn)) {
+            return [
+                'status' => 'UNKNOWN',
+                'reason' => 'table_or_columns_missing',
+                'total' => null,
+                'with_request_id' => null,
+                'coverage_ratio' => null,
+            ];
+        }
+
+        $windowStart = CarbonImmutable::now('UTC')->subMinutes($windowMinutes)->toDateTimeString();
+
+        try {
+            $query = DB::table($table)->where($timeColumn, '>=', $windowStart);
+            $total = (int) $query->count();
+            $withRequestId = (int) DB::table($table)
+                ->where($timeColumn, '>=', $windowStart)
+                ->whereNotNull('request_id')
+                ->where('request_id', '!=', '')
+                ->count();
+
+            $ratio = $total > 0 ? round($withRequestId / $total, 6) : null;
+
+            return [
+                'status' => 'OK',
+                'total' => $total,
+                'with_request_id' => $withRequestId,
+                'coverage_ratio' => $ratio,
+            ];
+        } catch (\Throwable) {
+            return [
+                'status' => 'UNKNOWN',
+                'reason' => 'query_failed',
+                'total' => null,
+                'with_request_id' => null,
+                'coverage_ratio' => null,
+            ];
+        }
     }
 
     /**

--- a/backend/app/Http/Controllers/API/V0_3/CommerceController.php
+++ b/backend/app/Http/Controllers/API/V0_3/CommerceController.php
@@ -94,7 +94,8 @@ class CommerceController extends Controller
             $payload['target_attempt_id'] ?? null,
             $provider,
             $idempotencyKey,
-            $contactEmail
+            $contactEmail,
+            $this->resolveRequestId($request)
         );
 
         if (! ($result['ok'] ?? false)) {
@@ -225,7 +226,8 @@ class CommerceController extends Controller
             $attemptId !== '' ? $attemptId : null,
             $provider,
             $idempotencyKey,
-            $contactEmail
+            $contactEmail,
+            $this->resolveRequestId($request)
         );
 
         if (! ($created['ok'] ?? false)) {

--- a/backend/app/Http/Middleware/AttachRequestId.php
+++ b/backend/app/Http/Middleware/AttachRequestId.php
@@ -1,43 +1,12 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Http\Middleware;
 
-use Closure;
-use Illuminate\Http\Exceptions\HttpResponseException;
-use Illuminate\Http\Request;
-use Illuminate\Support\Str;
-use Symfony\Component\HttpFoundation\Response;
-
-class AttachRequestId
+/**
+ * Backward-compatible alias for legacy middleware reference.
+ */
+class AttachRequestId extends InjectRequestId
 {
-    public function handle(Request $request, Closure $next): Response
-    {
-        $requestId = (string) ($request->attributes->get('request_id') ?? '');
-        if ($requestId === '') {
-            $requestId = (string) $request->header('X-Request-Id', '');
-        }
-        if ($requestId === '') {
-            $requestId = (string) $request->header('X-Request-ID', '');
-        }
-        if ($requestId === '') {
-            $requestId = (string) $request->input('request_id', '');
-        }
-        if ($requestId === '') {
-            $requestId = (string) Str::uuid();
-        }
-
-        $request->attributes->set('request_id', $requestId);
-
-        try {
-            $response = $next($request);
-        } catch (HttpResponseException $e) {
-            $response = $e->getResponse();
-            $response->headers->set('X-Request-Id', $requestId);
-
-            throw $e;
-        }
-        $response->headers->set('X-Request-Id', $requestId);
-
-        return $response;
-    }
 }

--- a/backend/app/Http/Middleware/InjectRequestId.php
+++ b/backend/app/Http/Middleware/InjectRequestId.php
@@ -1,0 +1,85 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Middleware;
+
+use Closure;
+use Illuminate\Http\Exceptions\HttpResponseException;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Log;
+use Illuminate\Support\Str;
+use Symfony\Component\HttpFoundation\Response;
+
+class InjectRequestId
+{
+    public function handle(Request $request, Closure $next): Response
+    {
+        $requestId = $this->resolveRequestId($request);
+
+        $request->attributes->set('request_id', $requestId);
+        $request->headers->set('X-Request-Id', $requestId);
+
+        Log::withContext($this->buildLogContext($request, $requestId));
+
+        try {
+            $response = $next($request);
+        } catch (HttpResponseException $e) {
+            $response = $e->getResponse();
+            $response->headers->set('X-Request-Id', $requestId);
+
+            throw $e;
+        } finally {
+            Log::withoutContext();
+        }
+
+        $response->headers->set('X-Request-Id', $requestId);
+
+        return $response;
+    }
+
+    private function resolveRequestId(Request $request): string
+    {
+        foreach ([
+            (string) ($request->attributes->get('request_id') ?? ''),
+            (string) $request->header('X-Request-Id', ''),
+            (string) $request->header('X-Request-ID', ''),
+            (string) $request->input('request_id', ''),
+        ] as $candidate) {
+            $value = trim($candidate);
+            if ($value !== '') {
+                return substr($value, 0, 128);
+            }
+        }
+
+        return (string) Str::uuid();
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function buildLogContext(Request $request, string $requestId): array
+    {
+        $context = [
+            'request_id' => $requestId,
+            'http_method' => strtoupper($request->method()),
+            'http_path' => (string) $request->path(),
+            'ip' => (string) ($request->ip() ?? ''),
+        ];
+
+        $orgId = $request->attributes->get('org_id', $request->attributes->get('fm_org_id'));
+        if (is_numeric($orgId) && (int) $orgId > 0) {
+            $context['org_id'] = (int) $orgId;
+        }
+
+        $userId = $request->attributes->get('fm_user_id', $request->attributes->get('user_id'));
+        if (is_string($userId) || is_numeric($userId)) {
+            $uid = trim((string) $userId);
+            if ($uid !== '') {
+                $context['user_id'] = $uid;
+            }
+        }
+
+        return $context;
+    }
+}

--- a/backend/app/Internal/Commerce/PaymentWebhookHandlerCore.php
+++ b/backend/app/Internal/Commerce/PaymentWebhookHandlerCore.php
@@ -117,6 +117,8 @@ class PaymentWebhookHandlerCore
         string $rawPayloadSha256 = '',
         int $rawPayloadBytes = -1
     ): array {
+        $requestId = $this->resolveRequestIdFromRuntimeContext();
+
         $ctx = $this->precheckStage->handle(
             $provider,
             $payload,
@@ -126,7 +128,8 @@ class PaymentWebhookHandlerCore
             $signatureOk,
             $payloadMeta,
             $rawPayloadSha256,
-            $rawPayloadBytes
+            $rawPayloadBytes,
+            $requestId
         );
 
         if (isset($ctx['result']) && is_array($ctx['result'])) {
@@ -241,6 +244,33 @@ class PaymentWebhookHandlerCore
         }
 
         return false;
+    }
+
+    private function resolveRequestIdFromRuntimeContext(): ?string
+    {
+        try {
+            $request = request();
+        } catch (\Throwable) {
+            return null;
+        }
+
+        if (! $request instanceof \Illuminate\Http\Request) {
+            return null;
+        }
+
+        foreach ([
+            (string) ($request->attributes->get('request_id') ?? ''),
+            (string) $request->header('X-Request-Id', ''),
+            (string) $request->header('X-Request-ID', ''),
+            (string) $request->input('request_id', ''),
+        ] as $candidate) {
+            $value = trim($candidate);
+            if ($value !== '') {
+                return substr($value, 0, 128);
+            }
+        }
+
+        return null;
     }
 
     public function evaluateDryRun(

--- a/backend/app/Services/Analytics/EventRecorder.php
+++ b/backend/app/Services/Analytics/EventRecorder.php
@@ -129,7 +129,10 @@ final class EventRecorder
 
     private function contextFromRequest(Request $request): array
     {
-        $requestId = trim((string) ($request->header('X-Request-Id') ?? $request->header('X-Request-ID')));
+        $requestId = trim((string) ($request->attributes->get('request_id') ?? ''));
+        if ($requestId === '') {
+            $requestId = trim((string) ($request->header('X-Request-Id') ?? $request->header('X-Request-ID')));
+        }
         $sessionId = trim((string) ($request->header('X-Session-Id') ?? $request->header('X-Session-ID')));
         $channel = trim((string) $request->header('X-Channel', ''));
         $attemptId = (string) $request->input('attempt_id', '');

--- a/backend/app/Services/Commerce/OrderManager.php
+++ b/backend/app/Services/Commerce/OrderManager.php
@@ -473,7 +473,9 @@ class OrderManager
         $row['item_sku'] = $row['sku'];
         $row['provider_order_id'] = null;
         $row['device_id'] = null;
-        $row['request_id'] = null;
+        $row['request_id'] = array_key_exists('request_id', $row)
+            ? $row['request_id']
+            : $this->resolveRequestIdFromCurrentRequest();
         $row['created_ip'] = null;
         $row['fulfilled_at'] = null;
         $row['refunded_at'] = null;
@@ -481,6 +483,27 @@ class OrderManager
         $row['refund_reason'] = null;
 
         return $row;
+    }
+
+    private function resolveRequestIdFromCurrentRequest(): ?string
+    {
+        $request = request();
+        if (! $request instanceof \Illuminate\Http\Request) {
+            return null;
+        }
+
+        foreach ([
+            (string) ($request->attributes->get('request_id') ?? ''),
+            (string) $request->header('X-Request-Id', ''),
+            (string) $request->header('X-Request-ID', ''),
+        ] as $candidate) {
+            $value = trim($candidate);
+            if ($value !== '') {
+                return substr($value, 0, 128);
+            }
+        }
+
+        return null;
     }
 
     private function allowedProviders(): array

--- a/backend/app/Services/Commerce/OrderManager.php
+++ b/backend/app/Services/Commerce/OrderManager.php
@@ -30,7 +30,8 @@ class OrderManager
         ?string $targetAttemptId,
         string $provider,
         ?string $idempotencyKey = null,
-        ?string $contactEmail = null
+        ?string $contactEmail = null,
+        ?string $requestId = null,
     ): array {
         $requestedSku = $this->skus->normalizeSku($sku);
         if ($requestedSku === '') {
@@ -95,7 +96,8 @@ class OrderManager
             $idempotencyKey,
             $useIdempotency,
             $modulesIncluded,
-            $contactEmailHash
+            $contactEmailHash,
+            $requestId
         ): array {
             $orderNo = 'ord_'.Str::uuid();
             $now = now();
@@ -143,7 +145,7 @@ class OrderManager
                 $row['idempotency_key'] = $idempotencyKey;
             }
 
-            return $this->applyLegacyColumns($row);
+            return $this->applyLegacyColumns($row, $requestId);
         };
 
         if ($useIdempotency) {
@@ -466,7 +468,7 @@ class OrderManager
         return false;
     }
 
-    private function applyLegacyColumns(array $row): array
+    private function applyLegacyColumns(array $row, ?string $requestId = null): array
     {
         $row['amount_total'] = $row['amount_cents'];
         $row['amount_refunded'] = 0;
@@ -474,8 +476,8 @@ class OrderManager
         $row['provider_order_id'] = null;
         $row['device_id'] = null;
         $row['request_id'] = array_key_exists('request_id', $row)
-            ? $row['request_id']
-            : $this->resolveRequestIdFromCurrentRequest();
+            ? $this->normalizeRequestId($row['request_id'])
+            : $this->normalizeRequestId($requestId);
         $row['created_ip'] = null;
         $row['fulfilled_at'] = null;
         $row['refunded_at'] = null;
@@ -485,25 +487,14 @@ class OrderManager
         return $row;
     }
 
-    private function resolveRequestIdFromCurrentRequest(): ?string
+    private function normalizeRequestId(mixed $value): ?string
     {
-        $request = request();
-        if (! $request instanceof \Illuminate\Http\Request) {
+        $normalized = trim((string) $value);
+        if ($normalized === '') {
             return null;
         }
 
-        foreach ([
-            (string) ($request->attributes->get('request_id') ?? ''),
-            (string) $request->header('X-Request-Id', ''),
-            (string) $request->header('X-Request-ID', ''),
-        ] as $candidate) {
-            $value = trim($candidate);
-            if ($value !== '') {
-                return substr($value, 0, 128);
-            }
-        }
-
-        return null;
+        return substr($normalized, 0, 128);
     }
 
     private function allowedProviders(): array

--- a/backend/app/Services/Commerce/Webhook/WebhookEntitlementService.php
+++ b/backend/app/Services/Commerce/Webhook/WebhookEntitlementService.php
@@ -3,7 +3,6 @@
 namespace App\Services\Commerce\Webhook;
 
 use App\Internal\Commerce\PaymentWebhookHandlerCore;
-use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Log;
@@ -35,6 +34,7 @@ class WebhookEntitlementService
         $lockTtl = (int) $ctx['lock_ttl'];
         $lockBlock = (int) $ctx['lock_block'];
         $contentionBudgetMs = (int) $ctx['contention_budget_ms'];
+        $requestId = $this->normalizeRequestId($ctx['request_id'] ?? null);
 
         $postCommitCtx = is_array($ctx['post_commit_ctx'] ?? null)
             ? $ctx['post_commit_ctx']
@@ -59,6 +59,7 @@ class WebhookEntitlementService
             $payloadExcerpt,
             $resolvedPayloadMeta,
             $signatureOk,
+            $requestId,
             &$ctx,
             &$postCommitCtx
         ) {
@@ -79,6 +80,7 @@ class WebhookEntitlementService
                 $payloadExcerpt,
                 $resolvedPayloadMeta,
                 $signatureOk,
+                $requestId,
                 $lockBlock,
                 $contentionBudgetMs,
                 $lockKey,
@@ -111,10 +113,9 @@ class WebhookEntitlementService
                     $payloadExcerpt,
                     $resolvedPayloadMeta,
                     $signatureOk,
+                    $requestId,
                     &$postCommitCtx
                 ) {
-                    $requestId = $this->resolveRequestIdForStorage();
-
                     $insertSeed = [
                         'id' => (string) Str::uuid(),
                         'provider' => $provider,
@@ -576,24 +577,13 @@ class WebhookEntitlementService
         return $ctx;
     }
 
-    private function resolveRequestIdForStorage(): ?string
+    private function normalizeRequestId(mixed $value): ?string
     {
-        $request = request();
-        if (! $request instanceof Request) {
+        $normalized = trim((string) $value);
+        if ($normalized === '') {
             return null;
         }
 
-        foreach ([
-            (string) ($request->attributes->get('request_id') ?? ''),
-            (string) $request->header('X-Request-Id', ''),
-            (string) $request->header('X-Request-ID', ''),
-        ] as $candidate) {
-            $value = trim($candidate);
-            if ($value !== '') {
-                return substr($value, 0, 128);
-            }
-        }
-
-        return null;
+        return substr($normalized, 0, 128);
     }
 }

--- a/backend/app/Services/Commerce/Webhook/WebhookEntitlementService.php
+++ b/backend/app/Services/Commerce/Webhook/WebhookEntitlementService.php
@@ -3,6 +3,7 @@
 namespace App\Services\Commerce\Webhook;
 
 use App\Internal\Commerce\PaymentWebhookHandlerCore;
+use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Log;
@@ -112,6 +113,8 @@ class WebhookEntitlementService
                     $signatureOk,
                     &$postCommitCtx
                 ) {
+                    $requestId = $this->resolveRequestIdForStorage();
+
                     $insertSeed = [
                         'id' => (string) Str::uuid(),
                         'provider' => $provider,
@@ -133,6 +136,7 @@ class WebhookEntitlementService
                         'payload_sha256' => $resolvedPayloadMeta['sha256'],
                         'payload_s3_key' => $resolvedPayloadMeta['s3_key'],
                         'payload_excerpt' => $payloadExcerpt,
+                        'request_id' => $requestId,
                         'received_at' => $receivedAt,
                         'created_at' => $receivedAt,
                         'updated_at' => $receivedAt,
@@ -187,6 +191,7 @@ class WebhookEntitlementService
                         'payload_sha256' => $resolvedPayloadMeta['sha256'],
                         'payload_s3_key' => $resolvedPayloadMeta['s3_key'],
                         'payload_excerpt' => $payloadExcerpt,
+                        'request_id' => $requestId,
                         'received_at' => $receivedAt,
                         'updated_at' => $receivedAt,
                     ];
@@ -569,5 +574,26 @@ class WebhookEntitlementService
         $ctx['post_commit_ctx'] = $postCommitCtx;
 
         return $ctx;
+    }
+
+    private function resolveRequestIdForStorage(): ?string
+    {
+        $request = request();
+        if (! $request instanceof Request) {
+            return null;
+        }
+
+        foreach ([
+            (string) ($request->attributes->get('request_id') ?? ''),
+            (string) $request->header('X-Request-Id', ''),
+            (string) $request->header('X-Request-ID', ''),
+        ] as $candidate) {
+            $value = trim($candidate);
+            if ($value !== '') {
+                return substr($value, 0, 128);
+            }
+        }
+
+        return null;
     }
 }

--- a/backend/app/Services/Commerce/Webhook/WebhookPrecheckService.php
+++ b/backend/app/Services/Commerce/Webhook/WebhookPrecheckService.php
@@ -19,7 +19,8 @@ class WebhookPrecheckService
         bool $signatureOk,
         array $payloadMeta,
         string $rawPayloadSha256,
-        int $rawPayloadBytes
+        int $rawPayloadBytes,
+        ?string $requestId = null
     ): array {
         $provider = strtolower(trim($provider));
         if ($provider === 'stub' && ! $this->core->isStubEnabled()) {
@@ -49,6 +50,10 @@ class WebhookPrecheckService
         );
         $payloadSummaryJson = $this->core->encodePayloadSummary($payloadSummary);
         $payloadExcerpt = $this->core->buildPayloadExcerpt($payloadSummaryJson);
+        $normalizedRequestId = trim((string) $requestId);
+        if ($normalizedRequestId !== '') {
+            $normalizedRequestId = substr($normalizedRequestId, 0, 128);
+        }
 
         return [
             'provider' => $provider,
@@ -65,6 +70,7 @@ class WebhookPrecheckService
             'resolved_payload_meta' => $resolvedPayloadMeta,
             'payload_summary_json' => $payloadSummaryJson,
             'payload_excerpt' => $payloadExcerpt,
+            'request_id' => $normalizedRequestId !== '' ? $normalizedRequestId : null,
         ];
     }
 }

--- a/backend/tests/Feature/Ops/EvidencePackCommandTest.php
+++ b/backend/tests/Feature/Ops/EvidencePackCommandTest.php
@@ -83,12 +83,14 @@ final class EvidencePackCommandTest extends TestCase
         $healthzPath = $packDir.'/healthz_snapshot.json';
         $queuePath = $packDir.'/queue_backlog_probe.json';
         $slowPath = $packDir.'/slow_query_telemetry.json';
+        $apiSloPath = $packDir.'/api_slo.json';
 
         $this->assertFileExists($manifestPath);
         $this->assertFileExists($revisionPath);
         $this->assertFileExists($healthzPath);
         $this->assertFileExists($queuePath);
         $this->assertFileExists($slowPath);
+        $this->assertFileExists($apiSloPath);
 
         $manifest = json_decode((string) file_get_contents($manifestPath), true);
         $this->assertIsArray($manifest);
@@ -114,6 +116,13 @@ final class EvidencePackCommandTest extends TestCase
         $this->assertIsArray($slowPayload);
         $this->assertGreaterThanOrEqual(1, (int) ($slowPayload['window_total'] ?? 0));
         $this->assertSame(1, (int) (($slowPayload['by_route']['api/v0.3/attempts/submit'] ?? 0)));
+
+        $apiSloPayload = json_decode((string) file_get_contents($apiSloPath), true);
+        $this->assertIsArray($apiSloPayload);
+        $this->assertSame('UNKNOWN', (string) ($apiSloPayload['status'] ?? ''));
+        $this->assertSame('UNKNOWN', (string) data_get($apiSloPayload, 'metrics.p95_ms.status', ''));
+        $this->assertSame('UNKNOWN', (string) data_get($apiSloPayload, 'metrics.error_rate.status', ''));
+        $this->assertIsArray($apiSloPayload['request_id_coverage'] ?? null);
     }
 
     private function useDatabaseQueueDriver(): void

--- a/backend/tests/Feature/RequestIdPropagationTest.php
+++ b/backend/tests/Feature/RequestIdPropagationTest.php
@@ -1,0 +1,208 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature;
+
+use App\Services\Analytics\EventRecorder;
+use App\Services\Commerce\OrderManager;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Log;
+use Illuminate\Support\Str;
+use Mockery;
+use Tests\TestCase;
+
+final class RequestIdPropagationTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_error_responses_echo_request_id_in_header_and_body_for_key_routes(): void
+    {
+        config([
+            'payments.providers.stripe.enabled' => true,
+            'services.stripe.webhook_secret' => 'whsec_req_id_probe',
+            'fap.rate_limits.bypass_in_test_env' => true,
+        ]);
+
+        $requestId = 'req_fer2_42_errors';
+
+        $webhook = $this->withHeader('X-Request-Id', $requestId)
+            ->postJson('/api/v0.3/webhooks/payment/stripe', $this->stripePayload('evt_reqid_err_1'));
+        $webhook->assertStatus(400);
+        $this->assertSame($requestId, (string) $webhook->headers->get('X-Request-Id'));
+        $this->assertSame($requestId, (string) $webhook->json('request_id'));
+
+        $attemptStart = $this->withHeader('X-Request-Id', $requestId)
+            ->postJson('/api/v0.3/attempts/start', []);
+        $this->assertGreaterThanOrEqual(400, $attemptStart->getStatusCode());
+        $this->assertSame($requestId, (string) $attemptStart->headers->get('X-Request-Id'));
+        $this->assertSame($requestId, (string) $attemptStart->json('request_id'));
+
+        $orderLookup = $this->withHeader('X-Request-Id', $requestId)
+            ->postJson('/api/v0.3/orders/lookup', []);
+        $this->assertGreaterThanOrEqual(400, $orderLookup->getStatusCode());
+        $this->assertSame($requestId, (string) $orderLookup->headers->get('X-Request-Id'));
+        $this->assertSame($requestId, (string) $orderLookup->json('request_id'));
+
+        $report = $this->withHeader('X-Request-Id', $requestId)
+            ->getJson('/api/v0.3/attempts/not-a-uuid/report');
+        $this->assertGreaterThanOrEqual(400, $report->getStatusCode());
+        $this->assertSame($requestId, (string) $report->headers->get('X-Request-Id'));
+        $this->assertSame($requestId, (string) $report->json('request_id'));
+    }
+
+    public function test_middleware_writes_request_id_into_log_context(): void
+    {
+        Log::spy();
+
+        $requestId = 'req_fer2_42_log_context';
+        $response = $this->withHeader('X-Request-Id', $requestId)
+            ->getJson('/api/healthz');
+
+        $response->assertStatus(200);
+        $this->assertSame($requestId, (string) $response->headers->get('X-Request-Id'));
+
+        Log::shouldHaveReceived('withContext')
+            ->with(Mockery::on(static function ($context) use ($requestId): bool {
+                return is_array($context)
+                    && (string) ($context['request_id'] ?? '') === $requestId;
+            }))
+            ->atLeast()
+            ->once();
+
+        Log::shouldHaveReceived('withoutContext')
+            ->atLeast()
+            ->once();
+    }
+
+    public function test_event_recorder_uses_request_attribute_request_id_when_header_absent(): void
+    {
+        $requestId = 'req_fer2_42_event_recorder';
+
+        $request = Request::create('/api/v0.3/events', 'POST', [
+            'anon_id' => 'anon_reqid_event_recorder',
+        ]);
+        $request->attributes->set('request_id', $requestId);
+        $request->attributes->set('org_id', 0);
+
+        app(EventRecorder::class)->recordFromRequest($request, 'request_id_probe', null, [
+            'probe' => true,
+        ]);
+
+        $event = DB::table('events')
+            ->where('event_code', 'request_id_probe')
+            ->orderByDesc('created_at')
+            ->first();
+
+        $this->assertNotNull($event);
+        $this->assertSame($requestId, (string) ($event->request_id ?? ''));
+    }
+
+    public function test_order_manager_writes_request_id_from_http_request_context(): void
+    {
+        $this->seedSku('SKU_REQ_ID_PROBE', 'MBTI');
+
+        $requestId = 'req_fer2_42_order_create';
+        $request = Request::create('/api/v0.3/orders', 'POST');
+        $request->attributes->set('request_id', $requestId);
+
+        $originalRequest = app('request');
+        app()->instance('request', $request);
+
+        try {
+            $result = app(OrderManager::class)->createOrder(
+                0,
+                null,
+                'anon_reqid_order',
+                'SKU_REQ_ID_PROBE',
+                1,
+                null,
+                'billing',
+                null,
+                'anon_reqid_order@example.com'
+            );
+        } finally {
+            app()->instance('request', $originalRequest);
+        }
+
+        $this->assertTrue((bool) ($result['ok'] ?? false));
+        $orderNo = (string) ($result['order_no'] ?? '');
+        $this->assertNotSame('', $orderNo);
+
+        $order = DB::table('orders')->where('order_no', $orderNo)->first();
+        $this->assertNotNull($order);
+        $this->assertSame($requestId, (string) ($order->request_id ?? ''));
+    }
+
+    public function test_payment_webhook_persists_request_id_into_payment_events(): void
+    {
+        config([
+            'payments.providers.stripe.enabled' => true,
+            'services.stripe.webhook_secret' => 'whsec_req_id_storage',
+            'fap.rate_limits.bypass_in_test_env' => true,
+        ]);
+
+        $requestId = 'req_fer2_42_webhook_store';
+        $providerEventId = 'evt_reqid_store_' . Str::lower(Str::random(10));
+
+        $response = $this->withHeader('X-Request-Id', $requestId)
+            ->postJson('/api/v0.3/webhooks/payment/stripe', $this->stripePayload($providerEventId));
+
+        $response->assertStatus(400);
+        $this->assertSame($requestId, (string) $response->headers->get('X-Request-Id'));
+        $this->assertSame($requestId, (string) $response->json('request_id'));
+
+        $event = DB::table('payment_events')
+            ->where('provider', 'stripe')
+            ->where('provider_event_id', $providerEventId)
+            ->first();
+
+        $this->assertNotNull($event);
+        $this->assertSame($requestId, (string) ($event->request_id ?? ''));
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function stripePayload(string $providerEventId): array
+    {
+        return [
+            'id' => $providerEventId,
+            'type' => 'charge.succeeded',
+            'data' => [
+                'object' => [
+                    'id' => 'ch_' . Str::lower(Str::random(8)),
+                    'amount' => 199,
+                    'currency' => 'usd',
+                    'metadata' => [
+                        'order_no' => 'ord_reqid_' . Str::lower(Str::random(8)),
+                    ],
+                ],
+            ],
+        ];
+    }
+
+    private function seedSku(string $sku, string $scaleCode): void
+    {
+        $now = now();
+
+        DB::table('skus')->updateOrInsert(
+            ['org_id' => 0, 'sku' => $sku],
+            [
+                'scale_code' => $scaleCode,
+                'kind' => 'report_unlock',
+                'unit_qty' => 1,
+                'benefit_code' => 'MBTI_REPORT_FULL',
+                'scope' => 'attempt',
+                'price_cents' => 199,
+                'currency' => 'CNY',
+                'is_active' => true,
+                'meta_json' => null,
+                'created_at' => $now,
+                'updated_at' => $now,
+            ]
+        );
+    }
+}

--- a/backend/tests/Feature/RequestIdPropagationTest.php
+++ b/backend/tests/Feature/RequestIdPropagationTest.php
@@ -105,27 +105,18 @@ final class RequestIdPropagationTest extends TestCase
         $this->seedSku('SKU_REQ_ID_PROBE', 'MBTI');
 
         $requestId = 'req_fer2_42_order_create';
-        $request = Request::create('/api/v0.3/orders', 'POST');
-        $request->attributes->set('request_id', $requestId);
-
-        $originalRequest = app('request');
-        app()->instance('request', $request);
-
-        try {
-            $result = app(OrderManager::class)->createOrder(
-                0,
-                null,
-                'anon_reqid_order',
-                'SKU_REQ_ID_PROBE',
-                1,
-                null,
-                'billing',
-                null,
-                'anon_reqid_order@example.com'
-            );
-        } finally {
-            app()->instance('request', $originalRequest);
-        }
+        $result = app(OrderManager::class)->createOrder(
+            0,
+            null,
+            'anon_reqid_order',
+            'SKU_REQ_ID_PROBE',
+            1,
+            null,
+            'billing',
+            null,
+            'anon_reqid_order@example.com',
+            $requestId
+        );
 
         $this->assertTrue((bool) ($result['ok'] ?? false));
         $orderNo = (string) ($result['order_no'] ?? '');


### PR DESCRIPTION
Fixes FER2-42

## Summary
- add `InjectRequestId` middleware to normalize request ID resolution, inject `X-Request-Id` on responses, and attach per-request log context
- keep backward compatibility by turning `AttachRequestId` into an alias of `InjectRequestId`
- propagate request IDs through analytics/order/webhook persistence paths (`events.request_id`, `orders.request_id`, `payment_events.request_id`)
- extend `ops:evidence-pack` with non-blocking `api_slo.json` UNKNOWN placeholders and request-id coverage sampling
- add regression coverage for request-id propagation and evidence pack artifact assertions

## Verification
- `cd backend && php artisan test --filter RequestIdPropagationTest`
- `cd backend && php artisan test --filter EvidencePackCommandTest`
- `bash backend/scripts/ci_verify_mbti.sh`
- `curl -i -sS http://127.0.0.1:8000/api/healthz | grep -i x-request-id`
- `curl -sS -X POST "http://127.0.0.1:8000/api/v0.3/orders/lookup" -H "Content-Type: application/json" -H "X-Request-Id: req_fer2_42_demo" -d '{"order_no":"ord_demo"}' | jq .`
