### PR TITLE
fix(cors): allow X-Fap-Locale header

### DIFF
--- a/backend/config/cors.php
+++ b/backend/config/cors.php
@@ -18,6 +18,7 @@ return [
         'X-Org-Id',
         'X-FM-Org-Id',
         'X-Anon-Id',
+        'X-Fap-Locale',
         'Idempotency-Key',
         'X-Request-Id',
         'X-Requested-With',


### PR DESCRIPTION
## Summary
- add `X-Fap-Locale` to the allowed CORS headers
- allow frontend locale context to pass through cross-origin API requests

## Testing
- `cd backend && php artisan route:list`