### PR TITLE
feat(share): add MBTI compare invite and attribution contract

### DIFF
--- a/backend/app/DTO/Attempts/SubmitAttemptDTO.php
+++ b/backend/app/DTO/Attempts/SubmitAttemptDTO.php
@@ -9,6 +9,7 @@ final class SubmitAttemptDTO
     /**
      * @param  array<int, array<string, mixed>>  $answers
      * @param  array<int, array{item_id:string,code:int}>  $validityItems
+     * @param  array<string, string>|null  $utm
      */
     public function __construct(
         public readonly array $answers,
@@ -20,6 +21,13 @@ final class SubmitAttemptDTO
         public readonly string $inviteToken,
         public readonly ?string $userId,
         public readonly ?string $anonId,
+        public readonly ?string $shareId,
+        public readonly ?string $compareInviteId,
+        public readonly ?string $shareClickId,
+        public readonly ?string $entrypoint,
+        public readonly ?string $referrer,
+        public readonly ?string $landingPath,
+        public readonly ?array $utm,
     ) {}
 
     /**
@@ -68,6 +76,19 @@ final class SubmitAttemptDTO
             $consent = [];
         }
 
+        $utm = $payload['utm'] ?? null;
+        if (! is_array($utm)) {
+            $utm = null;
+        }
+
+        $normalizedUtm = [];
+        foreach (['source', 'medium', 'campaign', 'term', 'content'] as $key) {
+            $value = self::nullableString($utm[$key] ?? null);
+            if ($value !== null) {
+                $normalizedUtm[$key] = $value;
+            }
+        }
+
         return new self(
             answers: $normalizedAnswers,
             validityItems: $normalizedValidityItems,
@@ -78,6 +99,13 @@ final class SubmitAttemptDTO
             inviteToken: trim((string) ($payload['invite_token'] ?? '')),
             userId: self::normalizeUserId($payload['user_id'] ?? null),
             anonId: self::nullableString($payload['anon_id'] ?? null),
+            shareId: self::nullableString($payload['share_id'] ?? null),
+            compareInviteId: self::nullableString($payload['compare_invite_id'] ?? null),
+            shareClickId: self::nullableString($payload['share_click_id'] ?? null),
+            entrypoint: self::nullableString($payload['entrypoint'] ?? null),
+            referrer: self::nullableString($payload['referrer'] ?? null),
+            landingPath: self::nullableString($payload['landing_path'] ?? null),
+            utm: $normalizedUtm !== [] ? $normalizedUtm : null,
         );
     }
 

--- a/backend/app/Http/Controllers/API/V0_3/CommerceController.php
+++ b/backend/app/Http/Controllers/API/V0_3/CommerceController.php
@@ -165,7 +165,20 @@ class CommerceController extends Controller
             'order_no' => ['nullable', 'string', 'max:64'],
             'provider' => ['nullable', 'string', 'max:32'],
             'idempotency_key' => ['nullable', 'string', 'max:128'],
+            'share_id' => ['nullable', 'string', 'max:128'],
+            'compare_invite_id' => ['nullable', 'string', 'max:128'],
+            'share_click_id' => ['nullable', 'string', 'max:128'],
+            'entrypoint' => ['nullable', 'string', 'max:128'],
+            'referrer' => ['nullable', 'string', 'max:2048'],
+            'landing_path' => ['nullable', 'string', 'max:2048'],
+            'utm' => ['nullable'],
+            'utm_source' => ['nullable', 'string', 'max:512'],
+            'utm_medium' => ['nullable', 'string', 'max:512'],
+            'utm_campaign' => ['nullable', 'string', 'max:512'],
+            'utm_term' => ['nullable', 'string', 'max:512'],
+            'utm_content' => ['nullable', 'string', 'max:512'],
         ]);
+        $attribution = $this->extractAttribution($request, $payload);
 
         $orgId = $this->orgContext->orgId();
         $userId = $this->orgContext->userId();
@@ -180,6 +193,9 @@ class CommerceController extends Controller
             $existing = $this->orders->getOrder($orgId, $userId !== null ? (string) $userId : null, $anonId, $existingOrderNo);
             if ($existing['ok'] ?? false) {
                 $order = $existing['order'];
+                if ($attribution !== []) {
+                    $this->orders->mergeAttribution((string) ($order->order_no ?? $existingOrderNo), $orgId, $attribution);
+                }
 
                 $provider = strtolower(trim((string) ($order->provider ?? '')));
                 if ($provider === '') {
@@ -229,13 +245,19 @@ class CommerceController extends Controller
             $provider,
             $idempotencyKey,
             $contactEmail,
-            $this->resolveRequestId($request)
+            $this->resolveRequestId($request),
+            $attribution
         );
 
         if (! ($created['ok'] ?? false)) {
             $status = $this->mapErrorStatus((string) data_get($created, 'error_code', data_get($created, 'error', '')));
             $message = trim((string) ($created['message'] ?? 'request failed.'));
             abort($status, $message);
+        }
+
+        $orderNoForAttribution = trim((string) data_get($created, 'order.order_no', $created['order_no'] ?? ''));
+        if ($orderNoForAttribution !== '' && $attribution !== []) {
+            $this->orders->mergeAttribution($orderNoForAttribution, $orgId, $attribution);
         }
 
         $order = $created['order'] ?? null;
@@ -740,5 +762,92 @@ class CommerceController extends Controller
             'refunded' => 'Order refunded.',
             default => 'Confirming your payment...',
         };
+    }
+
+    /**
+     * @param  array<string, mixed>  $payload
+     * @return array<string, mixed>
+     */
+    private function extractAttribution(Request $request, array $payload): array
+    {
+        $attribution = [];
+
+        foreach ([
+            'share_id' => 128,
+            'compare_invite_id' => 128,
+            'share_click_id' => 128,
+            'entrypoint' => 128,
+            'referrer' => 2048,
+            'landing_path' => 2048,
+        ] as $field => $maxLength) {
+            $value = $this->truncateNullableString($payload[$field] ?? $request->input($field), $maxLength);
+            if ($value !== null) {
+                $attribution[$field] = $value;
+            }
+        }
+
+        $utm = $this->normalizeUtm($payload['utm'] ?? $request->input('utm'));
+        $flatUtm = $this->normalizeFlatUtm($request, $payload);
+        $mergedUtm = array_replace($utm ?? [], $flatUtm);
+        if ($mergedUtm !== []) {
+            $attribution['utm'] = $mergedUtm;
+        }
+
+        return $attribution;
+    }
+
+    /**
+     * @return array<string, string>|null
+     */
+    private function normalizeUtm(mixed $value): ?array
+    {
+        if (! is_array($value)) {
+            return null;
+        }
+
+        $normalized = [];
+        foreach (['source', 'medium', 'campaign', 'term', 'content'] as $key) {
+            $candidate = $this->truncateNullableString($value[$key] ?? null, 512);
+            if ($candidate !== null) {
+                $normalized[$key] = $candidate;
+            }
+        }
+
+        return $normalized === [] ? null : $normalized;
+    }
+
+    /**
+     * @param  array<string, mixed>  $payload
+     * @return array<string, string>
+     */
+    private function normalizeFlatUtm(Request $request, array $payload): array
+    {
+        $normalized = [];
+        foreach (['source', 'medium', 'campaign', 'term', 'content'] as $key) {
+            $candidate = $this->truncateNullableString($payload['utm_'.$key] ?? $request->input('utm_'.$key), 512);
+            if ($candidate !== null) {
+                $normalized[$key] = $candidate;
+            }
+        }
+
+        return $normalized;
+    }
+
+    private function truncateNullableString(mixed $value, int $maxLength): ?string
+    {
+        if (! is_string($value) && ! is_numeric($value)) {
+            return null;
+        }
+
+        $normalized = trim((string) $value);
+        if ($normalized === '') {
+            return null;
+        }
+
+        if (mb_strlen($normalized, 'UTF-8') > $maxLength) {
+            $normalized = mb_substr($normalized, 0, $maxLength, 'UTF-8');
+        }
+
+        return $normalized;
     }
 }

--- a/backend/app/Http/Controllers/API/V0_3/MbtiCompareInviteController.php
+++ b/backend/app/Http/Controllers/API/V0_3/MbtiCompareInviteController.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Controllers\API\V0_3;
+
+use App\Http\Controllers\Controller;
+use App\Http\Requests\V0_3\CreateMbtiCompareInviteRequest;
+use App\Services\V0_3\MbtiCompareInviteService;
+use Illuminate\Http\JsonResponse;
+
+final class MbtiCompareInviteController extends Controller
+{
+    public function __construct(private readonly MbtiCompareInviteService $service) {}
+
+    public function store(CreateMbtiCompareInviteRequest $request, string $shareId): JsonResponse
+    {
+        $result = $this->service->create((string) $request->route('shareId', $shareId), $request->validated());
+
+        return response()->json(array_merge(['ok' => true], $result));
+    }
+
+    public function show(string $inviteId): JsonResponse
+    {
+        $result = $this->service->show($inviteId);
+
+        return response()->json(array_merge(['ok' => true], $result));
+    }
+}

--- a/backend/app/Http/Requests/V0_3/CreateMbtiCompareInviteRequest.php
+++ b/backend/app/Http/Requests/V0_3/CreateMbtiCompareInviteRequest.php
@@ -1,12 +1,14 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Http\Requests\V0_3;
 
 use App\Exceptions\Api\ApiProblemException;
 use Illuminate\Foundation\Http\FormRequest;
 use Illuminate\Validation\Validator;
 
-class ShareClickRequest extends FormRequest
+final class CreateMbtiCompareInviteRequest extends FormRequest
 {
     public function authorize(): bool
     {
@@ -40,6 +42,11 @@ class ShareClickRequest extends FormRequest
             }
         }
 
+        $metaShareClickId = $this->normalizeString($mergedMeta['share_click_id'] ?? null, 128);
+        if ($metaShareClickId !== null) {
+            $mergedMeta['share_click_id'] = $metaShareClickId;
+        }
+
         if ($this->has('compare_intent')) {
             $mergedMeta['compare_intent'] = $this->boolean('compare_intent');
         } elseif (array_key_exists('compare_intent', $mergedMeta)) {
@@ -61,27 +68,19 @@ class ShareClickRequest extends FormRequest
     {
         return [
             'anon_id' => ['nullable', 'string', 'max:128'],
-            'occurred_at' => ['nullable', 'date'],
-            'meta_json' => ['nullable', 'array'],
-            'meta' => ['nullable'],
-            'ref' => ['nullable', 'string', 'max:1024'],
-            'ua' => ['nullable', 'string', 'max:1024'],
-            'ip' => ['nullable', 'string', 'max:64'],
+            'entrypoint' => ['nullable', 'string', 'max:128'],
+            'referrer' => ['nullable', 'string', 'max:2048'],
+            'landing_path' => ['nullable', 'string', 'max:2048'],
+            'compare_intent' => ['nullable', 'boolean'],
             'utm' => ['nullable'],
             'utm_source' => ['nullable', 'string', 'max:512'],
             'utm_medium' => ['nullable', 'string', 'max:512'],
             'utm_campaign' => ['nullable', 'string', 'max:512'],
             'utm_term' => ['nullable', 'string', 'max:512'],
             'utm_content' => ['nullable', 'string', 'max:512'],
-            'experiment' => ['nullable', 'string', 'max:64'],
-            'version' => ['nullable', 'string', 'max:64'],
-            'url' => ['nullable', 'string', 'max:2048'],
-            'trace_id' => ['nullable', 'string', 'max:128'],
-            'entrypoint' => ['nullable', 'string', 'max:128'],
-            'referrer' => ['nullable', 'string', 'max:2048'],
-            'landing_path' => ['nullable', 'string', 'max:2048'],
-            'compare_intent' => ['nullable', 'boolean'],
             'share_click_id' => ['nullable', 'string', 'max:128'],
+            'meta_json' => ['nullable', 'array'],
+            'meta' => ['nullable'],
         ];
     }
 

--- a/backend/app/Http/Requests/V0_3/StartAttemptRequest.php
+++ b/backend/app/Http/Requests/V0_3/StartAttemptRequest.php
@@ -11,6 +11,44 @@ class StartAttemptRequest extends FormRequest
         return true;
     }
 
+    protected function prepareForValidation(): void
+    {
+        $meta = $this->input('meta');
+        $meta = is_array($meta) ? $meta : [];
+
+        $normalizedUtm = $this->normalizeUtm($this->input('utm'));
+        $flatUtm = $this->normalizeFlatUtm();
+        if ($normalizedUtm !== null || $flatUtm !== null) {
+            $existingUtm = $this->normalizeUtm($meta['utm'] ?? null) ?? [];
+            $meta['utm'] = array_replace($existingUtm, $normalizedUtm ?? [], $flatUtm ?? []);
+        }
+
+        foreach ([
+            'share_id' => 128,
+            'compare_invite_id' => 128,
+            'share_click_id' => 128,
+            'entrypoint' => 128,
+            'landing_path' => 2048,
+        ] as $field => $maxLength) {
+            $value = $this->normalizeString($this->input($field), $maxLength);
+            if ($value !== null) {
+                $meta[$field] = $value;
+            }
+        }
+
+        $referrer = $this->normalizeString($this->input('referrer'), 255);
+        if ($referrer !== null) {
+            $this->merge([
+                'referrer' => $referrer,
+            ]);
+            $meta['referrer'] = $referrer;
+        }
+
+        $this->merge([
+            'meta' => $this->filterMeta($meta),
+        ]);
+    }
+
     public function rules(): array
     {
         return [
@@ -23,11 +61,106 @@ class StartAttemptRequest extends FormRequest
             'channel' => ['nullable', 'string', 'max:32'],
             'referrer' => ['nullable', 'string', 'max:255'],
             'meta' => ['sometimes', 'array'],
+            'share_id' => ['nullable', 'string', 'max:128'],
+            'compare_invite_id' => ['nullable', 'string', 'max:128'],
+            'share_click_id' => ['nullable', 'string', 'max:128'],
+            'entrypoint' => ['nullable', 'string', 'max:128'],
+            'landing_path' => ['nullable', 'string', 'max:2048'],
+            'utm' => ['nullable'],
+            'utm_source' => ['nullable', 'string', 'max:512'],
+            'utm_medium' => ['nullable', 'string', 'max:512'],
+            'utm_campaign' => ['nullable', 'string', 'max:512'],
+            'utm_term' => ['nullable', 'string', 'max:512'],
+            'utm_content' => ['nullable', 'string', 'max:512'],
             'consent' => ['sometimes', 'array'],
             'consent.accepted' => ['sometimes', 'boolean'],
             'consent.version' => ['sometimes', 'string', 'max:128'],
             'consent.hash' => ['sometimes', 'string', 'size:64'],
             'consent.locale' => ['nullable', 'string', 'max:16'],
         ];
+    }
+
+    /**
+     * @return array<string, string>|null
+     */
+    private function normalizeUtm(mixed $value): ?array
+    {
+        if (! is_array($value)) {
+            return null;
+        }
+
+        $normalized = [];
+        foreach (['source', 'medium', 'campaign', 'term', 'content'] as $key) {
+            $candidate = $this->normalizeString($value[$key] ?? null, 512);
+            if ($candidate !== null) {
+                $normalized[$key] = $candidate;
+            }
+        }
+
+        return $normalized === [] ? null : $normalized;
+    }
+
+    /**
+     * @return array<string, string>|null
+     */
+    private function normalizeFlatUtm(): ?array
+    {
+        $normalized = [];
+        foreach (['source', 'medium', 'campaign', 'term', 'content'] as $key) {
+            $candidate = $this->normalizeString($this->input('utm_'.$key), 512);
+            if ($candidate !== null) {
+                $normalized[$key] = $candidate;
+            }
+        }
+
+        return $normalized === [] ? null : $normalized;
+    }
+
+    private function normalizeString(mixed $value, int $maxLength): ?string
+    {
+        if (! is_scalar($value)) {
+            return null;
+        }
+
+        $normalized = trim((string) $value);
+        if ($normalized === '') {
+            return null;
+        }
+
+        if (mb_strlen($normalized, 'UTF-8') > $maxLength) {
+            $normalized = mb_substr($normalized, 0, $maxLength, 'UTF-8');
+        }
+
+        return $normalized;
+    }
+
+    /**
+     * @param  array<string, mixed>  $meta
+     * @return array<string, mixed>
+     */
+    private function filterMeta(array $meta): array
+    {
+        $filtered = [];
+
+        foreach ($meta as $key => $value) {
+            if (is_array($value)) {
+                $value = $this->filterMeta($value);
+                if ($value === []) {
+                    continue;
+                }
+
+                $filtered[$key] = $value;
+
+                continue;
+            }
+
+            if ($value === null || $value === '') {
+                continue;
+            }
+
+            $filtered[$key] = $value;
+        }
+
+        return $filtered;
     }
 }

