### PR TITLE
fix(attempts): return 404 for missing submissions

### DIFF
--- a/backend/app/Http/Controllers/API/V0_3/AttemptWriteController.php
+++ b/backend/app/Http/Controllers/API/V0_3/AttemptWriteController.php
@@ -68,8 +68,11 @@ class AttemptWriteController extends Controller
         $payload['user_id'] = $request->attributes->get('fm_user_id')
             ?? $request->attributes->get('user_id')
             ?? $this->orgContext->userId();
+
+        $requestAnonId = trim((string) ($request->input('anon_id') ?? ''));
         $payload['anon_id'] = $request->attributes->get('anon_id')
             ?? $request->attributes->get('fm_anon_id')
+            ?? ($requestAnonId !== '' ? $requestAnonId : null)
             ?? $this->orgContext->anonId();
 
         $mode = strtolower(trim((string) $request->query('mode', '')));

--- a/backend/app/Services/Attempts/AttemptSubmissionService.php
+++ b/backend/app/Services/Attempts/AttemptSubmissionService.php
@@ -89,7 +89,11 @@ final class AttemptSubmissionService
 
         $actorUserId = $this->resolveUserId($ctx, $dto->userId);
         $actorAnonId = $this->resolveAnonId($ctx, $dto->anonId);
-        $this->ownedAttemptQuery($ctx, $attemptId, $actorUserId, $actorAnonId)->firstOrFail();
+
+        $attempt = $this->ownedAttemptQuery($ctx, $attemptId, $actorUserId, $actorAnonId)->first();
+        if (! $attempt) {
+            throw new ApiProblemException(404, 'RESOURCE_NOT_FOUND', 'attempt not found.');
+        }
 
         $payload = $this->buildPayload($dto, $actorUserId, $actorAnonId);
         $dedupeKey = $this->buildDedupeKey($orgId, $attemptId, $payload);

--- a/backend/app/Services/Attempts/AttemptSubmitGuardService.php
+++ b/backend/app/Services/Attempts/AttemptSubmitGuardService.php
@@ -27,8 +27,12 @@ class AttemptSubmitGuardService
         $actorUserId = $this->core->resolveUserId($ctx, $dto->userId);
         $actorAnonId = $this->core->resolveAnonId($ctx, $dto->anonId);
 
-        $orgId = $ctx->orgId();
-        $attempt = $this->core->ownedAttemptQuery($ctx, $attemptId, $actorUserId, $actorAnonId)->firstOrFail();
+        $orgId = $ctx->orgId() ?? 0;
+        $attempt = $this->core->ownedAttemptQuery($ctx, $attemptId, $actorUserId, $actorAnonId)->first();
+
+        if (! $attempt) {
+            throw new ApiProblemException(404, 'RESOURCE_NOT_FOUND', 'attempt not found.');
+        }
 
         $scaleCode = strtoupper((string) ($attempt->scale_code ?? ''));
         if ($scaleCode === '') {

--- a/backend/app/Services/Attempts/AttemptSubmitTxService.php
+++ b/backend/app/Services/Attempts/AttemptSubmitTxService.php
@@ -87,7 +87,11 @@ class AttemptSubmitTxService
         ) {
             $locked = $this->core->ownedAttemptQuery($ctx, $attemptId, $actorUserId, $actorAnonId)
                 ->lockForUpdate()
-                ->firstOrFail();
+                ->first();
+
+if (! $locked) {
+    throw new ApiProblemException(404, 'RESOURCE_NOT_FOUND', 'attempt not found.');
+}
 
             $existingDigest = trim((string) ($locked->answers_digest ?? ''));
             if ($locked->submitted_at && $existingDigest !== '') {


### PR DESCRIPTION
## Summary
- allow attempt submit to fall back to request `anon_id` when middleware attributes are absent
- replace `firstOrFail()` in submit flows with explicit `RESOURCE_NOT_FOUND` handling
- keep missing owned attempts returning a consistent `404 attempt not found` response

## Testing
- not run (not requested)