### PR TITLE
feat(career-cms): add career job urls to backend sitemap authority

### DIFF
--- a/backend/app/Services/SEO/SitemapGenerator.php
+++ b/backend/app/Services/SEO/SitemapGenerator.php
@@ -2,8 +2,10 @@
 
 namespace App\Services\SEO;
 
+use App\Models\CareerJob;
 use App\Models\PersonalityProfile;
 use App\Models\TopicProfile;
+use App\Services\Cms\CareerJobSeoService;
 use App\Services\Cms\PersonalityProfileSeoService;
 use App\Services\Cms\TopicProfileSeoService;
 use Illuminate\Support\Carbon;
@@ -14,6 +16,7 @@ class SitemapGenerator
     private string $urlPrefix;
 
     public function __construct(
+        private readonly CareerJobSeoService $careerJobSeoService,
         private readonly PersonalityProfileSeoService $personalityProfileSeoService,
         private readonly TopicProfileSeoService $topicProfileSeoService,
     ) {
@@ -32,6 +35,7 @@ class SitemapGenerator
         $urls = array_merge(
             $this->getScaleUrls($locale),
             $this->getArticleUrls($locale),
+            $this->getCareerJobUrls(),
             $this->getPersonalityUrls(),
             $this->getTopicUrls()
         );
@@ -226,6 +230,112 @@ class SitemapGenerator
         }
 
         return $urls;
+    }
+
+    private function getCareerJobUrls(): array
+    {
+        return array_merge(
+            $this->getCareerJobListUrls(),
+            $this->getCareerJobDetailUrls()
+        );
+    }
+
+    private function getCareerJobListUrls(): array
+    {
+        $baseUrl = rtrim((string) config('app.frontend_url', config('app.url', '')), '/');
+        if ($baseUrl === '') {
+            return [];
+        }
+
+        $rows = CareerJob::query()
+            ->withoutGlobalScopes()
+            ->where('org_id', 0)
+            ->where('status', CareerJob::STATUS_PUBLISHED)
+            ->where('is_public', true)
+            ->where('is_indexable', true)
+            ->whereIn('locale', CareerJob::SUPPORTED_LOCALES)
+            ->where(static function ($query): void {
+                $query->whereNull('published_at')
+                    ->orWhere('published_at', '<=', now());
+            })
+            ->select(['locale', 'updated_at', 'published_at'])
+            ->orderBy('locale')
+            ->get();
+
+        $listLastModified = [];
+
+        foreach ($rows as $row) {
+            $locale = trim((string) $row->locale);
+            if ($locale === '') {
+                continue;
+            }
+
+            $segment = $this->careerJobSeoService->mapBackendLocaleToFrontendSegment($locale);
+            $lastmod = $row->updated_at
+                ?? $row->published_at
+                ?? now();
+
+            if (! isset($listLastModified[$segment]) || $lastmod->gt($listLastModified[$segment])) {
+                $listLastModified[$segment] = $lastmod;
+            }
+        }
+
+        $urls = [];
+        foreach ($listLastModified as $segment => $lastmod) {
+            $urls[] = [
+                'loc' => $baseUrl.'/'.$segment.'/career/jobs',
+                'lastmod' => $lastmod->toAtomString(),
+                'slug' => 'career-jobs-list:'.$segment,
+                'updated_at' => $lastmod->toDateTimeString(),
+            ];
+        }
+
+        return $urls;
+    }
+
+    private function getCareerJobDetailUrls(): array
+    {
+        $rows = CareerJob::query()
+            ->withoutGlobalScopes()
+            ->where('org_id', 0)
+            ->where('status', CareerJob::STATUS_PUBLISHED)
+            ->where('is_public', true)
+            ->where('is_indexable', true)
+            ->whereIn('locale', CareerJob::SUPPORTED_LOCALES)
+            ->whereNotNull('slug')
+            ->where('slug', '<>', '')
+            ->where(static function ($query): void {
+                $query->whereNull('published_at')
+                    ->orWhere('published_at', '<=', now());
+            })
+            ->select(['slug', 'locale', 'updated_at', 'published_at'])
+            ->orderBy('locale')
+            ->orderBy('slug')
+            ->get();
+
+        $urls = [];
+
+        foreach ($rows as $row) {
+            $slug = trim((string) $row->slug);
+            $locale = trim((string) $row->locale);
+
+            if ($slug === '' || $locale === '') {
+                continue;
+            }
+
+            $lastmod = $row->updated_at
+                ?? $row->published_at
+                ?? now();
+
+            $urls[] = [
+                'loc' => $this->careerJobSeoService->buildCanonicalUrl($row, $locale),
+                'lastmod' => $lastmod->toAtomString(),
+                'slug' => 'career-jobs:'.$this->careerJobSeoService->mapBackendLocaleToFrontendSegment($locale).':'.$slug,
+                'updated_at' => $lastmod->toDateTimeString(),
+            ];
+        }
+
+        return array_values(array_filter($urls, static fn (array $row): bool => ! empty($row['loc'])));
     }
 
     private function getTopicUrls(): array

