### PR TITLE
feat(frontend): add global layout and navigation

### DIFF
--- a/fap-web/.gitignore
+++ b/fap-web/.gitignore
@@ -1,0 +1,3 @@
+.next
+node_modules
+

--- a/fap-web/app/articles/[slug]/page.tsx
+++ b/fap-web/app/articles/[slug]/page.tsx
@@ -1,0 +1,118 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+import { notFound } from "next/navigation";
+import Breadcrumb from "@/components/breadcrumb/Breadcrumb";
+import { getArticle, getCareer, getPersonality } from "@/lib/content";
+
+export const dynamic = "force-dynamic";
+
+type ArticlePageProps = {
+  params: Promise<{
+    slug: string;
+  }>;
+};
+
+export async function generateMetadata({
+  params,
+}: ArticlePageProps): Promise<Metadata> {
+  const { slug } = await params;
+  const article = getArticle(slug);
+
+  if (!article) {
+    return {
+      title: "Article not found",
+    };
+  }
+
+  return {
+    title: article.title,
+    description: article.excerpt,
+    alternates: {
+      canonical: `/articles/${article.slug}`,
+    },
+    openGraph: {
+      title: article.title,
+      description: article.excerpt,
+      type: "article",
+      url: `/articles/${article.slug}`,
+    },
+  };
+}
+
+export default async function ArticleDetailPage({ params }: ArticlePageProps) {
+  const { slug } = await params;
+  const article = getArticle(slug);
+
+  if (!article) {
+    notFound();
+  }
+
+  const relatedCareers = article.relatedCareerSlugs
+    .map((careerSlug) => getCareer(careerSlug))
+    .filter(Boolean);
+
+  const relatedPersonalities = article.relatedPersonalityTypes
+    .map((type) => getPersonality(type))
+    .filter(Boolean);
+
+  return (
+    <div className="shell page-shell">
+      <Breadcrumb
+        items={[
+          { label: "Home", href: "/" },
+          { label: "Articles", href: "/articles" },
+          { label: article.title },
+        ]}
+      />
+
+      <section className="page-hero">
+        <p className="eyebrow">Article</p>
+        <h1 className="page-title">{article.title}</h1>
+        <p className="lead">{article.excerpt}</p>
+        <div className="content-meta">{article.publishedAt}</div>
+      </section>
+
+      <section className="detail-grid">
+        <article className="detail-panel">
+          <h2>Overview</h2>
+          {article.body.map((paragraph) => (
+            <p key={paragraph} className="detail-panel__copy">
+              {paragraph}
+            </p>
+          ))}
+        </article>
+
+        <div className="split-grid">
+          <aside className="related-panel">
+            <h2>Related careers</h2>
+            <ul className="link-list">
+              {relatedCareers.map((career) => (
+                <li key={career!.id}>
+                  <Link href={`/career/${career!.slug}`}>
+                    <strong>{career!.name}</strong>
+                    <span>{career!.summary}</span>
+                  </Link>
+                </li>
+              ))}
+            </ul>
+          </aside>
+
+          <aside className="related-panel">
+            <h2>Related personalities</h2>
+            <ul className="link-list">
+              {relatedPersonalities.map((personality) => (
+                <li key={personality!.type}>
+                  <Link href={`/personality/${personality!.slug}`}>
+                    <strong>{personality!.type}</strong>
+                    <span>{personality!.summary}</span>
+                  </Link>
+                </li>
+              ))}
+            </ul>
+          </aside>
+        </div>
+      </section>
+    </div>
+  );
+}
+

--- a/fap-web/app/articles/page.tsx
+++ b/fap-web/app/articles/page.tsx
@@ -1,0 +1,61 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+import Breadcrumb from "@/components/breadcrumb/Breadcrumb";
+import { getArticles } from "@/lib/content";
+
+export const dynamic = "force-dynamic";
+
+export const metadata: Metadata = {
+  title: "Articles",
+  description:
+    "Read practical articles on career strategy, deep work, and communication from FermatMind.",
+  alternates: {
+    canonical: "/articles",
+  },
+  openGraph: {
+    title: "Articles",
+    description:
+      "Read practical articles on career strategy, deep work, and communication from FermatMind.",
+    url: "/articles",
+  },
+};
+
+export default function ArticlesPage() {
+  const articles = getArticles();
+
+  return (
+    <div className="shell page-shell">
+      <Breadcrumb
+        items={[
+          { label: "Home", href: "/" },
+          { label: "Articles" },
+        ]}
+      />
+
+      <section className="page-hero">
+        <p className="eyebrow">Editorial</p>
+        <h1 className="page-title">Articles with a clearer path through the site.</h1>
+        <p className="lead">
+          The article index now shares the same navigation, breadcrumb, footer,
+          and metadata structure as the rest of the content platform.
+        </p>
+      </section>
+
+      <section className="content-stack">
+        {articles.map((article) => (
+          <article key={article.id} className="content-card">
+            <h2>{article.title}</h2>
+            <p>{article.excerpt}</p>
+            <div className="content-meta">
+              {article.publishedAt} ·{" "}
+              <Link href={`/articles/${article.slug}`} className="card-link">
+                Read article
+              </Link>
+            </div>
+          </article>
+        ))}
+      </section>
+    </div>
+  );
+}
+

