### PR TITLE
fix(cors): use explicit public api allowlist

### DIFF
--- a/backend/config/cors.php
+++ b/backend/config/cors.php
@@ -1,29 +1,34 @@
 <?php
 
 return [
-    'paths' => [
-        'api/*',
-        'sanctum/csrf-cookie',
-    ],
+    'paths' => ['api/*'],
 
-    'allowed_methods' => ['*'],
+    'allowed_methods' => ['GET', 'POST', 'PUT', 'PATCH', 'DELETE', 'OPTIONS'],
 
     'allowed_origins' => [
-        'https://fermatmind.com',
         'https://www.fermatmind.com',
+        'https://fermatmind.com',
     ],
 
     'allowed_origins_patterns' => [],
 
-    'allowed_headers' => ['*'],
+    'allowed_headers' => [
+        'Authorization',
+        'Content-Type',
+        'X-Org-Id',
+        'X-FM-Org-Id',
+        'X-Anon-Id',
+        'Idempotency-Key',
+        'X-Request-Id',
+        'X-Requested-With',
+        'Accept',
+    ],
 
     'exposed_headers' => [
         'X-Request-Id',
-        'X-RateLimit-Limit',
-        'X-RateLimit-Remaining',
     ],
 
-    'max_age' => 600,
+    'max_age' => 86400,
 
     'supports_credentials' => false,
 ];


### PR DESCRIPTION
## Summary
- simplify the backend API CORS policy into an explicit public allowlist
- keep the allowlist limited to approved FermatMind origins while making preflight behavior predictable

## What changed
- limit CORS paths to `api/*`
- replace wildcard methods with an explicit method list
- replace wildcard headers with an explicit public API header allowlist
- keep the allowed origins restricted to `https://fermatmind.com` and `https://www.fermatmind.com`
- reduce exposed headers to `X-Request-Id`
- increase `max_age` to `86400`

## Why
- the previous wildcard configuration was broader than needed for the public API surface
- an explicit method/header allowlist makes the effective CORS contract easier to reason about and verify
- this PR only changes runtime CORS policy and does not touch routes, controllers, services, or schema

## Validation
- `php -l backend/config/cors.php`
- `cd backend && php artisan route:list`
- `cd backend && php artisan migrate`
- `curl -i -X OPTIONS http://127.0.0.1:18010/api/healthz ...`
- `curl -i http://127.0.0.1:18010/api/healthz -H 'Origin: https://fermatmind.com'`
