### PR TITLE
feat(assessment-ops): add Report / PDF Center for support diagnostics

### DIFF
--- a/backend/app/Filament/Ops/Resources/ReportSnapshotResource.php
+++ b/backend/app/Filament/Ops/Resources/ReportSnapshotResource.php
@@ -1,0 +1,268 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Filament\Ops\Resources;
+
+use App\Filament\Ops\Resources\ReportSnapshotResource\Pages;
+use App\Filament\Ops\Resources\ReportSnapshotResource\Support\ReportSnapshotExplorerSupport;
+use App\Models\ReportSnapshot;
+use App\Support\Rbac\PermissionNames;
+use Filament\Forms;
+use Filament\Forms\Form;
+use Filament\Resources\Resource;
+use Filament\Tables;
+use Filament\Tables\Enums\FiltersLayout;
+use Filament\Tables\Table;
+use Illuminate\Database\Eloquent\Builder;
+
+class ReportSnapshotResource extends Resource
+{
+    protected static ?string $model = ReportSnapshot::class;
+
+    protected static ?string $slug = 'reports';
+
+    protected static ?string $navigationIcon = 'heroicon-o-document-text';
+
+    protected static ?string $navigationGroup = 'Support';
+
+    protected static ?string $navigationLabel = 'Report / PDF Center';
+
+    protected static ?string $modelLabel = 'Report Snapshot';
+
+    protected static ?string $pluralModelLabel = 'Report Snapshots';
+
+    protected static ?int $navigationSort = 10;
+
+    public static function getNavigationGroup(): ?string
+    {
+        return __('ops.group.support');
+    }
+
+    public static function getNavigationLabel(): string
+    {
+        return 'Report / PDF Center';
+    }
+
+    public static function form(Form $form): Form
+    {
+        return $form->schema([]);
+    }
+
+    public static function canViewAny(): bool
+    {
+        return self::canSupportAccess();
+    }
+
+    public static function canView($record): bool
+    {
+        return self::canSupportAccess();
+    }
+
+    public static function canCreate(): bool
+    {
+        return false;
+    }
+
+    public static function canEdit($record): bool
+    {
+        return false;
+    }
+
+    public static function canDelete($record): bool
+    {
+        return false;
+    }
+
+    public static function table(Table $table): Table
+    {
+        $support = app(ReportSnapshotExplorerSupport::class);
+
+        return $table
+            ->searchPlaceholder('attempt_id / order_no / share_id / scale_code')
+            ->searchDebounce('600ms')
+            ->recordUrl(fn (ReportSnapshot $record): string => static::getUrl('view', ['record' => $record]))
+            ->columns([
+                Tables\Columns\TextColumn::make('attempt_id')
+                    ->label('attempt_id')
+                    ->copyable()
+                    ->searchable(query: function (Builder $query, string $search) use ($support): void {
+                        $support->applySearch($query, $search);
+                    })
+                    ->sortable(),
+                Tables\Columns\TextColumn::make('order_no')
+                    ->label('order_no')
+                    ->copyable()
+                    ->sortable(),
+                Tables\Columns\TextColumn::make('scale_code')
+                    ->sortable(),
+                Tables\Columns\TextColumn::make('locale')
+                    ->sortable(query: fn (Builder $query, string $direction): Builder => $query->orderBy('locale', $direction)),
+                Tables\Columns\TextColumn::make('snapshot_status')
+                    ->label('snapshot_status')
+                    ->state(fn (ReportSnapshot $record): string => $support->snapshotStatus($record)['label'])
+                    ->badge()
+                    ->color(fn (ReportSnapshot $record): string => $support->snapshotStatus($record)['state']),
+                Tables\Columns\TextColumn::make('unlock_status')
+                    ->label('unlock_status')
+                    ->state(fn (ReportSnapshot $record): string => $support->unlockStatus($record)['label'])
+                    ->badge()
+                    ->color(fn (ReportSnapshot $record): string => $support->unlockStatus($record)['state']),
+                Tables\Columns\TextColumn::make('pdf_ready')
+                    ->label('pdf_ready')
+                    ->state(fn (ReportSnapshot $record): string => $support->pdfStatus($record)['label'])
+                    ->badge()
+                    ->color(fn (ReportSnapshot $record): string => $support->pdfStatus($record)['state']),
+                Tables\Columns\TextColumn::make('delivery_status')
+                    ->label('delivery_status')
+                    ->state(fn (ReportSnapshot $record): string => $support->deliveryStatus($record)['label'])
+                    ->badge()
+                    ->color(fn (ReportSnapshot $record): string => $support->deliveryStatus($record)['state']),
+                Tables\Columns\TextColumn::make('updated_at')
+                    ->dateTime()
+                    ->sortable(),
+                Tables\Columns\TextColumn::make('region')
+                    ->toggleable(isToggledHiddenByDefault: true),
+                Tables\Columns\TextColumn::make('report_engine_version')
+                    ->toggleable(isToggledHiddenByDefault: true),
+                Tables\Columns\TextColumn::make('last_delivery_email_sent_at')
+                    ->label('last_delivery_email_sent_at')
+                    ->dateTime()
+                    ->toggleable(isToggledHiddenByDefault: true),
+                Tables\Columns\IconColumn::make('contact_email_present')
+                    ->label('contact_email_present')
+                    ->state(fn (ReportSnapshot $record): bool => $support->contactEmailPresent($record))
+                    ->boolean()
+                    ->toggleable(isToggledHiddenByDefault: true),
+                Tables\Columns\TextColumn::make('share_id')
+                    ->label('share_id')
+                    ->copyable()
+                    ->toggleable(isToggledHiddenByDefault: true),
+                Tables\Columns\TextColumn::make('report_job_status')
+                    ->label('report_job_status')
+                    ->state(fn (ReportSnapshot $record): string => $support->reportJobStatus($record)['label'])
+                    ->badge()
+                    ->color(fn (ReportSnapshot $record): string => $support->reportJobStatus($record)['state'])
+                    ->toggleable(isToggledHiddenByDefault: true),
+                Tables\Columns\TextColumn::make('org_id')
+                    ->sortable(),
+            ])
+            ->defaultSort('updated_at', 'desc')
+            ->filters([
+                Tables\Filters\Filter::make('activity_window')
+                    ->label('Date')
+                    ->form([
+                        Forms\Components\DatePicker::make('from')->label('from'),
+                        Forms\Components\DatePicker::make('until')->label('until'),
+                    ])
+                    ->query(function (Builder $query, array $data): void {
+                        $from = trim((string) ($data['from'] ?? ''));
+                        $until = trim((string) ($data['until'] ?? ''));
+
+                        if ($from !== '') {
+                            $query->whereRaw('date(coalesce(report_snapshots.updated_at, report_snapshots.created_at)) >= ?', [$from]);
+                        }
+
+                        if ($until !== '') {
+                            $query->whereRaw('date(coalesce(report_snapshots.updated_at, report_snapshots.created_at)) <= ?', [$until]);
+                        }
+                    }),
+                Tables\Filters\SelectFilter::make('scale_code')
+                    ->options(fn (): array => $support->distinctSnapshotOptions('scale_code')),
+                Tables\Filters\SelectFilter::make('locale')
+                    ->options(fn (): array => $support->distinctAttemptOptions('locale'))
+                    ->query(function (Builder $query, array $data) use ($support): void {
+                        $support->applyAttemptFieldFilter($query, 'locale', $data['value'] ?? null);
+                    }),
+                Tables\Filters\SelectFilter::make('region')
+                    ->options(fn (): array => $support->distinctAttemptOptions('region'))
+                    ->query(function (Builder $query, array $data) use ($support): void {
+                        $support->applyAttemptFieldFilter($query, 'region', $data['value'] ?? null);
+                    }),
+                Tables\Filters\SelectFilter::make('snapshot_status')
+                    ->options(fn (): array => $support->distinctSnapshotOptions('status'))
+                    ->query(function (Builder $query, array $data) use ($support): void {
+                        $support->applySnapshotStatusFilter($query, $data['value'] ?? null);
+                    }),
+                Tables\Filters\TernaryFilter::make('pdf_ready_filter')
+                    ->label('PDF ready')
+                    ->queries(
+                        true: fn (Builder $query): Builder => tap($query, fn (Builder $builder) => $support->applyPdfReadyFilter($builder, true)),
+                        false: fn (Builder $query): Builder => tap($query, fn (Builder $builder) => $support->applyPdfReadyFilter($builder, false)),
+                        blank: fn (Builder $query): Builder => $query,
+                    ),
+                Tables\Filters\SelectFilter::make('unlock_status_filter')
+                    ->label('Unlock status')
+                    ->options([
+                        'unlocked' => 'unlocked',
+                        'paid_pending' => 'paid_pending',
+                        'payment_pending' => 'payment_pending',
+                        'refunded' => 'refunded',
+                        'no_order' => 'no_order',
+                    ])
+                    ->query(function (Builder $query, array $data) use ($support): void {
+                        $support->applyUnlockStatusFilter($query, $data['value'] ?? null);
+                    }),
+                Tables\Filters\TernaryFilter::make('has_order')
+                    ->label('Has order')
+                    ->queries(
+                        true: fn (Builder $query): Builder => tap($query, fn (Builder $builder) => $support->applyHasOrderFilter($builder, true)),
+                        false: fn (Builder $query): Builder => tap($query, fn (Builder $builder) => $support->applyHasOrderFilter($builder, false)),
+                        blank: fn (Builder $query): Builder => $query,
+                    ),
+                Tables\Filters\TernaryFilter::make('paid_success')
+                    ->label('Paid success')
+                    ->queries(
+                        true: fn (Builder $query): Builder => tap($query, fn (Builder $builder) => $support->applyPaidSuccessFilter($builder, true)),
+                        false: fn (Builder $query): Builder => tap($query, fn (Builder $builder) => $support->applyPaidSuccessFilter($builder, false)),
+                        blank: fn (Builder $query): Builder => $query,
+                    ),
+                Tables\Filters\SelectFilter::make('delivery_status_filter')
+                    ->label('Delivery status')
+                    ->options([
+                        'delivered' => 'delivered',
+                        'ready' => 'ready',
+                        'pending' => 'pending',
+                        'failed' => 'failed',
+                    ])
+                    ->query(function (Builder $query, array $data) use ($support): void {
+                        $support->applyDeliveryStatusFilter($query, $data['value'] ?? null);
+                    }),
+                Tables\Filters\SelectFilter::make('report_engine_version')
+                    ->options(fn (): array => $support->distinctSnapshotOptions('report_engine_version')),
+            ])
+            ->filtersLayout(FiltersLayout::AboveContentCollapsible)
+            ->filtersFormColumns(4)
+            ->actions([
+                Tables\Actions\ViewAction::make(),
+            ])
+            ->bulkActions([]);
+    }
+
+    public static function getPages(): array
+    {
+        return [
+            'index' => Pages\ListReportSnapshots::route('/'),
+            'view' => Pages\ViewReportSnapshot::route('/{record}'),
+        ];
+    }
+
+    public static function getEloquentQuery(): Builder
+    {
+        return app(ReportSnapshotExplorerSupport::class)->query();
+    }
+
+    private static function canSupportAccess(): bool
+    {
+        $guard = (string) config('admin.guard', 'admin');
+        $user = auth($guard)->user();
+
+        return is_object($user)
+            && method_exists($user, 'hasPermission')
+            && (
+                $user->hasPermission(PermissionNames::ADMIN_MENU_SUPPORT)
+                || $user->hasPermission(PermissionNames::ADMIN_OPS_READ)
+                || $user->hasPermission(PermissionNames::ADMIN_OWNER)
+            );
+    }
+}

--- a/backend/app/Filament/Ops/Resources/ReportSnapshotResource/Pages/ListReportSnapshots.php
+++ b/backend/app/Filament/Ops/Resources/ReportSnapshotResource/Pages/ListReportSnapshots.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Filament\Ops\Resources\ReportSnapshotResource\Pages;
+
+use App\Filament\Ops\Resources\Pages\Concerns\HasSharedListEmptyState;
+use App\Filament\Ops\Resources\ReportSnapshotResource;
+use Filament\Resources\Pages\ListRecords;
+
+class ListReportSnapshots extends ListRecords
+{
+    use HasSharedListEmptyState;
+
+    protected static string $resource = ReportSnapshotResource::class;
+
+    public function getTitle(): string
+    {
+        return 'Report / PDF Center';
+    }
+
+    public function getHeading(): string
+    {
+        return 'Report / PDF Center';
+    }
+
+    public function getSubheading(): ?string
+    {
+        return 'Snapshot-rooted support diagnostics for report delivery, PDF availability, claim/resend clues, and unlock linkage.';
+    }
+
+    protected function getHeaderActions(): array
+    {
+        return [];
+    }
+}

