### PR TITLE
feat(personality-cms): add schema and models for personality profiles

### DIFF
--- a/backend/app/Models/PersonalityProfile.php
+++ b/backend/app/Models/PersonalityProfile.php
@@ -1,0 +1,119 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Models;
+
+use App\Models\Concerns\HasOrgScope;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+use Illuminate\Database\Eloquent\Relations\HasOne;
+
+class PersonalityProfile extends Model
+{
+    use HasFactory, HasOrgScope;
+
+    public const SCALE_CODE_MBTI = 'MBTI';
+
+    public const TYPE_CODES = [
+        'INTJ',
+        'INTP',
+        'ENTJ',
+        'ENTP',
+        'INFJ',
+        'INFP',
+        'ENFJ',
+        'ENFP',
+        'ISTJ',
+        'ISFJ',
+        'ESTJ',
+        'ESFJ',
+        'ISTP',
+        'ISFP',
+        'ESTP',
+        'ESFP',
+    ];
+
+    public const SUPPORTED_LOCALES = [
+        'en',
+        'zh-CN',
+    ];
+
+    protected $table = 'personality_profiles';
+
+    protected $fillable = [
+        'org_id',
+        'scale_code',
+        'type_code',
+        'slug',
+        'locale',
+        'title',
+        'subtitle',
+        'excerpt',
+        'hero_kicker',
+        'hero_quote',
+        'hero_image_url',
+        'status',
+        'is_public',
+        'is_indexable',
+        'published_at',
+        'scheduled_at',
+        'schema_version',
+        'created_by_admin_user_id',
+        'updated_by_admin_user_id',
+    ];
+
+    protected $casts = [
+        'org_id' => 'integer',
+        'created_by_admin_user_id' => 'integer',
+        'updated_by_admin_user_id' => 'integer',
+        'is_public' => 'boolean',
+        'is_indexable' => 'boolean',
+        'published_at' => 'datetime',
+        'scheduled_at' => 'datetime',
+        'created_at' => 'datetime',
+        'updated_at' => 'datetime',
+    ];
+
+    public static function allowOrgZeroContext(): bool
+    {
+        return true;
+    }
+
+    public function sections(): HasMany
+    {
+        return $this->hasMany(PersonalityProfileSection::class, 'profile_id', 'id')
+            ->orderBy('sort_order')
+            ->orderBy('id');
+    }
+
+    public function seoMeta(): HasOne
+    {
+        return $this->hasOne(PersonalityProfileSeoMeta::class, 'profile_id', 'id');
+    }
+
+    public function revisions(): HasMany
+    {
+        return $this->hasMany(PersonalityProfileRevision::class, 'profile_id', 'id')
+            ->orderByDesc('revision_no')
+            ->orderByDesc('id');
+    }
+
+    public function scopePublishedPublic($query)
+    {
+        return $query
+            ->where('status', 'published')
+            ->where('is_public', true);
+    }
+
+    public function scopeForLocale($query, string $locale)
+    {
+        return $query->where('locale', $locale);
+    }
+
+    public function scopeForType($query, string $typeCode)
+    {
+        return $query->where('type_code', strtoupper($typeCode));
+    }
+}

--- a/backend/app/Models/PersonalityProfileRevision.php
+++ b/backend/app/Models/PersonalityProfileRevision.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+class PersonalityProfileRevision extends Model
+{
+    use HasFactory;
+
+    protected $table = 'personality_profile_revisions';
+
+    public $timestamps = false;
+
+    protected $fillable = [
+        'profile_id',
+        'revision_no',
+        'snapshot_json',
+        'note',
+        'created_by_admin_user_id',
+        'created_at',
+    ];
+
+    protected $casts = [
+        'profile_id' => 'integer',
+        'revision_no' => 'integer',
+        'snapshot_json' => 'array',
+        'created_by_admin_user_id' => 'integer',
+        'created_at' => 'datetime',
+    ];
+
+    public function profile(): BelongsTo
+    {
+        return $this->belongsTo(PersonalityProfile::class, 'profile_id', 'id');
+    }
+}

