### PR TITLE
feat(commerce): add Unlock / Commerce Linkage for support diagnostics

### DIFF
--- a/backend/app/Filament/Ops/Resources/OrderResource.php
+++ b/backend/app/Filament/Ops/Resources/OrderResource.php
@@ -7,20 +7,17 @@ namespace App\Filament\Ops\Resources;
 use App\Filament\Ops\Resources\OrderResource\Pages;
 use App\Filament\Ops\Resources\OrderResource\RelationManagers\BenefitGrantsRelationManager;
 use App\Filament\Ops\Resources\OrderResource\RelationManagers\PaymentEventsRelationManager;
-use App\Filament\Ops\Support\StatusBadge;
-use App\Filament\Shared\BaseTenantResource;
-use App\Models\AdminApproval;
+use App\Filament\Ops\Resources\OrderResource\Support\OrderLinkageSupport;
 use App\Models\Order;
-use App\Services\Audit\AuditLogger;
 use App\Support\Rbac\PermissionNames;
 use Filament\Forms;
 use Filament\Forms\Form;
-use Filament\Notifications\Notification;
 use Filament\Tables;
+use Filament\Tables\Enums\FiltersLayout;
 use Filament\Tables\Table;
-use Illuminate\Support\Str;
+use Illuminate\Database\Eloquent\Builder;
 
-class OrderResource extends BaseTenantResource
+class OrderResource extends \App\Filament\Shared\BaseTenantResource
 {
     protected static ?string $model = Order::class;
 
@@ -47,92 +44,250 @@ class OrderResource extends BaseTenantResource
 
     public static function canViewAny(): bool
     {
-        return self::canCommerceAccess();
+        return self::canDiagnosticsAccess();
+    }
+
+    public static function canView($record): bool
+    {
+        return self::canDiagnosticsAccess();
+    }
+
+    public static function canCreate(): bool
+    {
+        return false;
+    }
+
+    public static function canEdit($record): bool
+    {
+        return false;
+    }
+
+    public static function canDelete($record): bool
+    {
+        return false;
+    }
+
+    public static function getEloquentQuery(): Builder
+    {
+        return app(OrderLinkageSupport::class)->query();
     }
 
     public static function table(Table $table): Table
     {
+        $support = app(OrderLinkageSupport::class);
+
         return $table
+            ->searchPlaceholder('order_no / attempt_id / contact_email / share_id')
+            ->searchDebounce('600ms')
+            ->recordUrl(fn (Order $record): string => static::getUrl('view', ['record' => $record]))
             ->columns([
-                Tables\Columns\TextColumn::make('order_no')->searchable()->copyable(),
-                Tables\Columns\TextColumn::make('status')
-                    ->badge()
-                    ->color(fn (string $state): string => StatusBadge::color($state))
+                Tables\Columns\TextColumn::make('order_no')
+                    ->copyable()
+                    ->searchable(query: function (Builder $query, string $search) use ($support): void {
+                        $support->applySearch($query, $search);
+                    })
                     ->sortable(),
-                Tables\Columns\TextColumn::make('provider')->sortable(),
-                Tables\Columns\TextColumn::make('amount_cents')->label('Amount')->numeric()->sortable(),
-                Tables\Columns\TextColumn::make('currency')->sortable(),
-                Tables\Columns\TextColumn::make('target_attempt_id')->label('Attempt')->toggleable(),
-                Tables\Columns\TextColumn::make('paid_at')->dateTime()->sortable()->toggleable(),
-                Tables\Columns\TextColumn::make('updated_at')->dateTime()->sortable(),
+                Tables\Columns\TextColumn::make('created_at')
+                    ->dateTime()
+                    ->sortable(),
+                Tables\Columns\TextColumn::make('paid_at')
+                    ->dateTime()
+                    ->sortable(),
+                Tables\Columns\TextColumn::make('updated_at')
+                    ->dateTime()
+                    ->sortable(),
+                Tables\Columns\TextColumn::make('provider')
+                    ->sortable(),
+                Tables\Columns\TextColumn::make('amount_cents')
+                    ->label('Amount (cents)')
+                    ->numeric()
+                    ->sortable(),
+                Tables\Columns\TextColumn::make('currency')
+                    ->sortable(),
+                Tables\Columns\TextColumn::make('status')
+                    ->label('Order status')
+                    ->formatStateUsing(fn (Order $record): string => $support->orderStatus($record)['label'])
+                    ->badge()
+                    ->color(fn (Order $record): string => $support->orderStatus($record)['state']),
+                Tables\Columns\TextColumn::make('latest_payment_status')
+                    ->label('Payment status')
+                    ->state(fn (Order $record): string => $support->paymentStatus($record)['label'])
+                    ->badge()
+                    ->color(fn (Order $record): string => $support->paymentStatus($record)['state']),
+                Tables\Columns\TextColumn::make('target_attempt_id')
+                    ->label('attempt_id')
+                    ->copyable(),
+                Tables\Columns\TextColumn::make('requested_sku')
+                    ->label('Requested SKU')
+                    ->state(fn (Order $record): string => $support->requestedSku($record)),
+                Tables\Columns\TextColumn::make('effective_sku')
+                    ->label('Effective SKU')
+                    ->state(fn (Order $record): string => $support->effectiveSku($record)),
+                Tables\Columns\TextColumn::make('latest_benefit_code')
+                    ->label('Benefit code')
+                    ->state(fn (Order $record): string => $record->latest_benefit_code !== null && trim((string) $record->latest_benefit_code) !== '' ? (string) $record->latest_benefit_code : '-'),
+                Tables\Columns\TextColumn::make('unlock_status')
+                    ->label('Unlock status')
+                    ->state(fn (Order $record): string => $support->unlockStatus($record)['label'])
+                    ->badge()
+                    ->color(fn (Order $record): string => $support->unlockStatus($record)['state']),
+                Tables\Columns\TextColumn::make('latest_snapshot_status')
+                    ->label('Report snapshot')
+                    ->state(fn (Order $record): string => $support->snapshotStatus($record)['label'])
+                    ->badge()
+                    ->color(fn (Order $record): string => $support->snapshotStatus($record)['state']),
+                Tables\Columns\TextColumn::make('pdf_ready')
+                    ->label('PDF ready')
+                    ->state(fn (Order $record): string => $support->pdfStatus($record)['label'])
+                    ->badge()
+                    ->color(fn (Order $record): string => $support->pdfStatus($record)['state']),
+                Tables\Columns\TextColumn::make('attempt_locale')
+                    ->label('locale')
+                    ->toggleable(isToggledHiddenByDefault: true),
+                Tables\Columns\TextColumn::make('attempt_region')
+                    ->label('region')
+                    ->toggleable(isToggledHiddenByDefault: true),
+                Tables\Columns\IconColumn::make('contact_email_present')
+                    ->label('contact_email')
+                    ->state(fn (Order $record): bool => $support->contactEmailPresent($record))
+                    ->boolean()
+                    ->toggleable(isToggledHiddenByDefault: true),
+                Tables\Columns\TextColumn::make('latest_delivery_email_sent_at')
+                    ->label('last_delivery_email_sent_at')
+                    ->dateTime()
+                    ->toggleable(isToggledHiddenByDefault: true),
+                Tables\Columns\TextColumn::make('latest_provider_event_id')
+                    ->label('latest_provider_event_id')
+                    ->copyable()
+                    ->toggleable(isToggledHiddenByDefault: true),
+                Tables\Columns\TextColumn::make('amount_refunded')
+                    ->label('amount_refunded')
+                    ->numeric()
+                    ->toggleable(isToggledHiddenByDefault: true),
+                Tables\Columns\TextColumn::make('delivery_status')
+                    ->state(fn (Order $record): string => $support->deliveryStatus($record)['label'])
+                    ->badge()
+                    ->color(fn (Order $record): string => $support->deliveryStatus($record)['state'])
+                    ->toggleable(isToggledHiddenByDefault: true),
+                Tables\Columns\TextColumn::make('attempt_channel')
+                    ->label('channel')
+                    ->toggleable(isToggledHiddenByDefault: true),
+                Tables\Columns\TextColumn::make('latest_share_id')
+                    ->label('share_id')
+                    ->copyable()
+                    ->toggleable(isToggledHiddenByDefault: true),
+                Tables\Columns\TextColumn::make('org_id')
+                    ->sortable()
+                    ->toggleable(isToggledHiddenByDefault: true),
             ])
             ->defaultSort('updated_at', 'desc')
             ->filters([
-                Tables\Filters\SelectFilter::make('status')
-                    ->options(fn () => Order::query()
-                        ->select('status')
-                        ->whereNotNull('status')
-                        ->distinct()
-                        ->orderBy('status')
-                        ->pluck('status', 'status')
-                        ->toArray()),
+                Tables\Filters\Filter::make('activity_window')
+                    ->label('Date')
+                    ->form([
+                        Forms\Components\DatePicker::make('from')->label('from'),
+                        Forms\Components\DatePicker::make('until')->label('until'),
+                    ])
+                    ->query(function (Builder $query, array $data): void {
+                        $from = trim((string) ($data['from'] ?? ''));
+                        $until = trim((string) ($data['until'] ?? ''));
+
+                        if ($from !== '') {
+                            $query->whereRaw('date(coalesce(orders.updated_at, orders.created_at)) >= ?', [$from]);
+                        }
+
+                        if ($until !== '') {
+                            $query->whereRaw('date(coalesce(orders.updated_at, orders.created_at)) <= ?', [$until]);
+                        }
+                    }),
+                Tables\Filters\SelectFilter::make('locale')
+                    ->options(fn (): array => $support->distinctAttemptOptions('locale'))
+                    ->query(function (Builder $query, array $data) use ($support): void {
+                        $support->applyLocaleFilter($query, $data['value'] ?? null);
+                    }),
+                Tables\Filters\SelectFilter::make('region')
+                    ->options(fn (): array => $support->distinctAttemptOptions('region'))
+                    ->query(function (Builder $query, array $data) use ($support): void {
+                        $support->applyRegionFilter($query, $data['value'] ?? null);
+                    }),
                 Tables\Filters\SelectFilter::make('provider')
-                    ->options(fn () => Order::query()
-                        ->select('provider')
-                        ->whereNotNull('provider')
-                        ->distinct()
-                        ->orderBy('provider')
-                        ->pluck('provider', 'provider')
-                        ->toArray()),
+                    ->options(fn (): array => $support->distinctOrderOptions('provider')),
+                Tables\Filters\TernaryFilter::make('paid_success')
+                    ->label('Paid success')
+                    ->queries(
+                        true: fn (Builder $query): Builder => tap($query, fn (Builder $builder) => $support->applyPaidSuccessFilter($builder, true)),
+                        false: fn (Builder $query): Builder => tap($query, fn (Builder $builder) => $support->applyPaidSuccessFilter($builder, false)),
+                        blank: fn (Builder $query): Builder => $query,
+                    ),
+                Tables\Filters\TernaryFilter::make('has_active_benefit_grant')
+                    ->label('Active benefit grant')
+                    ->queries(
+                        true: fn (Builder $query): Builder => tap($query, fn (Builder $builder) => $support->applyHasActiveBenefitGrantFilter($builder, true)),
+                        false: fn (Builder $query): Builder => tap($query, fn (Builder $builder) => $support->applyHasActiveBenefitGrantFilter($builder, false)),
+                        blank: fn (Builder $query): Builder => $query,
+                    ),
+                Tables\Filters\TernaryFilter::make('has_report_snapshot')
+                    ->label('Report snapshot')
+                    ->queries(
+                        true: fn (Builder $query): Builder => tap($query, fn (Builder $builder) => $support->applyHasReportSnapshotFilter($builder, true)),
+                        false: fn (Builder $query): Builder => tap($query, fn (Builder $builder) => $support->applyHasReportSnapshotFilter($builder, false)),
+                        blank: fn (Builder $query): Builder => $query,
+                    ),
+                Tables\Filters\TernaryFilter::make('pdf_ready_filter')
+                    ->label('PDF ready')
+                    ->queries(
+                        true: fn (Builder $query): Builder => tap($query, fn (Builder $builder) => $support->applyPdfReadyFilter($builder, true)),
+                        false: fn (Builder $query): Builder => tap($query, fn (Builder $builder) => $support->applyPdfReadyFilter($builder, false)),
+                        blank: fn (Builder $query): Builder => $query,
+                    ),
+                Tables\Filters\SelectFilter::make('sku_filter')
+                    ->label('SKU')
+                    ->options(fn (): array => $support->distinctSkuOptions())
+                    ->query(function (Builder $query, array $data) use ($support): void {
+                        $support->applySkuFilter($query, $data['value'] ?? null);
+                    }),
+                Tables\Filters\SelectFilter::make('benefit_code_filter')
+                    ->label('Benefit code')
+                    ->options(fn (): array => $support->distinctBenefitCodeOptions())
+                    ->query(function (Builder $query, array $data) use ($support): void {
+                        $support->applyBenefitCodeFilter($query, $data['value'] ?? null);
+                    }),
+                Tables\Filters\SelectFilter::make('status')
+                    ->label('Order status')
+                    ->options(fn (): array => $support->distinctOrderOptions('status')),
+                Tables\Filters\SelectFilter::make('payment_status_filter')
+                    ->label('Payment status')
+                    ->options(fn (): array => $support->distinctPaymentStatusOptions())
+                    ->query(function (Builder $query, array $data) use ($support): void {
+                        $support->applyPaymentStatusFilter($query, $data['value'] ?? null);
+                    }),
+                Tables\Filters\SelectFilter::make('unlock_status_filter')
+                    ->label('Unlock status')
+                    ->options([
+                        'unlocked' => 'unlocked',
+                        'paid_no_grant' => 'paid_no_grant',
+                        'refunded' => 'refunded',
+                        'pending' => 'pending',
+                    ])
+                    ->query(function (Builder $query, array $data) use ($support): void {
+                        $support->applyUnlockStatusFilter($query, $data['value'] ?? null);
+                    }),
+                Tables\Filters\SelectFilter::make('delivery_status_filter')
+                    ->label('Delivery status')
+                    ->options([
+                        'delivered' => 'delivered',
+                        'ready' => 'ready',
+                        'pending' => 'pending',
+                        'failed' => 'failed',
+                    ])
+                    ->query(function (Builder $query, array $data) use ($support): void {
+                        $support->applyDeliveryStatusFilter($query, $data['value'] ?? null);
+                    }),
             ])
+            ->filtersLayout(FiltersLayout::AboveContentCollapsible)
+            ->filtersFormColumns(4)
             ->actions([
                 Tables\Actions\ViewAction::make(),
-                Tables\Actions\Action::make('requestManualGrant')
-                    ->label('Request Manual Grant')
-                    ->icon('heroicon-o-gift')
-                    ->requiresConfirmation()
-                    ->form([
-                        Forms\Components\Textarea::make('reason')
-                            ->required()
-                            ->maxLength(255),
-                        Forms\Components\TextInput::make('benefit_code')
-                            ->label('Benefit Code (Optional)'),
-                        Forms\Components\TextInput::make('attempt_id')
-                            ->label('Attempt ID (Optional)'),
-                    ])
-                    ->action(function (Order $record, array $data): void {
-                        $approval = static::createApproval($record, AdminApproval::TYPE_MANUAL_GRANT, [
-                            'order_no' => (string) $record->order_no,
-                            'benefit_code' => trim((string) ($data['benefit_code'] ?? '')),
-                            'attempt_id' => trim((string) ($data['attempt_id'] ?? '')),
-                        ], (string) ($data['reason'] ?? ''));
-
-                        Notification::make()
-                            ->title('Manual grant request submitted')
-                            ->body('Approval #'.$approval->id)
-                            ->success()
-                            ->send();
-                    }),
-                Tables\Actions\Action::make('requestRefund')
-                    ->label('Request Refund')
-                    ->icon('heroicon-o-arrow-path-rounded-square')
-                    ->requiresConfirmation()
-                    ->form([
-                        Forms\Components\Textarea::make('reason')
-                            ->required()
-                            ->maxLength(255),
-                    ])
-                    ->action(function (Order $record, array $data): void {
-                        $approval = static::createApproval($record, AdminApproval::TYPE_REFUND, [
-                            'order_no' => (string) $record->order_no,
-                        ], (string) ($data['reason'] ?? ''));
-
-                        Notification::make()
-                            ->title('Refund request submitted')
-                            ->body('Approval #'.$approval->id)
-                            ->success()
-                            ->send();
-                    }),
             ])
             ->bulkActions([]);
     }
@@ -153,7 +308,7 @@ class OrderResource extends BaseTenantResource
         ];
     }
 
