### PR TITLE
feat(career-cms): add baseline import for local career jobs content

### DIFF
--- a/backend/app/CareerCms/Baseline/CareerJobBaselineImporter.php
+++ b/backend/app/CareerCms/Baseline/CareerJobBaselineImporter.php
@@ -1,0 +1,455 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\CareerCms\Baseline;
+
+use App\Models\CareerJob;
+use App\Models\CareerJobRevision;
+use App\Models\CareerJobSection;
+use App\Models\CareerJobSeoMeta;
+use App\Models\Scopes\TenantScope;
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Support\Carbon;
+use Illuminate\Support\Facades\DB;
+
+final class CareerJobBaselineImporter
+{
+    /**
+     * @param  array<int, array<string, mixed>>  $jobs
+     * @param  array{
+     *   dry_run: bool,
+     *   upsert: bool,
+     *   status: 'draft'|'published'
+     * }  $options
+     * @return array<string, int|string|bool>
+     */
+    public function import(array $jobs, array $options): array
+    {
+        $dryRun = (bool) ($options['dry_run'] ?? false);
+        $upsert = (bool) ($options['upsert'] ?? false);
+        $status = (string) ($options['status'] ?? CareerJob::STATUS_DRAFT);
+
+        $summary = [
+            'jobs_found' => count($jobs),
+            'will_create' => 0,
+            'will_update' => 0,
+            'will_skip' => 0,
+            'revisions_to_create' => 0,
+            'errors_count' => 0,
+            'dry_run' => $dryRun,
+            'upsert' => $upsert,
+            'status_mode' => $status,
+        ];
+
+        foreach ($jobs as $jobPayload) {
+            $existing = $this->jobQuery()
+                ->where('org_id', 0)
+                ->where('job_code', (string) $jobPayload['job_code'])
+                ->where('locale', (string) $jobPayload['locale'])
+                ->first();
+
+            if (! $existing instanceof CareerJob) {
+                $summary['will_create']++;
+                $summary['revisions_to_create']++;
+
+                if (! $dryRun) {
+                    DB::transaction(function () use ($jobPayload, $status): void {
+                        $job = CareerJob::query()->create(
+                            $this->jobAttributes($jobPayload, $status)
+                        );
+
+                        $this->syncSections($job, $jobPayload, false);
+                        $this->syncSeoMeta($job, $jobPayload);
+                        $this->createRevision($job, 'baseline import');
+                    });
+                }
+
+                continue;
+            }
+
+            if (! $upsert) {
+                $summary['will_skip']++;
+
+                continue;
+            }
+
+            $desiredState = $this->desiredComparableState($jobPayload, $status, $existing);
+            $currentState = $this->currentComparableState($existing);
+
+            if ($desiredState === $currentState) {
+                $summary['will_skip']++;
+
+                continue;
+            }
+
+            $summary['will_update']++;
+            $summary['revisions_to_create']++;
+
+            if (! $dryRun) {
+                DB::transaction(function () use ($existing, $jobPayload, $status): void {
+                    $existing->fill($this->jobAttributes($jobPayload, $status, $existing));
+                    $existing->save();
+
+                    $this->syncSections($existing, $jobPayload, true);
+                    $this->syncSeoMeta($existing, $jobPayload);
+                    $this->createRevision($existing, 'baseline upsert');
+                });
+            }
+        }
+
+        return $summary;
+    }
+
+    private function jobQuery(): Builder
+    {
+        return CareerJob::query()->withoutGlobalScope(TenantScope::class);
+    }
+
+    /**
+     * @param  array<string, mixed>  $jobPayload
+     * @return array<string, mixed>
+     */
+    private function jobAttributes(
+        array $jobPayload,
+        string $status,
+        ?CareerJob $existing = null,
+    ): array {
+        $publishedAt = $this->resolvePublishedAt($jobPayload, $status, $existing);
+
+        return [
+            'org_id' => 0,
+            'job_code' => (string) $jobPayload['job_code'],
+            'slug' => (string) $jobPayload['slug'],
+            'locale' => (string) $jobPayload['locale'],
+            'title' => (string) $jobPayload['title'],
+            'subtitle' => $jobPayload['subtitle'],
+            'excerpt' => $jobPayload['excerpt'],
+            'hero_kicker' => $jobPayload['hero_kicker'],
+            'hero_quote' => $jobPayload['hero_quote'],
+            'cover_image_url' => $jobPayload['cover_image_url'],
+            'industry_slug' => $jobPayload['industry_slug'],
+            'industry_label' => $jobPayload['industry_label'],
+            'body_md' => $jobPayload['body_md'],
+            'body_html' => $jobPayload['body_html'],
+            'salary_json' => $jobPayload['salary_json'],
+            'outlook_json' => $jobPayload['outlook_json'],
+            'skills_json' => $jobPayload['skills_json'],
+            'work_contents_json' => $jobPayload['work_contents_json'],
+            'growth_path_json' => $jobPayload['growth_path_json'],
+            'fit_personality_codes_json' => $jobPayload['fit_personality_codes_json'],
+            'mbti_primary_codes_json' => $jobPayload['mbti_primary_codes_json'],
+            'mbti_secondary_codes_json' => $jobPayload['mbti_secondary_codes_json'],
+            'riasec_profile_json' => $jobPayload['riasec_profile_json'],
+            'big5_targets_json' => $jobPayload['big5_targets_json'],
+            'iq_eq_notes_json' => $jobPayload['iq_eq_notes_json'],
+            'market_demand_json' => $jobPayload['market_demand_json'],
+            'status' => $status,
+            'is_public' => (bool) $jobPayload['is_public'],
+            'is_indexable' => (bool) $jobPayload['is_indexable'],
+            'published_at' => $publishedAt,
+            'scheduled_at' => $status === CareerJob::STATUS_DRAFT
+                ? null
+                : $this->normalizeNullableDate($jobPayload['scheduled_at'] ?? null),
+            'schema_version' => (string) ($jobPayload['schema_version'] ?? 'v1'),
+            'sort_order' => (int) ($jobPayload['sort_order'] ?? 0),
+        ];
+    }
+
+    /**
+     * @param  array<string, mixed>  $jobPayload
+     */
+    private function syncSections(CareerJob $job, array $jobPayload, bool $fullSync): void
+    {
+        $desiredSections = [];
+
+        foreach ((array) $jobPayload['sections'] as $section) {
+            $desiredSections[(string) $section['section_key']] = [
+                'title' => $section['title'],
+                'render_variant' => (string) $section['render_variant'],
+                'body_md' => $section['body_md'],
+                'body_html' => $section['body_html'],
+                'payload_json' => $section['payload_json'],
+                'sort_order' => (int) $section['sort_order'],
+                'is_enabled' => (bool) $section['is_enabled'],
+            ];
+        }
+
+        foreach ($desiredSections as $sectionKey => $attributes) {
+            CareerJobSection::query()->updateOrCreate(
+                [
+                    'job_id' => (int) $job->id,
+                    'section_key' => $sectionKey,
+                ],
+                $attributes,
+            );
+        }
+
+        if ($fullSync) {
+            $managedKeys = array_values(array_intersect(
+                array_keys($desiredSections),
+                CareerJobSection::SECTION_KEYS,
+            ));
+
+            $deleteQuery = CareerJobSection::query()
+                ->where('job_id', (int) $job->id)
+                ->whereIn('section_key', CareerJobSection::SECTION_KEYS);
+
+            if ($managedKeys !== []) {
+                $deleteQuery->whereNotIn('section_key', $managedKeys);
+            }
+
+            $deleteQuery->delete();
+        }
+
+        $job->unsetRelation('sections');
+    }
+
+    /**
+     * @param  array<string, mixed>  $jobPayload
+     */
+    private function syncSeoMeta(CareerJob $job, array $jobPayload): void
+    {
+        $seoMeta = (array) $jobPayload['seo_meta'];
+
+        CareerJobSeoMeta::query()->updateOrCreate(
+            [
+                'job_id' => (int) $job->id,
+            ],
+            [
+                'seo_title' => $seoMeta['seo_title'],
+                'seo_description' => $seoMeta['seo_description'],
+                'canonical_url' => $seoMeta['canonical_url'],
+                'og_title' => $seoMeta['og_title'],
+                'og_description' => $seoMeta['og_description'],
+                'og_image_url' => $seoMeta['og_image_url'],
+                'twitter_title' => $seoMeta['twitter_title'],
+                'twitter_description' => $seoMeta['twitter_description'],
+                'twitter_image_url' => $seoMeta['twitter_image_url'],
+                'robots' => $seoMeta['robots'],
+                'jsonld_overrides_json' => $seoMeta['jsonld_overrides_json'],
+            ],
+        );
+
+        $job->unsetRelation('seoMeta');
+    }
+
+    private function createRevision(CareerJob $job, string $note): void
+    {
+        CareerJobRevision::query()->create([
+            'job_id' => (int) $job->id,
+            'revision_no' => ((int) CareerJobRevision::query()
+                ->where('job_id', (int) $job->id)
+                ->max('revision_no')) + 1,
+            'snapshot_json' => $this->currentComparableState($job->fresh(['sections', 'seoMeta'])),
+            'note' => $note,
+            'created_by_admin_user_id' => null,
+            'created_at' => now(),
+        ]);
+    }
+
+    /**
+     * @param  array<string, mixed>  $jobPayload
+     * @return array<string, mixed>
+     */
+    private function desiredComparableState(
+        array $jobPayload,
+        string $status,
+        ?CareerJob $existing = null,
+    ): array {
+        $sections = collect((array) $jobPayload['sections'])
+            ->map(static fn (array $section): array => [
+                'section_key' => (string) $section['section_key'],
+                'title' => $section['title'],
+                'render_variant' => (string) $section['render_variant'],
+                'body_md' => $section['body_md'],
+                'body_html' => $section['body_html'],
+                'payload_json' => $section['payload_json'],
+                'sort_order' => (int) $section['sort_order'],
+                'is_enabled' => (bool) $section['is_enabled'],
+            ])
+            ->sortBy([
+                ['sort_order', 'asc'],
+                ['section_key', 'asc'],
+            ])
+            ->values()
+            ->all();
+
+        return [
+            'job' => [
+                'org_id' => 0,
+                'job_code' => (string) $jobPayload['job_code'],
+                'slug' => (string) $jobPayload['slug'],
+                'locale' => (string) $jobPayload['locale'],
+                'title' => (string) $jobPayload['title'],
+                'subtitle' => $jobPayload['subtitle'],
+                'excerpt' => $jobPayload['excerpt'],
+                'hero_kicker' => $jobPayload['hero_kicker'],
+                'hero_quote' => $jobPayload['hero_quote'],
+                'cover_image_url' => $jobPayload['cover_image_url'],
+                'industry_slug' => $jobPayload['industry_slug'],
+                'industry_label' => $jobPayload['industry_label'],
+                'body_md' => $jobPayload['body_md'],
+                'body_html' => $jobPayload['body_html'],
+                'salary_json' => $jobPayload['salary_json'],
+                'outlook_json' => $jobPayload['outlook_json'],
+                'skills_json' => $jobPayload['skills_json'],
+                'work_contents_json' => $jobPayload['work_contents_json'],
+                'growth_path_json' => $jobPayload['growth_path_json'],
+                'fit_personality_codes_json' => $jobPayload['fit_personality_codes_json'],
+                'mbti_primary_codes_json' => $jobPayload['mbti_primary_codes_json'],
+                'mbti_secondary_codes_json' => $jobPayload['mbti_secondary_codes_json'],
+                'riasec_profile_json' => $jobPayload['riasec_profile_json'],
+                'big5_targets_json' => $jobPayload['big5_targets_json'],
+                'iq_eq_notes_json' => $jobPayload['iq_eq_notes_json'],
+                'market_demand_json' => $jobPayload['market_demand_json'],
+                'status' => $status,
+                'is_public' => (bool) $jobPayload['is_public'],
+                'is_indexable' => (bool) $jobPayload['is_indexable'],
+                'published_at' => $this->normalizeDateForComparison(
+                    $this->resolvePublishedAt($jobPayload, $status, $existing)
+                ),
+                'scheduled_at' => $status === CareerJob::STATUS_DRAFT
+                    ? null
+                    : $this->normalizeDateForComparison($this->normalizeNullableDate($jobPayload['scheduled_at'] ?? null)),
+                'schema_version' => (string) ($jobPayload['schema_version'] ?? 'v1'),
+                'sort_order' => (int) ($jobPayload['sort_order'] ?? 0),
+            ],
+            'sections' => $sections,
+            'seo_meta' => (array) $jobPayload['seo_meta'],
+        ];
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function currentComparableState(CareerJob $job): array
+    {
+        $job->loadMissing('sections', 'seoMeta');
+
+        return [
+            'job' => [
+                'org_id' => (int) $job->org_id,
+                'job_code' => (string) $job->job_code,
+                'slug' => (string) $job->slug,
+                'locale' => (string) $job->locale,
+                'title' => (string) $job->title,
+                'subtitle' => $job->subtitle,
+                'excerpt' => $job->excerpt,
+                'hero_kicker' => $job->hero_kicker,
+                'hero_quote' => $job->hero_quote,
+                'cover_image_url' => $job->cover_image_url,
+                'industry_slug' => $job->industry_slug,
+                'industry_label' => $job->industry_label,
+                'body_md' => $job->body_md,
+                'body_html' => $job->body_html,
+                'salary_json' => $job->salary_json,
+                'outlook_json' => $job->outlook_json,
+                'skills_json' => $job->skills_json,
+                'work_contents_json' => $job->work_contents_json,
+                'growth_path_json' => $job->growth_path_json,
+                'fit_personality_codes_json' => $job->fit_personality_codes_json,
+                'mbti_primary_codes_json' => $job->mbti_primary_codes_json,
+                'mbti_secondary_codes_json' => $job->mbti_secondary_codes_json,
+                'riasec_profile_json' => $job->riasec_profile_json,
+                'big5_targets_json' => $job->big5_targets_json,
+                'iq_eq_notes_json' => $job->iq_eq_notes_json,
+                'market_demand_json' => $job->market_demand_json,
+                'status' => (string) $job->status,
+                'is_public' => (bool) $job->is_public,
+                'is_indexable' => (bool) $job->is_indexable,
+                'published_at' => $this->normalizeDateForComparison($job->published_at),
+                'scheduled_at' => $this->normalizeDateForComparison($job->scheduled_at),
+                'schema_version' => (string) $job->schema_version,
+                'sort_order' => (int) $job->sort_order,
+            ],
+            'sections' => $job->sections
+                ->map(static fn (CareerJobSection $section): array => [
+                    'section_key' => (string) $section->section_key,
+                    'title' => $section->title,
+                    'render_variant' => (string) $section->render_variant,
+                    'body_md' => $section->body_md,
+                    'body_html' => $section->body_html,
+                    'payload_json' => $section->payload_json,
+                    'sort_order' => (int) $section->sort_order,
+                    'is_enabled' => (bool) $section->is_enabled,
+                ])
+                ->sortBy([
+                    ['sort_order', 'asc'],
+                    ['section_key', 'asc'],
+                ])
+                ->values()
+                ->all(),
+            'seo_meta' => $job->seoMeta instanceof CareerJobSeoMeta
+                ? [
+                    'seo_title' => $job->seoMeta->seo_title,
+                    'seo_description' => $job->seoMeta->seo_description,
+                    'canonical_url' => $job->seoMeta->canonical_url,
+                    'og_title' => $job->seoMeta->og_title,
+                    'og_description' => $job->seoMeta->og_description,
+                    'og_image_url' => $job->seoMeta->og_image_url,
+                    'twitter_title' => $job->seoMeta->twitter_title,
+                    'twitter_description' => $job->seoMeta->twitter_description,
+                    'twitter_image_url' => $job->seoMeta->twitter_image_url,
+                    'robots' => $job->seoMeta->robots,
+                    'jsonld_overrides_json' => $job->seoMeta->jsonld_overrides_json,
+                ]
+                : [
+                    'seo_title' => null,
+                    'seo_description' => null,
+                    'canonical_url' => null,
+                    'og_title' => null,
+                    'og_description' => null,
+                    'og_image_url' => null,
+                    'twitter_title' => null,
+                    'twitter_description' => null,
+                    'twitter_image_url' => null,
+                    'robots' => null,
+                    'jsonld_overrides_json' => null,
+                ],
+        ];
+    }
+
+    /**
+     * @param  array<string, mixed>  $jobPayload
+     */
+    private function resolvePublishedAt(
+        array $jobPayload,
+        string $status,
+        ?CareerJob $existing = null,
+    ): ?Carbon {
+        if ($status === CareerJob::STATUS_DRAFT) {
+            return null;
+        }
+
+        return $this->normalizeNullableDate($jobPayload['published_at'] ?? null)
+            ?? $existing?->published_at
+            ?? now();
+    }
+
+    private function normalizeNullableDate(mixed $value): ?Carbon
+    {
+        if ($value instanceof Carbon) {
+            return $value;
+        }
+
+        if ($value instanceof \DateTimeInterface) {
+            return Carbon::instance($value);
+        }
+
+        $normalized = trim((string) $value);
+
+        if ($normalized === '') {
+            return null;
+        }
+
+        return Carbon::parse($normalized);
+    }
+
+    private function normalizeDateForComparison(mixed $value): ?string
+    {
+        $normalized = $this->normalizeNullableDate($value);
+
+        return $normalized?->toIso8601String();
+    }
+}

--- a/backend/app/CareerCms/Baseline/CareerJobBaselineNormalizer.php
+++ b/backend/app/CareerCms/Baseline/CareerJobBaselineNormalizer.php
@@ -1,0 +1,540 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\CareerCms\Baseline;
+
+use App\Models\CareerJob;
+use App\Models\CareerJobSection;
+use Illuminate\Support\Arr;
+use Illuminate\Support\Str;
+use RuntimeException;
+
+final class CareerJobBaselineNormalizer
+{
+    /**
+     * @var array<int, string>
+     */
+    private const VALID_MBTI_CODES = [
+        'INTJ',
+        'INTP',
+        'ENTJ',
+        'ENTP',
+        'INFJ',
+        'INFP',
+        'ENFJ',
+        'ENFP',
+        'ISTJ',
+        'ISFJ',
+        'ESTJ',
+        'ESFJ',
+        'ISTP',
+        'ISFP',
+        'ESTP',
+        'ESFP',
+    ];
+
+    /**
+     * @param  array<int, array{file: string, payload: array<string, mixed>}>  $documents
+     * @param  array<int, string>  $selectedJobs
+     * @return array<int, array<string, mixed>>
+     */
+    public function normalizeDocuments(array $documents, array $selectedJobs = []): array
+    {
+        $normalizedJobs = $this->normalizeSelectedJobs($selectedJobs);
+        $jobs = [];
+        $seenByLocaleJob = [];
+        $seenByLocaleSlug = [];
+
+        foreach ($documents as $document) {
+            $file = (string) ($document['file'] ?? 'unknown');
+            $payload = is_array($document['payload'] ?? null) ? $document['payload'] : [];
+            $meta = is_array($payload['meta'] ?? null) ? $payload['meta'] : [];
+            $locale = $this->normalizeLocale($meta['locale'] ?? null, $file);
+            $schemaVersion = trim((string) ($meta['schema_version'] ?? 'v1'));
+            $rows = $payload['jobs'] ?? null;
+
+            if (! is_array($rows)) {
+                throw new RuntimeException(sprintf(
+                    'Baseline file %s must contain a jobs array.',
+                    $file,
+                ));
+            }
+
+            foreach ($rows as $index => $row) {
+                if (! is_array($row)) {
+                    throw new RuntimeException(sprintf(
+                        'Baseline file %s contains a non-object job row at index %d.',
+                        $file,
+                        $index,
+                    ));
+                }
+
+                $job = $this->normalizeJob($row, $locale, $schemaVersion, $file, $index);
+                $jobCode = (string) $job['job_code'];
+                $slug = (string) $job['slug'];
+
+                if ($normalizedJobs !== [] && ! in_array($jobCode, $normalizedJobs, true)) {
+                    continue;
+                }
+
+                $jobKey = $locale.'|'.$jobCode;
+                $slugKey = $locale.'|'.$slug;
+
+                if (isset($seenByLocaleJob[$jobKey])) {
+                    throw new RuntimeException(sprintf(
+                        'Duplicate job_code %s for locale %s in baseline file %s.',
+                        $jobCode,
+                        $locale,
+                        $file,
+                    ));
+                }
+
+                if (isset($seenByLocaleSlug[$slugKey])) {
+                    throw new RuntimeException(sprintf(
+                        'Duplicate slug %s for locale %s in baseline file %s.',
+                        $slug,
+                        $locale,
+                        $file,
+                    ));
+                }
+
+                $seenByLocaleJob[$jobKey] = true;
+                $seenByLocaleSlug[$slugKey] = true;
+                $jobs[] = $job;
+            }
+        }
+
+        usort(
+            $jobs,
+            static fn (array $left, array $right): int => [$left['locale'], $left['job_code']]
+                <=> [$right['locale'], $right['job_code']],
+        );
+
+        return $jobs;
+    }
+
+    /**
+     * @param  array<string, mixed>  $row
+     * @return array<string, mixed>
+     */
+    private function normalizeJob(
+        array $row,
+        string $documentLocale,
+        string $schemaVersion,
+        string $file,
+        int $index,
+    ): array {
+        $jobCode = $this->normalizeIdentifier($row['job_code'] ?? $row['slug'] ?? null, 'job_code', $file, $index);
+        $slug = $this->normalizeIdentifier($row['slug'] ?? $jobCode, 'slug', $file, $index);
+        $locale = Arr::exists($row, 'locale')
+            ? $this->normalizeLocale($row['locale'], $file)
+            : $documentLocale;
+        $title = trim((string) ($row['title'] ?? ''));
+
+        if ($locale !== $documentLocale) {
+            throw new RuntimeException(sprintf(
+                'Baseline file %s has locale mismatch for %s at jobs[%d].',
+                $file,
+                $jobCode,
+                $index,
+            ));
+        }
+
+        if ($title === '') {
+            throw new RuntimeException(sprintf(
+                'Baseline file %s is missing title for %s at jobs[%d].',
+                $file,
+                $jobCode,
+                $index,
+            ));
+        }
+
+        return [
+            'org_id' => 0,
+            'schema_version' => $schemaVersion !== '' ? $schemaVersion : 'v1',
+            'job_code' => $jobCode,
+            'slug' => $slug,
+            'locale' => $locale,
+            'title' => $title,
+            'subtitle' => $this->normalizeNullableText($row['subtitle'] ?? null),
+            'excerpt' => $this->normalizeNullableText($row['excerpt'] ?? null),
+            'hero_kicker' => $this->normalizeNullableText($row['hero_kicker'] ?? null),
+            'hero_quote' => $this->normalizeNullableText($row['hero_quote'] ?? null),
+            'cover_image_url' => $this->normalizeNullableText($row['cover_image_url'] ?? null),
+            'industry_slug' => $this->normalizeNullableText($row['industry_slug'] ?? null),
+            'industry_label' => $this->normalizeNullableText($row['industry_label'] ?? null),
+            'body_md' => $this->normalizeNullableText($row['body_md'] ?? null),
+            'body_html' => $this->normalizeNullableText($row['body_html'] ?? null),
+            'salary_json' => $this->normalizeNullableArray($row['salary_json'] ?? null),
+            'outlook_json' => $this->normalizeNullableArray($row['outlook_json'] ?? null),
+            'skills_json' => $this->normalizeNullableArray($row['skills_json'] ?? null),
+            'work_contents_json' => $this->normalizeNullableArray($row['work_contents_json'] ?? null),
+            'growth_path_json' => $this->normalizeNullableArray($row['growth_path_json'] ?? null),
+            'fit_personality_codes_json' => $this->normalizeNullableMbtiArray(
+                $row['fit_personality_codes_json'] ?? null,
+                $file,
+                $jobCode,
+                'fit_personality_codes_json',
+            ),
+            'mbti_primary_codes_json' => $this->normalizeRequiredMbtiArray(
+                $row['mbti_primary_codes_json'] ?? null,
+                $file,
+                $jobCode,
+                'mbti_primary_codes_json',
+            ),
+            'mbti_secondary_codes_json' => $this->normalizeRequiredMbtiArray(
+                $row['mbti_secondary_codes_json'] ?? null,
+                $file,
+                $jobCode,
+                'mbti_secondary_codes_json',
+            ),
+            'riasec_profile_json' => $this->normalizeRiasecProfile(
+                $row['riasec_profile_json'] ?? null,
+                $file,
+                $jobCode,
+            ),
+            'big5_targets_json' => $this->normalizeNullableArray($row['big5_targets_json'] ?? null),
+            'iq_eq_notes_json' => $this->normalizeNullableArray($row['iq_eq_notes_json'] ?? null),
+            'market_demand_json' => $this->normalizeNullableArray($row['market_demand_json'] ?? null),
+            'status' => $this->normalizeStatus($row['status'] ?? 'published', $file, $index),
+            'is_public' => $this->normalizeBool($row['is_public'] ?? true),
+            'is_indexable' => $this->normalizeBool($row['is_indexable'] ?? true),
+            'published_at' => $this->normalizeNullableText($row['published_at'] ?? null),
+            'scheduled_at' => $this->normalizeNullableText($row['scheduled_at'] ?? null),
+            'sort_order' => (int) ($row['sort_order'] ?? 0),
+            'sections' => $this->normalizeSections(
+                is_array($row['sections'] ?? null) ? $row['sections'] : [],
+                $file,
+                $jobCode,
+            ),
+            'seo_meta' => $this->normalizeSeoMeta(
+                is_array($row['seo_meta'] ?? null) ? $row['seo_meta'] : [],
+            ),
+        ];
+    }
+
+    /**
+     * @param  array<int, mixed>  $rows
+     * @return array<int, array<string, mixed>>
+     */
+    private function normalizeSections(array $rows, string $file, string $jobCode): array
+    {
+        $sections = [];
+        $seen = [];
+
+        foreach ($rows as $index => $row) {
+            if (! is_array($row)) {
+                throw new RuntimeException(sprintf(
+                    'Baseline file %s contains a non-object section for %s at sections[%d].',
+                    $file,
+                    $jobCode,
+                    $index,
+                ));
+            }
+
+            $sectionKey = trim((string) ($row['section_key'] ?? ''));
+            $renderVariant = trim((string) ($row['render_variant'] ?? ''));
+
+            if ($sectionKey === '' || ! in_array($sectionKey, CareerJobSection::SECTION_KEYS, true)) {
+                throw new RuntimeException(sprintf(
+                    'Baseline file %s contains unsupported section_key=%s for %s.',
+                    $file,
+                    $sectionKey,
+                    $jobCode,
+                ));
+            }
+
+            if ($renderVariant === '' || ! in_array($renderVariant, CareerJobSection::RENDER_VARIANTS, true)) {
+                throw new RuntimeException(sprintf(
+                    'Baseline file %s contains invalid render_variant for %s section %s.',
+                    $file,
+                    $jobCode,
+                    $sectionKey,
+                ));
+            }
+
+            if (isset($seen[$sectionKey])) {
+                throw new RuntimeException(sprintf(
+                    'Baseline file %s contains duplicate section_key=%s for %s.',
+                    $file,
+                    $sectionKey,
+                    $jobCode,
+                ));
+            }
+
+            $sections[] = [
+                'section_key' => $sectionKey,
+                'title' => $this->normalizeNullableText($row['title'] ?? null),
+                'render_variant' => $renderVariant,
+                'body_md' => $this->normalizeNullableText($row['body_md'] ?? null),
+                'body_html' => $this->normalizeNullableText($row['body_html'] ?? null),
+                'payload_json' => Arr::exists($row, 'payload_json')
+                    ? $this->normalizeNullableArray($row['payload_json'])
+                    : null,
+                'sort_order' => (int) ($row['sort_order'] ?? 0),
+                'is_enabled' => $this->normalizeBool($row['is_enabled'] ?? true),
+            ];
+
+            $seen[$sectionKey] = true;
+        }
+
+        usort(
+            $sections,
+            static fn (array $left, array $right): int => [$left['sort_order'], $left['section_key']]
+                <=> [$right['sort_order'], $right['section_key']],
+        );
+
+        return $sections;
+    }
+
+    /**
+     * @param  array<string, mixed>  $seoMeta
+     * @return array<string, mixed>
+     */
+    private function normalizeSeoMeta(array $seoMeta): array
+    {
+        return [
+            'seo_title' => $this->normalizeNullableText($seoMeta['seo_title'] ?? null),
+            'seo_description' => $this->normalizeNullableText($seoMeta['seo_description'] ?? null),
+            'canonical_url' => $this->normalizeNullableText($seoMeta['canonical_url'] ?? null),
+            'og_title' => $this->normalizeNullableText($seoMeta['og_title'] ?? null),
+            'og_description' => $this->normalizeNullableText($seoMeta['og_description'] ?? null),
+            'og_image_url' => $this->normalizeNullableText($seoMeta['og_image_url'] ?? null),
+            'twitter_title' => $this->normalizeNullableText($seoMeta['twitter_title'] ?? null),
+            'twitter_description' => $this->normalizeNullableText($seoMeta['twitter_description'] ?? null),
+            'twitter_image_url' => $this->normalizeNullableText($seoMeta['twitter_image_url'] ?? null),
+            'robots' => $this->normalizeNullableText($seoMeta['robots'] ?? null),
+            'jsonld_overrides_json' => Arr::exists($seoMeta, 'jsonld_overrides_json')
+                ? $this->normalizeNullableArray($seoMeta['jsonld_overrides_json'])
+                : null,
+        ];
+    }
+
+    private function normalizeLocale(mixed $locale, string $file): string
+    {
+        $normalized = trim((string) $locale);
+        $normalized = $normalized === 'zh' ? 'zh-CN' : $normalized;
+
+        if (! in_array($normalized, CareerJob::SUPPORTED_LOCALES, true)) {
+            throw new RuntimeException(sprintf(
+                'Baseline file %s has unsupported locale=%s.',
+                $file,
+                (string) $locale,
+            ));
+        }
+
+        return $normalized;
+    }
+
+    /**
+     * @param  array<int, string>  $selectedJobs
+     * @return array<int, string>
+     */
+    private function normalizeSelectedJobs(array $selectedJobs): array
+    {
+        $normalized = [];
+
+        foreach ($selectedJobs as $job) {
+            $candidate = Str::lower(trim((string) $job));
+
+            if ($candidate === '') {
+                continue;
+            }
+
+            $normalized[] = $candidate;
+        }
+
+        return array_values(array_unique($normalized));
+    }
+
+    private function normalizeIdentifier(mixed $value, string $field, string $file, int $index): string
+    {
+        $normalized = Str::lower(trim((string) $value));
+
+        if ($normalized === '') {
+            throw new RuntimeException(sprintf(
+                'Baseline file %s is missing %s at jobs[%d].',
+                $file,
+                $field,
+                $index,
+            ));
+        }
+
+        return $normalized;
+    }
+
+    /**
+     * @return array<int, string>
+     */
+    private function normalizeRequiredMbtiArray(mixed $value, string $file, string $jobCode, string $field): array
+    {
+        $arr = $this->normalizeMbtiArray($value, $file, $jobCode, $field);
+
+        if ($arr === []) {
+            throw new RuntimeException(sprintf(
+                'Baseline file %s has empty %s for %s.',
+                $file,
+                $field,
+                $jobCode,
+            ));
+        }
+
+        return $arr;
+    }
+
+    /**
+     * @return array<int, string>|null
+     */
+    private function normalizeNullableMbtiArray(mixed $value, string $file, string $jobCode, string $field): ?array
+    {
+        if ($value === null) {
+            return null;
+        }
+
+        $arr = $this->normalizeMbtiArray($value, $file, $jobCode, $field);
+
+        return $arr === [] ? null : $arr;
+    }
+
+    /**
+     * @return array<int, string>
+     */
+    private function normalizeMbtiArray(mixed $value, string $file, string $jobCode, string $field): array
+    {
+        if (is_string($value)) {
+            $value = [$value];
+        }
+
+        if (! is_array($value)) {
+            throw new RuntimeException(sprintf(
+                'Baseline file %s has invalid %s for %s.',
+                $file,
+                $field,
+                $jobCode,
+            ));
+        }
+
+        $arr = array_values(array_filter(
+            array_map(static fn (mixed $item): string => Str::upper(trim((string) $item)), $value),
+            static fn (string $item): bool => $item !== '',
+        ));
+
+        foreach ($arr as $code) {
+            if (! in_array($code, self::VALID_MBTI_CODES, true)) {
+                throw new RuntimeException(sprintf(
+                    'Baseline file %s has invalid MBTI code=%s in %s for %s.',
+                    $file,
+                    $code,
+                    $field,
+                    $jobCode,
+                ));
+            }
+        }
+
+        return array_values(array_unique($arr));
+    }
+
+    /**
+     * @return array<string, int|float>|null
+     */
+    private function normalizeRiasecProfile(mixed $value, string $file, string $jobCode): ?array
+    {
+        if ($value === null) {
+            return null;
+        }
+
+        if (! is_array($value)) {
+            throw new RuntimeException(sprintf(
+                'Baseline file %s has invalid riasec_profile_json for %s.',
+                $file,
+                $jobCode,
+            ));
+        }
+
+        $normalized = [];
+        $validKeys = ['R', 'I', 'A', 'S', 'E', 'C'];
+
+        foreach ($value as $key => $score) {
+            $riasecKey = Str::upper(trim((string) $key));
+            if (! in_array($riasecKey, $validKeys, true)) {
+                throw new RuntimeException(sprintf(
+                    'Baseline file %s has invalid RIASEC key=%s for %s.',
+                    $file,
+                    (string) $key,
+                    $jobCode,
+                ));
+            }
+
+            if (! is_numeric($score)) {
+                throw new RuntimeException(sprintf(
+                    'Baseline file %s has non-numeric RIASEC score for %s key %s.',
+                    $file,
+                    $jobCode,
+                    $riasecKey,
+                ));
+            }
+
+            $normalized[$riasecKey] = $score + 0;
+        }
+
+        return $normalized;
+    }
+
+    private function normalizeStatus(mixed $status, string $file, int $index): string
+    {
+        $normalized = trim((string) $status);
+
+        if (! in_array($normalized, [CareerJob::STATUS_DRAFT, CareerJob::STATUS_PUBLISHED], true)) {
+            throw new RuntimeException(sprintf(
+                'Baseline file %s has invalid status at jobs[%d].',
+                $file,
+                $index,
+            ));
+        }
+
+        return $normalized;
+    }
+
+    private function normalizeBool(mixed $value): bool
+    {
+        if (is_bool($value)) {
+            return $value;
+        }
+
+        if (is_numeric($value)) {
+            return (bool) $value;
+        }
+
+        $normalized = Str::lower(trim((string) $value));
+
+        return in_array($normalized, ['1', 'true', 'yes', 'on'], true);
+    }
+
+    private function normalizeNullableText(mixed $value): ?string
+    {
+        if ($value === null) {
+            return null;
+        }
+
+        $normalized = trim((string) $value);
+
+        return $normalized === '' ? null : $normalized;
+    }
+
+    /**
+     * @return array<string, mixed>|array<int, mixed>|null
+     */
+    private function normalizeNullableArray(mixed $value): ?array
+    {
+        if ($value === null) {
+            return null;
+        }
+
+        if (! is_array($value)) {
+            throw new RuntimeException('Expected array-compatible baseline payload.');
+        }
+
+        return $value;
+    }
+}

--- a/backend/app/CareerCms/Baseline/CareerJobBaselineReader.php
+++ b/backend/app/CareerCms/Baseline/CareerJobBaselineReader.php
@@ -1,0 +1,128 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\CareerCms\Baseline;
+
+use App\Models\CareerJob;
+use RuntimeException;
+
+final class CareerJobBaselineReader
+{
+    public function resolveSourceDir(?string $sourceDir = null): string
+    {
+        $candidate = trim((string) $sourceDir);
+
+        if ($candidate === '') {
+            $candidate = base_path('../content_baselines/career_jobs');
+        } elseif (! str_starts_with($candidate, DIRECTORY_SEPARATOR)) {
+            $candidate = base_path($candidate);
+        }
+
+        $resolved = realpath($candidate);
+
+        if ($resolved === false || ! is_dir($resolved)) {
+            throw new RuntimeException(sprintf(
+                'Career job baseline source directory not found: %s',
+                $candidate,
+            ));
+        }
+
+        return $resolved;
+    }
+
+    /**
+     * @param  array<int, string>  $selectedLocales
+     * @return array<int, array{file: string, payload: array<string, mixed>}>
+     */
+    public function read(string $sourceDir, array $selectedLocales = []): array
+    {
+        $locales = $this->normalizeSelectedLocales($selectedLocales);
+        $files = $locales === []
+            ? glob(rtrim($sourceDir, DIRECTORY_SEPARATOR).DIRECTORY_SEPARATOR.'career_jobs.*.json') ?: []
+            : array_map(
+                static fn (string $locale): string => rtrim($sourceDir, DIRECTORY_SEPARATOR)
+                    .DIRECTORY_SEPARATOR
+                    .sprintf('career_jobs.%s.json', $locale),
+                $locales,
+            );
+
+        if ($files === []) {
+            throw new RuntimeException(sprintf(
+                'No career job baseline files found in %s.',
+                $sourceDir,
+            ));
+        }
+
+        sort($files);
+
+        $documents = [];
+
+        foreach ($files as $file) {
+            if (! is_file($file)) {
+                throw new RuntimeException(sprintf(
+                    'Career job baseline file missing: %s',
+                    $file,
+                ));
+            }
+
+            $raw = file_get_contents($file);
+
+            if (! is_string($raw) || trim($raw) === '') {
+                throw new RuntimeException(sprintf(
+                    'Career job baseline file is empty: %s',
+                    $file,
+                ));
+            }
+
+            $decoded = json_decode($raw, true);
+
+            if (! is_array($decoded)) {
+                throw new RuntimeException(sprintf(
+                    'Career job baseline file is not valid JSON: %s',
+                    $file,
+                ));
+            }
+
+            $documents[] = [
+                'file' => $file,
+                'payload' => $decoded,
+            ];
+        }
+
+        return $documents;
+    }
+
+    /**
+     * @param  array<int, string>  $selectedLocales
+     * @return array<int, string>
+     */
+    private function normalizeSelectedLocales(array $selectedLocales): array
+    {
+        $normalized = [];
+
+        foreach ($selectedLocales as $locale) {
+            $candidate = trim((string) $locale);
+
+            if ($candidate === '') {
+                continue;
+            }
+
+            $candidate = $candidate === 'zh' ? 'zh-CN' : $candidate;
+            $normalized[] = $candidate;
+        }
+
+        $normalized = array_values(array_unique($normalized));
+
+        foreach ($normalized as $locale) {
+            if (! in_array($locale, CareerJob::SUPPORTED_LOCALES, true)) {
+                throw new RuntimeException(sprintf(
+                    'Unsupported locale selection: %s',
+                    $locale,
+                ));
+            }
+        }
+
+        return $normalized;
+    }
+}

--- a/backend/app/Console/Commands/CareerJobImportLocalBaseline.php
+++ b/backend/app/Console/Commands/CareerJobImportLocalBaseline.php
@@ -1,0 +1,85 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Console\Commands;
+
+use App\CareerCms\Baseline\CareerJobBaselineImporter;
+use App\CareerCms\Baseline\CareerJobBaselineNormalizer;
+use App\CareerCms\Baseline\CareerJobBaselineReader;
+use App\Models\CareerJob;
+use Illuminate\Console\Command;
+use RuntimeException;
+
+final class CareerJobImportLocalBaseline extends Command
+{
+    protected $signature = 'career-jobs:import-local-baseline
+        {--dry-run : Validate and diff without writing to the database}
+        {--locale=* : Import only specific locale(s)}
+        {--job=* : Import only specific job code(s)}
+        {--upsert : Update existing records instead of create-missing only}
+        {--status=draft : Force imported records to draft or published}
+        {--source-dir= : Override the committed baseline source directory}';
+
+    protected $description = 'Import committed career jobs baseline content into CareerJob CMS tables.';
+
+    public function handle(
+        CareerJobBaselineReader $reader,
+        CareerJobBaselineNormalizer $normalizer,
+        CareerJobBaselineImporter $importer,
+    ): int {
+        try {
+            $status = trim((string) $this->option('status'));
+            if (! in_array($status, [CareerJob::STATUS_DRAFT, CareerJob::STATUS_PUBLISHED], true)) {
+                throw new RuntimeException(sprintf(
+                    'Unsupported --status value: %s',
+                    $status,
+                ));
+            }
+
+            $sourceDir = $reader->resolveSourceDir(
+                $this->option('source-dir') !== null
+                    ? (string) $this->option('source-dir')
+                    : null,
+            );
+            $selectedLocales = array_values(array_filter(
+                array_map(static fn (string $value): string => trim($value), (array) $this->option('locale')),
+                static fn (string $value): bool => $value !== '',
+            ));
+            $selectedJobs = array_values(array_filter(
+                array_map(static fn (string $value): string => trim($value), (array) $this->option('job')),
+                static fn (string $value): bool => $value !== '',
+            ));
+
+            $documents = $reader->read($sourceDir, $selectedLocales);
+            $jobs = $normalizer->normalizeDocuments($documents, $selectedJobs);
+            $summary = $importer->import($jobs, [
+                'dry_run' => (bool) $this->option('dry-run'),
+                'upsert' => (bool) $this->option('upsert'),
+                'status' => $status,
+            ]);
+
+            $this->line('baseline_source_dir='.$sourceDir);
+            $this->line('locales_selected='.($selectedLocales === [] ? 'all' : implode(',', $selectedLocales)));
+            $this->line('jobs_selected='.($selectedJobs === [] ? 'all' : implode(',', $selectedJobs)));
+            $this->line('dry_run='.((bool) $this->option('dry-run') ? '1' : '0'));
+            $this->line('upsert='.((bool) $this->option('upsert') ? '1' : '0'));
+            $this->line('status_mode='.$status);
+            $this->line('files_found='.(string) count($documents));
+            $this->line('jobs_found='.(string) $summary['jobs_found']);
+            $this->line('will_create='.(string) $summary['will_create']);
+            $this->line('will_update='.(string) $summary['will_update']);
+            $this->line('will_skip='.(string) $summary['will_skip']);
+            $this->line('revisions_to_create='.(string) $summary['revisions_to_create']);
+            $this->line('errors_count='.(string) $summary['errors_count']);
+
+            $this->info((bool) $this->option('dry-run') ? 'dry-run complete' : 'import complete');
+
+            return self::SUCCESS;
+        } catch (\Throwable $throwable) {
+            $this->error($throwable->getMessage());
+
+            return self::FAILURE;
+        }
+    }
+}

--- a/backend/tests/Feature/CareerCms/CareerJobBaselineImportTest.php
+++ b/backend/tests/Feature/CareerCms/CareerJobBaselineImportTest.php
@@ -1,0 +1,293 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\CareerCms;
+
+use App\Models\CareerJob;
+use App\Models\CareerJobRevision;
+use App\Models\CareerJobSection;
+use App\Models\CareerJobSeoMeta;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\File;
+use Tests\TestCase;
+
+final class CareerJobBaselineImportTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_dry_run_does_not_write_database(): void
+    {
+        $this->artisan('career-jobs:import-local-baseline', [
+            '--dry-run' => true,
+            '--source-dir' => 'tests/Fixtures/career_job_baseline',
+        ])
+            ->expectsOutputToContain('files_found=2')
+            ->expectsOutputToContain('jobs_found=4')
+            ->expectsOutputToContain('will_create=4')
+            ->expectsOutputToContain('revisions_to_create=4')
+            ->assertExitCode(0);
+
+        $this->assertSame(0, CareerJob::query()->count());
+        $this->assertSame(0, CareerJobSection::query()->count());
+        $this->assertSame(0, CareerJobSeoMeta::query()->count());
+        $this->assertSame(0, CareerJobRevision::query()->count());
+    }
+
+    public function test_default_mode_creates_missing_jobs_sections_seo_meta_and_revision(): void
+    {
+        $this->artisan('career-jobs:import-local-baseline', [
+            '--locale' => ['en'],
+            '--status' => 'draft',
+            '--source-dir' => 'tests/Fixtures/career_job_baseline',
+        ])
+            ->expectsOutputToContain('jobs_found=2')
+            ->expectsOutputToContain('will_create=2')
+            ->assertExitCode(0);
+
+        $this->assertSame(2, CareerJob::query()->count());
+        $this->assertSame(1, CareerJobSection::query()->count());
+        $this->assertSame(2, CareerJobSeoMeta::query()->count());
+        $this->assertSame(2, CareerJobRevision::query()->count());
+
+        $job = CareerJob::query()
+            ->withoutGlobalScopes()
+            ->where('job_code', 'product-manager')
+            ->where('locale', 'en')
+            ->firstOrFail();
+
+        $this->assertSame(0, (int) $job->org_id);
+        $this->assertSame('draft', $job->status);
+        $this->assertNull($job->published_at);
+        $this->assertNull($job->fit_personality_codes_json);
+        $this->assertSame(['raw' => 82], $job->market_demand_json);
+        $this->assertSame(
+            ['raw' => ['openness' => ['min' => 40, 'max' => 80], 'conscientiousness' => ['min' => 50, 'max' => 90]]],
+            $job->big5_targets_json,
+        );
+        $this->assertSame(
+            ['iq_range' => ['min' => 50, 'max' => 98], 'eq_range' => ['min' => 55, 'max' => 100]],
+            $job->iq_eq_notes_json,
+        );
+
+        $revision = CareerJobRevision::query()
+            ->where('job_id', (int) $job->id)
+            ->orderBy('revision_no')
+            ->firstOrFail();
+
+        $this->assertSame(1, (int) $revision->revision_no);
+        $this->assertSame('baseline import', $revision->note);
+    }
+
+    public function test_default_mode_skips_existing_jobs_without_overwriting(): void
+    {
+        $job = CareerJob::query()->create([
+            'org_id' => 0,
+            'job_code' => 'product-manager',
+            'slug' => 'product-manager',
+            'locale' => 'en',
+            'title' => 'Do Not Overwrite',
+            'status' => CareerJob::STATUS_DRAFT,
+            'is_public' => true,
+            'is_indexable' => true,
+            'schema_version' => 'v1',
+        ]);
+
+        CareerJobRevision::query()->create([
+            'job_id' => (int) $job->id,
+            'revision_no' => 1,
+            'snapshot_json' => ['title' => 'Do Not Overwrite'],
+            'note' => 'seed',
+            'created_at' => now(),
+        ]);
+
+        $this->artisan('career-jobs:import-local-baseline', [
+            '--locale' => ['en'],
+            '--job' => ['product-manager'],
+            '--source-dir' => 'tests/Fixtures/career_job_baseline',
+        ])
+            ->expectsOutputToContain('jobs_found=1')
+            ->expectsOutputToContain('will_skip=1')
+            ->assertExitCode(0);
+
+        $this->assertSame('Do Not Overwrite', (string) $job->fresh()->title);
+        $this->assertSame(1, CareerJobRevision::query()->where('job_id', (int) $job->id)->count());
+    }
+
+    public function test_upsert_updates_existing_jobs_and_only_creates_revision_when_changed(): void
+    {
+        $job = CareerJob::query()->create([
+            'org_id' => 0,
+            'job_code' => 'product-manager',
+            'slug' => 'product-manager',
+            'locale' => 'en',
+            'title' => 'Legacy PM',
+            'excerpt' => 'Legacy excerpt',
+            'status' => CareerJob::STATUS_PUBLISHED,
+            'is_public' => true,
+            'is_indexable' => false,
+            'published_at' => now()->subDay(),
+            'schema_version' => 'v1',
+            'salary_json' => ['raw' => '$1'],
+            'mbti_primary_codes_json' => ['INTJ'],
+            'mbti_secondary_codes_json' => ['INFJ'],
+            'riasec_profile_json' => ['R' => 1, 'I' => 2, 'A' => 3, 'S' => 4, 'E' => 5, 'C' => 6],
+        ]);
+
+        CareerJobSection::query()->create([
+            'job_id' => (int) $job->id,
+            'section_key' => 'faq',
+            'title' => 'Legacy FAQ',
+            'render_variant' => 'faq',
+            'payload_json' => ['items' => [['question' => 'Old', 'answer' => 'Old']]],
+            'sort_order' => 80,
+            'is_enabled' => true,
+        ]);
+        CareerJobSection::query()->create([
+            'job_id' => (int) $job->id,
+            'section_key' => 'day_to_day',
+            'title' => 'Legacy',
+            'render_variant' => 'rich_text',
+            'body_md' => 'Old',
+            'sort_order' => 10,
+            'is_enabled' => true,
+        ]);
+        CareerJobSeoMeta::query()->create([
+            'job_id' => (int) $job->id,
+            'seo_title' => 'Legacy title',
+            'seo_description' => 'Legacy description',
+        ]);
+        CareerJobRevision::query()->create([
+            'job_id' => (int) $job->id,
+            'revision_no' => 1,
+            'snapshot_json' => ['title' => 'Legacy PM'],
+            'note' => 'seed',
+            'created_at' => now()->subDay(),
+        ]);
+
+        $this->artisan('career-jobs:import-local-baseline', [
+            '--locale' => ['en'],
+            '--job' => ['product-manager'],
+            '--upsert' => true,
+            '--status' => 'published',
+            '--source-dir' => 'tests/Fixtures/career_job_baseline',
+        ])
+            ->expectsOutputToContain('jobs_found=1')
+            ->expectsOutputToContain('will_update=1')
+            ->expectsOutputToContain('revisions_to_create=1')
+            ->assertExitCode(0);
+
+        $job->refresh();
+
+        $this->assertSame('Product Manager', $job->title);
+        $this->assertTrue((bool) $job->is_indexable);
+        $this->assertNotNull($job->published_at);
+        $this->assertSame(
+            ['faq'],
+            CareerJobSection::query()
+                ->where('job_id', (int) $job->id)
+                ->orderBy('section_key')
+                ->pluck('section_key')
+                ->all(),
+        );
+        $this->assertSame(
+            'Product Manager Career Guide | FermatMind',
+            CareerJobSeoMeta::query()->where('job_id', (int) $job->id)->firstOrFail()->seo_title,
+        );
+        $this->assertSame(
+            2,
+            CareerJobRevision::query()->where('job_id', (int) $job->id)->max('revision_no'),
+        );
+
+        $this->artisan('career-jobs:import-local-baseline', [
+            '--locale' => ['en'],
+            '--job' => ['product-manager'],
+            '--upsert' => true,
+            '--status' => 'published',
+            '--source-dir' => 'tests/Fixtures/career_job_baseline',
+        ])
+            ->expectsOutputToContain('will_skip=1')
+            ->assertExitCode(0);
+
+        $this->assertSame(
+            2,
+            CareerJobRevision::query()->where('job_id', (int) $job->id)->count(),
+        );
+    }
+
+    public function test_locale_and_job_filters_limit_import_scope(): void
+    {
+        $this->artisan('career-jobs:import-local-baseline', [
+            '--locale' => ['zh-CN'],
+            '--job' => ['product-manager'],
+            '--status' => 'draft',
+            '--source-dir' => 'tests/Fixtures/career_job_baseline',
+        ])
+            ->expectsOutputToContain('jobs_found=1')
+            ->expectsOutputToContain('will_create=1')
+            ->assertExitCode(0);
+
+        $this->assertSame(1, CareerJob::query()->count());
+
+        $job = CareerJob::query()->firstOrFail();
+        $this->assertSame('product-manager', $job->job_code);
+        $this->assertSame('zh-CN', $job->locale);
+    }
+
+    public function test_invalid_baseline_fails_with_non_zero_exit_code(): void
+    {
+        $sourceDir = base_path('tests/Fixtures/career_job_baseline_invalid');
+
+        File::deleteDirectory($sourceDir);
+        File::ensureDirectoryExists($sourceDir);
+        File::put($sourceDir.'/career_jobs.en.json', json_encode([
+            'meta' => [
+                'schema_version' => 'v1',
+                'locale' => 'en',
+                'source' => 'test fixture',
+                'generated_at' => '2026-03-09T00:00:00Z',
+            ],
+            'jobs' => [
+                [
+                    'job_code' => 'bad-job',
+                    'slug' => 'bad-job',
+                    'locale' => 'en',
+                    'title' => 'Bad Job',
+                    'excerpt' => 'Bad',
+                    'body_md' => '# Bad',
+                    'body_html' => null,
+                    'salary_json' => ['raw' => '$1'],
+                    'outlook_json' => ['summary' => 'Bad'],
+                    'skills_json' => ['core' => ['Bad'], 'supporting' => []],
+                    'work_contents_json' => ['items' => ['Bad']],
+                    'growth_path_json' => ['raw' => ['Bad']],
+                    'fit_personality_codes_json' => null,
+                    'mbti_primary_codes_json' => ['BAD'],
+                    'mbti_secondary_codes_json' => ['ENFP'],
+                    'riasec_profile_json' => ['R' => 1, 'I' => 2, 'A' => 3, 'S' => 4, 'E' => 5, 'C' => 6],
+                    'big5_targets_json' => ['raw' => ['openness' => ['min' => 40, 'max' => 80]]],
+                    'iq_eq_notes_json' => ['iq_range' => ['min' => 1, 'max' => 2]],
+                    'market_demand_json' => ['raw' => 1],
+                    'status' => 'published',
+                    'is_public' => true,
+                    'is_indexable' => true,
+                    'published_at' => null,
+                    'scheduled_at' => null,
+                    'sort_order' => 0,
+                    'sections' => [],
+                    'seo_meta' => [],
+                ],
+            ],
+        ], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES | JSON_PRETTY_PRINT));
+
+        try {
+            $this->artisan('career-jobs:import-local-baseline', [
+                '--source-dir' => 'tests/Fixtures/career_job_baseline_invalid',
+            ])
+                ->expectsOutputToContain('invalid MBTI code')
+                ->assertExitCode(1);
+        } finally {
+            File::deleteDirectory($sourceDir);
+        }
+    }
+}

