### PR TITLE
feat(topics-cms): add public api, resolver, and seo service for topic profiles

### DIFF
--- a/backend/app/Http/Controllers/API/V0_5/Cms/TopicController.php
+++ b/backend/app/Http/Controllers/API/V0_5/Cms/TopicController.php
@@ -1,0 +1,276 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Controllers\API\V0_5\Cms;
+
+use App\Http\Controllers\Concerns\RespondsWithNotFound;
+use App\Http\Controllers\Controller;
+use App\Models\TopicProfile;
+use App\Models\TopicProfileSection;
+use App\Models\TopicProfileSeoMeta;
+use App\Services\Cms\TopicEntryResolverService;
+use App\Services\Cms\TopicProfileSeoService;
+use App\Services\Cms\TopicProfileService;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Validator;
+
+final class TopicController extends Controller
+{
+    use RespondsWithNotFound;
+
+    public function __construct(
+        private readonly TopicProfileService $topicProfileService,
+        private readonly TopicEntryResolverService $topicEntryResolverService,
+        private readonly TopicProfileSeoService $topicProfileSeoService,
+    ) {}
+
+    public function index(Request $request): JsonResponse
+    {
+        $validated = $this->validateListQuery($request);
+        if ($validated instanceof JsonResponse) {
+            return $validated;
+        }
+
+        $paginator = $this->topicProfileService->listPublicTopics(
+            $validated['org_id'],
+            $validated['locale'],
+            $validated['page'],
+            $validated['per_page'],
+        );
+
+        $items = [];
+        foreach ($paginator->items() as $profile) {
+            if (! $profile instanceof TopicProfile) {
+                continue;
+            }
+
+            $items[] = $this->profileListPayload($profile);
+        }
+
+        return response()->json([
+            'ok' => true,
+            'items' => $items,
+            'pagination' => [
+                'current_page' => (int) $paginator->currentPage(),
+                'per_page' => (int) $paginator->perPage(),
+                'total' => (int) $paginator->total(),
+                'last_page' => (int) $paginator->lastPage(),
+            ],
+        ]);
+    }
+
+    public function show(Request $request, string $slug): JsonResponse
+    {
+        $validated = $this->validateReadQuery($request);
+        if ($validated instanceof JsonResponse) {
+            return $validated;
+        }
+
+        $profile = $this->topicProfileService->getPublicTopicBySlug(
+            $slug,
+            $validated['org_id'],
+            $validated['locale'],
+        );
+
+        if (! $profile instanceof TopicProfile) {
+            return $this->notFoundResponse('topic not found.');
+        }
+
+        return response()->json([
+            'ok' => true,
+            'profile' => $this->profileDetailPayload($profile),
+            'sections' => array_map(
+                fn (TopicProfileSection $section): array => $this->sectionPayload($section),
+                $profile->sections->all()
+            ),
+            'entry_groups' => $this->topicEntryResolverService->resolveGroupedEntries($profile, $validated['locale']),
+            'seo_meta' => $this->seoMetaPayload($profile->seoMeta),
+        ]);
+    }
+
+    public function seo(Request $request, string $slug): JsonResponse
+    {
+        $validated = $this->validateReadQuery($request);
+        if ($validated instanceof JsonResponse) {
+            return $validated;
+        }
+
+        $profile = $this->topicProfileService->getPublicTopicBySlug(
+            $slug,
+            $validated['org_id'],
+            $validated['locale'],
+        );
+
+        if (! $profile instanceof TopicProfile) {
+            return response()->json(['error' => 'not found'], 404);
+        }
+
+        return response()->json([
+            'meta' => $this->topicProfileSeoService->buildMeta($profile, $validated['locale']),
+            'jsonld' => $this->topicProfileSeoService->buildJsonLd($profile, $validated['locale']),
+        ]);
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function profileListPayload(TopicProfile $profile): array
+    {
+        return [
+            'id' => (int) $profile->id,
+            'org_id' => (int) $profile->org_id,
+            'topic_code' => (string) $profile->topic_code,
+            'slug' => (string) $profile->slug,
+            'locale' => (string) $profile->locale,
+            'title' => (string) $profile->title,
+            'subtitle' => $profile->subtitle,
+            'excerpt' => $profile->excerpt,
+            'status' => (string) $profile->status,
+            'is_public' => (bool) $profile->is_public,
+            'is_indexable' => (bool) $profile->is_indexable,
+            'published_at' => $profile->published_at?->toISOString(),
+            'updated_at' => $profile->updated_at?->toISOString(),
+            'seo_meta' => $this->seoMetaSummaryPayload($profile->seoMeta),
+        ];
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function profileDetailPayload(TopicProfile $profile): array
+    {
+        return [
+            'id' => (int) $profile->id,
+            'org_id' => (int) $profile->org_id,
+            'topic_code' => (string) $profile->topic_code,
+            'slug' => (string) $profile->slug,
+            'locale' => (string) $profile->locale,
+            'title' => (string) $profile->title,
+            'subtitle' => $profile->subtitle,
+            'excerpt' => $profile->excerpt,
+            'hero_kicker' => $profile->hero_kicker,
+            'hero_quote' => $profile->hero_quote,
+            'cover_image_url' => $profile->cover_image_url,
+            'status' => (string) $profile->status,
+            'is_public' => (bool) $profile->is_public,
+            'is_indexable' => (bool) $profile->is_indexable,
+            'published_at' => $profile->published_at?->toISOString(),
+            'updated_at' => $profile->updated_at?->toISOString(),
+        ];
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function sectionPayload(TopicProfileSection $section): array
+    {
+        return [
+            'section_key' => (string) $section->section_key,
+            'title' => $section->title,
+            'render_variant' => (string) $section->render_variant,
+            'body_md' => $section->body_md,
+            'body_html' => $section->body_html,
+            'payload_json' => $section->payload_json,
+            'sort_order' => (int) $section->sort_order,
+            'is_enabled' => (bool) $section->is_enabled,
+        ];
+    }
+
+    /**
+     * @return array<string, mixed>|null
+     */
+    private function seoMetaPayload(?TopicProfileSeoMeta $seoMeta): ?array
+    {
+        if (! $seoMeta instanceof TopicProfileSeoMeta) {
+            return null;
+        }
+
+        return [
+            'seo_title' => $seoMeta->seo_title,
+            'seo_description' => $seoMeta->seo_description,
+            'canonical_url' => $seoMeta->canonical_url,
+            'og_title' => $seoMeta->og_title,
+            'og_description' => $seoMeta->og_description,
+            'og_image_url' => $seoMeta->og_image_url,
+            'twitter_title' => $seoMeta->twitter_title,
+            'twitter_description' => $seoMeta->twitter_description,
+            'twitter_image_url' => $seoMeta->twitter_image_url,
+            'robots' => $seoMeta->robots,
+            'jsonld_overrides_json' => $seoMeta->jsonld_overrides_json,
+        ];
+    }
+
+    /**
+     * @return array<string, mixed>|null
+     */
+    private function seoMetaSummaryPayload(?TopicProfileSeoMeta $seoMeta): ?array
+    {
+        if (! $seoMeta instanceof TopicProfileSeoMeta) {
+            return null;
+        }
+
+        return [
+            'seo_title' => $seoMeta->seo_title,
+            'seo_description' => $seoMeta->seo_description,
+        ];
+    }
+
+    /**
+     * @return array{org_id:int,locale:string,page:int,per_page:int}|JsonResponse
+     */
+    private function validateListQuery(Request $request): array|JsonResponse
+    {
+        $validator = Validator::make($request->query(), [
+            'org_id' => ['nullable', 'integer', 'min:0'],
+            'locale' => ['required', 'in:en,zh-CN'],
+            'page' => ['nullable', 'integer', 'min:1'],
+            'per_page' => ['nullable', 'integer', 'min:1', 'max:100'],
+        ]);
+
+        if ($validator->fails()) {
+            return $this->invalidArgument($validator->errors()->first());
+        }
+
+        $validated = $validator->validated();
+
+        return [
+            'org_id' => (int) ($validated['org_id'] ?? 0),
+            'locale' => (string) $validated['locale'],
+            'page' => (int) ($validated['page'] ?? 1),
+            'per_page' => (int) ($validated['per_page'] ?? 20),
+        ];
+    }
+
+    /**
+     * @return array{org_id:int,locale:string}|JsonResponse
+     */
+    private function validateReadQuery(Request $request): array|JsonResponse
+    {
+        $validator = Validator::make($request->query(), [
+            'org_id' => ['nullable', 'integer', 'min:0'],
+            'locale' => ['required', 'in:en,zh-CN'],
+        ]);
+
+        if ($validator->fails()) {
+            return $this->invalidArgument($validator->errors()->first());
+        }
+
+        $validated = $validator->validated();
+
+        return [
+            'org_id' => (int) ($validated['org_id'] ?? 0),
+            'locale' => (string) $validated['locale'],
+        ];
+    }
+
+    private function invalidArgument(string $message): JsonResponse
+    {
+        return response()->json([
+            'ok' => false,
+            'error_code' => 'INVALID_ARGUMENT',
+            'message' => $message,
+        ], 422);
+    }
+}

--- a/backend/app/Models/TopicProfile.php
+++ b/backend/app/Models/TopicProfile.php
@@ -1,0 +1,120 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Models;
+
+use App\Models\Concerns\HasOrgScope;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+use Illuminate\Database\Eloquent\Relations\HasOne;
+
+class TopicProfile extends Model
+{
+    use HasFactory, HasOrgScope;
+
+    public const STATUS_DRAFT = 'draft';
+
+    public const STATUS_PUBLISHED = 'published';
+
+    public const SUPPORTED_LOCALES = [
+        'en',
+        'zh-CN',
+    ];
+
+    protected $table = 'topic_profiles';
+
+    protected $fillable = [
+        'org_id',
+        'topic_code',
+        'slug',
+        'locale',
+        'title',
+        'subtitle',
+        'excerpt',
+        'hero_kicker',
+        'hero_quote',
+        'cover_image_url',
+        'status',
+        'is_public',
+        'is_indexable',
+        'published_at',
+        'scheduled_at',
+        'schema_version',
+        'sort_order',
+        'created_by_admin_user_id',
+        'updated_by_admin_user_id',
+    ];
+
+    protected $casts = [
+        'org_id' => 'integer',
+        'sort_order' => 'integer',
+        'created_by_admin_user_id' => 'integer',
+        'updated_by_admin_user_id' => 'integer',
+        'is_public' => 'boolean',
+        'is_indexable' => 'boolean',
+        'published_at' => 'datetime',
+        'scheduled_at' => 'datetime',
+        'created_at' => 'datetime',
+        'updated_at' => 'datetime',
+    ];
+
+    public static function allowOrgZeroContext(): bool
+    {
+        return true;
+    }
+
+    public function sections(): HasMany
+    {
+        return $this->hasMany(TopicProfileSection::class, 'profile_id', 'id')
+            ->orderBy('sort_order')
+            ->orderBy('id');
+    }
+
+    public function entries(): HasMany
+    {
+        return $this->hasMany(TopicProfileEntry::class, 'profile_id', 'id')
+            ->orderBy('sort_order')
+            ->orderBy('id');
+    }
+
+    public function seoMeta(): HasOne
+    {
+        return $this->hasOne(TopicProfileSeoMeta::class, 'profile_id', 'id');
+    }
+
+    public function revisions(): HasMany
+    {
+        return $this->hasMany(TopicProfileRevision::class, 'profile_id', 'id')
+            ->orderByDesc('revision_no')
+            ->orderByDesc('id');
+    }
+
+    public function scopePublishedPublic($query)
+    {
+        return $query
+            ->where('status', self::STATUS_PUBLISHED)
+            ->where('is_public', true);
+    }
+
+    public function scopeIndexable($query)
+    {
+        return $query->where('is_indexable', true);
+    }
+
+    public function scopeForLocale($query, string $locale)
+    {
+        return $query->where('locale', $locale);
+    }
+
+    public function scopeForSlug($query, string $slug)
+    {
+        return $query->where('slug', strtolower(trim($slug)));
+    }
+
+    public function scopeForTopicCode($query, string $topicCode)
+    {
+        return $query->where('topic_code', strtolower(trim($topicCode)));
+    }
+}

--- a/backend/app/Models/TopicProfileEntry.php
+++ b/backend/app/Models/TopicProfileEntry.php
@@ -1,0 +1,73 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+class TopicProfileEntry extends Model
+{
+    use HasFactory;
+
+    public const ENTRY_TYPES = [
+        'article',
+        'personality_profile',
+        'scale',
+        'custom_link',
+    ];
+
+    public const GROUP_KEYS = [
+        'featured',
+        'articles',
+        'personalities',
+        'tests',
+        'related',
+    ];
+
+    protected $table = 'topic_profile_entries';
+
+    protected $fillable = [
+        'profile_id',
+        'entry_type',
+        'group_key',
+        'target_key',
+        'target_locale',
+        'title_override',
+        'excerpt_override',
+        'badge_label',
+        'cta_label',
+        'target_url_override',
+        'payload_json',
+        'sort_order',
+        'is_featured',
+        'is_enabled',
+    ];
+
+    protected $casts = [
+        'profile_id' => 'integer',
+        'payload_json' => 'array',
+        'sort_order' => 'integer',
+        'is_featured' => 'boolean',
+        'is_enabled' => 'boolean',
+        'created_at' => 'datetime',
+        'updated_at' => 'datetime',
+    ];
+
+    public function profile(): BelongsTo
+    {
+        return $this->belongsTo(TopicProfile::class, 'profile_id', 'id');
+    }
+
+    public function isCustomLink(): bool
+    {
+        return $this->entry_type === 'custom_link';
+    }
+
+    public function effectiveTargetLocale(?string $fallbackLocale = null): ?string
+    {
+        return $this->target_locale ?: $fallbackLocale;
+    }
+}

--- a/backend/app/Models/TopicProfileRevision.php
+++ b/backend/app/Models/TopicProfileRevision.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+class TopicProfileRevision extends Model
+{
+    use HasFactory;
+
+    protected $table = 'topic_profile_revisions';
+
+    public $timestamps = false;
+
+    protected $fillable = [
+        'profile_id',
+        'revision_no',
+        'snapshot_json',
+        'note',
+        'created_by_admin_user_id',
+        'created_at',
+    ];
+
+    protected $casts = [
+        'profile_id' => 'integer',
+        'revision_no' => 'integer',
+        'snapshot_json' => 'array',
+        'created_by_admin_user_id' => 'integer',
+        'created_at' => 'datetime',
+    ];
+
+    public function profile(): BelongsTo
+    {
+        return $this->belongsTo(TopicProfile::class, 'profile_id', 'id');
+    }
+}

--- a/backend/app/Models/TopicProfileSection.php
+++ b/backend/app/Models/TopicProfileSection.php
@@ -1,0 +1,61 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+class TopicProfileSection extends Model
+{
+    use HasFactory;
+
+    public const SECTION_KEYS = [
+        'hero',
+        'overview',
+        'key_concepts',
+        'why_it_matters',
+        'who_should_read',
+        'faq',
+        'related_topics_intro',
+    ];
+
+    public const RENDER_VARIANTS = [
+        'rich_text',
+        'bullets',
+        'cards',
+        'faq',
+        'links',
+        'callout',
+    ];
+
+    protected $table = 'topic_profile_sections';
+
+    protected $fillable = [
+        'profile_id',
+        'section_key',
+        'title',
+        'render_variant',
+        'body_md',
+        'body_html',
+        'payload_json',
+        'sort_order',
+        'is_enabled',
+    ];
+
+    protected $casts = [
+        'profile_id' => 'integer',
+        'payload_json' => 'array',
+        'sort_order' => 'integer',
+        'is_enabled' => 'boolean',
+        'created_at' => 'datetime',
+        'updated_at' => 'datetime',
+    ];
+
+    public function profile(): BelongsTo
+    {
+        return $this->belongsTo(TopicProfile::class, 'profile_id', 'id');
+    }
+}

--- a/backend/app/Models/TopicProfileSeoMeta.php
+++ b/backend/app/Models/TopicProfileSeoMeta.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+class TopicProfileSeoMeta extends Model
+{
+    use HasFactory;
+
+    protected $table = 'topic_profile_seo_meta';
+
+    protected $fillable = [
+        'profile_id',
+        'seo_title',
+        'seo_description',
+        'canonical_url',
+        'og_title',
+        'og_description',
+        'og_image_url',
+        'twitter_title',
+        'twitter_description',
+        'twitter_image_url',
+        'robots',
+        'jsonld_overrides_json',
+    ];
+
+    protected $casts = [
+        'profile_id' => 'integer',
+        'jsonld_overrides_json' => 'array',
+        'created_at' => 'datetime',
+        'updated_at' => 'datetime',
+    ];
+
+    public function profile(): BelongsTo
+    {
+        return $this->belongsTo(TopicProfile::class, 'profile_id', 'id');
+    }
+}

--- a/backend/app/Services/Cms/TopicEntryResolverService.php
+++ b/backend/app/Services/Cms/TopicEntryResolverService.php
@@ -1,0 +1,273 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\Cms;
+
+use App\Models\Article;
+use App\Models\PersonalityProfile;
+use App\Models\TopicProfile;
+use App\Models\TopicProfileEntry;
+use Illuminate\Support\Facades\DB;
+
+final class TopicEntryResolverService
+{
+    public function __construct(
+        private readonly PersonalityProfileService $personalityProfileService,
+        private readonly TopicProfileSeoService $topicProfileSeoService,
+    ) {}
+
+    /**
+     * @return array<string, list<array<string, mixed>>>
+     */
+    public function resolveGroupedEntries(TopicProfile $profile, string $locale): array
+    {
+        $resolvedLocale = $this->normalizeLocale($locale);
+        $grouped = [];
+
+        foreach (TopicProfileEntry::GROUP_KEYS as $groupKey) {
+            $grouped[$groupKey] = [];
+        }
+
+        $entries = $profile->relationLoaded('entries')
+            ? $profile->entries
+            : $profile->entries()->where('is_enabled', true)->get();
+
+        foreach ($entries as $entry) {
+            if (! $entry instanceof TopicProfileEntry || ! in_array($entry->group_key, TopicProfileEntry::GROUP_KEYS, true)) {
+                continue;
+            }
+
+            $resolved = $this->resolveEntry($profile, $entry, $resolvedLocale);
+            if ($resolved === null) {
+                continue;
+            }
+
+            $grouped[$entry->group_key][] = $resolved;
+        }
+
+        return array_filter(
+            $grouped,
+            static fn (array $items): bool => $items !== []
+        );
+    }
+
+    /**
+     * @return array<string, mixed>|null
+     */
+    private function resolveEntry(TopicProfile $profile, TopicProfileEntry $entry, string $locale): ?array
+    {
+        return match ($entry->entry_type) {
+            'article' => $this->resolveArticleEntry($profile, $entry, $locale),
+            'personality_profile' => $this->resolvePersonalityEntry($profile, $entry, $locale),
+            'scale' => $this->resolveScaleEntry($entry, $locale),
+            'custom_link' => $this->resolveCustomLinkEntry($entry),
+            default => null,
+        };
+    }
+
+    /**
+     * @return array<string, mixed>|null
+     */
+    private function resolveArticleEntry(TopicProfile $profile, TopicProfileEntry $entry, string $locale): ?array
+    {
+        $targetLocale = $this->normalizeLocale($entry->effectiveTargetLocale($locale));
+        $article = Article::query()
+            ->withoutGlobalScopes()
+            ->where('org_id', (int) $profile->org_id)
+            ->where('slug', trim((string) $entry->target_key))
+            ->where('locale', $targetLocale)
+            ->where('status', 'published')
+            ->where('is_public', true)
+            ->first();
+
+        if (! $article instanceof Article) {
+            return null;
+        }
+
+        $segment = $this->topicProfileSeoService->mapBackendLocaleToFrontendSegment($targetLocale);
+
+        return $this->buildResolvedEntry(
+            $entry,
+            $article->title,
+            $article->excerpt,
+            '/'.$segment.'/articles/'.rawurlencode((string) $article->slug),
+            $article->cover_image_url,
+            $targetLocale
+        );
+    }
+
+    /**
+     * @return array<string, mixed>|null
+     */
+    private function resolvePersonalityEntry(TopicProfile $profile, TopicProfileEntry $entry, string $locale): ?array
+    {
+        $targetLocale = $this->normalizeLocale($entry->effectiveTargetLocale($locale));
+        $personality = $this->personalityProfileService->getPublicProfileByType(
+            (string) $entry->target_key,
+            (int) $profile->org_id,
+            PersonalityProfile::SCALE_CODE_MBTI,
+            $targetLocale
+        );
+
+        if (! $personality instanceof PersonalityProfile) {
+            return null;
+        }
+
+        $segment = $this->topicProfileSeoService->mapBackendLocaleToFrontendSegment($targetLocale);
+
+        return $this->buildResolvedEntry(
+            $entry,
+            $personality->title,
+            $personality->excerpt,
+            '/'.$segment.'/personality/'.rawurlencode((string) $personality->slug),
+            $personality->hero_image_url,
+            $targetLocale
+        );
+    }
+
+    /**
+     * @return array<string, mixed>|null
+     */
+    private function resolveScaleEntry(TopicProfileEntry $entry, string $locale): ?array
+    {
+        $code = strtoupper(trim((string) $entry->target_key));
+        if ($code === '') {
+            return null;
+        }
+
+        $row = DB::table('scales_registry')
+            ->select(['code', 'primary_slug', 'is_public', 'is_active'])
+            ->where('org_id', 0)
+            ->where('code', $code)
+            ->where('is_public', 1)
+            ->where('is_active', 1)
+            ->first();
+
+        if ($row === null) {
+            return null;
+        }
+
+        $primarySlug = trim((string) ($row->primary_slug ?? ''));
+        if ($primarySlug === '') {
+            return null;
+        }
+
+        $targetLocale = $this->normalizeLocale($entry->effectiveTargetLocale($locale));
+        $segment = $this->topicProfileSeoService->mapBackendLocaleToFrontendSegment($targetLocale);
+
+        return $this->buildResolvedEntry(
+            $entry,
+            $code,
+            null,
+            '/'.$segment.'/tests/'.rawurlencode($primarySlug),
+            null,
+            $targetLocale
+        );
+    }
+
+    /**
+     * @return array<string, mixed>|null
+     */
+    private function resolveCustomLinkEntry(TopicProfileEntry $entry): ?array
+    {
+        $url = trim((string) ($entry->target_url_override ?? ''));
+        if ($url === '' || ! str_starts_with($url, '/') || str_starts_with($url, '//') || preg_match('/^[a-z][a-z0-9+.-]*:/i', $url)) {
+            return null;
+        }
+
+        $title = trim((string) ($entry->title_override ?? ''));
+        if ($title === '') {
+            return null;
+        }
+
+        return $this->buildResolvedEntry(
+            $entry,
+            $title,
+            $entry->excerpt_override,
+            $url,
+            null,
+            $entry->effectiveTargetLocale()
+        );
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function buildResolvedEntry(
+        TopicProfileEntry $entry,
+        ?string $title,
+        ?string $excerpt,
+        string $url,
+        ?string $imageUrl,
+        ?string $targetLocale
+    ): array {
+        $resolvedLocale = $this->normalizeLocale((string) ($targetLocale ?: 'en'));
+
+        return [
+            'entry_type' => (string) $entry->entry_type,
+            'group_key' => (string) $entry->group_key,
+            'target_key' => (string) $entry->target_key,
+            'title' => $this->fallbackText($entry->title_override, $title) ?? (string) $entry->target_key,
+            'excerpt' => $this->fallbackText($entry->excerpt_override, $excerpt),
+            'url' => $url,
+            'badge_label' => $this->fallbackText(
+                $entry->badge_label,
+                $this->defaultBadgeLabel((string) $entry->entry_type, $resolvedLocale)
+            ),
+            'cta_label' => $this->fallbackText(
+                $entry->cta_label,
+                $this->defaultCtaLabel((string) $entry->entry_type, $resolvedLocale)
+            ),
+            'image_url' => $imageUrl,
+            'is_featured' => (bool) $entry->is_featured,
+        ];
+    }
+
+    private function defaultBadgeLabel(string $entryType, string $locale): string
+    {
+        $zh = $locale === 'zh-CN';
+
+        return match ($entryType) {
+            'article' => $zh ? '文章' : 'Article',
+            'personality_profile' => $zh ? '人格' : 'Personality',
+            'scale' => $zh ? '测试' : 'Test',
+            'custom_link' => $zh ? '推荐' : 'Link',
+            default => $zh ? '内容' : 'Content',
+        };
+    }
+
+    private function defaultCtaLabel(string $entryType, string $locale): string
+    {
+        $zh = $locale === 'zh-CN';
+
+        return match ($entryType) {
+            'article' => $zh ? '阅读' : 'Read',
+            'personality_profile' => $zh ? '查看' : 'Explore',
+            'scale' => $zh ? '开始测试' : 'Take the test',
+            'custom_link' => $zh ? '打开' : 'Open',
+            default => $zh ? '查看' : 'View',
+        };
+    }
+
+    private function normalizeLocale(string $locale): string
+    {
+        return trim($locale) === 'zh-CN' ? 'zh-CN' : 'en';
+    }
+
+    private function fallbackText(?string ...$candidates): ?string
+    {
+        foreach ($candidates as $candidate) {
+            if ($candidate === null) {
+                continue;
+            }
+
+            $normalized = trim($candidate);
+            if ($normalized !== '') {
+                return $normalized;
+            }
+        }
+
+        return null;
+    }
+}

--- a/backend/app/Services/Cms/TopicProfileSeoService.php
+++ b/backend/app/Services/Cms/TopicProfileSeoService.php
@@ -1,0 +1,136 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\Cms;
+
+use App\Models\TopicProfile;
+use App\Models\TopicProfileSeoMeta;
+
+final class TopicProfileSeoService
+{
+    /**
+     * @return array<string, mixed>
+     */
+    public function buildMeta(TopicProfile $profile, string $locale): array
+    {
+        $resolvedLocale = $this->normalizeLocale($locale);
+        $seoMeta = $this->resolveSeoMeta($profile);
+
+        $title = $this->fallbackText(
+            $seoMeta?->seo_title,
+            (string) $profile->title
+        ) ?? (string) $profile->title;
+        $description = $this->fallbackText(
+            $seoMeta?->seo_description,
+            (string) ($profile->excerpt ?? null),
+            (string) ($profile->subtitle ?? null)
+        );
+        $canonical = $this->buildCanonicalUrl($profile, $resolvedLocale);
+        $robots = $this->fallbackText($seoMeta?->robots)
+            ?? ((bool) $profile->is_indexable ? 'index,follow' : 'noindex,follow');
+        $image = $this->fallbackText($seoMeta?->og_image_url, (string) ($profile->cover_image_url ?? null));
+
+        return [
+            'title' => $title,
+            'description' => $description,
+            'canonical' => $canonical,
+            'alternates' => [
+                'en' => $this->buildCanonicalUrl($profile, 'en'),
+                'zh-CN' => $this->buildCanonicalUrl($profile, 'zh-CN'),
+            ],
+            'og' => [
+                'title' => $this->fallbackText($seoMeta?->og_title, $title),
+                'description' => $this->fallbackText($seoMeta?->og_description, $description),
+                'image' => $image,
+                'type' => 'article',
+            ],
+            'twitter' => [
+                'card' => 'summary_large_image',
+                'title' => $this->fallbackText($seoMeta?->twitter_title, $seoMeta?->og_title, $title),
+                'description' => $this->fallbackText(
+                    $seoMeta?->twitter_description,
+                    $seoMeta?->og_description,
+                    $description
+                ),
+                'image' => $this->fallbackText($seoMeta?->twitter_image_url, $image),
+            ],
+            'robots' => $robots,
+        ];
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function buildJsonLd(TopicProfile $profile, string $locale): array
+    {
+        $meta = $this->buildMeta($profile, $locale);
+
+        $jsonLd = [
+            '@context' => 'https://schema.org',
+            '@type' => 'CollectionPage',
+            'name' => $meta['title'],
+            'description' => $meta['description'],
+            'mainEntityOfPage' => $meta['canonical'],
+        ];
+
+        $seoMeta = $this->resolveSeoMeta($profile);
+        if ($seoMeta instanceof TopicProfileSeoMeta && is_array($seoMeta->jsonld_overrides_json)) {
+            return array_replace_recursive($jsonLd, $seoMeta->jsonld_overrides_json);
+        }
+
+        return $jsonLd;
+    }
+
+    public function buildCanonicalUrl(TopicProfile $profile, string $locale): ?string
+    {
+        $baseUrl = rtrim((string) config('app.frontend_url', config('app.url', '')), '/');
+        $slug = trim((string) $profile->slug);
+
+        if ($baseUrl === '' || $slug === '') {
+            return null;
+        }
+
+        return $baseUrl
+            .'/'.$this->mapBackendLocaleToFrontendSegment($locale)
+            .'/topics/'
+            .rawurlencode($slug);
+    }
+
+    public function mapBackendLocaleToFrontendSegment(string $locale): string
+    {
+        return $this->normalizeLocale($locale) === 'zh-CN' ? 'zh' : 'en';
+    }
+
+    private function normalizeLocale(string $locale): string
+    {
+        return trim($locale) === 'zh-CN' ? 'zh-CN' : 'en';
+    }
+
+    private function resolveSeoMeta(TopicProfile $profile): ?TopicProfileSeoMeta
+    {
+        if ($profile->relationLoaded('seoMeta') && $profile->seoMeta instanceof TopicProfileSeoMeta) {
+            return $profile->seoMeta;
+        }
+
+        return TopicProfileSeoMeta::query()
+            ->where('profile_id', (int) $profile->id)
+            ->first();
+    }
+
+    private function fallbackText(?string ...$candidates): ?string
+    {
+        foreach ($candidates as $candidate) {
+            if ($candidate === null) {
+                continue;
+            }
+
+            $normalized = trim($candidate);
+            if ($normalized !== '') {
+                return $normalized;
+            }
+        }
+
+        return null;
+    }
+}

--- a/backend/app/Services/Cms/TopicProfileService.php
+++ b/backend/app/Services/Cms/TopicProfileService.php
@@ -1,0 +1,66 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\Cms;
+
+use App\Models\TopicProfile;
+use Illuminate\Contracts\Pagination\LengthAwarePaginator;
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+
+final class TopicProfileService
+{
+    public function listPublicTopics(int $orgId, string $locale, int $page = 1, int $perPage = 20): LengthAwarePaginator
+    {
+        return $this->basePublicQuery($orgId, $locale)
+            ->with('seoMeta')
+            ->orderBy('sort_order')
+            ->orderBy('topic_code')
+            ->orderBy('id')
+            ->paginate($perPage, ['*'], 'page', $page);
+    }
+
+    public function getPublicTopicBySlug(string $slug, int $orgId, string $locale): ?TopicProfile
+    {
+        return $this->basePublicQuery($orgId, $locale)
+            ->forSlug($this->normalizeSlug($slug))
+            ->with([
+                'sections' => static function (HasMany $query): void {
+                    $query->where('is_enabled', true)
+                        ->orderBy('sort_order')
+                        ->orderBy('id');
+                },
+                'entries' => static function (HasMany $query): void {
+                    $query->where('is_enabled', true)
+                        ->orderBy('sort_order')
+                        ->orderBy('id');
+                },
+                'seoMeta',
+            ])
+            ->first();
+    }
+
+    private function basePublicQuery(int $orgId, string $locale): Builder
+    {
+        return TopicProfile::query()
+            ->withoutGlobalScopes()
+            ->where('org_id', max(0, $orgId))
+            ->forLocale($this->normalizeLocale($locale))
+            ->publishedPublic()
+            ->where(static function (Builder $query): void {
+                $query->whereNull('published_at')
+                    ->orWhere('published_at', '<=', now());
+            });
+    }
+
+    private function normalizeLocale(string $locale): string
+    {
+        return trim($locale);
+    }
+
+    private function normalizeSlug(string $slug): string
+    {
+        return strtolower(trim($slug));
+    }
+}

--- a/backend/database/migrations/2026_03_08_000200_create_topic_profiles_table.php
+++ b/backend/database/migrations/2026_03_08_000200_create_topic_profiles_table.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('topic_profiles', function (Blueprint $table): void {
+            $table->bigIncrements('id');
+            $table->unsignedBigInteger('org_id')->default(0);
+            $table->string('topic_code', 64);
+            $table->string('slug', 128);
+            $table->string('locale', 16);
+            $table->string('title', 255);
+            $table->string('subtitle', 255)->nullable();
+            $table->text('excerpt')->nullable();
+            $table->string('hero_kicker', 128)->nullable();
+            $table->text('hero_quote')->nullable();
+            $table->text('cover_image_url')->nullable();
+            $table->string('status', 32)->default('draft');
+            $table->boolean('is_public')->default(true);
+            $table->boolean('is_indexable')->default(true);
+            $table->timestamp('published_at')->nullable();
+            $table->timestamp('scheduled_at')->nullable();
+            $table->string('schema_version', 32)->default('v1');
+            $table->integer('sort_order')->default(0);
+            $table->unsignedBigInteger('created_by_admin_user_id')->nullable();
+            $table->unsignedBigInteger('updated_by_admin_user_id')->nullable();
+            $table->timestamps();
+
+            $table->unique(['org_id', 'topic_code', 'locale'], 'uq_topic_profile');
+            $table->unique(['org_id', 'slug', 'locale'], 'uq_topic_slug');
+            $table->index(['status', 'is_public', 'published_at'], 'idx_topic_status');
+            $table->index(['locale'], 'idx_topic_locale');
+            $table->index(['locale', 'sort_order'], 'idx_topic_sort');
+        });
+    }
+
+    public function down(): void
+    {
+        // forward-only migration: rollback disabled to prevent data loss in production.
+        // Irreversible operation: schema/data rollback handled via forward fix migrations.
+    }
+};

--- a/backend/database/migrations/2026_03_08_000210_create_topic_profile_sections_table.php
+++ b/backend/database/migrations/2026_03_08_000210_create_topic_profile_sections_table.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        $isSqlite = Schema::getConnection()->getDriverName() === 'sqlite';
+
+        Schema::create('topic_profile_sections', function (Blueprint $table) use ($isSqlite): void {
+            $table->bigIncrements('id');
+            $table->unsignedBigInteger('profile_id');
+            $table->string('section_key', 64);
+            $table->string('title', 255)->nullable();
+            $table->string('render_variant', 32)->default('rich_text');
+            $table->longText('body_md')->nullable();
+            $table->longText('body_html')->nullable();
+            if ($isSqlite) {
+                $table->text('payload_json')->nullable();
+            } else {
+                $table->json('payload_json')->nullable();
+            }
+            $table->integer('sort_order')->default(0);
+            $table->boolean('is_enabled')->default(true);
+            $table->timestamps();
+
+            $table->unique(['profile_id', 'section_key'], 'uq_topic_section');
+            $table->index(['profile_id', 'sort_order'], 'idx_topic_section_sort');
+            $table->foreign('profile_id', 'fk_topic_section_profile')
+                ->references('id')
+                ->on('topic_profiles')
+                ->cascadeOnDelete();
+        });
+    }
+
+    public function down(): void
+    {
+        // forward-only migration: rollback disabled to prevent data loss in production.
+        // Irreversible operation: schema/data rollback handled via forward fix migrations.
+    }
+};

--- a/backend/database/migrations/2026_03_08_000220_create_topic_profile_entries_table.php
+++ b/backend/database/migrations/2026_03_08_000220_create_topic_profile_entries_table.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        $isSqlite = Schema::getConnection()->getDriverName() === 'sqlite';
+
+        Schema::create('topic_profile_entries', function (Blueprint $table) use ($isSqlite): void {
+            $table->bigIncrements('id');
+            $table->unsignedBigInteger('profile_id');
+            $table->string('entry_type', 32);
+            $table->string('group_key', 32);
+            $table->string('target_key', 128);
+            $table->string('target_locale', 16)->nullable();
+            $table->string('title_override', 255)->nullable();
+            $table->text('excerpt_override')->nullable();
+            $table->string('badge_label', 64)->nullable();
+            $table->string('cta_label', 64)->nullable();
+            $table->text('target_url_override')->nullable();
+            if ($isSqlite) {
+                $table->text('payload_json')->nullable();
+            } else {
+                $table->json('payload_json')->nullable();
+            }
+            $table->integer('sort_order')->default(0);
+            $table->boolean('is_featured')->default(false);
+            $table->boolean('is_enabled')->default(true);
+            $table->timestamps();
+
+            $table->index(['profile_id', 'group_key', 'sort_order'], 'idx_topic_entries_group');
+            $table->index(['profile_id', 'entry_type', 'is_enabled'], 'idx_topic_entries_type');
+            $table->index(['entry_type', 'target_key', 'target_locale'], 'idx_topic_entries_target');
+            $table->foreign('profile_id', 'fk_topic_entry_profile')
+                ->references('id')
+                ->on('topic_profiles')
+                ->cascadeOnDelete();
+        });
+    }
+
+    public function down(): void
+    {
+        // forward-only migration: rollback disabled to prevent data loss in production.
+        // Irreversible operation: schema/data rollback handled via forward fix migrations.
+    }
+};

