### PR TITLE
feat(ops-ui): turn articles into an editorial workspace

### DIFF
--- a/backend/app/Filament/Ops/Resources/ArticleResource.php
+++ b/backend/app/Filament/Ops/Resources/ArticleResource.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Filament\Ops\Resources;
 
 use App\Filament\Ops\Resources\ArticleResource\Pages;
+use App\Filament\Ops\Resources\ArticleResource\Support\ArticleWorkspace;
 use App\Filament\Ops\Support\StatusBadge;
 use App\Models\Article;
 use App\Support\OrgContext;
@@ -60,87 +61,166 @@ class ArticleResource extends Resource
     public static function form(Form $form): Form
     {
         return $form->schema([
-            Forms\Components\Tabs::make('Article')
-                ->tabs([
-                    Forms\Components\Tabs\Tab::make('Basic')
-                        ->schema([
-                            Forms\Components\Hidden::make('org_id')
-                                ->default(fn (): int => max(0, (int) app(OrgContext::class)->orgId())),
-                            Forms\Components\TextInput::make('title')
-                                ->required()
-                                ->maxLength(255),
-                            Forms\Components\TextInput::make('slug')
-                                ->required()
-                                ->maxLength(127),
-                            Forms\Components\TextInput::make('locale')
-                                ->required()
-                                ->maxLength(16)
-                                ->default('en'),
-                            Forms\Components\Select::make('category_id')
-                                ->label('Category')
-                                ->relationship(
-                                    'category',
-                                    'name',
-                                    fn (Builder $query): Builder => $query->whereIn('article_categories.org_id', self::tenantOrgIds())
-                                )
-                                ->searchable()
-                                ->preload(),
-                            BelongsToManyMultiSelect::make('tags')
-                                ->relationship(
-                                    'tags',
-                                    'name',
-                                    fn (Builder $query): Builder => $query->whereIn('article_tags.org_id', self::tenantOrgIds())
-                                )
-                                ->searchable()
-                                ->preload(),
-                        ]),
-                    Forms\Components\Tabs\Tab::make('Content')
-                        ->schema([
-                            Forms\Components\Textarea::make('excerpt')
-                                ->rows(4),
-                            Forms\Components\MarkdownEditor::make('content_md')
-                                ->required()
-                                ->columnSpanFull(),
-                            Forms\Components\TextInput::make('cover_image_url')
-                                ->maxLength(255),
-                        ]),
-                    Forms\Components\Tabs\Tab::make('SEO')
-                        ->schema([
-                            Forms\Components\Section::make('SEO Meta')
-                                ->relationship('seoMeta')
-                                ->schema([
-                                    Forms\Components\TextInput::make('seo_title')
-                                        ->maxLength(60),
-                                    Forms\Components\Textarea::make('seo_description')
-                                        ->rows(3)
-                                        ->maxLength(160),
-                                    Forms\Components\TextInput::make('canonical_url')
-                                        ->maxLength(255),
-                                    Forms\Components\TextInput::make('og_title')
-                                        ->maxLength(90),
-                                    Forms\Components\Textarea::make('og_description')
-                                        ->rows(3)
-                                        ->maxLength(200),
-                                    Forms\Components\TextInput::make('og_image_url')
-                                        ->maxLength(255),
-                                ]),
-                        ]),
-                    Forms\Components\Tabs\Tab::make('Publish')
-                        ->schema([
-                            Forms\Components\Select::make('status')
-                                ->required()
-                                ->options([
-                                    'draft' => 'draft',
-                                    'published' => 'published',
-                                ])
-                                ->default('draft'),
-                            Forms\Components\Toggle::make('is_public')
-                                ->default(false),
-                            Forms\Components\Toggle::make('is_indexable')
-                                ->default(true),
-                            Forms\Components\DateTimePicker::make('published_at'),
-                            Forms\Components\DateTimePicker::make('scheduled_at'),
-                        ]),
+            Forms\Components\Hidden::make('org_id')
+                ->default(fn (): int => max(0, (int) app(OrgContext::class)->orgId())),
+            Forms\Components\Grid::make([
+                'default' => 1,
+                'xl' => 12,
+            ])
+                ->extraAttributes(['class' => 'ops-article-workspace-layout'])
+                ->schema([
+                    Forms\Components\Group::make([
+                        Forms\Components\Section::make('Basic')
+                            ->description('Write the article headline, URL slug, and short summary before moving into the body.')
+                            ->extraAttributes(['class' => 'ops-article-workspace-section ops-article-workspace-section--main'])
+                            ->schema([
+                                Forms\Components\TextInput::make('title')
+                                    ->required()
+                                    ->maxLength(255)
+                                    ->columnSpanFull()
+                                    ->helperText('Primary headline used throughout the editorial workspace and public article page.')
+                                    ->extraFieldWrapperAttributes(['class' => 'ops-article-workspace-field ops-article-workspace-field--title'])
+                                    ->extraInputAttributes(['class' => 'ops-article-workspace-input ops-article-workspace-input--title']),
+                                Forms\Components\TextInput::make('slug')
+                                    ->required()
+                                    ->maxLength(127)
+                                    ->helperText('Used in the public article URL. Keep it short, stable, and human-readable.')
+                                    ->extraFieldWrapperAttributes(['class' => 'ops-article-workspace-field']),
+                                Forms\Components\Textarea::make('excerpt')
+                                    ->rows(4)
+                                    ->columnSpanFull()
+                                    ->helperText('Short summary for list previews, share cards, and search snippets.')
+                                    ->extraFieldWrapperAttributes(['class' => 'ops-article-workspace-field ops-article-workspace-field--summary']),
+                            ])
+                            ->columns(2),
+                        Forms\Components\Section::make('Content')
+                            ->description('Draft the canonical article body and any lead media reference used by the frontend.')
+                            ->extraAttributes(['class' => 'ops-article-workspace-section ops-article-workspace-section--main'])
+                            ->schema([
+                                Forms\Components\MarkdownEditor::make('content_md')
+                                    ->required()
+                                    ->columnSpanFull()
+                                    ->helperText('This markdown body is the source content for article rendering and editorial review.')
+                                    ->extraFieldWrapperAttributes(['class' => 'ops-article-workspace-field ops-article-workspace-field--editor']),
+                                Forms\Components\TextInput::make('cover_image_url')
+                                    ->maxLength(255)
+                                    ->columnSpanFull()
+                                    ->helperText('Optional lead image URL used for cards, previews, and Open Graph fallback.'),
+                            ]),
+                    ])
+                        ->columnSpan([
+                            'xl' => 8,
+                        ])
+                        ->extraAttributes(['class' => 'ops-article-workspace-main-column']),
+                    Forms\Components\Group::make([
+                        Forms\Components\Section::make('Publish')
+                            ->description('Control editorial state, public visibility, and release timing from one side rail.')
+                            ->extraAttributes(['class' => 'ops-article-workspace-section ops-article-workspace-section--rail'])
+                            ->schema([
+                                Forms\Components\Placeholder::make('workspace_state')
+                                    ->label('Editorial cues')
+                                    ->content(fn (Forms\Get $get, ?Article $record) => ArticleWorkspace::renderEditorialCues($get, $record))
+                                    ->columnSpanFull(),
+                                Forms\Components\Select::make('status')
+                                    ->required()
+                                    ->options(self::statusOptions())
+                                    ->default('draft')
+                                    ->helperText('Published records are ready for release once visibility and scheduling are aligned.'),
+                                Forms\Components\Toggle::make('is_public')
+                                    ->label('Public visibility')
+                                    ->default(false)
+                                    ->helperText('Controls whether the article can be served on the public experience.'),
+                                Forms\Components\Toggle::make('is_indexable')
+                                    ->label('Search indexable')
+                                    ->default(true)
+                                    ->helperText('Signals whether search engines should index this article.'),
+                                Forms\Components\DateTimePicker::make('published_at')
+                                    ->helperText('Set the publish timestamp used for editorial reporting and release cues.'),
+                                Forms\Components\DateTimePicker::make('scheduled_at')
+                                    ->helperText('Optional future release time for editorial scheduling.'),
+                            ]),
+                        Forms\Components\Section::make('Locale, category, and tags')
+                            ->description('Organize the article for the right locale, taxonomy, and downstream filtering.')
+                            ->extraAttributes(['class' => 'ops-article-workspace-section ops-article-workspace-section--rail'])
+                            ->schema([
+                                Forms\Components\TextInput::make('locale')
+                                    ->required()
+                                    ->maxLength(16)
+                                    ->default('en')
+                                    ->helperText('Locale code used for editorial segmentation and frontend routing.'),
+                                Forms\Components\Select::make('category_id')
+                                    ->label('Category')
+                                    ->relationship(
+                                        'category',
+                                        'name',
+                                        fn (Builder $query): Builder => $query->whereIn('article_categories.org_id', self::tenantOrgIds())
+                                    )
+                                    ->searchable()
+                                    ->preload()
+                                    ->helperText('Primary editorial bucket for this article.'),
+                                BelongsToManyMultiSelect::make('tags')
+                                    ->relationship(
+                                        'tags',
+                                        'name',
+                                        fn (Builder $query): Builder => $query->whereIn('article_tags.org_id', self::tenantOrgIds())
+                                    )
+                                    ->searchable()
+                                    ->preload()
+                                    ->helperText('Tags help content operators slice the workspace and power discovery.'),
+                            ]),
+                        Forms\Components\Section::make('SEO')
+                            ->relationship('seoMeta')
+                            ->description('Keep search and social metadata grouped so the article stays easy to review and maintain.')
+                            ->extraAttributes(['class' => 'ops-article-workspace-section ops-article-workspace-section--rail'])
+                            ->schema([
+                                Forms\Components\Placeholder::make('seo_snapshot')
+                                    ->label('SEO snapshot')
+                                    ->content(fn (Forms\Get $get) => ArticleWorkspace::renderSeoSnapshot($get))
+                                    ->columnSpanFull(),
+                                Forms\Components\TextInput::make('seo_title')
+                                    ->maxLength(60)
+                                    ->helperText('Recommended search result headline. Keep it focused and concise.'),
+                                Forms\Components\Textarea::make('seo_description')
+                                    ->rows(3)
+                                    ->maxLength(160)
+                                    ->helperText('Search snippet summary shown in results and link previews.'),
+                                Forms\Components\TextInput::make('canonical_url')
+                                    ->maxLength(255)
+                                    ->helperText('Use when the public URL must explicitly point search engines to the canonical article URL.'),
+                                Forms\Components\TextInput::make('og_title')
+                                    ->maxLength(90)
+                                    ->helperText('Optional social headline override for richer sharing cards.'),
+                                Forms\Components\Textarea::make('og_description')
+                                    ->rows(3)
+                                    ->maxLength(200)
+                                    ->helperText('Optional social description override for editorial campaigns.'),
+                                Forms\Components\TextInput::make('og_image_url')
+                                    ->maxLength(255)
+                                    ->helperText('Optional image URL for Open Graph and social previews.'),
+                            ]),
+                        Forms\Components\Section::make('Record cues')
+                            ->description('Read-only context to help editors understand what is already live and when it last changed.')
+                            ->extraAttributes(['class' => 'ops-article-workspace-section ops-article-workspace-section--rail'])
+                            ->visible(fn (?Article $record): bool => filled($record))
+                            ->schema([
+                                Forms\Components\Placeholder::make('public_url_preview')
+                                    ->label('Public URL')
+                                    ->content(fn (Forms\Get $get, ?Article $record): string => ArticleWorkspace::publicUrl((string) ($get('slug') ?? $record?->slug ?? '')) ?? 'Public URL appears after a slug is set.'),
+                                Forms\Components\Placeholder::make('created_at_summary')
+                                    ->label('Created')
+                                    ->content(fn (?Article $record): string => ArticleWorkspace::formatTimestamp($record?->created_at, 'Draft not saved yet')),
+                                Forms\Components\Placeholder::make('updated_at_summary')
+                                    ->label('Last updated')
+                                    ->content(fn (?Article $record): string => ArticleWorkspace::formatTimestamp($record?->updated_at, 'Draft not saved yet')),
+                                Forms\Components\Placeholder::make('published_at_summary')
+                                    ->label('Last published')
+                                    ->content(fn (?Article $record): string => ArticleWorkspace::formatTimestamp($record?->published_at, 'Not published yet')),
+                            ]),
+                    ])
+                        ->columnSpan([
+                            'xl' => 4,
+                        ])
+                        ->extraAttributes(['class' => 'ops-article-workspace-rail-column']),
                 ]),
         ]);
     }
@@ -149,33 +229,45 @@ class ArticleResource extends Resource
     {
         return $table
             ->columns([
-                Tables\Columns\TextColumn::make('id')
-                    ->sortable(),
                 Tables\Columns\TextColumn::make('title')
+                    ->label('Article')
+                    ->html()
                     ->searchable()
-                    ->sortable(),
+                    ->sortable()
+                    ->formatStateUsing(fn (Article $record): string => (string) view('filament.ops.articles.partials.table-title', [
+                        'meta' => ArticleWorkspace::titleMeta($record),
+                        'title' => $record->title,
+                    ])->render()),
                 Tables\Columns\TextColumn::make('slug')
                     ->searchable()
-                    ->copyable(),
+                    ->copyable()
+                    ->formatStateUsing(fn (string $state): string => '/'.trim($state, '/'))
+                    ->toggleable(isToggledHiddenByDefault: true),
                 Tables\Columns\TextColumn::make('status')
                     ->badge()
                     ->sortable()
+                    ->formatStateUsing(fn (string $state): string => ucfirst($state))
+                    ->description(fn (Article $record): string => ArticleWorkspace::visibilityMeta($record))
                     ->color(fn (string $state): string => StatusBadge::color($state)),
                 Tables\Columns\TextColumn::make('locale')
-                    ->sortable(),
+                    ->sortable()
+                    ->toggleable(isToggledHiddenByDefault: true),
+                Tables\Columns\TextColumn::make('category.name')
+                    ->label('Category')
+                    ->toggleable(isToggledHiddenByDefault: true),
                 Tables\Columns\TextColumn::make('published_at')
+                    ->label('Published')
                     ->dateTime()
-                    ->sortable(),
+                    ->sortable()
+                    ->placeholder('Not published'),
                 Tables\Columns\TextColumn::make('updated_at')
-                    ->dateTime()
+                    ->label('Updated')
+                    ->since()
                     ->sortable(),
             ])
             ->filters([
                 Tables\Filters\SelectFilter::make('status')
-                    ->options([
-                        'draft' => 'draft',
-                        'published' => 'published',
-                    ]),
+                    ->options(self::statusOptions()),
                 Tables\Filters\SelectFilter::make('locale')
                     ->options(fn (): array => static::getEloquentQuery()
                         ->select('locale')
@@ -185,9 +277,14 @@ class ArticleResource extends Resource
                         ->pluck('locale', 'locale')
                         ->toArray()),
             ])
+            ->searchPlaceholder('Search title or slug')
             ->defaultSort('updated_at', 'desc')
+            ->recordUrl(fn (Article $record): string => static::getUrl('edit', ['record' => $record]))
             ->actions([
-                Tables\Actions\EditAction::make(),
+                Tables\Actions\EditAction::make()
+                    ->label('Edit')
+                    ->icon('heroicon-o-pencil-square')
+                    ->color('gray'),
             ])
             ->bulkActions([]);
     }
@@ -215,6 +312,17 @@ class ArticleResource extends Resource
         $orgId = max(0, (int) app(OrgContext::class)->orgId());
 
         return $orgId > 0 ? [0, $orgId] : [0];
+    }
+
+    /**
+     * @return array<string,string>
+     */
+    private static function statusOptions(): array
+    {
+        return [
+            'draft' => 'draft',
+            'published' => 'published',
+        ];
     }
 
     private static function canRead(): bool

--- a/backend/app/Filament/Ops/Resources/ArticleResource/Pages/CreateArticle.php
+++ b/backend/app/Filament/Ops/Resources/ArticleResource/Pages/CreateArticle.php
@@ -5,9 +5,63 @@ declare(strict_types=1);
 namespace App\Filament\Ops\Resources\ArticleResource\Pages;
 
 use App\Filament\Ops\Resources\ArticleResource;
+use Filament\Actions\Action;
 use Filament\Resources\Pages\CreateRecord;
+use Illuminate\Contracts\Support\Htmlable;
 
 class CreateArticle extends CreateRecord
 {
     protected static string $resource = ArticleResource::class;
+
+    public function getTitle(): string|Htmlable
+    {
+        return 'Create Article';
+    }
+
+    public function getSubheading(): ?string
+    {
+        return 'Draft the article body in the main canvas, then finish publishing and SEO details in the side rail.';
+    }
+
+    protected function getHeaderActions(): array
+    {
+        return [
+            Action::make('backToArticles')
+                ->label('All Articles')
+                ->url(ArticleResource::getUrl())
+                ->icon('heroicon-o-arrow-left')
+                ->color('gray'),
+        ];
+    }
+
+    protected function getCreateFormAction(): Action
+    {
+        return parent::getCreateFormAction()
+            ->label('Create Article')
+            ->icon('heroicon-o-check-circle');
+    }
+
+    protected function getCreateAnotherFormAction(): Action
+    {
+        return parent::getCreateAnotherFormAction()
+            ->label('Create & Add Another')
+            ->icon('heroicon-o-document-duplicate');
+    }
+
+    protected function getCancelFormAction(): Action
+    {
+        return parent::getCancelFormAction()
+            ->label('Back to Articles')
+            ->icon('heroicon-o-arrow-left');
+    }
+
+    protected function getCreatedNotificationTitle(): ?string
+    {
+        return 'Article created';
+    }
+
+    protected function getRedirectUrl(): string
+    {
+        return ArticleResource::getUrl('edit', ['record' => $this->getRecord()]);
+    }
 }

--- a/backend/app/Filament/Ops/Resources/ArticleResource/Pages/EditArticle.php
+++ b/backend/app/Filament/Ops/Resources/ArticleResource/Pages/EditArticle.php
@@ -5,9 +5,63 @@ declare(strict_types=1);
 namespace App\Filament\Ops\Resources\ArticleResource\Pages;
 
 use App\Filament\Ops\Resources\ArticleResource;
+use App\Filament\Ops\Resources\ArticleResource\Support\ArticleWorkspace;
+use Filament\Actions\Action;
 use Filament\Resources\Pages\EditRecord;
+use Illuminate\Contracts\Support\Htmlable;
 
 class EditArticle extends EditRecord
 {
     protected static string $resource = ArticleResource::class;
+
+    public function getTitle(): string|Htmlable
+    {
+        return filled($this->getRecord()->title) ? (string) $this->getRecord()->title : 'Edit Article';
+    }
+
+    public function getSubheading(): ?string
+    {
+        return 'Refine the article body, release cues, and SEO metadata without leaving the editorial workspace.';
+    }
+
+    protected function getHeaderActions(): array
+    {
+        return [
+            Action::make('backToArticles')
+                ->label('All Articles')
+                ->url(ArticleResource::getUrl())
+                ->icon('heroicon-o-arrow-left')
+                ->color('gray'),
+            Action::make('openPublicUrl')
+                ->label('Open Public URL')
+                ->url(fn (): ?string => ArticleWorkspace::publicUrl((string) $this->getRecord()->slug), shouldOpenInNewTab: true)
+                ->icon('heroicon-o-arrow-top-right-on-square')
+                ->color('gray')
+                ->visible(fn (): bool => (bool) $this->getRecord()->is_public && filled(ArticleWorkspace::publicUrl((string) $this->getRecord()->slug))),
+        ];
+    }
+
+    protected function getSaveFormAction(): Action
+    {
+        return parent::getSaveFormAction()
+            ->label('Save Changes')
+            ->icon('heroicon-o-check-circle');
+    }
+
+    protected function getCancelFormAction(): Action
+    {
+        return parent::getCancelFormAction()
+            ->label('Back to Articles')
+            ->icon('heroicon-o-arrow-left');
+    }
+
+    protected function getSavedNotificationTitle(): ?string
+    {
+        return 'Article updated';
+    }
+
+    protected function getRedirectUrl(): string
+    {
+        return ArticleResource::getUrl('edit', ['record' => $this->getRecord()]);
+    }
 }

--- a/backend/app/Filament/Ops/Resources/ArticleResource/Pages/ListArticles.php
+++ b/backend/app/Filament/Ops/Resources/ArticleResource/Pages/ListArticles.php
@@ -8,6 +8,7 @@ use App\Filament\Ops\Resources\ArticleResource;
 use App\Filament\Ops\Resources\Pages\Concerns\HasSharedListEmptyState;
 use Filament\Actions;
 use Filament\Resources\Pages\ListRecords;
+use Illuminate\Contracts\Support\Htmlable;
 
 class ListArticles extends ListRecords
 {
@@ -15,10 +16,22 @@ class ListArticles extends ListRecords
 
     protected static string $resource = ArticleResource::class;
 
+    public function getTitle(): string|Htmlable
+    {
+        return 'Articles';
+    }
+
+    public function getSubheading(): ?string
+    {
+        return 'Content workspace for drafting, publishing, and SEO-ready editorial updates.';
+    }
+
     protected function getHeaderActions(): array
     {
         return [
-            Actions\CreateAction::make(),
+            Actions\CreateAction::make()
+                ->label('Create Article')
+                ->icon('heroicon-o-plus'),
         ];
     }
 }

--- a/backend/app/Filament/Ops/Resources/ArticleResource/Support/ArticleWorkspace.php
+++ b/backend/app/Filament/Ops/Resources/ArticleResource/Support/ArticleWorkspace.php
@@ -1,0 +1,158 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Filament\Ops\Resources\ArticleResource\Support;
+
+use App\Filament\Ops\Support\StatusBadge;
+use App\Models\Article;
+use Filament\Forms\Get;
+use Illuminate\Contracts\Support\Htmlable;
+use Illuminate\Support\Carbon;
+use Illuminate\Support\HtmlString;
+use Illuminate\Support\Str;
+
+final class ArticleWorkspace
+{
+    public static function publicUrl(?string $slug): ?string
+    {
+        $baseUrl = rtrim((string) config('services.seo.articles_url_prefix', ''), '/');
+        $resolvedSlug = trim((string) $slug);
+
+        if ($baseUrl === '' || $resolvedSlug === '') {
+            return null;
+        }
+
+        return $baseUrl.'/'.rawurlencode($resolvedSlug);
+    }
+
+    public static function renderEditorialCues(Get $get, ?Article $record = null): Htmlable
+    {
+        $status = trim((string) ($get('status') ?? $record?->status ?? 'draft'));
+        $isPublic = StatusBadge::isTruthy($get('is_public') ?? $record?->is_public ?? false);
+        $isIndexable = StatusBadge::isTruthy($get('is_indexable') ?? $record?->is_indexable ?? true);
+        $publicUrl = self::publicUrl((string) ($get('slug') ?? $record?->slug ?? ''));
+
+        return new HtmlString((string) view('filament.ops.articles.partials.editorial-cues', [
+            'facts' => array_values(array_filter([
+                [
+                    'label' => 'Published',
+                    'value' => self::formatTimestamp($get('published_at') ?? $record?->published_at),
+                ],
+                [
+                    'label' => 'Scheduled',
+                    'value' => self::formatTimestamp($get('scheduled_at') ?? $record?->scheduled_at),
+                ],
+                [
+                    'label' => 'Public URL',
+                    'value' => $publicUrl,
+                    'href' => $publicUrl,
+                ],
+            ], static fn (array $fact): bool => filled($fact['value'] ?? null))),
+            'pills' => [
+                [
+                    'label' => self::statusLabel($status),
+                    'state' => $status,
+                ],
+                [
+                    'label' => $isPublic ? 'Public' : 'Private',
+                    'state' => $isPublic ? 'public' : 'inactive',
+                ],
+                [
+                    'label' => $isIndexable ? 'Indexable' : 'Noindex',
+                    'state' => $isIndexable ? 'indexable' : 'noindex',
+                ],
+            ],
+        ])->render());
+    }
+
+    public static function renderSeoSnapshot(Get $get): Htmlable
+    {
+        $seoTitle = trim((string) ($get('seo_title') ?? ''));
+        $seoDescription = trim((string) ($get('seo_description') ?? ''));
+        $canonicalUrl = trim((string) ($get('canonical_url') ?? ''));
+        $ogTitle = trim((string) ($get('og_title') ?? ''));
+        $ogDescription = trim((string) ($get('og_description') ?? ''));
+        $ogImageUrl = trim((string) ($get('og_image_url') ?? ''));
+
+        return new HtmlString((string) view('filament.ops.articles.partials.seo-snapshot', [
+            'canonicalUrl' => $canonicalUrl !== '' ? $canonicalUrl : null,
+            'checks' => [
+                [
+                    'label' => 'SEO title',
+                    'description' => 'Search result headline.',
+                    'ready' => $seoTitle !== '',
+                ],
+                [
+                    'label' => 'SEO description',
+                    'description' => 'Search snippet summary.',
+                    'ready' => $seoDescription !== '',
+                ],
+                [
+                    'label' => 'Canonical URL',
+                    'description' => 'Matches the intended public article URL.',
+                    'ready' => $canonicalUrl !== '',
+                ],
+                [
+                    'label' => 'Open Graph',
+                    'description' => 'Title, description, and social image coverage.',
+                    'ready' => $ogTitle !== '' && $ogDescription !== '' && $ogImageUrl !== '',
+                ],
+            ],
+        ])->render());
+    }
+
+    public static function formatTimestamp(mixed $value, string $fallback = 'Not set yet'): string
+    {
+        $formatted = self::normalizeTimestamp($value);
+
+        return $formatted ?? $fallback;
+    }
+
+    public static function titleMeta(Article $record): string
+    {
+        return collect([
+            filled($record->slug) ? '/'.trim((string) $record->slug, '/') : null,
+            filled($record->locale) ? Str::upper((string) $record->locale) : null,
+        ])->filter(static fn (?string $value): bool => filled($value))->implode(' · ');
+    }
+
+    public static function visibilityMeta(Article $record): string
+    {
+        return implode(' · ', [
+            StatusBadge::booleanLabel($record->is_public, 'Public', 'Private'),
+            StatusBadge::booleanLabel($record->is_indexable, 'Indexable', 'Noindex'),
+        ]);
+    }
+
+    private static function normalizeTimestamp(mixed $value): ?string
+    {
+        if ($value instanceof \DateTimeInterface) {
+            return Carbon::instance($value)->timezone(config('app.timezone'))->format('M j, Y H:i');
+        }
+
+        if (! is_string($value) || trim($value) === '') {
+            return null;
+        }
+
+        try {
+            return Carbon::parse($value)->timezone(config('app.timezone'))->format('M j, Y H:i');
+        } catch (\Throwable) {
+            return null;
+        }
+    }
+
+    private static function statusLabel(string $status): string
+    {
+        $normalized = trim($status);
+
+        if ($normalized === '') {
+            return 'Draft';
+        }
+
+        return Str::of($normalized)
+            ->replace(['_', '-'], ' ')
+            ->headline()
+            ->value();
+    }
+}

--- a/backend/resources/css/filament/ops/theme.css
+++ b/backend/resources/css/filament/ops/theme.css
@@ -1183,6 +1183,178 @@
     .ops-two-factor-stack .fi-btn {
         width: fit-content;
     }
+
+    .ops-article-workspace-layout {
+        align-items: start;
+    }
+
+    .ops-article-workspace-main-column,
+    .ops-article-workspace-rail-column {
+        display: grid;
+        gap: 1.25rem;
+        align-self: start;
+    }
+
+    .ops-article-workspace-section .fi-section-header {
+        gap: 0.45rem;
+    }
+
+    .ops-article-workspace-section--main .fi-section-header-heading {
+        font-size: 1.2rem;
+    }
+
+    .ops-article-workspace-section--rail .fi-section-header-heading {
+        font-size: 1rem;
+    }
+
+    .ops-article-workspace-field--title .fi-input-wrp {
+        min-height: 3.35rem;
+    }
+
+    .ops-article-workspace-input--title {
+        font-size: 1.1rem;
+        font-weight: 700;
+        letter-spacing: -0.025em;
+    }
+
+    .ops-article-workspace-field--summary textarea {
+        min-height: 8rem;
+    }
+
+    .ops-article-workspace-field--editor .fi-fo-markdown-editor {
+        min-height: 25rem;
+        background: linear-gradient(180deg, rgba(255, 255, 255, 0.99), rgba(251, 252, 253, 0.96));
+    }
+
+    .ops-article-workspace-field--editor .editor-toolbar {
+        border-color: var(--ops-border-default);
+        background: var(--ops-bg-surface-subtle);
+    }
+
+    .ops-article-workspace-field--editor .CodeMirror,
+    .ops-article-workspace-field--editor .EasyMDEContainer {
+        border-color: transparent;
+        background: transparent;
+    }
+
+    .ops-article-workspace-field--editor .CodeMirror-scroll {
+        min-height: 20rem;
+    }
+
+    .ops-article-workspace-section .fi-fo-placeholder {
+        display: grid;
+        gap: 0.75rem;
+        border-radius: 14px;
+        background: var(--ops-bg-surface-subtle);
+        padding: 0.95rem 1rem;
+        box-shadow: inset 0 0 0 1px rgba(229, 231, 235, 0.92);
+    }
+
+    .ops-article-workspace-cues,
+    .ops-article-workspace-seo {
+        display: grid;
+        gap: 0.85rem;
+    }
+
+    .ops-article-workspace-cues__pills {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 0.5rem;
+    }
+
+    .ops-article-workspace-cues__facts {
+        display: grid;
+        gap: 0.65rem;
+    }
+
+    .ops-article-workspace-cues__fact {
+        display: grid;
+        gap: 0.15rem;
+    }
+
+    .ops-article-workspace-cues__fact dt {
+        color: var(--ops-text-tertiary);
+        font-size: 0.6875rem;
+        font-weight: 700;
+        letter-spacing: 0.12em;
+        text-transform: uppercase;
+    }
+
+    .ops-article-workspace-cues__fact dd,
+    .ops-article-workspace-cues__fact a {
+        color: var(--ops-text-primary);
+        font-size: 0.875rem;
+        font-weight: 600;
+        line-height: 1.55;
+        text-decoration: none;
+    }
+
+    .ops-article-workspace-cues__fact a:hover {
+        color: rgb(var(--primary-700));
+    }
+
+    .ops-article-workspace-seo__grid {
+        display: grid;
+        gap: 0.75rem;
+    }
+
+    .ops-article-workspace-seo__item {
+        display: flex;
+        align-items: flex-start;
+        justify-content: space-between;
+        gap: 1rem;
+        border-radius: 14px;
+        background: rgba(255, 255, 255, 0.94);
+        padding: 0.85rem 0.95rem;
+        box-shadow: inset 0 0 0 1px rgba(229, 231, 235, 0.92);
+    }
+
+    .ops-article-workspace-seo__copy {
+        display: grid;
+        gap: 0.15rem;
+    }
+
+    .ops-article-workspace-seo__label {
+        color: var(--ops-text-primary);
+        font-size: 0.8125rem;
+        font-weight: 700;
+        letter-spacing: -0.01em;
+    }
+
+    .ops-article-workspace-seo__description {
+        color: var(--ops-text-secondary);
+        font-size: 0.75rem;
+        line-height: 1.55;
+    }
+
+    .ops-article-workspace-seo__link {
+        color: rgb(var(--primary-700));
+        font-size: 0.8125rem;
+        font-weight: 700;
+        text-decoration: none;
+    }
+
+    .ops-article-workspace-seo__link:hover {
+        color: rgb(var(--primary-600));
+    }
+
+    .ops-article-workspace-table-title {
+        display: grid;
+        gap: 0.2rem;
+    }
+
+    .ops-article-workspace-table-title__text {
+        color: var(--ops-text-primary);
+        font-size: 0.95rem;
+        font-weight: 700;
+        letter-spacing: -0.02em;
+    }
+
+    .ops-article-workspace-table-title__meta {
+        color: var(--ops-text-secondary);
+        font-size: 0.75rem;
+        line-height: 1.55;
+    }
 }
 
 @media (max-width: 1023px) {
@@ -1232,5 +1404,9 @@
 
     .ops-workbench-toolbar__actions {
         justify-content: flex-start;
+    }
+
+    .ops-article-workspace-seo__item {
+        flex-direction: column;
     }
 }

