### PR TITLE
feat(commerce): surface order delivery and report recovery contract

### DIFF
--- a/backend/app/Http/Controllers/API/V0_3/ClaimController.php
+++ b/backend/app/Http/Controllers/API/V0_3/ClaimController.php
@@ -20,10 +20,11 @@ class ClaimController extends Controller
         $logger = app(LookupEventLogger::class);
 
         $limitIp = $limiter->limit('FAP_RATE_CLAIM_REPORT_IP', 30);
-        if ($ip !== '' && !$limiter->hit("claim_report:ip:{$ip}", $limitIp, 60)) {
+        if ($ip !== '' && ! $limiter->hit("claim_report:ip:{$ip}", $limitIp, 60)) {
             $logger->log('claim_report', false, $request, null, [
                 'error_code' => 'RATE_LIMITED',
             ]);
+
             return response()->json([
                 'ok' => false,
                 'error_code' => 'RATE_LIMITED',
@@ -37,6 +38,7 @@ class ClaimController extends Controller
             $logger->log('claim_report', false, $request, null, [
                 'error_code' => 'INVALID_TOKEN',
             ]);
+
             return response()->json([
                 'ok' => false,
                 'error_code' => 'INVALID_TOKEN',
@@ -48,12 +50,13 @@ class ClaimController extends Controller
         $svc = app(EmailOutboxService::class);
         $res = $svc->claimReport($token);
 
-        if (!($res['ok'] ?? false)) {
+        if (! ($res['ok'] ?? false)) {
             $status = (int) ($res['status'] ?? 422);
             $logger->log('claim_report', false, $request, null, [
                 'error_code' => (string) ($res['error'] ?? 'INVALID_TOKEN'),
                 'token_hash' => hash('sha256', $token),
             ]);
+
             return response()->json([
                 'ok' => false,
                 'error_code' => $res['error'] ?? 'INVALID_TOKEN',
@@ -70,6 +73,7 @@ class ClaimController extends Controller
             'ok' => true,
             'attempt_id' => (string) ($res['attempt_id'] ?? ''),
             'report_url' => $res['report_url'] ?? null,
+            'report_pdf_url' => $res['report_pdf_url'] ?? null,
         ]);
     }
 }

--- a/backend/app/Http/Controllers/API/V0_3/CommerceController.php
+++ b/backend/app/Http/Controllers/API/V0_3/CommerceController.php
@@ -129,6 +129,7 @@ class CommerceController extends Controller
         $ownershipVerified = (bool) ($result['ownership_verified'] ?? true);
         $status = $this->normalizePublicOrderStatus((string) ($order->status ?? ''));
         $message = $this->publicOrderMessage((string) ($order->status ?? ''));
+        $delivery = $this->orders->presentOrderDelivery($order);
 
         if (! $ownershipVerified) {
             return response()->json([
@@ -143,11 +144,12 @@ class CommerceController extends Controller
             'ownership_verified' => true,
             'order' => $order,
             'order_no' => $order->order_no ?? null,
-            'attempt_id' => $order->target_attempt_id ?? null,
+            'attempt_id' => $delivery['attempt_id'],
             'status' => $status,
             'message' => $message,
             'amount_cents' => $order->amount_cents ?? $order->amount_total ?? null,
             'currency' => $order->currency ?? null,
+            'delivery' => $delivery['delivery'],
         ]);
     }
 
@@ -328,10 +330,14 @@ class CommerceController extends Controller
             ], 404);
         }
 
+        $delivery = $this->orders->presentOrderDelivery($order);
+
         return response()->json([
             'ok' => true,
             'order_no' => $order->order_no ?? $orderNo,
             'status' => $this->normalizePublicOrderStatus((string) ($order->status ?? '')),
+            'attempt_id' => $delivery['attempt_id'],
+            'delivery' => $delivery['delivery'],
         ]);
     }
 
@@ -343,8 +349,8 @@ class CommerceController extends Controller
         $orgId = $this->orgContext->orgId();
         $userId = $this->orgContext->userId();
         $anonId = $this->resolveAnonId($request);
-        $found = $this->orders->getOrder($orgId, $userId !== null ? (string) $userId : null, $anonId, $order_no);
-        if (! ($found['ok'] ?? false)) {
+        $resent = $this->orders->resendDelivery($orgId, $userId !== null ? (string) $userId : null, $anonId, $order_no);
+        if (! ($resent['ok'] ?? false)) {
             return response()->json([
                 'ok' => false,
                 'error_code' => 'ORDER_NOT_FOUND',
@@ -667,6 +673,7 @@ class CommerceController extends Controller
         });
 
         $sku = trim((string) ($items[0]['sku'] ?? ''));
+
         return $sku !== '' ? strtoupper($sku) : '';
     }
 

--- a/backend/app/Services/Commerce/OrderManager.php
+++ b/backend/app/Services/Commerce/OrderManager.php
@@ -2,6 +2,7 @@
 
 namespace App\Services\Commerce;
 
+use App\Services\Email\EmailOutboxService;
 use App\Services\Report\ReportAccess;
 use App\Services\Scale\ScaleIdentityWriteProjector;
 use Illuminate\Support\Facades\DB;
@@ -19,6 +20,7 @@ class OrderManager
     public function __construct(
         private SkuCatalog $skus,
         private ScaleIdentityWriteProjector $identityProjector,
+        private EmailOutboxService $emailOutbox,
     ) {}
 
     public function createOrder(
@@ -284,6 +286,58 @@ class OrderManager
         ];
     }
 
+    /**
+     * @return array{attempt_id:?string,delivery:array{can_view_report:bool,report_url:?string,can_download_pdf:bool,report_pdf_url:?string,can_resend:bool}}
+     */
+    public function presentOrderDelivery(object $order): array
+    {
+        $delivery = $this->compileOrderDeliveryState($order);
+
+        return [
+            'attempt_id' => $delivery['attempt_id'],
+            'delivery' => $this->presentCompiledOrderDeliveryState($delivery),
+        ];
+    }
+
+    public function resendDelivery(
+        int $orgId,
+        ?string $userId,
+        ?string $anonId,
+        string $orderNo
+    ): array {
+        $found = $this->getOrder($orgId, $userId, $anonId, $orderNo);
+        if (! ($found['ok'] ?? false)) {
+            return $found;
+        }
+
+        $order = $found['order'];
+        $delivery = $this->compileOrderDeliveryState($order);
+
+        if (($delivery['can_resend'] ?? false) !== true) {
+            return [
+                'ok' => true,
+                'queued' => false,
+                'order' => $order,
+                'delivery' => $this->presentCompiledOrderDeliveryState($delivery),
+            ];
+        }
+
+        $queued = $this->emailOutbox->queuePaymentSuccess(
+            (string) ($delivery['delivery_user_id'] ?? ''),
+            (string) ($delivery['delivery_email'] ?? ''),
+            (string) ($delivery['attempt_id'] ?? ''),
+            $this->trimOrNull((string) ($order->order_no ?? '')),
+            $this->resolveOrderProductSummary($order)
+        );
+
+        return [
+            'ok' => true,
+            'queued' => (bool) ($queued['ok'] ?? false),
+            'order' => $order,
+            'delivery' => $this->presentCompiledOrderDeliveryState($delivery),
+        ];
+    }
+
     public function transitionToPaidAtomic(
         string $orderNo,
         int $orgId,
@@ -485,6 +539,103 @@ class OrderManager
         $row['refund_reason'] = null;
 
         return $row;
+    }
+
+    /**
+     * @return array{attempt_id:?string,report_url:?string,report_pdf_url:?string,can_view_report:bool,can_download_pdf:bool,can_resend:bool,delivery_email:?string,delivery_user_id:?string}
+     */
+    private function compileOrderDeliveryState(object $order): array
+    {
+        $orgId = (int) ($order->org_id ?? 0);
+        $attemptId = $this->resolveKnownAttemptId($orgId, $order->target_attempt_id ?? null);
+        $reportUrl = $attemptId !== null ? $this->reportUrl($attemptId) : null;
+        $reportPdfUrl = $attemptId !== null ? $this->reportPdfUrl($attemptId) : null;
+        $deliveryEligible = $attemptId !== null && $this->isDeliveryEligibleStatus((string) ($order->status ?? ''));
+        $recipient = $attemptId !== null
+            ? $this->emailOutbox->resolvePaymentSuccessRecipient(
+                $this->trimOrNull((string) ($order->user_id ?? '')),
+                $this->trimOrNull((string) ($order->anon_id ?? '')),
+                $attemptId,
+                $this->trimOrNull((string) ($order->order_no ?? ''))
+            )
+            : ['email' => null, 'user_id' => null];
+
+        $deliveryEmail = $this->trimOrNull((string) ($recipient['email'] ?? ''));
+        $deliveryUserId = $this->trimOrNull((string) ($recipient['user_id'] ?? ''));
+
+        return [
+            'attempt_id' => $attemptId,
+            'report_url' => $reportUrl,
+            'report_pdf_url' => $reportPdfUrl,
+            'can_view_report' => $deliveryEligible,
+            'can_download_pdf' => $deliveryEligible,
+            'can_resend' => $deliveryEligible && $deliveryEmail !== null && $deliveryUserId !== null,
+            'delivery_email' => $deliveryEmail,
+            'delivery_user_id' => $deliveryUserId,
+        ];
+    }
+
+    /**
+     * @param  array{attempt_id:?string,report_url:?string,report_pdf_url:?string,can_view_report:bool,can_download_pdf:bool,can_resend:bool,delivery_email:?string,delivery_user_id:?string}  $delivery
+     * @return array{can_view_report:bool,report_url:?string,can_download_pdf:bool,report_pdf_url:?string,can_resend:bool}
+     */
+    private function presentCompiledOrderDeliveryState(array $delivery): array
+    {
+        return [
+            'can_view_report' => (bool) ($delivery['can_view_report'] ?? false),
+            'report_url' => $delivery['report_url'] ?? null,
+            'can_download_pdf' => (bool) ($delivery['can_download_pdf'] ?? false),
+            'report_pdf_url' => $delivery['report_pdf_url'] ?? null,
+            'can_resend' => (bool) ($delivery['can_resend'] ?? false),
+        ];
+    }
+
+    private function resolveKnownAttemptId(int $orgId, mixed $candidate): ?string
+    {
+        $attemptId = trim((string) $candidate);
+        if ($attemptId === '') {
+            return null;
+        }
+
+        $exists = DB::table('attempts')
+            ->where('id', $attemptId)
+            ->where('org_id', $orgId)
+            ->exists();
+
+        return $exists ? $attemptId : null;
+    }
+
+    private function isDeliveryEligibleStatus(string $status): bool
+    {
+        return in_array(strtolower(trim($status)), ['paid', 'fulfilled'], true);
+    }
+
+    private function resolveOrderProductSummary(object $order): ?string
+    {
+        $candidates = [
+            $order->effective_sku ?? null,
+            $order->requested_sku ?? null,
+            $order->sku ?? null,
+        ];
+
+        foreach ($candidates as $candidate) {
+            $value = $this->trimOrNull((string) $candidate);
+            if ($value !== null) {
+                return $value;
+            }
+        }
+
+        return null;
+    }
+
+    private function reportUrl(string $attemptId): string
+    {
+        return "/api/v0.3/attempts/{$attemptId}/report";
+    }
+
+    private function reportPdfUrl(string $attemptId): string
+    {
+        return "/api/v0.3/attempts/{$attemptId}/report.pdf";
     }
 
     private function normalizeRequestId(mixed $value): ?string

--- a/backend/app/Services/Email/EmailOutboxService.php
+++ b/backend/app/Services/Email/EmailOutboxService.php
@@ -44,12 +44,14 @@ class EmailOutboxService
         $locale = $this->resolveAttemptLocale($attemptId);
         $subject = $this->defaultSubjectForTemplate('report_claim', $locale);
 
-        $reportUrl = "/api/v0.3/attempts/{$attemptId}/report";
+        $reportUrl = $this->reportUrl($attemptId);
+        $reportPdfUrl = $this->reportPdfUrl($attemptId);
         $claimUrl = "/api/v0.3/claim/report?token={$token}";
 
         $payload = [
             'attempt_id' => $attemptId,
             'report_url' => $reportUrl,
+            'report_pdf_url' => $reportPdfUrl,
             'claim_token' => $token,
             'claim_url' => $claimUrl,
             'claim_expires_at' => $expiresAt->toIso8601String(),
@@ -226,8 +228,8 @@ class EmailOutboxService
 
         $locale = $this->resolveAttemptLocale($attemptId);
         $subject = $this->defaultSubjectForTemplate('payment_success', $locale);
-        $reportUrl = "/api/v0.3/attempts/{$attemptId}/report";
-        $reportPdfUrl = "/api/v0.3/attempts/{$attemptId}/report.pdf";
+        $reportUrl = $this->reportUrl($attemptId);
+        $reportPdfUrl = $this->reportPdfUrl($attemptId);
         $nonce = hash('sha256', 'payment_success|'.$attemptId.'|'.Str::uuid()->toString());
 
         $payload = [
@@ -466,11 +468,85 @@ class EmailOutboxService
         }
 
         $reportUrl = $payload['report_url'] ?? "/api/v0.3/attempts/{$attemptId}/report";
+        $reportPdfUrl = $payload['report_pdf_url'] ?? $this->reportPdfUrl($attemptId);
 
         return [
             'ok' => true,
             'attempt_id' => $attemptId,
             'report_url' => $reportUrl,
+            'report_pdf_url' => $reportPdfUrl,
+        ];
+    }
+
+    /**
+     * @return array{email:?string,user_id:?string}
+     */
+    public function resolvePaymentSuccessRecipient(
+        ?string $userId,
+        ?string $anonId,
+        ?string $attemptId,
+        ?string $orderNo = null
+    ): array {
+        $attemptId = $this->trimOrNull($attemptId);
+        if ($attemptId === null) {
+            return [
+                'email' => null,
+                'user_id' => null,
+            ];
+        }
+
+        $normalizedUserId = $this->trimOrNull($userId);
+        $normalizedAnonId = $this->trimOrNull($anonId);
+        $resolvedOutboxUserId = $this->resolveOutboxUserId($normalizedUserId, $normalizedAnonId, $attemptId);
+        $email = $this->resolveUserEmailById($normalizedUserId);
+        if ($email !== '') {
+            return [
+                'email' => $email,
+                'user_id' => $resolvedOutboxUserId,
+            ];
+        }
+
+        if (! \App\Support\SchemaBaseline::hasTable('email_outbox')
+            || ! \App\Support\SchemaBaseline::hasColumn('email_outbox', 'attempt_id')) {
+            return [
+                'email' => null,
+                'user_id' => null,
+            ];
+        }
+
+        $normalizedOrderNo = $this->trimOrNull($orderNo);
+        $rows = DB::table('email_outbox')
+            ->where('attempt_id', $attemptId)
+            ->whereIn('template', ['payment_success', 'report_claim'])
+            ->orderByDesc('updated_at')
+            ->get();
+
+        foreach ($rows as $row) {
+            $payload = null;
+            if ((string) ($row->template ?? '') === 'payment_success' && $normalizedOrderNo !== null) {
+                $payload = $this->decodePayloadFromRow($row);
+                $payloadOrderNo = $this->trimOrNull((string) ($payload['order_no'] ?? ''));
+                if ($payloadOrderNo !== null && $payloadOrderNo !== $normalizedOrderNo) {
+                    continue;
+                }
+            }
+
+            $email = $this->extractRecipientEmailFromOutboxRow($row, $payload);
+            if ($email === '') {
+                continue;
+            }
+
+            $rowUserId = $this->trimOrNull((string) ($row->user_id ?? ''));
+
+            return [
+                'email' => $email,
+                'user_id' => $this->resolveOutboxUserId($rowUserId, $normalizedAnonId, $attemptId),
+            ];
+        }
+
+        return [
+            'email' => null,
+            'user_id' => null,
         ];
     }
 
@@ -524,6 +600,34 @@ class EmailOutboxService
         );
 
         return $payload;
+    }
+
+    private function extractRecipientEmailFromOutboxRow(object $row, ?array $payload = null): string
+    {
+        $candidates = [];
+
+        if (\App\Support\SchemaBaseline::hasColumn('email_outbox', 'to_email_enc')) {
+            $candidates[] = $this->piiCipher->decrypt((string) ($row->to_email_enc ?? ''));
+        }
+        if (\App\Support\SchemaBaseline::hasColumn('email_outbox', 'email_enc')) {
+            $candidates[] = $this->piiCipher->decrypt((string) ($row->email_enc ?? ''));
+        }
+
+        if ($payload === null) {
+            $payload = $this->decodePayloadFromRow($row);
+        }
+
+        $candidates[] = $payload['to_email'] ?? null;
+        $candidates[] = $payload['email'] ?? null;
+
+        foreach ($candidates as $candidate) {
+            $email = $this->normalizeEmailAddress($candidate);
+            if ($email !== null) {
+                return $email;
+            }
+        }
+
+        return '';
     }
 
     private function maskedLegacyEmail(string $emailHash): string
