### PR TITLE
feat(assessment-ops): add Results Explorer for support diagnostics

### DIFF
--- a/backend/app/Filament/Ops/Resources/ResultResource.php
+++ b/backend/app/Filament/Ops/Resources/ResultResource.php
@@ -1,0 +1,269 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Filament\Ops\Resources;
+
+use App\Filament\Ops\Resources\ResultResource\Pages;
+use App\Filament\Ops\Resources\ResultResource\Support\ResultExplorerSupport;
+use App\Models\Result;
+use App\Support\Rbac\PermissionNames;
+use Filament\Forms;
+use Filament\Forms\Form;
+use Filament\Resources\Resource;
+use Filament\Tables;
+use Filament\Tables\Enums\FiltersLayout;
+use Filament\Tables\Table;
+use Illuminate\Database\Eloquent\Builder;
+
+class ResultResource extends Resource
+{
+    protected static ?string $model = Result::class;
+
+    protected static ?string $navigationIcon = 'heroicon-o-clipboard-document-list';
+
+    protected static ?string $navigationGroup = 'Support';
+
+    protected static ?string $navigationLabel = 'Results Explorer';
+
+    protected static ?int $navigationSort = 9;
+
+    public static function getNavigationGroup(): ?string
+    {
+        return __('ops.group.support');
+    }
+
+    public static function getNavigationLabel(): string
+    {
+        return 'Results Explorer';
+    }
+
+    public static function form(Form $form): Form
+    {
+        return $form->schema([]);
+    }
+
+    public static function canViewAny(): bool
+    {
+        return self::canSupportAccess();
+    }
+
+    public static function canView($record): bool
+    {
+        return self::canSupportAccess();
+    }
+
+    public static function canCreate(): bool
+    {
+        return false;
+    }
+
+    public static function canEdit($record): bool
+    {
+        return false;
+    }
+
+    public static function canDelete($record): bool
+    {
+        return false;
+    }
+
+    public static function table(Table $table): Table
+    {
+        $support = app(ResultExplorerSupport::class);
+
+        return $table
+            ->searchPlaceholder('attempt_id / result_id / order_no / share_id / type_code / scale_code')
+            ->searchDebounce('600ms')
+            ->recordUrl(fn (Result $record): string => static::getUrl('view', ['record' => $record]))
+            ->columns([
+                Tables\Columns\TextColumn::make('attempt_id')
+                    ->label('attempt_id')
+                    ->copyable()
+                    ->searchable(query: function (Builder $query, string $search) use ($support): void {
+                        $support->applySearch($query, $search);
+                    })
+                    ->sortable(),
+                Tables\Columns\TextColumn::make('scale_code')
+                    ->sortable(),
+                Tables\Columns\TextColumn::make('type_code')
+                    ->sortable(),
+                Tables\Columns\TextColumn::make('computed_at')
+                    ->dateTime()
+                    ->sortable(),
+                Tables\Columns\TextColumn::make('result_status')
+                    ->label('result_status')
+                    ->state(fn (Result $record): string => $support->resultStatus($record)['label'])
+                    ->badge()
+                    ->color(fn (Result $record): string => $support->resultStatus($record)['state']),
+                Tables\Columns\TextColumn::make('latest_snapshot_status')
+                    ->label('snapshot_status')
+                    ->state(fn (Result $record): string => $support->snapshotStatus($record)['label'])
+                    ->badge()
+                    ->color(fn (Result $record): string => $support->snapshotStatus($record)['state']),
+                Tables\Columns\TextColumn::make('unlock_status')
+                    ->label('unlock_status')
+                    ->state(fn (Result $record): string => $support->unlockStatus($record)['label'])
+                    ->badge()
+                    ->color(fn (Result $record): string => $support->unlockStatus($record)['state']),
+                Tables\Columns\TextColumn::make('attempt_locale')
+                    ->label('locale')
+                    ->state(fn (Result $record): string => $support->attemptLocale($record))
+                    ->sortable(query: fn (Builder $query, string $direction): Builder => $query->orderBy('attempt_locale', $direction)),
+                Tables\Columns\TextColumn::make('attempt_region')
+                    ->label('region')
+                    ->state(fn (Result $record): string => $support->attemptRegion($record))
+                    ->toggleable(isToggledHiddenByDefault: true),
+                Tables\Columns\TextColumn::make('latest_order_no')
+                    ->label('order_no')
+                    ->copyable()
+                    ->toggleable(isToggledHiddenByDefault: true),
+                Tables\Columns\TextColumn::make('latest_share_id')
+                    ->label('share_id')
+                    ->copyable()
+                    ->toggleable(isToggledHiddenByDefault: true),
+                Tables\Columns\TextColumn::make('content_package_version')
+                    ->toggleable(isToggledHiddenByDefault: true),
+                Tables\Columns\TextColumn::make('scoring_spec_version')
+                    ->toggleable(isToggledHiddenByDefault: true),
+                Tables\Columns\TextColumn::make('attempt_norm_version')
+                    ->label('norm_version')
+                    ->toggleable(isToggledHiddenByDefault: true),
+                Tables\Columns\TextColumn::make('report_engine_version')
+                    ->state(fn (Result $record): string => $support->reportEngineVersion($record))
+                    ->toggleable(isToggledHiddenByDefault: true),
+                Tables\Columns\TextColumn::make('id')
+                    ->label('result_id')
+                    ->copyable()
+                    ->toggleable(isToggledHiddenByDefault: true),
+                Tables\Columns\TextColumn::make('score_summary')
+                    ->state(fn (Result $record): string => $support->scoreSummary($record))
+                    ->toggleable(isToggledHiddenByDefault: true),
+                Tables\Columns\TextColumn::make('axis_summary')
+                    ->state(fn (Result $record): string => $support->axisSummary($record))
+                    ->toggleable(isToggledHiddenByDefault: true),
+                Tables\Columns\TextColumn::make('diagnostic_status')
+                    ->state(fn (Result $record): string => $support->diagnosticStatus($record)['label'])
+                    ->badge()
+                    ->color(fn (Result $record): string => $support->diagnosticStatus($record)['state'])
+                    ->toggleable(isToggledHiddenByDefault: true),
+                Tables\Columns\TextColumn::make('org_id')
+                    ->sortable()
+                    ->toggleable(isToggledHiddenByDefault: true),
+                Tables\Columns\TextColumn::make('scale_uid')
+                    ->toggleable(isToggledHiddenByDefault: true),
+            ])
+            ->defaultSort('computed_at', 'desc')
+            ->filters([
+                Tables\Filters\Filter::make('computed_window')
+                    ->label('Date')
+                    ->form([
+                        Forms\Components\DatePicker::make('from')->label('from'),
+                        Forms\Components\DatePicker::make('until')->label('until'),
+                    ])
+                    ->query(function (Builder $query, array $data): void {
+                        $from = trim((string) ($data['from'] ?? ''));
+                        $until = trim((string) ($data['until'] ?? ''));
+
+                        if ($from !== '') {
+                            $query->whereRaw('date(coalesce(results.computed_at, results.created_at)) >= ?', [$from]);
+                        }
+
+                        if ($until !== '') {
+                            $query->whereRaw('date(coalesce(results.computed_at, results.created_at)) <= ?', [$until]);
+                        }
+                    }),
+                Tables\Filters\SelectFilter::make('scale_code')
+                    ->options(fn (): array => $support->distinctResultOptions('scale_code')),
+                Tables\Filters\SelectFilter::make('type_code')
+                    ->options(fn (): array => $support->distinctResultOptions('type_code')),
+                Tables\Filters\SelectFilter::make('locale')
+                    ->options(fn (): array => $support->distinctAttemptOptions('locale'))
+                    ->query(function (Builder $query, array $data) use ($support): void {
+                        $support->applyAttemptFieldFilter($query, 'locale', $data['value'] ?? null);
+                    }),
+                Tables\Filters\SelectFilter::make('region')
+                    ->options(fn (): array => $support->distinctAttemptOptions('region'))
+                    ->query(function (Builder $query, array $data) use ($support): void {
+                        $support->applyAttemptFieldFilter($query, 'region', $data['value'] ?? null);
+                    }),
+                Tables\Filters\SelectFilter::make('snapshot_status')
+                    ->options(fn (): array => $support->distinctSnapshotStatusOptions())
+                    ->query(function (Builder $query, array $data) use ($support): void {
+                        $support->applySnapshotStatusFilter($query, $data['value'] ?? null);
+                    }),
+                Tables\Filters\SelectFilter::make('unlock_status')
+                    ->label('Unlock / commerce')
+                    ->options([
+                        'unlocked' => 'unlocked',
+                        'paid_pending' => 'paid_pending',
+                        'payment_pending' => 'payment_pending',
+                        'refunded' => 'refunded',
+                        'no_order' => 'no_order',
+                    ])
+                    ->query(function (Builder $query, array $data) use ($support): void {
+                        $support->applyUnlockStatusFilter($query, $data['value'] ?? null);
+                    }),
+                Tables\Filters\TernaryFilter::make('is_valid')
+                    ->label('Valid')
+                    ->queries(
+                        true: fn (Builder $query): Builder => $query->where('results.is_valid', true),
+                        false: fn (Builder $query): Builder => $query->where('results.is_valid', false),
+                        blank: fn (Builder $query): Builder => $query,
+                    ),
+                Tables\Filters\SelectFilter::make('content_package_version')
+                    ->options(fn (): array => $support->distinctResultOptions('content_package_version')),
+                Tables\Filters\SelectFilter::make('scoring_spec_version')
+                    ->options(fn (): array => $support->distinctResultOptions('scoring_spec_version')),
+                Tables\Filters\SelectFilter::make('norm_version')
+                    ->options(fn (): array => $support->distinctAttemptOptions('norm_version'))
+                    ->query(function (Builder $query, array $data) use ($support): void {
+                        $support->applyAttemptFieldFilter($query, 'norm_version', $data['value'] ?? null);
+                    }),
+                Tables\Filters\SelectFilter::make('report_engine_version')
+                    ->options(fn (): array => $support->distinctReportEngineVersionOptions())
+                    ->query(function (Builder $query, array $data) use ($support): void {
+                        $support->applyReportEngineVersionFilter($query, $data['value'] ?? null);
+                    }),
+                Tables\Filters\SelectFilter::make('diagnostic_status')
+                    ->label('Diagnostic')
+                    ->options($support->diagnosticOptions())
+                    ->query(function (Builder $query, array $data) use ($support): void {
+                        $support->applyDiagnosticStatusFilter($query, $data['value'] ?? null);
+                    }),
+            ])
+            ->filtersLayout(FiltersLayout::AboveContentCollapsible)
+            ->filtersFormColumns(4)
+            ->actions([
+                Tables\Actions\ViewAction::make(),
+            ])
+            ->bulkActions([]);
+    }
+
+    public static function getPages(): array
+    {
+        return [
+            'index' => Pages\ListResults::route('/'),
+            'view' => Pages\ViewResult::route('/{record}'),
+        ];
+    }
+
+    public static function getEloquentQuery(): Builder
+    {
+        return app(ResultExplorerSupport::class)->query();
+    }
+
+    private static function canSupportAccess(): bool
+    {
+        $guard = (string) config('admin.guard', 'admin');
+        $user = auth($guard)->user();
+
+        return is_object($user)
+            && method_exists($user, 'hasPermission')
+            && (
+                $user->hasPermission(PermissionNames::ADMIN_MENU_SUPPORT)
+                || $user->hasPermission(PermissionNames::ADMIN_OPS_READ)
+                || $user->hasPermission(PermissionNames::ADMIN_OWNER)
+            );
+    }
+}

--- a/backend/app/Filament/Ops/Resources/ResultResource/Pages/ListResults.php
+++ b/backend/app/Filament/Ops/Resources/ResultResource/Pages/ListResults.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Filament\Ops\Resources\ResultResource\Pages;
+
+use App\Filament\Ops\Resources\Pages\Concerns\HasSharedListEmptyState;
+use App\Filament\Ops\Resources\ResultResource;
+use Filament\Resources\Pages\ListRecords;
+
+class ListResults extends ListRecords
+{
+    use HasSharedListEmptyState;
+
+    protected static string $resource = ResultResource::class;
+
+    public function getTitle(): string
+    {
+        return 'Results Explorer';
+    }
+
+    protected function getHeaderActions(): array
+    {
+        return [];
+    }
+}