--- a/backend/resources/views/filament/ops/articles/partials/editorial-cues.blade.php
+++ b/backend/resources/views/filament/ops/articles/partials/editorial-cues.blade.php
@@ -1,0 +1,27 @@
+<div class="ops-article-workspace-cues">
+    <div class="ops-article-workspace-cues__pills">
+        @foreach ($pills as $pill)
+            <x-filament.ops.shared.status-pill :label="$pill['label']" :state="$pill['state']" />
+        @endforeach
+    </div>
+
+    @if ($facts !== [])
+        <dl class="ops-article-workspace-cues__facts">
+            @foreach ($facts as $fact)
+                <div class="ops-article-workspace-cues__fact">
+                    <dt>{{ $fact['label'] }}</dt>
+
+                    <dd>
+                        @if (filled($fact['href'] ?? null))
+                            <a href="{{ $fact['href'] }}" target="_blank" rel="noreferrer">
+                                {{ $fact['value'] }}
+                            </a>
+                        @else
+                            {{ $fact['value'] }}
+                        @endif
+                    </dd>
+                </div>
+            @endforeach
+        </dl>
+    @endif
+</div>

--- a/backend/resources/views/filament/ops/articles/partials/seo-snapshot.blade.php
+++ b/backend/resources/views/filament/ops/articles/partials/seo-snapshot.blade.php
@@ -1,0 +1,28 @@
+<div class="ops-article-workspace-seo">
+    <div class="ops-article-workspace-seo__grid">
+        @foreach ($checks as $check)
+            <div class="ops-article-workspace-seo__item">
+                <div class="ops-article-workspace-seo__copy">
+                    <span class="ops-article-workspace-seo__label">{{ $check['label'] }}</span>
+                    <span class="ops-article-workspace-seo__description">{{ $check['description'] }}</span>
+                </div>
+
+                <x-filament.ops.shared.status-pill
+                    :label="$check['ready'] ? 'Ready' : 'Missing'"
+                    :state="$check['ready'] ? 'ready' : 'draft'"
+                />
+            </div>
+        @endforeach
+    </div>
+
+    @if (filled($canonicalUrl))
+        <a
+            class="ops-article-workspace-seo__link"
+            href="{{ $canonicalUrl }}"
+            target="_blank"
+            rel="noreferrer"
+        >
+            Open canonical URL
+        </a>
+    @endif
+</div>