@@ -584,5 +688,74 @@ class EmailOutboxService
         }
 
         return $lang === 'zh' ? 'FermatMind 通知' : 'FermatMind notification';
+    }
+
+    private function resolveUserEmailById(?string $userId): string
+    {
+        $userId = $this->trimOrNull($userId);
+        if ($userId === null) {
+            return '';
+        }
+
+        if (! \App\Support\SchemaBaseline::hasTable('users')
+            || ! \App\Support\SchemaBaseline::hasColumn('users', 'email')) {
+            return '';
+        }
+
+        $email = DB::table('users')->where('id', $userId)->value('email');
+        $normalized = $this->normalizeEmailAddress($email);
+
+        return $normalized ?? '';
+    }
+
+    private function resolveOutboxUserId(?string $userId, ?string $anonId, string $attemptId): ?string
+    {
+        $userId = $this->trimOrNull($userId);
+        if ($userId !== null) {
+            return substr($userId, 0, 64);
+        }
+
+        $anonId = $this->trimOrNull($anonId);
+        if ($anonId !== null) {
+            return 'anon_'.substr(hash('sha256', $anonId), 0, 24);
+        }
+
+        $attemptId = $this->trimOrNull($attemptId);
+        if ($attemptId !== null) {
+            return 'attempt_'.substr(hash('sha256', $attemptId), 0, 24);
+        }
+
+        return null;
+    }
+
+    private function normalizeEmailAddress(mixed $email): ?string
+    {
+        $email = mb_strtolower(trim((string) $email), 'UTF-8');
+        if ($email === '') {
+            return null;
+        }
+
+        if (filter_var($email, FILTER_VALIDATE_EMAIL) === false) {
+            return null;
+        }
+
+        return $email;
+    }
+
+    private function trimOrNull(?string $value): ?string
+    {
+        $value = trim((string) $value);
+
+        return $value !== '' ? $value : null;
+    }
+
+    private function reportUrl(string $attemptId): string
+    {
+        return "/api/v0.3/attempts/{$attemptId}/report";
+    }
+
+    private function reportPdfUrl(string $attemptId): string
+    {
+        return "/api/v0.3/attempts/{$attemptId}/report.pdf";
     }
 }

