### PR TITLE
feat(commerce): add Funnel & Conversion as the first commerce-growth insights page

### DIFF
--- a/backend/app/Console/Commands/RefreshAnalyticsFunnelDailyCommand.php
+++ b/backend/app/Console/Commands/RefreshAnalyticsFunnelDailyCommand.php
@@ -1,0 +1,78 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Console\Commands;
+
+use App\Services\Analytics\AnalyticsFunnelDailyBuilder;
+use Carbon\CarbonImmutable;
+use Illuminate\Console\Command;
+
+class RefreshAnalyticsFunnelDailyCommand extends Command
+{
+    protected $signature = 'analytics:refresh-funnel-daily
+        {--from= : Inclusive start date (Y-m-d)}
+        {--to= : Inclusive end date (Y-m-d)}
+        {--scale=* : Limit refresh to one or more scale codes}
+        {--org=* : Limit refresh to one or more org ids}
+        {--dry-run : Preview the aggregation without writing rows}';
+
+    protected $description = 'Refresh the analytics_funnel_daily attempt-led commerce funnel read model.';
+
+    public function __construct(
+        private readonly AnalyticsFunnelDailyBuilder $builder,
+    ) {
+        parent::__construct();
+    }
+
+    public function handle(): int
+    {
+        $from = $this->parseDateOption((string) $this->option('from'), now()->subDays(6)->toDateString());
+        $to = $this->parseDateOption((string) $this->option('to'), now()->toDateString());
+
+        if ($from->greaterThan($to)) {
+            $this->error('The --from date must be on or before --to.');
+
+            return self::FAILURE;
+        }
+
+        $scaleCodes = array_values(array_filter(array_map(
+            static fn (mixed $value): string => strtoupper(trim((string) $value)),
+            (array) $this->option('scale')
+        ), static fn (string $value): bool => $value !== ''));
+
+        $orgIds = array_values(array_filter(array_map(
+            static fn (mixed $value): int => max(0, (int) $value),
+            (array) $this->option('org')
+        ), static fn (int $value): bool => $value >= 0));
+
+        $dryRun = (bool) $this->option('dry-run');
+
+        $result = $this->builder->refresh($from, $to, $orgIds, $scaleCodes, $dryRun);
+
+        $this->line('from='.$result['from']);
+        $this->line('to='.$result['to']);
+        $this->line('org_scope='.(empty($result['org_scope']) ? '*' : implode(',', $result['org_scope'])));
+        $this->line('scale_scope='.(empty($result['scale_scope']) ? '*' : implode(',', $result['scale_scope'])));
+        $this->line('dry_run='.(($result['dry_run'] ?? false) ? '1' : '0'));
+        $this->line('attempted_rows='.(string) ($result['attempted_rows'] ?? 0));
+        $this->line('deleted_rows='.(string) ($result['deleted_rows'] ?? 0));
+        $this->line('upserted_rows='.(string) ($result['upserted_rows'] ?? 0));
+
+        if (($result['attempted_rows'] ?? 0) === 0) {
+            $this->warn('No funnel rows were generated for the selected scope.');
+        } else {
+            $this->info($dryRun ? 'dry-run complete' : 'refresh complete');
+        }
+
+        return self::SUCCESS;
+    }
+
+    private function parseDateOption(string $value, string $fallback): CarbonImmutable
+    {
+        $candidate = trim($value) !== '' ? trim($value) : $fallback;
+
+        return CarbonImmutable::createFromFormat('Y-m-d', $candidate)?->startOfDay()
+            ?? CarbonImmutable::parse($candidate)->startOfDay();
+    }
+}

--- a/backend/app/Filament/Ops/Pages/FunnelConversionPage.php
+++ b/backend/app/Filament/Ops/Pages/FunnelConversionPage.php
@@ -1,0 +1,644 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Filament\Ops\Pages;
+
+use App\Support\OrgContext;
+use App\Support\Rbac\PermissionNames;
+use App\Support\SchemaBaseline;
+use Carbon\CarbonImmutable;
+use Filament\Actions\Action;
+use Filament\Pages\Page;
+use Illuminate\Support\Collection;
+use Illuminate\Support\Facades\DB;
+
+class FunnelConversionPage extends Page
+{
+    protected static ?string $navigationIcon = 'heroicon-o-chart-bar-square';
+
+    protected static ?string $navigationGroup = 'Commerce';
+
+    protected static ?string $navigationLabel = 'Funnel & Conversion';
+
+    protected static ?int $navigationSort = 5;
+
+    protected static ?string $slug = 'funnel-conversion';
+
+    protected static string $view = 'filament.ops.pages.funnel-conversion-page';
+
+    /** @var array<string,string> */
+    private const DAILY_TREND_METRICS = [
+        'started_attempts' => 'Started',
+        'submitted_attempts' => 'Submitted',
+        'order_created_attempts' => 'Order created',
+        'paid_attempts' => 'Paid',
+        'unlocked_attempts' => 'Unlocked',
+        'report_ready_attempts' => 'Report ready',
+    ];
+
+    /** @var array<int,array{key:string,label:string,note:string}> */
+    private const CONVERSION_STAGES = [
+        [
+            'key' => 'started_attempts',
+            'label' => 'test_start',
+            'note' => 'Hard fact: attempts.created_at',
+        ],
+        [
+            'key' => 'submitted_attempts',
+            'label' => 'test_submit_success',
+            'note' => 'Hard fact first, then attempt_submissions / results fallback',
+        ],
+        [
+            'key' => 'first_view_attempts',
+            'label' => 'first_result_or_report_view',
+            'note' => 'Behavioral mirror: normalized result_view / report_view events',
+        ],
+        [
+            'key' => 'order_created_attempts',
+            'label' => 'order_created',
+            'note' => 'Hard fact: orders.created_at by target_attempt_id',
+        ],
+        [
+            'key' => 'paid_attempts',
+            'label' => 'payment_success',
+            'note' => 'Hard fact first, payment_events fallback when paid_at is absent',
+        ],
+        [
+            'key' => 'unlocked_attempts',
+            'label' => 'unlock_success',
+            'note' => 'Hard fact: active benefit_grants; order status alone is not enough',
+        ],
+        [
+            'key' => 'report_ready_attempts',
+            'label' => 'report_ready',
+            'note' => 'Hard fact: ready/readable report_snapshots; report_jobs excluded',
+        ],
+    ];
+
+    public string $fromDate = '';
+
+    public string $toDate = '';
+
+    public string $scaleCode = 'all';
+
+    public string $locale = 'all';
+
+    /** @var array<string,string> */
+    public array $scaleOptions = [];
+
+    /** @var array<string,string> */
+    public array $localeOptions = [];
+
+    /** @var list<array<string,mixed>> */
+    public array $kpis = [];
+
+    /** @var list<array<string,mixed>> */
+    public array $dailyTrend = [];
+
+    /** @var list<array<string,mixed>> */
+    public array $conversionRows = [];
+
+    /** @var list<array<string,mixed>> */
+    public array $localeComparison = [];
+
+    /** @var array<string,mixed> */
+    public array $pdfPanel = [];
+
+    /** @var array<string,mixed> */
+    public array $sharePanel = [];
+
+    /** @var list<string> */
+    public array $warnings = [];
+
+    public bool $hasData = false;
+
+    public function mount(): void
+    {
+        $this->fromDate = now()->subDays(13)->toDateString();
+        $this->toDate = now()->toDateString();
+        $this->refreshPage();
+    }
+
+    public static function getNavigationGroup(): ?string
+    {
+        return __('ops.group.commerce');
+    }
+
+    public static function canAccess(): bool
+    {
+        $guard = (string) config('admin.guard', 'admin');
+        $user = auth($guard)->user();
+
+        return is_object($user)
+            && method_exists($user, 'hasPermission')
+            && (
+                $user->hasPermission(PermissionNames::ADMIN_MENU_COMMERCE)
+                || $user->hasPermission(PermissionNames::ADMIN_OPS_READ)
+                || $user->hasPermission(PermissionNames::ADMIN_OWNER)
+            );
+    }
+
+    public function getTitle(): string
+    {
+        return 'Funnel & Conversion';
+    }
+
+    public function getSubheading(): ?string
+    {
+        return 'Attempt-led commerce funnel for the selected org. Business facts stay authoritative for order, payment, unlock, and report readiness; events fill only the behavioral gaps.';
+    }
+
+    protected function getHeaderActions(): array
+    {
+        return [
+            Action::make('attempts')
+                ->label('Attempts Explorer')
+                ->url('/ops/attempts'),
+            Action::make('orders')
+                ->label('Orders')
+                ->url('/ops/orders'),
+            Action::make('paymentEvents')
+                ->label('Payment Events')
+                ->url('/ops/payment-events'),
+            Action::make('orderLookup')
+                ->label('Order Lookup')
+                ->url('/ops/order-lookup'),
+        ];
+    }
+
+    public function applyFilters(): void
+    {
+        $this->refreshPage();
+    }
+
+    public function refreshPage(): void
+    {
+        $this->warnings = [];
+        $this->loadFilterOptions();
+
+        if (! SchemaBaseline::hasTable('analytics_funnel_daily')) {
+            $this->resetPanels();
+            $this->warnings[] = 'analytics_funnel_daily is missing. Run php artisan migrate first.';
+
+            return;
+        }
+
+        [$from, $to] = $this->resolvedRange();
+
+        if ($from->greaterThan($to)) {
+            $this->resetPanels();
+            $this->warnings[] = 'The selected date range is invalid. Keep the start date on or before the end date.';
+
+            return;
+        }
+
+        $rows = $this->scopedQuery()
+            ->orderBy('day')
+            ->get([
+                'day',
+                'scale_code',
+                'locale',
+                'started_attempts',
+                'submitted_attempts',
+                'first_view_attempts',
+                'order_created_attempts',
+                'paid_attempts',
+                'paid_revenue_cents',
+                'unlocked_attempts',
+                'report_ready_attempts',
+                'pdf_download_attempts',
+                'share_generated_attempts',
+                'share_click_attempts',
+            ]);
+
+        $this->hasData = $rows->isNotEmpty();
+
+        if (! $this->hasData) {
+            $this->resetPanels();
+            $this->warnings[] = 'No analytics_funnel_daily rows match the current scope. Refresh the read model with php artisan analytics:refresh-funnel-daily --from='.$from->toDateString().' --to='.$to->toDateString().'.';
+
+            return;
+        }
+
+        $totals = $this->totalsFromRows($rows);
+        $dailyRows = $this->dailyRows($rows, $from, $to);
+
+        $this->kpis = $this->buildKpis($totals);
+        $this->dailyTrend = $this->buildDailyTrend($dailyRows);
+        $this->conversionRows = $this->buildConversionRows($totals);
+        $this->localeComparison = $this->buildLocaleComparison();
+        $this->pdfPanel = $this->buildPdfPanel($totals, $dailyRows);
+        $this->sharePanel = $this->buildSharePanel($totals, $dailyRows);
+    }
+
+    public function formatInt(int $value): string
+    {
+        return number_format($value);
+    }
+
+    public function formatCurrencyCents(int $value): string
+    {
+        return '$'.number_format($value / 100, 2);
+    }
+
+    public function formatRate(?float $value): string
+    {
+        if ($value === null) {
+            return 'n/a';
+        }
+
+        return number_format($value * 100, 1).'%';
+    }
+
+    private function resetPanels(): void
+    {
+        $this->hasData = false;
+        $this->kpis = [];
+        $this->dailyTrend = [];
+        $this->conversionRows = [];
+        $this->localeComparison = [];
+        $this->pdfPanel = [
+            'downloads' => 0,
+            'readiness_gap' => 0,
+            'download_rate' => null,
+            'trend' => [],
+        ];
+        $this->sharePanel = [
+            'generated' => 0,
+            'clicks' => 0,
+            'click_rate' => null,
+            'trend' => [],
+        ];
+    }
+
+    private function loadFilterOptions(): void
+    {
+        $this->scaleOptions = [];
+        $this->localeOptions = [];
+
+        if (! SchemaBaseline::hasTable('analytics_funnel_daily')) {
+            return;
+        }
+
+        $orgId = $this->currentOrgId();
+
+        $this->scaleOptions = DB::table('analytics_funnel_daily')
+            ->where('org_id', $orgId)
+            ->whereNotNull('scale_code')
+            ->where('scale_code', '!=', '')
+            ->distinct()
+            ->orderBy('scale_code')
+            ->pluck('scale_code', 'scale_code')
+            ->mapWithKeys(fn (string $value): array => [$value => $value])
+            ->all();
+
+        $this->localeOptions = DB::table('analytics_funnel_daily')
+            ->where('org_id', $orgId)
+            ->whereNotNull('locale')
+            ->where('locale', '!=', '')
+            ->distinct()
+            ->orderByRaw("case locale when 'en' then 0 when 'zh-CN' then 1 else 2 end")
+            ->orderBy('locale')
+            ->pluck('locale', 'locale')
+            ->mapWithKeys(fn (string $value): array => [$value => $value])
+            ->all();
+    }
+
+    private function currentOrgId(): int
+    {
+        return max(0, (int) app(OrgContext::class)->orgId());
+    }
+
+    /**
+     * @return array{CarbonImmutable,CarbonImmutable}
+     */
+    private function resolvedRange(): array
+    {
+        return [
+            CarbonImmutable::parse($this->fromDate)->startOfDay(),
+            CarbonImmutable::parse($this->toDate)->endOfDay(),
+        ];
+    }
+
+    private function scopedQuery(bool $applyLocaleFilter = true)
+    {
+        [$from, $to] = $this->resolvedRange();
+
+        $query = DB::table('analytics_funnel_daily')
+            ->where('org_id', $this->currentOrgId())
+            ->whereBetween('day', [$from->toDateString(), $to->toDateString()]);
+
+        if ($this->scaleCode !== 'all') {
+            $query->where('scale_code', $this->scaleCode);
+        }
+
+        if ($applyLocaleFilter && $this->locale !== 'all') {
+            $query->where('locale', $this->locale);
+        }
+
+        return $query;
+    }
+
+    /**
+     * @param  Collection<int,object>  $rows
+     * @return array<string,int>
+     */
+    private function totalsFromRows(Collection $rows): array
+    {
+        $metrics = [
+            'started_attempts',
+            'submitted_attempts',
+            'first_view_attempts',
+            'order_created_attempts',
+            'paid_attempts',
+            'paid_revenue_cents',
+            'unlocked_attempts',
+            'report_ready_attempts',
+            'pdf_download_attempts',
+            'share_generated_attempts',
+            'share_click_attempts',
+        ];
+
+        $totals = array_fill_keys($metrics, 0);
+
+        foreach ($rows as $row) {
+            foreach ($metrics as $metric) {
+                $totals[$metric] += (int) ($row->{$metric} ?? 0);
+            }
+        }
+
+        return $totals;
+    }
+
+    /**
+     * @param  Collection<int,object>  $rows
+     * @return list<array<string,int|string>>
+     */
+    private function dailyRows(Collection $rows, CarbonImmutable $from, CarbonImmutable $to): array
+    {
+        $days = [];
+        $cursor = $from->startOfDay();
+
+        while ($cursor->lessThanOrEqualTo($to)) {
+            $day = $cursor->toDateString();
+            $days[$day] = [
+                'day' => $day,
+                'started_attempts' => 0,
+                'submitted_attempts' => 0,
+                'order_created_attempts' => 0,
+                'paid_attempts' => 0,
+                'unlocked_attempts' => 0,
+                'report_ready_attempts' => 0,
+                'pdf_download_attempts' => 0,
+                'share_generated_attempts' => 0,
+                'share_click_attempts' => 0,
+            ];
+            $cursor = $cursor->addDay();
+        }
+
+        foreach ($rows as $row) {
+            $day = trim((string) ($row->day ?? ''));
+            if ($day === '' || ! isset($days[$day])) {
+                continue;
+            }
+
+            foreach (array_keys($days[$day]) as $metric) {
+                if ($metric === 'day') {
+                    continue;
+                }
+
+                $days[$day][$metric] += (int) ($row->{$metric} ?? 0);
+            }
+        }
+
+        return array_values($days);
+    }
+
+    /**
+     * @param  array<string,int>  $totals
+     * @return list<array<string,mixed>>
+     */
+    private function buildKpis(array $totals): array
+    {
+        return [
+            [
+                'label' => 'Started attempts',
+                'value' => (int) ($totals['started_attempts'] ?? 0),
+                'description' => 'Authority: attempts.created_at',
+            ],
+            [
+                'label' => 'Submitted attempts',
+                'value' => (int) ($totals['submitted_attempts'] ?? 0),
+                'description' => 'submit/start '.$this->formatRate($this->safeRate(
+                    (int) ($totals['submitted_attempts'] ?? 0),
+                    (int) ($totals['started_attempts'] ?? 0)
+                )),
+            ],
+            [
+                'label' => 'First result/report viewers',
+                'value' => (int) ($totals['first_view_attempts'] ?? 0),
+                'description' => 'view/submit '.$this->formatRate($this->safeRate(
+                    (int) ($totals['first_view_attempts'] ?? 0),
+                    (int) ($totals['submitted_attempts'] ?? 0)
+                )),
+            ],
+            [
+                'label' => 'Order-created attempts',
+                'value' => (int) ($totals['order_created_attempts'] ?? 0),
+                'description' => 'Hard fact: orders.created_at',
+            ],
+            [
+                'label' => 'Paid attempts',
+                'value' => (int) ($totals['paid_attempts'] ?? 0),
+                'description' => 'paid/order '.$this->formatRate($this->safeRate(
+                    (int) ($totals['paid_attempts'] ?? 0),
+                    (int) ($totals['order_created_attempts'] ?? 0)
+                )),
+            ],
+            [
+                'label' => 'Revenue',
+                'value' => (int) ($totals['paid_revenue_cents'] ?? 0),
+                'description' => 'Attempt-led dims, order-level paid revenue',
+                'currency' => true,
+            ],
+            [
+                'label' => 'Unlocked attempts',
+                'value' => (int) ($totals['unlocked_attempts'] ?? 0),
+                'description' => 'unlock/paid '.$this->formatRate($this->safeRate(
+                    (int) ($totals['unlocked_attempts'] ?? 0),
+                    (int) ($totals['paid_attempts'] ?? 0)
+                )),
+            ],
+            [
+                'label' => 'Report-ready attempts',
+                'value' => (int) ($totals['report_ready_attempts'] ?? 0),
+                'description' => 'ready/unlock '.$this->formatRate($this->safeRate(
+                    (int) ($totals['report_ready_attempts'] ?? 0),
+                    (int) ($totals['unlocked_attempts'] ?? 0)
+                )),
+            ],
+        ];
+    }
+
+    /**
+     * @param  list<array<string,int|string>>  $dailyRows
+     * @return list<array<string,mixed>>
+     */
+    private function buildDailyTrend(array $dailyRows): array
+    {
+        $maxima = [];
+
+        foreach (array_keys(self::DAILY_TREND_METRICS) as $metric) {
+            $maxima[$metric] = max(array_map(static fn (array $row): int => (int) ($row[$metric] ?? 0), $dailyRows));
+        }
+
+        return array_map(function (array $row) use ($maxima): array {
+            $entry = ['day' => $row['day']];
+
+            foreach (self::DAILY_TREND_METRICS as $metric => $label) {
+                $value = (int) ($row[$metric] ?? 0);
+                $entry[$metric] = $value;
+                $entry[$metric.'_pct'] = $this->maxPercentage($value, (int) ($maxima[$metric] ?? 0));
+                $entry[$metric.'_label'] = $label;
+            }
+
+            return $entry;
+        }, $dailyRows);
+    }
+
+    /**
+     * @param  array<string,int>  $totals
+     * @return list<array<string,mixed>>
+     */
+    private function buildConversionRows(array $totals): array
+    {
+        $rows = [];
+        $startValue = (int) ($totals['started_attempts'] ?? 0);
+        $previousValue = null;
+
+        foreach (self::CONVERSION_STAGES as $stage) {
+            $value = (int) ($totals[$stage['key']] ?? 0);
+            $rows[] = [
+                'label' => $stage['label'],
+                'value' => $value,
+                'previous_step_rate' => $previousValue === null ? null : $this->safeRate($value, $previousValue),
+                'cumulative_rate' => $this->safeRate($value, $startValue),
+                'note' => $stage['note'],
+            ];
+
+            $previousValue = $value;
+        }
+
+        return $rows;
+    }
+
+    /**
+     * @return list<array<string,mixed>>
+     */
+    private function buildLocaleComparison(): array
+    {
+        $rows = $this->scopedQuery($this->locale !== 'all')
+            ->select('locale')
+            ->selectRaw('SUM(started_attempts) as started_attempts')
+            ->selectRaw('SUM(submitted_attempts) as submitted_attempts')
+            ->selectRaw('SUM(paid_attempts) as paid_attempts')
+            ->selectRaw('SUM(unlocked_attempts) as unlocked_attempts')
+            ->selectRaw('SUM(report_ready_attempts) as report_ready_attempts')
+            ->groupBy('locale')
+            ->orderByRaw("case locale when 'en' then 0 when 'zh-CN' then 1 else 2 end")
+            ->orderBy('locale')
+            ->get();
+
+        return $rows
+            ->map(function (object $row): array {
+                $started = (int) ($row->started_attempts ?? 0);
+                $submitted = (int) ($row->submitted_attempts ?? 0);
+                $paid = (int) ($row->paid_attempts ?? 0);
+                $unlocked = (int) ($row->unlocked_attempts ?? 0);
+                $ready = (int) ($row->report_ready_attempts ?? 0);
+
+                return [
+                    'locale' => trim((string) ($row->locale ?? 'unknown')),
+                    'started_attempts' => $started,
+                    'submitted_attempts' => $submitted,
+                    'paid_attempts' => $paid,
+                    'unlocked_attempts' => $unlocked,
+                    'report_ready_attempts' => $ready,
+                    'submit_rate' => $this->safeRate($submitted, $started),
+                    'paid_rate' => $this->safeRate($paid, $submitted),
+                    'ready_rate' => $this->safeRate($ready, $unlocked),
+                ];
+            })
+            ->all();
+    }
+
+    /**
+     * @param  array<string,int>  $totals
+     * @param  list<array<string,int|string>>  $dailyRows
+     * @return array<string,mixed>
+     */
+    private function buildPdfPanel(array $totals, array $dailyRows): array
+    {
+        return [
+            'downloads' => (int) ($totals['pdf_download_attempts'] ?? 0),
+            'readiness_gap' => max(
+                0,
+                (int) ($totals['report_ready_attempts'] ?? 0) - (int) ($totals['pdf_download_attempts'] ?? 0)
+            ),
+            'download_rate' => $this->safeRate(
+                (int) ($totals['pdf_download_attempts'] ?? 0),
+                (int) ($totals['report_ready_attempts'] ?? 0)
+            ),
+            'trend' => array_slice(array_map(static function (array $row): array {
+                return [
+                    'day' => $row['day'],
+                    'report_ready_attempts' => (int) ($row['report_ready_attempts'] ?? 0),
+                    'pdf_download_attempts' => (int) ($row['pdf_download_attempts'] ?? 0),
+                ];
+            }, $dailyRows), -7),
+        ];
+    }
+
+    /**
+     * @param  array<string,int>  $totals
+     * @param  list<array<string,int|string>>  $dailyRows
+     * @return array<string,mixed>
+     */
+    private function buildSharePanel(array $totals, array $dailyRows): array
+    {
+        return [
+            'generated' => (int) ($totals['share_generated_attempts'] ?? 0),
+            'clicks' => (int) ($totals['share_click_attempts'] ?? 0),
+            'click_rate' => $this->safeRate(
+                (int) ($totals['share_click_attempts'] ?? 0),
+                (int) ($totals['share_generated_attempts'] ?? 0)
+            ),
+            'trend' => array_slice(array_map(static function (array $row): array {
+                return [
+                    'day' => $row['day'],
+                    'share_generated_attempts' => (int) ($row['share_generated_attempts'] ?? 0),
+                    'share_click_attempts' => (int) ($row['share_click_attempts'] ?? 0),
+                ];
+            }, $dailyRows), -7),
+        ];
+    }
+
+    private function safeRate(int $numerator, int $denominator): ?float
+    {
+        if ($denominator <= 0) {
+            return null;
+        }
+
+        return round($numerator / $denominator, 4);
+    }
+
+    private function maxPercentage(int $value, int $max): float
+    {
+        if ($max <= 0) {
+            return 0.0;
+        }
+
+        return round(($value / $max) * 100, 2);
+    }
+}

