### PR TITLE
feat(career-cms): add public api and seo service for career jobs

### DIFF
--- a/backend/app/Http/Controllers/API/V0_5/Cms/CareerJobController.php
+++ b/backend/app/Http/Controllers/API/V0_5/Cms/CareerJobController.php
@@ -1,0 +1,168 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Controllers\API\V0_5\Cms;
+
+use App\Http\Controllers\Concerns\RespondsWithNotFound;
+use App\Http\Controllers\Controller;
+use App\Models\CareerJob;
+use App\Models\CareerJobSection;
+use App\Services\Cms\CareerJobSeoService;
+use App\Services\Cms\CareerJobService;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Validator;
+
+final class CareerJobController extends Controller
+{
+    use RespondsWithNotFound;
+
+    public function __construct(
+        private readonly CareerJobService $careerJobService,
+        private readonly CareerJobSeoService $careerJobSeoService,
+    ) {}
+
+    public function index(Request $request): JsonResponse
+    {
+        $validated = $this->validateListQuery($request);
+        if ($validated instanceof JsonResponse) {
+            return $validated;
+        }
+
+        $paginator = $this->careerJobService->listPublicJobs(
+            $validated['org_id'],
+            $validated['locale'],
+            $validated['page'],
+            $validated['per_page'],
+        );
+
+        $items = [];
+        foreach ($paginator->items() as $job) {
+            if (! $job instanceof CareerJob) {
+                continue;
+            }
+
+            $items[] = $this->careerJobService->listPayload($job);
+        }
+
+        return response()->json([
+            'ok' => true,
+            'items' => $items,
+            'pagination' => [
+                'current_page' => (int) $paginator->currentPage(),
+                'per_page' => (int) $paginator->perPage(),
+                'total' => (int) $paginator->total(),
+                'last_page' => (int) $paginator->lastPage(),
+            ],
+        ]);
+    }
+
+    public function show(Request $request, string $slug): JsonResponse
+    {
+        $validated = $this->validateReadQuery($request);
+        if ($validated instanceof JsonResponse) {
+            return $validated;
+        }
+
+        $job = $this->careerJobService->getPublicJobBySlug(
+            $slug,
+            $validated['org_id'],
+            $validated['locale'],
+        );
+
+        if (! $job instanceof CareerJob) {
+            return $this->notFoundResponse('career job not found.');
+        }
+
+        return response()->json([
+            'ok' => true,
+            'job' => $this->careerJobService->detailPayload($job),
+            'sections' => array_map(
+                fn (CareerJobSection $section): array => $this->careerJobService->sectionPayload($section),
+                $job->sections->all()
+            ),
+            'seo_meta' => $this->careerJobService->seoMetaPayload($job->seoMeta),
+        ]);
+    }
+
+    public function seo(Request $request, string $slug): JsonResponse
+    {
+        $validated = $this->validateReadQuery($request);
+        if ($validated instanceof JsonResponse) {
+            return $validated;
+        }
+
+        $job = $this->careerJobService->getPublicJobBySlug(
+            $slug,
+            $validated['org_id'],
+            $validated['locale'],
+        );
+
+        if (! $job instanceof CareerJob) {
+            return response()->json(['error' => 'not found'], 404);
+        }
+
+        return response()->json([
+            'meta' => $this->careerJobSeoService->buildMeta($job, $validated['locale']),
+            'jsonld' => $this->careerJobSeoService->buildJsonLd($job, $validated['locale']),
+        ]);
+    }
+
+    /**
+     * @return array{org_id:int,locale:string,page:int,per_page:int}|JsonResponse
+     */
+    private function validateListQuery(Request $request): array|JsonResponse
+    {
+        $validator = Validator::make($request->query(), [
+            'org_id' => ['nullable', 'integer', 'min:0'],
+            'locale' => ['required', 'in:en,zh-CN'],
+            'page' => ['nullable', 'integer', 'min:1'],
+            'per_page' => ['nullable', 'integer', 'min:1', 'max:100'],
+        ]);
+
+        if ($validator->fails()) {
+            return $this->invalidArgument($validator->errors()->first());
+        }
+
+        $validated = $validator->validated();
+
+        return [
+            'org_id' => (int) ($validated['org_id'] ?? 0),
+            'locale' => (string) $validated['locale'],
+            'page' => (int) ($validated['page'] ?? 1),
+            'per_page' => (int) ($validated['per_page'] ?? 20),
+        ];
+    }
+
+    /**
+     * @return array{org_id:int,locale:string}|JsonResponse
+     */
+    private function validateReadQuery(Request $request): array|JsonResponse
+    {
+        $validator = Validator::make($request->query(), [
+            'org_id' => ['nullable', 'integer', 'min:0'],
+            'locale' => ['required', 'in:en,zh-CN'],
+        ]);
+
+        if ($validator->fails()) {
+            return $this->invalidArgument($validator->errors()->first());
+        }
+
+        $validated = $validator->validated();
+
+        return [
+            'org_id' => (int) ($validated['org_id'] ?? 0),
+            'locale' => (string) $validated['locale'],
+        ];
+    }
+
+    private function invalidArgument(string $message): JsonResponse
+    {
+        return response()->json([
+            'ok' => false,
+            'error_code' => 'INVALID_ARGUMENT',
+            'message' => $message,
+        ], 422);
+    }
+}