--- a/backend/tests/Feature/SEO/SitemapGeneratorTest.php
+++ b/backend/tests/Feature/SEO/SitemapGeneratorTest.php
@@ -2,8 +2,10 @@
 
 namespace Tests\Feature\SEO;
 
+use App\Models\CareerJob;
 use App\Models\PersonalityProfile;
 use App\Models\TopicProfile;
+use App\Services\Cms\CareerJobSeoService;
 use App\Services\Cms\PersonalityProfileSeoService;
 use App\Services\Cms\TopicProfileSeoService;
 use App\Services\SEO\SitemapGenerator;
@@ -296,6 +298,105 @@ class SitemapGeneratorTest extends TestCase
         $this->assertStringContainsString(data_get($seoService->buildMeta($eligibleZh, 'zh-CN'), 'canonical'), $xml);
     }
 
+    public function test_generate_includes_only_indexable_global_career_job_urls_with_locale_aware_paths(): void
+    {
+        config(['app.frontend_url' => 'https://staging.fermatmind.com']);
+
+        $eligibleEn = $this->createCareerJob([
+            'job_code' => 'product-manager',
+            'slug' => 'product-manager',
+            'locale' => 'en',
+            'title' => 'Product Manager',
+            'excerpt' => 'Responsibilities, salary, growth path, and personality fit for Product Managers.',
+            'is_indexable' => true,
+            'published_at' => Carbon::create(2026, 3, 8, 9, 0, 0, 'UTC'),
+            'updated_at' => Carbon::create(2026, 3, 8, 10, 0, 0, 'UTC'),
+        ]);
+
+        $eligibleZh = $this->createCareerJob([
+            'job_code' => 'product-manager',
+            'slug' => 'product-manager',
+            'locale' => 'zh-CN',
+            'title' => '产品经理',
+            'excerpt' => '了解产品经理的职责、薪资水平、发展路径和人格匹配。',
+            'is_indexable' => true,
+            'published_at' => Carbon::create(2026, 3, 8, 11, 0, 0, 'UTC'),
+            'updated_at' => Carbon::create(2026, 3, 8, 12, 0, 0, 'UTC'),
+        ]);
+
+        $this->createCareerJob([
+            'job_code' => 'draft-role',
+            'slug' => 'draft-role',
+            'locale' => 'en',
+            'status' => CareerJob::STATUS_DRAFT,
+            'updated_at' => Carbon::create(2026, 3, 8, 12, 30, 0, 'UTC'),
+        ]);
+        $this->createCareerJob([
+            'job_code' => 'private-role',
+            'slug' => 'private-role',
+            'locale' => 'en',
+            'is_public' => false,
+            'updated_at' => Carbon::create(2026, 3, 8, 12, 45, 0, 'UTC'),
+        ]);
+        $this->createCareerJob([
+            'job_code' => 'noindex-role',
+            'slug' => 'noindex-role',
+            'locale' => 'en',
+            'is_indexable' => false,
+            'updated_at' => Carbon::create(2026, 3, 8, 13, 0, 0, 'UTC'),
+        ]);
+        $this->createCareerJob([
+            'org_id' => 9,
+            'job_code' => 'tenant-role',
+            'slug' => 'tenant-role',
+            'locale' => 'en',
+            'updated_at' => Carbon::create(2026, 3, 8, 13, 15, 0, 'UTC'),
+        ]);
+        $this->createCareerJob([
+            'job_code' => 'future-role',
+            'slug' => 'future-role',
+            'locale' => 'en',
+            'published_at' => Carbon::create(2026, 3, 12, 9, 0, 0, 'UTC'),
+            'updated_at' => Carbon::create(2026, 3, 8, 13, 30, 0, 'UTC'),
+        ]);
+        $this->createCareerJob([
+            'job_code' => 'fr-role',
+            'slug' => 'fr-role',
+            'locale' => 'fr',
+            'updated_at' => Carbon::create(2026, 3, 8, 13, 45, 0, 'UTC'),
+        ]);
+
+        $payload = app(SitemapGenerator::class)->generate();
+        $xml = (string) ($payload['xml'] ?? '');
+
+        $this->assertStringContainsString('https://staging.fermatmind.com/en/career/jobs', $xml);
+        $this->assertStringContainsString('https://staging.fermatmind.com/zh/career/jobs', $xml);
+        $this->assertStringContainsString('https://staging.fermatmind.com/en/career/jobs/product-manager', $xml);
+        $this->assertStringContainsString('https://staging.fermatmind.com/zh/career/jobs/product-manager', $xml);
+
+        $this->assertStringNotContainsString('https://staging.fermatmind.com/en/career/jobs/draft-role', $xml);
+        $this->assertStringNotContainsString('https://staging.fermatmind.com/en/career/jobs/private-role', $xml);
+        $this->assertStringNotContainsString('https://staging.fermatmind.com/en/career/jobs/noindex-role', $xml);
+        $this->assertStringNotContainsString('https://staging.fermatmind.com/en/career/jobs/tenant-role', $xml);
+        $this->assertStringNotContainsString('https://staging.fermatmind.com/en/career/jobs/future-role', $xml);
+        $this->assertStringNotContainsString('https://staging.fermatmind.com/fr/career/jobs/fr-role', $xml);
+        $this->assertStringNotContainsString('https://staging.fermatmind.com/zh-CN/career/jobs/product-manager', $xml);
+
+        $seoService = app(CareerJobSeoService::class);
+
+        $this->assertSame(
+            data_get($seoService->buildMeta($eligibleEn, 'en'), 'canonical'),
+            data_get($seoService->buildJsonLd($eligibleEn, 'en'), 'mainEntityOfPage')
+        );
+        $this->assertSame(
+            data_get($seoService->buildMeta($eligibleZh, 'zh-CN'), 'canonical'),
+            data_get($seoService->buildJsonLd($eligibleZh, 'zh-CN'), 'mainEntityOfPage')
+        );
+        $this->assertSame('Occupation', data_get($seoService->buildJsonLd($eligibleEn, 'en'), '@type'));
+        $this->assertStringContainsString(data_get($seoService->buildMeta($eligibleEn, 'en'), 'canonical'), $xml);
+        $this->assertStringContainsString(data_get($seoService->buildMeta($eligibleZh, 'zh-CN'), 'canonical'), $xml);
+    }
+
     /**
      * @param  array<string, mixed>  $overrides
      */
