### PR TITLE
fix(v0.3 result): read public results from results table before attempt ownership

### DIFF
--- a/backend/app/Http/Controllers/API/V0_3/AttemptReadController.php
+++ b/backend/app/Http/Controllers/API/V0_3/AttemptReadController.php
@@ -2,11 +2,13 @@
 
 namespace App\Http\Controllers\API\V0_3;
 
+use App\Exceptions\Api\ApiProblemException;
 use App\Http\Controllers\API\V0_3\Concerns\ResolvesAttemptOwnership;
 use App\Http\Controllers\Controller;
+use App\Models\Attempt;
 use App\Models\Result;
-use App\Services\Attempts\AttemptSubmissionService;
 use App\Services\Analytics\EventRecorder;
+use App\Services\Attempts\AttemptSubmissionService;
 use App\Services\Observability\ClinicalComboTelemetry;
 use App\Services\Observability\Sds20Telemetry;
 use App\Services\Report\Pdf\ReportPdfDocumentService;
@@ -20,6 +22,10 @@ use Illuminate\Http\Response;
 class AttemptReadController extends Controller
 {
     use ResolvesAttemptOwnership;
+
+    private const PUBLIC_RESULT_READ_SCALES = ['MBTI', 'BIG5_OCEAN', 'IQ_RAVEN', 'EQ_60'];
+
+    private const SENSITIVE_RESULT_READ_SCALES = ['SDS_20', 'CLINICAL_COMBO_68'];
 
     public function __construct(
         private AttemptSubmissionService $attemptSubmissionService,
@@ -64,12 +70,21 @@ class AttemptReadController extends Controller
     public function result(Request $request, string $id): JsonResponse
     {
         $orgId = $this->orgContext->orgId();
-        $attempt = $this->ownedAttemptQuery($request, $id)->firstOrFail();
+        $result = Result::query()->where('org_id', $orgId)->where('attempt_id', $id)->first();
+        if (! $result instanceof Result) {
+            throw new ApiProblemException(404, 'RESULT_NOT_FOUND', 'result not found.');
+        }
 
-        $result = Result::where('org_id', $orgId)->where('attempt_id', $id)->firstOrFail();
-        $responseCodes = $this->resolveResponseScaleCodes($attempt);
+        $responseCodes = $this->resolveResponseScaleCodes($result);
+        $scaleCode = $this->resolveNormalizedScaleCode($responseCodes);
+        $attempt = $this->resolveAttemptForResultRead($request, $orgId, $id, $scaleCode);
+        $attemptId = $this->resolveAttemptId($result, $attempt, $id);
+        $packId = $this->preferredStringField($result, $attempt, 'pack_id');
+        $dirVersion = $this->preferredStringField($result, $attempt, 'dir_version');
+        $contentPackageVersion = $this->preferredStringField($result, $attempt, 'content_package_version');
+        $scoringSpecVersion = $this->preferredStringField($result, $attempt, 'scoring_spec_version');
+        $reportEngineVersion = $this->preferredStringField($result, null, 'report_engine_version', 'v1.2');
 
-        $scaleCode = strtoupper((string) ($attempt->scale_code ?? ''));
         if ($scaleCode === 'CLINICAL_COMBO_68') {
             $gate = $this->reportGatekeeper->resolve(
                 $orgId,
@@ -108,17 +123,17 @@ class AttemptReadController extends Controller
             ];
 
             $this->eventRecorder->recordFromRequest($request, 'result_view', $this->resolveUserId($request), [
-                'scale_code' => (string) ($attempt->scale_code ?? ''),
-                'pack_id' => (string) ($attempt->pack_id ?? ''),
-                'dir_version' => (string) ($attempt->dir_version ?? ''),
+                'scale_code' => $scaleCode,
+                'pack_id' => $packId,
+                'dir_version' => $dirVersion,
                 'type_code' => (string) ($result->type_code ?? ''),
-                'attempt_id' => (string) $attempt->id,
+                'attempt_id' => $attemptId,
                 'locked' => (bool) ($gate['locked'] ?? true),
             ]);
 
             return response()->json([
                 'ok' => true,
-                'attempt_id' => (string) $attempt->id,
+                'attempt_id' => $attemptId,
                 'type_code' => '',
                 'scores' => $safeResult['scores'],
                 'scores_pct' => [],
@@ -129,11 +144,11 @@ class AttemptReadController extends Controller
                     'scale_code_legacy' => $responseCodes['scale_code_legacy'],
                     'scale_code_v2' => $responseCodes['scale_code_v2'],
                     'scale_uid' => $responseCodes['scale_uid'],
-                    'pack_id' => (string) ($attempt->pack_id ?? ''),
-                    'dir_version' => (string) ($attempt->dir_version ?? ''),
-                    'content_package_version' => (string) ($attempt->content_package_version ?? ''),
-                    'scoring_spec_version' => (string) ($attempt->scoring_spec_version ?? ''),
-                    'report_engine_version' => (string) ($result->report_engine_version ?? 'v1.2'),
+                    'pack_id' => $packId,
+                    'dir_version' => $dirVersion,
+                    'content_package_version' => $contentPackageVersion,
+                    'scoring_spec_version' => $scoringSpecVersion,
+                    'report_engine_version' => $reportEngineVersion,
                 ],
             ]);
         }
@@ -166,16 +181,16 @@ class AttemptReadController extends Controller
         }
 
         $this->eventRecorder->recordFromRequest($request, 'result_view', $this->resolveUserId($request), [
-            'scale_code' => (string) ($attempt->scale_code ?? ''),
-            'pack_id' => (string) ($attempt->pack_id ?? ''),
-            'dir_version' => (string) ($attempt->dir_version ?? ''),
+            'scale_code' => $scaleCode,
+            'pack_id' => $packId,
+            'dir_version' => $dirVersion,
             'type_code' => (string) ($result->type_code ?? ''),
-            'attempt_id' => (string) $attempt->id,
+            'attempt_id' => $attemptId,
         ]);
 
         return response()->json([
             'ok' => true,
-            'attempt_id' => (string) $attempt->id,
+            'attempt_id' => $attemptId,
             'type_code' => $compatTypeCode,
             'scores' => $compatScores,
             'scores_pct' => $compatScoresPct,
@@ -185,11 +200,11 @@ class AttemptReadController extends Controller
                 'scale_code_legacy' => $responseCodes['scale_code_legacy'],
                 'scale_code_v2' => $responseCodes['scale_code_v2'],
                 'scale_uid' => $responseCodes['scale_uid'],
-                'pack_id' => (string) ($attempt->pack_id ?? ''),
-                'dir_version' => (string) ($attempt->dir_version ?? ''),
-                'content_package_version' => (string) ($attempt->content_package_version ?? ''),
-                'scoring_spec_version' => (string) ($attempt->scoring_spec_version ?? ''),
-                'report_engine_version' => (string) ($result->report_engine_version ?? 'v1.2'),
+                'pack_id' => $packId,
+                'dir_version' => $dirVersion,
+                'content_package_version' => $contentPackageVersion,
+                'scoring_spec_version' => $scoringSpecVersion,
+                'report_engine_version' => $reportEngineVersion,
             ],
         ]);
     }
