### PR TITLE
feat(career-cms): add ops resource and workspace for career jobs

### DIFF
--- a/backend/app/Filament/Ops/Resources/CareerJobResource.php
+++ b/backend/app/Filament/Ops/Resources/CareerJobResource.php
@@ -1,0 +1,687 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Filament\Ops\Resources;
+
+use App\Filament\Ops\Resources\CareerJobResource\Pages;
+use App\Filament\Ops\Resources\CareerJobResource\Support\CareerJobWorkspace;
+use App\Filament\Ops\Support\StatusBadge;
+use App\Models\CareerJob;
+use App\Support\Rbac\PermissionNames;
+use Filament\Forms;
+use Filament\Forms\Form;
+use Filament\Resources\Resource;
+use Filament\Tables;
+use Filament\Tables\Filters\TernaryFilter;
+use Filament\Tables\Table;
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Support\Str;
+
+class CareerJobResource extends Resource
+{
+    protected static ?string $model = CareerJob::class;
+
+    protected static ?string $slug = 'career-jobs';
+
+    protected static ?string $recordTitleAttribute = 'title';
+
+    protected static ?string $navigationIcon = 'heroicon-o-briefcase';
+
+    protected static ?string $navigationGroup = 'Content';
+
+    protected static ?string $navigationLabel = 'Career Jobs';
+
+    protected static ?string $modelLabel = 'Career Job';
+
+    protected static ?string $pluralModelLabel = 'Career Jobs';
+
+    public static function canViewAny(): bool
+    {
+        return self::canRead();
+    }
+
+    public static function canCreate(): bool
+    {
+        return self::canPublish();
+    }
+
+    public static function canEdit($record): bool
+    {
+        return self::canPublish();
+    }
+
+    public static function canDelete($record): bool
+    {
+        return false;
+    }
+
+    public static function getNavigationGroup(): ?string
+    {
+        return __('ops.group.content');
+    }
+
+    public static function getNavigationLabel(): string
+    {
+        return 'Career Jobs';
+    }
+
+    public static function form(Form $form): Form
+    {
+        return $form->schema([
+            Forms\Components\Hidden::make('org_id')
+                ->default(0),
+            Forms\Components\Grid::make([
+                'default' => 1,
+                'xl' => 12,
+            ])
+                ->extraAttributes(['class' => 'ops-career-job-workspace-layout'])
+                ->schema([
+                    Forms\Components\Group::make([
+                        Forms\Components\Section::make('Basic')
+                            ->description('Shape the career job headline, summary, and industry context before editing structured signals.')
+                            ->extraAttributes(['class' => 'ops-career-job-workspace-section ops-career-job-workspace-section--main'])
+                            ->schema([
+                                Forms\Components\TextInput::make('title')
+                                    ->required()
+                                    ->maxLength(255)
+                                    ->columnSpanFull()
+                                    ->helperText('Primary job heading used across the workspace, public detail page, and SEO fallbacks.')
+                                    ->extraFieldWrapperAttributes(['class' => 'ops-career-job-workspace-field ops-career-job-workspace-field--title'])
+                                    ->extraInputAttributes(['class' => 'ops-career-job-workspace-input ops-career-job-workspace-input--title']),
+                                Forms\Components\TextInput::make('subtitle')
+                                    ->maxLength(255)
+                                    ->columnSpanFull()
+                                    ->helperText('Optional supporting line for the hero and quick editorial scanning.'),
+                                Forms\Components\Textarea::make('excerpt')
+                                    ->rows(4)
+                                    ->columnSpanFull()
+                                    ->helperText('Short summary used for list previews, public excerpts, and SEO description fallbacks.')
+                                    ->extraFieldWrapperAttributes(['class' => 'ops-career-job-workspace-field ops-career-job-workspace-field--summary']),
+                                Forms\Components\TextInput::make('industry_slug')
+                                    ->maxLength(128)
+                                    ->helperText('Lightweight industry key used for current frontend grouping.'),
+                                Forms\Components\TextInput::make('industry_label')
+                                    ->maxLength(255)
+                                    ->helperText('Optional editor-facing label for the industry until Industry becomes its own CMS object.'),
+                            ])
+                            ->columns(2),
+                        Forms\Components\Section::make('Hero')
+                            ->description('Optional framing content for future frontend hero treatments. Safe to leave empty.')
+                            ->extraAttributes(['class' => 'ops-career-job-workspace-section ops-career-job-workspace-section--main'])
+                            ->schema([
+                                Forms\Components\TextInput::make('hero_kicker')
+                                    ->maxLength(128),
+                                Forms\Components\Textarea::make('hero_quote')
+                                    ->rows(4),
+                                Forms\Components\TextInput::make('cover_image_url')
+                                    ->maxLength(2048)
+                                    ->columnSpanFull(),
+                            ])
+                            ->columns(2),
+                        Forms\Components\Section::make('Primary narrative')
+                            ->description('The main long-form career narrative stays on the job record instead of being broken into free-form sections.')
+                            ->extraAttributes(['class' => 'ops-career-job-workspace-section ops-career-job-workspace-section--main'])
+                            ->schema([
+                                Forms\Components\MarkdownEditor::make('body_md')
+                                    ->columnSpanFull()
+                                    ->helperText('Use markdown for the primary career narrative shown after structured job signals on the public page.')
+                                    ->extraFieldWrapperAttributes(['class' => 'ops-career-job-workspace-field ops-career-job-workspace-field--editor']),
+                            ]),
+                        Forms\Components\Section::make('Job signals')
+                            ->description('Edit recommendation-relevant signals through constrained inputs instead of raw JSON blobs.')
+                            ->extraAttributes(['class' => 'ops-career-job-workspace-section ops-career-job-workspace-section--main'])
+                            ->schema([
+                                Forms\Components\Tabs::make('Career job signals')
+                                    ->contained(false)
+                                    ->extraAttributes(['class' => 'ops-career-job-workspace-tabs'])
+                                    ->tabs(self::signalTabs())
+                                    ->columnSpanFull(),
+                            ]),
+                        Forms\Components\Section::make('Supplemental sections')
+                            ->description('Fixed supplemental narrative blocks only. These complement the main body and do not replace it.')
+                            ->extraAttributes(['class' => 'ops-career-job-workspace-section ops-career-job-workspace-section--main'])
+                            ->schema([
+                                Forms\Components\Tabs::make('Career job sections')
+                                    ->contained(false)
+                                    ->extraAttributes(['class' => 'ops-career-job-workspace-tabs'])
+                                    ->tabs(self::sectionTabs())
+                                    ->columnSpanFull(),
+                            ]),
+                    ])
+                        ->columnSpan([
+                            'xl' => 8,
+                        ])
+                        ->extraAttributes(['class' => 'ops-career-job-workspace-main-column']),
+                    Forms\Components\Group::make([
+                        Forms\Components\Section::make('Identity')
+                            ->description('Career CMS Lite v1 manages global career content only. Org scope stays fixed to org_id=0.')
+                            ->extraAttributes(['class' => 'ops-career-job-workspace-section ops-career-job-workspace-section--rail'])
+                            ->schema([
+                                Forms\Components\TextInput::make('job_code')
+                                    ->required()
+                                    ->maxLength(96)
+                                    ->placeholder('product-manager')
+                                    ->helperText('Stable internal key for this career job. Defaults to the slug if left blank.')
+                                    ->live(onBlur: true)
+                                    ->dehydrateStateUsing(fn (?string $state, Forms\Get $get): string => CareerJobWorkspace::normalizeJobCode(
+                                        $state,
+                                        (string) $get('slug'),
+                                    ))
+                                    ->afterStateUpdated(function (?string $state, Forms\Set $set, Forms\Get $get): void {
+                                        if (trim((string) $get('slug')) !== '') {
+                                            return;
+                                        }
+
+                                        $set('slug', CareerJobWorkspace::normalizeSlug(null, $state));
+                                    })
+                                    ->rules(['regex:/^[a-z0-9-]+$/']),
+                                Forms\Components\TextInput::make('slug')
+                                    ->required()
+                                    ->maxLength(128)
+                                    ->placeholder('product-manager')
+                                    ->helperText('Frontend route key for locale-aware `/career/jobs/{slug}` pages.')
+                                    ->dehydrateStateUsing(fn (?string $state, Forms\Get $get): string => CareerJobWorkspace::normalizeSlug(
+                                        $state,
+                                        (string) $get('job_code'),
+                                    ))
+                                    ->rules(['regex:/^[a-z0-9-]+$/']),
+                                Forms\Components\Select::make('locale')
+                                    ->required()
+                                    ->native(false)
+                                    ->options(self::localeOptions())
+                                    ->default('en')
+                                    ->helperText('Stored as backend locale codes and mapped to `/en` or `/zh` in planned URLs.'),
+                                Forms\Components\Placeholder::make('identity_org')
+                                    ->label('Content scope')
+                                    ->content('Global career content (org_id=0)'),
+                            ])
+                            ->columns(2),
+                        Forms\Components\Section::make('Publish')
+                            ->description('Keep release state, visibility, indexing, and ordering cues together in the metadata rail.')
+                            ->extraAttributes(['class' => 'ops-career-job-workspace-section ops-career-job-workspace-section--rail'])
+                            ->schema([
+                                Forms\Components\Placeholder::make('workspace_state')
+                                    ->label('Editorial cues')
+                                    ->content(fn (Forms\Get $get, ?CareerJob $record) => CareerJobWorkspace::renderEditorialCues($get, $record))
+                                    ->columnSpanFull(),
+                                Forms\Components\Select::make('status')
+                                    ->required()
+                                    ->native(false)
+                                    ->options(self::statusOptions())
+                                    ->default(CareerJob::STATUS_DRAFT),
+                                Forms\Components\Toggle::make('is_public')
+                                    ->label('Public visibility')
+                                    ->default(true),
+                                Forms\Components\Toggle::make('is_indexable')
+                                    ->label('Search indexable')
+                                    ->default(true),
+                                Forms\Components\DateTimePicker::make('published_at'),
+                                Forms\Components\DateTimePicker::make('scheduled_at'),
+                                Forms\Components\TextInput::make('sort_order')
+                                    ->numeric()
+                                    ->default(0)
+                                    ->helperText('List ordering for future job directories and ops tables.'),
+                            ]),
+                        Forms\Components\Section::make('SEO')
+                            ->description('Keep search metadata, social overrides, and robots hints in one reviewable rail.')
+                            ->extraAttributes(['class' => 'ops-career-job-workspace-section ops-career-job-workspace-section--rail'])
+                            ->schema([
+                                Forms\Components\Placeholder::make('seo_snapshot')
+                                    ->label('SEO snapshot')
+                                    ->content(fn (Forms\Get $get, ?CareerJob $record) => CareerJobWorkspace::renderSeoSnapshot($get, $record))
+                                    ->columnSpanFull(),
+                                Forms\Components\TextInput::make('workspace_seo.seo_title')
+                                    ->label('SEO title')
+                                    ->maxLength(255)
+                                    ->helperText('Search headline fallback is the job title if left blank.'),
+                                Forms\Components\Textarea::make('workspace_seo.seo_description')
+                                    ->label('SEO description')
+                                    ->rows(3)
+                                    ->helperText('Description fallback is excerpt, then subtitle.'),
+                                Forms\Components\TextInput::make('workspace_seo.canonical_url')
+                                    ->label('Canonical override')
+                                    ->maxLength(2048)
+                                    ->helperText('Optional stored override. Planned canonical still follows locale-aware career job URLs.'),
+                                Forms\Components\TextInput::make('workspace_seo.og_title')
+                                    ->label('Open Graph title')
+                                    ->maxLength(255),
+                                Forms\Components\Textarea::make('workspace_seo.og_description')
+                                    ->label('Open Graph description')
+                                    ->rows(3),
+                                Forms\Components\TextInput::make('workspace_seo.og_image_url')
+                                    ->label('Open Graph image URL')
+                                    ->maxLength(2048),
+                                Forms\Components\TextInput::make('workspace_seo.twitter_title')
+                                    ->label('Twitter title')
+                                    ->maxLength(255),
+                                Forms\Components\Textarea::make('workspace_seo.twitter_description')
+                                    ->label('Twitter description')
+                                    ->rows(3),
+                                Forms\Components\TextInput::make('workspace_seo.twitter_image_url')
+                                    ->label('Twitter image URL')
+                                    ->maxLength(2048),
+                                Forms\Components\TextInput::make('workspace_seo.robots')
+                                    ->label('Robots')
+                                    ->maxLength(64)
+                                    ->helperText('Leave blank to derive robots from the current indexability toggle.'),
+                            ]),
+                        Forms\Components\Section::make('Record cues')
+                            ->description('Read-only context so editors can review the planned frontend route, timestamps, and revision trail before cutover.')
+                            ->extraAttributes(['class' => 'ops-career-job-workspace-section ops-career-job-workspace-section--rail'])
+                            ->schema([
+                                Forms\Components\Placeholder::make('planned_public_url')
+                                    ->label('Planned public URL')
+                                    ->content(fn (Forms\Get $get, ?CareerJob $record): string => CareerJobWorkspace::plannedPublicUrl(
+                                        (string) ($get('slug') ?? $record?->slug ?? ''),
+                                        (string) ($get('locale') ?? $record?->locale ?? 'en'),
+                                    ) ?? 'Appears once slug and locale are set.'),
+                                Forms\Components\Placeholder::make('created_at_summary')
+                                    ->label('Created')
+                                    ->content(fn (?CareerJob $record): string => CareerJobWorkspace::formatTimestamp(
+                                        $record?->created_at,
+                                        'Workspace draft not saved yet',
+                                    )),
+                                Forms\Components\Placeholder::make('updated_at_summary')
+                                    ->label('Last updated')
+                                    ->content(fn (?CareerJob $record): string => CareerJobWorkspace::formatTimestamp(
+                                        $record?->updated_at,
+                                        'Workspace draft not saved yet',
+                                    )),
+                                Forms\Components\Placeholder::make('revision_count_summary')
+                                    ->label('Revision count')
+                                    ->content(fn (?CareerJob $record): string => $record instanceof CareerJob
+                                        ? (string) $record->revisions()->count()
+                                        : 'Revision #1 will be written when this career job is created'),
+                            ])
+                            ->columns(2),
+                    ])
+                        ->columnSpan([
+                            'xl' => 4,
+                        ])
+                        ->extraAttributes(['class' => 'ops-career-job-workspace-rail-column']),
+                ]),
+        ]);
+    }
+
+    public static function table(Table $table): Table
+    {
+        return $table
+            ->columns([
+                Tables\Columns\TextColumn::make('title')
+                    ->label('Career Job')
+                    ->html()
+                    ->searchable(['title', 'job_code', 'slug'])
+                    ->sortable()
+                    ->formatStateUsing(fn (CareerJob $record): string => (string) view('filament.ops.career-jobs.partials.table-title', [
+                        'meta' => CareerJobWorkspace::titleMeta($record),
+                        'title' => $record->title,
+                    ])->render()),
+                Tables\Columns\TextColumn::make('status')
+                    ->badge()
+                    ->sortable()
+                    ->formatStateUsing(fn (string $state): string => Str::of($state)->headline()->value())
+                    ->description(fn (CareerJob $record): string => CareerJobWorkspace::visibilityMeta($record))
+                    ->color(fn (string $state): string => StatusBadge::color($state)),
+                Tables\Columns\TextColumn::make('is_public')
+                    ->label('Visibility')
+                    ->badge()
+                    ->formatStateUsing(fn (bool|int|string|null $state): string => StatusBadge::booleanLabel($state, 'Public', 'Private'))
+                    ->color(fn (bool|int|string|null $state): string => StatusBadge::booleanColor($state))
+                    ->sortable(),
+                Tables\Columns\TextColumn::make('is_indexable')
+                    ->label('Indexing')
+                    ->badge()
+                    ->formatStateUsing(fn (bool|int|string|null $state): string => StatusBadge::booleanLabel($state, 'Indexable', 'Noindex'))
+                    ->color(fn (bool|int|string|null $state): string => StatusBadge::booleanColor($state))
+                    ->sortable(),
+                Tables\Columns\TextColumn::make('industry_slug')
+                    ->label('Industry')
+                    ->sortable()
+                    ->toggleable(),
+                Tables\Columns\TextColumn::make('published_at')
+                    ->label('Published')
+                    ->dateTime()
+                    ->sortable()
+                    ->placeholder('Not published'),
+                Tables\Columns\TextColumn::make('updated_at')
+                    ->label('Updated')
+                    ->since()
+                    ->sortable(),
+            ])
+            ->filters([
+                Tables\Filters\SelectFilter::make('locale')
+                    ->options(self::localeOptions()),
+                Tables\Filters\SelectFilter::make('status')
+                    ->options(self::statusOptions()),
+                TernaryFilter::make('is_public')
+                    ->label('Public'),
+                TernaryFilter::make('is_indexable')
+                    ->label('Indexable'),
+                Tables\Filters\SelectFilter::make('industry_slug')
+                    ->label('Industry')
+                    ->options(self::industryFilterOptions()),
+            ])
+            ->searchPlaceholder('Search title, job code, or slug')
+            ->defaultSort('updated_at', 'desc')
+            ->recordUrl(fn (CareerJob $record): string => static::getUrl('edit', ['record' => $record]))
+            ->actions([
+                Tables\Actions\EditAction::make()
+                    ->label('Edit')
+                    ->icon('heroicon-o-pencil-square')
+                    ->color('gray'),
+            ])
+            ->bulkActions([]);
+    }
+
+    public static function getPages(): array
+    {
+        return [
+            'index' => Pages\ListCareerJobs::route('/'),
+            'create' => Pages\CreateCareerJob::route('/create'),
+            'edit' => Pages\EditCareerJob::route('/{record}/edit'),
+        ];
+    }
+
+    public static function getEloquentQuery(): Builder
+    {
+        return parent::getEloquentQuery()
+            ->withoutGlobalScopes()
+            ->where('org_id', 0);
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    private static function statusOptions(): array
+    {
+        return [
+            CareerJob::STATUS_DRAFT => CareerJob::STATUS_DRAFT,
+            CareerJob::STATUS_PUBLISHED => CareerJob::STATUS_PUBLISHED,
+        ];
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    private static function localeOptions(): array
+    {
+        return collect(CareerJob::SUPPORTED_LOCALES)
+            ->mapWithKeys(static fn (string $locale): array => [$locale => $locale])
+            ->all();
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    private static function industryFilterOptions(): array
+    {
+        return CareerJob::query()
+            ->withoutGlobalScopes()
+            ->where('org_id', 0)
+            ->whereNotNull('industry_slug')
+            ->orderBy('industry_slug')
+            ->pluck('industry_slug', 'industry_slug')
+            ->all();
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    private static function mbtiTypeOptions(): array
+    {
+        return collect([
+            'INTJ', 'INTP', 'ENTJ', 'ENTP',
+            'INFJ', 'INFP', 'ENFJ', 'ENFP',
+            'ISTJ', 'ISFJ', 'ESTJ', 'ESFJ',
+            'ISTP', 'ISFP', 'ESTP', 'ESFP',
+        ])->mapWithKeys(static fn (string $code): array => [$code => $code])->all();
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    private static function marketSignalOptions(): array
+    {
+        return [
+            'low' => 'low',
+            'balanced' => 'balanced',
+            'high' => 'high',
+            'unknown' => 'unknown',
+        ];
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    private static function traitTargetOptions(): array
+    {
+        return [
+            'low' => 'low',
+            'balanced' => 'balanced',
+            'high' => 'high',
+        ];
+    }
+
+    /**
+     * @return array<int, Forms\Components\Tabs\Tab>
+     */
+    private static function signalTabs(): array
+    {
+        return [
+            Forms\Components\Tabs\Tab::make('Compensation & Outlook')
+                ->schema([
+                    Forms\Components\TextInput::make('salary_json.currency')
+                        ->label('Salary currency')
+                        ->maxLength(16),
+                    Forms\Components\TextInput::make('salary_json.region')
+                        ->label('Salary region')
+                        ->maxLength(32),
+                    Forms\Components\TextInput::make('salary_json.low')
+                        ->label('Salary low')
+                        ->numeric(),
+                    Forms\Components\TextInput::make('salary_json.median')
+                        ->label('Salary median')
+                        ->numeric(),
+                    Forms\Components\TextInput::make('salary_json.high')
+                        ->label('Salary high')
+                        ->numeric(),
+                    Forms\Components\Textarea::make('salary_json.notes')
+                        ->label('Salary notes')
+                        ->rows(3)
+                        ->columnSpanFull(),
+                    Forms\Components\TextInput::make('outlook_json.summary')
+                        ->label('Outlook summary')
+                        ->maxLength(255),
+                    Forms\Components\TextInput::make('outlook_json.horizon_years')
+                        ->label('Outlook horizon (years)')
+                        ->numeric(),
+                    Forms\Components\Textarea::make('outlook_json.notes')
+                        ->label('Outlook notes')
+                        ->rows(3)
+                        ->columnSpanFull(),
+                ])
+                ->columns(2),
+            Forms\Components\Tabs\Tab::make('Work & Skills')
+                ->schema([
+                    Forms\Components\TagsInput::make('work_contents_json.items')
+                        ->label('Work contents')
+                        ->helperText('Each tag becomes one main responsibility or work-content item.')
+                        ->columnSpanFull(),
+                    Forms\Components\TagsInput::make('skills_json.core')
+                        ->label('Core skills')
+                        ->helperText('Primary capabilities that define day-to-day fit.'),
+                    Forms\Components\TagsInput::make('skills_json.supporting')
+                        ->label('Supporting skills')
+                        ->helperText('Secondary capabilities that strengthen performance but are not always central.'),
+                ])
+                ->columns(2),
+            Forms\Components\Tabs\Tab::make('Growth & Market')
+                ->schema([
+                    Forms\Components\TextInput::make('growth_path_json.entry')
+                        ->label('Entry level')
+                        ->maxLength(255),
+                    Forms\Components\TextInput::make('growth_path_json.mid')
+                        ->label('Mid level')
+                        ->maxLength(255),
+                    Forms\Components\TextInput::make('growth_path_json.senior')
+                        ->label('Senior level')
+                        ->maxLength(255),
+                    Forms\Components\Textarea::make('growth_path_json.notes')
+                        ->label('Growth notes')
+                        ->rows(3)
+                        ->columnSpanFull(),
+                    Forms\Components\Select::make('market_demand_json.signal')
+                        ->label('Market demand signal')
+                        ->native(false)
+                        ->options(self::marketSignalOptions()),
+                    Forms\Components\Textarea::make('market_demand_json.notes')
+                        ->label('Market demand notes')
+                        ->rows(3)
+                        ->columnSpanFull(),
+                ])
+                ->columns(2),
+            Forms\Components\Tabs\Tab::make('Personality & Assessment Signals')
+                ->schema([
+                    Forms\Components\Select::make('fit_personality_codes_json')
+                        ->label('Fit personality codes')
+                        ->multiple()
+                        ->native(false)
+                        ->options(self::mbtiTypeOptions())
+                        ->helperText('Constrain this field to the 16 MBTI codes for v1 consistency.')
+                        ->columnSpanFull(),
+                    Forms\Components\Select::make('mbti_primary_codes_json')
+                        ->label('MBTI primary codes')
+                        ->multiple()
+                        ->native(false)
+                        ->options(self::mbtiTypeOptions()),
+                    Forms\Components\Select::make('mbti_secondary_codes_json')
+                        ->label('MBTI secondary codes')
+                        ->multiple()
+                        ->native(false)
+                        ->options(self::mbtiTypeOptions()),
+                    Forms\Components\TextInput::make('riasec_profile_json.R')
+                        ->label('RIASEC R')
+                        ->numeric()
+                        ->helperText('Suggested 0-100'),
+                    Forms\Components\TextInput::make('riasec_profile_json.I')
+                        ->label('RIASEC I')
+                        ->numeric()
+                        ->helperText('Suggested 0-100'),
+                    Forms\Components\TextInput::make('riasec_profile_json.A')
+                        ->label('RIASEC A')
+                        ->numeric()
+                        ->helperText('Suggested 0-100'),
+                    Forms\Components\TextInput::make('riasec_profile_json.S')
+                        ->label('RIASEC S')
+                        ->numeric()
+                        ->helperText('Suggested 0-100'),
+                    Forms\Components\TextInput::make('riasec_profile_json.E')
+                        ->label('RIASEC E')
+                        ->numeric()
+                        ->helperText('Suggested 0-100'),
+                    Forms\Components\TextInput::make('riasec_profile_json.C')
+                        ->label('RIASEC C')
+                        ->numeric()
+                        ->helperText('Suggested 0-100'),
+                    Forms\Components\Select::make('big5_targets_json.openness')
+                        ->label('Big5 openness')
+                        ->native(false)
+                        ->options(self::traitTargetOptions()),
+                    Forms\Components\Select::make('big5_targets_json.conscientiousness')
+                        ->label('Big5 conscientiousness')
+                        ->native(false)
+                        ->options(self::traitTargetOptions()),
+                    Forms\Components\Select::make('big5_targets_json.extraversion')
+                        ->label('Big5 extraversion')
+                        ->native(false)
+                        ->options(self::traitTargetOptions()),
+                    Forms\Components\Select::make('big5_targets_json.agreeableness')
+                        ->label('Big5 agreeableness')
+                        ->native(false)
+                        ->options(self::traitTargetOptions()),
+                    Forms\Components\Select::make('big5_targets_json.neuroticism')
+                        ->label('Big5 neuroticism')
+                        ->native(false)
+                        ->options(self::traitTargetOptions()),
+                    Forms\Components\Textarea::make('iq_eq_notes_json.iq')
+                        ->label('IQ notes')
+                        ->rows(3),
+                    Forms\Components\Textarea::make('iq_eq_notes_json.eq')
+                        ->label('EQ notes')
+                        ->rows(3),
+                ])
+                ->columns(2),
+        ];
+    }
+
+    /**
+     * @return array<int, Forms\Components\Tabs\Tab>
+     */
+    private static function sectionTabs(): array
+    {
+        $variantOptions = CareerJobWorkspace::renderVariantOptions();
+
+        return collect(CareerJobWorkspace::sectionDefinitions())
+            ->map(function (array $definition, string $sectionKey) use ($variantOptions): Forms\Components\Tabs\Tab {
+                return Forms\Components\Tabs\Tab::make($definition['label'])
+                    ->schema([
+                        Forms\Components\Toggle::make("workspace_sections.{$sectionKey}.is_enabled")
+                            ->label('Enable this section')
+                            ->helperText($definition['description'])
+                            ->columnSpanFull(),
+                        Forms\Components\TextInput::make("workspace_sections.{$sectionKey}.title")
+                            ->label('Section title')
+                            ->required()
+                            ->maxLength(255),
+                        Forms\Components\Select::make("workspace_sections.{$sectionKey}.render_variant")
+                            ->label('Render variant')
+                            ->native(false)
+                            ->options($variantOptions)
+                            ->required(),
+                        Forms\Components\Textarea::make("workspace_sections.{$sectionKey}.body_md")
+                            ->label('Narrative body')
+                            ->rows(8)
+                            ->columnSpanFull()
+                            ->helperText('Use markdown-friendly narrative copy when this section needs long-form explanation.')
+                            ->extraFieldWrapperAttributes(['class' => 'ops-career-job-workspace-field ops-career-job-workspace-field--body']),
+                        Forms\Components\Textarea::make("workspace_sections.{$sectionKey}.payload_json_text")
+                            ->label('Structured payload JSON')
+                            ->rows(6)
+                            ->columnSpanFull()
+                            ->helperText('Optional structured payload for cards, FAQ, links, or other fixed render variants.')
+                            ->rules(['nullable', 'json'])
+                            ->extraFieldWrapperAttributes(['class' => 'ops-career-job-workspace-field ops-career-job-workspace-field--payload']),
+                    ])
+                    ->columns(2);
+            })
+            ->values()
+            ->all();
+    }
+
+    private static function canRead(): bool
+    {
+        $guard = (string) config('admin.guard', 'admin');
+        $user = auth($guard)->user();
+
+        return is_object($user)
+            && method_exists($user, 'hasPermission')
+            && (
+                $user->hasPermission(PermissionNames::ADMIN_CONTENT_READ)
+                || $user->hasPermission(PermissionNames::ADMIN_OWNER)
+            );
+    }
+
+    private static function canPublish(): bool
+    {
+        $guard = (string) config('admin.guard', 'admin');
+        $user = auth($guard)->user();
+
+        return is_object($user)
+            && method_exists($user, 'hasPermission')
+            && (
+                $user->hasPermission(PermissionNames::ADMIN_CONTENT_PUBLISH)
+                || $user->hasPermission(PermissionNames::ADMIN_OWNER)
+            );
+    }
+}

--- a/backend/app/Filament/Ops/Resources/CareerJobResource/Pages/CreateCareerJob.php
+++ b/backend/app/Filament/Ops/Resources/CareerJobResource/Pages/CreateCareerJob.php
@@ -1,0 +1,134 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Filament\Ops\Resources\CareerJobResource\Pages;
+
+use App\Filament\Ops\Resources\CareerJobResource;
+use App\Filament\Ops\Resources\CareerJobResource\Support\CareerJobWorkspace;
+use Filament\Actions\Action;
+use Filament\Resources\Pages\CreateRecord;
+use Illuminate\Contracts\Support\Htmlable;
+
+class CreateCareerJob extends CreateRecord
+{
+    protected static string $resource = CareerJobResource::class;
+
+    /**
+     * @var array<string, mixed>
+     */
+    protected array $workspaceSectionsState = [];
+
+    /**
+     * @var array<string, mixed>
+     */
+    protected array $workspaceSeoState = [];
+
+    public function getTitle(): string|Htmlable
+    {
+        return 'Create Career Job';
+    }
+
+    public function getSubheading(): ?string
+    {
+        return 'Build a structured career job in the main workspace, then finish publish and SEO cues in the side rail.';
+    }
+
+    protected function fillForm(): void
+    {
+        $this->callHook('beforeFill');
+
+        $this->form->fill(CareerJobWorkspace::defaultFormState());
+
+        $this->callHook('afterFill');
+    }
+
+    protected function getHeaderActions(): array
+    {
+        return [
+            Action::make('backToCareerJobs')
+                ->label('All Career Jobs')
+                ->url(CareerJobResource::getUrl())
+                ->icon('heroicon-o-arrow-left')
+                ->color('gray'),
+        ];
+    }
+
+    protected function getCreateFormAction(): Action
+    {
+        return parent::getCreateFormAction()
+            ->label('Create Career Job')
+            ->icon('heroicon-o-check-circle');
+    }
+
+    protected function getCreateAnotherFormAction(): Action
+    {
+        return parent::getCreateAnotherFormAction()
+            ->label('Create & Add Another')
+            ->icon('heroicon-o-document-duplicate');
+    }
+
+    protected function getCancelFormAction(): Action
+    {
+        return parent::getCancelFormAction()
+            ->label('Back to Career Jobs')
+            ->icon('heroicon-o-arrow-left');
+    }
+
+    /**
+     * @param  array<string, mixed>  $data
+     * @return array<string, mixed>
+     */
+    protected function mutateFormDataBeforeCreate(array $data): array
+    {
+        $this->workspaceSectionsState = is_array($data['workspace_sections'] ?? null) ? $data['workspace_sections'] : [];
+        $this->workspaceSeoState = is_array($data['workspace_seo'] ?? null) ? $data['workspace_seo'] : [];
+
+        unset($data['workspace_sections'], $data['workspace_seo']);
+
+        $jobCode = CareerJobWorkspace::normalizeJobCode(
+            (string) ($data['job_code'] ?? ''),
+            (string) ($data['slug'] ?? ''),
+        );
+
+        $data['org_id'] = 0;
+        $data['job_code'] = $jobCode;
+        $data['slug'] = CareerJobWorkspace::normalizeSlug((string) ($data['slug'] ?? ''), $jobCode);
+        $data['locale'] = CareerJobWorkspace::normalizeLocale((string) ($data['locale'] ?? 'en'));
+        $data['created_by_admin_user_id'] = $this->currentAdminId();
+        $data['updated_by_admin_user_id'] = $this->currentAdminId();
+
+        return $data;
+    }
+
+    protected function afterCreate(): void
+    {
+        CareerJobWorkspace::syncWorkspaceSections($this->getRecord(), $this->workspaceSectionsState);
+        CareerJobWorkspace::syncWorkspaceSeo($this->getRecord(), $this->workspaceSeoState);
+        $this->getRecord()->unsetRelation('sections');
+        $this->getRecord()->unsetRelation('seoMeta');
+        CareerJobWorkspace::createRevision($this->getRecord(), 'Initial workspace snapshot', auth((string) config('admin.guard', 'admin'))->user());
+    }
+
+    protected function getCreatedNotificationTitle(): ?string
+    {
+        return 'Career job created';
+    }
+
+    protected function getRedirectUrl(): string
+    {
+        return CareerJobResource::getUrl('edit', ['record' => $this->getRecord()]);
+    }
+
+    private function currentAdminId(): ?int
+    {
+        $guard = (string) config('admin.guard', 'admin');
+        $user = auth($guard)->user();
+
+        if (! is_object($user) || ! method_exists($user, 'getAuthIdentifier')) {
+            return null;
+        }
+
+        return (int) $user->getAuthIdentifier();
+    }
+}

--- a/backend/app/Filament/Ops/Resources/CareerJobResource/Pages/EditCareerJob.php
+++ b/backend/app/Filament/Ops/Resources/CareerJobResource/Pages/EditCareerJob.php
@@ -1,0 +1,130 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Filament\Ops\Resources\CareerJobResource\Pages;
+
+use App\Filament\Ops\Resources\CareerJobResource;
+use App\Filament\Ops\Resources\CareerJobResource\Support\CareerJobWorkspace;
+use Filament\Actions\Action;
+use Filament\Resources\Pages\EditRecord;
+use Illuminate\Contracts\Support\Htmlable;
+
+class EditCareerJob extends EditRecord
+{
+    protected static string $resource = CareerJobResource::class;
+
+    /**
+     * @var array<string, mixed>
+     */
+    protected array $workspaceSectionsState = [];
+
+    /**
+     * @var array<string, mixed>
+     */
+    protected array $workspaceSeoState = [];
+
+    public function getTitle(): string|Htmlable
+    {
+        return filled($this->getRecord()->title) ? (string) $this->getRecord()->title : 'Edit Career Job';
+    }
+
+    public function getSubheading(): ?string
+    {
+        return 'Maintain the career job without leaving the structured editorial workspace.';
+    }
+
+    protected function getHeaderActions(): array
+    {
+        return [
+            Action::make('backToCareerJobs')
+                ->label('All Career Jobs')
+                ->url(CareerJobResource::getUrl())
+                ->icon('heroicon-o-arrow-left')
+                ->color('gray'),
+        ];
+    }
+
+    protected function getSaveFormAction(): Action
+    {
+        return parent::getSaveFormAction()
+            ->label('Save Changes')
+            ->icon('heroicon-o-check-circle');
+    }
+
+    protected function getCancelFormAction(): Action
+    {
+        return parent::getCancelFormAction()
+            ->label('Back to Career Jobs')
+            ->icon('heroicon-o-arrow-left');
+    }
+
+    /**
+     * @param  array<string, mixed>  $data
+     * @return array<string, mixed>
+     */
+    protected function mutateFormDataBeforeFill(array $data): array
+    {
+        return [
+            ...$data,
+            'workspace_sections' => CareerJobWorkspace::workspaceSectionsFromRecord($this->getRecord()),
+            'workspace_seo' => CareerJobWorkspace::workspaceSeoFromRecord($this->getRecord()),
+        ];
+    }
+
+    /**
+     * @param  array<string, mixed>  $data
+     * @return array<string, mixed>
+     */
+    protected function mutateFormDataBeforeSave(array $data): array
+    {
+        $this->workspaceSectionsState = is_array($data['workspace_sections'] ?? null) ? $data['workspace_sections'] : [];
+        $this->workspaceSeoState = is_array($data['workspace_seo'] ?? null) ? $data['workspace_seo'] : [];
+
+        unset($data['workspace_sections'], $data['workspace_seo']);
+
+        $jobCode = CareerJobWorkspace::normalizeJobCode(
+            (string) ($data['job_code'] ?? ''),
+            (string) ($data['slug'] ?? ''),
+        );
+
+        $data['org_id'] = 0;
+        $data['job_code'] = $jobCode;
+        $data['slug'] = CareerJobWorkspace::normalizeSlug((string) ($data['slug'] ?? ''), $jobCode);
+        $data['locale'] = CareerJobWorkspace::normalizeLocale((string) ($data['locale'] ?? 'en'));
+        $data['updated_by_admin_user_id'] = $this->currentAdminId();
+
+        return $data;
+    }
+
+    protected function afterSave(): void
+    {
+        CareerJobWorkspace::syncWorkspaceSections($this->getRecord(), $this->workspaceSectionsState);
+        CareerJobWorkspace::syncWorkspaceSeo($this->getRecord(), $this->workspaceSeoState);
+        $this->getRecord()->unsetRelation('sections');
+        $this->getRecord()->unsetRelation('seoMeta');
+        CareerJobWorkspace::createRevision($this->getRecord(), 'Workspace update', auth((string) config('admin.guard', 'admin'))->user());
+    }
+
+    protected function getSavedNotificationTitle(): ?string
+    {
+        return 'Career job updated';
+    }
+
+    protected function getRedirectUrl(): string
+    {
+        return CareerJobResource::getUrl('edit', ['record' => $this->getRecord()]);
+    }
+
+    private function currentAdminId(): ?int
+    {
+        $guard = (string) config('admin.guard', 'admin');
+        $user = auth($guard)->user();
+
+        if (! is_object($user) || ! method_exists($user, 'getAuthIdentifier')) {
+            return null;
+        }
+
+        return (int) $user->getAuthIdentifier();
+    }
+}

--- a/backend/app/Filament/Ops/Resources/CareerJobResource/Pages/ListCareerJobs.php
+++ b/backend/app/Filament/Ops/Resources/CareerJobResource/Pages/ListCareerJobs.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Filament\Ops\Resources\CareerJobResource\Pages;
+
+use App\Filament\Ops\Resources\CareerJobResource;
+use App\Filament\Ops\Resources\Pages\Concerns\HasSharedListEmptyState;
+use Filament\Actions;
+use Filament\Resources\Pages\ListRecords;
+use Illuminate\Contracts\Support\Htmlable;
+
+class ListCareerJobs extends ListRecords
+{
+    use HasSharedListEmptyState;
+
+    protected static string $resource = CareerJobResource::class;
+
+    public function getTitle(): string|Htmlable
+    {
+        return 'Career Jobs';
+    }
+
+    public function getSubheading(): ?string
+    {
+        return 'Global career content workspace for structured career job profiles. Not tenant-specific.';
+    }
+
+    protected function getHeaderActions(): array
+    {
+        return [
+            Actions\CreateAction::make()
+                ->label('Create Career Job')
+                ->icon('heroicon-o-plus'),
+        ];
+    }
+}

--- a/backend/app/Filament/Ops/Resources/CareerJobResource/Support/CareerJobWorkspace.php
+++ b/backend/app/Filament/Ops/Resources/CareerJobResource/Support/CareerJobWorkspace.php
@@ -1,0 +1,764 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Filament\Ops\Resources\CareerJobResource\Support;
+
+use App\Filament\Ops\Support\StatusBadge;
+use App\Models\CareerJob;
+use App\Models\CareerJobRevision;
+use App\Models\CareerJobSection;
+use App\Models\CareerJobSeoMeta;
+use App\Services\Cms\CareerJobSeoService;
+use Filament\Forms\Get;
+use Illuminate\Contracts\Support\Htmlable;
+use Illuminate\Support\Carbon;
+use Illuminate\Support\HtmlString;
+use Illuminate\Support\Str;
+use Illuminate\Validation\ValidationException;
+
+final class CareerJobWorkspace
+{
+    /**
+     * @return array<string, array{label: string, title: string, description: string, render_variant: string, sort_order: int, enabled: bool}>
+     */
+    public static function sectionDefinitions(): array
+    {
+        return [
+            'day_to_day' => [
+                'label' => 'Day to Day',
+                'title' => 'A typical day',
+                'description' => 'Optional close-up on the rhythm, cadence, and recurring work patterns in this role.',
+                'render_variant' => 'rich_text',
+                'sort_order' => 10,
+                'enabled' => false,
+            ],
+            'skills_explained' => [
+                'label' => 'Skills Explained',
+                'title' => 'How the skills show up',
+                'description' => 'Optional explanation of how abstract skill labels appear in real work.',
+                'render_variant' => 'cards',
+                'sort_order' => 20,
+                'enabled' => false,
+            ],
+            'growth_story' => [
+                'label' => 'Growth Story',
+                'title' => 'Growth story',
+                'description' => 'Optional narrative that makes the career progression feel more concrete and human.',
+                'render_variant' => 'rich_text',
+                'sort_order' => 30,
+                'enabled' => false,
+            ],
+            'work_environment' => [
+                'label' => 'Work Environment',
+                'title' => 'Work environment',
+                'description' => 'Optional guidance about teams, collaboration patterns, pace, and operating context.',
+                'render_variant' => 'callout',
+                'sort_order' => 40,
+                'enabled' => false,
+            ],
+            'faq' => [
+                'label' => 'FAQ',
+                'title' => 'Frequently asked questions',
+                'description' => 'Optional FAQ block for recurring editorial questions about this career path.',
+                'render_variant' => 'faq',
+                'sort_order' => 50,
+                'enabled' => false,
+            ],
+            'related_reading_intro' => [
+                'label' => 'Related Reading Intro',
+                'title' => 'Related reading',
+                'description' => 'Optional lead-in copy for future supporting guides or resource links.',
+                'render_variant' => 'links',
+                'sort_order' => 60,
+                'enabled' => false,
+            ],
+        ];
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    public static function renderVariantOptions(): array
+    {
+        return collect(CareerJobSection::RENDER_VARIANTS)
+            ->mapWithKeys(static fn (string $variant): array => [
+                $variant => Str::of($variant)->replace('_', ' ')->headline()->value(),
+            ])
+            ->all();
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public static function defaultFormState(): array
+    {
+        return [
+            'org_id' => 0,
+            'job_code' => '',
+            'slug' => '',
+            'locale' => 'en',
+            'title' => '',
+            'subtitle' => '',
+            'excerpt' => '',
+            'hero_kicker' => '',
+            'hero_quote' => '',
+            'cover_image_url' => '',
+            'industry_slug' => '',
+            'industry_label' => '',
+            'body_md' => '',
+            'status' => CareerJob::STATUS_DRAFT,
+            'is_public' => true,
+            'is_indexable' => true,
+            'published_at' => null,
+            'scheduled_at' => null,
+            'sort_order' => 0,
+            'salary_json' => [
+                'currency' => '',
+                'region' => '',
+                'low' => null,
+                'median' => null,
+                'high' => null,
+                'notes' => '',
+            ],
+            'outlook_json' => [
+                'summary' => '',
+                'horizon_years' => null,
+                'notes' => '',
+            ],
+            'skills_json' => [
+                'core' => [],
+                'supporting' => [],
+            ],
+            'work_contents_json' => [
+                'items' => [],
+            ],
+            'growth_path_json' => [
+                'entry' => '',
+                'mid' => '',
+                'senior' => '',
+                'notes' => '',
+            ],
+            'fit_personality_codes_json' => [],
+            'mbti_primary_codes_json' => [],
+            'mbti_secondary_codes_json' => [],
+            'riasec_profile_json' => [
+                'R' => null,
+                'I' => null,
+                'A' => null,
+                'S' => null,
+                'E' => null,
+                'C' => null,
+            ],
+            'big5_targets_json' => [
+                'openness' => '',
+                'conscientiousness' => '',
+                'extraversion' => '',
+                'agreeableness' => '',
+                'neuroticism' => '',
+            ],
+            'iq_eq_notes_json' => [
+                'iq' => '',
+                'eq' => '',
+            ],
+            'market_demand_json' => [
+                'signal' => '',
+                'notes' => '',
+            ],
+            'workspace_sections' => self::defaultWorkspaceSectionsState(),
+            'workspace_seo' => self::defaultWorkspaceSeoState(),
+        ];
+    }
+
+    /**
+     * @return array<string, array<string, mixed>>
+     */
+    public static function defaultWorkspaceSectionsState(): array
+    {
+        $state = [];
+
+        foreach (self::sectionDefinitions() as $sectionKey => $definition) {
+            $state[$sectionKey] = [
+                'title' => $definition['title'],
+                'render_variant' => $definition['render_variant'],
+                'body_md' => '',
+                'payload_json_text' => '',
+                'sort_order' => $definition['sort_order'],
+                'is_enabled' => $definition['enabled'],
+            ];
+        }
+
+        return $state;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public static function defaultWorkspaceSeoState(): array
+    {
+        return [
+            'seo_title' => '',
+            'seo_description' => '',
+            'canonical_url' => '',
+            'og_title' => '',
+            'og_description' => '',
+            'og_image_url' => '',
+            'twitter_title' => '',
+            'twitter_description' => '',
+            'twitter_image_url' => '',
+            'robots' => '',
+        ];
+    }
+
+    /**
+     * @return array<string, array<string, mixed>>
+     */
+    public static function workspaceSectionsFromRecord(?CareerJob $job): array
+    {
+        $state = self::defaultWorkspaceSectionsState();
+
+        if (! $job instanceof CareerJob) {
+            return $state;
+        }
+
+        $job->loadMissing('sections');
+
+        foreach ($job->sections as $section) {
+            $sectionKey = (string) $section->section_key;
+
+            if (! array_key_exists($sectionKey, $state)) {
+                continue;
+            }
+
+            $state[$sectionKey] = [
+                'title' => filled($section->title) ? (string) $section->title : (string) $state[$sectionKey]['title'],
+                'render_variant' => filled($section->render_variant) ? (string) $section->render_variant : (string) $state[$sectionKey]['render_variant'],
+                'body_md' => (string) ($section->body_md ?? ''),
+                'payload_json_text' => self::encodeJson($section->payload_json),
+                'sort_order' => (int) ($section->sort_order ?? $state[$sectionKey]['sort_order']),
+                'is_enabled' => (bool) $section->is_enabled,
+            ];
+        }
+
+        return $state;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public static function workspaceSeoFromRecord(?CareerJob $job): array
+    {
+        $state = self::defaultWorkspaceSeoState();
+
+        if (! $job instanceof CareerJob) {
+            return $state;
+        }
+
+        $job->loadMissing('seoMeta');
+        $seoMeta = $job->seoMeta;
+
+        if (! $seoMeta instanceof CareerJobSeoMeta) {
+            return $state;
+        }
+
+        return [
+            'seo_title' => (string) ($seoMeta->seo_title ?? ''),
+            'seo_description' => (string) ($seoMeta->seo_description ?? ''),
+            'canonical_url' => (string) ($seoMeta->canonical_url ?? ''),
+            'og_title' => (string) ($seoMeta->og_title ?? ''),
+            'og_description' => (string) ($seoMeta->og_description ?? ''),
+            'og_image_url' => (string) ($seoMeta->og_image_url ?? ''),
+            'twitter_title' => (string) ($seoMeta->twitter_title ?? ''),
+            'twitter_description' => (string) ($seoMeta->twitter_description ?? ''),
+            'twitter_image_url' => (string) ($seoMeta->twitter_image_url ?? ''),
+            'robots' => (string) ($seoMeta->robots ?? ''),
+        ];
+    }
+
+    /**
+     * @param  array<string, mixed>  $state
+     */
+    public static function syncWorkspaceSections(CareerJob $job, array $state): void
+    {
+        $definitions = self::sectionDefinitions();
+        $knownSectionKeys = array_keys($definitions);
+
+        CareerJobSection::query()
+            ->where('job_id', (int) $job->id)
+            ->whereNotIn('section_key', $knownSectionKeys)
+            ->delete();
+
+        foreach ($definitions as $sectionKey => $definition) {
+            $sectionState = array_merge(
+                self::defaultWorkspaceSectionsState()[$sectionKey],
+                is_array($state[$sectionKey] ?? null) ? $state[$sectionKey] : [],
+            );
+
+            CareerJobSection::query()->updateOrCreate(
+                [
+                    'job_id' => (int) $job->id,
+                    'section_key' => $sectionKey,
+                ],
+                [
+                    'title' => self::normalizeNullableText((string) ($sectionState['title'] ?? '')) ?? $definition['title'],
+                    'render_variant' => self::normalizeRenderVariant((string) ($sectionState['render_variant'] ?? $definition['render_variant']), $definition['render_variant']),
+                    'body_md' => self::normalizeNullableText((string) ($sectionState['body_md'] ?? '')),
+                    'body_html' => null,
+                    'payload_json' => self::decodeJsonText(
+                        $sectionState['payload_json_text'] ?? null,
+                        "workspace_sections.{$sectionKey}.payload_json_text",
+                    ),
+                    'sort_order' => (int) ($sectionState['sort_order'] ?? $definition['sort_order']),
+                    'is_enabled' => StatusBadge::isTruthy($sectionState['is_enabled'] ?? $definition['enabled']),
+                ],
+            );
+        }
+
+        $job->unsetRelation('sections');
+    }
+
+    /**
+     * @param  array<string, mixed>  $state
+     */
+    public static function syncWorkspaceSeo(CareerJob $job, array $state): void
+    {
+        CareerJobSeoMeta::query()->updateOrCreate(
+            [
+                'job_id' => (int) $job->id,
+            ],
+            [
+                'seo_title' => self::normalizeNullableText((string) ($state['seo_title'] ?? '')),
+                'seo_description' => self::normalizeNullableText((string) ($state['seo_description'] ?? '')),
+                'canonical_url' => self::normalizeNullableText((string) ($state['canonical_url'] ?? '')),
+                'og_title' => self::normalizeNullableText((string) ($state['og_title'] ?? '')),
+                'og_description' => self::normalizeNullableText((string) ($state['og_description'] ?? '')),
+                'og_image_url' => self::normalizeNullableText((string) ($state['og_image_url'] ?? '')),
+                'twitter_title' => self::normalizeNullableText((string) ($state['twitter_title'] ?? '')),
+                'twitter_description' => self::normalizeNullableText((string) ($state['twitter_description'] ?? '')),
+                'twitter_image_url' => self::normalizeNullableText((string) ($state['twitter_image_url'] ?? '')),
+                'robots' => self::normalizeNullableText((string) ($state['robots'] ?? '')),
+            ],
+        );
+
+        $job->unsetRelation('seoMeta');
+    }
+
+    public static function nextRevisionNo(CareerJob $job): int
+    {
+        return (int) CareerJobRevision::query()
+            ->where('job_id', (int) $job->id)
+            ->max('revision_no') + 1;
+    }
+
+    /**
+     * @param  array<string, mixed>  $formData
+     * @return array<string, mixed>
+     */
+    public static function snapshotPayload(CareerJob $job, array $formData = []): array
+    {
+        $job->loadMissing('sections', 'seoMeta');
+
+        return [
+            'job' => [
+                'id' => (int) $job->id,
+                'org_id' => (int) $job->org_id,
+                'job_code' => (string) $job->job_code,
+                'slug' => (string) $job->slug,
+                'locale' => (string) $job->locale,
+                'title' => (string) $job->title,
+                'subtitle' => $job->subtitle,
+                'excerpt' => $job->excerpt,
+                'hero_kicker' => $job->hero_kicker,
+                'hero_quote' => $job->hero_quote,
+                'cover_image_url' => $job->cover_image_url,
+                'industry_slug' => $job->industry_slug,
+                'industry_label' => $job->industry_label,
+                'body_md' => $job->body_md,
+                'body_html' => $job->body_html,
+                'salary_json' => $job->salary_json,
+                'outlook_json' => $job->outlook_json,
+                'skills_json' => $job->skills_json,
+                'work_contents_json' => $job->work_contents_json,
+                'growth_path_json' => $job->growth_path_json,
+                'fit_personality_codes_json' => $job->fit_personality_codes_json,
+                'mbti_primary_codes_json' => $job->mbti_primary_codes_json,
+                'mbti_secondary_codes_json' => $job->mbti_secondary_codes_json,
+                'riasec_profile_json' => $job->riasec_profile_json,
+                'big5_targets_json' => $job->big5_targets_json,
+                'iq_eq_notes_json' => $job->iq_eq_notes_json,
+                'market_demand_json' => $job->market_demand_json,
+                'status' => (string) $job->status,
+                'is_public' => (bool) $job->is_public,
+                'is_indexable' => (bool) $job->is_indexable,
+                'published_at' => $job->published_at?->toIso8601String(),
+                'scheduled_at' => $job->scheduled_at?->toIso8601String(),
+                'schema_version' => (string) $job->schema_version,
+                'sort_order' => (int) $job->sort_order,
+            ],
+            'sections' => $job->sections
+                ->map(static fn (CareerJobSection $section): array => [
+                    'section_key' => (string) $section->section_key,
+                    'title' => $section->title,
+                    'render_variant' => (string) $section->render_variant,
+                    'body_md' => $section->body_md,
+                    'body_html' => $section->body_html,
+                    'payload_json' => $section->payload_json,
+                    'sort_order' => (int) $section->sort_order,
+                    'is_enabled' => (bool) $section->is_enabled,
+                ])
+                ->values()
+                ->all(),
+            'seo_meta' => $job->seoMeta instanceof CareerJobSeoMeta
+                ? [
+                    'seo_title' => $job->seoMeta->seo_title,
+                    'seo_description' => $job->seoMeta->seo_description,
+                    'canonical_url' => $job->seoMeta->canonical_url,
+                    'og_title' => $job->seoMeta->og_title,
+                    'og_description' => $job->seoMeta->og_description,
+                    'og_image_url' => $job->seoMeta->og_image_url,
+                    'twitter_title' => $job->seoMeta->twitter_title,
+                    'twitter_description' => $job->seoMeta->twitter_description,
+                    'twitter_image_url' => $job->seoMeta->twitter_image_url,
+                    'robots' => $job->seoMeta->robots,
+                ]
+                : null,
+            'workspace' => [
+                'form_data' => $formData,
+            ],
+        ];
+    }
+
+    public static function createRevision(CareerJob $job, string $note, ?object $adminUser = null): void
+    {
+        CareerJobRevision::query()->create([
+            'job_id' => (int) $job->id,
+            'revision_no' => self::nextRevisionNo($job),
+            'snapshot_json' => self::snapshotPayload($job),
+            'note' => $note,
+            'created_by_admin_user_id' => self::resolveAdminUserId($adminUser),
+            'created_at' => now(),
+        ]);
+    }
+
+    public static function plannedPublicUrl(CareerJob|string $jobOrSlug, string $locale): ?string
+    {
+        $slug = $jobOrSlug instanceof CareerJob
+            ? (string) $jobOrSlug->slug
+            : (string) $jobOrSlug;
+
+        $resolvedSlug = trim($slug);
+        $baseUrl = rtrim((string) config('app.frontend_url', config('app.url', '')), '/');
+
+        if ($resolvedSlug === '' || $baseUrl === '') {
+            return null;
+        }
+
+        $segment = app(CareerJobSeoService::class)->mapBackendLocaleToFrontendSegment($locale);
+
+        return $baseUrl.'/'.trim($segment, '/').'/career/jobs/'.rawurlencode(Str::lower($resolvedSlug));
+    }
+
+    /**
+     * @return array<int, array{label: string, description: string, ready: bool}>
+     */
+    public static function seoCompleteness(CareerJob $job): array
+    {
+        $seoMeta = self::resolveSeoMeta($job);
+
+        return self::buildSeoCompleteness([
+            'seo_title' => $seoMeta?->seo_title,
+            'seo_description' => $seoMeta?->seo_description,
+            'og_title' => $seoMeta?->og_title,
+            'og_description' => $seoMeta?->og_description,
+            'twitter_title' => $seoMeta?->twitter_title,
+            'twitter_description' => $seoMeta?->twitter_description,
+        ], self::plannedPublicUrl($job, (string) $job->locale), (bool) $job->is_indexable);
+    }
+
+    public static function renderEditorialCues(Get $get, ?CareerJob $record = null): Htmlable
+    {
+        $status = trim((string) ($get('status') ?? $record?->status ?? CareerJob::STATUS_DRAFT));
+        $isPublic = StatusBadge::isTruthy($get('is_public') ?? $record?->is_public ?? false);
+        $isIndexable = StatusBadge::isTruthy($get('is_indexable') ?? $record?->is_indexable ?? true);
+        $plannedUrl = self::plannedPublicUrl(
+            (string) ($get('slug') ?? $record?->slug ?? ''),
+            (string) ($get('locale') ?? $record?->locale ?? 'en'),
+        );
+
+        return new HtmlString((string) view('filament.ops.career-jobs.partials.editorial-cues', [
+            'facts' => array_values(array_filter([
+                [
+                    'label' => 'Published',
+                    'value' => self::formatTimestamp($get('published_at') ?? $record?->published_at),
+                ],
+                [
+                    'label' => 'Scheduled',
+                    'value' => self::formatTimestamp($get('scheduled_at') ?? $record?->scheduled_at),
+                ],
+                [
+                    'label' => 'Planned public URL',
+                    'value' => $plannedUrl,
+                ],
+                [
+                    'label' => 'Revisions',
+                    'value' => $record instanceof CareerJob ? (string) self::revisionCount($record) : null,
+                ],
+            ], static fn (array $fact): bool => filled($fact['value'] ?? null))),
+            'pills' => [
+                [
+                    'label' => self::statusLabel($status),
+                    'state' => $status,
+                ],
+                [
+                    'label' => $isPublic ? 'Public' : 'Private',
+                    'state' => $isPublic ? 'public' : 'inactive',
+                ],
+                [
+                    'label' => $isIndexable ? 'Indexable' : 'Noindex',
+                    'state' => $isIndexable ? 'indexable' : 'noindex',
+                ],
+            ],
+        ])->render());
+    }
+
+    public static function renderSeoSnapshot(Get $get, ?CareerJob $record = null): Htmlable
+    {
+        $plannedCanonical = self::plannedPublicUrl(
+            (string) ($get('slug') ?? $record?->slug ?? ''),
+            (string) ($get('locale') ?? $record?->locale ?? 'en'),
+        );
+
+        return new HtmlString((string) view('filament.ops.career-jobs.partials.seo-snapshot', [
+            'checks' => self::buildSeoCompleteness([
+                'seo_title' => $get('workspace_seo.seo_title') ?? $record?->seoMeta?->seo_title,
+                'seo_description' => $get('workspace_seo.seo_description') ?? $record?->seoMeta?->seo_description,
+                'og_title' => $get('workspace_seo.og_title') ?? $record?->seoMeta?->og_title,
+                'og_description' => $get('workspace_seo.og_description') ?? $record?->seoMeta?->og_description,
+                'twitter_title' => $get('workspace_seo.twitter_title') ?? $record?->seoMeta?->twitter_title,
+                'twitter_description' => $get('workspace_seo.twitter_description') ?? $record?->seoMeta?->twitter_description,
+            ], $plannedCanonical, StatusBadge::isTruthy($get('is_indexable') ?? $record?->is_indexable ?? true)),
+            'plannedCanonical' => $plannedCanonical,
+        ])->render());
+    }
+
+    public static function formatTimestamp(mixed $value, string $fallback = 'Not set yet'): string
+    {
+        $formatted = self::normalizeTimestamp($value);
+
+        return $formatted ?? $fallback;
+    }
+
+    public static function titleMeta(CareerJob $job): string
+    {
+        return collect([
+            filled($job->job_code) ? Str::lower((string) $job->job_code) : null,
+            filled($job->slug) ? '/'.trim((string) $job->slug, '/') : null,
+            filled($job->locale) ? Str::upper((string) $job->locale) : null,
+        ])->filter(static fn (?string $value): bool => filled($value))->implode(' · ');
+    }
+
+    public static function visibilityMeta(CareerJob $job): string
+    {
+        return implode(' · ', [
+            StatusBadge::booleanLabel($job->is_public, 'Public', 'Private'),
+            StatusBadge::booleanLabel($job->is_indexable, 'Indexable', 'Noindex'),
+        ]);
+    }
+
+    public static function normalizeJobCode(?string $jobCode, ?string $slug = null): string
+    {
+        $candidate = trim((string) $jobCode);
+
+        if ($candidate === '' && filled($slug)) {
+            $candidate = (string) $slug;
+        }
+
+        return Str::of($candidate)
+            ->lower()
+            ->replace('_', '-')
+            ->slug('-')
+            ->value();
+    }
+
+    public static function normalizeSlug(?string $slug, ?string $jobCode = null): string
+    {
+        $candidate = trim((string) $slug);
+
+        if ($candidate === '' && filled($jobCode)) {
+            $candidate = (string) $jobCode;
+        }
+
+        return Str::of($candidate)
+            ->lower()
+            ->replace('_', '-')
+            ->slug('-')
+            ->value();
+    }
+
+    public static function normalizeLocale(?string $locale): string
+    {
+        $normalized = trim((string) $locale);
+
+        return in_array($normalized, CareerJob::SUPPORTED_LOCALES, true) ? $normalized : 'en';
+    }
+
+    /**
+     * @param  array<string, mixed>  $state
+     * @return array<int, array{label: string, description: string, ready: bool}>
+     */
+    private static function buildSeoCompleteness(array $state, ?string $plannedCanonical, bool $isIndexable): array
+    {
+        return [
+            [
+                'label' => 'SEO title',
+                'description' => 'Search headline for the career job page.',
+                'ready' => filled(trim((string) ($state['seo_title'] ?? ''))),
+            ],
+            [
+                'label' => 'SEO description',
+                'description' => 'Search description fallback is excerpt, then subtitle.',
+                'ready' => filled(trim((string) ($state['seo_description'] ?? ''))),
+            ],
+            [
+                'label' => 'Canonical route',
+                'description' => 'Final frontend route stays locale-aware even before frontend cutover.',
+                'ready' => filled($plannedCanonical),
+            ],
+            [
+                'label' => 'Social coverage',
+                'description' => 'Open Graph and Twitter overrides for richer sharing cards.',
+                'ready' => filled(trim((string) ($state['og_title'] ?? '')))
+                    && filled(trim((string) ($state['og_description'] ?? '')))
+                    && filled(trim((string) ($state['twitter_title'] ?? '')))
+                    && filled(trim((string) ($state['twitter_description'] ?? ''))),
+            ],
+            [
+                'label' => 'Robots',
+                'description' => $isIndexable ? 'Defaults to index,follow when left blank.' : 'Defaults to noindex,follow when left blank.',
+                'ready' => true,
+            ],
+        ];
+    }
+
+    private static function resolveSeoMeta(CareerJob $job): ?CareerJobSeoMeta
+    {
+        if ($job->relationLoaded('seoMeta') && $job->seoMeta instanceof CareerJobSeoMeta) {
+            return $job->seoMeta;
+        }
+
+        return CareerJobSeoMeta::query()
+            ->where('job_id', (int) $job->id)
+            ->first();
+    }
+
+    private static function revisionCount(CareerJob $job): int
+    {
+        return CareerJobRevision::query()
+            ->where('job_id', (int) $job->id)
+            ->count();
+    }
+
+    private static function resolveAdminUserId(?object $adminUser = null): ?int
+    {
+        if (is_object($adminUser) && method_exists($adminUser, 'getAuthIdentifier')) {
+            return (int) $adminUser->getAuthIdentifier();
+        }
+
+        $guard = (string) config('admin.guard', 'admin');
+        $user = auth($guard)->user();
+
+        if (! is_object($user) || ! method_exists($user, 'getAuthIdentifier')) {
+            return null;
+        }
+
+        return (int) $user->getAuthIdentifier();
+    }
+
+    private static function normalizeNullableText(string $value): ?string
+    {
+        $normalized = trim($value);
+
+        return $normalized === '' ? null : $normalized;
+    }
+
+    private static function normalizeRenderVariant(string $value, string $fallback): string
+    {
+        $normalized = trim($value);
+
+        return in_array($normalized, CareerJobSection::RENDER_VARIANTS, true) ? $normalized : $fallback;
+    }
+
+    private static function normalizeTimestamp(mixed $value): ?string
+    {
+        if ($value instanceof \DateTimeInterface) {
+            return Carbon::instance($value)->timezone(config('app.timezone'))->format('M j, Y H:i');
+        }
+
+        if (! is_string($value) || trim($value) === '') {
+            return null;
+        }
+
+        try {
+            return Carbon::parse($value)->timezone(config('app.timezone'))->format('M j, Y H:i');
+        } catch (\Throwable) {
+            return null;
+        }
+    }
+
+    private static function statusLabel(string $status): string
+    {
+        $normalized = trim($status);
+
+        if ($normalized === '') {
+            return 'Draft';
+        }
+
+        return Str::of($normalized)
+            ->replace(['_', '-'], ' ')
+            ->headline()
+            ->value();
+    }
+
+    private static function encodeJson(mixed $value): string
+    {
+        if ($value === null || $value === '' || $value === []) {
+            return '';
+        }
+
+        try {
+            $encoded = json_encode($value, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE);
+        } catch (\Throwable) {
+            return '';
+        }
+
+        return is_string($encoded) ? $encoded : '';
+    }
+
+    private static function decodeJsonText(mixed $value, string $field): ?array
+    {
+        if ($value === null) {
+            return null;
+        }
+
+        $text = trim((string) $value);
+        if ($text === '') {
+            return null;
+        }
+
+        try {
+            $decoded = json_decode($text, true, flags: JSON_THROW_ON_ERROR);
+        } catch (\Throwable) {
+            throw ValidationException::withMessages([
+                $field => 'Structured payload must be valid JSON.',
+            ]);
+        }
+
+        if (! is_array($decoded)) {
+            throw ValidationException::withMessages([
+                $field => 'Structured payload must decode to a JSON object or array.',
+            ]);
+        }
+
+        return $decoded;
+    }
+}

--- a/backend/resources/css/filament/ops/theme.css
+++ b/backend/resources/css/filament/ops/theme.css
@@ -1763,6 +1763,207 @@
         font-size: 0.75rem;
         line-height: 1.55;
     }
+
+    .ops-career-job-workspace-layout {
+        align-items: start;
+    }
+
+    .ops-career-job-workspace-main-column,
+    .ops-career-job-workspace-rail-column {
+        gap: 1.5rem;
+        display: grid;
+        align-content: start;
+    }
+
+    .ops-career-job-workspace-section .fi-section-header {
+        min-height: 5.5rem;
+    }
+
+    .ops-career-job-workspace-section--main .fi-section-header-heading {
+        font-size: 1.15rem;
+    }
+
+    .ops-career-job-workspace-section--rail .fi-section-header-heading {
+        font-size: 1rem;
+    }
+
+    .ops-career-job-workspace-field--title .fi-input-wrp {
+        min-height: 3.75rem;
+    }
+
+    .ops-career-job-workspace-input--title {
+        font-size: 1.3rem;
+        font-weight: 650;
+        letter-spacing: -0.035em;
+    }
+
+    .ops-career-job-workspace-field--summary textarea {
+        min-height: 7rem;
+    }
+
+    .ops-career-job-workspace-field--body textarea {
+        min-height: 13rem;
+    }
+
+    .ops-career-job-workspace-field--payload textarea {
+        min-height: 10rem;
+        font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", monospace;
+        font-size: 0.8125rem;
+    }
+
+    .ops-career-job-workspace-field--editor .fi-fo-markdown-editor {
+        border-radius: 18px;
+        overflow: hidden;
+        box-shadow: inset 0 0 0 1px var(--ops-border-default);
+    }
+
+    .ops-career-job-workspace-field--editor .editor-toolbar {
+        border-color: var(--ops-border-default);
+        background: rgba(247, 248, 250, 0.94);
+    }
+
+    .ops-career-job-workspace-field--editor .CodeMirror,
+    .ops-career-job-workspace-field--editor .EasyMDEContainer {
+        background: #fff;
+    }
+
+    .ops-career-job-workspace-field--editor .CodeMirror-scroll {
+        min-height: 21rem;
+    }
+
+    .ops-career-job-workspace-section .fi-fo-placeholder {
+        gap: 0.85rem;
+    }
+
+    .ops-career-job-workspace-tabs {
+        gap: 1rem;
+    }
+
+    .ops-career-job-workspace-tabs .fi-tabs {
+        margin-bottom: 1rem;
+    }
+
+    .ops-career-job-workspace-tabs .fi-tabs-item {
+        min-height: 2.75rem;
+    }
+
+    .ops-career-job-workspace-tabs .fi-fo-tabs-tab {
+        gap: 1rem;
+    }
+
+    .ops-career-job-workspace-cues,
+    .ops-career-job-workspace-seo {
+        display: grid;
+        gap: 1rem;
+    }
+
+    .ops-career-job-workspace-cues__pills {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 0.5rem;
+    }
+
+    .ops-career-job-workspace-cues__facts {
+        display: grid;
+        gap: 0.8rem;
+    }
+
+    .ops-career-job-workspace-cues__fact {
+        display: grid;
+        gap: 0.18rem;
+    }
+
+    .ops-career-job-workspace-cues__fact dt {
+        color: var(--ops-text-tertiary);
+        font-size: 0.72rem;
+        font-weight: 700;
+        letter-spacing: 0.06em;
+        text-transform: uppercase;
+    }
+
+    .ops-career-job-workspace-cues__fact dd {
+        color: var(--ops-text-primary);
+        font-size: 0.875rem;
+        line-height: 1.55;
+        margin: 0;
+    }
+
+    .ops-career-job-workspace-seo__grid {
+        display: grid;
+        gap: 0.8rem;
+    }
+
+    .ops-career-job-workspace-seo__item {
+        display: flex;
+        align-items: flex-start;
+        justify-content: space-between;
+        gap: 1rem;
+        padding: 0.9rem 1rem;
+        border-radius: 14px;
+        background: rgba(247, 248, 250, 0.85);
+        box-shadow: inset 0 0 0 1px rgba(229, 231, 235, 0.92);
+    }
+
+    .ops-career-job-workspace-seo__copy {
+        display: grid;
+        gap: 0.2rem;
+    }
+
+    .ops-career-job-workspace-seo__label {
+        color: var(--ops-text-primary);
+        font-size: 0.9rem;
+        font-weight: 650;
+        letter-spacing: -0.015em;
+    }
+
+    .ops-career-job-workspace-seo__description {
+        color: var(--ops-text-secondary);
+        font-size: 0.8125rem;
+        line-height: 1.55;
+    }
+
+    .ops-career-job-workspace-seo__planned {
+        display: grid;
+        gap: 0.25rem;
+        padding: 0.9rem 1rem;
+        border-radius: 14px;
+        background: rgba(var(--primary-50), 0.72);
+        box-shadow: inset 0 0 0 1px rgba(var(--primary-100), 0.9);
+    }
+
+    .ops-career-job-workspace-seo__planned-label {
+        color: rgb(var(--primary-700));
+        font-size: 0.72rem;
+        font-weight: 700;
+        letter-spacing: 0.06em;
+        text-transform: uppercase;
+    }
+
+    .ops-career-job-workspace-seo__planned-value {
+        color: var(--ops-text-primary);
+        font-size: 0.8125rem;
+        font-weight: 600;
+        line-height: 1.55;
+        word-break: break-word;
+    }
+
+    .ops-career-job-workspace-table-title {
+        display: grid;
+        gap: 0.2rem;
+    }
+
+    .ops-career-job-workspace-table-title__text {
+        color: var(--ops-text-primary);
+        font-size: 0.95rem;
+        font-weight: 700;
+        letter-spacing: -0.02em;
+    }
+
+    .ops-career-job-workspace-table-title__meta {
+        color: var(--ops-text-secondary);
+        font-size: 0.75rem;
+        line-height: 1.55;
+    }
 }
 
 @media (max-width: 1023px) {
@@ -1819,6 +2020,10 @@
     }
 
     .ops-personality-workspace-seo__item {
+        flex-direction: column;
+    }
+
+    .ops-career-job-workspace-seo__item {
         flex-direction: column;
     }
 }

--- a/backend/resources/views/filament/ops/career-jobs/partials/editorial-cues.blade.php
+++ b/backend/resources/views/filament/ops/career-jobs/partials/editorial-cues.blade.php
@@ -1,0 +1,18 @@
+<div class="ops-career-job-workspace-cues">
+    <div class="ops-career-job-workspace-cues__pills">
+        @foreach ($pills as $pill)
+            <x-filament.ops.shared.status-pill :label="$pill['label']" :state="$pill['state']" />
+        @endforeach
+    </div>
+
+    @if ($facts !== [])
+        <dl class="ops-career-job-workspace-cues__facts">
+            @foreach ($facts as $fact)
+                <div class="ops-career-job-workspace-cues__fact">
+                    <dt>{{ $fact['label'] }}</dt>
+                    <dd>{{ $fact['value'] }}</dd>
+                </div>
+            @endforeach
+        </dl>
+    @endif
+</div>

--- a/backend/resources/views/filament/ops/career-jobs/partials/seo-snapshot.blade.php
+++ b/backend/resources/views/filament/ops/career-jobs/partials/seo-snapshot.blade.php
@@ -1,0 +1,24 @@
+<div class="ops-career-job-workspace-seo">
+    <div class="ops-career-job-workspace-seo__grid">
+        @foreach ($checks as $check)
+            <div class="ops-career-job-workspace-seo__item">
+                <div class="ops-career-job-workspace-seo__copy">
+                    <span class="ops-career-job-workspace-seo__label">{{ $check['label'] }}</span>
+                    <span class="ops-career-job-workspace-seo__description">{{ $check['description'] }}</span>
+                </div>
+
+                <x-filament.ops.shared.status-pill
+                    :label="$check['ready'] ? 'Ready' : 'Missing'"
+                    :state="$check['ready'] ? 'ready' : 'draft'"
+                />
+            </div>
+        @endforeach
+    </div>
+
+    @if (filled($plannedCanonical))
+        <div class="ops-career-job-workspace-seo__planned">
+            <span class="ops-career-job-workspace-seo__planned-label">Planned canonical</span>
+            <span class="ops-career-job-workspace-seo__planned-value">{{ $plannedCanonical }}</span>
+        </div>
+    @endif
+</div>

--- a/backend/resources/views/filament/ops/career-jobs/partials/table-title.blade.php
+++ b/backend/resources/views/filament/ops/career-jobs/partials/table-title.blade.php
@@ -1,0 +1,7 @@
+<div class="ops-career-job-workspace-table-title">
+    <span class="ops-career-job-workspace-table-title__text">{{ $title }}</span>
+
+    @if (filled($meta))
+        <span class="ops-career-job-workspace-table-title__meta">{{ $meta }}</span>
+    @endif
+</div>

--- a/backend/tests/Feature/Ops/CareerJobWorkspaceTest.php
+++ b/backend/tests/Feature/Ops/CareerJobWorkspaceTest.php
@@ -1,0 +1,410 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Ops;
+
+use App\Filament\Ops\Resources\CareerJobResource;
+use App\Filament\Ops\Resources\CareerJobResource\Support\CareerJobWorkspace;
+use App\Models\AdminUser;
+use App\Models\CareerJob;
+use App\Models\CareerJobRevision;
+use App\Models\Organization;
+use App\Models\Permission;
+use App\Models\Role;
+use App\Support\OrgContext;
+use App\Support\Rbac\PermissionNames;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Http\Request;
+use Illuminate\Support\Str;
+use Tests\TestCase;
+
+final class CareerJobWorkspaceTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_career_job_workspace_pages_render_for_authorized_admin(): void
+    {
+        $admin = $this->createAdminWithPermissions([
+            PermissionNames::ADMIN_CONTENT_READ,
+            PermissionNames::ADMIN_CONTENT_PUBLISH,
+        ]);
+        $selectedOrg = $this->createSelectedOrg();
+        $job = $this->seedJob([
+            'title' => 'Product Manager',
+        ]);
+
+        CareerJobWorkspace::syncWorkspaceSections($job, $this->workspaceSectionsState());
+        CareerJobWorkspace::syncWorkspaceSeo($job, $this->workspaceSeoState());
+        CareerJobWorkspace::createRevision($job, 'Seed revision', $admin);
+
+        $this->withSession([
+            'ops_org_id' => $selectedOrg->id,
+            'ops_admin_totp_verified_user_id' => (int) $admin->id,
+        ])->actingAs($admin, (string) config('admin.guard', 'admin'))
+            ->get('/ops/career-jobs')
+            ->assertOk()
+            ->assertSee('Global career content workspace', false)
+            ->assertSee('Create Career Job');
+
+        $this->withSession([
+            'ops_org_id' => $selectedOrg->id,
+            'ops_admin_totp_verified_user_id' => (int) $admin->id,
+        ])->actingAs($admin, (string) config('admin.guard', 'admin'))
+            ->get('/ops/career-jobs/create')
+            ->assertOk()
+            ->assertSee('ops-career-job-workspace-layout', false)
+            ->assertSee('Create Career Job');
+
+        $this->withSession([
+            'ops_org_id' => $selectedOrg->id,
+            'ops_admin_totp_verified_user_id' => (int) $admin->id,
+        ])->actingAs($admin, (string) config('admin.guard', 'admin'))
+            ->get('/ops/career-jobs/'.$job->id.'/edit')
+            ->assertOk()
+            ->assertSee('ops-career-job-workspace-layout', false)
+            ->assertSee('Planned public URL');
+    }
+
+    public function test_workspace_sync_persists_sections_seo_revision_and_json_signals(): void
+    {
+        $job = $this->seedJob();
+
+        CareerJobWorkspace::syncWorkspaceSections($job, $this->workspaceSectionsState());
+        CareerJobWorkspace::syncWorkspaceSeo($job, $this->workspaceSeoState());
+        CareerJobWorkspace::createRevision($job, 'Initial workspace snapshot');
+
+        $this->assertDatabaseHas('career_job_sections', [
+            'job_id' => $job->id,
+            'section_key' => 'day_to_day',
+            'title' => 'A typical day',
+            'render_variant' => 'rich_text',
+            'is_enabled' => 1,
+        ]);
+
+        $this->assertDatabaseHas('career_job_seo_meta', [
+            'job_id' => $job->id,
+            'seo_title' => 'Product Manager Career Guide | FermatMind',
+            'robots' => 'index,follow',
+        ]);
+
+        $this->assertDatabaseHas('career_job_revisions', [
+            'job_id' => $job->id,
+            'revision_no' => 1,
+            'note' => 'Initial workspace snapshot',
+        ]);
+
+        $job->refresh();
+
+        $this->assertSame('USD', $job->salary_json['currency']);
+        $this->assertSame(['ENTJ', 'ENFJ'], $job->mbti_primary_codes_json);
+        $this->assertSame(88, $job->riasec_profile_json['E']);
+    }
+
+    public function test_workspace_sync_updates_job_sections_seo_revision_counter_and_signals(): void
+    {
+        $job = $this->seedJob();
+
+        CareerJobWorkspace::syncWorkspaceSections($job, $this->workspaceSectionsState());
+        CareerJobWorkspace::syncWorkspaceSeo($job, $this->workspaceSeoState());
+        CareerJobWorkspace::createRevision($job, 'Initial workspace snapshot');
+
+        $job->update([
+            'title' => 'Product Manager (Updated)',
+            'subtitle' => 'Sharper, clearer, and more actionable.',
+            'salary_json' => [
+                'currency' => 'USD',
+                'region' => 'US',
+                'low' => 90000,
+                'median' => 135000,
+                'high' => 195000,
+                'notes' => 'Updated salary range after market review.',
+            ],
+            'mbti_primary_codes_json' => ['ENTJ', 'INTJ'],
+            'riasec_profile_json' => [
+                'R' => 35,
+                'I' => 70,
+                'A' => 52,
+                'S' => 58,
+                'E' => 92,
+                'C' => 66,
+            ],
+        ]);
+
+        $updatedSections = $this->workspaceSectionsState();
+        $updatedSections['faq']['is_enabled'] = true;
+        $updatedSections['faq']['payload_json_text'] = json_encode([
+            'items' => [
+                [
+                    'question' => 'Do product managers need to code?',
+                    'answer' => 'Not always, but strong product judgment and technical fluency help.',
+                ],
+            ],
+        ], JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE);
+        $updatedSections['growth_story']['body_md'] = 'Updated growth story for the product manager path.';
+
+        $updatedSeo = $this->workspaceSeoState();
+        $updatedSeo['seo_description'] = 'Updated SEO summary for the product manager workspace.';
+
+        CareerJobWorkspace::syncWorkspaceSections($job, $updatedSections);
+        CareerJobWorkspace::syncWorkspaceSeo($job, $updatedSeo);
+        CareerJobWorkspace::createRevision($job, 'Workspace update');
+
+        $this->assertDatabaseHas('career_job_sections', [
+            'job_id' => $job->id,
+            'section_key' => 'faq',
+            'is_enabled' => 1,
+            'render_variant' => 'faq',
+        ]);
+
+        $this->assertDatabaseHas('career_job_seo_meta', [
+            'job_id' => $job->id,
+            'seo_description' => 'Updated SEO summary for the product manager workspace.',
+        ]);
+
+        $this->assertDatabaseHas('career_job_revisions', [
+            'job_id' => $job->id,
+            'revision_no' => 2,
+            'note' => 'Workspace update',
+        ]);
+
+        $job->refresh();
+        $this->assertSame(135000, $job->salary_json['median']);
+        $this->assertSame(['ENTJ', 'INTJ'], $job->mbti_primary_codes_json);
+        $this->assertSame(92, $job->riasec_profile_json['E']);
+
+        $latestRevision = CareerJobRevision::query()
+            ->where('job_id', $job->id)
+            ->where('revision_no', 2)
+            ->firstOrFail();
+
+        $this->assertSame('Product Manager (Updated)', $latestRevision->snapshot_json['job']['title']);
+        $this->assertSame('Updated growth story for the product manager path.', $latestRevision->snapshot_json['sections'][2]['body_md']);
+    }
+
+    public function test_resource_query_is_locked_to_global_career_jobs(): void
+    {
+        $globalJob = $this->seedJob([
+            'org_id' => 0,
+            'slug' => 'product-manager-global',
+            'job_code' => 'product-manager-global',
+        ]);
+
+        $tenantJob = $this->seedJob([
+            'org_id' => 77,
+            'slug' => 'product-manager-tenant',
+            'job_code' => 'product-manager-tenant',
+        ]);
+
+        $request = Request::create('/ops/career-jobs', 'GET');
+        app()->instance('request', $request);
+
+        $context = app(OrgContext::class);
+        $context->set(77, 9001, 'admin');
+        app()->instance(OrgContext::class, $context);
+
+        $ids = CareerJobResource::getEloquentQuery()
+            ->orderBy('id')
+            ->pluck('id')
+            ->all();
+
+        $this->assertContains($globalJob->id, $ids);
+        $this->assertNotContains($tenantJob->id, $ids);
+    }
+
+    public function test_workspace_ignores_unknown_section_keys(): void
+    {
+        $job = $this->seedJob();
+
+        $sections = $this->workspaceSectionsState();
+        $sections['rogue_section'] = [
+            'title' => 'Rogue',
+            'render_variant' => 'rich_text',
+            'body_md' => 'Should never persist.',
+            'payload_json_text' => '',
+            'sort_order' => 999,
+            'is_enabled' => true,
+        ];
+
+        CareerJobWorkspace::syncWorkspaceSections($job, $sections);
+
+        $this->assertDatabaseMissing('career_job_sections', [
+            'job_id' => $job->id,
+            'section_key' => 'rogue_section',
+        ]);
+    }
+
+    private function createSelectedOrg(): Organization
+    {
+        return Organization::query()->create([
+            'name' => 'Ops Workspace Org',
+            'owner_user_id' => 9001,
+            'status' => 'active',
+            'domain' => 'ops-workspace.example.test',
+            'timezone' => 'Asia/Shanghai',
+            'locale' => 'en',
+        ]);
+    }
+
+    /**
+     * @param  list<string>  $permissions
+     */
+    private function createAdminWithPermissions(array $permissions): AdminUser
+    {
+        $admin = AdminUser::query()->create([
+            'name' => 'admin_'.Str::lower(Str::random(6)),
+            'email' => 'admin_'.Str::lower(Str::random(6)).'@example.test',
+            'password' => bcrypt('secret'),
+            'is_active' => 1,
+        ]);
+
+        if ($permissions === []) {
+            return $admin;
+        }
+
+        $role = Role::query()->create([
+            'name' => 'role_'.Str::lower(Str::random(10)),
+            'description' => null,
+        ]);
+
+        foreach ($permissions as $permissionName) {
+            $permission = Permission::query()->firstOrCreate(
+                ['name' => $permissionName],
+                ['description' => null],
+            );
+
+            $role->permissions()->syncWithoutDetaching([$permission->id]);
+        }
+
+        $admin->roles()->syncWithoutDetaching([$role->id]);
+
+        return $admin;
+    }
+
+    /**
+     * @param  array<string, mixed>  $overrides
+     */
+    private function seedJob(array $overrides = []): CareerJob
+    {
+        return CareerJob::query()->create(array_merge([
+            'org_id' => 0,
+            'job_code' => 'product-manager',
+            'slug' => 'product-manager',
+            'locale' => 'en',
+            'title' => 'Product Manager',
+            'subtitle' => 'Lead product direction across user, business, and engineering goals.',
+            'excerpt' => 'Understand the responsibilities, salary, growth path, and personality fit for product managers.',
+            'hero_kicker' => 'Career profile',
+            'hero_quote' => 'Translate uncertainty into direction.',
+            'cover_image_url' => 'https://example.test/product-manager.png',
+            'industry_slug' => 'technology',
+            'industry_label' => 'Technology',
+            'body_md' => "## Role Overview\n\nGuide product direction across user, business, and engineering goals.",
+            'salary_json' => [
+                'currency' => 'USD',
+                'region' => 'US',
+                'low' => 80000,
+                'median' => 120000,
+                'high' => 180000,
+                'notes' => 'Ranges vary by city and seniority.',
+            ],
+            'outlook_json' => [
+                'summary' => 'Growing',
+                'horizon_years' => 5,
+                'notes' => 'Strong demand in AI-enabled product roles.',
+            ],
+            'skills_json' => [
+                'core' => ['roadmapping', 'prioritization'],
+                'supporting' => ['stakeholder management'],
+            ],
+            'work_contents_json' => [
+                'items' => ['Define product strategy', 'Coordinate design and engineering execution'],
+            ],
+            'growth_path_json' => [
+                'entry' => 'Associate Product Manager',
+                'mid' => 'Product Manager',
+                'senior' => 'Senior PM / Group PM',
+                'notes' => 'Track can branch into leadership or strategy.',
+            ],
+            'fit_personality_codes_json' => ['ENTJ', 'ENFJ', 'ESTP'],
+            'mbti_primary_codes_json' => ['ENTJ', 'ENFJ'],
+            'mbti_secondary_codes_json' => ['ENFP', 'ENTP'],
+            'riasec_profile_json' => [
+                'R' => 42,
+                'I' => 66,
+                'A' => 56,
+                'S' => 60,
+                'E' => 88,
+                'C' => 70,
+            ],
+            'big5_targets_json' => [
+                'openness' => 'high',
+                'conscientiousness' => 'high',
+                'extraversion' => 'balanced',
+                'agreeableness' => 'balanced',
+                'neuroticism' => 'low',
+            ],
+            'iq_eq_notes_json' => [
+                'iq' => 'Requires strong analytical reasoning.',
+                'eq' => 'Requires stakeholder empathy and communication.',
+            ],
+            'market_demand_json' => [
+                'signal' => 'high',
+                'notes' => 'Demand remains strong across SaaS, fintech, and AI startups.',
+            ],
+            'status' => CareerJob::STATUS_DRAFT,
+            'is_public' => true,
+            'is_indexable' => true,
+            'sort_order' => 10,
+            'schema_version' => 'v1',
+        ], $overrides));
+    }
+
+    /**
+     * @return array<string, array<string, mixed>>
+     */
+    private function workspaceSectionsState(): array
+    {
+        return array_replace_recursive(CareerJobWorkspace::defaultWorkspaceSectionsState(), [
+            'day_to_day' => [
+                'is_enabled' => true,
+                'body_md' => 'Mornings focus on priorities, afternoons on alignment, and evenings on decision follow-through.',
+            ],
+            'skills_explained' => [
+                'is_enabled' => true,
+                'render_variant' => 'cards',
+                'payload_json_text' => json_encode([
+                    'items' => [
+                        [
+                            'title' => 'Roadmapping',
+                            'body' => 'Turn ambiguity into clear priorities and staged delivery decisions.',
+                        ],
+                    ],
+                ], JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE),
+            ],
+            'growth_story' => [
+                'is_enabled' => true,
+                'body_md' => 'The path often begins with execution detail, then expands into prioritization, strategy, and people influence.',
+            ],
+        ]);
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    private function workspaceSeoState(): array
+    {
+        return [
+            'seo_title' => 'Product Manager Career Guide | FermatMind',
+            'seo_description' => 'Responsibilities, salary, growth path, and personality fit for product managers.',
+            'canonical_url' => '',
+            'og_title' => 'Product Manager Career Guide',
+            'og_description' => 'Responsibilities, salary, growth path, and personality fit for product managers.',
+            'og_image_url' => 'https://example.test/product-manager-og.png',
+            'twitter_title' => 'Product Manager Career Guide',
+            'twitter_description' => 'Responsibilities, salary, growth path, and personality fit for product managers.',
+            'twitter_image_url' => 'https://example.test/product-manager-twitter.png',
+            'robots' => 'index,follow',
+        ];
+    }
+}


### PR DESCRIPTION
Summary
- add the Ops resource and editorial workspace for Career CMS Lite v1 career jobs
- provide list, create, and edit experiences for structured career job content

What changed
- add a Filament resource for career jobs
- add a structured workspace for create/edit flows
- organize career job editing into stronger main-content vs metadata rails
- add workspace helpers for supplemental sections, seo meta, revision snapshots, and planned public url cues
- keep the existing backend theme, shell, and shared component layers

Design choices
- career jobs are edited as structured career content objects, not generic articles
- the primary narrative body remains on the main job record
- supplemental narrative sections stay fixed and controlled
- structured signals are edited through constrained UI inputs instead of raw JSON blobs
- v1 operates on global career content (org_id=0)
- public URL handling stays conservative until the frontend cutover is complete
- revision snapshots are written on create/update

Why this PR is small and safe
- no API changes
- no frontend changes
- no route changes outside the new resource
- no RBAC changes
- no recommendation-engine changes
- only Ops resource/workspace implementation for CareerJob CMS

Validation
- php artisan about
- php artisan route:list --path=ops --except-vendor
- php artisan route:list --path=career-jobs --except-vendor
- php artisan migrate
- php artisan filament:assets
- npm run build
- php artisan test --filter='(CareerJob|Career)'
- checked /ops/career-jobs, /ops/career-jobs/create, /ops/career-jobs/{record}/edit
