### PR TITLE
feat(email): activate transactional delivery, templates, and suppression flow

### DIFF
--- a/backend/app/Console/Commands/FapEmailOutboxSend.php
+++ b/backend/app/Console/Commands/FapEmailOutboxSend.php
@@ -1,20 +1,25 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Console\Commands;
 
-use App\Support\PiiCipher;
-use App\Support\PiiReadFallbackMonitor;
+use App\Services\Email\EmailOutboxService;
+use App\Support\RuntimeConfig;
 use Illuminate\Console\Command;
-use Illuminate\Support\Facades\DB;
-use Illuminate\Support\Facades\Mail;
 use Illuminate\Support\Facades\Schema;
-use Illuminate\Support\Facades\View;
 
 class FapEmailOutboxSend extends Command
 {
     protected $signature = 'email:outbox-send {--limit=50}';
 
-    protected $description = 'Send pending email outbox rows using the log mailer.';
+    protected $description = 'Send pending email outbox rows using the configured mailer.';
+
+    public function __construct(
+        private readonly EmailOutboxService $emailOutbox,
+    ) {
+        parent::__construct();
+    }
 
     public function handle(): int
     {
@@ -30,410 +35,80 @@ class FapEmailOutboxSend extends Command
             return Command::SUCCESS;
         }
 
-        $limit = (int) $this->option('limit');
-        if ($limit <= 0) {
-            $limit = 50;
-        }
-        if ($limit > 500) {
-            $limit = 500;
+        $limit = $this->normalizeLimit((int) $this->option('limit'));
+        $mailer = $this->resolveMailer();
+        if (! $this->canUseMailer($mailer)) {
+            $this->warn("Configured mailer [{$mailer}] is not safe for this environment.");
+
+            return Command::SUCCESS;
         }
 
-        $rows = DB::table('email_outbox')
-            ->where('status', 'pending')
-            ->where(function ($q) {
-                $q->whereNull('claim_expires_at')
-                    ->orWhere('claim_expires_at', '>', now());
-            })
-            ->orderBy('created_at')
-            ->limit($limit)
-            ->get();
-
-        if ($rows->isEmpty()) {
+        $result = $this->emailOutbox->sendPending($limit, $mailer);
+        if (($result['processed'] ?? 0) < 1) {
             $this->info('No pending outbox rows.');
 
             return Command::SUCCESS;
         }
 
-        $sent = 0;
-        $skipped = 0;
-
-        foreach ($rows as $row) {
-            $payload = $this->decodePayloadFromRow($row);
-            $email = $this->resolveRecipientEmail($row, $payload);
-            if ($email === '') {
-                $skipped++;
-
-                continue;
-            }
-
-            $locale = $this->normalizeLocale((string) ($row->locale ?? ($payload['locale'] ?? 'en')));
-            $templateKey = $this->resolveTemplateKey($row, $payload);
-            $subject = $this->resolveSubject($row, $payload, $templateKey, $locale);
-            $bodyHtml = $this->resolveBodyHtml($row, $payload, $templateKey, $locale);
-            $bodyText = $this->resolveBodyText($payload);
-
-            try {
-                if ($bodyHtml !== '') {
-                    Mail::mailer('log')->html($bodyHtml, function ($m) use ($email, $subject): void {
-                        $m->to($email)->subject($subject);
-                    });
-                } else {
-                    Mail::mailer('log')->raw($bodyText, function ($m) use ($email, $subject): void {
-                        $m->to($email)->subject($subject);
-                    });
-                }
-            } catch (\Throwable $e) {
-                $this->warn('Send failed for outbox id='.(string) ($row->id ?? ''));
-
-                continue;
-            }
-
-            $update = [
-                'status' => 'sent',
-                'updated_at' => now(),
-            ];
-            if (Schema::hasColumn('email_outbox', 'locale')) {
-                $update['locale'] = $locale;
-            }
-            if (Schema::hasColumn('email_outbox', 'template_key')) {
-                $update['template_key'] = $templateKey;
-            }
-            if (Schema::hasColumn('email_outbox', 'to_email')) {
-                $update['to_email'] = $email;
-            }
-            if (Schema::hasColumn('email_outbox', 'subject')) {
-                $update['subject'] = $subject;
-            }
-            if (Schema::hasColumn('email_outbox', 'body_html') && $bodyHtml !== '') {
-                $update['body_html'] = $bodyHtml;
-            }
-            if (Schema::hasColumn('email_outbox', 'sent_at')) {
-                $update['sent_at'] = now();
-            }
-
-            DB::table('email_outbox')
-                ->where('id', $row->id)
-                ->where('status', 'pending')
-                ->update($update);
-
-            $sent++;
-        }
-
-        $this->info("Sent {$sent}, skipped {$skipped}.");
+        $this->info(sprintf(
+            'Mailer %s: sent %d, blocked %d, failed %d.',
+            (string) ($result['mailer'] ?? $mailer),
+            (int) ($result['sent'] ?? 0),
+            (int) ($result['blocked'] ?? 0),
+            (int) ($result['failed'] ?? 0),
+        ));
 
         return Command::SUCCESS;
     }
 
-    private function decodePayload($raw): array
-    {
-        if (is_array($raw)) {
-            return $raw;
-        }
-        if (! is_string($raw) || $raw === '') {
-            return [];
-        }
-
-        $decoded = json_decode($raw, true);
-
-        return is_array($decoded) ? $decoded : [];
-    }
-
-    private function decodePayloadFromRow(object $row): array
-    {
-        $pii = app(PiiCipher::class);
-        $monitor = app(PiiReadFallbackMonitor::class);
-
-        if (property_exists($row, 'payload_enc')) {
-            $decrypted = $pii->decrypt((string) ($row->payload_enc ?? ''));
-            if ($decrypted !== null) {
-                $decoded = json_decode($decrypted, true);
-                if (is_array($decoded)) {
-                    $monitor->record('email_outbox.payload_read', false);
-
-                    return $decoded;
-                }
-            }
-        }
-
-        $decoded = $this->decodePayload($row->payload_json ?? null);
-        $monitor->record('email_outbox.payload_read', $decoded !== []);
-
-        return $decoded;
-    }
-
     private function outboxSendEnabled(): bool
     {
-        $raw = \App\Support\RuntimeConfig::value('EMAIL_OUTBOX_SEND', '0');
+        $raw = RuntimeConfig::value('EMAIL_OUTBOX_SEND', '0');
 
         return filter_var($raw, FILTER_VALIDATE_BOOLEAN);
     }
 
-    /**
-     * @param  array<string,mixed>  $payload
-     */
-    private function resolveRecipientEmail(object $row, array $payload): string
+    private function normalizeLimit(int $limit): int
     {
-        $pii = app(PiiCipher::class);
-        $monitor = app(PiiReadFallbackMonitor::class);
-
-        $encryptedCandidates = [
-            $this->decryptOrEmpty($pii, property_exists($row, 'to_email_enc') ? ($row->to_email_enc ?? null) : null),
-            $this->decryptOrEmpty($pii, property_exists($row, 'email_enc') ? ($row->email_enc ?? null) : null),
-        ];
-        foreach ($encryptedCandidates as $candidate) {
-            $value = trim((string) $candidate);
-            if ($value !== '') {
-                $monitor->record('email_outbox.recipient_read', false);
-
-                return $value;
-            }
+        if ($limit <= 0) {
+            return 50;
         }
 
-        $candidates = [
-            $row->to_email ?? null,
-            $row->email ?? null,
-            $payload['to_email'] ?? null,
-            $payload['email'] ?? null,
-        ];
-        foreach ($candidates as $candidate) {
-            $value = trim((string) $candidate);
-            if ($value !== '') {
-                $monitor->record('email_outbox.recipient_read', true);
-
-                return $value;
-            }
-        }
-
-        $monitor->record('email_outbox.recipient_read', false);
-
-        return '';
+        return min($limit, 500);
     }
 
-    private function decryptOrEmpty(PiiCipher $pii, mixed $ciphertext): string
+    private function resolveMailer(): string
     {
-        $decrypted = $pii->decrypt(is_string($ciphertext) ? $ciphertext : null);
+        $configured = trim((string) config('mail.default', 'log'));
+        if ($configured === '') {
+            $configured = 'log';
+        }
 
-        return $decrypted !== null ? trim($decrypted) : '';
+        if (app()->environment('testing') && $this->isKnownExternalMailer($configured)) {
+            return 'array';
+        }
+
+        return $configured;
     }
 
-    /**
-     * @param  array<string,mixed>  $payload
-     */
-    private function resolveTemplateKey(object $row, array $payload): string
+    private function canUseMailer(string $mailer): bool
     {
-        $candidates = [
-            $row->template_key ?? null,
-            $row->template ?? null,
-            $payload['template_key'] ?? null,
-            $payload['template'] ?? null,
-        ];
-        foreach ($candidates as $candidate) {
-            $value = strtolower(trim((string) $candidate));
-            if ($value !== '') {
-                return $value;
-            }
+        $mailers = config('mail.mailers', []);
+        if (! is_array($mailers) || ! array_key_exists($mailer, $mailers)) {
+            return false;
         }
 
-        return 'report_claim';
+        if (app()->environment('testing') && $this->isKnownExternalMailer($mailer)) {
+            return false;
+        }
+
+        return true;
     }
 
-    /**
-     * @param  array<string,mixed>  $payload
-     */
-    private function resolveSubject(object $row, array $payload, string $templateKey, string $locale): string
+    private function isKnownExternalMailer(string $mailer): bool
     {
-        $candidates = [
-            $row->subject ?? null,
-            $payload['subject'] ?? null,
-        ];
-        foreach ($candidates as $candidate) {
-            $value = trim((string) $candidate);
-            if ($value !== '') {
-                return $value;
-            }
-        }
+        $transport = trim((string) config("mail.mailers.{$mailer}.transport", ''));
 
-        $isZh = $this->languageFromLocale($locale) === 'zh';
-
-        return match ($templateKey) {
-            'payment_success' => $isZh ? '支付成功与报告交付通知' : 'Payment successful and report delivered',
-            'refund_notice' => $isZh ? '退款处理通知' : 'Refund processing notice',
-            'support_contact' => $isZh ? '客服联系信息' : 'Support contact details',
-            'report_claim' => $isZh ? '你的报告链接已准备好' : 'Your report link is ready',
-            default => $isZh ? 'FermatMind 通知' : 'FermatMind notification',
-        };
-    }
-
-    /**
-     * @param  array<string,mixed>  $payload
-     */
-    private function resolveBodyHtml(object $row, array $payload, string $templateKey, string $locale): string
-    {
-        $existing = trim((string) ($row->body_html ?? ''));
-        if ($existing !== '') {
-            return $existing;
-        }
-
-        $inline = trim((string) ($payload['body_html'] ?? ''));
-        if ($inline !== '') {
-            return $inline;
-        }
-
-        $view = $this->resolveEmailViewName($templateKey, $locale);
-        if ($view === '') {
-            return '';
-        }
-        if (! View::exists($view)) {
-            return '';
-        }
-
-        return trim((string) view($view, $this->buildTemplateData($row, $payload, $locale))->render());
-    }
-
-    /**
-     * @param  array<string,mixed>  $payload
-     */
-    private function resolveBodyText(array $payload): string
-    {
-        $body = trim((string) ($payload['body'] ?? ''));
-        if ($body !== '') {
-            return $body;
-        }
-
-        $claimUrl = trim((string) ($payload['claim_url'] ?? ''));
-        if ($claimUrl !== '') {
-            return "Claim link: {$claimUrl}";
-        }
-
-        $reportUrl = trim((string) ($payload['report_url'] ?? ''));
-        if ($reportUrl !== '') {
-            return "Report link: {$reportUrl}";
-        }
-
-        return 'Please contact support@fermatmind.com for assistance.';
-    }
-
-    private function resolveEmailViewName(string $templateKey, string $locale): string
-    {
-        $lang = $this->languageFromLocale($locale);
-        $supported = ['payment_success', 'refund_notice', 'support_contact'];
-        if (! in_array($templateKey, $supported, true)) {
-            return '';
-        }
-
-        $view = "emails.{$lang}.{$templateKey}";
-        if (View::exists($view)) {
-            return $view;
-        }
-
-        $fallback = "emails.en.{$templateKey}";
-
-        return View::exists($fallback) ? $fallback : '';
-    }
-
-    /**
-     * @param  array<string,mixed>  $payload
-     * @return array<string,mixed>
-     */
-    private function buildTemplateData(object $row, array $payload, string $locale): array
-    {
-        $base = rtrim((string) config('app.url', 'http://localhost'), '/');
-        $legalUrls = $this->resolveLegalUrls($locale);
-        $supportEmail = $this->resolveSupportEmail();
-
-        $reportUrl = trim((string) ($payload['report_url'] ?? ''));
-        $claimUrl = trim((string) ($payload['claim_url'] ?? ''));
-        if ($reportUrl === '' && $claimUrl !== '') {
-            $reportUrl = $claimUrl;
-        }
-
-        return [
-            'locale' => $locale,
-            'orderNo' => trim((string) ($payload['order_no'] ?? $payload['orderNo'] ?? '')),
-            'attemptId' => trim((string) ($payload['attempt_id'] ?? '')),
-            'productSummary' => trim((string) ($payload['product_summary'] ?? $payload['item_summary'] ?? '')),
-            'reportUrl' => $this->absoluteUrl($reportUrl, $base),
-            'refundStatus' => trim((string) ($payload['refund_status'] ?? '')),
-            'refundEta' => trim((string) ($payload['refund_eta'] ?? '')),
-            'supportEmail' => $supportEmail,
-            'supportTicketUrl' => $this->absoluteUrl((string) ($payload['support_ticket_url'] ?? ''), $base),
-            'privacyUrl' => $legalUrls['privacy'],
-            'termsUrl' => $legalUrls['terms'],
-            'refundUrl' => $legalUrls['refund'],
-            'outboxId' => trim((string) ($row->id ?? '')),
-        ];
-    }
-
-    private function normalizeLocale(string $locale): string
-    {
-        $locale = trim(str_replace('_', '-', $locale));
-        if ($locale === '') {
-            return 'en';
-        }
-
-        $lang = strtolower((string) explode('-', $locale)[0]);
-
-        return $lang === 'zh' ? 'zh-CN' : 'en';
-    }
-
-    private function languageFromLocale(string $locale): string
-    {
-        return strtolower((string) explode('-', $this->normalizeLocale($locale))[0]) === 'zh'
-            ? 'zh'
-            : 'en';
-    }
-
-    /**
-     * @return array{terms:string,privacy:string,refund:string}
-     */
-    private function resolveLegalUrls(string $locale): array
-    {
-        $appUrl = rtrim((string) config('app.url', 'http://localhost'), '/');
-        $global = [
-            'terms' => trim((string) config('regions.regions.US.legal_urls.terms', $appUrl.'/terms')),
-            'privacy' => trim((string) config('regions.regions.US.legal_urls.privacy', $appUrl.'/privacy')),
-            'refund' => trim((string) config('regions.regions.US.legal_urls.refund', $appUrl.'/refund')),
-        ];
-        $cn = [
-            'terms' => trim((string) config('regions.regions.CN_MAINLAND.legal_urls.terms', $appUrl.'/zh/terms')),
-            'privacy' => trim((string) config('regions.regions.CN_MAINLAND.legal_urls.privacy', $appUrl.'/zh/privacy')),
-            'refund' => trim((string) config('regions.regions.CN_MAINLAND.legal_urls.refund', $appUrl.'/zh/refund')),
-        ];
-
-        $target = $this->languageFromLocale($locale) === 'zh' ? $cn : $global;
-
-        return [
-            'terms' => $target['terms'] !== '' ? $target['terms'] : $global['terms'],
-            'privacy' => $target['privacy'] !== '' ? $target['privacy'] : $global['privacy'],
-            'refund' => $target['refund'] !== '' ? $target['refund'] : $global['refund'],
-        ];
-    }
-
-    private function resolveSupportEmail(): string
-    {
-        $support = trim((string) config('fap.support_email', ''));
-        if ($support !== '') {
-            return $support;
-        }
-
-        $from = trim((string) config('mail.from.address', ''));
-        if ($from !== '') {
-            return $from;
-        }
-
-        return 'support@fermatmind.com';
-    }
-
-    private function absoluteUrl(string $url, string $base): string
-    {
-        $url = trim($url);
-        if ($url === '') {
-            return '';
-        }
-        if (preg_match('#^https?://#i', $url) === 1) {
-            return $url;
-        }
-
-        return rtrim($base, '/').'/'.ltrim($url, '/');
+        return in_array($transport, ['smtp', 'ses', 'ses-v2', 'postmark', 'resend', 'sendmail', 'failover', 'roundrobin'], true);
     }
 }

--- a/backend/app/Console/Kernel.php
+++ b/backend/app/Console/Kernel.php
@@ -148,6 +148,7 @@ class Kernel extends ConsoleKernel
         // 示例（需要就开）：
         // $schedule->command('fap:self-check')->dailyAt('03:10');
         // $schedule->command('fap:validate-report --attempt=...')->hourly();
+        $schedule->command('email:outbox-send')->everyMinute()->withoutOverlapping();
         $schedule->command('storage:prune --execute --scope=reports_backups --strategy=strict')->dailyAt('03:10')->withoutOverlapping();
         $schedule->command('storage:prune --execute --scope=content_releases_retention')->dailyAt('03:20')->withoutOverlapping();
         $schedule->command('storage:prune --execute --scope=legacy_private_private_cleanup')->dailyAt('03:30')->withoutOverlapping();

--- a/backend/app/Services/Email/EmailOutboxService.php
+++ b/backend/app/Services/Email/EmailOutboxService.php
@@ -4,7 +4,10 @@ namespace App\Services\Email;
 
 use App\Support\PiiCipher;
 use App\Support\PiiReadFallbackMonitor;
+use App\Support\RuntimeConfig;
 use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Mail;
+use Illuminate\Support\Facades\View;
 use Illuminate\Support\Str;
 
 class EmailOutboxService
@@ -12,6 +15,7 @@ class EmailOutboxService
     public function __construct(
         private readonly PiiCipher $piiCipher,
         private readonly PiiReadFallbackMonitor $fallbackMonitor,
+        private readonly EmailPreferenceService $emailPreferences,
     ) {}
 
     /**
@@ -380,6 +384,339 @@ class EmailOutboxService
     }
 
     /**
+     * @return array{mailer:string,sent:int,blocked:int,failed:int,processed:int}
+     */
+    public function sendPending(int $limit, string $mailer): array
+    {
+        $limit = max(1, min($limit, 500));
+
+        $rows = DB::table('email_outbox')
+            ->where('status', 'pending')
+            ->where(function ($query): void {
+                $query->whereNull('claim_expires_at')
+                    ->orWhere('claim_expires_at', '>', now());
+            })
+            ->orderBy('created_at')
+            ->limit($limit)
+            ->get();
+
+        $sent = 0;
+        $blocked = 0;
+        $failed = 0;
+
+        foreach ($rows as $row) {
+            $prepared = $this->preparePendingDelivery($row);
+            if (! ($prepared['ok'] ?? false)) {
+                $this->markDeliveryFailed(
+                    $row,
+                    $prepared['payload'] ?? [],
+                    (string) ($prepared['locale'] ?? 'en'),
+                    (string) ($prepared['template_key'] ?? ''),
+                    (string) ($prepared['subject'] ?? ''),
+                    (string) ($prepared['body_html'] ?? ''),
+                    (string) ($prepared['error_code'] ?? 'invalid_payload'),
+                    (string) ($prepared['error_message'] ?? 'Unable to prepare email delivery.'),
+                    $mailer
+                );
+                $failed++;
+
+                continue;
+            }
+
+            $payload = $prepared['payload'];
+            $locale = (string) $prepared['locale'];
+            $templateKey = (string) $prepared['template_key'];
+            $subject = (string) $prepared['subject'];
+            $bodyHtml = (string) $prepared['body_html'];
+            $bodyText = (string) $prepared['body_text'];
+            $recipientEmail = (string) $prepared['recipient_email'];
+            $guard = is_array($prepared['guard'] ?? null) ? $prepared['guard'] : [];
+
+            if (! ($guard['allowed'] ?? false)) {
+                $this->markDeliveryBlocked(
+                    $row,
+                    $payload,
+                    $locale,
+                    $templateKey,
+                    $subject,
+                    $bodyHtml,
+                    (string) ($guard['status'] ?? 'suppressed'),
+                    (string) ($guard['reason'] ?? 'delivery_blocked'),
+                    $mailer
+                );
+                $blocked++;
+
+                continue;
+            }
+
+            try {
+                $this->sendMessage($mailer, $recipientEmail, $subject, $bodyHtml, $bodyText);
+            } catch (\Throwable $e) {
+                $this->markDeliveryFailed(
+                    $row,
+                    $payload,
+                    $locale,
+                    $templateKey,
+                    $subject,
+                    $bodyHtml,
+                    'send_failed',
+                    $e->getMessage(),
+                    $mailer
+                );
+                $failed++;
+
+                continue;
+            }
+
+            $this->markDeliverySent(
+                $row,
+                $payload,
+                $locale,
+                $templateKey,
+                $recipientEmail,
+                $subject,
+                $bodyHtml,
+                $mailer
+            );
+            $sent++;
+        }
+
+        return [
+            'mailer' => $mailer,
+            'sent' => $sent,
+            'blocked' => $blocked,
+            'failed' => $failed,
+            'processed' => $sent + $blocked + $failed,
+        ];
+    }
+
+    /**
+     * @return array{
+     *     ok:bool,
+     *     payload:array<string,mixed>,
+     *     locale:string,
+     *     template_key:string,
+     *     subject:string,
+     *     body_html:string,
+     *     body_text:string,
+     *     recipient_email:string,
+     *     guard:array<string,mixed>,
+     *     error_code?:string,
+     *     error_message?:string
+     * }
+     */
+    private function preparePendingDelivery(object $row): array
+    {
+        $payload = $this->decodePayloadFromRow($row);
+        $locale = $this->normalizeLocale((string) ($row->locale ?? ($payload['locale'] ?? 'en')));
+        $templateKey = $this->resolveTemplateKeyFromRow($row, $payload);
+        $subject = $this->resolveSubjectFromRow($row, $payload, $templateKey, $locale);
+        $recipientEmail = $this->extractRecipientEmailFromOutboxRow($row, $payload);
+
+        if ($recipientEmail === '') {
+            return [
+                'ok' => false,
+                'payload' => $payload,
+                'locale' => $locale,
+                'template_key' => $templateKey,
+                'subject' => $subject,
+                'body_html' => '',
+                'body_text' => '',
+                'recipient_email' => '',
+                'guard' => [],
+                'error_code' => 'recipient_missing',
+                'error_message' => 'Recipient email is missing.',
+            ];
+        }
+
+        $guard = $this->emailPreferences->deliveryPolicyForEmail($recipientEmail, $templateKey);
+        $bodyHtml = $this->resolveBodyHtmlFromRow($row, $payload, $templateKey, $locale, $recipientEmail, $guard);
+        $bodyText = $this->resolveBodyTextFromPayload($payload, $locale, $templateKey, $recipientEmail);
+
+        return [
+            'ok' => true,
+            'payload' => $payload,
+            'locale' => $locale,
+            'template_key' => $templateKey,
+            'subject' => $subject,
+            'body_html' => $bodyHtml,
+            'body_text' => $bodyText,
+            'recipient_email' => $recipientEmail,
+            'guard' => $guard,
+        ];
+    }
+
+    private function sendMessage(string $mailer, string $recipientEmail, string $subject, string $bodyHtml, string $bodyText): void
+    {
+        if ($bodyHtml !== '') {
+            Mail::mailer($mailer)->html($bodyHtml, function ($message) use ($recipientEmail, $subject): void {
+                $message->to($recipientEmail)->subject($subject);
+            });
+
+            return;
+        }
+
+        Mail::mailer($mailer)->raw($bodyText, function ($message) use ($recipientEmail, $subject): void {
+            $message->to($recipientEmail)->subject($subject);
+        });
+    }
+
+    /**
+     * @param  array<string,mixed>  $payload
+     */
+    private function markDeliverySent(
+        object $row,
+        array $payload,
+        string $locale,
+        string $templateKey,
+        string $recipientEmail,
+        string $subject,
+        string $bodyHtml,
+        string $mailer
+    ): void {
+        $emailHash = $this->piiCipher->emailHash($recipientEmail);
+        $payload = $this->appendExecutionMeta($payload, [
+            'status' => 'sent',
+            'mailer' => $mailer,
+            'guard' => 'allowed',
+            'attempted_at' => now()->toIso8601String(),
+        ]);
+
+        $update = [
+            'status' => 'sent',
+            'payload_json' => $this->encodePayloadJson($this->sanitizePayloadForJson($payload)),
+            'updated_at' => now(),
+        ];
+
+        if (\App\Support\SchemaBaseline::hasColumn('email_outbox', 'payload_enc')) {
+            $update['payload_enc'] = $this->encodePayloadEncrypted($payload);
+        }
+        if (\App\Support\SchemaBaseline::hasColumn('email_outbox', 'locale')) {
+            $update['locale'] = $locale;
+        }
+        if (\App\Support\SchemaBaseline::hasColumn('email_outbox', 'template_key')) {
+            $update['template_key'] = $templateKey;
+        }
+        if (\App\Support\SchemaBaseline::hasColumn('email_outbox', 'to_email')) {
+            $update['to_email'] = $this->maskedLegacyEmail($emailHash);
+        }
+        if (\App\Support\SchemaBaseline::hasColumn('email_outbox', 'subject')) {
+            $update['subject'] = $subject;
+        }
+        if (\App\Support\SchemaBaseline::hasColumn('email_outbox', 'body_html')) {
+            $update['body_html'] = $bodyHtml !== '' ? $bodyHtml : null;
+        }
+        if (\App\Support\SchemaBaseline::hasColumn('email_outbox', 'sent_at')) {
+            $update['sent_at'] = now();
+        }
+
+        DB::table('email_outbox')
+            ->where('id', $row->id)
+            ->where('status', 'pending')
+            ->update($update);
+    }
+
+    /**
+     * @param  array<string,mixed>  $payload
+     */
+    private function markDeliveryBlocked(
+        object $row,
+        array $payload,
+        string $locale,
+        string $templateKey,
+        string $subject,
+        string $bodyHtml,
+        string $status,
+        string $reason,
+        string $mailer
+    ): void {
+        $payload = $this->appendExecutionMeta($payload, [
+            'status' => $status,
+            'mailer' => $mailer,
+            'guard' => $reason,
+            'attempted_at' => now()->toIso8601String(),
+        ]);
+
+        $update = [
+            'status' => $status,
+            'payload_json' => $this->encodePayloadJson($this->sanitizePayloadForJson($payload)),
+            'updated_at' => now(),
+        ];
+
+        if (\App\Support\SchemaBaseline::hasColumn('email_outbox', 'payload_enc')) {
+            $update['payload_enc'] = $this->encodePayloadEncrypted($payload);
+        }
+        if (\App\Support\SchemaBaseline::hasColumn('email_outbox', 'locale')) {
+            $update['locale'] = $locale;
+        }
+        if (\App\Support\SchemaBaseline::hasColumn('email_outbox', 'template_key')) {
+            $update['template_key'] = $templateKey;
+        }
+        if (\App\Support\SchemaBaseline::hasColumn('email_outbox', 'subject')) {
+            $update['subject'] = $subject;
+        }
+        if (\App\Support\SchemaBaseline::hasColumn('email_outbox', 'body_html')) {
+            $update['body_html'] = $bodyHtml !== '' ? $bodyHtml : null;
+        }
+
+        DB::table('email_outbox')
+            ->where('id', $row->id)
+            ->where('status', 'pending')
+            ->update($update);
+    }
+
+    /**
+     * @param  array<string,mixed>  $payload
+     */
+    private function markDeliveryFailed(
+        object $row,
+        array $payload,
+        string $locale,
+        string $templateKey,
+        string $subject,
+        string $bodyHtml,
+        string $errorCode,
+        string $errorMessage,
+        string $mailer
+    ): void {
+        $payload = $this->appendExecutionMeta($payload, [
+            'status' => 'failed',
+            'mailer' => $mailer,
+            'guard' => 'send_failed',
+            'attempted_at' => now()->toIso8601String(),
+            'error_code' => $errorCode,
+            'error_message' => $this->truncateExecutionMessage($errorMessage),
+        ]);
+
+        $update = [
+            'status' => 'failed',
+            'payload_json' => $this->encodePayloadJson($this->sanitizePayloadForJson($payload)),
+            'updated_at' => now(),
+        ];
+
+        if (\App\Support\SchemaBaseline::hasColumn('email_outbox', 'payload_enc')) {
+            $update['payload_enc'] = $this->encodePayloadEncrypted($payload);
+        }
+        if (\App\Support\SchemaBaseline::hasColumn('email_outbox', 'locale')) {
+            $update['locale'] = $locale;
+        }
+        if (\App\Support\SchemaBaseline::hasColumn('email_outbox', 'template_key')) {
+            $update['template_key'] = $templateKey;
+        }
+        if (\App\Support\SchemaBaseline::hasColumn('email_outbox', 'subject')) {
+            $update['subject'] = $subject;
+        }
+        if (\App\Support\SchemaBaseline::hasColumn('email_outbox', 'body_html')) {
+            $update['body_html'] = $bodyHtml !== '' ? $bodyHtml : null;
+        }
+
+        DB::table('email_outbox')
+            ->where('id', $row->id)
+            ->where('status', 'pending')
+            ->update($update);
+    }
+
+    /**
      * Claim report by token.
      *
      * @return array {ok:bool, attempt_id?:string, report_url?:string, status?:int, error?:string, message?:string}
@@ -439,7 +776,8 @@ class EmailOutboxService
             }
         }
 
-        if (! empty($row->status) && $row->status !== 'pending') {
+        $status = strtolower(trim((string) ($row->status ?? 'pending')));
+        if ($status !== '' && ! in_array($status, ['pending', 'sent'], true)) {
             return [
                 'ok' => false,
                 'status' => 410,
@@ -469,7 +807,7 @@ class EmailOutboxService
 
         $updated = DB::table('email_outbox')
             ->where('id', $row->id)
-            ->where('status', 'pending')
+            ->whereIn('status', ['pending', 'sent'])
             ->update($update);
 
         if ($updated < 1) {
@@ -706,6 +1044,351 @@ class EmailOutboxService
     }
 
     /**
+     * @param  array<string,mixed>  $payload
+     */
+    private function resolveTemplateKeyFromRow(object $row, array $payload): string
+    {
+        foreach ([
+            $row->template_key ?? null,
+            $row->template ?? null,
+            $payload['template_key'] ?? null,
+            $payload['template'] ?? null,
+        ] as $candidate) {
+            $value = strtolower(trim((string) $candidate));
+            if ($value !== '') {
+                return $value;
+            }
+        }
+
+        return 'report_claim';
+    }
+
+    /**
+     * @param  array<string,mixed>  $payload
+     */
+    private function resolveSubjectFromRow(object $row, array $payload, string $templateKey, string $locale): string
+    {
+        foreach ([
+            $row->subject ?? null,
+            $payload['subject'] ?? null,
+        ] as $candidate) {
+            $value = trim((string) $candidate);
+            if ($value !== '') {
+                return $value;
+            }
+        }
+
+        return $this->defaultSubjectForTemplate($templateKey, $locale);
+    }
+
+    /**
+     * @param  array<string,mixed>  $payload
+     * @param  array<string,mixed>  $guard
+     */
+    private function resolveBodyHtmlFromRow(
+        object $row,
+        array $payload,
+        string $templateKey,
+        string $locale,
+        string $recipientEmail,
+        array $guard
+    ): string {
+        $existing = trim((string) ($row->body_html ?? ''));
+        if ($existing !== '') {
+            return $existing;
+        }
+
+        $inline = trim((string) ($payload['body_html'] ?? ''));
+        if ($inline !== '') {
+            return $inline;
+        }
+
+        $view = $this->resolveEmailViewName($templateKey, $locale);
+        if ($view === '' || ! View::exists($view)) {
+            return '';
+        }
+
+        return trim((string) view(
+            $view,
+            $this->buildTemplateData($row, $payload, $locale, $templateKey, $recipientEmail, $guard)
+        )->render());
+    }
+
+    /**
+     * @param  array<string,mixed>  $payload
+     */
+    private function resolveBodyTextFromPayload(array $payload, string $locale, string $templateKey, string $recipientEmail): string
+    {
+        $body = trim((string) ($payload['body'] ?? ''));
+        if ($body !== '') {
+            return $body;
+        }
+
+        $data = $this->buildTemplateData((object) [], $payload, $locale, $templateKey, $recipientEmail, []);
+        $reportUrl = trim((string) ($data['report_url'] ?? ''));
+        if ($reportUrl !== '') {
+            return $reportUrl;
+        }
+
+        $orderLookupUrl = trim((string) ($data['order_lookup_url'] ?? ''));
+        if ($orderLookupUrl !== '') {
+            return $orderLookupUrl;
+        }
+
+        return 'Please contact support@fermatmind.com for assistance.';
+    }
+
+    private function resolveEmailViewName(string $templateKey, string $locale): string
+    {
+        $lang = strtolower((string) explode('-', $this->normalizeLocale($locale))[0]) === 'zh'
+            ? 'zh'
+            : 'en';
+        $supported = ['payment_success', 'report_claim', 'refund_notice', 'support_contact'];
+        if (! in_array($templateKey, $supported, true)) {
+            return '';
+        }
+
+        $view = "emails.{$lang}.{$templateKey}";
+        if (View::exists($view)) {
+            return $view;
+        }
+
+        $fallback = "emails.en.{$templateKey}";
+
+        return View::exists($fallback) ? $fallback : '';
+    }
+
+    /**
+     * @param  array<string,mixed>  $payload
+     * @param  array<string,mixed>  $guard
+     * @return array<string,mixed>
+     */
+    private function buildTemplateData(
+        object $row,
+        array $payload,
+        string $locale,
+        string $templateKey,
+        string $recipientEmail,
+        array $guard
+    ): array {
+        $backendBaseUrl = rtrim((string) config('app.url', 'http://localhost'), '/');
+        $frontendBaseUrl = $this->frontendBaseUrl($backendBaseUrl);
+        $legalUrls = $this->resolveLegalUrls($locale, $frontendBaseUrl);
+        $supportEmail = $this->resolveSupportEmail();
+        $normalizedAttribution = $this->normalizeAttribution(is_array($payload['attribution'] ?? null) ? $payload['attribution'] : []);
+
+        $orderNo = trim((string) ($payload['order_no'] ?? $payload['orderNo'] ?? ''));
+        $attemptId = trim((string) ($payload['attempt_id'] ?? ''));
+        $reportUrl = $this->absoluteUrl((string) ($payload['report_url'] ?? ''), $backendBaseUrl);
+        $reportPdfUrl = $this->absoluteUrl((string) ($payload['report_pdf_url'] ?? ''), $backendBaseUrl);
+
+        $tokenContext = [
+            'locale' => $locale,
+            'surface' => 'email_delivery',
+            'order_no' => $orderNo !== '' ? $orderNo : null,
+            'attempt_id' => $attemptId !== '' ? $attemptId : null,
+            'share_id' => $normalizedAttribution['share_id'] ?? null,
+            'compare_invite_id' => $normalizedAttribution['compare_invite_id'] ?? null,
+            'entrypoint' => $normalizedAttribution['entrypoint'] ?? "email_{$templateKey}",
+            'referrer' => $normalizedAttribution['referrer'] ?? null,
+            'landing_path' => $normalizedAttribution['landing_path'] ?? null,
+            'utm' => $normalizedAttribution['utm'] ?? null,
+        ];
+        $preferenceToken = $this->emailPreferences->issueTokenForEmail($recipientEmail, $tokenContext);
+        $query = $this->deepLinkQuery($normalizedAttribution, $locale, $orderNo, $attemptId);
+
+        $orderLookupUrl = $this->frontendUrl($frontendBaseUrl, '/orders/lookup', $query);
+        $emailPreferencesUrl = $this->frontendUrl($frontendBaseUrl, '/email/preferences', ['token' => $preferenceToken] + $query);
+        $emailUnsubscribeUrl = $this->frontendUrl($frontendBaseUrl, '/email/unsubscribe', ['token' => $preferenceToken] + $query);
+
+        $data = [
+            'locale' => $locale,
+            'template_key' => $templateKey,
+            'orderNo' => $orderNo,
+            'order_no' => $orderNo,
+            'attemptId' => $attemptId,
+            'attempt_id' => $attemptId,
+            'productSummary' => trim((string) ($payload['product_summary'] ?? $payload['item_summary'] ?? '')),
+            'product_summary' => trim((string) ($payload['product_summary'] ?? $payload['item_summary'] ?? '')),
+            'reportUrl' => $reportUrl,
+            'report_url' => $reportUrl,
+            'reportPdfUrl' => $reportPdfUrl,
+            'report_pdf_url' => $reportPdfUrl,
+            'orderLookupUrl' => $orderLookupUrl,
+            'order_lookup_url' => $orderLookupUrl,
+            'emailPreferencesUrl' => $emailPreferencesUrl,
+            'email_preferences_url' => $emailPreferencesUrl,
+            'emailUnsubscribeUrl' => $emailUnsubscribeUrl,
+            'email_unsubscribe_url' => $emailUnsubscribeUrl,
+            'refundStatus' => trim((string) ($payload['refund_status'] ?? '')),
+            'refund_status' => trim((string) ($payload['refund_status'] ?? '')),
+            'refundEta' => trim((string) ($payload['refund_eta'] ?? '')),
+            'refund_eta' => trim((string) ($payload['refund_eta'] ?? '')),
+            'supportEmail' => $supportEmail,
+            'support_email' => $supportEmail,
+            'supportTicketUrl' => $this->absoluteUrl((string) ($payload['support_ticket_url'] ?? ''), $frontendBaseUrl),
+            'support_ticket_url' => $this->absoluteUrl((string) ($payload['support_ticket_url'] ?? ''), $frontendBaseUrl),
+            'privacyUrl' => $legalUrls['privacy'],
+            'privacy_url' => $legalUrls['privacy'],
+            'termsUrl' => $legalUrls['terms'],
+            'terms_url' => $legalUrls['terms'],
+            'refundUrl' => $legalUrls['refund'],
+            'refund_url' => $legalUrls['refund'],
+            'outboxId' => trim((string) ($row->id ?? '')),
+            'outbox_id' => trim((string) ($row->id ?? '')),
+            'guard' => $guard,
+            'attribution' => $normalizedAttribution,
+            'share_id' => $normalizedAttribution['share_id'] ?? '',
+            'compare_invite_id' => $normalizedAttribution['compare_invite_id'] ?? '',
+            'share_click_id' => $normalizedAttribution['share_click_id'] ?? '',
+            'entrypoint' => $normalizedAttribution['entrypoint'] ?? '',
+            'referrer' => $normalizedAttribution['referrer'] ?? '',
+            'landing_path' => $normalizedAttribution['landing_path'] ?? '',
+            'utm_source' => (string) data_get($normalizedAttribution, 'utm.source', ''),
+            'utm_medium' => (string) data_get($normalizedAttribution, 'utm.medium', ''),
+            'utm_campaign' => (string) data_get($normalizedAttribution, 'utm.campaign', ''),
+            'utm_term' => (string) data_get($normalizedAttribution, 'utm.term', ''),
+            'utm_content' => (string) data_get($normalizedAttribution, 'utm.content', ''),
+        ];
+
+        return $data;
+    }
+
+    /**
+     * @param  array<string,mixed>  $attribution
+     * @return array<string,string>
+     */
+    private function deepLinkQuery(array $attribution, string $locale, string $orderNo, string $attemptId): array
+    {
+        $query = [];
+
+        if ($locale !== '') {
+            $query['locale'] = $locale;
+        }
+        if ($orderNo !== '') {
+            $query['order_no'] = $orderNo;
+        }
+        if ($attemptId !== '') {
+            $query['attempt_id'] = $attemptId;
+        }
+
+        foreach (['share_id', 'compare_invite_id', 'share_click_id', 'entrypoint', 'referrer', 'landing_path'] as $field) {
+            $value = $this->trimOrNull((string) ($attribution[$field] ?? ''));
+            if ($value !== null) {
+                $query[$field] = $value;
+            }
+        }
+
+        if (is_array($attribution['utm'] ?? null)) {
+            foreach (['source', 'medium', 'campaign', 'term', 'content'] as $field) {
+                $value = $this->trimOrNull((string) (($attribution['utm'][$field] ?? '')));
+                if ($value !== null) {
+                    $query['utm_'.$field] = $value;
+                }
+            }
+        }
+
+        return $query;
+    }
+
+    /**
+     * @param  array<string,string>  $query
+     */
+    private function frontendUrl(string $base, string $path, array $query = []): string
+    {
+        $url = rtrim($base, '/').'/'.ltrim($path, '/');
+        if ($query === []) {
+            return $url;
+        }
+
+        return $url.'?'.http_build_query($query, '', '&', PHP_QUERY_RFC3986);
+    }
+
+    private function frontendBaseUrl(string $backendBaseUrl): string
+    {
+        $configured = trim((string) (RuntimeConfig::raw('FAP_BASE_URL') ?? ''));
+
+        return $configured !== '' ? rtrim($configured, '/') : $backendBaseUrl;
+    }
+
+    /**
+     * @return array{terms:string,privacy:string,refund:string}
+     */
+    private function resolveLegalUrls(string $locale, string $baseUrl): array
+    {
+        $global = [
+            'terms' => trim((string) config('regions.regions.US.legal_urls.terms', $baseUrl.'/terms')),
+            'privacy' => trim((string) config('regions.regions.US.legal_urls.privacy', $baseUrl.'/privacy')),
+            'refund' => trim((string) config('regions.regions.US.legal_urls.refund', $baseUrl.'/refund')),
+        ];
+        $cn = [
+            'terms' => trim((string) config('regions.regions.CN_MAINLAND.legal_urls.terms', $baseUrl.'/zh/terms')),
+            'privacy' => trim((string) config('regions.regions.CN_MAINLAND.legal_urls.privacy', $baseUrl.'/zh/privacy')),
+            'refund' => trim((string) config('regions.regions.CN_MAINLAND.legal_urls.refund', $baseUrl.'/zh/refund')),
+        ];
+
+        $target = strtolower((string) explode('-', $this->normalizeLocale($locale))[0]) === 'zh' ? $cn : $global;
+
+        return [
+            'terms' => $target['terms'] !== '' ? $target['terms'] : $global['terms'],
+            'privacy' => $target['privacy'] !== '' ? $target['privacy'] : $global['privacy'],
+            'refund' => $target['refund'] !== '' ? $target['refund'] : $global['refund'],
+        ];
+    }
+
+    private function resolveSupportEmail(): string
+    {
+        $support = trim((string) config('fap.support_email', ''));
+        if ($support !== '') {
+            return $support;
+        }
+
+        $from = trim((string) config('mail.from.address', ''));
+        if ($from !== '') {
+            return $from;
+        }
+
+        return 'support@fermatmind.com';
+    }
+
+    private function absoluteUrl(string $url, string $base): string
+    {
+        $url = trim($url);
+        if ($url === '') {
+            return '';
+        }
+        if (preg_match('#^https?://#i', $url) === 1) {
+            return $url;
+        }
+
+        return rtrim($base, '/').'/'.ltrim($url, '/');
+    }
+
+    /**
+     * @param  array<string,mixed>  $payload
+     * @param  array<string,mixed>  $meta
+     * @return array<string,mixed>
+     */
+    private function appendExecutionMeta(array $payload, array $meta): array
+    {
+        $payload['delivery_execution'] = $meta;
+
+        return $payload;
+    }
+
+    private function truncateExecutionMessage(string $message): string
+    {
+        $normalized = trim($message);
+        if ($normalized === '') {
+            return 'Unknown delivery error.';
+        }
+
+        return mb_strlen($normalized, 'UTF-8') > 512
+            ? mb_substr($normalized, 0, 512, 'UTF-8')
+            : $normalized;
+    }
+
+    /**
      * Keep payload_json as a minimal non-sensitive fallback while payload_enc remains authoritative.
      *
      * @param  array<string,mixed>  $payload
@@ -779,6 +1462,18 @@ class EmailOutboxService
         return $this->piiCipher->encrypt($encoded);
     }
 
+    private function normalizeLocale(string $locale): string
+    {
+        $locale = trim(str_replace('_', '-', $locale));
+        if ($locale === '') {
+            return 'en';
+        }
+
+        $lang = strtolower((string) explode('-', $locale)[0]);
+
+        return $lang === 'zh' ? 'zh-CN' : 'en';
+    }
+
     private function resolveAttemptLocale(string $attemptId): string
     {
         if (! \App\Support\SchemaBaseline::hasTable('attempts')) {
@@ -818,6 +1513,12 @@ class EmailOutboxService
         }
         if ($templateKey === 'payment_success') {
             return $lang === 'zh' ? '支付成功与报告交付通知' : 'Payment successful and report delivered';
+        }
+        if ($templateKey === 'refund_notice') {
+            return $lang === 'zh' ? '退款处理通知' : 'Refund processing notice';
+        }
+        if ($templateKey === 'support_contact') {
+            return $lang === 'zh' ? '客服联系信息' : 'Support contact details';
         }
 
         return $lang === 'zh' ? 'FermatMind 通知' : 'FermatMind notification';

--- a/backend/app/Services/Email/EmailPreferenceService.php
+++ b/backend/app/Services/Email/EmailPreferenceService.php
@@ -6,6 +6,7 @@ namespace App\Services\Email;
 
 use App\Models\EmailPreference;
 use App\Models\EmailSubscriber;
+use App\Models\EmailSuppression;
 use App\Support\PiiCipher;
 use Illuminate\Support\Str;
 
@@ -42,6 +43,91 @@ class EmailPreferenceService
         }
 
         return self::TOKEN_PREFIX.$this->base64UrlEncode($encrypted);
+    }
+
+    /**
+     * @return array{
+     *     allowed:bool,
+     *     status:string,
+     *     reason:?string,
+     *     suppressed:bool,
+     *     report_recovery:bool,
+     *     marketing_updates:bool,
+     *     product_updates:bool
+     * }
+     */
+    public function deliveryPolicyForEmail(string $email, string $templateKey): array
+    {
+        $normalizedEmail = $this->normalizeEmail($email);
+        if ($normalizedEmail === null) {
+            return [
+                'allowed' => false,
+                'status' => 'failed',
+                'reason' => 'invalid_recipient',
+                'suppressed' => false,
+                'report_recovery' => false,
+                'marketing_updates' => false,
+                'product_updates' => false,
+            ];
+        }
+
+        $emailHash = $this->piiCipher->emailHash($normalizedEmail);
+        $suppressed = EmailSuppression::query()
+            ->where('email_hash', $emailHash)
+            ->exists();
+
+        $subscriber = EmailSubscriber::query()
+            ->with('preference')
+            ->where('email_hash', $emailHash)
+            ->first();
+
+        $preference = $subscriber?->preference instanceof EmailPreference
+            ? $subscriber->preference
+            : null;
+
+        $reportRecovery = $preference instanceof EmailPreference
+            ? (bool) $preference->report_recovery
+            : (bool) ($subscriber->transactional_recovery_enabled ?? true);
+        $marketingUpdates = $preference instanceof EmailPreference
+            ? (bool) $preference->marketing_updates
+            : (bool) ($subscriber->marketing_consent ?? false);
+        $productUpdates = $preference instanceof EmailPreference
+            ? (bool) $preference->product_updates
+            : (bool) ($subscriber->marketing_consent ?? false);
+
+        if ($suppressed) {
+            return [
+                'allowed' => false,
+                'status' => 'suppressed',
+                'reason' => 'email_suppressed',
+                'suppressed' => true,
+                'report_recovery' => $reportRecovery,
+                'marketing_updates' => $marketingUpdates,
+                'product_updates' => $productUpdates,
+            ];
+        }
+
+        if ($this->requiresReportRecovery($templateKey) && ! $reportRecovery) {
+            return [
+                'allowed' => false,
+                'status' => 'skipped',
+                'reason' => 'report_recovery_disabled',
+                'suppressed' => false,
+                'report_recovery' => false,
+                'marketing_updates' => $marketingUpdates,
+                'product_updates' => $productUpdates,
+            ];
+        }
+
+        return [
+            'allowed' => true,
+            'status' => 'allowed',
+            'reason' => null,
+            'suppressed' => false,
+            'report_recovery' => $reportRecovery,
+            'marketing_updates' => $marketingUpdates,
+            'product_updates' => $productUpdates,
+        ];
     }
 
     /**
@@ -239,6 +325,25 @@ class EmailPreferenceService
         $payload = json_decode($json, true);
 
         return is_array($payload) ? $payload : null;
+    }
+
+    private function requiresReportRecovery(string $templateKey): bool
+    {
+        return in_array(trim($templateKey), ['payment_success', 'report_claim'], true);
+    }
+
+    private function normalizeEmail(string $email): ?string
+    {
+        $normalized = mb_strtolower(trim($email), 'UTF-8');
+        if ($normalized === '') {
+            return null;
+        }
+
+        if (filter_var($normalized, FILTER_VALIDATE_EMAIL) === false) {
+            return null;
+        }
+
+        return $normalized;
     }
 
     private function base64UrlEncode(string $value): string

--- a/backend/resources/views/emails/en/payment_success.blade.php
+++ b/backend/resources/views/emails/en/payment_success.blade.php
@@ -4,19 +4,34 @@
     <meta charset="utf-8">
     <title>Payment Successful</title>
 </head>
-<body style="font-family:Arial,sans-serif;color:#111;line-height:1.6;">
-<h2>Payment Successful</h2>
-<p>Your payment has been confirmed and your report delivery is ready.</p>
-@if(!empty($orderNo))<p><strong>Order No:</strong> {{ $orderNo }}</p>@endif
-@if(!empty($productSummary))<p><strong>Purchase:</strong> {{ $productSummary }}</p>@endif
-@if(!empty($reportUrl))
-<p><a href="{{ $reportUrl }}">View your report</a></p>
-@endif
-<p>If you need help, contact <a href="mailto:{{ $supportEmail }}">{{ $supportEmail }}</a>.</p>
-<p>
-    <a href="{{ $privacyUrl }}">Privacy</a> |
-    <a href="{{ $termsUrl }}">Terms</a> |
-    <a href="{{ $refundUrl }}">Refund</a>
-</p>
+<body style="margin:0;padding:24px;background:#f6f4ef;font-family:Arial,sans-serif;color:#1f2933;line-height:1.6;">
+<div style="max-width:640px;margin:0 auto;background:#ffffff;border:1px solid #e5e7eb;padding:32px;">
+    <h1 style="margin:0 0 16px;font-size:28px;line-height:1.2;">Payment successful</h1>
+    <p style="margin:0 0 16px;">Your payment has been confirmed and your report is ready to view.</p>
+    @if(!empty($order_no))
+        <p style="margin:0 0 8px;"><strong>Order No:</strong> {{ $order_no }}</p>
+    @endif
+    @if(!empty($product_summary))
+        <p style="margin:0 0 20px;"><strong>Purchase:</strong> {{ $product_summary }}</p>
+    @endif
+
+    @if(!empty($report_url))
+        <p style="margin:0 0 12px;"><a href="{{ $report_url }}">View report</a></p>
+    @endif
+    @if(!empty($report_pdf_url))
+        <p style="margin:0 0 12px;"><a href="{{ $report_pdf_url }}">Download PDF</a></p>
+    @endif
+    <p style="margin:0 0 24px;"><a href="{{ $order_lookup_url }}">Order lookup</a></p>
+
+    <p style="margin:0 0 8px;">Need help? Contact <a href="mailto:{{ $support_email }}">{{ $support_email }}</a>.</p>
+    <p style="margin:0 0 8px;"><a href="{{ $email_preferences_url }}">Manage email preferences</a></p>
+    <p style="margin:0 0 24px;"><a href="{{ $email_unsubscribe_url }}">Unsubscribe from emails</a></p>
+
+    <p style="margin:0;font-size:12px;color:#52606d;">
+        <a href="{{ $privacy_url }}">Privacy</a> |
+        <a href="{{ $terms_url }}">Terms</a> |
+        <a href="{{ $refund_url }}">Refund</a>
+    </p>
+</div>
 </body>
 </html>

--- a/backend/resources/views/emails/en/report_claim.blade.php
+++ b/backend/resources/views/emails/en/report_claim.blade.php
@@ -2,24 +2,25 @@
 <html lang="en">
 <head>
     <meta charset="utf-8">
-    <title>Refund Notice</title>
+    <title>Report Recovery</title>
 </head>
 <body style="margin:0;padding:24px;background:#f6f4ef;font-family:Arial,sans-serif;color:#1f2933;line-height:1.6;">
 <div style="max-width:640px;margin:0 auto;background:#ffffff;border:1px solid #e5e7eb;padding:32px;">
-    <h1 style="margin:0 0 16px;font-size:28px;line-height:1.2;">Refund notice</h1>
-    <p style="margin:0 0 16px;">Your refund request is being processed.</p>
+    <h1 style="margin:0 0 16px;font-size:28px;line-height:1.2;">Report recovery</h1>
+    <p style="margin:0 0 16px;">This email was requested to help you recover access to your report.</p>
     @if(!empty($order_no))
         <p style="margin:0 0 8px;"><strong>Order No:</strong> {{ $order_no }}</p>
     @endif
-    @if(!empty($refund_status))
-        <p style="margin:0 0 8px;"><strong>Status:</strong> {{ $refund_status }}</p>
-    @endif
-    @if(!empty($refund_eta))
-        <p style="margin:0 0 20px;"><strong>Estimated arrival:</strong> {{ $refund_eta }}</p>
-    @endif
 
-    <p style="margin:0 0 12px;"><a href="{{ $order_lookup_url }}">Order lookup</a></p>
-    <p style="margin:0 0 8px;">Need support? Contact <a href="mailto:{{ $support_email }}">{{ $support_email }}</a>.</p>
+    @if(!empty($report_url))
+        <p style="margin:0 0 12px;"><a href="{{ $report_url }}">View report</a></p>
+    @endif
+    @if(!empty($report_pdf_url))
+        <p style="margin:0 0 12px;"><a href="{{ $report_pdf_url }}">Download PDF</a></p>
+    @endif
+    <p style="margin:0 0 24px;"><a href="{{ $order_lookup_url }}">Order lookup</a></p>
+
+    <p style="margin:0 0 8px;">Need help? Contact <a href="mailto:{{ $support_email }}">{{ $support_email }}</a>.</p>
     <p style="margin:0 0 8px;"><a href="{{ $email_preferences_url }}">Manage email preferences</a></p>
     <p style="margin:0 0 24px;"><a href="{{ $email_unsubscribe_url }}">Unsubscribe from emails</a></p>
 

--- a/backend/resources/views/emails/en/support_contact.blade.php
+++ b/backend/resources/views/emails/en/support_contact.blade.php
@@ -4,21 +4,26 @@
     <meta charset="utf-8">
     <title>Support Contact</title>
 </head>
-<body style="font-family:Arial,sans-serif;color:#111;line-height:1.6;">
-<h2>Support Contact</h2>
-<p>We received your support request.</p>
-@if(!empty($orderNo))<p><strong>Order No:</strong> {{ $orderNo }}</p>@endif
-@if(!empty($reportUrl))
-<p><a href="{{ $reportUrl }}">Open report link</a></p>
-@endif
-<p>Email: <a href="mailto:{{ $supportEmail }}">{{ $supportEmail }}</a></p>
-@if(!empty($supportTicketUrl))
-<p>Ticket: <a href="{{ $supportTicketUrl }}">{{ $supportTicketUrl }}</a></p>
-@endif
-<p>
-    <a href="{{ $privacyUrl }}">Privacy</a> |
-    <a href="{{ $termsUrl }}">Terms</a> |
-    <a href="{{ $refundUrl }}">Refund</a>
-</p>
+<body style="margin:0;padding:24px;background:#f6f4ef;font-family:Arial,sans-serif;color:#1f2933;line-height:1.6;">
+<div style="max-width:640px;margin:0 auto;background:#ffffff;border:1px solid #e5e7eb;padding:32px;">
+    <h1 style="margin:0 0 16px;font-size:28px;line-height:1.2;">Support contact</h1>
+    <p style="margin:0 0 16px;">We received your support request.</p>
+    @if(!empty($order_no))
+        <p style="margin:0 0 8px;"><strong>Order No:</strong> {{ $order_no }}</p>
+    @endif
+    @if(!empty($support_ticket_url))
+        <p style="margin:0 0 12px;"><a href="{{ $support_ticket_url }}">Open support ticket</a></p>
+    @endif
+    <p style="margin:0 0 12px;"><a href="{{ $order_lookup_url }}">Order lookup</a></p>
+    <p style="margin:0 0 8px;">Support email: <a href="mailto:{{ $support_email }}">{{ $support_email }}</a></p>
+    <p style="margin:0 0 8px;"><a href="{{ $email_preferences_url }}">Manage email preferences</a></p>
+    <p style="margin:0 0 24px;"><a href="{{ $email_unsubscribe_url }}">Unsubscribe from emails</a></p>
+
+    <p style="margin:0;font-size:12px;color:#52606d;">
+        <a href="{{ $privacy_url }}">Privacy</a> |
+        <a href="{{ $terms_url }}">Terms</a> |
+        <a href="{{ $refund_url }}">Refund</a>
+    </p>
+</div>
 </body>
 </html>

--- a/backend/resources/views/emails/zh/refund_notice.blade.php
+++ b/backend/resources/views/emails/zh/refund_notice.blade.php
@@ -4,17 +4,30 @@
     <meta charset="utf-8">
     <title>退款处理通知</title>
 </head>
-<body style="font-family:Arial,sans-serif;color:#111;line-height:1.7;">
-<h2>退款通知</h2>
-<p>您的退款申请正在处理。</p>
-@if(!empty($orderNo))<p><strong>订单号：</strong>{{ $orderNo }}</p>@endif
-@if(!empty($refundStatus))<p><strong>当前状态：</strong>{{ $refundStatus }}</p>@endif
-@if(!empty($refundEta))<p><strong>预计到账：</strong>{{ $refundEta }}</p>@endif
-<p>如需支持，请联系 <a href="mailto:{{ $supportEmail }}">{{ $supportEmail }}</a>。</p>
-<p>
-    <a href="{{ $privacyUrl }}">隐私政策</a> |
-    <a href="{{ $termsUrl }}">服务条款</a> |
-    <a href="{{ $refundUrl }}">退款政策</a>
-</p>
+<body style="margin:0;padding:24px;background:#f6f4ef;font-family:Arial,sans-serif;color:#1f2933;line-height:1.7;">
+<div style="max-width:640px;margin:0 auto;background:#ffffff;border:1px solid #e5e7eb;padding:32px;">
+    <h1 style="margin:0 0 16px;font-size:28px;line-height:1.2;">退款通知</h1>
+    <p style="margin:0 0 16px;">您的退款申请正在处理。</p>
+    @if(!empty($order_no))
+        <p style="margin:0 0 8px;"><strong>订单号：</strong>{{ $order_no }}</p>
+    @endif
+    @if(!empty($refund_status))
+        <p style="margin:0 0 8px;"><strong>当前状态：</strong>{{ $refund_status }}</p>
+    @endif
+    @if(!empty($refund_eta))
+        <p style="margin:0 0 20px;"><strong>预计到账：</strong>{{ $refund_eta }}</p>
+    @endif
+
+    <p style="margin:0 0 12px;"><a href="{{ $order_lookup_url }}">订单查询</a></p>
+    <p style="margin:0 0 8px;">如需支持，请联系 <a href="mailto:{{ $support_email }}">{{ $support_email }}</a>。</p>
+    <p style="margin:0 0 8px;"><a href="{{ $email_preferences_url }}">管理邮件偏好</a></p>
+    <p style="margin:0 0 24px;"><a href="{{ $email_unsubscribe_url }}">退订邮件</a></p>
+
+    <p style="margin:0;font-size:12px;color:#52606d;">
+        <a href="{{ $privacy_url }}">隐私政策</a> |
+        <a href="{{ $terms_url }}">服务条款</a> |
+        <a href="{{ $refund_url }}">退款政策</a>
+    </p>
+</div>
 </body>
 </html>

--- a/backend/resources/views/emails/zh/report_claim.blade.php
+++ b/backend/resources/views/emails/zh/report_claim.blade.php
@@ -2,17 +2,14 @@
 <html lang="zh-CN">
 <head>
     <meta charset="utf-8">
-    <title>支付成功通知</title>
+    <title>报告恢复邮件</title>
 </head>
 <body style="margin:0;padding:24px;background:#f6f4ef;font-family:Arial,sans-serif;color:#1f2933;line-height:1.7;">
 <div style="max-width:640px;margin:0 auto;background:#ffffff;border:1px solid #e5e7eb;padding:32px;">
-    <h1 style="margin:0 0 16px;font-size:28px;line-height:1.2;">支付成功</h1>
-    <p style="margin:0 0 16px;">您的支付已确认，报告已可查看。</p>
+    <h1 style="margin:0 0 16px;font-size:28px;line-height:1.2;">报告恢复</h1>
+    <p style="margin:0 0 16px;">这是一封应请求发送的恢复邮件，用于帮助您重新访问报告。</p>
     @if(!empty($order_no))
         <p style="margin:0 0 8px;"><strong>订单号：</strong>{{ $order_no }}</p>
-    @endif
-    @if(!empty($product_summary))
-        <p style="margin:0 0 20px;"><strong>购买内容：</strong>{{ $product_summary }}</p>
     @endif
 
     @if(!empty($report_url))

--- a/backend/resources/views/emails/zh/support_contact.blade.php
+++ b/backend/resources/views/emails/zh/support_contact.blade.php
@@ -2,23 +2,28 @@
 <html lang="zh-CN">
 <head>
     <meta charset="utf-8">
-    <title>客服联系方式</title>
+    <title>客服联系信息</title>
 </head>
-<body style="font-family:Arial,sans-serif;color:#111;line-height:1.7;">
-<h2>客服支持</h2>
-<p>我们已收到您的支持请求。</p>
-@if(!empty($orderNo))<p><strong>订单号：</strong>{{ $orderNo }}</p>@endif
-@if(!empty($reportUrl))
-<p><a href="{{ $reportUrl }}">打开报告链接</a></p>
-@endif
-<p>邮箱：<a href="mailto:{{ $supportEmail }}">{{ $supportEmail }}</a></p>
-@if(!empty($supportTicketUrl))
-<p>工单：<a href="{{ $supportTicketUrl }}">{{ $supportTicketUrl }}</a></p>
-@endif
-<p>
-    <a href="{{ $privacyUrl }}">隐私政策</a> |
-    <a href="{{ $termsUrl }}">服务条款</a> |
-    <a href="{{ $refundUrl }}">退款政策</a>
-</p>
+<body style="margin:0;padding:24px;background:#f6f4ef;font-family:Arial,sans-serif;color:#1f2933;line-height:1.7;">
+<div style="max-width:640px;margin:0 auto;background:#ffffff;border:1px solid #e5e7eb;padding:32px;">
+    <h1 style="margin:0 0 16px;font-size:28px;line-height:1.2;">客服支持</h1>
+    <p style="margin:0 0 16px;">我们已收到您的支持请求。</p>
+    @if(!empty($order_no))
+        <p style="margin:0 0 8px;"><strong>订单号：</strong>{{ $order_no }}</p>
+    @endif
+    @if(!empty($support_ticket_url))
+        <p style="margin:0 0 12px;"><a href="{{ $support_ticket_url }}">查看支持工单</a></p>
+    @endif
+    <p style="margin:0 0 12px;"><a href="{{ $order_lookup_url }}">订单查询</a></p>
+    <p style="margin:0 0 8px;">支持邮箱：<a href="mailto:{{ $support_email }}">{{ $support_email }}</a></p>
+    <p style="margin:0 0 8px;"><a href="{{ $email_preferences_url }}">管理邮件偏好</a></p>
+    <p style="margin:0 0 24px;"><a href="{{ $email_unsubscribe_url }}">退订邮件</a></p>
+
+    <p style="margin:0;font-size:12px;color:#52606d;">
+        <a href="{{ $privacy_url }}">隐私政策</a> |
+        <a href="{{ $terms_url }}">服务条款</a> |
+        <a href="{{ $refund_url }}">退款政策</a>
+    </p>
+</div>
 </body>
 </html>

--- a/backend/tests/Feature/Commerce/BigFiveUnlockDeliveryPipelineTest.php
+++ b/backend/tests/Feature/Commerce/BigFiveUnlockDeliveryPipelineTest.php
@@ -13,6 +13,7 @@ use Database\Seeders\Pr19CommerceSeeder;
 use Database\Seeders\ScaleRegistrySeeder;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Mail;
 use Illuminate\Support\Facades\Queue;
 use Illuminate\Support\Facades\Schema;
 use Illuminate\Support\Str;
@@ -186,6 +187,12 @@ final class BigFiveUnlockDeliveryPipelineTest extends TestCase
 
     public function test_big5_unlock_webhook_queues_pdf_job_and_email_outbox(): void
     {
+        config([
+            'fap.runtime.EMAIL_OUTBOX_SEND' => true,
+            'mail.default' => 'array',
+        ]);
+
+        Mail::mailer('array')->getSymfonyTransport()->flush();
         $this->seedCommerce();
         Queue::fake();
 
@@ -267,5 +274,20 @@ final class BigFiveUnlockDeliveryPipelineTest extends TestCase
             ->assertJsonPath('delivery.contact_email_present', true)
             ->assertJsonPath('delivery.last_delivery_email_sent_at', null)
             ->assertJsonPath('delivery.can_request_claim_email', true);
+
+        $this->artisan('email:outbox-send --limit=10')
+            ->expectsOutput('Mailer array: sent 1, blocked 0, failed 0.')
+            ->assertExitCode(0);
+
+        $this->assertCount(1, Mail::mailer('array')->getSymfonyTransport()->messages());
+        $sentOrderRead = $this->withHeaders([
+            'Authorization' => 'Bearer '.$token,
+        ])->getJson('/api/v0.3/orders/'.$orderNo);
+
+        $sentOrderRead->assertStatus(200)
+            ->assertJsonPath('ok', true)
+            ->assertJsonPath('delivery.contact_email_present', true)
+            ->assertJsonPath('delivery.can_request_claim_email', true);
+        $this->assertNotNull($sentOrderRead->json('delivery.last_delivery_email_sent_at'));
     }
 }

--- a/backend/tests/Feature/Email/EmailOutboxAttributionTest.php
+++ b/backend/tests/Feature/Email/EmailOutboxAttributionTest.php
@@ -8,6 +8,7 @@ use App\Services\Email\EmailOutboxService;
 use App\Support\PiiCipher;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Mail;
 use Illuminate\Support\Str;
 use Tests\TestCase;
 
@@ -17,6 +18,13 @@ final class EmailOutboxAttributionTest extends TestCase
 
     public function test_payment_success_outbox_payload_includes_attribution_contract(): void
     {
+        config([
+            'fap.runtime.EMAIL_OUTBOX_SEND' => true,
+            'fap.runtime.FAP_BASE_URL' => 'https://app.example.test',
+            'app.url' => 'https://api.example.test',
+            'mail.default' => 'array',
+        ]);
+
         $attemptId = $this->createAttempt();
         $email = 'buyer+'.random_int(1000, 9999).'@example.com';
 
@@ -66,10 +74,25 @@ final class EmailOutboxAttributionTest extends TestCase
         $this->assertIsArray($payloadEnc);
         $this->assertSame($email, (string) ($payloadEnc['to_email'] ?? ''));
         $this->assertSame('hero', (string) data_get($payloadEnc, 'attribution.utm.content'));
+
+        Mail::mailer('array')->getSymfonyTransport()->flush();
+        $this->artisan('email:outbox-send --limit=10')->assertExitCode(0);
+
+        $html = (string) Mail::mailer('array')->getSymfonyTransport()->messages()->first()->getOriginalMessage()->getHtmlBody();
+        $this->assertStringContainsString('share_id=share_123', $html);
+        $this->assertStringContainsString('utm_campaign=pr09', $html);
+        $this->assertStringContainsString('compare_invite_id=', $html);
     }
 
     public function test_report_claim_outbox_payload_includes_attribution_contract(): void
     {
+        config([
+            'fap.runtime.EMAIL_OUTBOX_SEND' => true,
+            'fap.runtime.FAP_BASE_URL' => 'https://app.example.test',
+            'app.url' => 'https://api.example.test',
+            'mail.default' => 'array',
+        ]);
+
         $attemptId = $this->createAttempt();
 
         /** @var EmailOutboxService $outbox */
@@ -102,6 +125,13 @@ final class EmailOutboxAttributionTest extends TestCase
         $this->assertIsArray($payloadJson);
         $this->assertSame('share_claim', (string) data_get($payloadJson, 'attribution.share_id'));
         $this->assertSame('order_lookup', (string) data_get($payloadJson, 'attribution.entrypoint'));
+
+        Mail::mailer('array')->getSymfonyTransport()->flush();
+        $this->artisan('email:outbox-send --limit=10')->assertExitCode(0);
+
+        $html = (string) Mail::mailer('array')->getSymfonyTransport()->messages()->first()->getOriginalMessage()->getHtmlBody();
+        $this->assertStringContainsString('share_id=share_claim', $html);
+        $this->assertStringContainsString('utm_campaign=report-recovery', $html);
     }
 
     private function createAttempt(): string

--- a/backend/tests/Feature/Email/EmailOutboxNoPlaintextPayloadTest.php
+++ b/backend/tests/Feature/Email/EmailOutboxNoPlaintextPayloadTest.php
@@ -53,10 +53,27 @@ final class EmailOutboxNoPlaintextPayloadTest extends TestCase
         /** @var PiiCipher $pii */
         $pii = app(PiiCipher::class);
 
-        $claim = $service->queueReportClaim($userId, $email, $attemptId);
+        $claim = $service->queueReportClaim($userId, $email, $attemptId, 'ord_1000', [
+            'share_id' => 'share_no_plaintext',
+            'entrypoint' => 'order_lookup',
+            'landing_path' => '/orders/lookup',
+            'utm' => [
+                'source' => 'help',
+                'medium' => 'owned',
+                'campaign' => 'report-recovery',
+            ],
+        ]);
         $this->assertTrue((bool) ($claim['ok'] ?? false));
 
-        $this->assertTrue($service->queuePaymentSuccess($userId, $email, $attemptId, 'ord_1001', 'MBTI Full Report')['ok']);
+        $this->assertTrue($service->queuePaymentSuccess($userId, $email, $attemptId, 'ord_1001', 'MBTI Full Report', [
+            'share_id' => 'share_no_plaintext',
+            'share_click_id' => 'clk_no_plaintext',
+            'utm' => [
+                'source' => 'share',
+                'medium' => 'organic',
+                'campaign' => 'pr09c',
+            ],
+        ])['ok']);
 
         $rows = DB::table('email_outbox')
             ->where('user_id', $userId)
@@ -89,6 +106,7 @@ final class EmailOutboxNoPlaintextPayloadTest extends TestCase
             $this->assertIsArray($payloadJson);
             $this->assertSame($attemptId, (string) ($payloadJson['attempt_id'] ?? ''));
             $this->assertArrayHasKey('attribution', $payloadJson);
+            $this->assertNotEmpty($payloadJson['attribution']);
             $this->assertArrayNotHasKey('email', $payloadJson);
             $this->assertArrayNotHasKey('to_email', $payloadJson);
             $this->assertArrayNotHasKey('claim_token', $payloadJson);

--- a/backend/tests/Feature/Email/EmailOutboxSendCommandTest.php
+++ b/backend/tests/Feature/Email/EmailOutboxSendCommandTest.php
@@ -1,0 +1,181 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Email;
+
+use App\Services\Email\EmailOutboxService;
+use App\Support\PiiCipher;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Mail;
+use Illuminate\Support\Str;
+use Symfony\Component\Mailer\Envelope;
+use Symfony\Component\Mailer\Transport\TransportInterface;
+use Symfony\Component\Mime\RawMessage;
+use Tests\TestCase;
+
+final class EmailOutboxSendCommandTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_command_uses_configured_mailer_and_advances_sent_rows(): void
+    {
+        config([
+            'fap.runtime.EMAIL_OUTBOX_SEND' => true,
+            'mail.default' => 'array',
+        ]);
+
+        $this->flushArrayTransport();
+        $attemptId = $this->createAttempt('zh-CN');
+
+        $queued = app(EmailOutboxService::class)->queuePaymentSuccess(
+            'command_send_user',
+            'buyer+send@example.com',
+            $attemptId,
+            'ord_send_001',
+            'MBTI Full Report'
+        );
+        $this->assertTrue((bool) ($queued['ok'] ?? false));
+
+        $this->artisan('email:outbox-send --limit=10')
+            ->expectsOutput('Mailer array: sent 1, blocked 0, failed 0.')
+            ->assertExitCode(0);
+
+        $row = DB::table('email_outbox')
+            ->where('attempt_id', $attemptId)
+            ->where('template', 'payment_success')
+            ->first();
+
+        $this->assertNotNull($row);
+        $this->assertSame('sent', (string) ($row->status ?? ''));
+        $this->assertNotNull($row->sent_at ?? null);
+
+        /** @var PiiCipher $pii */
+        $pii = app(PiiCipher::class);
+        $masked = $pii->legacyEmailPlaceholder($pii->emailHash('buyer+send@example.com'));
+        $this->assertSame($masked, (string) ($row->to_email ?? ''));
+
+        $messages = Mail::mailer('array')->getSymfonyTransport()->messages();
+        $this->assertCount(1, $messages);
+
+        $message = $messages->first()->getOriginalMessage();
+        $this->assertSame('支付成功与报告交付通知', (string) $message->getSubject());
+        $this->assertStringContainsString('查看报告', (string) $message->getHtmlBody());
+    }
+
+    public function test_command_safely_skips_when_delivery_is_disabled(): void
+    {
+        config([
+            'fap.runtime.EMAIL_OUTBOX_SEND' => false,
+            'mail.default' => 'array',
+        ]);
+
+        $this->flushArrayTransport();
+        $attemptId = $this->createAttempt();
+
+        $queued = app(EmailOutboxService::class)->queuePaymentSuccess(
+            'command_skip_user',
+            'buyer+skip@example.com',
+            $attemptId,
+            'ord_skip_001',
+            'MBTI Full Report'
+        );
+        $this->assertTrue((bool) ($queued['ok'] ?? false));
+
+        $this->artisan('email:outbox-send --limit=10')
+            ->expectsOutput('EMAIL_OUTBOX_SEND=0 (disabled)')
+            ->assertExitCode(0);
+
+        $this->assertSame('pending', (string) DB::table('email_outbox')->where('attempt_id', $attemptId)->value('status'));
+        $this->assertCount(0, Mail::mailer('array')->getSymfonyTransport()->messages());
+    }
+
+    public function test_command_marks_row_failed_when_mailer_throws(): void
+    {
+        config([
+            'fap.runtime.EMAIL_OUTBOX_SEND' => true,
+            'mail.default' => 'fail_test',
+            'mail.mailers.fail_test' => ['transport' => 'fail_test'],
+        ]);
+
+        app('mail.manager')->extend('fail_test', function (): TransportInterface {
+            return new class implements TransportInterface
+            {
+                public function send(RawMessage $message, ?Envelope $envelope = null): ?\Symfony\Component\Mailer\SentMessage
+                {
+                    throw new \RuntimeException('Simulated transport failure');
+                }
+
+                public function __toString(): string
+                {
+                    return 'fail_test';
+                }
+            };
+        });
+
+        $attemptId = $this->createAttempt();
+        $queued = app(EmailOutboxService::class)->queuePaymentSuccess(
+            'command_fail_user',
+            'buyer+fail@example.com',
+            $attemptId,
+            'ord_fail_001',
+            'MBTI Full Report'
+        );
+        $this->assertTrue((bool) ($queued['ok'] ?? false));
+
+        $this->artisan('email:outbox-send --limit=10')
+            ->expectsOutput('Mailer fail_test: sent 0, blocked 0, failed 1.')
+            ->assertExitCode(0);
+
+        $row = DB::table('email_outbox')
+            ->where('attempt_id', $attemptId)
+            ->where('template', 'payment_success')
+            ->first();
+
+        $this->assertNotNull($row);
+        $this->assertSame('failed', (string) ($row->status ?? ''));
+
+        $payloadJson = json_decode((string) ($row->payload_json ?? '{}'), true);
+        $this->assertIsArray($payloadJson);
+        $this->assertSame('send_failed', (string) data_get($payloadJson, 'delivery_execution.error_code'));
+        $this->assertStringContainsString('Simulated transport failure', (string) data_get($payloadJson, 'delivery_execution.error_message'));
+    }
+
+    private function createAttempt(string $locale = 'en'): string
+    {
+        $attemptId = (string) Str::uuid();
+
+        DB::table('attempts')->insert([
+            'id' => $attemptId,
+            'ticket_code' => 'FMT-'.strtoupper(substr(str_replace('-', '', $attemptId), 0, 8)),
+            'org_id' => 0,
+            'anon_id' => 'anon_email_send',
+            'user_id' => null,
+            'scale_code' => 'MBTI',
+            'scale_version' => 'v0.3',
+            'region' => 'CN_MAINLAND',
+            'locale' => $locale,
+            'question_count' => 144,
+            'answers_summary_json' => json_encode(['seed' => true], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES),
+            'client_platform' => 'test',
+            'client_version' => '1.0.0',
+            'channel' => 'test',
+            'started_at' => now()->subMinute(),
+            'submitted_at' => now(),
+            'pack_id' => (string) config('content_packs.default_pack_id'),
+            'dir_version' => (string) config('content_packs.default_dir_version'),
+            'content_package_version' => 'v0.3',
+            'scoring_spec_version' => '2026.01',
+            'created_at' => now(),
+            'updated_at' => now(),
+        ]);
+
+        return $attemptId;
+    }
+
+    private function flushArrayTransport(): void
+    {
+        Mail::mailer('array')->getSymfonyTransport()->flush();
+    }
+}

--- a/backend/tests/Feature/Email/EmailPreferencesExecutionTest.php
+++ b/backend/tests/Feature/Email/EmailPreferencesExecutionTest.php
@@ -1,0 +1,134 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Email;
+
+use App\Models\EmailPreference;
+use App\Services\Email\EmailCaptureService;
+use App\Services\Email\EmailOutboxService;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Mail;
+use Illuminate\Support\Str;
+use Tests\TestCase;
+
+final class EmailPreferencesExecutionTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_report_recovery_true_allows_transactional_delivery_even_when_marketing_flags_are_false(): void
+    {
+        config([
+            'fap.runtime.EMAIL_OUTBOX_SEND' => true,
+            'mail.default' => 'array',
+        ]);
+
+        $this->flushArrayTransport();
+        $attemptId = $this->createAttempt('en');
+        $email = 'preferences+allow@example.com';
+
+        $capture = app(EmailCaptureService::class)->capture($email, ['surface' => 'lookup']);
+        EmailPreference::query()
+            ->where('subscriber_id', (string) ($capture['subscriber_id'] ?? ''))
+            ->update([
+                'marketing_updates' => false,
+                'report_recovery' => true,
+                'product_updates' => false,
+            ]);
+
+        $queued = app(EmailOutboxService::class)->queuePaymentSuccess(
+            'preferences_allow_user',
+            $email,
+            $attemptId,
+            'ord_preferences_allow_001',
+            'MBTI Full Report'
+        );
+        $this->assertTrue((bool) ($queued['ok'] ?? false));
+
+        $this->artisan('email:outbox-send --limit=10')
+            ->expectsOutput('Mailer array: sent 1, blocked 0, failed 0.')
+            ->assertExitCode(0);
+
+        $row = DB::table('email_outbox')->where('attempt_id', $attemptId)->where('template', 'payment_success')->first();
+        $this->assertNotNull($row);
+        $this->assertSame('sent', (string) ($row->status ?? ''));
+        $this->assertCount(1, Mail::mailer('array')->getSymfonyTransport()->messages());
+    }
+
+    public function test_report_recovery_false_blocks_report_delivery_templates_but_marketing_flags_do_not_control_them(): void
+    {
+        config([
+            'fap.runtime.EMAIL_OUTBOX_SEND' => true,
+            'mail.default' => 'array',
+        ]);
+
+        $this->flushArrayTransport();
+        $attemptId = $this->createAttempt('en');
+        $email = 'preferences+block@example.com';
+
+        $capture = app(EmailCaptureService::class)->capture($email, ['surface' => 'lookup']);
+        EmailPreference::query()
+            ->where('subscriber_id', (string) ($capture['subscriber_id'] ?? ''))
+            ->update([
+                'marketing_updates' => true,
+                'report_recovery' => false,
+                'product_updates' => true,
+            ]);
+
+        $queued = app(EmailOutboxService::class)->queuePaymentSuccess(
+            'preferences_block_user',
+            $email,
+            $attemptId,
+            'ord_preferences_block_001',
+            'MBTI Full Report'
+        );
+        $this->assertTrue((bool) ($queued['ok'] ?? false));
+
+        $this->artisan('email:outbox-send --limit=10')
+            ->expectsOutput('Mailer array: sent 0, blocked 1, failed 0.')
+            ->assertExitCode(0);
+
+        $row = DB::table('email_outbox')->where('attempt_id', $attemptId)->where('template', 'payment_success')->first();
+        $this->assertNotNull($row);
+        $this->assertSame('skipped', (string) ($row->status ?? ''));
+        $this->assertSame(0, Mail::mailer('array')->getSymfonyTransport()->messages()->count());
+    }
+
+    private function createAttempt(string $locale): string
+    {
+        $attemptId = (string) Str::uuid();
+
+        DB::table('attempts')->insert([
+            'id' => $attemptId,
+            'ticket_code' => 'FMT-'.strtoupper(substr(str_replace('-', '', $attemptId), 0, 8)),
+            'org_id' => 0,
+            'anon_id' => 'anon_pref_exec',
+            'user_id' => null,
+            'scale_code' => 'MBTI',
+            'scale_version' => 'v0.3',
+            'region' => 'CN_MAINLAND',
+            'locale' => $locale,
+            'question_count' => 144,
+            'answers_summary_json' => json_encode(['seed' => true], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES),
+            'client_platform' => 'test',
+            'client_version' => '1.0.0',
+            'channel' => 'test',
+            'started_at' => now()->subMinute(),
+            'submitted_at' => now(),
+            'pack_id' => (string) config('content_packs.default_pack_id'),
+            'dir_version' => (string) config('content_packs.default_dir_version'),
+            'content_package_version' => 'v0.3',
+            'scoring_spec_version' => '2026.01',
+            'created_at' => now(),
+            'updated_at' => now(),
+        ]);
+
+        return $attemptId;
+    }
+
+    private function flushArrayTransport(): void
+    {
+        Mail::mailer('array')->getSymfonyTransport()->flush();
+    }
+}

