### PR TITLE
feat(assessment-ops): add Attempts Explorer for support diagnostics

### DIFF
--- a/backend/app/Filament/Ops/Resources/AttemptResource.php
+++ b/backend/app/Filament/Ops/Resources/AttemptResource.php
@@ -1,0 +1,272 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Filament\Ops\Resources;
+
+use App\Filament\Ops\Resources\AttemptResource\Pages;
+use App\Filament\Ops\Resources\AttemptResource\Support\AttemptExplorerSupport;
+use App\Models\Attempt;
+use App\Support\Rbac\PermissionNames;
+use Filament\Forms;
+use Filament\Forms\Form;
+use Filament\Resources\Resource;
+use Filament\Tables;
+use Filament\Tables\Enums\FiltersLayout;
+use Filament\Tables\Table;
+use Illuminate\Database\Eloquent\Builder;
+
+class AttemptResource extends Resource
+{
+    protected static ?string $model = Attempt::class;
+
+    protected static ?string $navigationIcon = 'heroicon-o-clipboard-document-list';
+
+    protected static ?string $navigationGroup = 'Support';
+
+    protected static ?string $navigationLabel = 'Attempts Explorer';
+
+    protected static ?int $navigationSort = 8;
+
+    public static function getNavigationGroup(): ?string
+    {
+        return __('ops.group.support');
+    }
+
+    public static function getNavigationLabel(): string
+    {
+        return 'Attempts Explorer';
+    }
+
+    public static function form(Form $form): Form
+    {
+        return $form->schema([]);
+    }
+
+    public static function canViewAny(): bool
+    {
+        return self::canSupportAccess();
+    }
+
+    public static function canView($record): bool
+    {
+        return self::canSupportAccess();
+    }
+
+    public static function canCreate(): bool
+    {
+        return false;
+    }
+
+    public static function canEdit($record): bool
+    {
+        return false;
+    }
+
+    public static function canDelete($record): bool
+    {
+        return false;
+    }
+
+    public static function table(Table $table): Table
+    {
+        return $table
+            ->searchPlaceholder('attempt_id / order_no / anon_id / user_id / ticket_code / share_id')
+            ->searchDebounce('600ms')
+            ->recordUrl(fn (Attempt $record): string => static::getUrl('view', ['record' => $record]))
+            ->columns([
+                Tables\Columns\TextColumn::make('id')
+                    ->label('attempt_id')
+                    ->copyable()
+                    ->searchable(query: function (Builder $query, string $search): void {
+                        app(AttemptExplorerSupport::class)->applySearch($query, $search);
+                    })
+                    ->sortable(),
+                Tables\Columns\TextColumn::make('scale_code')
+                    ->sortable(),
+                Tables\Columns\TextColumn::make('submitted_status')
+                    ->label('submitted_status')
+                    ->formatStateUsing(fn (Attempt $record): string => app(AttemptExplorerSupport::class)->submittedStatus($record)['label'])
+                    ->badge()
+                    ->color(fn (Attempt $record): string => app(AttemptExplorerSupport::class)->submittedStatus($record)['state']),
+                Tables\Columns\TextColumn::make('submitted_at')
+                    ->dateTime()
+                    ->sortable(),
+                Tables\Columns\TextColumn::make('locale')->sortable(),
+                Tables\Columns\TextColumn::make('region')->sortable(),
+                Tables\Columns\TextColumn::make('channel')->sortable(),
+                Tables\Columns\TextColumn::make('has_result')
+                    ->label('has_result')
+                    ->formatStateUsing(fn (Attempt $record): string => app(AttemptExplorerSupport::class)->resultStatus($record)['label'])
+                    ->badge()
+                    ->color(fn (Attempt $record): string => app(AttemptExplorerSupport::class)->resultStatus($record)['state']),
+                Tables\Columns\TextColumn::make('latest_report_snapshot_status')
+                    ->label('report_snapshot_status')
+                    ->formatStateUsing(fn (Attempt $record): string => app(AttemptExplorerSupport::class)->reportStatus($record)['label'])
+                    ->badge()
+                    ->color(fn (Attempt $record): string => app(AttemptExplorerSupport::class)->reportStatus($record)['state']),
+                Tables\Columns\TextColumn::make('unlock_status')
+                    ->label('unlock_status')
+                    ->formatStateUsing(fn (Attempt $record): string => app(AttemptExplorerSupport::class)->unlockStatus($record)['label'])
+                    ->badge()
+                    ->color(fn (Attempt $record): string => app(AttemptExplorerSupport::class)->unlockStatus($record)['state']),
+                Tables\Columns\TextColumn::make('latest_order_no')
+                    ->label('order_no')
+                    ->copyable()
+                    ->toggleable(isToggledHiddenByDefault: true),
+                Tables\Columns\TextColumn::make('latest_share_id')
+                    ->label('share_id')
+                    ->copyable()
+                    ->toggleable(isToggledHiddenByDefault: true),
+                Tables\Columns\TextColumn::make('anon_id')
+                    ->copyable()
+                    ->toggleable(isToggledHiddenByDefault: true),
+                Tables\Columns\TextColumn::make('user_id')
+                    ->copyable()
+                    ->toggleable(isToggledHiddenByDefault: true),
+                Tables\Columns\TextColumn::make('ticket_code')
+                    ->copyable()
+                    ->toggleable(isToggledHiddenByDefault: true),
+                Tables\Columns\TextColumn::make('pack_id')
+                    ->toggleable(isToggledHiddenByDefault: true),
+                Tables\Columns\TextColumn::make('scoring_spec_version')
+                    ->toggleable(isToggledHiddenByDefault: true),
+                Tables\Columns\TextColumn::make('norm_version')
+                    ->toggleable(isToggledHiddenByDefault: true),
+                Tables\Columns\TextColumn::make('report_engine_version')
+                    ->state(fn (Attempt $record): string => app(AttemptExplorerSupport::class)->reportEngineVersion($record))
+                    ->toggleable(isToggledHiddenByDefault: true),
+                Tables\Columns\TextColumn::make('org_id')
+                    ->sortable()
+                    ->toggleable(isToggledHiddenByDefault: true),
+                Tables\Columns\TextColumn::make('scale_uid')
+                    ->toggleable(isToggledHiddenByDefault: true),
+            ])
+            ->defaultSort('activity_at', 'desc')
+            ->filters([
+                Tables\Filters\Filter::make('submitted_window')
+                    ->label('Date')
+                    ->form([
+                        Forms\Components\DatePicker::make('from')->label('from'),
+                        Forms\Components\DatePicker::make('until')->label('until'),
+                    ])
+                    ->query(function (Builder $query, array $data): void {
+                        $from = trim((string) ($data['from'] ?? ''));
+                        $until = trim((string) ($data['until'] ?? ''));
+
+                        if ($from !== '') {
+                            $query->whereRaw('date(coalesce(attempts.submitted_at, attempts.created_at)) >= ?', [$from]);
+                        }
+
+                        if ($until !== '') {
+                            $query->whereRaw('date(coalesce(attempts.submitted_at, attempts.created_at)) <= ?', [$until]);
+                        }
+                    }),
+                Tables\Filters\SelectFilter::make('scale_code')
+                    ->options(fn (): array => app(AttemptExplorerSupport::class)->distinctAttemptOptions('scale_code')),
+                Tables\Filters\SelectFilter::make('locale')
+                    ->options(fn (): array => app(AttemptExplorerSupport::class)->distinctAttemptOptions('locale')),
+                Tables\Filters\SelectFilter::make('region')
+                    ->options(fn (): array => app(AttemptExplorerSupport::class)->distinctAttemptOptions('region')),
+                Tables\Filters\SelectFilter::make('channel')
+                    ->options(fn (): array => app(AttemptExplorerSupport::class)->distinctAttemptOptions('channel')),
+                Tables\Filters\TernaryFilter::make('submitted')
+                    ->label('Submitted')
+                    ->queries(
+                        true: fn (Builder $query): Builder => $query->whereNotNull('attempts.submitted_at'),
+                        false: fn (Builder $query): Builder => $query->whereNull('attempts.submitted_at'),
+                        blank: fn (Builder $query): Builder => $query,
+                    ),
+                Tables\Filters\TernaryFilter::make('has_result')
+                    ->label('Has result')
+                    ->queries(
+                        true: fn (Builder $query): Builder => $query->whereExists(function ($resultQuery): void {
+                            $resultQuery
+                                ->selectRaw('1')
+                                ->from('results')
+                                ->whereColumn('results.attempt_id', 'attempts.id');
+                        }),
+                        false: fn (Builder $query): Builder => $query->whereNotExists(function ($resultQuery): void {
+                            $resultQuery
+                                ->selectRaw('1')
+                                ->from('results')
+                                ->whereColumn('results.attempt_id', 'attempts.id');
+                        }),
+                        blank: fn (Builder $query): Builder => $query,
+                    ),
+                Tables\Filters\TernaryFilter::make('has_report_snapshot')
+                    ->label('Has report snapshot')
+                    ->queries(
+                        true: fn (Builder $query): Builder => $query->whereExists(function ($snapshotQuery): void {
+                            $snapshotQuery
+                                ->selectRaw('1')
+                                ->from('report_snapshots')
+                                ->whereColumn('report_snapshots.attempt_id', 'attempts.id');
+                        }),
+                        false: fn (Builder $query): Builder => $query->whereNotExists(function ($snapshotQuery): void {
+                            $snapshotQuery
+                                ->selectRaw('1')
+                                ->from('report_snapshots')
+                                ->whereColumn('report_snapshots.attempt_id', 'attempts.id');
+                        }),
+                        blank: fn (Builder $query): Builder => $query,
+                    ),
+                Tables\Filters\SelectFilter::make('unlock_status')
+                    ->label('Unlock / commerce')
+                    ->options([
+                        'unlocked' => 'unlocked',
+                        'paid_pending' => 'paid_pending',
+                        'payment_pending' => 'payment_pending',
+                        'refunded' => 'refunded',
+                        'no_order' => 'no_order',
+                    ])
+                    ->query(function (Builder $query, array $data): void {
+                        app(AttemptExplorerSupport::class)->applyUnlockStatusFilter($query, $data['value'] ?? null);
+                    }),
+                Tables\Filters\SelectFilter::make('pack_id')
+                    ->options(fn (): array => app(AttemptExplorerSupport::class)->distinctAttemptOptions('pack_id')),
+                Tables\Filters\SelectFilter::make('scoring_spec_version')
+                    ->options(fn (): array => app(AttemptExplorerSupport::class)->distinctAttemptOptions('scoring_spec_version')),
+                Tables\Filters\SelectFilter::make('norm_version')
+                    ->options(fn (): array => app(AttemptExplorerSupport::class)->distinctAttemptOptions('norm_version')),
+                Tables\Filters\SelectFilter::make('report_engine_version')
+                    ->options(fn (): array => app(AttemptExplorerSupport::class)->distinctReportEngineVersionOptions())
+                    ->query(function (Builder $query, array $data): void {
+                        app(AttemptExplorerSupport::class)->applyReportEngineVersionFilter($query, $data['value'] ?? null);
+                    }),
+            ])
+            ->filtersLayout(FiltersLayout::AboveContentCollapsible)
+            ->filtersFormColumns(4)
+            ->actions([
+                Tables\Actions\ViewAction::make(),
+            ])
+            ->bulkActions([]);
+    }
+
+    public static function getPages(): array
+    {
+        return [
+            'index' => Pages\ListAttempts::route('/'),
+            'view' => Pages\ViewAttempt::route('/{record}'),
+        ];
+    }
+
+    public static function getEloquentQuery(): Builder
+    {
+        return app(AttemptExplorerSupport::class)->query();
+    }
+
+    private static function canSupportAccess(): bool
+    {
+        $guard = (string) config('admin.guard', 'admin');
+        $user = auth($guard)->user();
+
+        return is_object($user)
+            && method_exists($user, 'hasPermission')
+            && (
+                $user->hasPermission(PermissionNames::ADMIN_MENU_SUPPORT)
+                || $user->hasPermission(PermissionNames::ADMIN_OPS_READ)
+                || $user->hasPermission(PermissionNames::ADMIN_OWNER)
+            );
+    }
+}

