### PR TITLE
hotfix: align v0.3 report public read with result-first access

### DIFF
--- a/backend/app/Http/Controllers/API/V0_3/AttemptReadController.php
+++ b/backend/app/Http/Controllers/API/V0_3/AttemptReadController.php
@@ -220,10 +220,8 @@ class AttemptReadController extends Controller
         $orgId = $this->orgContext->orgId();
         $userId = $this->resolveUserId($request);
         $anonId = $this->resolveAnonId($request);
-        $attempt = $this->ownedAttemptQuery($request, $id)->firstOrFail();
-
-        $result = Result::where('org_id', $orgId)->where('attempt_id', $id)->first();
-        if ($result === null) {
+        $result = Result::query()->where('org_id', $orgId)->where('attempt_id', $id)->first();
+        if (! $result instanceof Result) {
             $submissionPayload = $this->attemptSubmissionService->latestForAttempt(
                 $this->orgContext,
                 $id,
@@ -243,33 +241,21 @@ class AttemptReadController extends Controller
                 ], 202);
             }
 
-            abort(404, 'result not found.');
+            throw new ApiProblemException(404, 'RESULT_NOT_FOUND', 'result not found.');
         }
-        $responseCodes = $this->resolveResponseScaleCodes($attempt);
+        $responseCodes = $this->resolveResponseScaleCodes($result);
+        $scaleCode = $this->resolveNormalizedScaleCode($responseCodes);
+        $attempt = $this->resolveAttemptForReportRead($request, $orgId, $id, $scaleCode);
 
-        $gate = $this->reportGatekeeper->resolve(
+        $gate = $this->resolveReportGate(
             $orgId,
             $id,
             $userId !== null ? (string) $userId : null,
             $anonId,
             $this->orgContext->role(),
-            false,
+            $this->isPublicReportScale($scaleCode),
             $forceRefresh,
         );
-
-        if (! ($gate['ok'] ?? false)) {
-            $status = (int) ($gate['status'] ?? 0);
-            if ($status <= 0) {
-                $error = strtoupper((string) data_get($gate, 'error_code', data_get($gate, 'error', 'REPORT_FAILED')));
-                $status = match ($error) {
-                    'ATTEMPT_REQUIRED', 'SCALE_REQUIRED' => 400,
-                    'ATTEMPT_NOT_FOUND', 'RESULT_NOT_FOUND', 'SCALE_NOT_FOUND' => 404,
-                    default => 500,
-                };
-            }
-
-            abort($status, (string) ($gate['message'] ?? 'report generation failed.'));
-        }
 
         $this->eventRecorder->recordFromRequest($request, 'report_view', $this->resolveUserId($request), [
             'scale_code' => (string) ($attempt->scale_code ?? ''),
@@ -317,6 +303,70 @@ class AttemptReadController extends Controller
                 'report_engine_version' => (string) ($result->report_engine_version ?? 'v1.2'),
             ]),
         ]));
