### PR TITLE
feat(email): add subscriber consent and lifecycle foundation

### DIFF
--- a/backend/app/Http/Controllers/API/V0_3/CommerceController.php
+++ b/backend/app/Http/Controllers/API/V0_3/CommerceController.php
@@ -8,6 +8,7 @@ use App\Services\Commerce\Checkout\LemonSqueezyCheckoutService;
 use App\Services\Commerce\Checkout\WechatPayCheckoutService;
 use App\Services\Commerce\OrderManager;
 use App\Services\Commerce\SkuCatalog;
+use App\Services\Email\EmailCaptureService;
 use App\Services\Payments\PaymentRouter;
 use App\Support\OrgContext;
 use App\Support\RegionContext;
@@ -25,6 +26,7 @@ class CommerceController extends Controller
         private OrgContext $orgContext,
         private RegionContext $regionContext,
         private OrderManager $orders,
+        private EmailCaptureService $emailCaptures,
         private SkuCatalog $skus,
         private PaymentRouter $paymentRouter,
         private LemonSqueezyCheckoutService $lemonSqueezyCheckout,
@@ -162,6 +164,9 @@ class CommerceController extends Controller
             'attempt_id' => ['nullable', 'string', 'max:64'],
             'sku' => ['nullable', 'string', 'max:64'],
             'email' => ['nullable', 'string', 'max:320'],
+            'marketing_consent' => ['nullable', 'boolean'],
+            'transactional_recovery_enabled' => ['nullable', 'boolean'],
+            'surface' => ['nullable', 'string', 'max:64'],
             'order_no' => ['nullable', 'string', 'max:64'],
             'provider' => ['nullable', 'string', 'max:32'],
             'idempotency_key' => ['nullable', 'string', 'max:128'],
@@ -171,7 +176,12 @@ class CommerceController extends Controller
             'entrypoint' => ['nullable', 'string', 'max:128'],
             'referrer' => ['nullable', 'string', 'max:2048'],
             'landing_path' => ['nullable', 'string', 'max:2048'],
-            'utm' => ['nullable'],
+            'utm' => ['nullable', 'array'],
+            'utm.source' => ['nullable', 'string', 'max:512'],
+            'utm.medium' => ['nullable', 'string', 'max:512'],
+            'utm.campaign' => ['nullable', 'string', 'max:512'],
+            'utm.term' => ['nullable', 'string', 'max:512'],
+            'utm.content' => ['nullable', 'string', 'max:512'],
             'utm_source' => ['nullable', 'string', 'max:512'],
             'utm_medium' => ['nullable', 'string', 'max:512'],
             'utm_campaign' => ['nullable', 'string', 'max:512'],
@@ -188,13 +198,26 @@ class CommerceController extends Controller
             abort(422, 'email is required.');
         }
 
+        $subscriberCapture = $contactEmail !== null
+            ? $this->emailCaptures->capture(
+                $contactEmail,
+                $this->extractEmailCaptureContext($payload, $attribution)
+            )
+            : [];
+        $emailCapture = $this->buildCheckoutEmailCapture($contactEmail, $payload, $attribution, $subscriberCapture);
+
         $existingOrderNo = trim((string) ($payload['order_no'] ?? ''));
         if ($existingOrderNo !== '') {
             $existing = $this->orders->getOrder($orgId, $userId !== null ? (string) $userId : null, $anonId, $existingOrderNo);
             if ($existing['ok'] ?? false) {
                 $order = $existing['order'];
-                if ($attribution !== []) {
-                    $this->orders->mergeAttribution((string) ($order->order_no ?? $existingOrderNo), $orgId, $attribution);
+                if ($attribution !== [] || $emailCapture !== []) {
+                    $this->orders->mergeCheckoutContext(
+                        (string) ($order->order_no ?? $existingOrderNo),
+                        $orgId,
+                        $attribution,
+                        $emailCapture
+                    );
                 }
 
                 $provider = strtolower(trim((string) ($order->provider ?? '')));
@@ -246,7 +269,8 @@ class CommerceController extends Controller
             $idempotencyKey,
             $contactEmail,
             $this->resolveRequestId($request),
-            $attribution
+            $attribution,
+            $emailCapture
         );
 
         if (! ($created['ok'] ?? false)) {
@@ -256,8 +280,8 @@ class CommerceController extends Controller
         }
 
         $orderNoForAttribution = trim((string) data_get($created, 'order.order_no', $created['order_no'] ?? ''));
-        if ($orderNoForAttribution !== '' && $attribution !== []) {
-            $this->orders->mergeAttribution($orderNoForAttribution, $orgId, $attribution);
+        if ($orderNoForAttribution !== '' && ($attribution !== [] || $emailCapture !== [])) {
+            $this->orders->mergeCheckoutContext($orderNoForAttribution, $orgId, $attribution, $emailCapture);
         }
 
         $order = $created['order'] ?? null;
@@ -802,6 +826,76 @@ class CommerceController extends Controller
         }
 
         return $attribution;
+    }
+
+    /**
+     * @param  array<string,mixed>  $payload
+     * @param  array<string,mixed>  $attribution
+     * @return array<string,mixed>
+     */
+    private function extractEmailCaptureContext(array $payload, array $attribution): array
+    {
+        $context = [];
+
+        foreach ([
+            'attempt_id' => 64,
+            'order_no' => 64,
+            'surface' => 64,
+        ] as $field => $maxLength) {
+            $value = $this->truncateNullableString($payload[$field] ?? null, $maxLength);
+            if ($value !== null) {
+                $context[$field] = $value;
+            }
+        }
+
+        foreach (['marketing_consent', 'transactional_recovery_enabled'] as $field) {
+            if (array_key_exists($field, $payload)) {
+                $context[$field] = (bool) $payload[$field];
+            }
+        }
+
+        return array_replace($context, $attribution);
+    }
+
+    /**
+     * @param  array<string,mixed>  $payload
+     * @param  array<string,mixed>  $attribution
+     * @param  array<string,mixed>  $subscriberCapture
+     * @return array<string,mixed>
+     */
+    private function buildCheckoutEmailCapture(
+        ?string $contactEmail,
+        array $payload,
+        array $attribution,
+        array $subscriberCapture
+    ): array {
+        if ($contactEmail === null) {
+            return [];
+        }
+
+        $emailCapture = [
+            'contact_email_hash' => hash('sha256', mb_strtolower(trim($contactEmail), 'UTF-8')),
+            'subscriber_status' => (string) ($subscriberCapture['subscriber_status'] ?? 'active'),
+            'marketing_consent' => (bool) ($subscriberCapture['marketing_consent'] ?? false),
+            'transactional_recovery_enabled' => (bool) ($subscriberCapture['transactional_recovery_enabled'] ?? true),
+        ];
+
+        $capturedAt = trim((string) ($subscriberCapture['captured_at'] ?? ''));
+        if ($capturedAt !== '') {
+            $emailCapture['captured_at'] = $capturedAt;
+        }
+
+        $surface = $this->truncateNullableString($payload['surface'] ?? null, 64);
+        if ($surface !== null) {
+            $emailCapture['surface'] = $surface;
+        }
+
+        $attemptId = $this->truncateNullableString($payload['attempt_id'] ?? null, 64);
+        if ($attemptId !== null) {
+            $emailCapture['attempt_id'] = $attemptId;
+        }
+
+        return array_replace($emailCapture, $attribution);
     }
 
     /**

--- a/backend/app/Http/Controllers/API/V0_3/EmailCaptureController.php
+++ b/backend/app/Http/Controllers/API/V0_3/EmailCaptureController.php
@@ -13,7 +13,9 @@ final class EmailCaptureController extends Controller
 {
     public function store(EmailCaptureRequest $request, EmailCaptureService $captures): JsonResponse
     {
-        $result = $captures->capture((string) $request->validated('email'), $request->validated());
+        /** @var array<string,mixed> $payload */
+        $payload = $request->validated();
+        $result = $captures->capture((string) ($payload['email'] ?? ''), $payload);
 
         return response()->json($result);
     }

--- a/backend/app/Http/Controllers/API/V0_3/EmailPreferenceController.php
+++ b/backend/app/Http/Controllers/API/V0_3/EmailPreferenceController.php
@@ -40,7 +40,9 @@ final class EmailPreferenceController extends Controller
         EmailPreferencesUpdateRequest $request,
         EmailPreferenceService $preferences
     ): JsonResponse {
-        $result = $preferences->updateByToken((string) $request->validated('token'), $request->validated());
+        /** @var array<string,mixed> $payload */
+        $payload = $request->validated();
+        $result = $preferences->updateByToken((string) ($payload['token'] ?? ''), $payload);
 
         if (! ($result['ok'] ?? false)) {
             return response()->json([
@@ -63,9 +65,11 @@ final class EmailPreferenceController extends Controller
         EmailUnsubscribeRequest $request,
         EmailPreferenceService $preferences
     ): JsonResponse {
+        /** @var array<string,mixed> $payload */
+        $payload = $request->validated();
         $result = $preferences->unsubscribeByToken(
-            (string) $request->validated('token'),
-            (string) $request->validated('reason', 'user_request')
+            (string) ($payload['token'] ?? ''),
+            (string) ($payload['reason'] ?? 'user_request')
         );
 
         if (! ($result['ok'] ?? false)) {

--- a/backend/app/Http/Requests/V0_3/EmailCaptureRequest.php
+++ b/backend/app/Http/Requests/V0_3/EmailCaptureRequest.php
@@ -16,7 +16,7 @@ final class EmailCaptureRequest extends FormRequest
 
     protected function prepareForValidation(): void
     {
-        $this->merge([
+        $payload = [
             'email' => $this->normalizeEmail($this->input('email')),
             'locale' => $this->normalizeString($this->input('locale'), 16),
             'surface' => $this->normalizeString($this->input('surface'), 64),
@@ -24,12 +24,21 @@ final class EmailCaptureRequest extends FormRequest
             'attempt_id' => $this->normalizeString($this->input('attempt_id'), 64),
             'share_id' => $this->normalizeString($this->input('share_id'), 128),
             'compare_invite_id' => $this->normalizeString($this->input('compare_invite_id'), 128),
+            'share_click_id' => $this->normalizeString($this->input('share_click_id'), 128),
             'entrypoint' => $this->normalizeString($this->input('entrypoint'), 128),
             'referrer' => $this->normalizeString($this->input('referrer'), 2048),
             'landing_path' => $this->normalizeString($this->input('landing_path'), 2048),
             'utm' => $this->normalizeUtm($this->input('utm')),
-            'marketing_consent' => $this->has('marketing_consent') ? $this->boolean('marketing_consent') : false,
-        ]);
+        ];
+
+        if ($this->has('marketing_consent')) {
+            $payload['marketing_consent'] = $this->boolean('marketing_consent');
+        }
+        if ($this->has('transactional_recovery_enabled')) {
+            $payload['transactional_recovery_enabled'] = $this->boolean('transactional_recovery_enabled');
+        }
+
+        $this->merge($payload);
     }
 
     public function rules(): array
@@ -42,6 +51,7 @@ final class EmailCaptureRequest extends FormRequest
             'attempt_id' => ['nullable', 'string', 'max:64'],
             'share_id' => ['nullable', 'string', 'max:128'],
             'compare_invite_id' => ['nullable', 'string', 'max:128'],
+            'share_click_id' => ['nullable', 'string', 'max:128'],
             'entrypoint' => ['nullable', 'string', 'max:128'],
             'referrer' => ['nullable', 'string', 'max:2048'],
             'landing_path' => ['nullable', 'string', 'max:2048'],
@@ -52,6 +62,7 @@ final class EmailCaptureRequest extends FormRequest
             'utm.term' => ['nullable', 'string', 'max:512'],
             'utm.content' => ['nullable', 'string', 'max:512'],
             'marketing_consent' => ['nullable', 'boolean'],
+            'transactional_recovery_enabled' => ['nullable', 'boolean'],
         ];
     }
 

--- a/backend/app/Internal/Commerce/PaymentWebhookHandlerCore.php
+++ b/backend/app/Internal/Commerce/PaymentWebhookHandlerCore.php
@@ -765,6 +765,40 @@ class PaymentWebhookHandlerCore
     }
 
     /**
+     * @return array<string,mixed>
+     */
+    public function extractOrderLifecycleContext(object $order): array
+    {
+        $meta = $this->decodeMeta($order->meta_json ?? null);
+        $emailCapture = is_array($meta['email_capture'] ?? null) ? $meta['email_capture'] : [];
+        $normalized = [];
+
+        $subscriberStatus = strtolower(trim((string) ($emailCapture['subscriber_status'] ?? '')));
+        if (in_array($subscriberStatus, ['active', 'unsubscribed', 'suppressed'], true)) {
+            $normalized['subscriber_status'] = $subscriberStatus;
+        }
+
+        foreach (['marketing_consent', 'transactional_recovery_enabled'] as $field) {
+            if (array_key_exists($field, $emailCapture)) {
+                $normalized[$field] = filter_var(
+                    $emailCapture[$field],
+                    FILTER_VALIDATE_BOOLEAN,
+                    FILTER_NULL_ON_FAILURE
+                ) ?? false;
+            }
+        }
+
+        $surface = is_scalar($emailCapture['surface'] ?? null) ? trim((string) $emailCapture['surface']) : '';
+        if ($surface !== '') {
+            $normalized['surface'] = mb_strlen($surface, 'UTF-8') > 64
+                ? mb_substr($surface, 0, 64, 'UTF-8')
+                : $surface;
+        }
+
+        return array_replace($normalized, $this->extractOrderAttribution($order));
+    }
+
+    /**
      * @return list<string>
      */
     public function normalizeModulesIncluded(mixed $raw): array
@@ -1355,7 +1389,7 @@ class PaymentWebhookHandlerCore
                 if ($fromOrder !== '') {
                     $candidateUserIds[] = $fromOrder;
                 }
-                $attribution = $this->extractOrderAttribution($orderRow);
+                $attribution = $this->extractOrderLifecycleContext($orderRow);
             }
         }
 

