### PR TITLE
fix(deploy): set unique release_name for deployer

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -231,7 +231,9 @@ jobs:
           DEPLOYER_NO_INTERACTION: "1"
         run: |
           set -euo pipefail
-          php /tmp/dep.phar deploy "$TARGET" -f deploy.php -vvv --no-interaction
+          php /tmp/dep.phar deploy "$TARGET" -f deploy.php \
+            -o release_name="${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}" \
+            -vvv --no-interaction
 
       - name: Restart queue workers (Supervisor)
         shell: bash


### PR DESCRIPTION
Title
fix(deploy): set unique release_name for deployer

Body
## Summary
Fix repeated Deployer failures in `deploy:release` caused by release name collision when remote `releases/*` and `.dep/latest_release` drift.

## Root Cause
Deployer computed next numeric release from stale `.dep/latest_release`, while the target release directory already existed remotely, causing:
`Release name "<n>" already exists`.

## Changes
- In GitHub Actions deploy workflow, pass explicit unique release name:
  - `release_name=${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}`
- Keep Deployer version and deploy recipe flow unchanged.

## Runtime / API Impact
- No API contract changes.
- No business logic changes.
- Deployment behavior only: release naming becomes deterministic and collision-free per workflow run.

## Verification
- `php artisan route:list`
- `php artisan migrate`
- `curl -sS http://127.0.0.1:8000/api/healthz | jq .`
- `bash backend/scripts/ci_verify_mbti.sh` (passed)

## Notes
- One-time remote state reconciliation is still recommended separately:
  sync `.dep/latest_release` with max numeric release directory.
