### PR TITLE
fix(attempts): accept anon id in submit request

### DIFF
--- a/backend/app/Http/Controllers/API/V0_3/AttemptWriteController.php
+++ b/backend/app/Http/Controllers/API/V0_3/AttemptWriteController.php
@@ -74,7 +74,10 @@ class AttemptWriteController extends Controller
             ?? $request->attributes->get('fm_anon_id')
             ?? ''
         ));
-        $bodyAnonId = trim((string) ($payload['anon_id'] ?? ''));
+
+        // ✅ 必须从原始 request input 取，不能依赖 validated()，否则 rules 里没放 anon_id 就会被过滤掉
+        $bodyAnonId = trim((string) ($request->input('anon_id') ?? ''));
+
         $ctxAnonId = trim((string) ($this->orgContext->anonId() ?? ''));
 
         $payload['anon_id'] = $attrAnonId !== ''

--- a/backend/app/Http/Requests/V0_3/SubmitAttemptRequest.php
+++ b/backend/app/Http/Requests/V0_3/SubmitAttemptRequest.php
@@ -15,6 +15,7 @@ class SubmitAttemptRequest extends FormRequest
     {
         return [
             'attempt_id' => ['required', 'string', 'max:64'],
+            'anon_id' => ['nullable', 'string', 'max:191'],
             'answers' => ['nullable', 'array'],
             'answers.*.question_id' => ['required_with:answers', 'string', 'max:128'],
             // Keep submit contract scale-agnostic; scale-specific answer validation


### PR DESCRIPTION
## Summary
- add `anon_id` to `SubmitAttemptRequest` validation rules
- read submit `anon_id` from raw request input instead of relying on validated payload
- keep submit anon id fallback order as attributes -> body -> org context

## Testing
- not run (not requested)