### PR TITLE
fix(report): align snapshot queue binding

### DIFF
--- a/backend/app/CareerCms/Baseline/CareerJobBaselineImporter.php
+++ b/backend/app/CareerCms/Baseline/CareerJobBaselineImporter.php
@@ -1,0 +1,455 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\CareerCms\Baseline;
+
+use App\Models\CareerJob;
+use App\Models\CareerJobRevision;
+use App\Models\CareerJobSection;
+use App\Models\CareerJobSeoMeta;
+use App\Models\Scopes\TenantScope;
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Support\Carbon;
+use Illuminate\Support\Facades\DB;
+
+final class CareerJobBaselineImporter
+{
+    /**
+     * @param  array<int, array<string, mixed>>  $jobs
+     * @param  array{
+     *   dry_run: bool,
+     *   upsert: bool,
+     *   status: 'draft'|'published'
+     * }  $options
+     * @return array<string, int|string|bool>
+     */
+    public function import(array $jobs, array $options): array
+    {
+        $dryRun = (bool) ($options['dry_run'] ?? false);
+        $upsert = (bool) ($options['upsert'] ?? false);
+        $status = (string) ($options['status'] ?? CareerJob::STATUS_DRAFT);
+
+        $summary = [
+            'jobs_found' => count($jobs),
+            'will_create' => 0,
+            'will_update' => 0,
+            'will_skip' => 0,
+            'revisions_to_create' => 0,
+            'errors_count' => 0,
+            'dry_run' => $dryRun,
+            'upsert' => $upsert,
+            'status_mode' => $status,
+        ];
+
+        foreach ($jobs as $jobPayload) {
+            $existing = $this->jobQuery()
+                ->where('org_id', 0)
+                ->where('job_code', (string) $jobPayload['job_code'])
+                ->where('locale', (string) $jobPayload['locale'])
+                ->first();
+
+            if (! $existing instanceof CareerJob) {
+                $summary['will_create']++;
+                $summary['revisions_to_create']++;
+
+                if (! $dryRun) {
+                    DB::transaction(function () use ($jobPayload, $status): void {
+                        $job = CareerJob::query()->create(
+                            $this->jobAttributes($jobPayload, $status)
+                        );
+
+                        $this->syncSections($job, $jobPayload, false);
+                        $this->syncSeoMeta($job, $jobPayload);
+                        $this->createRevision($job, 'baseline import');
+                    });
+                }
+
+                continue;
+            }
+
+            if (! $upsert) {
+                $summary['will_skip']++;
+
+                continue;
+            }
+
+            $desiredState = $this->desiredComparableState($jobPayload, $status, $existing);
+            $currentState = $this->currentComparableState($existing);
+
+            if ($desiredState === $currentState) {
+                $summary['will_skip']++;
+
+                continue;
+            }
+
+            $summary['will_update']++;
+            $summary['revisions_to_create']++;
+
+            if (! $dryRun) {
+                DB::transaction(function () use ($existing, $jobPayload, $status): void {
+                    $existing->fill($this->jobAttributes($jobPayload, $status, $existing));
+                    $existing->save();
+
+                    $this->syncSections($existing, $jobPayload, true);
+                    $this->syncSeoMeta($existing, $jobPayload);
+                    $this->createRevision($existing, 'baseline upsert');
+                });
+            }
+        }
+
+        return $summary;
+    }
+
+    private function jobQuery(): Builder
+    {
+        return CareerJob::query()->withoutGlobalScope(TenantScope::class);
+    }
+
+    /**
+     * @param  array<string, mixed>  $jobPayload
+     * @return array<string, mixed>
+     */
+    private function jobAttributes(
+        array $jobPayload,
+        string $status,
+        ?CareerJob $existing = null,
+    ): array {
+        $publishedAt = $this->resolvePublishedAt($jobPayload, $status, $existing);
+
+        return [
+            'org_id' => 0,
+            'job_code' => (string) $jobPayload['job_code'],
+            'slug' => (string) $jobPayload['slug'],
+            'locale' => (string) $jobPayload['locale'],
+            'title' => (string) $jobPayload['title'],
+            'subtitle' => $jobPayload['subtitle'],
+            'excerpt' => $jobPayload['excerpt'],
+            'hero_kicker' => $jobPayload['hero_kicker'],
+            'hero_quote' => $jobPayload['hero_quote'],
+            'cover_image_url' => $jobPayload['cover_image_url'],
+            'industry_slug' => $jobPayload['industry_slug'],
+            'industry_label' => $jobPayload['industry_label'],
+            'body_md' => $jobPayload['body_md'],
+            'body_html' => $jobPayload['body_html'],
+            'salary_json' => $jobPayload['salary_json'],
+            'outlook_json' => $jobPayload['outlook_json'],
+            'skills_json' => $jobPayload['skills_json'],
+            'work_contents_json' => $jobPayload['work_contents_json'],
+            'growth_path_json' => $jobPayload['growth_path_json'],
+            'fit_personality_codes_json' => $jobPayload['fit_personality_codes_json'],
+            'mbti_primary_codes_json' => $jobPayload['mbti_primary_codes_json'],
+            'mbti_secondary_codes_json' => $jobPayload['mbti_secondary_codes_json'],
+            'riasec_profile_json' => $jobPayload['riasec_profile_json'],
+            'big5_targets_json' => $jobPayload['big5_targets_json'],
+            'iq_eq_notes_json' => $jobPayload['iq_eq_notes_json'],
+            'market_demand_json' => $jobPayload['market_demand_json'],
+            'status' => $status,
+            'is_public' => (bool) $jobPayload['is_public'],
+            'is_indexable' => (bool) $jobPayload['is_indexable'],
+            'published_at' => $publishedAt,
+            'scheduled_at' => $status === CareerJob::STATUS_DRAFT
+                ? null
+                : $this->normalizeNullableDate($jobPayload['scheduled_at'] ?? null),
+            'schema_version' => (string) ($jobPayload['schema_version'] ?? 'v1'),
+            'sort_order' => (int) ($jobPayload['sort_order'] ?? 0),
+        ];
+    }
+
+    /**
+     * @param  array<string, mixed>  $jobPayload
+     */
+    private function syncSections(CareerJob $job, array $jobPayload, bool $fullSync): void
+    {
+        $desiredSections = [];
+
+        foreach ((array) $jobPayload['sections'] as $section) {
+            $desiredSections[(string) $section['section_key']] = [
+                'title' => $section['title'],
+                'render_variant' => (string) $section['render_variant'],
+                'body_md' => $section['body_md'],
+                'body_html' => $section['body_html'],
+                'payload_json' => $section['payload_json'],
+                'sort_order' => (int) $section['sort_order'],
+                'is_enabled' => (bool) $section['is_enabled'],
+            ];
+        }
+
+        foreach ($desiredSections as $sectionKey => $attributes) {
+            CareerJobSection::query()->updateOrCreate(
+                [
+                    'job_id' => (int) $job->id,
+                    'section_key' => $sectionKey,
+                ],
+                $attributes,
+            );
+        }
+
+        if ($fullSync) {
+            $managedKeys = array_values(array_intersect(
+                array_keys($desiredSections),
+                CareerJobSection::SECTION_KEYS,
+            ));
+
+            $deleteQuery = CareerJobSection::query()
+                ->where('job_id', (int) $job->id)
+                ->whereIn('section_key', CareerJobSection::SECTION_KEYS);
+
+            if ($managedKeys !== []) {
+                $deleteQuery->whereNotIn('section_key', $managedKeys);
+            }
+
+            $deleteQuery->delete();
+        }
+
+        $job->unsetRelation('sections');
+    }
+
+    /**
+     * @param  array<string, mixed>  $jobPayload
+     */
+    private function syncSeoMeta(CareerJob $job, array $jobPayload): void
+    {
+        $seoMeta = (array) $jobPayload['seo_meta'];
+
+        CareerJobSeoMeta::query()->updateOrCreate(
+            [
+                'job_id' => (int) $job->id,
+            ],
+            [
+                'seo_title' => $seoMeta['seo_title'],
+                'seo_description' => $seoMeta['seo_description'],
+                'canonical_url' => $seoMeta['canonical_url'],
+                'og_title' => $seoMeta['og_title'],
+                'og_description' => $seoMeta['og_description'],
+                'og_image_url' => $seoMeta['og_image_url'],
+                'twitter_title' => $seoMeta['twitter_title'],
+                'twitter_description' => $seoMeta['twitter_description'],
+                'twitter_image_url' => $seoMeta['twitter_image_url'],
+                'robots' => $seoMeta['robots'],
+                'jsonld_overrides_json' => $seoMeta['jsonld_overrides_json'],
+            ],
+        );
+
+        $job->unsetRelation('seoMeta');
+    }
+
+    private function createRevision(CareerJob $job, string $note): void
+    {
+        CareerJobRevision::query()->create([
+            'job_id' => (int) $job->id,
+            'revision_no' => ((int) CareerJobRevision::query()
+                ->where('job_id', (int) $job->id)
+                ->max('revision_no')) + 1,
+            'snapshot_json' => $this->currentComparableState($job->fresh(['sections', 'seoMeta'])),
+            'note' => $note,
+            'created_by_admin_user_id' => null,
+            'created_at' => now(),
+        ]);
+    }
+
+    /**
+     * @param  array<string, mixed>  $jobPayload
+     * @return array<string, mixed>
+     */
+    private function desiredComparableState(
+        array $jobPayload,
+        string $status,
+        ?CareerJob $existing = null,
+    ): array {
+        $sections = collect((array) $jobPayload['sections'])
+            ->map(static fn (array $section): array => [
+                'section_key' => (string) $section['section_key'],
+                'title' => $section['title'],
+                'render_variant' => (string) $section['render_variant'],
+                'body_md' => $section['body_md'],
+                'body_html' => $section['body_html'],
+                'payload_json' => $section['payload_json'],
+                'sort_order' => (int) $section['sort_order'],
+                'is_enabled' => (bool) $section['is_enabled'],
+            ])
+            ->sortBy([
+                ['sort_order', 'asc'],
+                ['section_key', 'asc'],
+            ])
+            ->values()
+            ->all();
+
+        return [
+            'job' => [
+                'org_id' => 0,
+                'job_code' => (string) $jobPayload['job_code'],
+                'slug' => (string) $jobPayload['slug'],
+                'locale' => (string) $jobPayload['locale'],
+                'title' => (string) $jobPayload['title'],
+                'subtitle' => $jobPayload['subtitle'],
+                'excerpt' => $jobPayload['excerpt'],
+                'hero_kicker' => $jobPayload['hero_kicker'],
+                'hero_quote' => $jobPayload['hero_quote'],
+                'cover_image_url' => $jobPayload['cover_image_url'],
+                'industry_slug' => $jobPayload['industry_slug'],
+                'industry_label' => $jobPayload['industry_label'],
+                'body_md' => $jobPayload['body_md'],
+                'body_html' => $jobPayload['body_html'],
+                'salary_json' => $jobPayload['salary_json'],
+                'outlook_json' => $jobPayload['outlook_json'],
+                'skills_json' => $jobPayload['skills_json'],
+                'work_contents_json' => $jobPayload['work_contents_json'],
+                'growth_path_json' => $jobPayload['growth_path_json'],
+                'fit_personality_codes_json' => $jobPayload['fit_personality_codes_json'],
+                'mbti_primary_codes_json' => $jobPayload['mbti_primary_codes_json'],
+                'mbti_secondary_codes_json' => $jobPayload['mbti_secondary_codes_json'],
+                'riasec_profile_json' => $jobPayload['riasec_profile_json'],
+                'big5_targets_json' => $jobPayload['big5_targets_json'],
+                'iq_eq_notes_json' => $jobPayload['iq_eq_notes_json'],
+                'market_demand_json' => $jobPayload['market_demand_json'],
+                'status' => $status,
+                'is_public' => (bool) $jobPayload['is_public'],
+                'is_indexable' => (bool) $jobPayload['is_indexable'],
+                'published_at' => $this->normalizeDateForComparison(
+                    $this->resolvePublishedAt($jobPayload, $status, $existing)
+                ),
+                'scheduled_at' => $status === CareerJob::STATUS_DRAFT
+                    ? null
+                    : $this->normalizeDateForComparison($this->normalizeNullableDate($jobPayload['scheduled_at'] ?? null)),
+                'schema_version' => (string) ($jobPayload['schema_version'] ?? 'v1'),
+                'sort_order' => (int) ($jobPayload['sort_order'] ?? 0),
+            ],
+            'sections' => $sections,
+            'seo_meta' => (array) $jobPayload['seo_meta'],
+        ];
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function currentComparableState(CareerJob $job): array
+    {
+        $job->loadMissing('sections', 'seoMeta');
+
+        return [
+            'job' => [
+                'org_id' => (int) $job->org_id,
+                'job_code' => (string) $job->job_code,
+                'slug' => (string) $job->slug,
+                'locale' => (string) $job->locale,
+                'title' => (string) $job->title,
+                'subtitle' => $job->subtitle,
+                'excerpt' => $job->excerpt,
+                'hero_kicker' => $job->hero_kicker,
+                'hero_quote' => $job->hero_quote,
+                'cover_image_url' => $job->cover_image_url,
+                'industry_slug' => $job->industry_slug,
+                'industry_label' => $job->industry_label,
+                'body_md' => $job->body_md,
+                'body_html' => $job->body_html,
+                'salary_json' => $job->salary_json,
+                'outlook_json' => $job->outlook_json,
+                'skills_json' => $job->skills_json,
+                'work_contents_json' => $job->work_contents_json,
+                'growth_path_json' => $job->growth_path_json,
+                'fit_personality_codes_json' => $job->fit_personality_codes_json,
+                'mbti_primary_codes_json' => $job->mbti_primary_codes_json,
+                'mbti_secondary_codes_json' => $job->mbti_secondary_codes_json,
+                'riasec_profile_json' => $job->riasec_profile_json,
+                'big5_targets_json' => $job->big5_targets_json,
+                'iq_eq_notes_json' => $job->iq_eq_notes_json,
+                'market_demand_json' => $job->market_demand_json,
+                'status' => (string) $job->status,
+                'is_public' => (bool) $job->is_public,
+                'is_indexable' => (bool) $job->is_indexable,
+                'published_at' => $this->normalizeDateForComparison($job->published_at),
+                'scheduled_at' => $this->normalizeDateForComparison($job->scheduled_at),
+                'schema_version' => (string) $job->schema_version,
+                'sort_order' => (int) $job->sort_order,
+            ],
+            'sections' => $job->sections
+                ->map(static fn (CareerJobSection $section): array => [
+                    'section_key' => (string) $section->section_key,
+                    'title' => $section->title,
+                    'render_variant' => (string) $section->render_variant,
+                    'body_md' => $section->body_md,
+                    'body_html' => $section->body_html,
+                    'payload_json' => $section->payload_json,
+                    'sort_order' => (int) $section->sort_order,
+                    'is_enabled' => (bool) $section->is_enabled,
+                ])
+                ->sortBy([
+                    ['sort_order', 'asc'],
+                    ['section_key', 'asc'],
+                ])
+                ->values()
+                ->all(),
+            'seo_meta' => $job->seoMeta instanceof CareerJobSeoMeta
+                ? [
+                    'seo_title' => $job->seoMeta->seo_title,
+                    'seo_description' => $job->seoMeta->seo_description,
+                    'canonical_url' => $job->seoMeta->canonical_url,
+                    'og_title' => $job->seoMeta->og_title,
+                    'og_description' => $job->seoMeta->og_description,
+                    'og_image_url' => $job->seoMeta->og_image_url,
+                    'twitter_title' => $job->seoMeta->twitter_title,
+                    'twitter_description' => $job->seoMeta->twitter_description,
+                    'twitter_image_url' => $job->seoMeta->twitter_image_url,
+                    'robots' => $job->seoMeta->robots,
+                    'jsonld_overrides_json' => $job->seoMeta->jsonld_overrides_json,
+                ]
+                : [
+                    'seo_title' => null,
+                    'seo_description' => null,
+                    'canonical_url' => null,
+                    'og_title' => null,
+                    'og_description' => null,
+                    'og_image_url' => null,
+                    'twitter_title' => null,
+                    'twitter_description' => null,
+                    'twitter_image_url' => null,
+                    'robots' => null,
+                    'jsonld_overrides_json' => null,
+                ],
+        ];
+    }
+
+    /**
+     * @param  array<string, mixed>  $jobPayload
+     */
+    private function resolvePublishedAt(
+        array $jobPayload,
+        string $status,
+        ?CareerJob $existing = null,
+    ): ?Carbon {
+        if ($status === CareerJob::STATUS_DRAFT) {
+            return null;
+        }
+
+        return $this->normalizeNullableDate($jobPayload['published_at'] ?? null)
+            ?? $existing?->published_at
+            ?? now();
+    }
+
+    private function normalizeNullableDate(mixed $value): ?Carbon
+    {
+        if ($value instanceof Carbon) {
+            return $value;
+        }
+
+        if ($value instanceof \DateTimeInterface) {
+            return Carbon::instance($value);
+        }
+
+        $normalized = trim((string) $value);
+
+        if ($normalized === '') {
+            return null;
+        }
+
+        return Carbon::parse($normalized);
+    }
+
+    private function normalizeDateForComparison(mixed $value): ?string
+    {
+        $normalized = $this->normalizeNullableDate($value);
+
+        return $normalized?->toIso8601String();
+    }
+}

--- a/backend/app/CareerCms/Baseline/CareerJobBaselineNormalizer.php
+++ b/backend/app/CareerCms/Baseline/CareerJobBaselineNormalizer.php
@@ -1,0 +1,540 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\CareerCms\Baseline;
+
+use App\Models\CareerJob;
+use App\Models\CareerJobSection;
+use Illuminate\Support\Arr;
+use Illuminate\Support\Str;
+use RuntimeException;
+
+final class CareerJobBaselineNormalizer
+{
+    /**
+     * @var array<int, string>
+     */
+    private const VALID_MBTI_CODES = [
+        'INTJ',
+        'INTP',
+        'ENTJ',
+        'ENTP',
+        'INFJ',
+        'INFP',
+        'ENFJ',
+        'ENFP',
+        'ISTJ',
+        'ISFJ',
+        'ESTJ',
+        'ESFJ',
+        'ISTP',
+        'ISFP',
+        'ESTP',
+        'ESFP',
+    ];
+
+    /**
+     * @param  array<int, array{file: string, payload: array<string, mixed>}>  $documents
+     * @param  array<int, string>  $selectedJobs
+     * @return array<int, array<string, mixed>>
+     */
+    public function normalizeDocuments(array $documents, array $selectedJobs = []): array
+    {
+        $normalizedJobs = $this->normalizeSelectedJobs($selectedJobs);
+        $jobs = [];
+        $seenByLocaleJob = [];
+        $seenByLocaleSlug = [];
+
+        foreach ($documents as $document) {
+            $file = (string) ($document['file'] ?? 'unknown');
+            $payload = is_array($document['payload'] ?? null) ? $document['payload'] : [];
+            $meta = is_array($payload['meta'] ?? null) ? $payload['meta'] : [];
+            $locale = $this->normalizeLocale($meta['locale'] ?? null, $file);
+            $schemaVersion = trim((string) ($meta['schema_version'] ?? 'v1'));
+            $rows = $payload['jobs'] ?? null;
+
+            if (! is_array($rows)) {
+                throw new RuntimeException(sprintf(
+                    'Baseline file %s must contain a jobs array.',
+                    $file,
+                ));
+            }
+
+            foreach ($rows as $index => $row) {
+                if (! is_array($row)) {
+                    throw new RuntimeException(sprintf(
+                        'Baseline file %s contains a non-object job row at index %d.',
+                        $file,
+                        $index,
+                    ));
+                }
+
+                $job = $this->normalizeJob($row, $locale, $schemaVersion, $file, $index);
+                $jobCode = (string) $job['job_code'];
+                $slug = (string) $job['slug'];
+
+                if ($normalizedJobs !== [] && ! in_array($jobCode, $normalizedJobs, true)) {
+                    continue;
+                }
+
+                $jobKey = $locale.'|'.$jobCode;
+                $slugKey = $locale.'|'.$slug;
+
+                if (isset($seenByLocaleJob[$jobKey])) {
+                    throw new RuntimeException(sprintf(
+                        'Duplicate job_code %s for locale %s in baseline file %s.',
+                        $jobCode,
+                        $locale,
+                        $file,
+                    ));
+                }
+
+                if (isset($seenByLocaleSlug[$slugKey])) {
+                    throw new RuntimeException(sprintf(
+                        'Duplicate slug %s for locale %s in baseline file %s.',
+                        $slug,
+                        $locale,
+                        $file,
+                    ));
+                }
+
+                $seenByLocaleJob[$jobKey] = true;
+                $seenByLocaleSlug[$slugKey] = true;
+                $jobs[] = $job;
+            }
+        }
+
+        usort(
+            $jobs,
+            static fn (array $left, array $right): int => [$left['locale'], $left['job_code']]
+                <=> [$right['locale'], $right['job_code']],
+        );
+
+        return $jobs;
+    }
+
+    /**
+     * @param  array<string, mixed>  $row
+     * @return array<string, mixed>
+     */
+    private function normalizeJob(
+        array $row,
+        string $documentLocale,
+        string $schemaVersion,
+        string $file,
+        int $index,
+    ): array {
+        $jobCode = $this->normalizeIdentifier($row['job_code'] ?? $row['slug'] ?? null, 'job_code', $file, $index);
+        $slug = $this->normalizeIdentifier($row['slug'] ?? $jobCode, 'slug', $file, $index);
+        $locale = Arr::exists($row, 'locale')
+            ? $this->normalizeLocale($row['locale'], $file)
+            : $documentLocale;
+        $title = trim((string) ($row['title'] ?? ''));
+
+        if ($locale !== $documentLocale) {
+            throw new RuntimeException(sprintf(
+                'Baseline file %s has locale mismatch for %s at jobs[%d].',
+                $file,
+                $jobCode,
+                $index,
+            ));
+        }
+
+        if ($title === '') {
+            throw new RuntimeException(sprintf(
+                'Baseline file %s is missing title for %s at jobs[%d].',
+                $file,
+                $jobCode,
+                $index,
+            ));
+        }
+
+        return [
+            'org_id' => 0,
+            'schema_version' => $schemaVersion !== '' ? $schemaVersion : 'v1',
+            'job_code' => $jobCode,
+            'slug' => $slug,
+            'locale' => $locale,
+            'title' => $title,
+            'subtitle' => $this->normalizeNullableText($row['subtitle'] ?? null),
+            'excerpt' => $this->normalizeNullableText($row['excerpt'] ?? null),
+            'hero_kicker' => $this->normalizeNullableText($row['hero_kicker'] ?? null),
+            'hero_quote' => $this->normalizeNullableText($row['hero_quote'] ?? null),
+            'cover_image_url' => $this->normalizeNullableText($row['cover_image_url'] ?? null),
+            'industry_slug' => $this->normalizeNullableText($row['industry_slug'] ?? null),
+            'industry_label' => $this->normalizeNullableText($row['industry_label'] ?? null),
+            'body_md' => $this->normalizeNullableText($row['body_md'] ?? null),
+            'body_html' => $this->normalizeNullableText($row['body_html'] ?? null),
+            'salary_json' => $this->normalizeNullableArray($row['salary_json'] ?? null),
+            'outlook_json' => $this->normalizeNullableArray($row['outlook_json'] ?? null),
+            'skills_json' => $this->normalizeNullableArray($row['skills_json'] ?? null),
+            'work_contents_json' => $this->normalizeNullableArray($row['work_contents_json'] ?? null),
+            'growth_path_json' => $this->normalizeNullableArray($row['growth_path_json'] ?? null),
+            'fit_personality_codes_json' => $this->normalizeNullableMbtiArray(
+                $row['fit_personality_codes_json'] ?? null,
+                $file,
+                $jobCode,
+                'fit_personality_codes_json',
+            ),
+            'mbti_primary_codes_json' => $this->normalizeRequiredMbtiArray(
+                $row['mbti_primary_codes_json'] ?? null,
+                $file,
+                $jobCode,
+                'mbti_primary_codes_json',
+            ),
+            'mbti_secondary_codes_json' => $this->normalizeRequiredMbtiArray(
+                $row['mbti_secondary_codes_json'] ?? null,
+                $file,
+                $jobCode,
+                'mbti_secondary_codes_json',
+            ),
+            'riasec_profile_json' => $this->normalizeRiasecProfile(
+                $row['riasec_profile_json'] ?? null,
+                $file,
+                $jobCode,
+            ),
+            'big5_targets_json' => $this->normalizeNullableArray($row['big5_targets_json'] ?? null),
+            'iq_eq_notes_json' => $this->normalizeNullableArray($row['iq_eq_notes_json'] ?? null),
+            'market_demand_json' => $this->normalizeNullableArray($row['market_demand_json'] ?? null),
+            'status' => $this->normalizeStatus($row['status'] ?? 'published', $file, $index),
+            'is_public' => $this->normalizeBool($row['is_public'] ?? true),
+            'is_indexable' => $this->normalizeBool($row['is_indexable'] ?? true),
+            'published_at' => $this->normalizeNullableText($row['published_at'] ?? null),
+            'scheduled_at' => $this->normalizeNullableText($row['scheduled_at'] ?? null),
+            'sort_order' => (int) ($row['sort_order'] ?? 0),
+            'sections' => $this->normalizeSections(
+                is_array($row['sections'] ?? null) ? $row['sections'] : [],
+                $file,
+                $jobCode,
+            ),
+            'seo_meta' => $this->normalizeSeoMeta(
+                is_array($row['seo_meta'] ?? null) ? $row['seo_meta'] : [],
+            ),
+        ];
+    }
+
+    /**
+     * @param  array<int, mixed>  $rows
+     * @return array<int, array<string, mixed>>
+     */
+    private function normalizeSections(array $rows, string $file, string $jobCode): array
+    {
+        $sections = [];
+        $seen = [];
+
+        foreach ($rows as $index => $row) {
+            if (! is_array($row)) {
+                throw new RuntimeException(sprintf(
+                    'Baseline file %s contains a non-object section for %s at sections[%d].',
+                    $file,
+                    $jobCode,
+                    $index,
+                ));
+            }
+
+            $sectionKey = trim((string) ($row['section_key'] ?? ''));
+            $renderVariant = trim((string) ($row['render_variant'] ?? ''));
+
+            if ($sectionKey === '' || ! in_array($sectionKey, CareerJobSection::SECTION_KEYS, true)) {
+                throw new RuntimeException(sprintf(
+                    'Baseline file %s contains unsupported section_key=%s for %s.',
+                    $file,
+                    $sectionKey,
+                    $jobCode,
+                ));
+            }
+
+            if ($renderVariant === '' || ! in_array($renderVariant, CareerJobSection::RENDER_VARIANTS, true)) {
+                throw new RuntimeException(sprintf(
+                    'Baseline file %s contains invalid render_variant for %s section %s.',
+                    $file,
+                    $jobCode,
+                    $sectionKey,
+                ));
+            }
+
+            if (isset($seen[$sectionKey])) {
+                throw new RuntimeException(sprintf(
+                    'Baseline file %s contains duplicate section_key=%s for %s.',
+                    $file,
+                    $sectionKey,
+                    $jobCode,
+                ));
+            }
+
+            $sections[] = [
+                'section_key' => $sectionKey,
+                'title' => $this->normalizeNullableText($row['title'] ?? null),
+                'render_variant' => $renderVariant,
+                'body_md' => $this->normalizeNullableText($row['body_md'] ?? null),
+                'body_html' => $this->normalizeNullableText($row['body_html'] ?? null),
+                'payload_json' => Arr::exists($row, 'payload_json')
+                    ? $this->normalizeNullableArray($row['payload_json'])
+                    : null,
+                'sort_order' => (int) ($row['sort_order'] ?? 0),
+                'is_enabled' => $this->normalizeBool($row['is_enabled'] ?? true),
+            ];
+
+            $seen[$sectionKey] = true;
+        }
+
+        usort(
+            $sections,
+            static fn (array $left, array $right): int => [$left['sort_order'], $left['section_key']]
+                <=> [$right['sort_order'], $right['section_key']],
+        );
+
+        return $sections;
+    }
+
+    /**
+     * @param  array<string, mixed>  $seoMeta
+     * @return array<string, mixed>
+     */
+    private function normalizeSeoMeta(array $seoMeta): array
+    {
+        return [
+            'seo_title' => $this->normalizeNullableText($seoMeta['seo_title'] ?? null),
+            'seo_description' => $this->normalizeNullableText($seoMeta['seo_description'] ?? null),
+            'canonical_url' => $this->normalizeNullableText($seoMeta['canonical_url'] ?? null),
+            'og_title' => $this->normalizeNullableText($seoMeta['og_title'] ?? null),
+            'og_description' => $this->normalizeNullableText($seoMeta['og_description'] ?? null),
+            'og_image_url' => $this->normalizeNullableText($seoMeta['og_image_url'] ?? null),
+            'twitter_title' => $this->normalizeNullableText($seoMeta['twitter_title'] ?? null),
+            'twitter_description' => $this->normalizeNullableText($seoMeta['twitter_description'] ?? null),
+            'twitter_image_url' => $this->normalizeNullableText($seoMeta['twitter_image_url'] ?? null),
+            'robots' => $this->normalizeNullableText($seoMeta['robots'] ?? null),
+            'jsonld_overrides_json' => Arr::exists($seoMeta, 'jsonld_overrides_json')
+                ? $this->normalizeNullableArray($seoMeta['jsonld_overrides_json'])
+                : null,
+        ];
+    }
+
+    private function normalizeLocale(mixed $locale, string $file): string
+    {
+        $normalized = trim((string) $locale);
+        $normalized = $normalized === 'zh' ? 'zh-CN' : $normalized;
+
+        if (! in_array($normalized, CareerJob::SUPPORTED_LOCALES, true)) {
+            throw new RuntimeException(sprintf(
+                'Baseline file %s has unsupported locale=%s.',
+                $file,
+                (string) $locale,
+            ));
+        }
+
+        return $normalized;
+    }
+
+    /**
+     * @param  array<int, string>  $selectedJobs
+     * @return array<int, string>
+     */
+    private function normalizeSelectedJobs(array $selectedJobs): array
+    {
+        $normalized = [];
+
+        foreach ($selectedJobs as $job) {
+            $candidate = Str::lower(trim((string) $job));
+
+            if ($candidate === '') {
+                continue;
+            }
+
+            $normalized[] = $candidate;
+        }
+
+        return array_values(array_unique($normalized));
+    }
+
+    private function normalizeIdentifier(mixed $value, string $field, string $file, int $index): string
+    {
+        $normalized = Str::lower(trim((string) $value));
+
+        if ($normalized === '') {
+            throw new RuntimeException(sprintf(
+                'Baseline file %s is missing %s at jobs[%d].',
+                $file,
+                $field,
+                $index,
+            ));
+        }
+
+        return $normalized;
+    }
+
+    /**
+     * @return array<int, string>
+     */
+    private function normalizeRequiredMbtiArray(mixed $value, string $file, string $jobCode, string $field): array
+    {
+        $arr = $this->normalizeMbtiArray($value, $file, $jobCode, $field);
+
+        if ($arr === []) {
+            throw new RuntimeException(sprintf(
+                'Baseline file %s has empty %s for %s.',
+                $file,
+                $field,
+                $jobCode,
+            ));
+        }
+
+        return $arr;
+    }
+
+    /**
+     * @return array<int, string>|null
+     */
+    private function normalizeNullableMbtiArray(mixed $value, string $file, string $jobCode, string $field): ?array
+    {
+        if ($value === null) {
+            return null;
+        }
+
+        $arr = $this->normalizeMbtiArray($value, $file, $jobCode, $field);
+
+        return $arr === [] ? null : $arr;
+    }
+
+    /**
+     * @return array<int, string>
+     */
+    private function normalizeMbtiArray(mixed $value, string $file, string $jobCode, string $field): array
+    {
+        if (is_string($value)) {
+            $value = [$value];
+        }
+
+        if (! is_array($value)) {
+            throw new RuntimeException(sprintf(
+                'Baseline file %s has invalid %s for %s.',
+                $file,
+                $field,
+                $jobCode,
+            ));
+        }
+
+        $arr = array_values(array_filter(
+            array_map(static fn (mixed $item): string => Str::upper(trim((string) $item)), $value),
+            static fn (string $item): bool => $item !== '',
+        ));
+
+        foreach ($arr as $code) {
+            if (! in_array($code, self::VALID_MBTI_CODES, true)) {
+                throw new RuntimeException(sprintf(
+                    'Baseline file %s has invalid MBTI code=%s in %s for %s.',
+                    $file,
+                    $code,
+                    $field,
+                    $jobCode,
+                ));
+            }
+        }
+
+        return array_values(array_unique($arr));
+    }
+
+    /**
+     * @return array<string, int|float>|null
+     */
+    private function normalizeRiasecProfile(mixed $value, string $file, string $jobCode): ?array
+    {
+        if ($value === null) {
+            return null;
+        }
+
+        if (! is_array($value)) {
+            throw new RuntimeException(sprintf(
+                'Baseline file %s has invalid riasec_profile_json for %s.',
+                $file,
+                $jobCode,
+            ));
+        }
+
+        $normalized = [];
+        $validKeys = ['R', 'I', 'A', 'S', 'E', 'C'];
+
+        foreach ($value as $key => $score) {
+            $riasecKey = Str::upper(trim((string) $key));
+            if (! in_array($riasecKey, $validKeys, true)) {
+                throw new RuntimeException(sprintf(
+                    'Baseline file %s has invalid RIASEC key=%s for %s.',
+                    $file,
+                    (string) $key,
+                    $jobCode,
+                ));
+            }
+
+            if (! is_numeric($score)) {
+                throw new RuntimeException(sprintf(
+                    'Baseline file %s has non-numeric RIASEC score for %s key %s.',
+                    $file,
+                    $jobCode,
+                    $riasecKey,
+                ));
+            }
+
+            $normalized[$riasecKey] = $score + 0;
+        }
+
+        return $normalized;
+    }
+
+    private function normalizeStatus(mixed $status, string $file, int $index): string
+    {
+        $normalized = trim((string) $status);
+
+        if (! in_array($normalized, [CareerJob::STATUS_DRAFT, CareerJob::STATUS_PUBLISHED], true)) {
+            throw new RuntimeException(sprintf(
+                'Baseline file %s has invalid status at jobs[%d].',
+                $file,
+                $index,
+            ));
+        }
+
+        return $normalized;
+    }
+
+    private function normalizeBool(mixed $value): bool
+    {
+        if (is_bool($value)) {
+            return $value;
+        }
+
+        if (is_numeric($value)) {
+            return (bool) $value;
+        }
+
+        $normalized = Str::lower(trim((string) $value));
+
+        return in_array($normalized, ['1', 'true', 'yes', 'on'], true);
+    }
+
+    private function normalizeNullableText(mixed $value): ?string
+    {
+        if ($value === null) {
+            return null;
+        }
+
+        $normalized = trim((string) $value);
+
+        return $normalized === '' ? null : $normalized;
+    }
+
+    /**
+     * @return array<string, mixed>|array<int, mixed>|null
+     */
+    private function normalizeNullableArray(mixed $value): ?array
+    {
+        if ($value === null) {
+            return null;
+        }
+
+        if (! is_array($value)) {
+            throw new RuntimeException('Expected array-compatible baseline payload.');
+        }
+
+        return $value;
+    }
+}

--- a/backend/app/CareerCms/Baseline/CareerJobBaselineReader.php
+++ b/backend/app/CareerCms/Baseline/CareerJobBaselineReader.php
@@ -1,0 +1,128 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\CareerCms\Baseline;
+
+use App\Models\CareerJob;
+use RuntimeException;
+
+final class CareerJobBaselineReader
+{
+    public function resolveSourceDir(?string $sourceDir = null): string
+    {
+        $candidate = trim((string) $sourceDir);
+
+        if ($candidate === '') {
+            $candidate = base_path('../content_baselines/career_jobs');
+        } elseif (! str_starts_with($candidate, DIRECTORY_SEPARATOR)) {
+            $candidate = base_path($candidate);
+        }
+
+        $resolved = realpath($candidate);
+
+        if ($resolved === false || ! is_dir($resolved)) {
+            throw new RuntimeException(sprintf(
+                'Career job baseline source directory not found: %s',
+                $candidate,
+            ));
+        }
+
+        return $resolved;
+    }
+
+    /**
+     * @param  array<int, string>  $selectedLocales
+     * @return array<int, array{file: string, payload: array<string, mixed>}>
+     */
+    public function read(string $sourceDir, array $selectedLocales = []): array
+    {
+        $locales = $this->normalizeSelectedLocales($selectedLocales);
+        $files = $locales === []
+            ? glob(rtrim($sourceDir, DIRECTORY_SEPARATOR).DIRECTORY_SEPARATOR.'career_jobs.*.json') ?: []
+            : array_map(
+                static fn (string $locale): string => rtrim($sourceDir, DIRECTORY_SEPARATOR)
+                    .DIRECTORY_SEPARATOR
+                    .sprintf('career_jobs.%s.json', $locale),
+                $locales,
+            );
+
+        if ($files === []) {
+            throw new RuntimeException(sprintf(
+                'No career job baseline files found in %s.',
+                $sourceDir,
+            ));
+        }
+
+        sort($files);
+
+        $documents = [];
+
+        foreach ($files as $file) {
+            if (! is_file($file)) {
+                throw new RuntimeException(sprintf(
+                    'Career job baseline file missing: %s',
+                    $file,
+                ));
+            }
+
+            $raw = file_get_contents($file);
+
+            if (! is_string($raw) || trim($raw) === '') {
+                throw new RuntimeException(sprintf(
+                    'Career job baseline file is empty: %s',
+                    $file,
+                ));
+            }
+
+            $decoded = json_decode($raw, true);
+
+            if (! is_array($decoded)) {
+                throw new RuntimeException(sprintf(
+                    'Career job baseline file is not valid JSON: %s',
+                    $file,
+                ));
+            }
+
+            $documents[] = [
+                'file' => $file,
+                'payload' => $decoded,
+            ];
+        }
+
+        return $documents;
+    }
+
+    /**
+     * @param  array<int, string>  $selectedLocales
+     * @return array<int, string>
+     */
+    private function normalizeSelectedLocales(array $selectedLocales): array
+    {
+        $normalized = [];
+
+        foreach ($selectedLocales as $locale) {
+            $candidate = trim((string) $locale);
+
+            if ($candidate === '') {
+                continue;
+            }
+
+            $candidate = $candidate === 'zh' ? 'zh-CN' : $candidate;
+            $normalized[] = $candidate;
+        }
+
+        $normalized = array_values(array_unique($normalized));
+
+        foreach ($normalized as $locale) {
+            if (! in_array($locale, CareerJob::SUPPORTED_LOCALES, true)) {
+                throw new RuntimeException(sprintf(
+                    'Unsupported locale selection: %s',
+                    $locale,
+                ));
+            }
+        }
+
+        return $normalized;
+    }
+}

--- a/backend/app/Console/Commands/CareerJobImportLocalBaseline.php
+++ b/backend/app/Console/Commands/CareerJobImportLocalBaseline.php
@@ -1,0 +1,85 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Console\Commands;
+
+use App\CareerCms\Baseline\CareerJobBaselineImporter;
+use App\CareerCms\Baseline\CareerJobBaselineNormalizer;
+use App\CareerCms\Baseline\CareerJobBaselineReader;
+use App\Models\CareerJob;
+use Illuminate\Console\Command;
+use RuntimeException;
+
+final class CareerJobImportLocalBaseline extends Command
+{
+    protected $signature = 'career-jobs:import-local-baseline
+        {--dry-run : Validate and diff without writing to the database}
+        {--locale=* : Import only specific locale(s)}
+        {--job=* : Import only specific job code(s)}
+        {--upsert : Update existing records instead of create-missing only}
+        {--status=draft : Force imported records to draft or published}
+        {--source-dir= : Override the committed baseline source directory}';
+
+    protected $description = 'Import committed career jobs baseline content into CareerJob CMS tables.';
+
+    public function handle(
+        CareerJobBaselineReader $reader,
+        CareerJobBaselineNormalizer $normalizer,
+        CareerJobBaselineImporter $importer,
+    ): int {
+        try {
+            $status = trim((string) $this->option('status'));
+            if (! in_array($status, [CareerJob::STATUS_DRAFT, CareerJob::STATUS_PUBLISHED], true)) {
+                throw new RuntimeException(sprintf(
+                    'Unsupported --status value: %s',
+                    $status,
+                ));
+            }
+
+            $sourceDir = $reader->resolveSourceDir(
+                $this->option('source-dir') !== null
+                    ? (string) $this->option('source-dir')
+                    : null,
+            );
+            $selectedLocales = array_values(array_filter(
+                array_map(static fn (string $value): string => trim($value), (array) $this->option('locale')),
+                static fn (string $value): bool => $value !== '',
+            ));
+            $selectedJobs = array_values(array_filter(
+                array_map(static fn (string $value): string => trim($value), (array) $this->option('job')),
+                static fn (string $value): bool => $value !== '',
+            ));
+
+            $documents = $reader->read($sourceDir, $selectedLocales);
+            $jobs = $normalizer->normalizeDocuments($documents, $selectedJobs);
+            $summary = $importer->import($jobs, [
+                'dry_run' => (bool) $this->option('dry-run'),
+                'upsert' => (bool) $this->option('upsert'),
+                'status' => $status,
+            ]);
+
+            $this->line('baseline_source_dir='.$sourceDir);
+            $this->line('locales_selected='.($selectedLocales === [] ? 'all' : implode(',', $selectedLocales)));
+            $this->line('jobs_selected='.($selectedJobs === [] ? 'all' : implode(',', $selectedJobs)));
+            $this->line('dry_run='.((bool) $this->option('dry-run') ? '1' : '0'));
+            $this->line('upsert='.((bool) $this->option('upsert') ? '1' : '0'));
+            $this->line('status_mode='.$status);
+            $this->line('files_found='.(string) count($documents));
+            $this->line('jobs_found='.(string) $summary['jobs_found']);
+            $this->line('will_create='.(string) $summary['will_create']);
+            $this->line('will_update='.(string) $summary['will_update']);
+            $this->line('will_skip='.(string) $summary['will_skip']);
+            $this->line('revisions_to_create='.(string) $summary['revisions_to_create']);
+            $this->line('errors_count='.(string) $summary['errors_count']);
+
+            $this->info((bool) $this->option('dry-run') ? 'dry-run complete' : 'import complete');
+
+            return self::SUCCESS;
+        } catch (\Throwable $throwable) {
+            $this->error($throwable->getMessage());
+
+            return self::FAILURE;
+        }
+    }
+}

--- a/backend/app/Filament/Ops/Resources/CareerJobResource.php
+++ b/backend/app/Filament/Ops/Resources/CareerJobResource.php
@@ -1,0 +1,687 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Filament\Ops\Resources;
+
+use App\Filament\Ops\Resources\CareerJobResource\Pages;
+use App\Filament\Ops\Resources\CareerJobResource\Support\CareerJobWorkspace;
+use App\Filament\Ops\Support\StatusBadge;
+use App\Models\CareerJob;
+use App\Support\Rbac\PermissionNames;
+use Filament\Forms;
+use Filament\Forms\Form;
+use Filament\Resources\Resource;
+use Filament\Tables;
+use Filament\Tables\Filters\TernaryFilter;
+use Filament\Tables\Table;
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Support\Str;
+
+class CareerJobResource extends Resource
+{
+    protected static ?string $model = CareerJob::class;
+
+    protected static ?string $slug = 'career-jobs';
+
+    protected static ?string $recordTitleAttribute = 'title';
+
+    protected static ?string $navigationIcon = 'heroicon-o-briefcase';
+
+    protected static ?string $navigationGroup = 'Content';
+
+    protected static ?string $navigationLabel = 'Career Jobs';
+
+    protected static ?string $modelLabel = 'Career Job';
+
+    protected static ?string $pluralModelLabel = 'Career Jobs';
+
+    public static function canViewAny(): bool
+    {
+        return self::canRead();
+    }
+
+    public static function canCreate(): bool
+    {
+        return self::canPublish();
+    }
+
+    public static function canEdit($record): bool
+    {
+        return self::canPublish();
+    }
+
+    public static function canDelete($record): bool
+    {
+        return false;
+    }
+
+    public static function getNavigationGroup(): ?string
+    {
+        return __('ops.group.content');
+    }
+
+    public static function getNavigationLabel(): string
+    {
+        return 'Career Jobs';
+    }
+
+    public static function form(Form $form): Form
+    {
+        return $form->schema([
+            Forms\Components\Hidden::make('org_id')
+                ->default(0),
+            Forms\Components\Grid::make([
+                'default' => 1,
+                'xl' => 12,
+            ])
+                ->extraAttributes(['class' => 'ops-career-job-workspace-layout'])
+                ->schema([
+                    Forms\Components\Group::make([
+                        Forms\Components\Section::make('Basic')
+                            ->description('Shape the career job headline, summary, and industry context before editing structured signals.')
+                            ->extraAttributes(['class' => 'ops-career-job-workspace-section ops-career-job-workspace-section--main'])
+                            ->schema([
+                                Forms\Components\TextInput::make('title')
+                                    ->required()
+                                    ->maxLength(255)
+                                    ->columnSpanFull()
+                                    ->helperText('Primary job heading used across the workspace, public detail page, and SEO fallbacks.')
+                                    ->extraFieldWrapperAttributes(['class' => 'ops-career-job-workspace-field ops-career-job-workspace-field--title'])
+                                    ->extraInputAttributes(['class' => 'ops-career-job-workspace-input ops-career-job-workspace-input--title']),
+                                Forms\Components\TextInput::make('subtitle')
+                                    ->maxLength(255)
+                                    ->columnSpanFull()
+                                    ->helperText('Optional supporting line for the hero and quick editorial scanning.'),
+                                Forms\Components\Textarea::make('excerpt')
+                                    ->rows(4)
+                                    ->columnSpanFull()
+                                    ->helperText('Short summary used for list previews, public excerpts, and SEO description fallbacks.')
+                                    ->extraFieldWrapperAttributes(['class' => 'ops-career-job-workspace-field ops-career-job-workspace-field--summary']),
+                                Forms\Components\TextInput::make('industry_slug')
+                                    ->maxLength(128)
+                                    ->helperText('Lightweight industry key used for current frontend grouping.'),
+                                Forms\Components\TextInput::make('industry_label')
+                                    ->maxLength(255)
+                                    ->helperText('Optional editor-facing label for the industry until Industry becomes its own CMS object.'),
+                            ])
+                            ->columns(2),
+                        Forms\Components\Section::make('Hero')
+                            ->description('Optional framing content for future frontend hero treatments. Safe to leave empty.')
+                            ->extraAttributes(['class' => 'ops-career-job-workspace-section ops-career-job-workspace-section--main'])
+                            ->schema([
+                                Forms\Components\TextInput::make('hero_kicker')
+                                    ->maxLength(128),
+                                Forms\Components\Textarea::make('hero_quote')
+                                    ->rows(4),
+                                Forms\Components\TextInput::make('cover_image_url')
+                                    ->maxLength(2048)
+                                    ->columnSpanFull(),
+                            ])
+                            ->columns(2),
+                        Forms\Components\Section::make('Primary narrative')
+                            ->description('The main long-form career narrative stays on the job record instead of being broken into free-form sections.')
+                            ->extraAttributes(['class' => 'ops-career-job-workspace-section ops-career-job-workspace-section--main'])
+                            ->schema([
+                                Forms\Components\MarkdownEditor::make('body_md')
+                                    ->columnSpanFull()
+                                    ->helperText('Use markdown for the primary career narrative shown after structured job signals on the public page.')
+                                    ->extraFieldWrapperAttributes(['class' => 'ops-career-job-workspace-field ops-career-job-workspace-field--editor']),
+                            ]),
+                        Forms\Components\Section::make('Job signals')
+                            ->description('Edit recommendation-relevant signals through constrained inputs instead of raw JSON blobs.')
+                            ->extraAttributes(['class' => 'ops-career-job-workspace-section ops-career-job-workspace-section--main'])
+                            ->schema([
+                                Forms\Components\Tabs::make('Career job signals')
+                                    ->contained(false)
+                                    ->extraAttributes(['class' => 'ops-career-job-workspace-tabs'])
+                                    ->tabs(self::signalTabs())
+                                    ->columnSpanFull(),
+                            ]),
+                        Forms\Components\Section::make('Supplemental sections')
+                            ->description('Fixed supplemental narrative blocks only. These complement the main body and do not replace it.')
+                            ->extraAttributes(['class' => 'ops-career-job-workspace-section ops-career-job-workspace-section--main'])
+                            ->schema([
+                                Forms\Components\Tabs::make('Career job sections')
+                                    ->contained(false)
+                                    ->extraAttributes(['class' => 'ops-career-job-workspace-tabs'])
+                                    ->tabs(self::sectionTabs())
+                                    ->columnSpanFull(),
+                            ]),
+                    ])
+                        ->columnSpan([
+                            'xl' => 8,
+                        ])
+                        ->extraAttributes(['class' => 'ops-career-job-workspace-main-column']),
+                    Forms\Components\Group::make([
+                        Forms\Components\Section::make('Identity')
+                            ->description('Career CMS Lite v1 manages global career content only. Org scope stays fixed to org_id=0.')
+                            ->extraAttributes(['class' => 'ops-career-job-workspace-section ops-career-job-workspace-section--rail'])
+                            ->schema([
+                                Forms\Components\TextInput::make('job_code')
+                                    ->required()
+                                    ->maxLength(96)
+                                    ->placeholder('product-manager')
+                                    ->helperText('Stable internal key for this career job. Defaults to the slug if left blank.')
+                                    ->live(onBlur: true)
+                                    ->dehydrateStateUsing(fn (?string $state, Forms\Get $get): string => CareerJobWorkspace::normalizeJobCode(
+                                        $state,
+                                        (string) $get('slug'),
+                                    ))
+                                    ->afterStateUpdated(function (?string $state, Forms\Set $set, Forms\Get $get): void {
+                                        if (trim((string) $get('slug')) !== '') {
+                                            return;
+                                        }
+
+                                        $set('slug', CareerJobWorkspace::normalizeSlug(null, $state));
+                                    })
+                                    ->rules(['regex:/^[a-z0-9-]+$/']),
+                                Forms\Components\TextInput::make('slug')
+                                    ->required()
+                                    ->maxLength(128)
+                                    ->placeholder('product-manager')
+                                    ->helperText('Frontend route key for locale-aware `/career/jobs/{slug}` pages.')
+                                    ->dehydrateStateUsing(fn (?string $state, Forms\Get $get): string => CareerJobWorkspace::normalizeSlug(
+                                        $state,
+                                        (string) $get('job_code'),
+                                    ))
+                                    ->rules(['regex:/^[a-z0-9-]+$/']),
+                                Forms\Components\Select::make('locale')
+                                    ->required()
+                                    ->native(false)
+                                    ->options(self::localeOptions())
+                                    ->default('en')
+                                    ->helperText('Stored as backend locale codes and mapped to `/en` or `/zh` in planned URLs.'),
+                                Forms\Components\Placeholder::make('identity_org')
+                                    ->label('Content scope')
+                                    ->content('Global career content (org_id=0)'),
+                            ])
+                            ->columns(2),
+                        Forms\Components\Section::make('Publish')
+                            ->description('Keep release state, visibility, indexing, and ordering cues together in the metadata rail.')
+                            ->extraAttributes(['class' => 'ops-career-job-workspace-section ops-career-job-workspace-section--rail'])
+                            ->schema([
+                                Forms\Components\Placeholder::make('workspace_state')
+                                    ->label('Editorial cues')
+                                    ->content(fn (Forms\Get $get, ?CareerJob $record) => CareerJobWorkspace::renderEditorialCues($get, $record))
+                                    ->columnSpanFull(),
+                                Forms\Components\Select::make('status')
+                                    ->required()
+                                    ->native(false)
+                                    ->options(self::statusOptions())
+                                    ->default(CareerJob::STATUS_DRAFT),
+                                Forms\Components\Toggle::make('is_public')
+                                    ->label('Public visibility')
+                                    ->default(true),
+                                Forms\Components\Toggle::make('is_indexable')
+                                    ->label('Search indexable')
+                                    ->default(true),
+                                Forms\Components\DateTimePicker::make('published_at'),
+                                Forms\Components\DateTimePicker::make('scheduled_at'),
+                                Forms\Components\TextInput::make('sort_order')
+                                    ->numeric()
+                                    ->default(0)
+                                    ->helperText('List ordering for future job directories and ops tables.'),
+                            ]),
+                        Forms\Components\Section::make('SEO')
+                            ->description('Keep search metadata, social overrides, and robots hints in one reviewable rail.')
+                            ->extraAttributes(['class' => 'ops-career-job-workspace-section ops-career-job-workspace-section--rail'])
+                            ->schema([
+                                Forms\Components\Placeholder::make('seo_snapshot')
+                                    ->label('SEO snapshot')
+                                    ->content(fn (Forms\Get $get, ?CareerJob $record) => CareerJobWorkspace::renderSeoSnapshot($get, $record))
+                                    ->columnSpanFull(),
+                                Forms\Components\TextInput::make('workspace_seo.seo_title')
+                                    ->label('SEO title')
+                                    ->maxLength(255)
+                                    ->helperText('Search headline fallback is the job title if left blank.'),
+                                Forms\Components\Textarea::make('workspace_seo.seo_description')
+                                    ->label('SEO description')
+                                    ->rows(3)
+                                    ->helperText('Description fallback is excerpt, then subtitle.'),
+                                Forms\Components\TextInput::make('workspace_seo.canonical_url')
+                                    ->label('Canonical override')
+                                    ->maxLength(2048)
+                                    ->helperText('Optional stored override. Planned canonical still follows locale-aware career job URLs.'),
+                                Forms\Components\TextInput::make('workspace_seo.og_title')
+                                    ->label('Open Graph title')
+                                    ->maxLength(255),
+                                Forms\Components\Textarea::make('workspace_seo.og_description')
+                                    ->label('Open Graph description')
+                                    ->rows(3),
+                                Forms\Components\TextInput::make('workspace_seo.og_image_url')
+                                    ->label('Open Graph image URL')
+                                    ->maxLength(2048),
+                                Forms\Components\TextInput::make('workspace_seo.twitter_title')
+                                    ->label('Twitter title')
+                                    ->maxLength(255),
+                                Forms\Components\Textarea::make('workspace_seo.twitter_description')
+                                    ->label('Twitter description')
+                                    ->rows(3),
+                                Forms\Components\TextInput::make('workspace_seo.twitter_image_url')
+                                    ->label('Twitter image URL')
+                                    ->maxLength(2048),
+                                Forms\Components\TextInput::make('workspace_seo.robots')
+                                    ->label('Robots')
+                                    ->maxLength(64)
+                                    ->helperText('Leave blank to derive robots from the current indexability toggle.'),
+                            ]),
+                        Forms\Components\Section::make('Record cues')
+                            ->description('Read-only context so editors can review the planned frontend route, timestamps, and revision trail before cutover.')
+                            ->extraAttributes(['class' => 'ops-career-job-workspace-section ops-career-job-workspace-section--rail'])
+                            ->schema([
+                                Forms\Components\Placeholder::make('planned_public_url')
+                                    ->label('Planned public URL')
+                                    ->content(fn (Forms\Get $get, ?CareerJob $record): string => CareerJobWorkspace::plannedPublicUrl(
+                                        (string) ($get('slug') ?? $record?->slug ?? ''),
+                                        (string) ($get('locale') ?? $record?->locale ?? 'en'),
+                                    ) ?? 'Appears once slug and locale are set.'),
+                                Forms\Components\Placeholder::make('created_at_summary')
+                                    ->label('Created')
+                                    ->content(fn (?CareerJob $record): string => CareerJobWorkspace::formatTimestamp(
+                                        $record?->created_at,
+                                        'Workspace draft not saved yet',
+                                    )),
+                                Forms\Components\Placeholder::make('updated_at_summary')
+                                    ->label('Last updated')
+                                    ->content(fn (?CareerJob $record): string => CareerJobWorkspace::formatTimestamp(
+                                        $record?->updated_at,
+                                        'Workspace draft not saved yet',
+                                    )),
+                                Forms\Components\Placeholder::make('revision_count_summary')
+                                    ->label('Revision count')
+                                    ->content(fn (?CareerJob $record): string => $record instanceof CareerJob
+                                        ? (string) $record->revisions()->count()
+                                        : 'Revision #1 will be written when this career job is created'),
+                            ])
+                            ->columns(2),
+                    ])
+                        ->columnSpan([
+                            'xl' => 4,
+                        ])
+                        ->extraAttributes(['class' => 'ops-career-job-workspace-rail-column']),
+                ]),
+        ]);
+    }
+
+    public static function table(Table $table): Table
+    {
+        return $table
+            ->columns([
+                Tables\Columns\TextColumn::make('title')
+                    ->label('Career Job')
+                    ->html()
+                    ->searchable(['title', 'job_code', 'slug'])
+                    ->sortable()
+                    ->formatStateUsing(fn (CareerJob $record): string => (string) view('filament.ops.career-jobs.partials.table-title', [
+                        'meta' => CareerJobWorkspace::titleMeta($record),
+                        'title' => $record->title,
+                    ])->render()),
+                Tables\Columns\TextColumn::make('status')
+                    ->badge()
+                    ->sortable()
+                    ->formatStateUsing(fn (string $state): string => Str::of($state)->headline()->value())
+                    ->description(fn (CareerJob $record): string => CareerJobWorkspace::visibilityMeta($record))
+                    ->color(fn (string $state): string => StatusBadge::color($state)),
+                Tables\Columns\TextColumn::make('is_public')
+                    ->label('Visibility')
+                    ->badge()
+                    ->formatStateUsing(fn (bool|int|string|null $state): string => StatusBadge::booleanLabel($state, 'Public', 'Private'))
+                    ->color(fn (bool|int|string|null $state): string => StatusBadge::booleanColor($state))
+                    ->sortable(),
+                Tables\Columns\TextColumn::make('is_indexable')
+                    ->label('Indexing')
+                    ->badge()
+                    ->formatStateUsing(fn (bool|int|string|null $state): string => StatusBadge::booleanLabel($state, 'Indexable', 'Noindex'))
+                    ->color(fn (bool|int|string|null $state): string => StatusBadge::booleanColor($state))
+                    ->sortable(),
+                Tables\Columns\TextColumn::make('industry_slug')
+                    ->label('Industry')
+                    ->sortable()
+                    ->toggleable(),
+                Tables\Columns\TextColumn::make('published_at')
+                    ->label('Published')
+                    ->dateTime()
+                    ->sortable()
+                    ->placeholder('Not published'),
+                Tables\Columns\TextColumn::make('updated_at')
+                    ->label('Updated')
+                    ->since()
+                    ->sortable(),
+            ])
+            ->filters([
+                Tables\Filters\SelectFilter::make('locale')
+                    ->options(self::localeOptions()),
+                Tables\Filters\SelectFilter::make('status')
+                    ->options(self::statusOptions()),
+                TernaryFilter::make('is_public')
+                    ->label('Public'),
+                TernaryFilter::make('is_indexable')
+                    ->label('Indexable'),
+                Tables\Filters\SelectFilter::make('industry_slug')
+                    ->label('Industry')
+                    ->options(self::industryFilterOptions()),
+            ])
+            ->searchPlaceholder('Search title, job code, or slug')
+            ->defaultSort('updated_at', 'desc')
+            ->recordUrl(fn (CareerJob $record): string => static::getUrl('edit', ['record' => $record]))
+            ->actions([
+                Tables\Actions\EditAction::make()
+                    ->label('Edit')
+                    ->icon('heroicon-o-pencil-square')
+                    ->color('gray'),
+            ])
+            ->bulkActions([]);
+    }
+
+    public static function getPages(): array
+    {
+        return [
+            'index' => Pages\ListCareerJobs::route('/'),
+            'create' => Pages\CreateCareerJob::route('/create'),
+            'edit' => Pages\EditCareerJob::route('/{record}/edit'),
+        ];
+    }
+
+    public static function getEloquentQuery(): Builder
+    {
+        return parent::getEloquentQuery()
+            ->withoutGlobalScopes()
+            ->where('org_id', 0);
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    private static function statusOptions(): array
+    {
+        return [
+            CareerJob::STATUS_DRAFT => CareerJob::STATUS_DRAFT,
+            CareerJob::STATUS_PUBLISHED => CareerJob::STATUS_PUBLISHED,
+        ];
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    private static function localeOptions(): array
+    {
+        return collect(CareerJob::SUPPORTED_LOCALES)
+            ->mapWithKeys(static fn (string $locale): array => [$locale => $locale])
+            ->all();
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    private static function industryFilterOptions(): array
+    {
+        return CareerJob::query()
+            ->withoutGlobalScopes()
+            ->where('org_id', 0)
+            ->whereNotNull('industry_slug')
+            ->orderBy('industry_slug')
+            ->pluck('industry_slug', 'industry_slug')
+            ->all();
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    private static function mbtiTypeOptions(): array
+    {
+        return collect([
+            'INTJ', 'INTP', 'ENTJ', 'ENTP',
+            'INFJ', 'INFP', 'ENFJ', 'ENFP',
+            'ISTJ', 'ISFJ', 'ESTJ', 'ESFJ',
+            'ISTP', 'ISFP', 'ESTP', 'ESFP',
+        ])->mapWithKeys(static fn (string $code): array => [$code => $code])->all();
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    private static function marketSignalOptions(): array
+    {
+        return [
+            'low' => 'low',
+            'balanced' => 'balanced',
+            'high' => 'high',
+            'unknown' => 'unknown',
+        ];
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    private static function traitTargetOptions(): array
+    {
+        return [
+            'low' => 'low',
+            'balanced' => 'balanced',
+            'high' => 'high',
+        ];
+    }
+
+    /**
+     * @return array<int, Forms\Components\Tabs\Tab>
+     */
+    private static function signalTabs(): array
+    {
+        return [
+            Forms\Components\Tabs\Tab::make('Compensation & Outlook')
+                ->schema([
+                    Forms\Components\TextInput::make('salary_json.currency')
+                        ->label('Salary currency')
+                        ->maxLength(16),
+                    Forms\Components\TextInput::make('salary_json.region')
+                        ->label('Salary region')
+                        ->maxLength(32),
+                    Forms\Components\TextInput::make('salary_json.low')
+                        ->label('Salary low')
+                        ->numeric(),
+                    Forms\Components\TextInput::make('salary_json.median')
+                        ->label('Salary median')
+                        ->numeric(),
+                    Forms\Components\TextInput::make('salary_json.high')
+                        ->label('Salary high')
+                        ->numeric(),
+                    Forms\Components\Textarea::make('salary_json.notes')
+                        ->label('Salary notes')
+                        ->rows(3)
+                        ->columnSpanFull(),
+                    Forms\Components\TextInput::make('outlook_json.summary')
+                        ->label('Outlook summary')
+                        ->maxLength(255),
+                    Forms\Components\TextInput::make('outlook_json.horizon_years')
+                        ->label('Outlook horizon (years)')
+                        ->numeric(),
+                    Forms\Components\Textarea::make('outlook_json.notes')
+                        ->label('Outlook notes')
+                        ->rows(3)
+                        ->columnSpanFull(),
+                ])
+                ->columns(2),
+            Forms\Components\Tabs\Tab::make('Work & Skills')
+                ->schema([
+                    Forms\Components\TagsInput::make('work_contents_json.items')
+                        ->label('Work contents')
+                        ->helperText('Each tag becomes one main responsibility or work-content item.')
+                        ->columnSpanFull(),
+                    Forms\Components\TagsInput::make('skills_json.core')
+                        ->label('Core skills')
+                        ->helperText('Primary capabilities that define day-to-day fit.'),
+                    Forms\Components\TagsInput::make('skills_json.supporting')
+                        ->label('Supporting skills')
+                        ->helperText('Secondary capabilities that strengthen performance but are not always central.'),
+                ])
+                ->columns(2),
+            Forms\Components\Tabs\Tab::make('Growth & Market')
+                ->schema([
+                    Forms\Components\TextInput::make('growth_path_json.entry')
+                        ->label('Entry level')
+                        ->maxLength(255),
+                    Forms\Components\TextInput::make('growth_path_json.mid')
+                        ->label('Mid level')
+                        ->maxLength(255),
+                    Forms\Components\TextInput::make('growth_path_json.senior')
+                        ->label('Senior level')
+                        ->maxLength(255),
+                    Forms\Components\Textarea::make('growth_path_json.notes')
+                        ->label('Growth notes')
+                        ->rows(3)
+                        ->columnSpanFull(),
+                    Forms\Components\Select::make('market_demand_json.signal')
+                        ->label('Market demand signal')
+                        ->native(false)
+                        ->options(self::marketSignalOptions()),
+                    Forms\Components\Textarea::make('market_demand_json.notes')
+                        ->label('Market demand notes')
+                        ->rows(3)
+                        ->columnSpanFull(),
+                ])
+                ->columns(2),
+            Forms\Components\Tabs\Tab::make('Personality & Assessment Signals')
+                ->schema([
+                    Forms\Components\Select::make('fit_personality_codes_json')
+                        ->label('Fit personality codes')
+                        ->multiple()
+                        ->native(false)
+                        ->options(self::mbtiTypeOptions())
+                        ->helperText('Constrain this field to the 16 MBTI codes for v1 consistency.')
+                        ->columnSpanFull(),
+                    Forms\Components\Select::make('mbti_primary_codes_json')
+                        ->label('MBTI primary codes')
+                        ->multiple()
+                        ->native(false)
+                        ->options(self::mbtiTypeOptions()),
+                    Forms\Components\Select::make('mbti_secondary_codes_json')
+                        ->label('MBTI secondary codes')
+                        ->multiple()
+                        ->native(false)
+                        ->options(self::mbtiTypeOptions()),
+                    Forms\Components\TextInput::make('riasec_profile_json.R')
+                        ->label('RIASEC R')
+                        ->numeric()
+                        ->helperText('Suggested 0-100'),
+                    Forms\Components\TextInput::make('riasec_profile_json.I')
+                        ->label('RIASEC I')
+                        ->numeric()
+                        ->helperText('Suggested 0-100'),
+                    Forms\Components\TextInput::make('riasec_profile_json.A')
+                        ->label('RIASEC A')
+                        ->numeric()
+                        ->helperText('Suggested 0-100'),
+                    Forms\Components\TextInput::make('riasec_profile_json.S')
+                        ->label('RIASEC S')
+                        ->numeric()
+                        ->helperText('Suggested 0-100'),
+                    Forms\Components\TextInput::make('riasec_profile_json.E')
+                        ->label('RIASEC E')
+                        ->numeric()
+                        ->helperText('Suggested 0-100'),
+                    Forms\Components\TextInput::make('riasec_profile_json.C')
+                        ->label('RIASEC C')
+                        ->numeric()
+                        ->helperText('Suggested 0-100'),
+                    Forms\Components\Select::make('big5_targets_json.openness')
+                        ->label('Big5 openness')
+                        ->native(false)
+                        ->options(self::traitTargetOptions()),
+                    Forms\Components\Select::make('big5_targets_json.conscientiousness')
+                        ->label('Big5 conscientiousness')
+                        ->native(false)
+                        ->options(self::traitTargetOptions()),
+                    Forms\Components\Select::make('big5_targets_json.extraversion')
+                        ->label('Big5 extraversion')
+                        ->native(false)
+                        ->options(self::traitTargetOptions()),
+                    Forms\Components\Select::make('big5_targets_json.agreeableness')
+                        ->label('Big5 agreeableness')
+                        ->native(false)
+                        ->options(self::traitTargetOptions()),
+                    Forms\Components\Select::make('big5_targets_json.neuroticism')
+                        ->label('Big5 neuroticism')
+                        ->native(false)
+                        ->options(self::traitTargetOptions()),
+                    Forms\Components\Textarea::make('iq_eq_notes_json.iq')
+                        ->label('IQ notes')
+                        ->rows(3),
+                    Forms\Components\Textarea::make('iq_eq_notes_json.eq')
+                        ->label('EQ notes')
+                        ->rows(3),
+                ])
+                ->columns(2),
+        ];
+    }
+
+    /**
+     * @return array<int, Forms\Components\Tabs\Tab>
+     */
+    private static function sectionTabs(): array
+    {
+        $variantOptions = CareerJobWorkspace::renderVariantOptions();
+
+        return collect(CareerJobWorkspace::sectionDefinitions())
+            ->map(function (array $definition, string $sectionKey) use ($variantOptions): Forms\Components\Tabs\Tab {
+                return Forms\Components\Tabs\Tab::make($definition['label'])
+                    ->schema([
+                        Forms\Components\Toggle::make("workspace_sections.{$sectionKey}.is_enabled")
+                            ->label('Enable this section')
+                            ->helperText($definition['description'])
+                            ->columnSpanFull(),
+                        Forms\Components\TextInput::make("workspace_sections.{$sectionKey}.title")
+                            ->label('Section title')
+                            ->required()
+                            ->maxLength(255),
+                        Forms\Components\Select::make("workspace_sections.{$sectionKey}.render_variant")
+                            ->label('Render variant')
+                            ->native(false)
+                            ->options($variantOptions)
+                            ->required(),
+                        Forms\Components\Textarea::make("workspace_sections.{$sectionKey}.body_md")
+                            ->label('Narrative body')
+                            ->rows(8)
+                            ->columnSpanFull()
+                            ->helperText('Use markdown-friendly narrative copy when this section needs long-form explanation.')
+                            ->extraFieldWrapperAttributes(['class' => 'ops-career-job-workspace-field ops-career-job-workspace-field--body']),
+                        Forms\Components\Textarea::make("workspace_sections.{$sectionKey}.payload_json_text")
+                            ->label('Structured payload JSON')
+                            ->rows(6)
+                            ->columnSpanFull()
+                            ->helperText('Optional structured payload for cards, FAQ, links, or other fixed render variants.')
+                            ->rules(['nullable', 'json'])
+                            ->extraFieldWrapperAttributes(['class' => 'ops-career-job-workspace-field ops-career-job-workspace-field--payload']),
+                    ])
+                    ->columns(2);
+            })
+            ->values()
+            ->all();
+    }
+
+    private static function canRead(): bool
+    {
+        $guard = (string) config('admin.guard', 'admin');
+        $user = auth($guard)->user();
+
+        return is_object($user)
+            && method_exists($user, 'hasPermission')
+            && (
+                $user->hasPermission(PermissionNames::ADMIN_CONTENT_READ)
+                || $user->hasPermission(PermissionNames::ADMIN_OWNER)
+            );
+    }
+
+    private static function canPublish(): bool
+    {
+        $guard = (string) config('admin.guard', 'admin');
+        $user = auth($guard)->user();
+
+        return is_object($user)
+            && method_exists($user, 'hasPermission')
+            && (
+                $user->hasPermission(PermissionNames::ADMIN_CONTENT_PUBLISH)
+                || $user->hasPermission(PermissionNames::ADMIN_OWNER)
+            );
+    }
+}

--- a/backend/app/Filament/Ops/Resources/CareerJobResource/Pages/CreateCareerJob.php
+++ b/backend/app/Filament/Ops/Resources/CareerJobResource/Pages/CreateCareerJob.php
@@ -1,0 +1,134 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Filament\Ops\Resources\CareerJobResource\Pages;
+
+use App\Filament\Ops\Resources\CareerJobResource;
+use App\Filament\Ops\Resources\CareerJobResource\Support\CareerJobWorkspace;
+use Filament\Actions\Action;
+use Filament\Resources\Pages\CreateRecord;
+use Illuminate\Contracts\Support\Htmlable;
+
+class CreateCareerJob extends CreateRecord
+{
+    protected static string $resource = CareerJobResource::class;
+
+    /**
+     * @var array<string, mixed>
+     */
+    protected array $workspaceSectionsState = [];
+
+    /**
+     * @var array<string, mixed>
+     */
+    protected array $workspaceSeoState = [];
+
+    public function getTitle(): string|Htmlable
+    {
+        return 'Create Career Job';
+    }
+
+    public function getSubheading(): ?string
+    {
+        return 'Build a structured career job in the main workspace, then finish publish and SEO cues in the side rail.';
+    }
+
+    protected function fillForm(): void
+    {
+        $this->callHook('beforeFill');
+
+        $this->form->fill(CareerJobWorkspace::defaultFormState());
+
+        $this->callHook('afterFill');
+    }
+
+    protected function getHeaderActions(): array
+    {
+        return [
+            Action::make('backToCareerJobs')
+                ->label('All Career Jobs')
+                ->url(CareerJobResource::getUrl())
+                ->icon('heroicon-o-arrow-left')
+                ->color('gray'),
+        ];
+    }
+
+    protected function getCreateFormAction(): Action
+    {
+        return parent::getCreateFormAction()
+            ->label('Create Career Job')
+            ->icon('heroicon-o-check-circle');
+    }
+
+    protected function getCreateAnotherFormAction(): Action
+    {
+        return parent::getCreateAnotherFormAction()
+            ->label('Create & Add Another')
+            ->icon('heroicon-o-document-duplicate');
+    }
+
+    protected function getCancelFormAction(): Action
+    {
+        return parent::getCancelFormAction()
+            ->label('Back to Career Jobs')
+            ->icon('heroicon-o-arrow-left');
+    }
+
+    /**
+     * @param  array<string, mixed>  $data
+     * @return array<string, mixed>
+     */
+    protected function mutateFormDataBeforeCreate(array $data): array
+    {
+        $this->workspaceSectionsState = is_array($data['workspace_sections'] ?? null) ? $data['workspace_sections'] : [];
+        $this->workspaceSeoState = is_array($data['workspace_seo'] ?? null) ? $data['workspace_seo'] : [];
+
+        unset($data['workspace_sections'], $data['workspace_seo']);
+
+        $jobCode = CareerJobWorkspace::normalizeJobCode(
+            (string) ($data['job_code'] ?? ''),
+            (string) ($data['slug'] ?? ''),
+        );
+
+        $data['org_id'] = 0;
+        $data['job_code'] = $jobCode;
+        $data['slug'] = CareerJobWorkspace::normalizeSlug((string) ($data['slug'] ?? ''), $jobCode);
+        $data['locale'] = CareerJobWorkspace::normalizeLocale((string) ($data['locale'] ?? 'en'));
+        $data['created_by_admin_user_id'] = $this->currentAdminId();
+        $data['updated_by_admin_user_id'] = $this->currentAdminId();
+
+        return $data;
+    }
+
+    protected function afterCreate(): void
+    {
+        CareerJobWorkspace::syncWorkspaceSections($this->getRecord(), $this->workspaceSectionsState);
+        CareerJobWorkspace::syncWorkspaceSeo($this->getRecord(), $this->workspaceSeoState);
+        $this->getRecord()->unsetRelation('sections');
+        $this->getRecord()->unsetRelation('seoMeta');
+        CareerJobWorkspace::createRevision($this->getRecord(), 'Initial workspace snapshot', auth((string) config('admin.guard', 'admin'))->user());
+    }
+
+    protected function getCreatedNotificationTitle(): ?string
+    {
+        return 'Career job created';
+    }
+
+    protected function getRedirectUrl(): string
+    {
+        return CareerJobResource::getUrl('edit', ['record' => $this->getRecord()]);
+    }
+
+    private function currentAdminId(): ?int
+    {
+        $guard = (string) config('admin.guard', 'admin');
+        $user = auth($guard)->user();
+
+        if (! is_object($user) || ! method_exists($user, 'getAuthIdentifier')) {
+            return null;
+        }
+
+        return (int) $user->getAuthIdentifier();
+    }
+}

--- a/backend/app/Filament/Ops/Resources/CareerJobResource/Pages/EditCareerJob.php
+++ b/backend/app/Filament/Ops/Resources/CareerJobResource/Pages/EditCareerJob.php
@@ -1,0 +1,130 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Filament\Ops\Resources\CareerJobResource\Pages;
+
+use App\Filament\Ops\Resources\CareerJobResource;
+use App\Filament\Ops\Resources\CareerJobResource\Support\CareerJobWorkspace;
+use Filament\Actions\Action;
+use Filament\Resources\Pages\EditRecord;
+use Illuminate\Contracts\Support\Htmlable;
+
+class EditCareerJob extends EditRecord
+{
+    protected static string $resource = CareerJobResource::class;
+
+    /**
+     * @var array<string, mixed>
+     */
+    protected array $workspaceSectionsState = [];
+
+    /**
+     * @var array<string, mixed>
+     */
+    protected array $workspaceSeoState = [];
+
+    public function getTitle(): string|Htmlable
+    {
+        return filled($this->getRecord()->title) ? (string) $this->getRecord()->title : 'Edit Career Job';
+    }
+
+    public function getSubheading(): ?string
+    {
+        return 'Maintain the career job without leaving the structured editorial workspace.';
+    }
+
+    protected function getHeaderActions(): array
+    {
+        return [
+            Action::make('backToCareerJobs')
+                ->label('All Career Jobs')
+                ->url(CareerJobResource::getUrl())
+                ->icon('heroicon-o-arrow-left')
+                ->color('gray'),
+        ];
+    }
+
+    protected function getSaveFormAction(): Action
+    {
+        return parent::getSaveFormAction()
+            ->label('Save Changes')
+            ->icon('heroicon-o-check-circle');
+    }
+
+    protected function getCancelFormAction(): Action
+    {
+        return parent::getCancelFormAction()
+            ->label('Back to Career Jobs')
+            ->icon('heroicon-o-arrow-left');
+    }
+
+    /**
+     * @param  array<string, mixed>  $data
+     * @return array<string, mixed>
+     */
+    protected function mutateFormDataBeforeFill(array $data): array
+    {
+        return [
+            ...$data,
+            'workspace_sections' => CareerJobWorkspace::workspaceSectionsFromRecord($this->getRecord()),
+            'workspace_seo' => CareerJobWorkspace::workspaceSeoFromRecord($this->getRecord()),
+        ];
+    }
+
+    /**
+     * @param  array<string, mixed>  $data
+     * @return array<string, mixed>
+     */
+    protected function mutateFormDataBeforeSave(array $data): array
+    {
+        $this->workspaceSectionsState = is_array($data['workspace_sections'] ?? null) ? $data['workspace_sections'] : [];
+        $this->workspaceSeoState = is_array($data['workspace_seo'] ?? null) ? $data['workspace_seo'] : [];
+
+        unset($data['workspace_sections'], $data['workspace_seo']);
+
+        $jobCode = CareerJobWorkspace::normalizeJobCode(
+            (string) ($data['job_code'] ?? ''),
+            (string) ($data['slug'] ?? ''),
+        );
+
+        $data['org_id'] = 0;
+        $data['job_code'] = $jobCode;
+        $data['slug'] = CareerJobWorkspace::normalizeSlug((string) ($data['slug'] ?? ''), $jobCode);
+        $data['locale'] = CareerJobWorkspace::normalizeLocale((string) ($data['locale'] ?? 'en'));
+        $data['updated_by_admin_user_id'] = $this->currentAdminId();
+
+        return $data;
+    }
+
+    protected function afterSave(): void
+    {
+        CareerJobWorkspace::syncWorkspaceSections($this->getRecord(), $this->workspaceSectionsState);
+        CareerJobWorkspace::syncWorkspaceSeo($this->getRecord(), $this->workspaceSeoState);
+        $this->getRecord()->unsetRelation('sections');
+        $this->getRecord()->unsetRelation('seoMeta');
+        CareerJobWorkspace::createRevision($this->getRecord(), 'Workspace update', auth((string) config('admin.guard', 'admin'))->user());
+    }
+
+    protected function getSavedNotificationTitle(): ?string
+    {
+        return 'Career job updated';
+    }
+
+    protected function getRedirectUrl(): string
+    {
+        return CareerJobResource::getUrl('edit', ['record' => $this->getRecord()]);
+    }
+
+    private function currentAdminId(): ?int
+    {
+        $guard = (string) config('admin.guard', 'admin');
+        $user = auth($guard)->user();
+
+        if (! is_object($user) || ! method_exists($user, 'getAuthIdentifier')) {
+            return null;
+        }
+
+        return (int) $user->getAuthIdentifier();
+    }
+}

--- a/backend/app/Filament/Ops/Resources/CareerJobResource/Pages/ListCareerJobs.php
+++ b/backend/app/Filament/Ops/Resources/CareerJobResource/Pages/ListCareerJobs.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Filament\Ops\Resources\CareerJobResource\Pages;
+
+use App\Filament\Ops\Resources\CareerJobResource;
+use App\Filament\Ops\Resources\Pages\Concerns\HasSharedListEmptyState;
+use Filament\Actions;
+use Filament\Resources\Pages\ListRecords;
+use Illuminate\Contracts\Support\Htmlable;
+
+class ListCareerJobs extends ListRecords
+{
+    use HasSharedListEmptyState;
+
+    protected static string $resource = CareerJobResource::class;
+
+    public function getTitle(): string|Htmlable
+    {
+        return 'Career Jobs';
+    }
+
+    public function getSubheading(): ?string
+    {
+        return 'Global career content workspace for structured career job profiles. Not tenant-specific.';
+    }
+
+    protected function getHeaderActions(): array
+    {
+        return [
+            Actions\CreateAction::make()
+                ->label('Create Career Job')
+                ->icon('heroicon-o-plus'),
+        ];
+    }
+}

--- a/backend/app/Filament/Ops/Resources/CareerJobResource/Support/CareerJobWorkspace.php
+++ b/backend/app/Filament/Ops/Resources/CareerJobResource/Support/CareerJobWorkspace.php
@@ -1,0 +1,764 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Filament\Ops\Resources\CareerJobResource\Support;
+
+use App\Filament\Ops\Support\StatusBadge;
+use App\Models\CareerJob;
+use App\Models\CareerJobRevision;
+use App\Models\CareerJobSection;
+use App\Models\CareerJobSeoMeta;
+use App\Services\Cms\CareerJobSeoService;
+use Filament\Forms\Get;
+use Illuminate\Contracts\Support\Htmlable;
+use Illuminate\Support\Carbon;
+use Illuminate\Support\HtmlString;
+use Illuminate\Support\Str;
+use Illuminate\Validation\ValidationException;
+
+final class CareerJobWorkspace
+{
+    /**
+     * @return array<string, array{label: string, title: string, description: string, render_variant: string, sort_order: int, enabled: bool}>
+     */
+    public static function sectionDefinitions(): array
+    {
+        return [
+            'day_to_day' => [
+                'label' => 'Day to Day',
+                'title' => 'A typical day',
+                'description' => 'Optional close-up on the rhythm, cadence, and recurring work patterns in this role.',
+                'render_variant' => 'rich_text',
+                'sort_order' => 10,
+                'enabled' => false,
+            ],
+            'skills_explained' => [
+                'label' => 'Skills Explained',
+                'title' => 'How the skills show up',
+                'description' => 'Optional explanation of how abstract skill labels appear in real work.',
+                'render_variant' => 'cards',
+                'sort_order' => 20,
+                'enabled' => false,
+            ],
+            'growth_story' => [
+                'label' => 'Growth Story',
+                'title' => 'Growth story',
+                'description' => 'Optional narrative that makes the career progression feel more concrete and human.',
+                'render_variant' => 'rich_text',
+                'sort_order' => 30,
+                'enabled' => false,
+            ],
+            'work_environment' => [
+                'label' => 'Work Environment',
+                'title' => 'Work environment',
+                'description' => 'Optional guidance about teams, collaboration patterns, pace, and operating context.',
+                'render_variant' => 'callout',
+                'sort_order' => 40,
+                'enabled' => false,
+            ],
+            'faq' => [
+                'label' => 'FAQ',
+                'title' => 'Frequently asked questions',
+                'description' => 'Optional FAQ block for recurring editorial questions about this career path.',
+                'render_variant' => 'faq',
+                'sort_order' => 50,
+                'enabled' => false,
+            ],
+            'related_reading_intro' => [
+                'label' => 'Related Reading Intro',
+                'title' => 'Related reading',
+                'description' => 'Optional lead-in copy for future supporting guides or resource links.',
+                'render_variant' => 'links',
+                'sort_order' => 60,
+                'enabled' => false,
+            ],
+        ];
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    public static function renderVariantOptions(): array
+    {
+        return collect(CareerJobSection::RENDER_VARIANTS)
+            ->mapWithKeys(static fn (string $variant): array => [
+                $variant => Str::of($variant)->replace('_', ' ')->headline()->value(),
+            ])
+            ->all();
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public static function defaultFormState(): array
+    {
+        return [
+            'org_id' => 0,
+            'job_code' => '',
+            'slug' => '',
+            'locale' => 'en',
+            'title' => '',
+            'subtitle' => '',
+            'excerpt' => '',
+            'hero_kicker' => '',
+            'hero_quote' => '',
+            'cover_image_url' => '',
+            'industry_slug' => '',
+            'industry_label' => '',
+            'body_md' => '',
+            'status' => CareerJob::STATUS_DRAFT,
+            'is_public' => true,
+            'is_indexable' => true,
+            'published_at' => null,
+            'scheduled_at' => null,
+            'sort_order' => 0,
+            'salary_json' => [
+                'currency' => '',
+                'region' => '',
+                'low' => null,
+                'median' => null,
+                'high' => null,
+                'notes' => '',
+            ],
+            'outlook_json' => [
+                'summary' => '',
+                'horizon_years' => null,
+                'notes' => '',
+            ],
+            'skills_json' => [
+                'core' => [],
+                'supporting' => [],
+            ],
+            'work_contents_json' => [
+                'items' => [],
+            ],
+            'growth_path_json' => [
+                'entry' => '',
+                'mid' => '',
+                'senior' => '',
+                'notes' => '',
+            ],
+            'fit_personality_codes_json' => [],
+            'mbti_primary_codes_json' => [],
+            'mbti_secondary_codes_json' => [],
+            'riasec_profile_json' => [
+                'R' => null,
+                'I' => null,
+                'A' => null,
+                'S' => null,
+                'E' => null,
+                'C' => null,
+            ],
+            'big5_targets_json' => [
+                'openness' => '',
+                'conscientiousness' => '',
+                'extraversion' => '',
+                'agreeableness' => '',
+                'neuroticism' => '',
+            ],
+            'iq_eq_notes_json' => [
+                'iq' => '',
+                'eq' => '',
+            ],
+            'market_demand_json' => [
+                'signal' => '',
+                'notes' => '',
+            ],
+            'workspace_sections' => self::defaultWorkspaceSectionsState(),
+            'workspace_seo' => self::defaultWorkspaceSeoState(),
+        ];
+    }
+
+    /**
+     * @return array<string, array<string, mixed>>
+     */
+    public static function defaultWorkspaceSectionsState(): array
+    {
+        $state = [];
+
+        foreach (self::sectionDefinitions() as $sectionKey => $definition) {
+            $state[$sectionKey] = [
+                'title' => $definition['title'],
+                'render_variant' => $definition['render_variant'],
+                'body_md' => '',
+                'payload_json_text' => '',
+                'sort_order' => $definition['sort_order'],
+                'is_enabled' => $definition['enabled'],
+            ];
+        }
+
+        return $state;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public static function defaultWorkspaceSeoState(): array
+    {
+        return [
+            'seo_title' => '',
+            'seo_description' => '',
+            'canonical_url' => '',
+            'og_title' => '',
+            'og_description' => '',
+            'og_image_url' => '',
+            'twitter_title' => '',
+            'twitter_description' => '',
+            'twitter_image_url' => '',
+            'robots' => '',
+        ];
+    }
+
+    /**
+     * @return array<string, array<string, mixed>>
+     */
+    public static function workspaceSectionsFromRecord(?CareerJob $job): array
+    {
+        $state = self::defaultWorkspaceSectionsState();
+
+        if (! $job instanceof CareerJob) {
+            return $state;
+        }
+
+        $job->loadMissing('sections');
+
+        foreach ($job->sections as $section) {
+            $sectionKey = (string) $section->section_key;
+
+            if (! array_key_exists($sectionKey, $state)) {
+                continue;
+            }
+
+            $state[$sectionKey] = [
+                'title' => filled($section->title) ? (string) $section->title : (string) $state[$sectionKey]['title'],
+                'render_variant' => filled($section->render_variant) ? (string) $section->render_variant : (string) $state[$sectionKey]['render_variant'],
+                'body_md' => (string) ($section->body_md ?? ''),
+                'payload_json_text' => self::encodeJson($section->payload_json),
+                'sort_order' => (int) ($section->sort_order ?? $state[$sectionKey]['sort_order']),
+                'is_enabled' => (bool) $section->is_enabled,
+            ];
+        }
+
+        return $state;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public static function workspaceSeoFromRecord(?CareerJob $job): array
+    {
+        $state = self::defaultWorkspaceSeoState();
+
+        if (! $job instanceof CareerJob) {
+            return $state;
+        }
+
+        $job->loadMissing('seoMeta');
+        $seoMeta = $job->seoMeta;
+
+        if (! $seoMeta instanceof CareerJobSeoMeta) {
+            return $state;
+        }
+
+        return [
+            'seo_title' => (string) ($seoMeta->seo_title ?? ''),
+            'seo_description' => (string) ($seoMeta->seo_description ?? ''),
+            'canonical_url' => (string) ($seoMeta->canonical_url ?? ''),
+            'og_title' => (string) ($seoMeta->og_title ?? ''),
+            'og_description' => (string) ($seoMeta->og_description ?? ''),
+            'og_image_url' => (string) ($seoMeta->og_image_url ?? ''),
+            'twitter_title' => (string) ($seoMeta->twitter_title ?? ''),
+            'twitter_description' => (string) ($seoMeta->twitter_description ?? ''),
+            'twitter_image_url' => (string) ($seoMeta->twitter_image_url ?? ''),
+            'robots' => (string) ($seoMeta->robots ?? ''),
+        ];
+    }
+
+    /**
+     * @param  array<string, mixed>  $state
+     */
+    public static function syncWorkspaceSections(CareerJob $job, array $state): void
+    {
+        $definitions = self::sectionDefinitions();
+        $knownSectionKeys = array_keys($definitions);
+
+        CareerJobSection::query()
+            ->where('job_id', (int) $job->id)
+            ->whereNotIn('section_key', $knownSectionKeys)
+            ->delete();
+
+        foreach ($definitions as $sectionKey => $definition) {
+            $sectionState = array_merge(
+                self::defaultWorkspaceSectionsState()[$sectionKey],
+                is_array($state[$sectionKey] ?? null) ? $state[$sectionKey] : [],
+            );
+
+            CareerJobSection::query()->updateOrCreate(
+                [
+                    'job_id' => (int) $job->id,
+                    'section_key' => $sectionKey,
+                ],
+                [
+                    'title' => self::normalizeNullableText((string) ($sectionState['title'] ?? '')) ?? $definition['title'],
+                    'render_variant' => self::normalizeRenderVariant((string) ($sectionState['render_variant'] ?? $definition['render_variant']), $definition['render_variant']),
+                    'body_md' => self::normalizeNullableText((string) ($sectionState['body_md'] ?? '')),
+                    'body_html' => null,
+                    'payload_json' => self::decodeJsonText(
+                        $sectionState['payload_json_text'] ?? null,
+                        "workspace_sections.{$sectionKey}.payload_json_text",
+                    ),
+                    'sort_order' => (int) ($sectionState['sort_order'] ?? $definition['sort_order']),
+                    'is_enabled' => StatusBadge::isTruthy($sectionState['is_enabled'] ?? $definition['enabled']),
+                ],
+            );
+        }
+
+        $job->unsetRelation('sections');
+    }
+
+    /**
+     * @param  array<string, mixed>  $state
+     */
+    public static function syncWorkspaceSeo(CareerJob $job, array $state): void
+    {
+        CareerJobSeoMeta::query()->updateOrCreate(
+            [
+                'job_id' => (int) $job->id,
+            ],
+            [
+                'seo_title' => self::normalizeNullableText((string) ($state['seo_title'] ?? '')),
+                'seo_description' => self::normalizeNullableText((string) ($state['seo_description'] ?? '')),
+                'canonical_url' => self::normalizeNullableText((string) ($state['canonical_url'] ?? '')),
+                'og_title' => self::normalizeNullableText((string) ($state['og_title'] ?? '')),
+                'og_description' => self::normalizeNullableText((string) ($state['og_description'] ?? '')),
+                'og_image_url' => self::normalizeNullableText((string) ($state['og_image_url'] ?? '')),
+                'twitter_title' => self::normalizeNullableText((string) ($state['twitter_title'] ?? '')),
+                'twitter_description' => self::normalizeNullableText((string) ($state['twitter_description'] ?? '')),
+                'twitter_image_url' => self::normalizeNullableText((string) ($state['twitter_image_url'] ?? '')),
+                'robots' => self::normalizeNullableText((string) ($state['robots'] ?? '')),
+            ],
+        );
+
+        $job->unsetRelation('seoMeta');
+    }
+
+    public static function nextRevisionNo(CareerJob $job): int
+    {
+        return (int) CareerJobRevision::query()
+            ->where('job_id', (int) $job->id)
+            ->max('revision_no') + 1;
+    }
+
+    /**
+     * @param  array<string, mixed>  $formData
+     * @return array<string, mixed>
+     */
+    public static function snapshotPayload(CareerJob $job, array $formData = []): array
+    {
+        $job->loadMissing('sections', 'seoMeta');
+
+        return [
+            'job' => [
+                'id' => (int) $job->id,
+                'org_id' => (int) $job->org_id,
+                'job_code' => (string) $job->job_code,
+                'slug' => (string) $job->slug,
+                'locale' => (string) $job->locale,
+                'title' => (string) $job->title,
+                'subtitle' => $job->subtitle,
+                'excerpt' => $job->excerpt,
+                'hero_kicker' => $job->hero_kicker,
+                'hero_quote' => $job->hero_quote,
+                'cover_image_url' => $job->cover_image_url,
+                'industry_slug' => $job->industry_slug,
+                'industry_label' => $job->industry_label,
+                'body_md' => $job->body_md,
+                'body_html' => $job->body_html,
+                'salary_json' => $job->salary_json,
+                'outlook_json' => $job->outlook_json,
+                'skills_json' => $job->skills_json,
+                'work_contents_json' => $job->work_contents_json,
+                'growth_path_json' => $job->growth_path_json,
+                'fit_personality_codes_json' => $job->fit_personality_codes_json,
+                'mbti_primary_codes_json' => $job->mbti_primary_codes_json,
+                'mbti_secondary_codes_json' => $job->mbti_secondary_codes_json,
+                'riasec_profile_json' => $job->riasec_profile_json,
+                'big5_targets_json' => $job->big5_targets_json,
+                'iq_eq_notes_json' => $job->iq_eq_notes_json,
+                'market_demand_json' => $job->market_demand_json,
+                'status' => (string) $job->status,
+                'is_public' => (bool) $job->is_public,
+                'is_indexable' => (bool) $job->is_indexable,
+                'published_at' => $job->published_at?->toIso8601String(),
+                'scheduled_at' => $job->scheduled_at?->toIso8601String(),
+                'schema_version' => (string) $job->schema_version,
+                'sort_order' => (int) $job->sort_order,
+            ],
+            'sections' => $job->sections
+                ->map(static fn (CareerJobSection $section): array => [
+                    'section_key' => (string) $section->section_key,
+                    'title' => $section->title,
+                    'render_variant' => (string) $section->render_variant,
+                    'body_md' => $section->body_md,
+                    'body_html' => $section->body_html,
+                    'payload_json' => $section->payload_json,
+                    'sort_order' => (int) $section->sort_order,
+                    'is_enabled' => (bool) $section->is_enabled,
+                ])
+                ->values()
+                ->all(),
+            'seo_meta' => $job->seoMeta instanceof CareerJobSeoMeta
+                ? [
+                    'seo_title' => $job->seoMeta->seo_title,
+                    'seo_description' => $job->seoMeta->seo_description,
+                    'canonical_url' => $job->seoMeta->canonical_url,
+                    'og_title' => $job->seoMeta->og_title,
+                    'og_description' => $job->seoMeta->og_description,
+                    'og_image_url' => $job->seoMeta->og_image_url,
+                    'twitter_title' => $job->seoMeta->twitter_title,
+                    'twitter_description' => $job->seoMeta->twitter_description,
+                    'twitter_image_url' => $job->seoMeta->twitter_image_url,
+                    'robots' => $job->seoMeta->robots,
+                ]
+                : null,
+            'workspace' => [
+                'form_data' => $formData,
+            ],
+        ];
+    }
+
+    public static function createRevision(CareerJob $job, string $note, ?object $adminUser = null): void
+    {
+        CareerJobRevision::query()->create([
+            'job_id' => (int) $job->id,
+            'revision_no' => self::nextRevisionNo($job),
+            'snapshot_json' => self::snapshotPayload($job),
+            'note' => $note,
+            'created_by_admin_user_id' => self::resolveAdminUserId($adminUser),
+            'created_at' => now(),
+        ]);
+    }
+
+    public static function plannedPublicUrl(CareerJob|string $jobOrSlug, string $locale): ?string
+    {
+        $slug = $jobOrSlug instanceof CareerJob
+            ? (string) $jobOrSlug->slug
+            : (string) $jobOrSlug;
+
+        $resolvedSlug = trim($slug);
+        $baseUrl = rtrim((string) config('app.frontend_url', config('app.url', '')), '/');
+
+        if ($resolvedSlug === '' || $baseUrl === '') {
+            return null;
+        }
+
+        $segment = app(CareerJobSeoService::class)->mapBackendLocaleToFrontendSegment($locale);
+
+        return $baseUrl.'/'.trim($segment, '/').'/career/jobs/'.rawurlencode(Str::lower($resolvedSlug));
+    }
+
+    /**
+     * @return array<int, array{label: string, description: string, ready: bool}>
+     */
+    public static function seoCompleteness(CareerJob $job): array
+    {
+        $seoMeta = self::resolveSeoMeta($job);
+
+        return self::buildSeoCompleteness([
+            'seo_title' => $seoMeta?->seo_title,
+            'seo_description' => $seoMeta?->seo_description,
+            'og_title' => $seoMeta?->og_title,
+            'og_description' => $seoMeta?->og_description,
+            'twitter_title' => $seoMeta?->twitter_title,
+            'twitter_description' => $seoMeta?->twitter_description,
+        ], self::plannedPublicUrl($job, (string) $job->locale), (bool) $job->is_indexable);
+    }
+
+    public static function renderEditorialCues(Get $get, ?CareerJob $record = null): Htmlable
+    {
+        $status = trim((string) ($get('status') ?? $record?->status ?? CareerJob::STATUS_DRAFT));
+        $isPublic = StatusBadge::isTruthy($get('is_public') ?? $record?->is_public ?? false);
+        $isIndexable = StatusBadge::isTruthy($get('is_indexable') ?? $record?->is_indexable ?? true);
+        $plannedUrl = self::plannedPublicUrl(
+            (string) ($get('slug') ?? $record?->slug ?? ''),
+            (string) ($get('locale') ?? $record?->locale ?? 'en'),
+        );
+
+        return new HtmlString((string) view('filament.ops.career-jobs.partials.editorial-cues', [
+            'facts' => array_values(array_filter([
+                [
+                    'label' => 'Published',
+                    'value' => self::formatTimestamp($get('published_at') ?? $record?->published_at),
+                ],
+                [
+                    'label' => 'Scheduled',
+                    'value' => self::formatTimestamp($get('scheduled_at') ?? $record?->scheduled_at),
+                ],
+                [
+                    'label' => 'Planned public URL',
+                    'value' => $plannedUrl,
+                ],
+                [
+                    'label' => 'Revisions',
+                    'value' => $record instanceof CareerJob ? (string) self::revisionCount($record) : null,
+                ],
+            ], static fn (array $fact): bool => filled($fact['value'] ?? null))),
+            'pills' => [
+                [
+                    'label' => self::statusLabel($status),
+                    'state' => $status,
+                ],
+                [
+                    'label' => $isPublic ? 'Public' : 'Private',
+                    'state' => $isPublic ? 'public' : 'inactive',
+                ],
+                [
+                    'label' => $isIndexable ? 'Indexable' : 'Noindex',
+                    'state' => $isIndexable ? 'indexable' : 'noindex',
+                ],
+            ],
+        ])->render());
+    }
+
+    public static function renderSeoSnapshot(Get $get, ?CareerJob $record = null): Htmlable
+    {
+        $plannedCanonical = self::plannedPublicUrl(
+            (string) ($get('slug') ?? $record?->slug ?? ''),
+            (string) ($get('locale') ?? $record?->locale ?? 'en'),
+        );
+
+        return new HtmlString((string) view('filament.ops.career-jobs.partials.seo-snapshot', [
+            'checks' => self::buildSeoCompleteness([
+                'seo_title' => $get('workspace_seo.seo_title') ?? $record?->seoMeta?->seo_title,
+                'seo_description' => $get('workspace_seo.seo_description') ?? $record?->seoMeta?->seo_description,
+                'og_title' => $get('workspace_seo.og_title') ?? $record?->seoMeta?->og_title,
+                'og_description' => $get('workspace_seo.og_description') ?? $record?->seoMeta?->og_description,
+                'twitter_title' => $get('workspace_seo.twitter_title') ?? $record?->seoMeta?->twitter_title,
+                'twitter_description' => $get('workspace_seo.twitter_description') ?? $record?->seoMeta?->twitter_description,
+            ], $plannedCanonical, StatusBadge::isTruthy($get('is_indexable') ?? $record?->is_indexable ?? true)),
+            'plannedCanonical' => $plannedCanonical,
+        ])->render());
+    }
+
+    public static function formatTimestamp(mixed $value, string $fallback = 'Not set yet'): string
+    {
+        $formatted = self::normalizeTimestamp($value);
+
+        return $formatted ?? $fallback;
+    }
+
+    public static function titleMeta(CareerJob $job): string
+    {
+        return collect([
+            filled($job->job_code) ? Str::lower((string) $job->job_code) : null,
+            filled($job->slug) ? '/'.trim((string) $job->slug, '/') : null,
+            filled($job->locale) ? Str::upper((string) $job->locale) : null,
+        ])->filter(static fn (?string $value): bool => filled($value))->implode(' · ');
+    }
+
+    public static function visibilityMeta(CareerJob $job): string
+    {
+        return implode(' · ', [
+            StatusBadge::booleanLabel($job->is_public, 'Public', 'Private'),
+            StatusBadge::booleanLabel($job->is_indexable, 'Indexable', 'Noindex'),
+        ]);
+    }
+
+    public static function normalizeJobCode(?string $jobCode, ?string $slug = null): string
+    {
+        $candidate = trim((string) $jobCode);
+
+        if ($candidate === '' && filled($slug)) {
+            $candidate = (string) $slug;
+        }
+
+        return Str::of($candidate)
+            ->lower()
+            ->replace('_', '-')
+            ->slug('-')
+            ->value();
+    }
+
+    public static function normalizeSlug(?string $slug, ?string $jobCode = null): string
+    {
+        $candidate = trim((string) $slug);
+
+        if ($candidate === '' && filled($jobCode)) {
+            $candidate = (string) $jobCode;
+        }
+
+        return Str::of($candidate)
+            ->lower()
+            ->replace('_', '-')
+            ->slug('-')
+            ->value();
+    }
+
+    public static function normalizeLocale(?string $locale): string
+    {
+        $normalized = trim((string) $locale);
+
+        return in_array($normalized, CareerJob::SUPPORTED_LOCALES, true) ? $normalized : 'en';
+    }
+
+    /**
+     * @param  array<string, mixed>  $state
+     * @return array<int, array{label: string, description: string, ready: bool}>
+     */
+    private static function buildSeoCompleteness(array $state, ?string $plannedCanonical, bool $isIndexable): array
+    {
+        return [
+            [
+                'label' => 'SEO title',
+                'description' => 'Search headline for the career job page.',
+                'ready' => filled(trim((string) ($state['seo_title'] ?? ''))),
+            ],
+            [
+                'label' => 'SEO description',
+                'description' => 'Search description fallback is excerpt, then subtitle.',
+                'ready' => filled(trim((string) ($state['seo_description'] ?? ''))),
+            ],
+            [
+                'label' => 'Canonical route',
+                'description' => 'Final frontend route stays locale-aware even before frontend cutover.',
+                'ready' => filled($plannedCanonical),
+            ],
+            [
+                'label' => 'Social coverage',
+                'description' => 'Open Graph and Twitter overrides for richer sharing cards.',
+                'ready' => filled(trim((string) ($state['og_title'] ?? '')))
+                    && filled(trim((string) ($state['og_description'] ?? '')))
+                    && filled(trim((string) ($state['twitter_title'] ?? '')))
+                    && filled(trim((string) ($state['twitter_description'] ?? ''))),
+            ],
+            [
+                'label' => 'Robots',
+                'description' => $isIndexable ? 'Defaults to index,follow when left blank.' : 'Defaults to noindex,follow when left blank.',
+                'ready' => true,
+            ],
+        ];
+    }
+
+    private static function resolveSeoMeta(CareerJob $job): ?CareerJobSeoMeta
+    {
+        if ($job->relationLoaded('seoMeta') && $job->seoMeta instanceof CareerJobSeoMeta) {
+            return $job->seoMeta;
+        }
+
+        return CareerJobSeoMeta::query()
+            ->where('job_id', (int) $job->id)
+            ->first();
+    }
+
+    private static function revisionCount(CareerJob $job): int
+    {
+        return CareerJobRevision::query()
+            ->where('job_id', (int) $job->id)
+            ->count();
+    }
+
+    private static function resolveAdminUserId(?object $adminUser = null): ?int
+    {
+        if (is_object($adminUser) && method_exists($adminUser, 'getAuthIdentifier')) {
+            return (int) $adminUser->getAuthIdentifier();
+        }
+
+        $guard = (string) config('admin.guard', 'admin');
+        $user = auth($guard)->user();
+
+        if (! is_object($user) || ! method_exists($user, 'getAuthIdentifier')) {
+            return null;
+        }
+
+        return (int) $user->getAuthIdentifier();
+    }
+
+    private static function normalizeNullableText(string $value): ?string
+    {
+        $normalized = trim($value);
+
+        return $normalized === '' ? null : $normalized;
+    }
+
+    private static function normalizeRenderVariant(string $value, string $fallback): string
+    {
+        $normalized = trim($value);
+
+        return in_array($normalized, CareerJobSection::RENDER_VARIANTS, true) ? $normalized : $fallback;
+    }
+
+    private static function normalizeTimestamp(mixed $value): ?string
+    {
+        if ($value instanceof \DateTimeInterface) {
+            return Carbon::instance($value)->timezone(config('app.timezone'))->format('M j, Y H:i');
+        }
+
+        if (! is_string($value) || trim($value) === '') {
+            return null;
+        }
+
+        try {
+            return Carbon::parse($value)->timezone(config('app.timezone'))->format('M j, Y H:i');
+        } catch (\Throwable) {
+            return null;
+        }
+    }
+
+    private static function statusLabel(string $status): string
+    {
+        $normalized = trim($status);
+
+        if ($normalized === '') {
+            return 'Draft';
+        }
+
+        return Str::of($normalized)
+            ->replace(['_', '-'], ' ')
+            ->headline()
+            ->value();
+    }
+
+    private static function encodeJson(mixed $value): string
+    {
+        if ($value === null || $value === '' || $value === []) {
+            return '';
+        }
+
+        try {
+            $encoded = json_encode($value, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE);
+        } catch (\Throwable) {
+            return '';
+        }
+
+        return is_string($encoded) ? $encoded : '';
+    }
+
+    private static function decodeJsonText(mixed $value, string $field): ?array
+    {
+        if ($value === null) {
+            return null;
+        }
+
+        $text = trim((string) $value);
+        if ($text === '') {
+            return null;
+        }
+
+        try {
+            $decoded = json_decode($text, true, flags: JSON_THROW_ON_ERROR);
+        } catch (\Throwable) {
+            throw ValidationException::withMessages([
+                $field => 'Structured payload must be valid JSON.',
+            ]);
+        }
+
+        if (! is_array($decoded)) {
+            throw ValidationException::withMessages([
+                $field => 'Structured payload must decode to a JSON object or array.',
+            ]);
+        }
+
+        return $decoded;
+    }
+}

--- a/backend/app/Jobs/GenerateReportSnapshotJob.php
+++ b/backend/app/Jobs/GenerateReportSnapshotJob.php
@@ -32,8 +32,11 @@ class GenerateReportSnapshotJob implements ShouldQueue
         public string $triggerSource,
         public ?string $orderNo = null,
     ) {
-        $this->onConnection('database_reports');
-        $this->onQueue('reports');
+        $connection = trim((string) config('fap.queue.report_connection', 'database_reports'));
+        $queue = trim((string) config('fap.queue.report_queue', 'reports'));
+
+        $this->onConnection($connection !== '' ? $connection : 'database_reports');
+        $this->onQueue($queue !== '' ? $queue : 'reports');
     }
 
     public function handle(ReportSnapshotStore $store): void

--- a/backend/config/fap.php
+++ b/backend/config/fap.php
@@ -29,6 +29,8 @@ return [
     'queue' => [
         'attempt_connection' => env('FAP_ATTEMPT_QUEUE_CONNECTION', null),
         'attempt_queue' => env('FAP_ATTEMPT_QUEUE', 'default'),
+        'report_connection' => env('FAP_REPORT_QUEUE_CONNECTION', 'database_reports'),
+        'report_queue' => env('FAP_REPORT_QUEUE', 'reports'),
     ],
 
     'payments' => [

--- a/backend/resources/css/filament/ops/theme.css
+++ b/backend/resources/css/filament/ops/theme.css
@@ -1763,6 +1763,207 @@
         font-size: 0.75rem;
         line-height: 1.55;
     }
+
+    .ops-career-job-workspace-layout {
+        align-items: start;
+    }
+
+    .ops-career-job-workspace-main-column,
+    .ops-career-job-workspace-rail-column {
+        gap: 1.5rem;
+        display: grid;
+        align-content: start;
+    }
+
+    .ops-career-job-workspace-section .fi-section-header {
+        min-height: 5.5rem;
+    }
+
+    .ops-career-job-workspace-section--main .fi-section-header-heading {
+        font-size: 1.15rem;
+    }
+
+    .ops-career-job-workspace-section--rail .fi-section-header-heading {
+        font-size: 1rem;
+    }
+
+    .ops-career-job-workspace-field--title .fi-input-wrp {
+        min-height: 3.75rem;
+    }
+
+    .ops-career-job-workspace-input--title {
+        font-size: 1.3rem;
+        font-weight: 650;
+        letter-spacing: -0.035em;
+    }
+
+    .ops-career-job-workspace-field--summary textarea {
+        min-height: 7rem;
+    }
+
+    .ops-career-job-workspace-field--body textarea {
+        min-height: 13rem;
+    }
+
+    .ops-career-job-workspace-field--payload textarea {
+        min-height: 10rem;
+        font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", monospace;
+        font-size: 0.8125rem;
+    }
+
+    .ops-career-job-workspace-field--editor .fi-fo-markdown-editor {
+        border-radius: 18px;
+        overflow: hidden;
+        box-shadow: inset 0 0 0 1px var(--ops-border-default);
+    }
+
+    .ops-career-job-workspace-field--editor .editor-toolbar {
+        border-color: var(--ops-border-default);
+        background: rgba(247, 248, 250, 0.94);
+    }
+
+    .ops-career-job-workspace-field--editor .CodeMirror,
+    .ops-career-job-workspace-field--editor .EasyMDEContainer {
+        background: #fff;
+    }
+
+    .ops-career-job-workspace-field--editor .CodeMirror-scroll {
+        min-height: 21rem;
+    }
+
+    .ops-career-job-workspace-section .fi-fo-placeholder {
+        gap: 0.85rem;
+    }
+
+    .ops-career-job-workspace-tabs {
+        gap: 1rem;
+    }
+
+    .ops-career-job-workspace-tabs .fi-tabs {
+        margin-bottom: 1rem;
+    }
+
+    .ops-career-job-workspace-tabs .fi-tabs-item {
+        min-height: 2.75rem;
+    }
+
+    .ops-career-job-workspace-tabs .fi-fo-tabs-tab {
+        gap: 1rem;
+    }
+
+    .ops-career-job-workspace-cues,
+    .ops-career-job-workspace-seo {
+        display: grid;
+        gap: 1rem;
+    }
+
+    .ops-career-job-workspace-cues__pills {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 0.5rem;
+    }
+
+    .ops-career-job-workspace-cues__facts {
+        display: grid;
+        gap: 0.8rem;
+    }
+
+    .ops-career-job-workspace-cues__fact {
+        display: grid;
+        gap: 0.18rem;
+    }
+
+    .ops-career-job-workspace-cues__fact dt {
+        color: var(--ops-text-tertiary);
+        font-size: 0.72rem;
+        font-weight: 700;
+        letter-spacing: 0.06em;
+        text-transform: uppercase;
+    }
+
+    .ops-career-job-workspace-cues__fact dd {
+        color: var(--ops-text-primary);
+        font-size: 0.875rem;
+        line-height: 1.55;
+        margin: 0;
+    }
+
+    .ops-career-job-workspace-seo__grid {
+        display: grid;
+        gap: 0.8rem;
+    }
+
+    .ops-career-job-workspace-seo__item {
+        display: flex;
+        align-items: flex-start;
+        justify-content: space-between;
+        gap: 1rem;
+        padding: 0.9rem 1rem;
+        border-radius: 14px;
+        background: rgba(247, 248, 250, 0.85);
+        box-shadow: inset 0 0 0 1px rgba(229, 231, 235, 0.92);
+    }
+
+    .ops-career-job-workspace-seo__copy {
+        display: grid;
+        gap: 0.2rem;
+    }
+
+    .ops-career-job-workspace-seo__label {
+        color: var(--ops-text-primary);
+        font-size: 0.9rem;
+        font-weight: 650;
+        letter-spacing: -0.015em;
+    }
+
+    .ops-career-job-workspace-seo__description {
+        color: var(--ops-text-secondary);
+        font-size: 0.8125rem;
+        line-height: 1.55;
+    }
+
+    .ops-career-job-workspace-seo__planned {
+        display: grid;
+        gap: 0.25rem;
+        padding: 0.9rem 1rem;
+        border-radius: 14px;
+        background: rgba(var(--primary-50), 0.72);
+        box-shadow: inset 0 0 0 1px rgba(var(--primary-100), 0.9);
+    }
+
+    .ops-career-job-workspace-seo__planned-label {
+        color: rgb(var(--primary-700));
+        font-size: 0.72rem;
+        font-weight: 700;
+        letter-spacing: 0.06em;
+        text-transform: uppercase;
+    }
+
+    .ops-career-job-workspace-seo__planned-value {
+        color: var(--ops-text-primary);
+        font-size: 0.8125rem;
+        font-weight: 600;
+        line-height: 1.55;
+        word-break: break-word;
+    }
+
+    .ops-career-job-workspace-table-title {
+        display: grid;
+        gap: 0.2rem;
+    }
+
+    .ops-career-job-workspace-table-title__text {
+        color: var(--ops-text-primary);
+        font-size: 0.95rem;
+        font-weight: 700;
+        letter-spacing: -0.02em;
+    }
+
+    .ops-career-job-workspace-table-title__meta {
+        color: var(--ops-text-secondary);
+        font-size: 0.75rem;
+        line-height: 1.55;
+    }
 }
 
 @media (max-width: 1023px) {
@@ -1819,6 +2020,10 @@
     }
 
     .ops-personality-workspace-seo__item {
+        flex-direction: column;
+    }
+
+    .ops-career-job-workspace-seo__item {
         flex-direction: column;
     }
 }

--- a/backend/resources/views/filament/ops/career-jobs/partials/editorial-cues.blade.php
+++ b/backend/resources/views/filament/ops/career-jobs/partials/editorial-cues.blade.php
@@ -1,0 +1,18 @@
+<div class="ops-career-job-workspace-cues">
+    <div class="ops-career-job-workspace-cues__pills">
+        @foreach ($pills as $pill)
+            <x-filament.ops.shared.status-pill :label="$pill['label']" :state="$pill['state']" />
+        @endforeach
+    </div>
+
+    @if ($facts !== [])
+        <dl class="ops-career-job-workspace-cues__facts">
+            @foreach ($facts as $fact)
+                <div class="ops-career-job-workspace-cues__fact">
+                    <dt>{{ $fact['label'] }}</dt>
+                    <dd>{{ $fact['value'] }}</dd>
+                </div>
+            @endforeach
+        </dl>
+    @endif
+</div>

--- a/backend/resources/views/filament/ops/career-jobs/partials/seo-snapshot.blade.php
+++ b/backend/resources/views/filament/ops/career-jobs/partials/seo-snapshot.blade.php
@@ -1,0 +1,24 @@
+<div class="ops-career-job-workspace-seo">
+    <div class="ops-career-job-workspace-seo__grid">
+        @foreach ($checks as $check)
+            <div class="ops-career-job-workspace-seo__item">
+                <div class="ops-career-job-workspace-seo__copy">
+                    <span class="ops-career-job-workspace-seo__label">{{ $check['label'] }}</span>
+                    <span class="ops-career-job-workspace-seo__description">{{ $check['description'] }}</span>
+                </div>
+
+                <x-filament.ops.shared.status-pill
+                    :label="$check['ready'] ? 'Ready' : 'Missing'"
+                    :state="$check['ready'] ? 'ready' : 'draft'"
+                />
+            </div>
+        @endforeach
+    </div>
+
+    @if (filled($plannedCanonical))
+        <div class="ops-career-job-workspace-seo__planned">
+            <span class="ops-career-job-workspace-seo__planned-label">Planned canonical</span>
+            <span class="ops-career-job-workspace-seo__planned-value">{{ $plannedCanonical }}</span>
+        </div>
+    @endif
+</div>

--- a/backend/resources/views/filament/ops/career-jobs/partials/table-title.blade.php
+++ b/backend/resources/views/filament/ops/career-jobs/partials/table-title.blade.php
@@ -1,0 +1,7 @@
+<div class="ops-career-job-workspace-table-title">
+    <span class="ops-career-job-workspace-table-title__text">{{ $title }}</span>
+
+    @if (filled($meta))
+        <span class="ops-career-job-workspace-table-title__meta">{{ $meta }}</span>
+    @endif
+</div>

--- a/backend/tests/Feature/CareerCms/CareerJobBaselineImportTest.php
+++ b/backend/tests/Feature/CareerCms/CareerJobBaselineImportTest.php
@@ -1,0 +1,293 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\CareerCms;
+
+use App\Models\CareerJob;
+use App\Models\CareerJobRevision;
+use App\Models\CareerJobSection;
+use App\Models\CareerJobSeoMeta;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\File;
+use Tests\TestCase;
+
+final class CareerJobBaselineImportTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_dry_run_does_not_write_database(): void
+    {
+        $this->artisan('career-jobs:import-local-baseline', [
+            '--dry-run' => true,
+            '--source-dir' => 'tests/Fixtures/career_job_baseline',
+        ])
+            ->expectsOutputToContain('files_found=2')
+            ->expectsOutputToContain('jobs_found=4')
+            ->expectsOutputToContain('will_create=4')
+            ->expectsOutputToContain('revisions_to_create=4')
+            ->assertExitCode(0);
+
+        $this->assertSame(0, CareerJob::query()->count());
+        $this->assertSame(0, CareerJobSection::query()->count());
+        $this->assertSame(0, CareerJobSeoMeta::query()->count());
+        $this->assertSame(0, CareerJobRevision::query()->count());
+    }
+
+    public function test_default_mode_creates_missing_jobs_sections_seo_meta_and_revision(): void
+    {
+        $this->artisan('career-jobs:import-local-baseline', [
+            '--locale' => ['en'],
+            '--status' => 'draft',
+            '--source-dir' => 'tests/Fixtures/career_job_baseline',
+        ])
+            ->expectsOutputToContain('jobs_found=2')
+            ->expectsOutputToContain('will_create=2')
+            ->assertExitCode(0);
+
+        $this->assertSame(2, CareerJob::query()->count());
+        $this->assertSame(1, CareerJobSection::query()->count());
+        $this->assertSame(2, CareerJobSeoMeta::query()->count());
+        $this->assertSame(2, CareerJobRevision::query()->count());
+
+        $job = CareerJob::query()
+            ->withoutGlobalScopes()
+            ->where('job_code', 'product-manager')
+            ->where('locale', 'en')
+            ->firstOrFail();
+
+        $this->assertSame(0, (int) $job->org_id);
+        $this->assertSame('draft', $job->status);
+        $this->assertNull($job->published_at);
+        $this->assertNull($job->fit_personality_codes_json);
+        $this->assertSame(['raw' => 82], $job->market_demand_json);
+        $this->assertSame(
+            ['raw' => ['openness' => ['min' => 40, 'max' => 80], 'conscientiousness' => ['min' => 50, 'max' => 90]]],
+            $job->big5_targets_json,
+        );
+        $this->assertSame(
+            ['iq_range' => ['min' => 50, 'max' => 98], 'eq_range' => ['min' => 55, 'max' => 100]],
+            $job->iq_eq_notes_json,
+        );
+
+        $revision = CareerJobRevision::query()
+            ->where('job_id', (int) $job->id)
+            ->orderBy('revision_no')
+            ->firstOrFail();
+
+        $this->assertSame(1, (int) $revision->revision_no);
+        $this->assertSame('baseline import', $revision->note);
+    }
+
+    public function test_default_mode_skips_existing_jobs_without_overwriting(): void
+    {
+        $job = CareerJob::query()->create([
+            'org_id' => 0,
+            'job_code' => 'product-manager',
+            'slug' => 'product-manager',
+            'locale' => 'en',
+            'title' => 'Do Not Overwrite',
+            'status' => CareerJob::STATUS_DRAFT,
+            'is_public' => true,
+            'is_indexable' => true,
+            'schema_version' => 'v1',
+        ]);
+
+        CareerJobRevision::query()->create([
+            'job_id' => (int) $job->id,
+            'revision_no' => 1,
+            'snapshot_json' => ['title' => 'Do Not Overwrite'],
+            'note' => 'seed',
+            'created_at' => now(),
+        ]);
+
+        $this->artisan('career-jobs:import-local-baseline', [
+            '--locale' => ['en'],
+            '--job' => ['product-manager'],
+            '--source-dir' => 'tests/Fixtures/career_job_baseline',
+        ])
+            ->expectsOutputToContain('jobs_found=1')
+            ->expectsOutputToContain('will_skip=1')
+            ->assertExitCode(0);
+
+        $this->assertSame('Do Not Overwrite', (string) $job->fresh()->title);
+        $this->assertSame(1, CareerJobRevision::query()->where('job_id', (int) $job->id)->count());
+    }
+
+    public function test_upsert_updates_existing_jobs_and_only_creates_revision_when_changed(): void
+    {
+        $job = CareerJob::query()->create([
+            'org_id' => 0,
+            'job_code' => 'product-manager',
+            'slug' => 'product-manager',
+            'locale' => 'en',
+            'title' => 'Legacy PM',
+            'excerpt' => 'Legacy excerpt',
+            'status' => CareerJob::STATUS_PUBLISHED,
+            'is_public' => true,
+            'is_indexable' => false,
+            'published_at' => now()->subDay(),
+            'schema_version' => 'v1',
+            'salary_json' => ['raw' => '$1'],
+            'mbti_primary_codes_json' => ['INTJ'],
+            'mbti_secondary_codes_json' => ['INFJ'],
+            'riasec_profile_json' => ['R' => 1, 'I' => 2, 'A' => 3, 'S' => 4, 'E' => 5, 'C' => 6],
+        ]);
+
+        CareerJobSection::query()->create([
+            'job_id' => (int) $job->id,
+            'section_key' => 'faq',
+            'title' => 'Legacy FAQ',
+            'render_variant' => 'faq',
+            'payload_json' => ['items' => [['question' => 'Old', 'answer' => 'Old']]],
+            'sort_order' => 80,
+            'is_enabled' => true,
+        ]);
+        CareerJobSection::query()->create([
+            'job_id' => (int) $job->id,
+            'section_key' => 'day_to_day',
+            'title' => 'Legacy',
+            'render_variant' => 'rich_text',
+            'body_md' => 'Old',
+            'sort_order' => 10,
+            'is_enabled' => true,
+        ]);
+        CareerJobSeoMeta::query()->create([
+            'job_id' => (int) $job->id,
+            'seo_title' => 'Legacy title',
+            'seo_description' => 'Legacy description',
+        ]);
+        CareerJobRevision::query()->create([
+            'job_id' => (int) $job->id,
+            'revision_no' => 1,
+            'snapshot_json' => ['title' => 'Legacy PM'],
+            'note' => 'seed',
+            'created_at' => now()->subDay(),
+        ]);
+
+        $this->artisan('career-jobs:import-local-baseline', [
+            '--locale' => ['en'],
+            '--job' => ['product-manager'],
+            '--upsert' => true,
+            '--status' => 'published',
+            '--source-dir' => 'tests/Fixtures/career_job_baseline',
+        ])
+            ->expectsOutputToContain('jobs_found=1')
+            ->expectsOutputToContain('will_update=1')
+            ->expectsOutputToContain('revisions_to_create=1')
+            ->assertExitCode(0);
+
+        $job->refresh();
+
+        $this->assertSame('Product Manager', $job->title);
+        $this->assertTrue((bool) $job->is_indexable);
+        $this->assertNotNull($job->published_at);
+        $this->assertSame(
+            ['faq'],
+            CareerJobSection::query()
+                ->where('job_id', (int) $job->id)
+                ->orderBy('section_key')
+                ->pluck('section_key')
+                ->all(),
+        );
+        $this->assertSame(
+            'Product Manager Career Guide | FermatMind',
+            CareerJobSeoMeta::query()->where('job_id', (int) $job->id)->firstOrFail()->seo_title,
+        );
+        $this->assertSame(
+            2,
+            CareerJobRevision::query()->where('job_id', (int) $job->id)->max('revision_no'),
+        );
+
+        $this->artisan('career-jobs:import-local-baseline', [
+            '--locale' => ['en'],
+            '--job' => ['product-manager'],
+            '--upsert' => true,
+            '--status' => 'published',
+            '--source-dir' => 'tests/Fixtures/career_job_baseline',
+        ])
+            ->expectsOutputToContain('will_skip=1')
+            ->assertExitCode(0);
+
+        $this->assertSame(
+            2,
+            CareerJobRevision::query()->where('job_id', (int) $job->id)->count(),
+        );
+    }
+
+    public function test_locale_and_job_filters_limit_import_scope(): void
+    {
+        $this->artisan('career-jobs:import-local-baseline', [
+            '--locale' => ['zh-CN'],
+            '--job' => ['product-manager'],
+            '--status' => 'draft',
+            '--source-dir' => 'tests/Fixtures/career_job_baseline',
+        ])
+            ->expectsOutputToContain('jobs_found=1')
+            ->expectsOutputToContain('will_create=1')
+            ->assertExitCode(0);
+
+        $this->assertSame(1, CareerJob::query()->count());
+
+        $job = CareerJob::query()->firstOrFail();
+        $this->assertSame('product-manager', $job->job_code);
+        $this->assertSame('zh-CN', $job->locale);
+    }
+
+    public function test_invalid_baseline_fails_with_non_zero_exit_code(): void
+    {
+        $sourceDir = base_path('tests/Fixtures/career_job_baseline_invalid');
+
+        File::deleteDirectory($sourceDir);
+        File::ensureDirectoryExists($sourceDir);
+        File::put($sourceDir.'/career_jobs.en.json', json_encode([
+            'meta' => [
+                'schema_version' => 'v1',
+                'locale' => 'en',
+                'source' => 'test fixture',
+                'generated_at' => '2026-03-09T00:00:00Z',
+            ],
+            'jobs' => [
+                [
+                    'job_code' => 'bad-job',
+                    'slug' => 'bad-job',
+                    'locale' => 'en',
+                    'title' => 'Bad Job',
+                    'excerpt' => 'Bad',
+                    'body_md' => '# Bad',
+                    'body_html' => null,
+                    'salary_json' => ['raw' => '$1'],
+                    'outlook_json' => ['summary' => 'Bad'],
+                    'skills_json' => ['core' => ['Bad'], 'supporting' => []],
+                    'work_contents_json' => ['items' => ['Bad']],
+                    'growth_path_json' => ['raw' => ['Bad']],
+                    'fit_personality_codes_json' => null,
+                    'mbti_primary_codes_json' => ['BAD'],
+                    'mbti_secondary_codes_json' => ['ENFP'],
+                    'riasec_profile_json' => ['R' => 1, 'I' => 2, 'A' => 3, 'S' => 4, 'E' => 5, 'C' => 6],
+                    'big5_targets_json' => ['raw' => ['openness' => ['min' => 40, 'max' => 80]]],
+                    'iq_eq_notes_json' => ['iq_range' => ['min' => 1, 'max' => 2]],
+                    'market_demand_json' => ['raw' => 1],
+                    'status' => 'published',
+                    'is_public' => true,
+                    'is_indexable' => true,
+                    'published_at' => null,
+                    'scheduled_at' => null,
+                    'sort_order' => 0,
+                    'sections' => [],
+                    'seo_meta' => [],
+                ],
+            ],
+        ], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES | JSON_PRETTY_PRINT));
+
+        try {
+            $this->artisan('career-jobs:import-local-baseline', [
+                '--source-dir' => 'tests/Fixtures/career_job_baseline_invalid',
+            ])
+                ->expectsOutputToContain('invalid MBTI code')
+                ->assertExitCode(1);
+        } finally {
+            File::deleteDirectory($sourceDir);
+        }
+    }
+}

--- a/backend/tests/Feature/Ops/CareerJobWorkspaceTest.php
+++ b/backend/tests/Feature/Ops/CareerJobWorkspaceTest.php
@@ -1,0 +1,410 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Ops;
+
+use App\Filament\Ops\Resources\CareerJobResource;
+use App\Filament\Ops\Resources\CareerJobResource\Support\CareerJobWorkspace;
+use App\Models\AdminUser;
+use App\Models\CareerJob;
+use App\Models\CareerJobRevision;
+use App\Models\Organization;
+use App\Models\Permission;
+use App\Models\Role;
+use App\Support\OrgContext;
+use App\Support\Rbac\PermissionNames;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Http\Request;
+use Illuminate\Support\Str;
+use Tests\TestCase;
+
+final class CareerJobWorkspaceTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_career_job_workspace_pages_render_for_authorized_admin(): void
+    {
+        $admin = $this->createAdminWithPermissions([
+            PermissionNames::ADMIN_CONTENT_READ,
+            PermissionNames::ADMIN_CONTENT_PUBLISH,
+        ]);
+        $selectedOrg = $this->createSelectedOrg();
+        $job = $this->seedJob([
+            'title' => 'Product Manager',
+        ]);
+
+        CareerJobWorkspace::syncWorkspaceSections($job, $this->workspaceSectionsState());
+        CareerJobWorkspace::syncWorkspaceSeo($job, $this->workspaceSeoState());
+        CareerJobWorkspace::createRevision($job, 'Seed revision', $admin);
+
+        $this->withSession([
+            'ops_org_id' => $selectedOrg->id,
+            'ops_admin_totp_verified_user_id' => (int) $admin->id,
+        ])->actingAs($admin, (string) config('admin.guard', 'admin'))
+            ->get('/ops/career-jobs')
+            ->assertOk()
+            ->assertSee('Global career content workspace', false)
+            ->assertSee('Create Career Job');
+
+        $this->withSession([
+            'ops_org_id' => $selectedOrg->id,
+            'ops_admin_totp_verified_user_id' => (int) $admin->id,
+        ])->actingAs($admin, (string) config('admin.guard', 'admin'))
+            ->get('/ops/career-jobs/create')
+            ->assertOk()
+            ->assertSee('ops-career-job-workspace-layout', false)
+            ->assertSee('Create Career Job');
+
+        $this->withSession([
+            'ops_org_id' => $selectedOrg->id,
+            'ops_admin_totp_verified_user_id' => (int) $admin->id,
+        ])->actingAs($admin, (string) config('admin.guard', 'admin'))
+            ->get('/ops/career-jobs/'.$job->id.'/edit')
+            ->assertOk()
+            ->assertSee('ops-career-job-workspace-layout', false)
+            ->assertSee('Planned public URL');
+    }
+
+    public function test_workspace_sync_persists_sections_seo_revision_and_json_signals(): void
+    {
+        $job = $this->seedJob();
+
+        CareerJobWorkspace::syncWorkspaceSections($job, $this->workspaceSectionsState());
+        CareerJobWorkspace::syncWorkspaceSeo($job, $this->workspaceSeoState());
+        CareerJobWorkspace::createRevision($job, 'Initial workspace snapshot');
+
+        $this->assertDatabaseHas('career_job_sections', [
+            'job_id' => $job->id,
+            'section_key' => 'day_to_day',
+            'title' => 'A typical day',
+            'render_variant' => 'rich_text',
+            'is_enabled' => 1,
+        ]);
+
+        $this->assertDatabaseHas('career_job_seo_meta', [
+            'job_id' => $job->id,
+            'seo_title' => 'Product Manager Career Guide | FermatMind',
+            'robots' => 'index,follow',
+        ]);
+
+        $this->assertDatabaseHas('career_job_revisions', [
+            'job_id' => $job->id,
+            'revision_no' => 1,
+            'note' => 'Initial workspace snapshot',
+        ]);
+
+        $job->refresh();
+
+        $this->assertSame('USD', $job->salary_json['currency']);
+        $this->assertSame(['ENTJ', 'ENFJ'], $job->mbti_primary_codes_json);
+        $this->assertSame(88, $job->riasec_profile_json['E']);
+    }
+
+    public function test_workspace_sync_updates_job_sections_seo_revision_counter_and_signals(): void
+    {
+        $job = $this->seedJob();
+
+        CareerJobWorkspace::syncWorkspaceSections($job, $this->workspaceSectionsState());
+        CareerJobWorkspace::syncWorkspaceSeo($job, $this->workspaceSeoState());
+        CareerJobWorkspace::createRevision($job, 'Initial workspace snapshot');
+
+        $job->update([
+            'title' => 'Product Manager (Updated)',
+            'subtitle' => 'Sharper, clearer, and more actionable.',
+            'salary_json' => [
+                'currency' => 'USD',
+                'region' => 'US',
+                'low' => 90000,
+                'median' => 135000,
+                'high' => 195000,
+                'notes' => 'Updated salary range after market review.',
+            ],
+            'mbti_primary_codes_json' => ['ENTJ', 'INTJ'],
+            'riasec_profile_json' => [
+                'R' => 35,
+                'I' => 70,
+                'A' => 52,
+                'S' => 58,
+                'E' => 92,
+                'C' => 66,
+            ],
+        ]);
+
+        $updatedSections = $this->workspaceSectionsState();
+        $updatedSections['faq']['is_enabled'] = true;
+        $updatedSections['faq']['payload_json_text'] = json_encode([
+            'items' => [
+                [
+                    'question' => 'Do product managers need to code?',
+                    'answer' => 'Not always, but strong product judgment and technical fluency help.',
+                ],
+            ],
+        ], JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE);
+        $updatedSections['growth_story']['body_md'] = 'Updated growth story for the product manager path.';
+
+        $updatedSeo = $this->workspaceSeoState();
+        $updatedSeo['seo_description'] = 'Updated SEO summary for the product manager workspace.';
+
+        CareerJobWorkspace::syncWorkspaceSections($job, $updatedSections);
+        CareerJobWorkspace::syncWorkspaceSeo($job, $updatedSeo);
+        CareerJobWorkspace::createRevision($job, 'Workspace update');
+
+        $this->assertDatabaseHas('career_job_sections', [
+            'job_id' => $job->id,
+            'section_key' => 'faq',
+            'is_enabled' => 1,
+            'render_variant' => 'faq',
+        ]);
+
+        $this->assertDatabaseHas('career_job_seo_meta', [
+            'job_id' => $job->id,
+            'seo_description' => 'Updated SEO summary for the product manager workspace.',
+        ]);
+
+        $this->assertDatabaseHas('career_job_revisions', [
+            'job_id' => $job->id,
+            'revision_no' => 2,
+            'note' => 'Workspace update',
+        ]);
+
+        $job->refresh();
+        $this->assertSame(135000, $job->salary_json['median']);
+        $this->assertSame(['ENTJ', 'INTJ'], $job->mbti_primary_codes_json);
+        $this->assertSame(92, $job->riasec_profile_json['E']);
+
+        $latestRevision = CareerJobRevision::query()
+            ->where('job_id', $job->id)
+            ->where('revision_no', 2)
+            ->firstOrFail();
+
+        $this->assertSame('Product Manager (Updated)', $latestRevision->snapshot_json['job']['title']);
+        $this->assertSame('Updated growth story for the product manager path.', $latestRevision->snapshot_json['sections'][2]['body_md']);
+    }
+
+    public function test_resource_query_is_locked_to_global_career_jobs(): void
+    {
+        $globalJob = $this->seedJob([
+            'org_id' => 0,
+            'slug' => 'product-manager-global',
+            'job_code' => 'product-manager-global',
+        ]);
+
+        $tenantJob = $this->seedJob([
+            'org_id' => 77,
+            'slug' => 'product-manager-tenant',
+            'job_code' => 'product-manager-tenant',
+        ]);
+
+        $request = Request::create('/ops/career-jobs', 'GET');
+        app()->instance('request', $request);
+
+        $context = app(OrgContext::class);
+        $context->set(77, 9001, 'admin');
+        app()->instance(OrgContext::class, $context);
+
+        $ids = CareerJobResource::getEloquentQuery()
+            ->orderBy('id')
+            ->pluck('id')
+            ->all();
+
+        $this->assertContains($globalJob->id, $ids);
+        $this->assertNotContains($tenantJob->id, $ids);
+    }
+
+    public function test_workspace_ignores_unknown_section_keys(): void
+    {
+        $job = $this->seedJob();
+
+        $sections = $this->workspaceSectionsState();
+        $sections['rogue_section'] = [
+            'title' => 'Rogue',
+            'render_variant' => 'rich_text',
+            'body_md' => 'Should never persist.',
+            'payload_json_text' => '',
+            'sort_order' => 999,
+            'is_enabled' => true,
+        ];
+
+        CareerJobWorkspace::syncWorkspaceSections($job, $sections);
+
+        $this->assertDatabaseMissing('career_job_sections', [
+            'job_id' => $job->id,
+            'section_key' => 'rogue_section',
+        ]);
+    }
+
+    private function createSelectedOrg(): Organization
+    {
+        return Organization::query()->create([
+            'name' => 'Ops Workspace Org',
+            'owner_user_id' => 9001,
+            'status' => 'active',
+            'domain' => 'ops-workspace.example.test',
+            'timezone' => 'Asia/Shanghai',
+            'locale' => 'en',
+        ]);
+    }
+
+    /**
+     * @param  list<string>  $permissions
+     */
+    private function createAdminWithPermissions(array $permissions): AdminUser
+    {
+        $admin = AdminUser::query()->create([
+            'name' => 'admin_'.Str::lower(Str::random(6)),
+            'email' => 'admin_'.Str::lower(Str::random(6)).'@example.test',
+            'password' => bcrypt('secret'),
+            'is_active' => 1,
+        ]);
+
+        if ($permissions === []) {
+            return $admin;
+        }
+
+        $role = Role::query()->create([
+            'name' => 'role_'.Str::lower(Str::random(10)),
+            'description' => null,
+        ]);
+
+        foreach ($permissions as $permissionName) {
+            $permission = Permission::query()->firstOrCreate(
+                ['name' => $permissionName],
+                ['description' => null],
+            );
+
+            $role->permissions()->syncWithoutDetaching([$permission->id]);
+        }
+
+        $admin->roles()->syncWithoutDetaching([$role->id]);
+
+        return $admin;
+    }
+
+    /**
+     * @param  array<string, mixed>  $overrides
+     */
+    private function seedJob(array $overrides = []): CareerJob
+    {
+        return CareerJob::query()->create(array_merge([
+            'org_id' => 0,
+            'job_code' => 'product-manager',
+            'slug' => 'product-manager',
+            'locale' => 'en',
+            'title' => 'Product Manager',
+            'subtitle' => 'Lead product direction across user, business, and engineering goals.',
+            'excerpt' => 'Understand the responsibilities, salary, growth path, and personality fit for product managers.',
+            'hero_kicker' => 'Career profile',
+            'hero_quote' => 'Translate uncertainty into direction.',
+            'cover_image_url' => 'https://example.test/product-manager.png',
+            'industry_slug' => 'technology',
+            'industry_label' => 'Technology',
+            'body_md' => "## Role Overview\n\nGuide product direction across user, business, and engineering goals.",
+            'salary_json' => [
+                'currency' => 'USD',
+                'region' => 'US',
+                'low' => 80000,
+                'median' => 120000,
+                'high' => 180000,
+                'notes' => 'Ranges vary by city and seniority.',
+            ],
+            'outlook_json' => [
+                'summary' => 'Growing',
+                'horizon_years' => 5,
+                'notes' => 'Strong demand in AI-enabled product roles.',
+            ],
+            'skills_json' => [
+                'core' => ['roadmapping', 'prioritization'],
+                'supporting' => ['stakeholder management'],
+            ],
+            'work_contents_json' => [
+                'items' => ['Define product strategy', 'Coordinate design and engineering execution'],
+            ],
+            'growth_path_json' => [
+                'entry' => 'Associate Product Manager',
+                'mid' => 'Product Manager',
+                'senior' => 'Senior PM / Group PM',
+                'notes' => 'Track can branch into leadership or strategy.',
+            ],
+            'fit_personality_codes_json' => ['ENTJ', 'ENFJ', 'ESTP'],
+            'mbti_primary_codes_json' => ['ENTJ', 'ENFJ'],
+            'mbti_secondary_codes_json' => ['ENFP', 'ENTP'],
+            'riasec_profile_json' => [
+                'R' => 42,
+                'I' => 66,
+                'A' => 56,
+                'S' => 60,
+                'E' => 88,
+                'C' => 70,
+            ],
+            'big5_targets_json' => [
+                'openness' => 'high',
+                'conscientiousness' => 'high',
+                'extraversion' => 'balanced',
+                'agreeableness' => 'balanced',
+                'neuroticism' => 'low',
+            ],
+            'iq_eq_notes_json' => [
+                'iq' => 'Requires strong analytical reasoning.',
+                'eq' => 'Requires stakeholder empathy and communication.',
+            ],
+            'market_demand_json' => [
+                'signal' => 'high',
+                'notes' => 'Demand remains strong across SaaS, fintech, and AI startups.',
+            ],
+            'status' => CareerJob::STATUS_DRAFT,
+            'is_public' => true,
+            'is_indexable' => true,
+            'sort_order' => 10,
+            'schema_version' => 'v1',
+        ], $overrides));
+    }
+
+    /**
+     * @return array<string, array<string, mixed>>
+     */
+    private function workspaceSectionsState(): array
+    {
+        return array_replace_recursive(CareerJobWorkspace::defaultWorkspaceSectionsState(), [
+            'day_to_day' => [
+                'is_enabled' => true,
+                'body_md' => 'Mornings focus on priorities, afternoons on alignment, and evenings on decision follow-through.',
+            ],
+            'skills_explained' => [
+                'is_enabled' => true,
+                'render_variant' => 'cards',
+                'payload_json_text' => json_encode([
+                    'items' => [
+                        [
+                            'title' => 'Roadmapping',
+                            'body' => 'Turn ambiguity into clear priorities and staged delivery decisions.',
+                        ],
+                    ],
+                ], JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE),
+            ],
+            'growth_story' => [
+                'is_enabled' => true,
+                'body_md' => 'The path often begins with execution detail, then expands into prioritization, strategy, and people influence.',
+            ],
+        ]);
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    private function workspaceSeoState(): array
+    {
+        return [
+            'seo_title' => 'Product Manager Career Guide | FermatMind',
+            'seo_description' => 'Responsibilities, salary, growth path, and personality fit for product managers.',
+            'canonical_url' => '',
+            'og_title' => 'Product Manager Career Guide',
+            'og_description' => 'Responsibilities, salary, growth path, and personality fit for product managers.',
+            'og_image_url' => 'https://example.test/product-manager-og.png',
+            'twitter_title' => 'Product Manager Career Guide',
+            'twitter_description' => 'Responsibilities, salary, growth path, and personality fit for product managers.',
+            'twitter_image_url' => 'https://example.test/product-manager-twitter.png',
+            'robots' => 'index,follow',
+        ];
+    }
+}

--- a/backend/tests/Fixtures/career_job_baseline/career_jobs.en.json
+++ b/backend/tests/Fixtures/career_job_baseline/career_jobs.en.json
@@ -1,0 +1,230 @@
+{
+  "meta": {
+    "schema_version": "v1",
+    "locale": "en",
+    "source": "test fixture",
+    "generated_at": "2026-03-09T00:00:00Z"
+  },
+  "jobs": [
+    {
+      "job_code": "product-manager",
+      "slug": "product-manager",
+      "locale": "en",
+      "title": "Product Manager",
+      "subtitle": null,
+      "excerpt": "Lead product direction across user, business, and engineering goals.",
+      "hero_kicker": null,
+      "hero_quote": null,
+      "cover_image_url": null,
+      "industry_slug": "business",
+      "industry_label": null,
+      "body_md": "# Product Manager\n\nA practical role profile.\n",
+      "body_html": null,
+      "salary_json": {
+        "raw": "$55,000 - $180,000"
+      },
+      "outlook_json": {
+        "summary": "Demand remains strong in data-driven organizations."
+      },
+      "skills_json": {
+        "core": [
+          "Structured problem solving",
+          "Stakeholder communication"
+        ],
+        "supporting": []
+      },
+      "work_contents_json": {
+        "items": [
+          "Define product priorities.",
+          "Coordinate stakeholders."
+        ]
+      },
+      "growth_path_json": {
+        "raw": [
+          "0-2 years: build execution skills.",
+          "3-5 years: own medium complexity projects."
+        ]
+      },
+      "fit_personality_codes_json": null,
+      "mbti_primary_codes_json": [
+        "ENTJ",
+        "ENFJ",
+        "ESTP"
+      ],
+      "mbti_secondary_codes_json": [
+        "ENFP",
+        "ESTJ",
+        "ENTP"
+      ],
+      "riasec_profile_json": {
+        "R": 42,
+        "I": 66,
+        "A": 56,
+        "S": 60,
+        "E": 88,
+        "C": 70
+      },
+      "big5_targets_json": {
+        "raw": {
+          "openness": {
+            "min": 40,
+            "max": 80
+          },
+          "conscientiousness": {
+            "min": 50,
+            "max": 90
+          }
+        }
+      },
+      "iq_eq_notes_json": {
+        "iq_range": {
+          "min": 50,
+          "max": 98
+        },
+        "eq_range": {
+          "min": 55,
+          "max": 100
+        }
+      },
+      "market_demand_json": {
+        "raw": 82
+      },
+      "status": "published",
+      "is_public": true,
+      "is_indexable": true,
+      "published_at": null,
+      "scheduled_at": null,
+      "sort_order": 5,
+      "sections": [
+        {
+          "section_key": "faq",
+          "title": "FAQ",
+          "render_variant": "faq",
+          "body_md": null,
+          "body_html": null,
+          "payload_json": {
+            "items": [
+              {
+                "question": "What does a PM do?",
+                "answer": "Align product direction with business outcomes."
+              }
+            ]
+          },
+          "sort_order": 80,
+          "is_enabled": true
+        }
+      ],
+      "seo_meta": {
+        "seo_title": "Product Manager Career Guide | FermatMind",
+        "seo_description": "Responsibilities, salary, growth path, and personality fit for Product Managers.",
+        "canonical_url": null,
+        "og_title": null,
+        "og_description": null,
+        "og_image_url": null,
+        "twitter_title": null,
+        "twitter_description": null,
+        "twitter_image_url": null,
+        "robots": null,
+        "jsonld_overrides_json": null
+      }
+    },
+    {
+      "job_code": "teacher",
+      "slug": "teacher",
+      "locale": "en",
+      "title": "Teacher",
+      "subtitle": null,
+      "excerpt": "A practical role profile for teacher.",
+      "hero_kicker": null,
+      "hero_quote": null,
+      "cover_image_url": null,
+      "industry_slug": "education",
+      "industry_label": null,
+      "body_md": "# Teacher\n\nTeach, mentor, and guide learning outcomes.\n",
+      "body_html": null,
+      "salary_json": {
+        "raw": "$40,000 - $95,000"
+      },
+      "outlook_json": {
+        "summary": "Demand remains steady."
+      },
+      "skills_json": {
+        "core": [
+          "Communication",
+          "Lesson planning"
+        ],
+        "supporting": []
+      },
+      "work_contents_json": {
+        "items": [
+          "Prepare lessons.",
+          "Support students."
+        ]
+      },
+      "growth_path_json": {
+        "raw": [
+          "Build classroom fundamentals.",
+          "Advance into senior teaching roles."
+        ]
+      },
+      "fit_personality_codes_json": null,
+      "mbti_primary_codes_json": [
+        "ENFJ",
+        "ESFJ"
+      ],
+      "mbti_secondary_codes_json": [
+        "INFJ",
+        "ISFJ"
+      ],
+      "riasec_profile_json": {
+        "R": 20,
+        "I": 44,
+        "A": 38,
+        "S": 92,
+        "E": 54,
+        "C": 46
+      },
+      "big5_targets_json": {
+        "raw": {
+          "agreeableness": {
+            "min": 55,
+            "max": 95
+          }
+        }
+      },
+      "iq_eq_notes_json": {
+        "iq_range": {
+          "min": 40,
+          "max": 85
+        },
+        "eq_range": {
+          "min": 60,
+          "max": 100
+        }
+      },
+      "market_demand_json": {
+        "raw": 68
+      },
+      "status": "published",
+      "is_public": true,
+      "is_indexable": true,
+      "published_at": null,
+      "scheduled_at": null,
+      "sort_order": 20,
+      "sections": [],
+      "seo_meta": {
+        "seo_title": "Teacher Career Guide | FermatMind",
+        "seo_description": "Responsibilities, salary, growth path, and personality fit for Teachers.",
+        "canonical_url": null,
+        "og_title": null,
+        "og_description": null,
+        "og_image_url": null,
+        "twitter_title": null,
+        "twitter_description": null,
+        "twitter_image_url": null,
+        "robots": null,
+        "jsonld_overrides_json": null
+      }
+    }
+  ]
+}

--- a/backend/tests/Fixtures/career_job_baseline/career_jobs.zh-CN.json
+++ b/backend/tests/Fixtures/career_job_baseline/career_jobs.zh-CN.json
@@ -1,0 +1,230 @@
+{
+  "meta": {
+    "schema_version": "v1",
+    "locale": "zh-CN",
+    "source": "test fixture",
+    "generated_at": "2026-03-09T00:00:00Z"
+  },
+  "jobs": [
+    {
+      "job_code": "product-manager",
+      "slug": "product-manager",
+      "locale": "zh-CN",
+      "title": "产品经理",
+      "subtitle": null,
+      "excerpt": "面向产品经理的实用岗位画像。",
+      "hero_kicker": null,
+      "hero_quote": null,
+      "cover_image_url": null,
+      "industry_slug": "business",
+      "industry_label": null,
+      "body_md": "# 产品经理\n\n面向产品方向的职业画像。\n",
+      "body_html": null,
+      "salary_json": {
+        "raw": "人民币 18万 - 90万/年"
+      },
+      "outlook_json": {
+        "summary": "产品经理需求保持较高水平。"
+      },
+      "skills_json": {
+        "core": [
+          "结构化问题解决",
+          "跨角色沟通"
+        ],
+        "supporting": []
+      },
+      "work_contents_json": {
+        "items": [
+          "明确优先级。",
+          "推进跨团队协作。"
+        ]
+      },
+      "growth_path_json": {
+        "raw": [
+          "0-2 年：建立执行能力。",
+          "3-5 年：独立负责中等复杂度项目。"
+        ]
+      },
+      "fit_personality_codes_json": null,
+      "mbti_primary_codes_json": [
+        "ENTJ",
+        "ENFJ",
+        "ESTP"
+      ],
+      "mbti_secondary_codes_json": [
+        "ENFP",
+        "ESTJ",
+        "ENTP"
+      ],
+      "riasec_profile_json": {
+        "R": 42,
+        "I": 66,
+        "A": 56,
+        "S": 60,
+        "E": 88,
+        "C": 70
+      },
+      "big5_targets_json": {
+        "raw": {
+          "openness": {
+            "min": 40,
+            "max": 80
+          },
+          "conscientiousness": {
+            "min": 50,
+            "max": 90
+          }
+        }
+      },
+      "iq_eq_notes_json": {
+        "iq_range": {
+          "min": 50,
+          "max": 98
+        },
+        "eq_range": {
+          "min": 55,
+          "max": 100
+        }
+      },
+      "market_demand_json": {
+        "raw": 82
+      },
+      "status": "published",
+      "is_public": true,
+      "is_indexable": true,
+      "published_at": null,
+      "scheduled_at": null,
+      "sort_order": 5,
+      "sections": [
+        {
+          "section_key": "faq",
+          "title": "常见问题",
+          "render_variant": "faq",
+          "body_md": null,
+          "body_html": null,
+          "payload_json": {
+            "items": [
+              {
+                "question": "产品经理做什么？",
+                "answer": "把产品方向与业务目标对齐。"
+              }
+            ]
+          },
+          "sort_order": 80,
+          "is_enabled": true
+        }
+      ],
+      "seo_meta": {
+        "seo_title": "产品经理职业指南 | FermatMind",
+        "seo_description": "了解产品经理的职责、薪资、成长路径与人格适配。",
+        "canonical_url": null,
+        "og_title": null,
+        "og_description": null,
+        "og_image_url": null,
+        "twitter_title": null,
+        "twitter_description": null,
+        "twitter_image_url": null,
+        "robots": null,
+        "jsonld_overrides_json": null
+      }
+    },
+    {
+      "job_code": "teacher",
+      "slug": "teacher",
+      "locale": "zh-CN",
+      "title": "教师",
+      "subtitle": null,
+      "excerpt": "面向教师的实用岗位画像。",
+      "hero_kicker": null,
+      "hero_quote": null,
+      "cover_image_url": null,
+      "industry_slug": "education",
+      "industry_label": null,
+      "body_md": "# 教师\n\n围绕教学、陪伴与学习成果展开的职业画像。\n",
+      "body_html": null,
+      "salary_json": {
+        "raw": "人民币 10万 - 35万/年"
+      },
+      "outlook_json": {
+        "summary": "需求整体稳定。"
+      },
+      "skills_json": {
+        "core": [
+          "沟通",
+          "课程设计"
+        ],
+        "supporting": []
+      },
+      "work_contents_json": {
+        "items": [
+          "准备课程。",
+          "支持学生成长。"
+        ]
+      },
+      "growth_path_json": {
+        "raw": [
+          "打好课堂基础。",
+          "发展到资深教学岗位。"
+        ]
+      },
+      "fit_personality_codes_json": null,
+      "mbti_primary_codes_json": [
+        "ENFJ",
+        "ESFJ"
+      ],
+      "mbti_secondary_codes_json": [
+        "INFJ",
+        "ISFJ"
+      ],
+      "riasec_profile_json": {
+        "R": 20,
+        "I": 44,
+        "A": 38,
+        "S": 92,
+        "E": 54,
+        "C": 46
+      },
+      "big5_targets_json": {
+        "raw": {
+          "agreeableness": {
+            "min": 55,
+            "max": 95
+          }
+        }
+      },
+      "iq_eq_notes_json": {
+        "iq_range": {
+          "min": 40,
+          "max": 85
+        },
+        "eq_range": {
+          "min": 60,
+          "max": 100
+        }
+      },
+      "market_demand_json": {
+        "raw": 68
+      },
+      "status": "published",
+      "is_public": true,
+      "is_indexable": true,
+      "published_at": null,
+      "scheduled_at": null,
+      "sort_order": 20,
+      "sections": [],
+      "seo_meta": {
+        "seo_title": "教师职业指南 | FermatMind",
+        "seo_description": "了解教师的职责、薪资、成长路径与人格适配。",
+        "canonical_url": null,
+        "og_title": null,
+        "og_description": null,
+        "og_image_url": null,
+        "twitter_title": null,
+        "twitter_description": null,
+        "twitter_image_url": null,
+        "robots": null,
+        "jsonld_overrides_json": null
+      }
+    }
+  ]
+}

--- a/backend/tests/Unit/Jobs/GenerateReportSnapshotJobTest.php
+++ b/backend/tests/Unit/Jobs/GenerateReportSnapshotJobTest.php
@@ -1,0 +1,90 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Jobs;
+
+use App\Jobs\GenerateReportSnapshotJob;
+use Tests\TestCase;
+
+final class GenerateReportSnapshotJobTest extends TestCase
+{
+    private string|false $originalReportConnectionEnv;
+
+    private string|false $originalReportQueueEnv;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->originalReportConnectionEnv = getenv('FAP_REPORT_QUEUE_CONNECTION');
+        $this->originalReportQueueEnv = getenv('FAP_REPORT_QUEUE');
+    }
+
+    protected function tearDown(): void
+    {
+        $this->restoreEnv('FAP_REPORT_QUEUE_CONNECTION', $this->originalReportConnectionEnv);
+        $this->restoreEnv('FAP_REPORT_QUEUE', $this->originalReportQueueEnv);
+        $this->reloadReportQueueConfig();
+
+        parent::tearDown();
+    }
+
+    public function test_generate_report_snapshot_job_uses_default_report_queue_binding(): void
+    {
+        $this->setEnv('FAP_REPORT_QUEUE_CONNECTION', null);
+        $this->setEnv('FAP_REPORT_QUEUE', null);
+        $this->reloadReportQueueConfig();
+
+        $job = new GenerateReportSnapshotJob(0, 'attempt-default', 'submit', null);
+
+        $this->assertSame('database_reports', $job->connection);
+        $this->assertSame('reports', $job->queue);
+    }
+
+    public function test_generate_report_snapshot_job_uses_env_overridden_report_queue_binding(): void
+    {
+        $this->setEnv('FAP_REPORT_QUEUE_CONNECTION', 'redis');
+        $this->setEnv('FAP_REPORT_QUEUE', 'default');
+        $this->reloadReportQueueConfig();
+
+        $job = new GenerateReportSnapshotJob(0, 'attempt-redis', 'submit', null);
+
+        $this->assertSame('redis', $job->connection);
+        $this->assertSame('default', $job->queue);
+    }
+
+    private function reloadReportQueueConfig(): void
+    {
+        /** @var array{queue:array{report_connection:string|null,report_queue:string}} $config */
+        $config = require config_path('fap.php');
+
+        config()->set('fap.queue.report_connection', $config['queue']['report_connection']);
+        config()->set('fap.queue.report_queue', $config['queue']['report_queue']);
+    }
+
+    private function setEnv(string $key, ?string $value): void
+    {
+        if ($value === null) {
+            putenv($key);
+            unset($_ENV[$key], $_SERVER[$key]);
+
+            return;
+        }
+
+        putenv("{$key}={$value}");
+        $_ENV[$key] = $value;
+        $_SERVER[$key] = $value;
+    }
+
+    private function restoreEnv(string $key, string|false $value): void
+    {
+        if ($value === false) {
+            $this->setEnv($key, null);
+
+            return;
+        }
+
+        $this->setEnv($key, $value);
+    }
+}

--- a/content_baselines/career_jobs/career_jobs.en.json
+++ b/content_baselines/career_jobs/career_jobs.en.json
@@ -1,0 +1,3760 @@
+{
+  "meta": {
+    "schema_version": "v1",
+    "locale": "en",
+    "source": "fap-web career jobs baseline",
+    "generated_at": "2026-03-09T00:00:00Z"
+  },
+  "jobs": [
+    {
+      "job_code": "backend-engineer",
+      "slug": "backend-engineer",
+      "locale": "en",
+      "title": "Backend Engineer",
+      "subtitle": null,
+      "excerpt": "A practical role profile for backend engineer including responsibilities, required skills, salary, and growth path.",
+      "hero_kicker": null,
+      "hero_quote": null,
+      "cover_image_url": null,
+      "industry_slug": "technology",
+      "industry_label": null,
+      "body_md": "# Backend Engineer\n## Role Overview\nBackend Engineer is a role where performance compounds through execution quality, communication precision, and long-term learning velocity.\n\n## Core Work Scope\nThis role contributes to business outcomes by translating goals into high-quality deliverables, collaborating across functions, and continuously improving process quality.\n\n## Career Development Advice\nUse 90-day cycles to track output metrics, capability growth, and collaboration impact. Review your progress every quarter and adjust your growth plan based on evidence.\n",
+      "body_html": null,
+      "salary_json": {
+        "raw": "$55,000 - $180,000 (varies by region and seniority)"
+      },
+      "outlook_json": {
+        "summary": "Demand for backend engineer talent remains strong in data-driven organizations."
+      },
+      "skills_json": {
+        "core": [
+          "Structured problem solving",
+          "Stakeholder communication",
+          "Execution management",
+          "Data-informed decision making",
+          "Continuous learning"
+        ],
+        "supporting": [
+
+        ]
+      },
+      "work_contents_json": {
+        "items": [
+          "Define key responsibilities and delivery metrics for backend engineer workstreams.",
+          "Coordinate cross-functional stakeholders and align execution priorities.",
+          "Track progress, risks, and quality signals to ensure stable outcomes."
+        ]
+      },
+      "growth_path_json": {
+        "raw": [
+          "0-2 years: build core execution competency and domain literacy.",
+          "3-5 years: own medium-complexity projects and cross-team collaboration.",
+          "5+ years: move toward specialist leadership or managerial scope."
+        ]
+      },
+      "fit_personality_codes_json": null,
+      "mbti_primary_codes_json": [
+        "INTJ",
+        "INTP",
+        "ENTJ"
+      ],
+      "mbti_secondary_codes_json": [
+        "ENTP",
+        "ISTJ",
+        "INFJ"
+      ],
+      "riasec_profile_json": {
+        "R": 55,
+        "I": 88,
+        "A": 48,
+        "S": 42,
+        "E": 50,
+        "C": 68
+      },
+      "big5_targets_json": {
+        "raw": {
+          "openness": {
+            "min": 40,
+            "max": 80
+          },
+          "conscientiousness": {
+            "min": 50,
+            "max": 90
+          },
+          "extraversion": {
+            "min": 35,
+            "max": 82
+          },
+          "agreeableness": {
+            "min": 35,
+            "max": 85
+          },
+          "neuroticism": {
+            "min": 10,
+            "max": 55
+          }
+        }
+      },
+      "iq_eq_notes_json": {
+        "iq_range": {
+          "min": 65,
+          "max": 100
+        },
+        "eq_range": {
+          "min": 45,
+          "max": 90
+        }
+      },
+      "market_demand_json": {
+        "raw": 92
+      },
+      "status": "published",
+      "is_public": true,
+      "is_indexable": true,
+      "published_at": null,
+      "scheduled_at": null,
+      "sort_order": 0,
+      "sections": [
+
+      ],
+      "seo_meta": {
+        "seo_title": null,
+        "seo_description": null,
+        "canonical_url": null,
+        "og_title": null,
+        "og_description": null,
+        "og_image_url": null,
+        "twitter_title": null,
+        "twitter_description": null,
+        "twitter_image_url": null,
+        "robots": null,
+        "jsonld_overrides_json": null
+      }
+    },
+    {
+      "job_code": "brand-manager",
+      "slug": "brand-manager",
+      "locale": "en",
+      "title": "Brand Manager",
+      "subtitle": null,
+      "excerpt": "A practical role profile for brand manager including responsibilities, required skills, salary, and growth path.",
+      "hero_kicker": null,
+      "hero_quote": null,
+      "cover_image_url": null,
+      "industry_slug": "design",
+      "industry_label": null,
+      "body_md": "# Brand Manager\n## Role Overview\nBrand Manager is a role where performance compounds through execution quality, communication precision, and long-term learning velocity.\n\n## Core Work Scope\nThis role contributes to business outcomes by translating goals into high-quality deliverables, collaborating across functions, and continuously improving process quality.\n\n## Career Development Advice\nUse 90-day cycles to track output metrics, capability growth, and collaboration impact. Review your progress every quarter and adjust your growth plan based on evidence.\n",
+      "body_html": null,
+      "salary_json": {
+        "raw": "$55,000 - $180,000 (varies by region and seniority)"
+      },
+      "outlook_json": {
+        "summary": "Demand for brand manager talent remains strong in data-driven organizations."
+      },
+      "skills_json": {
+        "core": [
+          "Structured problem solving",
+          "Stakeholder communication",
+          "Execution management",
+          "Data-informed decision making",
+          "Continuous learning"
+        ],
+        "supporting": [
+
+        ]
+      },
+      "work_contents_json": {
+        "items": [
+          "Define key responsibilities and delivery metrics for brand manager workstreams.",
+          "Coordinate cross-functional stakeholders and align execution priorities.",
+          "Track progress, risks, and quality signals to ensure stable outcomes."
+        ]
+      },
+      "growth_path_json": {
+        "raw": [
+          "0-2 years: build core execution competency and domain literacy.",
+          "3-5 years: own medium-complexity projects and cross-team collaboration.",
+          "5+ years: move toward specialist leadership or managerial scope."
+        ]
+      },
+      "fit_personality_codes_json": null,
+      "mbti_primary_codes_json": [
+        "INFP",
+        "ENFP",
+        "ISFP"
+      ],
+      "mbti_secondary_codes_json": [
+        "INFJ",
+        "ENTP",
+        "ESFP"
+      ],
+      "riasec_profile_json": {
+        "R": 38,
+        "I": 62,
+        "A": 90,
+        "S": 54,
+        "E": 60,
+        "C": 44
+      },
+      "big5_targets_json": {
+        "raw": {
+          "openness": {
+            "min": 40,
+            "max": 80
+          },
+          "conscientiousness": {
+            "min": 50,
+            "max": 90
+          },
+          "extraversion": {
+            "min": 35,
+            "max": 82
+          },
+          "agreeableness": {
+            "min": 35,
+            "max": 85
+          },
+          "neuroticism": {
+            "min": 10,
+            "max": 55
+          }
+        }
+      },
+      "iq_eq_notes_json": {
+        "iq_range": {
+          "min": 45,
+          "max": 95
+        },
+        "eq_range": {
+          "min": 52,
+          "max": 96
+        }
+      },
+      "market_demand_json": {
+        "raw": 78
+      },
+      "status": "published",
+      "is_public": true,
+      "is_indexable": true,
+      "published_at": null,
+      "scheduled_at": null,
+      "sort_order": 0,
+      "sections": [
+
+      ],
+      "seo_meta": {
+        "seo_title": null,
+        "seo_description": null,
+        "canonical_url": null,
+        "og_title": null,
+        "og_description": null,
+        "og_image_url": null,
+        "twitter_title": null,
+        "twitter_description": null,
+        "twitter_image_url": null,
+        "robots": null,
+        "jsonld_overrides_json": null
+      }
+    },
+    {
+      "job_code": "business-analyst",
+      "slug": "business-analyst",
+      "locale": "en",
+      "title": "Business Analyst",
+      "subtitle": null,
+      "excerpt": "A practical role profile for business analyst including responsibilities, required skills, salary, and growth path.",
+      "hero_kicker": null,
+      "hero_quote": null,
+      "cover_image_url": null,
+      "industry_slug": "consulting",
+      "industry_label": null,
+      "body_md": "# Business Analyst\n## Role Overview\nBusiness Analyst is a role where performance compounds through execution quality, communication precision, and long-term learning velocity.\n\n## Core Work Scope\nThis role contributes to business outcomes by translating goals into high-quality deliverables, collaborating across functions, and continuously improving process quality.\n\n## Career Development Advice\nUse 90-day cycles to track output metrics, capability growth, and collaboration impact. Review your progress every quarter and adjust your growth plan based on evidence.\n",
+      "body_html": null,
+      "salary_json": {
+        "raw": "$55,000 - $180,000 (varies by region and seniority)"
+      },
+      "outlook_json": {
+        "summary": "Demand for business analyst talent remains strong in data-driven organizations."
+      },
+      "skills_json": {
+        "core": [
+          "Structured problem solving",
+          "Stakeholder communication",
+          "Execution management",
+          "Data-informed decision making",
+          "Continuous learning"
+        ],
+        "supporting": [
+
+        ]
+      },
+      "work_contents_json": {
+        "items": [
+          "Define key responsibilities and delivery metrics for business analyst workstreams.",
+          "Coordinate cross-functional stakeholders and align execution priorities.",
+          "Track progress, risks, and quality signals to ensure stable outcomes."
+        ]
+      },
+      "growth_path_json": {
+        "raw": [
+          "0-2 years: build core execution competency and domain literacy.",
+          "3-5 years: own medium-complexity projects and cross-team collaboration.",
+          "5+ years: move toward specialist leadership or managerial scope."
+        ]
+      },
+      "fit_personality_codes_json": null,
+      "mbti_primary_codes_json": [
+        "INTJ",
+        "INTP",
+        "ENTJ"
+      ],
+      "mbti_secondary_codes_json": [
+        "ENTP",
+        "ISTJ",
+        "INFJ"
+      ],
+      "riasec_profile_json": {
+        "R": 40,
+        "I": 90,
+        "A": 45,
+        "S": 38,
+        "E": 46,
+        "C": 72
+      },
+      "big5_targets_json": {
+        "raw": {
+          "openness": {
+            "min": 40,
+            "max": 80
+          },
+          "conscientiousness": {
+            "min": 50,
+            "max": 90
+          },
+          "extraversion": {
+            "min": 35,
+            "max": 82
+          },
+          "agreeableness": {
+            "min": 35,
+            "max": 85
+          },
+          "neuroticism": {
+            "min": 10,
+            "max": 55
+          }
+        }
+      },
+      "iq_eq_notes_json": {
+        "iq_range": {
+          "min": 62,
+          "max": 100
+        },
+        "eq_range": {
+          "min": 40,
+          "max": 86
+        }
+      },
+      "market_demand_json": {
+        "raw": 85
+      },
+      "status": "published",
+      "is_public": true,
+      "is_indexable": true,
+      "published_at": null,
+      "scheduled_at": null,
+      "sort_order": 0,
+      "sections": [
+
+      ],
+      "seo_meta": {
+        "seo_title": null,
+        "seo_description": null,
+        "canonical_url": null,
+        "og_title": null,
+        "og_description": null,
+        "og_image_url": null,
+        "twitter_title": null,
+        "twitter_description": null,
+        "twitter_image_url": null,
+        "robots": null,
+        "jsonld_overrides_json": null
+      }
+    },
+    {
+      "job_code": "cloud-architect",
+      "slug": "cloud-architect",
+      "locale": "en",
+      "title": "Cloud Architect",
+      "subtitle": null,
+      "excerpt": "A practical role profile for cloud architect including responsibilities, required skills, salary, and growth path.",
+      "hero_kicker": null,
+      "hero_quote": null,
+      "cover_image_url": null,
+      "industry_slug": "technology",
+      "industry_label": null,
+      "body_md": "# Cloud Architect\n## Role Overview\nCloud Architect is a role where performance compounds through execution quality, communication precision, and long-term learning velocity.\n\n## Core Work Scope\nThis role contributes to business outcomes by translating goals into high-quality deliverables, collaborating across functions, and continuously improving process quality.\n\n## Career Development Advice\nUse 90-day cycles to track output metrics, capability growth, and collaboration impact. Review your progress every quarter and adjust your growth plan based on evidence.\n",
+      "body_html": null,
+      "salary_json": {
+        "raw": "$55,000 - $180,000 (varies by region and seniority)"
+      },
+      "outlook_json": {
+        "summary": "Demand for cloud architect talent remains strong in data-driven organizations."
+      },
+      "skills_json": {
+        "core": [
+          "Structured problem solving",
+          "Stakeholder communication",
+          "Execution management",
+          "Data-informed decision making",
+          "Continuous learning"
+        ],
+        "supporting": [
+
+        ]
+      },
+      "work_contents_json": {
+        "items": [
+          "Define key responsibilities and delivery metrics for cloud architect workstreams.",
+          "Coordinate cross-functional stakeholders and align execution priorities.",
+          "Track progress, risks, and quality signals to ensure stable outcomes."
+        ]
+      },
+      "growth_path_json": {
+        "raw": [
+          "0-2 years: build core execution competency and domain literacy.",
+          "3-5 years: own medium-complexity projects and cross-team collaboration.",
+          "5+ years: move toward specialist leadership or managerial scope."
+        ]
+      },
+      "fit_personality_codes_json": null,
+      "mbti_primary_codes_json": [
+        "INTJ",
+        "INTP",
+        "ENTJ"
+      ],
+      "mbti_secondary_codes_json": [
+        "ENTP",
+        "ISTJ",
+        "INFJ"
+      ],
+      "riasec_profile_json": {
+        "R": 55,
+        "I": 88,
+        "A": 48,
+        "S": 42,
+        "E": 50,
+        "C": 68
+      },
+      "big5_targets_json": {
+        "raw": {
+          "openness": {
+            "min": 40,
+            "max": 80
+          },
+          "conscientiousness": {
+            "min": 50,
+            "max": 90
+          },
+          "extraversion": {
+            "min": 35,
+            "max": 82
+          },
+          "agreeableness": {
+            "min": 35,
+            "max": 85
+          },
+          "neuroticism": {
+            "min": 10,
+            "max": 55
+          }
+        }
+      },
+      "iq_eq_notes_json": {
+        "iq_range": {
+          "min": 65,
+          "max": 100
+        },
+        "eq_range": {
+          "min": 45,
+          "max": 90
+        }
+      },
+      "market_demand_json": {
+        "raw": 92
+      },
+      "status": "published",
+      "is_public": true,
+      "is_indexable": true,
+      "published_at": null,
+      "scheduled_at": null,
+      "sort_order": 0,
+      "sections": [
+
+      ],
+      "seo_meta": {
+        "seo_title": null,
+        "seo_description": null,
+        "canonical_url": null,
+        "og_title": null,
+        "og_description": null,
+        "og_image_url": null,
+        "twitter_title": null,
+        "twitter_description": null,
+        "twitter_image_url": null,
+        "robots": null,
+        "jsonld_overrides_json": null
+      }
+    },
+    {
+      "job_code": "content-strategist",
+      "slug": "content-strategist",
+      "locale": "en",
+      "title": "Content Strategist",
+      "subtitle": null,
+      "excerpt": "A practical role profile for content strategist including responsibilities, required skills, salary, and growth path.",
+      "hero_kicker": null,
+      "hero_quote": null,
+      "cover_image_url": null,
+      "industry_slug": "media",
+      "industry_label": null,
+      "body_md": "# Content Strategist\n## Role Overview\nContent Strategist is a role where performance compounds through execution quality, communication precision, and long-term learning velocity.\n\n## Core Work Scope\nThis role contributes to business outcomes by translating goals into high-quality deliverables, collaborating across functions, and continuously improving process quality.\n\n## Career Development Advice\nUse 90-day cycles to track output metrics, capability growth, and collaboration impact. Review your progress every quarter and adjust your growth plan based on evidence.\n",
+      "body_html": null,
+      "salary_json": {
+        "raw": "$55,000 - $180,000 (varies by region and seniority)"
+      },
+      "outlook_json": {
+        "summary": "Demand for content strategist talent remains strong in data-driven organizations."
+      },
+      "skills_json": {
+        "core": [
+          "Structured problem solving",
+          "Stakeholder communication",
+          "Execution management",
+          "Data-informed decision making",
+          "Continuous learning"
+        ],
+        "supporting": [
+
+        ]
+      },
+      "work_contents_json": {
+        "items": [
+          "Define key responsibilities and delivery metrics for content strategist workstreams.",
+          "Coordinate cross-functional stakeholders and align execution priorities.",
+          "Track progress, risks, and quality signals to ensure stable outcomes."
+        ]
+      },
+      "growth_path_json": {
+        "raw": [
+          "0-2 years: build core execution competency and domain literacy.",
+          "3-5 years: own medium-complexity projects and cross-team collaboration.",
+          "5+ years: move toward specialist leadership or managerial scope."
+        ]
+      },
+      "fit_personality_codes_json": null,
+      "mbti_primary_codes_json": [
+        "INFP",
+        "ENFP",
+        "ISFP"
+      ],
+      "mbti_secondary_codes_json": [
+        "INFJ",
+        "ENTP",
+        "ESFP"
+      ],
+      "riasec_profile_json": {
+        "R": 38,
+        "I": 62,
+        "A": 90,
+        "S": 54,
+        "E": 60,
+        "C": 44
+      },
+      "big5_targets_json": {
+        "raw": {
+          "openness": {
+            "min": 40,
+            "max": 80
+          },
+          "conscientiousness": {
+            "min": 50,
+            "max": 90
+          },
+          "extraversion": {
+            "min": 35,
+            "max": 82
+          },
+          "agreeableness": {
+            "min": 35,
+            "max": 85
+          },
+          "neuroticism": {
+            "min": 10,
+            "max": 55
+          }
+        }
+      },
+      "iq_eq_notes_json": {
+        "iq_range": {
+          "min": 45,
+          "max": 95
+        },
+        "eq_range": {
+          "min": 52,
+          "max": 96
+        }
+      },
+      "market_demand_json": {
+        "raw": 78
+      },
+      "status": "published",
+      "is_public": true,
+      "is_indexable": true,
+      "published_at": null,
+      "scheduled_at": null,
+      "sort_order": 0,
+      "sections": [
+
+      ],
+      "seo_meta": {
+        "seo_title": null,
+        "seo_description": null,
+        "canonical_url": null,
+        "og_title": null,
+        "og_description": null,
+        "og_image_url": null,
+        "twitter_title": null,
+        "twitter_description": null,
+        "twitter_image_url": null,
+        "robots": null,
+        "jsonld_overrides_json": null
+      }
+    },
+    {
+      "job_code": "cybersecurity-analyst",
+      "slug": "cybersecurity-analyst",
+      "locale": "en",
+      "title": "Cybersecurity Analyst",
+      "subtitle": null,
+      "excerpt": "A practical role profile for cybersecurity analyst including responsibilities, required skills, salary, and growth path.",
+      "hero_kicker": null,
+      "hero_quote": null,
+      "cover_image_url": null,
+      "industry_slug": "technology",
+      "industry_label": null,
+      "body_md": "# Cybersecurity Analyst\n## Role Overview\nCybersecurity Analyst is a role where performance compounds through execution quality, communication precision, and long-term learning velocity.\n\n## Core Work Scope\nThis role contributes to business outcomes by translating goals into high-quality deliverables, collaborating across functions, and continuously improving process quality.\n\n## Career Development Advice\nUse 90-day cycles to track output metrics, capability growth, and collaboration impact. Review your progress every quarter and adjust your growth plan based on evidence.\n",
+      "body_html": null,
+      "salary_json": {
+        "raw": "$55,000 - $180,000 (varies by region and seniority)"
+      },
+      "outlook_json": {
+        "summary": "Demand for cybersecurity analyst talent remains strong in data-driven organizations."
+      },
+      "skills_json": {
+        "core": [
+          "Structured problem solving",
+          "Stakeholder communication",
+          "Execution management",
+          "Data-informed decision making",
+          "Continuous learning"
+        ],
+        "supporting": [
+
+        ]
+      },
+      "work_contents_json": {
+        "items": [
+          "Define key responsibilities and delivery metrics for cybersecurity analyst workstreams.",
+          "Coordinate cross-functional stakeholders and align execution priorities.",
+          "Track progress, risks, and quality signals to ensure stable outcomes."
+        ]
+      },
+      "growth_path_json": {
+        "raw": [
+          "0-2 years: build core execution competency and domain literacy.",
+          "3-5 years: own medium-complexity projects and cross-team collaboration.",
+          "5+ years: move toward specialist leadership or managerial scope."
+        ]
+      },
+      "fit_personality_codes_json": null,
+      "mbti_primary_codes_json": [
+        "INTJ",
+        "INTP",
+        "ENTJ"
+      ],
+      "mbti_secondary_codes_json": [
+        "ENTP",
+        "ISTJ",
+        "INFJ"
+      ],
+      "riasec_profile_json": {
+        "R": 55,
+        "I": 88,
+        "A": 48,
+        "S": 42,
+        "E": 50,
+        "C": 68
+      },
+      "big5_targets_json": {
+        "raw": {
+          "openness": {
+            "min": 40,
+            "max": 80
+          },
+          "conscientiousness": {
+            "min": 50,
+            "max": 90
+          },
+          "extraversion": {
+            "min": 35,
+            "max": 82
+          },
+          "agreeableness": {
+            "min": 35,
+            "max": 85
+          },
+          "neuroticism": {
+            "min": 10,
+            "max": 55
+          }
+        }
+      },
+      "iq_eq_notes_json": {
+        "iq_range": {
+          "min": 65,
+          "max": 100
+        },
+        "eq_range": {
+          "min": 45,
+          "max": 90
+        }
+      },
+      "market_demand_json": {
+        "raw": 92
+      },
+      "status": "published",
+      "is_public": true,
+      "is_indexable": true,
+      "published_at": null,
+      "scheduled_at": null,
+      "sort_order": 0,
+      "sections": [
+
+      ],
+      "seo_meta": {
+        "seo_title": null,
+        "seo_description": null,
+        "canonical_url": null,
+        "og_title": null,
+        "og_description": null,
+        "og_image_url": null,
+        "twitter_title": null,
+        "twitter_description": null,
+        "twitter_image_url": null,
+        "robots": null,
+        "jsonld_overrides_json": null
+      }
+    },
+    {
+      "job_code": "data-analyst",
+      "slug": "data-analyst",
+      "locale": "en",
+      "title": "Data Analyst",
+      "subtitle": null,
+      "excerpt": "A practical role profile for data analyst including responsibilities, required skills, salary, and growth path.",
+      "hero_kicker": null,
+      "hero_quote": null,
+      "cover_image_url": null,
+      "industry_slug": "technology",
+      "industry_label": null,
+      "body_md": "# Data Analyst\n## Role Overview\nData Analyst is a role where performance compounds through execution quality, communication precision, and long-term learning velocity.\n\n## Core Work Scope\nThis role contributes to business outcomes by translating goals into high-quality deliverables, collaborating across functions, and continuously improving process quality.\n\n## Career Development Advice\nUse 90-day cycles to track output metrics, capability growth, and collaboration impact. Review your progress every quarter and adjust your growth plan based on evidence.\n",
+      "body_html": null,
+      "salary_json": {
+        "raw": "$55,000 - $180,000 (varies by region and seniority)"
+      },
+      "outlook_json": {
+        "summary": "Demand for data analyst talent remains strong in data-driven organizations."
+      },
+      "skills_json": {
+        "core": [
+          "Structured problem solving",
+          "Stakeholder communication",
+          "Execution management",
+          "Data-informed decision making",
+          "Continuous learning"
+        ],
+        "supporting": [
+
+        ]
+      },
+      "work_contents_json": {
+        "items": [
+          "Define key responsibilities and delivery metrics for data analyst workstreams.",
+          "Coordinate cross-functional stakeholders and align execution priorities.",
+          "Track progress, risks, and quality signals to ensure stable outcomes."
+        ]
+      },
+      "growth_path_json": {
+        "raw": [
+          "0-2 years: build core execution competency and domain literacy.",
+          "3-5 years: own medium-complexity projects and cross-team collaboration.",
+          "5+ years: move toward specialist leadership or managerial scope."
+        ]
+      },
+      "fit_personality_codes_json": null,
+      "mbti_primary_codes_json": [
+        "INTJ",
+        "INTP",
+        "ENTJ"
+      ],
+      "mbti_secondary_codes_json": [
+        "ENTP",
+        "ISTJ",
+        "INFJ"
+      ],
+      "riasec_profile_json": {
+        "R": 40,
+        "I": 90,
+        "A": 45,
+        "S": 38,
+        "E": 46,
+        "C": 72
+      },
+      "big5_targets_json": {
+        "raw": {
+          "openness": {
+            "min": 40,
+            "max": 80
+          },
+          "conscientiousness": {
+            "min": 50,
+            "max": 90
+          },
+          "extraversion": {
+            "min": 35,
+            "max": 82
+          },
+          "agreeableness": {
+            "min": 35,
+            "max": 85
+          },
+          "neuroticism": {
+            "min": 10,
+            "max": 55
+          }
+        }
+      },
+      "iq_eq_notes_json": {
+        "iq_range": {
+          "min": 62,
+          "max": 100
+        },
+        "eq_range": {
+          "min": 40,
+          "max": 86
+        }
+      },
+      "market_demand_json": {
+        "raw": 85
+      },
+      "status": "published",
+      "is_public": true,
+      "is_indexable": true,
+      "published_at": null,
+      "scheduled_at": null,
+      "sort_order": 0,
+      "sections": [
+
+      ],
+      "seo_meta": {
+        "seo_title": null,
+        "seo_description": null,
+        "canonical_url": null,
+        "og_title": null,
+        "og_description": null,
+        "og_image_url": null,
+        "twitter_title": null,
+        "twitter_description": null,
+        "twitter_image_url": null,
+        "robots": null,
+        "jsonld_overrides_json": null
+      }
+    },
+    {
+      "job_code": "data-scientist",
+      "slug": "data-scientist",
+      "locale": "en",
+      "title": "Data Scientist",
+      "subtitle": null,
+      "excerpt": "A practical role profile for data scientist including responsibilities, required skills, salary, and growth path.",
+      "hero_kicker": null,
+      "hero_quote": null,
+      "cover_image_url": null,
+      "industry_slug": "technology",
+      "industry_label": null,
+      "body_md": "# Data Scientist\n## Role Overview\nData Scientist is a role where performance compounds through execution quality, communication precision, and long-term learning velocity.\n\n## Core Work Scope\nThis role contributes to business outcomes by translating goals into high-quality deliverables, collaborating across functions, and continuously improving process quality.\n\n## Career Development Advice\nUse 90-day cycles to track output metrics, capability growth, and collaboration impact. Review your progress every quarter and adjust your growth plan based on evidence.\n",
+      "body_html": null,
+      "salary_json": {
+        "raw": "$55,000 - $180,000 (varies by region and seniority)"
+      },
+      "outlook_json": {
+        "summary": "Demand for data scientist talent remains strong in data-driven organizations."
+      },
+      "skills_json": {
+        "core": [
+          "Structured problem solving",
+          "Stakeholder communication",
+          "Execution management",
+          "Data-informed decision making",
+          "Continuous learning"
+        ],
+        "supporting": [
+
+        ]
+      },
+      "work_contents_json": {
+        "items": [
+          "Define key responsibilities and delivery metrics for data scientist workstreams.",
+          "Coordinate cross-functional stakeholders and align execution priorities.",
+          "Track progress, risks, and quality signals to ensure stable outcomes."
+        ]
+      },
+      "growth_path_json": {
+        "raw": [
+          "0-2 years: build core execution competency and domain literacy.",
+          "3-5 years: own medium-complexity projects and cross-team collaboration.",
+          "5+ years: move toward specialist leadership or managerial scope."
+        ]
+      },
+      "fit_personality_codes_json": null,
+      "mbti_primary_codes_json": [
+        "INTJ",
+        "INTP",
+        "ENTJ"
+      ],
+      "mbti_secondary_codes_json": [
+        "ENTP",
+        "ISTJ",
+        "INFJ"
+      ],
+      "riasec_profile_json": {
+        "R": 40,
+        "I": 90,
+        "A": 45,
+        "S": 38,
+        "E": 46,
+        "C": 72
+      },
+      "big5_targets_json": {
+        "raw": {
+          "openness": {
+            "min": 40,
+            "max": 80
+          },
+          "conscientiousness": {
+            "min": 50,
+            "max": 90
+          },
+          "extraversion": {
+            "min": 35,
+            "max": 82
+          },
+          "agreeableness": {
+            "min": 35,
+            "max": 85
+          },
+          "neuroticism": {
+            "min": 10,
+            "max": 55
+          }
+        }
+      },
+      "iq_eq_notes_json": {
+        "iq_range": {
+          "min": 62,
+          "max": 100
+        },
+        "eq_range": {
+          "min": 40,
+          "max": 86
+        }
+      },
+      "market_demand_json": {
+        "raw": 85
+      },
+      "status": "published",
+      "is_public": true,
+      "is_indexable": true,
+      "published_at": null,
+      "scheduled_at": null,
+      "sort_order": 0,
+      "sections": [
+
+      ],
+      "seo_meta": {
+        "seo_title": null,
+        "seo_description": null,
+        "canonical_url": null,
+        "og_title": null,
+        "og_description": null,
+        "og_image_url": null,
+        "twitter_title": null,
+        "twitter_description": null,
+        "twitter_image_url": null,
+        "robots": null,
+        "jsonld_overrides_json": null
+      }
+    },
+    {
+      "job_code": "digital-marketing-manager",
+      "slug": "digital-marketing-manager",
+      "locale": "en",
+      "title": "Digital Marketing Manager",
+      "subtitle": null,
+      "excerpt": "A practical role profile for digital marketing manager including responsibilities, required skills, salary, and growth path.",
+      "hero_kicker": null,
+      "hero_quote": null,
+      "cover_image_url": null,
+      "industry_slug": "media",
+      "industry_label": null,
+      "body_md": "# Digital Marketing Manager\n## Role Overview\nDigital Marketing Manager is a role where performance compounds through execution quality, communication precision, and long-term learning velocity.\n\n## Core Work Scope\nThis role contributes to business outcomes by translating goals into high-quality deliverables, collaborating across functions, and continuously improving process quality.\n\n## Career Development Advice\nUse 90-day cycles to track output metrics, capability growth, and collaboration impact. Review your progress every quarter and adjust your growth plan based on evidence.\n",
+      "body_html": null,
+      "salary_json": {
+        "raw": "$55,000 - $180,000 (varies by region and seniority)"
+      },
+      "outlook_json": {
+        "summary": "Demand for digital marketing manager talent remains strong in data-driven organizations."
+      },
+      "skills_json": {
+        "core": [
+          "Structured problem solving",
+          "Stakeholder communication",
+          "Execution management",
+          "Data-informed decision making",
+          "Continuous learning"
+        ],
+        "supporting": [
+
+        ]
+      },
+      "work_contents_json": {
+        "items": [
+          "Define key responsibilities and delivery metrics for digital marketing manager workstreams.",
+          "Coordinate cross-functional stakeholders and align execution priorities.",
+          "Track progress, risks, and quality signals to ensure stable outcomes."
+        ]
+      },
+      "growth_path_json": {
+        "raw": [
+          "0-2 years: build core execution competency and domain literacy.",
+          "3-5 years: own medium-complexity projects and cross-team collaboration.",
+          "5+ years: move toward specialist leadership or managerial scope."
+        ]
+      },
+      "fit_personality_codes_json": null,
+      "mbti_primary_codes_json": [
+        "ENTJ",
+        "ENFJ",
+        "ESTP"
+      ],
+      "mbti_secondary_codes_json": [
+        "ENFP",
+        "ESTJ",
+        "ENTP"
+      ],
+      "riasec_profile_json": {
+        "R": 42,
+        "I": 66,
+        "A": 56,
+        "S": 60,
+        "E": 88,
+        "C": 70
+      },
+      "big5_targets_json": {
+        "raw": {
+          "openness": {
+            "min": 40,
+            "max": 80
+          },
+          "conscientiousness": {
+            "min": 50,
+            "max": 90
+          },
+          "extraversion": {
+            "min": 35,
+            "max": 82
+          },
+          "agreeableness": {
+            "min": 35,
+            "max": 85
+          },
+          "neuroticism": {
+            "min": 10,
+            "max": 55
+          }
+        }
+      },
+      "iq_eq_notes_json": {
+        "iq_range": {
+          "min": 50,
+          "max": 98
+        },
+        "eq_range": {
+          "min": 55,
+          "max": 100
+        }
+      },
+      "market_demand_json": {
+        "raw": 82
+      },
+      "status": "published",
+      "is_public": true,
+      "is_indexable": true,
+      "published_at": null,
+      "scheduled_at": null,
+      "sort_order": 0,
+      "sections": [
+
+      ],
+      "seo_meta": {
+        "seo_title": null,
+        "seo_description": null,
+        "canonical_url": null,
+        "og_title": null,
+        "og_description": null,
+        "og_image_url": null,
+        "twitter_title": null,
+        "twitter_description": null,
+        "twitter_image_url": null,
+        "robots": null,
+        "jsonld_overrides_json": null
+      }
+    },
+    {
+      "job_code": "financial-planner",
+      "slug": "financial-planner",
+      "locale": "en",
+      "title": "Financial Planner",
+      "subtitle": null,
+      "excerpt": "A practical role profile for financial planner including responsibilities, required skills, salary, and growth path.",
+      "hero_kicker": null,
+      "hero_quote": null,
+      "cover_image_url": null,
+      "industry_slug": "finance",
+      "industry_label": null,
+      "body_md": "# Financial Planner\n## Role Overview\nFinancial Planner is a role where performance compounds through execution quality, communication precision, and long-term learning velocity.\n\n## Core Work Scope\nThis role contributes to business outcomes by translating goals into high-quality deliverables, collaborating across functions, and continuously improving process quality.\n\n## Career Development Advice\nUse 90-day cycles to track output metrics, capability growth, and collaboration impact. Review your progress every quarter and adjust your growth plan based on evidence.\n",
+      "body_html": null,
+      "salary_json": {
+        "raw": "$55,000 - $180,000 (varies by region and seniority)"
+      },
+      "outlook_json": {
+        "summary": "Demand for financial planner talent remains strong in data-driven organizations."
+      },
+      "skills_json": {
+        "core": [
+          "Structured problem solving",
+          "Stakeholder communication",
+          "Execution management",
+          "Data-informed decision making",
+          "Continuous learning"
+        ],
+        "supporting": [
+
+        ]
+      },
+      "work_contents_json": {
+        "items": [
+          "Define key responsibilities and delivery metrics for financial planner workstreams.",
+          "Coordinate cross-functional stakeholders and align execution priorities.",
+          "Track progress, risks, and quality signals to ensure stable outcomes."
+        ]
+      },
+      "growth_path_json": {
+        "raw": [
+          "0-2 years: build core execution competency and domain literacy.",
+          "3-5 years: own medium-complexity projects and cross-team collaboration.",
+          "5+ years: move toward specialist leadership or managerial scope."
+        ]
+      },
+      "fit_personality_codes_json": null,
+      "mbti_primary_codes_json": [
+        "ESTJ",
+        "ISTJ",
+        "ESFJ"
+      ],
+      "mbti_secondary_codes_json": [
+        "ISFJ",
+        "ENTJ",
+        "ESTP"
+      ],
+      "riasec_profile_json": {
+        "R": 52,
+        "I": 60,
+        "A": 36,
+        "S": 52,
+        "E": 70,
+        "C": 90
+      },
+      "big5_targets_json": {
+        "raw": {
+          "openness": {
+            "min": 40,
+            "max": 80
+          },
+          "conscientiousness": {
+            "min": 50,
+            "max": 90
+          },
+          "extraversion": {
+            "min": 35,
+            "max": 82
+          },
+          "agreeableness": {
+            "min": 35,
+            "max": 85
+          },
+          "neuroticism": {
+            "min": 10,
+            "max": 55
+          }
+        }
+      },
+      "iq_eq_notes_json": {
+        "iq_range": {
+          "min": 48,
+          "max": 95
+        },
+        "eq_range": {
+          "min": 48,
+          "max": 92
+        }
+      },
+      "market_demand_json": {
+        "raw": 74
+      },
+      "status": "published",
+      "is_public": true,
+      "is_indexable": true,
+      "published_at": null,
+      "scheduled_at": null,
+      "sort_order": 0,
+      "sections": [
+
+      ],
+      "seo_meta": {
+        "seo_title": null,
+        "seo_description": null,
+        "canonical_url": null,
+        "og_title": null,
+        "og_description": null,
+        "og_image_url": null,
+        "twitter_title": null,
+        "twitter_description": null,
+        "twitter_image_url": null,
+        "robots": null,
+        "jsonld_overrides_json": null
+      }
+    },
+    {
+      "job_code": "frontend-engineer",
+      "slug": "frontend-engineer",
+      "locale": "en",
+      "title": "Frontend Engineer",
+      "subtitle": null,
+      "excerpt": "A practical role profile for frontend engineer including responsibilities, required skills, salary, and growth path.",
+      "hero_kicker": null,
+      "hero_quote": null,
+      "cover_image_url": null,
+      "industry_slug": "technology",
+      "industry_label": null,
+      "body_md": "# Frontend Engineer\n## Role Overview\nFrontend Engineer is a role where performance compounds through execution quality, communication precision, and long-term learning velocity.\n\n## Core Work Scope\nThis role contributes to business outcomes by translating goals into high-quality deliverables, collaborating across functions, and continuously improving process quality.\n\n## Career Development Advice\nUse 90-day cycles to track output metrics, capability growth, and collaboration impact. Review your progress every quarter and adjust your growth plan based on evidence.\n",
+      "body_html": null,
+      "salary_json": {
+        "raw": "$55,000 - $180,000 (varies by region and seniority)"
+      },
+      "outlook_json": {
+        "summary": "Demand for frontend engineer talent remains strong in data-driven organizations."
+      },
+      "skills_json": {
+        "core": [
+          "Structured problem solving",
+          "Stakeholder communication",
+          "Execution management",
+          "Data-informed decision making",
+          "Continuous learning"
+        ],
+        "supporting": [
+
+        ]
+      },
+      "work_contents_json": {
+        "items": [
+          "Define key responsibilities and delivery metrics for frontend engineer workstreams.",
+          "Coordinate cross-functional stakeholders and align execution priorities.",
+          "Track progress, risks, and quality signals to ensure stable outcomes."
+        ]
+      },
+      "growth_path_json": {
+        "raw": [
+          "0-2 years: build core execution competency and domain literacy.",
+          "3-5 years: own medium-complexity projects and cross-team collaboration.",
+          "5+ years: move toward specialist leadership or managerial scope."
+        ]
+      },
+      "fit_personality_codes_json": null,
+      "mbti_primary_codes_json": [
+        "INTJ",
+        "INTP",
+        "ENTJ"
+      ],
+      "mbti_secondary_codes_json": [
+        "ENTP",
+        "ISTJ",
+        "INFJ"
+      ],
+      "riasec_profile_json": {
+        "R": 55,
+        "I": 88,
+        "A": 48,
+        "S": 42,
+        "E": 50,
+        "C": 68
+      },
+      "big5_targets_json": {
+        "raw": {
+          "openness": {
+            "min": 40,
+            "max": 80
+          },
+          "conscientiousness": {
+            "min": 50,
+            "max": 90
+          },
+          "extraversion": {
+            "min": 35,
+            "max": 82
+          },
+          "agreeableness": {
+            "min": 35,
+            "max": 85
+          },
+          "neuroticism": {
+            "min": 10,
+            "max": 55
+          }
+        }
+      },
+      "iq_eq_notes_json": {
+        "iq_range": {
+          "min": 65,
+          "max": 100
+        },
+        "eq_range": {
+          "min": 45,
+          "max": 90
+        }
+      },
+      "market_demand_json": {
+        "raw": 92
+      },
+      "status": "published",
+      "is_public": true,
+      "is_indexable": true,
+      "published_at": null,
+      "scheduled_at": null,
+      "sort_order": 0,
+      "sections": [
+
+      ],
+      "seo_meta": {
+        "seo_title": null,
+        "seo_description": null,
+        "canonical_url": null,
+        "og_title": null,
+        "og_description": null,
+        "og_image_url": null,
+        "twitter_title": null,
+        "twitter_description": null,
+        "twitter_image_url": null,
+        "robots": null,
+        "jsonld_overrides_json": null
+      }
+    },
+    {
+      "job_code": "fullstack-engineer",
+      "slug": "fullstack-engineer",
+      "locale": "en",
+      "title": "Fullstack Engineer",
+      "subtitle": null,
+      "excerpt": "A practical role profile for fullstack engineer including responsibilities, required skills, salary, and growth path.",
+      "hero_kicker": null,
+      "hero_quote": null,
+      "cover_image_url": null,
+      "industry_slug": "technology",
+      "industry_label": null,
+      "body_md": "# Fullstack Engineer\n## Role Overview\nFullstack Engineer is a role where performance compounds through execution quality, communication precision, and long-term learning velocity.\n\n## Core Work Scope\nThis role contributes to business outcomes by translating goals into high-quality deliverables, collaborating across functions, and continuously improving process quality.\n\n## Career Development Advice\nUse 90-day cycles to track output metrics, capability growth, and collaboration impact. Review your progress every quarter and adjust your growth plan based on evidence.\n",
+      "body_html": null,
+      "salary_json": {
+        "raw": "$55,000 - $180,000 (varies by region and seniority)"
+      },
+      "outlook_json": {
+        "summary": "Demand for fullstack engineer talent remains strong in data-driven organizations."
+      },
+      "skills_json": {
+        "core": [
+          "Structured problem solving",
+          "Stakeholder communication",
+          "Execution management",
+          "Data-informed decision making",
+          "Continuous learning"
+        ],
+        "supporting": [
+
+        ]
+      },
+      "work_contents_json": {
+        "items": [
+          "Define key responsibilities and delivery metrics for fullstack engineer workstreams.",
+          "Coordinate cross-functional stakeholders and align execution priorities.",
+          "Track progress, risks, and quality signals to ensure stable outcomes."
+        ]
+      },
+      "growth_path_json": {
+        "raw": [
+          "0-2 years: build core execution competency and domain literacy.",
+          "3-5 years: own medium-complexity projects and cross-team collaboration.",
+          "5+ years: move toward specialist leadership or managerial scope."
+        ]
+      },
+      "fit_personality_codes_json": null,
+      "mbti_primary_codes_json": [
+        "INTJ",
+        "INTP",
+        "ENTJ"
+      ],
+      "mbti_secondary_codes_json": [
+        "ENTP",
+        "ISTJ",
+        "INFJ"
+      ],
+      "riasec_profile_json": {
+        "R": 55,
+        "I": 88,
+        "A": 48,
+        "S": 42,
+        "E": 50,
+        "C": 68
+      },
+      "big5_targets_json": {
+        "raw": {
+          "openness": {
+            "min": 40,
+            "max": 80
+          },
+          "conscientiousness": {
+            "min": 50,
+            "max": 90
+          },
+          "extraversion": {
+            "min": 35,
+            "max": 82
+          },
+          "agreeableness": {
+            "min": 35,
+            "max": 85
+          },
+          "neuroticism": {
+            "min": 10,
+            "max": 55
+          }
+        }
+      },
+      "iq_eq_notes_json": {
+        "iq_range": {
+          "min": 65,
+          "max": 100
+        },
+        "eq_range": {
+          "min": 45,
+          "max": 90
+        }
+      },
+      "market_demand_json": {
+        "raw": 92
+      },
+      "status": "published",
+      "is_public": true,
+      "is_indexable": true,
+      "published_at": null,
+      "scheduled_at": null,
+      "sort_order": 0,
+      "sections": [
+
+      ],
+      "seo_meta": {
+        "seo_title": null,
+        "seo_description": null,
+        "canonical_url": null,
+        "og_title": null,
+        "og_description": null,
+        "og_image_url": null,
+        "twitter_title": null,
+        "twitter_description": null,
+        "twitter_image_url": null,
+        "robots": null,
+        "jsonld_overrides_json": null
+      }
+    },
+    {
+      "job_code": "hr-business-partner",
+      "slug": "hr-business-partner",
+      "locale": "en",
+      "title": "HR Business Partner",
+      "subtitle": null,
+      "excerpt": "A practical role profile for hr business partner including responsibilities, required skills, salary, and growth path.",
+      "hero_kicker": null,
+      "hero_quote": null,
+      "cover_image_url": null,
+      "industry_slug": "business",
+      "industry_label": null,
+      "body_md": "# HR Business Partner\n## Role Overview\nHR Business Partner is a role where performance compounds through execution quality, communication precision, and long-term learning velocity.\n\n## Core Work Scope\nThis role contributes to business outcomes by translating goals into high-quality deliverables, collaborating across functions, and continuously improving process quality.\n\n## Career Development Advice\nUse 90-day cycles to track output metrics, capability growth, and collaboration impact. Review your progress every quarter and adjust your growth plan based on evidence.\n",
+      "body_html": null,
+      "salary_json": {
+        "raw": "$55,000 - $180,000 (varies by region and seniority)"
+      },
+      "outlook_json": {
+        "summary": "Demand for hr business partner talent remains strong in data-driven organizations."
+      },
+      "skills_json": {
+        "core": [
+          "Structured problem solving",
+          "Stakeholder communication",
+          "Execution management",
+          "Data-informed decision making",
+          "Continuous learning"
+        ],
+        "supporting": [
+
+        ]
+      },
+      "work_contents_json": {
+        "items": [
+          "Define key responsibilities and delivery metrics for hr business partner workstreams.",
+          "Coordinate cross-functional stakeholders and align execution priorities.",
+          "Track progress, risks, and quality signals to ensure stable outcomes."
+        ]
+      },
+      "growth_path_json": {
+        "raw": [
+          "0-2 years: build core execution competency and domain literacy.",
+          "3-5 years: own medium-complexity projects and cross-team collaboration.",
+          "5+ years: move toward specialist leadership or managerial scope."
+        ]
+      },
+      "fit_personality_codes_json": null,
+      "mbti_primary_codes_json": [
+        "ENTJ",
+        "ENFJ",
+        "ESTP"
+      ],
+      "mbti_secondary_codes_json": [
+        "ENFP",
+        "ESTJ",
+        "ENTP"
+      ],
+      "riasec_profile_json": {
+        "R": 42,
+        "I": 66,
+        "A": 56,
+        "S": 60,
+        "E": 88,
+        "C": 70
+      },
+      "big5_targets_json": {
+        "raw": {
+          "openness": {
+            "min": 40,
+            "max": 80
+          },
+          "conscientiousness": {
+            "min": 50,
+            "max": 90
+          },
+          "extraversion": {
+            "min": 35,
+            "max": 82
+          },
+          "agreeableness": {
+            "min": 35,
+            "max": 85
+          },
+          "neuroticism": {
+            "min": 10,
+            "max": 55
+          }
+        }
+      },
+      "iq_eq_notes_json": {
+        "iq_range": {
+          "min": 50,
+          "max": 98
+        },
+        "eq_range": {
+          "min": 55,
+          "max": 100
+        }
+      },
+      "market_demand_json": {
+        "raw": 82
+      },
+      "status": "published",
+      "is_public": true,
+      "is_indexable": true,
+      "published_at": null,
+      "scheduled_at": null,
+      "sort_order": 0,
+      "sections": [
+
+      ],
+      "seo_meta": {
+        "seo_title": null,
+        "seo_description": null,
+        "canonical_url": null,
+        "og_title": null,
+        "og_description": null,
+        "og_image_url": null,
+        "twitter_title": null,
+        "twitter_description": null,
+        "twitter_image_url": null,
+        "robots": null,
+        "jsonld_overrides_json": null
+      }
+    },
+    {
+      "job_code": "investment-analyst",
+      "slug": "investment-analyst",
+      "locale": "en",
+      "title": "Investment Analyst",
+      "subtitle": null,
+      "excerpt": "A practical role profile for investment analyst including responsibilities, required skills, salary, and growth path.",
+      "hero_kicker": null,
+      "hero_quote": null,
+      "cover_image_url": null,
+      "industry_slug": "finance",
+      "industry_label": null,
+      "body_md": "# Investment Analyst\n## Role Overview\nInvestment Analyst is a role where performance compounds through execution quality, communication precision, and long-term learning velocity.\n\n## Core Work Scope\nThis role contributes to business outcomes by translating goals into high-quality deliverables, collaborating across functions, and continuously improving process quality.\n\n## Career Development Advice\nUse 90-day cycles to track output metrics, capability growth, and collaboration impact. Review your progress every quarter and adjust your growth plan based on evidence.\n",
+      "body_html": null,
+      "salary_json": {
+        "raw": "$55,000 - $180,000 (varies by region and seniority)"
+      },
+      "outlook_json": {
+        "summary": "Demand for investment analyst talent remains strong in data-driven organizations."
+      },
+      "skills_json": {
+        "core": [
+          "Structured problem solving",
+          "Stakeholder communication",
+          "Execution management",
+          "Data-informed decision making",
+          "Continuous learning"
+        ],
+        "supporting": [
+
+        ]
+      },
+      "work_contents_json": {
+        "items": [
+          "Define key responsibilities and delivery metrics for investment analyst workstreams.",
+          "Coordinate cross-functional stakeholders and align execution priorities.",
+          "Track progress, risks, and quality signals to ensure stable outcomes."
+        ]
+      },
+      "growth_path_json": {
+        "raw": [
+          "0-2 years: build core execution competency and domain literacy.",
+          "3-5 years: own medium-complexity projects and cross-team collaboration.",
+          "5+ years: move toward specialist leadership or managerial scope."
+        ]
+      },
+      "fit_personality_codes_json": null,
+      "mbti_primary_codes_json": [
+        "INTJ",
+        "INTP",
+        "ENTJ"
+      ],
+      "mbti_secondary_codes_json": [
+        "ENTP",
+        "ISTJ",
+        "INFJ"
+      ],
+      "riasec_profile_json": {
+        "R": 40,
+        "I": 90,
+        "A": 45,
+        "S": 38,
+        "E": 46,
+        "C": 72
+      },
+      "big5_targets_json": {
+        "raw": {
+          "openness": {
+            "min": 40,
+            "max": 80
+          },
+          "conscientiousness": {
+            "min": 50,
+            "max": 90
+          },
+          "extraversion": {
+            "min": 35,
+            "max": 82
+          },
+          "agreeableness": {
+            "min": 35,
+            "max": 85
+          },
+          "neuroticism": {
+            "min": 10,
+            "max": 55
+          }
+        }
+      },
+      "iq_eq_notes_json": {
+        "iq_range": {
+          "min": 62,
+          "max": 100
+        },
+        "eq_range": {
+          "min": 40,
+          "max": 86
+        }
+      },
+      "market_demand_json": {
+        "raw": 85
+      },
+      "status": "published",
+      "is_public": true,
+      "is_indexable": true,
+      "published_at": null,
+      "scheduled_at": null,
+      "sort_order": 0,
+      "sections": [
+
+      ],
+      "seo_meta": {
+        "seo_title": null,
+        "seo_description": null,
+        "canonical_url": null,
+        "og_title": null,
+        "og_description": null,
+        "og_image_url": null,
+        "twitter_title": null,
+        "twitter_description": null,
+        "twitter_image_url": null,
+        "robots": null,
+        "jsonld_overrides_json": null
+      }
+    },
+    {
+      "job_code": "lawyer",
+      "slug": "lawyer",
+      "locale": "en",
+      "title": "Lawyer",
+      "subtitle": null,
+      "excerpt": "A practical role profile for lawyer including responsibilities, required skills, salary, and growth path.",
+      "hero_kicker": null,
+      "hero_quote": null,
+      "cover_image_url": null,
+      "industry_slug": "legal",
+      "industry_label": null,
+      "body_md": "# Lawyer\n## Role Overview\nLawyer is a role where performance compounds through execution quality, communication precision, and long-term learning velocity.\n\n## Core Work Scope\nThis role contributes to business outcomes by translating goals into high-quality deliverables, collaborating across functions, and continuously improving process quality.\n\n## Career Development Advice\nUse 90-day cycles to track output metrics, capability growth, and collaboration impact. Review your progress every quarter and adjust your growth plan based on evidence.\n",
+      "body_html": null,
+      "salary_json": {
+        "raw": "$55,000 - $180,000 (varies by region and seniority)"
+      },
+      "outlook_json": {
+        "summary": "Demand for lawyer talent remains strong in data-driven organizations."
+      },
+      "skills_json": {
+        "core": [
+          "Structured problem solving",
+          "Stakeholder communication",
+          "Execution management",
+          "Data-informed decision making",
+          "Continuous learning"
+        ],
+        "supporting": [
+
+        ]
+      },
+      "work_contents_json": {
+        "items": [
+          "Define key responsibilities and delivery metrics for lawyer workstreams.",
+          "Coordinate cross-functional stakeholders and align execution priorities.",
+          "Track progress, risks, and quality signals to ensure stable outcomes."
+        ]
+      },
+      "growth_path_json": {
+        "raw": [
+          "0-2 years: build core execution competency and domain literacy.",
+          "3-5 years: own medium-complexity projects and cross-team collaboration.",
+          "5+ years: move toward specialist leadership or managerial scope."
+        ]
+      },
+      "fit_personality_codes_json": null,
+      "mbti_primary_codes_json": [
+        "ESTJ",
+        "ISTJ",
+        "ESFJ"
+      ],
+      "mbti_secondary_codes_json": [
+        "ISFJ",
+        "ENTJ",
+        "ESTP"
+      ],
+      "riasec_profile_json": {
+        "R": 33,
+        "I": 80,
+        "A": 40,
+        "S": 47,
+        "E": 52,
+        "C": 90
+      },
+      "big5_targets_json": {
+        "raw": {
+          "openness": {
+            "min": 40,
+            "max": 80
+          },
+          "conscientiousness": {
+            "min": 50,
+            "max": 90
+          },
+          "extraversion": {
+            "min": 35,
+            "max": 82
+          },
+          "agreeableness": {
+            "min": 35,
+            "max": 85
+          },
+          "neuroticism": {
+            "min": 10,
+            "max": 55
+          }
+        }
+      },
+      "iq_eq_notes_json": {
+        "iq_range": {
+          "min": 62,
+          "max": 100
+        },
+        "eq_range": {
+          "min": 52,
+          "max": 95
+        }
+      },
+      "market_demand_json": {
+        "raw": 70
+      },
+      "status": "published",
+      "is_public": true,
+      "is_indexable": true,
+      "published_at": null,
+      "scheduled_at": null,
+      "sort_order": 0,
+      "sections": [
+
+      ],
+      "seo_meta": {
+        "seo_title": null,
+        "seo_description": null,
+        "canonical_url": null,
+        "og_title": null,
+        "og_description": null,
+        "og_image_url": null,
+        "twitter_title": null,
+        "twitter_description": null,
+        "twitter_image_url": null,
+        "robots": null,
+        "jsonld_overrides_json": null
+      }
+    },
+    {
+      "job_code": "machine-learning-engineer",
+      "slug": "machine-learning-engineer",
+      "locale": "en",
+      "title": "Machine Learning Engineer",
+      "subtitle": null,
+      "excerpt": "A practical role profile for machine learning engineer including responsibilities, required skills, salary, and growth path.",
+      "hero_kicker": null,
+      "hero_quote": null,
+      "cover_image_url": null,
+      "industry_slug": "technology",
+      "industry_label": null,
+      "body_md": "# Machine Learning Engineer\n## Role Overview\nMachine Learning Engineer is a role where performance compounds through execution quality, communication precision, and long-term learning velocity.\n\n## Core Work Scope\nThis role contributes to business outcomes by translating goals into high-quality deliverables, collaborating across functions, and continuously improving process quality.\n\n## Career Development Advice\nUse 90-day cycles to track output metrics, capability growth, and collaboration impact. Review your progress every quarter and adjust your growth plan based on evidence.\n",
+      "body_html": null,
+      "salary_json": {
+        "raw": "$55,000 - $180,000 (varies by region and seniority)"
+      },
+      "outlook_json": {
+        "summary": "Demand for machine learning engineer talent remains strong in data-driven organizations."
+      },
+      "skills_json": {
+        "core": [
+          "Structured problem solving",
+          "Stakeholder communication",
+          "Execution management",
+          "Data-informed decision making",
+          "Continuous learning"
+        ],
+        "supporting": [
+
+        ]
+      },
+      "work_contents_json": {
+        "items": [
+          "Define key responsibilities and delivery metrics for machine learning engineer workstreams.",
+          "Coordinate cross-functional stakeholders and align execution priorities.",
+          "Track progress, risks, and quality signals to ensure stable outcomes."
+        ]
+      },
+      "growth_path_json": {
+        "raw": [
+          "0-2 years: build core execution competency and domain literacy.",
+          "3-5 years: own medium-complexity projects and cross-team collaboration.",
+          "5+ years: move toward specialist leadership or managerial scope."
+        ]
+      },
+      "fit_personality_codes_json": null,
+      "mbti_primary_codes_json": [
+        "INTJ",
+        "INTP",
+        "ENTJ"
+      ],
+      "mbti_secondary_codes_json": [
+        "ENTP",
+        "ISTJ",
+        "INFJ"
+      ],
+      "riasec_profile_json": {
+        "R": 55,
+        "I": 88,
+        "A": 48,
+        "S": 42,
+        "E": 50,
+        "C": 68
+      },
+      "big5_targets_json": {
+        "raw": {
+          "openness": {
+            "min": 40,
+            "max": 80
+          },
+          "conscientiousness": {
+            "min": 50,
+            "max": 90
+          },
+          "extraversion": {
+            "min": 35,
+            "max": 82
+          },
+          "agreeableness": {
+            "min": 35,
+            "max": 85
+          },
+          "neuroticism": {
+            "min": 10,
+            "max": 55
+          }
+        }
+      },
+      "iq_eq_notes_json": {
+        "iq_range": {
+          "min": 65,
+          "max": 100
+        },
+        "eq_range": {
+          "min": 45,
+          "max": 90
+        }
+      },
+      "market_demand_json": {
+        "raw": 92
+      },
+      "status": "published",
+      "is_public": true,
+      "is_indexable": true,
+      "published_at": null,
+      "scheduled_at": null,
+      "sort_order": 0,
+      "sections": [
+
+      ],
+      "seo_meta": {
+        "seo_title": null,
+        "seo_description": null,
+        "canonical_url": null,
+        "og_title": null,
+        "og_description": null,
+        "og_image_url": null,
+        "twitter_title": null,
+        "twitter_description": null,
+        "twitter_image_url": null,
+        "robots": null,
+        "jsonld_overrides_json": null
+      }
+    },
+    {
+      "job_code": "management-consultant",
+      "slug": "management-consultant",
+      "locale": "en",
+      "title": "Management Consultant",
+      "subtitle": null,
+      "excerpt": "A practical role profile for management consultant including responsibilities, required skills, salary, and growth path.",
+      "hero_kicker": null,
+      "hero_quote": null,
+      "cover_image_url": null,
+      "industry_slug": "consulting",
+      "industry_label": null,
+      "body_md": "# Management Consultant\n## Role Overview\nManagement Consultant is a role where performance compounds through execution quality, communication precision, and long-term learning velocity.\n\n## Core Work Scope\nThis role contributes to business outcomes by translating goals into high-quality deliverables, collaborating across functions, and continuously improving process quality.\n\n## Career Development Advice\nUse 90-day cycles to track output metrics, capability growth, and collaboration impact. Review your progress every quarter and adjust your growth plan based on evidence.\n",
+      "body_html": null,
+      "salary_json": {
+        "raw": "$55,000 - $180,000 (varies by region and seniority)"
+      },
+      "outlook_json": {
+        "summary": "Demand for management consultant talent remains strong in data-driven organizations."
+      },
+      "skills_json": {
+        "core": [
+          "Structured problem solving",
+          "Stakeholder communication",
+          "Execution management",
+          "Data-informed decision making",
+          "Continuous learning"
+        ],
+        "supporting": [
+
+        ]
+      },
+      "work_contents_json": {
+        "items": [
+          "Define key responsibilities and delivery metrics for management consultant workstreams.",
+          "Coordinate cross-functional stakeholders and align execution priorities.",
+          "Track progress, risks, and quality signals to ensure stable outcomes."
+        ]
+      },
+      "growth_path_json": {
+        "raw": [
+          "0-2 years: build core execution competency and domain literacy.",
+          "3-5 years: own medium-complexity projects and cross-team collaboration.",
+          "5+ years: move toward specialist leadership or managerial scope."
+        ]
+      },
+      "fit_personality_codes_json": null,
+      "mbti_primary_codes_json": [
+        "ENTJ",
+        "ENFJ",
+        "ESTP"
+      ],
+      "mbti_secondary_codes_json": [
+        "ENFP",
+        "ESTJ",
+        "ENTP"
+      ],
+      "riasec_profile_json": {
+        "R": 42,
+        "I": 66,
+        "A": 56,
+        "S": 60,
+        "E": 88,
+        "C": 70
+      },
+      "big5_targets_json": {
+        "raw": {
+          "openness": {
+            "min": 40,
+            "max": 80
+          },
+          "conscientiousness": {
+            "min": 50,
+            "max": 90
+          },
+          "extraversion": {
+            "min": 35,
+            "max": 82
+          },
+          "agreeableness": {
+            "min": 35,
+            "max": 85
+          },
+          "neuroticism": {
+            "min": 10,
+            "max": 55
+          }
+        }
+      },
+      "iq_eq_notes_json": {
+        "iq_range": {
+          "min": 50,
+          "max": 98
+        },
+        "eq_range": {
+          "min": 55,
+          "max": 100
+        }
+      },
+      "market_demand_json": {
+        "raw": 82
+      },
+      "status": "published",
+      "is_public": true,
+      "is_indexable": true,
+      "published_at": null,
+      "scheduled_at": null,
+      "sort_order": 0,
+      "sections": [
+
+      ],
+      "seo_meta": {
+        "seo_title": null,
+        "seo_description": null,
+        "canonical_url": null,
+        "og_title": null,
+        "og_description": null,
+        "og_image_url": null,
+        "twitter_title": null,
+        "twitter_description": null,
+        "twitter_image_url": null,
+        "robots": null,
+        "jsonld_overrides_json": null
+      }
+    },
+    {
+      "job_code": "nurse",
+      "slug": "nurse",
+      "locale": "en",
+      "title": "Nurse",
+      "subtitle": null,
+      "excerpt": "A practical role profile for nurse including responsibilities, required skills, salary, and growth path.",
+      "hero_kicker": null,
+      "hero_quote": null,
+      "cover_image_url": null,
+      "industry_slug": "healthcare",
+      "industry_label": null,
+      "body_md": "# Nurse\n## Role Overview\nNurse is a role where performance compounds through execution quality, communication precision, and long-term learning velocity.\n\n## Core Work Scope\nThis role contributes to business outcomes by translating goals into high-quality deliverables, collaborating across functions, and continuously improving process quality.\n\n## Career Development Advice\nUse 90-day cycles to track output metrics, capability growth, and collaboration impact. Review your progress every quarter and adjust your growth plan based on evidence.\n",
+      "body_html": null,
+      "salary_json": {
+        "raw": "$55,000 - $180,000 (varies by region and seniority)"
+      },
+      "outlook_json": {
+        "summary": "Demand for nurse talent remains strong in data-driven organizations."
+      },
+      "skills_json": {
+        "core": [
+          "Structured problem solving",
+          "Stakeholder communication",
+          "Execution management",
+          "Data-informed decision making",
+          "Continuous learning"
+        ],
+        "supporting": [
+
+        ]
+      },
+      "work_contents_json": {
+        "items": [
+          "Define key responsibilities and delivery metrics for nurse workstreams.",
+          "Coordinate cross-functional stakeholders and align execution priorities.",
+          "Track progress, risks, and quality signals to ensure stable outcomes."
+        ]
+      },
+      "growth_path_json": {
+        "raw": [
+          "0-2 years: build core execution competency and domain literacy.",
+          "3-5 years: own medium-complexity projects and cross-team collaboration.",
+          "5+ years: move toward specialist leadership or managerial scope."
+        ]
+      },
+      "fit_personality_codes_json": null,
+      "mbti_primary_codes_json": [
+        "ENFJ",
+        "ISFJ",
+        "INFJ"
+      ],
+      "mbti_secondary_codes_json": [
+        "ESFJ",
+        "INFP",
+        "ENFP"
+      ],
+      "riasec_profile_json": {
+        "R": 48,
+        "I": 64,
+        "A": 42,
+        "S": 88,
+        "E": 54,
+        "C": 74
+      },
+      "big5_targets_json": {
+        "raw": {
+          "openness": {
+            "min": 40,
+            "max": 80
+          },
+          "conscientiousness": {
+            "min": 50,
+            "max": 90
+          },
+          "extraversion": {
+            "min": 35,
+            "max": 82
+          },
+          "agreeableness": {
+            "min": 35,
+            "max": 85
+          },
+          "neuroticism": {
+            "min": 10,
+            "max": 55
+          }
+        }
+      },
+      "iq_eq_notes_json": {
+        "iq_range": {
+          "min": 50,
+          "max": 100
+        },
+        "eq_range": {
+          "min": 60,
+          "max": 100
+        }
+      },
+      "market_demand_json": {
+        "raw": 86
+      },
+      "status": "published",
+      "is_public": true,
+      "is_indexable": true,
+      "published_at": null,
+      "scheduled_at": null,
+      "sort_order": 0,
+      "sections": [
+
+      ],
+      "seo_meta": {
+        "seo_title": null,
+        "seo_description": null,
+        "canonical_url": null,
+        "og_title": null,
+        "og_description": null,
+        "og_image_url": null,
+        "twitter_title": null,
+        "twitter_description": null,
+        "twitter_image_url": null,
+        "robots": null,
+        "jsonld_overrides_json": null
+      }
+    },
+    {
+      "job_code": "operations-manager",
+      "slug": "operations-manager",
+      "locale": "en",
+      "title": "Operations Manager",
+      "subtitle": null,
+      "excerpt": "A practical role profile for operations manager including responsibilities, required skills, salary, and growth path.",
+      "hero_kicker": null,
+      "hero_quote": null,
+      "cover_image_url": null,
+      "industry_slug": "operations",
+      "industry_label": null,
+      "body_md": "# Operations Manager\n## Role Overview\nOperations Manager is a role where performance compounds through execution quality, communication precision, and long-term learning velocity.\n\n## Core Work Scope\nThis role contributes to business outcomes by translating goals into high-quality deliverables, collaborating across functions, and continuously improving process quality.\n\n## Career Development Advice\nUse 90-day cycles to track output metrics, capability growth, and collaboration impact. Review your progress every quarter and adjust your growth plan based on evidence.\n",
+      "body_html": null,
+      "salary_json": {
+        "raw": "$55,000 - $180,000 (varies by region and seniority)"
+      },
+      "outlook_json": {
+        "summary": "Demand for operations manager talent remains strong in data-driven organizations."
+      },
+      "skills_json": {
+        "core": [
+          "Structured problem solving",
+          "Stakeholder communication",
+          "Execution management",
+          "Data-informed decision making",
+          "Continuous learning"
+        ],
+        "supporting": [
+
+        ]
+      },
+      "work_contents_json": {
+        "items": [
+          "Define key responsibilities and delivery metrics for operations manager workstreams.",
+          "Coordinate cross-functional stakeholders and align execution priorities.",
+          "Track progress, risks, and quality signals to ensure stable outcomes."
+        ]
+      },
+      "growth_path_json": {
+        "raw": [
+          "0-2 years: build core execution competency and domain literacy.",
+          "3-5 years: own medium-complexity projects and cross-team collaboration.",
+          "5+ years: move toward specialist leadership or managerial scope."
+        ]
+      },
+      "fit_personality_codes_json": null,
+      "mbti_primary_codes_json": [
+        "ENTJ",
+        "ENFJ",
+        "ESTP"
+      ],
+      "mbti_secondary_codes_json": [
+        "ENFP",
+        "ESTJ",
+        "ENTP"
+      ],
+      "riasec_profile_json": {
+        "R": 42,
+        "I": 66,
+        "A": 56,
+        "S": 60,
+        "E": 88,
+        "C": 70
+      },
+      "big5_targets_json": {
+        "raw": {
+          "openness": {
+            "min": 40,
+            "max": 80
+          },
+          "conscientiousness": {
+            "min": 50,
+            "max": 90
+          },
+          "extraversion": {
+            "min": 35,
+            "max": 82
+          },
+          "agreeableness": {
+            "min": 35,
+            "max": 85
+          },
+          "neuroticism": {
+            "min": 10,
+            "max": 55
+          }
+        }
+      },
+      "iq_eq_notes_json": {
+        "iq_range": {
+          "min": 50,
+          "max": 98
+        },
+        "eq_range": {
+          "min": 55,
+          "max": 100
+        }
+      },
+      "market_demand_json": {
+        "raw": 82
+      },
+      "status": "published",
+      "is_public": true,
+      "is_indexable": true,
+      "published_at": null,
+      "scheduled_at": null,
+      "sort_order": 0,
+      "sections": [
+
+      ],
+      "seo_meta": {
+        "seo_title": null,
+        "seo_description": null,
+        "canonical_url": null,
+        "og_title": null,
+        "og_description": null,
+        "og_image_url": null,
+        "twitter_title": null,
+        "twitter_description": null,
+        "twitter_image_url": null,
+        "robots": null,
+        "jsonld_overrides_json": null
+      }
+    },
+    {
+      "job_code": "pharmacist",
+      "slug": "pharmacist",
+      "locale": "en",
+      "title": "Pharmacist",
+      "subtitle": null,
+      "excerpt": "A practical role profile for pharmacist including responsibilities, required skills, salary, and growth path.",
+      "hero_kicker": null,
+      "hero_quote": null,
+      "cover_image_url": null,
+      "industry_slug": "healthcare",
+      "industry_label": null,
+      "body_md": "# Pharmacist\n## Role Overview\nPharmacist is a role where performance compounds through execution quality, communication precision, and long-term learning velocity.\n\n## Core Work Scope\nThis role contributes to business outcomes by translating goals into high-quality deliverables, collaborating across functions, and continuously improving process quality.\n\n## Career Development Advice\nUse 90-day cycles to track output metrics, capability growth, and collaboration impact. Review your progress every quarter and adjust your growth plan based on evidence.\n",
+      "body_html": null,
+      "salary_json": {
+        "raw": "$55,000 - $180,000 (varies by region and seniority)"
+      },
+      "outlook_json": {
+        "summary": "Demand for pharmacist talent remains strong in data-driven organizations."
+      },
+      "skills_json": {
+        "core": [
+          "Structured problem solving",
+          "Stakeholder communication",
+          "Execution management",
+          "Data-informed decision making",
+          "Continuous learning"
+        ],
+        "supporting": [
+
+        ]
+      },
+      "work_contents_json": {
+        "items": [
+          "Define key responsibilities and delivery metrics for pharmacist workstreams.",
+          "Coordinate cross-functional stakeholders and align execution priorities.",
+          "Track progress, risks, and quality signals to ensure stable outcomes."
+        ]
+      },
+      "growth_path_json": {
+        "raw": [
+          "0-2 years: build core execution competency and domain literacy.",
+          "3-5 years: own medium-complexity projects and cross-team collaboration.",
+          "5+ years: move toward specialist leadership or managerial scope."
+        ]
+      },
+      "fit_personality_codes_json": null,
+      "mbti_primary_codes_json": [
+        "ENFJ",
+        "ISFJ",
+        "INFJ"
+      ],
+      "mbti_secondary_codes_json": [
+        "ESFJ",
+        "INFP",
+        "ENFP"
+      ],
+      "riasec_profile_json": {
+        "R": 48,
+        "I": 64,
+        "A": 42,
+        "S": 88,
+        "E": 54,
+        "C": 74
+      },
+      "big5_targets_json": {
+        "raw": {
+          "openness": {
+            "min": 40,
+            "max": 80
+          },
+          "conscientiousness": {
+            "min": 50,
+            "max": 90
+          },
+          "extraversion": {
+            "min": 35,
+            "max": 82
+          },
+          "agreeableness": {
+            "min": 35,
+            "max": 85
+          },
+          "neuroticism": {
+            "min": 10,
+            "max": 55
+          }
+        }
+      },
+      "iq_eq_notes_json": {
+        "iq_range": {
+          "min": 50,
+          "max": 100
+        },
+        "eq_range": {
+          "min": 60,
+          "max": 100
+        }
+      },
+      "market_demand_json": {
+        "raw": 86
+      },
+      "status": "published",
+      "is_public": true,
+      "is_indexable": true,
+      "published_at": null,
+      "scheduled_at": null,
+      "sort_order": 0,
+      "sections": [
+
+      ],
+      "seo_meta": {
+        "seo_title": null,
+        "seo_description": null,
+        "canonical_url": null,
+        "og_title": null,
+        "og_description": null,
+        "og_image_url": null,
+        "twitter_title": null,
+        "twitter_description": null,
+        "twitter_image_url": null,
+        "robots": null,
+        "jsonld_overrides_json": null
+      }
+    },
+    {
+      "job_code": "physician",
+      "slug": "physician",
+      "locale": "en",
+      "title": "Physician",
+      "subtitle": null,
+      "excerpt": "A practical role profile for physician including responsibilities, required skills, salary, and growth path.",
+      "hero_kicker": null,
+      "hero_quote": null,
+      "cover_image_url": null,
+      "industry_slug": "healthcare",
+      "industry_label": null,
+      "body_md": "# Physician\n## Role Overview\nPhysician is a role where performance compounds through execution quality, communication precision, and long-term learning velocity.\n\n## Core Work Scope\nThis role contributes to business outcomes by translating goals into high-quality deliverables, collaborating across functions, and continuously improving process quality.\n\n## Career Development Advice\nUse 90-day cycles to track output metrics, capability growth, and collaboration impact. Review your progress every quarter and adjust your growth plan based on evidence.\n",
+      "body_html": null,
+      "salary_json": {
+        "raw": "$55,000 - $180,000 (varies by region and seniority)"
+      },
+      "outlook_json": {
+        "summary": "Demand for physician talent remains strong in data-driven organizations."
+      },
+      "skills_json": {
+        "core": [
+          "Structured problem solving",
+          "Stakeholder communication",
+          "Execution management",
+          "Data-informed decision making",
+          "Continuous learning"
+        ],
+        "supporting": [
+
+        ]
+      },
+      "work_contents_json": {
+        "items": [
+          "Define key responsibilities and delivery metrics for physician workstreams.",
+          "Coordinate cross-functional stakeholders and align execution priorities.",
+          "Track progress, risks, and quality signals to ensure stable outcomes."
+        ]
+      },
+      "growth_path_json": {
+        "raw": [
+          "0-2 years: build core execution competency and domain literacy.",
+          "3-5 years: own medium-complexity projects and cross-team collaboration.",
+          "5+ years: move toward specialist leadership or managerial scope."
+        ]
+      },
+      "fit_personality_codes_json": null,
+      "mbti_primary_codes_json": [
+        "ENFJ",
+        "ISFJ",
+        "INFJ"
+      ],
+      "mbti_secondary_codes_json": [
+        "ESFJ",
+        "INFP",
+        "ENFP"
+      ],
+      "riasec_profile_json": {
+        "R": 48,
+        "I": 64,
+        "A": 42,
+        "S": 88,
+        "E": 54,
+        "C": 74
+      },
+      "big5_targets_json": {
+        "raw": {
+          "openness": {
+            "min": 40,
+            "max": 80
+          },
+          "conscientiousness": {
+            "min": 50,
+            "max": 90
+          },
+          "extraversion": {
+            "min": 35,
+            "max": 82
+          },
+          "agreeableness": {
+            "min": 35,
+            "max": 85
+          },
+          "neuroticism": {
+            "min": 10,
+            "max": 55
+          }
+        }
+      },
+      "iq_eq_notes_json": {
+        "iq_range": {
+          "min": 50,
+          "max": 100
+        },
+        "eq_range": {
+          "min": 60,
+          "max": 100
+        }
+      },
+      "market_demand_json": {
+        "raw": 86
+      },
+      "status": "published",
+      "is_public": true,
+      "is_indexable": true,
+      "published_at": null,
+      "scheduled_at": null,
+      "sort_order": 0,
+      "sections": [
+
+      ],
+      "seo_meta": {
+        "seo_title": null,
+        "seo_description": null,
+        "canonical_url": null,
+        "og_title": null,
+        "og_description": null,
+        "og_image_url": null,
+        "twitter_title": null,
+        "twitter_description": null,
+        "twitter_image_url": null,
+        "robots": null,
+        "jsonld_overrides_json": null
+      }
+    },
+    {
+      "job_code": "policy-analyst",
+      "slug": "policy-analyst",
+      "locale": "en",
+      "title": "Policy Analyst",
+      "subtitle": null,
+      "excerpt": "A practical role profile for policy analyst including responsibilities, required skills, salary, and growth path.",
+      "hero_kicker": null,
+      "hero_quote": null,
+      "cover_image_url": null,
+      "industry_slug": "public-service",
+      "industry_label": null,
+      "body_md": "# Policy Analyst\n## Role Overview\nPolicy Analyst is a role where performance compounds through execution quality, communication precision, and long-term learning velocity.\n\n## Core Work Scope\nThis role contributes to business outcomes by translating goals into high-quality deliverables, collaborating across functions, and continuously improving process quality.\n\n## Career Development Advice\nUse 90-day cycles to track output metrics, capability growth, and collaboration impact. Review your progress every quarter and adjust your growth plan based on evidence.\n",
+      "body_html": null,
+      "salary_json": {
+        "raw": "$55,000 - $180,000 (varies by region and seniority)"
+      },
+      "outlook_json": {
+        "summary": "Demand for policy analyst talent remains strong in data-driven organizations."
+      },
+      "skills_json": {
+        "core": [
+          "Structured problem solving",
+          "Stakeholder communication",
+          "Execution management",
+          "Data-informed decision making",
+          "Continuous learning"
+        ],
+        "supporting": [
+
+        ]
+      },
+      "work_contents_json": {
+        "items": [
+          "Define key responsibilities and delivery metrics for policy analyst workstreams.",
+          "Coordinate cross-functional stakeholders and align execution priorities.",
+          "Track progress, risks, and quality signals to ensure stable outcomes."
+        ]
+      },
+      "growth_path_json": {
+        "raw": [
+          "0-2 years: build core execution competency and domain literacy.",
+          "3-5 years: own medium-complexity projects and cross-team collaboration.",
+          "5+ years: move toward specialist leadership or managerial scope."
+        ]
+      },
+      "fit_personality_codes_json": null,
+      "mbti_primary_codes_json": [
+        "INTJ",
+        "INTP",
+        "ENTJ"
+      ],
+      "mbti_secondary_codes_json": [
+        "ENTP",
+        "ISTJ",
+        "INFJ"
+      ],
+      "riasec_profile_json": {
+        "R": 40,
+        "I": 90,
+        "A": 45,
+        "S": 38,
+        "E": 46,
+        "C": 72
+      },
+      "big5_targets_json": {
+        "raw": {
+          "openness": {
+            "min": 40,
+            "max": 80
+          },
+          "conscientiousness": {
+            "min": 50,
+            "max": 90
+          },
+          "extraversion": {
+            "min": 35,
+            "max": 82
+          },
+          "agreeableness": {
+            "min": 35,
+            "max": 85
+          },
+          "neuroticism": {
+            "min": 10,
+            "max": 55
+          }
+        }
+      },
+      "iq_eq_notes_json": {
+        "iq_range": {
+          "min": 62,
+          "max": 100
+        },
+        "eq_range": {
+          "min": 40,
+          "max": 86
+        }
+      },
+      "market_demand_json": {
+        "raw": 85
+      },
+      "status": "published",
+      "is_public": true,
+      "is_indexable": true,
+      "published_at": null,
+      "scheduled_at": null,
+      "sort_order": 0,
+      "sections": [
+
+      ],
+      "seo_meta": {
+        "seo_title": null,
+        "seo_description": null,
+        "canonical_url": null,
+        "og_title": null,
+        "og_description": null,
+        "og_image_url": null,
+        "twitter_title": null,
+        "twitter_description": null,
+        "twitter_image_url": null,
+        "robots": null,
+        "jsonld_overrides_json": null
+      }
+    },
+    {
+      "job_code": "product-manager",
+      "slug": "product-manager",
+      "locale": "en",
+      "title": "Product Manager",
+      "subtitle": null,
+      "excerpt": "A practical role profile for product manager including responsibilities, required skills, salary, and growth path.",
+      "hero_kicker": null,
+      "hero_quote": null,
+      "cover_image_url": null,
+      "industry_slug": "business",
+      "industry_label": null,
+      "body_md": "# Product Manager\n## Role Overview\nProduct Manager is a role where performance compounds through execution quality, communication precision, and long-term learning velocity.\n\n## Core Work Scope\nThis role contributes to business outcomes by translating goals into high-quality deliverables, collaborating across functions, and continuously improving process quality.\n\n## Career Development Advice\nUse 90-day cycles to track output metrics, capability growth, and collaboration impact. Review your progress every quarter and adjust your growth plan based on evidence.\n",
+      "body_html": null,
+      "salary_json": {
+        "raw": "$55,000 - $180,000 (varies by region and seniority)"
+      },
+      "outlook_json": {
+        "summary": "Demand for product manager talent remains strong in data-driven organizations."
+      },
+      "skills_json": {
+        "core": [
+          "Structured problem solving",
+          "Stakeholder communication",
+          "Execution management",
+          "Data-informed decision making",
+          "Continuous learning"
+        ],
+        "supporting": [
+
+        ]
+      },
+      "work_contents_json": {
+        "items": [
+          "Define key responsibilities and delivery metrics for product manager workstreams.",
+          "Coordinate cross-functional stakeholders and align execution priorities.",
+          "Track progress, risks, and quality signals to ensure stable outcomes."
+        ]
+      },
+      "growth_path_json": {
+        "raw": [
+          "0-2 years: build core execution competency and domain literacy.",
+          "3-5 years: own medium-complexity projects and cross-team collaboration.",
+          "5+ years: move toward specialist leadership or managerial scope."
+        ]
+      },
+      "fit_personality_codes_json": null,
+      "mbti_primary_codes_json": [
+        "ENTJ",
+        "ENFJ",
+        "ESTP"
+      ],
+      "mbti_secondary_codes_json": [
+        "ENFP",
+        "ESTJ",
+        "ENTP"
+      ],
+      "riasec_profile_json": {
+        "R": 42,
+        "I": 66,
+        "A": 56,
+        "S": 60,
+        "E": 88,
+        "C": 70
+      },
+      "big5_targets_json": {
+        "raw": {
+          "openness": {
+            "min": 40,
+            "max": 80
+          },
+          "conscientiousness": {
+            "min": 50,
+            "max": 90
+          },
+          "extraversion": {
+            "min": 35,
+            "max": 82
+          },
+          "agreeableness": {
+            "min": 35,
+            "max": 85
+          },
+          "neuroticism": {
+            "min": 10,
+            "max": 55
+          }
+        }
+      },
+      "iq_eq_notes_json": {
+        "iq_range": {
+          "min": 50,
+          "max": 98
+        },
+        "eq_range": {
+          "min": 55,
+          "max": 100
+        }
+      },
+      "market_demand_json": {
+        "raw": 82
+      },
+      "status": "published",
+      "is_public": true,
+      "is_indexable": true,
+      "published_at": null,
+      "scheduled_at": null,
+      "sort_order": 0,
+      "sections": [
+
+      ],
+      "seo_meta": {
+        "seo_title": null,
+        "seo_description": null,
+        "canonical_url": null,
+        "og_title": null,
+        "og_description": null,
+        "og_image_url": null,
+        "twitter_title": null,
+        "twitter_description": null,
+        "twitter_image_url": null,
+        "robots": null,
+        "jsonld_overrides_json": null
+      }
+    },
+    {
+      "job_code": "psychological-counselor",
+      "slug": "psychological-counselor",
+      "locale": "en",
+      "title": "Psychological Counselor",
+      "subtitle": null,
+      "excerpt": "A practical role profile for psychological counselor including responsibilities, required skills, salary, and growth path.",
+      "hero_kicker": null,
+      "hero_quote": null,
+      "cover_image_url": null,
+      "industry_slug": "healthcare",
+      "industry_label": null,
+      "body_md": "# Psychological Counselor\n## Role Overview\nPsychological Counselor is a role where performance compounds through execution quality, communication precision, and long-term learning velocity.\n\n## Core Work Scope\nThis role contributes to business outcomes by translating goals into high-quality deliverables, collaborating across functions, and continuously improving process quality.\n\n## Career Development Advice\nUse 90-day cycles to track output metrics, capability growth, and collaboration impact. Review your progress every quarter and adjust your growth plan based on evidence.\n",
+      "body_html": null,
+      "salary_json": {
+        "raw": "$55,000 - $180,000 (varies by region and seniority)"
+      },
+      "outlook_json": {
+        "summary": "Demand for psychological counselor talent remains strong in data-driven organizations."
+      },
+      "skills_json": {
+        "core": [
+          "Structured problem solving",
+          "Stakeholder communication",
+          "Execution management",
+          "Data-informed decision making",
+          "Continuous learning"
+        ],
+        "supporting": [
+
+        ]
+      },
+      "work_contents_json": {
+        "items": [
+          "Define key responsibilities and delivery metrics for psychological counselor workstreams.",
+          "Coordinate cross-functional stakeholders and align execution priorities.",
+          "Track progress, risks, and quality signals to ensure stable outcomes."
+        ]
+      },
+      "growth_path_json": {
+        "raw": [
+          "0-2 years: build core execution competency and domain literacy.",
+          "3-5 years: own medium-complexity projects and cross-team collaboration.",
+          "5+ years: move toward specialist leadership or managerial scope."
+        ]
+      },
+      "fit_personality_codes_json": null,
+      "mbti_primary_codes_json": [
+        "ENFJ",
+        "ISFJ",
+        "INFJ"
+      ],
+      "mbti_secondary_codes_json": [
+        "ESFJ",
+        "INFP",
+        "ENFP"
+      ],
+      "riasec_profile_json": {
+        "R": 48,
+        "I": 64,
+        "A": 42,
+        "S": 88,
+        "E": 54,
+        "C": 74
+      },
+      "big5_targets_json": {
+        "raw": {
+          "openness": {
+            "min": 40,
+            "max": 80
+          },
+          "conscientiousness": {
+            "min": 50,
+            "max": 90
+          },
+          "extraversion": {
+            "min": 35,
+            "max": 82
+          },
+          "agreeableness": {
+            "min": 35,
+            "max": 85
+          },
+          "neuroticism": {
+            "min": 10,
+            "max": 55
+          }
+        }
+      },
+      "iq_eq_notes_json": {
+        "iq_range": {
+          "min": 50,
+          "max": 100
+        },
+        "eq_range": {
+          "min": 60,
+          "max": 100
+        }
+      },
+      "market_demand_json": {
+        "raw": 86
+      },
+      "status": "published",
+      "is_public": true,
+      "is_indexable": true,
+      "published_at": null,
+      "scheduled_at": null,
+      "sort_order": 0,
+      "sections": [
+
+      ],
+      "seo_meta": {
+        "seo_title": null,
+        "seo_description": null,
+        "canonical_url": null,
+        "og_title": null,
+        "og_description": null,
+        "og_image_url": null,
+        "twitter_title": null,
+        "twitter_description": null,
+        "twitter_image_url": null,
+        "robots": null,
+        "jsonld_overrides_json": null
+      }
+    },
+    {
+      "job_code": "researcher",
+      "slug": "researcher",
+      "locale": "en",
+      "title": "Researcher",
+      "subtitle": null,
+      "excerpt": "A practical role profile for researcher including responsibilities, required skills, salary, and growth path.",
+      "hero_kicker": null,
+      "hero_quote": null,
+      "cover_image_url": null,
+      "industry_slug": "education",
+      "industry_label": null,
+      "body_md": "# Researcher\n## Role Overview\nResearcher is a role where performance compounds through execution quality, communication precision, and long-term learning velocity.\n\n## Core Work Scope\nThis role contributes to business outcomes by translating goals into high-quality deliverables, collaborating across functions, and continuously improving process quality.\n\n## Career Development Advice\nUse 90-day cycles to track output metrics, capability growth, and collaboration impact. Review your progress every quarter and adjust your growth plan based on evidence.\n",
+      "body_html": null,
+      "salary_json": {
+        "raw": "$55,000 - $180,000 (varies by region and seniority)"
+      },
+      "outlook_json": {
+        "summary": "Demand for researcher talent remains strong in data-driven organizations."
+      },
+      "skills_json": {
+        "core": [
+          "Structured problem solving",
+          "Stakeholder communication",
+          "Execution management",
+          "Data-informed decision making",
+          "Continuous learning"
+        ],
+        "supporting": [
+
+        ]
+      },
+      "work_contents_json": {
+        "items": [
+          "Define key responsibilities and delivery metrics for researcher workstreams.",
+          "Coordinate cross-functional stakeholders and align execution priorities.",
+          "Track progress, risks, and quality signals to ensure stable outcomes."
+        ]
+      },
+      "growth_path_json": {
+        "raw": [
+          "0-2 years: build core execution competency and domain literacy.",
+          "3-5 years: own medium-complexity projects and cross-team collaboration.",
+          "5+ years: move toward specialist leadership or managerial scope."
+        ]
+      },
+      "fit_personality_codes_json": null,
+      "mbti_primary_codes_json": [
+        "INTJ",
+        "INTP",
+        "ENTJ"
+      ],
+      "mbti_secondary_codes_json": [
+        "ENTP",
+        "ISTJ",
+        "INFJ"
+      ],
+      "riasec_profile_json": {
+        "R": 40,
+        "I": 90,
+        "A": 45,
+        "S": 38,
+        "E": 46,
+        "C": 72
+      },
+      "big5_targets_json": {
+        "raw": {
+          "openness": {
+            "min": 40,
+            "max": 80
+          },
+          "conscientiousness": {
+            "min": 50,
+            "max": 90
+          },
+          "extraversion": {
+            "min": 35,
+            "max": 82
+          },
+          "agreeableness": {
+            "min": 35,
+            "max": 85
+          },
+          "neuroticism": {
+            "min": 10,
+            "max": 55
+          }
+        }
+      },
+      "iq_eq_notes_json": {
+        "iq_range": {
+          "min": 62,
+          "max": 100
+        },
+        "eq_range": {
+          "min": 40,
+          "max": 86
+        }
+      },
+      "market_demand_json": {
+        "raw": 85
+      },
+      "status": "published",
+      "is_public": true,
+      "is_indexable": true,
+      "published_at": null,
+      "scheduled_at": null,
+      "sort_order": 0,
+      "sections": [
+
+      ],
+      "seo_meta": {
+        "seo_title": null,
+        "seo_description": null,
+        "canonical_url": null,
+        "og_title": null,
+        "og_description": null,
+        "og_image_url": null,
+        "twitter_title": null,
+        "twitter_description": null,
+        "twitter_image_url": null,
+        "robots": null,
+        "jsonld_overrides_json": null
+      }
+    },
+    {
+      "job_code": "sales-manager",
+      "slug": "sales-manager",
+      "locale": "en",
+      "title": "Sales Manager",
+      "subtitle": null,
+      "excerpt": "A practical role profile for sales manager including responsibilities, required skills, salary, and growth path.",
+      "hero_kicker": null,
+      "hero_quote": null,
+      "cover_image_url": null,
+      "industry_slug": "business",
+      "industry_label": null,
+      "body_md": "# Sales Manager\n## Role Overview\nSales Manager is a role where performance compounds through execution quality, communication precision, and long-term learning velocity.\n\n## Core Work Scope\nThis role contributes to business outcomes by translating goals into high-quality deliverables, collaborating across functions, and continuously improving process quality.\n\n## Career Development Advice\nUse 90-day cycles to track output metrics, capability growth, and collaboration impact. Review your progress every quarter and adjust your growth plan based on evidence.\n",
+      "body_html": null,
+      "salary_json": {
+        "raw": "$55,000 - $180,000 (varies by region and seniority)"
+      },
+      "outlook_json": {
+        "summary": "Demand for sales manager talent remains strong in data-driven organizations."
+      },
+      "skills_json": {
+        "core": [
+          "Structured problem solving",
+          "Stakeholder communication",
+          "Execution management",
+          "Data-informed decision making",
+          "Continuous learning"
+        ],
+        "supporting": [
+
+        ]
+      },
+      "work_contents_json": {
+        "items": [
+          "Define key responsibilities and delivery metrics for sales manager workstreams.",
+          "Coordinate cross-functional stakeholders and align execution priorities.",
+          "Track progress, risks, and quality signals to ensure stable outcomes."
+        ]
+      },
+      "growth_path_json": {
+        "raw": [
+          "0-2 years: build core execution competency and domain literacy.",
+          "3-5 years: own medium-complexity projects and cross-team collaboration.",
+          "5+ years: move toward specialist leadership or managerial scope."
+        ]
+      },
+      "fit_personality_codes_json": null,
+      "mbti_primary_codes_json": [
+        "ENTJ",
+        "ENFJ",
+        "ESTP"
+      ],
+      "mbti_secondary_codes_json": [
+        "ENFP",
+        "ESTJ",
+        "ENTP"
+      ],
+      "riasec_profile_json": {
+        "R": 42,
+        "I": 66,
+        "A": 56,
+        "S": 60,
+        "E": 88,
+        "C": 70
+      },
+      "big5_targets_json": {
+        "raw": {
+          "openness": {
+            "min": 40,
+            "max": 80
+          },
+          "conscientiousness": {
+            "min": 50,
+            "max": 90
+          },
+          "extraversion": {
+            "min": 35,
+            "max": 82
+          },
+          "agreeableness": {
+            "min": 35,
+            "max": 85
+          },
+          "neuroticism": {
+            "min": 10,
+            "max": 55
+          }
+        }
+      },
+      "iq_eq_notes_json": {
+        "iq_range": {
+          "min": 50,
+          "max": 98
+        },
+        "eq_range": {
+          "min": 55,
+          "max": 100
+        }
+      },
+      "market_demand_json": {
+        "raw": 82
+      },
+      "status": "published",
+      "is_public": true,
+      "is_indexable": true,
+      "published_at": null,
+      "scheduled_at": null,
+      "sort_order": 0,
+      "sections": [
+
+      ],
+      "seo_meta": {
+        "seo_title": null,
+        "seo_description": null,
+        "canonical_url": null,
+        "og_title": null,
+        "og_description": null,
+        "og_image_url": null,
+        "twitter_title": null,
+        "twitter_description": null,
+        "twitter_image_url": null,
+        "robots": null,
+        "jsonld_overrides_json": null
+      }
+    },
+    {
+      "job_code": "software-engineer",
+      "slug": "software-engineer",
+      "locale": "en",
+      "title": "Software Engineer",
+      "subtitle": null,
+      "excerpt": "A practical role profile for software engineer including responsibilities, required skills, salary, and growth path.",
+      "hero_kicker": null,
+      "hero_quote": null,
+      "cover_image_url": null,
+      "industry_slug": "technology",
+      "industry_label": null,
+      "body_md": "# Software Engineer\n## Role Overview\nSoftware Engineer is a role where performance compounds through execution quality, communication precision, and long-term learning velocity.\n\n## Core Work Scope\nThis role contributes to business outcomes by translating goals into high-quality deliverables, collaborating across functions, and continuously improving process quality.\n\n## Career Development Advice\nUse 90-day cycles to track output metrics, capability growth, and collaboration impact. Review your progress every quarter and adjust your growth plan based on evidence.\n",
+      "body_html": null,
+      "salary_json": {
+        "raw": "$55,000 - $180,000 (varies by region and seniority)"
+      },
+      "outlook_json": {
+        "summary": "Demand for software engineer talent remains strong in data-driven organizations."
+      },
+      "skills_json": {
+        "core": [
+          "Structured problem solving",
+          "Stakeholder communication",
+          "Execution management",
+          "Data-informed decision making",
+          "Continuous learning"
+        ],
+        "supporting": [
+
+        ]
+      },
+      "work_contents_json": {
+        "items": [
+          "Define key responsibilities and delivery metrics for software engineer workstreams.",
+          "Coordinate cross-functional stakeholders and align execution priorities.",
+          "Track progress, risks, and quality signals to ensure stable outcomes."
+        ]
+      },
+      "growth_path_json": {
+        "raw": [
+          "0-2 years: build core execution competency and domain literacy.",
+          "3-5 years: own medium-complexity projects and cross-team collaboration.",
+          "5+ years: move toward specialist leadership or managerial scope."
+        ]
+      },
+      "fit_personality_codes_json": null,
+      "mbti_primary_codes_json": [
+        "INTJ",
+        "INTP",
+        "ENTJ"
+      ],
+      "mbti_secondary_codes_json": [
+        "ENTP",
+        "ISTJ",
+        "INFJ"
+      ],
+      "riasec_profile_json": {
+        "R": 55,
+        "I": 88,
+        "A": 48,
+        "S": 42,
+        "E": 50,
+        "C": 68
+      },
+      "big5_targets_json": {
+        "raw": {
+          "openness": {
+            "min": 40,
+            "max": 80
+          },
+          "conscientiousness": {
+            "min": 50,
+            "max": 90
+          },
+          "extraversion": {
+            "min": 35,
+            "max": 82
+          },
+          "agreeableness": {
+            "min": 35,
+            "max": 85
+          },
+          "neuroticism": {
+            "min": 10,
+            "max": 55
+          }
+        }
+      },
+      "iq_eq_notes_json": {
+        "iq_range": {
+          "min": 65,
+          "max": 100
+        },
+        "eq_range": {
+          "min": 45,
+          "max": 90
+        }
+      },
+      "market_demand_json": {
+        "raw": 92
+      },
+      "status": "published",
+      "is_public": true,
+      "is_indexable": true,
+      "published_at": null,
+      "scheduled_at": null,
+      "sort_order": 0,
+      "sections": [
+
+      ],
+      "seo_meta": {
+        "seo_title": null,
+        "seo_description": null,
+        "canonical_url": null,
+        "og_title": null,
+        "og_description": null,
+        "og_image_url": null,
+        "twitter_title": null,
+        "twitter_description": null,
+        "twitter_image_url": null,
+        "robots": null,
+        "jsonld_overrides_json": null
+      }
+    },
+    {
+      "job_code": "supply-chain-manager",
+      "slug": "supply-chain-manager",
+      "locale": "en",
+      "title": "Supply Chain Manager",
+      "subtitle": null,
+      "excerpt": "A practical role profile for supply chain manager including responsibilities, required skills, salary, and growth path.",
+      "hero_kicker": null,
+      "hero_quote": null,
+      "cover_image_url": null,
+      "industry_slug": "operations",
+      "industry_label": null,
+      "body_md": "# Supply Chain Manager\n## Role Overview\nSupply Chain Manager is a role where performance compounds through execution quality, communication precision, and long-term learning velocity.\n\n## Core Work Scope\nThis role contributes to business outcomes by translating goals into high-quality deliverables, collaborating across functions, and continuously improving process quality.\n\n## Career Development Advice\nUse 90-day cycles to track output metrics, capability growth, and collaboration impact. Review your progress every quarter and adjust your growth plan based on evidence.\n",
+      "body_html": null,
+      "salary_json": {
+        "raw": "$55,000 - $180,000 (varies by region and seniority)"
+      },
+      "outlook_json": {
+        "summary": "Demand for supply chain manager talent remains strong in data-driven organizations."
+      },
+      "skills_json": {
+        "core": [
+          "Structured problem solving",
+          "Stakeholder communication",
+          "Execution management",
+          "Data-informed decision making",
+          "Continuous learning"
+        ],
+        "supporting": [
+
+        ]
+      },
+      "work_contents_json": {
+        "items": [
+          "Define key responsibilities and delivery metrics for supply chain manager workstreams.",
+          "Coordinate cross-functional stakeholders and align execution priorities.",
+          "Track progress, risks, and quality signals to ensure stable outcomes."
+        ]
+      },
+      "growth_path_json": {
+        "raw": [
+          "0-2 years: build core execution competency and domain literacy.",
+          "3-5 years: own medium-complexity projects and cross-team collaboration.",
+          "5+ years: move toward specialist leadership or managerial scope."
+        ]
+      },
+      "fit_personality_codes_json": null,
+      "mbti_primary_codes_json": [
+        "ENTJ",
+        "ENFJ",
+        "ESTP"
+      ],
+      "mbti_secondary_codes_json": [
+        "ENFP",
+        "ESTJ",
+        "ENTP"
+      ],
+      "riasec_profile_json": {
+        "R": 42,
+        "I": 66,
+        "A": 56,
+        "S": 60,
+        "E": 88,
+        "C": 70
+      },
+      "big5_targets_json": {
+        "raw": {
+          "openness": {
+            "min": 40,
+            "max": 80
+          },
+          "conscientiousness": {
+            "min": 50,
+            "max": 90
+          },
+          "extraversion": {
+            "min": 35,
+            "max": 82
+          },
+          "agreeableness": {
+            "min": 35,
+            "max": 85
+          },
+          "neuroticism": {
+            "min": 10,
+            "max": 55
+          }
+        }
+      },
+      "iq_eq_notes_json": {
+        "iq_range": {
+          "min": 50,
+          "max": 98
+        },
+        "eq_range": {
+          "min": 55,
+          "max": 100
+        }
+      },
+      "market_demand_json": {
+        "raw": 82
+      },
+      "status": "published",
+      "is_public": true,
+      "is_indexable": true,
+      "published_at": null,
+      "scheduled_at": null,
+      "sort_order": 0,
+      "sections": [
+
+      ],
+      "seo_meta": {
+        "seo_title": null,
+        "seo_description": null,
+        "canonical_url": null,
+        "og_title": null,
+        "og_description": null,
+        "og_image_url": null,
+        "twitter_title": null,
+        "twitter_description": null,
+        "twitter_image_url": null,
+        "robots": null,
+        "jsonld_overrides_json": null
+      }
+    },
+    {
+      "job_code": "teacher",
+      "slug": "teacher",
+      "locale": "en",
+      "title": "Teacher",
+      "subtitle": null,
+      "excerpt": "A practical role profile for teacher including responsibilities, required skills, salary, and growth path.",
+      "hero_kicker": null,
+      "hero_quote": null,
+      "cover_image_url": null,
+      "industry_slug": "education",
+      "industry_label": null,
+      "body_md": "# Teacher\n## Role Overview\nTeacher is a role where performance compounds through execution quality, communication precision, and long-term learning velocity.\n\n## Core Work Scope\nThis role contributes to business outcomes by translating goals into high-quality deliverables, collaborating across functions, and continuously improving process quality.\n\n## Career Development Advice\nUse 90-day cycles to track output metrics, capability growth, and collaboration impact. Review your progress every quarter and adjust your growth plan based on evidence.\n",
+      "body_html": null,
+      "salary_json": {
+        "raw": "$55,000 - $180,000 (varies by region and seniority)"
+      },
+      "outlook_json": {
+        "summary": "Demand for teacher talent remains strong in data-driven organizations."
+      },
+      "skills_json": {
+        "core": [
+          "Structured problem solving",
+          "Stakeholder communication",
+          "Execution management",
+          "Data-informed decision making",
+          "Continuous learning"
+        ],
+        "supporting": [
+
+        ]
+      },
+      "work_contents_json": {
+        "items": [
+          "Define key responsibilities and delivery metrics for teacher workstreams.",
+          "Coordinate cross-functional stakeholders and align execution priorities.",
+          "Track progress, risks, and quality signals to ensure stable outcomes."
+        ]
+      },
+      "growth_path_json": {
+        "raw": [
+          "0-2 years: build core execution competency and domain literacy.",
+          "3-5 years: own medium-complexity projects and cross-team collaboration.",
+          "5+ years: move toward specialist leadership or managerial scope."
+        ]
+      },
+      "fit_personality_codes_json": null,
+      "mbti_primary_codes_json": [
+        "ENFJ",
+        "ISFJ",
+        "INFJ"
+      ],
+      "mbti_secondary_codes_json": [
+        "ESFJ",
+        "INFP",
+        "ENFP"
+      ],
+      "riasec_profile_json": {
+        "R": 48,
+        "I": 64,
+        "A": 42,
+        "S": 88,
+        "E": 54,
+        "C": 74
+      },
+      "big5_targets_json": {
+        "raw": {
+          "openness": {
+            "min": 40,
+            "max": 80
+          },
+          "conscientiousness": {
+            "min": 50,
+            "max": 90
+          },
+          "extraversion": {
+            "min": 35,
+            "max": 82
+          },
+          "agreeableness": {
+            "min": 35,
+            "max": 85
+          },
+          "neuroticism": {
+            "min": 10,
+            "max": 55
+          }
+        }
+      },
+      "iq_eq_notes_json": {
+        "iq_range": {
+          "min": 50,
+          "max": 100
+        },
+        "eq_range": {
+          "min": 60,
+          "max": 100
+        }
+      },
+      "market_demand_json": {
+        "raw": 86
+      },
+      "status": "published",
+      "is_public": true,
+      "is_indexable": true,
+      "published_at": null,
+      "scheduled_at": null,
+      "sort_order": 0,
+      "sections": [
+
+      ],
+      "seo_meta": {
+        "seo_title": null,
+        "seo_description": null,
+        "canonical_url": null,
+        "og_title": null,
+        "og_description": null,
+        "og_image_url": null,
+        "twitter_title": null,
+        "twitter_description": null,
+        "twitter_image_url": null,
+        "robots": null,
+        "jsonld_overrides_json": null
+      }
+    },
+    {
+      "job_code": "ui-ux-designer",
+      "slug": "ui-ux-designer",
+      "locale": "en",
+      "title": "UI/UX Designer",
+      "subtitle": null,
+      "excerpt": "A practical role profile for ui/ux designer including responsibilities, required skills, salary, and growth path.",
+      "hero_kicker": null,
+      "hero_quote": null,
+      "cover_image_url": null,
+      "industry_slug": "design",
+      "industry_label": null,
+      "body_md": "# UI/UX Designer\n## Role Overview\nUI/UX Designer is a role where performance compounds through execution quality, communication precision, and long-term learning velocity.\n\n## Core Work Scope\nThis role contributes to business outcomes by translating goals into high-quality deliverables, collaborating across functions, and continuously improving process quality.\n\n## Career Development Advice\nUse 90-day cycles to track output metrics, capability growth, and collaboration impact. Review your progress every quarter and adjust your growth plan based on evidence.\n",
+      "body_html": null,
+      "salary_json": {
+        "raw": "$55,000 - $180,000 (varies by region and seniority)"
+      },
+      "outlook_json": {
+        "summary": "Demand for ui/ux designer talent remains strong in data-driven organizations."
+      },
+      "skills_json": {
+        "core": [
+          "Structured problem solving",
+          "Stakeholder communication",
+          "Execution management",
+          "Data-informed decision making",
+          "Continuous learning"
+        ],
+        "supporting": [
+
+        ]
+      },
+      "work_contents_json": {
+        "items": [
+          "Define key responsibilities and delivery metrics for ui/ux designer workstreams.",
+          "Coordinate cross-functional stakeholders and align execution priorities.",
+          "Track progress, risks, and quality signals to ensure stable outcomes."
+        ]
+      },
+      "growth_path_json": {
+        "raw": [
+          "0-2 years: build core execution competency and domain literacy.",
+          "3-5 years: own medium-complexity projects and cross-team collaboration.",
+          "5+ years: move toward specialist leadership or managerial scope."
+        ]
+      },
+      "fit_personality_codes_json": null,
+      "mbti_primary_codes_json": [
+        "INFP",
+        "ENFP",
+        "ISFP"
+      ],
+      "mbti_secondary_codes_json": [
+        "INFJ",
+        "ENTP",
+        "ESFP"
+      ],
+      "riasec_profile_json": {
+        "R": 38,
+        "I": 62,
+        "A": 90,
+        "S": 54,
+        "E": 60,
+        "C": 44
+      },
+      "big5_targets_json": {
+        "raw": {
+          "openness": {
+            "min": 40,
+            "max": 80
+          },
+          "conscientiousness": {
+            "min": 50,
+            "max": 90
+          },
+          "extraversion": {
+            "min": 35,
+            "max": 82
+          },
+          "agreeableness": {
+            "min": 35,
+            "max": 85
+          },
+          "neuroticism": {
+            "min": 10,
+            "max": 55
+          }
+        }
+      },
+      "iq_eq_notes_json": {
+        "iq_range": {
+          "min": 45,
+          "max": 95
+        },
+        "eq_range": {
+          "min": 52,
+          "max": 96
+        }
+      },
+      "market_demand_json": {
+        "raw": 78
+      },
+      "status": "published",
+      "is_public": true,
+      "is_indexable": true,
+      "published_at": null,
+      "scheduled_at": null,
+      "sort_order": 0,
+      "sections": [
+
+      ],
+      "seo_meta": {
+        "seo_title": null,
+        "seo_description": null,
+        "canonical_url": null,
+        "og_title": null,
+        "og_description": null,
+        "og_image_url": null,
+        "twitter_title": null,
+        "twitter_description": null,
+        "twitter_image_url": null,
+        "robots": null,
+        "jsonld_overrides_json": null
+      }
+    }
+  ]
+}

--- a/content_baselines/career_jobs/career_jobs.zh-CN.json
+++ b/content_baselines/career_jobs/career_jobs.zh-CN.json
@@ -1,0 +1,3760 @@
+{
+  "meta": {
+    "schema_version": "v1",
+    "locale": "zh-CN",
+    "source": "fap-web career jobs baseline",
+    "generated_at": "2026-03-09T00:00:00Z"
+  },
+  "jobs": [
+    {
+      "job_code": "backend-engineer",
+      "slug": "backend-engineer",
+      "locale": "zh-CN",
+      "title": "后端工程师",
+      "subtitle": null,
+      "excerpt": "面向后端工程师的实用岗位画像，覆盖职责范围、能力要求、薪资区间与成长路径。",
+      "hero_kicker": null,
+      "hero_quote": null,
+      "cover_image_url": null,
+      "industry_slug": "technology",
+      "industry_label": null,
+      "body_md": "# 后端工程师\n## 岗位概览\n后端工程师 是一个通过执行质量、沟通精度与持续学习能力持续放大职业价值的岗位。\n\n## 核心工作范围\n该岗位通过把目标拆解为可落地任务、推进跨团队协同，并持续优化流程质量来影响业务结果。\n\n## 职业发展建议\n建议按 90 天为周期跟踪交付指标、能力增长和协作影响，每季度做一次基于证据的职业复盘并调整成长策略。\n",
+      "body_html": null,
+      "salary_json": {
+        "raw": "人民币 18万 - 90万/年（视城市与资历而定）"
+      },
+      "outlook_json": {
+        "summary": "后端工程师 在数据化与精细化运营背景下仍保持较高需求。"
+      },
+      "skills_json": {
+        "core": [
+          "结构化问题解决",
+          "跨角色沟通",
+          "执行推进能力",
+          "数据驱动决策",
+          "持续学习能力"
+        ],
+        "supporting": [
+
+        ]
+      },
+      "work_contents_json": {
+        "items": [
+          "明确后端工程师核心职责与交付指标。",
+          "协同跨团队角色并统一执行优先级。",
+          "跟踪进度、风险与质量信号，保障结果稳定交付。"
+        ]
+      },
+      "growth_path_json": {
+        "raw": [
+          "0-2 年：建立基础执行能力与行业认知。",
+          "3-5 年：独立负责中等复杂度项目并推进跨团队协作。",
+          "5 年以上：走向专家型负责人或管理型角色。"
+        ]
+      },
+      "fit_personality_codes_json": null,
+      "mbti_primary_codes_json": [
+        "INTJ",
+        "INTP",
+        "ENTJ"
+      ],
+      "mbti_secondary_codes_json": [
+        "ENTP",
+        "ISTJ",
+        "INFJ"
+      ],
+      "riasec_profile_json": {
+        "R": 55,
+        "I": 88,
+        "A": 48,
+        "S": 42,
+        "E": 50,
+        "C": 68
+      },
+      "big5_targets_json": {
+        "raw": {
+          "openness": {
+            "min": 40,
+            "max": 80
+          },
+          "conscientiousness": {
+            "min": 50,
+            "max": 90
+          },
+          "extraversion": {
+            "min": 35,
+            "max": 82
+          },
+          "agreeableness": {
+            "min": 35,
+            "max": 85
+          },
+          "neuroticism": {
+            "min": 10,
+            "max": 55
+          }
+        }
+      },
+      "iq_eq_notes_json": {
+        "iq_range": {
+          "min": 65,
+          "max": 100
+        },
+        "eq_range": {
+          "min": 45,
+          "max": 90
+        }
+      },
+      "market_demand_json": {
+        "raw": 92
+      },
+      "status": "published",
+      "is_public": true,
+      "is_indexable": true,
+      "published_at": null,
+      "scheduled_at": null,
+      "sort_order": 0,
+      "sections": [
+
+      ],
+      "seo_meta": {
+        "seo_title": null,
+        "seo_description": null,
+        "canonical_url": null,
+        "og_title": null,
+        "og_description": null,
+        "og_image_url": null,
+        "twitter_title": null,
+        "twitter_description": null,
+        "twitter_image_url": null,
+        "robots": null,
+        "jsonld_overrides_json": null
+      }
+    },
+    {
+      "job_code": "brand-manager",
+      "slug": "brand-manager",
+      "locale": "zh-CN",
+      "title": "品牌经理",
+      "subtitle": null,
+      "excerpt": "面向品牌经理的实用岗位画像，覆盖职责范围、能力要求、薪资区间与成长路径。",
+      "hero_kicker": null,
+      "hero_quote": null,
+      "cover_image_url": null,
+      "industry_slug": "design",
+      "industry_label": null,
+      "body_md": "# 品牌经理\n## 岗位概览\n品牌经理 是一个通过执行质量、沟通精度与持续学习能力持续放大职业价值的岗位。\n\n## 核心工作范围\n该岗位通过把目标拆解为可落地任务、推进跨团队协同，并持续优化流程质量来影响业务结果。\n\n## 职业发展建议\n建议按 90 天为周期跟踪交付指标、能力增长和协作影响，每季度做一次基于证据的职业复盘并调整成长策略。\n",
+      "body_html": null,
+      "salary_json": {
+        "raw": "人民币 18万 - 90万/年（视城市与资历而定）"
+      },
+      "outlook_json": {
+        "summary": "品牌经理 在数据化与精细化运营背景下仍保持较高需求。"
+      },
+      "skills_json": {
+        "core": [
+          "结构化问题解决",
+          "跨角色沟通",
+          "执行推进能力",
+          "数据驱动决策",
+          "持续学习能力"
+        ],
+        "supporting": [
+
+        ]
+      },
+      "work_contents_json": {
+        "items": [
+          "明确品牌经理核心职责与交付指标。",
+          "协同跨团队角色并统一执行优先级。",
+          "跟踪进度、风险与质量信号，保障结果稳定交付。"
+        ]
+      },
+      "growth_path_json": {
+        "raw": [
+          "0-2 年：建立基础执行能力与行业认知。",
+          "3-5 年：独立负责中等复杂度项目并推进跨团队协作。",
+          "5 年以上：走向专家型负责人或管理型角色。"
+        ]
+      },
+      "fit_personality_codes_json": null,
+      "mbti_primary_codes_json": [
+        "INFP",
+        "ENFP",
+        "ISFP"
+      ],
+      "mbti_secondary_codes_json": [
+        "INFJ",
+        "ENTP",
+        "ESFP"
+      ],
+      "riasec_profile_json": {
+        "R": 38,
+        "I": 62,
+        "A": 90,
+        "S": 54,
+        "E": 60,
+        "C": 44
+      },
+      "big5_targets_json": {
+        "raw": {
+          "openness": {
+            "min": 40,
+            "max": 80
+          },
+          "conscientiousness": {
+            "min": 50,
+            "max": 90
+          },
+          "extraversion": {
+            "min": 35,
+            "max": 82
+          },
+          "agreeableness": {
+            "min": 35,
+            "max": 85
+          },
+          "neuroticism": {
+            "min": 10,
+            "max": 55
+          }
+        }
+      },
+      "iq_eq_notes_json": {
+        "iq_range": {
+          "min": 45,
+          "max": 95
+        },
+        "eq_range": {
+          "min": 52,
+          "max": 96
+        }
+      },
+      "market_demand_json": {
+        "raw": 78
+      },
+      "status": "published",
+      "is_public": true,
+      "is_indexable": true,
+      "published_at": null,
+      "scheduled_at": null,
+      "sort_order": 0,
+      "sections": [
+
+      ],
+      "seo_meta": {
+        "seo_title": null,
+        "seo_description": null,
+        "canonical_url": null,
+        "og_title": null,
+        "og_description": null,
+        "og_image_url": null,
+        "twitter_title": null,
+        "twitter_description": null,
+        "twitter_image_url": null,
+        "robots": null,
+        "jsonld_overrides_json": null
+      }
+    },
+    {
+      "job_code": "business-analyst",
+      "slug": "business-analyst",
+      "locale": "zh-CN",
+      "title": "商业分析师",
+      "subtitle": null,
+      "excerpt": "面向商业分析师的实用岗位画像，覆盖职责范围、能力要求、薪资区间与成长路径。",
+      "hero_kicker": null,
+      "hero_quote": null,
+      "cover_image_url": null,
+      "industry_slug": "consulting",
+      "industry_label": null,
+      "body_md": "# 商业分析师\n## 岗位概览\n商业分析师 是一个通过执行质量、沟通精度与持续学习能力持续放大职业价值的岗位。\n\n## 核心工作范围\n该岗位通过把目标拆解为可落地任务、推进跨团队协同，并持续优化流程质量来影响业务结果。\n\n## 职业发展建议\n建议按 90 天为周期跟踪交付指标、能力增长和协作影响，每季度做一次基于证据的职业复盘并调整成长策略。\n",
+      "body_html": null,
+      "salary_json": {
+        "raw": "人民币 18万 - 90万/年（视城市与资历而定）"
+      },
+      "outlook_json": {
+        "summary": "商业分析师 在数据化与精细化运营背景下仍保持较高需求。"
+      },
+      "skills_json": {
+        "core": [
+          "结构化问题解决",
+          "跨角色沟通",
+          "执行推进能力",
+          "数据驱动决策",
+          "持续学习能力"
+        ],
+        "supporting": [
+
+        ]
+      },
+      "work_contents_json": {
+        "items": [
+          "明确商业分析师核心职责与交付指标。",
+          "协同跨团队角色并统一执行优先级。",
+          "跟踪进度、风险与质量信号，保障结果稳定交付。"
+        ]
+      },
+      "growth_path_json": {
+        "raw": [
+          "0-2 年：建立基础执行能力与行业认知。",
+          "3-5 年：独立负责中等复杂度项目并推进跨团队协作。",
+          "5 年以上：走向专家型负责人或管理型角色。"
+        ]
+      },
+      "fit_personality_codes_json": null,
+      "mbti_primary_codes_json": [
+        "INTJ",
+        "INTP",
+        "ENTJ"
+      ],
+      "mbti_secondary_codes_json": [
+        "ENTP",
+        "ISTJ",
+        "INFJ"
+      ],
+      "riasec_profile_json": {
+        "R": 40,
+        "I": 90,
+        "A": 45,
+        "S": 38,
+        "E": 46,
+        "C": 72
+      },
+      "big5_targets_json": {
+        "raw": {
+          "openness": {
+            "min": 40,
+            "max": 80
+          },
+          "conscientiousness": {
+            "min": 50,
+            "max": 90
+          },
+          "extraversion": {
+            "min": 35,
+            "max": 82
+          },
+          "agreeableness": {
+            "min": 35,
+            "max": 85
+          },
+          "neuroticism": {
+            "min": 10,
+            "max": 55
+          }
+        }
+      },
+      "iq_eq_notes_json": {
+        "iq_range": {
+          "min": 62,
+          "max": 100
+        },
+        "eq_range": {
+          "min": 40,
+          "max": 86
+        }
+      },
+      "market_demand_json": {
+        "raw": 85
+      },
+      "status": "published",
+      "is_public": true,
+      "is_indexable": true,
+      "published_at": null,
+      "scheduled_at": null,
+      "sort_order": 0,
+      "sections": [
+
+      ],
+      "seo_meta": {
+        "seo_title": null,
+        "seo_description": null,
+        "canonical_url": null,
+        "og_title": null,
+        "og_description": null,
+        "og_image_url": null,
+        "twitter_title": null,
+        "twitter_description": null,
+        "twitter_image_url": null,
+        "robots": null,
+        "jsonld_overrides_json": null
+      }
+    },
+    {
+      "job_code": "cloud-architect",
+      "slug": "cloud-architect",
+      "locale": "zh-CN",
+      "title": "云架构师",
+      "subtitle": null,
+      "excerpt": "面向云架构师的实用岗位画像，覆盖职责范围、能力要求、薪资区间与成长路径。",
+      "hero_kicker": null,
+      "hero_quote": null,
+      "cover_image_url": null,
+      "industry_slug": "technology",
+      "industry_label": null,
+      "body_md": "# 云架构师\n## 岗位概览\n云架构师 是一个通过执行质量、沟通精度与持续学习能力持续放大职业价值的岗位。\n\n## 核心工作范围\n该岗位通过把目标拆解为可落地任务、推进跨团队协同，并持续优化流程质量来影响业务结果。\n\n## 职业发展建议\n建议按 90 天为周期跟踪交付指标、能力增长和协作影响，每季度做一次基于证据的职业复盘并调整成长策略。\n",
+      "body_html": null,
+      "salary_json": {
+        "raw": "人民币 18万 - 90万/年（视城市与资历而定）"
+      },
+      "outlook_json": {
+        "summary": "云架构师 在数据化与精细化运营背景下仍保持较高需求。"
+      },
+      "skills_json": {
+        "core": [
+          "结构化问题解决",
+          "跨角色沟通",
+          "执行推进能力",
+          "数据驱动决策",
+          "持续学习能力"
+        ],
+        "supporting": [
+
+        ]
+      },
+      "work_contents_json": {
+        "items": [
+          "明确云架构师核心职责与交付指标。",
+          "协同跨团队角色并统一执行优先级。",
+          "跟踪进度、风险与质量信号，保障结果稳定交付。"
+        ]
+      },
+      "growth_path_json": {
+        "raw": [
+          "0-2 年：建立基础执行能力与行业认知。",
+          "3-5 年：独立负责中等复杂度项目并推进跨团队协作。",
+          "5 年以上：走向专家型负责人或管理型角色。"
+        ]
+      },
+      "fit_personality_codes_json": null,
+      "mbti_primary_codes_json": [
+        "INTJ",
+        "INTP",
+        "ENTJ"
+      ],
+      "mbti_secondary_codes_json": [
+        "ENTP",
+        "ISTJ",
+        "INFJ"
+      ],
+      "riasec_profile_json": {
+        "R": 55,
+        "I": 88,
+        "A": 48,
+        "S": 42,
+        "E": 50,
+        "C": 68
+      },
+      "big5_targets_json": {
+        "raw": {
+          "openness": {
+            "min": 40,
+            "max": 80
+          },
+          "conscientiousness": {
+            "min": 50,
+            "max": 90
+          },
+          "extraversion": {
+            "min": 35,
+            "max": 82
+          },
+          "agreeableness": {
+            "min": 35,
+            "max": 85
+          },
+          "neuroticism": {
+            "min": 10,
+            "max": 55
+          }
+        }
+      },
+      "iq_eq_notes_json": {
+        "iq_range": {
+          "min": 65,
+          "max": 100
+        },
+        "eq_range": {
+          "min": 45,
+          "max": 90
+        }
+      },
+      "market_demand_json": {
+        "raw": 92
+      },
+      "status": "published",
+      "is_public": true,
+      "is_indexable": true,
+      "published_at": null,
+      "scheduled_at": null,
+      "sort_order": 0,
+      "sections": [
+
+      ],
+      "seo_meta": {
+        "seo_title": null,
+        "seo_description": null,
+        "canonical_url": null,
+        "og_title": null,
+        "og_description": null,
+        "og_image_url": null,
+        "twitter_title": null,
+        "twitter_description": null,
+        "twitter_image_url": null,
+        "robots": null,
+        "jsonld_overrides_json": null
+      }
+    },
+    {
+      "job_code": "content-strategist",
+      "slug": "content-strategist",
+      "locale": "zh-CN",
+      "title": "内容策略师",
+      "subtitle": null,
+      "excerpt": "面向内容策略师的实用岗位画像，覆盖职责范围、能力要求、薪资区间与成长路径。",
+      "hero_kicker": null,
+      "hero_quote": null,
+      "cover_image_url": null,
+      "industry_slug": "media",
+      "industry_label": null,
+      "body_md": "# 内容策略师\n## 岗位概览\n内容策略师 是一个通过执行质量、沟通精度与持续学习能力持续放大职业价值的岗位。\n\n## 核心工作范围\n该岗位通过把目标拆解为可落地任务、推进跨团队协同，并持续优化流程质量来影响业务结果。\n\n## 职业发展建议\n建议按 90 天为周期跟踪交付指标、能力增长和协作影响，每季度做一次基于证据的职业复盘并调整成长策略。\n",
+      "body_html": null,
+      "salary_json": {
+        "raw": "人民币 18万 - 90万/年（视城市与资历而定）"
+      },
+      "outlook_json": {
+        "summary": "内容策略师 在数据化与精细化运营背景下仍保持较高需求。"
+      },
+      "skills_json": {
+        "core": [
+          "结构化问题解决",
+          "跨角色沟通",
+          "执行推进能力",
+          "数据驱动决策",
+          "持续学习能力"
+        ],
+        "supporting": [
+
+        ]
+      },
+      "work_contents_json": {
+        "items": [
+          "明确内容策略师核心职责与交付指标。",
+          "协同跨团队角色并统一执行优先级。",
+          "跟踪进度、风险与质量信号，保障结果稳定交付。"
+        ]
+      },
+      "growth_path_json": {
+        "raw": [
+          "0-2 年：建立基础执行能力与行业认知。",
+          "3-5 年：独立负责中等复杂度项目并推进跨团队协作。",
+          "5 年以上：走向专家型负责人或管理型角色。"
+        ]
+      },
+      "fit_personality_codes_json": null,
+      "mbti_primary_codes_json": [
+        "INFP",
+        "ENFP",
+        "ISFP"
+      ],
+      "mbti_secondary_codes_json": [
+        "INFJ",
+        "ENTP",
+        "ESFP"
+      ],
+      "riasec_profile_json": {
+        "R": 38,
+        "I": 62,
+        "A": 90,
+        "S": 54,
+        "E": 60,
+        "C": 44
+      },
+      "big5_targets_json": {
+        "raw": {
+          "openness": {
+            "min": 40,
+            "max": 80
+          },
+          "conscientiousness": {
+            "min": 50,
+            "max": 90
+          },
+          "extraversion": {
+            "min": 35,
+            "max": 82
+          },
+          "agreeableness": {
+            "min": 35,
+            "max": 85
+          },
+          "neuroticism": {
+            "min": 10,
+            "max": 55
+          }
+        }
+      },
+      "iq_eq_notes_json": {
+        "iq_range": {
+          "min": 45,
+          "max": 95
+        },
+        "eq_range": {
+          "min": 52,
+          "max": 96
+        }
+      },
+      "market_demand_json": {
+        "raw": 78
+      },
+      "status": "published",
+      "is_public": true,
+      "is_indexable": true,
+      "published_at": null,
+      "scheduled_at": null,
+      "sort_order": 0,
+      "sections": [
+
+      ],
+      "seo_meta": {
+        "seo_title": null,
+        "seo_description": null,
+        "canonical_url": null,
+        "og_title": null,
+        "og_description": null,
+        "og_image_url": null,
+        "twitter_title": null,
+        "twitter_description": null,
+        "twitter_image_url": null,
+        "robots": null,
+        "jsonld_overrides_json": null
+      }
+    },
+    {
+      "job_code": "cybersecurity-analyst",
+      "slug": "cybersecurity-analyst",
+      "locale": "zh-CN",
+      "title": "网络安全分析师",
+      "subtitle": null,
+      "excerpt": "面向网络安全分析师的实用岗位画像，覆盖职责范围、能力要求、薪资区间与成长路径。",
+      "hero_kicker": null,
+      "hero_quote": null,
+      "cover_image_url": null,
+      "industry_slug": "technology",
+      "industry_label": null,
+      "body_md": "# 网络安全分析师\n## 岗位概览\n网络安全分析师 是一个通过执行质量、沟通精度与持续学习能力持续放大职业价值的岗位。\n\n## 核心工作范围\n该岗位通过把目标拆解为可落地任务、推进跨团队协同，并持续优化流程质量来影响业务结果。\n\n## 职业发展建议\n建议按 90 天为周期跟踪交付指标、能力增长和协作影响，每季度做一次基于证据的职业复盘并调整成长策略。\n",
+      "body_html": null,
+      "salary_json": {
+        "raw": "人民币 18万 - 90万/年（视城市与资历而定）"
+      },
+      "outlook_json": {
+        "summary": "网络安全分析师 在数据化与精细化运营背景下仍保持较高需求。"
+      },
+      "skills_json": {
+        "core": [
+          "结构化问题解决",
+          "跨角色沟通",
+          "执行推进能力",
+          "数据驱动决策",
+          "持续学习能力"
+        ],
+        "supporting": [
+
+        ]
+      },
+      "work_contents_json": {
+        "items": [
+          "明确网络安全分析师核心职责与交付指标。",
+          "协同跨团队角色并统一执行优先级。",
+          "跟踪进度、风险与质量信号，保障结果稳定交付。"
+        ]
+      },
+      "growth_path_json": {
+        "raw": [
+          "0-2 年：建立基础执行能力与行业认知。",
+          "3-5 年：独立负责中等复杂度项目并推进跨团队协作。",
+          "5 年以上：走向专家型负责人或管理型角色。"
+        ]
+      },
+      "fit_personality_codes_json": null,
+      "mbti_primary_codes_json": [
+        "INTJ",
+        "INTP",
+        "ENTJ"
+      ],
+      "mbti_secondary_codes_json": [
+        "ENTP",
+        "ISTJ",
+        "INFJ"
+      ],
+      "riasec_profile_json": {
+        "R": 55,
+        "I": 88,
+        "A": 48,
+        "S": 42,
+        "E": 50,
+        "C": 68
+      },
+      "big5_targets_json": {
+        "raw": {
+          "openness": {
+            "min": 40,
+            "max": 80
+          },
+          "conscientiousness": {
+            "min": 50,
+            "max": 90
+          },
+          "extraversion": {
+            "min": 35,
+            "max": 82
+          },
+          "agreeableness": {
+            "min": 35,
+            "max": 85
+          },
+          "neuroticism": {
+            "min": 10,
+            "max": 55
+          }
+        }
+      },
+      "iq_eq_notes_json": {
+        "iq_range": {
+          "min": 65,
+          "max": 100
+        },
+        "eq_range": {
+          "min": 45,
+          "max": 90
+        }
+      },
+      "market_demand_json": {
+        "raw": 92
+      },
+      "status": "published",
+      "is_public": true,
+      "is_indexable": true,
+      "published_at": null,
+      "scheduled_at": null,
+      "sort_order": 0,
+      "sections": [
+
+      ],
+      "seo_meta": {
+        "seo_title": null,
+        "seo_description": null,
+        "canonical_url": null,
+        "og_title": null,
+        "og_description": null,
+        "og_image_url": null,
+        "twitter_title": null,
+        "twitter_description": null,
+        "twitter_image_url": null,
+        "robots": null,
+        "jsonld_overrides_json": null
+      }
+    },
+    {
+      "job_code": "data-analyst",
+      "slug": "data-analyst",
+      "locale": "zh-CN",
+      "title": "数据分析师",
+      "subtitle": null,
+      "excerpt": "面向数据分析师的实用岗位画像，覆盖职责范围、能力要求、薪资区间与成长路径。",
+      "hero_kicker": null,
+      "hero_quote": null,
+      "cover_image_url": null,
+      "industry_slug": "technology",
+      "industry_label": null,
+      "body_md": "# 数据分析师\n## 岗位概览\n数据分析师 是一个通过执行质量、沟通精度与持续学习能力持续放大职业价值的岗位。\n\n## 核心工作范围\n该岗位通过把目标拆解为可落地任务、推进跨团队协同，并持续优化流程质量来影响业务结果。\n\n## 职业发展建议\n建议按 90 天为周期跟踪交付指标、能力增长和协作影响，每季度做一次基于证据的职业复盘并调整成长策略。\n",
+      "body_html": null,
+      "salary_json": {
+        "raw": "人民币 18万 - 90万/年（视城市与资历而定）"
+      },
+      "outlook_json": {
+        "summary": "数据分析师 在数据化与精细化运营背景下仍保持较高需求。"
+      },
+      "skills_json": {
+        "core": [
+          "结构化问题解决",
+          "跨角色沟通",
+          "执行推进能力",
+          "数据驱动决策",
+          "持续学习能力"
+        ],
+        "supporting": [
+
+        ]
+      },
+      "work_contents_json": {
+        "items": [
+          "明确数据分析师核心职责与交付指标。",
+          "协同跨团队角色并统一执行优先级。",
+          "跟踪进度、风险与质量信号，保障结果稳定交付。"
+        ]
+      },
+      "growth_path_json": {
+        "raw": [
+          "0-2 年：建立基础执行能力与行业认知。",
+          "3-5 年：独立负责中等复杂度项目并推进跨团队协作。",
+          "5 年以上：走向专家型负责人或管理型角色。"
+        ]
+      },
+      "fit_personality_codes_json": null,
+      "mbti_primary_codes_json": [
+        "INTJ",
+        "INTP",
+        "ENTJ"
+      ],
+      "mbti_secondary_codes_json": [
+        "ENTP",
+        "ISTJ",
+        "INFJ"
+      ],
+      "riasec_profile_json": {
+        "R": 40,
+        "I": 90,
+        "A": 45,
+        "S": 38,
+        "E": 46,
+        "C": 72
+      },
+      "big5_targets_json": {
+        "raw": {
+          "openness": {
+            "min": 40,
+            "max": 80
+          },
+          "conscientiousness": {
+            "min": 50,
+            "max": 90
+          },
+          "extraversion": {
+            "min": 35,
+            "max": 82
+          },
+          "agreeableness": {
+            "min": 35,
+            "max": 85
+          },
+          "neuroticism": {
+            "min": 10,
+            "max": 55
+          }
+        }
+      },
+      "iq_eq_notes_json": {
+        "iq_range": {
+          "min": 62,
+          "max": 100
+        },
+        "eq_range": {
+          "min": 40,
+          "max": 86
+        }
+      },
+      "market_demand_json": {
+        "raw": 85
+      },
+      "status": "published",
+      "is_public": true,
+      "is_indexable": true,
+      "published_at": null,
+      "scheduled_at": null,
+      "sort_order": 0,
+      "sections": [
+
+      ],
+      "seo_meta": {
+        "seo_title": null,
+        "seo_description": null,
+        "canonical_url": null,
+        "og_title": null,
+        "og_description": null,
+        "og_image_url": null,
+        "twitter_title": null,
+        "twitter_description": null,
+        "twitter_image_url": null,
+        "robots": null,
+        "jsonld_overrides_json": null
+      }
+    },
+    {
+      "job_code": "data-scientist",
+      "slug": "data-scientist",
+      "locale": "zh-CN",
+      "title": "数据科学家",
+      "subtitle": null,
+      "excerpt": "面向数据科学家的实用岗位画像，覆盖职责范围、能力要求、薪资区间与成长路径。",
+      "hero_kicker": null,
+      "hero_quote": null,
+      "cover_image_url": null,
+      "industry_slug": "technology",
+      "industry_label": null,
+      "body_md": "# 数据科学家\n## 岗位概览\n数据科学家 是一个通过执行质量、沟通精度与持续学习能力持续放大职业价值的岗位。\n\n## 核心工作范围\n该岗位通过把目标拆解为可落地任务、推进跨团队协同，并持续优化流程质量来影响业务结果。\n\n## 职业发展建议\n建议按 90 天为周期跟踪交付指标、能力增长和协作影响，每季度做一次基于证据的职业复盘并调整成长策略。\n",
+      "body_html": null,
+      "salary_json": {
+        "raw": "人民币 18万 - 90万/年（视城市与资历而定）"
+      },
+      "outlook_json": {
+        "summary": "数据科学家 在数据化与精细化运营背景下仍保持较高需求。"
+      },
+      "skills_json": {
+        "core": [
+          "结构化问题解决",
+          "跨角色沟通",
+          "执行推进能力",
+          "数据驱动决策",
+          "持续学习能力"
+        ],
+        "supporting": [
+
+        ]
+      },
+      "work_contents_json": {
+        "items": [
+          "明确数据科学家核心职责与交付指标。",
+          "协同跨团队角色并统一执行优先级。",
+          "跟踪进度、风险与质量信号，保障结果稳定交付。"
+        ]
+      },
+      "growth_path_json": {
+        "raw": [
+          "0-2 年：建立基础执行能力与行业认知。",
+          "3-5 年：独立负责中等复杂度项目并推进跨团队协作。",
+          "5 年以上：走向专家型负责人或管理型角色。"
+        ]
+      },
+      "fit_personality_codes_json": null,
+      "mbti_primary_codes_json": [
+        "INTJ",
+        "INTP",
+        "ENTJ"
+      ],
+      "mbti_secondary_codes_json": [
+        "ENTP",
+        "ISTJ",
+        "INFJ"
+      ],
+      "riasec_profile_json": {
+        "R": 40,
+        "I": 90,
+        "A": 45,
+        "S": 38,
+        "E": 46,
+        "C": 72
+      },
+      "big5_targets_json": {
+        "raw": {
+          "openness": {
+            "min": 40,
+            "max": 80
+          },
+          "conscientiousness": {
+            "min": 50,
+            "max": 90
+          },
+          "extraversion": {
+            "min": 35,
+            "max": 82
+          },
+          "agreeableness": {
+            "min": 35,
+            "max": 85
+          },
+          "neuroticism": {
+            "min": 10,
+            "max": 55
+          }
+        }
+      },
+      "iq_eq_notes_json": {
+        "iq_range": {
+          "min": 62,
+          "max": 100
+        },
+        "eq_range": {
+          "min": 40,
+          "max": 86
+        }
+      },
+      "market_demand_json": {
+        "raw": 85
+      },
+      "status": "published",
+      "is_public": true,
+      "is_indexable": true,
+      "published_at": null,
+      "scheduled_at": null,
+      "sort_order": 0,
+      "sections": [
+
+      ],
+      "seo_meta": {
+        "seo_title": null,
+        "seo_description": null,
+        "canonical_url": null,
+        "og_title": null,
+        "og_description": null,
+        "og_image_url": null,
+        "twitter_title": null,
+        "twitter_description": null,
+        "twitter_image_url": null,
+        "robots": null,
+        "jsonld_overrides_json": null
+      }
+    },
+    {
+      "job_code": "digital-marketing-manager",
+      "slug": "digital-marketing-manager",
+      "locale": "zh-CN",
+      "title": "数字营销经理",
+      "subtitle": null,
+      "excerpt": "面向数字营销经理的实用岗位画像，覆盖职责范围、能力要求、薪资区间与成长路径。",
+      "hero_kicker": null,
+      "hero_quote": null,
+      "cover_image_url": null,
+      "industry_slug": "media",
+      "industry_label": null,
+      "body_md": "# 数字营销经理\n## 岗位概览\n数字营销经理 是一个通过执行质量、沟通精度与持续学习能力持续放大职业价值的岗位。\n\n## 核心工作范围\n该岗位通过把目标拆解为可落地任务、推进跨团队协同，并持续优化流程质量来影响业务结果。\n\n## 职业发展建议\n建议按 90 天为周期跟踪交付指标、能力增长和协作影响，每季度做一次基于证据的职业复盘并调整成长策略。\n",
+      "body_html": null,
+      "salary_json": {
+        "raw": "人民币 18万 - 90万/年（视城市与资历而定）"
+      },
+      "outlook_json": {
+        "summary": "数字营销经理 在数据化与精细化运营背景下仍保持较高需求。"
+      },
+      "skills_json": {
+        "core": [
+          "结构化问题解决",
+          "跨角色沟通",
+          "执行推进能力",
+          "数据驱动决策",
+          "持续学习能力"
+        ],
+        "supporting": [
+
+        ]
+      },
+      "work_contents_json": {
+        "items": [
+          "明确数字营销经理核心职责与交付指标。",
+          "协同跨团队角色并统一执行优先级。",
+          "跟踪进度、风险与质量信号，保障结果稳定交付。"
+        ]
+      },
+      "growth_path_json": {
+        "raw": [
+          "0-2 年：建立基础执行能力与行业认知。",
+          "3-5 年：独立负责中等复杂度项目并推进跨团队协作。",
+          "5 年以上：走向专家型负责人或管理型角色。"
+        ]
+      },
+      "fit_personality_codes_json": null,
+      "mbti_primary_codes_json": [
+        "ENTJ",
+        "ENFJ",
+        "ESTP"
+      ],
+      "mbti_secondary_codes_json": [
+        "ENFP",
+        "ESTJ",
+        "ENTP"
+      ],
+      "riasec_profile_json": {
+        "R": 42,
+        "I": 66,
+        "A": 56,
+        "S": 60,
+        "E": 88,
+        "C": 70
+      },
+      "big5_targets_json": {
+        "raw": {
+          "openness": {
+            "min": 40,
+            "max": 80
+          },
+          "conscientiousness": {
+            "min": 50,
+            "max": 90
+          },
+          "extraversion": {
+            "min": 35,
+            "max": 82
+          },
+          "agreeableness": {
+            "min": 35,
+            "max": 85
+          },
+          "neuroticism": {
+            "min": 10,
+            "max": 55
+          }
+        }
+      },
+      "iq_eq_notes_json": {
+        "iq_range": {
+          "min": 50,
+          "max": 98
+        },
+        "eq_range": {
+          "min": 55,
+          "max": 100
+        }
+      },
+      "market_demand_json": {
+        "raw": 82
+      },
+      "status": "published",
+      "is_public": true,
+      "is_indexable": true,
+      "published_at": null,
+      "scheduled_at": null,
+      "sort_order": 0,
+      "sections": [
+
+      ],
+      "seo_meta": {
+        "seo_title": null,
+        "seo_description": null,
+        "canonical_url": null,
+        "og_title": null,
+        "og_description": null,
+        "og_image_url": null,
+        "twitter_title": null,
+        "twitter_description": null,
+        "twitter_image_url": null,
+        "robots": null,
+        "jsonld_overrides_json": null
+      }
+    },
+    {
+      "job_code": "financial-planner",
+      "slug": "financial-planner",
+      "locale": "zh-CN",
+      "title": "财务规划师",
+      "subtitle": null,
+      "excerpt": "面向财务规划师的实用岗位画像，覆盖职责范围、能力要求、薪资区间与成长路径。",
+      "hero_kicker": null,
+      "hero_quote": null,
+      "cover_image_url": null,
+      "industry_slug": "finance",
+      "industry_label": null,
+      "body_md": "# 财务规划师\n## 岗位概览\n财务规划师 是一个通过执行质量、沟通精度与持续学习能力持续放大职业价值的岗位。\n\n## 核心工作范围\n该岗位通过把目标拆解为可落地任务、推进跨团队协同，并持续优化流程质量来影响业务结果。\n\n## 职业发展建议\n建议按 90 天为周期跟踪交付指标、能力增长和协作影响，每季度做一次基于证据的职业复盘并调整成长策略。\n",
+      "body_html": null,
+      "salary_json": {
+        "raw": "人民币 18万 - 90万/年（视城市与资历而定）"
+      },
+      "outlook_json": {
+        "summary": "财务规划师 在数据化与精细化运营背景下仍保持较高需求。"
+      },
+      "skills_json": {
+        "core": [
+          "结构化问题解决",
+          "跨角色沟通",
+          "执行推进能力",
+          "数据驱动决策",
+          "持续学习能力"
+        ],
+        "supporting": [
+
+        ]
+      },
+      "work_contents_json": {
+        "items": [
+          "明确财务规划师核心职责与交付指标。",
+          "协同跨团队角色并统一执行优先级。",
+          "跟踪进度、风险与质量信号，保障结果稳定交付。"
+        ]
+      },
+      "growth_path_json": {
+        "raw": [
+          "0-2 年：建立基础执行能力与行业认知。",
+          "3-5 年：独立负责中等复杂度项目并推进跨团队协作。",
+          "5 年以上：走向专家型负责人或管理型角色。"
+        ]
+      },
+      "fit_personality_codes_json": null,
+      "mbti_primary_codes_json": [
+        "ESTJ",
+        "ISTJ",
+        "ESFJ"
+      ],
+      "mbti_secondary_codes_json": [
+        "ISFJ",
+        "ENTJ",
+        "ESTP"
+      ],
+      "riasec_profile_json": {
+        "R": 52,
+        "I": 60,
+        "A": 36,
+        "S": 52,
+        "E": 70,
+        "C": 90
+      },
+      "big5_targets_json": {
+        "raw": {
+          "openness": {
+            "min": 40,
+            "max": 80
+          },
+          "conscientiousness": {
+            "min": 50,
+            "max": 90
+          },
+          "extraversion": {
+            "min": 35,
+            "max": 82
+          },
+          "agreeableness": {
+            "min": 35,
+            "max": 85
+          },
+          "neuroticism": {
+            "min": 10,
+            "max": 55
+          }
+        }
+      },
+      "iq_eq_notes_json": {
+        "iq_range": {
+          "min": 48,
+          "max": 95
+        },
+        "eq_range": {
+          "min": 48,
+          "max": 92
+        }
+      },
+      "market_demand_json": {
+        "raw": 74
+      },
+      "status": "published",
+      "is_public": true,
+      "is_indexable": true,
+      "published_at": null,
+      "scheduled_at": null,
+      "sort_order": 0,
+      "sections": [
+
+      ],
+      "seo_meta": {
+        "seo_title": null,
+        "seo_description": null,
+        "canonical_url": null,
+        "og_title": null,
+        "og_description": null,
+        "og_image_url": null,
+        "twitter_title": null,
+        "twitter_description": null,
+        "twitter_image_url": null,
+        "robots": null,
+        "jsonld_overrides_json": null
+      }
+    },
+    {
+      "job_code": "frontend-engineer",
+      "slug": "frontend-engineer",
+      "locale": "zh-CN",
+      "title": "前端工程师",
+      "subtitle": null,
+      "excerpt": "面向前端工程师的实用岗位画像，覆盖职责范围、能力要求、薪资区间与成长路径。",
+      "hero_kicker": null,
+      "hero_quote": null,
+      "cover_image_url": null,
+      "industry_slug": "technology",
+      "industry_label": null,
+      "body_md": "# 前端工程师\n## 岗位概览\n前端工程师 是一个通过执行质量、沟通精度与持续学习能力持续放大职业价值的岗位。\n\n## 核心工作范围\n该岗位通过把目标拆解为可落地任务、推进跨团队协同，并持续优化流程质量来影响业务结果。\n\n## 职业发展建议\n建议按 90 天为周期跟踪交付指标、能力增长和协作影响，每季度做一次基于证据的职业复盘并调整成长策略。\n",
+      "body_html": null,
+      "salary_json": {
+        "raw": "人民币 18万 - 90万/年（视城市与资历而定）"
+      },
+      "outlook_json": {
+        "summary": "前端工程师 在数据化与精细化运营背景下仍保持较高需求。"
+      },
+      "skills_json": {
+        "core": [
+          "结构化问题解决",
+          "跨角色沟通",
+          "执行推进能力",
+          "数据驱动决策",
+          "持续学习能力"
+        ],
+        "supporting": [
+
+        ]
+      },
+      "work_contents_json": {
+        "items": [
+          "明确前端工程师核心职责与交付指标。",
+          "协同跨团队角色并统一执行优先级。",
+          "跟踪进度、风险与质量信号，保障结果稳定交付。"
+        ]
+      },
+      "growth_path_json": {
+        "raw": [
+          "0-2 年：建立基础执行能力与行业认知。",
+          "3-5 年：独立负责中等复杂度项目并推进跨团队协作。",
+          "5 年以上：走向专家型负责人或管理型角色。"
+        ]
+      },
+      "fit_personality_codes_json": null,
+      "mbti_primary_codes_json": [
+        "INTJ",
+        "INTP",
+        "ENTJ"
+      ],
+      "mbti_secondary_codes_json": [
+        "ENTP",
+        "ISTJ",
+        "INFJ"
+      ],
+      "riasec_profile_json": {
+        "R": 55,
+        "I": 88,
+        "A": 48,
+        "S": 42,
+        "E": 50,
+        "C": 68
+      },
+      "big5_targets_json": {
+        "raw": {
+          "openness": {
+            "min": 40,
+            "max": 80
+          },
+          "conscientiousness": {
+            "min": 50,
+            "max": 90
+          },
+          "extraversion": {
+            "min": 35,
+            "max": 82
+          },
+          "agreeableness": {
+            "min": 35,
+            "max": 85
+          },
+          "neuroticism": {
+            "min": 10,
+            "max": 55
+          }
+        }
+      },
+      "iq_eq_notes_json": {
+        "iq_range": {
+          "min": 65,
+          "max": 100
+        },
+        "eq_range": {
+          "min": 45,
+          "max": 90
+        }
+      },
+      "market_demand_json": {
+        "raw": 92
+      },
+      "status": "published",
+      "is_public": true,
+      "is_indexable": true,
+      "published_at": null,
+      "scheduled_at": null,
+      "sort_order": 0,
+      "sections": [
+
+      ],
+      "seo_meta": {
+        "seo_title": null,
+        "seo_description": null,
+        "canonical_url": null,
+        "og_title": null,
+        "og_description": null,
+        "og_image_url": null,
+        "twitter_title": null,
+        "twitter_description": null,
+        "twitter_image_url": null,
+        "robots": null,
+        "jsonld_overrides_json": null
+      }
+    },
+    {
+      "job_code": "fullstack-engineer",
+      "slug": "fullstack-engineer",
+      "locale": "zh-CN",
+      "title": "全栈工程师",
+      "subtitle": null,
+      "excerpt": "面向全栈工程师的实用岗位画像，覆盖职责范围、能力要求、薪资区间与成长路径。",
+      "hero_kicker": null,
+      "hero_quote": null,
+      "cover_image_url": null,
+      "industry_slug": "technology",
+      "industry_label": null,
+      "body_md": "# 全栈工程师\n## 岗位概览\n全栈工程师 是一个通过执行质量、沟通精度与持续学习能力持续放大职业价值的岗位。\n\n## 核心工作范围\n该岗位通过把目标拆解为可落地任务、推进跨团队协同，并持续优化流程质量来影响业务结果。\n\n## 职业发展建议\n建议按 90 天为周期跟踪交付指标、能力增长和协作影响，每季度做一次基于证据的职业复盘并调整成长策略。\n",
+      "body_html": null,
+      "salary_json": {
+        "raw": "人民币 18万 - 90万/年（视城市与资历而定）"
+      },
+      "outlook_json": {
+        "summary": "全栈工程师 在数据化与精细化运营背景下仍保持较高需求。"
+      },
+      "skills_json": {
+        "core": [
+          "结构化问题解决",
+          "跨角色沟通",
+          "执行推进能力",
+          "数据驱动决策",
+          "持续学习能力"
+        ],
+        "supporting": [
+
+        ]
+      },
+      "work_contents_json": {
+        "items": [
+          "明确全栈工程师核心职责与交付指标。",
+          "协同跨团队角色并统一执行优先级。",
+          "跟踪进度、风险与质量信号，保障结果稳定交付。"
+        ]
+      },
+      "growth_path_json": {
+        "raw": [
+          "0-2 年：建立基础执行能力与行业认知。",
+          "3-5 年：独立负责中等复杂度项目并推进跨团队协作。",
+          "5 年以上：走向专家型负责人或管理型角色。"
+        ]
+      },
+      "fit_personality_codes_json": null,
+      "mbti_primary_codes_json": [
+        "INTJ",
+        "INTP",
+        "ENTJ"
+      ],
+      "mbti_secondary_codes_json": [
+        "ENTP",
+        "ISTJ",
+        "INFJ"
+      ],
+      "riasec_profile_json": {
+        "R": 55,
+        "I": 88,
+        "A": 48,
+        "S": 42,
+        "E": 50,
+        "C": 68
+      },
+      "big5_targets_json": {
+        "raw": {
+          "openness": {
+            "min": 40,
+            "max": 80
+          },
+          "conscientiousness": {
+            "min": 50,
+            "max": 90
+          },
+          "extraversion": {
+            "min": 35,
+            "max": 82
+          },
+          "agreeableness": {
+            "min": 35,
+            "max": 85
+          },
+          "neuroticism": {
+            "min": 10,
+            "max": 55
+          }
+        }
+      },
+      "iq_eq_notes_json": {
+        "iq_range": {
+          "min": 65,
+          "max": 100
+        },
+        "eq_range": {
+          "min": 45,
+          "max": 90
+        }
+      },
+      "market_demand_json": {
+        "raw": 92
+      },
+      "status": "published",
+      "is_public": true,
+      "is_indexable": true,
+      "published_at": null,
+      "scheduled_at": null,
+      "sort_order": 0,
+      "sections": [
+
+      ],
+      "seo_meta": {
+        "seo_title": null,
+        "seo_description": null,
+        "canonical_url": null,
+        "og_title": null,
+        "og_description": null,
+        "og_image_url": null,
+        "twitter_title": null,
+        "twitter_description": null,
+        "twitter_image_url": null,
+        "robots": null,
+        "jsonld_overrides_json": null
+      }
+    },
+    {
+      "job_code": "hr-business-partner",
+      "slug": "hr-business-partner",
+      "locale": "zh-CN",
+      "title": "HRBP",
+      "subtitle": null,
+      "excerpt": "面向HRBP的实用岗位画像，覆盖职责范围、能力要求、薪资区间与成长路径。",
+      "hero_kicker": null,
+      "hero_quote": null,
+      "cover_image_url": null,
+      "industry_slug": "business",
+      "industry_label": null,
+      "body_md": "# HRBP\n## 岗位概览\nHRBP 是一个通过执行质量、沟通精度与持续学习能力持续放大职业价值的岗位。\n\n## 核心工作范围\n该岗位通过把目标拆解为可落地任务、推进跨团队协同，并持续优化流程质量来影响业务结果。\n\n## 职业发展建议\n建议按 90 天为周期跟踪交付指标、能力增长和协作影响，每季度做一次基于证据的职业复盘并调整成长策略。\n",
+      "body_html": null,
+      "salary_json": {
+        "raw": "人民币 18万 - 90万/年（视城市与资历而定）"
+      },
+      "outlook_json": {
+        "summary": "HRBP 在数据化与精细化运营背景下仍保持较高需求。"
+      },
+      "skills_json": {
+        "core": [
+          "结构化问题解决",
+          "跨角色沟通",
+          "执行推进能力",
+          "数据驱动决策",
+          "持续学习能力"
+        ],
+        "supporting": [
+
+        ]
+      },
+      "work_contents_json": {
+        "items": [
+          "明确HRBP核心职责与交付指标。",
+          "协同跨团队角色并统一执行优先级。",
+          "跟踪进度、风险与质量信号，保障结果稳定交付。"
+        ]
+      },
+      "growth_path_json": {
+        "raw": [
+          "0-2 年：建立基础执行能力与行业认知。",
+          "3-5 年：独立负责中等复杂度项目并推进跨团队协作。",
+          "5 年以上：走向专家型负责人或管理型角色。"
+        ]
+      },
+      "fit_personality_codes_json": null,
+      "mbti_primary_codes_json": [
+        "ENTJ",
+        "ENFJ",
+        "ESTP"
+      ],
+      "mbti_secondary_codes_json": [
+        "ENFP",
+        "ESTJ",
+        "ENTP"
+      ],
+      "riasec_profile_json": {
+        "R": 42,
+        "I": 66,
+        "A": 56,
+        "S": 60,
+        "E": 88,
+        "C": 70
+      },
+      "big5_targets_json": {
+        "raw": {
+          "openness": {
+            "min": 40,
+            "max": 80
+          },
+          "conscientiousness": {
+            "min": 50,
+            "max": 90
+          },
+          "extraversion": {
+            "min": 35,
+            "max": 82
+          },
+          "agreeableness": {
+            "min": 35,
+            "max": 85
+          },
+          "neuroticism": {
+            "min": 10,
+            "max": 55
+          }
+        }
+      },
+      "iq_eq_notes_json": {
+        "iq_range": {
+          "min": 50,
+          "max": 98
+        },
+        "eq_range": {
+          "min": 55,
+          "max": 100
+        }
+      },
+      "market_demand_json": {
+        "raw": 82
+      },
+      "status": "published",
+      "is_public": true,
+      "is_indexable": true,
+      "published_at": null,
+      "scheduled_at": null,
+      "sort_order": 0,
+      "sections": [
+
+      ],
+      "seo_meta": {
+        "seo_title": null,
+        "seo_description": null,
+        "canonical_url": null,
+        "og_title": null,
+        "og_description": null,
+        "og_image_url": null,
+        "twitter_title": null,
+        "twitter_description": null,
+        "twitter_image_url": null,
+        "robots": null,
+        "jsonld_overrides_json": null
+      }
+    },
+    {
+      "job_code": "investment-analyst",
+      "slug": "investment-analyst",
+      "locale": "zh-CN",
+      "title": "投资分析师",
+      "subtitle": null,
+      "excerpt": "面向投资分析师的实用岗位画像，覆盖职责范围、能力要求、薪资区间与成长路径。",
+      "hero_kicker": null,
+      "hero_quote": null,
+      "cover_image_url": null,
+      "industry_slug": "finance",
+      "industry_label": null,
+      "body_md": "# 投资分析师\n## 岗位概览\n投资分析师 是一个通过执行质量、沟通精度与持续学习能力持续放大职业价值的岗位。\n\n## 核心工作范围\n该岗位通过把目标拆解为可落地任务、推进跨团队协同，并持续优化流程质量来影响业务结果。\n\n## 职业发展建议\n建议按 90 天为周期跟踪交付指标、能力增长和协作影响，每季度做一次基于证据的职业复盘并调整成长策略。\n",
+      "body_html": null,
+      "salary_json": {
+        "raw": "人民币 18万 - 90万/年（视城市与资历而定）"
+      },
+      "outlook_json": {
+        "summary": "投资分析师 在数据化与精细化运营背景下仍保持较高需求。"
+      },
+      "skills_json": {
+        "core": [
+          "结构化问题解决",
+          "跨角色沟通",
+          "执行推进能力",
+          "数据驱动决策",
+          "持续学习能力"
+        ],
+        "supporting": [
+
+        ]
+      },
+      "work_contents_json": {
+        "items": [
+          "明确投资分析师核心职责与交付指标。",
+          "协同跨团队角色并统一执行优先级。",
+          "跟踪进度、风险与质量信号，保障结果稳定交付。"
+        ]
+      },
+      "growth_path_json": {
+        "raw": [
+          "0-2 年：建立基础执行能力与行业认知。",
+          "3-5 年：独立负责中等复杂度项目并推进跨团队协作。",
+          "5 年以上：走向专家型负责人或管理型角色。"
+        ]
+      },
+      "fit_personality_codes_json": null,
+      "mbti_primary_codes_json": [
+        "INTJ",
+        "INTP",
+        "ENTJ"
+      ],
+      "mbti_secondary_codes_json": [
+        "ENTP",
+        "ISTJ",
+        "INFJ"
+      ],
+      "riasec_profile_json": {
+        "R": 40,
+        "I": 90,
+        "A": 45,
+        "S": 38,
+        "E": 46,
+        "C": 72
+      },
+      "big5_targets_json": {
+        "raw": {
+          "openness": {
+            "min": 40,
+            "max": 80
+          },
+          "conscientiousness": {
+            "min": 50,
+            "max": 90
+          },
+          "extraversion": {
+            "min": 35,
+            "max": 82
+          },
+          "agreeableness": {
+            "min": 35,
+            "max": 85
+          },
+          "neuroticism": {
+            "min": 10,
+            "max": 55
+          }
+        }
+      },
+      "iq_eq_notes_json": {
+        "iq_range": {
+          "min": 62,
+          "max": 100
+        },
+        "eq_range": {
+          "min": 40,
+          "max": 86
+        }
+      },
+      "market_demand_json": {
+        "raw": 85
+      },
+      "status": "published",
+      "is_public": true,
+      "is_indexable": true,
+      "published_at": null,
+      "scheduled_at": null,
+      "sort_order": 0,
+      "sections": [
+
+      ],
+      "seo_meta": {
+        "seo_title": null,
+        "seo_description": null,
+        "canonical_url": null,
+        "og_title": null,
+        "og_description": null,
+        "og_image_url": null,
+        "twitter_title": null,
+        "twitter_description": null,
+        "twitter_image_url": null,
+        "robots": null,
+        "jsonld_overrides_json": null
+      }
+    },
+    {
+      "job_code": "lawyer",
+      "slug": "lawyer",
+      "locale": "zh-CN",
+      "title": "律师",
+      "subtitle": null,
+      "excerpt": "面向律师的实用岗位画像，覆盖职责范围、能力要求、薪资区间与成长路径。",
+      "hero_kicker": null,
+      "hero_quote": null,
+      "cover_image_url": null,
+      "industry_slug": "legal",
+      "industry_label": null,
+      "body_md": "# 律师\n## 岗位概览\n律师 是一个通过执行质量、沟通精度与持续学习能力持续放大职业价值的岗位。\n\n## 核心工作范围\n该岗位通过把目标拆解为可落地任务、推进跨团队协同，并持续优化流程质量来影响业务结果。\n\n## 职业发展建议\n建议按 90 天为周期跟踪交付指标、能力增长和协作影响，每季度做一次基于证据的职业复盘并调整成长策略。\n",
+      "body_html": null,
+      "salary_json": {
+        "raw": "人民币 18万 - 90万/年（视城市与资历而定）"
+      },
+      "outlook_json": {
+        "summary": "律师 在数据化与精细化运营背景下仍保持较高需求。"
+      },
+      "skills_json": {
+        "core": [
+          "结构化问题解决",
+          "跨角色沟通",
+          "执行推进能力",
+          "数据驱动决策",
+          "持续学习能力"
+        ],
+        "supporting": [
+
+        ]
+      },
+      "work_contents_json": {
+        "items": [
+          "明确律师核心职责与交付指标。",
+          "协同跨团队角色并统一执行优先级。",
+          "跟踪进度、风险与质量信号，保障结果稳定交付。"
+        ]
+      },
+      "growth_path_json": {
+        "raw": [
+          "0-2 年：建立基础执行能力与行业认知。",
+          "3-5 年：独立负责中等复杂度项目并推进跨团队协作。",
+          "5 年以上：走向专家型负责人或管理型角色。"
+        ]
+      },
+      "fit_personality_codes_json": null,
+      "mbti_primary_codes_json": [
+        "ESTJ",
+        "ISTJ",
+        "ESFJ"
+      ],
+      "mbti_secondary_codes_json": [
+        "ISFJ",
+        "ENTJ",
+        "ESTP"
+      ],
+      "riasec_profile_json": {
+        "R": 33,
+        "I": 80,
+        "A": 40,
+        "S": 47,
+        "E": 52,
+        "C": 90
+      },
+      "big5_targets_json": {
+        "raw": {
+          "openness": {
+            "min": 40,
+            "max": 80
+          },
+          "conscientiousness": {
+            "min": 50,
+            "max": 90
+          },
+          "extraversion": {
+            "min": 35,
+            "max": 82
+          },
+          "agreeableness": {
+            "min": 35,
+            "max": 85
+          },
+          "neuroticism": {
+            "min": 10,
+            "max": 55
+          }
+        }
+      },
+      "iq_eq_notes_json": {
+        "iq_range": {
+          "min": 62,
+          "max": 100
+        },
+        "eq_range": {
+          "min": 52,
+          "max": 95
+        }
+      },
+      "market_demand_json": {
+        "raw": 70
+      },
+      "status": "published",
+      "is_public": true,
+      "is_indexable": true,
+      "published_at": null,
+      "scheduled_at": null,
+      "sort_order": 0,
+      "sections": [
+
+      ],
+      "seo_meta": {
+        "seo_title": null,
+        "seo_description": null,
+        "canonical_url": null,
+        "og_title": null,
+        "og_description": null,
+        "og_image_url": null,
+        "twitter_title": null,
+        "twitter_description": null,
+        "twitter_image_url": null,
+        "robots": null,
+        "jsonld_overrides_json": null
+      }
+    },
+    {
+      "job_code": "machine-learning-engineer",
+      "slug": "machine-learning-engineer",
+      "locale": "zh-CN",
+      "title": "机器学习工程师",
+      "subtitle": null,
+      "excerpt": "面向机器学习工程师的实用岗位画像，覆盖职责范围、能力要求、薪资区间与成长路径。",
+      "hero_kicker": null,
+      "hero_quote": null,
+      "cover_image_url": null,
+      "industry_slug": "technology",
+      "industry_label": null,
+      "body_md": "# 机器学习工程师\n## 岗位概览\n机器学习工程师 是一个通过执行质量、沟通精度与持续学习能力持续放大职业价值的岗位。\n\n## 核心工作范围\n该岗位通过把目标拆解为可落地任务、推进跨团队协同，并持续优化流程质量来影响业务结果。\n\n## 职业发展建议\n建议按 90 天为周期跟踪交付指标、能力增长和协作影响，每季度做一次基于证据的职业复盘并调整成长策略。\n",
+      "body_html": null,
+      "salary_json": {
+        "raw": "人民币 18万 - 90万/年（视城市与资历而定）"
+      },
+      "outlook_json": {
+        "summary": "机器学习工程师 在数据化与精细化运营背景下仍保持较高需求。"
+      },
+      "skills_json": {
+        "core": [
+          "结构化问题解决",
+          "跨角色沟通",
+          "执行推进能力",
+          "数据驱动决策",
+          "持续学习能力"
+        ],
+        "supporting": [
+
+        ]
+      },
+      "work_contents_json": {
+        "items": [
+          "明确机器学习工程师核心职责与交付指标。",
+          "协同跨团队角色并统一执行优先级。",
+          "跟踪进度、风险与质量信号，保障结果稳定交付。"
+        ]
+      },
+      "growth_path_json": {
+        "raw": [
+          "0-2 年：建立基础执行能力与行业认知。",
+          "3-5 年：独立负责中等复杂度项目并推进跨团队协作。",
+          "5 年以上：走向专家型负责人或管理型角色。"
+        ]
+      },
+      "fit_personality_codes_json": null,
+      "mbti_primary_codes_json": [
+        "INTJ",
+        "INTP",
+        "ENTJ"
+      ],
+      "mbti_secondary_codes_json": [
+        "ENTP",
+        "ISTJ",
+        "INFJ"
+      ],
+      "riasec_profile_json": {
+        "R": 55,
+        "I": 88,
+        "A": 48,
+        "S": 42,
+        "E": 50,
+        "C": 68
+      },
+      "big5_targets_json": {
+        "raw": {
+          "openness": {
+            "min": 40,
+            "max": 80
+          },
+          "conscientiousness": {
+            "min": 50,
+            "max": 90
+          },
+          "extraversion": {
+            "min": 35,
+            "max": 82
+          },
+          "agreeableness": {
+            "min": 35,
+            "max": 85
+          },
+          "neuroticism": {
+            "min": 10,
+            "max": 55
+          }
+        }
+      },
+      "iq_eq_notes_json": {
+        "iq_range": {
+          "min": 65,
+          "max": 100
+        },
+        "eq_range": {
+          "min": 45,
+          "max": 90
+        }
+      },
+      "market_demand_json": {
+        "raw": 92
+      },
+      "status": "published",
+      "is_public": true,
+      "is_indexable": true,
+      "published_at": null,
+      "scheduled_at": null,
+      "sort_order": 0,
+      "sections": [
+
+      ],
+      "seo_meta": {
+        "seo_title": null,
+        "seo_description": null,
+        "canonical_url": null,
+        "og_title": null,
+        "og_description": null,
+        "og_image_url": null,
+        "twitter_title": null,
+        "twitter_description": null,
+        "twitter_image_url": null,
+        "robots": null,
+        "jsonld_overrides_json": null
+      }
+    },
+    {
+      "job_code": "management-consultant",
+      "slug": "management-consultant",
+      "locale": "zh-CN",
+      "title": "管理咨询顾问",
+      "subtitle": null,
+      "excerpt": "面向管理咨询顾问的实用岗位画像，覆盖职责范围、能力要求、薪资区间与成长路径。",
+      "hero_kicker": null,
+      "hero_quote": null,
+      "cover_image_url": null,
+      "industry_slug": "consulting",
+      "industry_label": null,
+      "body_md": "# 管理咨询顾问\n## 岗位概览\n管理咨询顾问 是一个通过执行质量、沟通精度与持续学习能力持续放大职业价值的岗位。\n\n## 核心工作范围\n该岗位通过把目标拆解为可落地任务、推进跨团队协同，并持续优化流程质量来影响业务结果。\n\n## 职业发展建议\n建议按 90 天为周期跟踪交付指标、能力增长和协作影响，每季度做一次基于证据的职业复盘并调整成长策略。\n",
+      "body_html": null,
+      "salary_json": {
+        "raw": "人民币 18万 - 90万/年（视城市与资历而定）"
+      },
+      "outlook_json": {
+        "summary": "管理咨询顾问 在数据化与精细化运营背景下仍保持较高需求。"
+      },
+      "skills_json": {
+        "core": [
+          "结构化问题解决",
+          "跨角色沟通",
+          "执行推进能力",
+          "数据驱动决策",
+          "持续学习能力"
+        ],
+        "supporting": [
+
+        ]
+      },
+      "work_contents_json": {
+        "items": [
+          "明确管理咨询顾问核心职责与交付指标。",
+          "协同跨团队角色并统一执行优先级。",
+          "跟踪进度、风险与质量信号，保障结果稳定交付。"
+        ]
+      },
+      "growth_path_json": {
+        "raw": [
+          "0-2 年：建立基础执行能力与行业认知。",
+          "3-5 年：独立负责中等复杂度项目并推进跨团队协作。",
+          "5 年以上：走向专家型负责人或管理型角色。"
+        ]
+      },
+      "fit_personality_codes_json": null,
+      "mbti_primary_codes_json": [
+        "ENTJ",
+        "ENFJ",
+        "ESTP"
+      ],
+      "mbti_secondary_codes_json": [
+        "ENFP",
+        "ESTJ",
+        "ENTP"
+      ],
+      "riasec_profile_json": {
+        "R": 42,
+        "I": 66,
+        "A": 56,
+        "S": 60,
+        "E": 88,
+        "C": 70
+      },
+      "big5_targets_json": {
+        "raw": {
+          "openness": {
+            "min": 40,
+            "max": 80
+          },
+          "conscientiousness": {
+            "min": 50,
+            "max": 90
+          },
+          "extraversion": {
+            "min": 35,
+            "max": 82
+          },
+          "agreeableness": {
+            "min": 35,
+            "max": 85
+          },
+          "neuroticism": {
+            "min": 10,
+            "max": 55
+          }
+        }
+      },
+      "iq_eq_notes_json": {
+        "iq_range": {
+          "min": 50,
+          "max": 98
+        },
+        "eq_range": {
+          "min": 55,
+          "max": 100
+        }
+      },
+      "market_demand_json": {
+        "raw": 82
+      },
+      "status": "published",
+      "is_public": true,
+      "is_indexable": true,
+      "published_at": null,
+      "scheduled_at": null,
+      "sort_order": 0,
+      "sections": [
+
+      ],
+      "seo_meta": {
+        "seo_title": null,
+        "seo_description": null,
+        "canonical_url": null,
+        "og_title": null,
+        "og_description": null,
+        "og_image_url": null,
+        "twitter_title": null,
+        "twitter_description": null,
+        "twitter_image_url": null,
+        "robots": null,
+        "jsonld_overrides_json": null
+      }
+    },
+    {
+      "job_code": "nurse",
+      "slug": "nurse",
+      "locale": "zh-CN",
+      "title": "护士",
+      "subtitle": null,
+      "excerpt": "面向护士的实用岗位画像，覆盖职责范围、能力要求、薪资区间与成长路径。",
+      "hero_kicker": null,
+      "hero_quote": null,
+      "cover_image_url": null,
+      "industry_slug": "healthcare",
+      "industry_label": null,
+      "body_md": "# 护士\n## 岗位概览\n护士 是一个通过执行质量、沟通精度与持续学习能力持续放大职业价值的岗位。\n\n## 核心工作范围\n该岗位通过把目标拆解为可落地任务、推进跨团队协同，并持续优化流程质量来影响业务结果。\n\n## 职业发展建议\n建议按 90 天为周期跟踪交付指标、能力增长和协作影响，每季度做一次基于证据的职业复盘并调整成长策略。\n",
+      "body_html": null,
+      "salary_json": {
+        "raw": "人民币 18万 - 90万/年（视城市与资历而定）"
+      },
+      "outlook_json": {
+        "summary": "护士 在数据化与精细化运营背景下仍保持较高需求。"
+      },
+      "skills_json": {
+        "core": [
+          "结构化问题解决",
+          "跨角色沟通",
+          "执行推进能力",
+          "数据驱动决策",
+          "持续学习能力"
+        ],
+        "supporting": [
+
+        ]
+      },
+      "work_contents_json": {
+        "items": [
+          "明确护士核心职责与交付指标。",
+          "协同跨团队角色并统一执行优先级。",
+          "跟踪进度、风险与质量信号，保障结果稳定交付。"
+        ]
+      },
+      "growth_path_json": {
+        "raw": [
+          "0-2 年：建立基础执行能力与行业认知。",
+          "3-5 年：独立负责中等复杂度项目并推进跨团队协作。",
+          "5 年以上：走向专家型负责人或管理型角色。"
+        ]
+      },
+      "fit_personality_codes_json": null,
+      "mbti_primary_codes_json": [
+        "ENFJ",
+        "ISFJ",
+        "INFJ"
+      ],
+      "mbti_secondary_codes_json": [
+        "ESFJ",
+        "INFP",
+        "ENFP"
+      ],
+      "riasec_profile_json": {
+        "R": 48,
+        "I": 64,
+        "A": 42,
+        "S": 88,
+        "E": 54,
+        "C": 74
+      },
+      "big5_targets_json": {
+        "raw": {
+          "openness": {
+            "min": 40,
+            "max": 80
+          },
+          "conscientiousness": {
+            "min": 50,
+            "max": 90
+          },
+          "extraversion": {
+            "min": 35,
+            "max": 82
+          },
+          "agreeableness": {
+            "min": 35,
+            "max": 85
+          },
+          "neuroticism": {
+            "min": 10,
+            "max": 55
+          }
+        }
+      },
+      "iq_eq_notes_json": {
+        "iq_range": {
+          "min": 50,
+          "max": 100
+        },
+        "eq_range": {
+          "min": 60,
+          "max": 100
+        }
+      },
+      "market_demand_json": {
+        "raw": 86
+      },
+      "status": "published",
+      "is_public": true,
+      "is_indexable": true,
+      "published_at": null,
+      "scheduled_at": null,
+      "sort_order": 0,
+      "sections": [
+
+      ],
+      "seo_meta": {
+        "seo_title": null,
+        "seo_description": null,
+        "canonical_url": null,
+        "og_title": null,
+        "og_description": null,
+        "og_image_url": null,
+        "twitter_title": null,
+        "twitter_description": null,
+        "twitter_image_url": null,
+        "robots": null,
+        "jsonld_overrides_json": null
+      }
+    },
+    {
+      "job_code": "operations-manager",
+      "slug": "operations-manager",
+      "locale": "zh-CN",
+      "title": "运营经理",
+      "subtitle": null,
+      "excerpt": "面向运营经理的实用岗位画像，覆盖职责范围、能力要求、薪资区间与成长路径。",
+      "hero_kicker": null,
+      "hero_quote": null,
+      "cover_image_url": null,
+      "industry_slug": "operations",
+      "industry_label": null,
+      "body_md": "# 运营经理\n## 岗位概览\n运营经理 是一个通过执行质量、沟通精度与持续学习能力持续放大职业价值的岗位。\n\n## 核心工作范围\n该岗位通过把目标拆解为可落地任务、推进跨团队协同，并持续优化流程质量来影响业务结果。\n\n## 职业发展建议\n建议按 90 天为周期跟踪交付指标、能力增长和协作影响，每季度做一次基于证据的职业复盘并调整成长策略。\n",
+      "body_html": null,
+      "salary_json": {
+        "raw": "人民币 18万 - 90万/年（视城市与资历而定）"
+      },
+      "outlook_json": {
+        "summary": "运营经理 在数据化与精细化运营背景下仍保持较高需求。"
+      },
+      "skills_json": {
+        "core": [
+          "结构化问题解决",
+          "跨角色沟通",
+          "执行推进能力",
+          "数据驱动决策",
+          "持续学习能力"
+        ],
+        "supporting": [
+
+        ]
+      },
+      "work_contents_json": {
+        "items": [
+          "明确运营经理核心职责与交付指标。",
+          "协同跨团队角色并统一执行优先级。",
+          "跟踪进度、风险与质量信号，保障结果稳定交付。"
+        ]
+      },
+      "growth_path_json": {
+        "raw": [
+          "0-2 年：建立基础执行能力与行业认知。",
+          "3-5 年：独立负责中等复杂度项目并推进跨团队协作。",
+          "5 年以上：走向专家型负责人或管理型角色。"
+        ]
+      },
+      "fit_personality_codes_json": null,
+      "mbti_primary_codes_json": [
+        "ENTJ",
+        "ENFJ",
+        "ESTP"
+      ],
+      "mbti_secondary_codes_json": [
+        "ENFP",
+        "ESTJ",
+        "ENTP"
+      ],
+      "riasec_profile_json": {
+        "R": 42,
+        "I": 66,
+        "A": 56,
+        "S": 60,
+        "E": 88,
+        "C": 70
+      },
+      "big5_targets_json": {
+        "raw": {
+          "openness": {
+            "min": 40,
+            "max": 80
+          },
+          "conscientiousness": {
+            "min": 50,
+            "max": 90
+          },
+          "extraversion": {
+            "min": 35,
+            "max": 82
+          },
+          "agreeableness": {
+            "min": 35,
+            "max": 85
+          },
+          "neuroticism": {
+            "min": 10,
+            "max": 55
+          }
+        }
+      },
+      "iq_eq_notes_json": {
+        "iq_range": {
+          "min": 50,
+          "max": 98
+        },
+        "eq_range": {
+          "min": 55,
+          "max": 100
+        }
+      },
+      "market_demand_json": {
+        "raw": 82
+      },
+      "status": "published",
+      "is_public": true,
+      "is_indexable": true,
+      "published_at": null,
+      "scheduled_at": null,
+      "sort_order": 0,
+      "sections": [
+
+      ],
+      "seo_meta": {
+        "seo_title": null,
+        "seo_description": null,
+        "canonical_url": null,
+        "og_title": null,
+        "og_description": null,
+        "og_image_url": null,
+        "twitter_title": null,
+        "twitter_description": null,
+        "twitter_image_url": null,
+        "robots": null,
+        "jsonld_overrides_json": null
+      }
+    },
+    {
+      "job_code": "pharmacist",
+      "slug": "pharmacist",
+      "locale": "zh-CN",
+      "title": "药师",
+      "subtitle": null,
+      "excerpt": "面向药师的实用岗位画像，覆盖职责范围、能力要求、薪资区间与成长路径。",
+      "hero_kicker": null,
+      "hero_quote": null,
+      "cover_image_url": null,
+      "industry_slug": "healthcare",
+      "industry_label": null,
+      "body_md": "# 药师\n## 岗位概览\n药师 是一个通过执行质量、沟通精度与持续学习能力持续放大职业价值的岗位。\n\n## 核心工作范围\n该岗位通过把目标拆解为可落地任务、推进跨团队协同，并持续优化流程质量来影响业务结果。\n\n## 职业发展建议\n建议按 90 天为周期跟踪交付指标、能力增长和协作影响，每季度做一次基于证据的职业复盘并调整成长策略。\n",
+      "body_html": null,
+      "salary_json": {
+        "raw": "人民币 18万 - 90万/年（视城市与资历而定）"
+      },
+      "outlook_json": {
+        "summary": "药师 在数据化与精细化运营背景下仍保持较高需求。"
+      },
+      "skills_json": {
+        "core": [
+          "结构化问题解决",
+          "跨角色沟通",
+          "执行推进能力",
+          "数据驱动决策",
+          "持续学习能力"
+        ],
+        "supporting": [
+
+        ]
+      },
+      "work_contents_json": {
+        "items": [
+          "明确药师核心职责与交付指标。",
+          "协同跨团队角色并统一执行优先级。",
+          "跟踪进度、风险与质量信号，保障结果稳定交付。"
+        ]
+      },
+      "growth_path_json": {
+        "raw": [
+          "0-2 年：建立基础执行能力与行业认知。",
+          "3-5 年：独立负责中等复杂度项目并推进跨团队协作。",
+          "5 年以上：走向专家型负责人或管理型角色。"
+        ]
+      },
+      "fit_personality_codes_json": null,
+      "mbti_primary_codes_json": [
+        "ENFJ",
+        "ISFJ",
+        "INFJ"
+      ],
+      "mbti_secondary_codes_json": [
+        "ESFJ",
+        "INFP",
+        "ENFP"
+      ],
+      "riasec_profile_json": {
+        "R": 48,
+        "I": 64,
+        "A": 42,
+        "S": 88,
+        "E": 54,
+        "C": 74
+      },
+      "big5_targets_json": {
+        "raw": {
+          "openness": {
+            "min": 40,
+            "max": 80
+          },
+          "conscientiousness": {
+            "min": 50,
+            "max": 90
+          },
+          "extraversion": {
+            "min": 35,
+            "max": 82
+          },
+          "agreeableness": {
+            "min": 35,
+            "max": 85
+          },
+          "neuroticism": {
+            "min": 10,
+            "max": 55
+          }
+        }
+      },
+      "iq_eq_notes_json": {
+        "iq_range": {
+          "min": 50,
+          "max": 100
+        },
+        "eq_range": {
+          "min": 60,
+          "max": 100
+        }
+      },
+      "market_demand_json": {
+        "raw": 86
+      },
+      "status": "published",
+      "is_public": true,
+      "is_indexable": true,
+      "published_at": null,
+      "scheduled_at": null,
+      "sort_order": 0,
+      "sections": [
+
+      ],
+      "seo_meta": {
+        "seo_title": null,
+        "seo_description": null,
+        "canonical_url": null,
+        "og_title": null,
+        "og_description": null,
+        "og_image_url": null,
+        "twitter_title": null,
+        "twitter_description": null,
+        "twitter_image_url": null,
+        "robots": null,
+        "jsonld_overrides_json": null
+      }
+    },
+    {
+      "job_code": "physician",
+      "slug": "physician",
+      "locale": "zh-CN",
+      "title": "医生",
+      "subtitle": null,
+      "excerpt": "面向医生的实用岗位画像，覆盖职责范围、能力要求、薪资区间与成长路径。",
+      "hero_kicker": null,
+      "hero_quote": null,
+      "cover_image_url": null,
+      "industry_slug": "healthcare",
+      "industry_label": null,
+      "body_md": "# 医生\n## 岗位概览\n医生 是一个通过执行质量、沟通精度与持续学习能力持续放大职业价值的岗位。\n\n## 核心工作范围\n该岗位通过把目标拆解为可落地任务、推进跨团队协同，并持续优化流程质量来影响业务结果。\n\n## 职业发展建议\n建议按 90 天为周期跟踪交付指标、能力增长和协作影响，每季度做一次基于证据的职业复盘并调整成长策略。\n",
+      "body_html": null,
+      "salary_json": {
+        "raw": "人民币 18万 - 90万/年（视城市与资历而定）"
+      },
+      "outlook_json": {
+        "summary": "医生 在数据化与精细化运营背景下仍保持较高需求。"
+      },
+      "skills_json": {
+        "core": [
+          "结构化问题解决",
+          "跨角色沟通",
+          "执行推进能力",
+          "数据驱动决策",
+          "持续学习能力"
+        ],
+        "supporting": [
+
+        ]
+      },
+      "work_contents_json": {
+        "items": [
+          "明确医生核心职责与交付指标。",
+          "协同跨团队角色并统一执行优先级。",
+          "跟踪进度、风险与质量信号，保障结果稳定交付。"
+        ]
+      },
+      "growth_path_json": {
+        "raw": [
+          "0-2 年：建立基础执行能力与行业认知。",
+          "3-5 年：独立负责中等复杂度项目并推进跨团队协作。",
+          "5 年以上：走向专家型负责人或管理型角色。"
+        ]
+      },
+      "fit_personality_codes_json": null,
+      "mbti_primary_codes_json": [
+        "ENFJ",
+        "ISFJ",
+        "INFJ"
+      ],
+      "mbti_secondary_codes_json": [
+        "ESFJ",
+        "INFP",
+        "ENFP"
+      ],
+      "riasec_profile_json": {
+        "R": 48,
+        "I": 64,
+        "A": 42,
+        "S": 88,
+        "E": 54,
+        "C": 74
+      },
+      "big5_targets_json": {
+        "raw": {
+          "openness": {
+            "min": 40,
+            "max": 80
+          },
+          "conscientiousness": {
+            "min": 50,
+            "max": 90
+          },
+          "extraversion": {
+            "min": 35,
+            "max": 82
+          },
+          "agreeableness": {
+            "min": 35,
+            "max": 85
+          },
+          "neuroticism": {
+            "min": 10,
+            "max": 55
+          }
+        }
+      },
+      "iq_eq_notes_json": {
+        "iq_range": {
+          "min": 50,
+          "max": 100
+        },
+        "eq_range": {
+          "min": 60,
+          "max": 100
+        }
+      },
+      "market_demand_json": {
+        "raw": 86
+      },
+      "status": "published",
+      "is_public": true,
+      "is_indexable": true,
+      "published_at": null,
+      "scheduled_at": null,
+      "sort_order": 0,
+      "sections": [
+
+      ],
+      "seo_meta": {
+        "seo_title": null,
+        "seo_description": null,
+        "canonical_url": null,
+        "og_title": null,
+        "og_description": null,
+        "og_image_url": null,
+        "twitter_title": null,
+        "twitter_description": null,
+        "twitter_image_url": null,
+        "robots": null,
+        "jsonld_overrides_json": null
+      }
+    },
+    {
+      "job_code": "policy-analyst",
+      "slug": "policy-analyst",
+      "locale": "zh-CN",
+      "title": "政策分析师",
+      "subtitle": null,
+      "excerpt": "面向政策分析师的实用岗位画像，覆盖职责范围、能力要求、薪资区间与成长路径。",
+      "hero_kicker": null,
+      "hero_quote": null,
+      "cover_image_url": null,
+      "industry_slug": "public-service",
+      "industry_label": null,
+      "body_md": "# 政策分析师\n## 岗位概览\n政策分析师 是一个通过执行质量、沟通精度与持续学习能力持续放大职业价值的岗位。\n\n## 核心工作范围\n该岗位通过把目标拆解为可落地任务、推进跨团队协同，并持续优化流程质量来影响业务结果。\n\n## 职业发展建议\n建议按 90 天为周期跟踪交付指标、能力增长和协作影响，每季度做一次基于证据的职业复盘并调整成长策略。\n",
+      "body_html": null,
+      "salary_json": {
+        "raw": "人民币 18万 - 90万/年（视城市与资历而定）"
+      },
+      "outlook_json": {
+        "summary": "政策分析师 在数据化与精细化运营背景下仍保持较高需求。"
+      },
+      "skills_json": {
+        "core": [
+          "结构化问题解决",
+          "跨角色沟通",
+          "执行推进能力",
+          "数据驱动决策",
+          "持续学习能力"
+        ],
+        "supporting": [
+
+        ]
+      },
+      "work_contents_json": {
+        "items": [
+          "明确政策分析师核心职责与交付指标。",
+          "协同跨团队角色并统一执行优先级。",
+          "跟踪进度、风险与质量信号，保障结果稳定交付。"
+        ]
+      },
+      "growth_path_json": {
+        "raw": [
+          "0-2 年：建立基础执行能力与行业认知。",
+          "3-5 年：独立负责中等复杂度项目并推进跨团队协作。",
+          "5 年以上：走向专家型负责人或管理型角色。"
+        ]
+      },
+      "fit_personality_codes_json": null,
+      "mbti_primary_codes_json": [
+        "INTJ",
+        "INTP",
+        "ENTJ"
+      ],
+      "mbti_secondary_codes_json": [
+        "ENTP",
+        "ISTJ",
+        "INFJ"
+      ],
+      "riasec_profile_json": {
+        "R": 40,
+        "I": 90,
+        "A": 45,
+        "S": 38,
+        "E": 46,
+        "C": 72
+      },
+      "big5_targets_json": {
+        "raw": {
+          "openness": {
+            "min": 40,
+            "max": 80
+          },
+          "conscientiousness": {
+            "min": 50,
+            "max": 90
+          },
+          "extraversion": {
+            "min": 35,
+            "max": 82
+          },
+          "agreeableness": {
+            "min": 35,
+            "max": 85
+          },
+          "neuroticism": {
+            "min": 10,
+            "max": 55
+          }
+        }
+      },
+      "iq_eq_notes_json": {
+        "iq_range": {
+          "min": 62,
+          "max": 100
+        },
+        "eq_range": {
+          "min": 40,
+          "max": 86
+        }
+      },
+      "market_demand_json": {
+        "raw": 85
+      },
+      "status": "published",
+      "is_public": true,
+      "is_indexable": true,
+      "published_at": null,
+      "scheduled_at": null,
+      "sort_order": 0,
+      "sections": [
+
+      ],
+      "seo_meta": {
+        "seo_title": null,
+        "seo_description": null,
+        "canonical_url": null,
+        "og_title": null,
+        "og_description": null,
+        "og_image_url": null,
+        "twitter_title": null,
+        "twitter_description": null,
+        "twitter_image_url": null,
+        "robots": null,
+        "jsonld_overrides_json": null
+      }
+    },
+    {
+      "job_code": "product-manager",
+      "slug": "product-manager",
+      "locale": "zh-CN",
+      "title": "产品经理",
+      "subtitle": null,
+      "excerpt": "面向产品经理的实用岗位画像，覆盖职责范围、能力要求、薪资区间与成长路径。",
+      "hero_kicker": null,
+      "hero_quote": null,
+      "cover_image_url": null,
+      "industry_slug": "business",
+      "industry_label": null,
+      "body_md": "# 产品经理\n## 岗位概览\n产品经理 是一个通过执行质量、沟通精度与持续学习能力持续放大职业价值的岗位。\n\n## 核心工作范围\n该岗位通过把目标拆解为可落地任务、推进跨团队协同，并持续优化流程质量来影响业务结果。\n\n## 职业发展建议\n建议按 90 天为周期跟踪交付指标、能力增长和协作影响，每季度做一次基于证据的职业复盘并调整成长策略。\n",
+      "body_html": null,
+      "salary_json": {
+        "raw": "人民币 18万 - 90万/年（视城市与资历而定）"
+      },
+      "outlook_json": {
+        "summary": "产品经理 在数据化与精细化运营背景下仍保持较高需求。"
+      },
+      "skills_json": {
+        "core": [
+          "结构化问题解决",
+          "跨角色沟通",
+          "执行推进能力",
+          "数据驱动决策",
+          "持续学习能力"
+        ],
+        "supporting": [
+
+        ]
+      },
+      "work_contents_json": {
+        "items": [
+          "明确产品经理核心职责与交付指标。",
+          "协同跨团队角色并统一执行优先级。",
+          "跟踪进度、风险与质量信号，保障结果稳定交付。"
+        ]
+      },
+      "growth_path_json": {
+        "raw": [
+          "0-2 年：建立基础执行能力与行业认知。",
+          "3-5 年：独立负责中等复杂度项目并推进跨团队协作。",
+          "5 年以上：走向专家型负责人或管理型角色。"
+        ]
+      },
+      "fit_personality_codes_json": null,
+      "mbti_primary_codes_json": [
+        "ENTJ",
+        "ENFJ",
+        "ESTP"
+      ],
+      "mbti_secondary_codes_json": [
+        "ENFP",
+        "ESTJ",
+        "ENTP"
+      ],
+      "riasec_profile_json": {
+        "R": 42,
+        "I": 66,
+        "A": 56,
+        "S": 60,
+        "E": 88,
+        "C": 70
+      },
+      "big5_targets_json": {
+        "raw": {
+          "openness": {
+            "min": 40,
+            "max": 80
+          },
+          "conscientiousness": {
+            "min": 50,
+            "max": 90
+          },
+          "extraversion": {
+            "min": 35,
+            "max": 82
+          },
+          "agreeableness": {
+            "min": 35,
+            "max": 85
+          },
+          "neuroticism": {
+            "min": 10,
+            "max": 55
+          }
+        }
+      },
+      "iq_eq_notes_json": {
+        "iq_range": {
+          "min": 50,
+          "max": 98
+        },
+        "eq_range": {
+          "min": 55,
+          "max": 100
+        }
+      },
+      "market_demand_json": {
+        "raw": 82
+      },
+      "status": "published",
+      "is_public": true,
+      "is_indexable": true,
+      "published_at": null,
+      "scheduled_at": null,
+      "sort_order": 0,
+      "sections": [
+
+      ],
+      "seo_meta": {
+        "seo_title": null,
+        "seo_description": null,
+        "canonical_url": null,
+        "og_title": null,
+        "og_description": null,
+        "og_image_url": null,
+        "twitter_title": null,
+        "twitter_description": null,
+        "twitter_image_url": null,
+        "robots": null,
+        "jsonld_overrides_json": null
+      }
+    },
+    {
+      "job_code": "psychological-counselor",
+      "slug": "psychological-counselor",
+      "locale": "zh-CN",
+      "title": "心理咨询师",
+      "subtitle": null,
+      "excerpt": "面向心理咨询师的实用岗位画像，覆盖职责范围、能力要求、薪资区间与成长路径。",
+      "hero_kicker": null,
+      "hero_quote": null,
+      "cover_image_url": null,
+      "industry_slug": "healthcare",
+      "industry_label": null,
+      "body_md": "# 心理咨询师\n## 岗位概览\n心理咨询师 是一个通过执行质量、沟通精度与持续学习能力持续放大职业价值的岗位。\n\n## 核心工作范围\n该岗位通过把目标拆解为可落地任务、推进跨团队协同，并持续优化流程质量来影响业务结果。\n\n## 职业发展建议\n建议按 90 天为周期跟踪交付指标、能力增长和协作影响，每季度做一次基于证据的职业复盘并调整成长策略。\n",
+      "body_html": null,
+      "salary_json": {
+        "raw": "人民币 18万 - 90万/年（视城市与资历而定）"
+      },
+      "outlook_json": {
+        "summary": "心理咨询师 在数据化与精细化运营背景下仍保持较高需求。"
+      },
+      "skills_json": {
+        "core": [
+          "结构化问题解决",
+          "跨角色沟通",
+          "执行推进能力",
+          "数据驱动决策",
+          "持续学习能力"
+        ],
+        "supporting": [
+
+        ]
+      },
+      "work_contents_json": {
+        "items": [
+          "明确心理咨询师核心职责与交付指标。",
+          "协同跨团队角色并统一执行优先级。",
+          "跟踪进度、风险与质量信号，保障结果稳定交付。"
+        ]
+      },
+      "growth_path_json": {
+        "raw": [
+          "0-2 年：建立基础执行能力与行业认知。",
+          "3-5 年：独立负责中等复杂度项目并推进跨团队协作。",
+          "5 年以上：走向专家型负责人或管理型角色。"
+        ]
+      },
+      "fit_personality_codes_json": null,
+      "mbti_primary_codes_json": [
+        "ENFJ",
+        "ISFJ",
+        "INFJ"
+      ],
+      "mbti_secondary_codes_json": [
+        "ESFJ",
+        "INFP",
+        "ENFP"
+      ],
+      "riasec_profile_json": {
+        "R": 48,
+        "I": 64,
+        "A": 42,
+        "S": 88,
+        "E": 54,
+        "C": 74
+      },
+      "big5_targets_json": {
+        "raw": {
+          "openness": {
+            "min": 40,
+            "max": 80
+          },
+          "conscientiousness": {
+            "min": 50,
+            "max": 90
+          },
+          "extraversion": {
+            "min": 35,
+            "max": 82
+          },
+          "agreeableness": {
+            "min": 35,
+            "max": 85
+          },
+          "neuroticism": {
+            "min": 10,
+            "max": 55
+          }
+        }
+      },
+      "iq_eq_notes_json": {
+        "iq_range": {
+          "min": 50,
+          "max": 100
+        },
+        "eq_range": {
+          "min": 60,
+          "max": 100
+        }
+      },
+      "market_demand_json": {
+        "raw": 86
+      },
+      "status": "published",
+      "is_public": true,
+      "is_indexable": true,
+      "published_at": null,
+      "scheduled_at": null,
+      "sort_order": 0,
+      "sections": [
+
+      ],
+      "seo_meta": {
+        "seo_title": null,
+        "seo_description": null,
+        "canonical_url": null,
+        "og_title": null,
+        "og_description": null,
+        "og_image_url": null,
+        "twitter_title": null,
+        "twitter_description": null,
+        "twitter_image_url": null,
+        "robots": null,
+        "jsonld_overrides_json": null
+      }
+    },
+    {
+      "job_code": "researcher",
+      "slug": "researcher",
+      "locale": "zh-CN",
+      "title": "研究员",
+      "subtitle": null,
+      "excerpt": "面向研究员的实用岗位画像，覆盖职责范围、能力要求、薪资区间与成长路径。",
+      "hero_kicker": null,
+      "hero_quote": null,
+      "cover_image_url": null,
+      "industry_slug": "education",
+      "industry_label": null,
+      "body_md": "# 研究员\n## 岗位概览\n研究员 是一个通过执行质量、沟通精度与持续学习能力持续放大职业价值的岗位。\n\n## 核心工作范围\n该岗位通过把目标拆解为可落地任务、推进跨团队协同，并持续优化流程质量来影响业务结果。\n\n## 职业发展建议\n建议按 90 天为周期跟踪交付指标、能力增长和协作影响，每季度做一次基于证据的职业复盘并调整成长策略。\n",
+      "body_html": null,
+      "salary_json": {
+        "raw": "人民币 18万 - 90万/年（视城市与资历而定）"
+      },
+      "outlook_json": {
+        "summary": "研究员 在数据化与精细化运营背景下仍保持较高需求。"
+      },
+      "skills_json": {
+        "core": [
+          "结构化问题解决",
+          "跨角色沟通",
+          "执行推进能力",
+          "数据驱动决策",
+          "持续学习能力"
+        ],
+        "supporting": [
+
+        ]
+      },
+      "work_contents_json": {
+        "items": [
+          "明确研究员核心职责与交付指标。",
+          "协同跨团队角色并统一执行优先级。",
+          "跟踪进度、风险与质量信号，保障结果稳定交付。"
+        ]
+      },
+      "growth_path_json": {
+        "raw": [
+          "0-2 年：建立基础执行能力与行业认知。",
+          "3-5 年：独立负责中等复杂度项目并推进跨团队协作。",
+          "5 年以上：走向专家型负责人或管理型角色。"
+        ]
+      },
+      "fit_personality_codes_json": null,
+      "mbti_primary_codes_json": [
+        "INTJ",
+        "INTP",
+        "ENTJ"
+      ],
+      "mbti_secondary_codes_json": [
+        "ENTP",
+        "ISTJ",
+        "INFJ"
+      ],
+      "riasec_profile_json": {
+        "R": 40,
+        "I": 90,
+        "A": 45,
+        "S": 38,
+        "E": 46,
+        "C": 72
+      },
+      "big5_targets_json": {
+        "raw": {
+          "openness": {
+            "min": 40,
+            "max": 80
+          },
+          "conscientiousness": {
+            "min": 50,
+            "max": 90
+          },
+          "extraversion": {
+            "min": 35,
+            "max": 82
+          },
+          "agreeableness": {
+            "min": 35,
+            "max": 85
+          },
+          "neuroticism": {
+            "min": 10,
+            "max": 55
+          }
+        }
+      },
+      "iq_eq_notes_json": {
+        "iq_range": {
+          "min": 62,
+          "max": 100
+        },
+        "eq_range": {
+          "min": 40,
+          "max": 86
+        }
+      },
+      "market_demand_json": {
+        "raw": 85
+      },
+      "status": "published",
+      "is_public": true,
+      "is_indexable": true,
+      "published_at": null,
+      "scheduled_at": null,
+      "sort_order": 0,
+      "sections": [
+
+      ],
+      "seo_meta": {
+        "seo_title": null,
+        "seo_description": null,
+        "canonical_url": null,
+        "og_title": null,
+        "og_description": null,
+        "og_image_url": null,
+        "twitter_title": null,
+        "twitter_description": null,
+        "twitter_image_url": null,
+        "robots": null,
+        "jsonld_overrides_json": null
+      }
+    },
+    {
+      "job_code": "sales-manager",
+      "slug": "sales-manager",
+      "locale": "zh-CN",
+      "title": "销售经理",
+      "subtitle": null,
+      "excerpt": "面向销售经理的实用岗位画像，覆盖职责范围、能力要求、薪资区间与成长路径。",
+      "hero_kicker": null,
+      "hero_quote": null,
+      "cover_image_url": null,
+      "industry_slug": "business",
+      "industry_label": null,
+      "body_md": "# 销售经理\n## 岗位概览\n销售经理 是一个通过执行质量、沟通精度与持续学习能力持续放大职业价值的岗位。\n\n## 核心工作范围\n该岗位通过把目标拆解为可落地任务、推进跨团队协同，并持续优化流程质量来影响业务结果。\n\n## 职业发展建议\n建议按 90 天为周期跟踪交付指标、能力增长和协作影响，每季度做一次基于证据的职业复盘并调整成长策略。\n",
+      "body_html": null,
+      "salary_json": {
+        "raw": "人民币 18万 - 90万/年（视城市与资历而定）"
+      },
+      "outlook_json": {
+        "summary": "销售经理 在数据化与精细化运营背景下仍保持较高需求。"
+      },
+      "skills_json": {
+        "core": [
+          "结构化问题解决",
+          "跨角色沟通",
+          "执行推进能力",
+          "数据驱动决策",
+          "持续学习能力"
+        ],
+        "supporting": [
+
+        ]
+      },
+      "work_contents_json": {
+        "items": [
+          "明确销售经理核心职责与交付指标。",
+          "协同跨团队角色并统一执行优先级。",
+          "跟踪进度、风险与质量信号，保障结果稳定交付。"
+        ]
+      },
+      "growth_path_json": {
+        "raw": [
+          "0-2 年：建立基础执行能力与行业认知。",
+          "3-5 年：独立负责中等复杂度项目并推进跨团队协作。",
+          "5 年以上：走向专家型负责人或管理型角色。"
+        ]
+      },
+      "fit_personality_codes_json": null,
+      "mbti_primary_codes_json": [
+        "ENTJ",
+        "ENFJ",
+        "ESTP"
+      ],
+      "mbti_secondary_codes_json": [
+        "ENFP",
+        "ESTJ",
+        "ENTP"
+      ],
+      "riasec_profile_json": {
+        "R": 42,
+        "I": 66,
+        "A": 56,
+        "S": 60,
+        "E": 88,
+        "C": 70
+      },
+      "big5_targets_json": {
+        "raw": {
+          "openness": {
+            "min": 40,
+            "max": 80
+          },
+          "conscientiousness": {
+            "min": 50,
+            "max": 90
+          },
+          "extraversion": {
+            "min": 35,
+            "max": 82
+          },
+          "agreeableness": {
+            "min": 35,
+            "max": 85
+          },
+          "neuroticism": {
+            "min": 10,
+            "max": 55
+          }
+        }
+      },
+      "iq_eq_notes_json": {
+        "iq_range": {
+          "min": 50,
+          "max": 98
+        },
+        "eq_range": {
+          "min": 55,
+          "max": 100
+        }
+      },
+      "market_demand_json": {
+        "raw": 82
+      },
+      "status": "published",
+      "is_public": true,
+      "is_indexable": true,
+      "published_at": null,
+      "scheduled_at": null,
+      "sort_order": 0,
+      "sections": [
+
+      ],
+      "seo_meta": {
+        "seo_title": null,
+        "seo_description": null,
+        "canonical_url": null,
+        "og_title": null,
+        "og_description": null,
+        "og_image_url": null,
+        "twitter_title": null,
+        "twitter_description": null,
+        "twitter_image_url": null,
+        "robots": null,
+        "jsonld_overrides_json": null
+      }
+    },
+    {
+      "job_code": "software-engineer",
+      "slug": "software-engineer",
+      "locale": "zh-CN",
+      "title": "软件工程师",
+      "subtitle": null,
+      "excerpt": "面向软件工程师的实用岗位画像，覆盖职责范围、能力要求、薪资区间与成长路径。",
+      "hero_kicker": null,
+      "hero_quote": null,
+      "cover_image_url": null,
+      "industry_slug": "technology",
+      "industry_label": null,
+      "body_md": "# 软件工程师\n## 岗位概览\n软件工程师 是一个通过执行质量、沟通精度与持续学习能力持续放大职业价值的岗位。\n\n## 核心工作范围\n该岗位通过把目标拆解为可落地任务、推进跨团队协同，并持续优化流程质量来影响业务结果。\n\n## 职业发展建议\n建议按 90 天为周期跟踪交付指标、能力增长和协作影响，每季度做一次基于证据的职业复盘并调整成长策略。\n",
+      "body_html": null,
+      "salary_json": {
+        "raw": "人民币 18万 - 90万/年（视城市与资历而定）"
+      },
+      "outlook_json": {
+        "summary": "软件工程师 在数据化与精细化运营背景下仍保持较高需求。"
+      },
+      "skills_json": {
+        "core": [
+          "结构化问题解决",
+          "跨角色沟通",
+          "执行推进能力",
+          "数据驱动决策",
+          "持续学习能力"
+        ],
+        "supporting": [
+
+        ]
+      },
+      "work_contents_json": {
+        "items": [
+          "明确软件工程师核心职责与交付指标。",
+          "协同跨团队角色并统一执行优先级。",
+          "跟踪进度、风险与质量信号，保障结果稳定交付。"
+        ]
+      },
+      "growth_path_json": {
+        "raw": [
+          "0-2 年：建立基础执行能力与行业认知。",
+          "3-5 年：独立负责中等复杂度项目并推进跨团队协作。",
+          "5 年以上：走向专家型负责人或管理型角色。"
+        ]
+      },
+      "fit_personality_codes_json": null,
+      "mbti_primary_codes_json": [
+        "INTJ",
+        "INTP",
+        "ENTJ"
+      ],
+      "mbti_secondary_codes_json": [
+        "ENTP",
+        "ISTJ",
+        "INFJ"
+      ],
+      "riasec_profile_json": {
+        "R": 55,
+        "I": 88,
+        "A": 48,
+        "S": 42,
+        "E": 50,
+        "C": 68
+      },
+      "big5_targets_json": {
+        "raw": {
+          "openness": {
+            "min": 40,
+            "max": 80
+          },
+          "conscientiousness": {
+            "min": 50,
+            "max": 90
+          },
+          "extraversion": {
+            "min": 35,
+            "max": 82
+          },
+          "agreeableness": {
+            "min": 35,
+            "max": 85
+          },
+          "neuroticism": {
+            "min": 10,
+            "max": 55
+          }
+        }
+      },
+      "iq_eq_notes_json": {
+        "iq_range": {
+          "min": 65,
+          "max": 100
+        },
+        "eq_range": {
+          "min": 45,
+          "max": 90
+        }
+      },
+      "market_demand_json": {
+        "raw": 92
+      },
+      "status": "published",
+      "is_public": true,
+      "is_indexable": true,
+      "published_at": null,
+      "scheduled_at": null,
+      "sort_order": 0,
+      "sections": [
+
+      ],
+      "seo_meta": {
+        "seo_title": null,
+        "seo_description": null,
+        "canonical_url": null,
+        "og_title": null,
+        "og_description": null,
+        "og_image_url": null,
+        "twitter_title": null,
+        "twitter_description": null,
+        "twitter_image_url": null,
+        "robots": null,
+        "jsonld_overrides_json": null
+      }
+    },
+    {
+      "job_code": "supply-chain-manager",
+      "slug": "supply-chain-manager",
+      "locale": "zh-CN",
+      "title": "供应链经理",
+      "subtitle": null,
+      "excerpt": "面向供应链经理的实用岗位画像，覆盖职责范围、能力要求、薪资区间与成长路径。",
+      "hero_kicker": null,
+      "hero_quote": null,
+      "cover_image_url": null,
+      "industry_slug": "operations",
+      "industry_label": null,
+      "body_md": "# 供应链经理\n## 岗位概览\n供应链经理 是一个通过执行质量、沟通精度与持续学习能力持续放大职业价值的岗位。\n\n## 核心工作范围\n该岗位通过把目标拆解为可落地任务、推进跨团队协同，并持续优化流程质量来影响业务结果。\n\n## 职业发展建议\n建议按 90 天为周期跟踪交付指标、能力增长和协作影响，每季度做一次基于证据的职业复盘并调整成长策略。\n",
+      "body_html": null,
+      "salary_json": {
+        "raw": "人民币 18万 - 90万/年（视城市与资历而定）"
+      },
+      "outlook_json": {
+        "summary": "供应链经理 在数据化与精细化运营背景下仍保持较高需求。"
+      },
+      "skills_json": {
+        "core": [
+          "结构化问题解决",
+          "跨角色沟通",
+          "执行推进能力",
+          "数据驱动决策",
+          "持续学习能力"
+        ],
+        "supporting": [
+
+        ]
+      },
+      "work_contents_json": {
+        "items": [
+          "明确供应链经理核心职责与交付指标。",
+          "协同跨团队角色并统一执行优先级。",
+          "跟踪进度、风险与质量信号，保障结果稳定交付。"
+        ]
+      },
+      "growth_path_json": {
+        "raw": [
+          "0-2 年：建立基础执行能力与行业认知。",
+          "3-5 年：独立负责中等复杂度项目并推进跨团队协作。",
+          "5 年以上：走向专家型负责人或管理型角色。"
+        ]
+      },
+      "fit_personality_codes_json": null,
+      "mbti_primary_codes_json": [
+        "ENTJ",
+        "ENFJ",
+        "ESTP"
+      ],
+      "mbti_secondary_codes_json": [
+        "ENFP",
+        "ESTJ",
+        "ENTP"
+      ],
+      "riasec_profile_json": {
+        "R": 42,
+        "I": 66,
+        "A": 56,
+        "S": 60,
+        "E": 88,
+        "C": 70
+      },
+      "big5_targets_json": {
+        "raw": {
+          "openness": {
+            "min": 40,
+            "max": 80
+          },
+          "conscientiousness": {
+            "min": 50,
+            "max": 90
+          },
+          "extraversion": {
+            "min": 35,
+            "max": 82
+          },
+          "agreeableness": {
+            "min": 35,
+            "max": 85
+          },
+          "neuroticism": {
+            "min": 10,
+            "max": 55
+          }
+        }
+      },
+      "iq_eq_notes_json": {
+        "iq_range": {
+          "min": 50,
+          "max": 98
+        },
+        "eq_range": {
+          "min": 55,
+          "max": 100
+        }
+      },
+      "market_demand_json": {
+        "raw": 82
+      },
+      "status": "published",
+      "is_public": true,
+      "is_indexable": true,
+      "published_at": null,
+      "scheduled_at": null,
+      "sort_order": 0,
+      "sections": [
+
+      ],
+      "seo_meta": {
+        "seo_title": null,
+        "seo_description": null,
+        "canonical_url": null,
+        "og_title": null,
+        "og_description": null,
+        "og_image_url": null,
+        "twitter_title": null,
+        "twitter_description": null,
+        "twitter_image_url": null,
+        "robots": null,
+        "jsonld_overrides_json": null
+      }
+    },
+    {
+      "job_code": "teacher",
+      "slug": "teacher",
+      "locale": "zh-CN",
+      "title": "教师",
+      "subtitle": null,
+      "excerpt": "面向教师的实用岗位画像，覆盖职责范围、能力要求、薪资区间与成长路径。",
+      "hero_kicker": null,
+      "hero_quote": null,
+      "cover_image_url": null,
+      "industry_slug": "education",
+      "industry_label": null,
+      "body_md": "# 教师\n## 岗位概览\n教师 是一个通过执行质量、沟通精度与持续学习能力持续放大职业价值的岗位。\n\n## 核心工作范围\n该岗位通过把目标拆解为可落地任务、推进跨团队协同，并持续优化流程质量来影响业务结果。\n\n## 职业发展建议\n建议按 90 天为周期跟踪交付指标、能力增长和协作影响，每季度做一次基于证据的职业复盘并调整成长策略。\n",
+      "body_html": null,
+      "salary_json": {
+        "raw": "人民币 18万 - 90万/年（视城市与资历而定）"
+      },
+      "outlook_json": {
+        "summary": "教师 在数据化与精细化运营背景下仍保持较高需求。"
+      },
+      "skills_json": {
+        "core": [
+          "结构化问题解决",
+          "跨角色沟通",
+          "执行推进能力",
+          "数据驱动决策",
+          "持续学习能力"
+        ],
+        "supporting": [
+
+        ]
+      },
+      "work_contents_json": {
+        "items": [
+          "明确教师核心职责与交付指标。",
+          "协同跨团队角色并统一执行优先级。",
+          "跟踪进度、风险与质量信号，保障结果稳定交付。"
+        ]
+      },
+      "growth_path_json": {
+        "raw": [
+          "0-2 年：建立基础执行能力与行业认知。",
+          "3-5 年：独立负责中等复杂度项目并推进跨团队协作。",
+          "5 年以上：走向专家型负责人或管理型角色。"
+        ]
+      },
+      "fit_personality_codes_json": null,
+      "mbti_primary_codes_json": [
+        "ENFJ",
+        "ISFJ",
+        "INFJ"
+      ],
+      "mbti_secondary_codes_json": [
+        "ESFJ",
+        "INFP",
+        "ENFP"
+      ],
+      "riasec_profile_json": {
+        "R": 48,
+        "I": 64,
+        "A": 42,
+        "S": 88,
+        "E": 54,
+        "C": 74
+      },
+      "big5_targets_json": {
+        "raw": {
+          "openness": {
+            "min": 40,
+            "max": 80
+          },
+          "conscientiousness": {
+            "min": 50,
+            "max": 90
+          },
+          "extraversion": {
+            "min": 35,
+            "max": 82
+          },
+          "agreeableness": {
+            "min": 35,
+            "max": 85
+          },
+          "neuroticism": {
+            "min": 10,
+            "max": 55
+          }
+        }
+      },
+      "iq_eq_notes_json": {
+        "iq_range": {
+          "min": 50,
+          "max": 100
+        },
+        "eq_range": {
+          "min": 60,
+          "max": 100
+        }
+      },
+      "market_demand_json": {
+        "raw": 86
+      },
+      "status": "published",
+      "is_public": true,
+      "is_indexable": true,
+      "published_at": null,
+      "scheduled_at": null,
+      "sort_order": 0,
+      "sections": [
+
+      ],
+      "seo_meta": {
+        "seo_title": null,
+        "seo_description": null,
+        "canonical_url": null,
+        "og_title": null,
+        "og_description": null,
+        "og_image_url": null,
+        "twitter_title": null,
+        "twitter_description": null,
+        "twitter_image_url": null,
+        "robots": null,
+        "jsonld_overrides_json": null
+      }
+    },
+    {
+      "job_code": "ui-ux-designer",
+      "slug": "ui-ux-designer",
+      "locale": "zh-CN",
+      "title": "UI/UX 设计师",
+      "subtitle": null,
+      "excerpt": "面向UI/UX 设计师的实用岗位画像，覆盖职责范围、能力要求、薪资区间与成长路径。",
+      "hero_kicker": null,
+      "hero_quote": null,
+      "cover_image_url": null,
+      "industry_slug": "design",
+      "industry_label": null,
+      "body_md": "# UI/UX 设计师\n## 岗位概览\nUI/UX 设计师 是一个通过执行质量、沟通精度与持续学习能力持续放大职业价值的岗位。\n\n## 核心工作范围\n该岗位通过把目标拆解为可落地任务、推进跨团队协同，并持续优化流程质量来影响业务结果。\n\n## 职业发展建议\n建议按 90 天为周期跟踪交付指标、能力增长和协作影响，每季度做一次基于证据的职业复盘并调整成长策略。\n",
+      "body_html": null,
+      "salary_json": {
+        "raw": "人民币 18万 - 90万/年（视城市与资历而定）"
+      },
+      "outlook_json": {
+        "summary": "UI/UX 设计师 在数据化与精细化运营背景下仍保持较高需求。"
+      },
+      "skills_json": {
+        "core": [
+          "结构化问题解决",
+          "跨角色沟通",
+          "执行推进能力",
+          "数据驱动决策",
+          "持续学习能力"
+        ],
+        "supporting": [
+
+        ]
+      },
+      "work_contents_json": {
+        "items": [
+          "明确UI/UX 设计师核心职责与交付指标。",
+          "协同跨团队角色并统一执行优先级。",
+          "跟踪进度、风险与质量信号，保障结果稳定交付。"
+        ]
+      },
+      "growth_path_json": {
+        "raw": [
+          "0-2 年：建立基础执行能力与行业认知。",
+          "3-5 年：独立负责中等复杂度项目并推进跨团队协作。",
+          "5 年以上：走向专家型负责人或管理型角色。"
+        ]
+      },
+      "fit_personality_codes_json": null,
+      "mbti_primary_codes_json": [
+        "INFP",
+        "ENFP",
+        "ISFP"
+      ],
+      "mbti_secondary_codes_json": [
+        "INFJ",
+        "ENTP",
+        "ESFP"
+      ],
+      "riasec_profile_json": {
+        "R": 38,
+        "I": 62,
+        "A": 90,
+        "S": 54,
+        "E": 60,
+        "C": 44
+      },
+      "big5_targets_json": {
+        "raw": {
+          "openness": {
+            "min": 40,
+            "max": 80
+          },
+          "conscientiousness": {
+            "min": 50,
+            "max": 90
+          },
+          "extraversion": {
+            "min": 35,
+            "max": 82
+          },
+          "agreeableness": {
+            "min": 35,
+            "max": 85
+          },
+          "neuroticism": {
+            "min": 10,
+            "max": 55
+          }
+        }
+      },
+      "iq_eq_notes_json": {
+        "iq_range": {
+          "min": 45,
+          "max": 95
+        },
+        "eq_range": {
+          "min": 52,
+          "max": 96
+        }
+      },
+      "market_demand_json": {
+        "raw": 78
+      },
+      "status": "published",
+      "is_public": true,
+      "is_indexable": true,
+      "published_at": null,
+      "scheduled_at": null,
+      "sort_order": 0,
+      "sections": [
+
+      ],
+      "seo_meta": {
+        "seo_title": null,
+        "seo_description": null,
+        "canonical_url": null,
+        "og_title": null,
+        "og_description": null,
+        "og_image_url": null,
+        "twitter_title": null,
+        "twitter_description": null,
+        "twitter_image_url": null,
+        "robots": null,
+        "jsonld_overrides_json": null
+      }
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- add configurable report snapshot queue binding in `backend/config/fap.php`
- switch `GenerateReportSnapshotJob` to read `fap.queue.report_connection` and `fap.queue.report_queue` instead of hard-coded `database_reports/reports`
- keep defaults unchanged and add focused unit tests for default binding and env override binding

## Scope
- only changes `backend/config/fap.php` and `backend/app/Jobs/GenerateReportSnapshotJob.php` in production code
- does not change controller, migration, report/pdf jobs, frontend, COS, DNS, or CORS

## Deploy Notes
- to reuse the existing production worker `queue:work redis`, set:
  - `FAP_REPORT_QUEUE_CONNECTION=redis`
  - `FAP_REPORT_QUEUE=default`
- if env is not set, behavior remains `database_reports/reports`

## Tests Ran
- `cd backend && php artisan test --filter="GenerateReportSnapshotJobTest|ProcessAttemptSubmissionJobTest"`
- `cd backend && php artisan route:list --path=api/v0.3/attempts`
- `cd backend && php artisan migrate`
