### PR TITLE
fix: ensure attempts row persists

### DIFF
--- a/backend/app/Services/Attempts/AttemptStartService.php
+++ b/backend/app/Services/Attempts/AttemptStartService.php
@@ -243,26 +243,27 @@ class AttemptStartService
 
         $persisted = DB::transaction(function () use ($attemptPayload): array {
 
-            $attempt = (new Attempt())
-                ->setConnection('mysql')
-                ->newQueryWithoutScopes()
-                ->create($attemptPayload);
-                
-            if (! $attempt instanceof Attempt) {
-                throw new \RuntimeException('Failed to persist attempt');
-            }
+    $attempt = new Attempt();
+    $attempt->setConnection('mysql');
+    $attempt->forceFill($attemptPayload);
+    $attempt->save();
 
-            $draft = $this->progressService->createDraftForAttempt($attempt);
-            if (! empty($draft['expires_at'])) {
-                $attempt->resume_expires_at = $draft['expires_at'];
-                $attempt->save();
-            }
+    if (! $attempt->exists) {
+        throw new \RuntimeException('Failed to persist attempt');
+    }
 
-            return [
-                'attempt' => $attempt,
-                'draft' => $draft,
-            ];
-        });
+    $draft = $this->progressService->createDraftForAttempt($attempt);
+
+    if (! empty($draft['expires_at'])) {
+        $attempt->resume_expires_at = $draft['expires_at'];
+        $attempt->save();
+    }
+
+    return [
+        'attempt' => $attempt,
+        'draft' => $draft,
+    ];
+});
 
         /** @var Attempt $attempt */
         $attempt = $persisted['attempt'];


### PR DESCRIPTION
## Summary
- Update `AttemptStartService` persistence path to explicitly create and save `Attempt` using model instance operations.
- Keep explicit MySQL connection for attempt persistence.
- Preserve downstream draft creation and response contract.

## Change
- File: `backend/app/Services/Attempts/AttemptStartService.php`
- Replace chained query-based create with:
  - `new Attempt()`
  - `setConnection('mysql')`
  - `forceFill($attemptPayload)`
  - `save()`
- Keep runtime failure check and draft/resume update flow.

## Commit
- `fix: ensure attempts row persists`
