### PR TITLE
feat(topics-cms): add baseline import for local topic content

### DIFF
--- a/backend/app/Console/Commands/TopicsImportLocalBaseline.php
+++ b/backend/app/Console/Commands/TopicsImportLocalBaseline.php
@@ -1,0 +1,84 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Console\Commands;
+
+use App\TopicsCms\Baseline\TopicBaselineImporter;
+use App\TopicsCms\Baseline\TopicBaselineNormalizer;
+use App\TopicsCms\Baseline\TopicBaselineReader;
+use Illuminate\Console\Command;
+use RuntimeException;
+
+final class TopicsImportLocalBaseline extends Command
+{
+    protected $signature = 'topics:import-local-baseline
+        {--dry-run : Validate and diff without writing to the database}
+        {--locale=* : Import only specific locale(s)}
+        {--topic=* : Import only specific topic_code(s)}
+        {--upsert : Update existing records instead of create-missing only}
+        {--status=draft : Force imported records to draft or published}
+        {--source-dir= : Override the committed baseline source directory}';
+
+    protected $description = 'Import committed topic baseline content into Topics CMS tables.';
+
+    public function handle(
+        TopicBaselineReader $reader,
+        TopicBaselineNormalizer $normalizer,
+        TopicBaselineImporter $importer,
+    ): int {
+        try {
+            $status = trim((string) $this->option('status'));
+            if (! in_array($status, [TopicBaselineImporter::STATUS_DRAFT, TopicBaselineImporter::STATUS_PUBLISHED], true)) {
+                throw new RuntimeException(sprintf(
+                    'Unsupported --status value: %s',
+                    $status,
+                ));
+            }
+
+            $sourceDir = $reader->resolveSourceDir(
+                $this->option('source-dir') !== null
+                    ? (string) $this->option('source-dir')
+                    : null,
+            );
+            $selectedLocales = array_values(array_filter(
+                array_map(static fn (string $value): string => trim($value), (array) $this->option('locale')),
+                static fn (string $value): bool => $value !== '',
+            ));
+            $selectedTopics = array_values(array_filter(
+                array_map(static fn (string $value): string => trim($value), (array) $this->option('topic')),
+                static fn (string $value): bool => $value !== '',
+            ));
+
+            $documents = $reader->read($sourceDir, $selectedLocales, $selectedTopics);
+            $profiles = $normalizer->normalizeDocuments($documents);
+            $summary = $importer->import($profiles, [
+                'dry_run' => (bool) $this->option('dry-run'),
+                'upsert' => (bool) $this->option('upsert'),
+                'status' => $status,
+            ]);
+
+            $this->line('baseline_source_dir='.$sourceDir);
+            $this->line('locales_selected='.($selectedLocales === [] ? 'all' : implode(',', $selectedLocales)));
+            $this->line('topics_selected='.($selectedTopics === [] ? 'all' : implode(',', $selectedTopics)));
+            $this->line('dry_run='.((bool) $this->option('dry-run') ? '1' : '0'));
+            $this->line('upsert='.((bool) $this->option('upsert') ? '1' : '0'));
+            $this->line('status_mode='.$status);
+            $this->line('files_found='.(string) count($documents));
+            $this->line('profiles_found='.(string) $summary['profiles_found']);
+            $this->line('will_create='.(string) $summary['will_create']);
+            $this->line('will_update='.(string) $summary['will_update']);
+            $this->line('will_skip='.(string) $summary['will_skip']);
+            $this->line('revisions_to_create='.(string) $summary['revisions_to_create']);
+            $this->line('errors_count='.(string) $summary['errors_count']);
+
+            $this->info((bool) $this->option('dry-run') ? 'dry-run complete' : 'import complete');
+
+            return 0;
+        } catch (\Throwable $throwable) {
+            $this->error($throwable->getMessage());
+
+            return 1;
+        }
+    }
+}