--- a/backend/app/Models/AnalyticsFunnelDaily.php
+++ b/backend/app/Models/AnalyticsFunnelDaily.php
@@ -1,0 +1,58 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Models;
+
+use App\Models\Concerns\HasOrgScope;
+use Illuminate\Database\Eloquent\Model;
+
+class AnalyticsFunnelDaily extends Model
+{
+    use HasOrgScope;
+
+    protected $table = 'analytics_funnel_daily';
+
+    protected $fillable = [
+        'day',
+        'org_id',
+        'scale_code',
+        'locale',
+        'started_attempts',
+        'submitted_attempts',
+        'first_view_attempts',
+        'order_created_attempts',
+        'paid_attempts',
+        'paid_revenue_cents',
+        'unlocked_attempts',
+        'report_ready_attempts',
+        'pdf_download_attempts',
+        'share_generated_attempts',
+        'share_click_attempts',
+        'last_refreshed_at',
+    ];
+
+    protected $casts = [
+        'day' => 'date',
+        'org_id' => 'integer',
+        'started_attempts' => 'integer',
+        'submitted_attempts' => 'integer',
+        'first_view_attempts' => 'integer',
+        'order_created_attempts' => 'integer',
+        'paid_attempts' => 'integer',
+        'paid_revenue_cents' => 'integer',
+        'unlocked_attempts' => 'integer',
+        'report_ready_attempts' => 'integer',
+        'pdf_download_attempts' => 'integer',
+        'share_generated_attempts' => 'integer',
+        'share_click_attempts' => 'integer',
+        'last_refreshed_at' => 'datetime',
+        'created_at' => 'datetime',
+        'updated_at' => 'datetime',
+    ];
+
+    public static function allowOrgZeroContext(): bool
+    {
+        return self::allowOrgZeroWithResolvedContext();
+    }
+}