--- a/backend/app/Models/PersonalityProfileSection.php
+++ b/backend/app/Models/PersonalityProfileSection.php
@@ -1,0 +1,65 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+class PersonalityProfileSection extends Model
+{
+    use HasFactory;
+
+    public const SECTION_KEYS = [
+        'hero',
+        'core_snapshot',
+        'strengths',
+        'growth_edges',
+        'work_style',
+        'relationships',
+        'communication',
+        'stress_and_recovery',
+        'career_fit',
+        'faq',
+        'related_content',
+    ];
+
+    public const RENDER_VARIANTS = [
+        'rich_text',
+        'bullets',
+        'cards',
+        'faq',
+        'links',
+        'callout',
+    ];
+
+    protected $table = 'personality_profile_sections';
+
+    protected $fillable = [
+        'profile_id',
+        'section_key',
+        'title',
+        'render_variant',
+        'body_md',
+        'body_html',
+        'payload_json',
+        'sort_order',
+        'is_enabled',
+    ];
+
+    protected $casts = [
+        'profile_id' => 'integer',
+        'payload_json' => 'array',
+        'sort_order' => 'integer',
+        'is_enabled' => 'boolean',
+        'created_at' => 'datetime',
+        'updated_at' => 'datetime',
+    ];
+
+    public function profile(): BelongsTo
+    {
+        return $this->belongsTo(PersonalityProfile::class, 'profile_id', 'id');
+    }
+}

--- a/backend/app/Models/PersonalityProfileSeoMeta.php
+++ b/backend/app/Models/PersonalityProfileSeoMeta.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+class PersonalityProfileSeoMeta extends Model
+{
+    use HasFactory;
+
+    protected $table = 'personality_profile_seo_meta';
+
+    protected $fillable = [
+        'profile_id',
+        'seo_title',
+        'seo_description',
+        'canonical_url',
+        'og_title',
+        'og_description',
+        'og_image_url',
+        'twitter_title',
+        'twitter_description',
+        'twitter_image_url',
+        'robots',
+        'jsonld_overrides_json',
+    ];
+
+    protected $casts = [
+        'profile_id' => 'integer',
+        'jsonld_overrides_json' => 'array',
+        'created_at' => 'datetime',
+        'updated_at' => 'datetime',
+    ];
+
+    public function profile(): BelongsTo
+    {
+        return $this->belongsTo(PersonalityProfile::class, 'profile_id', 'id');
+    }
+}

--- a/backend/database/migrations/2026_03_08_000100_create_personality_profiles_table.php
+++ b/backend/database/migrations/2026_03_08_000100_create_personality_profiles_table.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('personality_profiles', function (Blueprint $table): void {
+            $table->bigIncrements('id');
+            $table->unsignedBigInteger('org_id')->default(0);
+            $table->string('scale_code', 32)->default('MBTI');
+            $table->string('type_code', 8);
+            $table->string('slug', 64);
+            $table->string('locale', 16);
+            $table->string('title', 255);
+            $table->string('subtitle', 255)->nullable();
+            $table->text('excerpt')->nullable();
+            $table->string('hero_kicker', 128)->nullable();
+            $table->text('hero_quote')->nullable();
+            $table->text('hero_image_url')->nullable();
+            $table->string('status', 32)->default('draft');
+            $table->boolean('is_public')->default(true);
+            $table->boolean('is_indexable')->default(true);
+            $table->timestamp('published_at')->nullable();
+            $table->timestamp('scheduled_at')->nullable();
+            $table->string('schema_version', 32)->default('v1');
+            $table->unsignedBigInteger('created_by_admin_user_id')->nullable();
+            $table->unsignedBigInteger('updated_by_admin_user_id')->nullable();
+            $table->timestamps();
+
+            $table->unique(['org_id', 'scale_code', 'type_code', 'locale'], 'uq_personality_profile');
+            $table->unique(['org_id', 'scale_code', 'slug', 'locale'], 'uq_personality_slug');
+            $table->index(['status', 'is_public', 'published_at'], 'idx_personality_status');
+            $table->index(['locale'], 'idx_personality_locale');
+            $table->index(['type_code'], 'idx_personality_type');
+        });
+    }
+
+    public function down(): void
+    {
+        // forward-only migration: rollback disabled to prevent data loss in production.
+        // Irreversible operation: schema/data rollback handled via forward fix migrations.
+    }
+};