--- a/backend/app/TopicsCms/Baseline/TopicBaselineImporter.php
+++ b/backend/app/TopicsCms/Baseline/TopicBaselineImporter.php
@@ -1,0 +1,457 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\TopicsCms\Baseline;
+
+use App\Models\TopicProfile;
+use App\Models\TopicProfileEntry;
+use App\Models\TopicProfileRevision;
+use App\Models\TopicProfileSection;
+use App\Models\TopicProfileSeoMeta;
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Support\Carbon;
+use Illuminate\Support\Facades\DB;
+
+final class TopicBaselineImporter
+{
+    public const STATUS_DRAFT = 'draft';
+
+    public const STATUS_PUBLISHED = 'published';
+
+    /**
+     * @param  array<int, array<string, mixed>>  $profiles
+     * @param  array{
+     *   dry_run: bool,
+     *   upsert: bool,
+     *   status: 'draft'|'published'
+     * }  $options
+     * @return array<string, int|string|bool>
+     */
+    public function import(array $profiles, array $options): array
+    {
+        $dryRun = (bool) ($options['dry_run'] ?? false);
+        $upsert = (bool) ($options['upsert'] ?? false);
+        $status = (string) ($options['status'] ?? self::STATUS_DRAFT);
+
+        $summary = [
+            'profiles_found' => count($profiles),
+            'will_create' => 0,
+            'will_update' => 0,
+            'will_skip' => 0,
+            'revisions_to_create' => 0,
+            'errors_count' => 0,
+            'dry_run' => $dryRun,
+            'upsert' => $upsert,
+            'status_mode' => $status,
+        ];
+
+        foreach ($profiles as $profilePayload) {
+            $existing = $this->profileQuery()
+                ->where('org_id', 0)
+                ->where('topic_code', (string) $profilePayload['topic_code'])
+                ->where('locale', (string) $profilePayload['locale'])
+                ->first();
+
+            if (! $existing instanceof TopicProfile) {
+                $summary['will_create']++;
+                $summary['revisions_to_create']++;
+
+                if (! $dryRun) {
+                    DB::transaction(function () use ($profilePayload, $status): void {
+                        $profile = TopicProfile::query()->create(
+                            $this->profileAttributes($profilePayload, $status)
+                        );
+
+                        $this->syncSections($profile, $profilePayload);
+                        $this->syncEntries($profile, $profilePayload);
+                        $this->syncSeoMeta($profile, $profilePayload);
+                        $this->createRevision($profile, 'baseline import');
+                    });
+                }
+
+                continue;
+            }
+
+            if (! $upsert) {
+                $summary['will_skip']++;
+
+                continue;
+            }
+
+            $desiredState = $this->desiredComparableState($profilePayload, $status, $existing);
+            $currentState = $this->currentComparableState($existing);
+
+            if ($desiredState === $currentState) {
+                $summary['will_skip']++;
+
+                continue;
+            }
+
+            $summary['will_update']++;
+            $summary['revisions_to_create']++;
+
+            if (! $dryRun) {
+                DB::transaction(function () use ($existing, $profilePayload, $status): void {
+                    $existing->fill($this->profileAttributes($profilePayload, $status, $existing));
+                    $existing->save();
+
+                    $this->syncSections($existing, $profilePayload);
+                    $this->syncEntries($existing, $profilePayload);
+                    $this->syncSeoMeta($existing, $profilePayload);
+                    $this->createRevision($existing, 'baseline upsert');
+                });
+            }
+        }
+
+        return $summary;
+    }
+
+    private function profileQuery(): Builder
+    {
+        return TopicProfile::query()->withoutGlobalScopes();
+    }
+
+    /**
+     * @param  array<string, mixed>  $profilePayload
+     * @return array<string, mixed>
+     */
+    private function profileAttributes(
+        array $profilePayload,
+        string $status,
+        ?TopicProfile $existing = null,
+    ): array {
+        return [
+            'org_id' => 0,
+            'topic_code' => (string) $profilePayload['topic_code'],
+            'slug' => (string) $profilePayload['slug'],
+            'locale' => (string) $profilePayload['locale'],
+            'title' => (string) $profilePayload['title'],
+            'subtitle' => $profilePayload['subtitle'],
+            'excerpt' => $profilePayload['excerpt'],
+            'hero_kicker' => $profilePayload['hero_kicker'],
+            'hero_quote' => $profilePayload['hero_quote'],
+            'cover_image_url' => $profilePayload['cover_image_url'],
+            'status' => $status,
+            'is_public' => (bool) $profilePayload['is_public'],
+            'is_indexable' => (bool) $profilePayload['is_indexable'],
+            'published_at' => $this->resolvePublishedAt($profilePayload, $status, $existing),
+            'scheduled_at' => $status === self::STATUS_DRAFT
+                ? null
+                : $this->normalizeNullableDate($profilePayload['scheduled_at'] ?? null),
+            'schema_version' => (string) ($profilePayload['schema_version'] ?? 'v1'),
+            'sort_order' => (int) ($profilePayload['sort_order'] ?? 0),
+        ];
+    }
+
+    /**
+     * @param  array<string, mixed>  $profilePayload
+     */
+    private function syncSections(TopicProfile $profile, array $profilePayload): void
+    {
+        TopicProfileSection::query()
+            ->where('profile_id', (int) $profile->id)
+            ->delete();
+
+        foreach ((array) $profilePayload['sections'] as $section) {
+            TopicProfileSection::query()->create([
+                'profile_id' => (int) $profile->id,
+                'section_key' => (string) $section['section_key'],
+                'title' => $section['title'],
+                'render_variant' => (string) $section['render_variant'],
+                'body_md' => $section['body_md'],
+                'body_html' => $section['body_html'],
+                'payload_json' => $section['payload_json'],
+                'sort_order' => (int) $section['sort_order'],
+                'is_enabled' => (bool) $section['is_enabled'],
+            ]);
+        }
+
+        $profile->unsetRelation('sections');
+    }
+
+    /**
+     * @param  array<string, mixed>  $profilePayload
+     */
+    private function syncEntries(TopicProfile $profile, array $profilePayload): void
+    {
+        TopicProfileEntry::query()
+            ->where('profile_id', (int) $profile->id)
+            ->delete();
+
+        foreach ((array) $profilePayload['entries'] as $entry) {
+            TopicProfileEntry::query()->create([
+                'profile_id' => (int) $profile->id,
+                'entry_type' => (string) $entry['entry_type'],
+                'group_key' => (string) $entry['group_key'],
+                'target_key' => (string) $entry['target_key'],
+                'target_locale' => $entry['target_locale'],
+                'title_override' => $entry['title_override'],
+                'excerpt_override' => $entry['excerpt_override'],
+                'badge_label' => $entry['badge_label'],
+                'cta_label' => $entry['cta_label'],
+                'target_url_override' => $entry['target_url_override'],
+                'payload_json' => $entry['payload_json'],
+                'sort_order' => (int) $entry['sort_order'],
+                'is_featured' => (bool) $entry['is_featured'],
+                'is_enabled' => (bool) $entry['is_enabled'],
+            ]);
+        }
+
+        $profile->unsetRelation('entries');
+    }
+
+    /**
+     * @param  array<string, mixed>  $profilePayload
+     */
+    private function syncSeoMeta(TopicProfile $profile, array $profilePayload): void
+    {
+        $seoMeta = (array) $profilePayload['seo_meta'];
+
+        TopicProfileSeoMeta::query()->updateOrCreate(
+            [
+                'profile_id' => (int) $profile->id,
+            ],
+            [
+                'seo_title' => $seoMeta['seo_title'],
+                'seo_description' => $seoMeta['seo_description'],
+                'canonical_url' => $seoMeta['canonical_url'],
+                'og_title' => $seoMeta['og_title'],
+                'og_description' => $seoMeta['og_description'],
+                'og_image_url' => $seoMeta['og_image_url'],
+                'twitter_title' => $seoMeta['twitter_title'],
+                'twitter_description' => $seoMeta['twitter_description'],
+                'twitter_image_url' => $seoMeta['twitter_image_url'],
+                'robots' => $seoMeta['robots'],
+                'jsonld_overrides_json' => $seoMeta['jsonld_overrides_json'],
+            ],
+        );
+
+        $profile->unsetRelation('seoMeta');
+    }
+
+    private function createRevision(TopicProfile $profile, string $note): void
+    {
+        TopicProfileRevision::query()->create([
+            'profile_id' => (int) $profile->id,
+            'revision_no' => ((int) TopicProfileRevision::query()
+                ->where('profile_id', (int) $profile->id)
+                ->max('revision_no')) + 1,
+            'snapshot_json' => $this->currentComparableState($profile->fresh(['sections', 'entries', 'seoMeta'])),
+            'note' => $note,
+            'created_by_admin_user_id' => null,
+            'created_at' => now(),
+        ]);
+    }
+
+    /**
+     * @param  array<string, mixed>  $profilePayload
+     * @return array<string, mixed>
+     */
+    private function desiredComparableState(
+        array $profilePayload,
+        string $status,
+        ?TopicProfile $existing = null,
+    ): array {
+        $sections = collect((array) $profilePayload['sections'])
+            ->map(static fn (array $section): array => [
+                'section_key' => (string) $section['section_key'],
+                'title' => $section['title'],
+                'render_variant' => (string) $section['render_variant'],
+                'body_md' => $section['body_md'],
+                'body_html' => $section['body_html'],
+                'payload_json' => $section['payload_json'],
+                'sort_order' => (int) $section['sort_order'],
+                'is_enabled' => (bool) $section['is_enabled'],
+            ])
+            ->sortBy([
+                ['sort_order', 'asc'],
+                ['section_key', 'asc'],
+            ])
+            ->values()
+            ->all();
+
+        $entries = collect((array) $profilePayload['entries'])
+            ->map(static fn (array $entry): array => [
+                'entry_type' => (string) $entry['entry_type'],
+                'group_key' => (string) $entry['group_key'],
+                'target_key' => (string) $entry['target_key'],
+                'target_locale' => $entry['target_locale'],
+                'title_override' => $entry['title_override'],
+                'excerpt_override' => $entry['excerpt_override'],
+                'badge_label' => $entry['badge_label'],
+                'cta_label' => $entry['cta_label'],
+                'target_url_override' => $entry['target_url_override'],
+                'payload_json' => $entry['payload_json'],
+                'sort_order' => (int) $entry['sort_order'],
+                'is_featured' => (bool) $entry['is_featured'],
+                'is_enabled' => (bool) $entry['is_enabled'],
+            ])
+            ->sortBy([
+                ['group_key', 'asc'],
+                ['sort_order', 'asc'],
+                ['entry_type', 'asc'],
+                ['target_key', 'asc'],
+            ])
+            ->values()
+            ->all();
+
+        return [
+            'profile' => [
+                'org_id' => 0,
+                'topic_code' => (string) $profilePayload['topic_code'],
+                'slug' => (string) $profilePayload['slug'],
+                'locale' => (string) $profilePayload['locale'],
+                'title' => (string) $profilePayload['title'],
+                'subtitle' => $profilePayload['subtitle'],
+                'excerpt' => $profilePayload['excerpt'],
+                'hero_kicker' => $profilePayload['hero_kicker'],
+                'hero_quote' => $profilePayload['hero_quote'],
+                'cover_image_url' => $profilePayload['cover_image_url'],
+                'status' => $status,
+                'is_public' => (bool) $profilePayload['is_public'],
+                'is_indexable' => (bool) $profilePayload['is_indexable'],
+                'published_at' => $this->normalizeDateForComparison(
+                    $this->resolvePublishedAt($profilePayload, $status, $existing)
+                ),
+                'scheduled_at' => $status === self::STATUS_DRAFT
+                    ? null
+                    : $this->normalizeDateForComparison($this->normalizeNullableDate($profilePayload['scheduled_at'] ?? null)),
+                'schema_version' => (string) ($profilePayload['schema_version'] ?? 'v1'),
+                'sort_order' => (int) ($profilePayload['sort_order'] ?? 0),
+            ],
+            'sections' => $sections,
+            'entries' => $entries,
+            'seo_meta' => (array) $profilePayload['seo_meta'],
+        ];
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function currentComparableState(TopicProfile $profile): array
+    {
+        $profile->loadMissing('sections', 'entries', 'seoMeta');
+
+        return [
+            'profile' => [
+                'org_id' => (int) $profile->org_id,
+                'topic_code' => (string) $profile->topic_code,
+                'slug' => (string) $profile->slug,
+                'locale' => (string) $profile->locale,
+                'title' => (string) $profile->title,
+                'subtitle' => $profile->subtitle,
+                'excerpt' => $profile->excerpt,
+                'hero_kicker' => $profile->hero_kicker,
+                'hero_quote' => $profile->hero_quote,
+                'cover_image_url' => $profile->cover_image_url,
+                'status' => (string) $profile->status,
+                'is_public' => (bool) $profile->is_public,
+                'is_indexable' => (bool) $profile->is_indexable,
+                'published_at' => $this->normalizeDateForComparison($profile->published_at),
+                'scheduled_at' => $this->normalizeDateForComparison($profile->scheduled_at),
+                'schema_version' => (string) $profile->schema_version,
+                'sort_order' => (int) $profile->sort_order,
+            ],
+            'sections' => $profile->sections
+                ->map(static fn (TopicProfileSection $section): array => [
+                    'section_key' => (string) $section->section_key,
+                    'title' => $section->title,
+                    'render_variant' => (string) $section->render_variant,
+                    'body_md' => $section->body_md,
+                    'body_html' => $section->body_html,
+                    'payload_json' => $section->payload_json,
+                    'sort_order' => (int) $section->sort_order,
+                    'is_enabled' => (bool) $section->is_enabled,
+                ])
+                ->sortBy([
+                    ['sort_order', 'asc'],
+                    ['section_key', 'asc'],
+                ])
+                ->values()
+                ->all(),
+            'entries' => $profile->entries
+                ->map(static fn (TopicProfileEntry $entry): array => [
+                    'entry_type' => (string) $entry->entry_type,
+                    'group_key' => (string) $entry->group_key,
+                    'target_key' => (string) $entry->target_key,
+                    'target_locale' => $entry->target_locale,
+                    'title_override' => $entry->title_override,
+                    'excerpt_override' => $entry->excerpt_override,
+                    'badge_label' => $entry->badge_label,
+                    'cta_label' => $entry->cta_label,
+                    'target_url_override' => $entry->target_url_override,
+                    'payload_json' => $entry->payload_json,
+                    'sort_order' => (int) $entry->sort_order,
+                    'is_featured' => (bool) $entry->is_featured,
+                    'is_enabled' => (bool) $entry->is_enabled,
+                ])
+                ->sortBy([
+                    ['group_key', 'asc'],
+                    ['sort_order', 'asc'],
+                    ['entry_type', 'asc'],
+                    ['target_key', 'asc'],
+                ])
+                ->values()
+                ->all(),
+            'seo_meta' => $profile->seoMeta instanceof TopicProfileSeoMeta
+                ? [
+                    'seo_title' => $profile->seoMeta->seo_title,
+                    'seo_description' => $profile->seoMeta->seo_description,
+                    'canonical_url' => $profile->seoMeta->canonical_url,
+                    'og_title' => $profile->seoMeta->og_title,
+                    'og_description' => $profile->seoMeta->og_description,
+                    'og_image_url' => $profile->seoMeta->og_image_url,
+                    'twitter_title' => $profile->seoMeta->twitter_title,
+                    'twitter_description' => $profile->seoMeta->twitter_description,
+                    'twitter_image_url' => $profile->seoMeta->twitter_image_url,
+                    'robots' => $profile->seoMeta->robots,
+                    'jsonld_overrides_json' => $profile->seoMeta->jsonld_overrides_json,
+                ]
+                : [
+                    'seo_title' => null,
+                    'seo_description' => null,
+                    'canonical_url' => null,
+                    'og_title' => null,
+                    'og_description' => null,
+                    'og_image_url' => null,
+                    'twitter_title' => null,
+                    'twitter_description' => null,
+                    'twitter_image_url' => null,
+                    'robots' => null,
+                    'jsonld_overrides_json' => null,
+                ],
+        ];
+    }
+
+    /**
+     * @param  array<string, mixed>  $profilePayload
+     */
+    private function resolvePublishedAt(array $profilePayload, string $status, ?TopicProfile $existing = null): ?Carbon
+    {
+        if ($status === self::STATUS_DRAFT) {
+            return null;
+        }
+
+        $baselinePublishedAt = $this->normalizeNullableDate($profilePayload['published_at'] ?? null);
+        if ($baselinePublishedAt instanceof Carbon) {
+            return $baselinePublishedAt;
+        }
+
+        return $existing?->published_at;
+    }
+
+    private function normalizeNullableDate(mixed $value): ?Carbon
+    {
+        if ($value === null || trim((string) $value) === '') {
+            return null;
+        }
+
+        return Carbon::parse((string) $value);
+    }
+
+    private function normalizeDateForComparison(?Carbon $value): ?string
+    {
+        return $value?->copy()->utc()->toIso8601String();
+    }
+}

--- a/backend/app/TopicsCms/Baseline/TopicBaselineNormalizer.php
+++ b/backend/app/TopicsCms/Baseline/TopicBaselineNormalizer.php
@@ -1,0 +1,458 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\TopicsCms\Baseline;
+
+use App\Models\TopicProfile;
+use App\Models\TopicProfileEntry;
+use App\Models\TopicProfileSection;
+use Illuminate\Support\Arr;
+use RuntimeException;
+
+final class TopicBaselineNormalizer
+{
+    /**
+     * @var array<int, string>
+     */
+    private const MANAGED_SECTION_KEYS = [
+        'overview',
+        'key_concepts',
+        'why_it_matters',
+        'who_should_read',
+        'faq',
+        'related_topics_intro',
+    ];
+
+    /**
+     * @param  array<int, array{file: string, payload: array<string, mixed>}>  $documents
+     * @return array<int, array<string, mixed>>
+     */
+    public function normalizeDocuments(array $documents): array
+    {
+        $profiles = [];
+        $seenByLocaleTopic = [];
+        $seenByLocaleSlug = [];
+
+        foreach ($documents as $document) {
+            $file = (string) ($document['file'] ?? 'unknown');
+            $payload = is_array($document['payload'] ?? null) ? $document['payload'] : [];
+            $meta = is_array($payload['meta'] ?? null) ? $payload['meta'] : [];
+            $profileRow = is_array($payload['profile'] ?? null) ? $payload['profile'] : null;
+
+            if ($profileRow === null) {
+                throw new RuntimeException(sprintf(
+                    'Topic baseline file %s must contain a profile object.',
+                    $file,
+                ));
+            }
+
+            $topicCode = $this->normalizeTopicCode($meta['topic_code'] ?? null, $file);
+            $locale = $this->normalizeLocale($meta['locale'] ?? null, $file);
+            $schemaVersion = trim((string) ($meta['schema_version'] ?? 'v1'));
+            $profile = $this->normalizeProfile(
+                $profileRow,
+                is_array($payload['sections'] ?? null) ? $payload['sections'] : [],
+                is_array($payload['entries'] ?? null) ? $payload['entries'] : [],
+                is_array($payload['seo_meta'] ?? null) ? $payload['seo_meta'] : [],
+                $topicCode,
+                $locale,
+                $schemaVersion,
+                $file,
+            );
+
+            $localeTopicKey = $locale.'|'.$topicCode;
+            $localeSlugKey = $locale.'|'.$profile['slug'];
+
+            if (isset($seenByLocaleTopic[$localeTopicKey])) {
+                throw new RuntimeException(sprintf(
+                    'Duplicate topic_code %s for locale %s in baseline file %s.',
+                    $topicCode,
+                    $locale,
+                    $file,
+                ));
+            }
+
+            if (isset($seenByLocaleSlug[$localeSlugKey])) {
+                throw new RuntimeException(sprintf(
+                    'Duplicate slug %s for locale %s in baseline file %s.',
+                    $profile['slug'],
+                    $locale,
+                    $file,
+                ));
+            }
+
+            $seenByLocaleTopic[$localeTopicKey] = true;
+            $seenByLocaleSlug[$localeSlugKey] = true;
+            $profiles[] = $profile;
+        }
+
+        usort(
+            $profiles,
+            static fn (array $left, array $right): int => [$left['locale'], $left['topic_code']]
+                <=> [$right['locale'], $right['topic_code']],
+        );
+
+        return $profiles;
+    }
+
+    /**
+     * @param  array<string, mixed>  $profileRow
+     * @param  array<int, mixed>  $sectionRows
+     * @param  array<int, mixed>  $entryRows
+     * @param  array<string, mixed>  $seoMeta
+     * @return array<string, mixed>
+     */
+    private function normalizeProfile(
+        array $profileRow,
+        array $sectionRows,
+        array $entryRows,
+        array $seoMeta,
+        string $topicCode,
+        string $locale,
+        string $schemaVersion,
+        string $file,
+    ): array {
+        $slug = strtolower(trim((string) ($profileRow['slug'] ?? '')));
+        $title = trim((string) ($profileRow['title'] ?? ''));
+
+        if ($slug === '') {
+            throw new RuntimeException(sprintf(
+                'Topic baseline file %s is missing profile.slug.',
+                $file,
+            ));
+        }
+
+        if ($title === '') {
+            throw new RuntimeException(sprintf(
+                'Topic baseline file %s is missing profile.title.',
+                $file,
+            ));
+        }
+
+        return [
+            'org_id' => 0,
+            'topic_code' => $topicCode,
+            'slug' => $slug,
+            'locale' => $locale,
+            'title' => $title,
+            'subtitle' => $this->normalizeNullableText($profileRow['subtitle'] ?? null),
+            'excerpt' => $this->normalizeNullableText($profileRow['excerpt'] ?? null),
+            'hero_kicker' => $this->normalizeNullableText($profileRow['hero_kicker'] ?? null),
+            'hero_quote' => $this->normalizeNullableText($profileRow['hero_quote'] ?? null),
+            'cover_image_url' => $this->normalizeNullableText($profileRow['cover_image_url'] ?? null),
+            'status' => $this->normalizeStatus($profileRow['status'] ?? TopicBaselineImporter::STATUS_PUBLISHED, $file),
+            'is_public' => $this->normalizeBool($profileRow['is_public'] ?? true),
+            'is_indexable' => $this->normalizeBool($profileRow['is_indexable'] ?? true),
+            'published_at' => $this->normalizeNullableText($profileRow['published_at'] ?? null),
+            'scheduled_at' => $this->normalizeNullableText($profileRow['scheduled_at'] ?? null),
+            'schema_version' => $schemaVersion !== '' ? $schemaVersion : 'v1',
+            'sort_order' => (int) ($profileRow['sort_order'] ?? 0),
+            'sections' => $this->normalizeSections($sectionRows, $file),
+            'entries' => $this->normalizeEntries($entryRows, $locale, $file),
+            'seo_meta' => $this->normalizeSeoMeta($seoMeta),
+        ];
+    }
+
+    /**
+     * @param  array<int, mixed>  $rows
+     * @return array<int, array<string, mixed>>
+     */
+    private function normalizeSections(array $rows, string $file): array
+    {
+        $sections = [];
+        $seen = [];
+
+        foreach ($rows as $index => $row) {
+            if (! is_array($row)) {
+                throw new RuntimeException(sprintf(
+                    'Topic baseline file %s contains a non-object section at sections[%d].',
+                    $file,
+                    $index,
+                ));
+            }
+
+            $sectionKey = trim((string) ($row['section_key'] ?? ''));
+            if ($sectionKey === '' || ! in_array($sectionKey, self::MANAGED_SECTION_KEYS, true)) {
+                throw new RuntimeException(sprintf(
+                    'Topic baseline file %s contains unsupported section_key=%s at sections[%d].',
+                    $file,
+                    $sectionKey,
+                    $index,
+                ));
+            }
+
+            if (isset($seen[$sectionKey])) {
+                throw new RuntimeException(sprintf(
+                    'Topic baseline file %s contains duplicate section_key=%s.',
+                    $file,
+                    $sectionKey,
+                ));
+            }
+
+            $renderVariant = trim((string) ($row['render_variant'] ?? ''));
+            if ($renderVariant === '' || ! in_array($renderVariant, TopicProfileSection::RENDER_VARIANTS, true)) {
+                throw new RuntimeException(sprintf(
+                    'Topic baseline file %s contains invalid render_variant for section %s.',
+                    $file,
+                    $sectionKey,
+                ));
+            }
+
+            $sections[] = [
+                'section_key' => $sectionKey,
+                'title' => $this->normalizeNullableText($row['title'] ?? null),
+                'render_variant' => $renderVariant,
+                'body_md' => $this->normalizeNullableText($row['body_md'] ?? null),
+                'body_html' => $this->normalizeNullableText($row['body_html'] ?? null),
+                'payload_json' => Arr::exists($row, 'payload_json')
+                    ? $this->normalizeNullableArray($row['payload_json'])
+                    : null,
+                'sort_order' => (int) ($row['sort_order'] ?? 0),
+                'is_enabled' => $this->normalizeBool($row['is_enabled'] ?? true),
+            ];
+
+            $seen[$sectionKey] = true;
+        }
+
+        usort(
+            $sections,
+            static fn (array $left, array $right): int => [$left['sort_order'], $left['section_key']]
+                <=> [$right['sort_order'], $right['section_key']],
+        );
+
+        return $sections;
+    }
+
+    /**
+     * @param  array<int, mixed>  $rows
+     * @return array<int, array<string, mixed>>
+     */
+    private function normalizeEntries(array $rows, string $profileLocale, string $file): array
+    {
+        $entries = [];
+
+        foreach ($rows as $index => $row) {
+            if (! is_array($row)) {
+                throw new RuntimeException(sprintf(
+                    'Topic baseline file %s contains a non-object entry at entries[%d].',
+                    $file,
+                    $index,
+                ));
+            }
+
+            $entryType = trim((string) ($row['entry_type'] ?? ''));
+            $groupKey = trim((string) ($row['group_key'] ?? ''));
+            $targetKey = trim((string) ($row['target_key'] ?? ''));
+
+            if ($entryType === '' || ! in_array($entryType, TopicProfileEntry::ENTRY_TYPES, true)) {
+                throw new RuntimeException(sprintf(
+                    'Topic baseline file %s contains unsupported entry_type=%s at entries[%d].',
+                    $file,
+                    $entryType,
+                    $index,
+                ));
+            }
+
+            if ($groupKey === '' || ! in_array($groupKey, TopicProfileEntry::GROUP_KEYS, true)) {
+                throw new RuntimeException(sprintf(
+                    'Topic baseline file %s contains unsupported group_key=%s at entries[%d].',
+                    $file,
+                    $groupKey,
+                    $index,
+                ));
+            }
+
+            if ($targetKey === '') {
+                throw new RuntimeException(sprintf(
+                    'Topic baseline file %s is missing target_key at entries[%d].',
+                    $file,
+                    $index,
+                ));
+            }
+
+            $targetLocale = Arr::exists($row, 'target_locale')
+                ? $this->normalizeNullableLocale($row['target_locale'], $file, false)
+                : null;
+
+            $targetUrlOverride = $this->normalizeNullableText($row['target_url_override'] ?? null);
+            if ($entryType === 'custom_link') {
+                if ($targetUrlOverride === null || ! $this->isValidRelativePath($targetUrlOverride)) {
+                    throw new RuntimeException(sprintf(
+                        'Topic baseline file %s contains invalid custom_link target_url_override at entries[%d].',
+                        $file,
+                        $index,
+                    ));
+                }
+
+                if ($this->normalizeNullableText($row['title_override'] ?? null) === null) {
+                    throw new RuntimeException(sprintf(
+                        'Topic baseline file %s requires title_override for custom_link at entries[%d].',
+                        $file,
+                        $index,
+                    ));
+                }
+            }
+
+            if ($entryType !== 'custom_link' && $targetUrlOverride !== null && ! $this->isValidRelativePath($targetUrlOverride)) {
+                throw new RuntimeException(sprintf(
+                    'Topic baseline file %s contains invalid target_url_override at entries[%d].',
+                    $file,
+                    $index,
+                ));
+            }
+
+            $entries[] = [
+                'entry_type' => $entryType,
+                'group_key' => $groupKey,
+                'target_key' => $targetKey,
+                'target_locale' => $targetLocale ?? ($entryType === 'scale' ? null : $profileLocale),
+                'title_override' => $this->normalizeNullableText($row['title_override'] ?? null),
+                'excerpt_override' => $this->normalizeNullableText($row['excerpt_override'] ?? null),
+                'badge_label' => $this->normalizeNullableText($row['badge_label'] ?? null),
+                'cta_label' => $this->normalizeNullableText($row['cta_label'] ?? null),
+                'target_url_override' => $targetUrlOverride,
+                'payload_json' => Arr::exists($row, 'payload_json')
+                    ? $this->normalizeNullableArray($row['payload_json'])
+                    : null,
+                'sort_order' => (int) ($row['sort_order'] ?? 0),
+                'is_featured' => $this->normalizeBool($row['is_featured'] ?? false),
+                'is_enabled' => $this->normalizeBool($row['is_enabled'] ?? true),
+            ];
+        }
+
+        usort(
+            $entries,
+            static fn (array $left, array $right): int => [$left['group_key'], $left['sort_order'], $left['entry_type'], $left['target_key']]
+                <=> [$right['group_key'], $right['sort_order'], $right['entry_type'], $right['target_key']],
+        );
+
+        return $entries;
+    }
+
+    /**
+     * @param  array<string, mixed>  $seoMeta
+     * @return array<string, mixed>
+     */
+    private function normalizeSeoMeta(array $seoMeta): array
+    {
+        return [
+            'seo_title' => $this->normalizeNullableText($seoMeta['seo_title'] ?? null),
+            'seo_description' => $this->normalizeNullableText($seoMeta['seo_description'] ?? null),
+            'canonical_url' => $this->normalizeNullableText($seoMeta['canonical_url'] ?? null),
+            'og_title' => $this->normalizeNullableText($seoMeta['og_title'] ?? null),
+            'og_description' => $this->normalizeNullableText($seoMeta['og_description'] ?? null),
+            'og_image_url' => $this->normalizeNullableText($seoMeta['og_image_url'] ?? null),
+            'twitter_title' => $this->normalizeNullableText($seoMeta['twitter_title'] ?? null),
+            'twitter_description' => $this->normalizeNullableText($seoMeta['twitter_description'] ?? null),
+            'twitter_image_url' => $this->normalizeNullableText($seoMeta['twitter_image_url'] ?? null),
+            'robots' => $this->normalizeNullableText($seoMeta['robots'] ?? null),
+            'jsonld_overrides_json' => Arr::exists($seoMeta, 'jsonld_overrides_json')
+                ? $this->normalizeNullableArray($seoMeta['jsonld_overrides_json'])
+                : null,
+        ];
+    }
+
+    private function normalizeTopicCode(mixed $topicCode, string $file): string
+    {
+        $normalized = strtolower(trim((string) $topicCode));
+
+        if ($normalized === '' || ! preg_match('/^[a-z0-9-]+$/', $normalized)) {
+            throw new RuntimeException(sprintf(
+                'Topic baseline file %s has invalid topic_code=%s.',
+                $file,
+                (string) $topicCode,
+            ));
+        }
+
+        return $normalized;
+    }
+
+    private function normalizeLocale(mixed $locale, string $file): string
+    {
+        $normalized = $this->normalizeNullableLocale($locale, $file, true);
+
+        if ($normalized === null) {
+            throw new RuntimeException(sprintf(
+                'Topic baseline file %s is missing locale.',
+                $file,
+            ));
+        }
+
+        return $normalized;
+    }
+
+    private function normalizeNullableLocale(mixed $locale, string $file, bool $required): ?string
+    {
+        if ($locale === null || trim((string) $locale) === '') {
+            return $required ? null : null;
+        }
+
+        $normalized = trim((string) $locale);
+        $normalized = $normalized === 'zh' ? 'zh-CN' : $normalized;
+
+        if (! in_array($normalized, TopicProfile::SUPPORTED_LOCALES, true)) {
+            throw new RuntimeException(sprintf(
+                'Topic baseline file %s has unsupported locale=%s.',
+                $file,
+                (string) $locale,
+            ));
+        }
+
+        return $normalized;
+    }
+
+    private function normalizeStatus(mixed $status, string $file): string
+    {
+        $normalized = trim((string) $status);
+
+        if (! in_array($normalized, [TopicBaselineImporter::STATUS_DRAFT, TopicBaselineImporter::STATUS_PUBLISHED], true)) {
+            throw new RuntimeException(sprintf(
+                'Topic baseline file %s has unsupported status=%s.',
+                $file,
+                (string) $status,
+            ));
+        }
+
+        return $normalized;
+    }
+
+    private function normalizeBool(mixed $value): bool
+    {
+        return filter_var($value, FILTER_VALIDATE_BOOL, FILTER_NULL_ON_FAILURE) ?? false;
+    }
+
+    private function normalizeNullableText(mixed $value): ?string
+    {
+        if ($value === null) {
+            return null;
+        }
+
+        $normalized = trim((string) $value);
+
+        return $normalized === '' ? null : $normalized;
+    }
+
+    /**
+     * @return array<string, mixed>|list<mixed>|null
+     */
+    private function normalizeNullableArray(mixed $value): ?array
+    {
+        if ($value === null) {
+            return null;
+        }
+
+        if (! is_array($value)) {
+            throw new RuntimeException('Expected payload_json/jsonld_overrides_json to be an object or array.');
+        }
+
+        return $value;
+    }
+
+    private function isValidRelativePath(string $value): bool
+    {
+        return str_starts_with($value, '/')
+            && ! str_starts_with($value, '//')
+            && ! preg_match('/^[a-z][a-z0-9+.-]*:/i', $value);
+    }
+}

--- a/backend/app/TopicsCms/Baseline/TopicBaselineReader.php
+++ b/backend/app/TopicsCms/Baseline/TopicBaselineReader.php
@@ -1,0 +1,156 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\TopicsCms\Baseline;
+
+use RuntimeException;
+
+final class TopicBaselineReader
+{
+    public function resolveSourceDir(?string $sourceDir = null): string
+    {
+        $candidate = trim((string) $sourceDir);
+
+        if ($candidate === '') {
+            $candidate = base_path('../content_baselines/topics');
+        } elseif (! str_starts_with($candidate, DIRECTORY_SEPARATOR)) {
+            $candidate = base_path($candidate);
+        }
+
+        $resolved = realpath($candidate);
+
+        if ($resolved === false || ! is_dir($resolved)) {
+            throw new RuntimeException(sprintf(
+                'Topic baseline source directory not found: %s',
+                $candidate,
+            ));
+        }
+
+        return $resolved;
+    }
+
+    /**
+     * @param  array<int, string>  $selectedLocales
+     * @param  array<int, string>  $selectedTopics
+     * @return array<int, array{file: string, payload: array<string, mixed>}>
+     */
+    public function read(string $sourceDir, array $selectedLocales = [], array $selectedTopics = []): array
+    {
+        $locales = $this->normalizeSelectedLocales($selectedLocales);
+        $topics = $this->normalizeSelectedTopics($selectedTopics);
+        $files = glob(rtrim($sourceDir, DIRECTORY_SEPARATOR).DIRECTORY_SEPARATOR.'*.json') ?: [];
+
+        if ($files === []) {
+            throw new RuntimeException(sprintf(
+                'No topic baseline files found in %s.',
+                $sourceDir,
+            ));
+        }
+
+        sort($files);
+
+        $documents = [];
+
+        foreach ($files as $file) {
+            $basename = basename($file);
+            if (! preg_match('/^(?<topic>[a-z0-9-]+)\.(?<locale>en|zh-CN|zh)\.json$/', $basename, $matches)) {
+                continue;
+            }
+
+            $topicCode = trim((string) ($matches['topic'] ?? ''));
+            $locale = $matches['locale'] === 'zh' ? 'zh-CN' : (string) $matches['locale'];
+
+            if ($topics !== [] && ! in_array($topicCode, $topics, true)) {
+                continue;
+            }
+
+            if ($locales !== [] && ! in_array($locale, $locales, true)) {
+                continue;
+            }
+
+            $raw = file_get_contents($file);
+
+            if (! is_string($raw) || trim($raw) === '') {
+                throw new RuntimeException(sprintf(
+                    'Topic baseline file is empty: %s',
+                    $file,
+                ));
+            }
+
+            $decoded = json_decode($raw, true);
+
+            if (! is_array($decoded)) {
+                throw new RuntimeException(sprintf(
+                    'Topic baseline file is not valid JSON: %s',
+                    $file,
+                ));
+            }
+
+            $documents[] = [
+                'file' => $file,
+                'payload' => $decoded,
+            ];
+        }
+
+        if ($documents === []) {
+            throw new RuntimeException(sprintf(
+                'No matching topic baseline files found in %s.',
+                $sourceDir,
+            ));
+        }
+
+        return $documents;
+    }
+
+    /**
+     * @param  array<int, string>  $selectedLocales
+     * @return array<int, string>
+     */
+    private function normalizeSelectedLocales(array $selectedLocales): array
+    {
+        $normalized = [];
+
+        foreach ($selectedLocales as $locale) {
+            $candidate = trim((string) $locale);
+
+            if ($candidate === '') {
+                continue;
+            }
+
+            $candidate = $candidate === 'zh' ? 'zh-CN' : $candidate;
+
+            if (! in_array($candidate, ['en', 'zh-CN'], true)) {
+                throw new RuntimeException(sprintf(
+                    'Unsupported locale selection: %s',
+                    $candidate,
+                ));
+            }
+
+            $normalized[] = $candidate;
+        }
+
+        return array_values(array_unique($normalized));
+    }
+
+    /**
+     * @param  array<int, string>  $selectedTopics
+     * @return array<int, string>
+     */
+    private function normalizeSelectedTopics(array $selectedTopics): array
+    {
+        $normalized = [];
+
+        foreach ($selectedTopics as $topic) {
+            $candidate = strtolower(trim((string) $topic));
+
+            if ($candidate === '') {
+                continue;
+            }
+
+            $normalized[] = $candidate;
+        }
+
+        return array_values(array_unique($normalized));
+    }
+}

--- a/backend/tests/Feature/TopicsCms/TopicBaselineImportTest.php
+++ b/backend/tests/Feature/TopicsCms/TopicBaselineImportTest.php
@@ -1,0 +1,288 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\TopicsCms;
+
+use App\Models\TopicProfile;
+use App\Models\TopicProfileEntry;
+use App\Models\TopicProfileRevision;
+use App\Models\TopicProfileSection;
+use App\Models\TopicProfileSeoMeta;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\File;
+use Tests\TestCase;
+
+final class TopicBaselineImportTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->purgeTopicTables();
+    }
+
+    public function test_dry_run_does_not_write_database(): void
+    {
+        $this->artisan('topics:import-local-baseline', [
+            '--dry-run' => true,
+            '--source-dir' => 'tests/Fixtures/topic_baseline',
+        ])->assertExitCode(0);
+
+        $this->assertSame(0, TopicProfile::query()->count());
+        $this->assertSame(0, TopicProfileSection::query()->count());
+        $this->assertSame(0, TopicProfileEntry::query()->count());
+        $this->assertSame(0, TopicProfileSeoMeta::query()->count());
+        $this->assertSame(0, TopicProfileRevision::query()->count());
+    }
+
+    public function test_default_mode_creates_missing_topics_sections_entries_seo_meta_and_revision(): void
+    {
+        $this->artisan('topics:import-local-baseline', [
+            '--locale' => ['en'],
+            '--topic' => ['mbti'],
+            '--status' => 'draft',
+            '--source-dir' => 'tests/Fixtures/topic_baseline',
+        ])->assertExitCode(0);
+
+        $this->assertSame(1, TopicProfile::query()->count());
+        $this->assertSame(3, TopicProfileSection::query()->count());
+        $this->assertSame(4, TopicProfileEntry::query()->count());
+        $this->assertSame(1, TopicProfileSeoMeta::query()->count());
+        $this->assertSame(1, TopicProfileRevision::query()->count());
+
+        $profile = TopicProfile::query()
+            ->withoutGlobalScopes()
+            ->where('topic_code', 'mbti')
+            ->where('locale', 'en')
+            ->firstOrFail();
+
+        $this->assertSame(0, (int) $profile->org_id);
+        $this->assertSame('draft', $profile->status);
+        $this->assertNull($profile->published_at);
+
+        $revision = TopicProfileRevision::query()
+            ->where('profile_id', (int) $profile->id)
+            ->orderBy('revision_no')
+            ->firstOrFail();
+
+        $this->assertSame(1, (int) $revision->revision_no);
+        $this->assertSame('baseline import', $revision->note);
+    }
+
+    public function test_default_mode_skips_existing_topics_without_overwriting(): void
+    {
+        $topic = TopicProfile::query()->create([
+            'org_id' => 0,
+            'topic_code' => 'mbti',
+            'slug' => 'mbti',
+            'locale' => 'en',
+            'title' => 'Do Not Overwrite',
+            'status' => 'draft',
+            'is_public' => true,
+            'is_indexable' => true,
+            'schema_version' => 'v1',
+        ]);
+
+        TopicProfileRevision::query()->create([
+            'profile_id' => (int) $topic->id,
+            'revision_no' => 1,
+            'snapshot_json' => ['title' => 'Do Not Overwrite'],
+            'note' => 'seed',
+            'created_at' => now(),
+        ]);
+
+        $this->artisan('topics:import-local-baseline', [
+            '--locale' => ['en'],
+            '--topic' => ['mbti'],
+            '--source-dir' => 'tests/Fixtures/topic_baseline',
+        ])->assertExitCode(0);
+
+        $this->assertSame('Do Not Overwrite', (string) $topic->fresh()->title);
+        $this->assertSame(1, TopicProfileRevision::query()->where('profile_id', (int) $topic->id)->count());
+    }
+
+    public function test_upsert_updates_existing_topics_and_only_creates_revision_when_changed(): void
+    {
+        $topic = TopicProfile::query()->create([
+            'org_id' => 0,
+            'topic_code' => 'mbti',
+            'slug' => 'mbti',
+            'locale' => 'en',
+            'title' => 'Legacy MBTI',
+            'status' => 'published',
+            'is_public' => true,
+            'is_indexable' => false,
+            'published_at' => now()->subDay(),
+            'schema_version' => 'v1',
+            'sort_order' => 99,
+        ]);
+
+        TopicProfileSection::query()->create([
+            'profile_id' => (int) $topic->id,
+            'section_key' => 'overview',
+            'title' => 'Legacy overview',
+            'render_variant' => 'rich_text',
+            'body_md' => 'Legacy body',
+            'sort_order' => 10,
+            'is_enabled' => true,
+        ]);
+        TopicProfileEntry::query()->create([
+            'profile_id' => (int) $topic->id,
+            'entry_type' => 'custom_link',
+            'group_key' => 'related',
+            'target_key' => 'legacy',
+            'target_locale' => 'en',
+            'title_override' => 'Legacy link',
+            'target_url_override' => '/en/legacy',
+            'sort_order' => 10,
+            'is_featured' => false,
+            'is_enabled' => true,
+        ]);
+        TopicProfileSeoMeta::query()->create([
+            'profile_id' => (int) $topic->id,
+            'seo_title' => 'Legacy title',
+            'seo_description' => 'Legacy description',
+        ]);
+        TopicProfileRevision::query()->create([
+            'profile_id' => (int) $topic->id,
+            'revision_no' => 1,
+            'snapshot_json' => ['title' => 'Legacy MBTI'],
+            'note' => 'seed',
+            'created_at' => now()->subDay(),
+        ]);
+
+        $this->artisan('topics:import-local-baseline', [
+            '--locale' => ['en'],
+            '--topic' => ['mbti'],
+            '--upsert' => true,
+            '--status' => 'published',
+            '--source-dir' => 'tests/Fixtures/topic_baseline',
+        ])->assertExitCode(0);
+
+        $topic->refresh();
+
+        $this->assertSame('MBTI Topic Cluster', $topic->title);
+        $this->assertTrue((bool) $topic->is_indexable);
+        $this->assertSame(10, (int) $topic->sort_order);
+        $this->assertSame(3, TopicProfileSection::query()->where('profile_id', (int) $topic->id)->count());
+        $this->assertSame(4, TopicProfileEntry::query()->where('profile_id', (int) $topic->id)->count());
+        $this->assertSame(
+            'MBTI topic hub',
+            TopicProfileSeoMeta::query()->where('profile_id', (int) $topic->id)->firstOrFail()->seo_title,
+        );
+        $this->assertSame(
+            2,
+            TopicProfileRevision::query()->where('profile_id', (int) $topic->id)->max('revision_no'),
+        );
+
+        $this->artisan('topics:import-local-baseline', [
+            '--locale' => ['en'],
+            '--topic' => ['mbti'],
+            '--upsert' => true,
+            '--status' => 'published',
+            '--source-dir' => 'tests/Fixtures/topic_baseline',
+        ])->assertExitCode(0);
+
+        $this->assertSame(
+            2,
+            TopicProfileRevision::query()->where('profile_id', (int) $topic->id)->count(),
+        );
+    }
+
+    public function test_locale_and_topic_filters_limit_import_scope(): void
+    {
+        $this->artisan('topics:import-local-baseline', [
+            '--locale' => ['zh-CN'],
+            '--topic' => ['big-five'],
+            '--status' => 'draft',
+            '--source-dir' => 'tests/Fixtures/topic_baseline',
+        ])->assertExitCode(0);
+
+        $this->assertSame(1, TopicProfile::query()->count());
+
+        $profile = TopicProfile::query()->firstOrFail();
+        $this->assertSame('big-five', $profile->topic_code);
+        $this->assertSame('zh-CN', $profile->locale);
+    }
+
+    public function test_invalid_baseline_fails_with_non_zero_exit_code(): void
+    {
+        $sourceDir = base_path('tests/Fixtures/topic_baseline_invalid');
+
+        File::deleteDirectory($sourceDir);
+        File::ensureDirectoryExists($sourceDir);
+        File::put($sourceDir.'/mbti.en.json', json_encode([
+            'meta' => [
+                'schema_version' => 'v1',
+                'topic_code' => 'mbti',
+                'locale' => 'en',
+                'source' => 'test fixture',
+                'generated_at' => '2026-03-08T00:00:00Z',
+            ],
+            'profile' => [
+                'slug' => 'mbti',
+                'title' => 'MBTI Topic Cluster',
+                'status' => 'published',
+                'is_public' => true,
+                'is_indexable' => true,
+            ],
+            'sections' => [
+                [
+                    'section_key' => 'not-allowed',
+                    'render_variant' => 'rich_text',
+                    'body_md' => 'bad',
+                    'sort_order' => 10,
+                    'is_enabled' => true,
+                ],
+            ],
+            'entries' => [],
+            'seo_meta' => [],
+        ], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES | JSON_PRETTY_PRINT));
+
+        $this->artisan('topics:import-local-baseline', [
+            '--source-dir' => 'tests/Fixtures/topic_baseline_invalid',
+        ])
+            ->assertExitCode(1);
+
+        $this->assertSame(0, TopicProfile::query()->count());
+
+        File::deleteDirectory($sourceDir);
+    }
+
+    public function test_unresolved_targets_do_not_block_import(): void
+    {
+        $this->artisan('topics:import-local-baseline', [
+            '--locale' => ['en'],
+            '--topic' => ['mbti'],
+            '--status' => 'published',
+            '--source-dir' => 'tests/Fixtures/topic_baseline',
+        ])->assertExitCode(0);
+
+        $topic = TopicProfile::query()->withoutGlobalScopes()
+            ->where('topic_code', 'mbti')
+            ->where('locale', 'en')
+            ->firstOrFail();
+
+        $entries = TopicProfileEntry::query()
+            ->where('profile_id', (int) $topic->id)
+            ->orderBy('sort_order')
+            ->get();
+
+        $this->assertCount(4, $entries);
+        $this->assertSame('scale', $entries[0]->entry_type);
+        $this->assertSame('personality_profile', $entries[1]->entry_type);
+        $this->assertSame('custom_link', $entries[2]->entry_type);
+    }
+
+    private function purgeTopicTables(): void
+    {
+        TopicProfileRevision::query()->delete();
+        TopicProfileSeoMeta::query()->delete();
+        TopicProfileEntry::query()->delete();
+        TopicProfileSection::query()->delete();
+        TopicProfile::query()->withoutGlobalScopes()->delete();
+    }
+}

