### PR TITLE
feat(personality-cms): add public API and seo service for personality profiles

### DIFF
--- a/backend/app/Http/Controllers/API/V0_5/Cms/PersonalityController.php
+++ b/backend/app/Http/Controllers/API/V0_5/Cms/PersonalityController.php
@@ -1,0 +1,282 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Controllers\API\V0_5\Cms;
+
+use App\Http\Controllers\Concerns\RespondsWithNotFound;
+use App\Http\Controllers\Controller;
+use App\Models\PersonalityProfile;
+use App\Models\PersonalityProfileSection;
+use App\Models\PersonalityProfileSeoMeta;
+use App\Services\Cms\PersonalityProfileSeoService;
+use App\Services\Cms\PersonalityProfileService;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Validator;
+
+class PersonalityController extends Controller
+{
+    use RespondsWithNotFound;
+
+    public function __construct(
+        private readonly PersonalityProfileService $personalityProfileService,
+        private readonly PersonalityProfileSeoService $personalityProfileSeoService,
+    ) {}
+
+    public function index(Request $request): JsonResponse
+    {
+        $validated = $this->validateListQuery($request);
+        if ($validated instanceof JsonResponse) {
+            return $validated;
+        }
+
+        $paginator = $this->personalityProfileService->listPublicProfiles(
+            $validated['org_id'],
+            $validated['scale_code'],
+            $validated['locale'],
+            $validated['page'],
+            $validated['per_page'],
+        );
+
+        $items = [];
+        foreach ($paginator->items() as $profile) {
+            if (! $profile instanceof PersonalityProfile) {
+                continue;
+            }
+
+            $items[] = $this->profileListPayload($profile);
+        }
+
+        return response()->json([
+            'ok' => true,
+            'items' => $items,
+            'pagination' => [
+                'current_page' => (int) $paginator->currentPage(),
+                'per_page' => (int) $paginator->perPage(),
+                'total' => (int) $paginator->total(),
+                'last_page' => (int) $paginator->lastPage(),
+            ],
+        ]);
+    }
+
+    public function show(Request $request, string $type): JsonResponse
+    {
+        $validated = $this->validateReadQuery($request);
+        if ($validated instanceof JsonResponse) {
+            return $validated;
+        }
+
+        $profile = $this->personalityProfileService->getPublicProfileByType(
+            $type,
+            $validated['org_id'],
+            $validated['scale_code'],
+            $validated['locale'],
+        );
+
+        if (! $profile instanceof PersonalityProfile) {
+            return $this->notFoundResponse('personality profile not found.');
+        }
+
+        return response()->json([
+            'ok' => true,
+            'profile' => $this->profileDetailPayload($profile),
+            'sections' => array_map(
+                fn (PersonalityProfileSection $section): array => $this->sectionPayload($section),
+                $profile->sections->all()
+            ),
+            'seo_meta' => $this->seoMetaPayload($profile->seoMeta),
+        ]);
+    }
+
+    public function seo(Request $request, string $type): JsonResponse
+    {
+        $validated = $this->validateReadQuery($request);
+        if ($validated instanceof JsonResponse) {
+            return $validated;
+        }
+
+        $profile = $this->personalityProfileService->getPublicProfileByType(
+            $type,
+            $validated['org_id'],
+            $validated['scale_code'],
+            $validated['locale'],
+        );
+
+        if (! $profile instanceof PersonalityProfile) {
+            return response()->json(['error' => 'not found'], 404);
+        }
+
+        return response()->json([
+            'meta' => $this->personalityProfileSeoService->buildMeta($profile),
+            'jsonld' => $this->personalityProfileSeoService->buildJsonLd($profile),
+        ]);
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function profileListPayload(PersonalityProfile $profile): array
+    {
+        return [
+            'id' => (int) $profile->id,
+            'org_id' => (int) $profile->org_id,
+            'scale_code' => (string) $profile->scale_code,
+            'type_code' => (string) $profile->type_code,
+            'slug' => (string) $profile->slug,
+            'locale' => (string) $profile->locale,
+            'title' => (string) $profile->title,
+            'subtitle' => $profile->subtitle,
+            'excerpt' => $profile->excerpt,
+            'status' => (string) $profile->status,
+            'is_public' => (bool) $profile->is_public,
+            'is_indexable' => (bool) $profile->is_indexable,
+            'published_at' => $profile->published_at?->toISOString(),
+            'updated_at' => $profile->updated_at?->toISOString(),
+            'seo_meta' => $this->seoMetaSummaryPayload($profile->seoMeta),
+        ];
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function profileDetailPayload(PersonalityProfile $profile): array
+    {
+        return [
+            'id' => (int) $profile->id,
+            'org_id' => (int) $profile->org_id,
+            'scale_code' => (string) $profile->scale_code,
+            'type_code' => (string) $profile->type_code,
+            'slug' => (string) $profile->slug,
+            'locale' => (string) $profile->locale,
+            'title' => (string) $profile->title,
+            'subtitle' => $profile->subtitle,
+            'excerpt' => $profile->excerpt,
+            'hero_kicker' => $profile->hero_kicker,
+            'hero_quote' => $profile->hero_quote,
+            'hero_image_url' => $profile->hero_image_url,
+            'status' => (string) $profile->status,
+            'is_public' => (bool) $profile->is_public,
+            'is_indexable' => (bool) $profile->is_indexable,
+            'published_at' => $profile->published_at?->toISOString(),
+            'updated_at' => $profile->updated_at?->toISOString(),
+        ];
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function sectionPayload(PersonalityProfileSection $section): array
+    {
+        return [
+            'section_key' => (string) $section->section_key,
+            'title' => $section->title,
+            'render_variant' => (string) $section->render_variant,
+            'body_md' => $section->body_md,
+            'body_html' => $section->body_html,
+            'payload_json' => $section->payload_json,
+            'sort_order' => (int) $section->sort_order,
+            'is_enabled' => (bool) $section->is_enabled,
+        ];
+    }
+
+    /**
+     * @return array<string, mixed>|null
+     */
+    private function seoMetaPayload(?PersonalityProfileSeoMeta $seoMeta): ?array
+    {
+        if (! $seoMeta instanceof PersonalityProfileSeoMeta) {
+            return null;
+        }
+
+        return [
+            'seo_title' => $seoMeta->seo_title,
+            'seo_description' => $seoMeta->seo_description,
+            'canonical_url' => $seoMeta->canonical_url,
+            'og_title' => $seoMeta->og_title,
+            'og_description' => $seoMeta->og_description,
+            'og_image_url' => $seoMeta->og_image_url,
+            'twitter_title' => $seoMeta->twitter_title,
+            'twitter_description' => $seoMeta->twitter_description,
+            'twitter_image_url' => $seoMeta->twitter_image_url,
+            'robots' => $seoMeta->robots,
+            'jsonld_overrides_json' => $seoMeta->jsonld_overrides_json,
+        ];
+    }
+
+    /**
+     * @return array<string, mixed>|null
+     */
+    private function seoMetaSummaryPayload(?PersonalityProfileSeoMeta $seoMeta): ?array
+    {
+        if (! $seoMeta instanceof PersonalityProfileSeoMeta) {
+            return null;
+        }
+
+        return [
+            'seo_title' => $seoMeta->seo_title,
+            'seo_description' => $seoMeta->seo_description,
+        ];
+    }
+
+    /**
+     * @return array{org_id:int,scale_code:string,locale:string,page:int,per_page:int}|JsonResponse
+     */
+    private function validateListQuery(Request $request): array|JsonResponse
+    {
+        $validator = Validator::make($request->query(), [
+            'org_id' => ['nullable', 'integer', 'min:0'],
+            'scale_code' => ['nullable', 'in:MBTI'],
+            'locale' => ['required', 'in:en,zh-CN'],
+            'page' => ['nullable', 'integer', 'min:1'],
+            'per_page' => ['nullable', 'integer', 'min:1', 'max:100'],
+        ]);
+
+        if ($validator->fails()) {
+            return $this->invalidArgument($validator->errors()->first());
+        }
+
+        $validated = $validator->validated();
+
+        return [
+            'org_id' => (int) ($validated['org_id'] ?? 0),
+            'scale_code' => (string) ($validated['scale_code'] ?? PersonalityProfile::SCALE_CODE_MBTI),
+            'locale' => (string) $validated['locale'],
+            'page' => (int) ($validated['page'] ?? 1),
+            'per_page' => (int) ($validated['per_page'] ?? 20),
+        ];
+    }
+
+    /**
+     * @return array{org_id:int,scale_code:string,locale:string}|JsonResponse
+     */
+    private function validateReadQuery(Request $request): array|JsonResponse
+    {
+        $validator = Validator::make($request->query(), [
+            'org_id' => ['nullable', 'integer', 'min:0'],
+            'scale_code' => ['nullable', 'in:MBTI'],
+            'locale' => ['required', 'in:en,zh-CN'],
+        ]);
+
+        if ($validator->fails()) {
+            return $this->invalidArgument($validator->errors()->first());
+        }
+
+        $validated = $validator->validated();
+
+        return [
+            'org_id' => (int) ($validated['org_id'] ?? 0),
+            'scale_code' => (string) ($validated['scale_code'] ?? PersonalityProfile::SCALE_CODE_MBTI),
+            'locale' => (string) $validated['locale'],
+        ];
+    }
+
+    private function invalidArgument(string $message): JsonResponse
+    {
+        return response()->json([
+            'ok' => false,
+            'error_code' => 'INVALID_ARGUMENT',
+            'message' => $message,
+        ], 422);
+    }
+}

--- a/backend/app/Services/Cms/PersonalityProfileSeoService.php
+++ b/backend/app/Services/Cms/PersonalityProfileSeoService.php
@@ -1,0 +1,128 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\Cms;
+
+use App\Models\PersonalityProfile;
+use App\Models\PersonalityProfileSeoMeta;
+
+final class PersonalityProfileSeoService
+{
+    /**
+     * @return array<string, mixed>
+     */
+    public function buildMeta(PersonalityProfile $profile): array
+    {
+        $seoMeta = $this->resolveSeoMeta($profile);
+        $title = $this->fallbackText(
+            $seoMeta?->seo_title,
+            (string) $profile->title
+        ) ?? (string) $profile->title;
+        $description = $this->fallbackText(
+            $seoMeta?->seo_description,
+            (string) ($profile->excerpt ?? null),
+            (string) ($profile->subtitle ?? null)
+        );
+        $canonical = $this->buildCanonicalUrl($profile, (string) $profile->locale);
+        $robots = $this->fallbackText($seoMeta?->robots)
+            ?? ((bool) $profile->is_indexable ? 'index,follow' : 'noindex,follow');
+
+        return [
+            'title' => $title,
+            'description' => $description,
+            'canonical' => $canonical,
+            'og' => [
+                'title' => $this->fallbackText($seoMeta?->og_title, $title),
+                'description' => $this->fallbackText($seoMeta?->og_description, $description),
+                'image' => $this->fallbackText($seoMeta?->og_image_url),
+                'type' => 'article',
+            ],
+            'twitter' => [
+                'card' => 'summary_large_image',
+                'title' => $this->fallbackText($seoMeta?->twitter_title, $seoMeta?->og_title, $title),
+                'description' => $this->fallbackText(
+                    $seoMeta?->twitter_description,
+                    $seoMeta?->og_description,
+                    $description
+                ),
+                'image' => $this->fallbackText($seoMeta?->twitter_image_url, $seoMeta?->og_image_url),
+            ],
+            'robots' => $robots,
+        ];
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function buildJsonLd(PersonalityProfile $profile): array
+    {
+        $meta = $this->buildMeta($profile);
+        $jsonLd = [
+            '@context' => 'https://schema.org',
+            '@type' => 'AboutPage',
+            'name' => $meta['title'],
+            'description' => $meta['description'],
+            'about' => [
+                '@type' => 'DefinedTerm',
+                'name' => (string) $profile->type_code,
+                'inDefinedTermSet' => (string) $profile->scale_code,
+            ],
+            'mainEntityOfPage' => $meta['canonical'],
+        ];
+
+        $seoMeta = $this->resolveSeoMeta($profile);
+        if ($seoMeta instanceof PersonalityProfileSeoMeta && is_array($seoMeta->jsonld_overrides_json)) {
+            return array_replace_recursive($jsonLd, $seoMeta->jsonld_overrides_json);
+        }
+
+        return $jsonLd;
+    }
+
+    public function buildCanonicalUrl(PersonalityProfile $profile, string $locale): ?string
+    {
+        $baseUrl = rtrim((string) config('app.frontend_url', config('app.url', '')), '/');
+        $slug = trim((string) $profile->slug);
+
+        if ($baseUrl === '' || $slug === '') {
+            return null;
+        }
+
+        return $baseUrl
+            .'/'.$this->mapBackendLocaleToFrontendSegment($locale)
+            .'/personality/'
+            .rawurlencode($slug);
+    }
+
+    public function mapBackendLocaleToFrontendSegment(string $locale): string
+    {
+        return trim($locale) === 'zh-CN' ? 'zh' : 'en';
+    }
+
+    private function resolveSeoMeta(PersonalityProfile $profile): ?PersonalityProfileSeoMeta
+    {
+        if ($profile->relationLoaded('seoMeta') && $profile->seoMeta instanceof PersonalityProfileSeoMeta) {
+            return $profile->seoMeta;
+        }
+
+        return PersonalityProfileSeoMeta::query()
+            ->where('profile_id', (int) $profile->id)
+            ->first();
+    }
+
+    private function fallbackText(?string ...$candidates): ?string
+    {
+        foreach ($candidates as $candidate) {
+            if ($candidate === null) {
+                continue;
+            }
+
+            $normalized = trim($candidate);
+            if ($normalized !== '') {
+                return $normalized;
+            }
+        }
+
+        return null;
+    }
+}

--- a/backend/app/Services/Cms/PersonalityProfileService.php
+++ b/backend/app/Services/Cms/PersonalityProfileService.php
@@ -1,0 +1,90 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\Cms;
+
+use App\Models\PersonalityProfile;
+use Illuminate\Contracts\Pagination\LengthAwarePaginator;
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+
+final class PersonalityProfileService
+{
+    public function listPublicProfiles(
+        int $orgId,
+        string $scaleCode,
+        string $locale,
+        int $page = 1,
+        int $perPage = 20
+    ): LengthAwarePaginator {
+        return $this->basePublicQuery($orgId, $scaleCode, $locale)
+            ->with('seoMeta')
+            ->orderBy('type_code')
+            ->orderBy('id')
+            ->paginate($perPage, ['*'], 'page', $page);
+    }
+
+    public function getPublicProfileByType(
+        string $typeLookup,
+        int $orgId,
+        string $scaleCode,
+        string $locale
+    ): ?PersonalityProfile {
+        [$slug, $typeCode] = $this->resolveTypeLookup($typeLookup);
+
+        return $this->basePublicQuery($orgId, $scaleCode, $locale)
+            ->where(function (Builder $query) use ($slug, $typeCode): void {
+                $query->where('slug', $slug)
+                    ->orWhere('type_code', $typeCode);
+            })
+            ->with([
+                'sections' => static function (HasMany $query): void {
+                    $query->where('is_enabled', true)
+                        ->orderBy('sort_order')
+                        ->orderBy('id');
+                },
+                'seoMeta',
+            ])
+            ->first();
+    }
+
+    /**
+     * @return array{0:string,1:string}
+     */
+    public function resolveTypeLookup(string $typeLookup): array
+    {
+        $normalized = trim($typeLookup);
+
+        return [
+            strtolower($normalized),
+            strtoupper($normalized),
+        ];
+    }
+
+    private function basePublicQuery(int $orgId, string $scaleCode, string $locale): Builder
+    {
+        return PersonalityProfile::query()
+            ->withoutGlobalScopes()
+            ->where('org_id', max(0, $orgId))
+            ->where('scale_code', $this->normalizeScaleCode($scaleCode))
+            ->forLocale($this->normalizeLocale($locale))
+            ->publishedPublic()
+            ->where(static function (Builder $query): void {
+                $query->whereNull('published_at')
+                    ->orWhere('published_at', '<=', now());
+            });
+    }
+
+    private function normalizeLocale(string $locale): string
+    {
+        return trim($locale);
+    }
+
+    private function normalizeScaleCode(string $scaleCode): string
+    {
+        $normalized = strtoupper(trim($scaleCode));
+
+        return $normalized !== '' ? $normalized : PersonalityProfile::SCALE_CODE_MBTI;
+    }
+}

--- a/backend/docs/contracts/openapi.snapshot.json
+++ b/backend/docs/contracts/openapi.snapshot.json
@@ -1836,6 +1836,57 @@
                     "App\\Http\\Middleware\\EnsureCmsAdminAuthorized"
                 ]
             }
+        },
+        "/api/v0.5/personality": {
+            "get": {
+                "operationId": "get_api_v0_5_personality",
+                "tags": [
+                    "api:v0.5"
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK"
+                    }
+                },
+                "x-laravel-action": "App\\Http\\Controllers\\API\\V0_5\\Cms\\PersonalityController@index",
+                "x-laravel-middleware": [
+                    "api"
+                ]
+            }
+        },
+        "/api/v0.5/personality/{type}": {
+            "get": {
+                "operationId": "get_api_v0_5_personality_type_",
+                "tags": [
+                    "api:v0.5"
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK"
+                    }
+                },
+                "x-laravel-action": "App\\Http\\Controllers\\API\\V0_5\\Cms\\PersonalityController@show",
+                "x-laravel-middleware": [
+                    "api"
+                ]
+            }
+        },
+        "/api/v0.5/personality/{type}/seo": {
+            "get": {
+                "operationId": "get_api_v0_5_personality_type_seo",
+                "tags": [
+                    "api:v0.5"
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK"
+                    }
+                },
+                "x-laravel-action": "App\\Http\\Controllers\\API\\V0_5\\Cms\\PersonalityController@seo",
+                "x-laravel-middleware": [
+                    "api"
+                ]
+            }
         }
     }
 }