@@ -345,6 +446,32 @@ class SitemapGeneratorTest extends TestCase
             'sort_order' => 0,
             'created_at' => Carbon::create(2026, 3, 7, 8, 0, 0, 'UTC'),
             'updated_at' => Carbon::create(2026, 3, 7, 8, 0, 0, 'UTC'),
+        ], $overrides));
+    }
+
+    /**
+     * @param  array<string, mixed>  $overrides
+     */
+    private function createCareerJob(array $overrides = []): CareerJob
+    {
+        /** @var CareerJob */
+        return CareerJob::query()->create(array_merge([
+            'org_id' => 0,
+            'job_code' => 'product-manager',
+            'slug' => 'product-manager',
+            'locale' => 'en',
+            'title' => 'Product Manager',
+            'subtitle' => null,
+            'excerpt' => 'Responsibilities, salary, growth path, and personality fit for Product Managers.',
+            'status' => CareerJob::STATUS_PUBLISHED,
+            'is_public' => true,
+            'is_indexable' => true,
+            'published_at' => Carbon::create(2026, 3, 8, 8, 0, 0, 'UTC'),
+            'scheduled_at' => null,
+            'schema_version' => 'v1',
+            'sort_order' => 0,
+            'created_at' => Carbon::create(2026, 3, 8, 8, 0, 0, 'UTC'),
+            'updated_at' => Carbon::create(2026, 3, 8, 8, 0, 0, 'UTC'),
         ], $overrides));
     }
 }

--- a/backend/tests/Feature/SEO/SitemapXmlTest.php
+++ b/backend/tests/Feature/SEO/SitemapXmlTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Feature\SEO;
 
+use App\Models\CareerJob;
 use App\Models\PersonalityProfile;
 use App\Models\TopicProfile;
 use Illuminate\Foundation\Testing\RefreshDatabase;
@@ -176,6 +177,59 @@ class SitemapXmlTest extends TestCase
             'updated_at' => $nowB,
         ]);
 
