### PR TITLE
feat(email): add transactional email capture and recovery contract

### DIFF
--- a/backend/app/Http/Controllers/API/V0_3/ClaimController.php
+++ b/backend/app/Http/Controllers/API/V0_3/ClaimController.php
@@ -3,9 +3,13 @@
 namespace App\Http\Controllers\API\V0_3;
 
 use App\Http\Controllers\Controller;
+use App\Http\Requests\V0_3\ClaimReportRequest;
 use App\Services\Abuse\RateLimiter;
 use App\Services\Audit\LookupEventLogger;
+use App\Services\Commerce\OrderManager;
+use App\Services\Email\EmailCaptureService;
 use App\Services\Email\EmailOutboxService;
+use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
 
 class ClaimController extends Controller
@@ -75,5 +79,118 @@ class ClaimController extends Controller
             'report_url' => $res['report_url'] ?? null,
             'report_pdf_url' => $res['report_pdf_url'] ?? null,
         ]);
+    }
+
+    /**
+     * POST /api/v0.3/claim/report
+     */
+    public function requestReport(
+        ClaimReportRequest $request,
+        EmailCaptureService $captures,
+        OrderManager $orders,
+        EmailOutboxService $outbox
+    ): JsonResponse {
+        $payload = $request->validated();
+        $email = (string) ($payload['email'] ?? '');
+        $orderNo = (string) ($payload['order_no'] ?? '');
+        $orgId = is_numeric($request->attributes->get('org_id')) ? (int) $request->attributes->get('org_id') : 0;
+        $logger = app(LookupEventLogger::class);
+        $limiter = app(RateLimiter::class);
+        $ip = (string) ($request->ip() ?? '');
+
+        $limitIp = $limiter->limit('FAP_RATE_CLAIM_REPORT_IP', 30);
+        if ($ip !== '' && ! $limiter->hit("claim_report_request:ip:{$ip}", $limitIp, 60)) {
+            $logger->log('claim_report_request', false, $request, null, [
+                'error_code' => 'RATE_LIMITED',
+            ]);
+
+            return response()->json([
+                'ok' => false,
+                'error_code' => 'RATE_LIMITED',
+                'message' => 'Too many requests from this IP.',
+            ], 429);
+        }
+
+        $captures->capture($email, array_replace($payload, [
+            'marketing_consent' => false,
+        ]));
+
+        $eligible = $orders->resolveClaimRequestContext($orgId, $orderNo, $email);
+        $queued = false;
+        if (($eligible['eligible'] ?? false) === true && $captures->allowsReportRecovery($email)) {
+            $order = $eligible['order'] ?? null;
+            $requestAttribution = $this->normalizeAttribution($payload);
+            $mergedAttribution = array_replace(
+                is_array($eligible['attribution'] ?? null) ? $eligible['attribution'] : [],
+                $requestAttribution
+            );
+
+            $queued = (bool) ($outbox->queueReportClaim(
+                (string) ($eligible['outbox_user_id'] ?? ''),
+                $email,
+                (string) ($eligible['attempt_id'] ?? ''),
+                is_object($order) ? (string) ($order->order_no ?? '') : $orderNo,
+                $mergedAttribution,
+                is_string($payload['locale'] ?? null) ? (string) $payload['locale'] : null
+            )['ok'] ?? false);
+        }
+
+        $logger->log('claim_report_request', true, $request, null, [
+            'org_id' => $orgId,
+            'order_no' => $orderNo,
+            'queued' => $queued,
+        ]);
+
+        return response()->json([
+            'ok' => true,
+            'queued' => true,
+        ]);
+    }
+
+    /**
+     * @param  array<string,mixed>  $payload
+     * @return array<string,mixed>
+     */
+    private function normalizeAttribution(array $payload): array
+    {
+        $normalized = [];
+
+        foreach ([
+            'share_id' => 128,
+            'compare_invite_id' => 128,
+            'entrypoint' => 128,
+            'referrer' => 2048,
+            'landing_path' => 2048,
+        ] as $field => $maxLength) {
+            $value = is_scalar($payload[$field] ?? null) ? trim((string) $payload[$field]) : '';
+            if ($value === '') {
+                continue;
+            }
+
+            $normalized[$field] = mb_strlen($value, 'UTF-8') > $maxLength
+                ? mb_substr($value, 0, $maxLength, 'UTF-8')
+                : $value;
+        }
+
+        $utm = $payload['utm'] ?? null;
+        if (is_array($utm)) {
+            $normalizedUtm = [];
+            foreach (['source', 'medium', 'campaign', 'term', 'content'] as $key) {
+                $value = is_scalar($utm[$key] ?? null) ? trim((string) $utm[$key]) : '';
+                if ($value === '') {
+                    continue;
+                }
+
+                $normalizedUtm[$key] = mb_strlen($value, 'UTF-8') > 512
+                    ? mb_substr($value, 0, 512, 'UTF-8')
+                    : $value;
+            }
+
+            if ($normalizedUtm !== []) {
+                $normalized['utm'] = $normalizedUtm;
+            }
+        }
+
+        return $normalized;
     }
 }

--- a/backend/app/Http/Controllers/API/V0_3/CommerceController.php
+++ b/backend/app/Http/Controllers/API/V0_3/CommerceController.php
@@ -129,7 +129,7 @@ class CommerceController extends Controller
         $ownershipVerified = (bool) ($result['ownership_verified'] ?? true);
         $status = $this->normalizePublicOrderStatus((string) ($order->status ?? ''));
         $message = $this->publicOrderMessage((string) ($order->status ?? ''));
-        $delivery = $this->orders->presentOrderDelivery($order);
+        $delivery = $this->buildOrderDelivery($order);
 
         if (! $ownershipVerified) {
             return response()->json([
@@ -352,7 +352,7 @@ class CommerceController extends Controller
             ], 404);
         }
 
-        $delivery = $this->orders->presentOrderDelivery($order);
+        $delivery = $this->buildOrderDelivery($order);
 
         return response()->json([
             'ok' => true,
@@ -738,6 +738,14 @@ class CommerceController extends Controller
         }
 
         return $email;
+    }
+
+    /**
+     * @return array{attempt_id:?string,delivery:array<string,mixed>}
+     */
+    private function buildOrderDelivery(object $order): array
+    {
+        return $this->orders->presentOrderDelivery($order);
     }
 
     private function normalizePublicOrderStatus(string $status): string

--- a/backend/app/Http/Controllers/API/V0_3/EmailCaptureController.php
+++ b/backend/app/Http/Controllers/API/V0_3/EmailCaptureController.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Controllers\API\V0_3;
+
+use App\Http\Controllers\Controller;
+use App\Http\Requests\V0_3\EmailCaptureRequest;
+use App\Services\Email\EmailCaptureService;
+use Illuminate\Http\JsonResponse;
+
+final class EmailCaptureController extends Controller
+{
+    public function store(EmailCaptureRequest $request, EmailCaptureService $captures): JsonResponse
+    {
+        $result = $captures->capture((string) $request->validated('email'), $request->validated());
+
+        return response()->json($result);
+    }
+}

--- a/backend/app/Http/Controllers/API/V0_3/EmailPreferenceController.php
+++ b/backend/app/Http/Controllers/API/V0_3/EmailPreferenceController.php
@@ -1,0 +1,83 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Controllers\API\V0_3;
+
+use App\Http\Controllers\Controller;
+use App\Http\Requests\V0_3\EmailPreferencesUpdateRequest;
+use App\Http\Requests\V0_3\EmailUnsubscribeRequest;
+use App\Services\Email\EmailPreferenceService;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+
+final class EmailPreferenceController extends Controller
+{
+    public function show(Request $request, EmailPreferenceService $preferences): JsonResponse
+    {
+        $token = trim((string) $request->query('token', ''));
+        $result = $preferences->showByToken($token);
+
+        if (! ($result['ok'] ?? false)) {
+            return response()->json([
+                'ok' => false,
+                'error_code' => $result['error_code'] ?? 'INVALID_TOKEN',
+            ], (int) ($result['status'] ?? 422));
+        }
+
+        return response()->json([
+            'ok' => true,
+            'email_masked' => $result['email_masked'] ?? '***',
+            'preferences' => $result['preferences'] ?? [
+                'marketing_updates' => false,
+                'report_recovery' => true,
+                'product_updates' => false,
+            ],
+        ]);
+    }
+
+    public function update(
+        EmailPreferencesUpdateRequest $request,
+        EmailPreferenceService $preferences
+    ): JsonResponse {
+        $result = $preferences->updateByToken((string) $request->validated('token'), $request->validated());
+
+        if (! ($result['ok'] ?? false)) {
+            return response()->json([
+                'ok' => false,
+                'error_code' => $result['error_code'] ?? 'INVALID_TOKEN',
+            ], (int) ($result['status'] ?? 422));
+        }
+
+        return response()->json([
+            'ok' => true,
+            'preferences' => $result['preferences'] ?? [
+                'marketing_updates' => false,
+                'report_recovery' => true,
+                'product_updates' => false,
+            ],
+        ]);
+    }
+
+    public function unsubscribe(
+        EmailUnsubscribeRequest $request,
+        EmailPreferenceService $preferences
+    ): JsonResponse {
+        $result = $preferences->unsubscribeByToken(
+            (string) $request->validated('token'),
+            (string) $request->validated('reason', 'user_request')
+        );
+
+        if (! ($result['ok'] ?? false)) {
+            return response()->json([
+                'ok' => false,
+                'error_code' => $result['error_code'] ?? 'INVALID_TOKEN',
+            ], (int) ($result['status'] ?? 422));
+        }
+
+        return response()->json([
+            'ok' => true,
+            'status' => $result['status_text'] ?? 'unsubscribed',
+        ]);
+    }
+}

--- a/backend/app/Http/Requests/V0_3/ClaimReportRequest.php
+++ b/backend/app/Http/Requests/V0_3/ClaimReportRequest.php
@@ -1,0 +1,102 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Requests\V0_3;
+
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Rule;
+
+final class ClaimReportRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    protected function prepareForValidation(): void
+    {
+        $this->merge([
+            'order_no' => $this->normalizeString($this->input('order_no'), 64),
+            'email' => $this->normalizeEmail($this->input('email')),
+            'locale' => $this->normalizeString($this->input('locale'), 16),
+            'surface' => $this->normalizeString($this->input('surface'), 64),
+            'entrypoint' => $this->normalizeString($this->input('entrypoint'), 128),
+            'referrer' => $this->normalizeString($this->input('referrer'), 2048),
+            'landing_path' => $this->normalizeString($this->input('landing_path'), 2048),
+            'share_id' => $this->normalizeString($this->input('share_id'), 128),
+            'compare_invite_id' => $this->normalizeString($this->input('compare_invite_id'), 128),
+            'utm' => $this->normalizeUtm($this->input('utm')),
+        ]);
+    }
+
+    public function rules(): array
+    {
+        return [
+            'order_no' => ['required', 'string', 'max:64'],
+            'email' => ['required', 'email:rfc', 'max:320'],
+            'locale' => ['nullable', 'string', 'max:16'],
+            'surface' => ['nullable', Rule::in(['lookup', 'help', 'payment_success', 'payment_cancel'])],
+            'entrypoint' => ['nullable', 'string', 'max:128'],
+            'referrer' => ['nullable', 'string', 'max:2048'],
+            'landing_path' => ['nullable', 'string', 'max:2048'],
+            'utm' => ['nullable', 'array'],
+            'utm.source' => ['nullable', 'string', 'max:512'],
+            'utm.medium' => ['nullable', 'string', 'max:512'],
+            'utm.campaign' => ['nullable', 'string', 'max:512'],
+            'utm.term' => ['nullable', 'string', 'max:512'],
+            'utm.content' => ['nullable', 'string', 'max:512'],
+            'share_id' => ['nullable', 'string', 'max:128'],
+            'compare_invite_id' => ['nullable', 'string', 'max:128'],
+        ];
+    }
+
+    private function normalizeEmail(mixed $value): ?string
+    {
+        if (! is_scalar($value)) {
+            return null;
+        }
+
+        $normalized = mb_strtolower(trim((string) $value), 'UTF-8');
+
+        return $normalized !== '' ? $normalized : null;
+    }
+
+    private function normalizeString(mixed $value, int $maxLength): ?string
+    {
+        if (! is_scalar($value)) {
+            return null;
+        }
+
+        $normalized = trim((string) $value);
+        if ($normalized === '') {
+            return null;
+        }
+
+        if (mb_strlen($normalized, 'UTF-8') > $maxLength) {
+            $normalized = mb_substr($normalized, 0, $maxLength, 'UTF-8');
+        }
+
+        return $normalized;
+    }
+
+    /**
+     * @return array<string,string>|null
+     */
+    private function normalizeUtm(mixed $value): ?array
+    {
+        if (! is_array($value)) {
+            return null;
+        }
+
+        $normalized = [];
+        foreach (['source', 'medium', 'campaign', 'term', 'content'] as $key) {
+            $candidate = $this->normalizeString($value[$key] ?? null, 512);
+            if ($candidate !== null) {
+                $normalized[$key] = $candidate;
+            }
+        }
+
+        return $normalized === [] ? null : $normalized;
+    }
+}

