### PR TITLE
feat(referral): add reward issuance and anti-abuse foundation

### DIFF
--- a/backend/app/Internal/Commerce/PaymentWebhookHandlerCore.php
+++ b/backend/app/Internal/Commerce/PaymentWebhookHandlerCore.php
@@ -22,6 +22,7 @@ use App\Services\Email\EmailOutboxService;
 use App\Services\Observability\BigFiveTelemetry;
 use App\Services\Observability\ClinicalComboTelemetry;
 use App\Services\Observability\Sds20Telemetry;
+use App\Services\Referral\ReferralRewardService;
 use App\Services\Report\ReportAccess;
 use App\Services\Report\ReportSnapshotStore;
 use Illuminate\Contracts\Cache\LockTimeoutException;
@@ -151,6 +152,13 @@ class PaymentWebhookHandlerCore
             return $this->serverError('WEBHOOK_BUSY', 'payment webhook is busy, retry later.');
         }
 
+        $ctx = $this->runReferralRewardIssuanceStage($ctx);
+        if (($ctx['referral_reward_failed'] ?? false) === true) {
+            return is_array($ctx['result'] ?? null)
+                ? $ctx['result']
+                : $this->serverError('REFERRAL_REWARD_ISSUANCE_FAILED', 'referral reward issuance failed.');
+        }
+
         $ctx = $this->postCommitStage->handle($ctx);
         $normalizedResult = is_array($ctx['normalized_result'] ?? null)
             ? $ctx['normalized_result']
@@ -239,6 +247,49 @@ class PaymentWebhookHandlerCore
         }
 
         return false;
+    }
+
+    private function runReferralRewardIssuanceStage(array $ctx): array
+    {
+        $result = is_array($ctx['result'] ?? null) ? $ctx['result'] : [];
+        if (($result['ok'] ?? false) !== true || ($result['duplicate'] ?? false) === true || ($result['ignored'] ?? false) === true) {
+            return $ctx;
+        }
+
+        $orderNo = trim((string) ($ctx['order_no'] ?? ''));
+        if ($orderNo === '') {
+            return $ctx;
+        }
+
+        $outcome = app(ReferralRewardService::class)->issueForPaidOrder($orderNo, (int) ($ctx['org_id'] ?? 0), [
+            'provider' => (string) ($ctx['provider'] ?? ''),
+            'provider_event_id' => (string) ($ctx['provider_event_id'] ?? ''),
+        ]);
+
+        $ctx['referral_reward_outcome'] = $outcome;
+        if (($outcome['ok'] ?? false) === true) {
+            return $ctx;
+        }
+
+        $errorCode = (string) ($outcome['error_code'] ?? 'REFERRAL_REWARD_ISSUANCE_FAILED');
+        $errorMessage = (string) ($outcome['message'] ?? 'referral reward issuance failed.');
+        $provider = (string) ($ctx['provider'] ?? '');
+        $providerEventId = (string) ($ctx['provider_event_id'] ?? '');
+        if ($provider !== '' && $providerEventId !== '') {
+            $this->markEventError(
+                $provider,
+                $providerEventId,
+                'post_commit_failed',
+                $errorCode,
+                $errorMessage
+            );
+        }
+
+        $ctx['referral_reward_failed'] = true;
+        $ctx['result'] = $this->serverError($errorCode, $errorMessage);
+        $ctx['normalized_result'] = $this->normalizeResultStatus((array) $ctx['result']);
+
+        return $ctx;
     }
 
     private function resolveRequestIdFromRuntimeContext(): ?string

--- a/backend/app/Models/ReferralRewardIssuance.php
+++ b/backend/app/Models/ReferralRewardIssuance.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+
+final class ReferralRewardIssuance extends Model
+{
+    public $incrementing = false;
+
+    protected $keyType = 'string';
+
+    protected $table = 'referral_reward_issuances';
+
+    protected $fillable = [
+        'id',
+        'org_id',
+        'compare_invite_id',
+        'share_id',
+        'trigger_order_no',
+        'inviter_attempt_id',
+        'invitee_attempt_id',
+        'inviter_user_id',
+        'invitee_user_id',
+        'inviter_anon_id',
+        'invitee_anon_id',
+        'reward_sku',
+        'reward_quantity',
+        'status',
+        'reason_code',
+        'attribution_json',
+        'granted_at',
+    ];
+
+    protected $casts = [
+        'org_id' => 'integer',
+        'reward_quantity' => 'integer',
+        'attribution_json' => 'array',
+        'granted_at' => 'datetime',
+    ];
+}

--- a/backend/app/Services/Commerce/OrderManager.php
+++ b/backend/app/Services/Commerce/OrderManager.php
@@ -298,6 +298,24 @@ class OrderManager
         ];
     }
 