--- a/backend/app/Filament/Ops/Resources/AttemptResource/Pages/ListAttempts.php
+++ b/backend/app/Filament/Ops/Resources/AttemptResource/Pages/ListAttempts.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Filament\Ops\Resources\AttemptResource\Pages;
+
+use App\Filament\Ops\Resources\AttemptResource;
+use App\Filament\Ops\Resources\Pages\Concerns\HasSharedListEmptyState;
+use Filament\Resources\Pages\ListRecords;
+
+class ListAttempts extends ListRecords
+{
+    use HasSharedListEmptyState;
+
+    protected static string $resource = AttemptResource::class;
+
+    public function getTitle(): string
+    {
+        return 'Attempts Explorer';
+    }
+
+    protected function getHeaderActions(): array
+    {
+        return [];
+    }
+}

--- a/backend/app/Filament/Ops/Resources/AttemptResource/Pages/ViewAttempt.php
+++ b/backend/app/Filament/Ops/Resources/AttemptResource/Pages/ViewAttempt.php
@@ -1,0 +1,87 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Filament\Ops\Resources\AttemptResource\Pages;
+
+use App\Filament\Ops\Resources\AttemptResource;
+use App\Filament\Ops\Resources\AttemptResource\Support\AttemptExplorerSupport;
+use Filament\Resources\Pages\ViewRecord;
+
+class ViewAttempt extends ViewRecord
+{
+    protected static string $resource = AttemptResource::class;
+
+    protected static string $view = 'filament.ops.resources.attempts.view-attempt';
+
+    /**
+     * @var array<string, array{label:string,state:string}>
+     */
+    public array $headline = [];
+
+    /**
+     * @var array{fields:list<array{label:string,value:string,hint:?string,kind:string,state:?string}>}
+     */
+    public array $attemptSummary = ['fields' => []];
+
+    /**
+     * @var array{fields:list<array{label:string,value:string,hint:?string,kind:string,state:?string}>,notes:list<string>}
+     */
+    public array $answersSummary = ['fields' => [], 'notes' => []];
+
+    /**
+     * @var array{fields:list<array{label:string,value:string,hint:?string,kind:string,state:?string}>,notes:list<string>}
+     */
+    public array $resultSummary = ['fields' => [], 'notes' => []];
+
+    /**
+     * @var array{fields:list<array{label:string,value:string,hint:?string,kind:string,state:?string}>,notes:list<string>}
+     */
+    public array $reportSummary = ['fields' => [], 'notes' => []];
+
+    /**
+     * @var array{fields:list<array{label:string,value:string,hint:?string,kind:string,state:?string}>,notes:list<string>}
+     */
+    public array $commerceSummary = ['fields' => [], 'notes' => []];
+
+    /**
+     * @var list<array{title:string,occurred_at:string,meta:list<string>,share_id:string,channel:string}>
+     */
+    public array $eventTimeline = [];
+
+    /**
+     * @var list<array{label:string,url:string,kind:string}>
+     */
+    public array $links = [];
+
+    public function mount(int|string $record): void
+    {
+        parent::mount($record);
+
+        $detail = app(AttemptExplorerSupport::class)->buildDetail($this->getRecord());
+
+        $this->headline = $detail['headline'];
+        $this->attemptSummary = $detail['attempt_summary'];
+        $this->answersSummary = $detail['answers_summary'];
+        $this->resultSummary = $detail['result_summary'];
+        $this->reportSummary = $detail['report_summary'];
+        $this->commerceSummary = $detail['commerce_summary'];
+        $this->eventTimeline = $detail['event_timeline'];
+        $this->links = $detail['links'];
+    }
+
+    public function getTitle(): string
+    {
+        return 'Attempt Diagnostics';
+    }
+
+    public function getBreadcrumb(): string
+    {
+        return (string) $this->getRecord()->getKey();
+    }
+
+    protected function getHeaderActions(): array
+    {
+        return [];
+    }
+}

