### PR TITLE
feat(email): add welcome lifecycle rollout

### DIFF
--- a/backend/app/Console/Commands/FapEmailLifecycleRollout.php
+++ b/backend/app/Console/Commands/FapEmailLifecycleRollout.php
@@ -52,6 +52,11 @@ class FapEmailLifecycleRollout extends Command
             (int) data_get($result, 'templates.report_reactivation.candidates', 0),
             (int) data_get($result, 'templates.report_reactivation.enqueued', 0),
         ));
+        $this->line(sprintf(
+            'welcome => candidates %d, enqueued %d',
+            (int) data_get($result, 'templates.welcome.candidates', 0),
+            (int) data_get($result, 'templates.welcome.enqueued', 0),
+        ));
 
         if ((bool) ($result['dry_run'] ?? false)) {
             $this->comment('Dry run: no outbox rows were enqueued.');

--- a/backend/app/Services/Email/EmailLifecycleRolloutService.php
+++ b/backend/app/Services/Email/EmailLifecycleRolloutService.php
@@ -17,6 +17,10 @@ class EmailLifecycleRolloutService
 {
     public const CONFIRMATION_COOLDOWN_MINUTES = 10;
 
+    public const WELCOME_DELAY_MINUTES = 10;
+
+    public const WELCOME_COOLDOWN_DAYS = 7;
+
     public const POST_PURCHASE_FOLLOWUP_COOLDOWN_DAYS = 7;
 
     public const REPORT_REACTIVATION_COOLDOWN_DAYS = 14;
@@ -47,7 +51,8 @@ class EmailLifecycleRolloutService
      *         preferences_updated:array{candidates:int,enqueued:int},
      *         unsubscribe_confirmation:array{candidates:int,enqueued:int},
      *         post_purchase_followup:array{candidates:int,enqueued:int},
-     *         report_reactivation:array{candidates:int,enqueued:int}
+     *         report_reactivation:array{candidates:int,enqueued:int},
+     *         welcome:array{candidates:int,enqueued:int}
      *     }
      * }
      */
@@ -89,6 +94,14 @@ class EmailLifecycleRolloutService
             fn (EmailSubscriber $subscriber): array => $this->emailOutbox->queueUnsubscribeConfirmation($subscriber)
         );
 
+        $summary = $this->processSubscriberTemplate(
+            $summary,
+            'welcome',
+            $this->welcomeCandidates(),
+            $dryRun,
+            fn (EmailSubscriber $subscriber): array => $this->emailOutbox->queueWelcome($subscriber)
+        );
+
         $summary = $this->processOrderTemplate(
             $summary,
             'post_purchase_followup',
@@ -124,7 +137,8 @@ class EmailLifecycleRolloutService
      *     preferences_updated:array{candidates:int,enqueued:int},
      *     unsubscribe_confirmation:array{candidates:int,enqueued:int},
      *     post_purchase_followup:array{candidates:int,enqueued:int},
-     *     report_reactivation:array{candidates:int,enqueued:int}
+     *     report_reactivation:array{candidates:int,enqueued:int},
+     *     welcome:array{candidates:int,enqueued:int}
      * }
      */
     private function emptyTemplateSummary(): array
@@ -134,6 +148,7 @@ class EmailLifecycleRolloutService
             'unsubscribe_confirmation' => ['candidates' => 0, 'enqueued' => 0],
             'post_purchase_followup' => ['candidates' => 0, 'enqueued' => 0],
             'report_reactivation' => ['candidates' => 0, 'enqueued' => 0],
+            'welcome' => ['candidates' => 0, 'enqueued' => 0],
         ];
     }
 
@@ -267,6 +282,33 @@ class EmailLifecycleRolloutService
             ->orderBy('unsubscribed_at');
 
         return $this->excludeSuppressed($query)->get();