--- a/backend/resources/views/filament/ops/articles/partials/table-title.blade.php
+++ b/backend/resources/views/filament/ops/articles/partials/table-title.blade.php
@@ -1,0 +1,7 @@
+<div class="ops-article-workspace-table-title">
+    <span class="ops-article-workspace-table-title__text">{{ $title }}</span>
+
+    @if (filled($meta))
+        <span class="ops-article-workspace-table-title__meta">{{ $meta }}</span>
+    @endif
+</div>


### PR DESCRIPTION
## Summary
- turn the Articles resource into a more product-like editorial workspace
- improve the list, create, and edit experiences on top of the existing theme, shell, and shared-component upgrades

## What changed
- refine the Articles list as a clearer content workspace with stronger title/meta hierarchy and a clearer primary action
- reorganize create/edit pages into a stronger main-content vs metadata structure using Filament form layout APIs
- improve publish, URL, and SEO presentation without changing underlying logic or service behavior
- add lightweight editorial cues and SEO snapshot partials to make release state easier to scan
- keep the existing business logic, APIs, and permissions unchanged

## Implementation approach
- reused the existing custom Filament theme, shell, and shared component layers from PR-01 through PR-03
- used Filament Grid, Section, Placeholder, page actions, and table configuration instead of publishing vendor views
- added a small article-scoped helper and partials for editorial cues, SEO readiness, and list-row meta

