### PR TITLE
feat(ops-ui): upgrade panel shell and page chrome

### DIFF
--- a/backend/app/Providers/Filament/AdminPanelProvider.php
+++ b/backend/app/Providers/Filament/AdminPanelProvider.php
@@ -85,12 +85,16 @@ class AdminPanelProvider extends PanelProvider
                 fn () => view('filament.ops.hooks.login-intro')
             )
             ->renderHook(
-                PanelsRenderHook::TOPBAR_END,
-                fn () => view('filament.ops.livewire.locale-switcher-hook')
+                PanelsRenderHook::TOPBAR_START,
+                fn () => view('filament.ops.hooks.topbar-context')
             )
             ->renderHook(
-                PanelsRenderHook::TOPBAR_END,
-                fn () => view('filament.ops.livewire.current-org-switcher-hook')
+                PanelsRenderHook::USER_MENU_BEFORE,
+                fn () => view('filament.ops.hooks.topbar-controls')
+            )
+            ->renderHook(
+                PanelsRenderHook::SIDEBAR_FOOTER,
+                fn () => view('filament.ops.hooks.sidebar-footer')
             )
             ->authMiddleware([
                 Authenticate::class,

--- a/backend/resources/css/filament/ops/theme.css
+++ b/backend/resources/css/filament/ops/theme.css
@@ -63,15 +63,28 @@
         background: transparent;
     }
 
+    .fi-body.fi-panel-ops .fi-main-ctn {
+        background:
+            linear-gradient(180deg, rgba(255, 255, 255, 0.55) 0%, rgba(247, 248, 250, 0) 20%),
+            transparent;
+    }
+
     .fi-body.fi-panel-ops .fi-main {
-        padding-bottom: 2rem;
+        padding-top: 1.5rem;
+        padding-bottom: 2.5rem;
     }
 
     .fi-body.fi-panel-ops .fi-topbar nav {
+        min-height: 4.5rem;
+        gap: 1rem;
         background: rgba(255, 255, 255, 0.8);
         border-bottom: 1px solid rgba(229, 231, 235, 0.86);
         box-shadow: 0 1px 0 rgba(255, 255, 255, 0.85);
         backdrop-filter: blur(20px);
+    }
+
+    .fi-body.fi-panel-ops .fi-topbar nav > .ms-auto {
+        gap: 0.75rem;
     }
 
     .fi-body.fi-panel-ops .fi-sidebar {
@@ -87,14 +100,19 @@
         backdrop-filter: blur(18px);
     }
 
+    .fi-body.fi-panel-ops .fi-sidebar-header {
+        min-height: 4.5rem;
+        padding-inline: 1.25rem;
+    }
+
     .fi-body.fi-panel-ops .fi-sidebar-nav {
-        gap: 1.25rem;
-        padding-top: 1.5rem;
-        padding-bottom: 1.75rem;
+        gap: 1.4rem;
+        padding-top: 1.25rem;
+        padding-bottom: 1.25rem;
     }
 
     .fi-body.fi-panel-ops .fi-sidebar-nav-groups {
-        gap: 1.25rem;
+        gap: 1rem;
     }
 
     .fi-body.fi-panel-ops .fi-sidebar-group-label {
@@ -103,6 +121,11 @@
         font-weight: 700;
         letter-spacing: 0.12em;
         text-transform: uppercase;
+    }
+
+    .fi-body.fi-panel-ops .fi-sidebar-group-items,
+    .fi-body.fi-panel-ops .fi-sidebar-sub-group-items {
+        gap: 0.35rem;
     }
 
     .fi-body.fi-panel-ops .fi-sidebar-item-button,
@@ -117,6 +140,18 @@
     .fi-body.fi-panel-ops .fi-sidebar-group-button,
     .fi-body.fi-panel-ops .fi-topbar-item-button {
         color: var(--ops-text-secondary);
+    }
+
+    .fi-body.fi-panel-ops .fi-sidebar-item-button {
+        position: relative;
+        min-height: 2.75rem;
+        justify-content: flex-start;
+        padding-inline: 0.8rem;
+    }
+
+    .fi-body.fi-panel-ops .fi-sidebar-group-button {
+        min-height: 2.625rem;
+        padding-inline: 0.8rem;
     }
 
     .fi-body.fi-panel-ops .fi-sidebar-item-icon,
@@ -140,6 +175,17 @@
         color: rgb(var(--primary-700));
     }
 