--- a/backend/database/migrations/2026_03_08_000110_create_personality_profile_sections_table.php
+++ b/backend/database/migrations/2026_03_08_000110_create_personality_profile_sections_table.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        $isSqlite = Schema::getConnection()->getDriverName() === 'sqlite';
+
+        Schema::create('personality_profile_sections', function (Blueprint $table) use ($isSqlite): void {
+            $table->bigIncrements('id');
+            $table->unsignedBigInteger('profile_id');
+            $table->string('section_key', 64);
+            $table->string('title', 255)->nullable();
+            $table->string('render_variant', 32)->default('rich_text');
+            $table->longText('body_md')->nullable();
+            $table->longText('body_html')->nullable();
+            if ($isSqlite) {
+                $table->text('payload_json')->nullable();
+            } else {
+                $table->json('payload_json')->nullable();
+            }
+            $table->integer('sort_order')->default(0);
+            $table->boolean('is_enabled')->default(true);
+            $table->timestamps();
+
+            $table->unique(['profile_id', 'section_key'], 'uq_profile_section');
+            $table->index(['profile_id', 'sort_order'], 'idx_profile_section_sort');
+            $table->foreign('profile_id', 'fk_profile_section_profile')
+                ->references('id')
+                ->on('personality_profiles')
+                ->cascadeOnDelete();
+        });
+    }
+
+    public function down(): void
+    {
+        // forward-only migration: rollback disabled to prevent data loss in production.
+        // Irreversible operation: schema/data rollback handled via forward fix migrations.
+    }
+};

--- a/backend/database/migrations/2026_03_08_000120_create_personality_profile_seo_meta_table.php
+++ b/backend/database/migrations/2026_03_08_000120_create_personality_profile_seo_meta_table.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        $isSqlite = Schema::getConnection()->getDriverName() === 'sqlite';
+
+        Schema::create('personality_profile_seo_meta', function (Blueprint $table) use ($isSqlite): void {
+            $table->bigIncrements('id');
+            $table->unsignedBigInteger('profile_id');
+            $table->string('seo_title', 255)->nullable();
+            $table->text('seo_description')->nullable();
+            $table->text('canonical_url')->nullable();
+            $table->string('og_title', 255)->nullable();
+            $table->text('og_description')->nullable();
+            $table->text('og_image_url')->nullable();
+            $table->string('twitter_title', 255)->nullable();
+            $table->text('twitter_description')->nullable();
+            $table->text('twitter_image_url')->nullable();
+            $table->string('robots', 64)->nullable();
+            if ($isSqlite) {
+                $table->text('jsonld_overrides_json')->nullable();
+            } else {
+                $table->json('jsonld_overrides_json')->nullable();
+            }
+            $table->timestamps();
+
+            $table->unique(['profile_id'], 'uq_profile_seo');
+            $table->foreign('profile_id', 'fk_profile_seo_profile')
+                ->references('id')
+                ->on('personality_profiles')
+                ->cascadeOnDelete();
+        });
+    }
+
+    public function down(): void
+    {
+        // forward-only migration: rollback disabled to prevent data loss in production.
+        // Irreversible operation: schema/data rollback handled via forward fix migrations.
+    }
+};

--- a/backend/database/migrations/2026_03_08_000130_create_personality_profile_revisions_table.php
+++ b/backend/database/migrations/2026_03_08_000130_create_personality_profile_revisions_table.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        $isSqlite = Schema::getConnection()->getDriverName() === 'sqlite';
+
+        Schema::create('personality_profile_revisions', function (Blueprint $table) use ($isSqlite): void {
+            $table->bigIncrements('id');
+            $table->unsignedBigInteger('profile_id');
+            $table->unsignedInteger('revision_no');
+            if ($isSqlite) {
+                $table->text('snapshot_json')->nullable();
+            } else {
+                $table->json('snapshot_json')->nullable();
+            }
+            $table->string('note', 255)->nullable();
+            $table->unsignedBigInteger('created_by_admin_user_id')->nullable();
+            $table->timestamp('created_at')->nullable();
+
+            $table->unique(['profile_id', 'revision_no'], 'uq_profile_revision');
+            $table->index(['profile_id', 'created_at'], 'idx_profile_revision_created');
+            $table->foreign('profile_id', 'fk_profile_revision_profile')
+                ->references('id')
+                ->on('personality_profiles')
+                ->cascadeOnDelete();
+        });
+    }
+
+    public function down(): void
+    {
+        // forward-only migration: rollback disabled to prevent data loss in production.
+        // Irreversible operation: schema/data rollback handled via forward fix migrations.
+    }
+};

