### PR TITLE
feat(topics-cms): add ops resource and workspace for topic profiles

### DIFF
--- a/backend/app/Filament/Ops/Resources/TopicProfileResource.php
+++ b/backend/app/Filament/Ops/Resources/TopicProfileResource.php
@@ -1,0 +1,596 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Filament\Ops\Resources;
+
+use App\Filament\Ops\Resources\TopicProfileResource\Pages;
+use App\Filament\Ops\Resources\TopicProfileResource\Support\TopicWorkspace;
+use App\Filament\Ops\Support\StatusBadge;
+use App\Models\TopicProfile;
+use App\Support\Rbac\PermissionNames;
+use Filament\Forms;
+use Filament\Forms\Form;
+use Filament\Resources\Resource;
+use Filament\Tables;
+use Filament\Tables\Filters\TernaryFilter;
+use Filament\Tables\Table;
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Support\Str;
+
+class TopicProfileResource extends Resource
+{
+    protected static ?string $model = TopicProfile::class;
+
+    protected static ?string $slug = 'topics';
+
+    protected static ?string $recordTitleAttribute = 'title';
+
+    protected static ?string $navigationIcon = 'heroicon-o-book-open';
+
+    protected static ?string $navigationGroup = 'Content';
+
+    protected static ?string $navigationLabel = 'Topics';
+
+    protected static ?string $modelLabel = 'Topic Profile';
+
+    protected static ?string $pluralModelLabel = 'Topic Profiles';
+
+    public static function canViewAny(): bool
+    {
+        return self::canRead();
+    }
+
+    public static function canCreate(): bool
+    {
+        return self::canPublish();
+    }
+
+    public static function canEdit($record): bool
+    {
+        return self::canPublish();
+    }
+
+    public static function canDelete($record): bool
+    {
+        return false;
+    }
+
+    public static function getNavigationGroup(): ?string
+    {
+        return __('ops.group.content');
+    }
+
+    public static function getNavigationLabel(): string
+    {
+        return 'Topics';
+    }
+
+    public static function form(Form $form): Form
+    {
+        return $form->schema([
+            Forms\Components\Hidden::make('org_id')
+                ->default(0),
+            Forms\Components\Grid::make([
+                'default' => 1,
+                'xl' => 12,
+            ])
+                ->extraAttributes(['class' => 'ops-topic-workspace-layout'])
+                ->schema([
+                    Forms\Components\Group::make([
+                        Forms\Components\Section::make('Basic')
+                            ->description('Shape the topic identity, title hierarchy, and summary before expanding the narrative rails or aggregated entries.')
+                            ->extraAttributes(['class' => 'ops-topic-workspace-section ops-topic-workspace-section--main'])
+                            ->schema([
+                                Forms\Components\TextInput::make('topic_code')
+                                    ->required()
+                                    ->maxLength(64)
+                                    ->placeholder('mbti')
+                                    ->helperText('Stable internal key for this topic hub. Keep it lowercase and durable.')
+                                    ->live(onBlur: true)
+                                    ->dehydrateStateUsing(fn (?string $state): string => TopicWorkspace::normalizeTopicCode($state))
+                                    ->afterStateUpdated(function (?string $state, Forms\Set $set, Forms\Get $get): void {
+                                        if (trim((string) $get('slug')) !== '') {
+                                            return;
+                                        }
+
+                                        $set('slug', TopicWorkspace::normalizeSlug(null, $state));
+                                    })
+                                    ->rules(['regex:/^[a-z0-9-]+$/']),
+                                Forms\Components\TextInput::make('slug')
+                                    ->required()
+                                    ->maxLength(128)
+                                    ->placeholder('mbti')
+                                    ->helperText('Frontend route key for `/en/topics/{slug}` and `/zh/topics/{slug}`.')
+                                    ->dehydrateStateUsing(fn (?string $state, Forms\Get $get): string => TopicWorkspace::normalizeSlug(
+                                        $state,
+                                        (string) $get('topic_code'),
+                                    ))
+                                    ->rules(['regex:/^[a-z0-9-]+$/']),
+                                Forms\Components\Select::make('locale')
+                                    ->required()
+                                    ->native(false)
+                                    ->options(self::localeOptions())
+                                    ->default('en')
+                                    ->helperText('Stored as backend locale codes; frontend routes still resolve to locale-aware `/en` and `/zh`.'),
+                                Forms\Components\TextInput::make('title')
+                                    ->required()
+                                    ->maxLength(255)
+                                    ->columnSpanFull()
+                                    ->helperText('Primary topic heading shown in list rows, public hubs, and SEO fallbacks.')
+                                    ->extraFieldWrapperAttributes(['class' => 'ops-topic-workspace-field ops-topic-workspace-field--title'])
+                                    ->extraInputAttributes(['class' => 'ops-topic-workspace-input ops-topic-workspace-input--title']),
+                                Forms\Components\TextInput::make('subtitle')
+                                    ->maxLength(255)
+                                    ->columnSpanFull()
+                                    ->helperText('Supporting line for the hero and high-level positioning of the topic hub.'),
+                                Forms\Components\Textarea::make('excerpt')
+                                    ->rows(4)
+                                    ->columnSpanFull()
+                                    ->helperText('Short summary used across list cards, resolver fallbacks, and SEO fallback copy.')
+                                    ->extraFieldWrapperAttributes(['class' => 'ops-topic-workspace-field ops-topic-workspace-field--summary']),
+                            ])
+                            ->columns(3),
+                        Forms\Components\Section::make('Hero')
+                            ->description('Frame the topic hub with a short kicker, quote, and optional cover image without turning it into a generic article header.')
+                            ->extraAttributes(['class' => 'ops-topic-workspace-section ops-topic-workspace-section--main'])
+                            ->schema([
+                                Forms\Components\TextInput::make('hero_kicker')
+                                    ->maxLength(128)
+                                    ->helperText('Optional editorial kicker for topic landing pages.'),
+                                Forms\Components\Textarea::make('hero_quote')
+                                    ->rows(4)
+                                    ->helperText('Optional callout or orienting quote.'),
+                                Forms\Components\TextInput::make('cover_image_url')
+                                    ->maxLength(2048)
+                                    ->columnSpanFull()
+                                    ->helperText('Optional cover image URL for future frontend or card usage.'),
+                            ])
+                            ->columns(2),
+                        Forms\Components\Section::make('Narrative sections')
+                            ->description('Edit only the fixed narrative sections that define the topic story. Unknown section keys are ignored by the workspace.')
+                            ->extraAttributes(['class' => 'ops-topic-workspace-section ops-topic-workspace-section--main'])
+                            ->schema([
+                                Forms\Components\Tabs::make('Topic sections')
+                                    ->contained(false)
+                                    ->extraAttributes(['class' => 'ops-topic-workspace-tabs'])
+                                    ->tabs(self::sectionTabs())
+                                    ->columnSpanFull(),
+                            ]),
+                        Forms\Components\Section::make('Entry groups')
+                            ->description('Manage group-aware aggregations instead of editing raw database rows. Each group keeps allowed entry types constrained.')
+                            ->extraAttributes(['class' => 'ops-topic-workspace-section ops-topic-workspace-section--main'])
+                            ->schema([
+                                Forms\Components\Tabs::make('Topic entry groups')
+                                    ->contained(false)
+                                    ->extraAttributes(['class' => 'ops-topic-workspace-tabs'])
+                                    ->tabs(self::entryGroupTabs())
+                                    ->columnSpanFull(),
+                            ]),
+                    ])
+                        ->columnSpan([
+                            'xl' => 8,
+                        ])
+                        ->extraAttributes(['class' => 'ops-topic-workspace-main-column']),
+                    Forms\Components\Group::make([
+                        Forms\Components\Section::make('Identity')
+                            ->description('Topics CMS v1 manages global hub content only. Org scope stays fixed and not tenant-specific.')
+                            ->extraAttributes(['class' => 'ops-topic-workspace-section ops-topic-workspace-section--rail'])
+                            ->schema([
+                                Forms\Components\Placeholder::make('identity_topic_code')
+                                    ->label('Topic code')
+                                    ->content(fn (Forms\Get $get, ?TopicProfile $record): string => TopicWorkspace::normalizeTopicCode(
+                                        (string) ($get('topic_code') ?? $record?->topic_code ?? '')
+                                    ) ?: 'Not set yet'),
+                                Forms\Components\Placeholder::make('identity_slug')
+                                    ->label('Slug')
+                                    ->content(fn (Forms\Get $get, ?TopicProfile $record): string => TopicWorkspace::normalizeSlug(
+                                        (string) ($get('slug') ?? $record?->slug ?? ''),
+                                        (string) ($get('topic_code') ?? $record?->topic_code ?? ''),
+                                    ) ?: 'Not set yet'),
+                                Forms\Components\Placeholder::make('identity_locale')
+                                    ->label('Locale')
+                                    ->content(fn (Forms\Get $get, ?TopicProfile $record): string => TopicWorkspace::normalizeLocale(
+                                        (string) ($get('locale') ?? $record?->locale ?? 'en'),
+                                    )),
+                                Forms\Components\Placeholder::make('identity_org')
+                                    ->label('Content scope')
+                                    ->content('Global topic content (org_id=0)'),
+                            ])
+                            ->columns(2),
+                        Forms\Components\Section::make('Publish')
+                            ->description('Keep visibility, indexing, and ordering cues together on the metadata rail.')
+                            ->extraAttributes(['class' => 'ops-topic-workspace-section ops-topic-workspace-section--rail'])
+                            ->schema([
+                                Forms\Components\Placeholder::make('workspace_state')
+                                    ->label('Editorial cues')
+                                    ->content(fn (Forms\Get $get, ?TopicProfile $record) => TopicWorkspace::renderEditorialCues($get, $record))
+                                    ->columnSpanFull(),
+                                Forms\Components\Select::make('status')
+                                    ->required()
+                                    ->native(false)
+                                    ->options(self::statusOptions())
+                                    ->default(TopicProfile::STATUS_DRAFT)
+                                    ->helperText('Published topics become eligible for public topic APIs once locale and visibility align.'),
+                                Forms\Components\Toggle::make('is_public')
+                                    ->label('Public visibility')
+                                    ->default(true)
+                                    ->helperText('Controls whether public topic endpoints can serve this topic hub.'),
+                                Forms\Components\Toggle::make('is_indexable')
+                                    ->label('Search indexable')
+                                    ->default(true)
+                                    ->helperText('Used for SEO payload fallbacks and future sitemap eligibility.'),
+                                Forms\Components\DateTimePicker::make('published_at')
+                                    ->helperText('Timestamp shown in editorial cues and public topic payloads.'),
+                                Forms\Components\DateTimePicker::make('scheduled_at')
+                                    ->helperText('Optional scheduling hint for editorial planning.'),
+                                Forms\Components\TextInput::make('sort_order')
+                                    ->numeric()
+                                    ->default(0)
+                                    ->helperText('List ordering for future topic hubs and ops tables.'),
+                            ]),
+                        Forms\Components\Section::make('SEO')
+                            ->description('Keep search metadata, social overrides, and advanced JSON-LD input in one reviewable rail.')
+                            ->extraAttributes(['class' => 'ops-topic-workspace-section ops-topic-workspace-section--rail'])
+                            ->schema([
+                                Forms\Components\Placeholder::make('seo_snapshot')
+                                    ->label('SEO snapshot')
+                                    ->content(fn (Forms\Get $get, ?TopicProfile $record) => TopicWorkspace::renderSeoSnapshot($get, $record))
+                                    ->columnSpanFull(),
+                                Forms\Components\TextInput::make('workspace_seo.seo_title')
+                                    ->label('SEO title')
+                                    ->maxLength(255)
+                                    ->helperText('Search headline fallback is the topic title if this stays empty.'),
+                                Forms\Components\Textarea::make('workspace_seo.seo_description')
+                                    ->label('SEO description')
+                                    ->rows(3)
+                                    ->helperText('Search description fallback is excerpt, then subtitle.'),
+                                Forms\Components\TextInput::make('workspace_seo.canonical_url')
+                                    ->label('Canonical override')
+                                    ->maxLength(2048)
+                                    ->helperText('Optional stored override. Final frontend canonical still resolves to locale-aware topic URLs.'),
+                                Forms\Components\TextInput::make('workspace_seo.og_title')
+                                    ->label('Open Graph title')
+                                    ->maxLength(255),
+                                Forms\Components\Textarea::make('workspace_seo.og_description')
+                                    ->label('Open Graph description')
+                                    ->rows(3),
+                                Forms\Components\TextInput::make('workspace_seo.og_image_url')
+                                    ->label('Open Graph image URL')
+                                    ->maxLength(2048),
+                                Forms\Components\TextInput::make('workspace_seo.twitter_title')
+                                    ->label('Twitter title')
+                                    ->maxLength(255),
+                                Forms\Components\Textarea::make('workspace_seo.twitter_description')
+                                    ->label('Twitter description')
+                                    ->rows(3),
+                                Forms\Components\TextInput::make('workspace_seo.twitter_image_url')
+                                    ->label('Twitter image URL')
+                                    ->maxLength(2048),
+                                Forms\Components\TextInput::make('workspace_seo.robots')
+                                    ->label('Robots')
+                                    ->maxLength(64)
+                                    ->helperText('Leave blank to derive robots from the current indexability toggle.'),
+                                Forms\Components\Textarea::make('workspace_seo.jsonld_overrides_json_text')
+                                    ->label('JSON-LD overrides')
+                                    ->rows(5)
+                                    ->helperText('Optional advanced overrides merged into the public Topics JSON-LD payload.')
+                                    ->rules(['nullable', 'json'])
+                                    ->extraFieldWrapperAttributes(['class' => 'ops-topic-workspace-field ops-topic-workspace-field--payload']),
+                            ]),
+                        Forms\Components\Section::make('Record cues')
+                            ->description('Read-only context so editors can see the planned URL, revision trail, entry count, and SEO readiness before frontend cutover.')
+                            ->extraAttributes(['class' => 'ops-topic-workspace-section ops-topic-workspace-section--rail'])
+                            ->schema([
+                                Forms\Components\Placeholder::make('planned_public_url')
+                                    ->label('Planned public URL')
+                                    ->content(fn (Forms\Get $get, ?TopicProfile $record): string => TopicWorkspace::plannedPublicUrl(
+                                        (string) ($get('slug') ?? $record?->slug ?? ''),
+                                        (string) ($get('locale') ?? $record?->locale ?? 'en'),
+                                    ) ?? 'Appears once slug and locale are set.'),
+                                Forms\Components\Placeholder::make('created_at_summary')
+                                    ->label('Created')
+                                    ->content(fn (?TopicProfile $record): string => TopicWorkspace::formatTimestamp(
+                                        $record?->created_at,
+                                        'Workspace draft not saved yet',
+                                    )),
+                                Forms\Components\Placeholder::make('updated_at_summary')
+                                    ->label('Last updated')
+                                    ->content(fn (?TopicProfile $record): string => TopicWorkspace::formatTimestamp(
+                                        $record?->updated_at,
+                                        'Workspace draft not saved yet',
+                                    )),
+                                Forms\Components\Placeholder::make('revision_count_summary')
+                                    ->label('Revision count')
+                                    ->content(fn (?TopicProfile $record): string => $record instanceof TopicProfile
+                                        ? (string) $record->revisions()->count()
+                                        : 'Revision #1 will be written when this topic is created'),
+                                Forms\Components\Placeholder::make('entry_count_summary')
+                                    ->label('Entry summary')
+                                    ->content(fn (Forms\Get $get, ?TopicProfile $record): string => TopicWorkspace::entrySummary(
+                                        is_array($get('workspace_entries') ?? null) ? $get('workspace_entries') : [],
+                                        $record,
+                                    )),
+                            ])
+                            ->columns(2),
+                    ])
+                        ->columnSpan([
+                            'xl' => 4,
+                        ])
+                        ->extraAttributes(['class' => 'ops-topic-workspace-rail-column']),
+                ]),
+        ]);
+    }
+
+    public static function table(Table $table): Table
+    {
+        return $table
+            ->columns([
+                Tables\Columns\TextColumn::make('title')
+                    ->label('Topic')
+                    ->html()
+                    ->searchable(['topic_code', 'title', 'slug'])
+                    ->sortable()
+                    ->formatStateUsing(fn (TopicProfile $record): string => (string) view('filament.ops.topics.partials.table-title', [
+                        'meta' => TopicWorkspace::titleMeta($record),
+                        'title' => $record->title,
+                    ])->render()),
+                Tables\Columns\TextColumn::make('status')
+                    ->badge()
+                    ->sortable()
+                    ->formatStateUsing(fn (string $state): string => Str::of($state)->headline()->value())
+                    ->description(fn (TopicProfile $record): string => TopicWorkspace::visibilityMeta($record))
+                    ->color(fn (string $state): string => StatusBadge::color($state)),
+                Tables\Columns\TextColumn::make('is_public')
+                    ->label('Visibility')
+                    ->badge()
+                    ->formatStateUsing(fn (bool|int|string|null $state): string => StatusBadge::booleanLabel($state, 'Public', 'Private'))
+                    ->color(fn (bool|int|string|null $state): string => StatusBadge::booleanColor($state))
+                    ->sortable(),
+                Tables\Columns\TextColumn::make('is_indexable')
+                    ->label('Indexing')
+                    ->badge()
+                    ->formatStateUsing(fn (bool|int|string|null $state): string => StatusBadge::booleanLabel($state, 'Indexable', 'Noindex'))
+                    ->color(fn (bool|int|string|null $state): string => StatusBadge::booleanColor($state))
+                    ->sortable(),
+                Tables\Columns\TextColumn::make('entries_count')
+                    ->label('Entries')
+                    ->numeric()
+                    ->sortable()
+                    ->alignCenter(),
+                Tables\Columns\TextColumn::make('published_at')
+                    ->label('Published')
+                    ->dateTime()
+                    ->sortable()
+                    ->placeholder('Not published'),
+                Tables\Columns\TextColumn::make('updated_at')
+                    ->label('Updated')
+                    ->since()
+                    ->sortable(),
+            ])
+            ->filters([
+                Tables\Filters\SelectFilter::make('topic_code')
+                    ->label('Topic code')
+                    ->options(self::topicCodeFilterOptions()),
+                Tables\Filters\SelectFilter::make('locale')
+                    ->options(self::localeOptions()),
+                Tables\Filters\SelectFilter::make('status')
+                    ->options(self::statusOptions()),
+                TernaryFilter::make('is_public')
+                    ->label('Public'),
+                TernaryFilter::make('is_indexable')
+                    ->label('Indexable'),
+            ])
+            ->searchPlaceholder('Search topic code, title, or slug')
+            ->defaultSort('updated_at', 'desc')
+            ->recordUrl(fn (TopicProfile $record): string => static::getUrl('edit', ['record' => $record]))
+            ->actions([
+                Tables\Actions\EditAction::make()
+                    ->label('Edit')
+                    ->icon('heroicon-o-pencil-square')
+                    ->color('gray'),
+            ])
+            ->bulkActions([]);
+    }
+
+    public static function getPages(): array
+    {
+        return [
+            'index' => Pages\ListTopicProfiles::route('/'),
+            'create' => Pages\CreateTopicProfile::route('/create'),
+            'edit' => Pages\EditTopicProfile::route('/{record}/edit'),
+        ];
+    }
+
+    public static function getEloquentQuery(): Builder
+    {
+        return parent::getEloquentQuery()
+            ->withoutGlobalScopes()
+            ->where('org_id', 0)
+            ->withCount('entries');
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    private static function statusOptions(): array
+    {
+        return [
+            TopicProfile::STATUS_DRAFT => TopicProfile::STATUS_DRAFT,
+            TopicProfile::STATUS_PUBLISHED => TopicProfile::STATUS_PUBLISHED,
+        ];
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    private static function localeOptions(): array
+    {
+        return collect(TopicProfile::SUPPORTED_LOCALES)
+            ->mapWithKeys(static fn (string $locale): array => [$locale => $locale])
+            ->all();
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    private static function topicCodeFilterOptions(): array
+    {
+        return TopicProfile::query()
+            ->withoutGlobalScopes()
+            ->where('org_id', 0)
+            ->orderBy('topic_code')
+            ->pluck('topic_code', 'topic_code')
+            ->all();
+    }
+
+    /**
+     * @return array<int, Forms\Components\Tabs\Tab>
+     */
+    private static function sectionTabs(): array
+    {
+        $variantOptions = TopicWorkspace::renderVariantOptions();
+
+        return collect(TopicWorkspace::sectionDefinitions())
+            ->map(function (array $definition, string $sectionKey) use ($variantOptions): Forms\Components\Tabs\Tab {
+                return Forms\Components\Tabs\Tab::make($definition['label'])
+                    ->schema([
+                        Forms\Components\Toggle::make("workspace_sections.{$sectionKey}.is_enabled")
+                            ->label('Enable this section')
+                            ->helperText($definition['description'])
+                            ->columnSpanFull(),
+                        Forms\Components\TextInput::make("workspace_sections.{$sectionKey}.title")
+                            ->label('Section title')
+                            ->required()
+                            ->maxLength(255),
+                        Forms\Components\Select::make("workspace_sections.{$sectionKey}.render_variant")
+                            ->label('Render variant')
+                            ->native(false)
+                            ->options($variantOptions)
+                            ->required(),
+                        Forms\Components\Textarea::make("workspace_sections.{$sectionKey}.body_md")
+                            ->label('Narrative body')
+                            ->rows(8)
+                            ->columnSpanFull()
+                            ->helperText('Use markdown-friendly narrative copy when this section needs long-form explanation.')
+                            ->extraFieldWrapperAttributes(['class' => 'ops-topic-workspace-field ops-topic-workspace-field--body']),
+                        Forms\Components\Textarea::make("workspace_sections.{$sectionKey}.payload_json_text")
+                            ->label('Structured payload JSON')
+                            ->rows(6)
+                            ->columnSpanFull()
+                            ->helperText('Optional structured payload for cards, FAQ, links, or callout render variants.')
+                            ->rules(['nullable', 'json'])
+                            ->extraFieldWrapperAttributes(['class' => 'ops-topic-workspace-field ops-topic-workspace-field--payload']),
+                    ])
+                    ->columns(2);
+            })
+            ->values()
+            ->all();
+    }
+
+    /**
+     * @return array<int, Forms\Components\Tabs\Tab>
+     */
+    private static function entryGroupTabs(): array
+    {
+        return collect(TopicWorkspace::entryGroupDefinitions())
+            ->map(function (array $definition, string $groupKey): Forms\Components\Tabs\Tab {
+                return Forms\Components\Tabs\Tab::make($definition['label'])
+                    ->schema([
+                        Forms\Components\Repeater::make("workspace_entries.{$groupKey}")
+                            ->label($definition['label'])
+                            ->default([])
+                            ->addActionLabel($definition['add_label'])
+                            ->helperText($definition['description'])
+                            ->itemLabel(fn (array $state): ?string => TopicWorkspace::entryItemLabel($state))
+                            ->reorderableWithButtons()
+                            ->collapsible()
+                            ->cloneable()
+                            ->columns(2)
+                            ->schema([
+                                Forms\Components\Select::make('entry_type')
+                                    ->required()
+                                    ->native(false)
+                                    ->options(TopicWorkspace::entryTypeOptionsForGroup($groupKey))
+                                    ->helperText('Only entry types approved for this group appear here.'),
+                                Forms\Components\TextInput::make('target_key')
+                                    ->label('Target key')
+                                    ->helperText('Use article slug, personality type/slug, or scale code depending on the entry type.')
+                                    ->required(fn (Forms\Get $get): bool => $get('entry_type') !== 'custom_link')
+                                    ->visible(fn (Forms\Get $get): bool => $get('entry_type') !== 'custom_link'),
+                                Forms\Components\Select::make('target_locale')
+                                    ->label('Target locale')
+                                    ->native(false)
+                                    ->options(self::localeOptions())
+                                    ->helperText('Defaults to the current topic locale if left blank.')
+                                    ->visible(fn (Forms\Get $get): bool => $get('entry_type') !== 'custom_link'),
+                                Forms\Components\TextInput::make('target_url_override')
+                                    ->label('Custom relative URL')
+                                    ->helperText('Required for custom links. Use site-relative paths like `/en/articles/example`.')
+                                    ->required(fn (Forms\Get $get): bool => $get('entry_type') === 'custom_link')
+                                    ->visible(fn (Forms\Get $get): bool => $get('entry_type') === 'custom_link'),
+                                Forms\Components\TextInput::make('title_override')
+                                    ->label('Title override')
+                                    ->maxLength(255)
+                                    ->helperText('Optional for resolved entries. Required for custom links.')
+                                    ->required(fn (Forms\Get $get): bool => $get('entry_type') === 'custom_link'),
+                                Forms\Components\Textarea::make('excerpt_override')
+                                    ->label('Excerpt override')
+                                    ->rows(3),
+                                Forms\Components\TextInput::make('badge_label')
+                                    ->label('Badge label')
+                                    ->maxLength(64),
+                                Forms\Components\TextInput::make('cta_label')
+                                    ->label('CTA label')
+                                    ->maxLength(64),
+                                Forms\Components\Textarea::make('payload_json_text')
+                                    ->label('Payload JSON')
+                                    ->rows(5)
+                                    ->columnSpanFull()
+                                    ->rules(['nullable', 'json'])
+                                    ->helperText('Optional structured payload for future UI enrichment.')
+                                    ->extraFieldWrapperAttributes(['class' => 'ops-topic-workspace-field ops-topic-workspace-field--payload']),
+                                Forms\Components\Toggle::make('is_featured')
+                                    ->label('Featured')
+                                    ->default((bool) $definition['force_featured'])
+                                    ->hidden((bool) $definition['force_featured']),
+                                Forms\Components\Toggle::make('is_enabled')
+                                    ->label('Enabled')
+                                    ->default(true),
+                                Forms\Components\TextInput::make('sort_order')
+                                    ->label('Sort order')
+                                    ->numeric()
+                                    ->default(0),
+                            ]),
+                    ]);
+            })
+            ->values()
+            ->all();
+    }
+
+    private static function canRead(): bool
+    {
+        $guard = (string) config('admin.guard', 'admin');
+        $user = auth($guard)->user();
+
+        return is_object($user)
+            && method_exists($user, 'hasPermission')
+            && (
+                $user->hasPermission(PermissionNames::ADMIN_CONTENT_READ)
+                || $user->hasPermission(PermissionNames::ADMIN_OWNER)
+            );
+    }
+
+    private static function canPublish(): bool
+    {
+        $guard = (string) config('admin.guard', 'admin');
+        $user = auth($guard)->user();
+
+        return is_object($user)
+            && method_exists($user, 'hasPermission')
+            && (
+                $user->hasPermission(PermissionNames::ADMIN_CONTENT_PUBLISH)
+                || $user->hasPermission(PermissionNames::ADMIN_OWNER)
+            );
+    }
+}

--- a/backend/app/Filament/Ops/Resources/TopicProfileResource/Pages/CreateTopicProfile.php
+++ b/backend/app/Filament/Ops/Resources/TopicProfileResource/Pages/CreateTopicProfile.php
@@ -1,0 +1,139 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Filament\Ops\Resources\TopicProfileResource\Pages;
+
+use App\Filament\Ops\Resources\TopicProfileResource;
+use App\Filament\Ops\Resources\TopicProfileResource\Support\TopicWorkspace;
+use Filament\Actions\Action;
+use Filament\Resources\Pages\CreateRecord;
+use Illuminate\Contracts\Support\Htmlable;
+
+class CreateTopicProfile extends CreateRecord
+{
+    protected static string $resource = TopicProfileResource::class;
+
+    /**
+     * @var array<string, mixed>
+     */
+    protected array $workspaceSectionsState = [];
+
+    /**
+     * @var array<string, mixed>
+     */
+    protected array $workspaceEntriesState = [];
+
+    /**
+     * @var array<string, mixed>
+     */
+    protected array $workspaceSeoState = [];
+
+    public function getTitle(): string|Htmlable
+    {
+        return 'Create Topic';
+    }
+
+    public function getSubheading(): ?string
+    {
+        return 'Build a structured topic hub with fixed narrative sections, grouped entries, and metadata rails.';
+    }
+
+    protected function fillForm(): void
+    {
+        $this->callHook('beforeFill');
+
+        $this->form->fill(TopicWorkspace::defaultFormState());
+
+        $this->callHook('afterFill');
+    }
+
+    protected function getHeaderActions(): array
+    {
+        return [
+            Action::make('backToTopics')
+                ->label('All Topic Profiles')
+                ->url(TopicProfileResource::getUrl())
+                ->icon('heroicon-o-arrow-left')
+                ->color('gray'),
+        ];
+    }
+
+    protected function getCreateFormAction(): Action
+    {
+        return parent::getCreateFormAction()
+            ->label('Create Topic')
+            ->icon('heroicon-o-check-circle');
+    }
+
+    protected function getCreateAnotherFormAction(): Action
+    {
+        return parent::getCreateAnotherFormAction()
+            ->label('Create & Add Another')
+            ->icon('heroicon-o-document-duplicate');
+    }
+
+    protected function getCancelFormAction(): Action
+    {
+        return parent::getCancelFormAction()
+            ->label('Back to Topics')
+            ->icon('heroicon-o-arrow-left');
+    }
+
+    /**
+     * @param  array<string, mixed>  $data
+     * @return array<string, mixed>
+     */
+    protected function mutateFormDataBeforeCreate(array $data): array
+    {
+        $this->workspaceSectionsState = is_array($data['workspace_sections'] ?? null) ? $data['workspace_sections'] : [];
+        $this->workspaceEntriesState = is_array($data['workspace_entries'] ?? null) ? $data['workspace_entries'] : [];
+        $this->workspaceSeoState = is_array($data['workspace_seo'] ?? null) ? $data['workspace_seo'] : [];
+
+        unset($data['workspace_sections'], $data['workspace_entries'], $data['workspace_seo']);
+
+        $topicCode = TopicWorkspace::normalizeTopicCode((string) ($data['topic_code'] ?? ''));
+
+        $data['org_id'] = 0;
+        $data['topic_code'] = $topicCode;
+        $data['slug'] = TopicWorkspace::normalizeSlug((string) ($data['slug'] ?? ''), $topicCode);
+        $data['locale'] = TopicWorkspace::normalizeLocale((string) ($data['locale'] ?? 'en'));
+        $data['created_by_admin_user_id'] = $this->currentAdminId();
+        $data['updated_by_admin_user_id'] = $this->currentAdminId();
+
+        return $data;
+    }
+
+    protected function afterCreate(): void
+    {
+        TopicWorkspace::syncWorkspaceSections($this->getRecord(), $this->workspaceSectionsState);
+        TopicWorkspace::syncWorkspaceEntries($this->getRecord(), $this->workspaceEntriesState);
+        TopicWorkspace::syncWorkspaceSeo($this->getRecord(), $this->workspaceSeoState);
+        $this->getRecord()->unsetRelation('sections');
+        $this->getRecord()->unsetRelation('entries');
+        $this->getRecord()->unsetRelation('seoMeta');
+        TopicWorkspace::createRevision($this->getRecord(), 'Initial workspace snapshot');
+    }
+
+    protected function getCreatedNotificationTitle(): ?string
+    {
+        return 'Topic profile created';
+    }
+
+    protected function getRedirectUrl(): string
+    {
+        return TopicProfileResource::getUrl('edit', ['record' => $this->getRecord()]);
+    }
+
+    private function currentAdminId(): ?int
+    {
+        $guard = (string) config('admin.guard', 'admin');
+        $user = auth($guard)->user();
+
+        if (! is_object($user) || ! method_exists($user, 'getAuthIdentifier')) {
+            return null;
+        }
+
+        return (int) $user->getAuthIdentifier();
+    }
+}

--- a/backend/app/Filament/Ops/Resources/TopicProfileResource/Pages/EditTopicProfile.php
+++ b/backend/app/Filament/Ops/Resources/TopicProfileResource/Pages/EditTopicProfile.php
@@ -1,0 +1,136 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Filament\Ops\Resources\TopicProfileResource\Pages;
+
+use App\Filament\Ops\Resources\TopicProfileResource;
+use App\Filament\Ops\Resources\TopicProfileResource\Support\TopicWorkspace;
+use Filament\Actions\Action;
+use Filament\Resources\Pages\EditRecord;
+use Illuminate\Contracts\Support\Htmlable;
+
+class EditTopicProfile extends EditRecord
+{
+    protected static string $resource = TopicProfileResource::class;
+
+    /**
+     * @var array<string, mixed>
+     */
+    protected array $workspaceSectionsState = [];
+
+    /**
+     * @var array<string, mixed>
+     */
+    protected array $workspaceEntriesState = [];
+
+    /**
+     * @var array<string, mixed>
+     */
+    protected array $workspaceSeoState = [];
+
+    public function getTitle(): string|Htmlable
+    {
+        return filled($this->getRecord()->title) ? (string) $this->getRecord()->title : 'Edit Topic Profile';
+    }
+
+    public function getSubheading(): ?string
+    {
+        return 'Maintain the topic hub without leaving the structured editorial workspace.';
+    }
+
+    protected function getHeaderActions(): array
+    {
+        return [
+            Action::make('backToTopics')
+                ->label('All Topic Profiles')
+                ->url(TopicProfileResource::getUrl())
+                ->icon('heroicon-o-arrow-left')
+                ->color('gray'),
+        ];
+    }
+
+    protected function getSaveFormAction(): Action
+    {
+        return parent::getSaveFormAction()
+            ->label('Save Changes')
+            ->icon('heroicon-o-check-circle');
+    }
+
+    protected function getCancelFormAction(): Action
+    {
+        return parent::getCancelFormAction()
+            ->label('Back to Topics')
+            ->icon('heroicon-o-arrow-left');
+    }
+
+    /**
+     * @param  array<string, mixed>  $data
+     * @return array<string, mixed>
+     */
+    protected function mutateFormDataBeforeFill(array $data): array
+    {
+        return [
+            ...$data,
+            'workspace_sections' => TopicWorkspace::workspaceSectionsFromRecord($this->getRecord()),
+            'workspace_entries' => TopicWorkspace::workspaceEntriesFromRecord($this->getRecord()),
+            'workspace_seo' => TopicWorkspace::workspaceSeoFromRecord($this->getRecord()),
+        ];
+    }
+
+    /**
+     * @param  array<string, mixed>  $data
+     * @return array<string, mixed>
+     */
+    protected function mutateFormDataBeforeSave(array $data): array
+    {
+        $this->workspaceSectionsState = is_array($data['workspace_sections'] ?? null) ? $data['workspace_sections'] : [];
+        $this->workspaceEntriesState = is_array($data['workspace_entries'] ?? null) ? $data['workspace_entries'] : [];
+        $this->workspaceSeoState = is_array($data['workspace_seo'] ?? null) ? $data['workspace_seo'] : [];
+
+        unset($data['workspace_sections'], $data['workspace_entries'], $data['workspace_seo']);
+
+        $topicCode = TopicWorkspace::normalizeTopicCode((string) ($data['topic_code'] ?? ''));
+
+        $data['org_id'] = 0;
+        $data['topic_code'] = $topicCode;
+        $data['slug'] = TopicWorkspace::normalizeSlug((string) ($data['slug'] ?? ''), $topicCode);
+        $data['locale'] = TopicWorkspace::normalizeLocale((string) ($data['locale'] ?? 'en'));
+        $data['updated_by_admin_user_id'] = $this->currentAdminId();
+
+        return $data;
+    }
+
+    protected function afterSave(): void
+    {
+        TopicWorkspace::syncWorkspaceSections($this->getRecord(), $this->workspaceSectionsState);
+        TopicWorkspace::syncWorkspaceEntries($this->getRecord(), $this->workspaceEntriesState);
+        TopicWorkspace::syncWorkspaceSeo($this->getRecord(), $this->workspaceSeoState);
+        $this->getRecord()->unsetRelation('sections');
+        $this->getRecord()->unsetRelation('entries');
+        $this->getRecord()->unsetRelation('seoMeta');
+        TopicWorkspace::createRevision($this->getRecord(), 'Workspace update');
+    }
+
+    protected function getSavedNotificationTitle(): ?string
+    {
+        return 'Topic profile updated';
+    }
+
+    protected function getRedirectUrl(): string
+    {
+        return TopicProfileResource::getUrl('edit', ['record' => $this->getRecord()]);
+    }
+
+    private function currentAdminId(): ?int
+    {
+        $guard = (string) config('admin.guard', 'admin');
+        $user = auth($guard)->user();
+
+        if (! is_object($user) || ! method_exists($user, 'getAuthIdentifier')) {
+            return null;
+        }
+
+        return (int) $user->getAuthIdentifier();
+    }
+}

--- a/backend/app/Filament/Ops/Resources/TopicProfileResource/Pages/ListTopicProfiles.php
+++ b/backend/app/Filament/Ops/Resources/TopicProfileResource/Pages/ListTopicProfiles.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Filament\Ops\Resources\TopicProfileResource\Pages;
+
+use App\Filament\Ops\Resources\Pages\Concerns\HasSharedListEmptyState;
+use App\Filament\Ops\Resources\TopicProfileResource;
+use Filament\Actions;
+use Filament\Resources\Pages\ListRecords;
+use Illuminate\Contracts\Support\Htmlable;
+
+class ListTopicProfiles extends ListRecords
+{
+    use HasSharedListEmptyState;
+
+    protected static string $resource = TopicProfileResource::class;
+
+    public function getTitle(): string|Htmlable
+    {
+        return 'Topics';
+    }
+
+    public function getSubheading(): ?string
+    {
+        return 'Global topic content workspace for structured topic hubs and curated entry groups. Not tenant-specific.';
+    }
+
+    protected function getHeaderActions(): array
+    {
+        return [
+            Actions\CreateAction::make()
+                ->label('Create Topic')
+                ->icon('heroicon-o-plus'),
+        ];
+    }
+}

--- a/backend/app/Filament/Ops/Resources/TopicProfileResource/Support/TopicWorkspace.php
+++ b/backend/app/Filament/Ops/Resources/TopicProfileResource/Support/TopicWorkspace.php
@@ -1,0 +1,940 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Filament\Ops\Resources\TopicProfileResource\Support;
+
+use App\Filament\Ops\Support\StatusBadge;
+use App\Models\TopicProfile;
+use App\Models\TopicProfileEntry;
+use App\Models\TopicProfileRevision;
+use App\Models\TopicProfileSection;
+use App\Models\TopicProfileSeoMeta;
+use App\Services\Cms\TopicProfileSeoService;
+use Filament\Forms\Get;
+use Illuminate\Contracts\Support\Htmlable;
+use Illuminate\Support\Carbon;
+use Illuminate\Support\HtmlString;
+use Illuminate\Support\Str;
+use Illuminate\Validation\ValidationException;
+
+final class TopicWorkspace
+{
+    /**
+     * @return array<string, array{label: string, title: string, description: string, render_variant: string, sort_order: int, enabled: bool}>
+     */
+    public static function sectionDefinitions(): array
+    {
+        return [
+            'overview' => [
+                'label' => 'Overview',
+                'title' => 'Overview',
+                'description' => 'Core framing for what this topic is and how readers should orient to it.',
+                'render_variant' => 'rich_text',
+                'sort_order' => 10,
+                'enabled' => true,
+            ],
+            'key_concepts' => [
+                'label' => 'Key Concepts',
+                'title' => 'Key concepts',
+                'description' => 'Definitions, distinctions, and foundational concepts readers need first.',
+                'render_variant' => 'cards',
+                'sort_order' => 20,
+                'enabled' => true,
+            ],
+            'why_it_matters' => [
+                'label' => 'Why It Matters',
+                'title' => 'Why it matters',
+                'description' => 'Editorial explanation of why this topic matters in practice.',
+                'render_variant' => 'rich_text',
+                'sort_order' => 30,
+                'enabled' => true,
+            ],
+            'who_should_read' => [
+                'label' => 'Who Should Read',
+                'title' => 'Who should read',
+                'description' => 'Audience guidance and decision cues for this topic hub.',
+                'render_variant' => 'bullets',
+                'sort_order' => 40,
+                'enabled' => true,
+            ],
+            'faq' => [
+                'label' => 'FAQ',
+                'title' => 'Frequently asked questions',
+                'description' => 'Optional FAQ block for repeat questions the topic hub should answer directly.',
+                'render_variant' => 'faq',
+                'sort_order' => 50,
+                'enabled' => false,
+            ],
+            'related_topics_intro' => [
+                'label' => 'Related Topics Intro',
+                'title' => 'Related topics intro',
+                'description' => 'Lead-in copy for the related topics or related resources section.',
+                'render_variant' => 'callout',
+                'sort_order' => 60,
+                'enabled' => false,
+            ],
+        ];
+    }
+
+    /**
+     * @return array<string, array{label: string, description: string, allowed_entry_types: list<string>, add_label: string, sort_order: int, force_featured: bool}>
+     */
+    public static function entryGroupDefinitions(): array
+    {
+        return [
+            'featured' => [
+                'label' => 'Featured entries',
+                'description' => 'High-signal hero cards for the topic hub. Use sparingly and keep them editorially intentional.',
+                'allowed_entry_types' => ['article', 'personality_profile', 'scale', 'custom_link'],
+                'add_label' => 'Add featured entry',
+                'sort_order' => 10,
+                'force_featured' => true,
+            ],
+            'articles' => [
+                'label' => 'Article entries',
+                'description' => 'Link supporting articles by slug and locale, with optional copy overrides.',
+                'allowed_entry_types' => ['article', 'custom_link'],
+                'add_label' => 'Add article entry',
+                'sort_order' => 20,
+                'force_featured' => false,
+            ],
+            'personalities' => [
+                'label' => 'Personality entries',
+                'description' => 'Link personality profiles by type code or slug. Defaults to the current topic locale unless overridden.',
+                'allowed_entry_types' => ['personality_profile', 'custom_link'],
+                'add_label' => 'Add personality entry',
+                'sort_order' => 30,
+                'force_featured' => false,
+            ],
+            'tests' => [
+                'label' => 'Test entries',
+                'description' => 'Link assessment scales or a custom relative path while scale routing stabilizes.',
+                'allowed_entry_types' => ['scale', 'custom_link'],
+                'add_label' => 'Add test entry',
+                'sort_order' => 40,
+                'force_featured' => false,
+            ],
+            'related' => [
+                'label' => 'Related entries',
+                'description' => 'Catch-all related resources group for mixed supporting links that stay within the site.',
+                'allowed_entry_types' => ['article', 'personality_profile', 'scale', 'custom_link'],
+                'add_label' => 'Add related entry',
+                'sort_order' => 50,
+                'force_featured' => false,
+            ],
+        ];
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    public static function renderVariantOptions(): array
+    {
+        return collect(TopicProfileSection::RENDER_VARIANTS)
+            ->mapWithKeys(static fn (string $variant): array => [
+                $variant => Str::of($variant)->replace('_', ' ')->headline()->value(),
+            ])
+            ->all();
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public static function defaultFormState(): array
+    {
+        return [
+            'org_id' => 0,
+            'topic_code' => '',
+            'slug' => '',
+            'locale' => 'en',
+            'title' => '',
+            'subtitle' => '',
+            'excerpt' => '',
+            'hero_kicker' => '',
+            'hero_quote' => '',
+            'cover_image_url' => '',
+            'status' => TopicProfile::STATUS_DRAFT,
+            'is_public' => true,
+            'is_indexable' => true,
+            'published_at' => null,
+            'scheduled_at' => null,
+            'sort_order' => 0,
+            'workspace_sections' => self::defaultWorkspaceSectionsState(),
+            'workspace_entries' => self::defaultWorkspaceEntriesState(),
+            'workspace_seo' => self::defaultWorkspaceSeoState(),
+        ];
+    }
+
+    /**
+     * @return array<string, array<string, mixed>>
+     */
+    public static function defaultWorkspaceSectionsState(): array
+    {
+        $state = [];
+
+        foreach (self::sectionDefinitions() as $sectionKey => $definition) {
+            $state[$sectionKey] = [
+                'title' => $definition['title'],
+                'render_variant' => $definition['render_variant'],
+                'body_md' => '',
+                'payload_json_text' => '',
+                'sort_order' => $definition['sort_order'],
+                'is_enabled' => $definition['enabled'],
+            ];
+        }
+
+        return $state;
+    }
+
+    /**
+     * @return array<string, list<array<string, mixed>>>
+     */
+    public static function defaultWorkspaceEntriesState(): array
+    {
+        $state = [];
+
+        foreach (self::entryGroupDefinitions() as $groupKey => $_definition) {
+            $state[$groupKey] = [];
+        }
+
+        return $state;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public static function defaultWorkspaceSeoState(): array
+    {
+        return [
+            'seo_title' => '',
+            'seo_description' => '',
+            'canonical_url' => '',
+            'og_title' => '',
+            'og_description' => '',
+            'og_image_url' => '',
+            'twitter_title' => '',
+            'twitter_description' => '',
+            'twitter_image_url' => '',
+            'robots' => '',
+            'jsonld_overrides_json_text' => '',
+        ];
+    }
+
+    /**
+     * @return array<string, array<string, mixed>>
+     */
+    public static function workspaceSectionsFromRecord(?TopicProfile $profile): array
+    {
+        $state = self::defaultWorkspaceSectionsState();
+
+        if (! $profile instanceof TopicProfile) {
+            return $state;
+        }
+
+        $profile->loadMissing('sections');
+
+        foreach ($profile->sections as $section) {
+            $sectionKey = (string) $section->section_key;
+
+            if (! array_key_exists($sectionKey, $state)) {
+                continue;
+            }
+
+            $state[$sectionKey] = [
+                'title' => filled($section->title) ? (string) $section->title : (string) $state[$sectionKey]['title'],
+                'render_variant' => filled($section->render_variant) ? (string) $section->render_variant : (string) $state[$sectionKey]['render_variant'],
+                'body_md' => (string) ($section->body_md ?? ''),
+                'payload_json_text' => self::encodeJson($section->payload_json),
+                'sort_order' => (int) ($section->sort_order ?? $state[$sectionKey]['sort_order']),
+                'is_enabled' => (bool) $section->is_enabled,
+            ];
+        }
+
+        return $state;
+    }
+
+    /**
+     * @return array<string, list<array<string, mixed>>>
+     */
+    public static function workspaceEntriesFromRecord(?TopicProfile $profile): array
+    {
+        $state = self::defaultWorkspaceEntriesState();
+
+        if (! $profile instanceof TopicProfile) {
+            return $state;
+        }
+
+        $profile->loadMissing('entries');
+
+        foreach ($profile->entries as $entry) {
+            $groupKey = (string) $entry->group_key;
+
+            if (! array_key_exists($groupKey, $state)) {
+                continue;
+            }
+
+            $state[$groupKey][] = [
+                'entry_type' => (string) $entry->entry_type,
+                'target_key' => (string) ($entry->target_key ?? ''),
+                'target_locale' => (string) ($entry->target_locale ?? ''),
+                'title_override' => (string) ($entry->title_override ?? ''),
+                'excerpt_override' => (string) ($entry->excerpt_override ?? ''),
+                'badge_label' => (string) ($entry->badge_label ?? ''),
+                'cta_label' => (string) ($entry->cta_label ?? ''),
+                'target_url_override' => (string) ($entry->target_url_override ?? ''),
+                'payload_json_text' => self::encodeJson($entry->payload_json),
+                'sort_order' => (int) ($entry->sort_order ?? 0),
+                'is_featured' => (bool) $entry->is_featured,
+                'is_enabled' => (bool) $entry->is_enabled,
+            ];
+        }
+
+        return $state;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public static function workspaceSeoFromRecord(?TopicProfile $profile): array
+    {
+        $state = self::defaultWorkspaceSeoState();
+
+        if (! $profile instanceof TopicProfile) {
+            return $state;
+        }
+
+        $profile->loadMissing('seoMeta');
+        $seoMeta = $profile->seoMeta;
+
+        if (! $seoMeta instanceof TopicProfileSeoMeta) {
+            return $state;
+        }
+
+        return [
+            'seo_title' => (string) ($seoMeta->seo_title ?? ''),
+            'seo_description' => (string) ($seoMeta->seo_description ?? ''),
+            'canonical_url' => (string) ($seoMeta->canonical_url ?? ''),
+            'og_title' => (string) ($seoMeta->og_title ?? ''),
+            'og_description' => (string) ($seoMeta->og_description ?? ''),
+            'og_image_url' => (string) ($seoMeta->og_image_url ?? ''),
+            'twitter_title' => (string) ($seoMeta->twitter_title ?? ''),
+            'twitter_description' => (string) ($seoMeta->twitter_description ?? ''),
+            'twitter_image_url' => (string) ($seoMeta->twitter_image_url ?? ''),
+            'robots' => (string) ($seoMeta->robots ?? ''),
+            'jsonld_overrides_json_text' => self::encodeJson($seoMeta->jsonld_overrides_json),
+        ];
+    }
+
+    /**
+     * @param  array<string, mixed>  $state
+     */
+    public static function syncWorkspaceSections(TopicProfile $profile, array $state): void
+    {
+        $defaults = self::defaultWorkspaceSectionsState();
+
+        foreach (self::sectionDefinitions() as $sectionKey => $definition) {
+            $sectionState = array_merge(
+                $defaults[$sectionKey],
+                is_array($state[$sectionKey] ?? null) ? $state[$sectionKey] : [],
+            );
+
+            TopicProfileSection::query()->updateOrCreate(
+                [
+                    'profile_id' => (int) $profile->id,
+                    'section_key' => $sectionKey,
+                ],
+                [
+                    'title' => self::normalizeNullableText((string) ($sectionState['title'] ?? '')) ?? $definition['title'],
+                    'render_variant' => self::normalizeRenderVariant((string) ($sectionState['render_variant'] ?? $definition['render_variant']), $definition['render_variant']),
+                    'body_md' => self::normalizeNullableText((string) ($sectionState['body_md'] ?? '')),
+                    'body_html' => null,
+                    'payload_json' => self::decodeJsonText(
+                        $sectionState['payload_json_text'] ?? null,
+                        "workspace_sections.{$sectionKey}.payload_json_text",
+                    ),
+                    'sort_order' => (int) ($sectionState['sort_order'] ?? $definition['sort_order']),
+                    'is_enabled' => StatusBadge::isTruthy($sectionState['is_enabled'] ?? $definition['enabled']),
+                ],
+            );
+        }
+
+        $profile->unsetRelation('sections');
+    }
+
+    /**
+     * @param  array<string, mixed>  $state
+     */
+    public static function syncWorkspaceEntries(TopicProfile $profile, array $state): void
+    {
+        foreach (self::entryGroupDefinitions() as $groupKey => $definition) {
+            TopicProfileEntry::query()
+                ->where('profile_id', (int) $profile->id)
+                ->where('group_key', $groupKey)
+                ->delete();
+
+            $groupItems = is_array($state[$groupKey] ?? null) ? $state[$groupKey] : [];
+
+            foreach (array_values($groupItems) as $index => $item) {
+                if (! is_array($item)) {
+                    continue;
+                }
+
+                $entryType = trim((string) ($item['entry_type'] ?? ''));
+                if (! in_array($entryType, $definition['allowed_entry_types'], true)) {
+                    continue;
+                }
+
+                $targetLocale = $entryType === 'custom_link'
+                    ? null
+                    : self::normalizeNullableLocale((string) ($item['target_locale'] ?? ''), (string) $profile->locale);
+                $targetKey = $entryType === 'custom_link'
+                    ? self::normalizeNullableText((string) ($item['target_key'] ?? ''))
+                    : self::normalizeTargetKey((string) ($item['target_key'] ?? ''), $entryType);
+                $targetUrlOverride = $entryType === 'custom_link'
+                    ? self::normalizeRelativePath((string) ($item['target_url_override'] ?? ''))
+                    : null;
+                $titleOverride = self::normalizeNullableText((string) ($item['title_override'] ?? ''));
+
+                if ($entryType === 'custom_link') {
+                    if ($targetUrlOverride === null || $titleOverride === null) {
+                        continue;
+                    }
+                } elseif ($targetKey === null) {
+                    continue;
+                }
+
+                TopicProfileEntry::query()->create([
+                    'profile_id' => (int) $profile->id,
+                    'entry_type' => $entryType,
+                    'group_key' => $groupKey,
+                    'target_key' => $targetKey ?? '',
+                    'target_locale' => $targetLocale,
+                    'title_override' => $titleOverride,
+                    'excerpt_override' => self::normalizeNullableText((string) ($item['excerpt_override'] ?? '')),
+                    'badge_label' => self::normalizeNullableText((string) ($item['badge_label'] ?? '')),
+                    'cta_label' => self::normalizeNullableText((string) ($item['cta_label'] ?? '')),
+                    'target_url_override' => $targetUrlOverride,
+                    'payload_json' => self::decodeJsonText(
+                        $item['payload_json_text'] ?? null,
+                        "workspace_entries.{$groupKey}.{$index}.payload_json_text",
+                    ),
+                    'sort_order' => self::normalizeSortOrder($item['sort_order'] ?? null, ($index + 1) * 10),
+                    'is_featured' => (bool) ($definition['force_featured'] || StatusBadge::isTruthy($item['is_featured'] ?? false)),
+                    'is_enabled' => StatusBadge::isTruthy($item['is_enabled'] ?? true),
+                ]);
+            }
+        }
+
+        $profile->unsetRelation('entries');
+    }
+
+    /**
+     * @param  array<string, mixed>  $state
+     */
+    public static function syncWorkspaceSeo(TopicProfile $profile, array $state): void
+    {
+        TopicProfileSeoMeta::query()->updateOrCreate(
+            [
+                'profile_id' => (int) $profile->id,
+            ],
+            [
+                'seo_title' => self::normalizeNullableText((string) ($state['seo_title'] ?? '')),
+                'seo_description' => self::normalizeNullableText((string) ($state['seo_description'] ?? '')),
+                'canonical_url' => self::normalizeNullableText((string) ($state['canonical_url'] ?? '')),
+                'og_title' => self::normalizeNullableText((string) ($state['og_title'] ?? '')),
+                'og_description' => self::normalizeNullableText((string) ($state['og_description'] ?? '')),
+                'og_image_url' => self::normalizeNullableText((string) ($state['og_image_url'] ?? '')),
+                'twitter_title' => self::normalizeNullableText((string) ($state['twitter_title'] ?? '')),
+                'twitter_description' => self::normalizeNullableText((string) ($state['twitter_description'] ?? '')),
+                'twitter_image_url' => self::normalizeNullableText((string) ($state['twitter_image_url'] ?? '')),
+                'robots' => self::normalizeNullableText((string) ($state['robots'] ?? '')),
+                'jsonld_overrides_json' => self::decodeJsonText(
+                    $state['jsonld_overrides_json_text'] ?? null,
+                    'workspace_seo.jsonld_overrides_json_text',
+                ),
+            ],
+        );
+
+        $profile->unsetRelation('seoMeta');
+    }
+
+    public static function nextRevisionNo(TopicProfile $profile): int
+    {
+        return (int) TopicProfileRevision::query()
+            ->where('profile_id', (int) $profile->id)
+            ->max('revision_no') + 1;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public static function snapshotPayload(TopicProfile $profile): array
+    {
+        $profile->loadMissing('sections', 'entries', 'seoMeta');
+
+        return [
+            'profile' => [
+                'id' => (int) $profile->id,
+                'org_id' => (int) $profile->org_id,
+                'topic_code' => (string) $profile->topic_code,
+                'slug' => (string) $profile->slug,
+                'locale' => (string) $profile->locale,
+                'title' => (string) $profile->title,
+                'subtitle' => $profile->subtitle,
+                'excerpt' => $profile->excerpt,
+                'hero_kicker' => $profile->hero_kicker,
+                'hero_quote' => $profile->hero_quote,
+                'cover_image_url' => $profile->cover_image_url,
+                'status' => (string) $profile->status,
+                'is_public' => (bool) $profile->is_public,
+                'is_indexable' => (bool) $profile->is_indexable,
+                'published_at' => $profile->published_at?->toIso8601String(),
+                'scheduled_at' => $profile->scheduled_at?->toIso8601String(),
+                'schema_version' => (string) $profile->schema_version,
+                'sort_order' => (int) $profile->sort_order,
+            ],
+            'sections' => $profile->sections
+                ->map(static fn (TopicProfileSection $section): array => [
+                    'section_key' => (string) $section->section_key,
+                    'title' => $section->title,
+                    'render_variant' => (string) $section->render_variant,
+                    'body_md' => $section->body_md,
+                    'body_html' => $section->body_html,
+                    'payload_json' => $section->payload_json,
+                    'sort_order' => (int) $section->sort_order,
+                    'is_enabled' => (bool) $section->is_enabled,
+                ])
+                ->values()
+                ->all(),
+            'entries' => $profile->entries
+                ->map(static fn (TopicProfileEntry $entry): array => [
+                    'entry_type' => (string) $entry->entry_type,
+                    'group_key' => (string) $entry->group_key,
+                    'target_key' => (string) $entry->target_key,
+                    'target_locale' => $entry->target_locale,
+                    'title_override' => $entry->title_override,
+                    'excerpt_override' => $entry->excerpt_override,
+                    'badge_label' => $entry->badge_label,
+                    'cta_label' => $entry->cta_label,
+                    'target_url_override' => $entry->target_url_override,
+                    'payload_json' => $entry->payload_json,
+                    'sort_order' => (int) $entry->sort_order,
+                    'is_featured' => (bool) $entry->is_featured,
+                    'is_enabled' => (bool) $entry->is_enabled,
+                ])
+                ->values()
+                ->all(),
+            'seo_meta' => $profile->seoMeta instanceof TopicProfileSeoMeta
+                ? [
+                    'seo_title' => $profile->seoMeta->seo_title,
+                    'seo_description' => $profile->seoMeta->seo_description,
+                    'canonical_url' => $profile->seoMeta->canonical_url,
+                    'og_title' => $profile->seoMeta->og_title,
+                    'og_description' => $profile->seoMeta->og_description,
+                    'og_image_url' => $profile->seoMeta->og_image_url,
+                    'twitter_title' => $profile->seoMeta->twitter_title,
+                    'twitter_description' => $profile->seoMeta->twitter_description,
+                    'twitter_image_url' => $profile->seoMeta->twitter_image_url,
+                    'robots' => $profile->seoMeta->robots,
+                    'jsonld_overrides_json' => $profile->seoMeta->jsonld_overrides_json,
+                ]
+                : null,
+        ];
+    }
+
+    public static function createRevision(TopicProfile $profile, string $note): void
+    {
+        TopicProfileRevision::query()->create([
+            'profile_id' => (int) $profile->id,
+            'revision_no' => self::nextRevisionNo($profile),
+            'snapshot_json' => self::snapshotPayload($profile),
+            'note' => $note,
+            'created_by_admin_user_id' => self::currentAdminUserId(),
+            'created_at' => now(),
+        ]);
+    }
+
+    public static function plannedPublicUrl(?string $slug, string $locale): ?string
+    {
+        $resolvedSlug = trim((string) $slug);
+        $baseUrl = rtrim((string) config('app.frontend_url', config('app.url', '')), '/');
+
+        if ($resolvedSlug === '' || $baseUrl === '') {
+            return null;
+        }
+
+        $segment = app(TopicProfileSeoService::class)->mapBackendLocaleToFrontendSegment($locale);
+
+        return $baseUrl.'/'.trim($segment, '/').'/topics/'.rawurlencode(Str::lower($resolvedSlug));
+    }
+
+    public static function renderEditorialCues(Get $get, ?TopicProfile $record = null): Htmlable
+    {
+        $status = trim((string) ($get('status') ?? $record?->status ?? TopicProfile::STATUS_DRAFT));
+        $isPublic = StatusBadge::isTruthy($get('is_public') ?? $record?->is_public ?? false);
+        $isIndexable = StatusBadge::isTruthy($get('is_indexable') ?? $record?->is_indexable ?? true);
+        $plannedUrl = self::plannedPublicUrl(
+            (string) ($get('slug') ?? $record?->slug ?? ''),
+            (string) ($get('locale') ?? $record?->locale ?? 'en'),
+        );
+
+        return new HtmlString((string) view('filament.ops.topics.partials.editorial-cues', [
+            'facts' => array_values(array_filter([
+                [
+                    'label' => 'Published',
+                    'value' => self::formatTimestamp($get('published_at') ?? $record?->published_at),
+                ],
+                [
+                    'label' => 'Scheduled',
+                    'value' => self::formatTimestamp($get('scheduled_at') ?? $record?->scheduled_at),
+                ],
+                [
+                    'label' => 'Planned public URL',
+                    'value' => $plannedUrl,
+                ],
+                [
+                    'label' => 'Entry groups',
+                    'value' => self::entrySummary(is_array($get('workspace_entries') ?? null) ? $get('workspace_entries') : [], $record),
+                ],
+                [
+                    'label' => 'Revisions',
+                    'value' => $record instanceof TopicProfile ? (string) self::revisionCount($record) : null,
+                ],
+            ], static fn (array $fact): bool => filled($fact['value'] ?? null))),
+            'pills' => [
+                [
+                    'label' => self::statusLabel($status),
+                    'state' => $status,
+                ],
+                [
+                    'label' => $isPublic ? 'Public' : 'Private',
+                    'state' => $isPublic ? 'public' : 'inactive',
+                ],
+                [
+                    'label' => $isIndexable ? 'Indexable' : 'Noindex',
+                    'state' => $isIndexable ? 'indexable' : 'noindex',
+                ],
+            ],
+        ])->render());
+    }
+
+    public static function renderSeoSnapshot(Get $get, ?TopicProfile $record = null): Htmlable
+    {
+        $plannedCanonical = self::plannedPublicUrl(
+            (string) ($get('slug') ?? $record?->slug ?? ''),
+            (string) ($get('locale') ?? $record?->locale ?? 'en'),
+        );
+
+        return new HtmlString((string) view('filament.ops.topics.partials.seo-snapshot', [
+            'checks' => self::seoCompleteness([
+                'seo_title' => $get('workspace_seo.seo_title') ?? $record?->seoMeta?->seo_title,
+                'seo_description' => $get('workspace_seo.seo_description') ?? $record?->seoMeta?->seo_description,
+                'og_title' => $get('workspace_seo.og_title') ?? $record?->seoMeta?->og_title,
+                'og_description' => $get('workspace_seo.og_description') ?? $record?->seoMeta?->og_description,
+                'og_image_url' => $get('workspace_seo.og_image_url') ?? $record?->seoMeta?->og_image_url,
+                'twitter_title' => $get('workspace_seo.twitter_title') ?? $record?->seoMeta?->twitter_title,
+                'twitter_description' => $get('workspace_seo.twitter_description') ?? $record?->seoMeta?->twitter_description,
+                'twitter_image_url' => $get('workspace_seo.twitter_image_url') ?? $record?->seoMeta?->twitter_image_url,
+                'robots' => $get('workspace_seo.robots') ?? $record?->seoMeta?->robots,
+            ], $plannedCanonical, StatusBadge::isTruthy($get('is_indexable') ?? $record?->is_indexable ?? true)),
+            'plannedCanonical' => $plannedCanonical,
+        ])->render());
+    }
+
+    public static function formatTimestamp(mixed $value, string $fallback = 'Not set yet'): string
+    {
+        $formatted = self::normalizeTimestamp($value);
+
+        return $formatted ?? $fallback;
+    }
+
+    public static function titleMeta(TopicProfile $record): string
+    {
+        return collect([
+            filled($record->topic_code) ? Str::lower((string) $record->topic_code) : null,
+            filled($record->slug) ? '/'.trim((string) $record->slug, '/') : null,
+            filled($record->locale) ? Str::upper((string) $record->locale) : null,
+            isset($record->entries_count) ? ((int) $record->entries_count).' entries' : null,
+        ])->filter(static fn (?string $value): bool => filled($value))->implode(' · ');
+    }
+
+    public static function visibilityMeta(TopicProfile $record): string
+    {
+        return implode(' · ', [
+            StatusBadge::booleanLabel($record->is_public, 'Public', 'Private'),
+            StatusBadge::booleanLabel($record->is_indexable, 'Indexable', 'Noindex'),
+        ]);
+    }
+
+    public static function normalizeTopicCode(?string $topicCode): string
+    {
+        return Str::of((string) $topicCode)
+            ->lower()
+            ->replace('_', '-')
+            ->slug('-')
+            ->value();
+    }
+
+    public static function normalizeSlug(?string $slug, ?string $topicCode = null): string
+    {
+        $candidate = trim((string) $slug);
+
+        if ($candidate === '' && filled($topicCode)) {
+            $candidate = (string) $topicCode;
+        }
+
+        return Str::of($candidate)
+            ->lower()
+            ->replace('_', '-')
+            ->slug('-')
+            ->value();
+    }
+
+    public static function normalizeLocale(?string $locale): string
+    {
+        $normalized = trim((string) $locale);
+
+        return in_array($normalized, TopicProfile::SUPPORTED_LOCALES, true) ? $normalized : 'en';
+    }
+
+    /**
+     * @return array<int, array{label: string, description: string, ready: bool}>
+     */
+    public static function seoCompleteness(array $state, ?string $plannedCanonical, bool $isIndexable): array
+    {
+        return [
+            [
+                'label' => 'SEO title',
+                'description' => 'Search headline for the topic hub.',
+                'ready' => filled(trim((string) ($state['seo_title'] ?? ''))),
+            ],
+            [
+                'label' => 'SEO description',
+                'description' => 'Search summary for the topic hub, with excerpt fallback if left blank.',
+                'ready' => filled(trim((string) ($state['seo_description'] ?? ''))),
+            ],
+            [
+                'label' => 'Canonical route',
+                'description' => 'Final frontend topic URL stays locale-aware even before frontend cutover.',
+                'ready' => filled($plannedCanonical),
+            ],
+            [
+                'label' => 'Social coverage',
+                'description' => 'Open Graph and Twitter overrides for richer sharing cards.',
+                'ready' => filled(trim((string) ($state['og_title'] ?? '')))
+                    && filled(trim((string) ($state['og_description'] ?? '')))
+                    && filled(trim((string) ($state['twitter_title'] ?? '')))
+                    && filled(trim((string) ($state['twitter_description'] ?? ''))),
+            ],
+            [
+                'label' => 'Robots',
+                'description' => $isIndexable ? 'Defaults to index,follow when left blank.' : 'Defaults to noindex,follow when left blank.',
+                'ready' => true,
+            ],
+        ];
+    }
+
+    /**
+     * @param  array<string, mixed>  $state
+     */
+    public static function entrySummary(array $state, ?TopicProfile $record = null): string
+    {
+        $groups = self::defaultWorkspaceEntriesState();
+
+        foreach ($groups as $groupKey => $_items) {
+            $groups[$groupKey] = is_array($state[$groupKey] ?? null)
+                ? $state[$groupKey]
+                : ($record instanceof TopicProfile
+                    ? self::workspaceEntriesFromRecord($record)[$groupKey]
+                    : []);
+        }
+
+        return collect($groups)
+            ->map(function (array $items, string $groupKey): ?string {
+                $count = collect($items)
+                    ->filter(static fn ($item): bool => is_array($item) && StatusBadge::isTruthy($item['is_enabled'] ?? true))
+                    ->count();
+
+                if ($count === 0) {
+                    return null;
+                }
+
+                $label = self::entryGroupDefinitions()[$groupKey]['label'] ?? $groupKey;
+
+                return $label.': '.$count;
+            })
+            ->filter()
+            ->implode(' · ');
+    }
+
+    public static function entryItemLabel(array $state): ?string
+    {
+        $entryType = trim((string) ($state['entry_type'] ?? ''));
+        $target = trim((string) ($state['title_override'] ?? $state['target_key'] ?? $state['target_url_override'] ?? ''));
+
+        if ($target === '') {
+            return Str::of($entryType !== '' ? $entryType : 'Entry')
+                ->replace('_', ' ')
+                ->headline()
+                ->value();
+        }
+
+        if ($entryType === '') {
+            return $target;
+        }
+
+        return Str::of($entryType)->replace('_', ' ')->headline()->value().': '.$target;
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    public static function entryTypeOptionsForGroup(string $groupKey): array
+    {
+        $allowed = self::entryGroupDefinitions()[$groupKey]['allowed_entry_types'] ?? TopicProfileEntry::ENTRY_TYPES;
+
+        return collect($allowed)
+            ->mapWithKeys(static fn (string $entryType): array => [
+                $entryType => Str::of($entryType)->replace('_', ' ')->headline()->value(),
+            ])
+            ->all();
+    }
+
+    private static function revisionCount(TopicProfile $profile): int
+    {
+        if ($profile->relationLoaded('revisions')) {
+            return $profile->revisions->count();
+        }
+
+        return (int) $profile->revisions()->count();
+    }
+
+    private static function currentAdminUserId(): ?int
+    {
+        $guard = (string) config('admin.guard', 'admin');
+        $user = auth($guard)->user();
+
+        if (! is_object($user) || ! method_exists($user, 'getAuthIdentifier')) {
+            return null;
+        }
+
+        return (int) $user->getAuthIdentifier();
+    }
+
+    private static function normalizeRenderVariant(string $variant, string $fallback): string
+    {
+        $normalized = trim($variant);
+
+        return in_array($normalized, TopicProfileSection::RENDER_VARIANTS, true) ? $normalized : $fallback;
+    }
+
+    private static function normalizeNullableText(?string $value): ?string
+    {
+        $normalized = trim((string) $value);
+
+        return $normalized !== '' ? $normalized : null;
+    }
+
+    private static function normalizeNullableLocale(?string $locale, string $fallback): string
+    {
+        $normalized = self::normalizeNullableText($locale);
+
+        return self::normalizeLocale($normalized ?? $fallback);
+    }
+
+    private static function normalizeTargetKey(string $value, string $entryType): ?string
+    {
+        $normalized = trim($value);
+
+        if ($normalized === '') {
+            return null;
+        }
+
+        return match ($entryType) {
+            'article', 'custom_link' => Str::of($normalized)->lower()->replace('_', '-')->slug('-')->value(),
+            'personality_profile' => filled($normalized) && str_contains($normalized, '-') ? Str::of($normalized)->lower()->replace('_', '-')->slug('-')->value() : Str::upper($normalized),
+            'scale' => Str::upper($normalized),
+            default => $normalized,
+        };
+    }
+
+    private static function normalizeRelativePath(?string $value): ?string
+    {
+        $normalized = trim((string) $value);
+
+        if ($normalized === '' || ! str_starts_with($normalized, '/') || str_starts_with($normalized, '//') || preg_match('/^[a-z][a-z0-9+.-]*:/i', $normalized)) {
+            return null;
+        }
+
+        return $normalized;
+    }
+
+    private static function normalizeSortOrder(mixed $value, int $fallback): int
+    {
+        if ($value === null || $value === '') {
+            return $fallback;
+        }
+
+        return max(0, (int) $value);
+    }
+
+    private static function encodeJson(mixed $value): string
+    {
+        if ($value === null || $value === []) {
+            return '';
+        }
+
+        $encoded = json_encode($value, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE);
+
+        return is_string($encoded) ? $encoded : '';
+    }
+
+    private static function decodeJsonText(mixed $value, string $field): ?array
+    {
+        if (! is_string($value) || trim($value) === '') {
+            return null;
+        }
+
+        try {
+            $decoded = json_decode($value, true, 512, JSON_THROW_ON_ERROR);
+        } catch (\JsonException) {
+            throw ValidationException::withMessages([
+                $field => 'This field must contain valid JSON.',
+            ]);
+        }
+
+        return is_array($decoded) ? $decoded : null;
+    }
+
+    private static function normalizeTimestamp(mixed $value): ?string
+    {
+        if ($value instanceof \DateTimeInterface) {
+            return Carbon::instance($value)->timezone(config('app.timezone'))->format('M j, Y H:i');
+        }
+
+        if (! is_string($value) || trim($value) === '') {
+            return null;
+        }
+
+        try {
+            return Carbon::parse($value)->timezone(config('app.timezone'))->format('M j, Y H:i');
+        } catch (\Throwable) {
+            return null;
+        }
+    }
+
+    private static function statusLabel(string $status): string
+    {
+        $normalized = trim($status);
+
+        if ($normalized === '') {
+            return 'Draft';
+        }
+
+        return Str::of($normalized)
+            ->replace(['_', '-'], ' ')
+            ->headline()
+            ->value();
+    }
+}

--- a/backend/resources/css/filament/ops/theme.css
+++ b/backend/resources/css/filament/ops/theme.css
@@ -1549,6 +1549,220 @@
         font-size: 0.75rem;
         line-height: 1.55;
     }
+
+    .ops-topic-workspace-layout {
+        align-items: start;
+    }
+
+    .ops-topic-workspace-main-column,
+    .ops-topic-workspace-rail-column {
+        display: grid;
+        gap: 1.25rem;
+        align-self: start;
+    }
+
+    .ops-topic-workspace-section .fi-section-header {
+        gap: 0.45rem;
+    }
+
+    .ops-topic-workspace-section--main .fi-section-header-heading {
+        font-size: 1.2rem;
+    }
+
+    .ops-topic-workspace-section--rail .fi-section-header-heading {
+        font-size: 1rem;
+    }
+
+    .ops-topic-workspace-field--title .fi-input-wrp {
+        min-height: 3.35rem;
+    }
+
+    .ops-topic-workspace-input--title {
+        font-size: 1.05rem;
+        font-weight: 700;
+        letter-spacing: -0.025em;
+    }
+
+    .ops-topic-workspace-field--summary textarea {
+        min-height: 8rem;
+    }
+
+    .ops-topic-workspace-field--body textarea {
+        min-height: 12rem;
+    }
+
+    .ops-topic-workspace-field--payload textarea {
+        min-height: 9rem;
+        font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
+        font-size: 0.82rem;
+        line-height: 1.55;
+    }
+
+    .ops-topic-workspace-section .fi-fo-placeholder {
+        display: grid;
+        gap: 0.75rem;
+        border-radius: 14px;
+        background: var(--ops-bg-surface-subtle);
+        padding: 0.95rem 1rem;
+        box-shadow: inset 0 0 0 1px rgba(229, 231, 235, 0.92);
+    }
+
+    .ops-topic-workspace-tabs {
+        display: grid;
+        gap: 1rem;
+    }
+
+    .ops-topic-workspace-tabs .fi-tabs {
+        gap: 0.45rem;
+        border-radius: 16px;
+        background: rgba(251, 252, 253, 0.94);
+        padding: 0.35rem;
+        box-shadow: inset 0 0 0 1px rgba(229, 231, 235, 0.92);
+    }
+
+    .ops-topic-workspace-tabs .fi-tabs-item {
+        border-radius: 12px;
+    }
+
+    .ops-topic-workspace-tabs .fi-fo-tabs-tab {
+        border-radius: 18px;
+        background: linear-gradient(180deg, rgba(255, 255, 255, 0.99), rgba(251, 252, 253, 0.96));
+        box-shadow: var(--ops-shadow-surface);
+    }
+
+    .ops-topic-workspace-tabs .fi-fo-repeater {
+        gap: 1rem;
+    }
+
+    .ops-topic-workspace-tabs .fi-fo-repeater-item {
+        border-radius: 18px;
+        background: rgba(255, 255, 255, 0.98);
+        box-shadow: inset 0 0 0 1px rgba(229, 231, 235, 0.92), var(--ops-shadow-surface);
+    }
+
+    .ops-topic-workspace-tabs .fi-fo-repeater-item-header {
+        border-bottom: 1px solid rgba(229, 231, 235, 0.8);
+        padding-inline: 1rem;
+        padding-block: 0.85rem;
+    }
+
+    .ops-topic-workspace-tabs .fi-fo-repeater-item-content {
+        padding: 1rem;
+    }
+
+    .ops-topic-workspace-cues,
+    .ops-topic-workspace-seo {
+        display: grid;
+        gap: 0.85rem;
+    }
+
+    .ops-topic-workspace-cues__pills {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 0.5rem;
+    }
+
+    .ops-topic-workspace-cues__facts {
+        display: grid;
+        gap: 0.65rem;
+    }
+
+    .ops-topic-workspace-cues__fact {
+        display: grid;
+        gap: 0.15rem;
+    }
+
+    .ops-topic-workspace-cues__fact dt {
+        color: var(--ops-text-tertiary);
+        font-size: 0.6875rem;
+        font-weight: 700;
+        letter-spacing: 0.12em;
+        text-transform: uppercase;
+    }
+
+    .ops-topic-workspace-cues__fact dd {
+        color: var(--ops-text-primary);
+        font-size: 0.875rem;
+        font-weight: 600;
+        line-height: 1.55;
+    }
+
+    .ops-topic-workspace-seo__grid {
+        display: grid;
+        gap: 0.75rem;
+    }
+
+    .ops-topic-workspace-seo__item {
+        display: flex;
+        align-items: flex-start;
+        justify-content: space-between;
+        gap: 1rem;
+        border-radius: 14px;
+        background: rgba(255, 255, 255, 0.94);
+        padding: 0.85rem 0.95rem;
+        box-shadow: inset 0 0 0 1px rgba(229, 231, 235, 0.92);
+    }
+
+    .ops-topic-workspace-seo__copy {
+        display: grid;
+        gap: 0.15rem;
+    }
+
+    .ops-topic-workspace-seo__label {
+        color: var(--ops-text-primary);
+        font-size: 0.8125rem;
+        font-weight: 700;
+        letter-spacing: -0.01em;
+    }
+
+    .ops-topic-workspace-seo__description {
+        color: var(--ops-text-secondary);
+        font-size: 0.75rem;
+        line-height: 1.55;
+    }
+
+    .ops-topic-workspace-seo__planned {
+        display: grid;
+        gap: 0.2rem;
+        border-radius: 14px;
+        background: rgba(255, 255, 255, 0.94);
+        padding: 0.85rem 0.95rem;
+        box-shadow: inset 0 0 0 1px rgba(229, 231, 235, 0.92);
+    }
+
+    .ops-topic-workspace-seo__planned-label {
+        color: var(--ops-text-tertiary);
+        font-size: 0.6875rem;
+        font-weight: 700;
+        letter-spacing: 0.12em;
+        text-transform: uppercase;
+    }
+
+    .ops-topic-workspace-seo__planned-value {
+        color: var(--ops-text-primary);
+        font-size: 0.8125rem;
+        font-weight: 600;
+        line-height: 1.55;
+        word-break: break-word;
+    }
+
+    .ops-topic-workspace-table-title {
+        display: grid;
+        gap: 0.2rem;
+    }
+
+    .ops-topic-workspace-table-title__text {
+        color: var(--ops-text-primary);
+        font-size: 0.95rem;
+        font-weight: 700;
+        letter-spacing: -0.02em;
+    }
+
+    .ops-topic-workspace-table-title__meta {
+        color: var(--ops-text-secondary);
+        font-size: 0.75rem;
+        line-height: 1.55;
+    }
 }
 
 @media (max-width: 1023px) {

--- a/backend/resources/views/filament/ops/topics/partials/editorial-cues.blade.php
+++ b/backend/resources/views/filament/ops/topics/partials/editorial-cues.blade.php
@@ -1,0 +1,18 @@
+<div class="ops-topic-workspace-cues">
+    <div class="ops-topic-workspace-cues__pills">
+        @foreach ($pills as $pill)
+            <x-filament.ops.shared.status-pill :label="$pill['label']" :state="$pill['state']" />
+        @endforeach
+    </div>
+
+    @if ($facts !== [])
+        <dl class="ops-topic-workspace-cues__facts">
+            @foreach ($facts as $fact)
+                <div class="ops-topic-workspace-cues__fact">
+                    <dt>{{ $fact['label'] }}</dt>
+                    <dd>{{ $fact['value'] }}</dd>
+                </div>
+            @endforeach
+        </dl>
+    @endif
+</div>

--- a/backend/resources/views/filament/ops/topics/partials/seo-snapshot.blade.php
+++ b/backend/resources/views/filament/ops/topics/partials/seo-snapshot.blade.php
@@ -1,0 +1,24 @@
+<div class="ops-topic-workspace-seo">
+    <div class="ops-topic-workspace-seo__grid">
+        @foreach ($checks as $check)
+            <div class="ops-topic-workspace-seo__item">
+                <div class="ops-topic-workspace-seo__copy">
+                    <span class="ops-topic-workspace-seo__label">{{ $check['label'] }}</span>
+                    <span class="ops-topic-workspace-seo__description">{{ $check['description'] }}</span>
+                </div>
+
+                <x-filament.ops.shared.status-pill
+                    :label="$check['ready'] ? 'Ready' : 'Missing'"
+                    :state="$check['ready'] ? 'ready' : 'draft'"
+                />
+            </div>
+        @endforeach
+    </div>
+
+    @if (filled($plannedCanonical))
+        <div class="ops-topic-workspace-seo__planned">
+            <span class="ops-topic-workspace-seo__planned-label">Planned canonical</span>
+            <span class="ops-topic-workspace-seo__planned-value">{{ $plannedCanonical }}</span>
+        </div>
+    @endif
+</div>

--- a/backend/resources/views/filament/ops/topics/partials/table-title.blade.php
+++ b/backend/resources/views/filament/ops/topics/partials/table-title.blade.php
@@ -1,0 +1,7 @@
+<div class="ops-topic-workspace-table-title">
+    <span class="ops-topic-workspace-table-title__text">{{ $title }}</span>
+
+    @if (filled($meta))
+        <span class="ops-topic-workspace-table-title__meta">{{ $meta }}</span>
+    @endif
+</div>

--- a/backend/tests/Feature/Ops/TopicWorkspaceTest.php
+++ b/backend/tests/Feature/Ops/TopicWorkspaceTest.php
@@ -1,0 +1,439 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Ops;
+
+use App\Filament\Ops\Resources\TopicProfileResource;
+use App\Filament\Ops\Resources\TopicProfileResource\Support\TopicWorkspace;
+use App\Models\AdminUser;
+use App\Models\Organization;
+use App\Models\Permission;
+use App\Models\Role;
+use App\Models\TopicProfile;
+use App\Models\TopicProfileEntry;
+use App\Models\TopicProfileRevision;
+use App\Support\OrgContext;
+use App\Support\Rbac\PermissionNames;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Http\Request;
+use Illuminate\Support\Str;
+use Tests\TestCase;
+
+final class TopicWorkspaceTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_topic_workspace_pages_render_for_authorized_admin(): void
+    {
+        $admin = $this->createAdminWithPermissions([
+            PermissionNames::ADMIN_CONTENT_READ,
+            PermissionNames::ADMIN_CONTENT_PUBLISH,
+        ]);
+        $selectedOrg = $this->createSelectedOrg();
+        $profile = $this->seedProfile([
+            'title' => 'MBTI Topic Hub',
+        ]);
+
+        TopicWorkspace::syncWorkspaceSections($profile, $this->workspaceSectionsState());
+        TopicWorkspace::syncWorkspaceEntries($profile, $this->workspaceEntriesState());
+        TopicWorkspace::syncWorkspaceSeo($profile, $this->workspaceSeoState());
+        TopicWorkspace::createRevision($profile, 'Seed revision');
+
+        $this->withSession([
+            'ops_org_id' => $selectedOrg->id,
+            'ops_admin_totp_verified_user_id' => (int) $admin->id,
+        ])->actingAs($admin, (string) config('admin.guard', 'admin'))
+            ->get('/ops/topics')
+            ->assertOk()
+            ->assertSee('Global topic content workspace', false)
+            ->assertSee('Create Topic');
+
+        $this->withSession([
+            'ops_org_id' => $selectedOrg->id,
+            'ops_admin_totp_verified_user_id' => (int) $admin->id,
+        ])->actingAs($admin, (string) config('admin.guard', 'admin'))
+            ->get('/ops/topics/create')
+            ->assertOk()
+            ->assertSee('ops-topic-workspace-layout', false)
+            ->assertSee('Create Topic');
+
+        $this->withSession([
+            'ops_org_id' => $selectedOrg->id,
+            'ops_admin_totp_verified_user_id' => (int) $admin->id,
+        ])->actingAs($admin, (string) config('admin.guard', 'admin'))
+            ->get('/ops/topics/'.$profile->id.'/edit')
+            ->assertOk()
+            ->assertSee('ops-topic-workspace-layout', false)
+            ->assertSee('Planned public URL');
+    }
+
+    public function test_workspace_sync_persists_sections_entries_seo_and_initial_revision(): void
+    {
+        $profile = $this->seedProfile();
+
+        TopicWorkspace::syncWorkspaceSections($profile, $this->workspaceSectionsState());
+        TopicWorkspace::syncWorkspaceEntries($profile, $this->workspaceEntriesState());
+        TopicWorkspace::syncWorkspaceSeo($profile, $this->workspaceSeoState());
+        TopicWorkspace::createRevision($profile, 'Initial workspace snapshot');
+
+        $this->assertDatabaseHas('topic_profile_sections', [
+            'profile_id' => $profile->id,
+            'section_key' => 'overview',
+            'title' => 'Overview',
+            'render_variant' => 'rich_text',
+            'is_enabled' => 1,
+        ]);
+
+        $this->assertDatabaseHas('topic_profile_entries', [
+            'profile_id' => $profile->id,
+            'group_key' => 'featured',
+            'entry_type' => 'personality_profile',
+            'target_key' => 'INTJ',
+            'is_featured' => 1,
+            'is_enabled' => 1,
+        ]);
+
+        $this->assertDatabaseHas('topic_profile_seo_meta', [
+            'profile_id' => $profile->id,
+            'seo_title' => 'MBTI Guide and Type Hub | FermatMind',
+            'robots' => 'index,follow',
+        ]);
+
+        $this->assertDatabaseHas('topic_profile_revisions', [
+            'profile_id' => $profile->id,
+            'revision_no' => 1,
+            'note' => 'Initial workspace snapshot',
+        ]);
+    }
+
+    public function test_workspace_sync_updates_topic_sections_entries_seo_and_revision_counter(): void
+    {
+        $profile = $this->seedProfile();
+
+        TopicWorkspace::syncWorkspaceSections($profile, $this->workspaceSectionsState());
+        TopicWorkspace::syncWorkspaceEntries($profile, $this->workspaceEntriesState());
+        TopicWorkspace::syncWorkspaceSeo($profile, $this->workspaceSeoState());
+        TopicWorkspace::createRevision($profile, 'Initial workspace snapshot');
+
+        $profile->update([
+            'title' => 'MBTI Topic Hub (Updated)',
+            'subtitle' => 'Sharper, clearer, and more actionable.',
+        ]);
+
+        $updatedSections = $this->workspaceSectionsState();
+        $updatedSections['overview']['body_md'] = 'Updated overview for the MBTI topic hub.';
+        $updatedSections['faq']['is_enabled'] = true;
+        $updatedSections['faq']['payload_json_text'] = json_encode([
+            'items' => [
+                [
+                    'question' => 'Is MBTI a personality trait model?',
+                    'answer' => 'It is a typology framework rather than a trait scale.',
+                ],
+            ],
+        ], JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE);
+
+        $updatedEntries = $this->workspaceEntriesState();
+        $updatedEntries['articles'][] = [
+            'entry_type' => 'article',
+            'target_key' => 'how-to-read-mbti-results',
+            'target_locale' => 'en',
+            'title_override' => 'Read the MBTI guide',
+            'excerpt_override' => 'Updated supporting article guidance.',
+            'badge_label' => 'Guide',
+            'cta_label' => 'Read',
+            'target_url_override' => '',
+            'payload_json_text' => '',
+            'sort_order' => 40,
+            'is_featured' => false,
+            'is_enabled' => true,
+        ];
+
+        $updatedSeo = $this->workspaceSeoState();
+        $updatedSeo['seo_description'] = 'Updated SEO summary for the MBTI topic hub.';
+
+        TopicWorkspace::syncWorkspaceSections($profile, $updatedSections);
+        TopicWorkspace::syncWorkspaceEntries($profile, $updatedEntries);
+        TopicWorkspace::syncWorkspaceSeo($profile, $updatedSeo);
+        TopicWorkspace::createRevision($profile, 'Workspace update');
+
+        $this->assertDatabaseHas('topic_profile_sections', [
+            'profile_id' => $profile->id,
+            'section_key' => 'faq',
+            'is_enabled' => 1,
+            'render_variant' => 'faq',
+        ]);
+
+        $this->assertDatabaseHas('topic_profile_entries', [
+            'profile_id' => $profile->id,
+            'group_key' => 'articles',
+            'entry_type' => 'article',
+            'target_key' => 'how-to-read-mbti-results',
+        ]);
+
+        $this->assertDatabaseHas('topic_profile_seo_meta', [
+            'profile_id' => $profile->id,
+            'seo_description' => 'Updated SEO summary for the MBTI topic hub.',
+        ]);
+
+        $this->assertDatabaseHas('topic_profile_revisions', [
+            'profile_id' => $profile->id,
+            'revision_no' => 2,
+            'note' => 'Workspace update',
+        ]);
+
+        $latestRevision = TopicProfileRevision::query()
+            ->where('profile_id', $profile->id)
+            ->where('revision_no', 2)
+            ->firstOrFail();
+
+        $this->assertSame('MBTI Topic Hub (Updated)', $latestRevision->snapshot_json['profile']['title']);
+        $this->assertSame('Updated overview for the MBTI topic hub.', $latestRevision->snapshot_json['sections'][0]['body_md']);
+    }
+
+    public function test_resource_query_is_locked_to_global_topic_profiles(): void
+    {
+        $globalProfile = $this->seedProfile([
+            'org_id' => 0,
+            'slug' => 'mbti-global',
+        ]);
+
+        $tenantProfile = $this->seedProfile([
+            'org_id' => 77,
+            'slug' => 'mbti-tenant',
+        ]);
+
+        $request = Request::create('/ops/topics', 'GET');
+        app()->instance('request', $request);
+
+        $context = app(OrgContext::class);
+        $context->set(77, 9001, 'admin');
+        app()->instance(OrgContext::class, $context);
+
+        $ids = TopicProfileResource::getEloquentQuery()
+            ->orderBy('id')
+            ->pluck('id')
+            ->all();
+
+        $this->assertContains($globalProfile->id, $ids);
+        $this->assertNotContains($tenantProfile->id, $ids);
+    }
+
+    public function test_workspace_ignores_unknown_section_group_and_entry_type(): void
+    {
+        $profile = $this->seedProfile();
+
+        $sections = $this->workspaceSectionsState();
+        $sections['rogue_section'] = [
+            'title' => 'Rogue',
+            'render_variant' => 'rich_text',
+            'body_md' => 'Should never persist.',
+            'payload_json_text' => '',
+            'sort_order' => 999,
+            'is_enabled' => true,
+        ];
+
+        $entries = $this->workspaceEntriesState();
+        $entries['featured'][] = [
+            'entry_type' => 'not_real',
+            'target_key' => 'rogue',
+            'target_locale' => 'en',
+            'title_override' => '',
+            'excerpt_override' => '',
+            'badge_label' => '',
+            'cta_label' => '',
+            'target_url_override' => '',
+            'payload_json_text' => '',
+            'sort_order' => 10,
+            'is_featured' => false,
+            'is_enabled' => true,
+        ];
+        $entries['rogue_group'] = [[
+            'entry_type' => 'article',
+            'target_key' => 'rogue',
+            'target_locale' => 'en',
+        ]];
+
+        TopicWorkspace::syncWorkspaceSections($profile, $sections);
+        TopicWorkspace::syncWorkspaceEntries($profile, $entries);
+
+        $this->assertDatabaseMissing('topic_profile_sections', [
+            'profile_id' => $profile->id,
+            'section_key' => 'rogue_section',
+        ]);
+
+        $this->assertSame(0, TopicProfileEntry::query()
+            ->where('profile_id', $profile->id)
+            ->where('target_key', 'rogue')
+            ->count());
+    }
+
+    private function createSelectedOrg(): Organization
+    {
+        return Organization::query()->create([
+            'name' => 'Ops Workspace Org',
+            'owner_user_id' => 9001,
+            'status' => 'active',
+            'domain' => 'ops-workspace.example.test',
+            'timezone' => 'Asia/Shanghai',
+            'locale' => 'en',
+        ]);
+    }
+
+    /**
+     * @param  list<string>  $permissions
+     */
+    private function createAdminWithPermissions(array $permissions): AdminUser
+    {
+        $admin = AdminUser::query()->create([
+            'name' => 'admin_'.Str::lower(Str::random(6)),
+            'email' => 'admin_'.Str::lower(Str::random(6)).'@example.test',
+            'password' => bcrypt('secret'),
+            'is_active' => 1,
+        ]);
+
+        if ($permissions === []) {
+            return $admin;
+        }
+
+        $role = Role::query()->create([
+            'name' => 'role_'.Str::lower(Str::random(10)),
+            'description' => null,
+        ]);
+
+        foreach ($permissions as $permissionName) {
+            $permission = Permission::query()->firstOrCreate(
+                ['name' => $permissionName],
+                ['description' => null],
+            );
+
+            $role->permissions()->syncWithoutDetaching([$permission->id]);
+        }
+
+        $admin->roles()->syncWithoutDetaching([$role->id]);
+
+        return $admin;
+    }
+
+    /**
+     * @param  array<string, mixed>  $overrides
+     */
+    private function seedProfile(array $overrides = []): TopicProfile
+    {
+        return TopicProfile::query()->create(array_merge([
+            'org_id' => 0,
+            'topic_code' => 'mbti',
+            'slug' => 'mbti',
+            'locale' => 'en',
+            'title' => 'MBTI Topic Hub',
+            'subtitle' => 'Understand type concepts, profiles, and assessments.',
+            'excerpt' => 'Explore MBTI concepts, type profiles, and practical guidance.',
+            'hero_kicker' => 'Topic hub',
+            'hero_quote' => 'Start from the core ideas, then go deeper.',
+            'status' => TopicProfile::STATUS_DRAFT,
+            'is_public' => true,
+            'is_indexable' => true,
+            'sort_order' => 10,
+            'schema_version' => 'v1',
+        ], $overrides));
+    }
+
+    /**
+     * @return array<string, array<string, mixed>>
+     */
+    private function workspaceSectionsState(): array
+    {
+        return array_replace_recursive(TopicWorkspace::defaultWorkspaceSectionsState(), [
+            'overview' => [
+                'body_md' => 'MBTI is a typology framework for understanding patterns in how people take in information and make decisions.',
+            ],
+            'key_concepts' => [
+                'render_variant' => 'cards',
+                'payload_json_text' => json_encode([
+                    'items' => [
+                        [
+                            'title' => 'Preferences',
+                            'body' => 'Type codes describe preferences rather than fixed capabilities.',
+                        ],
+                        [
+                            'title' => 'Context',
+                            'body' => 'Type interpretation depends on context and development over time.',
+                        ],
+                    ],
+                ], JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE),
+            ],
+            'who_should_read' => [
+                'render_variant' => 'bullets',
+                'payload_json_text' => json_encode([
+                    'items' => [
+                        'Readers comparing personality frameworks',
+                        'Teams exploring communication and work preferences',
+                    ],
+                ], JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE),
+            ],
+        ]);
+    }
+
+    /**
+     * @return array<string, list<array<string, mixed>>>
+     */
+    private function workspaceEntriesState(): array
+    {
+        return array_replace_recursive(TopicWorkspace::defaultWorkspaceEntriesState(), [
+            'featured' => [[
+                'entry_type' => 'personality_profile',
+                'target_key' => 'INTJ',
+                'target_locale' => 'en',
+                'title_override' => 'INTJ - Architect',
+                'excerpt_override' => 'Independent, strategic, and future-oriented.',
+                'badge_label' => 'Personality',
+                'cta_label' => 'Explore',
+                'target_url_override' => '',
+                'payload_json_text' => '',
+                'sort_order' => 10,
+                'is_featured' => true,
+                'is_enabled' => true,
+            ]],
+            'tests' => [[
+                'entry_type' => 'scale',
+                'target_key' => 'MBTI',
+                'target_locale' => 'en',
+                'title_override' => 'Take the MBTI test',
+                'excerpt_override' => 'Start with the core type assessment.',
+                'badge_label' => 'Test',
+                'cta_label' => 'Take the test',
+                'target_url_override' => '',
+                'payload_json_text' => '',
+                'sort_order' => 10,
+                'is_featured' => false,
+                'is_enabled' => true,
+            ]],
+            'related' => [[
+                'entry_type' => 'custom_link',
+                'target_key' => '',
+                'target_locale' => '',
+                'title_override' => 'See all personality profiles',
+                'excerpt_override' => 'Jump to the broader personality hub.',
+                'badge_label' => 'Related',
+                'cta_label' => 'Browse',
+                'target_url_override' => '/en/personality',
+                'payload_json_text' => '',
+                'sort_order' => 10,
+                'is_featured' => false,
+                'is_enabled' => true,
+            ]],
+        ]);
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function workspaceSeoState(): array
+    {
+        return array_replace(TopicWorkspace::defaultWorkspaceSeoState(), [
+            'seo_title' => 'MBTI Guide and Type Hub | FermatMind',
+            'seo_description' => 'Explore MBTI concepts, type profiles, guides, and tests.',
+            'robots' => 'index,follow',
+        ]);
+    }
+}


### PR DESCRIPTION
Summary
- add the Ops resource and editorial workspace for Topics CMS v1
- provide list, create, and edit experiences for structured topic hub profiles

What changed
- add a Filament resource for topic profiles
- add a structured workspace for create/edit flows
- organize topic editing into stronger main-content vs metadata rails
- add workspace helpers for narrative sections, entry groups, seo meta, and revision snapshots
- keep the existing backend theme, shell, and shared component layers

Design choices
- topics are edited as structured hub profiles, not generic articles or tags
- narrative sections stay fixed and controlled
- aggregated entries are edited through constrained group-aware inputs
- v1 operates on global topic content (org_id=0)
- public URL handling stays conservative until the frontend cutover is complete
- revision snapshots are written on create/update

Why this PR is small and safe
- no API changes
- no frontend changes
- no route changes outside the new resource
- no RBAC changes
- no database changes beyond T01
- only Ops resource/workspace implementation for Topics CMS

Validation
- `php artisan about`
- `php artisan route:list --path=ops --except-vendor`
- `php artisan route:list --path=topics --except-vendor`
- `php artisan migrate`
- `php artisan filament:assets`
- `npm run build`
- `php artisan test --filter='(Topic|Topics)'`
- checked `/ops/topics`, `/ops/topics/create`, `/ops/topics/{record}/edit`
- `bash backend/scripts/ci_verify_mbti.sh`