@@ -330,6 +345,67 @@ class AttemptReadController extends Controller
         }
 
         return $payload;
+    }
+
+    private function resolveAttemptForResultRead(Request $request, int $orgId, string $attemptId, string $scaleCode): ?Attempt
+    {
+        if ($this->isPublicResultScale($scaleCode)) {
+            return Attempt::withoutGlobalScopes()
+                ->where('org_id', $orgId)
+                ->where('id', $attemptId)
+                ->first();
+        }
+
+        $attempt = $this->ownedAttemptQuery($request, $attemptId)->first();
+        if ($attempt instanceof Attempt) {
+            return $attempt;
+        }
+
+        throw new ApiProblemException(404, 'RESOURCE_NOT_FOUND', 'attempt not found.');
+    }
+
+    private function isPublicResultScale(string $scaleCode): bool
+    {
+        return in_array($scaleCode, self::PUBLIC_RESULT_READ_SCALES, true);
+    }
+
+    private function resolveNormalizedScaleCode(array $responseCodes): string
+    {
+        $legacy = strtoupper(trim((string) ($responseCodes['scale_code_legacy'] ?? '')));
+        if ($legacy !== '') {
+            return $legacy;
+        }
+
+        return strtoupper(trim((string) ($responseCodes['scale_code'] ?? '')));
+    }
+
+    private function resolveAttemptId(Result $result, ?Attempt $attempt, string $fallbackAttemptId): string
+    {
+        if ($attempt instanceof Attempt) {
+            return (string) $attempt->id;
+        }
+
+        $resultAttemptId = trim((string) ($result->attempt_id ?? ''));
+        if ($resultAttemptId !== '') {
+            return $resultAttemptId;
+        }
+
+        return $fallbackAttemptId;
+    }
+
+    private function preferredStringField(object $primary, ?object $fallback, string $field, string $default = ''): string
+    {
+        $primaryValue = trim((string) ($primary->{$field} ?? ''));
+        if ($primaryValue !== '') {
+            return $primaryValue;
+        }
+
+        $fallbackValue = trim((string) ($fallback?->{$field} ?? ''));
+        if ($fallbackValue !== '') {
+            return $fallbackValue;
+        }
+
+        return $default;
     }
 
     /**

--- a/backend/tests/Feature/ErrorContractConsistencyTest.php
+++ b/backend/tests/Feature/ErrorContractConsistencyTest.php
@@ -31,7 +31,7 @@ final class ErrorContractConsistencyTest extends TestCase
             ],
         ], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES);
 
-        if (!is_string($raw)) {
+        if (! is_string($raw)) {
             self::fail('Failed to encode webhook payload.');
         }
 
@@ -53,7 +53,7 @@ final class ErrorContractConsistencyTest extends TestCase
         $this->assertUnifiedErrorContract($response);
     }
 
-    public function test_v03_attempt_not_found_returns_resource_not_found_contract(): void
+    public function test_v03_attempt_not_found_returns_result_not_found_contract(): void
     {
         $attemptId = (string) Str::uuid();
 
@@ -62,7 +62,8 @@ final class ErrorContractConsistencyTest extends TestCase
         ])->getJson("/api/v0.3/attempts/{$attemptId}");
 
         $response->assertStatus(404);
-        $response->assertJsonPath('error_code', 'RESOURCE_NOT_FOUND');
+        $response->assertJsonPath('error_code', 'RESULT_NOT_FOUND');
+        $response->assertJsonPath('message', 'result not found.');
         $this->assertUnifiedErrorContract($response);
     }
 

--- a/backend/tests/Feature/V0_3/AttemptPublicResultReadHotfixTest.php
+++ b/backend/tests/Feature/V0_3/AttemptPublicResultReadHotfixTest.php
@@ -1,0 +1,202 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\V0_3;
+
+use App\Models\Attempt;
+use App\Models\Result;
+use Database\Seeders\ScaleRegistrySeeder;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Str;
+use Tests\TestCase;
+
+final class AttemptPublicResultReadHotfixTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private function seedScales(): void
+    {
+        (new ScaleRegistrySeeder)->run();
+    }
+
+    private function createAttempt(string $attemptId, string $scaleCode, string $anonId): void
+    {
+        Attempt::create([
+            'id' => $attemptId,
+            'org_id' => 0,
+            'anon_id' => $anonId,
+            'scale_code' => $scaleCode,
+            'scale_version' => 'v0.3',
+            'region' => 'CN_MAINLAND',
+            'locale' => 'zh-CN',
+            'question_count' => 144,
+            'client_platform' => 'test',
+            'answers_summary_json' => ['stage' => 'seed'],
+            'started_at' => now(),
+            'submitted_at' => now(),
+            'pack_id' => "{$scaleCode}.pack",
+            'dir_version' => "{$scaleCode}.dir",
+            'content_package_version' => 'attempt-v1',
+            'scoring_spec_version' => 'attempt-score-v1',
+        ]);
+    }
+
+    private function createResult(string $attemptId, string $scaleCode, array $overrides = []): void
+    {
+        Result::create(array_merge([
+            'id' => (string) Str::uuid(),
+            'org_id' => 0,
+            'attempt_id' => $attemptId,
+            'scale_code' => $scaleCode,
+            'scale_version' => 'v0.3',
+            'type_code' => 'INTJ-A',
+            'scores_json' => [
+                'EI' => ['a' => 10, 'b' => 10, 'sum' => 0, 'total' => 20],
+            ],
+            'scores_pct' => [
+                'EI' => 50,
+            ],
+            'axis_states' => [
+                'EI' => 'clear',
+            ],
+            'content_package_version' => 'result-v1',
+            'result_json' => [
+                'type_code' => 'INTJ-A',
+                'scores' => [
+                    'EI' => ['a' => 10, 'b' => 10, 'sum' => 0, 'total' => 20],
+                ],
+                'scores_pct' => [
+                    'EI' => 50,
+                ],
+            ],
+            'pack_id' => "{$scaleCode}.result-pack",
+            'dir_version' => "{$scaleCode}.result-dir",
+            'scoring_spec_version' => 'result-score-v1',
+            'report_engine_version' => 'v1.9',
+            'is_valid' => true,
+            'computed_at' => now(),
+        ], $overrides));
+    }
+
+    public function test_mbti_anonymous_result_can_be_read_by_attempt_id(): void
+    {
+        $this->seedScales();
+
+        $attemptId = (string) Str::uuid();
+        $this->createAttempt($attemptId, 'MBTI', 'anon_mbti_owner');
+        $this->createResult($attemptId, 'MBTI');
+
+        $response = $this->withHeader('X-Anon-Id', 'anon_mbti_owner')
+            ->getJson("/api/v0.3/attempts/{$attemptId}/result");
+
+        $response->assertStatus(200);
+        $response->assertJsonPath('ok', true);
+        $response->assertJsonPath('attempt_id', $attemptId);
+        $response->assertJsonPath('type_code', 'INTJ-A');
+        $response->assertJsonPath('meta.scale_code_legacy', 'MBTI');
+        $response->assertJsonPath('meta.pack_id', 'MBTI.result-pack');
+        $this->assertStringNotContainsString('No query results for model', (string) $response->getContent());
+    }
+
+    public function test_big5_anonymous_result_can_be_read_via_attempt_alias(): void
+    {
+        $this->seedScales();
+
+        $attemptId = (string) Str::uuid();
+        $this->createAttempt($attemptId, 'BIG5_OCEAN', 'anon_big5_owner');
+        $this->createResult($attemptId, 'BIG5_OCEAN', [
+            'type_code' => 'BIG5-READY',
+            'result_json' => [
+                'type_code' => 'BIG5-READY',
+                'traits' => [
+                    'O' => 72,
+                    'C' => 66,
+                ],
+            ],
+        ]);
+
+        $response = $this->withHeader('X-Anon-Id', 'anon_big5_owner')
+            ->getJson("/api/v0.3/attempts/{$attemptId}");
+
+        $response->assertStatus(200);
+        $response->assertJsonPath('ok', true);
+        $response->assertJsonPath('attempt_id', $attemptId);
+        $response->assertJsonPath('type_code', 'BIG5-READY');
+        $response->assertJsonPath('meta.scale_code_legacy', 'BIG5_OCEAN');
+    }
+
+    public function test_public_orphan_result_can_be_read_without_attempt_row(): void
+    {
+        $this->seedScales();
+
+        $attemptId = (string) Str::uuid();
+        $this->createResult($attemptId, 'IQ_RAVEN', [
+            'type_code' => 'IQ-RESULT',
+            'scores_json' => [
+                'raw_score' => 28,
+            ],
+            'scores_pct' => [],
+            'result_json' => [
+                'type_code' => 'IQ-RESULT',
+                'raw_score' => 28,
+                'final_score' => 28,
+            ],
+            'pack_id' => 'IQ_RAVEN.result-pack',
+            'dir_version' => 'IQ_RAVEN.result-dir',
+            'content_package_version' => 'result-only-v1',
+            'scoring_spec_version' => 'result-only-score-v1',
+            'report_engine_version' => 'v2.1',
+        ]);
+
+        $response = $this->withHeader('X-Anon-Id', 'anon_orphan_probe')
+            ->getJson("/api/v0.3/attempts/{$attemptId}/result");
+
+        $response->assertStatus(200);
+        $response->assertJsonPath('ok', true);
+        $response->assertJsonPath('attempt_id', $attemptId);
+        $response->assertJsonPath('type_code', 'IQ-RESULT');
+        $response->assertJsonPath('meta.scale_code_legacy', 'IQ_RAVEN');
+        $response->assertJsonPath('meta.pack_id', 'IQ_RAVEN.result-pack');
+        $response->assertJsonPath('meta.dir_version', 'IQ_RAVEN.result-dir');
+        $response->assertJsonPath('meta.content_package_version', 'result-only-v1');
+        $response->assertJsonPath('meta.scoring_spec_version', 'result-only-score-v1');
+        $response->assertJsonPath('meta.report_engine_version', 'v2.1');
+    }
+
+    public function test_sds20_anonymous_result_read_is_still_rejected(): void
+    {
+        $this->seedScales();
+
+        $attemptId = (string) Str::uuid();
+        $this->createAttempt($attemptId, 'SDS_20', 'anon_sds_owner');
+        $this->createResult($attemptId, 'SDS_20', [
+            'type_code' => 'SDS-READY',
+        ]);
+
+        $response = $this->withHeader('X-Anon-Id', 'anon_sds_owner')
+            ->getJson("/api/v0.3/attempts/{$attemptId}/result");
+
+        $response->assertStatus(404);
+        $response->assertJsonPath('error_code', 'RESOURCE_NOT_FOUND');
+        $this->assertStringNotContainsString('No query results for model [App\\Models\\Attempt].', (string) $response->getContent());
+    }
+
+    public function test_clinical_combo_68_anonymous_result_read_is_still_rejected(): void
+    {
+        $this->seedScales();
+
+        $attemptId = (string) Str::uuid();
+        $this->createAttempt($attemptId, 'CLINICAL_COMBO_68', 'anon_clinical_owner');
+        $this->createResult($attemptId, 'CLINICAL_COMBO_68', [
+            'type_code' => 'CLINICAL-READY',
+        ]);
+
+        $response = $this->withHeader('X-Anon-Id', 'anon_clinical_owner')
+            ->getJson("/api/v0.3/attempts/{$attemptId}/result");
+
+        $response->assertStatus(404);
+        $response->assertJsonPath('error_code', 'RESOURCE_NOT_FOUND');
+        $this->assertStringNotContainsString('No query results for model [App\\Models\\Attempt].', (string) $response->getContent());
+    }
+}


### PR DESCRIPTION
## Summary
- read `/api/v0.3/attempts/{id}/result` from `results` first and only enforce attempt ownership for non-public scales
- allow MBTI, BIG5_OCEAN, IQ_RAVEN, and EQ_60 result reads to succeed even when the attempt row is missing or ownership does not resolve
- keep SDS_20 and CLINICAL_COMBO_68 on the existing strict ownership path and replace raw Eloquent misses with explicit API errors

## Testing
- `cd backend && php artisan test --filter AttemptPublicResultReadHotfixTest`
- `cd backend && php artisan test --filter HighIdorOwnership404Test`
- `cd backend && php artisan test --filter ResolveAnonIdMiddlewareTest`
- `cd backend && php artisan test --filter ErrorContractConsistencyTest`