--- a/backend/database/migrations/2026_03_08_000230_create_topic_profile_seo_meta_table.php
+++ b/backend/database/migrations/2026_03_08_000230_create_topic_profile_seo_meta_table.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        $isSqlite = Schema::getConnection()->getDriverName() === 'sqlite';
+
+        Schema::create('topic_profile_seo_meta', function (Blueprint $table) use ($isSqlite): void {
+            $table->bigIncrements('id');
+            $table->unsignedBigInteger('profile_id');
+            $table->string('seo_title', 255)->nullable();
+            $table->text('seo_description')->nullable();
+            $table->text('canonical_url')->nullable();
+            $table->string('og_title', 255)->nullable();
+            $table->text('og_description')->nullable();
+            $table->text('og_image_url')->nullable();
+            $table->string('twitter_title', 255)->nullable();
+            $table->text('twitter_description')->nullable();
+            $table->text('twitter_image_url')->nullable();
+            $table->string('robots', 64)->nullable();
+            if ($isSqlite) {
+                $table->text('jsonld_overrides_json')->nullable();
+            } else {
+                $table->json('jsonld_overrides_json')->nullable();
+            }
+            $table->timestamps();
+
+            $table->unique(['profile_id'], 'uq_topic_seo');
+            $table->foreign('profile_id', 'fk_topic_seo_profile')
+                ->references('id')
+                ->on('topic_profiles')
+                ->cascadeOnDelete();
+        });
+    }
+
+    public function down(): void
+    {
+        // forward-only migration: rollback disabled to prevent data loss in production.
+        // Irreversible operation: schema/data rollback handled via forward fix migrations.
+    }
+};