--- a/backend/tests/Feature/Commerce/BigFiveUnlockDeliveryPipelineTest.php
+++ b/backend/tests/Feature/Commerce/BigFiveUnlockDeliveryPipelineTest.php
@@ -45,6 +45,41 @@ final class BigFiveUnlockDeliveryPipelineTest extends TestCase
         return (string) $userId;
     }
 
+    private function issueToken(string $userId, string $anonId): string
+    {
+        $token = 'fm_'.(string) Str::uuid();
+        $tokenHash = hash('sha256', $token);
+
+        DB::table('fm_tokens')->insert([
+            'token' => $token,
+            'token_hash' => $tokenHash,
+            'user_id' => $userId,
+            'anon_id' => $anonId,
+            'org_id' => 0,
+            'role' => 'public',
+            'expires_at' => now()->addDay(),
+            'revoked_at' => null,
+            'created_at' => now(),
+            'updated_at' => now(),
+        ]);
+
+        DB::table('auth_tokens')->insert([
+            'token_hash' => $tokenHash,
+            'user_id' => $userId,
+            'anon_id' => $anonId,
+            'org_id' => 0,
+            'role' => 'public',
+            'meta_json' => null,
+            'expires_at' => now()->addDay(),
+            'revoked_at' => null,
+            'last_used_at' => null,
+            'created_at' => now(),
+            'updated_at' => now(),
+        ]);
+
+        return $token;
+    }
+
     private function createBigFiveAttemptWithResult(string $anonId, ?string $userId): string
     {
         $attemptId = (string) Str::uuid();
@@ -141,6 +176,7 @@ final class BigFiveUnlockDeliveryPipelineTest extends TestCase
 
         $userId = $this->createUserWithEmail('buyer+big5@example.com');
         $anonId = 'anon_big5_delivery';
+        $token = $this->issueToken($userId, $anonId);
         $attemptId = $this->createBigFiveAttemptWithResult($anonId, $userId);
         $orderNo = 'ord_big5_delivery_1';
         $this->createOrder($orderNo, 'SKU_BIG5_FULL_REPORT_299', $attemptId, $anonId, 299, $userId);
@@ -195,5 +231,20 @@ final class BigFiveUnlockDeliveryPipelineTest extends TestCase
         if (Schema::hasColumn('email_outbox', 'template_key')) {
             $this->assertContains((string) ($row->template_key ?? ''), ['', 'payment_success']);
         }
+
+        $orderRead = $this->withHeaders([
+            'Authorization' => 'Bearer '.$token,
+        ])->getJson('/api/v0.3/orders/'.$orderNo);
+
+        $orderRead->assertStatus(200)
+            ->assertJsonPath('ok', true)
+            ->assertJsonPath('order_no', $orderNo)
+            ->assertJsonPath('attempt_id', $attemptId)
+            ->assertJsonPath('status', 'paid')
+            ->assertJsonPath('delivery.can_view_report', true)
+            ->assertJsonPath('delivery.report_url', "/api/v0.3/attempts/{$attemptId}/report")
+            ->assertJsonPath('delivery.can_download_pdf', true)
+            ->assertJsonPath('delivery.report_pdf_url', "/api/v0.3/attempts/{$attemptId}/report.pdf")
+            ->assertJsonPath('delivery.can_resend', true);
     }
 }