--- a/backend/app/Filament/Ops/Resources/ReportSnapshotResource/Pages/ViewReportSnapshot.php
+++ b/backend/app/Filament/Ops/Resources/ReportSnapshotResource/Pages/ViewReportSnapshot.php
@@ -1,0 +1,140 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Filament\Ops\Resources\ReportSnapshotResource\Pages;
+
+use App\Filament\Ops\Resources\ReportSnapshotResource;
+use App\Filament\Ops\Resources\ReportSnapshotResource\Support\ReportSnapshotExplorerSupport;
+use App\Models\ReportSnapshot;
+use Filament\Resources\Pages\Page;
+
+class ViewReportSnapshot extends Page
+{
+    protected static string $resource = ReportSnapshotResource::class;
+
+    protected static string $view = 'filament.ops.resources.reports.view-report-snapshot';
+
+    protected ?ReportSnapshot $recordModel = null;
+
+    /**
+     * @var array<string, array{label:string,state:string}>
+     */
+    public array $headline = [];
+
+    /**
+     * @var array{fields:list<array{label:string,value:string,hint:?string,kind:string,state:?string}>,notes:list<string>}
+     */
+    public array $snapshotSummary = ['fields' => [], 'notes' => []];
+
+    /**
+     * @var array{fields:list<array{label:string,value:string,hint:?string,kind:string,state:?string}>,notes:list<string>}
+     */
+    public array $pdfDeliverySummary = ['fields' => [], 'notes' => []];
+
+    /**
+     * @var array{fields:list<array{label:string,value:string,hint:?string,kind:string,state:?string}>,notes:list<string>}
+     */
+    public array $reportJobSummary = ['fields' => [], 'notes' => []];
+
+    /**
+     * @var array{fields:list<array{label:string,value:string,hint:?string,kind:string,state:?string}>,notes:list<string>}
+     */
+    public array $attemptSummary = ['fields' => [], 'notes' => []];
+
+    /**
+     * @var array{fields:list<array{label:string,value:string,hint:?string,kind:string,state:?string}>,notes:list<string>}
+     */
+    public array $resultSummary = ['fields' => [], 'notes' => []];
+
+    /**
+     * @var array{fields:list<array{label:string,value:string,hint:?string,kind:string,state:?string}>,notes:list<string>}
+     */
+    public array $commerceSummary = ['fields' => [], 'notes' => []];
+
+    /**
+     * @var array{fields:list<array{label:string,value:string,hint:?string,kind:string,state:?string}>,notes:list<string>}
+     */
+    public array $shareAccessSummary = ['fields' => [], 'notes' => []];
+
+    /**
+     * @var array{fields:list<array{label:string,value:string,hint:?string,kind:string,state:?string}>,notes:list<string>}
+     */
+    public array $exceptionSummary = ['fields' => [], 'notes' => []];
+
+    /**
+     * @var list<array{label:string,url:string,kind:string}>
+     */
+    public array $links = [];
+
+    public function mount(int|string $record): void
+    {
+        abort_unless(ReportSnapshotResource::canViewAny(), 403);
+
+        /** @var ReportSnapshot $resolved */
+        $resolved = ReportSnapshotResource::getEloquentQuery()->whereKey($record)->firstOrFail();
+
+        abort_unless(ReportSnapshotResource::canView($resolved), 403);
+
+        $this->recordModel = $resolved;
+
+        $detail = app(ReportSnapshotExplorerSupport::class)->buildDetail($this->getRecord());
+
+        $this->headline = $detail['headline'];
+        $this->snapshotSummary = $detail['snapshot_summary'];
+        $this->pdfDeliverySummary = $detail['pdf_delivery_summary'];
+        $this->reportJobSummary = $detail['report_job_summary'];
+        $this->attemptSummary = $detail['attempt_summary'];
+        $this->resultSummary = $detail['result_summary'];
+        $this->commerceSummary = $detail['commerce_summary'];
+        $this->shareAccessSummary = $detail['share_access_summary'];
+        $this->exceptionSummary = $detail['exception_summary'];
+        $this->links = $detail['links'];
+    }
+
+    public static function canAccess(array $parameters = []): bool
+    {
+        return ReportSnapshotResource::canViewAny();
+    }
+
+    public function getRecord(): ReportSnapshot
+    {
+        return $this->recordModel ?? throw new \LogicException('Report snapshot record has not been resolved.');
+    }
+
+    public function getTitle(): string
+    {
+        return 'Report / PDF Center';
+    }
+
+    public function getHeading(): string
+    {
+        return 'Report / PDF Center';
+    }
+
+    public function getSubheading(): ?string
+    {
+        return 'Read-only support diagnostics rooted on report snapshots.';
+    }
+
+    public function getBreadcrumb(): string
+    {
+        return (string) $this->getRecord()->getKey();
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    public function getBreadcrumbs(): array
+    {
+        return [
+            ReportSnapshotResource::getUrl() => ReportSnapshotResource::getBreadcrumb(),
+            $this->getBreadcrumb(),
+        ];
+    }
+
+    protected function getHeaderActions(): array
+    {
+        return [];
+    }
+}

--- a/backend/app/Filament/Ops/Resources/ReportSnapshotResource/Support/ReportSnapshotExplorerSupport.php
+++ b/backend/app/Filament/Ops/Resources/ReportSnapshotResource/Support/ReportSnapshotExplorerSupport.php
@@ -1,0 +1,1651 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Filament\Ops\Resources\ReportSnapshotResource\Support;
+
+use App\Filament\Ops\Resources\AttemptResource;
+use App\Filament\Ops\Resources\OrderResource;
+use App\Filament\Ops\Resources\ResultResource;
+use App\Filament\Ops\Support\StatusBadge;
+use App\Models\ReportSnapshot;
+use App\Services\Commerce\OrderManager;
+use App\Support\SchemaBaseline;
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Query\Builder as QueryBuilder;
+use Illuminate\Support\Carbon;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Str;
+
+final class ReportSnapshotExplorerSupport
+{
+    /**
+     * @return Builder<ReportSnapshot>
+     */
+    public function query(): Builder
+    {
+        $query = ReportSnapshot::query()
+            ->withoutGlobalScopes()
+            ->select('report_snapshots.*');
+
+        if (SchemaBaseline::hasTable('attempts')) {
+            foreach ([
+                'locale' => 'locale',
+                'region' => 'region',
+                'channel' => 'attempt_channel',
+                'ticket_code' => 'attempt_ticket_code',
+                'user_id' => 'attempt_user_id',
+                'anon_id' => 'attempt_anon_id',
+                'submitted_at' => 'attempt_submitted_at',
+            ] as $column => $alias) {
+                if (SchemaBaseline::hasColumn('attempts', $column)) {
+                    $query->selectSub($this->attemptField($column), $alias);
+                }
+            }
+        }
+
+        if (SchemaBaseline::hasTable('results')) {
+            foreach ([
+                'id' => 'result_id',
+                'type_code' => 'result_type_code',
+                'computed_at' => 'result_computed_at',
+            ] as $column => $alias) {
+                if (SchemaBaseline::hasColumn('results', $column)) {
+                    $query->selectSub($this->resultField($column), $alias);
+                }
+            }
+        }
+
+        if (SchemaBaseline::hasTable('orders')) {
+            foreach ([
+                'id' => 'order_id',
+                'status' => 'order_status',
+                'paid_at' => 'order_paid_at',
+                'updated_at' => 'order_updated_at',
+            ] as $column => $alias) {
+                if (SchemaBaseline::hasColumn('orders', $column)) {
+                    $query->selectSub($this->orderField($column), $alias);
+                }
+            }
+
+            $query->selectSub($this->orderExistsField(), 'has_order');
+
+            if (SchemaBaseline::hasColumn('orders', 'contact_email_hash')) {
+                $query->selectSub($this->contactEmailPresentField(), 'contact_email_present');
+            } else {
+                $query->selectRaw('0 as contact_email_present');
+            }
+        } else {
+            $query
+                ->selectRaw('0 as has_order')
+                ->selectRaw('0 as contact_email_present');
+        }
+
+        if (SchemaBaseline::hasTable('payment_events')) {
+            foreach ([
+                'status' => 'payment_status',
+                'processed_at' => 'payment_processed_at',
+                'provider_event_id' => 'payment_provider_event_id',
+            ] as $column => $alias) {
+                if (SchemaBaseline::hasColumn('payment_events', $column)) {
+                    $query->selectSub($this->paymentField($column), $alias);
+                }
+            }
+        }
+
+        if (SchemaBaseline::hasTable('benefit_grants')) {
+            foreach ([
+                'status' => 'benefit_status',
+                'benefit_code' => 'benefit_code',
+                'scope' => 'benefit_scope',
+                'expires_at' => 'benefit_expires_at',
+            ] as $column => $alias) {
+                if (SchemaBaseline::hasColumn('benefit_grants', $column)) {
+                    $query->selectSub($this->benefitField($column), $alias);
+                }
+            }
+
+            $query->selectSub($this->activeBenefitExistsField(), 'has_active_benefit_grant');
+        } else {
+            $query->selectRaw('0 as has_active_benefit_grant');
+        }
+
+        if (SchemaBaseline::hasTable('shares')) {
+            $query->selectSub($this->shareField('id'), 'share_id');
+        }
+
+        if (SchemaBaseline::hasTable('report_jobs')) {
+            foreach ([
+                'id' => 'report_job_id',
+                'status' => 'report_job_status',
+                'last_error' => 'report_job_last_error',
+                'updated_at' => 'report_job_updated_at',
+            ] as $column => $alias) {
+                if (SchemaBaseline::hasColumn('report_jobs', $column)) {
+                    $query->selectSub($this->reportJobField($column), $alias);
+                }
+            }
+        }
+
+        if (
+            SchemaBaseline::hasTable('email_outbox')
+            && SchemaBaseline::hasColumn('email_outbox', 'attempt_id')
+            && SchemaBaseline::hasColumn('email_outbox', 'sent_at')
+        ) {
+            $query->selectSub($this->deliveryEmailSentAtField(), 'last_delivery_email_sent_at');
+        }
+
+        return $query;
+    }
+
+    /**
+     * @param  Builder<ReportSnapshot>  $query
+     */
+    public function applySearch(Builder $query, string $search): void
+    {
+        $needle = trim($search);
+        if ($needle === '') {
+            return;
+        }
+
+        $like = '%'.$needle.'%';
+
+        $query->where(function (Builder $builder) use ($needle, $like): void {
+            $builder
+                ->where('report_snapshots.attempt_id', 'like', $like)
+                ->orWhere('report_snapshots.order_no', 'like', $like)
+                ->orWhere('report_snapshots.scale_code', 'like', $like);
+
+            if (SchemaBaseline::hasTable('shares')) {
+                $builder->orWhereExists(function (QueryBuilder $shareQuery) use ($like): void {
+                    $shareQuery
+                        ->selectRaw('1')
+                        ->from('shares')
+                        ->whereColumn('shares.attempt_id', 'report_snapshots.attempt_id')
+                        ->where('shares.id', 'like', $like);
+                });
+            }
+
+            if (SchemaBaseline::hasTable('orders') && SchemaBaseline::hasColumn('orders', 'target_attempt_id')) {
+                $builder->orWhereExists(function (QueryBuilder $orderQuery) use ($like): void {
+                    $orderQuery
+                        ->selectRaw('1')
+                        ->from('orders')
+                        ->where(function (QueryBuilder $nested): void {
+                            $this->applyOrderSnapshotCorrelation($nested);
+                        })
+                        ->where(function (QueryBuilder $nested) use ($like): void {
+                            $nested->where('orders.order_no', 'like', $like)
+                                ->orWhere('orders.target_attempt_id', 'like', $like);
+                        });
+                });
+            }
+
+            if (SchemaBaseline::hasTable('results')) {
+                $builder->orWhereExists(function (QueryBuilder $resultQuery) use ($needle, $like): void {
+                    $resultQuery
+                        ->selectRaw('1')
+                        ->from('results')
+                        ->whereColumn('results.attempt_id', 'report_snapshots.attempt_id')
+                        ->where(function (QueryBuilder $nested) use ($needle, $like): void {
+                            $nested->where('results.attempt_id', 'like', $like);
+
+                            if (SchemaBaseline::hasColumn('results', 'id')) {
+                                $nested->orWhere('results.id', 'like', $like);
+                            }
+
+                            if (SchemaBaseline::hasColumn('results', 'type_code')) {
+                                $nested->orWhere('results.type_code', 'like', $like);
+                            }
+                        });
+                });
+            }
+        });
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    public function distinctSnapshotOptions(string $column): array
+    {
+        if (! SchemaBaseline::hasColumn('report_snapshots', $column)) {
+            return [];
+        }
+
+        return DB::table('report_snapshots')
+            ->whereNotNull($column)
+            ->where($column, '!=', '')
+            ->distinct()
+            ->orderBy($column)
+            ->pluck($column, $column)
+            ->mapWithKeys(fn ($value): array => [(string) $value => (string) $value])
+            ->all();
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    public function distinctAttemptOptions(string $column): array
+    {
+        if (! SchemaBaseline::hasTable('attempts') || ! SchemaBaseline::hasColumn('attempts', $column)) {
+            return [];
+        }
+
+        return DB::table('attempts')
+            ->whereNotNull($column)
+            ->where($column, '!=', '')
+            ->distinct()
+            ->orderBy($column)
+            ->pluck($column, $column)
+            ->mapWithKeys(fn ($value): array => [(string) $value => (string) $value])
+            ->all();
+    }
+
+    /**
+     * @param  Builder<ReportSnapshot>  $query
+     */
+    public function applyAttemptFieldFilter(Builder $query, string $column, ?string $value): void
+    {
+        $needle = trim((string) $value);
+        if ($needle === '' || ! SchemaBaseline::hasTable('attempts') || ! SchemaBaseline::hasColumn('attempts', $column)) {
+            return;
+        }
+
+        $query->whereExists(function (QueryBuilder $attemptQuery) use ($column, $needle): void {
+            $attemptQuery
+                ->selectRaw('1')
+                ->from('attempts')
+                ->whereColumn('attempts.id', 'report_snapshots.attempt_id')
+                ->where('attempts.'.$column, $needle);
+        });
+    }
+
+    /**
+     * @param  Builder<ReportSnapshot>  $query
+     */
+    public function applySnapshotStatusFilter(Builder $query, ?string $value): void
+    {
+        $status = strtolower(trim((string) $value));
+        if ($status === '') {
+            return;
+        }
+
+        $query->whereRaw('lower(coalesce(report_snapshots.status, ?)) = ?', ['', $status]);
+    }
+
+    /**
+     * @param  Builder<ReportSnapshot>  $query
+     */
+    public function applyHasOrderFilter(Builder $query, bool $wanted): void
+    {
+        if (! SchemaBaseline::hasTable('orders')) {
+            if ($wanted) {
+                $query->whereRaw('1 = 0');
+            }
+
+            return;
+        }
+
+        if ($wanted) {
+            $query->whereExists($this->orderExistsField());
+
+            return;
+        }
+
+        $query->whereNotExists($this->orderExistsField());
+    }
+
+    /**
+     * @param  Builder<ReportSnapshot>  $query
+     */
+    public function applyPaidSuccessFilter(Builder $query, bool $wanted): void
+    {
+        $hasOrders = SchemaBaseline::hasTable('orders');
+        $hasPayments = SchemaBaseline::hasTable('payment_events');
+
+        if (! $hasOrders && ! $hasPayments) {
+            if ($wanted) {
+                $query->whereRaw('1 = 0');
+            }
+
+            return;
+        }
+
+        if ($wanted) {
+            $query->where(function (Builder $builder) use ($hasOrders, $hasPayments): void {
+                if ($hasOrders) {
+                    $builder->whereExists($this->paidOrderExistsField());
+                }
+
+                if ($hasPayments) {
+                    $method = $hasOrders ? 'orWhereExists' : 'whereExists';
+                    $builder->{$method}($this->paidPaymentExistsField());
+                }
+            });
+
+            return;
+        }
+
+        if ($hasOrders) {
+            $query->whereNotExists($this->paidOrderExistsField());
+        }
+
+        if ($hasPayments) {
+            $query->whereNotExists($this->paidPaymentExistsField());
+        }
+    }
+
+    /**
+     * @param  Builder<ReportSnapshot>  $query
+     */
+    public function applyPdfReadyFilter(Builder $query, bool $wanted): void
+    {
+        $query->where(function (Builder $builder) use ($wanted): void {
+            $readyStatuses = ['ready', 'full', 'completed'];
+
+            if ($wanted) {
+                $builder
+                    ->whereIn(DB::raw('lower(coalesce(report_snapshots.status, \'\'))'), $readyStatuses)
+                    ->where(function (Builder $nested): void {
+                        if (SchemaBaseline::hasTable('benefit_grants')) {
+                            $nested->whereExists($this->activeBenefitExistsField());
+                        }
+
+                        if (SchemaBaseline::hasTable('orders') || SchemaBaseline::hasTable('payment_events')) {
+                            $method = SchemaBaseline::hasTable('benefit_grants') ? 'orWhere' : 'where';
+                            $nested->{$method}(function (Builder $inner): void {
+                                $this->applyPaidSuccessFilter($inner, true);
+                            });
+                        }
+                    });
+
+                return;
+            }
+
+            $builder->where(function (Builder $nested) use ($readyStatuses): void {
+                $nested
+                    ->whereNotIn(DB::raw('lower(coalesce(report_snapshots.status, \'\'))'), $readyStatuses)
+                    ->orWhere(function (Builder $inner): void {
+                        $inner->whereIn(DB::raw('lower(coalesce(report_snapshots.status, \'\'))'), ['ready', 'full', 'completed']);
+
+                        if (SchemaBaseline::hasTable('benefit_grants')) {
+                            $inner->whereNotExists($this->activeBenefitExistsField());
+                        }
+
+                        if (SchemaBaseline::hasTable('orders') || SchemaBaseline::hasTable('payment_events')) {
+                            $this->applyPaidSuccessFilter($inner, false);
+                        }
+                    });
+            });
+        });
+    }
+
+    /**
+     * @param  Builder<ReportSnapshot>  $query
+     */
+    public function applyUnlockStatusFilter(Builder $query, ?string $value): void
+    {
+        $status = strtolower(trim((string) $value));
+        if ($status === '') {
+            return;
+        }
+
+        match ($status) {
+            'unlocked' => $query->whereExists($this->activeBenefitExistsField()),
+            'paid_pending' => $query
+                ->whereNotExists($this->activeBenefitExistsField())
+                ->where(function (Builder $builder): void {
+                    $this->applyPaidSuccessFilter($builder, true);
+                }),
+            'payment_pending' => $query
+                ->whereNotExists($this->activeBenefitExistsField())
+                ->where(function (Builder $builder): void {
+                    $this->applyHasOrderFilter($builder, true);
+                })
+                ->where(function (Builder $builder): void {
+                    $this->applyPaidSuccessFilter($builder, false);
+                }),
+            'refunded' => $query->where(function (Builder $builder): void {
+                if (SchemaBaseline::hasTable('orders')) {
+                    $builder->whereExists($this->refundedOrderExistsField());
+                }
+
+                if (SchemaBaseline::hasTable('payment_events')) {
+                    $method = SchemaBaseline::hasTable('orders') ? 'orWhereExists' : 'whereExists';
+                    $builder->{$method}($this->refundedPaymentExistsField());
+                }
+            }),
+            'no_order' => $query
+                ->whereNotExists($this->orderExistsField())
+                ->whereNotExists($this->activeBenefitExistsField()),
+            default => null,
+        };
+    }
+
+    /**
+     * @param  Builder<ReportSnapshot>  $query
+     */
+    public function applyDeliveryStatusFilter(Builder $query, ?string $value): void
+    {
+        $status = strtolower(trim((string) $value));
+        if ($status === '') {
+            return;
+        }
+
+        if ($status === 'delivered') {
+            if (! SchemaBaseline::hasTable('email_outbox')) {
+                $query->whereRaw('1 = 0');
+
+                return;
+            }
+
+            $query->whereExists($this->deliveryEmailExistsField());
+
+            return;
+        }
+
+        if ($status === 'failed') {
+            $query->where(function (Builder $builder): void {
+                $builder->whereIn(DB::raw('lower(coalesce(report_snapshots.status, \'\'))'), ['failed', 'error']);
+
+                if (SchemaBaseline::hasTable('report_jobs')) {
+                    $builder->orWhereExists($this->failedReportJobExistsField());
+                }
+            });
+
+            return;
+        }
+
+        if ($status === 'ready') {
+            if (SchemaBaseline::hasTable('email_outbox')) {
+                $query->whereNotExists($this->deliveryEmailExistsField());
+            }
+
+            $query->where(function (Builder $builder): void {
+                $builder->whereNotIn(DB::raw('lower(coalesce(report_snapshots.status, \'\'))'), ['failed', 'error']);
+
+                if (SchemaBaseline::hasTable('report_jobs')) {
+                    $builder->whereNotExists($this->failedReportJobExistsField());
+                }
+            });
+
+            $this->applyPdfReadyFilter($query, true);
+
+            return;
+        }
+
+        if ($status === 'pending') {
+            if (SchemaBaseline::hasTable('email_outbox')) {
+                $query->whereNotExists($this->deliveryEmailExistsField());
+            }
+
+            $query->where(function (Builder $builder): void {
+                $builder->whereNotIn(DB::raw('lower(coalesce(report_snapshots.status, \'\'))'), ['failed', 'error']);
+
+                if (SchemaBaseline::hasTable('report_jobs')) {
+                    $builder->whereNotExists($this->failedReportJobExistsField());
+                }
+            });
+
+            $this->applyPdfReadyFilter($query, false);
+        }
+    }
+
+    /**
+     * @return array{label:string,state:string}
+     */
+    public function snapshotStatus(object $snapshot): array
+    {
+        $status = strtolower(trim((string) ($snapshot->status ?? '')));
+        if ($status === '') {
+            $status = 'missing';
+        }
+
+        return [
+            'label' => $status,
+            'state' => StatusBadge::color($status),
+        ];
+    }
+
+    /**
+     * @return array{label:string,state:string}
+     */
+    public function unlockStatus(object $snapshot): array
+    {
+        if ($this->hasActiveGrant($snapshot)) {
+            return ['label' => 'unlocked', 'state' => 'success'];
+        }
+
+        if ($this->isRefundedLike((string) ($snapshot->order_status ?? '')) || $this->isRefundedLike((string) ($snapshot->payment_status ?? ''))) {
+            return ['label' => 'refunded', 'state' => 'danger'];
+        }
+
+        if ($this->isPaidLike((string) ($snapshot->order_status ?? '')) || $this->isPaidLike((string) ($snapshot->payment_status ?? ''))) {
+            return ['label' => 'paid_pending', 'state' => 'warning'];
+        }
+
+        if ($this->hasOrder($snapshot)) {
+            return ['label' => 'payment_pending', 'state' => 'gray'];
+        }
+
+        return ['label' => 'no_order', 'state' => 'gray'];
+    }
+
+    /**
+     * @return array{label:string,state:string}
+     */
+    public function pdfStatus(object $snapshot): array
+    {
+        if ($this->snapshotFailed($snapshot) || $this->reportJobFailed($snapshot)) {
+            return ['label' => 'failed', 'state' => 'danger'];
+        }
+
+        if ($this->pdfAvailable($snapshot)) {
+            return ['label' => 'ready', 'state' => 'success'];
+        }
+
+        if ($this->snapshotReady($snapshot)) {
+            return ['label' => 'unavailable', 'state' => 'gray'];
+        }
+
+        return ['label' => 'pending', 'state' => 'gray'];
+    }
+
+    /**
+     * @return array{label:string,state:string}
+     */
+    public function deliveryStatus(object $snapshot): array
+    {
+        $lastSentAt = trim((string) ($snapshot->last_delivery_email_sent_at ?? ''));
+        if ($lastSentAt !== '') {
+            return ['label' => 'delivered', 'state' => 'success'];
+        }
+
+        if ($this->snapshotFailed($snapshot) || $this->reportJobFailed($snapshot)) {
+            return ['label' => 'failed', 'state' => 'danger'];
+        }
+
+        if ($this->pdfAvailable($snapshot)) {
+            return ['label' => 'ready', 'state' => 'warning'];
+        }
+
+        return ['label' => 'pending', 'state' => 'gray'];
+    }
+
+    /**
+     * @return array{label:string,state:string}
+     */
+    public function reportJobStatus(object $snapshot): array
+    {
+        $status = strtolower(trim((string) ($snapshot->report_job_status ?? '')));
+        if ($status === '') {
+            return ['label' => 'missing', 'state' => 'gray'];
+        }
+
+        if ($status === 'succeeded') {
+            $status = 'succeeded';
+        }
+
+        return [
+            'label' => $status,
+            'state' => StatusBadge::color($status),
+        ];
+    }
+
+    public function contactEmailPresent(object $snapshot): bool
+    {
+        return StatusBadge::isTruthy($snapshot->contact_email_present ?? null);
+    }
+
+    /**
+     * @return array{
+     *     headline: array<string, array{label:string,state:string}>,
+     *     snapshot_summary: array{fields:list<array{label:string,value:string,hint:?string,kind:string,state:?string}>,notes:list<string>},
+     *     pdf_delivery_summary: array{fields:list<array{label:string,value:string,hint:?string,kind:string,state:?string}>,notes:list<string>},
+     *     report_job_summary: array{fields:list<array{label:string,value:string,hint:?string,kind:string,state:?string}>,notes:list<string>},
+     *     attempt_summary: array{fields:list<array{label:string,value:string,hint:?string,kind:string,state:?string}>,notes:list<string>},
+     *     result_summary: array{fields:list<array{label:string,value:string,hint:?string,kind:string,state:?string}>,notes:list<string>},
+     *     commerce_summary: array{fields:list<array{label:string,value:string,hint:?string,kind:string,state:?string}>,notes:list<string>},
+     *     share_access_summary: array{fields:list<array{label:string,value:string,hint:?string,kind:string,state:?string}>,notes:list<string>},
+     *     exception_summary: array{fields:list<array{label:string,value:string,hint:?string,kind:string,state:?string}>,notes:list<string>},
+     *     links: list<array{label:string,url:string,kind:string}>
+     * }
+     */
+    public function buildDetail(ReportSnapshot $snapshot): array
+    {
+        $attemptId = trim((string) $snapshot->getKey());
+        $snapshotRow = DB::table('report_snapshots')->where('attempt_id', $attemptId)->first() ?? $snapshot;
+        $attempt = $this->attempt($attemptId);
+        $result = $this->result($attemptId);
+        $order = $this->order((string) ($snapshotRow->order_no ?? $snapshot->order_no ?? ''), $attemptId);
+        $orderNo = trim((string) (($order->order_no ?? null) ?: ($snapshotRow->order_no ?? $snapshot->order_no ?? '')));
+        $payment = $this->payment($orderNo);
+        $grants = $this->benefitGrants($orderNo, $attemptId);
+        $activeGrant = $this->activeGrant($grants);
+        $share = $this->share($attemptId);
+        $reportJob = $this->reportJob($attemptId);
+        $delivery = $order !== null ? app(OrderManager::class)->presentOrderDelivery($order) : [];
+        $deliveryState = is_array($delivery['delivery'] ?? null) ? $delivery['delivery'] : [];
+        $attribution = $order !== null ? app(OrderManager::class)->extractAttributionFromOrder($order) : [];
+        $reportData = $this->arrayFromMixed($snapshot->report_json ?? ($snapshotRow->report_json ?? null));
+        $shareId = trim((string) (($share->id ?? null) ?: ($attribution['share_id'] ?? '')));
+        $events = $this->recentEvents($attemptId, $shareId);
+        $latestEvent = $events[0] ?? null;
+        $lastDeliveryEmailSentAt = trim((string) (($deliveryState['last_delivery_email_sent_at'] ?? null) ?: $this->lastDeliveryEmailSentAt($attemptId, $orderNo)));
+        $snapshotDisplay = (object) array_merge($snapshot->getAttributes(), [
+            'order_status' => $order->status ?? ($snapshot->order_status ?? null),
+            'payment_status' => $payment->status ?? ($snapshot->payment_status ?? null),
+            'has_active_benefit_grant' => $activeGrant !== null ? 1 : ($snapshot->has_active_benefit_grant ?? 0),
+            'report_job_status' => $reportJob->status ?? ($snapshot->report_job_status ?? null),
+            'last_delivery_email_sent_at' => $lastDeliveryEmailSentAt !== '' ? $lastDeliveryEmailSentAt : ($snapshot->last_delivery_email_sent_at ?? null),
+            'contact_email_present' => ($deliveryState['contact_email_present'] ?? null) ?? $snapshot->contact_email_present ?? ($this->orderHasContactEmailHash($order) ? 1 : 0),
+            'has_order' => $order !== null ? 1 : ($snapshot->has_order ?? 0),
+        ]);
+
+        $headline = [
+            'snapshot' => $this->snapshotStatus($snapshotDisplay),
+            'unlock' => $this->unlockStatus($snapshotDisplay),
+            'pdf' => $this->pdfStatus($snapshotDisplay),
+            'delivery' => $this->deliveryStatus($snapshotDisplay),
+            'job' => $this->reportJobStatus($snapshotDisplay),
+        ];
+
+        $resultId = ($result->id ?? null) !== null ? (string) $result->id : null;
+        $locale = (string) (($attempt->locale ?? null) ?: ($snapshot->locale ?? ''));
+        $region = (string) (($attempt->region ?? null) ?: ($snapshot->region ?? ''));
+        $reportEndpoint = $attemptId !== '' ? '/api/v0.3/attempts/'.urlencode($attemptId).'/report' : null;
+        $pdfEndpoint = $attemptId !== '' ? '/api/v0.3/attempts/'.urlencode($attemptId).'/report.pdf' : null;
+        $pdfAvailable = $this->pdfAvailable($snapshotDisplay);
+        $shareCreatedAt = $this->formatTimestamp($share->created_at ?? null);
+        $orderMeta = $this->arrayFromMixed($order->meta_json ?? null);
+        $benefitMeta = $this->arrayFromMixed($activeGrant->meta_json ?? null);
+        $claimStatus = $benefitMeta['claim_status'] ?? $orderMeta['claim_status'] ?? null;
+        $lastActivityAt = $this->latestTimestamp([
+            $snapshotRow->updated_at ?? null,
+            $order->updated_at ?? null,
+            $result->computed_at ?? null,
+            $reportJob->updated_at ?? null,
+            $lastDeliveryEmailSentAt,
+        ]);
+
+        $snapshotSummary = [
+            'fields' => [
+                $this->field('attempt_id', $attemptId),
+                $this->field('order_no', $orderNo !== '' ? $orderNo : '-'),
+                $this->field('org_id', $this->stringOrDash($snapshotRow->org_id ?? $snapshot->org_id ?? null)),
+                $this->field('scale_code', $this->stringOrDash($snapshotRow->scale_code ?? $snapshot->scale_code ?? null)),
+                $this->field('locale', $this->stringOrDash($locale)),
+                $this->field('region', $this->stringOrDash($region)),
+                $this->pillField('snapshot_status', $headline['snapshot']['label'], $headline['snapshot']['state']),
+                $this->field('report_engine_version', $this->stringOrDash($snapshotRow->report_engine_version ?? $snapshot->report_engine_version ?? null)),
+                $this->field('variant', $this->stringOrDash($reportData['variant'] ?? null)),
+                $this->field('access_level', $this->stringOrDash($reportData['access_level'] ?? null)),
+                $this->pillField(
+                    'locked',
+                    StatusBadge::isTruthy($reportData['locked'] ?? null) ? 'locked' : 'unlocked',
+                    StatusBadge::isTruthy($reportData['locked'] ?? null) ? 'warning' : 'success'
+                ),
+                $this->field('last_error', $this->shortText($snapshotRow->last_error ?? null)),
+                $this->field('updated_at', $this->formatTimestamp($snapshotRow->updated_at ?? $snapshot->updated_at ?? null)),
+                $this->field('last_activity_at', $lastActivityAt),
+            ],
+            'notes' => [
+                'Raw report payloads stay hidden by default.',
+            ],
+        ];
+
+        $pdfDeliveryNotes = ['Claim/resend clues are read-only here. This page does not trigger delivery writes.'];
+        if ($order === null) {
+            $pdfDeliveryNotes[] = 'No linked order row was found, so claim/resend eligibility may remain unavailable.';
+        }
+
+        $pdfDeliverySummary = [
+            'fields' => [
+                $this->pillField('pdf_ready', $headline['pdf']['label'], $headline['pdf']['state']),
+                $this->pillField('pdf_available', $pdfAvailable ? 'available' : 'unavailable', $pdfAvailable ? 'success' : 'gray'),
+                $this->field('report_endpoint', $this->stringOrDash($reportEndpoint)),
+                $this->field('report_pdf_endpoint', $this->stringOrDash($pdfEndpoint)),
+                $this->field('last_delivery_email_sent_at', $this->stringOrDash($lastDeliveryEmailSentAt)),
+                $this->pillField(
+                    'contact_email_present',
+                    (($deliveryState['contact_email_present'] ?? false) || $this->orderHasContactEmailHash($order)) ? 'present' : 'missing',
+                    (($deliveryState['contact_email_present'] ?? false) || $this->orderHasContactEmailHash($order)) ? 'success' : 'gray'
+                ),
+                $this->pillField(
+                    'can_resend',
+                    ($deliveryState['can_resend'] ?? false) ? 'eligible' : 'not_eligible',
+                    ($deliveryState['can_resend'] ?? false) ? 'warning' : 'gray'
+                ),
+                $this->pillField(
+                    'can_request_claim_email',
+                    ($deliveryState['can_request_claim_email'] ?? false) ? 'available' : 'not_available',
+                    ($deliveryState['can_request_claim_email'] ?? false) ? 'warning' : 'gray'
+                ),
+                $this->pillField('delivery_status', $headline['delivery']['label'], $headline['delivery']['state']),
+            ],
+            'notes' => $pdfDeliveryNotes,
+        ];
+
+        $reportJobNotes = ['Report jobs stay auxiliary. report_snapshots remain the persisted delivery object read by access flows.'];
+        if (filled($reportJob->last_error ?? null)) {
+            $reportJobNotes[] = 'Only a compact report job error summary is shown here.';
+        }
+
+        $reportJobSummary = [
+            'fields' => [
+                $this->pillField('report_job', $reportJob !== null ? 'present' : 'missing', $reportJob !== null ? 'warning' : 'gray'),
+                $this->pillField('report_job_status', $headline['job']['label'], $headline['job']['state']),
+                $this->field('report_job_id', $this->stringOrDash($reportJob->id ?? null)),
+                $this->field('tries', $this->stringOrDash($reportJob->tries ?? null)),
+                $this->field('started_at', $this->formatTimestamp($reportJob->started_at ?? null)),
+                $this->field('finished_at', $this->formatTimestamp($reportJob->finished_at ?? null)),
+                $this->field('failed_at', $this->formatTimestamp($reportJob->failed_at ?? null)),
+                $this->field('last_error', $this->shortText($reportJob->last_error ?? null)),
+            ],
+            'notes' => $reportJobNotes,
+        ];
+
+        $attemptNotes = ['Attempt linkage stays cross-org and read-only in ops/admin context.'];
+        if ($attempt === null) {
+            $attemptNotes[] = 'Attempt row is missing for this snapshot. attempt_id search remains available.';
+        }
+
+        $attemptSummary = [
+            'fields' => [
+                $this->pillField('attempt', $attempt !== null ? 'present' : 'missing', $attempt !== null ? 'success' : 'danger'),
+                $this->field('attempt_id', $attemptId),
+                $this->pillField(
+                    'submitted',
+                    filled($attempt->submitted_at ?? null) ? 'submitted' : 'pending',
+                    filled($attempt->submitted_at ?? null) ? 'success' : 'gray'
+                ),
+                $this->field('submitted_at', $this->formatTimestamp($attempt->submitted_at ?? null)),
+                $this->field('ticket_code', $this->stringOrDash($attempt->ticket_code ?? null)),
+                $this->field('user_id', $this->stringOrDash($attempt->user_id ?? null)),
+                $this->field('anon_id', $this->stringOrDash($attempt->anon_id ?? null)),
+                $this->field('channel', $this->stringOrDash($attempt->channel ?? null)),
+            ],
+            'notes' => $attemptNotes,
+        ];
+
+        $resultNotes = ['Raw result payloads stay hidden. This section only shows linkage and compact timing/type breadcrumbs.'];
+        if ($result === null) {
+            $resultNotes[] = 'No result row is linked to this snapshot yet.';
+        }
+
+        $resultSummary = [
+            'fields' => [
+                $this->pillField('result', $result !== null ? 'present' : 'missing', $result !== null ? 'success' : 'gray'),
+                $this->field('result_id', $this->stringOrDash($result->id ?? null)),
+                $this->field('type_code', $this->stringOrDash($result->type_code ?? null)),
+                $this->field('computed_at', $this->formatTimestamp($result->computed_at ?? null)),
+                $this->field('scale_code', $this->stringOrDash($result->scale_code ?? null)),
+            ],
+            'notes' => $resultNotes,
+        ];
+
+        $commerceNotes = [
+            'Unlock truth is derived from benefit_grants first, not from report_jobs or order status alone.',
+            'Raw payment payloads and forensics stay hidden.',
+        ];
+        if ($order === null) {
+            $commerceNotes[] = 'No linked order row was found for this snapshot chain.';
+        }
+
+        $commerceSummary = [
+            'fields' => [
+                $this->pillField('has_order', $order !== null ? 'present' : 'missing', $order !== null ? 'success' : 'gray'),
+                $this->field('order_no', $orderNo !== '' ? $orderNo : '-'),
+                $this->pillField('order_status', $this->stringOrDash($order->status ?? null), StatusBadge::color($order->status ?? null)),
+                $this->pillField('payment_status', $this->stringOrDash($payment->status ?? null), StatusBadge::color($payment->status ?? null)),
+                $this->field('payment_event', $this->stringOrDash($payment->provider_event_id ?? null), $this->stringOrDash($payment->event_type ?? null)),
+                $this->pillField('active_benefit_grant', $activeGrant !== null ? 'present' : 'missing', $activeGrant !== null ? 'success' : 'gray'),
+                $this->field('benefit_code', $this->stringOrDash($activeGrant->benefit_code ?? null)),
+                $this->field('benefit_scope', $this->stringOrDash($activeGrant->scope ?? null)),
+                $this->field('benefit_expires_at', $this->formatTimestamp($activeGrant->expires_at ?? null)),
+                $this->pillField('unlock_status', $headline['unlock']['label'], $headline['unlock']['state']),
+                $this->field('paid_at', $this->formatTimestamp($order->paid_at ?? null)),
+                $this->field('claim_status', $this->stringOrDash($claimStatus)),
+            ],
+            'notes' => $commerceNotes,
+        ];
+
+        $shareNotes = ['Share/access traces stay summarized only. Raw events and raw delivery meta stay hidden.'];
+        if ($shareId === '') {
+            $shareNotes[] = 'No share row or attribution share_id was found for this snapshot yet.';
+        }
+
+        $shareAccessSummary = [
+            'fields' => [
+                $this->field('share_id', $shareId !== '' ? $shareId : '-'),
+                $this->field('share_created_at', $shareCreatedAt),
+                $this->field('entrypoint', $this->stringOrDash($attribution['entrypoint'] ?? null)),
+                $this->field('share_click_id', $this->stringOrDash($attribution['share_click_id'] ?? null)),
+                $this->field('utm', $this->utmSummary($attribution['utm'] ?? null)),
+                $this->field('latest_event', $this->stringOrDash($latestEvent['title'] ?? null)),
+                $this->field('latest_channel', $this->stringOrDash($latestEvent['channel'] ?? null)),
+            ],
+            'notes' => $shareNotes,
+        ];
+
+        $exceptionSummary = [
+            'fields' => [
+                $this->pillField(
+                    'grant_exists_but_snapshot_missing',
+                    $activeGrant !== null && ! $this->snapshotPresent($snapshotRow) ? 'flagged' : 'clear',
+                    $activeGrant !== null && ! $this->snapshotPresent($snapshotRow) ? 'danger' : 'success'
+                ),
+                $this->pillField(
+                    'snapshot_failed',
+                    $this->snapshotFailed($snapshotDisplay) ? 'flagged' : 'clear',
+                    $this->snapshotFailed($snapshotDisplay) ? 'danger' : 'success'
+                ),
+                $this->pillField(
+                    'report_job_failed',
+                    $this->reportJobFailed($snapshotDisplay) ? 'flagged' : 'clear',
+                    $this->reportJobFailed($snapshotDisplay) ? 'danger' : 'success'
+                ),
+                $this->pillField(
+                    'pdf_unavailable',
+                    $headline['pdf']['label'] === 'unavailable' ? 'flagged' : 'clear',
+                    $headline['pdf']['label'] === 'unavailable' ? 'warning' : 'success'
+                ),
+                $this->pillField(
+                    'delivery_pending',
+                    $headline['delivery']['label'] === 'pending' ? 'flagged' : 'clear',
+                    $headline['delivery']['label'] === 'pending' ? 'warning' : 'success'
+                ),
+                $this->pillField(
+                    'paid_but_no_unlock',
+                    $headline['unlock']['label'] === 'paid_pending' ? 'flagged' : 'clear',
+                    $headline['unlock']['label'] === 'paid_pending' ? 'warning' : 'success'
+                ),
+            ],
+            'notes' => ['These diagnostics are explicit v1 support rules, not a remediation console or analytics read model.'],
+        ];
+
+        return [
+            'headline' => $headline,
+            'snapshot_summary' => $snapshotSummary,
+            'pdf_delivery_summary' => $pdfDeliverySummary,
+            'report_job_summary' => $reportJobSummary,
+            'attempt_summary' => $attemptSummary,
+            'result_summary' => $resultSummary,
+            'commerce_summary' => $commerceSummary,
+            'share_access_summary' => $shareAccessSummary,
+            'exception_summary' => $exceptionSummary,
+            'links' => $this->buildLinks(
+                $attemptId,
+                $orderNo !== '' ? $orderNo : null,
+                $shareId !== '' ? $shareId : null,
+                $locale,
+                ($order->id ?? null) !== null ? (string) $order->id : null,
+                $resultId,
+                $pdfEndpoint
+            ),
+        ];
+    }
+
+    private function attemptField(string $column): QueryBuilder
+    {
+        return DB::table('attempts')
+            ->select($column)
+            ->whereColumn('attempts.id', 'report_snapshots.attempt_id')
+            ->limit(1);
+    }
+
+    private function resultField(string $column): QueryBuilder
+    {
+        return DB::table('results')
+            ->select($column)
+            ->whereColumn('results.attempt_id', 'report_snapshots.attempt_id')
+            ->orderByRaw('coalesce(computed_at, updated_at, created_at) desc')
+            ->limit(1);
+    }
+
+    private function orderField(string $column): QueryBuilder
+    {
+        return DB::table('orders')
+            ->select($column)
+            ->where(function (QueryBuilder $builder): void {
+                $this->applyOrderSnapshotCorrelation($builder);
+            })
+            ->orderByRaw("case when lower(coalesce(status, '')) in ('paid', 'fulfilled') then 0 else 1 end")
+            ->orderByRaw('coalesce(paid_at, updated_at, created_at) desc')
+            ->limit(1);
+    }
+
+    private function orderExistsField(): QueryBuilder
+    {
+        return DB::table('orders')
+            ->selectRaw('1')
+            ->where(function (QueryBuilder $builder): void {
+                $this->applyOrderSnapshotCorrelation($builder);
+            })
+            ->limit(1);
+    }
+
+    private function contactEmailPresentField(): QueryBuilder
+    {
+        return DB::table('orders')
+            ->selectRaw("case when trim(coalesce(contact_email_hash, '')) <> '' then 1 else 0 end")
+            ->where(function (QueryBuilder $builder): void {
+                $this->applyOrderSnapshotCorrelation($builder);
+            })
+            ->orderByRaw("case when lower(coalesce(status, '')) in ('paid', 'fulfilled') then 0 else 1 end")
+            ->orderByRaw('coalesce(paid_at, updated_at, created_at) desc')
+            ->limit(1);
+    }
+
+    private function paymentField(string $column): QueryBuilder
+    {
+        return DB::table('payment_events')
+            ->select($column)
+            ->whereColumn('payment_events.order_no', 'report_snapshots.order_no')
+            ->orderByRaw('coalesce(processed_at, handled_at, updated_at, created_at) desc')
+            ->limit(1);
+    }
+
+    private function benefitField(string $column): QueryBuilder
+    {
+        return DB::table('benefit_grants')
+            ->select($column)
+            ->where(function (QueryBuilder $builder): void {
+                $this->applyBenefitSnapshotCorrelation($builder);
+            })
+            ->orderByRaw("case when lower(coalesce(status, '')) = 'active' then 0 else 1 end")
+            ->orderByRaw('coalesce(updated_at, created_at) desc')
+            ->limit(1);
+    }
+
+    private function activeBenefitExistsField(): QueryBuilder
+    {
+        return DB::table('benefit_grants')
+            ->selectRaw('1')
+            ->where('benefit_grants.status', 'active')
+            ->where(function (QueryBuilder $builder): void {
+                $this->applyBenefitSnapshotCorrelation($builder);
+            })
+            ->limit(1);
+    }
+
+    private function shareField(string $column): QueryBuilder
+    {
+        return DB::table('shares')
+            ->select($column)
+            ->whereColumn('shares.attempt_id', 'report_snapshots.attempt_id')
+            ->orderByDesc('created_at')
+            ->limit(1);
+    }
+
+    private function reportJobField(string $column): QueryBuilder
+    {
+        return DB::table('report_jobs')
+            ->select($column)
+            ->whereColumn('report_jobs.attempt_id', 'report_snapshots.attempt_id')
+            ->orderByRaw('coalesce(updated_at, created_at) desc')
+            ->limit(1);
+    }
+
+    private function deliveryEmailSentAtField(): QueryBuilder
+    {
+        $query = DB::table('email_outbox')
+            ->select('sent_at')
+            ->whereColumn('email_outbox.attempt_id', 'report_snapshots.attempt_id')
+            ->whereNotNull('sent_at');
+
+        if (SchemaBaseline::hasColumn('email_outbox', 'template')) {
+            $query->whereIn('template', ['payment_success', 'report_claim']);
+        } elseif (SchemaBaseline::hasColumn('email_outbox', 'template_key')) {
+            $query->whereIn('template_key', ['payment_success', 'report_claim']);
+        }
+
+        return $query
+            ->orderByDesc('sent_at')
+            ->limit(1);
+    }
+
+    private function deliveryEmailExistsField(): QueryBuilder
+    {
+        $query = DB::table('email_outbox')
+            ->selectRaw('1')
+            ->whereColumn('email_outbox.attempt_id', 'report_snapshots.attempt_id')
+            ->whereNotNull('sent_at');
+
+        if (SchemaBaseline::hasColumn('email_outbox', 'template')) {
+            $query->whereIn('template', ['payment_success', 'report_claim']);
+        } elseif (SchemaBaseline::hasColumn('email_outbox', 'template_key')) {
+            $query->whereIn('template_key', ['payment_success', 'report_claim']);
+        }
+
+        return $query->limit(1);
+    }
+
+    private function paidOrderExistsField(): QueryBuilder
+    {
+        return DB::table('orders')
+            ->selectRaw('1')
+            ->where(function (QueryBuilder $builder): void {
+                $this->applyOrderSnapshotCorrelation($builder);
+            })
+            ->whereIn(DB::raw('lower(coalesce(orders.status, \'\'))'), ['paid', 'fulfilled', 'complete', 'completed'])
+            ->limit(1);
+    }
+
+    private function refundedOrderExistsField(): QueryBuilder
+    {
+        return DB::table('orders')
+            ->selectRaw('1')
+            ->where(function (QueryBuilder $builder): void {
+                $this->applyOrderSnapshotCorrelation($builder);
+            })
+            ->whereRaw("lower(coalesce(orders.status, '')) like '%refund%'")
+            ->limit(1);
+    }
+
+    private function paidPaymentExistsField(): QueryBuilder
+    {
+        return DB::table('payment_events')
+            ->selectRaw('1')
+            ->whereColumn('payment_events.order_no', 'report_snapshots.order_no')
+            ->whereIn(DB::raw('lower(coalesce(payment_events.status, \'\'))'), ['paid', 'succeeded', 'fulfilled', 'complete', 'completed'])
+            ->limit(1);
+    }
+
+    private function refundedPaymentExistsField(): QueryBuilder
+    {
+        return DB::table('payment_events')
+            ->selectRaw('1')
+            ->whereColumn('payment_events.order_no', 'report_snapshots.order_no')
+            ->whereRaw("lower(coalesce(payment_events.status, '')) like '%refund%'")
+            ->limit(1);
+    }
+
+    private function failedReportJobExistsField(): QueryBuilder
+    {
+        return DB::table('report_jobs')
+            ->selectRaw('1')
+            ->whereColumn('report_jobs.attempt_id', 'report_snapshots.attempt_id')
+            ->whereIn(DB::raw('lower(coalesce(report_jobs.status, \'\'))'), ['failed', 'error'])
+            ->limit(1);
+    }
+
+    private function attempt(string $attemptId): ?object
+    {
+        if ($attemptId === '' || ! SchemaBaseline::hasTable('attempts')) {
+            return null;
+        }
+
+        return DB::table('attempts')->where('id', $attemptId)->first();
+    }
+
+    private function result(string $attemptId): ?object
+    {
+        if ($attemptId === '' || ! SchemaBaseline::hasTable('results')) {
+            return null;
+        }
+
+        return DB::table('results')
+            ->where('attempt_id', $attemptId)
+            ->orderByRaw('coalesce(computed_at, updated_at, created_at) desc')
+            ->first();
+    }
+
+    private function order(string $orderNo, string $attemptId): ?object
+    {
+        if (! SchemaBaseline::hasTable('orders')) {
+            return null;
+        }
+
+        $query = DB::table('orders')
+            ->where(function (QueryBuilder $builder) use ($orderNo, $attemptId): void {
+                $hasAny = false;
+
+                if ($orderNo !== '' && SchemaBaseline::hasColumn('orders', 'order_no')) {
+                    $builder->where('orders.order_no', $orderNo);
+                    $hasAny = true;
+                }
+
+                if ($attemptId !== '' && SchemaBaseline::hasColumn('orders', 'target_attempt_id')) {
+                    if ($hasAny) {
+                        $builder->orWhere('orders.target_attempt_id', $attemptId);
+                    } else {
+                        $builder->where('orders.target_attempt_id', $attemptId);
+                        $hasAny = true;
+                    }
+                }
+
+                if (! $hasAny) {
+                    $builder->whereRaw('1 = 0');
+                }
+            })
+            ->orderByRaw("case when lower(coalesce(status, '')) in ('paid', 'fulfilled') then 0 else 1 end")
+            ->orderByRaw('coalesce(paid_at, updated_at, created_at) desc');
+
+        return $query->first();
+    }
+
+    private function payment(string $orderNo): ?object
+    {
+        if ($orderNo === '' || ! SchemaBaseline::hasTable('payment_events')) {
+            return null;
+        }
+
+        return DB::table('payment_events')
+            ->where('order_no', $orderNo)
+            ->orderByRaw('coalesce(processed_at, handled_at, updated_at, created_at) desc')
+            ->first();
+    }
+
+    /**
+     * @return list<object>
+     */
+    private function benefitGrants(string $orderNo, string $attemptId): array
+    {
+        if (! SchemaBaseline::hasTable('benefit_grants')) {
+            return [];
+        }
+
+        $query = DB::table('benefit_grants')
+            ->where(function (QueryBuilder $builder) use ($orderNo, $attemptId): void {
+                $hasAny = false;
+
+                if ($attemptId !== '' && SchemaBaseline::hasColumn('benefit_grants', 'attempt_id')) {
+                    $builder->where('benefit_grants.attempt_id', $attemptId);
+                    $hasAny = true;
+                }
+
+                if ($orderNo !== '' && SchemaBaseline::hasColumn('benefit_grants', 'order_no')) {
+                    if ($hasAny) {
+                        $builder->orWhere('benefit_grants.order_no', $orderNo);
+                    } else {
+                        $builder->where('benefit_grants.order_no', $orderNo);
+                        $hasAny = true;
+                    }
+                }
+
+                if (! $hasAny) {
+                    $builder->whereRaw('1 = 0');
+                }
+            })
+            ->orderByRaw("case when lower(coalesce(status, '')) = 'active' then 0 else 1 end")
+            ->orderByRaw('coalesce(updated_at, created_at) desc');
+
+        return $query->get()->all();
+    }
+
+    private function activeGrant(array $grants): ?object
+    {
+        foreach ($grants as $grant) {
+            if (strtolower(trim((string) ($grant->status ?? ''))) === 'active') {
+                return $grant;
+            }
+        }
+
+        return $grants[0] ?? null;
+    }
+
+    private function share(string $attemptId): ?object
+    {
+        if ($attemptId === '' || ! SchemaBaseline::hasTable('shares')) {
+            return null;
+        }
+
+        return DB::table('shares')
+            ->where('attempt_id', $attemptId)
+            ->orderByDesc('created_at')
+            ->first();
+    }
+
+    private function reportJob(string $attemptId): ?object
+    {
+        if ($attemptId === '' || ! SchemaBaseline::hasTable('report_jobs')) {
+            return null;
+        }
+
+        return DB::table('report_jobs')
+            ->where('attempt_id', $attemptId)
+            ->orderByRaw('coalesce(updated_at, created_at) desc')
+            ->first();
+    }
+
+    private function lastDeliveryEmailSentAt(string $attemptId, string $orderNo): ?string
+    {
+        if (
+            $attemptId === ''
+            || ! SchemaBaseline::hasTable('email_outbox')
+            || ! SchemaBaseline::hasColumn('email_outbox', 'attempt_id')
+            || ! SchemaBaseline::hasColumn('email_outbox', 'sent_at')
+        ) {
+            return null;
+        }
+
+        $query = DB::table('email_outbox')
+            ->where('attempt_id', $attemptId)
+            ->whereNotNull('sent_at');
+
+        if (SchemaBaseline::hasColumn('email_outbox', 'template')) {
+            $query->whereIn('template', ['payment_success', 'report_claim']);
+        } elseif (SchemaBaseline::hasColumn('email_outbox', 'template_key')) {
+            $query->whereIn('template_key', ['payment_success', 'report_claim']);
+        }
+
+        $sentAt = $query->orderByDesc('sent_at')->value('sent_at');
+
+        return $sentAt !== null ? (string) $sentAt : null;
+    }
+
+    /**
+     * @return list<array{title:string,occurred_at:string,channel:string,meta:list<string>}>
+     */
+    private function recentEvents(string $attemptId, string $shareId): array
+    {
+        if (! SchemaBaseline::hasTable('events')) {
+            return [];
+        }
+
+        $query = DB::table('events')
+            ->select(['event_code', 'occurred_at', 'channel', 'meta_json']);
+
+        if (SchemaBaseline::hasColumn('events', 'share_id')) {
+            $query->addSelect('share_id');
+        }
+
+        $query->where(function (QueryBuilder $builder) use ($attemptId, $shareId): void {
+            $hasAny = false;
+
+            if ($attemptId !== '' && SchemaBaseline::hasColumn('events', 'attempt_id')) {
+                $builder->where('attempt_id', $attemptId);
+                $hasAny = true;
+            }
+
+            if ($shareId !== '' && SchemaBaseline::hasColumn('events', 'share_id')) {
+                if ($hasAny) {
+                    $builder->orWhere('share_id', $shareId);
+                } else {
+                    $builder->where('share_id', $shareId);
+                    $hasAny = true;
+                }
+            }
+
+            if (! $hasAny) {
+                $builder->whereRaw('1 = 0');
+            }
+        });
+
+        return $query
+            ->orderByRaw('coalesce(occurred_at, created_at) desc')
+            ->limit(5)
+            ->get()
+            ->map(fn ($row): array => [
+                'title' => $this->stringOrDash($row->event_code ?? null),
+                'occurred_at' => $this->formatTimestamp($row->occurred_at ?? null),
+                'channel' => $this->stringOrDash($row->channel ?? null),
+                'meta' => $this->summarizeMeta($this->arrayFromMixed($row->meta_json ?? null)),
+            ])
+            ->all();
+    }
+
+    /**
+     * @return list<array{label:string,url:string,kind:string}>
+     */
+    private function buildLinks(
+        string $attemptId,
+        ?string $orderNo,
+        ?string $shareId,
+        string $locale,
+        ?string $orderId,
+        ?string $resultId,
+        ?string $pdfEndpoint
+    ): array {
+        $base = rtrim((string) config('app.frontend_url', config('app.url', '')), '/');
+        $links = [];
+        $localeSegment = $this->frontendLocaleSegment($locale);
+
+        if ($base !== '') {
+            if ($orderNo !== null && $orderNo !== '') {
+                $links[] = [
+                    'label' => 'Order page',
+                    'url' => $base.'/'.$localeSegment.'/orders/'.urlencode($orderNo),
+                    'kind' => 'frontend',
+                ];
+            }
+
+            if ($attemptId !== '') {
+                $links[] = [
+                    'label' => 'Result page',
+                    'url' => $base.'/'.$localeSegment.'/result/'.urlencode($attemptId),
+                    'kind' => 'frontend',
+                ];
+                $links[] = [
+                    'label' => 'Report page',
+                    'url' => $base.'/'.$localeSegment.'/attempts/'.urlencode($attemptId).'/report',
+                    'kind' => 'frontend',
+                ];
+            }
+
+            if ($shareId !== null && $shareId !== '') {
+                $links[] = [
+                    'label' => 'Share page',
+                    'url' => $base.'/'.$localeSegment.'/share/'.urlencode($shareId),
+                    'kind' => 'frontend',
+                ];
+            }
+        }
+
+        if ($pdfEndpoint !== null && $pdfEndpoint !== '') {
+            $links[] = [
+                'label' => 'PDF endpoint',
+                'url' => $pdfEndpoint,
+                'kind' => 'frontend',
+            ];
+        }
+
+        if ($attemptId !== '') {
+            $links[] = [
+                'label' => 'Attempt Explorer',
+                'url' => AttemptResource::getUrl('view', ['record' => $attemptId]),
+                'kind' => 'ops',
+            ];
+        }
+
+        if ($resultId !== null && $resultId !== '') {
+            $links[] = [
+                'label' => 'Result diagnostics',
+                'url' => ResultResource::getUrl('view', ['record' => $resultId]),
+                'kind' => 'ops',
+            ];
+        }
+
+        if ($orderId !== null && $orderId !== '') {
+            $links[] = [
+                'label' => 'Order diagnostics',
+                'url' => OrderResource::getUrl('view', ['record' => $orderId]),
+                'kind' => 'ops',
+            ];
+        }
+
+        $links[] = [
+            'label' => 'Order Lookup',
+            'url' => '/ops/order-lookup',
+            'kind' => 'ops',
+        ];
+
+        return $links;
+    }
+
+    private function snapshotReady(object $snapshot): bool
+    {
+        return in_array(strtolower(trim((string) ($snapshot->status ?? ''))), ['ready', 'full', 'completed'], true);
+    }
+
+    private function snapshotFailed(object $snapshot): bool
+    {
+        return in_array(strtolower(trim((string) ($snapshot->status ?? ''))), ['failed', 'error'], true);
+    }
+
+    private function reportJobFailed(object $snapshot): bool
+    {
+        return in_array(strtolower(trim((string) ($snapshot->report_job_status ?? ''))), ['failed', 'error'], true);
+    }
+
+    private function snapshotPresent(object $snapshot): bool
+    {
+        return trim((string) ($snapshot->attempt_id ?? '')) !== '';
+    }
+
+    private function pdfAvailable(object $snapshot): bool
+    {
+        return $this->snapshotReady($snapshot)
+            && trim((string) ($snapshot->attempt_id ?? '')) !== ''
+            && ($this->hasActiveGrant($snapshot) || $this->isPaidLike((string) ($snapshot->order_status ?? '')) || $this->isPaidLike((string) ($snapshot->payment_status ?? '')));
+    }
+
+    private function hasOrder(object $snapshot): bool
+    {
+        return StatusBadge::isTruthy($snapshot->has_order ?? null)
+            || trim((string) ($snapshot->order_no ?? '')) !== ''
+            || trim((string) ($snapshot->order_id ?? '')) !== '';
+    }
+
+    private function hasActiveGrant(object $snapshot): bool
+    {
+        return StatusBadge::isTruthy($snapshot->has_active_benefit_grant ?? null)
+            || strtolower(trim((string) ($snapshot->benefit_status ?? ''))) === 'active';
+    }
+
+    private function orderHasContactEmailHash(?object $order): bool
+    {
+        if ($order === null) {
+            return false;
+        }
+
+        return trim((string) ($order->contact_email_hash ?? '')) !== '';
+    }
+
+    private function applyOrderSnapshotCorrelation(QueryBuilder $builder): void
+    {
+        $hasAny = false;
+
+        if (SchemaBaseline::hasColumn('orders', 'order_no') && SchemaBaseline::hasColumn('report_snapshots', 'order_no')) {
+            $builder->whereColumn('orders.order_no', 'report_snapshots.order_no');
+            $hasAny = true;
+        }
+
+        if (SchemaBaseline::hasColumn('orders', 'target_attempt_id')) {
+            if ($hasAny) {
+                $builder->orWhereColumn('orders.target_attempt_id', 'report_snapshots.attempt_id');
+            } else {
+                $builder->whereColumn('orders.target_attempt_id', 'report_snapshots.attempt_id');
+                $hasAny = true;
+            }
+        }
+
+        if (! $hasAny) {
+            $builder->whereRaw('1 = 0');
+        }
+    }
+
+    private function applyBenefitSnapshotCorrelation(QueryBuilder $builder): void
+    {
+        $hasAny = false;
+
+        if (SchemaBaseline::hasColumn('benefit_grants', 'attempt_id')) {
+            $builder->whereColumn('benefit_grants.attempt_id', 'report_snapshots.attempt_id');
+            $hasAny = true;
+        }
+
+        if (SchemaBaseline::hasColumn('benefit_grants', 'order_no') && SchemaBaseline::hasColumn('report_snapshots', 'order_no')) {
+            if ($hasAny) {
+                $builder->orWhereColumn('benefit_grants.order_no', 'report_snapshots.order_no');
+            } else {
+                $builder->whereColumn('benefit_grants.order_no', 'report_snapshots.order_no');
+                $hasAny = true;
+            }
+        }
+
+        if (! $hasAny) {
+            $builder->whereRaw('1 = 0');
+        }
+    }
+
+    private function isPaidLike(string $status): bool
+    {
+        return in_array(strtolower(trim($status)), ['paid', 'fulfilled', 'complete', 'completed', 'succeeded'], true);
+    }
+
+    private function isRefundedLike(string $status): bool
+    {
+        return str_contains(strtolower(trim($status)), 'refund');
+    }
+
+    private function frontendLocaleSegment(string $locale): string
+    {
+        return str_starts_with(strtolower(trim($locale)), 'zh') ? 'zh' : 'en';
+    }
+
+    /**
+     * @return array{label:string,value:string,hint:?string,kind:string,state:?string}
+     */
+    private function field(string $label, string $value, ?string $hint = null): array
+    {
+        return [
+            'label' => $label,
+            'value' => $value !== '' ? $value : '-',
+            'hint' => $hint,
+            'kind' => 'text',
+            'state' => null,
+        ];
+    }
+
+    /**
+     * @return array{label:string,value:string,hint:?string,kind:string,state:?string}
+     */
+    private function pillField(string $label, string $value, string $state, ?string $hint = null): array
+    {
+        return [
+            'label' => $label,
+            'value' => $value !== '' ? $value : '-',
+            'hint' => $hint,
+            'kind' => 'pill',
+            'state' => $state,
+        ];
+    }
+
+    private function stringOrDash(mixed $value): string
+    {
+        $string = trim((string) $value);
+
+        return $string !== '' ? $string : '-';
+    }
+
+    private function formatTimestamp(mixed $value): string
+    {
+        if ($value === null || $value === '') {
+            return '-';
+        }
+
+        if ($value instanceof Carbon) {
+            return $value->toDateTimeString();
+        }
+
+        try {
+            return Carbon::parse((string) $value)->toDateTimeString();
+        } catch (\Throwable) {
+            return $this->stringOrDash($value);
+        }
+    }
+
+    /**
+     * @param  array<mixed>  $values
+     */
+    private function latestTimestamp(array $values): string
+    {
+        $latest = null;
+
+        foreach ($values as $value) {
+            if ($value === null || $value === '') {
+                continue;
+            }
+
+            try {
+                $parsed = $value instanceof Carbon ? $value : Carbon::parse((string) $value);
+            } catch (\Throwable) {
+                continue;
+            }
+
+            if ($latest === null || $parsed->greaterThan($latest)) {
+                $latest = $parsed;
+            }
+        }
+
+        return $latest?->toDateTimeString() ?? '-';
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function arrayFromMixed(mixed $value): array
+    {
+        if (is_array($value)) {
+            return $value;
+        }
+
+        if (is_string($value)) {
+            $decoded = json_decode($value, true);
+
+            return is_array($decoded) ? $decoded : [];
+        }
+
+        return [];
+    }
+
+    private function shortText(mixed $value, int $limit = 140): string
+    {
+        $text = trim((string) $value);
+        if ($text === '') {
+            return '-';
+        }
+
+        return Str::limit($text, $limit, '...');
+    }
+
+    /**
+     * @param  mixed  $utm
+     */
+    private function utmSummary(mixed $utm): string
+    {
+        if (! is_array($utm)) {
+            return '-';
+        }
+
+        $parts = [];
+
+        foreach (['source', 'medium', 'campaign'] as $key) {
+            $value = trim((string) ($utm[$key] ?? ''));
+            if ($value !== '') {
+                $parts[] = $key.'='.$value;
+            }
+        }
+
+        return $parts === [] ? '-' : implode(' | ', $parts);
+    }
+
+    /**
+     * @param  array<string, mixed>  $meta
+     * @return list<string>
+     */
+    private function summarizeMeta(array $meta): array
+    {
+        $summary = [];
+
+        foreach (['status', 'stage', 'variant', 'locked', 'access_level', 'reason', 'provider'] as $key) {
+            $value = $meta[$key] ?? null;
+
+            if ($value === null || $value === '') {
+                continue;
+            }
+
+            $summary[] = $key.'='.$this->scalarSummary($value);
+        }
+
+        return $summary;
+    }
+
+    private function scalarSummary(mixed $value): string
+    {
+        if (is_bool($value)) {
+            return $value ? 'true' : 'false';
+        }
+
+        if (is_scalar($value)) {
+            return Str::limit((string) $value, 32, '...');
+        }
+
+        if (is_array($value)) {
+            return 'array('.count($value).')';
+        }
+
+        return '-';
+    }
+}

--- a/backend/resources/views/filament/ops/resources/reports/view-report-snapshot.blade.php
+++ b/backend/resources/views/filament/ops/resources/reports/view-report-snapshot.blade.php
@@ -1,0 +1,181 @@
+<x-filament-panels::page>
+    @php
+        $record = $this->getRecord();
+    @endphp
+
+    <div class="ops-shell-page">
+        <x-filament::section>
+            <div class="ops-workbench-toolbar ops-workbench-toolbar--split">
+                <div class="ops-workbench-toolbar__main">
+                    <div class="ops-shell-inline-intro">
+                        <span class="ops-shell-inline-intro__eyebrow">Support diagnostic</span>
+                        <p class="ops-shell-inline-intro__meta">
+                            Rooted on <code>{{ (string) $record->getKey() }}</code>. This page keeps snapshot, PDF, delivery, attempt, result, unlock, share, and claim/resend clues in one read-only surface.
+                        </p>
+                    </div>
+
+                    <div class="flex flex-wrap items-center gap-3">
+                        <x-filament.ops.shared.status-pill
+                            :state="(string) ($headline['snapshot']['state'] ?? 'gray')"
+                            :label="'snapshot: '.(string) ($headline['snapshot']['label'] ?? '-')"
+                        />
+                        <x-filament.ops.shared.status-pill
+                            :state="(string) ($headline['unlock']['state'] ?? 'gray')"
+                            :label="'unlock: '.(string) ($headline['unlock']['label'] ?? '-')"
+                        />
+                        <x-filament.ops.shared.status-pill
+                            :state="(string) ($headline['pdf']['state'] ?? 'gray')"
+                            :label="'pdf: '.(string) ($headline['pdf']['label'] ?? '-')"
+                        />
+                        <x-filament.ops.shared.status-pill
+                            :state="(string) ($headline['delivery']['state'] ?? 'gray')"
+                            :label="'delivery: '.(string) ($headline['delivery']['label'] ?? '-')"
+                        />
+                        <x-filament.ops.shared.status-pill
+                            :state="(string) ($headline['job']['state'] ?? 'gray')"
+                            :label="'report_job: '.(string) ($headline['job']['label'] ?? '-')"
+                        />
+                    </div>
+                </div>
+
+                <div class="ops-workbench-toolbar__actions">
+                    @foreach ($links as $link)
+                        <x-filament::button
+                            color="{{ ($link['kind'] ?? 'frontend') === 'ops' ? 'gray' : 'primary' }}"
+                            size="sm"
+                            tag="a"
+                            href="{{ (string) ($link['url'] ?? '#') }}"
+                            target="{{ ($link['kind'] ?? 'frontend') === 'ops' ? '_self' : '_blank' }}"
+                        >
+                            {{ (string) ($link['label'] ?? 'Open') }}
+                        </x-filament::button>
+                    @endforeach
+                </div>
+            </div>
+        </x-filament::section>
+
+        <x-filament::section>
+            <div class="ops-results-header">
+                <div>
+                    <h3 class="ops-results-header__title">Snapshot Summary</h3>
+                    <p class="ops-results-header__meta">Delivery-rooted snapshot identity, status, version, access clues, and lightweight error summary.</p>
+                </div>
+            </div>
+
+            <div class="mt-4">
+                @include('filament.ops.resources.attempts.partials.field-grid', [
+                    'fields' => $snapshotSummary['fields'] ?? [],
+                    'notes' => $snapshotSummary['notes'] ?? [],
+                ])
+            </div>
+        </x-filament::section>
+
+        <x-filament::section>
+            <div class="ops-results-header">
+                <div>
+                    <h3 class="ops-results-header__title">PDF / Delivery Status</h3>
+                    <p class="ops-results-header__meta">PDF readiness, report.pdf endpoint clue, contact presence, claim/resend eligibility, and delivery timing.</p>
+                </div>
+            </div>
+
+            <div class="mt-4">
+                @include('filament.ops.resources.attempts.partials.field-grid', [
+                    'fields' => $pdfDeliverySummary['fields'] ?? [],
+                    'notes' => $pdfDeliverySummary['notes'] ?? [],
+                ])
+            </div>
+        </x-filament::section>
+
+        <x-filament::section>
+            <div class="ops-results-header">
+                <div>
+                    <h3 class="ops-results-header__title">Report Job / Generation Status</h3>
+                    <p class="ops-results-header__meta">Auxiliary generation breadcrumbs only. Snapshot rows remain the delivery truth object for this view.</p>
+                </div>
+            </div>
+
+            <div class="mt-4">
+                @include('filament.ops.resources.attempts.partials.field-grid', [
+                    'fields' => $reportJobSummary['fields'] ?? [],
+                    'notes' => $reportJobSummary['notes'] ?? [],
+                ])
+            </div>
+        </x-filament::section>
+
+        <x-filament::section>
+            <div class="ops-results-header">
+                <div>
+                    <h3 class="ops-results-header__title">Attempt Linkage</h3>
+                    <p class="ops-results-header__meta">Attempt root, submit state, user/anon/ticket breadcrumbs, and attempt drill-through context.</p>
+                </div>
+            </div>
+
+            <div class="mt-4">
+                @include('filament.ops.resources.attempts.partials.field-grid', [
+                    'fields' => $attemptSummary['fields'] ?? [],
+                    'notes' => $attemptSummary['notes'] ?? [],
+                ])
+            </div>
+        </x-filament::section>
+
+        <x-filament::section>
+            <div class="ops-results-header">
+                <div>
+                    <h3 class="ops-results-header__title">Result Linkage</h3>
+                    <p class="ops-results-header__meta">Result presence, type, computed timing, and result drill-through without exposing raw result payload JSON.</p>
+                </div>
+            </div>
+
+            <div class="mt-4">
+                @include('filament.ops.resources.attempts.partials.field-grid', [
+                    'fields' => $resultSummary['fields'] ?? [],
+                    'notes' => $resultSummary['notes'] ?? [],
+                ])
+            </div>
+        </x-filament::section>
+
+        <x-filament::section>
+            <div class="ops-results-header">
+                <div>
+                    <h3 class="ops-results-header__title">Commerce / Unlock Linkage</h3>
+                    <p class="ops-results-header__meta">Order, payment, benefit grant, unlock truth, and order lookup breadcrumbs.</p>
+                </div>
+            </div>
+
+            <div class="mt-4">
+                @include('filament.ops.resources.attempts.partials.field-grid', [
+                    'fields' => $commerceSummary['fields'] ?? [],
+                    'notes' => $commerceSummary['notes'] ?? [],
+                ])
+            </div>
+        </x-filament::section>
+
+        <x-filament::section>
+            <div class="ops-results-header">
+                <div>
+                    <h3 class="ops-results-header__title">Share / Access Linkage + Exception Diagnostics</h3>
+                    <p class="ops-results-header__meta">Share/access breadcrumbs first, then explicit v1 exception rules for support and ops.</p>
+                </div>
+            </div>
+
+            <div class="mt-4">
+                @include('filament.ops.resources.attempts.partials.field-grid', [
+                    'fields' => $shareAccessSummary['fields'] ?? [],
+                    'notes' => $shareAccessSummary['notes'] ?? [],
+                ])
+            </div>
+
+            <div class="mt-6">
+                <h4 class="ops-results-header__title">Exception Diagnostics</h4>
+                <p class="ops-results-header__meta mt-1">Focused exception flags only. Raw email, payment, and storage payloads remain hidden.</p>
+            </div>
+
+            <div class="mt-4">
+                @include('filament.ops.resources.attempts.partials.field-grid', [
+                    'fields' => $exceptionSummary['fields'] ?? [],
+                    'notes' => $exceptionSummary['notes'] ?? [],
+                ])
+            </div>
+        </x-filament::section>
+    </div>
+</x-filament-panels::page>

--- a/backend/tests/Feature/Ops/ReportPdfCenterTest.php
+++ b/backend/tests/Feature/Ops/ReportPdfCenterTest.php
@@ -1,0 +1,543 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Ops;
+
+use App\Filament\Ops\Resources\ReportSnapshotResource\Pages\ListReportSnapshots;
+use App\Models\AdminUser;
+use App\Models\Organization;
+use App\Models\Permission;
+use App\Models\ReportSnapshot;
+use App\Models\Role;
+use App\Support\Rbac\PermissionNames;
+use Filament\Facades\Filament;
+use Filament\PanelRegistry;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Support\Str;
+use Livewire\Livewire;
+use Tests\TestCase;
+
+final class ReportPdfCenterTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        Filament::setCurrentPanel(app(PanelRegistry::class)->get('ops'));
+    }
+
+    public function test_report_pdf_center_list_is_accessible_read_only_and_has_core_columns(): void
+    {
+        $admin = $this->createAdminWithPermissions([
+            PermissionNames::ADMIN_MENU_SUPPORT,
+            PermissionNames::ADMIN_OPS_READ,
+        ]);
+        $selectedOrg = $this->createOrganization('Selected Support Org');
+        $chain = $this->seedDiagnosticChain(orgId: 61);
+
+        $this->withSession($this->opsSession($admin, $selectedOrg))
+            ->actingAs($admin, (string) config('admin.guard', 'admin'))
+            ->get('/ops/reports')
+            ->assertOk()
+            ->assertSee('Report / PDF Center')
+            ->assertDontSee('Create Report Snapshot')
+            ->assertDontSee('Edit Report Snapshot');
+
+        session($this->opsSession($admin, $selectedOrg));
+        $this->actingAs($admin, (string) config('admin.guard', 'admin'));
+
+        Livewire::test(ListReportSnapshots::class)
+            ->assertOk()
+            ->assertCanSeeTableRecords([$chain['snapshot']])
+            ->assertTableColumnExists('attempt_id')
+            ->assertTableColumnExists('order_no')
+            ->assertTableColumnExists('scale_code')
+            ->assertTableColumnExists('locale')
+            ->assertTableColumnExists('snapshot_status')
+            ->assertTableColumnExists('unlock_status')
+            ->assertTableColumnExists('pdf_ready')
+            ->assertTableColumnExists('delivery_status')
+            ->assertTableColumnExists('updated_at')
+            ->assertTableColumnExists('org_id')
+            ->assertTableActionExists('view', null, $chain['snapshot'])
+            ->assertTableActionDoesNotExist('edit', null, $chain['snapshot'])
+            ->assertTableActionDoesNotExist('delete', null, $chain['snapshot']);
+    }
+
+    public function test_report_pdf_center_detail_renders_seven_sections_hides_sensitive_payloads_and_shows_drill_through_links(): void
+    {
+        $admin = $this->createAdminWithPermissions([
+            PermissionNames::ADMIN_MENU_SUPPORT,
+            PermissionNames::ADMIN_OPS_READ,
+        ]);
+        $selectedOrg = $this->createOrganization('Cross Org Session');
+        $chain = $this->seedDiagnosticChain(orgId: 72, orderNo: 'ord_report_diag_001');
+
+        $response = $this->withSession($this->opsSession($admin, $selectedOrg))
+            ->actingAs($admin, (string) config('admin.guard', 'admin'))
+            ->get('/ops/reports/'.$chain['attempt_id']);
+
+        $response
+            ->assertOk()
+            ->assertSee('Snapshot Summary')
+            ->assertSee('PDF / Delivery Status')
+            ->assertSee('Report Job / Generation Status')
+            ->assertSee('Attempt Linkage')
+            ->assertSee('Result Linkage')
+            ->assertSee('Commerce / Unlock Linkage')
+            ->assertSee('Share / Access Linkage + Exception Diagnostics')
+            ->assertSee('unlock: unlocked')
+            ->assertSee('snapshot: ready')
+            ->assertSee((string) $chain['order_no'])
+            ->assertSee((string) $chain['attempt_id'])
+            ->assertSee((string) $chain['share_id'])
+            ->assertSee('/api/v0.3/attempts/'.$chain['attempt_id'].'/report.pdf')
+            ->assertSee('Order page')
+            ->assertSee('Result page')
+            ->assertSee('Report page')
+            ->assertSee('Share page')
+            ->assertSee('Order Lookup')
+            ->assertDontSee('report_json')
+            ->assertDontSee('report_free_json')
+            ->assertDontSee('report_full_json')
+            ->assertDontSee('result_json')
+            ->assertDontSee('payload_json')
+            ->assertDontSee((string) $chain['payment_secret'])
+            ->assertDontSee((string) $chain['report_secret'])
+            ->assertDontSee((string) $chain['email_secret']);
+    }
+
+    public function test_report_pdf_center_cross_org_search_works_for_attempt_id_order_no_and_share_id(): void
+    {
+        $admin = $this->createAdminWithPermissions([
+            PermissionNames::ADMIN_MENU_SUPPORT,
+            PermissionNames::ADMIN_OPS_READ,
+        ]);
+        $selectedOrg = $this->createOrganization('Current Session Org');
+        $local = $this->seedDiagnosticChain(orgId: (int) $selectedOrg->id, orderNo: 'ord_report_local_001');
+        $foreign = $this->seedDiagnosticChain(orgId: 88, orderNo: 'ord_report_cross_001');
+
+        session($this->opsSession($admin, $selectedOrg));
+        $this->actingAs($admin, (string) config('admin.guard', 'admin'));
+
+        Livewire::test(ListReportSnapshots::class)
+            ->assertOk()
+            ->searchTable('ord_report_cross_001')
+            ->assertCanSeeTableRecords([$foreign['snapshot']])
+            ->assertCanNotSeeTableRecords([$local['snapshot']])
+            ->assertTableColumnStateSet('org_id', 88, $foreign['snapshot'])
+            ->searchTable((string) $foreign['attempt_id'])
+            ->assertCanSeeTableRecords([$foreign['snapshot']])
+            ->searchTable((string) $foreign['share_id'])
+            ->assertCanSeeTableRecords([$foreign['snapshot']]);
+    }
+
+    public function test_report_pdf_center_uses_benefit_grant_for_unlock_truth_and_keeps_report_job_auxiliary(): void
+    {
+        $admin = $this->createAdminWithPermissions([
+            PermissionNames::ADMIN_MENU_SUPPORT,
+            PermissionNames::ADMIN_OPS_READ,
+        ]);
+        $selectedOrg = $this->createOrganization('Unlock Truth Org');
+        $chain = $this->seedDiagnosticChain(orgId: 91, orderNo: 'ord_unlock_truth_001');
+
+        $response = $this->withSession($this->opsSession($admin, $selectedOrg))
+            ->actingAs($admin, (string) config('admin.guard', 'admin'))
+            ->get('/ops/reports/'.$chain['attempt_id']);
+
+        $response
+            ->assertOk()
+            ->assertSee('Unlock truth is derived from benefit_grants first, not from report_jobs or order status alone.')
+            ->assertSee('Report jobs stay auxiliary. report_snapshots remain the persisted delivery object read by access flows.')
+            ->assertSee('active_benefit_grant')
+            ->assertSee('unlocked')
+            ->assertSee('succeeded');
+    }
+
+    private function createOrganization(string $name): Organization
+    {
+        return Organization::query()->create([
+            'name' => $name,
+            'owner_user_id' => random_int(1000, 9999),
+            'status' => 'active',
+            'domain' => Str::slug($name).'.example.test',
+            'timezone' => 'Asia/Shanghai',
+            'locale' => 'en',
+        ]);
+    }
+
+    /**
+     * @param  list<string>  $permissions
+     */
+    private function createAdminWithPermissions(array $permissions): AdminUser
+    {
+        $admin = AdminUser::query()->create([
+            'name' => 'ops_'.Str::lower(Str::random(6)),
+            'email' => 'ops_'.Str::lower(Str::random(6)).'@example.test',
+            'password' => bcrypt('secret'),
+            'is_active' => 1,
+        ]);
+
+        $role = Role::query()->create([
+            'name' => 'role_'.Str::lower(Str::random(8)),
+            'description' => null,
+        ]);
+
+        foreach ($permissions as $permissionName) {
+            $permission = Permission::query()->firstOrCreate(
+                ['name' => $permissionName],
+                ['description' => null],
+            );
+
+            $role->permissions()->syncWithoutDetaching([$permission->id]);
+        }
+
+        $admin->roles()->syncWithoutDetaching([$role->id]);
+
+        return $admin;
+    }
+
+    /**
+     * @return array{ops_org_id:int,ops_admin_totp_verified_user_id:int}
+     */
+    private function opsSession(AdminUser $admin, Organization $selectedOrg): array
+    {
+        return [
+            'ops_org_id' => (int) $selectedOrg->id,
+            'ops_admin_totp_verified_user_id' => (int) $admin->id,
+        ];
+    }
+
+    /**
+     * @return array{
+     *   snapshot:ReportSnapshot,
+     *   attempt_id:string,
+     *   order_no:string,
+     *   share_id:string,
+     *   payment_secret:string,
+     *   report_secret:string,
+     *   email_secret:string
+     * }
+     */
+    private function seedDiagnosticChain(int $orgId, ?string $orderNo = null): array
+    {
+        $attemptId = (string) Str::uuid();
+        $resultId = (string) Str::uuid();
+        $shareId = (string) Str::uuid();
+        $orderId = (string) Str::uuid();
+        $paymentEventId = (string) Str::uuid();
+        $orderNo ??= 'ord_report_'.Str::lower(Str::random(6));
+        $paymentSecret = 'payment-secret-'.Str::lower(Str::random(6));
+        $reportSecret = 'report-secret-'.Str::lower(Str::random(6));
+        $emailSecret = 'email-secret-'.Str::lower(Str::random(6));
+
+        DB::table('attempts')->insert([
+            'id' => $attemptId,
+            'ticket_code' => 'FMT-'.strtoupper(substr(str_replace('-', '', $attemptId), 0, 8)),
+            'org_id' => $orgId,
+            'user_id' => '1001',
+            'anon_id' => 'anon_report_chain',
+            'scale_code' => 'MBTI',
+            'scale_version' => 'v0.3',
+            'scale_uid' => '55555555-5555-4555-8555-555555555555',
+            'region' => 'US',
+            'locale' => 'en',
+            'question_count' => 93,
+            'answers_summary_json' => json_encode(['stage' => 'seed'], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES),
+            'client_platform' => 'test',
+            'channel' => 'web',
+            'started_at' => now()->subMinutes(20),
+            'submitted_at' => now()->subMinutes(15),
+            'pack_id' => 'MBTI',
+            'dir_version' => 'mbti_dir_2026_03',
+            'content_package_version' => 'content_2026_03',
+            'scoring_spec_version' => 'scoring_2026_03',
+            'norm_version' => 'norm_2026_03',
+            'created_at' => now()->subMinutes(20),
+            'updated_at' => now()->subMinutes(15),
+            'result_json' => json_encode(['type_code' => 'INTJ'], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES),
+        ]);
+
+        DB::table('results')->insert([
+            'id' => $resultId,
+            'attempt_id' => $attemptId,
+            'org_id' => $orgId,
+            'scale_code' => 'MBTI',
+            'scale_version' => 'v0.3',
+            'type_code' => 'INTJ',
+            'scores_json' => json_encode(['EI' => 78], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES),
+            'scores_pct' => json_encode(['EI' => 88], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES),
+            'axis_states' => json_encode(['EI' => 'I'], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES),
+            'profile_version' => 'profile_2026_03',
+            'result_json' => json_encode(['secret' => 'result-hidden'], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES),
+            'pack_id' => 'MBTI',
+            'dir_version' => 'mbti_dir_2026_03',
+            'content_package_version' => 'content_2026_03',
+            'scoring_spec_version' => 'scoring_2026_03',
+            'report_engine_version' => 'v2.3',
+            'is_valid' => 1,
+            'computed_at' => now()->subMinutes(12),
+            'created_at' => now()->subMinutes(12),
+            'updated_at' => now()->subMinutes(11),
+            'scale_uid' => '55555555-5555-4555-8555-555555555555',
+        ]);
+
+        DB::table('report_snapshots')->insert([
+            'org_id' => $orgId,
+            'attempt_id' => $attemptId,
+            'order_no' => $orderNo,
+            'scale_code' => 'MBTI',
+            'pack_id' => 'MBTI',
+            'dir_version' => 'mbti_dir_2026_03',
+            'scoring_spec_version' => 'scoring_2026_03',
+            'report_engine_version' => 'v2.3',
+            'snapshot_version' => 'v1',
+            'report_json' => json_encode([
+                'locked' => false,
+                'access_level' => 'full',
+                'variant' => 'full',
+            ], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES),
+            'report_free_json' => json_encode(['variant' => 'free'], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES),
+            'report_full_json' => json_encode(['secret' => $reportSecret], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES),
+            'status' => 'ready',
+            'last_error' => null,
+            'created_at' => now()->subMinutes(10),
+            'updated_at' => now()->subMinutes(9),
+            'scale_uid' => '55555555-5555-4555-8555-555555555555',
+        ]);
+
+        $orderRow = [
+            'id' => $orderId,
+            'order_no' => $orderNo,
+            'org_id' => $orgId,
+            'user_id' => '1001',
+            'anon_id' => 'anon_report_chain',
+            'sku' => 'MBTI_FULL_REPORT',
+            'quantity' => 1,
+            'target_attempt_id' => $attemptId,
+            'amount_cents' => 2990,
+            'currency' => 'USD',
+            'status' => 'paid',
+            'provider' => 'stripe',
+            'paid_at' => now()->subMinutes(9),
+            'created_at' => now()->subMinutes(10),
+            'updated_at' => now()->subMinutes(8),
+        ];
+
+        if (Schema::hasColumn('orders', 'amount_total')) {
+            $orderRow['amount_total'] = 2990;
+        }
+        if (Schema::hasColumn('orders', 'amount_refunded')) {
+            $orderRow['amount_refunded'] = 0;
+        }
+        if (Schema::hasColumn('orders', 'item_sku')) {
+            $orderRow['item_sku'] = 'MBTI_FULL_REPORT';
+        }
+        if (Schema::hasColumn('orders', 'provider_order_id')) {
+            $orderRow['provider_order_id'] = 'pi_'.$orderNo;
+        }
+        if (Schema::hasColumn('orders', 'fulfilled_at')) {
+            $orderRow['fulfilled_at'] = now()->subMinutes(7);
+        }
+        if (Schema::hasColumn('orders', 'requested_sku')) {
+            $orderRow['requested_sku'] = 'MBTI_FULL_REPORT';
+        }
+        if (Schema::hasColumn('orders', 'effective_sku')) {
+            $orderRow['effective_sku'] = 'MBTI_FULL_REPORT';
+        }
+        if (Schema::hasColumn('orders', 'entitlement_id')) {
+            $orderRow['entitlement_id'] = 'ent_'.$orderNo;
+        }
+        if (Schema::hasColumn('orders', 'contact_email_hash')) {
+            $orderRow['contact_email_hash'] = hash('sha256', 'buyer+'.$orderNo.'@example.test');
+        }
+        if (Schema::hasColumn('orders', 'meta_json')) {
+            $orderRow['meta_json'] = json_encode([
+                'attribution' => [
+                    'share_id' => $shareId,
+                    'share_click_id' => 'click_'.$orderNo,
+                    'entrypoint' => 'checkout_return',
+                    'utm' => [
+                        'source' => 'wechat',
+                        'medium' => 'organic',
+                        'campaign' => 'spring',
+                    ],
+                ],
+                'claim_status' => 'claimed',
+            ], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES);
+        }
+
+        DB::table('orders')->insert($orderRow);
+
+        DB::table('payment_events')->insert([
+            'id' => $paymentEventId,
+            'org_id' => $orgId,
+            'provider' => 'stripe',
+            'provider_event_id' => 'evt_'.Str::lower(Str::random(8)),
+            'order_id' => $orderId,
+            'order_no' => $orderNo,
+            'event_type' => 'payment_intent.succeeded',
+            'signature_ok' => 1,
+            'status' => 'paid',
+            'attempts' => 1,
+            'last_error_code' => null,
+            'last_error_message' => null,
+            'processed_at' => now()->subMinutes(9),
+            'handled_at' => now()->subMinutes(9),
+            'handle_status' => 'processed',
+            'reason' => 'checkout_paid',
+            'requested_sku' => 'MBTI_FULL_REPORT',
+            'effective_sku' => 'MBTI_FULL_REPORT',
+            'entitlement_id' => 'ent_'.$orderNo,
+            'payload_json' => json_encode(['secret' => $paymentSecret], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES),
+            'payload_size_bytes' => 128,
+            'payload_sha256' => hash('sha256', $paymentSecret),
+            'payload_s3_key' => null,
+            'payload_excerpt' => null,
+            'received_at' => now()->subMinutes(9),
+            'created_at' => now()->subMinutes(9),
+            'updated_at' => now()->subMinutes(9),
+            'scale_uid' => '55555555-5555-4555-8555-555555555555',
+        ]);
+
+        DB::table('benefit_grants')->insert([
+            'id' => (string) Str::uuid(),
+            'org_id' => $orgId,
+            'user_id' => '1001',
+            'benefit_code' => 'MBTI_FULL_REPORT',
+            'scope' => 'attempt',
+            'attempt_id' => $attemptId,
+            'status' => 'active',
+            'expires_at' => now()->addDays(30),
+            'benefit_type' => 'report',
+            'benefit_ref' => 'benefit_'.$orderNo,
+            'order_no' => $orderNo,
+            'source_order_id' => $orderId,
+            'source_event_id' => $paymentEventId,
+            'meta_json' => json_encode(['claim_status' => 'claimed'], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES),
+            'created_at' => now()->subMinutes(8),
+            'updated_at' => now()->subMinutes(8),
+        ]);
+
+        DB::table('shares')->insert([
+            'id' => $shareId,
+            'attempt_id' => $attemptId,
+            'anon_id' => 'anon_report_chain',
+            'scale_code' => 'MBTI',
+            'scale_version' => 'v0.3',
+            'content_package_version' => 'content_2026_03',
+            'created_at' => now()->subMinutes(6),
+            'updated_at' => now()->subMinutes(5),
+            'scale_uid' => '55555555-5555-4555-8555-555555555555',
+        ]);
+
+        DB::table('report_jobs')->insert([
+            'id' => (string) Str::uuid(),
+            'attempt_id' => $attemptId,
+            'status' => 'succeeded',
+            'tries' => 1,
+            'available_at' => now()->subMinutes(11),
+            'started_at' => now()->subMinutes(11),
+            'finished_at' => now()->subMinutes(10),
+            'failed_at' => null,
+            'last_error' => null,
+            'last_error_trace' => null,
+            'report_json' => '{}',
+            'meta' => '{}',
+            'created_at' => now()->subMinutes(11),
+            'updated_at' => now()->subMinutes(10),
+            'org_id' => $orgId,
+        ]);
+
+        $this->insertEmailOutbox($attemptId, $orderNo, $emailSecret);
+
+        DB::table('events')->insert([
+            'id' => (string) Str::uuid(),
+            'event_code' => 'share_visit',
+            'user_id' => null,
+            'anon_id' => 'anon_report_chain',
+            'scale_code' => 'MBTI',
+            'scale_version' => 'v0.3',
+            'attempt_id' => $attemptId,
+            'channel' => 'web',
+            'region' => 'US',
+            'locale' => 'en',
+            'client_platform' => 'test',
+            'client_version' => '1.0.0',
+            'meta_json' => json_encode([
+                'stage' => 'share',
+                'variant' => 'full',
+                'locked' => false,
+            ], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES),
+            'occurred_at' => now()->subMinutes(3),
+            'created_at' => now()->subMinutes(3),
+            'updated_at' => now()->subMinutes(3),
+            'org_id' => $orgId,
+            'share_id' => $shareId,
+            'scale_uid' => '55555555-5555-4555-8555-555555555555',
+        ]);
+
+        $snapshot = ReportSnapshot::query()
+            ->withoutGlobalScopes()
+            ->whereKey($attemptId)
+            ->firstOrFail();
+
+        return [
+            'snapshot' => $snapshot,
+            'attempt_id' => $attemptId,
+            'order_no' => $orderNo,
+            'share_id' => $shareId,
+            'payment_secret' => $paymentSecret,
+            'report_secret' => $reportSecret,
+            'email_secret' => $emailSecret,
+        ];
+    }
+
+    private function insertEmailOutbox(string $attemptId, string $orderNo, string $emailSecret): void
+    {
+        if (! Schema::hasTable('email_outbox')) {
+            return;
+        }
+
+        $row = [
+            'id' => (string) Str::uuid(),
+            'user_id' => '1001',
+            'email' => 'redacted+'.substr(hash('sha256', $orderNo), 0, 20).'@privacy.local',
+            'template' => 'payment_success',
+            'payload_json' => json_encode(['secret' => $emailSecret], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES),
+            'claim_token_hash' => hash('sha256', 'claim_'.$orderNo),
+            'claim_expires_at' => now()->addDay(),
+            'status' => 'sent',
+            'sent_at' => now()->subMinutes(4),
+            'consumed_at' => null,
+            'created_at' => now()->subMinutes(4),
+            'updated_at' => now()->subMinutes(4),
+        ];
+
+        if (Schema::hasColumn('email_outbox', 'attempt_id')) {
+            $row['attempt_id'] = $attemptId;
+        }
+        if (Schema::hasColumn('email_outbox', 'to_email')) {
+            $row['to_email'] = 'redacted+'.substr(hash('sha256', $orderNo), 0, 20).'@privacy.local';
+        }
+        if (Schema::hasColumn('email_outbox', 'locale')) {
+            $row['locale'] = 'en';
+        }
+        if (Schema::hasColumn('email_outbox', 'template_key')) {
+            $row['template_key'] = 'payment_success';
+        }
+        if (Schema::hasColumn('email_outbox', 'subject')) {
+            $row['subject'] = 'Payment success';
+        }
+        if (Schema::hasColumn('email_outbox', 'body_html')) {
+            $row['body_html'] = '<p>redacted</p>';
+        }
+
+        DB::table('email_outbox')->insert($row);
+    }
+}


### PR DESCRIPTION
Summary
- add Report / PDF Center as the next Assessment Intelligence Console page
- provide a read-only support diagnostic surface rooted on report snapshots

What changed
- add a new Report / PDF Center resource/page in Filament Ops
- use report_snapshots as the primary diagnostic delivery object
- expose PDF/delivery/attempt/result/order/share linkage summaries in a single detail view
- keep raw report, result, email, and storage payloads hidden by default
- add focused tests for read-only visibility, cross-org lookup behavior, report-job visibility, and delivery/unlock linkage rendering

Design choices
- use report_snapshots as the main root because it is the persisted delivery object read by report access flows
- treat report_jobs as auxiliary generation diagnostics, not the main truth object
- keep v1 read-only and avoid introducing a new analytics read model
- keep the page under Support because it primarily serves support/ops diagnostics
- defer deeper delivery analytics and write-side recovery tooling to later AIC phases

Why this PR is small and safe
- no schema changes
- no API changes
- no write-side behavior changes
- no frontend changes
- only the next support-facing assessment console entrypoint

Validation
- php artisan about
- php artisan route:list --path=ops --except-vendor
- php artisan migrate
- php artisan test --filter=ReportPdfCenterTest
- php artisan test --filter='(Report|Snapshot|Pdf|Delivery|Assessment)'
- php artisan filament:assets
- npm run build
- bash /Users/rainie/Desktop/GitHub/fap-api/backend/scripts/ci_verify_mbti.sh

Notes
- ReportPdfCenterTest passed.
- The broad '(Report|Snapshot|Pdf|Delivery|Assessment)' filter still includes pre-existing unrelated failures in Eq60 and ReportErrorContract paths.
