### PR TITLE
feat(cms): add topic engine for SEO clusters

### DIFF
--- a/backend/app/Filament/Ops/Resources/TopicResource.php
+++ b/backend/app/Filament/Ops/Resources/TopicResource.php
@@ -1,0 +1,171 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Filament\Ops\Resources;
+
+use App\Filament\Ops\Resources\TopicResource\Pages;
+use App\Models\Topic;
+use App\Support\OrgContext;
+use App\Support\Rbac\PermissionNames;
+use Filament\Forms;
+use Filament\Forms\Form;
+use Filament\Resources\Resource;
+use Filament\Tables;
+use Filament\Tables\Table;
+use Illuminate\Database\Eloquent\Builder;
+
+class TopicResource extends Resource
+{
+    protected static ?string $model = Topic::class;
+
+    protected static ?string $navigationIcon = 'heroicon-o-rectangle-stack';
+
+    protected static ?string $navigationGroup = 'Content';
+
+    protected static ?string $navigationLabel = 'Topics';
+
+    public static function canViewAny(): bool
+    {
+        return self::canRead();
+    }
+
+    public static function canCreate(): bool
+    {
+        return self::canPublish();
+    }
+
+    public static function canEdit($record): bool
+    {
+        return self::canPublish();
+    }
+
+    public static function canDelete($record): bool
+    {
+        return false;
+    }
+
+    public static function getNavigationGroup(): ?string
+    {
+        return __('ops.group.content');
+    }
+
+    public static function getNavigationLabel(): string
+    {
+        return 'Topics';
+    }
+
+    public static function form(Form $form): Form
+    {
+        return $form->schema([
+            Forms\Components\Section::make('Topic')
+                ->schema([
+                    Forms\Components\Hidden::make('org_id')
+                        ->default(fn (): int => max(0, (int) app(OrgContext::class)->orgId())),
+                    Forms\Components\TextInput::make('name')
+                        ->required()
+                        ->maxLength(255),
+                    Forms\Components\TextInput::make('slug')
+                        ->required()
+                        ->maxLength(127)
+                        ->unique(ignoreRecord: true),
+                    Forms\Components\Textarea::make('description')
+                        ->rows(4)
+                        ->columnSpanFull(),
+                    Forms\Components\TextInput::make('seo_title')
+                        ->maxLength(255),
+                    Forms\Components\Textarea::make('seo_description')
+                        ->rows(3)
+                        ->maxLength(255),
+                ])
+                ->columns(2),
+        ]);
+    }
+
+    public static function table(Table $table): Table
+    {
+        return $table
+            ->columns([
+                Tables\Columns\TextColumn::make('id')
+                    ->sortable(),
+                Tables\Columns\TextColumn::make('name')
+                    ->searchable()
+                    ->sortable(),
+                Tables\Columns\TextColumn::make('slug')
+                    ->searchable()
+                    ->copyable(),
+                Tables\Columns\TextColumn::make('articles_count')
+                    ->counts('articles')
+                    ->label('Articles')
+                    ->sortable(),
+                Tables\Columns\TextColumn::make('careers_count')
+                    ->counts('careers')
+                    ->label('Careers')
+                    ->sortable(),
+                Tables\Columns\TextColumn::make('personalities_count')
+                    ->counts('personalities')
+                    ->label('Personalities')
+                    ->sortable(),
+                Tables\Columns\TextColumn::make('updated_at')
+                    ->dateTime()
+                    ->sortable(),
+            ])
+            ->filters([])
+            ->defaultSort('updated_at', 'desc')
+            ->actions([
+                Tables\Actions\EditAction::make(),
+            ])
+            ->bulkActions([]);
+    }
+
+    public static function getPages(): array
+    {
+        return [
+            'index' => Pages\ListTopics::route('/'),
+            'create' => Pages\CreateTopic::route('/create'),
+            'edit' => Pages\EditTopic::route('/{record}/edit'),
+        ];
+    }
+
+    public static function getEloquentQuery(): Builder
+    {
+        return parent::getEloquentQuery()
+            ->whereIn('org_id', self::tenantOrgIds());
+    }
+
+    /**
+     * @return array<int,int>
+     */
+    private static function tenantOrgIds(): array
+    {
+        $orgId = max(0, (int) app(OrgContext::class)->orgId());
+
+        return $orgId > 0 ? [0, $orgId] : [0];
+    }
+
+    private static function canRead(): bool
+    {
+        $guard = (string) config('admin.guard', 'admin');
+        $user = auth($guard)->user();
+
+        return is_object($user)
+            && method_exists($user, 'hasPermission')
+            && (
+                $user->hasPermission(PermissionNames::ADMIN_CONTENT_READ)
+                || $user->hasPermission(PermissionNames::ADMIN_OWNER)
+            );
+    }
+
+    private static function canPublish(): bool
+    {
+        $guard = (string) config('admin.guard', 'admin');
+        $user = auth($guard)->user();
+
+        return is_object($user)
+            && method_exists($user, 'hasPermission')
+            && (
+                $user->hasPermission(PermissionNames::ADMIN_CONTENT_PUBLISH)
+                || $user->hasPermission(PermissionNames::ADMIN_OWNER)
+            );
+    }
+}

--- a/backend/app/Filament/Ops/Resources/TopicResource/Pages/CreateTopic.php
+++ b/backend/app/Filament/Ops/Resources/TopicResource/Pages/CreateTopic.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Filament\Ops\Resources\TopicResource\Pages;
+
+use App\Filament\Ops\Resources\TopicResource;
+use Filament\Resources\Pages\CreateRecord;
+
+class CreateTopic extends CreateRecord
+{
+    protected static string $resource = TopicResource::class;
+}