--- a/backend/tests/Feature/V0_3/CommerceOrderLookupSecurityTest.php
+++ b/backend/tests/Feature/V0_3/CommerceOrderLookupSecurityTest.php
@@ -40,10 +40,13 @@ final class CommerceOrderLookupSecurityTest extends TestCase
             ->assertJsonPath('error_code', 'ORDER_NOT_FOUND');
     }
 
-    public function test_lookup_with_matching_email_hash_returns_status(): void
+    public function test_lookup_with_matching_email_hash_returns_delivery_contract(): void
     {
         $orderNo = 'ord_lookup_'.Str::lower(Str::random(8));
-        $this->insertOrderForLookup($orderNo, 'owner@example.com');
+        $userId = $this->createUser('owner@example.com');
+        $attemptId = (string) Str::uuid();
+        $this->insertAttempt($attemptId, self::ANON_OWNER, (string) $userId);
+        $this->insertOrderForLookup($orderNo, 'owner@example.com', $attemptId, 'paid', (string) $userId);
 
         $response = $this->postJson('/api/v0.3/orders/lookup', [
             'order_no' => $orderNo,
@@ -53,7 +56,13 @@ final class CommerceOrderLookupSecurityTest extends TestCase
         $response->assertStatus(200)
             ->assertJsonPath('ok', true)
             ->assertJsonPath('order_no', $orderNo)
-            ->assertJsonPath('status', 'pending');
+            ->assertJsonPath('status', 'paid')
+            ->assertJsonPath('attempt_id', $attemptId)
+            ->assertJsonPath('delivery.can_view_report', true)
+            ->assertJsonPath('delivery.report_url', "/api/v0.3/attempts/{$attemptId}/report")
+            ->assertJsonPath('delivery.can_download_pdf', true)
+            ->assertJsonPath('delivery.report_pdf_url', "/api/v0.3/attempts/{$attemptId}/report.pdf")
+            ->assertJsonPath('delivery.can_resend', true);
     }
 
     public function test_lookup_with_token_owner_works_without_email(): void
@@ -72,7 +81,29 @@ final class CommerceOrderLookupSecurityTest extends TestCase
         $response->assertStatus(200)
             ->assertJsonPath('ok', true)
             ->assertJsonPath('order_no', $orderNo)
-            ->assertJsonPath('status', 'pending');
+            ->assertJsonPath('status', 'pending')
+            ->assertJsonPath('attempt_id', null)
+            ->assertJsonPath('delivery.can_view_report', false)
+            ->assertJsonPath('delivery.report_url', null)
+            ->assertJsonPath('delivery.can_download_pdf', false)
+            ->assertJsonPath('delivery.report_pdf_url', null)
+            ->assertJsonPath('delivery.can_resend', false);
+    }
+
+    private function createUser(string $email): int
+    {
+        $userId = random_int(100000, 999999);
+
+        DB::table('users')->insert([
+            'id' => $userId,
+            'name' => 'Lookup Owner',
+            'email' => $email,
+            'password' => bcrypt('secret'),
+            'created_at' => now(),
+            'updated_at' => now(),
+        ]);
+
+        return $userId;
     }
 
     private function issueAnonToken(string $anonId): string
@@ -110,24 +141,57 @@ final class CommerceOrderLookupSecurityTest extends TestCase
         return $token;
     }
 
