### PR TITLE
feat(topics-cms): add schema and models for topic profiles

### DIFF
--- a/backend/app/Models/TopicProfile.php
+++ b/backend/app/Models/TopicProfile.php
@@ -1,0 +1,120 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Models;
+
+use App\Models\Concerns\HasOrgScope;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+use Illuminate\Database\Eloquent\Relations\HasOne;
+
+class TopicProfile extends Model
+{
+    use HasFactory, HasOrgScope;
+
+    public const STATUS_DRAFT = 'draft';
+
+    public const STATUS_PUBLISHED = 'published';
+
+    public const SUPPORTED_LOCALES = [
+        'en',
+        'zh-CN',
+    ];
+
+    protected $table = 'topic_profiles';
+
+    protected $fillable = [
+        'org_id',
+        'topic_code',
+        'slug',
+        'locale',
+        'title',
+        'subtitle',
+        'excerpt',
+        'hero_kicker',
+        'hero_quote',
+        'cover_image_url',
+        'status',
+        'is_public',
+        'is_indexable',
+        'published_at',
+        'scheduled_at',
+        'schema_version',
+        'sort_order',
+        'created_by_admin_user_id',
+        'updated_by_admin_user_id',
+    ];
+
+    protected $casts = [
+        'org_id' => 'integer',
+        'sort_order' => 'integer',
+        'created_by_admin_user_id' => 'integer',
+        'updated_by_admin_user_id' => 'integer',
+        'is_public' => 'boolean',
+        'is_indexable' => 'boolean',
+        'published_at' => 'datetime',
+        'scheduled_at' => 'datetime',
+        'created_at' => 'datetime',
+        'updated_at' => 'datetime',
+    ];
+
+    public static function allowOrgZeroContext(): bool
+    {
+        return true;
+    }
+
+    public function sections(): HasMany
+    {
+        return $this->hasMany(TopicProfileSection::class, 'profile_id', 'id')
+            ->orderBy('sort_order')
+            ->orderBy('id');
+    }
+
+    public function entries(): HasMany
+    {
+        return $this->hasMany(TopicProfileEntry::class, 'profile_id', 'id')
+            ->orderBy('sort_order')
+            ->orderBy('id');
+    }
+
+    public function seoMeta(): HasOne
+    {
+        return $this->hasOne(TopicProfileSeoMeta::class, 'profile_id', 'id');
+    }
+
+    public function revisions(): HasMany
+    {
+        return $this->hasMany(TopicProfileRevision::class, 'profile_id', 'id')
+            ->orderByDesc('revision_no')
+            ->orderByDesc('id');
+    }
+
+    public function scopePublishedPublic($query)
+    {
+        return $query
+            ->where('status', self::STATUS_PUBLISHED)
+            ->where('is_public', true);
+    }
+
+    public function scopeIndexable($query)
+    {
+        return $query->where('is_indexable', true);
+    }
+
+    public function scopeForLocale($query, string $locale)
+    {
+        return $query->where('locale', $locale);
+    }
+
+    public function scopeForSlug($query, string $slug)
+    {
+        return $query->where('slug', strtolower(trim($slug)));
+    }
+
+    public function scopeForTopicCode($query, string $topicCode)
+    {
+        return $query->where('topic_code', strtolower(trim($topicCode)));
+    }
+}