--- a/backend/app/Filament/Ops/Resources/TopicResource/Pages/EditTopic.php
+++ b/backend/app/Filament/Ops/Resources/TopicResource/Pages/EditTopic.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Filament\Ops\Resources\TopicResource\Pages;
+
+use App\Filament\Ops\Resources\TopicResource;
+use Filament\Resources\Pages\EditRecord;
+
+class EditTopic extends EditRecord
+{
+    protected static string $resource = TopicResource::class;
+
+    protected function getHeaderActions(): array
+    {
+        return [];
+    }
+}

--- a/backend/app/Filament/Ops/Resources/TopicResource/Pages/ListTopics.php
+++ b/backend/app/Filament/Ops/Resources/TopicResource/Pages/ListTopics.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Filament\Ops\Resources\TopicResource\Pages;
+
+use App\Filament\Ops\Resources\TopicResource;
+use Filament\Actions;
+use Filament\Resources\Pages\ListRecords;
+
+class ListTopics extends ListRecords
+{
+    protected static string $resource = TopicResource::class;
+
+    protected function getHeaderActions(): array
+    {
+        return [
+            Actions\CreateAction::make(),
+        ];
+    }
+}

--- a/backend/app/Http/Controllers/API/V0_5/Cms/TopicController.php
+++ b/backend/app/Http/Controllers/API/V0_5/Cms/TopicController.php
@@ -1,0 +1,186 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Controllers\API\V0_5\Cms;
+
+use App\Http\Controllers\Controller;
+use App\Models\Article;
+use App\Models\Topic;
+use App\Support\Cms\TopicReferenceCatalog;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+
+class TopicController extends Controller
+{
+    /**
+     * GET /api/v0.5/topics
+     */
+    public function index(Request $request): JsonResponse
+    {
+        $orgId = $this->resolveOrgId($request);
+
+        $items = Topic::query()
+            ->withoutGlobalScopes()
+            ->where('org_id', $orgId)
+            ->withCount(['articleMaps as articles_count', 'careers', 'personalities'])
+            ->orderBy('name')
+            ->get()
+            ->map(fn (Topic $topic): array => $this->topicListPayload($topic))
+            ->values()
+            ->all();
+
+        return response()->json([
+            'ok' => true,
+            'items' => $items,
+        ]);
+    }
+
+    /**
+     * GET /api/v0.5/topics/{slug}
+     */
+    public function show(Request $request, string $slug): JsonResponse
+    {
+        $orgId = $this->resolveOrgId($request);
+        $normalizedSlug = trim($slug);
+
+        if ($normalizedSlug === '') {
+            return response()->json([
+                'ok' => false,
+                'error_code' => 'NOT_FOUND',
+                'message' => 'topic not found.',
+            ], 404);
+        }
+
+        $topic = Topic::query()
+            ->withoutGlobalScopes()
+            ->where('org_id', $orgId)
+            ->where('slug', $normalizedSlug)
+            ->with([
+                'articles' => function ($query) use ($orgId): void {
+                    $query
+                        ->withoutGlobalScopes()
+                        ->where('articles.org_id', $orgId)
+                        ->published()
+                        ->where('is_indexable', true)
+                        ->orderByDesc('published_at')
+                        ->orderByDesc('articles.id');
+                },
+                'careers',
+                'personalities',
+            ])
+            ->first();
+
+        if (! $topic instanceof Topic) {
+            return response()->json([
+                'ok' => false,
+                'error_code' => 'NOT_FOUND',
+                'message' => 'topic not found.',
+            ], 404);
+        }
+
+        $articles = $topic->articles
+            ->map(fn (Article $article): array => [
+                'title' => (string) $article->title,
+                'slug' => (string) $article->slug,
+                'url' => sprintf('/articles/%s', $article->slug),
+            ])
+            ->values()
+            ->all();
+
+        if ($articles === []) {
+            $articles = TopicReferenceCatalog::fallbackArticlesForTopic((string) $topic->slug);
+        }
+
+        $careers = $topic->careers
+            ->map(fn ($item): ?array => TopicReferenceCatalog::careerById((int) $item->career_id))
+            ->filter()
+            ->values()
+            ->all();
+
+        if ($careers === []) {
+            $careers = TopicReferenceCatalog::fallbackCareersForTopic((string) $topic->slug);
+        }
+
+        $personalities = $topic->personalities
+            ->map(fn ($item): ?array => TopicReferenceCatalog::personalityByType((string) $item->personality_type))
+            ->filter()
+            ->values()
+            ->all();
+
+        if ($personalities === []) {
+            $personalities = TopicReferenceCatalog::fallbackPersonalitiesForTopic((string) $topic->slug);
+        }
+
+        return response()->json([
+            'ok' => true,
+            'topic' => $this->topicPayload($topic),
+            'articles' => $articles,
+            'careers' => $careers,
+            'personalities' => $personalities,
+        ]);
+    }
+
+    private function resolveOrgId(Request $request): int
+    {
+        $raw = trim((string) $request->query('org_id', '0'));
+
+        return preg_match('/^\d+$/', $raw) === 1 ? (int) $raw : 0;
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    private function topicListPayload(Topic $topic): array
+    {
+        $articlesCount = (int) ($topic->articles_count ?? 0);
+        $careersCount = (int) ($topic->careers_count ?? 0);
+        $personalitiesCount = (int) ($topic->personalities_count ?? 0);
+
+        if ($articlesCount === 0) {
+            $articlesCount = count(TopicReferenceCatalog::fallbackArticlesForTopic((string) $topic->slug));
+        }
+
+        if ($careersCount === 0) {
+            $careersCount = count(TopicReferenceCatalog::fallbackCareersForTopic((string) $topic->slug));
+        }
+
+        if ($personalitiesCount === 0) {
+            $personalitiesCount = count(TopicReferenceCatalog::fallbackPersonalitiesForTopic((string) $topic->slug));
+        }
+
+        return [
+            'id' => (int) $topic->id,
+            'org_id' => (int) $topic->org_id,
+            'name' => (string) $topic->name,
+            'slug' => (string) $topic->slug,
+            'description' => $topic->description,
+            'seo_title' => $topic->seo_title,
+            'seo_description' => $topic->seo_description,
+            'articles_count' => $articlesCount,
+            'careers_count' => $careersCount,
+            'personalities_count' => $personalitiesCount,
+            'url' => sprintf('/topics/%s', $topic->slug),
+            'created_at' => $topic->created_at?->toISOString(),
+            'updated_at' => $topic->updated_at?->toISOString(),
+        ];
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    private function topicPayload(Topic $topic): array
+    {
+        return [
+            'id' => (int) $topic->id,
+            'org_id' => (int) $topic->org_id,
+            'name' => (string) $topic->name,
+            'slug' => (string) $topic->slug,
+            'description' => $topic->description,
+            'seo_title' => $topic->seo_title,
+            'seo_description' => $topic->seo_description,
+            'created_at' => $topic->created_at?->toISOString(),
+            'updated_at' => $topic->updated_at?->toISOString(),
+        ];
+    }
+}

--- a/backend/app/Models/Topic.php
+++ b/backend/app/Models/Topic.php
@@ -1,0 +1,58 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Models;
+
+use App\Models\Concerns\HasOrgScope;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsToMany;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+
+class Topic extends Model
+{
+    use HasFactory, HasOrgScope;
+
+    protected $table = 'topics';
+
+    protected $fillable = [
+        'org_id',
+        'name',
+        'slug',
+        'description',
+        'seo_title',
+        'seo_description',
+    ];
+
+    protected $casts = [
+        'org_id' => 'integer',
+        'created_at' => 'datetime',
+        'updated_at' => 'datetime',
+    ];
+
+    public function articleMaps(): HasMany
+    {
+        return $this->hasMany(TopicArticle::class, 'topic_id', 'id');
+    }
+
+    public function articles(): BelongsToMany
+    {
+        return $this->belongsToMany(
+            Article::class,
+            'topic_article_map',
+            'topic_id',
+            'article_id'
+        )->withTimestamps();
+    }
+
+    public function personalities(): HasMany
+    {
+        return $this->hasMany(TopicPersonality::class, 'topic_id', 'id');
+    }
+
+    public function careers(): HasMany
+    {
+        return $this->hasMany(TopicCareer::class, 'topic_id', 'id');
+    }
+}

--- a/backend/app/Models/TopicArticle.php
+++ b/backend/app/Models/TopicArticle.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+class TopicArticle extends Model
+{
+    use HasFactory;
+
+    protected $table = 'topic_article_map';
+
+    protected $fillable = [
+        'topic_id',
+        'article_id',
+    ];
+
+    protected $casts = [
+        'topic_id' => 'integer',
+        'article_id' => 'integer',
+        'created_at' => 'datetime',
+        'updated_at' => 'datetime',
+    ];
+
+    public function topic(): BelongsTo
+    {
+        return $this->belongsTo(Topic::class, 'topic_id', 'id');
+    }
+
+    public function article(): BelongsTo
+    {
+        return $this->belongsTo(Article::class, 'article_id', 'id');
+    }
+}

--- a/backend/app/Models/TopicCareer.php
+++ b/backend/app/Models/TopicCareer.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+class TopicCareer extends Model
+{
+    use HasFactory;
+
+    protected $table = 'topic_career_map';
+
+    protected $fillable = [
+        'topic_id',
+        'career_id',
+    ];
+
+    protected $casts = [
+        'topic_id' => 'integer',
+        'career_id' => 'integer',
+        'created_at' => 'datetime',
+        'updated_at' => 'datetime',
+    ];
+
+    public function topic(): BelongsTo
+    {
+        return $this->belongsTo(Topic::class, 'topic_id', 'id');
+    }
+}

--- a/backend/app/Models/TopicPersonality.php
+++ b/backend/app/Models/TopicPersonality.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+class TopicPersonality extends Model
+{
+    use HasFactory;
+
+    protected $table = 'topic_personality_map';
+
+    protected $fillable = [
+        'topic_id',
+        'personality_type',
+    ];
+
+    protected $casts = [
+        'topic_id' => 'integer',
+        'created_at' => 'datetime',
+        'updated_at' => 'datetime',
+    ];
+
+    public function topic(): BelongsTo
+    {
+        return $this->belongsTo(Topic::class, 'topic_id', 'id');
+    }
+}

--- a/backend/app/Services/SEO/SitemapGenerator.php
+++ b/backend/app/Services/SEO/SitemapGenerator.php
@@ -9,6 +9,8 @@ class SitemapGenerator
 {
     private string $urlPrefix;
 
+    private string $topicsUrlPrefix;
+
     public function __construct()
     {
         $configuredPrefix = trim((string) config('services.seo.tests_url_prefix', ''));
@@ -17,6 +19,13 @@ class SitemapGenerator
         }
 
         $this->urlPrefix = rtrim($configuredPrefix, '/').'/';
+
+        $configuredTopicsPrefix = trim((string) config('services.seo.topics_url_prefix', ''));
+        if ($configuredTopicsPrefix === '') {
+            $configuredTopicsPrefix = rtrim((string) config('app.url', 'http://localhost'), '/').'/topics';
+        }
+
+        $this->topicsUrlPrefix = rtrim($configuredTopicsPrefix, '/');
     }
 
     public function generate(): array
@@ -25,7 +34,8 @@ class SitemapGenerator
 
         $urls = array_merge(
             $this->getScaleUrls($locale),
-            $this->getArticleUrls($locale)
+            $this->getArticleUrls($locale),
+            $this->getTopicUrls($locale)
         );
 
         $urls = collect($urls)
@@ -147,6 +157,38 @@ class SitemapGenerator
                 'loc' => $url,
                 'lastmod' => $lastmod->toAtomString(),
                 'slug' => (string) $row->slug,
+                'updated_at' => $lastmod->toDateTimeString(),
+            ];
+        }
+
+        return $urls;
+    }
+
+    private function getTopicUrls(string $locale): array
+    {
+        $rows = \App\Models\Topic::query()
+            ->withoutGlobalScopes()
+            ->where('org_id', 0)
+            ->select(['slug', 'updated_at', 'created_at'])
+            ->orderByDesc('updated_at')
+            ->get();
+
+        $urls = [];
+
+        foreach ($rows as $row) {
+            $slug = trim((string) $row->slug);
+            if ($slug === '') {
+                continue;
+            }
+
+            $lastmod = $row->updated_at
+                ?? $row->created_at
+                ?? now();
+
+            $urls[] = [
+                'loc' => $this->topicsUrlPrefix.'/'.rawurlencode($slug),
+                'lastmod' => $lastmod->toAtomString(),
+                'slug' => $slug,
                 'updated_at' => $lastmod->toDateTimeString(),
             ];
         }

--- a/backend/app/Support/Cms/TopicReferenceCatalog.php
+++ b/backend/app/Support/Cms/TopicReferenceCatalog.php
@@ -1,0 +1,154 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Support\Cms;
+
+final class TopicReferenceCatalog
+{
+    /**
+     * @return array<int,array{id:int,title:string,slug:string,url:string}>
+     */
+    public static function careers(): array
+    {
+        return [
+            1 => [
+                'id' => 1,
+                'title' => 'Software Engineer',
+                'slug' => 'software-engineer',
+                'url' => '/career/software-engineer',
+            ],
+            2 => [
+                'id' => 2,
+                'title' => 'Product Manager',
+                'slug' => 'product-manager',
+                'url' => '/career/product-manager',
+            ],
+            3 => [
+                'id' => 3,
+                'title' => 'UX Researcher',
+                'slug' => 'ux-researcher',
+                'url' => '/career/ux-researcher',
+            ],
+        ];
+    }
+
+    /**
+     * @return array<string,array{title:string,slug:string,url:string}>
+     */
+    public static function personalities(): array
+    {
+        return [
+            'INTP' => self::personalityItem('INTP'),
+            'INTJ' => self::personalityItem('INTJ'),
+            'ENTP' => self::personalityItem('ENTP'),
+            'ENTJ' => self::personalityItem('ENTJ'),
+            'INFP' => self::personalityItem('INFP'),
+            'INFJ' => self::personalityItem('INFJ'),
+            'ENFP' => self::personalityItem('ENFP'),
+            'ENFJ' => self::personalityItem('ENFJ'),
+            'ISTP' => self::personalityItem('ISTP'),
+            'ISTJ' => self::personalityItem('ISTJ'),
+            'ESTP' => self::personalityItem('ESTP'),
+            'ESTJ' => self::personalityItem('ESTJ'),
+            'ISFP' => self::personalityItem('ISFP'),
+            'ISFJ' => self::personalityItem('ISFJ'),
+            'ESFP' => self::personalityItem('ESFP'),
+            'ESFJ' => self::personalityItem('ESFJ'),
+        ];
+    }
+
+    /**
+     * @return array<int,array{title:string,slug:string,url:string}>
+     */
+    public static function fallbackArticlesForTopic(string $slug): array
+    {
+        $normalizedSlug = strtolower(trim($slug));
+
+        return match ($normalizedSlug) {
+            'mbti' => [
+                self::articleItem('Example Article', 'example'),
+                self::articleItem('Logic and Luck in Career Planning', 'logic-and-luck'),
+                self::articleItem('Building a Deep Work Rhythm', 'building-a-deep-work-rhythm'),
+            ],
+            default => [],
+        };
+    }
+
+    /**
+     * @return array<int,array{id:int,title:string,slug:string,url:string}>
+     */
+    public static function fallbackCareersForTopic(string $slug): array
+    {
+        $normalizedSlug = strtolower(trim($slug));
+
+        return match ($normalizedSlug) {
+            'mbti' => array_values(array_filter([
+                self::careerById(1),
+                self::careerById(2),
+                self::careerById(3),
+            ])),
+            default => [],
+        };
+    }
+
+    /**
+     * @return array<int,array{title:string,slug:string,url:string}>
+     */
+    public static function fallbackPersonalitiesForTopic(string $slug): array
+    {
+        $normalizedSlug = strtolower(trim($slug));
+
+        return match ($normalizedSlug) {
+            'mbti' => array_values(array_filter([
+                self::personalityByType('INTP'),
+                self::personalityByType('ENTJ'),
+                self::personalityByType('INFJ'),
+                self::personalityByType('ENFP'),
+            ])),
+            default => [],
+        };
+    }
+
+    /**
+     * @return array{id:int,title:string,slug:string,url:string}|null
+     */
+    public static function careerById(int $careerId): ?array
+    {
+        return self::careers()[$careerId] ?? null;
+    }
+
+    /**
+     * @return array{title:string,slug:string,url:string}|null
+     */
+    public static function personalityByType(string $type): ?array
+    {
+        $normalizedType = strtoupper(trim($type));
+
+        return self::personalities()[$normalizedType] ?? null;
+    }
+
+    /**
+     * @return array{title:string,slug:string,url:string}
+     */
+    private static function personalityItem(string $type): array
+    {
+        return [
+            'title' => sprintf('%s Personality Guide', $type),
+            'slug' => strtolower($type),
+            'url' => sprintf('/personality/%s', strtolower($type)),
+        ];
+    }
+
+    /**
+     * @return array{title:string,slug:string,url:string}
+     */
+    private static function articleItem(string $title, string $slug): array
+    {
+        return [
+            'title' => $title,
+            'slug' => $slug,
+            'url' => sprintf('/articles/%s', $slug),
+        ];
+    }
+}

--- a/backend/config/services.php
+++ b/backend/config/services.php
@@ -113,6 +113,10 @@ return [
             'SEO_ARTICLES_PREFIX',
             rtrim((string) env('APP_URL', 'http://localhost'), '/').'/articles'
         ),
+        'topics_url_prefix' => env(
+            'SEO_TOPICS_PREFIX',
+            rtrim((string) env('APP_URL', 'http://localhost'), '/').'/topics'
+        ),
     ],
 
     'integrations' => [

--- a/backend/database/migrations/2026_03_06_012222_create_topics_table.php
+++ b/backend/database/migrations/2026_03_06_012222_create_topics_table.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('topics', function (Blueprint $table) {
+            $table->bigIncrements('id');
+            $table->unsignedBigInteger('org_id')->default(0);
+            $table->string('name', 255);
+            $table->string('slug', 127);
+            $table->text('description')->nullable();
+            $table->string('seo_title', 255)->nullable();
+            $table->string('seo_description', 255)->nullable();
+            $table->timestamps();
+
+            $table->unique(['slug'], 'topics_slug_unique');
+            $table->index(['org_id', 'updated_at'], 'topics_org_updated_idx');
+        });
+
+        DB::table('topics')->insert([
+            'org_id' => 0,
+            'name' => 'MBTI Topic Cluster',
+            'slug' => 'mbti',
+            'description' => 'A topic hub that connects MBTI personality guides, related careers, and editorial articles.',
+            'seo_title' => 'MBTI Topic Cluster | FermatMind',
+            'seo_description' => 'Explore MBTI personality content, matching careers, and related articles in one topic cluster.',
+            'created_at' => now(),
+            'updated_at' => now(),
+        ]);
+    }
+
+    public function down(): void
+    {
+        // forward-only migration: rollback disabled to prevent data loss in production.
+        // Irreversible operation: schema/data rollback handled via forward fix migrations.
+    }
+};