--- a/backend/app/Http/Requests/V0_3/SubmitAttemptRequest.php
+++ b/backend/app/Http/Requests/V0_3/SubmitAttemptRequest.php
@@ -11,6 +11,32 @@ class SubmitAttemptRequest extends FormRequest
         return true;
     }
 
+    protected function prepareForValidation(): void
+    {
+        $normalizedUtm = $this->normalizeUtm($this->input('utm'));
+        $flatUtm = $this->normalizeFlatUtm();
+        if ($normalizedUtm !== null || $flatUtm !== null) {
+            $existingUtm = $this->normalizeUtm($this->input('utm')) ?? [];
+            $this->merge([
+                'utm' => array_replace($existingUtm, $normalizedUtm ?? [], $flatUtm ?? []),
+            ]);
+        }
+
+        foreach ([
+            'share_id' => 128,
+            'compare_invite_id' => 128,
+            'share_click_id' => 128,
+            'entrypoint' => 128,
+            'referrer' => 2048,
+            'landing_path' => 2048,
+        ] as $field => $maxLength) {
+            $value = $this->normalizeString($this->input($field), $maxLength);
+            if ($value !== null) {
+                $this->merge([$field => $value]);
+            }
+        }
+    }
+
     public function rules(): array
     {
         return [
@@ -32,6 +58,72 @@ class SubmitAttemptRequest extends FormRequest
             'consent.version' => ['sometimes', 'string', 'max:128'],
             'consent.hash' => ['sometimes', 'string', 'size:64'],
             'invite_token' => ['nullable', 'string', 'max:64'],
+            'share_id' => ['nullable', 'string', 'max:128'],
+            'compare_invite_id' => ['nullable', 'string', 'max:128'],
+            'share_click_id' => ['nullable', 'string', 'max:128'],
+            'entrypoint' => ['nullable', 'string', 'max:128'],
+            'referrer' => ['nullable', 'string', 'max:2048'],
+            'landing_path' => ['nullable', 'string', 'max:2048'],
+            'utm' => ['nullable'],
+            'utm_source' => ['nullable', 'string', 'max:512'],
+            'utm_medium' => ['nullable', 'string', 'max:512'],
+            'utm_campaign' => ['nullable', 'string', 'max:512'],
+            'utm_term' => ['nullable', 'string', 'max:512'],
+            'utm_content' => ['nullable', 'string', 'max:512'],
         ];
+    }
+
+    /**
+     * @return array<string, string>|null
+     */
+    private function normalizeUtm(mixed $value): ?array
+    {
+        if (! is_array($value)) {
+            return null;
+        }
+
+        $normalized = [];
+        foreach (['source', 'medium', 'campaign', 'term', 'content'] as $key) {
+            $candidate = $this->normalizeString($value[$key] ?? null, 512);
+            if ($candidate !== null) {
+                $normalized[$key] = $candidate;
+            }
+        }
+
+        return $normalized === [] ? null : $normalized;
+    }
+
+    /**
+     * @return array<string, string>|null
+     */
+    private function normalizeFlatUtm(): ?array
+    {
+        $normalized = [];
+        foreach (['source', 'medium', 'campaign', 'term', 'content'] as $key) {
+            $candidate = $this->normalizeString($this->input('utm_'.$key), 512);
+            if ($candidate !== null) {
+                $normalized[$key] = $candidate;
+            }
+        }
+
+        return $normalized === [] ? null : $normalized;
+    }
+
+    private function normalizeString(mixed $value, int $maxLength): ?string
+    {
+        if (! is_scalar($value)) {
+            return null;
+        }
+
+        $normalized = trim((string) $value);
+        if ($normalized === '') {
+            return null;
+        }
+
+        if (mb_strlen($normalized, 'UTF-8') > $maxLength) {
+            $normalized = mb_substr($normalized, 0, $maxLength, 'UTF-8');
+        }
+
+        return $normalized;
     }
 }

--- a/backend/app/Models/MbtiCompareInvite.php
+++ b/backend/app/Models/MbtiCompareInvite.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+
+final class MbtiCompareInvite extends Model
+{
+    public $incrementing = false;
+
+    protected $keyType = 'string';
+
+    protected $table = 'mbti_compare_invites';
+
+    protected $fillable = [
+        'id',
+        'share_id',
+        'inviter_attempt_id',
+        'inviter_scale_code',
+        'locale',
+        'inviter_type_code',
+        'invitee_attempt_id',
+        'invitee_anon_id',
+        'invitee_user_id',
+        'invitee_order_no',
+        'status',
+        'meta_json',
+        'accepted_at',
+        'completed_at',
+        'purchased_at',
+    ];
+
+    protected $casts = [
+        'meta_json' => 'array',
+        'invitee_user_id' => 'integer',
+        'accepted_at' => 'datetime',
+        'completed_at' => 'datetime',
+        'purchased_at' => 'datetime',
+    ];
+}

--- a/backend/app/Services/Analytics/EventNormalizer.php
+++ b/backend/app/Services/Analytics/EventNormalizer.php
@@ -11,6 +11,7 @@ class EventNormalizer
         $props = self::ensureArray($payload['props'] ?? []);
         $meta = self::ensureArray($payload['meta_json'] ?? []);
         $mergedProps = array_merge($props, $meta);
+        $utm = self::ensureArray($mergedProps['utm'] ?? []);
 
         $eventName = self::firstNonEmpty([
             $payload['event_name'] ?? null,
@@ -140,18 +141,21 @@ class EventNormalizer
                 $payload['utmSource'] ?? null,
                 $mergedProps['utm_source'] ?? null,
                 $mergedProps['utmSource'] ?? null,
+                $utm['source'] ?? null,
             ])),
             'utm_medium' => self::toString(self::firstNonEmpty([
                 $payload['utm_medium'] ?? null,
                 $payload['utmMedium'] ?? null,
                 $mergedProps['utm_medium'] ?? null,
                 $mergedProps['utmMedium'] ?? null,
+                $utm['medium'] ?? null,
             ])),
             'utm_campaign' => self::toString(self::firstNonEmpty([
                 $payload['utm_campaign'] ?? null,
                 $payload['utmCampaign'] ?? null,
                 $mergedProps['utm_campaign'] ?? null,
                 $mergedProps['utmCampaign'] ?? null,
+                $utm['campaign'] ?? null,
             ])),
             'referrer' => self::toString(self::firstNonEmpty([
                 $payload['referrer'] ?? null,
@@ -211,8 +215,10 @@ class EventNormalizer
                 if ($trimmed === '') {
                     continue;
                 }
+
                 return $trimmed;
             }
+
             return $value;
         }
 
@@ -226,6 +232,7 @@ class EventNormalizer
         }
         if (is_string($value)) {
             $trimmed = trim($value);
+
             return $trimmed === '' ? null : $trimmed;
         }
 

--- a/backend/app/Services/Attempts/AttemptSubmissionService.php
+++ b/backend/app/Services/Attempts/AttemptSubmissionService.php
@@ -33,7 +33,7 @@ final class AttemptSubmissionService
             $normalizedUserId = $this->normalizeUserId($ctx->userId());
             $normalizedAnonId = $this->normalizeAnonId($ctx->anonId());
 
-            $fixedCtx = new OrgContext();
+            $fixedCtx = new OrgContext;
             $fixedCtx->set(
                 $orgId,
                 $normalizedUserId !== null ? (int) $normalizedUserId : null,
@@ -222,7 +222,7 @@ final class AttemptSubmissionService
             return;
         }
 
-        $ctx = new OrgContext();
+        $ctx = new OrgContext;
         $ctx->set(
             $orgId,
             $actorUserId !== null ? (int) $actorUserId : null,
@@ -265,7 +265,7 @@ final class AttemptSubmissionService
             ];
         }
 
-                $orgId = $ctx->orgId() ?? 0;
+        $orgId = $ctx->orgId() ?? 0;
         $actorUserId = $this->normalizeUserId($actorUserId);
         $actorAnonId = $this->normalizeAnonId($actorAnonId);
 
@@ -525,6 +525,13 @@ final class AttemptSubmissionService
             'invite_token' => $dto->inviteToken,
             'user_id' => $actorUserId,
             'anon_id' => $actorAnonId,
+            'share_id' => $dto->shareId,
+            'compare_invite_id' => $dto->compareInviteId,
+            'share_click_id' => $dto->shareClickId,
+            'entrypoint' => $dto->entrypoint,
+            'referrer' => $dto->referrer,
+            'landing_path' => $dto->landingPath,
+            'utm' => $dto->utm,
         ];
     }
 

--- a/backend/app/Services/Attempts/AttemptSubmitGuardService.php
+++ b/backend/app/Services/Attempts/AttemptSubmitGuardService.php
@@ -4,14 +4,12 @@ namespace App\Services\Attempts;
 
 use App\DTO\Attempts\SubmitAttemptDTO;
 use App\Exceptions\Api\ApiProblemException;
-use App\Support\OrgContext;
 use App\Services\Scale\ScaleRolloutGate;