--- a/backend/app/Models/TopicProfileEntry.php
+++ b/backend/app/Models/TopicProfileEntry.php
@@ -1,0 +1,73 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+class TopicProfileEntry extends Model
+{
+    use HasFactory;
+
+    public const ENTRY_TYPES = [
+        'article',
+        'personality_profile',
+        'scale',
+        'custom_link',
+    ];
+
+    public const GROUP_KEYS = [
+        'featured',
+        'articles',
+        'personalities',
+        'tests',
+        'related',
+    ];
+
+    protected $table = 'topic_profile_entries';
+
+    protected $fillable = [
+        'profile_id',
+        'entry_type',
+        'group_key',
+        'target_key',
+        'target_locale',
+        'title_override',
+        'excerpt_override',
+        'badge_label',
+        'cta_label',
+        'target_url_override',
+        'payload_json',
+        'sort_order',
+        'is_featured',
+        'is_enabled',
+    ];
+
+    protected $casts = [
+        'profile_id' => 'integer',
+        'payload_json' => 'array',
+        'sort_order' => 'integer',
+        'is_featured' => 'boolean',
+        'is_enabled' => 'boolean',
+        'created_at' => 'datetime',
+        'updated_at' => 'datetime',
+    ];
+
+    public function profile(): BelongsTo
+    {
+        return $this->belongsTo(TopicProfile::class, 'profile_id', 'id');
+    }
+
+    public function isCustomLink(): bool
+    {
+        return $this->entry_type === 'custom_link';
+    }
+
+    public function effectiveTargetLocale(?string $fallbackLocale = null): ?string
+    {
+        return $this->target_locale ?: $fallbackLocale;
+    }
+}

--- a/backend/app/Models/TopicProfileRevision.php
+++ b/backend/app/Models/TopicProfileRevision.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+class TopicProfileRevision extends Model
+{
+    use HasFactory;
+
+    protected $table = 'topic_profile_revisions';
+
+    public $timestamps = false;
+
+    protected $fillable = [
+        'profile_id',
+        'revision_no',
+        'snapshot_json',
+        'note',
+        'created_by_admin_user_id',
+        'created_at',
+    ];
+
+    protected $casts = [
+        'profile_id' => 'integer',
+        'revision_no' => 'integer',
+        'snapshot_json' => 'array',
+        'created_by_admin_user_id' => 'integer',
+        'created_at' => 'datetime',
+    ];
+
+    public function profile(): BelongsTo
+    {
+        return $this->belongsTo(TopicProfile::class, 'profile_id', 'id');
+    }
+}

--- a/backend/app/Models/TopicProfileSection.php
+++ b/backend/app/Models/TopicProfileSection.php
@@ -1,0 +1,61 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+class TopicProfileSection extends Model
+{
+    use HasFactory;
+
+    public const SECTION_KEYS = [
+        'hero',
+        'overview',
+        'key_concepts',
+        'why_it_matters',
+        'who_should_read',
+        'faq',
+        'related_topics_intro',
+    ];
+
+    public const RENDER_VARIANTS = [
+        'rich_text',
+        'bullets',
+        'cards',
+        'faq',
+        'links',
+        'callout',
+    ];
+
+    protected $table = 'topic_profile_sections';
+
+    protected $fillable = [
+        'profile_id',
+        'section_key',
+        'title',
+        'render_variant',
+        'body_md',
+        'body_html',
+        'payload_json',
+        'sort_order',
+        'is_enabled',
+    ];
+
+    protected $casts = [
+        'profile_id' => 'integer',
+        'payload_json' => 'array',
+        'sort_order' => 'integer',
+        'is_enabled' => 'boolean',
+        'created_at' => 'datetime',
+        'updated_at' => 'datetime',
+    ];
+
+    public function profile(): BelongsTo
+    {
+        return $this->belongsTo(TopicProfile::class, 'profile_id', 'id');
+    }
+}

--- a/backend/app/Models/TopicProfileSeoMeta.php
+++ b/backend/app/Models/TopicProfileSeoMeta.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+class TopicProfileSeoMeta extends Model
+{
+    use HasFactory;
+
+    protected $table = 'topic_profile_seo_meta';
+
+    protected $fillable = [
+        'profile_id',
+        'seo_title',
+        'seo_description',
+        'canonical_url',
+        'og_title',
+        'og_description',
+        'og_image_url',
+        'twitter_title',
+        'twitter_description',
+        'twitter_image_url',
+        'robots',
+        'jsonld_overrides_json',
+    ];
+
+    protected $casts = [
+        'profile_id' => 'integer',
+        'jsonld_overrides_json' => 'array',
+        'created_at' => 'datetime',
+        'updated_at' => 'datetime',
+    ];
+
+    public function profile(): BelongsTo
+    {
+        return $this->belongsTo(TopicProfile::class, 'profile_id', 'id');
+    }
+}

