### PR TITLE
fix(v0.3): persist sync submission status for /submission

### DIFF
--- a/backend/app/Services/Attempts/AttemptSubmissionService.php
+++ b/backend/app/Services/Attempts/AttemptSubmissionService.php
@@ -25,14 +25,47 @@ final class AttemptSubmissionService
      */
     public function submit(OrgContext $ctx, string $attemptId, SubmitAttemptDTO $dto, bool $preferAsync): array
     {
-        if (! $preferAsync || ! SchemaBaseline::hasTable('attempt_submissions')) {
+        $attemptId = trim($attemptId);
+        $hasTable = SchemaBaseline::hasTable('attempt_submissions');
+
+        // sync: keep submit contract unchanged and mirror status into attempt_submissions for /submission.
+        if (! $preferAsync || ! $hasTable) {
+            try {
+                $resultPayload = $this->attemptSubmitService->submit($ctx, $attemptId, $dto);
+            } catch (ApiProblemException $e) {
+                if ($hasTable) {
+                    $this->recordSyncSubmissionFailure(
+                        $ctx,
+                        $attemptId,
+                        $dto,
+                        $e->errorCode(),
+                        $e->getMessage()
+                    );
+                }
+                throw $e;
+            } catch (\Throwable $e) {
+                if ($hasTable) {
+                    $this->recordSyncSubmissionFailure(
+                        $ctx,
+                        $attemptId,
+                        $dto,
+                        'SUBMISSION_SYNC_FAILED',
+                        $e::class.': '.$e->getMessage()
+                    );
+                }
+                throw $e;
+            }
+
+            if ($hasTable) {
+                $this->recordSyncSubmissionSuccess($ctx, $attemptId, $dto, $resultPayload);
+            }
+
             return [
                 'http_status' => 200,
-                'payload' => $this->attemptSubmitService->submit($ctx, $attemptId, $dto),
+                'payload' => $resultPayload,
             ];
         }
 
-        $attemptId = trim($attemptId);
         if ($attemptId === '') {
             throw new ApiProblemException(400, 'VALIDATION_FAILED', 'attempt_id is required.');
         }
@@ -230,8 +263,8 @@ final class AttemptSubmissionService
         }
 
         $row = $query
-            ->orderByDesc('created_at')
             ->orderByDesc('updated_at')
+            ->orderByDesc('created_at')
             ->first();
 
         if ($row === null) {
@@ -251,6 +284,7 @@ final class AttemptSubmissionService
             'attempt_id' => $attemptId,
             'submission' => [
                 'id' => (string) ($row->id ?? ''),
+                'mode' => strtolower(trim((string) ($row->mode ?? ''))),
                 'state' => $state,
                 'error_code' => $this->nullableString($row->error_code ?? null),
                 'error_message' => $this->nullableString($row->error_message ?? null),
@@ -294,6 +328,142 @@ final class AttemptSubmissionService
                 'finished_at' => now(),
                 'updated_at' => now(),
             ]);
+    }
+
+    /**
+     * @param  array<string,mixed>  $responsePayload
+     */
+    private function recordSyncSubmissionSuccess(OrgContext $ctx, string $attemptId, SubmitAttemptDTO $dto, array $responsePayload): void
+    {
+        $attemptId = trim($attemptId);
+        if ($attemptId === '' || ! SchemaBaseline::hasTable('attempt_submissions')) {
+            return;
+        }
+
+        $actorUserId = $this->resolveUserId($ctx, $dto->userId);
+        $actorAnonId = $this->resolveAnonId($ctx, $dto->anonId);
+
+        $payload = $this->buildPayload($dto, $actorUserId, $actorAnonId);
+        $dedupeKey = $this->buildDedupeKey($ctx->orgId(), $attemptId, $payload);
+        $orgId = $ctx->orgId();
+        $now = now();
+
+        $encodedRequest = json_encode($payload, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES);
+        $encodedResponse = json_encode($responsePayload, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES);
+
+        DB::transaction(function () use ($orgId, $attemptId, $actorUserId, $actorAnonId, $dedupeKey, $encodedRequest, $encodedResponse, $now): void {
+            $existing = DB::table('attempt_submissions')
+                ->where('org_id', $orgId)
+                ->where('dedupe_key', $dedupeKey)
+                ->lockForUpdate()
+                ->first();
+
+            if ($existing !== null) {
+                DB::table('attempt_submissions')
+                    ->where('id', (string) $existing->id)
+                    ->update([
+                        'mode' => 'sync',
+                        'state' => 'succeeded',
+                        'error_code' => null,
+                        'error_message' => null,
+                        'request_payload_json' => $encodedRequest,
+                        'response_payload_json' => $encodedResponse,
+                        'started_at' => $existing->started_at ?? $now,
+                        'finished_at' => $now,
+                        'updated_at' => $now,
+                    ]);
+
+                return;
+            }
+
+            DB::table('attempt_submissions')->insert([
+                'id' => (string) Str::uuid(),
+                'org_id' => $orgId,
+                'attempt_id' => $attemptId,
+                'actor_user_id' => $actorUserId !== null ? (int) $actorUserId : null,
+                'actor_anon_id' => $actorAnonId,
+                'dedupe_key' => $dedupeKey,
+                'mode' => 'sync',
+                'state' => 'succeeded',
+                'error_code' => null,
+                'error_message' => null,
+                'request_payload_json' => $encodedRequest,
+                'response_payload_json' => $encodedResponse,
+                'started_at' => $now,
+                'finished_at' => $now,
+                'created_at' => $now,
+                'updated_at' => $now,
+            ]);
+        });
+    }
+
+    private function recordSyncSubmissionFailure(OrgContext $ctx, string $attemptId, SubmitAttemptDTO $dto, string $errorCode, string $message): void
+    {
+        $attemptId = trim($attemptId);
+        if ($attemptId === '' || ! SchemaBaseline::hasTable('attempt_submissions')) {
+            return;
+        }
+
+        $actorUserId = $this->resolveUserId($ctx, $dto->userId);
+        $actorAnonId = $this->resolveAnonId($ctx, $dto->anonId);
+
+        $payload = $this->buildPayload($dto, $actorUserId, $actorAnonId);
+        $dedupeKey = $this->buildDedupeKey($ctx->orgId(), $attemptId, $payload);
+        $orgId = $ctx->orgId();
+        $now = now();
+
+        $errorCode = strtoupper(trim($errorCode));
+        if ($errorCode === '') {
+            $errorCode = 'SUBMISSION_FAILED';
+        }
+
+        $encodedRequest = json_encode($payload, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES);
+        $errorMessage = $this->truncate($message, 255);
+
+        DB::transaction(function () use ($orgId, $attemptId, $actorUserId, $actorAnonId, $dedupeKey, $encodedRequest, $errorCode, $errorMessage, $now): void {
+            $existing = DB::table('attempt_submissions')
+                ->where('org_id', $orgId)
+                ->where('dedupe_key', $dedupeKey)
+                ->lockForUpdate()
+                ->first();
+
+            if ($existing !== null) {
+                DB::table('attempt_submissions')
+                    ->where('id', (string) $existing->id)
+                    ->update([
+                        'mode' => 'sync',
+                        'state' => 'failed',
+                        'error_code' => $errorCode,
+                        'error_message' => $errorMessage,
+                        'request_payload_json' => $encodedRequest,
+                        'response_payload_json' => null,
+                        'started_at' => $existing->started_at ?? $now,
+                        'finished_at' => $now,
+                        'updated_at' => $now,
+                    ]);
+
+                return;
+            }
+
+            DB::table('attempt_submissions')->insert([
+                'id' => (string) Str::uuid(),
+                'org_id' => $orgId,
+                'attempt_id' => $attemptId,
+                'actor_user_id' => $actorUserId !== null ? (int) $actorUserId : null,
+                'actor_anon_id' => $actorAnonId,
+                'dedupe_key' => $dedupeKey,
+                'mode' => 'sync',
+                'state' => 'failed',
+                'error_code' => $errorCode,
+                'error_message' => $errorMessage,
+                'request_payload_json' => $encodedRequest,
+                'response_payload_json' => null,
+                'started_at' => $now,
+                'finished_at' => $now,
+                'created_at' => $now,
+                'updated_at' => $now,
+            ]);
+        });
     }
 
     /**
@@ -457,4 +627,3 @@ final class AttemptSubmissionService
         return $query->whereRaw('1=0');
     }
 }
-

--- a/backend/tests/Feature/V0_3/AttemptSubmissionSyncFlowTest.php
+++ b/backend/tests/Feature/V0_3/AttemptSubmissionSyncFlowTest.php
@@ -1,0 +1,183 @@
+<?php
+
+namespace Tests\Feature\V0_3;
+
+use Database\Seeders\Pr17SimpleScoreDemoSeeder;
+use Database\Seeders\ScaleRegistrySeeder;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Str;
+use Tests\TestCase;
+
+class AttemptSubmissionSyncFlowTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private function issueAnonToken(string $anonId): string
+    {
+        $token = 'fm_'.(string) Str::uuid();
+        DB::table('auth_tokens')->insert([
+            'token_hash' => hash('sha256', $token),
+            'user_id' => null,
+            'anon_id' => $anonId,
+            'org_id' => 0,
+            'role' => 'public',
+            'meta_json' => null,
+            'expires_at' => now()->addDay(),
+            'revoked_at' => null,
+            'last_used_at' => null,
+            'created_at' => now(),
+            'updated_at' => now(),
+        ]);
+
+        return $token;
+    }
+
+    private function seedScales(): void
+    {
+        (new ScaleRegistrySeeder())->run();
+        (new Pr17SimpleScoreDemoSeeder())->run();
+    }
+
+    public function test_sync_legacy_submit_records_succeeded_submission_and_status_endpoint_reads_it(): void
+    {
+        config()->set('fap.features.submit_async_v2', true);
+        $this->seedScales();
+
+        $anonId = 'anon_sync_submit_owner';
+        $token = $this->issueAnonToken($anonId);
+
+        $start = $this->withHeaders([
+            'X-Anon-Id' => $anonId,
+        ])->postJson('/api/v0.3/attempts/start', [
+            'scale_code' => 'SIMPLE_SCORE_DEMO',
+            'anon_id' => $anonId,
+        ]);
+
+        $start->assertStatus(200);
+        $attemptId = (string) $start->json('attempt_id');
+
+        $submit = $this->withHeaders([
+            'X-Anon-Id' => $anonId,
+            'Authorization' => 'Bearer '.$token,
+        ])->postJson('/api/v0.3/attempts/submit?mode=sync_legacy', [
+            'attempt_id' => $attemptId,
+            'answers' => [
+                ['question_id' => 'SS-001', 'code' => '5'],
+                ['question_id' => 'SS-002', 'code' => '4'],
+                ['question_id' => 'SS-003', 'code' => '3'],
+                ['question_id' => 'SS-004', 'code' => '2'],
+                ['question_id' => 'SS-005', 'code' => '1'],
+            ],
+            'duration_ms' => 120000,
+        ]);
+
+        $submit->assertStatus(200);
+        $submit->assertJson([
+            'ok' => true,
+            'attempt_id' => $attemptId,
+        ]);
+
+        $row = DB::table('attempt_submissions')
+            ->where('org_id', 0)
+            ->where('attempt_id', $attemptId)
+            ->orderByDesc('updated_at')
+            ->first();
+
+        $this->assertNotNull($row);
+        $this->assertSame('sync', (string) ($row->mode ?? ''));
+        $this->assertSame('succeeded', (string) ($row->state ?? ''));
+        $this->assertNotNull($row->response_payload_json ?? null);
+
+        $status = $this->withHeaders([
+            'X-Anon-Id' => $anonId,
+        ])->getJson('/api/v0.3/attempts/'.$attemptId.'/submission');
+
+        $status->assertStatus(200);
+        $status->assertJson([
+            'ok' => true,
+            'attempt_id' => $attemptId,
+            'generating' => false,
+            'submission' => [
+                'state' => 'succeeded',
+                'mode' => 'sync',
+            ],
+        ]);
+        $this->assertNotNull(data_get($status->json(), 'result'));
+    }
+
+    public function test_sync_legacy_success_is_returned_when_previous_async_submission_failed(): void
+    {
+        config()->set('fap.features.submit_async_v2', true);
+        $this->seedScales();
+
+        $anonId = 'anon_sync_after_async_failed';
+        $token = $this->issueAnonToken($anonId);
+
+        $start = $this->withHeaders([
+            'X-Anon-Id' => $anonId,
+        ])->postJson('/api/v0.3/attempts/start', [
+            'scale_code' => 'SIMPLE_SCORE_DEMO',
+            'anon_id' => $anonId,
+        ]);
+
+        $start->assertStatus(200);
+        $attemptId = (string) $start->json('attempt_id');
+
+        $stale = now()->subMinutes(10);
+        DB::table('attempt_submissions')->insert([
+            'id' => (string) Str::uuid(),
+            'org_id' => 0,
+            'attempt_id' => $attemptId,
+            'actor_user_id' => null,
+            'actor_anon_id' => $anonId,
+            'dedupe_key' => hash('sha256', 'stale_failed_'.$attemptId),
+            'mode' => 'async',
+            'state' => 'failed',
+            'error_code' => 'VALIDATION_FAILED',
+            'error_message' => 'answers required.',
+            'request_payload_json' => json_encode(['answers' => []], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES),
+            'response_payload_json' => null,
+            'started_at' => $stale,
+            'finished_at' => $stale,
+            'created_at' => $stale,
+            'updated_at' => $stale,
+        ]);
+
+        $submit = $this->withHeaders([
+            'X-Anon-Id' => $anonId,
+            'Authorization' => 'Bearer '.$token,
+        ])->postJson('/api/v0.3/attempts/submit?mode=sync_legacy', [
+            'attempt_id' => $attemptId,
+            'answers' => [
+                ['question_id' => 'SS-001', 'code' => '5'],
+                ['question_id' => 'SS-002', 'code' => '4'],
+                ['question_id' => 'SS-003', 'code' => '3'],
+                ['question_id' => 'SS-004', 'code' => '2'],
+                ['question_id' => 'SS-005', 'code' => '1'],
+            ],
+            'duration_ms' => 120000,
+        ]);
+
+        $submit->assertStatus(200);
+        $submit->assertJson([
+            'ok' => true,
+            'attempt_id' => $attemptId,
+        ]);
+
+        $status = $this->withHeaders([
+            'X-Anon-Id' => $anonId,
+        ])->getJson('/api/v0.3/attempts/'.$attemptId.'/submission');
+
+        $status->assertStatus(200);
+        $status->assertJson([
+            'ok' => true,
+            'attempt_id' => $attemptId,
+            'generating' => false,
+            'submission' => [
+                'state' => 'succeeded',
+                'mode' => 'sync',
+            ],
+        ]);
+    }
+}


### PR DESCRIPTION
## Summary
- Persist sync submit outcomes into `attempt_submissions` so `GET /api/v0.3/attempts/{attempt_id}/submission` reflects the latest sync status instead of stale async failures.
- Keep sync submit API contract unchanged (`200 + original payload`).
- Extend submission payload with `submission.mode` and make latest ordering prefer `updated_at` over `created_at`.
- Add sync regression tests covering:
  - sync success writes `mode=sync,state=succeeded` and `/submission` returns success.
  - stale async `failed` record no longer overrides a newer sync success.

## Changed Files
- `backend/app/Services/Attempts/AttemptSubmissionService.php`
- `backend/tests/Feature/V0_3/AttemptSubmissionSyncFlowTest.php`

## Verification
- `php artisan route:list`
- `php artisan migrate`
- `php artisan route:list --path=api/v0.3/attempts/submit -vv`
- `php artisan test --filter AttemptSubmissionSyncFlowTest`
- `php artisan test --filter AttemptSubmissionAsyncFlowTest`
- `php artisan test --filter AttemptSubmitAsyncPlaceholderTest`
- `bash backend/scripts/ci_verify_mbti.sh`
