### PR TITLE
fix(api): ensure attempts/start persists attempt row before returning attempt_id

### DIFF
--- a/backend/app/Services/Attempts/AttemptStartService.php
+++ b/backend/app/Services/Attempts/AttemptStartService.php
@@ -21,6 +21,7 @@ use App\Services\Scale\ScaleIdentityWriteProjector;
 use App\Services\Scale\ScaleRegistry;
 use App\Services\Scale\ScaleRolloutGate;
 use App\Support\OrgContext;
+use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\File;
 use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Str;
@@ -240,13 +241,27 @@ class AttemptStartService
             $attemptPayload['scale_uid'] = $scaleUid;
         }
 
-        $attempt = Attempt::create($attemptPayload);
+        $persisted = DB::transaction(function () use ($attemptPayload): array {
+            $attempt = Attempt::create($attemptPayload);
+            if (! $attempt instanceof Attempt) {
+                throw new \RuntimeException('Failed to persist attempt');
+            }
 
-        $draft = $this->progressService->createDraftForAttempt($attempt);
-        if (! empty($draft['expires_at'])) {
-            $attempt->resume_expires_at = $draft['expires_at'];
-            $attempt->save();
-        }
+            $draft = $this->progressService->createDraftForAttempt($attempt);
+            if (! empty($draft['expires_at'])) {
+                $attempt->resume_expires_at = $draft['expires_at'];
+                $attempt->save();
+            }
+
+            return [
+                'attempt' => $attempt,
+                'draft' => $draft,
+            ];
+        });
+
+        /** @var Attempt $attempt */
+        $attempt = $persisted['attempt'];
+        $draft = is_array($persisted['draft'] ?? null) ? $persisted['draft'] : [];
 
         $this->eventRecorder()->record('test_start', $ctx->userId(), [
             'scale_code' => $scaleCode,

--- a/backend/tests/Feature/AttemptStartPersistenceTest.php
+++ b/backend/tests/Feature/AttemptStartPersistenceTest.php
@@ -1,0 +1,54 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature;
+
+use Database\Seeders\Pr17SimpleScoreDemoSeeder;
+use Database\Seeders\ScaleRegistrySeeder;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\DB;
+use Tests\TestCase;
+
+final class AttemptStartPersistenceTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private function seedScales(): void
+    {
+        (new ScaleRegistrySeeder)->run();
+        (new Pr17SimpleScoreDemoSeeder)->run();
+    }
+
+    public function test_attempt_start_persists_attempt(): void
+    {
+        $this->seedScales();
+
+        $anonId = 'test_anon';
+        $response = $this->withHeaders([
+            'X-Anon-Id' => $anonId,
+        ])->postJson('/api/v0.3/attempts/start', [
+            'scale_code' => 'SIMPLE_SCORE_DEMO',
+            'anon_id' => $anonId,
+        ]);
+
+        $response->assertStatus(200);
+        $response->assertJsonPath('ok', true);
+
+        $attemptId = (string) $response->json('attempt_id');
+        $this->assertNotSame('', $attemptId);
+
+        $this->assertDatabaseHas('attempts', [
+            'id' => $attemptId,
+            'anon_id' => $anonId,
+            'scale_code' => 'SIMPLE_SCORE_DEMO',
+            'scale_version' => 'v0.3',
+        ]);
+
+        $attempt = DB::table('attempts')->where('id', $attemptId)->first();
+        $this->assertNotNull($attempt);
+        $this->assertGreaterThan(0, (int) ($attempt->question_count ?? 0));
+        $this->assertNotNull($attempt->started_at);
+    }
+}
+


### PR DESCRIPTION
## Summary
- Ensure `POST /api/v0.3/attempts/start` always persists an `attempts` row before returning `attempt_id`.
- Wrap attempt creation + draft creation in a DB transaction to avoid partial state.
- Add regression test to lock persistence behavior.

## Changes
- `backend/app/Services/Attempts/AttemptStartService.php`
  - Added `DB::transaction(...)` around:
    - `Attempt::create(...)`
    - `progressService->createDraftForAttempt(...)`
    - optional `resume_expires_at` update
  - Added explicit runtime guard:
    - throw `RuntimeException` when attempt persistence fails.
- `backend/tests/Feature/AttemptStartPersistenceTest.php` (new)
  - Calls `/api/v0.3/attempts/start`
  - Asserts `attempt_id` is returned
  - Asserts `attempts` table contains inserted row and required persistence fields are present.

## Why
`/attempts/start` must persist before returning ID so downstream `/attempts/submit` does not fail due to missing attempt record.

## Validation
- `php -l backend/app/Services/Attempts/AttemptStartService.php`
- `php -l backend/tests/Feature/AttemptStartPersistenceTest.php`
- `php artisan test --filter AttemptStartPersistenceTest`
- `php artisan test --filter AttemptsStartSubmitTest`
- `php artisan test --filter AttemptWriteSlimControllerTest`
- `php artisan route:list -v --path=api/v0.3/attempts/start`
- `php artisan route:list -v --path=api/v0.3/attempts/submit`
- `php artisan migrate` (no pending migrations)