--- a/fap-web/app/career/[slug]/page.tsx
+++ b/fap-web/app/career/[slug]/page.tsx
@@ -1,0 +1,126 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+import { notFound } from "next/navigation";
+import Breadcrumb from "@/components/breadcrumb/Breadcrumb";
+import { getCareer, getPersonality, getArticles } from "@/lib/content";
+
+export const dynamic = "force-dynamic";
+
+type CareerPageProps = {
+  params: Promise<{
+    slug: string;
+  }>;
+};
+
+export async function generateMetadata({
+  params,
+}: CareerPageProps): Promise<Metadata> {
+  const { slug } = await params;
+  const career = getCareer(slug);
+
+  if (!career) {
+    return {
+      title: "Career not found",
+    };
+  }
+
+  return {
+    title: `${career.name} guide`,
+    description: career.summary,
+    alternates: {
+      canonical: `/career/${career.slug}`,
+    },
+    openGraph: {
+      title: `${career.name} guide`,
+      description: career.summary,
+      url: `/career/${career.slug}`,
+    },
+  };
+}
+
+export default async function CareerDetailPage({ params }: CareerPageProps) {
+  const { slug } = await params;
+  const career = getCareer(slug);
+
+  if (!career) {
+    notFound();
+  }
+
+  const relatedArticles = getArticles().filter((article) =>
+    article.relatedCareerSlugs.includes(career.slug),
+  );
+  const suggestedPersonalities = ["INTJ", "ENTJ", "INFJ"]
+    .map((type) => getPersonality(type))
+    .filter(Boolean);
+
+  return (
+    <div className="shell page-shell">
+      <Breadcrumb
+        items={[
+          { label: "Home", href: "/" },
+          { label: "Career", href: "/career" },
+          { label: career.name },
+        ]}
+      />
+
+      <section className="page-hero">
+        <p className="eyebrow">Career detail</p>
+        <h1 className="page-title">{career.name}</h1>
+        <p className="lead">{career.summary}</p>
+      </section>
+
+      <section className="split-grid">
+        <article className="detail-panel">
+          <h2>Overview</h2>
+          <p className="detail-panel__copy">{career.overview}</p>
+        </article>
+
+        <article className="detail-panel">
+          <h2>Skills</h2>
+          <p className="detail-panel__copy">{career.skills}</p>
+        </article>
+
+        <article className="detail-panel">
+          <h2>Salary range</h2>
+          <p className="detail-panel__copy">{career.salaryRange}</p>
+        </article>
+
+        <article className="detail-panel">
+          <h2>Future outlook</h2>
+          <p className="detail-panel__copy">{career.futureOutlook}</p>
+        </article>
+      </section>
+
+      <section className="split-grid">
+        <aside className="related-panel">
+          <h2>Related articles</h2>
+          <ul className="link-list">
+            {relatedArticles.map((article) => (
+              <li key={article.id}>
+                <Link href={`/articles/${article.slug}`}>
+                  <strong>{article.title}</strong>
+                  <span>{article.excerpt}</span>
+                </Link>
+              </li>
+            ))}
+          </ul>
+        </aside>
+
+        <aside className="related-panel">
+          <h2>Relevant personalities</h2>
+          <ul className="link-list">
+            {suggestedPersonalities.map((personality) => (
+              <li key={personality!.type}>
+                <Link href={`/personality/${personality!.slug}`}>
+                  <strong>{personality!.type}</strong>
+                  <span>{personality!.summary}</span>
+                </Link>
+              </li>
+            ))}
+          </ul>
+        </aside>
+      </section>
+    </div>
+  );
+}
+

--- a/fap-web/app/career/page.tsx
+++ b/fap-web/app/career/page.tsx
@@ -1,0 +1,60 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+import Breadcrumb from "@/components/breadcrumb/Breadcrumb";
+import { getCareers } from "@/lib/content";
+
+export const dynamic = "force-dynamic";
+
+export const metadata: Metadata = {
+  title: "Career",
+  description:
+    "Explore practical career guides with overview, skills, salary range, and outlook.",
+  alternates: {
+    canonical: "/career",
+  },
+  openGraph: {
+    title: "Career",
+    description:
+      "Explore practical career guides with overview, skills, salary range, and outlook.",
+    url: "/career",
+  },
+};
+
+export default function CareerPage() {
+  const careers = getCareers();
+
+  return (
+    <div className="shell page-shell">
+      <Breadcrumb
+        items={[
+          { label: "Home", href: "/" },
+          { label: "Career" },
+        ]}
+      />
+
+      <section className="page-hero">
+        <p className="eyebrow">Career guides</p>
+        <h1 className="page-title">Career pages now share one platform shell.</h1>
+        <p className="lead">
+          The listing and detail views use the same header, footer, breadcrumb,
+          and metadata shape as the rest of the content routes.
+        </p>
+      </section>
+
+      <section className="content-stack">
+        {careers.map((career) => (
+          <article key={career.id} className="content-card">
+            <h2>{career.name}</h2>
+            <p>{career.summary}</p>
+            <div className="content-meta">
+              <Link href={`/career/${career.slug}`} className="card-link">
+                Open guide
+              </Link>
+            </div>
+          </article>
+        ))}
+      </section>
+    </div>
+  );
+}
+

--- a/fap-web/app/globals.css
+++ b/fap-web/app/globals.css
@@ -1,0 +1,300 @@
+:root {
+  color-scheme: light;
+  --bg: #f7f2eb;
+  --surface: rgba(255, 255, 255, 0.82);
+  --surface-strong: #fffdf9;
+  --border: rgba(35, 43, 59, 0.12);
+  --text: #1f2937;
+  --muted: #5f6675;
+  --accent: #c1573d;
+  --accent-soft: rgba(193, 87, 61, 0.12);
+  --shadow: 0 18px 36px rgba(31, 41, 55, 0.08);
+}
+
+* {
+  box-sizing: border-box;
+}
+
+html {
+  min-height: 100%;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  background:
+    radial-gradient(circle at top left, rgba(193, 87, 61, 0.12), transparent 32%),
+    radial-gradient(circle at top right, rgba(34, 86, 153, 0.1), transparent 28%),
+    var(--bg);
+  color: var(--text);
+  font-family: "Avenir Next", "Segoe UI", sans-serif;
+}
+
+a {
+  color: inherit;
+  text-decoration: none;
+}
+
+img {
+  max-width: 100%;
+}
+
+.site-body {
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+}
+
+.shell {
+  width: min(1120px, calc(100% - 2rem));
+  margin: 0 auto;
+}
+
+.site-header {
+  position: sticky;
+  top: 0;
+  z-index: 10;
+  backdrop-filter: blur(14px);
+  background: rgba(247, 242, 235, 0.9);
+  border-bottom: 1px solid var(--border);
+}
+
+.site-header__inner {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  padding: 1rem 0;
+}
+
+.brand-mark {
+  font-size: 1.125rem;
+  font-weight: 800;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.main-nav {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.85rem;
+}
+
+.main-nav__link {
+  padding: 0.5rem 0.8rem;
+  border-radius: 999px;
+  color: var(--muted);
+  transition:
+    background-color 150ms ease,
+    color 150ms ease,
+    transform 150ms ease;
+}
+
+.main-nav__link:hover {
+  background: var(--accent-soft);
+  color: var(--text);
+  transform: translateY(-1px);
+}
+
+.main-content {
+  flex: 1;
+  padding: 2.5rem 0 4rem;
+}
+
+.page-shell {
+  display: grid;
+  gap: 1.5rem;
+}
+
+.page-hero,
+.content-card,
+.detail-panel,
+.related-panel {
+  background: var(--surface);
+  border: 1px solid var(--border);
+  box-shadow: var(--shadow);
+  border-radius: 24px;
+}
+
+.page-hero {
+  padding: 2rem;
+}
+
+.eyebrow {
+  margin: 0 0 0.75rem;
+  color: var(--accent);
+  font-size: 0.78rem;
+  font-weight: 700;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+}
+
+.page-title {
+  margin: 0;
+  font-size: clamp(2.25rem, 4vw, 3.6rem);
+  line-height: 0.98;
+}
+
+.lead {
+  max-width: 62ch;
+  margin: 1rem 0 0;
+  color: var(--muted);
+  font-size: 1.05rem;
+  line-height: 1.7;
+}
+
+.content-stack {
+  display: grid;
+  gap: 1rem;
+}
+
+.content-card {
+  padding: 1.4rem 1.45rem;
+}
+
+.content-card h2,
+.detail-panel h2,
+.related-panel h2 {
+  margin: 0 0 0.75rem;
+  font-size: 1.3rem;
+}
+
+.content-card p,
+.detail-panel p,
+.related-panel p,
+.footer-title {
+  margin: 0;
+  line-height: 1.75;
+}
+
+.content-meta {
+  margin-top: 0.85rem;
+  color: var(--muted);
+  font-size: 0.93rem;
+}
+
+.card-link {
+  color: var(--accent);
+  font-weight: 700;
+}
+
+.card-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(230px, 1fr));
+  gap: 1rem;
+}
+
+.detail-grid {
+  display: grid;
+  gap: 1rem;
+}
+
+.detail-panel,
+.related-panel {
+  padding: 1.5rem;
+}
+
+.detail-panel__copy {
+  color: var(--muted);
+}
+
+.detail-panel__copy + .detail-panel__copy {
+  margin-top: 0.75rem;
+}
+
+.split-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+  gap: 1rem;
+}
+
+.link-list {
+  display: grid;
+  gap: 0.85rem;
+  padding: 0;
+  margin: 0;
+  list-style: none;
+}
+
+.link-list a {
+  display: inline-flex;
+  flex-direction: column;
+  gap: 0.25rem;
+}
+
+.link-list strong {
+  color: var(--text);
+}
+
+.link-list span {
+  color: var(--muted);
+  line-height: 1.5;
+}
+
+.breadcrumb {
+  color: var(--muted);
+  font-size: 0.92rem;
+}
+
+.breadcrumb__list {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.55rem;
+  padding: 0;
+  margin: 0;
+  list-style: none;
+}
+
+.breadcrumb__item {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.55rem;
+}
+
+.breadcrumb__item + .breadcrumb__item::before {
+  content: "/";
+  color: rgba(95, 102, 117, 0.55);
+  margin-right: 0.1rem;
+}
+
+.site-footer {
+  border-top: 1px solid var(--border);
+  background: rgba(255, 255, 255, 0.4);
+}
+
+.site-footer__inner {
+  padding: 2rem 0 2.4rem;
+  color: var(--muted);
+}
+
+.footer-title {
+  font-weight: 700;
+  color: var(--text);
+  margin-bottom: 0.4rem;
+}
+
+.cta-strip {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 1rem;
+}
+
+.cta-strip .content-card {
+  min-height: 100%;
+}
+
+@media (max-width: 720px) {
+  .site-header__inner {
+    align-items: flex-start;
+    flex-direction: column;
+  }
+
+  .page-hero {
+    padding: 1.6rem;
+  }
+
+  .main-content {
+    padding-top: 1.5rem;
+  }
+}
+