--- a/backend/tests/Fixtures/topic_baseline/big-five.en.json
+++ b/backend/tests/Fixtures/topic_baseline/big-five.en.json
@@ -1,0 +1,91 @@
+{
+    "meta": {
+        "schema_version": "v1",
+        "topic_code": "big-five",
+        "locale": "en",
+        "source": "fap-web topics baseline",
+        "generated_at": "2026-03-08T00:00:00Z"
+    },
+    "profile": {
+        "slug": "big-five",
+        "title": "Big Five Topic Cluster",
+        "subtitle": "Group Big Five explainers, career-decision guides, and trait-based recommendation pages for stronger SEO clusters.",
+        "excerpt": "Start here if you want to connect the OCEAN model with practical career decisions and trait-by-trait recommendation content.",
+        "hero_kicker": null,
+        "hero_quote": null,
+        "cover_image_url": null,
+        "status": "published",
+        "is_public": true,
+        "is_indexable": true,
+        "published_at": null,
+        "scheduled_at": null,
+        "sort_order": 20
+    },
+    "sections": [
+        {
+            "section_key": "overview",
+            "title": null,
+            "render_variant": "rich_text",
+            "body_md": "Start here if you want to connect the OCEAN model with practical career decisions and trait-by-trait recommendation content.",
+            "body_html": null,
+            "payload_json": null,
+            "sort_order": 10,
+            "is_enabled": true
+        },
+        {
+            "section_key": "why_it_matters",
+            "title": null,
+            "render_variant": "callout",
+            "body_md": "Group Big Five explainers, career-decision guides, and trait-based recommendation pages for stronger SEO clusters.",
+            "body_html": null,
+            "payload_json": null,
+            "sort_order": 20,
+            "is_enabled": true
+        }
+    ],
+    "entries": [
+        {
+            "entry_type": "scale",
+            "group_key": "featured",
+            "target_key": "BIG5_OCEAN",
+            "target_locale": null,
+            "title_override": "Take the Big Five test",
+            "excerpt_override": "Measure your Openness, Conscientiousness, Extraversion, Agreeableness, and Neuroticism in one assessment.",
+            "badge_label": "Test",
+            "cta_label": "Take the test",
+            "target_url_override": null,
+            "payload_json": null,
+            "sort_order": 10,
+            "is_featured": true,
+            "is_enabled": true
+        },
+        {
+            "entry_type": "custom_link",
+            "group_key": "related",
+            "target_key": "big5-for-career-decisions",
+            "target_locale": "en",
+            "title_override": "Using Big Five for Career Decisions",
+            "excerpt_override": "Actionable framework to improve decision quality and execution in career development.",
+            "badge_label": "Career guide",
+            "cta_label": "Read",
+            "target_url_override": "/en/career/guides/big5-for-career-decisions",
+            "payload_json": null,
+            "sort_order": 20,
+            "is_featured": false,
+            "is_enabled": true
+        }
+    ],
+    "seo_meta": {
+        "seo_title": "Big Five topic hub",
+        "seo_description": "Group Big Five explainers, career-decision guides, and trait-based recommendation pages for stronger SEO clusters.",
+        "canonical_url": null,
+        "og_title": null,
+        "og_description": null,
+        "og_image_url": null,
+        "twitter_title": null,
+        "twitter_description": null,
+        "twitter_image_url": null,
+        "robots": null,
+        "jsonld_overrides_json": null
+    }
+}

