### PR TITLE
fix(api): bypass global scopes when creating attempt record

### DIFF
--- a/backend/app/Services/Attempts/AttemptStartService.php
+++ b/backend/app/Services/Attempts/AttemptStartService.php
@@ -242,7 +242,9 @@ class AttemptStartService
         }
 
         $persisted = DB::transaction(function () use ($attemptPayload): array {
-            $attempt = Attempt::onWriteConnection()->create($attemptPayload);
+            $attempt = Attempt::onWriteConnection()
+                ->withoutGlobalScopes()
+                ->create($attemptPayload);
             if (! $attempt instanceof Attempt) {
                 throw new \RuntimeException('Failed to persist attempt');
             }


### PR DESCRIPTION
## Summary
- Update attempt start persistence to bypass model global scopes before creating the attempt record.
- Keep write-primary behavior via `Attempt::onWriteConnection()`.
- Scope limited to `AttemptStartService` create path only.

## Why
In environments with global scopes on `Attempt`, `create` can be affected by scope constraints in unexpected runtime contexts. This change makes attempt creation deterministic for `/api/v0.3/attempts/start`.

## Change
- File: `backend/app/Services/Attempts/AttemptStartService.php`
- Method: `start(...)`
- Before: `Attempt::onWriteConnection()->create($attemptPayload)`
- After: `Attempt::onWriteConnection()->withoutGlobalScopes()->create($attemptPayload)`

## Test
- `php artisan test --filter "AttemptStartPersistenceTest|AttemptWriteSlimControllerTest|AttemptsStartSubmitTest"` (passed)