--- a/backend/database/migrations/2026_03_06_012223_create_topic_article_map_table.php
+++ b/backend/database/migrations/2026_03_06_012223_create_topic_article_map_table.php
@@ -1,0 +1,54 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('topic_article_map', function (Blueprint $table) {
+            $table->bigIncrements('id');
+            $table->unsignedBigInteger('topic_id');
+            $table->unsignedBigInteger('article_id');
+            $table->timestamps();
+
+            $table->unique(['topic_id', 'article_id'], 'topic_article_map_topic_article_unique');
+            $table->index(['topic_id', 'article_id'], 'topic_article_map_topic_article_idx');
+        });
+
+        $topicId = DB::table('topics')->where('slug', 'mbti')->value('id');
+        if (! is_int($topicId)) {
+            return;
+        }
+
+        $articleIds = DB::table('articles')
+            ->where('org_id', 0)
+            ->where('status', 'published')
+            ->where('is_public', 1)
+            ->orderByDesc('published_at')
+            ->orderByDesc('id')
+            ->limit(3)
+            ->pluck('id')
+            ->all();
+
+        foreach ($articleIds as $articleId) {
+            DB::table('topic_article_map')->insert([
+                'topic_id' => $topicId,
+                'article_id' => (int) $articleId,
+                'created_at' => now(),
+                'updated_at' => now(),
+            ]);
+        }
+    }
+
+    public function down(): void
+    {
+        // forward-only migration: rollback disabled to prevent data loss in production.
+        // Irreversible operation: schema/data rollback handled via forward fix migrations.
+    }
+};

