### PR TITLE
fix(content): relax content packs index scanning

### DIFF
--- a/backend/app/Services/Content/ContentPacksIndex.php
+++ b/backend/app/Services/Content/ContentPacksIndex.php
@@ -46,6 +46,11 @@ final class ContentPacksIndex
         }
 
         if ($packsRootFs === '' || !File::isDirectory($packsRootFs)) {
+            Log::error('CONTENT_PACKS_ROOT_INVALID', [
+                'driver' => $driver,
+                'packs_root' => $packsRootFs,
+            ]);
+
             return [
                 'ok' => false,
                 'driver' => $driver,
@@ -57,6 +62,13 @@ final class ContentPacksIndex
         }
 
         $items = $this->scanItems($packsRootFs);
+        if ($items === []) {
+            Log::error('CONTENT_PACKS_INDEX_EMPTY', [
+                'driver' => $driver,
+                'packs_root' => $packsRootFs,
+            ]);
+        }
+
         $byPackId = $this->buildByPackId($items, $defaults);
 
         $index = [
@@ -135,6 +147,15 @@ final class ContentPacksIndex
         }
     }
 
+    private function debugLog(string $event, array $context = []): void
+    {
+        if (! (bool) config('content_packs.debug_log', false)) {
+            return;
+        }
+
+        Log::warning($event, $context);
+    }
+
     private function defaults(): array
     {
         return [
@@ -153,19 +174,34 @@ final class ContentPacksIndex
         $seen = [];
         $rootNorm = rtrim(str_replace(DIRECTORY_SEPARATOR, '/', $packsRootFs), '/');
 
+        $stats = [
+            'manifests_seen' => 0,
+            'skipped_deprecated' => 0,
+            'skipped_manifest_json_invalid' => 0,
+            'skipped_manifest_consistency' => 0,
+            'skipped_version_invalid' => 0,
+            'skipped_questions_invalid' => 0,
+            'skipped_duplicate' => 0,
+            'accepted' => 0,
+        ];
+
         foreach (File::allFiles($packsRootFs) as $file) {
             if ($file->getFilename() !== 'manifest.json') {
                 continue;
             }
 
+            $stats['manifests_seen']++;
+
             $manifestPath = $file->getPathname();
             $manifestPathNorm = str_replace(DIRECTORY_SEPARATOR, '/', $manifestPath);
             if (str_contains($manifestPathNorm, '/_deprecated/')) {
+                $stats['skipped_deprecated']++;
                 continue;
             }
-            if (!str_contains($manifestPathNorm, '/default/')) {
-                continue;
-            }
+
+            // 正式修复：
+            // 不再强制要求 manifest 路径里必须包含 /default/
+            // 只要 manifest/version/questions 三件套一致，就视为有效 legacy pack。
 
             try {
                 $manifestRaw = File::get($manifestPath);
@@ -175,6 +211,7 @@ final class ContentPacksIndex
 
             $manifest = json_decode($manifestRaw, true);
             if (!is_array($manifest)) {
+                $stats['skipped_manifest_json_invalid']++;
                 continue;
             }
 
@@ -186,12 +223,14 @@ final class ContentPacksIndex
             $packDir = dirname($manifestPath);
             $dirVersion = basename($packDir);
             if (!$this->isManifestConsistent($manifest, $dirVersion, $packId)) {
+                $stats['skipped_manifest_consistency']++;
                 continue;
             }
 
             $versionPath = $packDir . DIRECTORY_SEPARATOR . 'version.json';
             $version = $this->readJsonFile($versionPath);
             if (!is_array($version)) {
+                $stats['skipped_version_invalid']++;
                 continue;
             }
             if (!$this->isVersionConsistent(
@@ -200,19 +239,23 @@ final class ContentPacksIndex
                 (string) ($manifest['content_package_version'] ?? ''),
                 $dirVersion
             )) {
+                $stats['skipped_version_invalid']++;
                 continue;
             }
 
             $questionsPath = $packDir . DIRECTORY_SEPARATOR . 'questions.json';
             if (!File::exists($questionsPath)) {
+                $stats['skipped_questions_invalid']++;
                 continue;
             }
             if (!is_array($this->readJsonFile($questionsPath))) {
+                $stats['skipped_questions_invalid']++;
                 continue;
             }
 
             $key = $packId . '|' . $dirVersion;
             if (isset($seen[$key])) {
+                $stats['skipped_duplicate']++;
                 continue;
             }
 
@@ -229,6 +272,8 @@ final class ContentPacksIndex
                 (int) ($versionSig['mtime'] ?? 0),
                 (int) ($questionsSig['mtime'] ?? 0)
             );
+
+            $stats['accepted']++;
 
             $items[] = [
                 'pack_id' => $packId,
@@ -260,6 +305,11 @@ final class ContentPacksIndex
             }
             return strcmp((string) ($a['dir_version'] ?? ''), (string) ($b['dir_version'] ?? ''));
         });
+
+        $this->debugLog('CONTENT_PACKS_INDEX_SCAN_SUMMARY', [
+            'packs_root' => $packsRootFs,
+            'stats' => $stats,
+        ]);
 
         return $items;
     }

--- a/backend/config/content_packs.php
+++ b/backend/config/content_packs.php
@@ -1,13 +1,16 @@
 <?php
 // file: backend/config/content_packs.php
 
-declare(strict_types=1);
+$defaultPacksRoot = realpath(dirname(base_path()) . '/content_packages');
+if ($defaultPacksRoot === false || $defaultPacksRoot === '') {
+    $defaultPacksRoot = dirname(base_path()) . '/content_packages';
+}
 
 return [
     // content_packages 根目录（本机/服务器/CI 都建议通过 env 固定）
     // - 本机默认：base_path('../content_packages')
     // - CI 建议：FAP_PACKS_ROOT=../content_packages（相对 backend/ 目录）
-    'root' => env('FAP_PACKS_ROOT', base_path('../content_packages')),
+    'root' => env('FAP_PACKS_ROOT', $defaultPacksRoot),
 
     // 内容源驱动：local|s3
     // - local：root 指向 content_packages 根目录
@@ -24,6 +27,7 @@ return [
     'cache_ttl_seconds' => (int)env('FAP_PACKS_CACHE_TTL_SECONDS', 3600),
     'loader_cache_store' => env('CONTENT_LOADER_CACHE_STORE', 'array'),
     'loader_cache_ttl_seconds' => (int) env('CONTENT_LOADER_CACHE_TTL_SECONDS', 300),
+    'debug_log' => (bool) env('FAP_PACKS_DEBUG_LOG', false),
 
     // ✅ CI/服务器建议强约束：默认 pack_id 明确指向你的主包，避免回退到 GLOBAL/en
     // default_pack_id 对应 manifest.json.pack_id（MBTI.cn-mainland.zh-CN.v0.3）


### PR DESCRIPTION
## Summary
- resolve the default `content_packs.root` path up front instead of relying on a fragile relative fallback
- stop requiring legacy pack manifests to live under `/default/` when manifest/version/questions are internally consistent
- add root-empty and scan-summary logging to make content pack indexing failures visible in runtime logs

## Testing
- not run (not requested)