+use App\Support\OrgContext;
 
 class AttemptSubmitGuardService
 {
-    public function __construct(private AttemptSubmitService $core)
-    {
-    }
+    public function __construct(private AttemptSubmitService $core) {}
 
     public function handle(OrgContext $ctx, string $attemptId, SubmitAttemptDTO $dto): array
     {
@@ -24,6 +22,13 @@ class AttemptSubmitGuardService
         $validityItems = $dto->validityItems;
         $durationMs = $dto->durationMs;
         $inviteToken = $dto->inviteToken;
+        $shareId = $dto->shareId;
+        $compareInviteId = $dto->compareInviteId;
+        $shareClickId = $dto->shareClickId;
+        $entrypoint = $dto->entrypoint;
+        $referrer = $dto->referrer;
+        $landingPath = $dto->landingPath;
+        $utm = $dto->utm;
         $actorUserId = $this->core->resolveUserId($ctx, $dto->userId);
         $actorAnonId = $this->core->resolveAnonId($ctx, $dto->anonId);
 
@@ -76,6 +81,13 @@ class AttemptSubmitGuardService
             'validity_items' => $validityItems,
             'duration_ms' => $durationMs,
             'invite_token' => $inviteToken,
+            'share_id' => $shareId,
+            'compare_invite_id' => $compareInviteId,
+            'share_click_id' => $shareClickId,
+            'entrypoint' => $entrypoint,
+            'referrer' => $referrer,
+            'landing_path' => $landingPath,
+            'utm' => $utm,
             'actor_user_id' => $actorUserId,
             'actor_anon_id' => $actorAnonId,
             'org_id' => $orgId,

--- a/backend/app/Services/Attempts/AttemptSubmitSideEffects.php
+++ b/backend/app/Services/Attempts/AttemptSubmitSideEffects.php
@@ -4,12 +4,14 @@ declare(strict_types=1);
 
 namespace App\Services\Attempts;
 
+use App\Models\Attempt;
 use App\Services\Analytics\EventRecorder;
 use App\Services\Assessments\AssessmentService;
 use App\Services\Commerce\BenefitWalletService;
 use App\Services\Commerce\EntitlementManager;
 use App\Services\Report\ReportGatekeeper;
 use App\Services\Report\ReportSnapshotStore;
+use App\Services\V0_3\MbtiCompareInviteService;
 use App\Support\OrgContext;
 use Illuminate\Support\Facades\Log;
 
@@ -24,8 +26,8 @@ final class AttemptSubmitSideEffects
         private ReportSnapshotStore $reportSnapshots,
         private EventRecorder $eventRecorder,
         private ReportGatekeeper $reportGatekeeper,
-    ) {
-    }
+        private MbtiCompareInviteService $mbtiCompareInvites,
+    ) {}
 
     public function runAfterSubmit(OrgContext $ctx, array $payload, ?string $actorUserId, ?string $actorAnonId): ?array
     {
@@ -42,8 +44,29 @@ final class AttemptSubmitSideEffects
         $dirVersion = trim((string) ($payload['dir_version'] ?? ''));
         $scoringSpecVersion = trim((string) ($payload['scoring_spec_version'] ?? ''));
         $inviteToken = trim((string) ($payload['invite_token'] ?? ''));
+        $shareId = trim((string) ($payload['share_id'] ?? ''));
+        $compareInviteId = trim((string) ($payload['compare_invite_id'] ?? ''));
         $creditBenefitCode = strtoupper(trim((string) ($payload['credit_benefit_code'] ?? '')));
         $entitlementBenefitCode = strtoupper(trim((string) ($payload['entitlement_benefit_code'] ?? '')));
+
+        if ($scaleCode === 'MBTI' && $compareInviteId !== '') {
+            $attempt = Attempt::query()->where('id', $attemptId)->where('org_id', $orgId)->first();
+            if (! $attempt instanceof Attempt) {
+                throw new \RuntimeException('submitted attempt missing for compare invite binding.');
+            }
+
+            if ($shareId === '') {
+                throw new \RuntimeException('share_id is required when compare_invite_id is present.');
+            }
+
+            $this->mbtiCompareInvites->attachInviteeFromSubmit(
+                $compareInviteId,
+                $shareId,
+                $attempt,
+                $this->resolveAnonId($ctx, $actorAnonId),
+                $this->resolveUserId($ctx, $actorUserId)
+            );
+        }
 
         $consumeB2BCredit = false;
         if ($inviteToken !== '' && $orgId > 0) {
@@ -65,7 +88,7 @@ final class AttemptSubmitSideEffects
             try {
                 $consume = $this->benefitWallets->consume($orgId, self::B2B_CREDIT_BENEFIT_CODE, $attemptId);
                 $creditOk = (bool) ($consume['ok'] ?? false);
-                if (!$creditOk) {
+                if (! $creditOk) {
                     Log::warning('SUBMIT_POST_COMMIT_B2B_CREDIT_CONSUME_FAILED', [
                         'org_id' => $orgId,
                         'attempt_id' => $attemptId,
@@ -83,7 +106,7 @@ final class AttemptSubmitSideEffects
             }
         }
 
-        if ($orgId > 0 && $creditBenefitCode !== '' && !$consumeB2BCredit) {
+        if ($orgId > 0 && $creditBenefitCode !== '' && ! $consumeB2BCredit) {
             try {
                 $consume = $this->benefitWallets->consume($orgId, $creditBenefitCode, $attemptId);
                 $creditOk = (bool) ($consume['ok'] ?? false);
@@ -141,7 +164,7 @@ final class AttemptSubmitSideEffects
                     null
                 );
 
-                if (!($grant['ok'] ?? false)) {
+                if (! ($grant['ok'] ?? false)) {
                     Log::warning('SUBMIT_POST_COMMIT_GRANT_FAILED', [
                         'org_id' => $orgId,
                         'attempt_id' => $attemptId,
@@ -248,7 +271,7 @@ final class AttemptSubmitSideEffects
             return;
         }
 
-        if (!($gate['ok'] ?? false)) {
+        if (! ($gate['ok'] ?? false)) {
             Log::warning('SUBMIT_REPORT_GATE_FAILED', [
                 'org_id' => $ctx->orgId(),
                 'attempt_id' => $attemptId,
@@ -270,8 +293,8 @@ final class AttemptSubmitSideEffects
     }
 
     /**
-     * @param array<string,mixed> $resultPayload
-     * @param array<string,mixed> $versionMeta
+     * @param  array<string,mixed>  $resultPayload
+     * @param  array<string,mixed>  $versionMeta
      */
     public function recordClinicalScoreEvent(
         OrgContext $ctx,
@@ -360,7 +383,7 @@ final class AttemptSubmitSideEffects
     }
 
     /**
-     * @param array<string,mixed> $payload
+     * @param  array<string,mixed>  $payload
      * @return array<string,mixed>
      */
     private function extractScoreContract(array $payload): array
@@ -373,7 +396,7 @@ final class AttemptSubmitSideEffects
         ];
 
         foreach ($candidates as $candidate) {
-            if (!is_array($candidate)) {
+            if (! is_array($candidate)) {
                 continue;
             }
             if (strtoupper((string) ($candidate['scale_code'] ?? '')) !== 'CLINICAL_COMBO_68') {
@@ -387,7 +410,7 @@ final class AttemptSubmitSideEffects
     }
 
     /**
-     * @param array<string,mixed> $scores
+     * @param  array<string,mixed>  $scores
      * @return array<string,array<string,mixed>>
      */
     private function extractClinicalScoreSnapshot(array $scores): array

--- a/backend/app/Services/Attempts/AttemptSubmitTxService.php
+++ b/backend/app/Services/Attempts/AttemptSubmitTxService.php
@@ -10,9 +10,7 @@ use Illuminate\Support\Str;
 
 class AttemptSubmitTxService
 {
-    public function __construct(private AttemptSubmitService $core)
-    {
-    }
+    public function __construct(private AttemptSubmitService $core) {}
 
     public function handle(OrgContext $ctx, array $canonicalized, array $scored): array
     {
@@ -27,6 +25,13 @@ class AttemptSubmitTxService
         $region = (string) ($canonicalized['region'] ?? '');
         $locale = (string) ($canonicalized['locale'] ?? '');
         $inviteToken = (string) ($canonicalized['invite_token'] ?? '');
+        $shareId = trim((string) ($canonicalized['share_id'] ?? ''));
+        $compareInviteId = trim((string) ($canonicalized['compare_invite_id'] ?? ''));
+        $shareClickId = trim((string) ($canonicalized['share_click_id'] ?? ''));
+        $entrypoint = trim((string) ($canonicalized['entrypoint'] ?? ''));
+        $referrer = trim((string) ($canonicalized['referrer'] ?? ''));
+        $landingPath = trim((string) ($canonicalized['landing_path'] ?? ''));
+        $utm = is_array($canonicalized['utm'] ?? null) ? $canonicalized['utm'] : [];
         $actorUserId = $canonicalized['actor_user_id'] ?? null;
         if ($actorUserId !== null) {
             $actorUserId = (string) $actorUserId;
@@ -70,6 +75,13 @@ class AttemptSubmitTxService
             $region,
             $locale,
             $inviteToken,
+            $shareId,
+            $compareInviteId,
+            $shareClickId,
+            $entrypoint,
+            $referrer,
+            $landingPath,
+            $utm,
             $creditBenefitCode,
             $entitlementBenefitCode,
             $scoreResult,
@@ -89,9 +101,9 @@ class AttemptSubmitTxService
                 ->lockForUpdate()
                 ->first();
 
-if (! $locked) {
-    throw new ApiProblemException(404, 'RESOURCE_NOT_FOUND', 'attempt not found.');
-}
+            if (! $locked) {
+                throw new ApiProblemException(404, 'RESOURCE_NOT_FOUND', 'attempt not found.');
+            }
 
             $existingDigest = trim((string) ($locked->answers_digest ?? ''));
             if ($locked->submitted_at && $existingDigest !== '') {
@@ -109,6 +121,13 @@ if (! $locked) {
                             'dir_version' => (string) ($locked->dir_version ?? $dirVersion),
                             'scoring_spec_version' => (string) ($locked->scoring_spec_version ?? $scoringSpecVersion),
                             'invite_token' => $inviteToken,
+                            'share_id' => $shareId,
+                            'compare_invite_id' => $compareInviteId,
+                            'share_click_id' => $shareClickId,
+                            'entrypoint' => $entrypoint,
+                            'referrer' => $referrer,
+                            'landing_path' => $landingPath,
+                            'utm' => $utm,
                             'credit_benefit_code' => $creditBenefitCode,
                             'entitlement_benefit_code' => $entitlementBenefitCode,
                         ];
@@ -134,6 +153,13 @@ if (! $locked) {
                         'dir_version' => (string) ($locked->dir_version ?? $dirVersion),
                         'scoring_spec_version' => (string) ($locked->scoring_spec_version ?? $scoringSpecVersion),
                         'invite_token' => $inviteToken,
+                        'share_id' => $shareId,
+                        'compare_invite_id' => $compareInviteId,
+                        'share_click_id' => $shareClickId,
+                        'entrypoint' => $entrypoint,
+                        'referrer' => $referrer,
+                        'landing_path' => $landingPath,
+                        'utm' => $utm,
                         'credit_benefit_code' => $creditBenefitCode,
                         'entitlement_benefit_code' => $entitlementBenefitCode,
                     ];
@@ -305,6 +331,27 @@ if (! $locked) {
             if ($locked->started_at === null) {
                 $locked->started_at = now();
             }
+
+            $answersSummary = is_array($locked->answers_summary_json ?? null) ? $locked->answers_summary_json : [];
+            $answersSummaryMeta = is_array($answersSummary['meta'] ?? null) ? $answersSummary['meta'] : [];
+            foreach ([
+                'share_id' => $shareId,
+                'compare_invite_id' => $compareInviteId,
+                'share_click_id' => $shareClickId,
+                'entrypoint' => $entrypoint,
+                'referrer' => $referrer,
+                'landing_path' => $landingPath,
+            ] as $field => $value) {
+                if ($value !== '') {
+                    $answersSummaryMeta[$field] = $value;
+                }
+            }
+            if ($utm !== []) {
+                $answersSummaryMeta['utm'] = $utm;
+            }
+            $answersSummary['meta'] = $answersSummaryMeta;
+            $locked->answers_summary_json = $answersSummary;
+
             $locked->save();
 
             $this->core->answerPersistence()->persist($locked, $mergedAnswers, $durationMs, $scoringSpecVersion);
@@ -394,6 +441,13 @@ if (! $locked) {
                 'dir_version' => $dirVersion,
                 'scoring_spec_version' => $scoringSpecVersion,
                 'invite_token' => $inviteToken,
+                'share_id' => $shareId,
+                'compare_invite_id' => $compareInviteId,
+                'share_click_id' => $shareClickId,
+                'entrypoint' => $entrypoint,
+                'referrer' => $referrer,
+                'landing_path' => $landingPath,
+                'utm' => $utm,
                 'credit_benefit_code' => $creditBenefitCode,
                 'entitlement_benefit_code' => $entitlementBenefitCode,
             ];

--- a/backend/app/Services/Commerce/OrderManager.php
+++ b/backend/app/Services/Commerce/OrderManager.php
@@ -34,6 +34,7 @@ class OrderManager
         ?string $idempotencyKey = null,
         ?string $contactEmail = null,
         ?string $requestId = null,
+        array $attribution = [],
     ): array {
         $requestedSku = $this->skus->normalizeSku($sku);
         if ($requestedSku === '') {
@@ -99,7 +100,8 @@ class OrderManager
             $useIdempotency,
             $modulesIncluded,
             $contactEmailHash,
-            $requestId
+            $requestId,
+            $attribution
         ): array {
             $orderNo = 'ord_'.Str::uuid();
             $now = now();
@@ -107,6 +109,10 @@ class OrderManager
             $orderMeta = [];
             if ($modulesIncluded !== []) {
                 $orderMeta['modules_included'] = $modulesIncluded;
+            }
+            $normalizedAttribution = $this->normalizeAttribution($attribution);
+            if ($normalizedAttribution !== []) {
+                $orderMeta['attribution'] = $normalizedAttribution;
             }
 
             $row = [
@@ -364,6 +370,8 @@ class OrderManager
         }
 
         if (in_array($fromStatus, ['paid', 'fulfilled'], true)) {
+            $this->syncPurchasedInviteFromOrder($order, $paidAt);
+
             return [
                 'ok' => true,
                 'order' => $order,
@@ -413,6 +421,7 @@ class OrderManager
         }
 
         $order = DB::table('orders')->where('order_no', $orderNo)->where('org_id', $orgId)->first();
+        $this->syncPurchasedInviteFromOrder($order, $paidAt);
 
         return [
             'ok' => true,
@@ -445,6 +454,10 @@ class OrderManager
         }
 
         if ($fromStatus === $toStatus) {
+            if (in_array($toStatus, ['paid', 'fulfilled'], true)) {
+                $this->syncPurchasedInviteFromOrder($order, null);
+            }
+
             return [
                 'ok' => true,
                 'order' => $order,
@@ -497,11 +510,43 @@ class OrderManager
         }
 
         $order = DB::table('orders')->where('order_no', $orderNo)->first();
+        if (in_array($toStatus, ['paid', 'fulfilled'], true)) {
+            $this->syncPurchasedInviteFromOrder($order, null);
+        }
 
         return [
             'ok' => true,
             'order' => $order,
         ];
+    }
+
+    public function mergeAttribution(string $orderNo, int $orgId, array $attribution): void
+    {
+        $normalizedAttribution = $this->normalizeAttribution($attribution);
+        if ($normalizedAttribution === []) {
+            return;
+        }
+
+        $order = DB::table('orders')
+            ->where('order_no', trim($orderNo))
+            ->where('org_id', $orgId)
+            ->first();
+
+        if (! $order) {
+            return;
+        }
+
+        $meta = $this->decodeMeta($order->meta_json ?? null);
+        $existingAttribution = is_array($meta['attribution'] ?? null) ? $meta['attribution'] : [];
+        $meta['attribution'] = array_replace($existingAttribution, $normalizedAttribution);
+
+        DB::table('orders')
+            ->where('order_no', (string) $order->order_no)
+            ->where('org_id', $orgId)
+            ->update([
+                'meta_json' => json_encode($meta, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES),
+                'updated_at' => now(),
+            ]);
     }
 
     private function isTransitionAllowed(string $fromStatus, string $toStatus): bool
@@ -636,6 +681,77 @@ class OrderManager
     private function reportPdfUrl(string $attemptId): string
     {
         return "/api/v0.3/attempts/{$attemptId}/report.pdf";
+    }
+
+    /**
+     * @param  array<string, mixed>  $attribution
+     * @return array<string, mixed>
+     */
+    private function normalizeAttribution(array $attribution): array
+    {
+        $normalized = [];
+
+        foreach ([
+            'share_id' => 128,
+            'compare_invite_id' => 128,
+            'share_click_id' => 128,
+            'entrypoint' => 128,
+            'referrer' => 2048,
+            'landing_path' => 2048,
+        ] as $field => $maxLength) {
+            $value = $this->trimOrNull($attribution[$field] ?? null);
+            if ($value === null) {
+                continue;
+            }
+
+            $normalized[$field] = mb_strlen($value, 'UTF-8') > $maxLength
+                ? mb_substr($value, 0, $maxLength, 'UTF-8')
+                : $value;
+        }
+
+        $utm = $attribution['utm'] ?? null;
+        if (is_array($utm)) {
+            $normalizedUtm = [];
+            foreach (['source', 'medium', 'campaign', 'term', 'content'] as $key) {
+                $value = $this->trimOrNull($utm[$key] ?? null);
+                if ($value !== null) {
+                    $normalizedUtm[$key] = mb_strlen($value, 'UTF-8') > 512
+                        ? mb_substr($value, 0, 512, 'UTF-8')
+                        : $value;
+                }
+            }
+
+            if ($normalizedUtm !== []) {
+                $normalized['utm'] = $normalizedUtm;
+            }
+        }
+
+        return $normalized;
+    }
+
+    private function syncPurchasedInviteFromOrder(?object $order, ?string $paidAt): void
+    {
+        if (! $order || ! Schema::hasTable('mbti_compare_invites')) {
+            return;
+        }
+
+        $meta = $this->decodeMeta($order->meta_json ?? null);
+        $attribution = is_array($meta['attribution'] ?? null) ? $meta['attribution'] : [];
+        $compareInviteId = trim((string) ($attribution['compare_invite_id'] ?? ''));
+        if ($compareInviteId === '') {
+            return;
+        }
+
+        $update = [
+            'invitee_order_no' => $this->trimOrNull((string) ($order->order_no ?? '')),
+            'purchased_at' => $paidAt !== null && trim($paidAt) !== '' ? $paidAt : ($order->paid_at ?? now()),
+            'status' => 'purchased',
+            'updated_at' => now(),
+        ];
+
+        DB::table('mbti_compare_invites')
+            ->where('id', $compareInviteId)
+            ->update($update);
     }
 
     private function normalizeRequestId(mixed $value): ?string

--- a/backend/app/Services/Share/ShareFlowCoreService.php
+++ b/backend/app/Services/Share/ShareFlowCoreService.php
@@ -59,7 +59,7 @@ final class ShareFlowCoreService
             $benefitCode
         );
 
-        if (! $hasFullAccess) {
+        if (! $hasFullAccess && ! $this->canGeneratePublicShareSummary($attempt)) {
             throw new HttpException(402, 'PAYMENT_REQUIRED');
         }
 
@@ -384,6 +384,11 @@ final class ShareFlowCoreService
             'subscription_benefit_code' => strtoupper(trim((string) ($commercial['subscription_benefit_code'] ?? ''))),
             'default_sku' => trim((string) ($commercial['default_sku'] ?? '')),
         ];
+    }
+
+    private function canGeneratePublicShareSummary(Attempt $attempt): bool
+    {
+        return strtoupper(trim((string) ($attempt->scale_code ?? ''))) === 'MBTI';
     }
 
     /**

--- a/backend/app/Services/V0_3/MbtiCompareInviteService.php
+++ b/backend/app/Services/V0_3/MbtiCompareInviteService.php
@@ -1,0 +1,373 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\V0_3;
+
+use App\Exceptions\Api\ApiProblemException;
+use App\Models\Attempt;
+use App\Models\MbtiCompareInvite;
+use App\Models\Result;
+use App\Models\Share;
+use Illuminate\Database\Eloquent\ModelNotFoundException;
+use Illuminate\Support\Carbon;
+use Illuminate\Support\Str;
+
+final class MbtiCompareInviteService
+{
+    public function __construct(
+        private readonly ShareService $shareService,
+    ) {}
+
+    /**
+     * @param  array<string, mixed>  $payload
+     * @return array<string, mixed>
+     */
+    public function create(string $shareId, array $payload): array
+    {
+        [$share, $attempt, $result] = $this->resolveMbtiShareContext($shareId);
+        $inviterPayload = $this->shareService->buildPublicSummaryPayload($attempt, $result, (string) $share->id, $share->created_at?->toISOString());
+        $locale = (string) ($inviterPayload['locale'] ?? 'zh-CN');
+
+        $invite = new MbtiCompareInvite;
+        $invite->id = (string) Str::uuid();
+        $invite->share_id = (string) $share->id;
+        $invite->inviter_attempt_id = (string) $attempt->id;
+        $invite->inviter_scale_code = 'MBTI';
+        $invite->locale = $locale;
+        $invite->inviter_type_code = $this->nullableString($inviterPayload['type_code'] ?? null);
+        $invite->status = 'pending';
+        $invite->meta_json = $this->normalizeMeta($payload['meta_json'] ?? null);
+        $invite->save();
+
+        return [
+            'invite_id' => (string) $invite->id,
+            'share_id' => (string) $share->id,
+            'scale_code' => 'MBTI',
+            'locale' => $locale,
+            'status' => 'pending',
+            'take_path' => $this->buildTakePath($locale, (string) $share->id, (string) $invite->id, (string) ($inviterPayload['primary_cta_path'] ?? '')),
+            'compare_path' => $this->buildComparePath($locale, (string) $invite->id),
+            'inviter' => $this->toSummaryLite($inviterPayload, true),
+        ];
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function show(string $inviteId): array
+    {
+        $invite = MbtiCompareInvite::query()->findOrFail($inviteId);
+        [$share, $attempt, $result] = $this->resolveMbtiShareContext((string) $invite->share_id);
+        $inviterPayload = $this->shareService->buildPublicSummaryPayload($attempt, $result, (string) $share->id, $share->created_at?->toISOString());
+        $locale = $this->normalizeLocale(
+            $this->nullableString($invite->locale)
+                ?? $this->nullableString($inviterPayload['locale'] ?? null)
+                ?? 'zh-CN'
+        );
+
+        $status = $this->normalizeStatus((string) ($invite->status ?? 'pending'));
+        $invitee = null;
+        $compare = null;
+
+        if (in_array($status, ['ready', 'purchased'], true)) {
+            $inviteeAttemptId = trim((string) ($invite->invitee_attempt_id ?? ''));
+            if ($inviteeAttemptId !== '') {
+                $inviteeAttempt = Attempt::query()->where('id', $inviteeAttemptId)->first();
+                if ($inviteeAttempt instanceof Attempt) {
+                    $inviteeResult = Result::query()
+                        ->where('attempt_id', (string) $inviteeAttempt->id)
+                        ->where('org_id', (int) ($inviteeAttempt->org_id ?? 0))
+                        ->first();
+
+                    if ($inviteeResult instanceof Result) {
+                        $inviteePayload = $this->shareService->buildPublicSummaryPayload($inviteeAttempt, $inviteeResult);
+                        $invitee = $this->toSummaryLite($inviteePayload, false);
+                        $compare = $this->buildComparePayload(
+                            $this->toSummaryLite($inviterPayload, true),
+                            $invitee,
+                            $locale
+                        );
+                    }
+                }
+            }
+        }
+
+        return [
+            'invite_id' => (string) $invite->id,
+            'share_id' => (string) $invite->share_id,
+            'scale_code' => 'MBTI',
+            'locale' => $locale,
+            'status' => $status,
+            'inviter' => $this->toSummaryLite($inviterPayload, true),
+            'invitee' => $invitee,
+            'compare' => $compare,
+            'primary_cta_label' => $locale === 'zh-CN' ? '开始测试' : 'Take the test',
+            'primary_cta_path' => $this->buildTakePath(
+                $locale,
+                (string) $invite->share_id,
+                (string) $invite->id,
+                (string) ($inviterPayload['primary_cta_path'] ?? '')
+            ),
+        ];
+    }
+
+    public function attachInviteeFromSubmit(
+        string $compareInviteId,
+        string $shareId,
+        Attempt $attempt,
+        ?string $anonId,
+        ?string $userId
+    ): void {
+        $invite = MbtiCompareInvite::query()->findOrFail($compareInviteId);
+        if ((string) $invite->share_id !== $shareId) {
+            throw new ApiProblemException(422, 'COMPARE_INVITE_SHARE_MISMATCH', 'compare invite share mismatch.');
+        }
+
+        if (strtoupper(trim((string) ($attempt->scale_code ?? ''))) !== 'MBTI') {
+            throw new ApiProblemException(404, 'COMPARE_INVITE_NOT_FOUND', 'compare invite not found.');
+        }
+
+        $now = now();
+        $invite->invitee_attempt_id = (string) $attempt->id;
+        $invite->invitee_anon_id = $this->nullableString($anonId);
+        $invite->invitee_user_id = $this->normalizeUserId($userId);
+        $invite->status = 'ready';
+        $invite->accepted_at = $invite->accepted_at ?? $now;
+        $invite->completed_at = $now;
+        $invite->save();
+    }
+
+    public function markPurchased(string $compareInviteId, string $orderNo, ?string $purchasedAt = null): void
+    {
+        $invite = MbtiCompareInvite::query()->find($compareInviteId);
+        if (! $invite instanceof MbtiCompareInvite) {
+            return;
+        }
+
+        $invite->invitee_order_no = trim($orderNo) !== '' ? trim($orderNo) : null;
+        $invite->purchased_at = $purchasedAt !== null && trim($purchasedAt) !== ''
+            ? Carbon::parse($purchasedAt)
+            : now();
+        $invite->status = 'purchased';
+        $invite->save();
+    }
+
+    /**
+     * @return array{0:Share,1:Attempt,2:Result}
+     */
+    private function resolveMbtiShareContext(string $shareId): array
+    {
+        $share = Share::query()->where('id', $shareId)->first();
+        if (! $share instanceof Share) {
+            throw (new ModelNotFoundException)->setModel(Share::class, [$shareId]);
+        }
+
+        $attempt = Attempt::query()->where('id', (string) $share->attempt_id)->first();
+        if (! $attempt instanceof Attempt || strtoupper(trim((string) ($attempt->scale_code ?? ''))) !== 'MBTI') {
+            throw (new ModelNotFoundException)->setModel(Share::class, [$shareId]);
+        }
+
+        $result = Result::query()
+            ->where('attempt_id', (string) $attempt->id)
+            ->where('org_id', (int) ($attempt->org_id ?? 0))
+            ->first();
+
+        if (! $result instanceof Result) {
+            throw (new ModelNotFoundException)->setModel(Result::class, [(string) $attempt->id]);
+        }
+
+        return [$share, $attempt, $result];
+    }
+
+    /**
+     * @param  array<string, mixed>  $payload
+     * @return array<string, mixed>
+     */
+    private function toSummaryLite(array $payload, bool $includeShareId): array
+    {
+        $summary = [
+            'type_code' => (string) ($payload['type_code'] ?? ''),
+            'type_name' => (string) ($payload['type_name'] ?? ''),
+            'title' => (string) ($payload['title'] ?? ''),
+            'subtitle' => $this->nullableString($payload['subtitle'] ?? null),
+            'summary' => $this->nullableString($payload['summary'] ?? null),
+            'tagline' => $this->nullableString($payload['tagline'] ?? null),
+            'rarity' => $payload['rarity'] ?? null,
+            'tags' => is_array($payload['tags'] ?? null) ? array_values($payload['tags']) : [],
+            'dimensions' => is_array($payload['dimensions'] ?? null) ? array_values($payload['dimensions']) : [],
+        ];
+
+        if ($includeShareId) {
+            $summary = [
+                'share_id' => (string) ($payload['share_id'] ?? ''),
+            ] + $summary;
+        }
+
+        return $summary;
+    }
+
+    private function buildTakePath(string $locale, string $shareId, string $inviteId, string $primaryCtaPath): string
+    {
+        $basePath = trim($primaryCtaPath);
+        if ($basePath === '') {
+            $segment = $locale === 'zh-CN' ? 'zh' : 'en';
+            $basePath = '/'.$segment.'/tests/mbti-personality-test-16-personality-types';
+        }
+
+        return $basePath.'/take?share_id='.rawurlencode($shareId).'&compare_invite_id='.rawurlencode($inviteId);
+    }
+
+    private function buildComparePath(string $locale, string $inviteId): string
+    {
+        $segment = $locale === 'zh-CN' ? 'zh' : 'en';
+
+        return '/'.$segment.'/compare/mbti/'.rawurlencode($inviteId);
+    }
+
+    private function normalizeStatus(string $status): string
+    {
+        $normalized = strtolower(trim($status));
+
+        return in_array($normalized, ['pending', 'ready', 'purchased'], true) ? $normalized : 'pending';
+    }
+
+    private function normalizeLocale(string $locale): string
+    {
+        return trim($locale) === 'zh-CN' ? 'zh-CN' : 'en';
+    }
+
+    /**
+     * @param  array<string, mixed>  $payload
+     * @param  array<string, mixed>  $invitee
+     * @return array<string, mixed>
+     */
+    private function buildComparePayload(array $inviter, array $invitee, string $locale): array
+    {
+        $inviterTypeCode = strtoupper(trim((string) ($inviter['type_code'] ?? '')));
+        $inviteeTypeCode = strtoupper(trim((string) ($invitee['type_code'] ?? '')));
+        $sameType = $inviterTypeCode !== '' && $inviterTypeCode === $inviteeTypeCode;
+
+        $inviteeDimensions = [];
+        foreach ((array) ($invitee['dimensions'] ?? []) as $dimension) {
+            if (! is_array($dimension)) {
+                continue;
+            }
+
+            $code = strtoupper(trim((string) ($dimension['code'] ?? '')));
+            if ($code === '') {
+                continue;
+            }
+
+            $inviteeDimensions[$code] = $dimension;
+        }
+
+        $axes = [];
+        $sharedCount = 0;
+        $divergingCount = 0;
+
+        foreach ((array) ($inviter['dimensions'] ?? []) as $dimension) {
+            if (! is_array($dimension)) {
+                continue;
+            }
+
+            $code = strtoupper(trim((string) ($dimension['code'] ?? '')));
+            if ($code === '' || ! isset($inviteeDimensions[$code])) {
+                continue;
+            }
+
+            $inviterSide = strtoupper(trim((string) ($dimension['side'] ?? '')));
+            $inviteeSide = strtoupper(trim((string) ($inviteeDimensions[$code]['side'] ?? '')));
+            $aligned = $inviterSide !== '' && $inviterSide === $inviteeSide;
+            if ($aligned) {
+                $sharedCount++;
+            } else {
+                $divergingCount++;
+            }
+
+            $axes[] = [
+                'code' => $code,
+                'label' => (string) ($dimension['label'] ?? ''),
+                'inviter_side' => $inviterSide,
+                'invitee_side' => $inviteeSide,
+                'aligned' => $aligned,
+            ];
+        }
+
+        [$title, $summary] = $this->resolveCompareCopy($sameType, $sharedCount, $locale);
+
+        return [
+            'same_type' => $sameType,
+            'shared_count' => $sharedCount,
+            'diverging_count' => $divergingCount,
+            'axes' => $axes,
+            'title' => $title,
+            'summary' => $summary,
+        ];
+    }
+
+    /**
+     * @return array{0:string,1:string}
+     */
+    private function resolveCompareCopy(bool $sameType, int $sharedCount, string $locale): array
+    {
+        if ($locale === 'zh-CN') {
+            if ($sameType) {
+                return ['你们的类型高度接近', '你们在多数公开维度上呈现出高度一致的偏好，整体风格非常接近。'];
+            }
+
+            if ($sharedCount >= 4) {
+                return ['你们的风格高度同频', '你们在大多数公开维度上都表现出相近偏好，互动节奏通常更容易自然对齐。'];
+            }
+
+            if ($sharedCount >= 2) {
+                return ['你们既有共鸣也有互补', '你们在部分维度上天然同频，在另外一些维度上形成互补。'];
+            }
+
+            return ['你们更偏互补型组合', '你们在公开维度上的差异更明显，但这也意味着彼此能带来不同的视角与补位。'];
+        }
+
+        if ($sameType) {
+            return ['Your types are highly aligned', 'Most public dimensions point to very similar preferences and a closely matched style.'];
+        }
+
+        if ($sharedCount >= 4) {
+            return ['Your styles are highly in sync', 'You line up on most public dimensions, so your default pace and preferences are likely to feel naturally aligned.'];
+        }
+
+        if ($sharedCount >= 2) {
+            return ['You share resonance and contrast', 'Some dimensions show clear overlap while others create useful contrast between you.'];
+        }
+
+        return ['You are a more complementary pair', 'Your public dimensions differ more often, which can create a more complementary dynamic.'];
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function normalizeMeta(mixed $meta): array
+    {
+        return is_array($meta) ? $meta : [];
+    }
+
+    private function nullableString(mixed $value): ?string
+    {
+        if (! is_string($value) && ! is_numeric($value)) {
+            return null;
+        }
+
+        $normalized = trim((string) $value);
+
+        return $normalized === '' ? null : $normalized;
+    }
+
+    private function normalizeUserId(?string $value): ?int
+    {
+        $normalized = $this->nullableString($value);
+        if ($normalized === null || preg_match('/^\d+$/', $normalized) !== 1) {
+            return null;
+        }
+
+        return (int) $normalized;
+    }
+}

--- a/backend/app/Services/V0_3/ShareService.php
+++ b/backend/app/Services/V0_3/ShareService.php
@@ -69,6 +69,15 @@ class ShareService
         return $this->buildSharePayload($share, $attempt, $result);
     }
 
+    public function buildPublicSummaryPayload(
+        Attempt $attempt,
+        Result $result,
+        ?string $shareId = null,
+        ?string $createdAt = null
+    ): array {
+        return $this->buildCanonicalPayload(null, $attempt, $result, $shareId, $createdAt);
+    }
+
     public function resolveAttemptForAuth(string $attemptId, OrgContext $ctx): Attempt
     {
         return $this->findAccessibleAttempt($attemptId, $ctx);
@@ -183,31 +192,13 @@ class ShareService
 
     private function buildSharePayload(Share $share, Attempt $attempt, Result $result): array
     {
-        $summary = $this->buildShareSummary($share, $attempt, $result);
-        $shareId = (string) $share->id;
-
-        return [
-            'share_id' => $shareId,
-            'share_url' => $this->buildShareUrl($shareId),
-            'attempt_id' => (string) $attempt->id,
-            'created_at' => $share->created_at?->toISOString(),
-            'org_id' => (int) ($attempt->org_id ?? 0),
-            'content_package_version' => (string) ($attempt->content_package_version ?? $result->content_package_version ?? ''),
-            'type_code' => $summary['type_code'],
-            'type_name' => $summary['type_name'],
-            'id' => $shareId,
-            'scale_code' => $summary['scale_code'],
-            'locale' => $summary['locale'],
-            'title' => $summary['title'],
-            'subtitle' => $summary['subtitle'],
-            'summary' => $summary['summary'],
-            'tagline' => $summary['tagline'],
-            'rarity' => $summary['rarity'],
-            'tags' => $summary['tags'],
-            'dimensions' => $summary['dimensions'],
-            'primary_cta_label' => $summary['primary_cta_label'],
-            'primary_cta_path' => $summary['primary_cta_path'],
-        ];
+        return $this->buildCanonicalPayload(
+            $share,
+            $attempt,
+            $result,
+            (string) $share->id,
+            $share->created_at?->toISOString()
+        );
     }
 
     /**
@@ -227,7 +218,7 @@ class ShareService
      *   primary_cta_path:string
      * }
      */
-    private function buildShareSummary(Share $share, Attempt $attempt, Result $result): array
+    private function buildShareSummary(?Share $share, Attempt $attempt, Result $result): array
     {
         $resultJson = $this->normalizeArray($result->result_json ?? null);
         $report = $this->buildPublicSafeReportSnapshot($attempt, $result);
@@ -235,7 +226,7 @@ class ShareService
         $identityCard = $this->normalizeArray($report['identity_card'] ?? null);
         $identityLayer = $this->normalizeArray(data_get($report, 'layers.identity'));
 
-        $scaleCode = strtoupper(trim((string) ($attempt->scale_code ?? $result->scale_code ?? $share->scale_code ?? '')));
+        $scaleCode = strtoupper(trim((string) ($attempt->scale_code ?? $result->scale_code ?? ($share?->scale_code ?? '') ?? '')));
         if ($scaleCode === '') {
             $scaleCode = 'MBTI';
         }
@@ -627,5 +618,57 @@ class ShareService
         $segment = $locale === 'zh-CN' ? 'zh' : 'en';
 
         return '/'.$segment.'/tests/'.rawurlencode($slug);
+    }
+
+    private function buildCanonicalPayload(
+        ?Share $share,
+        Attempt $attempt,
+        Result $result,
+        ?string $shareId,
+        ?string $createdAt
+    ): array {
+        $summary = $this->buildShareSummary($share, $attempt, $result);
+        $resolvedShareId = trim((string) $shareId);
+        $locale = (string) ($summary['locale'] ?? 'zh-CN');
+        $compareEnabled = strtoupper((string) ($summary['scale_code'] ?? '')) === 'MBTI';
+
+        return [
+            'share_id' => $resolvedShareId !== '' ? $resolvedShareId : null,
+            'share_url' => $resolvedShareId !== '' ? $this->buildLocalizedShareUrl($resolvedShareId, $locale) : null,
+            'attempt_id' => (string) $attempt->id,
+            'created_at' => $createdAt,
+            'org_id' => (int) ($attempt->org_id ?? 0),
+            'content_package_version' => (string) ($attempt->content_package_version ?? $result->content_package_version ?? ''),
+            'type_code' => $summary['type_code'],
+            'type_name' => $summary['type_name'],
+            'id' => $resolvedShareId !== '' ? $resolvedShareId : null,
+            'scale_code' => $summary['scale_code'],
+            'locale' => $locale,
+            'title' => $summary['title'],
+            'subtitle' => $summary['subtitle'],
+            'summary' => $summary['summary'],
+            'tagline' => $summary['tagline'],
+            'rarity' => $summary['rarity'],
+            'tags' => $summary['tags'],
+            'dimensions' => $summary['dimensions'],
+            'primary_cta_label' => $summary['primary_cta_label'],
+            'primary_cta_path' => $summary['primary_cta_path'],
+            'compare_enabled' => $compareEnabled,
+            'compare_cta_label' => $compareEnabled
+                ? $this->resolveCompareCtaLabel($locale)
+                : null,
+        ];
+    }
+
+    private function buildLocalizedShareUrl(string $shareId, string $locale): string
+    {
+        $segment = $locale === 'zh-CN' ? 'zh' : 'en';
+
+        return rtrim((string) config('app.frontend_url', 'http://localhost'), '/').'/'.$segment.'/share/'.$shareId;
+    }
+
+    private function resolveCompareCtaLabel(string $locale): string
+    {
+        return $locale === 'zh-CN' ? '邀请朋友来测并对比' : 'Invite a friend to compare';
     }
 }

--- a/backend/database/migrations/2026_03_12_000000_create_mbti_compare_invites_table.php
+++ b/backend/database/migrations/2026_03_12_000000_create_mbti_compare_invites_table.php
@@ -1,0 +1,36 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('mbti_compare_invites', function (Blueprint $table): void {
+            $table->string('id', 64)->primary();
+            $table->string('share_id', 128)->index();
+            $table->uuid('inviter_attempt_id')->index();
+            $table->string('inviter_scale_code', 32)->default('MBTI');
+            $table->string('locale', 16)->nullable();
+            $table->string('inviter_type_code', 32)->nullable();
+            $table->uuid('invitee_attempt_id')->nullable()->index();
+            $table->string('invitee_anon_id', 128)->nullable();
+            $table->unsignedBigInteger('invitee_user_id')->nullable()->index();
+            $table->string('invitee_order_no', 64)->nullable()->index();
+            $table->string('status', 16)->default('pending');
+            $table->json('meta_json')->nullable();
+            $table->timestamp('accepted_at')->nullable();
+            $table->timestamp('completed_at')->nullable();
+            $table->timestamp('purchased_at')->nullable();
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        // forward-only migration: rollback disabled to prevent data loss in production.
+        // Irreversible operation: schema/data rollback handled via forward fix migrations.
+    }
+};

--- a/backend/docs/contracts/openapi.snapshot.json
+++ b/backend/docs/contracts/openapi.snapshot.json
@@ -369,6 +369,26 @@
                     "App\\Http\\Middleware\\ResolveOrgContext",
                     "App\\Http\\Middleware\\FmTokenAuth"
                 ]
+            },
+            "post": {
+                "operationId": "post_api_v0_3_attempts_id_share",
+                "tags": [
+                    "api:v0.3"
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK"
+                    }
+                },
+                "x-laravel-action": "App\\Http\\Controllers\\API\\V0_3\\ShareController@getShare",
+                "x-laravel-middleware": [
+                    "api",
+                    "Illuminate\\Routing\\Middleware\\ThrottleRequests:api_public",
+                    "App\\Http\\Middleware\\NormalizeApiErrorContract",
+                    "App\\Http\\Middleware\\ResolveAnonId",
+                    "App\\Http\\Middleware\\ResolveOrgContext",
+                    "App\\Http\\Middleware\\FmTokenAuth"
+                ]
             }
         },
         "/api/v0.3/auth/guest": {
@@ -489,6 +509,30 @@
                     "api",
                     "Illuminate\\Routing\\Middleware\\ThrottleRequests:api_public",
                     "App\\Http\\Middleware\\NormalizeApiErrorContract"
+                ]
+            }
+        },
+        "/api/v0.3/compare/mbti/{inviteId}": {
+            "get": {
+                "operationId": "get_api_v0_3_compare_mbti_inviteid_",
+                "tags": [
+                    "api:v0.3"
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK"
+                    }
+                },
+                "x-laravel-action": "App\\Http\\Controllers\\API\\V0_3\\MbtiCompareInviteController@show",
+                "x-laravel-middleware": [
+                    "api",
+                    "Illuminate\\Routing\\Middleware\\ThrottleRequests:api_public",
+                    "App\\Http\\Middleware\\NormalizeApiErrorContract",
+                    "App\\Http\\Middleware\\ResolveAnonId",
+                    "App\\Http\\Middleware\\ResolveOrgContext",
+                    "App\\Http\\Middleware\\FmTokenOptional",
+                    "Illuminate\\Routing\\Middleware\\ThrottleRequests:api_track",
+                    "App\\Http\\Middleware\\EnsureUuidRouteParams:inviteId"
                 ]
             }
         },
@@ -1304,6 +1348,30 @@
                     }
                 },
                 "x-laravel-action": "App\\Http\\Controllers\\API\\V0_3\\ShareController@click",
+                "x-laravel-middleware": [
+                    "api",
+                    "Illuminate\\Routing\\Middleware\\ThrottleRequests:api_public",
+                    "App\\Http\\Middleware\\NormalizeApiErrorContract",
+                    "App\\Http\\Middleware\\ResolveAnonId",
+                    "App\\Http\\Middleware\\ResolveOrgContext",
+                    "App\\Http\\Middleware\\FmTokenOptional",
+                    "App\\Http\\Middleware\\LimitApiPublicPayloadSize",
+                    "Illuminate\\Routing\\Middleware\\ThrottleRequests:api_track"
+                ]
+            }
+        },
+        "/api/v0.3/shares/{shareId}/compare-invites": {
+            "post": {
+                "operationId": "post_api_v0_3_shares_shareid_compare_invites",
+                "tags": [
+                    "api:v0.3"
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK"
+                    }
+                },
+                "x-laravel-action": "App\\Http\\Controllers\\API\\V0_3\\MbtiCompareInviteController@store",
                 "x-laravel-middleware": [
                     "api",
                     "Illuminate\\Routing\\Middleware\\ThrottleRequests:api_public",

--- a/backend/routes/api.php
+++ b/backend/routes/api.php
@@ -10,6 +10,7 @@ use App\Http\Controllers\API\V0_3\BigFiveOpsController;
 use App\Http\Controllers\API\V0_3\BootController as BootV0_3Controller;
 use App\Http\Controllers\API\V0_3\ClaimController as ClaimV03Controller;
 use App\Http\Controllers\API\V0_3\ComplianceDsarController;
+use App\Http\Controllers\API\V0_3\MbtiCompareInviteController;
 use App\Http\Controllers\API\V0_3\MeController as MeV03Controller;
 use App\Http\Controllers\API\V0_3\OrgInvitesController;
 use App\Http\Controllers\API\V0_3\OrgsController;
@@ -165,7 +166,7 @@ Route::prefix('v0.3')->middleware([
             ->middleware('uuid:id')
             ->name('api.v0_3.attempts.report_pdf');
         // Share contract routes stay fixed; summary/click semantics are implemented in ShareController/services.
-        Route::get('/attempts/{id}/share', [ShareV03Controller::class, 'getShare'])
+        Route::match(['GET', 'POST'], '/attempts/{id}/share', [ShareV03Controller::class, 'getShare'])
             ->middleware(\App\Http\Middleware\FmTokenAuth::class);
 
         // 3) Commerce v2 (public with org context)
@@ -206,6 +207,19 @@ Route::prefix('v0.3')->middleware([
                 'throttle:api_track',
             ])
             ->where('shareId', '[A-Za-z0-9_-]{6,128}');
+        Route::post('/shares/{shareId}/compare-invites', [MbtiCompareInviteController::class, 'store'])
+            ->middleware([
+                \App\Http\Middleware\FmTokenOptional::class,
+                \App\Http\Middleware\LimitApiPublicPayloadSize::class,
+                'throttle:api_track',
+            ])
+            ->where('shareId', '[A-Za-z0-9_-]{6,128}');
+        Route::get('/compare/mbti/{inviteId}', [MbtiCompareInviteController::class, 'show'])
+            ->middleware([
+                \App\Http\Middleware\FmTokenOptional::class,
+                'throttle:api_track',
+                'uuid:inviteId',
+            ]);
     });
 
     Route::middleware([\App\Http\Middleware\FmTokenAuth::class, ResolveOrgContext::class])

--- a/backend/tests/Feature/UuidRouteParamsMiddlewareTest.php
+++ b/backend/tests/Feature/UuidRouteParamsMiddlewareTest.php
@@ -40,4 +40,15 @@ final class UuidRouteParamsMiddlewareTest extends TestCase
             'error_code' => 'NOT_FOUND',
         ]);
     }
+
+    public function test_v03_compare_mbti_with_invalid_invite_id_returns_uniform_404_json(): void
+    {
+        $response = $this->getJson('/api/v0.3/compare/mbti/not-a-uuid');
+
+        $response->assertStatus(404);
+        $response->assertJson([
+            'ok' => false,
+            'error_code' => 'NOT_FOUND',
+        ]);
+    }
 }

--- a/backend/tests/Feature/V0_3/MbtiAttemptShareAccessTest.php
+++ b/backend/tests/Feature/V0_3/MbtiAttemptShareAccessTest.php
@@ -1,0 +1,182 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\V0_3;
+
+use App\Models\Attempt;
+use App\Models\Result;
+use App\Models\Share;
+use Database\Seeders\ScaleRegistrySeeder;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Str;
+use Tests\TestCase;
+
+final class MbtiAttemptShareAccessTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_locked_mbti_owner_can_create_share_via_get_and_post(): void
+    {
+        $this->seedScales();
+
+        $anonId = 'anon_mbti_share_owner';
+        $attemptId = $this->createAttemptWithResult('MBTI', $anonId);
+        $token = $this->issueAnonToken($anonId);
+
+        $headers = [
+            'Authorization' => 'Bearer '.$token,
+            'X-Anon-Id' => $anonId,
+        ];
+
+        $get = $this->withHeaders($headers)->getJson("/api/v0.3/attempts/{$attemptId}/share");
+        $post = $this->withHeaders($headers)->postJson("/api/v0.3/attempts/{$attemptId}/share");
+
+        $get->assertOk()
+            ->assertJsonPath('ok', true)
+            ->assertJsonPath('attempt_id', $attemptId)
+            ->assertJsonPath('compare_enabled', true);
+        $post->assertOk()
+            ->assertJsonPath('ok', true)
+            ->assertJsonPath('attempt_id', $attemptId)
+            ->assertJsonPath('share_id', $get->json('share_id'));
+    }
+
+    public function test_non_owner_cannot_create_mbti_share(): void
+    {
+        $this->seedScales();
+
+        $ownerAnonId = 'anon_mbti_share_owner_2';
+        $probeAnonId = 'anon_mbti_share_probe';
+        $attemptId = $this->createAttemptWithResult('MBTI', $ownerAnonId);
+        $token = $this->issueAnonToken($probeAnonId);
+
+        $response = $this->withHeaders([
+            'Authorization' => 'Bearer '.$token,
+            'X-Anon-Id' => $probeAnonId,
+        ])->getJson("/api/v0.3/attempts/{$attemptId}/share");
+
+        $response->assertStatus(404);
+        $response->assertJsonPath('ok', false);
+    }
+
+    public function test_non_mbti_share_returns_not_found_for_compare_invite_contract(): void
+    {
+        $this->seedScales();
+
+        $attemptId = $this->createAttemptWithResult('SDS_20', 'anon_non_mbti_owner');
+        $share = new Share;
+        $share->id = bin2hex(random_bytes(16));
+        $share->attempt_id = $attemptId;
+        $share->anon_id = 'anon_non_mbti_owner';
+        $share->scale_code = 'SDS_20';
+        $share->scale_version = 'v0.3';
+        $share->content_package_version = 'v0.3';
+        $share->save();
+
+        $response = $this->postJson("/api/v0.3/shares/{$share->id}/compare-invites", [
+            'anon_id' => 'anon_non_mbti_probe',
+            'utm_source' => 'share',
+        ]);
+
+        $response->assertStatus(404);
+        $response->assertJsonPath('ok', false);
+    }
+
+    private function seedScales(): void
+    {
+        (new ScaleRegistrySeeder)->run();
+    }
+
+    private function issueAnonToken(string $anonId): string
+    {
+        $token = 'fm_'.(string) Str::uuid();
+
+        DB::table('fm_tokens')->insert([
+            'token' => $token,
+            'token_hash' => hash('sha256', $token),
+            'user_id' => null,
+            'anon_id' => $anonId,
+            'org_id' => 0,
+            'role' => 'public',
+            'expires_at' => now()->addDay(),
+            'created_at' => now(),
+            'updated_at' => now(),
+        ]);
+
+        return $token;
+    }
+
+    private function createAttemptWithResult(string $scaleCode, string $anonId): string
+    {
+        $attemptId = (string) Str::uuid();
+        $isMbti = $scaleCode === 'MBTI';
+
+        Attempt::create([
+            'id' => $attemptId,
+            'org_id' => 0,
+            'anon_id' => $anonId,
+            'scale_code' => $scaleCode,
+            'scale_version' => 'v0.3',
+            'region' => 'CN_MAINLAND',
+            'locale' => 'zh-CN',
+            'question_count' => $isMbti ? 144 : 20,
+            'client_platform' => 'test',
+            'answers_summary_json' => ['stage' => 'seed'],
+            'started_at' => now()->subMinute(),
+            'submitted_at' => now(),
+            'pack_id' => $isMbti ? (string) config('content_packs.default_pack_id', 'MBTI.cn-mainland.zh-CN.v0.3') : 'SDS_20.pack',
+            'dir_version' => $isMbti ? (string) config('content_packs.default_dir_version', 'MBTI-CN-v0.3') : 'SDS_20.dir',
+            'content_package_version' => 'v0.3',
+            'scoring_spec_version' => '2026.01',
+        ]);
+
+        Result::create([
+            'id' => (string) Str::uuid(),
+            'org_id' => 0,
+            'attempt_id' => $attemptId,
+            'scale_code' => $scaleCode,
+            'scale_version' => 'v0.3',
+            'type_code' => $isMbti ? 'INTJ-A' : 'SDS-READY',
+            'scores_json' => ['total' => 100],
+            'scores_pct' => $isMbti ? [
+                'EI' => 35,
+                'SN' => 72,
+                'TF' => 68,
+                'JP' => 63,
+                'AT' => 58,
+            ] : [],
+            'axis_states' => $isMbti ? [
+                'EI' => 'clear',
+                'SN' => 'clear',
+                'TF' => 'clear',
+                'JP' => 'moderate',
+                'AT' => 'moderate',
+            ] : [],
+            'content_package_version' => 'v0.3',
+            'result_json' => $isMbti
+                ? [
+                    'type_code' => 'INTJ-A',
+                    'type_name' => '建筑师型',
+                    'summary' => 'Public-safe share summary.',
+                    'tagline' => '冷静的长期规划者',
+                    'rarity' => '约 2%',
+                    'keywords' => ['战略', '独立', '前瞻'],
+                ]
+                : [
+                    'type_code' => 'SDS-READY',
+                    'type_name' => '抑郁自评',
+                    'summary' => 'Non MBTI summary',
+                ],
+            'pack_id' => $isMbti ? (string) config('content_packs.default_pack_id', 'MBTI.cn-mainland.zh-CN.v0.3') : 'SDS_20.pack',
+            'dir_version' => $isMbti ? (string) config('content_packs.default_dir_version', 'MBTI-CN-v0.3') : 'SDS_20.dir',
+            'scoring_spec_version' => '2026.01',
+            'report_engine_version' => 'v1.2',
+            'is_valid' => true,
+            'computed_at' => now(),
+        ]);
+
+        return $attemptId;
+    }
+}

--- a/backend/tests/Feature/V0_3/MbtiCompareInviteAttributionFlowTest.php
+++ b/backend/tests/Feature/V0_3/MbtiCompareInviteAttributionFlowTest.php
@@ -1,0 +1,357 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\V0_3;
+
+use App\Models\Attempt;
+use App\Models\Order;
+use App\Models\Result;
+use App\Services\Attempts\AttemptSubmitSideEffects;
+use App\Services\Commerce\OrderManager;
+use App\Support\OrgContext;
+use Database\Seeders\ScaleRegistrySeeder;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Str;
+use Tests\TestCase;
+
+final class MbtiCompareInviteAttributionFlowTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_start_submit_checkout_and_paid_flow_persist_compare_invite_attribution(): void
+    {
+        $this->seedScales();
+        $this->seedSku();
+
+        [$inviterAttemptId, $inviterAnonId, $inviterToken] = $this->createOwnerContext('anon_inviter_owner', 'INTJ-A');
+        $shareId = $this->createShareViaApi($inviterAttemptId, $inviterAnonId, $inviterToken);
+
+        $invite = $this->postJson("/api/v0.3/shares/{$shareId}/compare-invites", [
+            'anon_id' => 'scan_probe',
+            'entrypoint' => 'share_page',
+            'compare_intent' => true,
+            'landing_path' => '/zh/share/'.$shareId,
+            'utm_source' => 'share',
+            'utm_medium' => 'organic',
+            'utm_campaign' => 'mbti_compare',
+            'meta' => [
+                'share_click_id' => 'clk_flow_001',
+            ],
+        ]);
+        $invite->assertOk();
+        $inviteId = (string) $invite->json('invite_id');
+
+        $inviteeAnonId = 'anon_invitee_owner';
+        $start = $this->withHeaders([
+            'X-Anon-Id' => $inviteeAnonId,
+        ])->postJson('/api/v0.3/attempts/start', [
+            'scale_code' => 'MBTI',
+            'anon_id' => $inviteeAnonId,
+            'share_id' => $shareId,
+            'compare_invite_id' => $inviteId,
+            'share_click_id' => 'clk_flow_001',
+            'entrypoint' => 'share_page',
+            'referrer' => 'https://ref.example/share',
+            'landing_path' => '/zh/share/'.$shareId,
+            'utm_source' => 'share',
+            'utm_medium' => 'organic',
+            'utm_campaign' => 'pr07a',
+        ]);
+
+        $start->assertOk()
+            ->assertJsonPath('ok', true)
+            ->assertJsonPath('scale_code_legacy', 'MBTI');
+
+        $inviteeAttemptId = (string) $start->json('attempt_id');
+        $this->assertNotSame('', $inviteeAttemptId);
+
+        $inviteeAttempt = Attempt::query()->findOrFail($inviteeAttemptId);
+        $this->assertSame($shareId, data_get($inviteeAttempt->answers_summary_json, 'meta.share_id'));
+        $this->assertSame($inviteId, data_get($inviteeAttempt->answers_summary_json, 'meta.compare_invite_id'));
+        $this->assertSame('clk_flow_001', data_get($inviteeAttempt->answers_summary_json, 'meta.share_click_id'));
+        $this->assertSame('share_page', data_get($inviteeAttempt->answers_summary_json, 'meta.entrypoint'));
+        $this->assertSame('/zh/share/'.$shareId, data_get($inviteeAttempt->answers_summary_json, 'meta.landing_path'));
+        $this->assertSame('share', data_get($inviteeAttempt->answers_summary_json, 'meta.utm.source'));
+
+        $inviteeToken = $this->issueAnonToken($inviteeAnonId);
+
+        Result::create([
+            'id' => (string) Str::uuid(),
+            'org_id' => 0,
+            'attempt_id' => $inviteeAttemptId,
+            'scale_code' => 'MBTI',
+            'scale_version' => 'v0.3',
+            'type_code' => 'ENFP-T',
+            'scores_json' => ['total' => 100],
+            'scores_pct' => [
+                'EI' => 72,
+                'SN' => 74,
+                'TF' => 41,
+                'JP' => 38,
+                'AT' => 43,
+            ],
+            'axis_states' => [
+                'EI' => 'clear',
+                'SN' => 'clear',
+                'TF' => 'moderate',
+                'JP' => 'moderate',
+                'AT' => 'moderate',
+            ],
+            'content_package_version' => 'v0.3',
+            'result_json' => [
+                'type_code' => 'ENFP-T',
+                'type_name' => '竞选者型',
+                'summary' => 'Invitee public-safe share summary.',
+                'tagline' => '热情的连接者',
+                'rarity' => '约 8%',
+                'keywords' => ['热情', '灵感', '共情'],
+            ],
+            'pack_id' => (string) config('content_packs.default_pack_id', 'MBTI.cn-mainland.zh-CN.v0.3'),
+            'dir_version' => (string) config('content_packs.default_dir_version', 'MBTI-CN-v0.3'),
+            'scoring_spec_version' => '2026.01',
+            'report_engine_version' => 'v1.2',
+            'is_valid' => true,
+            'computed_at' => now(),
+        ]);
+
+        $inviteeAttempt->submitted_at = now();
+        $inviteeAttempt->answers_summary_json = [
+            'stage' => 'submit',
+            'meta' => [
+                'share_id' => $shareId,
+                'compare_invite_id' => $inviteId,
+                'share_click_id' => 'clk_flow_001',
+                'entrypoint' => 'share_page',
+                'referrer' => 'https://ref.example/share',
+                'landing_path' => '/zh/share/'.$shareId,
+                'utm' => [
+                    'source' => 'share',
+                    'medium' => 'organic',
+                    'campaign' => 'pr07a',
+                ],
+            ],
+        ];
+        $inviteeAttempt->save();
+
+        $ctx = new OrgContext;
+        $ctx->set(0, null, 'public', $inviteeAnonId);
+
+        app(AttemptSubmitSideEffects::class)->runAfterSubmit($ctx, [
+            'org_id' => 0,
+            'attempt_id' => $inviteeAttemptId,
+            'scale_code' => 'MBTI',
+            'pack_id' => (string) config('content_packs.default_pack_id', 'MBTI.cn-mainland.zh-CN.v0.3'),
+            'dir_version' => (string) config('content_packs.default_dir_version', 'MBTI-CN-v0.3'),
+            'scoring_spec_version' => '2026.01',
+            'invite_token' => '',
+            'credit_benefit_code' => '',
+            'entitlement_benefit_code' => '',
+            'share_id' => $shareId,
+            'compare_invite_id' => $inviteId,
+            'share_click_id' => 'clk_flow_001',
+            'entrypoint' => 'share_page',
+            'referrer' => 'https://ref.example/share',
+            'landing_path' => '/zh/share/'.$shareId,
+            'utm' => [
+                'source' => 'share',
+                'medium' => 'organic',
+                'campaign' => 'pr07a',
+            ],
+        ], null, $inviteeAnonId);
+
+        $compareReady = $this->getJson("/api/v0.3/compare/mbti/{$inviteId}");
+        $compareReady->assertOk()
+            ->assertJsonPath('ok', true)
+            ->assertJsonPath('status', 'ready')
+            ->assertJsonPath('invitee.type_code', 'ENFP-T')
+            ->assertJsonPath('compare.same_type', false)
+            ->assertJsonPath('compare.axes.0.code', 'EI');
+
+        config()->set('payments.allow_stub', true);
+        config()->set('payments.providers.stub.enabled', true);
+
+        $checkout = $this->withHeaders([
+            'Authorization' => 'Bearer '.$inviteeToken,
+            'X-Anon-Id' => $inviteeAnonId,
+        ])->postJson('/api/v0.3/orders/checkout', [
+            'attempt_id' => $inviteeAttemptId,
+            'sku' => 'MBTI_REPORT_FULL',
+            'provider' => 'stub',
+            'share_id' => $shareId,
+            'compare_invite_id' => $inviteId,
+            'share_click_id' => 'clk_flow_001',
+            'entrypoint' => 'share_page',
+            'referrer' => 'https://ref.example/share',
+            'landing_path' => '/zh/share/'.$shareId,
+            'utm_source' => 'share',
+            'utm_medium' => 'organic',
+            'utm_campaign' => 'pr07a',
+        ]);
+
+        $checkout->assertOk()
+            ->assertJsonPath('ok', true)
+            ->assertJsonPath('attempt_id', $inviteeAttemptId)
+            ->assertJsonPath('provider', 'stub');
+
+        $orderNo = (string) $checkout->json('order_no');
+        $this->assertNotSame('', $orderNo);
+
+        $order = Order::query()->where('order_no', $orderNo)->firstOrFail();
+        $this->assertSame($shareId, data_get($order->meta_json, 'attribution.share_id'));
+        $this->assertSame($inviteId, data_get($order->meta_json, 'attribution.compare_invite_id'));
+        $this->assertSame('clk_flow_001', data_get($order->meta_json, 'attribution.share_click_id'));
+        $this->assertSame('share_page', data_get($order->meta_json, 'attribution.entrypoint'));
+        $this->assertSame('/zh/share/'.$shareId, data_get($order->meta_json, 'attribution.landing_path'));
+        $this->assertSame('share', data_get($order->meta_json, 'attribution.utm.source'));
+
+        $paid = app(OrderManager::class)->transitionToPaidAtomic(
+            $orderNo,
+            0,
+            'trade_001',
+            now()->toISOString()
+        );
+
+        $this->assertTrue((bool) ($paid['ok'] ?? false));
+
+        $inviteRow = DB::table('mbti_compare_invites')->where('id', $inviteId)->first();
+        $this->assertNotNull($inviteRow);
+        $this->assertSame('purchased', (string) ($inviteRow->status ?? ''));
+        $this->assertSame($inviteeAttemptId, (string) ($inviteRow->invitee_attempt_id ?? ''));
+        $this->assertSame($inviteeAnonId, (string) ($inviteRow->invitee_anon_id ?? ''));
+        $this->assertSame($orderNo, (string) ($inviteRow->invitee_order_no ?? ''));
+        $this->assertNotNull($inviteRow->accepted_at);
+        $this->assertNotNull($inviteRow->completed_at);
+        $this->assertNotNull($inviteRow->purchased_at);
+    }
+
+    private function seedScales(): void
+    {
+        (new ScaleRegistrySeeder)->run();
+    }
+
+    private function seedSku(): void
+    {
+        DB::table('skus')->insert([
+            'sku' => 'MBTI_REPORT_FULL',
+            'scale_code' => 'MBTI',
+            'scope' => 'attempt',
+            'price_cents' => 299,
+            'currency' => 'USD',
+            'kind' => 'report',
+            'benefit_code' => 'MBTI_REPORT_FULL',
+            'unit_qty' => 1,
+            'org_id' => 0,
+            'meta_json' => json_encode([
+                'requested_sku' => 'MBTI_REPORT_FULL',
+                'effective_sku' => 'MBTI_REPORT_FULL',
+                'entitlement_id' => 'mbti_report_full',
+            ], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES),
+            'is_active' => 1,
+            'created_at' => now(),
+            'updated_at' => now(),
+        ]);
+    }
+
+    /**
+     * @return array{0:string,1:string,2:string}
+     */
+    private function createOwnerContext(string $anonId, string $typeCode): array
+    {
+        $attemptId = (string) Str::uuid();
+
+        Attempt::create([
+            'id' => $attemptId,
+            'org_id' => 0,
+            'anon_id' => $anonId,
+            'scale_code' => 'MBTI',
+            'scale_version' => 'v0.3',
+            'region' => 'CN_MAINLAND',
+            'locale' => 'zh-CN',
+            'question_count' => 144,
+            'client_platform' => 'test',
+            'answers_summary_json' => ['stage' => 'seed'],
+            'started_at' => now()->subMinute(),
+            'submitted_at' => now(),
+            'pack_id' => (string) config('content_packs.default_pack_id', 'MBTI.cn-mainland.zh-CN.v0.3'),
+            'dir_version' => (string) config('content_packs.default_dir_version', 'MBTI-CN-v0.3'),
+            'content_package_version' => 'v0.3',
+            'scoring_spec_version' => '2026.01',
+        ]);
+
+        Result::create([
+            'id' => (string) Str::uuid(),
+            'org_id' => 0,
+            'attempt_id' => $attemptId,
+            'scale_code' => 'MBTI',
+            'scale_version' => 'v0.3',
+            'type_code' => $typeCode,
+            'scores_json' => ['total' => 100],
+            'scores_pct' => [
+                'EI' => 35,
+                'SN' => 72,
+                'TF' => 68,
+                'JP' => 63,
+                'AT' => 58,
+            ],
+            'axis_states' => [
+                'EI' => 'clear',
+                'SN' => 'clear',
+                'TF' => 'clear',
+                'JP' => 'moderate',
+                'AT' => 'moderate',
+            ],
+            'content_package_version' => 'v0.3',
+            'result_json' => [
+                'type_code' => $typeCode,
+                'type_name' => $typeCode === 'INTJ-A' ? '建筑师型' : '竞选者型',
+                'summary' => 'Public-safe share summary.',
+                'tagline' => $typeCode === 'INTJ-A' ? '冷静的长期规划者' : '热情的连接者',
+                'rarity' => $typeCode === 'INTJ-A' ? '约 2%' : '约 8%',
+                'keywords' => $typeCode === 'INTJ-A' ? ['战略', '独立', '前瞻'] : ['热情', '灵感', '共情'],
+            ],
+            'pack_id' => (string) config('content_packs.default_pack_id', 'MBTI.cn-mainland.zh-CN.v0.3'),
+            'dir_version' => (string) config('content_packs.default_dir_version', 'MBTI-CN-v0.3'),
+            'scoring_spec_version' => '2026.01',
+            'report_engine_version' => 'v1.2',
+            'is_valid' => true,
+            'computed_at' => now(),
+        ]);
+
+        $token = $this->issueAnonToken($anonId);
+
+        return [$attemptId, $anonId, $token];
+    }
+
+    private function issueAnonToken(string $anonId): string
+    {
+        $token = 'fm_'.(string) Str::uuid();
+
+        DB::table('fm_tokens')->insert([
+            'token' => $token,
+            'token_hash' => hash('sha256', $token),
+            'user_id' => null,
+            'anon_id' => $anonId,
+            'org_id' => 0,
+            'role' => 'public',
+            'expires_at' => now()->addDay(),
+            'created_at' => now(),
+            'updated_at' => now(),
+        ]);
+
+        return $token;
+    }
+
+    private function createShareViaApi(string $attemptId, string $anonId, string $token): string
+    {
+        $response = $this->withHeaders([
+            'Authorization' => 'Bearer '.$token,
+            'X-Anon-Id' => $anonId,
+        ])->getJson("/api/v0.3/attempts/{$attemptId}/share");
+
+        $response->assertOk();
+
+        return (string) $response->json('share_id');
+    }
+}

--- a/backend/tests/Feature/V0_3/MbtiCompareInviteContractTest.php
+++ b/backend/tests/Feature/V0_3/MbtiCompareInviteContractTest.php
@@ -1,0 +1,238 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\V0_3;
+
+use App\Models\Attempt;
+use App\Models\Result;
+use Database\Seeders\ScaleRegistrySeeder;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Str;
+use Tests\TestCase;
+
+final class MbtiCompareInviteContractTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_create_compare_invite_returns_pending_contract_and_new_invite_id_each_time(): void
+    {
+        $this->seedScales();
+
+        [$attemptId, $anonId, $token] = $this->createOwnerContext();
+        $shareId = $this->createShareViaApi($attemptId, $anonId, $token);
+
+        $first = $this->postJson("/api/v0.3/shares/{$shareId}/compare-invites", [
+            'anon_id' => 'scan_probe',
+            'entrypoint' => 'share_page',
+            'compare_intent' => true,
+            'landing_path' => '/zh/share/'.$shareId,
+            'utm_source' => 'share',
+            'utm_medium' => 'organic',
+            'utm_campaign' => 'mbti_compare',
+            'meta' => [
+                'share_click_id' => 'clk_001',
+            ],
+        ]);
+
+        $second = $this->postJson("/api/v0.3/shares/{$shareId}/compare-invites", [
+            'anon_id' => 'scan_probe',
+            'entrypoint' => 'share_page',
+            'compare_intent' => true,
+            'utm_source' => 'share',
+        ]);
+
+        $first->assertOk()
+            ->assertJsonPath('ok', true)
+            ->assertJsonPath('share_id', $shareId)
+            ->assertJsonPath('scale_code', 'MBTI')
+            ->assertJsonPath('locale', 'zh-CN')
+            ->assertJsonPath('status', 'pending')
+            ->assertJsonPath('take_path', '/zh/tests/mbti-personality-test-16-personality-types/take?share_id='.$shareId.'&compare_invite_id='.$first->json('invite_id'))
+            ->assertJsonPath('compare_path', '/zh/compare/mbti/'.$first->json('invite_id'))
+            ->assertJsonPath('inviter.share_id', $shareId)
+            ->assertJsonPath('inviter.type_code', 'INTJ-A')
+            ->assertJsonPath('inviter.summary', 'Public-safe share summary.');
+
+        $second->assertOk()
+            ->assertJsonPath('ok', true)
+            ->assertJsonPath('share_id', $shareId);
+
+        $this->assertNotSame((string) $first->json('invite_id'), (string) $second->json('invite_id'));
+        $first->assertJsonMissingPath('report');
+        $first->assertJsonMissingPath('offers');
+        $first->assertJsonMissingPath('sections');
+        $first->assertJsonMissingPath('layers');
+    }
+
+    public function test_public_compare_pending_contract_is_public_safe(): void
+    {
+        $this->seedScales();
+
+        [$attemptId, $anonId, $token] = $this->createOwnerContext();
+        $shareId = $this->createShareViaApi($attemptId, $anonId, $token);
+        $invite = $this->postJson("/api/v0.3/shares/{$shareId}/compare-invites", [
+            'anon_id' => 'scan_probe',
+            'entrypoint' => 'share_page',
+            'compare_intent' => true,
+            'utm_source' => 'share',
+            'utm_medium' => 'organic',
+            'utm_campaign' => 'mbti_compare',
+        ]);
+        $invite->assertOk();
+
+        $inviteId = (string) $invite->json('invite_id');
+        $response = $this->getJson("/api/v0.3/compare/mbti/{$inviteId}");
+
+        $response->assertOk()
+            ->assertJsonPath('ok', true)
+            ->assertJsonPath('invite_id', $inviteId)
+            ->assertJsonPath('share_id', $shareId)
+            ->assertJsonPath('scale_code', 'MBTI')
+            ->assertJsonPath('locale', 'zh-CN')
+            ->assertJsonPath('status', 'pending')
+            ->assertJsonPath('invitee', null)
+            ->assertJsonPath('compare', null)
+            ->assertJsonPath('primary_cta_label', '开始测试')
+            ->assertJsonPath('primary_cta_path', '/zh/tests/mbti-personality-test-16-personality-types/take?share_id='.$shareId.'&compare_invite_id='.$inviteId)
+            ->assertJsonPath('inviter.share_id', $shareId)
+            ->assertJsonPath('inviter.type_code', 'INTJ-A')
+            ->assertJsonPath('inviter.summary', 'Public-safe share summary.');
+
+        foreach ([
+            'report',
+            'offers',
+            'recommended_reads',
+            'cta',
+            'sections',
+            'layers',
+            'pdf',
+            'order',
+            'reward',
+            'coupon',
+        ] as $forbiddenField) {
+            $response->assertJsonMissingPath($forbiddenField);
+        }
+
+        $this->assertStringNotContainsString('PRIVATE_PAID_SECTION_BODY', (string) $response->getContent());
+    }
+
+    /**
+     * @return array{0:string,1:string,2:string}
+     */
+    private function createOwnerContext(): array
+    {
+        $anonId = 'anon_compare_invite_owner';
+        $attemptId = $this->createMbtiAttemptWithResult($anonId);
+        $token = $this->issueAnonToken($anonId);
+
+        return [$attemptId, $anonId, $token];
+    }
+
+    private function seedScales(): void
+    {
+        (new ScaleRegistrySeeder)->run();
+    }
+
+    private function issueAnonToken(string $anonId): string
+    {
+        $token = 'fm_'.(string) Str::uuid();
+
+        DB::table('fm_tokens')->insert([
+            'token' => $token,
+            'token_hash' => hash('sha256', $token),
+            'user_id' => null,
+            'anon_id' => $anonId,
+            'org_id' => 0,
+            'role' => 'public',
+            'expires_at' => now()->addDay(),
+            'created_at' => now(),
+            'updated_at' => now(),
+        ]);
+
+        return $token;
+    }
+
+    private function createShareViaApi(string $attemptId, string $anonId, string $token): string
+    {
+        $response = $this->withHeaders([
+            'Authorization' => 'Bearer '.$token,
+            'X-Anon-Id' => $anonId,
+        ])->getJson("/api/v0.3/attempts/{$attemptId}/share");
+
+        $response->assertOk();
+
+        return (string) $response->json('share_id');
+    }
+
+    private function createMbtiAttemptWithResult(string $anonId): string
+    {
+        $attemptId = (string) Str::uuid();
+
+        Attempt::create([
+            'id' => $attemptId,
+            'org_id' => 0,
+            'anon_id' => $anonId,
+            'scale_code' => 'MBTI',
+            'scale_version' => 'v0.3',
+            'region' => 'CN_MAINLAND',
+            'locale' => 'zh-CN',
+            'question_count' => 144,
+            'client_platform' => 'test',
+            'answers_summary_json' => ['stage' => 'seed'],
+            'started_at' => now()->subMinute(),
+            'submitted_at' => now(),
+            'pack_id' => (string) config('content_packs.default_pack_id', 'MBTI.cn-mainland.zh-CN.v0.3'),
+            'dir_version' => (string) config('content_packs.default_dir_version', 'MBTI-CN-v0.3'),
+            'content_package_version' => 'v0.3',
+            'scoring_spec_version' => '2026.01',
+        ]);
+
+        Result::create([
+            'id' => (string) Str::uuid(),
+            'org_id' => 0,
+            'attempt_id' => $attemptId,
+            'scale_code' => 'MBTI',
+            'scale_version' => 'v0.3',
+            'type_code' => 'INTJ-A',
+            'scores_json' => ['total' => 100],
+            'scores_pct' => [
+                'EI' => 35,
+                'SN' => 72,
+                'TF' => 68,
+                'JP' => 63,
+                'AT' => 58,
+            ],
+            'axis_states' => [
+                'EI' => 'clear',
+                'SN' => 'clear',
+                'TF' => 'clear',
+                'JP' => 'moderate',
+                'AT' => 'moderate',
+            ],
+            'content_package_version' => 'v0.3',
+            'result_json' => [
+                'type_code' => 'INTJ-A',
+                'type_name' => '建筑师型',
+                'summary' => 'Public-safe share summary.',
+                'tagline' => '冷静的长期规划者',
+                'rarity' => '约 2%',
+                'keywords' => ['战略', '独立', '前瞻'],
+                'layers' => [
+                    'identity' => [
+                        'body' => 'PRIVATE_PAID_SECTION_BODY',
+                    ],
+                ],
+            ],
+            'pack_id' => (string) config('content_packs.default_pack_id', 'MBTI.cn-mainland.zh-CN.v0.3'),
+            'dir_version' => (string) config('content_packs.default_dir_version', 'MBTI-CN-v0.3'),
+            'scoring_spec_version' => '2026.01',
+            'report_engine_version' => 'v1.2',
+            'is_valid' => true,
+            'computed_at' => now(),
+        ]);
+
+        return $attemptId;
+    }
+}

--- a/backend/tests/Feature/V0_3/RateLimitKeyEndpointsTest.php
+++ b/backend/tests/Feature/V0_3/RateLimitKeyEndpointsTest.php
@@ -23,6 +23,12 @@ final class RateLimitKeyEndpointsTest extends TestCase
         $shareClick = $this->findRoute('POST', 'api/v0.3/shares/{shareId}/click');
         $this->assertContains('throttle:api_track', $shareClick->gatherMiddleware());
 
+        $compareInviteCreate = $this->findRoute('POST', 'api/v0.3/shares/{shareId}/compare-invites');
+        $this->assertContains('throttle:api_track', $compareInviteCreate->gatherMiddleware());
+
+        $compareInviteView = $this->findRoute('GET', 'api/v0.3/compare/mbti/{inviteId}');
+        $this->assertContains('throttle:api_track', $compareInviteView->gatherMiddleware());
+
         $paymentWebhook = $this->findRoute('POST', 'api/v0.3/webhooks/payment/{provider}');
         $this->assertContains('throttle:api_webhook', $paymentWebhook->gatherMiddleware());
     }
@@ -117,6 +123,36 @@ final class RateLimitKeyEndpointsTest extends TestCase
 
         $response = $this->call('POST', '/api/v0.3/webhooks/payment/stripe', [], [], [], $server, $raw);
         $this->assertRateLimitContract($response->status(), $response->json(), 'RATE_LIMIT_WEBHOOK');
+    }
+
+    public function test_compare_invite_public_routes_share_track_rate_limit_contract(): void
+    {
+        $this->configureRateLimitGate([
+            'fap.rate_limits.api_track_per_minute' => 2,
+        ]);
+
+        $server = ['REMOTE_ADDR' => '198.51.100.44'];
+
+        $first = $this->withServerVariables($server)->postJson('/api/v0.3/shares/abc12345/compare-invites', []);
+        $second = $this->withServerVariables($server)->postJson('/api/v0.3/shares/abc12345/compare-invites', []);
+
+        $this->assertNotSame(429, $first->status());
+        $this->assertNotSame(429, $second->status());
+
+        $response = $this->withServerVariables($server)->postJson('/api/v0.3/shares/abc12345/compare-invites', []);
+        $this->assertRateLimitContract($response->status(), $response->json(), 'RATE_LIMIT_TRACK');
+
+        $getServer = ['REMOTE_ADDR' => '198.51.100.45'];
+        $inviteId = '11111111-1111-4111-8111-111111111111';
+
+        $firstGet = $this->withServerVariables($getServer)->getJson("/api/v0.3/compare/mbti/{$inviteId}");
+        $secondGet = $this->withServerVariables($getServer)->getJson("/api/v0.3/compare/mbti/{$inviteId}");
+
+        $this->assertNotSame(429, $firstGet->status());
+        $this->assertNotSame(429, $secondGet->status());
+
+        $thirdGet = $this->withServerVariables($getServer)->getJson("/api/v0.3/compare/mbti/{$inviteId}");
+        $this->assertRateLimitContract($thirdGet->status(), $thirdGet->json(), 'RATE_LIMIT_TRACK');
     }
 
     private function configureRateLimitGate(array $overrides = []): void

--- a/backend/tests/Feature/V0_3/ShareClickAttributionTest.php
+++ b/backend/tests/Feature/V0_3/ShareClickAttributionTest.php
@@ -96,6 +96,40 @@ final class ShareClickAttributionTest extends TestCase
         $this->assertSame((string) $share->attempt_id, data_get($event->meta_json, 'attempt_id'));
     }
 
