### PR TITLE
feat(cms): implement CMS-01 schema migrations

### DIFF
--- a/backend/database/migrations/2026_03_05_154120_create_article_categories_table.php
+++ b/backend/database/migrations/2026_03_05_154120_create_article_categories_table.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('article_categories', function (Blueprint $table) {
+            $table->bigIncrements('id');
+            $table->unsignedBigInteger('org_id')->default(0);
+            $table->string('slug', 127);
+            $table->string('name', 128);
+            $table->text('description')->nullable();
+            $table->integer('sort_order')->default(0);
+            $table->boolean('is_active')->default(true);
+            $table->timestamps();
+
+            $table->unique(['org_id', 'slug'], 'article_categories_org_slug_unique');
+            $table->unique(['org_id', 'name'], 'article_categories_org_name_unique');
+            $table->index(['org_id', 'is_active', 'sort_order'], 'article_categories_org_active_sort_idx');
+        });
+    }
+
+    public function down(): void
+    {
+        // forward-only migration: rollback disabled to prevent data loss in production.
+        // Irreversible operation: schema/data rollback handled via forward fix migrations.
+    }
+};

--- a/backend/database/migrations/2026_03_05_154120_create_article_tags_table.php
+++ b/backend/database/migrations/2026_03_05_154120_create_article_tags_table.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('article_tags', function (Blueprint $table) {
+            $table->bigIncrements('id');
+            $table->unsignedBigInteger('org_id')->default(0);
+            $table->string('slug', 127);
+            $table->string('name', 64);
+            $table->boolean('is_active')->default(true);
+            $table->timestamps();
+
+            $table->unique(['org_id', 'slug'], 'article_tags_org_slug_unique');
+            $table->unique(['org_id', 'name'], 'article_tags_org_name_unique');
+            $table->index(['org_id', 'is_active'], 'article_tags_org_active_idx');
+        });
+    }
+
+    public function down(): void
+    {
+        // forward-only migration: rollback disabled to prevent data loss in production.
+        // Irreversible operation: schema/data rollback handled via forward fix migrations.
+    }
+};

--- a/backend/database/migrations/2026_03_05_154120_create_articles_table.php
+++ b/backend/database/migrations/2026_03_05_154120_create_articles_table.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('articles', function (Blueprint $table) {
+            $table->bigIncrements('id');
+            $table->unsignedBigInteger('org_id')->default(0);
+            $table->unsignedBigInteger('category_id')->nullable();
+            $table->unsignedBigInteger('author_admin_user_id')->nullable();
+            $table->string('slug', 127);
+            $table->string('locale', 16)->default('en');
+            $table->string('title', 255);
+            $table->text('excerpt')->nullable();
+            $table->longText('content_md');
+            $table->longText('content_html')->nullable();
+            $table->string('cover_image_url', 255)->nullable();
+            $table->string('status', 32)->default('draft');
+            $table->boolean('is_public')->default(false);
+            $table->boolean('is_indexable')->default(true);
+            $table->timestamp('published_at')->nullable();
+            $table->timestamp('scheduled_at')->nullable();
+            $table->timestamps();
+
+            $table->unique(['org_id', 'locale', 'slug'], 'articles_org_locale_slug_unique');
+            $table->index(['org_id', 'status', 'published_at'], 'articles_org_status_published_idx');
+            $table->index(['org_id', 'category_id', 'status'], 'articles_org_category_status_idx');
+            $table->index(['org_id', 'updated_at'], 'articles_org_updated_idx');
+        });
+    }
+
+    public function down(): void
+    {
+        // forward-only migration: rollback disabled to prevent data loss in production.
+        // Irreversible operation: schema/data rollback handled via forward fix migrations.
+    }
+};

