### PR TITLE
feat(email): add onboarding lifecycle rollout

### DIFF
--- a/backend/app/Console/Commands/FapEmailLifecycleRollout.php
+++ b/backend/app/Console/Commands/FapEmailLifecycleRollout.php
@@ -57,6 +57,11 @@ class FapEmailLifecycleRollout extends Command
             (int) data_get($result, 'templates.welcome.candidates', 0),
             (int) data_get($result, 'templates.welcome.enqueued', 0),
         ));
+        $this->line(sprintf(
+            'onboarding => candidates %d, enqueued %d',
+            (int) data_get($result, 'templates.onboarding.candidates', 0),
+            (int) data_get($result, 'templates.onboarding.enqueued', 0),
+        ));
 
         if ((bool) ($result['dry_run'] ?? false)) {
             $this->comment('Dry run: no outbox rows were enqueued.');

--- a/backend/app/Services/Email/EmailLifecycleRolloutService.php
+++ b/backend/app/Services/Email/EmailLifecycleRolloutService.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Services\Email;
 
+use App\Models\EmailPreference;
 use App\Models\EmailSubscriber;
 use App\Support\PiiCipher;
 use Carbon\CarbonInterface;
@@ -24,6 +25,10 @@ class EmailLifecycleRolloutService
     public const POST_PURCHASE_FOLLOWUP_COOLDOWN_DAYS = 7;
 
     public const REPORT_REACTIVATION_COOLDOWN_DAYS = 14;
+
+    public const ONBOARDING_DELAY_HOURS = 24;
+
+    public const ONBOARDING_COOLDOWN_DAYS = 7;
 
     /**
      * @var array<string,EmailSubscriber|null>
@@ -52,7 +57,8 @@ class EmailLifecycleRolloutService
      *         unsubscribe_confirmation:array{candidates:int,enqueued:int},
      *         post_purchase_followup:array{candidates:int,enqueued:int},
      *         report_reactivation:array{candidates:int,enqueued:int},
-     *         welcome:array{candidates:int,enqueued:int}
+     *         welcome:array{candidates:int,enqueued:int},
+     *         onboarding:array{candidates:int,enqueued:int}
      *     }
      * }
      */
@@ -114,12 +120,24 @@ class EmailLifecycleRolloutService
             )
         );
 
-        return $this->processOrderTemplate(
+        $summary = $this->processOrderTemplate(
             $summary,
             'report_reactivation',
             $this->reportReactivationCandidates(),
             $dryRun,
             fn (object $order, EmailSubscriber $subscriber): array => $this->emailOutbox->queueReportReactivation(
+                $subscriber,
+                (string) $order->target_attempt_id,
+                (string) $order->order_no
+            )
+        );
+
+        return $this->processOrderTemplate(
+            $summary,
+            'onboarding',
+            $this->onboardingCandidates(),
+            $dryRun,
+            fn (object $order, EmailSubscriber $subscriber): array => $this->emailOutbox->queueOnboarding(
                 $subscriber,
                 (string) $order->target_attempt_id,
                 (string) $order->order_no
@@ -138,7 +156,8 @@ class EmailLifecycleRolloutService
      *     unsubscribe_confirmation:array{candidates:int,enqueued:int},
      *     post_purchase_followup:array{candidates:int,enqueued:int},
      *     report_reactivation:array{candidates:int,enqueued:int},
-     *     welcome:array{candidates:int,enqueued:int}
+     *     welcome:array{candidates:int,enqueued:int},
+     *     onboarding:array{candidates:int,enqueued:int}
      * }
      */
     private function emptyTemplateSummary(): array
@@ -149,6 +168,7 @@ class EmailLifecycleRolloutService
             'post_purchase_followup' => ['candidates' => 0, 'enqueued' => 0],
             'report_reactivation' => ['candidates' => 0, 'enqueued' => 0],
             'welcome' => ['candidates' => 0, 'enqueued' => 0],
+            'onboarding' => ['candidates' => 0, 'enqueued' => 0],
         ];
     }
 
@@ -448,6 +468,67 @@ class EmailLifecycleRolloutService
             ->values();
     }
 
+    /**
+     * @return Collection<int,array{order:object,subscriber:EmailSubscriber}>
+     */
+    private function onboardingCandidates(): Collection
+    {
+        if (! $this->canEvaluateOrderFollowups()) {
+            return collect();
+        }
+
+        return DB::table('orders')
+            ->select([
+                'id',
+                'order_no',
+                'status',
+                'target_attempt_id',
+                'contact_email_hash',
+            ])
+            ->whereIn('status', ['paid', 'fulfilled'])
+            ->whereNotNull('target_attempt_id')
+            ->whereNotNull('contact_email_hash')
+            ->orderBy('updated_at')
+            ->get()
+            ->map(function (object $order): ?array {
+                $attemptId = trim((string) ($order->target_attempt_id ?? ''));
+                $orderNo = trim((string) ($order->order_no ?? ''));
+
+                if ($attemptId === '' || $orderNo === '') {
+                    return null;
+                }
+
+                $subscriber = $this->subscriberForEmailHash((string) ($order->contact_email_hash ?? ''));
+                if (! $this->subscriberAllowedForOnboarding($subscriber, 'onboarding')) {
+                    return null;
+                }
+
+                $firstReportViewAt = $this->earliestEventAt($attemptId, 'report_view');
+                if (! $firstReportViewAt instanceof Carbon) {
+                    return null;
+                }
+
+                if ($firstReportViewAt->gt($this->now()->copy()->subHours(self::ONBOARDING_DELAY_HOURS))) {
+                    return null;
+                }
+
+                if ($this->hasOutboxRowForOrder($orderNo, $attemptId, ['onboarding'], ['pending', 'sent', 'consumed'])) {
+                    return null;
+                }
+
+                if ($this->hasOutboxRowForOrder($orderNo, $attemptId, ['report_claim'], ['pending', 'sent', 'consumed'])) {
+                    return null;
+                }
+
+                return [
+                    'order' => $order,
+                    'subscriber' => $subscriber,
+                ];
+            })
+            ->filter()
+            ->values();
+    }
+
     private function canEvaluateOrderFollowups(): bool
     {
         return Schema::hasTable('orders')
@@ -483,6 +564,34 @@ class EmailLifecycleRolloutService
         }
 
         if (! $subscriber->allowsTransactionalRecovery()) {
+            return false;
+        }
+
+        if ($this->isSuppressedHash((string) $subscriber->email_hash)) {
+            return false;
+        }
+
+        if (! $this->subscriberOutsideLifecycleCooldown($subscriber, $templateKey)) {
+            return false;
+        }
+
+        return $this->decryptSubscriberEmail($subscriber) !== null;
+    }
+
+    private function subscriberAllowedForOnboarding(?EmailSubscriber $subscriber, string $templateKey): bool
+    {
+        if (! $subscriber instanceof EmailSubscriber) {
+            return false;
+        }
+
+        if ((string) ($subscriber->status ?? '') !== EmailSubscriber::STATUS_ACTIVE) {
+            return false;
+        }
+
+        $preference = $subscriber->preference instanceof EmailPreference
+            ? $subscriber->preference
+            : null;
+        if (! ($preference instanceof EmailPreference ? (bool) $preference->product_updates : false)) {
             return false;
         }
 
@@ -556,6 +665,24 @@ class EmailLifecycleRolloutService
             ->where('attempt_id', $attemptId)
             ->where('event_code', $eventCode)
             ->max('occurred_at');
+
+        if (! is_string($value) || trim($value) === '') {
+            return null;
+        }
+
+        try {
+            return Carbon::parse($value);
+        } catch (\Throwable) {
+            return null;
+        }
+    }
+
+    private function earliestEventAt(string $attemptId, string $eventCode): ?Carbon
+    {
+        $value = DB::table('events')
+            ->where('attempt_id', $attemptId)
+            ->where('event_code', $eventCode)
+            ->min('occurred_at');
 
         if (! is_string($value) || trim($value) === '') {
             return null;
@@ -718,6 +845,7 @@ class EmailLifecycleRolloutService
             'welcome' => CarbonInterval::days(self::WELCOME_COOLDOWN_DAYS),
             'post_purchase_followup' => CarbonInterval::days(self::POST_PURCHASE_FOLLOWUP_COOLDOWN_DAYS),
             'report_reactivation' => CarbonInterval::days(self::REPORT_REACTIVATION_COOLDOWN_DAYS),
+            'onboarding' => CarbonInterval::days(self::ONBOARDING_COOLDOWN_DAYS),
             default => CarbonInterval::minutes(self::CONFIRMATION_COOLDOWN_MINUTES),
         };
     }

