### PR TITLE
feat(cms): harden cms, expose v0.5 article api, add ops resources, and integrate sitemap/seo

### DIFF
--- a/backend/app/Filament/Ops/Resources/ArticleCategoryResource.php
+++ b/backend/app/Filament/Ops/Resources/ArticleCategoryResource.php
@@ -1,0 +1,171 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Filament\Ops\Resources;
+
+use App\Filament\Ops\Resources\ArticleCategoryResource\Pages;
+use App\Models\ArticleCategory;
+use App\Support\OrgContext;
+use App\Support\Rbac\PermissionNames;
+use Filament\Forms\Components\Hidden;
+use Filament\Forms\Components\Textarea;
+use Filament\Forms\Components\TextInput;
+use Filament\Forms\Components\Toggle;
+use Filament\Forms\Form;
+use Filament\Resources\Resource;
+use Filament\Tables;
+use Filament\Tables\Columns\IconColumn;
+use Filament\Tables\Columns\TextColumn;
+use Filament\Tables\Filters\TernaryFilter;
+use Filament\Tables\Table;
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Support\Str;
+
+class ArticleCategoryResource extends Resource
+{
+    protected static ?string $model = ArticleCategory::class;
+
+    protected static ?string $navigationIcon = 'heroicon-o-folder';
+
+    protected static ?string $navigationGroup = 'Content';
+
+    protected static ?string $navigationLabel = 'Categories';
+
+    public static function canViewAny(): bool
+    {
+        return self::canRead();
+    }
+
+    public static function canCreate(): bool
+    {
+        return self::canPublish();
+    }
+
+    public static function canEdit($record): bool
+    {
+        return self::canPublish();
+    }
+
+    public static function canDelete($record): bool
+    {
+        return false;
+    }
+
+    public static function getNavigationGroup(): ?string
+    {
+        return __('ops.group.content');
+    }
+
+    public static function getNavigationLabel(): string
+    {
+        return 'Categories';
+    }
+
+    public static function form(Form $form): Form
+    {
+        return $form->schema([
+            Hidden::make('org_id')
+                ->default(fn (): int => max(0, (int) app(OrgContext::class)->orgId())),
+            TextInput::make('name')
+                ->required()
+                ->maxLength(128),
+            TextInput::make('slug')
+                ->required()
+                ->maxLength(127)
+                ->afterStateUpdated(fn ($state, $set): mixed => $set('slug', Str::slug((string) $state))),
+            Textarea::make('description')
+                ->rows(4),
+            TextInput::make('sort_order')
+                ->numeric()
+                ->default(0),
+            Toggle::make('is_active')
+                ->default(true),
+        ]);
+    }
+
+    public static function table(Table $table): Table
+    {
+        return $table
+            ->columns([
+                TextColumn::make('name')
+                    ->searchable()
+                    ->sortable(),
+                TextColumn::make('slug')
+                    ->searchable()
+                    ->copyable(),
+                IconColumn::make('is_active')
+                    ->boolean()
+                    ->sortable(),
+                TextColumn::make('sort_order')
+                    ->sortable(),
+                TextColumn::make('updated_at')
+                    ->dateTime()
+                    ->sortable(),
+            ])
+            ->filters([
+                TernaryFilter::make('is_active'),
+            ])
+            ->defaultSort('sort_order', 'asc')
+            ->actions([
+                Tables\Actions\EditAction::make(),
+            ])
+            ->bulkActions([]);
+    }
+
+    public static function getRelations(): array
+    {
+        return [];
+    }
+
+    public static function getPages(): array
+    {
+        return [
+            'index' => Pages\ListArticleCategories::route('/'),
+            'create' => Pages\CreateArticleCategory::route('/create'),
+            'edit' => Pages\EditArticleCategory::route('/{record}/edit'),
+        ];
+    }
+
+    public static function getEloquentQuery(): Builder
+    {
+        return parent::getEloquentQuery()
+            ->whereIn('org_id', self::tenantOrgIds());
+    }
+
+    /**
+     * @return array<int,int>
+     */
+    private static function tenantOrgIds(): array
+    {
+        $orgId = max(0, (int) app(OrgContext::class)->orgId());
+
+        return $orgId > 0 ? [0, $orgId] : [0];
+    }
+
+    private static function canRead(): bool
+    {
+        $guard = (string) config('admin.guard', 'admin');
+        $user = auth($guard)->user();
+
+        return is_object($user)
+            && method_exists($user, 'hasPermission')
+            && (
+                $user->hasPermission(PermissionNames::ADMIN_CONTENT_READ)
+                || $user->hasPermission(PermissionNames::ADMIN_OWNER)
+            );
+    }
+
+    private static function canPublish(): bool
+    {
+        $guard = (string) config('admin.guard', 'admin');
+        $user = auth($guard)->user();
+
+        return is_object($user)
+            && method_exists($user, 'hasPermission')
+            && (
+                $user->hasPermission(PermissionNames::ADMIN_CONTENT_PUBLISH)
+                || $user->hasPermission(PermissionNames::ADMIN_OWNER)
+            );
+    }
+}

--- a/backend/app/Filament/Ops/Resources/ArticleCategoryResource/Pages/CreateArticleCategory.php
+++ b/backend/app/Filament/Ops/Resources/ArticleCategoryResource/Pages/CreateArticleCategory.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Filament\Ops\Resources\ArticleCategoryResource\Pages;
+
+use App\Filament\Ops\Resources\ArticleCategoryResource;
+use Filament\Resources\Pages\CreateRecord;
+
+class CreateArticleCategory extends CreateRecord
+{
+    protected static string $resource = ArticleCategoryResource::class;
+}

--- a/backend/app/Filament/Ops/Resources/ArticleCategoryResource/Pages/EditArticleCategory.php
+++ b/backend/app/Filament/Ops/Resources/ArticleCategoryResource/Pages/EditArticleCategory.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Filament\Ops\Resources\ArticleCategoryResource\Pages;
+
+use App\Filament\Ops\Resources\ArticleCategoryResource;
+use Filament\Resources\Pages\EditRecord;
+
+class EditArticleCategory extends EditRecord
+{
+    protected static string $resource = ArticleCategoryResource::class;
+}

--- a/backend/app/Filament/Ops/Resources/ArticleCategoryResource/Pages/ListArticleCategories.php
+++ b/backend/app/Filament/Ops/Resources/ArticleCategoryResource/Pages/ListArticleCategories.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Filament\Ops\Resources\ArticleCategoryResource\Pages;
+
+use App\Filament\Ops\Resources\ArticleCategoryResource;
+use Filament\Actions;
+use Filament\Resources\Pages\ListRecords;
+
+class ListArticleCategories extends ListRecords
+{
+    protected static string $resource = ArticleCategoryResource::class;
+
+    protected function getHeaderActions(): array
+    {
+        return [
+            Actions\CreateAction::make(),
+        ];
+    }
+}