+    }
+
+    private function resolveAttemptForReportRead(Request $request, int $orgId, string $attemptId, string $scaleCode): Attempt
+    {
+        if ($this->isPublicReportScale($scaleCode)) {
+            $attempt = Attempt::withoutGlobalScopes()
+                ->where('org_id', $orgId)
+                ->where('id', $attemptId)
+                ->first();
+
+            if ($attempt instanceof Attempt) {
+                return $attempt;
+            }
+
+            throw new ApiProblemException(404, 'ATTEMPT_NOT_FOUND', 'attempt not found.');
+        }
+
+        $attempt = $this->ownedAttemptQuery($request, $attemptId)->first();
+        if ($attempt instanceof Attempt) {
+            return $attempt;
+        }
+
+        throw new ApiProblemException(404, 'RESOURCE_NOT_FOUND', 'attempt not found.');
+    }
+
+    private function resolveReportGate(
+        int $orgId,
+        string $attemptId,
+        ?string $userId,
+        ?string $anonId,
+        ?string $role,
+        bool $forceSystemAccess,
+        bool $forceRefresh
+    ): array {
+        $gate = $this->reportGatekeeper->resolve(
+            $orgId,
+            $attemptId,
+            $userId,
+            $anonId,
+            $role,
+            $forceSystemAccess,
+            $forceRefresh,
+        );
+
+        if ($gate['ok'] ?? false) {
+            return $gate;
+        }
+
+        $errorCode = strtoupper((string) data_get($gate, 'error_code', data_get($gate, 'error', 'REPORT_FAILED')));
+        $status = (int) ($gate['status'] ?? 0);
+        if ($status <= 0) {
+            $status = match ($errorCode) {
+                'ATTEMPT_REQUIRED', 'SCALE_REQUIRED' => 400,
+                'ATTEMPT_NOT_FOUND', 'RESULT_NOT_FOUND', 'SCALE_NOT_FOUND' => 404,
+                default => 500,
+            };
+        }
+
+        $message = trim((string) ($gate['message'] ?? 'report generation failed.'));
+        if ($message === '') {
+            $message = 'report generation failed.';
+        }
+
+        throw new ApiProblemException($status, $errorCode !== '' ? $errorCode : 'REPORT_FAILED', $message);
     }
 
     /**
@@ -367,6 +417,11 @@ class AttemptReadController extends Controller
     private function isPublicResultScale(string $scaleCode): bool
     {
         return in_array($scaleCode, self::PUBLIC_RESULT_READ_SCALES, true);
+    }
+
+    private function isPublicReportScale(string $scaleCode): bool
+    {
+        return $this->isPublicResultScale($scaleCode);
     }
 
     private function resolveNormalizedScaleCode(array $responseCodes): string

--- a/backend/tests/Feature/V0_3/AttemptOwnershipTraitTest.php
+++ b/backend/tests/Feature/V0_3/AttemptOwnershipTraitTest.php
@@ -18,28 +18,29 @@ final class AttemptOwnershipTraitTest extends TestCase
 
     private function seedScales(): void
     {
-        (new ScaleRegistrySeeder())->run();
+        (new ScaleRegistrySeeder)->run();
     }
 
-    private function seedAttemptAndResult(string $anonId): string
+    private function seedAttemptAndResult(string $anonId, string $scaleCode = 'MBTI'): string
     {
         $attemptId = (string) Str::uuid();
+        $isMbti = $scaleCode === 'MBTI';
 
         Attempt::create([
             'id' => $attemptId,
             'org_id' => 0,
             'anon_id' => $anonId,
-            'scale_code' => 'MBTI',
+            'scale_code' => $scaleCode,
             'scale_version' => 'v0.3',
             'region' => 'CN_MAINLAND',
             'locale' => 'zh-CN',
-            'question_count' => 144,
+            'question_count' => $isMbti ? 144 : 5,
             'client_platform' => 'test',
             'answers_summary_json' => ['stage' => 'seed'],
             'started_at' => now(),
             'submitted_at' => now(),
-            'pack_id' => (string) config('content_packs.default_pack_id'),
-            'dir_version' => 'MBTI-CN-v0.3',
+            'pack_id' => $isMbti ? (string) config('content_packs.default_pack_id') : "{$scaleCode}.pack",
+            'dir_version' => $isMbti ? 'MBTI-CN-v0.3' : "{$scaleCode}.dir",
             'content_package_version' => 'v0.3',
             'scoring_spec_version' => '2026.01',
         ]);
@@ -48,39 +49,51 @@ final class AttemptOwnershipTraitTest extends TestCase
             'id' => (string) Str::uuid(),
             'org_id' => 0,
             'attempt_id' => $attemptId,
-            'scale_code' => 'MBTI',
+            'scale_code' => $scaleCode,
             'scale_version' => 'v0.3',
-            'type_code' => 'INTJ-A',
-            'scores_json' => [
-                'EI' => ['a' => 10, 'b' => 10, 'sum' => 0, 'total' => 20],
-                'SN' => ['a' => 10, 'b' => 10, 'sum' => 0, 'total' => 20],
-                'TF' => ['a' => 10, 'b' => 10, 'sum' => 0, 'total' => 20],
-                'JP' => ['a' => 10, 'b' => 10, 'sum' => 0, 'total' => 20],
-                'AT' => ['a' => 10, 'b' => 10, 'sum' => 0, 'total' => 20],
-            ],
-            'scores_pct' => [
-                'EI' => 50,
-                'SN' => 50,
-                'TF' => 50,
-                'JP' => 50,
-                'AT' => 50,
-            ],
-            'axis_states' => [
-                'EI' => 'clear',
-                'SN' => 'clear',
-                'TF' => 'clear',
-                'JP' => 'clear',
-                'AT' => 'clear',
-            ],
-            'content_package_version' => 'v0.3',
-            'result_json' => [
-                'type_code' => 'INTJ-A',
-                'scores_json' => [
+            'type_code' => $isMbti ? 'INTJ-A' : 'SIMPLE-SCORE',
+            'scores_json' => $isMbti
+                ? [
                     'EI' => ['a' => 10, 'b' => 10, 'sum' => 0, 'total' => 20],
+                    'SN' => ['a' => 10, 'b' => 10, 'sum' => 0, 'total' => 20],
+                    'TF' => ['a' => 10, 'b' => 10, 'sum' => 0, 'total' => 20],
+                    'JP' => ['a' => 10, 'b' => 10, 'sum' => 0, 'total' => 20],
+                    'AT' => ['a' => 10, 'b' => 10, 'sum' => 0, 'total' => 20],
+                ]
+                : ['raw_score' => 15, 'final_score' => 15],
+            'scores_pct' => $isMbti
+                ? [
+                    'EI' => 50,
+                    'SN' => 50,
+                    'TF' => 50,
+                    'JP' => 50,
+                    'AT' => 50,
+                ]
+                : [],
+            'axis_states' => $isMbti
+                ? [
+                    'EI' => 'clear',
+                    'SN' => 'clear',
+                    'TF' => 'clear',
+                    'JP' => 'clear',
+                    'AT' => 'clear',
+                ]
+                : [],
+            'content_package_version' => 'v0.3',
+            'result_json' => $isMbti
+                ? [
+                    'type_code' => 'INTJ-A',
+                    'scores_json' => [
+                        'EI' => ['a' => 10, 'b' => 10, 'sum' => 0, 'total' => 20],
+                    ],
+                ]
+                : [
+                    'raw_score' => 15,
+                    'final_score' => 15,
+                    'type_code' => 'SIMPLE-SCORE',
                 ],
-            ],
-            'pack_id' => (string) config('content_packs.default_pack_id'),
-            'dir_version' => 'MBTI-CN-v0.3',
+            'pack_id' => $isMbti ? (string) config('content_packs.default_pack_id') : "{$scaleCode}.pack",
+            'dir_version' => $isMbti ? 'MBTI-CN-v0.3' : "{$scaleCode}.dir",
             'scoring_spec_version' => '2026.01',
             'report_engine_version' => 'v1.2',
             'is_valid' => true,
@@ -113,7 +126,7 @@ final class AttemptOwnershipTraitTest extends TestCase
     public function test_report_returns_404_without_auth_and_anon_header(): void
     {
         $this->seedScales();
-        $attemptId = $this->seedAttemptAndResult('sec003-owner-anon');
+        $attemptId = $this->seedAttemptAndResult('sec003-owner-anon', 'SIMPLE_SCORE_DEMO');
 
         $this->getJson(route('api.v0_3.attempts.report', ['id' => $attemptId]))
             ->assertStatus(404);
@@ -122,7 +135,7 @@ final class AttemptOwnershipTraitTest extends TestCase
     public function test_report_returns_404_when_anon_header_mismatch(): void
     {
         $this->seedScales();
-        $attemptId = $this->seedAttemptAndResult('sec003-owner-anon');
+        $attemptId = $this->seedAttemptAndResult('sec003-owner-anon', 'SIMPLE_SCORE_DEMO');
 
         $this->withHeader('X-Anon-Id', 'sec003-other-anon')
             ->getJson(route('api.v0_3.attempts.report', ['id' => $attemptId]))
@@ -137,9 +150,9 @@ final class AttemptOwnershipTraitTest extends TestCase
         $token = $this->issueAnonToken($anonId);
 
         $response = $this->withHeaders([
-                'X-Anon-Id' => $anonId,
-                'Authorization' => 'Bearer '.$token,
-            ])
+            'X-Anon-Id' => $anonId,
+            'Authorization' => 'Bearer '.$token,
+        ])
             ->getJson(route('api.v0_3.attempts.report', ['id' => $attemptId]));
 
         $this->assertContains($response->status(), [200, 402]);

--- a/backend/tests/Feature/V0_3/AttemptPublicReportReadHotfixTest.php
+++ b/backend/tests/Feature/V0_3/AttemptPublicReportReadHotfixTest.php
@@ -1,0 +1,177 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\V0_3;
+
+use App\Models\Attempt;
+use App\Models\Result;
+use Database\Seeders\ScaleRegistrySeeder;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Str;
+use Tests\TestCase;
+
+final class AttemptPublicReportReadHotfixTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private function seedScales(): void
+    {
+        (new ScaleRegistrySeeder)->run();
+    }
+
+    private function createAttempt(string $attemptId, string $scaleCode, string $anonId): void
+    {
+        $isMbti = $scaleCode === 'MBTI';
+
+        Attempt::create([
+            'id' => $attemptId,
+            'org_id' => 0,
+            'anon_id' => $anonId,
+            'scale_code' => $scaleCode,
+            'scale_version' => 'v0.3',
+            'region' => 'CN_MAINLAND',
+            'locale' => 'zh-CN',
+            'question_count' => $isMbti ? 144 : 20,
+            'client_platform' => 'test',
+            'answers_summary_json' => ['stage' => 'seed'],
+            'started_at' => now(),
+            'submitted_at' => now(),
+            'pack_id' => $isMbti ? (string) config('content_packs.default_pack_id') : "{$scaleCode}.pack",
+            'dir_version' => $isMbti ? 'MBTI-CN-v0.3' : "{$scaleCode}.dir",
+            'content_package_version' => 'attempt-v1',
+            'scoring_spec_version' => 'attempt-score-v1',
+        ]);
+    }
+
+    private function createResult(string $attemptId, string $scaleCode): void
+    {
+        $isMbti = $scaleCode === 'MBTI';
+
+        Result::create([
+            'id' => (string) Str::uuid(),
+            'org_id' => 0,
+            'attempt_id' => $attemptId,
+            'scale_code' => $scaleCode,
+            'scale_version' => 'v0.3',
+            'type_code' => $isMbti ? 'INTJ-A' : 'SDS-READY',
+            'scores_json' => $isMbti
+                ? [
+                    'EI' => ['a' => 10, 'b' => 10, 'neutral' => 0, 'sum' => 0, 'total' => 20],
+                    'SN' => ['a' => 10, 'b' => 10, 'neutral' => 0, 'sum' => 0, 'total' => 20],
+                    'TF' => ['a' => 10, 'b' => 10, 'neutral' => 0, 'sum' => 0, 'total' => 20],
+                    'JP' => ['a' => 10, 'b' => 10, 'neutral' => 0, 'sum' => 0, 'total' => 20],
+                    'AT' => ['a' => 10, 'b' => 10, 'neutral' => 0, 'sum' => 0, 'total' => 20],
+                ]
+                : ['total' => 42],
+            'scores_pct' => $isMbti
+                ? [
+                    'EI' => 50,
+                    'SN' => 50,
+                    'TF' => 50,
+                    'JP' => 50,
+                    'AT' => 50,
+                ]
+                : [],
+            'axis_states' => $isMbti
+                ? [
+                    'EI' => 'clear',
+                    'SN' => 'clear',
+                    'TF' => 'clear',
+                    'JP' => 'clear',
+                    'AT' => 'clear',
+                ]
+                : [],
+            'content_package_version' => 'result-v1',
+            'result_json' => $isMbti
+                ? [
+                    'raw_score' => 0,
+                    'final_score' => 0,
+                    'breakdown_json' => [],
+                    'type_code' => 'INTJ-A',
+                    'axis_scores_json' => [
+                        'scores_pct' => [
+                            'EI' => 50,
+                            'SN' => 50,
+                            'TF' => 50,
+                            'JP' => 50,
+                            'AT' => 50,
+                        ],
+                        'axis_states' => [
+                            'EI' => 'clear',
+                            'SN' => 'clear',
+                            'TF' => 'clear',
+                            'JP' => 'clear',
+                            'AT' => 'clear',
+                        ],
+                    ],
+                ]
+                : [
+                    'scale_code' => 'SDS_20',
+                    'scores' => ['total' => 42],
+                    'quality' => ['level' => 'ok'],
+                    'report_tags' => [],
+                    'sections' => [],
+                ],
+            'pack_id' => $isMbti ? (string) config('content_packs.default_pack_id') : "{$scaleCode}.pack",
+            'dir_version' => $isMbti ? 'MBTI-CN-v0.3' : "{$scaleCode}.dir",
+            'scoring_spec_version' => 'result-score-v1',
+            'report_engine_version' => 'v1.2',
+            'is_valid' => true,
+            'computed_at' => now(),
+        ]);
+    }
+
+    public function test_public_mbti_report_can_be_read_without_attempt_ownership(): void
+    {
+        $this->seedScales();
+
+        $attemptId = (string) Str::uuid();
+        $this->createAttempt($attemptId, 'MBTI', 'anon_mbti_owner');
+        $this->createResult($attemptId, 'MBTI');
+
+        $response = $this->withHeader('X-Anon-Id', 'anon_public_probe')
+            ->getJson("/api/v0.3/attempts/{$attemptId}/report");
+
+        $response->assertStatus(200);
+        $response->assertJsonPath('ok', true);
+        $response->assertJsonPath('locked', true);
+        $response->assertJsonPath('variant', 'free');
+        $response->assertJsonPath('meta.scale_code_legacy', 'MBTI');
+        $this->assertIsArray($response->json('report'));
+        $this->assertStringNotContainsString('No query results for model', (string) $response->getContent());
+    }
+
+    public function test_public_mbti_report_rejects_orphan_result_with_explicit_attempt_not_found_contract(): void
+    {
+        $this->seedScales();
+
+        $attemptId = (string) Str::uuid();
+        $this->createResult($attemptId, 'MBTI');
+
+        $response = $this->withHeader('X-Anon-Id', 'anon_orphan_probe')
+            ->getJson("/api/v0.3/attempts/{$attemptId}/report");
+
+        $response->assertStatus(404);
+        $response->assertJsonPath('error_code', 'ATTEMPT_NOT_FOUND');
+        $response->assertJsonPath('message', 'attempt not found.');
+        $this->assertStringNotContainsString('No query results for model', (string) $response->getContent());
+    }
+
+    public function test_sds20_report_still_requires_existing_ownership_chain(): void
+    {
+        $this->seedScales();
+
+        $attemptId = (string) Str::uuid();
+        $this->createAttempt($attemptId, 'SDS_20', 'anon_sds_owner');
+        $this->createResult($attemptId, 'SDS_20');
+
+        $response = $this->withHeader('X-Anon-Id', 'anon_sds_probe')
+            ->getJson("/api/v0.3/attempts/{$attemptId}/report");
+
+        $response->assertStatus(404);
+        $response->assertJsonPath('error_code', 'RESOURCE_NOT_FOUND');
+        $response->assertJsonPath('message', 'attempt not found.');
+        $this->assertStringNotContainsString('No query results for model', (string) $response->getContent());
+    }
+}


### PR DESCRIPTION
## Root cause
- /result had already been moved to a result-first path for public scales.
- /report still started with attempt-first ownership via ownedAttemptQuery(...)->firstOrFail().
- X-Anon-Id only populated client_anon_id and never satisfied the anon_id branch used by ownedAttemptQuery().
- ReportGatekeeper::resolve() applied a second ownership gate unless forceSystemAccess was enabled.

## What changed
- switch AttemptReadController::report() to result-first
- resolve public-scale report reads with org_id + attempt_id on Result, then org_id + id on Attempt
- reuse ReportGatekeeper::resolve(... forceSystemAccess: true ...) for MBTI, BIG5_OCEAN, IQ_RAVEN, EQ_60
- keep SDS_20 / CLINICAL_COMBO_68 / other non-public scales on the existing ownership path
- replace report-path misses with explicit ApiProblemException contracts
- add focused regression tests

## Verification
- php artisan test tests/Feature/V0_3/AttemptPublicReportReadHotfixTest.php tests/Feature/V0_3/AttemptPublicResultReadHotfixTest.php tests/Feature/V0_3/AttemptOwnershipTraitTest.php tests/Feature/V0_3/AttemptsStartSubmitTest.php tests/Feature/ReportGatekeeperIdentityBoundaryTest.php
- php artisan route:list
- php artisan migrate
- bash scripts/ci_verify_mbti.sh