--- a/backend/database/migrations/2026_03_08_000200_create_topic_profiles_table.php
+++ b/backend/database/migrations/2026_03_08_000200_create_topic_profiles_table.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('topic_profiles', function (Blueprint $table): void {
+            $table->bigIncrements('id');
+            $table->unsignedBigInteger('org_id')->default(0);
+            $table->string('topic_code', 64);
+            $table->string('slug', 128);
+            $table->string('locale', 16);
+            $table->string('title', 255);
+            $table->string('subtitle', 255)->nullable();
+            $table->text('excerpt')->nullable();
+            $table->string('hero_kicker', 128)->nullable();
+            $table->text('hero_quote')->nullable();
+            $table->text('cover_image_url')->nullable();
+            $table->string('status', 32)->default('draft');
+            $table->boolean('is_public')->default(true);
+            $table->boolean('is_indexable')->default(true);
+            $table->timestamp('published_at')->nullable();
+            $table->timestamp('scheduled_at')->nullable();
+            $table->string('schema_version', 32)->default('v1');
+            $table->integer('sort_order')->default(0);
+            $table->unsignedBigInteger('created_by_admin_user_id')->nullable();
+            $table->unsignedBigInteger('updated_by_admin_user_id')->nullable();
+            $table->timestamps();
+
+            $table->unique(['org_id', 'topic_code', 'locale'], 'uq_topic_profile');
+            $table->unique(['org_id', 'slug', 'locale'], 'uq_topic_slug');
+            $table->index(['status', 'is_public', 'published_at'], 'idx_topic_status');
+            $table->index(['locale'], 'idx_topic_locale');
+            $table->index(['locale', 'sort_order'], 'idx_topic_sort');
+        });
+    }
+
+    public function down(): void
+    {
+        // forward-only migration: rollback disabled to prevent data loss in production.
+        // Irreversible operation: schema/data rollback handled via forward fix migrations.
+    }
+};

--- a/backend/database/migrations/2026_03_08_000210_create_topic_profile_sections_table.php
+++ b/backend/database/migrations/2026_03_08_000210_create_topic_profile_sections_table.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        $isSqlite = Schema::getConnection()->getDriverName() === 'sqlite';
+
+        Schema::create('topic_profile_sections', function (Blueprint $table) use ($isSqlite): void {
+            $table->bigIncrements('id');
+            $table->unsignedBigInteger('profile_id');
+            $table->string('section_key', 64);
+            $table->string('title', 255)->nullable();
+            $table->string('render_variant', 32)->default('rich_text');
+            $table->longText('body_md')->nullable();
+            $table->longText('body_html')->nullable();
+            if ($isSqlite) {
+                $table->text('payload_json')->nullable();
+            } else {
+                $table->json('payload_json')->nullable();
+            }
+            $table->integer('sort_order')->default(0);
+            $table->boolean('is_enabled')->default(true);
+            $table->timestamps();
+
+            $table->unique(['profile_id', 'section_key'], 'uq_topic_section');
+            $table->index(['profile_id', 'sort_order'], 'idx_topic_section_sort');
+            $table->foreign('profile_id', 'fk_topic_section_profile')
+                ->references('id')
+                ->on('topic_profiles')
+                ->cascadeOnDelete();
+        });
+    }
+
+    public function down(): void
+    {
+        // forward-only migration: rollback disabled to prevent data loss in production.
+        // Irreversible operation: schema/data rollback handled via forward fix migrations.
+    }
+};