--- a/backend/app/Models/EmailPreference.php
+++ b/backend/app/Models/EmailPreference.php
@@ -30,7 +30,19 @@ class EmailPreference extends Model
         'marketing_updates' => 'bool',
         'report_recovery' => 'bool',
         'product_updates' => 'bool',
+        'created_at' => 'datetime',
+        'updated_at' => 'datetime',
     ];
+
+    public function allowsMarketing(): bool
+    {
+        return (bool) ($this->marketing_updates || $this->product_updates);
+    }
+
+    public function allowsReportRecovery(): bool
+    {
+        return (bool) $this->report_recovery;
+    }
 
     public function subscriber(): BelongsTo
     {

--- a/backend/app/Models/EmailSubscriber.php
+++ b/backend/app/Models/EmailSubscriber.php
@@ -12,6 +12,12 @@ class EmailSubscriber extends Model
 {
     use HasUuids;
 
+    public const STATUS_ACTIVE = 'active';
+
+    public const STATUS_UNSUBSCRIBED = 'unsubscribed';
+
+    public const STATUS_SUPPRESSED = 'suppressed';
+
     protected $table = 'email_subscribers';
 
     public $incrementing = false;
@@ -26,10 +32,15 @@ class EmailSubscriber extends Model
         'locale',
         'first_source',
         'last_source',
+        'status',
         'marketing_consent',
         'transactional_recovery_enabled',
         'first_context_json',
         'last_context_json',
+        'first_captured_at',
+        'last_captured_at',
+        'last_marketing_consent_at',
+        'last_transactional_recovery_change_at',
         'unsubscribed_at',
     ];
 
@@ -38,8 +49,22 @@ class EmailSubscriber extends Model
         'transactional_recovery_enabled' => 'bool',
         'first_context_json' => 'array',
         'last_context_json' => 'array',
+        'first_captured_at' => 'datetime',
+        'last_captured_at' => 'datetime',
+        'last_marketing_consent_at' => 'datetime',
+        'last_transactional_recovery_change_at' => 'datetime',
         'unsubscribed_at' => 'datetime',
     ];
+
+    public function allowsMarketing(): bool
+    {
+        return (bool) $this->marketing_consent;
+    }
+
+    public function allowsTransactionalRecovery(): bool
+    {
+        return (bool) $this->transactional_recovery_enabled;
+    }
 
     public function preference(): HasOne
     {

--- a/backend/app/Models/EmailSuppression.php
+++ b/backend/app/Models/EmailSuppression.php
@@ -27,5 +27,7 @@ class EmailSuppression extends Model
 
     protected $casts = [
         'meta_json' => 'array',
+        'created_at' => 'datetime',
+        'updated_at' => 'datetime',
     ];
 }

--- a/backend/app/Models/Event.php
+++ b/backend/app/Models/Event.php
@@ -3,14 +3,15 @@
 namespace App\Models;
 
 use App\Models\Concerns\HasOrgScope;