--- a/backend/app/Http/Requests/V0_3/EmailCaptureRequest.php
+++ b/backend/app/Http/Requests/V0_3/EmailCaptureRequest.php
@@ -1,0 +1,106 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Requests\V0_3;
+
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Rule;
+
+final class EmailCaptureRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    protected function prepareForValidation(): void
+    {
+        $this->merge([
+            'email' => $this->normalizeEmail($this->input('email')),
+            'locale' => $this->normalizeString($this->input('locale'), 16),
+            'surface' => $this->normalizeString($this->input('surface'), 64),
+            'order_no' => $this->normalizeString($this->input('order_no'), 64),
+            'attempt_id' => $this->normalizeString($this->input('attempt_id'), 64),
+            'share_id' => $this->normalizeString($this->input('share_id'), 128),
+            'compare_invite_id' => $this->normalizeString($this->input('compare_invite_id'), 128),
+            'entrypoint' => $this->normalizeString($this->input('entrypoint'), 128),
+            'referrer' => $this->normalizeString($this->input('referrer'), 2048),
+            'landing_path' => $this->normalizeString($this->input('landing_path'), 2048),
+            'utm' => $this->normalizeUtm($this->input('utm')),
+            'marketing_consent' => $this->has('marketing_consent') ? $this->boolean('marketing_consent') : false,
+        ]);
+    }
+
+    public function rules(): array
+    {
+        return [
+            'email' => ['required', 'email:rfc', 'max:320'],
+            'locale' => ['nullable', 'string', 'max:16'],
+            'surface' => ['nullable', Rule::in(['lookup', 'checkout', 'share', 'compare', 'result', 'help'])],
+            'order_no' => ['nullable', 'string', 'max:64'],
+            'attempt_id' => ['nullable', 'string', 'max:64'],
+            'share_id' => ['nullable', 'string', 'max:128'],
+            'compare_invite_id' => ['nullable', 'string', 'max:128'],
+            'entrypoint' => ['nullable', 'string', 'max:128'],
+            'referrer' => ['nullable', 'string', 'max:2048'],
+            'landing_path' => ['nullable', 'string', 'max:2048'],
+            'utm' => ['nullable', 'array'],
+            'utm.source' => ['nullable', 'string', 'max:512'],
+            'utm.medium' => ['nullable', 'string', 'max:512'],
+            'utm.campaign' => ['nullable', 'string', 'max:512'],
+            'utm.term' => ['nullable', 'string', 'max:512'],
+            'utm.content' => ['nullable', 'string', 'max:512'],
+            'marketing_consent' => ['nullable', 'boolean'],
+        ];
+    }
+
+    private function normalizeEmail(mixed $value): ?string
+    {
+        if (! is_scalar($value)) {
+            return null;
+        }
+
+        $normalized = mb_strtolower(trim((string) $value), 'UTF-8');
+
+        return $normalized !== '' ? $normalized : null;
+    }
+
+    private function normalizeString(mixed $value, int $maxLength): ?string
+    {
+        if (! is_scalar($value)) {
+            return null;
+        }
+
+        $normalized = trim((string) $value);
+        if ($normalized === '') {
+            return null;
+        }
+
+        if (mb_strlen($normalized, 'UTF-8') > $maxLength) {
+            $normalized = mb_substr($normalized, 0, $maxLength, 'UTF-8');
+        }
+
+        return $normalized;
+    }
+
+    /**
+     * @return array<string,string>|null
+     */
+    private function normalizeUtm(mixed $value): ?array
+    {
+        if (! is_array($value)) {
+            return null;
+        }
+
+        $normalized = [];
+        foreach (['source', 'medium', 'campaign', 'term', 'content'] as $key) {
+            $candidate = $this->normalizeString($value[$key] ?? null, 512);
+            if ($candidate !== null) {
+                $normalized[$key] = $candidate;
+            }
+        }
+
+        return $normalized === [] ? null : $normalized;
+    }
+}

--- a/backend/app/Http/Requests/V0_3/EmailPreferencesUpdateRequest.php
+++ b/backend/app/Http/Requests/V0_3/EmailPreferencesUpdateRequest.php
@@ -1,0 +1,53 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Requests\V0_3;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+final class EmailPreferencesUpdateRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    protected function prepareForValidation(): void
+    {
+        $this->merge([
+            'token' => $this->normalizeString($this->input('token'), 4096),
+            'marketing_updates' => $this->boolean('marketing_updates'),
+            'report_recovery' => $this->boolean('report_recovery'),
+            'product_updates' => $this->boolean('product_updates'),
+        ]);
+    }
+
+    public function rules(): array
+    {
+        return [
+            'token' => ['required', 'string', 'max:4096'],
+            'marketing_updates' => ['required', 'boolean'],
+            'report_recovery' => ['required', 'boolean'],
+            'product_updates' => ['required', 'boolean'],
+        ];
+    }
+
+    private function normalizeString(mixed $value, int $maxLength): ?string
+    {
+        if (! is_scalar($value)) {
+            return null;
+        }
+
+        $normalized = trim((string) $value);
+        if ($normalized === '') {
+            return null;
+        }
+
+        if (mb_strlen($normalized, 'UTF-8') > $maxLength) {
+            $normalized = mb_substr($normalized, 0, $maxLength, 'UTF-8');
+        }
+
+        return $normalized;
+    }
+}

--- a/backend/app/Http/Requests/V0_3/EmailUnsubscribeRequest.php
+++ b/backend/app/Http/Requests/V0_3/EmailUnsubscribeRequest.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Requests\V0_3;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+final class EmailUnsubscribeRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    protected function prepareForValidation(): void
+    {
+        $this->merge([
+            'token' => $this->normalizeString($this->input('token'), 4096),
+            'reason' => $this->normalizeString($this->input('reason'), 128) ?? 'user_request',
+        ]);
+    }
+
+    public function rules(): array
+    {
+        return [
+            'token' => ['required', 'string', 'max:4096'],
+            'reason' => ['nullable', 'string', 'max:128'],
+        ];
+    }
+
+    private function normalizeString(mixed $value, int $maxLength): ?string
+    {
+        if (! is_scalar($value)) {
+            return null;
+        }
+
+        $normalized = trim((string) $value);
+        if ($normalized === '') {
+            return null;
+        }
+
+        if (mb_strlen($normalized, 'UTF-8') > $maxLength) {
+            $normalized = mb_substr($normalized, 0, $maxLength, 'UTF-8');
+        }
+
+        return $normalized;
+    }
+}

--- a/backend/app/Internal/Commerce/PaymentWebhookHandlerCore.php
+++ b/backend/app/Internal/Commerce/PaymentWebhookHandlerCore.php
@@ -2,8 +2,6 @@
 
 namespace App\Internal\Commerce;
 
-use App\Jobs\GenerateReportPdfJob;
-use App\Jobs\GenerateReportSnapshotJob;
 use App\Models\Attempt;
 use App\Services\Analytics\EventRecorder;
 use App\Services\Commerce\BenefitWalletService;
@@ -27,11 +25,9 @@ use App\Services\Observability\Sds20Telemetry;
 use App\Services\Report\ReportAccess;
 use App\Services\Report\ReportSnapshotStore;
 use Illuminate\Contracts\Cache\LockTimeoutException;
-use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Facades\Schema;
-use Illuminate\Support\Str;
 
 class PaymentWebhookHandlerCore
 {
@@ -180,7 +176,6 @@ class PaymentWebhookHandlerCore
 
         return $normalizedResult;
     }
-
 
     public function gatewayFor(string $provider): ?PaymentGatewayInterface
     {
@@ -718,6 +713,55 @@ class PaymentWebhookHandlerCore
         }
 
         return [];
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    public function extractOrderAttribution(object $order): array
+    {
+        $meta = $this->decodeMeta($order->meta_json ?? null);
+        $attribution = is_array($meta['attribution'] ?? null) ? $meta['attribution'] : [];
+        $normalized = [];
+
+        foreach ([
+            'share_id' => 128,
+            'compare_invite_id' => 128,
+            'share_click_id' => 128,
+            'entrypoint' => 128,
+            'referrer' => 2048,
+            'landing_path' => 2048,
+        ] as $field => $maxLength) {
+            $value = is_scalar($attribution[$field] ?? null) ? trim((string) $attribution[$field]) : '';
+            if ($value === '') {
+                continue;
+            }
+
+            $normalized[$field] = mb_strlen($value, 'UTF-8') > $maxLength
+                ? mb_substr($value, 0, $maxLength, 'UTF-8')
+                : $value;
+        }
+
+        $utm = $attribution['utm'] ?? null;
+        if (is_array($utm)) {
+            $normalizedUtm = [];
+            foreach (['source', 'medium', 'campaign', 'term', 'content'] as $key) {
+                $value = is_scalar($utm[$key] ?? null) ? trim((string) $utm[$key]) : '';
+                if ($value === '') {
+                    continue;
+                }
+
+                $normalizedUtm[$key] = mb_strlen($value, 'UTF-8') > 512
+                    ? mb_substr($value, 0, 512, 'UTF-8')
+                    : $value;
+            }
+
+            if ($normalizedUtm !== []) {
+                $normalized['utm'] = $normalizedUtm;
+            }
+        }
+
+        return $normalized;
     }
 
     /**
@@ -1288,6 +1332,8 @@ class PaymentWebhookHandlerCore
 
         $email = '';
         $resolvedUserId = '';
+        $attribution = [];
+        $orderRow = null;
 
         $candidateUserIds = [];
         $fromEvent = trim((string) ($eventUserId ?? ''));
@@ -1309,6 +1355,7 @@ class PaymentWebhookHandlerCore
                 if ($fromOrder !== '') {
                     $candidateUserIds[] = $fromOrder;
                 }
+                $attribution = $this->extractOrderAttribution($orderRow);
             }
         }
 
@@ -1342,7 +1389,8 @@ class PaymentWebhookHandlerCore
                 $email,
                 $attemptId,
                 $orderNo !== '' ? $orderNo : null,
-                $productSummary !== '' ? $productSummary : null
+                $productSummary !== '' ? $productSummary : null,
+                $attribution
             );
         } catch (\Throwable $e) {
             Log::warning('PAYMENT_WEBHOOK_POST_COMMIT_QUEUE_EMAIL_FAILED', [

--- a/backend/app/Models/EmailPreference.php
+++ b/backend/app/Models/EmailPreference.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Concerns\HasUuids;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+class EmailPreference extends Model
+{
+    use HasUuids;
+
+    protected $table = 'email_preferences';
+
+    public $incrementing = false;
+
+    protected $keyType = 'string';
+
+    protected $fillable = [
+        'id',
+        'subscriber_id',
+        'marketing_updates',
+        'report_recovery',
+        'product_updates',
+    ];
+
+    protected $casts = [
+        'marketing_updates' => 'bool',
+        'report_recovery' => 'bool',
+        'product_updates' => 'bool',
+    ];
+
+    public function subscriber(): BelongsTo
+    {
+        return $this->belongsTo(EmailSubscriber::class, 'subscriber_id', 'id');
+    }
+}

--- a/backend/app/Models/EmailSubscriber.php
+++ b/backend/app/Models/EmailSubscriber.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Concerns\HasUuids;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\HasOne;
+
+class EmailSubscriber extends Model
+{
+    use HasUuids;
+
+    protected $table = 'email_subscribers';
+
+    public $incrementing = false;
+
+    protected $keyType = 'string';
+
+    protected $fillable = [
+        'id',
+        'pii_email_key_version',
+        'email_enc',
+        'email_hash',
+        'locale',
+        'first_source',
+        'last_source',
+        'marketing_consent',
+        'transactional_recovery_enabled',
+        'first_context_json',
+        'last_context_json',
+        'unsubscribed_at',
+    ];
+
+    protected $casts = [
+        'marketing_consent' => 'bool',
+        'transactional_recovery_enabled' => 'bool',
+        'first_context_json' => 'array',
+        'last_context_json' => 'array',
+        'unsubscribed_at' => 'datetime',
+    ];
+
+    public function preference(): HasOne
+    {
+        return $this->hasOne(EmailPreference::class, 'subscriber_id', 'id');
+    }
+}

--- a/backend/app/Models/EmailSuppression.php
+++ b/backend/app/Models/EmailSuppression.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Concerns\HasUuids;
+use Illuminate\Database\Eloquent\Model;
+
+class EmailSuppression extends Model
+{
+    use HasUuids;
+
+    protected $table = 'email_suppressions';
+
+    public $incrementing = false;
+
+    protected $keyType = 'string';
+
+    protected $fillable = [
+        'id',
+        'email_hash',
+        'reason',
+        'source',
+        'meta_json',
+    ];
+
+    protected $casts = [
+        'meta_json' => 'array',
+    ];
+}

--- a/backend/app/Services/Commerce/OrderManager.php
+++ b/backend/app/Services/Commerce/OrderManager.php
@@ -293,7 +293,19 @@ class OrderManager
     }
 
     /**
-     * @return array{attempt_id:?string,delivery:array{can_view_report:bool,report_url:?string,can_download_pdf:bool,report_pdf_url:?string,can_resend:bool}}
+     * @return array{
+     *     attempt_id:?string,
+     *     delivery:array{
+     *         can_view_report:bool,
+     *         report_url:?string,
+     *         can_download_pdf:bool,
+     *         report_pdf_url:?string,
+     *         can_resend:bool,
+     *         contact_email_present:bool,
+     *         last_delivery_email_sent_at:?string,
+     *         can_request_claim_email:bool
+     *     }
+     * }
      */
     public function presentOrderDelivery(object $order): array
     {
@@ -333,7 +345,8 @@ class OrderManager
             (string) ($delivery['delivery_email'] ?? ''),
             (string) ($delivery['attempt_id'] ?? ''),
             $this->trimOrNull((string) ($order->order_no ?? '')),
-            $this->resolveOrderProductSummary($order)
+            $this->resolveOrderProductSummary($order),
+            $this->extractAttributionFromOrder($order)
         );
 
         return [
@@ -341,6 +354,80 @@ class OrderManager
             'queued' => (bool) ($queued['ok'] ?? false),
             'order' => $order,
             'delivery' => $this->presentCompiledOrderDeliveryState($delivery),
+        ];
+    }
+
+    /**
+     * @return array{
+     *     eligible:bool,
+     *     order:?object,
+     *     attempt_id:?string,
+     *     outbox_user_id:?string,
+     *     attribution:array<string,mixed>
+     * }
+     */
+    public function resolveClaimRequestContext(int $orgId, string $orderNo, string $email): array
+    {
+        $normalizedEmail = $this->normalizeEmail($email);
+        if ($normalizedEmail === null) {
+            return [
+                'eligible' => false,
+                'order' => null,
+                'attempt_id' => null,
+                'outbox_user_id' => null,
+                'attribution' => [],
+            ];
+        }
+
+        $order = DB::table('orders')
+            ->where('order_no', trim($orderNo))
+            ->where('org_id', $orgId)
+            ->first();
+        if (! $order) {
+            return [
+                'eligible' => false,
+                'order' => null,
+                'attempt_id' => null,
+                'outbox_user_id' => null,
+                'attribution' => [],
+            ];
+        }
+
+        $delivery = $this->compileOrderDeliveryState($order);
+        $attemptId = $this->trimOrNull((string) ($delivery['attempt_id'] ?? ''));
+        if ($attemptId === null || ($delivery['can_request_claim_email'] ?? false) !== true) {
+            return [
+                'eligible' => false,
+                'order' => $order,
+                'attempt_id' => $attemptId,
+                'outbox_user_id' => null,
+                'attribution' => $this->extractAttributionFromOrder($order),
+            ];
+        }
+
+        $emailMatches = $this->emailMatchesOrderContact($order, $normalizedEmail)
+            || $this->emailMatchesOrderUser($order, $normalizedEmail)
+            || $this->emailOutbox->hasHistoricalRecipient(
+                $attemptId,
+                $this->trimOrNull((string) ($order->order_no ?? '')),
+                $normalizedEmail
+            );
+
+        $outboxUserId = $this->trimOrNull((string) ($delivery['delivery_user_id'] ?? ''));
+        if ($outboxUserId === null) {
+            $outboxUserId = $this->emailOutbox->resolveDeliveryUserId(
+                $this->trimOrNull((string) ($order->user_id ?? '')),
+                $this->trimOrNull((string) ($order->anon_id ?? '')),
+                $attemptId
+            );
+        }
+
+        return [
+            'eligible' => $emailMatches && $outboxUserId !== null,
+            'order' => $order,
+            'attempt_id' => $attemptId,
+            'outbox_user_id' => $outboxUserId,
+            'attribution' => $this->extractAttributionFromOrder($order),
         ];
     }
 