--- a/backend/database/migrations/2026_03_08_000220_create_topic_profile_entries_table.php
+++ b/backend/database/migrations/2026_03_08_000220_create_topic_profile_entries_table.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        $isSqlite = Schema::getConnection()->getDriverName() === 'sqlite';
+
+        Schema::create('topic_profile_entries', function (Blueprint $table) use ($isSqlite): void {
+            $table->bigIncrements('id');
+            $table->unsignedBigInteger('profile_id');
+            $table->string('entry_type', 32);
+            $table->string('group_key', 32);
+            $table->string('target_key', 128);
+            $table->string('target_locale', 16)->nullable();
+            $table->string('title_override', 255)->nullable();
+            $table->text('excerpt_override')->nullable();
+            $table->string('badge_label', 64)->nullable();
+            $table->string('cta_label', 64)->nullable();
+            $table->text('target_url_override')->nullable();
+            if ($isSqlite) {
+                $table->text('payload_json')->nullable();
+            } else {
+                $table->json('payload_json')->nullable();
+            }
+            $table->integer('sort_order')->default(0);
+            $table->boolean('is_featured')->default(false);
+            $table->boolean('is_enabled')->default(true);
+            $table->timestamps();
+
+            $table->index(['profile_id', 'group_key', 'sort_order'], 'idx_topic_entries_group');
+            $table->index(['profile_id', 'entry_type', 'is_enabled'], 'idx_topic_entries_type');
+            $table->index(['entry_type', 'target_key', 'target_locale'], 'idx_topic_entries_target');
+            $table->foreign('profile_id', 'fk_topic_entry_profile')
+                ->references('id')
+                ->on('topic_profiles')
+                ->cascadeOnDelete();
+        });
+    }
+
+    public function down(): void
+    {
+        // forward-only migration: rollback disabled to prevent data loss in production.
+        // Irreversible operation: schema/data rollback handled via forward fix migrations.
+    }
+};

--- a/backend/database/migrations/2026_03_08_000230_create_topic_profile_seo_meta_table.php
+++ b/backend/database/migrations/2026_03_08_000230_create_topic_profile_seo_meta_table.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        $isSqlite = Schema::getConnection()->getDriverName() === 'sqlite';
+
+        Schema::create('topic_profile_seo_meta', function (Blueprint $table) use ($isSqlite): void {
+            $table->bigIncrements('id');
+            $table->unsignedBigInteger('profile_id');
+            $table->string('seo_title', 255)->nullable();
+            $table->text('seo_description')->nullable();
+            $table->text('canonical_url')->nullable();
+            $table->string('og_title', 255)->nullable();
+            $table->text('og_description')->nullable();
+            $table->text('og_image_url')->nullable();
+            $table->string('twitter_title', 255)->nullable();
+            $table->text('twitter_description')->nullable();
+            $table->text('twitter_image_url')->nullable();
+            $table->string('robots', 64)->nullable();
+            if ($isSqlite) {
+                $table->text('jsonld_overrides_json')->nullable();
+            } else {
+                $table->json('jsonld_overrides_json')->nullable();
+            }
+            $table->timestamps();
+
+            $table->unique(['profile_id'], 'uq_topic_seo');
+            $table->foreign('profile_id', 'fk_topic_seo_profile')
+                ->references('id')
+                ->on('topic_profiles')
+                ->cascadeOnDelete();
+        });
+    }
+
+    public function down(): void
+    {
+        // forward-only migration: rollback disabled to prevent data loss in production.
+        // Irreversible operation: schema/data rollback handled via forward fix migrations.
+    }
+};

