### PR TITLE
feat(ops-ui): unify shared components and interaction states

### DIFF
--- a/backend/app/Filament/Ops/Resources/AdminApprovalResource.php
+++ b/backend/app/Filament/Ops/Resources/AdminApprovalResource.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Filament\Ops\Resources;
 
 use App\Filament\Ops\Resources\AdminApprovalResource\Pages;
+use App\Filament\Ops\Support\StatusBadge;
 use App\Filament\Shared\BaseTenantResource;
 use App\Jobs\ExecuteApprovalJob;
 use App\Models\AdminApproval;
@@ -45,7 +46,7 @@ class AdminApprovalResource extends BaseTenantResource
         return $count > 0 ? (string) $count : null;
     }
 
-    public static function getNavigationBadgeColor(): string | array | null
+    public static function getNavigationBadgeColor(): string|array|null
     {
         return 'warning';
     }
@@ -70,7 +71,10 @@ class AdminApprovalResource extends BaseTenantResource
         return $table
             ->columns([
                 Tables\Columns\TextColumn::make('type')->badge(),
-                Tables\Columns\TextColumn::make('status')->badge()->sortable(),
+                Tables\Columns\TextColumn::make('status')
+                    ->badge()
+                    ->color(fn (string $state): string => StatusBadge::color($state))
+                    ->sortable(),
                 Tables\Columns\TextColumn::make('requested_by_admin_user_id')->label('Requested By'),
                 Tables\Columns\TextColumn::make('approved_by_admin_user_id')->label('Approved By'),
                 Tables\Columns\TextColumn::make('reason')->limit(60)->tooltip(fn (AdminApproval $record): string => (string) $record->reason),

--- a/backend/app/Filament/Ops/Resources/ArticleCategoryResource.php
+++ b/backend/app/Filament/Ops/Resources/ArticleCategoryResource.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Filament\Ops\Resources;
 
 use App\Filament\Ops\Resources\ArticleCategoryResource\Pages;
+use App\Filament\Ops\Support\StatusBadge;
 use App\Models\ArticleCategory;
 use App\Support\OrgContext;
 use App\Support\Rbac\PermissionNames;
@@ -15,7 +16,6 @@ use Filament\Forms\Components\Toggle;
 use Filament\Forms\Form;
 use Filament\Resources\Resource;
 use Filament\Tables;
-use Filament\Tables\Columns\IconColumn;
 use Filament\Tables\Columns\TextColumn;
 use Filament\Tables\Filters\TernaryFilter;
 use Filament\Tables\Table;
@@ -94,8 +94,11 @@ class ArticleCategoryResource extends Resource
                 TextColumn::make('slug')
                     ->searchable()
                     ->copyable(),
-                IconColumn::make('is_active')
-                    ->boolean()
+                TextColumn::make('is_active')
+                    ->label('Status')
+                    ->formatStateUsing(fn (bool|int|string|null $state): string => StatusBadge::booleanLabel($state, 'active', 'inactive'))
+                    ->badge()
+                    ->color(fn (bool|int|string|null $state): string => StatusBadge::booleanColor($state))
                     ->sortable(),
                 TextColumn::make('sort_order')
                     ->sortable(),
@@ -104,7 +107,8 @@ class ArticleCategoryResource extends Resource
                     ->sortable(),
             ])
             ->filters([
-                TernaryFilter::make('is_active'),
+                TernaryFilter::make('is_active')
+                    ->label('Status'),
             ])
             ->defaultSort('sort_order', 'asc')
             ->actions([

--- a/backend/app/Filament/Ops/Resources/ArticleCategoryResource/Pages/ListArticleCategories.php
+++ b/backend/app/Filament/Ops/Resources/ArticleCategoryResource/Pages/ListArticleCategories.php
@@ -5,11 +5,14 @@ declare(strict_types=1);
 namespace App\Filament\Ops\Resources\ArticleCategoryResource\Pages;
 
 use App\Filament\Ops\Resources\ArticleCategoryResource;
+use App\Filament\Ops\Resources\Pages\Concerns\HasSharedListEmptyState;
 use Filament\Actions;
 use Filament\Resources\Pages\ListRecords;
 
 class ListArticleCategories extends ListRecords
 {
+    use HasSharedListEmptyState;
+
     protected static string $resource = ArticleCategoryResource::class;
 
     protected function getHeaderActions(): array

--- a/backend/app/Filament/Ops/Resources/ArticleResource.php
+++ b/backend/app/Filament/Ops/Resources/ArticleResource.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Filament\Ops\Resources;
 
 use App\Filament\Ops\Resources\ArticleResource\Pages;
+use App\Filament\Ops\Support\StatusBadge;
 use App\Models\Article;
 use App\Support\OrgContext;
 use App\Support\Rbac\PermissionNames;
@@ -159,7 +160,7 @@ class ArticleResource extends Resource
                 Tables\Columns\TextColumn::make('status')
                     ->badge()
                     ->sortable()
-                    ->color(fn (string $state): string => $state === 'published' ? 'success' : 'gray'),
+                    ->color(fn (string $state): string => StatusBadge::color($state)),
                 Tables\Columns\TextColumn::make('locale')
                     ->sortable(),
                 Tables\Columns\TextColumn::make('published_at')

--- a/backend/app/Filament/Ops/Resources/ArticleResource/Pages/ListArticles.php
+++ b/backend/app/Filament/Ops/Resources/ArticleResource/Pages/ListArticles.php
@@ -5,11 +5,14 @@ declare(strict_types=1);
 namespace App\Filament\Ops\Resources\ArticleResource\Pages;
 
 use App\Filament\Ops\Resources\ArticleResource;
+use App\Filament\Ops\Resources\Pages\Concerns\HasSharedListEmptyState;
 use Filament\Actions;
 use Filament\Resources\Pages\ListRecords;
 
 class ListArticles extends ListRecords
 {
+    use HasSharedListEmptyState;
+
     protected static string $resource = ArticleResource::class;
 
     protected function getHeaderActions(): array

--- a/backend/app/Filament/Ops/Resources/ArticleTagResource.php
+++ b/backend/app/Filament/Ops/Resources/ArticleTagResource.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Filament\Ops\Resources;
 
 use App\Filament\Ops\Resources\ArticleTagResource\Pages;
+use App\Filament\Ops\Support\StatusBadge;
 use App\Models\ArticleTag;
 use App\Support\OrgContext;
 use App\Support\Rbac\PermissionNames;
@@ -14,7 +15,6 @@ use Filament\Forms\Components\Toggle;
 use Filament\Forms\Form;
 use Filament\Resources\Resource;
 use Filament\Tables;
-use Filament\Tables\Columns\IconColumn;
 use Filament\Tables\Columns\TextColumn;
 use Filament\Tables\Filters\TernaryFilter;
 use Filament\Tables\Table;
@@ -88,15 +88,19 @@ class ArticleTagResource extends Resource
                 TextColumn::make('slug')
                     ->searchable()
                     ->copyable(),
-                IconColumn::make('is_active')
-                    ->boolean()
+                TextColumn::make('is_active')
+                    ->label('Status')
+                    ->formatStateUsing(fn (bool|int|string|null $state): string => StatusBadge::booleanLabel($state, 'active', 'inactive'))
+                    ->badge()
+                    ->color(fn (bool|int|string|null $state): string => StatusBadge::booleanColor($state))
                     ->sortable(),
                 TextColumn::make('updated_at')
                     ->dateTime()
                     ->sortable(),
             ])
             ->filters([
-                TernaryFilter::make('is_active'),
+                TernaryFilter::make('is_active')
+                    ->label('Status'),
             ])
             ->actions([
                 Tables\Actions\EditAction::make(),

--- a/backend/app/Filament/Ops/Resources/ArticleTagResource/Pages/ListArticleTags.php
+++ b/backend/app/Filament/Ops/Resources/ArticleTagResource/Pages/ListArticleTags.php
@@ -5,11 +5,14 @@ declare(strict_types=1);
 namespace App\Filament\Ops\Resources\ArticleTagResource\Pages;
 
 use App\Filament\Ops\Resources\ArticleTagResource;
+use App\Filament\Ops\Resources\Pages\Concerns\HasSharedListEmptyState;
 use Filament\Actions;
 use Filament\Resources\Pages\ListRecords;
 
 class ListArticleTags extends ListRecords
 {
+    use HasSharedListEmptyState;
+
     protected static string $resource = ArticleTagResource::class;
 
     protected function getHeaderActions(): array

--- a/backend/app/Filament/Ops/Resources/AuditLogResource.php
+++ b/backend/app/Filament/Ops/Resources/AuditLogResource.php
@@ -2,8 +2,9 @@
 
 namespace App\Filament\Ops\Resources;
 
-use App\Filament\Shared\BaseTenantResource;
 use App\Filament\Ops\Resources\AuditLogResource\Pages;
+use App\Filament\Ops\Support\StatusBadge;
+use App\Filament\Shared\BaseTenantResource;
 use App\Models\AuditLog;
 use App\Support\Rbac\PermissionNames;
 use Filament\Forms;
@@ -18,7 +19,9 @@ class AuditLogResource extends BaseTenantResource
     protected static ?string $model = AuditLog::class;
 
     protected static ?string $navigationIcon = 'heroicon-o-clipboard-document-list';
+
     protected static ?string $navigationGroup = 'Observability';
+
     protected static ?string $navigationLabel = 'Audit Logs';
 
     private static function scopedQuery(): Builder
@@ -68,7 +71,10 @@ class AuditLogResource extends BaseTenantResource
                 Tables\Columns\TextColumn::make('ip')->toggleable(),
                 Tables\Columns\TextColumn::make('request_id')->toggleable(),
                 Tables\Columns\TextColumn::make('reason')->toggleable(),
-                Tables\Columns\TextColumn::make('result')->badge()->toggleable(),
+                Tables\Columns\TextColumn::make('result')
+                    ->badge()
+                    ->color(fn (?string $state): string => StatusBadge::color($state))
+                    ->toggleable(),
                 Tables\Columns\TextColumn::make('created_at')->dateTime()->sortable(),
             ])
             ->filters([
@@ -105,11 +111,11 @@ class AuditLogResource extends BaseTenantResource
                         Forms\Components\DatePicker::make('date_to')->label('To'),
                     ])
                     ->query(function ($query, array $data) {
-                        if (!empty($data['date_from'])) {
+                        if (! empty($data['date_from'])) {
                             $from = Carbon::parse((string) $data['date_from'])->startOfDay();
                             $query->where('created_at', '>=', $from);
                         }
-                        if (!empty($data['date_to'])) {
+                        if (! empty($data['date_to'])) {
                             $toExclusive = Carbon::parse((string) $data['date_to'])->addDay()->startOfDay();
                             $query->where('created_at', '<', $toExclusive);
                         }
@@ -169,11 +175,11 @@ class AuditLogResource extends BaseTenantResource
                             $query->where('actor_admin_id', $actorAdminId);
                         }
 
-                        if (!empty($data['date_from'])) {
+                        if (! empty($data['date_from'])) {
                             $from = Carbon::parse((string) $data['date_from'])->startOfDay();
                             $query->where('created_at', '>=', $from);
                         }
-                        if (!empty($data['date_to'])) {
+                        if (! empty($data['date_to'])) {
                             $toExclusive = Carbon::parse((string) $data['date_to'])->addDay()->startOfDay();
                             $query->where('created_at', '<', $toExclusive);
                         }
@@ -218,7 +224,8 @@ class AuditLogResource extends BaseTenantResource
                     ->label('Meta')
                     ->modalContent(function (AuditLog $record) {
                         $json = json_encode($record->meta_json, JSON_PRETTY_PRINT | JSON_UNESCAPED_UNICODE);
-                        return new \Illuminate\Support\HtmlString('<pre style="white-space: pre-wrap;">' . e($json) . '</pre>');
+
+                        return new \Illuminate\Support\HtmlString('<pre style="white-space: pre-wrap;">'.e($json).'</pre>');
                     })
                     ->modalHeading('Meta JSON'),
             ])

--- a/backend/app/Filament/Ops/Resources/BenefitGrantResource.php
+++ b/backend/app/Filament/Ops/Resources/BenefitGrantResource.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Filament\Ops\Resources;
 
 use App\Filament\Ops\Resources\BenefitGrantResource\Pages;
+use App\Filament\Ops\Support\StatusBadge;
 use App\Filament\Shared\BaseTenantResource;
 use App\Models\AdminApproval;
 use App\Models\BenefitGrant;
@@ -15,7 +16,6 @@ use Filament\Forms\Form;
 use Filament\Notifications\Notification;
 use Filament\Tables;
 use Filament\Tables\Table;
-use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Str;
 
 class BenefitGrantResource extends BaseTenantResource
@@ -55,7 +55,10 @@ class BenefitGrantResource extends BaseTenantResource
                 Tables\Columns\TextColumn::make('order_no')->searchable()->copyable(),
                 Tables\Columns\TextColumn::make('attempt_id')->searchable()->copyable(),
                 Tables\Columns\TextColumn::make('benefit_code')->sortable(),
-                Tables\Columns\TextColumn::make('status')->badge()->sortable(),
+                Tables\Columns\TextColumn::make('status')
+                    ->badge()
+                    ->color(fn (string $state): string => StatusBadge::color($state))
+                    ->sortable(),
                 Tables\Columns\TextColumn::make('user_id')->toggleable(),
                 Tables\Columns\TextColumn::make('expires_at')->dateTime()->toggleable(),
                 Tables\Columns\TextColumn::make('created_at')->dateTime()->sortable(),

--- a/backend/app/Filament/Ops/Resources/ContentPackReleaseResource.php
+++ b/backend/app/Filament/Ops/Resources/ContentPackReleaseResource.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Filament\Ops\Resources;
 
 use App\Filament\Ops\Resources\ContentPackReleaseResource\Pages;
+use App\Filament\Ops\Support\StatusBadge;
 use App\Jobs\Content\RunContentProbeJob;
 use App\Models\AdminApproval;
 use App\Models\ContentPackRelease;
@@ -68,7 +69,10 @@ class ContentPackReleaseResource extends Resource
                 Tables\Columns\TextColumn::make('dir_alias')->searchable(),
                 Tables\Columns\TextColumn::make('from_pack_id')->label('From Pack')->toggleable(),
                 Tables\Columns\TextColumn::make('to_pack_id')->label('To Pack')->toggleable(),
-                Tables\Columns\TextColumn::make('status')->badge()->sortable(),
+                Tables\Columns\TextColumn::make('status')
+                    ->badge()
+                    ->color(fn (string $state): string => StatusBadge::color($state))
+                    ->sortable(),
                 Tables\Columns\IconColumn::make('probe_ok')->boolean()->label('Probe OK'),
                 Tables\Columns\TextColumn::make('probe_run_at')->dateTime()->toggleable(),
                 Tables\Columns\TextColumn::make('created_at')->dateTime()->sortable(),

--- a/backend/app/Filament/Ops/Resources/OrderResource.php
+++ b/backend/app/Filament/Ops/Resources/OrderResource.php
@@ -7,6 +7,7 @@ namespace App\Filament\Ops\Resources;
 use App\Filament\Ops\Resources\OrderResource\Pages;
 use App\Filament\Ops\Resources\OrderResource\RelationManagers\BenefitGrantsRelationManager;
 use App\Filament\Ops\Resources\OrderResource\RelationManagers\PaymentEventsRelationManager;
+use App\Filament\Ops\Support\StatusBadge;
 use App\Filament\Shared\BaseTenantResource;
 use App\Models\AdminApproval;
 use App\Models\Order;
@@ -17,7 +18,6 @@ use Filament\Forms\Form;
 use Filament\Notifications\Notification;
 use Filament\Tables;
 use Filament\Tables\Table;
-use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Str;
 
 class OrderResource extends BaseTenantResource
@@ -55,7 +55,10 @@ class OrderResource extends BaseTenantResource
         return $table
             ->columns([
                 Tables\Columns\TextColumn::make('order_no')->searchable()->copyable(),
-                Tables\Columns\TextColumn::make('status')->badge()->sortable(),
+                Tables\Columns\TextColumn::make('status')
+                    ->badge()
+                    ->color(fn (string $state): string => StatusBadge::color($state))
+                    ->sortable(),
                 Tables\Columns\TextColumn::make('provider')->sortable(),
                 Tables\Columns\TextColumn::make('amount_cents')->label('Amount')->numeric()->sortable(),
                 Tables\Columns\TextColumn::make('currency')->sortable(),

--- a/backend/app/Filament/Ops/Resources/OrderResource/Pages/ListOrders.php
+++ b/backend/app/Filament/Ops/Resources/OrderResource/Pages/ListOrders.php
@@ -5,10 +5,13 @@ declare(strict_types=1);
 namespace App\Filament\Ops\Resources\OrderResource\Pages;
 
 use App\Filament\Ops\Resources\OrderResource;
+use App\Filament\Ops\Resources\Pages\Concerns\HasSharedListEmptyState;
 use Filament\Resources\Pages\ListRecords;
 
 class ListOrders extends ListRecords
 {
+    use HasSharedListEmptyState;
+
     protected static string $resource = OrderResource::class;
 
     protected function getHeaderActions(): array

--- a/backend/app/Filament/Ops/Resources/OrganizationResource.php
+++ b/backend/app/Filament/Ops/Resources/OrganizationResource.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Filament\Ops\Resources;
 
 use App\Filament\Ops\Resources\OrganizationResource\Pages;
+use App\Filament\Ops\Support\StatusBadge;
 use App\Models\Organization;
 use App\Support\Rbac\PermissionNames;
 use Filament\Forms;
@@ -88,7 +89,10 @@ class OrganizationResource extends Resource
             ->columns([
                 Tables\Columns\TextColumn::make('name')->searchable()->sortable(),
                 Tables\Columns\TextColumn::make('id')->label('Org ID')->sortable(),
-                Tables\Columns\TextColumn::make('status')->badge()->sortable(),
+                Tables\Columns\TextColumn::make('status')
+                    ->badge()
+                    ->color(fn (string $state): string => StatusBadge::color($state))
+                    ->sortable(),
                 Tables\Columns\TextColumn::make('domain')->toggleable(),
                 Tables\Columns\TextColumn::make('timezone')->toggleable(),
                 Tables\Columns\TextColumn::make('locale')->toggleable(),

--- a/backend/app/Filament/Ops/Resources/Pages/Concerns/HasSharedListEmptyState.php
+++ b/backend/app/Filament/Ops/Resources/Pages/Concerns/HasSharedListEmptyState.php
@@ -1,0 +1,74 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Filament\Ops\Resources\Pages\Concerns;
+
+use Filament\Tables\Actions\Action;
+use Illuminate\Support\Str;
+
+trait HasSharedListEmptyState
+{
+    protected function getTableEmptyStateHeading(): ?string
+    {
+        return 'No '.Str::lower((string) static::getResource()::getTitleCasePluralModelLabel()).' yet';
+    }
+
+    protected function getTableEmptyStateDescription(): ?string
+    {
+        if ($this->hasActiveTableQuery()) {
+            return 'Try adjusting the current search or filters to widen the result set.';
+        }
+
+        if (static::getResource()::canCreate() && static::getResource()::hasPage('create')) {
+            return 'Create the first '.Str::lower((string) static::getResource()::getTitleCaseModelLabel()).' to start this workspace.';
+        }
+
+        return 'Records will appear here as soon as data is available for the current organization context.';
+    }
+
+    protected function getTableEmptyStateIcon(): ?string
+    {
+        return static::getResource()::getNavigationIcon() ?? 'heroicon-o-sparkles';
+    }
+
+    protected function getTableEmptyStateActions(): array
+    {
+        if (! static::getResource()::canCreate() || ! static::getResource()::hasPage('create')) {
+            return [];
+        }
+
+        return [
+            Action::make('create')
+                ->label('Create '.static::getResource()::getTitleCaseModelLabel())
+                ->icon('heroicon-m-plus')
+                ->color('primary')
+                ->url(static::getResource()::getUrl('create')),
+        ];
+    }
+
+    private function hasActiveTableQuery(): bool
+    {
+        if (trim((string) ($this->tableSearch ?? '')) !== '') {
+            return true;
+        }
+
+        foreach (($this->tableFilters ?? []) as $value) {
+            if (is_array($value)) {
+                foreach ($value as $nested) {
+                    if ($nested !== null && $nested !== '' && $nested !== []) {
+                        return true;
+                    }
+                }
+
+                continue;
+            }
+
+            if ($value !== null && $value !== '' && $value !== []) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+}

--- a/backend/app/Filament/Ops/Resources/PaymentEventResource.php
+++ b/backend/app/Filament/Ops/Resources/PaymentEventResource.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Filament\Ops\Resources;
 
 use App\Filament\Ops\Resources\PaymentEventResource\Pages;
+use App\Filament\Ops\Support\StatusBadge;
 use App\Filament\Shared\BaseTenantResource;
 use App\Models\AdminApproval;
 use App\Models\PaymentEvent;
@@ -15,7 +16,6 @@ use Filament\Forms\Form;
 use Filament\Notifications\Notification;
 use Filament\Tables;
 use Filament\Tables\Table;
-use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Str;
 
 class PaymentEventResource extends BaseTenantResource
@@ -55,9 +55,20 @@ class PaymentEventResource extends BaseTenantResource
                 Tables\Columns\TextColumn::make('provider')->sortable(),
                 Tables\Columns\TextColumn::make('provider_event_id')->label('Event ID')->searchable()->copyable(),
                 Tables\Columns\TextColumn::make('order_no')->searchable()->copyable(),
-                Tables\Columns\TextColumn::make('status')->badge()->sortable(),
-                Tables\Columns\TextColumn::make('handle_status')->badge()->toggleable(),
-                Tables\Columns\IconColumn::make('signature_ok')->boolean()->sortable(),
+                Tables\Columns\TextColumn::make('status')
+                    ->badge()
+                    ->color(fn (string $state): string => StatusBadge::color($state))
+                    ->sortable(),
+                Tables\Columns\TextColumn::make('handle_status')
+                    ->badge()
+                    ->color(fn (?string $state): string => StatusBadge::color($state))
+                    ->toggleable(),
+                Tables\Columns\TextColumn::make('signature_ok')
+                    ->label('Signature')
+                    ->formatStateUsing(fn (bool|int|string|null $state): string => StatusBadge::booleanLabel($state, 'valid', 'invalid'))
+                    ->badge()
+                    ->color(fn (bool|int|string|null $state): string => StatusBadge::isTruthy($state) ? 'success' : 'danger')
+                    ->sortable(),
                 Tables\Columns\TextColumn::make('processed_at')->dateTime()->toggleable(),
                 Tables\Columns\TextColumn::make('created_at')->dateTime()->sortable(),
             ])

--- a/backend/app/Filament/Ops/Resources/PaymentEventResource/Pages/ListPaymentEvents.php
+++ b/backend/app/Filament/Ops/Resources/PaymentEventResource/Pages/ListPaymentEvents.php
@@ -4,11 +4,14 @@ declare(strict_types=1);
 
 namespace App\Filament\Ops\Resources\PaymentEventResource\Pages;
 
+use App\Filament\Ops\Resources\Pages\Concerns\HasSharedListEmptyState;
 use App\Filament\Ops\Resources\PaymentEventResource;
 use Filament\Resources\Pages\ListRecords;
 
 class ListPaymentEvents extends ListRecords
 {
+    use HasSharedListEmptyState;
+
     protected static string $resource = PaymentEventResource::class;
 
     protected function getHeaderActions(): array

--- a/backend/app/Filament/Ops/Support/StatusBadge.php
+++ b/backend/app/Filament/Ops/Support/StatusBadge.php
@@ -1,0 +1,75 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Filament\Ops\Support;
+
+use Illuminate\Support\Str;
+
+final class StatusBadge
+{
+    public static function color(bool|int|string|null $state): string
+    {
+        if (is_bool($state) || is_int($state)) {
+            return self::isTruthy($state) ? 'success' : 'gray';
+        }
+
+        $normalized = self::normalize($state);
+
+        if ($normalized === '') {
+            return 'gray';
+        }
+
+        return match (true) {
+            self::containsAny($normalized, ['published', 'active', 'success', 'approved', 'executed', 'complete', 'completed', 'pass', 'passed', 'valid', 'verified', 'healthy', 'public', 'indexable', 'ready']) => 'success',
+            self::containsAny($normalized, ['pending', 'queued', 'queue', 'processing', 'executing', 'running', 'requested', 'warning', 'hold', 'review']) => 'warning',
+            self::containsAny($normalized, ['failed', 'error', 'danger', 'rejected', 'revoked', 'expired', 'invalid', 'stop ship', 'rollback']) => 'danger',
+            self::containsAny($normalized, ['draft', 'inactive', 'disabled', 'archived', 'hidden', 'suspended', 'non indexable', 'noindex']) => 'gray',
+            default => 'gray',
+        };
+    }
+
+    public static function booleanColor(bool|int|string|null $state): string
+    {
+        return self::isTruthy($state) ? 'success' : 'gray';
+    }
+
+    public static function booleanLabel(bool|int|string|null $state, string $trueLabel, string $falseLabel): string
+    {
+        return self::isTruthy($state) ? $trueLabel : $falseLabel;
+    }
+
+    private static function containsAny(string $state, array $needles): bool
+    {
+        foreach ($needles as $needle) {
+            if (str_contains($state, $needle)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    public static function isTruthy(bool|int|string|null $state): bool
+    {
+        if (is_bool($state)) {
+            return $state;
+        }
+
+        if (is_int($state)) {
+            return $state === 1;
+        }
+
+        return in_array(self::normalize($state), ['1', 'true', 'yes', 'on', 'active', 'published', 'success', 'valid', 'verified', 'public', 'indexable'], true);
+    }
+
+    private static function normalize(bool|int|string|null $state): string
+    {
+        return Str::of((string) $state)
+            ->trim()
+            ->lower()
+            ->replace(['_', '-'], ' ')
+            ->squish()
+            ->value();
+    }
+}

--- a/backend/resources/css/filament/ops/theme.css
+++ b/backend/resources/css/filament/ops/theme.css
@@ -282,13 +282,48 @@
         color: var(--ops-text-secondary);
     }
 
+    .fi-body.fi-panel-ops .fi-section-header,
     .fi-body.fi-panel-ops .fi-section-content-ctn,
     .fi-body.fi-panel-ops .fi-section-footer {
         border-color: var(--ops-border-default);
     }
 
+    .fi-body.fi-panel-ops .fi-section-header,
+    .fi-body.fi-panel-ops .fi-ta-header-ctn {
+        background: linear-gradient(180deg, rgba(255, 255, 255, 0.98), rgba(250, 251, 252, 0.92));
+    }
+
+    .fi-body.fi-panel-ops .fi-section-header {
+        padding: 1.15rem 1.5rem 1rem;
+    }
+
     .fi-body.fi-panel-ops .fi-wi-stats-overview-stat-value {
         letter-spacing: -0.04em;
+    }
+
+    .fi-body.fi-panel-ops .fi-page .grid.flex-1.auto-cols-fr,
+    .fi-body.fi-panel-ops .fi-page-header-widgets,
+    .fi-body.fi-panel-ops .fi-page-footer-widgets,
+    .fi-body.fi-panel-ops .fi-fo-component-ctn {
+        gap: 1.5rem;
+    }
+
+    .fi-body.fi-panel-ops .fi-tabs {
+        gap: 0.35rem;
+        padding: 0.35rem;
+        border-radius: calc(var(--ops-radius-card) - 2px);
+        background: rgba(247, 248, 250, 0.92);
+        box-shadow: inset 0 0 0 1px var(--ops-border-default);
+    }
+
+    .fi-body.fi-panel-ops .fi-tabs-item {
+        min-height: 2.6rem;
+        padding-inline: 0.95rem;
+    }
+
+    .fi-body.fi-panel-ops .fi-tabs-item-label {
+        font-weight: 600;
+        letter-spacing: -0.01em;
     }
 
     .fi-body.fi-panel-ops .fi-ta-header-ctn,
@@ -306,21 +341,29 @@
         letter-spacing: 0.01em;
     }
 
-    .fi-body.fi-panel-ops .fi-page .grid.flex-1.auto-cols-fr,
-    .fi-body.fi-panel-ops .fi-page-header-widgets,
-    .fi-body.fi-panel-ops .fi-page-footer-widgets {
-        gap: 1.5rem;
-    }
-
     .fi-body.fi-panel-ops .fi-ta-header {
-        padding: 1.35rem 1.5rem 0.9rem;
+        padding: 1.35rem 1.5rem 0.8rem;
     }
 
     .fi-body.fi-panel-ops .fi-ta-header-toolbar {
-        align-items: flex-start;
+        align-items: center;
+        gap: 0.85rem;
+        padding: 1rem 1.5rem 1.1rem;
+        border-top: 1px solid rgba(229, 231, 235, 0.88);
+    }
+
+    .fi-body.fi-panel-ops .fi-ta-header-toolbar > .flex,
+    .fi-body.fi-panel-ops .fi-ta-header-toolbar > .ms-auto {
+        flex-wrap: wrap;
         gap: 0.75rem;
-        padding-top: 0.85rem;
-        padding-bottom: 0.95rem;
+    }
+
+    .fi-body.fi-panel-ops .fi-ta-search-field {
+        min-width: min(100%, 19rem);
+    }
+
+    .fi-body.fi-panel-ops .fi-ta-search-field .fi-input-wrp {
+        background: rgba(255, 255, 255, 0.96);
     }
 
     .fi-body.fi-panel-ops .fi-ta-content {
@@ -331,6 +374,13 @@
     .fi-body.fi-panel-ops .fi-ta-filters-below-content,
     .fi-body.fi-panel-ops .fi-ta-filters-above-content-ctn {
         border-top: 1px solid var(--ops-border-default);
+    }
+
+    .fi-body.fi-panel-ops .fi-ta-filters-above-content-ctn,
+    .fi-body.fi-panel-ops .fi-ta-filters-below-content,
+    .fi-body.fi-panel-ops .fi-ta-selection-indicator,
+    .fi-body.fi-panel-ops .fi-ta-filter-indicators {
+        padding: 1rem 1.5rem;
     }
 
     .fi-body.fi-panel-ops .fi-ta-row:hover,
@@ -345,23 +395,64 @@
         background: var(--ops-bg-surface-subtle);
     }
 
-    .fi-body.fi-panel-ops .fi-ta-empty-state-icon-ctn {
+    .fi-body.fi-panel-ops .fi-ta-actions {
+        gap: 0.5rem;
+    }
+
+    .fi-body.fi-panel-ops .fi-dropdown-list-item {
+        border-radius: 12px;
+        color: var(--ops-text-secondary);
+    }
+
+    .fi-body.fi-panel-ops .fi-dropdown-list-item:hover,
+    .fi-body.fi-panel-ops .fi-dropdown-list-item:focus-visible {
         background: rgba(var(--primary-50), 0.9);
+        color: rgb(var(--primary-700));
+    }
+
+    .fi-body.fi-panel-ops .fi-ta-empty-state {
+        padding: 1.6rem;
+    }
+
+    .fi-body.fi-panel-ops .fi-ta-empty-state-content {
+        gap: 0.75rem;
+    }
+
+    .fi-body.fi-panel-ops .fi-ta-empty-state-icon-ctn {
+        margin-bottom: 0;
+        padding: 1rem;
+        background: rgba(var(--primary-50), 0.9);
+        box-shadow: inset 0 0 0 1px rgba(var(--primary-100), 0.92);
     }
 
     .fi-body.fi-panel-ops .fi-ta-empty-state-icon {
         color: rgb(var(--primary-600));
     }
 
+    .fi-body.fi-panel-ops .fi-ta-empty-state-heading {
+        color: var(--ops-text-primary);
+        font-size: 1.05rem;
+        letter-spacing: -0.02em;
+    }
+
     .fi-body.fi-panel-ops .fi-btn,
     .fi-body.fi-panel-ops .fi-icon-btn {
         font-weight: 600;
         letter-spacing: -0.01em;
+        transition:
+            transform 120ms ease,
+            box-shadow 120ms ease,
+            background-color 120ms ease,
+            border-color 120ms ease,
+            color 120ms ease,
+            opacity 120ms ease;
     }
 
     .fi-body.fi-panel-ops .fi-btn {
         min-height: 2.75rem;
+        gap: 0.55rem;
         border-radius: var(--ops-radius-button);
+        padding-inline: 0.95rem;
     }
 
     .fi-body.fi-panel-ops .fi-btn:not(.fi-btn-outlined).fi-color-primary,
@@ -373,11 +464,13 @@
     .fi-body.fi-panel-ops .fi-btn:not(.fi-btn-outlined).fi-color-primary:hover,
     .fi-body.fi-panel-ops .fi-btn:not(.fi-btn-outlined).fi-color-info:hover {
         background: linear-gradient(180deg, rgba(var(--primary-500), 1), rgba(var(--primary-600), 1));
+        transform: translateY(-1px);
     }
 
     .fi-body.fi-panel-ops .fi-btn.fi-color-gray:not(.fi-btn-outlined),
     .fi-body.fi-panel-ops .fi-icon-btn.fi-color-gray {
-        background: rgba(255, 255, 255, 0.9);
+        background: rgba(255, 255, 255, 0.92);
+        color: var(--ops-text-secondary);
         box-shadow: inset 0 0 0 1px var(--ops-border-default);
     }
 
@@ -387,10 +480,31 @@
         color: var(--ops-text-primary);
     }
 
+    .fi-body.fi-panel-ops .fi-btn.fi-color-danger:not(.fi-btn-outlined),
+    .fi-body.fi-panel-ops .fi-icon-btn.fi-color-danger {
+        background: linear-gradient(180deg, #ef4444, #dc2626);
+        box-shadow: 0 10px 18px rgba(220, 38, 38, 0.16);
+    }
+
     .fi-body.fi-panel-ops .fi-btn.fi-btn-outlined {
         border-radius: var(--ops-radius-button);
         background: rgba(255, 255, 255, 0.72);
         box-shadow: inset 0 0 0 1px var(--ops-border-default);
+    }
+
+    .fi-body.fi-panel-ops .fi-btn.fi-btn-outlined:hover {
+        background: rgba(var(--primary-50), 0.72);
+        color: rgb(var(--primary-700));
+        box-shadow: inset 0 0 0 1px rgba(var(--primary-100), 0.96);
+    }
+
+    .fi-body.fi-panel-ops .fi-btn:disabled,
+    .fi-body.fi-panel-ops .fi-icon-btn:disabled,
+    .fi-body.fi-panel-ops .fi-dropdown-list-item:disabled {
+        cursor: not-allowed;
+        opacity: 0.56;
+        transform: none;
+        box-shadow: none;
     }
 
     .fi-body.fi-panel-ops .fi-btn:focus-visible,
@@ -398,10 +512,41 @@
         box-shadow: 0 0 0 4px rgba(var(--primary-100), 0.9);
     }
 
+    .fi-body.fi-panel-ops .fi-fo-field-wrp {
+        padding-block: 0.15rem;
+    }
+
+    .fi-body.fi-panel-ops .fi-fo-field-wrp-label,
+    .fi-body.fi-panel-ops .fi-input-wrp-label {
+        color: var(--ops-text-primary);
+        font-size: 0.8125rem;
+        font-weight: 700;
+        letter-spacing: -0.01em;
+    }
+
+    .fi-body.fi-panel-ops .fi-fo-field-wrp-helper-text,
+    .fi-body.fi-panel-ops .fi-fo-field-wrp-hint,
+    .fi-body.fi-panel-ops .fi-fo-field-wrp-hint-label,
+    .fi-body.fi-panel-ops .fi-input-wrp-label {
+        color: var(--ops-text-secondary);
+    }
+
+    .fi-body.fi-panel-ops .fi-fo-field-wrp-helper-text,
+    .fi-body.fi-panel-ops .fi-fo-field-wrp-hint {
+        font-size: 0.8125rem;
+        line-height: 1.55;
+    }
+
+    .fi-body.fi-panel-ops .fi-fo-field-wrp-error-message {
+        font-weight: 600;
+        line-height: 1.5;
+    }
+
     .fi-body.fi-panel-ops .fi-input-wrp {
         min-height: 3rem;
         border-radius: var(--ops-radius-input);
         background: var(--ops-bg-surface);
+        transition: box-shadow 120ms ease, background-color 120ms ease;
         box-shadow: inset 0 0 0 1px var(--ops-border-default);
     }
 
@@ -411,11 +556,10 @@
             0 0 0 4px rgba(var(--primary-100), 0.9);
     }
 
-    .fi-body.fi-panel-ops .fi-input-wrp-label {
-        color: var(--ops-text-tertiary);
-        font-size: var(--ops-font-meta);
-        font-weight: 600;
-        letter-spacing: 0.02em;
+    .fi-body.fi-panel-ops .fi-fo-field-wrp:has([data-validation-error]) .fi-input-wrp {
+        box-shadow:
+            inset 0 0 0 1px rgba(220, 38, 38, 0.82),
+            0 0 0 4px rgba(254, 226, 226, 0.9);
     }
 
     .fi-body.fi-panel-ops .fi-input,
@@ -424,6 +568,17 @@
     .fi-body.fi-panel-ops .fi-fo-textarea textarea,
     .fi-body.fi-panel-ops .choices__input {
         font-size: var(--ops-font-body);
+    }
+
+    .fi-body.fi-panel-ops .fi-input::placeholder,
+    .fi-body.fi-panel-ops .fi-select-input::placeholder,
+    .fi-body.fi-panel-ops .fi-fo-textarea textarea::placeholder,
+    .fi-body.fi-panel-ops .choices__input::placeholder {
+        color: var(--ops-text-tertiary);
+    }
+
+    .fi-body.fi-panel-ops .fi-fo-textarea textarea {
+        min-height: 7.5rem;
     }
 
     .fi-body.fi-panel-ops .choices__inner,
@@ -442,10 +597,95 @@
     }
 
     .fi-body.fi-panel-ops .fi-badge {
+        min-height: 1.65rem;
         border-radius: var(--ops-radius-badge);
+        padding-inline: 0.65rem;
         box-shadow: none;
-        font-weight: 600;
+        font-weight: 700;
         letter-spacing: 0.01em;
+        text-transform: capitalize;
+    }
+
+    .fi-body.fi-panel-ops .fi-badge.fi-color-gray {
+        background: #f3f4f6;
+        color: #4b5563;
+        box-shadow: inset 0 0 0 1px rgba(209, 213, 219, 0.95);
+    }
+
+    .fi-body.fi-panel-ops .fi-badge.fi-color-success {
+        background: rgba(22, 163, 74, 0.12);
+        color: #166534;
+        box-shadow: inset 0 0 0 1px rgba(22, 163, 74, 0.16);
+    }
+
+    .fi-body.fi-panel-ops .fi-badge.fi-color-warning {
+        background: rgba(217, 119, 6, 0.12);
+        color: #92400e;
+        box-shadow: inset 0 0 0 1px rgba(217, 119, 6, 0.16);
+    }
+
+    .fi-body.fi-panel-ops .fi-badge.fi-color-danger {
+        background: rgba(220, 38, 38, 0.12);
+        color: #991b1b;
+        box-shadow: inset 0 0 0 1px rgba(220, 38, 38, 0.14);
+    }
+
+    .fi-body.fi-panel-ops .fi-badge.fi-color-info,
+    .fi-body.fi-panel-ops .fi-badge.fi-color-primary {
+        background: rgba(var(--primary-50), 0.96);
+        color: rgb(var(--primary-700));
+        box-shadow: inset 0 0 0 1px rgba(var(--primary-100), 0.96);
+    }
+
+    .fi-body.fi-panel-ops .fi-modal-window {
+        border-radius: var(--ops-radius-overlay);
+        background: rgba(255, 255, 255, 0.98);
+        box-shadow: var(--ops-shadow-overlay);
+        backdrop-filter: blur(18px);
+    }
+
+    .fi-body.fi-panel-ops .fi-modal-footer-actions {
+        gap: 0.75rem;
+    }
+
+    .fi-body.fi-panel-ops .fi-no-notification {
+        border-radius: 18px;
+        overflow: hidden;
+        box-shadow: var(--ops-shadow-overlay);
+    }
+
+    .fi-body.fi-panel-ops .fi-no-notification .fi-no-notification-title {
+        color: var(--ops-text-primary);
+        font-size: 0.95rem;
+        font-weight: 700;
+        letter-spacing: -0.02em;
+    }
+
+    .fi-body.fi-panel-ops .fi-no-notification .fi-no-notification-body,
+    .fi-body.fi-panel-ops .fi-no-notification .fi-no-notification-date {
+        color: var(--ops-text-secondary);
+    }
+
+    .fi-body.fi-panel-ops .fi-no-notification.fi-color-success {
+        box-shadow: 0 16px 36px rgba(22, 163, 74, 0.12);
+    }
+
+    .fi-body.fi-panel-ops .fi-no-notification.fi-color-warning {
+        box-shadow: 0 16px 36px rgba(217, 119, 6, 0.12);
+    }
+
+    .fi-body.fi-panel-ops .fi-no-notification.fi-color-danger {
+        box-shadow: 0 16px 36px rgba(220, 38, 38, 0.12);
+    }
+
+    .fi-body.fi-panel-ops .fi-no-notification-close-btn {
+        border-radius: 999px;
+        color: var(--ops-text-tertiary);
+    }
+
+    .fi-body.fi-panel-ops .fi-no-notification-close-btn:hover {
+        background: rgba(255, 255, 255, 0.72);
+        color: var(--ops-text-primary);
     }
 
     .ops-shell-hero {
@@ -689,9 +929,220 @@
         line-height: 1.55;
     }
 
+    .ops-status-pill {
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        min-height: 1.7rem;
+        width: fit-content;
+        border-radius: var(--ops-radius-badge);
+        padding: 0.28rem 0.72rem;
+        font-size: 0.75rem;
+        font-weight: 700;
+        letter-spacing: 0.03em;
+        text-transform: uppercase;
+    }
+
+    .ops-status-pill--success {
+        background: rgba(22, 163, 74, 0.12);
+        color: #166534;
+        box-shadow: inset 0 0 0 1px rgba(22, 163, 74, 0.18);
+    }
+
+    .ops-status-pill--warning {
+        background: rgba(217, 119, 6, 0.12);
+        color: #92400e;
+        box-shadow: inset 0 0 0 1px rgba(217, 119, 6, 0.18);
+    }
+
+    .ops-status-pill--danger {
+        background: rgba(220, 38, 38, 0.12);
+        color: #991b1b;
+        box-shadow: inset 0 0 0 1px rgba(220, 38, 38, 0.16);
+    }
+
+    .ops-status-pill--gray {
+        background: #f3f4f6;
+        color: #4b5563;
+        box-shadow: inset 0 0 0 1px rgba(209, 213, 219, 0.96);
+    }
+
     .ops-shell-page {
         display: grid;
         gap: 1rem;
+    }
+
+    .ops-workbench-toolbar {
+        display: grid;
+        gap: 1rem;
+    }
+
+    .ops-workbench-toolbar--split {
+        align-items: end;
+        grid-template-columns: minmax(0, 1.75fr) minmax(12rem, 1fr);
+    }
+
+    .ops-workbench-toolbar__main {
+        display: grid;
+        gap: 0.95rem;
+        min-width: 0;
+    }
+
+    .ops-workbench-toolbar__actions {
+        display: flex;
+        align-items: end;
+        justify-content: flex-end;
+        flex-wrap: wrap;
+        gap: 0.65rem;
+    }
+
+    .ops-control-stack {
+        display: grid;
+        gap: 0.55rem;
+    }
+
+    .ops-control-label {
+        color: var(--ops-text-primary);
+        font-size: 0.8125rem;
+        font-weight: 700;
+        letter-spacing: -0.01em;
+    }
+
+    .ops-control-hint {
+        color: var(--ops-text-secondary);
+        font-size: 0.8125rem;
+        line-height: 1.55;
+    }
+
+    .ops-input {
+        width: 100%;
+        min-height: 3rem;
+        border-radius: var(--ops-radius-input);
+        border: none;
+        background: var(--ops-bg-surface);
+        padding: 0.8rem 0.95rem;
+        color: var(--ops-text-primary);
+        box-shadow: inset 0 0 0 1px var(--ops-border-default);
+        transition: box-shadow 120ms ease;
+    }
+
+    .ops-input::placeholder {
+        color: var(--ops-text-tertiary);
+    }
+
+    .ops-input:focus {
+        outline: none;
+        box-shadow:
+            inset 0 0 0 1px rgb(var(--primary-500)),
+            0 0 0 4px rgba(var(--primary-100), 0.9);
+    }
+
+    .ops-results-header {
+        display: flex;
+        align-items: flex-start;
+        justify-content: space-between;
+        gap: 1rem;
+    }
+
+    .ops-results-header__title {
+        color: var(--ops-text-primary);
+        font-size: 1rem;
+        font-weight: 700;
+        letter-spacing: -0.02em;
+    }
+
+    .ops-results-header__meta {
+        color: var(--ops-text-secondary);
+        font-size: 0.8125rem;
+        line-height: 1.55;
+    }
+
+    .ops-card-list {
+        display: grid;
+        gap: 0.85rem;
+    }
+
+    .ops-result-card {
+        display: grid;
+        gap: 0.55rem;
+        padding: 1rem 1.1rem;
+        border-radius: 14px;
+        background: rgba(255, 255, 255, 0.92);
+        box-shadow: inset 0 0 0 1px rgba(229, 231, 235, 0.96);
+    }
+
+    .ops-result-card__header {
+        display: flex;
+        align-items: flex-start;
+        justify-content: space-between;
+        gap: 1rem;
+    }
+
+    .ops-result-card__title {
+        color: var(--ops-text-primary);
+        font-size: 0.9375rem;
+        font-weight: 700;
+        letter-spacing: -0.01em;
+    }
+
+    .ops-result-card__meta {
+        color: var(--ops-text-secondary);
+        font-size: 0.8125rem;
+        line-height: 1.55;
+    }
+
+    .ops-empty-state {
+        display: grid;
+        justify-items: center;
+        gap: 0.85rem;
+        padding: 1.25rem 0.5rem;
+        text-align: center;
+    }
+
+    .ops-empty-state__icon {
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        height: 3.5rem;
+        width: 3.5rem;
+        border-radius: 999px;
+        background: rgba(var(--primary-50), 0.94);
+        color: rgb(var(--primary-600));
+        box-shadow: inset 0 0 0 1px rgba(var(--primary-100), 0.94);
+    }
+
+    .ops-empty-state__body {
+        display: grid;
+        gap: 0.3rem;
+        max-width: 28rem;
+    }
+
+    .ops-empty-state__eyebrow {
+        color: var(--ops-text-tertiary);
+        font-size: 0.6875rem;
+        font-weight: 700;
+        letter-spacing: 0.12em;
+        text-transform: uppercase;
+    }
+
+    .ops-empty-state__title {
+        color: var(--ops-text-primary);
+        font-size: 1.05rem;
+        font-weight: 700;
+        letter-spacing: -0.03em;
+    }
+
+    .ops-empty-state__description {
+        color: var(--ops-text-secondary);
+        font-size: 0.875rem;
+        line-height: 1.6;
+    }
+
+    .ops-empty-state__actions {
+        display: flex;
+        flex-wrap: wrap;
+        justify-content: center;
+        gap: 0.65rem;
     }
 
     .ops-select-org-actions {
@@ -768,5 +1219,18 @@
 
     .ops-topbar-chip__value {
         max-width: 10rem;
+    }
+
+    .ops-workbench-toolbar--split {
+        grid-template-columns: 1fr;
+    }
+
+    .ops-results-header,
+    .ops-result-card__header {
+        flex-direction: column;
+    }
+
+    .ops-workbench-toolbar__actions {
+        justify-content: flex-start;
     }
 }

--- a/backend/resources/views/components/filament/ops/shared/empty-state.blade.php
+++ b/backend/resources/views/components/filament/ops/shared/empty-state.blade.php
@@ -1,0 +1,30 @@
+@props([
+    'description' => null,
+    'eyebrow' => 'Workspace state',
+    'icon' => 'heroicon-o-sparkles',
+    'title',
+])
+
+<div {{ $attributes->class(['ops-empty-state']) }}>
+    <span class="ops-empty-state__icon">
+        <x-filament::icon :icon="$icon" class="h-6 w-6" />
+    </span>
+
+    <div class="ops-empty-state__body">
+        @if (filled($eyebrow))
+            <span class="ops-empty-state__eyebrow">{{ $eyebrow }}</span>
+        @endif
+
+        <h3 class="ops-empty-state__title">{{ $title }}</h3>
+
+        @if (filled($description))
+            <p class="ops-empty-state__description">{{ $description }}</p>
+        @endif
+    </div>
+
+    @isset($actions)
+        <div class="ops-empty-state__actions">
+            {{ $actions }}
+        </div>
+    @endisset
+</div>

--- a/backend/resources/views/components/filament/ops/shared/status-pill.blade.php
+++ b/backend/resources/views/components/filament/ops/shared/status-pill.blade.php
@@ -1,0 +1,13 @@
+@props([
+    'label' => null,
+    'state' => null,
+])
+
+@php
+    $tone = \App\Filament\Ops\Support\StatusBadge::color($state);
+    $display = $label ?? (is_bool($state) ? ($state ? 'active' : 'inactive') : (string) $state);
+@endphp
+
+<span {{ $attributes->class(['ops-status-pill', "ops-status-pill--{$tone}"]) }}>
+    {{ $display }}
+</span>

--- a/backend/resources/views/filament/ops/pages/global-search-page.blade.php
+++ b/backend/resources/views/filament/ops/pages/global-search-page.blade.php
@@ -1,18 +1,37 @@
 <x-filament-panels::page>
-    <div class="space-y-4">
+    @php
+        $hasQuery = trim($query) !== '';
+        $emptyTitle = $hasQuery ? 'No matching records' : 'Start with a search';
+        $emptyDescription = $hasQuery
+            ? 'Try another order number, attempt id, share id, or user email to widen the search.'
+            : 'Search by order number, attempt id, share id, or user email to open the right workflow quickly.';
+    @endphp
+
+    <div class="ops-shell-page">
         <x-filament::section>
-            <div class="grid gap-3 md:grid-cols-4">
-                <div class="md:col-span-3">
-                    <label class="block text-sm font-medium text-gray-700" for="ops-global-search-input">Search by order_no / attempt_id / share_id / user_email</label>
-                    <input
-                        id="ops-global-search-input"
-                        type="text"
-                        wire:model.defer="query"
-                        placeholder="ord_..., attempt..., share..., email"
-                        class="mt-1 block w-full rounded-lg border-gray-300 shadow-sm focus:border-primary-500 focus:ring-primary-500"
-                    />
+            <div class="ops-workbench-toolbar ops-workbench-toolbar--split">
+                <div class="ops-workbench-toolbar__main">
+                    <div class="ops-shell-inline-intro">
+                        <span class="ops-shell-inline-intro__eyebrow">Support workspace</span>
+                        <p class="ops-shell-inline-intro__meta">
+                            Jump directly to orders, attempts, shares, or user records without leaving the current ops context.
+                        </p>
+                    </div>
+
+                    <div class="ops-control-stack">
+                        <label class="ops-control-label" for="ops-global-search-input">Search by order_no / attempt_id / share_id / user_email</label>
+                        <input
+                            id="ops-global-search-input"
+                            type="text"
+                            wire:model.defer="query"
+                            placeholder="ord_..., attempt..., share..., email"
+                            class="ops-input"
+                        />
+                        <p class="ops-control-hint">The search stays read-only here. Open a result to continue in its native workspace.</p>
+                    </div>
                 </div>
-                <div class="flex items-end">
+
+                <div class="ops-workbench-toolbar__actions">
                     <x-filament::button color="primary" wire:click="runSearch">
                         Search
                     </x-filament::button>
@@ -21,18 +40,21 @@
         </x-filament::section>
 
         <x-filament::section>
-            <div class="flex items-center justify-between">
-                <h3 class="text-sm font-semibold text-gray-900">Results</h3>
-                <span class="text-xs text-gray-500">{{ $elapsedMs }} ms</span>
+            <div class="ops-results-header">
+                <div>
+                    <h3 class="ops-results-header__title">Results</h3>
+                    <p class="ops-results-header__meta">Shared result cards keep support actions readable even when records come from different domains.</p>
+                </div>
+                <span class="ops-results-header__meta">{{ $elapsedMs }} ms</span>
             </div>
 
-            <div class="mt-3 space-y-2">
+            <div class="ops-card-list mt-4">
                 @forelse ($items as $item)
-                    <div class="rounded-lg border border-gray-200 p-3">
-                        <div class="flex items-center justify-between gap-3">
+                    <div class="ops-result-card">
+                        <div class="ops-result-card__header">
                             <div>
-                                <p class="text-sm font-semibold text-gray-900">{{ (string) ($item['label'] ?? '-') }}</p>
-                                <p class="text-xs text-gray-500">
+                                <p class="ops-result-card__title">{{ (string) ($item['label'] ?? '-') }}</p>
+                                <p class="ops-result-card__meta">
                                     {{ (string) ($item['type'] ?? '-') }}
                                     @if ((int) ($item['org_id'] ?? 0) > 0)
                                         | org={{ (int) ($item['org_id'] ?? 0) }}
@@ -46,9 +68,12 @@
                         </div>
                     </div>
                 @empty
-                    <div class="rounded-lg border border-dashed border-gray-300 p-4 text-sm text-gray-500">
-                        No results yet.
-                    </div>
+                    <x-filament.ops.shared.empty-state
+                        eyebrow="Support search"
+                        icon="heroicon-o-magnifying-glass"
+                        :title="$emptyTitle"
+                        :description="$emptyDescription"
+                    />
                 @endforelse
             </div>
         </x-filament::section>

--- a/backend/resources/views/filament/ops/pages/go-live-gate-page.blade.php
+++ b/backend/resources/views/filament/ops/pages/go-live-gate-page.blade.php
@@ -1,30 +1,52 @@
 <x-filament-panels::page>
-    <div class="space-y-4">
+    <div class="ops-shell-page">
         <x-filament::section>
-            <div class="flex flex-wrap items-center gap-2">
-                <span class="text-sm font-semibold text-gray-900">Gate Status:</span>
-                <span class="rounded-full px-2 py-1 text-xs font-semibold {{ (($gate['status'] ?? 'STOP-SHIP') === 'PASS') ? 'bg-success-100 text-success-700' : 'bg-danger-100 text-danger-700' }}">
-                    {{ (string) ($gate['status'] ?? 'STOP-SHIP') }}
-                </span>
-                <x-filament::button size="sm" color="gray" wire:click="refreshChecks">Refresh</x-filament::button>
-                <x-filament::button size="sm" color="primary" wire:click="runChecks">Run Checks</x-filament::button>
+            <div class="ops-workbench-toolbar ops-workbench-toolbar--split">
+                <div class="ops-workbench-toolbar__main">
+                    <div class="ops-shell-inline-intro">
+                        <span class="ops-shell-inline-intro__eyebrow">Governance checkpoint</span>
+                        <p class="ops-shell-inline-intro__meta">
+                            Review the current go-live signals before releasing content or escalating operational changes.
+                        </p>
+                    </div>
+
+                    <div class="flex flex-wrap items-center gap-3">
+                        <span class="ops-control-label">Gate status</span>
+                        <x-filament.ops.shared.status-pill
+                            :state="(($gate['status'] ?? 'STOP-SHIP') === 'PASS') ? 'success' : 'failed'"
+                            :label="(string) ($gate['status'] ?? 'STOP-SHIP')"
+                        />
+                        <span class="ops-control-hint">Generated: {{ (string) ($gate['generated_at'] ?? '-') }}</span>
+                    </div>
+                </div>
+
+                <div class="ops-workbench-toolbar__actions">
+                    <x-filament::button size="sm" color="gray" wire:click="refreshChecks">Refresh</x-filament::button>
+                    <x-filament::button size="sm" color="primary" wire:click="runChecks">Run Checks</x-filament::button>
+                </div>
             </div>
-            <p class="mt-2 text-xs text-gray-500">Generated: {{ (string) ($gate['generated_at'] ?? '-') }}</p>
         </x-filament::section>
 
         @foreach (($gate['groups'] ?? []) as $groupKey => $group)
             <x-filament::section>
-                <h3 class="text-sm font-semibold text-gray-900">{{ (string) ($group['label'] ?? $groupKey) }}</h3>
-                <div class="mt-3 space-y-2">
+                <div class="ops-results-header">
+                    <div>
+                        <h3 class="ops-results-header__title">{{ (string) ($group['label'] ?? $groupKey) }}</h3>
+                        <p class="ops-results-header__meta">Each check shares the same status language as the rest of Ops.</p>
+                    </div>
+                </div>
+
+                <div class="ops-card-list mt-4">
                     @foreach (($group['checks'] ?? []) as $check)
-                        <div class="rounded-lg border border-gray-200 p-3">
-                            <div class="flex items-center justify-between gap-3">
-                                <p class="text-sm font-medium text-gray-900">{{ (string) ($check['key'] ?? '-') }}</p>
-                                <span class="rounded-full px-2 py-1 text-xs font-semibold {{ (($check['passed'] ?? false) ? 'bg-success-100 text-success-700' : 'bg-danger-100 text-danger-700') }}">
-                                    {{ (($check['passed'] ?? false) ? 'PASS' : 'STOP-SHIP') }}
-                                </span>
+                        <div class="ops-result-card">
+                            <div class="ops-result-card__header">
+                                <p class="ops-result-card__title">{{ (string) ($check['key'] ?? '-') }}</p>
+                                <x-filament.ops.shared.status-pill
+                                    :state="($check['passed'] ?? false) ? 'success' : 'failed'"
+                                    :label="(($check['passed'] ?? false) ? 'PASS' : 'STOP-SHIP')"
+                                />
                             </div>
-                            <p class="mt-1 text-xs text-gray-500">{{ (string) ($check['message'] ?? '') }}</p>
+                            <p class="ops-result-card__meta">{{ (string) ($check['message'] ?? '') }}</p>
                         </div>
                     @endforeach
                 </div>

--- a/backend/resources/views/filament/ops/pages/select-org-page.blade.php
+++ b/backend/resources/views/filament/ops/pages/select-org-page.blade.php
@@ -9,8 +9,8 @@
         @endif
 
         <x-filament::section>
-            <div class="ops-select-org-toolbar grid gap-4 md:grid-cols-3">
-                <div class="md:col-span-2">
+            <div class="ops-workbench-toolbar ops-workbench-toolbar--split ops-select-org-toolbar">
+                <div class="ops-workbench-toolbar__main md:col-span-2">
                     <div class="ops-shell-inline-intro">
                         <span class="ops-shell-inline-intro__eyebrow">Workspace scope</span>
                         <p class="ops-shell-inline-intro__meta">
@@ -18,16 +18,19 @@
                         </p>
                     </div>
 
-                    <label class="block text-sm font-medium text-gray-700" for="ops-org-search">Search organizations</label>
-                    <input
-                        id="ops-org-search"
-                        type="text"
-                        wire:model.live.debounce.300ms="search"
-                        placeholder="Search by org name or org id"
-                        class="mt-1 block w-full rounded-lg border-gray-300 shadow-sm focus:border-primary-500 focus:ring-primary-500"
-                    />
+                    <div class="ops-control-stack">
+                        <label class="ops-control-label" for="ops-org-search">Search organizations</label>
+                        <input
+                            id="ops-org-search"
+                            type="text"
+                            wire:model.live.debounce.300ms="search"
+                            placeholder="Search by org name or org id"
+                            class="ops-input"
+                        />
+                        <p class="ops-control-hint">Search the current admin-visible organization list by name or exact org id.</p>
+                    </div>
                 </div>
-                <div class="ops-select-org-actions flex items-end gap-2">
+                <div class="ops-workbench-toolbar__actions ops-select-org-actions">
                     @if ($this->canCreateOrganization())
                         <x-filament::button color="primary" wire:click="createOrganization">
                             Create Organization
@@ -50,7 +53,11 @@
                         </div>
                         <div>
                             <p class="ops-select-org-row__meta">status</p>
-                            <p class="ops-select-org-row__value">{{ $organization['status'] }}</p>
+                            <x-filament.ops.shared.status-pill
+                                class="mt-2"
+                                :state="$organization['status']"
+                                :label="$organization['status']"
+                            />
                         </div>
                         <div>
                             <p class="ops-select-org-row__meta">domain</p>
@@ -70,13 +77,14 @@
                 </x-filament::section>
             @empty
                 <x-filament::section>
-                    <div class="ops-select-org-empty space-y-4">
-                        <div>
-                            <p class="ops-select-org-row__title">No organizations found</p>
-                            <p class="ops-shell-inline-intro__meta">{{ $this->whyVisibleHint() }}</p>
-                        </div>
-
-                        <div class="flex flex-wrap gap-2">
+                    <x-filament.ops.shared.empty-state
+                        class="ops-select-org-empty"
+                        eyebrow="Organization scope"
+                        icon="heroicon-o-building-office-2"
+                        title="No organizations found"
+                        :description="$this->whyVisibleHint()"
+                    >
+                        <x-slot name="actions">
                             @if ($this->canCreateOrganization())
                                 <x-filament::button color="primary" wire:click="createOrganization">
                                     Create Organization
@@ -85,8 +93,8 @@
                             <x-filament::button color="gray" wire:click="goToImport">
                                 Import/Sync Organizations
                             </x-filament::button>
-                        </div>
-                    </div>
+                        </x-slot>
+                    </x-filament.ops.shared.empty-state>
                 </x-filament::section>
             @endforelse
         </div>

--- a/backend/resources/views/filament/ops/pages/two-factor-challenge.blade.php
+++ b/backend/resources/views/filament/ops/pages/two-factor-challenge.blade.php
@@ -5,15 +5,16 @@
                 Confirm your admin session with an authenticator code or one-time recovery code.
             </p>
 
-            <div>
-                <label class="block text-sm font-medium text-gray-700" for="totp-code">Verification code</label>
+            <div class="ops-control-stack">
+                <label class="ops-control-label" for="totp-code">Verification code</label>
                 <input
                     id="totp-code"
                     type="text"
                     wire:model.defer="code"
                     autocomplete="one-time-code"
-                    class="mt-1 block w-full rounded-lg border-gray-300 shadow-sm focus:border-primary-500 focus:ring-primary-500"
+                    class="ops-input"
                 />
+                <p class="ops-control-hint">Use the current code from your authenticator app or a one-time recovery code.</p>
             </div>
 
             <x-filament::button color="primary" wire:click="verify">

--- a/deploy.php
+++ b/deploy.php
@@ -298,13 +298,20 @@ task('fap:seed_shared_content_packages', function () {
 before('deploy', 'guard:forbid-destructive');
 before('deploy:prepare', 'ensure:phpredis');
 before('deploy:shared', 'fap:seed_shared_content_packages');
+
 after('deploy:update_code', 'ensure:node-toolchain');
-after('ensure:node-toolchain', 'build:ops-theme');
-after('build:ops-theme', 'guard:ops-theme-asset');
 
 after('deploy:shared', 'ensure:shared-perms');
 after('deploy:shared', 'ensure:healthz-deps');
-after('deploy:vendors', 'artisan:filament:assets');
+
+/**
+ * vendor 必须先安装完成：
+ * - build:ops-theme 依赖 vendor/filament/filament/tailwind.config.preset
+ * - artisan:filament:assets 也依赖 composer vendor
+ */
+after('deploy:vendors', 'build:ops-theme');
+after('build:ops-theme', 'guard:ops-theme-asset');
+after('guard:ops-theme-asset', 'artisan:filament:assets');
 after('artisan:filament:assets', 'guard:filament-assets');
 
 after('deploy:symlink', 'reload:php-fpm');


### PR DESCRIPTION
## Summary
- unify shared Ops UI components on top of the existing theme foundation and shell upgrade
- standardize buttons, badges, inputs, list empty states, and feedback patterns across core Ops resources
- keep the deploy release chain aligned by running the custom Ops theme build only after composer vendors are installed

## What changed
- add a shared status badge mapper and reusable anonymous components for status pills and empty states
- standardize shared button, badge, input, helper, validation, notification, and table toolbar chrome in the existing Ops theme
- apply shared empty-state handling to primary list pages including articles, categories, tags, orders, and payment events
- align select-org, two-factor, global-search, and go-live-gate pages with the shared component language
- normalize resource status columns to use consistent badge semantics across content, commerce, governance, and audit pages
- adjust deploy sequencing so the Ops theme build runs after `deploy:vendors`, matching its Filament vendor preset dependency

## Implementation approach
- reused the existing custom Filament theme and shell layers from PR-01 and PR-02
- used lightweight helpers and anonymous Blade components instead of publishing Filament vendor views
- kept routes, APIs, RBAC, resource logic, and CMS behavior unchanged

## Why this PR is small and safe
- no database changes
- no route changes
- no API changes
- no permission changes
- no resource field logic changes
- only shared component, interaction-layer UI work plus a minimal deploy sequencing correction required by the existing theme build

## Validation
- `cd backend && php artisan route:list --path=ops --except-vendor`
- `cd backend && php artisan about`
- `cd backend && php artisan route:list`
- `cd backend && php artisan migrate`
- `cd backend && php artisan filament:assets`
- `cd backend && npm run build`
- kernel-level smoke checks for `/ops`, `/ops/articles`, `/ops/article-categories`, `/ops/article-tags`, `/ops/select-org`, `/ops/two-factor-challenge`, `/ops/orders`, `/ops/payment-events`, `/ops/go-live-gate`, `/ops/global-search`
- `bash backend/scripts/ci_verify_mbti.sh`

## Notes
- Filament vendor views were not published
- local Playwright browser launch was blocked by an existing persistent Chrome session, so browser-console verification was replaced with framework-level page rendering smoke checks