--- a/backend/routes/api.php
+++ b/backend/routes/api.php
@@ -24,6 +24,7 @@ use App\Http\Controllers\API\V0_4\ExperimentGovernanceController;
 use App\Http\Controllers\API\V0_4\PartnerController;
 use App\Http\Controllers\API\V0_4\RotationAuditController;
 use App\Http\Controllers\API\V0_5\Cms\ArticleController;
+use App\Http\Controllers\API\V0_5\Cms\PersonalityController;
 use App\Http\Controllers\HealthzController;
 use App\Http\Middleware\AdminAuth;
 use App\Http\Middleware\EnsureCmsAdminAuthorized;
@@ -302,6 +303,9 @@ Route::prefix('v0.5')->group(function () {
     Route::get('/articles', [ArticleController::class, 'index']);
     Route::get('/articles/{slug}', [ArticleController::class, 'show']);
     Route::get('/articles/{slug}/seo', [ArticleController::class, 'seo']);
+    Route::get('/personality', [PersonalityController::class, 'index']);
+    Route::get('/personality/{type}/seo', [PersonalityController::class, 'seo']);
+    Route::get('/personality/{type}', [PersonalityController::class, 'show']);
 
     Route::middleware([
         EncryptCookies::class,

--- a/backend/tests/Feature/V0_5/PersonalityPublicApiTest.php
+++ b/backend/tests/Feature/V0_5/PersonalityPublicApiTest.php
@@ -1,0 +1,316 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\V0_5;
+
+use App\Models\PersonalityProfile;
+use App\Models\PersonalityProfileRevision;
+use App\Models\PersonalityProfileSection;
+use App\Models\PersonalityProfileSeoMeta;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+final class PersonalityPublicApiTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_list_returns_published_public_only(): void
+    {
+        $visible = $this->createProfile([
+            'type_code' => 'INTJ',
+            'slug' => 'intj',
+            'title' => 'INTJ - Architect',
+            'status' => 'published',
+            'is_public' => true,
+            'published_at' => now()->subMinute(),
+        ]);
+        $this->createSeoMeta($visible, [
+            'seo_title' => 'INTJ Personality',
+            'seo_description' => 'INTJ seo description',
+        ]);
+
+        $this->createProfile([
+            'type_code' => 'ENTP',
+            'slug' => 'entp',
+            'title' => 'ENTP draft',
+            'status' => 'draft',
+            'is_public' => true,
+        ]);
+        $this->createProfile([
+            'type_code' => 'INFJ',
+            'slug' => 'infj',
+            'title' => 'INFJ private',
+            'status' => 'published',
+            'is_public' => false,
+            'published_at' => now()->subMinute(),
+        ]);
+        $this->createProfile([
+            'type_code' => 'ENFP',
+            'slug' => 'enfp',
+            'title' => 'ENFP scheduled',
+            'status' => 'published',
+            'is_public' => true,
+            'published_at' => now()->addHour(),
+        ]);
+
+        $response = $this->getJson('/api/v0.5/personality?locale=en');
+
+        $response->assertOk()
+            ->assertJsonPath('ok', true)
+            ->assertJsonPath('pagination.total', 1)
+            ->assertJsonCount(1, 'items')
+            ->assertJsonPath('items.0.slug', 'intj')
+            ->assertJsonPath('items.0.seo_meta.seo_title', 'INTJ Personality');
+    }
+
+    public function test_list_respects_locale_and_org_scope(): void
+    {
+        $this->createProfile([
+            'org_id' => 0,
+            'type_code' => 'INTJ',
+            'slug' => 'intj',
+            'locale' => 'en',
+            'title' => 'INTJ EN',
+            'status' => 'published',
+            'is_public' => true,
+            'published_at' => now()->subMinute(),
+        ]);
+        $this->createProfile([
+            'org_id' => 0,
+            'type_code' => 'INTJ',
+            'slug' => 'intj',
+            'locale' => 'zh-CN',
+            'title' => 'INTJ ZH',
+            'status' => 'published',
+            'is_public' => true,
+            'published_at' => now()->subMinute(),
+        ]);
+        $this->createProfile([
+            'org_id' => 7,
+            'type_code' => 'INTJ',
+            'slug' => 'intj',
+            'locale' => 'en',
+            'title' => 'INTJ Org 7',
+            'status' => 'published',
+            'is_public' => true,
+            'published_at' => now()->subMinute(),
+        ]);
+
+        $en = $this->getJson('/api/v0.5/personality?locale=en');
+        $en->assertOk()
+            ->assertJsonCount(1, 'items')
+            ->assertJsonPath('items.0.title', 'INTJ EN');
+
+        $zh = $this->getJson('/api/v0.5/personality?locale=zh-CN');
+        $zh->assertOk()
+            ->assertJsonCount(1, 'items')
+            ->assertJsonPath('items.0.title', 'INTJ ZH');
+
+        $org = $this->getJson('/api/v0.5/personality?locale=en&org_id=7');
+        $org->assertOk()
+            ->assertJsonCount(1, 'items')
+            ->assertJsonPath('items.0.org_id', 7)
+            ->assertJsonPath('items.0.title', 'INTJ Org 7');
+    }
+
+    public function test_detail_returns_profile_sections_and_seo_meta(): void
+    {
+        $profile = $this->createProfile([
+            'type_code' => 'INTJ',
+            'slug' => 'intj',
+            'title' => 'INTJ - Architect',
+            'status' => 'published',
+            'is_public' => true,
+            'published_at' => now()->subMinute(),
+        ]);
+
+        PersonalityProfileSection::query()->create([
+            'profile_id' => (int) $profile->id,
+            'section_key' => 'core_snapshot',
+            'title' => 'Core snapshot',
+            'render_variant' => 'rich_text',
+            'body_md' => 'INTJ body',
+            'sort_order' => 10,
+            'is_enabled' => true,
+        ]);
+        PersonalityProfileSection::query()->create([
+            'profile_id' => (int) $profile->id,
+            'section_key' => 'strengths',
+            'title' => 'Strengths',
+            'render_variant' => 'bullets',
+            'payload_json' => ['items' => [['title' => 'Strategic thinking']]],
+            'sort_order' => 20,
+            'is_enabled' => false,
+        ]);
+
+        $this->createSeoMeta($profile, [
+            'seo_title' => 'INTJ Personality Type',
+            'seo_description' => 'Explore INTJ traits.',
+            'robots' => 'index,follow',
+        ]);
+        PersonalityProfileRevision::query()->create([
+            'profile_id' => (int) $profile->id,
+            'revision_no' => 1,
+            'snapshot_json' => ['title' => 'INTJ - Architect'],
+            'note' => 'initial',
+            'created_at' => now(),
+        ]);
+
+        $response = $this->getJson('/api/v0.5/personality/intj?locale=en');
+
+        $response->assertOk()
+            ->assertJsonPath('ok', true)
+            ->assertJsonPath('profile.type_code', 'INTJ')
+            ->assertJsonPath('profile.slug', 'intj')
+            ->assertJsonCount(1, 'sections')
+            ->assertJsonPath('sections.0.section_key', 'core_snapshot')
+            ->assertJsonPath('seo_meta.seo_title', 'INTJ Personality Type')
+            ->assertJsonMissingPath('revisions');
+    }
+
+    public function test_detail_returns_not_found_for_missing_hidden_or_locale_mismatch_profiles(): void
+    {
+        $draft = $this->createProfile([
+            'type_code' => 'INTJ',
+            'slug' => 'intj',
+            'status' => 'draft',
+            'is_public' => true,
+        ]);
+        $this->createProfile([
+            'type_code' => 'ENTJ',
+            'slug' => 'entj',
+            'status' => 'published',
+            'is_public' => false,
+            'published_at' => now()->subMinute(),
+        ]);
+        $this->createProfile([
+            'type_code' => 'INFJ',
+            'slug' => 'infj',
+            'locale' => 'zh-CN',
+            'status' => 'published',
+            'is_public' => true,
+            'published_at' => now()->subMinute(),
+        ]);
+
+        $this->getJson('/api/v0.5/personality/missing?locale=en')
+            ->assertStatus(404)
+            ->assertJsonPath('ok', false)
+            ->assertJsonPath('error_code', 'NOT_FOUND');
+
+        $this->getJson('/api/v0.5/personality/'.$draft->slug.'?locale=en')
+            ->assertStatus(404)
+            ->assertJsonPath('error_code', 'NOT_FOUND');
+
+        $this->getJson('/api/v0.5/personality/entj?locale=en')
+            ->assertStatus(404)
+            ->assertJsonPath('error_code', 'NOT_FOUND');
+
+        $this->getJson('/api/v0.5/personality/infj?locale=en')
+            ->assertStatus(404)
+            ->assertJsonPath('error_code', 'NOT_FOUND');
+    }
+
+    public function test_seo_endpoint_returns_locale_aware_meta_and_jsonld(): void
+    {
+        config(['app.frontend_url' => 'https://staging.fermatmind.com']);
+
+        $enProfile = $this->createProfile([
+            'type_code' => 'INTJ',
+            'slug' => 'intj',
+            'locale' => 'en',
+            'title' => 'INTJ Personality Type',
+            'excerpt' => 'Explore INTJ traits, strengths, and growth.',
+            'status' => 'published',
+            'is_public' => true,
+            'is_indexable' => true,
+            'published_at' => now()->subMinute(),
+        ]);
+        $this->createSeoMeta($enProfile, [
+            'seo_title' => 'INTJ Personality Type: Traits, Careers, and Growth | FermatMind',
+            'seo_description' => 'Explore INTJ traits, strengths, blind spots, work style, relationships, and growth advice.',
+        ]);
+
+        $zhProfile = $this->createProfile([
+            'type_code' => 'INTJ',
+            'slug' => 'intj',
+            'locale' => 'zh-CN',
+            'title' => 'INTJ 人格类型',
+            'excerpt' => '探索 INTJ 的特质、优势与成长方向。',
+            'status' => 'published',
+            'is_public' => true,
+            'is_indexable' => false,
+            'published_at' => now()->subMinute(),
+        ]);
+        $this->createSeoMeta($zhProfile, [
+            'seo_title' => 'INTJ 人格类型：特质、职业与成长 | FermatMind',
+            'seo_description' => '探索 INTJ 的特质、优势、关系模式与成长建议。',
+        ]);
+
+        $enResponse = $this->getJson('/api/v0.5/personality/INTJ/seo?locale=en');
+        $enResponse->assertOk()
+            ->assertJsonPath('meta.title', 'INTJ Personality Type: Traits, Careers, and Growth | FermatMind')
+            ->assertJsonPath('meta.canonical', 'https://staging.fermatmind.com/en/personality/intj')
+            ->assertJsonPath('meta.robots', 'index,follow');
+        self::assertSame('AboutPage', data_get($enResponse->json(), 'jsonld.@type'));
+        self::assertSame(
+            'https://staging.fermatmind.com/en/personality/intj',
+            data_get($enResponse->json(), 'jsonld.mainEntityOfPage')
+        );
+
+        $zhResponse = $this->getJson('/api/v0.5/personality/intj/seo?locale=zh-CN');
+        $zhResponse->assertOk()
+            ->assertJsonPath('meta.canonical', 'https://staging.fermatmind.com/zh/personality/intj')
+            ->assertJsonPath('meta.robots', 'noindex,follow');
+        self::assertSame(
+            'https://staging.fermatmind.com/zh/personality/intj',
+            data_get($zhResponse->json(), 'jsonld.mainEntityOfPage')
+        );
+    }
+
+    /**
+     * @param  array<string, mixed>  $overrides
+     */
+    private function createProfile(array $overrides = []): PersonalityProfile
+    {
+        /** @var PersonalityProfile */
+        return PersonalityProfile::query()->create(array_merge([
+            'org_id' => 0,
+            'scale_code' => PersonalityProfile::SCALE_CODE_MBTI,
+            'type_code' => 'INTJ',
+            'slug' => 'intj',
+            'locale' => 'en',
+            'title' => 'INTJ',
+            'subtitle' => 'Strategic and future-oriented',
+            'excerpt' => 'INTJs tend to value competence, systems, and long-range thinking.',
+            'status' => 'draft',
+            'is_public' => false,
+            'is_indexable' => true,
+            'published_at' => null,
+            'scheduled_at' => null,
+            'schema_version' => 'v1',
+        ], $overrides));
+    }
+
+    /**
+     * @param  array<string, mixed>  $overrides
+     */
+    private function createSeoMeta(PersonalityProfile $profile, array $overrides = []): PersonalityProfileSeoMeta
+    {
+        /** @var PersonalityProfileSeoMeta */
+        return PersonalityProfileSeoMeta::query()->create(array_merge([
+            'profile_id' => (int) $profile->id,
+            'seo_title' => null,
+            'seo_description' => null,
+            'canonical_url' => null,
+            'og_title' => null,
+            'og_description' => null,
+            'og_image_url' => null,
+            'twitter_title' => null,
+            'twitter_description' => null,
+            'twitter_image_url' => null,
+            'robots' => null,
+            'jsonld_overrides_json' => null,
+        ], $overrides));
+    }
+}


### PR DESCRIPTION
## Summary

- add the public read API for Personality CMS v1
- add read-side services and SEO payload generation for MBTI personality profiles

## What changed

- add public endpoints for profile list, detail, and SEO
- add read-side services to query published/public personality profiles
- add a dedicated SEO service for canonical/meta/jsonld payloads
- align validation and response envelopes with the existing v0.5 Articles API style
- add minimal feature coverage and route-contract snapshot updates required by the repository

## Design choices

- personality content remains modeled as structured profiles, not generic articles
- v1 targets the 16 base MBTI types only
- public API defaults to global content (`org_id=0`)
- SEO payloads emit locale-aware frontend URLs
- JSON-LD uses `AboutPage` instead of `Person`
- implementation follows the existing Articles API conventions instead of introducing JsonResource/FormRequest-only patterns

## Why this PR is small and safe

- no database changes beyond P01
- no write-side CMS API changes
- no frontend changes
- no RBAC changes
- no Filament resource changes
- only public read API / service groundwork for later Personality CMS PRs

## Validation

- `php artisan about`
- `php artisan route:list --path=api/v0.5 --except-vendor`
- `php artisan route:list --path=personality --except-vendor`
- `php artisan migrate`
- `php artisan test --filter=Personality`
- `bash scripts/export_openapi.sh --check`
- local curl checks for list/detail/seo
- `bash backend/scripts/ci_verify_mbti.sh`