@@ -587,7 +674,19 @@ class OrderManager
     }
 
     /**
-     * @return array{attempt_id:?string,report_url:?string,report_pdf_url:?string,can_view_report:bool,can_download_pdf:bool,can_resend:bool,delivery_email:?string,delivery_user_id:?string}
+     * @return array{
+     *     attempt_id:?string,
+     *     report_url:?string,
+     *     report_pdf_url:?string,
+     *     can_view_report:bool,
+     *     can_download_pdf:bool,
+     *     can_resend:bool,
+     *     delivery_email:?string,
+     *     delivery_user_id:?string,
+     *     contact_email_present:bool,
+     *     last_delivery_email_sent_at:?string,
+     *     can_request_claim_email:bool
+     * }
      */
     private function compileOrderDeliveryState(object $order): array
     {
@@ -607,6 +706,13 @@ class OrderManager
 
         $deliveryEmail = $this->trimOrNull((string) ($recipient['email'] ?? ''));
         $deliveryUserId = $this->trimOrNull((string) ($recipient['user_id'] ?? ''));
+        $contactEmailPresent = $deliveryEmail !== null || $this->orderHasContactEmailHash($order);
+        $lastDeliveryEmailSentAt = $attemptId !== null
+            ? $this->emailOutbox->lastDeliveryEmailSentAt(
+                $attemptId,
+                $this->trimOrNull((string) ($order->order_no ?? ''))
+            )
+            : null;
 
         return [
             'attempt_id' => $attemptId,
@@ -617,12 +723,36 @@ class OrderManager
             'can_resend' => $deliveryEligible && $deliveryEmail !== null && $deliveryUserId !== null,
             'delivery_email' => $deliveryEmail,
             'delivery_user_id' => $deliveryUserId,
+            'contact_email_present' => $contactEmailPresent,
+            'last_delivery_email_sent_at' => $lastDeliveryEmailSentAt,
+            'can_request_claim_email' => $deliveryEligible && $contactEmailPresent,
         ];
     }
 
     /**
-     * @param  array{attempt_id:?string,report_url:?string,report_pdf_url:?string,can_view_report:bool,can_download_pdf:bool,can_resend:bool,delivery_email:?string,delivery_user_id:?string}  $delivery
-     * @return array{can_view_report:bool,report_url:?string,can_download_pdf:bool,report_pdf_url:?string,can_resend:bool}
+     * @param  array{
+     *     attempt_id:?string,
+     *     report_url:?string,
+     *     report_pdf_url:?string,
+     *     can_view_report:bool,
+     *     can_download_pdf:bool,
+     *     can_resend:bool,
+     *     delivery_email:?string,
+     *     delivery_user_id:?string,
+     *     contact_email_present:bool,
+     *     last_delivery_email_sent_at:?string,
+     *     can_request_claim_email:bool
+     * }  $delivery
+     * @return array{
+     *     can_view_report:bool,
+     *     report_url:?string,
+     *     can_download_pdf:bool,
+     *     report_pdf_url:?string,
+     *     can_resend:bool,
+     *     contact_email_present:bool,
+     *     last_delivery_email_sent_at:?string,
+     *     can_request_claim_email:bool
+     * }
      */
     private function presentCompiledOrderDeliveryState(array $delivery): array
     {
@@ -632,6 +762,9 @@ class OrderManager
             'can_download_pdf' => (bool) ($delivery['can_download_pdf'] ?? false),
             'report_pdf_url' => $delivery['report_pdf_url'] ?? null,
             'can_resend' => (bool) ($delivery['can_resend'] ?? false),
+            'contact_email_present' => (bool) ($delivery['contact_email_present'] ?? false),
+            'last_delivery_email_sent_at' => $delivery['last_delivery_email_sent_at'] ?? null,
+            'can_request_claim_email' => (bool) ($delivery['can_request_claim_email'] ?? false),
         ];
     }
 
@@ -671,6 +804,17 @@ class OrderManager
         }
 
         return null;
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    public function extractAttributionFromOrder(object $order): array
+    {
+        $meta = $this->decodeMeta($order->meta_json ?? null);
+        $attribution = is_array($meta['attribution'] ?? null) ? $meta['attribution'] : [];
+
+        return $this->normalizeAttribution($attribution);
     }
 
     private function reportUrl(string $attemptId): string
@@ -922,6 +1066,34 @@ class OrderManager
         }
 
         return $hash;
+    }
+
+    private function orderHasContactEmailHash(object $order): bool
+    {
+        return Schema::hasColumn('orders', 'contact_email_hash')
+            && $this->normalizeEmailHash((string) ($order->contact_email_hash ?? '')) !== null;
+    }
+
+    private function emailMatchesOrderContact(object $order, string $email): bool
+    {
+        if (! $this->orderHasContactEmailHash($order)) {
+            return false;
+        }
+
+        return hash('sha256', $email) === strtolower(trim((string) ($order->contact_email_hash ?? '')));
+    }
+
+    private function emailMatchesOrderUser(object $order, string $email): bool
+    {
+        $userId = $this->trimOrNull((string) ($order->user_id ?? ''));
+        if ($userId === null || ! Schema::hasTable('users') || ! Schema::hasColumn('users', 'email')) {
+            return false;
+        }
+
+        $candidate = DB::table('users')->where('id', $userId)->value('email');
+        $normalized = $this->normalizeEmail((string) ($candidate ?? ''));
+
+        return $normalized !== null && $normalized === $email;
     }
 
     private function shouldWriteScaleIdentityColumns(): bool

--- a/backend/app/Services/Email/EmailCaptureService.php
+++ b/backend/app/Services/Email/EmailCaptureService.php
@@ -1,0 +1,343 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\Email;
+
+use App\Models\EmailPreference;
+use App\Models\EmailSubscriber;
+use App\Models\EmailSuppression;
+use App\Support\PiiCipher;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Str;
+use InvalidArgumentException;
+
+class EmailCaptureService
+{
+    public function __construct(
+        private readonly PiiCipher $piiCipher,
+    ) {}
+
+    /**
+     * @param  array<string,mixed>  $context
+     * @return array{
+     *     ok:bool,
+     *     subscriber_id:string,
+     *     status:string,
+     *     marketing_consent:bool,
+     *     preferences:array{marketing_updates:bool,report_recovery:bool,product_updates:bool}
+     * }
+     */
+    public function capture(string $email, array $context = []): array
+    {
+        $status = 'captured';
+        $subscriber = $this->upsertSubscriber($email, $context, $status);
+        $preference = $subscriber->preference instanceof EmailPreference
+            ? $subscriber->preference
+            : $this->ensurePreference($subscriber, null);
+
+        return [
+            'ok' => true,
+            'subscriber_id' => (string) $subscriber->getKey(),
+            'status' => $status,
+            'marketing_consent' => (bool) ($subscriber->marketing_consent ?? false),
+            'preferences' => $this->preferencesPayload($preference),
+        ];
+    }
+
+    /**
+     * @param  array<string,mixed>  $context
+     */
+    public function ensureSubscriber(string $email, array $context = []): EmailSubscriber
+    {
+        $status = 'captured';
+
+        return $this->upsertSubscriber($email, $context, $status);
+    }
+
+    public function isSuppressed(string $email): bool
+    {
+        $normalized = $this->normalizeEmail($email);
+        if ($normalized === null) {
+            return false;
+        }
+
+        return EmailSuppression::query()
+            ->where('email_hash', $this->piiCipher->emailHash($normalized))
+            ->exists();
+    }
+
+    public function allowsReportRecovery(string $email): bool
+    {
+        $normalized = $this->normalizeEmail($email);
+        if ($normalized === null) {
+            return false;
+        }
+
+        if ($this->isSuppressed($normalized)) {
+            return false;
+        }
+
+        $subscriber = EmailSubscriber::query()
+            ->with('preference')
+            ->where('email_hash', $this->piiCipher->emailHash($normalized))
+            ->first();
+
+        if (! $subscriber) {
+            return true;
+        }
+
+        $preference = $subscriber->preference instanceof EmailPreference
+            ? $subscriber->preference
+            : null;
+        if ($preference instanceof EmailPreference) {
+            return (bool) $preference->report_recovery;
+        }
+
+        return (bool) ($subscriber->transactional_recovery_enabled ?? true);
+    }
+
+    private function normalizeEmail(string $email): ?string
+    {
+        $normalized = mb_strtolower(trim($email), 'UTF-8');
+        if ($normalized === '') {
+            return null;
+        }
+
+        if (filter_var($normalized, FILTER_VALIDATE_EMAIL) === false) {
+            return null;
+        }
+
+        return $normalized;
+    }
+
+    /**
+     * @param  array<string,mixed>  $context
+     */
+    private function upsertSubscriber(string $email, array $context, string &$status): EmailSubscriber
+    {
+        $normalizedEmail = $this->normalizeEmail($email);
+        if ($normalizedEmail === null) {
+            throw new InvalidArgumentException('email invalid');
+        }
+
+        $emailHash = $this->piiCipher->emailHash($normalizedEmail);
+        $emailEnc = $this->piiCipher->encrypt($normalizedEmail);
+        if ($emailEnc === null) {
+            throw new InvalidArgumentException('email invalid');
+        }
+
+        $suppressed = EmailSuppression::query()
+            ->where('email_hash', $emailHash)
+            ->exists();
+        $locale = $this->truncateString($context['locale'] ?? null, 16);
+        $source = $this->resolveSource($context);
+        $contextPayload = $this->normalizeContext($context);
+        $marketingConsent = $this->resolveMarketingConsent($context);
+        $marketingConsentProvided = array_key_exists('marketing_consent', $context);
+        $created = false;
+        $subscriber = DB::transaction(function () use (
+            $emailHash,
+            $emailEnc,
+            $locale,
+            $source,
+            $contextPayload,
+            $marketingConsent,
+            $marketingConsentProvided,
+            &$created
+        ): EmailSubscriber {
+            $subscriber = EmailSubscriber::query()
+                ->where('email_hash', $emailHash)
+                ->lockForUpdate()
+                ->first();
+
+            if (! $subscriber) {
+                $subscriber = new EmailSubscriber([
+                    'id' => (string) Str::uuid(),
+                    'email_hash' => $emailHash,
+                    'marketing_consent' => false,
+                    'transactional_recovery_enabled' => true,
+                ]);
+                $created = true;
+            }
+
+            $subscriber->email_enc = $emailEnc;
+            $subscriber->pii_email_key_version = (string) $this->piiCipher->currentKeyVersion();
+
+            if ($locale !== null) {
+                $subscriber->locale = $locale;
+            }
+
+            if ($created && $source !== null && $subscriber->first_source === null) {
+                $subscriber->first_source = $source;
+            }
+            if ($source !== null) {
+                $subscriber->last_source = $source;
+            }
+
+            if ($created && $contextPayload !== [] && empty($subscriber->first_context_json)) {
+                $subscriber->first_context_json = $contextPayload;
+            }
+            if ($contextPayload !== []) {
+                $subscriber->last_context_json = $contextPayload;
+            }
+
+            if ($marketingConsentProvided && $marketingConsent !== null) {
+                $subscriber->marketing_consent = $marketingConsent;
+            }
+
+            $subscriber->save();
+
+            $preference = $this->ensurePreference($subscriber, $marketingConsentProvided ? $marketingConsent : null);
+            $subscriber->transactional_recovery_enabled = (bool) $preference->report_recovery;
+            $subscriber->marketing_consent = (bool) ($preference->marketing_updates || $preference->product_updates);
+            $subscriber->save();
+            $subscriber->setRelation('preference', $preference);
+
+            return $subscriber;
+        });
+
+        $status = $suppressed ? 'suppressed' : ($created ? 'captured' : 'updated');
+
+        return $subscriber;
+    }
+
+    private function ensurePreference(EmailSubscriber $subscriber, ?bool $marketingConsent): EmailPreference
+    {
+        $preference = EmailPreference::query()
+            ->where('subscriber_id', $subscriber->getKey())
+            ->first();
+
+        if (! $preference) {
+            $preference = new EmailPreference([
+                'id' => (string) Str::uuid(),
+                'subscriber_id' => (string) $subscriber->getKey(),
+                'marketing_updates' => (bool) $marketingConsent,
+                'report_recovery' => true,
+                'product_updates' => (bool) $marketingConsent,
+            ]);
+            $preference->save();
+
+            return $preference;
+        }
+
+        if ($marketingConsent !== null) {
+            $preference->marketing_updates = $marketingConsent;
+            $preference->product_updates = $marketingConsent;
+            $preference->save();
+        }
+
+        return $preference;
+    }
+
+    /**
+     * @param  array<string,mixed>  $context
+     */
+    private function normalizeContext(array $context): array
+    {
+        $normalized = [];
+
+        foreach ([
+            'locale' => 16,
+            'surface' => 64,
+            'order_no' => 64,
+            'attempt_id' => 64,
+            'share_id' => 128,
+            'compare_invite_id' => 128,
+            'entrypoint' => 128,
+            'referrer' => 2048,
+            'landing_path' => 2048,
+        ] as $field => $maxLength) {
+            $value = $this->truncateString($context[$field] ?? null, $maxLength);
+            if ($value !== null) {
+                $normalized[$field] = $value;
+            }
+        }
+
+        $utm = $this->normalizeUtm($context['utm'] ?? null);
+        if ($utm !== []) {
+            $normalized['utm'] = $utm;
+        }
+
+        if (array_key_exists('marketing_consent', $context)) {
+            $consent = $this->resolveMarketingConsent($context);
+            if ($consent !== null) {
+                $normalized['marketing_consent'] = $consent;
+            }
+        }
+
+        return $normalized;
+    }
+
+    /**
+     * @param  array<string,mixed>  $context
+     */
+    private function resolveSource(array $context): ?string
+    {
+        return $this->truncateString($context['surface'] ?? ($context['entrypoint'] ?? null), 64);
+    }
+
+    /**
+     * @param  array<string,mixed>  $context
+     */
+    private function resolveMarketingConsent(array $context): ?bool
+    {
+        if (! array_key_exists('marketing_consent', $context)) {
+            return null;
+        }
+
+        $value = filter_var($context['marketing_consent'], FILTER_VALIDATE_BOOLEAN, FILTER_NULL_ON_FAILURE);
+
+        return $value ?? false;
+    }
+
+    /**
+     * @return array<string,string>
+     */
+    private function normalizeUtm(mixed $value): array
+    {
+        if (! is_array($value)) {
+            return [];
+        }
+
+        $normalized = [];
+        foreach (['source', 'medium', 'campaign', 'term', 'content'] as $key) {
+            $candidate = $this->truncateString($value[$key] ?? null, 512);
+            if ($candidate !== null) {
+                $normalized[$key] = $candidate;
+            }
+        }
+
+        return $normalized;
+    }
+
+    private function truncateString(mixed $value, int $maxLength): ?string
+    {
+        if (! is_scalar($value)) {
+            return null;
+        }
+
+        $normalized = trim((string) $value);
+        if ($normalized === '') {
+            return null;
+        }
+
+        if (mb_strlen($normalized, 'UTF-8') > $maxLength) {
+            $normalized = mb_substr($normalized, 0, $maxLength, 'UTF-8');
+        }
+
+        return $normalized;
+    }
+
+    /**
+     * @return array{marketing_updates:bool,report_recovery:bool,product_updates:bool}
+     */
+    private function preferencesPayload(EmailPreference $preference): array
+    {
+        return [
+            'marketing_updates' => (bool) $preference->marketing_updates,
+            'report_recovery' => (bool) $preference->report_recovery,
+            'product_updates' => (bool) $preference->product_updates,
+        ];
+    }
+}