--- a/backend/app/Filament/Ops/Resources/ArticleResource.php
+++ b/backend/app/Filament/Ops/Resources/ArticleResource.php
@@ -1,0 +1,244 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Filament\Ops\Resources;
+
+use App\Filament\Ops\Resources\ArticleResource\Pages;
+use App\Models\Article;
+use App\Support\OrgContext;
+use App\Support\Rbac\PermissionNames;
+use Filament\Forms;
+use Filament\Forms\Components\BelongsToManyMultiSelect;
+use Filament\Forms\Form;
+use Filament\Resources\Resource;
+use Filament\Tables;
+use Filament\Tables\Table;
+use Illuminate\Database\Eloquent\Builder;
+
+class ArticleResource extends Resource
+{
+    protected static ?string $model = Article::class;
+
+    protected static ?string $navigationIcon = 'heroicon-o-document-text';
+
+    protected static ?string $navigationGroup = 'Content';
+
+    protected static ?string $navigationLabel = 'Articles';
+
+    public static function canViewAny(): bool
+    {
+        return self::canRead();
+    }
+
+    public static function canCreate(): bool
+    {
+        return self::canPublish();
+    }
+
+    public static function canEdit($record): bool
+    {
+        return self::canPublish();
+    }
+
+    public static function canDelete($record): bool
+    {
+        return false;
+    }
+
+    public static function getNavigationGroup(): ?string
+    {
+        return __('ops.group.content');
+    }
+
+    public static function getNavigationLabel(): string
+    {
+        return 'Articles';
+    }
+
+    public static function form(Form $form): Form
+    {
+        return $form->schema([
+            Forms\Components\Tabs::make('Article')
+                ->tabs([
+                    Forms\Components\Tabs\Tab::make('Basic')
+                        ->schema([
+                            Forms\Components\Hidden::make('org_id')
+                                ->default(fn (): int => max(0, (int) app(OrgContext::class)->orgId())),
+                            Forms\Components\TextInput::make('title')
+                                ->required()
+                                ->maxLength(255),
+                            Forms\Components\TextInput::make('slug')
+                                ->required()
+                                ->maxLength(127),
+                            Forms\Components\TextInput::make('locale')
+                                ->required()
+                                ->maxLength(16)
+                                ->default('en'),
+                            Forms\Components\Select::make('category_id')
+                                ->label('Category')
+                                ->relationship(
+                                    'category',
+                                    'name',
+                                    fn (Builder $query): Builder => $query->whereIn('article_categories.org_id', self::tenantOrgIds())
+                                )
+                                ->searchable()
+                                ->preload(),
+                            BelongsToManyMultiSelect::make('tags')
+                                ->relationship(
+                                    'tags',
+                                    'name',
+                                    fn (Builder $query): Builder => $query->whereIn('article_tags.org_id', self::tenantOrgIds())
+                                )
+                                ->searchable()
+                                ->preload(),
+                        ]),
+                    Forms\Components\Tabs\Tab::make('Content')
+                        ->schema([
+                            Forms\Components\Textarea::make('excerpt')
+                                ->rows(4),
+                            Forms\Components\MarkdownEditor::make('content_md')
+                                ->required()
+                                ->columnSpanFull(),
+                            Forms\Components\TextInput::make('cover_image_url')
+                                ->maxLength(255),
+                        ]),
+                    Forms\Components\Tabs\Tab::make('SEO')
+                        ->schema([
+                            Forms\Components\Section::make('SEO Meta')
+                                ->relationship('seoMeta')
+                                ->schema([
+                                    Forms\Components\TextInput::make('seo_title')
+                                        ->maxLength(60),
+                                    Forms\Components\Textarea::make('seo_description')
+                                        ->rows(3)
+                                        ->maxLength(160),
+                                    Forms\Components\TextInput::make('canonical_url')
+                                        ->maxLength(255),
+                                    Forms\Components\TextInput::make('og_title')
+                                        ->maxLength(90),
+                                    Forms\Components\Textarea::make('og_description')
+                                        ->rows(3)
+                                        ->maxLength(200),
+                                    Forms\Components\TextInput::make('og_image_url')
+                                        ->maxLength(255),
+                                ]),
+                        ]),
+                    Forms\Components\Tabs\Tab::make('Publish')
+                        ->schema([
+                            Forms\Components\Select::make('status')
+                                ->required()
+                                ->options([
+                                    'draft' => 'draft',
+                                    'published' => 'published',
+                                ])
+                                ->default('draft'),
+                            Forms\Components\Toggle::make('is_public')
+                                ->default(false),
+                            Forms\Components\Toggle::make('is_indexable')
+                                ->default(true),
+                            Forms\Components\DateTimePicker::make('published_at'),
+                            Forms\Components\DateTimePicker::make('scheduled_at'),
+                        ]),
+                ]),
+        ]);
+    }
+
+    public static function table(Table $table): Table
+    {
+        return $table
+            ->columns([
+                Tables\Columns\TextColumn::make('id')
+                    ->sortable(),
+                Tables\Columns\TextColumn::make('title')
+                    ->searchable()
+                    ->sortable(),
+                Tables\Columns\TextColumn::make('slug')
+                    ->searchable()
+                    ->copyable(),
+                Tables\Columns\TextColumn::make('status')
+                    ->badge()
+                    ->sortable()
+                    ->color(fn (string $state): string => $state === 'published' ? 'success' : 'gray'),
+                Tables\Columns\TextColumn::make('locale')
+                    ->sortable(),
+                Tables\Columns\TextColumn::make('published_at')
+                    ->dateTime()
+                    ->sortable(),
+                Tables\Columns\TextColumn::make('updated_at')
+                    ->dateTime()
+                    ->sortable(),
+            ])
+            ->filters([
+                Tables\Filters\SelectFilter::make('status')
+                    ->options([
+                        'draft' => 'draft',
+                        'published' => 'published',
+                    ]),
+                Tables\Filters\SelectFilter::make('locale')
+                    ->options(fn (): array => static::getEloquentQuery()
+                        ->select('locale')
+                        ->whereNotNull('locale')
+                        ->distinct()
+                        ->orderBy('locale')
+                        ->pluck('locale', 'locale')
+                        ->toArray()),
+            ])
+            ->defaultSort('updated_at', 'desc')
+            ->actions([
+                Tables\Actions\EditAction::make(),
+            ])
+            ->bulkActions([]);
+    }
+
+    public static function getPages(): array
+    {
+        return [
+            'index' => Pages\ListArticles::route('/'),
+            'create' => Pages\CreateArticle::route('/create'),
+            'edit' => Pages\EditArticle::route('/{record}/edit'),
+        ];
+    }
+
+    public static function getEloquentQuery(): Builder
+    {
+        return parent::getEloquentQuery()
+            ->whereIn('org_id', self::tenantOrgIds());
+    }
+
+    /**
+     * @return array<int,int>
+     */
+    private static function tenantOrgIds(): array
+    {
+        $orgId = max(0, (int) app(OrgContext::class)->orgId());
+
+        return $orgId > 0 ? [0, $orgId] : [0];
+    }
+
+    private static function canRead(): bool
+    {
+        $guard = (string) config('admin.guard', 'admin');
+        $user = auth($guard)->user();
+
+        return is_object($user)
+            && method_exists($user, 'hasPermission')
+            && (
+                $user->hasPermission(PermissionNames::ADMIN_CONTENT_READ)
+                || $user->hasPermission(PermissionNames::ADMIN_OWNER)
+            );
+    }
+
+    private static function canPublish(): bool
+    {
+        $guard = (string) config('admin.guard', 'admin');
+        $user = auth($guard)->user();
+
+        return is_object($user)
+            && method_exists($user, 'hasPermission')
+            && (
+                $user->hasPermission(PermissionNames::ADMIN_CONTENT_PUBLISH)
+                || $user->hasPermission(PermissionNames::ADMIN_OWNER)
+            );
+    }
+}

--- a/backend/app/Filament/Ops/Resources/ArticleResource/Pages/CreateArticle.php
+++ b/backend/app/Filament/Ops/Resources/ArticleResource/Pages/CreateArticle.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Filament\Ops\Resources\ArticleResource\Pages;
+
+use App\Filament\Ops\Resources\ArticleResource;
+use Filament\Resources\Pages\CreateRecord;
+
+class CreateArticle extends CreateRecord
+{
+    protected static string $resource = ArticleResource::class;
+}

--- a/backend/app/Filament/Ops/Resources/ArticleResource/Pages/EditArticle.php
+++ b/backend/app/Filament/Ops/Resources/ArticleResource/Pages/EditArticle.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Filament\Ops\Resources\ArticleResource\Pages;
+
+use App\Filament\Ops\Resources\ArticleResource;
+use Filament\Resources\Pages\EditRecord;
+
+class EditArticle extends EditRecord
+{
+    protected static string $resource = ArticleResource::class;
+}

