### PR TITLE
feat(personality-cms): add personality urls to backend sitemap authority

### DIFF
--- a/backend/app/Services/SEO/SitemapCache.php
+++ b/backend/app/Services/SEO/SitemapCache.php
@@ -6,9 +6,9 @@ use Illuminate\Support\Facades\Cache;
 
 class SitemapCache
 {
-    public const XML_CACHE_KEY = 'seo:sitemap:xml:v2';
+    public const XML_CACHE_KEY = 'seo:sitemap:xml:v3';
 
-    public const ETAG_CACHE_KEY = 'seo:sitemap:etag:v2';
+    public const ETAG_CACHE_KEY = 'seo:sitemap:etag:v3';
 
     public const TTL_SECONDS = 86400;
 

--- a/backend/app/Services/SEO/SitemapGenerator.php
+++ b/backend/app/Services/SEO/SitemapGenerator.php
@@ -2,6 +2,8 @@
 
 namespace App\Services\SEO;
 
+use App\Models\PersonalityProfile;
+use App\Services\Cms\PersonalityProfileSeoService;
 use Illuminate\Support\Carbon;
 use Illuminate\Support\Facades\DB;
 
@@ -9,8 +11,9 @@ class SitemapGenerator
 {
     private string $urlPrefix;
 
-    public function __construct()
-    {
+    public function __construct(
+        private readonly PersonalityProfileSeoService $personalityProfileSeoService,
+    ) {
         $configuredPrefix = trim((string) config('services.seo.tests_url_prefix', ''));
         if ($configuredPrefix === '') {
             $configuredPrefix = rtrim((string) config('app.url', 'http://localhost'), '/').'/tests/';
@@ -25,7 +28,8 @@ class SitemapGenerator
 
         $urls = array_merge(
             $this->getScaleUrls($locale),
-            $this->getArticleUrls($locale)
+            $this->getArticleUrls($locale),
+            $this->getPersonalityUrls()
         );
 
         $urls = collect($urls)
@@ -147,6 +151,72 @@ class SitemapGenerator
                 'loc' => $url,
                 'lastmod' => $lastmod->toAtomString(),
                 'slug' => (string) $row->slug,
+                'updated_at' => $lastmod->toDateTimeString(),
+            ];
+        }
+
+        return $urls;
+    }
+
+    private function getPersonalityUrls(): array
+    {
+        $baseUrl = rtrim((string) config('app.frontend_url', config('app.url', '')), '/');
+        if ($baseUrl === '') {
+            return [];
+        }
+
+        $rows = PersonalityProfile::query()
+            ->withoutGlobalScopes()
+            ->where('org_id', 0)
+            ->where('scale_code', PersonalityProfile::SCALE_CODE_MBTI)
+            ->where('status', 'published')
+            ->where('is_public', true)
+            ->where('is_indexable', true)
+            ->whereIn('locale', PersonalityProfile::SUPPORTED_LOCALES)
+            ->whereNotNull('slug')
+            ->where('slug', '<>', '')
+            ->where(static function ($query): void {
+                $query->whereNull('published_at')
+                    ->orWhere('published_at', '<=', now());
+            })
+            ->select(['slug', 'locale', 'updated_at', 'published_at'])
+            ->orderBy('locale')
+            ->orderBy('slug')
+            ->get();
+
+        $urls = [];
+        $listLastModified = [];
+
+        foreach ($rows as $row) {
+            $slug = trim((string) $row->slug);
+            $locale = trim((string) $row->locale);
+
+            if ($slug === '' || $locale === '') {
+                continue;
+            }
+
+            $segment = $this->personalityProfileSeoService->mapBackendLocaleToFrontendSegment($locale);
+            $lastmod = $row->updated_at
+                ?? $row->published_at
+                ?? now();
+
+            $urls[] = [
+                'loc' => $baseUrl.'/'.$segment.'/personality/'.rawurlencode($slug),
+                'lastmod' => $lastmod->toAtomString(),
+                'slug' => 'personality:'.$segment.':'.$slug,
+                'updated_at' => $lastmod->toDateTimeString(),
+            ];
+
+            if (! isset($listLastModified[$segment]) || $lastmod->gt($listLastModified[$segment])) {
+                $listLastModified[$segment] = $lastmod;
+            }
+        }
+
+        foreach ($listLastModified as $segment => $lastmod) {
+            $urls[] = [
+                'loc' => $baseUrl.'/'.$segment.'/personality',
+                'lastmod' => $lastmod->toAtomString(),
+                'slug' => 'personality-list:'.$segment,
                 'updated_at' => $lastmod->toDateTimeString(),
             ];
         }

--- a/backend/tests/Feature/SEO/SitemapGeneratorTest.php
+++ b/backend/tests/Feature/SEO/SitemapGeneratorTest.php
@@ -2,8 +2,11 @@
 
 namespace Tests\Feature\SEO;
 
+use App\Models\PersonalityProfile;
+use App\Services\Cms\PersonalityProfileSeoService;
 use App\Services\SEO\SitemapGenerator;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Carbon;
 use Illuminate\Support\Facades\DB;
 use Tests\TestCase;
 
@@ -87,12 +90,144 @@ class SitemapGeneratorTest extends TestCase
         $this->assertSame(['public-global', 'public-global-alt'], $slugList);
 
         $xml = (string) ($payload['xml'] ?? '');
-        $prefix = rtrim((string) config('services.seo.tests_url_prefix'), '/') . '/';
-        $this->assertStringContainsString($prefix . 'public-global', $xml);
-        $this->assertStringContainsString($prefix . 'public-global-alt', $xml);
-        $this->assertStringNotContainsString($prefix . 'private-global', $xml);
-        $this->assertStringNotContainsString($prefix . 'private-global-alt', $xml);
-        $this->assertStringNotContainsString($prefix . 'tenant-public', $xml);
-        $this->assertStringNotContainsString($prefix . 'tenant-public-alt', $xml);
+        $prefix = rtrim((string) config('services.seo.tests_url_prefix'), '/').'/';
+        $this->assertStringContainsString($prefix.'public-global', $xml);
+        $this->assertStringContainsString($prefix.'public-global-alt', $xml);
+        $this->assertStringNotContainsString($prefix.'private-global', $xml);
+        $this->assertStringNotContainsString($prefix.'private-global-alt', $xml);
+        $this->assertStringNotContainsString($prefix.'tenant-public', $xml);
+        $this->assertStringNotContainsString($prefix.'tenant-public-alt', $xml);
+    }
+
+    public function test_generate_includes_only_indexable_global_personality_urls_with_locale_aware_paths(): void
+    {
+        config(['app.frontend_url' => 'https://staging.fermatmind.com']);
+
+        $eligibleEn = $this->createPersonalityProfile([
+            'type_code' => 'INTJ',
+            'slug' => 'intj',
+            'locale' => 'en',
+            'is_indexable' => true,
+            'published_at' => Carbon::create(2026, 3, 7, 9, 0, 0, 'UTC'),
+            'updated_at' => Carbon::create(2026, 3, 7, 10, 0, 0, 'UTC'),
+        ]);
+
+        $eligibleZh = $this->createPersonalityProfile([
+            'type_code' => 'INTJ',
+            'slug' => 'intj',
+            'locale' => 'zh-CN',
+            'is_indexable' => true,
+            'published_at' => Carbon::create(2026, 3, 7, 11, 0, 0, 'UTC'),
+            'updated_at' => Carbon::create(2026, 3, 7, 12, 0, 0, 'UTC'),
+        ]);
+
+        $this->createPersonalityProfile([
+            'type_code' => 'ENTJ',
+            'slug' => 'entj',
+            'locale' => 'en',
+            'status' => 'draft',
+            'updated_at' => Carbon::create(2026, 3, 7, 12, 30, 0, 'UTC'),
+        ]);
+        $this->createPersonalityProfile([
+            'type_code' => 'ENTP',
+            'slug' => 'entp',
+            'locale' => 'en',
+            'is_public' => false,
+            'updated_at' => Carbon::create(2026, 3, 7, 12, 45, 0, 'UTC'),
+        ]);
+        $this->createPersonalityProfile([
+            'type_code' => 'INFJ',
+            'slug' => 'infj',
+            'locale' => 'en',
+            'is_indexable' => false,
+            'updated_at' => Carbon::create(2026, 3, 7, 13, 0, 0, 'UTC'),
+        ]);
+        $this->createPersonalityProfile([
+            'org_id' => 9,
+            'type_code' => 'INFP',
+            'slug' => 'infp',
+            'locale' => 'en',
+            'updated_at' => Carbon::create(2026, 3, 7, 13, 15, 0, 'UTC'),
+        ]);
+        $this->createPersonalityProfile([
+            'scale_code' => 'DISC',
+            'type_code' => 'DISC-I',
+            'slug' => 'disc-i',
+            'locale' => 'en',
+            'updated_at' => Carbon::create(2026, 3, 7, 13, 30, 0, 'UTC'),
+        ]);
+        $this->createPersonalityProfile([
+            'type_code' => 'ISFJ',
+            'slug' => 'isfj',
+            'locale' => 'fr',
+            'updated_at' => Carbon::create(2026, 3, 7, 13, 45, 0, 'UTC'),
+        ]);
+
+        $payload = app(SitemapGenerator::class)->generate();
+        $xml = (string) ($payload['xml'] ?? '');
+        $this->assertSame(2, DB::table('personality_profiles')
+            ->where('org_id', 0)
+            ->where('scale_code', PersonalityProfile::SCALE_CODE_MBTI)
+            ->where('status', 'published')
+            ->where('is_public', 1)
+            ->where('is_indexable', 1)
+            ->whereIn('locale', PersonalityProfile::SUPPORTED_LOCALES)
+            ->where(function ($query): void {
+                $query->whereNull('published_at')
+                    ->orWhere('published_at', '<=', now());
+            })
+            ->count());
+
+        $this->assertStringContainsString('https://staging.fermatmind.com/en/personality', $xml);
+        $this->assertStringContainsString('https://staging.fermatmind.com/zh/personality', $xml);
+        $this->assertStringContainsString('https://staging.fermatmind.com/en/personality/intj', $xml);
+        $this->assertStringContainsString('https://staging.fermatmind.com/zh/personality/intj', $xml);
+
+        $this->assertStringNotContainsString('https://staging.fermatmind.com/en/personality/entj', $xml);
+        $this->assertStringNotContainsString('https://staging.fermatmind.com/en/personality/entp', $xml);
+        $this->assertStringNotContainsString('https://staging.fermatmind.com/en/personality/infj', $xml);
+        $this->assertStringNotContainsString('https://staging.fermatmind.com/en/personality/infp', $xml);
+        $this->assertStringNotContainsString('https://staging.fermatmind.com/en/personality/disc-i', $xml);
+        $this->assertStringNotContainsString('https://staging.fermatmind.com/fr/personality/isfj', $xml);
+
+        $seoService = app(PersonalityProfileSeoService::class);
+
+        $this->assertSame(
+            data_get($seoService->buildMeta($eligibleEn), 'canonical'),
+            data_get($seoService->buildJsonLd($eligibleEn), 'mainEntityOfPage')
+        );
+        $this->assertSame(
+            data_get($seoService->buildMeta($eligibleZh), 'canonical'),
+            data_get($seoService->buildJsonLd($eligibleZh), 'mainEntityOfPage')
+        );
+        $this->assertSame('AboutPage', data_get($seoService->buildJsonLd($eligibleEn), '@type'));
+        $this->assertStringContainsString(data_get($seoService->buildMeta($eligibleEn), 'canonical'), $xml);
+        $this->assertStringContainsString(data_get($seoService->buildMeta($eligibleZh), 'canonical'), $xml);
+    }
+
+    /**
+     * @param  array<string, mixed>  $overrides
+     */
+    private function createPersonalityProfile(array $overrides = []): PersonalityProfile
+    {
+        /** @var PersonalityProfile */
+        return PersonalityProfile::query()->create(array_merge([
+            'org_id' => 0,
+            'scale_code' => PersonalityProfile::SCALE_CODE_MBTI,
+            'type_code' => 'INTJ',
+            'slug' => 'intj',
+            'locale' => 'en',
+            'title' => 'INTJ Personality Type',
+            'subtitle' => 'Strategic and future-oriented.',
+            'excerpt' => 'Explore INTJ traits, strengths, and growth.',
+            'status' => 'published',
+            'is_public' => true,
+            'is_indexable' => true,
+            'published_at' => Carbon::create(2026, 3, 7, 8, 0, 0, 'UTC'),
+            'scheduled_at' => null,
+            'schema_version' => 'v1',
+            'created_at' => Carbon::create(2026, 3, 7, 8, 0, 0, 'UTC'),
+            'updated_at' => Carbon::create(2026, 3, 7, 8, 0, 0, 'UTC'),
+        ], $overrides));
     }
 }

--- a/backend/tests/Feature/SEO/SitemapXmlTest.php
+++ b/backend/tests/Feature/SEO/SitemapXmlTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Feature\SEO;
 
+use App\Models\PersonalityProfile;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Carbon;
 use Illuminate\Support\Facades\DB;
@@ -14,6 +15,7 @@ class SitemapXmlTest extends TestCase
     public function test_sitemap_xml_is_cached_and_filtered(): void
     {
         config(['services.seo.tests_url_prefix' => 'https://fermatmind.com/tests/']);
+        config(['app.frontend_url' => 'https://staging.fermatmind.com']);
 
         $nowA = Carbon::create(2026, 1, 30, 10, 0, 0);
         $nowB = Carbon::create(2026, 1, 31, 12, 0, 0);
@@ -78,6 +80,44 @@ class SitemapXmlTest extends TestCase
             ],
         ]);
 