--- a/backend/app/Services/Email/EmailOutboxService.php
+++ b/backend/app/Services/Email/EmailOutboxService.php
@@ -19,8 +19,14 @@ class EmailOutboxService
      *
      * @return array {ok:bool, claim_token?:string, claim_url?:string, expires_at?:string}
      */
-    public function queueReportClaim(string $userId, string $email, string $attemptId): array
-    {
+    public function queueReportClaim(
+        string $userId,
+        string $email,
+        string $attemptId,
+        ?string $orderNo = null,
+        array $attribution = [],
+        ?string $preferredLocale = null
+    ): array {
         if (! \App\Support\SchemaBaseline::hasTable('email_outbox')) {
             return ['ok' => false, 'error' => 'TABLE_MISSING'];
         }
@@ -28,6 +34,7 @@ class EmailOutboxService
         $userId = trim($userId);
         $email = trim($email);
         $attemptId = trim($attemptId);
+        $orderNo = trim((string) $orderNo);
 
         if ($userId === '' || $email === '' || $attemptId === '') {
             return ['ok' => false, 'error' => 'INVALID_INPUT'];
@@ -41,15 +48,17 @@ class EmailOutboxService
         $token = 'claim_'.(string) Str::uuid();
         $tokenHash = hash('sha256', $token);
         $expiresAt = now()->addMinutes(15);
-        $locale = $this->resolveAttemptLocale($attemptId);
+        $locale = $this->resolveRequestedLocale($attemptId, $preferredLocale);
         $subject = $this->defaultSubjectForTemplate('report_claim', $locale);
 
         $reportUrl = $this->reportUrl($attemptId);
         $reportPdfUrl = $this->reportPdfUrl($attemptId);
         $claimUrl = "/api/v0.3/claim/report?token={$token}";
+        $normalizedAttribution = $this->normalizeAttribution($attribution);
 
         $payload = [
             'attempt_id' => $attemptId,
+            'order_no' => $orderNo !== '' ? $orderNo : null,
             'report_url' => $reportUrl,
             'report_pdf_url' => $reportPdfUrl,
             'claim_token' => $token,
@@ -59,6 +68,7 @@ class EmailOutboxService
             'template_key' => 'report_claim',
             'to_email' => $email,
             'subject' => $subject,
+            'attribution' => $this->payloadAttribution($normalizedAttribution),
         ];
         $payloadJson = $this->encodePayloadJson($this->sanitizePayloadForJson($payload));
         $payloadEnc = $this->encodePayloadEncrypted($payload);
@@ -206,7 +216,9 @@ class EmailOutboxService
         string $email,
         string $attemptId,
         ?string $orderNo = null,
-        ?string $productSummary = null
+        ?string $productSummary = null,
+        array $attribution = [],
+        ?string $preferredLocale = null
     ): array {
         if (! \App\Support\SchemaBaseline::hasTable('email_outbox')) {
             return ['ok' => false, 'error' => 'TABLE_MISSING'];
@@ -226,11 +238,12 @@ class EmailOutboxService
         $keyVersion = $this->piiCipher->currentKeyVersion();
         $maskedEmail = $this->maskedLegacyEmail($emailHash);
 
-        $locale = $this->resolveAttemptLocale($attemptId);
+        $locale = $this->resolveRequestedLocale($attemptId, $preferredLocale);
         $subject = $this->defaultSubjectForTemplate('payment_success', $locale);
         $reportUrl = $this->reportUrl($attemptId);
         $reportPdfUrl = $this->reportPdfUrl($attemptId);
         $nonce = hash('sha256', 'payment_success|'.$attemptId.'|'.Str::uuid()->toString());
+        $normalizedAttribution = $this->normalizeAttribution($attribution);
 
         $payload = [
             'attempt_id' => $attemptId,
@@ -242,6 +255,7 @@ class EmailOutboxService
             'template_key' => 'payment_success',
             'to_email' => $email,
             'subject' => $subject,
+            'attribution' => $this->payloadAttribution($normalizedAttribution),
         ];
         $payloadJson = $this->encodePayloadJson($this->sanitizePayloadForJson($payload));
         $payloadEnc = $this->encodePayloadEncrypted($payload);
@@ -550,6 +564,113 @@ class EmailOutboxService
         ];
     }
 
+    public function resolveDeliveryUserId(?string $userId, ?string $anonId, ?string $attemptId): ?string
+    {
+        $attemptId = $this->trimOrNull($attemptId);
+        if ($attemptId === null) {
+            return null;
+        }
+
+        return $this->resolveOutboxUserId(
+            $this->trimOrNull($userId),
+            $this->trimOrNull($anonId),
+            $attemptId
+        );
+    }
+
+    public function hasHistoricalRecipient(?string $attemptId, ?string $orderNo, string $email): bool
+    {
+        $attemptId = $this->trimOrNull($attemptId);
+        $email = $this->normalizeEmailAddress($email);
+        if ($attemptId === null || $email === null) {
+            return false;
+        }
+
+        if (! \App\Support\SchemaBaseline::hasTable('email_outbox')
+            || ! \App\Support\SchemaBaseline::hasColumn('email_outbox', 'attempt_id')) {
+            return false;
+        }
+
+        $normalizedOrderNo = $this->trimOrNull($orderNo);
+        $emailHash = $this->piiCipher->emailHash($email);
+        $query = DB::table('email_outbox')
+            ->where('attempt_id', $attemptId)
+            ->whereIn('template', ['payment_success', 'report_claim'])
+            ->orderByDesc('updated_at');
+
+        $hasEmailHash = \App\Support\SchemaBaseline::hasColumn('email_outbox', 'email_hash');
+        $hasToEmailHash = \App\Support\SchemaBaseline::hasColumn('email_outbox', 'to_email_hash');
+
+        if ($hasEmailHash || $hasToEmailHash) {
+            $query->where(function ($builder) use ($emailHash, $hasEmailHash, $hasToEmailHash): void {
+                if ($hasEmailHash) {
+                    $builder->orWhere('email_hash', $emailHash);
+                }
+
+                if ($hasToEmailHash) {
+                    $builder->orWhere('to_email_hash', $emailHash);
+                }
+            });
+        }
+
+        $rows = $query->get();
+
+        foreach ($rows as $row) {
+            if ($normalizedOrderNo !== null) {
+                $payload = $this->decodePayloadFromRow($row);
+                $payloadOrderNo = $this->trimOrNull((string) ($payload['order_no'] ?? ''));
+                if ($payloadOrderNo !== null && $payloadOrderNo !== $normalizedOrderNo) {
+                    continue;
+                }
+            }
+
+            return true;
+        }
+
+        return false;
+    }
+
+    public function lastDeliveryEmailSentAt(?string $attemptId, ?string $orderNo = null): ?string
+    {
+        $attemptId = $this->trimOrNull($attemptId);
+        if ($attemptId === null
+            || ! \App\Support\SchemaBaseline::hasTable('email_outbox')
+            || ! \App\Support\SchemaBaseline::hasColumn('email_outbox', 'attempt_id')
+            || ! \App\Support\SchemaBaseline::hasColumn('email_outbox', 'sent_at')) {
+            return null;
+        }
+
+        $normalizedOrderNo = $this->trimOrNull($orderNo);
+        $rows = DB::table('email_outbox')
+            ->where('attempt_id', $attemptId)
+            ->whereIn('template', ['payment_success', 'report_claim'])
+            ->whereNotNull('sent_at')
+            ->orderByDesc('sent_at')
+            ->limit($normalizedOrderNo === null ? 1 : 25)
+            ->get();
+
+        foreach ($rows as $row) {
+            if ($normalizedOrderNo !== null) {
+                $payload = $this->decodePayloadFromRow($row);
+                $payloadOrderNo = $this->trimOrNull((string) ($payload['order_no'] ?? ''));
+                if ($payloadOrderNo !== null && $payloadOrderNo !== $normalizedOrderNo) {
+                    continue;
+                }
+            }
+
+            $sentAt = $this->trimOrNull((string) ($row->sent_at ?? ''));
+            if ($sentAt !== null) {
+                try {
+                    return \Illuminate\Support\Carbon::parse($sentAt)->toIso8601String();
+                } catch (\Throwable) {
+                    return $sentAt;
+                }
+            }
+        }
+
+        return null;
+    }
+
     private function decodePayload($raw): array
     {
         if (is_array($raw)) {
@@ -677,6 +798,18 @@ class EmailOutboxService
         return $lang === 'zh' ? 'zh-CN' : 'en';
     }
 
+    private function resolveRequestedLocale(string $attemptId, ?string $preferredLocale = null): string
+    {
+        $preferredLocale = $this->trimOrNull($preferredLocale);
+        if ($preferredLocale !== null) {
+            $lang = strtolower((string) explode('-', str_replace('_', '-', $preferredLocale))[0]);
+
+            return $lang === 'zh' ? 'zh-CN' : 'en';
+        }
+
+        return $this->resolveAttemptLocale($attemptId);
+    }
+
     private function defaultSubjectForTemplate(string $templateKey, string $locale): string
     {
         $lang = strtolower((string) explode('-', str_replace('_', '-', $locale))[0]);
@@ -757,5 +890,59 @@ class EmailOutboxService
     private function reportPdfUrl(string $attemptId): string
     {
         return "/api/v0.3/attempts/{$attemptId}/report.pdf";
+    }
+
+    /**
+     * @param  array<string,mixed>  $attribution
+     * @return array<string,mixed>
+     */
+    private function normalizeAttribution(array $attribution): array
+    {
+        $normalized = [];
+
+        foreach ([
+            'share_id' => 128,
+            'compare_invite_id' => 128,
+            'share_click_id' => 128,
+            'entrypoint' => 128,
+            'referrer' => 2048,
+            'landing_path' => 2048,
+        ] as $field => $maxLength) {
+            $value = $this->trimOrNull(is_scalar($attribution[$field] ?? null) ? (string) $attribution[$field] : null);
+            if ($value === null) {
+                continue;
+            }
+
+            $normalized[$field] = mb_strlen($value, 'UTF-8') > $maxLength
+                ? mb_substr($value, 0, $maxLength, 'UTF-8')
+                : $value;
+        }
+
+        $utm = $attribution['utm'] ?? null;
+        if (is_array($utm)) {
+            $normalizedUtm = [];
+            foreach (['source', 'medium', 'campaign', 'term', 'content'] as $key) {
+                $value = $this->trimOrNull(is_scalar($utm[$key] ?? null) ? (string) $utm[$key] : null);
+                if ($value !== null) {
+                    $normalizedUtm[$key] = mb_strlen($value, 'UTF-8') > 512
+                        ? mb_substr($value, 0, 512, 'UTF-8')
+                        : $value;
+                }
+            }
+
+            if ($normalizedUtm !== []) {
+                $normalized['utm'] = $normalizedUtm;
+            }
+        }
+
+        return $normalized;
+    }
+
+    /**
+     * @param  array<string,mixed>  $attribution
+     */
+    private function payloadAttribution(array $attribution): mixed
+    {
+        return $attribution === [] ? new \stdClass : $attribution;
     }
 }

--- a/backend/app/Services/Email/EmailPreferenceService.php
+++ b/backend/app/Services/Email/EmailPreferenceService.php
@@ -1,0 +1,291 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\Email;
+
+use App\Models\EmailPreference;
+use App\Models\EmailSubscriber;
+use App\Support\PiiCipher;
+use Illuminate\Support\Str;
+
+class EmailPreferenceService
+{
+    private const TOKEN_PREFIX = 'pref_';
+
+    public function __construct(
+        private readonly PiiCipher $piiCipher,
+        private readonly EmailCaptureService $emailCapture,
+    ) {}
+
+    /**
+     * @param  array<string,mixed>  $context
+     */
+    public function issueTokenForEmail(string $email, array $context = []): string
+    {
+        $subscriber = $this->emailCapture->ensureSubscriber($email, $context);
+
+        return $this->issueTokenForSubscriber($subscriber);
+    }
+
+    public function issueTokenForSubscriber(EmailSubscriber $subscriber): string
+    {
+        $payload = json_encode([
+            'v' => 1,
+            'subscriber_id' => (string) $subscriber->getKey(),
+            'email_hash' => (string) $subscriber->email_hash,
+        ], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES);
+
+        $encrypted = $this->piiCipher->encrypt($payload ?: '');
+        if ($encrypted === null) {
+            $encrypted = $this->piiCipher->encrypt((string) Str::uuid()) ?? '';
+        }
+
+        return self::TOKEN_PREFIX.$this->base64UrlEncode($encrypted);
+    }
+
+    /**
+     * @return array{
+     *     ok:bool,
+     *     status:int,
+     *     error_code?:string,
+     *     email_masked?:string,
+     *     preferences?:array{marketing_updates:bool,report_recovery:bool,product_updates:bool}
+     * }
+     */
+    public function showByToken(string $token): array
+    {
+        $resolved = $this->resolveByToken($token);
+        if (! ($resolved['ok'] ?? false)) {
+            return $resolved;
+        }
+
+        /** @var EmailSubscriber $subscriber */
+        $subscriber = $resolved['subscriber'];
+        /** @var EmailPreference $preference */
+        $preference = $resolved['preference'];
+
+        return [
+            'ok' => true,
+            'status' => 200,
+            'email_masked' => $this->maskEmail($subscriber),
+            'preferences' => $this->preferencesPayload($preference),
+        ];
+    }
+
+    /**
+     * @param  array<string,mixed>  $preferences
+     * @return array{
+     *     ok:bool,
+     *     status:int,
+     *     error_code?:string,
+     *     preferences?:array{marketing_updates:bool,report_recovery:bool,product_updates:bool}
+     * }
+     */
+    public function updateByToken(string $token, array $preferences): array
+    {
+        $resolved = $this->resolveByToken($token);
+        if (! ($resolved['ok'] ?? false)) {
+            return $resolved;
+        }
+
+        /** @var EmailSubscriber $subscriber */
+        $subscriber = $resolved['subscriber'];
+        /** @var EmailPreference $preference */
+        $preference = $resolved['preference'];
+
+        $preference->marketing_updates = (bool) ($preferences['marketing_updates'] ?? false);
+        $preference->report_recovery = (bool) ($preferences['report_recovery'] ?? false);
+        $preference->product_updates = (bool) ($preferences['product_updates'] ?? false);
+        $preference->save();
+
+        $subscriber->marketing_consent = (bool) ($preference->marketing_updates || $preference->product_updates);
+        $subscriber->transactional_recovery_enabled = (bool) $preference->report_recovery;
+        $subscriber->unsubscribed_at = $preference->marketing_updates || $preference->report_recovery || $preference->product_updates
+            ? null
+            : now();
+        $subscriber->save();
+
+        return [
+            'ok' => true,
+            'status' => 200,
+            'preferences' => $this->preferencesPayload($preference),
+        ];
+    }
+
+    /**
+     * @return array{ok:bool,status:int,error_code?:string,status_text?:string}
+     */
+    public function unsubscribeByToken(string $token, ?string $reason = null): array
+    {
+        $resolved = $this->resolveByToken($token);
+        if (! ($resolved['ok'] ?? false)) {
+            return $resolved;
+        }
+
+        /** @var EmailSubscriber $subscriber */
+        $subscriber = $resolved['subscriber'];
+        /** @var EmailPreference $preference */
+        $preference = $resolved['preference'];
+
+        $preference->marketing_updates = false;
+        $preference->report_recovery = false;
+        $preference->product_updates = false;
+        $preference->save();
+
+        $subscriber->marketing_consent = false;
+        $subscriber->transactional_recovery_enabled = false;
+        $subscriber->unsubscribed_at = now();
+        $subscriber->save();
+
+        if (is_string($reason) && trim($reason) !== '' && empty($subscriber->last_context_json)) {
+            $subscriber->last_context_json = [
+                'unsubscribe_reason' => trim($reason),
+            ];
+            $subscriber->save();
+        }
+
+        return [
+            'ok' => true,
+            'status' => 200,
+            'status_text' => 'unsubscribed',
+        ];
+    }
+
+    /**
+     * @return array{
+     *     ok:bool,
+     *     status:int,
+     *     error_code?:string,
+     *     subscriber?:EmailSubscriber,
+     *     preference?:EmailPreference
+     * }
+     */
+    private function resolveByToken(string $token): array
+    {
+        $payload = $this->decodeToken($token);
+        if (! is_array($payload)) {
+            return [
+                'ok' => false,
+                'status' => 422,
+                'error_code' => 'INVALID_TOKEN',
+            ];
+        }
+
+        $subscriberId = trim((string) ($payload['subscriber_id'] ?? ''));
+        $emailHash = trim((string) ($payload['email_hash'] ?? ''));
+        if ($subscriberId === '' || $emailHash === '') {
+            return [
+                'ok' => false,
+                'status' => 422,
+                'error_code' => 'INVALID_TOKEN',
+            ];
+        }
+
+        $subscriber = EmailSubscriber::query()
+            ->with('preference')
+            ->find($subscriberId);
+        if (! $subscriber || (string) ($subscriber->email_hash ?? '') !== $emailHash) {
+            return [
+                'ok' => false,
+                'status' => 404,
+                'error_code' => 'TOKEN_NOT_FOUND',
+            ];
+        }
+
+        $preference = $subscriber->preference instanceof EmailPreference
+            ? $subscriber->preference
+            : new EmailPreference([
+                'id' => (string) Str::uuid(),
+                'subscriber_id' => (string) $subscriber->getKey(),
+                'marketing_updates' => (bool) $subscriber->marketing_consent,
+                'report_recovery' => (bool) ($subscriber->transactional_recovery_enabled ?? true),
+                'product_updates' => (bool) $subscriber->marketing_consent,
+            ]);
+        if (! $preference->exists) {
+            $preference->save();
+            $subscriber->setRelation('preference', $preference);
+        }
+
+        return [
+            'ok' => true,
+            'status' => 200,
+            'subscriber' => $subscriber,
+            'preference' => $preference,
+        ];
+    }
+
+    /**
+     * @return array<string,mixed>|null
+     */
+    private function decodeToken(string $token): ?array
+    {
+        $token = trim($token);
+        if (! str_starts_with($token, self::TOKEN_PREFIX)) {
+            return null;
+        }
+
+        $encoded = substr($token, strlen(self::TOKEN_PREFIX));
+        $decoded = $this->base64UrlDecode($encoded);
+        if ($decoded === null) {
+            return null;
+        }
+
+        $json = $this->piiCipher->decrypt($decoded);
+        if ($json === null) {
+            return null;
+        }
+
+        $payload = json_decode($json, true);
+
+        return is_array($payload) ? $payload : null;
+    }
+
+    private function base64UrlEncode(string $value): string
+    {
+        return rtrim(strtr(base64_encode($value), '+/', '-_'), '=');
+    }
+
+    private function base64UrlDecode(string $value): ?string
+    {
+        $normalized = strtr(trim($value), '-_', '+/');
+        if ($normalized === '') {
+            return null;
+        }
+
+        $padding = strlen($normalized) % 4;
+        if ($padding > 0) {
+            $normalized .= str_repeat('=', 4 - $padding);
+        }
+
+        $decoded = base64_decode($normalized, true);
+
+        return is_string($decoded) ? $decoded : null;
+    }
+
+    private function maskEmail(EmailSubscriber $subscriber): string
+    {
+        $email = $this->piiCipher->decrypt((string) ($subscriber->email_enc ?? ''));
+        if ($email === null || ! str_contains($email, '@')) {
+            return '***';
+        }
+
+        [$localPart, $domain] = explode('@', $email, 2);
+        $prefixLength = max(1, min(2, mb_strlen($localPart, 'UTF-8')));
+        $prefix = mb_substr($localPart, 0, $prefixLength, 'UTF-8');
+
+        return $prefix.'***@'.$domain;
+    }
+
+    /**
+     * @return array{marketing_updates:bool,report_recovery:bool,product_updates:bool}
+     */
+    private function preferencesPayload(EmailPreference $preference): array
+    {
+        return [
+            'marketing_updates' => (bool) $preference->marketing_updates,
+            'report_recovery' => (bool) $preference->report_recovery,
+            'product_updates' => (bool) $preference->product_updates,
+        ];
+    }
+}

--- a/backend/database/migrations/2026_03_12_010000_create_email_subscribers_table.php
+++ b/backend/database/migrations/2026_03_12_010000_create_email_subscribers_table.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        if (Schema::hasTable('email_subscribers')) {
+            return;
+        }
+
+        Schema::create('email_subscribers', function (Blueprint $table): void {
+            $table->uuid('id')->primary();
+            $table->string('pii_email_key_version', 32)->nullable();
+            $table->text('email_enc');
+            $table->string('email_hash', 64)->unique();
+            $table->string('locale', 16)->nullable();
+            $table->string('first_source', 64)->nullable();
+            $table->string('last_source', 64)->nullable();
+            $table->boolean('marketing_consent')->default(false);
+            $table->boolean('transactional_recovery_enabled')->default(true);
+            $table->json('first_context_json')->nullable();
+            $table->json('last_context_json')->nullable();
+            $table->timestamp('unsubscribed_at')->nullable();
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        // forward-only migration: rollback disabled to prevent data loss in production.
+        // Irreversible operation: schema/data rollback handled via forward fix migrations.
+    }
+};

--- a/backend/database/migrations/2026_03_12_010100_create_email_preferences_table.php
+++ b/backend/database/migrations/2026_03_12_010100_create_email_preferences_table.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        if (Schema::hasTable('email_preferences')) {
+            return;
+        }
+
+        Schema::create('email_preferences', function (Blueprint $table): void {
+            $table->uuid('id')->primary();
+            $table->uuid('subscriber_id')->unique();
+            $table->boolean('marketing_updates')->default(false);
+            $table->boolean('report_recovery')->default(true);
+            $table->boolean('product_updates')->default(false);
+            $table->timestamps();
+
+            $table->foreign('subscriber_id')
+                ->references('id')
+                ->on('email_subscribers')
+                ->cascadeOnDelete();
+        });
+    }
+
+    public function down(): void
+    {
+        // forward-only migration: rollback disabled to prevent data loss in production.
+        // Irreversible operation: schema/data rollback handled via forward fix migrations.
+    }
+};

--- a/backend/database/migrations/2026_03_12_010200_create_email_suppressions_table.php
+++ b/backend/database/migrations/2026_03_12_010200_create_email_suppressions_table.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        if (Schema::hasTable('email_suppressions')) {
+            return;
+        }
+
+        Schema::create('email_suppressions', function (Blueprint $table): void {
+            $table->uuid('id')->primary();
+            $table->string('email_hash', 64)->index();
+            $table->string('reason', 64);
+            $table->string('source', 128)->nullable();
+            $table->json('meta_json')->nullable();
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        // forward-only migration: rollback disabled to prevent data loss in production.
+        // Irreversible operation: schema/data rollback handled via forward fix migrations.
+    }
+};

--- a/backend/docs/contracts/openapi.snapshot.json
+++ b/backend/docs/contracts/openapi.snapshot.json
@@ -510,6 +510,26 @@
                     "Illuminate\\Routing\\Middleware\\ThrottleRequests:api_public",
                     "App\\Http\\Middleware\\NormalizeApiErrorContract"
                 ]
