### PR TITLE
fix: force attempt lookup on primary db

### DIFF
--- a/backend/app/Services/Attempts/AttemptSubmissionService.php
+++ b/backend/app/Services/Attempts/AttemptSubmissionService.php
@@ -612,8 +612,9 @@ final class AttemptSubmissionService
         ?string $actorUserId,
         ?string $actorAnonId
     ): Builder {
-        $query = Attempt::onWriteConnection()
-            ->withoutGlobalScopes()
+        $query = (new Attempt())
+            ->setConnection('mysql')
+            ->newQueryWithoutScopes()
             ->where('id', $attemptId)
             ->where('org_id', $ctx->orgId());
 


### PR DESCRIPTION
## Summary
- Update attempt ownership lookup in submit flow to use an explicit MySQL-bound query builder.
- Keep query unscoped by using `newQueryWithoutScopes()`.

## Change
- File: `backend/app/Services/Attempts/AttemptSubmissionService.php`
- Method: `ownedAttemptQuery(...)`
- Before:
  - `Attempt::onWriteConnection()->withoutGlobalScopes()->where(...)`
- After:
  - `(new Attempt())->setConnection('mysql')->newQueryWithoutScopes()->where(...)`

## Commit
- `fix: force attempt lookup on primary db`