--- a/backend/app/Services/Cms/CareerJobSeoService.php
+++ b/backend/app/Services/Cms/CareerJobSeoService.php
@@ -1,0 +1,186 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\Cms;
+
+use App\Models\CareerJob;
+use App\Models\CareerJobSeoMeta;
+
+final class CareerJobSeoService
+{
+    /**
+     * @return array<string, mixed>
+     */
+    public function buildMeta(CareerJob $job, string $locale): array
+    {
+        $resolvedLocale = $this->normalizeLocale($locale);
+        $seoMeta = $this->resolveSeoMeta($job);
+
+        $title = $this->fallbackText(
+            $seoMeta?->seo_title,
+            (string) $job->title
+        ) ?? (string) $job->title;
+        $description = $this->fallbackText(
+            $seoMeta?->seo_description,
+            (string) ($job->excerpt ?? null),
+            (string) ($job->subtitle ?? null),
+            (string) $job->title
+        ) ?? (string) $job->title;
+        $canonical = $seoMeta?->canonical_url ?? $this->buildCanonicalUrl($job, $resolvedLocale);
+        $robots = $this->fallbackText($seoMeta?->robots)
+            ?? ((bool) $job->is_indexable ? 'index,follow' : 'noindex,follow');
+        $image = $this->fallbackText($seoMeta?->og_image_url, (string) ($job->cover_image_url ?? null));
+
+        return [
+            'title' => $title,
+            'description' => $description,
+            'canonical' => $canonical,
+            'alternates' => [
+                'en' => $this->buildCanonicalUrl($job, 'en'),
+                'zh-CN' => $this->buildCanonicalUrl($job, 'zh-CN'),
+            ],
+            'og' => [
+                'title' => $this->fallbackText($seoMeta?->og_title, $title),
+                'description' => $this->fallbackText($seoMeta?->og_description, $description),
+                'image' => $image,
+                'type' => 'article',
+            ],
+            'twitter' => [
+                'card' => 'summary_large_image',
+                'title' => $this->fallbackText($seoMeta?->twitter_title, $seoMeta?->og_title, $title),
+                'description' => $this->fallbackText(
+                    $seoMeta?->twitter_description,
+                    $seoMeta?->og_description,
+                    $description
+                ),
+                'image' => $this->fallbackText($seoMeta?->twitter_image_url, $image),
+            ],
+            'robots' => $robots,
+        ];
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function buildJsonLd(CareerJob $job, string $locale): array
+    {
+        $resolvedLocale = $this->normalizeLocale($locale);
+        $meta = $this->buildMeta($job, $resolvedLocale);
+
+        $jsonLd = [
+            '@context' => 'https://schema.org',
+            '@type' => 'Occupation',
+            'name' => (string) $job->title,
+            'description' => $meta['description'],
+            'inLanguage' => $resolvedLocale,
+            'url' => $meta['canonical'],
+            'mainEntityOfPage' => $meta['canonical'],
+        ];
+
+        $skills = $this->flattenSkills($job->skills_json);
+        if ($skills !== []) {
+            $jsonLd['skills'] = $skills;
+        }
+
+        $seoMeta = $this->resolveSeoMeta($job);
+        if ($seoMeta instanceof CareerJobSeoMeta && is_array($seoMeta->jsonld_overrides_json)) {
+            return array_replace_recursive($jsonLd, $seoMeta->jsonld_overrides_json);
+        }
+
+        return $jsonLd;
+    }
+
+    public function buildCanonicalUrl(CareerJob $job, string $locale): ?string
+    {
+        $baseUrl = rtrim((string) config('app.frontend_url', config('app.url', '')), '/');
+        $slug = trim((string) $job->slug);
+
+        if ($baseUrl === '' || $slug === '') {
+            return null;
+        }
+
+        return $baseUrl
+            .'/'.$this->mapBackendLocaleToFrontendSegment($locale)
+            .'/career/jobs/'
+            .rawurlencode($slug);
+    }
+
+    public function mapBackendLocaleToFrontendSegment(string $locale): string
+    {
+        return $this->normalizeLocale($locale) === 'zh-CN' ? 'zh' : 'en';
+    }
+
+    private function resolveSeoMeta(CareerJob $job): ?CareerJobSeoMeta
+    {
+        if ($job->relationLoaded('seoMeta') && $job->seoMeta instanceof CareerJobSeoMeta) {
+            return $job->seoMeta;
+        }
+
+        return CareerJobSeoMeta::query()
+            ->where('job_id', (int) $job->id)
+            ->first();
+    }
+
+    private function normalizeLocale(string $locale): string
+    {
+        return trim($locale) === 'zh-CN' ? 'zh-CN' : 'en';
+    }
+
+    /**
+     * @param  array<string, mixed>|null  $skills
+     * @return array<int, string>
+     */
+    private function flattenSkills(?array $skills): array
+    {
+        if (! is_array($skills)) {
+            return [];
+        }
+
+        $flattened = [];
+
+        foreach ($skills as $value) {
+            if (is_string($value)) {
+                $normalized = trim($value);
+                if ($normalized !== '') {
+                    $flattened[] = $normalized;
+                }
+
+                continue;
+            }
+
+            if (! is_array($value)) {
+                continue;
+            }
+
+            foreach ($value as $item) {
+                if (! is_string($item)) {
+                    continue;
+                }
+
+                $normalized = trim($item);
+                if ($normalized !== '') {
+                    $flattened[] = $normalized;
+                }
+            }
+        }
+
+        return array_values(array_unique($flattened));
+    }
+
+    private function fallbackText(?string ...$candidates): ?string
+    {
+        foreach ($candidates as $candidate) {
+            if ($candidate === null) {
+                continue;
+            }
+
+            $normalized = trim($candidate);
+            if ($normalized !== '') {
+                return $normalized;
+            }
+        }
+
+        return null;
+    }
+}

--- a/backend/app/Services/Cms/CareerJobService.php
+++ b/backend/app/Services/Cms/CareerJobService.php
@@ -1,0 +1,207 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\Cms;
+
+use App\Models\CareerJob;
+use App\Models\CareerJobSection;
+use App\Models\CareerJobSeoMeta;
+use App\Models\Scopes\TenantScope;
+use Illuminate\Contracts\Pagination\LengthAwarePaginator;
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+
+final class CareerJobService
+{
+    public function listPublicJobs(int $orgId, string $locale, int $page = 1, int $perPage = 20): LengthAwarePaginator
+    {
+        return $this->basePublicQuery($orgId, $locale)
+            ->with('seoMeta')
+            ->orderBy('sort_order')
+            ->orderBy('job_code')
+            ->orderBy('id')
+            ->paginate($perPage, ['*'], 'page', $page);
+    }
+
+    public function getPublicJobBySlug(string $slug, int $orgId, string $locale): ?CareerJob
+    {
+        return $this->basePublicQuery($orgId, $locale)
+            ->forSlug($this->normalizeSlug($slug))
+            ->with([
+                'sections' => static function (HasMany $query): void {
+                    $query->where('is_enabled', true)
+                        ->orderBy('sort_order')
+                        ->orderBy('id');
+                },
+                'seoMeta',
+            ])
+            ->first();
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function listPayload(CareerJob $job): array
+    {
+        return [
+            'id' => (int) $job->id,
+            'org_id' => (int) $job->org_id,
+            'job_code' => (string) $job->job_code,
+            'slug' => (string) $job->slug,
+            'locale' => (string) $job->locale,
+            'title' => (string) $job->title,
+            'subtitle' => $job->subtitle,
+            'excerpt' => $job->excerpt,
+            'industry_slug' => $job->industry_slug,
+            'industry_label' => $job->industry_label,
+            'status' => (string) $job->status,
+            'is_public' => (bool) $job->is_public,
+            'is_indexable' => (bool) $job->is_indexable,
+            'published_at' => $job->published_at?->toISOString(),
+            'updated_at' => $job->updated_at?->toISOString(),
+            'salary' => $job->salary_json,
+            'seo_meta' => $this->seoMetaSummaryPayload($this->resolveSeoMeta($job)),
+        ];
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function detailPayload(CareerJob $job): array
+    {
+        return array_merge([
+            'id' => (int) $job->id,
+            'org_id' => (int) $job->org_id,
+            'job_code' => (string) $job->job_code,
+            'slug' => (string) $job->slug,
+            'locale' => (string) $job->locale,
+            'title' => (string) $job->title,
+            'subtitle' => $job->subtitle,
+            'excerpt' => $job->excerpt,
+            'hero_kicker' => $job->hero_kicker,
+            'hero_quote' => $job->hero_quote,
+            'cover_image_url' => $job->cover_image_url,
+            'industry_slug' => $job->industry_slug,
+            'industry_label' => $job->industry_label,
+            'body_md' => $job->body_md,
+            'body_html' => $job->body_html,
+            'status' => (string) $job->status,
+            'is_public' => (bool) $job->is_public,
+            'is_indexable' => (bool) $job->is_indexable,
+            'published_at' => $job->published_at?->toISOString(),
+            'updated_at' => $job->updated_at?->toISOString(),
+        ], $this->structuredPayload($job));
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function sectionPayload(CareerJobSection $section): array
+    {
+        return [
+            'section_key' => (string) $section->section_key,
+            'title' => $section->title,
+            'render_variant' => (string) $section->render_variant,
+            'body_md' => $section->body_md,
+            'body_html' => $section->body_html,
+            'payload_json' => $section->payload_json,
+            'sort_order' => (int) $section->sort_order,
+            'is_enabled' => (bool) $section->is_enabled,
+        ];
+    }
+
+    /**
+     * @return array<string, mixed>|null
+     */
+    public function seoMetaPayload(?CareerJobSeoMeta $seoMeta): ?array
+    {
+        if (! $seoMeta instanceof CareerJobSeoMeta) {
+            return null;
+        }
+
+        return [
+            'seo_title' => $seoMeta->seo_title,
+            'seo_description' => $seoMeta->seo_description,
+            'canonical_url' => $seoMeta->canonical_url,
+            'og_title' => $seoMeta->og_title,
+            'og_description' => $seoMeta->og_description,
+            'og_image_url' => $seoMeta->og_image_url,
+            'twitter_title' => $seoMeta->twitter_title,
+            'twitter_description' => $seoMeta->twitter_description,
+            'twitter_image_url' => $seoMeta->twitter_image_url,
+            'robots' => $seoMeta->robots,
+            'jsonld_overrides_json' => $seoMeta->jsonld_overrides_json,
+        ];
+    }
+
+    /**
+     * @return array<string, mixed>|null
+     */
+    public function seoMetaSummaryPayload(?CareerJobSeoMeta $seoMeta): ?array
+    {
+        if (! $seoMeta instanceof CareerJobSeoMeta) {
+            return null;
+        }
+
+        return [
+            'seo_title' => $seoMeta->seo_title,
+            'seo_description' => $seoMeta->seo_description,
+        ];
+    }
+
+    private function basePublicQuery(int $orgId, string $locale): Builder
+    {
+        return CareerJob::query()
+            ->withoutGlobalScope(TenantScope::class)
+            ->where('org_id', max(0, $orgId))
+            ->forLocale($this->normalizeLocale($locale))
+            ->publishedPublic()
+            ->where(static function (Builder $query): void {
+                $query->whereNull('published_at')
+                    ->orWhere('published_at', '<=', now());
+            });
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function structuredPayload(CareerJob $job): array
+    {
+        return [
+            'salary' => $job->salary_json,
+            'outlook' => $job->outlook_json,
+            'skills' => $job->skills_json,
+            'work_contents' => $job->work_contents_json,
+            'growth_path' => $job->growth_path_json,
+            'fit_personality_codes' => $job->fit_personality_codes_json,
+            'mbti_primary_codes' => $job->mbti_primary_codes_json,
+            'mbti_secondary_codes' => $job->mbti_secondary_codes_json,
+            'riasec_profile' => $job->riasec_profile_json,
+            'big5_targets' => $job->big5_targets_json,
+            'iq_eq_notes' => $job->iq_eq_notes_json,
+            'market_demand' => $job->market_demand_json,
+        ];
+    }
+
+    private function resolveSeoMeta(CareerJob $job): ?CareerJobSeoMeta
+    {
+        if ($job->relationLoaded('seoMeta') && $job->seoMeta instanceof CareerJobSeoMeta) {
+            return $job->seoMeta;
+        }
+
+        return CareerJobSeoMeta::query()
+            ->where('job_id', (int) $job->id)
+            ->first();
+    }
+
+    private function normalizeLocale(string $locale): string
+    {
+        return trim($locale) === 'zh-CN' ? 'zh-CN' : 'en';
+    }
+
+    private function normalizeSlug(string $slug): string
+    {
+        return strtolower(trim($slug));
+    }
+}

--- a/backend/docs/contracts/openapi.snapshot.json
+++ b/backend/docs/contracts/openapi.snapshot.json
@@ -1717,6 +1717,57 @@
                 ]
             }
         },
+        "/api/v0.5/career-jobs": {
+            "get": {
+                "operationId": "get_api_v0_5_career_jobs",
+                "tags": [
+                    "api:v0.5"
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK"
+                    }
+                },
+                "x-laravel-action": "App\\Http\\Controllers\\API\\V0_5\\Cms\\CareerJobController@index",
+                "x-laravel-middleware": [
+                    "api"
+                ]
+            }
+        },
+        "/api/v0.5/career-jobs/{slug}": {
+            "get": {
+                "operationId": "get_api_v0_5_career_jobs_slug_",
+                "tags": [
+                    "api:v0.5"
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK"
+                    }
+                },
+                "x-laravel-action": "App\\Http\\Controllers\\API\\V0_5\\Cms\\CareerJobController@show",
+                "x-laravel-middleware": [
+                    "api"
+                ]
+            }
+        },
+        "/api/v0.5/career-jobs/{slug}/seo": {
+            "get": {
+                "operationId": "get_api_v0_5_career_jobs_slug_seo",
+                "tags": [
+                    "api:v0.5"
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK"
+                    }
+                },
+                "x-laravel-action": "App\\Http\\Controllers\\API\\V0_5\\Cms\\CareerJobController@seo",
+                "x-laravel-middleware": [
+                    "api"
+                ]
+            }
+        },
         "/api/v0.5/cms/articles": {
             "post": {
                 "operationId": "post_api_v0_5_cms_articles",

--- a/backend/routes/api.php
+++ b/backend/routes/api.php
@@ -24,6 +24,7 @@ use App\Http\Controllers\API\V0_4\ExperimentGovernanceController;
 use App\Http\Controllers\API\V0_4\PartnerController;
 use App\Http\Controllers\API\V0_4\RotationAuditController;
 use App\Http\Controllers\API\V0_5\Cms\ArticleController;
+use App\Http\Controllers\API\V0_5\Cms\CareerJobController;
 use App\Http\Controllers\API\V0_5\Cms\PersonalityController;
 use App\Http\Controllers\API\V0_5\Cms\TopicController;
 use App\Http\Controllers\HealthzController;
@@ -304,6 +305,9 @@ Route::prefix('v0.5')->group(function () {
     Route::get('/articles', [ArticleController::class, 'index']);
     Route::get('/articles/{slug}', [ArticleController::class, 'show']);
     Route::get('/articles/{slug}/seo', [ArticleController::class, 'seo']);
+    Route::get('/career-jobs', [CareerJobController::class, 'index']);
+    Route::get('/career-jobs/{slug}/seo', [CareerJobController::class, 'seo']);
+    Route::get('/career-jobs/{slug}', [CareerJobController::class, 'show']);
     Route::get('/personality', [PersonalityController::class, 'index']);
     Route::get('/personality/{type}/seo', [PersonalityController::class, 'seo']);
     Route::get('/personality/{type}', [PersonalityController::class, 'show']);

--- a/backend/tests/Feature/V0_5/CareerJobPublicApiTest.php
+++ b/backend/tests/Feature/V0_5/CareerJobPublicApiTest.php
@@ -1,0 +1,523 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\V0_5;
+
+use App\Models\CareerJob;
+use App\Models\CareerJobSection;
+use App\Models\CareerJobSeoMeta;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+final class CareerJobPublicApiTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_list_returns_published_public_only_and_keeps_noindex_items_readable(): void
+    {
+        $visible = $this->createJob([
+            'job_code' => 'product-manager',
+            'slug' => 'product-manager',
+            'title' => 'Product Manager',
+            'status' => CareerJob::STATUS_PUBLISHED,
+            'is_public' => true,
+            'is_indexable' => true,
+            'published_at' => now()->subMinute(),
+            'sort_order' => 10,
+            'salary_json' => [
+                'currency' => 'USD',
+                'region' => 'US',
+                'low' => 80000,
+                'median' => 120000,
+                'high' => 180000,
+            ],
+        ]);
+        $this->createSeoMeta($visible, [
+            'seo_title' => 'Product Manager Career Guide | FermatMind',
+            'seo_description' => 'Responsibilities, salary, growth path, and personality fit for Product Managers.',
+        ]);
+
+        $noindex = $this->createJob([
+            'job_code' => 'ux-designer',
+            'slug' => 'ux-designer',
+            'title' => 'UX Designer',
+            'status' => CareerJob::STATUS_PUBLISHED,
+            'is_public' => true,
+            'is_indexable' => false,
+            'published_at' => now()->subMinute(),
+            'sort_order' => 20,
+        ]);
+        $this->createSeoMeta($noindex, [
+            'seo_title' => 'UX Designer Career Guide | FermatMind',
+            'robots' => 'noindex,follow',
+        ]);
+
+        $this->createJob([
+            'job_code' => 'data-scientist',
+            'slug' => 'data-scientist',
+            'title' => 'Data Scientist Draft',
+            'status' => CareerJob::STATUS_DRAFT,
+            'is_public' => true,
+            'sort_order' => 30,
+        ]);
+        $this->createJob([
+            'job_code' => 'private-role',
+            'slug' => 'private-role',
+            'title' => 'Private Role',
+            'status' => CareerJob::STATUS_PUBLISHED,
+            'is_public' => false,
+            'published_at' => now()->subMinute(),
+            'sort_order' => 40,
+        ]);
+        $this->createJob([
+            'job_code' => 'scheduled-role',
+            'slug' => 'scheduled-role',
+            'title' => 'Scheduled Role',
+            'status' => CareerJob::STATUS_PUBLISHED,
+            'is_public' => true,
+            'published_at' => now()->addHour(),
+            'sort_order' => 50,
+        ]);
+
+        $response = $this->getJson('/api/v0.5/career-jobs?locale=en');
+
+        $response->assertOk()
+            ->assertJsonPath('ok', true)
+            ->assertJsonPath('pagination.total', 2)
+            ->assertJsonCount(2, 'items')
+            ->assertJsonPath('items.0.slug', 'product-manager')
+            ->assertJsonPath('items.0.salary.currency', 'USD')
+            ->assertJsonPath('items.0.seo_meta.seo_title', 'Product Manager Career Guide | FermatMind')
+            ->assertJsonPath('items.1.slug', 'ux-designer')
+            ->assertJsonPath('items.1.is_indexable', false)
+            ->assertJsonMissingPath('items.0.salary_json');
+    }
+
+    public function test_list_respects_locale_and_requested_org_scope(): void
+    {
+        $this->createJob([
+            'org_id' => 0,
+            'job_code' => 'product-manager',
+            'slug' => 'product-manager',
+            'locale' => 'en',
+            'title' => 'Product Manager EN',
+            'status' => CareerJob::STATUS_PUBLISHED,
+            'is_public' => true,
+            'published_at' => now()->subMinute(),
+        ]);
+        $this->createJob([
+            'org_id' => 0,
+            'job_code' => 'product-manager',
+            'slug' => 'product-manager',
+            'locale' => 'zh-CN',
+            'title' => '产品经理',
+            'status' => CareerJob::STATUS_PUBLISHED,
+            'is_public' => true,
+            'published_at' => now()->subMinute(),
+        ]);
+        $this->createJob([
+            'org_id' => 7,
+            'job_code' => 'product-manager',
+            'slug' => 'product-manager',
+            'locale' => 'en',
+            'title' => 'Product Manager Org 7',
+            'status' => CareerJob::STATUS_PUBLISHED,
+            'is_public' => true,
+            'published_at' => now()->subMinute(),
+        ]);
+
+        $this->getJson('/api/v0.5/career-jobs?locale=en')
+            ->assertOk()
+            ->assertJsonCount(1, 'items')
+            ->assertJsonPath('items.0.org_id', 0)
+            ->assertJsonPath('items.0.title', 'Product Manager EN');
+
+        $this->getJson('/api/v0.5/career-jobs?locale=zh-CN')
+            ->assertOk()
+            ->assertJsonCount(1, 'items')
+            ->assertJsonPath('items.0.locale', 'zh-CN')
+            ->assertJsonPath('items.0.title', '产品经理');
+
+        $this->getJson('/api/v0.5/career-jobs?locale=en&org_id=7')
+            ->assertOk()
+            ->assertJsonCount(1, 'items')
+            ->assertJsonPath('items.0.org_id', 7)
+            ->assertJsonPath('items.0.title', 'Product Manager Org 7');
+    }
+
+    public function test_detail_returns_job_sections_seo_meta_and_normalized_structured_fields(): void
+    {
+        $job = $this->createJob([
+            'job_code' => 'product-manager',
+            'slug' => 'product-manager',
+            'title' => 'Product Manager',
+            'subtitle' => 'Lead product direction across user, business, and engineering goals.',
+            'excerpt' => 'Understand the responsibilities, salary, growth path, and personality fit for Product Managers.',
+            'hero_kicker' => 'Career profile',
+            'hero_quote' => 'Translate uncertainty into direction.',
+            'industry_slug' => 'technology',
+            'industry_label' => 'Technology',
+            'body_md' => '# Product Manager',
+            'status' => CareerJob::STATUS_PUBLISHED,
+            'is_public' => true,
+            'published_at' => now()->subMinute(),
+            'salary_json' => [
+                'currency' => 'USD',
+                'region' => 'US',
+                'low' => 80000,
+                'median' => 120000,
+                'high' => 180000,
+                'notes' => 'Ranges vary by city and seniority.',
+            ],
+            'outlook_json' => [
+                'summary' => 'Growing',
+                'horizon_years' => 5,
+                'notes' => 'Strong demand in AI-enabled product roles.',
+            ],
+            'skills_json' => [
+                'core' => ['roadmapping', 'prioritization'],
+                'supporting' => ['stakeholder management'],
+            ],
+            'work_contents_json' => [
+                'items' => ['Define product strategy', 'Prioritize roadmap'],
+            ],
+            'growth_path_json' => [
+                'entry' => 'Associate Product Manager',
+                'mid' => 'Product Manager',
+                'senior' => 'Senior PM / Group PM',
+            ],
+            'fit_personality_codes_json' => ['INTJ', 'ENTJ'],
+            'mbti_primary_codes_json' => ['INTJ', 'ENTJ'],
+            'mbti_secondary_codes_json' => ['INFJ', 'ENFP'],
+            'riasec_profile_json' => [
+                'R' => 10,
+                'I' => 72,
+                'A' => 40,
+                'S' => 38,
+                'E' => 67,
+                'C' => 45,
+            ],
+            'big5_targets_json' => [
+                'openness' => 'high',
+                'conscientiousness' => 'high',
+                'extraversion' => 'balanced',
+                'agreeableness' => 'balanced',
+                'neuroticism' => 'low',
+            ],
+            'iq_eq_notes_json' => [
+                'iq' => 'Requires strong analytical reasoning.',
+                'eq' => 'Requires stakeholder empathy and communication.',
+            ],
+            'market_demand_json' => [
+                'signal' => 'high',
+                'notes' => 'Demand remains strong across SaaS and AI startups.',
+            ],
+        ]);
+
+        CareerJobSection::query()->create([
+            'job_id' => (int) $job->id,
+            'section_key' => 'day_to_day',
+            'title' => 'A typical day',
+            'render_variant' => 'rich_text',
+            'body_md' => 'A typical day section body.',
+            'sort_order' => 10,
+            'is_enabled' => true,
+        ]);
+        CareerJobSection::query()->create([
+            'job_id' => (int) $job->id,
+            'section_key' => 'faq',
+            'title' => 'FAQ',
+            'render_variant' => 'faq',
+            'payload_json' => ['items' => [['q' => 'What is PM?', 'a' => 'A product role']]],
+            'sort_order' => 20,
+            'is_enabled' => false,
+        ]);
+        $this->createSeoMeta($job, [
+            'seo_title' => 'Product Manager Career Guide | FermatMind',
+            'seo_description' => 'Responsibilities, salary, growth path, and personality fit for Product Managers.',
+            'canonical_url' => 'https://staging.fermatmind.com/en/career/jobs/product-manager',
+            'og_title' => 'Product Manager Career Guide',
+            'robots' => 'index,follow',
+        ]);
+
+        $response = $this->getJson('/api/v0.5/career-jobs/product-manager?locale=en');
+
+        $response->assertOk()
+            ->assertJsonPath('ok', true)
+            ->assertJsonPath('job.job_code', 'product-manager')
+            ->assertJsonPath('job.industry_label', 'Technology')
+            ->assertJsonPath('job.salary.currency', 'USD')
+            ->assertJsonPath('job.outlook.summary', 'Growing')
+            ->assertJsonPath('job.skills.core.0', 'roadmapping')
+            ->assertJsonPath('job.work_contents.items.0', 'Define product strategy')
+            ->assertJsonPath('job.riasec_profile.I', 72)
+            ->assertJsonPath('job.fit_personality_codes.0', 'INTJ')
+            ->assertJsonCount(1, 'sections')
+            ->assertJsonPath('sections.0.section_key', 'day_to_day')
+            ->assertJsonPath('seo_meta.seo_title', 'Product Manager Career Guide | FermatMind')
+            ->assertJsonMissingPath('job.salary_json')
+            ->assertJsonMissingPath('revisions');
+    }
+
+    public function test_detail_returns_not_found_for_missing_hidden_or_locale_mismatch_jobs(): void
+    {
+        $draft = $this->createJob([
+            'job_code' => 'draft-role',
+            'slug' => 'draft-role',
+            'status' => CareerJob::STATUS_DRAFT,
+            'is_public' => true,
+        ]);
+        $this->createJob([
+            'job_code' => 'private-role',
+            'slug' => 'private-role',
+            'status' => CareerJob::STATUS_PUBLISHED,
+            'is_public' => false,
+            'published_at' => now()->subMinute(),
+        ]);
+        $this->createJob([
+            'job_code' => 'zh-role',
+            'slug' => 'zh-role',
+            'locale' => 'zh-CN',
+            'status' => CareerJob::STATUS_PUBLISHED,
+            'is_public' => true,
+            'published_at' => now()->subMinute(),
+        ]);
+
+        $this->getJson('/api/v0.5/career-jobs/missing?locale=en')
+            ->assertStatus(404)
+            ->assertJsonPath('ok', false)
+            ->assertJsonPath('error_code', 'NOT_FOUND');
+
+        $this->getJson('/api/v0.5/career-jobs/'.$draft->slug.'?locale=en')
+            ->assertStatus(404)
+            ->assertJsonPath('error_code', 'NOT_FOUND');
+
+        $this->getJson('/api/v0.5/career-jobs/private-role?locale=en')
+            ->assertStatus(404)
+            ->assertJsonPath('error_code', 'NOT_FOUND');
+
+        $this->getJson('/api/v0.5/career-jobs/zh-role?locale=en')
+            ->assertStatus(404)
+            ->assertJsonPath('error_code', 'NOT_FOUND');
+    }
+
+    public function test_detail_defaults_to_global_content_and_only_uses_requested_org_scope(): void
+    {
+        $this->createJob([
+            'org_id' => 0,
+            'job_code' => 'product-manager',
+            'slug' => 'product-manager',
+            'title' => 'Global Product Manager',
+            'status' => CareerJob::STATUS_PUBLISHED,
+            'is_public' => true,
+            'published_at' => now()->subMinute(),
+        ]);
+        $this->createJob([
+            'org_id' => 7,
+            'job_code' => 'product-manager',
+            'slug' => 'product-manager',
+            'title' => 'Tenant Product Manager',
+            'status' => CareerJob::STATUS_PUBLISHED,
+            'is_public' => true,
+            'published_at' => now()->subMinute(),
+        ]);
+
+        $this->getJson('/api/v0.5/career-jobs/product-manager?locale=en')
+            ->assertOk()
+            ->assertJsonPath('job.org_id', 0)
+            ->assertJsonPath('job.title', 'Global Product Manager');
+
+        $this->getJson('/api/v0.5/career-jobs/product-manager?locale=en&org_id=7')
+            ->assertOk()
+            ->assertJsonPath('job.org_id', 7)
+            ->assertJsonPath('job.title', 'Tenant Product Manager');
+    }
+
+    public function test_seo_endpoint_returns_locale_aware_meta_jsonld_and_robots_fallback(): void
+    {
+        config(['app.frontend_url' => 'https://staging.fermatmind.com']);
+
+        $enJob = $this->createJob([
+            'job_code' => 'product-manager',
+            'slug' => 'product-manager',
+            'locale' => 'en',
+            'title' => 'Product Manager',
+            'excerpt' => 'Responsibilities, salary, growth path, and personality fit for Product Managers.',
+            'status' => CareerJob::STATUS_PUBLISHED,
+            'is_public' => true,
+            'is_indexable' => true,
+            'published_at' => now()->subMinute(),
+            'skills_json' => [
+                'core' => ['roadmapping', 'prioritization'],
+            ],
+        ]);
+        $this->createSeoMeta($enJob, [
+            'seo_title' => 'Product Manager Career Guide | FermatMind',
+            'seo_description' => 'Responsibilities, salary, growth path, and personality fit for Product Managers.',
+        ]);
+
+        $zhJob = $this->createJob([
+            'job_code' => 'product-manager',
+            'slug' => 'product-manager',
+            'locale' => 'zh-CN',
+            'title' => '产品经理',
+            'excerpt' => '了解产品经理的职责、薪资水平、发展路径和人格匹配。',
+            'status' => CareerJob::STATUS_PUBLISHED,
+            'is_public' => true,
+            'is_indexable' => false,
+            'published_at' => now()->subMinute(),
+        ]);
+
+        $enResponse = $this->getJson('/api/v0.5/career-jobs/product-manager/seo?locale=en');
+        $enResponse->assertOk()
+            ->assertJsonPath('meta.title', 'Product Manager Career Guide | FermatMind')
+            ->assertJsonPath('meta.canonical', 'https://staging.fermatmind.com/en/career/jobs/product-manager')
+            ->assertJsonPath('meta.alternates.en', 'https://staging.fermatmind.com/en/career/jobs/product-manager')
+            ->assertJsonPath('meta.alternates.zh-CN', 'https://staging.fermatmind.com/zh/career/jobs/product-manager')
+            ->assertJsonPath('meta.robots', 'index,follow')
+            ->assertJsonPath('jsonld.@type', 'Occupation')
+            ->assertJsonPath('jsonld.mainEntityOfPage', 'https://staging.fermatmind.com/en/career/jobs/product-manager')
+            ->assertJsonPath('jsonld.skills.0', 'roadmapping');
+
+        $zhResponse = $this->getJson('/api/v0.5/career-jobs/product-manager/seo?locale=zh-CN');
+        $zhResponse->assertOk()
+            ->assertJsonPath('meta.canonical', 'https://staging.fermatmind.com/zh/career/jobs/product-manager')
+            ->assertJsonPath('meta.robots', 'noindex,follow')
+            ->assertJsonPath('jsonld.name', (string) $zhJob->title)
+            ->assertJsonPath('jsonld.mainEntityOfPage', 'https://staging.fermatmind.com/zh/career/jobs/product-manager');
+    }
+
+    public function test_seo_endpoint_returns_not_found_for_missing_or_hidden_jobs(): void
+    {
+        $this->createJob([
+            'job_code' => 'draft-role',
+            'slug' => 'draft-role',
+            'status' => CareerJob::STATUS_DRAFT,
+            'is_public' => true,
+        ]);
+        $this->createJob([
+            'job_code' => 'private-role',
+            'slug' => 'private-role',
+            'status' => CareerJob::STATUS_PUBLISHED,
+            'is_public' => false,
+            'published_at' => now()->subMinute(),
+        ]);
+
+        $this->getJson('/api/v0.5/career-jobs/missing/seo?locale=en')
+            ->assertStatus(404)
+            ->assertJsonPath('error', 'not found');
+
+        $this->getJson('/api/v0.5/career-jobs/draft-role/seo?locale=en')
+            ->assertStatus(404)
+            ->assertJsonPath('error', 'not found');
+
+        $this->getJson('/api/v0.5/career-jobs/private-role/seo?locale=en')
+            ->assertStatus(404)
+            ->assertJsonPath('error', 'not found');
+    }
+
+    /**
+     * @param  array<string, mixed>  $overrides
+     */
+    private function createJob(array $overrides = []): CareerJob
+    {
+        /** @var CareerJob */
+        return CareerJob::query()->create(array_merge([
+            'org_id' => 0,
+            'job_code' => 'product-manager',
+            'slug' => 'product-manager',
+            'locale' => 'en',
+            'title' => 'Career job',
+            'subtitle' => 'Structured role profile',
+            'excerpt' => 'A structured career job profile.',
+            'hero_kicker' => 'Career profile',
+            'hero_quote' => 'Build direction with evidence.',
+            'cover_image_url' => 'https://cdn.example.test/jobs/product-manager.png',
+            'industry_slug' => 'technology',
+            'industry_label' => 'Technology',
+            'body_md' => '# Career job',
+            'body_html' => '<h1>Career job</h1>',
+            'salary_json' => [
+                'currency' => 'USD',
+                'region' => 'US',
+                'low' => 70000,
+                'median' => 110000,
+                'high' => 160000,
+                'notes' => 'Varies by region and seniority.',
+            ],
+            'outlook_json' => [
+                'summary' => 'Stable',
+                'horizon_years' => 5,
+                'notes' => 'Demand remains stable.',
+            ],
+            'skills_json' => [
+                'core' => ['problem solving'],
+                'supporting' => ['communication'],
+            ],
+            'work_contents_json' => [
+                'items' => ['Define responsibilities'],
+            ],
+            'growth_path_json' => [
+                'entry' => 'Entry',
+                'mid' => 'Mid',
+                'senior' => 'Senior',
+            ],
+            'fit_personality_codes_json' => ['INTJ'],
+            'mbti_primary_codes_json' => ['INTJ'],
+            'mbti_secondary_codes_json' => ['ENTJ'],
+            'riasec_profile_json' => [
+                'R' => 30,
+                'I' => 70,
+                'A' => 50,
+                'S' => 40,
+                'E' => 80,
+                'C' => 60,
+            ],
+            'big5_targets_json' => [
+                'openness' => 'high',
+                'conscientiousness' => 'high',
+                'extraversion' => 'balanced',
+                'agreeableness' => 'balanced',
+                'neuroticism' => 'low',
+            ],
+            'iq_eq_notes_json' => [
+                'iq' => 'Strong analysis required.',
+                'eq' => 'Strong communication required.',
+            ],
+            'market_demand_json' => [
+                'signal' => 'high',
+                'notes' => 'Demand remains strong.',
+            ],
+            'status' => CareerJob::STATUS_DRAFT,
+            'is_public' => false,
+            'is_indexable' => true,
+            'published_at' => null,
+            'scheduled_at' => null,
+            'schema_version' => 'v1',
+            'sort_order' => 0,
+        ], $overrides));
+    }
+
+    /**
+     * @param  array<string, mixed>  $overrides
+     */
+    private function createSeoMeta(CareerJob $job, array $overrides = []): CareerJobSeoMeta
+    {
+        /** @var CareerJobSeoMeta */
+        return CareerJobSeoMeta::query()->create(array_merge([
+            'job_id' => (int) $job->id,
+            'seo_title' => null,
+            'seo_description' => null,
+            'canonical_url' => null,
+            'og_title' => null,
+            'og_description' => null,
+            'og_image_url' => null,
+            'twitter_title' => null,
+            'twitter_description' => null,
+            'twitter_image_url' => null,
+            'robots' => null,
+            'jsonld_overrides_json' => null,
+        ], $overrides));
+    }
+}


### PR DESCRIPTION
Summary
- add the public read API for Career CMS Lite v1 career jobs
- add read-side services and SEO payload generation for career job pages

What changed
- add public endpoints for career job list, detail, and SEO
- add read-side service(s) to query published/public global career jobs
- add a dedicated SEO service for canonical/meta/jsonld payloads
- align validation and response envelopes with the existing v0.5 content API style
- add minimal feature coverage and route snapshot updates

Design choices
- career jobs are modeled as structured career content objects instead of generic articles
- v1 targets global content (org_id=0)
- the public payload exposes normalized semantic keys instead of raw persistence field names with _json
- SEO payloads emit locale-aware frontend URLs
- JSON-LD uses Occupation

Why this PR is small and safe
- no database changes beyond C01
- no write-side CMS API changes
- no frontend changes
- no RBAC changes
- no recommendation-engine changes
- only public read API / seo groundwork for later Career CMS PRs

Validation
- php artisan about
- php artisan route:list --path=api/v0.5 --except-vendor
- php artisan route:list --path=career-jobs --except-vendor
- php artisan migrate
- php artisan test --filter='(CareerJob|Career)'\n- bash scripts/export_openapi.sh --check\n- local curl checks for list/detail/seo\n- bash backend/scripts/ci_verify_mbti.sh