+    public function test_click_accepts_flat_utm_fields_and_normalizes_them_into_nested_utm_meta(): void
+    {
+        $share = $this->createShareFixture('flat_utm_owner');
+
+        $response = $this->postJson("/api/v0.3/shares/{$share->id}/click", [
+            'anon_id' => 'flat_utm_probe',
+            'utm_source' => 'share',
+            'utm_medium' => 'organic',
+            'utm_campaign' => 'pr07a',
+            'utm_term' => 'mbti_compare',
+            'utm_content' => 'invite_card',
+            'entrypoint' => 'share_page',
+            'landing_path' => '/zh/share/'.(string) $share->id,
+            'share_click_id' => 'clk_flat_001',
+        ]);
+
+        $response->assertOk()
+            ->assertJsonPath('ok', true)
+            ->assertJsonPath('share_id', (string) $share->id);
+
+        $event = Event::query()
+            ->where('event_code', 'share_click')
+            ->where('share_id', (string) $share->id)
+            ->latest('created_at')
+            ->firstOrFail();
+
+        $this->assertSame('share', data_get($event->meta_json, 'utm.source'));
+        $this->assertSame('organic', data_get($event->meta_json, 'utm.medium'));
+        $this->assertSame('pr07a', data_get($event->meta_json, 'utm.campaign'));
+        $this->assertSame('mbti_compare', data_get($event->meta_json, 'utm.term'));
+        $this->assertSame('invite_card', data_get($event->meta_json, 'utm.content'));
+        $this->assertSame('clk_flat_001', data_get($event->meta_json, 'share_click_id'));
+    }
+
     private function createShareFixture(string $ownerAnonId): Share
     {
         $attemptId = (string) Str::uuid();

--- a/backend/tests/Feature/V0_3/ShareFlowCoreAlignmentTest.php
+++ b/backend/tests/Feature/V0_3/ShareFlowCoreAlignmentTest.php
@@ -6,10 +6,7 @@ namespace Tests\Feature\V0_3;
 
 use App\Models\Attempt;
 use App\Models\Result;
-use App\Services\Commerce\EntitlementManager;
-use App\Services\Legacy\LegacyShareFlowService;
-use App\Services\V0_3\ShareFlowService;
-use App\Support\OrgContext;
+use Database\Seeders\ScaleRegistrySeeder;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Str;
@@ -19,125 +16,211 @@ final class ShareFlowCoreAlignmentTest extends TestCase
 {
     use RefreshDatabase;
 
-    public function test_v03_and_legacy_share_flow_return_aligned_payloads_for_same_input(): void
+    public function test_attempt_share_get_and_post_return_aligned_payloads(): void
     {
-        $orgId = 123;
-        $attemptId = (string) Str::uuid();
-        $anonId = 'anon_share_flow_alignment';
-        $benefitCode = 'MBTI_REPORT_FULL';
+        $this->seedScales();
 
-        $this->seedScaleRegistry($orgId, $benefitCode);
-        $this->seedAttemptAndResult($orgId, $attemptId, $anonId);
+        $anonId = 'anon_share_alignment_get_post';
+        $attemptId = $this->createMbtiAttemptWithResult($anonId);
+        $token = $this->issueAnonToken($anonId);
 
-        $ctx = new OrgContext;
-        $ctx->set($orgId, null, 'public', $anonId);
-        app()->instance(OrgContext::class, $ctx);
-
-        app(EntitlementManager::class)->grantAttemptUnlock(
-            $orgId,
-            null,
-            $anonId,
-            $benefitCode,
-            $attemptId,
-            null
-        );
-
-        $input = [
-            'experiment' => 'exp_alignment',
-            'version' => '1.0.0',
-            'channel' => 'miniapp',
-            'client_platform' => 'wechat',
-            'entry_page' => 'result_page',
+        $headers = [
+            'Authorization' => 'Bearer '.$token,
+            'X-Anon-Id' => $anonId,
         ];
 
-        $v03 = app(ShareFlowService::class)->getShareLinkForAttempt($attemptId, $input);
-        $legacy = app(LegacyShareFlowService::class)->getShareLinkForAttempt($attemptId, $input);
+        $get = $this->withHeaders($headers)->getJson("/api/v0.3/attempts/{$attemptId}/share");
+        $post = $this->withHeaders($headers)->postJson("/api/v0.3/attempts/{$attemptId}/share");
 
-        $this->assertSame((string) ($v03['share_id'] ?? ''), (string) ($legacy['share_id'] ?? ''));
-        $this->assertSame((string) ($v03['share_url'] ?? ''), (string) ($legacy['share_url'] ?? ''));
-        $this->assertSame((string) ($v03['attempt_id'] ?? ''), (string) ($legacy['attempt_id'] ?? ''));
-        $this->assertSame((int) ($v03['org_id'] ?? -1), (int) ($legacy['org_id'] ?? -2));
-        $this->assertSame((string) ($v03['type_code'] ?? ''), (string) ($legacy['type_code'] ?? ''));
-        $this->assertNotSame('', trim((string) ($v03['type_name'] ?? '')));
-        $this->assertArrayHasKey('title', $v03);
-        $this->assertArrayHasKey('summary', $v03);
+        $get->assertOk()
+            ->assertJsonPath('ok', true)
+            ->assertJsonPath('compare_enabled', true)
+            ->assertJsonPath('compare_cta_label', '邀请朋友来测并对比')
+            ->assertJsonPath('primary_cta_path', '/zh/tests/mbti-personality-test-16-personality-types');
+        $post->assertOk()
+            ->assertJsonPath('ok', true);
 
-        $shareId = (string) ($v03['share_id'] ?? '');
+        foreach ([
+            'share_id',
+            'share_url',
+            'attempt_id',
+            'org_id',
+            'content_package_version',
+            'type_code',
+            'type_name',
+            'id',
+            'scale_code',
+            'locale',
+            'title',
+            'subtitle',
+            'summary',
+            'tagline',
+            'rarity',
+            'tags',
+            'dimensions',
+            'primary_cta_label',
+            'primary_cta_path',
+            'compare_enabled',
+            'compare_cta_label',
+        ] as $field) {
+            $this->assertSame($get->json($field), $post->json($field), "share field mismatch for {$field}");
+        }
+
+        $this->assertStringContainsString('/zh/share/'.$get->json('share_id'), (string) $get->json('share_url'));
+    }
+
+    public function test_attempt_share_and_public_share_view_return_aligned_summary_payloads(): void
+    {
+        $this->seedScales();
+
+        $anonId = 'anon_share_alignment_view';
+        $attemptId = $this->createMbtiAttemptWithResult($anonId);
+        $token = $this->issueAnonToken($anonId);
+
+        $share = $this->withHeaders([
+            'Authorization' => 'Bearer '.$token,
+            'X-Anon-Id' => $anonId,
+        ])->getJson("/api/v0.3/attempts/{$attemptId}/share");
+
+        $share->assertOk();
+        $shareId = (string) $share->json('share_id');
         $this->assertNotSame('', $shareId);
 
-        $v03View = app(ShareFlowService::class)->getShareView($shareId);
-        $legacyView = app(LegacyShareFlowService::class)->getShareView($shareId);
+        $view = $this->getJson("/api/v0.3/shares/{$shareId}");
+        $view->assertOk()
+            ->assertJsonPath('ok', true)
+            ->assertJsonPath('compare_enabled', true)
+            ->assertJsonPath('compare_cta_label', '邀请朋友来测并对比');
 
-        $this->assertSame((string) ($v03View['share_id'] ?? ''), (string) ($legacyView['share_id'] ?? ''));
-        $this->assertSame((string) ($v03View['attempt_id'] ?? ''), (string) ($legacyView['attempt_id'] ?? ''));
-        $this->assertSame((int) ($v03View['org_id'] ?? -1), (int) ($legacyView['org_id'] ?? -2));
-        $this->assertSame((string) ($v03View['type_code'] ?? ''), (string) ($legacyView['type_code'] ?? ''));
-        $this->assertNotSame('', trim((string) ($v03View['type_name'] ?? '')));
-        $this->assertArrayHasKey('dimensions', $v03View);
+        foreach ([
+            'share_id',
+            'share_url',
+            'attempt_id',
+            'org_id',
+            'content_package_version',
+            'type_code',
+            'type_name',
+            'id',
+            'scale_code',
+            'locale',
+            'title',
+            'subtitle',
+            'summary',
+            'tagline',
+            'rarity',
+            'tags',
+            'dimensions',
+            'primary_cta_label',
+            'primary_cta_path',
+            'compare_enabled',
+            'compare_cta_label',
+        ] as $field) {
+            $this->assertSame($share->json($field), $view->json($field), "share/view field mismatch for {$field}");
+        }
+
+        foreach ([
+            'report',
+            'result',
+            'offers',
+            'recommended_reads',
+            'layers',
+            'sections',
+            'cta',
+            'report_url',
+            'report_pdf_url',
+            'private_result_path',
+        ] as $forbiddenField) {
+            $view->assertJsonMissingPath($forbiddenField);
+        }
     }
 
-    private function seedScaleRegistry(int $orgId, string $benefitCode): void
+    private function seedScales(): void
     {
-        $now = now();
-        DB::table('scales_registry')->updateOrInsert(
-            ['code' => 'MBTI'],
-            [
-                'org_id' => $orgId,
-                'primary_slug' => 'mbti',
-                'slugs_json' => json_encode(['mbti'], JSON_UNESCAPED_UNICODE),
-                'driver_type' => 'questionnaire',
-                'default_pack_id' => 'MBTI.cn-mainland.zh-CN.v0.3',
-                'default_region' => 'CN_MAINLAND',
-                'default_locale' => 'zh-CN',
-                'default_dir_version' => 'MBTI-CN-v0.3',
-                'capabilities_json' => json_encode([], JSON_UNESCAPED_UNICODE),
-                'view_policy_json' => json_encode([], JSON_UNESCAPED_UNICODE),
-                'commercial_json' => json_encode(['report_benefit_code' => $benefitCode], JSON_UNESCAPED_UNICODE),
-                'seo_schema_json' => json_encode([], JSON_UNESCAPED_UNICODE),
-                'is_public' => 1,
-                'is_active' => 1,
-                'created_at' => $now,
-                'updated_at' => $now,
-            ]
-        );
+        (new ScaleRegistrySeeder)->run();
     }
 
-    private function seedAttemptAndResult(int $orgId, string $attemptId, string $anonId): void
+    private function issueAnonToken(string $anonId): string
     {
+        $token = 'fm_'.(string) Str::uuid();
+
+        DB::table('fm_tokens')->insert([
+            'token' => $token,
+            'token_hash' => hash('sha256', $token),
+            'user_id' => null,
+            'anon_id' => $anonId,
+            'org_id' => 0,
+            'role' => 'public',
+            'expires_at' => now()->addDay(),
+            'created_at' => now(),
+            'updated_at' => now(),
+        ]);
+
+        return $token;
+    }
+
+    private function createMbtiAttemptWithResult(string $anonId): string
+    {
+        $attemptId = (string) Str::uuid();
+
         Attempt::create([
             'id' => $attemptId,
-            'org_id' => $orgId,
+            'org_id' => 0,
             'anon_id' => $anonId,
             'scale_code' => 'MBTI',
             'scale_version' => 'v0.3',
             'region' => 'CN_MAINLAND',
             'locale' => 'zh-CN',
-            'question_count' => 1,
+            'question_count' => 144,
             'client_platform' => 'test',
             'answers_summary_json' => ['stage' => 'seed'],
             'started_at' => now()->subMinute(),
             'submitted_at' => now(),
-            'pack_id' => 'MBTI.cn-mainland.zh-CN.v0.3',
-            'dir_version' => 'MBTI-CN-v0.3',
+            'pack_id' => (string) config('content_packs.default_pack_id', 'MBTI.cn-mainland.zh-CN.v0.3'),
+            'dir_version' => (string) config('content_packs.default_dir_version', 'MBTI-CN-v0.3'),
             'content_package_version' => 'v0.3',
             'scoring_spec_version' => '2026.01',
         ]);
 
         Result::create([
             'id' => (string) Str::uuid(),
-            'org_id' => $orgId,
+            'org_id' => 0,
             'attempt_id' => $attemptId,
             'scale_code' => 'MBTI',
             'scale_version' => 'v0.3',
             'type_code' => 'INTJ-A',
             'scores_json' => ['total' => 100],
-            'is_valid' => true,
-            'computed_at' => now(),
-            'result_json' => ['type_code' => 'INTJ-A'],
-            'pack_id' => 'MBTI.cn-mainland.zh-CN.v0.3',
-            'dir_version' => 'MBTI-CN-v0.3',
+            'scores_pct' => [
+                'EI' => 35,
+                'SN' => 72,
+                'TF' => 68,
+                'JP' => 63,
+                'AT' => 58,
+            ],
+            'axis_states' => [
+                'EI' => 'clear',
+                'SN' => 'clear',
+                'TF' => 'clear',
+                'JP' => 'moderate',
+                'AT' => 'moderate',
+            ],
+            'profile_version' => 'mbti32-v2.5',
+            'content_package_version' => 'v0.3',
+            'result_json' => [
+                'type_code' => 'INTJ-A',
+                'type_name' => '建筑师型',
+                'summary' => 'Public-safe share summary.',
+                'tagline' => '冷静的长期规划者',
+                'rarity' => '约 2%',
+                'keywords' => ['战略', '独立', '前瞻'],
+            ],
+            'pack_id' => (string) config('content_packs.default_pack_id', 'MBTI.cn-mainland.zh-CN.v0.3'),
+            'dir_version' => (string) config('content_packs.default_dir_version', 'MBTI-CN-v0.3'),
             'scoring_spec_version' => '2026.01',
             'report_engine_version' => 'v1.2',
+            'is_valid' => true,
+            'computed_at' => now(),
         ]);
+
+        return $attemptId;
     }
 }


### PR DESCRIPTION
Summary
- add MBTI compare invite contract routes and table
- align share summary payloads and owner-safe MBTI share creation for locked/free attempts
- wire share/compare attribution through start, submit, checkout, and paid order transition
- add feature coverage for compare invite, attribution flow, share access, rate limits, route params, and share alignment
- sync OpenAPI route snapshot for CI gate

Tests ran
- cd /Users/rainie/Desktop/GitHub/fap-api/backend && php artisan route:list | rg 'attempts/.*/share|shares/.*/click|shares/.*/compare-invites|compare/mbti/.+'
- cd /Users/rainie/Desktop/GitHub/fap-api/backend && php artisan migrate
- cd /Users/rainie/Desktop/GitHub/fap-api/backend && php artisan test tests/Feature/V0_3/ShareClickAttributionTest.php
- cd /Users/rainie/Desktop/GitHub/fap-api/backend && php artisan test tests/Feature/V0_3/ShareFlowCoreAlignmentTest.php
- cd /Users/rainie/Desktop/GitHub/fap-api/backend && php artisan test tests/Feature/V0_3/RateLimitKeyEndpointsTest.php
- cd /Users/rainie/Desktop/GitHub/fap-api/backend && php artisan test tests/Feature/UuidRouteParamsMiddlewareTest.php
- cd /Users/rainie/Desktop/GitHub/fap-api/backend && php artisan test tests/Feature/V0_3/MbtiAttemptShareAccessTest.php
- cd /Users/rainie/Desktop/GitHub/fap-api/backend && php artisan test tests/Feature/V0_3/MbtiCompareInviteContractTest.php
- cd /Users/rainie/Desktop/GitHub/fap-api/backend && php artisan test tests/Feature/V0_3/MbtiCompareInviteAttributionFlowTest.php
- cd /Users/rainie/Desktop/GitHub/fap-api/backend && php artisan test tests/Feature/V0_3/AttemptPublicReportReadHotfixTest.php
- cd /Users/rainie/Desktop/GitHub/fap-api/backend && php artisan test tests/Sre/MigrationSafetyTest.php
- cd /Users/rainie/Desktop/GitHub/fap-api/backend && ./vendor/bin/pint routes/api.php app/Http/Controllers/API/V0_3/CommerceController.php app/Http/Controllers/API/V0_3/MbtiCompareInviteController.php app/Http/Requests/V0_3/ShareClickRequest.php app/Http/Requests/V0_3/CreateMbtiCompareInviteRequest.php app/Http/Requests/V0_3/StartAttemptRequest.php app/Http/Requests/V0_3/SubmitAttemptRequest.php app/DTO/Attempts/SubmitAttemptDTO.php app/Services/Share/ShareFlowCoreService.php app/Services/V0_3/ShareService.php app/Services/V0_3/MbtiCompareInviteService.php app/Services/Attempts/AttemptSubmitSideEffects.php app/Services/Commerce/OrderManager.php app/Services/Analytics/EventNormalizer.php app/Models/MbtiCompareInvite.php tests/Feature/V0_3/ShareClickAttributionTest.php tests/Feature/V0_3/ShareFlowCoreAlignmentTest.php tests/Feature/V0_3/MbtiAttemptShareAccessTest.php tests/Feature/V0_3/MbtiCompareInviteContractTest.php tests/Feature/V0_3/MbtiCompareInviteAttributionFlowTest.php
- cd /Users/rainie/Desktop/GitHub/fap-api && bash backend/scripts/ci_verify_mbti.sh
- manual curl verification for share, compare-invites, compare read, and share click on local sqlite server