+        PersonalityProfile::query()->create([
+            'org_id' => 0,
+            'scale_code' => PersonalityProfile::SCALE_CODE_MBTI,
+            'type_code' => 'INTJ',
+            'slug' => 'intj',
+            'locale' => 'en',
+            'title' => 'INTJ Personality Type',
+            'subtitle' => 'Strategic and future-oriented.',
+            'excerpt' => 'Explore INTJ traits, strengths, and growth.',
+            'status' => 'published',
+            'is_public' => true,
+            'is_indexable' => true,
+            'published_at' => Carbon::create(2026, 1, 31, 11, 0, 0),
+            'scheduled_at' => null,
+            'schema_version' => 'v1',
+            'created_at' => $nowB,
+            'updated_at' => $nowB,
+        ]);
+
+        PersonalityProfile::query()->create([
+            'org_id' => 0,
+            'scale_code' => PersonalityProfile::SCALE_CODE_MBTI,
+            'type_code' => 'INTJ',
+            'slug' => 'intj',
+            'locale' => 'zh-CN',
+            'title' => 'INTJ 人格类型',
+            'subtitle' => '理性、战略、面向未来。',
+            'excerpt' => '探索 INTJ 的特质、优势与成长方向。',
+            'status' => 'published',
+            'is_public' => true,
+            'is_indexable' => true,
+            'published_at' => Carbon::create(2026, 1, 31, 12, 0, 0),
+            'scheduled_at' => null,
+            'schema_version' => 'v1',
+            'created_at' => $nowB,
+            'updated_at' => $nowB,
+        ]);
+
         $response = $this->get('/sitemap.xml');
 
         $response->assertStatus(200);
