### PR TITLE
feat(email): add post-purchase follow-up and report reactivation rollout

### DIFF
--- a/backend/app/Console/Commands/FapEmailLifecycleRollout.php
+++ b/backend/app/Console/Commands/FapEmailLifecycleRollout.php
@@ -12,7 +12,7 @@ class FapEmailLifecycleRollout extends Command
 {
     protected $signature = 'email:lifecycle-rollout {--dry-run : Scan eligible subscribers without enqueueing outbox rows.}';
 
-    protected $description = 'Scan lifecycle confirmation candidates and enqueue pending outbox rows.';
+    protected $description = 'Scan lifecycle follow-up candidates and enqueue pending outbox rows.';
 
     public function __construct(
         private readonly EmailLifecycleRolloutService $rollout,
@@ -41,6 +41,16 @@ class FapEmailLifecycleRollout extends Command
             'unsubscribe_confirmation => candidates %d, enqueued %d',
             (int) data_get($result, 'templates.unsubscribe_confirmation.candidates', 0),
             (int) data_get($result, 'templates.unsubscribe_confirmation.enqueued', 0),
+        ));
+        $this->line(sprintf(
+            'post_purchase_followup => candidates %d, enqueued %d',
+            (int) data_get($result, 'templates.post_purchase_followup.candidates', 0),
+            (int) data_get($result, 'templates.post_purchase_followup.enqueued', 0),
+        ));
+        $this->line(sprintf(
+            'report_reactivation => candidates %d, enqueued %d',
+            (int) data_get($result, 'templates.report_reactivation.candidates', 0),
+            (int) data_get($result, 'templates.report_reactivation.enqueued', 0),
         ));
 
         if ((bool) ($result['dry_run'] ?? false)) {

--- a/backend/app/Models/EmailSubscriber.php
+++ b/backend/app/Models/EmailSubscriber.php
@@ -9,6 +9,8 @@ use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Concerns\HasUuids;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\HasOne;
+use Illuminate\Support\Carbon;
+use Illuminate\Support\Facades\Schema;
 
 class EmailSubscriber extends Model
 {
@@ -47,6 +49,8 @@ class EmailSubscriber extends Model
         'last_preferences_confirmation_sent_at',
         'last_unsubscribe_confirmation_sent_at',
         'last_lifecycle_email_sent_at',
+        'last_lifecycle_template_key',
+        'next_lifecycle_eligible_at',
         'unsubscribed_at',
     ];
 
@@ -63,6 +67,7 @@ class EmailSubscriber extends Model
         'last_preferences_confirmation_sent_at' => 'datetime',
         'last_unsubscribe_confirmation_sent_at' => 'datetime',
         'last_lifecycle_email_sent_at' => 'datetime',
+        'next_lifecycle_eligible_at' => 'datetime',
         'unsubscribed_at' => 'datetime',
     ];
 
