### PR TITLE
feat(email): roll out lifecycle confirmation automation

### DIFF
--- a/backend/app/Console/Commands/FapEmailLifecycleRollout.php
+++ b/backend/app/Console/Commands/FapEmailLifecycleRollout.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Console\Commands;
+
+use App\Services\Email\EmailLifecycleRolloutService;
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\Schema;
+
+class FapEmailLifecycleRollout extends Command
+{
+    protected $signature = 'email:lifecycle-rollout {--dry-run : Scan eligible subscribers without enqueueing outbox rows.}';
+
+    protected $description = 'Scan lifecycle confirmation candidates and enqueue pending outbox rows.';
+
+    public function __construct(
+        private readonly EmailLifecycleRolloutService $rollout,
+    ) {
+        parent::__construct();
+    }
+
+    public function handle(): int
+    {
+        if (! Schema::hasTable('email_subscribers') || ! Schema::hasTable('email_outbox')) {
+            $this->warn('Lifecycle rollout tables are missing.');
+
+            return Command::SUCCESS;
+        }
+
+        $result = $this->rollout->rollout((bool) $this->option('dry-run'));
+
+        $this->info('Candidates: '.(int) ($result['candidates'] ?? 0));
+        $this->info('Enqueued: '.(int) ($result['enqueued'] ?? 0));
+        $this->line(sprintf(
+            'preferences_updated => candidates %d, enqueued %d',
+            (int) data_get($result, 'templates.preferences_updated.candidates', 0),
+            (int) data_get($result, 'templates.preferences_updated.enqueued', 0),
+        ));
+        $this->line(sprintf(
+            'unsubscribe_confirmation => candidates %d, enqueued %d',
+            (int) data_get($result, 'templates.unsubscribe_confirmation.candidates', 0),
+            (int) data_get($result, 'templates.unsubscribe_confirmation.enqueued', 0),
+        ));
+
+        if ((bool) ($result['dry_run'] ?? false)) {
+            $this->comment('Dry run: no outbox rows were enqueued.');
+        }
+
+        return Command::SUCCESS;
+    }
+}

--- a/backend/app/Console/Kernel.php
+++ b/backend/app/Console/Kernel.php
@@ -13,6 +13,7 @@ use App\Console\Commands\CommerceReconcile;
 use App\Console\Commands\ContentCompile;
 use App\Console\Commands\ContentLint;
 use App\Console\Commands\Eq60PsychometricsReport;
+use App\Console\Commands\FapEmailLifecycleRollout;
 use App\Console\Commands\FapEmailOutboxSend;
 use App\Console\Commands\FapResolvePack;
 use App\Console\Commands\FapSelfCheck;
@@ -79,6 +80,7 @@ class Kernel extends ConsoleKernel
      */
     protected $commands = [
         FapEmailOutboxSend::class,
+        FapEmailLifecycleRollout::class,
         FapResolvePack::class,
         FapSelfCheck::class,
         FapValidateReport::class,
@@ -148,6 +150,7 @@ class Kernel extends ConsoleKernel
         // 示例（需要就开）：
         // $schedule->command('fap:self-check')->dailyAt('03:10');
         // $schedule->command('fap:validate-report --attempt=...')->hourly();
+        $schedule->command('email:lifecycle-rollout')->everyFiveMinutes()->withoutOverlapping();
         $schedule->command('email:outbox-send')->everyMinute()->withoutOverlapping();
         $schedule->command('storage:prune --execute --scope=reports_backups --strategy=strict')->dailyAt('03:10')->withoutOverlapping();
         $schedule->command('storage:prune --execute --scope=content_releases_retention')->dailyAt('03:20')->withoutOverlapping();

--- a/backend/app/Models/EmailSubscriber.php
+++ b/backend/app/Models/EmailSubscriber.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace App\Models;
 
+use Carbon\CarbonInterface;
+use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Concerns\HasUuids;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\HasOne;
@@ -41,6 +43,10 @@ class EmailSubscriber extends Model
         'last_captured_at',
         'last_marketing_consent_at',
         'last_transactional_recovery_change_at',
+        'last_preferences_changed_at',
+        'last_preferences_confirmation_sent_at',
+        'last_unsubscribe_confirmation_sent_at',
+        'last_lifecycle_email_sent_at',
         'unsubscribed_at',
     ];
 
@@ -53,6 +59,10 @@ class EmailSubscriber extends Model
         'last_captured_at' => 'datetime',
         'last_marketing_consent_at' => 'datetime',
         'last_transactional_recovery_change_at' => 'datetime',
+        'last_preferences_changed_at' => 'datetime',
+        'last_preferences_confirmation_sent_at' => 'datetime',
+        'last_unsubscribe_confirmation_sent_at' => 'datetime',
+        'last_lifecycle_email_sent_at' => 'datetime',
         'unsubscribed_at' => 'datetime',
     ];
 
@@ -69,5 +79,31 @@ class EmailSubscriber extends Model
     public function preference(): HasOne
     {
         return $this->hasOne(EmailPreference::class, 'subscriber_id', 'id');
+    }
+
+    public function scopeOutsideLifecycleCooldown(Builder $query, CarbonInterface $threshold): Builder
+    {
+        return $query->where(function (Builder $builder) use ($threshold): void {
+            $builder->whereNull('last_lifecycle_email_sent_at')
+                ->orWhere('last_lifecycle_email_sent_at', '<=', $threshold);
+        });
+    }
+
+    public function lifecycleOutboxUserId(): string
+    {
+        return 'subscriber_'.(string) $this->getKey();
+    }
+
+    public function recordLifecycleSend(string $templateKey, CarbonInterface $sentAt): void
+    {
+        $this->last_lifecycle_email_sent_at = $sentAt;
+
+        if ($templateKey === 'preferences_updated') {
+            $this->last_preferences_confirmation_sent_at = $sentAt;
+        }
+
+        if ($templateKey === 'unsubscribe_confirmation') {
+            $this->last_unsubscribe_confirmation_sent_at = $sentAt;
+        }
     }
 }

--- a/backend/app/Services/Email/EmailLifecycleRolloutService.php
+++ b/backend/app/Services/Email/EmailLifecycleRolloutService.php
@@ -1,0 +1,216 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\Email;
+
+use App\Models\EmailSubscriber;
+use App\Support\PiiCipher;
+use Illuminate\Support\Collection;
+use Illuminate\Support\Facades\Schema;
+
+class EmailLifecycleRolloutService
+{
+    private const COOLDOWN_MINUTES = 10;
+
+    public function __construct(
+        private readonly EmailOutboxService $emailOutbox,
+        private readonly PiiCipher $piiCipher,
+    ) {}
+
+    /**
+     * @return array{
+     *     dry_run:bool,
+     *     candidates:int,
+     *     enqueued:int,
+     *     templates:array{
+     *         preferences_updated:array{candidates:int,enqueued:int},
+     *         unsubscribe_confirmation:array{candidates:int,enqueued:int}
+     *     }
+     * }
+     */
+    public function rollout(bool $dryRun = false): array
+    {
+        if (! Schema::hasTable('email_subscribers') || ! Schema::hasTable('email_outbox')) {
+            return [
+                'dry_run' => $dryRun,
+                'candidates' => 0,
+                'enqueued' => 0,
+                'templates' => [
+                    'preferences_updated' => ['candidates' => 0, 'enqueued' => 0],
+                    'unsubscribe_confirmation' => ['candidates' => 0, 'enqueued' => 0],
+                ],
+            ];
+        }
+
+        $summary = [
+            'dry_run' => $dryRun,
+            'candidates' => 0,
+            'enqueued' => 0,
+            'templates' => [
+                'preferences_updated' => ['candidates' => 0, 'enqueued' => 0],
+                'unsubscribe_confirmation' => ['candidates' => 0, 'enqueued' => 0],
+            ],
+        ];
+
+        $summary = $this->processTemplate(
+            $summary,
+            'preferences_updated',
+            $this->preferencesUpdatedCandidates(),
+            $dryRun,
+            fn (EmailSubscriber $subscriber): array => $this->emailOutbox->queuePreferencesUpdatedConfirmation($subscriber)
+        );
+
+        return $this->processTemplate(
+            $summary,
+            'unsubscribe_confirmation',
+            $this->unsubscribeConfirmationCandidates(),
+            $dryRun,
+            fn (EmailSubscriber $subscriber): array => $this->emailOutbox->queueUnsubscribeConfirmation($subscriber)
+        );
+    }
+
+    /**
+     * @param  array{
+     *     dry_run:bool,
+     *     candidates:int,
+     *     enqueued:int,
+     *     templates:array<string,array{candidates:int,enqueued:int}>
+     * }  $summary
+     * @param  \Closure(EmailSubscriber):array{ok:bool,queued:bool,error?:string,reason?:string}  $enqueue
+     * @return array{
+     *     dry_run:bool,
+     *     candidates:int,
+     *     enqueued:int,
+     *     templates:array<string,array{candidates:int,enqueued:int}>
+     * }
+     */
+    private function processTemplate(array $summary, string $templateKey, Collection $subscribers, bool $dryRun, \Closure $enqueue): array
+    {
+        foreach ($subscribers as $subscriber) {
+            if (! $subscriber instanceof EmailSubscriber) {
+                continue;
+            }
+
+            $email = $this->decryptSubscriberEmail($subscriber);
+            if ($email === null) {
+                continue;
+            }
+
+            if ($this->hasPendingTemplate($subscriber, $templateKey)) {
+                continue;
+            }
+
+            $summary['candidates']++;
+            $summary['templates'][$templateKey]['candidates']++;
+
+            if ($dryRun) {
+                continue;
+            }
+
+            $result = $enqueue($subscriber);
+            if (($result['ok'] ?? false) && ($result['queued'] ?? false)) {
+                $summary['enqueued']++;
+                $summary['templates'][$templateKey]['enqueued']++;
+            }
+        }
+
+        return $summary;
+    }
+
+    /**
+     * @return Collection<int,EmailSubscriber>
+     */
+    private function preferencesUpdatedCandidates(): Collection
+    {
+        $threshold = now()->subMinutes(self::COOLDOWN_MINUTES);
+
+        $query = EmailSubscriber::query()
+            ->with('preference')
+            ->outsideLifecycleCooldown($threshold)
+            ->where('status', '!=', EmailSubscriber::STATUS_UNSUBSCRIBED)
+            ->whereNotNull('last_preferences_changed_at')
+            ->where(function ($builder): void {
+                $builder->whereNull('last_preferences_confirmation_sent_at')
+                    ->orWhereColumn('last_preferences_confirmation_sent_at', '<', 'last_preferences_changed_at');
+            })
+            ->orderBy('last_preferences_changed_at');
+
+        return $this->excludeSuppressed($query)->get();
+    }
+
+    /**
+     * @return Collection<int,EmailSubscriber>
+     */
+    private function unsubscribeConfirmationCandidates(): Collection
+    {
+        $threshold = now()->subMinutes(self::COOLDOWN_MINUTES);
+
+        $query = EmailSubscriber::query()
+            ->with('preference')
+            ->outsideLifecycleCooldown($threshold)
+            ->where('status', EmailSubscriber::STATUS_UNSUBSCRIBED)
+            ->whereNotNull('unsubscribed_at')
+            ->where(function ($builder): void {
+                $builder->whereNull('last_unsubscribe_confirmation_sent_at')
+                    ->orWhereColumn('last_unsubscribe_confirmation_sent_at', '<', 'unsubscribed_at');
+            })
+            ->orderBy('unsubscribed_at');
+
+        return $this->excludeSuppressed($query)->get();
+    }
+
+    private function excludeSuppressed($query)
+    {
+        if (! Schema::hasTable('email_suppressions')) {
+            return $query;
+        }
+
+        return $query->whereNotIn('email_hash', function ($builder): void {
+            $builder->select('email_hash')->from('email_suppressions');
+        });
+    }
+
+    private function decryptSubscriberEmail(EmailSubscriber $subscriber): ?string
+    {
+        $email = $this->piiCipher->decrypt((string) ($subscriber->email_enc ?? ''));
+
+        return is_string($email) && filter_var($email, FILTER_VALIDATE_EMAIL) !== false
+            ? mb_strtolower(trim($email), 'UTF-8')
+            : null;
+    }
+
+    private function hasPendingTemplate(EmailSubscriber $subscriber, string $templateKey): bool
+    {
+        $query = \Illuminate\Support\Facades\DB::table('email_outbox')
+            ->where('status', 'pending')
+            ->where(function ($builder) use ($templateKey): void {
+                if (Schema::hasColumn('email_outbox', 'template_key')) {
+                    $builder->where('template_key', $templateKey);
+
+                    return;
+                }
+
+                $builder->where('template', $templateKey);
+            });
+
+        $hasEmailHash = Schema::hasColumn('email_outbox', 'email_hash');
+        $hasToEmailHash = Schema::hasColumn('email_outbox', 'to_email_hash');
+        if (! $hasEmailHash && ! $hasToEmailHash) {
+            return false;
+        }
+
+        $query->where(function ($builder) use ($subscriber, $hasEmailHash, $hasToEmailHash): void {
+            if ($hasEmailHash) {
+                $builder->where('email_hash', (string) $subscriber->email_hash);
+            }
+
+            if ($hasToEmailHash) {
+                $method = $hasEmailHash ? 'orWhere' : 'where';
+                $builder->{$method}('to_email_hash', (string) $subscriber->email_hash);
+            }
+        });
+
+        return $query->exists();
+    }
+}