--- a/fap-web/app/layout.tsx
+++ b/fap-web/app/layout.tsx
@@ -1,0 +1,42 @@
+import type { Metadata } from "next";
+import type { ReactNode } from "react";
+import Footer from "@/components/layout/Footer";
+import Header from "@/components/navigation/Header";
+import { siteConfig } from "@/lib/site";
+import "./globals.css";
+
+export const metadata: Metadata = {
+  metadataBase: new URL(siteConfig.url),
+  title: {
+    default: "FermatMind Content Platform",
+    template: "%s | FermatMind",
+  },
+  description: siteConfig.description,
+  openGraph: {
+    siteName: siteConfig.name,
+    type: "website",
+    locale: "en_US",
+  },
+  twitter: {
+    card: "summary_large_image",
+  },
+};
+
+type RootLayoutProps = {
+  children: ReactNode;
+};
+
+export default function RootLayout({ children }: RootLayoutProps) {
+  return (
+    <html lang="en">
+      <body>
+        <div className="site-body">
+          <Header />
+          <main className="main-content">{children}</main>
+          <Footer />
+        </div>
+      </body>
+    </html>
+  );
+}
+

--- a/fap-web/app/not-found.tsx
+++ b/fap-web/app/not-found.tsx
@@ -1,0 +1,35 @@
+import Link from "next/link";
+
+export default function NotFound() {
+  return (
+    <div className="shell page-shell">
+      <section className="page-hero">
+        <p className="eyebrow">Not found</p>
+        <h1 className="page-title">This page does not exist.</h1>
+        <p className="lead">
+          The route may be outdated, or the content might not have been published
+          yet.
+        </p>
+      </section>
+
+      <section className="content-card">
+        <h2>Useful links</h2>
+        <p>Return to one of the active content sections below.</p>
+        <div className="content-meta">
+          <Link href="/articles" className="card-link">
+            Articles
+          </Link>
+          {" · "}
+          <Link href="/career" className="card-link">
+            Career
+          </Link>
+          {" · "}
+          <Link href="/personality" className="card-link">
+            Personality
+          </Link>
+        </div>
+      </section>
+    </div>
+  );
+}
+

--- a/fap-web/app/page.tsx
+++ b/fap-web/app/page.tsx
@@ -1,0 +1,58 @@
+import Link from "next/link";
+
+export default function HomePage() {
+  return (
+    <div className="shell page-shell">
+      <section className="page-hero">
+        <p className="eyebrow">Content platform</p>
+        <h1 className="page-title">Structured guides for thoughtful decisions.</h1>
+        <p className="lead">
+          Browse personality profiles, career guides, and editorial content with a
+          consistent navigation system and SEO-ready page structure.
+        </p>
+      </section>
+
+      <section className="cta-strip">
+        <article className="content-card">
+          <h2>Personality</h2>
+          <p>
+            Explore the 16 types and move into a detailed guide for strengths,
+            weaknesses, and career fit.
+          </p>
+          <div className="content-meta">
+            <Link href="/personality" className="card-link">
+              Open personality index
+            </Link>
+          </div>
+        </article>
+
+        <article className="content-card">
+          <h2>Career</h2>
+          <p>
+            Review compact career pages with overview, key skills, salary range,
+            and future outlook.
+          </p>
+          <div className="content-meta">
+            <Link href="/career" className="card-link">
+              Open career guides
+            </Link>
+          </div>
+        </article>
+
+        <article className="content-card">
+          <h2>Articles</h2>
+          <p>
+            Read editorial content that connects personality patterns with work,
+            learning, and team communication.
+          </p>
+          <div className="content-meta">
+            <Link href="/articles" className="card-link">
+              Open articles
+            </Link>
+          </div>
+        </article>
+      </section>
+    </div>
+  );
+}
+