--- a/backend/database/migrations/2026_03_08_000240_create_topic_profile_revisions_table.php
+++ b/backend/database/migrations/2026_03_08_000240_create_topic_profile_revisions_table.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        $isSqlite = Schema::getConnection()->getDriverName() === 'sqlite';
+
+        Schema::create('topic_profile_revisions', function (Blueprint $table) use ($isSqlite): void {
+            $table->bigIncrements('id');
+            $table->unsignedBigInteger('profile_id');
+            $table->unsignedInteger('revision_no');
+            if ($isSqlite) {
+                $table->text('snapshot_json');
+            } else {
+                $table->json('snapshot_json');
+            }
+            $table->string('note', 255)->nullable();
+            $table->unsignedBigInteger('created_by_admin_user_id')->nullable();
+            $table->timestamp('created_at')->nullable();
+
+            $table->unique(['profile_id', 'revision_no'], 'uq_topic_revision');
+            $table->index(['profile_id', 'created_at'], 'idx_topic_revision_created');
+            $table->foreign('profile_id', 'fk_topic_revision_profile')
+                ->references('id')
+                ->on('topic_profiles')
+                ->cascadeOnDelete();
+        });
+    }
+
+    public function down(): void
+    {
+        // forward-only migration: rollback disabled to prevent data loss in production.
+        // Irreversible operation: schema/data rollback handled via forward fix migrations.
+    }
+};