+    }
+
+    /**
+     * @return Collection<int,EmailSubscriber>
+     */
+    private function welcomeCandidates(): Collection
+    {
+        $threshold = $this->cooldownThresholdForTemplate('welcome');
+        $capturedBefore = $this->now()->copy()->subMinutes(self::WELCOME_DELAY_MINUTES);
+
+        $query = EmailSubscriber::query()
+            ->with('preference')
+            ->outsideLifecycleCooldown($threshold)
+            ->where('status', EmailSubscriber::STATUS_ACTIVE)
+            ->where('marketing_consent', true)
+            ->whereNotNull('first_captured_at')
+            ->where('first_captured_at', '<=', $capturedBefore)
+            ->orderBy('first_captured_at');
+
+        return $this->excludeSuppressed($query)
+            ->get()
+            ->reject(fn (EmailSubscriber $subscriber): bool => $this->hasTemplateForEmailHash(
+                (string) $subscriber->email_hash,
+                'welcome',
+                ['pending', 'sent', 'consumed']
+            ))
+            ->values();
     }
 
     /**
@@ -620,13 +662,21 @@ class EmailLifecycleRolloutService
 
     private function hasPendingTemplateForEmailHash(string $emailHash, string $templateKey): bool
     {
+        return $this->hasTemplateForEmailHash($emailHash, $templateKey, ['pending']);
+    }
+
+    /**
+     * @param  array<int,string>  $statuses
+     */
+    private function hasTemplateForEmailHash(string $emailHash, string $templateKey, array $statuses): bool
+    {
         $normalizedHash = strtolower(trim($emailHash));
-        if ($normalizedHash === '') {
+        if ($normalizedHash === '' || $statuses === []) {
             return false;
         }
 
         $query = DB::table('email_outbox')
-            ->where('status', 'pending')
+            ->whereIn('status', $statuses)
             ->where(function ($builder) use ($templateKey): void {
                 if (Schema::hasColumn('email_outbox', 'template_key')) {
                     $builder->where('template_key', $templateKey);
@@ -665,6 +715,7 @@ class EmailLifecycleRolloutService
     private static function cooldownIntervalForTemplate(string $templateKey): CarbonInterval
     {
         return match (trim($templateKey)) {
+            'welcome' => CarbonInterval::days(self::WELCOME_COOLDOWN_DAYS),
             'post_purchase_followup' => CarbonInterval::days(self::POST_PURCHASE_FOLLOWUP_COOLDOWN_DAYS),
             'report_reactivation' => CarbonInterval::days(self::REPORT_REACTIVATION_COOLDOWN_DAYS),
             default => CarbonInterval::minutes(self::CONFIRMATION_COOLDOWN_MINUTES),

--- a/backend/app/Services/Email/EmailOutboxService.php
+++ b/backend/app/Services/Email/EmailOutboxService.php
@@ -431,6 +431,29 @@ class EmailOutboxService
     /**
      * @return array{ok:bool,queued:bool,error?:string,reason?:string}
      */
+    public function queueWelcome(EmailSubscriber $subscriber, ?string $preferredLocale = null): array
+    {
+        return $this->queueSubscriberLifecycleEmail(
+            $subscriber,
+            'welcome',
+            'welcome',
+            null,
+            null,
+            $preferredLocale,
+            [
+                'attempt_id' => null,
+                'order_no' => null,
+                'report_url' => null,
+                'report_pdf_url' => null,
+            ],
+            ['pending', 'sent', 'consumed'],
+            false
+        );
+    }
+
+    /**
+     * @return array{ok:bool,queued:bool,error?:string,reason?:string}
+     */
     public function queuePostPurchaseFollowup(
         EmailSubscriber $subscriber,
         string $attemptId,
@@ -483,7 +506,8 @@ class EmailOutboxService
         ?string $orderNo = null,
         ?string $preferredLocale = null,
         array $payloadOverrides = [],
-        ?array $dedupeStatuses = null
+        ?array $dedupeStatuses = null,
+        bool $useLastContextFallback = true
     ): array {
         if (! \App\Support\SchemaBaseline::hasTable('email_outbox')) {
             return ['ok' => false, 'queued' => false, 'error' => 'TABLE_MISSING'];
@@ -495,7 +519,9 @@ class EmailOutboxService
             return ['ok' => false, 'queued' => false, 'error' => 'INVALID_RECIPIENT'];
         }
 
-        $lastContext = is_array($subscriber->last_context_json) ? $subscriber->last_context_json : [];
+        $lastContext = $useLastContextFallback && is_array($subscriber->last_context_json)
+            ? $subscriber->last_context_json
+            : [];
         $attemptId = $this->trimOrNull($attemptId) ?? $this->trimOrNull((string) ($lastContext['attempt_id'] ?? ''));
         $orderNo = $this->trimOrNull($orderNo) ?? $this->trimOrNull((string) ($lastContext['order_no'] ?? ''));
         $emailHash = $this->piiCipher->emailHash($email);
@@ -504,8 +530,8 @@ class EmailOutboxService
             if ($this->hasLifecycleTemplateRowForOrder($templateKey, $orderNo, $attemptId, $dedupeStatuses ?? ['pending', 'sent', 'consumed'])) {
                 return ['ok' => true, 'queued' => false, 'reason' => 'existing_order_template'];
             }
-        } elseif ($this->hasPendingLifecycleTemplateRow($emailHash, $templateKey)) {
-            return ['ok' => true, 'queued' => false, 'reason' => 'pending_exists'];
+        } elseif ($this->hasLifecycleTemplateRowForEmailHash($emailHash, $templateKey, $dedupeStatuses ?? ['pending'])) {
+            return ['ok' => true, 'queued' => false, 'reason' => 'existing_subscriber_template'];
         }
 
         $locale = $this->normalizeLocale((string) ($preferredLocale ?? ($subscriber->locale ?? '')));
@@ -708,7 +734,7 @@ class EmailOutboxService
             ];
         }
 
-        $guard = $this->emailPreferences->deliveryPolicyForEmail($recipientEmail, $templateKey);
+        $guard = $this->resolveDeliveryGuard($recipientEmail, $templateKey);
         $bodyHtml = $this->resolveBodyHtmlFromRow($row, $payload, $templateKey, $locale, $recipientEmail, $guard);
         $bodyText = $this->resolveBodyTextFromPayload($payload, $locale, $templateKey, $recipientEmail);
 
@@ -723,6 +749,65 @@ class EmailOutboxService
             'recipient_email' => $recipientEmail,
             'guard' => $guard,
         ];
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    private function resolveDeliveryGuard(string $recipientEmail, string $templateKey): array
+    {
+        $guard = $this->emailPreferences->deliveryPolicyForEmail($recipientEmail, $templateKey);
+
+        if ($templateKey !== 'welcome') {
+            return $guard;
+        }
+
+        $snapshot = $this->emailCaptures->subscriberLifecycleSnapshot($recipientEmail);
+        $subscriberStatus = (string) ($snapshot['subscriber_status'] ?? EmailSubscriber::STATUS_ACTIVE);
+        $marketingConsent = (bool) ($snapshot['marketing_consent'] ?? false);
+        $suppressed = $subscriberStatus === EmailSubscriber::STATUS_SUPPRESSED || (bool) ($guard['suppressed'] ?? false);
+
+        if ($suppressed) {
+            return array_replace($guard, [
+                'allowed' => false,
+                'status' => 'suppressed',
+                'reason' => 'email_suppressed',
+                'suppressed' => true,
+                'marketing_updates' => $marketingConsent,
+                'product_updates' => $marketingConsent,
+            ]);
+        }
+
+        if ($subscriberStatus !== EmailSubscriber::STATUS_ACTIVE) {
+            return array_replace($guard, [
+                'allowed' => false,
+                'status' => 'skipped',
+                'reason' => 'subscriber_inactive',
+                'suppressed' => false,
+                'marketing_updates' => $marketingConsent,
+                'product_updates' => $marketingConsent,
+            ]);
+        }
+
+        if (! $marketingConsent) {
+            return array_replace($guard, [
+                'allowed' => false,
+                'status' => 'skipped',
+                'reason' => 'marketing_consent_disabled',
+                'suppressed' => false,
+                'marketing_updates' => false,
+                'product_updates' => false,
+            ]);
+        }
+
+        return array_replace($guard, [
+            'allowed' => true,
+            'status' => 'allowed',
+            'reason' => null,
+            'suppressed' => false,
+            'marketing_updates' => true,
+            'product_updates' => true,
+        ]);
     }
 
     private function sendMessage(string $mailer, string $recipientEmail, string $subject, string $bodyHtml, string $bodyText): void
@@ -1346,6 +1431,7 @@ class EmailOutboxService
             'unsubscribe_confirmation',
             'post_purchase_followup',
             'report_reactivation',
+            'welcome',
         ];
         if (! in_array($templateKey, $supported, true)) {
             return '';
@@ -1445,10 +1531,14 @@ class EmailOutboxService
         ];
         $preferenceToken = $this->emailPreferences->issueTokenForEmail($recipientEmail, $tokenContext);
         $query = $this->deepLinkQuery($normalizedAttribution, $locale, $orderNo, $attemptId);
+        $helpPath = strtolower((string) explode('-', $this->normalizeLocale($locale))[0]) === 'zh'
+            ? '/zh/help'
+            : '/en/help';
 
         $orderLookupUrl = $this->frontendUrl($frontendBaseUrl, '/orders/lookup', $query);
         $emailPreferencesUrl = $this->frontendUrl($frontendBaseUrl, '/email/preferences', ['token' => $preferenceToken] + $query);
         $emailUnsubscribeUrl = $this->frontendUrl($frontendBaseUrl, '/email/unsubscribe', ['token' => $preferenceToken] + $query);
+        $helpUrl = $this->frontendUrl($frontendBaseUrl, $helpPath, $query);
         $preferences = is_array($payload['preferences'] ?? null) ? $payload['preferences'] : [];
 
         $data = [
@@ -1470,6 +1560,8 @@ class EmailOutboxService
             'email_preferences_url' => $emailPreferencesUrl,
             'emailUnsubscribeUrl' => $emailUnsubscribeUrl,
             'email_unsubscribe_url' => $emailUnsubscribeUrl,
+            'helpUrl' => $helpUrl,
+            'help_url' => $helpUrl,
             'preferences' => [
                 'marketing_updates' => (bool) ($preferences['marketing_updates'] ?? ($payload['marketing_updates'] ?? false)),
                 'report_recovery' => (bool) ($preferences['report_recovery'] ?? ($payload['report_recovery'] ?? true)),
@@ -1766,8 +1858,20 @@ class EmailOutboxService
 
     private function hasPendingLifecycleTemplateRow(string $emailHash, string $templateKey): bool
     {
+        return $this->hasLifecycleTemplateRowForEmailHash($emailHash, $templateKey, ['pending']);
+    }
+
+    /**
+     * @param  array<int,string>  $statuses
+     */
+    private function hasLifecycleTemplateRowForEmailHash(string $emailHash, string $templateKey, array $statuses): bool
+    {
+        if ($statuses === []) {
+            return false;
+        }
+
         $query = DB::table('email_outbox')
-            ->where('status', 'pending')
+            ->whereIn('status', $statuses)
             ->where(function ($builder) use ($templateKey): void {
                 if (\App\Support\SchemaBaseline::hasColumn('email_outbox', 'template_key')) {
                     $builder->where('template_key', $templateKey);
@@ -1837,6 +1941,7 @@ class EmailOutboxService
             'unsubscribe_confirmation',
             'post_purchase_followup',
             'report_reactivation',
+            'welcome',
         ], true)) {
             return;
         }
@@ -1982,6 +2087,9 @@ class EmailOutboxService
         }
         if ($templateKey === 'report_reactivation') {
             return $lang === 'zh' ? '回来继续查看你的报告' : 'Come back to your report';
+        }
+        if ($templateKey === 'welcome') {
+            return $lang === 'zh' ? '欢迎来到 FermatMind' : 'Welcome to FermatMind';
         }
 
         return $lang === 'zh' ? 'FermatMind 通知' : 'FermatMind notification';

--- a/backend/resources/views/emails/en/welcome.blade.php
+++ b/backend/resources/views/emails/en/welcome.blade.php
@@ -1,0 +1,27 @@
+<!doctype html>
+<html lang="en">
+<head>
+    <meta charset="utf-8">
+    <title>Welcome to FermatMind</title>
+</head>
+<body style="margin:0;padding:24px;background:#f6f4ef;font-family:Arial,sans-serif;color:#1f2933;line-height:1.6;">
+<div style="max-width:640px;margin:0 auto;background:#ffffff;border:1px solid #e5e7eb;padding:32px;">
+    <h1 style="margin:0 0 16px;font-size:28px;line-height:1.2;">Welcome to FermatMind</h1>
+    <p style="margin:0 0 16px;">This is a one-time welcome email confirming that FermatMind can reach you here when needed.</p>
+    <p style="margin:0 0 16px;">You can manage your email preferences, stop receiving emails at any time, and use order lookup later if you need to recover a report.</p>
+
+    <p style="margin:0 0 12px;"><a href="{{ $email_preferences_url }}">Manage email preferences</a></p>
+    <p style="margin:0 0 12px;"><a href="{{ $email_unsubscribe_url }}">Unsubscribe from emails</a></p>
+    <p style="margin:0 0 12px;"><a href="{{ $order_lookup_url }}">Order lookup</a></p>
+    <p style="margin:0 0 24px;"><a href="{{ $help_url }}">View help center</a></p>
+
+    <p style="margin:0 0 8px;">Need help? Contact <a href="mailto:{{ $support_email }}">{{ $support_email }}</a>.</p>
+
+    <p style="margin:0;font-size:12px;color:#52606d;">
+        <a href="{{ $privacy_url }}">Privacy</a> |
+        <a href="{{ $terms_url }}">Terms</a> |
+        <a href="{{ $refund_url }}">Refund</a>
+    </p>
+</div>
+</body>
+</html>

--- a/backend/resources/views/emails/zh/welcome.blade.php
+++ b/backend/resources/views/emails/zh/welcome.blade.php
@@ -1,0 +1,27 @@
+<!doctype html>
+<html lang="zh-CN">
+<head>
+    <meta charset="utf-8">
+    <title>欢迎来到 FermatMind</title>
+</head>
+<body style="margin:0;padding:24px;background:#f6f4ef;font-family:Arial,sans-serif;color:#1f2933;line-height:1.7;">
+<div style="max-width:640px;margin:0 auto;background:#ffffff;border:1px solid #e5e7eb;padding:32px;">
+    <h1 style="margin:0 0 16px;font-size:28px;line-height:1.2;">欢迎来到 FermatMind</h1>
+    <p style="margin:0 0 16px;">这是一封一次性的欢迎邮件，用来确认 FermatMind 之后可以在需要时通过这个邮箱联系你。</p>
+    <p style="margin:0 0 16px;">你可以随时管理邮件偏好、停止接收邮件；如果以后需要恢复报告，也可以通过订单查询找回。</p>
+
+    <p style="margin:0 0 12px;"><a href="{{ $email_preferences_url }}">管理邮件偏好</a></p>
+    <p style="margin:0 0 12px;"><a href="{{ $email_unsubscribe_url }}">退订邮件</a></p>
+    <p style="margin:0 0 12px;"><a href="{{ $order_lookup_url }}">订单查询</a></p>
+    <p style="margin:0 0 24px;"><a href="{{ $help_url }}">查看帮助中心</a></p>
+
+    <p style="margin:0 0 8px;">需要帮助？请联系 <a href="mailto:{{ $support_email }}">{{ $support_email }}</a>。</p>
+
+    <p style="margin:0;font-size:12px;color:#52606d;">
+        <a href="{{ $privacy_url }}">隐私政策</a> |
+        <a href="{{ $terms_url }}">服务条款</a> |
+        <a href="{{ $refund_url }}">退款政策</a>
+    </p>
+</div>
+</body>
+</html>

--- a/backend/tests/Feature/Email/EmailLifecycleRolloutCommandTest.php
+++ b/backend/tests/Feature/Email/EmailLifecycleRolloutCommandTest.php
@@ -36,6 +36,7 @@ final class EmailLifecycleRolloutCommandTest extends TestCase
             ->expectsOutput('unsubscribe_confirmation => candidates 0, enqueued 0')
             ->expectsOutput('post_purchase_followup => candidates 0, enqueued 0')
             ->expectsOutput('report_reactivation => candidates 0, enqueued 0')
+            ->expectsOutput('welcome => candidates 0, enqueued 0')
             ->expectsOutput('Dry run: no outbox rows were enqueued.')
             ->assertExitCode(0);
 
@@ -57,6 +58,7 @@ final class EmailLifecycleRolloutCommandTest extends TestCase
             ->expectsOutput('unsubscribe_confirmation => candidates 0, enqueued 0')
             ->expectsOutput('post_purchase_followup => candidates 0, enqueued 0')
             ->expectsOutput('report_reactivation => candidates 0, enqueued 0')
+            ->expectsOutput('welcome => candidates 0, enqueued 0')
             ->assertExitCode(0);
 
         $row = DB::table('email_outbox')->where('template', 'preferences_updated')->first();
@@ -76,6 +78,7 @@ final class EmailLifecycleRolloutCommandTest extends TestCase
             ->expectsOutput('unsubscribe_confirmation => candidates 0, enqueued 0')
             ->expectsOutput('post_purchase_followup => candidates 0, enqueued 0')
             ->expectsOutput('report_reactivation => candidates 0, enqueued 0')
+            ->expectsOutput('welcome => candidates 0, enqueued 0')
             ->assertExitCode(0);
 
         $this->assertSame(1, DB::table('email_outbox')->where('template', 'unsubscribe_confirmation')->count());
@@ -101,9 +104,112 @@ final class EmailLifecycleRolloutCommandTest extends TestCase
             ->expectsOutput('unsubscribe_confirmation => candidates 0, enqueued 0')
             ->expectsOutput('post_purchase_followup => candidates 0, enqueued 0')
             ->expectsOutput('report_reactivation => candidates 0, enqueued 0')
+            ->expectsOutput('welcome => candidates 0, enqueued 0')
             ->assertExitCode(0);
 
         $this->assertSame(0, DB::table('email_outbox')->count());
+    }
+
+    public function test_dry_run_counts_only_eligible_welcome_candidates(): void
+    {
+        $this->createWelcomeSubscriber('welcome+eligible@example.com', true, now()->subMinutes(11));
+        $this->createWelcomeSubscriber('welcome+recent@example.com', true, now()->subMinutes(9));
+        $this->createWelcomeSubscriber('welcome+no-consent@example.com', false, now()->subMinutes(11));
+
+        $this->artisan('email:lifecycle-rollout --dry-run')
+            ->expectsOutput('Candidates: 1')
+            ->expectsOutput('Enqueued: 0')
+            ->expectsOutput('preferences_updated => candidates 0, enqueued 0')
+            ->expectsOutput('unsubscribe_confirmation => candidates 0, enqueued 0')
+            ->expectsOutput('post_purchase_followup => candidates 0, enqueued 0')
+            ->expectsOutput('report_reactivation => candidates 0, enqueued 0')
+            ->expectsOutput('welcome => candidates 1, enqueued 0')
+            ->expectsOutput('Dry run: no outbox rows were enqueued.')
+            ->assertExitCode(0);
+
+        $this->assertSame(0, DB::table('email_outbox')->count());
+    }
+
+    public function test_command_enqueues_welcome_for_eligible_subscriber(): void
+    {
+        $this->createWelcomeSubscriber('welcome+enqueue@example.com', true, now()->subMinutes(11));
+
+        $this->artisan('email:lifecycle-rollout')
+            ->expectsOutput('Candidates: 1')
+            ->expectsOutput('Enqueued: 1')
+            ->expectsOutput('preferences_updated => candidates 0, enqueued 0')
+            ->expectsOutput('unsubscribe_confirmation => candidates 0, enqueued 0')
+            ->expectsOutput('post_purchase_followup => candidates 0, enqueued 0')
+            ->expectsOutput('report_reactivation => candidates 0, enqueued 0')
+            ->expectsOutput('welcome => candidates 1, enqueued 1')
+            ->assertExitCode(0);
+
+        $row = DB::table('email_outbox')->where('template', 'welcome')->first();
+        $this->assertNotNull($row);
+        $this->assertSame('pending', (string) ($row->status ?? ''));
+    }
+
+    public function test_command_dedupes_welcome_once_ever_after_existing_sent_row(): void
+    {
+        $subscriber = $this->createWelcomeSubscriber('welcome+dedupe@example.com', true, now()->subMinutes(11));
+        $queued = app(EmailOutboxService::class)->queueWelcome($subscriber, 'en');
+        $this->assertTrue((bool) ($queued['ok'] ?? false));
+        $this->assertTrue((bool) ($queued['queued'] ?? false));
+
+        DB::table('email_outbox')
+            ->where('template', 'welcome')
+            ->update([
+                'status' => 'sent',
+                'sent_at' => now()->subDay(),
+                'updated_at' => now()->subDay(),
+            ]);
+
+        $this->artisan('email:lifecycle-rollout')
+            ->expectsOutput('Candidates: 0')
+            ->expectsOutput('Enqueued: 0')
+            ->expectsOutput('preferences_updated => candidates 0, enqueued 0')
+            ->expectsOutput('unsubscribe_confirmation => candidates 0, enqueued 0')
+            ->expectsOutput('post_purchase_followup => candidates 0, enqueued 0')
+            ->expectsOutput('report_reactivation => candidates 0, enqueued 0')
+            ->expectsOutput('welcome => candidates 0, enqueued 0')
+            ->assertExitCode(0);
+
+        $this->assertSame(1, DB::table('email_outbox')->where('template', 'welcome')->count());
+    }
+
+    public function test_command_requires_marketing_consent_for_welcome(): void
+    {
+        $this->createWelcomeSubscriber('welcome+marketing-disabled@example.com', false, now()->subMinutes(11));
+
+        $this->artisan('email:lifecycle-rollout')
+            ->expectsOutput('Candidates: 0')
+            ->expectsOutput('Enqueued: 0')
+            ->expectsOutput('preferences_updated => candidates 0, enqueued 0')
+            ->expectsOutput('unsubscribe_confirmation => candidates 0, enqueued 0')
+            ->expectsOutput('post_purchase_followup => candidates 0, enqueued 0')
+            ->expectsOutput('report_reactivation => candidates 0, enqueued 0')
+            ->expectsOutput('welcome => candidates 0, enqueued 0')
+            ->assertExitCode(0);
+
+        $this->assertSame(0, DB::table('email_outbox')->where('template', 'welcome')->count());
+    }
+
+    public function test_command_respects_welcome_cooldown(): void
+    {
+        $subscriber = $this->createWelcomeSubscriber('welcome+cooldown@example.com', true, now()->subMinutes(11));
+        $this->markSubscriberInCooldown($subscriber, 'welcome', now()->subDays(2));
+
+        $this->artisan('email:lifecycle-rollout')
+            ->expectsOutput('Candidates: 0')
+            ->expectsOutput('Enqueued: 0')
+            ->expectsOutput('preferences_updated => candidates 0, enqueued 0')
+            ->expectsOutput('unsubscribe_confirmation => candidates 0, enqueued 0')
+            ->expectsOutput('post_purchase_followup => candidates 0, enqueued 0')
+            ->expectsOutput('report_reactivation => candidates 0, enqueued 0')
+            ->expectsOutput('welcome => candidates 0, enqueued 0')
+            ->assertExitCode(0);
+
+        $this->assertSame(0, DB::table('email_outbox')->where('template', 'welcome')->count());
     }
 
     public function test_dry_run_only_counts_eligible_post_purchase_followup_candidates(): void
@@ -151,6 +257,7 @@ final class EmailLifecycleRolloutCommandTest extends TestCase
             ->expectsOutput('unsubscribe_confirmation => candidates 0, enqueued 0')
             ->expectsOutput('post_purchase_followup => candidates 1, enqueued 1')
             ->expectsOutput('report_reactivation => candidates 0, enqueued 0')
+            ->expectsOutput('welcome => candidates 0, enqueued 0')
             ->assertExitCode(0);
 
         $row = DB::table('email_outbox')->where('template', 'post_purchase_followup')->first();
@@ -164,6 +271,7 @@ final class EmailLifecycleRolloutCommandTest extends TestCase
             ->expectsOutput('unsubscribe_confirmation => candidates 0, enqueued 0')
             ->expectsOutput('post_purchase_followup => candidates 0, enqueued 0')
             ->expectsOutput('report_reactivation => candidates 0, enqueued 0')
+            ->expectsOutput('welcome => candidates 0, enqueued 0')
             ->assertExitCode(0);
 
         $this->assertSame(1, DB::table('email_outbox')->where('template', 'post_purchase_followup')->count());
@@ -185,6 +293,7 @@ final class EmailLifecycleRolloutCommandTest extends TestCase
             ->expectsOutput('unsubscribe_confirmation => candidates 0, enqueued 0')
             ->expectsOutput('post_purchase_followup => candidates 0, enqueued 0')
             ->expectsOutput('report_reactivation => candidates 0, enqueued 0')
+            ->expectsOutput('welcome => candidates 0, enqueued 0')
             ->assertExitCode(0);
 
         $this->assertSame(0, DB::table('email_outbox')->where('template', 'post_purchase_followup')->count());
@@ -230,6 +339,7 @@ final class EmailLifecycleRolloutCommandTest extends TestCase
             ->expectsOutput('unsubscribe_confirmation => candidates 0, enqueued 0')
             ->expectsOutput('post_purchase_followup => candidates 0, enqueued 0')
             ->expectsOutput('report_reactivation => candidates 1, enqueued 0')
+            ->expectsOutput('welcome => candidates 0, enqueued 0')
             ->expectsOutput('Dry run: no outbox rows were enqueued.')
             ->assertExitCode(0);
 
@@ -253,6 +363,7 @@ final class EmailLifecycleRolloutCommandTest extends TestCase
             ->expectsOutput('unsubscribe_confirmation => candidates 0, enqueued 0')
             ->expectsOutput('post_purchase_followup => candidates 0, enqueued 0')
             ->expectsOutput('report_reactivation => candidates 1, enqueued 1')
+            ->expectsOutput('welcome => candidates 0, enqueued 0')
             ->assertExitCode(0);
 
         $row = DB::table('email_outbox')->where('template', 'report_reactivation')->first();
@@ -266,6 +377,7 @@ final class EmailLifecycleRolloutCommandTest extends TestCase
             ->expectsOutput('unsubscribe_confirmation => candidates 0, enqueued 0')
             ->expectsOutput('post_purchase_followup => candidates 0, enqueued 0')
             ->expectsOutput('report_reactivation => candidates 0, enqueued 0')
+            ->expectsOutput('welcome => candidates 0, enqueued 0')
             ->assertExitCode(0);
 
         $this->assertSame(1, DB::table('email_outbox')->where('template', 'report_reactivation')->count());
@@ -312,6 +424,32 @@ final class EmailLifecycleRolloutCommandTest extends TestCase
         ]);
 
         return $this->subscriberForEmail($email);
+    }
+
+    private function createWelcomeSubscriber(string $email, bool $marketingConsent, CarbonInterface $capturedAt, string $locale = 'en'): EmailSubscriber
+    {
+        $subscriber = app(EmailCaptureService::class)->ensureSubscriber($email, [
+            'surface' => 'welcome',
+            'locale' => $locale,
+            'entrypoint' => 'welcome_capture',
+            'marketing_consent' => $marketingConsent,
+            'share_id' => 'share_welcome_rollout',
+            'share_click_id' => 'clk_welcome_rollout',
+            'referrer' => 'https://example.com/help',
+            'landing_path' => '/en/help',
+            'utm' => [
+                'source' => 'welcome',
+                'medium' => 'owned',
+                'campaign' => 'welcome-lifecycle',
+            ],
+        ]);
+
+        $subscriber->forceFill([
+            'first_captured_at' => $capturedAt,
+            'last_captured_at' => $capturedAt,
+        ])->save();
+
+        return $subscriber->fresh(['preference']);
     }
 
     private function createAttempt(string $locale = 'en', ?CarbonInterface $submittedAt = null): string

--- a/backend/tests/Feature/Email/EmailOutboxAttributionTest.php
+++ b/backend/tests/Feature/Email/EmailOutboxAttributionTest.php
@@ -360,6 +360,73 @@ final class EmailOutboxAttributionTest extends TestCase
         $this->assertStringContainsString('compare_invite_id=', $html);
     }
 