--- a/backend/app/Services/Email/EmailOutboxService.php
+++ b/backend/app/Services/Email/EmailOutboxService.php
@@ -494,8 +494,43 @@ class EmailOutboxService
     }
 
     /**
+     * @return array{ok:bool,queued:bool,error?:string,reason?:string}
+     */
+    public function queueOnboarding(
+        EmailSubscriber $subscriber,
+        string $attemptId,
+        string $orderNo,
+        ?string $preferredLocale = null
+    ): array {
+        $attemptId = $this->trimOrNull($attemptId);
+        $orderNo = $this->trimOrNull($orderNo);
+
+        if ($attemptId === null || $orderNo === null) {
+            return ['ok' => false, 'queued' => false, 'error' => 'INVALID_INPUT'];
+        }
+
+        if ($this->hasLifecycleTemplateRowForOrder('report_claim', $orderNo, $attemptId, ['pending', 'sent', 'consumed'])) {
+            return ['ok' => true, 'queued' => false, 'reason' => 'existing_order_report_claim'];
+        }
+
+        return $this->queueSubscriberLifecycleEmail(
+            $subscriber,
+            'onboarding',
+            'first_report_view_onboarding',
+            $attemptId,
+            $orderNo,
+            $preferredLocale,
+            [],
+            ['pending', 'sent', 'consumed'],
+            true,
+            ['report_pdf_url']
+        );
+    }
+
+    /**
      * @param  array<string,mixed>  $payloadOverrides
      * @param  array<int,string>|null  $dedupeStatuses
+     * @param  array<int,string>  $payloadUnsetKeys
      * @return array{ok:bool,queued:bool,error?:string,reason?:string}
      */
     private function queueSubscriberLifecycleEmail(
@@ -507,7 +542,8 @@ class EmailOutboxService
         ?string $preferredLocale = null,
         array $payloadOverrides = [],
         ?array $dedupeStatuses = null,
-        bool $useLastContextFallback = true
+        bool $useLastContextFallback = true,
+        array $payloadUnsetKeys = []
     ): array {
         if (! \App\Support\SchemaBaseline::hasTable('email_outbox')) {
             return ['ok' => false, 'queued' => false, 'error' => 'TABLE_MISSING'];
@@ -526,7 +562,7 @@ class EmailOutboxService
         $orderNo = $this->trimOrNull($orderNo) ?? $this->trimOrNull((string) ($lastContext['order_no'] ?? ''));
         $emailHash = $this->piiCipher->emailHash($email);
 
-        if ($orderNo !== null && in_array($templateKey, ['post_purchase_followup', 'report_reactivation'], true)) {
+        if ($orderNo !== null && in_array($templateKey, ['post_purchase_followup', 'report_reactivation', 'onboarding'], true)) {
             if ($this->hasLifecycleTemplateRowForOrder($templateKey, $orderNo, $attemptId, $dedupeStatuses ?? ['pending', 'sent', 'consumed'])) {
                 return ['ok' => true, 'queued' => false, 'reason' => 'existing_order_template'];
             }
@@ -571,6 +607,11 @@ class EmailOutboxService
             'unsubscribed_at' => $subscriber->unsubscribed_at?->toIso8601String(),
             'attribution' => $this->payloadAttribution($normalizedAttribution),
         ], $payloadOverrides);
+
+        foreach ($payloadUnsetKeys as $key) {
+            unset($payload[$key]);
+        }
+
         $payloadJson = $this->encodePayloadJson($this->sanitizePayloadForJson($payload));
         $payloadEnc = $this->encodePayloadEncrypted($payload);
         DB::table('email_outbox')->insert($this->buildLifecycleOutboxRow(
@@ -1432,6 +1473,7 @@ class EmailOutboxService
             'post_purchase_followup',
             'report_reactivation',
             'welcome',
+            'onboarding',
         ];
         if (! in_array($templateKey, $supported, true)) {
             return '';
@@ -1942,6 +1984,7 @@ class EmailOutboxService
             'post_purchase_followup',
             'report_reactivation',
             'welcome',
+            'onboarding',
         ], true)) {
             return;
         }
@@ -2090,6 +2133,9 @@ class EmailOutboxService
         }
         if ($templateKey === 'welcome') {
             return $lang === 'zh' ? '欢迎来到 FermatMind' : 'Welcome to FermatMind';
+        }
+        if ($templateKey === 'onboarding') {
+            return $lang === 'zh' ? '如何更好地使用你的 FermatMind 报告' : 'How to get more from your FermatMind report';
         }
 
         return $lang === 'zh' ? 'FermatMind 通知' : 'FermatMind notification';