--- a/backend/tests/Feature/Email/EmailSuppressionExecutionTest.php
+++ b/backend/tests/Feature/Email/EmailSuppressionExecutionTest.php
@@ -1,0 +1,268 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Email;
+
+use App\Models\EmailPreference;
+use App\Models\EmailSuppression;
+use App\Services\Email\EmailCaptureService;
+use App\Services\Email\EmailOutboxService;
+use App\Support\PiiCipher;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Mail;
+use Illuminate\Support\Str;
+use Tests\TestCase;
+
+final class EmailSuppressionExecutionTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_suppression_hit_prevents_payment_success_delivery(): void
+    {
+        config([
+            'fap.runtime.EMAIL_OUTBOX_SEND' => true,
+            'mail.default' => 'array',
+        ]);
+
+        $this->flushArrayTransport();
+        $attemptId = $this->createAttempt('suppression_direct_anon');
+        $email = 'suppressed+payment@example.com';
+
+        $queued = app(EmailOutboxService::class)->queuePaymentSuccess(
+            'suppression_user',
+            $email,
+            $attemptId,
+            'ord_suppressed_001',
+            'MBTI Full Report'
+        );
+        $this->assertTrue((bool) ($queued['ok'] ?? false));
+
+        /** @var PiiCipher $pii */
+        $pii = app(PiiCipher::class);
+        EmailSuppression::query()->create([
+            'id' => (string) Str::uuid(),
+            'email_hash' => $pii->emailHash($email),
+            'reason' => 'bounce',
+            'source' => 'test',
+            'meta_json' => ['channel' => 'qa'],
+        ]);
+
+        $this->artisan('email:outbox-send --limit=10')
+            ->expectsOutput('Mailer array: sent 0, blocked 1, failed 0.')
+            ->assertExitCode(0);
+
+        $row = DB::table('email_outbox')->where('attempt_id', $attemptId)->where('template', 'payment_success')->first();
+        $this->assertNotNull($row);
+        $this->assertSame('suppressed', (string) ($row->status ?? ''));
+        $this->assertSame(0, Mail::mailer('array')->getSymfonyTransport()->messages()->count());
+    }
+
+    public function test_report_recovery_disabled_prevents_report_claim_delivery(): void
+    {
+        config([
+            'fap.runtime.EMAIL_OUTBOX_SEND' => true,
+            'mail.default' => 'array',
+        ]);
+
+        $this->flushArrayTransport();
+        $attemptId = $this->createAttempt('suppression_claim_anon');
+        $email = 'blocked+claim@example.com';
+
+        $capture = app(EmailCaptureService::class)->capture($email, ['surface' => 'lookup']);
+        EmailPreference::query()
+            ->where('subscriber_id', (string) ($capture['subscriber_id'] ?? ''))
+            ->update([
+                'marketing_updates' => false,
+                'report_recovery' => false,
+                'product_updates' => false,
+            ]);
+
+        $queued = app(EmailOutboxService::class)->queueReportClaim(
+            'claim_block_user',
+            $email,
+            $attemptId,
+            'ord_claim_blocked_001'
+        );
+        $this->assertTrue((bool) ($queued['ok'] ?? false));
+
+        $this->artisan('email:outbox-send --limit=10')
+            ->expectsOutput('Mailer array: sent 0, blocked 1, failed 0.')
+            ->assertExitCode(0);
+
+        $row = DB::table('email_outbox')->where('attempt_id', $attemptId)->where('template', 'report_claim')->first();
+        $this->assertNotNull($row);
+        $this->assertSame('skipped', (string) ($row->status ?? ''));
+        $this->assertSame('report_recovery_disabled', (string) data_get(json_decode((string) ($row->payload_json ?? '{}'), true), 'delivery_execution.guard'));
+    }
+
+    public function test_resend_payment_success_delivery_is_blocked_when_report_recovery_is_disabled(): void
+    {
+        config([
+            'fap.runtime.EMAIL_OUTBOX_SEND' => true,
+            'mail.default' => 'array',
+        ]);
+
+        $this->flushArrayTransport();
+        $email = 'resend+blocked@example.com';
+        $userId = $this->createUser($email);
+        $attemptId = $this->createAttempt('resend_blocked_anon', (string) $userId, 'BIG5_OCEAN');
+        $orderNo = 'ord_resend_blocked_'.Str::lower(Str::random(8));
+        $this->insertOrder($orderNo, $attemptId, 'paid', 'resend_blocked_anon', (string) $userId, 'BIG5_FULL_REPORT');
+
+        $capture = app(EmailCaptureService::class)->capture($email, ['surface' => 'lookup']);
+        EmailPreference::query()
+            ->where('subscriber_id', (string) ($capture['subscriber_id'] ?? ''))
+            ->update([
+                'marketing_updates' => false,
+                'report_recovery' => false,
+                'product_updates' => false,
+            ]);
+
+        $token = $this->issueToken((string) $userId, 'resend_blocked_anon');
+        $response = $this->withHeaders([
+            'Authorization' => 'Bearer '.$token,
+        ])->postJson('/api/v0.3/orders/'.$orderNo.'/resend');
+
+        $response->assertStatus(200)
+            ->assertJson([
+                'ok' => true,
+                'message' => 'Delivery notice has been queued.',
+            ]);
+
+        $this->artisan('email:outbox-send --limit=10')
+            ->expectsOutput('Mailer array: sent 0, blocked 1, failed 0.')
+            ->assertExitCode(0);
+
+        $row = DB::table('email_outbox')->where('attempt_id', $attemptId)->where('template', 'payment_success')->first();
+        $this->assertNotNull($row);
+        $this->assertSame('skipped', (string) ($row->status ?? ''));
+        $this->assertSame(0, Mail::mailer('array')->getSymfonyTransport()->messages()->count());
+    }
+
+    private function createUser(string $email): int
+    {
+        $userId = random_int(100000, 999999);
+
+        DB::table('users')->insert([
+            'id' => $userId,
+            'name' => 'Suppression User',
+            'email' => $email,
+            'password' => bcrypt('secret'),
+            'created_at' => now(),
+            'updated_at' => now(),
+        ]);
+
+        return $userId;
+    }
+
+    private function issueToken(?string $userId, string $anonId): string
+    {
+        $token = 'fm_'.(string) Str::uuid();
+        $tokenHash = hash('sha256', $token);
+
+        DB::table('fm_tokens')->insert([
+            'token' => $token,
+            'token_hash' => $tokenHash,
+            'user_id' => $userId,
+            'anon_id' => $anonId,
+            'org_id' => 0,
+            'role' => 'public',
+            'expires_at' => now()->addDay(),
+            'revoked_at' => null,
+            'created_at' => now(),
+            'updated_at' => now(),
+        ]);
+
+        DB::table('auth_tokens')->insert([
+            'token_hash' => $tokenHash,
+            'user_id' => $userId,
+            'anon_id' => $anonId,
+            'org_id' => 0,
+            'role' => 'public',
+            'meta_json' => null,
+            'expires_at' => now()->addDay(),
+            'revoked_at' => null,
+            'last_used_at' => null,
+            'created_at' => now(),
+            'updated_at' => now(),
+        ]);
+
+        return $token;
+    }
+
+    private function createAttempt(string $anonId, ?string $userId = null, string $scaleCode = 'MBTI'): string
+    {
+        $attemptId = (string) Str::uuid();
+
+        DB::table('attempts')->insert([
+            'id' => $attemptId,
+            'ticket_code' => 'FMT-'.strtoupper(substr(str_replace('-', '', $attemptId), 0, 8)),
+            'org_id' => 0,
+            'user_id' => $userId,
+            'anon_id' => $anonId,
+            'scale_code' => $scaleCode,
+            'scale_version' => 'v0.3',
+            'region' => 'CN_MAINLAND',
+            'locale' => 'en',
+            'question_count' => 144,
+            'answers_summary_json' => json_encode(['seed' => true], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES),
+            'client_platform' => 'test',
+            'client_version' => '1.0.0',
+            'channel' => 'test',
+            'started_at' => now()->subMinute(),
+            'submitted_at' => now(),
+            'pack_id' => (string) config('content_packs.default_pack_id'),
+            'dir_version' => (string) config('content_packs.default_dir_version'),
+            'content_package_version' => 'v0.3',
+            'scoring_spec_version' => '2026.01',
+            'created_at' => now(),
+            'updated_at' => now(),
+        ]);
+
+        return $attemptId;
+    }
+
+    private function insertOrder(
+        string $orderNo,
+        string $attemptId,
+        string $status,
+        string $anonId,
+        ?string $userId,
+        string $sku
+    ): void {
+        DB::table('orders')->insert([
+            'id' => (string) Str::uuid(),
+            'order_no' => $orderNo,
+            'org_id' => 0,
+            'user_id' => $userId,
+            'anon_id' => $anonId,
+            'sku' => $sku,
+            'quantity' => 1,
+            'target_attempt_id' => $attemptId,
+            'amount_cents' => 29900,
+            'currency' => 'CNY',
+            'status' => $status,
+            'provider' => 'billing',
+            'external_trade_no' => null,
+            'paid_at' => $status === 'paid' ? now() : null,
+            'created_at' => now(),
+            'updated_at' => now(),
+            'amount_total' => 29900,
+            'amount_refunded' => 0,
+            'item_sku' => $sku,
+            'provider_order_id' => null,
+            'device_id' => null,
+            'request_id' => null,
+            'created_ip' => null,
+            'fulfilled_at' => null,
+            'refunded_at' => null,
+        ]);
+    }
+
+    private function flushArrayTransport(): void
+    {
+        Mail::mailer('array')->getSymfonyTransport()->flush();
+    }
+}