--- a/fap-web/app/personality/[type]/page.tsx
+++ b/fap-web/app/personality/[type]/page.tsx
@@ -1,0 +1,136 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+import { notFound } from "next/navigation";
+import Breadcrumb from "@/components/breadcrumb/Breadcrumb";
+import { getArticle, getCareer, getPersonality } from "@/lib/content";
+
+export const dynamic = "force-dynamic";
+
+type PersonalityPageProps = {
+  params: Promise<{
+    type: string;
+  }>;
+};
+
+export async function generateMetadata({
+  params,
+}: PersonalityPageProps): Promise<Metadata> {
+  const { type } = await params;
+  const personality = getPersonality(type);
+
+  if (!personality) {
+    return {
+      title: "Personality not found",
+    };
+  }
+
+  const description = `Discover strengths, weaknesses, and career paths for the ${personality.type} personality type.`;
+
+  return {
+    title: `${personality.type} Personality Guide`,
+    description,
+    alternates: {
+      canonical: `/personality/${personality.slug}`,
+    },
+    openGraph: {
+      title: `${personality.type} Personality Guide`,
+      description,
+      type: "profile",
+      url: `/personality/${personality.slug}`,
+    },
+  };
+}
+
+export default async function PersonalityDetailPage({
+  params,
+}: PersonalityPageProps) {
+  const { type } = await params;
+  const personality = getPersonality(type);
+
+  if (!personality) {
+    notFound();
+  }
+
+  const relatedCareers = personality.relatedCareerSlugs
+    .map((slug) => getCareer(slug))
+    .filter(Boolean);
+  const relatedArticles = personality.relatedArticleSlugs
+    .map((slug) => getArticle(slug))
+    .filter(Boolean);
+
+  return (
+    <div className="shell page-shell">
+      <Breadcrumb
+        items={[
+          { label: "Home", href: "/" },
+          { label: "Personality", href: "/personality" },
+          { label: personality.type },
+        ]}
+      />
+
+      <section className="page-hero">
+        <p className="eyebrow">Personality detail</p>
+        <h1 className="page-title">{personality.type} Personality Guide</h1>
+        <p className="lead">{personality.summary}</p>
+      </section>
+
+      <section className="split-grid">
+        <article className="detail-panel">
+          <h2>Overview</h2>
+          <p className="detail-panel__copy">{personality.overview}</p>
+        </article>
+
+        <article className="detail-panel">
+          <h2>Strengths</h2>
+          <p className="detail-panel__copy">{personality.strengths}</p>
+        </article>
+
+        <article className="detail-panel">
+          <h2>Weaknesses</h2>
+          <p className="detail-panel__copy">{personality.weaknesses}</p>
+        </article>
+
+        <article className="detail-panel">
+          <h2>Career match</h2>
+          <p className="detail-panel__copy">{personality.careerMatch}</p>
+        </article>
+
+        <article className="detail-panel">
+          <h2>Relationships</h2>
+          <p className="detail-panel__copy">{personality.relationships}</p>
+        </article>
+      </section>
+
+      <section className="split-grid">
+        <aside className="related-panel">
+          <h2>Related careers</h2>
+          <ul className="link-list">
+            {relatedCareers.map((career) => (
+              <li key={career!.id}>
+                <Link href={`/career/${career!.slug}`}>
+                  <strong>{career!.name}</strong>
+                  <span>{career!.summary}</span>
+                </Link>
+              </li>
+            ))}
+          </ul>
+        </aside>
+
+        <aside className="related-panel">
+          <h2>Related articles</h2>
+          <ul className="link-list">
+            {relatedArticles.map((article) => (
+              <li key={article!.id}>
+                <Link href={`/articles/${article!.slug}`}>
+                  <strong>{article!.title}</strong>
+                  <span>{article!.excerpt}</span>
+                </Link>
+              </li>
+            ))}
+          </ul>
+        </aside>
+      </section>
+    </div>
+  );
+}
+

--- a/fap-web/app/personality/page.tsx
+++ b/fap-web/app/personality/page.tsx
@@ -1,0 +1,63 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+import Breadcrumb from "@/components/breadcrumb/Breadcrumb";
+import { getPersonalities } from "@/lib/content";
+
+export const dynamic = "force-dynamic";
+
+export const metadata: Metadata = {
+  title: "Personality",
+  description:
+    "Browse the 16 personality types with a consistent route structure and linked detail guides.",
+  alternates: {
+    canonical: "/personality",
+  },
+  openGraph: {
+    title: "Personality",
+    description:
+      "Browse the 16 personality types with a consistent route structure and linked detail guides.",
+    url: "/personality",
+  },
+};
+
+export default function PersonalityPage() {
+  const personalities = getPersonalities();
+
+  return (
+    <div className="shell page-shell">
+      <Breadcrumb
+        items={[
+          { label: "Home", href: "/" },
+          { label: "Personality" },
+        ]}
+      />
+
+      <section className="page-hero">
+        <p className="eyebrow">Personality library</p>
+        <h1 className="page-title">A navigable index for all 16 personality types.</h1>
+        <p className="lead">
+          Each profile now lives inside the same global shell, so readers can
+          move cleanly between personality, career, and article content.
+        </p>
+      </section>
+
+      <section className="card-grid">
+        {personalities.map((personality) => (
+          <article key={personality.type} className="content-card">
+            <h2>{personality.type}</h2>
+            <p>{personality.summary}</p>
+            <div className="content-meta">
+              <Link
+                href={`/personality/${personality.slug}`}
+                className="card-link"
+              >
+                Open profile
+              </Link>
+            </div>
+          </article>
+        ))}
+      </section>
+    </div>
+  );
+}
+

--- a/fap-web/app/robots.ts
+++ b/fap-web/app/robots.ts
@@ -1,8 +1,9 @@
-import type { MetadataRoute } from 'next';
+import type { MetadataRoute } from "next";
+import { absoluteUrl } from "@/lib/site";
 
 export default function robots(): MetadataRoute.Robots {
   return {
-    rules: [{ userAgent: '*', allow: '/' }],
-    sitemap: 'https://fermatmind.com/sitemap.xml',
+    rules: [{ userAgent: "*", allow: "/" }],
+    sitemap: absoluteUrl("/sitemap.xml"),
   };
 }

--- a/fap-web/app/sitemap.ts
+++ b/fap-web/app/sitemap.ts
@@ -1,5 +1,37 @@
-import type { MetadataRoute } from 'next';
+import type { MetadataRoute } from "next";
+import {
+  getArticles,
+  getCareers,
+  getPersonalityTypes,
+} from "@/lib/content";
+import { absoluteUrl } from "@/lib/site";
 
 export default function sitemap(): MetadataRoute.Sitemap {
-  return [];
+  const lastModified = new Date("2026-03-06T09:00:00+08:00");
+  const staticRoutes = [
+    "/",
+    "/tests",
+    "/articles",
+    "/career",
+    "/personality",
+  ];
+
+  return [
+    ...staticRoutes.map((route) => ({
+      url: absoluteUrl(route),
+      lastModified,
+    })),
+    ...getArticles().map((article) => ({
+      url: absoluteUrl(`/articles/${article.slug}`),
+      lastModified,
+    })),
+    ...getCareers().map((career) => ({
+      url: absoluteUrl(`/career/${career.slug}`),
+      lastModified,
+    })),
+    ...getPersonalityTypes().map((type) => ({
+      url: absoluteUrl(`/personality/${type.toLowerCase()}`),
+      lastModified,
+    })),
+  ];
 }

