### PR TITLE
feat(personality-cms): add baseline import for local personality content

### DIFF
--- a/backend/app/Console/Commands/PersonalityImportLocalBaseline.php
+++ b/backend/app/Console/Commands/PersonalityImportLocalBaseline.php
@@ -1,0 +1,83 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Console\Commands;
+
+use App\PersonalityCms\Baseline\PersonalityBaselineImporter;
+use App\PersonalityCms\Baseline\PersonalityBaselineNormalizer;
+use App\PersonalityCms\Baseline\PersonalityBaselineReader;
+use Illuminate\Console\Command;
+use RuntimeException;
+
+final class PersonalityImportLocalBaseline extends Command
+{
+    protected $signature = 'personality:import-local-baseline
+        {--dry-run : Validate and diff without writing to the database}
+        {--locale=* : Import only specific locale(s)}
+        {--type=* : Import only specific MBTI type code(s)}
+        {--upsert : Update existing records instead of create-missing only}
+        {--status=draft : Force imported records to draft or published}
+        {--source-dir= : Override the committed baseline source directory}';
+
+    protected $description = 'Import committed MBTI personality baseline content into Personality CMS tables.';
+
+    public function handle(
+        PersonalityBaselineReader $reader,
+        PersonalityBaselineNormalizer $normalizer,
+        PersonalityBaselineImporter $importer,
+    ): int {
+        try {
+            $status = trim((string) $this->option('status'));
+            if (! in_array($status, ['draft', 'published'], true)) {
+                throw new RuntimeException(sprintf(
+                    'Unsupported --status value: %s',
+                    $status,
+                ));
+            }
+
+            $sourceDir = $reader->resolveSourceDir(
+                $this->option('source-dir') !== null
+                    ? (string) $this->option('source-dir')
+                    : null,
+            );
+            $selectedLocales = array_values(array_filter(
+                array_map(static fn (string $value): string => trim($value), (array) $this->option('locale')),
+                static fn (string $value): bool => $value !== '',
+            ));
+            $selectedTypes = array_values(array_filter(
+                array_map(static fn (string $value): string => trim($value), (array) $this->option('type')),
+                static fn (string $value): bool => $value !== '',
+            ));
+
+            $documents = $reader->read($sourceDir, $selectedLocales);
+            $profiles = $normalizer->normalizeDocuments($documents, $selectedTypes);
+            $summary = $importer->import($profiles, [
+                'dry_run' => (bool) $this->option('dry-run'),
+                'upsert' => (bool) $this->option('upsert'),
+                'status' => $status,
+            ]);
+
+            $this->line('baseline_source_dir='.$sourceDir);
+            $this->line('locales_selected='.($selectedLocales === [] ? 'all' : implode(',', $selectedLocales)));
+            $this->line('types_selected='.($selectedTypes === [] ? 'all' : implode(',', $selectedTypes)));
+            $this->line('dry_run='.((bool) $this->option('dry-run') ? '1' : '0'));
+            $this->line('upsert='.((bool) $this->option('upsert') ? '1' : '0'));
+            $this->line('status_mode='.$status);
+            $this->line('profiles_found='.(string) $summary['profiles_found']);
+            $this->line('will_create='.(string) $summary['will_create']);
+            $this->line('will_update='.(string) $summary['will_update']);
+            $this->line('will_skip='.(string) $summary['will_skip']);
+            $this->line('revisions_to_create='.(string) $summary['revisions_to_create']);
+            $this->line('errors_count='.(string) $summary['errors_count']);
+
+            $this->info((bool) $this->option('dry-run') ? 'dry-run complete' : 'import complete');
+
+            return 0;
+        } catch (\Throwable $throwable) {
+            $this->error($throwable->getMessage());
+
+            return 1;
+        }
+    }
+}

--- a/backend/app/PersonalityCms/Baseline/PersonalityBaselineImporter.php
+++ b/backend/app/PersonalityCms/Baseline/PersonalityBaselineImporter.php
@@ -1,0 +1,407 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\PersonalityCms\Baseline;
+
+use App\Models\PersonalityProfile;
+use App\Models\PersonalityProfileRevision;
+use App\Models\PersonalityProfileSection;
+use App\Models\PersonalityProfileSeoMeta;
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Support\Carbon;
+use Illuminate\Support\Facades\DB;
+
+final class PersonalityBaselineImporter
+{
+    /**
+     * @param  array<int, array<string, mixed>>  $profiles
+     * @param  array{
+     *   dry_run: bool,
+     *   upsert: bool,
+     *   status: 'draft'|'published'
+     * }  $options
+     * @return array<string, int|string|bool>
+     */
+    public function import(array $profiles, array $options): array
+    {
+        $dryRun = (bool) ($options['dry_run'] ?? false);
+        $upsert = (bool) ($options['upsert'] ?? false);
+        $status = (string) ($options['status'] ?? 'draft');
+
+        $summary = [
+            'profiles_found' => count($profiles),
+            'will_create' => 0,
+            'will_update' => 0,
+            'will_skip' => 0,
+            'revisions_to_create' => 0,
+            'errors_count' => 0,
+            'dry_run' => $dryRun,
+            'upsert' => $upsert,
+            'status_mode' => $status,
+        ];
+
+        foreach ($profiles as $profilePayload) {
+            $existing = $this->profileQuery()
+                ->where('org_id', 0)
+                ->where('scale_code', PersonalityProfile::SCALE_CODE_MBTI)
+                ->where('type_code', (string) $profilePayload['type_code'])
+                ->where('locale', (string) $profilePayload['locale'])
+                ->first();
+
+            if (! $existing instanceof PersonalityProfile) {
+                $summary['will_create']++;
+                $summary['revisions_to_create']++;
+
+                if (! $dryRun) {
+                    DB::transaction(function () use ($profilePayload, $status): void {
+                        $profile = PersonalityProfile::query()->create(
+                            $this->profileAttributes($profilePayload, $status)
+                        );
+
+                        $this->syncSections($profile, $profilePayload, false);
+                        $this->syncSeoMeta($profile, $profilePayload);
+                        $this->createRevision($profile, 'baseline import');
+                    });
+                }
+
+                continue;
+            }
+
+            if (! $upsert) {
+                $summary['will_skip']++;
+
+                continue;
+            }
+
+            $desiredState = $this->desiredComparableState($profilePayload, $status, $existing);
+            $currentState = $this->currentComparableState($existing);
+
+            if ($desiredState === $currentState) {
+                $summary['will_skip']++;
+
+                continue;
+            }
+
+            $summary['will_update']++;
+            $summary['revisions_to_create']++;
+
+            if (! $dryRun) {
+                DB::transaction(function () use ($existing, $profilePayload, $status): void {
+                    $existing->fill($this->profileAttributes($profilePayload, $status, $existing));
+                    $existing->save();
+
+                    $this->syncSections($existing, $profilePayload, true);
+                    $this->syncSeoMeta($existing, $profilePayload);
+                    $this->createRevision($existing, 'baseline upsert');
+                });
+            }
+        }
+
+        return $summary;
+    }
+
+    private function profileQuery(): Builder
+    {
+        return PersonalityProfile::query()->withoutGlobalScopes();
+    }
+
+    /**
+     * @param  array<string, mixed>  $profilePayload
+     * @return array<string, mixed>
+     */
+    private function profileAttributes(
+        array $profilePayload,
+        string $status,
+        ?PersonalityProfile $existing = null,
+    ): array {
+        $publishedAt = $this->resolvePublishedAt($profilePayload, $status, $existing);
+
+        return [
+            'org_id' => 0,
+            'scale_code' => PersonalityProfile::SCALE_CODE_MBTI,
+            'type_code' => (string) $profilePayload['type_code'],
+            'slug' => (string) $profilePayload['slug'],
+            'locale' => (string) $profilePayload['locale'],
+            'title' => (string) $profilePayload['title'],
+            'subtitle' => $profilePayload['subtitle'],
+            'excerpt' => $profilePayload['excerpt'],
+            'hero_kicker' => $profilePayload['hero_kicker'],
+            'hero_quote' => $profilePayload['hero_quote'],
+            'hero_image_url' => $profilePayload['hero_image_url'],
+            'status' => $status,
+            'is_public' => (bool) $profilePayload['is_public'],
+            'is_indexable' => (bool) $profilePayload['is_indexable'],
+            'published_at' => $publishedAt,
+            'scheduled_at' => $status === 'draft'
+                ? null
+                : $this->normalizeNullableDate($profilePayload['scheduled_at'] ?? null),
+            'schema_version' => (string) ($profilePayload['schema_version'] ?? 'v1'),
+        ];
+    }
+
+    /**
+     * @param  array<string, mixed>  $profilePayload
+     */
+    private function syncSections(PersonalityProfile $profile, array $profilePayload, bool $fullSync): void
+    {
+        $desiredSections = [];
+
+        foreach ((array) $profilePayload['sections'] as $section) {
+            $desiredSections[(string) $section['section_key']] = [
+                'title' => $section['title'],
+                'render_variant' => (string) $section['render_variant'],
+                'body_md' => $section['body_md'],
+                'body_html' => $section['body_html'],
+                'payload_json' => $section['payload_json'],
+                'sort_order' => (int) $section['sort_order'],
+                'is_enabled' => (bool) $section['is_enabled'],
+            ];
+        }
+
+        foreach ($desiredSections as $sectionKey => $attributes) {
+            PersonalityProfileSection::query()->updateOrCreate(
+                [
+                    'profile_id' => (int) $profile->id,
+                    'section_key' => $sectionKey,
+                ],
+                $attributes,
+            );
+        }
+
+        if ($fullSync) {
+            $managedKeys = array_values(array_intersect(
+                array_keys($desiredSections),
+                PersonalityProfileSection::SECTION_KEYS,
+            ));
+
+            $deleteQuery = PersonalityProfileSection::query()
+                ->where('profile_id', (int) $profile->id)
+                ->whereIn('section_key', PersonalityProfileSection::SECTION_KEYS);
+
+            if ($managedKeys !== []) {
+                $deleteQuery->whereNotIn('section_key', $managedKeys);
+            }
+
+            $deleteQuery->delete();
+        }
+
+        $profile->unsetRelation('sections');
+    }
+
+    /**
+     * @param  array<string, mixed>  $profilePayload
+     */
+    private function syncSeoMeta(PersonalityProfile $profile, array $profilePayload): void
+    {
+        $seoMeta = (array) $profilePayload['seo_meta'];
+
+        PersonalityProfileSeoMeta::query()->updateOrCreate(
+            [
+                'profile_id' => (int) $profile->id,
+            ],
+            [
+                'seo_title' => $seoMeta['seo_title'],
+                'seo_description' => $seoMeta['seo_description'],
+                'canonical_url' => $seoMeta['canonical_url'],
+                'og_title' => $seoMeta['og_title'],
+                'og_description' => $seoMeta['og_description'],
+                'og_image_url' => $seoMeta['og_image_url'],
+                'twitter_title' => $seoMeta['twitter_title'],
+                'twitter_description' => $seoMeta['twitter_description'],
+                'twitter_image_url' => $seoMeta['twitter_image_url'],
+                'robots' => $seoMeta['robots'],
+                'jsonld_overrides_json' => $seoMeta['jsonld_overrides_json'],
+            ],
+        );
+
+        $profile->unsetRelation('seoMeta');
+    }
+
+    private function createRevision(PersonalityProfile $profile, string $note): void
+    {
+        PersonalityProfileRevision::query()->create([
+            'profile_id' => (int) $profile->id,
+            'revision_no' => ((int) PersonalityProfileRevision::query()
+                ->where('profile_id', (int) $profile->id)
+                ->max('revision_no')) + 1,
+            'snapshot_json' => $this->currentComparableState($profile->fresh(['sections', 'seoMeta'])),
+            'note' => $note,
+            'created_by_admin_user_id' => null,
+            'created_at' => now(),
+        ]);
+    }
+
+    /**
+     * @param  array<string, mixed>  $profilePayload
+     * @return array<string, mixed>
+     */
+    private function desiredComparableState(
+        array $profilePayload,
+        string $status,
+        ?PersonalityProfile $existing = null,
+    ): array {
+        $sections = collect((array) $profilePayload['sections'])
+            ->map(static fn (array $section): array => [
+                'section_key' => (string) $section['section_key'],
+                'title' => $section['title'],
+                'render_variant' => (string) $section['render_variant'],
+                'body_md' => $section['body_md'],
+                'body_html' => $section['body_html'],
+                'payload_json' => $section['payload_json'],
+                'sort_order' => (int) $section['sort_order'],
+                'is_enabled' => (bool) $section['is_enabled'],
+            ])
+            ->sortBy([
+                ['sort_order', 'asc'],
+                ['section_key', 'asc'],
+            ])
+            ->values()
+            ->all();
+
+        return [
+            'profile' => [
+                'org_id' => 0,
+                'scale_code' => PersonalityProfile::SCALE_CODE_MBTI,
+                'type_code' => (string) $profilePayload['type_code'],
+                'slug' => (string) $profilePayload['slug'],
+                'locale' => (string) $profilePayload['locale'],
+                'title' => (string) $profilePayload['title'],
+                'subtitle' => $profilePayload['subtitle'],
+                'excerpt' => $profilePayload['excerpt'],
+                'hero_kicker' => $profilePayload['hero_kicker'],
+                'hero_quote' => $profilePayload['hero_quote'],
+                'hero_image_url' => $profilePayload['hero_image_url'],
+                'status' => $status,
+                'is_public' => (bool) $profilePayload['is_public'],
+                'is_indexable' => (bool) $profilePayload['is_indexable'],
+                'published_at' => $this->normalizeDateForComparison(
+                    $this->resolvePublishedAt($profilePayload, $status, $existing)
+                ),
+                'scheduled_at' => $status === 'draft'
+                    ? null
+                    : $this->normalizeDateForComparison($this->normalizeNullableDate($profilePayload['scheduled_at'] ?? null)),
+                'schema_version' => (string) ($profilePayload['schema_version'] ?? 'v1'),
+            ],
+            'sections' => $sections,
+            'seo_meta' => (array) $profilePayload['seo_meta'],
+        ];
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function currentComparableState(PersonalityProfile $profile): array
+    {
+        $profile->loadMissing('sections', 'seoMeta');
+
+        return [
+            'profile' => [
+                'org_id' => (int) $profile->org_id,
+                'scale_code' => (string) $profile->scale_code,
+                'type_code' => (string) $profile->type_code,
+                'slug' => (string) $profile->slug,
+                'locale' => (string) $profile->locale,
+                'title' => (string) $profile->title,
+                'subtitle' => $profile->subtitle,
+                'excerpt' => $profile->excerpt,
+                'hero_kicker' => $profile->hero_kicker,
+                'hero_quote' => $profile->hero_quote,
+                'hero_image_url' => $profile->hero_image_url,
+                'status' => (string) $profile->status,
+                'is_public' => (bool) $profile->is_public,
+                'is_indexable' => (bool) $profile->is_indexable,
+                'published_at' => $this->normalizeDateForComparison($profile->published_at),
+                'scheduled_at' => $this->normalizeDateForComparison($profile->scheduled_at),
+                'schema_version' => (string) $profile->schema_version,
+            ],
+            'sections' => $profile->sections
+                ->map(static fn (PersonalityProfileSection $section): array => [
+                    'section_key' => (string) $section->section_key,
+                    'title' => $section->title,
+                    'render_variant' => (string) $section->render_variant,
+                    'body_md' => $section->body_md,
+                    'body_html' => $section->body_html,
+                    'payload_json' => $section->payload_json,
+                    'sort_order' => (int) $section->sort_order,
+                    'is_enabled' => (bool) $section->is_enabled,
+                ])
+                ->sortBy([
+                    ['sort_order', 'asc'],
+                    ['section_key', 'asc'],
+                ])
+                ->values()
+                ->all(),
+            'seo_meta' => $profile->seoMeta instanceof PersonalityProfileSeoMeta
+                ? [
+                    'seo_title' => $profile->seoMeta->seo_title,
+                    'seo_description' => $profile->seoMeta->seo_description,
+                    'canonical_url' => $profile->seoMeta->canonical_url,
+                    'og_title' => $profile->seoMeta->og_title,
+                    'og_description' => $profile->seoMeta->og_description,
+                    'og_image_url' => $profile->seoMeta->og_image_url,
+                    'twitter_title' => $profile->seoMeta->twitter_title,
+                    'twitter_description' => $profile->seoMeta->twitter_description,
+                    'twitter_image_url' => $profile->seoMeta->twitter_image_url,
+                    'robots' => $profile->seoMeta->robots,
+                    'jsonld_overrides_json' => $profile->seoMeta->jsonld_overrides_json,
+                ]
+                : [
+                    'seo_title' => null,
+                    'seo_description' => null,
+                    'canonical_url' => null,
+                    'og_title' => null,
+                    'og_description' => null,
+                    'og_image_url' => null,
+                    'twitter_title' => null,
+                    'twitter_description' => null,
+                    'twitter_image_url' => null,
+                    'robots' => null,
+                    'jsonld_overrides_json' => null,
+                ],
+        ];
+    }
+
+    /**
+     * @param  array<string, mixed>  $profilePayload
+     */
+    private function resolvePublishedAt(
+        array $profilePayload,
+        string $status,
+        ?PersonalityProfile $existing = null,
+    ): ?Carbon {
+        if ($status === 'draft') {
+            return null;
+        }
+
+        return $this->normalizeNullableDate($profilePayload['published_at'] ?? null)
+            ?? $existing?->published_at
+            ?? now();
+    }
+
+    private function normalizeNullableDate(mixed $value): ?Carbon
+    {
+        if ($value instanceof Carbon) {
+            return $value;
+        }
+
+        if ($value instanceof \DateTimeInterface) {
+            return Carbon::instance($value);
+        }
+
+        $normalized = trim((string) $value);
+
+        if ($normalized === '') {
+            return null;
+        }
+
+        return Carbon::parse($normalized);
+    }
+
+    private function normalizeDateForComparison(mixed $value): ?string
+    {
+        $normalized = $this->normalizeNullableDate($value);
+
+        return $normalized?->toIso8601String();
+    }
+}

--- a/backend/app/PersonalityCms/Baseline/PersonalityBaselineNormalizer.php
+++ b/backend/app/PersonalityCms/Baseline/PersonalityBaselineNormalizer.php
@@ -1,0 +1,371 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\PersonalityCms\Baseline;
+
+use App\Models\PersonalityProfile;
+use App\Models\PersonalityProfileSection;
+use Illuminate\Support\Arr;
+use Illuminate\Support\Str;
+use RuntimeException;
+
+final class PersonalityBaselineNormalizer
+{
+    /**
+     * @param  array<int, array{file: string, payload: array<string, mixed>}>  $documents
+     * @param  array<int, string>  $selectedTypes
+     * @return array<int, array<string, mixed>>
+     */
+    public function normalizeDocuments(array $documents, array $selectedTypes = []): array
+    {
+        $normalizedTypes = $this->normalizeSelectedTypes($selectedTypes);
+        $profiles = [];
+        $seenByLocaleType = [];
+        $seenByLocaleSlug = [];
+
+        foreach ($documents as $document) {
+            $file = (string) ($document['file'] ?? 'unknown');
+            $payload = is_array($document['payload'] ?? null) ? $document['payload'] : [];
+            $meta = is_array($payload['meta'] ?? null) ? $payload['meta'] : [];
+            $locale = $this->normalizeLocale($meta['locale'] ?? null, $file);
+            $scaleCode = trim((string) ($meta['scale_code'] ?? PersonalityProfile::SCALE_CODE_MBTI));
+            $schemaVersion = trim((string) ($meta['schema_version'] ?? 'v1'));
+
+            if ($scaleCode !== PersonalityProfile::SCALE_CODE_MBTI) {
+                throw new RuntimeException(sprintf(
+                    'Baseline file %s has unsupported scale_code=%s.',
+                    $file,
+                    $scaleCode,
+                ));
+            }
+
+            $rows = $payload['profiles'] ?? null;
+
+            if (! is_array($rows)) {
+                throw new RuntimeException(sprintf(
+                    'Baseline file %s must contain a profiles array.',
+                    $file,
+                ));
+            }
+
+            foreach ($rows as $index => $row) {
+                if (! is_array($row)) {
+                    throw new RuntimeException(sprintf(
+                        'Baseline file %s contains a non-object profile row at index %d.',
+                        $file,
+                        $index,
+                    ));
+                }
+
+                $profile = $this->normalizeProfile($row, $locale, $schemaVersion, $file, $index);
+                $typeCode = (string) $profile['type_code'];
+                $slug = (string) $profile['slug'];
+
+                if ($normalizedTypes !== [] && ! in_array($typeCode, $normalizedTypes, true)) {
+                    continue;
+                }
+
+                $typeKey = $locale.'|'.$typeCode;
+                $slugKey = $locale.'|'.$slug;
+
+                if (isset($seenByLocaleType[$typeKey])) {
+                    throw new RuntimeException(sprintf(
+                        'Duplicate type_code %s for locale %s in baseline file %s.',
+                        $typeCode,
+                        $locale,
+                        $file,
+                    ));
+                }
+
+                if (isset($seenByLocaleSlug[$slugKey])) {
+                    throw new RuntimeException(sprintf(
+                        'Duplicate slug %s for locale %s in baseline file %s.',
+                        $slug,
+                        $locale,
+                        $file,
+                    ));
+                }
+
+                $seenByLocaleType[$typeKey] = true;
+                $seenByLocaleSlug[$slugKey] = true;
+                $profiles[] = $profile;
+            }
+        }
+
+        usort(
+            $profiles,
+            static fn (array $left, array $right): int => [$left['locale'], $left['type_code']]
+                <=> [$right['locale'], $right['type_code']],
+        );
+
+        return $profiles;
+    }
+
+    /**
+     * @param  array<string, mixed>  $row
+     * @return array<string, mixed>
+     */
+    private function normalizeProfile(
+        array $row,
+        string $locale,
+        string $schemaVersion,
+        string $file,
+        int $index,
+    ): array {
+        $typeCode = Str::upper(trim((string) ($row['type_code'] ?? '')));
+        $slug = Str::lower(trim((string) ($row['slug'] ?? '')));
+        $title = trim((string) ($row['title'] ?? ''));
+
+        if ($typeCode === '' || ! in_array($typeCode, PersonalityProfile::TYPE_CODES, true)) {
+            throw new RuntimeException(sprintf(
+                'Baseline file %s has invalid type_code at profiles[%d].',
+                $file,
+                $index,
+            ));
+        }
+
+        if ($slug === '' || $slug !== Str::lower($typeCode)) {
+            throw new RuntimeException(sprintf(
+                'Baseline file %s has invalid slug for %s at profiles[%d].',
+                $file,
+                $typeCode,
+                $index,
+            ));
+        }
+
+        if ($title === '') {
+            throw new RuntimeException(sprintf(
+                'Baseline file %s is missing title for %s at profiles[%d].',
+                $file,
+                $typeCode,
+                $index,
+            ));
+        }
+
+        $sections = $this->normalizeSections(
+            is_array($row['sections'] ?? null) ? $row['sections'] : [],
+            $file,
+            $index,
+        );
+
+        return [
+            'org_id' => 0,
+            'scale_code' => PersonalityProfile::SCALE_CODE_MBTI,
+            'type_code' => $typeCode,
+            'slug' => $slug,
+            'locale' => $locale,
+            'title' => $title,
+            'subtitle' => $this->normalizeNullableText($row['subtitle'] ?? null),
+            'excerpt' => $this->normalizeNullableText($row['excerpt'] ?? null),
+            'hero_kicker' => $this->normalizeNullableText($row['hero_kicker'] ?? null),
+            'hero_quote' => $this->normalizeNullableText($row['hero_quote'] ?? null),
+            'hero_image_url' => $this->normalizeNullableText($row['hero_image_url'] ?? null),
+            'status' => $this->normalizeStatus($row['status'] ?? 'published', $file, $index),
+            'is_public' => $this->normalizeBool($row['is_public'] ?? true),
+            'is_indexable' => $this->normalizeBool($row['is_indexable'] ?? true),
+            'published_at' => $this->normalizeNullableText($row['published_at'] ?? null),
+            'scheduled_at' => $this->normalizeNullableText($row['scheduled_at'] ?? null),
+            'schema_version' => $schemaVersion !== '' ? $schemaVersion : 'v1',
+            'sections' => $sections,
+            'seo_meta' => $this->normalizeSeoMeta(
+                is_array($row['seo_meta'] ?? null) ? $row['seo_meta'] : [],
+            ),
+        ];
+    }
+
+    /**
+     * @param  array<int, mixed>  $rows
+     * @return array<int, array<string, mixed>>
+     */
+    private function normalizeSections(array $rows, string $file, int $profileIndex): array
+    {
+        $known = PersonalityProfileSection::SECTION_KEYS;
+        $sections = [];
+        $seen = [];
+
+        foreach ($rows as $sectionIndex => $row) {
+            if (! is_array($row)) {
+                throw new RuntimeException(sprintf(
+                    'Baseline file %s contains a non-object section at profiles[%d].sections[%d].',
+                    $file,
+                    $profileIndex,
+                    $sectionIndex,
+                ));
+            }
+
+            $sectionKey = trim((string) ($row['section_key'] ?? ''));
+
+            if ($sectionKey === '' || ! in_array($sectionKey, $known, true)) {
+                throw new RuntimeException(sprintf(
+                    'Baseline file %s contains unsupported section_key=%s at profiles[%d].sections[%d].',
+                    $file,
+                    $sectionKey,
+                    $profileIndex,
+                    $sectionIndex,
+                ));
+            }
+
+            if (isset($seen[$sectionKey])) {
+                throw new RuntimeException(sprintf(
+                    'Baseline file %s contains duplicate section_key=%s at profiles[%d].',
+                    $file,
+                    $sectionKey,
+                    $profileIndex,
+                ));
+            }
+
+            $renderVariant = trim((string) ($row['render_variant'] ?? ''));
+            if ($renderVariant === '' || ! in_array($renderVariant, PersonalityProfileSection::RENDER_VARIANTS, true)) {
+                throw new RuntimeException(sprintf(
+                    'Baseline file %s contains invalid render_variant for section %s at profiles[%d].sections[%d].',
+                    $file,
+                    $sectionKey,
+                    $profileIndex,
+                    $sectionIndex,
+                ));
+            }
+
+            $sections[] = [
+                'section_key' => $sectionKey,
+                'title' => $this->normalizeNullableText($row['title'] ?? null),
+                'render_variant' => $renderVariant,
+                'body_md' => $this->normalizeNullableText($row['body_md'] ?? null),
+                'body_html' => $this->normalizeNullableText($row['body_html'] ?? null),
+                'payload_json' => Arr::exists($row, 'payload_json') ? $this->normalizeNullableArray($row['payload_json']) : null,
+                'sort_order' => (int) ($row['sort_order'] ?? 0),
+                'is_enabled' => $this->normalizeBool($row['is_enabled'] ?? true),
+            ];
+
+            $seen[$sectionKey] = true;
+        }
+
+        usort(
+            $sections,
+            static fn (array $left, array $right): int => [$left['sort_order'], $left['section_key']]
+                <=> [$right['sort_order'], $right['section_key']],
+        );
+
+        return $sections;
+    }
+
+    /**
+     * @param  array<string, mixed>  $seoMeta
+     * @return array<string, mixed>
+     */
+    private function normalizeSeoMeta(array $seoMeta): array
+    {
+        return [
+            'seo_title' => $this->normalizeNullableText($seoMeta['seo_title'] ?? null),
+            'seo_description' => $this->normalizeNullableText($seoMeta['seo_description'] ?? null),
+            'canonical_url' => $this->normalizeNullableText($seoMeta['canonical_url'] ?? null),
+            'og_title' => $this->normalizeNullableText($seoMeta['og_title'] ?? null),
+            'og_description' => $this->normalizeNullableText($seoMeta['og_description'] ?? null),
+            'og_image_url' => $this->normalizeNullableText($seoMeta['og_image_url'] ?? null),
+            'twitter_title' => $this->normalizeNullableText($seoMeta['twitter_title'] ?? null),
+            'twitter_description' => $this->normalizeNullableText($seoMeta['twitter_description'] ?? null),
+            'twitter_image_url' => $this->normalizeNullableText($seoMeta['twitter_image_url'] ?? null),
+            'robots' => $this->normalizeNullableText($seoMeta['robots'] ?? null),
+            'jsonld_overrides_json' => Arr::exists($seoMeta, 'jsonld_overrides_json')
+                ? $this->normalizeNullableArray($seoMeta['jsonld_overrides_json'])
+                : null,
+        ];
+    }
+
+    private function normalizeLocale(mixed $locale, string $file): string
+    {
+        $normalized = trim((string) $locale);
+        $normalized = $normalized === 'zh' ? 'zh-CN' : $normalized;
+
+        if (! in_array($normalized, PersonalityProfile::SUPPORTED_LOCALES, true)) {
+            throw new RuntimeException(sprintf(
+                'Baseline file %s has unsupported locale=%s.',
+                $file,
+                (string) $locale,
+            ));
+        }
+
+        return $normalized;
+    }
+
+    /**
+     * @param  array<int, string>  $selectedTypes
+     * @return array<int, string>
+     */
+    private function normalizeSelectedTypes(array $selectedTypes): array
+    {
+        $normalized = [];
+
+        foreach ($selectedTypes as $type) {
+            $candidate = Str::upper(trim((string) $type));
+
+            if ($candidate === '') {
+                continue;
+            }
+
+            if (! in_array($candidate, PersonalityProfile::TYPE_CODES, true)) {
+                throw new RuntimeException(sprintf(
+                    'Unsupported type selection: %s',
+                    $candidate,
+                ));
+            }
+
+            $normalized[] = $candidate;
+        }
+
+        return array_values(array_unique($normalized));
+    }
+
+    private function normalizeStatus(mixed $status, string $file, int $index): string
+    {
+        $normalized = trim((string) $status);
+
+        if (! in_array($normalized, ['draft', 'published'], true)) {
+            throw new RuntimeException(sprintf(
+                'Baseline file %s has invalid status at profiles[%d].',
+                $file,
+                $index,
+            ));
+        }
+
+        return $normalized;
+    }
+
+    private function normalizeBool(mixed $value): bool
+    {
+        if (is_bool($value)) {
+            return $value;
+        }
+
+        if (is_numeric($value)) {
+            return (bool) $value;
+        }
+
+        $normalized = Str::lower(trim((string) $value));
+
+        return in_array($normalized, ['1', 'true', 'yes', 'on'], true);
+    }
+
+    private function normalizeNullableText(mixed $value): ?string
+    {
+        $normalized = trim((string) $value);
+
+        return $normalized === '' ? null : $normalized;
+    }
+
+    /**
+     * @return array<string, mixed>|array<int, mixed>|null
+     */
+    private function normalizeNullableArray(mixed $value): ?array
+    {
+        if ($value === null) {
+            return null;
+        }
+
+        if (! is_array($value)) {
+            throw new RuntimeException('Baseline JSON field must be an object or array when provided.');
+        }
+
+        return $value === [] ? null : $value;
+    }
+}

--- a/backend/app/PersonalityCms/Baseline/PersonalityBaselineReader.php
+++ b/backend/app/PersonalityCms/Baseline/PersonalityBaselineReader.php
@@ -1,0 +1,127 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\PersonalityCms\Baseline;
+
+use RuntimeException;
+
+final class PersonalityBaselineReader
+{
+    public function resolveSourceDir(?string $sourceDir = null): string
+    {
+        $candidate = trim((string) $sourceDir);
+
+        if ($candidate === '') {
+            $candidate = base_path('../content_baselines/personality');
+        } elseif (! str_starts_with($candidate, DIRECTORY_SEPARATOR)) {
+            $candidate = base_path($candidate);
+        }
+
+        $resolved = realpath($candidate);
+
+        if ($resolved === false || ! is_dir($resolved)) {
+            throw new RuntimeException(sprintf(
+                'Personality baseline source directory not found: %s',
+                $candidate,
+            ));
+        }
+
+        return $resolved;
+    }
+
+    /**
+     * @param  array<int, string>  $selectedLocales
+     * @return array<int, array{file: string, payload: array<string, mixed>}>
+     */
+    public function read(string $sourceDir, array $selectedLocales = []): array
+    {
+        $locales = $this->normalizeSelectedLocales($selectedLocales);
+        $files = $locales === []
+            ? glob(rtrim($sourceDir, DIRECTORY_SEPARATOR).DIRECTORY_SEPARATOR.'mbti.*.json') ?: []
+            : array_map(
+                static fn (string $locale): string => rtrim($sourceDir, DIRECTORY_SEPARATOR)
+                    .DIRECTORY_SEPARATOR
+                    .sprintf('mbti.%s.json', $locale),
+                $locales,
+            );
+
+        if ($files === []) {
+            throw new RuntimeException(sprintf(
+                'No personality baseline files found in %s.',
+                $sourceDir,
+            ));
+        }
+
+        sort($files);
+
+        $documents = [];
+
+        foreach ($files as $file) {
+            if (! is_file($file)) {
+                throw new RuntimeException(sprintf(
+                    'Personality baseline file missing: %s',
+                    $file,
+                ));
+            }
+
+            $raw = file_get_contents($file);
+
+            if (! is_string($raw) || trim($raw) === '') {
+                throw new RuntimeException(sprintf(
+                    'Personality baseline file is empty: %s',
+                    $file,
+                ));
+            }
+
+            $decoded = json_decode($raw, true);
+
+            if (! is_array($decoded)) {
+                throw new RuntimeException(sprintf(
+                    'Personality baseline file is not valid JSON: %s',
+                    $file,
+                ));
+            }
+
+            $documents[] = [
+                'file' => $file,
+                'payload' => $decoded,
+            ];
+        }
+
+        return $documents;
+    }
+
+    /**
+     * @param  array<int, string>  $selectedLocales
+     * @return array<int, string>
+     */
+    private function normalizeSelectedLocales(array $selectedLocales): array
+    {
+        $normalized = [];
+
+        foreach ($selectedLocales as $locale) {
+            $candidate = trim((string) $locale);
+
+            if ($candidate === '') {
+                continue;
+            }
+
+            $candidate = $candidate === 'zh' ? 'zh-CN' : $candidate;
+            $normalized[] = $candidate;
+        }
+
+        $normalized = array_values(array_unique($normalized));
+
+        foreach ($normalized as $locale) {
+            if (! in_array($locale, ['en', 'zh-CN'], true)) {
+                throw new RuntimeException(sprintf(
+                    'Unsupported locale selection: %s',
+                    $locale,
+                ));
+            }
+        }
+
+        return $normalized;
+    }
+}

--- a/backend/tests/Feature/PersonalityCms/PersonalityBaselineImportTest.php
+++ b/backend/tests/Feature/PersonalityCms/PersonalityBaselineImportTest.php
@@ -1,0 +1,272 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\PersonalityCms;
+
+use App\Models\PersonalityProfile;
+use App\Models\PersonalityProfileRevision;
+use App\Models\PersonalityProfileSection;
+use App\Models\PersonalityProfileSeoMeta;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\File;
+use Tests\TestCase;
+
+final class PersonalityBaselineImportTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_dry_run_does_not_write_database(): void
+    {
+        $this->artisan('personality:import-local-baseline', [
+            '--dry-run' => true,
+            '--source-dir' => 'tests/Fixtures/personality_baseline',
+        ])
+            ->expectsOutputToContain('profiles_found=4')
+            ->expectsOutputToContain('will_create=4')
+            ->expectsOutputToContain('revisions_to_create=4')
+            ->assertExitCode(0);
+
+        $this->assertSame(0, PersonalityProfile::query()->count());
+        $this->assertSame(0, PersonalityProfileSection::query()->count());
+        $this->assertSame(0, PersonalityProfileSeoMeta::query()->count());
+        $this->assertSame(0, PersonalityProfileRevision::query()->count());
+    }
+
+    public function test_default_mode_creates_missing_profiles_sections_seo_meta_and_revision(): void
+    {
+        $this->artisan('personality:import-local-baseline', [
+            '--locale' => ['en'],
+            '--status' => 'draft',
+            '--source-dir' => 'tests/Fixtures/personality_baseline',
+        ])
+            ->expectsOutputToContain('profiles_found=2')
+            ->expectsOutputToContain('will_create=2')
+            ->assertExitCode(0);
+
+        $this->assertSame(2, PersonalityProfile::query()->count());
+        $this->assertSame(5, PersonalityProfileSection::query()->count());
+        $this->assertSame(2, PersonalityProfileSeoMeta::query()->count());
+        $this->assertSame(2, PersonalityProfileRevision::query()->count());
+
+        $profile = PersonalityProfile::query()
+            ->withoutGlobalScopes()
+            ->where('type_code', 'INTJ')
+            ->where('locale', 'en')
+            ->firstOrFail();
+
+        $this->assertSame(0, (int) $profile->org_id);
+        $this->assertSame('MBTI', $profile->scale_code);
+        $this->assertSame('draft', $profile->status);
+        $this->assertNull($profile->published_at);
+
+        $revision = PersonalityProfileRevision::query()
+            ->where('profile_id', (int) $profile->id)
+            ->orderBy('revision_no')
+            ->firstOrFail();
+
+        $this->assertSame(1, (int) $revision->revision_no);
+        $this->assertSame('baseline import', $revision->note);
+    }
+
+    public function test_default_mode_skips_existing_profiles_without_overwriting(): void
+    {
+        $profile = PersonalityProfile::query()->create([
+            'org_id' => 0,
+            'scale_code' => 'MBTI',
+            'type_code' => 'INTJ',
+            'slug' => 'intj',
+            'locale' => 'en',
+            'title' => 'Do Not Overwrite',
+            'status' => 'draft',
+            'is_public' => true,
+            'is_indexable' => true,
+            'schema_version' => 'v1',
+        ]);
+
+        PersonalityProfileRevision::query()->create([
+            'profile_id' => (int) $profile->id,
+            'revision_no' => 1,
+            'snapshot_json' => ['title' => 'Do Not Overwrite'],
+            'note' => 'seed',
+            'created_at' => now(),
+        ]);
+
+        $this->artisan('personality:import-local-baseline', [
+            '--locale' => ['en'],
+            '--type' => ['INTJ'],
+            '--source-dir' => 'tests/Fixtures/personality_baseline',
+        ])
+            ->expectsOutputToContain('profiles_found=1')
+            ->expectsOutputToContain('will_skip=1')
+            ->assertExitCode(0);
+
+        $this->assertSame('Do Not Overwrite', (string) $profile->fresh()->title);
+        $this->assertSame(1, PersonalityProfileRevision::query()->where('profile_id', (int) $profile->id)->count());
+    }
+
+    public function test_upsert_updates_existing_profiles_and_only_creates_revision_when_changed(): void
+    {
+        $profile = PersonalityProfile::query()->create([
+            'org_id' => 0,
+            'scale_code' => 'MBTI',
+            'type_code' => 'INTJ',
+            'slug' => 'intj',
+            'locale' => 'en',
+            'title' => 'Legacy INTJ',
+            'status' => 'published',
+            'is_public' => true,
+            'is_indexable' => false,
+            'published_at' => now()->subDay(),
+            'schema_version' => 'v1',
+        ]);
+
+        PersonalityProfileSection::query()->create([
+            'profile_id' => (int) $profile->id,
+            'section_key' => 'core_snapshot',
+            'title' => 'Legacy snapshot',
+            'render_variant' => 'rich_text',
+            'body_md' => 'Legacy body',
+            'sort_order' => 10,
+            'is_enabled' => true,
+        ]);
+        PersonalityProfileSection::query()->create([
+            'profile_id' => (int) $profile->id,
+            'section_key' => 'growth_edges',
+            'title' => 'Growth edges',
+            'render_variant' => 'bullets',
+            'payload_json' => ['items' => [['title' => 'Old edge']]],
+            'sort_order' => 30,
+            'is_enabled' => true,
+        ]);
+        PersonalityProfileSeoMeta::query()->create([
+            'profile_id' => (int) $profile->id,
+            'seo_title' => 'Legacy title',
+            'seo_description' => 'Legacy description',
+        ]);
+        PersonalityProfileRevision::query()->create([
+            'profile_id' => (int) $profile->id,
+            'revision_no' => 1,
+            'snapshot_json' => ['title' => 'Legacy INTJ'],
+            'note' => 'seed',
+            'created_at' => now()->subDay(),
+        ]);
+
+        $this->artisan('personality:import-local-baseline', [
+            '--locale' => ['en'],
+            '--type' => ['INTJ'],
+            '--upsert' => true,
+            '--status' => 'published',
+            '--source-dir' => 'tests/Fixtures/personality_baseline',
+        ])
+            ->expectsOutputToContain('profiles_found=1')
+            ->expectsOutputToContain('will_update=1')
+            ->expectsOutputToContain('revisions_to_create=1')
+            ->assertExitCode(0);
+
+        $profile->refresh();
+
+        $this->assertSame('INTJ - Architect', $profile->title);
+        $this->assertTrue((bool) $profile->is_indexable);
+        $this->assertNotNull($profile->published_at);
+        $this->assertSame(
+            ['career_fit', 'core_snapshot', 'strengths'],
+            PersonalityProfileSection::query()
+                ->where('profile_id', (int) $profile->id)
+                ->orderBy('section_key')
+                ->pluck('section_key')
+                ->all(),
+        );
+        $this->assertSame(
+            'INTJ Personality Guide',
+            PersonalityProfileSeoMeta::query()->where('profile_id', (int) $profile->id)->firstOrFail()->seo_title,
+        );
+        $this->assertSame(
+            2,
+            PersonalityProfileRevision::query()->where('profile_id', (int) $profile->id)->max('revision_no'),
+        );
+
+        $this->artisan('personality:import-local-baseline', [
+            '--locale' => ['en'],
+            '--type' => ['INTJ'],
+            '--upsert' => true,
+            '--status' => 'published',
+            '--source-dir' => 'tests/Fixtures/personality_baseline',
+        ])
+            ->expectsOutputToContain('will_skip=1')
+            ->assertExitCode(0);
+
+        $this->assertSame(
+            2,
+            PersonalityProfileRevision::query()->where('profile_id', (int) $profile->id)->count(),
+        );
+    }
+
+    public function test_locale_and_type_filters_limit_import_scope(): void
+    {
+        $this->artisan('personality:import-local-baseline', [
+            '--locale' => ['zh-CN'],
+            '--type' => ['INTJ'],
+            '--status' => 'draft',
+            '--source-dir' => 'tests/Fixtures/personality_baseline',
+        ])
+            ->expectsOutputToContain('profiles_found=1')
+            ->expectsOutputToContain('will_create=1')
+            ->assertExitCode(0);
+
+        $this->assertSame(1, PersonalityProfile::query()->count());
+
+        $profile = PersonalityProfile::query()->firstOrFail();
+        $this->assertSame('INTJ', $profile->type_code);
+        $this->assertSame('zh-CN', $profile->locale);
+    }
+
+    public function test_invalid_baseline_fails_with_non_zero_exit_code(): void
+    {
+        $sourceDir = base_path('tests/Fixtures/personality_baseline_invalid');
+
+        File::deleteDirectory($sourceDir);
+        File::ensureDirectoryExists($sourceDir);
+        File::put($sourceDir.'/mbti.en.json', json_encode([
+            'meta' => [
+                'schema_version' => 'v1',
+                'scale_code' => 'MBTI',
+                'locale' => 'en',
+                'source' => 'test fixture',
+                'generated_at' => '2026-03-08T00:00:00Z',
+            ],
+            'profiles' => [
+                [
+                    'type_code' => 'BADTYPE',
+                    'slug' => 'badtype',
+                    'title' => 'Bad',
+                    'status' => 'published',
+                    'is_public' => true,
+                    'is_indexable' => true,
+                    'sections' => [
+                        [
+                            'section_key' => 'core_snapshot',
+                            'title' => 'Core snapshot',
+                            'render_variant' => 'rich_text',
+                            'body_md' => 'bad',
+                            'payload_json' => null,
+                            'sort_order' => 10,
+                            'is_enabled' => true,
+                        ],
+                    ],
+                    'seo_meta' => [],
+                ],
+            ],
+        ], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES | JSON_PRETTY_PRINT));
+
+        try {
+            $this->artisan('personality:import-local-baseline', [
+                '--source-dir' => 'tests/Fixtures/personality_baseline_invalid',
+            ])
+                ->expectsOutputToContain('invalid type_code')
+                ->assertExitCode(1);
+        } finally {
+            File::deleteDirectory($sourceDir);
+        }
+    }
+}