-    private function insertOrderForLookup(string $orderNo, string $email): void
+    private function insertAttempt(string $attemptId, string $anonId, ?string $userId = null): void
     {
+        DB::table('attempts')->insert([
+            'id' => $attemptId,
+            'ticket_code' => 'FMT-'.strtoupper(substr(str_replace('-', '', $attemptId), 0, 8)),
+            'org_id' => 0,
+            'user_id' => $userId,
+            'anon_id' => $anonId,
+            'scale_code' => 'BIG5_OCEAN',
+            'scale_version' => 'v0.3',
+            'region' => 'CN_MAINLAND',
+            'locale' => 'zh-CN',
+            'question_count' => 120,
+            'answers_summary_json' => json_encode(['stage' => 'seed'], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES),
+            'client_platform' => 'test',
+            'client_version' => '1.0.0',
+            'channel' => 'test',
+            'started_at' => now()->subMinute(),
+            'submitted_at' => now(),
+            'pack_id' => 'BIG5_OCEAN',
+            'dir_version' => 'v1',
+            'content_package_version' => 'v1',
+            'scoring_spec_version' => 'big5_spec_2026Q1_v1',
+            'created_at' => now(),
+            'updated_at' => now(),
+        ]);
+    }
+
+    private function insertOrderForLookup(
+        string $orderNo,
+        string $email,
+        ?string $attemptId = null,
+        string $status = 'created',
+        ?string $userId = null
+    ): void {
         $now = now();
         $row = [
             'id' => (string) Str::uuid(),
             'order_no' => $orderNo,
             'org_id' => 0,
-            'user_id' => null,
+            'user_id' => $userId,
             'anon_id' => self::ANON_OWNER,
             'sku' => 'MBTI_CREDIT',
             'quantity' => 1,
-            'target_attempt_id' => null,
+            'target_attempt_id' => $attemptId,
             'amount_cents' => 1990,
             'currency' => 'USD',
-            'status' => 'created',
+            'status' => $status,
             'provider' => 'billing',
             'external_trade_no' => null,
-            'paid_at' => null,
+            'paid_at' => $status === 'paid' ? $now : null,
             'created_at' => $now,
             'updated_at' => $now,
         ];

--- a/backend/tests/Feature/V0_3/CommerceOrderReadFallbackTest.php
+++ b/backend/tests/Feature/V0_3/CommerceOrderReadFallbackTest.php
@@ -46,7 +46,9 @@ final class CommerceOrderReadFallbackTest extends TestCase
     public function test_matching_token_identity_returns_full_payload(): void
     {
         $orderNo = 'ord_fallback_'.Str::lower(Str::random(10));
-        $this->insertOrderForOwner($orderNo);
+        $attemptId = (string) Str::uuid();
+        $this->insertAttempt($attemptId, self::ANON_OWNER);
+        $this->insertOrderForOwner($orderNo, $attemptId, 'paid');
 
         $token = $this->issueAnonToken(self::ANON_OWNER);
         $response = $this->withHeaders([
@@ -57,10 +59,16 @@ final class CommerceOrderReadFallbackTest extends TestCase
             ->assertJsonPath('ok', true)
             ->assertJsonPath('ownership_verified', true)
             ->assertJsonPath('order_no', $orderNo)
-            ->assertJsonPath('status', 'pending')
+            ->assertJsonPath('status', 'paid')
+            ->assertJsonPath('attempt_id', $attemptId)
             ->assertJsonPath('amount_cents', 1990)
             ->assertJsonPath('currency', 'USD')
-            ->assertJsonPath('order.anon_id', self::ANON_OWNER);
+            ->assertJsonPath('order.anon_id', self::ANON_OWNER)
+            ->assertJsonPath('delivery.can_view_report', true)
+            ->assertJsonPath('delivery.report_url', "/api/v0.3/attempts/{$attemptId}/report")
+            ->assertJsonPath('delivery.can_download_pdf', true)
+            ->assertJsonPath('delivery.report_pdf_url', "/api/v0.3/attempts/{$attemptId}/report.pdf")
+            ->assertJsonPath('delivery.can_resend', false);
     }
 
     private function issueAnonToken(string $anonId): string
@@ -98,7 +106,35 @@ final class CommerceOrderReadFallbackTest extends TestCase
         return $token;
     }
 
-    private function insertOrderForOwner(string $orderNo): void
+    private function insertAttempt(string $attemptId, string $anonId): void
+    {
+        DB::table('attempts')->insert([
+            'id' => $attemptId,
+            'ticket_code' => 'FMT-'.strtoupper(substr(str_replace('-', '', $attemptId), 0, 8)),
+            'org_id' => 0,
+            'user_id' => null,
+            'anon_id' => $anonId,
+            'scale_code' => 'BIG5_OCEAN',
+            'scale_version' => 'v0.3',
+            'region' => 'CN_MAINLAND',
+            'locale' => 'zh-CN',
+            'question_count' => 120,
+            'answers_summary_json' => json_encode(['stage' => 'seed'], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES),
+            'client_platform' => 'test',
+            'client_version' => '1.0.0',
+            'channel' => 'test',
+            'started_at' => now()->subMinute(),
+            'submitted_at' => now(),
+            'pack_id' => 'BIG5_OCEAN',
+            'dir_version' => 'v1',
+            'content_package_version' => 'v1',
+            'scoring_spec_version' => 'big5_spec_2026Q1_v1',
+            'created_at' => now(),
+            'updated_at' => now(),
+        ]);
+    }
+
+    private function insertOrderForOwner(string $orderNo, ?string $attemptId = null, string $status = 'created'): void
     {
         $now = now();
         $row = [
@@ -109,13 +145,13 @@ final class CommerceOrderReadFallbackTest extends TestCase
             'anon_id' => self::ANON_OWNER,
             'sku' => 'MBTI_CREDIT',
             'quantity' => 1,
-            'target_attempt_id' => null,
+            'target_attempt_id' => $attemptId,
             'amount_cents' => 1990,
             'currency' => 'USD',
-            'status' => 'created',
+            'status' => $status,
             'provider' => 'billing',
             'external_trade_no' => null,
-            'paid_at' => null,
+            'paid_at' => $status === 'paid' ? $now : null,
             'created_at' => $now,
             'updated_at' => $now,
         ];

--- a/backend/tests/Feature/V0_3/CommerceOrderResendTest.php
+++ b/backend/tests/Feature/V0_3/CommerceOrderResendTest.php
@@ -1,0 +1,267 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\V0_3;
+
+use App\Services\Email\EmailOutboxService;
+use App\Support\PiiCipher;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Support\Str;
+use Tests\TestCase;
+
+final class CommerceOrderResendTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private const USER_OWNER_ANON = 'order_resend_user_owner';
+
+    private const ANON_OWNER = 'order_resend_anon_owner';
+
+    public function test_resend_queues_payment_success_delivery_for_paid_user_order(): void
+    {
+        $userId = $this->createUser('resend-user@example.com');
+        $attemptId = $this->createAttempt(self::USER_OWNER_ANON, (string) $userId);
+        $orderNo = 'ord_resend_'.Str::lower(Str::random(8));
+        $this->insertOrder($orderNo, $attemptId, 'paid', self::USER_OWNER_ANON, (string) $userId, 'BIG5_FULL_REPORT');
+
+        $token = $this->issueToken((string) $userId, self::USER_OWNER_ANON);
+        $response = $this->withHeaders([
+            'Authorization' => 'Bearer '.$token,
+        ])->postJson('/api/v0.3/orders/'.$orderNo.'/resend');
+
+        $response->assertStatus(200)
+            ->assertJson([
+                'ok' => true,
+                'message' => 'Delivery notice has been queued.',
+            ]);
+
+        $row = DB::table('email_outbox')
+            ->where('attempt_id', $attemptId)
+            ->where('template', 'payment_success')
+            ->orderByDesc('updated_at')
+            ->first();
+
+        $this->assertNotNull($row);
+        $this->assertSame('pending', (string) ($row->status ?? ''));
+
+        $payloadJson = json_decode((string) ($row->payload_json ?? '{}'), true);
+        $this->assertIsArray($payloadJson);
+        $this->assertSame($orderNo, (string) ($payloadJson['order_no'] ?? ''));
+        $this->assertSame("/api/v0.3/attempts/{$attemptId}/report", (string) ($payloadJson['report_url'] ?? ''));
+        $this->assertSame("/api/v0.3/attempts/{$attemptId}/report.pdf", (string) ($payloadJson['report_pdf_url'] ?? ''));
+    }
+
+    public function test_resend_reuses_existing_outbox_recipient_for_paid_anon_order(): void
+    {
+        $attemptId = $this->createAttempt(self::ANON_OWNER);
+        $orderNo = 'ord_resend_'.Str::lower(Str::random(8));
+        $this->insertOrder($orderNo, $attemptId, 'paid', self::ANON_OWNER, null, 'BIG5_FULL_REPORT');
+
+        $outboxUserId = 'anon_'.substr(hash('sha256', self::ANON_OWNER), 0, 24);
+        $queued = app(EmailOutboxService::class)->queueReportClaim($outboxUserId, 'anon-resend@example.com', $attemptId);
+        $this->assertTrue((bool) ($queued['ok'] ?? false));
+
+        $token = $this->issueToken(null, self::ANON_OWNER);
+        $response = $this->withHeaders([
+            'Authorization' => 'Bearer '.$token,
+        ])->postJson('/api/v0.3/orders/'.$orderNo.'/resend');
+
+        $response->assertStatus(200)
+            ->assertJson([
+                'ok' => true,
+                'message' => 'Delivery notice has been queued.',
+            ]);
+
+        $row = DB::table('email_outbox')
+            ->where('attempt_id', $attemptId)
+            ->where('template', 'payment_success')
+            ->orderByDesc('updated_at')
+            ->first();
+
+        $this->assertNotNull($row);
+        $this->assertSame($outboxUserId, (string) ($row->user_id ?? ''));
+
+        /** @var PiiCipher $pii */
+        $pii = app(PiiCipher::class);
+        $encryptedEmail = (string) (($row->to_email_enc ?? '') !== '' ? ($row->to_email_enc ?? '') : ($row->email_enc ?? ''));
+        $this->assertSame('anon-resend@example.com', $pii->decrypt($encryptedEmail));
+    }
+
+    public function test_resend_keeps_blind_success_for_ineligible_order_without_outbox_side_effect(): void
+    {
+        $userId = $this->createUser('resend-ineligible@example.com');
+        $attemptId = $this->createAttempt(self::USER_OWNER_ANON, (string) $userId);
+        $orderNo = 'ord_resend_'.Str::lower(Str::random(8));
+        $this->insertOrder($orderNo, $attemptId, 'created', self::USER_OWNER_ANON, (string) $userId, 'BIG5_FULL_REPORT');
+
+        $token = $this->issueToken((string) $userId, self::USER_OWNER_ANON);
+        $response = $this->withHeaders([
+            'Authorization' => 'Bearer '.$token,
+        ])->postJson('/api/v0.3/orders/'.$orderNo.'/resend');
+
+        $response->assertStatus(200)
+            ->assertJson([
+                'ok' => true,
+                'message' => 'Delivery notice has been queued.',
+            ]);
+
+        $this->assertSame(
+            0,
+            DB::table('email_outbox')
+                ->where('attempt_id', $attemptId)
+                ->where('template', 'payment_success')
+                ->count()
+        );
+    }
+
+    private function createUser(string $email): int
+    {
+        $userId = random_int(100000, 999999);
+
+        DB::table('users')->insert([
+            'id' => $userId,
+            'name' => 'Order Resend User',
+            'email' => $email,
+            'password' => bcrypt('secret'),
+            'created_at' => now(),
+            'updated_at' => now(),
+        ]);
+
+        return $userId;
+    }
+
+    private function issueToken(?string $userId, string $anonId): string
+    {
+        $token = 'fm_'.(string) Str::uuid();
+        $tokenHash = hash('sha256', $token);
+
+        DB::table('fm_tokens')->insert([
+            'token' => $token,
+            'token_hash' => $tokenHash,
+            'user_id' => $userId,
+            'anon_id' => $anonId,
+            'org_id' => 0,
+            'role' => 'public',
+            'expires_at' => now()->addDay(),
+            'revoked_at' => null,
+            'created_at' => now(),
+            'updated_at' => now(),
+        ]);
+
+        DB::table('auth_tokens')->insert([
+            'token_hash' => $tokenHash,
+            'user_id' => $userId,
+            'anon_id' => $anonId,
+            'org_id' => 0,
+            'role' => 'public',
+            'meta_json' => null,
+            'expires_at' => now()->addDay(),
+            'revoked_at' => null,
+            'last_used_at' => null,
+            'created_at' => now(),
+            'updated_at' => now(),
+        ]);
+
+        return $token;
+    }
+
+    private function createAttempt(string $anonId, ?string $userId = null): string
+    {
+        $attemptId = (string) Str::uuid();
+
+        DB::table('attempts')->insert([
+            'id' => $attemptId,
+            'ticket_code' => 'FMT-'.strtoupper(substr(str_replace('-', '', $attemptId), 0, 8)),
+            'org_id' => 0,
+            'user_id' => $userId,
+            'anon_id' => $anonId,
+            'scale_code' => 'BIG5_OCEAN',
+            'scale_version' => 'v0.3',
+            'region' => 'CN_MAINLAND',
+            'locale' => 'zh-CN',
+            'question_count' => 120,
+            'answers_summary_json' => json_encode(['stage' => 'seed'], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES),
+            'client_platform' => 'test',
+            'client_version' => '1.0.0',
+            'channel' => 'test',
+            'started_at' => now()->subMinute(),
+            'submitted_at' => now(),
+            'pack_id' => 'BIG5_OCEAN',
+            'dir_version' => 'v1',
+            'content_package_version' => 'v1',
+            'scoring_spec_version' => 'big5_spec_2026Q1_v1',
+            'created_at' => now(),
+            'updated_at' => now(),
+        ]);
+
+        return $attemptId;
+    }
+
+    private function insertOrder(
+        string $orderNo,
+        string $attemptId,
+        string $status,
+        string $anonId,
+        ?string $userId,
+        string $sku
+    ): void {
+        $now = now();
+        $row = [
+            'id' => (string) Str::uuid(),
+            'order_no' => $orderNo,
+            'org_id' => 0,
+            'user_id' => $userId,
+            'anon_id' => $anonId,
+            'sku' => $sku,
+            'quantity' => 1,
+            'target_attempt_id' => $attemptId,
+            'amount_cents' => 2990,
+            'currency' => 'USD',
+            'status' => $status,
+            'provider' => 'billing',
+            'external_trade_no' => null,
+            'paid_at' => $status === 'paid' ? $now : null,
+            'created_at' => $now,
+            'updated_at' => $now,
+        ];
+
+        if (Schema::hasColumn('orders', 'amount_total')) {
+            $row['amount_total'] = 2990;
+        }
+        if (Schema::hasColumn('orders', 'amount_refunded')) {
+            $row['amount_refunded'] = 0;
+        }
+        if (Schema::hasColumn('orders', 'item_sku')) {
+            $row['item_sku'] = $sku;
+        }
+        if (Schema::hasColumn('orders', 'provider_order_id')) {
+            $row['provider_order_id'] = null;
+        }
+        if (Schema::hasColumn('orders', 'device_id')) {
+            $row['device_id'] = null;
+        }
+        if (Schema::hasColumn('orders', 'request_id')) {
+            $row['request_id'] = null;
+        }
+        if (Schema::hasColumn('orders', 'created_ip')) {
+            $row['created_ip'] = null;
+        }
+        if (Schema::hasColumn('orders', 'fulfilled_at')) {
+            $row['fulfilled_at'] = null;
+        }
+        if (Schema::hasColumn('orders', 'refunded_at')) {
+            $row['refunded_at'] = null;
+        }
+        if (Schema::hasColumn('orders', 'refund_amount_cents')) {
+            $row['refund_amount_cents'] = null;
+        }
+        if (Schema::hasColumn('orders', 'refund_reason')) {
+            $row['refund_reason'] = null;
+        }
+
+        DB::table('orders')->insert($row);
+    }
+}

--- a/backend/tests/Feature/V0_3/PiiKeyVersionCompatibilityTest.php
+++ b/backend/tests/Feature/V0_3/PiiKeyVersionCompatibilityTest.php
@@ -120,5 +120,6 @@ final class PiiKeyVersionCompatibilityTest extends TestCase
         $claimed = app(EmailOutboxService::class)->claimReport($token);
         $this->assertTrue((bool) ($claimed['ok'] ?? false));
         $this->assertSame($attemptId, (string) ($claimed['attempt_id'] ?? ''));
+        $this->assertSame("/api/v0.3/attempts/{$attemptId}/report.pdf", (string) ($claimed['report_pdf_url'] ?? ''));
     }
 }


