### PR TITLE
feat(cms): implement CMS-02 models

### DIFF
--- a/backend/app/Models/Article.php
+++ b/backend/app/Models/Article.php
@@ -1,0 +1,84 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Models;
+
+use App\Models\Concerns\HasOrgScope;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\BelongsToMany;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+use Illuminate\Database\Eloquent\Relations\HasOne;
+
+class Article extends Model
+{
+    use HasFactory, HasOrgScope;
+
+    protected $table = 'articles';
+
+    protected $fillable = [
+        'org_id',
+        'category_id',
+        'author_admin_user_id',
+        'slug',
+        'locale',
+        'title',
+        'excerpt',
+        'content_md',
+        'content_html',
+        'cover_image_url',
+        'status',
+        'is_public',
+        'is_indexable',
+        'published_at',
+        'scheduled_at',
+    ];
+
+    protected $casts = [
+        'org_id' => 'integer',
+        'category_id' => 'integer',
+        'author_admin_user_id' => 'integer',
+        'is_public' => 'boolean',
+        'is_indexable' => 'boolean',
+        'published_at' => 'datetime',
+        'scheduled_at' => 'datetime',
+        'created_at' => 'datetime',
+        'updated_at' => 'datetime',
+    ];
+
+    public function category(): BelongsTo
+    {
+        return $this->belongsTo(ArticleCategory::class, 'category_id', 'id');
+    }
+
+    public function tags(): BelongsToMany
+    {
+        return $this->belongsToMany(
+            ArticleTag::class,
+            'article_tag_map',
+            'article_id',
+            'tag_id'
+        );
+    }
+
+    public function revisions(): HasMany
+    {
+        return $this->hasMany(ArticleRevision::class, 'article_id', 'id');
+    }
+
+    public function seoMeta(): HasOne
+    {
+        return $this->hasOne(ArticleSeoMeta::class, 'article_id', 'id');
+    }
+
+    public static function findBySlug(string $slug, string $locale = 'en'): ?self
+    {
+        return static::query()
+            ->where('slug', $slug)
+            ->where('locale', $locale)
+            ->first();
+    }
+}
+

--- a/backend/app/Models/ArticleCategory.php
+++ b/backend/app/Models/ArticleCategory.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Models;
+
+use App\Models\Concerns\HasOrgScope;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+
+class ArticleCategory extends Model
+{
+    use HasFactory, HasOrgScope;
+
+    protected $table = 'article_categories';
+
+    protected $fillable = [
+        'org_id',
+        'slug',
+        'name',
+        'description',
+        'sort_order',
+        'is_active',
+    ];
+
+    protected $casts = [
+        'org_id' => 'integer',
+        'sort_order' => 'integer',
+        'is_active' => 'boolean',
+        'created_at' => 'datetime',
+        'updated_at' => 'datetime',
+    ];
+
+    public function articles(): HasMany
+    {
+        return $this->hasMany(Article::class, 'category_id', 'id');
+    }
+}
+

--- a/backend/app/Models/ArticleRevision.php
+++ b/backend/app/Models/ArticleRevision.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Models;
+
+use App\Models\Concerns\HasOrgScope;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+class ArticleRevision extends Model
+{
+    use HasFactory, HasOrgScope;
+
+    protected $table = 'article_revisions';
+
+    public $timestamps = false;
+
+    protected $fillable = [
+        'org_id',
+        'article_id',
+        'revision_no',
+        'editor_admin_user_id',
+        'title',
+        'excerpt',
+        'content_md',
+        'content_html',
+        'change_note',
+        'payload_json',
+        'created_at',
+    ];
+
+    protected $casts = [
+        'org_id' => 'integer',
+        'article_id' => 'integer',
+        'revision_no' => 'integer',
+        'editor_admin_user_id' => 'integer',
+        'payload_json' => 'array',
+        'created_at' => 'datetime',
+    ];
+
+    public function article(): BelongsTo
+    {
+        return $this->belongsTo(Article::class, 'article_id', 'id');
+    }
+}
+

--- a/backend/app/Models/ArticleSeoMeta.php
+++ b/backend/app/Models/ArticleSeoMeta.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Models;
+
+use App\Models\Concerns\HasOrgScope;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+class ArticleSeoMeta extends Model
+{
+    use HasFactory, HasOrgScope;
+
+    protected $table = 'article_seo_meta';
+
+    protected $fillable = [
+        'org_id',
+        'article_id',
+        'locale',
+        'seo_title',
+        'seo_description',
+        'canonical_url',
+        'og_title',
+        'og_description',
+        'og_image_url',
+        'robots',
+        'schema_json',
+        'is_indexable',
+    ];
+
+    protected $casts = [
+        'org_id' => 'integer',
+        'article_id' => 'integer',
+        'schema_json' => 'array',
+        'is_indexable' => 'boolean',
+        'created_at' => 'datetime',
+        'updated_at' => 'datetime',
+    ];
+
+    public function article(): BelongsTo
+    {
+        return $this->belongsTo(Article::class, 'article_id', 'id');
+    }
+}
+

--- a/backend/app/Models/ArticleTag.php
+++ b/backend/app/Models/ArticleTag.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Models;
+
+use App\Models\Concerns\HasOrgScope;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsToMany;
+
+class ArticleTag extends Model
+{
+    use HasFactory, HasOrgScope;
+
+    protected $table = 'article_tags';
+
+    protected $fillable = [
+        'org_id',
+        'slug',
+        'name',
+        'is_active',
+    ];
+
+    protected $casts = [
+        'org_id' => 'integer',
+        'is_active' => 'boolean',
+        'created_at' => 'datetime',
+        'updated_at' => 'datetime',
+    ];
+
+    public function articles(): BelongsToMany
+    {
+        return $this->belongsToMany(
+            Article::class,
+            'article_tag_map',
+            'tag_id',
+            'article_id'
+        );
+    }
+}
+


### PR DESCRIPTION
## Summary
- add CMS-02 Eloquent models for CMS tables:
  - `Article`
  - `ArticleCategory`
  - `ArticleTag`
  - `ArticleRevision`
  - `ArticleSeoMeta`
- define explicit `$table` names and `fillable`/`casts` with repo conventions (`HasOrgScope`)
- implement relationships:
  - `Article` -> `category`, `tags`, `revisions`, `seoMeta`
  - `ArticleCategory` -> `articles`
  - `ArticleTag` -> `articles` (via `article_tag_map`)
  - `ArticleRevision` -> `article`
  - `ArticleSeoMeta` -> `article`
- add helper: `Article::findBySlug(string $slug, string $locale = 'en')`

## Tests Ran
- `php -l app/Models/Article.php`
- `php -l app/Models/ArticleCategory.php`
- `php -l app/Models/ArticleTag.php`
- `php -l app/Models/ArticleRevision.php`
- `php -l app/Models/ArticleSeoMeta.php`
- `cd backend && php artisan tinker --execute="dump(App\\Models\\Article::first());"`
- `cd backend && php artisan tinker --execute="dump(App\\Models\\ArticleCategory::first());"`
- `cd backend && php artisan tinker --execute="dump(App\\Models\\ArticleTag::first());"`
