### PR TITLE
fix(cors): simplify api cors allowlist

### DIFF
--- a/backend/config/cors.php
+++ b/backend/config/cors.php
@@ -1,34 +1,29 @@
 <?php
 
 return [
-    'paths' => ['api/*'],
+    'paths' => [
+        'api/*',
+        'sanctum/csrf-cookie',
+    ],
 
-    'allowed_methods' => ['GET', 'POST', 'PUT', 'PATCH', 'DELETE', 'OPTIONS'],
+    'allowed_methods' => ['*'],
 
     'allowed_origins' => [
-        'https://www.fermatmind.com',
         'https://fermatmind.com',
+        'https://www.fermatmind.com',
     ],
 
     'allowed_origins_patterns' => [],
 
-    'allowed_headers' => [
-        'Authorization',
-        'Content-Type',
-        'X-Org-Id',
-        'X-FM-Org-Id',
-        'X-Anon-Id',
-        'Idempotency-Key',
-        'X-Request-Id',
-        'X-Requested-With',
-        'Accept',
-    ],
+    'allowed_headers' => ['*'],
 
     'exposed_headers' => [
         'X-Request-Id',
+        'X-RateLimit-Limit',
+        'X-RateLimit-Remaining',
     ],
 
-    'max_age' => 86400,
+    'max_age' => 600,
 
     'supports_credentials' => false,
 ];


### PR DESCRIPTION
## Summary
- simplify the backend API CORS configuration for the public FermatMind origins
- make preflight handling less brittle by allowing all methods and headers for the approved origins

## What changed
- include `sanctum/csrf-cookie` in the CORS paths alongside `api/*`
- switch `allowed_methods` to `['*']`
- switch `allowed_headers` to `['*']`
- keep the allowlist restricted to `https://fermatmind.com` and `https://www.fermatmind.com`
- expose rate-limit headers in addition to `X-Request-Id`
- reduce `max_age` from `86400` to `600`

## Why
- the previous configuration required keeping method and header lists in sync manually
- wildcard methods/headers reduce avoidable CORS/preflight failures for approved origins without opening the API to arbitrary origins
- adding `sanctum/csrf-cookie` keeps the CORS scope aligned with common Laravel frontend auth/bootstrap flows

## Validation
- `php -l backend/config/cors.php`
- `cd backend && php artisan route:list`
- `cd backend && php artisan migrate`

## Notes
- this PR only changes `backend/config/cors.php`
- no routes, controllers, services, or database schema were changed