+    public function findOrderByOrderNo(string $orderNo, int $orgId): ?object
+    {
+        $normalizedOrderNo = trim($orderNo);
+        if ($normalizedOrderNo === '') {
+            return null;
+        }
+
+        return DB::table('orders')
+            ->where('order_no', $normalizedOrderNo)
+            ->where('org_id', $orgId)
+            ->first();
+    }
+
+    public function isPaidOrFulfilledStatus(?string $status): bool
+    {
+        return $this->isDeliveryEligibleStatus((string) $status);
+    }
+
     /**
      * @return array{
      *     attempt_id:?string,

--- a/backend/app/Services/Referral/ReferralRewardService.php
+++ b/backend/app/Services/Referral/ReferralRewardService.php
@@ -1,0 +1,491 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\Referral;
+
+use App\Models\ReferralRewardIssuance;
+use App\Services\Commerce\BenefitWalletService;
+use App\Services\Commerce\OrderManager;
+use Illuminate\Database\QueryException;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Str;
+
+final class ReferralRewardService
+{
+    public const REWARD_BENEFIT_CODE = 'MBTI_GIFT_CREDITS';
+
+    public const REWARD_SKU = 'MBTI_GIFT_CREDITS';
+
+    public const REWARD_QUANTITY = 1;
+
+    public const STATUS_GRANTED = 'granted';
+
+    public const STATUS_BLOCKED = 'blocked';
+
+    public const REASON_SELF_REFERRAL_SAME_USER = 'self_referral_same_user';
+
+    public const REASON_SELF_REFERRAL_SAME_ANON = 'self_referral_same_anon';
+
+    public const REASON_SELF_REFERRAL_SAME_ATTEMPT = 'self_referral_same_attempt';
+
+    public const REASON_MISSING_COMPARE_INVITE = 'missing_compare_invite';
+
+    public const REASON_INVITE_MISMATCH = 'invite_mismatch';
+
+    public const REASON_DUPLICATE_COMPARE_INVITE = 'duplicate_compare_invite';
+
+    public const REASON_DUPLICATE_ORDER = 'duplicate_order';
+
+    public const REASON_MISSING_INVITER = 'missing_inviter';
+
+    public const REASON_MISSING_INVITEE = 'missing_invitee';
+
+    public const REASON_NOT_PAID = 'not_paid';
+
+    public function __construct(
+        private readonly OrderManager $orders,
+        private readonly BenefitWalletService $wallets,
+    ) {}
+
+    /**
+     * @param  array<string, mixed>  $context
+     * @return array<string, mixed>
+     */
+    public function issueForPaidOrder(string $orderNo, int $orgId, array $context = []): array
+    {
+        $order = $this->orders->findOrderByOrderNo($orderNo, $orgId);
+        if (! $order) {
+            return [
+                'ok' => true,
+                'ignored' => true,
+                'reason' => 'order_not_found',
+            ];
+        }
+
+        $attribution = $this->orders->extractAttributionFromOrder($order);
+        $compareInviteId = $this->normalizeString($attribution['compare_invite_id'] ?? null);
+        if ($compareInviteId === null) {
+            return [
+                'ok' => true,
+                'ignored' => true,
+                'reason' => self::REASON_MISSING_COMPARE_INVITE,
+            ];
+        }
+
+        $existing = $this->findExistingIssuance($compareInviteId, (string) ($order->order_no ?? ''));
+        if ($existing instanceof ReferralRewardIssuance) {
+            return [
+                'ok' => true,
+                'idempotent' => true,
+                'issuance' => $existing,
+                'status' => (string) ($existing->status ?? ''),
+                'reason_code' => $this->normalizeString($existing->reason_code ?? null),
+            ];
+        }
+
+        try {
+            return DB::transaction(function () use ($order, $orgId, $compareInviteId, $attribution, $context): array {
+                $lockedExisting = $this->findExistingIssuance($compareInviteId, (string) ($order->order_no ?? ''));
+                if ($lockedExisting instanceof ReferralRewardIssuance) {
+                    return [
+                        'ok' => true,
+                        'idempotent' => true,
+                        'issuance' => $lockedExisting,
+                        'status' => (string) ($lockedExisting->status ?? ''),
+                        'reason_code' => $this->normalizeString($lockedExisting->reason_code ?? null),
+                    ];
+                }
+
+                $decision = $this->buildDecision($order, $compareInviteId, $attribution, $context);
+                if (($decision['status'] ?? null) === self::STATUS_BLOCKED) {
+                    $issuance = $this->persistIssuance($decision['payload']);
+
+                    return [
+                        'ok' => true,
+                        'issuance' => $issuance,
+                        'status' => self::STATUS_BLOCKED,
+                        'reason_code' => $this->normalizeString($issuance->reason_code ?? null),
+                        'blocked' => true,
+                    ];
+                }
+
+                $grant = $this->recordRewardGrant($decision);
+                $wallet = $this->wallets->topUp(
+                    $orgId,
+                    self::REWARD_BENEFIT_CODE,
+                    self::REWARD_QUANTITY,
+                    $this->walletIdempotencyKey($compareInviteId),
+                    [
+                        'order_no' => (string) ($order->order_no ?? ''),
+                        'attempt_id' => (string) ($decision['inviter_attempt_id'] ?? ''),
+                        'compare_invite_id' => $compareInviteId,
+                        'provider' => $this->normalizeString($context['provider'] ?? null),
+                        'provider_event_id' => $this->normalizeString($context['provider_event_id'] ?? null),
+                    ]
+                );
+
+                if (! ($wallet['ok'] ?? false)) {
+                    $this->failIssuance(
+                        (string) ($wallet['error'] ?? 'REFERRAL_REWARD_WALLET_FAILED'),
+                        (string) ($wallet['message'] ?? 'referral reward wallet topup failed.')
+                    );
+                }
+
+                $issuance = $this->persistIssuance($decision['payload']);
+
+                return [
+                    'ok' => true,
+                    'issuance' => $issuance,
+                    'status' => self::STATUS_GRANTED,
+                    'grant' => $grant,
+                    'wallet' => $wallet['wallet'] ?? null,
+                ];
+            });
+        } catch (\Throwable $e) {
+            [$errorCode, $message] = $this->parseIssuanceFailure($e);
+
+            return [
+                'ok' => false,
+                'error_code' => $errorCode,
+                'message' => $message,
+            ];
+        }
+    }
+
+    /**
+     * @param  array<string, mixed>  $attribution
+     * @param  array<string, mixed>  $context
+     * @return array<string, mixed>
+     */
+    private function buildDecision(object $order, string $compareInviteId, array $attribution, array $context): array
+    {
+        $basePayload = [
+            'id' => (string) Str::uuid(),
+            'org_id' => (int) ($order->org_id ?? 0),
+            'compare_invite_id' => $compareInviteId,
+            'share_id' => $this->normalizeString($attribution['share_id'] ?? null),
+            'trigger_order_no' => (string) ($order->order_no ?? ''),
+            'inviter_attempt_id' => '',
+            'invitee_attempt_id' => '',
+            'inviter_user_id' => null,
+            'invitee_user_id' => null,
+            'inviter_anon_id' => null,
+            'invitee_anon_id' => null,
+            'reward_sku' => self::REWARD_SKU,
+            'reward_quantity' => self::REWARD_QUANTITY,
+            'status' => self::STATUS_BLOCKED,
+            'reason_code' => null,
+            'attribution_json' => null,
+            'granted_at' => null,
+        ];
+
+        if (! $this->orders->isPaidOrFulfilledStatus((string) ($order->status ?? ''))) {
+            $basePayload['reason_code'] = self::REASON_NOT_PAID;
+            $basePayload['attribution_json'] = $this->buildAttributionPayload($order, $attribution, null, null, $context);
+
+            return [
+                'status' => self::STATUS_BLOCKED,
+                'payload' => $basePayload,
+            ];
+        }
+
+        $invite = DB::table('mbti_compare_invites')->where('id', $compareInviteId)->first();
+        if (! $invite) {
+            $basePayload['reason_code'] = self::REASON_MISSING_COMPARE_INVITE;
+            $basePayload['attribution_json'] = $this->buildAttributionPayload($order, $attribution, null, null, $context);
+
+            return [
+                'status' => self::STATUS_BLOCKED,
+                'payload' => $basePayload,
+            ];
+        }
+
+        $inviterAttemptId = trim((string) ($invite->inviter_attempt_id ?? ''));
+        $inviteeAttemptId = trim((string) ($invite->invitee_attempt_id ?? ''));
+        $basePayload['share_id'] = $this->normalizeString($invite->share_id ?? null) ?? $basePayload['share_id'];
+        $basePayload['inviter_attempt_id'] = $inviterAttemptId;
+        $basePayload['invitee_attempt_id'] = $inviteeAttemptId;
+
+        $inviterAttempt = $inviterAttemptId !== ''
+            ? DB::table('attempts')->where('id', $inviterAttemptId)->first()
+            : null;
+        $inviteeAttempt = $inviteeAttemptId !== ''
+            ? DB::table('attempts')->where('id', $inviteeAttemptId)->first()
+            : null;
+
+        $basePayload['inviter_user_id'] = $this->normalizeString($inviterAttempt?->user_id);
+        $basePayload['invitee_user_id'] = $this->normalizeString($invite->invitee_user_id ?? null)
+            ?? $this->normalizeString($inviteeAttempt?->user_id);
+        $basePayload['inviter_anon_id'] = $this->normalizeString($inviterAttempt?->anon_id);
+        $basePayload['invitee_anon_id'] = $this->normalizeString($invite->invitee_anon_id ?? null)
+            ?? $this->normalizeString($inviteeAttempt?->anon_id);
+
+        if ($inviterAttemptId === '' || ! $inviterAttempt) {
+            $basePayload['reason_code'] = self::REASON_MISSING_INVITER;
+            $basePayload['attribution_json'] = $this->buildAttributionPayload($order, $attribution, $invite, null, $context);
+
+            return [
+                'status' => self::STATUS_BLOCKED,
+                'payload' => $basePayload,
+            ];
+        }
+
+        if ($inviteeAttemptId === '' || ! $inviteeAttempt) {
+            $basePayload['reason_code'] = self::REASON_MISSING_INVITEE;
+            $basePayload['attribution_json'] = $this->buildAttributionPayload($order, $attribution, $invite, $inviterAttempt, $context);
+
+            return [
+                'status' => self::STATUS_BLOCKED,
+                'payload' => $basePayload,
+            ];
+        }
+
+        $targetAttemptId = trim((string) ($order->target_attempt_id ?? ''));
+        if ($targetAttemptId === '' || $targetAttemptId !== $inviteeAttemptId) {
+            $basePayload['reason_code'] = self::REASON_INVITE_MISMATCH;
+            $basePayload['attribution_json'] = $this->buildAttributionPayload($order, $attribution, $invite, $inviterAttempt, $context);
+
+            return [
+                'status' => self::STATUS_BLOCKED,
+                'payload' => $basePayload,
+            ];
+        }
+
+        if (
+            $basePayload['inviter_user_id'] !== null
+            && $basePayload['invitee_user_id'] !== null
+            && $basePayload['inviter_user_id'] === $basePayload['invitee_user_id']
+        ) {
+            $basePayload['reason_code'] = self::REASON_SELF_REFERRAL_SAME_USER;
+            $basePayload['attribution_json'] = $this->buildAttributionPayload($order, $attribution, $invite, $inviterAttempt, $context);
+
+            return [
+                'status' => self::STATUS_BLOCKED,
+                'payload' => $basePayload,
+            ];
+        }
+
+        if (
+            $basePayload['inviter_anon_id'] !== null
+            && $basePayload['invitee_anon_id'] !== null
+            && $basePayload['inviter_anon_id'] === $basePayload['invitee_anon_id']
+        ) {
+            $basePayload['reason_code'] = self::REASON_SELF_REFERRAL_SAME_ANON;
+            $basePayload['attribution_json'] = $this->buildAttributionPayload($order, $attribution, $invite, $inviterAttempt, $context);
+
+            return [
+                'status' => self::STATUS_BLOCKED,
+                'payload' => $basePayload,
+            ];
+        }
+
+        if ($inviterAttemptId === $inviteeAttemptId) {
+            $basePayload['reason_code'] = self::REASON_SELF_REFERRAL_SAME_ATTEMPT;
+            $basePayload['attribution_json'] = $this->buildAttributionPayload($order, $attribution, $invite, $inviterAttempt, $context);
+
+            return [
+                'status' => self::STATUS_BLOCKED,
+                'payload' => $basePayload,
+            ];
+        }
+
+        $basePayload['status'] = self::STATUS_GRANTED;
+        $basePayload['granted_at'] = now();
+        $basePayload['attribution_json'] = $this->buildAttributionPayload($order, $attribution, $invite, $inviterAttempt, $context);
+
+        return [
+            'status' => self::STATUS_GRANTED,
+            'payload' => $basePayload,
+            'compare_invite_id' => $compareInviteId,
+            'trigger_order_no' => (string) ($order->order_no ?? ''),
+            'inviter_attempt_id' => $inviterAttemptId,
+            'inviter_user_id' => $basePayload['inviter_user_id'],
+            'inviter_anon_id' => $basePayload['inviter_anon_id'],
+        ];
+    }
+
+    /**
+     * @param  array<string, mixed>  $decision
+     */
+    private function recordRewardGrant(array $decision): object
+    {
+        $compareInviteId = (string) ($decision['compare_invite_id'] ?? '');
+        $triggerOrderNo = (string) ($decision['trigger_order_no'] ?? '');
+        $inviterAttemptId = (string) ($decision['inviter_attempt_id'] ?? '');
+        $inviterUserId = $this->normalizeString($decision['inviter_user_id'] ?? null);
+        $inviterAnonId = $this->normalizeString($decision['inviter_anon_id'] ?? null);
+        $beneficiary = $inviterUserId ?? $inviterAnonId ?? 'attempt:'.$inviterAttemptId;
+        $sourceOrderId = $this->deterministicUuid('referral_reward:'.$compareInviteId);
+        $benefitType = 'referral_reward';
+        $benefitRef = $compareInviteId;
+        $now = now();
+
+        DB::table('benefit_grants')->insertOrIgnore([
+            'id' => $this->deterministicUuid('referral_reward_grant:'.$compareInviteId),
+            'org_id' => (int) ($decision['payload']['org_id'] ?? 0),
+            'user_id' => mb_substr($beneficiary, 0, 64, 'UTF-8'),
+            'benefit_code' => self::REWARD_BENEFIT_CODE,
+            'scope' => 'org',
+            'attempt_id' => $inviterAttemptId !== '' ? $inviterAttemptId : null,
+            'order_no' => $triggerOrderNo !== '' ? $triggerOrderNo : null,
+            'status' => 'active',
+            'expires_at' => null,
+            'benefit_type' => $benefitType,
+            'benefit_ref' => $benefitRef,
+            'source_order_id' => $sourceOrderId,
+            'source_event_id' => null,
+            'meta_json' => json_encode([
+                'granted_via' => 'referral_reward_service',
+                'compare_invite_id' => $compareInviteId,
+                'reward_quantity' => self::REWARD_QUANTITY,
+            ], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES),
+            'created_at' => $now,
+            'updated_at' => $now,
+        ]);
+
+        return DB::table('benefit_grants')
+            ->where('id', $this->deterministicUuid('referral_reward_grant:'.$compareInviteId))
+            ->firstOrFail();
+    }
+
+    /**
+     * @param  array<string, mixed>  $payload
+     */
+    private function persistIssuance(array $payload): ReferralRewardIssuance
+    {
+        try {
+            /** @var ReferralRewardIssuance $issuance */
+            $issuance = ReferralRewardIssuance::query()->create($payload);
+
+            return $issuance;
+        } catch (QueryException $e) {
+            $existing = $this->findExistingIssuance(
+                (string) ($payload['compare_invite_id'] ?? ''),
+                (string) ($payload['trigger_order_no'] ?? ''),
+            );
+
+            if ($existing instanceof ReferralRewardIssuance) {
+                return $existing;
+            }
+
+            throw $e;
+        }
+    }
+
+    private function findExistingIssuance(string $compareInviteId, string $triggerOrderNo): ?ReferralRewardIssuance
+    {
+        $normalizedInviteId = trim($compareInviteId);
+        $normalizedOrderNo = trim($triggerOrderNo);
+        if ($normalizedInviteId === '' && $normalizedOrderNo === '') {
+            return null;
+        }
+
+        $query = ReferralRewardIssuance::query();
+        if ($normalizedInviteId !== '') {
+            $query->where('compare_invite_id', $normalizedInviteId);
+            if ($normalizedOrderNo !== '') {
+                $query->orWhere('trigger_order_no', $normalizedOrderNo);
+            }
+        } else {
+            $query->where('trigger_order_no', $normalizedOrderNo);
+        }
+
+        return $query->first();
+    }
+
+    /**
+     * @param  array<string, mixed>  $attribution
+     * @param  array<string, mixed>  $context
+     * @return array<string, mixed>
+     */
+    private function buildAttributionPayload(
+        object $order,
+        array $attribution,
+        ?object $invite,
+        ?object $inviterAttempt,
+        array $context
+    ): array {
+        return [
+            'source' => 'payment_webhook',
+            'provider' => $this->normalizeString($context['provider'] ?? null),
+            'provider_event_id' => $this->normalizeString($context['provider_event_id'] ?? null),
+            'order' => [
+                'order_no' => $this->normalizeString($order->order_no ?? null),
+                'status' => $this->normalizeString($order->status ?? null),
+                'target_attempt_id' => $this->normalizeString($order->target_attempt_id ?? null),
+            ],
+            'attribution' => $attribution,
+            'compare_invite' => [
+                'id' => $this->normalizeString($invite?->id),
+                'share_id' => $this->normalizeString($invite?->share_id),
+                'status' => $this->normalizeString($invite?->status),
+                'inviter_attempt_id' => $this->normalizeString($invite?->inviter_attempt_id),
+                'invitee_attempt_id' => $this->normalizeString($invite?->invitee_attempt_id),
+                'invitee_user_id' => $this->normalizeString($invite?->invitee_user_id),
+                'invitee_anon_id' => $this->normalizeString($invite?->invitee_anon_id),
+            ],
+            'inviter_attempt' => [
+                'id' => $this->normalizeString($inviterAttempt?->id),
+                'user_id' => $this->normalizeString($inviterAttempt?->user_id),
+                'anon_id' => $this->normalizeString($inviterAttempt?->anon_id),
+            ],
+        ];
+    }
+
+    private function walletIdempotencyKey(string $compareInviteId): string
+    {
+        return 'REFERRAL_REWARD:'.trim($compareInviteId);
+    }
+
+    private function failIssuance(string $errorCode, string $message): never
+    {
+        throw new \RuntimeException($errorCode.'|'.$message);
+    }
+
+    /**
+     * @return array{0:string,1:string}
+     */
+    private function parseIssuanceFailure(\Throwable $e): array
+    {
+        $message = trim($e->getMessage());
+        if ($message !== '' && str_contains($message, '|')) {
+            [$errorCode, $errorMessage] = explode('|', $message, 2);
+
+            return [
+                trim($errorCode) !== '' ? trim($errorCode) : 'REFERRAL_REWARD_ISSUANCE_FAILED',
+                trim($errorMessage) !== '' ? trim($errorMessage) : 'referral reward issuance failed.',
+            ];
+        }
+
+        return [
+            'REFERRAL_REWARD_ISSUANCE_FAILED',
+            $message !== '' ? $message : 'referral reward issuance failed.',
+        ];
+    }
+
+    private function deterministicUuid(string $seed): string
+    {
+        $hash = md5($seed);
+
+        return sprintf(
+            '%s-%s-%s-%s-%s',
+            substr($hash, 0, 8),
+            substr($hash, 8, 4),
+            substr($hash, 12, 4),
+            substr($hash, 16, 4),
+            substr($hash, 20, 12),
+        );
+    }
+
+    private function normalizeString(mixed $value): ?string
+    {
+        if (! is_scalar($value)) {
+            return null;
+        }
+
+        $normalized = trim((string) $value);
+
+        return $normalized === '' ? null : $normalized;
+    }
+}