-use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Concerns\HasUuids;
+use Illuminate\Database\Eloquent\Model;
 
 class Event extends Model
 {
-    use HasUuids, HasOrgScope;
+    use HasOrgScope, HasUuids;
 
     public $incrementing = false;
+
     protected $keyType = 'string';
 
     protected $fillable = [
@@ -54,11 +55,11 @@ class Event extends Model
     ];
 
     protected $casts = [
-        'meta_json'   => 'array',
+        'meta_json' => 'array',
         'experiments_json' => 'array',
         'occurred_at' => 'datetime',
-        'org_id'      => 'integer',
-        'user_id'     => 'integer',
+        'org_id' => 'integer',
+        'user_id' => 'integer',
         'question_index' => 'integer',
         'duration_ms' => 'integer',
         'is_dropoff' => 'integer',

--- a/backend/app/Models/Order.php
+++ b/backend/app/Models/Order.php
@@ -41,6 +41,7 @@ class Order extends Model
         'scale_code_v2',
         'scale_uid',
         'external_trade_no',
+        'contact_email_hash',
         'metadata',
         'meta_json',
         'paid_at',

--- a/backend/app/Services/Commerce/OrderManager.php
+++ b/backend/app/Services/Commerce/OrderManager.php
@@ -35,6 +35,7 @@ class OrderManager
         ?string $contactEmail = null,
         ?string $requestId = null,
         array $attribution = [],
+        array $emailCapture = [],
     ): array {
         $requestedSku = $this->skus->normalizeSku($sku);
         if ($requestedSku === '') {
@@ -101,7 +102,8 @@ class OrderManager
             $modulesIncluded,
             $contactEmailHash,
             $requestId,
-            $attribution
+            $attribution,
+            $emailCapture
         ): array {
             $orderNo = 'ord_'.Str::uuid();
             $now = now();
@@ -113,6 +115,10 @@ class OrderManager
             $normalizedAttribution = $this->normalizeAttribution($attribution);
             if ($normalizedAttribution !== []) {
                 $orderMeta['attribution'] = $normalizedAttribution;
+            }
+            $normalizedEmailCapture = $this->normalizeEmailCapture($emailCapture, $contactEmailHash);
+            if ($normalizedEmailCapture !== []) {
+                $orderMeta['email_capture'] = $normalizedEmailCapture;
             }
 
             $row = [
@@ -609,8 +615,14 @@ class OrderManager
 
     public function mergeAttribution(string $orderNo, int $orgId, array $attribution): void
     {
+        $this->mergeCheckoutContext($orderNo, $orgId, $attribution, []);
+    }
+
+    public function mergeCheckoutContext(string $orderNo, int $orgId, array $attribution, array $emailCapture): void
+    {
         $normalizedAttribution = $this->normalizeAttribution($attribution);
-        if ($normalizedAttribution === []) {
+        $normalizedEmailCapture = $this->normalizeEmailCapture($emailCapture);
+        if ($normalizedAttribution === [] && $normalizedEmailCapture === []) {
             return;
         }
 
@@ -624,8 +636,14 @@ class OrderManager
         }
 
         $meta = $this->decodeMeta($order->meta_json ?? null);
-        $existingAttribution = is_array($meta['attribution'] ?? null) ? $meta['attribution'] : [];
-        $meta['attribution'] = array_replace($existingAttribution, $normalizedAttribution);
+        if ($normalizedAttribution !== []) {
+            $existingAttribution = is_array($meta['attribution'] ?? null) ? $meta['attribution'] : [];
+            $meta['attribution'] = array_replace_recursive($existingAttribution, $normalizedAttribution);
+        }
+        if ($normalizedEmailCapture !== []) {
+            $existingEmailCapture = is_array($meta['email_capture'] ?? null) ? $meta['email_capture'] : [];
+            $meta['email_capture'] = array_replace_recursive($existingEmailCapture, $normalizedEmailCapture);
+        }
 
         DB::table('orders')
             ->where('order_no', (string) $order->order_no)
@@ -817,6 +835,20 @@ class OrderManager
         return $this->normalizeAttribution($attribution);
     }
 
+    /**
+     * @return array<string,mixed>
+     */
+    public function extractEmailCaptureFromOrder(object $order): array
+    {
+        $meta = $this->decodeMeta($order->meta_json ?? null);
+        $emailCapture = is_array($meta['email_capture'] ?? null) ? $meta['email_capture'] : [];
+
+        return $this->normalizeEmailCapture(
+            $emailCapture,
+            $this->normalizeEmailHash((string) ($order->contact_email_hash ?? ''))
+        );
+    }
+
     private function reportUrl(string $attemptId): string
     {
         return "/api/v0.3/attempts/{$attemptId}/report";
@@ -871,6 +903,52 @@ class OrderManager
         }
 
         return $normalized;
+    }
+
+    /**
+     * @param  array<string,mixed>  $emailCapture
+     * @return array<string,mixed>
+     */
+    private function normalizeEmailCapture(array $emailCapture, ?string $contactEmailHash = null): array
+    {
+        $normalized = [];
+
+        $resolvedContactEmailHash = $contactEmailHash ?? $this->normalizeEmailHash(
+            is_scalar($emailCapture['contact_email_hash'] ?? null) ? (string) $emailCapture['contact_email_hash'] : null
+        );
+        if ($resolvedContactEmailHash !== null) {
+            $normalized['contact_email_hash'] = $resolvedContactEmailHash;
+        }
+
+        $subscriberStatus = strtolower(trim((string) ($emailCapture['subscriber_status'] ?? '')));
+        if (in_array($subscriberStatus, ['active', 'unsubscribed', 'suppressed'], true)) {
+            $normalized['subscriber_status'] = $subscriberStatus;
+        }
+
+        foreach (['marketing_consent', 'transactional_recovery_enabled'] as $field) {
+            if (array_key_exists($field, $emailCapture)) {
+                $normalized[$field] = filter_var(
+                    $emailCapture[$field],
+                    FILTER_VALIDATE_BOOLEAN,
+                    FILTER_NULL_ON_FAILURE
+                ) ?? false;
+            }
+        }
+
+        foreach ([
+            'captured_at' => 64,
+            'surface' => 64,
+            'attempt_id' => 64,
+        ] as $field => $maxLength) {
+            $value = $this->trimOrNull(is_scalar($emailCapture[$field] ?? null) ? (string) $emailCapture[$field] : null);
+            if ($value !== null) {
+                $normalized[$field] = mb_strlen($value, 'UTF-8') > $maxLength
+                    ? mb_substr($value, 0, $maxLength, 'UTF-8')
+                    : $value;
+            }
+        }
+
+        return array_replace($normalized, $this->normalizeAttribution($emailCapture));
     }
 
     private function syncPurchasedInviteFromOrder(?object $order, ?string $paidAt): void

--- a/backend/app/Services/Email/EmailCaptureService.php
+++ b/backend/app/Services/Email/EmailCaptureService.php
@@ -24,23 +24,29 @@ class EmailCaptureService
      *     ok:bool,
      *     subscriber_id:string,
      *     status:string,
+     *     subscriber_status:string,
+     *     captured_at:string,
      *     marketing_consent:bool,
+     *     transactional_recovery_enabled:bool,
      *     preferences:array{marketing_updates:bool,report_recovery:bool,product_updates:bool}
      * }
      */
     public function capture(string $email, array $context = []): array
     {
-        $status = 'captured';
-        $subscriber = $this->upsertSubscriber($email, $context, $status);
+        $captureStatus = 'captured';
+        $subscriber = $this->upsertSubscriber($email, $context, $captureStatus);
         $preference = $subscriber->preference instanceof EmailPreference
             ? $subscriber->preference
-            : $this->ensurePreference($subscriber, null);
+            : $this->ensurePreference($subscriber, null, null);
 
         return [
             'ok' => true,
             'subscriber_id' => (string) $subscriber->getKey(),
-            'status' => $status,
-            'marketing_consent' => (bool) ($subscriber->marketing_consent ?? false),
+            'status' => $captureStatus,
+            'subscriber_status' => (string) ($subscriber->status ?? EmailSubscriber::STATUS_ACTIVE),
+            'captured_at' => $subscriber->last_captured_at?->toIso8601String() ?? now()->toIso8601String(),
+            'marketing_consent' => $subscriber->allowsMarketing(),
+            'transactional_recovery_enabled' => $subscriber->allowsTransactionalRecovery(),
             'preferences' => $this->preferencesPayload($preference),
         ];
     }
@@ -50,51 +56,107 @@ class EmailCaptureService
      */
     public function ensureSubscriber(string $email, array $context = []): EmailSubscriber
     {
-        $status = 'captured';
+        $captureStatus = 'captured';
 
-        return $this->upsertSubscriber($email, $context, $status);
+        return $this->upsertSubscriber($email, $context, $captureStatus);
     }
 
-    public function isSuppressed(string $email): bool
+    /**
+     * @return array{
+     *     subscriber_id:?string,
+     *     subscriber_status:string,
+     *     marketing_consent:bool,
+     *     transactional_recovery_enabled:bool,
+     *     first_source:?string,
+     *     last_source:?string,
+     *     first_context_json:array<string,mixed>,
+     *     last_context_json:array<string,mixed>,
+     *     first_captured_at:?string,
+     *     last_captured_at:?string
+     * }
+     */
+    public function subscriberLifecycleSnapshot(string $email): array
     {
-        $normalized = $this->normalizeEmail($email);
-        if ($normalized === null) {
-            return false;
+        $normalizedEmail = $this->normalizeEmail($email);
+        if ($normalizedEmail === null) {
+            return $this->defaultLifecycleSnapshot();
         }
 
-        return EmailSuppression::query()
-            ->where('email_hash', $this->piiCipher->emailHash($normalized))
+        $emailHash = $this->piiCipher->emailHash($normalizedEmail);
+        $suppressed = EmailSuppression::query()
+            ->where('email_hash', $emailHash)
             ->exists();
-    }
-
-    public function allowsReportRecovery(string $email): bool
-    {
-        $normalized = $this->normalizeEmail($email);
-        if ($normalized === null) {
-            return false;
-        }
-
-        if ($this->isSuppressed($normalized)) {
-            return false;
-        }
 
         $subscriber = EmailSubscriber::query()
             ->with('preference')
-            ->where('email_hash', $this->piiCipher->emailHash($normalized))
+            ->where('email_hash', $emailHash)
             ->first();
 
         if (! $subscriber) {
-            return true;
+            return [
+                'subscriber_id' => null,
+                'subscriber_status' => $suppressed ? EmailSubscriber::STATUS_SUPPRESSED : EmailSubscriber::STATUS_ACTIVE,
+                'marketing_consent' => false,
+                'transactional_recovery_enabled' => true,
+                'first_source' => null,
+                'last_source' => null,
+                'first_context_json' => [],
+                'last_context_json' => [],
+                'first_captured_at' => null,
+                'last_captured_at' => null,
+            ];
         }
 
         $preference = $subscriber->preference instanceof EmailPreference
             ? $subscriber->preference
             : null;
-        if ($preference instanceof EmailPreference) {
-            return (bool) $preference->report_recovery;
+
+        $marketingConsent = $preference instanceof EmailPreference
+            ? $preference->allowsMarketing()
+            : $subscriber->allowsMarketing();
+        $transactionalRecoveryEnabled = $preference instanceof EmailPreference
+            ? $preference->allowsReportRecovery()
+            : $subscriber->allowsTransactionalRecovery();
+        $subscriberStatus = $this->resolveLifecycleStatus(
+            $suppressed,
+            $marketingConsent,
+            $transactionalRecoveryEnabled,
+            $subscriber->unsubscribed_at
+        );
+
+        if ((string) ($subscriber->status ?? '') !== $subscriberStatus) {
+            $subscriber->status = $subscriberStatus;
+            $subscriber->save();
         }
 
-        return (bool) ($subscriber->transactional_recovery_enabled ?? true);
+        return [
+            'subscriber_id' => (string) $subscriber->getKey(),
+            'subscriber_status' => $subscriberStatus,
+            'marketing_consent' => $marketingConsent,
+            'transactional_recovery_enabled' => $transactionalRecoveryEnabled,
+            'first_source' => $subscriber->first_source,
+            'last_source' => $subscriber->last_source,
+            'first_context_json' => is_array($subscriber->first_context_json) ? $subscriber->first_context_json : [],
+            'last_context_json' => is_array($subscriber->last_context_json) ? $subscriber->last_context_json : [],
+            'first_captured_at' => $subscriber->first_captured_at?->toIso8601String(),
+            'last_captured_at' => $subscriber->last_captured_at?->toIso8601String(),
+        ];
+    }
+
+    public function isSuppressed(string $email): bool
+    {
+        return $this->subscriberLifecycleSnapshot($email)['subscriber_status'] === EmailSubscriber::STATUS_SUPPRESSED;
+    }
+
+    public function allowsReportRecovery(string $email): bool
+    {
+        $snapshot = $this->subscriberLifecycleSnapshot($email);
+
+        if ($snapshot['subscriber_status'] === EmailSubscriber::STATUS_SUPPRESSED) {
+            return false;
+        }
+
+        return (bool) $snapshot['transactional_recovery_enabled'];
     }
 
     private function normalizeEmail(string $email): ?string
@@ -114,7 +176,7 @@ class EmailCaptureService
     /**
      * @param  array<string,mixed>  $context
      */
-    private function upsertSubscriber(string $email, array $context, string &$status): EmailSubscriber
+    private function upsertSubscriber(string $email, array $context, string &$captureStatus): EmailSubscriber
     {
         $normalizedEmail = $this->normalizeEmail($email);
         if ($normalizedEmail === null) {
@@ -135,7 +197,11 @@ class EmailCaptureService
         $contextPayload = $this->normalizeContext($context);
         $marketingConsent = $this->resolveMarketingConsent($context);
         $marketingConsentProvided = array_key_exists('marketing_consent', $context);
+        $transactionalRecoveryEnabled = $this->resolveTransactionalRecoveryEnabled($context);
+        $transactionalRecoveryProvided = array_key_exists('transactional_recovery_enabled', $context);
+        $capturedAt = now();
         $created = false;
+
         $subscriber = DB::transaction(function () use (
             $emailHash,
             $emailEnc,
@@ -144,6 +210,10 @@ class EmailCaptureService
             $contextPayload,
             $marketingConsent,
             $marketingConsentProvided,
+            $transactionalRecoveryEnabled,
+            $transactionalRecoveryProvided,
+            $suppressed,
+            $capturedAt,
             &$created
         ): EmailSubscriber {
             $subscriber = EmailSubscriber::query()
@@ -155,6 +225,7 @@ class EmailCaptureService
                 $subscriber = new EmailSubscriber([
                     'id' => (string) Str::uuid(),
                     'email_hash' => $emailHash,
+                    'status' => EmailSubscriber::STATUS_ACTIVE,
                     'marketing_consent' => false,
                     'transactional_recovery_enabled' => true,
                 ]);
@@ -168,42 +239,75 @@ class EmailCaptureService
                 $subscriber->locale = $locale;
             }
 
-            if ($created && $source !== null && $subscriber->first_source === null) {
+            if ($source !== null && $subscriber->first_source === null) {
                 $subscriber->first_source = $source;
             }
             if ($source !== null) {
                 $subscriber->last_source = $source;
             }
 
-            if ($created && $contextPayload !== [] && empty($subscriber->first_context_json)) {
-                $subscriber->first_context_json = $contextPayload;
-            }
             if ($contextPayload !== []) {
-                $subscriber->last_context_json = $contextPayload;
+                $firstContext = is_array($subscriber->first_context_json) ? $subscriber->first_context_json : [];
+                $lastContext = is_array($subscriber->last_context_json) ? $subscriber->last_context_json : [];
+
+                if ($firstContext === []) {
+                    $subscriber->first_context_json = $contextPayload;
+                }
+                $subscriber->last_context_json = array_replace_recursive($lastContext, $contextPayload);
             }
+
+            if ($subscriber->first_captured_at === null) {
+                $subscriber->first_captured_at = $capturedAt;
+            }
+            $subscriber->last_captured_at = $capturedAt;
 
             if ($marketingConsentProvided && $marketingConsent !== null) {
                 $subscriber->marketing_consent = $marketingConsent;
+                $subscriber->last_marketing_consent_at = $capturedAt;
+            }
+            if ($transactionalRecoveryProvided && $transactionalRecoveryEnabled !== null) {
+                $subscriber->transactional_recovery_enabled = $transactionalRecoveryEnabled;
+                $subscriber->last_transactional_recovery_change_at = $capturedAt;
             }
 
             $subscriber->save();
 
-            $preference = $this->ensurePreference($subscriber, $marketingConsentProvided ? $marketingConsent : null);
-            $subscriber->transactional_recovery_enabled = (bool) $preference->report_recovery;
-            $subscriber->marketing_consent = (bool) ($preference->marketing_updates || $preference->product_updates);
+            $preference = $this->ensurePreference(
+                $subscriber,
+                $marketingConsentProvided ? $marketingConsent : null,
+                $transactionalRecoveryProvided ? $transactionalRecoveryEnabled : null
+            );
+
+            $subscriber->transactional_recovery_enabled = $preference->allowsReportRecovery();
+            $subscriber->marketing_consent = $preference->allowsMarketing();
+            $subscriber->status = $this->resolveLifecycleStatus(
+                $suppressed,
+                $subscriber->allowsMarketing(),
+                $subscriber->allowsTransactionalRecovery(),
+                $subscriber->unsubscribed_at
+            );
+            if ($subscriber->status === EmailSubscriber::STATUS_UNSUBSCRIBED && $subscriber->unsubscribed_at === null) {
+                $subscriber->unsubscribed_at = $capturedAt;
+            }
+            if ($subscriber->status === EmailSubscriber::STATUS_ACTIVE) {
+                $subscriber->unsubscribed_at = null;
+            }
             $subscriber->save();
             $subscriber->setRelation('preference', $preference);
 
-            return $subscriber;
+            return $subscriber->fresh(['preference']);
         });
 
-        $status = $suppressed ? 'suppressed' : ($created ? 'captured' : 'updated');
+        $captureStatus = $suppressed ? 'suppressed' : ($created ? 'captured' : 'updated');
 
         return $subscriber;
     }
 
-    private function ensurePreference(EmailSubscriber $subscriber, ?bool $marketingConsent): EmailPreference
-    {
+    private function ensurePreference(
+        EmailSubscriber $subscriber,
+        ?bool $marketingConsent,
+        ?bool $transactionalRecoveryEnabled
+    ): EmailPreference {
         $preference = EmailPreference::query()
             ->where('subscriber_id', $subscriber->getKey())
             ->first();
@@ -212,18 +316,28 @@ class EmailCaptureService
             $preference = new EmailPreference([
                 'id' => (string) Str::uuid(),
                 'subscriber_id' => (string) $subscriber->getKey(),
-                'marketing_updates' => (bool) $marketingConsent,
-                'report_recovery' => true,
-                'product_updates' => (bool) $marketingConsent,
+                'marketing_updates' => $marketingConsent ?? $subscriber->allowsMarketing(),
+                'report_recovery' => $transactionalRecoveryEnabled ?? $subscriber->allowsTransactionalRecovery(),
+                'product_updates' => $marketingConsent ?? $subscriber->allowsMarketing(),
             ]);
             $preference->save();
 
             return $preference;
         }
 
+        $dirty = false;
         if ($marketingConsent !== null) {
+            $dirty = $dirty || (bool) $preference->marketing_updates !== $marketingConsent;
+            $dirty = $dirty || (bool) $preference->product_updates !== $marketingConsent;
             $preference->marketing_updates = $marketingConsent;
             $preference->product_updates = $marketingConsent;
+        }
+        if ($transactionalRecoveryEnabled !== null) {
+            $dirty = $dirty || (bool) $preference->report_recovery !== $transactionalRecoveryEnabled;
+            $preference->report_recovery = $transactionalRecoveryEnabled;
+        }
+
+        if ($dirty) {
             $preference->save();
         }
 
@@ -232,6 +346,7 @@ class EmailCaptureService
 
     /**
      * @param  array<string,mixed>  $context
+     * @return array<string,mixed>
      */
     private function normalizeContext(array $context): array
     {
@@ -244,6 +359,7 @@ class EmailCaptureService
             'attempt_id' => 64,
             'share_id' => 128,
             'compare_invite_id' => 128,
+            'share_click_id' => 128,
             'entrypoint' => 128,
             'referrer' => 2048,
             'landing_path' => 2048,
@@ -263,6 +379,12 @@ class EmailCaptureService
             $consent = $this->resolveMarketingConsent($context);
             if ($consent !== null) {
                 $normalized['marketing_consent'] = $consent;
+            }
+        }
+        if (array_key_exists('transactional_recovery_enabled', $context)) {
+            $recovery = $this->resolveTransactionalRecoveryEnabled($context);
+            if ($recovery !== null) {
+                $normalized['transactional_recovery_enabled'] = $recovery;
             }
         }
 
@@ -287,6 +409,20 @@ class EmailCaptureService
         }
 
         $value = filter_var($context['marketing_consent'], FILTER_VALIDATE_BOOLEAN, FILTER_NULL_ON_FAILURE);
+
+        return $value ?? false;
+    }
+
+    /**
+     * @param  array<string,mixed>  $context
+     */
+    private function resolveTransactionalRecoveryEnabled(array $context): ?bool
+    {
+        if (! array_key_exists('transactional_recovery_enabled', $context)) {
+            return null;
+        }
+
+        $value = filter_var($context['transactional_recovery_enabled'], FILTER_VALIDATE_BOOLEAN, FILTER_NULL_ON_FAILURE);
 
         return $value ?? false;
     }
@@ -327,6 +463,53 @@ class EmailCaptureService
         }
 
         return $normalized;
+    }
+
+    private function resolveLifecycleStatus(
+        bool $suppressed,
+        bool $marketingConsent,
+        bool $transactionalRecoveryEnabled,
+        mixed $unsubscribedAt = null
+    ): string {
+        if ($suppressed) {
+            return EmailSubscriber::STATUS_SUPPRESSED;
+        }
+
+        if ($unsubscribedAt !== null || (! $marketingConsent && ! $transactionalRecoveryEnabled)) {
+            return EmailSubscriber::STATUS_UNSUBSCRIBED;
+        }
+
+        return EmailSubscriber::STATUS_ACTIVE;
+    }
+
+    /**
+     * @return array{
+     *     subscriber_id:?string,
+     *     subscriber_status:string,
+     *     marketing_consent:bool,
+     *     transactional_recovery_enabled:bool,
+     *     first_source:?string,
+     *     last_source:?string,
+     *     first_context_json:array<string,mixed>,
+     *     last_context_json:array<string,mixed>,
+     *     first_captured_at:?string,
+     *     last_captured_at:?string
+     * }
+     */
+    private function defaultLifecycleSnapshot(): array
+    {
+        return [
+            'subscriber_id' => null,
+            'subscriber_status' => EmailSubscriber::STATUS_ACTIVE,
+            'marketing_consent' => false,
+            'transactional_recovery_enabled' => true,
+            'first_source' => null,
+            'last_source' => null,
+            'first_context_json' => [],
+            'last_context_json' => [],
+            'first_captured_at' => null,
+            'last_captured_at' => null,
+        ];
     }
 
     /**

--- a/backend/app/Services/Email/EmailOutboxService.php
+++ b/backend/app/Services/Email/EmailOutboxService.php
@@ -16,6 +16,7 @@ class EmailOutboxService
         private readonly PiiCipher $piiCipher,
         private readonly PiiReadFallbackMonitor $fallbackMonitor,
         private readonly EmailPreferenceService $emailPreferences,
+        private readonly EmailCaptureService $emailCaptures,
     ) {}
 
     /**
@@ -58,20 +59,25 @@ class EmailOutboxService
         $reportUrl = $this->reportUrl($attemptId);
         $reportPdfUrl = $this->reportPdfUrl($attemptId);
         $claimUrl = "/api/v0.3/claim/report?token={$token}";
-        $normalizedAttribution = $this->normalizeAttribution($attribution);
+        $lifecycleContext = $this->buildLifecyclePayloadContext($email, $orderNo !== '' ? $orderNo : null, $attribution);
+        $normalizedAttribution = is_array($lifecycleContext['attribution'] ?? null)
+            ? $lifecycleContext['attribution']
+            : [];
 
         $payload = [
             'attempt_id' => $attemptId,
             'order_no' => $orderNo !== '' ? $orderNo : null,
             'report_url' => $reportUrl,
             'report_pdf_url' => $reportPdfUrl,
-            'claim_token' => $token,
-            'claim_url' => $claimUrl,
             'claim_expires_at' => $expiresAt->toIso8601String(),
             'locale' => $locale,
             'template_key' => 'report_claim',
             'to_email' => $email,
             'subject' => $subject,
+            'subscriber_status' => (string) ($lifecycleContext['subscriber_status'] ?? 'active'),
+            'marketing_consent' => (bool) ($lifecycleContext['marketing_consent'] ?? false),
+            'transactional_recovery_enabled' => (bool) ($lifecycleContext['transactional_recovery_enabled'] ?? true),
+            'surface' => $lifecycleContext['surface'] ?? null,
             'attribution' => $this->payloadAttribution($normalizedAttribution),
         ];
         $payloadJson = $this->encodePayloadJson($this->sanitizePayloadForJson($payload));
@@ -247,7 +253,10 @@ class EmailOutboxService
         $reportUrl = $this->reportUrl($attemptId);
         $reportPdfUrl = $this->reportPdfUrl($attemptId);
         $nonce = hash('sha256', 'payment_success|'.$attemptId.'|'.Str::uuid()->toString());
-        $normalizedAttribution = $this->normalizeAttribution($attribution);
+        $lifecycleContext = $this->buildLifecyclePayloadContext($email, $orderNo !== '' ? $orderNo : null, $attribution);
+        $normalizedAttribution = is_array($lifecycleContext['attribution'] ?? null)
+            ? $lifecycleContext['attribution']
+            : [];
 
         $payload = [
             'attempt_id' => $attemptId,
@@ -259,6 +268,10 @@ class EmailOutboxService
             'template_key' => 'payment_success',
             'to_email' => $email,
             'subject' => $subject,
+            'subscriber_status' => (string) ($lifecycleContext['subscriber_status'] ?? 'active'),
+            'marketing_consent' => (bool) ($lifecycleContext['marketing_consent'] ?? false),
+            'transactional_recovery_enabled' => (bool) ($lifecycleContext['transactional_recovery_enabled'] ?? true),
+            'surface' => $lifecycleContext['surface'] ?? null,
             'attribution' => $this->payloadAttribution($normalizedAttribution),
         ];
         $payloadJson = $this->encodePayloadJson($this->sanitizePayloadForJson($payload));
@@ -1159,6 +1172,51 @@ class EmailOutboxService
     }
 
     /**
+     * @param  array<string,mixed>  $context
+     * @return array<string,mixed>
+     */
+    public function buildLifecyclePayloadContext(string $email, ?string $orderNo = null, array $context = []): array
+    {
+        $subscriberSnapshot = $this->emailCaptures->subscriberLifecycleSnapshot($email);
+        $orderContext = $this->resolveOrderLifecycleContext($orderNo);
+
+        $subscriberAttribution = $this->normalizeAttribution(
+            is_array($subscriberSnapshot['last_context_json'] ?? null) ? $subscriberSnapshot['last_context_json'] : []
+        );
+        $orderAttribution = is_array($orderContext['attribution'] ?? null) ? $orderContext['attribution'] : [];
+        $contextAttribution = $this->normalizeAttribution(array_replace(
+            is_array($context['attribution'] ?? null) ? $context['attribution'] : [],
+            $context
+        ));
+
+        $surface = $this->firstNonEmptyString([
+            $context['surface'] ?? null,
+            data_get($orderContext, 'email_capture.surface'),
+            data_get($subscriberSnapshot, 'last_context_json.surface'),
+        ], 64);
+
+        return [
+            'subscriber_status' => $this->firstLifecycleStatus([
+                $subscriberSnapshot['subscriber_status'] ?? null,
+                data_get($orderContext, 'email_capture.subscriber_status'),
+                $context['subscriber_status'] ?? null,
+            ]) ?? 'active',
+            'marketing_consent' => $this->firstBoolean([
+                $context['marketing_consent'] ?? null,
+                $subscriberSnapshot['marketing_consent'] ?? null,
+                data_get($orderContext, 'email_capture.marketing_consent'),
+            ]) ?? false,
+            'transactional_recovery_enabled' => $this->firstBoolean([
+                $context['transactional_recovery_enabled'] ?? null,
+                $subscriberSnapshot['transactional_recovery_enabled'] ?? null,
+                data_get($orderContext, 'email_capture.transactional_recovery_enabled'),
+            ]) ?? true,
+            'surface' => $surface,
+            'attribution' => array_replace_recursive($subscriberAttribution, $orderAttribution, $contextAttribution),
+        ];
+    }
+
+    /**
      * @param  array<string,mixed>  $payload
      * @param  array<string,mixed>  $guard
      * @return array<string,mixed>
@@ -1189,6 +1247,7 @@ class EmailOutboxService
             'attempt_id' => $attemptId !== '' ? $attemptId : null,
             'share_id' => $normalizedAttribution['share_id'] ?? null,
             'compare_invite_id' => $normalizedAttribution['compare_invite_id'] ?? null,
+            'share_click_id' => $normalizedAttribution['share_click_id'] ?? null,
             'entrypoint' => $normalizedAttribution['entrypoint'] ?? "email_{$templateKey}",
             'referrer' => $normalizedAttribution['referrer'] ?? null,
             'landing_path' => $normalizedAttribution['landing_path'] ?? null,
@@ -1224,6 +1283,13 @@ class EmailOutboxService
             'refund_status' => trim((string) ($payload['refund_status'] ?? '')),
             'refundEta' => trim((string) ($payload['refund_eta'] ?? '')),
             'refund_eta' => trim((string) ($payload['refund_eta'] ?? '')),
+            'subscriberStatus' => trim((string) ($payload['subscriber_status'] ?? '')),
+            'subscriber_status' => trim((string) ($payload['subscriber_status'] ?? '')),
+            'marketingConsent' => (bool) ($payload['marketing_consent'] ?? false),
+            'marketing_consent' => (bool) ($payload['marketing_consent'] ?? false),
+            'transactionalRecoveryEnabled' => (bool) ($payload['transactional_recovery_enabled'] ?? true),
+            'transactional_recovery_enabled' => (bool) ($payload['transactional_recovery_enabled'] ?? true),
+            'surface' => trim((string) ($payload['surface'] ?? '')),
             'supportEmail' => $supportEmail,
             'support_email' => $supportEmail,
             'supportTicketUrl' => $this->absoluteUrl((string) ($payload['support_ticket_url'] ?? ''), $frontendBaseUrl),
@@ -1591,6 +1657,161 @@ class EmailOutboxService
     private function reportPdfUrl(string $attemptId): string
     {
         return "/api/v0.3/attempts/{$attemptId}/report.pdf";
+    }
+
+    /**
+     * @return array{attribution:array<string,mixed>,email_capture:array<string,mixed>}
+     */
+    private function resolveOrderLifecycleContext(?string $orderNo): array
+    {
+        $normalizedOrderNo = $this->trimOrNull($orderNo);
+        if ($normalizedOrderNo === null || ! \App\Support\SchemaBaseline::hasTable('orders')) {
+            return [
+                'attribution' => [],
+                'email_capture' => [],
+            ];
+        }
+
+        $order = DB::table('orders')
+            ->select(['meta_json', 'contact_email_hash'])
+            ->where('order_no', $normalizedOrderNo)
+            ->orderByDesc('updated_at')
+            ->first();
+
+        if (! $order) {
+            return [
+                'attribution' => [],
+                'email_capture' => [],
+            ];
+        }
+
+        $meta = $this->decodeMetaValue($order->meta_json ?? null);
+        $attribution = $this->normalizeAttribution(is_array($meta['attribution'] ?? null) ? $meta['attribution'] : []);
+        $emailCapture = $this->normalizeLifecycleEmailCapture(
+            is_array($meta['email_capture'] ?? null) ? $meta['email_capture'] : [],
+            $this->trimHash((string) ($order->contact_email_hash ?? ''))
+        );
+
+        return [
+            'attribution' => $attribution,
+            'email_capture' => $emailCapture,
+        ];
+    }
+
+    /**
+     * @param  array<string,mixed>  $emailCapture
+     * @return array<string,mixed>
+     */
+    private function normalizeLifecycleEmailCapture(array $emailCapture, ?string $contactEmailHash = null): array
+    {
+        $normalized = [];
+
+        $resolvedHash = $contactEmailHash ?? $this->trimHash((string) ($emailCapture['contact_email_hash'] ?? ''));
+        if ($resolvedHash !== null) {
+            $normalized['contact_email_hash'] = $resolvedHash;
+        }
+
+        $status = $this->firstLifecycleStatus([$emailCapture['subscriber_status'] ?? null]);
+        if ($status !== null) {
+            $normalized['subscriber_status'] = $status;
+        }
+
+        foreach (['marketing_consent', 'transactional_recovery_enabled'] as $field) {
+            $value = $this->firstBoolean([$emailCapture[$field] ?? null]);
+            if ($value !== null) {
+                $normalized[$field] = $value;
+            }
+        }
+
+        foreach ([
+            'captured_at' => 64,
+            'surface' => 64,
+            'attempt_id' => 64,
+        ] as $field => $maxLength) {
+            $value = $this->firstNonEmptyString([$emailCapture[$field] ?? null], $maxLength);
+            if ($value !== null) {
+                $normalized[$field] = $value;
+            }
+        }
+
+        return array_replace($normalized, $this->normalizeAttribution($emailCapture));
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    private function decodeMetaValue(mixed $value): array
+    {
+        if (is_array($value)) {
+            return $value;
+        }
+
+        if (is_string($value) && trim($value) !== '') {
+            $decoded = json_decode($value, true);
+            if (is_array($decoded)) {
+                return $decoded;
+            }
+        }
+
+        return [];
+    }
+
+    private function trimHash(string $value): ?string
+    {
+        $normalized = strtolower(trim($value));
+
+        return preg_match('/^[a-f0-9]{64}$/', $normalized) === 1 ? $normalized : null;
+    }
+
+    /**
+     * @param  array<int,mixed>  $candidates
+     */
+    private function firstBoolean(array $candidates): ?bool
+    {
+        foreach ($candidates as $candidate) {
+            if ($candidate === null) {
+                continue;
+            }
+
+            $value = filter_var($candidate, FILTER_VALIDATE_BOOLEAN, FILTER_NULL_ON_FAILURE);
+            if ($value !== null) {
+                return $value;
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * @param  array<int,mixed>  $candidates
+     */
+    private function firstLifecycleStatus(array $candidates): ?string
+    {
+        foreach ($candidates as $candidate) {
+            $value = strtolower(trim((string) $candidate));
+            if (in_array($value, ['active', 'unsubscribed', 'suppressed'], true)) {
+                return $value;
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * @param  array<int,mixed>  $candidates
+     */
+    private function firstNonEmptyString(array $candidates, int $maxLength): ?string
+    {
+        foreach ($candidates as $candidate) {
+            $value = $this->trimOrNull(is_scalar($candidate) ? (string) $candidate : null);
+            if ($value !== null) {
+                return mb_strlen($value, 'UTF-8') > $maxLength
+                    ? mb_substr($value, 0, $maxLength, 'UTF-8')
+                    : $value;
+            }
+        }
+
+        return null;
     }
 
     /**

--- a/backend/app/Services/Email/EmailPreferenceService.php
+++ b/backend/app/Services/Email/EmailPreferenceService.php
@@ -58,8 +58,8 @@ class EmailPreferenceService
      */
     public function deliveryPolicyForEmail(string $email, string $templateKey): array
     {
-        $normalizedEmail = $this->normalizeEmail($email);
-        if ($normalizedEmail === null) {
+        $snapshot = $this->emailCapture->subscriberLifecycleSnapshot($email);
+        if ($this->normalizeEmail($email) === null) {
             return [
                 'allowed' => false,
                 'status' => 'failed',
@@ -71,31 +71,12 @@ class EmailPreferenceService
             ];
         }
 
-        $emailHash = $this->piiCipher->emailHash($normalizedEmail);
-        $suppressed = EmailSuppression::query()
-            ->where('email_hash', $emailHash)
-            ->exists();
+        $subscriberStatus = (string) ($snapshot['subscriber_status'] ?? EmailSubscriber::STATUS_ACTIVE);
+        $reportRecovery = (bool) ($snapshot['transactional_recovery_enabled'] ?? true);
+        $marketingUpdates = (bool) ($snapshot['marketing_consent'] ?? false);
+        $productUpdates = (bool) ($snapshot['marketing_consent'] ?? false);
 
-        $subscriber = EmailSubscriber::query()
-            ->with('preference')
-            ->where('email_hash', $emailHash)
-            ->first();
-
-        $preference = $subscriber?->preference instanceof EmailPreference
-            ? $subscriber->preference
-            : null;
-
-        $reportRecovery = $preference instanceof EmailPreference
-            ? (bool) $preference->report_recovery
-            : (bool) ($subscriber->transactional_recovery_enabled ?? true);
-        $marketingUpdates = $preference instanceof EmailPreference
-            ? (bool) $preference->marketing_updates
-            : (bool) ($subscriber->marketing_consent ?? false);
-        $productUpdates = $preference instanceof EmailPreference
-            ? (bool) $preference->product_updates
-            : (bool) ($subscriber->marketing_consent ?? false);
-
-        if ($suppressed) {
+        if ($subscriberStatus === EmailSubscriber::STATUS_SUPPRESSED) {
             return [
                 'allowed' => false,
                 'status' => 'suppressed',
@@ -185,11 +166,18 @@ class EmailPreferenceService
         $preference->product_updates = (bool) ($preferences['product_updates'] ?? false);
         $preference->save();
 
-        $subscriber->marketing_consent = (bool) ($preference->marketing_updates || $preference->product_updates);
-        $subscriber->transactional_recovery_enabled = (bool) $preference->report_recovery;
-        $subscriber->unsubscribed_at = $preference->marketing_updates || $preference->report_recovery || $preference->product_updates
+        $subscriber->marketing_consent = $preference->allowsMarketing();
+        $subscriber->transactional_recovery_enabled = $preference->allowsReportRecovery();
+        $subscriber->last_marketing_consent_at = now();
+        $subscriber->last_transactional_recovery_change_at = now();
+        $subscriber->unsubscribed_at = $preference->allowsMarketing() || $preference->allowsReportRecovery()
             ? null
             : now();
+        $subscriber->status = $this->resolveSubscriberStatus(
+            $subscriber,
+            $subscriber->marketing_consent,
+            $subscriber->transactional_recovery_enabled
+        );
         $subscriber->save();
 
         return [
@@ -221,15 +209,17 @@ class EmailPreferenceService
 
         $subscriber->marketing_consent = false;
         $subscriber->transactional_recovery_enabled = false;
+        $subscriber->last_marketing_consent_at = now();
+        $subscriber->last_transactional_recovery_change_at = now();
         $subscriber->unsubscribed_at = now();
-        $subscriber->save();
+        $subscriber->status = EmailSubscriber::STATUS_UNSUBSCRIBED;
 
-        if (is_string($reason) && trim($reason) !== '' && empty($subscriber->last_context_json)) {
-            $subscriber->last_context_json = [
-                'unsubscribe_reason' => trim($reason),
-            ];
-            $subscriber->save();
+        if (is_string($reason) && trim($reason) !== '') {
+            $lastContext = is_array($subscriber->last_context_json) ? $subscriber->last_context_json : [];
+            $lastContext['unsubscribe_reason'] = trim($reason);
+            $subscriber->last_context_json = $lastContext;
         }
+        $subscriber->save();
 
         return [
             'ok' => true,
@@ -284,9 +274,9 @@ class EmailPreferenceService
             : new EmailPreference([
                 'id' => (string) Str::uuid(),
                 'subscriber_id' => (string) $subscriber->getKey(),
-                'marketing_updates' => (bool) $subscriber->marketing_consent,
-                'report_recovery' => (bool) ($subscriber->transactional_recovery_enabled ?? true),
-                'product_updates' => (bool) $subscriber->marketing_consent,
+                'marketing_updates' => $subscriber->allowsMarketing(),
+                'report_recovery' => $subscriber->allowsTransactionalRecovery(),
+                'product_updates' => $subscriber->allowsMarketing(),
             ]);
         if (! $preference->exists) {
             $preference->save();
@@ -366,6 +356,26 @@ class EmailPreferenceService
         $decoded = base64_decode($normalized, true);
 
         return is_string($decoded) ? $decoded : null;
+    }
+
+    private function resolveSubscriberStatus(
+        EmailSubscriber $subscriber,
+        bool $marketingConsent,
+        bool $transactionalRecoveryEnabled
+    ): string {
+        $suppressed = EmailSuppression::query()
+            ->where('email_hash', (string) ($subscriber->email_hash ?? ''))
+            ->exists();
+
+        if ($suppressed) {
+            return EmailSubscriber::STATUS_SUPPRESSED;
+        }
+
+        if ($subscriber->unsubscribed_at !== null || (! $marketingConsent && ! $transactionalRecoveryEnabled)) {
+            return EmailSubscriber::STATUS_UNSUBSCRIBED;
+        }
+
+        return EmailSubscriber::STATUS_ACTIVE;
     }
 
     private function maskEmail(EmailSubscriber $subscriber): string

--- a/backend/database/migrations/2026_03_13_000300_add_lifecycle_foundation_to_email_subscribers_table.php
+++ b/backend/database/migrations/2026_03_13_000300_add_lifecycle_foundation_to_email_subscribers_table.php
@@ -1,0 +1,105 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        if (! Schema::hasTable('email_subscribers')) {
+            return;
+        }
+
+        Schema::table('email_subscribers', function (Blueprint $table): void {
+            if (! Schema::hasColumn('email_subscribers', 'status')) {
+                $table->string('status', 32)->default('active')->after('last_source');
+            }
+            if (! Schema::hasColumn('email_subscribers', 'first_captured_at')) {
+                $table->timestamp('first_captured_at')->nullable()->after('last_context_json');
+            }
+            if (! Schema::hasColumn('email_subscribers', 'last_captured_at')) {
+                $table->timestamp('last_captured_at')->nullable()->after('first_captured_at');
+            }
+            if (! Schema::hasColumn('email_subscribers', 'last_marketing_consent_at')) {
+                $table->timestamp('last_marketing_consent_at')->nullable()->after('last_captured_at');
+            }
+            if (! Schema::hasColumn('email_subscribers', 'last_transactional_recovery_change_at')) {
+                $table->timestamp('last_transactional_recovery_change_at')->nullable()->after('last_marketing_consent_at');
+            }
+        });
+
+        $suppressedHashes = Schema::hasTable('email_suppressions')
+            ? DB::table('email_suppressions')
+                ->select('email_hash')
+                ->distinct()
+                ->pluck('email_hash')
+                ->map(static fn (mixed $value): string => strtolower(trim((string) $value)))
+                ->filter(static fn (string $value): bool => $value !== '')
+                ->all()
+            : [];
+
+        $preferencesBySubscriberId = Schema::hasTable('email_preferences')
+            ? DB::table('email_preferences')
+                ->select('subscriber_id', 'report_recovery', 'updated_at', 'created_at')
+                ->get()
+                ->keyBy(static fn (object $row): string => (string) $row->subscriber_id)
+            : collect();
+
+        DB::table('email_subscribers')
+            ->select([
+                'id',
+                'email_hash',
+                'marketing_consent',
+                'transactional_recovery_enabled',
+                'unsubscribed_at',
+                'created_at',
+                'updated_at',
+            ])
+            ->orderBy('created_at')
+            ->get()
+            ->each(function (object $subscriber) use ($suppressedHashes, $preferencesBySubscriberId): void {
+                $subscriberId = (string) $subscriber->id;
+                $emailHash = strtolower(trim((string) ($subscriber->email_hash ?? '')));
+                $isSuppressed = $emailHash !== '' && in_array($emailHash, $suppressedHashes, true);
+                $preference = $preferencesBySubscriberId->get($subscriberId);
+
+                $marketingConsent = (bool) ($subscriber->marketing_consent ?? false);
+                $transactionalRecoveryEnabled = $preference !== null
+                    ? (bool) ($preference->report_recovery ?? true)
+                    : (bool) ($subscriber->transactional_recovery_enabled ?? true);
+
+                $status = $isSuppressed
+                    ? 'suppressed'
+                    : (
+                        ($subscriber->unsubscribed_at !== null || (! $marketingConsent && ! $transactionalRecoveryEnabled))
+                            ? 'unsubscribed'
+                            : 'active'
+                    );
+
+                $createdAt = $subscriber->created_at ?? now();
+                $updatedAt = $subscriber->updated_at ?? $createdAt ?? now();
+                $preferenceUpdatedAt = $preference->updated_at ?? $preference->created_at ?? $updatedAt;
+
+                DB::table('email_subscribers')
+                    ->where('id', $subscriberId)
+                    ->update([
+                        'status' => $status,
+                        'first_captured_at' => $createdAt,
+                        'last_captured_at' => $updatedAt,
+                        'last_marketing_consent_at' => $updatedAt,
+                        'last_transactional_recovery_change_at' => $preferenceUpdatedAt,
+                    ]);
+            });
+    }
+
+    public function down(): void
+    {
+        // forward-only migration: rollback disabled to prevent data loss in production.
+        // Irreversible operation: schema/data rollback handled via forward fix migrations.
+    }
+};

--- a/backend/docs/contracts/openapi.snapshot.json
+++ b/backend/docs/contracts/openapi.snapshot.json
@@ -495,7 +495,7 @@
         },
         "/api/v0.3/claim/report": {
             "get": {
-                "operationId": "get_api_v0_3_claim_report",
+                "operationId": "api.v0_3.claim.report",
                 "tags": [
                     "api:v0.3"
                 ],
@@ -509,10 +509,11 @@
                     "api",
                     "Illuminate\\Routing\\Middleware\\ThrottleRequests:api_public",
                     "App\\Http\\Middleware\\NormalizeApiErrorContract"
-                ]
+                ],
+                "x-laravel-name": "api.v0_3.claim.report"
             },
             "post": {
-                "operationId": "post_api_v0_3_claim_report",
+                "operationId": "api.v0_3.claim.report.request",
                 "tags": [
                     "api:v0.3"
                 ],
@@ -529,7 +530,8 @@
                     "App\\Http\\Middleware\\ResolveAnonId",
                     "App\\Http\\Middleware\\ResolveOrgContext",
                     "App\\Http\\Middleware\\FmTokenOptional"
-                ]
+                ],
+                "x-laravel-name": "api.v0_3.claim.report.request"
             }
         },
         "/api/v0.3/compare/mbti/{inviteId}": {
@@ -626,7 +628,7 @@
         },
         "/api/v0.3/email/capture": {
             "post": {
-                "operationId": "post_api_v0_3_email_capture",
+                "operationId": "api.v0_3.email.capture",
                 "tags": [
                     "api:v0.3"
                 ],
@@ -643,12 +645,13 @@
                     "App\\Http\\Middleware\\ResolveAnonId",
                     "App\\Http\\Middleware\\ResolveOrgContext",
                     "App\\Http\\Middleware\\FmTokenOptional"
-                ]
+                ],
+                "x-laravel-name": "api.v0_3.email.capture"
             }
         },
         "/api/v0.3/email/preferences": {
             "get": {
-                "operationId": "get_api_v0_3_email_preferences",
+                "operationId": "api.v0_3.email.preferences.show",
                 "tags": [
                     "api:v0.3"
                 ],
@@ -664,10 +667,11 @@
                     "App\\Http\\Middleware\\NormalizeApiErrorContract",
                     "App\\Http\\Middleware\\ResolveAnonId",
                     "App\\Http\\Middleware\\ResolveOrgContext"
-                ]
+                ],
+                "x-laravel-name": "api.v0_3.email.preferences.show"
             },
             "post": {
-                "operationId": "post_api_v0_3_email_preferences",
+                "operationId": "api.v0_3.email.preferences.update",
                 "tags": [
                     "api:v0.3"
                 ],
@@ -683,12 +687,13 @@
                     "App\\Http\\Middleware\\NormalizeApiErrorContract",
                     "App\\Http\\Middleware\\ResolveAnonId",
                     "App\\Http\\Middleware\\ResolveOrgContext"
-                ]
+                ],
+                "x-laravel-name": "api.v0_3.email.preferences.update"
             }
         },
         "/api/v0.3/email/unsubscribe": {
             "post": {
-                "operationId": "post_api_v0_3_email_unsubscribe",
+                "operationId": "api.v0_3.email.unsubscribe",
                 "tags": [
                     "api:v0.3"
                 ],
@@ -704,7 +709,8 @@
                     "App\\Http\\Middleware\\NormalizeApiErrorContract",
                     "App\\Http\\Middleware\\ResolveAnonId",
                     "App\\Http\\Middleware\\ResolveOrgContext"
-                ]
+                ],
+                "x-laravel-name": "api.v0_3.email.unsubscribe"
             }
         },
         "/api/v0.3/experiments": {
@@ -793,7 +799,7 @@
         },
         "/api/v0.3/orders/checkout": {
             "post": {
-                "operationId": "post_api_v0_3_orders_checkout",
+                "operationId": "api.v0_3.orders.checkout",
                 "tags": [
                     "api:v0.3"
                 ],
@@ -810,12 +816,13 @@
                     "App\\Http\\Middleware\\ResolveAnonId",
                     "App\\Http\\Middleware\\ResolveOrgContext",
                     "App\\Http\\Middleware\\FmTokenOptional"
-                ]
+                ],
+                "x-laravel-name": "api.v0_3.orders.checkout"
             }
         },
         "/api/v0.3/orders/lookup": {
             "post": {
-                "operationId": "post_api_v0_3_orders_lookup",
+                "operationId": "api.v0_3.orders.lookup",
                 "tags": [
                     "api:v0.3"
                 ],
@@ -833,7 +840,8 @@
                     "App\\Http\\Middleware\\ResolveOrgContext",
                     "App\\Http\\Middleware\\FmTokenOptional",
                     "Illuminate\\Routing\\Middleware\\ThrottleRequests:api_order_lookup"
-                ]
+                ],
+                "x-laravel-name": "api.v0_3.orders.lookup"
             }
         },
         "/api/v0.3/orders/stub": {

--- a/backend/routes/api.php
+++ b/backend/routes/api.php
@@ -114,7 +114,8 @@ Route::prefix('v0.3')->middleware([
         Route::post('/auth/phone/verify', [AuthPhoneV03Controller::class, 'verify']);
     });
 
-    Route::get('/claim/report', [ClaimV03Controller::class, 'report']);
+    Route::get('/claim/report', [ClaimV03Controller::class, 'report'])
+        ->name('api.v0_3.claim.report');
 
     Route::middleware(\App\Http\Middleware\FmTokenAuth::class)->group(function () {
         Route::get('/me/attempts', [MeV03Controller::class, 'attempts']);
@@ -175,18 +176,25 @@ Route::prefix('v0.3')->middleware([
         Route::get('/skus', 'App\\Http\\Controllers\\API\\V0_3\\CommerceController@listSkus')
             ->name('api.v0_3.skus');
         Route::post('/orders/checkout', 'App\\Http\\Controllers\\API\\V0_3\\CommerceController@checkout')
-            ->middleware(\App\Http\Middleware\FmTokenOptional::class);
+            ->middleware(\App\Http\Middleware\FmTokenOptional::class)
+            ->name('api.v0_3.orders.checkout');
         Route::post('/orders/lookup', 'App\\Http\\Controllers\\API\\V0_3\\CommerceController@lookup')
-            ->middleware([\App\Http\Middleware\FmTokenOptional::class, 'throttle:api_order_lookup']);
+            ->middleware([\App\Http\Middleware\FmTokenOptional::class, 'throttle:api_order_lookup'])
+            ->name('api.v0_3.orders.lookup');
         Route::post('/orders/{order_no}/resend', 'App\\Http\\Controllers\\API\\V0_3\\CommerceController@resend')
             ->middleware(\App\Http\Middleware\FmTokenOptional::class);
         Route::post('/claim/report', [ClaimV03Controller::class, 'requestReport'])
-            ->middleware(\App\Http\Middleware\FmTokenOptional::class);
+            ->middleware(\App\Http\Middleware\FmTokenOptional::class)
+            ->name('api.v0_3.claim.report.request');
         Route::post('/email/capture', [EmailCaptureController::class, 'store'])
-            ->middleware(\App\Http\Middleware\FmTokenOptional::class);
-        Route::get('/email/preferences', [EmailPreferenceController::class, 'show']);
-        Route::post('/email/preferences', [EmailPreferenceController::class, 'update']);
-        Route::post('/email/unsubscribe', [EmailPreferenceController::class, 'unsubscribe']);
+            ->middleware(\App\Http\Middleware\FmTokenOptional::class)
+            ->name('api.v0_3.email.capture');
+        Route::get('/email/preferences', [EmailPreferenceController::class, 'show'])
+            ->name('api.v0_3.email.preferences.show');
+        Route::post('/email/preferences', [EmailPreferenceController::class, 'update'])
+            ->name('api.v0_3.email.preferences.update');
+        Route::post('/email/unsubscribe', [EmailPreferenceController::class, 'unsubscribe'])
+            ->name('api.v0_3.email.unsubscribe');
         Route::post('/orders', 'App\\Http\\Controllers\\API\\V0_3\\CommerceController@createOrder')
             ->middleware(\App\Http\Middleware\FmTokenAuth::class);
         Route::post('/orders/stub', static function (

--- a/backend/tests/Feature/Commerce/BigFiveUnlockDeliveryPipelineTest.php
+++ b/backend/tests/Feature/Commerce/BigFiveUnlockDeliveryPipelineTest.php
@@ -249,6 +249,7 @@ final class BigFiveUnlockDeliveryPipelineTest extends TestCase
         $this->assertIsArray($payloadJson);
         $this->assertSame("/api/v0.3/attempts/{$attemptId}/report", (string) ($payloadJson['report_url'] ?? ''));
         $this->assertSame("/api/v0.3/attempts/{$attemptId}/report.pdf", (string) ($payloadJson['report_pdf_url'] ?? ''));
+        $this->assertSame('active', (string) ($payloadJson['subscriber_status'] ?? ''));
         $this->assertSame('share_big5_unlock', (string) data_get($payloadJson, 'attribution.share_id'));
         $this->assertSame('clk_big5_unlock', (string) data_get($payloadJson, 'attribution.share_click_id'));
         $this->assertSame('organic', (string) data_get($payloadJson, 'attribution.utm.medium'));

--- a/backend/tests/Feature/Email/EmailOutboxAttributionTest.php
+++ b/backend/tests/Feature/Email/EmailOutboxAttributionTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Tests\Feature\Email;
 
+use App\Services\Email\EmailCaptureService;
 use App\Services\Email\EmailOutboxService;
 use App\Support\PiiCipher;
 use Illuminate\Foundation\Testing\RefreshDatabase;
@@ -27,6 +28,15 @@ final class EmailOutboxAttributionTest extends TestCase
 
         $attemptId = $this->createAttempt();
         $email = 'buyer+'.random_int(1000, 9999).'@example.com';
+
+        app(EmailCaptureService::class)->capture($email, [
+            'surface' => 'share',
+            'share_id' => 'share_123',
+            'share_click_id' => 'clk_456',
+            'entrypoint' => 'share_page',
+            'marketing_consent' => true,
+            'transactional_recovery_enabled' => true,
+        ]);
 
         /** @var EmailOutboxService $outbox */
         $outbox = app(EmailOutboxService::class);
@@ -62,6 +72,9 @@ final class EmailOutboxAttributionTest extends TestCase
 
         $payloadJson = json_decode((string) ($row->payload_json ?? '{}'), true);
         $this->assertIsArray($payloadJson);
+        $this->assertSame('active', (string) ($payloadJson['subscriber_status'] ?? ''));
+        $this->assertSame(true, $payloadJson['marketing_consent'] ?? null);
+        $this->assertSame(true, $payloadJson['transactional_recovery_enabled'] ?? null);
         $this->assertSame('share_123', (string) data_get($payloadJson, 'attribution.share_id'));
         $this->assertSame('clk_456', (string) data_get($payloadJson, 'attribution.share_click_id'));
         $this->assertSame('organic', (string) data_get($payloadJson, 'attribution.utm.medium'));
@@ -73,6 +86,7 @@ final class EmailOutboxAttributionTest extends TestCase
         $payloadEnc = json_decode((string) $pii->decrypt((string) ($row->payload_enc ?? '')), true);
         $this->assertIsArray($payloadEnc);
         $this->assertSame($email, (string) ($payloadEnc['to_email'] ?? ''));
+        $this->assertSame('active', (string) ($payloadEnc['subscriber_status'] ?? ''));
         $this->assertSame('hero', (string) data_get($payloadEnc, 'attribution.utm.content'));
 
         Mail::mailer('array')->getSymfonyTransport()->flush();
@@ -94,6 +108,12 @@ final class EmailOutboxAttributionTest extends TestCase
         ]);
 
         $attemptId = $this->createAttempt();
+        app(EmailCaptureService::class)->capture('claim@example.com', [
+            'surface' => 'lookup',
+            'entrypoint' => 'order_lookup',
+            'marketing_consent' => false,
+            'transactional_recovery_enabled' => true,
+        ]);
 
         /** @var EmailOutboxService $outbox */
         $outbox = app(EmailOutboxService::class);
@@ -123,8 +143,18 @@ final class EmailOutboxAttributionTest extends TestCase
 
         $payloadJson = json_decode((string) ($row->payload_json ?? '{}'), true);
         $this->assertIsArray($payloadJson);
+        $this->assertSame('active', (string) ($payloadJson['subscriber_status'] ?? ''));
+        $this->assertSame(false, $payloadJson['marketing_consent'] ?? null);
+        $this->assertSame(true, $payloadJson['transactional_recovery_enabled'] ?? null);
         $this->assertSame('share_claim', (string) data_get($payloadJson, 'attribution.share_id'));
         $this->assertSame('order_lookup', (string) data_get($payloadJson, 'attribution.entrypoint'));
+
+        /** @var PiiCipher $pii */
+        $pii = app(PiiCipher::class);
+        $payloadEnc = json_decode((string) $pii->decrypt((string) ($row->payload_enc ?? '')), true);
+        $this->assertIsArray($payloadEnc);
+        $this->assertArrayNotHasKey('claim_token', $payloadEnc);
+        $this->assertArrayNotHasKey('claim_url', $payloadEnc);
 
         Mail::mailer('array')->getSymfonyTransport()->flush();
         $this->artisan('email:outbox-send --limit=10')->assertExitCode(0);

--- a/backend/tests/Feature/Email/EmailOutboxLifecycleContextTest.php
+++ b/backend/tests/Feature/Email/EmailOutboxLifecycleContextTest.php
@@ -1,0 +1,203 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Email;
+
+use App\Services\Email\EmailOutboxService;
+use App\Support\PiiCipher;
+use Database\Seeders\Pr19CommerceSeeder;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Str;
+use Tests\TestCase;
+
+final class EmailOutboxLifecycleContextTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_payment_success_and_report_claim_payloads_include_lifecycle_foundation(): void
+    {
+        $this->seedCommerce();
+
+        $attemptId = $this->createAttempt();
+        $email = 'outbox+'.random_int(1000, 9999).'@example.com';
+
+        $checkout = $this->postJson('/api/v0.3/orders/checkout', [
+            'sku' => 'MBTI_CREDIT',
+            'provider' => 'billing',
+            'email' => $email,
+            'attempt_id' => $attemptId,
+            'surface' => 'checkout',
+            'marketing_consent' => true,
+            'transactional_recovery_enabled' => false,
+            'share_id' => 'share_outbox',
+            'compare_invite_id' => (string) Str::uuid(),
+            'share_click_id' => 'clk_outbox',
+            'entrypoint' => 'share_page',
+            'referrer' => 'https://example.com/share/outbox',
+            'landing_path' => '/zh/share/outbox',
+            'utm' => [
+                'source' => 'share',
+                'medium' => 'organic',
+                'campaign' => 'outbox-lifecycle',
+                'term' => 'mbti',
+                'content' => 'hero',
+            ],
+        ]);
+
+        $checkout->assertOk();
+        $orderNo = (string) $checkout->json('order_no');
+        $this->assertNotSame('', $orderNo);
+
+        /** @var EmailOutboxService $outbox */
+        $outbox = app(EmailOutboxService::class);
+        $this->assertTrue((bool) ($outbox->queuePaymentSuccess(
+            'outbox_lifecycle_user',
+            $email,
+            $attemptId,
+            $orderNo,
+            'MBTI Full Report'
+        )['ok'] ?? false));
+        $claim = $outbox->queueReportClaim(
+            'outbox_lifecycle_user',
+            $email,
+            $attemptId,
+            $orderNo
+        );
+        $this->assertTrue((bool) ($claim['ok'] ?? false));
+        $this->assertNotSame('', (string) ($claim['claim_url'] ?? ''));
+
+        $paymentRow = DB::table('email_outbox')
+            ->where('attempt_id', $attemptId)
+            ->where('template', 'payment_success')
+            ->first();
+        $claimRow = DB::table('email_outbox')
+            ->where('attempt_id', $attemptId)
+            ->where('template', 'report_claim')
+            ->first();
+
+        $this->assertNotNull($paymentRow);
+        $this->assertNotNull($claimRow);
+
+        $this->assertLifecyclePayload($paymentRow, $email, 'share_outbox', 'clk_outbox', false);
+        $this->assertLifecyclePayload($claimRow, $email, 'share_outbox', 'clk_outbox', true);
+    }
+
+    public function test_refund_and_support_lifecycle_context_builder_include_status_and_attribution(): void
+    {
+        $this->seedCommerce();
+
+        $attemptId = $this->createAttempt();
+        $email = 'builder+'.random_int(1000, 9999).'@example.com';
+
+        $checkout = $this->postJson('/api/v0.3/orders/checkout', [
+            'sku' => 'MBTI_CREDIT',
+            'provider' => 'billing',
+            'email' => $email,
+            'attempt_id' => $attemptId,
+            'surface' => 'checkout',
+            'marketing_consent' => false,
+            'transactional_recovery_enabled' => true,
+            'share_id' => 'share_builder',
+            'share_click_id' => 'clk_builder',
+            'entrypoint' => 'help_center',
+            'referrer' => 'https://example.com/help',
+            'landing_path' => '/zh/help/orders',
+            'utm' => [
+                'source' => 'help',
+                'medium' => 'owned',
+                'campaign' => 'support-context',
+            ],
+        ]);
+
+        $checkout->assertOk();
+        $orderNo = (string) $checkout->json('order_no');
+
+        /** @var EmailOutboxService $outbox */
+        $outbox = app(EmailOutboxService::class);
+
+        $refundContext = $outbox->buildLifecyclePayloadContext($email, $orderNo, [
+            'surface' => 'refund_notice',
+        ]);
+        $supportContext = $outbox->buildLifecyclePayloadContext($email, $orderNo, [
+            'surface' => 'support_contact',
+        ]);
+
+        $this->assertSame('active', (string) ($refundContext['subscriber_status'] ?? ''));
+        $this->assertSame('share_builder', (string) data_get($refundContext, 'attribution.share_id'));
+        $this->assertSame('refund_notice', (string) ($refundContext['surface'] ?? ''));
+        $this->assertSame('active', (string) ($supportContext['subscriber_status'] ?? ''));
+        $this->assertSame('owned', (string) data_get($supportContext, 'attribution.utm.medium'));
+        $this->assertSame('support_contact', (string) ($supportContext['surface'] ?? ''));
+    }
+
+    private function seedCommerce(): void
+    {
+        (new Pr19CommerceSeeder)->run();
+    }
+
+    private function createAttempt(): string
+    {
+        $attemptId = (string) Str::uuid();
+
+        DB::table('attempts')->insert([
+            'id' => $attemptId,
+            'ticket_code' => 'FMT-'.strtoupper(substr(str_replace('-', '', $attemptId), 0, 8)),
+            'org_id' => 0,
+            'anon_id' => 'anon_outbox_context',
+            'user_id' => null,
+            'scale_code' => 'MBTI',
+            'scale_version' => 'v0.3',
+            'region' => 'CN_MAINLAND',
+            'locale' => 'zh-CN',
+            'question_count' => 144,
+            'answers_summary_json' => json_encode(['seed' => true], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES),
+            'client_platform' => 'test',
+            'client_version' => '1.0.0',
+            'channel' => 'test',
+            'started_at' => now()->subMinute(),
+            'submitted_at' => now(),
+            'pack_id' => (string) config('content_packs.default_pack_id'),
+            'dir_version' => (string) config('content_packs.default_dir_version'),
+            'content_package_version' => 'v0.3',
+            'scoring_spec_version' => '2026.01',
+            'created_at' => now(),
+            'updated_at' => now(),
+        ]);
+
+        return $attemptId;
+    }
+
+    private function assertLifecyclePayload(object $row, string $email, string $shareId, string $shareClickId, bool $isClaim): void
+    {
+        $payloadJson = json_decode((string) ($row->payload_json ?? '{}'), true);
+        $this->assertIsArray($payloadJson);
+        $this->assertSame('active', (string) ($payloadJson['subscriber_status'] ?? ''));
+        $this->assertSame(true, $payloadJson['marketing_consent'] ?? null);
+        $this->assertSame(false, $payloadJson['transactional_recovery_enabled'] ?? null);
+        $this->assertSame('checkout', (string) ($payloadJson['surface'] ?? ''));
+        $this->assertSame($shareId, (string) data_get($payloadJson, 'attribution.share_id'));
+        $this->assertSame($shareClickId, (string) data_get($payloadJson, 'attribution.share_click_id'));
+        $this->assertSame('hero', (string) data_get($payloadJson, 'attribution.utm.content'));
+        $this->assertArrayNotHasKey('email', $payloadJson);
+        $this->assertArrayNotHasKey('to_email', $payloadJson);
+        $this->assertArrayNotHasKey('claim_token', $payloadJson);
+        $this->assertArrayNotHasKey('claim_url', $payloadJson);
+
+        /** @var PiiCipher $pii */
+        $pii = app(PiiCipher::class);
+        $payloadEnc = json_decode((string) $pii->decrypt((string) ($row->payload_enc ?? '')), true);
+        $this->assertIsArray($payloadEnc);
+        $this->assertSame($email, (string) ($payloadEnc['to_email'] ?? ''));
+        $this->assertSame('active', (string) ($payloadEnc['subscriber_status'] ?? ''));
+        $this->assertSame($shareId, (string) data_get($payloadEnc, 'attribution.share_id'));
+        $this->assertSame($shareClickId, (string) data_get($payloadEnc, 'attribution.share_click_id'));
+        $this->assertArrayNotHasKey('claim_token', $payloadEnc);
+        $this->assertArrayNotHasKey('claim_url', $payloadEnc);
+
+        if ($isClaim) {
+            $this->assertNotSame('', (string) ($payloadEnc['claim_expires_at'] ?? ''));
+        }
+    }
+}

--- a/backend/tests/Feature/Email/EmailOutboxNoPlaintextPayloadTest.php
+++ b/backend/tests/Feature/Email/EmailOutboxNoPlaintextPayloadTest.php
@@ -105,6 +105,9 @@ final class EmailOutboxNoPlaintextPayloadTest extends TestCase
             $payloadJson = json_decode((string) ($row->payload_json ?? '{}'), true);
             $this->assertIsArray($payloadJson);
             $this->assertSame($attemptId, (string) ($payloadJson['attempt_id'] ?? ''));
+            $this->assertSame('active', (string) ($payloadJson['subscriber_status'] ?? ''));
+            $this->assertSame(false, $payloadJson['marketing_consent'] ?? null);
+            $this->assertSame(true, $payloadJson['transactional_recovery_enabled'] ?? null);
             $this->assertArrayHasKey('attribution', $payloadJson);
             $this->assertNotEmpty($payloadJson['attribution']);
             $this->assertArrayNotHasKey('email', $payloadJson);
@@ -116,7 +119,10 @@ final class EmailOutboxNoPlaintextPayloadTest extends TestCase
             $this->assertIsArray($payloadEncDecoded);
             $this->assertSame($attemptId, (string) ($payloadEncDecoded['attempt_id'] ?? ''));
             $this->assertSame($email, (string) ($payloadEncDecoded['to_email'] ?? ''));
+            $this->assertSame('active', (string) ($payloadEncDecoded['subscriber_status'] ?? ''));
             $this->assertArrayHasKey('attribution', $payloadEncDecoded);
+            $this->assertArrayNotHasKey('claim_token', $payloadEncDecoded);
+            $this->assertArrayNotHasKey('claim_url', $payloadEncDecoded);
         }
     }
 }

--- a/backend/tests/Feature/V0_3/CheckoutEmailCaptureAttributionTest.php
+++ b/backend/tests/Feature/V0_3/CheckoutEmailCaptureAttributionTest.php
@@ -1,0 +1,100 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\V0_3;
+
+use Database\Seeders\Pr19CommerceSeeder;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Str;
+use Tests\TestCase;
+
+final class CheckoutEmailCaptureAttributionTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_checkout_persists_email_capture_and_attribution_foundation(): void
+    {
+        $this->seedCommerce();
+
+        $email = 'checkout+'.random_int(1000, 9999).'@example.com';
+        $compareInviteId = (string) Str::uuid();
+        $attemptId = (string) Str::uuid();
+
+        $response = $this->postJson('/api/v0.3/orders/checkout', [
+            'sku' => 'MBTI_CREDIT',
+            'provider' => 'billing',
+            'email' => $email,
+            'attempt_id' => $attemptId,
+            'surface' => 'checkout',
+            'marketing_consent' => true,
+            'transactional_recovery_enabled' => false,
+            'share_id' => 'share_checkout',
+            'compare_invite_id' => $compareInviteId,
+            'share_click_id' => 'clk_checkout',
+            'entrypoint' => 'share_page',
+            'referrer' => 'https://example.com/share/checkout',
+            'landing_path' => '/zh/share/checkout',
+            'utm' => [
+                'source' => 'share',
+                'medium' => 'organic',
+                'campaign' => 'checkout-foundation',
+                'term' => 'mbti',
+                'content' => 'hero',
+            ],
+        ]);
+
+        $response->assertOk()
+            ->assertJsonPath('ok', true)
+            ->assertJsonPath('provider', 'billing')
+            ->assertJsonPath('status', 'pending')
+            ->assertJsonPath('pay', null)
+            ->assertJsonPath('checkout_url', null);
+
+        $orderNo = (string) $response->json('order_no');
+        $this->assertNotSame('', $orderNo);
+
+        $order = DB::table('orders')->where('order_no', $orderNo)->first();
+        $this->assertNotNull($order);
+        $this->assertSame(hash('sha256', $email), (string) ($order->contact_email_hash ?? ''));
+
+        $meta = json_decode((string) ($order->meta_json ?? '{}'), true);
+        $this->assertIsArray($meta);
+        $this->assertSame('share_checkout', (string) data_get($meta, 'attribution.share_id'));
+        $this->assertSame($compareInviteId, (string) data_get($meta, 'attribution.compare_invite_id'));
+        $this->assertSame('clk_checkout', (string) data_get($meta, 'attribution.share_click_id'));
+        $this->assertSame('organic', (string) data_get($meta, 'attribution.utm.medium'));
+        $this->assertSame(hash('sha256', $email), (string) data_get($meta, 'email_capture.contact_email_hash'));
+        $this->assertSame('active', (string) data_get($meta, 'email_capture.subscriber_status'));
+        $this->assertSame(true, data_get($meta, 'email_capture.marketing_consent'));
+        $this->assertSame(false, data_get($meta, 'email_capture.transactional_recovery_enabled'));
+        $this->assertSame('checkout', (string) data_get($meta, 'email_capture.surface'));
+        $this->assertSame($attemptId, (string) data_get($meta, 'email_capture.attempt_id'));
+    }
+
+    public function test_checkout_legacy_contract_remains_compatible_without_lifecycle_fields(): void
+    {
+        $this->seedCommerce();
+
+        $response = $this->postJson('/api/v0.3/orders/checkout', [
+            'sku' => 'MBTI_CREDIT',
+            'provider' => 'billing',
+            'email' => 'legacy-checkout@example.com',
+        ]);
+
+        $response->assertOk()
+            ->assertJsonPath('ok', true)
+            ->assertJsonPath('provider', 'billing')
+            ->assertJsonPath('status', 'pending')
+            ->assertJsonPath('pay', null)
+            ->assertJsonPath('checkout_url', null);
+
+        $this->assertNotSame('', (string) $response->json('order_no'));
+    }
+
+    private function seedCommerce(): void
+    {
+        (new Pr19CommerceSeeder)->run();
+    }
+}