@@ -94,18 +134,22 @@ class SitemapXmlTest extends TestCase
         $response->assertHeaderMissing('Set-Cookie');
 
         $body = (string) $response->getContent();
-        $prefix = rtrim((string) config('services.seo.tests_url_prefix'), '/') . '/';
-        $this->assertStringContainsString('<loc>' . $prefix . 'alpha</loc>', $body);
-        $this->assertStringContainsString('<loc>' . $prefix . 'beta</loc>', $body);
-        $this->assertStringContainsString('<loc>' . $prefix . 'gamma</loc>', $body);
-        $this->assertStringContainsString('<loc>' . $prefix . 'delta</loc>', $body);
-        $this->assertStringNotContainsString('<loc>' . $prefix . 'hidden</loc>', $body);
-        $this->assertStringNotContainsString('<loc>' . $prefix . 'hidden-alt</loc>', $body);
+        $prefix = rtrim((string) config('services.seo.tests_url_prefix'), '/').'/';
+        $this->assertStringContainsString('<loc>'.$prefix.'alpha</loc>', $body);
+        $this->assertStringContainsString('<loc>'.$prefix.'beta</loc>', $body);
+        $this->assertStringContainsString('<loc>'.$prefix.'gamma</loc>', $body);
+        $this->assertStringContainsString('<loc>'.$prefix.'delta</loc>', $body);
+        $this->assertStringNotContainsString('<loc>'.$prefix.'hidden</loc>', $body);
+        $this->assertStringNotContainsString('<loc>'.$prefix.'hidden-alt</loc>', $body);
+        $this->assertStringContainsString('<loc>https://staging.fermatmind.com/en/personality</loc>', $body);
+        $this->assertStringContainsString('<loc>https://staging.fermatmind.com/zh/personality</loc>', $body);
+        $this->assertStringContainsString('<loc>https://staging.fermatmind.com/en/personality/intj</loc>', $body);
+        $this->assertStringContainsString('<loc>https://staging.fermatmind.com/zh/personality/intj</loc>', $body);
         $this->assertStringContainsString('<changefreq>weekly</changefreq>', $body);
         $this->assertStringContainsString('<priority>0.7</priority>', $body);
         $this->assertStringContainsString('<lastmod>2026-01-30</lastmod>', $body);
         $this->assertStringContainsString('<lastmod>2026-01-31</lastmod>', $body);
