### PR TITLE
feat(topics-cms): add topic urls to backend sitemap authority

### DIFF
--- a/backend/app/Services/SEO/SitemapCache.php
+++ b/backend/app/Services/SEO/SitemapCache.php
@@ -6,9 +6,9 @@ use Illuminate\Support\Facades\Cache;
 
 class SitemapCache
 {
-    public const XML_CACHE_KEY = 'seo:sitemap:xml:v3';
+    public const XML_CACHE_KEY = 'seo:sitemap:xml:v4';
 
-    public const ETAG_CACHE_KEY = 'seo:sitemap:etag:v3';
+    public const ETAG_CACHE_KEY = 'seo:sitemap:etag:v4';
 
     public const TTL_SECONDS = 86400;
 

--- a/backend/app/Services/SEO/SitemapGenerator.php
+++ b/backend/app/Services/SEO/SitemapGenerator.php
@@ -3,7 +3,9 @@
 namespace App\Services\SEO;
 
 use App\Models\PersonalityProfile;
+use App\Models\TopicProfile;
 use App\Services\Cms\PersonalityProfileSeoService;
+use App\Services\Cms\TopicProfileSeoService;
 use Illuminate\Support\Carbon;
 use Illuminate\Support\Facades\DB;
 
@@ -13,6 +15,7 @@ class SitemapGenerator
 
     public function __construct(
         private readonly PersonalityProfileSeoService $personalityProfileSeoService,
+        private readonly TopicProfileSeoService $topicProfileSeoService,
     ) {
         $configuredPrefix = trim((string) config('services.seo.tests_url_prefix', ''));
         if ($configuredPrefix === '') {
@@ -29,7 +32,8 @@ class SitemapGenerator
         $urls = array_merge(
             $this->getScaleUrls($locale),
             $this->getArticleUrls($locale),
-            $this->getPersonalityUrls()
+            $this->getPersonalityUrls(),
+            $this->getTopicUrls()
         );
 
         $urls = collect($urls)
@@ -217,6 +221,71 @@ class SitemapGenerator
                 'loc' => $baseUrl.'/'.$segment.'/personality',
                 'lastmod' => $lastmod->toAtomString(),
                 'slug' => 'personality-list:'.$segment,
+                'updated_at' => $lastmod->toDateTimeString(),
+            ];
+        }
+
+        return $urls;
+    }
+
+    private function getTopicUrls(): array
+    {
+        $baseUrl = rtrim((string) config('app.frontend_url', config('app.url', '')), '/');
+        if ($baseUrl === '') {
+            return [];
+        }
+
+        $rows = TopicProfile::query()
+            ->withoutGlobalScopes()
+            ->where('org_id', 0)
+            ->where('status', TopicProfile::STATUS_PUBLISHED)
+            ->where('is_public', true)
+            ->where('is_indexable', true)
+            ->whereIn('locale', TopicProfile::SUPPORTED_LOCALES)
+            ->whereNotNull('slug')
+            ->where('slug', '<>', '')
+            ->where(static function ($query): void {
+                $query->whereNull('published_at')
+                    ->orWhere('published_at', '<=', now());
+            })
+            ->select(['slug', 'locale', 'updated_at', 'published_at'])
+            ->orderBy('locale')
+            ->orderBy('slug')
+            ->get();
+
+        $urls = [];
+        $listLastModified = [];
+
+        foreach ($rows as $row) {
+            $slug = trim((string) $row->slug);
+            $locale = trim((string) $row->locale);
+
+            if ($slug === '' || $locale === '') {
+                continue;
+            }
+
+            $segment = $this->topicProfileSeoService->mapBackendLocaleToFrontendSegment($locale);
+            $lastmod = $row->updated_at
+                ?? $row->published_at
+                ?? now();
+
+            $urls[] = [
+                'loc' => $baseUrl.'/'.$segment.'/topics/'.rawurlencode($slug),
+                'lastmod' => $lastmod->toAtomString(),
+                'slug' => 'topics:'.$segment.':'.$slug,
+                'updated_at' => $lastmod->toDateTimeString(),
+            ];
+
+            if (! isset($listLastModified[$segment]) || $lastmod->gt($listLastModified[$segment])) {
+                $listLastModified[$segment] = $lastmod;
+            }
+        }
+
+        foreach ($listLastModified as $segment => $lastmod) {
+            $urls[] = [
+                'loc' => $baseUrl.'/'.$segment.'/topics',
+                'lastmod' => $lastmod->toAtomString(),
+                'slug' => 'topics-list:'.$segment,
                 'updated_at' => $lastmod->toDateTimeString(),
             ];
         }

--- a/backend/tests/Feature/SEO/SitemapGeneratorTest.php
+++ b/backend/tests/Feature/SEO/SitemapGeneratorTest.php
@@ -3,7 +3,9 @@
 namespace Tests\Feature\SEO;
 
 use App\Models\PersonalityProfile;
+use App\Models\TopicProfile;
 use App\Services\Cms\PersonalityProfileSeoService;
+use App\Services\Cms\TopicProfileSeoService;
 use App\Services\SEO\SitemapGenerator;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Carbon;
@@ -205,6 +207,95 @@ class SitemapGeneratorTest extends TestCase
         $this->assertStringContainsString(data_get($seoService->buildMeta($eligibleZh), 'canonical'), $xml);
     }
 