--- a/backend/tests/Feature/Email/ReportClaimTemplateDeliveryTest.php
+++ b/backend/tests/Feature/Email/ReportClaimTemplateDeliveryTest.php
@@ -1,0 +1,111 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Email;
+
+use App\Services\Email\EmailOutboxService;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Mail;
+use Illuminate\Support\Str;
+use PHPUnit\Framework\Attributes\DataProvider;
+use Tests\TestCase;
+
+final class ReportClaimTemplateDeliveryTest extends TestCase
+{
+    use RefreshDatabase;
+
+    #[DataProvider('localeProvider')]
+    public function test_report_claim_renders_required_links_for_each_supported_locale(string $locale, string $expectedTitle): void
+    {
+        config([
+            'fap.runtime.EMAIL_OUTBOX_SEND' => true,
+            'fap.runtime.FAP_BASE_URL' => 'https://app.example.test',
+            'app.url' => 'https://api.example.test',
+            'mail.default' => 'array',
+        ]);
+
+        $this->flushArrayTransport();
+        $attemptId = $this->createAttempt($locale);
+        $queued = app(EmailOutboxService::class)->queueReportClaim(
+            'report_claim_template_user',
+            'claim+template@example.com',
+            $attemptId,
+            'ord_template_001',
+            [
+                'entrypoint' => 'order_lookup',
+                'landing_path' => '/orders/lookup',
+                'utm' => [
+                    'source' => 'help',
+                    'medium' => 'owned',
+                    'campaign' => 'report-recovery',
+                ],
+            ],
+            $locale
+        );
+        $this->assertTrue((bool) ($queued['ok'] ?? false));
+
+        $this->artisan('email:outbox-send --limit=10')
+            ->expectsOutput('Mailer array: sent 1, blocked 0, failed 0.')
+            ->assertExitCode(0);
+
+        $html = (string) Mail::mailer('array')->getSymfonyTransport()->messages()->first()->getOriginalMessage()->getHtmlBody();
+
+        $this->assertStringContainsString($expectedTitle, $html);
+        $this->assertStringContainsString("https://api.example.test/api/v0.3/attempts/{$attemptId}/report", $html);
+        $this->assertStringContainsString("https://api.example.test/api/v0.3/attempts/{$attemptId}/report.pdf", $html);
+        $this->assertStringContainsString('https://app.example.test/orders/lookup?', $html);
+        $this->assertStringContainsString('https://app.example.test/email/preferences?token=', $html);
+        $this->assertStringContainsString('https://app.example.test/email/unsubscribe?token=', $html);
+        $this->assertStringContainsString('ord_template_001', $html);
+    }
+
+    /**
+     * @return array<string,array{0:string,1:string}>
+     */
+    public static function localeProvider(): array
+    {
+        return [
+            'en' => ['en', 'Report recovery'],
+            'zh-CN' => ['zh-CN', '报告恢复'],
+        ];
+    }
+
+    private function createAttempt(string $locale): string
+    {
+        $attemptId = (string) Str::uuid();
+
+        DB::table('attempts')->insert([
+            'id' => $attemptId,
+            'ticket_code' => 'FMT-'.strtoupper(substr(str_replace('-', '', $attemptId), 0, 8)),
+            'org_id' => 0,
+            'anon_id' => 'anon_template_claim',
+            'user_id' => null,
+            'scale_code' => 'MBTI',
+            'scale_version' => 'v0.3',
+            'region' => 'CN_MAINLAND',
+            'locale' => $locale,
+            'question_count' => 144,
+            'answers_summary_json' => json_encode(['seed' => true], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES),
+            'client_platform' => 'test',
+            'client_version' => '1.0.0',
+            'channel' => 'test',
+            'started_at' => now()->subMinute(),
+            'submitted_at' => now(),
+            'pack_id' => (string) config('content_packs.default_pack_id'),
+            'dir_version' => (string) config('content_packs.default_dir_version'),
+            'content_package_version' => 'v0.3',
+            'scoring_spec_version' => '2026.01',
+            'created_at' => now(),
+            'updated_at' => now(),
+        ]);
+
+        return $attemptId;
+    }
+
+    private function flushArrayTransport(): void
+    {
+        Mail::mailer('array')->getSymfonyTransport()->flush();
+    }
+}

