### PR TITLE
fix(cms): protect article write routes

### DIFF
--- a/backend/app/Http/Controllers/API/V0_5/Cms/ArticleController.php
+++ b/backend/app/Http/Controllers/API/V0_5/Cms/ArticleController.php
@@ -169,7 +169,6 @@ class ArticleController extends Controller
             'category_id' => ['nullable', 'integer', 'min:1'],
             'tags' => ['nullable', 'array'],
             'tags.*' => ['integer', 'min:1'],
-            'org_id' => ['nullable', 'integer', 'min:0'],
         ]);
 
         try {
@@ -180,7 +179,7 @@ class ArticleController extends Controller
                 (string) $payload['content_md'],
                 isset($payload['category_id']) ? (int) $payload['category_id'] : null,
                 isset($payload['tags']) && is_array($payload['tags']) ? $payload['tags'] : [],
-                isset($payload['org_id']) ? (int) $payload['org_id'] : $this->resolveOrgId($request)
+                $this->resolveTrustedOrgId($request)
             );
         } catch (InvalidArgumentException $e) {
             return $this->invalidArgument($e);
@@ -238,6 +237,7 @@ class ArticleController extends Controller
         }
 
         try {
+            $this->assertArticleInOrgScope($articleId, $this->resolveTrustedOrgId($request));
             $article = $this->articleService->updateArticle($articleId, $fields, $tags);
         } catch (InvalidArgumentException $e) {
             return $this->invalidArgument($e);
@@ -256,7 +256,7 @@ class ArticleController extends Controller
     /**
      * POST /api/v0.5/cms/articles/{id}/publish
      */
-    public function publish(string $id): JsonResponse
+    public function publish(Request $request, string $id): JsonResponse
     {
         $articleId = $this->resolveArticleId($id);
         if ($articleId === null) {
@@ -268,6 +268,7 @@ class ArticleController extends Controller
         }
 
         try {
+            $this->assertArticleInOrgScope($articleId, $this->resolveTrustedOrgId($request));
             $article = $this->articlePublishService->publishArticle($articleId);
         } catch (InvalidArgumentException $e) {
             return $this->invalidArgument($e);
@@ -286,7 +287,7 @@ class ArticleController extends Controller
     /**
      * POST /api/v0.5/cms/articles/{id}/unpublish
      */
-    public function unpublish(string $id): JsonResponse
+    public function unpublish(Request $request, string $id): JsonResponse
     {
         $articleId = $this->resolveArticleId($id);
         if ($articleId === null) {
@@ -298,6 +299,7 @@ class ArticleController extends Controller
         }
 
         try {
+            $this->assertArticleInOrgScope($articleId, $this->resolveTrustedOrgId($request));
             $article = $this->articlePublishService->unpublishArticle($articleId);
         } catch (InvalidArgumentException $e) {
             return $this->invalidArgument($e);
@@ -316,7 +318,7 @@ class ArticleController extends Controller
     /**
      * POST /api/v0.5/cms/articles/{id}/seo
      */
-    public function generateSeo(string $id): JsonResponse
+    public function generateSeo(Request $request, string $id): JsonResponse
     {
         $articleId = $this->resolveArticleId($id);
         if ($articleId === null) {
@@ -328,6 +330,7 @@ class ArticleController extends Controller
         }
 
         try {
+            $this->assertArticleInOrgScope($articleId, $this->resolveTrustedOrgId($request));
             $seoMeta = $this->articleSeoService->generateSeoMeta($articleId);
         } catch (InvalidArgumentException $e) {
             return $this->invalidArgument($e);
@@ -362,6 +365,30 @@ class ArticleController extends Controller
         return preg_match('/^\d+$/', $raw) === 1 ? (int) $raw : 0;
     }
 
+    private function resolveTrustedOrgId(Request $request): int
+    {
+        $candidates = [
+            $request->attributes->get('fm_org_id'),
+            $request->hasSession() ? $request->session()->get('ops_org_id') : null,
+        ];
+
+        foreach ($candidates as $candidate) {
+            if (! is_int($candidate) && ! is_string($candidate) && ! is_numeric($candidate)) {
+                continue;
+            }
+
+            $raw = trim((string) $candidate);
+            if ($raw === '' || preg_match('/^\d+$/', $raw) !== 1) {
+                continue;
+            }
+
+            return max(0, (int) $raw);
+        }
+
+        // CMS global/internal preview content lives in org 0 when no ops org is selected.
+        return 0;
+    }
+
     private function resolveArticleId(string $id): ?int
     {
         $normalized = trim($id);
@@ -372,6 +399,29 @@ class ArticleController extends Controller
         $articleId = (int) $normalized;
 
         return $articleId > 0 ? $articleId : null;
+    }
+
+    private function assertArticleInOrgScope(int $articleId, int $trustedOrgId): void
+    {
+        $exists = Article::query()
+            ->withoutGlobalScopes()
+            ->where('id', $articleId)
+            ->whereIn('org_id', $this->allowedOrgIds($trustedOrgId))
+            ->exists();
+
+        if (! $exists) {
+            throw new RuntimeException('article not found.');
+        }
+    }
+
+    /**
+     * @return array<int, int>
+     */
+    private function allowedOrgIds(int $trustedOrgId): array
+    {
+        $normalizedOrgId = max(0, $trustedOrgId);
+
+        return $normalizedOrgId > 0 ? [0, $normalizedOrgId] : [0];
     }
 
     /**

--- a/backend/app/Http/Middleware/EnsureCmsAdminAuthorized.php
+++ b/backend/app/Http/Middleware/EnsureCmsAdminAuthorized.php
@@ -1,0 +1,97 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Middleware;
+
+use App\Support\OrgContext;
+use App\Support\Rbac\PermissionNames;
+use Closure;
+use Illuminate\Http\Request;
+use Symfony\Component\HttpFoundation\Response;
+
+final class EnsureCmsAdminAuthorized
+{
+    public function __construct(
+        private readonly OrgContext $orgContext,
+    ) {}
+
+    public function handle(Request $request, Closure $next): Response
+    {
+        $guard = (string) config('admin.guard', 'admin');
+        $user = auth($guard)->user();
+
+        if (
+            ! is_object($user)
+            || ! method_exists($user, 'hasPermission')
+            || ! method_exists($user, 'getAuthIdentifier')
+        ) {
+            return $this->unauthorizedResponse('admin_session_required');
+        }
+
+        if (
+            ! $user->hasPermission(PermissionNames::ADMIN_CONTENT_PUBLISH)
+            && ! $user->hasPermission(PermissionNames::ADMIN_OWNER)
+        ) {
+            return $this->forbiddenResponse('admin_content_publish_required');
+        }
+
+        $adminUserId = (int) $user->getAuthIdentifier();
+        $orgId = $this->resolveTrustedOrgId($request);
+
+        $request->attributes->set('fm_admin_user_id', $adminUserId);
+        $request->attributes->set('fm_user_id', (string) $adminUserId);
+        $request->attributes->set('user_id', (string) $adminUserId);
+        $request->attributes->set('fm_org_id', $orgId);
+        $request->attributes->set('org_id', $orgId);
+        $request->attributes->set('org_role', 'admin');
+        $request->attributes->set('org_context_resolved', true);
+        $request->attributes->set('org_context_trusted', true);
+
+        $this->orgContext->set($orgId, $adminUserId, 'admin');
+        app()->instance(OrgContext::class, $this->orgContext);
+
+        return $next($request);
+    }
+
+    private function resolveTrustedOrgId(Request $request): int
+    {
+        $candidates = [
+            $request->attributes->get('fm_org_id'),
+            $request->hasSession() ? $request->session()->get('ops_org_id') : null,
+        ];
+
+        foreach ($candidates as $candidate) {
+            if (! is_int($candidate) && ! is_string($candidate) && ! is_numeric($candidate)) {
+                continue;
+            }
+
+            $raw = trim((string) $candidate);
+            if ($raw === '' || preg_match('/^\d+$/', $raw) !== 1) {
+                continue;
+            }
+
+            return max(0, (int) $raw);
+        }
+
+        return 0;
+    }
+
+    private function unauthorizedResponse(string $reason): Response
+    {
+        return response()->json([
+            'ok' => false,
+            'error_code' => 'UNAUTHORIZED',
+            'message' => $reason,
+        ], 401);
+    }
+
+    private function forbiddenResponse(string $reason): Response
+    {
+        return response()->json([
+            'ok' => false,
+            'error_code' => 'FORBIDDEN',
+            'message' => $reason,
+        ], 403);
+    }
+}

--- a/backend/docs/contracts/openapi.snapshot.json
+++ b/backend/docs/contracts/openapi.snapshot.json
@@ -1730,7 +1730,14 @@
                 },
                 "x-laravel-action": "App\\Http\\Controllers\\API\\V0_5\\Cms\\ArticleController@store",
                 "x-laravel-middleware": [
-                    "api"
+                    "api",
+                    "App\\Http\\Middleware\\EncryptCookies",
+                    "Illuminate\\Cookie\\Middleware\\AddQueuedCookiesToResponse",
+                    "Illuminate\\Session\\Middleware\\StartSession",
+                    "App\\Http\\Middleware\\SetOpsRequestContext",
+                    "App\\Http\\Middleware\\AdminAuth",
+                    "App\\Http\\Middleware\\ResolveOrgContext",
+                    "App\\Http\\Middleware\\EnsureCmsAdminAuthorized"
                 ]
             }
         },
@@ -1747,7 +1754,14 @@
                 },
                 "x-laravel-action": "App\\Http\\Controllers\\API\\V0_5\\Cms\\ArticleController@update",
                 "x-laravel-middleware": [
-                    "api"
+                    "api",
+                    "App\\Http\\Middleware\\EncryptCookies",
+                    "Illuminate\\Cookie\\Middleware\\AddQueuedCookiesToResponse",
+                    "Illuminate\\Session\\Middleware\\StartSession",
+                    "App\\Http\\Middleware\\SetOpsRequestContext",
+                    "App\\Http\\Middleware\\AdminAuth",
+                    "App\\Http\\Middleware\\ResolveOrgContext",
+                    "App\\Http\\Middleware\\EnsureCmsAdminAuthorized"
                 ]
             }
         },
@@ -1764,7 +1778,14 @@
                 },
                 "x-laravel-action": "App\\Http\\Controllers\\API\\V0_5\\Cms\\ArticleController@publish",
                 "x-laravel-middleware": [
-                    "api"
+                    "api",
+                    "App\\Http\\Middleware\\EncryptCookies",
+                    "Illuminate\\Cookie\\Middleware\\AddQueuedCookiesToResponse",
+                    "Illuminate\\Session\\Middleware\\StartSession",
+                    "App\\Http\\Middleware\\SetOpsRequestContext",
+                    "App\\Http\\Middleware\\AdminAuth",
+                    "App\\Http\\Middleware\\ResolveOrgContext",
+                    "App\\Http\\Middleware\\EnsureCmsAdminAuthorized"
                 ]
             }
         },
@@ -1781,7 +1802,14 @@
                 },
                 "x-laravel-action": "App\\Http\\Controllers\\API\\V0_5\\Cms\\ArticleController@generateSeo",
                 "x-laravel-middleware": [
-                    "api"
+                    "api",
+                    "App\\Http\\Middleware\\EncryptCookies",
+                    "Illuminate\\Cookie\\Middleware\\AddQueuedCookiesToResponse",
+                    "Illuminate\\Session\\Middleware\\StartSession",
+                    "App\\Http\\Middleware\\SetOpsRequestContext",
+                    "App\\Http\\Middleware\\AdminAuth",
+                    "App\\Http\\Middleware\\ResolveOrgContext",
+                    "App\\Http\\Middleware\\EnsureCmsAdminAuthorized"
                 ]
             }
         },
@@ -1798,7 +1826,14 @@
                 },
                 "x-laravel-action": "App\\Http\\Controllers\\API\\V0_5\\Cms\\ArticleController@unpublish",
                 "x-laravel-middleware": [
-                    "api"
+                    "api",
+                    "App\\Http\\Middleware\\EncryptCookies",
+                    "Illuminate\\Cookie\\Middleware\\AddQueuedCookiesToResponse",
+                    "Illuminate\\Session\\Middleware\\StartSession",
+                    "App\\Http\\Middleware\\SetOpsRequestContext",
+                    "App\\Http\\Middleware\\AdminAuth",
+                    "App\\Http\\Middleware\\ResolveOrgContext",
+                    "App\\Http\\Middleware\\EnsureCmsAdminAuthorized"
                 ]
             }
         }

--- a/backend/routes/api.php
+++ b/backend/routes/api.php
@@ -25,12 +25,18 @@ use App\Http\Controllers\API\V0_4\PartnerController;
 use App\Http\Controllers\API\V0_4\RotationAuditController;
 use App\Http\Controllers\API\V0_5\Cms\ArticleController;
 use App\Http\Controllers\HealthzController;
+use App\Http\Middleware\AdminAuth;
+use App\Http\Middleware\EnsureCmsAdminAuthorized;
+use App\Http\Middleware\EncryptCookies;
 use App\Http\Middleware\HealthzAccessControl;
 use App\Http\Middleware\LimitWebhookPayloadSize;
 use App\Http\Middleware\NormalizeApiErrorContract;
 use App\Http\Middleware\PartnerApiKeyAuth;
 use App\Http\Middleware\ResolveOrgContext;
+use App\Http\Middleware\SetOpsRequestContext;
+use Illuminate\Cookie\Middleware\AddQueuedCookiesToResponse;
 use Illuminate\Http\Request;
+use Illuminate\Session\Middleware\StartSession;
 use Illuminate\Support\Facades\Route;
 
 /*
@@ -297,10 +303,20 @@ Route::prefix('v0.5')->group(function () {
     Route::get('/articles/{slug}', [ArticleController::class, 'show']);
     Route::get('/articles/{slug}/seo', [ArticleController::class, 'seo']);
 
-    Route::post('/cms/articles', [ArticleController::class, 'store']);
-    Route::put('/cms/articles/{id}', [ArticleController::class, 'update']);
+    Route::middleware([
+        EncryptCookies::class,
+        AddQueuedCookiesToResponse::class,
+        StartSession::class,
+        SetOpsRequestContext::class,
+        AdminAuth::class,
+        ResolveOrgContext::class,
+        EnsureCmsAdminAuthorized::class,
+    ])->group(function () {
+        Route::post('/cms/articles', [ArticleController::class, 'store']);
+        Route::put('/cms/articles/{id}', [ArticleController::class, 'update']);
 
-    Route::post('/cms/articles/{id}/publish', [ArticleController::class, 'publish']);
-    Route::post('/cms/articles/{id}/unpublish', [ArticleController::class, 'unpublish']);
-    Route::post('/cms/articles/{id}/seo', [ArticleController::class, 'generateSeo']);
+        Route::post('/cms/articles/{id}/publish', [ArticleController::class, 'publish']);
+        Route::post('/cms/articles/{id}/unpublish', [ArticleController::class, 'unpublish']);
+        Route::post('/cms/articles/{id}/seo', [ArticleController::class, 'generateSeo']);
+    });
 });

--- a/backend/tests/Feature/V0_5/ArticleCmsWriteAuthTest.php
+++ b/backend/tests/Feature/V0_5/ArticleCmsWriteAuthTest.php
@@ -1,0 +1,158 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\V0_5;
+
+use App\Models\AdminUser;
+use App\Models\Article;
+use App\Models\Permission;
+use App\Models\Role;
+use App\Support\Rbac\PermissionNames;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Str;
+use Tests\TestCase;
+
+final class ArticleCmsWriteAuthTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_unauthenticated_cms_write_is_rejected(): void
+    {
+        $response = $this->postJson('/api/v0.5/cms/articles', $this->articlePayload());
+
+        $response->assertStatus(401)
+            ->assertJsonPath('ok', false)
+            ->assertJsonPath('error_code', 'UNAUTHORIZED');
+    }
+
+    public function test_admin_without_publish_permission_is_rejected(): void
+    {
+        $admin = $this->createAdminWithPermissions([]);
+
+        $response = $this->withSession(['ops_org_id' => 11])
+            ->actingAs($admin, (string) config('admin.guard', 'admin'))
+            ->postJson('/api/v0.5/cms/articles', $this->articlePayload());
+
+        $response->assertStatus(403)
+            ->assertJsonPath('ok', false)
+            ->assertJsonPath('error_code', 'FORBIDDEN');
+    }
+
+    public function test_admin_with_publish_permission_can_create_article_in_trusted_org_scope(): void
+    {
+        $admin = $this->createAdminWithPermissions([PermissionNames::ADMIN_CONTENT_PUBLISH]);
+
+        $response = $this->withSession(['ops_org_id' => 12])
+            ->actingAs($admin, (string) config('admin.guard', 'admin'))
+            ->postJson('/api/v0.5/cms/articles', array_merge($this->articlePayload(), [
+                'org_id' => 999,
+            ]));
+
+        $response->assertStatus(201)
+            ->assertJsonPath('ok', true)
+            ->assertJsonPath('article.org_id', 12);
+
+        $this->assertDatabaseHas('articles', [
+            'title' => 'CMS write auth test',
+            'org_id' => 12,
+        ]);
+
+        $this->assertDatabaseMissing('articles', [
+            'title' => 'CMS write auth test',
+            'org_id' => 999,
+        ]);
+    }
+
+    public function test_admin_owner_permission_can_write_articles(): void
+    {
+        $admin = $this->createAdminWithPermissions([PermissionNames::ADMIN_OWNER]);
+
+        $response = $this->withSession(['ops_org_id' => 13])
+            ->actingAs($admin, (string) config('admin.guard', 'admin'))
+            ->postJson('/api/v0.5/cms/articles', $this->articlePayload('owner-can-write'));
+
+        $response->assertStatus(201)
+            ->assertJsonPath('ok', true)
+            ->assertJsonPath('article.org_id', 13);
+    }
+
+    public function test_cross_org_article_update_is_rejected(): void
+    {
+        $admin = $this->createAdminWithPermissions([PermissionNames::ADMIN_CONTENT_PUBLISH]);
+        $article = Article::query()->create([
+            'org_id' => 21,
+            'slug' => 'cross-org-target',
+            'locale' => 'en',
+            'title' => 'Cross org target',
+            'content_md' => 'Initial content',
+            'status' => 'draft',
+            'is_public' => false,
+            'is_indexable' => true,
+        ]);
+
+        $response = $this->withSession(['ops_org_id' => 22])
+            ->actingAs($admin, (string) config('admin.guard', 'admin'))
+            ->putJson('/api/v0.5/cms/articles/'.$article->id, [
+                'title' => 'Should not update',
+            ]);
+
+        $response->assertStatus(404)
+            ->assertJsonPath('ok', false)
+            ->assertJsonPath('error_code', 'NOT_FOUND');
+
+        $this->assertDatabaseHas('articles', [
+            'id' => $article->id,
+            'title' => 'Cross org target',
+            'org_id' => 21,
+        ]);
+    }
+
+    /**
+     * @param  list<string>  $permissions
+     */
+    private function createAdminWithPermissions(array $permissions): AdminUser
+    {
+        $admin = AdminUser::query()->create([
+            'name' => 'admin_' . Str::lower(Str::random(6)),
+            'email' => 'admin_' . Str::lower(Str::random(6)) . '@example.test',
+            'password' => bcrypt('secret'),
+            'is_active' => 1,
+        ]);
+
+        if ($permissions === []) {
+            return $admin;
+        }
+
+        $role = Role::query()->create([
+            'name' => 'role_' . Str::lower(Str::random(10)),
+            'description' => null,
+        ]);
+
+        foreach ($permissions as $permissionName) {
+            $permission = Permission::query()->firstOrCreate(
+                ['name' => $permissionName],
+                ['description' => null]
+            );
+
+            $role->permissions()->syncWithoutDetaching([$permission->id]);
+        }
+
+        $admin->roles()->syncWithoutDetaching([$role->id]);
+
+        return $admin;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function articlePayload(string $slug = 'cms-write-auth-test'): array
+    {
+        return [
+            'title' => 'CMS write auth test',
+            'slug' => $slug,
+            'locale' => 'en',
+            'content_md' => 'Hello from the CMS write auth test.',
+        ];
+    }
+}


### PR DESCRIPTION
## Summary
- protect `/api/v0.5/cms/articles*` write endpoints with admin session and content publish RBAC
- keep public article GET endpoints unchanged
- remove client-controlled `org_id` from article create and use trusted ops org context instead
- enforce record-level org scope before update, publish, unpublish, and SEO generation
- sync OpenAPI snapshot and add focused feature coverage for the new auth behavior

## What changed
- moved the five CMS write routes into a protected middleware group
- added `EnsureCmsAdminAuthorized` to require a real admin session plus `admin.content.publish` or `admin.owner`
- rewired article writes to resolve org from trusted ops context instead of request payload
- added controller-level org scope assertions to block cross-org write access
- added feature tests for unauthenticated, unauthorized, authorized, trusted org, and cross-org denial paths

## Validation
- `cd backend && php artisan route:list --path=api/v0.5 --except-vendor`
- `cd backend && php artisan test --filter=ArticleCmsWriteAuthTest`
- `cd backend && bash scripts/export_openapi.sh --check`
- `cd backend && php artisan test --filter='(OpenApiDiffTest|SitemapXmlTest|SitemapGeneratorTest)'`
- `cd backend && php -l app/Http/Controllers/API/V0_5/Cms/ArticleController.php`

## Not run
- `cd backend && php artisan migrate`
- `cd /Users/rainie/Desktop/GitHub/fap-api && bash backend/scripts/ci_verify_mbti.sh`