+    public function test_generate_includes_only_indexable_global_topic_urls_with_locale_aware_paths(): void
+    {
+        config(['app.frontend_url' => 'https://staging.fermatmind.com']);
+
+        $eligibleEn = $this->createTopicProfile([
+            'topic_code' => 'mbti',
+            'slug' => 'mbti',
+            'locale' => 'en',
+            'is_indexable' => true,
+            'published_at' => Carbon::create(2026, 3, 7, 9, 0, 0, 'UTC'),
+            'updated_at' => Carbon::create(2026, 3, 7, 10, 0, 0, 'UTC'),
+        ]);
+
+        $eligibleZh = $this->createTopicProfile([
+            'topic_code' => 'mbti',
+            'slug' => 'mbti',
+            'locale' => 'zh-CN',
+            'title' => 'MBTI 主题',
+            'subtitle' => '理解人格偏好与类型框架。',
+            'excerpt' => '探索 MBTI 概念、类型档案与测试入口。',
+            'is_indexable' => true,
+            'published_at' => Carbon::create(2026, 3, 7, 11, 0, 0, 'UTC'),
+            'updated_at' => Carbon::create(2026, 3, 7, 12, 0, 0, 'UTC'),
+        ]);
+
+        $this->createTopicProfile([
+            'topic_code' => 'big-five',
+            'slug' => 'big-five',
+            'locale' => 'en',
+            'status' => 'draft',
+            'updated_at' => Carbon::create(2026, 3, 7, 12, 30, 0, 'UTC'),
+        ]);
+        $this->createTopicProfile([
+            'topic_code' => 'enneagram',
+            'slug' => 'enneagram',
+            'locale' => 'en',
+            'is_public' => false,
+            'updated_at' => Carbon::create(2026, 3, 7, 12, 45, 0, 'UTC'),
+        ]);
+        $this->createTopicProfile([
+            'topic_code' => 'self-awareness',
+            'slug' => 'self-awareness',
+            'locale' => 'en',
+            'is_indexable' => false,
+            'updated_at' => Carbon::create(2026, 3, 7, 13, 0, 0, 'UTC'),
+        ]);
+        $this->createTopicProfile([
+            'org_id' => 9,
+            'topic_code' => 'eq',
+            'slug' => 'eq',
+            'locale' => 'en',
+            'updated_at' => Carbon::create(2026, 3, 7, 13, 15, 0, 'UTC'),
+        ]);
+        $this->createTopicProfile([
+            'topic_code' => 'disc',
+            'slug' => 'disc',
+            'locale' => 'fr',
+            'updated_at' => Carbon::create(2026, 3, 7, 13, 30, 0, 'UTC'),
+        ]);
+
+        $payload = app(SitemapGenerator::class)->generate();
+        $xml = (string) ($payload['xml'] ?? '');
+
+        $this->assertStringContainsString('https://staging.fermatmind.com/en/topics', $xml);
+        $this->assertStringContainsString('https://staging.fermatmind.com/zh/topics', $xml);
+        $this->assertStringContainsString('https://staging.fermatmind.com/en/topics/mbti', $xml);
+        $this->assertStringContainsString('https://staging.fermatmind.com/zh/topics/mbti', $xml);
+
+        $this->assertStringNotContainsString('https://staging.fermatmind.com/en/topics/big-five', $xml);
+        $this->assertStringNotContainsString('https://staging.fermatmind.com/en/topics/enneagram', $xml);
+        $this->assertStringNotContainsString('https://staging.fermatmind.com/en/topics/self-awareness', $xml);
+        $this->assertStringNotContainsString('https://staging.fermatmind.com/en/topics/eq', $xml);
+        $this->assertStringNotContainsString('https://staging.fermatmind.com/fr/topics/disc', $xml);
+
+        $seoService = app(TopicProfileSeoService::class);
+
+        $this->assertSame(
+            data_get($seoService->buildMeta($eligibleEn, 'en'), 'canonical'),
+            data_get($seoService->buildJsonLd($eligibleEn, 'en'), 'mainEntityOfPage')
+        );
+        $this->assertSame(
+            data_get($seoService->buildMeta($eligibleZh, 'zh-CN'), 'canonical'),
+            data_get($seoService->buildJsonLd($eligibleZh, 'zh-CN'), 'mainEntityOfPage')
+        );
+        $this->assertSame('CollectionPage', data_get($seoService->buildJsonLd($eligibleEn, 'en'), '@type'));
+        $this->assertStringContainsString(data_get($seoService->buildMeta($eligibleEn, 'en'), 'canonical'), $xml);
+        $this->assertStringContainsString(data_get($seoService->buildMeta($eligibleZh, 'zh-CN'), 'canonical'), $xml);
+    }
+
     /**
      * @param  array<string, mixed>  $overrides
      */
