### PR TITLE
feat(share): freeze MBTI public share contract

### DIFF
--- a/backend/app/Http/Controllers/API/V0_3/ShareController.php
+++ b/backend/app/Http/Controllers/API/V0_3/ShareController.php
@@ -16,9 +16,7 @@ use Throwable;
 
 class ShareController extends Controller
 {
-    public function __construct(private readonly ShareFlowService $shareFlow)
-    {
-    }
+    public function __construct(private readonly ShareFlowService $shareFlow) {}
 
     public function click(ShareClickRequest $request, string $shareId): JsonResponse
     {
@@ -26,7 +24,7 @@ class ShareController extends Controller
         $this->ensureSupportedShareId($routeShareId);
 
         try {
-            $result = $this->shareFlow->clickAndComposeReport(
+            $result = $this->shareFlow->recordClick(
                 $routeShareId,
                 $request->validated(),
                 $this->requestMeta($request)
@@ -97,7 +95,7 @@ class ShareController extends Controller
     private function resolveOrgId(Request $request): int
     {
         $orgId = $request->attributes->get('org_id');
-        if (!is_numeric($orgId)) {
+        if (! is_numeric($orgId)) {
             $orgId = $request->attributes->get('fm_org_id');
         }
 

--- a/backend/app/Http/Requests/V0_3/ShareClickRequest.php
+++ b/backend/app/Http/Requests/V0_3/ShareClickRequest.php
@@ -13,12 +13,55 @@ class ShareClickRequest extends FormRequest
         return true;
     }
 
+    protected function prepareForValidation(): void
+    {
+        $metaJson = $this->normalizeMeta($this->input('meta_json'));
+        $meta = $this->normalizeMeta($this->input('meta'));
+        $mergedMeta = array_replace_recursive($metaJson, $meta);
+
+        $normalizedUtm = $this->normalizeUtm($this->input('utm'));
+        if ($normalizedUtm !== null) {
+            $existingUtm = $this->normalizeUtm($mergedMeta['utm'] ?? null) ?? [];
+            $mergedMeta['utm'] = array_replace($existingUtm, $normalizedUtm);
+        } elseif (isset($mergedMeta['utm'])) {
+            $mergedMeta['utm'] = $this->normalizeUtm($mergedMeta['utm']) ?? [];
+        }
+
+        foreach ([
+            'entrypoint' => 128,
+            'referrer' => 2048,
+            'landing_path' => 2048,
+        ] as $field => $maxLength) {
+            $value = $this->normalizeString($this->input($field), $maxLength);
+            if ($value !== null) {
+                $mergedMeta[$field] = $value;
+            }
+        }
+
+        if ($this->has('compare_intent')) {
+            $mergedMeta['compare_intent'] = $this->boolean('compare_intent');
+        } elseif (array_key_exists('compare_intent', $mergedMeta)) {
+            $mergedMeta['compare_intent'] = filter_var(
+                $mergedMeta['compare_intent'],
+                FILTER_VALIDATE_BOOLEAN,
+                FILTER_NULL_ON_FAILURE
+            );
+        }
+
+        $mergedMeta = $this->filterMeta($mergedMeta);
+
+        $this->merge([
+            'meta_json' => $mergedMeta,
+        ]);
+    }
+
     public function rules(): array
     {
         return [
             'anon_id' => ['nullable', 'string', 'max:128'],
             'occurred_at' => ['nullable', 'date'],
             'meta_json' => ['nullable', 'array'],
+            'meta' => ['nullable'],
             'ref' => ['nullable', 'string', 'max:1024'],
             'ua' => ['nullable', 'string', 'max:1024'],
             'ip' => ['nullable', 'string', 'max:64'],
@@ -27,6 +70,10 @@ class ShareClickRequest extends FormRequest
             'version' => ['nullable', 'string', 'max:64'],
             'url' => ['nullable', 'string', 'max:2048'],
             'trace_id' => ['nullable', 'string', 'max:128'],
+            'entrypoint' => ['nullable', 'string', 'max:128'],
+            'referrer' => ['nullable', 'string', 'max:2048'],
+            'landing_path' => ['nullable', 'string', 'max:2048'],
+            'compare_intent' => ['nullable', 'boolean'],
         ];
     }
 
@@ -71,5 +118,81 @@ class ShareClickRequest extends FormRequest
         if (($maxKeys > 0 && $keysCount > $maxKeys) || ($maxBytes > 0 && $metaBytes > $maxBytes)) {
             throw new ApiProblemException(413, 'META_TOO_LARGE', 'meta too large');
         }
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function normalizeMeta(mixed $value): array
+    {
+        return is_array($value) ? $value : [];
+    }
+
+    /**
+     * @return array<string, string>|null
+     */
+    private function normalizeUtm(mixed $value): ?array
+    {
+        if (! is_array($value)) {
+            return null;
+        }
+
+        $normalized = [];
+        foreach (['source', 'medium', 'campaign', 'term', 'content'] as $key) {
+            $candidate = $this->normalizeString($value[$key] ?? null, 512);
+            if ($candidate !== null) {
+                $normalized[$key] = $candidate;
+            }
+        }
+
+        return $normalized === [] ? null : $normalized;
+    }
+
+    private function normalizeString(mixed $value, int $maxLength): ?string
+    {
+        if (! is_scalar($value)) {
+            return null;
+        }
+
+        $normalized = trim((string) $value);
+        if ($normalized === '') {
+            return null;
+        }
+
+        if (mb_strlen($normalized, 'UTF-8') > $maxLength) {
+            $normalized = mb_substr($normalized, 0, $maxLength, 'UTF-8');
+        }
+
+        return $normalized;
+    }
+
+    /**
+     * @param  array<string, mixed>  $meta
+     * @return array<string, mixed>
+     */
+    private function filterMeta(array $meta): array
+    {
+        $filtered = [];
+
+        foreach ($meta as $key => $value) {
+            if (is_array($value)) {
+                $value = $this->filterMeta($value);
+                if ($value === []) {
+                    continue;
+                }
+
+                $filtered[$key] = $value;
+
+                continue;
+            }
+
+            if ($value === null || $value === '') {
+                continue;
+            }
+
+            $filtered[$key] = $value;
+        }
+
+        return $filtered;
     }
 }

--- a/backend/app/Services/Share/ShareFlowCoreService.php
+++ b/backend/app/Services/Share/ShareFlowCoreService.php
@@ -76,6 +76,16 @@ final class ShareFlowCoreService
      */
     public function clickAndComposeReport(string $shareId, array $input, array $requestMeta): array
     {
+        return $this->recordClick($shareId, $input, $requestMeta);
+    }
+
+    /**
+     * @param  array<string, mixed>  $input
+     * @param  array<string, mixed>  $requestMeta
+     * @return array<string, mixed>
+     */
+    public function recordClick(string $shareId, array $input, array $requestMeta): array
+    {
         $share = Share::withoutGlobalScopes()->where('id', $shareId)->first();
         if (! $share) {
             throw new NotFoundHttpException('share not found');
@@ -91,11 +101,15 @@ final class ShareFlowCoreService
             ->where('share_id', $shareId)
             ->orderByDesc('occurred_at')
             ->first();
-        if (! $gen) {
-            throw new NotFoundHttpException('share generate event not found');
-        }
+        $genMeta = $gen ? $this->normalizeMeta($gen->meta_json ?? null) : [];
 
-        $genMeta = $this->normalizeMeta($gen->meta_json ?? null);
+        $attempt = Attempt::withoutGlobalScopes()->where('id', $attemptId)->firstOrFail();
+        $this->assertOrgIsolation($attempt);
+
+        $result = Result::withoutGlobalScopes()
+            ->where('org_id', (int) ($attempt->org_id ?? 0))
+            ->where('attempt_id', (string) $attempt->id)
+            ->first();
 
         $experiment = trim((string) ($requestMeta['experiment'] ?? ($input['experiment'] ?? '')));
         if ($experiment === '') {
@@ -109,18 +123,18 @@ final class ShareFlowCoreService
 
         $channel = trim((string) ($requestMeta['channel'] ?? ($genMeta['channel'] ?? '')));
         $clientPlatform = trim((string) ($requestMeta['client_platform'] ?? ($genMeta['client_platform'] ?? '')));
-        $entryPage = trim((string) ($requestMeta['entry_page'] ?? ''));
+        $entryPage = trim((string) ($requestMeta['entry_page'] ?? ($genMeta['entry_page'] ?? '')));
 
-        $typeCode = trim((string) ($genMeta['type_code'] ?? ''));
-        $packVersion = trim((string) ($genMeta['content_package_version'] ?? ''));
+        $typeCode = trim((string) ($genMeta['type_code'] ?? ($result?->type_code ?? '')));
+        $packVersion = trim((string) (
+            $genMeta['content_package_version']
+            ?? ($attempt->content_package_version ?? $result?->content_package_version ?? '')
+        ));
         $engineVersion = trim((string) ($genMeta['engine_version'] ?? ($genMeta['engine'] ?? '')));
-        $profileVersion = trim((string) ($genMeta['profile_version'] ?? ''));
+        $profileVersion = trim((string) ($genMeta['profile_version'] ?? ($result?->profile_version ?? '')));
 
         $meta = is_array($input['meta_json'] ?? null) ? $input['meta_json'] : [];
-
-        if (! isset($meta['share_id'])) {
-            $meta['share_id'] = $shareId;
-        }
+        $meta['share_id'] = $shareId;
         $meta['attempt_id'] = $attemptId;
 
         if ($typeCode !== '' && ! isset($meta['type_code'])) {
@@ -137,6 +151,14 @@ final class ShareFlowCoreService
         }
         if ($profileVersion !== '' && ! isset($meta['profile_version'])) {
             $meta['profile_version'] = $profileVersion;
+        }
+
+        $entrypoint = trim((string) ($meta['entrypoint'] ?? ''));
+        if ($entrypoint === '') {
+            $entrypoint = trim((string) ($entryPage !== '' ? $entryPage : ($genMeta['entrypoint'] ?? '')));
+        }
+        if ($entrypoint !== '') {
+            $meta['entrypoint'] = $entrypoint;
         }
 
         if ($experiment !== '' && ! isset($meta['experiment'])) {
@@ -156,10 +178,10 @@ final class ShareFlowCoreService
             $meta['entry_page'] = $entryPage;
         }
 
-        if (! isset($meta['share_generate_event_id'])) {
+        if ($gen && ! isset($meta['share_generate_event_id'])) {
             $meta['share_generate_event_id'] = (string) ($gen->id ?? '');
         }
-        if (! isset($meta['share_generate_occurred_at'])) {
+        if ($gen && ! isset($meta['share_generate_occurred_at'])) {
             $meta['share_generate_occurred_at'] = (string) ($gen->occurred_at ?? '');
         }
 
@@ -172,17 +194,22 @@ final class ShareFlowCoreService
         if (! isset($meta['ref'])) {
             $meta['ref'] = trim((string) ($requestMeta['referer'] ?? ''));
         }
+        if (! isset($meta['referrer'])) {
+            $meta['referrer'] = trim((string) ($requestMeta['referer'] ?? ($input['ref'] ?? '')));
+        }
+        if (! isset($meta['landing_path'])) {
+            $meta['landing_path'] = $this->extractLandingPath($input);
+        }
+        if (! isset($meta['compare_intent']) && array_key_exists('compare_intent', $genMeta)) {
+            $meta['compare_intent'] = $genMeta['compare_intent'];
+        }
+        if (! isset($meta['utm']) && is_array($genMeta['utm'] ?? null)) {
+            $meta['utm'] = $genMeta['utm'];
+        }
 
-        $meta = array_filter($meta, static fn (mixed $v): bool => ! ($v === null || $v === ''));
+        $meta['utm'] = $this->normalizeUtmMeta($meta['utm'] ?? null);
+        $meta = $this->filterMeta($meta);
         $meta = $this->eventPayloadLimiter->limit($meta);
-
-        $attempt = Attempt::withoutGlobalScopes()->where('id', $attemptId)->firstOrFail();
-        $this->assertOrgIsolation($attempt);
-
-        $result = Result::withoutGlobalScopes()
-            ->where('org_id', (int) ($attempt->org_id ?? 0))
-            ->where('attempt_id', (string) $attempt->id)
-            ->firstOrFail();
 
         $event = new Event;
         $event->id = $this->newUuid();
@@ -190,73 +217,21 @@ final class ShareFlowCoreService
         $event->org_id = (int) ($attempt->org_id ?? 0);
         $event->attempt_id = (string) $attempt->id;
         $event->share_id = $shareId;
-        $event->anon_id = $this->resolveClickAnonId($input, $gen);
+        $event->anon_id = $this->resolveClickAnonId(
+            $input,
+            $gen,
+            is_string($share->anon_id ?? null) ? (string) $share->anon_id : null
+        );
         $event->meta_json = $meta;
         $event->occurred_at = ! empty($input['occurred_at'])
             ? Carbon::parse((string) $input['occurred_at'])
             : now();
         $event->save();
 
-        $ctx = [
-            'share_id' => $shareId,
-            'attempt_id' => (string) $attempt->id,
-            'experiment' => $experiment,
-            'version' => $version,
-            'type_code' => $typeCode,
-            'engine' => $engineVersion,
-            'profile_version' => $profileVersion,
-            'content_package_version' => $packVersion,
-            'org_id' => (int) ($attempt->org_id ?? 0),
-        ];
-
-        try {
-            $composed = $this->reportComposer->compose($attempt, $ctx, $result);
-        } catch (\Throwable $e) {
-            $this->logger->error('[share] report compose failed', [
-                'share_id' => $shareId,
-                'attempt_id' => (string) $attempt->id,
-                'org_id' => (int) ($attempt->org_id ?? 0),
-                'exception' => $e::class,
-                'message' => $e->getMessage(),
-            ]);
-            throw $e;
-        }
-
-        $report = is_array($composed['report'] ?? null) ? $composed['report'] : $this->toArray($composed);
-        if (! is_array($report)) {
-            $report = [];
-        }
-
-        if (! isset($report['_meta']) || ! is_array($report['_meta'])) {
-            $report['_meta'] = [];
-        }
-
-        $metaFill = [
-            'share_id' => $shareId,
-            'attempt_id' => (string) $attempt->id,
-            'type_code' => $typeCode,
-            'engine' => $engineVersion,
-            'profile_version' => $profileVersion,
-            'content_package_version' => $packVersion,
-            'experiment' => $experiment,
-            'version' => $version,
-            'generated_at' => now()->toISOString(),
-        ];
-
-        foreach ($metaFill as $key => $value) {
-            if ($value === '' || $value === null) {
-                continue;
-            }
-            if (! array_key_exists($key, $report['_meta'])) {
-                $report['_meta'][$key] = $value;
-            }
-        }
-
         return [
             'id' => (string) $event->id,
             'share_id' => $shareId,
-            'attempt_id' => (string) $attempt->id,
-            'report' => $this->filterReport($report),
+            'recorded_at' => $event->occurred_at?->toISOString(),
         ];
     }
 
@@ -414,7 +389,7 @@ final class ShareFlowCoreService
     /**
      * @param  array<string, mixed>  $input
      */
-    private function resolveClickAnonId(array $input, Event $gen): ?string
+    private function resolveClickAnonId(array $input, ?Event $gen = null, ?string $shareAnonId = null): ?string
     {
         $badAnon = static function (?string $value): bool {
             if ($value === null) {
@@ -455,6 +430,11 @@ final class ShareFlowCoreService
             return $fromInput;
         }
 
+        $fromShare = trim((string) ($shareAnonId ?? ''));
+        if ($fromShare !== '' && ! $badAnon($fromShare)) {
+            return $fromShare;
+        }
+
         $fromGen = trim((string) ($gen->anon_id ?? ''));
         if ($fromGen !== '' && ! $badAnon($fromGen)) {
             return $fromGen;
@@ -492,6 +472,73 @@ final class ShareFlowCoreService
         }
 
         return [];
+    }
+
+    /**
+     * @return array<string, string>|null
+     */
+    private function normalizeUtmMeta(mixed $utm): ?array
+    {
+        if (! is_array($utm)) {
+            return null;
+        }
+
+        $normalized = [];
+        foreach (['source', 'medium', 'campaign', 'term', 'content'] as $key) {
+            $value = trim((string) ($utm[$key] ?? ''));
+            if ($value !== '') {
+                $normalized[$key] = $value;
+            }
+        }
+
+        return $normalized === [] ? null : $normalized;
+    }
+
+    private function extractLandingPath(array $input): ?string
+    {
+        $landingPath = trim((string) ($input['landing_path'] ?? ''));
+        if ($landingPath !== '') {
+            return $landingPath;
+        }
+
+        $url = trim((string) ($input['url'] ?? ''));
+        if ($url === '') {
+            return null;
+        }
+
+        $parsed = parse_url($url, PHP_URL_PATH);
+
+        return is_string($parsed) && trim($parsed) !== '' ? trim($parsed) : null;
+    }
+
+    /**
+     * @param  array<string, mixed>  $meta
+     * @return array<string, mixed>
+     */
+    private function filterMeta(array $meta): array
+    {
+        $filtered = [];
+
+        foreach ($meta as $key => $value) {
+            if (is_array($value)) {
+                $value = $this->filterMeta($value);
+                if ($value === []) {
+                    continue;
+                }
+
+                $filtered[$key] = $value;
+
+                continue;
+            }
+
+            if ($value === null || $value === '') {
+                continue;
+            }
+
+            $filtered[$key] = $value;
+        }
+
+        return $filtered;
     }
 
     /**

--- a/backend/app/Services/V0_3/ShareFlowService.php
+++ b/backend/app/Services/V0_3/ShareFlowService.php
@@ -58,6 +58,16 @@ class ShareFlowService
     }
 
     /**
+     * @param  array<string, mixed>  $input
+     * @param  array<string, mixed>  $requestMeta
+     * @return array<string, mixed>
+     */
+    public function recordClick(string $shareId, array $input, array $requestMeta): array
+    {
+        return $this->core->recordClick($shareId, $input, $requestMeta);
+    }
+
+    /**
      * @return array<string, mixed>
      */
     public function getShareView(string $shareId): array

--- a/backend/app/Services/V0_3/ShareService.php
+++ b/backend/app/Services/V0_3/ShareService.php
@@ -3,9 +3,14 @@
 namespace App\Services\V0_3;
 
 use App\Models\Attempt;
+use App\Models\PersonalityProfile;
 use App\Models\Result;
 use App\Models\Share;
+use App\Services\Cms\PersonalityProfileService;
+use App\Services\Report\ReportAccess;
+use App\Services\Report\ReportComposer;
 use App\Services\Scale\ScaleIdentityWriteProjector;
+use App\Services\Scale\ScaleRegistry;
 use App\Support\OrgContext;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\ModelNotFoundException;
@@ -15,6 +20,9 @@ class ShareService
 {
     public function __construct(
         private readonly ScaleIdentityWriteProjector $identityProjector,
+        private readonly ReportComposer $reportComposer,
+        private readonly ScaleRegistry $scaleRegistry,
+        private readonly PersonalityProfileService $personalityProfileService,
     ) {}
 
     public function getOrCreateShare(string $attemptId, OrgContext $ctx): array
@@ -36,23 +44,7 @@ class ShareService
             $this->backfillShareScaleIdentityIfNeeded($share, $attempt);
         }
 
-        $typeCode = (string) ($result->type_code ?? '');
-        $resultJson = is_array($result->result_json ?? null) ? $result->result_json : [];
-        $typeName = (string) ($resultJson['type_name'] ?? $resultJson['type'] ?? $typeCode);
-
-        $shareId = (string) $share->id;
-        $shareUrl = rtrim((string) config('app.frontend_url', 'http://localhost'), '/').'/share/'.$shareId;
-
-        return [
-            'share_id' => $shareId,
-            'share_url' => $shareUrl,
-            'attempt_id' => (string) $attempt->id,
-            'created_at' => $share->created_at?->toISOString(),
-            'org_id' => (int) $ctx->orgId(),
-            'content_package_version' => (string) ($attempt->content_package_version ?? $result->content_package_version ?? ''),
-            'type_code' => $typeCode,
-            'type_name' => $typeName,
-        ];
+        return $this->buildSharePayload($share, $attempt, $result);
     }
 
     public function getShareView(string $shareId): array
@@ -74,18 +66,7 @@ class ShareService
             ->where('org_id', $orgId)
             ->firstOrFail();
 
-        $typeCode = (string) ($result->type_code ?? '');
-        $resultJson = is_array($result->result_json ?? null) ? $result->result_json : [];
-        $typeName = (string) ($resultJson['type_name'] ?? $resultJson['type'] ?? $typeCode);
-
-        return [
-            'share_id' => (string) $share->id,
-            'attempt_id' => (string) $attempt->id,
-            'org_id' => $orgId,
-            'type_code' => $typeCode,
-            'type_name' => $typeName,
-            'created_at' => $share->created_at?->toISOString(),
-        ];
+        return $this->buildSharePayload($share, $attempt, $result);
     }
 
     public function resolveAttemptForAuth(string $attemptId, OrgContext $ctx): Attempt
@@ -198,5 +179,453 @@ class ShareService
         $mode = strtolower(trim((string) config('scale_identity.write_mode', 'legacy')));
 
         return in_array($mode, ['dual', 'v2'], true);
+    }
+
+    private function buildSharePayload(Share $share, Attempt $attempt, Result $result): array
+    {
+        $summary = $this->buildShareSummary($share, $attempt, $result);
+        $shareId = (string) $share->id;
+
+        return [
+            'share_id' => $shareId,
+            'share_url' => $this->buildShareUrl($shareId),
+            'attempt_id' => (string) $attempt->id,
+            'created_at' => $share->created_at?->toISOString(),
+            'org_id' => (int) ($attempt->org_id ?? 0),
+            'content_package_version' => (string) ($attempt->content_package_version ?? $result->content_package_version ?? ''),
+            'type_code' => $summary['type_code'],
+            'type_name' => $summary['type_name'],
+            'id' => $shareId,
+            'scale_code' => $summary['scale_code'],
+            'locale' => $summary['locale'],
+            'title' => $summary['title'],
+            'subtitle' => $summary['subtitle'],
+            'summary' => $summary['summary'],
+            'tagline' => $summary['tagline'],
+            'rarity' => $summary['rarity'],
+            'tags' => $summary['tags'],
+            'dimensions' => $summary['dimensions'],
+            'primary_cta_label' => $summary['primary_cta_label'],
+            'primary_cta_path' => $summary['primary_cta_path'],
+        ];
+    }
+
+    /**
+     * @return array{
+     *   scale_code:string,
+     *   locale:string,
+     *   title:string,
+     *   subtitle:?string,
+     *   summary:?string,
+     *   type_code:string,
+     *   type_name:string,
+     *   tagline:?string,
+     *   rarity:string|int|float|null,
+     *   tags:list<string>,
+     *   dimensions:list<array<string,mixed>>,
+     *   primary_cta_label:string,
+     *   primary_cta_path:string
+     * }
+     */
+    private function buildShareSummary(Share $share, Attempt $attempt, Result $result): array
+    {
+        $resultJson = $this->normalizeArray($result->result_json ?? null);
+        $report = $this->buildPublicSafeReportSnapshot($attempt, $result);
+        $reportProfile = $this->normalizeArray($report['profile'] ?? null);
+        $identityCard = $this->normalizeArray($report['identity_card'] ?? null);
+        $identityLayer = $this->normalizeArray(data_get($report, 'layers.identity'));
+
+        $scaleCode = strtoupper(trim((string) ($attempt->scale_code ?? $result->scale_code ?? $share->scale_code ?? '')));
+        if ($scaleCode === '') {
+            $scaleCode = 'MBTI';
+        }
+
+        $locale = $this->normalizeLocale((string) ($attempt->locale ?? config('content_packs.default_locale', 'zh-CN')));
+        $typeCode = trim((string) ($result->type_code ?? $resultJson['type_code'] ?? ''));
+        $typeName = $this->firstNonEmpty(
+            $this->stringOrNull($resultJson['type_name'] ?? null),
+            $this->stringOrNull($resultJson['type'] ?? null),
+            $this->stringOrNull($reportProfile['type_name'] ?? null),
+            $typeCode
+        ) ?? $typeCode;
+
+        $publicProfile = $this->resolvePublicProfile(
+            $typeCode,
+            (int) ($attempt->org_id ?? 0),
+            $scaleCode,
+            $locale
+        );
+
+        $dimensions = $this->buildDimensions(
+            is_array($result->scores_pct ?? null) ? $result->scores_pct : $this->normalizeArray($report['scores_pct'] ?? null),
+            is_array($result->axis_states ?? null) ? $result->axis_states : $this->normalizeArray($report['axis_states'] ?? null),
+            $locale
+        );
+
+        $tags = $this->resolvePublicTags($resultJson, $reportProfile, $identityCard, $dimensions);
+
+        return [
+            'scale_code' => $scaleCode,
+            'locale' => $locale,
+            'title' => $this->firstNonEmpty(
+                $publicProfile?->title,
+                $this->stringOrNull($identityCard['title'] ?? null),
+                $this->stringOrNull($identityLayer['title'] ?? null),
+                $typeName,
+                $typeCode
+            ) ?? $typeCode,
+            'subtitle' => $this->firstNonEmpty(
+                $publicProfile?->subtitle,
+                $this->stringOrNull($resultJson['subtitle'] ?? null),
+                $this->stringOrNull($identityCard['subtitle'] ?? null),
+                $this->stringOrNull($identityLayer['subtitle'] ?? null)
+            ),
+            'summary' => $this->firstNonEmpty(
+                $this->stringOrNull($resultJson['summary'] ?? null),
+                $this->stringOrNull($resultJson['short_summary'] ?? null),
+                $this->stringOrNull($identityCard['summary'] ?? null),
+                $this->stringOrNull($reportProfile['short_summary'] ?? null),
+                $publicProfile?->excerpt,
+                $this->stringOrNull($identityLayer['one_liner'] ?? null)
+            ),
+            'type_code' => $typeCode,
+            'type_name' => $typeName,
+            'tagline' => $this->firstNonEmpty(
+                $this->stringOrNull($resultJson['tagline'] ?? null),
+                $this->stringOrNull($identityCard['tagline'] ?? null),
+                $this->stringOrNull($reportProfile['tagline'] ?? null),
+                $this->extractTaglineFromTitle($publicProfile?->title)
+            ),
+            'rarity' => $this->scalarOrNull($resultJson['rarity'] ?? null)
+                ?? $this->scalarOrNull($reportProfile['rarity'] ?? null),
+            'tags' => $tags,
+            'dimensions' => $dimensions,
+            'primary_cta_label' => $this->resolvePrimaryCtaLabel($locale),
+            'primary_cta_path' => $this->resolvePrimaryCtaPath($scaleCode, $locale, (int) ($attempt->org_id ?? 0)),
+        ];
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function buildPublicSafeReportSnapshot(Attempt $attempt, Result $result): array
+    {
+        if (strtoupper(trim((string) ($attempt->scale_code ?? ''))) !== 'MBTI') {
+            return [];
+        }
+
+        try {
+            $payload = $this->reportComposer->composeVariant(
+                $attempt,
+                ReportAccess::VARIANT_FREE,
+                [
+                    'org_id' => (int) ($attempt->org_id ?? 0),
+                    'persist' => false,
+                    'modules_allowed' => ReportAccess::defaultModulesAllowedForLocked($attempt->scale_code),
+                ],
+                $result
+            );
+        } catch (\Throwable) {
+            return [];
+        }
+
+        if (($payload['ok'] ?? false) !== true || ! is_array($payload['report'] ?? null)) {
+            return [];
+        }
+
+        return $payload['report'];
+    }
+
+    private function resolvePublicProfile(
+        string $typeCode,
+        int $orgId,
+        string $scaleCode,
+        string $locale
+    ): ?PersonalityProfile {
+        $baseTypeCode = $this->baseTypeCode($typeCode);
+        if ($baseTypeCode === '') {
+            return null;
+        }
+
+        return $this->personalityProfileService->getPublicProfileByType(
+            $baseTypeCode,
+            $orgId,
+            $scaleCode,
+            $locale
+        );
+    }
+
+    private function buildShareUrl(string $shareId): string
+    {
+        return rtrim((string) config('app.frontend_url', 'http://localhost'), '/').'/share/'.$shareId;
+    }
+
+    private function normalizeLocale(string $locale): string
+    {
+        return trim($locale) === 'zh-CN' ? 'zh-CN' : 'en';
+    }
+
+    private function baseTypeCode(string $typeCode): string
+    {
+        return strtoupper(trim((string) preg_replace('/-[A-Z]$/', '', $typeCode)));
+    }
+
+    /**
+     * @param  array<string, mixed>  $payload
+     * @return array<string, mixed>
+     */
+    private function normalizeArray(mixed $payload): array
+    {
+        if (is_array($payload)) {
+            return $payload;
+        }
+
+        if (! is_string($payload) || trim($payload) === '') {
+            return [];
+        }
+
+        $decoded = json_decode($payload, true);
+
+        return is_array($decoded) ? $decoded : [];
+    }
+
+    private function stringOrNull(mixed $value): ?string
+    {
+        if (! is_scalar($value)) {
+            return null;
+        }
+
+        $normalized = trim((string) $value);
+
+        return $normalized === '' ? null : $normalized;
+    }
+
+    private function scalarOrNull(mixed $value): string|int|float|null
+    {
+        if (is_int($value) || is_float($value)) {
+            return $value;
+        }
+
+        if (is_string($value)) {
+            $normalized = trim($value);
+
+            return $normalized === '' ? null : $normalized;
+        }
+
+        return null;
+    }
+
+    private function firstNonEmpty(?string ...$candidates): ?string
+    {
+        foreach ($candidates as $candidate) {
+            if ($candidate === null) {
+                continue;
+            }
+
+            $normalized = trim($candidate);
+            if ($normalized !== '') {
+                return $normalized;
+            }
+        }
+
+        return null;
+    }
+
+    private function extractTaglineFromTitle(?string $title): ?string
+    {
+        $normalized = trim((string) $title);
+        if ($normalized === '') {
+            return null;
+        }
+
+        $parts = preg_split('/\s[-–—]\s/u', $normalized);
+        if (! is_array($parts) || count($parts) < 2) {
+            return null;
+        }
+
+        $tagline = trim((string) end($parts));
+
+        return $tagline === '' ? null : $tagline;
+    }
+
+    /**
+     * @param  array<string, mixed>  $resultJson
+     * @param  array<string, mixed>  $reportProfile
+     * @param  array<string, mixed>  $identityCard
+     * @param  list<array<string, mixed>>  $dimensions
+     * @return list<string>
+     */
+    private function resolvePublicTags(
+        array $resultJson,
+        array $reportProfile,
+        array $identityCard,
+        array $dimensions
+    ): array {
+        $sources = [
+            $this->sanitizeTags($resultJson['tags'] ?? null),
+            $this->sanitizeTags($resultJson['keywords'] ?? null),
+            $this->sanitizeTags($reportProfile['keywords'] ?? null),
+            $this->sanitizeTags($identityCard['tags'] ?? null),
+        ];
+
+        foreach ($sources as $tags) {
+            if ($tags !== []) {
+                return $tags;
+            }
+        }
+
+        $derived = [];
+        foreach ($dimensions as $dimension) {
+            $label = $this->stringOrNull($dimension['side_label'] ?? null);
+            if ($label !== null) {
+                $derived[] = $label;
+            }
+        }
+
+        return array_values(array_slice(array_unique($derived), 0, 5));
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function sanitizeTags(mixed $value): array
+    {
+        if (! is_array($value)) {
+            return [];
+        }
+
+        $tags = [];
+        foreach ($value as $item) {
+            if (! is_scalar($item)) {
+                continue;
+            }
+
+            $tag = trim((string) $item);
+            if ($tag === '' || str_contains($tag, ':')) {
+                continue;
+            }
+
+            $tags[$tag] = true;
+            if (count($tags) >= 5) {
+                break;
+            }
+        }
+
+        return array_keys($tags);
+    }
+
+    /**
+     * @param  array<string, mixed>  $scoresPct
+     * @param  array<string, mixed>  $axisStates
+     * @return list<array<string, mixed>>
+     */
+    private function buildDimensions(array $scoresPct, array $axisStates, string $locale): array
+    {
+        $definitions = $this->axisDefinitions($locale);
+        $dimensions = [];
+
+        foreach ($definitions as $code => $definition) {
+            if (! isset($scoresPct[$code]) || ! is_numeric($scoresPct[$code])) {
+                continue;
+            }
+
+            $rawPct = max(0, min(100, (int) round((float) $scoresPct[$code])));
+            $primarySide = $rawPct >= 50 ? $definition['first_code'] : $definition['second_code'];
+            $primaryPct = $rawPct >= 50 ? $rawPct : (100 - $rawPct);
+
+            $dimensions[] = [
+                'code' => $code,
+                'label' => $definition['axis_label'],
+                'side' => $primarySide,
+                'side_label' => $definition['side_labels'][$primarySide],
+                'pct' => $primaryPct,
+                'state' => $this->stringOrNull($axisStates[$code] ?? null) ?? 'moderate',
+            ];
+        }
+
+        return $dimensions;
+    }
+
+    /**
+     * @return array<string, array{
+     *   axis_label:string,
+     *   first_code:string,
+     *   second_code:string,
+     *   side_labels:array<string, string>
+     * }>
+     */
+    private function axisDefinitions(string $locale): array
+    {
+        $zh = $locale === 'zh-CN';
+
+        return [
+            'EI' => [
+                'axis_label' => $zh ? '能量方向' : 'Energy',
+                'first_code' => 'E',
+                'second_code' => 'I',
+                'side_labels' => [
+                    'E' => $zh ? '外倾' : 'Extraversion',
+                    'I' => $zh ? '内倾' : 'Introversion',
+                ],
+            ],
+            'SN' => [
+                'axis_label' => $zh ? '信息偏好' : 'Information',
+                'first_code' => 'S',
+                'second_code' => 'N',
+                'side_labels' => [
+                    'S' => $zh ? '实感' : 'Sensing',
+                    'N' => $zh ? '直觉' : 'Intuition',
+                ],
+            ],
+            'TF' => [
+                'axis_label' => $zh ? '决策偏好' : 'Decision',
+                'first_code' => 'T',
+                'second_code' => 'F',
+                'side_labels' => [
+                    'T' => $zh ? '思考' : 'Thinking',
+                    'F' => $zh ? '情感' : 'Feeling',
+                ],
+            ],
+            'JP' => [
+                'axis_label' => $zh ? '生活方式' : 'Lifestyle',
+                'first_code' => 'J',
+                'second_code' => 'P',
+                'side_labels' => [
+                    'J' => $zh ? '判断' : 'Judging',
+                    'P' => $zh ? '感知' : 'Perceiving',
+                ],
+            ],
+            'AT' => [
+                'axis_label' => $zh ? '稳定度' : 'Identity',
+                'first_code' => 'A',
+                'second_code' => 'T',
+                'side_labels' => [
+                    'A' => $zh ? '果断' : 'Assertive',
+                    'T' => $zh ? '敏感' : 'Turbulent',
+                ],
+            ],
+        ];
+    }
+
+    private function resolvePrimaryCtaLabel(string $locale): string
+    {
+        return $locale === 'zh-CN' ? '开始测试' : 'Take the test';
+    }
+
+    private function resolvePrimaryCtaPath(string $scaleCode, string $locale, int $orgId): string
+    {
+        $row = $this->scaleRegistry->getByCode($scaleCode, $orgId);
+        if (! is_array($row) && $orgId > 0) {
+            $row = $this->scaleRegistry->getByCode($scaleCode, 0);
+        }
+
+        $slug = trim((string) ($row['primary_slug'] ?? ''));
+        if ($slug === '') {
+            $slug = strtolower(trim($scaleCode)) ?: 'mbti-personality-test-16-personality-types';
+        }
+
+        $segment = $locale === 'zh-CN' ? 'zh' : 'en';
+
+        return '/'.$segment.'/tests/'.rawurlencode($slug);
     }
 }

--- a/backend/routes/api.php
+++ b/backend/routes/api.php
@@ -29,8 +29,8 @@ use App\Http\Controllers\API\V0_5\Cms\PersonalityController;
 use App\Http\Controllers\API\V0_5\Cms\TopicController;
 use App\Http\Controllers\HealthzController;
 use App\Http\Middleware\AdminAuth;
-use App\Http\Middleware\EnsureCmsAdminAuthorized;
 use App\Http\Middleware\EncryptCookies;
+use App\Http\Middleware\EnsureCmsAdminAuthorized;
 use App\Http\Middleware\HealthzAccessControl;
 use App\Http\Middleware\LimitWebhookPayloadSize;
 use App\Http\Middleware\NormalizeApiErrorContract;
@@ -164,6 +164,7 @@ Route::prefix('v0.3')->middleware([
         Route::get('/attempts/{id}/report.pdf', [AttemptReadController::class, 'reportPdf'])
             ->middleware('uuid:id')
             ->name('api.v0_3.attempts.report_pdf');
+        // Share contract routes stay fixed; summary/click semantics are implemented in ShareController/services.
         Route::get('/attempts/{id}/share', [ShareV03Controller::class, 'getShare'])
             ->middleware(\App\Http\Middleware\FmTokenAuth::class);
 

--- a/backend/tests/Feature/V0_3/ShareClickAttributionTest.php
+++ b/backend/tests/Feature/V0_3/ShareClickAttributionTest.php
@@ -1,0 +1,166 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\V0_3;
+
+use App\Models\Attempt;
+use App\Models\Event;
+use App\Models\Result;
+use App\Models\Share;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Str;
+use Tests\TestCase;
+
+final class ShareClickAttributionTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_click_accepts_legacy_body_and_returns_lightweight_response(): void
+    {
+        $share = $this->createShareFixture('legacy_click_owner');
+
+        $response = $this->postJson("/api/v0.3/shares/{$share->id}/click", [
+            'anon_id' => 'legacy_click_probe',
+            'meta_json' => [
+                'legacy_marker' => 'keep_me',
+                'utm' => [
+                    'source' => 'legacy-source',
+                ],
+            ],
+        ]);
+
+        $response->assertOk()
+            ->assertJsonPath('ok', true)
+            ->assertJsonPath('share_id', (string) $share->id)
+            ->assertJsonMissingPath('report')
+            ->assertJsonMissingPath('result');
+
+        $event = Event::query()
+            ->where('event_code', 'share_click')
+            ->where('share_id', (string) $share->id)
+            ->latest('created_at')
+            ->firstOrFail();
+
+        $this->assertSame('legacy_click_probe', (string) $event->anon_id);
+        $this->assertSame('keep_me', data_get($event->meta_json, 'legacy_marker'));
+        $this->assertSame('legacy-source', data_get($event->meta_json, 'utm.source'));
+        $this->assertSame((string) $share->attempt_id, data_get($event->meta_json, 'attempt_id'));
+    }
+
+    public function test_click_persists_new_attribution_meta_without_share_generate_dependency(): void
+    {
+        $share = $this->createShareFixture('scan_owner_anon');
+
+        $response = $this->withHeaders([
+            'Referer' => 'https://ref.example/share',
+        ])->postJson("/api/v0.3/shares/{$share->id}/click", [
+            'anon_id' => 'scan_probe',
+            'meta' => [
+                'entrypoint' => 'share_page',
+                'utm' => [
+                    'source' => 'share',
+                    'medium' => 'organic',
+                    'campaign' => 'pr06',
+                    'term' => 'mbti',
+                    'content' => 'hero',
+                ],
+                'landing_path' => '/zh/share/'.(string) $share->id,
+                'compare_intent' => false,
+            ],
+        ]);
+
+        $response->assertOk()
+            ->assertJsonPath('ok', true)
+            ->assertJsonPath('share_id', (string) $share->id)
+            ->assertJsonMissingPath('report')
+            ->assertJsonMissingPath('result');
+
+        $event = Event::query()
+            ->where('event_code', 'share_click')
+            ->where('share_id', (string) $share->id)
+            ->latest('created_at')
+            ->firstOrFail();
+
+        $this->assertSame('scan_probe', (string) $event->anon_id);
+        $this->assertSame('share_page', data_get($event->meta_json, 'entrypoint'));
+        $this->assertSame('share', data_get($event->meta_json, 'utm.source'));
+        $this->assertSame('organic', data_get($event->meta_json, 'utm.medium'));
+        $this->assertSame('pr06', data_get($event->meta_json, 'utm.campaign'));
+        $this->assertSame('mbti', data_get($event->meta_json, 'utm.term'));
+        $this->assertSame('hero', data_get($event->meta_json, 'utm.content'));
+        $this->assertSame('https://ref.example/share', data_get($event->meta_json, 'referrer'));
+        $this->assertSame('/zh/share/'.(string) $share->id, data_get($event->meta_json, 'landing_path'));
+        $this->assertFalse((bool) data_get($event->meta_json, 'compare_intent'));
+        $this->assertSame('INTJ-A', data_get($event->meta_json, 'type_code'));
+        $this->assertSame((string) $share->attempt_id, data_get($event->meta_json, 'attempt_id'));
+    }
+
+    private function createShareFixture(string $ownerAnonId): Share
+    {
+        $attemptId = (string) Str::uuid();
+
+        Attempt::create([
+            'id' => $attemptId,
+            'org_id' => 0,
+            'anon_id' => $ownerAnonId,
+            'scale_code' => 'MBTI',
+            'scale_version' => 'v0.3',
+            'region' => 'CN_MAINLAND',
+            'locale' => 'zh-CN',
+            'question_count' => 144,
+            'client_platform' => 'test',
+            'answers_summary_json' => ['stage' => 'seed'],
+            'started_at' => now()->subMinute(),
+            'submitted_at' => now(),
+            'pack_id' => (string) config('content_packs.default_pack_id', 'MBTI.cn-mainland.zh-CN.v0.3'),
+            'dir_version' => (string) config('content_packs.default_dir_version', 'MBTI-CN-v0.3'),
+            'content_package_version' => 'v0.3',
+            'scoring_spec_version' => '2026.01',
+        ]);
+
+        Result::create([
+            'id' => (string) Str::uuid(),
+            'org_id' => 0,
+            'attempt_id' => $attemptId,
+            'scale_code' => 'MBTI',
+            'scale_version' => 'v0.3',
+            'type_code' => 'INTJ-A',
+            'scores_json' => ['total' => 100],
+            'scores_pct' => [
+                'EI' => 35,
+                'SN' => 72,
+                'TF' => 68,
+                'JP' => 63,
+                'AT' => 58,
+            ],
+            'axis_states' => [
+                'EI' => 'clear',
+                'SN' => 'clear',
+                'TF' => 'clear',
+                'JP' => 'moderate',
+                'AT' => 'moderate',
+            ],
+            'profile_version' => 'mbti32-v2.5',
+            'content_package_version' => 'v0.3',
+            'result_json' => ['type_code' => 'INTJ-A'],
+            'pack_id' => (string) config('content_packs.default_pack_id', 'MBTI.cn-mainland.zh-CN.v0.3'),
+            'dir_version' => (string) config('content_packs.default_dir_version', 'MBTI-CN-v0.3'),
+            'scoring_spec_version' => '2026.01',
+            'report_engine_version' => 'v1.2',
+            'is_valid' => true,
+            'computed_at' => now(),
+        ]);
+
+        $share = new Share;
+        $share->id = bin2hex(random_bytes(16));
+        $share->attempt_id = $attemptId;
+        $share->anon_id = $ownerAnonId;
+        $share->scale_code = 'MBTI';
+        $share->scale_version = 'v0.3';
+        $share->content_package_version = 'v0.3';
+        $share->save();
+
+        return $share;
+    }
+}

--- a/backend/tests/Feature/V0_3/ShareFlowCoreAlignmentTest.php
+++ b/backend/tests/Feature/V0_3/ShareFlowCoreAlignmentTest.php
@@ -58,7 +58,9 @@ final class ShareFlowCoreAlignmentTest extends TestCase
         $this->assertSame((string) ($v03['attempt_id'] ?? ''), (string) ($legacy['attempt_id'] ?? ''));
         $this->assertSame((int) ($v03['org_id'] ?? -1), (int) ($legacy['org_id'] ?? -2));
         $this->assertSame((string) ($v03['type_code'] ?? ''), (string) ($legacy['type_code'] ?? ''));
-        $this->assertSame((string) ($v03['type_name'] ?? ''), (string) ($legacy['type_name'] ?? ''));
+        $this->assertNotSame('', trim((string) ($v03['type_name'] ?? '')));
+        $this->assertArrayHasKey('title', $v03);
+        $this->assertArrayHasKey('summary', $v03);
 
         $shareId = (string) ($v03['share_id'] ?? '');
         $this->assertNotSame('', $shareId);
@@ -70,7 +72,8 @@ final class ShareFlowCoreAlignmentTest extends TestCase
         $this->assertSame((string) ($v03View['attempt_id'] ?? ''), (string) ($legacyView['attempt_id'] ?? ''));
         $this->assertSame((int) ($v03View['org_id'] ?? -1), (int) ($legacyView['org_id'] ?? -2));
         $this->assertSame((string) ($v03View['type_code'] ?? ''), (string) ($legacyView['type_code'] ?? ''));
-        $this->assertSame((string) ($v03View['type_name'] ?? ''), (string) ($legacyView['type_name'] ?? ''));
+        $this->assertNotSame('', trim((string) ($v03View['type_name'] ?? '')));
+        $this->assertArrayHasKey('dimensions', $v03View);
     }
 
     private function seedScaleRegistry(int $orgId, string $benefitCode): void

--- a/backend/tests/Feature/V0_3/ShareSummaryContractTest.php
+++ b/backend/tests/Feature/V0_3/ShareSummaryContractTest.php
@@ -1,0 +1,283 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\V0_3;
+
+use App\Models\Attempt;
+use App\Models\PersonalityProfile;
+use App\Models\Result;
+use App\Services\Commerce\EntitlementManager;
+use Database\Seeders\ScaleRegistrySeeder;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Str;
+use Tests\TestCase;
+
+final class ShareSummaryContractTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_attempt_share_returns_canonical_public_safe_summary_contract(): void
+    {
+        $this->seedScales();
+
+        $anonId = 'anon_share_summary_contract';
+        $attemptId = $this->createAttemptWithResult($anonId);
+        $this->createPublicProfile('INTJ', 'zh-CN', 'INTJ - Architect', '独立、冷静、面向长期规划', '公开人格简介兜底文案');
+        $token = $this->issueAnonToken($anonId);
+        $this->grantShareAccess($attemptId, $anonId);
+
+        $response = $this->withHeaders([
+            'Authorization' => 'Bearer '.$token,
+            'X-Anon-Id' => $anonId,
+        ])->getJson("/api/v0.3/attempts/{$attemptId}/share");
+
+        $response->assertOk()
+            ->assertJsonPath('ok', true)
+            ->assertJsonPath('attempt_id', $attemptId)
+            ->assertJsonPath('id', $response->json('share_id'))
+            ->assertJsonPath('scale_code', 'MBTI')
+            ->assertJsonPath('locale', 'zh-CN')
+            ->assertJsonPath('title', 'INTJ - Architect')
+            ->assertJsonPath('subtitle', '独立、冷静、面向长期规划')
+            ->assertJsonPath('summary', 'Public-safe share summary.')
+            ->assertJsonPath('type_code', 'INTJ-A')
+            ->assertJsonPath('type_name', '建筑师型')
+            ->assertJsonPath('tagline', '冷静的长期规划者')
+            ->assertJsonPath('rarity', '约 2%')
+            ->assertJsonPath('tags.0', '战略')
+            ->assertJsonPath('primary_cta_label', '开始测试')
+            ->assertJsonPath('primary_cta_path', '/zh/tests/mbti-personality-test-16-personality-types')
+            ->assertJsonMissingPath('report')
+            ->assertJsonMissingPath('result')
+            ->assertJsonMissingPath('offers')
+            ->assertJsonMissingPath('recommended_reads')
+            ->assertJsonMissingPath('layers')
+            ->assertJsonMissingPath('sections')
+            ->assertJsonMissingPath('cta');
+
+        $this->assertCount(5, (array) $response->json('dimensions'));
+        $this->assertSame('EI', $response->json('dimensions.0.code'));
+        $this->assertSame('I', $response->json('dimensions.0.side'));
+        $this->assertSame(65, $response->json('dimensions.0.pct'));
+        $this->assertSame('clear', $response->json('dimensions.0.state'));
+        $this->assertStringContainsString('/share/'.$response->json('share_id'), (string) $response->json('share_url'));
+        $this->assertStringNotContainsString('PRIVATE_PAID_SECTION_BODY', (string) $response->getContent());
+        $this->assertStringNotContainsString('PRIVATE_RESULT_PATH', (string) $response->getContent());
+        $this->assertStringNotContainsString('PRIVATE_RECOMMENDED_READ', (string) $response->getContent());
+    }
+
+    public function test_public_share_view_matches_summary_contract_without_private_payload_leaks(): void
+    {
+        $this->seedScales();
+
+        $anonId = 'anon_share_view_contract';
+        $attemptId = $this->createAttemptWithResult($anonId);
+        $this->createPublicProfile('INTJ', 'zh-CN', 'INTJ - Architect', '独立、冷静、面向长期规划', '公开人格简介兜底文案');
+        $token = $this->issueAnonToken($anonId);
+        $this->grantShareAccess($attemptId, $anonId);
+
+        $share = $this->withHeaders([
+            'Authorization' => 'Bearer '.$token,
+            'X-Anon-Id' => $anonId,
+        ])->getJson("/api/v0.3/attempts/{$attemptId}/share");
+
+        $share->assertOk();
+        $shareId = (string) $share->json('share_id');
+        $this->assertNotSame('', $shareId);
+
+        $view = $this->getJson("/api/v0.3/shares/{$shareId}");
+        $view->assertOk()
+            ->assertJsonPath('ok', true)
+            ->assertJsonPath('share_id', $shareId)
+            ->assertJsonPath('id', $shareId)
+            ->assertJsonPath('title', 'INTJ - Architect')
+            ->assertJsonPath('subtitle', '独立、冷静、面向长期规划')
+            ->assertJsonPath('summary', 'Public-safe share summary.')
+            ->assertJsonPath('type_code', 'INTJ-A')
+            ->assertJsonPath('type_name', '建筑师型')
+            ->assertJsonPath('tagline', '冷静的长期规划者')
+            ->assertJsonPath('rarity', '约 2%')
+            ->assertJsonPath('primary_cta_label', '开始测试')
+            ->assertJsonPath('primary_cta_path', '/zh/tests/mbti-personality-test-16-personality-types')
+            ->assertJsonMissingPath('report')
+            ->assertJsonMissingPath('result')
+            ->assertJsonMissingPath('offers')
+            ->assertJsonMissingPath('recommended_reads')
+            ->assertJsonMissingPath('layers')
+            ->assertJsonMissingPath('sections')
+            ->assertJsonMissingPath('cta');
+
+        foreach ([
+            'share_url',
+            'scale_code',
+            'locale',
+            'title',
+            'subtitle',
+            'summary',
+            'type_code',
+            'type_name',
+            'tagline',
+            'rarity',
+            'tags',
+            'dimensions',
+            'primary_cta_label',
+            'primary_cta_path',
+        ] as $key) {
+            $this->assertSame($share->json($key), $view->json($key), "share field mismatch: {$key}");
+        }
+
+        $this->assertStringNotContainsString('PRIVATE_PAID_SECTION_BODY', (string) $view->getContent());
+        $this->assertStringNotContainsString('PRIVATE_RESULT_PATH', (string) $view->getContent());
+        $this->assertStringNotContainsString('PRIVATE_RECOMMENDED_READ', (string) $view->getContent());
+    }
+
+    private function seedScales(): void
+    {
+        (new ScaleRegistrySeeder)->run();
+    }
+
+    private function issueAnonToken(string $anonId): string
+    {
+        $token = 'fm_'.(string) Str::uuid();
+
+        DB::table('fm_tokens')->insert([
+            'token' => $token,
+            'token_hash' => hash('sha256', $token),
+            'user_id' => null,
+            'anon_id' => $anonId,
+            'org_id' => 0,
+            'role' => 'public',
+            'expires_at' => now()->addDay(),
+            'created_at' => now(),
+            'updated_at' => now(),
+        ]);
+
+        return $token;
+    }
+
+    private function grantShareAccess(string $attemptId, string $anonId): void
+    {
+        app(EntitlementManager::class)->grantAttemptUnlock(
+            0,
+            null,
+            $anonId,
+            'MBTI_REPORT_FULL',
+            $attemptId,
+            null
+        );
+    }
+
+    private function createAttemptWithResult(string $anonId): string
+    {
+        $attemptId = (string) Str::uuid();
+
+        Attempt::create([
+            'id' => $attemptId,
+            'org_id' => 0,
+            'anon_id' => $anonId,
+            'scale_code' => 'MBTI',
+            'scale_code_v2' => 'MBTI_PERSONALITY_TEST_16_TYPES',
+            'scale_uid' => '11111111-1111-4111-8111-111111111111',
+            'scale_version' => 'v0.3',
+            'region' => 'CN_MAINLAND',
+            'locale' => 'zh-CN',
+            'question_count' => 144,
+            'client_platform' => 'test',
+            'answers_summary_json' => ['stage' => 'seed'],
+            'started_at' => now()->subMinute(),
+            'submitted_at' => now(),
+            'pack_id' => (string) config('content_packs.default_pack_id', 'MBTI.cn-mainland.zh-CN.v0.3'),
+            'dir_version' => (string) config('content_packs.default_dir_version', 'MBTI-CN-v0.3'),
+            'content_package_version' => 'v0.3',
+            'scoring_spec_version' => '2026.01',
+        ]);
+
+        Result::create([
+            'id' => (string) Str::uuid(),
+            'org_id' => 0,
+            'attempt_id' => $attemptId,
+            'scale_code' => 'MBTI',
+            'scale_code_v2' => 'MBTI_PERSONALITY_TEST_16_TYPES',
+            'scale_uid' => '11111111-1111-4111-8111-111111111111',
+            'scale_version' => 'v0.3',
+            'type_code' => 'INTJ-A',
+            'scores_json' => [
+                'EI' => ['a' => 13, 'b' => 7, 'neutral' => 0, 'sum' => -6, 'total' => 20],
+                'SN' => ['a' => 6, 'b' => 14, 'neutral' => 0, 'sum' => 8, 'total' => 20],
+                'TF' => ['a' => 14, 'b' => 6, 'neutral' => 0, 'sum' => -8, 'total' => 20],
+                'JP' => ['a' => 12, 'b' => 8, 'neutral' => 0, 'sum' => -4, 'total' => 20],
+                'AT' => ['a' => 11, 'b' => 9, 'neutral' => 0, 'sum' => 2, 'total' => 20],
+            ],
+            'scores_pct' => [
+                'EI' => 35,
+                'SN' => 72,
+                'TF' => 68,
+                'JP' => 63,
+                'AT' => 58,
+            ],
+            'axis_states' => [
+                'EI' => 'clear',
+                'SN' => 'clear',
+                'TF' => 'clear',
+                'JP' => 'moderate',
+                'AT' => 'moderate',
+            ],
+            'profile_version' => 'mbti32-v2.5',
+            'content_package_version' => 'v0.3',
+            'result_json' => [
+                'type_code' => 'INTJ-A',
+                'type_name' => '建筑师型',
+                'summary' => 'Public-safe share summary.',
+                'tagline' => '冷静的长期规划者',
+                'rarity' => '约 2%',
+                'keywords' => ['战略', '独立', '前瞻'],
+                'recommended_reads' => [
+                    ['title' => 'PRIVATE_RECOMMENDED_READ'],
+                ],
+                'cta' => [
+                    'primary_label' => 'PRIVATE_CTA',
+                ],
+                'layers' => [
+                    'identity' => [
+                        'body' => 'PRIVATE_PAID_SECTION_BODY',
+                    ],
+                ],
+                'result_path' => 'PRIVATE_RESULT_PATH',
+            ],
+            'pack_id' => (string) config('content_packs.default_pack_id', 'MBTI.cn-mainland.zh-CN.v0.3'),
+            'dir_version' => (string) config('content_packs.default_dir_version', 'MBTI-CN-v0.3'),
+            'scoring_spec_version' => '2026.01',
+            'report_engine_version' => 'v1.2',
+            'is_valid' => true,
+            'computed_at' => now(),
+        ]);
+
+        return $attemptId;
+    }
+
+    private function createPublicProfile(
+        string $typeCode,
+        string $locale,
+        string $title,
+        string $subtitle,
+        string $excerpt
+    ): void {
+        PersonalityProfile::query()->create([
+            'org_id' => 0,
+            'scale_code' => 'MBTI',
+            'type_code' => $typeCode,
+            'slug' => strtolower($typeCode),
+            'locale' => $locale,
+            'title' => $title,
+            'subtitle' => $subtitle,
+            'excerpt' => $excerpt,
+            'status' => 'published',
+            'is_public' => true,
+            'is_indexable' => true,
+            'published_at' => now()->subMinute(),
+            'schema_version' => 'v1',
+        ]);
+    }
+}


### PR DESCRIPTION
## Summary

- freeze the MBTI public share summary contract for `GET /api/v0.3/attempts/{id}/share`
- align `GET /api/v0.3/shares/{id}` to the same public-safe summary payload
- keep `POST /api/v0.3/shares/{shareId}/click` lightweight while persisting richer attribution into `meta_json`

## Scope

- no report contract change
- no checkout/webhook change
- no migration
- no compare / referral reward

## Verification

- `php artisan route:list | rg 'attempts/.*/share|shares/.*/click|shares/.+'`
- `php artisan migrate`
- `php artisan test tests/Feature/V0_3/ShareSummaryContractTest.php`
- `php artisan test tests/Feature/V0_3/ShareClickAttributionTest.php`
- `php artisan test tests/Feature/V0_3/AttemptPublicReportReadHotfixTest.php`
- `php artisan test tests/Feature/V0_3/ShareFlowCoreAlignmentTest.php tests/Feature/V0_3/ShareScaleIdentityDualWriteTest.php tests/Feature/V0_3/RateLimitKeyEndpointsTest.php tests/Feature/UuidRouteParamsMiddlewareTest.php`
- `./vendor/bin/pint routes/api.php app/Http/Controllers/API/V0_3/ShareController.php app/Http/Requests/V0_3/ShareClickRequest.php app/Services/Share/ShareFlowCoreService.php app/Services/V0_3/ShareFlowService.php app/Services/V0_3/ShareService.php tests/Feature/V0_3/ShareFlowCoreAlignmentTest.php tests/Feature/V0_3/ShareSummaryContractTest.php tests/Feature/V0_3/ShareClickAttributionTest.php`
- `bash backend/scripts/ci_verify_mbti.sh`