+    public function test_welcome_outbox_payload_includes_attribution_contract(): void
+    {
+        config([
+            'fap.runtime.EMAIL_OUTBOX_SEND' => true,
+            'fap.runtime.FAP_BASE_URL' => 'https://app.example.test',
+            'app.url' => 'https://api.example.test',
+            'mail.default' => 'array',
+        ]);
+
+        $email = 'welcome@example.com';
+
+        $subscriber = app(EmailCaptureService::class)->ensureSubscriber($email, [
+            'surface' => 'welcome',
+            'locale' => 'en',
+            'share_id' => 'share_welcome_attr',
+            'compare_invite_id' => (string) Str::uuid(),
+            'share_click_id' => 'clk_welcome_attr',
+            'entrypoint' => 'welcome_capture',
+            'referrer' => 'https://example.com/help',
+            'landing_path' => '/en/help',
+            'utm' => [
+                'source' => 'welcome',
+                'medium' => 'owned',
+                'campaign' => 'welcome-lifecycle',
+                'term' => 'consent',
+                'content' => 'hero',
+            ],
+            'marketing_consent' => true,
+        ]);
+        $subscriber->forceFill([
+            'first_captured_at' => now()->subMinutes(11),
+            'last_captured_at' => now()->subMinutes(11),
+        ])->save();
+
+        $queued = app(EmailOutboxService::class)->queueWelcome($subscriber, 'en');
+        $this->assertTrue((bool) ($queued['ok'] ?? false));
+        $this->assertTrue((bool) ($queued['queued'] ?? false));
+
+        $row = DB::table('email_outbox')
+            ->where('template', 'welcome')
+            ->first();
+        $this->assertNotNull($row);
+
+        $payloadJson = json_decode((string) ($row->payload_json ?? '{}'), true);
+        $this->assertIsArray($payloadJson);
+        $this->assertSame('share_welcome_attr', (string) data_get($payloadJson, 'attribution.share_id'));
+        $this->assertSame('clk_welcome_attr', (string) data_get($payloadJson, 'attribution.share_click_id'));
+        $this->assertSame('owned', (string) data_get($payloadJson, 'attribution.utm.medium'));
+        $this->assertArrayNotHasKey('email', $payloadJson);
+        $this->assertArrayNotHasKey('to_email', $payloadJson);
+
+        /** @var PiiCipher $pii */
+        $pii = app(PiiCipher::class);
+        $payloadEnc = json_decode((string) $pii->decrypt((string) ($row->payload_enc ?? '')), true);
+        $this->assertIsArray($payloadEnc);
+        $this->assertSame($email, (string) ($payloadEnc['to_email'] ?? ''));
+        $this->assertSame('hero', (string) data_get($payloadEnc, 'attribution.utm.content'));
+
+        Mail::mailer('array')->getSymfonyTransport()->flush();
+        $this->artisan('email:outbox-send --limit=10')->assertExitCode(0);
+
+        $html = (string) Mail::mailer('array')->getSymfonyTransport()->messages()->first()->getOriginalMessage()->getHtmlBody();
+        $this->assertStringContainsString('share_id=share_welcome_attr', $html);
+        $this->assertStringContainsString('utm_campaign=welcome-lifecycle', $html);
+        $this->assertStringContainsString('compare_invite_id=', $html);
+    }
+
     private function createAttempt(): string
     {
         $attemptId = (string) Str::uuid();

--- a/backend/tests/Feature/Email/EmailOutboxSendCommandTest.php
+++ b/backend/tests/Feature/Email/EmailOutboxSendCommandTest.php
@@ -179,6 +179,63 @@ final class EmailOutboxSendCommandTest extends TestCase
         $this->assertStringContainsString('Manage email preferences', (string) $message->getHtmlBody());
     }
 
