### PR TITLE
fix(api): bypass global scopes in attempt submit ownership query

### DIFF
--- a/backend/app/Services/Attempts/AttemptSubmissionService.php
+++ b/backend/app/Services/Attempts/AttemptSubmissionService.php
@@ -613,6 +613,7 @@ final class AttemptSubmissionService
         ?string $actorAnonId
     ): Builder {
         $query = Attempt::onWriteConnection()
+            ->withoutGlobalScopes()
             ->where('id', $attemptId)
             ->where('org_id', $ctx->orgId());
 


### PR DESCRIPTION
## Summary
- Update `/api/v0.3/attempts/submit` attempt ownership query to bypass model global scopes.
- Keep primary/read-write safety by preserving `Attempt::onWriteConnection()`.
- Add `withoutGlobalScopes()` before ownership filters (`id`, `org_id`, `user_id/anon_id`).

## Why
In some runtime contexts, global scopes on `Attempt` can hide rows that are valid for submit ownership checks, causing false `RESOURCE_NOT_FOUND`/not-found style failures. This change keeps ownership checks explicit and deterministic.

## Change
- File: `backend/app/Services/Attempts/AttemptSubmissionService.php`
- Method: `ownedAttemptQuery(...)`
- Before: `Attempt::onWriteConnection()->where(...)`
- After: `Attempt::onWriteConnection()->withoutGlobalScopes()->where(...)`

## Test
- `php artisan test --filter "AttemptSubmissionAsyncFlowTest|AttemptSubmissionSyncFlowTest|AttemptSubmitRefactorParityTest|AttemptSubmitAuthTest"` (passed)
