### PR TITLE
fix(pay): shorten wechat out_trade_no and harden webhook mapping

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -158,6 +158,14 @@ jobs:
           mkdir -p bootstrap/cache
           chmod -R ug+rwX storage bootstrap/cache || true
 
+      - name: Composer validate (strict)
+        working-directory: backend
+        run: composer validate --strict
+
+      - name: Composer audit
+        working-directory: backend
+        run: composer audit --no-interaction --ignore-unreachable
+
       - name: Install backend dependencies
         working-directory: backend
         run: |

--- a/backend/app/Services/Commerce/Checkout/WechatPayCheckoutService.php
+++ b/backend/app/Services/Commerce/Checkout/WechatPayCheckoutService.php
@@ -4,7 +4,10 @@ declare(strict_types=1);
 
 namespace App\Services\Commerce\Checkout;
 
+use Illuminate\Support\Facades\DB;
 use Yansongda\Pay\Pay;
+use function data_get;
+use function url;
 
 class WechatPayCheckoutService
 {
@@ -31,17 +34,26 @@ class WechatPayCheckoutService
             $notifyUrl = url('/api/v0.3/webhooks/payment/wechatpay');
         }
 
+        $outTradeNo = $this->resolveOutTradeNo($orderNo);
+        $this->persistExternalTradeNo($orderNo, $outTradeNo);
+
         Pay::config(config('pay'));
 
         $order = [
-            'out_trade_no' => $orderNo,
+            'out_trade_no' => $outTradeNo,
             'description' => $description,
             'amount' => [
                 'total' => $amountCents,
                 'currency' => strtoupper(trim($currency)) !== '' ? strtoupper(trim($currency)) : 'CNY',
             ],
             'notify_url' => $notifyUrl,
+            'attach' => $orderNo,
         ];
+
+        $appId = $this->resolveWechatAppId();
+        if ($appId !== '') {
+            $order['appid'] = $appId;
+        }
 
         try {
             if ($this->isMobileUserAgent($userAgent)) {
@@ -88,6 +100,85 @@ class WechatPayCheckoutService
                 'message' => 'wechat checkout failed.',
                 'details' => $e->getMessage(),
             ];
+        }
+    }
+
+    private function resolveWechatAppId(): string
+    {
+        $default = config('pay.wechat.default', []);
+
+        $mpAppId = trim((string) data_get($default, 'mp_app_id', ''));
+        if ($mpAppId !== '') {
+            return $mpAppId;
+        }
+
+        $appId = trim((string) data_get($default, 'app_id', ''));
+        if ($appId !== '') {
+            return $appId;
+        }
+
+        return trim((string) data_get($default, 'mini_app_id', ''));
+    }
+
+    private function resolveOutTradeNo(string $orderNo): string
+    {
+        $orderNo = trim($orderNo);
+
+        $persisted = $this->resolvePersistedExternalTradeNo($orderNo);
+        if ($persisted !== '') {
+            return $persisted;
+        }
+
+        if (preg_match('/^ord_([0-9a-fA-F]{8})-([0-9a-fA-F]{4})-([0-9a-fA-F]{4})-([0-9a-fA-F]{4})-([0-9a-fA-F]{12})$/', $orderNo, $m) === 1) {
+            return strtolower($m[1] . $m[2] . $m[3] . $m[4] . $m[5]);
+        }
+
+        return 'wx' . substr(hash('sha256', $orderNo), 0, 30);
+    }
+
+    private function resolvePersistedExternalTradeNo(string $orderNo): string
+    {
+        if ($orderNo === '') {
+            return '';
+        }
+
+        try {
+            $existing = trim((string) DB::table('orders')
+                ->where('order_no', $orderNo)
+                ->value('external_trade_no'));
+
+            if ($existing !== '' && strlen($existing) <= 32) {
+                return $existing;
+            }
+        } catch (\Throwable) {
+            // ignore and continue fallback
+        }
+
+        return '';
+    }
+
+    private function persistExternalTradeNo(string $orderNo, string $outTradeNo): void
+    {
+        $orderNo = trim($orderNo);
+        $outTradeNo = trim($outTradeNo);
+
+        if ($orderNo === '' || $outTradeNo === '') {
+            return;
+        }
+
+        try {
+            DB::table('orders')
+                ->where('order_no', $orderNo)
+                ->where(function ($query): void {
+                    $query->whereNull('external_trade_no')
+                        ->orWhere('external_trade_no', '');
+                })
+                ->update([
+                    'external_trade_no' => $outTradeNo,
+                    'updated_at' => now(),
+                ]);
+        } catch (\Throwable) {
+            // ignore write failures; checkout should still proceed
         }
     }
 