--- a/backend/app/Services/Email/EmailPreferenceService.php
+++ b/backend/app/Services/Email/EmailPreferenceService.php
@@ -75,7 +75,7 @@ class EmailPreferenceService
         $subscriberStatus = (string) ($snapshot['subscriber_status'] ?? EmailSubscriber::STATUS_ACTIVE);
         $reportRecovery = (bool) ($snapshot['transactional_recovery_enabled'] ?? true);
         $marketingUpdates = (bool) ($snapshot['marketing_consent'] ?? false);
-        $productUpdates = (bool) ($snapshot['marketing_consent'] ?? false);
+        $productUpdates = $this->resolveProductUpdatesForEmail($email);
 
         if ($subscriberStatus === EmailSubscriber::STATUS_SUPPRESSED) {
             return [
@@ -110,6 +110,30 @@ class EmailPreferenceService
                 'report_recovery' => $reportRecovery,
                 'marketing_updates' => $marketingUpdates,
                 'product_updates' => $productUpdates,
+            ];
+        }
+
+        if ($templateKey === 'onboarding' && $subscriberStatus !== EmailSubscriber::STATUS_ACTIVE) {
+            return [
+                'allowed' => false,
+                'status' => 'skipped',
+                'reason' => 'subscriber_inactive',
+                'suppressed' => false,
+                'report_recovery' => $reportRecovery,
+                'marketing_updates' => $marketingUpdates,
+                'product_updates' => $productUpdates,
+            ];
+        }
+
+        if ($templateKey === 'onboarding' && ! $productUpdates) {
+            return [
+                'allowed' => false,
+                'status' => 'skipped',
+                'reason' => 'product_updates_disabled',
+                'suppressed' => false,
+                'report_recovery' => $reportRecovery,
+                'marketing_updates' => $marketingUpdates,
+                'product_updates' => false,
             ];
         }
 
@@ -402,6 +426,30 @@ class EmailPreferenceService
         $payload = json_decode($json, true);
 
         return is_array($payload) ? $payload : null;
+    }
+
+    private function resolveProductUpdatesForEmail(string $email): bool
+    {
+        $normalizedEmail = $this->normalizeEmail($email);
+        if ($normalizedEmail === null) {
+            return false;
+        }
+
+        $subscriber = EmailSubscriber::query()
+            ->with('preference')
+            ->where('email_hash', $this->piiCipher->emailHash($normalizedEmail))
+            ->first();
+        if (! $subscriber) {
+            return false;
+        }
+
+        $preference = $subscriber->preference instanceof EmailPreference
+            ? $subscriber->preference
+            : null;
+
+        return $preference instanceof EmailPreference
+            ? (bool) $preference->product_updates
+            : (bool) $subscriber->marketing_consent;
     }
 
     private function requiresReportRecovery(string $templateKey): bool

--- a/backend/resources/views/emails/en/onboarding.blade.php
+++ b/backend/resources/views/emails/en/onboarding.blade.php
@@ -1,0 +1,33 @@
+<!doctype html>
+<html lang="en">
+<head>
+    <meta charset="utf-8">
+    <title>How to get more from your FermatMind report</title>
+</head>
+<body style="margin:0;padding:24px;background:#f6f4ef;font-family:Arial,sans-serif;color:#1f2933;line-height:1.6;">
+<div style="max-width:640px;margin:0 auto;background:#ffffff;border:1px solid #e5e7eb;padding:32px;">
+    <h1 style="margin:0 0 16px;font-size:28px;line-height:1.2;">How to get more from your FermatMind report</h1>
+    <p style="margin:0 0 16px;">You already opened your report, and you can come back to keep using it whenever you are ready.</p>
+    <p style="margin:0 0 16px;">This email is a short reminder of the key paths: return to the report, look up your order if needed, and reach help when you want support.</p>
+    @if(!empty($order_no))
+        <p style="margin:0 0 8px;"><strong>Order No:</strong> {{ $order_no }}</p>
+    @endif
+
+    @if(!empty($report_url))
+        <p style="margin:0 0 12px;"><a href="{{ $report_url }}">Return to your report</a></p>
+    @endif
+    <p style="margin:0 0 12px;"><a href="{{ $order_lookup_url }}">Order lookup</a></p>
+    <p style="margin:0 0 24px;"><a href="{{ $help_url }}">Get help</a></p>
+
+    <p style="margin:0 0 8px;">Need help? Contact <a href="mailto:{{ $support_email }}">{{ $support_email }}</a>.</p>
+    <p style="margin:0 0 8px;"><a href="{{ $email_preferences_url }}">Manage email preferences</a></p>
+    <p style="margin:0 0 24px;"><a href="{{ $email_unsubscribe_url }}">Unsubscribe from emails</a></p>
+
+    <p style="margin:0;font-size:12px;color:#52606d;">
+        <a href="{{ $privacy_url }}">Privacy</a> |
+        <a href="{{ $terms_url }}">Terms</a> |
+        <a href="{{ $refund_url }}">Refund</a>
+    </p>
+</div>
+</body>
+</html>

--- a/backend/resources/views/emails/zh/onboarding.blade.php
+++ b/backend/resources/views/emails/zh/onboarding.blade.php
@@ -1,0 +1,33 @@
+<!doctype html>
+<html lang="zh-CN">
+<head>
+    <meta charset="utf-8">
+    <title>如何更好地使用你的 FermatMind 报告</title>
+</head>
+<body style="margin:0;padding:24px;background:#f6f4ef;font-family:Arial,sans-serif;color:#1f2933;line-height:1.7;">
+<div style="max-width:640px;margin:0 auto;background:#ffffff;border:1px solid #e5e7eb;padding:32px;">
+    <h1 style="margin:0 0 16px;font-size:28px;line-height:1.2;">如何更好地使用你的 FermatMind 报告</h1>
+    <p style="margin:0 0 16px;">你已经打开过报告，之后随时都可以回到报告继续查看和使用。</p>
+    <p style="margin:0 0 16px;">这封邮件只收口几个继续使用的入口：返回报告、需要时查询订单，以及遇到问题时获取帮助。</p>
+    @if(!empty($order_no))
+        <p style="margin:0 0 8px;"><strong>订单号：</strong>{{ $order_no }}</p>
+    @endif
+
+    @if(!empty($report_url))
+        <p style="margin:0 0 12px;"><a href="{{ $report_url }}">返回报告</a></p>
+    @endif
+    <p style="margin:0 0 12px;"><a href="{{ $order_lookup_url }}">订单查询</a></p>
+    <p style="margin:0 0 24px;"><a href="{{ $help_url }}">获取帮助</a></p>
+
+    <p style="margin:0 0 8px;">如需帮助，请联系 <a href="mailto:{{ $support_email }}">{{ $support_email }}</a>。</p>
+    <p style="margin:0 0 8px;"><a href="{{ $email_preferences_url }}">管理邮件偏好</a></p>
+    <p style="margin:0 0 24px;"><a href="{{ $email_unsubscribe_url }}">退订邮件</a></p>
+
+    <p style="margin:0;font-size:12px;color:#52606d;">
+        <a href="{{ $privacy_url }}">隐私政策</a> |
+        <a href="{{ $terms_url }}">服务条款</a> |
+        <a href="{{ $refund_url }}">退款政策</a>
+    </p>
+</div>
+</body>
+</html>