--- a/backend/database/migrations/2026_03_06_012223_create_topic_career_map_table.php
+++ b/backend/database/migrations/2026_03_06_012223_create_topic_career_map_table.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('topic_career_map', function (Blueprint $table) {
+            $table->bigIncrements('id');
+            $table->unsignedBigInteger('topic_id');
+            $table->unsignedBigInteger('career_id');
+            $table->timestamps();
+
+            $table->unique(['topic_id', 'career_id'], 'topic_career_map_topic_career_unique');
+            $table->index(['topic_id', 'career_id'], 'topic_career_map_topic_career_idx');
+        });
+
+        $topicId = DB::table('topics')->where('slug', 'mbti')->value('id');
+        if (! is_int($topicId)) {
+            return;
+        }
+
+        foreach ([1, 2, 3] as $careerId) {
+            DB::table('topic_career_map')->insert([
+                'topic_id' => $topicId,
+                'career_id' => $careerId,
+                'created_at' => now(),
+                'updated_at' => now(),
+            ]);
+        }
+    }
+
+    public function down(): void
+    {
+        // forward-only migration: rollback disabled to prevent data loss in production.
+        // Irreversible operation: schema/data rollback handled via forward fix migrations.
+    }
+};

--- a/backend/database/migrations/2026_03_06_012223_create_topic_personality_map_table.php
+++ b/backend/database/migrations/2026_03_06_012223_create_topic_personality_map_table.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('topic_personality_map', function (Blueprint $table) {
+            $table->bigIncrements('id');
+            $table->unsignedBigInteger('topic_id');
+            $table->string('personality_type', 16);
+            $table->timestamps();
+
+            $table->unique(['topic_id', 'personality_type'], 'topic_personality_map_topic_type_unique');
+            $table->index(['topic_id', 'personality_type'], 'topic_personality_map_topic_type_idx');
+        });
+
+        $topicId = DB::table('topics')->where('slug', 'mbti')->value('id');
+        if (! is_int($topicId)) {
+            return;
+        }
+
+        foreach (['INTP', 'ENTJ', 'INFJ', 'ENFP'] as $type) {
+            DB::table('topic_personality_map')->insert([
+                'topic_id' => $topicId,
+                'personality_type' => $type,
+                'created_at' => now(),
+                'updated_at' => now(),
+            ]);
+        }
+    }
+
+    public function down(): void
+    {
+        // forward-only migration: rollback disabled to prevent data loss in production.
+        // Irreversible operation: schema/data rollback handled via forward fix migrations.
+    }
+};