--- a/fap-web/app/tests/page.tsx
+++ b/fap-web/app/tests/page.tsx
@@ -1,0 +1,35 @@
+import type { Metadata } from "next";
+import Breadcrumb from "@/components/breadcrumb/Breadcrumb";
+
+export const dynamic = "force-dynamic";
+
+export const metadata: Metadata = {
+  title: "Tests",
+  description: "Browse assessment entry points available on FermatMind.",
+  alternates: {
+    canonical: "/tests",
+  },
+};
+
+export default function TestsPage() {
+  return (
+    <div className="shell page-shell">
+      <Breadcrumb
+        items={[
+          { label: "Home", href: "/" },
+          { label: "Tests" },
+        ]}
+      />
+
+      <section className="page-hero">
+        <p className="eyebrow">Assessments</p>
+        <h1 className="page-title">Testing entry points live here.</h1>
+        <p className="lead">
+          This placeholder route keeps the global navigation complete while the
+          product-side assessment flows continue shipping separately.
+        </p>
+      </section>
+    </div>
+  );
+}
+

--- a/fap-web/components/breadcrumb/Breadcrumb.tsx
+++ b/fap-web/components/breadcrumb/Breadcrumb.tsx
@@ -1,0 +1,29 @@
+import Link from "next/link";
+
+export type BreadcrumbItem = {
+  label: string;
+  href?: string;
+};
+
+type BreadcrumbProps = {
+  items: BreadcrumbItem[];
+};
+
+export default function Breadcrumb({ items }: BreadcrumbProps) {
+  return (
+    <nav aria-label="Breadcrumb" className="breadcrumb">
+      <ol className="breadcrumb__list">
+        {items.map((item, index) => (
+          <li key={`${item.label}-${index}`} className="breadcrumb__item">
+            {item.href ? (
+              <Link href={item.href}>{item.label}</Link>
+            ) : (
+              <span>{item.label}</span>
+            )}
+          </li>
+        ))}
+      </ol>
+    </nav>
+  );
+}
+

--- a/fap-web/components/layout/Footer.tsx
+++ b/fap-web/components/layout/Footer.tsx
@@ -1,0 +1,14 @@
+export default function Footer() {
+  return (
+    <footer className="site-footer">
+      <div className="shell site-footer__inner">
+        <p className="footer-title">FermatMind content platform</p>
+        <p>
+          Structured guides for personality types, career planning, and practical
+          articles.
+        </p>
+      </div>
+    </footer>
+  );
+}
+

--- a/fap-web/components/navigation/Header.tsx
+++ b/fap-web/components/navigation/Header.tsx
@@ -1,0 +1,29 @@
+import Link from "next/link";
+
+const navItems = [
+  { href: "/tests", label: "Tests" },
+  { href: "/personality", label: "Personality" },
+  { href: "/career", label: "Career" },
+  { href: "/articles", label: "Articles" },
+];
+
+export default function Header() {
+  return (
+    <header className="site-header">
+      <div className="shell site-header__inner">
+        <Link href="/" className="brand-mark">
+          FermatMind
+        </Link>
+
+        <nav aria-label="Primary" className="main-nav">
+          {navItems.map((item) => (
+            <Link key={item.href} href={item.href} className="main-nav__link">
+              {item.label}
+            </Link>
+          ))}
+        </nav>
+      </div>
+    </header>
+  );
+}
+