--- a/backend/tests/Feature/Email/EmailLifecycleExecutionPolicyTest.php
+++ b/backend/tests/Feature/Email/EmailLifecycleExecutionPolicyTest.php
@@ -37,6 +37,7 @@ final class EmailLifecycleExecutionPolicyTest extends TestCase
         $unsubscribePolicy = $service->deliveryPolicyForEmail($email, 'unsubscribe_confirmation');
         $postPurchasePolicy = $service->deliveryPolicyForEmail($email, 'post_purchase_followup');
         $reportReactivationPolicy = $service->deliveryPolicyForEmail($email, 'report_reactivation');
+        $onboardingPolicy = $service->deliveryPolicyForEmail($email, 'onboarding');
 
         $this->assertFalse((bool) ($preferencesPolicy['allowed'] ?? true));
         $this->assertSame('suppressed', (string) ($preferencesPolicy['status'] ?? ''));
@@ -46,6 +47,8 @@ final class EmailLifecycleExecutionPolicyTest extends TestCase
         $this->assertSame('suppressed', (string) ($postPurchasePolicy['status'] ?? ''));
         $this->assertFalse((bool) ($reportReactivationPolicy['allowed'] ?? true));
         $this->assertSame('suppressed', (string) ($reportReactivationPolicy['status'] ?? ''));
+        $this->assertFalse((bool) ($onboardingPolicy['allowed'] ?? true));
+        $this->assertSame('suppressed', (string) ($onboardingPolicy['status'] ?? ''));
     }
 
     public function test_preferences_updated_is_not_blocked_by_preference_toggles(): void
@@ -126,5 +129,73 @@ final class EmailLifecycleExecutionPolicyTest extends TestCase
         $this->assertSame('subscriber_inactive', (string) ($postPurchasePolicy['reason'] ?? ''));
         $this->assertFalse((bool) ($reportReactivationPolicy['allowed'] ?? true));
         $this->assertSame('subscriber_inactive', (string) ($reportReactivationPolicy['reason'] ?? ''));
+    }
+
+    public function test_onboarding_requires_active_subscriber_status(): void
+    {
+        $email = 'onboarding+inactive@example.com';
+        $subscriber = app(EmailCaptureService::class)->ensureSubscriber($email, [
+            'surface' => 'report',
+            'marketing_consent' => true,
+        ]);
+        $subscriber->forceFill([
+            'status' => 'unsubscribed',
+            'unsubscribed_at' => now(),
+            'marketing_consent' => true,
+            'transactional_recovery_enabled' => true,
+        ])->save();
+
+        $policy = app(EmailPreferenceService::class)->deliveryPolicyForEmail($email, 'onboarding');
+
+        $this->assertFalse((bool) ($policy['allowed'] ?? true));
+        $this->assertSame('subscriber_inactive', (string) ($policy['reason'] ?? ''));
+    }
+
+    public function test_onboarding_requires_product_updates_enabled(): void
+    {
+        $email = 'onboarding+product-disabled@example.com';
+        app(EmailCaptureService::class)->ensureSubscriber($email, [
+            'surface' => 'report',
+            'marketing_consent' => true,
+        ]);
+
+        $service = app(EmailPreferenceService::class);
+        $token = $service->issueTokenForEmail($email);
+        $result = $service->updateByToken($token, [
+            'marketing_updates' => true,
+            'report_recovery' => true,
+            'product_updates' => false,
+        ]);
+        $this->assertTrue((bool) ($result['ok'] ?? false));
+
+        $policy = $service->deliveryPolicyForEmail($email, 'onboarding');
+
+        $this->assertFalse((bool) ($policy['allowed'] ?? true));
+        $this->assertSame('product_updates_disabled', (string) ($policy['reason'] ?? ''));
+    }
+
+    public function test_onboarding_does_not_depend_on_report_recovery_or_transactional_recovery(): void
+    {
+        $email = 'onboarding+recovery-disabled@example.com';
+        app(EmailCaptureService::class)->ensureSubscriber($email, [
+            'surface' => 'report',
+            'marketing_consent' => true,
+        ]);
+
+        $service = app(EmailPreferenceService::class);
+        $token = $service->issueTokenForEmail($email);
+        $result = $service->updateByToken($token, [
+            'marketing_updates' => false,
+            'report_recovery' => false,
+            'product_updates' => true,
+        ]);
+        $this->assertTrue((bool) ($result['ok'] ?? false));
+
+        $policy = $service->deliveryPolicyForEmail($email, 'onboarding');
+
+        $this->assertTrue((bool) ($policy['allowed'] ?? false));
+        $this->assertSame('allowed', (string) ($policy['status'] ?? ''));
+        $this->assertSame(false, $policy['report_recovery'] ?? null);
+        $this->assertSame(true, $policy['product_updates'] ?? null);
     }
 }

--- a/backend/tests/Feature/Email/EmailLifecycleRolloutCommandTest.php
+++ b/backend/tests/Feature/Email/EmailLifecycleRolloutCommandTest.php
@@ -383,6 +383,125 @@ final class EmailLifecycleRolloutCommandTest extends TestCase
         $this->assertSame(1, DB::table('email_outbox')->where('template', 'report_reactivation')->count());
     }
 