--- a/backend/app/Services/Email/EmailOutboxService.php
+++ b/backend/app/Services/Email/EmailOutboxService.php
@@ -2,6 +2,8 @@
 
 namespace App\Services\Email;
 
+use App\Models\EmailPreference;
+use App\Models\EmailSubscriber;
 use App\Support\PiiCipher;
 use App\Support\PiiReadFallbackMonitor;
 use App\Support\RuntimeConfig;
@@ -397,6 +399,154 @@ class EmailOutboxService
     }
 
     /**
+     * @return array{ok:bool,queued:bool,error?:string,reason?:string}
+     */
+    public function queuePreferencesUpdatedConfirmation(EmailSubscriber $subscriber, ?string $preferredLocale = null): array
+    {
+        return $this->queueSubscriberLifecycleConfirmation(
+            $subscriber,
+            'preferences_updated',
+            'email_preferences',
+            $preferredLocale
+        );
+    }
+
+    /**
+     * @return array{ok:bool,queued:bool,error?:string,reason?:string}
+     */
+    public function queueUnsubscribeConfirmation(EmailSubscriber $subscriber, ?string $preferredLocale = null): array
+    {
+        return $this->queueSubscriberLifecycleConfirmation(
+            $subscriber,
+            'unsubscribe_confirmation',
+            'email_unsubscribe',
+            $preferredLocale
+        );
+    }
+
+    /**
+     * @return array{ok:bool,queued:bool,error?:string,reason?:string}
+     */
+    private function queueSubscriberLifecycleConfirmation(
+        EmailSubscriber $subscriber,
+        string $templateKey,
+        string $surface,
+        ?string $preferredLocale = null
+    ): array {
+        if (! \App\Support\SchemaBaseline::hasTable('email_outbox')) {
+            return ['ok' => false, 'queued' => false, 'error' => 'TABLE_MISSING'];
+        }
+
+        $subscriber->loadMissing('preference');
+        $email = $this->normalizeEmailAddress($this->piiCipher->decrypt((string) ($subscriber->email_enc ?? '')));
+        if ($email === null) {
+            return ['ok' => false, 'queued' => false, 'error' => 'INVALID_RECIPIENT'];
+        }
+
+        $emailHash = $this->piiCipher->emailHash($email);
+        if ($this->hasPendingLifecycleTemplateRow($emailHash, $templateKey)) {
+            return ['ok' => true, 'queued' => false, 'reason' => 'pending_exists'];
+        }
+
+        $locale = $this->normalizeLocale((string) ($preferredLocale ?? ($subscriber->locale ?? '')));
+        $subject = $this->defaultSubjectForTemplate($templateKey, $locale);
+        $emailEnc = $this->piiCipher->encrypt($email);
+        $keyVersion = $this->piiCipher->currentKeyVersion();
+        $lastContext = is_array($subscriber->last_context_json) ? $subscriber->last_context_json : [];
+        $attemptId = $this->trimOrNull((string) ($lastContext['attempt_id'] ?? ''));
+        $orderNo = $this->trimOrNull((string) ($lastContext['order_no'] ?? ''));
+        $preferenceSnapshot = $this->preferenceSnapshotForSubscriber($subscriber);
+        $lifecycleContext = $this->buildLifecyclePayloadContext($email, $orderNo, [
+            'surface' => $surface,
+            'locale' => $locale,
+        ]);
+        $normalizedAttribution = is_array($lifecycleContext['attribution'] ?? null)
+            ? $lifecycleContext['attribution']
+            : [];
+
+        $payload = [
+            'attempt_id' => $attemptId,
+            'order_no' => $orderNo,
+            'locale' => $locale,
+            'template_key' => $templateKey,
+            'to_email' => $email,
+            'subject' => $subject,
+            'subscriber_status' => (string) ($lifecycleContext['subscriber_status'] ?? $subscriber->status ?? EmailSubscriber::STATUS_ACTIVE),
+            'marketing_consent' => (bool) ($lifecycleContext['marketing_consent'] ?? $subscriber->marketing_consent ?? false),
+            'transactional_recovery_enabled' => (bool) ($lifecycleContext['transactional_recovery_enabled'] ?? $subscriber->transactional_recovery_enabled ?? true),
+            'surface' => $surface,
+            'preferences' => $preferenceSnapshot,
+            'marketing_updates' => $preferenceSnapshot['marketing_updates'],
+            'report_recovery' => $preferenceSnapshot['report_recovery'],
+            'product_updates' => $preferenceSnapshot['product_updates'],
+            'preferences_changed_at' => $subscriber->last_preferences_changed_at?->toIso8601String(),
+            'unsubscribed_at' => $subscriber->unsubscribed_at?->toIso8601String(),
+            'attribution' => $this->payloadAttribution($normalizedAttribution),
+        ];
+        $payloadJson = $this->encodePayloadJson($this->sanitizePayloadForJson($payload));
+        $payloadEnc = $this->encodePayloadEncrypted($payload);
+
+        $row = [
+            'id' => (string) Str::uuid(),
+            'user_id' => $subscriber->lifecycleOutboxUserId(),
+            'email' => $this->maskedLegacyEmail($emailHash),
+            'template' => $templateKey,
+            'payload_json' => $payloadJson,
+            'claim_token_hash' => hash('sha256', $templateKey.'|'.(string) $subscriber->getKey().'|'.Str::uuid()->toString()),
+            'claim_expires_at' => null,
+            'status' => 'pending',
+            'sent_at' => null,
+            'consumed_at' => null,
+            'created_at' => now(),
+            'updated_at' => now(),
+        ];
+
+        if (\App\Support\SchemaBaseline::hasColumn('email_outbox', 'attempt_id')) {
+            $row['attempt_id'] = $attemptId;
+        }
+        if (\App\Support\SchemaBaseline::hasColumn('email_outbox', 'email_hash')) {
+            $row['email_hash'] = $emailHash;
+        }
+        if (\App\Support\SchemaBaseline::hasColumn('email_outbox', 'email_enc')) {
+            $row['email_enc'] = $emailEnc;
+        }
+        if (\App\Support\SchemaBaseline::hasColumn('email_outbox', 'to_email_hash')) {
+            $row['to_email_hash'] = $emailHash;
+        }
+        if (\App\Support\SchemaBaseline::hasColumn('email_outbox', 'to_email_enc')) {
+            $row['to_email_enc'] = $emailEnc;
+        }
+        if (\App\Support\SchemaBaseline::hasColumn('email_outbox', 'payload_enc')) {
+            $row['payload_enc'] = $payloadEnc;
+        }
+        if (\App\Support\SchemaBaseline::hasColumn('email_outbox', 'payload_schema_version')) {
+            $row['payload_schema_version'] = 'v1';
+        }
+        if (\App\Support\SchemaBaseline::hasColumn('email_outbox', 'key_version')) {
+            $row['key_version'] = $keyVersion;
+        }
+        if (\App\Support\SchemaBaseline::hasColumn('email_outbox', 'locale')) {
+            $row['locale'] = $locale;
+        }
+        if (\App\Support\SchemaBaseline::hasColumn('email_outbox', 'template_key')) {
+            $row['template_key'] = $templateKey;
+        }
+        if (\App\Support\SchemaBaseline::hasColumn('email_outbox', 'to_email')) {
+            $row['to_email'] = $this->maskedLegacyEmail($emailHash);
+        }
+        if (\App\Support\SchemaBaseline::hasColumn('email_outbox', 'subject')) {
+            $row['subject'] = $subject;
+        }
+        if (\App\Support\SchemaBaseline::hasColumn('email_outbox', 'body_html')) {
+            $row['body_html'] = null;
+        }
+
+        DB::table('email_outbox')->insert($row);
+
+        return ['ok' => true, 'queued' => true];
+    }
+
+    /**
      * @return array{mailer:string,sent:int,blocked:int,failed:int,processed:int}
      */
     public function sendPending(int $limit, string $mailer): array