--- a/backend/tests/Fixtures/personality_baseline/mbti.en.json
+++ b/backend/tests/Fixtures/personality_baseline/mbti.en.json
@@ -1,0 +1,139 @@
+{
+  "meta": {
+    "schema_version": "v1",
+    "scale_code": "MBTI",
+    "locale": "en",
+    "source": "test fixture",
+    "generated_at": "2026-03-08T00:00:00Z"
+  },
+  "profiles": [
+    {
+      "type_code": "INTJ",
+      "slug": "intj",
+      "title": "INTJ - Architect",
+      "subtitle": null,
+      "excerpt": "Strategic and future-oriented.",
+      "hero_kicker": "Architect",
+      "hero_quote": null,
+      "hero_image_url": null,
+      "status": "published",
+      "is_public": true,
+      "is_indexable": true,
+      "published_at": null,
+      "scheduled_at": null,
+      "sections": [
+        {
+          "section_key": "core_snapshot",
+          "title": "Core snapshot",
+          "render_variant": "rich_text",
+          "body_md": "INTJs often focus on structure, strategy, and long-range planning.",
+          "body_html": null,
+          "payload_json": null,
+          "sort_order": 10,
+          "is_enabled": true
+        },
+        {
+          "section_key": "strengths",
+          "title": "Strengths",
+          "render_variant": "bullets",
+          "body_md": null,
+          "body_html": null,
+          "payload_json": {
+            "items": [
+              { "title": "System thinking", "body": null },
+              { "title": "Strategic planning", "body": null }
+            ]
+          },
+          "sort_order": 20,
+          "is_enabled": true
+        },
+        {
+          "section_key": "career_fit",
+          "title": "Career fit",
+          "render_variant": "cards",
+          "body_md": "INTJs usually perform best when the environment is structured and autonomous.",
+          "body_html": null,
+          "payload_json": {
+            "recommended_jobs": [
+              { "slug": "product-manager", "title": "Product Manager" }
+            ],
+            "avoid_jobs": [
+              { "slug": "teacher", "title": "Teacher" }
+            ],
+            "work_env": "Clear metrics and independent execution"
+          },
+          "sort_order": 80,
+          "is_enabled": true
+        }
+      ],
+      "seo_meta": {
+        "seo_title": "INTJ Personality Guide",
+        "seo_description": "Discover strengths, risks, and career fit for INTJ.",
+        "canonical_url": null,
+        "og_title": null,
+        "og_description": null,
+        "og_image_url": null,
+        "twitter_title": null,
+        "twitter_description": null,
+        "twitter_image_url": null,
+        "robots": null,
+        "jsonld_overrides_json": null
+      }
+    },
+    {
+      "type_code": "ENFP",
+      "slug": "enfp",
+      "title": "ENFP - Campaigner",
+      "subtitle": null,
+      "excerpt": "Curious, energetic, and possibility-driven.",
+      "hero_kicker": "Campaigner",
+      "hero_quote": null,
+      "hero_image_url": null,
+      "status": "published",
+      "is_public": true,
+      "is_indexable": true,
+      "published_at": null,
+      "scheduled_at": null,
+      "sections": [
+        {
+          "section_key": "core_snapshot",
+          "title": "Core snapshot",
+          "render_variant": "rich_text",
+          "body_md": "ENFPs often thrive when they can connect ideas, people, and momentum.",
+          "body_html": null,
+          "payload_json": null,
+          "sort_order": 10,
+          "is_enabled": true
+        },
+        {
+          "section_key": "strengths",
+          "title": "Strengths",
+          "render_variant": "bullets",
+          "body_md": null,
+          "body_html": null,
+          "payload_json": {
+            "items": [
+              { "title": "Creative range", "body": null },
+              { "title": "High social energy", "body": null }
+            ]
+          },
+          "sort_order": 20,
+          "is_enabled": true
+        }
+      ],
+      "seo_meta": {
+        "seo_title": "ENFP Personality Guide",
+        "seo_description": "Discover strengths, risks, and career fit for ENFP.",
+        "canonical_url": null,
+        "og_title": null,
+        "og_description": null,
+        "og_image_url": null,
+        "twitter_title": null,
+        "twitter_description": null,
+        "twitter_image_url": null,
+        "robots": null,
+        "jsonld_overrides_json": null
+      }
+    }
+  ]
+}

--- a/backend/tests/Fixtures/personality_baseline/mbti.zh-CN.json
+++ b/backend/tests/Fixtures/personality_baseline/mbti.zh-CN.json
@@ -1,0 +1,121 @@
+{
+  "meta": {
+    "schema_version": "v1",
+    "scale_code": "MBTI",
+    "locale": "zh-CN",
+    "source": "test fixture",
+    "generated_at": "2026-03-08T00:00:00Z"
+  },
+  "profiles": [
+    {
+      "type_code": "INTJ",
+      "slug": "intj",
+      "title": "INTJ - 建筑师",
+      "subtitle": null,
+      "excerpt": "偏好战略与长期规划。",
+      "hero_kicker": "建筑师",
+      "hero_quote": null,
+      "hero_image_url": null,
+      "status": "published",
+      "is_public": true,
+      "is_indexable": true,
+      "published_at": null,
+      "scheduled_at": null,
+      "sections": [
+        {
+          "section_key": "core_snapshot",
+          "title": "核心概览",
+          "render_variant": "rich_text",
+          "body_md": "INTJ 通常重视结构、战略和长期方向。",
+          "body_html": null,
+          "payload_json": null,
+          "sort_order": 10,
+          "is_enabled": true
+        },
+        {
+          "section_key": "strengths",
+          "title": "优势",
+          "render_variant": "bullets",
+          "body_md": null,
+          "body_html": null,
+          "payload_json": {
+            "items": [
+              { "title": "系统化思考", "body": null },
+              { "title": "长期规划", "body": null }
+            ]
+          },
+          "sort_order": 20,
+          "is_enabled": true
+        }
+      ],
+      "seo_meta": {
+        "seo_title": "INTJ 人格指南",
+        "seo_description": "了解 INTJ 的优势、风险与职业匹配。",
+        "canonical_url": null,
+        "og_title": null,
+        "og_description": null,
+        "og_image_url": null,
+        "twitter_title": null,
+        "twitter_description": null,
+        "twitter_image_url": null,
+        "robots": null,
+        "jsonld_overrides_json": null
+      }
+    },
+    {
+      "type_code": "ENFP",
+      "slug": "enfp",
+      "title": "ENFP - 竞选者",
+      "subtitle": null,
+      "excerpt": "充满好奇、热情且看重可能性。",
+      "hero_kicker": "竞选者",
+      "hero_quote": null,
+      "hero_image_url": null,
+      "status": "published",
+      "is_public": true,
+      "is_indexable": true,
+      "published_at": null,
+      "scheduled_at": null,
+      "sections": [
+        {
+          "section_key": "core_snapshot",
+          "title": "核心概览",
+          "render_variant": "rich_text",
+          "body_md": "ENFP 通常在连接想法、人与机会时表现更好。",
+          "body_html": null,
+          "payload_json": null,
+          "sort_order": 10,
+          "is_enabled": true
+        },
+        {
+          "section_key": "strengths",
+          "title": "优势",
+          "render_variant": "bullets",
+          "body_md": null,
+          "body_html": null,
+          "payload_json": {
+            "items": [
+              { "title": "创意延展性", "body": null },
+              { "title": "高社交能量", "body": null }
+            ]
+          },
+          "sort_order": 20,
+          "is_enabled": true
+        }
+      ],
+      "seo_meta": {
+        "seo_title": "ENFP 人格指南",
+        "seo_description": "了解 ENFP 的优势、风险与职业匹配。",
+        "canonical_url": null,
+        "og_title": null,
+        "og_description": null,
+        "og_image_url": null,
+        "twitter_title": null,
+        "twitter_description": null,
+        "twitter_image_url": null,
+        "robots": null,
+        "jsonld_overrides_json": null
+      }
+    }
+  ]
+}