--- a/backend/tests/Feature/V0_3/CommerceOrderResendTest.php
+++ b/backend/tests/Feature/V0_3/CommerceOrderResendTest.php
@@ -4,10 +4,13 @@ declare(strict_types=1);
 
 namespace Tests\Feature\V0_3;
 
+use App\Models\EmailPreference;
+use App\Services\Email\EmailCaptureService;
 use App\Services\Email\EmailOutboxService;
 use App\Support\PiiCipher;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Mail;
 use Illuminate\Support\Facades\Schema;
 use Illuminate\Support\Str;
 use Tests\TestCase;
@@ -119,6 +122,56 @@ final class CommerceOrderResendTest extends TestCase
                 ->where('template', 'payment_success')
                 ->count()
         );
+    }
+
+    public function test_resend_delivery_send_execution_respects_report_recovery_preference(): void
+    {
+        config([
+            'fap.runtime.EMAIL_OUTBOX_SEND' => true,
+            'mail.default' => 'array',
+        ]);
+
+        Mail::mailer('array')->getSymfonyTransport()->flush();
+
+        $email = 'resend-pref@example.com';
+        $userId = $this->createUser($email);
+        $attemptId = $this->createAttempt(self::USER_OWNER_ANON, (string) $userId);
+        $orderNo = 'ord_resend_'.Str::lower(Str::random(8));
+        $this->insertOrder($orderNo, $attemptId, 'paid', self::USER_OWNER_ANON, (string) $userId, 'BIG5_FULL_REPORT');
+
+        $capture = app(EmailCaptureService::class)->capture($email, ['surface' => 'lookup']);
+        EmailPreference::query()
+            ->where('subscriber_id', (string) ($capture['subscriber_id'] ?? ''))
+            ->update([
+                'marketing_updates' => true,
+                'report_recovery' => false,
+                'product_updates' => true,
+            ]);
+
+        $token = $this->issueToken((string) $userId, self::USER_OWNER_ANON);
+        $response = $this->withHeaders([
+            'Authorization' => 'Bearer '.$token,
+        ])->postJson('/api/v0.3/orders/'.$orderNo.'/resend');
+
+        $response->assertStatus(200)
+            ->assertJson([
+                'ok' => true,
+                'message' => 'Delivery notice has been queued.',
+            ]);
+
+        $this->artisan('email:outbox-send --limit=10')
+            ->expectsOutput('Mailer array: sent 0, blocked 1, failed 0.')
+            ->assertExitCode(0);
+
+        $row = DB::table('email_outbox')
+            ->where('attempt_id', $attemptId)
+            ->where('template', 'payment_success')
+            ->orderByDesc('updated_at')
+            ->first();
+
+        $this->assertNotNull($row);
+        $this->assertSame('skipped', (string) ($row->status ?? ''));
+        $this->assertCount(0, Mail::mailer('array')->getSymfonyTransport()->messages());
     }
 
     private function createUser(string $email): int