@@ -588,17 +738,18 @@ class EmailOutboxService
         string $mailer
     ): void {
         $emailHash = $this->piiCipher->emailHash($recipientEmail);
+        $sentAt = now();
         $payload = $this->appendExecutionMeta($payload, [
             'status' => 'sent',
             'mailer' => $mailer,
             'guard' => 'allowed',
-            'attempted_at' => now()->toIso8601String(),
+            'attempted_at' => $sentAt->toIso8601String(),
         ]);
 
         $update = [
             'status' => 'sent',
             'payload_json' => $this->encodePayloadJson($this->sanitizePayloadForJson($payload)),
-            'updated_at' => now(),
+            'updated_at' => $sentAt,
         ];
 
         if (\App\Support\SchemaBaseline::hasColumn('email_outbox', 'payload_enc')) {
@@ -620,13 +771,17 @@ class EmailOutboxService
             $update['body_html'] = $bodyHtml !== '' ? $bodyHtml : null;
         }
         if (\App\Support\SchemaBaseline::hasColumn('email_outbox', 'sent_at')) {
-            $update['sent_at'] = now();
+            $update['sent_at'] = $sentAt;
         }
 
-        DB::table('email_outbox')
+        $updated = DB::table('email_outbox')
             ->where('id', $row->id)
             ->where('status', 'pending')
             ->update($update);
+
+        if ($updated > 0) {
+            $this->recordLifecycleSubscriberDelivery($templateKey, $recipientEmail, $sentAt);
+        }
     }
 
     /**
@@ -1148,6 +1303,16 @@ class EmailOutboxService
             return $orderLookupUrl;
         }
 
+        $preferencesUrl = trim((string) ($data['email_preferences_url'] ?? ''));
+        if ($preferencesUrl !== '') {
+            return $preferencesUrl;
+        }
+
+        $unsubscribeUrl = trim((string) ($data['email_unsubscribe_url'] ?? ''));
+        if ($unsubscribeUrl !== '') {
+            return $unsubscribeUrl;
+        }
+
         return 'Please contact support@fermatmind.com for assistance.';
     }
 
@@ -1156,7 +1321,14 @@ class EmailOutboxService
         $lang = strtolower((string) explode('-', $this->normalizeLocale($locale))[0]) === 'zh'
             ? 'zh'
             : 'en';
-        $supported = ['payment_success', 'report_claim', 'refund_notice', 'support_contact'];
+        $supported = [
+            'payment_success',
+            'report_claim',
+            'refund_notice',
+            'support_contact',
+            'preferences_updated',
+            'unsubscribe_confirmation',
+        ];
         if (! in_array($templateKey, $supported, true)) {
             return '';
         }
@@ -1259,6 +1431,7 @@ class EmailOutboxService
         $orderLookupUrl = $this->frontendUrl($frontendBaseUrl, '/orders/lookup', $query);
         $emailPreferencesUrl = $this->frontendUrl($frontendBaseUrl, '/email/preferences', ['token' => $preferenceToken] + $query);
         $emailUnsubscribeUrl = $this->frontendUrl($frontendBaseUrl, '/email/unsubscribe', ['token' => $preferenceToken] + $query);
+        $preferences = is_array($payload['preferences'] ?? null) ? $payload['preferences'] : [];
 
         $data = [
             'locale' => $locale,
@@ -1279,6 +1452,16 @@ class EmailOutboxService
             'email_preferences_url' => $emailPreferencesUrl,
             'emailUnsubscribeUrl' => $emailUnsubscribeUrl,
             'email_unsubscribe_url' => $emailUnsubscribeUrl,
+            'preferences' => [
+                'marketing_updates' => (bool) ($preferences['marketing_updates'] ?? ($payload['marketing_updates'] ?? false)),
+                'report_recovery' => (bool) ($preferences['report_recovery'] ?? ($payload['report_recovery'] ?? true)),
+                'product_updates' => (bool) ($preferences['product_updates'] ?? ($payload['product_updates'] ?? false)),
+            ],
+            'marketing_updates' => (bool) ($preferences['marketing_updates'] ?? ($payload['marketing_updates'] ?? false)),
+            'report_recovery' => (bool) ($preferences['report_recovery'] ?? ($payload['report_recovery'] ?? true)),
+            'product_updates' => (bool) ($preferences['product_updates'] ?? ($payload['product_updates'] ?? false)),
+            'preferences_changed_at' => trim((string) ($payload['preferences_changed_at'] ?? '')),
+            'unsubscribed_at' => trim((string) ($payload['unsubscribed_at'] ?? '')),
             'refundStatus' => trim((string) ($payload['refund_status'] ?? '')),
             'refund_status' => trim((string) ($payload['refund_status'] ?? '')),
             'refundEta' => trim((string) ($payload['refund_eta'] ?? '')),
@@ -1472,6 +1655,80 @@ class EmailOutboxService
         return $payload;
     }
 
+    /**
+     * @return array{marketing_updates:bool,report_recovery:bool,product_updates:bool}
+     */
+    private function preferenceSnapshotForSubscriber(EmailSubscriber $subscriber): array
+    {
+        $preference = $subscriber->preference instanceof EmailPreference
+            ? $subscriber->preference
+            : null;
+
+        return [
+            'marketing_updates' => $preference instanceof EmailPreference
+                ? (bool) $preference->marketing_updates
+                : (bool) $subscriber->marketing_consent,
+            'report_recovery' => $preference instanceof EmailPreference
+                ? (bool) $preference->report_recovery
+                : (bool) $subscriber->transactional_recovery_enabled,
+            'product_updates' => $preference instanceof EmailPreference
+                ? (bool) $preference->product_updates
+                : (bool) $subscriber->marketing_consent,
+        ];
+    }
+
+    private function hasPendingLifecycleTemplateRow(string $emailHash, string $templateKey): bool
+    {
+        $query = DB::table('email_outbox')
+            ->where('status', 'pending')
+            ->where(function ($builder) use ($templateKey): void {
+                if (\App\Support\SchemaBaseline::hasColumn('email_outbox', 'template_key')) {
+                    $builder->where('template_key', $templateKey);
+
+                    return;
+                }
+
+                $builder->where('template', $templateKey);
+            });
+
+        $hasEmailHash = \App\Support\SchemaBaseline::hasColumn('email_outbox', 'email_hash');
+        $hasToEmailHash = \App\Support\SchemaBaseline::hasColumn('email_outbox', 'to_email_hash');
+        if (! $hasEmailHash && ! $hasToEmailHash) {
+            return false;
+        }
+
+        $query->where(function ($builder) use ($emailHash, $hasEmailHash, $hasToEmailHash): void {
+            if ($hasEmailHash) {
+                $builder->where('email_hash', $emailHash);
+            }
+
+            if ($hasToEmailHash) {
+                $method = $hasEmailHash ? 'orWhere' : 'where';
+                $builder->{$method}('to_email_hash', $emailHash);
+            }
+        });
+
+        return $query->exists();
+    }
+
+    private function recordLifecycleSubscriberDelivery(string $templateKey, string $recipientEmail, \Illuminate\Support\Carbon $sentAt): void
+    {
+        if (! in_array($templateKey, ['preferences_updated', 'unsubscribe_confirmation'], true)) {
+            return;
+        }
+
+        $subscriber = EmailSubscriber::query()
+            ->where('email_hash', $this->piiCipher->emailHash($recipientEmail))
+            ->first();
+
+        if (! $subscriber) {
+            return;
+        }
+
+        $subscriber->recordLifecycleSend($templateKey, $sentAt);
+        $subscriber->save();
+    }
+
     private function extractRecipientEmailFromOutboxRow(object $row, ?array $payload = null): string
     {
         $candidates = [];
@@ -1585,6 +1842,12 @@ class EmailOutboxService
         }
         if ($templateKey === 'support_contact') {
             return $lang === 'zh' ? '客服联系信息' : 'Support contact details';
+        }
+        if ($templateKey === 'preferences_updated') {
+            return $lang === 'zh' ? '邮件偏好已更新' : 'Your email preferences were updated';
+        }
+        if ($templateKey === 'unsubscribe_confirmation') {
+            return $lang === 'zh' ? '你已退订邮件' : 'You have been unsubscribed from emails';
         }
 
         return $lang === 'zh' ? 'FermatMind 通知' : 'FermatMind notification';