--- a/backend/app/Filament/Ops/Resources/ArticleResource/Pages/ListArticles.php
+++ b/backend/app/Filament/Ops/Resources/ArticleResource/Pages/ListArticles.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Filament\Ops\Resources\ArticleResource\Pages;
+
+use App\Filament\Ops\Resources\ArticleResource;
+use Filament\Actions;
+use Filament\Resources\Pages\ListRecords;
+
+class ListArticles extends ListRecords
+{
+    protected static string $resource = ArticleResource::class;
+
+    protected function getHeaderActions(): array
+    {
+        return [
+            Actions\CreateAction::make(),
+        ];
+    }
+}

--- a/backend/app/Filament/Ops/Resources/ArticleTagResource.php
+++ b/backend/app/Filament/Ops/Resources/ArticleTagResource.php
@@ -1,0 +1,163 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Filament\Ops\Resources;
+
+use App\Filament\Ops\Resources\ArticleTagResource\Pages;
+use App\Models\ArticleTag;
+use App\Support\OrgContext;
+use App\Support\Rbac\PermissionNames;
+use Filament\Forms\Components\Hidden;
+use Filament\Forms\Components\TextInput;
+use Filament\Forms\Components\Toggle;
+use Filament\Forms\Form;
+use Filament\Resources\Resource;
+use Filament\Tables;
+use Filament\Tables\Columns\IconColumn;
+use Filament\Tables\Columns\TextColumn;
+use Filament\Tables\Filters\TernaryFilter;
+use Filament\Tables\Table;
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Support\Str;
+
+class ArticleTagResource extends Resource
+{
+    protected static ?string $model = ArticleTag::class;
+
+    protected static ?string $navigationIcon = 'heroicon-o-tag';
+
+    protected static ?string $navigationGroup = 'Content';
+
+    protected static ?string $navigationLabel = 'Tags';
+
+    public static function canViewAny(): bool
+    {
+        return self::canRead();
+    }
+
+    public static function canCreate(): bool
+    {
+        return self::canPublish();
+    }
+
+    public static function canEdit($record): bool
+    {
+        return self::canPublish();
+    }
+
+    public static function canDelete($record): bool
+    {
+        return false;
+    }
+
+    public static function getNavigationGroup(): ?string
+    {
+        return __('ops.group.content');
+    }
+
+    public static function getNavigationLabel(): string
+    {
+        return 'Tags';
+    }
+
+    public static function form(Form $form): Form
+    {
+        return $form->schema([
+            Hidden::make('org_id')
+                ->default(fn (): int => max(0, (int) app(OrgContext::class)->orgId())),
+            TextInput::make('name')
+                ->required()
+                ->maxLength(64),
+            TextInput::make('slug')
+                ->required()
+                ->maxLength(127)
+                ->afterStateUpdated(fn ($state, $set): mixed => $set('slug', Str::slug((string) $state))),
+            Toggle::make('is_active')
+                ->default(true),
+        ]);
+    }
+
+    public static function table(Table $table): Table
+    {
+        return $table
+            ->columns([
+                TextColumn::make('name')
+                    ->searchable()
+                    ->sortable(),
+                TextColumn::make('slug')
+                    ->searchable()
+                    ->copyable(),
+                IconColumn::make('is_active')
+                    ->boolean()
+                    ->sortable(),
+                TextColumn::make('updated_at')
+                    ->dateTime()
+                    ->sortable(),
+            ])
+            ->filters([
+                TernaryFilter::make('is_active'),
+            ])
+            ->actions([
+                Tables\Actions\EditAction::make(),
+            ])
+            ->defaultSort('updated_at', 'desc')
+            ->bulkActions([]);
+    }
+
+    public static function getRelations(): array
+    {
+        return [];
+    }
+
+    public static function getPages(): array
+    {
+        return [
+            'index' => Pages\ListArticleTags::route('/'),
+            'create' => Pages\CreateArticleTag::route('/create'),
+            'edit' => Pages\EditArticleTag::route('/{record}/edit'),
+        ];
+    }
+
+    public static function getEloquentQuery(): Builder
+    {
+        return parent::getEloquentQuery()
+            ->whereIn('org_id', self::tenantOrgIds());
+    }
+
+    /**
+     * @return array<int,int>
+     */
+    private static function tenantOrgIds(): array
+    {
+        $orgId = max(0, (int) app(OrgContext::class)->orgId());
+
+        return $orgId > 0 ? [0, $orgId] : [0];
+    }
+
+    private static function canRead(): bool
+    {
+        $guard = (string) config('admin.guard', 'admin');
+        $user = auth($guard)->user();
+
+        return is_object($user)
+            && method_exists($user, 'hasPermission')
+            && (
+                $user->hasPermission(PermissionNames::ADMIN_CONTENT_READ)
+                || $user->hasPermission(PermissionNames::ADMIN_OWNER)
+            );
+    }
+
+    private static function canPublish(): bool
+    {
+        $guard = (string) config('admin.guard', 'admin');
+        $user = auth($guard)->user();
+
+        return is_object($user)
+            && method_exists($user, 'hasPermission')
+            && (
+                $user->hasPermission(PermissionNames::ADMIN_CONTENT_PUBLISH)
+                || $user->hasPermission(PermissionNames::ADMIN_OWNER)
+            );
+    }
+}

--- a/backend/app/Filament/Ops/Resources/ArticleTagResource/Pages/CreateArticleTag.php
+++ b/backend/app/Filament/Ops/Resources/ArticleTagResource/Pages/CreateArticleTag.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Filament\Ops\Resources\ArticleTagResource\Pages;
+
+use App\Filament\Ops\Resources\ArticleTagResource;
+use Filament\Resources\Pages\CreateRecord;
+
+class CreateArticleTag extends CreateRecord
+{
+    protected static string $resource = ArticleTagResource::class;
+}

--- a/backend/app/Filament/Ops/Resources/ArticleTagResource/Pages/EditArticleTag.php
+++ b/backend/app/Filament/Ops/Resources/ArticleTagResource/Pages/EditArticleTag.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Filament\Ops\Resources\ArticleTagResource\Pages;
+
+use App\Filament\Ops\Resources\ArticleTagResource;
+use Filament\Resources\Pages\EditRecord;
+
+class EditArticleTag extends EditRecord
+{
+    protected static string $resource = ArticleTagResource::class;
+}

--- a/backend/app/Filament/Ops/Resources/ArticleTagResource/Pages/ListArticleTags.php
+++ b/backend/app/Filament/Ops/Resources/ArticleTagResource/Pages/ListArticleTags.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Filament\Ops\Resources\ArticleTagResource\Pages;
+
+use App\Filament\Ops\Resources\ArticleTagResource;
+use Filament\Actions;
+use Filament\Resources\Pages\ListRecords;
+
+class ListArticleTags extends ListRecords
+{
+    protected static string $resource = ArticleTagResource::class;
+
+    protected function getHeaderActions(): array
+    {
+        return [
+            Actions\CreateAction::make(),
+        ];
+    }
+}

