### PR TITLE
fix(api): use primary connection when persisting attempt start

### DIFF
--- a/backend/app/Services/Attempts/AttemptStartService.php
+++ b/backend/app/Services/Attempts/AttemptStartService.php
@@ -242,7 +242,7 @@ class AttemptStartService
         }
 
         $persisted = DB::transaction(function () use ($attemptPayload): array {
-            $attempt = Attempt::create($attemptPayload);
+            $attempt = Attempt::onWriteConnection()->create($attemptPayload);
             if (! $attempt instanceof Attempt) {
                 throw new \RuntimeException('Failed to persist attempt');
             }


### PR DESCRIPTION
## Summary
- Update attempts/start persistence path to use primary DB connection when inserting attempt row.
- Change in `AttemptStartService` from `Attempt::create(...)` to `Attempt::onWriteConnection()->create(...)`.
- Scope limited to one file and one query statement.

## Why
In read/write split setups, forcing the write connection on create makes the write path explicit and avoids any connection-routing ambiguity during attempt start persistence.

## Test
- `php artisan test --filter "AttemptStartPersistenceTest|AttemptWriteSlimControllerTest|AttemptsStartSubmitTest"` (passed)