--- a/fap-web/lib/content.ts
+++ b/fap-web/lib/content.ts
@@ -1,0 +1,445 @@
+export type Article = {
+  id: string;
+  slug: string;
+  title: string;
+  excerpt: string;
+  publishedAt: string;
+  body: string[];
+  relatedCareerSlugs: string[];
+  relatedPersonalityTypes: string[];
+};
+
+export type Career = {
+  id: string;
+  slug: string;
+  name: string;
+  summary: string;
+  overview: string;
+  skills: string;
+  salaryRange: string;
+  futureOutlook: string;
+};
+
+export type Personality = {
+  type: string;
+  slug: string;
+  summary: string;
+  overview: string;
+  strengths: string;
+  weaknesses: string;
+  careerMatch: string;
+  relationships: string;
+  relatedCareerSlugs: string[];
+  relatedArticleSlugs: string[];
+};
+
+const articles: Article[] = [
+  {
+    id: "article-logic-luck",
+    slug: "logic-and-luck",
+    title: "Logic and Luck in Career Planning",
+    excerpt:
+      "A practical look at how deliberate choices and randomness shape long-term career growth.",
+    publishedAt: "March 6, 2026",
+    body: [
+      "Career progress is rarely a straight line. Good systems increase the odds of useful opportunities, but timing and context still matter.",
+      "The most resilient professionals combine clear decision rules with room to adapt. That balance makes luck easier to capture when it appears.",
+    ],
+    relatedCareerSlugs: ["product-manager", "software-engineer"],
+    relatedPersonalityTypes: ["INTP", "ENTJ"],
+  },
+  {
+    id: "article-deep-work",
+    slug: "building-a-deep-work-rhythm",
+    title: "Building a Deep Work Rhythm",
+    excerpt:
+      "Design a weekly cadence that protects focus, creative energy, and execution quality.",
+    publishedAt: "February 18, 2026",
+    body: [
+      "Sustained focus is not just a habit. It is an operating model that shapes how a team protects time, energy, and attention.",
+      "High-signal calendars separate thinking blocks from collaboration blocks, which lowers switching costs and improves output quality.",
+    ],
+    relatedCareerSlugs: ["ux-researcher", "software-engineer"],
+    relatedPersonalityTypes: ["INFJ", "INTJ"],
+  },
+  {
+    id: "article-team-communication",
+    slug: "clear-communication-for-fast-teams",
+    title: "Clear Communication for Fast Teams",
+    excerpt:
+      "How faster teams reduce friction by making intent, ownership, and tradeoffs explicit.",
+    publishedAt: "January 27, 2026",
+    body: [
+      "Most execution problems are coordination problems in disguise. Teams move faster when decisions, risks, and next steps are visible.",
+      "Communication frameworks work best when they are simple enough to survive real deadlines and real ambiguity.",
+    ],
+    relatedCareerSlugs: ["product-manager", "ux-researcher"],
+    relatedPersonalityTypes: ["ENFJ", "ENTP"],
+  },
+];
+
+const careers: Career[] = [
+  {
+    id: "career-software-engineer",
+    slug: "software-engineer",
+    name: "Software Engineer",
+    summary:
+      "Build dependable products and systems through structured problem-solving and iterative delivery.",
+    overview:
+      "Software engineers turn ideas into working systems. The role rewards people who enjoy analysis, experimentation, and shipping improvements over time.",
+    skills:
+      "Systems thinking, debugging, architecture, communication, and steady execution under changing requirements.",
+    salaryRange: "$95,000 - $185,000 depending on market, level, and product scope.",
+    futureOutlook:
+      "Demand remains strong for engineers who can pair technical depth with product judgment and collaborative delivery.",
+  },
+  {
+    id: "career-product-manager",
+    slug: "product-manager",
+    name: "Product Manager",
+    summary:
+      "Shape priorities, connect teams, and turn ambiguous needs into coordinated product decisions.",
+    overview:
+      "Product managers align customer needs, business goals, and delivery tradeoffs. The role works well for people who think clearly under uncertainty.",
+    skills:
+      "Prioritization, communication, discovery, stakeholder management, and translating strategy into action.",
+    salaryRange: "$110,000 - $210,000 depending on stage, domain, and ownership scope.",
+    futureOutlook:
+      "The strongest opportunities favor product managers who combine analytical thinking with execution discipline.",
+  },
+  {
+    id: "career-ux-researcher",
+    slug: "ux-researcher",
+    name: "UX Researcher",
+    summary:
+      "Uncover patterns in user behavior and turn qualitative evidence into better product decisions.",
+    overview:
+      "UX researchers create clarity about how people think, behave, and decide. The work rewards curiosity, empathy, and methodological rigor.",
+    skills:
+      "Interviewing, synthesis, experiment design, storytelling, and turning observations into practical product guidance.",
+    salaryRange: "$90,000 - $170,000 depending on market, seniority, and research scope.",
+    futureOutlook:
+      "Research remains valuable where teams need sharper product judgment and more evidence behind design choices.",
+  },
+];
+
+const personalityTypes = [
+  "INTP",
+  "INTJ",
+  "ENTP",
+  "ENTJ",
+  "INFP",
+  "INFJ",
+  "ENFP",
+  "ENFJ",
+  "ISTP",
+  "ISTJ",
+  "ESTP",
+  "ESTJ",
+  "ISFP",
+  "ISFJ",
+  "ESFP",
+  "ESFJ",
+] as const;
+
+type PersonalityType = (typeof personalityTypes)[number];
+
+type PersonalitySeed = Omit<Personality, "slug" | "type">;
+
+const personalitySeeds: Record<PersonalityType, PersonalitySeed> = {
+  INTP: {
+    summary:
+      "Analytical, curious, and independent thinkers who enjoy systems, models, and clean logic.",
+    overview:
+      "INTP personalities often seek elegant explanations for complex problems. They prefer autonomy, depth, and enough space to test ideas thoroughly.",
+    strengths:
+      "Abstract reasoning, pattern recognition, calm analysis, and the ability to improve systems without needing constant external direction.",
+    weaknesses:
+      "They may delay decisions, over-analyze tradeoffs, or disconnect from emotional context when a problem feels primarily structural.",
+    careerMatch:
+      "They often thrive in software engineering, research, analytics, strategy, and technical writing where deep thinking is rewarded.",
+    relationships:
+      "INTPs usually value low-drama, honest relationships with enough room for independence and intellectually engaging conversations.",
+    relatedCareerSlugs: ["software-engineer", "ux-researcher"],
+    relatedArticleSlugs: ["logic-and-luck", "building-a-deep-work-rhythm"],
+  },
+  INTJ: {
+    summary:
+      "Strategic, self-directed builders who like long-range plans and high-leverage decisions.",
+    overview:
+      "INTJ personalities tend to notice systems, inefficiencies, and future implications quickly. They often prefer deliberate progress over reactive motion.",
+    strengths:
+      "Strategic planning, independent execution, long-term focus, and comfort making decisions from imperfect information.",
+    weaknesses:
+      "They can become impatient with vague processes, repetitive social rituals, or teams that avoid direct feedback.",
+    careerMatch:
+      "They often fit product strategy, engineering leadership, architecture, operations, and business analysis roles.",
+    relationships:
+      "INTJs usually value trust, competence, and clarity. They connect best with people who respect boundaries and depth.",
+    relatedCareerSlugs: ["product-manager", "software-engineer"],
+    relatedArticleSlugs: ["logic-and-luck", "building-a-deep-work-rhythm"],
+  },
+  ENTP: {
+    summary:
+      "Inventive challengers who enjoy possibility, experimentation, and rethinking stale assumptions.",
+    overview:
+      "ENTP personalities often generate options quickly and enjoy environments where fresh thinking can reshape a system or product.",
+    strengths:
+      "Idea generation, reframing problems, persuasive communication, and spotting opportunities others miss.",
+    weaknesses:
+      "They can lose interest once novelty fades, or push debate further than the relationship can comfortably hold.",
+    careerMatch:
+      "They often do well in entrepreneurship, product discovery, growth, strategy, and communication-heavy technical roles.",
+    relationships:
+      "ENTPs tend to enjoy energetic, flexible relationships that allow for humor, debate, and constant evolution.",
+    relatedCareerSlugs: ["product-manager", "software-engineer"],
+    relatedArticleSlugs: ["clear-communication-for-fast-teams", "logic-and-luck"],
+  },
+  ENTJ: {
+    summary:
+      "Decisive, ambitious organizers who like momentum, accountability, and clear strategic direction.",
+    overview:
+      "ENTJ personalities usually move toward structure and execution quickly. They enjoy aligning people around a plan and moving work forward.",
+    strengths:
+      "Leadership, prioritization, direct communication, and the ability to translate big goals into concrete action.",
+    weaknesses:
+      "They can move too fast for consensus, underestimate emotional processing time, or default to control when trust feels low.",
+    careerMatch:
+      "They often excel in management, product leadership, consulting, operations, and entrepreneurship.",
+    relationships:
+      "ENTJs often value honesty, ambition, and partnership that supports mutual growth without unnecessary ambiguity.",
+    relatedCareerSlugs: ["product-manager", "software-engineer"],
+    relatedArticleSlugs: ["clear-communication-for-fast-teams", "logic-and-luck"],
+  },
+  INFP: {
+    summary:
+      "Idealistic and reflective people who look for meaning, alignment, and human depth.",
+    overview:
+      "INFP personalities often evaluate choices through values and authenticity. They do their best work when purpose and craft reinforce each other.",
+    strengths:
+      "Empathy, imagination, deep reflection, and commitment to work that feels genuinely meaningful.",
+    weaknesses:
+      "They can avoid conflict for too long, become discouraged by misalignment, or struggle with harshly rigid systems.",
+    careerMatch:
+      "They often fit writing, counseling, education, design, and research roles that combine creativity with purpose.",
+    relationships:
+      "INFPs typically want sincere, emotionally safe relationships where individuality and care can both stay visible.",
+    relatedCareerSlugs: ["ux-researcher", "product-manager"],
+    relatedArticleSlugs: ["building-a-deep-work-rhythm", "clear-communication-for-fast-teams"],
+  },
+  INFJ: {
+    summary:
+      "Insightful pattern readers who connect vision, empathy, and long-range meaning.",
+    overview:
+      "INFJ personalities often see subtext quickly and think deeply about what will help people or systems evolve over time.",
+    strengths:
+      "Insight, synthesis, empathy, and the ability to translate complex emotional or strategic signals into direction.",
+    weaknesses:
+      "They may absorb too much context, overextend for others, or need more recovery time than fast teams expect.",
+    careerMatch:
+      "They often thrive in research, education, coaching, product strategy, and mission-driven leadership work.",
+    relationships:
+      "INFJs usually seek emotionally honest, thoughtful relationships with a strong sense of trust and mutual growth.",
+    relatedCareerSlugs: ["ux-researcher", "product-manager"],
+    relatedArticleSlugs: ["building-a-deep-work-rhythm", "clear-communication-for-fast-teams"],
+  },
+  ENFP: {
+    summary:
+      "Energetic connectors who mix imagination, empathy, and forward motion.",
+    overview:
+      "ENFP personalities often bring possibility, enthusiasm, and social intuition into spaces that need momentum and renewed perspective.",
+    strengths:
+      "Creativity, emotional range, storytelling, and helping groups stay engaged around a shared direction.",
+    weaknesses:
+      "They may overcommit, chase too many ideas at once, or resist repetitive structure for too long.",
+    careerMatch:
+      "They often fit community, education, facilitation, marketing, coaching, and product discovery roles.",
+    relationships:
+      "ENFPs usually prefer lively, supportive relationships with space for spontaneity, honesty, and evolving goals.",
+    relatedCareerSlugs: ["product-manager", "ux-researcher"],
+    relatedArticleSlugs: ["clear-communication-for-fast-teams", "building-a-deep-work-rhythm"],
+  },
+  ENFJ: {
+    summary:
+      "People-centered organizers who combine warmth, communication, and strong directional energy.",
+    overview:
+      "ENFJ personalities often notice how a group is feeling and where it is stuck. They naturally move toward alignment and encouragement.",
+    strengths:
+      "Communication, leadership, empathy, and helping teams coordinate around a clear shared purpose.",
+    weaknesses:
+      "They can over-function for a group, absorb too much emotional responsibility, or neglect their own recovery needs.",
+    careerMatch:
+      "They often excel in leadership, education, people development, community strategy, and partnership roles.",
+    relationships:
+      "ENFJs generally value mutual care, loyalty, and direct communication that strengthens trust over time.",
+    relatedCareerSlugs: ["product-manager", "ux-researcher"],
+    relatedArticleSlugs: ["clear-communication-for-fast-teams", "logic-and-luck"],
+  },
+  ISTP: {
+    summary:
+      "Practical troubleshooters who stay calm under pressure and learn by engaging directly with the problem.",
+    overview:
+      "ISTP personalities often trust observation and experimentation. They like environments where action, feedback, and technical skill matter.",
+    strengths:
+      "Adaptability, troubleshooting, mechanical logic, and composure when complexity gets real and immediate.",
+    weaknesses:
+      "They may resist heavy process, delay emotional conversations, or seem detached when they are actually concentrating.",
+    careerMatch:
+      "They often fit engineering, operations, emergency response, technical support, and hands-on product roles.",
+    relationships:
+      "ISTPs usually need respect, independence, and practical honesty more than overt emotional display.",
+    relatedCareerSlugs: ["software-engineer", "ux-researcher"],
+    relatedArticleSlugs: ["logic-and-luck", "building-a-deep-work-rhythm"],
+  },
+  ISTJ: {
+    summary:
+      "Reliable system keepers who value precision, accountability, and follow-through.",
+    overview:
+      "ISTJ personalities often stabilize teams by making expectations concrete and execution dependable. They prefer clarity over spectacle.",
+    strengths:
+      "Discipline, consistency, detail orientation, and turning commitments into repeatable working systems.",
+    weaknesses:
+      "They can be slow to trust abrupt change, frustrated by loose processes, or overly committed to existing methods.",
+    careerMatch:
+      "They often do well in operations, finance, engineering, governance, and structured project delivery roles.",
+    relationships:
+      "ISTJs generally show care through dependability, practical support, and keeping commitments over time.",
+    relatedCareerSlugs: ["software-engineer", "product-manager"],
+    relatedArticleSlugs: ["building-a-deep-work-rhythm", "clear-communication-for-fast-teams"],
+  },
+  ESTP: {
+    summary:
+      "Action-oriented realists who move quickly, read situations well, and enjoy practical challenge.",
+    overview:
+      "ESTP personalities often prefer learning through action. They bring adaptability and decisiveness to fast-changing environments.",
+    strengths:
+      "Quick judgment, negotiation, situational awareness, and confidence in real-time problem-solving.",
+    weaknesses:
+      "They may underweight long-term planning, grow bored with routine, or push risk further than a team prefers.",
+    careerMatch:
+      "They often thrive in sales, operations, entrepreneurship, field leadership, and live problem-solving roles.",
+    relationships:
+      "ESTPs usually appreciate directness, shared activity, and relationships that feel energetic rather than constrained.",
+    relatedCareerSlugs: ["product-manager", "software-engineer"],
+    relatedArticleSlugs: ["logic-and-luck", "clear-communication-for-fast-teams"],
+  },
+  ESTJ: {
+    summary:
+      "Structured executors who bring order, standards, and visible accountability to complex work.",
+    overview:
+      "ESTJ personalities often focus on what needs to happen now and how to organize people around it effectively.",
+    strengths:
+      "Coordination, reliability, decision-making, and comfort taking responsibility when a team needs clearer structure.",
+    weaknesses:
+      "They can become rigid, impatient with ambiguity, or too quick to value efficiency over nuance.",
+    careerMatch:
+      "They often fit operations, management, logistics, administration, and implementation-heavy leadership roles.",
+    relationships:
+      "ESTJs usually value consistency, responsibility, and straightforward communication that avoids guesswork.",
+    relatedCareerSlugs: ["product-manager", "software-engineer"],
+    relatedArticleSlugs: ["clear-communication-for-fast-teams", "building-a-deep-work-rhythm"],
+  },
+  ISFP: {
+    summary:
+      "Observant creatives who value authenticity, craft, and calm responsiveness to what is real.",
+    overview:
+      "ISFP personalities often care deeply about quality and alignment but prefer showing that through work more than overt self-promotion.",
+    strengths:
+      "Aesthetic sensitivity, adaptability, empathy, and careful attention to lived experience and personal values.",
+    weaknesses:
+      "They may avoid confrontation, keep too much internal, or struggle in highly rigid and impersonal systems.",
+    careerMatch:
+      "They often thrive in design, care work, creative production, and user-focused problem-solving roles.",
+    relationships:
+      "ISFPs usually value gentle honesty, respect for individuality, and relationships that feel sincere instead of performative.",
+    relatedCareerSlugs: ["ux-researcher", "software-engineer"],
+    relatedArticleSlugs: ["building-a-deep-work-rhythm", "clear-communication-for-fast-teams"],
+  },
+  ISFJ: {
+    summary:
+      "Thoughtful supporters who combine quiet commitment, memory, and care for concrete needs.",
+    overview:
+      "ISFJ personalities often help teams and relationships function smoothly by noticing details that keep people supported and prepared.",
+    strengths:
+      "Dependability, empathy, organization, and sustained care expressed through practical follow-through.",
+    weaknesses:
+      "They can overextend, avoid direct conflict, or remain in unbalanced situations for too long out of loyalty.",
+    careerMatch:
+      "They often fit education, healthcare, operations, support, and coordination roles that reward responsibility and care.",
+    relationships:
+      "ISFJs typically want stable, considerate relationships where trust is built through dependable action.",
+    relatedCareerSlugs: ["ux-researcher", "product-manager"],
+    relatedArticleSlugs: ["clear-communication-for-fast-teams", "logic-and-luck"],
+  },
+  ESFP: {
+    summary:
+      "Warm, expressive doers who bring energy, social ease, and a bias toward immediate engagement.",
+    overview:
+      "ESFP personalities often help teams and communities feel alive. They respond well to work that is tangible, social, and human-centered.",
+    strengths:
+      "Presence, adaptability, encouragement, and an instinct for what makes an experience feel engaging and real.",
+    weaknesses:
+      "They may resist long planning cycles, lose patience with abstraction, or avoid difficult stillness and reflection.",
+    careerMatch:
+      "They often excel in community, customer experience, facilitation, hospitality, and creative collaboration roles.",
+    relationships:
+      "ESFPs usually value warmth, responsiveness, and relationships that leave room for joy and spontaneity.",
+    relatedCareerSlugs: ["ux-researcher", "product-manager"],
+    relatedArticleSlugs: ["clear-communication-for-fast-teams", "building-a-deep-work-rhythm"],
+  },
+  ESFJ: {
+    summary:
+      "Coordinated relationship builders who keep groups connected, supported, and moving together.",
+    overview:
+      "ESFJ personalities often bring structure to care. They are usually attentive to how a group is functioning and what people need next.",
+    strengths:
+      "Coordination, empathy, responsiveness, and the ability to keep social systems stable and welcoming.",
+    weaknesses:
+      "They may become overly approval-sensitive, take too much responsibility for harmony, or resist disruptive change.",
+    careerMatch:
+      "They often fit people operations, education, customer success, community leadership, and team support roles.",
+    relationships:
+      "ESFJs generally value reliability, warmth, and clearly expressed appreciation inside close relationships.",
+    relatedCareerSlugs: ["product-manager", "ux-researcher"],
+    relatedArticleSlugs: ["clear-communication-for-fast-teams", "logic-and-luck"],
+  },
+};
+
+export function getArticles() {
+  return articles;
+}
+
+export function getArticle(slug: string) {
+  return articles.find((article) => article.slug === slug) || null;
+}
+
+export function getCareers() {
+  return careers;
+}
+
+export function getCareer(slug: string) {
+  return careers.find((career) => career.slug === slug) || null;
+}
+
+export function getPersonalityTypes() {
+  return [...personalityTypes];
+}
+
+export function getPersonality(type: string) {
+  const normalized = type.toUpperCase() as PersonalityType;
+
+  if (!personalityTypes.includes(normalized)) {
+    return null;
+  }
+
+  return {
+    type: normalized,
+    slug: normalized.toLowerCase(),
+    ...personalitySeeds[normalized],
+  };
+}
+
+export function getPersonalities() {
+  return personalityTypes.map((type) => getPersonality(type)!);
+}
+