--- a/backend/tests/Fixtures/career_job_baseline/career_jobs.en.json
+++ b/backend/tests/Fixtures/career_job_baseline/career_jobs.en.json
@@ -1,0 +1,230 @@
+{
+  "meta": {
+    "schema_version": "v1",
+    "locale": "en",
+    "source": "test fixture",
+    "generated_at": "2026-03-09T00:00:00Z"
+  },
+  "jobs": [
+    {
+      "job_code": "product-manager",
+      "slug": "product-manager",
+      "locale": "en",
+      "title": "Product Manager",
+      "subtitle": null,
+      "excerpt": "Lead product direction across user, business, and engineering goals.",
+      "hero_kicker": null,
+      "hero_quote": null,
+      "cover_image_url": null,
+      "industry_slug": "business",
+      "industry_label": null,
+      "body_md": "# Product Manager\n\nA practical role profile.\n",
+      "body_html": null,
+      "salary_json": {
+        "raw": "$55,000 - $180,000"
+      },
+      "outlook_json": {
+        "summary": "Demand remains strong in data-driven organizations."
+      },
+      "skills_json": {
+        "core": [
+          "Structured problem solving",
+          "Stakeholder communication"
+        ],
+        "supporting": []
+      },
+      "work_contents_json": {
+        "items": [
+          "Define product priorities.",
+          "Coordinate stakeholders."
+        ]
+      },
+      "growth_path_json": {
+        "raw": [
+          "0-2 years: build execution skills.",
+          "3-5 years: own medium complexity projects."
+        ]
+      },
+      "fit_personality_codes_json": null,
+      "mbti_primary_codes_json": [
+        "ENTJ",
+        "ENFJ",
+        "ESTP"
+      ],
+      "mbti_secondary_codes_json": [
+        "ENFP",
+        "ESTJ",
+        "ENTP"
+      ],
+      "riasec_profile_json": {
+        "R": 42,
+        "I": 66,
+        "A": 56,
+        "S": 60,
+        "E": 88,
+        "C": 70
+      },
+      "big5_targets_json": {
+        "raw": {
+          "openness": {
+            "min": 40,
+            "max": 80
+          },
+          "conscientiousness": {
+            "min": 50,
+            "max": 90
+          }
+        }
+      },
+      "iq_eq_notes_json": {
+        "iq_range": {
+          "min": 50,
+          "max": 98
+        },
+        "eq_range": {
+          "min": 55,
+          "max": 100
+        }
+      },
+      "market_demand_json": {
+        "raw": 82
+      },
+      "status": "published",
+      "is_public": true,
+      "is_indexable": true,
+      "published_at": null,
+      "scheduled_at": null,
+      "sort_order": 5,
+      "sections": [
+        {
+          "section_key": "faq",
+          "title": "FAQ",
+          "render_variant": "faq",
+          "body_md": null,
+          "body_html": null,
+          "payload_json": {
+            "items": [
+              {
+                "question": "What does a PM do?",
+                "answer": "Align product direction with business outcomes."
+              }
+            ]
+          },
+          "sort_order": 80,
+          "is_enabled": true
+        }
+      ],
+      "seo_meta": {
+        "seo_title": "Product Manager Career Guide | FermatMind",
+        "seo_description": "Responsibilities, salary, growth path, and personality fit for Product Managers.",
+        "canonical_url": null,
+        "og_title": null,
+        "og_description": null,
+        "og_image_url": null,
+        "twitter_title": null,
+        "twitter_description": null,
+        "twitter_image_url": null,
+        "robots": null,
+        "jsonld_overrides_json": null
+      }
+    },
+    {
+      "job_code": "teacher",
+      "slug": "teacher",
+      "locale": "en",
+      "title": "Teacher",
+      "subtitle": null,
+      "excerpt": "A practical role profile for teacher.",
+      "hero_kicker": null,
+      "hero_quote": null,
+      "cover_image_url": null,
+      "industry_slug": "education",
+      "industry_label": null,
+      "body_md": "# Teacher\n\nTeach, mentor, and guide learning outcomes.\n",
+      "body_html": null,
+      "salary_json": {
+        "raw": "$40,000 - $95,000"
+      },
+      "outlook_json": {
+        "summary": "Demand remains steady."
+      },
+      "skills_json": {
+        "core": [
+          "Communication",
+          "Lesson planning"
+        ],
+        "supporting": []
+      },
+      "work_contents_json": {
+        "items": [
+          "Prepare lessons.",
+          "Support students."
+        ]
+      },
+      "growth_path_json": {
+        "raw": [
+          "Build classroom fundamentals.",
+          "Advance into senior teaching roles."
+        ]
+      },
+      "fit_personality_codes_json": null,
+      "mbti_primary_codes_json": [
+        "ENFJ",
+        "ESFJ"
+      ],
+      "mbti_secondary_codes_json": [
+        "INFJ",
+        "ISFJ"
+      ],
+      "riasec_profile_json": {
+        "R": 20,
+        "I": 44,
+        "A": 38,
+        "S": 92,
+        "E": 54,
+        "C": 46
+      },
+      "big5_targets_json": {
+        "raw": {
+          "agreeableness": {
+            "min": 55,
+            "max": 95
+          }
+        }
+      },
+      "iq_eq_notes_json": {
+        "iq_range": {
+          "min": 40,
+          "max": 85
+        },
+        "eq_range": {
+          "min": 60,
+          "max": 100
+        }
+      },
+      "market_demand_json": {
+        "raw": 68
+      },
+      "status": "published",
+      "is_public": true,
+      "is_indexable": true,
+      "published_at": null,
+      "scheduled_at": null,
+      "sort_order": 20,
+      "sections": [],
+      "seo_meta": {
+        "seo_title": "Teacher Career Guide | FermatMind",
+        "seo_description": "Responsibilities, salary, growth path, and personality fit for Teachers.",
+        "canonical_url": null,
+        "og_title": null,
+        "og_description": null,
+        "og_image_url": null,
+        "twitter_title": null,
+        "twitter_description": null,
+        "twitter_image_url": null,
+        "robots": null,
+        "jsonld_overrides_json": null
+      }
+    }
+  ]
+}

--- a/backend/tests/Fixtures/career_job_baseline/career_jobs.zh-CN.json
+++ b/backend/tests/Fixtures/career_job_baseline/career_jobs.zh-CN.json
@@ -1,0 +1,230 @@
+{
+  "meta": {
+    "schema_version": "v1",
+    "locale": "zh-CN",
+    "source": "test fixture",
+    "generated_at": "2026-03-09T00:00:00Z"
+  },
+  "jobs": [
+    {
+      "job_code": "product-manager",
+      "slug": "product-manager",
+      "locale": "zh-CN",
+      "title": "产品经理",
+      "subtitle": null,
+      "excerpt": "面向产品经理的实用岗位画像。",
+      "hero_kicker": null,
+      "hero_quote": null,
+      "cover_image_url": null,
+      "industry_slug": "business",
+      "industry_label": null,
+      "body_md": "# 产品经理\n\n面向产品方向的职业画像。\n",
+      "body_html": null,
+      "salary_json": {
+        "raw": "人民币 18万 - 90万/年"
+      },
+      "outlook_json": {
+        "summary": "产品经理需求保持较高水平。"
+      },
+      "skills_json": {
+        "core": [
+          "结构化问题解决",
+          "跨角色沟通"
+        ],
+        "supporting": []
+      },
+      "work_contents_json": {
+        "items": [
+          "明确优先级。",
+          "推进跨团队协作。"
+        ]
+      },
+      "growth_path_json": {
+        "raw": [
+          "0-2 年：建立执行能力。",
+          "3-5 年：独立负责中等复杂度项目。"
+        ]
+      },
+      "fit_personality_codes_json": null,
+      "mbti_primary_codes_json": [
+        "ENTJ",
+        "ENFJ",
+        "ESTP"
+      ],
+      "mbti_secondary_codes_json": [
+        "ENFP",
+        "ESTJ",
+        "ENTP"
+      ],
+      "riasec_profile_json": {
+        "R": 42,
+        "I": 66,
+        "A": 56,
+        "S": 60,
+        "E": 88,
+        "C": 70
+      },
+      "big5_targets_json": {
+        "raw": {
+          "openness": {
+            "min": 40,
+            "max": 80
+          },
+          "conscientiousness": {
+            "min": 50,
+            "max": 90
+          }
+        }
+      },
+      "iq_eq_notes_json": {
+        "iq_range": {
+          "min": 50,
+          "max": 98
+        },
+        "eq_range": {
+          "min": 55,
+          "max": 100
+        }
+      },
+      "market_demand_json": {
+        "raw": 82
+      },
+      "status": "published",
+      "is_public": true,
+      "is_indexable": true,
+      "published_at": null,
+      "scheduled_at": null,
+      "sort_order": 5,
+      "sections": [
+        {
+          "section_key": "faq",
+          "title": "常见问题",
+          "render_variant": "faq",
+          "body_md": null,
+          "body_html": null,
+          "payload_json": {
+            "items": [
+              {
+                "question": "产品经理做什么？",
+                "answer": "把产品方向与业务目标对齐。"
+              }
+            ]
+          },
+          "sort_order": 80,
+          "is_enabled": true
+        }
+      ],
+      "seo_meta": {
+        "seo_title": "产品经理职业指南 | FermatMind",
+        "seo_description": "了解产品经理的职责、薪资、成长路径与人格适配。",
+        "canonical_url": null,
+        "og_title": null,
+        "og_description": null,
+        "og_image_url": null,
+        "twitter_title": null,
+        "twitter_description": null,
+        "twitter_image_url": null,
+        "robots": null,
+        "jsonld_overrides_json": null
+      }
+    },
+    {
+      "job_code": "teacher",
+      "slug": "teacher",
+      "locale": "zh-CN",
+      "title": "教师",
+      "subtitle": null,
+      "excerpt": "面向教师的实用岗位画像。",
+      "hero_kicker": null,
+      "hero_quote": null,
+      "cover_image_url": null,
+      "industry_slug": "education",
+      "industry_label": null,
+      "body_md": "# 教师\n\n围绕教学、陪伴与学习成果展开的职业画像。\n",
+      "body_html": null,
+      "salary_json": {
+        "raw": "人民币 10万 - 35万/年"
+      },
+      "outlook_json": {
+        "summary": "需求整体稳定。"
+      },
+      "skills_json": {
+        "core": [
+          "沟通",
+          "课程设计"
+        ],
+        "supporting": []
+      },
+      "work_contents_json": {
+        "items": [
+          "准备课程。",
+          "支持学生成长。"
+        ]
+      },
+      "growth_path_json": {
+        "raw": [
+          "打好课堂基础。",
+          "发展到资深教学岗位。"
+        ]
+      },
+      "fit_personality_codes_json": null,
+      "mbti_primary_codes_json": [
+        "ENFJ",
+        "ESFJ"
+      ],
+      "mbti_secondary_codes_json": [
+        "INFJ",
+        "ISFJ"
+      ],
+      "riasec_profile_json": {
+        "R": 20,
+        "I": 44,
+        "A": 38,
+        "S": 92,
+        "E": 54,
+        "C": 46
+      },
+      "big5_targets_json": {
+        "raw": {
+          "agreeableness": {
+            "min": 55,
+            "max": 95
+          }
+        }
+      },
+      "iq_eq_notes_json": {
+        "iq_range": {
+          "min": 40,
+          "max": 85
+        },
+        "eq_range": {
+          "min": 60,
+          "max": 100
+        }
+      },
+      "market_demand_json": {
+        "raw": 68
+      },
+      "status": "published",
+      "is_public": true,
+      "is_indexable": true,
+      "published_at": null,
+      "scheduled_at": null,
+      "sort_order": 20,
+      "sections": [],
+      "seo_meta": {
+        "seo_title": "教师职业指南 | FermatMind",
+        "seo_description": "了解教师的职责、薪资、成长路径与人格适配。",
+        "canonical_url": null,
+        "og_title": null,
+        "og_description": null,
+        "og_image_url": null,
+        "twitter_title": null,
+        "twitter_description": null,
+        "twitter_image_url": null,
+        "robots": null,
+        "jsonld_overrides_json": null
+      }
+    }
+  ]
+}