--- a/backend/app/Http/Controllers/API/V0_5/Cms/ArticleController.php
+++ b/backend/app/Http/Controllers/API/V0_5/Cms/ArticleController.php
@@ -1,0 +1,386 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Controllers\API\V0_5\Cms;
+
+use App\Exceptions\OrgContextMissingException;
+use App\Http\Controllers\Controller;
+use App\Models\Article;
+use App\Services\Cms\ArticlePublishService;
+use App\Services\Cms\ArticleSeoService;
+use App\Services\Cms\ArticleService;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+use InvalidArgumentException;
+use RuntimeException;
+
+class ArticleController extends Controller
+{
+    public function __construct(
+        private readonly ArticleService $articleService,
+        private readonly ArticlePublishService $articlePublishService,
+        private readonly ArticleSeoService $articleSeoService,
+    ) {
+    }
+
+    /**
+     * GET /api/v0.5/articles
+     */
+    public function index(Request $request): JsonResponse
+    {
+        $orgId = $this->resolveOrgId($request);
+
+        $paginator = Article::query()
+            ->withoutGlobalScopes()
+            ->where('org_id', $orgId)
+            ->published()
+            ->with(['category', 'tags', 'seoMeta'])
+            ->orderByDesc('published_at')
+            ->orderByDesc('id')
+            ->paginate(20);
+
+        $items = [];
+        foreach ($paginator->items() as $article) {
+            if (! $article instanceof Article) {
+                continue;
+            }
+
+            $items[] = $this->articlePayload($article);
+        }
+
+        return response()->json([
+            'ok' => true,
+            'items' => $items,
+            'pagination' => [
+                'current_page' => (int) $paginator->currentPage(),
+                'per_page' => (int) $paginator->perPage(),
+                'total' => (int) $paginator->total(),
+                'last_page' => (int) $paginator->lastPage(),
+            ],
+        ]);
+    }
+
+    /**
+     * GET /api/v0.5/articles/{slug}
+     */
+    public function show(Request $request, string $slug): JsonResponse
+    {
+        $locale = trim((string) $request->query('locale', 'en'));
+        if ($locale === '') {
+            $locale = 'en';
+        }
+
+        $orgId = $this->resolveOrgId($request);
+        $normalizedSlug = trim($slug);
+        if ($normalizedSlug === '') {
+            return response()->json([
+                'ok' => false,
+                'error_code' => 'SLUG_REQUIRED',
+                'message' => 'slug is required.',
+            ], 400);
+        }
+
+        $article = null;
+
+        try {
+            $article = Article::findBySlug($normalizedSlug, $locale);
+        } catch (OrgContextMissingException) {
+            $article = null;
+        }
+
+        if (! $article instanceof Article || (int) $article->org_id !== $orgId) {
+            $article = Article::query()
+                ->withoutGlobalScopes()
+                ->where('org_id', $orgId)
+                ->where('slug', $normalizedSlug)
+                ->where('locale', $locale)
+                ->first();
+        }
+
+        if (! $article instanceof Article || (string) $article->status !== 'published' || ! (bool) $article->is_public) {
+            return response()->json([
+                'ok' => false,
+                'error_code' => 'NOT_FOUND',
+                'message' => 'article not found.',
+            ], 404);
+        }
+
+        $article->loadMissing(['category', 'tags', 'seoMeta']);
+
+        return response()->json([
+            'ok' => true,
+            'article' => $this->articlePayload($article),
+        ]);
+    }
+
+    /**
+     * POST /api/v0.5/cms/articles
+     */
+    public function store(Request $request): JsonResponse
+    {
+        $payload = $request->validate([
+            'title' => ['required', 'string', 'max:255'],
+            'slug' => ['nullable', 'string', 'max:127'],
+            'locale' => ['nullable', 'string', 'max:16'],
+            'content_md' => ['required', 'string'],
+            'category_id' => ['nullable', 'integer', 'min:1'],
+            'tags' => ['nullable', 'array'],
+            'tags.*' => ['integer', 'min:1'],
+            'org_id' => ['nullable', 'integer', 'min:0'],
+        ]);
+
+        try {
+            $article = $this->articleService->createArticle(
+                (string) $payload['title'],
+                isset($payload['slug']) ? (string) $payload['slug'] : null,
+                isset($payload['locale']) ? (string) $payload['locale'] : 'en',
+                (string) $payload['content_md'],
+                isset($payload['category_id']) ? (int) $payload['category_id'] : null,
+                isset($payload['tags']) && is_array($payload['tags']) ? $payload['tags'] : [],
+                isset($payload['org_id']) ? (int) $payload['org_id'] : $this->resolveOrgId($request)
+            );
+        } catch (InvalidArgumentException $e) {
+            return $this->invalidArgument($e);
+        } catch (RuntimeException $e) {
+            return $this->runtimeError($e);
+        }
+
+        $article->loadMissing(['category', 'tags', 'seoMeta']);
+
+        return response()->json([
+            'ok' => true,
+            'article' => $this->articlePayload($article),
+        ], 201);
+    }
+
+    /**
+     * PUT /api/v0.5/cms/articles/{id}
+     */
+    public function update(Request $request, string $id): JsonResponse
+    {
+        $articleId = $this->resolveArticleId($id);
+        if ($articleId === null) {
+            return response()->json([
+                'ok' => false,
+                'error_code' => 'ARTICLE_ID_INVALID',
+                'message' => 'article id must be a positive integer.',
+            ], 422);
+        }
+
+        $payload = $request->validate([
+            'title' => ['sometimes', 'string', 'max:255'],
+            'slug' => ['nullable', 'string', 'max:127'],
+            'locale' => ['nullable', 'string', 'max:16'],
+            'content_md' => ['sometimes', 'string'],
+            'category_id' => ['nullable', 'integer', 'min:1'],
+            'author_admin_user_id' => ['nullable', 'integer', 'min:1'],
+            'excerpt' => ['nullable', 'string'],
+            'content_html' => ['nullable', 'string'],
+            'cover_image_url' => ['nullable', 'string', 'max:255'],
+            'status' => ['sometimes', 'string', 'max:32'],
+            'is_public' => ['sometimes', 'boolean'],
+            'is_indexable' => ['sometimes', 'boolean'],
+            'published_at' => ['nullable', 'date'],
+            'scheduled_at' => ['nullable', 'date'],
+            'tags' => ['sometimes', 'array'],
+            'tags.*' => ['integer', 'min:1'],
+        ]);
+
+        $fields = $payload;
+        $tags = null;
+        if (array_key_exists('tags', $fields)) {
+            $rawTags = $fields['tags'];
+            $tags = is_array($rawTags) ? $rawTags : [];
+            unset($fields['tags']);
+        }
+
+        try {
+            $article = $this->articleService->updateArticle($articleId, $fields, $tags);
+        } catch (InvalidArgumentException $e) {
+            return $this->invalidArgument($e);
+        } catch (RuntimeException $e) {
+            return $this->runtimeError($e);
+        }
+
+        $article->loadMissing(['category', 'tags', 'seoMeta']);
+
+        return response()->json([
+            'ok' => true,
+            'article' => $this->articlePayload($article),
+        ]);
+    }
+
+    /**
+     * POST /api/v0.5/cms/articles/{id}/publish
+     */
+    public function publish(string $id): JsonResponse
+    {
+        $articleId = $this->resolveArticleId($id);
+        if ($articleId === null) {
+            return response()->json([
+                'ok' => false,
+                'error_code' => 'ARTICLE_ID_INVALID',
+                'message' => 'article id must be a positive integer.',
+            ], 422);
+        }
+
+        try {
+            $article = $this->articlePublishService->publishArticle($articleId);
+        } catch (InvalidArgumentException $e) {
+            return $this->invalidArgument($e);
+        } catch (RuntimeException $e) {
+            return $this->runtimeError($e);
+        }
+
+        $article->loadMissing(['category', 'tags', 'seoMeta']);
+
+        return response()->json([
+            'ok' => true,
+            'article' => $this->articlePayload($article),
+        ]);
+    }
+
+    /**
+     * POST /api/v0.5/cms/articles/{id}/unpublish
+     */
+    public function unpublish(string $id): JsonResponse
+    {
+        $articleId = $this->resolveArticleId($id);
+        if ($articleId === null) {
+            return response()->json([
+                'ok' => false,
+                'error_code' => 'ARTICLE_ID_INVALID',
+                'message' => 'article id must be a positive integer.',
+            ], 422);
+        }
+
+        try {
+            $article = $this->articlePublishService->unpublishArticle($articleId);
+        } catch (InvalidArgumentException $e) {
+            return $this->invalidArgument($e);
+        } catch (RuntimeException $e) {
+            return $this->runtimeError($e);
+        }
+
+        $article->loadMissing(['category', 'tags', 'seoMeta']);
+
+        return response()->json([
+            'ok' => true,
+            'article' => $this->articlePayload($article),
+        ]);
+    }
+
+    /**
+     * POST /api/v0.5/cms/articles/{id}/seo
+     */
+    public function generateSeo(string $id): JsonResponse
+    {
+        $articleId = $this->resolveArticleId($id);
+        if ($articleId === null) {
+            return response()->json([
+                'ok' => false,
+                'error_code' => 'ARTICLE_ID_INVALID',
+                'message' => 'article id must be a positive integer.',
+            ], 422);
+        }
+
+        try {
+            $seoMeta = $this->articleSeoService->generateSeoMeta($articleId);
+        } catch (InvalidArgumentException $e) {
+            return $this->invalidArgument($e);
+        } catch (RuntimeException $e) {
+            return $this->runtimeError($e);
+        }
+
+        return response()->json([
+            'ok' => true,
+            'seo_meta' => [
+                'id' => (int) $seoMeta->id,
+                'org_id' => (int) $seoMeta->org_id,
+                'article_id' => (int) $seoMeta->article_id,
+                'locale' => (string) $seoMeta->locale,
+                'seo_title' => (string) ($seoMeta->seo_title ?? ''),
+                'seo_description' => (string) ($seoMeta->seo_description ?? ''),
+                'canonical_url' => $seoMeta->canonical_url,
+                'og_title' => (string) ($seoMeta->og_title ?? ''),
+                'og_description' => (string) ($seoMeta->og_description ?? ''),
+                'is_indexable' => (bool) $seoMeta->is_indexable,
+                'robots' => (string) ($seoMeta->robots ?? ''),
+                'created_at' => $seoMeta->created_at?->toISOString(),
+                'updated_at' => $seoMeta->updated_at?->toISOString(),
+            ],
+        ]);
+    }
+
+    private function resolveOrgId(Request $request): int
+    {
+        $raw = trim((string) $request->query('org_id', '0'));
+
+        return preg_match('/^\d+$/', $raw) === 1 ? (int) $raw : 0;
+    }
+
+    private function resolveArticleId(string $id): ?int
+    {
+        $normalized = trim($id);
+        if ($normalized === '' || preg_match('/^\d+$/', $normalized) !== 1) {
+            return null;
+        }
+
+        $articleId = (int) $normalized;
+
+        return $articleId > 0 ? $articleId : null;
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    private function articlePayload(Article $article): array
+    {
+        return [
+            'id' => (int) $article->id,
+            'org_id' => (int) $article->org_id,
+            'category_id' => $article->category_id !== null ? (int) $article->category_id : null,
+            'author_admin_user_id' => $article->author_admin_user_id !== null ? (int) $article->author_admin_user_id : null,
+            'slug' => (string) $article->slug,
+            'locale' => (string) $article->locale,
+            'title' => (string) $article->title,
+            'excerpt' => $article->excerpt,
+            'content_md' => (string) $article->content_md,
+            'content_html' => $article->content_html,
+            'cover_image_url' => $article->cover_image_url,
+            'status' => (string) $article->status,
+            'is_public' => (bool) $article->is_public,
+            'is_indexable' => (bool) $article->is_indexable,
+            'published_at' => $article->published_at?->toISOString(),
+            'scheduled_at' => $article->scheduled_at?->toISOString(),
+            'created_at' => $article->created_at?->toISOString(),
+            'updated_at' => $article->updated_at?->toISOString(),
+            'category' => $article->relationLoaded('category') ? $article->category : null,
+            'tags' => $article->relationLoaded('tags') ? $article->tags : [],
+            'seo_meta' => $article->relationLoaded('seoMeta') ? $article->seoMeta : null,
+        ];
+    }
+
+    private function invalidArgument(InvalidArgumentException $e): JsonResponse
+    {
+        return response()->json([
+            'ok' => false,
+            'error_code' => 'INVALID_ARGUMENT',
+            'message' => $e->getMessage(),
+        ], 422);
+    }
+
+    private function runtimeError(RuntimeException $e): JsonResponse
+    {
+        $message = $e->getMessage();
+        $status = $message === 'article not found.' ? 404 : 400;
+        $errorCode = $status === 404 ? 'NOT_FOUND' : 'RUNTIME_ERROR';
+
+        return response()->json([
+            'ok' => false,
+            'error_code' => $errorCode,
+            'message' => $message,
+        ], $status);
+    }
+}

--- a/backend/app/Http/Controllers/API/V0_5/Cms/ArticleController.php
+++ b/backend/app/Http/Controllers/API/V0_5/Cms/ArticleController.php
@@ -21,8 +21,7 @@ class ArticleController extends Controller
         private readonly ArticleService $articleService,
         private readonly ArticlePublishService $articlePublishService,
         private readonly ArticleSeoService $articleSeoService,
-    ) {
-    }
+    ) {}
 
     /**
      * GET /api/v0.5/articles
@@ -111,6 +110,49 @@ class ArticleController extends Controller
         return response()->json([
             'ok' => true,
             'article' => $this->articlePayload($article),
+        ]);
+    }
+
+    /**
+     * GET /api/v0.5/articles/{slug}/seo
+     */
+    public function seo(Request $request, string $slug): JsonResponse
+    {
+        $locale = trim((string) $request->query('locale', 'en'));
+        if ($locale === '') {
+            $locale = 'en';
+        }
+
+        $orgId = $this->resolveOrgId($request);
+        $normalizedSlug = trim($slug);
+        if ($normalizedSlug === '') {
+            return response()->json(['error' => 'not found'], 404);
+        }
+
+        $article = null;
+
+        try {
+            $article = Article::findBySlug($normalizedSlug, $locale);
+        } catch (OrgContextMissingException) {
+            $article = null;
+        }
+
+        if (! $article instanceof Article || (int) $article->org_id !== $orgId) {
+            $article = Article::query()
+                ->withoutGlobalScopes()
+                ->where('org_id', $orgId)
+                ->where('slug', $normalizedSlug)
+                ->where('locale', $locale)
+                ->first();
+        }
+
+        if (! $article instanceof Article || (string) $article->status !== 'published' || ! (bool) $article->is_public) {
+            return response()->json(['error' => 'not found'], 404);
+        }
+
+        return response()->json([
+            'meta' => $this->articleSeoService->buildSeoPayload($article),
+            'jsonld' => $this->articleSeoService->generateJsonLd($article),
         ]);
     }
 

