### PR TITLE
fix(api): create attempt with explicit mysql unscoped query

### DIFF
--- a/backend/app/Services/Attempts/AttemptStartService.php
+++ b/backend/app/Services/Attempts/AttemptStartService.php
@@ -242,8 +242,9 @@ class AttemptStartService
         }
 
         $persisted = DB::transaction(function () use ($attemptPayload): array {
-            $attempt = Attempt::onWriteConnection()
-                ->withoutGlobalScopes()
+            $attempt = (new Attempt())
+                ->setConnection('mysql')
+                ->newQueryWithoutScopes()
                 ->create($attemptPayload);
             if (! $attempt instanceof Attempt) {
                 throw new \RuntimeException('Failed to persist attempt');


### PR DESCRIPTION
## Summary
- Update attempt start persistence query to use an explicit model instance bound to `mysql`.
- Bypass global scopes by using `newQueryWithoutScopes()` before `create(...)`.
- Scope limited to `AttemptStartService` attempt creation path.

## Change
- File: `backend/app/Services/Attempts/AttemptStartService.php`
- Method: `start(...)`
- Before:
  - `Attempt::onWriteConnection()->withoutGlobalScopes()->create($attemptPayload)`
- After:
  - `(new Attempt())->setConnection('mysql')->newQueryWithoutScopes()->create($attemptPayload)`

## Test
- Ran:
  - `php artisan test --filter "AttemptStartPersistenceTest|AttemptWriteSlimControllerTest|AttemptsStartSubmitTest"`
- Result:
  - Failed locally because this change forces MySQL in tests that currently run on SQLite, producing:
    - `SQLSTATE[HY000] [1045] Access denied for user 'root'@'localhost'`