--- a/backend/tests/Fixtures/topic_baseline/big-five.zh-CN.json
+++ b/backend/tests/Fixtures/topic_baseline/big-five.zh-CN.json
@@ -1,0 +1,91 @@
+{
+    "meta": {
+        "schema_version": "v1",
+        "topic_code": "big-five",
+        "locale": "zh-CN",
+        "source": "fap-web topics baseline",
+        "generated_at": "2026-03-08T00:00:00Z"
+    },
+    "profile": {
+        "slug": "big-five",
+        "title": "大五人格主题内容聚合",
+        "subtitle": "聚合大五人格文章、职业决策指南和特质推荐页面，形成更完整的 SEO 主题簇。",
+        "excerpt": "如果你想把 OCEAN 模型与职业决策、分特质职业建议联系起来，可以从这里展开阅读。",
+        "hero_kicker": null,
+        "hero_quote": null,
+        "cover_image_url": null,
+        "status": "published",
+        "is_public": true,
+        "is_indexable": true,
+        "published_at": null,
+        "scheduled_at": null,
+        "sort_order": 20
+    },
+    "sections": [
+        {
+            "section_key": "overview",
+            "title": null,
+            "render_variant": "rich_text",
+            "body_md": "如果你想把 OCEAN 模型与职业决策、分特质职业建议联系起来，可以从这里展开阅读。",
+            "body_html": null,
+            "payload_json": null,
+            "sort_order": 10,
+            "is_enabled": true
+        },
+        {
+            "section_key": "why_it_matters",
+            "title": null,
+            "render_variant": "callout",
+            "body_md": "聚合大五人格文章、职业决策指南和特质推荐页面，形成更完整的 SEO 主题簇。",
+            "body_html": null,
+            "payload_json": null,
+            "sort_order": 20,
+            "is_enabled": true
+        }
+    ],
+    "entries": [
+        {
+            "entry_type": "scale",
+            "group_key": "featured",
+            "target_key": "BIG5_OCEAN",
+            "target_locale": null,
+            "title_override": "开始大五人格测试",
+            "excerpt_override": "测量开放性、尽责性、外倾性、宜人性与神经质五个维度。",
+            "badge_label": "测试",
+            "cta_label": "开始测试",
+            "target_url_override": null,
+            "payload_json": null,
+            "sort_order": 10,
+            "is_featured": true,
+            "is_enabled": true
+        },
+        {
+            "entry_type": "custom_link",
+            "group_key": "related",
+            "target_key": "big5-for-career-decisions",
+            "target_locale": "zh-CN",
+            "title_override": "如何用大五人格做职业决策",
+            "excerpt_override": "用于提升职业决策质量与执行结果的实操框架。",
+            "badge_label": "职业指南",
+            "cta_label": "阅读",
+            "target_url_override": "/zh/career/guides/big5-for-career-decisions",
+            "payload_json": null,
+            "sort_order": 20,
+            "is_featured": false,
+            "is_enabled": true
+        }
+    ],
+    "seo_meta": {
+        "seo_title": "大五人格主题中心",
+        "seo_description": "聚合大五人格文章、职业决策指南和特质推荐页面，形成更完整的 SEO 主题簇。",
+        "canonical_url": null,
+        "og_title": null,
+        "og_description": null,
+        "og_image_url": null,
+        "twitter_title": null,
+        "twitter_description": null,
+        "twitter_image_url": null,
+        "robots": null,
+        "jsonld_overrides_json": null
+    }
+}