--- a/backend/tests/Feature/V0_3/PaymentWebhookControllerTest.php
+++ b/backend/tests/Feature/V0_3/PaymentWebhookControllerTest.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Tests\Feature\V0_3;
 
+use App\Models\Attempt;
+use App\Models\Result;
 use App\Services\Commerce\PaymentWebhookProcessor;
 use Database\Seeders\Pr19CommerceSeeder;
 use Illuminate\Foundation\Testing\RefreshDatabase;
@@ -269,6 +271,139 @@ final class PaymentWebhookControllerTest extends TestCase
             ->where('provider_event_id', 'evt_sec002_bill_1')
             ->count());
         $this->assertSame(0, DB::table('email_outbox')->count());
+    }
+
+    public function test_valid_billing_signature_queues_payment_success_email_when_delivery_context_exists(): void
+    {
+        (new Pr19CommerceSeeder)->run();
+
+        config([
+            'services.billing.webhook_secret' => 'billing_secret_email_queue',
+            'services.billing.webhook_tolerance_seconds' => 300,
+            'services.billing.allow_legacy_signature' => false,
+        ]);
+
+        $userId = random_int(100000, 999999);
+        $attemptId = (string) Str::uuid();
+        $orderNo = 'ord_sec002_email_queue_1';
+
+        DB::table('users')->insert([
+            'id' => $userId,
+            'name' => 'Webhook Email User',
+            'email' => 'webhook-queue@example.com',
+            'password' => bcrypt('secret'),
+            'created_at' => now(),
+            'updated_at' => now(),
+        ]);
+
+        Attempt::query()->create([
+            'id' => $attemptId,
+            'ticket_code' => 'FMT-'.strtoupper(substr(str_replace('-', '', $attemptId), 0, 8)),
+            'org_id' => 0,
+            'user_id' => (string) $userId,
+            'anon_id' => 'anon_webhook_email_queue',
+            'scale_code' => 'BIG5_OCEAN',
+            'scale_version' => 'v0.3',
+            'region' => 'CN_MAINLAND',
+            'locale' => 'en',
+            'question_count' => 120,
+            'answers_summary_json' => ['seed' => true],
+            'client_platform' => 'test',
+            'client_version' => '1.0.0',
+            'channel' => 'test',
+            'started_at' => now()->subMinute(),
+            'submitted_at' => now(),
+            'pack_id' => 'BIG5_OCEAN',
+            'dir_version' => 'v1',
+            'content_package_version' => 'v1',
+            'scoring_spec_version' => 'big5_spec_2026Q1_v1',
+        ]);
+
+        Result::query()->create([
+            'id' => (string) Str::uuid(),
+            'org_id' => 0,
+            'attempt_id' => $attemptId,
+            'scale_code' => 'BIG5_OCEAN',
+            'scale_version' => 'v0.3',
+            'type_code' => '',
+            'scores_json' => ['domains_mean' => ['O' => 3.0, 'C' => 3.0, 'E' => 3.0, 'A' => 3.0, 'N' => 3.0]],
+            'scores_pct' => ['O' => 50, 'C' => 50, 'E' => 50, 'A' => 50, 'N' => 50],
+            'axis_states' => [],
+            'content_package_version' => 'v1',
+            'result_json' => [
+                'normed_json' => [
+                    'norms' => ['status' => 'CALIBRATED'],
+                    'quality' => ['level' => 'A'],
+                ],
+            ],
+            'pack_id' => 'BIG5_OCEAN',
+            'dir_version' => 'v1',
+            'scoring_spec_version' => 'big5_spec_2026Q1_v1',
+            'report_engine_version' => 'v1.2',
+            'is_valid' => true,
+            'computed_at' => now(),
+        ]);
+
+        DB::table('orders')->insert([
+            'id' => (string) Str::uuid(),
+            'order_no' => $orderNo,
+            'org_id' => 0,
+            'user_id' => (string) $userId,
+            'anon_id' => 'anon_webhook_email_queue',
+            'sku' => 'SKU_BIG5_FULL_REPORT_299',
+            'quantity' => 1,
+            'target_attempt_id' => $attemptId,
+            'amount_cents' => 299,
+            'currency' => 'CNY',
+            'status' => 'created',
+            'provider' => 'billing',
+            'external_trade_no' => null,
+            'paid_at' => null,
+            'created_at' => now(),
+            'updated_at' => now(),
+            'amount_total' => 299,
+            'amount_refunded' => 0,
+            'item_sku' => 'SKU_BIG5_FULL_REPORT_299',
+            'provider_order_id' => null,
+            'device_id' => null,
+            'request_id' => null,
+            'created_ip' => null,
+            'fulfilled_at' => null,
+            'refunded_at' => null,
+            'meta_json' => json_encode([
+                'attribution' => [
+                    'share_id' => 'share_webhook_queue',
+                    'utm' => [
+                        'source' => 'share',
+                        'medium' => 'organic',
+                        'campaign' => 'pr09c',
+                    ],
+                ],
+            ], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES),
+        ]);
+
+        $payload = [
+            'provider_event_id' => 'evt_sec002_bill_email_queue',
+            'order_no' => $orderNo,
+            'amount_cents' => 299,
+            'currency' => 'CNY',
+        ];
+        $raw = $this->encodePayload($payload);
+
+        $response = $this->postSignedBilling($raw, 'billing_secret_email_queue');
+        $response->assertStatus(200);
+        $response->assertJsonPath('ok', true);
+        $response->assertJsonMissingPath('error');
+        $this->assertNoLegacyErrorKey($response);
+
+        $row = DB::table('email_outbox')
+            ->where('attempt_id', $attemptId)
+            ->where('template', 'payment_success')
+            ->first();
+
+        $this->assertNotNull($row);
+        $this->assertSame('pending', (string) ($row->status ?? ''));
+        $this->assertSame('share_webhook_queue', (string) data_get(json_decode((string) ($row->payload_json ?? '{}'), true), 'attribution.share_id'));
     }
 
     private function postSignedBilling(string $raw, string $secret): TestResponse