--- a/backend/database/migrations/2026_03_08_000240_create_topic_profile_revisions_table.php
+++ b/backend/database/migrations/2026_03_08_000240_create_topic_profile_revisions_table.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        $isSqlite = Schema::getConnection()->getDriverName() === 'sqlite';
+
+        Schema::create('topic_profile_revisions', function (Blueprint $table) use ($isSqlite): void {
+            $table->bigIncrements('id');
+            $table->unsignedBigInteger('profile_id');
+            $table->unsignedInteger('revision_no');
+            if ($isSqlite) {
+                $table->text('snapshot_json');
+            } else {
+                $table->json('snapshot_json');
+            }
+            $table->string('note', 255)->nullable();
+            $table->unsignedBigInteger('created_by_admin_user_id')->nullable();
+            $table->timestamp('created_at')->nullable();
+
+            $table->unique(['profile_id', 'revision_no'], 'uq_topic_revision');
+            $table->index(['profile_id', 'created_at'], 'idx_topic_revision_created');
+            $table->foreign('profile_id', 'fk_topic_revision_profile')
+                ->references('id')
+                ->on('topic_profiles')
+                ->cascadeOnDelete();
+        });
+    }
+
+    public function down(): void
+    {
+        // forward-only migration: rollback disabled to prevent data loss in production.
+        // Irreversible operation: schema/data rollback handled via forward fix migrations.
+    }
+};