@@ -226,6 +317,32 @@ class SitemapGeneratorTest extends TestCase
             'published_at' => Carbon::create(2026, 3, 7, 8, 0, 0, 'UTC'),
             'scheduled_at' => null,
             'schema_version' => 'v1',
+            'created_at' => Carbon::create(2026, 3, 7, 8, 0, 0, 'UTC'),
+            'updated_at' => Carbon::create(2026, 3, 7, 8, 0, 0, 'UTC'),
+        ], $overrides));
+    }
+
+    /**
+     * @param  array<string, mixed>  $overrides
+     */
+    private function createTopicProfile(array $overrides = []): TopicProfile
+    {
+        /** @var TopicProfile */
+        return TopicProfile::query()->create(array_merge([
+            'org_id' => 0,
+            'topic_code' => 'mbti',
+            'slug' => 'mbti',
+            'locale' => 'en',
+            'title' => 'MBTI',
+            'subtitle' => 'Understand personality preferences and type dynamics.',
+            'excerpt' => 'Explore MBTI concepts, type profiles, guides, and tests.',
+            'status' => TopicProfile::STATUS_PUBLISHED,
+            'is_public' => true,
+            'is_indexable' => true,
+            'published_at' => Carbon::create(2026, 3, 7, 8, 0, 0, 'UTC'),
+            'scheduled_at' => null,
+            'schema_version' => 'v1',
+            'sort_order' => 0,
             'created_at' => Carbon::create(2026, 3, 7, 8, 0, 0, 'UTC'),
             'updated_at' => Carbon::create(2026, 3, 7, 8, 0, 0, 'UTC'),
         ], $overrides));

--- a/backend/tests/Feature/SEO/SitemapXmlTest.php
+++ b/backend/tests/Feature/SEO/SitemapXmlTest.php
@@ -3,6 +3,7 @@
 namespace Tests\Feature\SEO;
 
 use App\Models\PersonalityProfile;
+use App\Models\TopicProfile;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Carbon;
 use Illuminate\Support\Facades\DB;
@@ -118,6 +119,63 @@ class SitemapXmlTest extends TestCase
             'updated_at' => $nowB,
         ]);
 