--- a/backend/tests/Feature/TopicsCms/TopicSchemaSmokeTest.php
+++ b/backend/tests/Feature/TopicsCms/TopicSchemaSmokeTest.php
@@ -1,0 +1,237 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\TopicsCms;
+
+use App\Models\TopicProfile;
+use App\Models\TopicProfileEntry;
+use App\Models\TopicProfileRevision;
+use App\Models\TopicProfileSection;
+use App\Models\TopicProfileSeoMeta;
+use Illuminate\Database\QueryException;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+final class TopicSchemaSmokeTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_profile_relations_scopes_and_casts_work(): void
+    {
+        $profile = TopicProfile::query()->create([
+            'org_id' => 0,
+            'topic_code' => 'mbti',
+            'slug' => 'mbti',
+            'locale' => 'en',
+            'title' => 'MBTI topic hub',
+            'subtitle' => 'Structured guidance for MBTI readers',
+            'excerpt' => 'A short topic overview.',
+            'hero_kicker' => 'Topic hub',
+            'hero_quote' => 'Find the next read with context.',
+            'cover_image_url' => 'https://cdn.example.test/topic.png',
+            'status' => TopicProfile::STATUS_PUBLISHED,
+            'is_public' => true,
+            'is_indexable' => true,
+            'schema_version' => 'v1',
+            'sort_order' => 10,
+            'published_at' => now(),
+        ]);
+
+        TopicProfileSection::query()->create([
+            'profile_id' => $profile->id,
+            'section_key' => 'overview',
+            'title' => 'Overview',
+            'render_variant' => 'rich_text',
+            'body_md' => 'A topic overview.',
+            'payload_json' => ['chips' => ['MBTI']],
+            'sort_order' => 10,
+            'is_enabled' => true,
+        ]);
+
+        TopicProfileSection::query()->create([
+            'profile_id' => $profile->id,
+            'section_key' => 'faq',
+            'title' => 'FAQ',
+            'render_variant' => 'faq',
+            'payload_json' => [
+                'items' => [
+                    ['q' => 'What is MBTI?', 'a' => 'A personality framework.'],
+                ],
+            ],
+            'sort_order' => 20,
+            'is_enabled' => true,
+        ]);
+
+        $entryA = TopicProfileEntry::query()->create([
+            'profile_id' => $profile->id,
+            'entry_type' => 'custom_link',
+            'group_key' => 'featured',
+            'target_key' => 'mbti-intro',
+            'target_locale' => 'en',
+            'title_override' => 'Start here',
+            'target_url_override' => 'https://example.test/en/topics/mbti',
+            'payload_json' => ['style' => 'hero'],
+            'sort_order' => 10,
+            'is_featured' => true,
+            'is_enabled' => true,
+        ]);
+
+        $entryB = TopicProfileEntry::query()->create([
+            'profile_id' => $profile->id,
+            'entry_type' => 'article',
+            'group_key' => 'articles',
+            'target_key' => 'mbti-personality-test-16-personality-types',
+            'target_locale' => null,
+            'excerpt_override' => 'Why MBTI matters in practice.',
+            'payload_json' => ['rank' => 1],
+            'sort_order' => 20,
+            'is_featured' => false,
+            'is_enabled' => true,
+        ]);
+
+        TopicProfileSeoMeta::query()->create([
+            'profile_id' => $profile->id,
+            'seo_title' => 'MBTI topic hub',
+            'seo_description' => 'Understand MBTI and its adjacent content.',
+            'jsonld_overrides_json' => ['@type' => 'CollectionPage'],
+        ]);
+
+        TopicProfileRevision::query()->create([
+            'profile_id' => $profile->id,
+            'revision_no' => 1,
+            'snapshot_json' => ['title' => 'MBTI topic hub'],
+            'note' => 'Initial draft',
+            'created_at' => now()->subMinute(),
+        ]);
+
+        TopicProfileRevision::query()->create([
+            'profile_id' => $profile->id,
+            'revision_no' => 2,
+            'snapshot_json' => ['title' => 'MBTI topic hub v2'],
+            'note' => 'Publish update',
+            'created_at' => now(),
+        ]);
+
+        $freshProfile = TopicProfile::query()->findOrFail($profile->id);
+
+        $this->assertSame(
+            ['overview', 'faq'],
+            $freshProfile->sections()->pluck('section_key')->all()
+        );
+        $this->assertSame(
+            [$entryA->id, $entryB->id],
+            $freshProfile->entries()->pluck('id')->all()
+        );
+        $this->assertSame('MBTI topic hub', $freshProfile->seoMeta?->seo_title);
+        $this->assertSame([2, 1], $freshProfile->revisions()->pluck('revision_no')->all());
+        $this->assertSame(
+            [$profile->id],
+            TopicProfile::query()
+                ->publishedPublic()
+                ->indexable()
+                ->forLocale('en')
+                ->forSlug('MBTI')
+                ->forTopicCode('MBTI')
+                ->pluck('id')
+                ->all()
+        );
+        $this->assertSame(['chips' => ['MBTI']], $freshProfile->sections()->firstOrFail()->payload_json);
+        $this->assertSame(['@type' => 'CollectionPage'], $freshProfile->seoMeta?->jsonld_overrides_json);
+        $this->assertTrue($entryA->fresh()->isCustomLink());
+        $this->assertSame('en', $entryB->fresh()->effectiveTargetLocale('en'));
+        $this->assertTrue($entryA->fresh()->is_featured);
+        $this->assertTrue($entryB->fresh()->is_enabled);
+    }
+
+    public function test_unique_org_topic_code_locale_constraint_is_enforced(): void
+    {
+        TopicProfile::query()->create($this->profilePayload([
+            'topic_code' => 'mbti',
+            'slug' => 'mbti',
+        ]));
+
+        $this->expectException(QueryException::class);
+
+        TopicProfile::query()->create($this->profilePayload([
+            'topic_code' => 'mbti',
+            'slug' => 'mbti-second',
+        ]));
+    }
+
+    public function test_unique_org_slug_locale_constraint_is_enforced(): void
+    {
+        TopicProfile::query()->create($this->profilePayload([
+            'topic_code' => 'big-five',
+            'slug' => 'personality-basics',
+        ]));
+
+        $this->expectException(QueryException::class);
+
+        TopicProfile::query()->create($this->profilePayload([
+            'topic_code' => 'self-awareness',
+            'slug' => 'personality-basics',
+        ]));
+    }
+
+    public function test_deleting_profile_cascades_sections_entries_seo_meta_and_revisions(): void
+    {
+        $profile = TopicProfile::query()->create($this->profilePayload([
+            'topic_code' => 'self-awareness',
+            'slug' => 'self-awareness',
+        ]));
+
+        $section = TopicProfileSection::query()->create([
+            'profile_id' => $profile->id,
+            'section_key' => 'overview',
+            'render_variant' => 'rich_text',
+        ]);
+
+        $entry = TopicProfileEntry::query()->create([
+            'profile_id' => $profile->id,
+            'entry_type' => 'article',
+            'group_key' => 'articles',
+            'target_key' => 'how-to-find-right-career-direction',
+        ]);
+
+        $seoMeta = TopicProfileSeoMeta::query()->create([
+            'profile_id' => $profile->id,
+            'seo_title' => 'Self awareness topic',
+        ]);
+
+        $revision = TopicProfileRevision::query()->create([
+            'profile_id' => $profile->id,
+            'revision_no' => 1,
+            'snapshot_json' => ['slug' => 'self-awareness'],
+            'created_at' => now(),
+        ]);
+
+        $profile->delete();
+
+        $this->assertDatabaseMissing('topic_profiles', ['id' => $profile->id]);
+        $this->assertDatabaseMissing('topic_profile_sections', ['id' => $section->id]);
+        $this->assertDatabaseMissing('topic_profile_entries', ['id' => $entry->id]);
+        $this->assertDatabaseMissing('topic_profile_seo_meta', ['id' => $seoMeta->id]);
+        $this->assertDatabaseMissing('topic_profile_revisions', ['id' => $revision->id]);
+    }
+
+    /**
+     * @param  array<string, mixed>  $overrides
+     * @return array<string, mixed>
+     */
+    private function profilePayload(array $overrides = []): array
+    {
+        return array_merge([
+            'org_id' => 0,
+            'topic_code' => 'mbti',
+            'slug' => 'mbti',
+            'locale' => 'en',
+            'title' => 'Topic profile',
+            'status' => TopicProfile::STATUS_DRAFT,
+            'is_public' => true,
+            'is_indexable' => true,
+            'schema_version' => 'v1',
+            'sort_order' => 0,
+        ], $overrides);
+    }
+}