--- a/content_baselines/career_jobs/career_jobs.en.json
+++ b/content_baselines/career_jobs/career_jobs.en.json
@@ -1,0 +1,3760 @@
+{
+  "meta": {
+    "schema_version": "v1",
+    "locale": "en",
+    "source": "fap-web career jobs baseline",
+    "generated_at": "2026-03-09T00:00:00Z"
+  },
+  "jobs": [
+    {
+      "job_code": "backend-engineer",
+      "slug": "backend-engineer",
+      "locale": "en",
+      "title": "Backend Engineer",
+      "subtitle": null,
+      "excerpt": "A practical role profile for backend engineer including responsibilities, required skills, salary, and growth path.",
+      "hero_kicker": null,
+      "hero_quote": null,
+      "cover_image_url": null,
+      "industry_slug": "technology",
+      "industry_label": null,
+      "body_md": "# Backend Engineer\n## Role Overview\nBackend Engineer is a role where performance compounds through execution quality, communication precision, and long-term learning velocity.\n\n## Core Work Scope\nThis role contributes to business outcomes by translating goals into high-quality deliverables, collaborating across functions, and continuously improving process quality.\n\n## Career Development Advice\nUse 90-day cycles to track output metrics, capability growth, and collaboration impact. Review your progress every quarter and adjust your growth plan based on evidence.\n",
+      "body_html": null,
+      "salary_json": {
+        "raw": "$55,000 - $180,000 (varies by region and seniority)"
+      },
+      "outlook_json": {
+        "summary": "Demand for backend engineer talent remains strong in data-driven organizations."
+      },
+      "skills_json": {
+        "core": [
+          "Structured problem solving",
+          "Stakeholder communication",
+          "Execution management",
+          "Data-informed decision making",
+          "Continuous learning"
+        ],
+        "supporting": [
+
+        ]
+      },
+      "work_contents_json": {
+        "items": [
+          "Define key responsibilities and delivery metrics for backend engineer workstreams.",
+          "Coordinate cross-functional stakeholders and align execution priorities.",
+          "Track progress, risks, and quality signals to ensure stable outcomes."
+        ]
+      },
+      "growth_path_json": {
+        "raw": [
+          "0-2 years: build core execution competency and domain literacy.",
+          "3-5 years: own medium-complexity projects and cross-team collaboration.",
+          "5+ years: move toward specialist leadership or managerial scope."
+        ]
+      },
+      "fit_personality_codes_json": null,
+      "mbti_primary_codes_json": [
+        "INTJ",
+        "INTP",
+        "ENTJ"
+      ],
+      "mbti_secondary_codes_json": [
+        "ENTP",
+        "ISTJ",
+        "INFJ"
+      ],
+      "riasec_profile_json": {
+        "R": 55,
+        "I": 88,
+        "A": 48,
+        "S": 42,
+        "E": 50,
+        "C": 68
+      },
+      "big5_targets_json": {
+        "raw": {
+          "openness": {
+            "min": 40,
+            "max": 80
+          },
+          "conscientiousness": {
+            "min": 50,
+            "max": 90
+          },
+          "extraversion": {
+            "min": 35,
+            "max": 82
+          },
+          "agreeableness": {
+            "min": 35,
+            "max": 85
+          },
+          "neuroticism": {
+            "min": 10,
+            "max": 55
+          }
+        }
+      },
+      "iq_eq_notes_json": {
+        "iq_range": {
+          "min": 65,
+          "max": 100
+        },
+        "eq_range": {
+          "min": 45,
+          "max": 90
+        }
+      },
+      "market_demand_json": {
+        "raw": 92
+      },
+      "status": "published",
+      "is_public": true,
+      "is_indexable": true,
+      "published_at": null,
+      "scheduled_at": null,
+      "sort_order": 0,
+      "sections": [
+
+      ],
+      "seo_meta": {
+        "seo_title": null,
+        "seo_description": null,
+        "canonical_url": null,
+        "og_title": null,
+        "og_description": null,
+        "og_image_url": null,
+        "twitter_title": null,
+        "twitter_description": null,
+        "twitter_image_url": null,
+        "robots": null,
+        "jsonld_overrides_json": null
+      }
+    },
+    {
+      "job_code": "brand-manager",
+      "slug": "brand-manager",
+      "locale": "en",
+      "title": "Brand Manager",
+      "subtitle": null,
+      "excerpt": "A practical role profile for brand manager including responsibilities, required skills, salary, and growth path.",
+      "hero_kicker": null,
+      "hero_quote": null,
+      "cover_image_url": null,
+      "industry_slug": "design",
+      "industry_label": null,
+      "body_md": "# Brand Manager\n## Role Overview\nBrand Manager is a role where performance compounds through execution quality, communication precision, and long-term learning velocity.\n\n## Core Work Scope\nThis role contributes to business outcomes by translating goals into high-quality deliverables, collaborating across functions, and continuously improving process quality.\n\n## Career Development Advice\nUse 90-day cycles to track output metrics, capability growth, and collaboration impact. Review your progress every quarter and adjust your growth plan based on evidence.\n",
+      "body_html": null,
+      "salary_json": {
+        "raw": "$55,000 - $180,000 (varies by region and seniority)"
+      },
+      "outlook_json": {
+        "summary": "Demand for brand manager talent remains strong in data-driven organizations."
+      },
+      "skills_json": {
+        "core": [
+          "Structured problem solving",
+          "Stakeholder communication",
+          "Execution management",
+          "Data-informed decision making",
+          "Continuous learning"
+        ],
+        "supporting": [
+
+        ]
+      },
+      "work_contents_json": {
+        "items": [
+          "Define key responsibilities and delivery metrics for brand manager workstreams.",
+          "Coordinate cross-functional stakeholders and align execution priorities.",
+          "Track progress, risks, and quality signals to ensure stable outcomes."
+        ]
+      },
+      "growth_path_json": {
+        "raw": [
+          "0-2 years: build core execution competency and domain literacy.",
+          "3-5 years: own medium-complexity projects and cross-team collaboration.",
+          "5+ years: move toward specialist leadership or managerial scope."
+        ]
+      },
+      "fit_personality_codes_json": null,
+      "mbti_primary_codes_json": [
+        "INFP",
+        "ENFP",
+        "ISFP"
+      ],
+      "mbti_secondary_codes_json": [
+        "INFJ",
+        "ENTP",
+        "ESFP"
+      ],
+      "riasec_profile_json": {
+        "R": 38,
+        "I": 62,
+        "A": 90,
+        "S": 54,
+        "E": 60,
+        "C": 44
+      },
+      "big5_targets_json": {
+        "raw": {
+          "openness": {
+            "min": 40,
+            "max": 80
+          },
+          "conscientiousness": {
+            "min": 50,
+            "max": 90
+          },
+          "extraversion": {
+            "min": 35,
+            "max": 82
+          },
+          "agreeableness": {
+            "min": 35,
+            "max": 85
+          },
+          "neuroticism": {
+            "min": 10,
+            "max": 55
+          }
+        }
+      },
+      "iq_eq_notes_json": {
+        "iq_range": {
+          "min": 45,
+          "max": 95
+        },
+        "eq_range": {
+          "min": 52,
+          "max": 96
+        }
+      },
+      "market_demand_json": {
+        "raw": 78
+      },
+      "status": "published",
+      "is_public": true,
+      "is_indexable": true,
+      "published_at": null,
+      "scheduled_at": null,
+      "sort_order": 0,
+      "sections": [
+
+      ],
+      "seo_meta": {
+        "seo_title": null,
+        "seo_description": null,
+        "canonical_url": null,
+        "og_title": null,
+        "og_description": null,
+        "og_image_url": null,
+        "twitter_title": null,
+        "twitter_description": null,
+        "twitter_image_url": null,
+        "robots": null,
+        "jsonld_overrides_json": null
+      }
+    },
+    {
+      "job_code": "business-analyst",
+      "slug": "business-analyst",
+      "locale": "en",
+      "title": "Business Analyst",
+      "subtitle": null,
+      "excerpt": "A practical role profile for business analyst including responsibilities, required skills, salary, and growth path.",
+      "hero_kicker": null,
+      "hero_quote": null,
+      "cover_image_url": null,
+      "industry_slug": "consulting",
+      "industry_label": null,
+      "body_md": "# Business Analyst\n## Role Overview\nBusiness Analyst is a role where performance compounds through execution quality, communication precision, and long-term learning velocity.\n\n## Core Work Scope\nThis role contributes to business outcomes by translating goals into high-quality deliverables, collaborating across functions, and continuously improving process quality.\n\n## Career Development Advice\nUse 90-day cycles to track output metrics, capability growth, and collaboration impact. Review your progress every quarter and adjust your growth plan based on evidence.\n",
+      "body_html": null,
+      "salary_json": {
+        "raw": "$55,000 - $180,000 (varies by region and seniority)"
+      },
+      "outlook_json": {
+        "summary": "Demand for business analyst talent remains strong in data-driven organizations."
+      },
+      "skills_json": {
+        "core": [
+          "Structured problem solving",
+          "Stakeholder communication",
+          "Execution management",
+          "Data-informed decision making",
+          "Continuous learning"
+        ],
+        "supporting": [
+
+        ]
+      },
+      "work_contents_json": {
+        "items": [
+          "Define key responsibilities and delivery metrics for business analyst workstreams.",
+          "Coordinate cross-functional stakeholders and align execution priorities.",
+          "Track progress, risks, and quality signals to ensure stable outcomes."
+        ]
+      },
+      "growth_path_json": {
+        "raw": [
+          "0-2 years: build core execution competency and domain literacy.",
+          "3-5 years: own medium-complexity projects and cross-team collaboration.",
+          "5+ years: move toward specialist leadership or managerial scope."
+        ]
+      },
+      "fit_personality_codes_json": null,
+      "mbti_primary_codes_json": [
+        "INTJ",
+        "INTP",
+        "ENTJ"
+      ],
+      "mbti_secondary_codes_json": [
+        "ENTP",
+        "ISTJ",
+        "INFJ"
+      ],
+      "riasec_profile_json": {
+        "R": 40,
+        "I": 90,
+        "A": 45,
+        "S": 38,
+        "E": 46,
+        "C": 72
+      },
+      "big5_targets_json": {
+        "raw": {
+          "openness": {
+            "min": 40,
+            "max": 80
+          },
+          "conscientiousness": {
+            "min": 50,
+            "max": 90
+          },
+          "extraversion": {
+            "min": 35,
+            "max": 82
+          },
+          "agreeableness": {
+            "min": 35,
+            "max": 85
+          },
+          "neuroticism": {
+            "min": 10,
+            "max": 55
+          }
+        }
+      },
+      "iq_eq_notes_json": {
+        "iq_range": {
+          "min": 62,
+          "max": 100
+        },
+        "eq_range": {
+          "min": 40,
+          "max": 86
+        }
+      },
+      "market_demand_json": {
+        "raw": 85
+      },
+      "status": "published",
+      "is_public": true,
+      "is_indexable": true,
+      "published_at": null,
+      "scheduled_at": null,
+      "sort_order": 0,
+      "sections": [
+
+      ],
+      "seo_meta": {
+        "seo_title": null,
+        "seo_description": null,
+        "canonical_url": null,
+        "og_title": null,
+        "og_description": null,
+        "og_image_url": null,
+        "twitter_title": null,
+        "twitter_description": null,
+        "twitter_image_url": null,
+        "robots": null,
+        "jsonld_overrides_json": null
+      }
+    },
+    {
+      "job_code": "cloud-architect",
+      "slug": "cloud-architect",
+      "locale": "en",
+      "title": "Cloud Architect",
+      "subtitle": null,
+      "excerpt": "A practical role profile for cloud architect including responsibilities, required skills, salary, and growth path.",
+      "hero_kicker": null,
+      "hero_quote": null,
+      "cover_image_url": null,
+      "industry_slug": "technology",
+      "industry_label": null,
+      "body_md": "# Cloud Architect\n## Role Overview\nCloud Architect is a role where performance compounds through execution quality, communication precision, and long-term learning velocity.\n\n## Core Work Scope\nThis role contributes to business outcomes by translating goals into high-quality deliverables, collaborating across functions, and continuously improving process quality.\n\n## Career Development Advice\nUse 90-day cycles to track output metrics, capability growth, and collaboration impact. Review your progress every quarter and adjust your growth plan based on evidence.\n",
+      "body_html": null,
+      "salary_json": {
+        "raw": "$55,000 - $180,000 (varies by region and seniority)"
+      },
+      "outlook_json": {
+        "summary": "Demand for cloud architect talent remains strong in data-driven organizations."
+      },
+      "skills_json": {
+        "core": [
+          "Structured problem solving",
+          "Stakeholder communication",
+          "Execution management",
+          "Data-informed decision making",
+          "Continuous learning"
+        ],
+        "supporting": [
+
+        ]
+      },
+      "work_contents_json": {
+        "items": [
+          "Define key responsibilities and delivery metrics for cloud architect workstreams.",
+          "Coordinate cross-functional stakeholders and align execution priorities.",
+          "Track progress, risks, and quality signals to ensure stable outcomes."
+        ]
+      },
+      "growth_path_json": {
+        "raw": [
+          "0-2 years: build core execution competency and domain literacy.",
+          "3-5 years: own medium-complexity projects and cross-team collaboration.",
+          "5+ years: move toward specialist leadership or managerial scope."
+        ]
+      },
+      "fit_personality_codes_json": null,
+      "mbti_primary_codes_json": [
+        "INTJ",
+        "INTP",
+        "ENTJ"
+      ],
+      "mbti_secondary_codes_json": [
+        "ENTP",
+        "ISTJ",
+        "INFJ"
+      ],
+      "riasec_profile_json": {
+        "R": 55,
+        "I": 88,
+        "A": 48,
+        "S": 42,
+        "E": 50,
+        "C": 68
+      },
+      "big5_targets_json": {
+        "raw": {
+          "openness": {
+            "min": 40,
+            "max": 80
+          },
+          "conscientiousness": {
+            "min": 50,
+            "max": 90
+          },
+          "extraversion": {
+            "min": 35,
+            "max": 82
+          },
+          "agreeableness": {
+            "min": 35,
+            "max": 85
+          },
+          "neuroticism": {
+            "min": 10,
+            "max": 55
+          }
+        }
+      },
+      "iq_eq_notes_json": {
+        "iq_range": {
+          "min": 65,
+          "max": 100
+        },
+        "eq_range": {
+          "min": 45,
+          "max": 90
+        }
+      },
+      "market_demand_json": {
+        "raw": 92
+      },
+      "status": "published",
+      "is_public": true,
+      "is_indexable": true,
+      "published_at": null,
+      "scheduled_at": null,
+      "sort_order": 0,
+      "sections": [
+
+      ],
+      "seo_meta": {
+        "seo_title": null,
+        "seo_description": null,
+        "canonical_url": null,
+        "og_title": null,
+        "og_description": null,
+        "og_image_url": null,
+        "twitter_title": null,
+        "twitter_description": null,
+        "twitter_image_url": null,
+        "robots": null,
+        "jsonld_overrides_json": null
+      }
+    },
+    {
+      "job_code": "content-strategist",
+      "slug": "content-strategist",
+      "locale": "en",
+      "title": "Content Strategist",
+      "subtitle": null,
+      "excerpt": "A practical role profile for content strategist including responsibilities, required skills, salary, and growth path.",
+      "hero_kicker": null,
+      "hero_quote": null,
+      "cover_image_url": null,
+      "industry_slug": "media",
+      "industry_label": null,
+      "body_md": "# Content Strategist\n## Role Overview\nContent Strategist is a role where performance compounds through execution quality, communication precision, and long-term learning velocity.\n\n## Core Work Scope\nThis role contributes to business outcomes by translating goals into high-quality deliverables, collaborating across functions, and continuously improving process quality.\n\n## Career Development Advice\nUse 90-day cycles to track output metrics, capability growth, and collaboration impact. Review your progress every quarter and adjust your growth plan based on evidence.\n",
+      "body_html": null,
+      "salary_json": {
+        "raw": "$55,000 - $180,000 (varies by region and seniority)"
+      },
+      "outlook_json": {
+        "summary": "Demand for content strategist talent remains strong in data-driven organizations."
+      },
+      "skills_json": {
+        "core": [
+          "Structured problem solving",
+          "Stakeholder communication",
+          "Execution management",
+          "Data-informed decision making",
+          "Continuous learning"
+        ],
+        "supporting": [
+
+        ]
+      },
+      "work_contents_json": {
+        "items": [
+          "Define key responsibilities and delivery metrics for content strategist workstreams.",
+          "Coordinate cross-functional stakeholders and align execution priorities.",
+          "Track progress, risks, and quality signals to ensure stable outcomes."
+        ]
+      },
+      "growth_path_json": {
+        "raw": [
+          "0-2 years: build core execution competency and domain literacy.",
+          "3-5 years: own medium-complexity projects and cross-team collaboration.",
+          "5+ years: move toward specialist leadership or managerial scope."
+        ]
+      },
+      "fit_personality_codes_json": null,
+      "mbti_primary_codes_json": [
+        "INFP",
+        "ENFP",
+        "ISFP"
+      ],
+      "mbti_secondary_codes_json": [
+        "INFJ",
+        "ENTP",
+        "ESFP"
+      ],
+      "riasec_profile_json": {
+        "R": 38,
+        "I": 62,
+        "A": 90,
+        "S": 54,
+        "E": 60,
+        "C": 44
+      },
+      "big5_targets_json": {
+        "raw": {
+          "openness": {
+            "min": 40,
+            "max": 80
+          },
+          "conscientiousness": {
+            "min": 50,
+            "max": 90
+          },
+          "extraversion": {
+            "min": 35,
+            "max": 82
+          },
+          "agreeableness": {
+            "min": 35,
+            "max": 85
+          },
+          "neuroticism": {
+            "min": 10,
+            "max": 55
+          }
+        }
+      },
+      "iq_eq_notes_json": {
+        "iq_range": {
+          "min": 45,
+          "max": 95
+        },
+        "eq_range": {
+          "min": 52,
+          "max": 96
+        }
+      },
+      "market_demand_json": {
+        "raw": 78
+      },
+      "status": "published",
+      "is_public": true,
+      "is_indexable": true,
+      "published_at": null,
+      "scheduled_at": null,
+      "sort_order": 0,
+      "sections": [
+
+      ],
+      "seo_meta": {
+        "seo_title": null,
+        "seo_description": null,
+        "canonical_url": null,
+        "og_title": null,
+        "og_description": null,
+        "og_image_url": null,
+        "twitter_title": null,
+        "twitter_description": null,
+        "twitter_image_url": null,
+        "robots": null,
+        "jsonld_overrides_json": null
+      }
+    },
+    {
+      "job_code": "cybersecurity-analyst",
+      "slug": "cybersecurity-analyst",
+      "locale": "en",
+      "title": "Cybersecurity Analyst",
+      "subtitle": null,
+      "excerpt": "A practical role profile for cybersecurity analyst including responsibilities, required skills, salary, and growth path.",
+      "hero_kicker": null,
+      "hero_quote": null,
+      "cover_image_url": null,
+      "industry_slug": "technology",
+      "industry_label": null,
+      "body_md": "# Cybersecurity Analyst\n## Role Overview\nCybersecurity Analyst is a role where performance compounds through execution quality, communication precision, and long-term learning velocity.\n\n## Core Work Scope\nThis role contributes to business outcomes by translating goals into high-quality deliverables, collaborating across functions, and continuously improving process quality.\n\n## Career Development Advice\nUse 90-day cycles to track output metrics, capability growth, and collaboration impact. Review your progress every quarter and adjust your growth plan based on evidence.\n",
+      "body_html": null,
+      "salary_json": {
+        "raw": "$55,000 - $180,000 (varies by region and seniority)"
+      },
+      "outlook_json": {
+        "summary": "Demand for cybersecurity analyst talent remains strong in data-driven organizations."
+      },
+      "skills_json": {
+        "core": [
+          "Structured problem solving",
+          "Stakeholder communication",
+          "Execution management",
+          "Data-informed decision making",
+          "Continuous learning"
+        ],
+        "supporting": [
+
+        ]
+      },
+      "work_contents_json": {
+        "items": [
+          "Define key responsibilities and delivery metrics for cybersecurity analyst workstreams.",
+          "Coordinate cross-functional stakeholders and align execution priorities.",
+          "Track progress, risks, and quality signals to ensure stable outcomes."
+        ]
+      },
+      "growth_path_json": {
+        "raw": [
+          "0-2 years: build core execution competency and domain literacy.",
+          "3-5 years: own medium-complexity projects and cross-team collaboration.",
+          "5+ years: move toward specialist leadership or managerial scope."
+        ]
+      },
+      "fit_personality_codes_json": null,
+      "mbti_primary_codes_json": [
+        "INTJ",
+        "INTP",
+        "ENTJ"
+      ],
+      "mbti_secondary_codes_json": [
+        "ENTP",
+        "ISTJ",
+        "INFJ"
+      ],
+      "riasec_profile_json": {
+        "R": 55,
+        "I": 88,
+        "A": 48,
+        "S": 42,
+        "E": 50,
+        "C": 68
+      },
+      "big5_targets_json": {
+        "raw": {
+          "openness": {
+            "min": 40,
+            "max": 80
+          },
+          "conscientiousness": {
+            "min": 50,
+            "max": 90
+          },
+          "extraversion": {
+            "min": 35,
+            "max": 82
+          },
+          "agreeableness": {
+            "min": 35,
+            "max": 85
+          },
+          "neuroticism": {
+            "min": 10,
+            "max": 55
+          }
+        }
+      },
+      "iq_eq_notes_json": {
+        "iq_range": {
+          "min": 65,
+          "max": 100
+        },
+        "eq_range": {
+          "min": 45,
+          "max": 90
+        }
+      },
+      "market_demand_json": {
+        "raw": 92
+      },
+      "status": "published",
+      "is_public": true,
+      "is_indexable": true,
+      "published_at": null,
+      "scheduled_at": null,
+      "sort_order": 0,
+      "sections": [
+
+      ],
+      "seo_meta": {
+        "seo_title": null,
+        "seo_description": null,
+        "canonical_url": null,
+        "og_title": null,
+        "og_description": null,
+        "og_image_url": null,
+        "twitter_title": null,
+        "twitter_description": null,
+        "twitter_image_url": null,
+        "robots": null,
+        "jsonld_overrides_json": null
+      }
+    },
+    {
+      "job_code": "data-analyst",
+      "slug": "data-analyst",
+      "locale": "en",
+      "title": "Data Analyst",
+      "subtitle": null,
+      "excerpt": "A practical role profile for data analyst including responsibilities, required skills, salary, and growth path.",
+      "hero_kicker": null,
+      "hero_quote": null,
+      "cover_image_url": null,
+      "industry_slug": "technology",
+      "industry_label": null,
+      "body_md": "# Data Analyst\n## Role Overview\nData Analyst is a role where performance compounds through execution quality, communication precision, and long-term learning velocity.\n\n## Core Work Scope\nThis role contributes to business outcomes by translating goals into high-quality deliverables, collaborating across functions, and continuously improving process quality.\n\n## Career Development Advice\nUse 90-day cycles to track output metrics, capability growth, and collaboration impact. Review your progress every quarter and adjust your growth plan based on evidence.\n",
+      "body_html": null,
+      "salary_json": {
+        "raw": "$55,000 - $180,000 (varies by region and seniority)"
+      },
+      "outlook_json": {
+        "summary": "Demand for data analyst talent remains strong in data-driven organizations."
+      },
+      "skills_json": {
+        "core": [
+          "Structured problem solving",
+          "Stakeholder communication",
+          "Execution management",
+          "Data-informed decision making",
+          "Continuous learning"
+        ],
+        "supporting": [
+
+        ]
+      },
+      "work_contents_json": {
+        "items": [
+          "Define key responsibilities and delivery metrics for data analyst workstreams.",
+          "Coordinate cross-functional stakeholders and align execution priorities.",
+          "Track progress, risks, and quality signals to ensure stable outcomes."
+        ]
+      },
+      "growth_path_json": {
+        "raw": [
+          "0-2 years: build core execution competency and domain literacy.",
+          "3-5 years: own medium-complexity projects and cross-team collaboration.",
+          "5+ years: move toward specialist leadership or managerial scope."
+        ]
+      },
+      "fit_personality_codes_json": null,
+      "mbti_primary_codes_json": [
+        "INTJ",
+        "INTP",
+        "ENTJ"
+      ],
+      "mbti_secondary_codes_json": [
+        "ENTP",
+        "ISTJ",
+        "INFJ"
+      ],
+      "riasec_profile_json": {
+        "R": 40,
+        "I": 90,
+        "A": 45,
+        "S": 38,
+        "E": 46,
+        "C": 72
+      },
+      "big5_targets_json": {
+        "raw": {
+          "openness": {
+            "min": 40,
+            "max": 80
+          },
+          "conscientiousness": {
+            "min": 50,
+            "max": 90
+          },
+          "extraversion": {
+            "min": 35,
+            "max": 82
+          },
+          "agreeableness": {
+            "min": 35,
+            "max": 85
+          },
+          "neuroticism": {
+            "min": 10,
+            "max": 55
+          }
+        }
+      },
+      "iq_eq_notes_json": {
+        "iq_range": {
+          "min": 62,
+          "max": 100
+        },
+        "eq_range": {
+          "min": 40,
+          "max": 86
+        }
+      },
+      "market_demand_json": {
+        "raw": 85
+      },
+      "status": "published",
+      "is_public": true,
+      "is_indexable": true,
+      "published_at": null,
+      "scheduled_at": null,
+      "sort_order": 0,
+      "sections": [
+
+      ],
+      "seo_meta": {
+        "seo_title": null,
+        "seo_description": null,
+        "canonical_url": null,
+        "og_title": null,
+        "og_description": null,
+        "og_image_url": null,
+        "twitter_title": null,
+        "twitter_description": null,
+        "twitter_image_url": null,
+        "robots": null,
+        "jsonld_overrides_json": null
+      }
+    },
+    {
+      "job_code": "data-scientist",
+      "slug": "data-scientist",
+      "locale": "en",
+      "title": "Data Scientist",
+      "subtitle": null,
+      "excerpt": "A practical role profile for data scientist including responsibilities, required skills, salary, and growth path.",
+      "hero_kicker": null,
+      "hero_quote": null,
+      "cover_image_url": null,
+      "industry_slug": "technology",
+      "industry_label": null,
+      "body_md": "# Data Scientist\n## Role Overview\nData Scientist is a role where performance compounds through execution quality, communication precision, and long-term learning velocity.\n\n## Core Work Scope\nThis role contributes to business outcomes by translating goals into high-quality deliverables, collaborating across functions, and continuously improving process quality.\n\n## Career Development Advice\nUse 90-day cycles to track output metrics, capability growth, and collaboration impact. Review your progress every quarter and adjust your growth plan based on evidence.\n",
+      "body_html": null,
+      "salary_json": {
+        "raw": "$55,000 - $180,000 (varies by region and seniority)"
+      },
+      "outlook_json": {
+        "summary": "Demand for data scientist talent remains strong in data-driven organizations."
+      },
+      "skills_json": {
+        "core": [
+          "Structured problem solving",
+          "Stakeholder communication",
+          "Execution management",
+          "Data-informed decision making",
+          "Continuous learning"
+        ],
+        "supporting": [
+
+        ]
+      },
+      "work_contents_json": {
+        "items": [
+          "Define key responsibilities and delivery metrics for data scientist workstreams.",
+          "Coordinate cross-functional stakeholders and align execution priorities.",
+          "Track progress, risks, and quality signals to ensure stable outcomes."
+        ]
+      },
+      "growth_path_json": {
+        "raw": [
+          "0-2 years: build core execution competency and domain literacy.",
+          "3-5 years: own medium-complexity projects and cross-team collaboration.",
+          "5+ years: move toward specialist leadership or managerial scope."
+        ]
+      },
+      "fit_personality_codes_json": null,
+      "mbti_primary_codes_json": [
+        "INTJ",
+        "INTP",
+        "ENTJ"
+      ],
+      "mbti_secondary_codes_json": [
+        "ENTP",
+        "ISTJ",
+        "INFJ"
+      ],
+      "riasec_profile_json": {
+        "R": 40,
+        "I": 90,
+        "A": 45,
+        "S": 38,
+        "E": 46,
+        "C": 72
+      },
+      "big5_targets_json": {
+        "raw": {
+          "openness": {
+            "min": 40,
+            "max": 80
+          },
+          "conscientiousness": {
+            "min": 50,
+            "max": 90
+          },
+          "extraversion": {
+            "min": 35,
+            "max": 82
+          },
+          "agreeableness": {
+            "min": 35,
+            "max": 85
+          },
+          "neuroticism": {
+            "min": 10,
+            "max": 55
+          }
+        }
+      },
+      "iq_eq_notes_json": {
+        "iq_range": {
+          "min": 62,
+          "max": 100
+        },
+        "eq_range": {
+          "min": 40,
+          "max": 86
+        }
+      },
+      "market_demand_json": {
+        "raw": 85
+      },
+      "status": "published",
+      "is_public": true,
+      "is_indexable": true,
+      "published_at": null,
+      "scheduled_at": null,
+      "sort_order": 0,
+      "sections": [
+
+      ],
+      "seo_meta": {
+        "seo_title": null,
+        "seo_description": null,
+        "canonical_url": null,
+        "og_title": null,
+        "og_description": null,
+        "og_image_url": null,
+        "twitter_title": null,
+        "twitter_description": null,
+        "twitter_image_url": null,
+        "robots": null,
+        "jsonld_overrides_json": null
+      }
+    },
+    {
+      "job_code": "digital-marketing-manager",
+      "slug": "digital-marketing-manager",
+      "locale": "en",
+      "title": "Digital Marketing Manager",
+      "subtitle": null,
+      "excerpt": "A practical role profile for digital marketing manager including responsibilities, required skills, salary, and growth path.",
+      "hero_kicker": null,
+      "hero_quote": null,
+      "cover_image_url": null,
+      "industry_slug": "media",
+      "industry_label": null,
+      "body_md": "# Digital Marketing Manager\n## Role Overview\nDigital Marketing Manager is a role where performance compounds through execution quality, communication precision, and long-term learning velocity.\n\n## Core Work Scope\nThis role contributes to business outcomes by translating goals into high-quality deliverables, collaborating across functions, and continuously improving process quality.\n\n## Career Development Advice\nUse 90-day cycles to track output metrics, capability growth, and collaboration impact. Review your progress every quarter and adjust your growth plan based on evidence.\n",
+      "body_html": null,
+      "salary_json": {
+        "raw": "$55,000 - $180,000 (varies by region and seniority)"
+      },
+      "outlook_json": {
+        "summary": "Demand for digital marketing manager talent remains strong in data-driven organizations."
+      },
+      "skills_json": {
+        "core": [
+          "Structured problem solving",
+          "Stakeholder communication",
+          "Execution management",
+          "Data-informed decision making",
+          "Continuous learning"
+        ],
+        "supporting": [
+
+        ]
+      },
+      "work_contents_json": {
+        "items": [
+          "Define key responsibilities and delivery metrics for digital marketing manager workstreams.",
+          "Coordinate cross-functional stakeholders and align execution priorities.",
+          "Track progress, risks, and quality signals to ensure stable outcomes."
+        ]
+      },
+      "growth_path_json": {
+        "raw": [
+          "0-2 years: build core execution competency and domain literacy.",
+          "3-5 years: own medium-complexity projects and cross-team collaboration.",
+          "5+ years: move toward specialist leadership or managerial scope."
+        ]
+      },
+      "fit_personality_codes_json": null,
+      "mbti_primary_codes_json": [
+        "ENTJ",
+        "ENFJ",
+        "ESTP"
+      ],
+      "mbti_secondary_codes_json": [
+        "ENFP",
+        "ESTJ",
+        "ENTP"
+      ],
+      "riasec_profile_json": {
+        "R": 42,
+        "I": 66,
+        "A": 56,
+        "S": 60,
+        "E": 88,
+        "C": 70
+      },
+      "big5_targets_json": {
+        "raw": {
+          "openness": {
+            "min": 40,
+            "max": 80
+          },
+          "conscientiousness": {
+            "min": 50,
+            "max": 90
+          },
+          "extraversion": {
+            "min": 35,
+            "max": 82
+          },
+          "agreeableness": {
+            "min": 35,
+            "max": 85
+          },
+          "neuroticism": {
+            "min": 10,
+            "max": 55
+          }
+        }
+      },
+      "iq_eq_notes_json": {
+        "iq_range": {
+          "min": 50,
+          "max": 98
+        },
+        "eq_range": {
+          "min": 55,
+          "max": 100
+        }
+      },
+      "market_demand_json": {
+        "raw": 82
+      },
+      "status": "published",
+      "is_public": true,
+      "is_indexable": true,
+      "published_at": null,
+      "scheduled_at": null,
+      "sort_order": 0,
+      "sections": [
+
+      ],
+      "seo_meta": {
+        "seo_title": null,
+        "seo_description": null,
+        "canonical_url": null,
+        "og_title": null,
+        "og_description": null,
+        "og_image_url": null,
+        "twitter_title": null,
+        "twitter_description": null,
+        "twitter_image_url": null,
+        "robots": null,
+        "jsonld_overrides_json": null
+      }
+    },
+    {
+      "job_code": "financial-planner",
+      "slug": "financial-planner",
+      "locale": "en",
+      "title": "Financial Planner",
+      "subtitle": null,
+      "excerpt": "A practical role profile for financial planner including responsibilities, required skills, salary, and growth path.",
+      "hero_kicker": null,
+      "hero_quote": null,
+      "cover_image_url": null,
+      "industry_slug": "finance",
+      "industry_label": null,
+      "body_md": "# Financial Planner\n## Role Overview\nFinancial Planner is a role where performance compounds through execution quality, communication precision, and long-term learning velocity.\n\n## Core Work Scope\nThis role contributes to business outcomes by translating goals into high-quality deliverables, collaborating across functions, and continuously improving process quality.\n\n## Career Development Advice\nUse 90-day cycles to track output metrics, capability growth, and collaboration impact. Review your progress every quarter and adjust your growth plan based on evidence.\n",
+      "body_html": null,
+      "salary_json": {
+        "raw": "$55,000 - $180,000 (varies by region and seniority)"
+      },
+      "outlook_json": {
+        "summary": "Demand for financial planner talent remains strong in data-driven organizations."
+      },
+      "skills_json": {
+        "core": [
+          "Structured problem solving",
+          "Stakeholder communication",
+          "Execution management",
+          "Data-informed decision making",
+          "Continuous learning"
+        ],
+        "supporting": [
+
+        ]
+      },
+      "work_contents_json": {
+        "items": [
+          "Define key responsibilities and delivery metrics for financial planner workstreams.",
+          "Coordinate cross-functional stakeholders and align execution priorities.",
+          "Track progress, risks, and quality signals to ensure stable outcomes."
+        ]
+      },
+      "growth_path_json": {
+        "raw": [
+          "0-2 years: build core execution competency and domain literacy.",
+          "3-5 years: own medium-complexity projects and cross-team collaboration.",
+          "5+ years: move toward specialist leadership or managerial scope."
+        ]
+      },
+      "fit_personality_codes_json": null,
+      "mbti_primary_codes_json": [
+        "ESTJ",
+        "ISTJ",
+        "ESFJ"
+      ],
+      "mbti_secondary_codes_json": [
+        "ISFJ",
+        "ENTJ",
+        "ESTP"
+      ],
+      "riasec_profile_json": {
+        "R": 52,
+        "I": 60,
+        "A": 36,
+        "S": 52,
+        "E": 70,
+        "C": 90
+      },
+      "big5_targets_json": {
+        "raw": {
+          "openness": {
+            "min": 40,
+            "max": 80
+          },
+          "conscientiousness": {
+            "min": 50,
+            "max": 90
+          },
+          "extraversion": {
+            "min": 35,
+            "max": 82
+          },
+          "agreeableness": {
+            "min": 35,
+            "max": 85
+          },
+          "neuroticism": {
+            "min": 10,
+            "max": 55
+          }
+        }
+      },
+      "iq_eq_notes_json": {
+        "iq_range": {
+          "min": 48,
+          "max": 95
+        },
+        "eq_range": {
+          "min": 48,
+          "max": 92
+        }
+      },
+      "market_demand_json": {
+        "raw": 74
+      },
+      "status": "published",
+      "is_public": true,
+      "is_indexable": true,
+      "published_at": null,
+      "scheduled_at": null,
+      "sort_order": 0,
+      "sections": [
+
+      ],
+      "seo_meta": {
+        "seo_title": null,
+        "seo_description": null,
+        "canonical_url": null,
+        "og_title": null,
+        "og_description": null,
+        "og_image_url": null,
+        "twitter_title": null,
+        "twitter_description": null,
+        "twitter_image_url": null,
+        "robots": null,
+        "jsonld_overrides_json": null
+      }
+    },
+    {
+      "job_code": "frontend-engineer",
+      "slug": "frontend-engineer",
+      "locale": "en",
+      "title": "Frontend Engineer",
+      "subtitle": null,
+      "excerpt": "A practical role profile for frontend engineer including responsibilities, required skills, salary, and growth path.",
+      "hero_kicker": null,
+      "hero_quote": null,
+      "cover_image_url": null,
+      "industry_slug": "technology",
+      "industry_label": null,
+      "body_md": "# Frontend Engineer\n## Role Overview\nFrontend Engineer is a role where performance compounds through execution quality, communication precision, and long-term learning velocity.\n\n## Core Work Scope\nThis role contributes to business outcomes by translating goals into high-quality deliverables, collaborating across functions, and continuously improving process quality.\n\n## Career Development Advice\nUse 90-day cycles to track output metrics, capability growth, and collaboration impact. Review your progress every quarter and adjust your growth plan based on evidence.\n",
+      "body_html": null,
+      "salary_json": {
+        "raw": "$55,000 - $180,000 (varies by region and seniority)"
+      },
+      "outlook_json": {
+        "summary": "Demand for frontend engineer talent remains strong in data-driven organizations."
+      },
+      "skills_json": {
+        "core": [
+          "Structured problem solving",
+          "Stakeholder communication",
+          "Execution management",
+          "Data-informed decision making",
+          "Continuous learning"
+        ],
+        "supporting": [
+
+        ]
+      },
+      "work_contents_json": {
+        "items": [
+          "Define key responsibilities and delivery metrics for frontend engineer workstreams.",
+          "Coordinate cross-functional stakeholders and align execution priorities.",
+          "Track progress, risks, and quality signals to ensure stable outcomes."
+        ]
+      },
+      "growth_path_json": {
+        "raw": [
+          "0-2 years: build core execution competency and domain literacy.",
+          "3-5 years: own medium-complexity projects and cross-team collaboration.",
+          "5+ years: move toward specialist leadership or managerial scope."
+        ]
+      },
+      "fit_personality_codes_json": null,
+      "mbti_primary_codes_json": [
+        "INTJ",
+        "INTP",
+        "ENTJ"
+      ],
+      "mbti_secondary_codes_json": [
+        "ENTP",
+        "ISTJ",
+        "INFJ"
+      ],
+      "riasec_profile_json": {
+        "R": 55,
+        "I": 88,
+        "A": 48,
+        "S": 42,
+        "E": 50,
+        "C": 68
+      },
+      "big5_targets_json": {
+        "raw": {
+          "openness": {
+            "min": 40,
+            "max": 80
+          },
+          "conscientiousness": {
+            "min": 50,
+            "max": 90
+          },
+          "extraversion": {
+            "min": 35,
+            "max": 82
+          },
+          "agreeableness": {
+            "min": 35,
+            "max": 85
+          },
+          "neuroticism": {
+            "min": 10,
+            "max": 55
+          }
+        }
+      },
+      "iq_eq_notes_json": {
+        "iq_range": {
+          "min": 65,
+          "max": 100
+        },
+        "eq_range": {
+          "min": 45,
+          "max": 90
+        }
+      },
+      "market_demand_json": {
+        "raw": 92
+      },
+      "status": "published",
+      "is_public": true,
+      "is_indexable": true,
+      "published_at": null,
+      "scheduled_at": null,
+      "sort_order": 0,
+      "sections": [
+
+      ],
+      "seo_meta": {
+        "seo_title": null,
+        "seo_description": null,
+        "canonical_url": null,
+        "og_title": null,
+        "og_description": null,
+        "og_image_url": null,
+        "twitter_title": null,
+        "twitter_description": null,
+        "twitter_image_url": null,
+        "robots": null,
+        "jsonld_overrides_json": null
+      }
+    },
+    {
+      "job_code": "fullstack-engineer",
+      "slug": "fullstack-engineer",
+      "locale": "en",
+      "title": "Fullstack Engineer",
+      "subtitle": null,
+      "excerpt": "A practical role profile for fullstack engineer including responsibilities, required skills, salary, and growth path.",
+      "hero_kicker": null,
+      "hero_quote": null,
+      "cover_image_url": null,
+      "industry_slug": "technology",
+      "industry_label": null,
+      "body_md": "# Fullstack Engineer\n## Role Overview\nFullstack Engineer is a role where performance compounds through execution quality, communication precision, and long-term learning velocity.\n\n## Core Work Scope\nThis role contributes to business outcomes by translating goals into high-quality deliverables, collaborating across functions, and continuously improving process quality.\n\n## Career Development Advice\nUse 90-day cycles to track output metrics, capability growth, and collaboration impact. Review your progress every quarter and adjust your growth plan based on evidence.\n",
+      "body_html": null,
+      "salary_json": {
+        "raw": "$55,000 - $180,000 (varies by region and seniority)"
+      },
+      "outlook_json": {
+        "summary": "Demand for fullstack engineer talent remains strong in data-driven organizations."
+      },
+      "skills_json": {
+        "core": [
+          "Structured problem solving",
+          "Stakeholder communication",
+          "Execution management",
+          "Data-informed decision making",
+          "Continuous learning"
+        ],
+        "supporting": [
+
+        ]
+      },
+      "work_contents_json": {
+        "items": [
+          "Define key responsibilities and delivery metrics for fullstack engineer workstreams.",
+          "Coordinate cross-functional stakeholders and align execution priorities.",
+          "Track progress, risks, and quality signals to ensure stable outcomes."
+        ]
+      },
+      "growth_path_json": {
+        "raw": [
+          "0-2 years: build core execution competency and domain literacy.",
+          "3-5 years: own medium-complexity projects and cross-team collaboration.",
+          "5+ years: move toward specialist leadership or managerial scope."
+        ]
+      },
+      "fit_personality_codes_json": null,
+      "mbti_primary_codes_json": [
+        "INTJ",
+        "INTP",
+        "ENTJ"
+      ],
+      "mbti_secondary_codes_json": [
+        "ENTP",
+        "ISTJ",
+        "INFJ"
+      ],
+      "riasec_profile_json": {
+        "R": 55,
+        "I": 88,
+        "A": 48,
+        "S": 42,
+        "E": 50,
+        "C": 68
+      },
+      "big5_targets_json": {
+        "raw": {
+          "openness": {
+            "min": 40,
+            "max": 80
+          },
+          "conscientiousness": {
+            "min": 50,
+            "max": 90
+          },
+          "extraversion": {
+            "min": 35,
+            "max": 82
+          },
+          "agreeableness": {
+            "min": 35,
+            "max": 85
+          },
+          "neuroticism": {
+            "min": 10,
+            "max": 55
+          }
+        }
+      },
+      "iq_eq_notes_json": {
+        "iq_range": {
+          "min": 65,
+          "max": 100
+        },
+        "eq_range": {
+          "min": 45,
+          "max": 90
+        }
+      },
+      "market_demand_json": {
+        "raw": 92
+      },
+      "status": "published",
+      "is_public": true,
+      "is_indexable": true,
+      "published_at": null,
+      "scheduled_at": null,
+      "sort_order": 0,
+      "sections": [
+
+      ],
+      "seo_meta": {
+        "seo_title": null,
+        "seo_description": null,
+        "canonical_url": null,
+        "og_title": null,
+        "og_description": null,
+        "og_image_url": null,
+        "twitter_title": null,
+        "twitter_description": null,
+        "twitter_image_url": null,
+        "robots": null,
+        "jsonld_overrides_json": null
+      }
+    },
+    {
+      "job_code": "hr-business-partner",
+      "slug": "hr-business-partner",
+      "locale": "en",
+      "title": "HR Business Partner",
+      "subtitle": null,
+      "excerpt": "A practical role profile for hr business partner including responsibilities, required skills, salary, and growth path.",
+      "hero_kicker": null,
+      "hero_quote": null,
+      "cover_image_url": null,
+      "industry_slug": "business",
+      "industry_label": null,
+      "body_md": "# HR Business Partner\n## Role Overview\nHR Business Partner is a role where performance compounds through execution quality, communication precision, and long-term learning velocity.\n\n## Core Work Scope\nThis role contributes to business outcomes by translating goals into high-quality deliverables, collaborating across functions, and continuously improving process quality.\n\n## Career Development Advice\nUse 90-day cycles to track output metrics, capability growth, and collaboration impact. Review your progress every quarter and adjust your growth plan based on evidence.\n",
+      "body_html": null,
+      "salary_json": {
+        "raw": "$55,000 - $180,000 (varies by region and seniority)"
+      },
+      "outlook_json": {
+        "summary": "Demand for hr business partner talent remains strong in data-driven organizations."
+      },
+      "skills_json": {
+        "core": [
+          "Structured problem solving",
+          "Stakeholder communication",
+          "Execution management",
+          "Data-informed decision making",
+          "Continuous learning"
+        ],
+        "supporting": [
+
+        ]
+      },
+      "work_contents_json": {
+        "items": [
+          "Define key responsibilities and delivery metrics for hr business partner workstreams.",
+          "Coordinate cross-functional stakeholders and align execution priorities.",
+          "Track progress, risks, and quality signals to ensure stable outcomes."
+        ]
+      },
+      "growth_path_json": {
+        "raw": [
+          "0-2 years: build core execution competency and domain literacy.",
+          "3-5 years: own medium-complexity projects and cross-team collaboration.",
+          "5+ years: move toward specialist leadership or managerial scope."
+        ]
+      },
+      "fit_personality_codes_json": null,
+      "mbti_primary_codes_json": [
+        "ENTJ",
+        "ENFJ",
+        "ESTP"
+      ],
+      "mbti_secondary_codes_json": [
+        "ENFP",
+        "ESTJ",
+        "ENTP"
+      ],
+      "riasec_profile_json": {
+        "R": 42,
+        "I": 66,
+        "A": 56,
+        "S": 60,
+        "E": 88,
+        "C": 70
+      },
+      "big5_targets_json": {
+        "raw": {
+          "openness": {
+            "min": 40,
+            "max": 80
+          },
+          "conscientiousness": {
+            "min": 50,
+            "max": 90
+          },
+          "extraversion": {
+            "min": 35,
+            "max": 82
+          },
+          "agreeableness": {
+            "min": 35,
+            "max": 85
+          },
+          "neuroticism": {
+            "min": 10,
+            "max": 55
+          }
+        }
+      },
+      "iq_eq_notes_json": {
+        "iq_range": {
+          "min": 50,
+          "max": 98
+        },
+        "eq_range": {
+          "min": 55,
+          "max": 100
+        }
+      },
+      "market_demand_json": {
+        "raw": 82
+      },
+      "status": "published",
+      "is_public": true,
+      "is_indexable": true,
+      "published_at": null,
+      "scheduled_at": null,
+      "sort_order": 0,
+      "sections": [
+
+      ],
+      "seo_meta": {
+        "seo_title": null,
+        "seo_description": null,
+        "canonical_url": null,
+        "og_title": null,
+        "og_description": null,
+        "og_image_url": null,
+        "twitter_title": null,
+        "twitter_description": null,
+        "twitter_image_url": null,
+        "robots": null,
+        "jsonld_overrides_json": null
+      }
+    },
+    {
+      "job_code": "investment-analyst",
+      "slug": "investment-analyst",
+      "locale": "en",
+      "title": "Investment Analyst",
+      "subtitle": null,
+      "excerpt": "A practical role profile for investment analyst including responsibilities, required skills, salary, and growth path.",
+      "hero_kicker": null,
+      "hero_quote": null,
+      "cover_image_url": null,
+      "industry_slug": "finance",
+      "industry_label": null,
+      "body_md": "# Investment Analyst\n## Role Overview\nInvestment Analyst is a role where performance compounds through execution quality, communication precision, and long-term learning velocity.\n\n## Core Work Scope\nThis role contributes to business outcomes by translating goals into high-quality deliverables, collaborating across functions, and continuously improving process quality.\n\n## Career Development Advice\nUse 90-day cycles to track output metrics, capability growth, and collaboration impact. Review your progress every quarter and adjust your growth plan based on evidence.\n",
+      "body_html": null,
+      "salary_json": {
+        "raw": "$55,000 - $180,000 (varies by region and seniority)"
+      },
+      "outlook_json": {
+        "summary": "Demand for investment analyst talent remains strong in data-driven organizations."
+      },
+      "skills_json": {
+        "core": [
+          "Structured problem solving",
+          "Stakeholder communication",
+          "Execution management",
+          "Data-informed decision making",
+          "Continuous learning"
+        ],
+        "supporting": [
+
+        ]
+      },
+      "work_contents_json": {
+        "items": [
+          "Define key responsibilities and delivery metrics for investment analyst workstreams.",
+          "Coordinate cross-functional stakeholders and align execution priorities.",
+          "Track progress, risks, and quality signals to ensure stable outcomes."
+        ]
+      },
+      "growth_path_json": {
+        "raw": [
+          "0-2 years: build core execution competency and domain literacy.",
+          "3-5 years: own medium-complexity projects and cross-team collaboration.",
+          "5+ years: move toward specialist leadership or managerial scope."
+        ]
+      },
+      "fit_personality_codes_json": null,
+      "mbti_primary_codes_json": [
+        "INTJ",
+        "INTP",
+        "ENTJ"
+      ],
+      "mbti_secondary_codes_json": [
+        "ENTP",
+        "ISTJ",
+        "INFJ"
+      ],
+      "riasec_profile_json": {
+        "R": 40,
+        "I": 90,
+        "A": 45,
+        "S": 38,
+        "E": 46,
+        "C": 72
+      },
+      "big5_targets_json": {
+        "raw": {
+          "openness": {
+            "min": 40,
+            "max": 80
+          },
+          "conscientiousness": {
+            "min": 50,
+            "max": 90
+          },
+          "extraversion": {
+            "min": 35,
+            "max": 82
+          },
+          "agreeableness": {
+            "min": 35,
+            "max": 85
+          },
+          "neuroticism": {
+            "min": 10,
+            "max": 55
+          }
+        }
+      },
+      "iq_eq_notes_json": {
+        "iq_range": {
+          "min": 62,
+          "max": 100
+        },
+        "eq_range": {
+          "min": 40,
+          "max": 86
+        }
+      },
+      "market_demand_json": {
+        "raw": 85
+      },
+      "status": "published",
+      "is_public": true,
+      "is_indexable": true,
+      "published_at": null,
+      "scheduled_at": null,
+      "sort_order": 0,
+      "sections": [
+
+      ],
+      "seo_meta": {
+        "seo_title": null,
+        "seo_description": null,
+        "canonical_url": null,
+        "og_title": null,
+        "og_description": null,
+        "og_image_url": null,
+        "twitter_title": null,
+        "twitter_description": null,
+        "twitter_image_url": null,
+        "robots": null,
+        "jsonld_overrides_json": null
+      }
+    },
+    {
+      "job_code": "lawyer",
+      "slug": "lawyer",
+      "locale": "en",
+      "title": "Lawyer",
+      "subtitle": null,
+      "excerpt": "A practical role profile for lawyer including responsibilities, required skills, salary, and growth path.",
+      "hero_kicker": null,
+      "hero_quote": null,
+      "cover_image_url": null,
+      "industry_slug": "legal",
+      "industry_label": null,
+      "body_md": "# Lawyer\n## Role Overview\nLawyer is a role where performance compounds through execution quality, communication precision, and long-term learning velocity.\n\n## Core Work Scope\nThis role contributes to business outcomes by translating goals into high-quality deliverables, collaborating across functions, and continuously improving process quality.\n\n## Career Development Advice\nUse 90-day cycles to track output metrics, capability growth, and collaboration impact. Review your progress every quarter and adjust your growth plan based on evidence.\n",
+      "body_html": null,
+      "salary_json": {
+        "raw": "$55,000 - $180,000 (varies by region and seniority)"
+      },
+      "outlook_json": {
+        "summary": "Demand for lawyer talent remains strong in data-driven organizations."
+      },
+      "skills_json": {
+        "core": [
+          "Structured problem solving",
+          "Stakeholder communication",
+          "Execution management",
+          "Data-informed decision making",
+          "Continuous learning"
+        ],
+        "supporting": [
+
+        ]
+      },
+      "work_contents_json": {
+        "items": [
+          "Define key responsibilities and delivery metrics for lawyer workstreams.",
+          "Coordinate cross-functional stakeholders and align execution priorities.",
+          "Track progress, risks, and quality signals to ensure stable outcomes."
+        ]
+      },
+      "growth_path_json": {
+        "raw": [
+          "0-2 years: build core execution competency and domain literacy.",
+          "3-5 years: own medium-complexity projects and cross-team collaboration.",
+          "5+ years: move toward specialist leadership or managerial scope."
+        ]
+      },
+      "fit_personality_codes_json": null,
+      "mbti_primary_codes_json": [
+        "ESTJ",
+        "ISTJ",
+        "ESFJ"
+      ],
+      "mbti_secondary_codes_json": [
+        "ISFJ",
+        "ENTJ",
+        "ESTP"
+      ],
+      "riasec_profile_json": {
+        "R": 33,
+        "I": 80,
+        "A": 40,
+        "S": 47,
+        "E": 52,
+        "C": 90
+      },
+      "big5_targets_json": {
+        "raw": {
+          "openness": {
+            "min": 40,
+            "max": 80
+          },
+          "conscientiousness": {
+            "min": 50,
+            "max": 90
+          },
+          "extraversion": {
+            "min": 35,
+            "max": 82
+          },
+          "agreeableness": {
+            "min": 35,
+            "max": 85
+          },
+          "neuroticism": {
+            "min": 10,
+            "max": 55
+          }
+        }
+      },
+      "iq_eq_notes_json": {
+        "iq_range": {
+          "min": 62,
+          "max": 100
+        },
+        "eq_range": {
+          "min": 52,
+          "max": 95
+        }
+      },
+      "market_demand_json": {
+        "raw": 70
+      },
+      "status": "published",
+      "is_public": true,
+      "is_indexable": true,
+      "published_at": null,
+      "scheduled_at": null,
+      "sort_order": 0,
+      "sections": [
+
+      ],
+      "seo_meta": {
+        "seo_title": null,
+        "seo_description": null,
+        "canonical_url": null,
+        "og_title": null,
+        "og_description": null,
+        "og_image_url": null,
+        "twitter_title": null,
+        "twitter_description": null,
+        "twitter_image_url": null,
+        "robots": null,
+        "jsonld_overrides_json": null
+      }
+    },
+    {
+      "job_code": "machine-learning-engineer",
+      "slug": "machine-learning-engineer",
+      "locale": "en",
+      "title": "Machine Learning Engineer",
+      "subtitle": null,
+      "excerpt": "A practical role profile for machine learning engineer including responsibilities, required skills, salary, and growth path.",
+      "hero_kicker": null,
+      "hero_quote": null,
+      "cover_image_url": null,
+      "industry_slug": "technology",
+      "industry_label": null,
+      "body_md": "# Machine Learning Engineer\n## Role Overview\nMachine Learning Engineer is a role where performance compounds through execution quality, communication precision, and long-term learning velocity.\n\n## Core Work Scope\nThis role contributes to business outcomes by translating goals into high-quality deliverables, collaborating across functions, and continuously improving process quality.\n\n## Career Development Advice\nUse 90-day cycles to track output metrics, capability growth, and collaboration impact. Review your progress every quarter and adjust your growth plan based on evidence.\n",
+      "body_html": null,
+      "salary_json": {
+        "raw": "$55,000 - $180,000 (varies by region and seniority)"
+      },
+      "outlook_json": {
+        "summary": "Demand for machine learning engineer talent remains strong in data-driven organizations."
+      },
+      "skills_json": {
+        "core": [
+          "Structured problem solving",
+          "Stakeholder communication",
+          "Execution management",
+          "Data-informed decision making",
+          "Continuous learning"
+        ],
+        "supporting": [
+
+        ]
+      },
+      "work_contents_json": {
+        "items": [
+          "Define key responsibilities and delivery metrics for machine learning engineer workstreams.",
+          "Coordinate cross-functional stakeholders and align execution priorities.",
+          "Track progress, risks, and quality signals to ensure stable outcomes."
+        ]
+      },
+      "growth_path_json": {
+        "raw": [
+          "0-2 years: build core execution competency and domain literacy.",
+          "3-5 years: own medium-complexity projects and cross-team collaboration.",
+          "5+ years: move toward specialist leadership or managerial scope."
+        ]
+      },
+      "fit_personality_codes_json": null,
+      "mbti_primary_codes_json": [
+        "INTJ",
+        "INTP",
+        "ENTJ"
+      ],
+      "mbti_secondary_codes_json": [
+        "ENTP",
+        "ISTJ",
+        "INFJ"
+      ],
+      "riasec_profile_json": {
+        "R": 55,
+        "I": 88,
+        "A": 48,
+        "S": 42,
+        "E": 50,
+        "C": 68
+      },
+      "big5_targets_json": {
+        "raw": {
+          "openness": {
+            "min": 40,
+            "max": 80
+          },
+          "conscientiousness": {
+            "min": 50,
+            "max": 90
+          },
+          "extraversion": {
+            "min": 35,
+            "max": 82
+          },
+          "agreeableness": {
+            "min": 35,
+            "max": 85
+          },
+          "neuroticism": {
+            "min": 10,
+            "max": 55
+          }
+        }
+      },
+      "iq_eq_notes_json": {
+        "iq_range": {
+          "min": 65,
+          "max": 100
+        },
+        "eq_range": {
+          "min": 45,
+          "max": 90
+        }
+      },
+      "market_demand_json": {
+        "raw": 92
+      },
+      "status": "published",
+      "is_public": true,
+      "is_indexable": true,
+      "published_at": null,
+      "scheduled_at": null,
+      "sort_order": 0,
+      "sections": [
+
+      ],
+      "seo_meta": {
+        "seo_title": null,
+        "seo_description": null,
+        "canonical_url": null,
+        "og_title": null,
+        "og_description": null,
+        "og_image_url": null,
+        "twitter_title": null,
+        "twitter_description": null,
+        "twitter_image_url": null,
+        "robots": null,
+        "jsonld_overrides_json": null
+      }
+    },
+    {
+      "job_code": "management-consultant",
+      "slug": "management-consultant",
+      "locale": "en",
+      "title": "Management Consultant",
+      "subtitle": null,
+      "excerpt": "A practical role profile for management consultant including responsibilities, required skills, salary, and growth path.",
+      "hero_kicker": null,
+      "hero_quote": null,
+      "cover_image_url": null,
+      "industry_slug": "consulting",
+      "industry_label": null,
+      "body_md": "# Management Consultant\n## Role Overview\nManagement Consultant is a role where performance compounds through execution quality, communication precision, and long-term learning velocity.\n\n## Core Work Scope\nThis role contributes to business outcomes by translating goals into high-quality deliverables, collaborating across functions, and continuously improving process quality.\n\n## Career Development Advice\nUse 90-day cycles to track output metrics, capability growth, and collaboration impact. Review your progress every quarter and adjust your growth plan based on evidence.\n",
+      "body_html": null,
+      "salary_json": {
+        "raw": "$55,000 - $180,000 (varies by region and seniority)"
+      },
+      "outlook_json": {
+        "summary": "Demand for management consultant talent remains strong in data-driven organizations."
+      },
+      "skills_json": {
+        "core": [
+          "Structured problem solving",
+          "Stakeholder communication",
+          "Execution management",
+          "Data-informed decision making",
+          "Continuous learning"
+        ],
+        "supporting": [
+
+        ]
+      },
+      "work_contents_json": {
+        "items": [
+          "Define key responsibilities and delivery metrics for management consultant workstreams.",
+          "Coordinate cross-functional stakeholders and align execution priorities.",
+          "Track progress, risks, and quality signals to ensure stable outcomes."
+        ]
+      },
+      "growth_path_json": {
+        "raw": [
+          "0-2 years: build core execution competency and domain literacy.",
+          "3-5 years: own medium-complexity projects and cross-team collaboration.",
+          "5+ years: move toward specialist leadership or managerial scope."
+        ]
+      },
+      "fit_personality_codes_json": null,
+      "mbti_primary_codes_json": [
+        "ENTJ",
+        "ENFJ",
+        "ESTP"
+      ],
+      "mbti_secondary_codes_json": [
+        "ENFP",
+        "ESTJ",
+        "ENTP"
+      ],
+      "riasec_profile_json": {
+        "R": 42,
+        "I": 66,
+        "A": 56,
+        "S": 60,
+        "E": 88,
+        "C": 70
+      },
+      "big5_targets_json": {
+        "raw": {
+          "openness": {
+            "min": 40,
+            "max": 80
+          },
+          "conscientiousness": {
+            "min": 50,
+            "max": 90
+          },
+          "extraversion": {
+            "min": 35,
+            "max": 82
+          },
+          "agreeableness": {
+            "min": 35,
+            "max": 85
+          },
+          "neuroticism": {
+            "min": 10,
+            "max": 55
+          }
+        }
+      },
+      "iq_eq_notes_json": {
+        "iq_range": {
+          "min": 50,
+          "max": 98
+        },
+        "eq_range": {
+          "min": 55,
+          "max": 100
+        }
+      },
+      "market_demand_json": {
+        "raw": 82
+      },
+      "status": "published",
+      "is_public": true,
+      "is_indexable": true,
+      "published_at": null,
+      "scheduled_at": null,
+      "sort_order": 0,
+      "sections": [
+
+      ],
+      "seo_meta": {
+        "seo_title": null,
+        "seo_description": null,
+        "canonical_url": null,
+        "og_title": null,
+        "og_description": null,
+        "og_image_url": null,
+        "twitter_title": null,
+        "twitter_description": null,
+        "twitter_image_url": null,
+        "robots": null,
+        "jsonld_overrides_json": null
+      }
+    },
+    {
+      "job_code": "nurse",
+      "slug": "nurse",
+      "locale": "en",
+      "title": "Nurse",
+      "subtitle": null,
+      "excerpt": "A practical role profile for nurse including responsibilities, required skills, salary, and growth path.",
+      "hero_kicker": null,
+      "hero_quote": null,
+      "cover_image_url": null,
+      "industry_slug": "healthcare",
+      "industry_label": null,
+      "body_md": "# Nurse\n## Role Overview\nNurse is a role where performance compounds through execution quality, communication precision, and long-term learning velocity.\n\n## Core Work Scope\nThis role contributes to business outcomes by translating goals into high-quality deliverables, collaborating across functions, and continuously improving process quality.\n\n## Career Development Advice\nUse 90-day cycles to track output metrics, capability growth, and collaboration impact. Review your progress every quarter and adjust your growth plan based on evidence.\n",
+      "body_html": null,
+      "salary_json": {
+        "raw": "$55,000 - $180,000 (varies by region and seniority)"
+      },
+      "outlook_json": {
+        "summary": "Demand for nurse talent remains strong in data-driven organizations."
+      },
+      "skills_json": {
+        "core": [
+          "Structured problem solving",
+          "Stakeholder communication",
+          "Execution management",
+          "Data-informed decision making",
+          "Continuous learning"
+        ],
+        "supporting": [
+
+        ]
+      },
+      "work_contents_json": {
+        "items": [
+          "Define key responsibilities and delivery metrics for nurse workstreams.",
+          "Coordinate cross-functional stakeholders and align execution priorities.",
+          "Track progress, risks, and quality signals to ensure stable outcomes."
+        ]
+      },
+      "growth_path_json": {
+        "raw": [
+          "0-2 years: build core execution competency and domain literacy.",
+          "3-5 years: own medium-complexity projects and cross-team collaboration.",
+          "5+ years: move toward specialist leadership or managerial scope."
+        ]
+      },
+      "fit_personality_codes_json": null,
+      "mbti_primary_codes_json": [
+        "ENFJ",
+        "ISFJ",
+        "INFJ"
+      ],
+      "mbti_secondary_codes_json": [
+        "ESFJ",
+        "INFP",
+        "ENFP"
+      ],
+      "riasec_profile_json": {
+        "R": 48,
+        "I": 64,
+        "A": 42,
+        "S": 88,
+        "E": 54,
+        "C": 74
+      },
+      "big5_targets_json": {
+        "raw": {
+          "openness": {
+            "min": 40,
+            "max": 80
+          },
+          "conscientiousness": {
+            "min": 50,
+            "max": 90
+          },
+          "extraversion": {
+            "min": 35,
+            "max": 82
+          },
+          "agreeableness": {
+            "min": 35,
+            "max": 85
+          },
+          "neuroticism": {
+            "min": 10,
+            "max": 55
+          }
+        }
+      },
+      "iq_eq_notes_json": {
+        "iq_range": {
+          "min": 50,
+          "max": 100
+        },
+        "eq_range": {
+          "min": 60,
+          "max": 100
+        }
+      },
+      "market_demand_json": {
+        "raw": 86
+      },
+      "status": "published",
+      "is_public": true,
+      "is_indexable": true,
+      "published_at": null,
+      "scheduled_at": null,
+      "sort_order": 0,
+      "sections": [
+
+      ],
+      "seo_meta": {
+        "seo_title": null,
+        "seo_description": null,
+        "canonical_url": null,
+        "og_title": null,
+        "og_description": null,
+        "og_image_url": null,
+        "twitter_title": null,
+        "twitter_description": null,
+        "twitter_image_url": null,
+        "robots": null,
+        "jsonld_overrides_json": null
+      }
+    },
+    {
+      "job_code": "operations-manager",
+      "slug": "operations-manager",
+      "locale": "en",
+      "title": "Operations Manager",
+      "subtitle": null,
+      "excerpt": "A practical role profile for operations manager including responsibilities, required skills, salary, and growth path.",
+      "hero_kicker": null,
+      "hero_quote": null,
+      "cover_image_url": null,
+      "industry_slug": "operations",
+      "industry_label": null,
+      "body_md": "# Operations Manager\n## Role Overview\nOperations Manager is a role where performance compounds through execution quality, communication precision, and long-term learning velocity.\n\n## Core Work Scope\nThis role contributes to business outcomes by translating goals into high-quality deliverables, collaborating across functions, and continuously improving process quality.\n\n## Career Development Advice\nUse 90-day cycles to track output metrics, capability growth, and collaboration impact. Review your progress every quarter and adjust your growth plan based on evidence.\n",
+      "body_html": null,
+      "salary_json": {
+        "raw": "$55,000 - $180,000 (varies by region and seniority)"
+      },
+      "outlook_json": {
+        "summary": "Demand for operations manager talent remains strong in data-driven organizations."
+      },
+      "skills_json": {
+        "core": [
+          "Structured problem solving",
+          "Stakeholder communication",
+          "Execution management",
+          "Data-informed decision making",
+          "Continuous learning"
+        ],
+        "supporting": [
+
+        ]
+      },
+      "work_contents_json": {
+        "items": [
+          "Define key responsibilities and delivery metrics for operations manager workstreams.",
+          "Coordinate cross-functional stakeholders and align execution priorities.",
+          "Track progress, risks, and quality signals to ensure stable outcomes."
+        ]
+      },
+      "growth_path_json": {
+        "raw": [
+          "0-2 years: build core execution competency and domain literacy.",
+          "3-5 years: own medium-complexity projects and cross-team collaboration.",
+          "5+ years: move toward specialist leadership or managerial scope."
+        ]
+      },
+      "fit_personality_codes_json": null,
+      "mbti_primary_codes_json": [
+        "ENTJ",
+        "ENFJ",
+        "ESTP"
+      ],
+      "mbti_secondary_codes_json": [
+        "ENFP",
+        "ESTJ",
+        "ENTP"
+      ],
+      "riasec_profile_json": {
+        "R": 42,
+        "I": 66,
+        "A": 56,
+        "S": 60,
+        "E": 88,
+        "C": 70
+      },
+      "big5_targets_json": {
+        "raw": {
+          "openness": {
+            "min": 40,
+            "max": 80
+          },
+          "conscientiousness": {
+            "min": 50,
+            "max": 90
+          },
+          "extraversion": {
+            "min": 35,
+            "max": 82
+          },
+          "agreeableness": {
+            "min": 35,
+            "max": 85
+          },
+          "neuroticism": {
+            "min": 10,
+            "max": 55
+          }
+        }
+      },
+      "iq_eq_notes_json": {
+        "iq_range": {
+          "min": 50,
+          "max": 98
+        },
+        "eq_range": {
+          "min": 55,
+          "max": 100
+        }
+      },
+      "market_demand_json": {
+        "raw": 82
+      },
+      "status": "published",
+      "is_public": true,
+      "is_indexable": true,
+      "published_at": null,
+      "scheduled_at": null,
+      "sort_order": 0,
+      "sections": [
+
+      ],
+      "seo_meta": {
+        "seo_title": null,
+        "seo_description": null,
+        "canonical_url": null,
+        "og_title": null,
+        "og_description": null,
+        "og_image_url": null,
+        "twitter_title": null,
+        "twitter_description": null,
+        "twitter_image_url": null,
+        "robots": null,
+        "jsonld_overrides_json": null
+      }
+    },
+    {
+      "job_code": "pharmacist",
+      "slug": "pharmacist",
+      "locale": "en",
+      "title": "Pharmacist",
+      "subtitle": null,
+      "excerpt": "A practical role profile for pharmacist including responsibilities, required skills, salary, and growth path.",
+      "hero_kicker": null,
+      "hero_quote": null,
+      "cover_image_url": null,
+      "industry_slug": "healthcare",
+      "industry_label": null,
+      "body_md": "# Pharmacist\n## Role Overview\nPharmacist is a role where performance compounds through execution quality, communication precision, and long-term learning velocity.\n\n## Core Work Scope\nThis role contributes to business outcomes by translating goals into high-quality deliverables, collaborating across functions, and continuously improving process quality.\n\n## Career Development Advice\nUse 90-day cycles to track output metrics, capability growth, and collaboration impact. Review your progress every quarter and adjust your growth plan based on evidence.\n",
+      "body_html": null,
+      "salary_json": {
+        "raw": "$55,000 - $180,000 (varies by region and seniority)"
+      },
+      "outlook_json": {
+        "summary": "Demand for pharmacist talent remains strong in data-driven organizations."
+      },
+      "skills_json": {
+        "core": [
+          "Structured problem solving",
+          "Stakeholder communication",
+          "Execution management",
+          "Data-informed decision making",
+          "Continuous learning"
+        ],
+        "supporting": [
+
+        ]
+      },
+      "work_contents_json": {
+        "items": [
+          "Define key responsibilities and delivery metrics for pharmacist workstreams.",
+          "Coordinate cross-functional stakeholders and align execution priorities.",
+          "Track progress, risks, and quality signals to ensure stable outcomes."
+        ]
+      },
+      "growth_path_json": {
+        "raw": [
+          "0-2 years: build core execution competency and domain literacy.",
+          "3-5 years: own medium-complexity projects and cross-team collaboration.",
+          "5+ years: move toward specialist leadership or managerial scope."
+        ]
+      },
+      "fit_personality_codes_json": null,
+      "mbti_primary_codes_json": [
+        "ENFJ",
+        "ISFJ",
+        "INFJ"
+      ],
+      "mbti_secondary_codes_json": [
+        "ESFJ",
+        "INFP",
+        "ENFP"
+      ],
+      "riasec_profile_json": {
+        "R": 48,
+        "I": 64,
+        "A": 42,
+        "S": 88,
+        "E": 54,
+        "C": 74
+      },
+      "big5_targets_json": {
+        "raw": {
+          "openness": {
+            "min": 40,
+            "max": 80
+          },
+          "conscientiousness": {
+            "min": 50,
+            "max": 90
+          },
+          "extraversion": {
+            "min": 35,
+            "max": 82
+          },
+          "agreeableness": {
+            "min": 35,
+            "max": 85
+          },
+          "neuroticism": {
+            "min": 10,
+            "max": 55
+          }
+        }
+      },
+      "iq_eq_notes_json": {
+        "iq_range": {
+          "min": 50,
+          "max": 100
+        },
+        "eq_range": {
+          "min": 60,
+          "max": 100
+        }
+      },
+      "market_demand_json": {
+        "raw": 86
+      },
+      "status": "published",
+      "is_public": true,
+      "is_indexable": true,
+      "published_at": null,
+      "scheduled_at": null,
+      "sort_order": 0,
+      "sections": [
+
+      ],
+      "seo_meta": {
+        "seo_title": null,
+        "seo_description": null,
+        "canonical_url": null,
+        "og_title": null,
+        "og_description": null,
+        "og_image_url": null,
+        "twitter_title": null,
+        "twitter_description": null,
+        "twitter_image_url": null,
+        "robots": null,
+        "jsonld_overrides_json": null
+      }
+    },
+    {
+      "job_code": "physician",
+      "slug": "physician",
+      "locale": "en",
+      "title": "Physician",
+      "subtitle": null,
+      "excerpt": "A practical role profile for physician including responsibilities, required skills, salary, and growth path.",
+      "hero_kicker": null,
+      "hero_quote": null,
+      "cover_image_url": null,
+      "industry_slug": "healthcare",
+      "industry_label": null,
+      "body_md": "# Physician\n## Role Overview\nPhysician is a role where performance compounds through execution quality, communication precision, and long-term learning velocity.\n\n## Core Work Scope\nThis role contributes to business outcomes by translating goals into high-quality deliverables, collaborating across functions, and continuously improving process quality.\n\n## Career Development Advice\nUse 90-day cycles to track output metrics, capability growth, and collaboration impact. Review your progress every quarter and adjust your growth plan based on evidence.\n",
+      "body_html": null,
+      "salary_json": {
+        "raw": "$55,000 - $180,000 (varies by region and seniority)"
+      },
+      "outlook_json": {
+        "summary": "Demand for physician talent remains strong in data-driven organizations."
+      },
+      "skills_json": {
+        "core": [
+          "Structured problem solving",
+          "Stakeholder communication",
+          "Execution management",
+          "Data-informed decision making",
+          "Continuous learning"
+        ],
+        "supporting": [
+
+        ]
+      },
+      "work_contents_json": {
+        "items": [
+          "Define key responsibilities and delivery metrics for physician workstreams.",
+          "Coordinate cross-functional stakeholders and align execution priorities.",
+          "Track progress, risks, and quality signals to ensure stable outcomes."
+        ]
+      },
+      "growth_path_json": {
+        "raw": [
+          "0-2 years: build core execution competency and domain literacy.",
+          "3-5 years: own medium-complexity projects and cross-team collaboration.",
+          "5+ years: move toward specialist leadership or managerial scope."
+        ]
+      },
+      "fit_personality_codes_json": null,
+      "mbti_primary_codes_json": [
+        "ENFJ",
+        "ISFJ",
+        "INFJ"
+      ],
+      "mbti_secondary_codes_json": [
+        "ESFJ",
+        "INFP",
+        "ENFP"
+      ],
+      "riasec_profile_json": {
+        "R": 48,
+        "I": 64,
+        "A": 42,
+        "S": 88,
+        "E": 54,
+        "C": 74
+      },
+      "big5_targets_json": {
+        "raw": {
+          "openness": {
+            "min": 40,
+            "max": 80
+          },
+          "conscientiousness": {
+            "min": 50,
+            "max": 90
+          },
+          "extraversion": {
+            "min": 35,
+            "max": 82
+          },
+          "agreeableness": {
+            "min": 35,
+            "max": 85
+          },
+          "neuroticism": {
+            "min": 10,
+            "max": 55
+          }
+        }
+      },
+      "iq_eq_notes_json": {
+        "iq_range": {
+          "min": 50,
+          "max": 100
+        },
+        "eq_range": {
+          "min": 60,
+          "max": 100
+        }
+      },
+      "market_demand_json": {
+        "raw": 86
+      },
+      "status": "published",
+      "is_public": true,
+      "is_indexable": true,
+      "published_at": null,
+      "scheduled_at": null,
+      "sort_order": 0,
+      "sections": [
+
+      ],
+      "seo_meta": {
+        "seo_title": null,
+        "seo_description": null,
+        "canonical_url": null,
+        "og_title": null,
+        "og_description": null,
+        "og_image_url": null,
+        "twitter_title": null,
+        "twitter_description": null,
+        "twitter_image_url": null,
+        "robots": null,
+        "jsonld_overrides_json": null
+      }
+    },
+    {
+      "job_code": "policy-analyst",
+      "slug": "policy-analyst",
+      "locale": "en",
+      "title": "Policy Analyst",
+      "subtitle": null,
+      "excerpt": "A practical role profile for policy analyst including responsibilities, required skills, salary, and growth path.",
+      "hero_kicker": null,
+      "hero_quote": null,
+      "cover_image_url": null,
+      "industry_slug": "public-service",
+      "industry_label": null,
+      "body_md": "# Policy Analyst\n## Role Overview\nPolicy Analyst is a role where performance compounds through execution quality, communication precision, and long-term learning velocity.\n\n## Core Work Scope\nThis role contributes to business outcomes by translating goals into high-quality deliverables, collaborating across functions, and continuously improving process quality.\n\n## Career Development Advice\nUse 90-day cycles to track output metrics, capability growth, and collaboration impact. Review your progress every quarter and adjust your growth plan based on evidence.\n",
+      "body_html": null,
+      "salary_json": {
+        "raw": "$55,000 - $180,000 (varies by region and seniority)"
+      },
+      "outlook_json": {
+        "summary": "Demand for policy analyst talent remains strong in data-driven organizations."
+      },
+      "skills_json": {
+        "core": [
+          "Structured problem solving",
+          "Stakeholder communication",
+          "Execution management",
+          "Data-informed decision making",
+          "Continuous learning"
+        ],
+        "supporting": [
+
+        ]
+      },
+      "work_contents_json": {
+        "items": [
+          "Define key responsibilities and delivery metrics for policy analyst workstreams.",
+          "Coordinate cross-functional stakeholders and align execution priorities.",
+          "Track progress, risks, and quality signals to ensure stable outcomes."
+        ]
+      },
+      "growth_path_json": {
+        "raw": [
+          "0-2 years: build core execution competency and domain literacy.",
+          "3-5 years: own medium-complexity projects and cross-team collaboration.",
+          "5+ years: move toward specialist leadership or managerial scope."
+        ]
+      },
+      "fit_personality_codes_json": null,
+      "mbti_primary_codes_json": [
+        "INTJ",
+        "INTP",
+        "ENTJ"
+      ],
+      "mbti_secondary_codes_json": [
+        "ENTP",
+        "ISTJ",
+        "INFJ"
+      ],
+      "riasec_profile_json": {
+        "R": 40,
+        "I": 90,
+        "A": 45,
+        "S": 38,
+        "E": 46,
+        "C": 72
+      },
+      "big5_targets_json": {
+        "raw": {
+          "openness": {
+            "min": 40,
+            "max": 80
+          },
+          "conscientiousness": {
+            "min": 50,
+            "max": 90
+          },
+          "extraversion": {
+            "min": 35,
+            "max": 82
+          },
+          "agreeableness": {
+            "min": 35,
+            "max": 85
+          },
+          "neuroticism": {
+            "min": 10,
+            "max": 55
+          }
+        }
+      },
+      "iq_eq_notes_json": {
+        "iq_range": {
+          "min": 62,
+          "max": 100
+        },
+        "eq_range": {
+          "min": 40,
+          "max": 86
+        }
+      },
+      "market_demand_json": {
+        "raw": 85
+      },
+      "status": "published",
+      "is_public": true,
+      "is_indexable": true,
+      "published_at": null,
+      "scheduled_at": null,
+      "sort_order": 0,
+      "sections": [
+
+      ],
+      "seo_meta": {
+        "seo_title": null,
+        "seo_description": null,
+        "canonical_url": null,
+        "og_title": null,
+        "og_description": null,
+        "og_image_url": null,
+        "twitter_title": null,
+        "twitter_description": null,
+        "twitter_image_url": null,
+        "robots": null,
+        "jsonld_overrides_json": null
+      }
+    },
+    {
+      "job_code": "product-manager",
+      "slug": "product-manager",
+      "locale": "en",
+      "title": "Product Manager",
+      "subtitle": null,
+      "excerpt": "A practical role profile for product manager including responsibilities, required skills, salary, and growth path.",
+      "hero_kicker": null,
+      "hero_quote": null,
+      "cover_image_url": null,
+      "industry_slug": "business",
+      "industry_label": null,
+      "body_md": "# Product Manager\n## Role Overview\nProduct Manager is a role where performance compounds through execution quality, communication precision, and long-term learning velocity.\n\n## Core Work Scope\nThis role contributes to business outcomes by translating goals into high-quality deliverables, collaborating across functions, and continuously improving process quality.\n\n## Career Development Advice\nUse 90-day cycles to track output metrics, capability growth, and collaboration impact. Review your progress every quarter and adjust your growth plan based on evidence.\n",
+      "body_html": null,
+      "salary_json": {
+        "raw": "$55,000 - $180,000 (varies by region and seniority)"
+      },
+      "outlook_json": {
+        "summary": "Demand for product manager talent remains strong in data-driven organizations."
+      },
+      "skills_json": {
+        "core": [
+          "Structured problem solving",
+          "Stakeholder communication",
+          "Execution management",
+          "Data-informed decision making",
+          "Continuous learning"
+        ],
+        "supporting": [
+
+        ]
+      },
+      "work_contents_json": {
+        "items": [
+          "Define key responsibilities and delivery metrics for product manager workstreams.",
+          "Coordinate cross-functional stakeholders and align execution priorities.",
+          "Track progress, risks, and quality signals to ensure stable outcomes."
+        ]
+      },
+      "growth_path_json": {
+        "raw": [
+          "0-2 years: build core execution competency and domain literacy.",
+          "3-5 years: own medium-complexity projects and cross-team collaboration.",
+          "5+ years: move toward specialist leadership or managerial scope."
+        ]
+      },
+      "fit_personality_codes_json": null,
+      "mbti_primary_codes_json": [
+        "ENTJ",
+        "ENFJ",
+        "ESTP"
+      ],
+      "mbti_secondary_codes_json": [
+        "ENFP",
+        "ESTJ",
+        "ENTP"
+      ],
+      "riasec_profile_json": {
+        "R": 42,
+        "I": 66,
+        "A": 56,
+        "S": 60,
+        "E": 88,
+        "C": 70
+      },
+      "big5_targets_json": {
+        "raw": {
+          "openness": {
+            "min": 40,
+            "max": 80
+          },
+          "conscientiousness": {
+            "min": 50,
+            "max": 90
+          },
+          "extraversion": {
+            "min": 35,
+            "max": 82
+          },
+          "agreeableness": {
+            "min": 35,
+            "max": 85
+          },
+          "neuroticism": {
+            "min": 10,
+            "max": 55
+          }
+        }
+      },
+      "iq_eq_notes_json": {
+        "iq_range": {
+          "min": 50,
+          "max": 98
+        },
+        "eq_range": {
+          "min": 55,
+          "max": 100
+        }
+      },
+      "market_demand_json": {
+        "raw": 82
+      },
+      "status": "published",
+      "is_public": true,
+      "is_indexable": true,
+      "published_at": null,
+      "scheduled_at": null,
+      "sort_order": 0,
+      "sections": [
+
+      ],
+      "seo_meta": {
+        "seo_title": null,
+        "seo_description": null,
+        "canonical_url": null,
+        "og_title": null,
+        "og_description": null,
+        "og_image_url": null,
+        "twitter_title": null,
+        "twitter_description": null,
+        "twitter_image_url": null,
+        "robots": null,
+        "jsonld_overrides_json": null
+      }
+    },
+    {
+      "job_code": "psychological-counselor",
+      "slug": "psychological-counselor",
+      "locale": "en",
+      "title": "Psychological Counselor",
+      "subtitle": null,
+      "excerpt": "A practical role profile for psychological counselor including responsibilities, required skills, salary, and growth path.",
+      "hero_kicker": null,
+      "hero_quote": null,
+      "cover_image_url": null,
+      "industry_slug": "healthcare",
+      "industry_label": null,
+      "body_md": "# Psychological Counselor\n## Role Overview\nPsychological Counselor is a role where performance compounds through execution quality, communication precision, and long-term learning velocity.\n\n## Core Work Scope\nThis role contributes to business outcomes by translating goals into high-quality deliverables, collaborating across functions, and continuously improving process quality.\n\n## Career Development Advice\nUse 90-day cycles to track output metrics, capability growth, and collaboration impact. Review your progress every quarter and adjust your growth plan based on evidence.\n",
+      "body_html": null,
+      "salary_json": {
+        "raw": "$55,000 - $180,000 (varies by region and seniority)"
+      },
+      "outlook_json": {
+        "summary": "Demand for psychological counselor talent remains strong in data-driven organizations."
+      },
+      "skills_json": {
+        "core": [
+          "Structured problem solving",
+          "Stakeholder communication",
+          "Execution management",
+          "Data-informed decision making",
+          "Continuous learning"
+        ],
+        "supporting": [
+
+        ]
+      },
+      "work_contents_json": {
+        "items": [
+          "Define key responsibilities and delivery metrics for psychological counselor workstreams.",
+          "Coordinate cross-functional stakeholders and align execution priorities.",
+          "Track progress, risks, and quality signals to ensure stable outcomes."
+        ]
+      },
+      "growth_path_json": {
+        "raw": [
+          "0-2 years: build core execution competency and domain literacy.",
+          "3-5 years: own medium-complexity projects and cross-team collaboration.",
+          "5+ years: move toward specialist leadership or managerial scope."
+        ]
+      },
+      "fit_personality_codes_json": null,
+      "mbti_primary_codes_json": [
+        "ENFJ",
+        "ISFJ",
+        "INFJ"
+      ],
+      "mbti_secondary_codes_json": [
+        "ESFJ",
+        "INFP",
+        "ENFP"
+      ],
+      "riasec_profile_json": {
+        "R": 48,
+        "I": 64,
+        "A": 42,
+        "S": 88,
+        "E": 54,
+        "C": 74
+      },
+      "big5_targets_json": {
+        "raw": {
+          "openness": {
+            "min": 40,
+            "max": 80
+          },
+          "conscientiousness": {
+            "min": 50,
+            "max": 90
+          },
+          "extraversion": {
+            "min": 35,
+            "max": 82
+          },
+          "agreeableness": {
+            "min": 35,
+            "max": 85
+          },
+          "neuroticism": {
+            "min": 10,
+            "max": 55
+          }
+        }
+      },
+      "iq_eq_notes_json": {
+        "iq_range": {
+          "min": 50,
+          "max": 100
+        },
+        "eq_range": {
+          "min": 60,
+          "max": 100
+        }
+      },
+      "market_demand_json": {
+        "raw": 86
+      },
+      "status": "published",
+      "is_public": true,
+      "is_indexable": true,
+      "published_at": null,
+      "scheduled_at": null,
+      "sort_order": 0,
+      "sections": [
+
+      ],
+      "seo_meta": {
+        "seo_title": null,
+        "seo_description": null,
+        "canonical_url": null,
+        "og_title": null,
+        "og_description": null,
+        "og_image_url": null,
+        "twitter_title": null,
+        "twitter_description": null,
+        "twitter_image_url": null,
+        "robots": null,
+        "jsonld_overrides_json": null
+      }
+    },
+    {
+      "job_code": "researcher",
+      "slug": "researcher",
+      "locale": "en",
+      "title": "Researcher",
+      "subtitle": null,
+      "excerpt": "A practical role profile for researcher including responsibilities, required skills, salary, and growth path.",
+      "hero_kicker": null,
+      "hero_quote": null,
+      "cover_image_url": null,
+      "industry_slug": "education",
+      "industry_label": null,
+      "body_md": "# Researcher\n## Role Overview\nResearcher is a role where performance compounds through execution quality, communication precision, and long-term learning velocity.\n\n## Core Work Scope\nThis role contributes to business outcomes by translating goals into high-quality deliverables, collaborating across functions, and continuously improving process quality.\n\n## Career Development Advice\nUse 90-day cycles to track output metrics, capability growth, and collaboration impact. Review your progress every quarter and adjust your growth plan based on evidence.\n",
+      "body_html": null,
+      "salary_json": {
+        "raw": "$55,000 - $180,000 (varies by region and seniority)"
+      },
+      "outlook_json": {
+        "summary": "Demand for researcher talent remains strong in data-driven organizations."
+      },
+      "skills_json": {
+        "core": [
+          "Structured problem solving",
+          "Stakeholder communication",
+          "Execution management",
+          "Data-informed decision making",
+          "Continuous learning"
+        ],
+        "supporting": [
+
+        ]
+      },
+      "work_contents_json": {
+        "items": [
+          "Define key responsibilities and delivery metrics for researcher workstreams.",
+          "Coordinate cross-functional stakeholders and align execution priorities.",
+          "Track progress, risks, and quality signals to ensure stable outcomes."
+        ]
+      },
+      "growth_path_json": {
+        "raw": [
+          "0-2 years: build core execution competency and domain literacy.",
+          "3-5 years: own medium-complexity projects and cross-team collaboration.",
+          "5+ years: move toward specialist leadership or managerial scope."
+        ]
+      },
+      "fit_personality_codes_json": null,
+      "mbti_primary_codes_json": [
+        "INTJ",
+        "INTP",
+        "ENTJ"
+      ],
+      "mbti_secondary_codes_json": [
+        "ENTP",
+        "ISTJ",
+        "INFJ"
+      ],
+      "riasec_profile_json": {
+        "R": 40,
+        "I": 90,
+        "A": 45,
+        "S": 38,
+        "E": 46,
+        "C": 72
+      },
+      "big5_targets_json": {
+        "raw": {
+          "openness": {
+            "min": 40,
+            "max": 80
+          },
+          "conscientiousness": {
+            "min": 50,
+            "max": 90
+          },
+          "extraversion": {
+            "min": 35,
+            "max": 82
+          },
+          "agreeableness": {
+            "min": 35,
+            "max": 85
+          },
+          "neuroticism": {
+            "min": 10,
+            "max": 55
+          }
+        }
+      },
+      "iq_eq_notes_json": {
+        "iq_range": {
+          "min": 62,
+          "max": 100
+        },
+        "eq_range": {
+          "min": 40,
+          "max": 86
+        }
+      },
+      "market_demand_json": {
+        "raw": 85
+      },
+      "status": "published",
+      "is_public": true,
+      "is_indexable": true,
+      "published_at": null,
+      "scheduled_at": null,
+      "sort_order": 0,
+      "sections": [
+
+      ],
+      "seo_meta": {
+        "seo_title": null,
+        "seo_description": null,
+        "canonical_url": null,
+        "og_title": null,
+        "og_description": null,
+        "og_image_url": null,
+        "twitter_title": null,
+        "twitter_description": null,
+        "twitter_image_url": null,
+        "robots": null,
+        "jsonld_overrides_json": null
+      }
+    },
+    {
+      "job_code": "sales-manager",
+      "slug": "sales-manager",
+      "locale": "en",
+      "title": "Sales Manager",
+      "subtitle": null,
+      "excerpt": "A practical role profile for sales manager including responsibilities, required skills, salary, and growth path.",
+      "hero_kicker": null,
+      "hero_quote": null,
+      "cover_image_url": null,
+      "industry_slug": "business",
+      "industry_label": null,
+      "body_md": "# Sales Manager\n## Role Overview\nSales Manager is a role where performance compounds through execution quality, communication precision, and long-term learning velocity.\n\n## Core Work Scope\nThis role contributes to business outcomes by translating goals into high-quality deliverables, collaborating across functions, and continuously improving process quality.\n\n## Career Development Advice\nUse 90-day cycles to track output metrics, capability growth, and collaboration impact. Review your progress every quarter and adjust your growth plan based on evidence.\n",
+      "body_html": null,
+      "salary_json": {
+        "raw": "$55,000 - $180,000 (varies by region and seniority)"
+      },
+      "outlook_json": {
+        "summary": "Demand for sales manager talent remains strong in data-driven organizations."
+      },
+      "skills_json": {
+        "core": [
+          "Structured problem solving",
+          "Stakeholder communication",
+          "Execution management",
+          "Data-informed decision making",
+          "Continuous learning"
+        ],
+        "supporting": [
+
+        ]
+      },
+      "work_contents_json": {
+        "items": [
+          "Define key responsibilities and delivery metrics for sales manager workstreams.",
+          "Coordinate cross-functional stakeholders and align execution priorities.",
+          "Track progress, risks, and quality signals to ensure stable outcomes."
+        ]
+      },
+      "growth_path_json": {
+        "raw": [
+          "0-2 years: build core execution competency and domain literacy.",
+          "3-5 years: own medium-complexity projects and cross-team collaboration.",
+          "5+ years: move toward specialist leadership or managerial scope."
+        ]
+      },
+      "fit_personality_codes_json": null,
+      "mbti_primary_codes_json": [
+        "ENTJ",
+        "ENFJ",
+        "ESTP"
+      ],
+      "mbti_secondary_codes_json": [
+        "ENFP",
+        "ESTJ",
+        "ENTP"
+      ],
+      "riasec_profile_json": {
+        "R": 42,
+        "I": 66,
+        "A": 56,
+        "S": 60,
+        "E": 88,
+        "C": 70
+      },
+      "big5_targets_json": {
+        "raw": {
+          "openness": {
+            "min": 40,
+            "max": 80
+          },
+          "conscientiousness": {
+            "min": 50,
+            "max": 90
+          },
+          "extraversion": {
+            "min": 35,
+            "max": 82
+          },
+          "agreeableness": {
+            "min": 35,
+            "max": 85
+          },
+          "neuroticism": {
+            "min": 10,
+            "max": 55
+          }
+        }
+      },
+      "iq_eq_notes_json": {
+        "iq_range": {
+          "min": 50,
+          "max": 98
+        },
+        "eq_range": {
+          "min": 55,
+          "max": 100
+        }
+      },
+      "market_demand_json": {
+        "raw": 82
+      },
+      "status": "published",
+      "is_public": true,
+      "is_indexable": true,
+      "published_at": null,
+      "scheduled_at": null,
+      "sort_order": 0,
+      "sections": [
+
+      ],
+      "seo_meta": {
+        "seo_title": null,
+        "seo_description": null,
+        "canonical_url": null,
+        "og_title": null,
+        "og_description": null,
+        "og_image_url": null,
+        "twitter_title": null,
+        "twitter_description": null,
+        "twitter_image_url": null,
+        "robots": null,
+        "jsonld_overrides_json": null
+      }
+    },
+    {
+      "job_code": "software-engineer",
+      "slug": "software-engineer",
+      "locale": "en",
+      "title": "Software Engineer",
+      "subtitle": null,
+      "excerpt": "A practical role profile for software engineer including responsibilities, required skills, salary, and growth path.",
+      "hero_kicker": null,
+      "hero_quote": null,
+      "cover_image_url": null,
+      "industry_slug": "technology",
+      "industry_label": null,
+      "body_md": "# Software Engineer\n## Role Overview\nSoftware Engineer is a role where performance compounds through execution quality, communication precision, and long-term learning velocity.\n\n## Core Work Scope\nThis role contributes to business outcomes by translating goals into high-quality deliverables, collaborating across functions, and continuously improving process quality.\n\n## Career Development Advice\nUse 90-day cycles to track output metrics, capability growth, and collaboration impact. Review your progress every quarter and adjust your growth plan based on evidence.\n",
+      "body_html": null,
+      "salary_json": {
+        "raw": "$55,000 - $180,000 (varies by region and seniority)"
+      },
+      "outlook_json": {
+        "summary": "Demand for software engineer talent remains strong in data-driven organizations."
+      },
+      "skills_json": {
+        "core": [
+          "Structured problem solving",
+          "Stakeholder communication",
+          "Execution management",
+          "Data-informed decision making",
+          "Continuous learning"
+        ],
+        "supporting": [
+
+        ]
+      },
+      "work_contents_json": {
+        "items": [
+          "Define key responsibilities and delivery metrics for software engineer workstreams.",
+          "Coordinate cross-functional stakeholders and align execution priorities.",
+          "Track progress, risks, and quality signals to ensure stable outcomes."
+        ]
+      },
+      "growth_path_json": {
+        "raw": [
+          "0-2 years: build core execution competency and domain literacy.",
+          "3-5 years: own medium-complexity projects and cross-team collaboration.",
+          "5+ years: move toward specialist leadership or managerial scope."
+        ]
+      },
+      "fit_personality_codes_json": null,
+      "mbti_primary_codes_json": [
+        "INTJ",
+        "INTP",
+        "ENTJ"
+      ],
+      "mbti_secondary_codes_json": [
+        "ENTP",
+        "ISTJ",
+        "INFJ"
+      ],
+      "riasec_profile_json": {
+        "R": 55,
+        "I": 88,
+        "A": 48,
+        "S": 42,
+        "E": 50,
+        "C": 68
+      },
+      "big5_targets_json": {
+        "raw": {
+          "openness": {
+            "min": 40,
+            "max": 80
+          },
+          "conscientiousness": {
+            "min": 50,
+            "max": 90
+          },
+          "extraversion": {
+            "min": 35,
+            "max": 82
+          },
+          "agreeableness": {
+            "min": 35,
+            "max": 85
+          },
+          "neuroticism": {
+            "min": 10,
+            "max": 55
+          }
+        }
+      },
+      "iq_eq_notes_json": {
+        "iq_range": {
+          "min": 65,
+          "max": 100
+        },
+        "eq_range": {
+          "min": 45,
+          "max": 90
+        }
+      },
+      "market_demand_json": {
+        "raw": 92
+      },
+      "status": "published",
+      "is_public": true,
+      "is_indexable": true,
+      "published_at": null,
+      "scheduled_at": null,
+      "sort_order": 0,
+      "sections": [
+
+      ],
+      "seo_meta": {
+        "seo_title": null,
+        "seo_description": null,
+        "canonical_url": null,
+        "og_title": null,
+        "og_description": null,
+        "og_image_url": null,
+        "twitter_title": null,
+        "twitter_description": null,
+        "twitter_image_url": null,
+        "robots": null,
+        "jsonld_overrides_json": null
+      }
+    },
+    {
+      "job_code": "supply-chain-manager",
+      "slug": "supply-chain-manager",
+      "locale": "en",
+      "title": "Supply Chain Manager",
+      "subtitle": null,
+      "excerpt": "A practical role profile for supply chain manager including responsibilities, required skills, salary, and growth path.",
+      "hero_kicker": null,
+      "hero_quote": null,
+      "cover_image_url": null,
+      "industry_slug": "operations",
+      "industry_label": null,
+      "body_md": "# Supply Chain Manager\n## Role Overview\nSupply Chain Manager is a role where performance compounds through execution quality, communication precision, and long-term learning velocity.\n\n## Core Work Scope\nThis role contributes to business outcomes by translating goals into high-quality deliverables, collaborating across functions, and continuously improving process quality.\n\n## Career Development Advice\nUse 90-day cycles to track output metrics, capability growth, and collaboration impact. Review your progress every quarter and adjust your growth plan based on evidence.\n",
+      "body_html": null,
+      "salary_json": {
+        "raw": "$55,000 - $180,000 (varies by region and seniority)"
+      },
+      "outlook_json": {
+        "summary": "Demand for supply chain manager talent remains strong in data-driven organizations."
+      },
+      "skills_json": {
+        "core": [
+          "Structured problem solving",
+          "Stakeholder communication",
+          "Execution management",
+          "Data-informed decision making",
+          "Continuous learning"
+        ],
+        "supporting": [
+
+        ]
+      },
+      "work_contents_json": {
+        "items": [
+          "Define key responsibilities and delivery metrics for supply chain manager workstreams.",
+          "Coordinate cross-functional stakeholders and align execution priorities.",
+          "Track progress, risks, and quality signals to ensure stable outcomes."
+        ]
+      },
+      "growth_path_json": {
+        "raw": [
+          "0-2 years: build core execution competency and domain literacy.",
+          "3-5 years: own medium-complexity projects and cross-team collaboration.",
+          "5+ years: move toward specialist leadership or managerial scope."
+        ]
+      },
+      "fit_personality_codes_json": null,
+      "mbti_primary_codes_json": [
+        "ENTJ",
+        "ENFJ",
+        "ESTP"
+      ],
+      "mbti_secondary_codes_json": [
+        "ENFP",
+        "ESTJ",
+        "ENTP"
+      ],
+      "riasec_profile_json": {
+        "R": 42,
+        "I": 66,
+        "A": 56,
+        "S": 60,
+        "E": 88,
+        "C": 70
+      },
+      "big5_targets_json": {
+        "raw": {
+          "openness": {
+            "min": 40,
+            "max": 80
+          },
+          "conscientiousness": {
+            "min": 50,
+            "max": 90
+          },
+          "extraversion": {
+            "min": 35,
+            "max": 82
+          },
+          "agreeableness": {
+            "min": 35,
+            "max": 85
+          },
+          "neuroticism": {
+            "min": 10,
+            "max": 55
+          }
+        }
+      },
+      "iq_eq_notes_json": {
+        "iq_range": {
+          "min": 50,
+          "max": 98
+        },
+        "eq_range": {
+          "min": 55,
+          "max": 100
+        }
+      },
+      "market_demand_json": {
+        "raw": 82
+      },
+      "status": "published",
+      "is_public": true,
+      "is_indexable": true,
+      "published_at": null,
+      "scheduled_at": null,
+      "sort_order": 0,
+      "sections": [
+
+      ],
+      "seo_meta": {
+        "seo_title": null,
+        "seo_description": null,
+        "canonical_url": null,
+        "og_title": null,
+        "og_description": null,
+        "og_image_url": null,
+        "twitter_title": null,
+        "twitter_description": null,
+        "twitter_image_url": null,
+        "robots": null,
+        "jsonld_overrides_json": null
+      }
+    },
+    {
+      "job_code": "teacher",
+      "slug": "teacher",
+      "locale": "en",
+      "title": "Teacher",
+      "subtitle": null,
+      "excerpt": "A practical role profile for teacher including responsibilities, required skills, salary, and growth path.",
+      "hero_kicker": null,
+      "hero_quote": null,
+      "cover_image_url": null,
+      "industry_slug": "education",
+      "industry_label": null,
+      "body_md": "# Teacher\n## Role Overview\nTeacher is a role where performance compounds through execution quality, communication precision, and long-term learning velocity.\n\n## Core Work Scope\nThis role contributes to business outcomes by translating goals into high-quality deliverables, collaborating across functions, and continuously improving process quality.\n\n## Career Development Advice\nUse 90-day cycles to track output metrics, capability growth, and collaboration impact. Review your progress every quarter and adjust your growth plan based on evidence.\n",
+      "body_html": null,
+      "salary_json": {
+        "raw": "$55,000 - $180,000 (varies by region and seniority)"
+      },
+      "outlook_json": {
+        "summary": "Demand for teacher talent remains strong in data-driven organizations."
+      },
+      "skills_json": {
+        "core": [
+          "Structured problem solving",
+          "Stakeholder communication",
+          "Execution management",
+          "Data-informed decision making",
+          "Continuous learning"
+        ],
+        "supporting": [
+
+        ]
+      },
+      "work_contents_json": {
+        "items": [
+          "Define key responsibilities and delivery metrics for teacher workstreams.",
+          "Coordinate cross-functional stakeholders and align execution priorities.",
+          "Track progress, risks, and quality signals to ensure stable outcomes."
+        ]
+      },
+      "growth_path_json": {
+        "raw": [
+          "0-2 years: build core execution competency and domain literacy.",
+          "3-5 years: own medium-complexity projects and cross-team collaboration.",
+          "5+ years: move toward specialist leadership or managerial scope."
+        ]
+      },
+      "fit_personality_codes_json": null,
+      "mbti_primary_codes_json": [
+        "ENFJ",
+        "ISFJ",
+        "INFJ"
+      ],
+      "mbti_secondary_codes_json": [
+        "ESFJ",
+        "INFP",
+        "ENFP"
+      ],
+      "riasec_profile_json": {
+        "R": 48,
+        "I": 64,
+        "A": 42,
+        "S": 88,
+        "E": 54,
+        "C": 74
+      },
+      "big5_targets_json": {
+        "raw": {
+          "openness": {
+            "min": 40,
+            "max": 80
+          },
+          "conscientiousness": {
+            "min": 50,
+            "max": 90
+          },
+          "extraversion": {
+            "min": 35,
+            "max": 82
+          },
+          "agreeableness": {
+            "min": 35,
+            "max": 85
+          },
+          "neuroticism": {
+            "min": 10,
+            "max": 55
+          }
+        }
+      },
+      "iq_eq_notes_json": {
+        "iq_range": {
+          "min": 50,
+          "max": 100
+        },
+        "eq_range": {
+          "min": 60,
+          "max": 100
+        }
+      },
+      "market_demand_json": {
+        "raw": 86
+      },
+      "status": "published",
+      "is_public": true,
+      "is_indexable": true,
+      "published_at": null,
+      "scheduled_at": null,
+      "sort_order": 0,
+      "sections": [
+
+      ],
+      "seo_meta": {
+        "seo_title": null,
+        "seo_description": null,
+        "canonical_url": null,
+        "og_title": null,
+        "og_description": null,
+        "og_image_url": null,
+        "twitter_title": null,
+        "twitter_description": null,
+        "twitter_image_url": null,
+        "robots": null,
+        "jsonld_overrides_json": null
+      }
+    },
+    {
+      "job_code": "ui-ux-designer",
+      "slug": "ui-ux-designer",
+      "locale": "en",
+      "title": "UI/UX Designer",
+      "subtitle": null,
+      "excerpt": "A practical role profile for ui/ux designer including responsibilities, required skills, salary, and growth path.",
+      "hero_kicker": null,
+      "hero_quote": null,
+      "cover_image_url": null,
+      "industry_slug": "design",
+      "industry_label": null,
+      "body_md": "# UI/UX Designer\n## Role Overview\nUI/UX Designer is a role where performance compounds through execution quality, communication precision, and long-term learning velocity.\n\n## Core Work Scope\nThis role contributes to business outcomes by translating goals into high-quality deliverables, collaborating across functions, and continuously improving process quality.\n\n## Career Development Advice\nUse 90-day cycles to track output metrics, capability growth, and collaboration impact. Review your progress every quarter and adjust your growth plan based on evidence.\n",
+      "body_html": null,
+      "salary_json": {
+        "raw": "$55,000 - $180,000 (varies by region and seniority)"
+      },
+      "outlook_json": {
+        "summary": "Demand for ui/ux designer talent remains strong in data-driven organizations."
+      },
+      "skills_json": {
+        "core": [
+          "Structured problem solving",
+          "Stakeholder communication",
+          "Execution management",
+          "Data-informed decision making",
+          "Continuous learning"
+        ],
+        "supporting": [
+
+        ]
+      },
+      "work_contents_json": {
+        "items": [
+          "Define key responsibilities and delivery metrics for ui/ux designer workstreams.",
+          "Coordinate cross-functional stakeholders and align execution priorities.",
+          "Track progress, risks, and quality signals to ensure stable outcomes."
+        ]
+      },
+      "growth_path_json": {
+        "raw": [
+          "0-2 years: build core execution competency and domain literacy.",
+          "3-5 years: own medium-complexity projects and cross-team collaboration.",
+          "5+ years: move toward specialist leadership or managerial scope."
+        ]
+      },
+      "fit_personality_codes_json": null,
+      "mbti_primary_codes_json": [
+        "INFP",
+        "ENFP",
+        "ISFP"
+      ],
+      "mbti_secondary_codes_json": [
+        "INFJ",
+        "ENTP",
+        "ESFP"
+      ],
+      "riasec_profile_json": {
+        "R": 38,
+        "I": 62,
+        "A": 90,
+        "S": 54,
+        "E": 60,
+        "C": 44
+      },
+      "big5_targets_json": {
+        "raw": {
+          "openness": {
+            "min": 40,
+            "max": 80
+          },
+          "conscientiousness": {
+            "min": 50,
+            "max": 90
+          },
+          "extraversion": {
+            "min": 35,
+            "max": 82
+          },
+          "agreeableness": {
+            "min": 35,
+            "max": 85
+          },
+          "neuroticism": {
+            "min": 10,
+            "max": 55
+          }
+        }
+      },
+      "iq_eq_notes_json": {
+        "iq_range": {
+          "min": 45,
+          "max": 95
+        },
+        "eq_range": {
+          "min": 52,
+          "max": 96
+        }
+      },
+      "market_demand_json": {
+        "raw": 78
+      },
+      "status": "published",
+      "is_public": true,
+      "is_indexable": true,
+      "published_at": null,
+      "scheduled_at": null,
+      "sort_order": 0,
+      "sections": [
+
+      ],
+      "seo_meta": {
+        "seo_title": null,
+        "seo_description": null,
+        "canonical_url": null,
+        "og_title": null,
+        "og_description": null,
+        "og_image_url": null,
+        "twitter_title": null,
+        "twitter_description": null,
+        "twitter_image_url": null,
+        "robots": null,
+        "jsonld_overrides_json": null
+      }
+    }
+  ]
+}