+    .fi-body.fi-panel-ops .fi-sidebar-item.fi-active > .fi-sidebar-item-button::before {
+        content: '';
+        position: absolute;
+        inset-inline-start: -0.55rem;
+        top: 0.45rem;
+        bottom: 0.45rem;
+        width: 3px;
+        border-radius: 999px;
+        background: rgb(var(--primary-600));
+    }
+
     .fi-body.fi-panel-ops .fi-sidebar-item.fi-active .fi-sidebar-item-icon,
     .fi-body.fi-panel-ops .fi-topbar-item.fi-active .fi-topbar-item-icon,
     .fi-body.fi-panel-ops .fi-tabs-item.fi-active .fi-tabs-item-icon {
@@ -148,6 +194,19 @@
 
     .fi-body.fi-panel-ops .fi-header {
         gap: 1.25rem;
+    }
+
+    .fi-body.fi-panel-ops .fi-page > section {
+        gap: 1.5rem;
+        padding-top: 0.5rem;
+    }
+
+    .fi-body.fi-panel-ops .fi-page > section > .fi-header {
+        padding: 1.5rem 1.6rem;
+        background: linear-gradient(180deg, rgba(255, 255, 255, 0.98), rgba(251, 252, 253, 0.92));
+        border: 1px solid rgba(229, 231, 235, 0.92);
+        border-radius: calc(var(--ops-radius-card) + 4px);
+        box-shadow: var(--ops-shadow-surface);
     }
 
     .fi-body.fi-panel-ops .fi-header-heading {
@@ -165,6 +224,28 @@
         line-height: 1.6;
     }
 
+    .fi-body.fi-panel-ops .fi-header > div:last-child {
+        gap: 0.65rem;
+        flex-wrap: wrap;
+        align-self: flex-start;
+    }
+
+    .fi-body.fi-panel-ops .fi-breadcrumbs-list {
+        gap: 0.3rem 0.55rem;
+    }
+
+    .fi-body.fi-panel-ops .fi-breadcrumbs-item-label {
+        color: var(--ops-text-tertiary);
+        font-size: 0.75rem;
+        font-weight: 600;
+        letter-spacing: 0.01em;
+    }
+
+    .fi-body.fi-panel-ops .fi-breadcrumbs-item-separator {
+        height: 0.875rem;
+        width: 0.875rem;
+    }
+
     .fi-body.fi-panel-ops .fi-section,
     .fi-body.fi-panel-ops .fi-simple-main,
     .fi-body.fi-panel-ops .fi-ta-ctn,
@@ -174,6 +255,7 @@
         border: 1px solid var(--ops-border-default);
         border-radius: var(--ops-radius-card);
         box-shadow: var(--ops-shadow-surface);
+        overflow: hidden;
     }
 
     .fi-body.fi-panel-ops .fi-simple-main {
@@ -222,6 +304,33 @@
         color: var(--ops-text-primary);
         font-size: 0.8125rem;
         letter-spacing: 0.01em;
+    }
+
+    .fi-body.fi-panel-ops .fi-page .grid.flex-1.auto-cols-fr,
+    .fi-body.fi-panel-ops .fi-page-header-widgets,
+    .fi-body.fi-panel-ops .fi-page-footer-widgets {
+        gap: 1.5rem;
+    }
+
+    .fi-body.fi-panel-ops .fi-ta-header {
+        padding: 1.35rem 1.5rem 0.9rem;
+    }
+
+    .fi-body.fi-panel-ops .fi-ta-header-toolbar {
+        align-items: flex-start;
+        gap: 0.75rem;
+        padding-top: 0.85rem;
+        padding-bottom: 0.95rem;
+    }
+
+    .fi-body.fi-panel-ops .fi-ta-content {
+        border-top: 1px solid var(--ops-border-default);
+    }
+
+    .fi-body.fi-panel-ops .fi-ta-pagination,
+    .fi-body.fi-panel-ops .fi-ta-filters-below-content,
+    .fi-body.fi-panel-ops .fi-ta-filters-above-content-ctn {
+        border-top: 1px solid var(--ops-border-default);
     }
 
     .fi-body.fi-panel-ops .fi-ta-row:hover,