--- a/content_baselines/personality/mbti.en.json
+++ b/content_baselines/personality/mbti.en.json
@@ -1,0 +1,2539 @@
+{
+  "meta": {
+    "schema_version": "v1",
+    "scale_code": "MBTI",
+    "locale": "en",
+    "source": "fap-web careerRecommendationProfiles + personality.ts deterministic transforms",
+    "generated_at": "2026-03-08T00:00:00Z"
+  },
+  "profiles": [
+    {
+      "type_code": "ENFJ",
+      "slug": "enfj",
+      "title": "ENFJ - Protagonist",
+      "subtitle": null,
+      "excerpt": "Role recommendations and work-environment guidance for ENFJ profiles.",
+      "hero_kicker": "Protagonist",
+      "hero_quote": null,
+      "hero_image_url": null,
+      "status": "published",
+      "is_public": true,
+      "is_indexable": true,
+      "published_at": null,
+      "scheduled_at": null,
+      "sections": [
+        {
+          "section_key": "core_snapshot",
+          "title": "Core snapshot",
+          "render_variant": "rich_text",
+          "body_md": "Role recommendations and work-environment guidance for ENFJ profiles. This profile tends to do best when goals are explicit, feedback is available, and growth loops stay visible.",
+          "body_html": null,
+          "payload_json": null,
+          "sort_order": 10,
+          "is_enabled": true
+        },
+        {
+          "section_key": "strengths",
+          "title": "Strengths",
+          "render_variant": "bullets",
+          "body_md": null,
+          "body_html": null,
+          "payload_json": {
+            "items": [
+              {
+                "title": "Strategic pattern recognition",
+                "body": null
+              },
+              {
+                "title": "Stable execution under constraints",
+                "body": null
+              },
+              {
+                "title": "Strong ownership on meaningful goals",
+                "body": null
+              }
+            ]
+          },
+          "sort_order": 20,
+          "is_enabled": true
+        },
+        {
+          "section_key": "growth_edges",
+          "title": "Growth edges",
+          "render_variant": "bullets",
+          "body_md": null,
+          "body_html": null,
+          "payload_json": {
+            "items": [
+              {
+                "title": "Over-specialization without cross-functional exposure",
+                "body": null
+              },
+              {
+                "title": "Delayed feedback loops causing slower iteration",
+                "body": null
+              }
+            ]
+          },
+          "sort_order": 30,
+          "is_enabled": true
+        },
+        {
+          "section_key": "work_style",
+          "title": "Work style",
+          "render_variant": "rich_text",
+          "body_md": "High-autonomy role scope, clear success metrics, and consistent feedback cadence.",
+          "body_html": null,
+          "payload_json": null,
+          "sort_order": 40,
+          "is_enabled": true
+        },
+        {
+          "section_key": "relationships",
+          "title": "Relationships",
+          "render_variant": "rich_text",
+          "body_md": "You usually build trust through direct dialogue, shared activity, and fast feedback. You tend to connect more deeply with people who enjoy discussing patterns, future possibilities, and meaning. In conflict you often default to harmony and emotional tone, so it helps to make your principles explicit. In close relationships and teamwork, you usually prefer clarity, commitment, and predictable pace.",
+          "body_html": null,
+          "payload_json": null,
+          "sort_order": 50,
+          "is_enabled": true
+        },
+        {
+          "section_key": "career_fit",
+          "title": "Career fit",
+          "render_variant": "cards",
+          "body_md": "You usually perform best in high-autonomy role scope, clear success metrics, and consistent feedback cadence. Prioritize options like Lawyer, Teacher, Machine Learning Engineer.",
+          "body_html": null,
+          "payload_json": {
+            "recommended_jobs": [
+              {
+                "slug": "lawyer",
+                "title": "Lawyer"
+              },
+              {
+                "slug": "teacher",
+                "title": "Teacher"
+              },
+              {
+                "slug": "machine-learning-engineer",
+                "title": "Machine Learning Engineer"
+              },
+              {
+                "slug": "backend-engineer",
+                "title": "Backend Engineer"
+              },
+              {
+                "slug": "cybersecurity-analyst",
+                "title": "Cybersecurity Analyst"
+              },
+              {
+                "slug": "operations-manager",
+                "title": "Operations Manager"
+              }
+            ],
+            "avoid_jobs": [
+              {
+                "slug": "cybersecurity-analyst",
+                "title": "Cybersecurity Analyst"
+              },
+              {
+                "slug": "operations-manager",
+                "title": "Operations Manager"
+              },
+              {
+                "slug": "sales-manager",
+                "title": "Sales Manager"
+              }
+            ],
+            "work_env": "High-autonomy role scope, clear success metrics, and consistent feedback cadence."
+          },
+          "sort_order": 80,
+          "is_enabled": true
+        }
+      ],
+      "seo_meta": {
+        "seo_title": "ENFJ Personality Guide",
+        "seo_description": "Discover strengths, weaknesses, relationship patterns, and career direction for the ENFJ personality type.",
+        "canonical_url": null,
+        "og_title": null,
+        "og_description": null,
+        "og_image_url": null,
+        "twitter_title": null,
+        "twitter_description": null,
+        "twitter_image_url": null,
+        "robots": null,
+        "jsonld_overrides_json": null
+      }
+    },
+    {
+      "type_code": "ENFP",
+      "slug": "enfp",
+      "title": "ENFP - Campaigner",
+      "subtitle": null,
+      "excerpt": "Role recommendations and work-environment guidance for ENFP profiles.",
+      "hero_kicker": "Campaigner",
+      "hero_quote": null,
+      "hero_image_url": null,
+      "status": "published",
+      "is_public": true,
+      "is_indexable": true,
+      "published_at": null,
+      "scheduled_at": null,
+      "sections": [
+        {
+          "section_key": "core_snapshot",
+          "title": "Core snapshot",
+          "render_variant": "rich_text",
+          "body_md": "Role recommendations and work-environment guidance for ENFP profiles. This profile tends to do best when goals are explicit, feedback is available, and growth loops stay visible.",
+          "body_html": null,
+          "payload_json": null,
+          "sort_order": 10,
+          "is_enabled": true
+        },
+        {
+          "section_key": "strengths",
+          "title": "Strengths",
+          "render_variant": "bullets",
+          "body_md": null,
+          "body_html": null,
+          "payload_json": {
+            "items": [
+              {
+                "title": "Strategic pattern recognition",
+                "body": null
+              },
+              {
+                "title": "Stable execution under constraints",
+                "body": null
+              },
+              {
+                "title": "Strong ownership on meaningful goals",
+                "body": null
+              }
+            ]
+          },
+          "sort_order": 20,
+          "is_enabled": true
+        },
+        {
+          "section_key": "growth_edges",
+          "title": "Growth edges",
+          "render_variant": "bullets",
+          "body_md": null,
+          "body_html": null,
+          "payload_json": {
+            "items": [
+              {
+                "title": "Over-specialization without cross-functional exposure",
+                "body": null
+              },
+              {
+                "title": "Delayed feedback loops causing slower iteration",
+                "body": null
+              }
+            ]
+          },
+          "sort_order": 30,
+          "is_enabled": true
+        },
+        {
+          "section_key": "work_style",
+          "title": "Work style",
+          "render_variant": "rich_text",
+          "body_md": "High-autonomy role scope, clear success metrics, and consistent feedback cadence.",
+          "body_html": null,
+          "payload_json": null,
+          "sort_order": 40,
+          "is_enabled": true
+        },
+        {
+          "section_key": "relationships",
+          "title": "Relationships",
+          "render_variant": "rich_text",
+          "body_md": "You usually build trust through direct dialogue, shared activity, and fast feedback. You tend to connect more deeply with people who enjoy discussing patterns, future possibilities, and meaning. In conflict you often default to harmony and emotional tone, so it helps to make your principles explicit. In close relationships and teamwork, you usually prefer flexibility, openness, and room to adapt.",
+          "body_html": null,
+          "payload_json": null,
+          "sort_order": 50,
+          "is_enabled": true
+        },
+        {
+          "section_key": "career_fit",
+          "title": "Career fit",
+          "render_variant": "cards",
+          "body_md": "You usually perform best in high-autonomy role scope, clear success metrics, and consistent feedback cadence. Prioritize options like Physician, Data Scientist, Frontend Engineer.",
+          "body_html": null,
+          "payload_json": {
+            "recommended_jobs": [
+              {
+                "slug": "physician",
+                "title": "Physician"
+              },
+              {
+                "slug": "data-scientist",
+                "title": "Data Scientist"
+              },
+              {
+                "slug": "frontend-engineer",
+                "title": "Frontend Engineer"
+              },
+              {
+                "slug": "fullstack-engineer",
+                "title": "Fullstack Engineer"
+              },
+              {
+                "slug": "cloud-architect",
+                "title": "Cloud Architect"
+              },
+              {
+                "slug": "hr-business-partner",
+                "title": "HR Business Partner"
+              }
+            ],
+            "avoid_jobs": [
+              {
+                "slug": "cloud-architect",
+                "title": "Cloud Architect"
+              },
+              {
+                "slug": "hr-business-partner",
+                "title": "HR Business Partner"
+              },
+              {
+                "slug": "management-consultant",
+                "title": "Management Consultant"
+              }
+            ],
+            "work_env": "High-autonomy role scope, clear success metrics, and consistent feedback cadence."
+          },
+          "sort_order": 80,
+          "is_enabled": true
+        }
+      ],
+      "seo_meta": {
+        "seo_title": "ENFP Personality Guide",
+        "seo_description": "Discover strengths, weaknesses, relationship patterns, and career direction for the ENFP personality type.",
+        "canonical_url": null,
+        "og_title": null,
+        "og_description": null,
+        "og_image_url": null,
+        "twitter_title": null,
+        "twitter_description": null,
+        "twitter_image_url": null,
+        "robots": null,
+        "jsonld_overrides_json": null
+      }
+    },
+    {
+      "type_code": "ENTJ",
+      "slug": "entj",
+      "title": "ENTJ - Commander",
+      "subtitle": null,
+      "excerpt": "Role recommendations and work-environment guidance for ENTJ profiles.",
+      "hero_kicker": "Commander",
+      "hero_quote": null,
+      "hero_image_url": null,
+      "status": "published",
+      "is_public": true,
+      "is_indexable": true,
+      "published_at": null,
+      "scheduled_at": null,
+      "sections": [
+        {
+          "section_key": "core_snapshot",
+          "title": "Core snapshot",
+          "render_variant": "rich_text",
+          "body_md": "Role recommendations and work-environment guidance for ENTJ profiles. This profile tends to do best when goals are explicit, feedback is available, and growth loops stay visible.",
+          "body_html": null,
+          "payload_json": null,
+          "sort_order": 10,
+          "is_enabled": true
+        },
+        {
+          "section_key": "strengths",
+          "title": "Strengths",
+          "render_variant": "bullets",
+          "body_md": null,
+          "body_html": null,
+          "payload_json": {
+            "items": [
+              {
+                "title": "Strategic pattern recognition",
+                "body": null
+              },
+              {
+                "title": "Stable execution under constraints",
+                "body": null
+              },
+              {
+                "title": "Strong ownership on meaningful goals",
+                "body": null
+              }
+            ]
+          },
+          "sort_order": 20,
+          "is_enabled": true
+        },
+        {
+          "section_key": "growth_edges",
+          "title": "Growth edges",
+          "render_variant": "bullets",
+          "body_md": null,
+          "body_html": null,
+          "payload_json": {
+            "items": [
+              {
+                "title": "Over-specialization without cross-functional exposure",
+                "body": null
+              },
+              {
+                "title": "Delayed feedback loops causing slower iteration",
+                "body": null
+              }
+            ]
+          },
+          "sort_order": 30,
+          "is_enabled": true
+        },
+        {
+          "section_key": "work_style",
+          "title": "Work style",
+          "render_variant": "rich_text",
+          "body_md": "High-autonomy role scope, clear success metrics, and consistent feedback cadence.",
+          "body_html": null,
+          "payload_json": null,
+          "sort_order": 40,
+          "is_enabled": true
+        },
+        {
+          "section_key": "relationships",
+          "title": "Relationships",
+          "render_variant": "rich_text",
+          "body_md": "You usually build trust through direct dialogue, shared activity, and fast feedback. You tend to connect more deeply with people who enjoy discussing patterns, future possibilities, and meaning. In conflict you often default to logic and boundaries, so it helps to add explicit emotional acknowledgment. In close relationships and teamwork, you usually prefer clarity, commitment, and predictable pace.",
+          "body_html": null,
+          "payload_json": null,
+          "sort_order": 50,
+          "is_enabled": true
+        },
+        {
+          "section_key": "career_fit",
+          "title": "Career fit",
+          "render_variant": "cards",
+          "body_md": "You usually perform best in high-autonomy role scope, clear success metrics, and consistent feedback cadence. Prioritize options like UI/UX Designer, Digital Marketing Manager, Lawyer.",
+          "body_html": null,
+          "payload_json": {
+            "recommended_jobs": [
+              {
+                "slug": "ui-ux-designer",
+                "title": "UI/UX Designer"
+              },
+              {
+                "slug": "digital-marketing-manager",
+                "title": "Digital Marketing Manager"
+              },
+              {
+                "slug": "lawyer",
+                "title": "Lawyer"
+              },
+              {
+                "slug": "teacher",
+                "title": "Teacher"
+              },
+              {
+                "slug": "machine-learning-engineer",
+                "title": "Machine Learning Engineer"
+              },
+              {
+                "slug": "backend-engineer",
+                "title": "Backend Engineer"
+              }
+            ],
+            "avoid_jobs": [
+              {
+                "slug": "machine-learning-engineer",
+                "title": "Machine Learning Engineer"
+              },
+              {
+                "slug": "backend-engineer",
+                "title": "Backend Engineer"
+              },
+              {
+                "slug": "cybersecurity-analyst",
+                "title": "Cybersecurity Analyst"
+              }
+            ],
+            "work_env": "High-autonomy role scope, clear success metrics, and consistent feedback cadence."
+          },
+          "sort_order": 80,
+          "is_enabled": true
+        }
+      ],
+      "seo_meta": {
+        "seo_title": "ENTJ Personality Guide",
+        "seo_description": "Discover strengths, weaknesses, relationship patterns, and career direction for the ENTJ personality type.",
+        "canonical_url": null,
+        "og_title": null,
+        "og_description": null,
+        "og_image_url": null,
+        "twitter_title": null,
+        "twitter_description": null,
+        "twitter_image_url": null,
+        "robots": null,
+        "jsonld_overrides_json": null
+      }
+    },
+    {
+      "type_code": "ENTP",
+      "slug": "entp",
+      "title": "ENTP - Debater",
+      "subtitle": null,
+      "excerpt": "Role recommendations and work-environment guidance for ENTP profiles.",
+      "hero_kicker": "Debater",
+      "hero_quote": null,
+      "hero_image_url": null,
+      "status": "published",
+      "is_public": true,
+      "is_indexable": true,
+      "published_at": null,
+      "scheduled_at": null,
+      "sections": [
+        {
+          "section_key": "core_snapshot",
+          "title": "Core snapshot",
+          "render_variant": "rich_text",
+          "body_md": "Role recommendations and work-environment guidance for ENTP profiles. This profile tends to do best when goals are explicit, feedback is available, and growth loops stay visible.",
+          "body_html": null,
+          "payload_json": null,
+          "sort_order": 10,
+          "is_enabled": true
+        },
+        {
+          "section_key": "strengths",
+          "title": "Strengths",
+          "render_variant": "bullets",
+          "body_md": null,
+          "body_html": null,
+          "payload_json": {
+            "items": [
+              {
+                "title": "Strategic pattern recognition",
+                "body": null
+              },
+              {
+                "title": "Stable execution under constraints",
+                "body": null
+              },
+              {
+                "title": "Strong ownership on meaningful goals",
+                "body": null
+              }
+            ]
+          },
+          "sort_order": 20,
+          "is_enabled": true
+        },
+        {
+          "section_key": "growth_edges",
+          "title": "Growth edges",
+          "render_variant": "bullets",
+          "body_md": null,
+          "body_html": null,
+          "payload_json": {
+            "items": [
+              {
+                "title": "Over-specialization without cross-functional exposure",
+                "body": null
+              },
+              {
+                "title": "Delayed feedback loops causing slower iteration",
+                "body": null
+              }
+            ]
+          },
+          "sort_order": 30,
+          "is_enabled": true
+        },
+        {
+          "section_key": "work_style",
+          "title": "Work style",
+          "render_variant": "rich_text",
+          "body_md": "High-autonomy role scope, clear success metrics, and consistent feedback cadence.",
+          "body_html": null,
+          "payload_json": null,
+          "sort_order": 40,
+          "is_enabled": true
+        },
+        {
+          "section_key": "relationships",
+          "title": "Relationships",
+          "render_variant": "rich_text",
+          "body_md": "You usually build trust through direct dialogue, shared activity, and fast feedback. You tend to connect more deeply with people who enjoy discussing patterns, future possibilities, and meaning. In conflict you often default to logic and boundaries, so it helps to add explicit emotional acknowledgment. In close relationships and teamwork, you usually prefer flexibility, openness, and room to adapt.",
+          "body_html": null,
+          "payload_json": null,
+          "sort_order": 50,
+          "is_enabled": true
+        },
+        {
+          "section_key": "career_fit",
+          "title": "Career fit",
+          "render_variant": "cards",
+          "body_md": "You usually perform best in high-autonomy role scope, clear success metrics, and consistent feedback cadence. Prioritize options like Psychological Counselor, Investment Analyst, Physician.",
+          "body_html": null,
+          "payload_json": {
+            "recommended_jobs": [
+              {
+                "slug": "psychological-counselor",
+                "title": "Psychological Counselor"
+              },
+              {
+                "slug": "investment-analyst",
+                "title": "Investment Analyst"
+              },
+              {
+                "slug": "physician",
+                "title": "Physician"
+              },
+              {
+                "slug": "data-scientist",
+                "title": "Data Scientist"
+              },
+              {
+                "slug": "frontend-engineer",
+                "title": "Frontend Engineer"
+              },
+              {
+                "slug": "fullstack-engineer",
+                "title": "Fullstack Engineer"
+              }
+            ],
+            "avoid_jobs": [
+              {
+                "slug": "frontend-engineer",
+                "title": "Frontend Engineer"
+              },
+              {
+                "slug": "fullstack-engineer",
+                "title": "Fullstack Engineer"
+              },
+              {
+                "slug": "cloud-architect",
+                "title": "Cloud Architect"
+              }
+            ],
+            "work_env": "High-autonomy role scope, clear success metrics, and consistent feedback cadence."
+          },
+          "sort_order": 80,
+          "is_enabled": true
+        }
+      ],
+      "seo_meta": {
+        "seo_title": "ENTP Personality Guide",
+        "seo_description": "Discover strengths, weaknesses, relationship patterns, and career direction for the ENTP personality type.",
+        "canonical_url": null,
+        "og_title": null,
+        "og_description": null,
+        "og_image_url": null,
+        "twitter_title": null,
+        "twitter_description": null,
+        "twitter_image_url": null,
+        "robots": null,
+        "jsonld_overrides_json": null
+      }
+    },
+    {
+      "type_code": "ESFJ",
+      "slug": "esfj",
+      "title": "ESFJ - Consul",
+      "subtitle": null,
+      "excerpt": "Role recommendations and work-environment guidance for ESFJ profiles.",
+      "hero_kicker": "Consul",
+      "hero_quote": null,
+      "hero_image_url": null,
+      "status": "published",
+      "is_public": true,
+      "is_indexable": true,
+      "published_at": null,
+      "scheduled_at": null,
+      "sections": [
+        {
+          "section_key": "core_snapshot",
+          "title": "Core snapshot",
+          "render_variant": "rich_text",
+          "body_md": "Role recommendations and work-environment guidance for ESFJ profiles. This profile tends to do best when goals are explicit, feedback is available, and growth loops stay visible.",
+          "body_html": null,
+          "payload_json": null,
+          "sort_order": 10,
+          "is_enabled": true
+        },
+        {
+          "section_key": "strengths",
+          "title": "Strengths",
+          "render_variant": "bullets",
+          "body_md": null,
+          "body_html": null,
+          "payload_json": {
+            "items": [
+              {
+                "title": "Strategic pattern recognition",
+                "body": null
+              },
+              {
+                "title": "Stable execution under constraints",
+                "body": null
+              },
+              {
+                "title": "Strong ownership on meaningful goals",
+                "body": null
+              }
+            ]
+          },
+          "sort_order": 20,
+          "is_enabled": true
+        },
+        {
+          "section_key": "growth_edges",
+          "title": "Growth edges",
+          "render_variant": "bullets",
+          "body_md": null,
+          "body_html": null,
+          "payload_json": {
+            "items": [
+              {
+                "title": "Over-specialization without cross-functional exposure",
+                "body": null
+              },
+              {
+                "title": "Delayed feedback loops causing slower iteration",
+                "body": null
+              }
+            ]
+          },
+          "sort_order": 30,
+          "is_enabled": true
+        },
+        {
+          "section_key": "work_style",
+          "title": "Work style",
+          "render_variant": "rich_text",
+          "body_md": "High-autonomy role scope, clear success metrics, and consistent feedback cadence.",
+          "body_html": null,
+          "payload_json": null,
+          "sort_order": 40,
+          "is_enabled": true
+        },
+        {
+          "section_key": "relationships",
+          "title": "Relationships",
+          "render_variant": "rich_text",
+          "body_md": "You usually build trust through direct dialogue, shared activity, and fast feedback. You tend to value people who are reliable, concrete, and consistent in day-to-day follow-through. In conflict you often default to harmony and emotional tone, so it helps to make your principles explicit. In close relationships and teamwork, you usually prefer clarity, commitment, and predictable pace.",
+          "body_html": null,
+          "payload_json": null,
+          "sort_order": 50,
+          "is_enabled": true
+        },
+        {
+          "section_key": "career_fit",
+          "title": "Career fit",
+          "render_variant": "cards",
+          "body_md": "You usually perform best in high-autonomy role scope, clear success metrics, and consistent feedback cadence. Prioritize options like Frontend Engineer, Fullstack Engineer, Cloud Architect.",
+          "body_html": null,
+          "payload_json": {
+            "recommended_jobs": [
+              {
+                "slug": "frontend-engineer",
+                "title": "Frontend Engineer"
+              },
+              {
+                "slug": "fullstack-engineer",
+                "title": "Fullstack Engineer"
+              },
+              {
+                "slug": "cloud-architect",
+                "title": "Cloud Architect"
+              },
+              {
+                "slug": "hr-business-partner",
+                "title": "HR Business Partner"
+              },
+              {
+                "slug": "management-consultant",
+                "title": "Management Consultant"
+              },
+              {
+                "slug": "business-analyst",
+                "title": "Business Analyst"
+              }
+            ],
+            "avoid_jobs": [
+              {
+                "slug": "management-consultant",
+                "title": "Management Consultant"
+              },
+              {
+                "slug": "business-analyst",
+                "title": "Business Analyst"
+              },
+              {
+                "slug": "brand-manager",
+                "title": "Brand Manager"
+              }
+            ],
+            "work_env": "High-autonomy role scope, clear success metrics, and consistent feedback cadence."
+          },
+          "sort_order": 80,
+          "is_enabled": true
+        }
+      ],
+      "seo_meta": {
+        "seo_title": "ESFJ Personality Guide",
+        "seo_description": "Discover strengths, weaknesses, relationship patterns, and career direction for the ESFJ personality type.",
+        "canonical_url": null,
+        "og_title": null,
+        "og_description": null,
+        "og_image_url": null,
+        "twitter_title": null,
+        "twitter_description": null,
+        "twitter_image_url": null,
+        "robots": null,
+        "jsonld_overrides_json": null
+      }
+    },
+    {
+      "type_code": "ESFP",
+      "slug": "esfp",
+      "title": "ESFP - Entertainer",
+      "subtitle": null,
+      "excerpt": "Role recommendations and work-environment guidance for ESFP profiles.",
+      "hero_kicker": "Entertainer",
+      "hero_quote": null,
+      "hero_image_url": null,
+      "status": "published",
+      "is_public": true,
+      "is_indexable": true,
+      "published_at": null,
+      "scheduled_at": null,
+      "sections": [
+        {
+          "section_key": "core_snapshot",
+          "title": "Core snapshot",
+          "render_variant": "rich_text",
+          "body_md": "Role recommendations and work-environment guidance for ESFP profiles. This profile tends to do best when goals are explicit, feedback is available, and growth loops stay visible.",
+          "body_html": null,
+          "payload_json": null,
+          "sort_order": 10,
+          "is_enabled": true
+        },
+        {
+          "section_key": "strengths",
+          "title": "Strengths",
+          "render_variant": "bullets",
+          "body_md": null,
+          "body_html": null,
+          "payload_json": {
+            "items": [
+              {
+                "title": "Strategic pattern recognition",
+                "body": null
+              },
+              {
+                "title": "Stable execution under constraints",
+                "body": null
+              },
+              {
+                "title": "Strong ownership on meaningful goals",
+                "body": null
+              }
+            ]
+          },
+          "sort_order": 20,
+          "is_enabled": true
+        },
+        {
+          "section_key": "growth_edges",
+          "title": "Growth edges",
+          "render_variant": "bullets",
+          "body_md": null,
+          "body_html": null,
+          "payload_json": {
+            "items": [
+              {
+                "title": "Over-specialization without cross-functional exposure",
+                "body": null
+              },
+              {
+                "title": "Delayed feedback loops causing slower iteration",
+                "body": null
+              }
+            ]
+          },
+          "sort_order": 30,
+          "is_enabled": true
+        },
+        {
+          "section_key": "work_style",
+          "title": "Work style",
+          "render_variant": "rich_text",
+          "body_md": "High-autonomy role scope, clear success metrics, and consistent feedback cadence.",
+          "body_html": null,
+          "payload_json": null,
+          "sort_order": 40,
+          "is_enabled": true
+        },
+        {
+          "section_key": "relationships",
+          "title": "Relationships",
+          "render_variant": "rich_text",
+          "body_md": "You usually build trust through direct dialogue, shared activity, and fast feedback. You tend to value people who are reliable, concrete, and consistent in day-to-day follow-through. In conflict you often default to harmony and emotional tone, so it helps to make your principles explicit. In close relationships and teamwork, you usually prefer flexibility, openness, and room to adapt.",
+          "body_html": null,
+          "payload_json": null,
+          "sort_order": 50,
+          "is_enabled": true
+        },
+        {
+          "section_key": "career_fit",
+          "title": "Career fit",
+          "render_variant": "cards",
+          "body_md": "You usually perform best in high-autonomy role scope, clear success metrics, and consistent feedback cadence. Prioritize options like Cloud Architect, HR Business Partner, Management Consultant.",
+          "body_html": null,
+          "payload_json": {
+            "recommended_jobs": [
+              {
+                "slug": "cloud-architect",
+                "title": "Cloud Architect"
+              },
+              {
+                "slug": "hr-business-partner",
+                "title": "HR Business Partner"
+              },
+              {
+                "slug": "management-consultant",
+                "title": "Management Consultant"
+              },
+              {
+                "slug": "business-analyst",
+                "title": "Business Analyst"
+              },
+              {
+                "slug": "brand-manager",
+                "title": "Brand Manager"
+              },
+              {
+                "slug": "nurse",
+                "title": "Nurse"
+              }
+            ],
+            "avoid_jobs": [
+              {
+                "slug": "brand-manager",
+                "title": "Brand Manager"
+              },
+              {
+                "slug": "nurse",
+                "title": "Nurse"
+              },
+              {
+                "slug": "supply-chain-manager",
+                "title": "Supply Chain Manager"
+              }
+            ],
+            "work_env": "High-autonomy role scope, clear success metrics, and consistent feedback cadence."
+          },
+          "sort_order": 80,
+          "is_enabled": true
+        }
+      ],
+      "seo_meta": {
+        "seo_title": "ESFP Personality Guide",
+        "seo_description": "Discover strengths, weaknesses, relationship patterns, and career direction for the ESFP personality type.",
+        "canonical_url": null,
+        "og_title": null,
+        "og_description": null,
+        "og_image_url": null,
+        "twitter_title": null,
+        "twitter_description": null,
+        "twitter_image_url": null,
+        "robots": null,
+        "jsonld_overrides_json": null
+      }
+    },
+    {
+      "type_code": "ESTJ",
+      "slug": "estj",
+      "title": "ESTJ - Executive",
+      "subtitle": null,
+      "excerpt": "Role recommendations and work-environment guidance for ESTJ profiles.",
+      "hero_kicker": "Executive",
+      "hero_quote": null,
+      "hero_image_url": null,
+      "status": "published",
+      "is_public": true,
+      "is_indexable": true,
+      "published_at": null,
+      "scheduled_at": null,
+      "sections": [
+        {
+          "section_key": "core_snapshot",
+          "title": "Core snapshot",
+          "render_variant": "rich_text",
+          "body_md": "Role recommendations and work-environment guidance for ESTJ profiles. This profile tends to do best when goals are explicit, feedback is available, and growth loops stay visible.",
+          "body_html": null,
+          "payload_json": null,
+          "sort_order": 10,
+          "is_enabled": true
+        },
+        {
+          "section_key": "strengths",
+          "title": "Strengths",
+          "render_variant": "bullets",
+          "body_md": null,
+          "body_html": null,
+          "payload_json": {
+            "items": [
+              {
+                "title": "Strategic pattern recognition",
+                "body": null
+              },
+              {
+                "title": "Stable execution under constraints",
+                "body": null
+              },
+              {
+                "title": "Strong ownership on meaningful goals",
+                "body": null
+              }
+            ]
+          },
+          "sort_order": 20,
+          "is_enabled": true
+        },
+        {
+          "section_key": "growth_edges",
+          "title": "Growth edges",
+          "render_variant": "bullets",
+          "body_md": null,
+          "body_html": null,
+          "payload_json": {
+            "items": [
+              {
+                "title": "Over-specialization without cross-functional exposure",
+                "body": null
+              },
+              {
+                "title": "Delayed feedback loops causing slower iteration",
+                "body": null
+              }
+            ]
+          },
+          "sort_order": 30,
+          "is_enabled": true
+        },
+        {
+          "section_key": "work_style",
+          "title": "Work style",
+          "render_variant": "rich_text",
+          "body_md": "High-autonomy role scope, clear success metrics, and consistent feedback cadence.",
+          "body_html": null,
+          "payload_json": null,
+          "sort_order": 40,
+          "is_enabled": true
+        },
+        {
+          "section_key": "relationships",
+          "title": "Relationships",
+          "render_variant": "rich_text",
+          "body_md": "You usually build trust through direct dialogue, shared activity, and fast feedback. You tend to value people who are reliable, concrete, and consistent in day-to-day follow-through. In conflict you often default to logic and boundaries, so it helps to add explicit emotional acknowledgment. In close relationships and teamwork, you usually prefer clarity, commitment, and predictable pace.",
+          "body_html": null,
+          "payload_json": null,
+          "sort_order": 50,
+          "is_enabled": true
+        },
+        {
+          "section_key": "career_fit",
+          "title": "Career fit",
+          "render_variant": "cards",
+          "body_md": "You usually perform best in high-autonomy role scope, clear success metrics, and consistent feedback cadence. Prioritize options like Machine Learning Engineer, Backend Engineer, Cybersecurity Analyst.",
+          "body_html": null,
+          "payload_json": {
+            "recommended_jobs": [
+              {
+                "slug": "machine-learning-engineer",
+                "title": "Machine Learning Engineer"
+              },
+              {
+                "slug": "backend-engineer",
+                "title": "Backend Engineer"
+              },
+              {
+                "slug": "cybersecurity-analyst",
+                "title": "Cybersecurity Analyst"
+              },
+              {
+                "slug": "operations-manager",
+                "title": "Operations Manager"
+              },
+              {
+                "slug": "sales-manager",
+                "title": "Sales Manager"
+              },
+              {
+                "slug": "financial-planner",
+                "title": "Financial Planner"
+              }
+            ],
+            "avoid_jobs": [
+              {
+                "slug": "sales-manager",
+                "title": "Sales Manager"
+              },
+              {
+                "slug": "financial-planner",
+                "title": "Financial Planner"
+              },
+              {
+                "slug": "content-strategist",
+                "title": "Content Strategist"
+              }
+            ],
+            "work_env": "High-autonomy role scope, clear success metrics, and consistent feedback cadence."
+          },
+          "sort_order": 80,
+          "is_enabled": true
+        }
+      ],
+      "seo_meta": {
+        "seo_title": "ESTJ Personality Guide",
+        "seo_description": "Discover strengths, weaknesses, relationship patterns, and career direction for the ESTJ personality type.",
+        "canonical_url": null,
+        "og_title": null,
+        "og_description": null,
+        "og_image_url": null,
+        "twitter_title": null,
+        "twitter_description": null,
+        "twitter_image_url": null,
+        "robots": null,
+        "jsonld_overrides_json": null
+      }
+    },
+    {
+      "type_code": "ESTP",
+      "slug": "estp",
+      "title": "ESTP - Entrepreneur",
+      "subtitle": null,
+      "excerpt": "Role recommendations and work-environment guidance for ESTP profiles.",
+      "hero_kicker": "Entrepreneur",
+      "hero_quote": null,
+      "hero_image_url": null,
+      "status": "published",
+      "is_public": true,
+      "is_indexable": true,
+      "published_at": null,
+      "scheduled_at": null,
+      "sections": [
+        {
+          "section_key": "core_snapshot",
+          "title": "Core snapshot",
+          "render_variant": "rich_text",
+          "body_md": "Role recommendations and work-environment guidance for ESTP profiles. This profile tends to do best when goals are explicit, feedback is available, and growth loops stay visible.",
+          "body_html": null,
+          "payload_json": null,
+          "sort_order": 10,
+          "is_enabled": true
+        },
+        {
+          "section_key": "strengths",
+          "title": "Strengths",
+          "render_variant": "bullets",
+          "body_md": null,
+          "body_html": null,
+          "payload_json": {
+            "items": [
+              {
+                "title": "Strategic pattern recognition",
+                "body": null
+              },
+              {
+                "title": "Stable execution under constraints",
+                "body": null
+              },
+              {
+                "title": "Strong ownership on meaningful goals",
+                "body": null
+              }
+            ]
+          },
+          "sort_order": 20,
+          "is_enabled": true
+        },
+        {
+          "section_key": "growth_edges",
+          "title": "Growth edges",
+          "render_variant": "bullets",
+          "body_md": null,
+          "body_html": null,
+          "payload_json": {
+            "items": [
+              {
+                "title": "Over-specialization without cross-functional exposure",
+                "body": null
+              },
+              {
+                "title": "Delayed feedback loops causing slower iteration",
+                "body": null
+              }
+            ]
+          },
+          "sort_order": 30,
+          "is_enabled": true
+        },
+        {
+          "section_key": "work_style",
+          "title": "Work style",
+          "render_variant": "rich_text",
+          "body_md": "High-autonomy role scope, clear success metrics, and consistent feedback cadence.",
+          "body_html": null,
+          "payload_json": null,
+          "sort_order": 40,
+          "is_enabled": true
+        },
+        {
+          "section_key": "relationships",
+          "title": "Relationships",
+          "render_variant": "rich_text",
+          "body_md": "You usually build trust through direct dialogue, shared activity, and fast feedback. You tend to value people who are reliable, concrete, and consistent in day-to-day follow-through. In conflict you often default to logic and boundaries, so it helps to add explicit emotional acknowledgment. In close relationships and teamwork, you usually prefer flexibility, openness, and room to adapt.",
+          "body_html": null,
+          "payload_json": null,
+          "sort_order": 50,
+          "is_enabled": true
+        },
+        {
+          "section_key": "career_fit",
+          "title": "Career fit",
+          "render_variant": "cards",
+          "body_md": "You usually perform best in high-autonomy role scope, clear success metrics, and consistent feedback cadence. Prioritize options like Cybersecurity Analyst, Operations Manager, Sales Manager.",
+          "body_html": null,
+          "payload_json": {
+            "recommended_jobs": [
+              {
+                "slug": "cybersecurity-analyst",
+                "title": "Cybersecurity Analyst"
+              },
+              {
+                "slug": "operations-manager",
+                "title": "Operations Manager"
+              },
+              {
+                "slug": "sales-manager",
+                "title": "Sales Manager"
+              },
+              {
+                "slug": "financial-planner",
+                "title": "Financial Planner"
+              },
+              {
+                "slug": "content-strategist",
+                "title": "Content Strategist"
+              },
+              {
+                "slug": "researcher",
+                "title": "Researcher"
+              }
+            ],
+            "avoid_jobs": [
+              {
+                "slug": "content-strategist",
+                "title": "Content Strategist"
+              },
+              {
+                "slug": "researcher",
+                "title": "Researcher"
+              },
+              {
+                "slug": "pharmacist",
+                "title": "Pharmacist"
+              }
+            ],
+            "work_env": "High-autonomy role scope, clear success metrics, and consistent feedback cadence."
+          },
+          "sort_order": 80,
+          "is_enabled": true
+        }
+      ],
+      "seo_meta": {
+        "seo_title": "ESTP Personality Guide",
+        "seo_description": "Discover strengths, weaknesses, relationship patterns, and career direction for the ESTP personality type.",
+        "canonical_url": null,
+        "og_title": null,
+        "og_description": null,
+        "og_image_url": null,
+        "twitter_title": null,
+        "twitter_description": null,
+        "twitter_image_url": null,
+        "robots": null,
+        "jsonld_overrides_json": null
+      }
+    },
+    {
+      "type_code": "INFJ",
+      "slug": "infj",
+      "title": "INFJ - Advocate",
+      "subtitle": null,
+      "excerpt": "Role recommendations and work-environment guidance for INFJ profiles.",
+      "hero_kicker": "Advocate",
+      "hero_quote": null,
+      "hero_image_url": null,
+      "status": "published",
+      "is_public": true,
+      "is_indexable": true,
+      "published_at": null,
+      "scheduled_at": null,
+      "sections": [
+        {
+          "section_key": "core_snapshot",
+          "title": "Core snapshot",
+          "render_variant": "rich_text",
+          "body_md": "Role recommendations and work-environment guidance for INFJ profiles. This profile tends to do best when goals are explicit, feedback is available, and growth loops stay visible.",
+          "body_html": null,
+          "payload_json": null,
+          "sort_order": 10,
+          "is_enabled": true
+        },
+        {
+          "section_key": "strengths",
+          "title": "Strengths",
+          "render_variant": "bullets",
+          "body_md": null,
+          "body_html": null,
+          "payload_json": {
+            "items": [
+              {
+                "title": "Strategic pattern recognition",
+                "body": null
+              },
+              {
+                "title": "Stable execution under constraints",
+                "body": null
+              },
+              {
+                "title": "Strong ownership on meaningful goals",
+                "body": null
+              }
+            ]
+          },
+          "sort_order": 20,
+          "is_enabled": true
+        },
+        {
+          "section_key": "growth_edges",
+          "title": "Growth edges",
+          "render_variant": "bullets",
+          "body_md": null,
+          "body_html": null,
+          "payload_json": {
+            "items": [
+              {
+                "title": "Over-specialization without cross-functional exposure",
+                "body": null
+              },
+              {
+                "title": "Delayed feedback loops causing slower iteration",
+                "body": null
+              }
+            ]
+          },
+          "sort_order": 30,
+          "is_enabled": true
+        },
+        {
+          "section_key": "work_style",
+          "title": "Work style",
+          "render_variant": "rich_text",
+          "body_md": "High-autonomy role scope, clear success metrics, and consistent feedback cadence.",
+          "body_html": null,
+          "payload_json": null,
+          "sort_order": 40,
+          "is_enabled": true
+        },
+        {
+          "section_key": "relationships",
+          "title": "Relationships",
+          "render_variant": "rich_text",
+          "body_md": "You usually build trust through steady one-on-one conversations, reflection, and protected space. You tend to connect more deeply with people who enjoy discussing patterns, future possibilities, and meaning. In conflict you often default to harmony and emotional tone, so it helps to make your principles explicit. In close relationships and teamwork, you usually prefer clarity, commitment, and predictable pace.",
+          "body_html": null,
+          "payload_json": null,
+          "sort_order": 50,
+          "is_enabled": true
+        },
+        {
+          "section_key": "career_fit",
+          "title": "Career fit",
+          "render_variant": "cards",
+          "body_md": "You usually perform best in high-autonomy role scope, clear success metrics, and consistent feedback cadence. Prioritize options like Digital Marketing Manager, Lawyer, Teacher.",
+          "body_html": null,
+          "payload_json": {
+            "recommended_jobs": [
+              {
+                "slug": "digital-marketing-manager",
+                "title": "Digital Marketing Manager"
+              },
+              {
+                "slug": "lawyer",
+                "title": "Lawyer"
+              },
+              {
+                "slug": "teacher",
+                "title": "Teacher"
+              },
+              {
+                "slug": "machine-learning-engineer",
+                "title": "Machine Learning Engineer"
+              },
+              {
+                "slug": "backend-engineer",
+                "title": "Backend Engineer"
+              },
+              {
+                "slug": "cybersecurity-analyst",
+                "title": "Cybersecurity Analyst"
+              }
+            ],
+            "avoid_jobs": [
+              {
+                "slug": "backend-engineer",
+                "title": "Backend Engineer"
+              },
+              {
+                "slug": "cybersecurity-analyst",
+                "title": "Cybersecurity Analyst"
+              },
+              {
+                "slug": "operations-manager",
+                "title": "Operations Manager"
+              }
+            ],
+            "work_env": "High-autonomy role scope, clear success metrics, and consistent feedback cadence."
+          },
+          "sort_order": 80,
+          "is_enabled": true
+        }
+      ],
+      "seo_meta": {
+        "seo_title": "INFJ Personality Guide",
+        "seo_description": "Discover strengths, weaknesses, relationship patterns, and career direction for the INFJ personality type.",
+        "canonical_url": null,
+        "og_title": null,
+        "og_description": null,
+        "og_image_url": null,
+        "twitter_title": null,
+        "twitter_description": null,
+        "twitter_image_url": null,
+        "robots": null,
+        "jsonld_overrides_json": null
+      }
+    },
+    {
+      "type_code": "INFP",
+      "slug": "infp",
+      "title": "INFP - Mediator",
+      "subtitle": null,
+      "excerpt": "Role recommendations and work-environment guidance for INFP profiles.",
+      "hero_kicker": "Mediator",
+      "hero_quote": null,
+      "hero_image_url": null,
+      "status": "published",
+      "is_public": true,
+      "is_indexable": true,
+      "published_at": null,
+      "scheduled_at": null,
+      "sections": [
+        {
+          "section_key": "core_snapshot",
+          "title": "Core snapshot",
+          "render_variant": "rich_text",
+          "body_md": "Role recommendations and work-environment guidance for INFP profiles. This profile tends to do best when goals are explicit, feedback is available, and growth loops stay visible.",
+          "body_html": null,
+          "payload_json": null,
+          "sort_order": 10,
+          "is_enabled": true
+        },
+        {
+          "section_key": "strengths",
+          "title": "Strengths",
+          "render_variant": "bullets",
+          "body_md": null,
+          "body_html": null,
+          "payload_json": {
+            "items": [
+              {
+                "title": "Strategic pattern recognition",
+                "body": null
+              },
+              {
+                "title": "Stable execution under constraints",
+                "body": null
+              },
+              {
+                "title": "Strong ownership on meaningful goals",
+                "body": null
+              }
+            ]
+          },
+          "sort_order": 20,
+          "is_enabled": true
+        },
+        {
+          "section_key": "growth_edges",
+          "title": "Growth edges",
+          "render_variant": "bullets",
+          "body_md": null,
+          "body_html": null,
+          "payload_json": {
+            "items": [
+              {
+                "title": "Over-specialization without cross-functional exposure",
+                "body": null
+              },
+              {
+                "title": "Delayed feedback loops causing slower iteration",
+                "body": null
+              }
+            ]
+          },
+          "sort_order": 30,
+          "is_enabled": true
+        },
+        {
+          "section_key": "work_style",
+          "title": "Work style",
+          "render_variant": "rich_text",
+          "body_md": "High-autonomy role scope, clear success metrics, and consistent feedback cadence.",
+          "body_html": null,
+          "payload_json": null,
+          "sort_order": 40,
+          "is_enabled": true
+        },
+        {
+          "section_key": "relationships",
+          "title": "Relationships",
+          "render_variant": "rich_text",
+          "body_md": "You usually build trust through steady one-on-one conversations, reflection, and protected space. You tend to connect more deeply with people who enjoy discussing patterns, future possibilities, and meaning. In conflict you often default to harmony and emotional tone, so it helps to make your principles explicit. In close relationships and teamwork, you usually prefer flexibility, openness, and room to adapt.",
+          "body_html": null,
+          "payload_json": null,
+          "sort_order": 50,
+          "is_enabled": true
+        },
+        {
+          "section_key": "career_fit",
+          "title": "Career fit",
+          "render_variant": "cards",
+          "body_md": "You usually perform best in high-autonomy role scope, clear success metrics, and consistent feedback cadence. Prioritize options like Investment Analyst, Physician, Data Scientist.",
+          "body_html": null,
+          "payload_json": {
+            "recommended_jobs": [
+              {
+                "slug": "investment-analyst",
+                "title": "Investment Analyst"
+              },
+              {
+                "slug": "physician",
+                "title": "Physician"
+              },
+              {
+                "slug": "data-scientist",
+                "title": "Data Scientist"
+              },
+              {
+                "slug": "frontend-engineer",
+                "title": "Frontend Engineer"
+              },
+              {
+                "slug": "fullstack-engineer",
+                "title": "Fullstack Engineer"
+              },
+              {
+                "slug": "cloud-architect",
+                "title": "Cloud Architect"
+              }
+            ],
+            "avoid_jobs": [
+              {
+                "slug": "fullstack-engineer",
+                "title": "Fullstack Engineer"
+              },
+              {
+                "slug": "cloud-architect",
+                "title": "Cloud Architect"
+              },
+              {
+                "slug": "hr-business-partner",
+                "title": "HR Business Partner"
+              }
+            ],
+            "work_env": "High-autonomy role scope, clear success metrics, and consistent feedback cadence."
+          },
+          "sort_order": 80,
+          "is_enabled": true
+        }
+      ],
+      "seo_meta": {
+        "seo_title": "INFP Personality Guide",
+        "seo_description": "Discover strengths, weaknesses, relationship patterns, and career direction for the INFP personality type.",
+        "canonical_url": null,
+        "og_title": null,
+        "og_description": null,
+        "og_image_url": null,
+        "twitter_title": null,
+        "twitter_description": null,
+        "twitter_image_url": null,
+        "robots": null,
+        "jsonld_overrides_json": null
+      }
+    },
+    {
+      "type_code": "INTJ",
+      "slug": "intj",
+      "title": "INTJ - Architect",
+      "subtitle": null,
+      "excerpt": "Role recommendations and work-environment guidance for INTJ profiles.",
+      "hero_kicker": "Architect",
+      "hero_quote": null,
+      "hero_image_url": null,
+      "status": "published",
+      "is_public": true,
+      "is_indexable": true,
+      "published_at": null,
+      "scheduled_at": null,
+      "sections": [
+        {
+          "section_key": "core_snapshot",
+          "title": "Core snapshot",
+          "render_variant": "rich_text",
+          "body_md": "Role recommendations and work-environment guidance for INTJ profiles. This profile tends to do best when goals are explicit, feedback is available, and growth loops stay visible.",
+          "body_html": null,
+          "payload_json": null,
+          "sort_order": 10,
+          "is_enabled": true
+        },
+        {
+          "section_key": "strengths",
+          "title": "Strengths",
+          "render_variant": "bullets",
+          "body_md": null,
+          "body_html": null,
+          "payload_json": {
+            "items": [
+              {
+                "title": "Strategic pattern recognition",
+                "body": null
+              },
+              {
+                "title": "Stable execution under constraints",
+                "body": null
+              },
+              {
+                "title": "Strong ownership on meaningful goals",
+                "body": null
+              }
+            ]
+          },
+          "sort_order": 20,
+          "is_enabled": true
+        },
+        {
+          "section_key": "growth_edges",
+          "title": "Growth edges",
+          "render_variant": "bullets",
+          "body_md": null,
+          "body_html": null,
+          "payload_json": {
+            "items": [
+              {
+                "title": "Over-specialization without cross-functional exposure",
+                "body": null
+              },
+              {
+                "title": "Delayed feedback loops causing slower iteration",
+                "body": null
+              }
+            ]
+          },
+          "sort_order": 30,
+          "is_enabled": true
+        },
+        {
+          "section_key": "work_style",
+          "title": "Work style",
+          "render_variant": "rich_text",
+          "body_md": "High-autonomy role scope, clear success metrics, and consistent feedback cadence.",
+          "body_html": null,
+          "payload_json": null,
+          "sort_order": 40,
+          "is_enabled": true
+        },
+        {
+          "section_key": "relationships",
+          "title": "Relationships",
+          "render_variant": "rich_text",
+          "body_md": "You usually build trust through steady one-on-one conversations, reflection, and protected space. You tend to connect more deeply with people who enjoy discussing patterns, future possibilities, and meaning. In conflict you often default to logic and boundaries, so it helps to add explicit emotional acknowledgment. In close relationships and teamwork, you usually prefer clarity, commitment, and predictable pace.",
+          "body_html": null,
+          "payload_json": null,
+          "sort_order": 50,
+          "is_enabled": true
+        },
+        {
+          "section_key": "career_fit",
+          "title": "Career fit",
+          "render_variant": "cards",
+          "body_md": "You usually perform best in high-autonomy role scope, clear success metrics, and consistent feedback cadence. Prioritize options like Product Manager, UI/UX Designer, Digital Marketing Manager.",
+          "body_html": null,
+          "payload_json": {
+            "recommended_jobs": [
+              {
+                "slug": "product-manager",
+                "title": "Product Manager"
+              },
+              {
+                "slug": "ui-ux-designer",
+                "title": "UI/UX Designer"
+              },
+              {
+                "slug": "digital-marketing-manager",
+                "title": "Digital Marketing Manager"
+              },
+              {
+                "slug": "lawyer",
+                "title": "Lawyer"
+              },
+              {
+                "slug": "teacher",
+                "title": "Teacher"
+              },
+              {
+                "slug": "machine-learning-engineer",
+                "title": "Machine Learning Engineer"
+              }
+            ],
+            "avoid_jobs": [
+              {
+                "slug": "teacher",
+                "title": "Teacher"
+              },
+              {
+                "slug": "machine-learning-engineer",
+                "title": "Machine Learning Engineer"
+              },
+              {
+                "slug": "backend-engineer",
+                "title": "Backend Engineer"
+              }
+            ],
+            "work_env": "High-autonomy role scope, clear success metrics, and consistent feedback cadence."
+          },
+          "sort_order": 80,
+          "is_enabled": true
+        }
+      ],
+      "seo_meta": {
+        "seo_title": "INTJ Personality Guide",
+        "seo_description": "Discover strengths, weaknesses, relationship patterns, and career direction for the INTJ personality type.",
+        "canonical_url": null,
+        "og_title": null,
+        "og_description": null,
+        "og_image_url": null,
+        "twitter_title": null,
+        "twitter_description": null,
+        "twitter_image_url": null,
+        "robots": null,
+        "jsonld_overrides_json": null
+      }
+    },
+    {
+      "type_code": "INTP",
+      "slug": "intp",
+      "title": "INTP - Logician",
+      "subtitle": null,
+      "excerpt": "Role recommendations and work-environment guidance for INTP profiles.",
+      "hero_kicker": "Logician",
+      "hero_quote": null,
+      "hero_image_url": null,
+      "status": "published",
+      "is_public": true,
+      "is_indexable": true,
+      "published_at": null,
+      "scheduled_at": null,
+      "sections": [
+        {
+          "section_key": "core_snapshot",
+          "title": "Core snapshot",
+          "render_variant": "rich_text",
+          "body_md": "Role recommendations and work-environment guidance for INTP profiles. This profile tends to do best when goals are explicit, feedback is available, and growth loops stay visible.",
+          "body_html": null,
+          "payload_json": null,
+          "sort_order": 10,
+          "is_enabled": true
+        },
+        {
+          "section_key": "strengths",
+          "title": "Strengths",
+          "render_variant": "bullets",
+          "body_md": null,
+          "body_html": null,
+          "payload_json": {
+            "items": [
+              {
+                "title": "Strategic pattern recognition",
+                "body": null
+              },
+              {
+                "title": "Stable execution under constraints",
+                "body": null
+              },
+              {
+                "title": "Strong ownership on meaningful goals",
+                "body": null
+              }
+            ]
+          },
+          "sort_order": 20,
+          "is_enabled": true
+        },
+        {
+          "section_key": "growth_edges",
+          "title": "Growth edges",
+          "render_variant": "bullets",
+          "body_md": null,
+          "body_html": null,
+          "payload_json": {
+            "items": [
+              {
+                "title": "Over-specialization without cross-functional exposure",
+                "body": null
+              },
+              {
+                "title": "Delayed feedback loops causing slower iteration",
+                "body": null
+              }
+            ]
+          },
+          "sort_order": 30,
+          "is_enabled": true
+        },
+        {
+          "section_key": "work_style",
+          "title": "Work style",
+          "render_variant": "rich_text",
+          "body_md": "High-autonomy role scope, clear success metrics, and consistent feedback cadence.",
+          "body_html": null,
+          "payload_json": null,
+          "sort_order": 40,
+          "is_enabled": true
+        },
+        {
+          "section_key": "relationships",
+          "title": "Relationships",
+          "render_variant": "rich_text",
+          "body_md": "You usually build trust through steady one-on-one conversations, reflection, and protected space. You tend to connect more deeply with people who enjoy discussing patterns, future possibilities, and meaning. In conflict you often default to logic and boundaries, so it helps to add explicit emotional acknowledgment. In close relationships and teamwork, you usually prefer flexibility, openness, and room to adapt.",
+          "body_html": null,
+          "payload_json": null,
+          "sort_order": 50,
+          "is_enabled": true
+        },
+        {
+          "section_key": "career_fit",
+          "title": "Career fit",
+          "render_variant": "cards",
+          "body_md": "You usually perform best in high-autonomy role scope, clear success metrics, and consistent feedback cadence. Prioritize options like Data Analyst, Psychological Counselor, Investment Analyst.",
+          "body_html": null,
+          "payload_json": {
+            "recommended_jobs": [
+              {
+                "slug": "data-analyst",
+                "title": "Data Analyst"
+              },
+              {
+                "slug": "psychological-counselor",
+                "title": "Psychological Counselor"
+              },
+              {
+                "slug": "investment-analyst",
+                "title": "Investment Analyst"
+              },
+              {
+                "slug": "physician",
+                "title": "Physician"
+              },
+              {
+                "slug": "data-scientist",
+                "title": "Data Scientist"
+              },
+              {
+                "slug": "frontend-engineer",
+                "title": "Frontend Engineer"
+              }
+            ],
+            "avoid_jobs": [
+              {
+                "slug": "data-scientist",
+                "title": "Data Scientist"
+              },
+              {
+                "slug": "frontend-engineer",
+                "title": "Frontend Engineer"
+              },
+              {
+                "slug": "fullstack-engineer",
+                "title": "Fullstack Engineer"
+              }
+            ],
+            "work_env": "High-autonomy role scope, clear success metrics, and consistent feedback cadence."
+          },
+          "sort_order": 80,
+          "is_enabled": true
+        }
+      ],
+      "seo_meta": {
+        "seo_title": "INTP Personality Guide",
+        "seo_description": "Discover strengths, weaknesses, relationship patterns, and career direction for the INTP personality type.",
+        "canonical_url": null,
+        "og_title": null,
+        "og_description": null,
+        "og_image_url": null,
+        "twitter_title": null,
+        "twitter_description": null,
+        "twitter_image_url": null,
+        "robots": null,
+        "jsonld_overrides_json": null
+      }
+    },
+    {
+      "type_code": "ISFJ",
+      "slug": "isfj",
+      "title": "ISFJ - Defender",
+      "subtitle": null,
+      "excerpt": "Role recommendations and work-environment guidance for ISFJ profiles.",
+      "hero_kicker": "Defender",
+      "hero_quote": null,
+      "hero_image_url": null,
+      "status": "published",
+      "is_public": true,
+      "is_indexable": true,
+      "published_at": null,
+      "scheduled_at": null,
+      "sections": [
+        {
+          "section_key": "core_snapshot",
+          "title": "Core snapshot",
+          "render_variant": "rich_text",
+          "body_md": "Role recommendations and work-environment guidance for ISFJ profiles. This profile tends to do best when goals are explicit, feedback is available, and growth loops stay visible.",
+          "body_html": null,
+          "payload_json": null,
+          "sort_order": 10,
+          "is_enabled": true
+        },
+        {
+          "section_key": "strengths",
+          "title": "Strengths",
+          "render_variant": "bullets",
+          "body_md": null,
+          "body_html": null,
+          "payload_json": {
+            "items": [
+              {
+                "title": "Strategic pattern recognition",
+                "body": null
+              },
+              {
+                "title": "Stable execution under constraints",
+                "body": null
+              },
+              {
+                "title": "Strong ownership on meaningful goals",
+                "body": null
+              }
+            ]
+          },
+          "sort_order": 20,
+          "is_enabled": true
+        },
+        {
+          "section_key": "growth_edges",
+          "title": "Growth edges",
+          "render_variant": "bullets",
+          "body_md": null,
+          "body_html": null,
+          "payload_json": {
+            "items": [
+              {
+                "title": "Over-specialization without cross-functional exposure",
+                "body": null
+              },
+              {
+                "title": "Delayed feedback loops causing slower iteration",
+                "body": null
+              }
+            ]
+          },
+          "sort_order": 30,
+          "is_enabled": true
+        },
+        {
+          "section_key": "work_style",
+          "title": "Work style",
+          "render_variant": "rich_text",
+          "body_md": "High-autonomy role scope, clear success metrics, and consistent feedback cadence.",
+          "body_html": null,
+          "payload_json": null,
+          "sort_order": 40,
+          "is_enabled": true
+        },
+        {
+          "section_key": "relationships",
+          "title": "Relationships",
+          "render_variant": "rich_text",
+          "body_md": "You usually build trust through steady one-on-one conversations, reflection, and protected space. You tend to value people who are reliable, concrete, and consistent in day-to-day follow-through. In conflict you often default to harmony and emotional tone, so it helps to make your principles explicit. In close relationships and teamwork, you usually prefer clarity, commitment, and predictable pace.",
+          "body_html": null,
+          "payload_json": null,
+          "sort_order": 50,
+          "is_enabled": true
+        },
+        {
+          "section_key": "career_fit",
+          "title": "Career fit",
+          "render_variant": "cards",
+          "body_md": "You usually perform best in high-autonomy role scope, clear success metrics, and consistent feedback cadence. Prioritize options like Data Scientist, Frontend Engineer, Fullstack Engineer.",
+          "body_html": null,
+          "payload_json": {
+            "recommended_jobs": [
+              {
+                "slug": "data-scientist",
+                "title": "Data Scientist"
+              },
+              {
+                "slug": "frontend-engineer",
+                "title": "Frontend Engineer"
+              },
+              {
+                "slug": "fullstack-engineer",
+                "title": "Fullstack Engineer"
+              },
+              {
+                "slug": "cloud-architect",
+                "title": "Cloud Architect"
+              },
+              {
+                "slug": "hr-business-partner",
+                "title": "HR Business Partner"
+              },
+              {
+                "slug": "management-consultant",
+                "title": "Management Consultant"
+              }
+            ],
+            "avoid_jobs": [
+              {
+                "slug": "hr-business-partner",
+                "title": "HR Business Partner"
+              },
+              {
+                "slug": "management-consultant",
+                "title": "Management Consultant"
+              },
+              {
+                "slug": "business-analyst",
+                "title": "Business Analyst"
+              }
+            ],
+            "work_env": "High-autonomy role scope, clear success metrics, and consistent feedback cadence."
+          },
+          "sort_order": 80,
+          "is_enabled": true
+        }
+      ],
+      "seo_meta": {
+        "seo_title": "ISFJ Personality Guide",
+        "seo_description": "Discover strengths, weaknesses, relationship patterns, and career direction for the ISFJ personality type.",
+        "canonical_url": null,
+        "og_title": null,
+        "og_description": null,
+        "og_image_url": null,
+        "twitter_title": null,
+        "twitter_description": null,
+        "twitter_image_url": null,
+        "robots": null,
+        "jsonld_overrides_json": null
+      }
+    },
+    {
+      "type_code": "ISFP",
+      "slug": "isfp",
+      "title": "ISFP - Adventurer",
+      "subtitle": null,
+      "excerpt": "Role recommendations and work-environment guidance for ISFP profiles.",
+      "hero_kicker": "Adventurer",
+      "hero_quote": null,
+      "hero_image_url": null,
+      "status": "published",
+      "is_public": true,
+      "is_indexable": true,
+      "published_at": null,
+      "scheduled_at": null,
+      "sections": [
+        {
+          "section_key": "core_snapshot",
+          "title": "Core snapshot",
+          "render_variant": "rich_text",
+          "body_md": "Role recommendations and work-environment guidance for ISFP profiles. This profile tends to do best when goals are explicit, feedback is available, and growth loops stay visible.",
+          "body_html": null,
+          "payload_json": null,
+          "sort_order": 10,
+          "is_enabled": true
+        },
+        {
+          "section_key": "strengths",
+          "title": "Strengths",
+          "render_variant": "bullets",
+          "body_md": null,
+          "body_html": null,
+          "payload_json": {
+            "items": [
+              {
+                "title": "Strategic pattern recognition",
+                "body": null
+              },
+              {
+                "title": "Stable execution under constraints",
+                "body": null
+              },
+              {
+                "title": "Strong ownership on meaningful goals",
+                "body": null
+              }
+            ]
+          },
+          "sort_order": 20,
+          "is_enabled": true
+        },
+        {
+          "section_key": "growth_edges",
+          "title": "Growth edges",
+          "render_variant": "bullets",
+          "body_md": null,
+          "body_html": null,
+          "payload_json": {
+            "items": [
+              {
+                "title": "Over-specialization without cross-functional exposure",
+                "body": null
+              },
+              {
+                "title": "Delayed feedback loops causing slower iteration",
+                "body": null
+              }
+            ]
+          },
+          "sort_order": 30,
+          "is_enabled": true
+        },
+        {
+          "section_key": "work_style",
+          "title": "Work style",
+          "render_variant": "rich_text",
+          "body_md": "High-autonomy role scope, clear success metrics, and consistent feedback cadence.",
+          "body_html": null,
+          "payload_json": null,
+          "sort_order": 40,
+          "is_enabled": true
+        },
+        {
+          "section_key": "relationships",
+          "title": "Relationships",
+          "render_variant": "rich_text",
+          "body_md": "You usually build trust through steady one-on-one conversations, reflection, and protected space. You tend to value people who are reliable, concrete, and consistent in day-to-day follow-through. In conflict you often default to harmony and emotional tone, so it helps to make your principles explicit. In close relationships and teamwork, you usually prefer flexibility, openness, and room to adapt.",
+          "body_html": null,
+          "payload_json": null,
+          "sort_order": 50,
+          "is_enabled": true
+        },
+        {
+          "section_key": "career_fit",
+          "title": "Career fit",
+          "render_variant": "cards",
+          "body_md": "You usually perform best in high-autonomy role scope, clear success metrics, and consistent feedback cadence. Prioritize options like Fullstack Engineer, Cloud Architect, HR Business Partner.",
+          "body_html": null,
+          "payload_json": {
+            "recommended_jobs": [
+              {
+                "slug": "fullstack-engineer",
+                "title": "Fullstack Engineer"
+              },
+              {
+                "slug": "cloud-architect",
+                "title": "Cloud Architect"
+              },
+              {
+                "slug": "hr-business-partner",
+                "title": "HR Business Partner"
+              },
+              {
+                "slug": "management-consultant",
+                "title": "Management Consultant"
+              },
+              {
+                "slug": "business-analyst",
+                "title": "Business Analyst"
+              },
+              {
+                "slug": "brand-manager",
+                "title": "Brand Manager"
+              }
+            ],
+            "avoid_jobs": [
+              {
+                "slug": "business-analyst",
+                "title": "Business Analyst"
+              },
+              {
+                "slug": "brand-manager",
+                "title": "Brand Manager"
+              },
+              {
+                "slug": "nurse",
+                "title": "Nurse"
+              }
+            ],
+            "work_env": "High-autonomy role scope, clear success metrics, and consistent feedback cadence."
+          },
+          "sort_order": 80,
+          "is_enabled": true
+        }
+      ],
+      "seo_meta": {
+        "seo_title": "ISFP Personality Guide",
+        "seo_description": "Discover strengths, weaknesses, relationship patterns, and career direction for the ISFP personality type.",
+        "canonical_url": null,
+        "og_title": null,
+        "og_description": null,
+        "og_image_url": null,
+        "twitter_title": null,
+        "twitter_description": null,
+        "twitter_image_url": null,
+        "robots": null,
+        "jsonld_overrides_json": null
+      }
+    },
+    {
+      "type_code": "ISTJ",
+      "slug": "istj",
+      "title": "ISTJ - Logistician",
+      "subtitle": null,
+      "excerpt": "Role recommendations and work-environment guidance for ISTJ profiles.",
+      "hero_kicker": "Logistician",
+      "hero_quote": null,
+      "hero_image_url": null,
+      "status": "published",
+      "is_public": true,
+      "is_indexable": true,
+      "published_at": null,
+      "scheduled_at": null,
+      "sections": [
+        {
+          "section_key": "core_snapshot",
+          "title": "Core snapshot",
+          "render_variant": "rich_text",
+          "body_md": "Role recommendations and work-environment guidance for ISTJ profiles. This profile tends to do best when goals are explicit, feedback is available, and growth loops stay visible.",
+          "body_html": null,
+          "payload_json": null,
+          "sort_order": 10,
+          "is_enabled": true
+        },
+        {
+          "section_key": "strengths",
+          "title": "Strengths",
+          "render_variant": "bullets",
+          "body_md": null,
+          "body_html": null,
+          "payload_json": {
+            "items": [
+              {
+                "title": "Strategic pattern recognition",
+                "body": null
+              },
+              {
+                "title": "Stable execution under constraints",
+                "body": null
+              },
+              {
+                "title": "Strong ownership on meaningful goals",
+                "body": null
+              }
+            ]
+          },
+          "sort_order": 20,
+          "is_enabled": true
+        },
+        {
+          "section_key": "growth_edges",
+          "title": "Growth edges",
+          "render_variant": "bullets",
+          "body_md": null,
+          "body_html": null,
+          "payload_json": {
+            "items": [
+              {
+                "title": "Over-specialization without cross-functional exposure",
+                "body": null
+              },
+              {
+                "title": "Delayed feedback loops causing slower iteration",
+                "body": null
+              }
+            ]
+          },
+          "sort_order": 30,
+          "is_enabled": true
+        },
+        {
+          "section_key": "work_style",
+          "title": "Work style",
+          "render_variant": "rich_text",
+          "body_md": "High-autonomy role scope, clear success metrics, and consistent feedback cadence.",
+          "body_html": null,
+          "payload_json": null,
+          "sort_order": 40,
+          "is_enabled": true
+        },
+        {
+          "section_key": "relationships",
+          "title": "Relationships",
+          "render_variant": "rich_text",
+          "body_md": "You usually build trust through steady one-on-one conversations, reflection, and protected space. You tend to value people who are reliable, concrete, and consistent in day-to-day follow-through. In conflict you often default to logic and boundaries, so it helps to add explicit emotional acknowledgment. In close relationships and teamwork, you usually prefer clarity, commitment, and predictable pace.",
+          "body_html": null,
+          "payload_json": null,
+          "sort_order": 50,
+          "is_enabled": true
+        },
+        {
+          "section_key": "career_fit",
+          "title": "Career fit",
+          "render_variant": "cards",
+          "body_md": "You usually perform best in high-autonomy role scope, clear success metrics, and consistent feedback cadence. Prioritize options like Teacher, Machine Learning Engineer, Backend Engineer.",
+          "body_html": null,
+          "payload_json": {
+            "recommended_jobs": [
+              {
+                "slug": "teacher",
+                "title": "Teacher"
+              },
+              {
+                "slug": "machine-learning-engineer",
+                "title": "Machine Learning Engineer"
+              },
+              {
+                "slug": "backend-engineer",
+                "title": "Backend Engineer"
+              },
+              {
+                "slug": "cybersecurity-analyst",
+                "title": "Cybersecurity Analyst"
+              },
+              {
+                "slug": "operations-manager",
+                "title": "Operations Manager"
+              },
+              {
+                "slug": "sales-manager",
+                "title": "Sales Manager"
+              }
+            ],
+            "avoid_jobs": [
+              {
+                "slug": "operations-manager",
+                "title": "Operations Manager"
+              },
+              {
+                "slug": "sales-manager",
+                "title": "Sales Manager"
+              },
+              {
+                "slug": "financial-planner",
+                "title": "Financial Planner"
+              }
+            ],
+            "work_env": "High-autonomy role scope, clear success metrics, and consistent feedback cadence."
+          },
+          "sort_order": 80,
+          "is_enabled": true
+        }
+      ],
+      "seo_meta": {
+        "seo_title": "ISTJ Personality Guide",
+        "seo_description": "Discover strengths, weaknesses, relationship patterns, and career direction for the ISTJ personality type.",
+        "canonical_url": null,
+        "og_title": null,
+        "og_description": null,
+        "og_image_url": null,
+        "twitter_title": null,
+        "twitter_description": null,
+        "twitter_image_url": null,
+        "robots": null,
+        "jsonld_overrides_json": null
+      }
+    },
+    {
+      "type_code": "ISTP",
+      "slug": "istp",
+      "title": "ISTP - Virtuoso",
+      "subtitle": null,
+      "excerpt": "Role recommendations and work-environment guidance for ISTP profiles.",
+      "hero_kicker": "Virtuoso",
+      "hero_quote": null,
+      "hero_image_url": null,
+      "status": "published",
+      "is_public": true,
+      "is_indexable": true,
+      "published_at": null,
+      "scheduled_at": null,
+      "sections": [
+        {
+          "section_key": "core_snapshot",
+          "title": "Core snapshot",
+          "render_variant": "rich_text",
+          "body_md": "Role recommendations and work-environment guidance for ISTP profiles. This profile tends to do best when goals are explicit, feedback is available, and growth loops stay visible.",
+          "body_html": null,
+          "payload_json": null,
+          "sort_order": 10,
+          "is_enabled": true
+        },
+        {
+          "section_key": "strengths",
+          "title": "Strengths",
+          "render_variant": "bullets",
+          "body_md": null,
+          "body_html": null,
+          "payload_json": {
+            "items": [
+              {
+                "title": "Strategic pattern recognition",
+                "body": null
+              },
+              {
+                "title": "Stable execution under constraints",
+                "body": null
+              },
+              {
+                "title": "Strong ownership on meaningful goals",
+                "body": null
+              }
+            ]
+          },
+          "sort_order": 20,
+          "is_enabled": true
+        },
+        {
+          "section_key": "growth_edges",
+          "title": "Growth edges",
+          "render_variant": "bullets",
+          "body_md": null,
+          "body_html": null,
+          "payload_json": {
+            "items": [
+              {
+                "title": "Over-specialization without cross-functional exposure",
+                "body": null
+              },
+              {
+                "title": "Delayed feedback loops causing slower iteration",
+                "body": null
+              }
+            ]
+          },
+          "sort_order": 30,
+          "is_enabled": true
+        },
+        {
+          "section_key": "work_style",
+          "title": "Work style",
+          "render_variant": "rich_text",
+          "body_md": "High-autonomy role scope, clear success metrics, and consistent feedback cadence.",
+          "body_html": null,
+          "payload_json": null,
+          "sort_order": 40,
+          "is_enabled": true
+        },
+        {
+          "section_key": "relationships",
+          "title": "Relationships",
+          "render_variant": "rich_text",
+          "body_md": "You usually build trust through steady one-on-one conversations, reflection, and protected space. You tend to value people who are reliable, concrete, and consistent in day-to-day follow-through. In conflict you often default to logic and boundaries, so it helps to add explicit emotional acknowledgment. In close relationships and teamwork, you usually prefer flexibility, openness, and room to adapt.",
+          "body_html": null,
+          "payload_json": null,
+          "sort_order": 50,
+          "is_enabled": true
+        },
+        {
+          "section_key": "career_fit",
+          "title": "Career fit",
+          "render_variant": "cards",
+          "body_md": "You usually perform best in high-autonomy role scope, clear success metrics, and consistent feedback cadence. Prioritize options like Backend Engineer, Cybersecurity Analyst, Operations Manager.",
+          "body_html": null,
+          "payload_json": {
+            "recommended_jobs": [
+              {
+                "slug": "backend-engineer",
+                "title": "Backend Engineer"
+              },
+              {
+                "slug": "cybersecurity-analyst",
+                "title": "Cybersecurity Analyst"
+              },
+              {
+                "slug": "operations-manager",
+                "title": "Operations Manager"
+              },
+              {
+                "slug": "sales-manager",
+                "title": "Sales Manager"
+              },
+              {
+                "slug": "financial-planner",
+                "title": "Financial Planner"
+              },
+              {
+                "slug": "content-strategist",
+                "title": "Content Strategist"
+              }
+            ],
+            "avoid_jobs": [
+              {
+                "slug": "financial-planner",
+                "title": "Financial Planner"
+              },
+              {
+                "slug": "content-strategist",
+                "title": "Content Strategist"
+              },
+              {
+                "slug": "researcher",
+                "title": "Researcher"
+              }
+            ],
+            "work_env": "High-autonomy role scope, clear success metrics, and consistent feedback cadence."
+          },
+          "sort_order": 80,
+          "is_enabled": true
+        }
+      ],
+      "seo_meta": {
+        "seo_title": "ISTP Personality Guide",
+        "seo_description": "Discover strengths, weaknesses, relationship patterns, and career direction for the ISTP personality type.",
+        "canonical_url": null,
+        "og_title": null,
+        "og_description": null,
+        "og_image_url": null,
+        "twitter_title": null,
+        "twitter_description": null,
+        "twitter_image_url": null,
+        "robots": null,
+        "jsonld_overrides_json": null
+      }
+    }
+  ]
+}

