### PR TITLE
feat(frontend): add related content engine

### DIFF
--- a/fap-web/app/articles/[slug]/page.tsx
+++ b/fap-web/app/articles/[slug]/page.tsx
@@ -1,8 +1,13 @@
 import type { Metadata } from "next";
-import Link from "next/link";
 import { notFound } from "next/navigation";
 import Breadcrumb from "@/components/breadcrumb/Breadcrumb";
-import { getArticle, getCareer, getPersonality } from "@/lib/content";
+import RelatedContent from "@/components/content/RelatedContent";
+import {
+  getArticle,
+  getRelatedArticlesForArticle,
+  getRelatedCareersForArticle,
+  getRelatedPersonalitiesForArticle,
+} from "@/lib/content";
 
 export const dynamic = "force-dynamic";
 
@@ -47,13 +52,9 @@ export default async function ArticleDetailPage({ params }: ArticlePageProps) {
     notFound();
   }
 
-  const relatedCareers = article.relatedCareerSlugs
-    .map((careerSlug) => getCareer(careerSlug))
-    .filter(Boolean);
-
-  const relatedPersonalities = article.relatedPersonalityTypes
-    .map((type) => getPersonality(type))
-    .filter(Boolean);
+  const relatedArticles = getRelatedArticlesForArticle(article);
+  const relatedCareers = getRelatedCareersForArticle(article);
+  const relatedPersonalities = getRelatedPersonalitiesForArticle(article);
 
   return (
     <div className="shell page-shell">
@@ -83,36 +84,14 @@ export default async function ArticleDetailPage({ params }: ArticlePageProps) {
         </article>
 
         <div className="split-grid">
-          <aside className="related-panel">
-            <h2>Related careers</h2>
-            <ul className="link-list">
-              {relatedCareers.map((career) => (
-                <li key={career!.id}>
-                  <Link href={`/career/${career!.slug}`}>
-                    <strong>{career!.name}</strong>
-                    <span>{career!.summary}</span>
-                  </Link>
-                </li>
-              ))}
-            </ul>
-          </aside>
-
-          <aside className="related-panel">
-            <h2>Related personalities</h2>
-            <ul className="link-list">
-              {relatedPersonalities.map((personality) => (
-                <li key={personality!.type}>
-                  <Link href={`/personality/${personality!.slug}`}>
-                    <strong>{personality!.type}</strong>
-                    <span>{personality!.summary}</span>
-                  </Link>
-                </li>
-              ))}
-            </ul>
-          </aside>
+          <RelatedContent title="Related Articles" items={relatedArticles} />
+          <RelatedContent title="Related Careers" items={relatedCareers} />
+          <RelatedContent
+            title="Related Personality Types"
+            items={relatedPersonalities}
+          />
         </div>
       </section>
     </div>
   );
 }
-

--- a/fap-web/app/career/[slug]/page.tsx
+++ b/fap-web/app/career/[slug]/page.tsx
@@ -1,8 +1,12 @@
 import type { Metadata } from "next";
-import Link from "next/link";
 import { notFound } from "next/navigation";
 import Breadcrumb from "@/components/breadcrumb/Breadcrumb";
-import { getCareer, getPersonality, getArticles } from "@/lib/content";
+import RelatedContent from "@/components/content/RelatedContent";
+import {
+  getCareer,
+  getRelatedArticlesForCareer,
+  getRelatedPersonalitiesForCareer,
+} from "@/lib/content";
 
 export const dynamic = "force-dynamic";
 
@@ -46,12 +50,8 @@ export default async function CareerDetailPage({ params }: CareerPageProps) {
     notFound();
   }
 