--- a/backend/tests/Feature/V0_3/ClaimReportEmailRequestTest.php
+++ b/backend/tests/Feature/V0_3/ClaimReportEmailRequestTest.php
@@ -108,6 +108,7 @@ final class ClaimReportEmailRequestTest extends TestCase
         $this->assertIsArray($payloadJson);
         $this->assertSame($orderNo, (string) ($payloadJson['order_no'] ?? ''));
         $this->assertSame($attemptId, (string) ($payloadJson['attempt_id'] ?? ''));
+        $this->assertSame('active', (string) ($payloadJson['subscriber_status'] ?? ''));
         $this->assertSame('/zh/orders/lookup', (string) data_get($payloadJson, 'attribution.landing_path'));
         $this->assertSame('clk_001', (string) data_get($payloadJson, 'attribution.share_click_id'));
         $this->assertArrayNotHasKey('email', $payloadJson);
@@ -121,6 +122,8 @@ final class ClaimReportEmailRequestTest extends TestCase
         $this->assertIsArray($payloadEnc);
         $this->assertSame('owner@example.com', (string) ($payloadEnc['to_email'] ?? ''));
         $this->assertSame('share_123', (string) data_get($payloadEnc, 'attribution.share_id'));
+        $this->assertArrayNotHasKey('claim_token', $payloadEnc);
+        $this->assertArrayNotHasKey('claim_url', $payloadEnc);
     }
 
     private function createAttempt(string $anonId): string

