### PR TITLE
fix(api): ensure submit reads attempt from primary DB to avoid replication lag

### DIFF
--- a/backend/app/Services/Attempts/AttemptSubmissionService.php
+++ b/backend/app/Services/Attempts/AttemptSubmissionService.php
@@ -612,7 +612,7 @@ final class AttemptSubmissionService
         ?string $actorUserId,
         ?string $actorAnonId
     ): Builder {
-        $query = Attempt::query()
+        $query = Attempt::onWriteConnection()
             ->where('id', $attemptId)
             ->where('org_id', $ctx->orgId());
 


### PR DESCRIPTION
## Summary
- Force attempt lookup in AttemptSubmissionService to read from the write/primary connection in submit flow.
- Replace Attempt::query() with Attempt::onWriteConnection() in ownership lookup only.
- Keep existing DTO/controller/business flow unchanged.

## Why
Under read-replica lag, /api/v0.3/attempts/submit can fail to find freshly created attempts if it reads from a replica. This change guarantees submit checks primary DB for the attempt row.

## Test
- php artisan test (repo currently has unrelated baseline failures)
- php artisan test --filter "AttemptSubmissionAsyncFlowTest|AttemptSubmissionSyncFlowTest|AttemptSubmitRefactorParityTest|AttemptSubmitAuthTest" (passed)