--- a/backend/app/Models/Article.php
+++ b/backend/app/Models/Article.php
@@ -63,6 +63,13 @@ class Article extends Model
         );
     }
 
+    public function scopePublished($query)
+    {
+        return $query
+            ->where('status', 'published')
+            ->where('is_public', true);
+    }
+
     public function revisions(): HasMany
     {
         return $this->hasMany(ArticleRevision::class, 'article_id', 'id');
@@ -81,4 +88,3 @@ class Article extends Model
             ->first();
     }
 }
-

--- a/backend/app/Models/ArticleTag.php
+++ b/backend/app/Models/ArticleTag.php
@@ -36,7 +36,8 @@ class ArticleTag extends Model
             'article_tag_map',
             'tag_id',
             'article_id'
-        );
+        )
+            ->withPivot(['org_id', 'created_at'])
+            ->withTimestamps();
     }
 }
-

--- a/backend/app/Services/Cms/ArticleSeoService.php
+++ b/backend/app/Services/Cms/ArticleSeoService.php
@@ -68,6 +68,79 @@ final class ArticleSeoService
         });
     }
 
+    /**
+     * @return array<string,mixed>
+     */
+    public function buildSeoPayload(Article $article): array
+    {
+        $locale = trim((string) $article->locale);
+        if ($locale === '') {
+            $locale = 'en';
+        }
+
+        $seo = null;
+        if ($article->relationLoaded('seoMeta') && $article->seoMeta instanceof ArticleSeoMeta) {
+            $seo = $article->seoMeta;
+        }
+
+        if (! $seo instanceof ArticleSeoMeta) {
+            $seo = ArticleSeoMeta::query()
+                ->withoutGlobalScopes()
+                ->where('org_id', (int) $article->org_id)
+                ->where('article_id', (int) $article->id)
+                ->where('locale', $locale)
+                ->first();
+        }
+
+        $title = $seo?->seo_title ?? $article->title;
+        $descriptionSource = (string) ($article->excerpt ?? $article->content_md);
+        $description = $seo?->seo_description ?? Str::limit(strip_tags($descriptionSource), 160);
+
+        $canonical = $seo?->canonical_url
+            ?? rtrim((string) config('app.url', ''), '/').'/articles/'.rawurlencode((string) $article->slug);
+
+        return [
+            'title' => $title,
+            'description' => $description,
+            'canonical' => $canonical,
+
+            'og' => [
+                'title' => $seo?->og_title ?? $title,
+                'description' => $seo?->og_description ?? $description,
+                'image' => $seo?->og_image_url,
+                'type' => 'article',
+            ],
+
+            'twitter' => [
+                'card' => 'summary_large_image',
+                'title' => $title,
+                'description' => $description,
+                'image' => $seo?->og_image_url,
+            ],
+
+            'robots' => $seo?->robots ?? 'index,follow',
+        ];
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    public function generateJsonLd(Article $article): array
+    {
+        return [
+            '@context' => 'https://schema.org',
+            '@type' => 'Article',
+            'headline' => $article->title,
+            'datePublished' => optional($article->published_at)->toAtomString(),
+            'dateModified' => optional($article->updated_at)->toAtomString(),
+            'author' => [
+                '@type' => 'Organization',
+                'name' => 'FermatMind',
+            ],
+            'mainEntityOfPage' => rtrim((string) config('app.url', ''), '/').'/articles/'.rawurlencode((string) $article->slug),
+        ];
+    }
+
     private function extractDescription(string $contentMd): string
     {
         $text = preg_replace('/`{1,3}[^`]*`{1,3}/u', ' ', $contentMd);

--- a/backend/app/Services/Cms/ArticleSeoService.php
+++ b/backend/app/Services/Cms/ArticleSeoService.php
@@ -104,6 +104,6 @@ final class ArticleSeoService
             return null;
         }
 
-        return $baseUrl.'/articles/'.rawurlencode($locale).'/'.rawurlencode($slug);
+        return $baseUrl.'/articles/'.rawurlencode($slug);
     }
 }