-    private static function canCommerceAccess(): bool
+    private static function canDiagnosticsAccess(): bool
     {
         $guard = (string) config('admin.guard', 'admin');
         $user = auth($guard)->user();
@@ -162,51 +317,9 @@ class OrderResource extends BaseTenantResource
             && method_exists($user, 'hasPermission')
             && (
                 $user->hasPermission(PermissionNames::ADMIN_MENU_COMMERCE)
+                || $user->hasPermission(PermissionNames::ADMIN_MENU_SUPPORT)
+                || $user->hasPermission(PermissionNames::ADMIN_OPS_READ)
                 || $user->hasPermission(PermissionNames::ADMIN_OWNER)
             );
-    }
-
-    private static function createApproval(Order $record, string $type, array $payload, string $reason): AdminApproval
-    {
-        $reason = trim($reason);
-        if ($reason === '') {
-            throw new \InvalidArgumentException('reason is required');
-        }
-
-        $guard = (string) config('admin.guard', 'admin');
-        $user = auth($guard)->user();
-        $adminId = is_object($user) && method_exists($user, 'getAuthIdentifier')
-            ? (int) $user->getAuthIdentifier()
-            : null;
-
-        $approval = AdminApproval::create([
-            'id' => (string) Str::uuid(),
-            'org_id' => (int) $record->org_id,
-            'type' => $type,
-            'status' => AdminApproval::STATUS_PENDING,
-            'requested_by_admin_user_id' => $adminId,
-            'reason' => $reason,
-            'payload_json' => $payload,
-            'correlation_id' => (string) Str::uuid(),
-        ]);
-
-        app(AuditLogger::class)->log(
-            request(),
-            'approval_requested',
-            'AdminApproval',
-            (string) $approval->id,
-            [
-                'actor' => $adminId,
-                'org_id' => (int) $record->org_id,
-                'order_no' => (string) $record->order_no,
-                'correlation_id' => (string) $approval->correlation_id,
-                'type' => $type,
-                'payload' => $payload,
-            ],
-            $reason,
-            'requested',
-        );
-
-        return $approval;
     }
 }

--- a/backend/app/Filament/Ops/Resources/OrderResource/Pages/ListOrders.php
+++ b/backend/app/Filament/Ops/Resources/OrderResource/Pages/ListOrders.php
@@ -14,6 +14,21 @@ class ListOrders extends ListRecords
 
     protected static string $resource = OrderResource::class;
 