+    public function test_dry_run_counts_eligible_onboarding_candidates(): void
+    {
+        $eligibleEmail = 'onboarding+eligible@example.com';
+        $this->createOnboardingSubscriber($eligibleEmail, true);
+        $eligibleAttempt = $this->createAttempt('en', now()->subDays(3));
+        $eligibleOrder = 'ord_onboarding_eligible';
+        $this->createOrder($eligibleOrder, $eligibleAttempt, $eligibleEmail, 'fulfilled', now()->subDays(3), now()->subDays(2));
+        $this->recordEvent($eligibleAttempt, 'report_view', now()->subHours(30));
+
+        $recentEmail = 'onboarding+recent@example.com';
+        $this->createOnboardingSubscriber($recentEmail, true);
+        $recentAttempt = $this->createAttempt('en', now()->subDays(2));
+        $recentOrder = 'ord_onboarding_recent';
+        $this->createOrder($recentOrder, $recentAttempt, $recentEmail, 'paid', now()->subDays(2), null);
+        $this->recordEvent($recentAttempt, 'report_view', now()->subHours(12));
+
+        $this->artisan('email:lifecycle-rollout --dry-run')
+            ->expectsOutput('Candidates: 1')
+            ->expectsOutput('Enqueued: 0')
+            ->expectsOutput('onboarding => candidates 1, enqueued 0')
+            ->expectsOutput('Dry run: no outbox rows were enqueued.')
+            ->assertExitCode(0);
+
+        $this->assertSame(0, DB::table('email_outbox')->where('template', 'onboarding')->count());
+    }
+
+    public function test_command_enqueues_onboarding_once_per_order(): void
+    {
+        $email = 'onboarding+enqueue@example.com';
+        $this->createOnboardingSubscriber($email, true);
+        $attemptId = $this->createAttempt('en', now()->subDays(3));
+        $orderNo = 'ord_onboarding_enqueue';
+        $this->createOrder($orderNo, $attemptId, $email, 'fulfilled', now()->subDays(3), now()->subDays(2));
+        $this->recordEvent($attemptId, 'report_view', now()->subHours(30));
+
+        $this->artisan('email:lifecycle-rollout')
+            ->expectsOutput('Candidates: 1')
+            ->expectsOutput('Enqueued: 1')
+            ->expectsOutput('onboarding => candidates 1, enqueued 1')
+            ->assertExitCode(0);
+
+        $row = DB::table('email_outbox')->where('template', 'onboarding')->first();
+        $this->assertNotNull($row);
+        $this->assertSame('pending', (string) ($row->status ?? ''));
+
+        $this->artisan('email:lifecycle-rollout')
+            ->expectsOutput('Candidates: 0')
+            ->expectsOutput('Enqueued: 0')
+            ->expectsOutput('onboarding => candidates 0, enqueued 0')
+            ->assertExitCode(0);
+
+        $this->assertSame(1, DB::table('email_outbox')->where('template', 'onboarding')->count());
+    }
+
+    public function test_command_requires_product_updates_for_onboarding(): void
+    {
+        $email = 'onboarding+product-disabled@example.com';
+        $this->createOnboardingSubscriber($email, true);
+        $this->updateSubscriberPreferences($email, [
+            'marketing_updates' => true,
+            'report_recovery' => true,
+            'product_updates' => false,
+        ]);
+        $subscriber = $this->subscriberForEmail($email);
+        $subscriber->forceFill([
+            'last_preferences_confirmation_sent_at' => $subscriber->last_preferences_changed_at,
+        ])->save();
+        $attemptId = $this->createAttempt('en', now()->subDays(3));
+        $orderNo = 'ord_onboarding_product_disabled';
+        $this->createOrder($orderNo, $attemptId, $email, 'paid', now()->subDays(3), null);
+        $this->recordEvent($attemptId, 'report_view', now()->subHours(30));
+
+        $this->artisan('email:lifecycle-rollout')
+            ->expectsOutput('Candidates: 0')
+            ->expectsOutput('Enqueued: 0')
+            ->expectsOutput('onboarding => candidates 0, enqueued 0')
+            ->assertExitCode(0);
+
+        $this->assertSame(0, DB::table('email_outbox')->where('template', 'onboarding')->count());
+    }
+
+    public function test_command_respects_onboarding_cooldown(): void
+    {
+        $email = 'onboarding+cooldown@example.com';
+        $subscriber = $this->createOnboardingSubscriber($email, true);
+        $attemptId = $this->createAttempt('en', now()->subDays(3));
+        $orderNo = 'ord_onboarding_cooldown';
+        $this->createOrder($orderNo, $attemptId, $email, 'fulfilled', now()->subDays(3), now()->subDays(2));
+        $this->recordEvent($attemptId, 'report_view', now()->subHours(30));
+        $this->markSubscriberInCooldown($subscriber, 'onboarding', now()->subDay());
+
+        $this->artisan('email:lifecycle-rollout')
+            ->expectsOutput('Candidates: 0')
+            ->expectsOutput('Enqueued: 0')
+            ->expectsOutput('onboarding => candidates 0, enqueued 0')
+            ->assertExitCode(0);
+
+        $this->assertSame(0, DB::table('email_outbox')->where('template', 'onboarding')->count());
+    }
+
+    public function test_command_does_not_enqueue_onboarding_when_report_claim_exists_for_order(): void
+    {
+        $email = 'onboarding+claimed@example.com';
+        $this->createOnboardingSubscriber($email, true);
+        $attemptId = $this->createAttempt('en', now()->subDays(3));
+        $orderNo = 'ord_onboarding_claimed';
+        $this->createOrder($orderNo, $attemptId, $email, 'paid', now()->subDays(3), null);
+        $this->recordEvent($attemptId, 'report_view', now()->subHours(30));
+        $this->queueReportClaim($email, $attemptId, $orderNo);
+
+        $this->artisan('email:lifecycle-rollout')
+            ->expectsOutput('Candidates: 0')
+            ->expectsOutput('Enqueued: 0')
+            ->expectsOutput('onboarding => candidates 0, enqueued 0')
+            ->assertExitCode(0);
+
+        $this->assertSame(0, DB::table('email_outbox')->where('template', 'onboarding')->count());
+    }
+
     private function updatePreferencesFor(string $email, array $preferences): EmailSubscriber
     {
         app(EmailCaptureService::class)->ensureSubscriber($email, [
@@ -448,6 +567,18 @@ final class EmailLifecycleRolloutCommandTest extends TestCase
             'first_captured_at' => $capturedAt,
             'last_captured_at' => $capturedAt,
         ])->save();
+
+        return $subscriber->fresh(['preference']);
+    }
+
+    private function createOnboardingSubscriber(string $email, bool $marketingConsent, string $locale = 'en'): EmailSubscriber
+    {
+        $subscriber = app(EmailCaptureService::class)->ensureSubscriber($email, [
+            'surface' => 'report',
+            'locale' => $locale,
+            'entrypoint' => 'report_view',
+            'marketing_consent' => $marketingConsent,
+        ]);
 
         return $subscriber->fresh(['preference']);
     }
@@ -581,6 +712,14 @@ final class EmailLifecycleRolloutCommandTest extends TestCase
             $orderNo
         );
         $this->assertTrue((bool) ($queued['ok'] ?? false));
+    }
+
+    private function updateSubscriberPreferences(string $email, array $preferences): void
+    {
+        $service = app(EmailPreferenceService::class);
+        $token = $service->issueTokenForEmail($email);
+        $result = $service->updateByToken($token, $preferences);
+        $this->assertTrue((bool) ($result['ok'] ?? false));
     }
 
     private function recordEvent(string $attemptId, string $eventCode, CarbonInterface $occurredAt): void

--- a/backend/tests/Feature/Email/EmailOutboxAttributionTest.php
+++ b/backend/tests/Feature/Email/EmailOutboxAttributionTest.php
@@ -427,6 +427,77 @@ final class EmailOutboxAttributionTest extends TestCase
         $this->assertStringContainsString('compare_invite_id=', $html);
     }
 