--- a/content_baselines/personality/mbti.zh-CN.json
+++ b/content_baselines/personality/mbti.zh-CN.json
@@ -1,0 +1,2539 @@
+{
+  "meta": {
+    "schema_version": "v1",
+    "scale_code": "MBTI",
+    "locale": "zh-CN",
+    "source": "fap-web careerRecommendationProfiles + personality.ts deterministic transforms",
+    "generated_at": "2026-03-08T00:00:00Z"
+  },
+  "profiles": [
+    {
+      "type_code": "ENFJ",
+      "slug": "enfj",
+      "title": "ENFJ - 主人公",
+      "subtitle": null,
+      "excerpt": "基于 ENFJ 人格画像的职业建议与工作环境匹配策略。",
+      "hero_kicker": "主人公",
+      "hero_quote": null,
+      "hero_image_url": null,
+      "status": "published",
+      "is_public": true,
+      "is_indexable": true,
+      "published_at": null,
+      "scheduled_at": null,
+      "sections": [
+        {
+          "section_key": "core_snapshot",
+          "title": "核心概览",
+          "render_variant": "rich_text",
+          "body_md": "基于 ENFJ 人格画像的职业建议与工作环境匹配策略。 这类人格通常在目标清晰、反馈可获得、能够持续迭代的环境里更容易稳定发挥。",
+          "body_html": null,
+          "payload_json": null,
+          "sort_order": 10,
+          "is_enabled": true
+        },
+        {
+          "section_key": "strengths",
+          "title": "优势",
+          "render_variant": "bullets",
+          "body_md": null,
+          "body_html": null,
+          "payload_json": {
+            "items": [
+              {
+                "title": "战略性模式识别",
+                "body": null
+              },
+              {
+                "title": "在约束下保持执行稳定",
+                "body": null
+              },
+              {
+                "title": "对关键目标具备持续投入能力",
+                "body": null
+              }
+            ]
+          },
+          "sort_order": 20,
+          "is_enabled": true
+        },
+        {
+          "section_key": "growth_edges",
+          "title": "成长边界",
+          "render_variant": "bullets",
+          "body_md": null,
+          "body_html": null,
+          "payload_json": {
+            "items": [
+              {
+                "title": "过度单一专精导致横向能力不足",
+                "body": null
+              },
+              {
+                "title": "反馈周期过长影响迭代速度",
+                "body": null
+              }
+            ]
+          },
+          "sort_order": 30,
+          "is_enabled": true
+        },
+        {
+          "section_key": "work_style",
+          "title": "工作风格",
+          "render_variant": "rich_text",
+          "body_md": "高自主度、目标清晰、反馈节奏稳定的工作环境。",
+          "body_html": null,
+          "payload_json": null,
+          "sort_order": 40,
+          "is_enabled": true
+        },
+        {
+          "section_key": "relationships",
+          "title": "关系模式",
+          "render_variant": "rich_text",
+          "body_md": "你往往通过直接交流、共同经历和快速反馈来建立关系。你倾向于和能讨论长期可能性、模式和意义的人建立更深连接。在冲突里你通常优先照顾感受和氛围，因此需要主动讲清原则和底线。亲密关系与协作关系里，你通常更喜欢明确承诺、稳定节奏和可预期安排。",
+          "body_html": null,
+          "payload_json": null,
+          "sort_order": 50,
+          "is_enabled": true
+        },
+        {
+          "section_key": "career_fit",
+          "title": "职业匹配",
+          "render_variant": "cards",
+          "body_md": "你通常更适合在高自主度、目标清晰、反馈节奏稳定的工作环境中发挥优势。优先探索这些方向：律师, 教师, 机器学习工程师。",
+          "body_html": null,
+          "payload_json": {
+            "recommended_jobs": [
+              {
+                "slug": "lawyer",
+                "title": "律师"
+              },
+              {
+                "slug": "teacher",
+                "title": "教师"
+              },
+              {
+                "slug": "machine-learning-engineer",
+                "title": "机器学习工程师"
+              },
+              {
+                "slug": "backend-engineer",
+                "title": "后端工程师"
+              },
+              {
+                "slug": "cybersecurity-analyst",
+                "title": "网络安全分析师"
+              },
+              {
+                "slug": "operations-manager",
+                "title": "运营经理"
+              }
+            ],
+            "avoid_jobs": [
+              {
+                "slug": "cybersecurity-analyst",
+                "title": "网络安全分析师"
+              },
+              {
+                "slug": "operations-manager",
+                "title": "运营经理"
+              },
+              {
+                "slug": "sales-manager",
+                "title": "销售经理"
+              }
+            ],
+            "work_env": "高自主度、目标清晰、反馈节奏稳定的工作环境。"
+          },
+          "sort_order": 80,
+          "is_enabled": true
+        }
+      ],
+      "seo_meta": {
+        "seo_title": "ENFJ 人格指南",
+        "seo_description": "了解 ENFJ 的优势、弱项、人际模式和职业方向。",
+        "canonical_url": null,
+        "og_title": null,
+        "og_description": null,
+        "og_image_url": null,
+        "twitter_title": null,
+        "twitter_description": null,
+        "twitter_image_url": null,
+        "robots": null,
+        "jsonld_overrides_json": null
+      }
+    },
+    {
+      "type_code": "ENFP",
+      "slug": "enfp",
+      "title": "ENFP - 竞选者",
+      "subtitle": null,
+      "excerpt": "基于 ENFP 人格画像的职业建议与工作环境匹配策略。",
+      "hero_kicker": "竞选者",
+      "hero_quote": null,
+      "hero_image_url": null,
+      "status": "published",
+      "is_public": true,
+      "is_indexable": true,
+      "published_at": null,
+      "scheduled_at": null,
+      "sections": [
+        {
+          "section_key": "core_snapshot",
+          "title": "核心概览",
+          "render_variant": "rich_text",
+          "body_md": "基于 ENFP 人格画像的职业建议与工作环境匹配策略。 这类人格通常在目标清晰、反馈可获得、能够持续迭代的环境里更容易稳定发挥。",
+          "body_html": null,
+          "payload_json": null,
+          "sort_order": 10,
+          "is_enabled": true
+        },
+        {
+          "section_key": "strengths",
+          "title": "优势",
+          "render_variant": "bullets",
+          "body_md": null,
+          "body_html": null,
+          "payload_json": {
+            "items": [
+              {
+                "title": "战略性模式识别",
+                "body": null
+              },
+              {
+                "title": "在约束下保持执行稳定",
+                "body": null
+              },
+              {
+                "title": "对关键目标具备持续投入能力",
+                "body": null
+              }
+            ]
+          },
+          "sort_order": 20,
+          "is_enabled": true
+        },
+        {
+          "section_key": "growth_edges",
+          "title": "成长边界",
+          "render_variant": "bullets",
+          "body_md": null,
+          "body_html": null,
+          "payload_json": {
+            "items": [
+              {
+                "title": "过度单一专精导致横向能力不足",
+                "body": null
+              },
+              {
+                "title": "反馈周期过长影响迭代速度",
+                "body": null
+              }
+            ]
+          },
+          "sort_order": 30,
+          "is_enabled": true
+        },
+        {
+          "section_key": "work_style",
+          "title": "工作风格",
+          "render_variant": "rich_text",
+          "body_md": "高自主度、目标清晰、反馈节奏稳定的工作环境。",
+          "body_html": null,
+          "payload_json": null,
+          "sort_order": 40,
+          "is_enabled": true
+        },
+        {
+          "section_key": "relationships",
+          "title": "关系模式",
+          "render_variant": "rich_text",
+          "body_md": "你往往通过直接交流、共同经历和快速反馈来建立关系。你倾向于和能讨论长期可能性、模式和意义的人建立更深连接。在冲突里你通常优先照顾感受和氛围，因此需要主动讲清原则和底线。亲密关系与协作关系里，你通常更喜欢弹性空间、自然推进和保留选择余地。",
+          "body_html": null,
+          "payload_json": null,
+          "sort_order": 50,
+          "is_enabled": true
+        },
+        {
+          "section_key": "career_fit",
+          "title": "职业匹配",
+          "render_variant": "cards",
+          "body_md": "你通常更适合在高自主度、目标清晰、反馈节奏稳定的工作环境中发挥优势。优先探索这些方向：医生, 数据科学家, 前端工程师。",
+          "body_html": null,
+          "payload_json": {
+            "recommended_jobs": [
+              {
+                "slug": "physician",
+                "title": "医生"
+              },
+              {
+                "slug": "data-scientist",
+                "title": "数据科学家"
+              },
+              {
+                "slug": "frontend-engineer",
+                "title": "前端工程师"
+              },
+              {
+                "slug": "fullstack-engineer",
+                "title": "全栈工程师"
+              },
+              {
+                "slug": "cloud-architect",
+                "title": "云架构师"
+              },
+              {
+                "slug": "hr-business-partner",
+                "title": "HRBP"
+              }
+            ],
+            "avoid_jobs": [
+              {
+                "slug": "cloud-architect",
+                "title": "云架构师"
+              },
+              {
+                "slug": "hr-business-partner",
+                "title": "HRBP"
+              },
+              {
+                "slug": "management-consultant",
+                "title": "管理咨询顾问"
+              }
+            ],
+            "work_env": "高自主度、目标清晰、反馈节奏稳定的工作环境。"
+          },
+          "sort_order": 80,
+          "is_enabled": true
+        }
+      ],
+      "seo_meta": {
+        "seo_title": "ENFP 人格指南",
+        "seo_description": "了解 ENFP 的优势、弱项、人际模式和职业方向。",
+        "canonical_url": null,
+        "og_title": null,
+        "og_description": null,
+        "og_image_url": null,
+        "twitter_title": null,
+        "twitter_description": null,
+        "twitter_image_url": null,
+        "robots": null,
+        "jsonld_overrides_json": null
+      }
+    },
+    {
+      "type_code": "ENTJ",
+      "slug": "entj",
+      "title": "ENTJ - 指挥官",
+      "subtitle": null,
+      "excerpt": "基于 ENTJ 人格画像的职业建议与工作环境匹配策略。",
+      "hero_kicker": "指挥官",
+      "hero_quote": null,
+      "hero_image_url": null,
+      "status": "published",
+      "is_public": true,
+      "is_indexable": true,
+      "published_at": null,
+      "scheduled_at": null,
+      "sections": [
+        {
+          "section_key": "core_snapshot",
+          "title": "核心概览",
+          "render_variant": "rich_text",
+          "body_md": "基于 ENTJ 人格画像的职业建议与工作环境匹配策略。 这类人格通常在目标清晰、反馈可获得、能够持续迭代的环境里更容易稳定发挥。",
+          "body_html": null,
+          "payload_json": null,
+          "sort_order": 10,
+          "is_enabled": true
+        },
+        {
+          "section_key": "strengths",
+          "title": "优势",
+          "render_variant": "bullets",
+          "body_md": null,
+          "body_html": null,
+          "payload_json": {
+            "items": [
+              {
+                "title": "战略性模式识别",
+                "body": null
+              },
+              {
+                "title": "在约束下保持执行稳定",
+                "body": null
+              },
+              {
+                "title": "对关键目标具备持续投入能力",
+                "body": null
+              }
+            ]
+          },
+          "sort_order": 20,
+          "is_enabled": true
+        },
+        {
+          "section_key": "growth_edges",
+          "title": "成长边界",
+          "render_variant": "bullets",
+          "body_md": null,
+          "body_html": null,
+          "payload_json": {
+            "items": [
+              {
+                "title": "过度单一专精导致横向能力不足",
+                "body": null
+              },
+              {
+                "title": "反馈周期过长影响迭代速度",
+                "body": null
+              }
+            ]
+          },
+          "sort_order": 30,
+          "is_enabled": true
+        },
+        {
+          "section_key": "work_style",
+          "title": "工作风格",
+          "render_variant": "rich_text",
+          "body_md": "高自主度、目标清晰、反馈节奏稳定的工作环境。",
+          "body_html": null,
+          "payload_json": null,
+          "sort_order": 40,
+          "is_enabled": true
+        },
+        {
+          "section_key": "relationships",
+          "title": "关系模式",
+          "render_variant": "rich_text",
+          "body_md": "你往往通过直接交流、共同经历和快速反馈来建立关系。你倾向于和能讨论长期可能性、模式和意义的人建立更深连接。在冲突里你通常优先讲逻辑和边界，因此需要主动补充情绪确认。亲密关系与协作关系里，你通常更喜欢明确承诺、稳定节奏和可预期安排。",
+          "body_html": null,
+          "payload_json": null,
+          "sort_order": 50,
+          "is_enabled": true
+        },
+        {
+          "section_key": "career_fit",
+          "title": "职业匹配",
+          "render_variant": "cards",
+          "body_md": "你通常更适合在高自主度、目标清晰、反馈节奏稳定的工作环境中发挥优势。优先探索这些方向：UI/UX 设计师, 数字营销经理, 律师。",
+          "body_html": null,
+          "payload_json": {
+            "recommended_jobs": [
+              {
+                "slug": "ui-ux-designer",
+                "title": "UI/UX 设计师"
+              },
+              {
+                "slug": "digital-marketing-manager",
+                "title": "数字营销经理"
+              },
+              {
+                "slug": "lawyer",
+                "title": "律师"
+              },
+              {
+                "slug": "teacher",
+                "title": "教师"
+              },
+              {
+                "slug": "machine-learning-engineer",
+                "title": "机器学习工程师"
+              },
+              {
+                "slug": "backend-engineer",
+                "title": "后端工程师"
+              }
+            ],
+            "avoid_jobs": [
+              {
+                "slug": "machine-learning-engineer",
+                "title": "机器学习工程师"
+              },
+              {
+                "slug": "backend-engineer",
+                "title": "后端工程师"
+              },
+              {
+                "slug": "cybersecurity-analyst",
+                "title": "网络安全分析师"
+              }
+            ],
+            "work_env": "高自主度、目标清晰、反馈节奏稳定的工作环境。"
+          },
+          "sort_order": 80,
+          "is_enabled": true
+        }
+      ],
+      "seo_meta": {
+        "seo_title": "ENTJ 人格指南",
+        "seo_description": "了解 ENTJ 的优势、弱项、人际模式和职业方向。",
+        "canonical_url": null,
+        "og_title": null,
+        "og_description": null,
+        "og_image_url": null,
+        "twitter_title": null,
+        "twitter_description": null,
+        "twitter_image_url": null,
+        "robots": null,
+        "jsonld_overrides_json": null
+      }
+    },
+    {
+      "type_code": "ENTP",
+      "slug": "entp",
+      "title": "ENTP - 辩论家",
+      "subtitle": null,
+      "excerpt": "基于 ENTP 人格画像的职业建议与工作环境匹配策略。",
+      "hero_kicker": "辩论家",
+      "hero_quote": null,
+      "hero_image_url": null,
+      "status": "published",
+      "is_public": true,
+      "is_indexable": true,
+      "published_at": null,
+      "scheduled_at": null,
+      "sections": [
+        {
+          "section_key": "core_snapshot",
+          "title": "核心概览",
+          "render_variant": "rich_text",
+          "body_md": "基于 ENTP 人格画像的职业建议与工作环境匹配策略。 这类人格通常在目标清晰、反馈可获得、能够持续迭代的环境里更容易稳定发挥。",
+          "body_html": null,
+          "payload_json": null,
+          "sort_order": 10,
+          "is_enabled": true
+        },
+        {
+          "section_key": "strengths",
+          "title": "优势",
+          "render_variant": "bullets",
+          "body_md": null,
+          "body_html": null,
+          "payload_json": {
+            "items": [
+              {
+                "title": "战略性模式识别",
+                "body": null
+              },
+              {
+                "title": "在约束下保持执行稳定",
+                "body": null
+              },
+              {
+                "title": "对关键目标具备持续投入能力",
+                "body": null
+              }
+            ]
+          },
+          "sort_order": 20,
+          "is_enabled": true
+        },
+        {
+          "section_key": "growth_edges",
+          "title": "成长边界",
+          "render_variant": "bullets",
+          "body_md": null,
+          "body_html": null,
+          "payload_json": {
+            "items": [
+              {
+                "title": "过度单一专精导致横向能力不足",
+                "body": null
+              },
+              {
+                "title": "反馈周期过长影响迭代速度",
+                "body": null
+              }
+            ]
+          },
+          "sort_order": 30,
+          "is_enabled": true
+        },
+        {
+          "section_key": "work_style",
+          "title": "工作风格",
+          "render_variant": "rich_text",
+          "body_md": "高自主度、目标清晰、反馈节奏稳定的工作环境。",
+          "body_html": null,
+          "payload_json": null,
+          "sort_order": 40,
+          "is_enabled": true
+        },
+        {
+          "section_key": "relationships",
+          "title": "关系模式",
+          "render_variant": "rich_text",
+          "body_md": "你往往通过直接交流、共同经历和快速反馈来建立关系。你倾向于和能讨论长期可能性、模式和意义的人建立更深连接。在冲突里你通常优先讲逻辑和边界，因此需要主动补充情绪确认。亲密关系与协作关系里，你通常更喜欢弹性空间、自然推进和保留选择余地。",
+          "body_html": null,
+          "payload_json": null,
+          "sort_order": 50,
+          "is_enabled": true
+        },
+        {
+          "section_key": "career_fit",
+          "title": "职业匹配",
+          "render_variant": "cards",
+          "body_md": "你通常更适合在高自主度、目标清晰、反馈节奏稳定的工作环境中发挥优势。优先探索这些方向：心理咨询师, 投资分析师, 医生。",
+          "body_html": null,
+          "payload_json": {
+            "recommended_jobs": [
+              {
+                "slug": "psychological-counselor",
+                "title": "心理咨询师"
+              },
+              {
+                "slug": "investment-analyst",
+                "title": "投资分析师"
+              },
+              {
+                "slug": "physician",
+                "title": "医生"
+              },
+              {
+                "slug": "data-scientist",
+                "title": "数据科学家"
+              },
+              {
+                "slug": "frontend-engineer",
+                "title": "前端工程师"
+              },
+              {
+                "slug": "fullstack-engineer",
+                "title": "全栈工程师"
+              }
+            ],
+            "avoid_jobs": [
+              {
+                "slug": "frontend-engineer",
+                "title": "前端工程师"
+              },
+              {
+                "slug": "fullstack-engineer",
+                "title": "全栈工程师"
+              },
+              {
+                "slug": "cloud-architect",
+                "title": "云架构师"
+              }
+            ],
+            "work_env": "高自主度、目标清晰、反馈节奏稳定的工作环境。"
+          },
+          "sort_order": 80,
+          "is_enabled": true
+        }
+      ],
+      "seo_meta": {
+        "seo_title": "ENTP 人格指南",
+        "seo_description": "了解 ENTP 的优势、弱项、人际模式和职业方向。",
+        "canonical_url": null,
+        "og_title": null,
+        "og_description": null,
+        "og_image_url": null,
+        "twitter_title": null,
+        "twitter_description": null,
+        "twitter_image_url": null,
+        "robots": null,
+        "jsonld_overrides_json": null
+      }
+    },
+    {
+      "type_code": "ESFJ",
+      "slug": "esfj",
+      "title": "ESFJ - 执政官",
+      "subtitle": null,
+      "excerpt": "基于 ESFJ 人格画像的职业建议与工作环境匹配策略。",
+      "hero_kicker": "执政官",
+      "hero_quote": null,
+      "hero_image_url": null,
+      "status": "published",
+      "is_public": true,
+      "is_indexable": true,
+      "published_at": null,
+      "scheduled_at": null,
+      "sections": [
+        {
+          "section_key": "core_snapshot",
+          "title": "核心概览",
+          "render_variant": "rich_text",
+          "body_md": "基于 ESFJ 人格画像的职业建议与工作环境匹配策略。 这类人格通常在目标清晰、反馈可获得、能够持续迭代的环境里更容易稳定发挥。",
+          "body_html": null,
+          "payload_json": null,
+          "sort_order": 10,
+          "is_enabled": true
+        },
+        {
+          "section_key": "strengths",
+          "title": "优势",
+          "render_variant": "bullets",
+          "body_md": null,
+          "body_html": null,
+          "payload_json": {
+            "items": [
+              {
+                "title": "战略性模式识别",
+                "body": null
+              },
+              {
+                "title": "在约束下保持执行稳定",
+                "body": null
+              },
+              {
+                "title": "对关键目标具备持续投入能力",
+                "body": null
+              }
+            ]
+          },
+          "sort_order": 20,
+          "is_enabled": true
+        },
+        {
+          "section_key": "growth_edges",
+          "title": "成长边界",
+          "render_variant": "bullets",
+          "body_md": null,
+          "body_html": null,
+          "payload_json": {
+            "items": [
+              {
+                "title": "过度单一专精导致横向能力不足",
+                "body": null
+              },
+              {
+                "title": "反馈周期过长影响迭代速度",
+                "body": null
+              }
+            ]
+          },
+          "sort_order": 30,
+          "is_enabled": true
+        },
+        {
+          "section_key": "work_style",
+          "title": "工作风格",
+          "render_variant": "rich_text",
+          "body_md": "高自主度、目标清晰、反馈节奏稳定的工作环境。",
+          "body_html": null,
+          "payload_json": null,
+          "sort_order": 40,
+          "is_enabled": true
+        },
+        {
+          "section_key": "relationships",
+          "title": "关系模式",
+          "render_variant": "rich_text",
+          "body_md": "你往往通过直接交流、共同经历和快速反馈来建立关系。你更看重现实可靠、说到做到和细节可落地的人际互动。在冲突里你通常优先照顾感受和氛围，因此需要主动讲清原则和底线。亲密关系与协作关系里，你通常更喜欢明确承诺、稳定节奏和可预期安排。",
+          "body_html": null,
+          "payload_json": null,
+          "sort_order": 50,
+          "is_enabled": true
+        },
+        {
+          "section_key": "career_fit",
+          "title": "职业匹配",
+          "render_variant": "cards",
+          "body_md": "你通常更适合在高自主度、目标清晰、反馈节奏稳定的工作环境中发挥优势。优先探索这些方向：前端工程师, 全栈工程师, 云架构师。",
+          "body_html": null,
+          "payload_json": {
+            "recommended_jobs": [
+              {
+                "slug": "frontend-engineer",
+                "title": "前端工程师"
+              },
+              {
+                "slug": "fullstack-engineer",
+                "title": "全栈工程师"
+              },
+              {
+                "slug": "cloud-architect",
+                "title": "云架构师"
+              },
+              {
+                "slug": "hr-business-partner",
+                "title": "HRBP"
+              },
+              {
+                "slug": "management-consultant",
+                "title": "管理咨询顾问"
+              },
+              {
+                "slug": "business-analyst",
+                "title": "商业分析师"
+              }
+            ],
+            "avoid_jobs": [
+              {
+                "slug": "management-consultant",
+                "title": "管理咨询顾问"
+              },
+              {
+                "slug": "business-analyst",
+                "title": "商业分析师"
+              },
+              {
+                "slug": "brand-manager",
+                "title": "品牌经理"
+              }
+            ],
+            "work_env": "高自主度、目标清晰、反馈节奏稳定的工作环境。"
+          },
+          "sort_order": 80,
+          "is_enabled": true
+        }
+      ],
+      "seo_meta": {
+        "seo_title": "ESFJ 人格指南",
+        "seo_description": "了解 ESFJ 的优势、弱项、人际模式和职业方向。",
+        "canonical_url": null,
+        "og_title": null,
+        "og_description": null,
+        "og_image_url": null,
+        "twitter_title": null,
+        "twitter_description": null,
+        "twitter_image_url": null,
+        "robots": null,
+        "jsonld_overrides_json": null
+      }
+    },
+    {
+      "type_code": "ESFP",
+      "slug": "esfp",
+      "title": "ESFP - 表演者",
+      "subtitle": null,
+      "excerpt": "基于 ESFP 人格画像的职业建议与工作环境匹配策略。",
+      "hero_kicker": "表演者",
+      "hero_quote": null,
+      "hero_image_url": null,
+      "status": "published",
+      "is_public": true,
+      "is_indexable": true,
+      "published_at": null,
+      "scheduled_at": null,
+      "sections": [
+        {
+          "section_key": "core_snapshot",
+          "title": "核心概览",
+          "render_variant": "rich_text",
+          "body_md": "基于 ESFP 人格画像的职业建议与工作环境匹配策略。 这类人格通常在目标清晰、反馈可获得、能够持续迭代的环境里更容易稳定发挥。",
+          "body_html": null,
+          "payload_json": null,
+          "sort_order": 10,
+          "is_enabled": true
+        },
+        {
+          "section_key": "strengths",
+          "title": "优势",
+          "render_variant": "bullets",
+          "body_md": null,
+          "body_html": null,
+          "payload_json": {
+            "items": [
+              {
+                "title": "战略性模式识别",
+                "body": null
+              },
+              {
+                "title": "在约束下保持执行稳定",
+                "body": null
+              },
+              {
+                "title": "对关键目标具备持续投入能力",
+                "body": null
+              }
+            ]
+          },
+          "sort_order": 20,
+          "is_enabled": true
+        },
+        {
+          "section_key": "growth_edges",
+          "title": "成长边界",
+          "render_variant": "bullets",
+          "body_md": null,
+          "body_html": null,
+          "payload_json": {
+            "items": [
+              {
+                "title": "过度单一专精导致横向能力不足",
+                "body": null
+              },
+              {
+                "title": "反馈周期过长影响迭代速度",
+                "body": null
+              }
+            ]
+          },
+          "sort_order": 30,
+          "is_enabled": true
+        },
+        {
+          "section_key": "work_style",
+          "title": "工作风格",
+          "render_variant": "rich_text",
+          "body_md": "高自主度、目标清晰、反馈节奏稳定的工作环境。",
+          "body_html": null,
+          "payload_json": null,
+          "sort_order": 40,
+          "is_enabled": true
+        },
+        {
+          "section_key": "relationships",
+          "title": "关系模式",
+          "render_variant": "rich_text",
+          "body_md": "你往往通过直接交流、共同经历和快速反馈来建立关系。你更看重现实可靠、说到做到和细节可落地的人际互动。在冲突里你通常优先照顾感受和氛围，因此需要主动讲清原则和底线。亲密关系与协作关系里，你通常更喜欢弹性空间、自然推进和保留选择余地。",
+          "body_html": null,
+          "payload_json": null,
+          "sort_order": 50,
+          "is_enabled": true
+        },
+        {
+          "section_key": "career_fit",
+          "title": "职业匹配",
+          "render_variant": "cards",
+          "body_md": "你通常更适合在高自主度、目标清晰、反馈节奏稳定的工作环境中发挥优势。优先探索这些方向：云架构师, HRBP, 管理咨询顾问。",
+          "body_html": null,
+          "payload_json": {
+            "recommended_jobs": [
+              {
+                "slug": "cloud-architect",
+                "title": "云架构师"
+              },
+              {
+                "slug": "hr-business-partner",
+                "title": "HRBP"
+              },
+              {
+                "slug": "management-consultant",
+                "title": "管理咨询顾问"
+              },
+              {
+                "slug": "business-analyst",
+                "title": "商业分析师"
+              },
+              {
+                "slug": "brand-manager",
+                "title": "品牌经理"
+              },
+              {
+                "slug": "nurse",
+                "title": "护士"
+              }
+            ],
+            "avoid_jobs": [
+              {
+                "slug": "brand-manager",
+                "title": "品牌经理"
+              },
+              {
+                "slug": "nurse",
+                "title": "护士"
+              },
+              {
+                "slug": "supply-chain-manager",
+                "title": "供应链经理"
+              }
+            ],
+            "work_env": "高自主度、目标清晰、反馈节奏稳定的工作环境。"
+          },
+          "sort_order": 80,
+          "is_enabled": true
+        }
+      ],
+      "seo_meta": {
+        "seo_title": "ESFP 人格指南",
+        "seo_description": "了解 ESFP 的优势、弱项、人际模式和职业方向。",
+        "canonical_url": null,
+        "og_title": null,
+        "og_description": null,
+        "og_image_url": null,
+        "twitter_title": null,
+        "twitter_description": null,
+        "twitter_image_url": null,
+        "robots": null,
+        "jsonld_overrides_json": null
+      }
+    },
+    {
+      "type_code": "ESTJ",
+      "slug": "estj",
+      "title": "ESTJ - 总经理",
+      "subtitle": null,
+      "excerpt": "基于 ESTJ 人格画像的职业建议与工作环境匹配策略。",
+      "hero_kicker": "总经理",
+      "hero_quote": null,
+      "hero_image_url": null,
+      "status": "published",
+      "is_public": true,
+      "is_indexable": true,
+      "published_at": null,
+      "scheduled_at": null,
+      "sections": [
+        {
+          "section_key": "core_snapshot",
+          "title": "核心概览",
+          "render_variant": "rich_text",
+          "body_md": "基于 ESTJ 人格画像的职业建议与工作环境匹配策略。 这类人格通常在目标清晰、反馈可获得、能够持续迭代的环境里更容易稳定发挥。",
+          "body_html": null,
+          "payload_json": null,
+          "sort_order": 10,
+          "is_enabled": true
+        },
+        {
+          "section_key": "strengths",
+          "title": "优势",
+          "render_variant": "bullets",
+          "body_md": null,
+          "body_html": null,
+          "payload_json": {
+            "items": [
+              {
+                "title": "战略性模式识别",
+                "body": null
+              },
+              {
+                "title": "在约束下保持执行稳定",
+                "body": null
+              },
+              {
+                "title": "对关键目标具备持续投入能力",
+                "body": null
+              }
+            ]
+          },
+          "sort_order": 20,
+          "is_enabled": true
+        },
+        {
+          "section_key": "growth_edges",
+          "title": "成长边界",
+          "render_variant": "bullets",
+          "body_md": null,
+          "body_html": null,
+          "payload_json": {
+            "items": [
+              {
+                "title": "过度单一专精导致横向能力不足",
+                "body": null
+              },
+              {
+                "title": "反馈周期过长影响迭代速度",
+                "body": null
+              }
+            ]
+          },
+          "sort_order": 30,
+          "is_enabled": true
+        },
+        {
+          "section_key": "work_style",
+          "title": "工作风格",
+          "render_variant": "rich_text",
+          "body_md": "高自主度、目标清晰、反馈节奏稳定的工作环境。",
+          "body_html": null,
+          "payload_json": null,
+          "sort_order": 40,
+          "is_enabled": true
+        },
+        {
+          "section_key": "relationships",
+          "title": "关系模式",
+          "render_variant": "rich_text",
+          "body_md": "你往往通过直接交流、共同经历和快速反馈来建立关系。你更看重现实可靠、说到做到和细节可落地的人际互动。在冲突里你通常优先讲逻辑和边界，因此需要主动补充情绪确认。亲密关系与协作关系里，你通常更喜欢明确承诺、稳定节奏和可预期安排。",
+          "body_html": null,
+          "payload_json": null,
+          "sort_order": 50,
+          "is_enabled": true
+        },
+        {
+          "section_key": "career_fit",
+          "title": "职业匹配",
+          "render_variant": "cards",
+          "body_md": "你通常更适合在高自主度、目标清晰、反馈节奏稳定的工作环境中发挥优势。优先探索这些方向：机器学习工程师, 后端工程师, 网络安全分析师。",
+          "body_html": null,
+          "payload_json": {
+            "recommended_jobs": [
+              {
+                "slug": "machine-learning-engineer",
+                "title": "机器学习工程师"
+              },
+              {
+                "slug": "backend-engineer",
+                "title": "后端工程师"
+              },
+              {
+                "slug": "cybersecurity-analyst",
+                "title": "网络安全分析师"
+              },
+              {
+                "slug": "operations-manager",
+                "title": "运营经理"
+              },
+              {
+                "slug": "sales-manager",
+                "title": "销售经理"
+              },
+              {
+                "slug": "financial-planner",
+                "title": "财务规划师"
+              }
+            ],
+            "avoid_jobs": [
+              {
+                "slug": "sales-manager",
+                "title": "销售经理"
+              },
+              {
+                "slug": "financial-planner",
+                "title": "财务规划师"
+              },
+              {
+                "slug": "content-strategist",
+                "title": "内容策略师"
+              }
+            ],
+            "work_env": "高自主度、目标清晰、反馈节奏稳定的工作环境。"
+          },
+          "sort_order": 80,
+          "is_enabled": true
+        }
+      ],
+      "seo_meta": {
+        "seo_title": "ESTJ 人格指南",
+        "seo_description": "了解 ESTJ 的优势、弱项、人际模式和职业方向。",
+        "canonical_url": null,
+        "og_title": null,
+        "og_description": null,
+        "og_image_url": null,
+        "twitter_title": null,
+        "twitter_description": null,
+        "twitter_image_url": null,
+        "robots": null,
+        "jsonld_overrides_json": null
+      }
+    },
+    {
+      "type_code": "ESTP",
+      "slug": "estp",
+      "title": "ESTP - 企业家",
+      "subtitle": null,
+      "excerpt": "基于 ESTP 人格画像的职业建议与工作环境匹配策略。",
+      "hero_kicker": "企业家",
+      "hero_quote": null,
+      "hero_image_url": null,
+      "status": "published",
+      "is_public": true,
+      "is_indexable": true,
+      "published_at": null,
+      "scheduled_at": null,
+      "sections": [
+        {
+          "section_key": "core_snapshot",
+          "title": "核心概览",
+          "render_variant": "rich_text",
+          "body_md": "基于 ESTP 人格画像的职业建议与工作环境匹配策略。 这类人格通常在目标清晰、反馈可获得、能够持续迭代的环境里更容易稳定发挥。",
+          "body_html": null,
+          "payload_json": null,
+          "sort_order": 10,
+          "is_enabled": true
+        },
+        {
+          "section_key": "strengths",
+          "title": "优势",
+          "render_variant": "bullets",
+          "body_md": null,
+          "body_html": null,
+          "payload_json": {
+            "items": [
+              {
+                "title": "战略性模式识别",
+                "body": null
+              },
+              {
+                "title": "在约束下保持执行稳定",
+                "body": null
+              },
+              {
+                "title": "对关键目标具备持续投入能力",
+                "body": null
+              }
+            ]
+          },
+          "sort_order": 20,
+          "is_enabled": true
+        },
+        {
+          "section_key": "growth_edges",
+          "title": "成长边界",
+          "render_variant": "bullets",
+          "body_md": null,
+          "body_html": null,
+          "payload_json": {
+            "items": [
+              {
+                "title": "过度单一专精导致横向能力不足",
+                "body": null
+              },
+              {
+                "title": "反馈周期过长影响迭代速度",
+                "body": null
+              }
+            ]
+          },
+          "sort_order": 30,
+          "is_enabled": true
+        },
+        {
+          "section_key": "work_style",
+          "title": "工作风格",
+          "render_variant": "rich_text",
+          "body_md": "高自主度、目标清晰、反馈节奏稳定的工作环境。",
+          "body_html": null,
+          "payload_json": null,
+          "sort_order": 40,
+          "is_enabled": true
+        },
+        {
+          "section_key": "relationships",
+          "title": "关系模式",
+          "render_variant": "rich_text",
+          "body_md": "你往往通过直接交流、共同经历和快速反馈来建立关系。你更看重现实可靠、说到做到和细节可落地的人际互动。在冲突里你通常优先讲逻辑和边界，因此需要主动补充情绪确认。亲密关系与协作关系里，你通常更喜欢弹性空间、自然推进和保留选择余地。",
+          "body_html": null,
+          "payload_json": null,
+          "sort_order": 50,
+          "is_enabled": true
+        },
+        {
+          "section_key": "career_fit",
+          "title": "职业匹配",
+          "render_variant": "cards",
+          "body_md": "你通常更适合在高自主度、目标清晰、反馈节奏稳定的工作环境中发挥优势。优先探索这些方向：网络安全分析师, 运营经理, 销售经理。",
+          "body_html": null,
+          "payload_json": {
+            "recommended_jobs": [
+              {
+                "slug": "cybersecurity-analyst",
+                "title": "网络安全分析师"
+              },
+              {
+                "slug": "operations-manager",
+                "title": "运营经理"
+              },
+              {
+                "slug": "sales-manager",
+                "title": "销售经理"
+              },
+              {
+                "slug": "financial-planner",
+                "title": "财务规划师"
+              },
+              {
+                "slug": "content-strategist",
+                "title": "内容策略师"
+              },
+              {
+                "slug": "researcher",
+                "title": "研究员"
+              }
+            ],
+            "avoid_jobs": [
+              {
+                "slug": "content-strategist",
+                "title": "内容策略师"
+              },
+              {
+                "slug": "researcher",
+                "title": "研究员"
+              },
+              {
+                "slug": "pharmacist",
+                "title": "药师"
+              }
+            ],
+            "work_env": "高自主度、目标清晰、反馈节奏稳定的工作环境。"
+          },
+          "sort_order": 80,
+          "is_enabled": true
+        }
+      ],
+      "seo_meta": {
+        "seo_title": "ESTP 人格指南",
+        "seo_description": "了解 ESTP 的优势、弱项、人际模式和职业方向。",
+        "canonical_url": null,
+        "og_title": null,
+        "og_description": null,
+        "og_image_url": null,
+        "twitter_title": null,
+        "twitter_description": null,
+        "twitter_image_url": null,
+        "robots": null,
+        "jsonld_overrides_json": null
+      }
+    },
+    {
+      "type_code": "INFJ",
+      "slug": "infj",
+      "title": "INFJ - 提倡者",
+      "subtitle": null,
+      "excerpt": "基于 INFJ 人格画像的职业建议与工作环境匹配策略。",
+      "hero_kicker": "提倡者",
+      "hero_quote": null,
+      "hero_image_url": null,
+      "status": "published",
+      "is_public": true,
+      "is_indexable": true,
+      "published_at": null,
+      "scheduled_at": null,
+      "sections": [
+        {
+          "section_key": "core_snapshot",
+          "title": "核心概览",
+          "render_variant": "rich_text",
+          "body_md": "基于 INFJ 人格画像的职业建议与工作环境匹配策略。 这类人格通常在目标清晰、反馈可获得、能够持续迭代的环境里更容易稳定发挥。",
+          "body_html": null,
+          "payload_json": null,
+          "sort_order": 10,
+          "is_enabled": true
+        },
+        {
+          "section_key": "strengths",
+          "title": "优势",
+          "render_variant": "bullets",
+          "body_md": null,
+          "body_html": null,
+          "payload_json": {
+            "items": [
+              {
+                "title": "战略性模式识别",
+                "body": null
+              },
+              {
+                "title": "在约束下保持执行稳定",
+                "body": null
+              },
+              {
+                "title": "对关键目标具备持续投入能力",
+                "body": null
+              }
+            ]
+          },
+          "sort_order": 20,
+          "is_enabled": true
+        },
+        {
+          "section_key": "growth_edges",
+          "title": "成长边界",
+          "render_variant": "bullets",
+          "body_md": null,
+          "body_html": null,
+          "payload_json": {
+            "items": [
+              {
+                "title": "过度单一专精导致横向能力不足",
+                "body": null
+              },
+              {
+                "title": "反馈周期过长影响迭代速度",
+                "body": null
+              }
+            ]
+          },
+          "sort_order": 30,
+          "is_enabled": true
+        },
+        {
+          "section_key": "work_style",
+          "title": "工作风格",
+          "render_variant": "rich_text",
+          "body_md": "高自主度、目标清晰、反馈节奏稳定的工作环境。",
+          "body_html": null,
+          "payload_json": null,
+          "sort_order": 40,
+          "is_enabled": true
+        },
+        {
+          "section_key": "relationships",
+          "title": "关系模式",
+          "render_variant": "rich_text",
+          "body_md": "你更容易通过稳定的一对一沟通、留白和安静空间来建立信任。你倾向于和能讨论长期可能性、模式和意义的人建立更深连接。在冲突里你通常优先照顾感受和氛围，因此需要主动讲清原则和底线。亲密关系与协作关系里，你通常更喜欢明确承诺、稳定节奏和可预期安排。",
+          "body_html": null,
+          "payload_json": null,
+          "sort_order": 50,
+          "is_enabled": true
+        },
+        {
+          "section_key": "career_fit",
+          "title": "职业匹配",
+          "render_variant": "cards",
+          "body_md": "你通常更适合在高自主度、目标清晰、反馈节奏稳定的工作环境中发挥优势。优先探索这些方向：数字营销经理, 律师, 教师。",
+          "body_html": null,
+          "payload_json": {
+            "recommended_jobs": [
+              {
+                "slug": "digital-marketing-manager",
+                "title": "数字营销经理"
+              },
+              {
+                "slug": "lawyer",
+                "title": "律师"
+              },
+              {
+                "slug": "teacher",
+                "title": "教师"
+              },
+              {
+                "slug": "machine-learning-engineer",
+                "title": "机器学习工程师"
+              },
+              {
+                "slug": "backend-engineer",
+                "title": "后端工程师"
+              },
+              {
+                "slug": "cybersecurity-analyst",
+                "title": "网络安全分析师"
+              }
+            ],
+            "avoid_jobs": [
+              {
+                "slug": "backend-engineer",
+                "title": "后端工程师"
+              },
+              {
+                "slug": "cybersecurity-analyst",
+                "title": "网络安全分析师"
+              },
+              {
+                "slug": "operations-manager",
+                "title": "运营经理"
+              }
+            ],
+            "work_env": "高自主度、目标清晰、反馈节奏稳定的工作环境。"
+          },
+          "sort_order": 80,
+          "is_enabled": true
+        }
+      ],
+      "seo_meta": {
+        "seo_title": "INFJ 人格指南",
+        "seo_description": "了解 INFJ 的优势、弱项、人际模式和职业方向。",
+        "canonical_url": null,
+        "og_title": null,
+        "og_description": null,
+        "og_image_url": null,
+        "twitter_title": null,
+        "twitter_description": null,
+        "twitter_image_url": null,
+        "robots": null,
+        "jsonld_overrides_json": null
+      }
+    },
+    {
+      "type_code": "INFP",
+      "slug": "infp",
+      "title": "INFP - 调停者",
+      "subtitle": null,
+      "excerpt": "基于 INFP 人格画像的职业建议与工作环境匹配策略。",
+      "hero_kicker": "调停者",
+      "hero_quote": null,
+      "hero_image_url": null,
+      "status": "published",
+      "is_public": true,
+      "is_indexable": true,
+      "published_at": null,
+      "scheduled_at": null,
+      "sections": [
+        {
+          "section_key": "core_snapshot",
+          "title": "核心概览",
+          "render_variant": "rich_text",
+          "body_md": "基于 INFP 人格画像的职业建议与工作环境匹配策略。 这类人格通常在目标清晰、反馈可获得、能够持续迭代的环境里更容易稳定发挥。",
+          "body_html": null,
+          "payload_json": null,
+          "sort_order": 10,
+          "is_enabled": true
+        },
+        {
+          "section_key": "strengths",
+          "title": "优势",
+          "render_variant": "bullets",
+          "body_md": null,
+          "body_html": null,
+          "payload_json": {
+            "items": [
+              {
+                "title": "战略性模式识别",
+                "body": null
+              },
+              {
+                "title": "在约束下保持执行稳定",
+                "body": null
+              },
+              {
+                "title": "对关键目标具备持续投入能力",
+                "body": null
+              }
+            ]
+          },
+          "sort_order": 20,
+          "is_enabled": true
+        },
+        {
+          "section_key": "growth_edges",
+          "title": "成长边界",
+          "render_variant": "bullets",
+          "body_md": null,
+          "body_html": null,
+          "payload_json": {
+            "items": [
+              {
+                "title": "过度单一专精导致横向能力不足",
+                "body": null
+              },
+              {
+                "title": "反馈周期过长影响迭代速度",
+                "body": null
+              }
+            ]
+          },
+          "sort_order": 30,
+          "is_enabled": true
+        },
+        {
+          "section_key": "work_style",
+          "title": "工作风格",
+          "render_variant": "rich_text",
+          "body_md": "高自主度、目标清晰、反馈节奏稳定的工作环境。",
+          "body_html": null,
+          "payload_json": null,
+          "sort_order": 40,
+          "is_enabled": true
+        },
+        {
+          "section_key": "relationships",
+          "title": "关系模式",
+          "render_variant": "rich_text",
+          "body_md": "你更容易通过稳定的一对一沟通、留白和安静空间来建立信任。你倾向于和能讨论长期可能性、模式和意义的人建立更深连接。在冲突里你通常优先照顾感受和氛围，因此需要主动讲清原则和底线。亲密关系与协作关系里，你通常更喜欢弹性空间、自然推进和保留选择余地。",
+          "body_html": null,
+          "payload_json": null,
+          "sort_order": 50,
+          "is_enabled": true
+        },
+        {
+          "section_key": "career_fit",
+          "title": "职业匹配",
+          "render_variant": "cards",
+          "body_md": "你通常更适合在高自主度、目标清晰、反馈节奏稳定的工作环境中发挥优势。优先探索这些方向：投资分析师, 医生, 数据科学家。",
+          "body_html": null,
+          "payload_json": {
+            "recommended_jobs": [
+              {
+                "slug": "investment-analyst",
+                "title": "投资分析师"
+              },
+              {
+                "slug": "physician",
+                "title": "医生"
+              },
+              {
+                "slug": "data-scientist",
+                "title": "数据科学家"
+              },
+              {
+                "slug": "frontend-engineer",
+                "title": "前端工程师"
+              },
+              {
+                "slug": "fullstack-engineer",
+                "title": "全栈工程师"
+              },
+              {
+                "slug": "cloud-architect",
+                "title": "云架构师"
+              }
+            ],
+            "avoid_jobs": [
+              {
+                "slug": "fullstack-engineer",
+                "title": "全栈工程师"
+              },
+              {
+                "slug": "cloud-architect",
+                "title": "云架构师"
+              },
+              {
+                "slug": "hr-business-partner",
+                "title": "HRBP"
+              }
+            ],
+            "work_env": "高自主度、目标清晰、反馈节奏稳定的工作环境。"
+          },
+          "sort_order": 80,
+          "is_enabled": true
+        }
+      ],
+      "seo_meta": {
+        "seo_title": "INFP 人格指南",
+        "seo_description": "了解 INFP 的优势、弱项、人际模式和职业方向。",
+        "canonical_url": null,
+        "og_title": null,
+        "og_description": null,
+        "og_image_url": null,
+        "twitter_title": null,
+        "twitter_description": null,
+        "twitter_image_url": null,
+        "robots": null,
+        "jsonld_overrides_json": null
+      }
+    },
+    {
+      "type_code": "INTJ",
+      "slug": "intj",
+      "title": "INTJ - 建筑师",
+      "subtitle": null,
+      "excerpt": "基于 INTJ 人格画像的职业建议与工作环境匹配策略。",
+      "hero_kicker": "建筑师",
+      "hero_quote": null,
+      "hero_image_url": null,
+      "status": "published",
+      "is_public": true,
+      "is_indexable": true,
+      "published_at": null,
+      "scheduled_at": null,
+      "sections": [
+        {
+          "section_key": "core_snapshot",
+          "title": "核心概览",
+          "render_variant": "rich_text",
+          "body_md": "基于 INTJ 人格画像的职业建议与工作环境匹配策略。 这类人格通常在目标清晰、反馈可获得、能够持续迭代的环境里更容易稳定发挥。",
+          "body_html": null,
+          "payload_json": null,
+          "sort_order": 10,
+          "is_enabled": true
+        },
+        {
+          "section_key": "strengths",
+          "title": "优势",
+          "render_variant": "bullets",
+          "body_md": null,
+          "body_html": null,
+          "payload_json": {
+            "items": [
+              {
+                "title": "战略性模式识别",
+                "body": null
+              },
+              {
+                "title": "在约束下保持执行稳定",
+                "body": null
+              },
+              {
+                "title": "对关键目标具备持续投入能力",
+                "body": null
+              }
+            ]
+          },
+          "sort_order": 20,
+          "is_enabled": true
+        },
+        {
+          "section_key": "growth_edges",
+          "title": "成长边界",
+          "render_variant": "bullets",
+          "body_md": null,
+          "body_html": null,
+          "payload_json": {
+            "items": [
+              {
+                "title": "过度单一专精导致横向能力不足",
+                "body": null
+              },
+              {
+                "title": "反馈周期过长影响迭代速度",
+                "body": null
+              }
+            ]
+          },
+          "sort_order": 30,
+          "is_enabled": true
+        },
+        {
+          "section_key": "work_style",
+          "title": "工作风格",
+          "render_variant": "rich_text",
+          "body_md": "高自主度、目标清晰、反馈节奏稳定的工作环境。",
+          "body_html": null,
+          "payload_json": null,
+          "sort_order": 40,
+          "is_enabled": true
+        },
+        {
+          "section_key": "relationships",
+          "title": "关系模式",
+          "render_variant": "rich_text",
+          "body_md": "你更容易通过稳定的一对一沟通、留白和安静空间来建立信任。你倾向于和能讨论长期可能性、模式和意义的人建立更深连接。在冲突里你通常优先讲逻辑和边界，因此需要主动补充情绪确认。亲密关系与协作关系里，你通常更喜欢明确承诺、稳定节奏和可预期安排。",
+          "body_html": null,
+          "payload_json": null,
+          "sort_order": 50,
+          "is_enabled": true
+        },
+        {
+          "section_key": "career_fit",
+          "title": "职业匹配",
+          "render_variant": "cards",
+          "body_md": "你通常更适合在高自主度、目标清晰、反馈节奏稳定的工作环境中发挥优势。优先探索这些方向：产品经理, UI/UX 设计师, 数字营销经理。",
+          "body_html": null,
+          "payload_json": {
+            "recommended_jobs": [
+              {
+                "slug": "product-manager",
+                "title": "产品经理"
+              },
+              {
+                "slug": "ui-ux-designer",
+                "title": "UI/UX 设计师"
+              },
+              {
+                "slug": "digital-marketing-manager",
+                "title": "数字营销经理"
+              },
+              {
+                "slug": "lawyer",
+                "title": "律师"
+              },
+              {
+                "slug": "teacher",
+                "title": "教师"
+              },
+              {
+                "slug": "machine-learning-engineer",
+                "title": "机器学习工程师"
+              }
+            ],
+            "avoid_jobs": [
+              {
+                "slug": "teacher",
+                "title": "教师"
+              },
+              {
+                "slug": "machine-learning-engineer",
+                "title": "机器学习工程师"
+              },
+              {
+                "slug": "backend-engineer",
+                "title": "后端工程师"
+              }
+            ],
+            "work_env": "高自主度、目标清晰、反馈节奏稳定的工作环境。"
+          },
+          "sort_order": 80,
+          "is_enabled": true
+        }
+      ],
+      "seo_meta": {
+        "seo_title": "INTJ 人格指南",
+        "seo_description": "了解 INTJ 的优势、弱项、人际模式和职业方向。",
+        "canonical_url": null,
+        "og_title": null,
+        "og_description": null,
+        "og_image_url": null,
+        "twitter_title": null,
+        "twitter_description": null,
+        "twitter_image_url": null,
+        "robots": null,
+        "jsonld_overrides_json": null
+      }
+    },
+    {
+      "type_code": "INTP",
+      "slug": "intp",
+      "title": "INTP - 逻辑学家",
+      "subtitle": null,
+      "excerpt": "基于 INTP 人格画像的职业建议与工作环境匹配策略。",
+      "hero_kicker": "逻辑学家",
+      "hero_quote": null,
+      "hero_image_url": null,
+      "status": "published",
+      "is_public": true,
+      "is_indexable": true,
+      "published_at": null,
+      "scheduled_at": null,
+      "sections": [
+        {
+          "section_key": "core_snapshot",
+          "title": "核心概览",
+          "render_variant": "rich_text",
+          "body_md": "基于 INTP 人格画像的职业建议与工作环境匹配策略。 这类人格通常在目标清晰、反馈可获得、能够持续迭代的环境里更容易稳定发挥。",
+          "body_html": null,
+          "payload_json": null,
+          "sort_order": 10,
+          "is_enabled": true
+        },
+        {
+          "section_key": "strengths",
+          "title": "优势",
+          "render_variant": "bullets",
+          "body_md": null,
+          "body_html": null,
+          "payload_json": {
+            "items": [
+              {
+                "title": "战略性模式识别",
+                "body": null
+              },
+              {
+                "title": "在约束下保持执行稳定",
+                "body": null
+              },
+              {
+                "title": "对关键目标具备持续投入能力",
+                "body": null
+              }
+            ]
+          },
+          "sort_order": 20,
+          "is_enabled": true
+        },
+        {
+          "section_key": "growth_edges",
+          "title": "成长边界",
+          "render_variant": "bullets",
+          "body_md": null,
+          "body_html": null,
+          "payload_json": {
+            "items": [
+              {
+                "title": "过度单一专精导致横向能力不足",
+                "body": null
+              },
+              {
+                "title": "反馈周期过长影响迭代速度",
+                "body": null
+              }
+            ]
+          },
+          "sort_order": 30,
+          "is_enabled": true
+        },
+        {
+          "section_key": "work_style",
+          "title": "工作风格",
+          "render_variant": "rich_text",
+          "body_md": "高自主度、目标清晰、反馈节奏稳定的工作环境。",
+          "body_html": null,
+          "payload_json": null,
+          "sort_order": 40,
+          "is_enabled": true
+        },
+        {
+          "section_key": "relationships",
+          "title": "关系模式",
+          "render_variant": "rich_text",
+          "body_md": "你更容易通过稳定的一对一沟通、留白和安静空间来建立信任。你倾向于和能讨论长期可能性、模式和意义的人建立更深连接。在冲突里你通常优先讲逻辑和边界，因此需要主动补充情绪确认。亲密关系与协作关系里，你通常更喜欢弹性空间、自然推进和保留选择余地。",
+          "body_html": null,
+          "payload_json": null,
+          "sort_order": 50,
+          "is_enabled": true
+        },
+        {
+          "section_key": "career_fit",
+          "title": "职业匹配",
+          "render_variant": "cards",
+          "body_md": "你通常更适合在高自主度、目标清晰、反馈节奏稳定的工作环境中发挥优势。优先探索这些方向：数据分析师, 心理咨询师, 投资分析师。",
+          "body_html": null,
+          "payload_json": {
+            "recommended_jobs": [
+              {
+                "slug": "data-analyst",
+                "title": "数据分析师"
+              },
+              {
+                "slug": "psychological-counselor",
+                "title": "心理咨询师"
+              },
+              {
+                "slug": "investment-analyst",
+                "title": "投资分析师"
+              },
+              {
+                "slug": "physician",
+                "title": "医生"
+              },
+              {
+                "slug": "data-scientist",
+                "title": "数据科学家"
+              },
+              {
+                "slug": "frontend-engineer",
+                "title": "前端工程师"
+              }
+            ],
+            "avoid_jobs": [
+              {
+                "slug": "data-scientist",
+                "title": "数据科学家"
+              },
+              {
+                "slug": "frontend-engineer",
+                "title": "前端工程师"
+              },
+              {
+                "slug": "fullstack-engineer",
+                "title": "全栈工程师"
+              }
+            ],
+            "work_env": "高自主度、目标清晰、反馈节奏稳定的工作环境。"
+          },
+          "sort_order": 80,
+          "is_enabled": true
+        }
+      ],
+      "seo_meta": {
+        "seo_title": "INTP 人格指南",
+        "seo_description": "了解 INTP 的优势、弱项、人际模式和职业方向。",
+        "canonical_url": null,
+        "og_title": null,
+        "og_description": null,
+        "og_image_url": null,
+        "twitter_title": null,
+        "twitter_description": null,
+        "twitter_image_url": null,
+        "robots": null,
+        "jsonld_overrides_json": null
+      }
+    },
+    {
+      "type_code": "ISFJ",
+      "slug": "isfj",
+      "title": "ISFJ - 守卫者",
+      "subtitle": null,
+      "excerpt": "基于 ISFJ 人格画像的职业建议与工作环境匹配策略。",
+      "hero_kicker": "守卫者",
+      "hero_quote": null,
+      "hero_image_url": null,
+      "status": "published",
+      "is_public": true,
+      "is_indexable": true,
+      "published_at": null,
+      "scheduled_at": null,
+      "sections": [
+        {
+          "section_key": "core_snapshot",
+          "title": "核心概览",
+          "render_variant": "rich_text",
+          "body_md": "基于 ISFJ 人格画像的职业建议与工作环境匹配策略。 这类人格通常在目标清晰、反馈可获得、能够持续迭代的环境里更容易稳定发挥。",
+          "body_html": null,
+          "payload_json": null,
+          "sort_order": 10,
+          "is_enabled": true
+        },
+        {
+          "section_key": "strengths",
+          "title": "优势",
+          "render_variant": "bullets",
+          "body_md": null,
+          "body_html": null,
+          "payload_json": {
+            "items": [
+              {
+                "title": "战略性模式识别",
+                "body": null
+              },
+              {
+                "title": "在约束下保持执行稳定",
+                "body": null
+              },
+              {
+                "title": "对关键目标具备持续投入能力",
+                "body": null
+              }
+            ]
+          },
+          "sort_order": 20,
+          "is_enabled": true
+        },
+        {
+          "section_key": "growth_edges",
+          "title": "成长边界",
+          "render_variant": "bullets",
+          "body_md": null,
+          "body_html": null,
+          "payload_json": {
+            "items": [
+              {
+                "title": "过度单一专精导致横向能力不足",
+                "body": null
+              },
+              {
+                "title": "反馈周期过长影响迭代速度",
+                "body": null
+              }
+            ]
+          },
+          "sort_order": 30,
+          "is_enabled": true
+        },
+        {
+          "section_key": "work_style",
+          "title": "工作风格",
+          "render_variant": "rich_text",
+          "body_md": "高自主度、目标清晰、反馈节奏稳定的工作环境。",
+          "body_html": null,
+          "payload_json": null,
+          "sort_order": 40,
+          "is_enabled": true
+        },
+        {
+          "section_key": "relationships",
+          "title": "关系模式",
+          "render_variant": "rich_text",
+          "body_md": "你更容易通过稳定的一对一沟通、留白和安静空间来建立信任。你更看重现实可靠、说到做到和细节可落地的人际互动。在冲突里你通常优先照顾感受和氛围，因此需要主动讲清原则和底线。亲密关系与协作关系里，你通常更喜欢明确承诺、稳定节奏和可预期安排。",
+          "body_html": null,
+          "payload_json": null,
+          "sort_order": 50,
+          "is_enabled": true
+        },
+        {
+          "section_key": "career_fit",
+          "title": "职业匹配",
+          "render_variant": "cards",
+          "body_md": "你通常更适合在高自主度、目标清晰、反馈节奏稳定的工作环境中发挥优势。优先探索这些方向：数据科学家, 前端工程师, 全栈工程师。",
+          "body_html": null,
+          "payload_json": {
+            "recommended_jobs": [
+              {
+                "slug": "data-scientist",
+                "title": "数据科学家"
+              },
+              {
+                "slug": "frontend-engineer",
+                "title": "前端工程师"
+              },
+              {
+                "slug": "fullstack-engineer",
+                "title": "全栈工程师"
+              },
+              {
+                "slug": "cloud-architect",
+                "title": "云架构师"
+              },
+              {
+                "slug": "hr-business-partner",
+                "title": "HRBP"
+              },
+              {
+                "slug": "management-consultant",
+                "title": "管理咨询顾问"
+              }
+            ],
+            "avoid_jobs": [
+              {
+                "slug": "hr-business-partner",
+                "title": "HRBP"
+              },
+              {
+                "slug": "management-consultant",
+                "title": "管理咨询顾问"
+              },
+              {
+                "slug": "business-analyst",
+                "title": "商业分析师"
+              }
+            ],
+            "work_env": "高自主度、目标清晰、反馈节奏稳定的工作环境。"
+          },
+          "sort_order": 80,
+          "is_enabled": true
+        }
+      ],
+      "seo_meta": {
+        "seo_title": "ISFJ 人格指南",
+        "seo_description": "了解 ISFJ 的优势、弱项、人际模式和职业方向。",
+        "canonical_url": null,
+        "og_title": null,
+        "og_description": null,
+        "og_image_url": null,
+        "twitter_title": null,
+        "twitter_description": null,
+        "twitter_image_url": null,
+        "robots": null,
+        "jsonld_overrides_json": null
+      }
+    },
+    {
+      "type_code": "ISFP",
+      "slug": "isfp",
+      "title": "ISFP - 探险家",
+      "subtitle": null,
+      "excerpt": "基于 ISFP 人格画像的职业建议与工作环境匹配策略。",
+      "hero_kicker": "探险家",
+      "hero_quote": null,
+      "hero_image_url": null,
+      "status": "published",
+      "is_public": true,
+      "is_indexable": true,
+      "published_at": null,
+      "scheduled_at": null,
+      "sections": [
+        {
+          "section_key": "core_snapshot",
+          "title": "核心概览",
+          "render_variant": "rich_text",
+          "body_md": "基于 ISFP 人格画像的职业建议与工作环境匹配策略。 这类人格通常在目标清晰、反馈可获得、能够持续迭代的环境里更容易稳定发挥。",
+          "body_html": null,
+          "payload_json": null,
+          "sort_order": 10,
+          "is_enabled": true
+        },
+        {
+          "section_key": "strengths",
+          "title": "优势",
+          "render_variant": "bullets",
+          "body_md": null,
+          "body_html": null,
+          "payload_json": {
+            "items": [
+              {
+                "title": "战略性模式识别",
+                "body": null
+              },
+              {
+                "title": "在约束下保持执行稳定",
+                "body": null
+              },
+              {
+                "title": "对关键目标具备持续投入能力",
+                "body": null
+              }
+            ]
+          },
+          "sort_order": 20,
+          "is_enabled": true
+        },
+        {
+          "section_key": "growth_edges",
+          "title": "成长边界",
+          "render_variant": "bullets",
+          "body_md": null,
+          "body_html": null,
+          "payload_json": {
+            "items": [
+              {
+                "title": "过度单一专精导致横向能力不足",
+                "body": null
+              },
+              {
+                "title": "反馈周期过长影响迭代速度",
+                "body": null
+              }
+            ]
+          },
+          "sort_order": 30,
+          "is_enabled": true
+        },
+        {
+          "section_key": "work_style",
+          "title": "工作风格",
+          "render_variant": "rich_text",
+          "body_md": "高自主度、目标清晰、反馈节奏稳定的工作环境。",
+          "body_html": null,
+          "payload_json": null,
+          "sort_order": 40,
+          "is_enabled": true
+        },
+        {
+          "section_key": "relationships",
+          "title": "关系模式",
+          "render_variant": "rich_text",
+          "body_md": "你更容易通过稳定的一对一沟通、留白和安静空间来建立信任。你更看重现实可靠、说到做到和细节可落地的人际互动。在冲突里你通常优先照顾感受和氛围，因此需要主动讲清原则和底线。亲密关系与协作关系里，你通常更喜欢弹性空间、自然推进和保留选择余地。",
+          "body_html": null,
+          "payload_json": null,
+          "sort_order": 50,
+          "is_enabled": true
+        },
+        {
+          "section_key": "career_fit",
+          "title": "职业匹配",
+          "render_variant": "cards",
+          "body_md": "你通常更适合在高自主度、目标清晰、反馈节奏稳定的工作环境中发挥优势。优先探索这些方向：全栈工程师, 云架构师, HRBP。",
+          "body_html": null,
+          "payload_json": {
+            "recommended_jobs": [
+              {
+                "slug": "fullstack-engineer",
+                "title": "全栈工程师"
+              },
+              {
+                "slug": "cloud-architect",
+                "title": "云架构师"
+              },
+              {
+                "slug": "hr-business-partner",
+                "title": "HRBP"
+              },
+              {
+                "slug": "management-consultant",
+                "title": "管理咨询顾问"
+              },
+              {
+                "slug": "business-analyst",
+                "title": "商业分析师"
+              },
+              {
+                "slug": "brand-manager",
+                "title": "品牌经理"
+              }
+            ],
+            "avoid_jobs": [
+              {
+                "slug": "business-analyst",
+                "title": "商业分析师"
+              },
+              {
+                "slug": "brand-manager",
+                "title": "品牌经理"
+              },
+              {
+                "slug": "nurse",
+                "title": "护士"
+              }
+            ],
+            "work_env": "高自主度、目标清晰、反馈节奏稳定的工作环境。"
+          },
+          "sort_order": 80,
+          "is_enabled": true
+        }
+      ],
+      "seo_meta": {
+        "seo_title": "ISFP 人格指南",
+        "seo_description": "了解 ISFP 的优势、弱项、人际模式和职业方向。",
+        "canonical_url": null,
+        "og_title": null,
+        "og_description": null,
+        "og_image_url": null,
+        "twitter_title": null,
+        "twitter_description": null,
+        "twitter_image_url": null,
+        "robots": null,
+        "jsonld_overrides_json": null
+      }
+    },
+    {
+      "type_code": "ISTJ",
+      "slug": "istj",
+      "title": "ISTJ - 物流师",
+      "subtitle": null,
+      "excerpt": "基于 ISTJ 人格画像的职业建议与工作环境匹配策略。",
+      "hero_kicker": "物流师",
+      "hero_quote": null,
+      "hero_image_url": null,
+      "status": "published",
+      "is_public": true,
+      "is_indexable": true,
+      "published_at": null,
+      "scheduled_at": null,
+      "sections": [
+        {
+          "section_key": "core_snapshot",
+          "title": "核心概览",
+          "render_variant": "rich_text",
+          "body_md": "基于 ISTJ 人格画像的职业建议与工作环境匹配策略。 这类人格通常在目标清晰、反馈可获得、能够持续迭代的环境里更容易稳定发挥。",
+          "body_html": null,
+          "payload_json": null,
+          "sort_order": 10,
+          "is_enabled": true
+        },
+        {
+          "section_key": "strengths",
+          "title": "优势",
+          "render_variant": "bullets",
+          "body_md": null,
+          "body_html": null,
+          "payload_json": {
+            "items": [
+              {
+                "title": "战略性模式识别",
+                "body": null
+              },
+              {
+                "title": "在约束下保持执行稳定",
+                "body": null
+              },
+              {
+                "title": "对关键目标具备持续投入能力",
+                "body": null
+              }
+            ]
+          },
+          "sort_order": 20,
+          "is_enabled": true
+        },
+        {
+          "section_key": "growth_edges",
+          "title": "成长边界",
+          "render_variant": "bullets",
+          "body_md": null,
+          "body_html": null,
+          "payload_json": {
+            "items": [
+              {
+                "title": "过度单一专精导致横向能力不足",
+                "body": null
+              },
+              {
+                "title": "反馈周期过长影响迭代速度",
+                "body": null
+              }
+            ]
+          },
+          "sort_order": 30,
+          "is_enabled": true
+        },
+        {
+          "section_key": "work_style",
+          "title": "工作风格",
+          "render_variant": "rich_text",
+          "body_md": "高自主度、目标清晰、反馈节奏稳定的工作环境。",
+          "body_html": null,
+          "payload_json": null,
+          "sort_order": 40,
+          "is_enabled": true
+        },
+        {
+          "section_key": "relationships",
+          "title": "关系模式",
+          "render_variant": "rich_text",
+          "body_md": "你更容易通过稳定的一对一沟通、留白和安静空间来建立信任。你更看重现实可靠、说到做到和细节可落地的人际互动。在冲突里你通常优先讲逻辑和边界，因此需要主动补充情绪确认。亲密关系与协作关系里，你通常更喜欢明确承诺、稳定节奏和可预期安排。",
+          "body_html": null,
+          "payload_json": null,
+          "sort_order": 50,
+          "is_enabled": true
+        },
+        {
+          "section_key": "career_fit",
+          "title": "职业匹配",
+          "render_variant": "cards",
+          "body_md": "你通常更适合在高自主度、目标清晰、反馈节奏稳定的工作环境中发挥优势。优先探索这些方向：教师, 机器学习工程师, 后端工程师。",
+          "body_html": null,
+          "payload_json": {
+            "recommended_jobs": [
+              {
+                "slug": "teacher",
+                "title": "教师"
+              },
+              {
+                "slug": "machine-learning-engineer",
+                "title": "机器学习工程师"
+              },
+              {
+                "slug": "backend-engineer",
+                "title": "后端工程师"
+              },
+              {
+                "slug": "cybersecurity-analyst",
+                "title": "网络安全分析师"
+              },
+              {
+                "slug": "operations-manager",
+                "title": "运营经理"
+              },
+              {
+                "slug": "sales-manager",
+                "title": "销售经理"
+              }
+            ],
+            "avoid_jobs": [
+              {
+                "slug": "operations-manager",
+                "title": "运营经理"
+              },
+              {
+                "slug": "sales-manager",
+                "title": "销售经理"
+              },
+              {
+                "slug": "financial-planner",
+                "title": "财务规划师"
+              }
+            ],
+            "work_env": "高自主度、目标清晰、反馈节奏稳定的工作环境。"
+          },
+          "sort_order": 80,
+          "is_enabled": true
+        }
+      ],
+      "seo_meta": {
+        "seo_title": "ISTJ 人格指南",
+        "seo_description": "了解 ISTJ 的优势、弱项、人际模式和职业方向。",
+        "canonical_url": null,
+        "og_title": null,
+        "og_description": null,
+        "og_image_url": null,
+        "twitter_title": null,
+        "twitter_description": null,
+        "twitter_image_url": null,
+        "robots": null,
+        "jsonld_overrides_json": null
+      }
+    },
+    {
+      "type_code": "ISTP",
+      "slug": "istp",
+      "title": "ISTP - 鉴赏家",
+      "subtitle": null,
+      "excerpt": "基于 ISTP 人格画像的职业建议与工作环境匹配策略。",
+      "hero_kicker": "鉴赏家",
+      "hero_quote": null,
+      "hero_image_url": null,
+      "status": "published",
+      "is_public": true,
+      "is_indexable": true,
+      "published_at": null,
+      "scheduled_at": null,
+      "sections": [
+        {
+          "section_key": "core_snapshot",
+          "title": "核心概览",
+          "render_variant": "rich_text",
+          "body_md": "基于 ISTP 人格画像的职业建议与工作环境匹配策略。 这类人格通常在目标清晰、反馈可获得、能够持续迭代的环境里更容易稳定发挥。",
+          "body_html": null,
+          "payload_json": null,
+          "sort_order": 10,
+          "is_enabled": true
+        },
+        {
+          "section_key": "strengths",
+          "title": "优势",
+          "render_variant": "bullets",
+          "body_md": null,
+          "body_html": null,
+          "payload_json": {
+            "items": [
+              {
+                "title": "战略性模式识别",
+                "body": null
+              },
+              {
+                "title": "在约束下保持执行稳定",
+                "body": null
+              },
+              {
+                "title": "对关键目标具备持续投入能力",
+                "body": null
+              }
+            ]
+          },
+          "sort_order": 20,
+          "is_enabled": true
+        },
+        {
+          "section_key": "growth_edges",
+          "title": "成长边界",
+          "render_variant": "bullets",
+          "body_md": null,
+          "body_html": null,
+          "payload_json": {
+            "items": [
+              {
+                "title": "过度单一专精导致横向能力不足",
+                "body": null
+              },
+              {
+                "title": "反馈周期过长影响迭代速度",
+                "body": null
+              }
+            ]
+          },
+          "sort_order": 30,
+          "is_enabled": true
+        },
+        {
+          "section_key": "work_style",
+          "title": "工作风格",
+          "render_variant": "rich_text",
+          "body_md": "高自主度、目标清晰、反馈节奏稳定的工作环境。",
+          "body_html": null,
+          "payload_json": null,
+          "sort_order": 40,
+          "is_enabled": true
+        },
+        {
+          "section_key": "relationships",
+          "title": "关系模式",
+          "render_variant": "rich_text",
+          "body_md": "你更容易通过稳定的一对一沟通、留白和安静空间来建立信任。你更看重现实可靠、说到做到和细节可落地的人际互动。在冲突里你通常优先讲逻辑和边界，因此需要主动补充情绪确认。亲密关系与协作关系里，你通常更喜欢弹性空间、自然推进和保留选择余地。",
+          "body_html": null,
+          "payload_json": null,
+          "sort_order": 50,
+          "is_enabled": true
+        },
+        {
+          "section_key": "career_fit",
+          "title": "职业匹配",
+          "render_variant": "cards",
+          "body_md": "你通常更适合在高自主度、目标清晰、反馈节奏稳定的工作环境中发挥优势。优先探索这些方向：后端工程师, 网络安全分析师, 运营经理。",
+          "body_html": null,
+          "payload_json": {
+            "recommended_jobs": [
+              {
+                "slug": "backend-engineer",
+                "title": "后端工程师"
+              },
+              {
+                "slug": "cybersecurity-analyst",
+                "title": "网络安全分析师"
+              },
+              {
+                "slug": "operations-manager",
+                "title": "运营经理"
+              },
+              {
+                "slug": "sales-manager",
+                "title": "销售经理"
+              },
+              {
+                "slug": "financial-planner",
+                "title": "财务规划师"
+              },
+              {
+                "slug": "content-strategist",
+                "title": "内容策略师"
+              }
+            ],
+            "avoid_jobs": [
+              {
+                "slug": "financial-planner",
+                "title": "财务规划师"
+              },
+              {
+                "slug": "content-strategist",
+                "title": "内容策略师"
+              },
+              {
+                "slug": "researcher",
+                "title": "研究员"
+              }
+            ],
+            "work_env": "高自主度、目标清晰、反馈节奏稳定的工作环境。"
+          },
+          "sort_order": 80,
+          "is_enabled": true
+        }
+      ],
+      "seo_meta": {
+        "seo_title": "ISTP 人格指南",
+        "seo_description": "了解 ISTP 的优势、弱项、人际模式和职业方向。",
+        "canonical_url": null,
+        "og_title": null,
+        "og_description": null,
+        "og_image_url": null,
+        "twitter_title": null,
+        "twitter_description": null,
+        "twitter_image_url": null,
+        "robots": null,
+        "jsonld_overrides_json": null
+      }
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- add a repeatable baseline import for Personality CMS v1
- normalize the current local MBTI personality content into committed baseline files and import it into personality profile tables

## What changed
- add committed baseline files for MBTI personality profiles
- add an Artisan command to import local baseline content into Personality CMS
- add reader/normalizer/importer support for deterministic imports
- add revision creation during baseline import
- add minimal feature coverage for dry-run, create-missing, upsert, and filtering behavior

## Design choices
- the import reads from committed baseline files in fap-api, not directly from the sibling frontend repo at runtime
- v1 imports the 16 base MBTI types only
- imports target global content (org_id=0)
- fixed section keys are preserved and validated
- default import mode is conservative and does not overwrite existing records unless --upsert is used

## Why this PR is small and safe
- no frontend changes
- no route changes
- no Filament changes
- no AI generation
- no A/T 32-profile expansion
- only baseline import groundwork for later Personality CMS rollout

## Validation
- `php artisan about`
- `php artisan route:list`
- `php artisan migrate`
- `php artisan test --filter=Personality`
- `php artisan personality:import-local-baseline --dry-run`
- `php artisan personality:import-local-baseline --locale=en --status=draft`
- `php artisan personality:import-local-baseline --locale=zh-CN --type=INTJ --dry-run`
- `php artisan personality:import-local-baseline --locale=en --upsert --status=published`
- `bash backend/scripts/ci_verify_mbti.sh`
