### PR TITLE
feat(personality-cms): add ops resource and workspace for personality profiles

### DIFF
--- a/backend/app/Filament/Ops/Resources/PersonalityProfileResource.php
+++ b/backend/app/Filament/Ops/Resources/PersonalityProfileResource.php
@@ -1,0 +1,498 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Filament\Ops\Resources;
+
+use App\Filament\Ops\Resources\PersonalityProfileResource\Pages;
+use App\Filament\Ops\Resources\PersonalityProfileResource\Support\PersonalityWorkspace;
+use App\Filament\Ops\Support\StatusBadge;
+use App\Models\PersonalityProfile;
+use App\Support\Rbac\PermissionNames;
+use Filament\Forms;
+use Filament\Forms\Form;
+use Filament\Resources\Resource;
+use Filament\Tables;
+use Filament\Tables\Filters\TernaryFilter;
+use Filament\Tables\Table;
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Support\Str;
+
+class PersonalityProfileResource extends Resource
+{
+    protected static ?string $model = PersonalityProfile::class;
+
+    protected static ?string $slug = 'personality';
+
+    protected static ?string $recordTitleAttribute = 'title';
+
+    protected static ?string $navigationIcon = 'heroicon-o-sparkles';
+
+    protected static ?string $navigationGroup = 'Content';
+
+    protected static ?string $navigationLabel = 'Personality';
+
+    protected static ?string $modelLabel = 'Personality Profile';
+
+    protected static ?string $pluralModelLabel = 'Personality Profiles';
+
+    public static function canViewAny(): bool
+    {
+        return self::canRead();
+    }
+
+    public static function canCreate(): bool
+    {
+        return self::canPublish();
+    }
+
+    public static function canEdit($record): bool
+    {
+        return self::canPublish();
+    }
+
+    public static function canDelete($record): bool
+    {
+        return false;
+    }
+
+    public static function getNavigationGroup(): ?string
+    {
+        return __('ops.group.content');
+    }
+
+    public static function getNavigationLabel(): string
+    {
+        return 'Personality';
+    }
+
+    public static function form(Form $form): Form
+    {
+        return $form->schema([
+            Forms\Components\Hidden::make('org_id')
+                ->default(0),
+            Forms\Components\Hidden::make('scale_code')
+                ->default(PersonalityProfile::SCALE_CODE_MBTI),
+            Forms\Components\Grid::make([
+                'default' => 1,
+                'xl' => 12,
+            ])
+                ->extraAttributes(['class' => 'ops-personality-workspace-layout'])
+                ->schema([
+                    Forms\Components\Group::make([
+                        Forms\Components\Section::make('Basic')
+                            ->description('Shape the core MBTI profile identity before moving into structured sections and metadata.')
+                            ->extraAttributes(['class' => 'ops-personality-workspace-section ops-personality-workspace-section--main'])
+                            ->schema([
+                                Forms\Components\Select::make('type_code')
+                                    ->label('MBTI type')
+                                    ->required()
+                                    ->native(false)
+                                    ->searchable()
+                                    ->options(self::typeOptions())
+                                    ->helperText('V1 supports the 16 base MBTI types only.')
+                                    ->live()
+                                    ->afterStateUpdated(function (?string $state, Forms\Set $set, Forms\Get $get): void {
+                                        if (trim((string) $get('slug')) !== '') {
+                                            return;
+                                        }
+
+                                        $set('slug', PersonalityWorkspace::normalizeSlug(null, $state));
+                                    }),
+                                Forms\Components\TextInput::make('slug')
+                                    ->required()
+                                    ->maxLength(64)
+                                    ->placeholder('intj')
+                                    ->helperText('Stored in lowercase and used in the planned frontend personality URL.')
+                                    ->dehydrateStateUsing(fn (?string $state, Forms\Get $get): string => PersonalityWorkspace::normalizeSlug(
+                                        $state,
+                                        (string) $get('type_code'),
+                                    ))
+                                    ->rules(['regex:/^[a-z0-9-]+$/']),
+                                Forms\Components\Select::make('locale')
+                                    ->required()
+                                    ->native(false)
+                                    ->options(self::localeOptions())
+                                    ->default('en')
+                                    ->helperText('Stored as backend locale codes. Frontend URL mapping still resolves to locale-aware paths.'),
+                                Forms\Components\TextInput::make('title')
+                                    ->required()
+                                    ->maxLength(255)
+                                    ->columnSpanFull()
+                                    ->helperText('Primary profile heading shown in the workspace, public detail page, and SEO fallback.')
+                                    ->extraFieldWrapperAttributes(['class' => 'ops-personality-workspace-field ops-personality-workspace-field--title'])
+                                    ->extraInputAttributes(['class' => 'ops-personality-workspace-input ops-personality-workspace-input--title']),
+                                Forms\Components\TextInput::make('subtitle')
+                                    ->maxLength(255)
+                                    ->columnSpanFull()
+                                    ->helperText('Short supporting line for the hero and quick list scanning.'),
+                                Forms\Components\Textarea::make('excerpt')
+                                    ->rows(4)
+                                    ->columnSpanFull()
+                                    ->helperText('Used as the summary fallback across list, SEO, and public profile contexts.')
+                                    ->extraFieldWrapperAttributes(['class' => 'ops-personality-workspace-field ops-personality-workspace-field--summary']),
+                            ])
+                            ->columns(3),
+                        Forms\Components\Section::make('Hero')
+                            ->description('Set the lead framing used to introduce the personality profile before readers enter the structured sections.')
+                            ->extraAttributes(['class' => 'ops-personality-workspace-section ops-personality-workspace-section--main'])
+                            ->schema([
+                                Forms\Components\TextInput::make('hero_kicker')
+                                    ->maxLength(128)
+                                    ->helperText('Short kicker that frames the profile in a more editorial tone.'),
+                                Forms\Components\Textarea::make('hero_quote')
+                                    ->rows(4)
+                                    ->helperText('Optional quote or rallying line for the hero block.'),
+                                Forms\Components\TextInput::make('hero_image_url')
+                                    ->maxLength(2048)
+                                    ->columnSpanFull()
+                                    ->helperText('Optional lead image URL for future frontend card or hero coverage.'),
+                            ])
+                            ->columns(2),
+                        Forms\Components\Section::make('Structured sections')
+                            ->description('Edit fixed profile sections instead of inventing new content blocks. The section keys stay controlled by the workspace.')
+                            ->extraAttributes(['class' => 'ops-personality-workspace-section ops-personality-workspace-section--main'])
+                            ->schema([
+                                Forms\Components\Tabs::make('Personality sections')
+                                    ->contained(false)
+                                    ->extraAttributes(['class' => 'ops-personality-workspace-tabs'])
+                                    ->tabs(self::sectionTabs())
+                                    ->columnSpanFull(),
+                            ]),
+                    ])
+                        ->columnSpan([
+                            'xl' => 8,
+                        ])
+                        ->extraAttributes(['class' => 'ops-personality-workspace-main-column']),
+                    Forms\Components\Group::make([
+                        Forms\Components\Section::make('Identity')
+                            ->description('Personality CMS v1 is global MBTI content. Org scope and scale are fixed by the workspace.')
+                            ->extraAttributes(['class' => 'ops-personality-workspace-section ops-personality-workspace-section--rail'])
+                            ->schema([
+                                Forms\Components\Placeholder::make('identity_scale')
+                                    ->label('Scale')
+                                    ->content(PersonalityProfile::SCALE_CODE_MBTI),
+                                Forms\Components\Placeholder::make('identity_type')
+                                    ->label('Type code')
+                                    ->content(fn (Forms\Get $get, ?PersonalityProfile $record): string => PersonalityWorkspace::normalizeTypeCode(
+                                        (string) ($get('type_code') ?? $record?->type_code ?? '')
+                                    ) ?: 'Not set yet'),
+                                Forms\Components\Placeholder::make('identity_slug')
+                                    ->label('Slug')
+                                    ->content(fn (Forms\Get $get, ?PersonalityProfile $record): string => PersonalityWorkspace::normalizeSlug(
+                                        (string) ($get('slug') ?? $record?->slug ?? ''),
+                                        (string) ($get('type_code') ?? $record?->type_code ?? ''),
+                                    ) ?: 'Not set yet'),
+                                Forms\Components\Placeholder::make('identity_locale')
+                                    ->label('Locale')
+                                    ->content(fn (Forms\Get $get, ?PersonalityProfile $record): string => PersonalityWorkspace::normalizeLocale(
+                                        (string) ($get('locale') ?? $record?->locale ?? 'en'),
+                                    )),
+                                Forms\Components\Placeholder::make('identity_org')
+                                    ->label('Content scope')
+                                    ->content('Global MBTI content (org_id=0)'),
+                            ])
+                            ->columns(2),
+                        Forms\Components\Section::make('Publish')
+                            ->description('Keep editorial visibility, indexing, and scheduling cues together in the side rail.')
+                            ->extraAttributes(['class' => 'ops-personality-workspace-section ops-personality-workspace-section--rail'])
+                            ->schema([
+                                Forms\Components\Placeholder::make('workspace_state')
+                                    ->label('Editorial cues')
+                                    ->content(fn (Forms\Get $get, ?PersonalityProfile $record) => PersonalityWorkspace::renderEditorialCues($get, $record))
+                                    ->columnSpanFull(),
+                                Forms\Components\Select::make('status')
+                                    ->required()
+                                    ->native(false)
+                                    ->options(self::statusOptions())
+                                    ->default('draft')
+                                    ->helperText('Published profiles are eligible for the public read API once visibility and locale are aligned.'),
+                                Forms\Components\Toggle::make('is_public')
+                                    ->label('Public visibility')
+                                    ->default(true)
+                                    ->helperText('Controls whether the public personality API can serve this profile.'),
+                                Forms\Components\Toggle::make('is_indexable')
+                                    ->label('Search indexable')
+                                    ->default(true)
+                                    ->helperText('Used for SEO payload fallbacks and robots defaults.'),
+                                Forms\Components\DateTimePicker::make('published_at')
+                                    ->helperText('Timestamp shown in editorial cues and public profile responses.'),
+                                Forms\Components\DateTimePicker::make('scheduled_at')
+                                    ->helperText('Optional future release time for editorial planning.'),
+                            ]),
+                        Forms\Components\Section::make('SEO')
+                            ->description('Keep title, summary, social metadata, and advanced JSON-LD overrides in one reviewable rail.')
+                            ->extraAttributes(['class' => 'ops-personality-workspace-section ops-personality-workspace-section--rail'])
+                            ->schema([
+                                Forms\Components\Placeholder::make('seo_snapshot')
+                                    ->label('SEO snapshot')
+                                    ->content(fn (Forms\Get $get, ?PersonalityProfile $record) => PersonalityWorkspace::renderSeoSnapshot($get, $record))
+                                    ->columnSpanFull(),
+                                Forms\Components\TextInput::make('workspace_seo.seo_title')
+                                    ->label('SEO title')
+                                    ->maxLength(255)
+                                    ->helperText('Search headline fallback is the profile title if this stays empty.'),
+                                Forms\Components\Textarea::make('workspace_seo.seo_description')
+                                    ->label('SEO description')
+                                    ->rows(3)
+                                    ->helperText('Search description fallback is excerpt, then subtitle.'),
+                                Forms\Components\TextInput::make('workspace_seo.canonical_url')
+                                    ->label('Canonical override')
+                                    ->maxLength(2048)
+                                    ->helperText('Optional stored override. Final frontend canonical still follows locale-aware personality URLs.'),
+                                Forms\Components\TextInput::make('workspace_seo.og_title')
+                                    ->label('Open Graph title')
+                                    ->maxLength(255),
+                                Forms\Components\Textarea::make('workspace_seo.og_description')
+                                    ->label('Open Graph description')
+                                    ->rows(3),
+                                Forms\Components\TextInput::make('workspace_seo.og_image_url')
+                                    ->label('Open Graph image URL')
+                                    ->maxLength(2048),
+                                Forms\Components\TextInput::make('workspace_seo.twitter_title')
+                                    ->label('Twitter title')
+                                    ->maxLength(255),
+                                Forms\Components\Textarea::make('workspace_seo.twitter_description')
+                                    ->label('Twitter description')
+                                    ->rows(3),
+                                Forms\Components\TextInput::make('workspace_seo.twitter_image_url')
+                                    ->label('Twitter image URL')
+                                    ->maxLength(2048),
+                                Forms\Components\TextInput::make('workspace_seo.robots')
+                                    ->label('Robots')
+                                    ->maxLength(64)
+                                    ->helperText('Leave blank to derive robots from the current indexability toggle.'),
+                                Forms\Components\Textarea::make('workspace_seo.jsonld_overrides_json_text')
+                                    ->label('JSON-LD overrides')
+                                    ->rows(5)
+                                    ->helperText('Optional advanced overrides merged into the public Personality JSON-LD payload.')
+                                    ->rules(['nullable', 'json'])
+                                    ->extraFieldWrapperAttributes(['class' => 'ops-personality-workspace-field ops-personality-workspace-field--payload']),
+                            ]),
+                        Forms\Components\Section::make('Record cues')
+                            ->description('Read-only context so editors can see what is planned, when the record changed, and how many revisions already exist.')
+                            ->extraAttributes(['class' => 'ops-personality-workspace-section ops-personality-workspace-section--rail'])
+                            ->schema([
+                                Forms\Components\Placeholder::make('planned_public_url')
+                                    ->label('Planned public URL')
+                                    ->content(fn (Forms\Get $get, ?PersonalityProfile $record): string => PersonalityWorkspace::plannedPublicUrl(
+                                        (string) ($get('slug') ?? $record?->slug ?? ''),
+                                        (string) ($get('locale') ?? $record?->locale ?? 'en'),
+                                    ) ?? 'Appears once slug and locale are set.'),
+                                Forms\Components\Placeholder::make('created_at_summary')
+                                    ->label('Created')
+                                    ->content(fn (?PersonalityProfile $record): string => PersonalityWorkspace::formatTimestamp(
+                                        $record?->created_at,
+                                        'Workspace draft not saved yet',
+                                    )),
+                                Forms\Components\Placeholder::make('updated_at_summary')
+                                    ->label('Last updated')
+                                    ->content(fn (?PersonalityProfile $record): string => PersonalityWorkspace::formatTimestamp(
+                                        $record?->updated_at,
+                                        'Workspace draft not saved yet',
+                                    )),
+                                Forms\Components\Placeholder::make('revision_count_summary')
+                                    ->label('Revision count')
+                                    ->content(fn (?PersonalityProfile $record): string => $record instanceof PersonalityProfile
+                                        ? (string) $record->revisions()->count()
+                                        : 'Revision #1 will be written when this profile is created'),
+                            ])
+                            ->columns(2),
+                    ])
+                        ->columnSpan([
+                            'xl' => 4,
+                        ])
+                        ->extraAttributes(['class' => 'ops-personality-workspace-rail-column']),
+                ]),
+        ]);
+    }
+
+    public static function table(Table $table): Table
+    {
+        return $table
+            ->columns([
+                Tables\Columns\TextColumn::make('title')
+                    ->label('Profile')
+                    ->html()
+                    ->searchable(['title', 'slug', 'type_code'])
+                    ->sortable()
+                    ->formatStateUsing(fn (PersonalityProfile $record): string => (string) view('filament.ops.personality.partials.table-title', [
+                        'meta' => PersonalityWorkspace::titleMeta($record),
+                        'title' => $record->title,
+                    ])->render()),
+                Tables\Columns\TextColumn::make('slug')
+                    ->searchable()
+                    ->copyable()
+                    ->formatStateUsing(fn (string $state): string => '/'.trim($state, '/'))
+                    ->toggleable(isToggledHiddenByDefault: true),
+                Tables\Columns\TextColumn::make('status')
+                    ->badge()
+                    ->sortable()
+                    ->formatStateUsing(fn (string $state): string => Str::of($state)->headline()->value())
+                    ->description(fn (PersonalityProfile $record): string => PersonalityWorkspace::visibilityMeta($record))
+                    ->color(fn (string $state): string => StatusBadge::color($state)),
+                Tables\Columns\TextColumn::make('is_public')
+                    ->label('Visibility')
+                    ->badge()
+                    ->formatStateUsing(fn (bool|int|string|null $state): string => StatusBadge::booleanLabel($state, 'Public', 'Private'))
+                    ->color(fn (bool|int|string|null $state): string => StatusBadge::booleanColor($state))
+                    ->sortable(),
+                Tables\Columns\TextColumn::make('is_indexable')
+                    ->label('Indexing')
+                    ->badge()
+                    ->formatStateUsing(fn (bool|int|string|null $state): string => StatusBadge::booleanLabel($state, 'Indexable', 'Noindex'))
+                    ->color(fn (bool|int|string|null $state): string => StatusBadge::booleanColor($state))
+                    ->sortable(),
+                Tables\Columns\TextColumn::make('published_at')
+                    ->label('Published')
+                    ->dateTime()
+                    ->sortable()
+                    ->placeholder('Not published'),
+                Tables\Columns\TextColumn::make('updated_at')
+                    ->label('Updated')
+                    ->since()
+                    ->sortable(),
+            ])
+            ->filters([
+                Tables\Filters\SelectFilter::make('type_code')
+                    ->label('Type')
+                    ->options(self::typeOptions()),
+                Tables\Filters\SelectFilter::make('locale')
+                    ->options(self::localeOptions()),
+                Tables\Filters\SelectFilter::make('status')
+                    ->options(self::statusOptions()),
+                TernaryFilter::make('is_public')
+                    ->label('Public'),
+                TernaryFilter::make('is_indexable')
+                    ->label('Indexable'),
+            ])
+            ->searchPlaceholder('Search type, title, or slug')
+            ->defaultSort('updated_at', 'desc')
+            ->recordUrl(fn (PersonalityProfile $record): string => static::getUrl('edit', ['record' => $record]))
+            ->actions([
+                Tables\Actions\EditAction::make()
+                    ->label('Edit')
+                    ->icon('heroicon-o-pencil-square')
+                    ->color('gray'),
+            ])
+            ->bulkActions([]);
+    }
+
+    public static function getPages(): array
+    {
+        return [
+            'index' => Pages\ListPersonalityProfiles::route('/'),
+            'create' => Pages\CreatePersonalityProfile::route('/create'),
+            'edit' => Pages\EditPersonalityProfile::route('/{record}/edit'),
+        ];
+    }
+
+    public static function getEloquentQuery(): Builder
+    {
+        return parent::getEloquentQuery()
+            ->withoutGlobalScopes()
+            ->where('org_id', 0)
+            ->where('scale_code', PersonalityProfile::SCALE_CODE_MBTI);
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    private static function statusOptions(): array
+    {
+        return [
+            'draft' => 'draft',
+            'published' => 'published',
+        ];
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    private static function localeOptions(): array
+    {
+        return collect(PersonalityProfile::SUPPORTED_LOCALES)
+            ->mapWithKeys(static fn (string $locale): array => [$locale => $locale])
+            ->all();
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    private static function typeOptions(): array
+    {
+        return collect(PersonalityProfile::TYPE_CODES)
+            ->mapWithKeys(static fn (string $typeCode): array => [$typeCode => $typeCode])
+            ->all();
+    }
+
+    /**
+     * @return array<int, Forms\Components\Tabs\Tab>
+     */
+    private static function sectionTabs(): array
+    {
+        $variantOptions = PersonalityWorkspace::renderVariantOptions();
+
+        return collect(PersonalityWorkspace::sectionDefinitions())
+            ->map(function (array $definition, string $sectionKey) use ($variantOptions): Forms\Components\Tabs\Tab {
+                return Forms\Components\Tabs\Tab::make($definition['label'])
+                    ->schema([
+                        Forms\Components\Toggle::make("workspace_sections.{$sectionKey}.is_enabled")
+                            ->label('Enable this section')
+                            ->helperText($definition['description'])
+                            ->columnSpanFull(),
+                        Forms\Components\TextInput::make("workspace_sections.{$sectionKey}.title")
+                            ->label('Section title')
+                            ->required()
+                            ->maxLength(255),
+                        Forms\Components\Select::make("workspace_sections.{$sectionKey}.render_variant")
+                            ->label('Render variant')
+                            ->native(false)
+                            ->options($variantOptions)
+                            ->required(),
+                        Forms\Components\Textarea::make("workspace_sections.{$sectionKey}.body_md")
+                            ->label('Narrative body')
+                            ->rows(8)
+                            ->columnSpanFull()
+                            ->helperText('Use markdown-friendly narrative copy when this section needs long-form explanation.')
+                            ->extraFieldWrapperAttributes(['class' => 'ops-personality-workspace-field ops-personality-workspace-field--body']),
+                        Forms\Components\Textarea::make("workspace_sections.{$sectionKey}.payload_json_text")
+                            ->label('Structured payload JSON')
+                            ->rows(6)
+                            ->columnSpanFull()
+                            ->helperText('Optional structured payload for cards, FAQ, links, or other fixed render variants.')
+                            ->rules(['nullable', 'json'])
+                            ->extraFieldWrapperAttributes(['class' => 'ops-personality-workspace-field ops-personality-workspace-field--payload']),
+                    ])
+                    ->columns(2);
+            })
+            ->values()
+            ->all();
+    }
+
+    private static function canRead(): bool
+    {
+        $guard = (string) config('admin.guard', 'admin');
+        $user = auth($guard)->user();
+
+        return is_object($user)
+            && method_exists($user, 'hasPermission')
+            && (
+                $user->hasPermission(PermissionNames::ADMIN_CONTENT_READ)
+                || $user->hasPermission(PermissionNames::ADMIN_OWNER)
+            );
+    }
+
+    private static function canPublish(): bool
+    {
+        $guard = (string) config('admin.guard', 'admin');
+        $user = auth($guard)->user();
+
+        return is_object($user)
+            && method_exists($user, 'hasPermission')
+            && (
+                $user->hasPermission(PermissionNames::ADMIN_CONTENT_PUBLISH)
+                || $user->hasPermission(PermissionNames::ADMIN_OWNER)
+            );
+    }
+}

--- a/backend/app/Filament/Ops/Resources/PersonalityProfileResource/Pages/CreatePersonalityProfile.php
+++ b/backend/app/Filament/Ops/Resources/PersonalityProfileResource/Pages/CreatePersonalityProfile.php
@@ -1,0 +1,133 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Filament\Ops\Resources\PersonalityProfileResource\Pages;
+
+use App\Filament\Ops\Resources\PersonalityProfileResource;
+use App\Filament\Ops\Resources\PersonalityProfileResource\Support\PersonalityWorkspace;
+use App\Models\PersonalityProfile;
+use Filament\Actions\Action;
+use Filament\Resources\Pages\CreateRecord;
+use Illuminate\Contracts\Support\Htmlable;
+
+class CreatePersonalityProfile extends CreateRecord
+{
+    protected static string $resource = PersonalityProfileResource::class;
+
+    /**
+     * @var array<string, mixed>
+     */
+    protected array $workspaceSectionsState = [];
+
+    /**
+     * @var array<string, mixed>
+     */
+    protected array $workspaceSeoState = [];
+
+    public function getTitle(): string|Htmlable
+    {
+        return 'Create Personality Profile';
+    }
+
+    public function getSubheading(): ?string
+    {
+        return 'Build a structured MBTI profile in the main workspace, then finish publish and SEO cues in the side rail.';
+    }
+
+    protected function fillForm(): void
+    {
+        $this->callHook('beforeFill');
+
+        $this->form->fill(PersonalityWorkspace::defaultFormState());
+
+        $this->callHook('afterFill');
+    }
+
+    protected function getHeaderActions(): array
+    {
+        return [
+            Action::make('backToPersonality')
+                ->label('All Personality Profiles')
+                ->url(PersonalityProfileResource::getUrl())
+                ->icon('heroicon-o-arrow-left')
+                ->color('gray'),
+        ];
+    }
+
+    protected function getCreateFormAction(): Action
+    {
+        return parent::getCreateFormAction()
+            ->label('Create Personality Profile')
+            ->icon('heroicon-o-check-circle');
+    }
+
+    protected function getCreateAnotherFormAction(): Action
+    {
+        return parent::getCreateAnotherFormAction()
+            ->label('Create & Add Another')
+            ->icon('heroicon-o-document-duplicate');
+    }
+
+    protected function getCancelFormAction(): Action
+    {
+        return parent::getCancelFormAction()
+            ->label('Back to Personality')
+            ->icon('heroicon-o-arrow-left');
+    }
+
+    /**
+     * @param  array<string, mixed>  $data
+     * @return array<string, mixed>
+     */
+    protected function mutateFormDataBeforeCreate(array $data): array
+    {
+        $this->workspaceSectionsState = is_array($data['workspace_sections'] ?? null) ? $data['workspace_sections'] : [];
+        $this->workspaceSeoState = is_array($data['workspace_seo'] ?? null) ? $data['workspace_seo'] : [];
+
+        unset($data['workspace_sections'], $data['workspace_seo']);
+
+        $typeCode = PersonalityWorkspace::normalizeTypeCode((string) ($data['type_code'] ?? ''));
+
+        $data['org_id'] = 0;
+        $data['scale_code'] = PersonalityProfile::SCALE_CODE_MBTI;
+        $data['type_code'] = $typeCode;
+        $data['slug'] = PersonalityWorkspace::normalizeSlug((string) ($data['slug'] ?? ''), $typeCode);
+        $data['locale'] = PersonalityWorkspace::normalizeLocale((string) ($data['locale'] ?? 'en'));
+        $data['created_by_admin_user_id'] = $this->currentAdminId();
+        $data['updated_by_admin_user_id'] = $this->currentAdminId();
+
+        return $data;
+    }
+
+    protected function afterCreate(): void
+    {
+        PersonalityWorkspace::syncWorkspaceSections($this->getRecord(), $this->workspaceSectionsState);
+        PersonalityWorkspace::syncWorkspaceSeo($this->getRecord(), $this->workspaceSeoState);
+        $this->getRecord()->unsetRelation('sections');
+        $this->getRecord()->unsetRelation('seoMeta');
+        PersonalityWorkspace::createRevision($this->getRecord(), 'Initial workspace snapshot');
+    }
+
+    protected function getCreatedNotificationTitle(): ?string
+    {
+        return 'Personality profile created';
+    }
+
+    protected function getRedirectUrl(): string
+    {
+        return PersonalityProfileResource::getUrl('edit', ['record' => $this->getRecord()]);
+    }
+
+    private function currentAdminId(): ?int
+    {
+        $guard = (string) config('admin.guard', 'admin');
+        $user = auth($guard)->user();
+
+        if (! is_object($user) || ! method_exists($user, 'getAuthIdentifier')) {
+            return null;
+        }
+
+        return (int) $user->getAuthIdentifier();
+    }
+}

--- a/backend/app/Filament/Ops/Resources/PersonalityProfileResource/Pages/EditPersonalityProfile.php
+++ b/backend/app/Filament/Ops/Resources/PersonalityProfileResource/Pages/EditPersonalityProfile.php
@@ -1,0 +1,129 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Filament\Ops\Resources\PersonalityProfileResource\Pages;
+
+use App\Filament\Ops\Resources\PersonalityProfileResource;
+use App\Filament\Ops\Resources\PersonalityProfileResource\Support\PersonalityWorkspace;
+use App\Models\PersonalityProfile;
+use Filament\Actions\Action;
+use Filament\Resources\Pages\EditRecord;
+use Illuminate\Contracts\Support\Htmlable;
+
+class EditPersonalityProfile extends EditRecord
+{
+    protected static string $resource = PersonalityProfileResource::class;
+
+    /**
+     * @var array<string, mixed>
+     */
+    protected array $workspaceSectionsState = [];
+
+    /**
+     * @var array<string, mixed>
+     */
+    protected array $workspaceSeoState = [];
+
+    public function getTitle(): string|Htmlable
+    {
+        return filled($this->getRecord()->title) ? (string) $this->getRecord()->title : 'Edit Personality Profile';
+    }
+
+    public function getSubheading(): ?string
+    {
+        return 'Maintain the structured MBTI profile without leaving the editorial workspace.';
+    }
+
+    protected function getHeaderActions(): array
+    {
+        return [
+            Action::make('backToPersonality')
+                ->label('All Personality Profiles')
+                ->url(PersonalityProfileResource::getUrl())
+                ->icon('heroicon-o-arrow-left')
+                ->color('gray'),
+        ];
+    }
+
+    protected function getSaveFormAction(): Action
+    {
+        return parent::getSaveFormAction()
+            ->label('Save Changes')
+            ->icon('heroicon-o-check-circle');
+    }
+
+    protected function getCancelFormAction(): Action
+    {
+        return parent::getCancelFormAction()
+            ->label('Back to Personality')
+            ->icon('heroicon-o-arrow-left');
+    }
+
+    /**
+     * @param  array<string, mixed>  $data
+     * @return array<string, mixed>
+     */
+    protected function mutateFormDataBeforeFill(array $data): array
+    {
+        return [
+            ...$data,
+            'workspace_sections' => PersonalityWorkspace::workspaceSectionsFromRecord($this->getRecord()),
+            'workspace_seo' => PersonalityWorkspace::workspaceSeoFromRecord($this->getRecord()),
+        ];
+    }
+
+    /**
+     * @param  array<string, mixed>  $data
+     * @return array<string, mixed>
+     */
+    protected function mutateFormDataBeforeSave(array $data): array
+    {
+        $this->workspaceSectionsState = is_array($data['workspace_sections'] ?? null) ? $data['workspace_sections'] : [];
+        $this->workspaceSeoState = is_array($data['workspace_seo'] ?? null) ? $data['workspace_seo'] : [];
+
+        unset($data['workspace_sections'], $data['workspace_seo']);
+
+        $typeCode = PersonalityWorkspace::normalizeTypeCode((string) ($data['type_code'] ?? ''));
+
+        $data['org_id'] = 0;
+        $data['scale_code'] = PersonalityProfile::SCALE_CODE_MBTI;
+        $data['type_code'] = $typeCode;
+        $data['slug'] = PersonalityWorkspace::normalizeSlug((string) ($data['slug'] ?? ''), $typeCode);
+        $data['locale'] = PersonalityWorkspace::normalizeLocale((string) ($data['locale'] ?? 'en'));
+        $data['updated_by_admin_user_id'] = $this->currentAdminId();
+
+        return $data;
+    }
+
+    protected function afterSave(): void
+    {
+        PersonalityWorkspace::syncWorkspaceSections($this->getRecord(), $this->workspaceSectionsState);
+        PersonalityWorkspace::syncWorkspaceSeo($this->getRecord(), $this->workspaceSeoState);
+        $this->getRecord()->unsetRelation('sections');
+        $this->getRecord()->unsetRelation('seoMeta');
+        PersonalityWorkspace::createRevision($this->getRecord(), 'Workspace update');
+    }
+
+    protected function getSavedNotificationTitle(): ?string
+    {
+        return 'Personality profile updated';
+    }
+
+    protected function getRedirectUrl(): string
+    {
+        return PersonalityProfileResource::getUrl('edit', ['record' => $this->getRecord()]);
+    }
+
+    private function currentAdminId(): ?int
+    {
+        $guard = (string) config('admin.guard', 'admin');
+        $user = auth($guard)->user();
+
+        if (! is_object($user) || ! method_exists($user, 'getAuthIdentifier')) {
+            return null;
+        }
+
+        return (int) $user->getAuthIdentifier();
+    }
+}

--- a/backend/app/Filament/Ops/Resources/PersonalityProfileResource/Pages/ListPersonalityProfiles.php
+++ b/backend/app/Filament/Ops/Resources/PersonalityProfileResource/Pages/ListPersonalityProfiles.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Filament\Ops\Resources\PersonalityProfileResource\Pages;
+
+use App\Filament\Ops\Resources\Pages\Concerns\HasSharedListEmptyState;
+use App\Filament\Ops\Resources\PersonalityProfileResource;
+use Filament\Actions;
+use Filament\Resources\Pages\ListRecords;
+use Illuminate\Contracts\Support\Htmlable;
+
+class ListPersonalityProfiles extends ListRecords
+{
+    use HasSharedListEmptyState;
+
+    protected static string $resource = PersonalityProfileResource::class;
+
+    public function getTitle(): string|Htmlable
+    {
+        return 'Personality';
+    }
+
+    public function getSubheading(): ?string
+    {
+        return 'Global MBTI content workspace for structured personality profiles. Not tenant-specific.';
+    }
+
+    protected function getHeaderActions(): array
+    {
+        return [
+            Actions\CreateAction::make()
+                ->label('Create Personality Profile')
+                ->icon('heroicon-o-plus'),
+        ];
+    }
+}

--- a/backend/app/Filament/Ops/Resources/PersonalityProfileResource/Support/PersonalityWorkspace.php
+++ b/backend/app/Filament/Ops/Resources/PersonalityProfileResource/Support/PersonalityWorkspace.php
@@ -1,0 +1,674 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Filament\Ops\Resources\PersonalityProfileResource\Support;
+
+use App\Filament\Ops\Support\StatusBadge;
+use App\Models\PersonalityProfile;
+use App\Models\PersonalityProfileRevision;
+use App\Models\PersonalityProfileSection;
+use App\Models\PersonalityProfileSeoMeta;
+use App\Services\Cms\PersonalityProfileSeoService;
+use Filament\Forms\Get;
+use Illuminate\Contracts\Support\Htmlable;
+use Illuminate\Support\Carbon;
+use Illuminate\Support\HtmlString;
+use Illuminate\Support\Str;
+use Illuminate\Validation\ValidationException;
+
+final class PersonalityWorkspace
+{
+    /**
+     * @return array<string, array{label: string, title: string, description: string, render_variant: string, sort_order: int, enabled: bool}>
+     */
+    public static function sectionDefinitions(): array
+    {
+        return [
+            'core_snapshot' => [
+                'label' => 'Core Snapshot',
+                'title' => 'Core snapshot',
+                'description' => 'Foundational summary of the personality type and how it tends to orient to the world.',
+                'render_variant' => 'rich_text',
+                'sort_order' => 10,
+                'enabled' => true,
+            ],
+            'strengths' => [
+                'label' => 'Strengths',
+                'title' => 'Strengths',
+                'description' => 'Clear strengths editors want to highlight on the public profile.',
+                'render_variant' => 'bullets',
+                'sort_order' => 20,
+                'enabled' => true,
+            ],
+            'growth_edges' => [
+                'label' => 'Growth Edges',
+                'title' => 'Growth edges',
+                'description' => 'Blind spots, trade-offs, and development cues written in a constructive tone.',
+                'render_variant' => 'bullets',
+                'sort_order' => 30,
+                'enabled' => true,
+            ],
+            'work_style' => [
+                'label' => 'Work Style',
+                'title' => 'Work style',
+                'description' => 'How this profile tends to work, plan, execute, and collaborate.',
+                'render_variant' => 'rich_text',
+                'sort_order' => 40,
+                'enabled' => true,
+            ],
+            'relationships' => [
+                'label' => 'Relationships',
+                'title' => 'Relationships',
+                'description' => 'How this personality profile tends to show up in close partnerships and teamwork.',
+                'render_variant' => 'rich_text',
+                'sort_order' => 50,
+                'enabled' => true,
+            ],
+            'communication' => [
+                'label' => 'Communication',
+                'title' => 'Communication',
+                'description' => 'What communication style works best and what commonly creates friction.',
+                'render_variant' => 'rich_text',
+                'sort_order' => 60,
+                'enabled' => true,
+            ],
+            'stress_and_recovery' => [
+                'label' => 'Stress & Recovery',
+                'title' => 'Stress and recovery',
+                'description' => 'What overload tends to look like and what helps the profile reset.',
+                'render_variant' => 'cards',
+                'sort_order' => 70,
+                'enabled' => true,
+            ],
+            'career_fit' => [
+                'label' => 'Career Fit',
+                'title' => 'Career fit',
+                'description' => 'Career and environment patterns that usually fit this profile best.',
+                'render_variant' => 'cards',
+                'sort_order' => 80,
+                'enabled' => true,
+            ],
+            'faq' => [
+                'label' => 'FAQ',
+                'title' => 'Frequently asked questions',
+                'description' => 'Optional FAQ block for recurring editor-curated questions.',
+                'render_variant' => 'faq',
+                'sort_order' => 90,
+                'enabled' => false,
+            ],
+            'related_content' => [
+                'label' => 'Related Content',
+                'title' => 'Related content',
+                'description' => 'Optional structured links or references that complement the profile.',
+                'render_variant' => 'links',
+                'sort_order' => 100,
+                'enabled' => false,
+            ],
+        ];
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    public static function renderVariantOptions(): array
+    {
+        return collect(PersonalityProfileSection::RENDER_VARIANTS)
+            ->mapWithKeys(static fn (string $variant): array => [
+                $variant => Str::of($variant)->replace('_', ' ')->headline()->value(),
+            ])
+            ->all();
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public static function defaultFormState(): array
+    {
+        return [
+            'org_id' => 0,
+            'scale_code' => PersonalityProfile::SCALE_CODE_MBTI,
+            'type_code' => '',
+            'slug' => '',
+            'locale' => 'en',
+            'title' => '',
+            'subtitle' => '',
+            'excerpt' => '',
+            'hero_kicker' => '',
+            'hero_quote' => '',
+            'hero_image_url' => '',
+            'status' => 'draft',
+            'is_public' => true,
+            'is_indexable' => true,
+            'published_at' => null,
+            'scheduled_at' => null,
+            'workspace_sections' => self::defaultWorkspaceSectionsState(),
+            'workspace_seo' => self::defaultWorkspaceSeoState(),
+        ];
+    }
+
+    /**
+     * @return array<string, array<string, mixed>>
+     */
+    public static function defaultWorkspaceSectionsState(): array
+    {
+        $state = [];
+
+        foreach (self::sectionDefinitions() as $sectionKey => $definition) {
+            $state[$sectionKey] = [
+                'title' => $definition['title'],
+                'render_variant' => $definition['render_variant'],
+                'body_md' => '',
+                'payload_json_text' => '',
+                'sort_order' => $definition['sort_order'],
+                'is_enabled' => $definition['enabled'],
+            ];
+        }
+
+        return $state;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public static function defaultWorkspaceSeoState(): array
+    {
+        return [
+            'seo_title' => '',
+            'seo_description' => '',
+            'canonical_url' => '',
+            'og_title' => '',
+            'og_description' => '',
+            'og_image_url' => '',
+            'twitter_title' => '',
+            'twitter_description' => '',
+            'twitter_image_url' => '',
+            'robots' => '',
+            'jsonld_overrides_json_text' => '',
+        ];
+    }
+
+    /**
+     * @return array<string, array<string, mixed>>
+     */
+    public static function workspaceSectionsFromRecord(?PersonalityProfile $profile): array
+    {
+        $state = self::defaultWorkspaceSectionsState();
+
+        if (! $profile instanceof PersonalityProfile) {
+            return $state;
+        }
+
+        $profile->loadMissing('sections');
+
+        foreach ($profile->sections as $section) {
+            $sectionKey = (string) $section->section_key;
+
+            if (! array_key_exists($sectionKey, $state)) {
+                continue;
+            }
+
+            $state[$sectionKey] = [
+                'title' => filled($section->title) ? (string) $section->title : (string) $state[$sectionKey]['title'],
+                'render_variant' => filled($section->render_variant) ? (string) $section->render_variant : (string) $state[$sectionKey]['render_variant'],
+                'body_md' => (string) ($section->body_md ?? ''),
+                'payload_json_text' => self::encodeJson($section->payload_json),
+                'sort_order' => (int) ($section->sort_order ?? $state[$sectionKey]['sort_order']),
+                'is_enabled' => (bool) $section->is_enabled,
+            ];
+        }
+
+        return $state;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public static function workspaceSeoFromRecord(?PersonalityProfile $profile): array
+    {
+        $state = self::defaultWorkspaceSeoState();
+
+        if (! $profile instanceof PersonalityProfile) {
+            return $state;
+        }
+
+        $profile->loadMissing('seoMeta');
+        $seoMeta = $profile->seoMeta;
+
+        if (! $seoMeta instanceof PersonalityProfileSeoMeta) {
+            return $state;
+        }
+
+        return [
+            'seo_title' => (string) ($seoMeta->seo_title ?? ''),
+            'seo_description' => (string) ($seoMeta->seo_description ?? ''),
+            'canonical_url' => (string) ($seoMeta->canonical_url ?? ''),
+            'og_title' => (string) ($seoMeta->og_title ?? ''),
+            'og_description' => (string) ($seoMeta->og_description ?? ''),
+            'og_image_url' => (string) ($seoMeta->og_image_url ?? ''),
+            'twitter_title' => (string) ($seoMeta->twitter_title ?? ''),
+            'twitter_description' => (string) ($seoMeta->twitter_description ?? ''),
+            'twitter_image_url' => (string) ($seoMeta->twitter_image_url ?? ''),
+            'robots' => (string) ($seoMeta->robots ?? ''),
+            'jsonld_overrides_json_text' => self::encodeJson($seoMeta->jsonld_overrides_json),
+        ];
+    }
+
+    /**
+     * @param  array<string, mixed>  $state
+     */
+    public static function syncWorkspaceSections(PersonalityProfile $profile, array $state): void
+    {
+        $definitions = self::sectionDefinitions();
+        $knownSectionKeys = array_keys($definitions);
+
+        PersonalityProfileSection::query()
+            ->where('profile_id', (int) $profile->id)
+            ->whereNotIn('section_key', $knownSectionKeys)
+            ->delete();
+
+        foreach ($definitions as $sectionKey => $definition) {
+            $sectionState = array_merge(
+                self::defaultWorkspaceSectionsState()[$sectionKey],
+                is_array($state[$sectionKey] ?? null) ? $state[$sectionKey] : [],
+            );
+
+            PersonalityProfileSection::query()->updateOrCreate(
+                [
+                    'profile_id' => (int) $profile->id,
+                    'section_key' => $sectionKey,
+                ],
+                [
+                    'title' => self::normalizeNullableText((string) ($sectionState['title'] ?? '')) ?? $definition['title'],
+                    'render_variant' => self::normalizeRenderVariant((string) ($sectionState['render_variant'] ?? $definition['render_variant']), $definition['render_variant']),
+                    'body_md' => self::normalizeNullableText((string) ($sectionState['body_md'] ?? '')),
+                    'body_html' => null,
+                    'payload_json' => self::decodeJsonText(
+                        $sectionState['payload_json_text'] ?? null,
+                        "workspace_sections.{$sectionKey}.payload_json_text",
+                    ),
+                    'sort_order' => (int) ($sectionState['sort_order'] ?? $definition['sort_order']),
+                    'is_enabled' => StatusBadge::isTruthy($sectionState['is_enabled'] ?? $definition['enabled']),
+                ],
+            );
+        }
+
+        $profile->unsetRelation('sections');
+    }
+
+    /**
+     * @param  array<string, mixed>  $state
+     */
+    public static function syncWorkspaceSeo(PersonalityProfile $profile, array $state): void
+    {
+        PersonalityProfileSeoMeta::query()->updateOrCreate(
+            [
+                'profile_id' => (int) $profile->id,
+            ],
+            [
+                'seo_title' => self::normalizeNullableText((string) ($state['seo_title'] ?? '')),
+                'seo_description' => self::normalizeNullableText((string) ($state['seo_description'] ?? '')),
+                'canonical_url' => self::normalizeNullableText((string) ($state['canonical_url'] ?? '')),
+                'og_title' => self::normalizeNullableText((string) ($state['og_title'] ?? '')),
+                'og_description' => self::normalizeNullableText((string) ($state['og_description'] ?? '')),
+                'og_image_url' => self::normalizeNullableText((string) ($state['og_image_url'] ?? '')),
+                'twitter_title' => self::normalizeNullableText((string) ($state['twitter_title'] ?? '')),
+                'twitter_description' => self::normalizeNullableText((string) ($state['twitter_description'] ?? '')),
+                'twitter_image_url' => self::normalizeNullableText((string) ($state['twitter_image_url'] ?? '')),
+                'robots' => self::normalizeNullableText((string) ($state['robots'] ?? '')),
+                'jsonld_overrides_json' => self::decodeJsonText(
+                    $state['jsonld_overrides_json_text'] ?? null,
+                    'workspace_seo.jsonld_overrides_json_text',
+                ),
+            ],
+        );
+
+        $profile->unsetRelation('seoMeta');
+    }
+
+    public static function nextRevisionNo(PersonalityProfile $profile): int
+    {
+        return (int) PersonalityProfileRevision::query()
+            ->where('profile_id', (int) $profile->id)
+            ->max('revision_no') + 1;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public static function snapshotPayload(PersonalityProfile $profile): array
+    {
+        $profile->loadMissing('sections', 'seoMeta');
+
+        return [
+            'profile' => [
+                'id' => (int) $profile->id,
+                'org_id' => (int) $profile->org_id,
+                'scale_code' => (string) $profile->scale_code,
+                'type_code' => (string) $profile->type_code,
+                'slug' => (string) $profile->slug,
+                'locale' => (string) $profile->locale,
+                'title' => (string) $profile->title,
+                'subtitle' => $profile->subtitle,
+                'excerpt' => $profile->excerpt,
+                'hero_kicker' => $profile->hero_kicker,
+                'hero_quote' => $profile->hero_quote,
+                'hero_image_url' => $profile->hero_image_url,
+                'status' => (string) $profile->status,
+                'is_public' => (bool) $profile->is_public,
+                'is_indexable' => (bool) $profile->is_indexable,
+                'published_at' => $profile->published_at?->toIso8601String(),
+                'scheduled_at' => $profile->scheduled_at?->toIso8601String(),
+                'schema_version' => (string) $profile->schema_version,
+            ],
+            'sections' => $profile->sections
+                ->map(static fn (PersonalityProfileSection $section): array => [
+                    'section_key' => (string) $section->section_key,
+                    'title' => $section->title,
+                    'render_variant' => (string) $section->render_variant,
+                    'body_md' => $section->body_md,
+                    'body_html' => $section->body_html,
+                    'payload_json' => $section->payload_json,
+                    'sort_order' => (int) $section->sort_order,
+                    'is_enabled' => (bool) $section->is_enabled,
+                ])
+                ->values()
+                ->all(),
+            'seo_meta' => $profile->seoMeta instanceof PersonalityProfileSeoMeta
+                ? [
+                    'seo_title' => $profile->seoMeta->seo_title,
+                    'seo_description' => $profile->seoMeta->seo_description,
+                    'canonical_url' => $profile->seoMeta->canonical_url,
+                    'og_title' => $profile->seoMeta->og_title,
+                    'og_description' => $profile->seoMeta->og_description,
+                    'og_image_url' => $profile->seoMeta->og_image_url,
+                    'twitter_title' => $profile->seoMeta->twitter_title,
+                    'twitter_description' => $profile->seoMeta->twitter_description,
+                    'twitter_image_url' => $profile->seoMeta->twitter_image_url,
+                    'robots' => $profile->seoMeta->robots,
+                    'jsonld_overrides_json' => $profile->seoMeta->jsonld_overrides_json,
+                ]
+                : null,
+        ];
+    }
+
+    public static function createRevision(PersonalityProfile $profile, string $note): void
+    {
+        PersonalityProfileRevision::query()->create([
+            'profile_id' => (int) $profile->id,
+            'revision_no' => self::nextRevisionNo($profile),
+            'snapshot_json' => self::snapshotPayload($profile),
+            'note' => $note,
+            'created_by_admin_user_id' => self::currentAdminUserId(),
+            'created_at' => now(),
+        ]);
+    }
+
+    public static function plannedPublicUrl(?string $slug, string $locale): ?string
+    {
+        $resolvedSlug = trim((string) $slug);
+        $baseUrl = rtrim((string) config('app.frontend_url', config('app.url', '')), '/');
+
+        if ($resolvedSlug === '' || $baseUrl === '') {
+            return null;
+        }
+
+        $segment = app(PersonalityProfileSeoService::class)->mapBackendLocaleToFrontendSegment($locale);
+
+        return $baseUrl.'/'.trim($segment, '/').'/personality/'.rawurlencode(Str::lower($resolvedSlug));
+    }
+
+    public static function renderEditorialCues(Get $get, ?PersonalityProfile $record = null): Htmlable
+    {
+        $status = trim((string) ($get('status') ?? $record?->status ?? 'draft'));
+        $isPublic = StatusBadge::isTruthy($get('is_public') ?? $record?->is_public ?? false);
+        $isIndexable = StatusBadge::isTruthy($get('is_indexable') ?? $record?->is_indexable ?? true);
+        $plannedUrl = self::plannedPublicUrl(
+            (string) ($get('slug') ?? $record?->slug ?? ''),
+            (string) ($get('locale') ?? $record?->locale ?? 'en'),
+        );
+
+        return new HtmlString((string) view('filament.ops.personality.partials.editorial-cues', [
+            'facts' => array_values(array_filter([
+                [
+                    'label' => 'Published',
+                    'value' => self::formatTimestamp($get('published_at') ?? $record?->published_at),
+                ],
+                [
+                    'label' => 'Scheduled',
+                    'value' => self::formatTimestamp($get('scheduled_at') ?? $record?->scheduled_at),
+                ],
+                [
+                    'label' => 'Planned public URL',
+                    'value' => $plannedUrl,
+                ],
+                [
+                    'label' => 'Revisions',
+                    'value' => $record instanceof PersonalityProfile ? (string) self::revisionCount($record) : null,
+                ],
+            ], static fn (array $fact): bool => filled($fact['value'] ?? null))),
+            'pills' => [
+                [
+                    'label' => self::statusLabel($status),
+                    'state' => $status,
+                ],
+                [
+                    'label' => $isPublic ? 'Public' : 'Private',
+                    'state' => $isPublic ? 'public' : 'inactive',
+                ],
+                [
+                    'label' => $isIndexable ? 'Indexable' : 'Noindex',
+                    'state' => $isIndexable ? 'indexable' : 'noindex',
+                ],
+            ],
+        ])->render());
+    }
+
+    public static function renderSeoSnapshot(Get $get, ?PersonalityProfile $record = null): Htmlable
+    {
+        $plannedCanonical = self::plannedPublicUrl(
+            (string) ($get('slug') ?? $record?->slug ?? ''),
+            (string) ($get('locale') ?? $record?->locale ?? 'en'),
+        );
+
+        return new HtmlString((string) view('filament.ops.personality.partials.seo-snapshot', [
+            'checks' => self::seoCompleteness([
+                'seo_title' => $get('workspace_seo.seo_title') ?? $record?->seoMeta?->seo_title,
+                'seo_description' => $get('workspace_seo.seo_description') ?? $record?->seoMeta?->seo_description,
+                'og_title' => $get('workspace_seo.og_title') ?? $record?->seoMeta?->og_title,
+                'og_description' => $get('workspace_seo.og_description') ?? $record?->seoMeta?->og_description,
+                'og_image_url' => $get('workspace_seo.og_image_url') ?? $record?->seoMeta?->og_image_url,
+                'twitter_title' => $get('workspace_seo.twitter_title') ?? $record?->seoMeta?->twitter_title,
+                'twitter_description' => $get('workspace_seo.twitter_description') ?? $record?->seoMeta?->twitter_description,
+                'twitter_image_url' => $get('workspace_seo.twitter_image_url') ?? $record?->seoMeta?->twitter_image_url,
+                'robots' => $get('workspace_seo.robots') ?? $record?->seoMeta?->robots,
+            ], $plannedCanonical, StatusBadge::isTruthy($get('is_indexable') ?? $record?->is_indexable ?? true)),
+            'plannedCanonical' => $plannedCanonical,
+        ])->render());
+    }
+
+    public static function formatTimestamp(mixed $value, string $fallback = 'Not set yet'): string
+    {
+        $formatted = self::normalizeTimestamp($value);
+
+        return $formatted ?? $fallback;
+    }
+
+    public static function titleMeta(PersonalityProfile $record): string
+    {
+        return collect([
+            filled($record->type_code) ? Str::upper((string) $record->type_code) : null,
+            filled($record->slug) ? '/'.trim((string) $record->slug, '/') : null,
+            filled($record->locale) ? Str::upper((string) $record->locale) : null,
+        ])->filter(static fn (?string $value): bool => filled($value))->implode(' · ');
+    }
+
+    public static function visibilityMeta(PersonalityProfile $record): string
+    {
+        return implode(' · ', [
+            StatusBadge::booleanLabel($record->is_public, 'Public', 'Private'),
+            StatusBadge::booleanLabel($record->is_indexable, 'Indexable', 'Noindex'),
+        ]);
+    }
+
+    public static function normalizeTypeCode(?string $typeCode): string
+    {
+        $normalized = Str::upper(trim((string) $typeCode));
+
+        return in_array($normalized, PersonalityProfile::TYPE_CODES, true) ? $normalized : $normalized;
+    }
+
+    public static function normalizeSlug(?string $slug, ?string $typeCode = null): string
+    {
+        $candidate = trim((string) $slug);
+
+        if ($candidate === '' && filled($typeCode)) {
+            $candidate = (string) $typeCode;
+        }
+
+        return Str::of($candidate)
+            ->lower()
+            ->replace('_', '-')
+            ->slug('-')
+            ->value();
+    }
+
+    public static function normalizeLocale(?string $locale): string
+    {
+        $normalized = trim((string) $locale);
+
+        return in_array($normalized, PersonalityProfile::SUPPORTED_LOCALES, true) ? $normalized : 'en';
+    }
+
+    /**
+     * @param  array<string, mixed>  $state
+     * @return array<int, array{label: string, description: string, ready: bool}>
+     */
+    public static function seoCompleteness(array $state, ?string $plannedCanonical, bool $isIndexable): array
+    {
+        return [
+            [
+                'label' => 'SEO title',
+                'description' => 'Search headline for the profile detail page.',
+                'ready' => filled(trim((string) ($state['seo_title'] ?? ''))),
+            ],
+            [
+                'label' => 'SEO description',
+                'description' => 'Search snippet summary, with excerpt fallback if left blank.',
+                'ready' => filled(trim((string) ($state['seo_description'] ?? ''))),
+            ],
+            [
+                'label' => 'Canonical route',
+                'description' => 'Final frontend URL stays locale-aware even before frontend cutover.',
+                'ready' => filled($plannedCanonical),
+            ],
+            [
+                'label' => 'Social coverage',
+                'description' => 'Open Graph and Twitter overrides for richer sharing cards.',
+                'ready' => filled(trim((string) ($state['og_title'] ?? '')))
+                    && filled(trim((string) ($state['og_description'] ?? '')))
+                    && filled(trim((string) ($state['twitter_title'] ?? '')))
+                    && filled(trim((string) ($state['twitter_description'] ?? ''))),
+            ],
+            [
+                'label' => 'Robots',
+                'description' => $isIndexable ? 'Defaults to index,follow when left blank.' : 'Defaults to noindex,follow when left blank.',
+                'ready' => true,
+            ],
+        ];
+    }
+
+    private static function revisionCount(PersonalityProfile $profile): int
+    {
+        if ($profile->relationLoaded('revisions')) {
+            return $profile->revisions->count();
+        }
+
+        return (int) $profile->revisions()->count();
+    }
+
+    private static function currentAdminUserId(): ?int
+    {
+        $guard = (string) config('admin.guard', 'admin');
+        $user = auth($guard)->user();
+
+        if (! is_object($user) || ! method_exists($user, 'getAuthIdentifier')) {
+            return null;
+        }
+
+        return (int) $user->getAuthIdentifier();
+    }
+
+    private static function normalizeRenderVariant(string $variant, string $fallback): string
+    {
+        $normalized = trim($variant);
+
+        return in_array($normalized, PersonalityProfileSection::RENDER_VARIANTS, true) ? $normalized : $fallback;
+    }
+
+    private static function normalizeNullableText(string $value): ?string
+    {
+        $normalized = trim($value);
+
+        return $normalized !== '' ? $normalized : null;
+    }
+
+    private static function encodeJson(mixed $value): string
+    {
+        if ($value === null || $value === []) {
+            return '';
+        }
+
+        $encoded = json_encode($value, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE);
+
+        return is_string($encoded) ? $encoded : '';
+    }
+
+    private static function decodeJsonText(mixed $value, string $field): ?array
+    {
+        if (! is_string($value) || trim($value) === '') {
+            return null;
+        }
+
+        try {
+            $decoded = json_decode($value, true, 512, JSON_THROW_ON_ERROR);
+        } catch (\JsonException $exception) {
+            throw ValidationException::withMessages([
+                $field => 'This field must contain valid JSON.',
+            ]);
+        }
+
+        return is_array($decoded) ? $decoded : null;
+    }
+
+    private static function normalizeTimestamp(mixed $value): ?string
+    {
+        if ($value instanceof \DateTimeInterface) {
+            return Carbon::instance($value)->timezone(config('app.timezone'))->format('M j, Y H:i');
+        }
+
+        if (! is_string($value) || trim($value) === '') {
+            return null;
+        }
+
+        try {
+            return Carbon::parse($value)->timezone(config('app.timezone'))->format('M j, Y H:i');
+        } catch (\Throwable) {
+            return null;
+        }
+    }
+
+    private static function statusLabel(string $status): string
+    {
+        $normalized = trim($status);
+
+        if ($normalized === '') {
+            return 'Draft';
+        }
+
+        return Str::of($normalized)
+            ->replace(['_', '-'], ' ')
+            ->headline()
+            ->value();
+    }
+}

--- a/backend/app/Http/Controllers/API/V0_5/Cms/PersonalityController.php
+++ b/backend/app/Http/Controllers/API/V0_5/Cms/PersonalityController.php
@@ -1,0 +1,282 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Controllers\API\V0_5\Cms;
+
+use App\Http\Controllers\Concerns\RespondsWithNotFound;
+use App\Http\Controllers\Controller;
+use App\Models\PersonalityProfile;
+use App\Models\PersonalityProfileSection;
+use App\Models\PersonalityProfileSeoMeta;
+use App\Services\Cms\PersonalityProfileSeoService;
+use App\Services\Cms\PersonalityProfileService;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Validator;
+
+class PersonalityController extends Controller
+{
+    use RespondsWithNotFound;
+
+    public function __construct(
+        private readonly PersonalityProfileService $personalityProfileService,
+        private readonly PersonalityProfileSeoService $personalityProfileSeoService,
+    ) {}
+
+    public function index(Request $request): JsonResponse
+    {
+        $validated = $this->validateListQuery($request);
+        if ($validated instanceof JsonResponse) {
+            return $validated;
+        }
+
+        $paginator = $this->personalityProfileService->listPublicProfiles(
+            $validated['org_id'],
+            $validated['scale_code'],
+            $validated['locale'],
+            $validated['page'],
+            $validated['per_page'],
+        );
+
+        $items = [];
+        foreach ($paginator->items() as $profile) {
+            if (! $profile instanceof PersonalityProfile) {
+                continue;
+            }
+
+            $items[] = $this->profileListPayload($profile);
+        }
+
+        return response()->json([
+            'ok' => true,
+            'items' => $items,
+            'pagination' => [
+                'current_page' => (int) $paginator->currentPage(),
+                'per_page' => (int) $paginator->perPage(),
+                'total' => (int) $paginator->total(),
+                'last_page' => (int) $paginator->lastPage(),
+            ],
+        ]);
+    }
+
+    public function show(Request $request, string $type): JsonResponse
+    {
+        $validated = $this->validateReadQuery($request);
+        if ($validated instanceof JsonResponse) {
+            return $validated;
+        }
+
+        $profile = $this->personalityProfileService->getPublicProfileByType(
+            $type,
+            $validated['org_id'],
+            $validated['scale_code'],
+            $validated['locale'],
+        );
+
+        if (! $profile instanceof PersonalityProfile) {
+            return $this->notFoundResponse('personality profile not found.');
+        }
+
+        return response()->json([
+            'ok' => true,
+            'profile' => $this->profileDetailPayload($profile),
+            'sections' => array_map(
+                fn (PersonalityProfileSection $section): array => $this->sectionPayload($section),
+                $profile->sections->all()
+            ),
+            'seo_meta' => $this->seoMetaPayload($profile->seoMeta),
+        ]);
+    }
+
+    public function seo(Request $request, string $type): JsonResponse
+    {
+        $validated = $this->validateReadQuery($request);
+        if ($validated instanceof JsonResponse) {
+            return $validated;
+        }
+
+        $profile = $this->personalityProfileService->getPublicProfileByType(
+            $type,
+            $validated['org_id'],
+            $validated['scale_code'],
+            $validated['locale'],
+        );
+
+        if (! $profile instanceof PersonalityProfile) {
+            return response()->json(['error' => 'not found'], 404);
+        }
+
+        return response()->json([
+            'meta' => $this->personalityProfileSeoService->buildMeta($profile),
+            'jsonld' => $this->personalityProfileSeoService->buildJsonLd($profile),
+        ]);
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function profileListPayload(PersonalityProfile $profile): array
+    {
+        return [
+            'id' => (int) $profile->id,
+            'org_id' => (int) $profile->org_id,
+            'scale_code' => (string) $profile->scale_code,
+            'type_code' => (string) $profile->type_code,
+            'slug' => (string) $profile->slug,
+            'locale' => (string) $profile->locale,
+            'title' => (string) $profile->title,
+            'subtitle' => $profile->subtitle,
+            'excerpt' => $profile->excerpt,
+            'status' => (string) $profile->status,
+            'is_public' => (bool) $profile->is_public,
+            'is_indexable' => (bool) $profile->is_indexable,
+            'published_at' => $profile->published_at?->toISOString(),
+            'updated_at' => $profile->updated_at?->toISOString(),
+            'seo_meta' => $this->seoMetaSummaryPayload($profile->seoMeta),
+        ];
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function profileDetailPayload(PersonalityProfile $profile): array
+    {
+        return [
+            'id' => (int) $profile->id,
+            'org_id' => (int) $profile->org_id,
+            'scale_code' => (string) $profile->scale_code,
+            'type_code' => (string) $profile->type_code,
+            'slug' => (string) $profile->slug,
+            'locale' => (string) $profile->locale,
+            'title' => (string) $profile->title,
+            'subtitle' => $profile->subtitle,
+            'excerpt' => $profile->excerpt,
+            'hero_kicker' => $profile->hero_kicker,
+            'hero_quote' => $profile->hero_quote,
+            'hero_image_url' => $profile->hero_image_url,
+            'status' => (string) $profile->status,
+            'is_public' => (bool) $profile->is_public,
+            'is_indexable' => (bool) $profile->is_indexable,
+            'published_at' => $profile->published_at?->toISOString(),
+            'updated_at' => $profile->updated_at?->toISOString(),
+        ];
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function sectionPayload(PersonalityProfileSection $section): array
+    {
+        return [
+            'section_key' => (string) $section->section_key,
+            'title' => $section->title,
+            'render_variant' => (string) $section->render_variant,
+            'body_md' => $section->body_md,
+            'body_html' => $section->body_html,
+            'payload_json' => $section->payload_json,
+            'sort_order' => (int) $section->sort_order,
+            'is_enabled' => (bool) $section->is_enabled,
+        ];
+    }
+
+    /**
+     * @return array<string, mixed>|null
+     */
+    private function seoMetaPayload(?PersonalityProfileSeoMeta $seoMeta): ?array
+    {
+        if (! $seoMeta instanceof PersonalityProfileSeoMeta) {
+            return null;
+        }
+
+        return [
+            'seo_title' => $seoMeta->seo_title,
+            'seo_description' => $seoMeta->seo_description,
+            'canonical_url' => $seoMeta->canonical_url,
+            'og_title' => $seoMeta->og_title,
+            'og_description' => $seoMeta->og_description,
+            'og_image_url' => $seoMeta->og_image_url,
+            'twitter_title' => $seoMeta->twitter_title,
+            'twitter_description' => $seoMeta->twitter_description,
+            'twitter_image_url' => $seoMeta->twitter_image_url,
+            'robots' => $seoMeta->robots,
+            'jsonld_overrides_json' => $seoMeta->jsonld_overrides_json,
+        ];
+    }
+
+    /**
+     * @return array<string, mixed>|null
+     */
+    private function seoMetaSummaryPayload(?PersonalityProfileSeoMeta $seoMeta): ?array
+    {
+        if (! $seoMeta instanceof PersonalityProfileSeoMeta) {
+            return null;
+        }
+
+        return [
+            'seo_title' => $seoMeta->seo_title,
+            'seo_description' => $seoMeta->seo_description,
+        ];
+    }
+
+    /**
+     * @return array{org_id:int,scale_code:string,locale:string,page:int,per_page:int}|JsonResponse
+     */
+    private function validateListQuery(Request $request): array|JsonResponse
+    {
+        $validator = Validator::make($request->query(), [
+            'org_id' => ['nullable', 'integer', 'min:0'],
+            'scale_code' => ['nullable', 'in:MBTI'],
+            'locale' => ['required', 'in:en,zh-CN'],
+            'page' => ['nullable', 'integer', 'min:1'],
+            'per_page' => ['nullable', 'integer', 'min:1', 'max:100'],
+        ]);
+
+        if ($validator->fails()) {
+            return $this->invalidArgument($validator->errors()->first());
+        }
+
+        $validated = $validator->validated();
+
+        return [
+            'org_id' => (int) ($validated['org_id'] ?? 0),
+            'scale_code' => (string) ($validated['scale_code'] ?? PersonalityProfile::SCALE_CODE_MBTI),
+            'locale' => (string) $validated['locale'],
+            'page' => (int) ($validated['page'] ?? 1),
+            'per_page' => (int) ($validated['per_page'] ?? 20),
+        ];
+    }
+
+    /**
+     * @return array{org_id:int,scale_code:string,locale:string}|JsonResponse
+     */
+    private function validateReadQuery(Request $request): array|JsonResponse
+    {
+        $validator = Validator::make($request->query(), [
+            'org_id' => ['nullable', 'integer', 'min:0'],
+            'scale_code' => ['nullable', 'in:MBTI'],
+            'locale' => ['required', 'in:en,zh-CN'],
+        ]);
+
+        if ($validator->fails()) {
+            return $this->invalidArgument($validator->errors()->first());
+        }
+
+        $validated = $validator->validated();
+
+        return [
+            'org_id' => (int) ($validated['org_id'] ?? 0),
+            'scale_code' => (string) ($validated['scale_code'] ?? PersonalityProfile::SCALE_CODE_MBTI),
+            'locale' => (string) $validated['locale'],
+        ];
+    }
+
+    private function invalidArgument(string $message): JsonResponse
+    {
+        return response()->json([
+            'ok' => false,
+            'error_code' => 'INVALID_ARGUMENT',
+            'message' => $message,
+        ], 422);
+    }
+}

--- a/backend/app/Services/Cms/PersonalityProfileSeoService.php
+++ b/backend/app/Services/Cms/PersonalityProfileSeoService.php
@@ -1,0 +1,128 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\Cms;
+
+use App\Models\PersonalityProfile;
+use App\Models\PersonalityProfileSeoMeta;
+
+final class PersonalityProfileSeoService
+{
+    /**
+     * @return array<string, mixed>
+     */
+    public function buildMeta(PersonalityProfile $profile): array
+    {
+        $seoMeta = $this->resolveSeoMeta($profile);
+        $title = $this->fallbackText(
+            $seoMeta?->seo_title,
+            (string) $profile->title
+        ) ?? (string) $profile->title;
+        $description = $this->fallbackText(
+            $seoMeta?->seo_description,
+            (string) ($profile->excerpt ?? null),
+            (string) ($profile->subtitle ?? null)
+        );
+        $canonical = $this->buildCanonicalUrl($profile, (string) $profile->locale);
+        $robots = $this->fallbackText($seoMeta?->robots)
+            ?? ((bool) $profile->is_indexable ? 'index,follow' : 'noindex,follow');
+
+        return [
+            'title' => $title,
+            'description' => $description,
+            'canonical' => $canonical,
+            'og' => [
+                'title' => $this->fallbackText($seoMeta?->og_title, $title),
+                'description' => $this->fallbackText($seoMeta?->og_description, $description),
+                'image' => $this->fallbackText($seoMeta?->og_image_url),
+                'type' => 'article',
+            ],
+            'twitter' => [
+                'card' => 'summary_large_image',
+                'title' => $this->fallbackText($seoMeta?->twitter_title, $seoMeta?->og_title, $title),
+                'description' => $this->fallbackText(
+                    $seoMeta?->twitter_description,
+                    $seoMeta?->og_description,
+                    $description
+                ),
+                'image' => $this->fallbackText($seoMeta?->twitter_image_url, $seoMeta?->og_image_url),
+            ],
+            'robots' => $robots,
+        ];
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function buildJsonLd(PersonalityProfile $profile): array
+    {
+        $meta = $this->buildMeta($profile);
+        $jsonLd = [
+            '@context' => 'https://schema.org',
+            '@type' => 'AboutPage',
+            'name' => $meta['title'],
+            'description' => $meta['description'],
+            'about' => [
+                '@type' => 'DefinedTerm',
+                'name' => (string) $profile->type_code,
+                'inDefinedTermSet' => (string) $profile->scale_code,
+            ],
+            'mainEntityOfPage' => $meta['canonical'],
+        ];
+
+        $seoMeta = $this->resolveSeoMeta($profile);
+        if ($seoMeta instanceof PersonalityProfileSeoMeta && is_array($seoMeta->jsonld_overrides_json)) {
+            return array_replace_recursive($jsonLd, $seoMeta->jsonld_overrides_json);
+        }
+
+        return $jsonLd;
+    }
+
+    public function buildCanonicalUrl(PersonalityProfile $profile, string $locale): ?string
+    {
+        $baseUrl = rtrim((string) config('app.frontend_url', config('app.url', '')), '/');
+        $slug = trim((string) $profile->slug);
+
+        if ($baseUrl === '' || $slug === '') {
+            return null;
+        }
+
+        return $baseUrl
+            .'/'.$this->mapBackendLocaleToFrontendSegment($locale)
+            .'/personality/'
+            .rawurlencode($slug);
+    }
+
+    public function mapBackendLocaleToFrontendSegment(string $locale): string
+    {
+        return trim($locale) === 'zh-CN' ? 'zh' : 'en';
+    }
+
+    private function resolveSeoMeta(PersonalityProfile $profile): ?PersonalityProfileSeoMeta
+    {
+        if ($profile->relationLoaded('seoMeta') && $profile->seoMeta instanceof PersonalityProfileSeoMeta) {
+            return $profile->seoMeta;
+        }
+
+        return PersonalityProfileSeoMeta::query()
+            ->where('profile_id', (int) $profile->id)
+            ->first();
+    }
+
+    private function fallbackText(?string ...$candidates): ?string
+    {
+        foreach ($candidates as $candidate) {
+            if ($candidate === null) {
+                continue;
+            }
+
+            $normalized = trim($candidate);
+            if ($normalized !== '') {
+                return $normalized;
+            }
+        }
+
+        return null;
+    }
+}

--- a/backend/app/Services/Cms/PersonalityProfileService.php
+++ b/backend/app/Services/Cms/PersonalityProfileService.php
@@ -1,0 +1,90 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\Cms;
+
+use App\Models\PersonalityProfile;
+use Illuminate\Contracts\Pagination\LengthAwarePaginator;
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+
+final class PersonalityProfileService
+{
+    public function listPublicProfiles(
+        int $orgId,
+        string $scaleCode,
+        string $locale,
+        int $page = 1,
+        int $perPage = 20
+    ): LengthAwarePaginator {
+        return $this->basePublicQuery($orgId, $scaleCode, $locale)
+            ->with('seoMeta')
+            ->orderBy('type_code')
+            ->orderBy('id')
+            ->paginate($perPage, ['*'], 'page', $page);
+    }
+
+    public function getPublicProfileByType(
+        string $typeLookup,
+        int $orgId,
+        string $scaleCode,
+        string $locale
+    ): ?PersonalityProfile {
+        [$slug, $typeCode] = $this->resolveTypeLookup($typeLookup);
+
+        return $this->basePublicQuery($orgId, $scaleCode, $locale)
+            ->where(function (Builder $query) use ($slug, $typeCode): void {
+                $query->where('slug', $slug)
+                    ->orWhere('type_code', $typeCode);
+            })
+            ->with([
+                'sections' => static function (HasMany $query): void {
+                    $query->where('is_enabled', true)
+                        ->orderBy('sort_order')
+                        ->orderBy('id');
+                },
+                'seoMeta',
+            ])
+            ->first();
+    }
+
+    /**
+     * @return array{0:string,1:string}
+     */
+    public function resolveTypeLookup(string $typeLookup): array
+    {
+        $normalized = trim($typeLookup);
+
+        return [
+            strtolower($normalized),
+            strtoupper($normalized),
+        ];
+    }
+
+    private function basePublicQuery(int $orgId, string $scaleCode, string $locale): Builder
+    {
+        return PersonalityProfile::query()
+            ->withoutGlobalScopes()
+            ->where('org_id', max(0, $orgId))
+            ->where('scale_code', $this->normalizeScaleCode($scaleCode))
+            ->forLocale($this->normalizeLocale($locale))
+            ->publishedPublic()
+            ->where(static function (Builder $query): void {
+                $query->whereNull('published_at')
+                    ->orWhere('published_at', '<=', now());
+            });
+    }
+
+    private function normalizeLocale(string $locale): string
+    {
+        return trim($locale);
+    }
+
+    private function normalizeScaleCode(string $scaleCode): string
+    {
+        $normalized = strtoupper(trim($scaleCode));
+
+        return $normalized !== '' ? $normalized : PersonalityProfile::SCALE_CODE_MBTI;
+    }
+}

--- a/backend/docs/contracts/openapi.snapshot.json
+++ b/backend/docs/contracts/openapi.snapshot.json
@@ -1836,6 +1836,57 @@
                     "App\\Http\\Middleware\\EnsureCmsAdminAuthorized"
                 ]
             }
+        },
+        "/api/v0.5/personality": {
+            "get": {
+                "operationId": "get_api_v0_5_personality",
+                "tags": [
+                    "api:v0.5"
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK"
+                    }
+                },
+                "x-laravel-action": "App\\Http\\Controllers\\API\\V0_5\\Cms\\PersonalityController@index",
+                "x-laravel-middleware": [
+                    "api"
+                ]
+            }
+        },
+        "/api/v0.5/personality/{type}": {
+            "get": {
+                "operationId": "get_api_v0_5_personality_type_",
+                "tags": [
+                    "api:v0.5"
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK"
+                    }
+                },
+                "x-laravel-action": "App\\Http\\Controllers\\API\\V0_5\\Cms\\PersonalityController@show",
+                "x-laravel-middleware": [
+                    "api"
+                ]
+            }
+        },
+        "/api/v0.5/personality/{type}/seo": {
+            "get": {
+                "operationId": "get_api_v0_5_personality_type_seo",
+                "tags": [
+                    "api:v0.5"
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK"
+                    }
+                },
+                "x-laravel-action": "App\\Http\\Controllers\\API\\V0_5\\Cms\\PersonalityController@seo",
+                "x-laravel-middleware": [
+                    "api"
+                ]
+            }
         }
     }
 }

--- a/backend/resources/css/filament/ops/theme.css
+++ b/backend/resources/css/filament/ops/theme.css
@@ -1355,6 +1355,200 @@
         font-size: 0.75rem;
         line-height: 1.55;
     }
+
+    .ops-personality-workspace-layout {
+        align-items: start;
+    }
+
+    .ops-personality-workspace-main-column,
+    .ops-personality-workspace-rail-column {
+        display: grid;
+        gap: 1.25rem;
+        align-self: start;
+    }
+
+    .ops-personality-workspace-section .fi-section-header {
+        gap: 0.45rem;
+    }
+
+    .ops-personality-workspace-section--main .fi-section-header-heading {
+        font-size: 1.2rem;
+    }
+
+    .ops-personality-workspace-section--rail .fi-section-header-heading {
+        font-size: 1rem;
+    }
+
+    .ops-personality-workspace-field--title .fi-input-wrp {
+        min-height: 3.35rem;
+    }
+
+    .ops-personality-workspace-input--title {
+        font-size: 1.05rem;
+        font-weight: 700;
+        letter-spacing: -0.025em;
+    }
+
+    .ops-personality-workspace-field--summary textarea {
+        min-height: 8rem;
+    }
+
+    .ops-personality-workspace-field--body textarea {
+        min-height: 12rem;
+    }
+
+    .ops-personality-workspace-field--payload textarea {
+        min-height: 10rem;
+        font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
+        font-size: 0.82rem;
+        line-height: 1.55;
+    }
+
+    .ops-personality-workspace-section .fi-fo-placeholder {
+        display: grid;
+        gap: 0.75rem;
+        border-radius: 14px;
+        background: var(--ops-bg-surface-subtle);
+        padding: 0.95rem 1rem;
+        box-shadow: inset 0 0 0 1px rgba(229, 231, 235, 0.92);
+    }
+
+    .ops-personality-workspace-tabs {
+        display: grid;
+        gap: 1rem;
+    }
+
+    .ops-personality-workspace-tabs .fi-tabs {
+        gap: 0.45rem;
+        border-radius: 16px;
+        background: rgba(251, 252, 253, 0.94);
+        padding: 0.35rem;
+        box-shadow: inset 0 0 0 1px rgba(229, 231, 235, 0.92);
+    }
+
+    .ops-personality-workspace-tabs .fi-tabs-item {
+        border-radius: 12px;
+    }
+
+    .ops-personality-workspace-tabs .fi-fo-tabs-tab {
+        border-radius: 18px;
+        background: linear-gradient(180deg, rgba(255, 255, 255, 0.99), rgba(251, 252, 253, 0.96));
+        box-shadow: var(--ops-shadow-surface);
+    }
+
+    .ops-personality-workspace-cues,
+    .ops-personality-workspace-seo {
+        display: grid;
+        gap: 0.85rem;
+    }
+
+    .ops-personality-workspace-cues__pills {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 0.5rem;
+    }
+
+    .ops-personality-workspace-cues__facts {
+        display: grid;
+        gap: 0.65rem;
+    }
+
+    .ops-personality-workspace-cues__fact {
+        display: grid;
+        gap: 0.15rem;
+    }
+
+    .ops-personality-workspace-cues__fact dt {
+        color: var(--ops-text-tertiary);
+        font-size: 0.6875rem;
+        font-weight: 700;
+        letter-spacing: 0.12em;
+        text-transform: uppercase;
+    }
+
+    .ops-personality-workspace-cues__fact dd {
+        color: var(--ops-text-primary);
+        font-size: 0.875rem;
+        font-weight: 600;
+        line-height: 1.55;
+    }
+
+    .ops-personality-workspace-seo__grid {
+        display: grid;
+        gap: 0.75rem;
+    }
+
+    .ops-personality-workspace-seo__item {
+        display: flex;
+        align-items: flex-start;
+        justify-content: space-between;
+        gap: 1rem;
+        border-radius: 14px;
+        background: rgba(255, 255, 255, 0.94);
+        padding: 0.85rem 0.95rem;
+        box-shadow: inset 0 0 0 1px rgba(229, 231, 235, 0.92);
+    }
+
+    .ops-personality-workspace-seo__copy {
+        display: grid;
+        gap: 0.15rem;
+    }
+
+    .ops-personality-workspace-seo__label {
+        color: var(--ops-text-primary);
+        font-size: 0.8125rem;
+        font-weight: 700;
+        letter-spacing: -0.01em;
+    }
+
+    .ops-personality-workspace-seo__description {
+        color: var(--ops-text-secondary);
+        font-size: 0.75rem;
+        line-height: 1.55;
+    }
+
+    .ops-personality-workspace-seo__planned {
+        display: grid;
+        gap: 0.2rem;
+        border-radius: 14px;
+        background: rgba(255, 255, 255, 0.94);
+        padding: 0.85rem 0.95rem;
+        box-shadow: inset 0 0 0 1px rgba(229, 231, 235, 0.92);
+    }
+
+    .ops-personality-workspace-seo__planned-label {
+        color: var(--ops-text-tertiary);
+        font-size: 0.6875rem;
+        font-weight: 700;
+        letter-spacing: 0.12em;
+        text-transform: uppercase;
+    }
+
+    .ops-personality-workspace-seo__planned-value {
+        color: var(--ops-text-primary);
+        font-size: 0.8125rem;
+        font-weight: 600;
+        line-height: 1.55;
+        word-break: break-word;
+    }
+
+    .ops-personality-workspace-table-title {
+        display: grid;
+        gap: 0.2rem;
+    }
+
+    .ops-personality-workspace-table-title__text {
+        color: var(--ops-text-primary);
+        font-size: 0.95rem;
+        font-weight: 700;
+        letter-spacing: -0.02em;
+    }
+
+    .ops-personality-workspace-table-title__meta {
+        color: var(--ops-text-secondary);
+        font-size: 0.75rem;
+        line-height: 1.55;
+    }
 }
 
 @media (max-width: 1023px) {
@@ -1407,6 +1601,10 @@
     }
 
     .ops-article-workspace-seo__item {
+        flex-direction: column;
+    }
+
+    .ops-personality-workspace-seo__item {
         flex-direction: column;
     }
 }

--- a/backend/resources/views/filament/ops/personality/partials/editorial-cues.blade.php
+++ b/backend/resources/views/filament/ops/personality/partials/editorial-cues.blade.php
@@ -1,0 +1,18 @@
+<div class="ops-personality-workspace-cues">
+    <div class="ops-personality-workspace-cues__pills">
+        @foreach ($pills as $pill)
+            <x-filament.ops.shared.status-pill :label="$pill['label']" :state="$pill['state']" />
+        @endforeach
+    </div>
+
+    @if ($facts !== [])
+        <dl class="ops-personality-workspace-cues__facts">
+            @foreach ($facts as $fact)
+                <div class="ops-personality-workspace-cues__fact">
+                    <dt>{{ $fact['label'] }}</dt>
+                    <dd>{{ $fact['value'] }}</dd>
+                </div>
+            @endforeach
+        </dl>
+    @endif
+</div>

--- a/backend/resources/views/filament/ops/personality/partials/seo-snapshot.blade.php
+++ b/backend/resources/views/filament/ops/personality/partials/seo-snapshot.blade.php
@@ -1,0 +1,24 @@
+<div class="ops-personality-workspace-seo">
+    <div class="ops-personality-workspace-seo__grid">
+        @foreach ($checks as $check)
+            <div class="ops-personality-workspace-seo__item">
+                <div class="ops-personality-workspace-seo__copy">
+                    <span class="ops-personality-workspace-seo__label">{{ $check['label'] }}</span>
+                    <span class="ops-personality-workspace-seo__description">{{ $check['description'] }}</span>
+                </div>
+
+                <x-filament.ops.shared.status-pill
+                    :label="$check['ready'] ? 'Ready' : 'Missing'"
+                    :state="$check['ready'] ? 'ready' : 'draft'"
+                />
+            </div>
+        @endforeach
+    </div>
+
+    @if (filled($plannedCanonical))
+        <div class="ops-personality-workspace-seo__planned">
+            <span class="ops-personality-workspace-seo__planned-label">Planned canonical</span>
+            <span class="ops-personality-workspace-seo__planned-value">{{ $plannedCanonical }}</span>
+        </div>
+    @endif
+</div>

--- a/backend/resources/views/filament/ops/personality/partials/table-title.blade.php
+++ b/backend/resources/views/filament/ops/personality/partials/table-title.blade.php
@@ -1,0 +1,7 @@
+<div class="ops-personality-workspace-table-title">
+    <span class="ops-personality-workspace-table-title__text">{{ $title }}</span>
+
+    @if (filled($meta))
+        <span class="ops-personality-workspace-table-title__meta">{{ $meta }}</span>
+    @endif
+</div>

--- a/backend/routes/api.php
+++ b/backend/routes/api.php
@@ -24,6 +24,7 @@ use App\Http\Controllers\API\V0_4\ExperimentGovernanceController;
 use App\Http\Controllers\API\V0_4\PartnerController;
 use App\Http\Controllers\API\V0_4\RotationAuditController;
 use App\Http\Controllers\API\V0_5\Cms\ArticleController;
+use App\Http\Controllers\API\V0_5\Cms\PersonalityController;
 use App\Http\Controllers\HealthzController;
 use App\Http\Middleware\AdminAuth;
 use App\Http\Middleware\EnsureCmsAdminAuthorized;
@@ -302,6 +303,9 @@ Route::prefix('v0.5')->group(function () {
     Route::get('/articles', [ArticleController::class, 'index']);
     Route::get('/articles/{slug}', [ArticleController::class, 'show']);
     Route::get('/articles/{slug}/seo', [ArticleController::class, 'seo']);
+    Route::get('/personality', [PersonalityController::class, 'index']);
+    Route::get('/personality/{type}/seo', [PersonalityController::class, 'seo']);
+    Route::get('/personality/{type}', [PersonalityController::class, 'show']);
 
     Route::middleware([
         EncryptCookies::class,

--- a/backend/tests/Feature/Ops/PersonalityWorkspaceTest.php
+++ b/backend/tests/Feature/Ops/PersonalityWorkspaceTest.php
@@ -1,0 +1,315 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Ops;
+
+use App\Filament\Ops\Resources\PersonalityProfileResource;
+use App\Filament\Ops\Resources\PersonalityProfileResource\Support\PersonalityWorkspace;
+use App\Models\AdminUser;
+use App\Models\Organization;
+use App\Models\Permission;
+use App\Models\PersonalityProfile;
+use App\Models\PersonalityProfileRevision;
+use App\Models\Role;
+use App\Support\OrgContext;
+use App\Support\Rbac\PermissionNames;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Http\Request;
+use Illuminate\Support\Str;
+use Tests\TestCase;
+
+final class PersonalityWorkspaceTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_personality_workspace_pages_render_for_authorized_admin(): void
+    {
+        $admin = $this->createAdminWithPermissions([
+            PermissionNames::ADMIN_CONTENT_READ,
+            PermissionNames::ADMIN_CONTENT_PUBLISH,
+        ]);
+        $selectedOrg = $this->createSelectedOrg();
+        $profile = $this->seedProfile([
+            'title' => 'INTJ - Architect',
+        ]);
+
+        PersonalityWorkspace::syncWorkspaceSections($profile, $this->workspaceSectionsState());
+        PersonalityWorkspace::syncWorkspaceSeo($profile, $this->workspaceSeoState());
+        PersonalityWorkspace::createRevision($profile, 'Seed revision');
+
+        $this->withSession([
+            'ops_org_id' => $selectedOrg->id,
+            'ops_admin_totp_verified_user_id' => (int) $admin->id,
+        ])->actingAs($admin, (string) config('admin.guard', 'admin'))
+            ->get('/ops/personality')
+            ->assertOk()
+            ->assertSee('Global MBTI content workspace', false)
+            ->assertSee('Create Personality Profile');
+
+        $this->withSession([
+            'ops_org_id' => $selectedOrg->id,
+            'ops_admin_totp_verified_user_id' => (int) $admin->id,
+        ])->actingAs($admin, (string) config('admin.guard', 'admin'))
+            ->get('/ops/personality/create')
+            ->assertOk()
+            ->assertSee('ops-personality-workspace-layout', false)
+            ->assertSee('Create Personality Profile');
+
+        $this->withSession([
+            'ops_org_id' => $selectedOrg->id,
+            'ops_admin_totp_verified_user_id' => (int) $admin->id,
+        ])->actingAs($admin, (string) config('admin.guard', 'admin'))
+            ->get('/ops/personality/'.$profile->id.'/edit')
+            ->assertOk()
+            ->assertSee('ops-personality-workspace-layout', false)
+            ->assertSee('Planned public URL');
+    }
+
+    public function test_workspace_sync_persists_sections_seo_and_initial_revision(): void
+    {
+        $profile = $this->seedProfile();
+
+        PersonalityWorkspace::syncWorkspaceSections($profile, $this->workspaceSectionsState());
+        PersonalityWorkspace::syncWorkspaceSeo($profile, $this->workspaceSeoState());
+        PersonalityWorkspace::createRevision($profile, 'Initial workspace snapshot');
+
+        $this->assertDatabaseHas('personality_profile_sections', [
+            'profile_id' => $profile->id,
+            'section_key' => 'core_snapshot',
+            'title' => 'Core snapshot',
+            'render_variant' => 'rich_text',
+            'is_enabled' => 1,
+        ]);
+
+        $this->assertDatabaseHas('personality_profile_seo_meta', [
+            'profile_id' => $profile->id,
+            'seo_title' => 'INTJ Personality Type: Traits, Careers, and Growth | FermatMind',
+            'robots' => 'index,follow',
+        ]);
+
+        $this->assertDatabaseHas('personality_profile_revisions', [
+            'profile_id' => $profile->id,
+            'revision_no' => 1,
+            'note' => 'Initial workspace snapshot',
+        ]);
+    }
+
+    public function test_workspace_sync_updates_profile_sections_seo_and_revision_counter(): void
+    {
+        $profile = $this->seedProfile();
+
+        PersonalityWorkspace::syncWorkspaceSections($profile, $this->workspaceSectionsState());
+        PersonalityWorkspace::syncWorkspaceSeo($profile, $this->workspaceSeoState());
+        PersonalityWorkspace::createRevision($profile, 'Initial workspace snapshot');
+
+        $profile->update([
+            'title' => 'INTJ - Architect (Updated)',
+            'subtitle' => 'Sharper, quieter, and more deliberate.',
+        ]);
+
+        $updatedSections = $this->workspaceSectionsState();
+        $updatedSections['core_snapshot']['body_md'] = 'Updated long-range systems framing.';
+        $updatedSections['faq']['is_enabled'] = true;
+        $updatedSections['faq']['payload_json_text'] = json_encode([
+            'items' => [
+                [
+                    'question' => 'Do INTJs always work alone?',
+                    'answer' => 'No. They often prefer clarity, autonomy, and high trust.',
+                ],
+            ],
+        ], JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE);
+
+        $updatedSeo = $this->workspaceSeoState();
+        $updatedSeo['seo_description'] = 'Updated SEO summary for the INTJ workspace.';
+
+        PersonalityWorkspace::syncWorkspaceSections($profile, $updatedSections);
+        PersonalityWorkspace::syncWorkspaceSeo($profile, $updatedSeo);
+        PersonalityWorkspace::createRevision($profile, 'Workspace update');
+
+        $this->assertDatabaseHas('personality_profile_sections', [
+            'profile_id' => $profile->id,
+            'section_key' => 'faq',
+            'is_enabled' => 1,
+            'render_variant' => 'faq',
+        ]);
+
+        $this->assertDatabaseHas('personality_profile_seo_meta', [
+            'profile_id' => $profile->id,
+            'seo_description' => 'Updated SEO summary for the INTJ workspace.',
+        ]);
+
+        $this->assertDatabaseHas('personality_profile_revisions', [
+            'profile_id' => $profile->id,
+            'revision_no' => 2,
+            'note' => 'Workspace update',
+        ]);
+
+        $latestRevision = PersonalityProfileRevision::query()
+            ->where('profile_id', $profile->id)
+            ->where('revision_no', 2)
+            ->firstOrFail();
+
+        $this->assertSame('INTJ - Architect (Updated)', $latestRevision->snapshot_json['profile']['title']);
+        $this->assertSame('Updated long-range systems framing.', $latestRevision->snapshot_json['sections'][0]['body_md']);
+    }
+
+    public function test_resource_query_is_locked_to_global_mbti_profiles(): void
+    {
+        $globalProfile = $this->seedProfile([
+            'org_id' => 0,
+            'scale_code' => PersonalityProfile::SCALE_CODE_MBTI,
+            'slug' => 'intj-global',
+        ]);
+
+        $tenantProfile = $this->seedProfile([
+            'org_id' => 77,
+            'slug' => 'intj-tenant',
+        ]);
+
+        $otherScale = $this->seedProfile([
+            'org_id' => 0,
+            'scale_code' => 'DISC',
+            'type_code' => 'DISC',
+            'slug' => 'disc-driver',
+            'title' => 'DISC - Driver',
+        ]);
+
+        $request = Request::create('/ops/personality', 'GET');
+        app()->instance('request', $request);
+
+        $context = app(OrgContext::class);
+        $context->set(77, 9001, 'admin');
+        app()->instance(OrgContext::class, $context);
+
+        $ids = PersonalityProfileResource::getEloquentQuery()
+            ->orderBy('id')
+            ->pluck('id')
+            ->all();
+
+        $this->assertContains($globalProfile->id, $ids);
+        $this->assertNotContains($tenantProfile->id, $ids);
+        $this->assertNotContains($otherScale->id, $ids);
+    }
+
+    private function createSelectedOrg(): Organization
+    {
+        return Organization::query()->create([
+            'name' => 'Ops Workspace Org',
+            'owner_user_id' => 9001,
+            'status' => 'active',
+            'domain' => 'ops-workspace.example.test',
+            'timezone' => 'Asia/Shanghai',
+            'locale' => 'en',
+        ]);
+    }
+
+    /**
+     * @param  list<string>  $permissions
+     */
+    private function createAdminWithPermissions(array $permissions): AdminUser
+    {
+        $admin = AdminUser::query()->create([
+            'name' => 'admin_'.Str::lower(Str::random(6)),
+            'email' => 'admin_'.Str::lower(Str::random(6)).'@example.test',
+            'password' => bcrypt('secret'),
+            'is_active' => 1,
+        ]);
+
+        if ($permissions === []) {
+            return $admin;
+        }
+
+        $role = Role::query()->create([
+            'name' => 'role_'.Str::lower(Str::random(10)),
+            'description' => null,
+        ]);
+
+        foreach ($permissions as $permissionName) {
+            $permission = Permission::query()->firstOrCreate(
+                ['name' => $permissionName],
+                ['description' => null],
+            );
+
+            $role->permissions()->syncWithoutDetaching([$permission->id]);
+        }
+
+        $admin->roles()->syncWithoutDetaching([$role->id]);
+
+        return $admin;
+    }
+
+    /**
+     * @param  array<string, mixed>  $overrides
+     */
+    private function seedProfile(array $overrides = []): PersonalityProfile
+    {
+        return PersonalityProfile::query()->create(array_merge([
+            'org_id' => 0,
+            'scale_code' => PersonalityProfile::SCALE_CODE_MBTI,
+            'type_code' => 'INTJ',
+            'slug' => 'intj',
+            'locale' => 'en',
+            'title' => 'INTJ - Architect',
+            'subtitle' => 'Independent, strategic, and future-oriented.',
+            'excerpt' => 'INTJs tend to value competence, systems, and long-range thinking.',
+            'hero_kicker' => 'The Strategist',
+            'hero_quote' => 'See the pattern. Build the system.',
+            'status' => 'draft',
+            'is_public' => true,
+            'is_indexable' => true,
+        ], $overrides));
+    }
+
+    /**
+     * @return array<string, array<string, mixed>>
+     */
+    private function workspaceSectionsState(): array
+    {
+        $state = PersonalityWorkspace::defaultWorkspaceSectionsState();
+
+        $state['core_snapshot']['body_md'] = 'INTJs are analytical, strategic, and long-range systems thinkers.';
+        $state['strengths']['payload_json_text'] = json_encode([
+            'items' => [
+                [
+                    'title' => 'Strategic thinking',
+                    'body' => 'Sees long-range patterns and system dependencies.',
+                ],
+                [
+                    'title' => 'Independent execution',
+                    'body' => 'Can move fast with clarity and autonomy.',
+                ],
+            ],
+        ], JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE);
+        $state['growth_edges']['payload_json_text'] = json_encode([
+            'items' => [
+                [
+                    'title' => 'Over-indexing on systems',
+                    'body' => 'Can miss emotional pacing when pushing for the cleanest plan.',
+                ],
+            ],
+        ], JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE);
+
+        return $state;
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    private function workspaceSeoState(): array
+    {
+        return [
+            'seo_title' => 'INTJ Personality Type: Traits, Careers, and Growth | FermatMind',
+            'seo_description' => 'Explore INTJ traits, strengths, blind spots, work style, relationships, and growth advice.',
+            'canonical_url' => '',
+            'og_title' => 'INTJ Personality Type',
+            'og_description' => 'Explore INTJ traits, careers, relationships, and growth.',
+            'og_image_url' => '',
+            'twitter_title' => 'INTJ Personality Type',
+            'twitter_description' => 'Explore INTJ traits, careers, relationships, and growth.',
+            'twitter_image_url' => '',
+            'robots' => 'index,follow',
+            'jsonld_overrides_json_text' => '',
+        ];
+    }
+}

--- a/backend/tests/Feature/V0_5/PersonalityPublicApiTest.php
+++ b/backend/tests/Feature/V0_5/PersonalityPublicApiTest.php
@@ -1,0 +1,316 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\V0_5;
+
+use App\Models\PersonalityProfile;
+use App\Models\PersonalityProfileRevision;
+use App\Models\PersonalityProfileSection;
+use App\Models\PersonalityProfileSeoMeta;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+final class PersonalityPublicApiTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_list_returns_published_public_only(): void
+    {
+        $visible = $this->createProfile([
+            'type_code' => 'INTJ',
+            'slug' => 'intj',
+            'title' => 'INTJ - Architect',
+            'status' => 'published',
+            'is_public' => true,
+            'published_at' => now()->subMinute(),
+        ]);
+        $this->createSeoMeta($visible, [
+            'seo_title' => 'INTJ Personality',
+            'seo_description' => 'INTJ seo description',
+        ]);
+
+        $this->createProfile([
+            'type_code' => 'ENTP',
+            'slug' => 'entp',
+            'title' => 'ENTP draft',
+            'status' => 'draft',
+            'is_public' => true,
+        ]);
+        $this->createProfile([
+            'type_code' => 'INFJ',
+            'slug' => 'infj',
+            'title' => 'INFJ private',
+            'status' => 'published',
+            'is_public' => false,
+            'published_at' => now()->subMinute(),
+        ]);
+        $this->createProfile([
+            'type_code' => 'ENFP',
+            'slug' => 'enfp',
+            'title' => 'ENFP scheduled',
+            'status' => 'published',
+            'is_public' => true,
+            'published_at' => now()->addHour(),
+        ]);
+
+        $response = $this->getJson('/api/v0.5/personality?locale=en');
+
+        $response->assertOk()
+            ->assertJsonPath('ok', true)
+            ->assertJsonPath('pagination.total', 1)
+            ->assertJsonCount(1, 'items')
+            ->assertJsonPath('items.0.slug', 'intj')
+            ->assertJsonPath('items.0.seo_meta.seo_title', 'INTJ Personality');
+    }
+
+    public function test_list_respects_locale_and_org_scope(): void
+    {
+        $this->createProfile([
+            'org_id' => 0,
+            'type_code' => 'INTJ',
+            'slug' => 'intj',
+            'locale' => 'en',
+            'title' => 'INTJ EN',
+            'status' => 'published',
+            'is_public' => true,
+            'published_at' => now()->subMinute(),
+        ]);
+        $this->createProfile([
+            'org_id' => 0,
+            'type_code' => 'INTJ',
+            'slug' => 'intj',
+            'locale' => 'zh-CN',
+            'title' => 'INTJ ZH',
+            'status' => 'published',
+            'is_public' => true,
+            'published_at' => now()->subMinute(),
+        ]);
+        $this->createProfile([
+            'org_id' => 7,
+            'type_code' => 'INTJ',
+            'slug' => 'intj',
+            'locale' => 'en',
+            'title' => 'INTJ Org 7',
+            'status' => 'published',
+            'is_public' => true,
+            'published_at' => now()->subMinute(),
+        ]);
+
+        $en = $this->getJson('/api/v0.5/personality?locale=en');
+        $en->assertOk()
+            ->assertJsonCount(1, 'items')
+            ->assertJsonPath('items.0.title', 'INTJ EN');
+
+        $zh = $this->getJson('/api/v0.5/personality?locale=zh-CN');
+        $zh->assertOk()
+            ->assertJsonCount(1, 'items')
+            ->assertJsonPath('items.0.title', 'INTJ ZH');
+
+        $org = $this->getJson('/api/v0.5/personality?locale=en&org_id=7');
+        $org->assertOk()
+            ->assertJsonCount(1, 'items')
+            ->assertJsonPath('items.0.org_id', 7)
+            ->assertJsonPath('items.0.title', 'INTJ Org 7');
+    }
+
+    public function test_detail_returns_profile_sections_and_seo_meta(): void
+    {
+        $profile = $this->createProfile([
+            'type_code' => 'INTJ',
+            'slug' => 'intj',
+            'title' => 'INTJ - Architect',
+            'status' => 'published',
+            'is_public' => true,
+            'published_at' => now()->subMinute(),
+        ]);
+
+        PersonalityProfileSection::query()->create([
+            'profile_id' => (int) $profile->id,
+            'section_key' => 'core_snapshot',
+            'title' => 'Core snapshot',
+            'render_variant' => 'rich_text',
+            'body_md' => 'INTJ body',
+            'sort_order' => 10,
+            'is_enabled' => true,
+        ]);
+        PersonalityProfileSection::query()->create([
+            'profile_id' => (int) $profile->id,
+            'section_key' => 'strengths',
+            'title' => 'Strengths',
+            'render_variant' => 'bullets',
+            'payload_json' => ['items' => [['title' => 'Strategic thinking']]],
+            'sort_order' => 20,
+            'is_enabled' => false,
+        ]);
+
+        $this->createSeoMeta($profile, [
+            'seo_title' => 'INTJ Personality Type',
+            'seo_description' => 'Explore INTJ traits.',
+            'robots' => 'index,follow',
+        ]);
+        PersonalityProfileRevision::query()->create([
+            'profile_id' => (int) $profile->id,
+            'revision_no' => 1,
+            'snapshot_json' => ['title' => 'INTJ - Architect'],
+            'note' => 'initial',
+            'created_at' => now(),
+        ]);
+
+        $response = $this->getJson('/api/v0.5/personality/intj?locale=en');
+
+        $response->assertOk()
+            ->assertJsonPath('ok', true)
+            ->assertJsonPath('profile.type_code', 'INTJ')
+            ->assertJsonPath('profile.slug', 'intj')
+            ->assertJsonCount(1, 'sections')
+            ->assertJsonPath('sections.0.section_key', 'core_snapshot')
+            ->assertJsonPath('seo_meta.seo_title', 'INTJ Personality Type')
+            ->assertJsonMissingPath('revisions');
+    }
+
+    public function test_detail_returns_not_found_for_missing_hidden_or_locale_mismatch_profiles(): void
+    {
+        $draft = $this->createProfile([
+            'type_code' => 'INTJ',
+            'slug' => 'intj',
+            'status' => 'draft',
+            'is_public' => true,
+        ]);
+        $this->createProfile([
+            'type_code' => 'ENTJ',
+            'slug' => 'entj',
+            'status' => 'published',
+            'is_public' => false,
+            'published_at' => now()->subMinute(),
+        ]);
+        $this->createProfile([
+            'type_code' => 'INFJ',
+            'slug' => 'infj',
+            'locale' => 'zh-CN',
+            'status' => 'published',
+            'is_public' => true,
+            'published_at' => now()->subMinute(),
+        ]);
+
+        $this->getJson('/api/v0.5/personality/missing?locale=en')
+            ->assertStatus(404)
+            ->assertJsonPath('ok', false)
+            ->assertJsonPath('error_code', 'NOT_FOUND');
+
+        $this->getJson('/api/v0.5/personality/'.$draft->slug.'?locale=en')
+            ->assertStatus(404)
+            ->assertJsonPath('error_code', 'NOT_FOUND');
+
+        $this->getJson('/api/v0.5/personality/entj?locale=en')
+            ->assertStatus(404)
+            ->assertJsonPath('error_code', 'NOT_FOUND');
+
+        $this->getJson('/api/v0.5/personality/infj?locale=en')
+            ->assertStatus(404)
+            ->assertJsonPath('error_code', 'NOT_FOUND');
+    }
+
+    public function test_seo_endpoint_returns_locale_aware_meta_and_jsonld(): void
+    {
+        config(['app.frontend_url' => 'https://staging.fermatmind.com']);
+
+        $enProfile = $this->createProfile([
+            'type_code' => 'INTJ',
+            'slug' => 'intj',
+            'locale' => 'en',
+            'title' => 'INTJ Personality Type',
+            'excerpt' => 'Explore INTJ traits, strengths, and growth.',
+            'status' => 'published',
+            'is_public' => true,
+            'is_indexable' => true,
+            'published_at' => now()->subMinute(),
+        ]);
+        $this->createSeoMeta($enProfile, [
+            'seo_title' => 'INTJ Personality Type: Traits, Careers, and Growth | FermatMind',
+            'seo_description' => 'Explore INTJ traits, strengths, blind spots, work style, relationships, and growth advice.',
+        ]);
+
+        $zhProfile = $this->createProfile([
+            'type_code' => 'INTJ',
+            'slug' => 'intj',
+            'locale' => 'zh-CN',
+            'title' => 'INTJ 人格类型',
+            'excerpt' => '探索 INTJ 的特质、优势与成长方向。',
+            'status' => 'published',
+            'is_public' => true,
+            'is_indexable' => false,
+            'published_at' => now()->subMinute(),
+        ]);
+        $this->createSeoMeta($zhProfile, [
+            'seo_title' => 'INTJ 人格类型：特质、职业与成长 | FermatMind',
+            'seo_description' => '探索 INTJ 的特质、优势、关系模式与成长建议。',
+        ]);
+
+        $enResponse = $this->getJson('/api/v0.5/personality/INTJ/seo?locale=en');
+        $enResponse->assertOk()
+            ->assertJsonPath('meta.title', 'INTJ Personality Type: Traits, Careers, and Growth | FermatMind')
+            ->assertJsonPath('meta.canonical', 'https://staging.fermatmind.com/en/personality/intj')
+            ->assertJsonPath('meta.robots', 'index,follow');
+        self::assertSame('AboutPage', data_get($enResponse->json(), 'jsonld.@type'));
+        self::assertSame(
+            'https://staging.fermatmind.com/en/personality/intj',
+            data_get($enResponse->json(), 'jsonld.mainEntityOfPage')
+        );
+
+        $zhResponse = $this->getJson('/api/v0.5/personality/intj/seo?locale=zh-CN');
+        $zhResponse->assertOk()
+            ->assertJsonPath('meta.canonical', 'https://staging.fermatmind.com/zh/personality/intj')
+            ->assertJsonPath('meta.robots', 'noindex,follow');
+        self::assertSame(
+            'https://staging.fermatmind.com/zh/personality/intj',
+            data_get($zhResponse->json(), 'jsonld.mainEntityOfPage')
+        );
+    }
+
+    /**
+     * @param  array<string, mixed>  $overrides
+     */
+    private function createProfile(array $overrides = []): PersonalityProfile
+    {
+        /** @var PersonalityProfile */
+        return PersonalityProfile::query()->create(array_merge([
+            'org_id' => 0,
+            'scale_code' => PersonalityProfile::SCALE_CODE_MBTI,
+            'type_code' => 'INTJ',
+            'slug' => 'intj',
+            'locale' => 'en',
+            'title' => 'INTJ',
+            'subtitle' => 'Strategic and future-oriented',
+            'excerpt' => 'INTJs tend to value competence, systems, and long-range thinking.',
+            'status' => 'draft',
+            'is_public' => false,
+            'is_indexable' => true,
+            'published_at' => null,
+            'scheduled_at' => null,
+            'schema_version' => 'v1',
+        ], $overrides));
+    }
+
+    /**
+     * @param  array<string, mixed>  $overrides
+     */
+    private function createSeoMeta(PersonalityProfile $profile, array $overrides = []): PersonalityProfileSeoMeta
+    {
+        /** @var PersonalityProfileSeoMeta */
+        return PersonalityProfileSeoMeta::query()->create(array_merge([
+            'profile_id' => (int) $profile->id,
+            'seo_title' => null,
+            'seo_description' => null,
+            'canonical_url' => null,
+            'og_title' => null,
+            'og_description' => null,
+            'og_image_url' => null,
+            'twitter_title' => null,
+            'twitter_description' => null,
+            'twitter_image_url' => null,
+            'robots' => null,
+            'jsonld_overrides_json' => null,
+        ], $overrides));
+    }
+}


### PR DESCRIPTION
## Summary

- add the Ops resource and editorial workspace for Personality CMS v1
- provide list, create, and edit experiences for structured MBTI personality profiles

## What changed

- add a Filament resource for personality profiles
- add a structured workspace for create/edit flows
- organize profile editing into stronger main-content vs metadata rails
- add workspace helpers for sections, seo meta, and revision snapshots
- keep the existing backend theme, shell, and shared component layers

## Design choices

- personality content is edited as structured profiles, not generic articles
- the workspace keeps section keys fixed and controlled
- v1 operates on global MBTI content (`org_id=0`)
- public URL handling stays conservative until the frontend cutover is complete
- revision snapshots are written on create/update

## Why this PR is small and safe

- no API changes
- no frontend changes
- no route changes outside the new resource
- no RBAC changes
- no database changes beyond P01
- only Ops resource/workspace implementation for Personality CMS

## Validation

- `php artisan about`
- `php artisan route:list --path=ops --except-vendor`
- `php artisan route:list --path=personality --except-vendor`
- `php artisan migrate`
- `php artisan filament:assets`
- `npm run build`
- `php artisan test --filter=Personality`
- checked `/ops/personality`, `/ops/personality/create`, `/ops/personality/{record}/edit`
- `bash backend/scripts/ci_verify_mbti.sh`