--- a/backend/tests/Feature/V0_3/CommerceOrderResendTest.php
+++ b/backend/tests/Feature/V0_3/CommerceOrderResendTest.php
@@ -55,6 +55,7 @@ final class CommerceOrderResendTest extends TestCase
         $this->assertSame($orderNo, (string) ($payloadJson['order_no'] ?? ''));
         $this->assertSame("/api/v0.3/attempts/{$attemptId}/report", (string) ($payloadJson['report_url'] ?? ''));
         $this->assertSame("/api/v0.3/attempts/{$attemptId}/report.pdf", (string) ($payloadJson['report_pdf_url'] ?? ''));
+        $this->assertSame('active', (string) ($payloadJson['subscriber_status'] ?? ''));
         $this->assertSame([], $payloadJson['attribution'] ?? null);
     }
 
@@ -94,6 +95,7 @@ final class CommerceOrderResendTest extends TestCase
         $this->assertSame('anon-resend@example.com', $pii->decrypt($encryptedEmail));
         $payloadJson = json_decode((string) ($row->payload_json ?? '{}'), true);
         $this->assertIsArray($payloadJson);
+        $this->assertSame('active', (string) ($payloadJson['subscriber_status'] ?? ''));
         $this->assertSame([], $payloadJson['attribution'] ?? null);
     }
 