--- a/backend/app/Services/Email/EmailPreferenceService.php
+++ b/backend/app/Services/Email/EmailPreferenceService.php
@@ -59,6 +59,7 @@ class EmailPreferenceService
     public function deliveryPolicyForEmail(string $email, string $templateKey): array
     {
         $snapshot = $this->emailCapture->subscriberLifecycleSnapshot($email);
+        $templateKey = strtolower(trim($templateKey));
         if ($this->normalizeEmail($email) === null) {
             return [
                 'allowed' => false,
@@ -82,6 +83,18 @@ class EmailPreferenceService
                 'status' => 'suppressed',
                 'reason' => 'email_suppressed',
                 'suppressed' => true,
+                'report_recovery' => $reportRecovery,
+                'marketing_updates' => $marketingUpdates,
+                'product_updates' => $productUpdates,
+            ];
+        }
+
+        if ($this->isLifecycleConfirmationTemplate($templateKey)) {
+            return [
+                'allowed' => true,
+                'status' => 'allowed',
+                'reason' => null,
+                'suppressed' => false,
                 'report_recovery' => $reportRecovery,
                 'marketing_updates' => $marketingUpdates,
                 'product_updates' => $productUpdates,
@@ -161,24 +174,60 @@ class EmailPreferenceService
         /** @var EmailPreference $preference */
         $preference = $resolved['preference'];
 
-        $preference->marketing_updates = (bool) ($preferences['marketing_updates'] ?? false);
-        $preference->report_recovery = (bool) ($preferences['report_recovery'] ?? false);
-        $preference->product_updates = (bool) ($preferences['product_updates'] ?? false);
-        $preference->save();
+        $requestedMarketingUpdates = (bool) ($preferences['marketing_updates'] ?? false);
+        $requestedReportRecovery = (bool) ($preferences['report_recovery'] ?? false);
+        $requestedProductUpdates = (bool) ($preferences['product_updates'] ?? false);
+        $timestamp = now();
 
-        $subscriber->marketing_consent = $preference->allowsMarketing();
-        $subscriber->transactional_recovery_enabled = $preference->allowsReportRecovery();
-        $subscriber->last_marketing_consent_at = now();
-        $subscriber->last_transactional_recovery_change_at = now();
-        $subscriber->unsubscribed_at = $preference->allowsMarketing() || $preference->allowsReportRecovery()
+        $preferencesChanged = (bool) $preference->marketing_updates !== $requestedMarketingUpdates
+            || (bool) $preference->report_recovery !== $requestedReportRecovery
+            || (bool) $preference->product_updates !== $requestedProductUpdates;
+
+        if ($preferencesChanged) {
+            $preference->marketing_updates = $requestedMarketingUpdates;
+            $preference->report_recovery = $requestedReportRecovery;
+            $preference->product_updates = $requestedProductUpdates;
+            $preference->save();
+        }
+
+        $marketingConsent = $preference->allowsMarketing();
+        $transactionalRecoveryEnabled = $preference->allowsReportRecovery();
+        $marketingConsentChanged = (bool) $subscriber->marketing_consent !== $marketingConsent;
+        $transactionalRecoveryChanged = (bool) $subscriber->transactional_recovery_enabled !== $transactionalRecoveryEnabled;
+
+        $nextUnsubscribedAt = $marketingConsent || $transactionalRecoveryEnabled
             ? null
-            : now();
-        $subscriber->status = $this->resolveSubscriberStatus(
+            : ($subscriber->unsubscribed_at ?? $timestamp);
+        $unsubscribedAtChanged = $subscriber->unsubscribed_at?->toIso8601String() !== $nextUnsubscribedAt?->toIso8601String();
+
+        $resolvedStatus = $this->resolveSubscriberStatus(
             $subscriber,
-            $subscriber->marketing_consent,
-            $subscriber->transactional_recovery_enabled
+            $marketingConsent,
+            $transactionalRecoveryEnabled,
+            $nextUnsubscribedAt
         );
-        $subscriber->save();
+        $statusChanged = (string) ($subscriber->status ?? '') !== $resolvedStatus;
+
+        if ($preferencesChanged || $marketingConsentChanged || $transactionalRecoveryChanged || $unsubscribedAtChanged || $statusChanged) {
+            $subscriber->marketing_consent = $marketingConsent;
+            $subscriber->transactional_recovery_enabled = $transactionalRecoveryEnabled;
+
+            if ($marketingConsentChanged) {
+                $subscriber->last_marketing_consent_at = $timestamp;
+            }
+
+            if ($transactionalRecoveryChanged) {
+                $subscriber->last_transactional_recovery_change_at = $timestamp;
+            }
+
+            if ($preferencesChanged) {
+                $subscriber->last_preferences_changed_at = $timestamp;
+            }
+
+            $subscriber->unsubscribed_at = $nextUnsubscribedAt;
+            $subscriber->status = $resolvedStatus;
+            $subscriber->save();
+        }
 
         return [
             'ok' => true,
@@ -202,24 +251,50 @@ class EmailPreferenceService
         /** @var EmailPreference $preference */
         $preference = $resolved['preference'];
 
-        $preference->marketing_updates = false;
-        $preference->report_recovery = false;
-        $preference->product_updates = false;
-        $preference->save();
+        $timestamp = now();
+        $preferencesChanged = (bool) $preference->marketing_updates
+            || (bool) $preference->report_recovery
+            || (bool) $preference->product_updates;
 
-        $subscriber->marketing_consent = false;
-        $subscriber->transactional_recovery_enabled = false;
-        $subscriber->last_marketing_consent_at = now();
-        $subscriber->last_transactional_recovery_change_at = now();
-        $subscriber->unsubscribed_at = now();
-        $subscriber->status = EmailSubscriber::STATUS_UNSUBSCRIBED;
+        if ($preferencesChanged) {
+            $preference->marketing_updates = false;
+            $preference->report_recovery = false;
+            $preference->product_updates = false;
+            $preference->save();
+        }
 
+        $marketingConsentChanged = (bool) $subscriber->marketing_consent;
+        $transactionalRecoveryChanged = (bool) $subscriber->transactional_recovery_enabled;
+        $nextUnsubscribedAt = $subscriber->unsubscribed_at ?? $timestamp;
+        $status = $this->resolveSubscriberStatus($subscriber, false, false, $nextUnsubscribedAt);
+        $statusChanged = (string) ($subscriber->status ?? '') !== $status;
+        $contextChanged = false;
         if (is_string($reason) && trim($reason) !== '') {
             $lastContext = is_array($subscriber->last_context_json) ? $subscriber->last_context_json : [];
-            $lastContext['unsubscribe_reason'] = trim($reason);
-            $subscriber->last_context_json = $lastContext;
+            $normalizedReason = trim($reason);
+            if (($lastContext['unsubscribe_reason'] ?? null) !== $normalizedReason) {
+                $lastContext['unsubscribe_reason'] = $normalizedReason;
+                $subscriber->last_context_json = $lastContext;
+                $contextChanged = true;
+            }
         }
-        $subscriber->save();
+
+        if ($preferencesChanged || $marketingConsentChanged || $transactionalRecoveryChanged || $statusChanged || $subscriber->unsubscribed_at === null || $contextChanged) {
+            $subscriber->marketing_consent = false;
+            $subscriber->transactional_recovery_enabled = false;
+            if ($marketingConsentChanged) {
+                $subscriber->last_marketing_consent_at = $timestamp;
+            }
+            if ($transactionalRecoveryChanged) {
+                $subscriber->last_transactional_recovery_change_at = $timestamp;
+            }
+            if ($preferencesChanged || $marketingConsentChanged || $transactionalRecoveryChanged || $subscriber->unsubscribed_at === null) {
+                $subscriber->last_preferences_changed_at = $timestamp;
+            }
+            $subscriber->unsubscribed_at = $nextUnsubscribedAt;
+            $subscriber->status = $status;
+            $subscriber->save();
+        }
 
         return [
             'ok' => true,
@@ -322,6 +397,11 @@ class EmailPreferenceService
         return in_array(trim($templateKey), ['payment_success', 'report_claim'], true);
     }
 
+    private function isLifecycleConfirmationTemplate(string $templateKey): bool
+    {
+        return in_array(trim($templateKey), ['preferences_updated', 'unsubscribe_confirmation'], true);
+    }
+
     private function normalizeEmail(string $email): ?string
     {
         $normalized = mb_strtolower(trim($email), 'UTF-8');
@@ -361,7 +441,8 @@ class EmailPreferenceService
     private function resolveSubscriberStatus(
         EmailSubscriber $subscriber,
         bool $marketingConsent,
-        bool $transactionalRecoveryEnabled
+        bool $transactionalRecoveryEnabled,
+        mixed $unsubscribedAt = null
     ): string {
         $suppressed = EmailSuppression::query()
             ->where('email_hash', (string) ($subscriber->email_hash ?? ''))
@@ -371,7 +452,7 @@ class EmailPreferenceService
             return EmailSubscriber::STATUS_SUPPRESSED;
         }
 
-        if ($subscriber->unsubscribed_at !== null || (! $marketingConsent && ! $transactionalRecoveryEnabled)) {
+        if ($unsubscribedAt !== null || (! $marketingConsent && ! $transactionalRecoveryEnabled)) {
             return EmailSubscriber::STATUS_UNSUBSCRIBED;
         }
 

--- a/backend/database/migrations/2026_03_13_010000_add_lifecycle_rollout_state_to_email_subscribers_table.php
+++ b/backend/database/migrations/2026_03_13_010000_add_lifecycle_rollout_state_to_email_subscribers_table.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        if (! Schema::hasTable('email_subscribers')) {
+            return;
+        }
+
+        Schema::table('email_subscribers', function (Blueprint $table): void {
+            if (! Schema::hasColumn('email_subscribers', 'last_preferences_changed_at')) {
+                $table->timestamp('last_preferences_changed_at')
+                    ->nullable()
+                    ->after('last_transactional_recovery_change_at');
+            }
+
+            if (! Schema::hasColumn('email_subscribers', 'last_preferences_confirmation_sent_at')) {
+                $table->timestamp('last_preferences_confirmation_sent_at')
+                    ->nullable()
+                    ->after('last_preferences_changed_at');
+            }
+
+            if (! Schema::hasColumn('email_subscribers', 'last_unsubscribe_confirmation_sent_at')) {
+                $table->timestamp('last_unsubscribe_confirmation_sent_at')
+                    ->nullable()
+                    ->after('last_preferences_confirmation_sent_at');
+            }
+
+            if (! Schema::hasColumn('email_subscribers', 'last_lifecycle_email_sent_at')) {
+                $table->timestamp('last_lifecycle_email_sent_at')
+                    ->nullable()
+                    ->after('last_unsubscribe_confirmation_sent_at');
+            }
+        });
+    }
+
+    public function down(): void
+    {
+        // forward-only migration: rollback disabled to prevent data loss in production.
+        // Irreversible operation: schema/data rollback handled via forward fix migrations.
+    }
+};

--- a/backend/resources/views/emails/en/preferences_updated.blade.php
+++ b/backend/resources/views/emails/en/preferences_updated.blade.php
@@ -1,0 +1,32 @@
+<!doctype html>
+<html lang="en">
+<head>
+    <meta charset="utf-8">
+    <title>Email Preferences Updated</title>
+</head>
+<body style="margin:0;padding:24px;background:#f6f4ef;font-family:Arial,sans-serif;color:#1f2933;line-height:1.6;">
+<div style="max-width:640px;margin:0 auto;background:#ffffff;border:1px solid #e5e7eb;padding:32px;">
+    <h1 style="margin:0 0 16px;font-size:28px;line-height:1.2;">Email preferences updated</h1>
+    <p style="margin:0 0 16px;">This lifecycle confirmation records a change to your FermatMind email settings. It is not a newsletter or campaign email.</p>
+
+    <p style="margin:0 0 8px;"><strong>Current settings</strong></p>
+    <ul style="margin:0 0 20px;padding-left:20px;">
+        <li>Marketing updates: {{ !empty($marketing_updates) ? 'On' : 'Off' }}</li>
+        <li>Report recovery: {{ !empty($report_recovery) ? 'On' : 'Off' }}</li>
+        <li>Product updates: {{ !empty($product_updates) ? 'On' : 'Off' }}</li>
+    </ul>
+
+    <p style="margin:0 0 12px;"><a href="{{ $email_preferences_url }}">Manage email preferences</a></p>
+    <p style="margin:0 0 12px;"><a href="{{ $email_unsubscribe_url }}">Unsubscribe from emails</a></p>
+    <p style="margin:0 0 24px;"><a href="{{ $order_lookup_url }}">Order lookup</a></p>
+
+    <p style="margin:0 0 8px;">If you did not expect this change, review your settings and contact <a href="mailto:{{ $support_email }}">{{ $support_email }}</a>.</p>
+
+    <p style="margin:0;font-size:12px;color:#52606d;">
+        <a href="{{ $privacy_url }}">Privacy</a> |
+        <a href="{{ $terms_url }}">Terms</a> |
+        <a href="{{ $refund_url }}">Refund</a>
+    </p>
+</div>
+</body>
+</html>

--- a/backend/resources/views/emails/en/unsubscribe_confirmation.blade.php
+++ b/backend/resources/views/emails/en/unsubscribe_confirmation.blade.php
@@ -1,0 +1,33 @@
+<!doctype html>
+<html lang="en">
+<head>
+    <meta charset="utf-8">
+    <title>Unsubscribe Confirmation</title>
+</head>
+<body style="margin:0;padding:24px;background:#f6f4ef;font-family:Arial,sans-serif;color:#1f2933;line-height:1.6;">
+<div style="max-width:640px;margin:0 auto;background:#ffffff;border:1px solid #e5e7eb;padding:32px;">
+    <h1 style="margin:0 0 16px;font-size:28px;line-height:1.2;">You have been unsubscribed</h1>
+    <p style="margin:0 0 16px;">This lifecycle confirmation records that your email subscription was turned off. It is a one-time system confirmation, not a marketing email.</p>
+
+    <p style="margin:0 0 8px;"><strong>Current settings</strong></p>
+    <ul style="margin:0 0 20px;padding-left:20px;">
+        <li>Marketing updates: {{ !empty($marketing_updates) ? 'On' : 'Off' }}</li>
+        <li>Report recovery: {{ !empty($report_recovery) ? 'On' : 'Off' }}</li>
+        <li>Product updates: {{ !empty($product_updates) ? 'On' : 'Off' }}</li>
+    </ul>
+
+    <p style="margin:0 0 12px;"><a href="{{ $email_preferences_url }}">Manage email preferences</a></p>
+    <p style="margin:0 0 12px;"><a href="{{ $email_unsubscribe_url }}">Unsubscribe from emails</a></p>
+    <p style="margin:0 0 24px;"><a href="{{ $order_lookup_url }}">Order lookup</a></p>
+
+    <p style="margin:0 0 8px;">You can restore settings later from the preferences page if needed.</p>
+    <p style="margin:0 0 8px;">Need help? Contact <a href="mailto:{{ $support_email }}">{{ $support_email }}</a>.</p>
+
+    <p style="margin:0;font-size:12px;color:#52606d;">
+        <a href="{{ $privacy_url }}">Privacy</a> |
+        <a href="{{ $terms_url }}">Terms</a> |
+        <a href="{{ $refund_url }}">Refund</a>
+    </p>
+</div>
+</body>
+</html>

--- a/backend/resources/views/emails/zh/preferences_updated.blade.php
+++ b/backend/resources/views/emails/zh/preferences_updated.blade.php
@@ -1,0 +1,32 @@
+<!doctype html>
+<html lang="zh-CN">
+<head>
+    <meta charset="utf-8">
+    <title>邮件偏好已更新</title>
+</head>
+<body style="margin:0;padding:24px;background:#f6f4ef;font-family:Arial,sans-serif;color:#1f2933;line-height:1.7;">
+<div style="max-width:640px;margin:0 auto;background:#ffffff;border:1px solid #e5e7eb;padding:32px;">
+    <h1 style="margin:0 0 16px;font-size:28px;line-height:1.2;">邮件偏好已更新</h1>
+    <p style="margin:0 0 16px;">这是一封 lifecycle confirmation，用于确认你的 FermatMind 邮件设置发生了变更。它不是 newsletter，也不是 campaign 邮件。</p>
+
+    <p style="margin:0 0 8px;"><strong>当前设置</strong></p>
+    <ul style="margin:0 0 20px;padding-left:20px;">
+        <li>营销更新：{{ !empty($marketing_updates) ? '开启' : '关闭' }}</li>
+        <li>报告恢复：{{ !empty($report_recovery) ? '开启' : '关闭' }}</li>
+        <li>产品更新：{{ !empty($product_updates) ? '开启' : '关闭' }}</li>
+    </ul>
+
+    <p style="margin:0 0 12px;"><a href="{{ $email_preferences_url }}">管理邮件偏好</a></p>
+    <p style="margin:0 0 12px;"><a href="{{ $email_unsubscribe_url }}">退订邮件</a></p>
+    <p style="margin:0 0 24px;"><a href="{{ $order_lookup_url }}">订单查询</a></p>
+
+    <p style="margin:0 0 8px;">如果这次变更并非你本人操作，请检查设置并联系 <a href="mailto:{{ $support_email }}">{{ $support_email }}</a>。</p>
+
+    <p style="margin:0;font-size:12px;color:#52606d;">
+        <a href="{{ $privacy_url }}">隐私政策</a> |
+        <a href="{{ $terms_url }}">服务条款</a> |
+        <a href="{{ $refund_url }}">退款政策</a>
+    </p>
+</div>
+</body>
+</html>

--- a/backend/resources/views/emails/zh/unsubscribe_confirmation.blade.php
+++ b/backend/resources/views/emails/zh/unsubscribe_confirmation.blade.php
@@ -1,0 +1,33 @@
+<!doctype html>
+<html lang="zh-CN">
+<head>
+    <meta charset="utf-8">
+    <title>退订确认</title>
+</head>
+<body style="margin:0;padding:24px;background:#f6f4ef;font-family:Arial,sans-serif;color:#1f2933;line-height:1.7;">
+<div style="max-width:640px;margin:0 auto;background:#ffffff;border:1px solid #e5e7eb;padding:32px;">
+    <h1 style="margin:0 0 16px;font-size:28px;line-height:1.2;">你已退订邮件</h1>
+    <p style="margin:0 0 16px;">这是一封 lifecycle confirmation，用于确认你的邮件订阅已关闭。它是一封一次性的系统确认邮件，不是营销邮件。</p>
+
+    <p style="margin:0 0 8px;"><strong>当前设置</strong></p>
+    <ul style="margin:0 0 20px;padding-left:20px;">
+        <li>营销更新：{{ !empty($marketing_updates) ? '开启' : '关闭' }}</li>
+        <li>报告恢复：{{ !empty($report_recovery) ? '开启' : '关闭' }}</li>
+        <li>产品更新：{{ !empty($product_updates) ? '开启' : '关闭' }}</li>
+    </ul>
+
+    <p style="margin:0 0 12px;"><a href="{{ $email_preferences_url }}">管理邮件偏好</a></p>
+    <p style="margin:0 0 12px;"><a href="{{ $email_unsubscribe_url }}">退订邮件</a></p>
+    <p style="margin:0 0 24px;"><a href="{{ $order_lookup_url }}">订单查询</a></p>
+
+    <p style="margin:0 0 8px;">如有需要，你之后仍可在偏好页恢复设置。</p>
+    <p style="margin:0 0 8px;">如需帮助，请联系 <a href="mailto:{{ $support_email }}">{{ $support_email }}</a>。</p>
+
+    <p style="margin:0;font-size:12px;color:#52606d;">
+        <a href="{{ $privacy_url }}">隐私政策</a> |
+        <a href="{{ $terms_url }}">服务条款</a> |
+        <a href="{{ $refund_url }}">退款政策</a>
+    </p>
+</div>
+</body>
+</html>

--- a/backend/tests/Feature/Email/EmailLifecycleExecutionPolicyTest.php
+++ b/backend/tests/Feature/Email/EmailLifecycleExecutionPolicyTest.php
@@ -1,0 +1,80 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Email;
+
+use App\Models\EmailSuppression;
+use App\Services\Email\EmailCaptureService;
+use App\Services\Email\EmailPreferenceService;
+use App\Support\PiiCipher;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Str;
+use Tests\TestCase;
+
+final class EmailLifecycleExecutionPolicyTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_suppression_blocks_both_lifecycle_confirmation_templates(): void
+    {
+        $email = 'suppressed+lifecycle@example.com';
+        app(EmailCaptureService::class)->ensureSubscriber($email, ['surface' => 'preferences']);
+
+        /** @var PiiCipher $pii */
+        $pii = app(PiiCipher::class);
+        EmailSuppression::query()->create([
+            'id' => (string) Str::uuid(),
+            'email_hash' => $pii->emailHash($email),
+            'reason' => 'bounce',
+            'source' => 'test',
+            'meta_json' => ['channel' => 'qa'],
+        ]);
+
+        $service = app(EmailPreferenceService::class);
+
+        $preferencesPolicy = $service->deliveryPolicyForEmail($email, 'preferences_updated');
+        $unsubscribePolicy = $service->deliveryPolicyForEmail($email, 'unsubscribe_confirmation');
+
+        $this->assertFalse((bool) ($preferencesPolicy['allowed'] ?? true));
+        $this->assertSame('suppressed', (string) ($preferencesPolicy['status'] ?? ''));
+        $this->assertFalse((bool) ($unsubscribePolicy['allowed'] ?? true));
+        $this->assertSame('suppressed', (string) ($unsubscribePolicy['status'] ?? ''));
+    }
+
+    public function test_preferences_updated_is_not_blocked_by_preference_toggles(): void
+    {
+        $email = 'preferences+policy@example.com';
+        app(EmailCaptureService::class)->ensureSubscriber($email, ['surface' => 'preferences']);
+
+        $service = app(EmailPreferenceService::class);
+        $token = $service->issueTokenForEmail($email);
+        $result = $service->updateByToken($token, [
+            'marketing_updates' => false,
+            'report_recovery' => false,
+            'product_updates' => false,
+        ]);
+        $this->assertTrue((bool) ($result['ok'] ?? false));
+
+        $policy = $service->deliveryPolicyForEmail($email, 'preferences_updated');
+
+        $this->assertTrue((bool) ($policy['allowed'] ?? false));
+        $this->assertSame('allowed', (string) ($policy['status'] ?? ''));
+    }
+
+    public function test_unsubscribe_confirmation_is_allowed_once_subscriber_is_unsubscribed(): void
+    {
+        $email = 'unsubscribe+policy@example.com';
+        app(EmailCaptureService::class)->ensureSubscriber($email, ['surface' => 'unsubscribe']);
+
+        $service = app(EmailPreferenceService::class);
+        $token = $service->issueTokenForEmail($email);
+        $result = $service->unsubscribeByToken($token, 'requested_by_user');
+        $this->assertTrue((bool) ($result['ok'] ?? false));
+
+        $policy = $service->deliveryPolicyForEmail($email, 'unsubscribe_confirmation');
+
+        $this->assertTrue((bool) ($policy['allowed'] ?? false));
+        $this->assertSame('allowed', (string) ($policy['status'] ?? ''));
+    }
+}

--- a/backend/tests/Feature/Email/EmailLifecycleRolloutCommandTest.php
+++ b/backend/tests/Feature/Email/EmailLifecycleRolloutCommandTest.php
@@ -1,0 +1,140 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Email;
+
+use App\Models\EmailSubscriber;
+use App\Services\Email\EmailCaptureService;
+use App\Services\Email\EmailPreferenceService;
+use App\Support\PiiCipher;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\DB;
+use Tests\TestCase;
+
+final class EmailLifecycleRolloutCommandTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_dry_run_reports_candidates_without_writing_outbox_rows(): void
+    {
+        $this->updatePreferencesFor('dry-run@example.com', [
+            'marketing_updates' => true,
+            'report_recovery' => true,
+            'product_updates' => false,
+        ]);
+
+        $this->artisan('email:lifecycle-rollout --dry-run')
+            ->expectsOutput('Candidates: 1')
+            ->expectsOutput('Enqueued: 0')
+            ->expectsOutput('preferences_updated => candidates 1, enqueued 0')
+            ->expectsOutput('unsubscribe_confirmation => candidates 0, enqueued 0')
+            ->expectsOutput('Dry run: no outbox rows were enqueued.')
+            ->assertExitCode(0);
+
+        $this->assertSame(0, DB::table('email_outbox')->count());
+    }
+
+    public function test_command_enqueues_preferences_updated_confirmation_for_eligible_subscriber(): void
+    {
+        $this->updatePreferencesFor('preferences+rollout@example.com', [
+            'marketing_updates' => true,
+            'report_recovery' => true,
+            'product_updates' => false,
+        ]);
+
+        $this->artisan('email:lifecycle-rollout')
+            ->expectsOutput('Candidates: 1')
+            ->expectsOutput('Enqueued: 1')
+            ->expectsOutput('preferences_updated => candidates 1, enqueued 1')
+            ->expectsOutput('unsubscribe_confirmation => candidates 0, enqueued 0')
+            ->assertExitCode(0);
+
+        $row = DB::table('email_outbox')->where('template', 'preferences_updated')->first();
+        $this->assertNotNull($row);
+        $this->assertSame('pending', (string) ($row->status ?? ''));
+    }
+
+    public function test_command_does_not_duplicate_existing_pending_confirmation_rows(): void
+    {
+        $this->unsubscribeSubscriber('unsubscribe+rollout@example.com');
+
+        $this->artisan('email:lifecycle-rollout')->assertExitCode(0);
+        $this->artisan('email:lifecycle-rollout')
+            ->expectsOutput('Candidates: 0')
+            ->expectsOutput('Enqueued: 0')
+            ->expectsOutput('preferences_updated => candidates 0, enqueued 0')
+            ->expectsOutput('unsubscribe_confirmation => candidates 0, enqueued 0')
+            ->assertExitCode(0);
+
+        $this->assertSame(1, DB::table('email_outbox')->where('template', 'unsubscribe_confirmation')->count());
+    }
+
+    public function test_command_respects_lifecycle_cooldown_window(): void
+    {
+        $subscriber = $this->updatePreferencesFor('cooldown@example.com', [
+            'marketing_updates' => true,
+            'report_recovery' => true,
+            'product_updates' => true,
+        ]);
+
+        $subscriber->forceFill([
+            'last_lifecycle_email_sent_at' => now()->subMinutes(5),
+            'last_preferences_confirmation_sent_at' => null,
+        ])->save();
+
+        $this->artisan('email:lifecycle-rollout')
+            ->expectsOutput('Candidates: 0')
+            ->expectsOutput('Enqueued: 0')
+            ->expectsOutput('preferences_updated => candidates 0, enqueued 0')
+            ->expectsOutput('unsubscribe_confirmation => candidates 0, enqueued 0')
+            ->assertExitCode(0);
+
+        $this->assertSame(0, DB::table('email_outbox')->count());
+    }
+
+    private function updatePreferencesFor(string $email, array $preferences): EmailSubscriber
+    {
+        app(EmailCaptureService::class)->ensureSubscriber($email, [
+            'surface' => 'preferences',
+            'locale' => 'en',
+            'share_id' => 'share_rollout',
+            'entrypoint' => 'preferences_page',
+        ]);
+
+        $service = app(EmailPreferenceService::class);
+        $token = $service->issueTokenForEmail($email);
+        $result = $service->updateByToken($token, $preferences);
+        $this->assertTrue((bool) ($result['ok'] ?? false));
+
+        return $this->subscriberForEmail($email);
+    }
+
+    private function unsubscribeSubscriber(string $email): EmailSubscriber
+    {
+        app(EmailCaptureService::class)->ensureSubscriber($email, [
+            'surface' => 'unsubscribe',
+            'locale' => 'en',
+        ]);
+
+        $service = app(EmailPreferenceService::class);
+        $token = $service->issueTokenForEmail($email);
+        $result = $service->unsubscribeByToken($token, 'requested_by_user');
+        $this->assertTrue((bool) ($result['ok'] ?? false));
+
+        return $this->subscriberForEmail($email);
+    }
+
+    private function subscriberForEmail(string $email): EmailSubscriber
+    {
+        /** @var PiiCipher $pii */
+        $pii = app(PiiCipher::class);
+
+        /** @var EmailSubscriber $subscriber */
+        $subscriber = EmailSubscriber::query()
+            ->where('email_hash', $pii->emailHash($email))
+            ->firstOrFail();
+
+        return $subscriber;
+    }
+}

--- a/backend/tests/Feature/Email/EmailOutboxAttributionTest.php
+++ b/backend/tests/Feature/Email/EmailOutboxAttributionTest.php
@@ -164,6 +164,70 @@ final class EmailOutboxAttributionTest extends TestCase
         $this->assertStringContainsString('utm_campaign=report-recovery', $html);
     }
 
+    public function test_preferences_updated_outbox_payload_includes_attribution_contract(): void
+    {
+        config([
+            'fap.runtime.EMAIL_OUTBOX_SEND' => true,
+            'fap.runtime.FAP_BASE_URL' => 'https://app.example.test',
+            'app.url' => 'https://api.example.test',
+            'mail.default' => 'array',
+        ]);
+
+        $email = 'preferences+attr@example.com';
+
+        $subscriber = app(EmailCaptureService::class)->ensureSubscriber($email, [
+            'surface' => 'preferences',
+            'locale' => 'en',
+            'share_id' => 'share_preferences_attr',
+            'compare_invite_id' => (string) Str::uuid(),
+            'share_click_id' => 'clk_preferences_attr',
+            'entrypoint' => 'preferences_page',
+            'referrer' => 'https://example.com/preferences',
+            'landing_path' => '/en/email/preferences',
+            'utm' => [
+                'source' => 'settings',
+                'medium' => 'owned',
+                'campaign' => 'preferences-updated',
+                'term' => 'email',
+                'content' => 'footer',
+            ],
+        ]);
+        $subscriber->last_preferences_changed_at = now();
+        $subscriber->save();
+
+        $queued = app(EmailOutboxService::class)->queuePreferencesUpdatedConfirmation($subscriber, 'en');
+        $this->assertTrue((bool) ($queued['ok'] ?? false));
+        $this->assertTrue((bool) ($queued['queued'] ?? false));
+
+        $row = DB::table('email_outbox')
+            ->where('template', 'preferences_updated')
+            ->first();
+        $this->assertNotNull($row);
+
+        $payloadJson = json_decode((string) ($row->payload_json ?? '{}'), true);
+        $this->assertIsArray($payloadJson);
+        $this->assertSame('share_preferences_attr', (string) data_get($payloadJson, 'attribution.share_id'));
+        $this->assertSame('clk_preferences_attr', (string) data_get($payloadJson, 'attribution.share_click_id'));
+        $this->assertSame('owned', (string) data_get($payloadJson, 'attribution.utm.medium'));
+        $this->assertArrayNotHasKey('email', $payloadJson);
+        $this->assertArrayNotHasKey('to_email', $payloadJson);
+
+        /** @var PiiCipher $pii */
+        $pii = app(PiiCipher::class);
+        $payloadEnc = json_decode((string) $pii->decrypt((string) ($row->payload_enc ?? '')), true);
+        $this->assertIsArray($payloadEnc);
+        $this->assertSame($email, (string) ($payloadEnc['to_email'] ?? ''));
+        $this->assertSame('footer', (string) data_get($payloadEnc, 'attribution.utm.content'));
+
+        Mail::mailer('array')->getSymfonyTransport()->flush();
+        $this->artisan('email:outbox-send --limit=10')->assertExitCode(0);
+
+        $html = (string) Mail::mailer('array')->getSymfonyTransport()->messages()->first()->getOriginalMessage()->getHtmlBody();
+        $this->assertStringContainsString('share_id=share_preferences_attr', $html);
+        $this->assertStringContainsString('utm_campaign=preferences-updated', $html);
+        $this->assertStringContainsString('compare_invite_id=', $html);
+    }
+
     private function createAttempt(): string
     {
         $attemptId = (string) Str::uuid();

--- a/backend/tests/Feature/Email/EmailOutboxSendCommandTest.php
+++ b/backend/tests/Feature/Email/EmailOutboxSendCommandTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Tests\Feature\Email;
 
+use App\Services\Email\EmailCaptureService;
 use App\Services\Email\EmailOutboxService;
 use App\Support\PiiCipher;
 use Illuminate\Foundation\Testing\RefreshDatabase;
@@ -140,6 +141,40 @@ final class EmailOutboxSendCommandTest extends TestCase
         $this->assertIsArray($payloadJson);
         $this->assertSame('send_failed', (string) data_get($payloadJson, 'delivery_execution.error_code'));
         $this->assertStringContainsString('Simulated transport failure', (string) data_get($payloadJson, 'delivery_execution.error_message'));
+    }
+
+    public function test_command_updates_lifecycle_sent_markers_for_preferences_confirmation(): void
+    {
+        config([
+            'fap.runtime.EMAIL_OUTBOX_SEND' => true,
+            'mail.default' => 'array',
+        ]);
+
+        $this->flushArrayTransport();
+        $email = 'buyer+preferences-marker@example.com';
+        $subscriber = app(EmailCaptureService::class)->ensureSubscriber($email, [
+            'surface' => 'preferences',
+            'locale' => 'en',
+            'entrypoint' => 'preferences_page',
+        ]);
+        $subscriber->last_preferences_changed_at = now();
+        $subscriber->save();
+
+        $queued = app(EmailOutboxService::class)->queuePreferencesUpdatedConfirmation($subscriber);
+        $this->assertTrue((bool) ($queued['ok'] ?? false));
+        $this->assertTrue((bool) ($queued['queued'] ?? false));
+
+        $this->artisan('email:outbox-send --limit=10')
+            ->expectsOutput('Mailer array: sent 1, blocked 0, failed 0.')
+            ->assertExitCode(0);
+
+        $subscriber->refresh();
+        $this->assertNotNull($subscriber->last_lifecycle_email_sent_at);
+        $this->assertNotNull($subscriber->last_preferences_confirmation_sent_at);
+
+        $message = Mail::mailer('array')->getSymfonyTransport()->messages()->first()->getOriginalMessage();
+        $this->assertSame('Your email preferences were updated', (string) $message->getSubject());
+        $this->assertStringContainsString('Manage email preferences', (string) $message->getHtmlBody());
     }
 
     private function createAttempt(string $locale = 'en'): string

--- a/backend/tests/Feature/Email/EmailPreferencesExecutionTest.php
+++ b/backend/tests/Feature/Email/EmailPreferencesExecutionTest.php
@@ -5,8 +5,11 @@ declare(strict_types=1);
 namespace Tests\Feature\Email;
 
 use App\Models\EmailPreference;
+use App\Models\EmailSubscriber;
 use App\Services\Email\EmailCaptureService;
 use App\Services\Email\EmailOutboxService;
+use App\Services\Email\EmailPreferenceService;
+use App\Support\PiiCipher;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Mail;
@@ -16,6 +19,41 @@ use Tests\TestCase;
 final class EmailPreferencesExecutionTest extends TestCase
 {
     use RefreshDatabase;
+
+    public function test_preference_update_writes_foundation_state_and_rollout_command_enqueues_confirmation(): void
+    {
+        $email = 'preferences+foundation@example.com';
+        app(EmailCaptureService::class)->ensureSubscriber($email, [
+            'surface' => 'preferences',
+            'locale' => 'en',
+            'share_id' => 'share_preferences_exec',
+        ]);
+
+        /** @var EmailPreferenceService $service */
+        $service = app(EmailPreferenceService::class);
+        $token = $service->issueTokenForEmail($email);
+        $response = $service->updateByToken($token, [
+            'marketing_updates' => true,
+            'report_recovery' => true,
+            'product_updates' => false,
+        ]);
+
+        $this->assertTrue((bool) ($response['ok'] ?? false));
+        $subscriber = $this->subscriberForEmail($email);
+        $this->assertNotNull($subscriber->last_preferences_changed_at);
+        $this->assertSame(0, DB::table('email_outbox')->count());
+
+        $this->artisan('email:lifecycle-rollout')
+            ->expectsOutput('Candidates: 1')
+            ->expectsOutput('Enqueued: 1')
+            ->expectsOutput('preferences_updated => candidates 1, enqueued 1')
+            ->expectsOutput('unsubscribe_confirmation => candidates 0, enqueued 0')
+            ->assertExitCode(0);
+
+        $row = DB::table('email_outbox')->where('template', 'preferences_updated')->first();
+        $this->assertNotNull($row);
+        $this->assertSame('pending', (string) ($row->status ?? ''));
+    }
 
     public function test_report_recovery_true_allows_transactional_delivery_even_when_marketing_flags_are_false(): void
     {
@@ -130,5 +168,18 @@ final class EmailPreferencesExecutionTest extends TestCase
     private function flushArrayTransport(): void
     {
         Mail::mailer('array')->getSymfonyTransport()->flush();
+    }
+
+    private function subscriberForEmail(string $email): EmailSubscriber
+    {
+        /** @var PiiCipher $pii */
+        $pii = app(PiiCipher::class);
+
+        /** @var EmailSubscriber $subscriber */
+        $subscriber = EmailSubscriber::query()
+            ->where('email_hash', $pii->emailHash($email))
+            ->firstOrFail();
+
+        return $subscriber;
     }
 }

--- a/backend/tests/Feature/Email/EmailSuppressionExecutionTest.php
+++ b/backend/tests/Feature/Email/EmailSuppressionExecutionTest.php
@@ -141,6 +141,46 @@ final class EmailSuppressionExecutionTest extends TestCase
         $this->assertSame(0, Mail::mailer('array')->getSymfonyTransport()->messages()->count());
     }
 
+    public function test_suppression_hit_blocks_preferences_updated_confirmation_delivery(): void
+    {
+        config([
+            'fap.runtime.EMAIL_OUTBOX_SEND' => true,
+            'mail.default' => 'array',
+        ]);
+
+        $this->flushArrayTransport();
+        $email = 'suppressed+preferences-confirmation@example.com';
+        $subscriber = app(EmailCaptureService::class)->ensureSubscriber($email, [
+            'surface' => 'preferences',
+            'locale' => 'en',
+        ]);
+        $subscriber->last_preferences_changed_at = now();
+        $subscriber->save();
+
+        $queued = app(EmailOutboxService::class)->queuePreferencesUpdatedConfirmation($subscriber);
+        $this->assertTrue((bool) ($queued['ok'] ?? false));
+        $this->assertTrue((bool) ($queued['queued'] ?? false));
+
+        /** @var PiiCipher $pii */
+        $pii = app(PiiCipher::class);
+        EmailSuppression::query()->create([
+            'id' => (string) Str::uuid(),
+            'email_hash' => $pii->emailHash($email),
+            'reason' => 'complaint',
+            'source' => 'test',
+            'meta_json' => ['channel' => 'qa'],
+        ]);
+
+        $this->artisan('email:outbox-send --limit=10')
+            ->expectsOutput('Mailer array: sent 0, blocked 1, failed 0.')
+            ->assertExitCode(0);
+
+        $row = DB::table('email_outbox')->where('template', 'preferences_updated')->first();
+        $this->assertNotNull($row);
+        $this->assertSame('suppressed', (string) ($row->status ?? ''));
+        $this->assertSame(0, Mail::mailer('array')->getSymfonyTransport()->messages()->count());
+    }
+
     private function createUser(string $email): int
     {
         $userId = random_int(100000, 999999);

--- a/backend/tests/Feature/Email/PreferencesUpdatedTemplateDeliveryTest.php
+++ b/backend/tests/Feature/Email/PreferencesUpdatedTemplateDeliveryTest.php
@@ -1,0 +1,96 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Email;
+
+use App\Services\Email\EmailCaptureService;
+use App\Services\Email\EmailOutboxService;
+use App\Support\PiiCipher;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Mail;
+use PHPUnit\Framework\Attributes\DataProvider;
+use Tests\TestCase;
+
+final class PreferencesUpdatedTemplateDeliveryTest extends TestCase
+{
+    use RefreshDatabase;
+
+    #[DataProvider('localeProvider')]
+    public function test_preferences_updated_template_renders_supported_locales(string $locale, string $expectedTitle, string $expectedLinkLabel): void
+    {
+        config([
+            'fap.runtime.EMAIL_OUTBOX_SEND' => true,
+            'fap.runtime.FAP_BASE_URL' => 'https://app.example.test',
+            'app.url' => 'https://api.example.test',
+            'mail.default' => 'array',
+        ]);
+
+        $this->flushArrayTransport();
+        $email = 'preferences+template+'.md5($locale).'@example.com';
+        $subscriber = app(EmailCaptureService::class)->ensureSubscriber($email, [
+            'surface' => 'preferences',
+            'locale' => $locale,
+            'share_id' => 'share_preferences_template',
+            'entrypoint' => 'preferences_page',
+            'utm' => [
+                'source' => 'email',
+                'medium' => 'owned',
+                'campaign' => 'preferences-updated',
+            ],
+        ]);
+        $subscriber->last_preferences_changed_at = now();
+        $subscriber->save();
+
+        $queued = app(EmailOutboxService::class)->queuePreferencesUpdatedConfirmation($subscriber, $locale);
+        $this->assertTrue((bool) ($queued['ok'] ?? false));
+        $this->assertTrue((bool) ($queued['queued'] ?? false));
+
+        $row = DB::table('email_outbox')->where('template', 'preferences_updated')->first();
+        $this->assertNotNull($row);
+
+        $payloadJson = json_decode((string) ($row->payload_json ?? '{}'), true);
+        $this->assertIsArray($payloadJson);
+        $this->assertArrayNotHasKey('email', $payloadJson);
+        $this->assertArrayNotHasKey('to_email', $payloadJson);
+        $this->assertArrayNotHasKey('claim_token', $payloadJson);
+        $this->assertArrayNotHasKey('claim_url', $payloadJson);
+        $this->assertSame('share_preferences_template', (string) data_get($payloadJson, 'attribution.share_id'));
+
+        /** @var PiiCipher $pii */
+        $pii = app(PiiCipher::class);
+        $payloadEnc = json_decode((string) $pii->decrypt((string) ($row->payload_enc ?? '')), true);
+        $this->assertIsArray($payloadEnc);
+        $this->assertSame($email, (string) ($payloadEnc['to_email'] ?? ''));
+        $this->assertArrayNotHasKey('claim_token', $payloadEnc);
+        $this->assertArrayNotHasKey('claim_url', $payloadEnc);
+
+        $this->artisan('email:outbox-send --limit=10')
+            ->expectsOutput('Mailer array: sent 1, blocked 0, failed 0.')
+            ->assertExitCode(0);
+
+        $html = (string) Mail::mailer('array')->getSymfonyTransport()->messages()->first()->getOriginalMessage()->getHtmlBody();
+        $this->assertStringContainsString($expectedTitle, $html);
+        $this->assertStringContainsString($expectedLinkLabel, $html);
+        $this->assertStringContainsString('https://app.example.test/email/preferences?token=', $html);
+        $this->assertStringContainsString('https://app.example.test/email/unsubscribe?token=', $html);
+        $this->assertStringContainsString('https://app.example.test/orders/lookup?', $html);
+    }
+
+    /**
+     * @return array<string,array{0:string,1:string,2:string}>
+     */
+    public static function localeProvider(): array
+    {
+        return [
+            'en' => ['en', 'Email preferences updated', 'Manage email preferences'],
+            'zh-CN' => ['zh-CN', '邮件偏好已更新', '管理邮件偏好'],
+        ];
+    }
+
+    private function flushArrayTransport(): void
+    {
+        Mail::mailer('array')->getSymfonyTransport()->flush();
+    }
+}

--- a/backend/tests/Feature/Email/UnsubscribeConfirmationTemplateDeliveryTest.php
+++ b/backend/tests/Feature/Email/UnsubscribeConfirmationTemplateDeliveryTest.php
@@ -1,0 +1,98 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Email;
+
+use App\Services\Email\EmailCaptureService;
+use App\Services\Email\EmailOutboxService;
+use App\Support\PiiCipher;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Mail;
+use PHPUnit\Framework\Attributes\DataProvider;
+use Tests\TestCase;
+
+final class UnsubscribeConfirmationTemplateDeliveryTest extends TestCase
+{
+    use RefreshDatabase;
+
+    #[DataProvider('localeProvider')]
+    public function test_unsubscribe_confirmation_template_renders_supported_locales(string $locale, string $expectedTitle, string $expectedLinkLabel): void
+    {
+        config([
+            'fap.runtime.EMAIL_OUTBOX_SEND' => true,
+            'fap.runtime.FAP_BASE_URL' => 'https://app.example.test',
+            'app.url' => 'https://api.example.test',
+            'mail.default' => 'array',
+        ]);
+
+        $this->flushArrayTransport();
+        $email = 'unsubscribe+template+'.md5($locale).'@example.com';
+        $subscriber = app(EmailCaptureService::class)->ensureSubscriber($email, [
+            'surface' => 'unsubscribe',
+            'locale' => $locale,
+            'share_id' => 'share_unsubscribe_template',
+            'entrypoint' => 'unsubscribe_page',
+            'utm' => [
+                'source' => 'email',
+                'medium' => 'owned',
+                'campaign' => 'unsubscribe-confirmation',
+            ],
+        ]);
+        $subscriber->status = 'unsubscribed';
+        $subscriber->unsubscribed_at = now();
+        $subscriber->last_preferences_changed_at = now();
+        $subscriber->save();
+
+        $queued = app(EmailOutboxService::class)->queueUnsubscribeConfirmation($subscriber, $locale);
+        $this->assertTrue((bool) ($queued['ok'] ?? false));
+        $this->assertTrue((bool) ($queued['queued'] ?? false));
+
+        $row = DB::table('email_outbox')->where('template', 'unsubscribe_confirmation')->first();
+        $this->assertNotNull($row);
+
+        $payloadJson = json_decode((string) ($row->payload_json ?? '{}'), true);
+        $this->assertIsArray($payloadJson);
+        $this->assertArrayNotHasKey('email', $payloadJson);
+        $this->assertArrayNotHasKey('to_email', $payloadJson);
+        $this->assertArrayNotHasKey('claim_token', $payloadJson);
+        $this->assertArrayNotHasKey('claim_url', $payloadJson);
+        $this->assertSame('share_unsubscribe_template', (string) data_get($payloadJson, 'attribution.share_id'));
+
+        /** @var PiiCipher $pii */
+        $pii = app(PiiCipher::class);
+        $payloadEnc = json_decode((string) $pii->decrypt((string) ($row->payload_enc ?? '')), true);
+        $this->assertIsArray($payloadEnc);
+        $this->assertSame($email, (string) ($payloadEnc['to_email'] ?? ''));
+        $this->assertArrayNotHasKey('claim_token', $payloadEnc);
+        $this->assertArrayNotHasKey('claim_url', $payloadEnc);
+
+        $this->artisan('email:outbox-send --limit=10')
+            ->expectsOutput('Mailer array: sent 1, blocked 0, failed 0.')
+            ->assertExitCode(0);
+
+        $html = (string) Mail::mailer('array')->getSymfonyTransport()->messages()->first()->getOriginalMessage()->getHtmlBody();
+        $this->assertStringContainsString($expectedTitle, $html);
+        $this->assertStringContainsString($expectedLinkLabel, $html);
+        $this->assertStringContainsString('https://app.example.test/email/preferences?token=', $html);
+        $this->assertStringContainsString('https://app.example.test/email/unsubscribe?token=', $html);
+        $this->assertStringContainsString('https://app.example.test/orders/lookup?', $html);
+    }
+
+    /**
+     * @return array<string,array{0:string,1:string,2:string}>
+     */
+    public static function localeProvider(): array
+    {
+        return [
+            'en' => ['en', 'You have been unsubscribed', 'Manage email preferences'],
+            'zh-CN' => ['zh-CN', '你已退订邮件', '管理邮件偏好'],
+        ];
+    }
+
+    private function flushArrayTransport(): void
+    {
+        Mail::mailer('array')->getSymfonyTransport()->flush();
+    }
+}


### PR DESCRIPTION
## Summary
- add backend-only lifecycle rollout command and scheduler for confirmation automation
- enqueue `preferences_updated` and `unsubscribe_confirmation` through the existing email outbox
- extend delivery policy, subscriber lifecycle state, and localized templates for lifecycle confirmations

## Tests
- php artisan test tests/Feature/Email/EmailLifecycleRolloutCommandTest.php
- php artisan test tests/Feature/Email/EmailLifecycleExecutionPolicyTest.php
- php artisan test tests/Feature/Email/PreferencesUpdatedTemplateDeliveryTest.php
- php artisan test tests/Feature/Email/UnsubscribeConfirmationTemplateDeliveryTest.php
- php artisan test tests/Feature/Email/EmailOutboxSendCommandTest.php
- php artisan test tests/Feature/Email/EmailSuppressionExecutionTest.php
- php artisan test tests/Feature/Email/EmailPreferencesExecutionTest.php
- php artisan test tests/Feature/Email/EmailOutboxAttributionTest.php
- php artisan test tests/Feature/Email/ReportClaimTemplateDeliveryTest.php
- php artisan test tests/Feature/Email/EmailOutboxNoPlaintextPayloadTest.php
- php artisan test tests/Feature/V0_3/EmailCaptureContractTest.php
- php artisan test tests/Feature/V0_3/EmailPreferencesContractTest.php
- php artisan test tests/Feature/V0_3/EmailUnsubscribeContractTest.php
- php artisan test tests/Feature/V0_3/ClaimReportEmailRequestTest.php
- php artisan test tests/Feature/V0_3/CommerceOrderResendTest.php
- php artisan test tests/Feature/V0_3/PaymentWebhookControllerTest.php
- php artisan test tests/Feature/Commerce/BigFiveUnlockDeliveryPipelineTest.php
- php artisan test tests/Feature/Report/ReportPdfCrossScaleDeliveryTest.php
- php artisan email:lifecycle-rollout --dry-run
- bash scripts/ci_verify_mbti.sh