+            },
+            "post": {
+                "operationId": "post_api_v0_3_claim_report",
+                "tags": [
+                    "api:v0.3"
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK"
+                    }
+                },
+                "x-laravel-action": "App\\Http\\Controllers\\API\\V0_3\\ClaimController@requestReport",
+                "x-laravel-middleware": [
+                    "api",
+                    "Illuminate\\Routing\\Middleware\\ThrottleRequests:api_public",
+                    "App\\Http\\Middleware\\NormalizeApiErrorContract",
+                    "App\\Http\\Middleware\\ResolveAnonId",
+                    "App\\Http\\Middleware\\ResolveOrgContext",
+                    "App\\Http\\Middleware\\FmTokenOptional"
+                ]
             }
         },
         "/api/v0.3/compare/mbti/{inviteId}": {
@@ -601,6 +621,89 @@
                     "App\\Http\\Middleware\\ResolveOrgContext",
                     "App\\Http\\Middleware\\EnsureUuidRouteParams:id",
                     "Illuminate\\Routing\\Middleware\\ThrottleRequests:api_auth"
+                ]
+            }
+        },
+        "/api/v0.3/email/capture": {
+            "post": {
+                "operationId": "post_api_v0_3_email_capture",
+                "tags": [
+                    "api:v0.3"
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK"
+                    }
+                },
+                "x-laravel-action": "App\\Http\\Controllers\\API\\V0_3\\EmailCaptureController@store",
+                "x-laravel-middleware": [
+                    "api",
+                    "Illuminate\\Routing\\Middleware\\ThrottleRequests:api_public",
+                    "App\\Http\\Middleware\\NormalizeApiErrorContract",
+                    "App\\Http\\Middleware\\ResolveAnonId",
+                    "App\\Http\\Middleware\\ResolveOrgContext",
+                    "App\\Http\\Middleware\\FmTokenOptional"
+                ]
+            }
+        },
+        "/api/v0.3/email/preferences": {
+            "get": {
+                "operationId": "get_api_v0_3_email_preferences",
+                "tags": [
+                    "api:v0.3"
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK"
+                    }
+                },
+                "x-laravel-action": "App\\Http\\Controllers\\API\\V0_3\\EmailPreferenceController@show",
+                "x-laravel-middleware": [
+                    "api",
+                    "Illuminate\\Routing\\Middleware\\ThrottleRequests:api_public",
+                    "App\\Http\\Middleware\\NormalizeApiErrorContract",
+                    "App\\Http\\Middleware\\ResolveAnonId",
+                    "App\\Http\\Middleware\\ResolveOrgContext"
+                ]
+            },
+            "post": {
+                "operationId": "post_api_v0_3_email_preferences",
+                "tags": [
+                    "api:v0.3"
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK"
+                    }
+                },
+                "x-laravel-action": "App\\Http\\Controllers\\API\\V0_3\\EmailPreferenceController@update",
+                "x-laravel-middleware": [
+                    "api",
+                    "Illuminate\\Routing\\Middleware\\ThrottleRequests:api_public",
+                    "App\\Http\\Middleware\\NormalizeApiErrorContract",
+                    "App\\Http\\Middleware\\ResolveAnonId",
+                    "App\\Http\\Middleware\\ResolveOrgContext"
+                ]
+            }
+        },
+        "/api/v0.3/email/unsubscribe": {
+            "post": {
+                "operationId": "post_api_v0_3_email_unsubscribe",
+                "tags": [
+                    "api:v0.3"
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK"
+                    }
+                },
+                "x-laravel-action": "App\\Http\\Controllers\\API\\V0_3\\EmailPreferenceController@unsubscribe",
+                "x-laravel-middleware": [
+                    "api",
+                    "Illuminate\\Routing\\Middleware\\ThrottleRequests:api_public",
+                    "App\\Http\\Middleware\\NormalizeApiErrorContract",
+                    "App\\Http\\Middleware\\ResolveAnonId",
+                    "App\\Http\\Middleware\\ResolveOrgContext"
                 ]
             }
         },