+    public function getTitle(): string
+    {
+        return 'Unlock / Commerce Linkage';
+    }
+
+    public function getHeading(): string
+    {
+        return 'Unlock / Commerce Linkage';
+    }
+
+    public function getSubheading(): ?string
+    {
+        return 'Order-rooted support diagnostics for payment, unlock, report, PDF, and share linkage.';
+    }
+
     protected function getHeaderActions(): array
     {
         return [];

--- a/backend/app/Filament/Ops/Resources/OrderResource/Pages/ViewOrder.php
+++ b/backend/app/Filament/Ops/Resources/OrderResource/Pages/ViewOrder.php
@@ -5,9 +5,102 @@ declare(strict_types=1);
 namespace App\Filament\Ops\Resources\OrderResource\Pages;
 
 use App\Filament\Ops\Resources\OrderResource;
+use App\Filament\Ops\Resources\OrderResource\Support\OrderLinkageSupport;
 use Filament\Resources\Pages\ViewRecord;
 
 class ViewOrder extends ViewRecord
 {
     protected static string $resource = OrderResource::class;
+
+    protected static string $view = 'filament.ops.resources.orders.view-order';
+
+    /**
+     * @var array<string, array{label:string,state:string}>
+     */
+    public array $headline = [];
+
+    /**
+     * @var array{fields:list<array{label:string,value:string,hint:?string,kind:string,state:?string}>,notes:list<string>}
+     */
+    public array $orderSummary = ['fields' => [], 'notes' => []];
+
+    /**
+     * @var list<array{
+     *     provider_event_id:string,
+     *     status:array{label:string,state:string},
+     *     handle_status:array{label:string,state:string},
+     *     signature:array{label:string,state:string},
+     *     reason:string,
+     *     processed_at:string,
+     *     handled_at:string,
+     *     error:string
+     * }>
+     */
+    public array $paymentEvents = [];
+
+    /**
+     * @var array{fields:list<array{label:string,value:string,hint:?string,kind:string,state:?string}>,notes:list<string>}
+     */
+    public array $benefitSummary = ['fields' => [], 'notes' => []];
+
+    /**
+     * @var array{fields:list<array{label:string,value:string,hint:?string,kind:string,state:?string}>,notes:list<string>}
+     */
+    public array $reportSummary = ['fields' => [], 'notes' => []];
+
+    /**
+     * @var array{fields:list<array{label:string,value:string,hint:?string,kind:string,state:?string}>,notes:list<string>}
+     */
+    public array $attemptSummary = ['fields' => [], 'notes' => []];
+
+    /**
+     * @var array{fields:list<array{label:string,value:string,hint:?string,kind:string,state:?string}>,notes:list<string>}
+     */
+    public array $exceptionSummary = ['fields' => [], 'notes' => []];
+
+    /**
+     * @var list<array{label:string,url:string,kind:string}>
+     */
+    public array $links = [];
+
+    public function mount(int|string $record): void
+    {
+        parent::mount($record);
+
+        $detail = app(OrderLinkageSupport::class)->buildDetail($this->getRecord());
+
+        $this->headline = $detail['headline'];
+        $this->orderSummary = $detail['order_summary'];
+        $this->paymentEvents = $detail['payment_events'];
+        $this->benefitSummary = $detail['benefit_summary'];
+        $this->reportSummary = $detail['report_summary'];
+        $this->attemptSummary = $detail['attempt_summary'];
+        $this->exceptionSummary = $detail['exception_summary'];
+        $this->links = $detail['links'];
+    }
+
+    public function getTitle(): string
+    {
+        return 'Unlock / Commerce Linkage';
+    }
+
+    public function getHeading(): string
+    {
+        return 'Unlock / Commerce Linkage';
+    }
+
+    public function getSubheading(): ?string
+    {
+        return 'Read-only order diagnostics across payment, grant, report, PDF, and share linkage.';
+    }
+
+    public function getBreadcrumb(): string
+    {
+        return (string) ($this->getRecord()->order_no ?? $this->getRecord()->getKey());
+    }
+
+    protected function getHeaderActions(): array
+    {
+        return [];
+    }
 }

--- a/backend/app/Filament/Ops/Resources/OrderResource/Support/OrderLinkageSupport.php
+++ b/backend/app/Filament/Ops/Resources/OrderResource/Support/OrderLinkageSupport.php
@@ -1,0 +1,1522 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Filament\Ops\Resources\OrderResource\Support;
+
+use App\Models\Order;
+use App\Services\Commerce\OrderManager;
+use App\Support\SchemaBaseline;
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Query\Builder as QueryBuilder;
+use Illuminate\Support\Carbon;
+use Illuminate\Support\Facades\DB;
+
+final class OrderLinkageSupport
+{
+    /**
+     * @return Builder<Order>
+     */
+    public function query(): Builder
+    {
+        $query = Order::query()
+            ->withoutGlobalScopes()
+            ->select('orders.*');
+
+        if (SchemaBaseline::hasTable('attempts')) {
+            $query
+                ->selectSub($this->attemptField('locale'), 'attempt_locale')
+                ->selectSub($this->attemptField('region'), 'attempt_region')
+                ->selectSub($this->attemptField('scale_code'), 'attempt_scale_code')
+                ->selectSub($this->attemptField('channel'), 'attempt_channel');
+        }
+
+        if (SchemaBaseline::hasTable('results')) {
+            $query->selectSub($this->resultField('type_code'), 'latest_result_type_code');
+        }
+
+        if (SchemaBaseline::hasTable('payment_events')) {
+            $query
+                ->selectSub($this->paymentField('id'), 'latest_payment_event_id')
+                ->selectSub($this->paymentField('provider_event_id'), 'latest_provider_event_id')
+                ->selectSub($this->paymentField('status'), 'latest_payment_status')
+                ->selectSub($this->paymentField('handle_status'), 'latest_handle_status')
+                ->selectSub($this->paymentField('signature_ok'), 'latest_signature_ok')
+                ->selectSub($this->paymentField('reason'), 'latest_payment_reason')
+                ->selectSub($this->paymentField('last_error_message'), 'latest_payment_error')
+                ->selectSub($this->paymentField('requested_sku'), 'latest_requested_sku')
+                ->selectSub($this->paymentField('effective_sku'), 'latest_effective_sku')
+                ->selectSub($this->paymentField('processed_at'), 'latest_payment_processed_at')
+                ->selectSub($this->paymentField('handled_at'), 'latest_payment_handled_at');
+        }
+
+        if (SchemaBaseline::hasTable('benefit_grants')) {
+            $query
+                ->selectSub($this->benefitField('id'), 'latest_benefit_grant_id')
+                ->selectSub($this->benefitField('attempt_id'), 'latest_benefit_attempt_id')
+                ->selectSub($this->benefitField('benefit_code'), 'latest_benefit_code')
+                ->selectSub($this->benefitField('status'), 'latest_benefit_status')
+                ->selectSub($this->benefitField('scope'), 'latest_benefit_scope')
+                ->selectSub($this->benefitField('expires_at'), 'latest_benefit_expires_at')
+                ->selectSub($this->activeBenefitExistsField(), 'has_active_benefit_grant');
+        } else {
+            $query->selectRaw('0 as has_active_benefit_grant');
+        }
+
+        if (SchemaBaseline::hasTable('report_snapshots')) {
+            $query
+                ->selectSub($this->snapshotField('attempt_id'), 'latest_snapshot_attempt_id')
+                ->selectSub($this->snapshotField('status'), 'latest_snapshot_status')
+                ->selectSub($this->snapshotField('last_error'), 'latest_snapshot_last_error')
+                ->selectSub($this->snapshotField('updated_at'), 'latest_snapshot_updated_at')
+                ->selectSub($this->snapshotExistsField(), 'has_report_snapshot');
+        } else {
+            $query->selectRaw('0 as has_report_snapshot');
+        }
+
+        if (SchemaBaseline::hasTable('report_jobs')) {
+            $query
+                ->selectSub($this->reportJobField('status'), 'latest_report_job_status')
+                ->selectSub($this->reportJobField('last_error'), 'latest_report_job_error');
+        }
+
+        if (SchemaBaseline::hasTable('shares')) {
+            $query->selectSub($this->shareField('id'), 'latest_share_id');
+        }
+
+        if (SchemaBaseline::hasTable('email_outbox')
+            && SchemaBaseline::hasColumn('email_outbox', 'attempt_id')
+            && SchemaBaseline::hasColumn('email_outbox', 'sent_at')) {
+            $query->selectSub($this->deliveryEmailSentAtField(), 'latest_delivery_email_sent_at');
+        }
+
+        if (SchemaBaseline::hasColumn('orders', 'contact_email_hash')) {
+            $query->selectRaw("case when trim(coalesce(orders.contact_email_hash, '')) <> '' then 1 else 0 end as contact_email_present");
+        } else {
+            $query->selectRaw('0 as contact_email_present');
+        }
+
+        return $query;
+    }
+
+    /**
+     * @param  Builder<Order>  $query
+     */
+    public function applySearch(Builder $query, string $search): void
+    {
+        $needle = trim($search);
+        if ($needle === '') {
+            return;
+        }
+
+        $like = '%'.$needle.'%';
+        $emailHash = $this->contactEmailHash($needle);
+
+        $query->where(function (Builder $builder) use ($needle, $like, $emailHash): void {
+            $builder
+                ->where('orders.order_no', 'like', $like)
+                ->orWhere('orders.target_attempt_id', 'like', $like);
+
+            if ($emailHash !== null && SchemaBaseline::hasColumn('orders', 'contact_email_hash')) {
+                $builder->orWhere('orders.contact_email_hash', $emailHash);
+            }
+
+            if (SchemaBaseline::hasTable('users') && SchemaBaseline::hasColumn('users', 'email')) {
+                $builder->orWhereExists(function (QueryBuilder $userQuery) use ($needle, $like): void {
+                    $userQuery
+                        ->selectRaw('1')
+                        ->from('users')
+                        ->whereColumn('users.id', 'orders.user_id')
+                        ->where(function (QueryBuilder $nested) use ($needle, $like): void {
+                            $nested
+                                ->where('users.email', 'like', $like)
+                                ->orWhereRaw('lower(users.email) = ?', [mb_strtolower($needle, 'UTF-8')]);
+                        });
+                });
+            }
+
+            if (SchemaBaseline::hasTable('shares')) {
+                $builder->orWhereExists(function (QueryBuilder $shareQuery) use ($like): void {
+                    $shareQuery
+                        ->selectRaw('1')
+                        ->from('shares')
+                        ->whereColumn('shares.attempt_id', 'orders.target_attempt_id')
+                        ->where('shares.id', 'like', $like);
+                });
+            }
+
+            if (SchemaBaseline::hasTable('benefit_grants')) {
+                $builder->orWhereExists(function (QueryBuilder $grantQuery) use ($like): void {
+                    $grantQuery
+                        ->selectRaw('1')
+                        ->from('benefit_grants')
+                        ->where(function (QueryBuilder $nested): void {
+                            $nested->whereColumn('benefit_grants.order_no', 'orders.order_no')
+                                ->orWhereColumn('benefit_grants.attempt_id', 'orders.target_attempt_id');
+                        })
+                        ->where('benefit_grants.attempt_id', 'like', $like);
+                });
+            }
+
+            if (SchemaBaseline::hasTable('report_snapshots')) {
+                $builder->orWhereExists(function (QueryBuilder $snapshotQuery) use ($like): void {
+                    $snapshotQuery
+                        ->selectRaw('1')
+                        ->from('report_snapshots')
+                        ->where(function (QueryBuilder $nested): void {
+                            $nested->whereColumn('report_snapshots.attempt_id', 'orders.target_attempt_id')
+                                ->orWhereColumn('report_snapshots.order_no', 'orders.order_no');
+                        })
+                        ->where('report_snapshots.attempt_id', 'like', $like);
+                });
+            }
+        });
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    public function distinctOrderOptions(string $column): array
+    {
+        if (! SchemaBaseline::hasColumn('orders', $column)) {
+            return [];
+        }
+
+        return DB::table('orders')
+            ->whereNotNull($column)
+            ->where($column, '!=', '')
+            ->distinct()
+            ->orderBy($column)
+            ->pluck($column, $column)
+            ->mapWithKeys(fn ($value): array => [(string) $value => (string) $value])
+            ->all();
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    public function distinctAttemptOptions(string $column): array
+    {
+        if (! SchemaBaseline::hasTable('attempts') || ! SchemaBaseline::hasColumn('attempts', $column)) {
+            return [];
+        }
+
+        return DB::table('attempts')
+            ->whereNotNull($column)
+            ->where($column, '!=', '')
+            ->distinct()
+            ->orderBy($column)
+            ->pluck($column, $column)
+            ->mapWithKeys(fn ($value): array => [(string) $value => (string) $value])
+            ->all();
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    public function distinctPaymentStatusOptions(): array
+    {
+        if (! SchemaBaseline::hasTable('payment_events') || ! SchemaBaseline::hasColumn('payment_events', 'status')) {
+            return [];
+        }
+
+        return DB::table('payment_events')
+            ->whereNotNull('status')
+            ->where('status', '!=', '')
+            ->distinct()
+            ->orderBy('status')
+            ->pluck('status', 'status')
+            ->mapWithKeys(fn ($value): array => [(string) $value => (string) $value])
+            ->all();
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    public function distinctBenefitCodeOptions(): array
+    {
+        if (! SchemaBaseline::hasTable('benefit_grants') || ! SchemaBaseline::hasColumn('benefit_grants', 'benefit_code')) {
+            return [];
+        }
+
+        return DB::table('benefit_grants')
+            ->whereNotNull('benefit_code')
+            ->where('benefit_code', '!=', '')
+            ->distinct()
+            ->orderBy('benefit_code')
+            ->pluck('benefit_code', 'benefit_code')
+            ->mapWithKeys(fn ($value): array => [(string) $value => (string) $value])
+            ->all();
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    public function distinctSkuOptions(): array
+    {
+        $values = collect();
+
+        foreach (['requested_sku', 'effective_sku', 'sku'] as $column) {
+            if (! SchemaBaseline::hasColumn('orders', $column)) {
+                continue;
+            }
+
+            $values = $values->merge(
+                DB::table('orders')
+                    ->whereNotNull($column)
+                    ->where($column, '!=', '')
+                    ->distinct()
+                    ->pluck($column)
+                    ->map(fn ($value): string => (string) $value)
+            );
+        }
+
+        if (SchemaBaseline::hasTable('payment_events')) {
+            foreach (['requested_sku', 'effective_sku'] as $column) {
+                if (! SchemaBaseline::hasColumn('payment_events', $column)) {
+                    continue;
+                }
+
+                $values = $values->merge(
+                    DB::table('payment_events')
+                        ->whereNotNull($column)
+                        ->where($column, '!=', '')
+                        ->distinct()
+                        ->pluck($column)
+                        ->map(fn ($value): string => (string) $value)
+                );
+            }
+        }
+
+        return $values
+            ->filter(fn (string $value): bool => $value !== '')
+            ->unique()
+            ->sort()
+            ->mapWithKeys(fn (string $value): array => [$value => $value])
+            ->all();
+    }
+
+    /**
+     * @param  Builder<Order>  $query
+     */
+    public function applySkuFilter(Builder $query, ?string $value): void
+    {
+        $sku = trim((string) $value);
+        if ($sku === '') {
+            return;
+        }
+
+        $query->where(function (Builder $builder) use ($sku): void {
+            foreach (['requested_sku', 'effective_sku', 'sku'] as $column) {
+                if (SchemaBaseline::hasColumn('orders', $column)) {
+                    $builder->orWhere('orders.'.$column, $sku);
+                }
+            }
+
+            if (SchemaBaseline::hasTable('payment_events')) {
+                $builder->orWhereExists(function (QueryBuilder $paymentQuery) use ($sku): void {
+                    $paymentQuery
+                        ->selectRaw('1')
+                        ->from('payment_events')
+                        ->whereColumn('payment_events.order_no', 'orders.order_no')
+                        ->where(function (QueryBuilder $nested) use ($sku): void {
+                            $nested->where('payment_events.requested_sku', $sku)
+                                ->orWhere('payment_events.effective_sku', $sku);
+                        });
+                });
+            }
+        });
+    }
+
+    /**
+     * @param  Builder<Order>  $query
+     */
+    public function applyBenefitCodeFilter(Builder $query, ?string $value): void
+    {
+        $benefitCode = trim((string) $value);
+        if ($benefitCode === '' || ! SchemaBaseline::hasTable('benefit_grants')) {
+            return;
+        }
+
+        $query->whereExists(function (QueryBuilder $grantQuery) use ($benefitCode): void {
+            $grantQuery
+                ->selectRaw('1')
+                ->from('benefit_grants')
+                ->where('benefit_grants.benefit_code', $benefitCode)
+                ->where(function (QueryBuilder $nested): void {
+                    $nested->whereColumn('benefit_grants.order_no', 'orders.order_no')
+                        ->orWhereColumn('benefit_grants.attempt_id', 'orders.target_attempt_id');
+                });
+        });
+    }
+
+    /**
+     * @param  Builder<Order>  $query
+     */
+    public function applyLocaleFilter(Builder $query, ?string $value): void
+    {
+        $locale = trim((string) $value);
+        if ($locale === '' || ! SchemaBaseline::hasTable('attempts')) {
+            return;
+        }
+
+        $query->whereExists(function (QueryBuilder $attemptQuery) use ($locale): void {
+            $attemptQuery
+                ->selectRaw('1')
+                ->from('attempts')
+                ->whereColumn('attempts.id', 'orders.target_attempt_id')
+                ->where('attempts.locale', $locale);
+        });
+    }
+
+    /**
+     * @param  Builder<Order>  $query
+     */
+    public function applyRegionFilter(Builder $query, ?string $value): void
+    {
+        $region = trim((string) $value);
+        if ($region === '' || ! SchemaBaseline::hasTable('attempts')) {
+            return;
+        }
+
+        $query->whereExists(function (QueryBuilder $attemptQuery) use ($region): void {
+            $attemptQuery
+                ->selectRaw('1')
+                ->from('attempts')
+                ->whereColumn('attempts.id', 'orders.target_attempt_id')
+                ->where('attempts.region', $region);
+        });
+    }
+
+    /**
+     * @param  Builder<Order>  $query
+     */
+    public function applyPaymentStatusFilter(Builder $query, ?string $value): void
+    {
+        $paymentStatus = trim((string) $value);
+        if ($paymentStatus === '' || ! SchemaBaseline::hasTable('payment_events')) {
+            return;
+        }
+
+        $query->whereExists(function (QueryBuilder $paymentQuery) use ($paymentStatus): void {
+            $paymentQuery
+                ->selectRaw('1')
+                ->from('payment_events')
+                ->whereColumn('payment_events.order_no', 'orders.order_no')
+                ->where('payment_events.status', $paymentStatus);
+        });
+    }
+
+    /**
+     * @param  Builder<Order>  $query
+     */
+    public function applyPaidSuccessFilter(Builder $query, ?bool $value): void
+    {
+        if ($value === null) {
+            return;
+        }
+
+        if ($value) {
+            $query->where($this->paidLikeOrderClause());
+
+            return;
+        }
+
+        $query->where($this->notPaidLikeOrderClause());
+    }
+
+    /**
+     * @param  Builder<Order>  $query
+     */
+    public function applyHasActiveBenefitGrantFilter(Builder $query, ?bool $value): void
+    {
+        if ($value === null) {
+            return;
+        }
+
+        if ($value) {
+            $query->whereExists($this->activeBenefitExistsQuery());
+
+            return;
+        }
+
+        $query->whereNotExists($this->activeBenefitExistsQuery());
+    }
+
+    /**
+     * @param  Builder<Order>  $query
+     */
+    public function applyHasReportSnapshotFilter(Builder $query, ?bool $value): void
+    {
+        if ($value === null) {
+            return;
+        }
+
+        if ($value) {
+            $query->whereExists($this->snapshotExistsQuery());
+
+            return;
+        }
+
+        $query->whereNotExists($this->snapshotExistsQuery());
+    }
+
+    /**
+     * @param  Builder<Order>  $query
+     */
+    public function applyPdfReadyFilter(Builder $query, ?bool $value): void
+    {
+        if ($value === null) {
+            return;
+        }
+
+        if ($value) {
+            $query
+                ->where($this->paidLikeOrderClause())
+                ->whereExists($this->snapshotReadyExistsQuery());
+
+            return;
+        }
+
+        $query->where(function (Builder $builder): void {
+            $builder
+                ->where($this->notPaidLikeOrderClause())
+                ->orWhereNotExists($this->snapshotReadyExistsQuery());
+        });
+    }
+
+    /**
+     * @param  Builder<Order>  $query
+     */
+    public function applyUnlockStatusFilter(Builder $query, ?string $value): void
+    {
+        $status = strtolower(trim((string) $value));
+        if ($status === '') {
+            return;
+        }
+
+        match ($status) {
+            'unlocked' => $query->whereExists($this->activeBenefitExistsQuery()),
+            'paid_no_grant' => $query
+                ->where($this->paidLikeOrderClause())
+                ->whereNotExists($this->activeBenefitExistsQuery())
+                ->where($this->notRefundedLikeOrderClause()),
+            'refunded' => $query->where($this->refundedLikeOrderClause()),
+            'pending' => $query
+                ->whereNotExists($this->activeBenefitExistsQuery())
+                ->where($this->notPaidLikeOrderClause())
+                ->where($this->notRefundedLikeOrderClause()),
+            default => null,
+        };
+    }
+
+    /**
+     * @param  Builder<Order>  $query
+     */
+    public function applyDeliveryStatusFilter(Builder $query, ?string $value): void
+    {
+        $status = strtolower(trim((string) $value));
+        if ($status === '') {
+            return;
+        }
+
+        match ($status) {
+            'delivered' => $query->whereExists($this->deliveryEmailExistsQuery()),
+            'ready' => $query
+                ->where($this->paidLikeOrderClause())
+                ->whereNotExists($this->deliveryEmailExistsQuery())
+                ->whereExists($this->snapshotReadyExistsQuery()),
+            'failed' => $query->where(function (Builder $builder): void {
+                $builder->whereExists($this->snapshotFailedExistsQuery());
+
+                if (SchemaBaseline::hasTable('report_jobs')) {
+                    $builder->orWhereExists($this->reportJobFailedExistsQuery());
+                }
+            }),
+            'pending' => $query
+                ->whereNotExists($this->deliveryEmailExistsQuery())
+                ->where(function (Builder $builder): void {
+                    $builder->where($this->notPaidLikeOrderClause())
+                        ->orWhereNotExists($this->snapshotReadyExistsQuery());
+                }),
+            default => null,
+        };
+    }
+
+    /**
+     * @return array{label:string,state:string}
+     */
+    public function orderStatus(object $order): array
+    {
+        $label = $this->stringOrDash($order->status ?? null);
+
+        return ['label' => $label, 'state' => $this->statusState((string) ($order->status ?? ''))];
+    }
+
+    /**
+     * @return array{label:string,state:string}
+     */
+    public function paymentStatus(object $order): array
+    {
+        $status = trim((string) ($order->latest_payment_status ?? ''));
+        if ($status === '') {
+            return ['label' => 'missing', 'state' => 'gray'];
+        }
+
+        return ['label' => $status, 'state' => $this->statusState($status)];
+    }
+
+    /**
+     * @return array{label:string,state:string}
+     */
+    public function unlockStatus(object $order): array
+    {
+        if ($this->hasActiveBenefitGrant($order)) {
+            return ['label' => 'unlocked', 'state' => 'success'];
+        }
+
+        if ($this->isRefundedLike((string) ($order->status ?? ''))) {
+            return ['label' => 'refunded', 'state' => 'danger'];
+        }
+
+        if ($this->isPaidLike((string) ($order->status ?? '')) || $this->isPaidLike((string) ($order->latest_payment_status ?? ''))) {
+            return ['label' => 'paid_no_grant', 'state' => 'warning'];
+        }
+
+        return ['label' => 'pending', 'state' => 'gray'];
+    }
+
+    /**
+     * @return array{label:string,state:string}
+     */
+    public function snapshotStatus(object $order): array
+    {
+        $status = trim((string) ($order->latest_snapshot_status ?? ''));
+        if ($status === '') {
+            return ['label' => 'missing', 'state' => 'gray'];
+        }
+
+        return ['label' => $status, 'state' => $this->statusState($status)];
+    }
+
+    /**
+     * @return array{label:string,state:string}
+     */
+    public function pdfStatus(object $order): array
+    {
+        return $this->isPdfReady($order)
+            ? ['label' => 'ready', 'state' => 'success']
+            : ['label' => 'unavailable', 'state' => 'gray'];
+    }
+
+    /**
+     * @return array{label:string,state:string}
+     */
+    public function deliveryStatus(object $order): array
+    {
+        $lastSentAt = trim((string) ($order->latest_delivery_email_sent_at ?? ''));
+        $snapshot = strtolower(trim((string) ($order->latest_snapshot_status ?? '')));
+        $jobStatus = strtolower(trim((string) ($order->latest_report_job_status ?? '')));
+
+        if ($snapshot === 'failed' || $snapshot === 'error' || in_array($jobStatus, ['failed', 'error'], true)) {
+            return ['label' => 'failed', 'state' => 'danger'];
+        }
+
+        if ($lastSentAt !== '') {
+            return ['label' => 'delivered', 'state' => 'success'];
+        }
+
+        if ($this->isPdfReady($order)) {
+            return ['label' => 'ready', 'state' => 'warning'];
+        }
+
+        return ['label' => 'pending', 'state' => 'gray'];
+    }
+
+    public function requestedSku(object $order): string
+    {
+        foreach ([
+            $order->requested_sku ?? null,
+            $order->latest_requested_sku ?? null,
+            $order->sku ?? null,
+        ] as $candidate) {
+            $value = trim((string) $candidate);
+            if ($value !== '') {
+                return $value;
+            }
+        }
+
+        return '-';
+    }
+
+    public function effectiveSku(object $order): string
+    {
+        foreach ([
+            $order->effective_sku ?? null,
+            $order->latest_effective_sku ?? null,
+            $order->sku ?? null,
+        ] as $candidate) {
+            $value = trim((string) $candidate);
+            if ($value !== '') {
+                return $value;
+            }
+        }
+
+        return '-';
+    }
+
+    public function contactEmailPresent(object $order): bool
+    {
+        return $this->truthy($order->contact_email_present ?? null)
+            || trim((string) ($order->contact_email_hash ?? '')) !== '';
+    }
+
+    /**
+     * @return array{
+     *     headline: array<string, array{label:string,state:string}>,
+     *     order_summary: array{fields:list<array{label:string,value:string,hint:?string,kind:string,state:?string}>,notes:list<string>},
+     *     payment_events: list<array{
+     *         provider_event_id:string,
+     *         status:array{label:string,state:string},
+     *         handle_status:array{label:string,state:string},
+     *         signature:array{label:string,state:string},
+     *         reason:string,
+     *         processed_at:string,
+     *         handled_at:string,
+     *         error:string
+     *     }>,
+     *     benefit_summary: array{fields:list<array{label:string,value:string,hint:?string,kind:string,state:?string}>,notes:list<string>},
+     *     report_summary: array{fields:list<array{label:string,value:string,hint:?string,kind:string,state:?string}>,notes:list<string>},
+     *     attempt_summary: array{fields:list<array{label:string,value:string,hint:?string,kind:string,state:?string}>,notes:list<string>},
+     *     exception_summary: array{fields:list<array{label:string,value:string,hint:?string,kind:string,state:?string}>,notes:list<string>},
+     *     links: list<array{label:string,url:string,kind:string}>
+     * }
+     */
+    public function buildDetail(Order $order): array
+    {
+        $orderRow = DB::table('orders')->where('id', (string) $order->getKey())->first() ?? $order;
+        $resolvedAttemptId = $this->resolvedAttemptId($order);
+        $paymentEvents = $this->paymentEvents((string) ($orderRow->order_no ?? ''));
+        $grants = $this->benefitGrants((string) ($orderRow->order_no ?? ''), $resolvedAttemptId);
+        $activeGrant = $this->activeGrant($grants);
+        $snapshot = $this->reportSnapshot((string) ($orderRow->order_no ?? ''), $resolvedAttemptId);
+        $reportPayload = $this->decodeJson($snapshot->report_json ?? null);
+        $reportJob = $this->reportJob($resolvedAttemptId);
+        $attempt = $this->attempt($resolvedAttemptId);
+        $result = $this->result($resolvedAttemptId);
+        $share = $this->share($resolvedAttemptId);
+        $delivery = app(OrderManager::class)->presentOrderDelivery($orderRow);
+        $deliveryState = is_array($delivery['delivery'] ?? null) ? $delivery['delivery'] : [];
+        $attribution = app(OrderManager::class)->extractAttributionFromOrder($orderRow);
+        $shareId = trim((string) (($share->id ?? null) ?: ($attribution['share_id'] ?? '')));
+        $headline = [
+            'order' => $this->orderStatus($order),
+            'payment' => $this->paymentStatus($order),
+            'unlock' => $this->unlockStatus($order),
+            'snapshot' => $this->snapshotStatus($order),
+            'pdf' => $this->pdfStatus($order),
+        ];
+
+        $orderSummary = [
+            'fields' => [
+                $this->field('order_no', $this->stringOrDash($orderRow->order_no ?? null)),
+                $this->field('org_id', $this->stringOrDash($orderRow->org_id ?? null)),
+                $this->field('amount', $this->formatMoney($orderRow), $this->stringOrDash($orderRow->amount_cents ?? null).' cents'),
+                $this->field('provider', $this->stringOrDash($orderRow->provider ?? null)),
+                $this->pillField('order_status', $headline['order']['label'], $headline['order']['state']),
+                $this->pillField('payment_status', $headline['payment']['label'], $headline['payment']['state']),
+                $this->field('created_at', $this->formatTimestamp($orderRow->created_at ?? null)),
+                $this->field('paid_at', $this->formatTimestamp($orderRow->paid_at ?? null)),
+                $this->field('updated_at', $this->formatTimestamp($orderRow->updated_at ?? null)),
+                $this->field('target_attempt_id', $this->stringOrDash($orderRow->target_attempt_id ?? null), $resolvedAttemptId !== null && $resolvedAttemptId !== trim((string) ($orderRow->target_attempt_id ?? '')) ? 'resolved='.$resolvedAttemptId : null),
+                $this->field('requested_sku', $this->requestedSku($order)),
+                $this->field('effective_sku', $this->effectiveSku($order)),
+                $this->field('benefit_code', $this->stringOrDash($activeGrant->benefit_code ?? ($order->latest_benefit_code ?? null))),
+                $this->pillField(
+                    'contact_email_present',
+                    $this->truthy($deliveryState['contact_email_present'] ?? null) ? 'present' : 'missing',
+                    $this->truthy($deliveryState['contact_email_present'] ?? null) ? 'success' : 'gray'
+                ),
+            ],
+            'notes' => ['Frontend order drill-through is available in the action bar. Raw order meta stays hidden.'],
+        ];
+
+        $benefitNotes = ['Unlock truth is derived from benefit_grants, not only order status.'];
+        if ($activeGrant === null) {
+            $benefitNotes[] = 'No active grant found yet for this order/attempt pair.';
+        }
+
+        $benefitSummary = [
+            'fields' => [
+                $this->pillField('active_grant', $activeGrant !== null ? 'present' : 'missing', $activeGrant !== null ? 'success' : 'gray'),
+                $this->pillField('unlock_status', $headline['unlock']['label'], $headline['unlock']['state']),
+                $this->field('benefit_grant_id', $this->stringOrDash($activeGrant->id ?? ($order->latest_benefit_grant_id ?? null))),
+                $this->field('benefit_code', $this->stringOrDash($activeGrant->benefit_code ?? ($order->latest_benefit_code ?? null))),
+                $this->field('scope', $this->stringOrDash($activeGrant->scope ?? ($order->latest_benefit_scope ?? null))),
+                $this->field('expires_at', $this->formatTimestamp($activeGrant->expires_at ?? ($order->latest_benefit_expires_at ?? null))),
+                $this->field('source_order_id', $this->stringOrDash($activeGrant->source_order_id ?? null)),
+                $this->field('source_event_id', $this->stringOrDash($activeGrant->source_event_id ?? null)),
+            ],
+            'notes' => $benefitNotes,
+        ];
+
+        $reportNotes = ['Report JSON and full snapshot payload stay hidden on this page.'];
+        if (filled($snapshot->last_error ?? null)) {
+            $reportNotes[] = 'Snapshot error is summarized below without expanding report payload JSON.';
+        }
+
+        $deliveryLabel = $this->deliveryStatus($order);
+        $reportSummary = [
+            'fields' => [
+                $this->pillField('snapshot', $snapshot !== null ? 'present' : 'missing', $snapshot !== null ? 'success' : 'gray'),
+                $this->pillField('snapshot_status', $headline['snapshot']['label'], $headline['snapshot']['state']),
+                $this->field('snapshot_last_error', $this->shortText($snapshot->last_error ?? null)),
+                $this->field('variant', $this->stringOrDash($reportPayload['variant'] ?? null)),
+                $this->field('access_level', $this->stringOrDash($reportPayload['access_level'] ?? null)),
+                $this->pillField(
+                    'locked',
+                    $this->truthy($reportPayload['locked'] ?? null) ? 'locked' : 'unlocked',
+                    $this->truthy($reportPayload['locked'] ?? null) ? 'warning' : 'success'
+                ),
+                $this->pillField('pdf_ready', $headline['pdf']['label'], $headline['pdf']['state']),
+                $this->pillField('delivery_status', $deliveryLabel['label'], $deliveryLabel['state']),
+                $this->field('last_delivery_email_sent_at', $this->stringOrDash($deliveryState['last_delivery_email_sent_at'] ?? null)),
+                $this->pillField('claim_email', $this->truthy($deliveryState['can_request_claim_email'] ?? null) ? 'available' : 'not_available', $this->truthy($deliveryState['can_request_claim_email'] ?? null) ? 'warning' : 'gray'),
+                $this->pillField('resend_delivery', $this->truthy($deliveryState['can_resend'] ?? null) ? 'eligible' : 'not_eligible', $this->truthy($deliveryState['can_resend'] ?? null) ? 'warning' : 'gray'),
+                $this->field(
+                    'report_job',
+                    $this->stringOrDash($reportJob->status ?? null),
+                    $this->shortText($reportJob->last_error ?? null)
+                ),
+            ],
+            'notes' => $reportNotes,
+        ];
+
+        $attemptNotes = ['Attempt linkage shows result, locale, report, and share breadcrumbs without exposing raw result payload JSON.'];
+        $utmSummary = $this->utmSummary($attribution['utm'] ?? null);
+        if ($utmSummary !== '-') {
+            $attemptNotes[] = 'UTM summary is reduced to compact marketing breadcrumbs only.';
+        }
+
+        $attemptSummary = [
+            'fields' => [
+                $this->field('attempt_id', $resolvedAttemptId ?? '-'),
+                $this->field('result_type', $this->stringOrDash($result->type_code ?? null)),
+                $this->field('scale_code', $this->stringOrDash($attempt->scale_code ?? ($order->attempt_scale_code ?? null))),
+                $this->field('locale', $this->stringOrDash($attempt->locale ?? ($order->attempt_locale ?? null))),
+                $this->field('region', $this->stringOrDash($attempt->region ?? ($order->attempt_region ?? null))),
+                $this->field('share_id', $shareId !== '' ? $shareId : '-'),
+                $this->field('share_click_id', $this->stringOrDash($attribution['share_click_id'] ?? null)),
+                $this->field('entrypoint', $this->stringOrDash($attribution['entrypoint'] ?? null)),
+                $this->field('utm', $utmSummary),
+                $this->field('channel', $this->stringOrDash($attempt->channel ?? ($order->attempt_channel ?? null))),
+            ],
+            'notes' => $attemptNotes,
+        ];
+
+        $paymentSummary = array_map(function (object $event): array {
+            return [
+                'provider_event_id' => $this->stringOrDash($event->provider_event_id ?? null),
+                'status' => [
+                    'label' => $this->stringOrDash($event->status ?? null),
+                    'state' => $this->statusState((string) ($event->status ?? '')),
+                ],
+                'handle_status' => [
+                    'label' => $this->stringOrDash($event->handle_status ?? null),
+                    'state' => $this->statusState((string) ($event->handle_status ?? '')),
+                ],
+                'signature' => [
+                    'label' => $this->truthy($event->signature_ok ?? null) ? 'valid' : 'invalid',
+                    'state' => $this->truthy($event->signature_ok ?? null) ? 'success' : 'danger',
+                ],
+                'reason' => $this->stringOrDash($event->reason ?? null),
+                'processed_at' => $this->formatTimestamp($event->processed_at ?? null),
+                'handled_at' => $this->formatTimestamp($event->handled_at ?? null),
+                'error' => $this->shortText($event->last_error_message ?? null),
+            ];
+        }, $paymentEvents);
+
+        $exceptionSummary = [
+            'fields' => $this->exceptionFields($orderRow, $paymentEvents, $activeGrant, $snapshot, $reportJob, $deliveryState, $resolvedAttemptId),
+            'notes' => ['These rules are explicit v1 diagnostics, not a full rule engine or BI funnel.'],
+        ];
+
+        return [
+            'headline' => $headline,
+            'order_summary' => $orderSummary,
+            'payment_events' => $paymentSummary,
+            'benefit_summary' => $benefitSummary,
+            'report_summary' => $reportSummary,
+            'attempt_summary' => $attemptSummary,
+            'exception_summary' => $exceptionSummary,
+            'links' => $this->links($orderRow, $resolvedAttemptId, $shareId !== '' ? $shareId : null, $attempt),
+        ];
+    }
+
+    private function attemptField(string $column): QueryBuilder
+    {
+        return DB::table('attempts')
+            ->select($column)
+            ->whereColumn('attempts.id', 'orders.target_attempt_id')
+            ->limit(1);
+    }
+
+    private function resultField(string $column): QueryBuilder
+    {
+        return DB::table('results')
+            ->select($column)
+            ->whereColumn('results.attempt_id', 'orders.target_attempt_id')
+            ->orderByRaw('coalesce(computed_at, updated_at, created_at) desc')
+            ->limit(1);
+    }
+
+    private function paymentField(string $column): QueryBuilder
+    {
+        return DB::table('payment_events')
+            ->select($column)
+            ->whereColumn('payment_events.order_no', 'orders.order_no')
+            ->orderByRaw('coalesce(processed_at, handled_at, updated_at, created_at) desc')
+            ->limit(1);
+    }
+
+    private function benefitField(string $column): QueryBuilder
+    {
+        return DB::table('benefit_grants')
+            ->select($column)
+            ->where(function (QueryBuilder $builder): void {
+                $builder->whereColumn('benefit_grants.order_no', 'orders.order_no')
+                    ->orWhereColumn('benefit_grants.attempt_id', 'orders.target_attempt_id');
+            })
+            ->orderByRaw("case when lower(coalesce(status, '')) = 'active' then 0 else 1 end")
+            ->orderByRaw('coalesce(updated_at, created_at) desc')
+            ->limit(1);
+    }
+
+    private function activeBenefitExistsField(): QueryBuilder
+    {
+        return DB::table('benefit_grants')
+            ->selectRaw('1')
+            ->where('benefit_grants.status', 'active')
+            ->where(function (QueryBuilder $builder): void {
+                $builder->whereColumn('benefit_grants.order_no', 'orders.order_no')
+                    ->orWhereColumn('benefit_grants.attempt_id', 'orders.target_attempt_id');
+            })
+            ->limit(1);
+    }
+
+    private function snapshotField(string $column): QueryBuilder
+    {
+        return DB::table('report_snapshots')
+            ->select($column)
+            ->where(function (QueryBuilder $builder): void {
+                $builder->whereColumn('report_snapshots.attempt_id', 'orders.target_attempt_id')
+                    ->orWhereColumn('report_snapshots.order_no', 'orders.order_no');
+            })
+            ->orderByRaw('coalesce(updated_at, created_at) desc')
+            ->limit(1);
+    }
+
+    private function snapshotExistsField(): QueryBuilder
+    {
+        return DB::table('report_snapshots')
+            ->selectRaw('1')
+            ->where(function (QueryBuilder $builder): void {
+                $builder->whereColumn('report_snapshots.attempt_id', 'orders.target_attempt_id')
+                    ->orWhereColumn('report_snapshots.order_no', 'orders.order_no');
+            })
+            ->limit(1);
+    }
+
+    private function reportJobField(string $column): QueryBuilder
+    {
+        return DB::table('report_jobs')
+            ->select($column)
+            ->whereColumn('report_jobs.attempt_id', 'orders.target_attempt_id')
+            ->orderByRaw('coalesce(updated_at, created_at) desc')
+            ->limit(1);
+    }
+
+    private function shareField(string $column): QueryBuilder
+    {
+        return DB::table('shares')
+            ->select($column)
+            ->whereColumn('shares.attempt_id', 'orders.target_attempt_id')
+            ->orderByDesc('created_at')
+            ->limit(1);
+    }
+
+    private function deliveryEmailSentAtField(): QueryBuilder
+    {
+        return DB::table('email_outbox')
+            ->select('sent_at')
+            ->whereColumn('email_outbox.attempt_id', 'orders.target_attempt_id')
+            ->whereIn('template', ['payment_success', 'report_claim'])
+            ->whereNotNull('sent_at')
+            ->orderByDesc('sent_at')
+            ->limit(1);
+    }
+
+    private function activeBenefitExistsQuery(): \Closure
+    {
+        return function (QueryBuilder $benefitQuery): void {
+            $benefitQuery
+                ->selectRaw('1')
+                ->from('benefit_grants')
+                ->where('benefit_grants.status', 'active')
+                ->where(function (QueryBuilder $builder): void {
+                    $builder->whereColumn('benefit_grants.order_no', 'orders.order_no')
+                        ->orWhereColumn('benefit_grants.attempt_id', 'orders.target_attempt_id');
+                });
+        };
+    }
+
+    private function snapshotReadyExistsQuery(): \Closure
+    {
+        return function (QueryBuilder $snapshotQuery): void {
+            $snapshotQuery
+                ->selectRaw('1')
+                ->from('report_snapshots')
+                ->where(function (QueryBuilder $builder): void {
+                    $builder->whereColumn('report_snapshots.attempt_id', 'orders.target_attempt_id')
+                        ->orWhereColumn('report_snapshots.order_no', 'orders.order_no');
+                })
+                ->whereRaw("lower(coalesce(report_snapshots.status, '')) in (?, ?, ?)", ['ready', 'full', 'completed']);
+        };
+    }
+
+    private function snapshotExistsQuery(): \Closure
+    {
+        return function (QueryBuilder $snapshotQuery): void {
+            $snapshotQuery
+                ->selectRaw('1')
+                ->from('report_snapshots')
+                ->where(function (QueryBuilder $builder): void {
+                    $builder->whereColumn('report_snapshots.attempt_id', 'orders.target_attempt_id')
+                        ->orWhereColumn('report_snapshots.order_no', 'orders.order_no');
+                });
+        };
+    }
+
+    private function snapshotFailedExistsQuery(): \Closure
+    {
+        return function (QueryBuilder $snapshotQuery): void {
+            $snapshotQuery
+                ->selectRaw('1')
+                ->from('report_snapshots')
+                ->where(function (QueryBuilder $builder): void {
+                    $builder->whereColumn('report_snapshots.attempt_id', 'orders.target_attempt_id')
+                        ->orWhereColumn('report_snapshots.order_no', 'orders.order_no');
+                })
+                ->where(function (QueryBuilder $builder): void {
+                    $builder
+                        ->whereRaw("lower(coalesce(report_snapshots.status, '')) in (?, ?)", ['failed', 'error'])
+                        ->orWhereNotNull('report_snapshots.last_error');
+                });
+        };
+    }
+
+    private function reportJobFailedExistsQuery(): \Closure
+    {
+        return function (QueryBuilder $jobQuery): void {
+            $jobQuery
+                ->selectRaw('1')
+                ->from('report_jobs')
+                ->whereColumn('report_jobs.attempt_id', 'orders.target_attempt_id')
+                ->whereRaw("lower(coalesce(report_jobs.status, '')) in (?, ?)", ['failed', 'error']);
+        };
+    }
+
+    private function deliveryEmailExistsQuery(): \Closure
+    {
+        return function (QueryBuilder $deliveryQuery): void {
+            $deliveryQuery
+                ->selectRaw('1')
+                ->from('email_outbox')
+                ->whereColumn('email_outbox.attempt_id', 'orders.target_attempt_id')
+                ->whereIn('template', ['payment_success', 'report_claim'])
+                ->whereNotNull('sent_at');
+        };
+    }
+
+    private function paidLikeOrderClause(): \Closure
+    {
+        return function (Builder|QueryBuilder $builder): void {
+            $builder->where(function (Builder|QueryBuilder $nested): void {
+                $nested
+                    ->whereRaw("lower(coalesce(orders.status, '')) in (?, ?, ?, ?)", ['paid', 'fulfilled', 'complete', 'completed'])
+                    ->orWhereNotNull('orders.paid_at');
+            });
+        };
+    }
+
+    private function refundedLikeOrderClause(): \Closure
+    {
+        return function (Builder|QueryBuilder $builder): void {
+            $builder->where(function (Builder|QueryBuilder $nested): void {
+                $nested
+                    ->whereRaw("lower(coalesce(orders.status, '')) like ?", ['%refund%']);
+
+                if (SchemaBaseline::hasColumn('orders', 'refunded_at')) {
+                    $nested->orWhereNotNull('orders.refunded_at');
+                }
+            });
+        };
+    }
+
+    private function notPaidLikeOrderClause(): \Closure
+    {
+        return function (Builder|QueryBuilder $builder): void {
+            $builder
+                ->whereRaw("lower(coalesce(orders.status, '')) not in (?, ?, ?, ?)", ['paid', 'fulfilled', 'complete', 'completed'])
+                ->whereNull('orders.paid_at');
+        };
+    }
+
+    private function notRefundedLikeOrderClause(): \Closure
+    {
+        return function (Builder|QueryBuilder $builder): void {
+            $builder->whereRaw("lower(coalesce(orders.status, '')) not like ?", ['%refund%']);
+
+            if (SchemaBaseline::hasColumn('orders', 'refunded_at')) {
+                $builder->whereNull('orders.refunded_at');
+            }
+        };
+    }
+
+    /**
+     * @return list<object>
+     */
+    private function paymentEvents(string $orderNo): array
+    {
+        if ($orderNo === '' || ! SchemaBaseline::hasTable('payment_events')) {
+            return [];
+        }
+
+        return DB::table('payment_events')
+            ->select([
+                'provider_event_id',
+                'status',
+                'handle_status',
+                'signature_ok',
+                'reason',
+                'processed_at',
+                'handled_at',
+                'last_error_message',
+            ])
+            ->where('order_no', $orderNo)
+            ->orderByRaw('coalesce(processed_at, handled_at, updated_at, created_at) desc')
+            ->limit(10)
+            ->get()
+            ->all();
+    }
+
+    /**
+     * @return list<object>
+     */
+    private function benefitGrants(string $orderNo, ?string $attemptId): array
+    {
+        if (! SchemaBaseline::hasTable('benefit_grants')) {
+            return [];
+        }
+
+        return DB::table('benefit_grants')
+            ->select([
+                'id',
+                'benefit_code',
+                'scope',
+                'status',
+                'expires_at',
+                'source_order_id',
+                'source_event_id',
+                'meta_json',
+            ])
+            ->where(function (QueryBuilder $builder) use ($orderNo, $attemptId): void {
+                if ($orderNo !== '') {
+                    $builder->where('order_no', $orderNo);
+                }
+
+                if ($attemptId !== null) {
+                    $method = $orderNo !== '' ? 'orWhere' : 'where';
+                    $builder->{$method}('attempt_id', $attemptId);
+                }
+            })
+            ->orderByRaw("case when lower(coalesce(status, '')) = 'active' then 0 else 1 end")
+            ->orderByRaw('coalesce(updated_at, created_at) desc')
+            ->limit(10)
+            ->get()
+            ->all();
+    }
+
+    private function activeGrant(array $grants): ?object
+    {
+        foreach ($grants as $grant) {
+            if (strtolower(trim((string) ($grant->status ?? ''))) === 'active') {
+                return $grant;
+            }
+        }
+
+        return $grants[0] ?? null;
+    }
+
+    private function reportSnapshot(string $orderNo, ?string $attemptId): ?object
+    {
+        if (! SchemaBaseline::hasTable('report_snapshots')) {
+            return null;
+        }
+
+        return DB::table('report_snapshots')
+            ->where(function (QueryBuilder $builder) use ($orderNo, $attemptId): void {
+                if ($attemptId !== null) {
+                    $builder->where('attempt_id', $attemptId);
+                }
+
+                if ($orderNo !== '') {
+                    $method = $attemptId !== null ? 'orWhere' : 'where';
+                    $builder->{$method}('order_no', $orderNo);
+                }
+            })
+            ->orderByRaw('coalesce(updated_at, created_at) desc')
+            ->first();
+    }
+
+    private function reportJob(?string $attemptId): ?object
+    {
+        if ($attemptId === null || ! SchemaBaseline::hasTable('report_jobs')) {
+            return null;
+        }
+
+        return DB::table('report_jobs')
+            ->where('attempt_id', $attemptId)
+            ->orderByRaw('coalesce(updated_at, created_at) desc')
+            ->first();
+    }
+
+    private function attempt(?string $attemptId): ?object
+    {
+        if ($attemptId === null || ! SchemaBaseline::hasTable('attempts')) {
+            return null;
+        }
+
+        return DB::table('attempts')->where('id', $attemptId)->first();
+    }
+
+    private function result(?string $attemptId): ?object
+    {
+        if ($attemptId === null || ! SchemaBaseline::hasTable('results')) {
+            return null;
+        }
+
+        return DB::table('results')
+            ->where('attempt_id', $attemptId)
+            ->orderByRaw('coalesce(computed_at, updated_at, created_at) desc')
+            ->first();
+    }
+
+    private function share(?string $attemptId): ?object
+    {
+        if ($attemptId === null || ! SchemaBaseline::hasTable('shares')) {
+            return null;
+        }
+
+        return DB::table('shares')
+            ->where('attempt_id', $attemptId)
+            ->orderByDesc('created_at')
+            ->first();
+    }
+
+    /**
+     * @return list<array{label:string,value:string,hint:?string,kind:string,state:?string}>
+     */
+    private function exceptionFields(
+        object $order,
+        array $paymentEvents,
+        ?object $activeGrant,
+        ?object $snapshot,
+        ?object $reportJob,
+        array $deliveryState,
+        ?string $resolvedAttemptId,
+    ): array {
+        $paymentHandled = collect($paymentEvents)->contains(function (object $event): bool {
+            return filled($event->handled_at ?? null)
+                || in_array(strtolower(trim((string) ($event->handle_status ?? ''))), ['processed', 'handled', 'succeeded'], true);
+        });
+
+        $paid = $this->isPaidLike((string) ($order->status ?? '')) || filled($order->paid_at ?? null);
+        $snapshotStatus = strtolower(trim((string) ($snapshot->status ?? '')));
+        $reportJobStatus = strtolower(trim((string) ($reportJob->status ?? '')));
+        $pdfReady = (bool) ($deliveryState['can_download_pdf'] ?? false);
+
+        return [
+            $this->pillField(
+                'paid_but_no_grant',
+                $paid && $activeGrant === null ? 'triggered' : 'clear',
+                $paid && $activeGrant === null ? 'danger' : 'success',
+                $paid && $activeGrant === null ? 'Payment succeeded but no active benefit_grant exists.' : null
+            ),
+            $this->pillField(
+                'grant_exists_but_snapshot_missing',
+                $activeGrant !== null && $snapshot === null ? 'triggered' : 'clear',
+                $activeGrant !== null && $snapshot === null ? 'danger' : 'success',
+                $activeGrant !== null && $snapshot === null ? 'Unlock fact exists without a report_snapshot.' : null
+            ),
+            $this->pillField(
+                'snapshot_failed',
+                in_array($snapshotStatus, ['failed', 'error'], true) || in_array($reportJobStatus, ['failed', 'error'], true) ? 'triggered' : 'clear',
+                in_array($snapshotStatus, ['failed', 'error'], true) || in_array($reportJobStatus, ['failed', 'error'], true) ? 'danger' : 'success',
+                $this->shortText(($snapshot->last_error ?? null) ?: ($reportJob->last_error ?? null))
+            ),
+            $this->pillField(
+                'pdf_unavailable',
+                $resolvedAttemptId !== null && ! $pdfReady ? 'triggered' : 'clear',
+                $resolvedAttemptId !== null && ! $pdfReady ? 'warning' : 'success',
+                $resolvedAttemptId !== null && ! $pdfReady ? 'Attempt is linked but PDF is not marked ready.' : null
+            ),
+            $this->pillField(
+                'order_exists_but_no_payment_handled',
+                ! $paymentHandled ? 'triggered' : 'clear',
+                ! $paymentHandled ? 'warning' : 'success',
+                ! $paymentHandled ? 'No handled payment event summary is available yet.' : null
+            ),
+        ];
+    }
+
+    /**
+     * @return list<array{label:string,url:string,kind:string}>
+     */
+    private function links(object $order, ?string $attemptId, ?string $shareId, ?object $attempt): array
+    {
+        $base = rtrim((string) config('app.frontend_url', config('app.url', '')), '/');
+        $localeSegment = $this->localeSegment((string) ($attempt->locale ?? ''));
+        $links = [];
+
+        if ($base !== '') {
+            $orderNo = trim((string) ($order->order_no ?? ''));
+            if ($orderNo !== '') {
+                $links[] = [
+                    'label' => 'Order page',
+                    'url' => $base.'/'.$localeSegment.'/orders/'.urlencode($orderNo),
+                    'kind' => 'frontend',
+                ];
+            }
+
+            if ($attemptId !== null) {
+                $links[] = [
+                    'label' => 'Result page',
+                    'url' => $base.'/'.$localeSegment.'/result/'.urlencode($attemptId),
+                    'kind' => 'frontend',
+                ];
+                $links[] = [
+                    'label' => 'Report page',
+                    'url' => $base.'/'.$localeSegment.'/attempts/'.urlencode($attemptId).'/report',
+                    'kind' => 'frontend',
+                ];
+            }
+
+            if ($shareId !== null && $shareId !== '') {
+                $links[] = [
+                    'label' => 'Share page',
+                    'url' => $base.'/'.$localeSegment.'/share/'.urlencode($shareId),
+                    'kind' => 'frontend',
+                ];
+            }
+        }
+
+        if ($attemptId !== null) {
+            $links[] = [
+                'label' => 'Attempt Explorer',
+                'url' => '/ops/attempts/'.urlencode($attemptId),
+                'kind' => 'ops',
+            ];
+        }
+
+        $links[] = [
+            'label' => 'Order Lookup',
+            'url' => '/ops/order-lookup',
+            'kind' => 'ops',
+        ];
+
+        return $links;
+    }
+
+    private function resolvedAttemptId(object $order): ?string
+    {
+        foreach ([
+            $order->target_attempt_id ?? null,
+            $order->latest_snapshot_attempt_id ?? null,
+            $order->latest_benefit_attempt_id ?? null,
+        ] as $candidate) {
+            $value = trim((string) $candidate);
+            if ($value !== '') {
+                return $value;
+            }
+        }
+
+        return null;
+    }
+
+    private function isPdfReady(object $order): bool
+    {
+        $snapshotStatus = strtolower(trim((string) ($order->latest_snapshot_status ?? '')));
+
+        return $this->resolvedAttemptId($order) !== null
+            && ($this->isPaidLike((string) ($order->status ?? '')) || $this->isPaidLike((string) ($order->latest_payment_status ?? '')))
+            && in_array($snapshotStatus, ['ready', 'full', 'completed'], true);
+    }
+
+    private function hasActiveBenefitGrant(object $order): bool
+    {
+        return $this->truthy($order->has_active_benefit_grant ?? null)
+            || strtolower(trim((string) ($order->latest_benefit_status ?? ''))) === 'active';
+    }
+
+    private function statusState(?string $status): string
+    {
+        $status = strtolower(trim((string) $status));
+
+        return match (true) {
+            $status === '' => 'gray',
+            in_array($status, ['paid', 'fulfilled', 'active', 'ready', 'full', 'completed', 'processed', 'handled', 'succeeded'], true) => 'success',
+            in_array($status, ['pending', 'queued', 'running', 'processing'], true) => 'warning',
+            in_array($status, ['failed', 'error', 'revoked', 'expired', 'invalid', 'refunded'], true) => 'danger',
+            default => 'gray',
+        };
+    }
+
+    private function isPaidLike(?string $status): bool
+    {
+        return in_array(strtolower(trim((string) $status)), ['paid', 'fulfilled', 'complete', 'completed', 'succeeded'], true);
+    }
+
+    private function isRefundedLike(?string $status): bool
+    {
+        return str_contains(strtolower(trim((string) $status)), 'refund');
+    }
+
+    private function contactEmailHash(string $candidate): ?string
+    {
+        $email = mb_strtolower(trim($candidate), 'UTF-8');
+        if ($email === '' || filter_var($email, FILTER_VALIDATE_EMAIL) === false) {
+            return null;
+        }
+
+        return hash('sha256', $email);
+    }
+
+    private function localeSegment(string $locale): string
+    {
+        return str_starts_with(strtolower(trim($locale)), 'zh') ? 'zh' : 'en';
+    }
+
+    private function decodeJson(mixed $value): array
+    {
+        if (is_array($value)) {
+            return $value;
+        }
+
+        if (! is_string($value) || trim($value) === '') {
+            return [];
+        }
+
+        $decoded = json_decode($value, true);
+
+        return is_array($decoded) ? $decoded : [];
+    }
+
+    private function truthy(mixed $value): bool
+    {
+        if (is_bool($value)) {
+            return $value;
+        }
+
+        if (is_int($value)) {
+            return $value === 1;
+        }
+
+        return in_array(strtolower(trim((string) $value)), ['1', 'true', 'yes', 'on'], true);
+    }
+
+    private function formatTimestamp(mixed $value): string
+    {
+        if ($value === null || $value === '') {
+            return '-';
+        }
+
+        try {
+            return Carbon::parse($value)->toDateTimeString();
+        } catch (\Throwable) {
+            return (string) $value;
+        }
+    }
+
+    private function formatMoney(object $order): string
+    {
+        $amountCents = (int) ($order->amount_cents ?? 0);
+        $currency = strtoupper(trim((string) ($order->currency ?? 'USD')));
+
+        return number_format($amountCents / 100, 2, '.', '').' '.$currency;
+    }
+
+    private function utmSummary(mixed $value): string
+    {
+        if (! is_array($value)) {
+            return '-';
+        }
+
+        $parts = [];
+        foreach (['source', 'medium', 'campaign'] as $key) {
+            $segment = trim((string) ($value[$key] ?? ''));
+            if ($segment !== '') {
+                $parts[] = $key.'='.$segment;
+            }
+        }
+
+        return $parts === [] ? '-' : implode(' | ', $parts);
+    }
+
+    private function shortText(mixed $value): string
+    {
+        $text = trim((string) $value);
+        if ($text === '') {
+            return '-';
+        }
+
+        return mb_strlen($text, 'UTF-8') > 140
+            ? mb_substr($text, 0, 137, 'UTF-8').'...'
+            : $text;
+    }
+
+    /**
+     * @return array{label:string,value:string,hint:?string,kind:string,state:?string}
+     */
+    private function field(string $label, mixed $value, ?string $hint = null): array
+    {
+        return [
+            'label' => $label,
+            'value' => $this->stringOrDash($value),
+            'hint' => $hint,
+            'kind' => 'text',
+            'state' => null,
+        ];
+    }
+
+    /**
+     * @return array{label:string,value:string,hint:?string,kind:string,state:?string}
+     */
+    private function pillField(string $label, string $value, string $state, ?string $hint = null): array
+    {
+        return [
+            'label' => $label,
+            'value' => $value,
+            'hint' => $hint,
+            'kind' => 'pill',
+            'state' => $state,
+        ];
+    }
+
+    private function stringOrDash(mixed $value): string
+    {
+        $text = trim((string) $value);
+
+        return $text !== '' ? $text : '-';
+    }
+}

--- a/backend/resources/views/filament/ops/resources/orders/view-order.blade.php
+++ b/backend/resources/views/filament/ops/resources/orders/view-order.blade.php
@@ -1,0 +1,189 @@
+<x-filament-panels::page>
+    @php
+        $record = $this->getRecord();
+    @endphp
+
+    <div class="ops-shell-page">
+        <x-filament::section>
+            <div class="ops-workbench-toolbar ops-workbench-toolbar--split">
+                <div class="ops-workbench-toolbar__main">
+                    <div class="ops-shell-inline-intro">
+                        <span class="ops-shell-inline-intro__eyebrow">Support diagnostic</span>
+                        <p class="ops-shell-inline-intro__meta">
+                            Rooted on <code>{{ (string) ($record->order_no ?? $record->getKey()) }}</code>. This page keeps order, payment, unlock, report, PDF, and share breadcrumbs in one read-only surface.
+                        </p>
+                    </div>
+
+                    <div class="flex flex-wrap items-center gap-3">
+                        <x-filament.ops.shared.status-pill
+                            :state="(string) ($headline['order']['state'] ?? 'gray')"
+                            :label="'order: '.(string) ($headline['order']['label'] ?? '-')"
+                        />
+                        <x-filament.ops.shared.status-pill
+                            :state="(string) ($headline['payment']['state'] ?? 'gray')"
+                            :label="'payment: '.(string) ($headline['payment']['label'] ?? '-')"
+                        />
+                        <x-filament.ops.shared.status-pill
+                            :state="(string) ($headline['unlock']['state'] ?? 'gray')"
+                            :label="'unlock: '.(string) ($headline['unlock']['label'] ?? '-')"
+                        />
+                        <x-filament.ops.shared.status-pill
+                            :state="(string) ($headline['snapshot']['state'] ?? 'gray')"
+                            :label="'snapshot: '.(string) ($headline['snapshot']['label'] ?? '-')"
+                        />
+                        <x-filament.ops.shared.status-pill
+                            :state="(string) ($headline['pdf']['state'] ?? 'gray')"
+                            :label="'pdf: '.(string) ($headline['pdf']['label'] ?? '-')"
+                        />
+                    </div>
+                </div>
+
+                <div class="ops-workbench-toolbar__actions">
+                    @foreach ($links as $link)
+                        <x-filament::button
+                            color="{{ ($link['kind'] ?? 'frontend') === 'ops' ? 'gray' : 'primary' }}"
+                            size="sm"
+                            tag="a"
+                            href="{{ (string) ($link['url'] ?? '#') }}"
+                            target="{{ ($link['kind'] ?? 'frontend') === 'ops' ? '_self' : '_blank' }}"
+                        >
+                            {{ (string) ($link['label'] ?? 'Open') }}
+                        </x-filament::button>
+                    @endforeach
+                </div>
+            </div>
+        </x-filament::section>
+
+        <x-filament::section>
+            <div class="ops-results-header">
+                <div>
+                    <h3 class="ops-results-header__title">Order Summary</h3>
+                    <p class="ops-results-header__meta">Order root, payment posture, SKU, benefit key, org scope, and contact presence.</p>
+                </div>
+            </div>
+
+            <div class="mt-4">
+                @include('filament.ops.resources.attempts.partials.field-grid', [
+                    'fields' => $orderSummary['fields'] ?? [],
+                    'notes' => $orderSummary['notes'] ?? [],
+                ])
+            </div>
+        </x-filament::section>
+
+        <x-filament::section>
+            <div class="ops-results-header">
+                <div>
+                    <h3 class="ops-results-header__title">Payment Events</h3>
+                    <p class="ops-results-header__meta">Latest-first payment timeline with compact status, signature, handling, and error summaries only.</p>
+                </div>
+            </div>
+
+            <div class="ops-card-list mt-4">
+                @forelse ($paymentEvents as $event)
+                    <div class="ops-result-card">
+                        <div class="ops-result-card__header">
+                            <div>
+                                <p class="ops-result-card__title">{{ (string) ($event['provider_event_id'] ?? '-') }}</p>
+                                <p class="ops-result-card__meta">
+                                    processed={{ (string) ($event['processed_at'] ?? '-') }}
+                                    | handled={{ (string) ($event['handled_at'] ?? '-') }}
+                                </p>
+                            </div>
+                        </div>
+
+                        <div class="flex flex-wrap gap-2">
+                            <x-filament.ops.shared.status-pill
+                                :state="(string) ($event['status']['state'] ?? 'gray')"
+                                :label="'status: '.(string) ($event['status']['label'] ?? '-')"
+                            />
+                            <x-filament.ops.shared.status-pill
+                                :state="(string) ($event['handle_status']['state'] ?? 'gray')"
+                                :label="'handle: '.(string) ($event['handle_status']['label'] ?? '-')"
+                            />
+                            <x-filament.ops.shared.status-pill
+                                :state="(string) ($event['signature']['state'] ?? 'gray')"
+                                :label="'signature: '.(string) ($event['signature']['label'] ?? '-')"
+                            />
+                        </div>
+
+                        <div class="mt-4 space-y-2">
+                            <p class="ops-control-hint">reason={{ (string) ($event['reason'] ?? '-') }}</p>
+                            <p class="ops-control-hint">error={{ (string) ($event['error'] ?? '-') }}</p>
+                        </div>
+                    </div>
+                @empty
+                    <x-filament.ops.shared.empty-state
+                        eyebrow="Payment events"
+                        icon="heroicon-o-credit-card"
+                        title="No payment events found"
+                        description="Webhook payloads and headers stay hidden by default even when payment diagnostics exist."
+                    />
+                @endforelse
+            </div>
+        </x-filament::section>
+
+        <x-filament::section>
+            <div class="ops-results-header">
+                <div>
+                    <h3 class="ops-results-header__title">Benefit / Unlock</h3>
+                    <p class="ops-results-header__meta">Grant-backed unlock fact, benefit scope, expiry, and audit breadcrumbs.</p>
+                </div>
+            </div>
+
+            <div class="mt-4">
+                @include('filament.ops.resources.attempts.partials.field-grid', [
+                    'fields' => $benefitSummary['fields'] ?? [],
+                    'notes' => $benefitSummary['notes'] ?? [],
+                ])
+            </div>
+        </x-filament::section>
+
+        <x-filament::section>
+            <div class="ops-results-header">
+                <div>
+                    <h3 class="ops-results-header__title">Report / PDF Delivery</h3>
+                    <p class="ops-results-header__meta">Snapshot status, delivery clues, claim eligibility, resend posture, and lightweight report job summary.</p>
+                </div>
+            </div>
+
+            <div class="mt-4">
+                @include('filament.ops.resources.attempts.partials.field-grid', [
+                    'fields' => $reportSummary['fields'] ?? [],
+                    'notes' => $reportSummary['notes'] ?? [],
+                ])
+            </div>
+        </x-filament::section>
+
+        <x-filament::section>
+            <div class="ops-results-header">
+                <div>
+                    <h3 class="ops-results-header__title">Attempt Linkage</h3>
+                    <p class="ops-results-header__meta">Attempt, result, locale, region, and share attribution breadcrumbs for drill-through diagnostics.</p>
+                </div>
+            </div>
+
+            <div class="mt-4">
+                @include('filament.ops.resources.attempts.partials.field-grid', [
+                    'fields' => $attemptSummary['fields'] ?? [],
+                    'notes' => $attemptSummary['notes'] ?? [],
+                ])
+            </div>
+        </x-filament::section>
+
+        <x-filament::section>
+            <div class="ops-results-header">
+                <div>
+                    <h3 class="ops-results-header__title">Exception Diagnostics</h3>
+                    <p class="ops-results-header__meta">Explicit v1 exception rules for support and ops, without expanding into a full BI or remediation console.</p>
+                </div>
+            </div>
+
+            <div class="mt-4">
+                @include('filament.ops.resources.attempts.partials.field-grid', [
+                    'fields' => $exceptionSummary['fields'] ?? [],
+                    'notes' => $exceptionSummary['notes'] ?? [],
+                ])
+            </div>
+        </x-filament::section>
+    </div>
+</x-filament-panels::page>

--- a/backend/tests/Feature/Ops/OrderCommerceLinkageTest.php
+++ b/backend/tests/Feature/Ops/OrderCommerceLinkageTest.php
@@ -1,0 +1,485 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Ops;
+
+use App\Filament\Ops\Resources\OrderResource\Pages\ListOrders;
+use App\Models\AdminUser;
+use App\Models\Order;
+use App\Models\Organization;
+use App\Models\Permission;
+use App\Models\Role;
+use App\Support\Rbac\PermissionNames;
+use Filament\Facades\Filament;
+use Filament\PanelRegistry;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Support\Str;
+use Livewire\Livewire;
+use Tests\TestCase;
+
+final class OrderCommerceLinkageTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        Filament::setCurrentPanel(app(PanelRegistry::class)->get('ops'));
+    }
+
+    public function test_orders_linkage_list_is_accessible_read_only_and_has_core_columns(): void
+    {
+        $admin = $this->createAdminWithPermissions([
+            PermissionNames::ADMIN_MENU_COMMERCE,
+            PermissionNames::ADMIN_OPS_READ,
+        ]);
+        $selectedOrg = $this->createOrganization('Selected Commerce Org');
+        $chain = $this->seedDiagnosticChain(orgId: 41);
+
+        $this->withSession($this->opsSession($admin, $selectedOrg))
+            ->actingAs($admin, (string) config('admin.guard', 'admin'))
+            ->get('/ops/orders')
+            ->assertOk()
+            ->assertSee('Unlock / Commerce Linkage')
+            ->assertDontSee('Request Manual Grant')
+            ->assertDontSee('Request Refund');
+
+        session($this->opsSession($admin, $selectedOrg));
+        $this->actingAs($admin, (string) config('admin.guard', 'admin'));
+
+        Livewire::test(ListOrders::class)
+            ->assertOk()
+            ->assertCanSeeTableRecords([$chain['order']])
+            ->assertTableColumnExists('order_no')
+            ->assertTableColumnExists('created_at')
+            ->assertTableColumnExists('paid_at')
+            ->assertTableColumnExists('updated_at')
+            ->assertTableColumnExists('provider')
+            ->assertTableColumnExists('amount_cents')
+            ->assertTableColumnExists('currency')
+            ->assertTableColumnExists('status')
+            ->assertTableColumnExists('latest_payment_status')
+            ->assertTableColumnExists('target_attempt_id')
+            ->assertTableColumnExists('requested_sku')
+            ->assertTableColumnExists('effective_sku')
+            ->assertTableColumnExists('latest_benefit_code')
+            ->assertTableColumnExists('unlock_status')
+            ->assertTableColumnExists('latest_snapshot_status')
+            ->assertTableColumnExists('pdf_ready')
+            ->assertTableActionExists('view', null, $chain['order'])
+            ->assertTableActionDoesNotExist('requestManualGrant', null, $chain['order'])
+            ->assertTableActionDoesNotExist('requestRefund', null, $chain['order']);
+    }
+
+    public function test_orders_linkage_detail_renders_six_sections_hides_sensitive_payloads_and_uses_grant_for_unlock(): void
+    {
+        $admin = $this->createAdminWithPermissions([
+            PermissionNames::ADMIN_MENU_COMMERCE,
+            PermissionNames::ADMIN_OPS_READ,
+        ]);
+        $selectedOrg = $this->createOrganization('Cross Org Session');
+        $chain = $this->seedDiagnosticChain(orgId: 52, orderNo: 'ord_unlock_chain_001');
+
+        $this->withSession($this->opsSession($admin, $selectedOrg))
+            ->actingAs($admin, (string) config('admin.guard', 'admin'))
+            ->get('/ops/orders/'.$chain['order']->getKey())
+            ->assertOk()
+            ->assertSee('Order Summary')
+            ->assertSee('Payment Events')
+            ->assertSee('Benefit / Unlock')
+            ->assertSee('Report / PDF Delivery')
+            ->assertSee('Attempt Linkage')
+            ->assertSee('Exception Diagnostics')
+            ->assertSee('unlock: unlocked')
+            ->assertSee('paid')
+            ->assertSee('active')
+            ->assertSee('INTJ')
+            ->assertSee((string) $chain['order_no'])
+            ->assertSee((string) $chain['attempt_id'])
+            ->assertSee((string) $chain['share_id'])
+            ->assertSee('Order page')
+            ->assertSee('Result page')
+            ->assertSee('Report page')
+            ->assertSee('Share page')
+            ->assertDontSee('payload_json')
+            ->assertDontSee('report_json')
+            ->assertDontSee('report_full_json')
+            ->assertDontSee((string) $chain['payment_secret'])
+            ->assertDontSee((string) $chain['report_secret']);
+    }
+
+    public function test_orders_linkage_cross_org_search_works_for_order_no_and_attempt_id(): void
+    {
+        $admin = $this->createAdminWithPermissions([
+            PermissionNames::ADMIN_MENU_COMMERCE,
+            PermissionNames::ADMIN_OPS_READ,
+        ]);
+        $selectedOrg = $this->createOrganization('Current Session Org');
+        $localOrder = $this->seedDiagnosticChain(orgId: (int) $selectedOrg->id, orderNo: 'ord_local_scope_001')['order'];
+        $foreign = $this->seedDiagnosticChain(orgId: 88, orderNo: 'ord_cross_scope_001');
+
+        session($this->opsSession($admin, $selectedOrg));
+        $this->actingAs($admin, (string) config('admin.guard', 'admin'));
+
+        Livewire::test(ListOrders::class)
+            ->assertOk()
+            ->searchTable('ord_cross_scope_001')
+            ->assertCanSeeTableRecords([$foreign['order']])
+            ->assertCanNotSeeTableRecords([$localOrder])
+            ->searchTable((string) $foreign['attempt_id'])
+            ->assertCanSeeTableRecords([$foreign['order']]);
+    }
+
+    private function createOrganization(string $name): Organization
+    {
+        return Organization::query()->create([
+            'name' => $name,
+            'owner_user_id' => random_int(1000, 9999),
+            'status' => 'active',
+            'domain' => Str::slug($name).'.example.test',
+            'timezone' => 'Asia/Shanghai',
+            'locale' => 'en',
+        ]);
+    }
+
+    /**
+     * @param  list<string>  $permissions
+     */
+    private function createAdminWithPermissions(array $permissions): AdminUser
+    {
+        $admin = AdminUser::query()->create([
+            'name' => 'ops_'.Str::lower(Str::random(6)),
+            'email' => 'ops_'.Str::lower(Str::random(6)).'@example.test',
+            'password' => bcrypt('secret'),
+            'is_active' => 1,
+        ]);
+
+        $role = Role::query()->create([
+            'name' => 'role_'.Str::lower(Str::random(8)),
+            'description' => null,
+        ]);
+
+        foreach ($permissions as $permissionName) {
+            $permission = Permission::query()->firstOrCreate(
+                ['name' => $permissionName],
+                ['description' => null],
+            );
+
+            $role->permissions()->syncWithoutDetaching([$permission->id]);
+        }
+
+        $admin->roles()->syncWithoutDetaching([$role->id]);
+
+        return $admin;
+    }
+
+    /**
+     * @return array{ops_org_id:int,ops_admin_totp_verified_user_id:int}
+     */
+    private function opsSession(AdminUser $admin, Organization $selectedOrg): array
+    {
+        return [
+            'ops_org_id' => (int) $selectedOrg->id,
+            'ops_admin_totp_verified_user_id' => (int) $admin->id,
+        ];
+    }
+
+    /**
+     * @return array{
+     *     order:Order,
+     *     order_no:string,
+     *     attempt_id:string,
+     *     share_id:string,
+     *     payment_secret:string,
+     *     report_secret:string
+     * }
+     */
+    private function seedDiagnosticChain(int $orgId, ?string $orderNo = null): array
+    {
+        $attemptId = (string) Str::uuid();
+        $shareId = (string) Str::uuid();
+        $orderId = (string) Str::uuid();
+        $paymentEventId = (string) Str::uuid();
+        $orderNo ??= 'ord_diag_'.Str::lower(Str::random(6));
+        $paymentSecret = 'payment-secret-'.Str::lower(Str::random(6));
+        $reportSecret = 'report-secret-'.Str::lower(Str::random(6));
+
+        DB::table('attempts')->insert([
+            'id' => $attemptId,
+            'ticket_code' => 'FMT-'.strtoupper(substr(str_replace('-', '', $attemptId), 0, 8)),
+            'org_id' => $orgId,
+            'user_id' => '1001',
+            'anon_id' => 'anon_linkage',
+            'scale_code' => 'MBTI',
+            'scale_version' => 'v0.3',
+            'scale_uid' => '55555555-5555-4555-8555-555555555555',
+            'region' => 'US',
+            'locale' => 'en',
+            'question_count' => 93,
+            'answers_summary_json' => json_encode(['stage' => 'seed'], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES),
+            'client_platform' => 'test',
+            'channel' => 'web',
+            'started_at' => now()->subMinutes(20),
+            'submitted_at' => now()->subMinutes(15),
+            'pack_id' => 'MBTI',
+            'dir_version' => 'mbti_dir_2026_03',
+            'content_package_version' => 'content_2026_03',
+            'scoring_spec_version' => 'scoring_2026_03',
+            'norm_version' => 'norm_2026_03',
+            'created_at' => now()->subMinutes(20),
+            'updated_at' => now()->subMinutes(15),
+            'result_json' => json_encode(['type_code' => 'INTJ'], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES),
+        ]);
+
+        DB::table('results')->insert([
+            'id' => (string) Str::uuid(),
+            'attempt_id' => $attemptId,
+            'org_id' => $orgId,
+            'scale_code' => 'MBTI',
+            'scale_version' => 'v0.3',
+            'type_code' => 'INTJ',
+            'scores_json' => json_encode(['EI' => 78], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES),
+            'scores_pct' => json_encode(['EI' => 88], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES),
+            'axis_states' => json_encode(['EI' => 'I'], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES),
+            'profile_version' => 'profile_2026_03',
+            'result_json' => json_encode(['private' => 'result-hidden'], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES),
+            'pack_id' => 'MBTI',
+            'dir_version' => 'mbti_dir_2026_03',
+            'content_package_version' => 'content_2026_03',
+            'scoring_spec_version' => 'scoring_2026_03',
+            'report_engine_version' => 'v2.3',
+            'is_valid' => 1,
+            'computed_at' => now()->subMinutes(12),
+            'created_at' => now()->subMinutes(12),
+            'updated_at' => now()->subMinutes(11),
+            'scale_uid' => '55555555-5555-4555-8555-555555555555',
+        ]);
+
+        DB::table('report_snapshots')->insert([
+            'org_id' => $orgId,
+            'attempt_id' => $attemptId,
+            'order_no' => $orderNo,
+            'scale_code' => 'MBTI',
+            'pack_id' => 'MBTI',
+            'dir_version' => 'mbti_dir_2026_03',
+            'scoring_spec_version' => 'scoring_2026_03',
+            'report_engine_version' => 'v2.3',
+            'snapshot_version' => 'v1',
+            'report_json' => json_encode([
+                'locked' => false,
+                'access_level' => 'full',
+                'variant' => 'full',
+            ], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES),
+            'report_free_json' => json_encode(['variant' => 'free'], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES),
+            'report_full_json' => json_encode(['secret' => $reportSecret], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES),
+            'status' => 'ready',
+            'last_error' => null,
+            'created_at' => now()->subMinutes(10),
+            'updated_at' => now()->subMinutes(9),
+            'scale_uid' => '55555555-5555-4555-8555-555555555555',
+        ]);
+
+        $orderRow = [
+            'id' => $orderId,
+            'order_no' => $orderNo,
+            'org_id' => $orgId,
+            'user_id' => '1001',
+            'anon_id' => 'anon_linkage',
+            'sku' => 'MBTI_FULL_REPORT',
+            'quantity' => 1,
+            'target_attempt_id' => $attemptId,
+            'amount_cents' => 2990,
+            'currency' => 'USD',
+            'status' => 'paid',
+            'provider' => 'stripe',
+            'paid_at' => now()->subMinutes(9),
+            'created_at' => now()->subMinutes(10),
+            'updated_at' => now()->subMinutes(8),
+        ];
+
+        if (Schema::hasColumn('orders', 'amount_total')) {
+            $orderRow['amount_total'] = 2990;
+        }
+        if (Schema::hasColumn('orders', 'amount_refunded')) {
+            $orderRow['amount_refunded'] = 0;
+        }
+        if (Schema::hasColumn('orders', 'item_sku')) {
+            $orderRow['item_sku'] = 'MBTI_FULL_REPORT';
+        }
+        if (Schema::hasColumn('orders', 'provider_order_id')) {
+            $orderRow['provider_order_id'] = 'pi_'.$orderNo;
+        }
+        if (Schema::hasColumn('orders', 'fulfilled_at')) {
+            $orderRow['fulfilled_at'] = now()->subMinutes(7);
+        }
+        if (Schema::hasColumn('orders', 'requested_sku')) {
+            $orderRow['requested_sku'] = 'MBTI_FULL_REPORT';
+        }
+        if (Schema::hasColumn('orders', 'effective_sku')) {
+            $orderRow['effective_sku'] = 'MBTI_FULL_REPORT';
+        }
+        if (Schema::hasColumn('orders', 'entitlement_id')) {
+            $orderRow['entitlement_id'] = 'ent_'.$orderNo;
+        }
+        if (Schema::hasColumn('orders', 'contact_email_hash')) {
+            $orderRow['contact_email_hash'] = hash('sha256', 'buyer+'.$orderNo.'@example.test');
+        }
+        if (Schema::hasColumn('orders', 'meta_json')) {
+            $orderRow['meta_json'] = json_encode([
+                'attribution' => [
+                    'share_id' => $shareId,
+                    'share_click_id' => 'click_'.$orderNo,
+                    'entrypoint' => 'checkout_return',
+                    'utm' => [
+                        'source' => 'wechat',
+                        'medium' => 'organic',
+                        'campaign' => 'spring',
+                    ],
+                ],
+                'claim_status' => 'claimed',
+            ], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES);
+        }
+
+        DB::table('orders')->insert($orderRow);
+
+        DB::table('payment_events')->insert([
+            'id' => $paymentEventId,
+            'org_id' => $orgId,
+            'provider' => 'stripe',
+            'provider_event_id' => 'evt_'.Str::lower(Str::random(8)),
+            'order_id' => $orderId,
+            'order_no' => $orderNo,
+            'event_type' => 'payment_intent.succeeded',
+            'signature_ok' => 1,
+            'status' => 'paid',
+            'attempts' => 1,
+            'last_error_code' => null,
+            'last_error_message' => null,
+            'processed_at' => now()->subMinutes(9),
+            'handled_at' => now()->subMinutes(9),
+            'handle_status' => 'processed',
+            'reason' => 'checkout_paid',
+            'requested_sku' => 'MBTI_FULL_REPORT',
+            'effective_sku' => 'MBTI_FULL_REPORT',
+            'entitlement_id' => 'ent_'.$orderNo,
+            'payload_json' => json_encode(['secret' => $paymentSecret], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES),
+            'payload_size_bytes' => 128,
+            'payload_sha256' => hash('sha256', $paymentSecret),
+            'payload_s3_key' => null,
+            'payload_excerpt' => null,
+            'received_at' => now()->subMinutes(9),
+            'created_at' => now()->subMinutes(9),
+            'updated_at' => now()->subMinutes(9),
+            'scale_uid' => '55555555-5555-4555-8555-555555555555',
+        ]);
+
+        DB::table('benefit_grants')->insert([
+            'id' => (string) Str::uuid(),
+            'org_id' => $orgId,
+            'user_id' => '1001',
+            'benefit_code' => 'MBTI_FULL_REPORT',
+            'scope' => 'attempt',
+            'attempt_id' => $attemptId,
+            'status' => 'active',
+            'expires_at' => now()->addDays(30),
+            'benefit_type' => 'report',
+            'benefit_ref' => 'benefit_'.$orderNo,
+            'order_no' => $orderNo,
+            'source_order_id' => $orderId,
+            'source_event_id' => $paymentEventId,
+            'meta_json' => json_encode(['claim_status' => 'claimed'], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES),
+            'created_at' => now()->subMinutes(8),
+            'updated_at' => now()->subMinutes(8),
+        ]);
+
+        DB::table('shares')->insert([
+            'id' => $shareId,
+            'attempt_id' => $attemptId,
+            'anon_id' => 'anon_linkage',
+            'scale_code' => 'MBTI',
+            'scale_version' => 'v0.3',
+            'content_package_version' => 'content_2026_03',
+            'created_at' => now()->subMinutes(6),
+            'updated_at' => now()->subMinutes(5),
+            'scale_uid' => '55555555-5555-4555-8555-555555555555',
+        ]);
+
+        DB::table('report_jobs')->insert([
+            'id' => (string) Str::uuid(),
+            'attempt_id' => $attemptId,
+            'status' => 'succeeded',
+            'tries' => 1,
+            'available_at' => now()->subMinutes(11),
+            'started_at' => now()->subMinutes(11),
+            'finished_at' => now()->subMinutes(10),
+            'failed_at' => null,
+            'last_error' => null,
+            'last_error_trace' => null,
+            'report_json' => '{}',
+            'meta' => '{}',
+            'created_at' => now()->subMinutes(11),
+            'updated_at' => now()->subMinutes(10),
+            'org_id' => $orgId,
+        ]);
+
+        $this->insertEmailOutbox($attemptId, $orderNo);
+
+        $order = Order::query()->withoutGlobalScopes()->whereKey($orderId)->firstOrFail();
+
+        return [
+            'order' => $order,
+            'order_no' => $orderNo,
+            'attempt_id' => $attemptId,
+            'share_id' => $shareId,
+            'payment_secret' => $paymentSecret,
+            'report_secret' => $reportSecret,
+        ];
+    }
+
+    private function insertEmailOutbox(string $attemptId, string $orderNo): void
+    {
+        if (! Schema::hasTable('email_outbox')) {
+            return;
+        }
+
+        $row = [
+            'id' => (string) Str::uuid(),
+            'user_id' => '1001',
+            'email' => 'redacted+'.substr(hash('sha256', $orderNo), 0, 20).'@privacy.local',
+            'template' => 'payment_success',
+            'payload_json' => json_encode(['order_no' => $orderNo], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES),
+            'claim_token_hash' => hash('sha256', 'claim_'.$orderNo),
+            'claim_expires_at' => now()->addDay(),
+            'status' => 'sent',
+            'sent_at' => now()->subMinutes(4),
+            'consumed_at' => null,
+            'created_at' => now()->subMinutes(4),
+            'updated_at' => now()->subMinutes(4),
+        ];
+
+        if (Schema::hasColumn('email_outbox', 'attempt_id')) {
+            $row['attempt_id'] = $attemptId;
+        }
+        if (Schema::hasColumn('email_outbox', 'to_email')) {
+            $row['to_email'] = 'redacted+'.substr(hash('sha256', $orderNo), 0, 20).'@privacy.local';
+        }
+        if (Schema::hasColumn('email_outbox', 'locale')) {
+            $row['locale'] = 'en';
+        }
+        if (Schema::hasColumn('email_outbox', 'template_key')) {
+            $row['template_key'] = 'payment_success';
+        }
+        if (Schema::hasColumn('email_outbox', 'subject')) {
+            $row['subject'] = 'Payment success';
+        }
+        if (Schema::hasColumn('email_outbox', 'body_html')) {
+            $row['body_html'] = '<p>sent</p>';
+        }
+
+        DB::table('email_outbox')->insert($row);
+    }
+}


### PR DESCRIPTION
Summary
- add Unlock / Commerce Linkage as the second Assessment Intelligence Console page
- provide a read-only support diagnostic surface rooted on orders

What changed
- evolve the existing order-rooted diagnostics surface in Filament Ops by extending OrderResource
- use orders as the primary commerce linkage root object
- expose payment / grant / report / attempt / share summaries in a single detail view
- keep raw payment and report payloads hidden by default
- add focused tests for read-only visibility, cross-org lookup behavior, and unlock/report linkage rendering

Design choices
- use orders as the main root because support workflows typically start from order_no
- treat benefit_grants as the source of truth for successful unlocks
- keep v1 read-only and avoid introducing a new analytics read model
- keep the page under Commerce because it serves payment/unlock/delivery diagnostics
- defer deeper funnel analytics and full report-center work to later AIC phases

Why this PR is small and safe
- no schema changes
- no API changes
- no write-side behavior changes
- no frontend changes
- only the second support-facing assessment console entrypoint

Validation
- php artisan about
- php artisan route:list --path=ops --except-vendor
- php artisan migrate
- php artisan test --filter=OrderCommerceLinkageTest
- php artisan test --filter='(Order|Payment|Benefit|Commerce|Unlock)'
- php artisan filament:assets
- npm run build
- bash scripts/ci_verify_mbti.sh

Notes
- the broad pattern test run still hits existing unrelated suite instability in this repo\s sqlite/phpunit baseline; the new OrderCommerceLinkageTest passes cleanly on its own