--- a/fap-web/lib/site.ts
+++ b/fap-web/lib/site.ts
@@ -1,0 +1,11 @@
+export const siteConfig = {
+  name: "FermatMind",
+  description:
+    "Explore structured articles, career guides, and personality profiles on FermatMind.",
+  url: process.env.NEXT_PUBLIC_SITE_URL || "http://localhost:3000",
+};
+
+export function absoluteUrl(path = "/") {
+  return new URL(path, siteConfig.url).toString();
+}
+

--- a/fap-web/next-env.d.ts
+++ b/fap-web/next-env.d.ts
@@ -1,0 +1,6 @@
+/// <reference types="next" />
+/// <reference types="next/image-types/global" />
+import "./.next/dev/types/routes.d.ts";
+
+// NOTE: This file should not be edited
+// see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/fap-web/package.json
+++ b/fap-web/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "fap-web",
+  "private": true,
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start"
+  },
+  "dependencies": {
+    "next": "^16.1.6",
+    "react": "^19.2.4",
+    "react-dom": "^19.2.4"
+  },
+  "devDependencies": {
+    "@types/node": "^25.3.4",
+    "@types/react": "^19.2.14",
+    "@types/react-dom": "^19.2.3",
+    "typescript": "^5.9.3"
+  }
+}
+