--- a/backend/tests/Feature/V0_3/EmailCaptureContractTest.php
+++ b/backend/tests/Feature/V0_3/EmailCaptureContractTest.php
@@ -38,10 +38,13 @@ final class EmailCaptureContractTest extends TestCase
         $response->assertOk()
             ->assertJsonPath('ok', true)
             ->assertJsonPath('status', 'captured')
+            ->assertJsonPath('subscriber_status', 'active')
+            ->assertJsonPath('transactional_recovery_enabled', true)
             ->assertJsonPath('marketing_consent', true)
             ->assertJsonPath('preferences.marketing_updates', true)
             ->assertJsonPath('preferences.report_recovery', true)
             ->assertJsonPath('preferences.product_updates', true);
+        $this->assertNotSame('', (string) $response->json('captured_at'));
 
         /** @var PiiCipher $pii */
         $pii = app(PiiCipher::class);
@@ -51,8 +54,12 @@ final class EmailCaptureContractTest extends TestCase
         $this->assertSame($email, $pii->decrypt((string) ($subscriber->email_enc ?? '')));
         $this->assertSame('lookup', (string) ($subscriber->first_source ?? ''));
         $this->assertSame('lookup', (string) ($subscriber->last_source ?? ''));
+        $this->assertSame('active', (string) ($subscriber->status ?? ''));
         $this->assertSame('zh-CN', (string) ($subscriber->locale ?? ''));
         $this->assertSame((string) $pii->currentKeyVersion(), (string) ($subscriber->pii_email_key_version ?? ''));