@@ -83,6 +88,21 @@ class EmailSubscriber extends Model
 
     public function scopeOutsideLifecycleCooldown(Builder $query, CarbonInterface $threshold): Builder
     {
+        if (Schema::hasColumn($this->getTable(), 'next_lifecycle_eligible_at')) {
+            return $query->where(function (Builder $builder) use ($threshold): void {
+                $builder->where(function (Builder $eligible): void {
+                    $eligible->whereNotNull('next_lifecycle_eligible_at')
+                        ->where('next_lifecycle_eligible_at', '<=', now());
+                })->orWhere(function (Builder $legacy) use ($threshold): void {
+                    $legacy->whereNull('next_lifecycle_eligible_at')
+                        ->where(function (Builder $fallback) use ($threshold): void {
+                            $fallback->whereNull('last_lifecycle_email_sent_at')
+                                ->orWhere('last_lifecycle_email_sent_at', '<=', $threshold);
+                        });
+                });
+            });
+        }
+
         return $query->where(function (Builder $builder) use ($threshold): void {
             $builder->whereNull('last_lifecycle_email_sent_at')
                 ->orWhere('last_lifecycle_email_sent_at', '<=', $threshold);
@@ -94,9 +114,20 @@ class EmailSubscriber extends Model
         return 'subscriber_'.(string) $this->getKey();
     }
 
-    public function recordLifecycleSend(string $templateKey, CarbonInterface $sentAt): void
+    public function recordLifecycleSend(string $templateKey, CarbonInterface $sentAt, ?CarbonInterface $nextEligibleAt = null): void
     {
         $this->last_lifecycle_email_sent_at = $sentAt;
+
+        if (Schema::hasColumn($this->getTable(), 'last_lifecycle_template_key')) {
+            $this->setAttribute('last_lifecycle_template_key', $templateKey);
+        }
+
+        if (Schema::hasColumn($this->getTable(), 'next_lifecycle_eligible_at')) {
+            $this->setAttribute(
+                'next_lifecycle_eligible_at',
+                $nextEligibleAt instanceof CarbonInterface ? Carbon::parse($nextEligibleAt) : null
+            );
+        }
 
         if ($templateKey === 'preferences_updated') {
             $this->last_preferences_confirmation_sent_at = $sentAt;

--- a/backend/app/Services/Email/EmailLifecycleRolloutService.php
+++ b/backend/app/Services/Email/EmailLifecycleRolloutService.php
@@ -6,12 +6,32 @@ namespace App\Services\Email;
 
 use App\Models\EmailSubscriber;
 use App\Support\PiiCipher;
+use Carbon\CarbonInterface;
+use Carbon\CarbonInterval;
+use Illuminate\Support\Carbon;
 use Illuminate\Support\Collection;
+use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Schema;
 
 class EmailLifecycleRolloutService
 {
-    private const COOLDOWN_MINUTES = 10;
+    public const CONFIRMATION_COOLDOWN_MINUTES = 10;
+
+    public const POST_PURCHASE_FOLLOWUP_COOLDOWN_DAYS = 7;
+
+    public const REPORT_REACTIVATION_COOLDOWN_DAYS = 14;
+
+    /**
+     * @var array<string,EmailSubscriber|null>
+     */
+    private array $subscriberCache = [];
+
+    /**
+     * @var array<string,bool>
+     */
+    private array $suppressedHashCache = [];
+
+    private ?Carbon $now = null;
 
     public function __construct(
         private readonly EmailOutboxService $emailOutbox,
@@ -25,21 +45,24 @@ class EmailLifecycleRolloutService
      *     enqueued:int,
      *     templates:array{
      *         preferences_updated:array{candidates:int,enqueued:int},
-     *         unsubscribe_confirmation:array{candidates:int,enqueued:int}
+     *         unsubscribe_confirmation:array{candidates:int,enqueued:int},
+     *         post_purchase_followup:array{candidates:int,enqueued:int},
+     *         report_reactivation:array{candidates:int,enqueued:int}
      *     }
      * }
      */
     public function rollout(bool $dryRun = false): array
     {
+        $this->now = now();
+        $this->subscriberCache = [];
+        $this->suppressedHashCache = [];
+
         if (! Schema::hasTable('email_subscribers') || ! Schema::hasTable('email_outbox')) {
             return [
                 'dry_run' => $dryRun,
                 'candidates' => 0,
                 'enqueued' => 0,
-                'templates' => [
-                    'preferences_updated' => ['candidates' => 0, 'enqueued' => 0],
-                    'unsubscribe_confirmation' => ['candidates' => 0, 'enqueued' => 0],
-                ],
+                'templates' => $this->emptyTemplateSummary(),
             ];
         }
 
@@ -47,13 +70,10 @@ class EmailLifecycleRolloutService
             'dry_run' => $dryRun,
             'candidates' => 0,
             'enqueued' => 0,
-            'templates' => [
-                'preferences_updated' => ['candidates' => 0, 'enqueued' => 0],
-                'unsubscribe_confirmation' => ['candidates' => 0, 'enqueued' => 0],
-            ],
+            'templates' => $this->emptyTemplateSummary(),
         ];
 
-        $summary = $this->processTemplate(
+        $summary = $this->processSubscriberTemplate(
             $summary,
             'preferences_updated',
             $this->preferencesUpdatedCandidates(),
@@ -61,13 +81,60 @@ class EmailLifecycleRolloutService
             fn (EmailSubscriber $subscriber): array => $this->emailOutbox->queuePreferencesUpdatedConfirmation($subscriber)
         );
 
-        return $this->processTemplate(
+        $summary = $this->processSubscriberTemplate(
             $summary,
             'unsubscribe_confirmation',
             $this->unsubscribeConfirmationCandidates(),
             $dryRun,
             fn (EmailSubscriber $subscriber): array => $this->emailOutbox->queueUnsubscribeConfirmation($subscriber)
         );
+
+        $summary = $this->processOrderTemplate(
+            $summary,
+            'post_purchase_followup',
+            $this->postPurchaseFollowupCandidates(),
+            $dryRun,
+            fn (object $order, EmailSubscriber $subscriber): array => $this->emailOutbox->queuePostPurchaseFollowup(
+                $subscriber,
+                (string) $order->target_attempt_id,
+                (string) $order->order_no
+            )
+        );
+
+        return $this->processOrderTemplate(
+            $summary,
+            'report_reactivation',
+            $this->reportReactivationCandidates(),
+            $dryRun,
+            fn (object $order, EmailSubscriber $subscriber): array => $this->emailOutbox->queueReportReactivation(
+                $subscriber,
+                (string) $order->target_attempt_id,
+                (string) $order->order_no
+            )
+        );
+    }
+
+    public static function nextEligibleAtForTemplate(string $templateKey, CarbonInterface $sentAt): Carbon
+    {
+        return Carbon::parse($sentAt)->add(self::cooldownIntervalForTemplate($templateKey));
+    }
+
+    /**
+     * @return array{
+     *     preferences_updated:array{candidates:int,enqueued:int},
+     *     unsubscribe_confirmation:array{candidates:int,enqueued:int},
+     *     post_purchase_followup:array{candidates:int,enqueued:int},
+     *     report_reactivation:array{candidates:int,enqueued:int}
+     * }
+     */
+    private function emptyTemplateSummary(): array
+    {
+        return [
+            'preferences_updated' => ['candidates' => 0, 'enqueued' => 0],
+            'unsubscribe_confirmation' => ['candidates' => 0, 'enqueued' => 0],
+            'post_purchase_followup' => ['candidates' => 0, 'enqueued' => 0],
+            'report_reactivation' => ['candidates' => 0, 'enqueued' => 0],
+        ];
     }
 
     /**
@@ -85,19 +152,18 @@ class EmailLifecycleRolloutService
      *     templates:array<string,array{candidates:int,enqueued:int}>
      * }
      */
-    private function processTemplate(array $summary, string $templateKey, Collection $subscribers, bool $dryRun, \Closure $enqueue): array
+    private function processSubscriberTemplate(array $summary, string $templateKey, Collection $subscribers, bool $dryRun, \Closure $enqueue): array
     {
         foreach ($subscribers as $subscriber) {
             if (! $subscriber instanceof EmailSubscriber) {
                 continue;
             }
 
-            $email = $this->decryptSubscriberEmail($subscriber);
-            if ($email === null) {
+            if ($this->decryptSubscriberEmail($subscriber) === null) {
                 continue;
             }
 
-            if ($this->hasPendingTemplate($subscriber, $templateKey)) {
+            if ($this->hasPendingTemplateForEmailHash((string) $subscriber->email_hash, $templateKey)) {
                 continue;
             }
 
@@ -119,11 +185,54 @@ class EmailLifecycleRolloutService
     }
 
     /**
+     * @param  array{
+     *     dry_run:bool,
+     *     candidates:int,
+     *     enqueued:int,
+     *     templates:array<string,array{candidates:int,enqueued:int}>
+     * }  $summary
+     * @param  Collection<int,array{order:object,subscriber:EmailSubscriber}>  $candidates
+     * @param  \Closure(object,EmailSubscriber):array{ok:bool,queued:bool,error?:string,reason?:string}  $enqueue
+     * @return array{
+     *     dry_run:bool,
+     *     candidates:int,
+     *     enqueued:int,
+     *     templates:array<string,array{candidates:int,enqueued:int}>
+     * }
+     */
+    private function processOrderTemplate(array $summary, string $templateKey, Collection $candidates, bool $dryRun, \Closure $enqueue): array
+    {
+        foreach ($candidates as $candidate) {
+            $order = $candidate['order'] ?? null;
+            $subscriber = $candidate['subscriber'] ?? null;
+
+            if (! is_object($order) || ! $subscriber instanceof EmailSubscriber) {
+                continue;
+            }
+
+            $summary['candidates']++;
+            $summary['templates'][$templateKey]['candidates']++;
+
+            if ($dryRun) {
+                continue;
+            }
+
+            $result = $enqueue($order, $subscriber);
+            if (($result['ok'] ?? false) && ($result['queued'] ?? false)) {
+                $summary['enqueued']++;
+                $summary['templates'][$templateKey]['enqueued']++;
+            }
+        }
+
+        return $summary;
+    }
+
+    /**
      * @return Collection<int,EmailSubscriber>
      */
     private function preferencesUpdatedCandidates(): Collection
     {
-        $threshold = now()->subMinutes(self::COOLDOWN_MINUTES);
+        $threshold = $this->cooldownThresholdForTemplate('preferences_updated');
 
         $query = EmailSubscriber::query()
             ->with('preference')
@@ -144,7 +253,7 @@ class EmailLifecycleRolloutService
      */
     private function unsubscribeConfirmationCandidates(): Collection
     {
-        $threshold = now()->subMinutes(self::COOLDOWN_MINUTES);
+        $threshold = $this->cooldownThresholdForTemplate('unsubscribe_confirmation');
 
         $query = EmailSubscriber::query()
             ->with('preference')
@@ -158,6 +267,335 @@ class EmailLifecycleRolloutService
             ->orderBy('unsubscribed_at');
 
         return $this->excludeSuppressed($query)->get();
+    }
+
+    /**
+     * @return Collection<int,array{order:object,subscriber:EmailSubscriber}>
+     */
+    private function postPurchaseFollowupCandidates(): Collection
+    {
+        if (! $this->canEvaluateOrderFollowups()) {
+            return collect();
+        }
+
+        return DB::table('orders')
+            ->select([
+                'id',
+                'order_no',
+                'status',
+                'target_attempt_id',
+                'contact_email_hash',
+                'paid_at',
+                'fulfilled_at',
+            ])
+            ->whereIn('status', ['paid', 'fulfilled'])
+            ->whereNotNull('target_attempt_id')
+            ->whereNotNull('contact_email_hash')
+            ->where(function ($builder): void {
+                $builder->whereNotNull('fulfilled_at')
+                    ->orWhereNotNull('paid_at');
+            })
+            ->orderBy('fulfilled_at')
+            ->orderBy('paid_at')
+            ->get()
+            ->map(function (object $order): ?array {
+                $attemptId = trim((string) ($order->target_attempt_id ?? ''));
+                $orderNo = trim((string) ($order->order_no ?? ''));
+                $businessAt = $this->businessTimeForPostPurchase($order);
+
+                if ($attemptId === '' || $orderNo === '' || ! $businessAt instanceof Carbon) {
+                    return null;
+                }
+
+                if ($businessAt->gt($this->now()->copy()->subDay())) {
+                    return null;
+                }
+
+                $subscriber = $this->subscriberForEmailHash((string) ($order->contact_email_hash ?? ''));
+                if (! $this->subscriberAllowedForRecoveryFollowup($subscriber, 'post_purchase_followup')) {
+                    return null;
+                }
+
+                if ($this->attemptHasEvent($attemptId, ['report_view', 'report_pdf_view'])) {
+                    return null;
+                }
+
+                if ($this->hasOutboxRowForOrder($orderNo, $attemptId, ['report_claim'])) {
+                    return null;
+                }
+
+                if ($this->paymentSuccessSentCountForOrder($orderNo, $attemptId) !== 1) {
+                    return null;
+                }
+
+                if ($this->hasOutboxRowForOrder($orderNo, $attemptId, ['post_purchase_followup'], ['pending', 'sent', 'consumed'])) {
+                    return null;
+                }
+
+                return [
+                    'order' => $order,
+                    'subscriber' => $subscriber,
+                ];
+            })
+            ->filter()
+            ->values();
+    }
+
+    /**
+     * @return Collection<int,array{order:object,subscriber:EmailSubscriber}>
+     */
+    private function reportReactivationCandidates(): Collection
+    {
+        if (! $this->canEvaluateOrderFollowups()) {
+            return collect();
+        }
+
+        return DB::table('orders')
+            ->select([
+                'id',
+                'order_no',
+                'status',
+                'target_attempt_id',
+                'contact_email_hash',
+            ])
+            ->whereIn('status', ['paid', 'fulfilled'])
+            ->whereNotNull('target_attempt_id')
+            ->whereNotNull('contact_email_hash')
+            ->orderBy('updated_at')
+            ->get()
+            ->map(function (object $order): ?array {
+                $attemptId = trim((string) ($order->target_attempt_id ?? ''));
+                $orderNo = trim((string) ($order->order_no ?? ''));
+
+                if ($attemptId === '' || $orderNo === '') {
+                    return null;
+                }
+
+                $subscriber = $this->subscriberForEmailHash((string) ($order->contact_email_hash ?? ''));
+                if (! $this->subscriberAllowedForRecoveryFollowup($subscriber, 'report_reactivation')) {
+                    return null;
+                }
+
+                $lastReportViewAt = $this->latestEventAt($attemptId, 'report_view');
+                if (! $lastReportViewAt instanceof Carbon) {
+                    return null;
+                }
+
+                if ($lastReportViewAt->gt($this->now()->copy()->subDays(self::REPORT_REACTIVATION_COOLDOWN_DAYS))) {
+                    return null;
+                }
+
+                if ($this->hasReportPdfViewAfter($attemptId, $lastReportViewAt)) {
+                    return null;
+                }
+
+                if ($this->hasOutboxRowForOrder($orderNo, $attemptId, ['report_claim'])) {
+                    return null;
+                }
+
+                if ($this->hasOutboxRowForOrder($orderNo, $attemptId, ['report_reactivation'], ['pending', 'sent', 'consumed'])) {
+                    return null;
+                }
+
+                return [
+                    'order' => $order,
+                    'subscriber' => $subscriber,
+                ];
+            })
+            ->filter()
+            ->values();
+    }
+
+    private function canEvaluateOrderFollowups(): bool
+    {
+        return Schema::hasTable('orders')
+            && Schema::hasTable('events')
+            && Schema::hasTable('email_outbox');
+    }
+
+    private function subscriberForEmailHash(string $emailHash): ?EmailSubscriber
+    {
+        $normalizedHash = strtolower(trim($emailHash));
+        if ($normalizedHash === '') {
+            return null;
+        }
+
+        if (array_key_exists($normalizedHash, $this->subscriberCache)) {
+            return $this->subscriberCache[$normalizedHash];
+        }
+
+        return $this->subscriberCache[$normalizedHash] = EmailSubscriber::query()
+            ->with('preference')
+            ->where('email_hash', $normalizedHash)
+            ->first();
+    }
+
+    private function subscriberAllowedForRecoveryFollowup(?EmailSubscriber $subscriber, string $templateKey): bool
+    {
+        if (! $subscriber instanceof EmailSubscriber) {
+            return false;
+        }
+
+        if ((string) ($subscriber->status ?? '') !== EmailSubscriber::STATUS_ACTIVE) {
+            return false;
+        }
+
+        if (! $subscriber->allowsTransactionalRecovery()) {
+            return false;
+        }
+
+        if ($this->isSuppressedHash((string) $subscriber->email_hash)) {
+            return false;
+        }
+
+        if (! $this->subscriberOutsideLifecycleCooldown($subscriber, $templateKey)) {
+            return false;
+        }
+
+        return $this->decryptSubscriberEmail($subscriber) !== null;
+    }
+
+    private function subscriberOutsideLifecycleCooldown(EmailSubscriber $subscriber, string $templateKey): bool
+    {
+        if (Schema::hasColumn('email_subscribers', 'next_lifecycle_eligible_at')) {
+            $nextEligibleAt = $subscriber->getAttribute('next_lifecycle_eligible_at');
+            if ($nextEligibleAt instanceof CarbonInterface) {
+                return $nextEligibleAt->lessThanOrEqualTo($this->now());
+            }
+
+            if (is_string($nextEligibleAt) && trim($nextEligibleAt) !== '') {
+                try {
+                    return Carbon::parse($nextEligibleAt)->lessThanOrEqualTo($this->now());
+                } catch (\Throwable) {
+                    // Fall through to legacy last sent timestamp.
+                }
+            }
+        }
+
+        $lastSentAt = $subscriber->last_lifecycle_email_sent_at;
+        if (! $lastSentAt instanceof CarbonInterface) {
+            return true;
+        }
+
+        return $lastSentAt->lessThanOrEqualTo($this->cooldownThresholdForTemplate($templateKey));
+    }
+
+    private function businessTimeForPostPurchase(object $order): ?Carbon
+    {
+        foreach ([$order->fulfilled_at ?? null, $order->paid_at ?? null] as $candidate) {
+            if (! is_string($candidate) || trim($candidate) === '') {
+                continue;
+            }
+
+            try {
+                return Carbon::parse($candidate);
+            } catch (\Throwable) {
+                continue;
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * @param  array<int,string>  $eventCodes
+     */
+    private function attemptHasEvent(string $attemptId, array $eventCodes): bool
+    {
+        return DB::table('events')
+            ->where('attempt_id', $attemptId)
+            ->whereIn('event_code', $eventCodes)
+            ->exists();
+    }
+
+    private function latestEventAt(string $attemptId, string $eventCode): ?Carbon
+    {
+        $value = DB::table('events')
+            ->where('attempt_id', $attemptId)
+            ->where('event_code', $eventCode)
+            ->max('occurred_at');
+
+        if (! is_string($value) || trim($value) === '') {
+            return null;
+        }
+
+        try {
+            return Carbon::parse($value);
+        } catch (\Throwable) {
+            return null;
+        }
+    }
+
+    private function hasReportPdfViewAfter(string $attemptId, CarbonInterface $anchor): bool
+    {
+        return DB::table('events')
+            ->where('attempt_id', $attemptId)
+            ->where('event_code', 'report_pdf_view')
+            ->where('occurred_at', '>', $anchor->toDateTimeString())
+            ->exists();
+    }
+
+    /**
+     * @param  array<int,string>  $templateKeys
+     * @param  array<int,string>|null  $statuses
+     */
+    private function hasOutboxRowForOrder(string $orderNo, string $attemptId, array $templateKeys, ?array $statuses = null): bool
+    {
+        return $this->matchingOutboxRowsForOrder($orderNo, $attemptId, $templateKeys, $statuses)->isNotEmpty();
+    }
+
+    private function paymentSuccessSentCountForOrder(string $orderNo, string $attemptId): int
+    {
+        return $this->matchingOutboxRowsForOrder($orderNo, $attemptId, ['payment_success'], ['sent'])->count();
+    }
+
+    /**
+     * @param  array<int,string>  $templateKeys
+     * @param  array<int,string>|null  $statuses
+     * @return Collection<int,object>
+     */
+    private function matchingOutboxRowsForOrder(string $orderNo, string $attemptId, array $templateKeys, ?array $statuses = null): Collection
+    {
+        $query = DB::table('email_outbox')
+            ->whereIn('template', $templateKeys)
+            ->orderByDesc('updated_at');
+
+        if ($statuses !== null) {
+            $query->whereIn('status', $statuses);
+        }
+
+        if (Schema::hasColumn('email_outbox', 'attempt_id')) {
+            $query->where('attempt_id', $attemptId);
+        }
+
+        return $query->get()->filter(function (object $row) use ($orderNo): bool {
+            $payload = $this->decodePayload((string) ($row->payload_json ?? ''));
+
+            return trim((string) ($payload['order_no'] ?? '')) === $orderNo;
+        })->values();
+    }
+
+    private function decodePayload(string $payload): array
+    {
+        $decoded = json_decode($payload, true);
+
+        return is_array($decoded) ? $decoded : [];
+    }
+
+    private function isSuppressedHash(string $emailHash): bool
+    {
+        $normalizedHash = strtolower(trim($emailHash));
+        if ($normalizedHash === '' || ! Schema::hasTable('email_suppressions')) {
+            return false;
+        }
+
+        if (array_key_exists($normalizedHash, $this->suppressedHashCache)) {
+            return $this->suppressedHashCache[$normalizedHash];
+        }
+
+        return $this->suppressedHashCache[$normalizedHash] = DB::table('email_suppressions')
+            ->where('email_hash', $normalizedHash)
+            ->exists();
     }
 
     private function excludeSuppressed($query)
@@ -180,9 +618,14 @@ class EmailLifecycleRolloutService
             : null;
     }
 
-    private function hasPendingTemplate(EmailSubscriber $subscriber, string $templateKey): bool
+    private function hasPendingTemplateForEmailHash(string $emailHash, string $templateKey): bool
     {
-        $query = \Illuminate\Support\Facades\DB::table('email_outbox')
+        $normalizedHash = strtolower(trim($emailHash));
+        if ($normalizedHash === '') {
+            return false;
+        }
+
+        $query = DB::table('email_outbox')
             ->where('status', 'pending')
             ->where(function ($builder) use ($templateKey): void {
                 if (Schema::hasColumn('email_outbox', 'template_key')) {
@@ -200,17 +643,36 @@ class EmailLifecycleRolloutService
             return false;
         }
 
-        $query->where(function ($builder) use ($subscriber, $hasEmailHash, $hasToEmailHash): void {
+        $query->where(function ($builder) use ($normalizedHash, $hasEmailHash, $hasToEmailHash): void {
             if ($hasEmailHash) {
-                $builder->where('email_hash', (string) $subscriber->email_hash);
+                $builder->where('email_hash', $normalizedHash);
             }
 
             if ($hasToEmailHash) {
                 $method = $hasEmailHash ? 'orWhere' : 'where';
-                $builder->{$method}('to_email_hash', (string) $subscriber->email_hash);
+                $builder->{$method}('to_email_hash', $normalizedHash);
             }
         });
 
         return $query->exists();
+    }
+
+    private function cooldownThresholdForTemplate(string $templateKey): Carbon
+    {
+        return $this->now()->copy()->sub(self::cooldownIntervalForTemplate($templateKey));
+    }
+
+    private static function cooldownIntervalForTemplate(string $templateKey): CarbonInterval
+    {
+        return match (trim($templateKey)) {
+            'post_purchase_followup' => CarbonInterval::days(self::POST_PURCHASE_FOLLOWUP_COOLDOWN_DAYS),
+            'report_reactivation' => CarbonInterval::days(self::REPORT_REACTIVATION_COOLDOWN_DAYS),
+            default => CarbonInterval::minutes(self::CONFIRMATION_COOLDOWN_MINUTES),
+        };
+    }
+
+    private function now(): Carbon
+    {
+        return $this->now instanceof Carbon ? $this->now : now();
     }
 }

--- a/backend/app/Services/Email/EmailOutboxService.php
+++ b/backend/app/Services/Email/EmailOutboxService.php
@@ -403,10 +403,12 @@ class EmailOutboxService
      */
     public function queuePreferencesUpdatedConfirmation(EmailSubscriber $subscriber, ?string $preferredLocale = null): array
     {
-        return $this->queueSubscriberLifecycleConfirmation(
+        return $this->queueSubscriberLifecycleEmail(
             $subscriber,
             'preferences_updated',
             'email_preferences',
+            null,
+            null,
             $preferredLocale
         );
     }
@@ -416,10 +418,12 @@ class EmailOutboxService
      */
     public function queueUnsubscribeConfirmation(EmailSubscriber $subscriber, ?string $preferredLocale = null): array
     {
-        return $this->queueSubscriberLifecycleConfirmation(
+        return $this->queueSubscriberLifecycleEmail(
             $subscriber,
             'unsubscribe_confirmation',
             'email_unsubscribe',
+            null,
+            null,
             $preferredLocale
         );
     }
@@ -427,11 +431,59 @@ class EmailOutboxService
     /**
      * @return array{ok:bool,queued:bool,error?:string,reason?:string}
      */
-    private function queueSubscriberLifecycleConfirmation(
+    public function queuePostPurchaseFollowup(
+        EmailSubscriber $subscriber,
+        string $attemptId,
+        string $orderNo,
+        ?string $preferredLocale = null
+    ): array {
+        return $this->queueSubscriberLifecycleEmail(
+            $subscriber,
+            'post_purchase_followup',
+            'post_purchase_followup',
+            $attemptId,
+            $orderNo,
+            $preferredLocale,
+            [],
+            ['pending', 'sent', 'consumed']
+        );
+    }
+
+    /**
+     * @return array{ok:bool,queued:bool,error?:string,reason?:string}
+     */
+    public function queueReportReactivation(
+        EmailSubscriber $subscriber,
+        string $attemptId,
+        string $orderNo,
+        ?string $preferredLocale = null
+    ): array {
+        return $this->queueSubscriberLifecycleEmail(
+            $subscriber,
+            'report_reactivation',
+            'report_reactivation',
+            $attemptId,
+            $orderNo,
+            $preferredLocale,
+            [],
+            ['pending', 'sent', 'consumed']
+        );
+    }
+
+    /**
+     * @param  array<string,mixed>  $payloadOverrides
+     * @param  array<int,string>|null  $dedupeStatuses
+     * @return array{ok:bool,queued:bool,error?:string,reason?:string}
+     */
+    private function queueSubscriberLifecycleEmail(
         EmailSubscriber $subscriber,
         string $templateKey,
         string $surface,
-        ?string $preferredLocale = null
+        ?string $attemptId = null,
+        ?string $orderNo = null,
+        ?string $preferredLocale = null,
+        array $payloadOverrides = [],
+        ?array $dedupeStatuses = null
     ): array {
         if (! \App\Support\SchemaBaseline::hasTable('email_outbox')) {
             return ['ok' => false, 'queued' => false, 'error' => 'TABLE_MISSING'];
@@ -443,18 +495,26 @@ class EmailOutboxService
             return ['ok' => false, 'queued' => false, 'error' => 'INVALID_RECIPIENT'];
         }
 
+        $lastContext = is_array($subscriber->last_context_json) ? $subscriber->last_context_json : [];
+        $attemptId = $this->trimOrNull($attemptId) ?? $this->trimOrNull((string) ($lastContext['attempt_id'] ?? ''));
+        $orderNo = $this->trimOrNull($orderNo) ?? $this->trimOrNull((string) ($lastContext['order_no'] ?? ''));
         $emailHash = $this->piiCipher->emailHash($email);
-        if ($this->hasPendingLifecycleTemplateRow($emailHash, $templateKey)) {
+
+        if ($orderNo !== null && in_array($templateKey, ['post_purchase_followup', 'report_reactivation'], true)) {
+            if ($this->hasLifecycleTemplateRowForOrder($templateKey, $orderNo, $attemptId, $dedupeStatuses ?? ['pending', 'sent', 'consumed'])) {
+                return ['ok' => true, 'queued' => false, 'reason' => 'existing_order_template'];
+            }
+        } elseif ($this->hasPendingLifecycleTemplateRow($emailHash, $templateKey)) {
             return ['ok' => true, 'queued' => false, 'reason' => 'pending_exists'];
         }
 
         $locale = $this->normalizeLocale((string) ($preferredLocale ?? ($subscriber->locale ?? '')));
+        if ($attemptId !== null && $preferredLocale === null) {
+            $locale = $this->resolveRequestedLocale($attemptId, null);
+        }
+
         $subject = $this->defaultSubjectForTemplate($templateKey, $locale);
         $emailEnc = $this->piiCipher->encrypt($email);
-        $keyVersion = $this->piiCipher->currentKeyVersion();
-        $lastContext = is_array($subscriber->last_context_json) ? $subscriber->last_context_json : [];
-        $attemptId = $this->trimOrNull((string) ($lastContext['attempt_id'] ?? ''));
-        $orderNo = $this->trimOrNull((string) ($lastContext['order_no'] ?? ''));
         $preferenceSnapshot = $this->preferenceSnapshotForSubscriber($subscriber);
         $lifecycleContext = $this->buildLifecyclePayloadContext($email, $orderNo, [
             'surface' => $surface,
@@ -464,9 +524,11 @@ class EmailOutboxService
             ? $lifecycleContext['attribution']
             : [];
 
-        $payload = [
+        $payload = array_replace([
             'attempt_id' => $attemptId,
             'order_no' => $orderNo,
+            'report_url' => $attemptId !== null ? $this->reportUrl($attemptId) : null,
+            'report_pdf_url' => $attemptId !== null ? $this->reportPdfUrl($attemptId) : null,
             'locale' => $locale,
             'template_key' => $templateKey,
             'to_email' => $email,
@@ -482,66 +544,20 @@ class EmailOutboxService
             'preferences_changed_at' => $subscriber->last_preferences_changed_at?->toIso8601String(),
             'unsubscribed_at' => $subscriber->unsubscribed_at?->toIso8601String(),
             'attribution' => $this->payloadAttribution($normalizedAttribution),
-        ];
+        ], $payloadOverrides);
         $payloadJson = $this->encodePayloadJson($this->sanitizePayloadForJson($payload));
         $payloadEnc = $this->encodePayloadEncrypted($payload);
-
-        $row = [
-            'id' => (string) Str::uuid(),
-            'user_id' => $subscriber->lifecycleOutboxUserId(),
-            'email' => $this->maskedLegacyEmail($emailHash),
-            'template' => $templateKey,
-            'payload_json' => $payloadJson,
-            'claim_token_hash' => hash('sha256', $templateKey.'|'.(string) $subscriber->getKey().'|'.Str::uuid()->toString()),
-            'claim_expires_at' => null,
-            'status' => 'pending',
-            'sent_at' => null,
-            'consumed_at' => null,
-            'created_at' => now(),
-            'updated_at' => now(),
-        ];
-
-        if (\App\Support\SchemaBaseline::hasColumn('email_outbox', 'attempt_id')) {
-            $row['attempt_id'] = $attemptId;
-        }
-        if (\App\Support\SchemaBaseline::hasColumn('email_outbox', 'email_hash')) {
-            $row['email_hash'] = $emailHash;
-        }
-        if (\App\Support\SchemaBaseline::hasColumn('email_outbox', 'email_enc')) {
-            $row['email_enc'] = $emailEnc;
-        }
-        if (\App\Support\SchemaBaseline::hasColumn('email_outbox', 'to_email_hash')) {
-            $row['to_email_hash'] = $emailHash;
-        }
-        if (\App\Support\SchemaBaseline::hasColumn('email_outbox', 'to_email_enc')) {
-            $row['to_email_enc'] = $emailEnc;
-        }
-        if (\App\Support\SchemaBaseline::hasColumn('email_outbox', 'payload_enc')) {
-            $row['payload_enc'] = $payloadEnc;
-        }
-        if (\App\Support\SchemaBaseline::hasColumn('email_outbox', 'payload_schema_version')) {
-            $row['payload_schema_version'] = 'v1';
-        }
-        if (\App\Support\SchemaBaseline::hasColumn('email_outbox', 'key_version')) {
-            $row['key_version'] = $keyVersion;
-        }
-        if (\App\Support\SchemaBaseline::hasColumn('email_outbox', 'locale')) {
-            $row['locale'] = $locale;
-        }
-        if (\App\Support\SchemaBaseline::hasColumn('email_outbox', 'template_key')) {
-            $row['template_key'] = $templateKey;
-        }
-        if (\App\Support\SchemaBaseline::hasColumn('email_outbox', 'to_email')) {
-            $row['to_email'] = $this->maskedLegacyEmail($emailHash);
-        }
-        if (\App\Support\SchemaBaseline::hasColumn('email_outbox', 'subject')) {
-            $row['subject'] = $subject;
-        }
-        if (\App\Support\SchemaBaseline::hasColumn('email_outbox', 'body_html')) {
-            $row['body_html'] = null;
-        }
-
-        DB::table('email_outbox')->insert($row);
+        DB::table('email_outbox')->insert($this->buildLifecycleOutboxRow(
+            $subscriber->lifecycleOutboxUserId(),
+            $templateKey,
+            $emailHash,
+            $emailEnc,
+            $attemptId,
+            $locale,
+            $subject,
+            $payloadJson,
+            $payloadEnc
+        ));
 
         return ['ok' => true, 'queued' => true];
     }
@@ -1328,6 +1344,8 @@ class EmailOutboxService
             'support_contact',
             'preferences_updated',
             'unsubscribe_confirmation',
+            'post_purchase_followup',
+            'report_reactivation',
         ];
         if (! in_array($templateKey, $supported, true)) {
             return '';
@@ -1677,6 +1695,75 @@ class EmailOutboxService
         ];
     }
 
+    private function buildLifecycleOutboxRow(
+        string $userId,
+        string $templateKey,
+        string $emailHash,
+        ?string $emailEnc,
+        ?string $attemptId,
+        string $locale,
+        string $subject,
+        string $payloadJson,
+        ?string $payloadEnc
+    ): array {
+        $row = [
+            'id' => (string) Str::uuid(),
+            'user_id' => $userId,
+            'email' => $this->maskedLegacyEmail($emailHash),
+            'template' => $templateKey,
+            'payload_json' => $payloadJson,
+            'claim_token_hash' => hash('sha256', $templateKey.'|'.$userId.'|'.Str::uuid()->toString()),
+            'claim_expires_at' => null,
+            'status' => 'pending',
+            'sent_at' => null,
+            'consumed_at' => null,
+            'created_at' => now(),
+            'updated_at' => now(),
+        ];
+
+        if (\App\Support\SchemaBaseline::hasColumn('email_outbox', 'attempt_id')) {
+            $row['attempt_id'] = $attemptId;
+        }
+        if (\App\Support\SchemaBaseline::hasColumn('email_outbox', 'email_hash')) {
+            $row['email_hash'] = $emailHash;
+        }
+        if (\App\Support\SchemaBaseline::hasColumn('email_outbox', 'email_enc')) {
+            $row['email_enc'] = $emailEnc;
+        }
+        if (\App\Support\SchemaBaseline::hasColumn('email_outbox', 'to_email_hash')) {
+            $row['to_email_hash'] = $emailHash;
+        }
+        if (\App\Support\SchemaBaseline::hasColumn('email_outbox', 'to_email_enc')) {
+            $row['to_email_enc'] = $emailEnc;
+        }
+        if (\App\Support\SchemaBaseline::hasColumn('email_outbox', 'payload_enc')) {
+            $row['payload_enc'] = $payloadEnc;
+        }
+        if (\App\Support\SchemaBaseline::hasColumn('email_outbox', 'payload_schema_version')) {
+            $row['payload_schema_version'] = 'v1';
+        }
+        if (\App\Support\SchemaBaseline::hasColumn('email_outbox', 'key_version')) {
+            $row['key_version'] = $this->piiCipher->currentKeyVersion();
+        }
+        if (\App\Support\SchemaBaseline::hasColumn('email_outbox', 'locale')) {
+            $row['locale'] = $locale;
+        }
+        if (\App\Support\SchemaBaseline::hasColumn('email_outbox', 'template_key')) {
+            $row['template_key'] = $templateKey;
+        }
+        if (\App\Support\SchemaBaseline::hasColumn('email_outbox', 'to_email')) {
+            $row['to_email'] = $this->maskedLegacyEmail($emailHash);
+        }
+        if (\App\Support\SchemaBaseline::hasColumn('email_outbox', 'subject')) {
+            $row['subject'] = $subject;
+        }
+        if (\App\Support\SchemaBaseline::hasColumn('email_outbox', 'body_html')) {
+            $row['body_html'] = null;
+        }
+
+        return $row;
+    }
+
     private function hasPendingLifecycleTemplateRow(string $emailHash, string $templateKey): bool
     {
         $query = DB::table('email_outbox')
@@ -1711,9 +1798,46 @@ class EmailOutboxService
         return $query->exists();
     }
 
+    /**
+     * @param  array<int,string>  $statuses
+     */
+    private function hasLifecycleTemplateRowForOrder(string $templateKey, string $orderNo, ?string $attemptId, array $statuses): bool
+    {
+        $query = DB::table('email_outbox')
+            ->whereIn('status', $statuses)
+            ->where(function ($builder) use ($templateKey): void {
+                if (\App\Support\SchemaBaseline::hasColumn('email_outbox', 'template_key')) {
+                    $builder->where('template_key', $templateKey);
+
+                    return;
+                }
+
+                $builder->where('template', $templateKey);
+            })
+            ->orderByDesc('updated_at');
+
+        if ($attemptId !== null && \App\Support\SchemaBaseline::hasColumn('email_outbox', 'attempt_id')) {
+            $query->where('attempt_id', $attemptId);
+        }
+
+        foreach ($query->get() as $row) {
+            $payload = $this->decodePayloadFromRow($row);
+            if ($this->trimOrNull((string) ($payload['order_no'] ?? '')) === $orderNo) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
     private function recordLifecycleSubscriberDelivery(string $templateKey, string $recipientEmail, \Illuminate\Support\Carbon $sentAt): void
     {
-        if (! in_array($templateKey, ['preferences_updated', 'unsubscribe_confirmation'], true)) {
+        if (! in_array($templateKey, [
+            'preferences_updated',
+            'unsubscribe_confirmation',
+            'post_purchase_followup',
+            'report_reactivation',
+        ], true)) {
             return;
         }
 
@@ -1725,7 +1849,11 @@ class EmailOutboxService
             return;
         }
 
-        $subscriber->recordLifecycleSend($templateKey, $sentAt);
+        $subscriber->recordLifecycleSend(
+            $templateKey,
+            $sentAt,
+            EmailLifecycleRolloutService::nextEligibleAtForTemplate($templateKey, $sentAt)
+        );
         $subscriber->save();
     }
 
@@ -1848,6 +1976,12 @@ class EmailOutboxService
         }
         if ($templateKey === 'unsubscribe_confirmation') {
             return $lang === 'zh' ? '你已退订邮件' : 'You have been unsubscribed from emails';
+        }
+        if ($templateKey === 'post_purchase_followup') {
+            return $lang === 'zh' ? '你的报告已准备好查看' : 'Your report is ready to view';
+        }
+        if ($templateKey === 'report_reactivation') {
+            return $lang === 'zh' ? '回来继续查看你的报告' : 'Come back to your report';
         }
 
         return $lang === 'zh' ? 'FermatMind 通知' : 'FermatMind notification';

--- a/backend/app/Services/Email/EmailPreferenceService.php
+++ b/backend/app/Services/Email/EmailPreferenceService.php
@@ -101,6 +101,18 @@ class EmailPreferenceService
             ];
         }
 
+        if ($this->isRecoveryLifecycleFollowupTemplate($templateKey) && $subscriberStatus !== EmailSubscriber::STATUS_ACTIVE) {
+            return [
+                'allowed' => false,
+                'status' => 'skipped',
+                'reason' => 'subscriber_inactive',
+                'suppressed' => false,
+                'report_recovery' => $reportRecovery,
+                'marketing_updates' => $marketingUpdates,
+                'product_updates' => $productUpdates,
+            ];
+        }
+
         if ($this->requiresReportRecovery($templateKey) && ! $reportRecovery) {
             return [
                 'allowed' => false,
@@ -394,12 +406,22 @@ class EmailPreferenceService
 
     private function requiresReportRecovery(string $templateKey): bool
     {
-        return in_array(trim($templateKey), ['payment_success', 'report_claim'], true);
+        return in_array(trim($templateKey), [
+            'payment_success',
+            'report_claim',
+            'post_purchase_followup',
+            'report_reactivation',
+        ], true);
     }
 
     private function isLifecycleConfirmationTemplate(string $templateKey): bool
     {
         return in_array(trim($templateKey), ['preferences_updated', 'unsubscribe_confirmation'], true);
+    }
+
+    private function isRecoveryLifecycleFollowupTemplate(string $templateKey): bool
+    {
+        return in_array(trim($templateKey), ['post_purchase_followup', 'report_reactivation'], true);
     }
 
     private function normalizeEmail(string $email): ?string

--- a/backend/resources/views/emails/en/post_purchase_followup.blade.php
+++ b/backend/resources/views/emails/en/post_purchase_followup.blade.php
@@ -1,0 +1,34 @@
+<!doctype html>
+<html lang="en">
+<head>
+    <meta charset="utf-8">
+    <title>Your report is ready</title>
+</head>
+<body style="margin:0;padding:24px;background:#f6f4ef;font-family:Arial,sans-serif;color:#1f2933;line-height:1.6;">
+<div style="max-width:640px;margin:0 auto;background:#ffffff;border:1px solid #e5e7eb;padding:32px;">
+    <h1 style="margin:0 0 16px;font-size:28px;line-height:1.2;">Your report is ready</h1>
+    <p style="margin:0 0 16px;">Your purchase is complete and your report is available. We noticed it has not been opened or downloaded yet, so you can continue from the links below.</p>
+    @if(!empty($order_no))
+        <p style="margin:0 0 8px;"><strong>Order No:</strong> {{ $order_no }}</p>
+    @endif
+
+    @if(!empty($report_url))
+        <p style="margin:0 0 12px;"><a href="{{ $report_url }}">View report</a></p>
+    @endif
+    @if(!empty($report_pdf_url))
+        <p style="margin:0 0 12px;"><a href="{{ $report_pdf_url }}">Download PDF</a></p>
+    @endif
+    <p style="margin:0 0 24px;"><a href="{{ $order_lookup_url }}">Order lookup</a></p>
+
+    <p style="margin:0 0 8px;">Need help? Contact <a href="mailto:{{ $support_email }}">{{ $support_email }}</a>.</p>
+    <p style="margin:0 0 8px;"><a href="{{ $email_preferences_url }}">Manage email preferences</a></p>
+    <p style="margin:0 0 24px;"><a href="{{ $email_unsubscribe_url }}">Unsubscribe from emails</a></p>
+
+    <p style="margin:0;font-size:12px;color:#52606d;">
+        <a href="{{ $privacy_url }}">Privacy</a> |
+        <a href="{{ $terms_url }}">Terms</a> |
+        <a href="{{ $refund_url }}">Refund</a>
+    </p>
+</div>
+</body>
+</html>

--- a/backend/resources/views/emails/en/report_reactivation.blade.php
+++ b/backend/resources/views/emails/en/report_reactivation.blade.php
@@ -1,0 +1,34 @@
+<!doctype html>
+<html lang="en">
+<head>
+    <meta charset="utf-8">
+    <title>Come back to your report</title>
+</head>
+<body style="margin:0;padding:24px;background:#f6f4ef;font-family:Arial,sans-serif;color:#1f2933;line-height:1.6;">
+<div style="max-width:640px;margin:0 auto;background:#ffffff;border:1px solid #e5e7eb;padding:32px;">
+    <h1 style="margin:0 0 16px;font-size:28px;line-height:1.2;">Come back to your report</h1>
+    <p style="margin:0 0 16px;">You viewed your report before, and you can come back to continue reading it from the links below.</p>
+    @if(!empty($order_no))
+        <p style="margin:0 0 8px;"><strong>Order No:</strong> {{ $order_no }}</p>
+    @endif
+
+    @if(!empty($report_url))
+        <p style="margin:0 0 12px;"><a href="{{ $report_url }}">Return to report</a></p>
+    @endif
+    @if(!empty($report_pdf_url))
+        <p style="margin:0 0 12px;"><a href="{{ $report_pdf_url }}">Download PDF</a></p>
+    @endif
+    <p style="margin:0 0 24px;"><a href="{{ $order_lookup_url }}">Order lookup</a></p>
+
+    <p style="margin:0 0 8px;">Need help? Contact <a href="mailto:{{ $support_email }}">{{ $support_email }}</a>.</p>
+    <p style="margin:0 0 8px;"><a href="{{ $email_preferences_url }}">Manage email preferences</a></p>
+    <p style="margin:0 0 24px;"><a href="{{ $email_unsubscribe_url }}">Unsubscribe from emails</a></p>
+
+    <p style="margin:0;font-size:12px;color:#52606d;">
+        <a href="{{ $privacy_url }}">Privacy</a> |
+        <a href="{{ $terms_url }}">Terms</a> |
+        <a href="{{ $refund_url }}">Refund</a>
+    </p>
+</div>
+</body>
+</html>

--- a/backend/resources/views/emails/zh/post_purchase_followup.blade.php
+++ b/backend/resources/views/emails/zh/post_purchase_followup.blade.php
@@ -1,0 +1,34 @@
+<!doctype html>
+<html lang="zh-CN">
+<head>
+    <meta charset="utf-8">
+    <title>你的报告已经准备好</title>
+</head>
+<body style="margin:0;padding:24px;background:#f6f4ef;font-family:Arial,sans-serif;color:#1f2933;line-height:1.7;">
+<div style="max-width:640px;margin:0 auto;background:#ffffff;border:1px solid #e5e7eb;padding:32px;">
+    <h1 style="margin:0 0 16px;font-size:28px;line-height:1.2;">你的报告已经准备好</h1>
+    <p style="margin:0 0 16px;">你的购买已经完成，报告也已可查看。我们注意到你还没有打开或下载报告，你可以通过下面的链接继续查看。</p>
+    @if(!empty($order_no))
+        <p style="margin:0 0 8px;"><strong>订单号：</strong>{{ $order_no }}</p>
+    @endif
+
+    @if(!empty($report_url))
+        <p style="margin:0 0 12px;"><a href="{{ $report_url }}">查看报告</a></p>
+    @endif
+    @if(!empty($report_pdf_url))
+        <p style="margin:0 0 12px;"><a href="{{ $report_pdf_url }}">下载 PDF</a></p>
+    @endif
+    <p style="margin:0 0 24px;"><a href="{{ $order_lookup_url }}">订单查询</a></p>
+
+    <p style="margin:0 0 8px;">如需帮助，请联系 <a href="mailto:{{ $support_email }}">{{ $support_email }}</a>。</p>
+    <p style="margin:0 0 8px;"><a href="{{ $email_preferences_url }}">管理邮件偏好</a></p>
+    <p style="margin:0 0 24px;"><a href="{{ $email_unsubscribe_url }}">退订邮件</a></p>
+
+    <p style="margin:0;font-size:12px;color:#52606d;">
+        <a href="{{ $privacy_url }}">隐私政策</a> |
+        <a href="{{ $terms_url }}">服务条款</a> |
+        <a href="{{ $refund_url }}">退款政策</a>
+    </p>
+</div>
+</body>
+</html>

--- a/backend/resources/views/emails/zh/report_reactivation.blade.php
+++ b/backend/resources/views/emails/zh/report_reactivation.blade.php
@@ -1,0 +1,34 @@
+<!doctype html>
+<html lang="zh-CN">
+<head>
+    <meta charset="utf-8">
+    <title>回来继续查看你的报告</title>
+</head>
+<body style="margin:0;padding:24px;background:#f6f4ef;font-family:Arial,sans-serif;color:#1f2933;line-height:1.7;">
+<div style="max-width:640px;margin:0 auto;background:#ffffff;border:1px solid #e5e7eb;padding:32px;">
+    <h1 style="margin:0 0 16px;font-size:28px;line-height:1.2;">回来继续查看你的报告</h1>
+    <p style="margin:0 0 16px;">你之前已经查看过报告，你可以通过下面的链接继续回来阅读。</p>
+    @if(!empty($order_no))
+        <p style="margin:0 0 8px;"><strong>订单号：</strong>{{ $order_no }}</p>
+    @endif
+
+    @if(!empty($report_url))
+        <p style="margin:0 0 12px;"><a href="{{ $report_url }}">继续查看报告</a></p>
+    @endif
+    @if(!empty($report_pdf_url))
+        <p style="margin:0 0 12px;"><a href="{{ $report_pdf_url }}">下载 PDF</a></p>
+    @endif
+    <p style="margin:0 0 24px;"><a href="{{ $order_lookup_url }}">订单查询</a></p>
+
+    <p style="margin:0 0 8px;">如需帮助，请联系 <a href="mailto:{{ $support_email }}">{{ $support_email }}</a>。</p>
+    <p style="margin:0 0 8px;"><a href="{{ $email_preferences_url }}">管理邮件偏好</a></p>
+    <p style="margin:0 0 24px;"><a href="{{ $email_unsubscribe_url }}">退订邮件</a></p>
+
+    <p style="margin:0;font-size:12px;color:#52606d;">
+        <a href="{{ $privacy_url }}">隐私政策</a> |
+        <a href="{{ $terms_url }}">服务条款</a> |
+        <a href="{{ $refund_url }}">退款政策</a>
+    </p>
+</div>
+</body>
+</html>

--- a/backend/tests/Feature/Email/EmailLifecycleExecutionPolicyTest.php
+++ b/backend/tests/Feature/Email/EmailLifecycleExecutionPolicyTest.php
@@ -35,11 +35,17 @@ final class EmailLifecycleExecutionPolicyTest extends TestCase
 
         $preferencesPolicy = $service->deliveryPolicyForEmail($email, 'preferences_updated');
         $unsubscribePolicy = $service->deliveryPolicyForEmail($email, 'unsubscribe_confirmation');
+        $postPurchasePolicy = $service->deliveryPolicyForEmail($email, 'post_purchase_followup');
+        $reportReactivationPolicy = $service->deliveryPolicyForEmail($email, 'report_reactivation');
 
         $this->assertFalse((bool) ($preferencesPolicy['allowed'] ?? true));
         $this->assertSame('suppressed', (string) ($preferencesPolicy['status'] ?? ''));
         $this->assertFalse((bool) ($unsubscribePolicy['allowed'] ?? true));
         $this->assertSame('suppressed', (string) ($unsubscribePolicy['status'] ?? ''));
+        $this->assertFalse((bool) ($postPurchasePolicy['allowed'] ?? true));
+        $this->assertSame('suppressed', (string) ($postPurchasePolicy['status'] ?? ''));
+        $this->assertFalse((bool) ($reportReactivationPolicy['allowed'] ?? true));
+        $this->assertSame('suppressed', (string) ($reportReactivationPolicy['status'] ?? ''));
     }
 
     public function test_preferences_updated_is_not_blocked_by_preference_toggles(): void
@@ -76,5 +82,49 @@ final class EmailLifecycleExecutionPolicyTest extends TestCase
 
         $this->assertTrue((bool) ($policy['allowed'] ?? false));
         $this->assertSame('allowed', (string) ($policy['status'] ?? ''));
+    }
+
+    public function test_recovery_lifecycle_followups_require_transactional_recovery_to_stay_enabled(): void
+    {
+        $email = 'recovery+disabled@example.com';
+        app(EmailCaptureService::class)->ensureSubscriber($email, ['surface' => 'checkout']);
+
+        $service = app(EmailPreferenceService::class);
+        $token = $service->issueTokenForEmail($email);
+        $result = $service->updateByToken($token, [
+            'marketing_updates' => true,
+            'report_recovery' => false,
+            'product_updates' => true,
+        ]);
+        $this->assertTrue((bool) ($result['ok'] ?? false));
+
+        $postPurchasePolicy = $service->deliveryPolicyForEmail($email, 'post_purchase_followup');
+        $reportReactivationPolicy = $service->deliveryPolicyForEmail($email, 'report_reactivation');
+
+        $this->assertFalse((bool) ($postPurchasePolicy['allowed'] ?? true));
+        $this->assertSame('report_recovery_disabled', (string) ($postPurchasePolicy['reason'] ?? ''));
+        $this->assertFalse((bool) ($reportReactivationPolicy['allowed'] ?? true));
+        $this->assertSame('report_recovery_disabled', (string) ($reportReactivationPolicy['reason'] ?? ''));
+    }
+
+    public function test_recovery_lifecycle_followups_require_active_subscriber_status(): void
+    {
+        $email = 'recovery+inactive@example.com';
+        $subscriber = app(EmailCaptureService::class)->ensureSubscriber($email, ['surface' => 'checkout']);
+        $subscriber->forceFill([
+            'status' => 'unsubscribed',
+            'unsubscribed_at' => now(),
+            'marketing_consent' => true,
+            'transactional_recovery_enabled' => true,
+        ])->save();
+
+        $service = app(EmailPreferenceService::class);
+        $postPurchasePolicy = $service->deliveryPolicyForEmail($email, 'post_purchase_followup');
+        $reportReactivationPolicy = $service->deliveryPolicyForEmail($email, 'report_reactivation');
+
+        $this->assertFalse((bool) ($postPurchasePolicy['allowed'] ?? true));
+        $this->assertSame('subscriber_inactive', (string) ($postPurchasePolicy['reason'] ?? ''));
+        $this->assertFalse((bool) ($reportReactivationPolicy['allowed'] ?? true));
+        $this->assertSame('subscriber_inactive', (string) ($reportReactivationPolicy['reason'] ?? ''));
     }
 }

--- a/backend/tests/Feature/Email/EmailLifecycleRolloutCommandTest.php
+++ b/backend/tests/Feature/Email/EmailLifecycleRolloutCommandTest.php
@@ -6,10 +6,15 @@ namespace Tests\Feature\Email;
 
 use App\Models\EmailSubscriber;
 use App\Services\Email\EmailCaptureService;
+use App\Services\Email\EmailLifecycleRolloutService;
+use App\Services\Email\EmailOutboxService;
 use App\Services\Email\EmailPreferenceService;
 use App\Support\PiiCipher;
+use Carbon\CarbonInterface;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Support\Str;
 use Tests\TestCase;
 
 final class EmailLifecycleRolloutCommandTest extends TestCase
@@ -29,6 +34,8 @@ final class EmailLifecycleRolloutCommandTest extends TestCase
             ->expectsOutput('Enqueued: 0')
             ->expectsOutput('preferences_updated => candidates 1, enqueued 0')
             ->expectsOutput('unsubscribe_confirmation => candidates 0, enqueued 0')
+            ->expectsOutput('post_purchase_followup => candidates 0, enqueued 0')
+            ->expectsOutput('report_reactivation => candidates 0, enqueued 0')
             ->expectsOutput('Dry run: no outbox rows were enqueued.')
             ->assertExitCode(0);
 
@@ -48,6 +55,8 @@ final class EmailLifecycleRolloutCommandTest extends TestCase
             ->expectsOutput('Enqueued: 1')
             ->expectsOutput('preferences_updated => candidates 1, enqueued 1')
             ->expectsOutput('unsubscribe_confirmation => candidates 0, enqueued 0')
+            ->expectsOutput('post_purchase_followup => candidates 0, enqueued 0')
+            ->expectsOutput('report_reactivation => candidates 0, enqueued 0')
             ->assertExitCode(0);
 
         $row = DB::table('email_outbox')->where('template', 'preferences_updated')->first();
@@ -65,6 +74,8 @@ final class EmailLifecycleRolloutCommandTest extends TestCase
             ->expectsOutput('Enqueued: 0')
             ->expectsOutput('preferences_updated => candidates 0, enqueued 0')
             ->expectsOutput('unsubscribe_confirmation => candidates 0, enqueued 0')
+            ->expectsOutput('post_purchase_followup => candidates 0, enqueued 0')
+            ->expectsOutput('report_reactivation => candidates 0, enqueued 0')
             ->assertExitCode(0);
 
         $this->assertSame(1, DB::table('email_outbox')->where('template', 'unsubscribe_confirmation')->count());
@@ -88,9 +99,176 @@ final class EmailLifecycleRolloutCommandTest extends TestCase
             ->expectsOutput('Enqueued: 0')
             ->expectsOutput('preferences_updated => candidates 0, enqueued 0')
             ->expectsOutput('unsubscribe_confirmation => candidates 0, enqueued 0')
+            ->expectsOutput('post_purchase_followup => candidates 0, enqueued 0')
+            ->expectsOutput('report_reactivation => candidates 0, enqueued 0')
             ->assertExitCode(0);
 
         $this->assertSame(0, DB::table('email_outbox')->count());
+    }
+
+    public function test_dry_run_only_counts_eligible_post_purchase_followup_candidates(): void
+    {
+        $eligibleEmail = 'post-purchase+eligible@example.com';
+        $eligibleSubscriber = $this->createSubscriber($eligibleEmail);
+        $eligibleAttempt = $this->createAttempt('en', now()->subDays(3));
+        $eligibleOrder = 'ord_post_purchase_eligible';
+        $this->createOrder($eligibleOrder, $eligibleAttempt, $eligibleEmail, 'fulfilled', now()->subDays(3), now()->subDays(2));
+        $this->markPaymentSuccessSent($eligibleEmail, $eligibleAttempt, $eligibleOrder);
+
+        $recentEmail = 'post-purchase+recent@example.com';
+        $this->createSubscriber($recentEmail);
+        $recentAttempt = $this->createAttempt('en', now()->subHours(18));
+        $recentOrder = 'ord_post_purchase_recent';
+        $this->createOrder($recentOrder, $recentAttempt, $recentEmail, 'fulfilled', now()->subHours(18), now()->subHours(12));
+        $this->markPaymentSuccessSent($recentEmail, $recentAttempt, $recentOrder);
+
+        $before = DB::table('email_outbox')->count();
+        $summary = app(EmailLifecycleRolloutService::class)->rollout(true);
+        $this->assertSame(1, (int) data_get($summary, 'templates.post_purchase_followup.candidates', 0));
+        $this->assertSame(0, (int) data_get($summary, 'templates.post_purchase_followup.enqueued', 0));
+
+        $this->artisan('email:lifecycle-rollout --dry-run')->assertExitCode(0);
+
+        $this->assertSame($before, DB::table('email_outbox')->count());
+        $this->assertSame(0, DB::table('email_outbox')->where('template', 'post_purchase_followup')->count());
+        $eligibleSubscriber->refresh();
+        $this->assertNull($eligibleSubscriber->last_lifecycle_email_sent_at);
+    }
+
+    public function test_command_enqueues_post_purchase_followup_once_per_order(): void
+    {
+        $email = 'post-purchase+enqueue@example.com';
+        $this->createSubscriber($email);
+        $attemptId = $this->createAttempt('en', now()->subDays(3));
+        $orderNo = 'ord_post_purchase_enqueue';
+        $this->createOrder($orderNo, $attemptId, $email, 'fulfilled', now()->subDays(3), now()->subDays(2));
+        $this->markPaymentSuccessSent($email, $attemptId, $orderNo);
+
+        $this->artisan('email:lifecycle-rollout')
+            ->expectsOutput('Candidates: 1')
+            ->expectsOutput('Enqueued: 1')
+            ->expectsOutput('preferences_updated => candidates 0, enqueued 0')
+            ->expectsOutput('unsubscribe_confirmation => candidates 0, enqueued 0')
+            ->expectsOutput('post_purchase_followup => candidates 1, enqueued 1')
+            ->expectsOutput('report_reactivation => candidates 0, enqueued 0')
+            ->assertExitCode(0);
+
+        $row = DB::table('email_outbox')->where('template', 'post_purchase_followup')->first();
+        $this->assertNotNull($row);
+        $this->assertSame('pending', (string) ($row->status ?? ''));
+
+        $this->artisan('email:lifecycle-rollout')
+            ->expectsOutput('Candidates: 0')
+            ->expectsOutput('Enqueued: 0')
+            ->expectsOutput('preferences_updated => candidates 0, enqueued 0')
+            ->expectsOutput('unsubscribe_confirmation => candidates 0, enqueued 0')
+            ->expectsOutput('post_purchase_followup => candidates 0, enqueued 0')
+            ->expectsOutput('report_reactivation => candidates 0, enqueued 0')
+            ->assertExitCode(0);
+
+        $this->assertSame(1, DB::table('email_outbox')->where('template', 'post_purchase_followup')->count());
+    }
+
+    public function test_command_respects_post_purchase_followup_cooldown(): void
+    {
+        $subscriber = $this->createSubscriber('post-purchase+cooldown@example.com');
+        $attemptId = $this->createAttempt('en', now()->subDays(4));
+        $orderNo = 'ord_post_purchase_cooldown';
+        $this->createOrder($orderNo, $attemptId, 'post-purchase+cooldown@example.com', 'fulfilled', now()->subDays(4), now()->subDays(3));
+        $this->markPaymentSuccessSent('post-purchase+cooldown@example.com', $attemptId, $orderNo);
+        $this->markSubscriberInCooldown($subscriber, 'post_purchase_followup', now()->subDay());
+
+        $this->artisan('email:lifecycle-rollout')
+            ->expectsOutput('Candidates: 0')
+            ->expectsOutput('Enqueued: 0')
+            ->expectsOutput('preferences_updated => candidates 0, enqueued 0')
+            ->expectsOutput('unsubscribe_confirmation => candidates 0, enqueued 0')
+            ->expectsOutput('post_purchase_followup => candidates 0, enqueued 0')
+            ->expectsOutput('report_reactivation => candidates 0, enqueued 0')
+            ->assertExitCode(0);
+
+        $this->assertSame(0, DB::table('email_outbox')->where('template', 'post_purchase_followup')->count());
+    }
+
+    public function test_dry_run_only_counts_eligible_report_reactivation_candidates(): void
+    {
+        $eligibleEmail = 'report-reactivation+eligible@example.com';
+        $this->createSubscriber($eligibleEmail);
+        $eligibleAttempt = $this->createAttempt('en', now()->subDays(20));
+        $eligibleOrder = 'ord_report_reactivation_eligible';
+        $this->createOrder($eligibleOrder, $eligibleAttempt, $eligibleEmail, 'paid', now()->subDays(20), null);
+        $this->recordEvent($eligibleAttempt, 'report_view', now()->subDays(15));
+
+        $recentEmail = 'report-reactivation+recent@example.com';
+        $this->createSubscriber($recentEmail);
+        $recentAttempt = $this->createAttempt('en', now()->subDays(8));
+        $recentOrder = 'ord_report_reactivation_recent';
+        $this->createOrder($recentOrder, $recentAttempt, $recentEmail, 'paid', now()->subDays(8), null);
+        $this->recordEvent($recentAttempt, 'report_view', now()->subDays(7));
+
+        $downloadedEmail = 'report-reactivation+downloaded@example.com';
+        $this->createSubscriber($downloadedEmail);
+        $downloadedAttempt = $this->createAttempt('en', now()->subDays(20));
+        $downloadedOrder = 'ord_report_reactivation_downloaded';
+        $this->createOrder($downloadedOrder, $downloadedAttempt, $downloadedEmail, 'fulfilled', now()->subDays(20), now()->subDays(19));
+        $this->recordEvent($downloadedAttempt, 'report_view', now()->subDays(18));
+        $this->recordEvent($downloadedAttempt, 'report_pdf_view', now()->subDays(17));
+
+        $claimedEmail = 'report-reactivation+claimed@example.com';
+        $this->createSubscriber($claimedEmail);
+        $claimedAttempt = $this->createAttempt('en', now()->subDays(22));
+        $claimedOrder = 'ord_report_reactivation_claimed';
+        $this->createOrder($claimedOrder, $claimedAttempt, $claimedEmail, 'paid', now()->subDays(22), null);
+        $this->recordEvent($claimedAttempt, 'report_view', now()->subDays(16));
+        $this->queueReportClaim($claimedEmail, $claimedAttempt, $claimedOrder);
+
+        $before = DB::table('email_outbox')->count();
+
+        $this->artisan('email:lifecycle-rollout --dry-run')
+            ->expectsOutput('Enqueued: 0')
+            ->expectsOutput('preferences_updated => candidates 0, enqueued 0')
+            ->expectsOutput('unsubscribe_confirmation => candidates 0, enqueued 0')
+            ->expectsOutput('post_purchase_followup => candidates 0, enqueued 0')
+            ->expectsOutput('report_reactivation => candidates 1, enqueued 0')
+            ->expectsOutput('Dry run: no outbox rows were enqueued.')
+            ->assertExitCode(0);
+
+        $this->assertSame($before, DB::table('email_outbox')->count());
+        $this->assertSame(0, DB::table('email_outbox')->where('template', 'report_reactivation')->count());
+    }
+
+    public function test_command_enqueues_report_reactivation_once_per_order(): void
+    {
+        $email = 'report-reactivation+enqueue@example.com';
+        $this->createSubscriber($email);
+        $attemptId = $this->createAttempt('en', now()->subDays(20));
+        $orderNo = 'ord_report_reactivation_enqueue';
+        $this->createOrder($orderNo, $attemptId, $email, 'fulfilled', now()->subDays(20), now()->subDays(18));
+        $this->recordEvent($attemptId, 'report_view', now()->subDays(15));
+
+        $this->artisan('email:lifecycle-rollout')
+            ->expectsOutput('Candidates: 1')
+            ->expectsOutput('Enqueued: 1')
+            ->expectsOutput('preferences_updated => candidates 0, enqueued 0')
+            ->expectsOutput('unsubscribe_confirmation => candidates 0, enqueued 0')
+            ->expectsOutput('post_purchase_followup => candidates 0, enqueued 0')
+            ->expectsOutput('report_reactivation => candidates 1, enqueued 1')
+            ->assertExitCode(0);
+
+        $row = DB::table('email_outbox')->where('template', 'report_reactivation')->first();
+        $this->assertNotNull($row);
+        $this->assertSame('pending', (string) ($row->status ?? ''));
+
+        $this->artisan('email:lifecycle-rollout')
+            ->expectsOutput('Candidates: 0')
+            ->expectsOutput('Enqueued: 0')
+            ->expectsOutput('preferences_updated => candidates 0, enqueued 0')
+            ->expectsOutput('unsubscribe_confirmation => candidates 0, enqueued 0')
+            ->expectsOutput('post_purchase_followup => candidates 0, enqueued 0')
+            ->expectsOutput('report_reactivation => candidates 0, enqueued 0')
+            ->assertExitCode(0);
+
+        $this->assertSame(1, DB::table('email_outbox')->where('template', 'report_reactivation')->count());
     }
 
     private function updatePreferencesFor(string $email, array $preferences): EmailSubscriber
@@ -123,6 +301,191 @@ final class EmailLifecycleRolloutCommandTest extends TestCase
         $this->assertTrue((bool) ($result['ok'] ?? false));
 
         return $this->subscriberForEmail($email);
+    }
+
+    private function createSubscriber(string $email, string $locale = 'en'): EmailSubscriber
+    {
+        app(EmailCaptureService::class)->ensureSubscriber($email, [
+            'surface' => 'checkout',
+            'locale' => $locale,
+            'entrypoint' => 'checkout_success',
+        ]);
+
+        return $this->subscriberForEmail($email);
+    }
+
+    private function createAttempt(string $locale = 'en', ?CarbonInterface $submittedAt = null): string
+    {
+        $submittedAt = $submittedAt ?? now();
+        $attemptId = (string) Str::uuid();
+
+        DB::table('attempts')->insert([
+            'id' => $attemptId,
+            'ticket_code' => 'FMT-'.strtoupper(substr(str_replace('-', '', $attemptId), 0, 8)),
+            'org_id' => 0,
+            'anon_id' => 'anon_email_rollout',
+            'user_id' => null,
+            'scale_code' => 'MBTI',
+            'scale_version' => 'v0.3',
+            'region' => 'CN_MAINLAND',
+            'locale' => $locale,
+            'question_count' => 144,
+            'answers_summary_json' => json_encode(['seed' => true], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES),
+            'client_platform' => 'test',
+            'client_version' => '1.0.0',
+            'channel' => 'test',
+            'started_at' => $submittedAt->copy()->subHour(),
+            'submitted_at' => $submittedAt,
+            'pack_id' => (string) config('content_packs.default_pack_id'),
+            'dir_version' => (string) config('content_packs.default_dir_version'),
+            'content_package_version' => 'v0.3',
+            'scoring_spec_version' => '2026.01',
+            'created_at' => $submittedAt,
+            'updated_at' => $submittedAt,
+        ]);
+
+        return $attemptId;
+    }
+
+    private function createOrder(
+        string $orderNo,
+        string $attemptId,
+        string $email,
+        string $status,
+        ?CarbonInterface $paidAt,
+        ?CarbonInterface $fulfilledAt
+    ): void {
+        /** @var PiiCipher $pii */
+        $pii = app(PiiCipher::class);
+
+        DB::table('orders')->insert([
+            'id' => (string) Str::uuid(),
+            'order_no' => $orderNo,
+            'org_id' => 0,
+            'user_id' => null,
+            'anon_id' => 'anon_email_rollout',
+            'sku' => 'SKU_MBTI_FULL_REPORT',
+            'quantity' => 1,
+            'target_attempt_id' => $attemptId,
+            'amount_cents' => 299,
+            'currency' => 'USD',
+            'status' => $status,
+            'provider' => 'billing',
+            'external_trade_no' => null,
+            'contact_email_hash' => $pii->emailHash($email),
+            'meta_json' => json_encode([
+                'attribution' => [
+                    'share_id' => 'share_rollout_order',
+                    'compare_invite_id' => (string) Str::uuid(),
+                    'share_click_id' => 'clk_rollout_order',
+                    'entrypoint' => 'checkout_success',
+                    'referrer' => 'https://example.com/checkout',
+                    'landing_path' => '/en/checkout',
+                    'utm' => [
+                        'source' => 'checkout',
+                        'medium' => 'owned',
+                        'campaign' => 'lifecycle-rollout',
+                    ],
+                ],
+            ], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES),
+            'paid_at' => $paidAt,
+            'fulfilled_at' => $fulfilledAt,
+            'amount_total' => 299,
+            'amount_refunded' => 0,
+            'item_sku' => 'SKU_MBTI_FULL_REPORT',
+            'provider_order_id' => null,
+            'device_id' => null,
+            'request_id' => null,
+            'created_ip' => null,
+            'refunded_at' => null,
+            'created_at' => $paidAt ?? $fulfilledAt ?? now(),
+            'updated_at' => $paidAt ?? $fulfilledAt ?? now(),
+        ]);
+    }
+
+    private function markPaymentSuccessSent(string $email, string $attemptId, string $orderNo, int $times = 1): void
+    {
+        /** @var EmailOutboxService $outbox */
+        $outbox = app(EmailOutboxService::class);
+
+        for ($i = 0; $i < $times; $i++) {
+            $queued = $outbox->queuePaymentSuccess(
+                'payment_success_'.$i.'_'.$orderNo,
+                $email,
+                $attemptId,
+                $orderNo,
+                'MBTI Full Report'
+            );
+            $this->assertTrue((bool) ($queued['ok'] ?? false));
+
+            $rowId = DB::table('email_outbox')
+                ->where('template', 'payment_success')
+                ->where('attempt_id', $attemptId)
+                ->orderByDesc('created_at')
+                ->value('id');
+
+            DB::table('email_outbox')
+                ->where('id', $rowId)
+                ->update([
+                    'status' => 'sent',
+                    'sent_at' => now()->subDays(2),
+                    'updated_at' => now()->subDays(2),
+                ]);
+        }
+    }
+
+    private function queueReportClaim(string $email, string $attemptId, string $orderNo): void
+    {
+        $queued = app(EmailOutboxService::class)->queueReportClaim(
+            'report_claim_'.$orderNo,
+            $email,
+            $attemptId,
+            $orderNo
+        );
+        $this->assertTrue((bool) ($queued['ok'] ?? false));
+    }
+
+    private function recordEvent(string $attemptId, string $eventCode, CarbonInterface $occurredAt): void
+    {
+        DB::table('events')->insert([
+            'id' => (string) Str::uuid(),
+            'event_code' => $eventCode,
+            'event_name' => $eventCode,
+            'user_id' => null,
+            'anon_id' => 'anon_email_rollout',
+            'scale_code' => 'MBTI',
+            'scale_version' => 'v0.3',
+            'attempt_id' => $attemptId,
+            'channel' => 'test',
+            'region' => 'CN_MAINLAND',
+            'locale' => 'en',
+            'client_platform' => 'test',
+            'client_version' => '1.0.0',
+            'meta_json' => json_encode(['seed' => true], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES),
+            'occurred_at' => $occurredAt,
+            'created_at' => $occurredAt,
+            'updated_at' => $occurredAt,
+        ]);
+    }
+
+    private function markSubscriberInCooldown(EmailSubscriber $subscriber, string $templateKey, CarbonInterface $sentAt): void
+    {
+        $subscriber->forceFill([
+            'last_lifecycle_email_sent_at' => $sentAt,
+        ]);
+
+        if (Schema::hasColumn('email_subscribers', 'last_lifecycle_template_key')) {
+            $subscriber->setAttribute('last_lifecycle_template_key', $templateKey);
+        }
+
+        if (Schema::hasColumn('email_subscribers', 'next_lifecycle_eligible_at')) {
+            $subscriber->setAttribute(
+                'next_lifecycle_eligible_at',
+                EmailLifecycleRolloutService::nextEligibleAtForTemplate($templateKey, $sentAt)
+            );
+        }
+
+        $subscriber->save();
     }
 
     private function subscriberForEmail(string $email): EmailSubscriber

--- a/backend/tests/Feature/Email/EmailOutboxAttributionTest.php
+++ b/backend/tests/Feature/Email/EmailOutboxAttributionTest.php
@@ -228,6 +228,138 @@ final class EmailOutboxAttributionTest extends TestCase
         $this->assertStringContainsString('compare_invite_id=', $html);
     }
 
+    public function test_post_purchase_followup_outbox_payload_includes_attribution_contract(): void
+    {
+        config([
+            'fap.runtime.EMAIL_OUTBOX_SEND' => true,
+            'fap.runtime.FAP_BASE_URL' => 'https://app.example.test',
+            'app.url' => 'https://api.example.test',
+            'mail.default' => 'array',
+        ]);
+
+        $attemptId = $this->createAttempt();
+        $email = 'postpurchase@example.com';
+        $orderNo = 'ord_attr_post_purchase';
+
+        $subscriber = app(EmailCaptureService::class)->ensureSubscriber($email, [
+            'surface' => 'checkout',
+            'locale' => 'en',
+            'entrypoint' => 'checkout_success',
+        ]);
+        $this->createOrder($orderNo, $attemptId, $email, [
+            'share_id' => 'share_post_purchase',
+            'compare_invite_id' => (string) Str::uuid(),
+            'share_click_id' => 'clk_post_purchase',
+            'entrypoint' => 'checkout_success',
+            'referrer' => 'https://example.com/checkout',
+            'landing_path' => '/en/checkout',
+            'utm' => [
+                'source' => 'checkout',
+                'medium' => 'owned',
+                'campaign' => 'post-purchase-followup',
+                'content' => 'receipt',
+            ],
+        ]);
+
+        $queued = app(EmailOutboxService::class)->queuePostPurchaseFollowup($subscriber, $attemptId, $orderNo, 'en');
+        $this->assertTrue((bool) ($queued['ok'] ?? false));
+        $this->assertTrue((bool) ($queued['queued'] ?? false));
+
+        $row = DB::table('email_outbox')
+            ->where('attempt_id', $attemptId)
+            ->where('template', 'post_purchase_followup')
+            ->first();
+        $this->assertNotNull($row);
+
+        $payloadJson = json_decode((string) ($row->payload_json ?? '{}'), true);
+        $this->assertIsArray($payloadJson);
+        $this->assertSame('share_post_purchase', (string) data_get($payloadJson, 'attribution.share_id'));
+        $this->assertSame('checkout_success', (string) data_get($payloadJson, 'attribution.entrypoint'));
+        $this->assertSame('owned', (string) data_get($payloadJson, 'attribution.utm.medium'));
+        $this->assertArrayNotHasKey('email', $payloadJson);
+        $this->assertArrayNotHasKey('to_email', $payloadJson);
+
+        /** @var PiiCipher $pii */
+        $pii = app(PiiCipher::class);
+        $payloadEnc = json_decode((string) $pii->decrypt((string) ($row->payload_enc ?? '')), true);
+        $this->assertIsArray($payloadEnc);
+        $this->assertSame($email, (string) ($payloadEnc['to_email'] ?? ''));
+        $this->assertSame('receipt', (string) data_get($payloadEnc, 'attribution.utm.content'));
+
+        Mail::mailer('array')->getSymfonyTransport()->flush();
+        $this->artisan('email:outbox-send --limit=10')->assertExitCode(0);
+
+        $html = (string) Mail::mailer('array')->getSymfonyTransport()->messages()->first()->getOriginalMessage()->getHtmlBody();
+        $this->assertStringContainsString('share_id=share_post_purchase', $html);
+        $this->assertStringContainsString('utm_campaign=post-purchase-followup', $html);
+        $this->assertStringContainsString('compare_invite_id=', $html);
+    }
+
+    public function test_report_reactivation_outbox_payload_includes_attribution_contract(): void
+    {
+        config([
+            'fap.runtime.EMAIL_OUTBOX_SEND' => true,
+            'fap.runtime.FAP_BASE_URL' => 'https://app.example.test',
+            'app.url' => 'https://api.example.test',
+            'mail.default' => 'array',
+        ]);
+
+        $attemptId = $this->createAttempt();
+        $email = 'reactivation@example.com';
+        $orderNo = 'ord_attr_report_reactivation';
+
+        $subscriber = app(EmailCaptureService::class)->ensureSubscriber($email, [
+            'surface' => 'report',
+            'locale' => 'en',
+            'entrypoint' => 'report_view',
+        ]);
+        $this->createOrder($orderNo, $attemptId, $email, [
+            'share_id' => 'share_report_reactivation',
+            'compare_invite_id' => (string) Str::uuid(),
+            'share_click_id' => 'clk_report_reactivation',
+            'entrypoint' => 'report_view',
+            'referrer' => 'https://example.com/report',
+            'landing_path' => '/en/report',
+            'utm' => [
+                'source' => 'email',
+                'medium' => 'owned',
+                'campaign' => 'report-reactivation',
+                'content' => 'followup',
+            ],
+        ]);
+
+        $queued = app(EmailOutboxService::class)->queueReportReactivation($subscriber, $attemptId, $orderNo, 'en');
+        $this->assertTrue((bool) ($queued['ok'] ?? false));
+        $this->assertTrue((bool) ($queued['queued'] ?? false));
+
+        $row = DB::table('email_outbox')
+            ->where('attempt_id', $attemptId)
+            ->where('template', 'report_reactivation')
+            ->first();
+        $this->assertNotNull($row);
+
+        $payloadJson = json_decode((string) ($row->payload_json ?? '{}'), true);
+        $this->assertIsArray($payloadJson);
+        $this->assertSame('share_report_reactivation', (string) data_get($payloadJson, 'attribution.share_id'));
+        $this->assertSame('report_view', (string) data_get($payloadJson, 'attribution.entrypoint'));
+        $this->assertSame('owned', (string) data_get($payloadJson, 'attribution.utm.medium'));
+
+        /** @var PiiCipher $pii */
+        $pii = app(PiiCipher::class);
+        $payloadEnc = json_decode((string) $pii->decrypt((string) ($row->payload_enc ?? '')), true);
+        $this->assertIsArray($payloadEnc);
+        $this->assertSame($email, (string) ($payloadEnc['to_email'] ?? ''));
+        $this->assertSame('followup', (string) data_get($payloadEnc, 'attribution.utm.content'));
+
+        Mail::mailer('array')->getSymfonyTransport()->flush();
+        $this->artisan('email:outbox-send --limit=10')->assertExitCode(0);
+
+        $html = (string) Mail::mailer('array')->getSymfonyTransport()->messages()->first()->getOriginalMessage()->getHtmlBody();
+        $this->assertStringContainsString('share_id=share_report_reactivation', $html);
+        $this->assertStringContainsString('utm_campaign=report-reactivation', $html);
+        $this->assertStringContainsString('compare_invite_id=', $html);
+    }
+
     private function createAttempt(): string
     {
         $attemptId = (string) Str::uuid();
@@ -258,5 +390,46 @@ final class EmailOutboxAttributionTest extends TestCase
         ]);
 
         return $attemptId;
+    }
+
+    /**
+     * @param  array<string,mixed>  $attribution
+     */
+    private function createOrder(string $orderNo, string $attemptId, string $email, array $attribution): void
+    {
+        /** @var PiiCipher $pii */
+        $pii = app(PiiCipher::class);
+
+        DB::table('orders')->insert([
+            'id' => (string) Str::uuid(),
+            'order_no' => $orderNo,
+            'org_id' => 0,
+            'user_id' => null,
+            'anon_id' => 'anon_attr_order',
+            'sku' => 'SKU_MBTI_FULL_REPORT',
+            'quantity' => 1,
+            'target_attempt_id' => $attemptId,
+            'amount_cents' => 299,
+            'currency' => 'USD',
+            'status' => 'paid',
+            'provider' => 'billing',
+            'external_trade_no' => null,
+            'contact_email_hash' => $pii->emailHash($email),
+            'meta_json' => json_encode([
+                'attribution' => $attribution,
+            ], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES),
+            'paid_at' => now()->subDays(20),
+            'fulfilled_at' => now()->subDays(19),
+            'amount_total' => 299,
+            'amount_refunded' => 0,
+            'item_sku' => 'SKU_MBTI_FULL_REPORT',
+            'provider_order_id' => null,
+            'device_id' => null,
+            'request_id' => null,
+            'created_ip' => null,
+            'refunded_at' => null,
+            'created_at' => now()->subDays(20),
+            'updated_at' => now()->subDays(19),
+        ]);
     }
 }

--- a/backend/tests/Feature/Email/EmailOutboxSendCommandTest.php
+++ b/backend/tests/Feature/Email/EmailOutboxSendCommandTest.php
@@ -10,7 +10,9 @@ use App\Support\PiiCipher;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Mail;
+use Illuminate\Support\Facades\Schema;
 use Illuminate\Support\Str;
+use PHPUnit\Framework\Attributes\DataProvider;
 use Symfony\Component\Mailer\Envelope;
 use Symfony\Component\Mailer\Transport\TransportInterface;
 use Symfony\Component\Mime\RawMessage;
@@ -177,6 +179,75 @@ final class EmailOutboxSendCommandTest extends TestCase
         $this->assertStringContainsString('Manage email preferences', (string) $message->getHtmlBody());
     }
 
+    #[DataProvider('followupTemplateProvider')]
+    public function test_command_sends_followup_templates_and_updates_lifecycle_sent_markers(
+        string $templateKey,
+        string $expectedSubject,
+        string $expectedLinkLabel
+    ): void {
+        config([
+            'fap.runtime.EMAIL_OUTBOX_SEND' => true,
+            'fap.runtime.FAP_BASE_URL' => 'https://app.example.test',
+            'app.url' => 'https://api.example.test',
+            'mail.default' => 'array',
+        ]);
+
+        $this->flushArrayTransport();
+        $email = $templateKey.'@example.com';
+        $attemptId = $this->createAttempt();
+        $orderNo = 'ord_'.$templateKey.'_'.Str::lower(Str::random(8));
+        $subscriber = app(EmailCaptureService::class)->ensureSubscriber($email, [
+            'surface' => 'checkout',
+            'locale' => 'en',
+            'entrypoint' => 'checkout_success',
+        ]);
+        $this->createLifecycleOrder($orderNo, $attemptId, $email);
+
+        $queued = $templateKey === 'post_purchase_followup'
+            ? app(EmailOutboxService::class)->queuePostPurchaseFollowup($subscriber, $attemptId, $orderNo, 'en')
+            : app(EmailOutboxService::class)->queueReportReactivation($subscriber, $attemptId, $orderNo, 'en');
+
+        $this->assertTrue((bool) ($queued['ok'] ?? false));
+        $this->assertTrue((bool) ($queued['queued'] ?? false));
+
+        $this->artisan('email:outbox-send --limit=10')
+            ->expectsOutput('Mailer array: sent 1, blocked 0, failed 0.')
+            ->assertExitCode(0);
+
+        $row = DB::table('email_outbox')
+            ->where('attempt_id', $attemptId)
+            ->where('template', $templateKey)
+            ->first();
+
+        $this->assertNotNull($row);
+        $this->assertSame('sent', (string) ($row->status ?? ''));
+        $this->assertNotNull($row->sent_at ?? null);
+
+        $subscriber->refresh();
+        $this->assertNotNull($subscriber->last_lifecycle_email_sent_at);
+        if (Schema::hasColumn('email_subscribers', 'last_lifecycle_template_key')) {
+            $this->assertSame($templateKey, (string) $subscriber->getAttribute('last_lifecycle_template_key'));
+        }
+        if (Schema::hasColumn('email_subscribers', 'next_lifecycle_eligible_at')) {
+            $this->assertNotNull($subscriber->getAttribute('next_lifecycle_eligible_at'));
+        }
+
+        $message = Mail::mailer('array')->getSymfonyTransport()->messages()->first()->getOriginalMessage();
+        $this->assertSame($expectedSubject, (string) $message->getSubject());
+        $this->assertStringContainsString($expectedLinkLabel, (string) $message->getHtmlBody());
+    }
+
+    /**
+     * @return array<string,array{0:string,1:string,2:string}>
+     */
+    public static function followupTemplateProvider(): array
+    {
+        return [
+            'post_purchase_followup' => ['post_purchase_followup', 'Your report is ready to view', 'View report'],
+            'report_reactivation' => ['report_reactivation', 'Come back to your report', 'Return to report'],
+        ];
+    }
+
     private function createAttempt(string $locale = 'en'): string
     {
         $attemptId = (string) Str::uuid();
@@ -207,6 +278,56 @@ final class EmailOutboxSendCommandTest extends TestCase
         ]);
 
         return $attemptId;
+    }
+
+    private function createLifecycleOrder(string $orderNo, string $attemptId, string $email): void
+    {
+        /** @var PiiCipher $pii */
+        $pii = app(PiiCipher::class);
+
+        DB::table('orders')->insert([
+            'id' => (string) Str::uuid(),
+            'order_no' => $orderNo,
+            'org_id' => 0,
+            'user_id' => null,
+            'anon_id' => 'anon_followup_send',
+            'sku' => 'SKU_MBTI_FULL_REPORT',
+            'quantity' => 1,
+            'target_attempt_id' => $attemptId,
+            'amount_cents' => 299,
+            'currency' => 'USD',
+            'status' => 'fulfilled',
+            'provider' => 'billing',
+            'external_trade_no' => null,
+            'contact_email_hash' => $pii->emailHash($email),
+            'meta_json' => json_encode([
+                'attribution' => [
+                    'share_id' => 'share_followup_send',
+                    'compare_invite_id' => (string) Str::uuid(),
+                    'share_click_id' => 'clk_followup_send',
+                    'entrypoint' => 'checkout_success',
+                    'referrer' => 'https://example.com/checkout',
+                    'landing_path' => '/en/checkout',
+                    'utm' => [
+                        'source' => 'checkout',
+                        'medium' => 'owned',
+                        'campaign' => 'followup-send',
+                    ],
+                ],
+            ], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES),
+            'paid_at' => now()->subDays(20),
+            'fulfilled_at' => now()->subDays(19),
+            'amount_total' => 299,
+            'amount_refunded' => 0,
+            'item_sku' => 'SKU_MBTI_FULL_REPORT',
+            'provider_order_id' => null,
+            'device_id' => null,
+            'request_id' => null,
+            'created_ip' => null,
+            'refunded_at' => null,
+            'created_at' => now()->subDays(20),
+            'updated_at' => now()->subDays(19),
+        ]);
     }
 
     private function flushArrayTransport(): void

--- a/backend/tests/Feature/Email/PostPurchaseFollowupTemplateDeliveryTest.php
+++ b/backend/tests/Feature/Email/PostPurchaseFollowupTemplateDeliveryTest.php
@@ -1,0 +1,181 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Email;
+
+use App\Services\Email\EmailCaptureService;
+use App\Services\Email\EmailOutboxService;
+use App\Support\PiiCipher;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Mail;
+use Illuminate\Support\Str;
+use PHPUnit\Framework\Attributes\DataProvider;
+use Tests\TestCase;
+
+final class PostPurchaseFollowupTemplateDeliveryTest extends TestCase
+{
+    use RefreshDatabase;
+
+    #[DataProvider('localeProvider')]
+    public function test_post_purchase_followup_renders_supported_locales(string $locale, string $expectedTitle, string $expectedReportLabel): void
+    {
+        config([
+            'fap.runtime.EMAIL_OUTBOX_SEND' => true,
+            'fap.runtime.FAP_BASE_URL' => 'https://app.example.test',
+            'app.url' => 'https://api.example.test',
+            'mail.default' => 'array',
+        ]);
+
+        $this->flushArrayTransport();
+
+        $email = 'post-purchase+'.md5($locale).'@example.com';
+        $attemptId = $this->createAttempt($locale);
+        $orderNo = 'ord_post_purchase_'.Str::lower(Str::random(8));
+        $subscriber = app(EmailCaptureService::class)->ensureSubscriber($email, [
+            'surface' => 'checkout',
+            'locale' => $locale,
+            'entrypoint' => 'checkout_success',
+        ]);
+        $this->createOrder($orderNo, $attemptId, $email);
+
+        $queued = app(EmailOutboxService::class)->queuePostPurchaseFollowup($subscriber, $attemptId, $orderNo, $locale);
+        $this->assertTrue((bool) ($queued['ok'] ?? false));
+        $this->assertTrue((bool) ($queued['queued'] ?? false));
+
+        $row = DB::table('email_outbox')->where('template', 'post_purchase_followup')->first();
+        $this->assertNotNull($row);
+
+        $payloadJson = json_decode((string) ($row->payload_json ?? '{}'), true);
+        $this->assertIsArray($payloadJson);
+        $this->assertSame('share_post_purchase', (string) data_get($payloadJson, 'attribution.share_id'));
+        $this->assertSame('organic', (string) data_get($payloadJson, 'attribution.utm.medium'));
+        $this->assertArrayNotHasKey('email', $payloadJson);
+        $this->assertArrayNotHasKey('to_email', $payloadJson);
+        $this->assertArrayNotHasKey('claim_token', $payloadJson);
+        $this->assertArrayNotHasKey('claim_url', $payloadJson);
+
+        /** @var PiiCipher $pii */
+        $pii = app(PiiCipher::class);
+        $payloadEnc = json_decode((string) $pii->decrypt((string) ($row->payload_enc ?? '')), true);
+        $this->assertIsArray($payloadEnc);
+        $this->assertSame($email, (string) ($payloadEnc['to_email'] ?? ''));
+        $this->assertSame('share_post_purchase', (string) data_get($payloadEnc, 'attribution.share_id'));
+        $this->assertArrayNotHasKey('claim_token', $payloadEnc);
+        $this->assertArrayNotHasKey('claim_url', $payloadEnc);
+
+        $this->artisan('email:outbox-send --limit=10')
+            ->expectsOutput('Mailer array: sent 1, blocked 0, failed 0.')
+            ->assertExitCode(0);
+
+        $html = (string) Mail::mailer('array')->getSymfonyTransport()->messages()->first()->getOriginalMessage()->getHtmlBody();
+        $this->assertStringContainsString($expectedTitle, $html);
+        $this->assertStringContainsString($expectedReportLabel, $html);
+        $this->assertStringContainsString("https://api.example.test/api/v0.3/attempts/{$attemptId}/report", $html);
+        $this->assertStringContainsString("https://api.example.test/api/v0.3/attempts/{$attemptId}/report.pdf", $html);
+        $this->assertStringContainsString('https://app.example.test/orders/lookup?', $html);
+        $this->assertStringContainsString('https://app.example.test/email/preferences?token=', $html);
+        $this->assertStringContainsString('https://app.example.test/email/unsubscribe?token=', $html);
+        $this->assertStringContainsString('ord_post_purchase_', $html);
+    }
+
+    /**
+     * @return array<string,array{0:string,1:string,2:string}>
+     */
+    public static function localeProvider(): array
+    {
+        return [
+            'en' => ['en', 'Your report is ready', 'View report'],
+            'zh-CN' => ['zh-CN', '你的报告已经准备好', '查看报告'],
+        ];
+    }
+
+    private function createAttempt(string $locale): string
+    {
+        $attemptId = (string) Str::uuid();
+
+        DB::table('attempts')->insert([
+            'id' => $attemptId,
+            'ticket_code' => 'FMT-'.strtoupper(substr(str_replace('-', '', $attemptId), 0, 8)),
+            'org_id' => 0,
+            'anon_id' => 'anon_post_purchase_template',
+            'user_id' => null,
+            'scale_code' => 'MBTI',
+            'scale_version' => 'v0.3',
+            'region' => 'CN_MAINLAND',
+            'locale' => $locale,
+            'question_count' => 144,
+            'answers_summary_json' => json_encode(['seed' => true], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES),
+            'client_platform' => 'test',
+            'client_version' => '1.0.0',
+            'channel' => 'test',
+            'started_at' => now()->subDays(2),
+            'submitted_at' => now()->subDays(2),
+            'pack_id' => (string) config('content_packs.default_pack_id'),
+            'dir_version' => (string) config('content_packs.default_dir_version'),
+            'content_package_version' => 'v0.3',
+            'scoring_spec_version' => '2026.01',
+            'created_at' => now()->subDays(2),
+            'updated_at' => now()->subDays(2),
+        ]);
+
+        return $attemptId;
+    }
+
+    private function createOrder(string $orderNo, string $attemptId, string $email): void
+    {
+        /** @var PiiCipher $pii */
+        $pii = app(PiiCipher::class);
+
+        DB::table('orders')->insert([
+            'id' => (string) Str::uuid(),
+            'order_no' => $orderNo,
+            'org_id' => 0,
+            'user_id' => null,
+            'anon_id' => 'anon_post_purchase_template',
+            'sku' => 'SKU_MBTI_FULL_REPORT',
+            'quantity' => 1,
+            'target_attempt_id' => $attemptId,
+            'amount_cents' => 299,
+            'currency' => 'USD',
+            'status' => 'fulfilled',
+            'provider' => 'billing',
+            'external_trade_no' => null,
+            'contact_email_hash' => $pii->emailHash($email),
+            'meta_json' => json_encode([
+                'attribution' => [
+                    'share_id' => 'share_post_purchase',
+                    'compare_invite_id' => (string) Str::uuid(),
+                    'share_click_id' => 'clk_post_purchase',
+                    'entrypoint' => 'checkout_success',
+                    'referrer' => 'https://example.com/checkout/success',
+                    'landing_path' => '/en/checkout/success',
+                    'utm' => [
+                        'source' => 'checkout',
+                        'medium' => 'organic',
+                        'campaign' => 'post-purchase-followup',
+                        'content' => 'receipt',
+                    ],
+                ],
+            ], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES),
+            'paid_at' => now()->subDays(2),
+            'fulfilled_at' => now()->subDays(2)->addHour(),
+            'amount_total' => 299,
+            'amount_refunded' => 0,
+            'item_sku' => 'SKU_MBTI_FULL_REPORT',
+            'provider_order_id' => null,
+            'device_id' => null,
+            'request_id' => null,
+            'created_ip' => null,
+            'refunded_at' => null,
+            'created_at' => now()->subDays(2),
+            'updated_at' => now()->subDays(2),
+        ]);
+    }
+
+    private function flushArrayTransport(): void
+    {
+        Mail::mailer('array')->getSymfonyTransport()->flush();
+    }
+}

--- a/backend/tests/Feature/Email/ReportReactivationTemplateDeliveryTest.php
+++ b/backend/tests/Feature/Email/ReportReactivationTemplateDeliveryTest.php
@@ -1,0 +1,181 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Email;
+
+use App\Services\Email\EmailCaptureService;
+use App\Services\Email\EmailOutboxService;
+use App\Support\PiiCipher;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Mail;
+use Illuminate\Support\Str;
+use PHPUnit\Framework\Attributes\DataProvider;
+use Tests\TestCase;
+
+final class ReportReactivationTemplateDeliveryTest extends TestCase
+{
+    use RefreshDatabase;
+
+    #[DataProvider('localeProvider')]
+    public function test_report_reactivation_renders_supported_locales(string $locale, string $expectedTitle, string $expectedReportLabel): void
+    {
+        config([
+            'fap.runtime.EMAIL_OUTBOX_SEND' => true,
+            'fap.runtime.FAP_BASE_URL' => 'https://app.example.test',
+            'app.url' => 'https://api.example.test',
+            'mail.default' => 'array',
+        ]);
+
+        $this->flushArrayTransport();
+
+        $email = 'report-reactivation+'.md5($locale).'@example.com';
+        $attemptId = $this->createAttempt($locale);
+        $orderNo = 'ord_report_reactivation_'.Str::lower(Str::random(8));
+        $subscriber = app(EmailCaptureService::class)->ensureSubscriber($email, [
+            'surface' => 'report',
+            'locale' => $locale,
+            'entrypoint' => 'report_view',
+        ]);
+        $this->createOrder($orderNo, $attemptId, $email);
+
+        $queued = app(EmailOutboxService::class)->queueReportReactivation($subscriber, $attemptId, $orderNo, $locale);
+        $this->assertTrue((bool) ($queued['ok'] ?? false));
+        $this->assertTrue((bool) ($queued['queued'] ?? false));
+
+        $row = DB::table('email_outbox')->where('template', 'report_reactivation')->first();
+        $this->assertNotNull($row);
+
+        $payloadJson = json_decode((string) ($row->payload_json ?? '{}'), true);
+        $this->assertIsArray($payloadJson);
+        $this->assertSame('share_report_reactivation', (string) data_get($payloadJson, 'attribution.share_id'));
+        $this->assertSame('owned', (string) data_get($payloadJson, 'attribution.utm.medium'));
+        $this->assertArrayNotHasKey('email', $payloadJson);
+        $this->assertArrayNotHasKey('to_email', $payloadJson);
+        $this->assertArrayNotHasKey('claim_token', $payloadJson);
+        $this->assertArrayNotHasKey('claim_url', $payloadJson);
+
+        /** @var PiiCipher $pii */
+        $pii = app(PiiCipher::class);
+        $payloadEnc = json_decode((string) $pii->decrypt((string) ($row->payload_enc ?? '')), true);
+        $this->assertIsArray($payloadEnc);
+        $this->assertSame($email, (string) ($payloadEnc['to_email'] ?? ''));
+        $this->assertSame('share_report_reactivation', (string) data_get($payloadEnc, 'attribution.share_id'));
+        $this->assertArrayNotHasKey('claim_token', $payloadEnc);
+        $this->assertArrayNotHasKey('claim_url', $payloadEnc);
+
+        $this->artisan('email:outbox-send --limit=10')
+            ->expectsOutput('Mailer array: sent 1, blocked 0, failed 0.')
+            ->assertExitCode(0);
+
+        $html = (string) Mail::mailer('array')->getSymfonyTransport()->messages()->first()->getOriginalMessage()->getHtmlBody();
+        $this->assertStringContainsString($expectedTitle, $html);
+        $this->assertStringContainsString($expectedReportLabel, $html);
+        $this->assertStringContainsString("https://api.example.test/api/v0.3/attempts/{$attemptId}/report", $html);
+        $this->assertStringContainsString("https://api.example.test/api/v0.3/attempts/{$attemptId}/report.pdf", $html);
+        $this->assertStringContainsString('https://app.example.test/orders/lookup?', $html);
+        $this->assertStringContainsString('https://app.example.test/email/preferences?token=', $html);
+        $this->assertStringContainsString('https://app.example.test/email/unsubscribe?token=', $html);
+        $this->assertStringContainsString('ord_report_reactivation_', $html);
+    }
+
+    /**
+     * @return array<string,array{0:string,1:string,2:string}>
+     */
+    public static function localeProvider(): array
+    {
+        return [
+            'en' => ['en', 'Come back to your report', 'Return to report'],
+            'zh-CN' => ['zh-CN', '回来继续查看你的报告', '继续查看报告'],
+        ];
+    }
+
+    private function createAttempt(string $locale): string
+    {
+        $attemptId = (string) Str::uuid();
+
+        DB::table('attempts')->insert([
+            'id' => $attemptId,
+            'ticket_code' => 'FMT-'.strtoupper(substr(str_replace('-', '', $attemptId), 0, 8)),
+            'org_id' => 0,
+            'anon_id' => 'anon_report_reactivation_template',
+            'user_id' => null,
+            'scale_code' => 'MBTI',
+            'scale_version' => 'v0.3',
+            'region' => 'CN_MAINLAND',
+            'locale' => $locale,
+            'question_count' => 144,
+            'answers_summary_json' => json_encode(['seed' => true], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES),
+            'client_platform' => 'test',
+            'client_version' => '1.0.0',
+            'channel' => 'test',
+            'started_at' => now()->subDays(20),
+            'submitted_at' => now()->subDays(20),
+            'pack_id' => (string) config('content_packs.default_pack_id'),
+            'dir_version' => (string) config('content_packs.default_dir_version'),
+            'content_package_version' => 'v0.3',
+            'scoring_spec_version' => '2026.01',
+            'created_at' => now()->subDays(20),
+            'updated_at' => now()->subDays(20),
+        ]);
+
+        return $attemptId;
+    }
+
+    private function createOrder(string $orderNo, string $attemptId, string $email): void
+    {
+        /** @var PiiCipher $pii */
+        $pii = app(PiiCipher::class);
+
+        DB::table('orders')->insert([
+            'id' => (string) Str::uuid(),
+            'order_no' => $orderNo,
+            'org_id' => 0,
+            'user_id' => null,
+            'anon_id' => 'anon_report_reactivation_template',
+            'sku' => 'SKU_MBTI_FULL_REPORT',
+            'quantity' => 1,
+            'target_attempt_id' => $attemptId,
+            'amount_cents' => 299,
+            'currency' => 'USD',
+            'status' => 'paid',
+            'provider' => 'billing',
+            'external_trade_no' => null,
+            'contact_email_hash' => $pii->emailHash($email),
+            'meta_json' => json_encode([
+                'attribution' => [
+                    'share_id' => 'share_report_reactivation',
+                    'compare_invite_id' => (string) Str::uuid(),
+                    'share_click_id' => 'clk_report_reactivation',
+                    'entrypoint' => 'report_view',
+                    'referrer' => 'https://example.com/report',
+                    'landing_path' => '/en/report',
+                    'utm' => [
+                        'source' => 'email',
+                        'medium' => 'owned',
+                        'campaign' => 'report-reactivation',
+                        'content' => 'reactivation',
+                    ],
+                ],
+            ], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES),
+            'paid_at' => now()->subDays(20),
+            'fulfilled_at' => null,
+            'amount_total' => 299,
+            'amount_refunded' => 0,
+            'item_sku' => 'SKU_MBTI_FULL_REPORT',
+            'provider_order_id' => null,
+            'device_id' => null,
+            'request_id' => null,
+            'created_ip' => null,
+            'refunded_at' => null,
+            'created_at' => now()->subDays(20),
+            'updated_at' => now()->subDays(20),
+        ]);
+    }
+
+    private function flushArrayTransport(): void
+    {
+        Mail::mailer('array')->getSymfonyTransport()->flush();
+    }
+}


### PR DESCRIPTION
## Summary

- add `post_purchase_followup` and `report_reactivation` to `email:lifecycle-rollout`
- centralize selector, cooldown, and dedupe rules in `EmailLifecycleRolloutService`
- add en/zh templates and queue/send support for both lifecycle follow-up emails
- extend lifecycle policy and sent-state tests without changing routes, controllers, OpenAPI, or frontend code

## Verification

- `php artisan list | rg "email:outbox-send|email:lifecycle-rollout"`
- `php artisan route:list | rg "orders/lookup|claim/report|email/preferences|email/unsubscribe|attempts/.*/report|orders/.*/resend"`
- `php artisan migrate`
- `php artisan test tests/Feature/Email/EmailLifecycleExecutionPolicyTest.php`
- `php artisan test tests/Feature/Email/EmailLifecycleRolloutCommandTest.php`
- `php artisan test tests/Feature/Email/PostPurchaseFollowupTemplateDeliveryTest.php`
- `php artisan test tests/Feature/Email/ReportReactivationTemplateDeliveryTest.php`
- `php artisan test tests/Feature/Email/EmailOutboxAttributionTest.php`
- `php artisan test tests/Feature/Email/EmailOutboxSendCommandTest.php`
- `php artisan test tests/Feature/Email/EmailSuppressionExecutionTest.php`
- `php artisan test tests/Feature/Email/EmailPreferencesExecutionTest.php`
- `php artisan test tests/Feature/Email/ReportClaimTemplateDeliveryTest.php`
- `php artisan test tests/Feature/Email/EmailOutboxNoPlaintextPayloadTest.php`
- `php artisan test tests/Feature/V0_3/EmailCaptureContractTest.php`
- `php artisan test tests/Feature/V0_3/EmailPreferencesContractTest.php`
- `php artisan test tests/Feature/V0_3/EmailUnsubscribeContractTest.php`
- `php artisan test tests/Feature/V0_3/ClaimReportEmailRequestTest.php`
- `php artisan test tests/Feature/V0_3/CommerceOrderResendTest.php`
- `php artisan test tests/Feature/V0_3/PaymentWebhookControllerTest.php`
- `php artisan test tests/Feature/Commerce/BigFiveUnlockDeliveryPipelineTest.php`
- `php artisan test tests/Feature/Report/ReportPdfCrossScaleDeliveryTest.php`
- `./vendor/bin/pint app/Console/Commands/FapEmailLifecycleRollout.php app/Services/Email/EmailLifecycleRolloutService.php app/Services/Email/EmailOutboxService.php app/Services/Email/EmailPreferenceService.php app/Models/EmailSubscriber.php resources/views/emails/en/post_purchase_followup.blade.php resources/views/emails/zh/post_purchase_followup.blade.php resources/views/emails/en/report_reactivation.blade.php resources/views/emails/zh/report_reactivation.blade.php tests/Feature/Email/EmailLifecycleExecutionPolicyTest.php tests/Feature/Email/EmailLifecycleRolloutCommandTest.php tests/Feature/Email/PostPurchaseFollowupTemplateDeliveryTest.php tests/Feature/Email/ReportReactivationTemplateDeliveryTest.php tests/Feature/Email/EmailOutboxAttributionTest.php tests/Feature/Email/EmailOutboxSendCommandTest.php`
- `php artisan email:lifecycle-rollout --dry-run`
- `bash scripts/ci_verify_mbti.sh`
- `pnpm exec vitest run tests/contracts/email-preferences.contract.test.tsx tests/contracts/order-lookup-recovery.contract.test.tsx tests/contracts/orders-client-delivery.contract.test.tsx tests/contracts/result-client-view-state.contract.test.tsx tests/contracts/mbti-checkout-wiring.contract.test.tsx tests/contracts/mbti-post-purchase-retention.contract.test.tsx`
- `pnpm exec playwright test tests/e2e/email-preferences.spec.ts tests/e2e/email-unsubscribe.spec.ts tests/e2e/help-center.spec.ts tests/e2e/order-lookup-recovery.spec.ts tests/e2e/mbti-post-purchase.spec.ts tests/e2e/mbti-share.spec.ts tests/e2e/mbti-compare-invite.spec.ts`

## Scope

- backend-only lifecycle follow-up rollout
- no routes/OpenAPI/controller/frontend changes