--- a/backend/docs/contracts/openapi.snapshot.json
+++ b/backend/docs/contracts/openapi.snapshot.json
@@ -1887,6 +1887,57 @@
                     "api"
                 ]
             }
+        },
+        "/api/v0.5/topics": {
+            "get": {
+                "operationId": "get_api_v0_5_topics",
+                "tags": [
+                    "api:v0.5"
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK"
+                    }
+                },
+                "x-laravel-action": "App\\Http\\Controllers\\API\\V0_5\\Cms\\TopicController@index",
+                "x-laravel-middleware": [
+                    "api"
+                ]
+            }
+        },
+        "/api/v0.5/topics/{slug}": {
+            "get": {
+                "operationId": "get_api_v0_5_topics_slug_",
+                "tags": [
+                    "api:v0.5"
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK"
+                    }
+                },
+                "x-laravel-action": "App\\Http\\Controllers\\API\\V0_5\\Cms\\TopicController@show",
+                "x-laravel-middleware": [
+                    "api"
+                ]
+            }
+        },
+        "/api/v0.5/topics/{slug}/seo": {
+            "get": {
+                "operationId": "get_api_v0_5_topics_slug_seo",
+                "tags": [
+                    "api:v0.5"
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK"
+                    }
+                },
+                "x-laravel-action": "App\\Http\\Controllers\\API\\V0_5\\Cms\\TopicController@seo",
+                "x-laravel-middleware": [
+                    "api"
+                ]
+            }
         }
     }
 }