--- a/backend/app/Filament/Ops/Resources/AttemptResource/Support/AttemptExplorerSupport.php
+++ b/backend/app/Filament/Ops/Resources/AttemptResource/Support/AttemptExplorerSupport.php
@@ -1,0 +1,1183 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Filament\Ops\Resources\AttemptResource\Support;
+
+use App\Models\Attempt;
+use App\Support\SchemaBaseline;
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Query\Builder as QueryBuilder;
+use Illuminate\Support\Carbon;
+use Illuminate\Support\Facades\DB;
+
+final class AttemptExplorerSupport
+{
+    /**
+     * @return Builder<Attempt>
+     */
+    public function query(): Builder
+    {
+        $query = Attempt::query()
+            ->withoutGlobalScopes()
+            ->select('attempts.*')
+            ->selectRaw('coalesce(attempts.submitted_at, attempts.created_at) as activity_at');
+
+        if (SchemaBaseline::hasTable('attempt_submissions')) {
+            $query
+                ->selectSub($this->latestAttemptSubmissionField('state'), 'latest_submission_state')
+                ->selectSub($this->latestAttemptSubmissionField('mode'), 'latest_submission_mode');
+        }
+
+        if (SchemaBaseline::hasTable('results')) {
+            $query
+                ->selectSub($this->latestAttemptResultField('id'), 'latest_result_id')
+                ->selectSub($this->latestAttemptResultField('type_code'), 'latest_result_type_code')
+                ->selectSub($this->latestAttemptResultField('computed_at'), 'latest_result_computed_at')
+                ->selectSub($this->latestAttemptResultField('report_engine_version'), 'latest_result_report_engine_version');
+        }
+
+        if (SchemaBaseline::hasTable('report_snapshots')) {
+            $query
+                ->selectSub($this->latestReportSnapshotField('status'), 'latest_report_snapshot_status')
+                ->selectSub($this->latestReportSnapshotField('order_no'), 'latest_snapshot_order_no')
+                ->selectSub($this->latestReportSnapshotField('report_engine_version'), 'latest_snapshot_report_engine_version');
+        }
+
+        if (SchemaBaseline::hasTable('orders')) {
+            $query
+                ->selectSub($this->latestAttemptOrderField('order_no'), 'latest_order_no')
+                ->selectSub($this->latestAttemptOrderField('status'), 'latest_order_status')
+                ->selectSub($this->latestAttemptOrderField('provider'), 'latest_order_provider')
+                ->selectSub($this->latestAttemptOrderField('paid_at'), 'latest_order_paid_at');
+        }
+
+        if (SchemaBaseline::hasTable('payment_events')) {
+            $query->selectSub($this->latestAttemptPaymentField('status'), 'latest_payment_status');
+        }
+
+        if (SchemaBaseline::hasTable('benefit_grants')) {
+            $query->selectSub($this->latestAttemptBenefitField('status'), 'latest_benefit_status');
+        }
+
+        if (SchemaBaseline::hasTable('shares')) {
+            $query->selectSub($this->latestAttemptShareField('id'), 'latest_share_id');
+        }
+
+        return $query;
+    }
+
+    /**
+     * @param  Builder<Attempt>  $query
+     */
+    public function applySearch(Builder $query, string $search): void
+    {
+        $needle = trim($search);
+        if ($needle === '') {
+            return;
+        }
+
+        $like = '%'.$needle.'%';
+
+        $query->where(function (Builder $attemptQuery) use ($like): void {
+            $attemptQuery
+                ->where('attempts.id', 'like', $like)
+                ->orWhere('attempts.anon_id', 'like', $like)
+                ->orWhere('attempts.user_id', 'like', $like)
+                ->orWhere('attempts.ticket_code', 'like', $like);
+
+            if (SchemaBaseline::hasTable('orders')) {
+                $attemptQuery->orWhereExists(function (QueryBuilder $orderQuery) use ($like): void {
+                    $orderQuery
+                        ->selectRaw('1')
+                        ->from('orders')
+                        ->whereColumn('orders.target_attempt_id', 'attempts.id')
+                        ->where('orders.order_no', 'like', $like);
+                });
+            }
+
+            if (SchemaBaseline::hasTable('shares')) {
+                $attemptQuery->orWhereExists(function (QueryBuilder $shareQuery) use ($like): void {
+                    $shareQuery
+                        ->selectRaw('1')
+                        ->from('shares')
+                        ->whereColumn('shares.attempt_id', 'attempts.id')
+                        ->where('shares.id', 'like', $like);
+                });
+            }
+        });
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    public function distinctAttemptOptions(string $column): array
+    {
+        if (! SchemaBaseline::hasColumn('attempts', $column)) {
+            return [];
+        }
+
+        return DB::table('attempts')
+            ->whereNotNull($column)
+            ->where($column, '!=', '')
+            ->distinct()
+            ->orderBy($column)
+            ->pluck($column, $column)
+            ->mapWithKeys(fn ($value): array => [(string) $value => (string) $value])
+            ->all();
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    public function distinctReportEngineVersionOptions(): array
+    {
+        $values = collect();
+
+        if (SchemaBaseline::hasColumn('results', 'report_engine_version')) {
+            $values = $values->merge(
+                DB::table('results')
+                    ->whereNotNull('report_engine_version')
+                    ->where('report_engine_version', '!=', '')
+                    ->distinct()
+                    ->pluck('report_engine_version')
+                    ->map(fn ($value): string => (string) $value)
+            );
+        }
+
+        if (SchemaBaseline::hasColumn('report_snapshots', 'report_engine_version')) {
+            $values = $values->merge(
+                DB::table('report_snapshots')
+                    ->whereNotNull('report_engine_version')
+                    ->where('report_engine_version', '!=', '')
+                    ->distinct()
+                    ->pluck('report_engine_version')
+                    ->map(fn ($value): string => (string) $value)
+            );
+        }
+
+        return $values
+            ->filter(fn (string $value): bool => $value !== '')
+            ->unique()
+            ->sort()
+            ->mapWithKeys(fn (string $value): array => [$value => $value])
+            ->all();
+    }
+
+    /**
+     * @param  Builder<Attempt>  $query
+     */
+    public function applyUnlockStatusFilter(Builder $query, ?string $value): void
+    {
+        $status = strtolower(trim((string) $value));
+        if ($status === '') {
+            return;
+        }
+
+        match ($status) {
+            'unlocked' => $query->whereExists($this->activeBenefitExistsQuery()),
+            'paid_pending' => $query->whereExists($this->paidOrderExistsQuery())
+                ->whereNotExists($this->activeBenefitExistsQuery()),
+            'payment_pending' => $query->whereExists($this->orderExistsQuery())
+                ->whereNotExists($this->paidOrderExistsQuery())
+                ->whereNotExists($this->refundedOrderExistsQuery()),
+            'refunded' => $query->whereExists($this->refundedOrderExistsQuery()),
+            'no_order' => $query->whereNotExists($this->orderExistsQuery()),
+            default => null,
+        };
+    }
+
+    /**
+     * @param  Builder<Attempt>  $query
+     */
+    public function applyReportEngineVersionFilter(Builder $query, ?string $value): void
+    {
+        $version = trim((string) $value);
+        if ($version === '') {
+            return;
+        }
+
+        $query->where(function (Builder $builder) use ($version): void {
+            if (SchemaBaseline::hasColumn('results', 'report_engine_version')) {
+                $builder->whereExists(function (QueryBuilder $resultQuery) use ($version): void {
+                    $resultQuery
+                        ->selectRaw('1')
+                        ->from('results')
+                        ->whereColumn('results.attempt_id', 'attempts.id')
+                        ->where('results.report_engine_version', $version);
+                });
+            }
+
+            if (SchemaBaseline::hasColumn('report_snapshots', 'report_engine_version')) {
+                $builder->orWhereExists(function (QueryBuilder $snapshotQuery) use ($version): void {
+                    $snapshotQuery
+                        ->selectRaw('1')
+                        ->from('report_snapshots')
+                        ->whereColumn('report_snapshots.attempt_id', 'attempts.id')
+                        ->where('report_snapshots.report_engine_version', $version);
+                });
+            }
+        });
+    }
+
+    /**
+     * @return array{label:string,state:string}
+     */
+    public function submittedStatus(Attempt $attempt): array
+    {
+        $state = strtolower(trim((string) ($attempt->latest_submission_state ?? '')));
+
+        if ($state !== '') {
+            return [
+                'label' => $state,
+                'state' => match ($state) {
+                    'succeeded', 'ready' => 'success',
+                    'pending', 'running' => 'warning',
+                    'failed' => 'danger',
+                    default => 'gray',
+                },
+            ];
+        }
+
+        if ($attempt->submitted_at !== null) {
+            return ['label' => 'submitted', 'state' => 'success'];
+        }
+
+        return ['label' => 'draft', 'state' => 'gray'];
+    }
+
+    /**
+     * @return array{label:string,state:string}
+     */
+    public function resultStatus(Attempt $attempt): array
+    {
+        return filled((string) ($attempt->latest_result_id ?? ''))
+            ? ['label' => 'present', 'state' => 'success']
+            : ['label' => 'missing', 'state' => 'gray'];
+    }
+
+    /**
+     * @return array{label:string,state:string}
+     */
+    public function reportStatus(Attempt $attempt): array
+    {
+        $status = strtolower(trim((string) ($attempt->latest_report_snapshot_status ?? '')));
+
+        if ($status === '') {
+            return ['label' => 'missing', 'state' => 'gray'];
+        }
+
+        return [
+            'label' => $status,
+            'state' => match (true) {
+                in_array($status, ['ready', 'full', 'completed'], true) => 'success',
+                in_array($status, ['pending', 'queued', 'running'], true) => 'warning',
+                in_array($status, ['failed', 'error'], true) => 'danger',
+                default => 'gray',
+            },
+        ];
+    }
+
+    /**
+     * @return array{label:string,state:string}
+     */
+    public function unlockStatus(Attempt $attempt): array
+    {
+        $benefitStatus = strtolower(trim((string) ($attempt->latest_benefit_status ?? '')));
+        $orderStatus = strtolower(trim((string) ($attempt->latest_order_status ?? '')));
+        $paymentStatus = strtolower(trim((string) ($attempt->latest_payment_status ?? '')));
+
+        if ($benefitStatus === 'active') {
+            return ['label' => 'unlocked', 'state' => 'success'];
+        }
+
+        if ($this->isPaidLike($orderStatus) || $this->isPaidLike($paymentStatus)) {
+            return ['label' => 'paid_pending', 'state' => 'warning'];
+        }
+
+        if ($this->isRefundedLike($orderStatus)) {
+            return ['label' => 'refunded', 'state' => 'danger'];
+        }
+
+        if ($orderStatus !== '') {
+            return ['label' => 'payment_pending', 'state' => 'gray'];
+        }
+
+        return ['label' => 'no_order', 'state' => 'gray'];
+    }
+
+    public function latestOrderNo(Attempt $attempt): string
+    {
+        $orderNo = trim((string) ($attempt->latest_order_no ?? ''));
+        if ($orderNo !== '') {
+            return $orderNo;
+        }
+
+        return trim((string) ($attempt->latest_snapshot_order_no ?? ''));
+    }
+
+    public function latestShareId(Attempt $attempt): string
+    {
+        return trim((string) ($attempt->latest_share_id ?? ''));
+    }
+
+    public function reportEngineVersion(Attempt $attempt): string
+    {
+        $resultVersion = trim((string) ($attempt->latest_result_report_engine_version ?? ''));
+        if ($resultVersion !== '') {
+            return $resultVersion;
+        }
+
+        return trim((string) ($attempt->latest_snapshot_report_engine_version ?? ''));
+    }
+
+    /**
+     * @return array{
+     *   headline: array<string, array{label:string,state:string}>,
+     *   attempt_summary: array{fields:list<array{label:string,value:string,hint:?string,kind:string,state:?string}>},
+     *   answers_summary: array{fields:list<array{label:string,value:string,hint:?string,kind:string,state:?string}>,notes:list<string>},
+     *   result_summary: array{fields:list<array{label:string,value:string,hint:?string,kind:string,state:?string}>,notes:list<string>},
+     *   report_summary: array{fields:list<array{label:string,value:string,hint:?string,kind:string,state:?string}>,notes:list<string>},
+     *   commerce_summary: array{fields:list<array{label:string,value:string,hint:?string,kind:string,state:?string}>,notes:list<string>},
+     *   event_timeline: list<array{title:string,occurred_at:string,meta:list<string>,share_id:string,channel:string}>,
+     *   links: list<array{label:string,url:string,kind:string}>
+     * }
+     */
+    public function buildDetail(Attempt $attempt): array
+    {
+        $result = $this->fetchResult($attempt);
+        $snapshot = $this->fetchReportSnapshot($attempt);
+        $answerSummary = $this->fetchAnswersSummary($attempt);
+        $commerce = $this->fetchCommerceSummary($attempt);
+        $timeline = $this->fetchEventTimeline($attempt, $commerce['share_id']);
+        $reportJobSummary = $this->fetchReportJobSummary($attempt);
+        $localeSegment = $this->frontendLocaleSegment((string) ($attempt->locale ?? ''));
+
+        $headline = [
+            'submitted' => $this->submittedStatus($attempt),
+            'result' => $this->resultStatus($attempt),
+            'report' => $this->reportStatus($attempt),
+            'unlock' => $this->unlockStatus($attempt),
+        ];
+
+        $attemptSummary = [
+            'fields' => [
+                $this->field('attempt_id', (string) $attempt->id),
+                $this->field('org_id', (string) ($attempt->org_id ?? '-')),
+                $this->field('user_id', $this->stringOrDash($attempt->user_id)),
+                $this->field('anon_id', $this->stringOrDash($attempt->anon_id)),
+                $this->field('scale_code', $this->stringOrDash($attempt->scale_code)),
+                $this->field('scale_uid', $this->stringOrDash($attempt->scale_uid)),
+                $this->field('locale', $this->stringOrDash($attempt->locale)),
+                $this->field('region', $this->stringOrDash($attempt->region)),
+                $this->field('channel', $this->stringOrDash($attempt->channel)),
+                $this->field('created_at', $this->formatTimestamp($attempt->created_at)),
+                $this->field('submitted_at', $this->formatTimestamp($attempt->submitted_at)),
+                $this->pillField('status', $headline['submitted']['label'], $headline['submitted']['state'], $this->stringOrNull($attempt->latest_submission_mode)),
+                $this->field('pack_id', $this->stringOrDash($attempt->pack_id)),
+                $this->field('dir_version', $this->stringOrDash($attempt->dir_version)),
+                $this->field('content_package_version', $this->stringOrDash($attempt->content_package_version)),
+                $this->field('scoring_spec_version', $this->stringOrDash($attempt->scoring_spec_version)),
+                $this->field('norm_version', $this->stringOrDash($attempt->norm_version)),
+                $this->field('scale_version', $this->stringOrDash($attempt->scale_version)),
+                $this->field('report_engine_version', $this->stringOrDash($this->reportEngineVersion($attempt))),
+            ],
+        ];
+
+        $answersSummarySection = [
+            'fields' => [
+                $this->pillField('answer_set', $answerSummary['exists'] ? 'present' : 'missing', $answerSummary['exists'] ? 'success' : 'gray'),
+                $this->field('answers_hash', $answerSummary['answers_hash']),
+                $this->field('row_count', (string) $answerSummary['row_count']),
+                $this->pillField('storage_mode', $answerSummary['storage_mode'], $answerSummary['storage_state']),
+                $this->field('question_count', $answerSummary['question_count']),
+            ],
+            'notes' => $answerSummary['notes'],
+        ];
+
+        $resultSummarySection = [
+            'fields' => [
+                $this->pillField('result', $result['exists'] ? 'present' : 'missing', $result['exists'] ? 'success' : 'gray'),
+                $this->field('computed_at', $result['computed_at']),
+                $this->field('type_code', $result['type_code']),
+                $this->pillField('validity', $result['validity_label'], $result['validity_state']),
+                $this->field('profile_version', $result['profile_version']),
+                $this->field('content_package_version', $result['content_package_version']),
+                $this->field('scoring_spec_version', $result['scoring_spec_version']),
+                $this->field('report_engine_version', $result['report_engine_version']),
+            ],
+            'notes' => $result['notes'],
+        ];
+
+        $reportSummarySection = [
+            'fields' => [
+                $this->pillField('snapshot', $snapshot['exists'] ? 'present' : 'missing', $snapshot['exists'] ? 'success' : 'gray'),
+                $this->pillField('status', $snapshot['status'], $snapshot['status_state']),
+                $this->pillField('locked', $snapshot['locked'], $snapshot['locked_state']),
+                $this->field('access_level', $snapshot['access_level']),
+                $this->field('variant', $snapshot['variant']),
+                $this->field('pack_id', $snapshot['pack_id']),
+                $this->field('dir_version', $snapshot['dir_version']),
+                $this->field('scoring_spec_version', $snapshot['scoring_spec_version']),
+                $this->field('report_engine_version', $snapshot['report_engine_version']),
+                $this->field('snapshot_version', $snapshot['snapshot_version']),
+                $this->field('report_jobs', $reportJobSummary['summary'], $reportJobSummary['hint']),
+            ],
+            'notes' => $snapshot['notes'],
+        ];
+
+        $commerceSummarySection = [
+            'fields' => [
+                $this->field('order_no', $commerce['order_no']),
+                $this->pillField('order_status', $commerce['order_status'], $commerce['order_status_state']),
+                $this->field('payment_summary', $commerce['payment_summary'], $commerce['payment_hint']),
+                $this->field('active_benefit_grant', $commerce['benefit_summary'], $commerce['benefit_hint']),
+                $this->field('entitlement', $commerce['entitlement']),
+                $this->field('delivery', $commerce['delivery']),
+                $this->field('claim', $commerce['claim']),
+                $this->field('share_id', $commerce['share_id']),
+            ],
+            'notes' => $commerce['notes'],
+        ];
+
+        return [
+            'headline' => $headline,
+            'attempt_summary' => $attemptSummary,
+            'answers_summary' => $answersSummarySection,
+            'result_summary' => $resultSummarySection,
+            'report_summary' => $reportSummarySection,
+            'commerce_summary' => $commerceSummarySection,
+            'event_timeline' => $timeline,
+            'links' => $this->buildLinks($attempt, $localeSegment, $commerce['order_no'], $commerce['share_id']),
+        ];
+    }
+
+    private function latestAttemptSubmissionField(string $column): QueryBuilder
+    {
+        return DB::table('attempt_submissions')
+            ->select($column)
+            ->whereColumn('attempt_submissions.attempt_id', 'attempts.id')
+            ->orderByRaw('coalesce(finished_at, updated_at, created_at) desc')
+            ->limit(1);
+    }
+
+    private function latestAttemptResultField(string $column): QueryBuilder
+    {
+        return DB::table('results')
+            ->select($column)
+            ->whereColumn('results.attempt_id', 'attempts.id')
+            ->orderByRaw('coalesce(computed_at, updated_at, created_at) desc')
+            ->limit(1);
+    }
+
+    private function latestReportSnapshotField(string $column): QueryBuilder
+    {
+        return DB::table('report_snapshots')
+            ->select($column)
+            ->whereColumn('report_snapshots.attempt_id', 'attempts.id')
+            ->orderByRaw('coalesce(updated_at, created_at) desc')
+            ->limit(1);
+    }
+
+    private function latestAttemptOrderField(string $column): QueryBuilder
+    {
+        return DB::table('orders')
+            ->select($column)
+            ->whereColumn('orders.target_attempt_id', 'attempts.id')
+            ->orderByRaw('coalesce(paid_at, updated_at, created_at) desc')
+            ->limit(1);
+    }
+
+    private function latestAttemptPaymentField(string $column): QueryBuilder
+    {
+        return DB::table('payment_events')
+            ->select($column)
+            ->whereExists(function (QueryBuilder $orderQuery): void {
+                $orderQuery
+                    ->selectRaw('1')
+                    ->from('orders')
+                    ->whereColumn('orders.order_no', 'payment_events.order_no')
+                    ->whereColumn('orders.target_attempt_id', 'attempts.id');
+            })
+            ->orderByRaw('coalesce(processed_at, updated_at, created_at) desc')
+            ->limit(1);
+    }
+
+    private function latestAttemptBenefitField(string $column): QueryBuilder
+    {
+        return DB::table('benefit_grants')
+            ->select($column)
+            ->where(function (QueryBuilder $benefitQuery): void {
+                $benefitQuery->whereColumn('benefit_grants.attempt_id', 'attempts.id')
+                    ->orWhereExists(function (QueryBuilder $orderQuery): void {
+                        $orderQuery
+                            ->selectRaw('1')
+                            ->from('orders')
+                            ->whereColumn('orders.order_no', 'benefit_grants.order_no')
+                            ->whereColumn('orders.target_attempt_id', 'attempts.id');
+                    });
+            })
+            ->orderByRaw("case when lower(status) = 'active' then 0 else 1 end")
+            ->orderByRaw('coalesce(updated_at, created_at) desc')
+            ->limit(1);
+    }
+
+    private function latestAttemptShareField(string $column): QueryBuilder
+    {
+        return DB::table('shares')
+            ->select($column)
+            ->whereColumn('shares.attempt_id', 'attempts.id')
+            ->orderByDesc('created_at')
+            ->limit(1);
+    }
+
+    private function orderExistsQuery(): \Closure
+    {
+        return function (QueryBuilder $orderQuery): void {
+            if (! SchemaBaseline::hasTable('orders')) {
+                $orderQuery->selectRaw('1')->fromRaw('(select 1) as noop')->whereRaw('1 = 0');
+
+                return;
+            }
+
+            $orderQuery
+                ->selectRaw('1')
+                ->from('orders')
+                ->whereColumn('orders.target_attempt_id', 'attempts.id');
+        };
+    }
+
+    private function paidOrderExistsQuery(): \Closure
+    {
+        return function (QueryBuilder $orderQuery): void {
+            if (! SchemaBaseline::hasTable('orders')) {
+                $orderQuery->selectRaw('1')->fromRaw('(select 1) as noop')->whereRaw('1 = 0');
+
+                return;
+            }
+
+            $orderQuery
+                ->selectRaw('1')
+                ->from('orders')
+                ->whereColumn('orders.target_attempt_id', 'attempts.id')
+                ->where(function (QueryBuilder $builder): void {
+                    $builder->whereRaw("lower(coalesce(orders.status, '')) in (?, ?, ?, ?)", ['paid', 'fulfilled', 'complete', 'completed']);
+
+                    if (SchemaBaseline::hasColumn('orders', 'paid_at')) {
+                        $builder->orWhereNotNull('orders.paid_at');
+                    }
+                });
+        };
+    }
+
+    private function refundedOrderExistsQuery(): \Closure
+    {
+        return function (QueryBuilder $orderQuery): void {
+            if (! SchemaBaseline::hasTable('orders')) {
+                $orderQuery->selectRaw('1')->fromRaw('(select 1) as noop')->whereRaw('1 = 0');
+
+                return;
+            }
+
+            $orderQuery
+                ->selectRaw('1')
+                ->from('orders')
+                ->whereColumn('orders.target_attempt_id', 'attempts.id')
+                ->where(function (QueryBuilder $builder): void {
+                    $builder->whereRaw("lower(coalesce(orders.status, '')) like ?", ['%refund%']);
+
+                    if (SchemaBaseline::hasColumn('orders', 'refunded_at')) {
+                        $builder->orWhereNotNull('orders.refunded_at');
+                    }
+                });
+        };
+    }
+
+    private function activeBenefitExistsQuery(): \Closure
+    {
+        return function (QueryBuilder $benefitQuery): void {
+            if (! SchemaBaseline::hasTable('benefit_grants')) {
+                $benefitQuery->selectRaw('1')->fromRaw('(select 1) as noop')->whereRaw('1 = 0');
+
+                return;
+            }
+
+            $benefitQuery
+                ->selectRaw('1')
+                ->from('benefit_grants')
+                ->where('benefit_grants.status', 'active')
+                ->where(function (QueryBuilder $builder): void {
+                    $builder->whereColumn('benefit_grants.attempt_id', 'attempts.id')
+                        ->orWhereExists(function (QueryBuilder $orderQuery): void {
+                            $orderQuery
+                                ->selectRaw('1')
+                                ->from('orders')
+                                ->whereColumn('orders.order_no', 'benefit_grants.order_no')
+                                ->whereColumn('orders.target_attempt_id', 'attempts.id');
+                        });
+                });
+        };
+    }
+
+    /**
+     * @return array{
+     *   exists:bool,
+     *   answers_hash:string,
+     *   row_count:int,
+     *   question_count:string,
+     *   storage_mode:string,
+     *   storage_state:string,
+     *   notes:list<string>
+     * }
+     */
+    private function fetchAnswersSummary(Attempt $attempt): array
+    {
+        $answerSet = null;
+
+        if (SchemaBaseline::hasTable('attempt_answer_sets')) {
+            $answerSet = DB::table('attempt_answer_sets')
+                ->where('attempt_id', (string) $attempt->id)
+                ->first();
+        }
+
+        $rowCount = 0;
+        if (SchemaBaseline::hasTable('attempt_answer_rows')) {
+            $rowCount = (int) DB::table('attempt_answer_rows')
+                ->where('attempt_id', (string) $attempt->id)
+                ->count();
+        }
+
+        $scaleCode = strtoupper(trim((string) ($attempt->scale_code ?? '')));
+        $answersHash = trim((string) (($answerSet->answers_hash ?? null) ?: ($attempt->answers_hash ?? '')));
+        $questionCount = (string) (($answerSet->question_count ?? null) ?: ($attempt->question_count ?? '-'));
+        $storedAnswers = $answerSet->answers_json ?? null;
+
+        $storageMode = 'missing';
+        $storageState = 'gray';
+
+        if ($answerSet !== null) {
+            if ($scaleCode === 'CLINICAL_COMBO_68' || ($storedAnswers === null && $rowCount === 0 && $answersHash !== '')) {
+                $storageMode = 'rowless';
+                $storageState = 'warning';
+            } elseif ($storedAnswers === null && $rowCount > 0) {
+                $storageMode = 'redacted';
+                $storageState = 'warning';
+            } elseif ($storedAnswers !== null) {
+                $storageMode = 'full';
+                $storageState = 'success';
+            }
+        }
+
+        $notes = [];
+        if ($scaleCode === 'CLINICAL_COMBO_68') {
+            $notes[] = 'Clinical assessments default to rowless storage.';
+        }
+        if ($scaleCode === 'SDS_20') {
+            $notes[] = 'SDS answer rows stay redacted by design.';
+        }
+        $notes[] = 'Raw answers stay hidden here. Only answer-set presence, hash, row count, and storage mode are shown.';
+
+        return [
+            'exists' => $answerSet !== null,
+            'answers_hash' => $answersHash !== '' ? $answersHash : '-',
+            'row_count' => $rowCount,
+            'question_count' => $questionCount !== '' ? $questionCount : '-',
+            'storage_mode' => $storageMode,
+            'storage_state' => $storageState,
+            'notes' => $notes,
+        ];
+    }
+
+    /**
+     * @return array{
+     *   exists:bool,
+     *   computed_at:string,
+     *   type_code:string,
+     *   validity_label:string,
+     *   validity_state:string,
+     *   profile_version:string,
+     *   content_package_version:string,
+     *   scoring_spec_version:string,
+     *   report_engine_version:string,
+     *   notes:list<string>
+     * }
+     */
+    private function fetchResult(Attempt $attempt): array
+    {
+        $row = null;
+
+        if (SchemaBaseline::hasTable('results')) {
+            $row = DB::table('results')
+                ->where('attempt_id', (string) $attempt->id)
+                ->orderByRaw('coalesce(computed_at, updated_at, created_at) desc')
+                ->first();
+        }
+
+        $resultJson = $this->decodeJson($row->result_json ?? null);
+        $attemptResultJson = $this->decodeJson($attempt->result_json ?? null);
+        $notes = [];
+
+        if (! empty($attemptResultJson)) {
+            $notes[] = 'Public attempt cache is present on attempts.result_json.';
+        }
+
+        if (! empty($resultJson)) {
+            $notes[] = 'Private result row is present on results.result_json.';
+        }
+
+        if ($row === null) {
+            return [
+                'exists' => false,
+                'computed_at' => '-',
+                'type_code' => '-',
+                'validity_label' => 'unknown',
+                'validity_state' => 'gray',
+                'profile_version' => '-',
+                'content_package_version' => '-',
+                'scoring_spec_version' => '-',
+                'report_engine_version' => $this->stringOrDash($this->reportEngineVersion($attempt)),
+                'notes' => $notes === [] ? ['No result row found for this attempt yet.'] : $notes,
+            ];
+        }
+
+        $validity = is_null($row->is_valid ?? null)
+            ? ['label' => 'unknown', 'state' => 'gray']
+            : ((bool) $row->is_valid ? ['label' => 'valid', 'state' => 'success'] : ['label' => 'invalid', 'state' => 'danger']);
+
+        return [
+            'exists' => true,
+            'computed_at' => $this->formatTimestamp($row->computed_at ?? null),
+            'type_code' => $this->stringOrDash($row->type_code ?? null),
+            'validity_label' => $validity['label'],
+            'validity_state' => $validity['state'],
+            'profile_version' => $this->stringOrDash($row->profile_version ?? null),
+            'content_package_version' => $this->stringOrDash($row->content_package_version ?? null),
+            'scoring_spec_version' => $this->stringOrDash($row->scoring_spec_version ?? null),
+            'report_engine_version' => $this->stringOrDash($row->report_engine_version ?? null),
+            'notes' => $notes === [] ? ['Result payload stays collapsed here.'] : $notes,
+        ];
+    }
+
+    /**
+     * @return array{
+     *   exists:bool,
+     *   status:string,
+     *   status_state:string,
+     *   locked:string,
+     *   locked_state:string,
+     *   access_level:string,
+     *   variant:string,
+     *   pack_id:string,
+     *   dir_version:string,
+     *   scoring_spec_version:string,
+     *   report_engine_version:string,
+     *   snapshot_version:string,
+     *   notes:list<string>
+     * }
+     */
+    private function fetchReportSnapshot(Attempt $attempt): array
+    {
+        $row = null;
+
+        if (SchemaBaseline::hasTable('report_snapshots')) {
+            $row = DB::table('report_snapshots')
+                ->where('attempt_id', (string) $attempt->id)
+                ->orderByRaw('coalesce(updated_at, created_at) desc')
+                ->first();
+        }
+
+        if ($row === null) {
+            return [
+                'exists' => false,
+                'status' => 'missing',
+                'status_state' => 'gray',
+                'locked' => '-',
+                'locked_state' => 'gray',
+                'access_level' => '-',
+                'variant' => '-',
+                'pack_id' => '-',
+                'dir_version' => '-',
+                'scoring_spec_version' => '-',
+                'report_engine_version' => $this->stringOrDash($this->reportEngineVersion($attempt)),
+                'snapshot_version' => '-',
+                'notes' => ['No report snapshot row found for this attempt yet.'],
+            ];
+        }
+
+        $reportJson = $this->decodeJson($row->report_json ?? null);
+        $locked = $this->normalizeBooleanLabel(data_get($reportJson, 'locked'));
+        $variant = $this->stringOrDash(data_get($reportJson, 'variant'));
+        $accessLevel = $this->stringOrDash(data_get($reportJson, 'access_level'));
+        $notes = [];
+
+        if ($row->report_free_json !== null) {
+            $notes[] = 'Free snapshot payload is present.';
+        }
+
+        if ($row->report_full_json !== null) {
+            $notes[] = 'Full snapshot payload is present.';
+        }
+
+        $notes[] = 'Report payload JSON stays collapsed here.';
+
+        return [
+            'exists' => true,
+            'status' => $this->stringOrDash($row->status ?? null),
+            'status_state' => $this->statusState((string) ($row->status ?? '')),
+            'locked' => $locked['label'],
+            'locked_state' => $locked['state'],
+            'access_level' => $accessLevel,
+            'variant' => $variant,
+            'pack_id' => $this->stringOrDash($row->pack_id ?? null),
+            'dir_version' => $this->stringOrDash($row->dir_version ?? null),
+            'scoring_spec_version' => $this->stringOrDash($row->scoring_spec_version ?? null),
+            'report_engine_version' => $this->stringOrDash($row->report_engine_version ?? null),
+            'snapshot_version' => $this->stringOrDash($row->snapshot_version ?? null),
+            'notes' => $notes,
+        ];
+    }
+
+    /**
+     * @return array{
+     *   order_no:string,
+     *   order_status:string,
+     *   order_status_state:string,
+     *   payment_summary:string,
+     *   payment_hint:?string,
+     *   benefit_summary:string,
+     *   benefit_hint:?string,
+     *   entitlement:string,
+     *   delivery:string,
+     *   claim:string,
+     *   share_id:string,
+     *   notes:list<string>
+     * }
+     */
+    private function fetchCommerceSummary(Attempt $attempt): array
+    {
+        $order = null;
+        $orderNo = $this->latestOrderNo($attempt);
+
+        if (SchemaBaseline::hasTable('orders')) {
+            $order = DB::table('orders')
+                ->where('target_attempt_id', (string) $attempt->id)
+                ->orderByRaw('coalesce(paid_at, updated_at, created_at) desc')
+                ->first();
+
+            if ($order !== null) {
+                $orderNo = trim((string) ($order->order_no ?? $orderNo));
+            }
+        }
+
+        $payment = null;
+        if ($orderNo !== '' && SchemaBaseline::hasTable('payment_events')) {
+            $payment = DB::table('payment_events')
+                ->where('order_no', $orderNo)
+                ->orderByRaw('coalesce(processed_at, updated_at, created_at) desc')
+                ->first();
+        }
+
+        $benefit = null;
+        if (SchemaBaseline::hasTable('benefit_grants')) {
+            $benefit = DB::table('benefit_grants')
+                ->where(function (QueryBuilder $builder) use ($attempt, $orderNo): void {
+                    $builder->where('attempt_id', (string) $attempt->id);
+
+                    if ($orderNo !== '') {
+                        $builder->orWhere('order_no', $orderNo);
+                    }
+                })
+                ->orderByRaw("case when lower(status) = 'active' then 0 else 1 end")
+                ->orderByRaw('coalesce(updated_at, created_at) desc')
+                ->first();
+        }
+
+        $benefitMeta = $this->decodeJson($benefit->meta_json ?? null);
+        $orderMeta = $this->decodeJson($order->meta_json ?? null);
+        $shareId = $this->latestShareId($attempt);
+
+        $notes = [];
+        if ($orderNo !== '') {
+            $notes[] = 'Support can follow payment, unlock, and share state from the same attempt root.';
+        } else {
+            $notes[] = 'No linked order found for this attempt yet.';
+        }
+
+        return [
+            'order_no' => $orderNo !== '' ? $orderNo : '-',
+            'order_status' => $this->stringOrDash($order->status ?? null),
+            'order_status_state' => $this->statusState((string) ($order->status ?? '')),
+            'payment_summary' => $payment ? $this->stringOrDash($payment->status ?? null) : '-',
+            'payment_hint' => $payment ? 'event='.$this->stringOrDash($payment->event_type ?? null) : null,
+            'benefit_summary' => $benefit ? $this->stringOrDash($benefit->status ?? null) : '-',
+            'benefit_hint' => $benefit ? 'benefit='.$this->stringOrDash($benefit->benefit_code ?? null) : null,
+            'entitlement' => $this->stringOrDash(($order->entitlement_id ?? null) ?: ($payment->entitlement_id ?? null)),
+            'delivery' => $this->formatTimestamp(($order->fulfilled_at ?? null) ?: ($attempt->paid_at ?? null)),
+            'claim' => $this->stringOrDash(data_get($benefitMeta, 'claim_status') ?: data_get($orderMeta, 'claim_status')),
+            'share_id' => $shareId !== '' ? $shareId : '-',
+            'notes' => $notes,
+        ];
+    }
+
+    /**
+     * @return list<array{title:string,occurred_at:string,meta:list<string>,share_id:string,channel:string}>
+     */
+    private function fetchEventTimeline(Attempt $attempt, string $shareId): array
+    {
+        if (! SchemaBaseline::hasTable('events')) {
+            return [];
+        }
+
+        $rows = DB::table('events')
+            ->select(['event_code', 'occurred_at', 'share_id', 'channel', 'meta_json'])
+            ->where(function (QueryBuilder $query) use ($attempt, $shareId): void {
+                $query->where('attempt_id', (string) $attempt->id);
+
+                if ($shareId !== '' && $shareId !== '-') {
+                    $query->orWhere('share_id', $shareId);
+                }
+            })
+            ->orderByRaw('coalesce(occurred_at, created_at) desc')
+            ->limit(20)
+            ->get();
+
+        return $rows
+            ->map(function ($row): array {
+                $meta = $this->decodeJson($row->meta_json ?? null);
+
+                return [
+                    'title' => $this->stringOrDash($row->event_code ?? null),
+                    'occurred_at' => $this->formatTimestamp($row->occurred_at ?? null),
+                    'meta' => $this->summarizeMeta($meta),
+                    'share_id' => $this->stringOrDash($row->share_id ?? null),
+                    'channel' => $this->stringOrDash($row->channel ?? null),
+                ];
+            })
+            ->all();
+    }
+
+    /**
+     * @return array{summary:string,hint:?string}
+     */
+    private function fetchReportJobSummary(Attempt $attempt): array
+    {
+        if (! SchemaBaseline::hasTable('report_jobs')) {
+            return ['summary' => '-', 'hint' => null];
+        }
+
+        $rows = DB::table('report_jobs')
+            ->select(['status', 'created_at', 'finished_at'])
+            ->where('attempt_id', (string) $attempt->id)
+            ->orderByDesc('created_at')
+            ->limit(10)
+            ->get();
+
+        if ($rows->isEmpty()) {
+            return ['summary' => 'missing', 'hint' => null];
+        }
+
+        $latest = $rows->first();
+
+        return [
+            'summary' => sprintf('latest=%s total=%d', (string) ($latest->status ?? 'unknown'), $rows->count()),
+            'hint' => 'finished='.$this->formatTimestamp($latest->finished_at ?? null),
+        ];
+    }
+
+    /**
+     * @return list<array{label:string,url:string,kind:string}>
+     */
+    private function buildLinks(Attempt $attempt, string $localeSegment, string $orderNo, string $shareId): array
+    {
+        $base = rtrim((string) config('app.frontend_url', config('app.url', '')), '/');
+        $links = [];
+
+        if ($base !== '') {
+            $links[] = [
+                'label' => 'Result page',
+                'url' => $base.'/'.$localeSegment.'/result/'.urlencode((string) $attempt->id),
+                'kind' => 'frontend',
+            ];
+
+            $links[] = [
+                'label' => 'Report page',
+                'url' => $base.'/'.$localeSegment.'/attempts/'.urlencode((string) $attempt->id).'/report',
+                'kind' => 'frontend',
+            ];
+
+            if ($orderNo !== '' && $orderNo !== '-') {
+                $links[] = [
+                    'label' => 'Order page',
+                    'url' => $base.'/'.$localeSegment.'/orders/'.urlencode($orderNo),
+                    'kind' => 'frontend',
+                ];
+            }
+
+            if ($shareId !== '' && $shareId !== '-') {
+                $links[] = [
+                    'label' => 'Share page',
+                    'url' => $base.'/'.$localeSegment.'/share/'.urlencode($shareId),
+                    'kind' => 'frontend',
+                ];
+            }
+        }
+
+        $links[] = [
+            'label' => 'Order Lookup',
+            'url' => '/ops/order-lookup',
+            'kind' => 'ops',
+        ];
+
+        return $links;
+    }
+
+    private function frontendLocaleSegment(string $locale): string
+    {
+        return str_starts_with(strtolower(trim($locale)), 'zh') ? 'zh' : 'en';
+    }
+
+    /**
+     * @return array{label:string,value:string,hint:?string,kind:string,state:?string}
+     */
+    private function field(string $label, string $value, ?string $hint = null): array
+    {
+        return [
+            'label' => $label,
+            'value' => $value !== '' ? $value : '-',
+            'hint' => $hint,
+            'kind' => 'text',
+            'state' => null,
+        ];
+    }
+
+    /**
+     * @return array{label:string,value:string,hint:?string,kind:string,state:?string}
+     */
+    private function pillField(string $label, string $value, string $state, ?string $hint = null): array
+    {
+        return [
+            'label' => $label,
+            'value' => $value !== '' ? $value : '-',
+            'hint' => $hint,
+            'kind' => 'pill',
+            'state' => $state,
+        ];
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function summarizeMeta(array $meta): array
+    {
+        $summary = [];
+
+        foreach (['status', 'stage', 'variant', 'locked', 'access_level', 'question_id', 'reason', 'provider'] as $key) {
+            $value = $meta[$key] ?? null;
+            if (is_scalar($value) || is_bool($value)) {
+                $summary[] = sprintf('%s=%s', $key, $this->scalarToString($value));
+            }
+        }
+
+        return array_slice($summary, 0, 4);
+    }
+
+    private function stringOrDash(mixed $value): string
+    {
+        $string = trim((string) ($value ?? ''));
+
+        return $string !== '' ? $string : '-';
+    }
+
+    private function stringOrNull(mixed $value): ?string
+    {
+        $string = trim((string) ($value ?? ''));
+
+        return $string !== '' ? $string : null;
+    }
+
+    private function formatTimestamp(mixed $value): string
+    {
+        if ($value === null || $value === '') {
+            return '-';
+        }
+
+        try {
+            if ($value instanceof Carbon) {
+                return $value->toDateTimeString();
+            }
+
+            return Carbon::parse((string) $value)->toDateTimeString();
+        } catch (\Throwable) {
+            return trim((string) $value) !== '' ? (string) $value : '-';
+        }
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function decodeJson(mixed $value): array
+    {
+        if (is_array($value)) {
+            return $value;
+        }
+
+        if (! is_string($value) || trim($value) === '') {
+            return [];
+        }
+
+        $decoded = json_decode($value, true);
+
+        return is_array($decoded) ? $decoded : [];
+    }
+
+    /**
+     * @return array{label:string,state:string}
+     */
+    private function normalizeBooleanLabel(mixed $value): array
+    {
+        if ($value === null || $value === '') {
+            return ['label' => '-', 'state' => 'gray'];
+        }
+
+        $bool = filter_var($value, FILTER_VALIDATE_BOOLEAN, FILTER_NULL_ON_FAILURE);
+        if ($bool === null) {
+            return ['label' => (string) $value, 'state' => 'gray'];
+        }
+
+        return $bool
+            ? ['label' => 'yes', 'state' => 'success']
+            : ['label' => 'no', 'state' => 'gray'];
+    }
+
+    private function scalarToString(mixed $value): string
+    {
+        if (is_bool($value)) {
+            return $value ? 'true' : 'false';
+        }
+
+        return (string) $value;
+    }
+
+    private function statusState(string $value): string
+    {
+        $status = strtolower(trim($value));
+
+        return match (true) {
+            $status === '' => 'gray',
+            in_array($status, ['ready', 'completed', 'complete', 'active', 'paid', 'fulfilled', 'success', 'succeeded'], true) => 'success',
+            in_array($status, ['pending', 'queued', 'running', 'processing'], true) => 'warning',
+            str_contains($status, 'fail') || str_contains($status, 'error') || str_contains($status, 'refund') => 'danger',
+            default => 'gray',
+        };
+    }
+
+    private function isPaidLike(string $value): bool
+    {
+        return in_array(strtolower(trim($value)), ['paid', 'fulfilled', 'complete', 'completed', 'success', 'succeeded'], true);
+    }
+
+    private function isRefundedLike(string $value): bool
+    {
+        return str_contains(strtolower(trim($value)), 'refund');
+    }
+}

--- a/backend/resources/views/filament/ops/resources/attempts/partials/field-grid.blade.php
+++ b/backend/resources/views/filament/ops/resources/attempts/partials/field-grid.blade.php
@@ -1,0 +1,42 @@
+@props([
+    'fields' => [],
+    'notes' => [],
+])
+
+<div class="space-y-4">
+    <div class="grid gap-3 md:grid-cols-2 xl:grid-cols-3">
+        @forelse ($fields as $field)
+            <div class="ops-result-card">
+                <p class="ops-result-card__meta">{{ (string) ($field['label'] ?? '-') }}</p>
+
+                @if (($field['kind'] ?? 'text') === 'pill')
+                    <x-filament.ops.shared.status-pill
+                        :state="(string) ($field['state'] ?? 'gray')"
+                        :label="(string) ($field['value'] ?? '-')"
+                    />
+                @else
+                    <p class="ops-result-card__title break-all">{{ (string) ($field['value'] ?? '-') }}</p>
+                @endif
+
+                @if (filled($field['hint'] ?? null))
+                    <p class="ops-control-hint">{{ (string) $field['hint'] }}</p>
+                @endif
+            </div>
+        @empty
+            <x-filament.ops.shared.empty-state
+                eyebrow="Attempt diagnostics"
+                icon="heroicon-o-clipboard-document-list"
+                title="No diagnostic fields"
+                description="This section has no summary fields for the current attempt."
+            />
+        @endforelse
+    </div>
+
+    @if ($notes !== [])
+        <div class="space-y-2">
+            @foreach ($notes as $note)
+                <p class="ops-control-hint">{{ (string) $note }}</p>
+            @endforeach
+        </div>
+    @endif
+</div>

--- a/backend/resources/views/filament/ops/resources/attempts/view-attempt.blade.php
+++ b/backend/resources/views/filament/ops/resources/attempts/view-attempt.blade.php
@@ -1,0 +1,176 @@
+<x-filament-panels::page>
+    @php
+        $record = $this->getRecord();
+    @endphp
+
+    <div class="ops-shell-page">
+        <x-filament::section>
+            <div class="ops-workbench-toolbar ops-workbench-toolbar--split">
+                <div class="ops-workbench-toolbar__main">
+                    <div class="ops-shell-inline-intro">
+                        <span class="ops-shell-inline-intro__eyebrow">Support diagnostic</span>
+                        <p class="ops-shell-inline-intro__meta">
+                            Rooted on <code>{{ (string) $record->getKey() }}</code>. This page keeps submit, result, report, payment, and share state in one read-only view.
+                        </p>
+                    </div>
+
+                    <div class="flex flex-wrap items-center gap-3">
+                        <x-filament.ops.shared.status-pill
+                            :state="(string) ($headline['submitted']['state'] ?? 'gray')"
+                            :label="'submitted: '.(string) ($headline['submitted']['label'] ?? '-')"
+                        />
+                        <x-filament.ops.shared.status-pill
+                            :state="(string) ($headline['result']['state'] ?? 'gray')"
+                            :label="'result: '.(string) ($headline['result']['label'] ?? '-')"
+                        />
+                        <x-filament.ops.shared.status-pill
+                            :state="(string) ($headline['report']['state'] ?? 'gray')"
+                            :label="'report: '.(string) ($headline['report']['label'] ?? '-')"
+                        />
+                        <x-filament.ops.shared.status-pill
+                            :state="(string) ($headline['unlock']['state'] ?? 'gray')"
+                            :label="'unlock: '.(string) ($headline['unlock']['label'] ?? '-')"
+                        />
+                    </div>
+                </div>
+
+                <div class="ops-workbench-toolbar__actions">
+                    @foreach ($links as $link)
+                        <x-filament::button
+                            color="{{ ($link['kind'] ?? 'frontend') === 'ops' ? 'gray' : 'primary' }}"
+                            size="sm"
+                            tag="a"
+                            href="{{ (string) ($link['url'] ?? '#') }}"
+                            target="{{ ($link['kind'] ?? 'frontend') === 'ops' ? '_self' : '_blank' }}"
+                        >
+                            {{ (string) ($link['label'] ?? 'Open') }}
+                        </x-filament::button>
+                    @endforeach
+                </div>
+            </div>
+        </x-filament::section>
+
+        <x-filament::section>
+            <div class="ops-results-header">
+                <div>
+                    <h3 class="ops-results-header__title">Attempt Summary</h3>
+                    <p class="ops-results-header__meta">Attempt root fields, identity, and version dimensions.</p>
+                </div>
+            </div>
+
+            <div class="mt-4">
+                @include('filament.ops.resources.attempts.partials.field-grid', [
+                    'fields' => $attemptSummary['fields'] ?? [],
+                    'notes' => [],
+                ])
+            </div>
+        </x-filament::section>
+
+        <x-filament::section>
+            <div class="ops-results-header">
+                <div>
+                    <h3 class="ops-results-header__title">Answers Summary</h3>
+                    <p class="ops-results-header__meta">Presence, hash, row count, and storage mode only. Raw answers stay hidden.</p>
+                </div>
+            </div>
+
+            <div class="mt-4">
+                @include('filament.ops.resources.attempts.partials.field-grid', [
+                    'fields' => $answersSummary['fields'] ?? [],
+                    'notes' => $answersSummary['notes'] ?? [],
+                ])
+            </div>
+        </x-filament::section>
+
+        <x-filament::section>
+            <div class="ops-results-header">
+                <div>
+                    <h3 class="ops-results-header__title">Result</h3>
+                    <p class="ops-results-header__meta">Result availability, computed timing, and version breadcrumbs.</p>
+                </div>
+            </div>
+
+            <div class="mt-4">
+                @include('filament.ops.resources.attempts.partials.field-grid', [
+                    'fields' => $resultSummary['fields'] ?? [],
+                    'notes' => $resultSummary['notes'] ?? [],
+                ])
+            </div>
+        </x-filament::section>
+
+        <x-filament::section>
+            <div class="ops-results-header">
+                <div>
+                    <h3 class="ops-results-header__title">Report Snapshot</h3>
+                    <p class="ops-results-header__meta">Snapshot status, gate clues, and lightweight report job breadcrumbs.</p>
+                </div>
+            </div>
+
+            <div class="mt-4">
+                @include('filament.ops.resources.attempts.partials.field-grid', [
+                    'fields' => $reportSummary['fields'] ?? [],
+                    'notes' => $reportSummary['notes'] ?? [],
+                ])
+            </div>
+        </x-filament::section>
+
+        <x-filament::section>
+            <div class="ops-results-header">
+                <div>
+                    <h3 class="ops-results-header__title">Commerce / Unlock Linkage</h3>
+                    <p class="ops-results-header__meta">Order, payment, benefit, entitlement, delivery, and claim clues.</p>
+                </div>
+            </div>
+
+            <div class="mt-4">
+                @include('filament.ops.resources.attempts.partials.field-grid', [
+                    'fields' => $commerceSummary['fields'] ?? [],
+                    'notes' => $commerceSummary['notes'] ?? [],
+                ])
+            </div>
+        </x-filament::section>
+
+        <x-filament::section>
+            <div class="ops-results-header">
+                <div>
+                    <h3 class="ops-results-header__title">Event Timeline</h3>
+                    <p class="ops-results-header__meta">Latest attempt and share events with compact meta summaries only.</p>
+                </div>
+            </div>
+
+            <div class="ops-card-list mt-4">
+                @forelse ($eventTimeline as $event)
+                    <div class="ops-result-card">
+                        <div class="ops-result-card__header">
+                            <div>
+                                <p class="ops-result-card__title">{{ (string) ($event['title'] ?? '-') }}</p>
+                                <p class="ops-result-card__meta">
+                                    {{ (string) ($event['occurred_at'] ?? '-') }}
+                                    | channel={{ (string) ($event['channel'] ?? '-') }}
+                                    | share_id={{ (string) ($event['share_id'] ?? '-') }}
+                                </p>
+                            </div>
+                        </div>
+
+                        @if (($event['meta'] ?? []) !== [])
+                            <div class="flex flex-wrap gap-2">
+                                @foreach (($event['meta'] ?? []) as $meta)
+                                    <x-filament.ops.shared.status-pill state="gray" :label="(string) $meta" />
+                                @endforeach
+                            </div>
+                        @else
+                            <p class="ops-control-hint">No compact meta summary for this event.</p>
+                        @endif
+                    </div>
+                @empty
+                    <x-filament.ops.shared.empty-state
+                        eyebrow="Event timeline"
+                        icon="heroicon-o-clock"
+                        title="No event timeline yet"
+                        description="Attempt-linked events will appear here once the analytics trail exists."
+                    />
+                @endforelse
+            </div>
+        </x-filament::section>
+    </div>
+</x-filament-panels::page>

--- a/backend/tests/Feature/Ops/AttemptsExplorerTest.php
+++ b/backend/tests/Feature/Ops/AttemptsExplorerTest.php
@@ -1,0 +1,635 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Ops;
+
+use App\Filament\Ops\Resources\AttemptResource\Pages\ListAttempts;
+use App\Models\AdminUser;
+use App\Models\Attempt;
+use App\Models\Organization;
+use App\Models\Permission;
+use App\Models\Role;
+use App\Support\Rbac\PermissionNames;
+use Filament\Facades\Filament;
+use Filament\PanelRegistry;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Support\Str;
+use Livewire\Livewire;
+use Tests\TestCase;
+
+final class AttemptsExplorerTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        Filament::setCurrentPanel(app(PanelRegistry::class)->get('ops'));
+    }
+
+    public function test_attempts_explorer_list_is_accessible_read_only_and_has_core_columns(): void
+    {
+        $admin = $this->createAdminWithPermissions([
+            PermissionNames::ADMIN_MENU_SUPPORT,
+            PermissionNames::ADMIN_OPS_READ,
+        ]);
+        $selectedOrg = $this->createOrganization('Selected Ops Org');
+        $chain = $this->seedFullDiagnosticChain(orgId: 22);
+
+        $this->withSession($this->opsSession($admin, $selectedOrg))
+            ->actingAs($admin, (string) config('admin.guard', 'admin'))
+            ->get('/ops/attempts')
+            ->assertOk()
+            ->assertSee('Attempts Explorer')
+            ->assertDontSee('Create Attempt')
+            ->assertDontSee('Edit Attempt');
+
+        session($this->opsSession($admin, $selectedOrg));
+        $this->actingAs($admin, (string) config('admin.guard', 'admin'));
+
+        Livewire::test(ListAttempts::class)
+            ->assertOk()
+            ->assertCanSeeTableRecords([$chain['attempt']])
+            ->assertTableColumnExists('id')
+            ->assertTableColumnExists('scale_code')
+            ->assertTableColumnExists('submitted_status')
+            ->assertTableColumnExists('submitted_at')
+            ->assertTableColumnExists('locale')
+            ->assertTableColumnExists('region')
+            ->assertTableColumnExists('channel')
+            ->assertTableColumnExists('has_result')
+            ->assertTableColumnExists('latest_report_snapshot_status')
+            ->assertTableColumnExists('unlock_status')
+            ->assertTableColumnExists('org_id')
+            ->assertTableActionExists('view', null, $chain['attempt'])
+            ->assertTableActionDoesNotExist('edit', null, $chain['attempt'])
+            ->assertTableActionDoesNotExist('delete', null, $chain['attempt']);
+    }
+
+    public function test_attempts_explorer_detail_renders_full_chain_sections_and_drill_through_links(): void
+    {
+        $admin = $this->createAdminWithPermissions([
+            PermissionNames::ADMIN_MENU_SUPPORT,
+            PermissionNames::ADMIN_OPS_READ,
+        ]);
+        $selectedOrg = $this->createOrganization('Support Selection Org');
+        $chain = $this->seedFullDiagnosticChain(orgId: 33);
+
+        $this->withSession($this->opsSession($admin, $selectedOrg))
+            ->actingAs($admin, (string) config('admin.guard', 'admin'))
+            ->get('/ops/attempts/'.$chain['attempt']->id)
+            ->assertOk()
+            ->assertSee('Attempt Summary')
+            ->assertSee('Answers Summary')
+            ->assertSee('Result')
+            ->assertSee('Report Snapshot')
+            ->assertSee('Commerce / Unlock Linkage')
+            ->assertSee('Event Timeline')
+            ->assertSee((string) $chain['attempt']->id)
+            ->assertSee((string) $chain['order_no'])
+            ->assertSee((string) $chain['share_id'])
+            ->assertSee('Result page')
+            ->assertSee('Report page')
+            ->assertSee('Order page')
+            ->assertSee('Share page')
+            ->assertSee('Order Lookup')
+            ->assertSee('succeeded')
+            ->assertSee('present')
+            ->assertSee('INTJ')
+            ->assertSee('full')
+            ->assertSee('active');
+    }
+
+    public function test_attempts_explorer_cross_org_order_search_bypasses_selected_org_context(): void
+    {
+        $admin = $this->createAdminWithPermissions([
+            PermissionNames::ADMIN_MENU_SUPPORT,
+            PermissionNames::ADMIN_OPS_READ,
+        ]);
+        $selectedOrg = $this->createOrganization('Current Session Org');
+        $localAttempt = $this->createAttempt([
+            'org_id' => $selectedOrg->id,
+            'ticket_code' => 'FMT-LOCAL01',
+            'anon_id' => 'anon-local',
+            'user_id' => '1010',
+        ]);
+        $foreignChain = $this->seedFullDiagnosticChain(orgId: 77, orderNo: 'ord_cross_org_001');
+
+        session($this->opsSession($admin, $selectedOrg));
+        $this->actingAs($admin, (string) config('admin.guard', 'admin'));
+
+        Livewire::test(ListAttempts::class)
+            ->assertOk()
+            ->searchTable('ord_cross_org_001')
+            ->assertCanSeeTableRecords([$foreignChain['attempt']])
+            ->assertCanNotSeeTableRecords([$localAttempt])
+            ->assertTableColumnStateSet('org_id', 77, $foreignChain['attempt']);
+    }
+
+    public function test_attempts_explorer_keeps_raw_answers_hidden_and_surfaces_sensitive_storage_modes(): void
+    {
+        $admin = $this->createAdminWithPermissions([
+            PermissionNames::ADMIN_MENU_SUPPORT,
+            PermissionNames::ADMIN_OPS_READ,
+        ]);
+        $selectedOrg = $this->createOrganization('Sensitivity Org');
+
+        $clinicalAttempt = $this->createAttempt([
+            'id' => '11111111-1111-4111-8111-111111111111',
+            'org_id' => 44,
+            'scale_code' => 'CLINICAL_COMBO_68',
+            'locale' => 'zh-CN',
+            'region' => 'CN_MAINLAND',
+            'channel' => 'mobile',
+            'pack_id' => 'CLINICAL_COMBO_68',
+            'scoring_spec_version' => 'clinical_v1',
+            'question_count' => 68,
+        ]);
+        $this->insertAnswerSet($clinicalAttempt->id, 44, 'CLINICAL_COMBO_68', null, hash('sha256', 'clinical-secret-answer'), 68);
+
+        $sdsAttempt = $this->createAttempt([
+            'id' => '22222222-2222-4222-8222-222222222222',
+            'org_id' => 44,
+            'scale_code' => 'SDS_20',
+            'locale' => 'zh-CN',
+            'region' => 'CN_MAINLAND',
+            'channel' => 'mobile',
+            'pack_id' => 'SDS_20',
+            'scoring_spec_version' => 'sds_v2',
+            'question_count' => 20,
+        ]);
+        $this->insertAnswerSet($sdsAttempt->id, 44, 'SDS_20', null, hash('sha256', 'sds-secret-answer'), 20);
+        $this->insertAnswerRow($sdsAttempt->id, 44, 'SDS_20', 'Q-1', ['code' => 'SDS_SECRET', 'answer' => 'Very secret']);
+
+        $this->withSession($this->opsSession($admin, $selectedOrg))
+            ->actingAs($admin, (string) config('admin.guard', 'admin'))
+            ->get('/ops/attempts/'.$clinicalAttempt->id)
+            ->assertOk()
+            ->assertSee('rowless')
+            ->assertSee('Clinical assessments default to rowless storage.')
+            ->assertDontSee('clinical-secret-answer')
+            ->assertDontSeeText('answers_json')
+            ->assertDontSeeText('answer_json');
+
+        $this->withSession($this->opsSession($admin, $selectedOrg))
+            ->actingAs($admin, (string) config('admin.guard', 'admin'))
+            ->get('/ops/attempts/'.$sdsAttempt->id)
+            ->assertOk()
+            ->assertSee('redacted')
+            ->assertSee('SDS answer rows stay redacted by design.')
+            ->assertDontSee('SDS_SECRET')
+            ->assertDontSee('Very secret')
+            ->assertDontSeeText('answers_json')
+            ->assertDontSeeText('answer_json');
+    }
+
+    private function createOrganization(string $name): Organization
+    {
+        return Organization::query()->create([
+            'name' => $name,
+            'owner_user_id' => random_int(1000, 9999),
+            'status' => 'active',
+            'domain' => Str::slug($name).'.example.test',
+            'timezone' => 'Asia/Shanghai',
+            'locale' => 'en',
+        ]);
+    }
+
+    /**
+     * @param  list<string>  $permissions
+     */
+    private function createAdminWithPermissions(array $permissions): AdminUser
+    {
+        $admin = AdminUser::query()->create([
+            'name' => 'ops_'.Str::lower(Str::random(6)),
+            'email' => 'ops_'.Str::lower(Str::random(6)).'@example.test',
+            'password' => bcrypt('secret'),
+            'is_active' => 1,
+        ]);
+
+        $role = Role::query()->create([
+            'name' => 'role_'.Str::lower(Str::random(8)),
+            'description' => null,
+        ]);
+
+        foreach ($permissions as $permissionName) {
+            $permission = Permission::query()->firstOrCreate(
+                ['name' => $permissionName],
+                ['description' => null],
+            );
+
+            $role->permissions()->syncWithoutDetaching([$permission->id]);
+        }
+
+        $admin->roles()->syncWithoutDetaching([$role->id]);
+
+        return $admin;
+    }
+
+    /**
+     * @return array{ops_org_id:int,ops_admin_totp_verified_user_id:int}
+     */
+    private function opsSession(AdminUser $admin, Organization $selectedOrg): array
+    {
+        return [
+            'ops_org_id' => (int) $selectedOrg->id,
+            'ops_admin_totp_verified_user_id' => (int) $admin->id,
+        ];
+    }
+
+    /**
+     * @return array{attempt:Attempt,order_no:string,share_id:string}
+     */
+    private function seedFullDiagnosticChain(int $orgId, ?string $orderNo = null): array
+    {
+        $attemptId = (string) Str::uuid();
+        $shareId = (string) Str::uuid();
+        $orderNo ??= 'ord_ops_chain_'.Str::lower(Str::random(6));
+
+        $attempt = $this->createAttempt([
+            'id' => $attemptId,
+            'org_id' => $orgId,
+            'scale_code' => 'MBTI',
+            'scale_version' => 'v0.3',
+            'scale_uid' => '33333333-3333-4333-8333-333333333333',
+            'user_id' => '1001',
+            'anon_id' => 'anon_ops_chain',
+            'ticket_code' => 'FMT-CHAIN01',
+            'locale' => 'en',
+            'region' => 'US',
+            'channel' => 'web',
+            'pack_id' => 'MBTI',
+            'dir_version' => 'mbti_dir_2026_03',
+            'content_package_version' => 'content_2026_03',
+            'scoring_spec_version' => 'scoring_2026_03',
+            'norm_version' => 'norm_2026_03',
+            'question_count' => 93,
+            'result_json' => [
+                'type_code' => 'INTJ',
+                'public_hint' => true,
+            ],
+        ]);
+
+        DB::table('results')->insert([
+            'id' => (string) Str::uuid(),
+            'attempt_id' => $attemptId,
+            'org_id' => $orgId,
+            'scale_code' => 'MBTI',
+            'scale_version' => 'v0.3',
+            'type_code' => 'INTJ',
+            'scores_json' => json_encode(['EI' => 78, 'SN' => 62], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES),
+            'scores_pct' => json_encode(['EI' => 88, 'SN' => 74], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES),
+            'axis_states' => json_encode(['EI' => 'I', 'SN' => 'N'], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES),
+            'profile_version' => 'profile_2026_03',
+            'is_valid' => 1,
+            'computed_at' => now()->subMinutes(12),
+            'created_at' => now()->subMinutes(12),
+            'updated_at' => now()->subMinutes(11),
+            'content_package_version' => 'content_2026_03',
+            'result_json' => json_encode(['type_code' => 'INTJ', 'private_hint' => true], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES),
+            'pack_id' => 'MBTI',
+            'dir_version' => 'mbti_dir_2026_03',
+            'scoring_spec_version' => 'scoring_2026_03',
+            'report_engine_version' => 'v2.3',
+            'scale_uid' => '33333333-3333-4333-8333-333333333333',
+        ]);
+
+        DB::table('report_snapshots')->insert([
+            'org_id' => $orgId,
+            'attempt_id' => $attemptId,
+            'order_no' => $orderNo,
+            'scale_code' => 'MBTI',
+            'pack_id' => 'MBTI',
+            'dir_version' => 'mbti_dir_2026_03',
+            'scoring_spec_version' => 'scoring_2026_03',
+            'report_engine_version' => 'v2.3',
+            'snapshot_version' => 'v1',
+            'report_json' => json_encode([
+                'locked' => false,
+                'access_level' => 'full',
+                'variant' => 'full',
+            ], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES),
+            'report_free_json' => json_encode(['variant' => 'free'], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES),
+            'report_full_json' => json_encode(['variant' => 'full'], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES),
+            'status' => 'ready',
+            'last_error' => null,
+            'created_at' => now()->subMinutes(10),
+            'updated_at' => now()->subMinutes(9),
+            'scale_uid' => '33333333-3333-4333-8333-333333333333',
+        ]);
+
+        $orderId = $this->insertOrder($orderNo, $attemptId, $orgId, 'paid', 'anon_ops_chain', '1001');
+        $paymentEventId = $this->insertPaymentEvent($orderId, $orderNo, $orgId, 'paid', 'payment_intent.succeeded');
+        $this->insertBenefitGrant($attemptId, $orderId, $paymentEventId, $orderNo, $orgId, 'active');
+
+        DB::table('shares')->insert([
+            'id' => $shareId,
+            'attempt_id' => $attemptId,
+            'anon_id' => 'anon_ops_chain',
+            'scale_code' => 'MBTI',
+            'scale_version' => 'v0.3',
+            'content_package_version' => 'content_2026_03',
+            'scale_uid' => '33333333-3333-4333-8333-333333333333',
+            'created_at' => now()->subMinutes(6),
+            'updated_at' => now()->subMinutes(5),
+        ]);
+
+        DB::table('attempt_submissions')->insert([
+            'id' => (string) Str::uuid(),
+            'org_id' => $orgId,
+            'attempt_id' => $attemptId,
+            'actor_user_id' => '1001',
+            'actor_anon_id' => 'anon_ops_chain',
+            'dedupe_key' => 'attempt-chain-dedupe',
+            'mode' => 'sync',
+            'state' => 'succeeded',
+            'error_code' => null,
+            'error_message' => null,
+            'request_payload_json' => '{}',
+            'response_payload_json' => '{}',
+            'started_at' => now()->subMinutes(14),
+            'finished_at' => now()->subMinutes(13),
+            'created_at' => now()->subMinutes(14),
+            'updated_at' => now()->subMinutes(13),
+        ]);
+
+        DB::table('attempt_quality')->insert([
+            'attempt_id' => $attemptId,
+            'checks_json' => json_encode(['speeding' => false, 'straightlining' => false], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES),
+            'grade' => 'A',
+            'created_at' => now()->subMinutes(13),
+        ]);
+
+        $this->insertAnswerSet($attemptId, $orgId, 'MBTI', base64_encode(json_encode([['question_id' => 'Q-1', 'code' => 'A']], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES)), hash('sha256', 'mbti-chain'), 93);
+
+        DB::table('events')->insert([
+            [
+                'id' => (string) Str::uuid(),
+                'event_code' => 'attempt_submitted',
+                'user_id' => '1001',
+                'anon_id' => 'anon_ops_chain',
+                'scale_code' => 'MBTI',
+                'scale_version' => 'v0.3',
+                'attempt_id' => $attemptId,
+                'channel' => 'web',
+                'region' => 'US',
+                'locale' => 'en',
+                'meta_json' => json_encode(['status' => 'submitted', 'stage' => 'complete'], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES),
+                'occurred_at' => now()->subMinutes(13),
+                'created_at' => now()->subMinutes(13),
+                'updated_at' => now()->subMinutes(13),
+                'share_id' => null,
+                'org_id' => $orgId,
+                'scale_uid' => '33333333-3333-4333-8333-333333333333',
+            ],
+            [
+                'id' => (string) Str::uuid(),
+                'event_code' => 'share_created',
+                'user_id' => '1001',
+                'anon_id' => 'anon_ops_chain',
+                'scale_code' => 'MBTI',
+                'scale_version' => 'v0.3',
+                'attempt_id' => $attemptId,
+                'channel' => 'web',
+                'region' => 'US',
+                'locale' => 'en',
+                'meta_json' => json_encode(['variant' => 'full', 'locked' => false], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES),
+                'occurred_at' => now()->subMinutes(5),
+                'created_at' => now()->subMinutes(5),
+                'updated_at' => now()->subMinutes(5),
+                'share_id' => $shareId,
+                'org_id' => $orgId,
+                'scale_uid' => '33333333-3333-4333-8333-333333333333',
+            ],
+        ]);
+
+        DB::table('report_jobs')->insert([
+            'id' => (string) Str::uuid(),
+            'attempt_id' => $attemptId,
+            'status' => 'succeeded',
+            'tries' => 1,
+            'available_at' => now()->subMinutes(11),
+            'started_at' => now()->subMinutes(11),
+            'finished_at' => now()->subMinutes(10),
+            'failed_at' => null,
+            'last_error' => null,
+            'last_error_trace' => null,
+            'report_json' => '{}',
+            'meta' => '{}',
+            'created_at' => now()->subMinutes(11),
+            'updated_at' => now()->subMinutes(10),
+            'org_id' => $orgId,
+        ]);
+
+        return [
+            'attempt' => $attempt->fresh(),
+            'order_no' => $orderNo,
+            'share_id' => $shareId,
+        ];
+    }
+
+    /**
+     * @param  array<string, mixed>  $overrides
+     */
+    private function createAttempt(array $overrides = []): Attempt
+    {
+        $attemptId = (string) ($overrides['id'] ?? Str::uuid());
+
+        return Attempt::query()->create(array_merge([
+            'id' => $attemptId,
+            'org_id' => 0,
+            'user_id' => '1001',
+            'anon_id' => 'anon-default',
+            'scale_code' => 'MBTI',
+            'scale_version' => 'v0.3',
+            'scale_uid' => '55555555-5555-4555-8555-555555555555',
+            'region' => 'US',
+            'locale' => 'en',
+            'question_count' => 93,
+            'answers_summary_json' => ['stage' => 'seed'],
+            'client_platform' => 'test',
+            'channel' => 'web',
+            'started_at' => now()->subMinutes(20),
+            'submitted_at' => now()->subMinutes(15),
+            'pack_id' => 'MBTI',
+            'dir_version' => 'mbti_dir_default',
+            'content_package_version' => 'content_default',
+            'scoring_spec_version' => 'scoring_default',
+            'norm_version' => 'norm_default',
+            'ticket_code' => 'FMT-'.strtoupper(substr(str_replace('-', '', $attemptId), 0, 8)),
+        ], $overrides));
+    }
+
+    private function insertAnswerSet(string $attemptId, int $orgId, string $scaleCode, ?string $answersJson, string $answersHash, int $questionCount): void
+    {
+        DB::table('attempt_answer_sets')->insert([
+            'attempt_id' => $attemptId,
+            'org_id' => $orgId,
+            'scale_code' => $scaleCode,
+            'pack_id' => $scaleCode,
+            'dir_version' => 'dir_v1',
+            'scoring_spec_version' => 'spec_v1',
+            'answers_json' => $answersJson,
+            'answers_hash' => $answersHash,
+            'question_count' => $questionCount,
+            'duration_ms' => 120000,
+            'submitted_at' => now()->subMinutes(15),
+            'created_at' => now()->subMinutes(15),
+            'scale_uid' => '44444444-4444-4444-8444-444444444444',
+        ]);
+    }
+
+    /**
+     * @param  array<string, mixed>  $answerJson
+     */
+    private function insertAnswerRow(string $attemptId, int $orgId, string $scaleCode, string $questionId, array $answerJson): void
+    {
+        DB::table('attempt_answer_rows')->insert([
+            'attempt_id' => $attemptId,
+            'org_id' => $orgId,
+            'scale_code' => $scaleCode,
+            'question_id' => $questionId,
+            'question_index' => 1,
+            'question_type' => 'single_choice',
+            'answer_json' => json_encode($answerJson, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES),
+            'duration_ms' => 5000,
+            'submitted_at' => now()->subMinutes(15),
+            'created_at' => now()->subMinutes(15),
+            'scale_uid' => '44444444-4444-4444-8444-444444444444',
+        ]);
+    }
+
+    private function insertOrder(string $orderNo, string $attemptId, int $orgId, string $status, string $anonId, ?string $userId): string
+    {
+        $orderId = (string) Str::uuid();
+        $row = [
+            'id' => $orderId,
+            'order_no' => $orderNo,
+            'org_id' => $orgId,
+            'user_id' => $userId,
+            'anon_id' => $anonId,
+            'sku' => 'MBTI_FULL_REPORT',
+            'quantity' => 1,
+            'target_attempt_id' => $attemptId,
+            'amount_cents' => 2990,
+            'currency' => 'USD',
+            'status' => $status,
+            'provider' => 'stripe',
+            'paid_at' => now()->subMinutes(9),
+            'fulfilled_at' => now()->subMinutes(8),
+            'created_at' => now()->subMinutes(10),
+            'updated_at' => now()->subMinutes(8),
+            'entitlement_id' => 'ent_ops_chain',
+            'meta_json' => json_encode(['claim_status' => 'claimed'], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES),
+        ];
+
+        if (Schema::hasColumn('orders', 'amount_total')) {
+            $row['amount_total'] = 2990;
+        }
+        if (Schema::hasColumn('orders', 'amount_refunded')) {
+            $row['amount_refunded'] = 0;
+        }
+        if (Schema::hasColumn('orders', 'item_sku')) {
+            $row['item_sku'] = 'MBTI_FULL_REPORT';
+        }
+        if (Schema::hasColumn('orders', 'provider_order_id')) {
+            $row['provider_order_id'] = null;
+        }
+        if (Schema::hasColumn('orders', 'device_id')) {
+            $row['device_id'] = null;
+        }
+        if (Schema::hasColumn('orders', 'request_id')) {
+            $row['request_id'] = null;
+        }
+        if (Schema::hasColumn('orders', 'created_ip')) {
+            $row['created_ip'] = null;
+        }
+        if (Schema::hasColumn('orders', 'refunded_at')) {
+            $row['refunded_at'] = null;
+        }
+        if (Schema::hasColumn('orders', 'external_trade_no')) {
+            $row['external_trade_no'] = null;
+        }
+        if (Schema::hasColumn('orders', 'requested_sku')) {
+            $row['requested_sku'] = 'MBTI_FULL_REPORT';
+        }
+        if (Schema::hasColumn('orders', 'effective_sku')) {
+            $row['effective_sku'] = 'MBTI_FULL_REPORT';
+        }
+        if (Schema::hasColumn('orders', 'idempotency_key')) {
+            $row['idempotency_key'] = 'idem_'.$orderNo;
+        }
+
+        DB::table('orders')->insert($row);
+
+        return $orderId;
+    }
+
+    private function insertPaymentEvent(string $orderId, string $orderNo, int $orgId, string $status, string $eventType): string
+    {
+        $paymentEventId = (string) Str::uuid();
+
+        DB::table('payment_events')->insert([
+            'id' => $paymentEventId,
+            'provider' => 'stripe',
+            'provider_event_id' => 'evt_'.Str::lower(Str::random(8)),
+            'order_id' => $orderId,
+            'event_type' => $eventType,
+            'payload_json' => '{}',
+            'signature_ok' => 1,
+            'handled_at' => now()->subMinutes(9),
+            'handle_status' => 'processed',
+            'request_id' => null,
+            'ip' => null,
+            'headers_digest' => null,
+            'created_at' => now()->subMinutes(9),
+            'updated_at' => now()->subMinutes(9),
+            'order_no' => $orderNo,
+            'received_at' => now()->subMinutes(9),
+            'requested_sku' => 'MBTI_FULL_REPORT',
+            'effective_sku' => 'MBTI_FULL_REPORT',
+            'entitlement_id' => 'ent_ops_chain',
+            'status' => $status,
+            'processed_at' => now()->subMinutes(9),
+            'attempts' => 1,
+            'last_error_code' => null,
+            'last_error_message' => null,
+            'reason' => null,
+            'payload_size_bytes' => 128,
+            'payload_sha256' => hash('sha256', 'payload-'.$orderNo),
+            'payload_s3_key' => null,
+            'payload_excerpt' => null,
+            'org_id' => $orgId,
+            'scale_uid' => '33333333-3333-4333-8333-333333333333',
+        ]);
+
+        return $paymentEventId;
+    }
+
+    private function insertBenefitGrant(string $attemptId, string $orderId, string $paymentEventId, string $orderNo, int $orgId, string $status): void
+    {
+        DB::table('benefit_grants')->insert([
+            'id' => (string) Str::uuid(),
+            'user_id' => '1001',
+            'benefit_type' => 'report',
+            'benefit_ref' => 'benefit_ref_'.$orderNo,
+            'source_order_id' => $orderId,
+            'source_event_id' => $paymentEventId,
+            'status' => $status,
+            'expires_at' => now()->addDays(30),
+            'created_at' => now()->subMinutes(8),
+            'updated_at' => now()->subMinutes(8),
+            'org_id' => $orgId,
+            'benefit_code' => 'MBTI_FULL_REPORT',
+            'scope' => 'attempt',
+            'attempt_id' => $attemptId,
+            'revoked_at' => null,
+            'order_no' => $orderNo,
+            'meta_json' => json_encode(['claim_status' => 'claimed'], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES),
+        ]);
+    }
+}


### PR DESCRIPTION
Summary
- add Attempts Explorer as the first Assessment Intelligence Console page
- provide a read-only support diagnostic surface rooted on attempts

What changed
- add a new Attempts Explorer resource/page in Filament Ops
- use attempts as the primary diagnostic root object
- expose result/report/order/share linkage summaries in a single detail view
- keep raw answers hidden by default
- add focused tests for read-only visibility, cross-org lookup behavior, and summary rendering

Design choices
- use attempts as the main root because it spans the full assessment lifecycle
- keep v1 read-only and avoid introducing a new analytics read model
- use scale_code as the primary first-phase assessment dimension
- keep the page under Support because it primarily serves support/ops diagnostics
- defer deeper analytics and psychometrics views to later AIC phases

Why this PR is small and safe
- no schema changes
- no API changes
- no write-side behavior changes
- no frontend changes
- only the first support-facing assessment console entrypoint

Validation
- php artisan about
- php artisan route:list --path=ops --except-vendor
- php artisan migrate
- php artisan test --filter=AttemptsExplorerTest
- php artisan test --filter='(Attempt|Attempts|Assessment)'
- php artisan filament:assets
- npm run build
- bash scripts/ci_verify_mbti.sh

Notes
- the broad `(Attempt|Attempts|Assessment)` suite still has unrelated existing Eq60 failures caused by missing `content_pack_activations` in the in-memory sqlite test path