--- a/backend/tests/Fixtures/topic_baseline/mbti.en.json
+++ b/backend/tests/Fixtures/topic_baseline/mbti.en.json
@@ -1,0 +1,131 @@
+{
+    "meta": {
+        "schema_version": "v1",
+        "topic_code": "mbti",
+        "locale": "en",
+        "source": "fap-web topics baseline",
+        "generated_at": "2026-03-08T00:00:00Z"
+    },
+    "profile": {
+        "slug": "mbti",
+        "title": "MBTI Topic Cluster",
+        "subtitle": "Connect MBTI articles, career guides, and recommendation profiles in one internal-linking hub.",
+        "excerpt": "Use this cluster when you want one page that connects MBTI interpretation, career-fit guidance, and personality-led next steps.",
+        "hero_kicker": null,
+        "hero_quote": null,
+        "cover_image_url": null,
+        "status": "published",
+        "is_public": true,
+        "is_indexable": true,
+        "published_at": null,
+        "scheduled_at": null,
+        "sort_order": 10
+    },
+    "sections": [
+        {
+            "section_key": "overview",
+            "title": null,
+            "render_variant": "rich_text",
+            "body_md": "Use this cluster when you want one page that connects MBTI interpretation, career-fit guidance, and personality-led next steps.",
+            "body_html": null,
+            "payload_json": null,
+            "sort_order": 10,
+            "is_enabled": true
+        },
+        {
+            "section_key": "why_it_matters",
+            "title": null,
+            "render_variant": "callout",
+            "body_md": "Connect MBTI articles, career guides, and recommendation profiles in one internal-linking hub.",
+            "body_html": null,
+            "payload_json": null,
+            "sort_order": 20,
+            "is_enabled": true
+        },
+        {
+            "section_key": "related_topics_intro",
+            "title": "Related personality profiles",
+            "render_variant": "callout",
+            "body_md": null,
+            "body_html": null,
+            "payload_json": null,
+            "sort_order": 30,
+            "is_enabled": true
+        }
+    ],
+    "entries": [
+        {
+            "entry_type": "scale",
+            "group_key": "featured",
+            "target_key": "MBTI",
+            "target_locale": null,
+            "title_override": "Take the MBTI test",
+            "excerpt_override": "Discover your MBTI profile across 16 personality types with a structured assessment.",
+            "badge_label": "Test",
+            "cta_label": "Take the test",
+            "target_url_override": null,
+            "payload_json": null,
+            "sort_order": 10,
+            "is_featured": true,
+            "is_enabled": true
+        },
+        {
+            "entry_type": "personality_profile",
+            "group_key": "personalities",
+            "target_key": "INTJ",
+            "target_locale": "en",
+            "title_override": null,
+            "excerpt_override": null,
+            "badge_label": "Personality",
+            "cta_label": "Explore",
+            "target_url_override": null,
+            "payload_json": null,
+            "sort_order": 20,
+            "is_featured": false,
+            "is_enabled": true
+        },
+        {
+            "entry_type": "custom_link",
+            "group_key": "related",
+            "target_key": "from-mbti-to-job-fit",
+            "target_locale": "en",
+            "title_override": "From MBTI to Job Fit",
+            "excerpt_override": "Actionable framework to improve decision quality and execution in career development.",
+            "badge_label": "Career guide",
+            "cta_label": "Read",
+            "target_url_override": "/en/career/guides/from-mbti-to-job-fit",
+            "payload_json": null,
+            "sort_order": 30,
+            "is_featured": false,
+            "is_enabled": true
+        },
+        {
+            "entry_type": "custom_link",
+            "group_key": "related",
+            "target_key": "how-to-find-right-career-direction",
+            "target_locale": "en",
+            "title_override": "How to Find the Right Career Direction",
+            "excerpt_override": "Actionable framework to improve decision quality and execution in career development.",
+            "badge_label": "Career guide",
+            "cta_label": "Read",
+            "target_url_override": "/en/career/guides/how-to-find-right-career-direction",
+            "payload_json": null,
+            "sort_order": 40,
+            "is_featured": false,
+            "is_enabled": true
+        }
+    ],
+    "seo_meta": {
+        "seo_title": "MBTI topic hub",
+        "seo_description": "Connect MBTI articles, career guides, and recommendation profiles in one internal-linking hub.",
+        "canonical_url": null,
+        "og_title": null,
+        "og_description": null,
+        "og_image_url": null,
+        "twitter_title": null,
+        "twitter_description": null,
+        "twitter_image_url": null,
+        "robots": null,
+        "jsonld_overrides_json": null
+    }
+}