-  const relatedArticles = getArticles().filter((article) =>
-    article.relatedCareerSlugs.includes(career.slug),
-  );
-  const suggestedPersonalities = ["INTJ", "ENTJ", "INFJ"]
-    .map((type) => getPersonality(type))
-    .filter(Boolean);
+  const relatedArticles = getRelatedArticlesForCareer(career);
+  const relatedPersonalities = getRelatedPersonalitiesForCareer(career);
 
   return (
     <div className="shell page-shell">
@@ -92,35 +92,12 @@ export default async function CareerDetailPage({ params }: CareerPageProps) {
       </section>
 
       <section className="split-grid">
-        <aside className="related-panel">
-          <h2>Related articles</h2>
-          <ul className="link-list">
-            {relatedArticles.map((article) => (
-              <li key={article.id}>
-                <Link href={`/articles/${article.slug}`}>
-                  <strong>{article.title}</strong>
-                  <span>{article.excerpt}</span>
-                </Link>
-              </li>
-            ))}
-          </ul>
-        </aside>
-
-        <aside className="related-panel">
-          <h2>Relevant personalities</h2>
-          <ul className="link-list">
-            {suggestedPersonalities.map((personality) => (
-              <li key={personality!.type}>
-                <Link href={`/personality/${personality!.slug}`}>
-                  <strong>{personality!.type}</strong>
-                  <span>{personality!.summary}</span>
-                </Link>
-              </li>
-            ))}
-          </ul>
-        </aside>
+        <RelatedContent title="Related Articles" items={relatedArticles} />
+        <RelatedContent
+          title="Related Personality Types"
+          items={relatedPersonalities}
+        />
       </section>
     </div>
   );
 }
-

--- a/fap-web/app/globals.css
+++ b/fap-web/app/globals.css
@@ -222,6 +222,16 @@ img {
   gap: 0.25rem;
 }
 
+.related-content .link-list {
+  gap: 0.6rem;
+}
+
+.related-content__link {
+  color: var(--accent);
+  font-weight: 700;
+  line-height: 1.5;
+}
+
 .link-list strong {
   color: var(--text);
 }
@@ -297,4 +307,3 @@ img {
     padding-top: 1.5rem;
   }
 }
-

--- a/fap-web/app/personality/[type]/page.tsx
+++ b/fap-web/app/personality/[type]/page.tsx
@@ -1,8 +1,12 @@
 import type { Metadata } from "next";
-import Link from "next/link";
 import { notFound } from "next/navigation";
 import Breadcrumb from "@/components/breadcrumb/Breadcrumb";
-import { getArticle, getCareer, getPersonality } from "@/lib/content";
+import RelatedContent from "@/components/content/RelatedContent";
+import {
+  getPersonality,
+  getRelatedArticlesForPersonality,
+  getRelatedCareersForPersonality,
+} from "@/lib/content";
 
 export const dynamic = "force-dynamic";
 