### PR DESCRIPTION
## Summary
- surface delivery/recovery fields on purchase-centric order read + lookup responses
- queue real payment_success outbox entries on resend when the order is eligible
- append report_pdf_url to claim/report without changing attempt/report contracts

## Tests
- php artisan route:list | rg 'orders/checkout|orders/lookup|orders/.*/resend|orders/.+|claim/report|attempts/.*/report|attempts/.*/report.pdf|me/attempts|webhooks/payment'
- php artisan migrate
- php artisan test tests/Feature/V0_3/CommerceOrderLookupSecurityTest.php
- php artisan test tests/Feature/V0_3/CommerceOrderReadFallbackTest.php
- php artisan test tests/Feature/V0_3/CommerceOrderResendTest.php
- php artisan test tests/Feature/V0_3/AttemptReportPaymentUnlockFlowTest.php
- php artisan test tests/Feature/Commerce/BigFiveUnlockDeliveryPipelineTest.php
- php artisan test tests/Feature/Commerce/PaymentWebhookProcessorAtomicityTest.php
- php artisan test tests/Feature/V0_3/CommerceRefundWebhookTest.php
- php artisan test tests/Feature/Report/ReportPdfCrossScaleDeliveryTest.php
- php artisan test tests/Feature/V0_3/PiiKeyVersionCompatibilityTest.php
- php artisan test tests/Feature/Report/BigFivePdfDeliveryTest.php
- php artisan test tests/Feature/Report/Eq60PdfDeliveryTest.php
- php artisan test tests/Feature/V0_3/AttemptPublicReportReadHotfixTest.php
- bash backend/scripts/ci_verify_mbti.sh