--- a/backend/tests/Fixtures/topic_baseline/mbti.zh-CN.json
+++ b/backend/tests/Fixtures/topic_baseline/mbti.zh-CN.json
@@ -1,0 +1,131 @@
+{
+    "meta": {
+        "schema_version": "v1",
+        "topic_code": "mbti",
+        "locale": "zh-CN",
+        "source": "fap-web topics baseline",
+        "generated_at": "2026-03-08T00:00:00Z"
+    },
+    "profile": {
+        "slug": "mbti",
+        "title": "MBTI 主题内容聚合",
+        "subtitle": "把 MBTI 文章、职业发展内容与推荐画像聚合到一个内部链接中心。",
+        "excerpt": "当你希望把 MBTI 解读、职业匹配和后续行动放到同一个内容路径里时，从这个主题页开始。",
+        "hero_kicker": null,
+        "hero_quote": null,
+        "cover_image_url": null,
+        "status": "published",
+        "is_public": true,
+        "is_indexable": true,
+        "published_at": null,
+        "scheduled_at": null,
+        "sort_order": 10
+    },
+    "sections": [
+        {
+            "section_key": "overview",
+            "title": null,
+            "render_variant": "rich_text",
+            "body_md": "当你希望把 MBTI 解读、职业匹配和后续行动放到同一个内容路径里时，从这个主题页开始。",
+            "body_html": null,
+            "payload_json": null,
+            "sort_order": 10,
+            "is_enabled": true
+        },
+        {
+            "section_key": "why_it_matters",
+            "title": null,
+            "render_variant": "callout",
+            "body_md": "把 MBTI 文章、职业发展内容与推荐画像聚合到一个内部链接中心。",
+            "body_html": null,
+            "payload_json": null,
+            "sort_order": 20,
+            "is_enabled": true
+        },
+        {
+            "section_key": "related_topics_intro",
+            "title": "相关人格画像",
+            "render_variant": "callout",
+            "body_md": null,
+            "body_html": null,
+            "payload_json": null,
+            "sort_order": 30,
+            "is_enabled": true
+        }
+    ],
+    "entries": [
+        {
+            "entry_type": "scale",
+            "group_key": "featured",
+            "target_key": "MBTI",
+            "target_locale": null,
+            "title_override": "开始 MBTI 性格测试",
+            "excerpt_override": "探索你的 16 型人格偏好，并获得结构化类型解读。",
+            "badge_label": "测试",
+            "cta_label": "开始测试",
+            "target_url_override": null,
+            "payload_json": null,
+            "sort_order": 10,
+            "is_featured": true,
+            "is_enabled": true
+        },
+        {
+            "entry_type": "personality_profile",
+            "group_key": "personalities",
+            "target_key": "INTJ",
+            "target_locale": "zh-CN",
+            "title_override": null,
+            "excerpt_override": null,
+            "badge_label": "人格",
+            "cta_label": "查看",
+            "target_url_override": null,
+            "payload_json": null,
+            "sort_order": 20,
+            "is_featured": false,
+            "is_enabled": true
+        },
+        {
+            "entry_type": "custom_link",
+            "group_key": "related",
+            "target_key": "from-mbti-to-job-fit",
+            "target_locale": "zh-CN",
+            "title_override": "如何将 MBTI 用于职业匹配",
+            "excerpt_override": "用于提升职业决策质量与执行结果的实操框架。",
+            "badge_label": "职业指南",
+            "cta_label": "阅读",
+            "target_url_override": "/zh/career/guides/from-mbti-to-job-fit",
+            "payload_json": null,
+            "sort_order": 30,
+            "is_featured": false,
+            "is_enabled": true
+        },
+        {
+            "entry_type": "custom_link",
+            "group_key": "related",
+            "target_key": "how-to-find-right-career-direction",
+            "target_locale": "zh-CN",
+            "title_override": "如何找到适合自己的职业方向",
+            "excerpt_override": "用于提升职业决策质量与执行结果的实操框架。",
+            "badge_label": "职业指南",
+            "cta_label": "阅读",
+            "target_url_override": "/zh/career/guides/how-to-find-right-career-direction",
+            "payload_json": null,
+            "sort_order": 40,
+            "is_featured": false,
+            "is_enabled": true
+        }
+    ],
+    "seo_meta": {
+        "seo_title": "MBTI 主题中心",
+        "seo_description": "把 MBTI 文章、职业发展内容与推荐画像聚合到一个内部链接中心。",
+        "canonical_url": null,
+        "og_title": null,
+        "og_description": null,
+        "og_image_url": null,
+        "twitter_title": null,
+        "twitter_description": null,
+        "twitter_image_url": null,
+        "robots": null,
+        "jsonld_overrides_json": null
+    }
+}