--- a/backend/database/migrations/2026_03_14_120000_create_referral_reward_issuances_table.php
+++ b/backend/database/migrations/2026_03_14_120000_create_referral_reward_issuances_table.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    private const TABLE = 'referral_reward_issuances';
+
+    public function up(): void
+    {
+        if (Schema::hasTable(self::TABLE)) {
+            return;
+        }
+
+        Schema::create(self::TABLE, function (Blueprint $table): void {
+            $table->uuid('id')->primary();
+            $table->unsignedBigInteger('org_id')->default(0)->index();
+            $table->string('compare_invite_id', 128)->unique();
+            $table->string('share_id', 128)->nullable()->index();
+            $table->string('trigger_order_no', 64)->unique();
+            $table->string('inviter_attempt_id', 64);
+            $table->string('invitee_attempt_id', 64);
+            $table->string('inviter_user_id', 64)->nullable();
+            $table->string('invitee_user_id', 64)->nullable();
+            $table->string('inviter_anon_id', 128)->nullable();
+            $table->string('invitee_anon_id', 128)->nullable();
+            $table->string('reward_sku', 64);
+            $table->unsignedInteger('reward_quantity')->default(1);
+            $table->string('status', 16)->index();
+            $table->string('reason_code', 64)->nullable();
+            $table->json('attribution_json')->nullable();
+            $table->timestamp('granted_at')->nullable();
+            $table->timestamps();
+
+            $table->index(['org_id', 'status', 'created_at'], 'referral_reward_issuances_org_status_created_idx');
+        });
+    }
+
+    public function down(): void
+    {
+        // forward-only migration: rollback disabled to prevent data loss in production.
+        // Irreversible operation: schema/data rollback handled via forward fix migrations.
+    }
+};

