### PR TITLE
fix(attempts): 稳定结果页的 attempt start / submit / submission 查询链路

### DIFF
--- a/backend/app/Services/Attempts/AttemptStartService.php
+++ b/backend/app/Services/Attempts/AttemptStartService.php
@@ -251,13 +251,13 @@ if ($anonId === '') {
             $attemptPayload['duration_ms'] = 0;
         }
 
-        $persisted = DB::transaction(function () use ($attemptPayload): array {
+        $writeConnectionName = Attempt::onWriteConnection()->getModel()->getConnectionName();
+
+        $persisted = DB::connection($writeConnectionName)->transaction(function () use ($attemptPayload, $writeConnectionName): array {
             $attempt = new Attempt;
 
-            // ✅ 保证 start 和 submit 使用同一套 Attempt::onWriteConnection() 的写库连接
-            $attempt->setConnection(
-                Attempt::onWriteConnection()->getModel()->getConnectionName()
-            );
+            // ✅ 保证 start / submit / report 都使用同一套写库连接
+            $attempt->setConnection($writeConnectionName);
 
             // keep model casts/mutators for json columns
             $attempt->forceFill($attemptPayload);
@@ -327,6 +327,9 @@ if ($anonId === '') {
 
         return [
             'ok' => true,
+            'org_id' => $orgId,
+            'anon_id' => $anonId,
+
             'attempt_id' => (string) $attempt->id,
             'scale_code' => $responseCodes['scale_code'],
             'scale_code_legacy' => $responseCodes['scale_code_legacy'],

--- a/backend/app/Services/Attempts/AttemptSubmissionService.php
+++ b/backend/app/Services/Attempts/AttemptSubmissionService.php
@@ -261,8 +261,12 @@ final class AttemptSubmissionService
             ];
         }
 
+                $orgId = $ctx->orgId() ?? 0;
+        $actorUserId = $this->normalizeUserId($actorUserId);
+        $actorAnonId = $this->normalizeAnonId($actorAnonId);
+
         $query = DB::table('attempt_submissions')
-            ->where('org_id', $ctx->orgId() ?? 0)
+            ->where('org_id', $orgId)
             ->where('attempt_id', $attemptId);
 
         if ($actorUserId !== null) {
@@ -282,6 +286,24 @@ final class AttemptSubmissionService
             ->orderByDesc('updated_at')
             ->orderByDesc('created_at')
             ->first();
+
+        // ✅ org fallback：兼容历史 public attempt/submission 写成 org_id=0
+        if ($row === null && $orgId !== 0) {
+            $fallback = DB::table('attempt_submissions')
+                ->where('org_id', 0)
+                ->where('attempt_id', $attemptId);
+
+            if ($actorUserId !== null) {
+                $fallback->where('actor_user_id', (int) $actorUserId);
+            } elseif ($actorAnonId !== null) {
+                $fallback->where('actor_anon_id', $actorAnonId);
+            }
+
+            $row = $fallback
+                ->orderByDesc('updated_at')
+                ->orderByDesc('created_at')
+                ->first();
+        }
 
         if ($row === null) {
             return [
@@ -360,8 +382,8 @@ final class AttemptSubmissionService
         $actorAnonId = $this->resolveAnonId($ctx, $dto->anonId);
 
         $payload = $this->buildPayload($dto, $actorUserId, $actorAnonId);
-        $dedupeKey = $this->buildDedupeKey($ctx->orgId(), $attemptId, $payload);
-        $orgId = $ctx->orgId();
+        $orgId = $ctx->orgId() ?? 0;
+        $dedupeKey = $this->buildDedupeKey($orgId, $attemptId, $payload);
         $now = now();
 
         $encodedRequest = json_encode($payload, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES);
@@ -424,8 +446,8 @@ final class AttemptSubmissionService
         $actorAnonId = $this->resolveAnonId($ctx, $dto->anonId);
 
         $payload = $this->buildPayload($dto, $actorUserId, $actorAnonId);
-        $dedupeKey = $this->buildDedupeKey($ctx->orgId(), $attemptId, $payload);
-        $orgId = $ctx->orgId();
+        $orgId = $ctx->orgId() ?? 0;
+        $dedupeKey = $this->buildDedupeKey($orgId, $attemptId, $payload);
         $now = now();
 
         $errorCode = strtoupper(trim($errorCode));
@@ -628,9 +650,18 @@ final class AttemptSubmissionService
         ?string $actorUserId,
         ?string $actorAnonId
     ): Builder {
+        $orgId = $ctx->orgId() ?? 0;
+        $orgIds = $orgId === 0 ? [0] : [$orgId, 0];
+
+        // ✅ 强制走写库 + 去掉全局 scopes
+        // ✅ whereIn(org_id, [$orgId, 0])：兼容历史 attempt 写成 org_id=0 的情况
         $query = Attempt::onWriteConnection()
             ->withoutGlobalScopes()
-            ->where('id', $attemptId);
+            ->where('id', $attemptId)
+            ->whereIn('org_id', $orgIds);
+
+        $actorUserId = $this->normalizeUserId($actorUserId);
+        $actorAnonId = $this->normalizeAnonId($actorAnonId);
 
         if ($actorUserId !== null) {
             return $query->where('user_id', $actorUserId);
@@ -640,6 +671,6 @@ final class AttemptSubmissionService
             return $query->where('anon_id', $actorAnonId);
         }
 
-        return $query->whereRaw('1=0');
+        throw new ApiProblemException(401, 'UNAUTHORIZED', 'actor identity missing.');
     }
 }

--- a/backend/app/Services/Attempts/AttemptSubmitService.php
+++ b/backend/app/Services/Attempts/AttemptSubmitService.php
@@ -148,9 +148,15 @@ class AttemptSubmitService
         ?string $actorUserId,
         ?string $actorAnonId
     ): Builder {
-        $query = Attempt::query()
+        $orgId = $ctx->orgId() ?? 0;
+        $orgIds = $orgId === 0 ? [0] : [$orgId, 0];
+
+        // ✅ 强制走写库 + 去掉全局 scopes
+        // ✅ whereIn(org_id, [$orgId, 0])：兼容历史 attempt 写成 org_id=0
+        $query = Attempt::onWriteConnection()
+            ->withoutGlobalScopes()
             ->where('id', $attemptId)
-            ->where('org_id', $ctx->orgId());
+            ->whereIn('org_id', $orgIds);
 
         $role = (string) ($ctx->role() ?? '');
         if (in_array($role, ['owner', 'admin'], true)) {


### PR DESCRIPTION
## Summary
- 统一 attempt start / submit / submission 的写库读取路径，避免结果页在主从延迟下读不到刚创建的 attempt / submission
- 为历史 public 数据补齐 `org_id=0` 回退，兼容旧 `attempts` / `attempt_submissions`
- 修正 sync submission 的 `org_id` 默认值与 dedupe key 计算
- 在 start 响应中返回 `org_id` 和 `anon_id`，保证结果页链路能拿到完整上下文

## Scope
- backend only
- no route changes
- no migration changes
- no middleware changes
- service layer only:
  - `backend/app/Services/Attempts/AttemptStartService.php`
  - `backend/app/Services/Attempts/AttemptSubmissionService.php`
  - `backend/app/Services/Attempts/AttemptSubmitService.php`

## Key Changes
- `AttemptStartService`
  - 在 `Attempt::onWriteConnection()` 对应写库事务中创建 attempt
  - start 返回值补充 `org_id` 与 `anon_id`
- `AttemptSubmissionService`
  - 查询 submission 前统一 normalize `org_id` / `actor_user_id` / `actor_anon_id`
  - 查询不到当前 org 数据时回退 `org_id=0`
  - sync success/failure 统一使用 `org_id ?? 0` 计算 dedupe key 和落库
  - `ownedAttemptQuery` 改为写库 + `withoutGlobalScopes()` + `whereIn('org_id', [$orgId, 0])`
  - actor identity 缺失时显式返回 401
- `AttemptSubmitService`
  - `ownedAttemptQuery` 改为写库 + `withoutGlobalScopes()` + `whereIn('org_id', [$orgId, 0])`

## Why
- 结果页依赖 attempt / submission 立即可读；当前链路在主从延迟或历史 `org_id=0` 数据下会出现“刚提交就查不到”的问题。
- 这次调整只收敛在 service 层，不改 API 路由、migration 或中间件。

## Validation
- `php artisan route:list`
- `php artisan migrate`
- `curl` 走 `/api/v0.3/attempts/start` -> `/api/v0.3/attempts/submit` -> `/api/v0.3/attempts/{attempt_id}/submission`
- `bash backend/scripts/ci_verify_mbti.sh`

## Risk
- 低风险，影响面集中在 attempt ownership / submission lookup / start response payload
- 历史 public 数据兼容路径已保留
