### PR TITLE
fix(ci): stabilize ci_verify_mbti attempt writes on sqlite

### DIFF
--- a/backend/scripts/ci_verify_mbti.sh
+++ b/backend/scripts/ci_verify_mbti.sh
@@ -19,6 +19,7 @@ export APP_ENV="${APP_ENV:-testing}"
 export DB_CONNECTION=sqlite
 export DB_DATABASE=/tmp/fap-ci.sqlite
 export QUEUE_CONNECTION=sync
+export FAP_ATTEMPT_WRITE_CONNECTION="${FAP_ATTEMPT_WRITE_CONNECTION:-sqlite}"
 
 # Content packs (force local driver + repo path)
 export FAP_PACKS_DRIVER=local


### PR DESCRIPTION
## Summary
- set `FAP_ATTEMPT_WRITE_CONNECTION` default to `sqlite` in `backend/scripts/ci_verify_mbti.sh`
- ensure `/api/v0.3/attempts/start` writes to sqlite during local CI chain
- remove implicit dependency on local MySQL credentials for this path

## Verification
- `bash backend/scripts/ci_verify_mbti.sh`