--- a/backend/routes/api.php
+++ b/backend/routes/api.php
@@ -10,6 +10,8 @@ use App\Http\Controllers\API\V0_3\BigFiveOpsController;
 use App\Http\Controllers\API\V0_3\BootController as BootV0_3Controller;
 use App\Http\Controllers\API\V0_3\ClaimController as ClaimV03Controller;
 use App\Http\Controllers\API\V0_3\ComplianceDsarController;
+use App\Http\Controllers\API\V0_3\EmailCaptureController;
+use App\Http\Controllers\API\V0_3\EmailPreferenceController;
 use App\Http\Controllers\API\V0_3\MbtiCompareInviteController;
 use App\Http\Controllers\API\V0_3\MeController as MeV03Controller;
 use App\Http\Controllers\API\V0_3\OrgInvitesController;
@@ -178,6 +180,13 @@ Route::prefix('v0.3')->middleware([
             ->middleware([\App\Http\Middleware\FmTokenOptional::class, 'throttle:api_order_lookup']);
         Route::post('/orders/{order_no}/resend', 'App\\Http\\Controllers\\API\\V0_3\\CommerceController@resend')
             ->middleware(\App\Http\Middleware\FmTokenOptional::class);
+        Route::post('/claim/report', [ClaimV03Controller::class, 'requestReport'])
+            ->middleware(\App\Http\Middleware\FmTokenOptional::class);
+        Route::post('/email/capture', [EmailCaptureController::class, 'store'])
+            ->middleware(\App\Http\Middleware\FmTokenOptional::class);
+        Route::get('/email/preferences', [EmailPreferenceController::class, 'show']);
+        Route::post('/email/preferences', [EmailPreferenceController::class, 'update']);
+        Route::post('/email/unsubscribe', [EmailPreferenceController::class, 'unsubscribe']);
         Route::post('/orders', 'App\\Http\\Controllers\\API\\V0_3\\CommerceController@createOrder')
             ->middleware(\App\Http\Middleware\FmTokenAuth::class);
         Route::post('/orders/stub', static function (

--- a/backend/tests/Feature/Commerce/BigFiveUnlockDeliveryPipelineTest.php
+++ b/backend/tests/Feature/Commerce/BigFiveUnlockDeliveryPipelineTest.php
@@ -157,6 +157,21 @@ final class BigFiveUnlockDeliveryPipelineTest extends TestCase
             'paid_at' => null,
             'created_at' => now(),
             'updated_at' => now(),
+            'meta_json' => json_encode([
+                'attribution' => [
+                    'share_id' => 'share_big5_unlock',
+                    'compare_invite_id' => (string) Str::uuid(),
+                    'share_click_id' => 'clk_big5_unlock',
+                    'entrypoint' => 'share_page',
+                    'referrer' => 'https://example.com/share/big5',
+                    'landing_path' => '/zh/share/big5',
+                    'utm' => [
+                        'source' => 'share',
+                        'medium' => 'organic',
+                        'campaign' => 'pr09',
+                    ],
+                ],
+            ], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES),
             'amount_total' => $amountCents,
             'amount_refunded' => 0,
             'item_sku' => $sku,
@@ -227,6 +242,9 @@ final class BigFiveUnlockDeliveryPipelineTest extends TestCase
         $this->assertIsArray($payloadJson);
         $this->assertSame("/api/v0.3/attempts/{$attemptId}/report", (string) ($payloadJson['report_url'] ?? ''));
         $this->assertSame("/api/v0.3/attempts/{$attemptId}/report.pdf", (string) ($payloadJson['report_pdf_url'] ?? ''));
+        $this->assertSame('share_big5_unlock', (string) data_get($payloadJson, 'attribution.share_id'));
+        $this->assertSame('clk_big5_unlock', (string) data_get($payloadJson, 'attribution.share_click_id'));
+        $this->assertSame('organic', (string) data_get($payloadJson, 'attribution.utm.medium'));
 
         if (Schema::hasColumn('email_outbox', 'template_key')) {
             $this->assertContains((string) ($row->template_key ?? ''), ['', 'payment_success']);
@@ -245,6 +263,9 @@ final class BigFiveUnlockDeliveryPipelineTest extends TestCase
             ->assertJsonPath('delivery.report_url', "/api/v0.3/attempts/{$attemptId}/report")
             ->assertJsonPath('delivery.can_download_pdf', true)
             ->assertJsonPath('delivery.report_pdf_url', "/api/v0.3/attempts/{$attemptId}/report.pdf")
-            ->assertJsonPath('delivery.can_resend', true);
+            ->assertJsonPath('delivery.can_resend', true)
+            ->assertJsonPath('delivery.contact_email_present', true)
+            ->assertJsonPath('delivery.last_delivery_email_sent_at', null)
+            ->assertJsonPath('delivery.can_request_claim_email', true);
     }
 }

--- a/backend/tests/Feature/Email/EmailOutboxAttributionTest.php
+++ b/backend/tests/Feature/Email/EmailOutboxAttributionTest.php
@@ -1,0 +1,138 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Email;
+
+use App\Services\Email\EmailOutboxService;
+use App\Support\PiiCipher;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Str;
+use Tests\TestCase;
+
+final class EmailOutboxAttributionTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_payment_success_outbox_payload_includes_attribution_contract(): void
+    {
+        $attemptId = $this->createAttempt();
+        $email = 'buyer+'.random_int(1000, 9999).'@example.com';
+
+        /** @var EmailOutboxService $outbox */
+        $outbox = app(EmailOutboxService::class);
+        $queued = $outbox->queuePaymentSuccess(
+            'payment_success_user',
+            $email,
+            $attemptId,
+            'ord_attr_001',
+            'MBTI Full Report',
+            [
+                'share_id' => 'share_123',
+                'compare_invite_id' => (string) Str::uuid(),
+                'share_click_id' => 'clk_456',
+                'entrypoint' => 'share_page',
+                'referrer' => 'https://example.com/share',
+                'landing_path' => '/zh/share/123',
+                'utm' => [
+                    'source' => 'share',
+                    'medium' => 'organic',
+                    'campaign' => 'pr09',
+                    'term' => 'mbti',
+                    'content' => 'hero',
+                ],
+            ]
+        );
+        $this->assertTrue((bool) ($queued['ok'] ?? false));
+
+        $row = DB::table('email_outbox')
+            ->where('attempt_id', $attemptId)
+            ->where('template', 'payment_success')
+            ->first();
+        $this->assertNotNull($row);
+
+        $payloadJson = json_decode((string) ($row->payload_json ?? '{}'), true);
+        $this->assertIsArray($payloadJson);
+        $this->assertSame('share_123', (string) data_get($payloadJson, 'attribution.share_id'));
+        $this->assertSame('clk_456', (string) data_get($payloadJson, 'attribution.share_click_id'));
+        $this->assertSame('organic', (string) data_get($payloadJson, 'attribution.utm.medium'));
+        $this->assertArrayNotHasKey('email', $payloadJson);
+        $this->assertArrayNotHasKey('to_email', $payloadJson);
+
+        /** @var PiiCipher $pii */
+        $pii = app(PiiCipher::class);
+        $payloadEnc = json_decode((string) $pii->decrypt((string) ($row->payload_enc ?? '')), true);
+        $this->assertIsArray($payloadEnc);
+        $this->assertSame($email, (string) ($payloadEnc['to_email'] ?? ''));
+        $this->assertSame('hero', (string) data_get($payloadEnc, 'attribution.utm.content'));
+    }
+
+    public function test_report_claim_outbox_payload_includes_attribution_contract(): void
+    {
+        $attemptId = $this->createAttempt();
+
+        /** @var EmailOutboxService $outbox */
+        $outbox = app(EmailOutboxService::class);
+        $queued = $outbox->queueReportClaim(
+            'report_claim_user',
+            'claim@example.com',
+            $attemptId,
+            'ord_attr_002',
+            [
+                'share_id' => 'share_claim',
+                'entrypoint' => 'order_lookup',
+                'landing_path' => '/zh/orders/lookup',
+                'utm' => [
+                    'source' => 'help',
+                    'medium' => 'owned',
+                    'campaign' => 'report-recovery',
+                ],
+            ]
+        );
+        $this->assertTrue((bool) ($queued['ok'] ?? false));
+
+        $row = DB::table('email_outbox')
+            ->where('attempt_id', $attemptId)
+            ->where('template', 'report_claim')
+            ->first();
+        $this->assertNotNull($row);
+
+        $payloadJson = json_decode((string) ($row->payload_json ?? '{}'), true);
+        $this->assertIsArray($payloadJson);
+        $this->assertSame('share_claim', (string) data_get($payloadJson, 'attribution.share_id'));
+        $this->assertSame('order_lookup', (string) data_get($payloadJson, 'attribution.entrypoint'));
+    }
+
+    private function createAttempt(): string
+    {
+        $attemptId = (string) Str::uuid();
+
+        DB::table('attempts')->insert([
+            'id' => $attemptId,
+            'ticket_code' => 'FMT-'.strtoupper(substr(str_replace('-', '', $attemptId), 0, 8)),
+            'org_id' => 0,
+            'anon_id' => 'anon_attr',
+            'user_id' => null,
+            'scale_code' => 'MBTI',
+            'scale_version' => 'v0.3',
+            'region' => 'CN_MAINLAND',
+            'locale' => 'zh-CN',
+            'question_count' => 144,
+            'answers_summary_json' => json_encode(['seed' => true], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES),
+            'client_platform' => 'test',
+            'client_version' => '1.0.0',
+            'channel' => 'test',
+            'started_at' => now()->subMinute(),
+            'submitted_at' => now(),
+            'pack_id' => (string) config('content_packs.default_pack_id'),
+            'dir_version' => (string) config('content_packs.default_dir_version'),
+            'content_package_version' => 'v0.3',
+            'scoring_spec_version' => '2026.01',
+            'created_at' => now(),
+            'updated_at' => now(),
+        ]);
+
+        return $attemptId;
+    }
+}

--- a/backend/tests/Feature/Email/EmailOutboxNoPlaintextPayloadTest.php
+++ b/backend/tests/Feature/Email/EmailOutboxNoPlaintextPayloadTest.php
@@ -18,13 +18,13 @@ final class EmailOutboxNoPlaintextPayloadTest extends TestCase
 
     public function test_outbox_writes_masked_plaintext_columns_and_sanitized_payload_json(): void
     {
-        $userId = 'email_outbox_user_' . random_int(1000, 9999);
-        $email = 'buyer+' . random_int(1000, 9999) . '@example.com';
+        $userId = 'email_outbox_user_'.random_int(1000, 9999);
+        $email = 'buyer+'.random_int(1000, 9999).'@example.com';
         $attemptId = (string) Str::uuid();
 
         DB::table('attempts')->insert([
             'id' => $attemptId,
-            'ticket_code' => 'FMT-' . strtoupper(substr(str_replace('-', '', (string) Str::uuid()), 0, 8)),
+            'ticket_code' => 'FMT-'.strtoupper(substr(str_replace('-', '', (string) Str::uuid()), 0, 8)),
             'org_id' => 0,
             'anon_id' => 'anon_email_outbox',
             'user_id' => null,
@@ -88,6 +88,7 @@ final class EmailOutboxNoPlaintextPayloadTest extends TestCase
             $payloadJson = json_decode((string) ($row->payload_json ?? '{}'), true);
             $this->assertIsArray($payloadJson);
             $this->assertSame($attemptId, (string) ($payloadJson['attempt_id'] ?? ''));
+            $this->assertArrayHasKey('attribution', $payloadJson);
             $this->assertArrayNotHasKey('email', $payloadJson);
             $this->assertArrayNotHasKey('to_email', $payloadJson);
             $this->assertArrayNotHasKey('claim_token', $payloadJson);
@@ -97,6 +98,7 @@ final class EmailOutboxNoPlaintextPayloadTest extends TestCase
             $this->assertIsArray($payloadEncDecoded);
             $this->assertSame($attemptId, (string) ($payloadEncDecoded['attempt_id'] ?? ''));
             $this->assertSame($email, (string) ($payloadEncDecoded['to_email'] ?? ''));
+            $this->assertArrayHasKey('attribution', $payloadEncDecoded);
         }
     }
 }

--- a/backend/tests/Feature/V0_3/ClaimReportEmailRequestTest.php
+++ b/backend/tests/Feature/V0_3/ClaimReportEmailRequestTest.php
@@ -1,0 +1,226 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\V0_3;
+
+use App\Support\PiiCipher;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Support\Str;
+use Tests\TestCase;
+
+final class ClaimReportEmailRequestTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_claim_report_post_blinds_missing_order(): void
+    {
+        $response = $this->postJson('/api/v0.3/claim/report', [
+            'order_no' => 'ord_missing_claim',
+            'email' => 'missing@example.com',
+            'surface' => 'help',
+            'entrypoint' => 'help_center',
+        ]);
+
+        $response->assertOk()
+            ->assertJson([
+                'ok' => true,
+                'queued' => true,
+            ]);
+
+        $this->assertSame(0, DB::table('email_outbox')->count());
+    }
+
+    public function test_claim_report_post_blinds_email_mismatch(): void
+    {
+        $attemptId = $this->createAttempt('claim_owner');
+        $orderNo = 'ord_claim_'.Str::lower(Str::random(8));
+        $this->insertOrder($orderNo, $attemptId, 'owner@example.com');
+
+        $response = $this->postJson('/api/v0.3/claim/report', [
+            'order_no' => $orderNo,
+            'email' => 'attacker@example.com',
+            'surface' => 'lookup',
+            'entrypoint' => 'order_lookup',
+        ]);
+
+        $response->assertOk()
+            ->assertJson([
+                'ok' => true,
+                'queued' => true,
+            ]);
+
+        $this->assertSame(
+            0,
+            DB::table('email_outbox')
+                ->where('attempt_id', $attemptId)
+                ->where('template', 'report_claim')
+                ->count()
+        );
+    }
+
+    public function test_claim_report_post_queues_outbox_for_eligible_request(): void
+    {
+        $attemptId = $this->createAttempt('claim_owner');
+        $orderNo = 'ord_claim_'.Str::lower(Str::random(8));
+        $this->insertOrder($orderNo, $attemptId, 'owner@example.com', [
+            'share_click_id' => 'clk_001',
+            'landing_path' => '/zh/share/source',
+        ]);
+
+        $response = $this->postJson('/api/v0.3/claim/report', [
+            'order_no' => $orderNo,
+            'email' => 'owner@example.com',
+            'locale' => 'zh-CN',
+            'surface' => 'help',
+            'entrypoint' => 'help_center',
+            'referrer' => 'https://example.com/help',
+            'landing_path' => '/zh/orders/lookup',
+            'share_id' => 'share_123',
+            'compare_invite_id' => (string) Str::uuid(),
+            'utm' => [
+                'source' => 'help',
+                'medium' => 'owned',
+                'campaign' => 'report-recovery',
+                'term' => 'claim',
+                'content' => 'cta',
+            ],
+        ]);
+
+        $response->assertOk()
+            ->assertJson([
+                'ok' => true,
+                'queued' => true,
+            ]);
+
+        $row = DB::table('email_outbox')
+            ->where('attempt_id', $attemptId)
+            ->where('template', 'report_claim')
+            ->orderByDesc('updated_at')
+            ->first();
+
+        $this->assertNotNull($row);
+        $this->assertSame('pending', (string) ($row->status ?? ''));
+
+        $payloadJson = json_decode((string) ($row->payload_json ?? '{}'), true);
+        $this->assertIsArray($payloadJson);
+        $this->assertSame($orderNo, (string) ($payloadJson['order_no'] ?? ''));
+        $this->assertSame($attemptId, (string) ($payloadJson['attempt_id'] ?? ''));
+        $this->assertSame('/zh/orders/lookup', (string) data_get($payloadJson, 'attribution.landing_path'));
+        $this->assertSame('clk_001', (string) data_get($payloadJson, 'attribution.share_click_id'));
+        $this->assertArrayNotHasKey('email', $payloadJson);
+        $this->assertArrayNotHasKey('to_email', $payloadJson);
+        $this->assertArrayNotHasKey('claim_token', $payloadJson);
+        $this->assertArrayNotHasKey('claim_url', $payloadJson);
+
+        /** @var PiiCipher $pii */
+        $pii = app(PiiCipher::class);
+        $payloadEnc = json_decode((string) $pii->decrypt((string) ($row->payload_enc ?? '')), true);
+        $this->assertIsArray($payloadEnc);
+        $this->assertSame('owner@example.com', (string) ($payloadEnc['to_email'] ?? ''));
+        $this->assertSame('share_123', (string) data_get($payloadEnc, 'attribution.share_id'));
+    }
+
+    private function createAttempt(string $anonId): string
+    {
+        $attemptId = (string) Str::uuid();
+
+        DB::table('attempts')->insert([
+            'id' => $attemptId,
+            'ticket_code' => 'FMT-'.strtoupper(substr(str_replace('-', '', $attemptId), 0, 8)),
+            'org_id' => 0,
+            'user_id' => null,
+            'anon_id' => $anonId,
+            'scale_code' => 'MBTI',
+            'scale_version' => 'v0.3',
+            'region' => 'CN_MAINLAND',
+            'locale' => 'zh-CN',
+            'question_count' => 144,
+            'answers_summary_json' => json_encode(['seed' => true], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES),
+            'client_platform' => 'test',
+            'client_version' => '1.0.0',
+            'channel' => 'test',
+            'started_at' => now()->subMinute(),
+            'submitted_at' => now(),
+            'pack_id' => (string) config('content_packs.default_pack_id'),
+            'dir_version' => (string) config('content_packs.default_dir_version'),
+            'content_package_version' => 'v0.3',
+            'scoring_spec_version' => '2026.01',
+            'created_at' => now(),
+            'updated_at' => now(),
+        ]);
+
+        return $attemptId;
+    }
+
+    /**
+     * @param  array<string,mixed>  $attribution
+     */
+    private function insertOrder(string $orderNo, string $attemptId, string $email, array $attribution = []): void
+    {
+        $meta = $attribution === [] ? null : json_encode([
+            'attribution' => $attribution,
+        ], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES);
+
+        $row = [
+            'id' => (string) Str::uuid(),
+            'order_no' => $orderNo,
+            'org_id' => 0,
+            'user_id' => null,
+            'anon_id' => 'claim_owner',
+            'sku' => 'MBTI_CREDIT',
+            'quantity' => 1,
+            'target_attempt_id' => $attemptId,
+            'amount_cents' => 1990,
+            'currency' => 'USD',
+            'status' => 'paid',
+            'provider' => 'billing',
+            'external_trade_no' => null,
+            'paid_at' => now(),
+            'created_at' => now(),
+            'updated_at' => now(),
+            'meta_json' => $meta,
+        ];
+
+        if (Schema::hasColumn('orders', 'contact_email_hash')) {
+            $row['contact_email_hash'] = hash('sha256', mb_strtolower(trim($email), 'UTF-8'));
+        }
+        if (Schema::hasColumn('orders', 'amount_total')) {
+            $row['amount_total'] = 1990;
+        }
+        if (Schema::hasColumn('orders', 'amount_refunded')) {
+            $row['amount_refunded'] = 0;
+        }
+        if (Schema::hasColumn('orders', 'item_sku')) {
+            $row['item_sku'] = 'MBTI_CREDIT';
+        }
+        if (Schema::hasColumn('orders', 'provider_order_id')) {
+            $row['provider_order_id'] = null;
+        }
+        if (Schema::hasColumn('orders', 'device_id')) {
+            $row['device_id'] = null;
+        }
+        if (Schema::hasColumn('orders', 'request_id')) {
+            $row['request_id'] = null;
+        }
+        if (Schema::hasColumn('orders', 'created_ip')) {
+            $row['created_ip'] = null;
+        }
+        if (Schema::hasColumn('orders', 'fulfilled_at')) {
+            $row['fulfilled_at'] = null;
+        }
+        if (Schema::hasColumn('orders', 'refunded_at')) {
+            $row['refunded_at'] = null;
+        }
+        if (Schema::hasColumn('orders', 'refund_amount_cents')) {
+            $row['refund_amount_cents'] = null;
+        }
+        if (Schema::hasColumn('orders', 'refund_reason')) {
+            $row['refund_reason'] = null;
+        }
+
+        DB::table('orders')->insert($row);
+    }
+}

--- a/backend/tests/Feature/V0_3/CommerceOrderLookupSecurityTest.php
+++ b/backend/tests/Feature/V0_3/CommerceOrderLookupSecurityTest.php
@@ -62,7 +62,10 @@ final class CommerceOrderLookupSecurityTest extends TestCase
             ->assertJsonPath('delivery.report_url', "/api/v0.3/attempts/{$attemptId}/report")
             ->assertJsonPath('delivery.can_download_pdf', true)
             ->assertJsonPath('delivery.report_pdf_url', "/api/v0.3/attempts/{$attemptId}/report.pdf")
-            ->assertJsonPath('delivery.can_resend', true);
+            ->assertJsonPath('delivery.can_resend', true)
+            ->assertJsonPath('delivery.contact_email_present', true)
+            ->assertJsonPath('delivery.last_delivery_email_sent_at', null)
+            ->assertJsonPath('delivery.can_request_claim_email', true);
     }
 
     public function test_lookup_with_token_owner_works_without_email(): void