--- a/backend/app/Services/Cms/ArticleService.php
+++ b/backend/app/Services/Cms/ArticleService.php
@@ -314,6 +314,7 @@ final class ArticleService
         $payload = $snapshotArticle instanceof Article
             ? $snapshotArticle->toArray()
             : $article->toArray();
+        $payload['snapshot_at'] = now();
 
         return ArticleRevision::query()
             ->withoutGlobalScopes()

--- a/backend/app/Services/SEO/SitemapCache.php
+++ b/backend/app/Services/SEO/SitemapCache.php
@@ -6,8 +6,10 @@ use Illuminate\Support\Facades\Cache;
 
 class SitemapCache
 {
-    public const XML_CACHE_KEY = 'seo:sitemap:xml:v1';
-    public const ETAG_CACHE_KEY = 'seo:sitemap:etag:v1';
+    public const XML_CACHE_KEY = 'seo:sitemap:xml:v2';
+
+    public const ETAG_CACHE_KEY = 'seo:sitemap:etag:v2';
+
     public const TTL_SECONDS = 86400;
 
     public function get(): ?array
@@ -15,11 +17,11 @@ class SitemapCache
         $xml = Cache::get(self::XML_CACHE_KEY);
         $etag = Cache::get(self::ETAG_CACHE_KEY);
 
-        if (!is_string($xml) || $xml === '') {
+        if (! is_string($xml) || $xml === '') {
             return null;
         }
 
-        if (!is_string($etag) || $etag === '') {
+        if (! is_string($etag) || $etag === '') {
             return null;
         }
 
@@ -39,8 +41,8 @@ class SitemapCache
     {
         $normalizedList = array_values($slugList);
         $slugListHash = sha1(implode("\n", $normalizedList));
-        $etagBase = $maxUpdatedAt . '|' . $slugCount . '|' . $slugListHash;
+        $etagBase = $maxUpdatedAt.'|'.$slugCount.'|'.$slugListHash;
 
-        return '"' . sha1($etagBase) . '"';
+        return '"'.sha1($etagBase).'"';
     }
 }

--- a/backend/app/Services/SEO/SitemapGenerator.php
+++ b/backend/app/Services/SEO/SitemapGenerator.php
@@ -21,6 +21,54 @@ class SitemapGenerator
 
     public function generate(): array
     {
+        $locale = (string) config('app.locale', 'en');
+
+        $urls = array_merge(
+            $this->getScaleUrls($locale),
+            $this->getArticleUrls($locale)
+        );
+
+        $urls = collect($urls)
+            ->unique('loc')
+            ->values()
+            ->all();
+
+        usort($urls, static function (array $a, array $b): int {
+            return strcmp((string) ($a['loc'] ?? ''), (string) ($b['loc'] ?? ''));
+        });
+
+        $slugList = [];
+        $maxUpdatedAt = null;
+
+        foreach ($urls as $row) {
+            $slug = trim((string) ($row['slug'] ?? ''));
+            if ($slug !== '') {
+                $slugList[] = $slug;
+            }
+
+            $updatedValue = (string) ($row['updated_at'] ?? '');
+            if ($updatedValue === '') {
+                $updatedValue = (string) ($row['lastmod'] ?? '');
+            }
+
+            $updatedAt = $this->parseUpdatedAt($updatedValue);
+            if ($updatedAt && ($maxUpdatedAt === null || $updatedAt->gt($maxUpdatedAt))) {
+                $maxUpdatedAt = $updatedAt;
+            }
+        }
+
+        $xml = $this->buildXml($urls);
+
+        return [
+            'xml' => $xml,
+            'slug_list' => $slugList,
+            'slug_count' => count($slugList),
+            'max_updated_at' => $maxUpdatedAt ? $maxUpdatedAt->toDateTimeString() : '',
+        ];
+    }
+
+    private function getScaleUrls(string $locale): array
+    {
         $rows = DB::table('scales_registry')
             ->select('primary_slug', 'slugs_json', 'view_policy_json', 'updated_at')
             ->where('is_active', 1)
@@ -29,7 +77,6 @@ class SitemapGenerator
             ->get();
 
         $slugDates = [];
-        $maxUpdatedAt = null;
 
         foreach ($rows as $row) {
             if (! $this->isIndexablePublic($row->view_policy_json ?? null)) {
@@ -37,9 +84,6 @@ class SitemapGenerator
             }
 
             $updatedAt = $this->parseUpdatedAt($row->updated_at ?? null);
-            if ($updatedAt && ($maxUpdatedAt === null || $updatedAt->gt($maxUpdatedAt))) {
-                $maxUpdatedAt = $updatedAt;
-            }
 
             $slugs = $this->collectSlugs($row->primary_slug ?? null, $row->slugs_json ?? null);
             foreach ($slugs as $slug) {
@@ -63,14 +107,51 @@ class SitemapGenerator
         $slugList = array_keys($slugDates);
         sort($slugList, SORT_STRING);
 
-        $xml = $this->buildXml($slugList, $slugDates);
+        $urls = [];
+        foreach ($slugList as $slug) {
+            $urls[] = [
+                'loc' => $this->urlPrefix.rawurlencode($slug),
+                'lastmod' => $this->formatLastmod($slugDates[$slug] ?? null),
+                'slug' => $slug,
+                'updated_at' => ($slugDates[$slug] ?? null)?->toDateTimeString(),
+            ];
+        }
 
-        return [
-            'xml' => $xml,
-            'slug_list' => $slugList,
-            'slug_count' => count($slugList),
-            'max_updated_at' => $maxUpdatedAt ? $maxUpdatedAt->toDateTimeString() : '',
-        ];
+        return $urls;
+    }
+
+    private function getArticleUrls(string $locale): array
+    {
+        $rows = \App\Models\Article::query()
+            ->withoutGlobalScopes()
+            ->where('org_id', 0)
+            ->where('status', 'published')
+            ->where('is_public', true)
+            ->where('is_indexable', true)
+            ->select(['slug', 'updated_at', 'published_at'])
+            ->orderByDesc('updated_at')
+            ->get();
+
+        $prefix = rtrim((string) config('services.seo.articles_url_prefix'), '/');
+
+        $urls = [];
+
+        foreach ($rows as $row) {
+            $url = $prefix.'/'.rawurlencode($row->slug);
+
+            $lastmod = $row->updated_at
+                ?? $row->published_at
+                ?? now();
+
+            $urls[] = [
+                'loc' => $url,
+                'lastmod' => $lastmod->toAtomString(),
+                'slug' => (string) $row->slug,
+                'updated_at' => $lastmod->toDateTimeString(),
+            ];
+        }
+
+        return $urls;
     }
 
     private function collectSlugs($primarySlug, $slugsJson): array
@@ -154,24 +235,26 @@ class SitemapGenerator
         return true;
     }
 
-    private function buildXml(array $slugList, array $slugDates): string
+    private function buildXml(array $urls): string
     {
         $lines = [];
         $lines[] = '<?xml version="1.0" encoding="UTF-8"?>';
         $lines[] = '<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">';
 
-        foreach ($slugList as $slug) {
-            $slug = trim((string) $slug);
-            if ($slug === '') {
+        foreach ($urls as $row) {
+            $loc = trim((string) ($row['loc'] ?? ''));
+            if ($loc === '') {
                 continue;
             }
 
-            $loc = $this->urlPrefix.rawurlencode($slug);
-            $lastmod = $this->formatLastmod($slugDates[$slug] ?? null);
+            $lastmod = trim((string) ($row['lastmod'] ?? ''));
+            if ($lastmod === '') {
+                $lastmod = '1970-01-01';
+            }
 
             $lines[] = '  <url>';
             $lines[] = '    <loc>'.htmlspecialchars($loc, ENT_XML1).'</loc>';
-            $lines[] = '    <lastmod>'.$lastmod.'</lastmod>';
+            $lines[] = '    <lastmod>'.htmlspecialchars($lastmod, ENT_XML1).'</lastmod>';
             $lines[] = '    <changefreq>weekly</changefreq>';
             $lines[] = '    <priority>0.7</priority>';
             $lines[] = '  </url>';

--- a/backend/config/services.php
+++ b/backend/config/services.php
@@ -109,6 +109,10 @@ return [
             'SEO_TESTS_URL_PREFIX',
             rtrim((string) env('APP_URL', 'http://localhost'), '/').'/tests/'
         ),
+        'articles_url_prefix' => env(
+            'SEO_ARTICLES_PREFIX',
+            rtrim((string) env('APP_URL', 'http://localhost'), '/').'/articles'
+        ),
     ],
 
     'integrations' => [

--- a/backend/database/migrations/2026_03_05_154120_create_articles_table.php
+++ b/backend/database/migrations/2026_03_05_154120_create_articles_table.php
@@ -28,6 +28,7 @@ return new class extends Migration
             $table->timestamp('published_at')->nullable();
             $table->timestamp('scheduled_at')->nullable();
             $table->timestamps();
+            $table->softDeletes();
 
             $table->unique(['org_id', 'locale', 'slug'], 'articles_org_locale_slug_unique');
             $table->index(['org_id', 'status', 'published_at'], 'articles_org_status_published_idx');

--- a/backend/database/migrations/2026_03_05_154121_create_article_tag_map_table.php
+++ b/backend/database/migrations/2026_03_05_154121_create_article_tag_map_table.php
@@ -15,7 +15,7 @@ return new class extends Migration
             $table->unsignedBigInteger('org_id')->default(0);
             $table->unsignedBigInteger('article_id');
             $table->unsignedBigInteger('tag_id');
-            $table->timestamp('created_at')->nullable();
+            $table->timestamps();
 
             $table->unique(['org_id', 'article_id', 'tag_id'], 'article_tag_map_org_article_tag_unique');
             $table->index(['org_id', 'tag_id', 'article_id'], 'article_tag_map_org_tag_article_idx');

--- a/backend/docs/contracts/openapi.snapshot.json
+++ b/backend/docs/contracts/openapi.snapshot.json
@@ -1665,6 +1665,125 @@
                     "App\\Http\\Middleware\\PartnerApiKeyAuth"
                 ]
             }
+        },
+        "/api/v0.5/articles": {
+            "get": {
+                "operationId": "get_api_v0_5_articles",
+                "tags": [
+                    "api:v0.5"
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK"
+                    }
+                },
+                "x-laravel-action": "App\\Http\\Controllers\\API\\V0_5\\Cms\\ArticleController@index",
+                "x-laravel-middleware": [
+                    "api"
+                ]
+            }
+        },
+        "/api/v0.5/articles/{slug}": {
+            "get": {
+                "operationId": "get_api_v0_5_articles_slug_",
+                "tags": [
+                    "api:v0.5"
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK"
+                    }
+                },
+                "x-laravel-action": "App\\Http\\Controllers\\API\\V0_5\\Cms\\ArticleController@show",
+                "x-laravel-middleware": [
+                    "api"
+                ]
+            }
+        },
+        "/api/v0.5/cms/articles": {
+            "post": {
+                "operationId": "post_api_v0_5_cms_articles",
+                "tags": [
+                    "api:v0.5"
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK"
+                    }
+                },
+                "x-laravel-action": "App\\Http\\Controllers\\API\\V0_5\\Cms\\ArticleController@store",
+                "x-laravel-middleware": [
+                    "api"
+                ]
+            }
+        },
+        "/api/v0.5/cms/articles/{id}": {
+            "put": {
+                "operationId": "put_api_v0_5_cms_articles_id_",
+                "tags": [
+                    "api:v0.5"
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK"
+                    }
+                },
+                "x-laravel-action": "App\\Http\\Controllers\\API\\V0_5\\Cms\\ArticleController@update",
+                "x-laravel-middleware": [
+                    "api"
+                ]
+            }
+        },
+        "/api/v0.5/cms/articles/{id}/publish": {
+            "post": {
+                "operationId": "post_api_v0_5_cms_articles_id_publish",
+                "tags": [
+                    "api:v0.5"
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK"
+                    }
+                },
+                "x-laravel-action": "App\\Http\\Controllers\\API\\V0_5\\Cms\\ArticleController@publish",
+                "x-laravel-middleware": [
+                    "api"
+                ]
+            }
+        },
+        "/api/v0.5/cms/articles/{id}/seo": {
+            "post": {
+                "operationId": "post_api_v0_5_cms_articles_id_seo",
+                "tags": [
+                    "api:v0.5"
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK"
+                    }
+                },
+                "x-laravel-action": "App\\Http\\Controllers\\API\\V0_5\\Cms\\ArticleController@generateSeo",
+                "x-laravel-middleware": [
+                    "api"
+                ]
+            }
+        },
+        "/api/v0.5/cms/articles/{id}/unpublish": {
+            "post": {
+                "operationId": "post_api_v0_5_cms_articles_id_unpublish",
+                "tags": [
+                    "api:v0.5"
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK"
+                    }
+                },
+                "x-laravel-action": "App\\Http\\Controllers\\API\\V0_5\\Cms\\ArticleController@unpublish",
+                "x-laravel-middleware": [
+                    "api"
+                ]
+            }
         }
     }
 }