+    public function test_command_sends_welcome_and_updates_lifecycle_sent_markers(): void
+    {
+        config([
+            'fap.runtime.EMAIL_OUTBOX_SEND' => true,
+            'fap.runtime.FAP_BASE_URL' => 'https://app.example.test',
+            'app.url' => 'https://api.example.test',
+            'mail.default' => 'array',
+        ]);
+
+        $this->flushArrayTransport();
+        $email = 'buyer+welcome-marker@example.com';
+        $subscriber = app(EmailCaptureService::class)->ensureSubscriber($email, [
+            'surface' => 'welcome',
+            'locale' => 'en',
+            'entrypoint' => 'welcome_capture',
+            'marketing_consent' => true,
+        ]);
+        $subscriber->forceFill([
+            'first_captured_at' => now()->subMinutes(11),
+            'last_captured_at' => now()->subMinutes(11),
+        ])->save();
+
+        $queued = app(EmailOutboxService::class)->queueWelcome($subscriber, 'en');
+        $this->assertTrue((bool) ($queued['ok'] ?? false));
+        $this->assertTrue((bool) ($queued['queued'] ?? false));
+
+        $this->artisan('email:outbox-send --limit=10')
+            ->expectsOutput('Mailer array: sent 1, blocked 0, failed 0.')
+            ->assertExitCode(0);
+
+        $row = DB::table('email_outbox')
+            ->where('template', 'welcome')
+            ->first();
+
+        $this->assertNotNull($row);
+        $this->assertSame('sent', (string) ($row->status ?? ''));
+        $this->assertNotNull($row->sent_at ?? null);
+
+        $subscriber->refresh();
+        $this->assertNotNull($subscriber->last_lifecycle_email_sent_at);
+        if (Schema::hasColumn('email_subscribers', 'last_lifecycle_template_key')) {
+            $this->assertSame('welcome', (string) $subscriber->getAttribute('last_lifecycle_template_key'));
+        }
+        if (Schema::hasColumn('email_subscribers', 'next_lifecycle_eligible_at')) {
+            $this->assertNotNull($subscriber->getAttribute('next_lifecycle_eligible_at'));
+            $this->assertTrue(
+                $subscriber->getAttribute('next_lifecycle_eligible_at')->greaterThan(
+                    $subscriber->last_lifecycle_email_sent_at->copy()->addDays(6)
+                )
+            );
+        }
+
+        $message = Mail::mailer('array')->getSymfonyTransport()->messages()->first()->getOriginalMessage();
+        $this->assertSame('Welcome to FermatMind', (string) $message->getSubject());
+        $this->assertStringContainsString('View help center', (string) $message->getHtmlBody());
+    }
+
     #[DataProvider('followupTemplateProvider')]
     public function test_command_sends_followup_templates_and_updates_lifecycle_sent_markers(
         string $templateKey,

--- a/backend/tests/Feature/Email/WelcomeTemplateDeliveryTest.php
+++ b/backend/tests/Feature/Email/WelcomeTemplateDeliveryTest.php
@@ -1,0 +1,119 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Email;
+
+use App\Services\Email\EmailCaptureService;
+use App\Services\Email\EmailOutboxService;
+use App\Support\PiiCipher;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Mail;
+use Illuminate\Support\Str;
+use PHPUnit\Framework\Attributes\DataProvider;
+use Tests\TestCase;
+
+final class WelcomeTemplateDeliveryTest extends TestCase
+{
+    use RefreshDatabase;
+
+    #[DataProvider('localeProvider')]
+    public function test_welcome_template_renders_supported_locales(
+        string $locale,
+        string $expectedTitle,
+        string $expectedPreferencesLabel,
+        string $expectedHelpLabel,
+        string $expectedHelpPath
+    ): void {
+        config([
+            'fap.runtime.EMAIL_OUTBOX_SEND' => true,
+            'fap.runtime.FAP_BASE_URL' => 'https://app.example.test',
+            'app.url' => 'https://api.example.test',
+            'mail.default' => 'array',
+        ]);
+
+        $this->flushArrayTransport();
+
+        $email = 'welcome+template+'.md5($locale).'@example.com';
+        $subscriber = app(EmailCaptureService::class)->ensureSubscriber($email, [
+            'surface' => 'welcome',
+            'locale' => $locale,
+            'share_id' => 'share_welcome_template',
+            'compare_invite_id' => (string) Str::uuid(),
+            'share_click_id' => 'clk_welcome_template',
+            'entrypoint' => 'welcome_capture',
+            'referrer' => 'https://example.com/help',
+            'landing_path' => '/en/help',
+            'utm' => [
+                'source' => 'welcome',
+                'medium' => 'owned',
+                'campaign' => 'welcome-lifecycle',
+                'content' => 'template',
+            ],
+            'marketing_consent' => true,
+        ]);
+        $subscriber->forceFill([
+            'first_captured_at' => now()->subMinutes(11),
+            'last_captured_at' => now()->subMinutes(11),
+        ])->save();
+
+        $queued = app(EmailOutboxService::class)->queueWelcome($subscriber, $locale);
+        $this->assertTrue((bool) ($queued['ok'] ?? false));
+        $this->assertTrue((bool) ($queued['queued'] ?? false));
+
+        $row = DB::table('email_outbox')->where('template', 'welcome')->first();
+        $this->assertNotNull($row);
+
+        $payloadJson = json_decode((string) ($row->payload_json ?? '{}'), true);
+        $this->assertIsArray($payloadJson);
+        $this->assertArrayNotHasKey('email', $payloadJson);
+        $this->assertArrayNotHasKey('to_email', $payloadJson);
+        $this->assertArrayNotHasKey('claim_token', $payloadJson);
+        $this->assertArrayNotHasKey('claim_url', $payloadJson);
+        $this->assertSame('share_welcome_template', (string) data_get($payloadJson, 'attribution.share_id'));
+        $this->assertSame('owned', (string) data_get($payloadJson, 'attribution.utm.medium'));
+
+        /** @var PiiCipher $pii */
+        $pii = app(PiiCipher::class);
+        $payloadEnc = json_decode((string) $pii->decrypt((string) ($row->payload_enc ?? '')), true);
+        $this->assertIsArray($payloadEnc);
+        $this->assertSame($email, (string) ($payloadEnc['to_email'] ?? ''));
+        $this->assertArrayNotHasKey('claim_token', $payloadEnc);
+        $this->assertArrayNotHasKey('claim_url', $payloadEnc);
+        $this->assertSame('template', (string) data_get($payloadEnc, 'attribution.utm.content'));
+
+        $this->artisan('email:outbox-send --limit=10')
+            ->expectsOutput('Mailer array: sent 1, blocked 0, failed 0.')
+            ->assertExitCode(0);
+
+        $html = (string) Mail::mailer('array')->getSymfonyTransport()->messages()->first()->getOriginalMessage()->getHtmlBody();
+        $this->assertStringContainsString($expectedTitle, $html);
+        $this->assertStringContainsString($expectedPreferencesLabel, $html);
+        $this->assertStringContainsString($expectedHelpLabel, $html);
+        $this->assertStringContainsString('https://app.example.test/email/preferences?token=', $html);
+        $this->assertStringContainsString('https://app.example.test/email/unsubscribe?token=', $html);
+        $this->assertStringContainsString('https://app.example.test/orders/lookup?', $html);
+        $this->assertStringContainsString('https://app.example.test/'.$expectedHelpPath.'?', $html);
+        $this->assertStringContainsString('share_id=share_welcome_template', $html);
+        $this->assertStringContainsString('utm_campaign=welcome-lifecycle', $html);
+        $this->assertStringNotContainsString('/api/v0.3/attempts/', $html);
+        $this->assertStringNotContainsString('report.pdf', $html);
+    }
+
+    /**
+     * @return array<string,array{0:string,1:string,2:string,3:string,4:string}>
+     */
+    public static function localeProvider(): array
+    {
+        return [
+            'en' => ['en', 'Welcome to FermatMind', 'Manage email preferences', 'View help center', 'en/help'],
+            'zh-CN' => ['zh-CN', '欢迎来到 FermatMind', '管理邮件偏好', '查看帮助中心', 'zh/help'],
+        ];
+    }
+
+    private function flushArrayTransport(): void
+    {
+        Mail::mailer('array')->getSymfonyTransport()->flush();
+    }
+}


### PR DESCRIPTION
## Summary

- add `welcome` to the existing `email:lifecycle-rollout` orchestration
- queue `welcome` through the shared lifecycle outbox path with once-ever dedupe, 10 minute delay, and 7 day cooldown sent-state
- roll out localized `welcome` templates for `en` and `zh`
- add and update backend tests for welcome rollout, delivery, attribution, and sent-state behavior

## Scope

- backend-only
- no public API, route, or OpenAPI changes
- no frontend code changes

## Tests

- `php -l app/Console/Commands/FapEmailLifecycleRollout.php`
- `php -l app/Services/Email/EmailLifecycleRolloutService.php`
- `php -l app/Services/Email/EmailOutboxService.php`
- `php -l tests/Feature/Email/WelcomeTemplateDeliveryTest.php`
- `php -l tests/Feature/Email/EmailLifecycleRolloutCommandTest.php`
- `php -l tests/Feature/Email/EmailOutboxAttributionTest.php`
- `php -l tests/Feature/Email/EmailOutboxSendCommandTest.php`
- `php artisan list | rg "email:outbox-send|email:lifecycle-rollout"`
- `php artisan route:list | rg "orders/lookup|claim/report|email/preferences|email/unsubscribe|attempts/.*/report|orders/.*/resend"`
- `php artisan migrate`
- `php artisan test tests/Feature/Email/WelcomeTemplateDeliveryTest.php`
- `php artisan test tests/Feature/Email/EmailLifecycleRolloutCommandTest.php`
- `php artisan test tests/Feature/Email/EmailOutboxAttributionTest.php`
- `php artisan test tests/Feature/Email/EmailOutboxSendCommandTest.php`
- `php artisan test tests/Feature/Email/EmailLifecycleExecutionPolicyTest.php`
- `php artisan test tests/Feature/Email/EmailSuppressionExecutionTest.php`
- `php artisan test tests/Feature/Email/EmailPreferencesExecutionTest.php`
- `php artisan test tests/Feature/Email/ReportClaimTemplateDeliveryTest.php`
- `php artisan test tests/Feature/Email/EmailOutboxNoPlaintextPayloadTest.php`
- `php artisan test tests/Feature/V0_3/EmailCaptureContractTest.php`
- `php artisan test tests/Feature/V0_3/EmailPreferencesContractTest.php`
- `php artisan test tests/Feature/V0_3/EmailUnsubscribeContractTest.php`
- `php artisan test tests/Feature/V0_3/ClaimReportEmailRequestTest.php`
- `php artisan test tests/Feature/V0_3/CommerceOrderResendTest.php`
- `php artisan test tests/Feature/V0_3/PaymentWebhookControllerTest.php`
- `php artisan test tests/Feature/Commerce/BigFiveUnlockDeliveryPipelineTest.php`
- `php artisan test tests/Feature/Report/ReportPdfCrossScaleDeliveryTest.php`
- `./vendor/bin/pint app/Console/Commands/FapEmailLifecycleRollout.php app/Services/Email/EmailLifecycleRolloutService.php app/Services/Email/EmailOutboxService.php resources/views/emails/en/welcome.blade.php resources/views/emails/zh/welcome.blade.php tests/Feature/Email/WelcomeTemplateDeliveryTest.php tests/Feature/Email/EmailLifecycleRolloutCommandTest.php tests/Feature/Email/EmailOutboxAttributionTest.php tests/Feature/Email/EmailOutboxSendCommandTest.php`
- `php artisan email:lifecycle-rollout --dry-run`
- `bash scripts/ci_verify_mbti.sh`
- `pnpm exec vitest run tests/contracts/email-preferences.contract.test.tsx tests/contracts/order-lookup-recovery.contract.test.tsx tests/contracts/orders-client-delivery.contract.test.tsx tests/contracts/result-client-view-state.contract.test.tsx tests/contracts/mbti-checkout-wiring.contract.test.tsx tests/contracts/mbti-post-purchase-retention.contract.test.tsx`
- `pnpm exec playwright test tests/e2e/email-preferences.spec.ts tests/e2e/email-unsubscribe.spec.ts tests/e2e/help-center.spec.ts tests/e2e/order-lookup-recovery.spec.ts tests/e2e/mbti-post-purchase.spec.ts tests/e2e/mbti-share.spec.ts tests/e2e/mbti-compare-invite.spec.ts`