--- a/backend/routes/api.php
+++ b/backend/routes/api.php
@@ -24,6 +24,7 @@ use App\Http\Controllers\API\V0_4\ExperimentGovernanceController;
 use App\Http\Controllers\API\V0_4\PartnerController;
 use App\Http\Controllers\API\V0_4\RotationAuditController;
 use App\Http\Controllers\API\V0_5\Cms\ArticleController;
+use App\Http\Controllers\API\V0_5\Cms\TopicController;
 use App\Http\Controllers\HealthzController;
 use App\Http\Middleware\HealthzAccessControl;
 use App\Http\Middleware\LimitWebhookPayloadSize;
@@ -296,6 +297,8 @@ Route::prefix('v0.5')->group(function () {
     Route::get('/articles', [ArticleController::class, 'index']);
     Route::get('/articles/{slug}', [ArticleController::class, 'show']);
     Route::get('/articles/{slug}/seo', [ArticleController::class, 'seo']);
+    Route::get('/topics', [TopicController::class, 'index']);
+    Route::get('/topics/{slug}', [TopicController::class, 'show']);
 
     Route::post('/cms/articles', [ArticleController::class, 'store']);
     Route::put('/cms/articles/{id}', [ArticleController::class, 'update']);

--- a/backend/tests/Feature/Api/V0_5/TopicControllerTest.php
+++ b/backend/tests/Feature/Api/V0_5/TopicControllerTest.php
@@ -1,0 +1,94 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\API\V0_5;
+
+use App\Models\Article;
+use App\Models\Topic;
+use App\Models\TopicArticle;
+use App\Models\TopicCareer;
+use App\Models\TopicPersonality;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class TopicControllerTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_index_returns_global_topics_by_default(): void
+    {
+        Topic::query()->withoutGlobalScopes()->create([
+            'org_id' => 15,
+            'name' => 'Tenant Topic',
+            'slug' => 'tenant-topic',
+            'description' => 'Tenant only topic',
+        ]);
+
+        $response = $this->getJson('/api/v0.5/topics');
+
+        $response
+            ->assertOk()
+            ->assertJsonPath('ok', true);
+
+        $slugs = collect($response->json('items'))->pluck('slug')->all();
+
+        $this->assertContains('mbti', $slugs);
+        $this->assertNotContains('tenant-topic', $slugs);
+    }
+
+    public function test_show_returns_topic_with_articles_careers_and_personalities(): void
+    {
+        $topic = Topic::query()->withoutGlobalScopes()->create([
+            'org_id' => 0,
+            'name' => 'Career Strategy',
+            'slug' => 'career-strategy',
+            'description' => 'Topic for articles and guidance',
+            'seo_title' => 'Career Strategy Topic | FermatMind',
+            'seo_description' => 'Grouped career strategy content.',
+        ]);
+
+        $article = Article::query()->withoutGlobalScopes()->create([
+            'org_id' => 0,
+            'category_id' => null,
+            'author_admin_user_id' => null,
+            'slug' => 'systems-over-speed',
+            'locale' => 'en',
+            'title' => 'Systems Over Speed',
+            'excerpt' => 'A systems-first approach to work.',
+            'content_md' => 'Body copy',
+            'content_html' => null,
+            'cover_image_url' => null,
+            'status' => 'published',
+            'is_public' => true,
+            'is_indexable' => true,
+            'published_at' => now(),
+            'scheduled_at' => null,
+        ]);
+
+        TopicArticle::query()->create([
+            'topic_id' => (int) $topic->id,
+            'article_id' => (int) $article->id,
+        ]);
+
+        TopicCareer::query()->create([
+            'topic_id' => (int) $topic->id,
+            'career_id' => 1,
+        ]);
+
+        TopicPersonality::query()->create([
+            'topic_id' => (int) $topic->id,
+            'personality_type' => 'INTP',
+        ]);
+
+        $response = $this->getJson('/api/v0.5/topics/career-strategy');
+
+        $response
+            ->assertOk()
+            ->assertJsonPath('ok', true)
+            ->assertJsonPath('topic.slug', 'career-strategy')
+            ->assertJsonPath('articles.0.slug', 'systems-over-speed')
+            ->assertJsonPath('careers.0.slug', 'software-engineer')
+            ->assertJsonPath('personalities.0.slug', 'intp');
+    }
+}

--- a/backend/tests/Feature/SEO/SitemapGeneratorTest.php
+++ b/backend/tests/Feature/SEO/SitemapGeneratorTest.php
@@ -18,6 +18,7 @@ class SitemapGeneratorTest extends TestCase
         $now = now();
         // Isolate this test from migration-seeded default scales.
         DB::table('scales_registry')->delete();
+        DB::table('topics')->delete();
 
         DB::table('scales_registry')->insert([
             [
@@ -94,5 +95,54 @@ class SitemapGeneratorTest extends TestCase
         $this->assertStringNotContainsString($prefix . 'private-global-alt', $xml);
         $this->assertStringNotContainsString($prefix . 'tenant-public', $xml);
         $this->assertStringNotContainsString($prefix . 'tenant-public-alt', $xml);
+    }
+
+    public function test_generate_includes_global_topics_and_excludes_tenant_topics(): void
+    {
+        config([
+            'services.seo.tests_url_prefix' => 'https://fermatmind.com/tests/',
+            'services.seo.topics_url_prefix' => 'https://fermatmind.com/topics',
+        ]);
+
+        $now = now();
+
+        DB::table('scales_registry')->delete();
+        DB::table('articles')->delete();
+        DB::table('topics')->delete();
+
+        DB::table('topics')->insert([
+            [
+                'org_id' => 0,
+                'name' => 'MBTI',
+                'slug' => 'mbti',
+                'description' => 'Global topic',
+                'seo_title' => null,
+                'seo_description' => null,
+                'created_at' => $now,
+                'updated_at' => $now,
+            ],
+            [
+                'org_id' => 42,
+                'name' => 'Tenant Topic',
+                'slug' => 'tenant-topic',
+                'description' => 'Tenant topic',
+                'seo_title' => null,
+                'seo_description' => null,
+                'created_at' => $now,
+                'updated_at' => $now,
+            ],
+        ]);
+
+        $payload = app(SitemapGenerator::class)->generate();
+
+        $slugList = (array) ($payload['slug_list'] ?? []);
+
+        $this->assertContains('mbti', $slugList);
+        $this->assertNotContains('tenant-topic', $slugList);
+
+        $xml = (string) ($payload['xml'] ?? '');
+
+        $this->assertStringContainsString('https://fermatmind.com/topics/mbti', $xml);
+        $this->assertStringNotContainsString('https://fermatmind.com/topics/tenant-topic', $xml);
     }
 }

--- a/fap-web/app/topics/[slug]/page.tsx
+++ b/fap-web/app/topics/[slug]/page.tsx
@@ -1,0 +1,89 @@
+import type { Metadata } from "next";
+import { notFound } from "next/navigation";
+import Breadcrumb from "@/components/breadcrumb/Breadcrumb";
+import RelatedContent from "@/components/content/RelatedContent";
+import { getTopic } from "@/lib/topics";
+
+export const dynamic = "force-dynamic";
+
+type TopicPageProps = {
+  params: Promise<{
+    slug: string;
+  }>;
+};
+
+export async function generateMetadata({
+  params,
+}: TopicPageProps): Promise<Metadata> {
+  const { slug } = await params;
+  const data = await getTopic(slug);
+
+  if (!data) {
+    return {
+      title: "Topic not found",
+    };
+  }
+
+  const description =
+    data.topic.seo_description ??
+    data.topic.description ??
+    `Explore articles, careers, and personality guides related to ${data.topic.name}.`;
+
+  const title = data.topic.seo_title ?? `${data.topic.name} | FermatMind`;
+
+  return {
+    title: {
+      absolute: title,
+    },
+    description,
+    alternates: {
+      canonical: `/topics/${data.topic.slug}`,
+    },
+    openGraph: {
+      title,
+      description,
+      url: `/topics/${data.topic.slug}`,
+    },
+  };
+}
+
+export default async function TopicDetailPage({ params }: TopicPageProps) {
+  const { slug } = await params;
+  const data = await getTopic(slug);
+
+  if (!data) {
+    notFound();
+  }
+
+  return (
+    <div className="shell page-shell">
+      <Breadcrumb
+        items={[
+          { label: "Home", href: "/" },
+          { label: "Topics", href: "/topics" },
+          { label: data.topic.name },
+        ]}
+      />
+
+      <section className="page-hero">
+        <p className="eyebrow">Topic cluster</p>
+        <h1 className="page-title">{data.topic.name}</h1>
+        <p className="lead">
+          {data.topic.description ??
+            "This topic groups related articles, careers, and personality guides."}
+        </p>
+        <div className="content-meta">
+          {data.personalities.length} personalities · {data.careers.length} careers
+          {" · "}
+          {data.articles.length} articles
+        </div>
+      </section>
+
+      <section className="split-grid">
+        <RelatedContent title="Related Personality" items={data.personalities} />
+        <RelatedContent title="Related Careers" items={data.careers} />
+        <RelatedContent title="Related Articles" items={data.articles} />
+      </section>
+    </div>
+  );
+}

--- a/fap-web/app/topics/page.tsx
+++ b/fap-web/app/topics/page.tsx
@@ -1,0 +1,63 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+import Breadcrumb from "@/components/breadcrumb/Breadcrumb";
+import { getTopics } from "@/lib/topics";
+
+export const dynamic = "force-dynamic";
+
+export const metadata: Metadata = {
+  title: "Topics",
+  description:
+    "Browse topic clusters that connect articles, careers, and personality guides across FermatMind.",
+  alternates: {
+    canonical: "/topics",
+  },
+  openGraph: {
+    title: "Topics",
+    description:
+      "Browse topic clusters that connect articles, careers, and personality guides across FermatMind.",
+    url: "/topics",
+  },
+};
+
+export default async function TopicsPage() {
+  const topics = await getTopics();
+
+  return (
+    <div className="shell page-shell">
+      <Breadcrumb
+        items={[
+          { label: "Home", href: "/" },
+          { label: "Topics" },
+        ]}
+      />
+
+      <section className="page-hero">
+        <p className="eyebrow">Topic engine</p>
+        <h1 className="page-title">SEO topic clusters for the content platform.</h1>
+        <p className="lead">
+          Each topic connects editorial articles, career guides, and personality
+          content into one navigable hub for stronger internal linking.
+        </p>
+      </section>
+
+      <section className="content-stack">
+        {topics.map((topic) => (
+          <article key={topic.id} className="content-card">
+            <h2>{topic.name}</h2>
+            <p>{topic.description ?? "No topic description yet."}</p>
+            <div className="content-meta">
+              {topic.articles_count} articles · {topic.careers_count} careers ·{" "}
+              {topic.personalities_count} personalities
+            </div>
+            <div className="content-meta">
+              <Link href={`/topics/${topic.slug}`} className="card-link">
+                Open topic
+              </Link>
+            </div>
+          </article>
+        ))}
+      </section>
+    </div>
+  );
+}

--- a/fap-web/components/navigation/Header.tsx
+++ b/fap-web/components/navigation/Header.tsx
@@ -2,6 +2,7 @@ import Link from "next/link";
 
 const navItems = [
   { href: "/tests", label: "Tests" },
+  { href: "/topics", label: "Topics" },
   { href: "/personality", label: "Personality" },
   { href: "/career", label: "Career" },
   { href: "/articles", label: "Articles" },
@@ -26,4 +27,3 @@ export default function Header() {
     </header>
   );
 }
-

--- a/fap-web/lib/topics.ts
+++ b/fap-web/lib/topics.ts
@@ -1,0 +1,81 @@
+const apiBase = (
+  process.env.NEXT_PUBLIC_API_BASE ?? "http://127.0.0.1:18080"
+).replace(/\/$/, "");
+
+export type TopicListItem = {
+  id: number;
+  org_id: number;
+  name: string;
+  slug: string;
+  description: string | null;
+  seo_title: string | null;
+  seo_description: string | null;
+  articles_count: number;
+  careers_count: number;
+  personalities_count: number;
+  url: string;
+  created_at: string | null;
+  updated_at: string | null;
+};
+
+export type TopicDetail = {
+  id: number;
+  org_id: number;
+  name: string;
+  slug: string;
+  description: string | null;
+  seo_title: string | null;
+  seo_description: string | null;
+  created_at: string | null;
+  updated_at: string | null;
+};
+
+export type TopicRelatedItem = {
+  title: string;
+  slug: string;
+  url: string;
+};
+
+export type TopicDetailResponse = {
+  ok: boolean;
+  topic: TopicDetail;
+  articles: TopicRelatedItem[];
+  careers: TopicRelatedItem[];
+  personalities: TopicRelatedItem[];
+};
+
+type TopicListResponse = {
+  ok: boolean;
+  items?: TopicListItem[];
+};
+
+export async function getTopics(): Promise<TopicListItem[]> {
+  const response = await fetch(`${apiBase}/api/v0.5/topics`, {
+    cache: "no-store",
+  });
+
+  if (!response.ok) {
+    throw new Error("failed to fetch topics");
+  }
+
+  const data = (await response.json()) as TopicListResponse;
+
+  return data.items ?? [];
+}
+
+export async function getTopic(slug: string): Promise<TopicDetailResponse | null> {
+  const response = await fetch(
+    `${apiBase}/api/v0.5/topics/${encodeURIComponent(slug)}`,
+    { cache: "no-store" },
+  );
+
+  if (response.status === 404) {
+    return null;
+  }
+
+  if (!response.ok) {
+    throw new Error("failed to fetch topic");
+  }
+
+  return (await response.json()) as TopicDetailResponse;
+}


### PR DESCRIPTION
## Summary

- add topic tables and cluster mapping tables for articles, personalities, and careers
- expose `GET /api/v0.5/topics` and `GET /api/v0.5/topics/{slug}`
- add `TopicResource` in Ops CMS and include topic URLs in the SEO sitemap
- add frontend `/topics` and `/topics/[slug]` pages with shared navigation and related content sections
- seed an `mbti` topic cluster so the route is verifiable after migrate

## Tests

- `cd backend && php artisan migrate --force`
- `cd backend && php artisan route:list | rg "api/v0.5/topics|ops/topics"`
- `cd backend && php artisan test --filter=TopicControllerTest`
- `cd backend && php artisan test --filter=SitemapGeneratorTest`
- `cd fap-web && npm run build`
- open `/topics`
- open `/topics/mbti`