### PR TITLE
fix(v0.3): persist token user owner on public attempts start

### DIFF
--- a/backend/app/Http/Middleware/ResolveOrgContext.php
+++ b/backend/app/Http/Middleware/ResolveOrgContext.php
@@ -61,6 +61,15 @@ class ResolveOrgContext
             }
         } else {
             $orgId = 0;
+
+            if ($userId === null) {
+                $userId = $this->resolveUserIdFromToken($request);
+                if ($userId !== null) {
+                    $request->attributes->set('fm_user_id', (string) $userId);
+                    $request->attributes->set('user_id', (string) $userId);
+                }
+            }
+
             $role = $this->resolveTokenRole($request) ?? 'public';
         }
 

--- a/backend/tests/Feature/V0_3/AttemptWriteSlimControllerTest.php
+++ b/backend/tests/Feature/V0_3/AttemptWriteSlimControllerTest.php
@@ -37,6 +37,18 @@ class AttemptWriteSlimControllerTest extends TestCase
         (new Pr17SimpleScoreDemoSeeder)->run();
     }
 
+    private function issueUserToken(string $userId, string $anonId): string
+    {
+        $issued = app(\App\Services\Auth\FmTokenService::class)->issueForUser($userId, [
+            'provider' => 'phone',
+            'anon_id' => $anonId,
+            'org_id' => 0,
+            'role' => 'public',
+        ]);
+
+        return (string) ($issued['token'] ?? '');
+    }
+
     public function test_start_returns_attempt_id_and_question_count(): void
     {
         $this->seedScales();
@@ -97,5 +109,40 @@ class AttemptWriteSlimControllerTest extends TestCase
         $this->assertIsBool($submit->json('report.locked'));
         $this->assertIsString($submit->json('report.access_level'));
         $this->assertIsString($submit->json('report.variant'));
+    }
+
+    public function test_start_persists_numeric_user_owner_from_token_in_public_org_context(): void
+    {
+        $this->seedScales();
+
+        DB::table('users')->insertOrIgnore([
+            'id' => 1001,
+            'name' => 'owner-1001',
+            'email' => 'owner1001@example.test',
+            'password' => '$2y$10$92IXUNpkjO0rOQ5byMi.Ye4oKoEa3Ro9llC/.og/at2.uheWG/igi',
+            'created_at' => now(),
+            'updated_at' => now(),
+        ]);
+
+        $token = $this->issueUserToken('1001', 'anon_token_owner');
+        $this->assertNotSame('', $token);
+
+        $start = $this->withHeaders([
+            'Authorization' => 'Bearer '.$token,
+        ])->postJson('/api/v0.3/attempts/start', [
+            'scale_code' => 'SIMPLE_SCORE_DEMO',
+            'anon_id' => 'anon_payload_owner',
+        ]);
+
+        $start->assertStatus(200);
+
+        $attemptId = (string) $start->json('attempt_id');
+        $this->assertNotSame('', $attemptId);
+
+        $attempt = DB::table('attempts')->where('id', $attemptId)->first();
+
+        $this->assertNotNull($attempt);
+        $this->assertSame('1001', (string) ($attempt->user_id ?? ''));
+        $this->assertSame('anon_payload_owner', (string) ($attempt->anon_id ?? ''));
     }
 }


### PR DESCRIPTION
## Summary
- resolve `user_id` from fm token in `ResolveOrgContext` when `org_id=0`
- write resolved token user into request attributes so downstream ownership resolution is consistent
- add regression test to verify `/api/v0.3/attempts/start` persists `attempts.user_id` for public-org token flow

## Why
- fixes owner loss on public start flow that could lead to `ATTEMPT_OWNER_MISMATCH` during payment unlock

## Tests Ran
- `php artisan route:list | egrep 'api/v0\.3/attempts/(start|submit)'`
- `php artisan migrate`
- `php artisan test --filter test_start_persists_numeric_user_owner_from_token_in_public_org_context`
- `php artisan test --filter AttemptWriteSlimControllerTest`
- `bash backend/scripts/ci_verify_mbti.sh`