+        CareerJob::query()->create([
+            'org_id' => 0,
+            'job_code' => 'product-manager',
+            'slug' => 'product-manager',
+            'locale' => 'en',
+            'title' => 'Product Manager',
+            'excerpt' => 'Responsibilities, salary, growth path, and personality fit for Product Managers.',
+            'status' => CareerJob::STATUS_PUBLISHED,
+            'is_public' => true,
+            'is_indexable' => true,
+            'published_at' => Carbon::create(2026, 1, 31, 11, 45, 0),
+            'scheduled_at' => null,
+            'schema_version' => 'v1',
+            'sort_order' => 0,
+            'created_at' => $nowB,
+            'updated_at' => $nowB,
+        ]);
+
+        CareerJob::query()->create([
+            'org_id' => 0,
+            'job_code' => 'product-manager',
+            'slug' => 'product-manager',
+            'locale' => 'zh-CN',
+            'title' => '产品经理',
+            'excerpt' => '了解产品经理的职责、薪资水平、发展路径和人格匹配。',
+            'status' => CareerJob::STATUS_PUBLISHED,
+            'is_public' => true,
+            'is_indexable' => true,
+            'published_at' => Carbon::create(2026, 1, 31, 12, 45, 0),
+            'scheduled_at' => null,
+            'schema_version' => 'v1',
+            'sort_order' => 0,
+            'created_at' => $nowB,
+            'updated_at' => $nowB,
+        ]);
+
+        CareerJob::query()->create([
+            'org_id' => 0,
+            'job_code' => 'private-role',
+            'slug' => 'private-role',
+            'locale' => 'en',
+            'title' => 'Private Role',
+            'status' => CareerJob::STATUS_PUBLISHED,
+            'is_public' => false,
+            'is_indexable' => true,
+            'published_at' => Carbon::create(2026, 1, 31, 12, 50, 0),
+            'scheduled_at' => null,
+            'schema_version' => 'v1',
+            'sort_order' => 0,
+            'created_at' => $nowB,
+            'updated_at' => $nowB,
+        ]);
+
         $response = $this->get('/sitemap.xml');
 
         $response->assertStatus(200);
@@ -208,6 +262,11 @@ class SitemapXmlTest extends TestCase
         $this->assertStringContainsString('<loc>https://staging.fermatmind.com/en/topics/mbti</loc>', $body);
         $this->assertStringContainsString('<loc>https://staging.fermatmind.com/zh/topics/mbti</loc>', $body);
         $this->assertStringNotContainsString('<loc>https://staging.fermatmind.com/en/topics/big-five</loc>', $body);
+        $this->assertStringContainsString('<loc>https://staging.fermatmind.com/en/career/jobs</loc>', $body);
+        $this->assertStringContainsString('<loc>https://staging.fermatmind.com/zh/career/jobs</loc>', $body);
+        $this->assertStringContainsString('<loc>https://staging.fermatmind.com/en/career/jobs/product-manager</loc>', $body);
+        $this->assertStringContainsString('<loc>https://staging.fermatmind.com/zh/career/jobs/product-manager</loc>', $body);
+        $this->assertStringNotContainsString('<loc>https://staging.fermatmind.com/en/career/jobs/private-role</loc>', $body);
         $this->assertStringContainsString('<changefreq>weekly</changefreq>', $body);
         $this->assertStringContainsString('<priority>0.7</priority>', $body);
         $this->assertStringContainsString('<lastmod>2026-01-30</lastmod>', $body);


### PR DESCRIPTION
Summary
- add CareerJob list/detail URLs to the current backend sitemap authority
- align backend sitemap output with locale-aware canonical career job URLs

What changed
- extend the current sitemap generator to include career job list/detail URLs
- filter career job URLs to published/public/indexable global content only
- keep career job sitemap URLs aligned with the existing canonical SEO output
- add sitemap coverage for CareerJob list/detail inclusion and exclusion rules

Design choices
- keep sitemap authority in fap-api because /sitemap.xml is currently served by backend
- use locale-aware frontend URLs (/en/..., /zh/...) as canonical sitemap entries
- keep CareerJob restricted to global content (org_id=0) for v1
- reuse the existing CareerJob SEO service for canonical consistency instead of introducing a second URL builder

Why this PR is small and safe
- no frontend changes
- no write-side API changes
- no Filament changes
- no deploy changes
- only backend sitemap authority work for CareerJob

Validation
- php artisan about
- php artisan route:list
- php artisan migrate
- php artisan test --filter='(Sitemap|CareerJob|Career)'
- bash scripts/export_openapi.sh --check
- local sitemap and SEO curl checks
- bash backend/scripts/ci_verify_mbti.sh