@@ -339,13 +448,17 @@
         letter-spacing: 0.01em;
     }
 
-    .ops-auth-intro {
+    .ops-shell-hero {
         display: grid;
         gap: 0.75rem;
-        margin-bottom: 1.25rem;
     }
 
-    .ops-auth-intro__eyebrow {
+    .ops-shell-hero__body {
+        display: grid;
+        gap: 0.35rem;
+    }
+
+    .ops-shell-eyebrow {
         display: inline-flex;
         width: fit-content;
         align-items: center;
@@ -359,35 +472,134 @@
         text-transform: uppercase;
     }
 
-    .ops-auth-intro__title {
+    .ops-shell-title {
         color: var(--ops-text-primary);
         font-size: 1.625rem;
         font-weight: 700;
         letter-spacing: -0.04em;
     }
 
-    .ops-auth-intro__meta {
-        margin-top: 0.35rem;
+    .ops-shell-meta {
         color: var(--ops-text-secondary);
         font-size: 0.95rem;
         line-height: 1.65;
     }
 
-    .ops-topbar-chip {
+    .ops-auth-intro {
+        margin-bottom: 1.25rem;
+    }
+
+    .ops-shell-inline-intro {
+        display: grid;
+        gap: 0.35rem;
+        margin-bottom: 0.85rem;
+    }
+
+    .ops-shell-inline-intro__eyebrow {
+        color: var(--ops-text-tertiary);
+        font-size: 0.6875rem;
+        font-weight: 700;
+        letter-spacing: 0.12em;
+        text-transform: uppercase;
+    }
+
+    .ops-shell-inline-intro__meta {
+        color: var(--ops-text-secondary);
+        font-size: 0.9375rem;
+        line-height: 1.6;
+    }
+
+    .ops-shell-callout {
+        border-radius: 14px;
+        padding: 0.9rem 1rem;
+        font-size: 0.9375rem;
+        line-height: 1.6;
+    }
+
+    .ops-shell-callout--warning {
+        background: rgba(245, 158, 11, 0.08);
+        color: #92400e;
+        box-shadow: inset 0 0 0 1px rgba(245, 158, 11, 0.18);
+    }
+
+    .ops-topbar-context {
+        align-items: center;
+        gap: 0.9rem;
+        min-width: 0;
+        padding-inline-end: 0.35rem;
+    }
+
+    .ops-topbar-context__eyebrow {
+        display: inline-flex;
+        align-items: center;
+        border-radius: var(--ops-radius-badge);
+        background: rgba(var(--primary-50), 0.95);
+        color: rgb(var(--primary-700));
+        padding: 0.35rem 0.7rem;
+        font-size: 0.6875rem;
+        font-weight: 700;
+        letter-spacing: 0.12em;
+        text-transform: uppercase;
+    }
+
+    .ops-topbar-context__body {
+        display: grid;
+        gap: 0.15rem;
+    }
+
+    .ops-topbar-context__title {
+        color: var(--ops-text-primary);
+        font-size: 0.95rem;
+        font-weight: 700;
+        letter-spacing: -0.03em;
+    }
+
+    .ops-topbar-context__meta {
+        color: var(--ops-text-secondary);
+        font-size: 0.75rem;
+        font-weight: 500;
+    }
+
+    .ops-topbar-controls {
         display: inline-flex;
         align-items: center;
         gap: 0.75rem;
+        padding-inline-start: 0.9rem;
+        margin-inline-start: 0.15rem;
+        border-inline-start: 1px solid rgba(209, 213, 219, 0.85);
+    }
+
+    .ops-topbar-controls__item {
+        display: inline-flex;
+        align-items: center;
+    }
+
+    .ops-topbar-chip {
+        display: inline-flex;
+        align-items: center;
+        gap: 0.625rem;
         border-radius: var(--ops-radius-badge);
         background: rgba(255, 255, 255, 0.88);
-        padding: 0.375rem 0.45rem 0.375rem 0.75rem;
+        padding: 0.35rem 0.4rem 0.35rem 0.55rem;
         box-shadow: inset 0 0 0 1px var(--ops-border-default);
     }
 
-    .ops-topbar-chip__text {
-        display: flex;
+    .ops-topbar-chip__icon {
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        flex-shrink: 0;
+        height: 2rem;
+        width: 2rem;
+        border-radius: 999px;
+        background: rgba(var(--primary-50), 0.92);
+        color: rgb(var(--primary-700));
+    }
+
+    .ops-topbar-chip__stack {
+        display: grid;
         min-width: 0;
-        align-items: baseline;
-        gap: 0.45rem;
+        gap: 0.1rem;
     }
 
     .ops-topbar-chip__label {
@@ -408,14 +620,123 @@
         white-space: nowrap;
     }
 
-    .ops-topbar-locale {
-        display: flex;
+    .ops-topbar-chip__action.fi-btn {
+        min-height: 2.25rem;
+        border-radius: 999px;
+        padding-inline: 0.8rem;
+    }
+
+    .fi-body.fi-panel-ops .fi-global-search {
+        min-width: min(100%, 19rem);
+    }
+
+    .fi-body.fi-panel-ops .fi-global-search .fi-input-wrp {
+        min-height: 2.75rem;
+        background: rgba(255, 255, 255, 0.92);
+    }
+
+    .fi-body.fi-panel-ops .fi-global-search-results-ctn {
+        border-radius: var(--ops-radius-overlay);
+        box-shadow: var(--ops-shadow-overlay);
+    }
+
+    .fi-body.fi-panel-ops .fi-user-menu > button,
+    .fi-body.fi-panel-ops .fi-topbar-database-notifications-btn {
+        display: inline-flex;
         align-items: center;
+        justify-content: center;
+        min-height: 2.75rem;
+        min-width: 2.75rem;
+        border-radius: 999px;
+        background: rgba(255, 255, 255, 0.92);
+        box-shadow: inset 0 0 0 1px var(--ops-border-default);
+    }
+
+    .fi-body.fi-panel-ops .fi-user-menu .fi-avatar {
+        height: 2rem;
+        width: 2rem;
+    }
+
+    .ops-sidebar-footer {
+        display: grid;
+        gap: 0.45rem;
+        margin: 0 1.25rem 1.25rem;
+        padding: 1rem;
+        background: rgba(255, 255, 255, 0.92);
+        border: 1px solid rgba(229, 231, 235, 0.92);
+        border-radius: calc(var(--ops-radius-card) + 2px);
+        box-shadow: var(--ops-shadow-surface);
+    }
+
+    .ops-sidebar-footer__eyebrow {
+        color: var(--ops-text-tertiary);
+        font-size: 0.6875rem;
+        font-weight: 700;
+        letter-spacing: 0.12em;
+        text-transform: uppercase;
+    }
+
+    .ops-sidebar-footer__title {
+        color: var(--ops-text-primary);
+        font-size: 0.95rem;
+        font-weight: 700;
+        letter-spacing: -0.025em;
+    }
+
+    .ops-sidebar-footer__meta {
+        color: var(--ops-text-secondary);
+        font-size: 0.8125rem;
+        line-height: 1.55;
+    }
+
+    .ops-shell-page {
+        display: grid;
+        gap: 1rem;
+    }
+
+    .ops-select-org-actions {
+        justify-content: flex-end;
+        flex-wrap: wrap;
+    }
+
+    .ops-select-org-row {
+        gap: 0.95rem;
+    }
+
+    .ops-select-org-row__title {
+        color: var(--ops-text-primary);
+        font-size: 1rem;
+        font-weight: 700;
+        letter-spacing: -0.02em;
+    }
+
+    .ops-select-org-row__meta {
+        color: var(--ops-text-tertiary);
+        font-size: 0.75rem;
+        font-weight: 600;
+        letter-spacing: 0.04em;
+        text-transform: uppercase;
+    }
+
+    .ops-select-org-row__value {
+        color: var(--ops-text-primary);
+        font-size: 0.9375rem;
+        font-weight: 600;
+    }
+
+    .ops-two-factor-stack {
+        display: grid;
+        gap: 0.9rem;
+    }
+
+    .ops-two-factor-stack .fi-btn {
+        width: fit-content;
     }
 }
 
 @media (max-width: 1023px) {
     .fi-body.fi-panel-ops .fi-main {
+        padding-top: 1rem;
         padding-bottom: 1.5rem;
     }
 
@@ -423,6 +744,26 @@
         margin-top: 4rem;
         margin-bottom: 4rem;
         padding: 2rem 1.5rem;
+    }
+
+    .ops-topbar-controls {
+        padding-inline-start: 0;
+        margin-inline-start: 0;
+        border-inline-start: none;
+    }
+
+    .ops-topbar-chip {
+        gap: 0.45rem;
+        padding: 0.25rem 0.3rem 0.25rem 0.4rem;
+    }
+
+    .ops-topbar-chip__icon {
+        height: 1.75rem;
+        width: 1.75rem;
+    }
+
+    .ops-topbar-chip__label {
+        display: none;
     }
 
     .ops-topbar-chip__value {

--- a/backend/resources/views/filament/ops/hooks/login-intro.blade.php
+++ b/backend/resources/views/filament/ops/hooks/login-intro.blade.php
@@ -1,9 +1,9 @@
-<div class="ops-auth-intro">
-    <span class="ops-auth-intro__eyebrow">Fermat Ops</span>
+<div class="ops-shell-hero ops-auth-intro">
+    <span class="ops-shell-eyebrow">Fermat Ops</span>
 
-    <div>
-        <h2 class="ops-auth-intro__title">Operations console</h2>
-        <p class="ops-auth-intro__meta">
+    <div class="ops-shell-hero__body">
+        <h2 class="ops-shell-title">Operations console</h2>
+        <p class="ops-shell-meta">
             Sign in with your admin account to manage content, commerce, and runtime operations.
         </p>
     </div>

--- a/backend/resources/views/filament/ops/hooks/sidebar-footer.blade.php
+++ b/backend/resources/views/filament/ops/hooks/sidebar-footer.blade.php
@@ -1,0 +1,7 @@
+<div class="ops-sidebar-footer">
+    <span class="ops-sidebar-footer__eyebrow">Fermat Ops</span>
+    <p class="ops-sidebar-footer__title">Control plane</p>
+    <p class="ops-sidebar-footer__meta">
+        Content, commerce, governance, and runtime operations share the same shell.
+    </p>
+</div>

--- a/backend/resources/views/filament/ops/hooks/topbar-context.blade.php
+++ b/backend/resources/views/filament/ops/hooks/topbar-context.blade.php
@@ -1,0 +1,39 @@
+@php
+    $routeName = (string) request()->route()?->getName();
+
+    $sectionLabel = match (true) {
+        str_contains($routeName, 'article'),
+        str_contains($routeName, 'content-pack'),
+        str_contains($routeName, 'scale-registry'),
+        str_contains($routeName, 'scale-slug') => __('ops.group.content'),
+        str_contains($routeName, 'order'),
+        str_contains($routeName, 'payment'),
+        str_contains($routeName, 'benefit'),
+        str_contains($routeName, 'sku') => __('ops.group.commerce'),
+        str_contains($routeName, 'organization'),
+        str_contains($routeName, 'role'),
+        str_contains($routeName, 'permission'),
+        str_contains($routeName, 'admin-user') => __('ops.group.admin'),
+        str_contains($routeName, 'approval'),
+        str_contains($routeName, 'go-live') => __('ops.group.governance'),
+        str_contains($routeName, 'queue'),
+        str_contains($routeName, 'health'),
+        str_contains($routeName, 'webhook') => __('ops.group.sre'),
+        str_contains($routeName, 'audit'),
+        str_contains($routeName, 'deploy') => __('ops.group.observability'),
+        str_contains($routeName, 'global-search'),
+        str_contains($routeName, 'order-lookup'),
+        str_contains($routeName, 'delivery-tools'),
+        str_contains($routeName, 'secure-link') => __('ops.group.support'),
+        default => __('ops.nav.dashboard'),
+    };
+@endphp
+
+<div class="ops-topbar-context hidden lg:flex">
+    <span class="ops-topbar-context__eyebrow">{{ $sectionLabel }}</span>
+
+    <div class="ops-topbar-context__body">
+        <span class="ops-topbar-context__title">Fermat Ops</span>
+        <span class="ops-topbar-context__meta">Operations shell</span>
+    </div>
+</div>

--- a/backend/resources/views/filament/ops/hooks/topbar-controls.blade.php
+++ b/backend/resources/views/filament/ops/hooks/topbar-controls.blade.php
@@ -1,0 +1,4 @@
+<div class="ops-topbar-controls">
+    @include('filament.ops.livewire.current-org-switcher-hook')
+    @include('filament.ops.livewire.locale-switcher-hook')
+</div>

--- a/backend/resources/views/filament/ops/livewire/current-org-switcher-hook.blade.php
+++ b/backend/resources/views/filament/ops/livewire/current-org-switcher-hook.blade.php
@@ -1,3 +1,3 @@
-<div class="px-2">
+<div class="ops-topbar-controls__item">
     @livewire('filament.ops.livewire.current-org-switcher')
 </div>

--- a/backend/resources/views/filament/ops/livewire/locale-switcher-hook.blade.php
+++ b/backend/resources/views/filament/ops/livewire/locale-switcher-hook.blade.php
@@ -1,2 +1,3 @@
-@livewire('filament.ops.livewire.locale-switcher')
-
+<div class="ops-topbar-controls__item">
+    @livewire('filament.ops.livewire.locale-switcher')
+</div>

--- a/backend/resources/views/filament/ops/pages/select-org-page.blade.php
+++ b/backend/resources/views/filament/ops/pages/select-org-page.blade.php
@@ -1,8 +1,8 @@
 <x-filament-panels::page>
-    <div class="ops-select-org-page space-y-6">
+    <div class="ops-shell-page ops-select-org-page space-y-6">
         @if (session()->has('ops_org_required_message'))
             <x-filament::section>
-                <p class="text-sm text-warning-700">
+                <p class="ops-shell-callout ops-shell-callout--warning">
                     {{ (string) session('ops_org_required_message') }}
                 </p>
             </x-filament::section>
@@ -11,6 +11,13 @@
         <x-filament::section>
             <div class="ops-select-org-toolbar grid gap-4 md:grid-cols-3">
                 <div class="md:col-span-2">
+                    <div class="ops-shell-inline-intro">
+                        <span class="ops-shell-inline-intro__eyebrow">Workspace scope</span>
+                        <p class="ops-shell-inline-intro__meta">
+                            Choose the organization context before editing content, reviewing commerce, or running runtime workflows.
+                        </p>
+                    </div>
+
                     <label class="block text-sm font-medium text-gray-700" for="ops-org-search">Search organizations</label>
                     <input
                         id="ops-org-search"
@@ -20,7 +27,7 @@
                         class="mt-1 block w-full rounded-lg border-gray-300 shadow-sm focus:border-primary-500 focus:ring-primary-500"
                     />
                 </div>
-                <div class="flex items-end gap-2">
+                <div class="ops-select-org-actions flex items-end gap-2">
                     @if ($this->canCreateOrganization())
                         <x-filament::button color="primary" wire:click="createOrganization">
                             Create Organization
@@ -37,22 +44,22 @@
             @forelse ($organizations as $organization)
                 <x-filament::section>
                     <div class="ops-select-org-row grid gap-3 md:grid-cols-6 md:items-center">
-                        <div class="md:col-span-2">
-                            <p class="text-sm font-semibold text-gray-900">{{ $organization['name'] }}</p>
-                            <p class="text-xs text-gray-500">org id: {{ $organization['id'] }}</p>
+                        <div class="ops-select-org-row__primary md:col-span-2">
+                            <p class="ops-select-org-row__title">{{ $organization['name'] }}</p>
+                            <p class="ops-select-org-row__meta">org id: {{ $organization['id'] }}</p>
                         </div>
                         <div>
-                            <p class="text-xs text-gray-500">status</p>
-                            <p class="text-sm font-medium">{{ $organization['status'] }}</p>
+                            <p class="ops-select-org-row__meta">status</p>
+                            <p class="ops-select-org-row__value">{{ $organization['status'] }}</p>
                         </div>
                         <div>
-                            <p class="text-xs text-gray-500">domain</p>
-                            <p class="text-sm font-medium">{{ $organization['domain'] ?: '-' }}</p>
+                            <p class="ops-select-org-row__meta">domain</p>
+                            <p class="ops-select-org-row__value">{{ $organization['domain'] ?: '-' }}</p>
                         </div>
-                        <div class="md:col-span-2 flex items-center justify-between gap-2">
+                        <div class="ops-select-org-row__actions md:col-span-2 flex items-center justify-between gap-2">
                             <div>
-                                <p class="text-xs text-gray-500">updated_at</p>
-                                <p class="text-sm font-medium">{{ $organization['updated_at'] !== '' ? $organization['updated_at'] : '-' }}</p>
+                                <p class="ops-select-org-row__meta">updated_at</p>
+                                <p class="ops-select-org-row__value">{{ $organization['updated_at'] !== '' ? $organization['updated_at'] : '-' }}</p>
                             </div>
 
                             <x-filament::button color="primary" wire:click="selectOrg({{ $organization['id'] }})">
@@ -65,8 +72,8 @@
                 <x-filament::section>
                     <div class="ops-select-org-empty space-y-4">
                         <div>
-                            <p class="text-base font-semibold text-gray-900">No organizations found</p>
-                            <p class="text-sm text-gray-600">{{ $this->whyVisibleHint() }}</p>
+                            <p class="ops-select-org-row__title">No organizations found</p>
+                            <p class="ops-shell-inline-intro__meta">{{ $this->whyVisibleHint() }}</p>
                         </div>
 
                         <div class="flex flex-wrap gap-2">

--- a/backend/resources/views/filament/ops/pages/two-factor-challenge.blade.php
+++ b/backend/resources/views/filament/ops/pages/two-factor-challenge.blade.php
@@ -1,8 +1,9 @@
 <x-filament-panels::page>
     <x-filament::section>
-        <div class="ops-two-factor-stack max-w-md space-y-3">
-            <h3 class="text-lg font-semibold text-gray-900">Two-Factor Authentication</h3>
-            <p class="text-sm text-gray-600">Enter your authenticator code or one-time recovery code.</p>
+        <div class="ops-two-factor-stack max-w-md space-y-4">
+            <p class="ops-shell-inline-intro__meta">
+                Confirm your admin session with an authenticator code or one-time recovery code.
+            </p>
 
             <div>
                 <label class="block text-sm font-medium text-gray-700" for="totp-code">Verification code</label>

--- a/backend/resources/views/livewire/filament/ops/livewire/current-org-switcher.blade.php
+++ b/backend/resources/views/livewire/filament/ops/livewire/current-org-switcher.blade.php
@@ -1,5 +1,12 @@
-<div class="ops-topbar-chip">
-    <div class="ops-topbar-chip__text">
+<div class="ops-topbar-chip ops-topbar-chip--org">
+    <span class="ops-topbar-chip__icon">
+        <x-filament::icon
+            icon="heroicon-m-building-office-2"
+            class="h-4 w-4"
+        />
+    </span>
+
+    <div class="ops-topbar-chip__stack">
         <span class="ops-topbar-chip__label">
             {{ __('ops.topbar.current_org') }}
         </span>
@@ -12,6 +19,7 @@
         type="button"
         size="sm"
         color="gray"
+        class="ops-topbar-chip__action"
         wire:click="goSelectOrg"
     >
         {{ $orgId ? __('ops.topbar.switch_org') : __('ops.topbar.select_org') }}

--- a/backend/resources/views/livewire/filament/ops/livewire/locale-switcher.blade.php
+++ b/backend/resources/views/livewire/filament/ops/livewire/locale-switcher.blade.php
@@ -1,8 +1,34 @@
-<div class="ops-topbar-locale">
+@php
+    $localeLabel = $locales[$locale] ?? __('ops.locale.switcher_label');
+    $localeCode = strtoupper(str_replace('_', '-', $locale));
+@endphp
+
+<div class="ops-topbar-chip ops-topbar-chip--locale">
+    <span class="ops-topbar-chip__icon">
+        <x-filament::icon
+            icon="heroicon-m-language"
+            class="h-4 w-4"
+        />
+    </span>
+
+    <div class="ops-topbar-chip__stack">
+        <span class="ops-topbar-chip__label">
+            {{ __('ops.locale.switcher_label') }}
+        </span>
+        <span class="ops-topbar-chip__value">
+            {{ $localeLabel }}
+        </span>
+    </div>
+
     <x-filament::dropdown placement="bottom-end">
         <x-slot name="trigger">
-            <x-filament::button color="gray" size="sm" icon="heroicon-m-language">
-                {{ $locales[$locale] ?? __('ops.locale.switcher_label') }}
+            <x-filament::button
+                color="gray"
+                size="sm"
+                icon="heroicon-m-chevron-up-down"
+                class="ops-topbar-chip__action"
+            >
+                {{ $localeCode }}
             </x-filament::button>
         </x-slot>
 


### PR DESCRIPTION
## Summary
- upgrade the Filament Ops shell on top of the existing theme foundation
- improve sidebar, topbar, page header, and page chrome without changing information architecture or business logic

## What changed
- refine sidebar grouping, active states, spacing, and footer chrome
- improve topbar composition and present current org / locale in a shared chip language
- unify page header hierarchy, breadcrumb weight, and action alignment
- add a more consistent content chrome for list, dashboard, and auth-related pages
- align login, TOTP, and select-org pages with the Ops UI 2.0 shell language

## Implementation approach
- reused the existing custom Filament theme foundation from PR-01
- used panel config, custom theme CSS, and lightweight render-hook views instead of publishing vendor views
- kept resources, APIs, RBAC, routes, and CMS logic unchanged

## Why this PR is small and safe
- no database changes
- no API changes
- no route changes
- no permissions changes
- no resource field logic changes
- only shell/chrome-level UI improvements

## Validation
- `cd backend && php artisan about`
- `cd backend && php artisan route:list --path=ops --except-vendor`
- `cd backend && php artisan route:list`
- `cd backend && php artisan migrate`
- `cd backend && php artisan filament:assets`
- `cd backend && npm run build`
- checked `/ops/login`, `/ops`, `/ops/articles`, `/ops/article-categories`, `/ops/article-tags`, `/ops/select-org`, `/ops/two-factor-challenge`
- `bash backend/scripts/ci_verify_mbti.sh`