+    public function test_onboarding_outbox_payload_includes_attribution_contract(): void
+    {
+        config([
+            'fap.runtime.EMAIL_OUTBOX_SEND' => true,
+            'fap.runtime.FAP_BASE_URL' => 'https://app.example.test',
+            'app.url' => 'https://api.example.test',
+            'mail.default' => 'array',
+        ]);
+
+        $attemptId = $this->createAttempt();
+        $email = 'onboarding@example.com';
+        $orderNo = 'ord_attr_onboarding';
+
+        $subscriber = app(EmailCaptureService::class)->ensureSubscriber($email, [
+            'surface' => 'report',
+            'locale' => 'en',
+            'entrypoint' => 'report_view',
+            'marketing_consent' => true,
+        ]);
+        $this->createOrder($orderNo, $attemptId, $email, [
+            'share_id' => 'share_onboarding_attr',
+            'compare_invite_id' => (string) Str::uuid(),
+            'share_click_id' => 'clk_onboarding_attr',
+            'entrypoint' => 'report_view',
+            'referrer' => 'https://example.com/report',
+            'landing_path' => '/en/report',
+            'utm' => [
+                'source' => 'report',
+                'medium' => 'owned',
+                'campaign' => 'first-report-view-onboarding',
+                'content' => 'followup',
+            ],
+        ]);
+
+        $queued = app(EmailOutboxService::class)->queueOnboarding($subscriber, $attemptId, $orderNo, 'en');
+        $this->assertTrue((bool) ($queued['ok'] ?? false));
+        $this->assertTrue((bool) ($queued['queued'] ?? false));
+
+        $row = DB::table('email_outbox')
+            ->where('attempt_id', $attemptId)
+            ->where('template', 'onboarding')
+            ->first();
+        $this->assertNotNull($row);
+
+        $payloadJson = json_decode((string) ($row->payload_json ?? '{}'), true);
+        $this->assertIsArray($payloadJson);
+        $this->assertSame('share_onboarding_attr', (string) data_get($payloadJson, 'attribution.share_id'));
+        $this->assertSame('report_view', (string) data_get($payloadJson, 'attribution.entrypoint'));
+        $this->assertSame('owned', (string) data_get($payloadJson, 'attribution.utm.medium'));
+        $this->assertArrayNotHasKey('email', $payloadJson);
+        $this->assertArrayNotHasKey('to_email', $payloadJson);
+        $this->assertArrayNotHasKey('report_pdf_url', $payloadJson);
+
+        /** @var PiiCipher $pii */
+        $pii = app(PiiCipher::class);
+        $payloadEnc = json_decode((string) $pii->decrypt((string) ($row->payload_enc ?? '')), true);
+        $this->assertIsArray($payloadEnc);
+        $this->assertSame($email, (string) ($payloadEnc['to_email'] ?? ''));
+        $this->assertSame('followup', (string) data_get($payloadEnc, 'attribution.utm.content'));
+        $this->assertArrayNotHasKey('report_pdf_url', $payloadEnc);
+
+        Mail::mailer('array')->getSymfonyTransport()->flush();
+        $this->artisan('email:outbox-send --limit=10')->assertExitCode(0);
+
+        $html = (string) Mail::mailer('array')->getSymfonyTransport()->messages()->first()->getOriginalMessage()->getHtmlBody();
+        $this->assertStringContainsString('share_id=share_onboarding_attr', $html);
+        $this->assertStringContainsString('utm_campaign=first-report-view-onboarding', $html);
+        $this->assertStringContainsString('compare_invite_id=', $html);
+        $this->assertStringNotContainsString('report.pdf', $html);
+    }
+
     private function createAttempt(): string
     {
         $attemptId = (string) Str::uuid();

--- a/backend/tests/Feature/Email/EmailOutboxSendCommandTest.php
+++ b/backend/tests/Feature/Email/EmailOutboxSendCommandTest.php
@@ -236,6 +236,63 @@ final class EmailOutboxSendCommandTest extends TestCase
         $this->assertStringContainsString('View help center', (string) $message->getHtmlBody());
     }
 