@@ -87,7 +90,10 @@ final class CommerceOrderLookupSecurityTest extends TestCase
             ->assertJsonPath('delivery.report_url', null)
             ->assertJsonPath('delivery.can_download_pdf', false)
             ->assertJsonPath('delivery.report_pdf_url', null)
-            ->assertJsonPath('delivery.can_resend', false);
+            ->assertJsonPath('delivery.can_resend', false)
+            ->assertJsonPath('delivery.contact_email_present', true)
+            ->assertJsonPath('delivery.last_delivery_email_sent_at', null)
+            ->assertJsonPath('delivery.can_request_claim_email', false);
     }
 
     private function createUser(string $email): int
@@ -198,6 +204,9 @@ final class CommerceOrderLookupSecurityTest extends TestCase
 
         if (Schema::hasColumn('orders', 'contact_email_hash')) {
             $row['contact_email_hash'] = hash('sha256', mb_strtolower(trim($email), 'UTF-8'));
+        }
+        if (Schema::hasColumn('orders', 'meta_json')) {
+            $row['meta_json'] = null;
         }
         if (Schema::hasColumn('orders', 'amount_total')) {
             $row['amount_total'] = 1990;

--- a/backend/tests/Feature/V0_3/CommerceOrderResendTest.php
+++ b/backend/tests/Feature/V0_3/CommerceOrderResendTest.php
@@ -52,6 +52,7 @@ final class CommerceOrderResendTest extends TestCase
         $this->assertSame($orderNo, (string) ($payloadJson['order_no'] ?? ''));
         $this->assertSame("/api/v0.3/attempts/{$attemptId}/report", (string) ($payloadJson['report_url'] ?? ''));
         $this->assertSame("/api/v0.3/attempts/{$attemptId}/report.pdf", (string) ($payloadJson['report_pdf_url'] ?? ''));
+        $this->assertSame([], $payloadJson['attribution'] ?? null);
     }
 
     public function test_resend_reuses_existing_outbox_recipient_for_paid_anon_order(): void
@@ -88,6 +89,9 @@ final class CommerceOrderResendTest extends TestCase
         $pii = app(PiiCipher::class);
         $encryptedEmail = (string) (($row->to_email_enc ?? '') !== '' ? ($row->to_email_enc ?? '') : ($row->email_enc ?? ''));
         $this->assertSame('anon-resend@example.com', $pii->decrypt($encryptedEmail));
+        $payloadJson = json_decode((string) ($row->payload_json ?? '{}'), true);
+        $this->assertIsArray($payloadJson);
+        $this->assertSame([], $payloadJson['attribution'] ?? null);
     }
 
     public function test_resend_keeps_blind_success_for_ineligible_order_without_outbox_side_effect(): void