--- a/content_baselines/career_jobs/career_jobs.zh-CN.json
+++ b/content_baselines/career_jobs/career_jobs.zh-CN.json
@@ -1,0 +1,3760 @@
+{
+  "meta": {
+    "schema_version": "v1",
+    "locale": "zh-CN",
+    "source": "fap-web career jobs baseline",
+    "generated_at": "2026-03-09T00:00:00Z"
+  },
+  "jobs": [
+    {
+      "job_code": "backend-engineer",
+      "slug": "backend-engineer",
+      "locale": "zh-CN",
+      "title": "后端工程师",
+      "subtitle": null,
+      "excerpt": "面向后端工程师的实用岗位画像，覆盖职责范围、能力要求、薪资区间与成长路径。",
+      "hero_kicker": null,
+      "hero_quote": null,
+      "cover_image_url": null,
+      "industry_slug": "technology",
+      "industry_label": null,
+      "body_md": "# 后端工程师\n## 岗位概览\n后端工程师 是一个通过执行质量、沟通精度与持续学习能力持续放大职业价值的岗位。\n\n## 核心工作范围\n该岗位通过把目标拆解为可落地任务、推进跨团队协同，并持续优化流程质量来影响业务结果。\n\n## 职业发展建议\n建议按 90 天为周期跟踪交付指标、能力增长和协作影响，每季度做一次基于证据的职业复盘并调整成长策略。\n",
+      "body_html": null,
+      "salary_json": {
+        "raw": "人民币 18万 - 90万/年（视城市与资历而定）"
+      },
+      "outlook_json": {
+        "summary": "后端工程师 在数据化与精细化运营背景下仍保持较高需求。"
+      },
+      "skills_json": {
+        "core": [
+          "结构化问题解决",
+          "跨角色沟通",
+          "执行推进能力",
+          "数据驱动决策",
+          "持续学习能力"
+        ],
+        "supporting": [
+
+        ]
+      },
+      "work_contents_json": {
+        "items": [
+          "明确后端工程师核心职责与交付指标。",
+          "协同跨团队角色并统一执行优先级。",
+          "跟踪进度、风险与质量信号，保障结果稳定交付。"
+        ]
+      },
+      "growth_path_json": {
+        "raw": [
+          "0-2 年：建立基础执行能力与行业认知。",
+          "3-5 年：独立负责中等复杂度项目并推进跨团队协作。",
+          "5 年以上：走向专家型负责人或管理型角色。"
+        ]
+      },
+      "fit_personality_codes_json": null,
+      "mbti_primary_codes_json": [
+        "INTJ",
+        "INTP",
+        "ENTJ"
+      ],
+      "mbti_secondary_codes_json": [
+        "ENTP",
+        "ISTJ",
+        "INFJ"
+      ],
+      "riasec_profile_json": {
+        "R": 55,
+        "I": 88,
+        "A": 48,
+        "S": 42,
+        "E": 50,
+        "C": 68
+      },
+      "big5_targets_json": {
+        "raw": {
+          "openness": {
+            "min": 40,
+            "max": 80
+          },
+          "conscientiousness": {
+            "min": 50,
+            "max": 90
+          },
+          "extraversion": {
+            "min": 35,
+            "max": 82
+          },
+          "agreeableness": {
+            "min": 35,
+            "max": 85
+          },
+          "neuroticism": {
+            "min": 10,
+            "max": 55
+          }
+        }
+      },
+      "iq_eq_notes_json": {
+        "iq_range": {
+          "min": 65,
+          "max": 100
+        },
+        "eq_range": {
+          "min": 45,
+          "max": 90
+        }
+      },
+      "market_demand_json": {
+        "raw": 92
+      },
+      "status": "published",
+      "is_public": true,
+      "is_indexable": true,
+      "published_at": null,
+      "scheduled_at": null,
+      "sort_order": 0,
+      "sections": [
+
+      ],
+      "seo_meta": {
+        "seo_title": null,
+        "seo_description": null,
+        "canonical_url": null,
+        "og_title": null,
+        "og_description": null,
+        "og_image_url": null,
+        "twitter_title": null,
+        "twitter_description": null,
+        "twitter_image_url": null,
+        "robots": null,
+        "jsonld_overrides_json": null
+      }
+    },
+    {
+      "job_code": "brand-manager",
+      "slug": "brand-manager",
+      "locale": "zh-CN",
+      "title": "品牌经理",
+      "subtitle": null,
+      "excerpt": "面向品牌经理的实用岗位画像，覆盖职责范围、能力要求、薪资区间与成长路径。",
+      "hero_kicker": null,
+      "hero_quote": null,
+      "cover_image_url": null,
+      "industry_slug": "design",
+      "industry_label": null,
+      "body_md": "# 品牌经理\n## 岗位概览\n品牌经理 是一个通过执行质量、沟通精度与持续学习能力持续放大职业价值的岗位。\n\n## 核心工作范围\n该岗位通过把目标拆解为可落地任务、推进跨团队协同，并持续优化流程质量来影响业务结果。\n\n## 职业发展建议\n建议按 90 天为周期跟踪交付指标、能力增长和协作影响，每季度做一次基于证据的职业复盘并调整成长策略。\n",
+      "body_html": null,
+      "salary_json": {
+        "raw": "人民币 18万 - 90万/年（视城市与资历而定）"
+      },
+      "outlook_json": {
+        "summary": "品牌经理 在数据化与精细化运营背景下仍保持较高需求。"
+      },
+      "skills_json": {
+        "core": [
+          "结构化问题解决",
+          "跨角色沟通",
+          "执行推进能力",
+          "数据驱动决策",
+          "持续学习能力"
+        ],
+        "supporting": [
+
+        ]
+      },
+      "work_contents_json": {
+        "items": [
+          "明确品牌经理核心职责与交付指标。",
+          "协同跨团队角色并统一执行优先级。",
+          "跟踪进度、风险与质量信号，保障结果稳定交付。"
+        ]
+      },
+      "growth_path_json": {
+        "raw": [
+          "0-2 年：建立基础执行能力与行业认知。",
+          "3-5 年：独立负责中等复杂度项目并推进跨团队协作。",
+          "5 年以上：走向专家型负责人或管理型角色。"
+        ]
+      },
+      "fit_personality_codes_json": null,
+      "mbti_primary_codes_json": [
+        "INFP",
+        "ENFP",
+        "ISFP"
+      ],
+      "mbti_secondary_codes_json": [
+        "INFJ",
+        "ENTP",
+        "ESFP"
+      ],
+      "riasec_profile_json": {
+        "R": 38,
+        "I": 62,
+        "A": 90,
+        "S": 54,
+        "E": 60,
+        "C": 44
+      },
+      "big5_targets_json": {
+        "raw": {
+          "openness": {
+            "min": 40,
+            "max": 80
+          },
+          "conscientiousness": {
+            "min": 50,
+            "max": 90
+          },
+          "extraversion": {
+            "min": 35,
+            "max": 82
+          },
+          "agreeableness": {
+            "min": 35,
+            "max": 85
+          },
+          "neuroticism": {
+            "min": 10,
+            "max": 55
+          }
+        }
+      },
+      "iq_eq_notes_json": {
+        "iq_range": {
+          "min": 45,
+          "max": 95
+        },
+        "eq_range": {
+          "min": 52,
+          "max": 96
+        }
+      },
+      "market_demand_json": {
+        "raw": 78
+      },
+      "status": "published",
+      "is_public": true,
+      "is_indexable": true,
+      "published_at": null,
+      "scheduled_at": null,
+      "sort_order": 0,
+      "sections": [
+
+      ],
+      "seo_meta": {
+        "seo_title": null,
+        "seo_description": null,
+        "canonical_url": null,
+        "og_title": null,
+        "og_description": null,
+        "og_image_url": null,
+        "twitter_title": null,
+        "twitter_description": null,
+        "twitter_image_url": null,
+        "robots": null,
+        "jsonld_overrides_json": null
+      }
+    },
+    {
+      "job_code": "business-analyst",
+      "slug": "business-analyst",
+      "locale": "zh-CN",
+      "title": "商业分析师",
+      "subtitle": null,
+      "excerpt": "面向商业分析师的实用岗位画像，覆盖职责范围、能力要求、薪资区间与成长路径。",
+      "hero_kicker": null,
+      "hero_quote": null,
+      "cover_image_url": null,
+      "industry_slug": "consulting",
+      "industry_label": null,
+      "body_md": "# 商业分析师\n## 岗位概览\n商业分析师 是一个通过执行质量、沟通精度与持续学习能力持续放大职业价值的岗位。\n\n## 核心工作范围\n该岗位通过把目标拆解为可落地任务、推进跨团队协同，并持续优化流程质量来影响业务结果。\n\n## 职业发展建议\n建议按 90 天为周期跟踪交付指标、能力增长和协作影响，每季度做一次基于证据的职业复盘并调整成长策略。\n",
+      "body_html": null,
+      "salary_json": {
+        "raw": "人民币 18万 - 90万/年（视城市与资历而定）"
+      },
+      "outlook_json": {
+        "summary": "商业分析师 在数据化与精细化运营背景下仍保持较高需求。"
+      },
+      "skills_json": {
+        "core": [
+          "结构化问题解决",
+          "跨角色沟通",
+          "执行推进能力",
+          "数据驱动决策",
+          "持续学习能力"
+        ],
+        "supporting": [
+
+        ]
+      },
+      "work_contents_json": {
+        "items": [
+          "明确商业分析师核心职责与交付指标。",
+          "协同跨团队角色并统一执行优先级。",
+          "跟踪进度、风险与质量信号，保障结果稳定交付。"
+        ]
+      },
+      "growth_path_json": {
+        "raw": [
+          "0-2 年：建立基础执行能力与行业认知。",
+          "3-5 年：独立负责中等复杂度项目并推进跨团队协作。",
+          "5 年以上：走向专家型负责人或管理型角色。"
+        ]
+      },
+      "fit_personality_codes_json": null,
+      "mbti_primary_codes_json": [
+        "INTJ",
+        "INTP",
+        "ENTJ"
+      ],
+      "mbti_secondary_codes_json": [
+        "ENTP",
+        "ISTJ",
+        "INFJ"
+      ],
+      "riasec_profile_json": {
+        "R": 40,
+        "I": 90,
+        "A": 45,
+        "S": 38,
+        "E": 46,
+        "C": 72
+      },
+      "big5_targets_json": {
+        "raw": {
+          "openness": {
+            "min": 40,
+            "max": 80
+          },
+          "conscientiousness": {
+            "min": 50,
+            "max": 90
+          },
+          "extraversion": {
+            "min": 35,
+            "max": 82
+          },
+          "agreeableness": {
+            "min": 35,
+            "max": 85
+          },
+          "neuroticism": {
+            "min": 10,
+            "max": 55
+          }
+        }
+      },
+      "iq_eq_notes_json": {
+        "iq_range": {
+          "min": 62,
+          "max": 100
+        },
+        "eq_range": {
+          "min": 40,
+          "max": 86
+        }
+      },
+      "market_demand_json": {
+        "raw": 85
+      },
+      "status": "published",
+      "is_public": true,
+      "is_indexable": true,
+      "published_at": null,
+      "scheduled_at": null,
+      "sort_order": 0,
+      "sections": [
+
+      ],
+      "seo_meta": {
+        "seo_title": null,
+        "seo_description": null,
+        "canonical_url": null,
+        "og_title": null,
+        "og_description": null,
+        "og_image_url": null,
+        "twitter_title": null,
+        "twitter_description": null,
+        "twitter_image_url": null,
+        "robots": null,
+        "jsonld_overrides_json": null
+      }
+    },
+    {
+      "job_code": "cloud-architect",
+      "slug": "cloud-architect",
+      "locale": "zh-CN",
+      "title": "云架构师",
+      "subtitle": null,
+      "excerpt": "面向云架构师的实用岗位画像，覆盖职责范围、能力要求、薪资区间与成长路径。",
+      "hero_kicker": null,
+      "hero_quote": null,
+      "cover_image_url": null,
+      "industry_slug": "technology",
+      "industry_label": null,
+      "body_md": "# 云架构师\n## 岗位概览\n云架构师 是一个通过执行质量、沟通精度与持续学习能力持续放大职业价值的岗位。\n\n## 核心工作范围\n该岗位通过把目标拆解为可落地任务、推进跨团队协同，并持续优化流程质量来影响业务结果。\n\n## 职业发展建议\n建议按 90 天为周期跟踪交付指标、能力增长和协作影响，每季度做一次基于证据的职业复盘并调整成长策略。\n",
+      "body_html": null,
+      "salary_json": {
+        "raw": "人民币 18万 - 90万/年（视城市与资历而定）"
+      },
+      "outlook_json": {
+        "summary": "云架构师 在数据化与精细化运营背景下仍保持较高需求。"
+      },
+      "skills_json": {
+        "core": [
+          "结构化问题解决",
+          "跨角色沟通",
+          "执行推进能力",
+          "数据驱动决策",
+          "持续学习能力"
+        ],
+        "supporting": [
+
+        ]
+      },
+      "work_contents_json": {
+        "items": [
+          "明确云架构师核心职责与交付指标。",
+          "协同跨团队角色并统一执行优先级。",
+          "跟踪进度、风险与质量信号，保障结果稳定交付。"
+        ]
+      },
+      "growth_path_json": {
+        "raw": [
+          "0-2 年：建立基础执行能力与行业认知。",
+          "3-5 年：独立负责中等复杂度项目并推进跨团队协作。",
+          "5 年以上：走向专家型负责人或管理型角色。"
+        ]
+      },
+      "fit_personality_codes_json": null,
+      "mbti_primary_codes_json": [
+        "INTJ",
+        "INTP",
+        "ENTJ"
+      ],
+      "mbti_secondary_codes_json": [
+        "ENTP",
+        "ISTJ",
+        "INFJ"
+      ],
+      "riasec_profile_json": {
+        "R": 55,
+        "I": 88,
+        "A": 48,
+        "S": 42,
+        "E": 50,
+        "C": 68
+      },
+      "big5_targets_json": {
+        "raw": {
+          "openness": {
+            "min": 40,
+            "max": 80
+          },
+          "conscientiousness": {
+            "min": 50,
+            "max": 90
+          },
+          "extraversion": {
+            "min": 35,
+            "max": 82
+          },
+          "agreeableness": {
+            "min": 35,
+            "max": 85
+          },
+          "neuroticism": {
+            "min": 10,
+            "max": 55
+          }
+        }
+      },
+      "iq_eq_notes_json": {
+        "iq_range": {
+          "min": 65,
+          "max": 100
+        },
+        "eq_range": {
+          "min": 45,
+          "max": 90
+        }
+      },
+      "market_demand_json": {
+        "raw": 92
+      },
+      "status": "published",
+      "is_public": true,
+      "is_indexable": true,
+      "published_at": null,
+      "scheduled_at": null,
+      "sort_order": 0,
+      "sections": [
+
+      ],
+      "seo_meta": {
+        "seo_title": null,
+        "seo_description": null,
+        "canonical_url": null,
+        "og_title": null,
+        "og_description": null,
+        "og_image_url": null,
+        "twitter_title": null,
+        "twitter_description": null,
+        "twitter_image_url": null,
+        "robots": null,
+        "jsonld_overrides_json": null
+      }
+    },
+    {
+      "job_code": "content-strategist",
+      "slug": "content-strategist",
+      "locale": "zh-CN",
+      "title": "内容策略师",
+      "subtitle": null,
+      "excerpt": "面向内容策略师的实用岗位画像，覆盖职责范围、能力要求、薪资区间与成长路径。",
+      "hero_kicker": null,
+      "hero_quote": null,
+      "cover_image_url": null,
+      "industry_slug": "media",
+      "industry_label": null,
+      "body_md": "# 内容策略师\n## 岗位概览\n内容策略师 是一个通过执行质量、沟通精度与持续学习能力持续放大职业价值的岗位。\n\n## 核心工作范围\n该岗位通过把目标拆解为可落地任务、推进跨团队协同，并持续优化流程质量来影响业务结果。\n\n## 职业发展建议\n建议按 90 天为周期跟踪交付指标、能力增长和协作影响，每季度做一次基于证据的职业复盘并调整成长策略。\n",
+      "body_html": null,
+      "salary_json": {
+        "raw": "人民币 18万 - 90万/年（视城市与资历而定）"
+      },
+      "outlook_json": {
+        "summary": "内容策略师 在数据化与精细化运营背景下仍保持较高需求。"
+      },
+      "skills_json": {
+        "core": [
+          "结构化问题解决",
+          "跨角色沟通",
+          "执行推进能力",
+          "数据驱动决策",
+          "持续学习能力"
+        ],
+        "supporting": [
+
+        ]
+      },
+      "work_contents_json": {
+        "items": [
+          "明确内容策略师核心职责与交付指标。",
+          "协同跨团队角色并统一执行优先级。",
+          "跟踪进度、风险与质量信号，保障结果稳定交付。"
+        ]
+      },
+      "growth_path_json": {
+        "raw": [
+          "0-2 年：建立基础执行能力与行业认知。",
+          "3-5 年：独立负责中等复杂度项目并推进跨团队协作。",
+          "5 年以上：走向专家型负责人或管理型角色。"
+        ]
+      },
+      "fit_personality_codes_json": null,
+      "mbti_primary_codes_json": [
+        "INFP",
+        "ENFP",
+        "ISFP"
+      ],
+      "mbti_secondary_codes_json": [
+        "INFJ",
+        "ENTP",
+        "ESFP"
+      ],
+      "riasec_profile_json": {
+        "R": 38,
+        "I": 62,
+        "A": 90,
+        "S": 54,
+        "E": 60,
+        "C": 44
+      },
+      "big5_targets_json": {
+        "raw": {
+          "openness": {
+            "min": 40,
+            "max": 80
+          },
+          "conscientiousness": {
+            "min": 50,
+            "max": 90
+          },
+          "extraversion": {
+            "min": 35,
+            "max": 82
+          },
+          "agreeableness": {
+            "min": 35,
+            "max": 85
+          },
+          "neuroticism": {
+            "min": 10,
+            "max": 55
+          }
+        }
+      },
+      "iq_eq_notes_json": {
+        "iq_range": {
+          "min": 45,
+          "max": 95
+        },
+        "eq_range": {
+          "min": 52,
+          "max": 96
+        }
+      },
+      "market_demand_json": {
+        "raw": 78
+      },
+      "status": "published",
+      "is_public": true,
+      "is_indexable": true,
+      "published_at": null,
+      "scheduled_at": null,
+      "sort_order": 0,
+      "sections": [
+
+      ],
+      "seo_meta": {
+        "seo_title": null,
+        "seo_description": null,
+        "canonical_url": null,
+        "og_title": null,
+        "og_description": null,
+        "og_image_url": null,
+        "twitter_title": null,
+        "twitter_description": null,
+        "twitter_image_url": null,
+        "robots": null,
+        "jsonld_overrides_json": null
+      }
+    },
+    {
+      "job_code": "cybersecurity-analyst",
+      "slug": "cybersecurity-analyst",
+      "locale": "zh-CN",
+      "title": "网络安全分析师",
+      "subtitle": null,
+      "excerpt": "面向网络安全分析师的实用岗位画像，覆盖职责范围、能力要求、薪资区间与成长路径。",
+      "hero_kicker": null,
+      "hero_quote": null,
+      "cover_image_url": null,
+      "industry_slug": "technology",
+      "industry_label": null,
+      "body_md": "# 网络安全分析师\n## 岗位概览\n网络安全分析师 是一个通过执行质量、沟通精度与持续学习能力持续放大职业价值的岗位。\n\n## 核心工作范围\n该岗位通过把目标拆解为可落地任务、推进跨团队协同，并持续优化流程质量来影响业务结果。\n\n## 职业发展建议\n建议按 90 天为周期跟踪交付指标、能力增长和协作影响，每季度做一次基于证据的职业复盘并调整成长策略。\n",
+      "body_html": null,
+      "salary_json": {
+        "raw": "人民币 18万 - 90万/年（视城市与资历而定）"
+      },
+      "outlook_json": {
+        "summary": "网络安全分析师 在数据化与精细化运营背景下仍保持较高需求。"
+      },
+      "skills_json": {
+        "core": [
+          "结构化问题解决",
+          "跨角色沟通",
+          "执行推进能力",
+          "数据驱动决策",
+          "持续学习能力"
+        ],
+        "supporting": [
+
+        ]
+      },
+      "work_contents_json": {
+        "items": [
+          "明确网络安全分析师核心职责与交付指标。",
+          "协同跨团队角色并统一执行优先级。",
+          "跟踪进度、风险与质量信号，保障结果稳定交付。"
+        ]
+      },
+      "growth_path_json": {
+        "raw": [
+          "0-2 年：建立基础执行能力与行业认知。",
+          "3-5 年：独立负责中等复杂度项目并推进跨团队协作。",
+          "5 年以上：走向专家型负责人或管理型角色。"
+        ]
+      },
+      "fit_personality_codes_json": null,
+      "mbti_primary_codes_json": [
+        "INTJ",
+        "INTP",
+        "ENTJ"
+      ],
+      "mbti_secondary_codes_json": [
+        "ENTP",
+        "ISTJ",
+        "INFJ"
+      ],
+      "riasec_profile_json": {
+        "R": 55,
+        "I": 88,
+        "A": 48,
+        "S": 42,
+        "E": 50,
+        "C": 68
+      },
+      "big5_targets_json": {
+        "raw": {
+          "openness": {
+            "min": 40,
+            "max": 80
+          },
+          "conscientiousness": {
+            "min": 50,
+            "max": 90
+          },
+          "extraversion": {
+            "min": 35,
+            "max": 82
+          },
+          "agreeableness": {
+            "min": 35,
+            "max": 85
+          },
+          "neuroticism": {
+            "min": 10,
+            "max": 55
+          }
+        }
+      },
+      "iq_eq_notes_json": {
+        "iq_range": {
+          "min": 65,
+          "max": 100
+        },
+        "eq_range": {
+          "min": 45,
+          "max": 90
+        }
+      },
+      "market_demand_json": {
+        "raw": 92
+      },
+      "status": "published",
+      "is_public": true,
+      "is_indexable": true,
+      "published_at": null,
+      "scheduled_at": null,
+      "sort_order": 0,
+      "sections": [
+
+      ],
+      "seo_meta": {
+        "seo_title": null,
+        "seo_description": null,
+        "canonical_url": null,
+        "og_title": null,
+        "og_description": null,
+        "og_image_url": null,
+        "twitter_title": null,
+        "twitter_description": null,
+        "twitter_image_url": null,
+        "robots": null,
+        "jsonld_overrides_json": null
+      }
+    },
+    {
+      "job_code": "data-analyst",
+      "slug": "data-analyst",
+      "locale": "zh-CN",
+      "title": "数据分析师",
+      "subtitle": null,
+      "excerpt": "面向数据分析师的实用岗位画像，覆盖职责范围、能力要求、薪资区间与成长路径。",
+      "hero_kicker": null,
+      "hero_quote": null,
+      "cover_image_url": null,
+      "industry_slug": "technology",
+      "industry_label": null,
+      "body_md": "# 数据分析师\n## 岗位概览\n数据分析师 是一个通过执行质量、沟通精度与持续学习能力持续放大职业价值的岗位。\n\n## 核心工作范围\n该岗位通过把目标拆解为可落地任务、推进跨团队协同，并持续优化流程质量来影响业务结果。\n\n## 职业发展建议\n建议按 90 天为周期跟踪交付指标、能力增长和协作影响，每季度做一次基于证据的职业复盘并调整成长策略。\n",
+      "body_html": null,
+      "salary_json": {
+        "raw": "人民币 18万 - 90万/年（视城市与资历而定）"
+      },
+      "outlook_json": {
+        "summary": "数据分析师 在数据化与精细化运营背景下仍保持较高需求。"
+      },
+      "skills_json": {
+        "core": [
+          "结构化问题解决",
+          "跨角色沟通",
+          "执行推进能力",
+          "数据驱动决策",
+          "持续学习能力"
+        ],
+        "supporting": [
+
+        ]
+      },
+      "work_contents_json": {
+        "items": [
+          "明确数据分析师核心职责与交付指标。",
+          "协同跨团队角色并统一执行优先级。",
+          "跟踪进度、风险与质量信号，保障结果稳定交付。"
+        ]
+      },
+      "growth_path_json": {
+        "raw": [
+          "0-2 年：建立基础执行能力与行业认知。",
+          "3-5 年：独立负责中等复杂度项目并推进跨团队协作。",
+          "5 年以上：走向专家型负责人或管理型角色。"
+        ]
+      },
+      "fit_personality_codes_json": null,
+      "mbti_primary_codes_json": [
+        "INTJ",
+        "INTP",
+        "ENTJ"
+      ],
+      "mbti_secondary_codes_json": [
+        "ENTP",
+        "ISTJ",
+        "INFJ"
+      ],
+      "riasec_profile_json": {
+        "R": 40,
+        "I": 90,
+        "A": 45,
+        "S": 38,
+        "E": 46,
+        "C": 72
+      },
+      "big5_targets_json": {
+        "raw": {
+          "openness": {
+            "min": 40,
+            "max": 80
+          },
+          "conscientiousness": {
+            "min": 50,
+            "max": 90
+          },
+          "extraversion": {
+            "min": 35,
+            "max": 82
+          },
+          "agreeableness": {
+            "min": 35,
+            "max": 85
+          },
+          "neuroticism": {
+            "min": 10,
+            "max": 55
+          }
+        }
+      },
+      "iq_eq_notes_json": {
+        "iq_range": {
+          "min": 62,
+          "max": 100
+        },
+        "eq_range": {
+          "min": 40,
+          "max": 86
+        }
+      },
+      "market_demand_json": {
+        "raw": 85
+      },
+      "status": "published",
+      "is_public": true,
+      "is_indexable": true,
+      "published_at": null,
+      "scheduled_at": null,
+      "sort_order": 0,
+      "sections": [
+
+      ],
+      "seo_meta": {
+        "seo_title": null,
+        "seo_description": null,
+        "canonical_url": null,
+        "og_title": null,
+        "og_description": null,
+        "og_image_url": null,
+        "twitter_title": null,
+        "twitter_description": null,
+        "twitter_image_url": null,
+        "robots": null,
+        "jsonld_overrides_json": null
+      }
+    },
+    {
+      "job_code": "data-scientist",
+      "slug": "data-scientist",
+      "locale": "zh-CN",
+      "title": "数据科学家",
+      "subtitle": null,
+      "excerpt": "面向数据科学家的实用岗位画像，覆盖职责范围、能力要求、薪资区间与成长路径。",
+      "hero_kicker": null,
+      "hero_quote": null,
+      "cover_image_url": null,
+      "industry_slug": "technology",
+      "industry_label": null,
+      "body_md": "# 数据科学家\n## 岗位概览\n数据科学家 是一个通过执行质量、沟通精度与持续学习能力持续放大职业价值的岗位。\n\n## 核心工作范围\n该岗位通过把目标拆解为可落地任务、推进跨团队协同，并持续优化流程质量来影响业务结果。\n\n## 职业发展建议\n建议按 90 天为周期跟踪交付指标、能力增长和协作影响，每季度做一次基于证据的职业复盘并调整成长策略。\n",
+      "body_html": null,
+      "salary_json": {
+        "raw": "人民币 18万 - 90万/年（视城市与资历而定）"
+      },
+      "outlook_json": {
+        "summary": "数据科学家 在数据化与精细化运营背景下仍保持较高需求。"
+      },
+      "skills_json": {
+        "core": [
+          "结构化问题解决",
+          "跨角色沟通",
+          "执行推进能力",
+          "数据驱动决策",
+          "持续学习能力"
+        ],
+        "supporting": [
+
+        ]
+      },
+      "work_contents_json": {
+        "items": [
+          "明确数据科学家核心职责与交付指标。",
+          "协同跨团队角色并统一执行优先级。",
+          "跟踪进度、风险与质量信号，保障结果稳定交付。"
+        ]
+      },
+      "growth_path_json": {
+        "raw": [
+          "0-2 年：建立基础执行能力与行业认知。",
+          "3-5 年：独立负责中等复杂度项目并推进跨团队协作。",
+          "5 年以上：走向专家型负责人或管理型角色。"
+        ]
+      },
+      "fit_personality_codes_json": null,
+      "mbti_primary_codes_json": [
+        "INTJ",
+        "INTP",
+        "ENTJ"
+      ],
+      "mbti_secondary_codes_json": [
+        "ENTP",
+        "ISTJ",
+        "INFJ"
+      ],
+      "riasec_profile_json": {
+        "R": 40,
+        "I": 90,
+        "A": 45,
+        "S": 38,
+        "E": 46,
+        "C": 72
+      },
+      "big5_targets_json": {
+        "raw": {
+          "openness": {
+            "min": 40,
+            "max": 80
+          },
+          "conscientiousness": {
+            "min": 50,
+            "max": 90
+          },
+          "extraversion": {
+            "min": 35,
+            "max": 82
+          },
+          "agreeableness": {
+            "min": 35,
+            "max": 85
+          },
+          "neuroticism": {
+            "min": 10,
+            "max": 55
+          }
+        }
+      },
+      "iq_eq_notes_json": {
+        "iq_range": {
+          "min": 62,
+          "max": 100
+        },
+        "eq_range": {
+          "min": 40,
+          "max": 86
+        }
+      },
+      "market_demand_json": {
+        "raw": 85
+      },
+      "status": "published",
+      "is_public": true,
+      "is_indexable": true,
+      "published_at": null,
+      "scheduled_at": null,
+      "sort_order": 0,
+      "sections": [
+
+      ],
+      "seo_meta": {
+        "seo_title": null,
+        "seo_description": null,
+        "canonical_url": null,
+        "og_title": null,
+        "og_description": null,
+        "og_image_url": null,
+        "twitter_title": null,
+        "twitter_description": null,
+        "twitter_image_url": null,
+        "robots": null,
+        "jsonld_overrides_json": null
+      }
+    },
+    {
+      "job_code": "digital-marketing-manager",
+      "slug": "digital-marketing-manager",
+      "locale": "zh-CN",
+      "title": "数字营销经理",
+      "subtitle": null,
+      "excerpt": "面向数字营销经理的实用岗位画像，覆盖职责范围、能力要求、薪资区间与成长路径。",
+      "hero_kicker": null,
+      "hero_quote": null,
+      "cover_image_url": null,
+      "industry_slug": "media",
+      "industry_label": null,
+      "body_md": "# 数字营销经理\n## 岗位概览\n数字营销经理 是一个通过执行质量、沟通精度与持续学习能力持续放大职业价值的岗位。\n\n## 核心工作范围\n该岗位通过把目标拆解为可落地任务、推进跨团队协同，并持续优化流程质量来影响业务结果。\n\n## 职业发展建议\n建议按 90 天为周期跟踪交付指标、能力增长和协作影响，每季度做一次基于证据的职业复盘并调整成长策略。\n",
+      "body_html": null,
+      "salary_json": {
+        "raw": "人民币 18万 - 90万/年（视城市与资历而定）"
+      },
+      "outlook_json": {
+        "summary": "数字营销经理 在数据化与精细化运营背景下仍保持较高需求。"
+      },
+      "skills_json": {
+        "core": [
+          "结构化问题解决",
+          "跨角色沟通",
+          "执行推进能力",
+          "数据驱动决策",
+          "持续学习能力"
+        ],
+        "supporting": [
+
+        ]
+      },
+      "work_contents_json": {
+        "items": [
+          "明确数字营销经理核心职责与交付指标。",
+          "协同跨团队角色并统一执行优先级。",
+          "跟踪进度、风险与质量信号，保障结果稳定交付。"
+        ]
+      },
+      "growth_path_json": {
+        "raw": [
+          "0-2 年：建立基础执行能力与行业认知。",
+          "3-5 年：独立负责中等复杂度项目并推进跨团队协作。",
+          "5 年以上：走向专家型负责人或管理型角色。"
+        ]
+      },
+      "fit_personality_codes_json": null,
+      "mbti_primary_codes_json": [
+        "ENTJ",
+        "ENFJ",
+        "ESTP"
+      ],
+      "mbti_secondary_codes_json": [
+        "ENFP",
+        "ESTJ",
+        "ENTP"
+      ],
+      "riasec_profile_json": {
+        "R": 42,
+        "I": 66,
+        "A": 56,
+        "S": 60,
+        "E": 88,
+        "C": 70
+      },
+      "big5_targets_json": {
+        "raw": {
+          "openness": {
+            "min": 40,
+            "max": 80
+          },
+          "conscientiousness": {
+            "min": 50,
+            "max": 90
+          },
+          "extraversion": {
+            "min": 35,
+            "max": 82
+          },
+          "agreeableness": {
+            "min": 35,
+            "max": 85
+          },
+          "neuroticism": {
+            "min": 10,
+            "max": 55
+          }
+        }
+      },
+      "iq_eq_notes_json": {
+        "iq_range": {
+          "min": 50,
+          "max": 98
+        },
+        "eq_range": {
+          "min": 55,
+          "max": 100
+        }
+      },
+      "market_demand_json": {
+        "raw": 82
+      },
+      "status": "published",
+      "is_public": true,
+      "is_indexable": true,
+      "published_at": null,
+      "scheduled_at": null,
+      "sort_order": 0,
+      "sections": [
+
+      ],
+      "seo_meta": {
+        "seo_title": null,
+        "seo_description": null,
+        "canonical_url": null,
+        "og_title": null,
+        "og_description": null,
+        "og_image_url": null,
+        "twitter_title": null,
+        "twitter_description": null,
+        "twitter_image_url": null,
+        "robots": null,
+        "jsonld_overrides_json": null
+      }
+    },
+    {
+      "job_code": "financial-planner",
+      "slug": "financial-planner",
+      "locale": "zh-CN",
+      "title": "财务规划师",
+      "subtitle": null,
+      "excerpt": "面向财务规划师的实用岗位画像，覆盖职责范围、能力要求、薪资区间与成长路径。",
+      "hero_kicker": null,
+      "hero_quote": null,
+      "cover_image_url": null,
+      "industry_slug": "finance",
+      "industry_label": null,
+      "body_md": "# 财务规划师\n## 岗位概览\n财务规划师 是一个通过执行质量、沟通精度与持续学习能力持续放大职业价值的岗位。\n\n## 核心工作范围\n该岗位通过把目标拆解为可落地任务、推进跨团队协同，并持续优化流程质量来影响业务结果。\n\n## 职业发展建议\n建议按 90 天为周期跟踪交付指标、能力增长和协作影响，每季度做一次基于证据的职业复盘并调整成长策略。\n",
+      "body_html": null,
+      "salary_json": {
+        "raw": "人民币 18万 - 90万/年（视城市与资历而定）"
+      },
+      "outlook_json": {
+        "summary": "财务规划师 在数据化与精细化运营背景下仍保持较高需求。"
+      },
+      "skills_json": {
+        "core": [
+          "结构化问题解决",
+          "跨角色沟通",
+          "执行推进能力",
+          "数据驱动决策",
+          "持续学习能力"
+        ],
+        "supporting": [
+
+        ]
+      },
+      "work_contents_json": {
+        "items": [
+          "明确财务规划师核心职责与交付指标。",
+          "协同跨团队角色并统一执行优先级。",
+          "跟踪进度、风险与质量信号，保障结果稳定交付。"
+        ]
+      },
+      "growth_path_json": {
+        "raw": [
+          "0-2 年：建立基础执行能力与行业认知。",
+          "3-5 年：独立负责中等复杂度项目并推进跨团队协作。",
+          "5 年以上：走向专家型负责人或管理型角色。"
+        ]
+      },
+      "fit_personality_codes_json": null,
+      "mbti_primary_codes_json": [
+        "ESTJ",
+        "ISTJ",
+        "ESFJ"
+      ],
+      "mbti_secondary_codes_json": [
+        "ISFJ",
+        "ENTJ",
+        "ESTP"
+      ],
+      "riasec_profile_json": {
+        "R": 52,
+        "I": 60,
+        "A": 36,
+        "S": 52,
+        "E": 70,
+        "C": 90
+      },
+      "big5_targets_json": {
+        "raw": {
+          "openness": {
+            "min": 40,
+            "max": 80
+          },
+          "conscientiousness": {
+            "min": 50,
+            "max": 90
+          },
+          "extraversion": {
+            "min": 35,
+            "max": 82
+          },
+          "agreeableness": {
+            "min": 35,
+            "max": 85
+          },
+          "neuroticism": {
+            "min": 10,
+            "max": 55
+          }
+        }
+      },
+      "iq_eq_notes_json": {
+        "iq_range": {
+          "min": 48,
+          "max": 95
+        },
+        "eq_range": {
+          "min": 48,
+          "max": 92
+        }
+      },
+      "market_demand_json": {
+        "raw": 74
+      },
+      "status": "published",
+      "is_public": true,
+      "is_indexable": true,
+      "published_at": null,
+      "scheduled_at": null,
+      "sort_order": 0,
+      "sections": [
+
+      ],
+      "seo_meta": {
+        "seo_title": null,
+        "seo_description": null,
+        "canonical_url": null,
+        "og_title": null,
+        "og_description": null,
+        "og_image_url": null,
+        "twitter_title": null,
+        "twitter_description": null,
+        "twitter_image_url": null,
+        "robots": null,
+        "jsonld_overrides_json": null
+      }
+    },
+    {
+      "job_code": "frontend-engineer",
+      "slug": "frontend-engineer",
+      "locale": "zh-CN",
+      "title": "前端工程师",
+      "subtitle": null,
+      "excerpt": "面向前端工程师的实用岗位画像，覆盖职责范围、能力要求、薪资区间与成长路径。",
+      "hero_kicker": null,
+      "hero_quote": null,
+      "cover_image_url": null,
+      "industry_slug": "technology",
+      "industry_label": null,
+      "body_md": "# 前端工程师\n## 岗位概览\n前端工程师 是一个通过执行质量、沟通精度与持续学习能力持续放大职业价值的岗位。\n\n## 核心工作范围\n该岗位通过把目标拆解为可落地任务、推进跨团队协同，并持续优化流程质量来影响业务结果。\n\n## 职业发展建议\n建议按 90 天为周期跟踪交付指标、能力增长和协作影响，每季度做一次基于证据的职业复盘并调整成长策略。\n",
+      "body_html": null,
+      "salary_json": {
+        "raw": "人民币 18万 - 90万/年（视城市与资历而定）"
+      },
+      "outlook_json": {
+        "summary": "前端工程师 在数据化与精细化运营背景下仍保持较高需求。"
+      },
+      "skills_json": {
+        "core": [
+          "结构化问题解决",
+          "跨角色沟通",
+          "执行推进能力",
+          "数据驱动决策",
+          "持续学习能力"
+        ],
+        "supporting": [
+
+        ]
+      },
+      "work_contents_json": {
+        "items": [
+          "明确前端工程师核心职责与交付指标。",
+          "协同跨团队角色并统一执行优先级。",
+          "跟踪进度、风险与质量信号，保障结果稳定交付。"
+        ]
+      },
+      "growth_path_json": {
+        "raw": [
+          "0-2 年：建立基础执行能力与行业认知。",
+          "3-5 年：独立负责中等复杂度项目并推进跨团队协作。",
+          "5 年以上：走向专家型负责人或管理型角色。"
+        ]
+      },
+      "fit_personality_codes_json": null,
+      "mbti_primary_codes_json": [
+        "INTJ",
+        "INTP",
+        "ENTJ"
+      ],
+      "mbti_secondary_codes_json": [
+        "ENTP",
+        "ISTJ",
+        "INFJ"
+      ],
+      "riasec_profile_json": {
+        "R": 55,
+        "I": 88,
+        "A": 48,
+        "S": 42,
+        "E": 50,
+        "C": 68
+      },
+      "big5_targets_json": {
+        "raw": {
+          "openness": {
+            "min": 40,
+            "max": 80
+          },
+          "conscientiousness": {
+            "min": 50,
+            "max": 90
+          },
+          "extraversion": {
+            "min": 35,
+            "max": 82
+          },
+          "agreeableness": {
+            "min": 35,
+            "max": 85
+          },
+          "neuroticism": {
+            "min": 10,
+            "max": 55
+          }
+        }
+      },
+      "iq_eq_notes_json": {
+        "iq_range": {
+          "min": 65,
+          "max": 100
+        },
+        "eq_range": {
+          "min": 45,
+          "max": 90
+        }
+      },
+      "market_demand_json": {
+        "raw": 92
+      },
+      "status": "published",
+      "is_public": true,
+      "is_indexable": true,
+      "published_at": null,
+      "scheduled_at": null,
+      "sort_order": 0,
+      "sections": [
+
+      ],
+      "seo_meta": {
+        "seo_title": null,
+        "seo_description": null,
+        "canonical_url": null,
+        "og_title": null,
+        "og_description": null,
+        "og_image_url": null,
+        "twitter_title": null,
+        "twitter_description": null,
+        "twitter_image_url": null,
+        "robots": null,
+        "jsonld_overrides_json": null
+      }
+    },
+    {
+      "job_code": "fullstack-engineer",
+      "slug": "fullstack-engineer",
+      "locale": "zh-CN",
+      "title": "全栈工程师",
+      "subtitle": null,
+      "excerpt": "面向全栈工程师的实用岗位画像，覆盖职责范围、能力要求、薪资区间与成长路径。",
+      "hero_kicker": null,
+      "hero_quote": null,
+      "cover_image_url": null,
+      "industry_slug": "technology",
+      "industry_label": null,
+      "body_md": "# 全栈工程师\n## 岗位概览\n全栈工程师 是一个通过执行质量、沟通精度与持续学习能力持续放大职业价值的岗位。\n\n## 核心工作范围\n该岗位通过把目标拆解为可落地任务、推进跨团队协同，并持续优化流程质量来影响业务结果。\n\n## 职业发展建议\n建议按 90 天为周期跟踪交付指标、能力增长和协作影响，每季度做一次基于证据的职业复盘并调整成长策略。\n",
+      "body_html": null,
+      "salary_json": {
+        "raw": "人民币 18万 - 90万/年（视城市与资历而定）"
+      },
+      "outlook_json": {
+        "summary": "全栈工程师 在数据化与精细化运营背景下仍保持较高需求。"
+      },
+      "skills_json": {
+        "core": [
+          "结构化问题解决",
+          "跨角色沟通",
+          "执行推进能力",
+          "数据驱动决策",
+          "持续学习能力"
+        ],
+        "supporting": [
+
+        ]
+      },
+      "work_contents_json": {
+        "items": [
+          "明确全栈工程师核心职责与交付指标。",
+          "协同跨团队角色并统一执行优先级。",
+          "跟踪进度、风险与质量信号，保障结果稳定交付。"
+        ]
+      },
+      "growth_path_json": {
+        "raw": [
+          "0-2 年：建立基础执行能力与行业认知。",
+          "3-5 年：独立负责中等复杂度项目并推进跨团队协作。",
+          "5 年以上：走向专家型负责人或管理型角色。"
+        ]
+      },
+      "fit_personality_codes_json": null,
+      "mbti_primary_codes_json": [
+        "INTJ",
+        "INTP",
+        "ENTJ"
+      ],
+      "mbti_secondary_codes_json": [
+        "ENTP",
+        "ISTJ",
+        "INFJ"
+      ],
+      "riasec_profile_json": {
+        "R": 55,
+        "I": 88,
+        "A": 48,
+        "S": 42,
+        "E": 50,
+        "C": 68
+      },
+      "big5_targets_json": {
+        "raw": {
+          "openness": {
+            "min": 40,
+            "max": 80
+          },
+          "conscientiousness": {
+            "min": 50,
+            "max": 90
+          },
+          "extraversion": {
+            "min": 35,
+            "max": 82
+          },
+          "agreeableness": {
+            "min": 35,
+            "max": 85
+          },
+          "neuroticism": {
+            "min": 10,
+            "max": 55
+          }
+        }
+      },
+      "iq_eq_notes_json": {
+        "iq_range": {
+          "min": 65,
+          "max": 100
+        },
+        "eq_range": {
+          "min": 45,
+          "max": 90
+        }
+      },
+      "market_demand_json": {
+        "raw": 92
+      },
+      "status": "published",
+      "is_public": true,
+      "is_indexable": true,
+      "published_at": null,
+      "scheduled_at": null,
+      "sort_order": 0,
+      "sections": [
+
+      ],
+      "seo_meta": {
+        "seo_title": null,
+        "seo_description": null,
+        "canonical_url": null,
+        "og_title": null,
+        "og_description": null,
+        "og_image_url": null,
+        "twitter_title": null,
+        "twitter_description": null,
+        "twitter_image_url": null,
+        "robots": null,
+        "jsonld_overrides_json": null
+      }
+    },
+    {
+      "job_code": "hr-business-partner",
+      "slug": "hr-business-partner",
+      "locale": "zh-CN",
+      "title": "HRBP",
+      "subtitle": null,
+      "excerpt": "面向HRBP的实用岗位画像，覆盖职责范围、能力要求、薪资区间与成长路径。",
+      "hero_kicker": null,
+      "hero_quote": null,
+      "cover_image_url": null,
+      "industry_slug": "business",
+      "industry_label": null,
+      "body_md": "# HRBP\n## 岗位概览\nHRBP 是一个通过执行质量、沟通精度与持续学习能力持续放大职业价值的岗位。\n\n## 核心工作范围\n该岗位通过把目标拆解为可落地任务、推进跨团队协同，并持续优化流程质量来影响业务结果。\n\n## 职业发展建议\n建议按 90 天为周期跟踪交付指标、能力增长和协作影响，每季度做一次基于证据的职业复盘并调整成长策略。\n",
+      "body_html": null,
+      "salary_json": {
+        "raw": "人民币 18万 - 90万/年（视城市与资历而定）"
+      },
+      "outlook_json": {
+        "summary": "HRBP 在数据化与精细化运营背景下仍保持较高需求。"
+      },
+      "skills_json": {
+        "core": [
+          "结构化问题解决",
+          "跨角色沟通",
+          "执行推进能力",
+          "数据驱动决策",
+          "持续学习能力"
+        ],
+        "supporting": [
+
+        ]
+      },
+      "work_contents_json": {
+        "items": [
+          "明确HRBP核心职责与交付指标。",
+          "协同跨团队角色并统一执行优先级。",
+          "跟踪进度、风险与质量信号，保障结果稳定交付。"
+        ]
+      },
+      "growth_path_json": {
+        "raw": [
+          "0-2 年：建立基础执行能力与行业认知。",
+          "3-5 年：独立负责中等复杂度项目并推进跨团队协作。",
+          "5 年以上：走向专家型负责人或管理型角色。"
+        ]
+      },
+      "fit_personality_codes_json": null,
+      "mbti_primary_codes_json": [
+        "ENTJ",
+        "ENFJ",
+        "ESTP"
+      ],
+      "mbti_secondary_codes_json": [
+        "ENFP",
+        "ESTJ",
+        "ENTP"
+      ],
+      "riasec_profile_json": {
+        "R": 42,
+        "I": 66,
+        "A": 56,
+        "S": 60,
+        "E": 88,
+        "C": 70
+      },
+      "big5_targets_json": {
+        "raw": {
+          "openness": {
+            "min": 40,
+            "max": 80
+          },
+          "conscientiousness": {
+            "min": 50,
+            "max": 90
+          },
+          "extraversion": {
+            "min": 35,
+            "max": 82
+          },
+          "agreeableness": {
+            "min": 35,
+            "max": 85
+          },
+          "neuroticism": {
+            "min": 10,
+            "max": 55
+          }
+        }
+      },
+      "iq_eq_notes_json": {
+        "iq_range": {
+          "min": 50,
+          "max": 98
+        },
+        "eq_range": {
+          "min": 55,
+          "max": 100
+        }
+      },
+      "market_demand_json": {
+        "raw": 82
+      },
+      "status": "published",
+      "is_public": true,
+      "is_indexable": true,
+      "published_at": null,
+      "scheduled_at": null,
+      "sort_order": 0,
+      "sections": [
+
+      ],
+      "seo_meta": {
+        "seo_title": null,
+        "seo_description": null,
+        "canonical_url": null,
+        "og_title": null,
+        "og_description": null,
+        "og_image_url": null,
+        "twitter_title": null,
+        "twitter_description": null,
+        "twitter_image_url": null,
+        "robots": null,
+        "jsonld_overrides_json": null
+      }
+    },
+    {
+      "job_code": "investment-analyst",
+      "slug": "investment-analyst",
+      "locale": "zh-CN",
+      "title": "投资分析师",
+      "subtitle": null,
+      "excerpt": "面向投资分析师的实用岗位画像，覆盖职责范围、能力要求、薪资区间与成长路径。",
+      "hero_kicker": null,
+      "hero_quote": null,
+      "cover_image_url": null,
+      "industry_slug": "finance",
+      "industry_label": null,
+      "body_md": "# 投资分析师\n## 岗位概览\n投资分析师 是一个通过执行质量、沟通精度与持续学习能力持续放大职业价值的岗位。\n\n## 核心工作范围\n该岗位通过把目标拆解为可落地任务、推进跨团队协同，并持续优化流程质量来影响业务结果。\n\n## 职业发展建议\n建议按 90 天为周期跟踪交付指标、能力增长和协作影响，每季度做一次基于证据的职业复盘并调整成长策略。\n",
+      "body_html": null,
+      "salary_json": {
+        "raw": "人民币 18万 - 90万/年（视城市与资历而定）"
+      },
+      "outlook_json": {
+        "summary": "投资分析师 在数据化与精细化运营背景下仍保持较高需求。"
+      },
+      "skills_json": {
+        "core": [
+          "结构化问题解决",
+          "跨角色沟通",
+          "执行推进能力",
+          "数据驱动决策",
+          "持续学习能力"
+        ],
+        "supporting": [
+
+        ]
+      },
+      "work_contents_json": {
+        "items": [
+          "明确投资分析师核心职责与交付指标。",
+          "协同跨团队角色并统一执行优先级。",
+          "跟踪进度、风险与质量信号，保障结果稳定交付。"
+        ]
+      },
+      "growth_path_json": {
+        "raw": [
+          "0-2 年：建立基础执行能力与行业认知。",
+          "3-5 年：独立负责中等复杂度项目并推进跨团队协作。",
+          "5 年以上：走向专家型负责人或管理型角色。"
+        ]
+      },
+      "fit_personality_codes_json": null,
+      "mbti_primary_codes_json": [
+        "INTJ",
+        "INTP",
+        "ENTJ"
+      ],
+      "mbti_secondary_codes_json": [
+        "ENTP",
+        "ISTJ",
+        "INFJ"
+      ],
+      "riasec_profile_json": {
+        "R": 40,
+        "I": 90,
+        "A": 45,
+        "S": 38,
+        "E": 46,
+        "C": 72
+      },
+      "big5_targets_json": {
+        "raw": {
+          "openness": {
+            "min": 40,
+            "max": 80
+          },
+          "conscientiousness": {
+            "min": 50,
+            "max": 90
+          },
+          "extraversion": {
+            "min": 35,
+            "max": 82
+          },
+          "agreeableness": {
+            "min": 35,
+            "max": 85
+          },
+          "neuroticism": {
+            "min": 10,
+            "max": 55
+          }
+        }
+      },
+      "iq_eq_notes_json": {
+        "iq_range": {
+          "min": 62,
+          "max": 100
+        },
+        "eq_range": {
+          "min": 40,
+          "max": 86
+        }
+      },
+      "market_demand_json": {
+        "raw": 85
+      },
+      "status": "published",
+      "is_public": true,
+      "is_indexable": true,
+      "published_at": null,
+      "scheduled_at": null,
+      "sort_order": 0,
+      "sections": [
+
+      ],
+      "seo_meta": {
+        "seo_title": null,
+        "seo_description": null,
+        "canonical_url": null,
+        "og_title": null,
+        "og_description": null,
+        "og_image_url": null,
+        "twitter_title": null,
+        "twitter_description": null,
+        "twitter_image_url": null,
+        "robots": null,
+        "jsonld_overrides_json": null
+      }
+    },
+    {
+      "job_code": "lawyer",
+      "slug": "lawyer",
+      "locale": "zh-CN",
+      "title": "律师",
+      "subtitle": null,
+      "excerpt": "面向律师的实用岗位画像，覆盖职责范围、能力要求、薪资区间与成长路径。",
+      "hero_kicker": null,
+      "hero_quote": null,
+      "cover_image_url": null,
+      "industry_slug": "legal",
+      "industry_label": null,
+      "body_md": "# 律师\n## 岗位概览\n律师 是一个通过执行质量、沟通精度与持续学习能力持续放大职业价值的岗位。\n\n## 核心工作范围\n该岗位通过把目标拆解为可落地任务、推进跨团队协同，并持续优化流程质量来影响业务结果。\n\n## 职业发展建议\n建议按 90 天为周期跟踪交付指标、能力增长和协作影响，每季度做一次基于证据的职业复盘并调整成长策略。\n",
+      "body_html": null,
+      "salary_json": {
+        "raw": "人民币 18万 - 90万/年（视城市与资历而定）"
+      },
+      "outlook_json": {
+        "summary": "律师 在数据化与精细化运营背景下仍保持较高需求。"
+      },
+      "skills_json": {
+        "core": [
+          "结构化问题解决",
+          "跨角色沟通",
+          "执行推进能力",
+          "数据驱动决策",
+          "持续学习能力"
+        ],
+        "supporting": [
+
+        ]
+      },
+      "work_contents_json": {
+        "items": [
+          "明确律师核心职责与交付指标。",
+          "协同跨团队角色并统一执行优先级。",
+          "跟踪进度、风险与质量信号，保障结果稳定交付。"
+        ]
+      },
+      "growth_path_json": {
+        "raw": [
+          "0-2 年：建立基础执行能力与行业认知。",
+          "3-5 年：独立负责中等复杂度项目并推进跨团队协作。",
+          "5 年以上：走向专家型负责人或管理型角色。"
+        ]
+      },
+      "fit_personality_codes_json": null,
+      "mbti_primary_codes_json": [
+        "ESTJ",
+        "ISTJ",
+        "ESFJ"
+      ],
+      "mbti_secondary_codes_json": [
+        "ISFJ",
+        "ENTJ",
+        "ESTP"
+      ],
+      "riasec_profile_json": {
+        "R": 33,
+        "I": 80,
+        "A": 40,
+        "S": 47,
+        "E": 52,
+        "C": 90
+      },
+      "big5_targets_json": {
+        "raw": {
+          "openness": {
+            "min": 40,
+            "max": 80
+          },
+          "conscientiousness": {
+            "min": 50,
+            "max": 90
+          },
+          "extraversion": {
+            "min": 35,
+            "max": 82
+          },
+          "agreeableness": {
+            "min": 35,
+            "max": 85
+          },
+          "neuroticism": {
+            "min": 10,
+            "max": 55
+          }
+        }
+      },
+      "iq_eq_notes_json": {
+        "iq_range": {
+          "min": 62,
+          "max": 100
+        },
+        "eq_range": {
+          "min": 52,
+          "max": 95
+        }
+      },
+      "market_demand_json": {
+        "raw": 70
+      },
+      "status": "published",
+      "is_public": true,
+      "is_indexable": true,
+      "published_at": null,
+      "scheduled_at": null,
+      "sort_order": 0,
+      "sections": [
+
+      ],
+      "seo_meta": {
+        "seo_title": null,
+        "seo_description": null,
+        "canonical_url": null,
+        "og_title": null,
+        "og_description": null,
+        "og_image_url": null,
+        "twitter_title": null,
+        "twitter_description": null,
+        "twitter_image_url": null,
+        "robots": null,
+        "jsonld_overrides_json": null
+      }
+    },
+    {
+      "job_code": "machine-learning-engineer",
+      "slug": "machine-learning-engineer",
+      "locale": "zh-CN",
+      "title": "机器学习工程师",
+      "subtitle": null,
+      "excerpt": "面向机器学习工程师的实用岗位画像，覆盖职责范围、能力要求、薪资区间与成长路径。",
+      "hero_kicker": null,
+      "hero_quote": null,
+      "cover_image_url": null,
+      "industry_slug": "technology",
+      "industry_label": null,
+      "body_md": "# 机器学习工程师\n## 岗位概览\n机器学习工程师 是一个通过执行质量、沟通精度与持续学习能力持续放大职业价值的岗位。\n\n## 核心工作范围\n该岗位通过把目标拆解为可落地任务、推进跨团队协同，并持续优化流程质量来影响业务结果。\n\n## 职业发展建议\n建议按 90 天为周期跟踪交付指标、能力增长和协作影响，每季度做一次基于证据的职业复盘并调整成长策略。\n",
+      "body_html": null,
+      "salary_json": {
+        "raw": "人民币 18万 - 90万/年（视城市与资历而定）"
+      },
+      "outlook_json": {
+        "summary": "机器学习工程师 在数据化与精细化运营背景下仍保持较高需求。"
+      },
+      "skills_json": {
+        "core": [
+          "结构化问题解决",
+          "跨角色沟通",
+          "执行推进能力",
+          "数据驱动决策",
+          "持续学习能力"
+        ],
+        "supporting": [
+
+        ]
+      },
+      "work_contents_json": {
+        "items": [
+          "明确机器学习工程师核心职责与交付指标。",
+          "协同跨团队角色并统一执行优先级。",
+          "跟踪进度、风险与质量信号，保障结果稳定交付。"
+        ]
+      },
+      "growth_path_json": {
+        "raw": [
+          "0-2 年：建立基础执行能力与行业认知。",
+          "3-5 年：独立负责中等复杂度项目并推进跨团队协作。",
+          "5 年以上：走向专家型负责人或管理型角色。"
+        ]
+      },
+      "fit_personality_codes_json": null,
+      "mbti_primary_codes_json": [
+        "INTJ",
+        "INTP",
+        "ENTJ"
+      ],
+      "mbti_secondary_codes_json": [
+        "ENTP",
+        "ISTJ",
+        "INFJ"
+      ],
+      "riasec_profile_json": {
+        "R": 55,
+        "I": 88,
+        "A": 48,
+        "S": 42,
+        "E": 50,
+        "C": 68
+      },
+      "big5_targets_json": {
+        "raw": {
+          "openness": {
+            "min": 40,
+            "max": 80
+          },
+          "conscientiousness": {
+            "min": 50,
+            "max": 90
+          },
+          "extraversion": {
+            "min": 35,
+            "max": 82
+          },
+          "agreeableness": {
+            "min": 35,
+            "max": 85
+          },
+          "neuroticism": {
+            "min": 10,
+            "max": 55
+          }
+        }
+      },
+      "iq_eq_notes_json": {
+        "iq_range": {
+          "min": 65,
+          "max": 100
+        },
+        "eq_range": {
+          "min": 45,
+          "max": 90
+        }
+      },
+      "market_demand_json": {
+        "raw": 92
+      },
+      "status": "published",
+      "is_public": true,
+      "is_indexable": true,
+      "published_at": null,
+      "scheduled_at": null,
+      "sort_order": 0,
+      "sections": [
+
+      ],
+      "seo_meta": {
+        "seo_title": null,
+        "seo_description": null,
+        "canonical_url": null,
+        "og_title": null,
+        "og_description": null,
+        "og_image_url": null,
+        "twitter_title": null,
+        "twitter_description": null,
+        "twitter_image_url": null,
+        "robots": null,
+        "jsonld_overrides_json": null
+      }
+    },
+    {
+      "job_code": "management-consultant",
+      "slug": "management-consultant",
+      "locale": "zh-CN",
+      "title": "管理咨询顾问",
+      "subtitle": null,
+      "excerpt": "面向管理咨询顾问的实用岗位画像，覆盖职责范围、能力要求、薪资区间与成长路径。",
+      "hero_kicker": null,
+      "hero_quote": null,
+      "cover_image_url": null,
+      "industry_slug": "consulting",
+      "industry_label": null,
+      "body_md": "# 管理咨询顾问\n## 岗位概览\n管理咨询顾问 是一个通过执行质量、沟通精度与持续学习能力持续放大职业价值的岗位。\n\n## 核心工作范围\n该岗位通过把目标拆解为可落地任务、推进跨团队协同，并持续优化流程质量来影响业务结果。\n\n## 职业发展建议\n建议按 90 天为周期跟踪交付指标、能力增长和协作影响，每季度做一次基于证据的职业复盘并调整成长策略。\n",
+      "body_html": null,
+      "salary_json": {
+        "raw": "人民币 18万 - 90万/年（视城市与资历而定）"
+      },
+      "outlook_json": {
+        "summary": "管理咨询顾问 在数据化与精细化运营背景下仍保持较高需求。"
+      },
+      "skills_json": {
+        "core": [
+          "结构化问题解决",
+          "跨角色沟通",
+          "执行推进能力",
+          "数据驱动决策",
+          "持续学习能力"
+        ],
+        "supporting": [
+
+        ]
+      },
+      "work_contents_json": {
+        "items": [
+          "明确管理咨询顾问核心职责与交付指标。",
+          "协同跨团队角色并统一执行优先级。",
+          "跟踪进度、风险与质量信号，保障结果稳定交付。"
+        ]
+      },
+      "growth_path_json": {
+        "raw": [
+          "0-2 年：建立基础执行能力与行业认知。",
+          "3-5 年：独立负责中等复杂度项目并推进跨团队协作。",
+          "5 年以上：走向专家型负责人或管理型角色。"
+        ]
+      },
+      "fit_personality_codes_json": null,
+      "mbti_primary_codes_json": [
+        "ENTJ",
+        "ENFJ",
+        "ESTP"
+      ],
+      "mbti_secondary_codes_json": [
+        "ENFP",
+        "ESTJ",
+        "ENTP"
+      ],
+      "riasec_profile_json": {
+        "R": 42,
+        "I": 66,
+        "A": 56,
+        "S": 60,
+        "E": 88,
+        "C": 70
+      },
+      "big5_targets_json": {
+        "raw": {
+          "openness": {
+            "min": 40,
+            "max": 80
+          },
+          "conscientiousness": {
+            "min": 50,
+            "max": 90
+          },
+          "extraversion": {
+            "min": 35,
+            "max": 82
+          },
+          "agreeableness": {
+            "min": 35,
+            "max": 85
+          },
+          "neuroticism": {
+            "min": 10,
+            "max": 55
+          }
+        }
+      },
+      "iq_eq_notes_json": {
+        "iq_range": {
+          "min": 50,
+          "max": 98
+        },
+        "eq_range": {
+          "min": 55,
+          "max": 100
+        }
+      },
+      "market_demand_json": {
+        "raw": 82
+      },
+      "status": "published",
+      "is_public": true,
+      "is_indexable": true,
+      "published_at": null,
+      "scheduled_at": null,
+      "sort_order": 0,
+      "sections": [
+
+      ],
+      "seo_meta": {
+        "seo_title": null,
+        "seo_description": null,
+        "canonical_url": null,
+        "og_title": null,
+        "og_description": null,
+        "og_image_url": null,
+        "twitter_title": null,
+        "twitter_description": null,
+        "twitter_image_url": null,
+        "robots": null,
+        "jsonld_overrides_json": null
+      }
+    },
+    {
+      "job_code": "nurse",
+      "slug": "nurse",
+      "locale": "zh-CN",
+      "title": "护士",
+      "subtitle": null,
+      "excerpt": "面向护士的实用岗位画像，覆盖职责范围、能力要求、薪资区间与成长路径。",
+      "hero_kicker": null,
+      "hero_quote": null,
+      "cover_image_url": null,
+      "industry_slug": "healthcare",
+      "industry_label": null,
+      "body_md": "# 护士\n## 岗位概览\n护士 是一个通过执行质量、沟通精度与持续学习能力持续放大职业价值的岗位。\n\n## 核心工作范围\n该岗位通过把目标拆解为可落地任务、推进跨团队协同，并持续优化流程质量来影响业务结果。\n\n## 职业发展建议\n建议按 90 天为周期跟踪交付指标、能力增长和协作影响，每季度做一次基于证据的职业复盘并调整成长策略。\n",
+      "body_html": null,
+      "salary_json": {
+        "raw": "人民币 18万 - 90万/年（视城市与资历而定）"
+      },
+      "outlook_json": {
+        "summary": "护士 在数据化与精细化运营背景下仍保持较高需求。"
+      },
+      "skills_json": {
+        "core": [
+          "结构化问题解决",
+          "跨角色沟通",
+          "执行推进能力",
+          "数据驱动决策",
+          "持续学习能力"
+        ],
+        "supporting": [
+
+        ]
+      },
+      "work_contents_json": {
+        "items": [
+          "明确护士核心职责与交付指标。",
+          "协同跨团队角色并统一执行优先级。",
+          "跟踪进度、风险与质量信号，保障结果稳定交付。"
+        ]
+      },
+      "growth_path_json": {
+        "raw": [
+          "0-2 年：建立基础执行能力与行业认知。",
+          "3-5 年：独立负责中等复杂度项目并推进跨团队协作。",
+          "5 年以上：走向专家型负责人或管理型角色。"
+        ]
+      },
+      "fit_personality_codes_json": null,
+      "mbti_primary_codes_json": [
+        "ENFJ",
+        "ISFJ",
+        "INFJ"
+      ],
+      "mbti_secondary_codes_json": [
+        "ESFJ",
+        "INFP",
+        "ENFP"
+      ],
+      "riasec_profile_json": {
+        "R": 48,
+        "I": 64,
+        "A": 42,
+        "S": 88,
+        "E": 54,
+        "C": 74
+      },
+      "big5_targets_json": {
+        "raw": {
+          "openness": {
+            "min": 40,
+            "max": 80
+          },
+          "conscientiousness": {
+            "min": 50,
+            "max": 90
+          },
+          "extraversion": {
+            "min": 35,
+            "max": 82
+          },
+          "agreeableness": {
+            "min": 35,
+            "max": 85
+          },
+          "neuroticism": {
+            "min": 10,
+            "max": 55
+          }
+        }
+      },
+      "iq_eq_notes_json": {
+        "iq_range": {
+          "min": 50,
+          "max": 100
+        },
+        "eq_range": {
+          "min": 60,
+          "max": 100
+        }
+      },
+      "market_demand_json": {
+        "raw": 86
+      },
+      "status": "published",
+      "is_public": true,
+      "is_indexable": true,
+      "published_at": null,
+      "scheduled_at": null,
+      "sort_order": 0,
+      "sections": [
+
+      ],
+      "seo_meta": {
+        "seo_title": null,
+        "seo_description": null,
+        "canonical_url": null,
+        "og_title": null,
+        "og_description": null,
+        "og_image_url": null,
+        "twitter_title": null,
+        "twitter_description": null,
+        "twitter_image_url": null,
+        "robots": null,
+        "jsonld_overrides_json": null
+      }
+    },
+    {
+      "job_code": "operations-manager",
+      "slug": "operations-manager",
+      "locale": "zh-CN",
+      "title": "运营经理",
+      "subtitle": null,
+      "excerpt": "面向运营经理的实用岗位画像，覆盖职责范围、能力要求、薪资区间与成长路径。",
+      "hero_kicker": null,
+      "hero_quote": null,
+      "cover_image_url": null,
+      "industry_slug": "operations",
+      "industry_label": null,
+      "body_md": "# 运营经理\n## 岗位概览\n运营经理 是一个通过执行质量、沟通精度与持续学习能力持续放大职业价值的岗位。\n\n## 核心工作范围\n该岗位通过把目标拆解为可落地任务、推进跨团队协同，并持续优化流程质量来影响业务结果。\n\n## 职业发展建议\n建议按 90 天为周期跟踪交付指标、能力增长和协作影响，每季度做一次基于证据的职业复盘并调整成长策略。\n",
+      "body_html": null,
+      "salary_json": {
+        "raw": "人民币 18万 - 90万/年（视城市与资历而定）"
+      },
+      "outlook_json": {
+        "summary": "运营经理 在数据化与精细化运营背景下仍保持较高需求。"
+      },
+      "skills_json": {
+        "core": [
+          "结构化问题解决",
+          "跨角色沟通",
+          "执行推进能力",
+          "数据驱动决策",
+          "持续学习能力"
+        ],
+        "supporting": [
+
+        ]
+      },
+      "work_contents_json": {
+        "items": [
+          "明确运营经理核心职责与交付指标。",
+          "协同跨团队角色并统一执行优先级。",
+          "跟踪进度、风险与质量信号，保障结果稳定交付。"
+        ]
+      },
+      "growth_path_json": {
+        "raw": [
+          "0-2 年：建立基础执行能力与行业认知。",
+          "3-5 年：独立负责中等复杂度项目并推进跨团队协作。",
+          "5 年以上：走向专家型负责人或管理型角色。"
+        ]
+      },
+      "fit_personality_codes_json": null,
+      "mbti_primary_codes_json": [
+        "ENTJ",
+        "ENFJ",
+        "ESTP"
+      ],
+      "mbti_secondary_codes_json": [
+        "ENFP",
+        "ESTJ",
+        "ENTP"
+      ],
+      "riasec_profile_json": {
+        "R": 42,
+        "I": 66,
+        "A": 56,
+        "S": 60,
+        "E": 88,
+        "C": 70
+      },
+      "big5_targets_json": {
+        "raw": {
+          "openness": {
+            "min": 40,
+            "max": 80
+          },
+          "conscientiousness": {
+            "min": 50,
+            "max": 90
+          },
+          "extraversion": {
+            "min": 35,
+            "max": 82
+          },
+          "agreeableness": {
+            "min": 35,
+            "max": 85
+          },
+          "neuroticism": {
+            "min": 10,
+            "max": 55
+          }
+        }
+      },
+      "iq_eq_notes_json": {
+        "iq_range": {
+          "min": 50,
+          "max": 98
+        },
+        "eq_range": {
+          "min": 55,
+          "max": 100
+        }
+      },
+      "market_demand_json": {
+        "raw": 82
+      },
+      "status": "published",
+      "is_public": true,
+      "is_indexable": true,
+      "published_at": null,
+      "scheduled_at": null,
+      "sort_order": 0,
+      "sections": [
+
+      ],
+      "seo_meta": {
+        "seo_title": null,
+        "seo_description": null,
+        "canonical_url": null,
+        "og_title": null,
+        "og_description": null,
+        "og_image_url": null,
+        "twitter_title": null,
+        "twitter_description": null,
+        "twitter_image_url": null,
+        "robots": null,
+        "jsonld_overrides_json": null
+      }
+    },
+    {
+      "job_code": "pharmacist",
+      "slug": "pharmacist",
+      "locale": "zh-CN",
+      "title": "药师",
+      "subtitle": null,
+      "excerpt": "面向药师的实用岗位画像，覆盖职责范围、能力要求、薪资区间与成长路径。",
+      "hero_kicker": null,
+      "hero_quote": null,
+      "cover_image_url": null,
+      "industry_slug": "healthcare",
+      "industry_label": null,
+      "body_md": "# 药师\n## 岗位概览\n药师 是一个通过执行质量、沟通精度与持续学习能力持续放大职业价值的岗位。\n\n## 核心工作范围\n该岗位通过把目标拆解为可落地任务、推进跨团队协同，并持续优化流程质量来影响业务结果。\n\n## 职业发展建议\n建议按 90 天为周期跟踪交付指标、能力增长和协作影响，每季度做一次基于证据的职业复盘并调整成长策略。\n",
+      "body_html": null,
+      "salary_json": {
+        "raw": "人民币 18万 - 90万/年（视城市与资历而定）"
+      },
+      "outlook_json": {
+        "summary": "药师 在数据化与精细化运营背景下仍保持较高需求。"
+      },
+      "skills_json": {
+        "core": [
+          "结构化问题解决",
+          "跨角色沟通",
+          "执行推进能力",
+          "数据驱动决策",
+          "持续学习能力"
+        ],
+        "supporting": [
+
+        ]
+      },
+      "work_contents_json": {
+        "items": [
+          "明确药师核心职责与交付指标。",
+          "协同跨团队角色并统一执行优先级。",
+          "跟踪进度、风险与质量信号，保障结果稳定交付。"
+        ]
+      },
+      "growth_path_json": {
+        "raw": [
+          "0-2 年：建立基础执行能力与行业认知。",
+          "3-5 年：独立负责中等复杂度项目并推进跨团队协作。",
+          "5 年以上：走向专家型负责人或管理型角色。"
+        ]
+      },
+      "fit_personality_codes_json": null,
+      "mbti_primary_codes_json": [
+        "ENFJ",
+        "ISFJ",
+        "INFJ"
+      ],
+      "mbti_secondary_codes_json": [
+        "ESFJ",
+        "INFP",
+        "ENFP"
+      ],
+      "riasec_profile_json": {
+        "R": 48,
+        "I": 64,
+        "A": 42,
+        "S": 88,
+        "E": 54,
+        "C": 74
+      },
+      "big5_targets_json": {
+        "raw": {
+          "openness": {
+            "min": 40,
+            "max": 80
+          },
+          "conscientiousness": {
+            "min": 50,
+            "max": 90
+          },
+          "extraversion": {
+            "min": 35,
+            "max": 82
+          },
+          "agreeableness": {
+            "min": 35,
+            "max": 85
+          },
+          "neuroticism": {
+            "min": 10,
+            "max": 55
+          }
+        }
+      },
+      "iq_eq_notes_json": {
+        "iq_range": {
+          "min": 50,
+          "max": 100
+        },
+        "eq_range": {
+          "min": 60,
+          "max": 100
+        }
+      },
+      "market_demand_json": {
+        "raw": 86
+      },
+      "status": "published",
+      "is_public": true,
+      "is_indexable": true,
+      "published_at": null,
+      "scheduled_at": null,
+      "sort_order": 0,
+      "sections": [
+
+      ],
+      "seo_meta": {
+        "seo_title": null,
+        "seo_description": null,
+        "canonical_url": null,
+        "og_title": null,
+        "og_description": null,
+        "og_image_url": null,
+        "twitter_title": null,
+        "twitter_description": null,
+        "twitter_image_url": null,
+        "robots": null,
+        "jsonld_overrides_json": null
+      }
+    },
+    {
+      "job_code": "physician",
+      "slug": "physician",
+      "locale": "zh-CN",
+      "title": "医生",
+      "subtitle": null,
+      "excerpt": "面向医生的实用岗位画像，覆盖职责范围、能力要求、薪资区间与成长路径。",
+      "hero_kicker": null,
+      "hero_quote": null,
+      "cover_image_url": null,
+      "industry_slug": "healthcare",
+      "industry_label": null,
+      "body_md": "# 医生\n## 岗位概览\n医生 是一个通过执行质量、沟通精度与持续学习能力持续放大职业价值的岗位。\n\n## 核心工作范围\n该岗位通过把目标拆解为可落地任务、推进跨团队协同，并持续优化流程质量来影响业务结果。\n\n## 职业发展建议\n建议按 90 天为周期跟踪交付指标、能力增长和协作影响，每季度做一次基于证据的职业复盘并调整成长策略。\n",
+      "body_html": null,
+      "salary_json": {
+        "raw": "人民币 18万 - 90万/年（视城市与资历而定）"
+      },
+      "outlook_json": {
+        "summary": "医生 在数据化与精细化运营背景下仍保持较高需求。"
+      },
+      "skills_json": {
+        "core": [
+          "结构化问题解决",
+          "跨角色沟通",
+          "执行推进能力",
+          "数据驱动决策",
+          "持续学习能力"
+        ],
+        "supporting": [
+
+        ]
+      },
+      "work_contents_json": {
+        "items": [
+          "明确医生核心职责与交付指标。",
+          "协同跨团队角色并统一执行优先级。",
+          "跟踪进度、风险与质量信号，保障结果稳定交付。"
+        ]
+      },
+      "growth_path_json": {
+        "raw": [
+          "0-2 年：建立基础执行能力与行业认知。",
+          "3-5 年：独立负责中等复杂度项目并推进跨团队协作。",
+          "5 年以上：走向专家型负责人或管理型角色。"
+        ]
+      },
+      "fit_personality_codes_json": null,
+      "mbti_primary_codes_json": [
+        "ENFJ",
+        "ISFJ",
+        "INFJ"
+      ],
+      "mbti_secondary_codes_json": [
+        "ESFJ",
+        "INFP",
+        "ENFP"
+      ],
+      "riasec_profile_json": {
+        "R": 48,
+        "I": 64,
+        "A": 42,
+        "S": 88,
+        "E": 54,
+        "C": 74
+      },
+      "big5_targets_json": {
+        "raw": {
+          "openness": {
+            "min": 40,
+            "max": 80
+          },
+          "conscientiousness": {
+            "min": 50,
+            "max": 90
+          },
+          "extraversion": {
+            "min": 35,
+            "max": 82
+          },
+          "agreeableness": {
+            "min": 35,
+            "max": 85
+          },
+          "neuroticism": {
+            "min": 10,
+            "max": 55
+          }
+        }
+      },
+      "iq_eq_notes_json": {
+        "iq_range": {
+          "min": 50,
+          "max": 100
+        },
+        "eq_range": {
+          "min": 60,
+          "max": 100
+        }
+      },
+      "market_demand_json": {
+        "raw": 86
+      },
+      "status": "published",
+      "is_public": true,
+      "is_indexable": true,
+      "published_at": null,
+      "scheduled_at": null,
+      "sort_order": 0,
+      "sections": [
+
+      ],
+      "seo_meta": {
+        "seo_title": null,
+        "seo_description": null,
+        "canonical_url": null,
+        "og_title": null,
+        "og_description": null,
+        "og_image_url": null,
+        "twitter_title": null,
+        "twitter_description": null,
+        "twitter_image_url": null,
+        "robots": null,
+        "jsonld_overrides_json": null
+      }
+    },
+    {
+      "job_code": "policy-analyst",
+      "slug": "policy-analyst",
+      "locale": "zh-CN",
+      "title": "政策分析师",
+      "subtitle": null,
+      "excerpt": "面向政策分析师的实用岗位画像，覆盖职责范围、能力要求、薪资区间与成长路径。",
+      "hero_kicker": null,
+      "hero_quote": null,
+      "cover_image_url": null,
+      "industry_slug": "public-service",
+      "industry_label": null,
+      "body_md": "# 政策分析师\n## 岗位概览\n政策分析师 是一个通过执行质量、沟通精度与持续学习能力持续放大职业价值的岗位。\n\n## 核心工作范围\n该岗位通过把目标拆解为可落地任务、推进跨团队协同，并持续优化流程质量来影响业务结果。\n\n## 职业发展建议\n建议按 90 天为周期跟踪交付指标、能力增长和协作影响，每季度做一次基于证据的职业复盘并调整成长策略。\n",
+      "body_html": null,
+      "salary_json": {
+        "raw": "人民币 18万 - 90万/年（视城市与资历而定）"
+      },
+      "outlook_json": {
+        "summary": "政策分析师 在数据化与精细化运营背景下仍保持较高需求。"
+      },
+      "skills_json": {
+        "core": [
+          "结构化问题解决",
+          "跨角色沟通",
+          "执行推进能力",
+          "数据驱动决策",
+          "持续学习能力"
+        ],
+        "supporting": [
+
+        ]
+      },
+      "work_contents_json": {
+        "items": [
+          "明确政策分析师核心职责与交付指标。",
+          "协同跨团队角色并统一执行优先级。",
+          "跟踪进度、风险与质量信号，保障结果稳定交付。"
+        ]
+      },
+      "growth_path_json": {
+        "raw": [
+          "0-2 年：建立基础执行能力与行业认知。",
+          "3-5 年：独立负责中等复杂度项目并推进跨团队协作。",
+          "5 年以上：走向专家型负责人或管理型角色。"
+        ]
+      },
+      "fit_personality_codes_json": null,
+      "mbti_primary_codes_json": [
+        "INTJ",
+        "INTP",
+        "ENTJ"
+      ],
+      "mbti_secondary_codes_json": [
+        "ENTP",
+        "ISTJ",
+        "INFJ"
+      ],
+      "riasec_profile_json": {
+        "R": 40,
+        "I": 90,
+        "A": 45,
+        "S": 38,
+        "E": 46,
+        "C": 72
+      },
+      "big5_targets_json": {
+        "raw": {
+          "openness": {
+            "min": 40,
+            "max": 80
+          },
+          "conscientiousness": {
+            "min": 50,
+            "max": 90
+          },
+          "extraversion": {
+            "min": 35,
+            "max": 82
+          },
+          "agreeableness": {
+            "min": 35,
+            "max": 85
+          },
+          "neuroticism": {
+            "min": 10,
+            "max": 55
+          }
+        }
+      },
+      "iq_eq_notes_json": {
+        "iq_range": {
+          "min": 62,
+          "max": 100
+        },
+        "eq_range": {
+          "min": 40,
+          "max": 86
+        }
+      },
+      "market_demand_json": {
+        "raw": 85
+      },
+      "status": "published",
+      "is_public": true,
+      "is_indexable": true,
+      "published_at": null,
+      "scheduled_at": null,
+      "sort_order": 0,
+      "sections": [
+
+      ],
+      "seo_meta": {
+        "seo_title": null,
+        "seo_description": null,
+        "canonical_url": null,
+        "og_title": null,
+        "og_description": null,
+        "og_image_url": null,
+        "twitter_title": null,
+        "twitter_description": null,
+        "twitter_image_url": null,
+        "robots": null,
+        "jsonld_overrides_json": null
+      }
+    },
+    {
+      "job_code": "product-manager",
+      "slug": "product-manager",
+      "locale": "zh-CN",
+      "title": "产品经理",
+      "subtitle": null,
+      "excerpt": "面向产品经理的实用岗位画像，覆盖职责范围、能力要求、薪资区间与成长路径。",
+      "hero_kicker": null,
+      "hero_quote": null,
+      "cover_image_url": null,
+      "industry_slug": "business",
+      "industry_label": null,
+      "body_md": "# 产品经理\n## 岗位概览\n产品经理 是一个通过执行质量、沟通精度与持续学习能力持续放大职业价值的岗位。\n\n## 核心工作范围\n该岗位通过把目标拆解为可落地任务、推进跨团队协同，并持续优化流程质量来影响业务结果。\n\n## 职业发展建议\n建议按 90 天为周期跟踪交付指标、能力增长和协作影响，每季度做一次基于证据的职业复盘并调整成长策略。\n",
+      "body_html": null,
+      "salary_json": {
+        "raw": "人民币 18万 - 90万/年（视城市与资历而定）"
+      },
+      "outlook_json": {
+        "summary": "产品经理 在数据化与精细化运营背景下仍保持较高需求。"
+      },
+      "skills_json": {
+        "core": [
+          "结构化问题解决",
+          "跨角色沟通",
+          "执行推进能力",
+          "数据驱动决策",
+          "持续学习能力"
+        ],
+        "supporting": [
+
+        ]
+      },
+      "work_contents_json": {
+        "items": [
+          "明确产品经理核心职责与交付指标。",
+          "协同跨团队角色并统一执行优先级。",
+          "跟踪进度、风险与质量信号，保障结果稳定交付。"
+        ]
+      },
+      "growth_path_json": {
+        "raw": [
+          "0-2 年：建立基础执行能力与行业认知。",
+          "3-5 年：独立负责中等复杂度项目并推进跨团队协作。",
+          "5 年以上：走向专家型负责人或管理型角色。"
+        ]
+      },
+      "fit_personality_codes_json": null,
+      "mbti_primary_codes_json": [
+        "ENTJ",
+        "ENFJ",
+        "ESTP"
+      ],
+      "mbti_secondary_codes_json": [
+        "ENFP",
+        "ESTJ",
+        "ENTP"
+      ],
+      "riasec_profile_json": {
+        "R": 42,
+        "I": 66,
+        "A": 56,
+        "S": 60,
+        "E": 88,
+        "C": 70
+      },
+      "big5_targets_json": {
+        "raw": {
+          "openness": {
+            "min": 40,
+            "max": 80
+          },
+          "conscientiousness": {
+            "min": 50,
+            "max": 90
+          },
+          "extraversion": {
+            "min": 35,
+            "max": 82
+          },
+          "agreeableness": {
+            "min": 35,
+            "max": 85
+          },
+          "neuroticism": {
+            "min": 10,
+            "max": 55
+          }
+        }
+      },
+      "iq_eq_notes_json": {
+        "iq_range": {
+          "min": 50,
+          "max": 98
+        },
+        "eq_range": {
+          "min": 55,
+          "max": 100
+        }
+      },
+      "market_demand_json": {
+        "raw": 82
+      },
+      "status": "published",
+      "is_public": true,
+      "is_indexable": true,
+      "published_at": null,
+      "scheduled_at": null,
+      "sort_order": 0,
+      "sections": [
+
+      ],
+      "seo_meta": {
+        "seo_title": null,
+        "seo_description": null,
+        "canonical_url": null,
+        "og_title": null,
+        "og_description": null,
+        "og_image_url": null,
+        "twitter_title": null,
+        "twitter_description": null,
+        "twitter_image_url": null,
+        "robots": null,
+        "jsonld_overrides_json": null
+      }
+    },
+    {
+      "job_code": "psychological-counselor",
+      "slug": "psychological-counselor",
+      "locale": "zh-CN",
+      "title": "心理咨询师",
+      "subtitle": null,
+      "excerpt": "面向心理咨询师的实用岗位画像，覆盖职责范围、能力要求、薪资区间与成长路径。",
+      "hero_kicker": null,
+      "hero_quote": null,
+      "cover_image_url": null,
+      "industry_slug": "healthcare",
+      "industry_label": null,
+      "body_md": "# 心理咨询师\n## 岗位概览\n心理咨询师 是一个通过执行质量、沟通精度与持续学习能力持续放大职业价值的岗位。\n\n## 核心工作范围\n该岗位通过把目标拆解为可落地任务、推进跨团队协同，并持续优化流程质量来影响业务结果。\n\n## 职业发展建议\n建议按 90 天为周期跟踪交付指标、能力增长和协作影响，每季度做一次基于证据的职业复盘并调整成长策略。\n",
+      "body_html": null,
+      "salary_json": {
+        "raw": "人民币 18万 - 90万/年（视城市与资历而定）"
+      },
+      "outlook_json": {
+        "summary": "心理咨询师 在数据化与精细化运营背景下仍保持较高需求。"
+      },
+      "skills_json": {
+        "core": [
+          "结构化问题解决",
+          "跨角色沟通",
+          "执行推进能力",
+          "数据驱动决策",
+          "持续学习能力"
+        ],
+        "supporting": [
+
+        ]
+      },
+      "work_contents_json": {
+        "items": [
+          "明确心理咨询师核心职责与交付指标。",
+          "协同跨团队角色并统一执行优先级。",
+          "跟踪进度、风险与质量信号，保障结果稳定交付。"
+        ]
+      },
+      "growth_path_json": {
+        "raw": [
+          "0-2 年：建立基础执行能力与行业认知。",
+          "3-5 年：独立负责中等复杂度项目并推进跨团队协作。",
+          "5 年以上：走向专家型负责人或管理型角色。"
+        ]
+      },
+      "fit_personality_codes_json": null,
+      "mbti_primary_codes_json": [
+        "ENFJ",
+        "ISFJ",
+        "INFJ"
+      ],
+      "mbti_secondary_codes_json": [
+        "ESFJ",
+        "INFP",
+        "ENFP"
+      ],
+      "riasec_profile_json": {
+        "R": 48,
+        "I": 64,
+        "A": 42,
+        "S": 88,
+        "E": 54,
+        "C": 74
+      },
+      "big5_targets_json": {
+        "raw": {
+          "openness": {
+            "min": 40,
+            "max": 80
+          },
+          "conscientiousness": {
+            "min": 50,
+            "max": 90
+          },
+          "extraversion": {
+            "min": 35,
+            "max": 82
+          },
+          "agreeableness": {
+            "min": 35,
+            "max": 85
+          },
+          "neuroticism": {
+            "min": 10,
+            "max": 55
+          }
+        }
+      },
+      "iq_eq_notes_json": {
+        "iq_range": {
+          "min": 50,
+          "max": 100
+        },
+        "eq_range": {
+          "min": 60,
+          "max": 100
+        }
+      },
+      "market_demand_json": {
+        "raw": 86
+      },
+      "status": "published",
+      "is_public": true,
+      "is_indexable": true,
+      "published_at": null,
+      "scheduled_at": null,
+      "sort_order": 0,
+      "sections": [
+
+      ],
+      "seo_meta": {
+        "seo_title": null,
+        "seo_description": null,
+        "canonical_url": null,
+        "og_title": null,
+        "og_description": null,
+        "og_image_url": null,
+        "twitter_title": null,
+        "twitter_description": null,
+        "twitter_image_url": null,
+        "robots": null,
+        "jsonld_overrides_json": null
+      }
+    },
+    {
+      "job_code": "researcher",
+      "slug": "researcher",
+      "locale": "zh-CN",
+      "title": "研究员",
+      "subtitle": null,
+      "excerpt": "面向研究员的实用岗位画像，覆盖职责范围、能力要求、薪资区间与成长路径。",
+      "hero_kicker": null,
+      "hero_quote": null,
+      "cover_image_url": null,
+      "industry_slug": "education",
+      "industry_label": null,
+      "body_md": "# 研究员\n## 岗位概览\n研究员 是一个通过执行质量、沟通精度与持续学习能力持续放大职业价值的岗位。\n\n## 核心工作范围\n该岗位通过把目标拆解为可落地任务、推进跨团队协同，并持续优化流程质量来影响业务结果。\n\n## 职业发展建议\n建议按 90 天为周期跟踪交付指标、能力增长和协作影响，每季度做一次基于证据的职业复盘并调整成长策略。\n",
+      "body_html": null,
+      "salary_json": {
+        "raw": "人民币 18万 - 90万/年（视城市与资历而定）"
+      },
+      "outlook_json": {
+        "summary": "研究员 在数据化与精细化运营背景下仍保持较高需求。"
+      },
+      "skills_json": {
+        "core": [
+          "结构化问题解决",
+          "跨角色沟通",
+          "执行推进能力",
+          "数据驱动决策",
+          "持续学习能力"
+        ],
+        "supporting": [
+
+        ]
+      },
+      "work_contents_json": {
+        "items": [
+          "明确研究员核心职责与交付指标。",
+          "协同跨团队角色并统一执行优先级。",
+          "跟踪进度、风险与质量信号，保障结果稳定交付。"
+        ]
+      },
+      "growth_path_json": {
+        "raw": [
+          "0-2 年：建立基础执行能力与行业认知。",
+          "3-5 年：独立负责中等复杂度项目并推进跨团队协作。",
+          "5 年以上：走向专家型负责人或管理型角色。"
+        ]
+      },
+      "fit_personality_codes_json": null,
+      "mbti_primary_codes_json": [
+        "INTJ",
+        "INTP",
+        "ENTJ"
+      ],
+      "mbti_secondary_codes_json": [
+        "ENTP",
+        "ISTJ",
+        "INFJ"
+      ],
+      "riasec_profile_json": {
+        "R": 40,
+        "I": 90,
+        "A": 45,
+        "S": 38,
+        "E": 46,
+        "C": 72
+      },
+      "big5_targets_json": {
+        "raw": {
+          "openness": {
+            "min": 40,
+            "max": 80
+          },
+          "conscientiousness": {
+            "min": 50,
+            "max": 90
+          },
+          "extraversion": {
+            "min": 35,
+            "max": 82
+          },
+          "agreeableness": {
+            "min": 35,
+            "max": 85
+          },
+          "neuroticism": {
+            "min": 10,
+            "max": 55
+          }
+        }
+      },
+      "iq_eq_notes_json": {
+        "iq_range": {
+          "min": 62,
+          "max": 100
+        },
+        "eq_range": {
+          "min": 40,
+          "max": 86
+        }
+      },
+      "market_demand_json": {
+        "raw": 85
+      },
+      "status": "published",
+      "is_public": true,
+      "is_indexable": true,
+      "published_at": null,
+      "scheduled_at": null,
+      "sort_order": 0,
+      "sections": [
+
+      ],
+      "seo_meta": {
+        "seo_title": null,
+        "seo_description": null,
+        "canonical_url": null,
+        "og_title": null,
+        "og_description": null,
+        "og_image_url": null,
+        "twitter_title": null,
+        "twitter_description": null,
+        "twitter_image_url": null,
+        "robots": null,
+        "jsonld_overrides_json": null
+      }
+    },
+    {
+      "job_code": "sales-manager",
+      "slug": "sales-manager",
+      "locale": "zh-CN",
+      "title": "销售经理",
+      "subtitle": null,
+      "excerpt": "面向销售经理的实用岗位画像，覆盖职责范围、能力要求、薪资区间与成长路径。",
+      "hero_kicker": null,
+      "hero_quote": null,
+      "cover_image_url": null,
+      "industry_slug": "business",
+      "industry_label": null,
+      "body_md": "# 销售经理\n## 岗位概览\n销售经理 是一个通过执行质量、沟通精度与持续学习能力持续放大职业价值的岗位。\n\n## 核心工作范围\n该岗位通过把目标拆解为可落地任务、推进跨团队协同，并持续优化流程质量来影响业务结果。\n\n## 职业发展建议\n建议按 90 天为周期跟踪交付指标、能力增长和协作影响，每季度做一次基于证据的职业复盘并调整成长策略。\n",
+      "body_html": null,
+      "salary_json": {
+        "raw": "人民币 18万 - 90万/年（视城市与资历而定）"
+      },
+      "outlook_json": {
+        "summary": "销售经理 在数据化与精细化运营背景下仍保持较高需求。"
+      },
+      "skills_json": {
+        "core": [
+          "结构化问题解决",
+          "跨角色沟通",
+          "执行推进能力",
+          "数据驱动决策",
+          "持续学习能力"
+        ],
+        "supporting": [
+
+        ]
+      },
+      "work_contents_json": {
+        "items": [
+          "明确销售经理核心职责与交付指标。",
+          "协同跨团队角色并统一执行优先级。",
+          "跟踪进度、风险与质量信号，保障结果稳定交付。"
+        ]
+      },
+      "growth_path_json": {
+        "raw": [
+          "0-2 年：建立基础执行能力与行业认知。",
+          "3-5 年：独立负责中等复杂度项目并推进跨团队协作。",
+          "5 年以上：走向专家型负责人或管理型角色。"
+        ]
+      },
+      "fit_personality_codes_json": null,
+      "mbti_primary_codes_json": [
+        "ENTJ",
+        "ENFJ",
+        "ESTP"
+      ],
+      "mbti_secondary_codes_json": [
+        "ENFP",
+        "ESTJ",
+        "ENTP"
+      ],
+      "riasec_profile_json": {
+        "R": 42,
+        "I": 66,
+        "A": 56,
+        "S": 60,
+        "E": 88,
+        "C": 70
+      },
+      "big5_targets_json": {
+        "raw": {
+          "openness": {
+            "min": 40,
+            "max": 80
+          },
+          "conscientiousness": {
+            "min": 50,
+            "max": 90
+          },
+          "extraversion": {
+            "min": 35,
+            "max": 82
+          },
+          "agreeableness": {
+            "min": 35,
+            "max": 85
+          },
+          "neuroticism": {
+            "min": 10,
+            "max": 55
+          }
+        }
+      },
+      "iq_eq_notes_json": {
+        "iq_range": {
+          "min": 50,
+          "max": 98
+        },
+        "eq_range": {
+          "min": 55,
+          "max": 100
+        }
+      },
+      "market_demand_json": {
+        "raw": 82
+      },
+      "status": "published",
+      "is_public": true,
+      "is_indexable": true,
+      "published_at": null,
+      "scheduled_at": null,
+      "sort_order": 0,
+      "sections": [
+
+      ],
+      "seo_meta": {
+        "seo_title": null,
+        "seo_description": null,
+        "canonical_url": null,
+        "og_title": null,
+        "og_description": null,
+        "og_image_url": null,
+        "twitter_title": null,
+        "twitter_description": null,
+        "twitter_image_url": null,
+        "robots": null,
+        "jsonld_overrides_json": null
+      }
+    },
+    {
+      "job_code": "software-engineer",
+      "slug": "software-engineer",
+      "locale": "zh-CN",
+      "title": "软件工程师",
+      "subtitle": null,
+      "excerpt": "面向软件工程师的实用岗位画像，覆盖职责范围、能力要求、薪资区间与成长路径。",
+      "hero_kicker": null,
+      "hero_quote": null,
+      "cover_image_url": null,
+      "industry_slug": "technology",
+      "industry_label": null,
+      "body_md": "# 软件工程师\n## 岗位概览\n软件工程师 是一个通过执行质量、沟通精度与持续学习能力持续放大职业价值的岗位。\n\n## 核心工作范围\n该岗位通过把目标拆解为可落地任务、推进跨团队协同，并持续优化流程质量来影响业务结果。\n\n## 职业发展建议\n建议按 90 天为周期跟踪交付指标、能力增长和协作影响，每季度做一次基于证据的职业复盘并调整成长策略。\n",
+      "body_html": null,
+      "salary_json": {
+        "raw": "人民币 18万 - 90万/年（视城市与资历而定）"
+      },
+      "outlook_json": {
+        "summary": "软件工程师 在数据化与精细化运营背景下仍保持较高需求。"
+      },
+      "skills_json": {
+        "core": [
+          "结构化问题解决",
+          "跨角色沟通",
+          "执行推进能力",
+          "数据驱动决策",
+          "持续学习能力"
+        ],
+        "supporting": [
+
+        ]
+      },
+      "work_contents_json": {
+        "items": [
+          "明确软件工程师核心职责与交付指标。",
+          "协同跨团队角色并统一执行优先级。",
+          "跟踪进度、风险与质量信号，保障结果稳定交付。"
+        ]
+      },
+      "growth_path_json": {
+        "raw": [
+          "0-2 年：建立基础执行能力与行业认知。",
+          "3-5 年：独立负责中等复杂度项目并推进跨团队协作。",
+          "5 年以上：走向专家型负责人或管理型角色。"
+        ]
+      },
+      "fit_personality_codes_json": null,
+      "mbti_primary_codes_json": [
+        "INTJ",
+        "INTP",
+        "ENTJ"
+      ],
+      "mbti_secondary_codes_json": [
+        "ENTP",
+        "ISTJ",
+        "INFJ"
+      ],
+      "riasec_profile_json": {
+        "R": 55,
+        "I": 88,
+        "A": 48,
+        "S": 42,
+        "E": 50,
+        "C": 68
+      },
+      "big5_targets_json": {
+        "raw": {
+          "openness": {
+            "min": 40,
+            "max": 80
+          },
+          "conscientiousness": {
+            "min": 50,
+            "max": 90
+          },
+          "extraversion": {
+            "min": 35,
+            "max": 82
+          },
+          "agreeableness": {
+            "min": 35,
+            "max": 85
+          },
+          "neuroticism": {
+            "min": 10,
+            "max": 55
+          }
+        }
+      },
+      "iq_eq_notes_json": {
+        "iq_range": {
+          "min": 65,
+          "max": 100
+        },
+        "eq_range": {
+          "min": 45,
+          "max": 90
+        }
+      },
+      "market_demand_json": {
+        "raw": 92
+      },
+      "status": "published",
+      "is_public": true,
+      "is_indexable": true,
+      "published_at": null,
+      "scheduled_at": null,
+      "sort_order": 0,
+      "sections": [
+
+      ],
+      "seo_meta": {
+        "seo_title": null,
+        "seo_description": null,
+        "canonical_url": null,
+        "og_title": null,
+        "og_description": null,
+        "og_image_url": null,
+        "twitter_title": null,
+        "twitter_description": null,
+        "twitter_image_url": null,
+        "robots": null,
+        "jsonld_overrides_json": null
+      }
+    },
+    {
+      "job_code": "supply-chain-manager",
+      "slug": "supply-chain-manager",
+      "locale": "zh-CN",
+      "title": "供应链经理",
+      "subtitle": null,
+      "excerpt": "面向供应链经理的实用岗位画像，覆盖职责范围、能力要求、薪资区间与成长路径。",
+      "hero_kicker": null,
+      "hero_quote": null,
+      "cover_image_url": null,
+      "industry_slug": "operations",
+      "industry_label": null,
+      "body_md": "# 供应链经理\n## 岗位概览\n供应链经理 是一个通过执行质量、沟通精度与持续学习能力持续放大职业价值的岗位。\n\n## 核心工作范围\n该岗位通过把目标拆解为可落地任务、推进跨团队协同，并持续优化流程质量来影响业务结果。\n\n## 职业发展建议\n建议按 90 天为周期跟踪交付指标、能力增长和协作影响，每季度做一次基于证据的职业复盘并调整成长策略。\n",
+      "body_html": null,
+      "salary_json": {
+        "raw": "人民币 18万 - 90万/年（视城市与资历而定）"
+      },
+      "outlook_json": {
+        "summary": "供应链经理 在数据化与精细化运营背景下仍保持较高需求。"
+      },
+      "skills_json": {
+        "core": [
+          "结构化问题解决",
+          "跨角色沟通",
+          "执行推进能力",
+          "数据驱动决策",
+          "持续学习能力"
+        ],
+        "supporting": [
+
+        ]
+      },
+      "work_contents_json": {
+        "items": [
+          "明确供应链经理核心职责与交付指标。",
+          "协同跨团队角色并统一执行优先级。",
+          "跟踪进度、风险与质量信号，保障结果稳定交付。"
+        ]
+      },
+      "growth_path_json": {
+        "raw": [
+          "0-2 年：建立基础执行能力与行业认知。",
+          "3-5 年：独立负责中等复杂度项目并推进跨团队协作。",
+          "5 年以上：走向专家型负责人或管理型角色。"
+        ]
+      },
+      "fit_personality_codes_json": null,
+      "mbti_primary_codes_json": [
+        "ENTJ",
+        "ENFJ",
+        "ESTP"
+      ],
+      "mbti_secondary_codes_json": [
+        "ENFP",
+        "ESTJ",
+        "ENTP"
+      ],
+      "riasec_profile_json": {
+        "R": 42,
+        "I": 66,
+        "A": 56,
+        "S": 60,
+        "E": 88,
+        "C": 70
+      },
+      "big5_targets_json": {
+        "raw": {
+          "openness": {
+            "min": 40,
+            "max": 80
+          },
+          "conscientiousness": {
+            "min": 50,
+            "max": 90
+          },
+          "extraversion": {
+            "min": 35,
+            "max": 82
+          },
+          "agreeableness": {
+            "min": 35,
+            "max": 85
+          },
+          "neuroticism": {
+            "min": 10,
+            "max": 55
+          }
+        }
+      },
+      "iq_eq_notes_json": {
+        "iq_range": {
+          "min": 50,
+          "max": 98
+        },
+        "eq_range": {
+          "min": 55,
+          "max": 100
+        }
+      },
+      "market_demand_json": {
+        "raw": 82
+      },
+      "status": "published",
+      "is_public": true,
+      "is_indexable": true,
+      "published_at": null,
+      "scheduled_at": null,
+      "sort_order": 0,
+      "sections": [
+
+      ],
+      "seo_meta": {
+        "seo_title": null,
+        "seo_description": null,
+        "canonical_url": null,
+        "og_title": null,
+        "og_description": null,
+        "og_image_url": null,
+        "twitter_title": null,
+        "twitter_description": null,
+        "twitter_image_url": null,
+        "robots": null,
+        "jsonld_overrides_json": null
+      }
+    },
+    {
+      "job_code": "teacher",
+      "slug": "teacher",
+      "locale": "zh-CN",
+      "title": "教师",
+      "subtitle": null,
+      "excerpt": "面向教师的实用岗位画像，覆盖职责范围、能力要求、薪资区间与成长路径。",
+      "hero_kicker": null,
+      "hero_quote": null,
+      "cover_image_url": null,
+      "industry_slug": "education",
+      "industry_label": null,
+      "body_md": "# 教师\n## 岗位概览\n教师 是一个通过执行质量、沟通精度与持续学习能力持续放大职业价值的岗位。\n\n## 核心工作范围\n该岗位通过把目标拆解为可落地任务、推进跨团队协同，并持续优化流程质量来影响业务结果。\n\n## 职业发展建议\n建议按 90 天为周期跟踪交付指标、能力增长和协作影响，每季度做一次基于证据的职业复盘并调整成长策略。\n",
+      "body_html": null,
+      "salary_json": {
+        "raw": "人民币 18万 - 90万/年（视城市与资历而定）"
+      },
+      "outlook_json": {
+        "summary": "教师 在数据化与精细化运营背景下仍保持较高需求。"
+      },
+      "skills_json": {
+        "core": [
+          "结构化问题解决",
+          "跨角色沟通",
+          "执行推进能力",
+          "数据驱动决策",
+          "持续学习能力"
+        ],
+        "supporting": [
+
+        ]
+      },
+      "work_contents_json": {
+        "items": [
+          "明确教师核心职责与交付指标。",
+          "协同跨团队角色并统一执行优先级。",
+          "跟踪进度、风险与质量信号，保障结果稳定交付。"
+        ]
+      },
+      "growth_path_json": {
+        "raw": [
+          "0-2 年：建立基础执行能力与行业认知。",
+          "3-5 年：独立负责中等复杂度项目并推进跨团队协作。",
+          "5 年以上：走向专家型负责人或管理型角色。"
+        ]
+      },
+      "fit_personality_codes_json": null,
+      "mbti_primary_codes_json": [
+        "ENFJ",
+        "ISFJ",
+        "INFJ"
+      ],
+      "mbti_secondary_codes_json": [
+        "ESFJ",
+        "INFP",
+        "ENFP"
+      ],
+      "riasec_profile_json": {
+        "R": 48,
+        "I": 64,
+        "A": 42,
+        "S": 88,
+        "E": 54,
+        "C": 74
+      },
+      "big5_targets_json": {
+        "raw": {
+          "openness": {
+            "min": 40,
+            "max": 80
+          },
+          "conscientiousness": {
+            "min": 50,
+            "max": 90
+          },
+          "extraversion": {
+            "min": 35,
+            "max": 82
+          },
+          "agreeableness": {
+            "min": 35,
+            "max": 85
+          },
+          "neuroticism": {
+            "min": 10,
+            "max": 55
+          }
+        }
+      },
+      "iq_eq_notes_json": {
+        "iq_range": {
+          "min": 50,
+          "max": 100
+        },
+        "eq_range": {
+          "min": 60,
+          "max": 100
+        }
+      },
+      "market_demand_json": {
+        "raw": 86
+      },
+      "status": "published",
+      "is_public": true,
+      "is_indexable": true,
+      "published_at": null,
+      "scheduled_at": null,
+      "sort_order": 0,
+      "sections": [
+
+      ],
+      "seo_meta": {
+        "seo_title": null,
+        "seo_description": null,
+        "canonical_url": null,
+        "og_title": null,
+        "og_description": null,
+        "og_image_url": null,
+        "twitter_title": null,
+        "twitter_description": null,
+        "twitter_image_url": null,
+        "robots": null,
+        "jsonld_overrides_json": null
+      }
+    },
+    {
+      "job_code": "ui-ux-designer",
+      "slug": "ui-ux-designer",
+      "locale": "zh-CN",
+      "title": "UI/UX 设计师",
+      "subtitle": null,
+      "excerpt": "面向UI/UX 设计师的实用岗位画像，覆盖职责范围、能力要求、薪资区间与成长路径。",
+      "hero_kicker": null,
+      "hero_quote": null,
+      "cover_image_url": null,
+      "industry_slug": "design",
+      "industry_label": null,
+      "body_md": "# UI/UX 设计师\n## 岗位概览\nUI/UX 设计师 是一个通过执行质量、沟通精度与持续学习能力持续放大职业价值的岗位。\n\n## 核心工作范围\n该岗位通过把目标拆解为可落地任务、推进跨团队协同，并持续优化流程质量来影响业务结果。\n\n## 职业发展建议\n建议按 90 天为周期跟踪交付指标、能力增长和协作影响，每季度做一次基于证据的职业复盘并调整成长策略。\n",
+      "body_html": null,
+      "salary_json": {
+        "raw": "人民币 18万 - 90万/年（视城市与资历而定）"
+      },
+      "outlook_json": {
+        "summary": "UI/UX 设计师 在数据化与精细化运营背景下仍保持较高需求。"
+      },
+      "skills_json": {
+        "core": [
+          "结构化问题解决",
+          "跨角色沟通",
+          "执行推进能力",
+          "数据驱动决策",
+          "持续学习能力"
+        ],
+        "supporting": [
+
+        ]
+      },
+      "work_contents_json": {
+        "items": [
+          "明确UI/UX 设计师核心职责与交付指标。",
+          "协同跨团队角色并统一执行优先级。",
+          "跟踪进度、风险与质量信号，保障结果稳定交付。"
+        ]
+      },
+      "growth_path_json": {
+        "raw": [
+          "0-2 年：建立基础执行能力与行业认知。",
+          "3-5 年：独立负责中等复杂度项目并推进跨团队协作。",
+          "5 年以上：走向专家型负责人或管理型角色。"
+        ]
+      },
+      "fit_personality_codes_json": null,
+      "mbti_primary_codes_json": [
+        "INFP",
+        "ENFP",
+        "ISFP"
+      ],
+      "mbti_secondary_codes_json": [
+        "INFJ",
+        "ENTP",
+        "ESFP"
+      ],
+      "riasec_profile_json": {
+        "R": 38,
+        "I": 62,
+        "A": 90,
+        "S": 54,
+        "E": 60,
+        "C": 44
+      },
+      "big5_targets_json": {
+        "raw": {
+          "openness": {
+            "min": 40,
+            "max": 80
+          },
+          "conscientiousness": {
+            "min": 50,
+            "max": 90
+          },
+          "extraversion": {
+            "min": 35,
+            "max": 82
+          },
+          "agreeableness": {
+            "min": 35,
+            "max": 85
+          },
+          "neuroticism": {
+            "min": 10,
+            "max": 55
+          }
+        }
+      },
+      "iq_eq_notes_json": {
+        "iq_range": {
+          "min": 45,
+          "max": 95
+        },
+        "eq_range": {
+          "min": 52,
+          "max": 96
+        }
+      },
+      "market_demand_json": {
+        "raw": 78
+      },
+      "status": "published",
+      "is_public": true,
+      "is_indexable": true,
+      "published_at": null,
+      "scheduled_at": null,
+      "sort_order": 0,
+      "sections": [
+
+      ],
+      "seo_meta": {
+        "seo_title": null,
+        "seo_description": null,
+        "canonical_url": null,
+        "og_title": null,
+        "og_description": null,
+        "og_image_url": null,
+        "twitter_title": null,
+        "twitter_description": null,
+        "twitter_image_url": null,
+        "robots": null,
+        "jsonld_overrides_json": null
+      }
+    }
+  ]
+}


### PR DESCRIPTION
Summary
- add a repeatable baseline import for Career CMS Lite v1 career jobs
- normalize the current local career job content into committed baseline files and import it into career job tables

What changed
- add committed baseline files for career jobs
- add an Artisan command to import local baseline content into CareerJob CMS
- add reader/normalizer/importer support for deterministic imports
- add revision creation during baseline import
- add minimal feature coverage for dry-run, create-missing, upsert, and filtering behavior

Design choices
- the import reads from committed baseline files in fap-api, not directly from the sibling frontend repo at runtime
- v1 imports global career content (org_id=0)
- the primary narrative body is imported into body_md
- source/schema mismatches are handled conservatively during normalization, not guessed at import time
- default import mode is conservative and does not overwrite existing records unless --upsert is used

Why this PR is small and safe
- no frontend changes
- no route changes
- no Filament changes
- no recommendation-engine changes
- no sitemap changes
- only baseline import groundwork for later Career CMS rollout

Validation
- php artisan about
- php artisan route:list
- php artisan migrate
- php artisan test --filter='(CareerJob|Career)'
- php artisan career-jobs:import-local-baseline --dry-run
- php artisan career-jobs:import-local-baseline --locale=en --job=product-manager --status=draft