### PR DESCRIPTION
## Summary
- activate transactional email outbox sending via configured mailer
- schedule email:outbox-send every minute without overlapping
- roll out localized transactional templates and enforce suppression/preferences at send time

## Tests
- php artisan test tests/Feature/Email/EmailOutboxSendCommandTest.php
- php artisan test tests/Feature/Email/EmailSuppressionExecutionTest.php
- php artisan test tests/Feature/Email/EmailPreferencesExecutionTest.php
- php artisan test tests/Feature/Email/ReportClaimTemplateDeliveryTest.php
- php artisan test tests/Feature/Email/EmailOutboxNoPlaintextPayloadTest.php
- php artisan test tests/Feature/Email/EmailOutboxAttributionTest.php
- php artisan test tests/Feature/V0_3/CommerceOrderResendTest.php
- php artisan test tests/Feature/Commerce/BigFiveUnlockDeliveryPipelineTest.php
- php artisan test tests/Feature/V0_3/PaymentWebhookControllerTest.php
- php artisan test tests/Feature/V0_3/EmailCaptureContractTest.php
- php artisan test tests/Feature/V0_3/ClaimReportEmailRequestTest.php
- php artisan test tests/Feature/V0_3/EmailPreferencesContractTest.php
- php artisan test tests/Feature/V0_3/EmailUnsubscribeContractTest.php
- php artisan test tests/Feature/Report/ReportPdfCrossScaleDeliveryTest.php
- bash scripts/ci_verify_mbti.sh