@@ -51,12 +55,8 @@ export default async function PersonalityDetailPage({
     notFound();
   }
 
-  const relatedCareers = personality.relatedCareerSlugs
-    .map((slug) => getCareer(slug))
-    .filter(Boolean);
-  const relatedArticles = personality.relatedArticleSlugs
-    .map((slug) => getArticle(slug))
-    .filter(Boolean);
+  const relatedCareers = getRelatedCareersForPersonality(personality);
+  const relatedArticles = getRelatedArticlesForPersonality(personality);
 
   return (
     <div className="shell page-shell">
@@ -102,35 +102,9 @@ export default async function PersonalityDetailPage({
       </section>
 
       <section className="split-grid">
-        <aside className="related-panel">
-          <h2>Related careers</h2>
-          <ul className="link-list">
-            {relatedCareers.map((career) => (
-              <li key={career!.id}>
-                <Link href={`/career/${career!.slug}`}>
-                  <strong>{career!.name}</strong>
-                  <span>{career!.summary}</span>
-                </Link>
-              </li>
-            ))}
-          </ul>
-        </aside>
-
-        <aside className="related-panel">
-          <h2>Related articles</h2>
-          <ul className="link-list">
-            {relatedArticles.map((article) => (
-              <li key={article!.id}>
-                <Link href={`/articles/${article!.slug}`}>
-                  <strong>{article!.title}</strong>
-                  <span>{article!.excerpt}</span>
-                </Link>
-              </li>
-            ))}
-          </ul>
-        </aside>
+        <RelatedContent title="Related Careers" items={relatedCareers} />
+        <RelatedContent title="Related Articles" items={relatedArticles} />
       </section>
     </div>
   );
 }
-

--- a/fap-web/components/content/RelatedContent.tsx
+++ b/fap-web/components/content/RelatedContent.tsx
@@ -1,0 +1,33 @@
+import Link from "next/link";
+import type { RelatedContentItem } from "@/lib/content";
+
+type RelatedContentProps = {
+  title: string;
+  items?: RelatedContentItem[];
+};
+
+export default function RelatedContent({
+  title,
+  items,
+}: RelatedContentProps) {
+  if (!items?.length) {
+    return null;
+  }
+
+  return (
+    <section className="related-panel related-content">
+      <h2>{title}</h2>
+
+      <ul className="link-list">
+        {items.map((item) => (
+          <li key={item.slug}>
+            <Link href={item.url} className="related-content__link">
+              {item.title}
+            </Link>
+          </li>
+        ))}
+      </ul>
+    </section>
+  );
+}
+

--- a/fap-web/lib/content.ts
+++ b/fap-web/lib/content.ts
@@ -4,6 +4,10 @@ export type Article = {
   title: string;
   excerpt: string;
   publishedAt: string;
+  tags: {
+    slug: string;
+    name: string;
+  }[];
   body: string[];
   relatedCareerSlugs: string[];
   relatedPersonalityTypes: string[];
@@ -33,6 +37,12 @@ export type Personality = {
   relatedArticleSlugs: string[];
 };
 
+export type RelatedContentItem = {
+  title: string;
+  slug: string;
+  url: string;
+};
+
 const articles: Article[] = [
   {
     id: "article-logic-luck",
@@ -41,6 +51,10 @@ const articles: Article[] = [
     excerpt:
       "A practical look at how deliberate choices and randomness shape long-term career growth.",
     publishedAt: "March 6, 2026",
+    tags: [
+      { slug: "career-strategy", name: "Career Strategy" },
+      { slug: "decision-making", name: "Decision Making" },
+    ],
     body: [
       "Career progress is rarely a straight line. Good systems increase the odds of useful opportunities, but timing and context still matter.",
       "The most resilient professionals combine clear decision rules with room to adapt. That balance makes luck easier to capture when it appears.",
@@ -55,6 +69,10 @@ const articles: Article[] = [
     excerpt:
       "Design a weekly cadence that protects focus, creative energy, and execution quality.",
     publishedAt: "February 18, 2026",
+    tags: [
+      { slug: "career-strategy", name: "Career Strategy" },
+      { slug: "deep-work", name: "Deep Work" },
+    ],
     body: [
       "Sustained focus is not just a habit. It is an operating model that shapes how a team protects time, energy, and attention.",
       "High-signal calendars separate thinking blocks from collaboration blocks, which lowers switching costs and improves output quality.",
@@ -69,12 +87,34 @@ const articles: Article[] = [
     excerpt:
       "How faster teams reduce friction by making intent, ownership, and tradeoffs explicit.",
     publishedAt: "January 27, 2026",
+    tags: [
+      { slug: "career-strategy", name: "Career Strategy" },
+      { slug: "team-communication", name: "Team Communication" },
+    ],
     body: [
       "Most execution problems are coordination problems in disguise. Teams move faster when decisions, risks, and next steps are visible.",
       "Communication frameworks work best when they are simple enough to survive real deadlines and real ambiguity.",
     ],
     relatedCareerSlugs: ["product-manager", "ux-researcher"],
     relatedPersonalityTypes: ["ENFJ", "ENTP"],
+  },
+  {
+    id: "article-example",
+    slug: "example",
+    title: "Example Article",
+    excerpt:
+      "A reference article used to validate internal recommendations across the content platform.",
+    publishedAt: "March 6, 2026",
+    tags: [
+      { slug: "career-strategy", name: "Career Strategy" },
+      { slug: "internal-linking", name: "Internal Linking" },
+    ],
+    body: [
+      "This page exists so related content can be validated quickly during development and review.",
+      "Because it shares tags with other articles, the recommendation engine can surface useful internal links immediately.",
+    ],
+    relatedCareerSlugs: ["software-engineer", "product-manager"],
+    relatedPersonalityTypes: ["INTP", "ENTJ"],
   },
 ];
 
@@ -413,6 +453,14 @@ export function getArticle(slug: string) {
   return articles.find((article) => article.slug === slug) || null;
 }
 
+export function getArticlesByTag(tagSlug: string, excludeSlug?: string) {
+  return articles.filter(
+    (article) =>
+      article.slug !== excludeSlug &&
+      article.tags.some((tag) => tag.slug === tagSlug),
+  );
+}
+
 export function getCareers() {
   return careers;
 }
@@ -443,3 +491,80 @@ export function getPersonalities() {
   return personalityTypes.map((type) => getPersonality(type)!);
 }
 
+function toRelatedArticleItem(article: Article): RelatedContentItem {
+  return {
+    title: article.title,
+    slug: article.slug,
+    url: `/articles/${article.slug}`,
+  };
+}
+
+function toRelatedCareerItem(career: Career): RelatedContentItem {
+  return {
+    title: career.name,
+    slug: career.slug,
+    url: `/career/${career.slug}`,
+  };
+}
+
+function toRelatedPersonalityItem(personality: Personality): RelatedContentItem {
+  return {
+    title: `${personality.type} Personality Guide`,
+    slug: personality.slug,
+    url: `/personality/${personality.slug}`,
+  };
+}
+
+export function getRelatedArticlesForArticle(article: Article) {
+  const primaryTag = article.tags[0]?.slug;
+
+  if (!primaryTag) {
+    return [];
+  }
+
+  return getArticlesByTag(primaryTag, article.slug)
+    .map(toRelatedArticleItem)
+    .slice(0, 3);
+}
+
+export function getRelatedCareersForArticle(article: Article) {
+  return article.relatedCareerSlugs
+    .map((careerSlug) => getCareer(careerSlug))
+    .filter(Boolean)
+    .map((career) => toRelatedCareerItem(career!));
+}
+
+export function getRelatedPersonalitiesForArticle(article: Article) {
+  return article.relatedPersonalityTypes
+    .map((type) => getPersonality(type))
+    .filter(Boolean)
+    .map((personality) => toRelatedPersonalityItem(personality!));
+}
+
+export function getRelatedArticlesForCareer(career: Career) {
+  return getArticles()
+    .filter((article) => article.relatedCareerSlugs.includes(career.slug))
+    .map(toRelatedArticleItem)
+    .slice(0, 4);
+}
+
+export function getRelatedPersonalitiesForCareer(career: Career) {
+  return getPersonalities()
+    .filter((personality) => personality.relatedCareerSlugs.includes(career.slug))
+    .map(toRelatedPersonalityItem)
+    .slice(0, 4);
+}
+
+export function getRelatedCareersForPersonality(personality: Personality) {
+  return personality.relatedCareerSlugs
+    .map((slug) => getCareer(slug))
+    .filter(Boolean)
+    .map((career) => toRelatedCareerItem(career!));
+}
+
+export function getRelatedArticlesForPersonality(personality: Personality) {
+  return personality.relatedArticleSlugs
+    .map((slug) => getArticle(slug))
+    .filter(Boolean)
+    .map((article) => toRelatedArticleItem(article!));
+}


### PR DESCRIPTION
## Summary

Add a related content engine for the content platform in `fap-web`.

Includes:
- shared `RelatedContent` component
- article-to-article recommendations driven by the primary tag
- reusable related item format for articles, careers, and personality pages
- detail page integration for `/articles/[slug]`, `/career/[slug]`, and `/personality/[type]`
- `/articles/example` seed content for review and verification

## Tests

- `cd fap-web && npm run build`
- `cd fap-web && npm run dev`
- Open `/articles/example`
- Verify related articles render
- Verify internal links resolve to article, career, and personality pages