--- a/backend/tests/Feature/PersonalityCms/PersonalitySchemaSmokeTest.php
+++ b/backend/tests/Feature/PersonalityCms/PersonalitySchemaSmokeTest.php
@@ -1,0 +1,182 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\PersonalityCms;
+
+use App\Models\PersonalityProfile;
+use App\Models\PersonalityProfileRevision;
+use App\Models\PersonalityProfileSection;
+use App\Models\PersonalityProfileSeoMeta;
+use Illuminate\Database\QueryException;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+final class PersonalitySchemaSmokeTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_profile_relations_and_scopes_work(): void
+    {
+        $profile = PersonalityProfile::query()->create([
+            'org_id' => 0,
+            'scale_code' => PersonalityProfile::SCALE_CODE_MBTI,
+            'type_code' => 'INTJ',
+            'slug' => 'intj',
+            'locale' => 'en',
+            'title' => 'INTJ personality profile',
+            'subtitle' => 'Strategic and independent',
+            'excerpt' => 'A compact personality summary.',
+            'hero_kicker' => 'Architect',
+            'hero_quote' => 'Systems first.',
+            'status' => 'published',
+            'is_public' => true,
+            'is_indexable' => true,
+            'schema_version' => 'v1',
+            'published_at' => now(),
+        ]);
+
+        PersonalityProfileSection::query()->create([
+            'profile_id' => $profile->id,
+            'section_key' => 'strengths',
+            'title' => 'Strengths',
+            'render_variant' => 'bullets',
+            'body_md' => '- Strategic',
+            'payload_json' => ['items' => ['Strategic']],
+            'sort_order' => 20,
+            'is_enabled' => true,
+        ]);
+
+        PersonalityProfileSection::query()->create([
+            'profile_id' => $profile->id,
+            'section_key' => 'hero',
+            'title' => 'Hero',
+            'render_variant' => 'callout',
+            'body_md' => 'Architect archetype',
+            'sort_order' => 10,
+            'is_enabled' => true,
+        ]);
+
+        PersonalityProfileSeoMeta::query()->create([
+            'profile_id' => $profile->id,
+            'seo_title' => 'INTJ personality',
+            'seo_description' => 'INTJ summary',
+            'jsonld_overrides_json' => ['@type' => 'WebPage'],
+        ]);
+
+        PersonalityProfileRevision::query()->create([
+            'profile_id' => $profile->id,
+            'revision_no' => 1,
+            'snapshot_json' => ['title' => 'INTJ personality profile'],
+            'note' => 'Initial draft',
+            'created_at' => now()->subMinute(),
+        ]);
+
+        PersonalityProfileRevision::query()->create([
+            'profile_id' => $profile->id,
+            'revision_no' => 2,
+            'snapshot_json' => ['title' => 'INTJ personality profile v2'],
+            'note' => 'Publish update',
+            'created_at' => now(),
+        ]);
+
+        $freshProfile = PersonalityProfile::query()->findOrFail($profile->id);
+
+        $this->assertSame(
+            ['hero', 'strengths'],
+            $freshProfile->sections()->pluck('section_key')->all()
+        );
+        $this->assertSame('INTJ personality', $freshProfile->seoMeta?->seo_title);
+        $this->assertSame(
+            [2, 1],
+            $freshProfile->revisions()->pluck('revision_no')->all()
+        );
+        $this->assertSame(
+            [$profile->id],
+            PersonalityProfile::query()->publishedPublic()->forLocale('en')->forType('intj')->pluck('id')->all()
+        );
+    }
+
+    public function test_unique_org_scale_type_locale_constraint_is_enforced(): void
+    {
+        PersonalityProfile::query()->create($this->profilePayload([
+            'type_code' => 'ENFP',
+            'slug' => 'enfp',
+        ]));
+
+        $this->expectException(QueryException::class);
+
+        PersonalityProfile::query()->create($this->profilePayload([
+            'type_code' => 'ENFP',
+            'slug' => 'enfp-second',
+        ]));
+    }
+
+    public function test_unique_org_scale_slug_locale_constraint_is_enforced(): void
+    {
+        PersonalityProfile::query()->create($this->profilePayload([
+            'type_code' => 'INFJ',
+            'slug' => 'advocate',
+        ]));
+
+        $this->expectException(QueryException::class);
+
+        PersonalityProfile::query()->create($this->profilePayload([
+            'type_code' => 'INFP',
+            'slug' => 'advocate',
+        ]));
+    }
+
+    public function test_deleting_profile_cascades_sections_seo_meta_and_revisions(): void
+    {
+        $profile = PersonalityProfile::query()->create($this->profilePayload([
+            'type_code' => 'ENTJ',
+            'slug' => 'entj',
+        ]));
+
+        $section = PersonalityProfileSection::query()->create([
+            'profile_id' => $profile->id,
+            'section_key' => 'hero',
+            'render_variant' => 'rich_text',
+        ]);
+
+        $seoMeta = PersonalityProfileSeoMeta::query()->create([
+            'profile_id' => $profile->id,
+            'seo_title' => 'ENTJ',
+        ]);
+
+        $revision = PersonalityProfileRevision::query()->create([
+            'profile_id' => $profile->id,
+            'revision_no' => 1,
+            'snapshot_json' => ['slug' => 'entj'],
+            'created_at' => now(),
+        ]);
+
+        $profile->delete();
+
+        $this->assertDatabaseMissing('personality_profiles', ['id' => $profile->id]);
+        $this->assertDatabaseMissing('personality_profile_sections', ['id' => $section->id]);
+        $this->assertDatabaseMissing('personality_profile_seo_meta', ['id' => $seoMeta->id]);
+        $this->assertDatabaseMissing('personality_profile_revisions', ['id' => $revision->id]);
+    }
+
+    /**
+     * @param  array<string, mixed>  $overrides
+     * @return array<string, mixed>
+     */
+    private function profilePayload(array $overrides = []): array
+    {
+        return array_merge([
+            'org_id' => 0,
+            'scale_code' => PersonalityProfile::SCALE_CODE_MBTI,
+            'type_code' => 'INTJ',
+            'slug' => 'intj',
+            'locale' => 'en',
+            'title' => 'Personality profile',
+            'status' => 'draft',
+            'is_public' => true,
+            'is_indexable' => true,
+            'schema_version' => 'v1',
+        ], $overrides);
+    }
+}