-        $this->assertSame(1, substr_count($body, '<loc>' . $prefix . 'alpha</loc>'));
+        $this->assertSame(1, substr_count($body, '<loc>'.$prefix.'alpha</loc>'));
 
         $second = $this->withHeaders(['If-None-Match' => $etag])->get('/sitemap.xml');
         $second->assertStatus(304);


### PR DESCRIPTION
## Summary
- add Personality CMS list/detail URLs to the current backend sitemap authority
- align backend sitemap output with locale-aware canonical personality URLs

## What changed
- extend the current sitemap generator to include personality list/detail URLs
- filter personality URLs to published/public/indexable global MBTI content only
- harden cache invalidation for sitemap payload changes
- add minimal sitemap/seo coverage for locale-aware personality URLs and exclusion rules

## Design choices
- keep sitemap authority in fap-api because `/sitemap.xml` is currently served by backend
- use locale-aware frontend URLs (`/en/...`, `/zh/...`) as canonical sitemap entries
- keep Personality restricted to global MBTI content for v1
- reuse the existing `PersonalityProfileSeoService` because its canonical and `AboutPage` JSON-LD rules already match the required authority behavior

## Why this PR is small and safe
- no frontend changes
- no write-side API changes
- no Filament changes
- no deploy changes
- only backend sitemap/seo authority work for Personality CMS

## Validation
- `php artisan about`
- `php artisan route:list`
- `php artisan route:list --path=personality --except-vendor`
- `php artisan migrate`
- `php artisan test --filter='Sitemap|Personality'`
- `bash scripts/export_openapi.sh --check`
- `curl -I http://127.0.0.1:18011/sitemap.xml`
- `curl -sS http://127.0.0.1:18011/sitemap.xml | rg "personality"`
- `curl -sS "http://127.0.0.1:18011/api/v0.5/personality/intj/seo?org_id=0&locale=en"`
- `bash backend/scripts/ci_verify_mbti.sh`