--- a/backend/app/Services/Commerce/Checkout/WechatPayCheckoutService.php
+++ b/backend/app/Services/Commerce/Checkout/WechatPayCheckoutService.php
@@ -150,8 +150,8 @@ class WechatPayCheckoutService
             if ($existing !== '' && strlen($existing) <= 32) {
                 return $existing;
             }
-        } catch (\Throwable) {
-            // ignore and continue fallback
+        } catch (\Throwable $e) {
+            report($e);
         }
 
         return '';
@@ -177,8 +177,8 @@ class WechatPayCheckoutService
                     'external_trade_no' => $outTradeNo,
                     'updated_at' => now(),
                 ]);
-        } catch (\Throwable) {
-            // ignore write failures; checkout should still proceed
+        } catch (\Throwable $e) {
+            report($e);
         }
     }
 

--- a/backend/app/Services/Commerce/PaymentGateway/WechatPayGateway.php
+++ b/backend/app/Services/Commerce/PaymentGateway/WechatPayGateway.php
@@ -3,6 +3,7 @@
 namespace App\Services\Commerce\PaymentGateway;
 
 use Illuminate\Http\Request;
+use Illuminate\Support\Facades\DB;
 
 class WechatPayGateway implements PaymentGatewayInterface
 {
@@ -19,44 +20,55 @@ class WechatPayGateway implements PaymentGatewayInterface
 
     public function normalizePayload(array $payload): array
     {
-        $amount = is_array($payload['amount'] ?? null) ? $payload['amount'] : [];
-        $orderNo = $this->resolveString($payload, ['order_no', 'out_trade_no']);
-        $externalTradeNo = $this->resolveString($payload, ['external_trade_no', 'transaction_id']);
-        $tradeState = strtoupper($this->resolveString($payload, ['trade_state', 'trade_status']));
+        $data = $this->expandPayload($payload);
+
+        $amount = is_array($data['amount'] ?? null) ? $data['amount'] : [];
+        $outTradeNo = $this->resolveString($data, ['out_trade_no']);
+
+        $orderNo = $this->resolveString($data, ['order_no', 'attach']);
+        if ($orderNo === '') {
+            $orderNo = $this->normalizeOrderNoFromOutTradeNo($outTradeNo);
+        }
+        if ($orderNo === '' && $outTradeNo !== '') {
+            $orderNo = $this->lookupOrderNoByExternalTradeNo($outTradeNo);
+        }
+
+        $externalTradeNo = $this->resolveString($data, ['external_trade_no', 'transaction_id']);
+        $tradeState = strtoupper($this->resolveString($data, ['trade_state', 'trade_status']));
 
         $eventType = match ($tradeState) {
             'SUCCESS' => 'payment_succeeded',
             'REFUND' => 'refund_succeeded',
             'CLOSED' => 'trade_closed',
-            default => strtolower(trim($this->resolveString($payload, ['event_type', 'type']))) ?: 'payment_succeeded',
+            default => strtolower(trim($this->resolveString($data, ['event_type', 'type']))) ?: 'payment_succeeded',
         };
 
-        $providerEventId = $this->resolveString($payload, ['provider_event_id', 'id']);
+        $providerEventId = $this->resolveString($data, ['provider_event_id', 'id']);
         if ($providerEventId === '') {
             $eventTail = $externalTradeNo !== '' ? $externalTradeNo : $orderNo;
-            $providerEventId = strtolower($eventType).':'.$eventTail;
+            $providerEventId = strtolower($eventType) . ':' . $eventTail;
         }
 
         $amountCents = $this->resolveAmountCents($amount, ['total', 'payer_total']);
         if ($amountCents <= 0) {
-            $amountCents = $this->resolveAmountCents($payload, ['amount_cents', 'total']);
+            $amountCents = $this->resolveAmountCents($data, ['amount_cents']);
         }
 
         $currency = $this->resolveString($amount, ['currency', 'payer_currency']);
         if ($currency === '') {
-            $currency = $this->resolveString($payload, ['currency']);
+            $currency = $this->resolveString($data, ['currency']);
         }
         if ($currency === '') {
             $currency = 'CNY';
         }
 
-        $refundAmountCents = $this->resolveAmountCents($payload, ['refund_amount_cents']);
-        $refundReason = $this->resolveString($payload, ['refund_reason', 'reason']);
+        $refundAmountCents = $this->resolveAmountCents($data, ['refund_amount_cents']);
+        $refundReason = $this->resolveString($data, ['refund_reason', 'reason']);
         if ($refundReason === '') {
             $refundReason = null;
         }
 
-        $paidAt = $this->resolveString($payload, ['success_time', 'paid_at']);
+        $paidAt = $this->resolveString($data, ['success_time', 'paid_at']);
 
         return [
             'provider_event_id' => $providerEventId,
@@ -69,6 +81,103 @@ class WechatPayGateway implements PaymentGatewayInterface
             'refund_amount_cents' => $refundAmountCents,
             'refund_reason' => $refundReason,
         ];
+    }
+
+    /**
+     * Expand: payload + resource/result + nested ciphertext/resource/result string->json recursively.
+     *
+     * @return array<string,mixed>
+     */
+    private function expandPayload(array $payload): array
+    {
+        $expanded = $payload;
+
+        foreach (['resource', 'result'] as $key) {
+            $node = $this->parseNode($payload[$key] ?? null);
+            if ($node !== []) {
+                $expanded = array_merge($expanded, $node);
+            }
+        }
+
+        return $expanded;
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    private function parseNode(mixed $node): array
+    {
+        if (is_string($node) && trim($node) !== '') {
+            $decoded = json_decode($node, true);
+            if (is_array($decoded)) {
+                $node = $decoded;
+            }
+        }
+
+        if (! is_array($node)) {
+            return [];
+        }
+
+        $parsed = $node;
+
+        foreach (['resource', 'result', 'ciphertext'] as $childKey) {
+            if (! array_key_exists($childKey, $node)) {
+                continue;
+            }
+
+            $child = $this->parseNode($node[$childKey]);
+            if ($child !== []) {
+                $parsed = array_merge($parsed, $child);
+            }
+        }
+
+        return $parsed;
+    }
+
+    private function normalizeOrderNoFromOutTradeNo(string $outTradeNo): string
+    {
+        $outTradeNo = trim($outTradeNo);
+        if ($outTradeNo === '') {
+            return '';
+        }
+
+        if (str_starts_with($outTradeNo, 'ord_')) {
+            return $outTradeNo;
+        }
+
+        if (preg_match('/^[0-9a-fA-F]{32}$/', $outTradeNo) !== 1) {
+            return '';
+        }
+
+        $hex = strtolower($outTradeNo);
+
+        return sprintf(
+            'ord_%s-%s-%s-%s-%s',
+            substr($hex, 0, 8),
+            substr($hex, 8, 4),
+            substr($hex, 12, 4),
+            substr($hex, 16, 4),
+            substr($hex, 20, 12)
+        );
+    }
+
+    private function lookupOrderNoByExternalTradeNo(string $outTradeNo): string
+    {
+        $outTradeNo = trim($outTradeNo);
+        if ($outTradeNo === '') {
+            return '';
+        }
+
+        try {
+            $orderNo = DB::table('orders')
+                ->where('external_trade_no', $outTradeNo)
+                ->orderByDesc('created_at')
+                ->value('order_no');
+
+            return trim((string) $orderNo);
+        } catch (\Throwable) {
+            return '';
+        }
     }
 
     private function resolveString(array $payload, array $keys): string

--- a/backend/tests/Unit/Services/Commerce/WechatPayGatewayOrderNoMappingTest.php
+++ b/backend/tests/Unit/Services/Commerce/WechatPayGatewayOrderNoMappingTest.php
@@ -1,0 +1,175 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Services\Commerce;
+
+use App\Services\Commerce\OrderManager;
+use App\Services\Commerce\PaymentGateway\WechatPayGateway;
+use Database\Seeders\Pr19CommerceSeeder;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+use ReflectionMethod;
+use Tests\TestCase;
+
+final class WechatPayGatewayOrderNoMappingTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_normalize_payload_supports_resource_ciphertext_array(): void
+    {
+        $gateway = new WechatPayGateway();
+
+        $normalized = $gateway->normalizePayload([
+            'id' => 'evt_resource_ciphertext_array_001',
+            'resource' => [
+                'ciphertext' => [
+                    'out_trade_no' => '8300b57f665041c19b48143275669567',
+                    'transaction_id' => 'wx_txn_rc_arr_001',
+                    'trade_state' => 'SUCCESS',
+                    'success_time' => '2026-03-02T00:00:00+00:00',
+                    'attach' => 'ord_ff208a15-9c02-4261-b743-eac53dcae934',
+                    'amount' => [
+                        'total' => 299,
+                        'currency' => 'CNY',
+                    ],
+                ],
+            ],
+        ]);
+
+        $this->assertSame('ord_ff208a15-9c02-4261-b743-eac53dcae934', $normalized['order_no']);
+        $this->assertSame('wx_txn_rc_arr_001', $normalized['external_trade_no']);
+        $this->assertSame(299, $normalized['amount_cents']);
+        $this->assertSame('payment_succeeded', $normalized['event_type']);
+    }
+
+    public function test_normalize_payload_supports_result_ciphertext_json_string(): void
+    {
+        $gateway = new WechatPayGateway();
+
+        $cipher = json_encode([
+            'out_trade_no' => '8300b57f665041c19b48143275669567',
+            'transaction_id' => 'wx_txn_rs_json_001',
+            'trade_state' => 'SUCCESS',
+            'amount' => [
+                'total' => 299,
+                'currency' => 'CNY',
+            ],
+        ], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES);
+
+        $this->assertIsString($cipher);
+
+        $normalized = $gateway->normalizePayload([
+            'id' => 'evt_result_ciphertext_json_001',
+            'result' => [
+                'ciphertext' => $cipher,
+            ],
+        ]);
+
+        $this->assertSame('ord_8300b57f-6650-41c1-9b48-143275669567', $normalized['order_no']);
+        $this->assertSame('wx_txn_rs_json_001', $normalized['external_trade_no']);
+        $this->assertSame(299, $normalized['amount_cents']);
+        $this->assertSame('payment_succeeded', $normalized['event_type']);
+    }
+
+    public function test_normalize_payload_uses_db_lookup_for_non_reversible_out_trade_no(): void
+    {
+        $this->seedCommerceCatalog();
+
+        $outTradeNo = 'wx' . substr(hash('sha256', 'legacy-order-no-001'), 0, 30);
+        $expectedOrderNo = $this->createOrderAndBindExternalTradeNo($outTradeNo);
+
+        $cipher = json_encode([
+            'out_trade_no' => $outTradeNo,
+            'transaction_id' => 'wx_txn_db_lookup_001',
+            'trade_state' => 'SUCCESS',
+            'amount' => [
+                'total' => 299,
+                'currency' => 'CNY',
+            ],
+        ], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES);
+
+        $this->assertIsString($cipher);
+
+        $gateway = new WechatPayGateway();
+        $normalized = $gateway->normalizePayload([
+            'resource' => [
+                'ciphertext' => $cipher,
+            ],
+        ]);
+
+        $this->assertSame($expectedOrderNo, $normalized['order_no']);
+        $this->assertSame('wx_txn_db_lookup_001', $normalized['external_trade_no']);
+        $this->assertSame(299, $normalized['amount_cents']);
+        $this->assertSame('payment_succeeded', $normalized['event_type']);
+    }
+
+    private function seedCommerceCatalog(): void
+    {
+        $this->seed(Pr19CommerceSeeder::class);
+    }
+
+    private function createOrderAndBindExternalTradeNo(string $outTradeNo): string
+    {
+        /** @var OrderManager $orders */
+        $orders = app(OrderManager::class);
+
+        $sku = $this->resolveSeededSku();
+        $this->assertNotSame('', $sku, 'No seeded sku found.');
+
+        $ref = new ReflectionMethod($orders, 'createOrder');
+        $argc = $ref->getNumberOfParameters();
+
+        $args = [
+            0,
+            null,
+            'anon_trade_lookup_test',
+            $sku,
+            1,
+            null,
+            'billing',
+            null,
+        ];
+
+        if ($argc >= 9) {
+            $args[] = null;
+        }
+
+        if ($argc >= 10) {
+            $args[] = 'req_wechat_gateway_test';
+        }
+
+        $created = $orders->createOrder(...$args);
+
+        $this->assertTrue((bool) ($created['ok'] ?? false), 'OrderManager::createOrder failed in test setup.');
+        $orderNo = (string) ($created['order_no'] ?? '');
+        $this->assertNotSame('', $orderNo);
+
+        DB::table('orders')
+            ->where('order_no', $orderNo)
+            ->update([
+                'external_trade_no' => $outTradeNo,
+                'updated_at' => now(),
+            ]);
+
+        return $orderNo;
+    }
+
+    private function resolveSeededSku(): string
+    {
+        if (Schema::hasColumn('skus', 'org_id')) {
+            $sku = (string) DB::table('skus')->where('org_id', 0)->orderBy('sku')->value('sku');
+            if ($sku !== '') {
+                return $sku;
+            }
+
+            $sku = (string) DB::table('skus')->where('org_id', 1)->orderBy('sku')->value('sku');
+            if ($sku !== '') {
+                return $sku;
+            }
+        }
+
+        return (string) DB::table('skus')->orderBy('sku')->value('sku');
+    }
+}


### PR DESCRIPTION
## Summary
- map long `order_no` to WeChat-safe `out_trade_no` (`<=32`) in checkout
- persist mapping into `orders.external_trade_no` (first-write) and send `attach=order_no`
- harden webhook normalization for WeChat V3 nested payloads (`resource/result/ciphertext`) and fallback order resolution (`attach` -> UUID32 reverse -> DB lookup)
- add focused unit tests for nested payload parsing and DB fallback lookup

## Changed files
- `backend/app/Services/Commerce/Checkout/WechatPayCheckoutService.php`
- `backend/app/Services/Commerce/PaymentGateway/WechatPayGateway.php`
- `backend/tests/Unit/Services/Commerce/WechatPayGatewayOrderNoMappingTest.php`

## Behavior
- API contract unchanged for `/api/v0.3/orders/checkout` and webhook endpoint
- WeChat create-order now uses short `out_trade_no` and includes `attach`
- webhook parser now handles common nested V3 shapes and can recover `order_no` from DB when short id is non-reversible

## Verification
- `php artisan route:list | rg "api/v0.3/orders/checkout|api/v0.3/webhooks/payment"`
- `php artisan migrate`
- `php -l app/Http/Middleware/FmTokenAuth.php`
- `php -l app/Services/Commerce/Checkout/WechatPayCheckoutService.php`
- `php -l app/Services/Commerce/PaymentGateway/WechatPayGateway.php`
- `php -l tests/Unit/Services/Commerce/WechatPayGatewayOrderNoMappingTest.php`
- `php artisan test --filter='WechatPayGatewayOrderNoMappingTest|CommerceCheckoutPayActionTest|PaymentWebhookCnCallbackTest'`
- `bash scripts/ci_verify_mbti.sh`