--- a/backend/docs/contracts/openapi.snapshot.json
+++ b/backend/docs/contracts/openapi.snapshot.json
@@ -1700,6 +1700,23 @@
                 ]
             }
         },
+        "/api/v0.5/articles/{slug}/seo": {
+            "get": {
+                "operationId": "get_api_v0_5_articles_slug_seo",
+                "tags": [
+                    "api:v0.5"
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK"
+                    }
+                },
+                "x-laravel-action": "App\\Http\\Controllers\\API\\V0_5\\Cms\\ArticleController@seo",
+                "x-laravel-middleware": [
+                    "api"
+                ]
+            }
+        },
         "/api/v0.5/cms/articles": {
             "post": {
                 "operationId": "post_api_v0_5_cms_articles",

--- a/backend/routes/api.php
+++ b/backend/routes/api.php
@@ -23,6 +23,7 @@ use App\Http\Controllers\API\V0_4\BootController;
 use App\Http\Controllers\API\V0_4\ExperimentGovernanceController;
 use App\Http\Controllers\API\V0_4\PartnerController;
 use App\Http\Controllers\API\V0_4\RotationAuditController;
+use App\Http\Controllers\API\V0_5\Cms\ArticleController;
 use App\Http\Controllers\HealthzController;
 use App\Http\Middleware\HealthzAccessControl;
 use App\Http\Middleware\LimitWebhookPayloadSize;
@@ -289,4 +290,16 @@ Route::prefix('v0.4')->middleware(NormalizeApiErrorContract::class)->group(funct
         Route::get('/orgs/{org_id}/assessments/{id}/progress', [AssessmentController::class, 'progress']);
         Route::get('/orgs/{org_id}/assessments/{id}/summary', [AssessmentController::class, 'summary']);
     });
+});
+
+Route::prefix('v0.5')->group(function () {
+    Route::get('/articles', [ArticleController::class, 'index']);
+    Route::get('/articles/{slug}', [ArticleController::class, 'show']);
+
+    Route::post('/cms/articles', [ArticleController::class, 'store']);
+    Route::put('/cms/articles/{id}', [ArticleController::class, 'update']);
+
+    Route::post('/cms/articles/{id}/publish', [ArticleController::class, 'publish']);
+    Route::post('/cms/articles/{id}/unpublish', [ArticleController::class, 'unpublish']);
+    Route::post('/cms/articles/{id}/seo', [ArticleController::class, 'generateSeo']);
 });