--- a/content_baselines/topics/big-five.en.json
+++ b/content_baselines/topics/big-five.en.json
@@ -1,0 +1,91 @@
+{
+    "meta": {
+        "schema_version": "v1",
+        "topic_code": "big-five",
+        "locale": "en",
+        "source": "fap-web topics baseline",
+        "generated_at": "2026-03-08T00:00:00Z"
+    },
+    "profile": {
+        "slug": "big-five",
+        "title": "Big Five Topic Cluster",
+        "subtitle": "Group Big Five explainers, career-decision guides, and trait-based recommendation pages for stronger SEO clusters.",
+        "excerpt": "Start here if you want to connect the OCEAN model with practical career decisions and trait-by-trait recommendation content.",
+        "hero_kicker": null,
+        "hero_quote": null,
+        "cover_image_url": null,
+        "status": "published",
+        "is_public": true,
+        "is_indexable": true,
+        "published_at": null,
+        "scheduled_at": null,
+        "sort_order": 20
+    },
+    "sections": [
+        {
+            "section_key": "overview",
+            "title": null,
+            "render_variant": "rich_text",
+            "body_md": "Start here if you want to connect the OCEAN model with practical career decisions and trait-by-trait recommendation content.",
+            "body_html": null,
+            "payload_json": null,
+            "sort_order": 10,
+            "is_enabled": true
+        },
+        {
+            "section_key": "why_it_matters",
+            "title": null,
+            "render_variant": "callout",
+            "body_md": "Group Big Five explainers, career-decision guides, and trait-based recommendation pages for stronger SEO clusters.",
+            "body_html": null,
+            "payload_json": null,
+            "sort_order": 20,
+            "is_enabled": true
+        }
+    ],
+    "entries": [
+        {
+            "entry_type": "scale",
+            "group_key": "featured",
+            "target_key": "BIG5_OCEAN",
+            "target_locale": null,
+            "title_override": "Take the Big Five test",
+            "excerpt_override": "Measure your Openness, Conscientiousness, Extraversion, Agreeableness, and Neuroticism in one assessment.",
+            "badge_label": "Test",
+            "cta_label": "Take the test",
+            "target_url_override": null,
+            "payload_json": null,
+            "sort_order": 10,
+            "is_featured": true,
+            "is_enabled": true
+        },
+        {
+            "entry_type": "custom_link",
+            "group_key": "related",
+            "target_key": "big5-for-career-decisions",
+            "target_locale": "en",
+            "title_override": "Using Big Five for Career Decisions",
+            "excerpt_override": "Actionable framework to improve decision quality and execution in career development.",
+            "badge_label": "Career guide",
+            "cta_label": "Read",
+            "target_url_override": "/en/career/guides/big5-for-career-decisions",
+            "payload_json": null,
+            "sort_order": 20,
+            "is_featured": false,
+            "is_enabled": true
+        }
+    ],
+    "seo_meta": {
+        "seo_title": "Big Five topic hub",
+        "seo_description": "Group Big Five explainers, career-decision guides, and trait-based recommendation pages for stronger SEO clusters.",
+        "canonical_url": null,
+        "og_title": null,
+        "og_description": null,
+        "og_image_url": null,
+        "twitter_title": null,
+        "twitter_description": null,
+        "twitter_image_url": null,
+        "robots": null,
+        "jsonld_overrides_json": null
+    }
+}

--- a/content_baselines/topics/big-five.zh-CN.json
+++ b/content_baselines/topics/big-five.zh-CN.json
@@ -1,0 +1,91 @@
+{
+    "meta": {
+        "schema_version": "v1",
+        "topic_code": "big-five",
+        "locale": "zh-CN",
+        "source": "fap-web topics baseline",
+        "generated_at": "2026-03-08T00:00:00Z"
+    },
+    "profile": {
+        "slug": "big-five",
+        "title": "大五人格主题内容聚合",
+        "subtitle": "聚合大五人格文章、职业决策指南和特质推荐页面，形成更完整的 SEO 主题簇。",
+        "excerpt": "如果你想把 OCEAN 模型与职业决策、分特质职业建议联系起来，可以从这里展开阅读。",
+        "hero_kicker": null,
+        "hero_quote": null,
+        "cover_image_url": null,
+        "status": "published",
+        "is_public": true,
+        "is_indexable": true,
+        "published_at": null,
+        "scheduled_at": null,
+        "sort_order": 20
+    },
+    "sections": [
+        {
+            "section_key": "overview",
+            "title": null,
+            "render_variant": "rich_text",
+            "body_md": "如果你想把 OCEAN 模型与职业决策、分特质职业建议联系起来，可以从这里展开阅读。",
+            "body_html": null,
+            "payload_json": null,
+            "sort_order": 10,
+            "is_enabled": true
+        },
+        {
+            "section_key": "why_it_matters",
+            "title": null,
+            "render_variant": "callout",
+            "body_md": "聚合大五人格文章、职业决策指南和特质推荐页面，形成更完整的 SEO 主题簇。",
+            "body_html": null,
+            "payload_json": null,
+            "sort_order": 20,
+            "is_enabled": true
+        }
+    ],
+    "entries": [
+        {
+            "entry_type": "scale",
+            "group_key": "featured",
+            "target_key": "BIG5_OCEAN",
+            "target_locale": null,
+            "title_override": "开始大五人格测试",
+            "excerpt_override": "测量开放性、尽责性、外倾性、宜人性与神经质五个维度。",
+            "badge_label": "测试",
+            "cta_label": "开始测试",
+            "target_url_override": null,
+            "payload_json": null,
+            "sort_order": 10,
+            "is_featured": true,
+            "is_enabled": true
+        },
+        {
+            "entry_type": "custom_link",
+            "group_key": "related",
+            "target_key": "big5-for-career-decisions",
+            "target_locale": "zh-CN",
+            "title_override": "如何用大五人格做职业决策",
+            "excerpt_override": "用于提升职业决策质量与执行结果的实操框架。",
+            "badge_label": "职业指南",
+            "cta_label": "阅读",
+            "target_url_override": "/zh/career/guides/big5-for-career-decisions",
+            "payload_json": null,
+            "sort_order": 20,
+            "is_featured": false,
+            "is_enabled": true
+        }
+    ],
+    "seo_meta": {
+        "seo_title": "大五人格主题中心",
+        "seo_description": "聚合大五人格文章、职业决策指南和特质推荐页面，形成更完整的 SEO 主题簇。",
+        "canonical_url": null,
+        "og_title": null,
+        "og_description": null,
+        "og_image_url": null,
+        "twitter_title": null,
+        "twitter_description": null,
+        "twitter_image_url": null,
+        "robots": null,
+        "jsonld_overrides_json": null
+    }
+}

--- a/content_baselines/topics/iq-eq.en.json
+++ b/content_baselines/topics/iq-eq.en.json
@@ -1,0 +1,106 @@
+{
+    "meta": {
+        "schema_version": "v1",
+        "topic_code": "iq-eq",
+        "locale": "en",
+        "source": "fap-web topics baseline",
+        "generated_at": "2026-03-08T00:00:00Z"
+    },
+    "profile": {
+        "slug": "iq-eq",
+        "title": "IQ & EQ Topic Cluster",
+        "subtitle": "Bring together cognitive, emotional, and career-execution content around decision quality at work.",
+        "excerpt": "This cluster helps readers move from IQ and EQ test output into better communication, judgment, and career execution habits.",
+        "hero_kicker": null,
+        "hero_quote": null,
+        "cover_image_url": null,
+        "status": "published",
+        "is_public": true,
+        "is_indexable": true,
+        "published_at": null,
+        "scheduled_at": null,
+        "sort_order": 30
+    },
+    "sections": [
+        {
+            "section_key": "overview",
+            "title": null,
+            "render_variant": "rich_text",
+            "body_md": "This cluster helps readers move from IQ and EQ test output into better communication, judgment, and career execution habits.",
+            "body_html": null,
+            "payload_json": null,
+            "sort_order": 10,
+            "is_enabled": true
+        },
+        {
+            "section_key": "why_it_matters",
+            "title": null,
+            "render_variant": "callout",
+            "body_md": "Bring together cognitive, emotional, and career-execution content around decision quality at work.",
+            "body_html": null,
+            "payload_json": null,
+            "sort_order": 20,
+            "is_enabled": true
+        }
+    ],
+    "entries": [
+        {
+            "entry_type": "scale",
+            "group_key": "featured",
+            "target_key": "IQ_RAVEN",
+            "target_locale": null,
+            "title_override": "IQ Test (Intelligence Quotient Assessment)",
+            "excerpt_override": "Assess your matrix reasoning, pattern recognition, and abstract problem-solving ability.",
+            "badge_label": "Test",
+            "cta_label": "Take the test",
+            "target_url_override": null,
+            "payload_json": null,
+            "sort_order": 10,
+            "is_featured": true,
+            "is_enabled": true
+        },
+        {
+            "entry_type": "scale",
+            "group_key": "tests",
+            "target_key": "EQ_60",
+            "target_locale": null,
+            "title_override": "EQ Test (Emotional Intelligence Assessment)",
+            "excerpt_override": "Measure emotional awareness, regulation, empathy, and interpersonal communication tendencies.",
+            "badge_label": "Test",
+            "cta_label": "Take the test",
+            "target_url_override": null,
+            "payload_json": null,
+            "sort_order": 20,
+            "is_featured": false,
+            "is_enabled": true
+        },
+        {
+            "entry_type": "custom_link",
+            "group_key": "related",
+            "target_key": "iq-eq-balance-at-work",
+            "target_locale": "en",
+            "title_override": "Balancing IQ and EQ at Work",
+            "excerpt_override": "Actionable framework to improve decision quality and execution in career development.",
+            "badge_label": "Career guide",
+            "cta_label": "Read",
+            "target_url_override": "/en/career/guides/iq-eq-balance-at-work",
+            "payload_json": null,
+            "sort_order": 30,
+            "is_featured": false,
+            "is_enabled": true
+        }
+    ],
+    "seo_meta": {
+        "seo_title": "IQ & EQ topic hub",
+        "seo_description": "Bring together cognitive, emotional, and career-execution content around decision quality at work.",
+        "canonical_url": null,
+        "og_title": null,
+        "og_description": null,
+        "og_image_url": null,
+        "twitter_title": null,
+        "twitter_description": null,
+        "twitter_image_url": null,
+        "robots": null,
+        "jsonld_overrides_json": null
+    }
+}

--- a/content_baselines/topics/iq-eq.zh-CN.json
+++ b/content_baselines/topics/iq-eq.zh-CN.json
@@ -1,0 +1,106 @@
+{
+    "meta": {
+        "schema_version": "v1",
+        "topic_code": "iq-eq",
+        "locale": "zh-CN",
+        "source": "fap-web topics baseline",
+        "generated_at": "2026-03-08T00:00:00Z"
+    },
+    "profile": {
+        "slug": "iq-eq",
+        "title": "IQ 与 EQ 主题内容聚合",
+        "subtitle": "把认知能力、情绪能力与职业执行相关内容放到同一个内容簇里。",
+        "excerpt": "这个主题页帮助读者把 IQ 与 EQ 的测评结果转成更好的沟通、判断和职业执行方式。",
+        "hero_kicker": null,
+        "hero_quote": null,
+        "cover_image_url": null,
+        "status": "published",
+        "is_public": true,
+        "is_indexable": true,
+        "published_at": null,
+        "scheduled_at": null,
+        "sort_order": 30
+    },
+    "sections": [
+        {
+            "section_key": "overview",
+            "title": null,
+            "render_variant": "rich_text",
+            "body_md": "这个主题页帮助读者把 IQ 与 EQ 的测评结果转成更好的沟通、判断和职业执行方式。",
+            "body_html": null,
+            "payload_json": null,
+            "sort_order": 10,
+            "is_enabled": true
+        },
+        {
+            "section_key": "why_it_matters",
+            "title": null,
+            "render_variant": "callout",
+            "body_md": "把认知能力、情绪能力与职业执行相关内容放到同一个内容簇里。",
+            "body_html": null,
+            "payload_json": null,
+            "sort_order": 20,
+            "is_enabled": true
+        }
+    ],
+    "entries": [
+        {
+            "entry_type": "scale",
+            "group_key": "featured",
+            "target_key": "IQ_RAVEN",
+            "target_locale": null,
+            "title_override": "智商（IQ）测试",
+            "excerpt_override": "评估你的矩阵推理、模式识别与抽象问题解决能力。",
+            "badge_label": "测试",
+            "cta_label": "开始测试",
+            "target_url_override": null,
+            "payload_json": null,
+            "sort_order": 10,
+            "is_featured": true,
+            "is_enabled": true
+        },
+        {
+            "entry_type": "scale",
+            "group_key": "tests",
+            "target_key": "EQ_60",
+            "target_locale": null,
+            "title_override": "情商（EQ）测试",
+            "excerpt_override": "测量情绪觉察、情绪调节、共情与人际沟通倾向。",
+            "badge_label": "测试",
+            "cta_label": "开始测试",
+            "target_url_override": null,
+            "payload_json": null,
+            "sort_order": 20,
+            "is_featured": false,
+            "is_enabled": true
+        },
+        {
+            "entry_type": "custom_link",
+            "group_key": "related",
+            "target_key": "iq-eq-balance-at-work",
+            "target_locale": "zh-CN",
+            "title_override": "IQ 与 EQ 如何协同影响职业表现",
+            "excerpt_override": "用于提升职业决策质量与执行结果的实操框架。",
+            "badge_label": "职业指南",
+            "cta_label": "阅读",
+            "target_url_override": "/zh/career/guides/iq-eq-balance-at-work",
+            "payload_json": null,
+            "sort_order": 30,
+            "is_featured": false,
+            "is_enabled": true
+        }
+    ],
+    "seo_meta": {
+        "seo_title": "IQ 与 EQ 主题中心",
+        "seo_description": "把认知能力、情绪能力与职业执行相关内容放到同一个内容簇里。",
+        "canonical_url": null,
+        "og_title": null,
+        "og_description": null,
+        "og_image_url": null,
+        "twitter_title": null,
+        "twitter_description": null,
+        "twitter_image_url": null,
+        "robots": null,
+        "jsonld_overrides_json": null
+    }
+}