--- a/fap-web/tsconfig.json
+++ b/fap-web/tsconfig.json
@@ -1,0 +1,43 @@
+{
+  "compilerOptions": {
+    "target": "ES2017",
+    "lib": [
+      "dom",
+      "dom.iterable",
+      "esnext"
+    ],
+    "allowJs": false,
+    "skipLibCheck": true,
+    "strict": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "react-jsx",
+    "incremental": true,
+    "forceConsistentCasingInFileNames": true,
+    "plugins": [
+      {
+        "name": "next"
+      }
+    ],
+    "paths": {
+      "@/*": [
+        "./*"
+      ]
+    }
+  },
+  "include": [
+    "next-env.d.ts",
+    "**/*.ts",
+    "**/*.tsx",
+    ".next/types/**/*.ts",
+    ".next/dev/types/**/*.ts"
+  ],
+  "exclude": [
+    "node_modules"
+  ]
+}
+


### PR DESCRIPTION
## Summary

Add a global layout system for the content platform in `fap-web`.

Includes:
- shared header navigation
- breadcrumb component
- shared footer
- consistent metadata structure across content routes
- content route scaffolding for articles, career, and personality pages

Routes covered:
- `/articles`
- `/articles/[slug]`
- `/career`
- `/career/[slug]`
- `/personality`
- `/personality/[type]`

## Tests

- `cd fap-web && npm run build`
- `cd fap-web && npm run dev`
- Open `/articles`
- Open `/personality/intp`
- Verify header navigation, breadcrumb, and footer render