+        TopicProfile::query()->create([
+            'org_id' => 0,
+            'topic_code' => 'mbti',
+            'slug' => 'mbti',
+            'locale' => 'en',
+            'title' => 'MBTI',
+            'subtitle' => 'Understand personality preferences and type dynamics.',
+            'excerpt' => 'Explore MBTI concepts, type profiles, guides, and tests.',
+            'status' => TopicProfile::STATUS_PUBLISHED,
+            'is_public' => true,
+            'is_indexable' => true,
+            'published_at' => Carbon::create(2026, 1, 31, 11, 30, 0),
+            'scheduled_at' => null,
+            'schema_version' => 'v1',
+            'sort_order' => 10,
+            'created_at' => $nowB,
+            'updated_at' => $nowB,
+        ]);
+
+        TopicProfile::query()->create([
+            'org_id' => 0,
+            'topic_code' => 'mbti',
+            'slug' => 'mbti',
+            'locale' => 'zh-CN',
+            'title' => 'MBTI 主题',
+            'subtitle' => '理解人格偏好与类型框架。',
+            'excerpt' => '探索 MBTI 概念、类型档案与测试入口。',
+            'status' => TopicProfile::STATUS_PUBLISHED,
+            'is_public' => true,
+            'is_indexable' => true,
+            'published_at' => Carbon::create(2026, 1, 31, 12, 30, 0),
+            'scheduled_at' => null,
+            'schema_version' => 'v1',
+            'sort_order' => 10,
+            'created_at' => $nowB,
+            'updated_at' => $nowB,
+        ]);
+
+        TopicProfile::query()->create([
+            'org_id' => 0,
+            'topic_code' => 'big-five',
+            'slug' => 'big-five',
+            'locale' => 'en',
+            'title' => 'Big Five',
+            'subtitle' => 'Trait dimensions for personality description.',
+            'excerpt' => 'Explore the Big Five model.',
+            'status' => TopicProfile::STATUS_DRAFT,
+            'is_public' => true,
+            'is_indexable' => true,
+            'published_at' => null,
+            'scheduled_at' => null,
+            'schema_version' => 'v1',
+            'sort_order' => 20,
+            'created_at' => $nowB,
+            'updated_at' => $nowB,
+        ]);
+
         $response = $this->get('/sitemap.xml');
 
         $response->assertStatus(200);
@@ -145,6 +203,11 @@ class SitemapXmlTest extends TestCase
         $this->assertStringContainsString('<loc>https://staging.fermatmind.com/zh/personality</loc>', $body);
         $this->assertStringContainsString('<loc>https://staging.fermatmind.com/en/personality/intj</loc>', $body);
         $this->assertStringContainsString('<loc>https://staging.fermatmind.com/zh/personality/intj</loc>', $body);
+        $this->assertStringContainsString('<loc>https://staging.fermatmind.com/en/topics</loc>', $body);
+        $this->assertStringContainsString('<loc>https://staging.fermatmind.com/zh/topics</loc>', $body);
+        $this->assertStringContainsString('<loc>https://staging.fermatmind.com/en/topics/mbti</loc>', $body);
+        $this->assertStringContainsString('<loc>https://staging.fermatmind.com/zh/topics/mbti</loc>', $body);
+        $this->assertStringNotContainsString('<loc>https://staging.fermatmind.com/en/topics/big-five</loc>', $body);
         $this->assertStringContainsString('<changefreq>weekly</changefreq>', $body);
         $this->assertStringContainsString('<priority>0.7</priority>', $body);
         $this->assertStringContainsString('<lastmod>2026-01-30</lastmod>', $body);


### PR DESCRIPTION
Summary
- add Topics CMS list/detail URLs to the current backend sitemap authority
- align backend sitemap output with locale-aware canonical topic URLs

What changed
- extend the current sitemap generator to include topic list/detail URLs
- filter topic URLs to published/public/indexable global topic content only
- harden topic SEO output if needed so canonical and JSON-LD match sitemap URLs
- add minimal sitemap/seo coverage

Design choices
- keep sitemap authority in fap-api because /sitemap.xml is currently served by backend
- use locale-aware frontend URLs (/en/..., /zh/...) as canonical sitemap entries
- keep Topics restricted to global content for v1

Why this PR is small and safe
- no frontend changes
- no write-side API changes
- no Filament changes
- no deploy changes
- only backend sitemap/seo authority work for Topics CMS

Validation
- php artisan about
- php artisan route:list
- php artisan migrate
- php artisan test --filter='(Sitemap|Topic|Topics)'
- bash scripts/export_openapi.sh --check
- local sitemap and seo curl checks
- bash backend/scripts/ci_verify_mbti.sh