## Why this PR is small and safe
- no database changes
- no API changes
- no route changes
- no permission changes
- no Article service logic changes
- only workspace-level UI improvements for the Articles resource

## Validation
- `cd backend && ./vendor/bin/pint app/Filament/Ops/Resources/ArticleResource.php app/Filament/Ops/Resources/ArticleResource/Pages/ListArticles.php app/Filament/Ops/Resources/ArticleResource/Pages/CreateArticle.php app/Filament/Ops/Resources/ArticleResource/Pages/EditArticle.php app/Filament/Ops/Resources/ArticleResource/Support/ArticleWorkspace.php`
- `cd backend && php artisan route:list --path=ops --except-vendor`
- `cd backend && php artisan about`
- `cd backend && php artisan route:list`
- `cd backend && php artisan migrate`
- `cd backend && php artisan filament:assets`
- `cd backend && npm run build`
- authenticated smoke checks for `/ops/articles`, `/ops/articles/create`, `/ops/articles/{record}/edit`
- `bash backend/scripts/ci_verify_mbti.sh`

## Notes
- Filament vendor views were not published
- `npm run build` still shows the non-blocking `Browserslist: caniuse-lite is outdated` warning
- PHP 8.5 emits existing Filament 3 deprecation warnings during framework-level page smoke checks; this PR does not change vendor code