--- a/content_baselines/topics/mbti.en.json
+++ b/content_baselines/topics/mbti.en.json
@@ -1,0 +1,131 @@
+{
+    "meta": {
+        "schema_version": "v1",
+        "topic_code": "mbti",
+        "locale": "en",
+        "source": "fap-web topics baseline",
+        "generated_at": "2026-03-08T00:00:00Z"
+    },
+    "profile": {
+        "slug": "mbti",
+        "title": "MBTI Topic Cluster",
+        "subtitle": "Connect MBTI articles, career guides, and recommendation profiles in one internal-linking hub.",
+        "excerpt": "Use this cluster when you want one page that connects MBTI interpretation, career-fit guidance, and personality-led next steps.",
+        "hero_kicker": null,
+        "hero_quote": null,
+        "cover_image_url": null,
+        "status": "published",
+        "is_public": true,
+        "is_indexable": true,
+        "published_at": null,
+        "scheduled_at": null,
+        "sort_order": 10
+    },
+    "sections": [
+        {
+            "section_key": "overview",
+            "title": null,
+            "render_variant": "rich_text",
+            "body_md": "Use this cluster when you want one page that connects MBTI interpretation, career-fit guidance, and personality-led next steps.",
+            "body_html": null,
+            "payload_json": null,
+            "sort_order": 10,
+            "is_enabled": true
+        },
+        {
+            "section_key": "why_it_matters",
+            "title": null,
+            "render_variant": "callout",
+            "body_md": "Connect MBTI articles, career guides, and recommendation profiles in one internal-linking hub.",
+            "body_html": null,
+            "payload_json": null,
+            "sort_order": 20,
+            "is_enabled": true
+        },
+        {
+            "section_key": "related_topics_intro",
+            "title": "Related personality profiles",
+            "render_variant": "callout",
+            "body_md": null,
+            "body_html": null,
+            "payload_json": null,
+            "sort_order": 30,
+            "is_enabled": true
+        }
+    ],
+    "entries": [
+        {
+            "entry_type": "scale",
+            "group_key": "featured",
+            "target_key": "MBTI",
+            "target_locale": null,
+            "title_override": "Take the MBTI test",
+            "excerpt_override": "Discover your MBTI profile across 16 personality types with a structured assessment.",
+            "badge_label": "Test",
+            "cta_label": "Take the test",
+            "target_url_override": null,
+            "payload_json": null,
+            "sort_order": 10,
+            "is_featured": true,
+            "is_enabled": true
+        },
+        {
+            "entry_type": "personality_profile",
+            "group_key": "personalities",
+            "target_key": "INTJ",
+            "target_locale": "en",
+            "title_override": null,
+            "excerpt_override": null,
+            "badge_label": "Personality",
+            "cta_label": "Explore",
+            "target_url_override": null,
+            "payload_json": null,
+            "sort_order": 20,
+            "is_featured": false,
+            "is_enabled": true
+        },
+        {
+            "entry_type": "custom_link",
+            "group_key": "related",
+            "target_key": "from-mbti-to-job-fit",
+            "target_locale": "en",
+            "title_override": "From MBTI to Job Fit",
+            "excerpt_override": "Actionable framework to improve decision quality and execution in career development.",
+            "badge_label": "Career guide",
+            "cta_label": "Read",
+            "target_url_override": "/en/career/guides/from-mbti-to-job-fit",
+            "payload_json": null,
+            "sort_order": 30,
+            "is_featured": false,
+            "is_enabled": true
+        },
+        {
+            "entry_type": "custom_link",
+            "group_key": "related",
+            "target_key": "how-to-find-right-career-direction",
+            "target_locale": "en",
+            "title_override": "How to Find the Right Career Direction",
+            "excerpt_override": "Actionable framework to improve decision quality and execution in career development.",
+            "badge_label": "Career guide",
+            "cta_label": "Read",
+            "target_url_override": "/en/career/guides/how-to-find-right-career-direction",
+            "payload_json": null,
+            "sort_order": 40,
+            "is_featured": false,
+            "is_enabled": true
+        }
+    ],
+    "seo_meta": {
+        "seo_title": "MBTI topic hub",
+        "seo_description": "Connect MBTI articles, career guides, and recommendation profiles in one internal-linking hub.",
+        "canonical_url": null,
+        "og_title": null,
+        "og_description": null,
+        "og_image_url": null,
+        "twitter_title": null,
+        "twitter_description": null,
+        "twitter_image_url": null,
+        "robots": null,
+        "jsonld_overrides_json": null
+    }
+}

--- a/content_baselines/topics/mbti.zh-CN.json
+++ b/content_baselines/topics/mbti.zh-CN.json
@@ -1,0 +1,131 @@
+{
+    "meta": {
+        "schema_version": "v1",
+        "topic_code": "mbti",
+        "locale": "zh-CN",
+        "source": "fap-web topics baseline",
+        "generated_at": "2026-03-08T00:00:00Z"
+    },
+    "profile": {
+        "slug": "mbti",
+        "title": "MBTI 主题内容聚合",
+        "subtitle": "把 MBTI 文章、职业发展内容与推荐画像聚合到一个内部链接中心。",
+        "excerpt": "当你希望把 MBTI 解读、职业匹配和后续行动放到同一个内容路径里时，从这个主题页开始。",
+        "hero_kicker": null,
+        "hero_quote": null,
+        "cover_image_url": null,
+        "status": "published",
+        "is_public": true,
+        "is_indexable": true,
+        "published_at": null,
+        "scheduled_at": null,
+        "sort_order": 10
+    },
+    "sections": [
+        {
+            "section_key": "overview",
+            "title": null,
+            "render_variant": "rich_text",
+            "body_md": "当你希望把 MBTI 解读、职业匹配和后续行动放到同一个内容路径里时，从这个主题页开始。",
+            "body_html": null,
+            "payload_json": null,
+            "sort_order": 10,
+            "is_enabled": true
+        },
+        {
+            "section_key": "why_it_matters",
+            "title": null,
+            "render_variant": "callout",
+            "body_md": "把 MBTI 文章、职业发展内容与推荐画像聚合到一个内部链接中心。",
+            "body_html": null,
+            "payload_json": null,
+            "sort_order": 20,
+            "is_enabled": true
+        },
+        {
+            "section_key": "related_topics_intro",
+            "title": "相关人格画像",
+            "render_variant": "callout",
+            "body_md": null,
+            "body_html": null,
+            "payload_json": null,
+            "sort_order": 30,
+            "is_enabled": true
+        }
+    ],
+    "entries": [
+        {
+            "entry_type": "scale",
+            "group_key": "featured",
+            "target_key": "MBTI",
+            "target_locale": null,
+            "title_override": "开始 MBTI 性格测试",
+            "excerpt_override": "探索你的 16 型人格偏好，并获得结构化类型解读。",
+            "badge_label": "测试",
+            "cta_label": "开始测试",
+            "target_url_override": null,
+            "payload_json": null,
+            "sort_order": 10,
+            "is_featured": true,
+            "is_enabled": true
+        },
+        {
+            "entry_type": "personality_profile",
+            "group_key": "personalities",
+            "target_key": "INTJ",
+            "target_locale": "zh-CN",
+            "title_override": null,
+            "excerpt_override": null,
+            "badge_label": "人格",
+            "cta_label": "查看",
+            "target_url_override": null,
+            "payload_json": null,
+            "sort_order": 20,
+            "is_featured": false,
+            "is_enabled": true
+        },
+        {
+            "entry_type": "custom_link",
+            "group_key": "related",
+            "target_key": "from-mbti-to-job-fit",
+            "target_locale": "zh-CN",
+            "title_override": "如何将 MBTI 用于职业匹配",
+            "excerpt_override": "用于提升职业决策质量与执行结果的实操框架。",
+            "badge_label": "职业指南",
+            "cta_label": "阅读",
+            "target_url_override": "/zh/career/guides/from-mbti-to-job-fit",
+            "payload_json": null,
+            "sort_order": 30,
+            "is_featured": false,
+            "is_enabled": true
+        },
+        {
+            "entry_type": "custom_link",
+            "group_key": "related",
+            "target_key": "how-to-find-right-career-direction",
+            "target_locale": "zh-CN",
+            "title_override": "如何找到适合自己的职业方向",
+            "excerpt_override": "用于提升职业决策质量与执行结果的实操框架。",
+            "badge_label": "职业指南",
+            "cta_label": "阅读",
+            "target_url_override": "/zh/career/guides/how-to-find-right-career-direction",
+            "payload_json": null,
+            "sort_order": 40,
+            "is_featured": false,
+            "is_enabled": true
+        }
+    ],
+    "seo_meta": {
+        "seo_title": "MBTI 主题中心",
+        "seo_description": "把 MBTI 文章、职业发展内容与推荐画像聚合到一个内部链接中心。",
+        "canonical_url": null,
+        "og_title": null,
+        "og_description": null,
+        "og_image_url": null,
+        "twitter_title": null,
+        "twitter_description": null,
+        "twitter_image_url": null,
+        "robots": null,
+        "jsonld_overrides_json": null
+    }
+}


### PR DESCRIPTION
Summary
- add a repeatable baseline import for Topics CMS v1
- normalize the current local topic content into committed baseline files and import it into topic profile tables

What changed
- add committed baseline files for topic profiles
- add an Artisan command to import local baseline content into Topics CMS
- add reader/normalizer/importer support for deterministic imports
- add revision creation during baseline import
- add minimal feature coverage for dry-run, create-missing, upsert, and filtering behavior

Design choices
- the import reads from committed baseline files in fap-api, not directly from the sibling frontend repo at runtime
- v1 imports global topic content (org_id=0)
- fixed section keys and entry groups are preserved and validated
- entry references use stable target_key / target_locale
- default import mode is conservative and does not overwrite existing records unless --upsert is used

Why this PR is small and safe
- no frontend changes
- no route changes
- no Filament changes
- no AI generation
- no sitemap changes
- only baseline import groundwork for later Topics CMS rollout

Validation
- `php artisan about`
- `php artisan route:list`
- `php artisan migrate`
- `php artisan test --filter='(Topic|Topics)'`
- `php artisan topics:import-local-baseline --dry-run`
- `php artisan topics:import-local-baseline --locale=en --topic=mbti --status=draft`
- `php artisan topics:import-local-baseline --locale=zh-CN --topic=mbti --dry-run`
- `php artisan topics:import-local-baseline --locale=en --upsert --status=published`
- `bash backend/scripts/ci_verify_mbti.sh`