--- a/backend/tests/Feature/V0_3/EmailCaptureContractTest.php
+++ b/backend/tests/Feature/V0_3/EmailCaptureContractTest.php
@@ -1,0 +1,129 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\V0_3;
+
+use App\Support\PiiCipher;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Str;
+use Tests\TestCase;
+
+final class EmailCaptureContractTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_email_capture_creates_transactional_subscriber_contract(): void
+    {
+        $email = 'buyer+'.random_int(1000, 9999).'@example.com';
+
+        $response = $this->postJson('/api/v0.3/email/capture', [
+            'email' => $email,
+            'locale' => 'zh-CN',
+            'surface' => 'lookup',
+            'order_no' => 'ord_capture_'.Str::lower(Str::random(6)),
+            'attempt_id' => (string) Str::uuid(),
+            'entrypoint' => 'order_lookup',
+            'referrer' => 'https://example.com/help',
+            'landing_path' => '/zh/orders/lookup',
+            'utm' => [
+                'source' => 'help',
+                'medium' => 'owned',
+                'campaign' => 'pr09',
+            ],
+            'marketing_consent' => true,
+        ]);
+
+        $response->assertOk()
+            ->assertJsonPath('ok', true)
+            ->assertJsonPath('status', 'captured')
+            ->assertJsonPath('marketing_consent', true)
+            ->assertJsonPath('preferences.marketing_updates', true)
+            ->assertJsonPath('preferences.report_recovery', true)
+            ->assertJsonPath('preferences.product_updates', true);
+
+        /** @var PiiCipher $pii */
+        $pii = app(PiiCipher::class);
+        $subscriber = DB::table('email_subscribers')->first();
+        $this->assertNotNull($subscriber);
+        $this->assertSame($pii->emailHash($email), (string) ($subscriber->email_hash ?? ''));
+        $this->assertSame($email, $pii->decrypt((string) ($subscriber->email_enc ?? '')));
+        $this->assertSame('lookup', (string) ($subscriber->first_source ?? ''));
+        $this->assertSame('lookup', (string) ($subscriber->last_source ?? ''));
+        $this->assertSame('zh-CN', (string) ($subscriber->locale ?? ''));
+        $this->assertSame((string) $pii->currentKeyVersion(), (string) ($subscriber->pii_email_key_version ?? ''));
+
+        $firstContext = json_decode((string) ($subscriber->first_context_json ?? '{}'), true);
+        $this->assertIsArray($firstContext);
+        $this->assertSame('order_lookup', (string) ($firstContext['entrypoint'] ?? ''));
+        $this->assertArrayNotHasKey('email', $firstContext);
+
+        $preferences = DB::table('email_preferences')
+            ->where('subscriber_id', $subscriber->id)
+            ->first();
+        $this->assertNotNull($preferences);
+        $this->assertTrue((bool) ($preferences->marketing_updates ?? false));
+        $this->assertTrue((bool) ($preferences->report_recovery ?? false));
+        $this->assertTrue((bool) ($preferences->product_updates ?? false));
+    }
+
+    public function test_email_capture_updates_existing_subscriber_without_plaintext_leak(): void
+    {
+        $email = 'update+'.random_int(1000, 9999).'@example.com';
+
+        $this->postJson('/api/v0.3/email/capture', [
+            'email' => $email,
+            'surface' => 'lookup',
+            'marketing_consent' => false,
+        ])->assertOk();
+
+        $response = $this->postJson('/api/v0.3/email/capture', [
+            'email' => $email,
+            'surface' => 'help',
+            'entrypoint' => 'help_center',
+            'marketing_consent' => false,
+        ]);
+
+        $response->assertOk()
+            ->assertJsonPath('status', 'updated')
+            ->assertJsonPath('marketing_consent', false)
+            ->assertJsonPath('preferences.marketing_updates', false)
+            ->assertJsonPath('preferences.report_recovery', true)
+            ->assertJsonPath('preferences.product_updates', false);
+
+        $subscriber = DB::table('email_subscribers')->first();
+        $this->assertNotNull($subscriber);
+        $this->assertSame(1, DB::table('email_subscribers')->count());
+        $this->assertSame('lookup', (string) ($subscriber->first_source ?? ''));
+        $this->assertSame('help', (string) ($subscriber->last_source ?? ''));
+        $this->assertStringNotContainsString($email, (string) ($subscriber->last_context_json ?? ''));
+    }
+
+    public function test_email_capture_returns_suppressed_when_email_hash_is_suppressed(): void
+    {
+        $email = 'suppressed+'.random_int(1000, 9999).'@example.com';
+
+        /** @var PiiCipher $pii */
+        $pii = app(PiiCipher::class);
+        DB::table('email_suppressions')->insert([
+            'id' => (string) Str::uuid(),
+            'email_hash' => $pii->emailHash($email),
+            'reason' => 'bounce',
+            'source' => 'mailgun',
+            'meta_json' => json_encode(['code' => '550'], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES),
+            'created_at' => now(),
+            'updated_at' => now(),
+        ]);
+
+        $response = $this->postJson('/api/v0.3/email/capture', [
+            'email' => $email,
+            'surface' => 'help',
+        ]);
+
+        $response->assertOk()
+            ->assertJsonPath('ok', true)
+            ->assertJsonPath('status', 'suppressed')
+            ->assertJsonPath('preferences.report_recovery', true);
+    }
+}

--- a/backend/tests/Feature/V0_3/EmailPreferencesContractTest.php
+++ b/backend/tests/Feature/V0_3/EmailPreferencesContractTest.php
@@ -1,0 +1,64 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\V0_3;
+
+use App\Services\Email\EmailPreferenceService;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\DB;
+use Tests\TestCase;
+
+final class EmailPreferencesContractTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_email_preferences_get_returns_masked_email_and_defaults(): void
+    {
+        /** @var EmailPreferenceService $preferences */
+        $preferences = app(EmailPreferenceService::class);
+        $token = $preferences->issueTokenForEmail('buyer@example.com', [
+            'surface' => 'help',
+            'entrypoint' => 'help_center',
+        ]);
+
+        $response = $this->getJson('/api/v0.3/email/preferences?token='.urlencode($token));
+
+        $response->assertOk()
+            ->assertJsonPath('ok', true)
+            ->assertJsonPath('email_masked', 'bu***@example.com')
+            ->assertJsonPath('preferences.marketing_updates', false)
+            ->assertJsonPath('preferences.report_recovery', true)
+            ->assertJsonPath('preferences.product_updates', false);
+    }
+
+    public function test_email_preferences_post_updates_contract_and_subscriber_state(): void
+    {
+        /** @var EmailPreferenceService $preferences */
+        $preferences = app(EmailPreferenceService::class);
+        $token = $preferences->issueTokenForEmail('buyer@example.com');
+
+        $response = $this->postJson('/api/v0.3/email/preferences', [
+            'token' => $token,
+            'marketing_updates' => true,
+            'report_recovery' => false,
+            'product_updates' => true,
+        ]);
+
+        $response->assertOk()
+            ->assertJsonPath('ok', true)
+            ->assertJsonPath('preferences.marketing_updates', true)
+            ->assertJsonPath('preferences.report_recovery', false)
+            ->assertJsonPath('preferences.product_updates', true);
+
+        $subscriber = DB::table('email_subscribers')->first();
+        $preference = DB::table('email_preferences')->first();
+        $this->assertNotNull($subscriber);
+        $this->assertNotNull($preference);
+        $this->assertTrue((bool) ($subscriber->marketing_consent ?? false));
+        $this->assertFalse((bool) ($subscriber->transactional_recovery_enabled ?? true));
+        $this->assertTrue((bool) ($preference->marketing_updates ?? false));
+        $this->assertFalse((bool) ($preference->report_recovery ?? true));
+        $this->assertTrue((bool) ($preference->product_updates ?? false));
+    }
+}

--- a/backend/tests/Feature/V0_3/EmailUnsubscribeContractTest.php
+++ b/backend/tests/Feature/V0_3/EmailUnsubscribeContractTest.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\V0_3;
+
+use App\Services\Email\EmailPreferenceService;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\DB;
+use Tests\TestCase;
+
+final class EmailUnsubscribeContractTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_email_unsubscribe_turns_off_all_preferences(): void
+    {
+        /** @var EmailPreferenceService $preferences */
+        $preferences = app(EmailPreferenceService::class);
+        $token = $preferences->issueTokenForEmail('buyer@example.com', [
+            'marketing_consent' => true,
+        ]);
+
+        $response = $this->postJson('/api/v0.3/email/unsubscribe', [
+            'token' => $token,
+            'reason' => 'user_request',
+        ]);
+
+        $response->assertOk()
+            ->assertJson([
+                'ok' => true,
+                'status' => 'unsubscribed',
+            ]);
+
+        $subscriber = DB::table('email_subscribers')->first();
+        $preference = DB::table('email_preferences')->first();
+        $this->assertNotNull($subscriber);
+        $this->assertNotNull($preference);
+        $this->assertFalse((bool) ($subscriber->marketing_consent ?? true));
+        $this->assertFalse((bool) ($subscriber->transactional_recovery_enabled ?? true));
+        $this->assertNotNull($subscriber->unsubscribed_at);
+        $this->assertFalse((bool) ($preference->marketing_updates ?? true));
+        $this->assertFalse((bool) ($preference->report_recovery ?? true));
+        $this->assertFalse((bool) ($preference->product_updates ?? true));
+    }
+}

--- a/backend/tests/Feature/V0_3/PaymentWebhookControllerTest.php
+++ b/backend/tests/Feature/V0_3/PaymentWebhookControllerTest.php
@@ -16,8 +16,8 @@ use Tests\TestCase;
 
 final class PaymentWebhookControllerTest extends TestCase
 {
-    use RefreshDatabase;
     use MockeryPHPUnitIntegration;
+    use RefreshDatabase;
 
     public function test_unsigned_webhook_request_is_rejected_without_500(): void
     {
@@ -206,7 +206,7 @@ final class PaymentWebhookControllerTest extends TestCase
 
     public function test_valid_billing_signature_returns_200_and_writes_or_hits_idempotency(): void
     {
-        (new Pr19CommerceSeeder())->run();
+        (new Pr19CommerceSeeder)->run();
 
         config([
             'services.billing.webhook_secret' => 'billing_secret_sec002',
@@ -263,10 +263,12 @@ final class PaymentWebhookControllerTest extends TestCase
         $second->assertJsonMissingPath('error');
         $this->assertNoLegacyErrorKey($second);
 
+        $this->assertSame('fulfilled', (string) DB::table('orders')->where('order_no', $orderNo)->value('status'));
         $this->assertSame(1, DB::table('payment_events')
             ->where('provider', 'billing')
             ->where('provider_event_id', 'evt_sec002_bill_1')
             ->count());
+        $this->assertSame(0, DB::table('email_outbox')->count());
     }
 
     private function postSignedBilling(string $raw, string $secret): TestResponse
@@ -301,7 +303,7 @@ final class PaymentWebhookControllerTest extends TestCase
     private function encodePayload(array $payload): string
     {
         $raw = json_encode($payload, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES);
-        if (!is_string($raw)) {
+        if (! is_string($raw)) {
             self::fail('json_encode payload failed.');
         }
 


### PR DESCRIPTION
## Summary

- add transactional email capture, claim recovery request, preferences, and unsubscribe backend contracts
- append recovery state to order read/lookup delivery payloads
- append attribution into payment_success and report_claim email outbox payloads without leaking plaintext email
- add migrations, models, services, OpenAPI snapshot, and contract/regression tests

## Tests

- `php artisan route:list | rg "orders/lookup|orders/.*/resend|claim/report|email/capture|email/preferences|email/unsubscribe"`
- `php artisan migrate`
- `php artisan test tests/Feature/FmTokenOptionalAuthMiddlewareTest.php`
- `php artisan test tests/Feature/V0_3/EmailCaptureContractTest.php tests/Feature/V0_3/ClaimReportEmailRequestTest.php tests/Feature/V0_3/EmailPreferencesContractTest.php tests/Feature/V0_3/EmailUnsubscribeContractTest.php tests/Feature/Email/EmailOutboxAttributionTest.php tests/Feature/Email/EmailOutboxNoPlaintextPayloadTest.php tests/Feature/V0_3/CommerceOrderLookupSecurityTest.php tests/Feature/V0_3/CommerceOrderResendTest.php tests/Feature/V0_3/CommerceOrderReadFallbackTest.php tests/Feature/V0_3/AttemptReportPaymentUnlockFlowTest.php tests/Feature/Commerce/BigFiveUnlockDeliveryPipelineTest.php tests/Feature/V0_3/PaymentWebhookControllerTest.php tests/Feature/Report/ReportPdfCrossScaleDeliveryTest.php`
- `php artisan test tests/Feature/OpenApiDiffTest.php`
- `./vendor/bin/pint routes/api.php app/Http/Controllers/API/V0_3/ClaimController.php app/Http/Controllers/API/V0_3/CommerceController.php app/Http/Controllers/API/V0_3/EmailCaptureController.php app/Http/Controllers/API/V0_3/EmailPreferenceController.php app/Http/Requests/V0_3/EmailCaptureRequest.php app/Http/Requests/V0_3/ClaimReportRequest.php app/Http/Requests/V0_3/EmailPreferencesUpdateRequest.php app/Http/Requests/V0_3/EmailUnsubscribeRequest.php app/Services/Commerce/OrderManager.php app/Services/Email/EmailCaptureService.php app/Services/Email/EmailPreferenceService.php app/Services/Email/EmailOutboxService.php app/Internal/Commerce/PaymentWebhookHandlerCore.php app/Models/EmailSubscriber.php app/Models/EmailPreference.php app/Models/EmailSuppression.php database/migrations/2026_03_12_010000_create_email_subscribers_table.php database/migrations/2026_03_12_010100_create_email_preferences_table.php database/migrations/2026_03_12_010200_create_email_suppressions_table.php tests/Feature/V0_3/EmailCaptureContractTest.php tests/Feature/V0_3/ClaimReportEmailRequestTest.php tests/Feature/V0_3/EmailPreferencesContractTest.php tests/Feature/V0_3/EmailUnsubscribeContractTest.php tests/Feature/Email/EmailOutboxAttributionTest.php tests/Feature/Email/EmailOutboxNoPlaintextPayloadTest.php tests/Feature/V0_3/CommerceOrderLookupSecurityTest.php tests/Feature/V0_3/CommerceOrderResendTest.php tests/Feature/Commerce/BigFiveUnlockDeliveryPipelineTest.php tests/Feature/V0_3/PaymentWebhookControllerTest.php`
- `bash backend/scripts/export_openapi.sh`
- `bash backend/scripts/ci_verify_mbti.sh`