--- a/backend/routes/api.php
+++ b/backend/routes/api.php
@@ -25,6 +25,7 @@ use App\Http\Controllers\API\V0_4\PartnerController;
 use App\Http\Controllers\API\V0_4\RotationAuditController;
 use App\Http\Controllers\API\V0_5\Cms\ArticleController;
 use App\Http\Controllers\API\V0_5\Cms\PersonalityController;
+use App\Http\Controllers\API\V0_5\Cms\TopicController;
 use App\Http\Controllers\HealthzController;
 use App\Http\Middleware\AdminAuth;
 use App\Http\Middleware\EnsureCmsAdminAuthorized;
@@ -306,6 +307,9 @@ Route::prefix('v0.5')->group(function () {
     Route::get('/personality', [PersonalityController::class, 'index']);
     Route::get('/personality/{type}/seo', [PersonalityController::class, 'seo']);
     Route::get('/personality/{type}', [PersonalityController::class, 'show']);
+    Route::get('/topics', [TopicController::class, 'index']);
+    Route::get('/topics/{slug}/seo', [TopicController::class, 'seo']);
+    Route::get('/topics/{slug}', [TopicController::class, 'show']);
 
     Route::middleware([
         EncryptCookies::class,

--- a/backend/tests/Feature/TopicsCms/TopicSchemaSmokeTest.php
+++ b/backend/tests/Feature/TopicsCms/TopicSchemaSmokeTest.php
@@ -1,0 +1,237 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\TopicsCms;
+
+use App\Models\TopicProfile;
+use App\Models\TopicProfileEntry;
+use App\Models\TopicProfileRevision;
+use App\Models\TopicProfileSection;
+use App\Models\TopicProfileSeoMeta;
+use Illuminate\Database\QueryException;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+final class TopicSchemaSmokeTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_profile_relations_scopes_and_casts_work(): void
+    {
+        $profile = TopicProfile::query()->create([
+            'org_id' => 0,
+            'topic_code' => 'mbti',
+            'slug' => 'mbti',
+            'locale' => 'en',
+            'title' => 'MBTI topic hub',
+            'subtitle' => 'Structured guidance for MBTI readers',
+            'excerpt' => 'A short topic overview.',
+            'hero_kicker' => 'Topic hub',
+            'hero_quote' => 'Find the next read with context.',
+            'cover_image_url' => 'https://cdn.example.test/topic.png',
+            'status' => TopicProfile::STATUS_PUBLISHED,
+            'is_public' => true,
+            'is_indexable' => true,
+            'schema_version' => 'v1',
+            'sort_order' => 10,
+            'published_at' => now(),
+        ]);
+
+        TopicProfileSection::query()->create([
+            'profile_id' => $profile->id,
+            'section_key' => 'overview',
+            'title' => 'Overview',
+            'render_variant' => 'rich_text',
+            'body_md' => 'A topic overview.',
+            'payload_json' => ['chips' => ['MBTI']],
+            'sort_order' => 10,
+            'is_enabled' => true,
+        ]);
+
+        TopicProfileSection::query()->create([
+            'profile_id' => $profile->id,
+            'section_key' => 'faq',
+            'title' => 'FAQ',
+            'render_variant' => 'faq',
+            'payload_json' => [
+                'items' => [
+                    ['q' => 'What is MBTI?', 'a' => 'A personality framework.'],
+                ],
+            ],
+            'sort_order' => 20,
+            'is_enabled' => true,
+        ]);
+
+        $entryA = TopicProfileEntry::query()->create([
+            'profile_id' => $profile->id,
+            'entry_type' => 'custom_link',
+            'group_key' => 'featured',
+            'target_key' => 'mbti-intro',
+            'target_locale' => 'en',
+            'title_override' => 'Start here',
+            'target_url_override' => 'https://example.test/en/topics/mbti',
+            'payload_json' => ['style' => 'hero'],
+            'sort_order' => 10,
+            'is_featured' => true,
+            'is_enabled' => true,
+        ]);
+
+        $entryB = TopicProfileEntry::query()->create([
+            'profile_id' => $profile->id,
+            'entry_type' => 'article',
+            'group_key' => 'articles',
+            'target_key' => 'mbti-personality-test-16-personality-types',
+            'target_locale' => null,
+            'excerpt_override' => 'Why MBTI matters in practice.',
+            'payload_json' => ['rank' => 1],
+            'sort_order' => 20,
+            'is_featured' => false,
+            'is_enabled' => true,
+        ]);
+
+        TopicProfileSeoMeta::query()->create([
+            'profile_id' => $profile->id,
+            'seo_title' => 'MBTI topic hub',
+            'seo_description' => 'Understand MBTI and its adjacent content.',
+            'jsonld_overrides_json' => ['@type' => 'CollectionPage'],
+        ]);
+
+        TopicProfileRevision::query()->create([
+            'profile_id' => $profile->id,
+            'revision_no' => 1,
+            'snapshot_json' => ['title' => 'MBTI topic hub'],
+            'note' => 'Initial draft',
+            'created_at' => now()->subMinute(),
+        ]);
+
+        TopicProfileRevision::query()->create([
+            'profile_id' => $profile->id,
+            'revision_no' => 2,
+            'snapshot_json' => ['title' => 'MBTI topic hub v2'],
+            'note' => 'Publish update',
+            'created_at' => now(),
+        ]);
+
+        $freshProfile = TopicProfile::query()->findOrFail($profile->id);
+
+        $this->assertSame(
+            ['overview', 'faq'],
+            $freshProfile->sections()->pluck('section_key')->all()
+        );
+        $this->assertSame(
+            [$entryA->id, $entryB->id],
+            $freshProfile->entries()->pluck('id')->all()
+        );
+        $this->assertSame('MBTI topic hub', $freshProfile->seoMeta?->seo_title);
+        $this->assertSame([2, 1], $freshProfile->revisions()->pluck('revision_no')->all());
+        $this->assertSame(
+            [$profile->id],
+            TopicProfile::query()
+                ->publishedPublic()
+                ->indexable()
+                ->forLocale('en')
+                ->forSlug('MBTI')
+                ->forTopicCode('MBTI')
+                ->pluck('id')
+                ->all()
+        );
+        $this->assertSame(['chips' => ['MBTI']], $freshProfile->sections()->firstOrFail()->payload_json);
+        $this->assertSame(['@type' => 'CollectionPage'], $freshProfile->seoMeta?->jsonld_overrides_json);
+        $this->assertTrue($entryA->fresh()->isCustomLink());
+        $this->assertSame('en', $entryB->fresh()->effectiveTargetLocale('en'));
+        $this->assertTrue($entryA->fresh()->is_featured);
+        $this->assertTrue($entryB->fresh()->is_enabled);
+    }
+
+    public function test_unique_org_topic_code_locale_constraint_is_enforced(): void
+    {
+        TopicProfile::query()->create($this->profilePayload([
+            'topic_code' => 'mbti',
+            'slug' => 'mbti',
+        ]));
+
+        $this->expectException(QueryException::class);
+
+        TopicProfile::query()->create($this->profilePayload([
+            'topic_code' => 'mbti',
+            'slug' => 'mbti-second',
+        ]));
+    }
+
+    public function test_unique_org_slug_locale_constraint_is_enforced(): void
+    {
+        TopicProfile::query()->create($this->profilePayload([
+            'topic_code' => 'big-five',
+            'slug' => 'personality-basics',
+        ]));
+
+        $this->expectException(QueryException::class);
+
+        TopicProfile::query()->create($this->profilePayload([
+            'topic_code' => 'self-awareness',
+            'slug' => 'personality-basics',
+        ]));
+    }
+
+    public function test_deleting_profile_cascades_sections_entries_seo_meta_and_revisions(): void
+    {
+        $profile = TopicProfile::query()->create($this->profilePayload([
+            'topic_code' => 'self-awareness',
+            'slug' => 'self-awareness',
+        ]));
+
+        $section = TopicProfileSection::query()->create([
+            'profile_id' => $profile->id,
+            'section_key' => 'overview',
+            'render_variant' => 'rich_text',
+        ]);
+
+        $entry = TopicProfileEntry::query()->create([
+            'profile_id' => $profile->id,
+            'entry_type' => 'article',
+            'group_key' => 'articles',
+            'target_key' => 'how-to-find-right-career-direction',
+        ]);
+
+        $seoMeta = TopicProfileSeoMeta::query()->create([
+            'profile_id' => $profile->id,
+            'seo_title' => 'Self awareness topic',
+        ]);
+
+        $revision = TopicProfileRevision::query()->create([
+            'profile_id' => $profile->id,
+            'revision_no' => 1,
+            'snapshot_json' => ['slug' => 'self-awareness'],
+            'created_at' => now(),
+        ]);
+
+        $profile->delete();
+
+        $this->assertDatabaseMissing('topic_profiles', ['id' => $profile->id]);
+        $this->assertDatabaseMissing('topic_profile_sections', ['id' => $section->id]);
+        $this->assertDatabaseMissing('topic_profile_entries', ['id' => $entry->id]);
+        $this->assertDatabaseMissing('topic_profile_seo_meta', ['id' => $seoMeta->id]);
+        $this->assertDatabaseMissing('topic_profile_revisions', ['id' => $revision->id]);
+    }
+
+    /**
+     * @param  array<string, mixed>  $overrides
+     * @return array<string, mixed>
+     */
+    private function profilePayload(array $overrides = []): array
+    {
+        return array_merge([
+            'org_id' => 0,
+            'topic_code' => 'mbti',
+            'slug' => 'mbti',
+            'locale' => 'en',
+            'title' => 'Topic profile',
+            'status' => TopicProfile::STATUS_DRAFT,
+            'is_public' => true,
+            'is_indexable' => true,
+            'schema_version' => 'v1',
+            'sort_order' => 0,
+        ], $overrides);
+    }
+}

--- a/backend/tests/Feature/V0_5/TopicsPublicApiTest.php
+++ b/backend/tests/Feature/V0_5/TopicsPublicApiTest.php
@@ -1,0 +1,528 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\V0_5;
+
+use App\Models\Article;
+use App\Models\PersonalityProfile;
+use App\Models\TopicProfile;
+use App\Models\TopicProfileEntry;
+use App\Models\TopicProfileRevision;
+use App\Models\TopicProfileSection;
+use App\Models\TopicProfileSeoMeta;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\DB;
+use Tests\TestCase;
+
+final class TopicsPublicApiTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_list_returns_published_public_only(): void
+    {
+        $visible = $this->createTopicProfile([
+            'topic_code' => 'mbti',
+            'slug' => 'mbti',
+            'title' => 'MBTI',
+            'status' => TopicProfile::STATUS_PUBLISHED,
+            'is_public' => true,
+            'published_at' => now()->subMinute(),
+        ]);
+        $this->createTopicSeoMeta($visible, [
+            'seo_title' => 'MBTI Guide and Type Hub',
+            'seo_description' => 'Explore MBTI concepts, type profiles, guides, and tests.',
+        ]);
+
+        $this->createTopicProfile([
+            'topic_code' => 'big-five',
+            'slug' => 'big-five',
+            'title' => 'Big Five draft',
+            'status' => TopicProfile::STATUS_DRAFT,
+            'is_public' => true,
+        ]);
+        $this->createTopicProfile([
+            'topic_code' => 'enneagram',
+            'slug' => 'enneagram',
+            'title' => 'Enneagram private',
+            'status' => TopicProfile::STATUS_PUBLISHED,
+            'is_public' => false,
+            'published_at' => now()->subMinute(),
+        ]);
+        $this->createTopicProfile([
+            'topic_code' => 'self-awareness',
+            'slug' => 'self-awareness',
+            'title' => 'Scheduled topic',
+            'status' => TopicProfile::STATUS_PUBLISHED,
+            'is_public' => true,
+            'published_at' => now()->addHour(),
+        ]);
+
+        $response = $this->getJson('/api/v0.5/topics?locale=en');
+
+        $response->assertOk()
+            ->assertJsonPath('ok', true)
+            ->assertJsonPath('pagination.total', 1)
+            ->assertJsonCount(1, 'items')
+            ->assertJsonPath('items.0.slug', 'mbti')
+            ->assertJsonPath('items.0.seo_meta.seo_title', 'MBTI Guide and Type Hub');
+    }
+
+    public function test_list_respects_locale_and_org_scope(): void
+    {
+        $this->createTopicProfile([
+            'org_id' => 0,
+            'topic_code' => 'mbti',
+            'slug' => 'mbti',
+            'locale' => 'en',
+            'title' => 'MBTI EN',
+            'status' => TopicProfile::STATUS_PUBLISHED,
+            'is_public' => true,
+            'published_at' => now()->subMinute(),
+        ]);
+        $this->createTopicProfile([
+            'org_id' => 0,
+            'topic_code' => 'mbti',
+            'slug' => 'mbti',
+            'locale' => 'zh-CN',
+            'title' => 'MBTI ZH',
+            'status' => TopicProfile::STATUS_PUBLISHED,
+            'is_public' => true,
+            'published_at' => now()->subMinute(),
+        ]);
+        $this->createTopicProfile([
+            'org_id' => 7,
+            'topic_code' => 'mbti',
+            'slug' => 'mbti',
+            'locale' => 'en',
+            'title' => 'MBTI Org 7',
+            'status' => TopicProfile::STATUS_PUBLISHED,
+            'is_public' => true,
+            'published_at' => now()->subMinute(),
+        ]);
+
+        $this->getJson('/api/v0.5/topics?locale=en')
+            ->assertOk()
+            ->assertJsonCount(1, 'items')
+            ->assertJsonPath('items.0.title', 'MBTI EN');
+
+        $this->getJson('/api/v0.5/topics?locale=zh-CN')
+            ->assertOk()
+            ->assertJsonCount(1, 'items')
+            ->assertJsonPath('items.0.title', 'MBTI ZH');
+
+        $this->getJson('/api/v0.5/topics?locale=en&org_id=7')
+            ->assertOk()
+            ->assertJsonCount(1, 'items')
+            ->assertJsonPath('items.0.org_id', 7)
+            ->assertJsonPath('items.0.title', 'MBTI Org 7');
+    }
+
+    public function test_detail_returns_sections_entry_groups_and_seo_meta(): void
+    {
+        $topic = $this->createTopicProfile([
+            'topic_code' => 'mbti',
+            'slug' => 'mbti',
+            'title' => 'MBTI',
+            'excerpt' => 'Explore MBTI concepts, type profiles, guides, and tests.',
+            'status' => TopicProfile::STATUS_PUBLISHED,
+            'is_public' => true,
+            'published_at' => now()->subMinute(),
+        ]);
+
+        TopicProfileSection::query()->create([
+            'profile_id' => (int) $topic->id,
+            'section_key' => 'overview',
+            'title' => 'What is MBTI?',
+            'render_variant' => 'rich_text',
+            'body_md' => 'MBTI is a typology framework.',
+            'sort_order' => 10,
+            'is_enabled' => true,
+        ]);
+        TopicProfileSection::query()->create([
+            'profile_id' => (int) $topic->id,
+            'section_key' => 'faq',
+            'title' => 'FAQ',
+            'render_variant' => 'faq',
+            'payload_json' => ['items' => [['q' => 'What is MBTI?', 'a' => 'A typology framework']]],
+            'sort_order' => 20,
+            'is_enabled' => false,
+        ]);
+
+        $this->createTopicSeoMeta($topic, [
+            'seo_title' => 'MBTI Guide and Type Hub | FermatMind',
+            'seo_description' => 'Explore MBTI concepts, type profiles, guides, and tests.',
+            'robots' => 'index,follow',
+        ]);
+        TopicProfileRevision::query()->create([
+            'profile_id' => (int) $topic->id,
+            'revision_no' => 1,
+            'snapshot_json' => ['title' => 'MBTI'],
+            'note' => 'initial',
+            'created_at' => now(),
+        ]);
+
+        $article = $this->createArticle([
+            'slug' => 'how-to-read-mbti-results',
+            'locale' => 'en',
+            'title' => 'How to read MBTI results',
+            'excerpt' => 'A practical guide to understanding type results.',
+            'status' => 'published',
+            'is_public' => true,
+            'published_at' => now()->subMinute(),
+        ]);
+        $personality = $this->createPersonalityProfile([
+            'type_code' => 'INTJ',
+            'slug' => 'intj',
+            'title' => 'INTJ - Architect',
+            'excerpt' => 'Independent, strategic, and future-oriented.',
+            'status' => 'published',
+            'is_public' => true,
+            'published_at' => now()->subMinute(),
+        ]);
+        $this->createScaleRegistryRow('MBTI', 'mbti-personality-test-16-personality-types');
+
+        $this->createTopicEntry($topic, [
+            'entry_type' => 'personality_profile',
+            'group_key' => 'featured',
+            'target_key' => 'INTJ',
+            'badge_label' => 'Personality',
+            'cta_label' => 'Explore',
+            'sort_order' => 10,
+            'is_featured' => true,
+        ]);
+        $this->createTopicEntry($topic, [
+            'entry_type' => 'article',
+            'group_key' => 'articles',
+            'target_key' => (string) $article->slug,
+            'target_locale' => 'en',
+            'sort_order' => 20,
+        ]);
+        $this->createTopicEntry($topic, [
+            'entry_type' => 'scale',
+            'group_key' => 'tests',
+            'target_key' => 'MBTI',
+            'sort_order' => 30,
+            'is_featured' => true,
+        ]);
+        $this->createTopicEntry($topic, [
+            'entry_type' => 'custom_link',
+            'group_key' => 'related',
+            'target_key' => 'docs',
+            'title_override' => 'MBTI methodology',
+            'excerpt_override' => 'Read the methodology behind the MBTI topic hub.',
+            'target_url_override' => '/en/about/methodology',
+            'sort_order' => 40,
+        ]);
+        $this->createTopicEntry($topic, [
+            'entry_type' => 'article',
+            'group_key' => 'articles',
+            'target_key' => 'missing-article',
+            'target_locale' => 'en',
+            'sort_order' => 50,
+        ]);
+
+        $response = $this->getJson('/api/v0.5/topics/mbti?locale=en');
+
+        $response->assertOk()
+            ->assertJsonPath('ok', true)
+            ->assertJsonPath('profile.topic_code', 'mbti')
+            ->assertJsonPath('profile.slug', 'mbti')
+            ->assertJsonCount(1, 'sections')
+            ->assertJsonPath('sections.0.section_key', 'overview')
+            ->assertJsonPath('seo_meta.seo_title', 'MBTI Guide and Type Hub | FermatMind')
+            ->assertJsonPath('entry_groups.featured.0.entry_type', 'personality_profile')
+            ->assertJsonPath('entry_groups.featured.0.title', (string) $personality->title)
+            ->assertJsonPath('entry_groups.featured.0.url', '/en/personality/intj')
+            ->assertJsonPath('entry_groups.articles.0.title', (string) $article->title)
+            ->assertJsonPath('entry_groups.articles.0.url', '/en/articles/how-to-read-mbti-results')
+            ->assertJsonPath('entry_groups.tests.0.url', '/en/tests/mbti-personality-test-16-personality-types')
+            ->assertJsonPath('entry_groups.related.0.url', '/en/about/methodology')
+            ->assertJsonMissingPath('revisions');
+    }
+
+    public function test_detail_returns_not_found_for_missing_hidden_or_locale_mismatch_topics(): void
+    {
+        $draft = $this->createTopicProfile([
+            'topic_code' => 'mbti',
+            'slug' => 'mbti',
+            'status' => TopicProfile::STATUS_DRAFT,
+            'is_public' => true,
+        ]);
+
+        $this->createTopicProfile([
+            'topic_code' => 'big-five',
+            'slug' => 'big-five',
+            'status' => TopicProfile::STATUS_PUBLISHED,
+            'is_public' => false,
+            'published_at' => now()->subMinute(),
+        ]);
+        $this->createTopicProfile([
+            'topic_code' => 'enneagram',
+            'slug' => 'enneagram',
+            'locale' => 'zh-CN',
+            'status' => TopicProfile::STATUS_PUBLISHED,
+            'is_public' => true,
+            'published_at' => now()->subMinute(),
+        ]);
+
+        $this->getJson('/api/v0.5/topics/missing?locale=en')
+            ->assertStatus(404)
+            ->assertJsonPath('ok', false)
+            ->assertJsonPath('error_code', 'NOT_FOUND');
+
+        $this->getJson('/api/v0.5/topics/'.$draft->slug.'?locale=en')
+            ->assertStatus(404)
+            ->assertJsonPath('error_code', 'NOT_FOUND');
+
+        $this->getJson('/api/v0.5/topics/big-five?locale=en')
+            ->assertStatus(404)
+            ->assertJsonPath('error_code', 'NOT_FOUND');
+
+        $this->getJson('/api/v0.5/topics/enneagram?locale=en')
+            ->assertStatus(404)
+            ->assertJsonPath('error_code', 'NOT_FOUND');
+    }
+
+    public function test_resolver_skips_invalid_targets_safely(): void
+    {
+        $topic = $this->createTopicProfile([
+            'topic_code' => 'mbti',
+            'slug' => 'mbti',
+            'status' => TopicProfile::STATUS_PUBLISHED,
+            'is_public' => true,
+            'published_at' => now()->subMinute(),
+        ]);
+
+        $this->createTopicEntry($topic, [
+            'entry_type' => 'article',
+            'group_key' => 'articles',
+            'target_key' => 'missing-article',
+        ]);
+        $this->createTopicEntry($topic, [
+            'entry_type' => 'custom_link',
+            'group_key' => 'related',
+            'target_key' => 'docs',
+            'title_override' => 'External docs',
+            'target_url_override' => 'https://example.com/docs',
+        ]);
+        $this->createTopicEntry($topic, [
+            'entry_type' => 'scale',
+            'group_key' => 'tests',
+            'target_key' => 'MISSING_SCALE',
+        ]);
+
+        $response = $this->getJson('/api/v0.5/topics/mbti?locale=en');
+
+        $response->assertOk()
+            ->assertJsonPath('ok', true)
+            ->assertJsonMissingPath('entry_groups.articles')
+            ->assertJsonMissingPath('entry_groups.related')
+            ->assertJsonMissingPath('entry_groups.tests');
+    }
+
+    public function test_seo_endpoint_returns_locale_aware_meta_and_jsonld(): void
+    {
+        config(['app.frontend_url' => 'https://staging.fermatmind.com']);
+
+        $enTopic = $this->createTopicProfile([
+            'topic_code' => 'mbti',
+            'slug' => 'mbti',
+            'locale' => 'en',
+            'title' => 'MBTI Guide and Type Hub',
+            'excerpt' => 'Explore MBTI concepts, type profiles, guides, and tests.',
+            'status' => TopicProfile::STATUS_PUBLISHED,
+            'is_public' => true,
+            'is_indexable' => true,
+            'published_at' => now()->subMinute(),
+        ]);
+        $this->createTopicSeoMeta($enTopic, [
+            'seo_title' => 'MBTI Guide and Type Hub | FermatMind',
+            'seo_description' => 'Explore MBTI concepts, type profiles, guides, and tests.',
+        ]);
+
+        $zhTopic = $this->createTopicProfile([
+            'topic_code' => 'mbti',
+            'slug' => 'mbti',
+            'locale' => 'zh-CN',
+            'title' => 'MBTI 主题中心',
+            'excerpt' => '探索 MBTI 概念、人格画像、指南与测试。',
+            'status' => TopicProfile::STATUS_PUBLISHED,
+            'is_public' => true,
+            'is_indexable' => false,
+            'published_at' => now()->subMinute(),
+        ]);
+        $this->createTopicSeoMeta($zhTopic, [
+            'seo_title' => 'MBTI 主题中心 | FermatMind',
+            'seo_description' => '探索 MBTI 概念、人格画像、指南与测试。',
+        ]);
+
+        $enResponse = $this->getJson('/api/v0.5/topics/mbti/seo?locale=en');
+        $enResponse->assertOk()
+            ->assertJsonPath('meta.title', 'MBTI Guide and Type Hub | FermatMind')
+            ->assertJsonPath('meta.canonical', 'https://staging.fermatmind.com/en/topics/mbti')
+            ->assertJsonPath('meta.robots', 'index,follow');
+        self::assertSame('CollectionPage', data_get($enResponse->json(), 'jsonld.@type'));
+        self::assertSame(
+            'https://staging.fermatmind.com/en/topics/mbti',
+            data_get($enResponse->json(), 'jsonld.mainEntityOfPage')
+        );
+
+        $zhResponse = $this->getJson('/api/v0.5/topics/mbti/seo?locale=zh-CN');
+        $zhResponse->assertOk()
+            ->assertJsonPath('meta.canonical', 'https://staging.fermatmind.com/zh/topics/mbti')
+            ->assertJsonPath('meta.robots', 'noindex,follow');
+        self::assertSame(
+            'https://staging.fermatmind.com/zh/topics/mbti',
+            data_get($zhResponse->json(), 'jsonld.mainEntityOfPage')
+        );
+    }
+
+    /**
+     * @param  array<string, mixed>  $overrides
+     */
+    private function createTopicProfile(array $overrides = []): TopicProfile
+    {
+        /** @var TopicProfile */
+        return TopicProfile::query()->create(array_merge([
+            'org_id' => 0,
+            'topic_code' => 'mbti',
+            'slug' => 'mbti',
+            'locale' => 'en',
+            'title' => 'MBTI',
+            'subtitle' => 'Understand personality preferences and type dynamics.',
+            'excerpt' => 'Explore MBTI concepts, type profiles, guides, and tests.',
+            'hero_kicker' => 'Topic hub',
+            'hero_quote' => 'Start from the core ideas, then go deeper.',
+            'cover_image_url' => null,
+            'status' => TopicProfile::STATUS_DRAFT,
+            'is_public' => false,
+            'is_indexable' => true,
+            'published_at' => null,
+            'scheduled_at' => null,
+            'schema_version' => 'v1',
+            'sort_order' => 0,
+        ], $overrides));
+    }
+
+    /**
+     * @param  array<string, mixed>  $overrides
+     */
+    private function createTopicSeoMeta(TopicProfile $profile, array $overrides = []): TopicProfileSeoMeta
+    {
+        /** @var TopicProfileSeoMeta */
+        return TopicProfileSeoMeta::query()->create(array_merge([
+            'profile_id' => (int) $profile->id,
+            'seo_title' => null,
+            'seo_description' => null,
+            'canonical_url' => null,
+            'og_title' => null,
+            'og_description' => null,
+            'og_image_url' => null,
+            'twitter_title' => null,
+            'twitter_description' => null,
+            'twitter_image_url' => null,
+            'robots' => null,
+            'jsonld_overrides_json' => null,
+        ], $overrides));
+    }
+
+    /**
+     * @param  array<string, mixed>  $overrides
+     */
+    private function createTopicEntry(TopicProfile $profile, array $overrides = []): TopicProfileEntry
+    {
+        /** @var TopicProfileEntry */
+        return TopicProfileEntry::query()->create(array_merge([
+            'profile_id' => (int) $profile->id,
+            'entry_type' => 'article',
+            'group_key' => 'articles',
+            'target_key' => 'target-key',
+            'target_locale' => 'en',
+            'title_override' => null,
+            'excerpt_override' => null,
+            'badge_label' => null,
+            'cta_label' => null,
+            'target_url_override' => null,
+            'payload_json' => null,
+            'sort_order' => 0,
+            'is_featured' => false,
+            'is_enabled' => true,
+        ], $overrides));
+    }
+
+    /**
+     * @param  array<string, mixed>  $overrides
+     */
+    private function createArticle(array $overrides = []): Article
+    {
+        /** @var Article */
+        return Article::query()->create(array_merge([
+            'org_id' => 0,
+            'category_id' => null,
+            'author_admin_user_id' => null,
+            'slug' => 'article-slug',
+            'locale' => 'en',
+            'title' => 'Article title',
+            'excerpt' => 'Article excerpt',
+            'content_md' => '# Article',
+            'content_html' => null,
+            'cover_image_url' => null,
+            'status' => 'draft',
+            'is_public' => false,
+            'is_indexable' => true,
+            'published_at' => null,
+            'scheduled_at' => null,
+        ], $overrides));
+    }
+
+    /**
+     * @param  array<string, mixed>  $overrides
+     */
+    private function createPersonalityProfile(array $overrides = []): PersonalityProfile
+    {
+        /** @var PersonalityProfile */
+        return PersonalityProfile::query()->create(array_merge([
+            'org_id' => 0,
+            'scale_code' => PersonalityProfile::SCALE_CODE_MBTI,
+            'type_code' => 'INTJ',
+            'slug' => 'intj',
+            'locale' => 'en',
+            'title' => 'INTJ',
+            'subtitle' => 'Strategic and future-oriented',
+            'excerpt' => 'INTJs tend to value competence, systems, and long-range thinking.',
+            'status' => 'draft',
+            'is_public' => false,
+            'is_indexable' => true,
+            'published_at' => null,
+            'scheduled_at' => null,
+            'schema_version' => 'v1',
+        ], $overrides));
+    }
+
+    private function createScaleRegistryRow(string $code, string $primarySlug): void
+    {
+        DB::table('scales_registry')->updateOrInsert([
+            'org_id' => 0,
+            'primary_slug' => $primarySlug,
+        ], [
+            'code' => strtoupper($code),
+            'org_id' => 0,
+            'primary_slug' => $primarySlug,
+            'slugs_json' => json_encode([$primarySlug], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES),
+            'driver_type' => 'MBTI',
+            'default_pack_id' => null,
+            'default_region' => null,
+            'default_locale' => null,
+            'default_dir_version' => null,
+            'capabilities_json' => null,
+            'view_policy_json' => null,
+            'commercial_json' => null,
+            'seo_schema_json' => null,
+            'is_public' => 1,
+            'is_active' => 1,
+            'created_at' => now(),
+            'updated_at' => now(),
+        ]);
+    }
+}


### PR DESCRIPTION
Summary
- add the public read API for Topics CMS v1
- add read-side services, entry resolution, and SEO payload generation for topic hub pages

What changed
- add public endpoints for topic list, detail, and SEO
- add read-side service(s) to query published/public topic profiles
- add an entry resolver to expand topic entries into frontend-ready grouped cards
- add a dedicated SEO service for canonical/meta/jsonld payloads
- align validation and response envelopes with the existing v0.5 Articles API style
- add minimal feature coverage and contract/openapi updates if required by the repository

Design choices
- topics are modeled as structured hub profiles instead of generic articles or tags
- narrative sections and aggregated entries are returned separately
- v1 targets global topic content (org_id=0)
- entry references prefer stable target_key / target_locale
- SEO payloads emit locale-aware frontend URLs
- JSON-LD uses CollectionPage

Why this PR is small and safe
- no database changes beyond T01
- no write-side CMS API changes
- no frontend changes
- no RBAC changes
- no Filament changes
- only public read API / resolver / SEO groundwork for later Topics CMS PRs

Validation
- php artisan about
- php artisan route:list --path=api/v0.5 --except-vendor
- php artisan route:list --path=topics --except-vendor
- php artisan migrate
- php artisan test --filter='(Topic|Topics)'
- bash scripts/export_openapi.sh --check
- local curl checks for list/detail/seo
- bash backend/scripts/ci_verify_mbti.sh