--- a/backend/app/Services/Analytics/AnalyticsFunnelDailyBuilder.php
+++ b/backend/app/Services/Analytics/AnalyticsFunnelDailyBuilder.php
@@ -1,0 +1,1311 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\Analytics;
+
+use App\Support\SchemaBaseline;
+use Carbon\CarbonImmutable;
+use Illuminate\Database\Query\Builder as QueryBuilder;
+use Illuminate\Support\Facades\DB;
+
+final class AnalyticsFunnelDailyBuilder
+{
+    private const FIRST_VIEW_EVENT_ALIASES = [
+        'result_view',
+        'report_view',
+        'report_viewed',
+        'clinical_combo_68_report_viewed',
+        'sds_20_report_viewed',
+    ];
+
+    private const PDF_EVENT_ALIASES = [
+        'report_pdf_view',
+    ];
+
+    private const SHARE_CLICK_EVENT_ALIASES = [
+        'share_click',
+    ];
+
+    private const SUBMISSION_SUCCESS_STATES = [
+        'succeeded',
+        'success',
+        'ready',
+        'completed',
+    ];
+
+    private const READY_SNAPSHOT_STATUSES = [
+        'ready',
+        'full',
+        'completed',
+        'complete',
+        'done',
+        'generated',
+        'success',
+        'succeeded',
+    ];
+
+    private const PAYMENT_SUCCESS_EVENT_TYPES = [
+        'payment_succeeded',
+        'payment_success',
+        'subscription_payment_success',
+        'invoice.payment_succeeded',
+    ];
+
+    private const PAYMENT_SUCCESS_STATUSES = [
+        'paid',
+        'fulfilled',
+        'completed',
+        'complete',
+        'success',
+        'succeeded',
+    ];
+
+    private const PAYMENT_SUCCESS_HANDLE_STATUSES = [
+        'processed',
+        'handled',
+        'success',
+        'succeeded',
+        'ok',
+        'reprocessed',
+    ];
+
+    private const PAYMENT_SUCCESS_REASONS = [
+        'paid',
+        'completed',
+        'success',
+        'succeeded',
+        'payment_succeeded',
+        'settled',
+    ];
+
+    private const METRIC_COLUMN_MAP = [
+        'test_start' => 'started_attempts',
+        'test_submit_success' => 'submitted_attempts',
+        'first_result_or_report_view' => 'first_view_attempts',
+        'order_created' => 'order_created_attempts',
+        'payment_success' => 'paid_attempts',
+        'unlock_success' => 'unlocked_attempts',
+        'report_ready' => 'report_ready_attempts',
+        'pdf_download' => 'pdf_download_attempts',
+        'share_generate' => 'share_generated_attempts',
+        'share_click' => 'share_click_attempts',
+    ];
+
+    private const PRIMARY_STAGE_KEYS = [
+        'test_start',
+        'test_submit_success',
+        'first_result_or_report_view',
+        'order_created',
+        'payment_success',
+        'unlock_success',
+        'report_ready',
+    ];
+
+    private const NON_PAYMENT_EVENT_TYPES = [
+        'order_created',
+        'checkout_start',
+        'checkout_started',
+        'payment_failed',
+        'refund',
+        'refund_succeeded',
+        'refund_failed',
+    ];
+
+    /**
+     * @param  list<int>  $orgIds
+     * @param  list<string>  $scaleCodes
+     * @return array{
+     *     rows:list<array<string,mixed>>,
+     *     attempted_rows:int,
+     *     org_scope:list<int>,
+     *     scale_scope:list<string>,
+     *     from:string,
+     *     to:string
+     * }
+     */
+    public function build(
+        \DateTimeInterface $from,
+        \DateTimeInterface $to,
+        array $orgIds = [],
+        array $scaleCodes = [],
+    ): array {
+        $fromAt = CarbonImmutable::parse($from)->startOfDay();
+        $toAt = CarbonImmutable::parse($to)->endOfDay();
+        $normalizedOrgIds = $this->normalizeOrgIds($orgIds);
+        $normalizedScaleCodes = $this->normalizeScaleCodes($scaleCodes);
+
+        $stageMaps = [
+            'test_start' => $this->collectTestStartMap($fromAt, $toAt, $normalizedOrgIds, $normalizedScaleCodes),
+            'test_submit_success' => $this->collectSubmitSuccessMap($fromAt, $toAt, $normalizedOrgIds, $normalizedScaleCodes),
+            'first_result_or_report_view' => $this->collectFirstViewMap($fromAt, $toAt, $normalizedOrgIds),
+            'order_created' => $this->collectOrderCreatedMap($fromAt, $toAt, $normalizedOrgIds),
+            'payment_success' => $this->collectPaymentSuccessMap($fromAt, $toAt, $normalizedOrgIds),
+            'unlock_success' => $this->collectUnlockSuccessMap($fromAt, $toAt, $normalizedOrgIds),
+            'report_ready' => $this->collectReportReadyMap($fromAt, $toAt, $normalizedOrgIds),
+            'pdf_download' => $this->collectPdfDownloadMap($fromAt, $toAt, $normalizedOrgIds),
+            'share_generate' => $this->collectShareGenerateMap($fromAt, $toAt, $normalizedOrgIds, $normalizedScaleCodes),
+            'share_click' => $this->collectShareClickMap($fromAt, $toAt, $normalizedOrgIds),
+        ];
+        $stageMaps = $this->normalizePrimaryStageMaps($stageMaps);
+
+        $revenueEntries = $this->collectPaidRevenueEntries($fromAt, $toAt, $normalizedOrgIds);
+        $candidateAttemptIds = $this->candidateAttemptIds($stageMaps, $revenueEntries);
+        $dimensions = $this->loadAttemptDimensions($candidateAttemptIds, $normalizedOrgIds, $normalizedScaleCodes);
+
+        $rows = $this->aggregateRows($stageMaps, $revenueEntries, $dimensions);
+
+        return [
+            'rows' => array_values($rows),
+            'attempted_rows' => count($rows),
+            'org_scope' => $normalizedOrgIds,
+            'scale_scope' => $normalizedScaleCodes,
+            'from' => $fromAt->toDateString(),
+            'to' => $toAt->toDateString(),
+        ];
+    }
+
+    /**
+     * @param  list<int>  $orgIds
+     * @param  list<string>  $scaleCodes
+     * @return array{
+     *     rows:list<array<string,mixed>>,
+     *     attempted_rows:int,
+     *     deleted_rows:int,
+     *     upserted_rows:int,
+     *     org_scope:list<int>,
+     *     scale_scope:list<string>,
+     *     from:string,
+     *     to:string,
+     *     dry_run:bool
+     * }
+     */
+    public function refresh(
+        \DateTimeInterface $from,
+        \DateTimeInterface $to,
+        array $orgIds = [],
+        array $scaleCodes = [],
+        bool $dryRun = false,
+    ): array {
+        $payload = $this->build($from, $to, $orgIds, $scaleCodes);
+        $rows = $payload['rows'];
+        $deletedRows = 0;
+        $upsertedRows = 0;
+
+        if (! $dryRun) {
+            DB::transaction(function () use ($payload, $rows, &$deletedRows, &$upsertedRows): void {
+                $deletedRows = $this->deleteScope(
+                    $payload['from'],
+                    $payload['to'],
+                    $payload['org_scope'],
+                    $payload['scale_scope']
+                );
+
+                if ($rows === []) {
+                    return;
+                }
+
+                DB::table('analytics_funnel_daily')->upsert(
+                    $rows,
+                    ['day', 'org_id', 'scale_code', 'locale'],
+                    [
+                        'started_attempts',
+                        'submitted_attempts',
+                        'first_view_attempts',
+                        'order_created_attempts',
+                        'paid_attempts',
+                        'paid_revenue_cents',
+                        'unlocked_attempts',
+                        'report_ready_attempts',
+                        'pdf_download_attempts',
+                        'share_generated_attempts',
+                        'share_click_attempts',
+                        'last_refreshed_at',
+                        'updated_at',
+                    ]
+                );
+
+                $upsertedRows = count($rows);
+            });
+        }
+
+        return $payload + [
+            'deleted_rows' => $deletedRows,
+            'upserted_rows' => $upsertedRows,
+            'dry_run' => $dryRun,
+        ];
+    }
+
+    /**
+     * @param  array<string,array<string,string>>  $stageMaps
+     * @param  list<array{attempt_id:string,paid_at:string,amount_cents:int}>  $revenueEntries
+     * @return list<string>
+     */
+    private function candidateAttemptIds(array $stageMaps, array $revenueEntries): array
+    {
+        $attemptIds = [];
+
+        foreach ($stageMaps as $stageMap) {
+            foreach (array_keys($stageMap) as $attemptId) {
+                $attemptIds[$attemptId] = true;
+            }
+        }
+
+        foreach ($revenueEntries as $revenueEntry) {
+            $attemptId = trim((string) ($revenueEntry['attempt_id'] ?? ''));
+            if ($attemptId !== '') {
+                $attemptIds[$attemptId] = true;
+            }
+        }
+
+        return array_keys($attemptIds);
+    }
+
+    /**
+     * @param  list<string>  $attemptIds
+     * @param  list<int>  $orgIds
+     * @param  list<string>  $scaleCodes
+     * @return array<string,array{org_id:int,scale_code:string,locale:string}>
+     */
+    private function loadAttemptDimensions(array $attemptIds, array $orgIds, array $scaleCodes): array
+    {
+        if ($attemptIds === [] || ! SchemaBaseline::hasTable('attempts')) {
+            return [];
+        }
+
+        $dimensions = [];
+
+        foreach (array_chunk($attemptIds, 500) as $attemptChunk) {
+            $query = DB::table('attempts')
+                ->whereIn('id', $attemptChunk)
+                ->select('id', 'org_id', 'scale_code', 'locale');
+
+            if (SchemaBaseline::hasColumn('attempts', 'scale_code_v2')) {
+                $query->addSelect('scale_code_v2');
+            }
+
+            if ($orgIds !== []) {
+                $query->whereIn('org_id', $orgIds);
+            }
+
+            $this->applyAttemptScaleFilter($query, $scaleCodes);
+
+            foreach ($query->get() as $row) {
+                $attemptId = trim((string) ($row->id ?? ''));
+                if ($attemptId === '') {
+                    continue;
+                }
+
+                $dimensions[$attemptId] = [
+                    'org_id' => max(0, (int) ($row->org_id ?? 0)),
+                    'scale_code' => $this->normalizeScaleCodeValue(
+                        $row->scale_code_v2 ?? $row->scale_code ?? null
+                    ),
+                    'locale' => $this->normalizeLocaleValue($row->locale ?? null),
+                ];
+            }
+        }
+
+        return $dimensions;
+    }
+
+    /**
+     * @param  array<string,array<string,string>>  $stageMaps
+     * @param  list<array{attempt_id:string,paid_at:string,amount_cents:int}>  $revenueEntries
+     * @param  array<string,array{org_id:int,scale_code:string,locale:string}>  $dimensions
+     * @return array<string,array<string,mixed>>
+     */
+    private function aggregateRows(array $stageMaps, array $revenueEntries, array $dimensions): array
+    {
+        $rows = [];
+        $refreshedAt = now();
+
+        foreach ($stageMaps as $stageKey => $stageMap) {
+            $metricColumn = self::METRIC_COLUMN_MAP[$stageKey] ?? null;
+            if ($metricColumn === null) {
+                continue;
+            }
+
+            foreach ($stageMap as $attemptId => $stageAt) {
+                if (! isset($dimensions[$attemptId])) {
+                    continue;
+                }
+
+                $dimension = $dimensions[$attemptId];
+                $day = CarbonImmutable::parse($stageAt)->toDateString();
+                $rowKey = $this->aggregateKey($day, $dimension['org_id'], $dimension['scale_code'], $dimension['locale']);
+
+                if (! isset($rows[$rowKey])) {
+                    $rows[$rowKey] = $this->emptyAggregateRow($day, $dimension, $refreshedAt);
+                }
+
+                $rows[$rowKey][$metricColumn]++;
+            }
+        }
+
+        foreach ($revenueEntries as $revenueEntry) {
+            $attemptId = trim((string) ($revenueEntry['attempt_id'] ?? ''));
+            if ($attemptId === '' || ! isset($dimensions[$attemptId])) {
+                continue;
+            }
+
+            $dimension = $dimensions[$attemptId];
+            $day = CarbonImmutable::parse($revenueEntry['paid_at'])->toDateString();
+            $rowKey = $this->aggregateKey($day, $dimension['org_id'], $dimension['scale_code'], $dimension['locale']);
+
+            if (! isset($rows[$rowKey])) {
+                $rows[$rowKey] = $this->emptyAggregateRow($day, $dimension, $refreshedAt);
+            }
+
+            $rows[$rowKey]['paid_revenue_cents'] += max(0, (int) ($revenueEntry['amount_cents'] ?? 0));
+        }
+
+        ksort($rows);
+
+        return $rows;
+    }
+
+    /**
+     * @param  array{org_id:int,scale_code:string,locale:string}  $dimension
+     * @return array<string,mixed>
+     */
+    private function emptyAggregateRow(string $day, array $dimension, \DateTimeInterface $refreshedAt): array
+    {
+        return [
+            'day' => $day,
+            'org_id' => $dimension['org_id'],
+            'scale_code' => $dimension['scale_code'],
+            'locale' => $dimension['locale'],
+            'started_attempts' => 0,
+            'submitted_attempts' => 0,
+            'first_view_attempts' => 0,
+            'order_created_attempts' => 0,
+            'paid_attempts' => 0,
+            'paid_revenue_cents' => 0,
+            'unlocked_attempts' => 0,
+            'report_ready_attempts' => 0,
+            'pdf_download_attempts' => 0,
+            'share_generated_attempts' => 0,
+            'share_click_attempts' => 0,
+            'last_refreshed_at' => $refreshedAt,
+            'created_at' => $refreshedAt,
+            'updated_at' => $refreshedAt,
+        ];
+    }
+
+    private function aggregateKey(string $day, int $orgId, string $scaleCode, string $locale): string
+    {
+        return implode('|', [$day, (string) $orgId, $scaleCode, $locale]);
+    }
+
+    /**
+     * @param  list<int>  $orgIds
+     * @param  list<string>  $scaleCodes
+     * @return array<string,string>
+     */
+    private function collectTestStartMap(CarbonImmutable $from, CarbonImmutable $to, array $orgIds, array $scaleCodes): array
+    {
+        if (! SchemaBaseline::hasTable('attempts')) {
+            return [];
+        }
+
+        $query = DB::table('attempts')
+            ->whereNotNull('id')
+            ->whereNotNull('created_at')
+            ->whereBetween('created_at', [$from, $to])
+            ->select('id as attempt_id', 'created_at as stage_at');
+
+        if ($orgIds !== []) {
+            $query->whereIn('org_id', $orgIds);
+        }
+
+        $this->applyAttemptScaleFilter($query, $scaleCodes);
+
+        return $this->rowsToAttemptMap($query->get()->all(), 'attempt_id', 'stage_at');
+    }
+
+    /**
+     * @param  list<int>  $orgIds
+     * @param  list<string>  $scaleCodes
+     * @return array<string,string>
+     */
+    private function collectSubmitSuccessMap(CarbonImmutable $from, CarbonImmutable $to, array $orgIds, array $scaleCodes): array
+    {
+        if (! SchemaBaseline::hasTable('attempts')) {
+            return [];
+        }
+
+        $submittedMap = [];
+
+        $submittedQuery = DB::table('attempts')
+            ->whereNotNull('id')
+            ->whereNotNull('submitted_at')
+            ->whereBetween('submitted_at', [$from, $to])
+            ->select('id as attempt_id', 'submitted_at as stage_at');
+
+        if ($orgIds !== []) {
+            $submittedQuery->whereIn('org_id', $orgIds);
+        }
+
+        $this->applyAttemptScaleFilter($submittedQuery, $scaleCodes);
+        $submittedMap += $this->rowsToAttemptMap($submittedQuery->get()->all(), 'attempt_id', 'stage_at');
+
+        if (SchemaBaseline::hasTable('attempt_submissions')) {
+            [$stateSql, $stateBindings] = $this->lowerInSql('state', self::SUBMISSION_SUCCESS_STATES);
+            $submissionsSub = DB::table('attempt_submissions')
+                ->select('attempt_id')
+                ->selectRaw('MIN(COALESCE(finished_at, updated_at, created_at)) as stage_at')
+                ->whereRaw($stateSql, $stateBindings)
+                ->groupBy('attempt_id');
+
+            $fallbackQuery = DB::table('attempts')
+                ->joinSub($submissionsSub, 'submission_stage', function ($join): void {
+                    $join->on('submission_stage.attempt_id', '=', 'attempts.id');
+                })
+                ->whereNull('attempts.submitted_at')
+                ->whereBetween('submission_stage.stage_at', [$from, $to])
+                ->select('attempts.id as attempt_id', 'submission_stage.stage_at');
+
+            if ($orgIds !== []) {
+                $fallbackQuery->whereIn('attempts.org_id', $orgIds);
+            }
+
+            $this->applyAttemptScaleFilter($fallbackQuery, $scaleCodes);
+            $submittedMap += $this->rowsToAttemptMap($fallbackQuery->get()->all(), 'attempt_id', 'stage_at');
+        }
+
+        if (SchemaBaseline::hasTable('results')) {
+            $resultsSub = DB::table('results')
+                ->select('attempt_id')
+                ->selectRaw('MIN(COALESCE(computed_at, created_at)) as stage_at')
+                ->groupBy('attempt_id');
+
+            $fallbackQuery = DB::table('attempts')
+                ->joinSub($resultsSub, 'result_stage', function ($join): void {
+                    $join->on('result_stage.attempt_id', '=', 'attempts.id');
+                })
+                ->whereNull('attempts.submitted_at');
+
+            if (SchemaBaseline::hasTable('attempt_submissions')) {
+                [$stateSql, $stateBindings] = $this->lowerInSql('state', self::SUBMISSION_SUCCESS_STATES);
+                $fallbackQuery->leftJoinSub(
+                    DB::table('attempt_submissions')
+                        ->select('attempt_id')
+                        ->selectRaw('MIN(COALESCE(finished_at, updated_at, created_at)) as stage_at')
+                        ->whereRaw($stateSql, $stateBindings)
+                        ->groupBy('attempt_id'),
+                    'submission_stage',
+                    function ($join): void {
+                        $join->on('submission_stage.attempt_id', '=', 'attempts.id');
+                    }
+                )->whereNull('submission_stage.stage_at');
+            }
+
+            $fallbackQuery
+                ->whereBetween('result_stage.stage_at', [$from, $to])
+                ->select('attempts.id as attempt_id', 'result_stage.stage_at');
+
+            if ($orgIds !== []) {
+                $fallbackQuery->whereIn('attempts.org_id', $orgIds);
+            }
+
+            $this->applyAttemptScaleFilter($fallbackQuery, $scaleCodes);
+
+            foreach ($fallbackQuery->get() as $row) {
+                $attemptId = trim((string) ($row->attempt_id ?? ''));
+                $stageAt = trim((string) ($row->stage_at ?? ''));
+                if ($attemptId === '' || $stageAt === '' || isset($submittedMap[$attemptId])) {
+                    continue;
+                }
+
+                $submittedMap[$attemptId] = $stageAt;
+            }
+        }
+
+        ksort($submittedMap);
+
+        return $submittedMap;
+    }
+
+    /**
+     * @param  list<int>  $orgIds
+     * @return array<string,string>
+     */
+    private function collectFirstViewMap(CarbonImmutable $from, CarbonImmutable $to, array $orgIds): array
+    {
+        if (! SchemaBaseline::hasTable('events')) {
+            return [];
+        }
+
+        $query = DB::table('events')
+            ->whereNotNull('attempt_id')
+            ->where('attempt_id', '!=', '')
+            ->select('attempt_id')
+            ->selectRaw('MIN(occurred_at) as stage_at')
+            ->groupBy('attempt_id');
+
+        if ($orgIds !== []) {
+            $query->whereIn('org_id', $orgIds);
+        }
+
+        $this->applyEventAliasFilter($query, self::FIRST_VIEW_EVENT_ALIASES);
+        $query->havingRaw('MIN(occurred_at) between ? and ?', [$from->toDateTimeString(), $to->toDateTimeString()]);
+
+        return $this->rowsToAttemptMap($query->get()->all(), 'attempt_id', 'stage_at');
+    }
+
+    /**
+     * @param  list<int>  $orgIds
+     * @return array<string,string>
+     */
+    private function collectOrderCreatedMap(CarbonImmutable $from, CarbonImmutable $to, array $orgIds): array
+    {
+        if (! SchemaBaseline::hasTable('orders')) {
+            return [];
+        }
+
+        $query = DB::table('orders')
+            ->whereNotNull('target_attempt_id')
+            ->where('target_attempt_id', '!=', '')
+            ->select('target_attempt_id as attempt_id')
+            ->selectRaw('MIN(created_at) as stage_at')
+            ->groupBy('target_attempt_id');
+
+        if ($orgIds !== []) {
+            $query->whereIn('org_id', $orgIds);
+        }
+
+        $query->havingRaw('MIN(created_at) between ? and ?', [$from->toDateTimeString(), $to->toDateTimeString()]);
+
+        return $this->rowsToAttemptMap($query->get()->all(), 'attempt_id', 'stage_at');
+    }
+
+    /**
+     * @param  list<int>  $orgIds
+     * @return array<string,string>
+     */
+    private function collectPaymentSuccessMap(CarbonImmutable $from, CarbonImmutable $to, array $orgIds): array
+    {
+        if (! SchemaBaseline::hasTable('orders')) {
+            return [];
+        }
+
+        $paidMap = [];
+
+        $paidQuery = DB::table('orders')
+            ->whereNotNull('target_attempt_id')
+            ->where('target_attempt_id', '!=', '')
+            ->whereNotNull('paid_at')
+            ->select('target_attempt_id as attempt_id')
+            ->selectRaw('MIN(paid_at) as stage_at')
+            ->groupBy('target_attempt_id')
+            ->havingRaw('MIN(paid_at) between ? and ?', [$from->toDateTimeString(), $to->toDateTimeString()]);
+
+        if ($orgIds !== []) {
+            $paidQuery->whereIn('org_id', $orgIds);
+        }
+
+        $paidMap += $this->rowsToAttemptMap($paidQuery->get()->all(), 'attempt_id', 'stage_at');
+
+        if (! SchemaBaseline::hasTable('payment_events')) {
+            return $paidMap;
+        }
+
+        $fallbackQuery = DB::table('payment_events')
+            ->join('orders', 'orders.order_no', '=', 'payment_events.order_no')
+            ->whereNotNull('orders.target_attempt_id')
+            ->where('orders.target_attempt_id', '!=', '')
+            ->whereNull('orders.paid_at')
+            ->where(function (QueryBuilder $query): void {
+                $query->whereNotNull('payment_events.handled_at')
+                    ->orWhereNotNull('payment_events.processed_at');
+            })
+            ->select('orders.target_attempt_id as attempt_id')
+            ->selectRaw('MIN(COALESCE(payment_events.handled_at, payment_events.processed_at)) as stage_at')
+            ->groupBy('orders.target_attempt_id');
+
+        if ($orgIds !== []) {
+            $fallbackQuery->whereIn('orders.org_id', $orgIds);
+        }
+
+        $this->applyPaymentSuccessSignalFilter($fallbackQuery);
+        $fallbackQuery->havingRaw(
+            'MIN(COALESCE(payment_events.handled_at, payment_events.processed_at)) between ? and ?',
+            [$from->toDateTimeString(), $to->toDateTimeString()]
+        );
+
+        foreach ($fallbackQuery->get() as $row) {
+            $attemptId = trim((string) ($row->attempt_id ?? ''));
+            $stageAt = trim((string) ($row->stage_at ?? ''));
+
+            if ($attemptId === '' || $stageAt === '' || isset($paidMap[$attemptId])) {
+                continue;
+            }
+
+            $paidMap[$attemptId] = $stageAt;
+        }
+
+        ksort($paidMap);
+
+        return $paidMap;
+    }
+
+    /**
+     * @param  list<int>  $orgIds
+     * @return array<string,string>
+     */
+    private function collectUnlockSuccessMap(CarbonImmutable $from, CarbonImmutable $to, array $orgIds): array
+    {
+        if (! SchemaBaseline::hasTable('benefit_grants')) {
+            return [];
+        }
+
+        $query = DB::table('benefit_grants')
+            ->whereRaw("lower(coalesce(benefit_grants.status, '')) = ?", ['active'])
+            ->selectRaw(
+                SchemaBaseline::hasTable('orders')
+                    ? 'COALESCE(benefit_grants.attempt_id, orders.target_attempt_id) as attempt_id'
+                    : 'benefit_grants.attempt_id as attempt_id'
+            )
+            ->selectRaw('MIN(benefit_grants.created_at) as stage_at')
+            ->havingRaw('MIN(benefit_grants.created_at) between ? and ?', [$from->toDateTimeString(), $to->toDateTimeString()]);
+
+        if (SchemaBaseline::hasTable('orders')) {
+            $query->leftJoin('orders', function ($join): void {
+                $join->on('orders.id', '=', 'benefit_grants.source_order_id');
+
+                if (SchemaBaseline::hasColumn('benefit_grants', 'order_no')) {
+                    $join->orOn('orders.order_no', '=', 'benefit_grants.order_no');
+                }
+            })->groupByRaw('COALESCE(benefit_grants.attempt_id, orders.target_attempt_id)')
+                ->havingRaw('COALESCE(benefit_grants.attempt_id, orders.target_attempt_id) is not null');
+        } else {
+            $query->groupBy('benefit_grants.attempt_id')
+                ->whereNotNull('benefit_grants.attempt_id')
+                ->where('benefit_grants.attempt_id', '!=', '');
+        }
+
+        if ($orgIds !== []) {
+            $query->whereIn('benefit_grants.org_id', $orgIds);
+        }
+
+        return $this->rowsToAttemptMap($query->get()->all(), 'attempt_id', 'stage_at');
+    }
+
+    /**
+     * @param  list<int>  $orgIds
+     * @return array<string,string>
+     */
+    private function collectReportReadyMap(CarbonImmutable $from, CarbonImmutable $to, array $orgIds): array
+    {
+        if (! SchemaBaseline::hasTable('report_snapshots')) {
+            return [];
+        }
+
+        $query = DB::table('report_snapshots')
+            ->whereNotNull('attempt_id')
+            ->where('attempt_id', '!=', '')
+            ->where(function (QueryBuilder $query) use ($from, $to): void {
+                $query->whereBetween('created_at', [$from, $to])
+                    ->orWhereBetween('updated_at', [$from, $to]);
+            });
+
+        if ($orgIds !== []) {
+            $query->whereIn('org_id', $orgIds);
+        }
+
+        $columns = ['attempt_id', 'status', 'created_at', 'updated_at'];
+
+        foreach (['report_json', 'report_free_json', 'report_full_json'] as $column) {
+            if (SchemaBaseline::hasColumn('report_snapshots', $column)) {
+                $columns[] = $column;
+            }
+        }
+
+        $map = [];
+
+        foreach ($query->get($columns) as $row) {
+            if (! $this->isReadySnapshot($row)) {
+                continue;
+            }
+
+            $attemptId = trim((string) ($row->attempt_id ?? ''));
+            $stageAt = $this->resolveTimestamp([
+                $row->updated_at ?? null,
+                $row->created_at ?? null,
+            ]);
+
+            if ($attemptId === '' || $stageAt === null) {
+                continue;
+            }
+
+            $map[$attemptId] = $this->minTimestamp($map[$attemptId] ?? null, $stageAt);
+        }
+
+        ksort($map);
+
+        return $map;
+    }
+
+    /**
+     * @param  list<int>  $orgIds
+     * @return array<string,string>
+     */
+    private function collectPdfDownloadMap(CarbonImmutable $from, CarbonImmutable $to, array $orgIds): array
+    {
+        if (! SchemaBaseline::hasTable('events')) {
+            return [];
+        }
+
+        $query = DB::table('events')
+            ->whereNotNull('attempt_id')
+            ->where('attempt_id', '!=', '')
+            ->select('attempt_id')
+            ->selectRaw('MIN(occurred_at) as stage_at')
+            ->groupBy('attempt_id');
+
+        if ($orgIds !== []) {
+            $query->whereIn('org_id', $orgIds);
+        }
+
+        $this->applyEventAliasFilter($query, self::PDF_EVENT_ALIASES);
+        $query->havingRaw('MIN(occurred_at) between ? and ?', [$from->toDateTimeString(), $to->toDateTimeString()]);
+
+        return $this->rowsToAttemptMap($query->get()->all(), 'attempt_id', 'stage_at');
+    }
+
+    /**
+     * @param  list<int>  $orgIds
+     * @param  list<string>  $scaleCodes
+     * @return array<string,string>
+     */
+    private function collectShareGenerateMap(CarbonImmutable $from, CarbonImmutable $to, array $orgIds, array $scaleCodes): array
+    {
+        if (! SchemaBaseline::hasTable('shares') || ! SchemaBaseline::hasTable('attempts')) {
+            return [];
+        }
+
+        $query = DB::table('shares')
+            ->join('attempts', 'attempts.id', '=', 'shares.attempt_id')
+            ->whereNotNull('shares.attempt_id')
+            ->where('shares.attempt_id', '!=', '')
+            ->select('shares.attempt_id')
+            ->selectRaw('COALESCE(shares.created_at, shares.updated_at) as stage_at')
+            ->whereBetween(DB::raw('COALESCE(shares.created_at, shares.updated_at)'), [$from->toDateTimeString(), $to->toDateTimeString()]);
+
+        if ($orgIds !== []) {
+            $query->whereIn('attempts.org_id', $orgIds);
+        }
+
+        $this->applyAttemptScaleFilter($query, $scaleCodes, 'attempts');
+
+        return $this->rowsToAttemptMap($query->get()->all(), 'attempt_id', 'stage_at');
+    }
+
+    /**
+     * @param  list<int>  $orgIds
+     * @return array<string,string>
+     */
+    private function collectShareClickMap(CarbonImmutable $from, CarbonImmutable $to, array $orgIds): array
+    {
+        if (! SchemaBaseline::hasTable('events')) {
+            return [];
+        }
+
+        $attemptExpression = SchemaBaseline::hasTable('shares')
+            ? 'COALESCE(events.attempt_id, shares.attempt_id)'
+            : 'events.attempt_id';
+
+        $query = DB::table('events')
+            ->selectRaw($attemptExpression.' as attempt_id')
+            ->selectRaw('MIN(events.occurred_at) as stage_at')
+            ->groupByRaw($attemptExpression)
+            ->havingRaw($attemptExpression.' is not null')
+            ->havingRaw('MIN(events.occurred_at) between ? and ?', [$from->toDateTimeString(), $to->toDateTimeString()]);
+
+        if (SchemaBaseline::hasTable('shares')) {
+            $query->leftJoin('shares', 'shares.id', '=', 'events.share_id');
+        }
+
+        if ($orgIds !== []) {
+            $query->whereIn('events.org_id', $orgIds);
+        }
+
+        $this->applyEventAliasFilter($query, self::SHARE_CLICK_EVENT_ALIASES, 'events');
+
+        return $this->rowsToAttemptMap($query->get()->all(), 'attempt_id', 'stage_at');
+    }
+
+    /**
+     * @param  list<int>  $orgIds
+     * @return list<array{attempt_id:string,paid_at:string,amount_cents:int}>
+     */
+    private function collectPaidRevenueEntries(CarbonImmutable $from, CarbonImmutable $to, array $orgIds): array
+    {
+        if (! SchemaBaseline::hasTable('orders')) {
+            return [];
+        }
+
+        $entries = [];
+
+        $paidOrdersQuery = DB::table('orders')
+            ->whereNotNull('target_attempt_id')
+            ->where('target_attempt_id', '!=', '')
+            ->whereNotNull('paid_at')
+            ->whereBetween('paid_at', [$from, $to])
+            ->select('target_attempt_id as attempt_id', 'paid_at', 'amount_cents');
+
+        if ($orgIds !== []) {
+            $paidOrdersQuery->whereIn('org_id', $orgIds);
+        }
+
+        foreach ($paidOrdersQuery->get() as $row) {
+            $attemptId = trim((string) ($row->attempt_id ?? ''));
+            $paidAt = trim((string) ($row->paid_at ?? ''));
+            if ($attemptId === '' || $paidAt === '') {
+                continue;
+            }
+
+            $entries[] = [
+                'attempt_id' => $attemptId,
+                'paid_at' => $paidAt,
+                'amount_cents' => max(0, (int) ($row->amount_cents ?? 0)),
+            ];
+        }
+
+        if (! SchemaBaseline::hasTable('payment_events')) {
+            return $entries;
+        }
+
+        $fallbackQuery = DB::table('payment_events')
+            ->join('orders', 'orders.order_no', '=', 'payment_events.order_no')
+            ->whereNotNull('orders.target_attempt_id')
+            ->where('orders.target_attempt_id', '!=', '')
+            ->whereNull('orders.paid_at')
+            ->where(function (QueryBuilder $query): void {
+                $query->whereNotNull('payment_events.handled_at')
+                    ->orWhereNotNull('payment_events.processed_at');
+            })
+            ->select('orders.order_no', 'orders.target_attempt_id as attempt_id', 'orders.amount_cents')
+            ->selectRaw('MIN(COALESCE(payment_events.handled_at, payment_events.processed_at)) as paid_at')
+            ->groupBy('orders.order_no', 'orders.target_attempt_id', 'orders.amount_cents')
+            ->havingRaw(
+                'MIN(COALESCE(payment_events.handled_at, payment_events.processed_at)) between ? and ?',
+                [$from->toDateTimeString(), $to->toDateTimeString()]
+            );
+
+        if ($orgIds !== []) {
+            $fallbackQuery->whereIn('orders.org_id', $orgIds);
+        }
+
+        $this->applyPaymentSuccessSignalFilter($fallbackQuery);
+
+        foreach ($fallbackQuery->get() as $row) {
+            $attemptId = trim((string) ($row->attempt_id ?? ''));
+            $paidAt = trim((string) ($row->paid_at ?? ''));
+
+            if ($attemptId === '' || $paidAt === '') {
+                continue;
+            }
+
+            $entries[] = [
+                'attempt_id' => $attemptId,
+                'paid_at' => $paidAt,
+                'amount_cents' => max(0, (int) ($row->amount_cents ?? 0)),
+            ];
+        }
+
+        return $entries;
+    }
+
+    /**
+     * @param  list<object>  $rows
+     * @return array<string,string>
+     */
+    private function rowsToAttemptMap(array $rows, string $attemptField, string $stageField): array
+    {
+        $map = [];
+
+        foreach ($rows as $row) {
+            $attemptId = trim((string) ($row->{$attemptField} ?? ''));
+            $stageAt = trim((string) ($row->{$stageField} ?? ''));
+
+            if ($attemptId === '' || $stageAt === '') {
+                continue;
+            }
+
+            $map[$attemptId] = $this->minTimestamp($map[$attemptId] ?? null, $stageAt);
+        }
+
+        ksort($map);
+
+        return $map;
+    }
+
+    /**
+     * @param  list<int>  $orgIds
+     * @param  list<string>  $scaleCodes
+     */
+    private function deleteScope(string $fromDate, string $toDate, array $orgIds, array $scaleCodes): int
+    {
+        $query = DB::table('analytics_funnel_daily')
+            ->whereBetween('day', [$fromDate, $toDate]);
+
+        if ($orgIds !== []) {
+            $query->whereIn('org_id', $orgIds);
+        }
+
+        if ($scaleCodes !== []) {
+            $query->whereIn('scale_code', $scaleCodes);
+        }
+
+        return $query->delete();
+    }
+
+    /**
+     * @param  list<int>  $orgIds
+     * @return list<int>
+     */
+    private function normalizeOrgIds(array $orgIds): array
+    {
+        return array_values(array_unique(array_filter(array_map(
+            static fn (mixed $value): int => max(0, (int) $value),
+            $orgIds
+        ), static fn (int $value): bool => $value >= 0)));
+    }
+
+    /**
+     * @param  list<string>  $scaleCodes
+     * @return list<string>
+     */
+    private function normalizeScaleCodes(array $scaleCodes): array
+    {
+        $normalized = array_map(
+            fn (mixed $value): string => $this->normalizeScaleCodeValue($value),
+            $scaleCodes
+        );
+
+        return array_values(array_unique(array_filter(
+            $normalized,
+            static fn (string $value): bool => $value !== '' && $value !== 'unknown'
+        )));
+    }
+
+    private function normalizeScaleCodeValue(mixed $value): string
+    {
+        $normalized = strtoupper(trim((string) $value));
+
+        return $normalized !== '' ? $normalized : 'unknown';
+    }
+
+    private function normalizeLocaleValue(mixed $value): string
+    {
+        $normalized = trim((string) $value);
+
+        return $normalized !== '' ? $normalized : 'unknown';
+    }
+
+    /**
+     * @param  list<string>  $scaleCodes
+     */
+    private function applyAttemptScaleFilter(QueryBuilder $query, array $scaleCodes, string $table = 'attempts'): void
+    {
+        if ($scaleCodes === []) {
+            return;
+        }
+
+        $query->where(function (QueryBuilder $builder) use ($scaleCodes, $table): void {
+            if (SchemaBaseline::hasColumn('attempts', 'scale_code_v2')) {
+                $builder->whereIn($table.'.scale_code_v2', $scaleCodes)
+                    ->orWhereIn($table.'.scale_code', $scaleCodes);
+
+                return;
+            }
+
+            $builder->whereIn($table.'.scale_code', $scaleCodes);
+        });
+    }
+
+    /**
+     * @param  array<string,array<string,string>>  $stageMaps
+     * @return array<string,array<string,string>>
+     */
+    private function normalizePrimaryStageMaps(array $stageMaps): array
+    {
+        $attemptIds = [];
+
+        foreach (self::PRIMARY_STAGE_KEYS as $stageKey) {
+            foreach (array_keys($stageMaps[$stageKey] ?? []) as $attemptId) {
+                $attemptIds[$attemptId] = true;
+            }
+        }
+
+        foreach (array_keys($attemptIds) as $attemptId) {
+            $timeline = $this->normalizePrimaryStageTimeline([
+                'test_start' => $stageMaps['test_start'][$attemptId] ?? null,
+                'test_submit_success' => $stageMaps['test_submit_success'][$attemptId] ?? null,
+                'first_result_or_report_view' => $stageMaps['first_result_or_report_view'][$attemptId] ?? null,
+                'order_created' => $stageMaps['order_created'][$attemptId] ?? null,
+                'payment_success' => $stageMaps['payment_success'][$attemptId] ?? null,
+                'unlock_success' => $stageMaps['unlock_success'][$attemptId] ?? null,
+                'report_ready' => $stageMaps['report_ready'][$attemptId] ?? null,
+            ]);
+
+            foreach (self::PRIMARY_STAGE_KEYS as $stageKey) {
+                if ($timeline[$stageKey] === null) {
+                    unset($stageMaps[$stageKey][$attemptId]);
+
+                    continue;
+                }
+
+                $stageMaps[$stageKey][$attemptId] = $timeline[$stageKey];
+            }
+        }
+
+        return $stageMaps;
+    }
+
+    /**
+     * @param  array{
+     *     test_start:?string,
+     *     test_submit_success:?string,
+     *     first_result_or_report_view:?string,
+     *     order_created:?string,
+     *     payment_success:?string,
+     *     unlock_success:?string,
+     *     report_ready:?string
+     * }  $timeline
+     * @return array{
+     *     test_start:?string,
+     *     test_submit_success:?string,
+     *     first_result_or_report_view:?string,
+     *     order_created:?string,
+     *     payment_success:?string,
+     *     unlock_success:?string,
+     *     report_ready:?string
+     * }
+     */
+    private function normalizePrimaryStageTimeline(array $timeline): array
+    {
+        $startAt = $timeline['test_start'] ?? null;
+        $submitAt = $timeline['test_submit_success'] ?? null;
+        $viewAt = $timeline['first_result_or_report_view'] ?? null;
+        $orderAt = $timeline['order_created'] ?? null;
+        $paymentAt = $timeline['payment_success'] ?? null;
+        $unlockAt = $timeline['unlock_success'] ?? null;
+        $readyAt = $timeline['report_ready'] ?? null;
+
+        if ($startAt === null) {
+            return array_fill_keys(self::PRIMARY_STAGE_KEYS, null);
+        }
+
+        if ($submitAt === null || $this->timestampBefore($submitAt, $startAt)) {
+            $submitAt = null;
+            $viewAt = null;
+            $orderAt = null;
+            $paymentAt = null;
+            $unlockAt = null;
+            $readyAt = null;
+        }
+
+        if ($viewAt === null || $submitAt === null || $this->timestampBefore($viewAt, $submitAt)) {
+            $viewAt = null;
+            $orderAt = null;
+            $paymentAt = null;
+            $unlockAt = null;
+            $readyAt = null;
+        }
+
+        if ($orderAt === null || $viewAt === null || $this->timestampBefore($orderAt, $viewAt)) {
+            $orderAt = null;
+            $paymentAt = null;
+            $unlockAt = null;
+            $readyAt = null;
+        }
+
+        if ($paymentAt === null || $orderAt === null || $this->timestampBefore($paymentAt, $orderAt)) {
+            $paymentAt = null;
+            $unlockAt = null;
+            $readyAt = null;
+        }
+
+        if ($unlockAt === null || $paymentAt === null || $this->timestampBefore($unlockAt, $paymentAt)) {
+            $unlockAt = null;
+            $readyAt = null;
+        }
+
+        if ($readyAt === null || $unlockAt === null || $this->timestampBefore($readyAt, $unlockAt)) {
+            $readyAt = null;
+        }
+
+        return [
+            'test_start' => $startAt,
+            'test_submit_success' => $submitAt,
+            'first_result_or_report_view' => $viewAt,
+            'order_created' => $orderAt,
+            'payment_success' => $paymentAt,
+            'unlock_success' => $unlockAt,
+            'report_ready' => $readyAt,
+        ];
+    }
+
+    private function timestampBefore(string $left, string $right): bool
+    {
+        return CarbonImmutable::parse($left)->lessThan(CarbonImmutable::parse($right));
+    }
+
+    /**
+     * @param  list<string>  $eventAliases
+     */
+    private function applyEventAliasFilter(QueryBuilder $query, array $eventAliases, string $table = 'events'): void
+    {
+        [$codeSql, $codeBindings] = $this->lowerInSql($table.'.event_code', $eventAliases);
+        [$nameSql, $nameBindings] = $this->lowerInSql($table.'.event_name', $eventAliases);
+
+        $query->where(function (QueryBuilder $builder) use ($codeSql, $codeBindings, $nameSql, $nameBindings): void {
+            $builder->whereRaw($codeSql, $codeBindings)
+                ->orWhereRaw($nameSql, $nameBindings);
+        });
+    }
+
+    private function applyPaymentSuccessSignalFilter(QueryBuilder $query): void
+    {
+        [$typeSql, $typeBindings] = $this->lowerInSql('payment_events.event_type', self::PAYMENT_SUCCESS_EVENT_TYPES);
+        [$statusSql, $statusBindings] = $this->lowerInSql('payment_events.status', self::PAYMENT_SUCCESS_STATUSES);
+        [$handleSql, $handleBindings] = $this->lowerInSql('payment_events.handle_status', self::PAYMENT_SUCCESS_HANDLE_STATUSES);
+        [$reasonSql, $reasonBindings] = $this->lowerInSql('payment_events.reason', self::PAYMENT_SUCCESS_REASONS);
+        [$excludeTypeSql, $excludeTypeBindings] = $this->lowerNotInSql('payment_events.event_type', self::NON_PAYMENT_EVENT_TYPES);
+
+        $query->where(function (QueryBuilder $builder) use (
+            $typeSql,
+            $typeBindings,
+            $statusSql,
+            $statusBindings,
+            $handleSql,
+            $handleBindings,
+            $reasonSql,
+            $reasonBindings,
+            $excludeTypeSql,
+            $excludeTypeBindings
+        ): void {
+            $builder->whereRaw($typeSql, $typeBindings)
+                ->orWhere(function (QueryBuilder $fallback) use (
+                    $statusSql,
+                    $statusBindings,
+                    $handleSql,
+                    $handleBindings,
+                    $reasonSql,
+                    $reasonBindings,
+                    $excludeTypeSql,
+                    $excludeTypeBindings
+                ): void {
+                    $fallback->whereRaw($excludeTypeSql, $excludeTypeBindings)
+                        ->where(function (QueryBuilder $signals) use (
+                            $statusSql,
+                            $statusBindings,
+                            $handleSql,
+                            $handleBindings,
+                            $reasonSql,
+                            $reasonBindings
+                        ): void {
+                            $signals->whereRaw($statusSql, $statusBindings)
+                                ->orWhereRaw($handleSql, $handleBindings)
+                                ->orWhereRaw($reasonSql, $reasonBindings);
+                        });
+                });
+        });
+    }
+
+    /**
+     * @param  list<string>  $values
+     * @return array{string,list<string>}
+     */
+    private function lowerInSql(string $column, array $values): array
+    {
+        $placeholders = implode(', ', array_fill(0, count($values), '?'));
+
+        return [
+            "lower(coalesce({$column}, '')) in ({$placeholders})",
+            array_map(static fn (string $value): string => strtolower($value), $values),
+        ];
+    }
+
+    /**
+     * @param  list<string>  $values
+     * @return array{string,list<string>}
+     */
+    private function lowerNotInSql(string $column, array $values): array
+    {
+        $placeholders = implode(', ', array_fill(0, count($values), '?'));
+
+        return [
+            "(lower(coalesce({$column}, '')) = '' or lower(coalesce({$column}, '')) not in ({$placeholders}))",
+            array_map(static fn (string $value): string => strtolower($value), $values),
+        ];
+    }
+
+    private function isReadySnapshot(object $row): bool
+    {
+        $status = strtolower(trim((string) ($row->status ?? '')));
+        if (in_array($status, self::READY_SNAPSHOT_STATUSES, true)) {
+            return true;
+        }
+
+        foreach (['report_full_json', 'report_free_json', 'report_json'] as $column) {
+            $value = $row->{$column} ?? null;
+            if ($this->hasReadablePayload($value)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private function hasReadablePayload(mixed $value): bool
+    {
+        if (is_array($value)) {
+            return $value !== [];
+        }
+
+        if (! is_string($value)) {
+            return false;
+        }
+
+        return trim($value) !== '' && trim($value) !== 'null' && trim($value) !== '{}';
+    }
+
+    /**
+     * @param  array<int,mixed>  $candidates
+     */
+    private function resolveTimestamp(array $candidates): ?string
+    {
+        foreach ($candidates as $candidate) {
+            if ($candidate === null) {
+                continue;
+            }
+
+            try {
+                return CarbonImmutable::parse($candidate)->toIso8601String();
+            } catch (\Throwable) {
+                continue;
+            }
+        }
+
+        return null;
+    }
+
+    private function minTimestamp(?string $left, ?string $right): ?string
+    {
+        if ($left === null) {
+            return $right;
+        }
+
+        if ($right === null) {
+            return $left;
+        }
+
+        return CarbonImmutable::parse($left)->lessThanOrEqualTo(CarbonImmutable::parse($right))
+            ? $left
+            : $right;
+    }
+}

--- a/backend/database/migrations/2026_03_14_130000_create_analytics_funnel_daily_table.php
+++ b/backend/database/migrations/2026_03_14_130000_create_analytics_funnel_daily_table.php
@@ -1,0 +1,142 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Support\Database\SchemaIndex;
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    private const TABLE = 'analytics_funnel_daily';
+
+    public function up(): void
+    {
+        if (! Schema::hasTable(self::TABLE)) {
+            Schema::create(self::TABLE, function (Blueprint $table): void {
+                $table->date('day');
+                $table->unsignedBigInteger('org_id')->default(0);
+                $table->string('scale_code', 64)->default('unknown');
+                $table->string('locale', 16)->default('unknown');
+
+                $table->unsignedInteger('started_attempts')->default(0);
+                $table->unsignedInteger('submitted_attempts')->default(0);
+                $table->unsignedInteger('first_view_attempts')->default(0);
+                $table->unsignedInteger('order_created_attempts')->default(0);
+                $table->unsignedInteger('paid_attempts')->default(0);
+                $table->unsignedBigInteger('paid_revenue_cents')->default(0);
+                $table->unsignedInteger('unlocked_attempts')->default(0);
+                $table->unsignedInteger('report_ready_attempts')->default(0);
+
+                $table->unsignedInteger('pdf_download_attempts')->default(0);
+                $table->unsignedInteger('share_generated_attempts')->default(0);
+                $table->unsignedInteger('share_click_attempts')->default(0);
+
+                $table->timestamp('last_refreshed_at')->nullable();
+                $table->timestamps();
+            });
+        } else {
+            Schema::table(self::TABLE, function (Blueprint $table): void {
+                if (! Schema::hasColumn(self::TABLE, 'day')) {
+                    $table->date('day')->nullable();
+                }
+                if (! Schema::hasColumn(self::TABLE, 'org_id')) {
+                    $table->unsignedBigInteger('org_id')->default(0);
+                }
+                if (! Schema::hasColumn(self::TABLE, 'scale_code')) {
+                    $table->string('scale_code', 64)->default('unknown');
+                }
+                if (! Schema::hasColumn(self::TABLE, 'locale')) {
+                    $table->string('locale', 16)->default('unknown');
+                }
+                if (! Schema::hasColumn(self::TABLE, 'started_attempts')) {
+                    $table->unsignedInteger('started_attempts')->default(0);
+                }
+                if (! Schema::hasColumn(self::TABLE, 'submitted_attempts')) {
+                    $table->unsignedInteger('submitted_attempts')->default(0);
+                }
+                if (! Schema::hasColumn(self::TABLE, 'first_view_attempts')) {
+                    $table->unsignedInteger('first_view_attempts')->default(0);
+                }
+                if (! Schema::hasColumn(self::TABLE, 'order_created_attempts')) {
+                    $table->unsignedInteger('order_created_attempts')->default(0);
+                }
+                if (! Schema::hasColumn(self::TABLE, 'paid_attempts')) {
+                    $table->unsignedInteger('paid_attempts')->default(0);
+                }
+                if (! Schema::hasColumn(self::TABLE, 'paid_revenue_cents')) {
+                    $table->unsignedBigInteger('paid_revenue_cents')->default(0);
+                }
+                if (! Schema::hasColumn(self::TABLE, 'unlocked_attempts')) {
+                    $table->unsignedInteger('unlocked_attempts')->default(0);
+                }
+                if (! Schema::hasColumn(self::TABLE, 'report_ready_attempts')) {
+                    $table->unsignedInteger('report_ready_attempts')->default(0);
+                }
+                if (! Schema::hasColumn(self::TABLE, 'pdf_download_attempts')) {
+                    $table->unsignedInteger('pdf_download_attempts')->default(0);
+                }
+                if (! Schema::hasColumn(self::TABLE, 'share_generated_attempts')) {
+                    $table->unsignedInteger('share_generated_attempts')->default(0);
+                }
+                if (! Schema::hasColumn(self::TABLE, 'share_click_attempts')) {
+                    $table->unsignedInteger('share_click_attempts')->default(0);
+                }
+                if (! Schema::hasColumn(self::TABLE, 'last_refreshed_at')) {
+                    $table->timestamp('last_refreshed_at')->nullable();
+                }
+                if (! Schema::hasColumn(self::TABLE, 'created_at')) {
+                    $table->timestamp('created_at')->nullable();
+                }
+                if (! Schema::hasColumn(self::TABLE, 'updated_at')) {
+                    $table->timestamp('updated_at')->nullable();
+                }
+            });
+        }
+
+        $this->ensureUnique(
+            ['day', 'org_id', 'scale_code', 'locale'],
+            'analytics_funnel_daily_day_org_scale_locale_unique'
+        );
+        $this->ensureIndex(['org_id', 'day'], 'analytics_funnel_daily_org_day_idx');
+        $this->ensureIndex(
+            ['org_id', 'scale_code', 'locale', 'day'],
+            'analytics_funnel_daily_org_scale_locale_day_idx'
+        );
+    }
+
+    public function down(): void
+    {
+        // forward-only migration: rollback disabled to prevent data loss in production.
+        // Irreversible operation: schema/data rollback handled via forward fix migrations.
+    }
+
+    /**
+     * @param  array<int,string>  $columns
+     */
+    private function ensureUnique(array $columns, string $indexName): void
+    {
+        if (! Schema::hasTable(self::TABLE) || SchemaIndex::indexExists(self::TABLE, $indexName)) {
+            return;
+        }
+
+        Schema::table(self::TABLE, function (Blueprint $table) use ($columns, $indexName): void {
+            $table->unique($columns, $indexName);
+        });
+    }
+
+    /**
+     * @param  array<int,string>  $columns
+     */
+    private function ensureIndex(array $columns, string $indexName): void
+    {
+        if (! Schema::hasTable(self::TABLE) || SchemaIndex::indexExists(self::TABLE, $indexName)) {
+            return;
+        }
+
+        Schema::table(self::TABLE, function (Blueprint $table) use ($columns, $indexName): void {
+            $table->index($columns, $indexName);
+        });
+    }
+};

--- a/backend/docs/ops/funnel-conversion.md
+++ b/backend/docs/ops/funnel-conversion.md
@@ -1,0 +1,90 @@
+# Funnel & Conversion
+
+This page is the first aggregated commerce-growth insight surface for AIC v1. It is intentionally attempt-led, daily, and operational rather than a full BI or attribution system.
+
+## First-phase stage definitions
+
+Main funnel stages:
+
+- `test_start`
+  Source: `attempts.created_at`
+  Note: `events.test_start` stays a mirror only.
+- `test_submit_success`
+  Source priority: `attempts.submitted_at` -> successful `attempt_submissions` -> first `results` timestamp
+- `first_result_or_report_view`
+  Source: normalized `events`
+  Included aliases: `result_view`, `report_view`, and legacy report-view variants such as `report_viewed`
+- `order_created`
+  Source: earliest `orders.created_at` by `target_attempt_id`
+- `payment_success`
+  Source priority: `orders.paid_at` -> successful `payment_events` handled/processed timestamp
+- `unlock_success`
+  Source: active `benefit_grants`
+  Rule: paid order status alone does not count as unlock
+- `report_ready`
+  Source: ready/readable `report_snapshots`
+  Rule: `report_jobs` are process telemetry only and never the authority fact
+
+Trailing panels only:
+
+- `pdf_download`
+  Source: `events.report_pdf_view`
+- `share_generate`
+  Source priority: `shares`
+- `share_click`
+  Source: `events.share_click`, resolved with `share_id`
+
+## Hard facts vs approximate metrics
+
+Hard-fact stages:
+
+- `test_start`
+- `order_created`
+- `payment_success` when `orders.paid_at` exists
+- `unlock_success`
+- `report_ready`
+
+Behavioral / approximate stages:
+
+- `first_result_or_report_view`
+- `payment_success` when falling back to payment-event handled/processed time
+- trailing PDF/share metrics
+
+## Read model refresh
+
+The page reads from `analytics_funnel_daily`.
+
+Refresh command:
+
+```bash
+php artisan analytics:refresh-funnel-daily --from=2026-01-01 --to=2026-01-07
+```
+
+Supported scope flags:
+
+- `--org=*`
+- `--scale=*`
+- `--dry-run`
+
+Refresh behavior:
+
+- recompute earliest reliable stage timestamps per attempt
+- normalize them into the fixed first-phase funnel order
+- aggregate into daily rows by `day`, `org_id`, `scale_code`, and `locale`
+- store counts plus `paid_revenue_cents`
+
+## Explicitly out of scope in v1
+
+- `landing_view`
+- `paywall_view` as a main-funnel authority stage
+- channel attribution
+- region comparison as a main control surface
+- share-to-purchase attribution
+- MBTI overview / type / axis / question analytics
+- extra read models outside `analytics_funnel_daily`
+
+## Likely next extensions
+
+- richer locale / region breakouts once taxonomy stabilizes
+- separate unlock/share read models if operational demand justifies them
+- attribution and paywall analysis only after event taxonomy is unified

--- a/backend/resources/views/filament/ops/pages/funnel-conversion-page.blade.php
+++ b/backend/resources/views/filament/ops/pages/funnel-conversion-page.blade.php
@@ -1,0 +1,329 @@
+<x-filament-panels::page>
+    <div class="space-y-6">
+        <form wire:submit.prevent="applyFilters" class="rounded-2xl border border-slate-200 bg-white/95 p-5 shadow-sm">
+            <div class="grid gap-4 xl:grid-cols-[minmax(0,1fr)_minmax(0,1fr)_220px_220px_auto]">
+                <label class="space-y-2">
+                    <span class="text-xs font-semibold uppercase tracking-[0.16em] text-slate-500">From</span>
+                    <input
+                        type="date"
+                        wire:model.defer="fromDate"
+                        class="block w-full rounded-xl border-slate-300 text-sm shadow-sm"
+                    />
+                </label>
+
+                <label class="space-y-2">
+                    <span class="text-xs font-semibold uppercase tracking-[0.16em] text-slate-500">To</span>
+                    <input
+                        type="date"
+                        wire:model.defer="toDate"
+                        class="block w-full rounded-xl border-slate-300 text-sm shadow-sm"
+                    />
+                </label>
+
+                <label class="space-y-2">
+                    <span class="text-xs font-semibold uppercase tracking-[0.16em] text-slate-500">Scale</span>
+                    <select wire:model.defer="scaleCode" class="block w-full rounded-xl border-slate-300 text-sm shadow-sm">
+                        <option value="all">All scales</option>
+                        @foreach ($scaleOptions as $value => $label)
+                            <option value="{{ $value }}">{{ $label }}</option>
+                        @endforeach
+                    </select>
+                </label>
+
+                <label class="space-y-2">
+                    <span class="text-xs font-semibold uppercase tracking-[0.16em] text-slate-500">Locale</span>
+                    <select wire:model.defer="locale" class="block w-full rounded-xl border-slate-300 text-sm shadow-sm">
+                        <option value="all">All locales</option>
+                        @foreach ($localeOptions as $value => $label)
+                            <option value="{{ $value }}">{{ $label }}</option>
+                        @endforeach
+                    </select>
+                </label>
+
+                <div class="flex items-end gap-3">
+                    <x-filament::button type="submit">
+                        Apply
+                    </x-filament::button>
+
+                    <a href="/ops/attempts" class="inline-flex items-center rounded-xl border border-slate-200 px-3 py-2 text-sm font-medium text-slate-600 transition hover:border-slate-300 hover:text-slate-900">
+                        Drill into attempts
+                    </a>
+                </div>
+            </div>
+        </form>
+
+        @if ($warnings !== [])
+            <div class="space-y-3">
+                @foreach ($warnings as $warning)
+                    <div class="rounded-2xl border border-amber-200 bg-amber-50 px-4 py-3 text-sm text-amber-900">
+                        {{ $warning }}
+                    </div>
+                @endforeach
+            </div>
+        @endif
+
+        <section class="rounded-2xl border border-slate-200 bg-white/95 p-5 shadow-sm">
+            <div class="mb-4 flex items-center justify-between gap-3">
+                <div>
+                    <h2 class="text-lg font-semibold text-slate-950">KPI Cards</h2>
+                    <p class="text-sm text-slate-500">First-phase attempt-led funnel totals for the selected scope.</p>
+                </div>
+                <div class="flex flex-wrap gap-2 text-xs text-slate-500">
+                    <a href="/ops/orders" class="rounded-full border border-slate-200 px-3 py-1.5 hover:border-slate-300 hover:text-slate-900">Orders</a>
+                    <a href="/ops/payment-events" class="rounded-full border border-slate-200 px-3 py-1.5 hover:border-slate-300 hover:text-slate-900">Payment Events</a>
+                    <a href="/ops/order-lookup" class="rounded-full border border-slate-200 px-3 py-1.5 hover:border-slate-300 hover:text-slate-900">Order Lookup</a>
+                </div>
+            </div>
+
+            <div class="grid gap-4 md:grid-cols-2 xl:grid-cols-4">
+                @foreach ($kpis as $card)
+                    <article class="rounded-2xl border border-slate-200 bg-slate-50/70 p-4">
+                        <div class="text-xs font-semibold uppercase tracking-[0.16em] text-slate-500">{{ $card['label'] }}</div>
+                        <div class="mt-3 text-2xl font-semibold tracking-tight text-slate-950">
+                            @if (($card['currency'] ?? false) === true)
+                                {{ $this->formatCurrencyCents((int) $card['value']) }}
+                            @else
+                                {{ $this->formatInt((int) $card['value']) }}
+                            @endif
+                        </div>
+                        <p class="mt-2 text-sm leading-6 text-slate-600">{{ $card['description'] }}</p>
+                    </article>
+                @endforeach
+            </div>
+        </section>
+
+        <section class="rounded-2xl border border-slate-200 bg-white/95 p-5 shadow-sm">
+            <div class="mb-4">
+                <h2 class="text-lg font-semibold text-slate-950">Daily Funnel Trend</h2>
+                <p class="text-sm text-slate-500">Operational daily counts for the core commerce funnel. Bars are scaled within each metric column.</p>
+            </div>
+
+            <div class="overflow-x-auto">
+                <table class="min-w-full divide-y divide-slate-200 text-sm">
+                    <thead class="bg-slate-50 text-left text-xs font-semibold uppercase tracking-[0.14em] text-slate-500">
+                        <tr>
+                            <th class="px-3 py-3">Day</th>
+                            @foreach ($dailyTrend[0] ?? [] as $key => $value)
+                                @if (str_ends_with((string) $key, '_attempts'))
+                                    <th class="px-3 py-3">{{ $value !== null ? ($dailyTrend[0][$key . '_label'] ?? ucwords(str_replace('_', ' ', $key))) : '' }}</th>
+                                @endif
+                            @endforeach
+                        </tr>
+                    </thead>
+                    <tbody class="divide-y divide-slate-100 bg-white">
+                        @foreach ($dailyTrend as $row)
+                            <tr>
+                                <td class="px-3 py-3 font-medium text-slate-900">{{ $row['day'] }}</td>
+                                @foreach ($row as $key => $value)
+                                    @if (str_ends_with((string) $key, '_attempts'))
+                                        <td class="px-3 py-3">
+                                            <div class="flex min-w-[120px] flex-col gap-1">
+                                                <div class="flex items-center justify-between gap-3">
+                                                    <span class="font-medium text-slate-900">{{ $this->formatInt((int) $value) }}</span>
+                                                </div>
+                                                <div class="h-1.5 rounded-full bg-slate-100">
+                                                    <div
+                                                        class="h-1.5 rounded-full bg-sky-500"
+                                                        style="width: {{ $row[$key . '_pct'] ?? 0 }}%;"
+                                                    ></div>
+                                                </div>
+                                            </div>
+                                        </td>
+                                    @endif
+                                @endforeach
+                            </tr>
+                        @endforeach
+                    </tbody>
+                </table>
+            </div>
+        </section>
+
+        <section class="grid gap-6 xl:grid-cols-[minmax(0,1.45fr)_minmax(0,1fr)]">
+            <div class="rounded-2xl border border-slate-200 bg-white/95 p-5 shadow-sm">
+                <div class="mb-4">
+                    <h2 class="text-lg font-semibold text-slate-950">Step Conversion Table</h2>
+                    <p class="text-sm text-slate-500">Main funnel stages only. paywall_view and attribution-only events stay out of this authority table.</p>
+                </div>
+
+                <div class="overflow-x-auto">
+                    <table class="min-w-full divide-y divide-slate-200 text-sm">
+                        <thead class="bg-slate-50 text-left text-xs font-semibold uppercase tracking-[0.14em] text-slate-500">
+                            <tr>
+                                <th class="px-3 py-3">Stage</th>
+                                <th class="px-3 py-3">Distinct attempts</th>
+                                <th class="px-3 py-3">Previous-step conversion</th>
+                                <th class="px-3 py-3">Cumulative progression</th>
+                                <th class="px-3 py-3">Note</th>
+                            </tr>
+                        </thead>
+                        <tbody class="divide-y divide-slate-100 bg-white">
+                            @foreach ($conversionRows as $row)
+                                <tr>
+                                    <td class="px-3 py-3 font-medium text-slate-900">{{ $row['label'] }}</td>
+                                    <td class="px-3 py-3">{{ $this->formatInt((int) $row['value']) }}</td>
+                                    <td class="px-3 py-3">{{ $this->formatRate($row['previous_step_rate']) }}</td>
+                                    <td class="px-3 py-3">{{ $this->formatRate($row['cumulative_rate']) }}</td>
+                                    <td class="px-3 py-3 text-slate-600">{{ $row['note'] }}</td>
+                                </tr>
+                            @endforeach
+                        </tbody>
+                    </table>
+                </div>
+            </div>
+
+            <div class="rounded-2xl border border-slate-200 bg-white/95 p-5 shadow-sm">
+                <div class="mb-4">
+                    <h2 class="text-lg font-semibold text-slate-950">Locale Comparison</h2>
+                    <p class="text-sm text-slate-500">Compare the current date and scale scope by locale. Keep locale = All to preserve the cross-locale view.</p>
+                </div>
+
+                <div class="overflow-x-auto">
+                    <table class="min-w-full divide-y divide-slate-200 text-sm">
+                        <thead class="bg-slate-50 text-left text-xs font-semibold uppercase tracking-[0.14em] text-slate-500">
+                            <tr>
+                                <th class="px-3 py-3">Locale</th>
+                                <th class="px-3 py-3">Started</th>
+                                <th class="px-3 py-3">Submitted</th>
+                                <th class="px-3 py-3">Paid</th>
+                                <th class="px-3 py-3">Unlocked</th>
+                                <th class="px-3 py-3">Report ready</th>
+                                <th class="px-3 py-3">Submit/start</th>
+                                <th class="px-3 py-3">Paid/submit</th>
+                                <th class="px-3 py-3">Ready/unlock</th>
+                            </tr>
+                        </thead>
+                        <tbody class="divide-y divide-slate-100 bg-white">
+                            @forelse ($localeComparison as $row)
+                                <tr>
+                                    <td class="px-3 py-3 font-medium text-slate-900">{{ $row['locale'] }}</td>
+                                    <td class="px-3 py-3">{{ $this->formatInt((int) $row['started_attempts']) }}</td>
+                                    <td class="px-3 py-3">{{ $this->formatInt((int) $row['submitted_attempts']) }}</td>
+                                    <td class="px-3 py-3">{{ $this->formatInt((int) $row['paid_attempts']) }}</td>
+                                    <td class="px-3 py-3">{{ $this->formatInt((int) $row['unlocked_attempts']) }}</td>
+                                    <td class="px-3 py-3">{{ $this->formatInt((int) $row['report_ready_attempts']) }}</td>
+                                    <td class="px-3 py-3">{{ $this->formatRate($row['submit_rate']) }}</td>
+                                    <td class="px-3 py-3">{{ $this->formatRate($row['paid_rate']) }}</td>
+                                    <td class="px-3 py-3">{{ $this->formatRate($row['ready_rate']) }}</td>
+                                </tr>
+                            @empty
+                                <tr>
+                                    <td colspan="9" class="px-3 py-4 text-center text-slate-500">No locale rows for the current scope.</td>
+                                </tr>
+                            @endforelse
+                        </tbody>
+                    </table>
+                </div>
+            </div>
+        </section>
+
+        <section class="grid gap-6 xl:grid-cols-2">
+            <div class="rounded-2xl border border-slate-200 bg-white/95 p-5 shadow-sm">
+                <div class="mb-4">
+                    <h2 class="text-lg font-semibold text-slate-950">PDF Panel</h2>
+                    <p class="text-sm text-slate-500">Trailing delivery health only. PDF does not become a main-funnel authority stage in v1.</p>
+                </div>
+
+                <div class="grid gap-4 md:grid-cols-3">
+                    <article class="rounded-2xl border border-slate-200 bg-slate-50/70 p-4">
+                        <div class="text-xs font-semibold uppercase tracking-[0.16em] text-slate-500">PDF download attempts</div>
+                        <div class="mt-3 text-2xl font-semibold tracking-tight text-slate-950">{{ $this->formatInt((int) ($pdfPanel['downloads'] ?? 0)) }}</div>
+                    </article>
+                    <article class="rounded-2xl border border-slate-200 bg-slate-50/70 p-4">
+                        <div class="text-xs font-semibold uppercase tracking-[0.16em] text-slate-500">PDF readiness gap</div>
+                        <div class="mt-3 text-2xl font-semibold tracking-tight text-slate-950">{{ $this->formatInt((int) ($pdfPanel['readiness_gap'] ?? 0)) }}</div>
+                    </article>
+                    <article class="rounded-2xl border border-slate-200 bg-slate-50/70 p-4">
+                        <div class="text-xs font-semibold uppercase tracking-[0.16em] text-slate-500">Download / ready</div>
+                        <div class="mt-3 text-2xl font-semibold tracking-tight text-slate-950">{{ $this->formatRate($pdfPanel['download_rate'] ?? null) }}</div>
+                    </article>
+                </div>
+
+                <div class="mt-5 overflow-x-auto">
+                    <table class="min-w-full divide-y divide-slate-200 text-sm">
+                        <thead class="bg-slate-50 text-left text-xs font-semibold uppercase tracking-[0.14em] text-slate-500">
+                            <tr>
+                                <th class="px-3 py-3">Day</th>
+                                <th class="px-3 py-3">Report ready</th>
+                                <th class="px-3 py-3">PDF downloads</th>
+                            </tr>
+                        </thead>
+                        <tbody class="divide-y divide-slate-100 bg-white">
+                            @foreach ($pdfPanel['trend'] ?? [] as $row)
+                                <tr>
+                                    <td class="px-3 py-3 font-medium text-slate-900">{{ $row['day'] }}</td>
+                                    <td class="px-3 py-3">{{ $this->formatInt((int) $row['report_ready_attempts']) }}</td>
+                                    <td class="px-3 py-3">{{ $this->formatInt((int) $row['pdf_download_attempts']) }}</td>
+                                </tr>
+                            @endforeach
+                        </tbody>
+                    </table>
+                </div>
+            </div>
+
+            <div class="rounded-2xl border border-slate-200 bg-white/95 p-5 shadow-sm">
+                <div class="mb-4">
+                    <h2 class="text-lg font-semibold text-slate-950">Share Panel</h2>
+                    <p class="text-sm text-slate-500">Operational share health only. share-to-purchase attribution stays explicitly non-authoritative in v1.</p>
+                </div>
+
+                <div class="grid gap-4 md:grid-cols-3">
+                    <article class="rounded-2xl border border-slate-200 bg-slate-50/70 p-4">
+                        <div class="text-xs font-semibold uppercase tracking-[0.16em] text-slate-500">Share generated attempts</div>
+                        <div class="mt-3 text-2xl font-semibold tracking-tight text-slate-950">{{ $this->formatInt((int) ($sharePanel['generated'] ?? 0)) }}</div>
+                    </article>
+                    <article class="rounded-2xl border border-slate-200 bg-slate-50/70 p-4">
+                        <div class="text-xs font-semibold uppercase tracking-[0.16em] text-slate-500">Share click attempts</div>
+                        <div class="mt-3 text-2xl font-semibold tracking-tight text-slate-950">{{ $this->formatInt((int) ($sharePanel['clicks'] ?? 0)) }}</div>
+                    </article>
+                    <article class="rounded-2xl border border-slate-200 bg-slate-50/70 p-4">
+                        <div class="text-xs font-semibold uppercase tracking-[0.16em] text-slate-500">Click / generated</div>
+                        <div class="mt-3 text-2xl font-semibold tracking-tight text-slate-950">{{ $this->formatRate($sharePanel['click_rate'] ?? null) }}</div>
+                    </article>
+                </div>
+
+                <div class="mt-5 overflow-x-auto">
+                    <table class="min-w-full divide-y divide-slate-200 text-sm">
+                        <thead class="bg-slate-50 text-left text-xs font-semibold uppercase tracking-[0.14em] text-slate-500">
+                            <tr>
+                                <th class="px-3 py-3">Day</th>
+                                <th class="px-3 py-3">Share generated</th>
+                                <th class="px-3 py-3">Share clicks</th>
+                            </tr>
+                        </thead>
+                        <tbody class="divide-y divide-slate-100 bg-white">
+                            @foreach ($sharePanel['trend'] ?? [] as $row)
+                                <tr>
+                                    <td class="px-3 py-3 font-medium text-slate-900">{{ $row['day'] }}</td>
+                                    <td class="px-3 py-3">{{ $this->formatInt((int) $row['share_generated_attempts']) }}</td>
+                                    <td class="px-3 py-3">{{ $this->formatInt((int) $row['share_click_attempts']) }}</td>
+                                </tr>
+                            @endforeach
+                        </tbody>
+                    </table>
+                </div>
+            </div>
+        </section>
+
+        <section class="rounded-2xl border border-slate-200 bg-white/95 p-5 shadow-sm">
+            <div class="mb-4">
+                <h2 class="text-lg font-semibold text-slate-950">Stage Definition Note</h2>
+                <p class="text-sm text-slate-500">Keep these caveats visible: the page is operationally authoritative for the core stage chain, but not every metric here is a finance-grade truth table.</p>
+            </div>
+
+            <div class="grid gap-5 xl:grid-cols-2">
+                <div class="space-y-3 text-sm leading-6 text-slate-700">
+                    <p><strong>Hard facts in v1:</strong> <code>test_start</code> from <code>attempts.created_at</code>, <code>order_created</code> from <code>orders.created_at</code>, <code>payment_success</code> from <code>orders.paid_at</code> with a payment-event fallback, <code>unlock_success</code> from active <code>benefit_grants</code>, and <code>report_ready</code> from ready/readable <code>report_snapshots</code>.</p>
+                    <p><strong>Behavioral / approximate stages:</strong> <code>first_result_or_report_view</code> comes from normalized view events. It is intentionally a single merged stage in v1 and stays downstream of submit in the authority chain.</p>
+                    <p><strong>Explicitly non-authoritative in v1:</strong> PDF downloads, share generated, share clicks, paywall views, landing views, channel attribution, region comparisons, and any share-to-purchase revenue story.</p>
+                </div>
+
+                <ul class="space-y-2 text-sm leading-6 text-slate-700">
+                    <li><strong>Main stages:</strong> <code>test_start</code>, <code>test_submit_success</code>, <code>first_result_or_report_view</code>, <code>order_created</code>, <code>payment_success</code>, <code>unlock_success</code>, <code>report_ready</code>.</li>
+                    <li><strong>Trailing panels only:</strong> <code>pdf_download</code>, <code>share_generate</code>, <code>share_click</code>.</li>
+                    <li><strong>Why paywall_view stays out:</strong> event taxonomy and attribution around paywall exposure are still too unstable to serve as the first authority stage.</li>
+                    <li><strong>Why locale/scale only:</strong> they are the stable operating cuts today; region, channel, and attribution dimensions remain exploratory.</li>
+                </ul>
+            </div>
+        </section>
+    </div>
+</x-filament-panels::page>

--- a/backend/tests/Concerns/SeedsFunnelAnalyticsScenario.php
+++ b/backend/tests/Concerns/SeedsFunnelAnalyticsScenario.php
@@ -1,0 +1,407 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Concerns;
+
+use Carbon\CarbonImmutable;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Support\Str;
+
+trait SeedsFunnelAnalyticsScenario
+{
+    /**
+     * @return array{
+     *     day:string,
+     *     attempt_a:string,
+     *     attempt_b:string,
+     *     attempt_c:string,
+     *     share_a:string
+     * }
+     */
+    private function seedFunnelAnalyticsScenario(int $orgId): array
+    {
+        $day = CarbonImmutable::parse('2026-01-03 08:00:00');
+        $attemptA = (string) Str::uuid();
+        $attemptB = (string) Str::uuid();
+        $attemptC = (string) Str::uuid();
+        $shareA = (string) Str::uuid();
+        $orderA = 'ord_funnel_a_001';
+        $orderB = 'ord_funnel_b_001';
+
+        $this->insertAttempt($attemptA, $orgId, 'en', $day, null);
+        $this->insertAttempt($attemptB, $orgId, 'zh-CN', $day->addHours(3), null);
+        $this->insertAttempt($attemptC, $orgId, 'en', $day->addHours(4), $day->addHours(4)->addMinutes(5));
+
+        $this->insertAttemptSubmission($attemptA, $orgId, $day->addMinutes(5));
+        $this->insertResult($attemptA, $orgId, $day->addMinutes(6));
+        $this->insertResult($attemptB, $orgId, $day->addHours(3)->addMinutes(6));
+
+        $this->insertEvent($orgId, 'paywall_view', $attemptA, $day->addMinutes(7));
+        $this->insertEvent($orgId, 'report_viewed', $attemptA, $day->addMinutes(10));
+        $this->insertEvent($orgId, 'paywall_view', $attemptB, $day->addHours(3)->addMinutes(7));
+        $this->insertEvent($orgId, 'result_view', $attemptB, $day->addHours(3)->addMinutes(10));
+        $this->insertEvent($orgId, 'paywall_view', $attemptC, $day->addHours(4)->addMinutes(10));
+
+        $this->insertOrder($orderA, $attemptA, $orgId, $day->addMinutes(20), 1299, null);
+        $this->insertOrder($orderB, $attemptB, $orgId, $day->addHours(3)->addMinutes(15), 2599, $day->addHours(3)->addMinutes(20));
+
+        $this->insertPaymentEvent($orderA, $orgId, $day->addMinutes(30));
+        $this->insertBenefitGrant($attemptA, $orderA, $orgId, $day->addMinutes(35));
+
+        $this->insertReportSnapshot($attemptA, $orderA, $orgId, $day->addMinutes(40));
+        $this->insertReportSnapshot($attemptB, $orderB, $orgId, $day->addHours(3)->addMinutes(25));
+
+        $this->insertEvent($orgId, 'report_pdf_view', $attemptA, $day->addMinutes(50));
+        $this->insertShare($shareA, $attemptA, $day->addHour());
+        $this->insertEvent($orgId, 'share_click', null, $day->addHour()->addMinutes(5), $shareA);
+
+        return [
+            'day' => $day->toDateString(),
+            'attempt_a' => $attemptA,
+            'attempt_b' => $attemptB,
+            'attempt_c' => $attemptC,
+            'share_a' => $shareA,
+        ];
+    }
+
+    private function insertAttempt(
+        string $attemptId,
+        int $orgId,
+        string $locale,
+        CarbonImmutable $createdAt,
+        ?CarbonImmutable $submittedAt
+    ): void {
+        $row = [
+            'id' => $attemptId,
+            'ticket_code' => 'FMT-'.strtoupper(substr(str_replace('-', '', $attemptId), 0, 8)),
+            'anon_id' => 'anon_'.substr(str_replace('-', '', $attemptId), 0, 10),
+            'user_id' => null,
+            'org_id' => $orgId,
+            'scale_code' => 'MBTI',
+            'scale_version' => 'v0.3',
+            'question_count' => 93,
+            'answers_summary_json' => json_encode(['seed' => true], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES),
+            'client_platform' => 'web',
+            'client_version' => 'test',
+            'channel' => 'web',
+            'referrer' => '/tests/funnel',
+            'region' => $locale === 'zh-CN' ? 'CN_MAINLAND' : 'US',
+            'locale' => $locale,
+            'started_at' => $createdAt,
+            'submitted_at' => $submittedAt,
+            'created_at' => $createdAt,
+            'updated_at' => $submittedAt ?? $createdAt,
+            'pack_id' => 'MBTI',
+            'dir_version' => 'mbti_dir_2026_01',
+            'content_package_version' => 'content_2026_01',
+            'scoring_spec_version' => 'scoring_2026_01',
+            'norm_version' => 'norm_2026_01',
+            'result_json' => json_encode(['type_code' => 'INTJ'], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES),
+        ];
+
+        if (Schema::hasColumn('attempts', 'scale_code_v2')) {
+            $row['scale_code_v2'] = 'MBTI';
+        }
+
+        if (Schema::hasColumn('attempts', 'scale_uid')) {
+            $row['scale_uid'] = 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa';
+        }
+
+        DB::table('attempts')->insert($row);
+    }
+
+    private function insertAttemptSubmission(string $attemptId, int $orgId, CarbonImmutable $finishedAt): void
+    {
+        DB::table('attempt_submissions')->insert([
+            'id' => (string) Str::uuid(),
+            'org_id' => $orgId,
+            'attempt_id' => $attemptId,
+            'actor_user_id' => null,
+            'actor_anon_id' => 'actor_'.$attemptId,
+            'dedupe_key' => 'dedupe_'.$attemptId,
+            'mode' => 'async',
+            'state' => 'succeeded',
+            'error_code' => null,
+            'error_message' => null,
+            'request_payload_json' => json_encode(['attempt_id' => $attemptId], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES),
+            'response_payload_json' => json_encode(['ok' => true], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES),
+            'started_at' => $finishedAt->subMinute(),
+            'finished_at' => $finishedAt,
+            'created_at' => $finishedAt->subMinute(),
+            'updated_at' => $finishedAt,
+        ]);
+    }
+
+    private function insertResult(string $attemptId, int $orgId, CarbonImmutable $computedAt): void
+    {
+        $row = [
+            'id' => (string) Str::uuid(),
+            'attempt_id' => $attemptId,
+            'org_id' => $orgId,
+            'scale_code' => 'MBTI',
+            'scale_version' => 'v0.3',
+            'type_code' => 'INTJ',
+            'scores_json' => json_encode(['EI' => 10], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES),
+            'profile_version' => 'profile_2026_01',
+            'is_valid' => 1,
+            'computed_at' => $computedAt,
+            'created_at' => $computedAt,
+            'updated_at' => $computedAt,
+        ];
+
+        if (Schema::hasColumn('results', 'scores_pct')) {
+            $row['scores_pct'] = json_encode(['EI' => 0.75], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES);
+        }
+
+        if (Schema::hasColumn('results', 'axis_states')) {
+            $row['axis_states'] = json_encode(['EI' => 'I'], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES);
+        }
+
+        if (Schema::hasColumn('results', 'scale_code_v2')) {
+            $row['scale_code_v2'] = 'MBTI';
+        }
+
+        if (Schema::hasColumn('results', 'scale_uid')) {
+            $row['scale_uid'] = 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa';
+        }
+
+        if (Schema::hasColumn('results', 'result_json')) {
+            $row['result_json'] = json_encode(['type_code' => 'INTJ'], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES);
+        }
+
+        if (Schema::hasColumn('results', 'pack_id')) {
+            $row['pack_id'] = 'MBTI';
+        }
+
+        if (Schema::hasColumn('results', 'content_package_version')) {
+            $row['content_package_version'] = 'content_2026_01';
+        }
+
+        if (Schema::hasColumn('results', 'dir_version')) {
+            $row['dir_version'] = 'mbti_dir_2026_01';
+        }
+
+        if (Schema::hasColumn('results', 'scoring_spec_version')) {
+            $row['scoring_spec_version'] = 'scoring_2026_01';
+        }
+
+        if (Schema::hasColumn('results', 'report_engine_version')) {
+            $row['report_engine_version'] = 'report_2026_01';
+        }
+
+        DB::table('results')->insert($row);
+    }
+
+    private function insertOrder(
+        string $orderNo,
+        string $attemptId,
+        int $orgId,
+        CarbonImmutable $createdAt,
+        int $amountCents,
+        ?CarbonImmutable $paidAt
+    ): void {
+        $row = [
+            'id' => (string) Str::uuid(),
+            'order_no' => $orderNo,
+            'provider' => 'stripe',
+            'status' => $paidAt ? 'paid' : 'created',
+            'amount_cents' => $amountCents,
+            'currency' => 'USD',
+            'sku' => 'MBTI_REPORT_FULL',
+            'quantity' => 1,
+            'user_id' => null,
+            'anon_id' => 'anon_'.$attemptId,
+            'org_id' => $orgId,
+            'target_attempt_id' => $attemptId,
+            'paid_at' => $paidAt,
+            'created_at' => $createdAt,
+            'updated_at' => $paidAt ?? $createdAt,
+        ];
+
+        if (Schema::hasColumn('orders', 'scale_code_v2')) {
+            $row['scale_code_v2'] = 'MBTI';
+        }
+
+        if (Schema::hasColumn('orders', 'scale_uid')) {
+            $row['scale_uid'] = 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa';
+        }
+
+        if (Schema::hasColumn('orders', 'amount_total')) {
+            $row['amount_total'] = $amountCents;
+        }
+
+        if (Schema::hasColumn('orders', 'item_sku')) {
+            $row['item_sku'] = 'MBTI_REPORT_FULL';
+        }
+
+        if (Schema::hasColumn('orders', 'provider_order_id')) {
+            $row['provider_order_id'] = $orderNo;
+        }
+
+        DB::table('orders')->insert($row);
+    }
+
+    private function insertPaymentEvent(string $orderNo, int $orgId, CarbonImmutable $processedAt): void
+    {
+        $orderId = DB::table('orders')->where('order_no', $orderNo)->value('id');
+
+        $row = [
+            'id' => (string) Str::uuid(),
+            'org_id' => $orgId,
+            'provider' => 'stripe',
+            'provider_event_id' => 'evt_'.Str::lower(Str::random(12)),
+            'order_id' => $orderId,
+            'order_no' => $orderNo,
+            'event_type' => 'payment_succeeded',
+            'payload_json' => json_encode(['order_no' => $orderNo], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES),
+            'received_at' => $processedAt->subMinute(),
+            'created_at' => $processedAt->subMinute(),
+            'updated_at' => $processedAt,
+            'status' => 'paid',
+            'handle_status' => 'processed',
+            'processed_at' => $processedAt,
+        ];
+
+        if (Schema::hasColumn('payment_events', 'handled_at')) {
+            $row['handled_at'] = $processedAt;
+        }
+
+        if (Schema::hasColumn('payment_events', 'signature_ok')) {
+            $row['signature_ok'] = 1;
+        }
+
+        if (Schema::hasColumn('payment_events', 'reason')) {
+            $row['reason'] = 'paid';
+        }
+
+        if (Schema::hasColumn('payment_events', 'order_id')) {
+            $row['order_id'] = $orderId;
+        }
+
+        DB::table('payment_events')->insert($row);
+    }
+
+    private function insertBenefitGrant(string $attemptId, string $orderNo, int $orgId, CarbonImmutable $createdAt): void
+    {
+        $row = [
+            'id' => (string) Str::uuid(),
+            'org_id' => $orgId,
+            'user_id' => null,
+            'benefit_code' => 'MBTI_REPORT_FULL',
+            'scope' => 'attempt',
+            'attempt_id' => $attemptId,
+            'status' => 'active',
+            'benefit_type' => 'report',
+            'benefit_ref' => 'full',
+            'order_no' => $orderNo,
+            'source_order_id' => DB::table('orders')->where('order_no', $orderNo)->value('id'),
+            'source_event_id' => null,
+            'created_at' => $createdAt,
+            'updated_at' => $createdAt,
+        ];
+
+        DB::table('benefit_grants')->insert($row);
+    }
+
+    private function insertReportSnapshot(string $attemptId, string $orderNo, int $orgId, CarbonImmutable $updatedAt): void
+    {
+        $row = [
+            'org_id' => $orgId,
+            'attempt_id' => $attemptId,
+            'order_no' => $orderNo,
+            'scale_code' => 'MBTI',
+            'pack_id' => 'MBTI',
+            'dir_version' => 'mbti_dir_2026_01',
+            'scoring_spec_version' => 'scoring_2026_01',
+            'report_engine_version' => 'report_2026_01',
+            'snapshot_version' => 'v1',
+            'report_json' => json_encode(['summary' => 'ready'], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES),
+            'status' => 'ready',
+            'created_at' => $updatedAt->subMinutes(2),
+            'updated_at' => $updatedAt,
+        ];
+
+        if (Schema::hasColumn('report_snapshots', 'scale_code_v2')) {
+            $row['scale_code_v2'] = 'MBTI';
+        }
+
+        if (Schema::hasColumn('report_snapshots', 'scale_uid')) {
+            $row['scale_uid'] = 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa';
+        }
+
+        if (Schema::hasColumn('report_snapshots', 'report_free_json')) {
+            $row['report_free_json'] = json_encode(['summary' => 'free'], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES);
+        }
+
+        if (Schema::hasColumn('report_snapshots', 'report_full_json')) {
+            $row['report_full_json'] = json_encode(['summary' => 'full'], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES);
+        }
+
+        DB::table('report_snapshots')->insert($row);
+    }
+
+    private function insertShare(string $shareId, string $attemptId, CarbonImmutable $createdAt): void
+    {
+        $row = [
+            'id' => $shareId,
+            'attempt_id' => $attemptId,
+            'anon_id' => 'anon_'.$attemptId,
+            'scale_code' => 'MBTI',
+            'scale_version' => 'v0.3',
+            'content_package_version' => 'content_2026_01',
+            'created_at' => $createdAt,
+            'updated_at' => $createdAt,
+        ];
+
+        if (Schema::hasColumn('shares', 'scale_code_v2')) {
+            $row['scale_code_v2'] = 'MBTI';
+        }
+
+        if (Schema::hasColumn('shares', 'scale_uid')) {
+            $row['scale_uid'] = 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa';
+        }
+
+        DB::table('shares')->insert($row);
+    }
+
+    private function insertEvent(
+        int $orgId,
+        string $eventCode,
+        ?string $attemptId,
+        CarbonImmutable $occurredAt,
+        ?string $shareId = null
+    ): void {
+        $row = [
+            'id' => (string) Str::uuid(),
+            'event_code' => $eventCode,
+            'event_name' => $eventCode,
+            'org_id' => $orgId,
+            'user_id' => null,
+            'anon_id' => $attemptId ? 'anon_'.$attemptId : null,
+            'session_id' => 'session_'.substr(str_replace('-', '', (string) Str::uuid()), 0, 8),
+            'request_id' => 'req_'.substr(str_replace('-', '', (string) Str::uuid()), 0, 12),
+            'attempt_id' => $attemptId,
+            'meta_json' => json_encode(['attempt_id' => $attemptId, 'share_id' => $shareId], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES),
+            'occurred_at' => $occurredAt,
+            'share_id' => $shareId,
+            'created_at' => $occurredAt,
+            'updated_at' => $occurredAt,
+            'scale_code' => 'MBTI',
+            'channel' => 'web',
+            'region' => 'US',
+            'locale' => 'en',
+        ];
+
+        if (Schema::hasColumn('events', 'scale_code_v2')) {
+            $row['scale_code_v2'] = 'MBTI';
+        }
+
+        if (Schema::hasColumn('events', 'scale_uid')) {
+            $row['scale_uid'] = 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa';
+        }
+
+        DB::table('events')->insert($row);
+    }
+}

--- a/backend/tests/Feature/Analytics/AnalyticsFunnelDailyBuilderTest.php
+++ b/backend/tests/Feature/Analytics/AnalyticsFunnelDailyBuilderTest.php
@@ -1,0 +1,89 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Analytics;
+
+use App\Services\Analytics\AnalyticsFunnelDailyBuilder;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\Concerns\SeedsFunnelAnalyticsScenario;
+use Tests\TestCase;
+
+final class AnalyticsFunnelDailyBuilderTest extends TestCase
+{
+    use RefreshDatabase;
+    use SeedsFunnelAnalyticsScenario;
+
+    public function test_builder_builds_attempt_led_rows_with_stage_fallbacks_and_trailing_metrics(): void
+    {
+        $scenario = $this->seedFunnelAnalyticsScenario(77);
+
+        $payload = app(AnalyticsFunnelDailyBuilder::class)->build(
+            new \DateTimeImmutable($scenario['day']),
+            new \DateTimeImmutable($scenario['day']),
+            [77],
+        );
+
+        $this->assertSame(2, (int) ($payload['attempted_rows'] ?? 0));
+
+        $rowsByLocale = collect($payload['rows'])->keyBy('locale');
+
+        $en = $rowsByLocale->get('en');
+        $zh = $rowsByLocale->get('zh-CN');
+
+        $this->assertNotNull($en);
+        $this->assertNotNull($zh);
+
+        $this->assertSame(2, (int) ($en['started_attempts'] ?? 0));
+        $this->assertSame(2, (int) ($en['submitted_attempts'] ?? 0));
+        $this->assertSame(1, (int) ($en['first_view_attempts'] ?? 0));
+        $this->assertSame(1, (int) ($en['order_created_attempts'] ?? 0));
+        $this->assertSame(1, (int) ($en['paid_attempts'] ?? 0));
+        $this->assertSame(1299, (int) ($en['paid_revenue_cents'] ?? 0));
+        $this->assertSame(1, (int) ($en['unlocked_attempts'] ?? 0));
+        $this->assertSame(1, (int) ($en['report_ready_attempts'] ?? 0));
+        $this->assertSame(1, (int) ($en['pdf_download_attempts'] ?? 0));
+        $this->assertSame(1, (int) ($en['share_generated_attempts'] ?? 0));
+        $this->assertSame(1, (int) ($en['share_click_attempts'] ?? 0));
+
+        $this->assertSame(1, (int) ($zh['started_attempts'] ?? 0));
+        $this->assertSame(1, (int) ($zh['submitted_attempts'] ?? 0));
+        $this->assertSame(1, (int) ($zh['first_view_attempts'] ?? 0));
+        $this->assertSame(1, (int) ($zh['order_created_attempts'] ?? 0));
+        $this->assertSame(1, (int) ($zh['paid_attempts'] ?? 0));
+        $this->assertSame(2599, (int) ($zh['paid_revenue_cents'] ?? 0));
+        $this->assertSame(0, (int) ($zh['unlocked_attempts'] ?? 0));
+        $this->assertSame(0, (int) ($zh['report_ready_attempts'] ?? 0));
+    }
+
+    public function test_builder_excludes_paywall_view_from_main_funnel_and_requires_active_grant_for_unlock(): void
+    {
+        $scenario = $this->seedFunnelAnalyticsScenario(88);
+
+        $payload = app(AnalyticsFunnelDailyBuilder::class)->build(
+            new \DateTimeImmutable($scenario['day']),
+            new \DateTimeImmutable($scenario['day']),
+            [88],
+        );
+
+        $totals = collect($payload['rows'])->reduce(function (array $carry, array $row): array {
+            foreach ([
+                'started_attempts',
+                'submitted_attempts',
+                'first_view_attempts',
+                'paid_attempts',
+                'unlocked_attempts',
+            ] as $metric) {
+                $carry[$metric] = (int) ($carry[$metric] ?? 0) + (int) ($row[$metric] ?? 0);
+            }
+
+            return $carry;
+        }, []);
+
+        $this->assertSame(3, (int) ($totals['started_attempts'] ?? 0));
+        $this->assertSame(3, (int) ($totals['submitted_attempts'] ?? 0));
+        $this->assertSame(2, (int) ($totals['first_view_attempts'] ?? 0), 'paywall_view must stay outside the main view stage');
+        $this->assertSame(2, (int) ($totals['paid_attempts'] ?? 0));
+        $this->assertSame(1, (int) ($totals['unlocked_attempts'] ?? 0), 'unlock_success must depend on active grants, not paid order status');
+    }
+}

--- a/backend/tests/Feature/Analytics/RefreshAnalyticsFunnelDailyCommandTest.php
+++ b/backend/tests/Feature/Analytics/RefreshAnalyticsFunnelDailyCommandTest.php
@@ -1,0 +1,56 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Analytics;
+
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\DB;
+use Tests\Concerns\SeedsFunnelAnalyticsScenario;
+use Tests\TestCase;
+
+final class RefreshAnalyticsFunnelDailyCommandTest extends TestCase
+{
+    use RefreshDatabase;
+    use SeedsFunnelAnalyticsScenario;
+
+    public function test_command_supports_dry_run_and_upserts_refresh_scope(): void
+    {
+        $scenario = $this->seedFunnelAnalyticsScenario(91);
+
+        $this->artisan('analytics:refresh-funnel-daily', [
+            '--from' => $scenario['day'],
+            '--to' => $scenario['day'],
+            '--org' => [91],
+            '--dry-run' => true,
+        ])
+            ->expectsOutputToContain('dry_run=1')
+            ->expectsOutputToContain('attempted_rows=2')
+            ->assertExitCode(0);
+
+        $this->assertSame(0, DB::table('analytics_funnel_daily')->count());
+
+        $this->artisan('analytics:refresh-funnel-daily', [
+            '--from' => $scenario['day'],
+            '--to' => $scenario['day'],
+            '--org' => [91],
+        ])
+            ->expectsOutputToContain('dry_run=0')
+            ->expectsOutputToContain('upserted_rows=2')
+            ->assertExitCode(0);
+
+        $this->assertSame(2, DB::table('analytics_funnel_daily')->count());
+
+        $this->artisan('analytics:refresh-funnel-daily', [
+            '--from' => $scenario['day'],
+            '--to' => $scenario['day'],
+            '--org' => [91],
+        ])->assertExitCode(0);
+
+        $this->assertSame(2, DB::table('analytics_funnel_daily')->count());
+        $this->assertSame(
+            3898,
+            (int) DB::table('analytics_funnel_daily')->where('org_id', 91)->sum('paid_revenue_cents')
+        );
+    }
+}

--- a/backend/tests/Feature/Ops/FunnelConversionPageTest.php
+++ b/backend/tests/Feature/Ops/FunnelConversionPageTest.php
@@ -1,0 +1,126 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Ops;
+
+use App\Models\AdminUser;
+use App\Models\Organization;
+use App\Models\Permission;
+use App\Models\Role;
+use App\Services\Analytics\AnalyticsFunnelDailyBuilder;
+use App\Support\Rbac\PermissionNames;
+use Filament\Facades\Filament;
+use Filament\PanelRegistry;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Carbon;
+use Illuminate\Support\Str;
+use Tests\Concerns\SeedsFunnelAnalyticsScenario;
+use Tests\TestCase;
+
+final class FunnelConversionPageTest extends TestCase
+{
+    use RefreshDatabase;
+    use SeedsFunnelAnalyticsScenario;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        Filament::setCurrentPanel(app(PanelRegistry::class)->get('ops'));
+    }
+
+    public function test_funnel_conversion_page_is_accessible_and_renders_primary_sections(): void
+    {
+        $admin = $this->createAdminWithPermissions([
+            PermissionNames::ADMIN_MENU_COMMERCE,
+            PermissionNames::ADMIN_OPS_READ,
+        ]);
+        $selectedOrg = $this->createOrganization('Funnel Selected Org');
+        $scenario = $this->seedFunnelAnalyticsScenario((int) $selectedOrg->id);
+
+        Carbon::setTestNow($scenario['day'].' 12:00:00');
+
+        try {
+            app(AnalyticsFunnelDailyBuilder::class)->refresh(
+                new \DateTimeImmutable($scenario['day']),
+                new \DateTimeImmutable($scenario['day']),
+                [(int) $selectedOrg->id],
+            );
+
+            $this->withSession($this->opsSession($admin, $selectedOrg))
+                ->actingAs($admin, (string) config('admin.guard', 'admin'))
+                ->get('/ops/funnel-conversion')
+                ->assertOk()
+                ->assertSee('Funnel & Conversion')
+                ->assertSee('KPI Cards')
+                ->assertSee('Started attempts')
+                ->assertSee('Daily Funnel Trend')
+                ->assertSee('Step Conversion Table')
+                ->assertSee('Locale Comparison')
+                ->assertSee('PDF Panel')
+                ->assertSee('Share Panel')
+                ->assertSee('Stage Definition Note')
+                ->assertSee('test_submit_success')
+                ->assertSee('first_result_or_report_view')
+                ->assertSee('unlock_success')
+                ->assertSee('$38.98');
+        } finally {
+            Carbon::setTestNow();
+        }
+    }
+
+    private function createOrganization(string $name): Organization
+    {
+        return Organization::query()->create([
+            'name' => $name,
+            'owner_user_id' => random_int(1000, 9999),
+            'status' => 'active',
+            'domain' => Str::slug($name).'.example.test',
+            'timezone' => 'Asia/Shanghai',
+            'locale' => 'en',
+        ]);
+    }
+
+    /**
+     * @param  list<string>  $permissions
+     */
+    private function createAdminWithPermissions(array $permissions): AdminUser
+    {
+        $admin = AdminUser::query()->create([
+            'name' => 'ops_'.Str::lower(Str::random(6)),
+            'email' => 'ops_'.Str::lower(Str::random(6)).'@example.test',
+            'password' => bcrypt('secret'),
+            'is_active' => 1,
+        ]);
+
+        $role = Role::query()->create([
+            'name' => 'role_'.Str::lower(Str::random(8)),
+            'description' => null,
+        ]);
+
+        foreach ($permissions as $permissionName) {
+            $permission = Permission::query()->firstOrCreate(
+                ['name' => $permissionName],
+                ['description' => null],
+            );
+
+            $role->permissions()->syncWithoutDetaching([$permission->id]);
+        }
+
+        $admin->roles()->syncWithoutDetaching([$role->id]);
+
+        return $admin;
+    }
+
+    /**
+     * @return array{ops_org_id:int,ops_admin_totp_verified_user_id:int}
+     */
+    private function opsSession(AdminUser $admin, Organization $selectedOrg): array
+    {
+        return [
+            'ops_org_id' => (int) $selectedOrg->id,
+            'ops_admin_totp_verified_user_id' => (int) $admin->id,
+        ];
+    }
+}


### PR DESCRIPTION
Summary
- add Funnel & Conversion as the first aggregated commerce-growth insights page
- normalize the first-phase assessment funnel around attempt-led business facts with event-level behavior signals

What changed
- add a first-phase analytics_funnel_daily read model
- add a refresh path for funnel aggregation
- add a custom Funnel & Conversion page in Filament Ops
- show KPI cards, daily funnel trends, step conversion tables, locale comparison, and trailing PDF/share panels
- document the first-phase stage definitions and non-authoritative metrics

Design choices
- use attempts as the primary funnel axis and supplement with events
- keep business facts authoritative for order/paid/unlock/report-ready stages
- defer channel attribution, paywall-view authority, and share-to-purchase attribution
- keep the page under Commerce for now, without broad navigation refactors
- keep first-phase filters focused on date range, scale, and locale

Why this PR is small and safe
- no frontend changes
- no API changes
- no Node/runtime changes
- no write-side behavior changes
- only the first aggregated Funnel & Conversion surface for AIC

Validation
- php artisan about
- php artisan route:list --path=ops --except-vendor
- php artisan migrate
- php artisan analytics:refresh-funnel-daily --from=2026-01-01 --to=2026-01-07
- php artisan test --filter='(AnalyticsFunnel|FunnelConversion)'
- php artisan filament:assets
- npm run build
- bash backend/scripts/ci_verify_mbti.sh