+    public function test_command_sends_onboarding_and_updates_lifecycle_sent_markers(): void
+    {
+        config([
+            'fap.runtime.EMAIL_OUTBOX_SEND' => true,
+            'fap.runtime.FAP_BASE_URL' => 'https://app.example.test',
+            'app.url' => 'https://api.example.test',
+            'mail.default' => 'array',
+        ]);
+
+        $this->flushArrayTransport();
+        $email = 'buyer+onboarding-marker@example.com';
+        $attemptId = $this->createAttempt();
+        $orderNo = 'ord_onboarding_marker_'.Str::lower(Str::random(8));
+        $subscriber = app(EmailCaptureService::class)->ensureSubscriber($email, [
+            'surface' => 'report',
+            'locale' => 'en',
+            'entrypoint' => 'report_view',
+            'marketing_consent' => true,
+        ]);
+        $this->createLifecycleOrder($orderNo, $attemptId, $email);
+
+        $queued = app(EmailOutboxService::class)->queueOnboarding($subscriber, $attemptId, $orderNo, 'en');
+        $this->assertTrue((bool) ($queued['ok'] ?? false));
+        $this->assertTrue((bool) ($queued['queued'] ?? false));
+
+        $this->artisan('email:outbox-send --limit=10')
+            ->expectsOutput('Mailer array: sent 1, blocked 0, failed 0.')
+            ->assertExitCode(0);
+
+        $row = DB::table('email_outbox')
+            ->where('attempt_id', $attemptId)
+            ->where('template', 'onboarding')
+            ->first();
+
+        $this->assertNotNull($row);
+        $this->assertSame('sent', (string) ($row->status ?? ''));
+        $this->assertNotNull($row->sent_at ?? null);
+
+        $subscriber->refresh();
+        $this->assertNotNull($subscriber->last_lifecycle_email_sent_at);
+        if (Schema::hasColumn('email_subscribers', 'last_lifecycle_template_key')) {
+            $this->assertSame('onboarding', (string) $subscriber->getAttribute('last_lifecycle_template_key'));
+        }
+        if (Schema::hasColumn('email_subscribers', 'next_lifecycle_eligible_at')) {
+            $this->assertNotNull($subscriber->getAttribute('next_lifecycle_eligible_at'));
+            $this->assertTrue(
+                $subscriber->getAttribute('next_lifecycle_eligible_at')->greaterThan(
+                    $subscriber->last_lifecycle_email_sent_at->copy()->addDays(6)
+                )
+            );
+        }
+
+        $message = Mail::mailer('array')->getSymfonyTransport()->messages()->first()->getOriginalMessage();
+        $this->assertSame('How to get more from your FermatMind report', (string) $message->getSubject());
+        $this->assertStringContainsString('Return to your report', (string) $message->getHtmlBody());
+    }
+
     #[DataProvider('followupTemplateProvider')]
     public function test_command_sends_followup_templates_and_updates_lifecycle_sent_markers(
         string $templateKey,

--- a/backend/tests/Feature/Email/OnboardingTemplateDeliveryTest.php
+++ b/backend/tests/Feature/Email/OnboardingTemplateDeliveryTest.php
@@ -1,0 +1,195 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Email;
+
+use App\Services\Email\EmailCaptureService;
+use App\Services\Email\EmailOutboxService;
+use App\Support\PiiCipher;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Mail;
+use Illuminate\Support\Str;
+use PHPUnit\Framework\Attributes\DataProvider;
+use Tests\TestCase;
+
+final class OnboardingTemplateDeliveryTest extends TestCase
+{
+    use RefreshDatabase;
+
+    #[DataProvider('localeProvider')]
+    public function test_onboarding_template_renders_supported_locales(
+        string $locale,
+        string $expectedSubject,
+        string $expectedReportLabel,
+        string $expectedHelpLabel,
+        string $expectedHelpPath
+    ): void {
+        config([
+            'fap.runtime.EMAIL_OUTBOX_SEND' => true,
+            'fap.runtime.FAP_BASE_URL' => 'https://app.example.test',
+            'app.url' => 'https://api.example.test',
+            'mail.default' => 'array',
+        ]);
+
+        $this->flushArrayTransport();
+
+        $email = 'onboarding+'.md5($locale).'@example.com';
+        $attemptId = $this->createAttempt($locale);
+        $orderNo = 'ord_onboarding_'.Str::lower(Str::random(8));
+        $subscriber = app(EmailCaptureService::class)->ensureSubscriber($email, [
+            'surface' => 'report',
+            'locale' => $locale,
+            'entrypoint' => 'report_view',
+            'marketing_consent' => true,
+        ]);
+        $this->createOrder($orderNo, $attemptId, $email);
+
+        $queued = app(EmailOutboxService::class)->queueOnboarding($subscriber, $attemptId, $orderNo, $locale);
+        $this->assertTrue((bool) ($queued['ok'] ?? false));
+        $this->assertTrue((bool) ($queued['queued'] ?? false));
+
+        $row = DB::table('email_outbox')->where('template', 'onboarding')->first();
+        $this->assertNotNull($row);
+
+        $payloadJson = json_decode((string) ($row->payload_json ?? '{}'), true);
+        $this->assertIsArray($payloadJson);
+        $this->assertSame('share_onboarding', (string) data_get($payloadJson, 'attribution.share_id'));
+        $this->assertSame('owned', (string) data_get($payloadJson, 'attribution.utm.medium'));
+        $this->assertArrayNotHasKey('email', $payloadJson);
+        $this->assertArrayNotHasKey('to_email', $payloadJson);
+        $this->assertArrayNotHasKey('claim_token', $payloadJson);
+        $this->assertArrayNotHasKey('claim_url', $payloadJson);
+        $this->assertArrayNotHasKey('report_pdf_url', $payloadJson);
+
+        /** @var PiiCipher $pii */
+        $pii = app(PiiCipher::class);
+        $payloadEnc = json_decode((string) $pii->decrypt((string) ($row->payload_enc ?? '')), true);
+        $this->assertIsArray($payloadEnc);
+        $this->assertSame($email, (string) ($payloadEnc['to_email'] ?? ''));
+        $this->assertSame('share_onboarding', (string) data_get($payloadEnc, 'attribution.share_id'));
+        $this->assertArrayNotHasKey('claim_token', $payloadEnc);
+        $this->assertArrayNotHasKey('claim_url', $payloadEnc);
+        $this->assertArrayNotHasKey('report_pdf_url', $payloadEnc);
+
+        $this->artisan('email:outbox-send --limit=10')
+            ->expectsOutput('Mailer array: sent 1, blocked 0, failed 0.')
+            ->assertExitCode(0);
+
+        $message = Mail::mailer('array')->getSymfonyTransport()->messages()->first()->getOriginalMessage();
+        $html = (string) $message->getHtmlBody();
+        $this->assertSame($expectedSubject, (string) $message->getSubject());
+        $this->assertStringContainsString($expectedSubject, $html);
+        $this->assertStringContainsString($expectedReportLabel, $html);
+        $this->assertStringContainsString($expectedHelpLabel, $html);
+        $this->assertStringContainsString("https://api.example.test/api/v0.3/attempts/{$attemptId}/report", $html);
+        $this->assertStringContainsString('https://app.example.test/orders/lookup?', $html);
+        $this->assertStringContainsString('https://app.example.test/email/preferences?token=', $html);
+        $this->assertStringContainsString('https://app.example.test/email/unsubscribe?token=', $html);
+        $this->assertStringContainsString('https://app.example.test/'.$expectedHelpPath.'?', $html);
+        $this->assertStringContainsString('share_id=share_onboarding', $html);
+        $this->assertStringContainsString('utm_campaign=first-report-view-onboarding', $html);
+        $this->assertStringContainsString('compare_invite_id=', $html);
+        $this->assertStringNotContainsString('report.pdf', $html);
+    }
+
+    /**
+     * @return array<string,array{0:string,1:string,2:string,3:string,4:string}>
+     */
+    public static function localeProvider(): array
+    {
+        return [
+            'en' => ['en', 'How to get more from your FermatMind report', 'Return to your report', 'Get help', 'en/help'],
+            'zh-CN' => ['zh-CN', '如何更好地使用你的 FermatMind 报告', '返回报告', '获取帮助', 'zh/help'],
+        ];
+    }
+
+    private function createAttempt(string $locale): string
+    {
+        $attemptId = (string) Str::uuid();
+
+        DB::table('attempts')->insert([
+            'id' => $attemptId,
+            'ticket_code' => 'FMT-'.strtoupper(substr(str_replace('-', '', $attemptId), 0, 8)),
+            'org_id' => 0,
+            'anon_id' => 'anon_onboarding_template',
+            'user_id' => null,
+            'scale_code' => 'MBTI',
+            'scale_version' => 'v0.3',
+            'region' => 'CN_MAINLAND',
+            'locale' => $locale,
+            'question_count' => 144,
+            'answers_summary_json' => json_encode(['seed' => true], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES),
+            'client_platform' => 'test',
+            'client_version' => '1.0.0',
+            'channel' => 'test',
+            'started_at' => now()->subDays(3),
+            'submitted_at' => now()->subDays(3),
+            'pack_id' => (string) config('content_packs.default_pack_id'),
+            'dir_version' => (string) config('content_packs.default_dir_version'),
+            'content_package_version' => 'v0.3',
+            'scoring_spec_version' => '2026.01',
+            'created_at' => now()->subDays(3),
+            'updated_at' => now()->subDays(3),
+        ]);
+
+        return $attemptId;
+    }
+
+    private function createOrder(string $orderNo, string $attemptId, string $email): void
+    {
+        /** @var PiiCipher $pii */
+        $pii = app(PiiCipher::class);
+
+        DB::table('orders')->insert([
+            'id' => (string) Str::uuid(),
+            'order_no' => $orderNo,
+            'org_id' => 0,
+            'user_id' => null,
+            'anon_id' => 'anon_onboarding_template',
+            'sku' => 'SKU_MBTI_FULL_REPORT',
+            'quantity' => 1,
+            'target_attempt_id' => $attemptId,
+            'amount_cents' => 299,
+            'currency' => 'USD',
+            'status' => 'paid',
+            'provider' => 'billing',
+            'external_trade_no' => null,
+            'contact_email_hash' => $pii->emailHash($email),
+            'meta_json' => json_encode([
+                'attribution' => [
+                    'share_id' => 'share_onboarding',
+                    'compare_invite_id' => (string) Str::uuid(),
+                    'share_click_id' => 'clk_onboarding',
+                    'entrypoint' => 'report_view',
+                    'referrer' => 'https://example.com/report',
+                    'landing_path' => '/en/report',
+                    'utm' => [
+                        'source' => 'report',
+                        'medium' => 'owned',
+                        'campaign' => 'first-report-view-onboarding',
+                        'content' => 'template',
+                    ],
+                ],
+            ], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES),
+            'paid_at' => now()->subDays(3),
+            'fulfilled_at' => now()->subDays(2),
+            'amount_total' => 299,
+            'amount_refunded' => 0,
+            'item_sku' => 'SKU_MBTI_FULL_REPORT',
+            'provider_order_id' => null,
+            'device_id' => null,
+            'request_id' => null,
+            'created_ip' => null,
+            'refunded_at' => null,
+            'created_at' => now()->subDays(3),
+            'updated_at' => now()->subDays(2),
+        ]);
+    }
+
+    private function flushArrayTransport(): void
+    {
+        Mail::mailer('array')->getSymfonyTransport()->flush();
+    }
+}


### PR DESCRIPTION
## Summary
- add `onboarding` to the existing `email:lifecycle-rollout` orchestration
- add `queueOnboarding()` plus onboarding selector, cooldown, order-level dedupe, sent-state, and execution policy wiring
- add localized onboarding templates and backend coverage for rollout, delivery, attribution, and policy

## Tests
- `php -l app/Console/Commands/FapEmailLifecycleRollout.php`
- `php -l app/Services/Email/EmailLifecycleRolloutService.php`
- `php -l app/Services/Email/EmailOutboxService.php`
- `php -l app/Services/Email/EmailPreferenceService.php`
- `php -l tests/Feature/Email/OnboardingTemplateDeliveryTest.php`
- `php -l tests/Feature/Email/EmailLifecycleRolloutCommandTest.php`
- `php -l tests/Feature/Email/EmailOutboxAttributionTest.php`
- `php -l tests/Feature/Email/EmailOutboxSendCommandTest.php`
- `php -l tests/Feature/Email/EmailLifecycleExecutionPolicyTest.php`
- `php artisan list | rg "email:outbox-send|email:lifecycle-rollout"`
- `php artisan route:list | rg "orders/lookup|claim/report|email/preferences|email/unsubscribe|attempts/.*/report|orders/.*/resend"`
- `php artisan migrate`
- `./vendor/bin/pint app/Console/Commands/FapEmailLifecycleRollout.php app/Services/Email/EmailLifecycleRolloutService.php app/Services/Email/EmailOutboxService.php app/Services/Email/EmailPreferenceService.php resources/views/emails/en/onboarding.blade.php resources/views/emails/zh/onboarding.blade.php tests/Feature/Email/OnboardingTemplateDeliveryTest.php tests/Feature/Email/EmailLifecycleRolloutCommandTest.php tests/Feature/Email/EmailOutboxAttributionTest.php tests/Feature/Email/EmailOutboxSendCommandTest.php tests/Feature/Email/EmailLifecycleExecutionPolicyTest.php`
- `php artisan test tests/Feature/Email/OnboardingTemplateDeliveryTest.php`
- `php artisan test tests/Feature/Email/EmailLifecycleRolloutCommandTest.php`
- `php artisan test tests/Feature/Email/EmailOutboxAttributionTest.php`
- `php artisan test tests/Feature/Email/EmailOutboxSendCommandTest.php`
- `php artisan test tests/Feature/Email/EmailLifecycleExecutionPolicyTest.php`
- `php artisan test tests/Feature/Email/EmailSuppressionExecutionTest.php`
- `php artisan test tests/Feature/Email/EmailPreferencesExecutionTest.php`
- `php artisan test tests/Feature/Email/WelcomeTemplateDeliveryTest.php`
- `php artisan test tests/Feature/Email/ReportClaimTemplateDeliveryTest.php`
- `php artisan test tests/Feature/Email/EmailOutboxNoPlaintextPayloadTest.php`
- `php artisan test tests/Feature/V0_3/EmailCaptureContractTest.php`
- `php artisan test tests/Feature/V0_3/EmailPreferencesContractTest.php`
- `php artisan test tests/Feature/V0_3/EmailUnsubscribeContractTest.php`
- `php artisan test tests/Feature/V0_3/ClaimReportEmailRequestTest.php`
- `php artisan test tests/Feature/V0_3/CommerceOrderResendTest.php`
- `php artisan test tests/Feature/V0_3/PaymentWebhookControllerTest.php`
- `php artisan test tests/Feature/Commerce/BigFiveUnlockDeliveryPipelineTest.php`
- `php artisan test tests/Feature/Report/ReportPdfCrossScaleDeliveryTest.php`
- `php artisan email:lifecycle-rollout --dry-run`
- `bash scripts/ci_verify_mbti.sh`
- `pnpm exec vitest run tests/contracts/email-preferences.contract.test.tsx tests/contracts/order-lookup-recovery.contract.test.tsx tests/contracts/orders-client-delivery.contract.test.tsx tests/contracts/result-client-view-state.contract.test.tsx tests/contracts/mbti-checkout-wiring.contract.test.tsx tests/contracts/mbti-post-purchase-retention.contract.test.tsx`
- `pnpm exec playwright test tests/e2e/email-preferences.spec.ts tests/e2e/email-unsubscribe.spec.ts tests/e2e/help-center.spec.ts tests/e2e/order-lookup-recovery.spec.ts tests/e2e/mbti-post-purchase.spec.ts tests/e2e/mbti-share.spec.ts tests/e2e/mbti-compare-invite.spec.ts`