--- a/backend/database/migrations/2026_03_05_154121_create_article_revisions_table.php
+++ b/backend/database/migrations/2026_03_05_154121_create_article_revisions_table.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        $isSqlite = Schema::getConnection()->getDriverName() === 'sqlite';
+
+        Schema::create('article_revisions', function (Blueprint $table) use ($isSqlite) {
+            $table->bigIncrements('id');
+            $table->unsignedBigInteger('org_id')->default(0);
+            $table->unsignedBigInteger('article_id');
+            $table->unsignedInteger('revision_no');
+            $table->unsignedBigInteger('editor_admin_user_id')->nullable();
+            $table->string('title', 255);
+            $table->text('excerpt')->nullable();
+            $table->longText('content_md');
+            $table->longText('content_html')->nullable();
+            $table->string('change_note', 255)->nullable();
+            if ($isSqlite) {
+                $table->text('payload_json')->nullable();
+            } else {
+                $table->json('payload_json')->nullable();
+            }
+            $table->timestamp('created_at');
+
+            $table->unique(['org_id', 'article_id', 'revision_no'], 'article_revisions_org_article_rev_unique');
+            $table->index(['org_id', 'article_id', 'created_at'], 'article_revisions_org_article_created_idx');
+        });
+    }
+
+    public function down(): void
+    {
+        // forward-only migration: rollback disabled to prevent data loss in production.
+        // Irreversible operation: schema/data rollback handled via forward fix migrations.
+    }
+};

--- a/backend/database/migrations/2026_03_05_154121_create_article_seo_meta_table.php
+++ b/backend/database/migrations/2026_03_05_154121_create_article_seo_meta_table.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        $isSqlite = Schema::getConnection()->getDriverName() === 'sqlite';
+
+        Schema::create('article_seo_meta', function (Blueprint $table) use ($isSqlite) {
+            $table->bigIncrements('id');
+            $table->unsignedBigInteger('org_id')->default(0);
+            $table->unsignedBigInteger('article_id');
+            $table->string('locale', 16)->default('en');
+            $table->string('seo_title', 60)->nullable();
+            $table->string('seo_description', 160)->nullable();
+            $table->string('canonical_url', 255)->nullable();
+            $table->string('og_title', 90)->nullable();
+            $table->string('og_description', 200)->nullable();
+            $table->string('og_image_url', 255)->nullable();
+            $table->string('robots', 64)->nullable();
+            if ($isSqlite) {
+                $table->text('schema_json')->nullable();
+            } else {
+                $table->json('schema_json')->nullable();
+            }
+            $table->boolean('is_indexable')->default(true);
+            $table->timestamps();
+
+            $table->unique(['org_id', 'article_id', 'locale'], 'article_seo_meta_org_article_locale_unique');
+            $table->index(['org_id', 'locale', 'is_indexable'], 'article_seo_meta_org_locale_indexable_idx');
+        });
+    }
+
+    public function down(): void
+    {
+        // forward-only migration: rollback disabled to prevent data loss in production.
+        // Irreversible operation: schema/data rollback handled via forward fix migrations.
+    }
+};

--- a/backend/database/migrations/2026_03_05_154121_create_article_tag_map_table.php
+++ b/backend/database/migrations/2026_03_05_154121_create_article_tag_map_table.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('article_tag_map', function (Blueprint $table) {
+            $table->bigIncrements('id');
+            $table->unsignedBigInteger('org_id')->default(0);
+            $table->unsignedBigInteger('article_id');
+            $table->unsignedBigInteger('tag_id');
+            $table->timestamp('created_at')->nullable();
+
+            $table->unique(['org_id', 'article_id', 'tag_id'], 'article_tag_map_org_article_tag_unique');
+            $table->index(['org_id', 'tag_id', 'article_id'], 'article_tag_map_org_tag_article_idx');
+            $table->index(['org_id', 'article_id'], 'article_tag_map_org_article_idx');
+        });
+    }
+
+    public function down(): void
+    {
+        // forward-only migration: rollback disabled to prevent data loss in production.
+        // Irreversible operation: schema/data rollback handled via forward fix migrations.
+    }
+};


### PR DESCRIPTION
## Summary
- add CMS-01 migrations for: `articles`, `article_categories`, `article_tags`, `article_tag_map`, `article_revisions`, `article_seo_meta`
- implement explicit named composite indexes/uniques, `org_id` default `0`, and forward-only `down()`
- add sqlite-safe JSON fallback (`text` on sqlite) for `article_revisions.payload_json` and `article_seo_meta.schema_json`

## Tests Ran
- `cd backend && php artisan migrate`
- `cd backend && php artisan migrate:status`
- `cd backend && php artisan tinker --execute='dump(collect(DB::select("SELECT name FROM sqlite_master WHERE type=\"table\" ORDER BY name"))->pluck("name")->filter(fn($n)=>str_starts_with($n,"article"))->values()->all());'`
- `cd backend && php artisan route:list`