--- a/backend/tests/Feature/Commerce/ReferralRewardIssuanceTest.php
+++ b/backend/tests/Feature/Commerce/ReferralRewardIssuanceTest.php
@@ -1,0 +1,262 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Commerce;
+
+use Database\Seeders\Pr19CommerceSeeder;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Str;
+use Tests\Concerns\SignedBillingWebhook;
+use Tests\TestCase;
+
+final class ReferralRewardIssuanceTest extends TestCase
+{
+    use RefreshDatabase;
+    use SignedBillingWebhook;
+
+    public function test_paid_order_with_compare_invite_grants_one_referral_reward(): void
+    {
+        $this->seedCommerce();
+
+        $inviterAttemptId = $this->createAttempt('anon_reward_inviter', '1001');
+        $inviteeAttemptId = $this->createAttempt('anon_reward_invitee');
+        $inviteId = $this->createCompareInvite($inviterAttemptId, $inviteeAttemptId, 'anon_reward_invitee');
+        $orderNo = 'ord_referral_reward_1';
+
+        $this->createCreditOrder($orderNo, $inviteeAttemptId, [
+            'share_id' => 'share_reward_1',
+            'compare_invite_id' => $inviteId,
+        ], 'anon_reward_invitee');
+
+        $response = $this->postSignedBillingWebhook($this->billingPayload('evt_referral_reward_1', $orderNo), [
+            'X-Org-Id' => '0',
+        ]);
+
+        $response->assertOk()
+            ->assertJsonPath('ok', true)
+            ->assertJsonPath('order_no', $orderNo);
+
+        $issuance = DB::table('referral_reward_issuances')->where('compare_invite_id', $inviteId)->first();
+        $this->assertNotNull($issuance);
+        $this->assertSame('granted', (string) ($issuance->status ?? ''));
+        $this->assertSame($orderNo, (string) ($issuance->trigger_order_no ?? ''));
+        $this->assertSame($inviterAttemptId, (string) ($issuance->inviter_attempt_id ?? ''));
+        $this->assertSame($inviteeAttemptId, (string) ($issuance->invitee_attempt_id ?? ''));
+        $this->assertSame('MBTI_GIFT_CREDITS', (string) ($issuance->reward_sku ?? ''));
+        $this->assertSame(1, (int) ($issuance->reward_quantity ?? 0));
+        $this->assertNotNull($issuance->granted_at);
+
+        $this->assertSame(1, DB::table('benefit_grants')
+            ->where('benefit_code', 'MBTI_GIFT_CREDITS')
+            ->where('order_no', $orderNo)
+            ->count());
+        $this->assertSame(1, DB::table('benefit_wallet_ledgers')
+            ->where('benefit_code', 'MBTI_GIFT_CREDITS')
+            ->where('reason', 'topup')
+            ->count());
+        $this->assertSame(1, (int) DB::table('benefit_wallets')
+            ->where('org_id', 0)
+            ->where('benefit_code', 'MBTI_GIFT_CREDITS')
+            ->value('balance'));
+
+        $inviteRow = DB::table('mbti_compare_invites')->where('id', $inviteId)->first();
+        $this->assertSame('purchased', (string) ($inviteRow->status ?? ''));
+        $this->assertSame($orderNo, (string) ($inviteRow->invitee_order_no ?? ''));
+    }
+
+    public function test_same_webhook_replay_does_not_issue_a_second_referral_reward(): void
+    {
+        $this->seedCommerce();
+
+        $inviterAttemptId = $this->createAttempt('anon_reward_replay_inviter');
+        $inviteeAttemptId = $this->createAttempt('anon_reward_replay_invitee');
+        $inviteId = $this->createCompareInvite($inviterAttemptId, $inviteeAttemptId, 'anon_reward_replay_invitee');
+        $orderNo = 'ord_referral_reward_replay_1';
+        $payload = $this->billingPayload('evt_referral_reward_replay_1', $orderNo);
+
+        $this->createCreditOrder($orderNo, $inviteeAttemptId, [
+            'share_id' => 'share_reward_replay_1',
+            'compare_invite_id' => $inviteId,
+        ], 'anon_reward_replay_invitee');
+
+        $first = $this->postSignedBillingWebhook($payload, [
+            'X-Org-Id' => '0',
+        ]);
+        $first->assertOk()->assertJsonPath('ok', true);
+
+        $second = $this->postSignedBillingWebhook($payload, [
+            'X-Org-Id' => '0',
+        ]);
+        $second->assertOk()
+            ->assertJsonPath('ok', true)
+            ->assertJsonPath('duplicate', true);
+
+        $this->assertSame(1, DB::table('referral_reward_issuances')->where('compare_invite_id', $inviteId)->count());
+        $this->assertSame(1, DB::table('benefit_grants')
+            ->where('benefit_code', 'MBTI_GIFT_CREDITS')
+            ->where('order_no', $orderNo)
+            ->count());
+        $this->assertSame(1, DB::table('benefit_wallet_ledgers')
+            ->where('benefit_code', 'MBTI_GIFT_CREDITS')
+            ->where('reason', 'topup')
+            ->count());
+    }
+
+    public function test_share_id_only_attribution_does_not_issue_reward(): void
+    {
+        $this->seedCommerce();
+
+        $inviteeAttemptId = $this->createAttempt('anon_share_only_invitee');
+        $orderNo = 'ord_referral_share_only_1';
+
+        $this->createCreditOrder($orderNo, $inviteeAttemptId, [
+            'share_id' => 'share_only_1',
+        ], 'anon_share_only_invitee');
+
+        $response = $this->postSignedBillingWebhook($this->billingPayload('evt_referral_share_only_1', $orderNo), [
+            'X-Org-Id' => '0',
+        ]);
+
+        $response->assertOk()->assertJsonPath('ok', true);
+
+        $this->assertSame(0, DB::table('referral_reward_issuances')->count());
+        $this->assertSame(0, DB::table('benefit_grants')->where('benefit_code', 'MBTI_GIFT_CREDITS')->count());
+        $this->assertSame(0, DB::table('benefit_wallet_ledgers')->where('benefit_code', 'MBTI_GIFT_CREDITS')->count());
+    }
+
+    public function test_missing_compare_invite_id_does_not_issue_reward(): void
+    {
+        $this->seedCommerce();
+
+        $inviteeAttemptId = $this->createAttempt('anon_no_compare_invitee');
+        $orderNo = 'ord_referral_missing_compare_1';
+
+        $this->createCreditOrder($orderNo, $inviteeAttemptId, [], 'anon_no_compare_invitee');
+
+        $response = $this->postSignedBillingWebhook($this->billingPayload('evt_referral_missing_compare_1', $orderNo), [
+            'X-Org-Id' => '0',
+        ]);
+
+        $response->assertOk()->assertJsonPath('ok', true);
+
+        $this->assertSame(0, DB::table('referral_reward_issuances')->count());
+        $this->assertSame(0, DB::table('benefit_grants')->where('benefit_code', 'MBTI_GIFT_CREDITS')->count());
+        $this->assertSame(0, DB::table('benefit_wallet_ledgers')->where('benefit_code', 'MBTI_GIFT_CREDITS')->count());
+    }
+
+    private function seedCommerce(): void
+    {
+        (new Pr19CommerceSeeder)->run();
+    }
+
+    private function createAttempt(string $anonId, ?string $userId = null): string
+    {
+        $attemptId = (string) Str::uuid();
+
+        DB::table('attempts')->insert([
+            'id' => $attemptId,
+            'org_id' => 0,
+            'anon_id' => $anonId,
+            'user_id' => $userId,
+            'scale_code' => 'MBTI',
+            'scale_version' => 'v0.3',
+            'region' => 'CN_MAINLAND',
+            'locale' => 'zh-CN',
+            'question_count' => 144,
+            'answers_summary_json' => json_encode(['stage' => 'seed'], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES),
+            'client_platform' => 'test',
+            'started_at' => now()->subMinutes(5),
+            'submitted_at' => now()->subMinute(),
+            'pack_id' => 'MBTI.cn-mainland.zh-CN.v0.3',
+            'dir_version' => 'MBTI-CN-v0.3',
+            'content_package_version' => 'v0.3',
+            'scoring_spec_version' => '2026.01',
+            'created_at' => now(),
+            'updated_at' => now(),
+        ]);
+
+        return $attemptId;
+    }
+
+    private function createCompareInvite(string $inviterAttemptId, string $inviteeAttemptId, string $inviteeAnonId, ?int $inviteeUserId = null): string
+    {
+        $inviteId = (string) Str::uuid();
+
+        DB::table('mbti_compare_invites')->insert([
+            'id' => $inviteId,
+            'share_id' => 'share_'.Str::lower(Str::random(8)),
+            'inviter_attempt_id' => $inviterAttemptId,
+            'inviter_scale_code' => 'MBTI',
+            'locale' => 'zh-CN',
+            'inviter_type_code' => 'INTJ-A',
+            'invitee_attempt_id' => $inviteeAttemptId,
+            'invitee_anon_id' => $inviteeAnonId,
+            'invitee_user_id' => $inviteeUserId,
+            'invitee_order_no' => null,
+            'status' => 'ready',
+            'meta_json' => null,
+            'accepted_at' => now()->subMinutes(2),
+            'completed_at' => now()->subMinute(),
+            'purchased_at' => null,
+            'created_at' => now()->subMinutes(3),
+            'updated_at' => now()->subMinute(),
+        ]);
+
+        return $inviteId;
+    }
+
+    /**
+     * @param  array<string, mixed>  $attribution
+     */
+    private function createCreditOrder(string $orderNo, string $targetAttemptId, array $attribution, string $anonId, ?string $userId = null): void
+    {
+        $meta = $attribution !== []
+            ? json_encode(['attribution' => $attribution], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES)
+            : null;
+
+        DB::table('orders')->insert([
+            'id' => (string) Str::uuid(),
+            'order_no' => $orderNo,
+            'org_id' => 0,
+            'user_id' => $userId,
+            'anon_id' => $anonId,
+            'sku' => 'MBTI_CREDIT',
+            'quantity' => 1,
+            'target_attempt_id' => $targetAttemptId,
+            'amount_cents' => 4990,
+            'currency' => 'USD',
+            'status' => 'created',
+            'provider' => 'billing',
+            'external_trade_no' => null,
+            'paid_at' => null,
+            'created_at' => now(),
+            'updated_at' => now(),
+            'amount_total' => 4990,
+            'amount_refunded' => 0,
+            'item_sku' => 'MBTI_CREDIT',
+            'provider_order_id' => null,
+            'device_id' => null,
+            'request_id' => null,
+            'created_ip' => null,
+            'fulfilled_at' => null,
+            'refunded_at' => null,
+            'meta_json' => $meta,
+        ]);
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function billingPayload(string $eventId, string $orderNo): array
+    {
+        return [
+            'provider_event_id' => $eventId,
+            'order_no' => $orderNo,
+            'external_trade_no' => 'trade_'.$eventId,
+            'amount_cents' => 4990,
+            'currency' => 'USD',
+        ];
+    }
+}

--- a/backend/tests/Feature/V0_3/ReferralRewardAbuseGuardTest.php
+++ b/backend/tests/Feature/V0_3/ReferralRewardAbuseGuardTest.php
@@ -1,0 +1,235 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\V0_3;
+
+use Database\Seeders\Pr19CommerceSeeder;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Str;
+use Tests\Concerns\SignedBillingWebhook;
+use Tests\TestCase;
+
+final class ReferralRewardAbuseGuardTest extends TestCase
+{
+    use RefreshDatabase;
+    use SignedBillingWebhook;
+
+    public function test_self_referral_same_user_is_blocked(): void
+    {
+        $this->seedCommerce();
+
+        $inviterAttemptId = $this->createAttempt('anon_same_user_inviter', '1001');
+        $inviteeAttemptId = $this->createAttempt('anon_same_user_invitee', '1001');
+        $inviteId = $this->createCompareInvite($inviterAttemptId, $inviteeAttemptId, 'anon_same_user_invitee', 1001);
+        $orderNo = 'ord_referral_block_same_user';
+
+        $this->createCreditOrder($orderNo, $inviteeAttemptId, $inviteId, 'anon_same_user_invitee', '1001');
+
+        $response = $this->postSignedBillingWebhook($this->billingPayload('evt_referral_block_same_user', $orderNo), [
+            'X-Org-Id' => '0',
+        ]);
+
+        $response->assertOk()->assertJsonPath('ok', true);
+
+        $this->assertBlockedReward($inviteId, $orderNo, 'self_referral_same_user');
+    }
+
+    public function test_self_referral_same_anon_is_blocked(): void
+    {
+        $this->seedCommerce();
+
+        $inviterAttemptId = $this->createAttempt('anon_same_anon');
+        $inviteeAttemptId = $this->createAttempt('anon_same_anon');
+        $inviteId = $this->createCompareInvite($inviterAttemptId, $inviteeAttemptId, 'anon_same_anon');
+        $orderNo = 'ord_referral_block_same_anon';
+
+        $this->createCreditOrder($orderNo, $inviteeAttemptId, $inviteId, 'anon_same_anon');
+
+        $response = $this->postSignedBillingWebhook($this->billingPayload('evt_referral_block_same_anon', $orderNo), [
+            'X-Org-Id' => '0',
+        ]);
+
+        $response->assertOk()->assertJsonPath('ok', true);
+
+        $this->assertBlockedReward($inviteId, $orderNo, 'self_referral_same_anon');
+    }
+
+    public function test_self_referral_same_attempt_is_blocked(): void
+    {
+        $this->seedCommerce();
+
+        $sharedAttemptId = $this->createAttempt('anon_same_attempt_inviter');
+        $inviteId = $this->createCompareInvite($sharedAttemptId, $sharedAttemptId, 'anon_same_attempt_invitee');
+        $orderNo = 'ord_referral_block_same_attempt';
+
+        DB::table('mbti_compare_invites')
+            ->where('id', $inviteId)
+            ->update([
+                'invitee_anon_id' => 'anon_same_attempt_invitee',
+                'invitee_user_id' => null,
+            ]);
+
+        $this->createCreditOrder($orderNo, $sharedAttemptId, $inviteId, 'anon_same_attempt_invitee');
+
+        $response = $this->postSignedBillingWebhook($this->billingPayload('evt_referral_block_same_attempt', $orderNo), [
+            'X-Org-Id' => '0',
+        ]);
+
+        $response->assertOk()->assertJsonPath('ok', true);
+
+        $this->assertBlockedReward($inviteId, $orderNo, 'self_referral_same_attempt');
+    }
+
+    public function test_compare_invite_mismatch_with_order_target_is_blocked(): void
+    {
+        $this->seedCommerce();
+
+        $inviterAttemptId = $this->createAttempt('anon_mismatch_inviter');
+        $inviteeAttemptId = $this->createAttempt('anon_mismatch_invitee');
+        $orderAttemptId = $this->createAttempt('anon_mismatch_order_target');
+        $inviteId = $this->createCompareInvite($inviterAttemptId, $inviteeAttemptId, 'anon_mismatch_invitee');
+        $orderNo = 'ord_referral_block_mismatch';
+
+        $this->createCreditOrder($orderNo, $orderAttemptId, $inviteId, 'anon_mismatch_order_target');
+
+        $response = $this->postSignedBillingWebhook($this->billingPayload('evt_referral_block_mismatch', $orderNo), [
+            'X-Org-Id' => '0',
+        ]);
+
+        $response->assertOk()->assertJsonPath('ok', true);
+
+        $this->assertBlockedReward($inviteId, $orderNo, 'invite_mismatch');
+    }
+
+    private function assertBlockedReward(string $inviteId, string $orderNo, string $reasonCode): void
+    {
+        $issuance = DB::table('referral_reward_issuances')->where('compare_invite_id', $inviteId)->first();
+        $this->assertNotNull($issuance);
+        $this->assertSame('blocked', (string) ($issuance->status ?? ''));
+        $this->assertSame($reasonCode, (string) ($issuance->reason_code ?? ''));
+        $this->assertSame($orderNo, (string) ($issuance->trigger_order_no ?? ''));
+        $this->assertNull($issuance->granted_at);
+        $this->assertSame(0, DB::table('benefit_grants')
+            ->where('benefit_code', 'MBTI_GIFT_CREDITS')
+            ->where('order_no', $orderNo)
+            ->count());
+        $this->assertSame(0, DB::table('benefit_wallet_ledgers')
+            ->where('benefit_code', 'MBTI_GIFT_CREDITS')
+            ->where('order_no', $orderNo)
+            ->count());
+    }
+
+    private function seedCommerce(): void
+    {
+        (new Pr19CommerceSeeder)->run();
+    }
+
+    private function createAttempt(string $anonId, ?string $userId = null): string
+    {
+        $attemptId = (string) Str::uuid();
+
+        DB::table('attempts')->insert([
+            'id' => $attemptId,
+            'org_id' => 0,
+            'anon_id' => $anonId,
+            'user_id' => $userId,
+            'scale_code' => 'MBTI',
+            'scale_version' => 'v0.3',
+            'region' => 'CN_MAINLAND',
+            'locale' => 'zh-CN',
+            'question_count' => 144,
+            'answers_summary_json' => json_encode(['stage' => 'seed'], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES),
+            'client_platform' => 'test',
+            'started_at' => now()->subMinutes(5),
+            'submitted_at' => now()->subMinute(),
+            'pack_id' => 'MBTI.cn-mainland.zh-CN.v0.3',
+            'dir_version' => 'MBTI-CN-v0.3',
+            'content_package_version' => 'v0.3',
+            'scoring_spec_version' => '2026.01',
+            'created_at' => now(),
+            'updated_at' => now(),
+        ]);
+
+        return $attemptId;
+    }
+
+    private function createCompareInvite(string $inviterAttemptId, string $inviteeAttemptId, string $inviteeAnonId, ?int $inviteeUserId = null): string
+    {
+        $inviteId = (string) Str::uuid();
+
+        DB::table('mbti_compare_invites')->insert([
+            'id' => $inviteId,
+            'share_id' => 'share_'.Str::lower(Str::random(8)),
+            'inviter_attempt_id' => $inviterAttemptId,
+            'inviter_scale_code' => 'MBTI',
+            'locale' => 'zh-CN',
+            'inviter_type_code' => 'INTJ-A',
+            'invitee_attempt_id' => $inviteeAttemptId,
+            'invitee_anon_id' => $inviteeAnonId,
+            'invitee_user_id' => $inviteeUserId,
+            'invitee_order_no' => null,
+            'status' => 'ready',
+            'meta_json' => null,
+            'accepted_at' => now()->subMinutes(2),
+            'completed_at' => now()->subMinute(),
+            'purchased_at' => null,
+            'created_at' => now()->subMinutes(3),
+            'updated_at' => now()->subMinute(),
+        ]);
+
+        return $inviteId;
+    }
+
+    private function createCreditOrder(string $orderNo, string $targetAttemptId, string $compareInviteId, string $anonId, ?string $userId = null): void
+    {
+        DB::table('orders')->insert([
+            'id' => (string) Str::uuid(),
+            'order_no' => $orderNo,
+            'org_id' => 0,
+            'user_id' => $userId,
+            'anon_id' => $anonId,
+            'sku' => 'MBTI_CREDIT',
+            'quantity' => 1,
+            'target_attempt_id' => $targetAttemptId,
+            'amount_cents' => 4990,
+            'currency' => 'USD',
+            'status' => 'created',
+            'provider' => 'billing',
+            'external_trade_no' => null,
+            'paid_at' => null,
+            'created_at' => now(),
+            'updated_at' => now(),
+            'amount_total' => 4990,
+            'amount_refunded' => 0,
+            'item_sku' => 'MBTI_CREDIT',
+            'provider_order_id' => null,
+            'device_id' => null,
+            'request_id' => null,
+            'created_ip' => null,
+            'fulfilled_at' => null,
+            'refunded_at' => null,
+            'meta_json' => json_encode([
+                'attribution' => [
+                    'share_id' => 'share_abuse_'.Str::lower(Str::random(6)),
+                    'compare_invite_id' => $compareInviteId,
+                ],
+            ], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES),
+        ]);
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function billingPayload(string $eventId, string $orderNo): array
+    {
+        return [
+            'provider_event_id' => $eventId,
+            'order_no' => $orderNo,
+            'external_trade_no' => 'trade_'.$eventId,
+            'amount_cents' => 4990,
+            'currency' => 'USD',
+        ];
+    }
+}


### PR DESCRIPTION
## Summary

- add `referral_reward_issuances` as the backend-only issuance fact table
- issue one inviter-side referral reward after paid/fulfilled webhook processing when `order.meta_json.attribution.compare_invite_id` closes correctly
- block self-referral, invite mismatch, and replay/once-only duplicates while preserving the existing share/compare/take/checkout main chain

## Tests

- `php -l app/Services/Commerce/OrderManager.php`
- `php -l app/Internal/Commerce/PaymentWebhookHandlerCore.php`
- `php -l app/Models/ReferralRewardIssuance.php`
- `php -l app/Services/Referral/ReferralRewardService.php`
- `php -l tests/Feature/Commerce/ReferralRewardIssuanceTest.php`
- `php -l tests/Feature/V0_3/ReferralRewardAbuseGuardTest.php`
- `php artisan route:list | rg "share|compare|invite|orders|checkout|claim|wallet|benefit|reward"`
- `php artisan migrate`
- `php artisan test tests/Feature/Commerce/ReferralRewardIssuanceTest.php`
- `php artisan test tests/Feature/V0_3/ReferralRewardAbuseGuardTest.php`
- `php artisan test tests/Feature/V0_3/ShareClickAttributionTest.php`
- `php artisan test tests/Feature/V0_3/ShareFlowCoreAlignmentTest.php`
- `php artisan test tests/Feature/V0_3/MbtiCompareInviteContractTest.php`
- `php artisan test tests/Feature/V0_3/MbtiCompareInviteAttributionFlowTest.php`
- `php artisan test tests/Feature/V0_3/RateLimitKeyEndpointsTest.php`
- `php artisan test tests/Feature/UuidRouteParamsMiddlewareTest.php`
- `php artisan test tests/Feature/V0_3/CommerceOrderLookupSecurityTest.php`
- `php artisan test tests/Feature/V0_3/CommerceOrderReadFallbackTest.php`
- `php artisan test tests/Feature/Commerce/PaymentWebhookProcessorAtomicityTest.php`
- `php artisan test tests/Feature/V0_3/CommerceCheckoutPayActionTest.php`
- `php artisan test tests/Feature/Commerce/BigFiveUnlockDeliveryPipelineTest.php`
- `php artisan test tests/Feature/V0_3/PaymentWebhookControllerTest.php`
- `php artisan test tests/Feature/Report/ReportPdfCrossScaleDeliveryTest.php`
- `./vendor/bin/pint app/Services/Commerce/OrderManager.php app/Internal/Commerce/PaymentWebhookHandlerCore.php app/Models/ReferralRewardIssuance.php app/Services/Referral/ReferralRewardService.php tests/Feature/Commerce/ReferralRewardIssuanceTest.php tests/Feature/V0_3/ReferralRewardAbuseGuardTest.php database/migrations/2026_03_14_120000_create_referral_reward_issuances_table.php`
- `bash scripts/ci_verify_mbti.sh`
- `pnpm exec vitest run tests/contracts/email-preferences.contract.test.tsx tests/contracts/order-lookup-recovery.contract.test.tsx tests/contracts/orders-client-delivery.contract.test.tsx tests/contracts/result-client-view-state.contract.test.tsx tests/contracts/mbti-checkout-wiring.contract.test.tsx tests/contracts/mbti-post-purchase-retention.contract.test.tsx tests/contracts/mbti-share-consumer.contract.test.tsx tests/contracts/mbti-compare-invite.consumer.contract.test.tsx tests/contracts/mbti-take-attribution.contract.test.tsx`
- `pnpm exec playwright test tests/e2e/email-preferences.spec.ts tests/e2e/email-unsubscribe.spec.ts tests/e2e/help-center.spec.ts tests/e2e/order-lookup-recovery.spec.ts tests/e2e/mbti-post-purchase.spec.ts tests/e2e/mbti-share.spec.ts tests/e2e/mbti-compare-invite.spec.ts`