--- a/backend/app/Filament/Ops/Resources/ResultResource/Pages/ViewResult.php
+++ b/backend/app/Filament/Ops/Resources/ResultResource/Pages/ViewResult.php
@@ -1,0 +1,138 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Filament\Ops\Resources\ResultResource\Pages;
+
+use App\Filament\Ops\Resources\ResultResource;
+use App\Filament\Ops\Resources\ResultResource\Support\ResultExplorerSupport;
+use App\Models\Result;
+use Filament\Resources\Pages\Page;
+
+class ViewResult extends Page
+{
+    protected static string $resource = ResultResource::class;
+
+    protected static string $view = 'filament.ops.resources.results.view-result';
+
+    protected ?Result $recordModel = null;
+
+    /**
+     * @var array<string, array{label:string,state:string}>
+     */
+    public array $headline = [];
+
+    /**
+     * @var array{fields:list<array{label:string,value:string,hint:?string,kind:string,state:?string}>,notes:list<string>}
+     */
+    public array $resultSummary = ['fields' => [], 'notes' => []];
+
+    /**
+     * @var array{fields:list<array{label:string,value:string,hint:?string,kind:string,state:?string}>,notes:list<string>}
+     */
+    public array $scoreAxisSummary = ['fields' => [], 'notes' => []];
+
+    /**
+     * @var array{fields:list<array{label:string,value:string,hint:?string,kind:string,state:?string}>,notes:list<string>}
+     */
+    public array $versionSummary = ['fields' => [], 'notes' => []];
+
+    /**
+     * @var array{fields:list<array{label:string,value:string,hint:?string,kind:string,state:?string}>,notes:list<string>}
+     */
+    public array $reportSummary = ['fields' => [], 'notes' => []];
+
+    /**
+     * @var array{fields:list<array{label:string,value:string,hint:?string,kind:string,state:?string}>,notes:list<string>}
+     */
+    public array $attemptSummary = ['fields' => [], 'notes' => []];
+
+    /**
+     * @var array{fields:list<array{label:string,value:string,hint:?string,kind:string,state:?string}>,notes:list<string>}
+     */
+    public array $commerceSummary = ['fields' => [], 'notes' => []];
+
+    /**
+     * @var array{
+     *     fields:list<array{label:string,value:string,hint:?string,kind:string,state:?string}>,
+     *     notes:list<string>,
+     *     events:list<array{title:string,occurred_at:string,meta:list<string>,share_id:string,channel:string}>
+     * }
+     */
+    public array $shareSummary = ['fields' => [], 'notes' => [], 'events' => []];
+
+    /**
+     * @var list<array{label:string,url:string,kind:string}>
+     */
+    public array $links = [];
+
+    public function mount(int|string $record): void
+    {
+        abort_unless(ResultResource::canViewAny(), 403);
+
+        /** @var Result $resolved */
+        $resolved = ResultResource::getEloquentQuery()->whereKey($record)->firstOrFail();
+
+        abort_unless(ResultResource::canView($resolved), 403);
+
+        $this->recordModel = $resolved;
+
+        $detail = app(ResultExplorerSupport::class)->buildDetail($this->getRecord());
+
+        $this->headline = $detail['headline'];
+        $this->resultSummary = $detail['result_summary'];
+        $this->scoreAxisSummary = $detail['score_axis_summary'];
+        $this->versionSummary = $detail['version_summary'];
+        $this->reportSummary = $detail['report_summary'];
+        $this->attemptSummary = $detail['attempt_summary'];
+        $this->commerceSummary = $detail['commerce_summary'];
+        $this->shareSummary = $detail['share_summary'];
+        $this->links = $detail['links'];
+    }
+
+    public static function canAccess(array $parameters = []): bool
+    {
+        return ResultResource::canViewAny();
+    }
+
+    public function getRecord(): Result
+    {
+        return $this->recordModel ?? throw new \LogicException('Result record has not been resolved.');
+    }
+
+    public function getTitle(): string
+    {
+        return 'Results Explorer';
+    }
+
+    public function getHeading(): string
+    {
+        return 'Results Explorer';
+    }
+
+    public function getSubheading(): ?string
+    {
+        return 'Read-only support diagnostics rooted on results.';
+    }
+
+    public function getBreadcrumb(): string
+    {
+        return (string) $this->getRecord()->getKey();
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    public function getBreadcrumbs(): array
+    {
+        return [
+            ResultResource::getUrl() => ResultResource::getBreadcrumb(),
+            $this->getBreadcrumb(),
+        ];
+    }
+
+    protected function getHeaderActions(): array
+    {
+        return [];
+    }
+}

--- a/backend/app/Filament/Ops/Resources/ResultResource/Support/ResultExplorerSupport.php
+++ b/backend/app/Filament/Ops/Resources/ResultResource/Support/ResultExplorerSupport.php
@@ -1,0 +1,1505 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Filament\Ops\Resources\ResultResource\Support;
+
+use App\Filament\Ops\Resources\AttemptResource;
+use App\Filament\Ops\Resources\OrderResource;
+use App\Filament\Ops\Support\StatusBadge;
+use App\Models\Result;
+use App\Support\SchemaBaseline;
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Query\Builder as QueryBuilder;
+use Illuminate\Support\Carbon;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Str;
+
+final class ResultExplorerSupport
+{
+    /**
+     * @return Builder<Result>
+     */
+    public function query(): Builder
+    {
+        $query = Result::query()
+            ->withoutGlobalScopes()
+            ->select('results.*')
+            ->selectRaw('coalesce(results.computed_at, results.updated_at, results.created_at) as activity_at');
+
+        if (SchemaBaseline::hasTable('attempts')) {
+            $query
+                ->selectRaw('case when exists (select 1 from attempts where attempts.id = results.attempt_id) then 1 else 0 end as attempt_exists')
+                ->selectSub($this->latestAttemptField('locale'), 'attempt_locale')
+                ->selectSub($this->latestAttemptField('region'), 'attempt_region')
+                ->selectSub($this->latestAttemptField('norm_version'), 'attempt_norm_version');
+        }
+
+        if (SchemaBaseline::hasTable('report_snapshots')) {
+            $query
+                ->selectSub($this->latestSnapshotField('status'), 'latest_snapshot_status')
+                ->selectSub($this->latestSnapshotField('order_no'), 'latest_snapshot_order_no')
+                ->selectSub($this->latestSnapshotField('report_engine_version'), 'latest_snapshot_report_engine_version');
+        }
+
+        if (SchemaBaseline::hasTable('orders')) {
+            $query
+                ->selectSub($this->latestOrderField('id'), 'latest_order_id')
+                ->selectSub($this->latestOrderField('order_no'), 'latest_order_no')
+                ->selectSub($this->latestOrderField('status'), 'latest_order_status')
+                ->selectSub($this->latestOrderField('paid_at'), 'latest_order_paid_at');
+        }
+
+        if (SchemaBaseline::hasTable('payment_events')) {
+            $query->selectSub($this->latestPaymentField('status'), 'latest_payment_status');
+        }
+
+        if (SchemaBaseline::hasTable('benefit_grants')) {
+            $query->selectSub($this->latestBenefitField('status'), 'latest_benefit_status');
+        }
+
+        if (SchemaBaseline::hasTable('shares')) {
+            $query->selectSub($this->latestShareField('id'), 'latest_share_id');
+        }
+
+        return $query;
+    }
+
+    /**
+     * @param  Builder<Result>  $query
+     */
+    public function applySearch(Builder $query, string $search): void
+    {
+        $needle = trim($search);
+        if ($needle === '') {
+            return;
+        }
+
+        $like = '%'.$needle.'%';
+
+        $query->where(function (Builder $builder) use ($like): void {
+            $builder
+                ->where('results.id', 'like', $like)
+                ->orWhere('results.attempt_id', 'like', $like)
+                ->orWhere('results.type_code', 'like', $like)
+                ->orWhere('results.scale_code', 'like', $like);
+
+            if (SchemaBaseline::hasTable('orders')) {
+                $builder->orWhereExists(function (QueryBuilder $orderQuery) use ($like): void {
+                    $orderQuery
+                        ->selectRaw('1')
+                        ->from('orders')
+                        ->whereColumn('orders.target_attempt_id', 'results.attempt_id')
+                        ->where('orders.order_no', 'like', $like);
+                });
+            }
+
+            if (SchemaBaseline::hasTable('report_snapshots')) {
+                $builder->orWhereExists(function (QueryBuilder $snapshotQuery) use ($like): void {
+                    $snapshotQuery
+                        ->selectRaw('1')
+                        ->from('report_snapshots')
+                        ->whereColumn('report_snapshots.attempt_id', 'results.attempt_id')
+                        ->where('report_snapshots.order_no', 'like', $like);
+                });
+            }
+
+            if (SchemaBaseline::hasTable('shares')) {
+                $builder->orWhereExists(function (QueryBuilder $shareQuery) use ($like): void {
+                    $shareQuery
+                        ->selectRaw('1')
+                        ->from('shares')
+                        ->whereColumn('shares.attempt_id', 'results.attempt_id')
+                        ->where('shares.id', 'like', $like);
+                });
+            }
+        });
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    public function distinctResultOptions(string $column): array
+    {
+        if (! SchemaBaseline::hasColumn('results', $column)) {
+            return [];
+        }
+
+        return DB::table('results')
+            ->whereNotNull($column)
+            ->where($column, '!=', '')
+            ->distinct()
+            ->orderBy($column)
+            ->pluck($column, $column)
+            ->mapWithKeys(fn ($value): array => [(string) $value => (string) $value])
+            ->all();
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    public function distinctAttemptOptions(string $column): array
+    {
+        if (! SchemaBaseline::hasColumn('attempts', $column)) {
+            return [];
+        }
+
+        return DB::table('attempts')
+            ->whereNotNull($column)
+            ->where($column, '!=', '')
+            ->distinct()
+            ->orderBy($column)
+            ->pluck($column, $column)
+            ->mapWithKeys(fn ($value): array => [(string) $value => (string) $value])
+            ->all();
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    public function distinctSnapshotStatusOptions(): array
+    {
+        $options = ['missing' => 'missing'];
+
+        if (! SchemaBaseline::hasColumn('report_snapshots', 'status')) {
+            return $options;
+        }
+
+        return $options + DB::table('report_snapshots')
+            ->whereNotNull('status')
+            ->where('status', '!=', '')
+            ->distinct()
+            ->orderBy('status')
+            ->pluck('status', 'status')
+            ->mapWithKeys(fn ($value): array => [(string) $value => (string) $value])
+            ->all();
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    public function distinctReportEngineVersionOptions(): array
+    {
+        $values = collect();
+
+        if (SchemaBaseline::hasColumn('results', 'report_engine_version')) {
+            $values = $values->merge(
+                DB::table('results')
+                    ->whereNotNull('report_engine_version')
+                    ->where('report_engine_version', '!=', '')
+                    ->distinct()
+                    ->pluck('report_engine_version')
+                    ->map(fn ($value): string => (string) $value)
+            );
+        }
+
+        if (SchemaBaseline::hasColumn('report_snapshots', 'report_engine_version')) {
+            $values = $values->merge(
+                DB::table('report_snapshots')
+                    ->whereNotNull('report_engine_version')
+                    ->where('report_engine_version', '!=', '')
+                    ->distinct()
+                    ->pluck('report_engine_version')
+                    ->map(fn ($value): string => (string) $value)
+            );
+        }
+
+        return $values
+            ->filter(fn (string $value): bool => $value !== '')
+            ->unique()
+            ->sort()
+            ->mapWithKeys(fn (string $value): array => [$value => $value])
+            ->all();
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    public function diagnosticOptions(): array
+    {
+        return [
+            'linked' => 'linked',
+            'orphan_result' => 'orphan_result',
+            'report_missing' => 'report_missing',
+            'report_pending' => 'report_pending',
+            'report_failed' => 'report_failed',
+        ];
+    }
+
+    /**
+     * @param  Builder<Result>  $query
+     */
+    public function applyAttemptFieldFilter(Builder $query, string $column, ?string $value): void
+    {
+        $selected = trim((string) $value);
+        if ($selected === '' || ! SchemaBaseline::hasColumn('attempts', $column)) {
+            return;
+        }
+
+        $query->whereExists(function (QueryBuilder $attemptQuery) use ($column, $selected): void {
+            $attemptQuery
+                ->selectRaw('1')
+                ->from('attempts')
+                ->whereColumn('attempts.id', 'results.attempt_id')
+                ->where('attempts.'.$column, $selected);
+        });
+    }
+
+    /**
+     * @param  Builder<Result>  $query
+     */
+    public function applySnapshotStatusFilter(Builder $query, ?string $value): void
+    {
+        $status = strtolower(trim((string) $value));
+        if ($status === '') {
+            return;
+        }
+
+        if ($status === 'missing') {
+            $query->whereNotExists($this->snapshotExistsQuery());
+
+            return;
+        }
+
+        $query->whereExists(function (QueryBuilder $snapshotQuery) use ($status): void {
+            $snapshotQuery
+                ->selectRaw('1')
+                ->from('report_snapshots')
+                ->whereColumn('report_snapshots.attempt_id', 'results.attempt_id')
+                ->whereRaw('lower(coalesce(report_snapshots.status, \'\')) = ?', [$status]);
+        });
+    }
+
+    /**
+     * @param  Builder<Result>  $query
+     */
+    public function applyUnlockStatusFilter(Builder $query, ?string $value): void
+    {
+        $status = strtolower(trim((string) $value));
+        if ($status === '') {
+            return;
+        }
+
+        match ($status) {
+            'unlocked' => $query->whereExists($this->activeBenefitExistsQuery()),
+            'paid_pending' => $query->whereExists($this->paidOrderExistsQuery())
+                ->whereNotExists($this->activeBenefitExistsQuery()),
+            'payment_pending' => $query->whereExists($this->orderExistsQuery())
+                ->whereNotExists($this->paidOrderExistsQuery())
+                ->whereNotExists($this->refundedOrderExistsQuery()),
+            'refunded' => $query->whereExists($this->refundedOrderExistsQuery()),
+            'no_order' => $query->whereNotExists($this->orderExistsQuery()),
+            default => null,
+        };
+    }
+
+    /**
+     * @param  Builder<Result>  $query
+     */
+    public function applyReportEngineVersionFilter(Builder $query, ?string $value): void
+    {
+        $version = trim((string) $value);
+        if ($version === '') {
+            return;
+        }
+
+        $query->where(function (Builder $builder) use ($version): void {
+            if (SchemaBaseline::hasColumn('results', 'report_engine_version')) {
+                $builder->where('results.report_engine_version', $version);
+            }
+
+            if (SchemaBaseline::hasColumn('report_snapshots', 'report_engine_version')) {
+                $builder->orWhereExists(function (QueryBuilder $snapshotQuery) use ($version): void {
+                    $snapshotQuery
+                        ->selectRaw('1')
+                        ->from('report_snapshots')
+                        ->whereColumn('report_snapshots.attempt_id', 'results.attempt_id')
+                        ->where('report_snapshots.report_engine_version', $version);
+                });
+            }
+        });
+    }
+
+    /**
+     * @param  Builder<Result>  $query
+     */
+    public function applyDiagnosticStatusFilter(Builder $query, ?string $value): void
+    {
+        $status = strtolower(trim((string) $value));
+        if ($status === '') {
+            return;
+        }
+
+        match ($status) {
+            'linked' => $query
+                ->whereExists($this->attemptExistsQuery())
+                ->where(function (Builder $builder): void {
+                    $builder
+                        ->whereExists($this->snapshotReadyExistsQuery())
+                        ->orWhere(function (Builder $nested): void {
+                            $nested
+                                ->whereNotExists($this->snapshotExistsQuery())
+                                ->whereNotExists($this->orderExistsQuery());
+                        });
+                }),
+            'orphan_result' => $query->whereNotExists($this->attemptExistsQuery()),
+            'report_missing' => $query
+                ->whereExists($this->attemptExistsQuery())
+                ->whereNotExists($this->snapshotExistsQuery()),
+            'report_pending' => $query
+                ->whereExists($this->attemptExistsQuery())
+                ->where(function (Builder $builder): void {
+                    $builder->whereExists($this->snapshotPendingExistsQuery());
+
+                    if (SchemaBaseline::hasTable('report_jobs')) {
+                        $builder->orWhereExists($this->reportJobPendingExistsQuery());
+                    }
+                }),
+            'report_failed' => $query
+                ->whereExists($this->attemptExistsQuery())
+                ->where(function (Builder $builder): void {
+                    $builder->whereExists($this->snapshotFailedExistsQuery());
+
+                    if (SchemaBaseline::hasTable('report_jobs')) {
+                        $builder->orWhereExists($this->reportJobFailedExistsQuery());
+                    }
+                }),
+            default => null,
+        };
+    }
+
+    /**
+     * @return array{label:string,state:string}
+     */
+    public function resultStatus(Result $result): array
+    {
+        if ($this->isOrphanResult($result)) {
+            return ['label' => 'orphan_result', 'state' => 'danger'];
+        }
+
+        if ($result->is_valid === true) {
+            return ['label' => 'valid', 'state' => 'success'];
+        }
+
+        if ($result->is_valid === false) {
+            return ['label' => 'invalid', 'state' => 'danger'];
+        }
+
+        return ['label' => 'computed', 'state' => 'warning'];
+    }
+
+    /**
+     * @return array{label:string,state:string}
+     */
+    public function snapshotStatus(Result $result): array
+    {
+        $status = strtolower(trim((string) ($result->latest_snapshot_status ?? '')));
+        if ($status === '') {
+            return ['label' => 'missing', 'state' => 'gray'];
+        }
+
+        return ['label' => $status, 'state' => StatusBadge::color($status)];
+    }
+
+    /**
+     * @return array{label:string,state:string}
+     */
+    public function unlockStatus(Result $result): array
+    {
+        $benefitStatus = strtolower(trim((string) ($result->latest_benefit_status ?? '')));
+        $orderStatus = strtolower(trim((string) ($result->latest_order_status ?? '')));
+        $paymentStatus = strtolower(trim((string) ($result->latest_payment_status ?? '')));
+
+        if ($benefitStatus === 'active') {
+            return ['label' => 'unlocked', 'state' => 'success'];
+        }
+
+        if ($this->isRefundedLike($orderStatus)) {
+            return ['label' => 'refunded', 'state' => 'danger'];
+        }
+
+        if ($this->isPaidLike($orderStatus) || $this->isPaidLike($paymentStatus)) {
+            return ['label' => 'paid_pending', 'state' => 'warning'];
+        }
+
+        if ($orderStatus !== '') {
+            return ['label' => 'payment_pending', 'state' => 'gray'];
+        }
+
+        return ['label' => 'no_order', 'state' => 'gray'];
+    }
+
+    /**
+     * @return array{label:string,state:string}
+     */
+    public function diagnosticStatus(Result $result): array
+    {
+        if ($this->isOrphanResult($result)) {
+            return ['label' => 'orphan_result', 'state' => 'danger'];
+        }
+
+        $snapshotStatus = $this->snapshotStatus($result)['label'];
+        if (in_array($snapshotStatus, ['failed', 'error'], true)) {
+            return ['label' => 'report_failed', 'state' => 'danger'];
+        }
+
+        if (in_array($snapshotStatus, ['pending', 'queued', 'running'], true)) {
+            return ['label' => 'report_pending', 'state' => 'warning'];
+        }
+
+        if ($snapshotStatus === 'missing' && $this->unlockStatus($result)['label'] !== 'no_order') {
+            return ['label' => 'report_missing', 'state' => 'warning'];
+        }
+
+        return ['label' => 'linked', 'state' => 'success'];
+    }
+
+    public function attemptLocale(Result $result): string
+    {
+        return $this->stringOrDash($result->attempt_locale ?? null);
+    }
+
+    public function attemptRegion(Result $result): string
+    {
+        return $this->stringOrDash($result->attempt_region ?? null);
+    }
+
+    public function reportEngineVersion(Result $result): string
+    {
+        $resultVersion = trim((string) ($result->report_engine_version ?? ''));
+        if ($resultVersion !== '') {
+            return $resultVersion;
+        }
+
+        return $this->stringOrDash($result->latest_snapshot_report_engine_version ?? null);
+    }
+
+    public function scoreSummary(Result $result): string
+    {
+        $scores = $this->arrayFromMixed($result->scores_pct ?? null);
+        if ($scores !== []) {
+            return $this->summarizePairs($scores);
+        }
+
+        $fallback = $this->arrayFromMixed($result->scores_json ?? null);
+        if ($fallback !== []) {
+            return $this->summarizePairs($fallback);
+        }
+
+        return 'not_applicable';
+    }
+
+    public function axisSummary(Result $result): string
+    {
+        $axes = $this->arrayFromMixed($result->axis_states ?? null);
+        if ($axes !== []) {
+            return $this->summarizePairs($axes);
+        }
+
+        return 'not_applicable';
+    }
+
+    /**
+     * @return array{
+     *   headline: array<string, array{label:string,state:string}>,
+     *   result_summary: array{fields:list<array{label:string,value:string,hint:?string,kind:string,state:?string}>,notes:list<string>},
+     *   score_axis_summary: array{fields:list<array{label:string,value:string,hint:?string,kind:string,state:?string}>,notes:list<string>},
+     *   version_summary: array{fields:list<array{label:string,value:string,hint:?string,kind:string,state:?string}>,notes:list<string>},
+     *   report_summary: array{fields:list<array{label:string,value:string,hint:?string,kind:string,state:?string}>,notes:list<string>},
+     *   attempt_summary: array{fields:list<array{label:string,value:string,hint:?string,kind:string,state:?string}>,notes:list<string>},
+     *   commerce_summary: array{fields:list<array{label:string,value:string,hint:?string,kind:string,state:?string}>,notes:list<string>},
+     *   share_summary: array{
+     *      fields:list<array{label:string,value:string,hint:?string,kind:string,state:?string}>,
+     *      notes:list<string>,
+     *      events:list<array{title:string,occurred_at:string,meta:list<string>,share_id:string,channel:string}>
+     *   },
+     *   links:list<array{label:string,url:string,kind:string}>
+     * }
+     */
+    public function buildDetail(Result $result): array
+    {
+        $attempt = $this->fetchAttempt($result);
+        $snapshot = $this->fetchSnapshot($result);
+        $commerce = $this->fetchCommerceSummary($result, $snapshot);
+        $share = $this->fetchShareSummary($result, $commerce['share_id']);
+        $reportJobs = $this->fetchReportJobSummary($result);
+        $attemptSubmission = $this->fetchAttemptSubmissionSummary($result);
+        $quality = $this->fetchAttemptQualitySummary($result);
+        $orphanResult = $this->isOrphanResult($result);
+        $headline = [
+            'result' => $this->resultStatus($result),
+            'diagnostic' => $this->diagnosticStatus($result),
+            'snapshot' => $this->snapshotStatus($result),
+            'unlock' => $this->unlockStatus($result),
+        ];
+        $localeSegment = $this->frontendLocaleSegment((string) ($attempt->locale ?? $result->attempt_locale ?? ''));
+
+        $resultSummary = [
+            'fields' => [
+                $this->field('result_id', (string) $result->id),
+                $this->field('attempt_id', $this->stringOrDash($result->attempt_id)),
+                $this->field('org_id', $this->stringOrDash($result->org_id)),
+                $this->field('scale_code', $this->stringOrDash($result->scale_code)),
+                $this->field('type_code', $this->stringOrDash($result->type_code)),
+                $this->field('computed_at', $this->formatTimestamp($result->computed_at)),
+                $this->pillField('result_status', $headline['result']['label'], $headline['result']['state']),
+                $this->pillField('orphan_result', $orphanResult ? 'yes' : 'no', $orphanResult ? 'danger' : 'success'),
+            ],
+            'notes' => [
+                'Raw result payloads stay hidden here.',
+            ],
+        ];
+
+        $scoreAxisSummary = [
+            'fields' => [
+                $this->field('score_summary', $this->scoreSummary($result)),
+                $this->field('axis_summary', $this->axisSummary($result)),
+                $this->field('dominant_outcome', $this->stringOrDash($result->type_code)),
+                $this->field('scale_uid', $this->stringOrDash($result->scale_uid)),
+                $this->field('scale_version', $this->stringOrDash($result->scale_version)),
+            ],
+            'notes' => [
+                'Compact summaries only. Raw score and axis payloads stay collapsed.',
+            ],
+        ];
+
+        $versionNotes = [];
+        if ($attempt === null) {
+            $versionNotes[] = 'Attempt-derived norm_version is unavailable because the attempt row is missing.';
+        }
+
+        $versionSummary = [
+            'fields' => [
+                $this->field('pack_id', $this->stringOrDash($result->pack_id)),
+                $this->field('dir_version', $this->stringOrDash($result->dir_version)),
+                $this->field('content_package_version', $this->stringOrDash($result->content_package_version)),
+                $this->field('scoring_spec_version', $this->stringOrDash($result->scoring_spec_version)),
+                $this->field('norm_version', $this->stringOrDash($attempt->norm_version ?? null)),
+                $this->field('report_engine_version', $this->reportEngineVersion($result)),
+                $this->field('profile_version', $this->stringOrDash($result->profile_version)),
+                $this->pillField('diagnostic_status', $headline['diagnostic']['label'], $headline['diagnostic']['state']),
+            ],
+            'notes' => $versionNotes,
+        ];
+
+        $reportNotes = $snapshot['notes'];
+        if ($orphanResult) {
+            $reportNotes[] = 'Report drill-through is unavailable while the attempt row is missing.';
+        }
+
+        $reportSummary = [
+            'fields' => [
+                $this->pillField('snapshot_present', $snapshot['exists'] ? 'present' : 'missing', $snapshot['exists'] ? 'success' : 'gray'),
+                $this->pillField('snapshot_status', $snapshot['status'], $snapshot['status_state']),
+                $this->pillField('locked', $snapshot['locked'], $snapshot['locked_state']),
+                $this->field('access_level', $snapshot['access_level']),
+                $this->field('variant', $snapshot['variant']),
+                $this->field('order_no', $snapshot['order_no']),
+                $this->field('report_jobs', $reportJobs['summary'], $reportJobs['hint']),
+                $this->field('pdf_hint', $commerce['pdf']),
+            ],
+            'notes' => $reportNotes,
+        ];
+
+        $attemptNotes = $attempt === null
+            ? ['Attempt row is missing for this result. Result search stays available by result_id and attempt_id.']
+            : [];
+
+        if ($quality['hint'] !== null) {
+            $attemptNotes[] = $quality['hint'];
+        }
+
+        $attemptSummary = [
+            'fields' => [
+                $this->pillField('attempt_linkage', $attempt === null ? 'missing' : 'linked', $attempt === null ? 'danger' : 'success'),
+                $this->pillField('submitted_status', $attemptSubmission['submitted_status'], $attemptSubmission['submitted_state'], $attemptSubmission['summary']),
+                $this->field('locale', $this->stringOrDash($attempt->locale ?? null)),
+                $this->field('region', $this->stringOrDash($attempt->region ?? null)),
+                $this->field('user_id', $this->stringOrDash($attempt->user_id ?? null)),
+                $this->field('anon_id', $this->stringOrDash($attempt->anon_id ?? null)),
+                $this->field('ticket_code', $this->stringOrDash($attempt->ticket_code ?? null)),
+                $this->field('quality', $quality['summary']),
+            ],
+            'notes' => $attemptNotes,
+        ];
+
+        $commerceSummary = [
+            'fields' => [
+                $this->field('order_no', $commerce['order_no']),
+                $this->pillField('order_status', $commerce['order_status'], $commerce['order_status_state']),
+                $this->field('payment_summary', $commerce['payment_summary'], $commerce['payment_hint']),
+                $this->field('active_benefit_grant', $commerce['benefit_summary'], $commerce['benefit_hint']),
+                $this->pillField('unlock_status', $headline['unlock']['label'], $headline['unlock']['state']),
+                $this->field('delivery', $commerce['delivery']),
+                $this->field('pdf', $commerce['pdf']),
+                $this->field('claim', $commerce['claim']),
+            ],
+            'notes' => $commerce['notes'],
+        ];
+
+        $shareSummary = [
+            'fields' => [
+                $this->field('share_id', $share['share_id']),
+                $this->field('share_created_at', $share['created_at']),
+                $this->field('latest_event', $share['latest_event']),
+                $this->field('recent_events', (string) count($share['events'])),
+                $this->field('engagement_channel', $share['latest_channel']),
+            ],
+            'notes' => $share['notes'],
+            'events' => $share['events'],
+        ];
+
+        return [
+            'headline' => $headline,
+            'result_summary' => $resultSummary,
+            'score_axis_summary' => $scoreAxisSummary,
+            'version_summary' => $versionSummary,
+            'report_summary' => $reportSummary,
+            'attempt_summary' => $attemptSummary,
+            'commerce_summary' => $commerceSummary,
+            'share_summary' => $shareSummary,
+            'links' => $this->buildLinks($result, $attempt, $localeSegment, $commerce['order_id'], $share['share_id']),
+        ];
+    }
+
+    private function latestAttemptField(string $column): QueryBuilder
+    {
+        return DB::table('attempts')
+            ->select($column)
+            ->whereColumn('attempts.id', 'results.attempt_id')
+            ->limit(1);
+    }
+
+    private function latestSnapshotField(string $column): QueryBuilder
+    {
+        return DB::table('report_snapshots')
+            ->select($column)
+            ->whereColumn('report_snapshots.attempt_id', 'results.attempt_id')
+            ->orderByRaw('coalesce(updated_at, created_at) desc')
+            ->limit(1);
+    }
+
+    private function latestOrderField(string $column): QueryBuilder
+    {
+        return DB::table('orders')
+            ->select($column)
+            ->whereColumn('orders.target_attempt_id', 'results.attempt_id')
+            ->orderByRaw('coalesce(paid_at, updated_at, created_at) desc')
+            ->limit(1);
+    }
+
+    private function latestPaymentField(string $column): QueryBuilder
+    {
+        return DB::table('payment_events')
+            ->select($column)
+            ->whereExists(function (QueryBuilder $orderQuery): void {
+                $orderQuery
+                    ->selectRaw('1')
+                    ->from('orders')
+                    ->whereColumn('orders.order_no', 'payment_events.order_no')
+                    ->whereColumn('orders.target_attempt_id', 'results.attempt_id');
+            })
+            ->orderByRaw('coalesce(processed_at, updated_at, created_at) desc')
+            ->limit(1);
+    }
+
+    private function latestBenefitField(string $column): QueryBuilder
+    {
+        return DB::table('benefit_grants')
+            ->select($column)
+            ->where(function (QueryBuilder $benefitQuery): void {
+                $benefitQuery
+                    ->whereColumn('benefit_grants.attempt_id', 'results.attempt_id')
+                    ->orWhereExists(function (QueryBuilder $orderQuery): void {
+                        $orderQuery
+                            ->selectRaw('1')
+                            ->from('orders')
+                            ->whereColumn('orders.order_no', 'benefit_grants.order_no')
+                            ->whereColumn('orders.target_attempt_id', 'results.attempt_id');
+                    });
+            })
+            ->orderByRaw("case when lower(coalesce(status, '')) = 'active' then 0 else 1 end")
+            ->orderByRaw('coalesce(updated_at, created_at) desc')
+            ->limit(1);
+    }
+
+    private function latestShareField(string $column): QueryBuilder
+    {
+        return DB::table('shares')
+            ->select($column)
+            ->whereColumn('shares.attempt_id', 'results.attempt_id')
+            ->orderByDesc('created_at')
+            ->limit(1);
+    }
+
+    private function attemptExistsQuery(): \Closure
+    {
+        return function (QueryBuilder $attemptQuery): void {
+            if (! SchemaBaseline::hasTable('attempts')) {
+                $attemptQuery->selectRaw('1')->fromRaw('(select 1) as noop')->whereRaw('1 = 0');
+
+                return;
+            }
+
+            $attemptQuery
+                ->selectRaw('1')
+                ->from('attempts')
+                ->whereColumn('attempts.id', 'results.attempt_id');
+        };
+    }
+
+    private function snapshotExistsQuery(): \Closure
+    {
+        return function (QueryBuilder $snapshotQuery): void {
+            if (! SchemaBaseline::hasTable('report_snapshots')) {
+                $snapshotQuery->selectRaw('1')->fromRaw('(select 1) as noop')->whereRaw('1 = 0');
+
+                return;
+            }
+
+            $snapshotQuery
+                ->selectRaw('1')
+                ->from('report_snapshots')
+                ->whereColumn('report_snapshots.attempt_id', 'results.attempt_id');
+        };
+    }
+
+    private function snapshotReadyExistsQuery(): \Closure
+    {
+        return function (QueryBuilder $snapshotQuery): void {
+            if (! SchemaBaseline::hasTable('report_snapshots')) {
+                $snapshotQuery->selectRaw('1')->fromRaw('(select 1) as noop')->whereRaw('1 = 0');
+
+                return;
+            }
+
+            $snapshotQuery
+                ->selectRaw('1')
+                ->from('report_snapshots')
+                ->whereColumn('report_snapshots.attempt_id', 'results.attempt_id')
+                ->whereRaw("lower(coalesce(report_snapshots.status, '')) in (?, ?, ?)", ['ready', 'full', 'completed']);
+        };
+    }
+
+    private function snapshotPendingExistsQuery(): \Closure
+    {
+        return function (QueryBuilder $snapshotQuery): void {
+            if (! SchemaBaseline::hasTable('report_snapshots')) {
+                $snapshotQuery->selectRaw('1')->fromRaw('(select 1) as noop')->whereRaw('1 = 0');
+
+                return;
+            }
+
+            $snapshotQuery
+                ->selectRaw('1')
+                ->from('report_snapshots')
+                ->whereColumn('report_snapshots.attempt_id', 'results.attempt_id')
+                ->whereRaw("lower(coalesce(report_snapshots.status, '')) in (?, ?, ?)", ['pending', 'queued', 'running']);
+        };
+    }
+
+    private function snapshotFailedExistsQuery(): \Closure
+    {
+        return function (QueryBuilder $snapshotQuery): void {
+            if (! SchemaBaseline::hasTable('report_snapshots')) {
+                $snapshotQuery->selectRaw('1')->fromRaw('(select 1) as noop')->whereRaw('1 = 0');
+
+                return;
+            }
+
+            $snapshotQuery
+                ->selectRaw('1')
+                ->from('report_snapshots')
+                ->whereColumn('report_snapshots.attempt_id', 'results.attempt_id')
+                ->whereRaw("lower(coalesce(report_snapshots.status, '')) in (?, ?)", ['failed', 'error']);
+        };
+    }
+
+    private function orderExistsQuery(): \Closure
+    {
+        return function (QueryBuilder $orderQuery): void {
+            if (! SchemaBaseline::hasTable('orders')) {
+                $orderQuery->selectRaw('1')->fromRaw('(select 1) as noop')->whereRaw('1 = 0');
+
+                return;
+            }
+
+            $orderQuery
+                ->selectRaw('1')
+                ->from('orders')
+                ->whereColumn('orders.target_attempt_id', 'results.attempt_id');
+        };
+    }
+
+    private function paidOrderExistsQuery(): \Closure
+    {
+        return function (QueryBuilder $orderQuery): void {
+            if (! SchemaBaseline::hasTable('orders')) {
+                $orderQuery->selectRaw('1')->fromRaw('(select 1) as noop')->whereRaw('1 = 0');
+
+                return;
+            }
+
+            $orderQuery
+                ->selectRaw('1')
+                ->from('orders')
+                ->whereColumn('orders.target_attempt_id', 'results.attempt_id')
+                ->where(function (QueryBuilder $builder): void {
+                    $builder->whereRaw("lower(coalesce(orders.status, '')) in (?, ?, ?, ?)", ['paid', 'fulfilled', 'complete', 'completed']);
+
+                    if (SchemaBaseline::hasColumn('orders', 'paid_at')) {
+                        $builder->orWhereNotNull('orders.paid_at');
+                    }
+                });
+        };
+    }
+
+    private function refundedOrderExistsQuery(): \Closure
+    {
+        return function (QueryBuilder $orderQuery): void {
+            if (! SchemaBaseline::hasTable('orders')) {
+                $orderQuery->selectRaw('1')->fromRaw('(select 1) as noop')->whereRaw('1 = 0');
+
+                return;
+            }
+
+            $orderQuery
+                ->selectRaw('1')
+                ->from('orders')
+                ->whereColumn('orders.target_attempt_id', 'results.attempt_id')
+                ->where(function (QueryBuilder $builder): void {
+                    $builder->whereRaw("lower(coalesce(orders.status, '')) like ?", ['%refund%']);
+
+                    if (SchemaBaseline::hasColumn('orders', 'refunded_at')) {
+                        $builder->orWhereNotNull('orders.refunded_at');
+                    }
+                });
+        };
+    }
+
+    private function activeBenefitExistsQuery(): \Closure
+    {
+        return function (QueryBuilder $benefitQuery): void {
+            if (! SchemaBaseline::hasTable('benefit_grants')) {
+                $benefitQuery->selectRaw('1')->fromRaw('(select 1) as noop')->whereRaw('1 = 0');
+
+                return;
+            }
+
+            $benefitQuery
+                ->selectRaw('1')
+                ->from('benefit_grants')
+                ->whereRaw("lower(coalesce(benefit_grants.status, '')) = 'active'")
+                ->where(function (QueryBuilder $builder): void {
+                    $builder
+                        ->whereColumn('benefit_grants.attempt_id', 'results.attempt_id')
+                        ->orWhereExists(function (QueryBuilder $orderQuery): void {
+                            $orderQuery
+                                ->selectRaw('1')
+                                ->from('orders')
+                                ->whereColumn('orders.order_no', 'benefit_grants.order_no')
+                                ->whereColumn('orders.target_attempt_id', 'results.attempt_id');
+                        });
+                });
+        };
+    }
+
+    private function reportJobPendingExistsQuery(): \Closure
+    {
+        return function (QueryBuilder $jobQuery): void {
+            if (! SchemaBaseline::hasTable('report_jobs')) {
+                $jobQuery->selectRaw('1')->fromRaw('(select 1) as noop')->whereRaw('1 = 0');
+
+                return;
+            }
+
+            $jobQuery
+                ->selectRaw('1')
+                ->from('report_jobs')
+                ->whereColumn('report_jobs.attempt_id', 'results.attempt_id')
+                ->whereRaw("lower(coalesce(report_jobs.status, '')) in (?, ?, ?)", ['pending', 'queued', 'running']);
+        };
+    }
+
+    private function reportJobFailedExistsQuery(): \Closure
+    {
+        return function (QueryBuilder $jobQuery): void {
+            if (! SchemaBaseline::hasTable('report_jobs')) {
+                $jobQuery->selectRaw('1')->fromRaw('(select 1) as noop')->whereRaw('1 = 0');
+
+                return;
+            }
+
+            $jobQuery
+                ->selectRaw('1')
+                ->from('report_jobs')
+                ->whereColumn('report_jobs.attempt_id', 'results.attempt_id')
+                ->whereRaw("lower(coalesce(report_jobs.status, '')) in (?, ?)", ['failed', 'error']);
+        };
+    }
+
+    private function fetchAttempt(Result $result): ?object
+    {
+        if (! SchemaBaseline::hasTable('attempts')) {
+            return null;
+        }
+
+        return DB::table('attempts')
+            ->where('id', (string) $result->attempt_id)
+            ->first();
+    }
+
+    /**
+     * @return array{
+     *   exists:bool,
+     *   status:string,
+     *   status_state:string,
+     *   locked:string,
+     *   locked_state:string,
+     *   access_level:string,
+     *   variant:string,
+     *   order_no:string,
+     *   notes:list<string>
+     * }
+     */
+    private function fetchSnapshot(Result $result): array
+    {
+        if (! SchemaBaseline::hasTable('report_snapshots')) {
+            return [
+                'exists' => false,
+                'status' => 'missing',
+                'status_state' => 'gray',
+                'locked' => '-',
+                'locked_state' => 'gray',
+                'access_level' => '-',
+                'variant' => '-',
+                'order_no' => '-',
+                'notes' => ['No report snapshot row found for this result yet.'],
+            ];
+        }
+
+        $row = DB::table('report_snapshots')
+            ->where('attempt_id', (string) $result->attempt_id)
+            ->orderByRaw('coalesce(updated_at, created_at) desc')
+            ->first();
+
+        if ($row === null) {
+            return [
+                'exists' => false,
+                'status' => 'missing',
+                'status_state' => 'gray',
+                'locked' => '-',
+                'locked_state' => 'gray',
+                'access_level' => '-',
+                'variant' => '-',
+                'order_no' => '-',
+                'notes' => ['No report snapshot row found for this result yet.'],
+            ];
+        }
+
+        $reportJson = SchemaBaseline::hasColumn('report_snapshots', 'report_json')
+            ? $this->arrayFromMixed($row->report_json ?? null)
+            : [];
+        $locked = $this->normalizeBooleanLabel($reportJson['locked'] ?? null);
+        $notes = ['Report payload JSON stays collapsed here.'];
+
+        if (SchemaBaseline::hasColumn('report_snapshots', 'report_free_json') && ($row->report_free_json ?? null) !== null) {
+            $notes[] = 'Free report snapshot is present.';
+        }
+        if (SchemaBaseline::hasColumn('report_snapshots', 'report_full_json') && ($row->report_full_json ?? null) !== null) {
+            $notes[] = 'Full report snapshot is present.';
+        }
+
+        return [
+            'exists' => true,
+            'status' => $this->stringOrDash($row->status ?? null),
+            'status_state' => StatusBadge::color($row->status ?? null),
+            'locked' => $locked['label'],
+            'locked_state' => $locked['state'],
+            'access_level' => $this->stringOrDash($reportJson['access_level'] ?? null),
+            'variant' => $this->stringOrDash($reportJson['variant'] ?? null),
+            'order_no' => $this->stringOrDash($row->order_no ?? null),
+            'notes' => $notes,
+        ];
+    }
+
+    /**
+     * @param  array{order_no:string}  $snapshot
+     * @return array{
+     *   order_id:?string,
+     *   order_no:string,
+     *   order_status:string,
+     *   order_status_state:string,
+     *   payment_summary:string,
+     *   payment_hint:?string,
+     *   benefit_summary:string,
+     *   benefit_hint:?string,
+     *   delivery:string,
+     *   pdf:string,
+     *   claim:string,
+     *   share_id:string,
+     *   notes:list<string>
+     * }
+     */
+    private function fetchCommerceSummary(Result $result, array $snapshot): array
+    {
+        $order = null;
+        if (SchemaBaseline::hasTable('orders')) {
+            $order = DB::table('orders')
+                ->where('target_attempt_id', (string) $result->attempt_id)
+                ->orderByRaw('coalesce(paid_at, updated_at, created_at) desc')
+                ->first();
+        }
+
+        $orderNo = trim((string) (($order->order_no ?? null) ?: ($snapshot['order_no'] ?? '')));
+        $payment = null;
+        if ($orderNo !== '' && SchemaBaseline::hasTable('payment_events')) {
+            $payment = DB::table('payment_events')
+                ->where('order_no', $orderNo)
+                ->orderByRaw('coalesce(processed_at, updated_at, created_at) desc')
+                ->first();
+        }
+
+        $benefit = null;
+        if (SchemaBaseline::hasTable('benefit_grants')) {
+            $benefit = DB::table('benefit_grants')
+                ->where(function (QueryBuilder $builder) use ($result, $orderNo): void {
+                    $builder->where('attempt_id', (string) $result->attempt_id);
+
+                    if ($orderNo !== '') {
+                        $builder->orWhere('order_no', $orderNo);
+                    }
+                })
+                ->orderByRaw("case when lower(coalesce(status, '')) = 'active' then 0 else 1 end")
+                ->orderByRaw('coalesce(updated_at, created_at) desc')
+                ->first();
+        }
+
+        $orderMeta = SchemaBaseline::hasColumn('orders', 'meta_json') ? $this->arrayFromMixed($order->meta_json ?? null) : [];
+        $benefitMeta = SchemaBaseline::hasColumn('benefit_grants', 'meta_json') ? $this->arrayFromMixed($benefit->meta_json ?? null) : [];
+        $shareId = trim((string) ($result->latest_share_id ?? ''));
+        $unlock = $this->unlockStatus($result);
+        $snapshotStatus = $this->snapshotStatus($result)['label'];
+
+        $notes = ['Unlock status is derived from active benefit_grants first, not from order status alone.'];
+        if ($orderNo === '') {
+            $notes[] = 'No linked order row was found for this result yet.';
+        }
+
+        return [
+            'order_id' => ($order->id ?? null) !== null ? (string) $order->id : null,
+            'order_no' => $orderNo !== '' ? $orderNo : '-',
+            'order_status' => $this->stringOrDash($order->status ?? null),
+            'order_status_state' => StatusBadge::color($order->status ?? null),
+            'payment_summary' => $this->stringOrDash($payment->status ?? null),
+            'payment_hint' => $payment !== null ? 'event='.$this->stringOrDash($payment->event_type ?? null) : null,
+            'benefit_summary' => $this->stringOrDash($benefit->status ?? null),
+            'benefit_hint' => $benefit !== null ? 'benefit='.$this->stringOrDash($benefit->benefit_code ?? null) : null,
+            'delivery' => $this->formatTimestamp(($order->fulfilled_at ?? null) ?: ($order->paid_at ?? null)),
+            'pdf' => $snapshotStatus === 'ready' && $unlock['label'] === 'unlocked' ? 'ready' : 'unavailable',
+            'claim' => $this->stringOrDash($benefitMeta['claim_status'] ?? $orderMeta['claim_status'] ?? null),
+            'share_id' => $shareId !== '' ? $shareId : '-',
+            'notes' => $notes,
+        ];
+    }
+
+    /**
+     * @return array{
+     *   share_id:string,
+     *   created_at:string,
+     *   latest_event:string,
+     *   latest_channel:string,
+     *   notes:list<string>,
+     *   events:list<array{title:string,occurred_at:string,meta:list<string>,share_id:string,channel:string}>
+     * }
+     */
+    private function fetchShareSummary(Result $result, string $fallbackShareId): array
+    {
+        $shareId = trim((string) $fallbackShareId);
+        $createdAt = '-';
+        $notes = ['Share and engagement traces stay summarized only. Raw event payloads stay hidden.'];
+
+        if (SchemaBaseline::hasTable('shares')) {
+            $share = DB::table('shares')
+                ->where('attempt_id', (string) $result->attempt_id)
+                ->orderByDesc('created_at')
+                ->first();
+
+            if ($share !== null) {
+                $shareId = trim((string) (($share->id ?? null) ?: $shareId));
+                $createdAt = $this->formatTimestamp($share->created_at ?? null);
+            }
+        }
+
+        if ($shareId === '') {
+            $notes[] = 'No share row found for this result yet.';
+        }
+
+        $events = $this->fetchRecentEvents((string) $result->attempt_id, $shareId);
+        $latestEvent = $events[0]['title'] ?? '-';
+        $latestChannel = $events[0]['channel'] ?? '-';
+
+        return [
+            'share_id' => $shareId !== '' ? $shareId : '-',
+            'created_at' => $createdAt,
+            'latest_event' => $latestEvent,
+            'latest_channel' => $latestChannel,
+            'notes' => $notes,
+            'events' => $events,
+        ];
+    }
+
+    /**
+     * @return list<array{title:string,occurred_at:string,meta:list<string>,share_id:string,channel:string}>
+     */
+    private function fetchRecentEvents(string $attemptId, string $shareId): array
+    {
+        if (! SchemaBaseline::hasTable('events')) {
+            return [];
+        }
+
+        $rows = DB::table('events')
+            ->select(['event_code', 'occurred_at', 'share_id', 'channel', 'meta_json'])
+            ->where(function (QueryBuilder $query) use ($attemptId, $shareId): void {
+                $query->where('attempt_id', $attemptId);
+
+                if ($shareId !== '' && $shareId !== '-') {
+                    $query->orWhere('share_id', $shareId);
+                }
+            })
+            ->orderByRaw('coalesce(occurred_at, created_at) desc')
+            ->limit(8)
+            ->get();
+
+        return $rows->map(function ($row): array {
+            return [
+                'title' => $this->stringOrDash($row->event_code ?? null),
+                'occurred_at' => $this->formatTimestamp($row->occurred_at ?? null),
+                'meta' => $this->summarizeMeta($this->arrayFromMixed($row->meta_json ?? null)),
+                'share_id' => $this->stringOrDash($row->share_id ?? null),
+                'channel' => $this->stringOrDash($row->channel ?? null),
+            ];
+        })->all();
+    }
+
+    /**
+     * @return array{summary:string,hint:?string}
+     */
+    private function fetchReportJobSummary(Result $result): array
+    {
+        if (! SchemaBaseline::hasTable('report_jobs')) {
+            return ['summary' => '-', 'hint' => null];
+        }
+
+        $rows = DB::table('report_jobs')
+            ->select(['status', 'created_at', 'finished_at'])
+            ->where('attempt_id', (string) $result->attempt_id)
+            ->orderByDesc('created_at')
+            ->limit(10)
+            ->get();
+
+        if ($rows->isEmpty()) {
+            return ['summary' => 'missing', 'hint' => null];
+        }
+
+        $latest = $rows->first();
+
+        return [
+            'summary' => sprintf('latest=%s total=%d', (string) ($latest->status ?? 'unknown'), $rows->count()),
+            'hint' => 'finished='.$this->formatTimestamp($latest->finished_at ?? null),
+        ];
+    }
+
+    /**
+     * @return array{summary:string,submitted_status:string,submitted_state:string}
+     */
+    private function fetchAttemptSubmissionSummary(Result $result): array
+    {
+        if (! SchemaBaseline::hasTable('attempt_submissions')) {
+            return [
+                'summary' => 'missing',
+                'submitted_status' => 'unknown',
+                'submitted_state' => 'gray',
+            ];
+        }
+
+        $row = DB::table('attempt_submissions')
+            ->select(['state', 'mode', 'finished_at', 'error_code'])
+            ->where('attempt_id', (string) $result->attempt_id)
+            ->orderByRaw('coalesce(finished_at, updated_at, created_at) desc')
+            ->first();
+
+        if ($row === null) {
+            return [
+                'summary' => 'missing',
+                'submitted_status' => 'unknown',
+                'submitted_state' => 'gray',
+            ];
+        }
+
+        $state = strtolower(trim((string) ($row->state ?? 'unknown')));
+        $parts = [
+            'mode='.$this->stringOrDash($row->mode ?? null),
+            'finished='.$this->formatTimestamp($row->finished_at ?? null),
+        ];
+
+        if (filled($row->error_code ?? null)) {
+            $parts[] = 'error='.$this->stringOrDash($row->error_code ?? null);
+        }
+
+        return [
+            'summary' => implode(' | ', $parts),
+            'submitted_status' => $state !== '' ? $state : 'unknown',
+            'submitted_state' => StatusBadge::color($state),
+        ];
+    }
+
+    /**
+     * @return array{summary:string,hint:?string}
+     */
+    private function fetchAttemptQualitySummary(Result $result): array
+    {
+        if (! SchemaBaseline::hasTable('attempt_quality')) {
+            return ['summary' => '-', 'hint' => null];
+        }
+
+        $row = DB::table('attempt_quality')
+            ->select(['grade', 'created_at'])
+            ->where('attempt_id', (string) $result->attempt_id)
+            ->orderByDesc('created_at')
+            ->first();
+
+        if ($row === null) {
+            return ['summary' => 'missing', 'hint' => 'Raw checks_json stays hidden.'];
+        }
+
+        return [
+            'summary' => $this->stringOrDash($row->grade ?? null),
+            'hint' => 'Raw checks_json stays hidden.',
+        ];
+    }
+
+    /**
+     * @return list<array{label:string,url:string,kind:string}>
+     */
+    private function buildLinks(Result $result, ?object $attempt, string $localeSegment, ?string $orderId, string $shareId): array
+    {
+        $base = rtrim((string) config('app.frontend_url', config('app.url', '')), '/');
+        $links = [];
+
+        if ($base !== '') {
+            $attemptId = trim((string) $result->attempt_id);
+
+            if ($attemptId !== '') {
+                $links[] = [
+                    'label' => 'Result page',
+                    'url' => $base.'/'.$localeSegment.'/result/'.urlencode($attemptId),
+                    'kind' => 'frontend',
+                ];
+            }
+
+            if ($attempt !== null && $attemptId !== '') {
+                $links[] = [
+                    'label' => 'Report page',
+                    'url' => $base.'/'.$localeSegment.'/attempts/'.urlencode($attemptId).'/report',
+                    'kind' => 'frontend',
+                ];
+            }
+
+            if ($shareId !== '' && $shareId !== '-') {
+                $links[] = [
+                    'label' => 'Share page',
+                    'url' => $base.'/'.$localeSegment.'/share/'.urlencode($shareId),
+                    'kind' => 'frontend',
+                ];
+            }
+        }
+
+        if ($attempt !== null) {
+            $links[] = [
+                'label' => 'Attempt Explorer',
+                'url' => AttemptResource::getUrl('view', ['record' => (string) $result->attempt_id]),
+                'kind' => 'ops',
+            ];
+        }
+
+        if ($orderId !== null && $orderId !== '') {
+            $links[] = [
+                'label' => 'Order diagnostics',
+                'url' => OrderResource::getUrl('view', ['record' => $orderId]),
+                'kind' => 'ops',
+            ];
+        }
+
+        $links[] = [
+            'label' => 'Order Lookup',
+            'url' => '/ops/order-lookup',
+            'kind' => 'ops',
+        ];
+
+        return $links;
+    }
+
+    private function isOrphanResult(Result $result): bool
+    {
+        return (int) ($result->attempt_exists ?? 0) !== 1;
+    }
+
+    private function isPaidLike(string $status): bool
+    {
+        return in_array(strtolower(trim($status)), ['paid', 'fulfilled', 'complete', 'completed'], true);
+    }
+
+    private function isRefundedLike(string $status): bool
+    {
+        return str_contains(strtolower(trim($status)), 'refund');
+    }
+
+    private function frontendLocaleSegment(string $locale): string
+    {
+        return str_starts_with(strtolower(trim($locale)), 'zh') ? 'zh' : 'en';
+    }
+
+    /**
+     * @return array{label:string,value:string,hint:?string,kind:string,state:?string}
+     */
+    private function field(string $label, string $value, ?string $hint = null): array
+    {
+        return [
+            'label' => $label,
+            'value' => $value !== '' ? $value : '-',
+            'hint' => $hint,
+            'kind' => 'text',
+            'state' => null,
+        ];
+    }
+
+    /**
+     * @return array{label:string,value:string,hint:?string,kind:string,state:?string}
+     */
+    private function pillField(string $label, string $value, string $state, ?string $hint = null): array
+    {
+        return [
+            'label' => $label,
+            'value' => $value !== '' ? $value : '-',
+            'hint' => $hint,
+            'kind' => 'pill',
+            'state' => $state,
+        ];
+    }
+
+    private function stringOrDash(mixed $value): string
+    {
+        $string = trim((string) $value);
+
+        return $string !== '' ? $string : '-';
+    }
+
+    private function formatTimestamp(mixed $value): string
+    {
+        if ($value === null || $value === '') {
+            return '-';
+        }
+
+        if ($value instanceof Carbon) {
+            return $value->toDateTimeString();
+        }
+
+        try {
+            return Carbon::parse((string) $value)->toDateTimeString();
+        } catch (\Throwable) {
+            return $this->stringOrDash($value);
+        }
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function arrayFromMixed(mixed $value): array
+    {
+        if (is_array($value)) {
+            return $value;
+        }
+
+        if (is_string($value)) {
+            $decoded = json_decode($value, true);
+
+            return is_array($decoded) ? $decoded : [];
+        }
+
+        return [];
+    }
+
+    /**
+     * @param  array<string, mixed>  $pairs
+     */
+    private function summarizePairs(array $pairs, int $limit = 4): string
+    {
+        $summary = [];
+
+        foreach ($pairs as $key => $value) {
+            if (count($summary) >= $limit) {
+                break;
+            }
+
+            $summary[] = sprintf('%s=%s', (string) $key, $this->scalarSummary($value));
+        }
+
+        return $summary === [] ? 'not_applicable' : implode(' | ', $summary);
+    }
+
+    private function scalarSummary(mixed $value): string
+    {
+        if (is_bool($value)) {
+            return $value ? 'true' : 'false';
+        }
+
+        if (is_scalar($value)) {
+            return Str::limit((string) $value, 32, '...');
+        }
+
+        if (is_array($value)) {
+            return 'array('.count($value).')';
+        }
+
+        return '-';
+    }
+
+    /**
+     * @return array{label:string,state:string}
+     */
+    private function normalizeBooleanLabel(mixed $value): array
+    {
+        if ($value === null || $value === '') {
+            return ['label' => '-', 'state' => 'gray'];
+        }
+
+        $truthy = StatusBadge::isTruthy($value);
+
+        return [
+            'label' => $truthy ? 'yes' : 'no',
+            'state' => $truthy ? 'warning' : 'success',
+        ];
+    }
+
+    /**
+     * @param  array<string, mixed>  $meta
+     * @return list<string>
+     */
+    private function summarizeMeta(array $meta): array
+    {
+        $summary = [];
+
+        foreach (['status', 'stage', 'variant', 'locked', 'access_level', 'reason', 'provider'] as $key) {
+            $value = $meta[$key] ?? null;
+
+            if ($value === null || $value === '') {
+                continue;
+            }
+
+            $summary[] = $key.'='.$this->scalarSummary($value);
+        }
+
+        return $summary;
+    }
+}

--- a/backend/resources/views/filament/ops/resources/results/view-result.blade.php
+++ b/backend/resources/views/filament/ops/resources/results/view-result.blade.php
@@ -1,0 +1,199 @@
+<x-filament-panels::page>
+    @php
+        $record = $this->getRecord();
+    @endphp
+
+    <div class="ops-shell-page">
+        <x-filament::section>
+            <div class="ops-workbench-toolbar ops-workbench-toolbar--split">
+                <div class="ops-workbench-toolbar__main">
+                    <div class="ops-shell-inline-intro">
+                        <span class="ops-shell-inline-intro__eyebrow">Support diagnostic</span>
+                        <p class="ops-shell-inline-intro__meta">
+                            Rooted on <code>{{ (string) $record->getKey() }}</code>. This page keeps result, versions, report, attempt, unlock, and share linkage in one read-only view.
+                        </p>
+                    </div>
+
+                    <div class="flex flex-wrap items-center gap-3">
+                        <x-filament.ops.shared.status-pill
+                            :state="(string) ($headline['result']['state'] ?? 'gray')"
+                            :label="'result: '.(string) ($headline['result']['label'] ?? '-')"
+                        />
+                        <x-filament.ops.shared.status-pill
+                            :state="(string) ($headline['diagnostic']['state'] ?? 'gray')"
+                            :label="'diagnostic: '.(string) ($headline['diagnostic']['label'] ?? '-')"
+                        />
+                        <x-filament.ops.shared.status-pill
+                            :state="(string) ($headline['snapshot']['state'] ?? 'gray')"
+                            :label="'snapshot: '.(string) ($headline['snapshot']['label'] ?? '-')"
+                        />
+                        <x-filament.ops.shared.status-pill
+                            :state="(string) ($headline['unlock']['state'] ?? 'gray')"
+                            :label="'unlock: '.(string) ($headline['unlock']['label'] ?? '-')"
+                        />
+                    </div>
+                </div>
+
+                <div class="ops-workbench-toolbar__actions">
+                    @foreach ($links as $link)
+                        <x-filament::button
+                            color="{{ ($link['kind'] ?? 'frontend') === 'ops' ? 'gray' : 'primary' }}"
+                            size="sm"
+                            tag="a"
+                            href="{{ (string) ($link['url'] ?? '#') }}"
+                            target="{{ ($link['kind'] ?? 'frontend') === 'ops' ? '_self' : '_blank' }}"
+                        >
+                            {{ (string) ($link['label'] ?? 'Open') }}
+                        </x-filament::button>
+                    @endforeach
+                </div>
+            </div>
+        </x-filament::section>
+
+        <x-filament::section>
+            <div class="ops-results-header">
+                <div>
+                    <h3 class="ops-results-header__title">Result Summary</h3>
+                    <p class="ops-results-header__meta">Canonical result identity, validity, computed timing, and orphan visibility.</p>
+                </div>
+            </div>
+
+            <div class="mt-4">
+                @include('filament.ops.resources.attempts.partials.field-grid', [
+                    'fields' => $resultSummary['fields'] ?? [],
+                    'notes' => $resultSummary['notes'] ?? [],
+                ])
+            </div>
+        </x-filament::section>
+
+        <x-filament::section>
+            <div class="ops-results-header">
+                <div>
+                    <h3 class="ops-results-header__title">Score / Axis Summary</h3>
+                    <p class="ops-results-header__meta">Compact summaries only. Raw scores_pct, axis_states, and result payloads stay hidden.</p>
+                </div>
+            </div>
+
+            <div class="mt-4">
+                @include('filament.ops.resources.attempts.partials.field-grid', [
+                    'fields' => $scoreAxisSummary['fields'] ?? [],
+                    'notes' => $scoreAxisSummary['notes'] ?? [],
+                ])
+            </div>
+        </x-filament::section>
+
+        <x-filament::section>
+            <div class="ops-results-header">
+                <div>
+                    <h3 class="ops-results-header__title">Version / Diagnostics</h3>
+                    <p class="ops-results-header__meta">Version breadcrumbs and first-pass diagnostic status without turning v1 into aggregate analytics.</p>
+                </div>
+            </div>
+
+            <div class="mt-4">
+                @include('filament.ops.resources.attempts.partials.field-grid', [
+                    'fields' => $versionSummary['fields'] ?? [],
+                    'notes' => $versionSummary['notes'] ?? [],
+                ])
+            </div>
+        </x-filament::section>
+
+        <x-filament::section>
+            <div class="ops-results-header">
+                <div>
+                    <h3 class="ops-results-header__title">Report Linkage</h3>
+                    <p class="ops-results-header__meta">Snapshot status, variant/access clues, and lightweight report job breadcrumbs only.</p>
+                </div>
+            </div>
+
+            <div class="mt-4">
+                @include('filament.ops.resources.attempts.partials.field-grid', [
+                    'fields' => $reportSummary['fields'] ?? [],
+                    'notes' => $reportSummary['notes'] ?? [],
+                ])
+            </div>
+        </x-filament::section>
+
+        <x-filament::section>
+            <div class="ops-results-header">
+                <div>
+                    <h3 class="ops-results-header__title">Attempt Linkage</h3>
+                    <p class="ops-results-header__meta">Attempt presence, submit status, locale, region, and identity breadcrumbs with orphan-safe degradation.</p>
+                </div>
+            </div>
+
+            <div class="mt-4">
+                @include('filament.ops.resources.attempts.partials.field-grid', [
+                    'fields' => $attemptSummary['fields'] ?? [],
+                    'notes' => $attemptSummary['notes'] ?? [],
+                ])
+            </div>
+        </x-filament::section>
+
+        <x-filament::section>
+            <div class="ops-results-header">
+                <div>
+                    <h3 class="ops-results-header__title">Commerce / Unlock Linkage</h3>
+                    <p class="ops-results-header__meta">Order, payment, benefit grant, unlock fact, and delivery/PDF clues rooted on the result attempt.</p>
+                </div>
+            </div>
+
+            <div class="mt-4">
+                @include('filament.ops.resources.attempts.partials.field-grid', [
+                    'fields' => $commerceSummary['fields'] ?? [],
+                    'notes' => $commerceSummary['notes'] ?? [],
+                ])
+            </div>
+        </x-filament::section>
+
+        <x-filament::section>
+            <div class="ops-results-header">
+                <div>
+                    <h3 class="ops-results-header__title">Share / Engagement</h3>
+                    <p class="ops-results-header__meta">Share breadcrumbs and recent event summaries only. Raw event payloads stay hidden.</p>
+                </div>
+            </div>
+
+            <div class="mt-4">
+                @include('filament.ops.resources.attempts.partials.field-grid', [
+                    'fields' => $shareSummary['fields'] ?? [],
+                    'notes' => $shareSummary['notes'] ?? [],
+                ])
+            </div>
+
+            <div class="ops-card-list mt-4">
+                @forelse (($shareSummary['events'] ?? []) as $event)
+                    <div class="ops-result-card">
+                        <div class="ops-result-card__header">
+                            <div>
+                                <p class="ops-result-card__title">{{ (string) ($event['title'] ?? '-') }}</p>
+                                <p class="ops-result-card__meta">
+                                    {{ (string) ($event['occurred_at'] ?? '-') }}
+                                    | channel={{ (string) ($event['channel'] ?? '-') }}
+                                    | share_id={{ (string) ($event['share_id'] ?? '-') }}
+                                </p>
+                            </div>
+                        </div>
+
+                        @if (($event['meta'] ?? []) !== [])
+                            <div class="flex flex-wrap gap-2">
+                                @foreach (($event['meta'] ?? []) as $meta)
+                                    <x-filament.ops.shared.status-pill state="gray" :label="(string) $meta" />
+                                @endforeach
+                            </div>
+                        @else
+                            <p class="ops-control-hint">No compact meta summary for this event.</p>
+                        @endif
+                    </div>
+                @empty
+                    <x-filament.ops.shared.empty-state
+                        eyebrow="Share engagement"
+                        icon="heroicon-o-share"
+                        title="No share engagement events yet"
+                        description="Share-linked events will appear here once the analytics trail exists."
+                    />
+                @endforelse
+            </div>
+        </x-filament::section>
+    </div>
+</x-filament-panels::page>

--- a/backend/tests/Feature/Ops/ResultsExplorerTest.php
+++ b/backend/tests/Feature/Ops/ResultsExplorerTest.php
@@ -1,0 +1,585 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Ops;
+
+use App\Filament\Ops\Resources\ResultResource\Pages\ListResults;
+use App\Models\AdminUser;
+use App\Models\Attempt;
+use App\Models\Organization;
+use App\Models\Permission;
+use App\Models\Result;
+use App\Models\Role;
+use App\Support\Rbac\PermissionNames;
+use Filament\Facades\Filament;
+use Filament\PanelRegistry;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Support\Str;
+use Livewire\Livewire;
+use Tests\TestCase;
+
+final class ResultsExplorerTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        Filament::setCurrentPanel(app(PanelRegistry::class)->get('ops'));
+    }
+
+    public function test_results_explorer_list_is_accessible_read_only_and_has_core_columns(): void
+    {
+        $admin = $this->createAdminWithPermissions([
+            PermissionNames::ADMIN_MENU_SUPPORT,
+            PermissionNames::ADMIN_OPS_READ,
+        ]);
+        $selectedOrg = $this->createOrganization('Selected Results Org');
+        $chain = $this->seedDiagnosticChain(orgId: 22);
+
+        $this->withSession($this->opsSession($admin, $selectedOrg))
+            ->actingAs($admin, (string) config('admin.guard', 'admin'))
+            ->get('/ops/results')
+            ->assertOk()
+            ->assertSee('Results Explorer')
+            ->assertDontSee('Create Result')
+            ->assertDontSee('Edit Result');
+
+        session($this->opsSession($admin, $selectedOrg));
+        $this->actingAs($admin, (string) config('admin.guard', 'admin'));
+
+        Livewire::test(ListResults::class)
+            ->assertOk()
+            ->assertCanSeeTableRecords([$chain['result']])
+            ->assertTableColumnExists('attempt_id')
+            ->assertTableColumnExists('scale_code')
+            ->assertTableColumnExists('type_code')
+            ->assertTableColumnExists('computed_at')
+            ->assertTableColumnExists('result_status')
+            ->assertTableColumnExists('latest_snapshot_status')
+            ->assertTableColumnExists('unlock_status')
+            ->assertTableColumnExists('attempt_locale')
+            ->assertTableColumnExists('org_id')
+            ->assertTableActionExists('view', null, $chain['result'])
+            ->assertTableActionDoesNotExist('edit', null, $chain['result'])
+            ->assertTableActionDoesNotExist('delete', null, $chain['result']);
+    }
+
+    public function test_results_explorer_detail_renders_seven_sections_hides_raw_payloads_and_shows_chain_links(): void
+    {
+        $admin = $this->createAdminWithPermissions([
+            PermissionNames::ADMIN_MENU_SUPPORT,
+            PermissionNames::ADMIN_OPS_READ,
+        ]);
+        $selectedOrg = $this->createOrganization('Result Detail Org');
+        $chain = $this->seedDiagnosticChain(orgId: 33, orderNo: 'ord_results_chain_001');
+
+        $this->withSession($this->opsSession($admin, $selectedOrg))
+            ->actingAs($admin, (string) config('admin.guard', 'admin'))
+            ->get('/ops/results/'.$chain['result']->getKey())
+            ->assertOk()
+            ->assertSee('Result Summary')
+            ->assertSee('Score / Axis Summary')
+            ->assertSee('Version / Diagnostics')
+            ->assertSee('Report Linkage')
+            ->assertSee('Attempt Linkage')
+            ->assertSee('Commerce / Unlock Linkage')
+            ->assertSee('Share / Engagement')
+            ->assertSee((string) $chain['result']->id)
+            ->assertSee((string) $chain['attempt_id'])
+            ->assertSee((string) $chain['order_no'])
+            ->assertSee((string) $chain['share_id'])
+            ->assertSee('Result page')
+            ->assertSee('Report page')
+            ->assertSee('Share page')
+            ->assertSee('Order diagnostics')
+            ->assertSee('Order Lookup')
+            ->assertSee('unlock: unlocked')
+            ->assertSee('valid')
+            ->assertSee('INTJ')
+            ->assertDontSee('result_json')
+            ->assertDontSee('scores_json')
+            ->assertDontSee('report_json')
+            ->assertDontSee('report_full_json')
+            ->assertDontSee((string) $chain['result_secret'])
+            ->assertDontSee((string) $chain['payment_secret'])
+            ->assertDontSee((string) $chain['report_secret']);
+    }
+
+    public function test_results_explorer_cross_org_search_works_for_order_no_share_id_result_id_and_attempt_id(): void
+    {
+        $admin = $this->createAdminWithPermissions([
+            PermissionNames::ADMIN_MENU_SUPPORT,
+            PermissionNames::ADMIN_OPS_READ,
+        ]);
+        $selectedOrg = $this->createOrganization('Current Support Org');
+        $local = $this->seedDiagnosticChain(orgId: (int) $selectedOrg->id, orderNo: 'ord_results_local_001');
+        $foreign = $this->seedDiagnosticChain(orgId: 77, orderNo: 'ord_results_cross_001');
+
+        session($this->opsSession($admin, $selectedOrg));
+        $this->actingAs($admin, (string) config('admin.guard', 'admin'));
+
+        Livewire::test(ListResults::class)
+            ->assertOk()
+            ->searchTable('ord_results_cross_001')
+            ->assertCanSeeTableRecords([$foreign['result']])
+            ->assertCanNotSeeTableRecords([$local['result']])
+            ->assertTableColumnStateSet('org_id', 77, $foreign['result'])
+            ->searchTable($foreign['share_id'])
+            ->assertCanSeeTableRecords([$foreign['result']])
+            ->searchTable((string) $foreign['result']->id)
+            ->assertCanSeeTableRecords([$foreign['result']])
+            ->searchTable((string) $foreign['attempt_id'])
+            ->assertCanSeeTableRecords([$foreign['result']]);
+    }
+
+    public function test_results_explorer_orphan_result_stays_visible_and_degrades_attempt_report_linkage(): void
+    {
+        $admin = $this->createAdminWithPermissions([
+            PermissionNames::ADMIN_MENU_SUPPORT,
+            PermissionNames::ADMIN_OPS_READ,
+        ]);
+        $selectedOrg = $this->createOrganization('Orphan Result Org');
+        $orphan = $this->seedOrphanResult(orgId: 66);
+
+        session($this->opsSession($admin, $selectedOrg));
+        $this->actingAs($admin, (string) config('admin.guard', 'admin'));
+
+        Livewire::test(ListResults::class)
+            ->assertOk()
+            ->searchTable((string) $orphan->id)
+            ->assertCanSeeTableRecords([$orphan]);
+
+        $this->withSession($this->opsSession($admin, $selectedOrg))
+            ->actingAs($admin, (string) config('admin.guard', 'admin'))
+            ->get('/ops/results/'.$orphan->getKey())
+            ->assertOk()
+            ->assertSee('orphan_result')
+            ->assertSee('Attempt row is missing for this result. Result search stays available by result_id and attempt_id.')
+            ->assertSee('Result page')
+            ->assertDontSee('Report page')
+            ->assertDontSee('Attempt Explorer')
+            ->assertSee('Report drill-through is unavailable while the attempt row is missing.');
+    }
+
+    private function createOrganization(string $name): Organization
+    {
+        return Organization::query()->create([
+            'name' => $name,
+            'owner_user_id' => random_int(1000, 9999),
+            'status' => 'active',
+            'domain' => Str::slug($name).'.example.test',
+            'timezone' => 'Asia/Shanghai',
+            'locale' => 'en',
+        ]);
+    }
+
+    /**
+     * @param  list<string>  $permissions
+     */
+    private function createAdminWithPermissions(array $permissions): AdminUser
+    {
+        $admin = AdminUser::query()->create([
+            'name' => 'ops_'.Str::lower(Str::random(6)),
+            'email' => 'ops_'.Str::lower(Str::random(6)).'@example.test',
+            'password' => bcrypt('secret'),
+            'is_active' => 1,
+        ]);
+
+        $role = Role::query()->create([
+            'name' => 'role_'.Str::lower(Str::random(8)),
+            'description' => null,
+        ]);
+
+        foreach ($permissions as $permissionName) {
+            $permission = Permission::query()->firstOrCreate(
+                ['name' => $permissionName],
+                ['description' => null],
+            );
+
+            $role->permissions()->syncWithoutDetaching([$permission->id]);
+        }
+
+        $admin->roles()->syncWithoutDetaching([$role->id]);
+
+        return $admin;
+    }
+
+    /**
+     * @return array{ops_org_id:int,ops_admin_totp_verified_user_id:int}
+     */
+    private function opsSession(AdminUser $admin, Organization $selectedOrg): array
+    {
+        return [
+            'ops_org_id' => (int) $selectedOrg->id,
+            'ops_admin_totp_verified_user_id' => (int) $admin->id,
+        ];
+    }
+
+    /**
+     * @return array{
+     *   result:Result,
+     *   attempt_id:string,
+     *   order_no:string,
+     *   share_id:string,
+     *   result_secret:string,
+     *   payment_secret:string,
+     *   report_secret:string
+     * }
+     */
+    private function seedDiagnosticChain(int $orgId, ?string $orderNo = null): array
+    {
+        $attemptId = (string) Str::uuid();
+        $resultId = (string) Str::uuid();
+        $shareId = (string) Str::uuid();
+        $orderId = (string) Str::uuid();
+        $paymentEventId = (string) Str::uuid();
+        $orderNo ??= 'ord_result_diag_'.Str::lower(Str::random(6));
+        $resultSecret = 'result-secret-'.Str::lower(Str::random(6));
+        $paymentSecret = 'payment-secret-'.Str::lower(Str::random(6));
+        $reportSecret = 'report-secret-'.Str::lower(Str::random(6));
+
+        $this->createAttempt([
+            'id' => $attemptId,
+            'org_id' => $orgId,
+            'user_id' => '1001',
+            'anon_id' => 'anon_results_chain',
+            'ticket_code' => 'FMT-'.strtoupper(substr(str_replace('-', '', $attemptId), 0, 8)),
+            'scale_code' => 'MBTI',
+            'scale_version' => 'v0.3',
+            'scale_uid' => '66666666-6666-4666-8666-666666666666',
+            'locale' => 'en',
+            'region' => 'US',
+            'channel' => 'web',
+            'pack_id' => 'MBTI',
+            'dir_version' => 'mbti_dir_2026_03',
+            'content_package_version' => 'content_2026_03',
+            'scoring_spec_version' => 'scoring_2026_03',
+            'norm_version' => 'norm_2026_03',
+            'result_json' => [
+                'type_code' => 'INTJ',
+                'public_hint' => true,
+            ],
+        ]);
+
+        DB::table('results')->insert([
+            'id' => $resultId,
+            'attempt_id' => $attemptId,
+            'org_id' => $orgId,
+            'scale_code' => 'MBTI',
+            'scale_version' => 'v0.3',
+            'scale_uid' => '66666666-6666-4666-8666-666666666666',
+            'type_code' => 'INTJ',
+            'scores_json' => json_encode(['EI' => 78, 'SN' => 62], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES),
+            'scores_pct' => json_encode(['EI' => 88, 'SN' => 74], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES),
+            'axis_states' => json_encode(['EI' => 'I', 'SN' => 'N'], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES),
+            'profile_version' => 'profile_2026_03',
+            'content_package_version' => 'content_2026_03',
+            'result_json' => json_encode(['type_code' => 'INTJ', 'private_secret' => $resultSecret], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES),
+            'pack_id' => 'MBTI',
+            'dir_version' => 'mbti_dir_2026_03',
+            'scoring_spec_version' => 'scoring_2026_03',
+            'report_engine_version' => 'v2.3',
+            'is_valid' => 1,
+            'computed_at' => now()->subMinutes(12),
+            'created_at' => now()->subMinutes(12),
+            'updated_at' => now()->subMinutes(11),
+        ]);
+
+        DB::table('report_snapshots')->insert([
+            'org_id' => $orgId,
+            'attempt_id' => $attemptId,
+            'order_no' => $orderNo,
+            'scale_code' => 'MBTI',
+            'scale_uid' => '66666666-6666-4666-8666-666666666666',
+            'pack_id' => 'MBTI',
+            'dir_version' => 'mbti_dir_2026_03',
+            'scoring_spec_version' => 'scoring_2026_03',
+            'report_engine_version' => 'v2.3',
+            'snapshot_version' => 'v1',
+            'report_json' => json_encode([
+                'locked' => false,
+                'access_level' => 'full',
+                'variant' => 'full',
+            ], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES),
+            'report_free_json' => json_encode(['variant' => 'free'], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES),
+            'report_full_json' => json_encode(['secret' => $reportSecret], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES),
+            'status' => 'ready',
+            'last_error' => null,
+            'created_at' => now()->subMinutes(10),
+            'updated_at' => now()->subMinutes(9),
+        ]);
+
+        $orderRow = [
+            'id' => $orderId,
+            'order_no' => $orderNo,
+            'org_id' => $orgId,
+            'user_id' => '1001',
+            'anon_id' => 'anon_results_chain',
+            'sku' => 'MBTI_FULL_REPORT',
+            'quantity' => 1,
+            'target_attempt_id' => $attemptId,
+            'amount_cents' => 2990,
+            'currency' => 'USD',
+            'status' => 'paid',
+            'provider' => 'stripe',
+            'paid_at' => now()->subMinutes(9),
+            'created_at' => now()->subMinutes(10),
+            'updated_at' => now()->subMinutes(8),
+        ];
+
+        if (Schema::hasColumn('orders', 'amount_total')) {
+            $orderRow['amount_total'] = 2990;
+        }
+        if (Schema::hasColumn('orders', 'amount_refunded')) {
+            $orderRow['amount_refunded'] = 0;
+        }
+        if (Schema::hasColumn('orders', 'item_sku')) {
+            $orderRow['item_sku'] = 'MBTI_FULL_REPORT';
+        }
+        if (Schema::hasColumn('orders', 'provider_order_id')) {
+            $orderRow['provider_order_id'] = 'pi_'.$orderNo;
+        }
+        if (Schema::hasColumn('orders', 'fulfilled_at')) {
+            $orderRow['fulfilled_at'] = now()->subMinutes(7);
+        }
+        if (Schema::hasColumn('orders', 'requested_sku')) {
+            $orderRow['requested_sku'] = 'MBTI_FULL_REPORT';
+        }
+        if (Schema::hasColumn('orders', 'effective_sku')) {
+            $orderRow['effective_sku'] = 'MBTI_FULL_REPORT';
+        }
+        if (Schema::hasColumn('orders', 'entitlement_id')) {
+            $orderRow['entitlement_id'] = 'ent_'.$orderNo;
+        }
+        if (Schema::hasColumn('orders', 'meta_json')) {
+            $orderRow['meta_json'] = json_encode(['claim_status' => 'claimed'], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES);
+        }
+
+        DB::table('orders')->insert($orderRow);
+
+        DB::table('payment_events')->insert([
+            'id' => $paymentEventId,
+            'org_id' => $orgId,
+            'provider' => 'stripe',
+            'provider_event_id' => 'evt_'.Str::lower(Str::random(8)),
+            'order_id' => $orderId,
+            'order_no' => $orderNo,
+            'event_type' => 'payment_intent.succeeded',
+            'signature_ok' => 1,
+            'status' => 'paid',
+            'attempts' => 1,
+            'last_error_code' => null,
+            'last_error_message' => null,
+            'processed_at' => now()->subMinutes(9),
+            'handled_at' => now()->subMinutes(9),
+            'handle_status' => 'processed',
+            'reason' => 'checkout_paid',
+            'requested_sku' => 'MBTI_FULL_REPORT',
+            'effective_sku' => 'MBTI_FULL_REPORT',
+            'entitlement_id' => 'ent_'.$orderNo,
+            'payload_json' => json_encode(['secret' => $paymentSecret], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES),
+            'payload_size_bytes' => 128,
+            'payload_sha256' => hash('sha256', $paymentSecret),
+            'payload_s3_key' => null,
+            'payload_excerpt' => null,
+            'received_at' => now()->subMinutes(9),
+            'created_at' => now()->subMinutes(9),
+            'updated_at' => now()->subMinutes(9),
+            'scale_uid' => '66666666-6666-4666-8666-666666666666',
+        ]);
+
+        DB::table('benefit_grants')->insert([
+            'id' => (string) Str::uuid(),
+            'org_id' => $orgId,
+            'user_id' => '1001',
+            'benefit_code' => 'MBTI_FULL_REPORT',
+            'scope' => 'attempt',
+            'attempt_id' => $attemptId,
+            'status' => 'active',
+            'expires_at' => now()->addDays(30),
+            'benefit_type' => 'report',
+            'benefit_ref' => 'benefit_'.$orderNo,
+            'order_no' => $orderNo,
+            'source_order_id' => $orderId,
+            'source_event_id' => $paymentEventId,
+            'meta_json' => json_encode(['claim_status' => 'claimed'], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES),
+            'created_at' => now()->subMinutes(8),
+            'updated_at' => now()->subMinutes(8),
+        ]);
+
+        DB::table('shares')->insert([
+            'id' => $shareId,
+            'attempt_id' => $attemptId,
+            'anon_id' => 'anon_results_chain',
+            'scale_code' => 'MBTI',
+            'scale_version' => 'v0.3',
+            'content_package_version' => 'content_2026_03',
+            'created_at' => now()->subMinutes(6),
+            'updated_at' => now()->subMinutes(5),
+            'scale_uid' => '66666666-6666-4666-8666-666666666666',
+        ]);
+
+        DB::table('attempt_submissions')->insert([
+            'id' => (string) Str::uuid(),
+            'org_id' => $orgId,
+            'attempt_id' => $attemptId,
+            'actor_user_id' => '1001',
+            'actor_anon_id' => 'anon_results_chain',
+            'dedupe_key' => 'result-chain-dedupe',
+            'mode' => 'sync',
+            'state' => 'succeeded',
+            'error_code' => null,
+            'error_message' => null,
+            'request_payload_json' => '{}',
+            'response_payload_json' => '{}',
+            'started_at' => now()->subMinutes(14),
+            'finished_at' => now()->subMinutes(13),
+            'created_at' => now()->subMinutes(14),
+            'updated_at' => now()->subMinutes(13),
+        ]);
+
+        DB::table('attempt_quality')->insert([
+            'attempt_id' => $attemptId,
+            'checks_json' => json_encode(['speeding' => false], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES),
+            'grade' => 'A',
+            'created_at' => now()->subMinutes(13),
+        ]);
+
+        DB::table('events')->insert([
+            [
+                'id' => (string) Str::uuid(),
+                'event_code' => 'share_created',
+                'user_id' => '1001',
+                'anon_id' => 'anon_results_chain',
+                'scale_code' => 'MBTI',
+                'scale_version' => 'v0.3',
+                'attempt_id' => $attemptId,
+                'channel' => 'web',
+                'region' => 'US',
+                'locale' => 'en',
+                'meta_json' => json_encode(['variant' => 'full', 'locked' => false], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES),
+                'occurred_at' => now()->subMinutes(5),
+                'created_at' => now()->subMinutes(5),
+                'updated_at' => now()->subMinutes(5),
+                'share_id' => $shareId,
+                'org_id' => $orgId,
+                'scale_uid' => '66666666-6666-4666-8666-666666666666',
+            ],
+            [
+                'id' => (string) Str::uuid(),
+                'event_code' => 'share_click',
+                'user_id' => '1001',
+                'anon_id' => 'anon_results_chain',
+                'scale_code' => 'MBTI',
+                'scale_version' => 'v0.3',
+                'attempt_id' => $attemptId,
+                'channel' => 'web',
+                'region' => 'US',
+                'locale' => 'en',
+                'meta_json' => json_encode(['stage' => 'landing', 'provider' => 'wechat'], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES),
+                'occurred_at' => now()->subMinutes(4),
+                'created_at' => now()->subMinutes(4),
+                'updated_at' => now()->subMinutes(4),
+                'share_id' => $shareId,
+                'org_id' => $orgId,
+                'scale_uid' => '66666666-6666-4666-8666-666666666666',
+            ],
+        ]);
+
+        DB::table('report_jobs')->insert([
+            'id' => (string) Str::uuid(),
+            'attempt_id' => $attemptId,
+            'status' => 'succeeded',
+            'tries' => 1,
+            'available_at' => now()->subMinutes(11),
+            'started_at' => now()->subMinutes(11),
+            'finished_at' => now()->subMinutes(10),
+            'failed_at' => null,
+            'last_error' => null,
+            'last_error_trace' => null,
+            'report_json' => '{}',
+            'meta' => '{}',
+            'created_at' => now()->subMinutes(11),
+            'updated_at' => now()->subMinutes(10),
+            'org_id' => $orgId,
+        ]);
+
+        return [
+            'result' => Result::query()->withoutGlobalScopes()->whereKey($resultId)->firstOrFail(),
+            'attempt_id' => $attemptId,
+            'order_no' => $orderNo,
+            'share_id' => $shareId,
+            'result_secret' => $resultSecret,
+            'payment_secret' => $paymentSecret,
+            'report_secret' => $reportSecret,
+        ];
+    }
+
+    private function seedOrphanResult(int $orgId): Result
+    {
+        $resultId = (string) Str::uuid();
+
+        DB::table('results')->insert([
+            'id' => $resultId,
+            'attempt_id' => (string) Str::uuid(),
+            'org_id' => $orgId,
+            'scale_code' => 'MBTI',
+            'scale_version' => 'v0.3',
+            'scale_uid' => '77777777-7777-4777-8777-777777777777',
+            'type_code' => 'ENTP',
+            'scores_json' => json_encode(['EI' => 70], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES),
+            'scores_pct' => json_encode(['EI' => 82], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES),
+            'axis_states' => json_encode(['EI' => 'E'], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES),
+            'profile_version' => 'profile_orphan',
+            'content_package_version' => 'content_orphan',
+            'result_json' => json_encode(['type_code' => 'ENTP', 'private_secret' => 'orphan-hidden'], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES),
+            'pack_id' => 'MBTI',
+            'dir_version' => 'mbti_dir_orphan',
+            'scoring_spec_version' => 'scoring_orphan',
+            'report_engine_version' => 'v2.3',
+            'is_valid' => 1,
+            'computed_at' => now()->subMinutes(3),
+            'created_at' => now()->subMinutes(3),
+            'updated_at' => now()->subMinutes(2),
+        ]);
+
+        return Result::query()->withoutGlobalScopes()->whereKey($resultId)->firstOrFail();
+    }
+
+    /**
+     * @param  array<string, mixed>  $overrides
+     */
+    private function createAttempt(array $overrides = []): Attempt
+    {
+        $attemptId = (string) ($overrides['id'] ?? Str::uuid());
+
+        return Attempt::query()->create(array_merge([
+            'id' => $attemptId,
+            'org_id' => 0,
+            'user_id' => '1001',
+            'anon_id' => 'anon-default',
+            'scale_code' => 'MBTI',
+            'scale_version' => 'v0.3',
+            'scale_uid' => '55555555-5555-4555-8555-555555555555',
+            'region' => 'US',
+            'locale' => 'en',
+            'question_count' => 93,
+            'answers_summary_json' => ['stage' => 'seed'],
+            'client_platform' => 'test',
+            'channel' => 'web',
+            'started_at' => now()->subMinutes(20),
+            'submitted_at' => now()->subMinutes(15),
+            'pack_id' => 'MBTI',
+            'dir_version' => 'mbti_dir_default',
+            'content_package_version' => 'content_default',
+            'scoring_spec_version' => 'scoring_default',
+            'norm_version' => 'norm_default',
+            'ticket_code' => 'FMT-'.strtoupper(substr(str_replace('-', '', $attemptId), 0, 8)),
+        ], $overrides));
+    }
+}


### PR DESCRIPTION
Summary
- add Results Explorer as the next Assessment Intelligence Console page
- provide a read-only support diagnostic surface rooted on results

What changed
- add a new Results Explorer resource/page in Filament Ops
- use results as the primary diagnostic result object
- expose report/attempt/order/share linkage summaries in a single detail view
- keep raw result and report payloads hidden by default
- add focused tests for read-only visibility, cross-org lookup behavior, orphan-result handling, and summary rendering

Design choices
- use results as the main root because it is the backend truth row for computed outcomes
- keep v1 read-only and avoid introducing a new analytics read model
- use scale_code as the primary first-phase assessment dimension
- keep the page under Support because it primarily serves support/ops diagnostics
- defer aggregate result analytics to later AIC phases

Why this PR is small and safe
- no schema changes
- no API changes
- no write-side behavior changes
- no frontend changes
- only the next support-facing assessment console entrypoint

Validation
- php artisan about
- php artisan route:list --path=ops --except-vendor
- php artisan migrate
- php artisan test --filter='(Result|Results|Assessment)'
- php artisan test --filter=ResultsExplorerTest
- php artisan filament:assets
- npm run build
- bash backend/scripts/ci_verify_mbti.sh

Notes
- php artisan test --filter='(Result|Results|Assessment)' still hits pre-existing EQ_60 sqlite failures caused by missing content_pack_activations in those tests; ResultsExplorerTest passes cleanly.
