### PR TITLE
fix(queue): route async attempt submissions to default queue

### DIFF
--- a/backend/config/fap.php
+++ b/backend/config/fap.php
@@ -28,7 +28,7 @@ return [
 
     'queue' => [
         'attempt_connection' => env('FAP_ATTEMPT_QUEUE_CONNECTION', null),
-        'attempt_queue' => env('FAP_ATTEMPT_QUEUE', 'attempts'),
+        'attempt_queue' => env('FAP_ATTEMPT_QUEUE', 'default'),
     ],
 
     'payments' => [


### PR DESCRIPTION
## Summary
- change `backend/config/fap.php` queue default from `attempts` to `default`
- keep `FAP_ATTEMPT_QUEUE` override behavior unchanged
- no code-path, API, migration, or CI script changes

## Why
`ProcessAttemptSubmissionJob` defaulted to queue `attempts`, while existing production workers consume `default`, causing async submit jobs to remain unconsumed and downstream snapshot generation to never trigger.

## Scope
- 1 file changed
- 1 line changed

## Validation
- configuration-only change
- no automated tests run in this PR