### PR DESCRIPTION
## Summary

- add the initial database schema and Eloquent models for Personality CMS v1
- establish a structured profile/section/seo/revision data model for MBTI personality content

## What changed

- add `personality_profiles`
- add `personality_profile_sections`
- add `personality_profile_seo_meta`
- add `personality_profile_revisions`
- add the corresponding Eloquent models and relationships
- add minimal schema/model smoke coverage for migrations, relations, unique constraints, and cascade deletes

## Design choices

- personality content is modeled as structured profiles instead of generic articles
- v1 targets the 16 base MBTI types only
- `org_id` is preserved for future expansion but defaults to global content usage
- section keys and render variants are controlled in application code, not hard-coded as database enums
- JSON field compatibility follows the repository's existing sqlite/mysql strategy
- migrations follow the repository's forward-only rollback style

## Why this PR is small and safe

- no API changes
- no route changes
- no RBAC changes
- no frontend changes
- no service layer changes
- only schema/model groundwork for later Personality CMS PRs

## Validation

- `php artisan about`
- `php artisan migrate:status`
- `php artisan migrate`
- `php artisan route:list`
- `php artisan tinker --execute="dump([\Schema::hasTable('personality_profiles'), \Schema::hasTable('personality_profile_sections'), \Schema::hasTable('personality_profile_seo_meta'), \Schema::hasTable('personality_profile_revisions')]);"`
- `php artisan test --filter=Personality`
- `./vendor/bin/pint app/Models/PersonalityProfile.php app/Models/PersonalityProfileSection.php app/Models/PersonalityProfileSeoMeta.php app/Models/PersonalityProfileRevision.php database/migrations/2026_03_08_000100_create_personality_profiles_table.php database/migrations/2026_03_08_000110_create_personality_profile_sections_table.php database/migrations/2026_03_08_000120_create_personality_profile_seo_meta_table.php database/migrations/2026_03_08_000130_create_personality_profile_revisions_table.php tests/Feature/PersonalityCms/PersonalitySchemaSmokeTest.php`
- `bash backend/scripts/ci_verify_mbti.sh`