### PR DESCRIPTION
Summary
- add the initial database schema and Eloquent models for Topics CMS v1
- establish a structured topic profile/section/entry/seo/revision data model for topic hub pages

What changed
- add topic_profiles
- add topic_profile_sections
- add topic_profile_entries
- add topic_profile_seo_meta
- add topic_profile_revisions
- add the corresponding Eloquent models and relationships
- add minimal schema/model smoke coverage

Design choices
- topics are modeled as structured hub profiles instead of generic articles or tags
- narrative sections and aggregated entries are stored separately
- v1 targets global topic content (org_id=0)
- entry references prefer stable target_key / target_locale instead of environment-specific IDs
- JSON field compatibility follows the repository’s existing sqlite/mysql strategy
- migrations follow the repository’s forward-only rollback style

Why this PR is small and safe
- no API changes
- no route changes
- no RBAC changes
- no frontend changes
- no service layer changes
- only schema/model groundwork for later Topics CMS PRs

Validation
- php artisan about
- php artisan migrate:status
- php artisan migrate
- php artisan route:list
- php artisan tinker --execute="dump([\Schema::hasTable('topic_profiles'), \Schema::hasTable('topic_profile_sections'), \Schema::hasTable('topic_profile_entries'), \Schema::hasTable('topic_profile_seo_meta'), \Schema::hasTable('topic_profile_revisions')]);"
- php artisan test --filter=TopicSchemaSmokeTest
- ./vendor/bin/pint app/Models/TopicProfile.php app/Models/TopicProfileSection.php app/Models/TopicProfileEntry.php app/Models/TopicProfileSeoMeta.php app/Models/TopicProfileRevision.php database/migrations/2026_03_08_000200_create_topic_profiles_table.php database/migrations/2026_03_08_000210_create_topic_profile_sections_table.php database/migrations/2026_03_08_000220_create_topic_profile_entries_table.php database/migrations/2026_03_08_000230_create_topic_profile_seo_meta_table.php database/migrations/2026_03_08_000240_create_topic_profile_revisions_table.php tests/Feature/TopicsCms/TopicSchemaSmokeTest.php
- bash backend/scripts/ci_verify_mbti.sh