+        $this->assertNotNull($subscriber->first_captured_at);
+        $this->assertNotNull($subscriber->last_captured_at);
+        $this->assertNotNull($subscriber->last_marketing_consent_at);
 
         $firstContext = json_decode((string) ($subscriber->first_context_json ?? '{}'), true);
         $this->assertIsArray($firstContext);
@@ -87,7 +94,9 @@ final class EmailCaptureContractTest extends TestCase
 
         $response->assertOk()
             ->assertJsonPath('status', 'updated')
+            ->assertJsonPath('subscriber_status', 'active')
             ->assertJsonPath('marketing_consent', false)
+            ->assertJsonPath('transactional_recovery_enabled', true)
             ->assertJsonPath('preferences.marketing_updates', false)
             ->assertJsonPath('preferences.report_recovery', true)
             ->assertJsonPath('preferences.product_updates', false);
@@ -124,6 +133,8 @@ final class EmailCaptureContractTest extends TestCase
         $response->assertOk()
             ->assertJsonPath('ok', true)
             ->assertJsonPath('status', 'suppressed')
+            ->assertJsonPath('subscriber_status', 'suppressed')
+            ->assertJsonPath('transactional_recovery_enabled', true)
             ->assertJsonPath('preferences.report_recovery', true);
     }
 }