--- a/backend/routes/api.php
+++ b/backend/routes/api.php
@@ -50,7 +50,7 @@ Route::middleware([HealthzAccessControl::class, 'throttle:api_public'])
     ->get('/healthz', [HealthzController::class, 'show'])
     ->name('healthz');
 
-Route::prefix("v0.2")->middleware([
+Route::prefix('v0.2')->middleware([
     'throttle:api_public',
     NormalizeApiErrorContract::class,
 ])->group(function () {
@@ -133,7 +133,7 @@ Route::prefix('v0.3')->middleware([
         // 2) Attempts lifecycle
         Route::middleware('throttle:api_attempt_submit')->group(function () {
             Route::post('/attempts/start', [AttemptWriteController::class, 'start']);
-            Route::post("/attempts/submit", [AttemptWriteController::class, "submit"])
+            Route::post('/attempts/submit', [AttemptWriteController::class, 'submit'])
                 ->middleware(\App\Http\Middleware\FmTokenAuth::class);
         });
         Route::put('/attempts/{attempt_id}/progress', [AttemptProgressController::class, 'upsert'])
@@ -295,6 +295,7 @@ Route::prefix('v0.4')->middleware(NormalizeApiErrorContract::class)->group(funct
 Route::prefix('v0.5')->group(function () {
     Route::get('/articles', [ArticleController::class, 'index']);
     Route::get('/articles/{slug}', [ArticleController::class, 'show']);
+    Route::get('/articles/{slug}/seo', [ArticleController::class, 'seo']);
 
     Route::post('/cms/articles', [ArticleController::class, 'store']);
     Route::put('/cms/articles/{id}', [ArticleController::class, 'update']);


### PR DESCRIPTION
## Summary

This PR completes the core article CMS backend stack and related SEO integration.

Included changes:

### CMS hardening
- add soft delete support to `articles`
- update `article_tag_map` to use full timestamps
- add `Article::published()` scope
- include pivot metadata in `ArticleTag::articles()`
- persist `snapshot_at` in article revision payload
- unify canonical path to `/articles/{slug}`

### CMS API
- add `ArticleController` under `API/V0_5/Cms`
- add public endpoints:
  - `GET /api/v0.5/articles`
  - `GET /api/v0.5/articles/{slug}`
  - `GET /api/v0.5/articles/{slug}/seo`
- add admin endpoints:
  - `POST /api/v0.5/cms/articles`
  - `PUT /api/v0.5/cms/articles/{id}`
  - `POST /api/v0.5/cms/articles/{id}/publish`
  - `POST /api/v0.5/cms/articles/{id}/unpublish`
  - `POST /api/v0.5/cms/articles/{id}/seo`

### Ops CMS resources
- add `ArticleResource`
- add `ArticleCategoryResource`
- add `ArticleTagResource`
- support create/edit/list flows in `/ops`

### SEO integration
- extend sitemap generation to include CMS article URLs
- bump sitemap cache version from `v1` to `v2`
- add `services.seo.articles_url_prefix`
- add SEO meta payload generation and JSON-LD article output

### Contracts / docs
- update `openapi.snapshot.json`

## Files changed

### Added
- `backend/app/Filament/Ops/Resources/ArticleCategoryResource.php`
- `backend/app/Filament/Ops/Resources/ArticleCategoryResource/Pages/CreateArticleCategory.php`
- `backend/app/Filament/Ops/Resources/ArticleCategoryResource/Pages/EditArticleCategory.php`
- `backend/app/Filament/Ops/Resources/ArticleCategoryResource/Pages/ListArticleCategories.php`
- `backend/app/Filament/Ops/Resources/ArticleResource.php`
- `backend/app/Filament/Ops/Resources/ArticleResource/Pages/CreateArticle.php`
- `backend/app/Filament/Ops/Resources/ArticleResource/Pages/EditArticle.php`
- `backend/app/Filament/Ops/Resources/ArticleResource/Pages/ListArticles.php`
- `backend/app/Filament/Ops/Resources/ArticleTagResource.php`
- `backend/app/Filament/Ops/Resources/ArticleTagResource/Pages/CreateArticleTag.php`
- `backend/app/Filament/Ops/Resources/ArticleTagResource/Pages/EditArticleTag.php`
- `backend/app/Filament/Ops/Resources/ArticleTagResource/Pages/ListArticleTags.php`
- `backend/app/Http/Controllers/API/V0_5/Cms/ArticleController.php`

### Modified
- `backend/app/Models/Article.php`
- `backend/app/Models/ArticleTag.php`
- `backend/app/Services/Cms/ArticleSeoService.php`
- `backend/app/Services/Cms/ArticleService.php`
- `backend/app/Services/SEO/SitemapCache.php`
- `backend/app/Services/SEO/SitemapGenerator.php`
- `backend/config/services.php`
- `backend/database/migrations/2026_03_05_154120_create_articles_table.php`
- `backend/database/migrations/2026_03_05_154121_create_article_tag_map_table.php`
- `backend/docs/contracts/openapi.snapshot.json`
- `backend/routes/api.php`

## Verification

- `php artisan migrate --force`
- `php artisan route:list`
- `php artisan route:list | grep v0.5`
- `php artisan route:list | grep seo`
- `php artisan tinker --execute="dump(App\\Models\\Article::published()->first());"`
- `bash backend/scripts/ci_verify_mbti.sh`
- `curl http://127.0.0.1:8000/api/v0.5/articles`
- `curl http://127.0.0.1:8000/api/v0.5/articles/{slug}/seo`

## Notes

This PR is larger than a typical single-scope change because it consolidates CMS hardening, article API, ops resources, sitemap integration, and SEO meta support into one branch.