--- a/backend/tests/Feature/V0_3/EmailCaptureSubscriberFoundationTest.php
+++ b/backend/tests/Feature/V0_3/EmailCaptureSubscriberFoundationTest.php
@@ -1,0 +1,86 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\V0_3;
+
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Str;
+use Tests\TestCase;
+
+final class EmailCaptureSubscriberFoundationTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_email_capture_persists_subscriber_lifecycle_foundation(): void
+    {
+        $email = 'foundation+'.random_int(1000, 9999).'@example.com';
+        $compareInviteId = (string) Str::uuid();
+
+        $response = $this->postJson('/api/v0.3/email/capture', [
+            'email' => $email,
+            'surface' => 'checkout',
+            'attempt_id' => (string) Str::uuid(),
+            'share_id' => 'share_foundation',
+            'compare_invite_id' => $compareInviteId,
+            'share_click_id' => 'clk_foundation',
+            'entrypoint' => 'share_page',
+            'referrer' => 'https://example.com/share/foundation',
+            'landing_path' => '/zh/share/foundation',
+            'utm' => [
+                'source' => 'share',
+                'medium' => 'organic',
+                'campaign' => 'subscriber-foundation',
+                'term' => 'mbti',
+                'content' => 'hero',
+            ],
+            'marketing_consent' => true,
+            'transactional_recovery_enabled' => false,
+        ]);
+
+        $response->assertOk()
+            ->assertJsonPath('ok', true)
+            ->assertJsonPath('status', 'captured')
+            ->assertJsonPath('subscriber_status', 'active')
+            ->assertJsonPath('marketing_consent', true)
+            ->assertJsonPath('transactional_recovery_enabled', false)
+            ->assertJsonPath('preferences.marketing_updates', true)
+            ->assertJsonPath('preferences.report_recovery', false)
+            ->assertJsonPath('preferences.product_updates', true);
+
+        $capturedAt = (string) $response->json('captured_at');
+        $this->assertNotSame('', $capturedAt);
+        $this->assertFalse(array_key_exists('email', $response->json()));
+        $this->assertFalse(array_key_exists('email_hash', $response->json()));
+
+        $subscriber = DB::table('email_subscribers')->first();
+        $this->assertNotNull($subscriber);
+        $this->assertSame('active', (string) ($subscriber->status ?? ''));
+        $this->assertTrue((bool) ($subscriber->marketing_consent ?? false));
+        $this->assertFalse((bool) ($subscriber->transactional_recovery_enabled ?? true));
+        $this->assertSame('checkout', (string) ($subscriber->first_source ?? ''));
+        $this->assertSame('checkout', (string) ($subscriber->last_source ?? ''));
+        $this->assertNotNull($subscriber->first_captured_at);
+        $this->assertNotNull($subscriber->last_captured_at);
+        $this->assertNotNull($subscriber->last_marketing_consent_at);
+        $this->assertNotNull($subscriber->last_transactional_recovery_change_at);
+
+        $firstContext = json_decode((string) ($subscriber->first_context_json ?? '{}'), true);
+        $lastContext = json_decode((string) ($subscriber->last_context_json ?? '{}'), true);
+        $this->assertIsArray($firstContext);
+        $this->assertIsArray($lastContext);
+        $this->assertSame('clk_foundation', (string) ($firstContext['share_click_id'] ?? ''));
+        $this->assertSame($compareInviteId, (string) ($lastContext['compare_invite_id'] ?? ''));
+        $this->assertSame(true, $lastContext['marketing_consent'] ?? null);
+        $this->assertSame(false, $lastContext['transactional_recovery_enabled'] ?? null);
+
+        $preferences = DB::table('email_preferences')
+            ->where('subscriber_id', $subscriber->id)
+            ->first();
+        $this->assertNotNull($preferences);
+        $this->assertTrue((bool) ($preferences->marketing_updates ?? false));
+        $this->assertFalse((bool) ($preferences->report_recovery ?? true));
+        $this->assertTrue((bool) ($preferences->product_updates ?? false));
+    }
+}

--- a/backend/tests/Feature/V0_3/EmailPreferencesContractTest.php
+++ b/backend/tests/Feature/V0_3/EmailPreferencesContractTest.php
@@ -55,8 +55,11 @@ final class EmailPreferencesContractTest extends TestCase
         $preference = DB::table('email_preferences')->first();
         $this->assertNotNull($subscriber);
         $this->assertNotNull($preference);
+        $this->assertSame('active', (string) ($subscriber->status ?? ''));
         $this->assertTrue((bool) ($subscriber->marketing_consent ?? false));
         $this->assertFalse((bool) ($subscriber->transactional_recovery_enabled ?? true));
+        $this->assertNotNull($subscriber->last_marketing_consent_at);
+        $this->assertNotNull($subscriber->last_transactional_recovery_change_at);
         $this->assertTrue((bool) ($preference->marketing_updates ?? false));
         $this->assertFalse((bool) ($preference->report_recovery ?? true));
         $this->assertTrue((bool) ($preference->product_updates ?? false));

--- a/backend/tests/Feature/V0_3/EmailSubscriberStatusTransitionTest.php
+++ b/backend/tests/Feature/V0_3/EmailSubscriberStatusTransitionTest.php
@@ -1,0 +1,65 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\V0_3;
+
+use App\Services\Email\EmailPreferenceService;
+use App\Support\PiiCipher;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\DB;
+use Tests\TestCase;
+
+final class EmailSubscriberStatusTransitionTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_subscriber_status_transitions_from_capture_to_unsubscribe_to_suppression(): void
+    {
+        $email = 'status+'.random_int(1000, 9999).'@example.com';
+
+        $capture = $this->postJson('/api/v0.3/email/capture', [
+            'email' => $email,
+            'surface' => 'help',
+        ]);
+
+        $capture->assertOk()
+            ->assertJsonPath('subscriber_status', 'active');
+        $this->assertSame('active', (string) DB::table('email_subscribers')->value('status'));
+
+        /** @var EmailPreferenceService $preferences */
+        $preferences = app(EmailPreferenceService::class);
+        $token = $preferences->issueTokenForEmail($email);
+
+        $unsubscribe = $this->postJson('/api/v0.3/email/unsubscribe', [
+            'token' => $token,
+            'reason' => 'user_request',
+        ]);
+
+        $unsubscribe->assertOk()
+            ->assertJsonPath('status', 'unsubscribed');
+        $this->assertSame('unsubscribed', (string) DB::table('email_subscribers')->value('status'));
+
+        /** @var PiiCipher $pii */
+        $pii = app(PiiCipher::class);
+        DB::table('email_suppressions')->insert([
+            'id' => (string) \Illuminate\Support\Str::uuid(),
+            'email_hash' => $pii->emailHash($email),
+            'reason' => 'bounce',
+            'source' => 'mailgun',
+            'meta_json' => json_encode(['code' => '550'], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES),
+            'created_at' => now(),
+            'updated_at' => now(),
+        ]);
+
+        $suppressed = $this->postJson('/api/v0.3/email/capture', [
+            'email' => $email,
+            'surface' => 'lookup',
+        ]);
+
+        $suppressed->assertOk()
+            ->assertJsonPath('status', 'suppressed')
+            ->assertJsonPath('subscriber_status', 'suppressed');
+        $this->assertSame('suppressed', (string) DB::table('email_subscribers')->value('status'));
+    }
+}

--- a/backend/tests/Feature/V0_3/EmailUnsubscribeContractTest.php
+++ b/backend/tests/Feature/V0_3/EmailUnsubscribeContractTest.php
@@ -36,9 +36,12 @@ final class EmailUnsubscribeContractTest extends TestCase
         $preference = DB::table('email_preferences')->first();
         $this->assertNotNull($subscriber);
         $this->assertNotNull($preference);
+        $this->assertSame('unsubscribed', (string) ($subscriber->status ?? ''));
         $this->assertFalse((bool) ($subscriber->marketing_consent ?? true));
         $this->assertFalse((bool) ($subscriber->transactional_recovery_enabled ?? true));
         $this->assertNotNull($subscriber->unsubscribed_at);
+        $this->assertNotNull($subscriber->last_marketing_consent_at);
+        $this->assertNotNull($subscriber->last_transactional_recovery_change_at);
         $this->assertFalse((bool) ($preference->marketing_updates ?? true));
         $this->assertFalse((bool) ($preference->report_recovery ?? true));
         $this->assertFalse((bool) ($preference->product_updates ?? true));

--- a/backend/tests/Feature/V0_3/PaymentWebhookControllerTest.php
+++ b/backend/tests/Feature/V0_3/PaymentWebhookControllerTest.php
@@ -403,7 +403,10 @@ final class PaymentWebhookControllerTest extends TestCase
 
         $this->assertNotNull($row);
         $this->assertSame('pending', (string) ($row->status ?? ''));
-        $this->assertSame('share_webhook_queue', (string) data_get(json_decode((string) ($row->payload_json ?? '{}'), true), 'attribution.share_id'));
+        $payloadJson = json_decode((string) ($row->payload_json ?? '{}'), true);
+        $this->assertIsArray($payloadJson);
+        $this->assertSame('active', (string) ($payloadJson['subscriber_status'] ?? ''));
+        $this->assertSame('share_webhook_queue', (string) data_get($payloadJson, 'attribution.share_id'));
     }
 
     private function postSignedBilling(string $raw, string $secret): TestResponse


### PR DESCRIPTION
## Summary

- add subscriber lifecycle foundation to `email_subscribers` with persisted status and consent/capture timestamps
- persist checkout email capture context into `orders.meta_json.email_capture` while keeping `meta_json.attribution` stable
- enrich outbox payloads with subscriber lifecycle context and block raw claim token persistence
- add/update backend tests for capture, checkout attribution, outbox lifecycle context, and subscriber status transitions

## Tests

- `php artisan route:list | rg "email/capture|email/preferences|email/unsubscribe|orders/checkout|orders/lookup|claim/report"`
- `php artisan migrate`
- `php artisan test tests/Feature/V0_3/EmailCaptureSubscriberFoundationTest.php`
- `php artisan test tests/Feature/V0_3/CheckoutEmailCaptureAttributionTest.php`
- `php artisan test tests/Feature/Email/EmailOutboxLifecycleContextTest.php`
- `php artisan test tests/Feature/V0_3/EmailSubscriberStatusTransitionTest.php`
- `php artisan test tests/Feature/V0_3/EmailCaptureContractTest.php`
- `php artisan test tests/Feature/V0_3/EmailPreferencesContractTest.php`
- `php artisan test tests/Feature/V0_3/EmailUnsubscribeContractTest.php`
- `php artisan test tests/Feature/Email/EmailOutboxAttributionTest.php`
- `php artisan test tests/Feature/Email/EmailOutboxNoPlaintextPayloadTest.php`
- `php artisan test tests/Feature/V0_3/ClaimReportEmailRequestTest.php`
- `php artisan test tests/Feature/V0_3/CommerceOrderResendTest.php`
- `php artisan test tests/Feature/Commerce/BigFiveUnlockDeliveryPipelineTest.php`
- `php artisan test tests/Feature/V0_3/PaymentWebhookControllerTest.php`
- `php artisan test tests/Feature/Report/ReportPdfCrossScaleDeliveryTest.php`
- `php artisan test tests/Feature/V0_3/CommerceCheckoutPayActionTest.php`
- `php artisan test tests/Feature/V0_3/MbtiCompareInviteAttributionFlowTest.php`
- `./vendor/bin/pint ...`
- `bash scripts/export_openapi.sh`
- `bash scripts/ci_verify_mbti.sh`
