### PR TITLE
feat(assessment-insights): add MBTI overview, type distribution, and axis distribution

### DIFF
--- a/backend/app/Console/Commands/RefreshMbtiDailyCommand.php
+++ b/backend/app/Console/Commands/RefreshMbtiDailyCommand.php
@@ -1,0 +1,85 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Console\Commands;
+
+use App\Services\Analytics\MbtiDistributionDailyBuilder;
+use Carbon\CarbonImmutable;
+use Illuminate\Console\Command;
+
+class RefreshMbtiDailyCommand extends Command
+{
+    protected $signature = 'analytics:refresh-mbti-daily
+        {--from= : Inclusive start date (Y-m-d)}
+        {--to= : Inclusive end date (Y-m-d)}
+        {--locale=* : Limit refresh to one or more locales}
+        {--org=* : Limit refresh to one or more org ids}
+        {--dry-run : Preview the aggregation without writing rows}';
+
+    protected $description = 'Refresh the MBTI type and axis daily aggregation read models.';
+
+    public function __construct(
+        private readonly MbtiDistributionDailyBuilder $builder,
+    ) {
+        parent::__construct();
+    }
+
+    public function handle(): int
+    {
+        $from = $this->parseDateOption((string) $this->option('from'), now()->subDays(13)->toDateString());
+        $to = $this->parseDateOption((string) $this->option('to'), now()->toDateString());
+
+        if ($from->greaterThan($to)) {
+            $this->error('The --from date must be on or before --to.');
+
+            return self::FAILURE;
+        }
+
+        $locales = array_values(array_filter(array_map(
+            static fn (mixed $value): string => trim((string) $value),
+            (array) $this->option('locale')
+        ), static fn (string $value): bool => $value !== ''));
+
+        $orgIds = array_values(array_filter(array_map(
+            static fn (mixed $value): int => max(0, (int) $value),
+            (array) $this->option('org')
+        ), static fn (int $value): bool => $value > 0));
+
+        $dryRun = (bool) $this->option('dry-run');
+
+        $result = $this->builder->refresh($from, $to, $orgIds, $locales, $dryRun);
+
+        $this->line('from='.$result['from']);
+        $this->line('to='.$result['to']);
+        $this->line('org_scope='.(empty($result['org_scope']) ? '*' : implode(',', $result['org_scope'])));
+        $this->line('locale_scope='.(empty($result['locale_scope']) ? '*' : implode(',', $result['locale_scope'])));
+        $this->line('scale_scope='.$result['scale_scope']['scale_code'].'/'.$result['scale_scope']['scale_code_v2']);
+        $this->line('dry_run='.(($result['dry_run'] ?? false) ? '1' : '0'));
+        $this->line('source_results='.(string) ($result['source_results'] ?? 0));
+        $this->line('source_results_with_at='.(string) ($result['source_results_with_at'] ?? 0));
+        $this->line('attempted_type_rows='.(string) ($result['attempted_type_rows'] ?? 0));
+        $this->line('attempted_axis_rows='.(string) ($result['attempted_axis_rows'] ?? 0));
+        $this->line('deleted_type_rows='.(string) ($result['deleted_type_rows'] ?? 0));
+        $this->line('deleted_axis_rows='.(string) ($result['deleted_axis_rows'] ?? 0));
+        $this->line('upserted_type_rows='.(string) ($result['upserted_type_rows'] ?? 0));
+        $this->line('upserted_axis_rows='.(string) ($result['upserted_axis_rows'] ?? 0));
+        $this->line('at_authority_complete='.(($result['at_authority_complete'] ?? false) ? '1' : '0'));
+
+        if ((($result['attempted_type_rows'] ?? 0) === 0) && (($result['attempted_axis_rows'] ?? 0) === 0)) {
+            $this->warn('No MBTI authority rows were generated for the selected scope.');
+        } else {
+            $this->info($dryRun ? 'dry-run complete' : 'refresh complete');
+        }
+
+        return self::SUCCESS;
+    }
+
+    private function parseDateOption(string $value, string $fallback): CarbonImmutable
+    {
+        $candidate = trim($value) !== '' ? trim($value) : $fallback;
+
+        return CarbonImmutable::createFromFormat('Y-m-d', $candidate)?->startOfDay()
+            ?? CarbonImmutable::parse($candidate)->startOfDay();
+    }
+}

--- a/backend/app/Filament/Ops/Pages/MbtiInsightsPage.php
+++ b/backend/app/Filament/Ops/Pages/MbtiInsightsPage.php
@@ -1,0 +1,723 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Filament\Ops\Pages;
+
+use App\Services\Analytics\MbtiInsightsSupport;
+use App\Support\OrgContext;
+use App\Support\Rbac\PermissionNames;
+use App\Support\SchemaBaseline;
+use Carbon\CarbonImmutable;
+use Filament\Actions\Action;
+use Filament\Pages\Page;
+use Illuminate\Support\Collection;
+use Illuminate\Support\Facades\DB;
+
+class MbtiInsightsPage extends Page
+{
+    protected static ?string $navigationIcon = 'heroicon-o-chart-pie';
+
+    protected static ?string $navigationGroup = 'Assessment Insights';
+
+    protected static ?string $navigationLabel = 'MBTI Insights';
+
+    protected static ?int $navigationSort = 1;
+
+    protected static ?string $slug = 'mbti-insights';
+
+    protected static string $view = 'filament.ops.pages.mbti-insights-page';
+
+    public string $activeTab = 'overview';
+
+    public string $fromDate = '';
+
+    public string $toDate = '';
+
+    public string $locale = 'all';
+
+    public string $region = 'all';
+
+    public string $contentPackageVersion = 'all';
+
+    public string $scoringSpecVersion = 'all';
+
+    public string $normVersion = 'all';
+
+    /** @var array<string,string> */
+    public array $localeOptions = [];
+
+    /** @var array<string,string> */
+    public array $regionOptions = [];
+
+    /** @var array<string,string> */
+    public array $contentPackageVersionOptions = [];
+
+    /** @var array<string,string> */
+    public array $scoringSpecVersionOptions = [];
+
+    /** @var array<string,string> */
+    public array $normVersionOptions = [];
+
+    /** @var list<array<string,mixed>> */
+    public array $kpis = [];
+
+    /** @var list<array<string,mixed>> */
+    public array $dailyTrend = [];
+
+    /** @var list<array<string,mixed>> */
+    public array $localeSplit = [];
+
+    /** @var list<array<string,mixed>> */
+    public array $versionSplit = [];
+
+    /** @var list<array<string,mixed>> */
+    public array $typeDistribution = [];
+
+    /** @var list<array<string,mixed>> */
+    public array $typeTrend = [];
+
+    /** @var list<array<string,mixed>> */
+    public array $axisSummary = [];
+
+    /** @var list<array<string,mixed>> */
+    public array $axisComparisonByLocale = [];
+
+    /** @var list<array<string,mixed>> */
+    public array $axisComparisonByVersion = [];
+
+    /** @var list<string> */
+    public array $scopeNotes = [];
+
+    /** @var list<string> */
+    public array $warnings = [];
+
+    /** @var array{scale_code:string,scale_code_v2:string,scale_uid:?string} */
+    public array $canonicalScale = [
+        'scale_code' => 'MBTI',
+        'scale_code_v2' => 'MBTI_PERSONALITY_TEST_16_TYPES',
+        'scale_uid' => null,
+    ];
+
+    public bool $hasData = false;
+
+    public bool $showsAtAxis = false;
+
+    public function mount(): void
+    {
+        $this->canonicalScale = app(MbtiInsightsSupport::class)->canonicalScale();
+        $this->fromDate = now()->subDays(13)->toDateString();
+        $this->toDate = now()->toDateString();
+        $this->refreshPage();
+    }
+
+    public static function canAccess(): bool
+    {
+        $guard = (string) config('admin.guard', 'admin');
+        $user = auth($guard)->user();
+
+        return is_object($user)
+            && method_exists($user, 'hasPermission')
+            && (
+                $user->hasPermission(PermissionNames::ADMIN_OPS_READ)
+                || $user->hasPermission(PermissionNames::ADMIN_OWNER)
+            );
+    }
+
+    public function getTitle(): string
+    {
+        return 'MBTI Insights';
+    }
+
+    public function getSubheading(): ?string
+    {
+        return 'Results-rooted MBTI Overview, Type Distribution, and Axis Distribution with attempt-side locale, region, and version context.';
+    }
+
+    public function applyFilters(): void
+    {
+        $this->refreshPage();
+    }
+
+    public function setActiveTab(string $tab): void
+    {
+        if (! in_array($tab, ['overview', 'types', 'axes'], true)) {
+            return;
+        }
+
+        $this->activeTab = $tab;
+    }
+
+    public function formatInt(int $value): string
+    {
+        return number_format($value);
+    }
+
+    public function formatRate(?float $value): string
+    {
+        if ($value === null) {
+            return 'n/a';
+        }
+
+        return number_format($value * 100, 1).'%';
+    }
+
+    public function typeDrillUrl(string $typeCode): string
+    {
+        return '/ops/results?tableSearch='.rawurlencode($typeCode);
+    }
+
+    protected function getHeaderActions(): array
+    {
+        return [
+            Action::make('results')
+                ->label('Results Explorer')
+                ->url('/ops/results'),
+        ];
+    }
+
+    private function refreshPage(): void
+    {
+        $this->warnings = [];
+        $this->scopeNotes = [];
+        $this->hasData = false;
+        $this->showsAtAxis = false;
+        $this->resetPanels();
+        $this->loadFilterOptions();
+
+        if (! SchemaBaseline::hasTable('analytics_mbti_type_daily') || ! SchemaBaseline::hasTable('analytics_axis_daily')) {
+            $this->warnings[] = 'MBTI daily read models are missing. Run php artisan migrate first.';
+
+            return;
+        }
+
+        [$from, $to] = $this->resolvedRange();
+        if ($from->greaterThan($to)) {
+            $this->warnings[] = 'The selected date range is invalid. Keep the start date on or before the end date.';
+
+            return;
+        }
+
+        $orgId = $this->selectedOrgId();
+        if ($orgId <= 0) {
+            $this->warnings[] = 'Select an org before loading MBTI Insights.';
+
+            return;
+        }
+
+        $typeRows = $this->scopedTypeQuery()
+            ->orderBy('day')
+            ->orderBy('type_code')
+            ->get([
+                'day',
+                'locale',
+                'region',
+                'content_package_version',
+                'scoring_spec_version',
+                'norm_version',
+                'type_code',
+                'results_count',
+                'distinct_attempts_with_results',
+            ]);
+
+        $axisRows = $this->scopedAxisQuery()
+            ->orderBy('day')
+            ->orderBy('axis_code')
+            ->orderBy('side_code')
+            ->get([
+                'day',
+                'locale',
+                'region',
+                'content_package_version',
+                'scoring_spec_version',
+                'norm_version',
+                'axis_code',
+                'side_code',
+                'results_count',
+                'distinct_attempts_with_results',
+            ]);
+
+        $this->hasData = $typeRows->isNotEmpty();
+        if (! $this->hasData) {
+            $this->warnings[] = 'No MBTI authority rows match the current scope. Refresh with php artisan analytics:refresh-mbti-daily --from='.$from->toDateString().' --to='.$to->toDateString().'.';
+
+            return;
+        }
+
+        $totals = $this->summarizeTypeRows($typeRows);
+        $atCoverage = (int) $axisRows->where('axis_code', 'AT')->sum('results_count');
+        $this->showsAtAxis = $atCoverage > 0 && $atCoverage === (int) ($totals['total_results'] ?? 0);
+
+        $this->kpis = $this->buildKpis($totals);
+        $this->dailyTrend = $this->buildDailyTrend($typeRows);
+        $this->localeSplit = $this->buildLocaleSplit($typeRows, (int) ($totals['total_results'] ?? 0));
+        $this->versionSplit = $this->buildVersionSplit($typeRows, (int) ($totals['total_results'] ?? 0));
+        $this->typeDistribution = $this->buildTypeDistribution($typeRows, (int) ($totals['total_results'] ?? 0));
+        $this->typeTrend = $this->buildTypeTrend($typeRows);
+        $this->axisSummary = $this->buildAxisSummary($axisRows, $this->showsAtAxis);
+        $this->axisComparisonByLocale = $this->buildAxisComparisonByLocale($axisRows, $this->showsAtAxis);
+        $this->axisComparisonByVersion = $this->buildAxisComparisonByVersion($axisRows, $this->showsAtAxis);
+        $this->scopeNotes = $this->buildScopeNotes($this->showsAtAxis);
+    }
+
+    private function loadFilterOptions(): void
+    {
+        $this->localeOptions = [];
+        $this->regionOptions = [];
+        $this->contentPackageVersionOptions = [];
+        $this->scoringSpecVersionOptions = [];
+        $this->normVersionOptions = [];
+
+        if (! SchemaBaseline::hasTable('analytics_mbti_type_daily')) {
+            return;
+        }
+
+        $orgId = $this->selectedOrgId();
+        if ($orgId <= 0) {
+            return;
+        }
+
+        $base = DB::table('analytics_mbti_type_daily')->where('org_id', $orgId);
+        $this->localeOptions = $this->distinctOptions(clone $base, 'locale');
+        $this->regionOptions = $this->distinctOptions(clone $base, 'region');
+        $this->contentPackageVersionOptions = $this->distinctOptions(clone $base, 'content_package_version');
+        $this->scoringSpecVersionOptions = $this->distinctOptions(clone $base, 'scoring_spec_version');
+        $this->normVersionOptions = $this->distinctOptions(clone $base, 'norm_version');
+    }
+
+    private function scopedTypeQuery(): \Illuminate\Database\Query\Builder
+    {
+        [$from, $to] = $this->resolvedRange();
+        $query = DB::table('analytics_mbti_type_daily')
+            ->where('org_id', $this->selectedOrgId())
+            ->whereBetween('day', [$from->toDateString(), $to->toDateString()])
+            ->where('scale_code', $this->canonicalScale['scale_code']);
+
+        $this->applySharedFilters($query);
+
+        return $query;
+    }
+
+    private function scopedAxisQuery(): \Illuminate\Database\Query\Builder
+    {
+        [$from, $to] = $this->resolvedRange();
+        $query = DB::table('analytics_axis_daily')
+            ->where('org_id', $this->selectedOrgId())
+            ->whereBetween('day', [$from->toDateString(), $to->toDateString()])
+            ->where('scale_code', $this->canonicalScale['scale_code']);
+
+        $this->applySharedFilters($query);
+
+        return $query;
+    }
+
+    private function applySharedFilters(\Illuminate\Database\Query\Builder $query): void
+    {
+        if ($this->locale !== 'all') {
+            $query->where('locale', $this->locale);
+        }
+        if ($this->region !== 'all') {
+            $query->where('region', $this->region);
+        }
+        if ($this->contentPackageVersion !== 'all') {
+            $query->where('content_package_version', $this->contentPackageVersion);
+        }
+        if ($this->scoringSpecVersion !== 'all') {
+            $query->where('scoring_spec_version', $this->scoringSpecVersion);
+        }
+        if ($this->normVersion !== 'all') {
+            $query->where('norm_version', $this->normVersion);
+        }
+    }
+
+    /**
+     * @return array{0:CarbonImmutable,1:CarbonImmutable}
+     */
+    private function resolvedRange(): array
+    {
+        $from = CarbonImmutable::parse($this->fromDate !== '' ? $this->fromDate : now()->subDays(13)->toDateString())->startOfDay();
+        $to = CarbonImmutable::parse($this->toDate !== '' ? $this->toDate : now()->toDateString())->startOfDay();
+
+        return [$from, $to];
+    }
+
+    private function selectedOrgId(): int
+    {
+        $sessionOrgId = max(0, (int) session('ops_org_id', 0));
+        if ($sessionOrgId > 0) {
+            return $sessionOrgId;
+        }
+
+        return max(0, (int) app(OrgContext::class)->orgId());
+    }
+
+    /**
+     * @return array<string,string>
+     */
+    private function distinctOptions(\Illuminate\Database\Query\Builder $query, string $column): array
+    {
+        return $query
+            ->whereNotNull($column)
+            ->where($column, '<>', '')
+            ->distinct()
+            ->orderBy($column)
+            ->pluck($column, $column)
+            ->mapWithKeys(static fn ($value): array => [(string) $value => (string) $value])
+            ->all();
+    }
+
+    /**
+     * @return array{
+     *     total_results:int,
+     *     distinct_attempts_with_results:int,
+     *     top_type:string,
+     *     top_type_share:?float,
+     *     valid_locale_count:int
+     * }
+     */
+    private function summarizeTypeRows(Collection $rows): array
+    {
+        $totalResults = (int) $rows->sum('results_count');
+        $distinctAttempts = (int) $rows->sum('distinct_attempts_with_results');
+        $byType = $rows
+            ->groupBy('type_code')
+            ->map(static fn (Collection $group): int => (int) $group->sum('results_count'))
+            ->sortDesc();
+        $topType = (string) ($byType->keys()->first() ?? 'n/a');
+        $topCount = (int) ($byType->first() ?? 0);
+        $validLocaleCount = (int) $rows
+            ->pluck('locale')
+            ->filter(static fn ($value): bool => trim((string) $value) !== '' && (string) $value !== 'unknown')
+            ->unique()
+            ->count();
+
+        return [
+            'total_results' => $totalResults,
+            'distinct_attempts_with_results' => $distinctAttempts,
+            'top_type' => $topType,
+            'top_type_share' => $totalResults > 0 ? $topCount / $totalResults : null,
+            'valid_locale_count' => $validLocaleCount,
+        ];
+    }
+
+    /**
+     * @param  array<string,mixed>  $totals
+     * @return list<array<string,mixed>>
+     */
+    private function buildKpis(array $totals): array
+    {
+        return [
+            [
+                'label' => 'Total results',
+                'value' => (int) ($totals['total_results'] ?? 0),
+                'description' => 'Authority scope only: MBTI-only results, linked attempts, valid result rows.',
+            ],
+            [
+                'label' => 'Distinct attempts',
+                'value' => (int) ($totals['distinct_attempts_with_results'] ?? 0),
+                'description' => 'Distinct attempts with authoritative MBTI results in the current scope.',
+            ],
+            [
+                'label' => 'Top type',
+                'value' => 0,
+                'display_value' => (string) ($totals['top_type'] ?? 'n/a'),
+                'description' => '16-type ranking uses the MBTI base code and keeps A/T out of the main type split.',
+            ],
+            [
+                'label' => 'Top type share',
+                'value' => 0,
+                'display_value' => $this->formatRate($totals['top_type_share'] ?? null),
+                'description' => 'Share of the leading 16-type in the current scope.',
+            ],
+            [
+                'label' => 'Valid locale count',
+                'value' => (int) ($totals['valid_locale_count'] ?? 0),
+                'description' => 'Locales with at least one authority result row in the current filter scope.',
+            ],
+        ];
+    }
+
+    /**
+     * @return list<array<string,mixed>>
+     */
+    private function buildDailyTrend(Collection $rows): array
+    {
+        $daily = $rows
+            ->groupBy('day')
+            ->map(static fn (Collection $group): int => (int) $group->sum('results_count'));
+        $max = max(1, (int) $daily->max());
+
+        return $daily
+            ->sortKeys()
+            ->map(static fn (int $count, string $day) => [
+                'day' => $day,
+                'results_count' => $count,
+                'pct' => round(($count / $max) * 100, 1),
+            ])
+            ->values()
+            ->all();
+    }
+
+    /**
+     * @return list<array<string,mixed>>
+     */
+    private function buildLocaleSplit(Collection $rows, int $totalResults): array
+    {
+        return $rows
+            ->groupBy('locale')
+            ->map(function (Collection $group, string $locale) use ($totalResults): array {
+                $typeMap = $group
+                    ->groupBy('type_code')
+                    ->map(static fn (Collection $rows): int => (int) $rows->sum('results_count'))
+                    ->sortDesc();
+
+                return [
+                    'locale' => $locale,
+                    'results_count' => (int) $group->sum('results_count'),
+                    'share' => $totalResults > 0 ? ((int) $group->sum('results_count')) / $totalResults : null,
+                    'top_type' => (string) ($typeMap->keys()->first() ?? 'n/a'),
+                ];
+            })
+            ->sortByDesc('results_count')
+            ->values()
+            ->all();
+    }
+
+    /**
+     * @return list<array<string,mixed>>
+     */
+    private function buildVersionSplit(Collection $rows, int $totalResults): array
+    {
+        return $rows
+            ->groupBy(static fn ($row): string => implode('|', [
+                (string) $row->content_package_version,
+                (string) $row->scoring_spec_version,
+                (string) $row->norm_version,
+            ]))
+            ->map(function (Collection $group, string $key) use ($totalResults): array {
+                [$contentVersion, $scoringVersion, $normVersion] = explode('|', $key);
+
+                return [
+                    'content_package_version' => $contentVersion,
+                    'scoring_spec_version' => $scoringVersion,
+                    'norm_version' => $normVersion,
+                    'results_count' => (int) $group->sum('results_count'),
+                    'share' => $totalResults > 0 ? ((int) $group->sum('results_count')) / $totalResults : null,
+                ];
+            })
+            ->sortByDesc('results_count')
+            ->values()
+            ->take(8)
+            ->all();
+    }
+
+    /**
+     * @return list<array<string,mixed>>
+     */
+    private function buildTypeDistribution(Collection $rows, int $totalResults): array
+    {
+        return $rows
+            ->groupBy('type_code')
+            ->map(function (Collection $group, string $typeCode) use ($totalResults): array {
+                $count = (int) $group->sum('results_count');
+
+                return [
+                    'type_code' => $typeCode,
+                    'results_count' => $count,
+                    'share' => $totalResults > 0 ? $count / $totalResults : null,
+                    'drill_url' => $this->typeDrillUrl($typeCode),
+                ];
+            })
+            ->sortByDesc('results_count')
+            ->values()
+            ->all();
+    }
+
+    /**
+     * @return list<array<string,mixed>>
+     */
+    private function buildTypeTrend(Collection $rows): array
+    {
+        return $rows
+            ->groupBy('day')
+            ->map(function (Collection $group, string $day): array {
+                $typeMap = $group
+                    ->groupBy('type_code')
+                    ->map(static fn (Collection $rows): int => (int) $rows->sum('results_count'))
+                    ->sortDesc();
+                $total = (int) $group->sum('results_count');
+                $topCount = (int) ($typeMap->first() ?? 0);
+
+                return [
+                    'day' => $day,
+                    'results_count' => $total,
+                    'top_type' => (string) ($typeMap->keys()->first() ?? 'n/a'),
+                    'top_type_share' => $total > 0 ? $topCount / $total : null,
+                ];
+            })
+            ->sortBy('day')
+            ->values()
+            ->all();
+    }
+
+    /**
+     * @return list<array<string,mixed>>
+     */
+    private function buildAxisSummary(Collection $rows, bool $includeAt): array
+    {
+        $allowedAxes = $includeAt ? ['EI', 'SN', 'TF', 'JP', 'AT'] : ['EI', 'SN', 'TF', 'JP'];
+        $definitions = app(MbtiInsightsSupport::class)->axisDefinitions($includeAt);
+
+        return $rows
+            ->filter(static fn ($row): bool => in_array((string) $row->axis_code, $allowedAxes, true))
+            ->groupBy('axis_code')
+            ->map(function (Collection $group, string $axisCode) use ($definitions): array {
+                $axisTotal = max(1, (int) $group->sum('results_count'));
+                $sides = $group
+                    ->groupBy('side_code')
+                    ->map(function (Collection $rows, string $sideCode) use ($axisTotal): array {
+                        $count = (int) $rows->sum('results_count');
+
+                        return [
+                            'side_code' => $sideCode,
+                            'results_count' => $count,
+                            'share' => $count / $axisTotal,
+                        ];
+                    })
+                    ->sortByDesc('results_count')
+                    ->values()
+                    ->all();
+
+                return [
+                    'axis_code' => $axisCode,
+                    'label' => $definitions[$axisCode]['label'] ?? $axisCode,
+                    'results_count' => (int) $group->sum('results_count'),
+                    'sides' => $sides,
+                ];
+            })
+            ->sortBy(static fn (array $row): int => array_search($row['axis_code'], $allowedAxes, true))
+            ->values()
+            ->all();
+    }
+
+    /**
+     * @return list<array<string,mixed>>
+     */
+    private function buildAxisComparisonByLocale(Collection $rows, bool $includeAt): array
+    {
+        $allowedAxes = $includeAt ? ['EI', 'SN', 'TF', 'JP', 'AT'] : ['EI', 'SN', 'TF', 'JP'];
+
+        return $rows
+            ->filter(static fn ($row): bool => in_array((string) $row->axis_code, $allowedAxes, true))
+            ->groupBy('locale')
+            ->map(function (Collection $group, string $locale) use ($allowedAxes): array {
+                $leadMap = [];
+
+                foreach ($allowedAxes as $axisCode) {
+                    $axisGroup = $group->where('axis_code', $axisCode);
+                    $axisTotal = (int) $axisGroup->sum('results_count');
+                    if ($axisTotal <= 0) {
+                        $leadMap[$axisCode] = 'n/a';
+                        continue;
+                    }
+
+                    $leader = $axisGroup->groupBy('side_code')
+                        ->map(static fn (Collection $rows): int => (int) $rows->sum('results_count'))
+                        ->sortDesc();
+                    $side = (string) ($leader->keys()->first() ?? 'n/a');
+                    $count = (int) ($leader->first() ?? 0);
+                    $leadMap[$axisCode] = $side.' '.$this->formatRate($count / $axisTotal);
+                }
+
+                return [
+                    'locale' => $locale,
+                    'results_count' => (int) $group->where('axis_code', 'EI')->sum('results_count'),
+                    'lead_map' => $leadMap,
+                ];
+            })
+            ->sortByDesc('results_count')
+            ->values()
+            ->all();
+    }
+
+    /**
+     * @return list<array<string,mixed>>
+     */
+    private function buildAxisComparisonByVersion(Collection $rows, bool $includeAt): array
+    {
+        $allowedAxes = $includeAt ? ['EI', 'SN', 'TF', 'JP', 'AT'] : ['EI', 'SN', 'TF', 'JP'];
+
+        return $rows
+            ->filter(static fn ($row): bool => in_array((string) $row->axis_code, $allowedAxes, true))
+            ->groupBy(static fn ($row): string => implode('|', [
+                (string) $row->content_package_version,
+                (string) $row->scoring_spec_version,
+            ]))
+            ->map(function (Collection $group, string $key): array {
+                [$contentVersion, $scoringVersion] = explode('|', $key);
+                $axisSnapshot = $group
+                    ->groupBy('axis_code')
+                    ->map(function (Collection $rows): string {
+                        $totals = $rows
+                            ->groupBy('side_code')
+                            ->map(static fn (Collection $rows): int => (int) $rows->sum('results_count'))
+                            ->sortDesc();
+                        $axisTotal = max(1, (int) $totals->sum());
+                        $side = (string) ($totals->keys()->first() ?? 'n/a');
+                        $count = (int) ($totals->first() ?? 0);
+
+                        return $side.' '.$this->formatRate($count / $axisTotal);
+                    })
+                    ->sortKeys()
+                    ->map(static fn (string $value, string $axisCode): string => $axisCode.': '.$value)
+                    ->implode(' | ');
+
+                return [
+                    'content_package_version' => $contentVersion,
+                    'scoring_spec_version' => $scoringVersion,
+                    'results_count' => (int) $group->where('axis_code', 'EI')->sum('results_count'),
+                    'axis_snapshot' => $axisSnapshot !== '' ? $axisSnapshot : 'n/a',
+                ];
+            })
+            ->sortByDesc('results_count')
+            ->values()
+            ->take(8)
+            ->all();
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function buildScopeNotes(bool $showsAtAxis): array
+    {
+        $notes = [
+            'Authority scope is MBTI-only and results-based.',
+            'The page excludes invalid rows, orphan results, and fallback-only result payloads without a direct results.type_code.',
+            'Attempt-side locale, region, content_package_version, scoring_spec_version, and norm_version define the operational filter context.',
+            'Paid, unlocked, share, channel, and commerce subsets are intentionally out of the first authority surface.',
+            'Canonical scale scope is '.$this->canonicalScale['scale_code'].' with dual-write support for '.$this->canonicalScale['scale_code_v2'].'.',
+            'Axis direction is derived from scores_pct first and falls back to type_code when scores_pct is missing. axis_states remain strength labels, not side winners.',
+        ];
+
+        if ($showsAtAxis) {
+            $notes[] = 'A/T is included because the current filtered scope has full A/T coverage.';
+        } else {
+            $notes[] = 'A/T is omitted from the first authority axis panel when the current filtered scope lacks full A/T coverage.';
+        }
+
+        return $notes;
+    }
+
+    private function resetPanels(): void
+    {
+        $this->kpis = [];
+        $this->dailyTrend = [];
+        $this->localeSplit = [];
+        $this->versionSplit = [];
+        $this->typeDistribution = [];
+        $this->typeTrend = [];
+        $this->axisSummary = [];
+        $this->axisComparisonByLocale = [];
+        $this->axisComparisonByVersion = [];
+    }
+}

--- a/backend/app/Models/AnalyticsAxisDaily.php
+++ b/backend/app/Models/AnalyticsAxisDaily.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Models;
+
+use App\Models\Concerns\HasOrgScope;
+use Illuminate\Database\Eloquent\Model;
+
+class AnalyticsAxisDaily extends Model
+{
+    use HasOrgScope;
+
+    protected $table = 'analytics_axis_daily';
+
+    protected $fillable = [
+        'day',
+        'org_id',
+        'locale',
+        'region',
+        'scale_code',
+        'content_package_version',
+        'scoring_spec_version',
+        'norm_version',
+        'axis_code',
+        'side_code',
+        'results_count',
+        'distinct_attempts_with_results',
+        'last_refreshed_at',
+    ];
+
+    protected $casts = [
+        'day' => 'date',
+        'org_id' => 'integer',
+        'results_count' => 'integer',
+        'distinct_attempts_with_results' => 'integer',
+        'last_refreshed_at' => 'datetime',
+        'created_at' => 'datetime',
+        'updated_at' => 'datetime',
+    ];
+
+    public static function allowOrgZeroContext(): bool
+    {
+        return self::allowOrgZeroWithResolvedContext();
+    }
+}

--- a/backend/app/Models/AnalyticsMbtiTypeDaily.php
+++ b/backend/app/Models/AnalyticsMbtiTypeDaily.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Models;
+
+use App\Models\Concerns\HasOrgScope;
+use Illuminate\Database\Eloquent\Model;
+
+class AnalyticsMbtiTypeDaily extends Model
+{
+    use HasOrgScope;
+
+    protected $table = 'analytics_mbti_type_daily';
+
+    protected $fillable = [
+        'day',
+        'org_id',
+        'locale',
+        'region',
+        'scale_code',
+        'content_package_version',
+        'scoring_spec_version',
+        'norm_version',
+        'type_code',
+        'results_count',
+        'distinct_attempts_with_results',
+        'last_refreshed_at',
+    ];
+
+    protected $casts = [
+        'day' => 'date',
+        'org_id' => 'integer',
+        'results_count' => 'integer',
+        'distinct_attempts_with_results' => 'integer',
+        'last_refreshed_at' => 'datetime',
+        'created_at' => 'datetime',
+        'updated_at' => 'datetime',
+    ];
+
+    public static function allowOrgZeroContext(): bool
+    {
+        return self::allowOrgZeroWithResolvedContext();
+    }
+}

--- a/backend/app/Services/Analytics/MbtiDistributionDailyBuilder.php
+++ b/backend/app/Services/Analytics/MbtiDistributionDailyBuilder.php
@@ -1,0 +1,619 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\Analytics;
+
+use App\Support\SchemaBaseline;
+use Carbon\CarbonImmutable;
+use Illuminate\Database\Query\Builder as QueryBuilder;
+use Illuminate\Support\Facades\DB;
+
+final class MbtiDistributionDailyBuilder
+{
+    /**
+     * @param  list<int>  $orgIds
+     * @param  list<string>  $locales
+     * @return array{
+     *     type_rows:list<array<string,mixed>>,
+     *     axis_rows:list<array<string,mixed>>,
+     *     attempted_type_rows:int,
+     *     attempted_axis_rows:int,
+     *     source_results:int,
+     *     source_results_with_at:int,
+     *     at_authority_complete:bool,
+     *     org_scope:list<int>,
+     *     locale_scope:list<string>,
+     *     scale_scope:array{scale_code:string,scale_code_v2:string,scale_uid:?string},
+     *     from:string,
+     *     to:string
+     * }
+     */
+    public function build(
+        \DateTimeInterface $from,
+        \DateTimeInterface $to,
+        array $orgIds = [],
+        array $locales = [],
+    ): array {
+        $fromAt = CarbonImmutable::parse($from)->startOfDay();
+        $toAt = CarbonImmutable::parse($to)->endOfDay();
+        $normalizedOrgIds = $this->normalizeOrgIds($orgIds);
+        $normalizedLocales = $this->normalizeLocales($locales);
+        $scaleScope = $this->support->canonicalScale();
+
+        if (! SchemaBaseline::hasTable('results') || ! SchemaBaseline::hasTable('attempts')) {
+            return [
+                'type_rows' => [],
+                'axis_rows' => [],
+                'attempted_type_rows' => 0,
+                'attempted_axis_rows' => 0,
+                'source_results' => 0,
+                'source_results_with_at' => 0,
+                'at_authority_complete' => false,
+                'org_scope' => $normalizedOrgIds,
+                'locale_scope' => $normalizedLocales,
+                'scale_scope' => $scaleScope,
+                'from' => $fromAt->toDateString(),
+                'to' => $toAt->toDateString(),
+            ];
+        }
+
+        $typeAggregates = [];
+        $axisAggregates = [];
+        $sourceResults = 0;
+        $sourceResultsWithAt = 0;
+
+        foreach ($this->authoritativeResultCursor($fromAt, $toAt, $normalizedOrgIds, $normalizedLocales, $scaleScope) as $row) {
+            $projected = $this->projectRow($row, $scaleScope);
+            if ($projected === null) {
+                continue;
+            }
+
+            $sourceResults++;
+            if (isset($projected['axis_sides']['AT'])) {
+                $sourceResultsWithAt++;
+            }
+
+            $this->accumulateTypeRow($typeAggregates, $projected);
+            $this->accumulateAxisRows($axisAggregates, $projected);
+        }
+
+        $typeRows = $this->finalizeTypeRows($typeAggregates);
+        $axisRows = $this->finalizeAxisRows($axisAggregates);
+
+        return [
+            'type_rows' => $typeRows,
+            'axis_rows' => $axisRows,
+            'attempted_type_rows' => count($typeRows),
+            'attempted_axis_rows' => count($axisRows),
+            'source_results' => $sourceResults,
+            'source_results_with_at' => $sourceResultsWithAt,
+            'at_authority_complete' => $sourceResults > 0 && $sourceResults === $sourceResultsWithAt,
+            'org_scope' => $normalizedOrgIds,
+            'locale_scope' => $normalizedLocales,
+            'scale_scope' => $scaleScope,
+            'from' => $fromAt->toDateString(),
+            'to' => $toAt->toDateString(),
+        ];
+    }
+
+    /**
+     * @param  list<int>  $orgIds
+     * @param  list<string>  $locales
+     * @return array{
+     *     type_rows:list<array<string,mixed>>,
+     *     axis_rows:list<array<string,mixed>>,
+     *     attempted_type_rows:int,
+     *     attempted_axis_rows:int,
+     *     source_results:int,
+     *     source_results_with_at:int,
+     *     at_authority_complete:bool,
+     *     org_scope:list<int>,
+     *     locale_scope:list<string>,
+     *     scale_scope:array{scale_code:string,scale_code_v2:string,scale_uid:?string},
+     *     from:string,
+     *     to:string,
+     *     deleted_type_rows:int,
+     *     deleted_axis_rows:int,
+     *     upserted_type_rows:int,
+     *     upserted_axis_rows:int,
+     *     dry_run:bool
+     * }
+     */
+    public function refresh(
+        \DateTimeInterface $from,
+        \DateTimeInterface $to,
+        array $orgIds = [],
+        array $locales = [],
+        bool $dryRun = false,
+    ): array {
+        $payload = $this->build($from, $to, $orgIds, $locales);
+        $deletedTypeRows = 0;
+        $deletedAxisRows = 0;
+        $upsertedTypeRows = 0;
+        $upsertedAxisRows = 0;
+
+        if (! $dryRun) {
+            DB::transaction(function () use (
+                $payload,
+                &$deletedTypeRows,
+                &$deletedAxisRows,
+                &$upsertedTypeRows,
+                &$upsertedAxisRows
+            ): void {
+                $deletedTypeRows = $this->deleteScope(
+                    'analytics_mbti_type_daily',
+                    $payload['from'],
+                    $payload['to'],
+                    $payload['org_scope'],
+                    $payload['locale_scope'],
+                    $payload['scale_scope']['scale_code']
+                );
+                $deletedAxisRows = $this->deleteScope(
+                    'analytics_axis_daily',
+                    $payload['from'],
+                    $payload['to'],
+                    $payload['org_scope'],
+                    $payload['locale_scope'],
+                    $payload['scale_scope']['scale_code']
+                );
+
+                if ($payload['type_rows'] !== []) {
+                    DB::table('analytics_mbti_type_daily')->upsert(
+                        $payload['type_rows'],
+                        [
+                            'day',
+                            'org_id',
+                            'locale',
+                            'region',
+                            'scale_code',
+                            'content_package_version',
+                            'scoring_spec_version',
+                            'norm_version',
+                            'type_code',
+                        ],
+                        [
+                            'results_count',
+                            'distinct_attempts_with_results',
+                            'last_refreshed_at',
+                            'updated_at',
+                        ]
+                    );
+                    $upsertedTypeRows = count($payload['type_rows']);
+                }
+
+                if ($payload['axis_rows'] !== []) {
+                    DB::table('analytics_axis_daily')->upsert(
+                        $payload['axis_rows'],
+                        [
+                            'day',
+                            'org_id',
+                            'locale',
+                            'region',
+                            'scale_code',
+                            'content_package_version',
+                            'scoring_spec_version',
+                            'norm_version',
+                            'axis_code',
+                            'side_code',
+                        ],
+                        [
+                            'results_count',
+                            'distinct_attempts_with_results',
+                            'last_refreshed_at',
+                            'updated_at',
+                        ]
+                    );
+                    $upsertedAxisRows = count($payload['axis_rows']);
+                }
+            });
+        }
+
+        return $payload + [
+            'deleted_type_rows' => $deletedTypeRows,
+            'deleted_axis_rows' => $deletedAxisRows,
+            'upserted_type_rows' => $upsertedTypeRows,
+            'upserted_axis_rows' => $upsertedAxisRows,
+            'dry_run' => $dryRun,
+        ];
+    }
+
+    public function __construct(
+        private readonly MbtiInsightsSupport $support,
+    ) {}
+
+    /**
+     * @param  list<int>  $orgIds
+     * @param  list<string>  $locales
+     */
+    private function authoritativeResultCursor(
+        CarbonImmutable $fromAt,
+        CarbonImmutable $toAt,
+        array $orgIds,
+        array $locales,
+        array $scaleScope,
+    ): \Traversable {
+        $query = DB::table('results as results')
+            ->join('attempts as attempts', 'attempts.id', '=', 'results.attempt_id')
+            ->select([
+                'results.id as result_id',
+                'results.attempt_id',
+                'results.type_code',
+                'results.scale_code as result_scale_code',
+                'results.org_id as result_org_id',
+                'attempts.scale_code as attempt_scale_code',
+                'attempts.org_id as attempt_org_id',
+                'attempts.locale',
+                'attempts.region',
+                'attempts.norm_version',
+            ])
+            ->selectRaw('coalesce(results.computed_at, results.created_at, results.updated_at) as activity_at')
+            ->whereRaw('coalesce(results.computed_at, results.created_at, results.updated_at) >= ?', [$fromAt->toDateTimeString()])
+            ->whereRaw('coalesce(results.computed_at, results.created_at, results.updated_at) <= ?', [$toAt->toDateTimeString()])
+            ->whereNotNull('results.type_code')
+            ->where('results.type_code', '<>', '')
+            ->orderBy('results.id');
+
+        if (SchemaBaseline::hasColumn('results', 'is_valid')) {
+            $query->where('results.is_valid', true);
+        }
+
+        if (SchemaBaseline::hasColumn('results', 'scale_code_v2')) {
+            $query->addSelect('results.scale_code_v2 as result_scale_code_v2');
+        }
+        if (SchemaBaseline::hasColumn('results', 'scale_uid')) {
+            $query->addSelect('results.scale_uid as result_scale_uid');
+        }
+        if (SchemaBaseline::hasColumn('results', 'scores_pct')) {
+            $query->addSelect('results.scores_pct');
+        }
+        if (SchemaBaseline::hasColumn('results', 'content_package_version')) {
+            $query->addSelect('results.content_package_version as result_content_package_version');
+        }
+        if (SchemaBaseline::hasColumn('results', 'scoring_spec_version')) {
+            $query->addSelect('results.scoring_spec_version as result_scoring_spec_version');
+        }
+        if (SchemaBaseline::hasColumn('attempts', 'scale_code_v2')) {
+            $query->addSelect('attempts.scale_code_v2 as attempt_scale_code_v2');
+        }
+        if (SchemaBaseline::hasColumn('attempts', 'scale_uid')) {
+            $query->addSelect('attempts.scale_uid as attempt_scale_uid');
+        }
+        if (SchemaBaseline::hasColumn('attempts', 'content_package_version')) {
+            $query->addSelect('attempts.content_package_version as attempt_content_package_version');
+        }
+        if (SchemaBaseline::hasColumn('attempts', 'scoring_spec_version')) {
+            $query->addSelect('attempts.scoring_spec_version as attempt_scoring_spec_version');
+        }
+
+        $this->applyCanonicalScaleFilter($query, 'results', 'results', $scaleScope);
+        $this->applyCanonicalScaleFilter($query, 'attempts', 'attempts', $scaleScope);
+
+        if ($orgIds !== []) {
+            $query->where(function (QueryBuilder $builder) use ($orgIds): void {
+                $builder
+                    ->whereIn('attempts.org_id', $orgIds)
+                    ->orWhereIn('results.org_id', $orgIds);
+            });
+        }
+
+        if ($locales !== []) {
+            $query->whereIn('attempts.locale', $locales);
+        }
+
+        return $query->cursor();
+    }
+
+    /**
+     * @param  array{scale_code:string,scale_code_v2:string,scale_uid:?string}  $scaleScope
+     */
+    private function projectRow(object $row, array $scaleScope): ?array
+    {
+        $typeVariant = $this->support->normalizeTypeVariant((string) ($row->type_code ?? ''));
+        if ($typeVariant === null) {
+            return null;
+        }
+
+        $activityAt = trim((string) ($row->activity_at ?? ''));
+        if ($activityAt === '') {
+            return null;
+        }
+
+        $scoresPct = $this->decodeJsonAssoc($row->scores_pct ?? null);
+        $axisSides = $this->support->deriveAxisSides($scoresPct, (string) ($row->type_code ?? ''));
+
+        $orgId = max(0, (int) ($row->attempt_org_id ?? 0));
+        if ($orgId <= 0) {
+            $orgId = max(0, (int) ($row->result_org_id ?? 0));
+        }
+
+        return [
+            'day' => CarbonImmutable::parse($activityAt)->toDateString(),
+            'org_id' => $orgId,
+            'locale' => $this->normalizeDimension((string) ($row->locale ?? 'unknown')),
+            'region' => $this->normalizeDimension((string) ($row->region ?? 'unknown')),
+            'scale_code' => $scaleScope['scale_code'],
+            'content_package_version' => $this->normalizeDimension(
+                (string) (($row->attempt_content_package_version ?? null) ?: ($row->result_content_package_version ?? ''))
+            ),
+            'scoring_spec_version' => $this->normalizeDimension(
+                (string) (($row->attempt_scoring_spec_version ?? null) ?: ($row->result_scoring_spec_version ?? ''))
+            ),
+            'norm_version' => $this->normalizeDimension((string) ($row->norm_version ?? '')),
+            'type_code' => $typeVariant['base'],
+            'attempt_id' => (string) ($row->attempt_id ?? ''),
+            'axis_sides' => $axisSides,
+        ];
+    }
+
+    /**
+     * @param  array<string,array<string,mixed>>  $aggregates
+     * @param  array<string,mixed>  $projected
+     */
+    private function accumulateTypeRow(array &$aggregates, array $projected): void
+    {
+        $key = implode('|', [
+            $projected['day'],
+            (string) $projected['org_id'],
+            $projected['locale'],
+            $projected['region'],
+            $projected['scale_code'],
+            $projected['content_package_version'],
+            $projected['scoring_spec_version'],
+            $projected['norm_version'],
+            $projected['type_code'],
+        ]);
+
+        if (! isset($aggregates[$key])) {
+            $aggregates[$key] = [
+                'day' => $projected['day'],
+                'org_id' => $projected['org_id'],
+                'locale' => $projected['locale'],
+                'region' => $projected['region'],
+                'scale_code' => $projected['scale_code'],
+                'content_package_version' => $projected['content_package_version'],
+                'scoring_spec_version' => $projected['scoring_spec_version'],
+                'norm_version' => $projected['norm_version'],
+                'type_code' => $projected['type_code'],
+                'results_count' => 0,
+                'attempt_ids' => [],
+            ];
+        }
+
+        $aggregates[$key]['results_count']++;
+        $aggregates[$key]['attempt_ids'][$projected['attempt_id']] = true;
+    }
+
+    /**
+     * @param  array<string,array<string,mixed>>  $aggregates
+     * @param  array<string,mixed>  $projected
+     */
+    private function accumulateAxisRows(array &$aggregates, array $projected): void
+    {
+        foreach ((array) ($projected['axis_sides'] ?? []) as $axisCode => $sideCode) {
+            $key = implode('|', [
+                $projected['day'],
+                (string) $projected['org_id'],
+                $projected['locale'],
+                $projected['region'],
+                $projected['scale_code'],
+                $projected['content_package_version'],
+                $projected['scoring_spec_version'],
+                $projected['norm_version'],
+                $axisCode,
+                $sideCode,
+            ]);
+
+            if (! isset($aggregates[$key])) {
+                $aggregates[$key] = [
+                    'day' => $projected['day'],
+                    'org_id' => $projected['org_id'],
+                    'locale' => $projected['locale'],
+                    'region' => $projected['region'],
+                    'scale_code' => $projected['scale_code'],
+                    'content_package_version' => $projected['content_package_version'],
+                    'scoring_spec_version' => $projected['scoring_spec_version'],
+                    'norm_version' => $projected['norm_version'],
+                    'axis_code' => $axisCode,
+                    'side_code' => $sideCode,
+                    'results_count' => 0,
+                    'attempt_ids' => [],
+                ];
+            }
+
+            $aggregates[$key]['results_count']++;
+            $aggregates[$key]['attempt_ids'][$projected['attempt_id']] = true;
+        }
+    }
+
+    /**
+     * @param  array<string,array<string,mixed>>  $aggregates
+     * @return list<array<string,mixed>>
+     */
+    private function finalizeTypeRows(array $aggregates): array
+    {
+        $timestamp = now();
+        $rows = [];
+
+        foreach ($aggregates as $row) {
+            $rows[] = [
+                'day' => $row['day'],
+                'org_id' => $row['org_id'],
+                'locale' => $row['locale'],
+                'region' => $row['region'],
+                'scale_code' => $row['scale_code'],
+                'content_package_version' => $row['content_package_version'],
+                'scoring_spec_version' => $row['scoring_spec_version'],
+                'norm_version' => $row['norm_version'],
+                'type_code' => $row['type_code'],
+                'results_count' => (int) ($row['results_count'] ?? 0),
+                'distinct_attempts_with_results' => count((array) ($row['attempt_ids'] ?? [])),
+                'last_refreshed_at' => $timestamp,
+                'created_at' => $timestamp,
+                'updated_at' => $timestamp,
+            ];
+        }
+
+        usort($rows, static function (array $a, array $b): int {
+            return [$a['day'], $a['locale'], $a['type_code']] <=> [$b['day'], $b['locale'], $b['type_code']];
+        });
+
+        return $rows;
+    }
+
+    /**
+     * @param  array<string,array<string,mixed>>  $aggregates
+     * @return list<array<string,mixed>>
+     */
+    private function finalizeAxisRows(array $aggregates): array
+    {
+        $timestamp = now();
+        $rows = [];
+
+        foreach ($aggregates as $row) {
+            $rows[] = [
+                'day' => $row['day'],
+                'org_id' => $row['org_id'],
+                'locale' => $row['locale'],
+                'region' => $row['region'],
+                'scale_code' => $row['scale_code'],
+                'content_package_version' => $row['content_package_version'],
+                'scoring_spec_version' => $row['scoring_spec_version'],
+                'norm_version' => $row['norm_version'],
+                'axis_code' => $row['axis_code'],
+                'side_code' => $row['side_code'],
+                'results_count' => (int) ($row['results_count'] ?? 0),
+                'distinct_attempts_with_results' => count((array) ($row['attempt_ids'] ?? [])),
+                'last_refreshed_at' => $timestamp,
+                'created_at' => $timestamp,
+                'updated_at' => $timestamp,
+            ];
+        }
+
+        usort($rows, static function (array $a, array $b): int {
+            return [$a['day'], $a['locale'], $a['axis_code'], $a['side_code']] <=> [$b['day'], $b['locale'], $b['axis_code'], $b['side_code']];
+        });
+
+        return $rows;
+    }
+
+    /**
+     * @param  list<int>  $orgIds
+     * @param  list<string>  $locales
+     */
+    private function deleteScope(
+        string $table,
+        string $from,
+        string $to,
+        array $orgIds,
+        array $locales,
+        string $scaleCode,
+    ): int {
+        if (! SchemaBaseline::hasTable($table)) {
+            return 0;
+        }
+
+        $query = DB::table($table)
+            ->whereBetween('day', [$from, $to])
+            ->where('scale_code', $scaleCode);
+
+        if ($orgIds !== []) {
+            $query->whereIn('org_id', $orgIds);
+        }
+
+        if ($locales !== []) {
+            $query->whereIn('locale', $locales);
+        }
+
+        return $query->delete();
+    }
+
+    /**
+     * @param  array{scale_code:string,scale_code_v2:string,scale_uid:?string}  $scaleScope
+     */
+    private function applyCanonicalScaleFilter(
+        QueryBuilder $query,
+        string $tableName,
+        string $alias,
+        array $scaleScope,
+    ): void {
+        $query->where(function (QueryBuilder $builder) use ($tableName, $alias, $scaleScope): void {
+            $builder->whereRaw('1 = 0');
+
+            if (SchemaBaseline::hasColumn($tableName, 'scale_uid') && $scaleScope['scale_uid'] !== null) {
+                $builder->orWhere($alias.'.scale_uid', $scaleScope['scale_uid']);
+            }
+
+            if (SchemaBaseline::hasColumn($tableName, 'scale_code_v2') && $scaleScope['scale_code_v2'] !== '') {
+                $builder->orWhereRaw('upper('.$alias.'.scale_code_v2) = ?', [$scaleScope['scale_code_v2']]);
+            }
+
+            if (SchemaBaseline::hasColumn($tableName, 'scale_code')) {
+                $builder->orWhereRaw('upper('.$alias.'.scale_code) = ?', [$scaleScope['scale_code']]);
+            }
+        });
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    private function decodeJsonAssoc(mixed $value): array
+    {
+        if (is_array($value)) {
+            return $value;
+        }
+
+        if (! is_string($value) || trim($value) === '') {
+            return [];
+        }
+
+        $decoded = json_decode($value, true);
+
+        return is_array($decoded) ? $decoded : [];
+    }
+
+    private function normalizeDimension(string $value): string
+    {
+        $normalized = trim($value);
+
+        return $normalized !== '' ? $normalized : 'unknown';
+    }
+
+    /**
+     * @param  list<int|string>  $orgIds
+     * @return list<int>
+     */
+    private function normalizeOrgIds(array $orgIds): array
+    {
+        $set = [];
+
+        foreach ($orgIds as $orgId) {
+            $normalized = max(0, (int) $orgId);
+            if ($normalized <= 0) {
+                continue;
+            }
+            $set[$normalized] = true;
+        }
+
+        return array_values(array_keys($set));
+    }
+
+    /**
+     * @param  list<mixed>  $locales
+     * @return list<string>
+     */
+    private function normalizeLocales(array $locales): array
+    {
+        $set = [];
+
+        foreach ($locales as $locale) {
+            $normalized = trim((string) $locale);
+            if ($normalized === '') {
+                continue;
+            }
+            $set[$normalized] = true;
+        }
+
+        return array_values(array_keys($set));
+    }
+}

--- a/backend/app/Services/Analytics/MbtiInsightsSupport.php
+++ b/backend/app/Services/Analytics/MbtiInsightsSupport.php
@@ -1,0 +1,170 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\Analytics;
+
+use App\Services\Scale\ScaleIdentityResolver;
+
+final class MbtiInsightsSupport
+{
+    public function __construct(
+        private readonly ScaleIdentityResolver $scaleIdentityResolver,
+    ) {}
+
+    /**
+     * @return array{
+     *     scale_code:string,
+     *     scale_code_v2:string,
+     *     scale_uid:?string
+     * }
+     */
+    public function canonicalScale(): array
+    {
+        $resolved = $this->scaleIdentityResolver->resolveByAnyCode('MBTI');
+
+        $legacy = strtoupper(trim((string) ($resolved['scale_code_v1'] ?? 'MBTI')));
+        $v2 = strtoupper(trim((string) ($resolved['scale_code_v2'] ?? (config('scale_identity.code_map_v1_to_v2.MBTI') ?? 'MBTI'))));
+        $uid = trim((string) ($resolved['scale_uid'] ?? (config('scale_identity.scale_uid_map.MBTI') ?? '')));
+
+        return [
+            'scale_code' => $legacy !== '' ? $legacy : 'MBTI',
+            'scale_code_v2' => $v2 !== '' ? $v2 : 'MBTI_PERSONALITY_TEST_16_TYPES',
+            'scale_uid' => $uid !== '' ? $uid : null,
+        ];
+    }
+
+    /**
+     * @return array<string, array{
+     *     label:string,
+     *     first_code:string,
+     *     second_code:string,
+     *     side_labels:array<string,string>
+     * }>
+     */
+    public function axisDefinitions(bool $includeAt = true): array
+    {
+        $definitions = [
+            'EI' => [
+                'label' => 'E / I',
+                'first_code' => 'E',
+                'second_code' => 'I',
+                'side_labels' => [
+                    'E' => 'Extraversion',
+                    'I' => 'Introversion',
+                ],
+            ],
+            'SN' => [
+                'label' => 'S / N',
+                'first_code' => 'S',
+                'second_code' => 'N',
+                'side_labels' => [
+                    'S' => 'Sensing',
+                    'N' => 'Intuition',
+                ],
+            ],
+            'TF' => [
+                'label' => 'T / F',
+                'first_code' => 'T',
+                'second_code' => 'F',
+                'side_labels' => [
+                    'T' => 'Thinking',
+                    'F' => 'Feeling',
+                ],
+            ],
+            'JP' => [
+                'label' => 'J / P',
+                'first_code' => 'J',
+                'second_code' => 'P',
+                'side_labels' => [
+                    'J' => 'Judging',
+                    'P' => 'Perceiving',
+                ],
+            ],
+        ];
+
+        if ($includeAt) {
+            $definitions['AT'] = [
+                'label' => 'A / T',
+                'first_code' => 'A',
+                'second_code' => 'T',
+                'side_labels' => [
+                    'A' => 'Assertive',
+                    'T' => 'Turbulent',
+                ],
+            ];
+        }
+
+        return $definitions;
+    }
+
+    /**
+     * @return array{base:string,suffix:?string,raw:string}|null
+     */
+    public function normalizeTypeVariant(string $typeCode): ?array
+    {
+        $normalized = strtoupper(trim($typeCode));
+        if ($normalized === '') {
+            return null;
+        }
+
+        if (preg_match('/^([EI][SN][TF][JP])(?:-([AT]))?$/', $normalized, $matches) !== 1) {
+            return null;
+        }
+
+        $base = (string) ($matches[1] ?? '');
+        $suffix = trim((string) ($matches[2] ?? ''));
+
+        return [
+            'base' => $base,
+            'suffix' => $suffix !== '' ? $suffix : null,
+            'raw' => $normalized,
+        ];
+    }
+
+    public function normalizeBaseTypeCode(string $typeCode): ?string
+    {
+        return $this->normalizeTypeVariant($typeCode)['base'] ?? null;
+    }
+
+    /**
+     * @param  array<string,mixed>  $scoresPct
+     * @return array<string,string>
+     */
+    public function deriveAxisSides(array $scoresPct, string $typeCode): array
+    {
+        $variant = $this->normalizeTypeVariant($typeCode);
+        $base = $variant['base'] ?? '';
+        $suffix = $variant['suffix'] ?? null;
+        $definitions = $this->axisDefinitions();
+        $sides = [];
+
+        foreach ($definitions as $axisCode => $definition) {
+            $resolved = null;
+
+            if (array_key_exists($axisCode, $scoresPct) && is_numeric($scoresPct[$axisCode])) {
+                $pct = max(0.0, min(100.0, (float) $scoresPct[$axisCode]));
+                $resolved = $pct >= 50.0 ? $definition['first_code'] : $definition['second_code'];
+            } elseif ($base !== '' && strlen($base) === 4) {
+                $resolved = match ($axisCode) {
+                    'EI' => $base[0],
+                    'SN' => $base[1],
+                    'TF' => $base[2],
+                    'JP' => $base[3],
+                    'AT' => $suffix,
+                    default => null,
+                };
+            } elseif ($axisCode === 'AT' && $suffix !== null) {
+                $resolved = $suffix;
+            }
+
+            $candidate = strtoupper(trim((string) $resolved));
+            $allowed = [$definition['first_code'], $definition['second_code']];
+            if ($candidate !== '' && in_array($candidate, $allowed, true)) {
+                $sides[$axisCode] = $candidate;
+            }
+        }
+
+        return $sides;
+    }
+}

--- a/backend/database/migrations/2026_03_14_140000_create_analytics_mbti_daily_tables.php
+++ b/backend/database/migrations/2026_03_14_140000_create_analytics_mbti_daily_tables.php
@@ -1,0 +1,246 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Support\Database\SchemaIndex;
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    private const TYPE_TABLE = 'analytics_mbti_type_daily';
+
+    private const AXIS_TABLE = 'analytics_axis_daily';
+
+    public function up(): void
+    {
+        $this->createTypeTable();
+        $this->createAxisTable();
+    }
+
+    public function down(): void
+    {
+        // forward-only migration: rollback disabled to prevent data loss in production.
+        // Irreversible operation: schema/data rollback handled via forward fix migrations.
+    }
+
+    private function createTypeTable(): void
+    {
+        if (! Schema::hasTable(self::TYPE_TABLE)) {
+            Schema::create(self::TYPE_TABLE, function (Blueprint $table): void {
+                $table->date('day');
+                $table->unsignedBigInteger('org_id')->default(0);
+                $table->string('locale', 16)->default('unknown');
+                $table->string('region', 32)->default('unknown');
+                $table->string('scale_code', 64)->default('MBTI');
+                $table->string('content_package_version', 128)->default('unknown');
+                $table->string('scoring_spec_version', 64)->default('unknown');
+                $table->string('norm_version', 64)->default('unknown');
+                $table->string('type_code', 16);
+                $table->unsignedInteger('results_count')->default(0);
+                $table->unsignedInteger('distinct_attempts_with_results')->default(0);
+                $table->timestamp('last_refreshed_at')->nullable();
+                $table->timestamps();
+            });
+        } else {
+            Schema::table(self::TYPE_TABLE, function (Blueprint $table): void {
+                if (! Schema::hasColumn(self::TYPE_TABLE, 'day')) {
+                    $table->date('day')->nullable();
+                }
+                if (! Schema::hasColumn(self::TYPE_TABLE, 'org_id')) {
+                    $table->unsignedBigInteger('org_id')->default(0);
+                }
+                if (! Schema::hasColumn(self::TYPE_TABLE, 'locale')) {
+                    $table->string('locale', 16)->default('unknown');
+                }
+                if (! Schema::hasColumn(self::TYPE_TABLE, 'region')) {
+                    $table->string('region', 32)->default('unknown');
+                }
+                if (! Schema::hasColumn(self::TYPE_TABLE, 'scale_code')) {
+                    $table->string('scale_code', 64)->default('MBTI');
+                }
+                if (! Schema::hasColumn(self::TYPE_TABLE, 'content_package_version')) {
+                    $table->string('content_package_version', 128)->default('unknown');
+                }
+                if (! Schema::hasColumn(self::TYPE_TABLE, 'scoring_spec_version')) {
+                    $table->string('scoring_spec_version', 64)->default('unknown');
+                }
+                if (! Schema::hasColumn(self::TYPE_TABLE, 'norm_version')) {
+                    $table->string('norm_version', 64)->default('unknown');
+                }
+                if (! Schema::hasColumn(self::TYPE_TABLE, 'type_code')) {
+                    $table->string('type_code', 16)->nullable();
+                }
+                if (! Schema::hasColumn(self::TYPE_TABLE, 'results_count')) {
+                    $table->unsignedInteger('results_count')->default(0);
+                }
+                if (! Schema::hasColumn(self::TYPE_TABLE, 'distinct_attempts_with_results')) {
+                    $table->unsignedInteger('distinct_attempts_with_results')->default(0);
+                }
+                if (! Schema::hasColumn(self::TYPE_TABLE, 'last_refreshed_at')) {
+                    $table->timestamp('last_refreshed_at')->nullable();
+                }
+                if (! Schema::hasColumn(self::TYPE_TABLE, 'created_at')) {
+                    $table->timestamp('created_at')->nullable();
+                }
+                if (! Schema::hasColumn(self::TYPE_TABLE, 'updated_at')) {
+                    $table->timestamp('updated_at')->nullable();
+                }
+            });
+        }
+
+        $this->ensureUnique(
+            self::TYPE_TABLE,
+            [
+                'day',
+                'org_id',
+                'locale',
+                'region',
+                'scale_code',
+                'content_package_version',
+                'scoring_spec_version',
+                'norm_version',
+                'type_code',
+            ],
+            'analytics_mbti_type_daily_scope_unique'
+        );
+        $this->ensureIndex(self::TYPE_TABLE, ['org_id', 'day'], 'analytics_mbti_type_daily_org_day_idx');
+        $this->ensureIndex(
+            self::TYPE_TABLE,
+            ['org_id', 'locale', 'day'],
+            'analytics_mbti_type_daily_org_locale_day_idx'
+        );
+        $this->ensureIndex(
+            self::TYPE_TABLE,
+            ['org_id', 'type_code', 'day'],
+            'analytics_mbti_type_daily_org_type_day_idx'
+        );
+    }
+
+    private function createAxisTable(): void
+    {
+        if (! Schema::hasTable(self::AXIS_TABLE)) {
+            Schema::create(self::AXIS_TABLE, function (Blueprint $table): void {
+                $table->date('day');
+                $table->unsignedBigInteger('org_id')->default(0);
+                $table->string('locale', 16)->default('unknown');
+                $table->string('region', 32)->default('unknown');
+                $table->string('scale_code', 64)->default('MBTI');
+                $table->string('content_package_version', 128)->default('unknown');
+                $table->string('scoring_spec_version', 64)->default('unknown');
+                $table->string('norm_version', 64)->default('unknown');
+                $table->string('axis_code', 8);
+                $table->string('side_code', 4);
+                $table->unsignedInteger('results_count')->default(0);
+                $table->unsignedInteger('distinct_attempts_with_results')->default(0);
+                $table->timestamp('last_refreshed_at')->nullable();
+                $table->timestamps();
+            });
+        } else {
+            Schema::table(self::AXIS_TABLE, function (Blueprint $table): void {
+                if (! Schema::hasColumn(self::AXIS_TABLE, 'day')) {
+                    $table->date('day')->nullable();
+                }
+                if (! Schema::hasColumn(self::AXIS_TABLE, 'org_id')) {
+                    $table->unsignedBigInteger('org_id')->default(0);
+                }
+                if (! Schema::hasColumn(self::AXIS_TABLE, 'locale')) {
+                    $table->string('locale', 16)->default('unknown');
+                }
+                if (! Schema::hasColumn(self::AXIS_TABLE, 'region')) {
+                    $table->string('region', 32)->default('unknown');
+                }
+                if (! Schema::hasColumn(self::AXIS_TABLE, 'scale_code')) {
+                    $table->string('scale_code', 64)->default('MBTI');
+                }
+                if (! Schema::hasColumn(self::AXIS_TABLE, 'content_package_version')) {
+                    $table->string('content_package_version', 128)->default('unknown');
+                }
+                if (! Schema::hasColumn(self::AXIS_TABLE, 'scoring_spec_version')) {
+                    $table->string('scoring_spec_version', 64)->default('unknown');
+                }
+                if (! Schema::hasColumn(self::AXIS_TABLE, 'norm_version')) {
+                    $table->string('norm_version', 64)->default('unknown');
+                }
+                if (! Schema::hasColumn(self::AXIS_TABLE, 'axis_code')) {
+                    $table->string('axis_code', 8)->nullable();
+                }
+                if (! Schema::hasColumn(self::AXIS_TABLE, 'side_code')) {
+                    $table->string('side_code', 4)->nullable();
+                }
+                if (! Schema::hasColumn(self::AXIS_TABLE, 'results_count')) {
+                    $table->unsignedInteger('results_count')->default(0);
+                }
+                if (! Schema::hasColumn(self::AXIS_TABLE, 'distinct_attempts_with_results')) {
+                    $table->unsignedInteger('distinct_attempts_with_results')->default(0);
+                }
+                if (! Schema::hasColumn(self::AXIS_TABLE, 'last_refreshed_at')) {
+                    $table->timestamp('last_refreshed_at')->nullable();
+                }
+                if (! Schema::hasColumn(self::AXIS_TABLE, 'created_at')) {
+                    $table->timestamp('created_at')->nullable();
+                }
+                if (! Schema::hasColumn(self::AXIS_TABLE, 'updated_at')) {
+                    $table->timestamp('updated_at')->nullable();
+                }
+            });
+        }
+
+        $this->ensureUnique(
+            self::AXIS_TABLE,
+            [
+                'day',
+                'org_id',
+                'locale',
+                'region',
+                'scale_code',
+                'content_package_version',
+                'scoring_spec_version',
+                'norm_version',
+                'axis_code',
+                'side_code',
+            ],
+            'analytics_axis_daily_scope_unique'
+        );
+        $this->ensureIndex(self::AXIS_TABLE, ['org_id', 'day'], 'analytics_axis_daily_org_day_idx');
+        $this->ensureIndex(
+            self::AXIS_TABLE,
+            ['org_id', 'locale', 'day'],
+            'analytics_axis_daily_org_locale_day_idx'
+        );
+        $this->ensureIndex(
+            self::AXIS_TABLE,
+            ['org_id', 'axis_code', 'day'],
+            'analytics_axis_daily_org_axis_day_idx'
+        );
+    }
+
+    /**
+     * @param  array<int,string>  $columns
+     */
+    private function ensureUnique(string $tableName, array $columns, string $indexName): void
+    {
+        if (! Schema::hasTable($tableName) || SchemaIndex::indexExists($tableName, $indexName)) {
+            return;
+        }
+
+        Schema::table($tableName, function (Blueprint $table) use ($columns, $indexName): void {
+            $table->unique($columns, $indexName);
+        });
+    }
+
+    /**
+     * @param  array<int,string>  $columns
+     */
+    private function ensureIndex(string $tableName, array $columns, string $indexName): void
+    {
+        if (! Schema::hasTable($tableName) || SchemaIndex::indexExists($tableName, $indexName)) {
+            return;
+        }
+
+        Schema::table($tableName, function (Blueprint $table) use ($columns, $indexName): void {
+            $table->index($columns, $indexName);
+        });
+    }
+};

--- a/backend/docs/ops/mbti-insights.md
+++ b/backend/docs/ops/mbti-insights.md
@@ -1,0 +1,115 @@
+# MBTI Insights
+
+## First-phase authority sample
+
+MBTI Insights v1 is fixed to MBTI-only and results-based daily aggregation.
+
+Authority rows must satisfy all of the following:
+
+- `results` is the primary fact axis
+- `results.type_code` exists directly on the row
+- the result can join back to `attempts`
+- the result passes the current stable validity gate (`results.is_valid = true` when present)
+- the result resolves to the MBTI canonical scale scope
+
+The first-phase authority surface excludes:
+
+- invalid results
+- orphan results
+- fallback-only payloads that do not have a direct `results.type_code`
+- non-MBTI scales
+
+## Read models
+
+### `analytics_mbti_type_daily`
+
+Purpose:
+
+- daily 16-type distribution
+- overview KPI rollups
+- locale and version splits
+
+Core dimensions:
+
+- `day`
+- `org_id`
+- `locale`
+- `region`
+- `scale_code`
+- `content_package_version`
+- `scoring_spec_version`
+- `norm_version`
+- `type_code`
+
+Core metrics:
+
+- `results_count`
+- `distinct_attempts_with_results`
+
+### `analytics_axis_daily`
+
+Purpose:
+
+- daily axis distribution
+- locale/version axis comparison
+- A/T coverage detection
+
+Core dimensions:
+
+- `day`
+- `org_id`
+- `locale`
+- `region`
+- `scale_code`
+- `content_package_version`
+- `scoring_spec_version`
+- `norm_version`
+- `axis_code`
+- `side_code`
+
+Core metrics:
+
+- `results_count`
+- `distinct_attempts_with_results`
+
+## Hard metrics vs reference metrics
+
+First-phase hard metrics:
+
+- total results
+- distinct attempts with results
+- top type
+- 16-type count/share
+- E/I, S/N, T/F, J/P axis count/share
+- locale split
+- content/scoring version split
+
+Reference or explicitly non-authoritative metrics:
+
+- paid subset
+- unlocked subset
+- share subset
+- share-to-purchase
+- channel attribution
+- tiny locale comparisons
+- cross-version pools without explicit filtering
+
+## A/T handling
+
+`axis_states` in the current MBTI result chain represents strength labels such as `clear` or `weak`. It is not the side winner itself.
+
+For AIC-06 v1:
+
+- axis side resolution uses `scores_pct` first
+- `type_code` is used as the fallback for side reconstruction
+- A/T is only shown in the main axis panel when the current filtered scope has full A/T coverage
+
+If the filtered scope does not fully cover A/T, the page keeps A/T out of the first authority axis panel and labels that omission explicitly.
+
+## Later extensions
+
+Out of scope for this PR, but expected next:
+
+- paid/unlocked/share reference slices
+- deeper version drift and norms analysis
+- richer drill-through on locale/version cohorts

--- a/backend/resources/views/filament/ops/hooks/topbar-context.blade.php
+++ b/backend/resources/views/filament/ops/hooks/topbar-context.blade.php
@@ -2,6 +2,7 @@
     $routeName = (string) request()->route()?->getName();
 
     $sectionLabel = match (true) {
+        str_contains($routeName, 'mbti-insights') => 'Assessment Insights',
         str_contains($routeName, 'article'),
         str_contains($routeName, 'content-pack'),
         str_contains($routeName, 'scale-registry'),

--- a/backend/resources/views/filament/ops/pages/mbti-insights-page.blade.php
+++ b/backend/resources/views/filament/ops/pages/mbti-insights-page.blade.php
@@ -1,0 +1,440 @@
+<x-filament-panels::page>
+    <div class="space-y-6">
+        <form wire:submit.prevent="applyFilters" class="rounded-2xl border border-slate-200 bg-white/95 p-5 shadow-sm">
+            <div class="grid gap-4 xl:grid-cols-[repeat(7,minmax(0,1fr))_auto]">
+                <label class="space-y-2">
+                    <span class="text-xs font-semibold uppercase tracking-[0.16em] text-slate-500">From</span>
+                    <input type="date" wire:model.defer="fromDate" class="block w-full rounded-xl border-slate-300 text-sm shadow-sm" />
+                </label>
+
+                <label class="space-y-2">
+                    <span class="text-xs font-semibold uppercase tracking-[0.16em] text-slate-500">To</span>
+                    <input type="date" wire:model.defer="toDate" class="block w-full rounded-xl border-slate-300 text-sm shadow-sm" />
+                </label>
+
+                <label class="space-y-2">
+                    <span class="text-xs font-semibold uppercase tracking-[0.16em] text-slate-500">Locale</span>
+                    <select wire:model.defer="locale" class="block w-full rounded-xl border-slate-300 text-sm shadow-sm">
+                        <option value="all">All locales</option>
+                        @foreach ($localeOptions as $value => $label)
+                            <option value="{{ $value }}">{{ $label }}</option>
+                        @endforeach
+                    </select>
+                </label>
+
+                <label class="space-y-2">
+                    <span class="text-xs font-semibold uppercase tracking-[0.16em] text-slate-500">Region</span>
+                    <select wire:model.defer="region" class="block w-full rounded-xl border-slate-300 text-sm shadow-sm">
+                        <option value="all">All regions</option>
+                        @foreach ($regionOptions as $value => $label)
+                            <option value="{{ $value }}">{{ $label }}</option>
+                        @endforeach
+                    </select>
+                </label>
+
+                <label class="space-y-2">
+                    <span class="text-xs font-semibold uppercase tracking-[0.16em] text-slate-500">Content</span>
+                    <select wire:model.defer="contentPackageVersion" class="block w-full rounded-xl border-slate-300 text-sm shadow-sm">
+                        <option value="all">All content versions</option>
+                        @foreach ($contentPackageVersionOptions as $value => $label)
+                            <option value="{{ $value }}">{{ $label }}</option>
+                        @endforeach
+                    </select>
+                </label>
+
+                <label class="space-y-2">
+                    <span class="text-xs font-semibold uppercase tracking-[0.16em] text-slate-500">Scoring</span>
+                    <select wire:model.defer="scoringSpecVersion" class="block w-full rounded-xl border-slate-300 text-sm shadow-sm">
+                        <option value="all">All scoring versions</option>
+                        @foreach ($scoringSpecVersionOptions as $value => $label)
+                            <option value="{{ $value }}">{{ $label }}</option>
+                        @endforeach
+                    </select>
+                </label>
+
+                <label class="space-y-2">
+                    <span class="text-xs font-semibold uppercase tracking-[0.16em] text-slate-500">Norm</span>
+                    <select wire:model.defer="normVersion" class="block w-full rounded-xl border-slate-300 text-sm shadow-sm">
+                        <option value="all">All norm versions</option>
+                        @foreach ($normVersionOptions as $value => $label)
+                            <option value="{{ $value }}">{{ $label }}</option>
+                        @endforeach
+                    </select>
+                </label>
+
+                <div class="flex items-end gap-3">
+                    <x-filament::button type="submit">Apply</x-filament::button>
+                    <a href="/ops/results" class="inline-flex items-center rounded-xl border border-slate-200 px-3 py-2 text-sm font-medium text-slate-600 transition hover:border-slate-300 hover:text-slate-900">
+                        Results Explorer
+                    </a>
+                </div>
+            </div>
+        </form>
+
+        <section class="rounded-2xl border border-slate-200 bg-white/95 p-5 shadow-sm">
+            <div class="flex flex-wrap items-center justify-between gap-4">
+                <div>
+                    <h2 class="text-lg font-semibold text-slate-950">Authority Scope</h2>
+                    <p class="text-sm text-slate-500">
+                        Fixed to {{ $canonicalScale['scale_code'] }} only, with dual-write recognition for {{ $canonicalScale['scale_code_v2'] }}.
+                    </p>
+                </div>
+
+                <div class="flex flex-wrap gap-2">
+                    @foreach (['overview' => 'Overview', 'types' => 'Type Distribution', 'axes' => 'Axis Distribution'] as $tabKey => $label)
+                        <button
+                            type="button"
+                            wire:click="setActiveTab('{{ $tabKey }}')"
+                            class="rounded-full border px-4 py-2 text-sm font-medium transition {{ $activeTab === $tabKey ? 'border-sky-300 bg-sky-50 text-sky-700' : 'border-slate-200 text-slate-600 hover:border-slate-300 hover:text-slate-900' }}"
+                        >
+                            {{ $label }}
+                        </button>
+                    @endforeach
+                </div>
+            </div>
+
+            <div class="mt-4 grid gap-3 lg:grid-cols-2">
+                @foreach ($scopeNotes as $note)
+                    <div class="rounded-2xl border border-slate-200 bg-slate-50/80 px-4 py-3 text-sm leading-6 text-slate-700">
+                        {{ $note }}
+                    </div>
+                @endforeach
+            </div>
+        </section>
+
+        @if ($warnings !== [])
+            <div class="space-y-3">
+                @foreach ($warnings as $warning)
+                    <div class="rounded-2xl border border-amber-200 bg-amber-50 px-4 py-3 text-sm text-amber-900">
+                        {{ $warning }}
+                    </div>
+                @endforeach
+            </div>
+        @endif
+
+        @if ($hasData)
+            @if ($activeTab === 'overview')
+                <section class="rounded-2xl border border-slate-200 bg-white/95 p-5 shadow-sm">
+                    <div class="mb-4">
+                        <h2 class="text-lg font-semibold text-slate-950">Overview KPI Cards</h2>
+                        <p class="text-sm text-slate-500">First-phase authority numbers only. No paid, share, or channel subsets in the core KPI line.</p>
+                    </div>
+
+                    <div class="grid gap-4 md:grid-cols-2 xl:grid-cols-5">
+                        @foreach ($kpis as $card)
+                            <article class="rounded-2xl border border-slate-200 bg-slate-50/70 p-4">
+                                <div class="text-xs font-semibold uppercase tracking-[0.16em] text-slate-500">{{ $card['label'] }}</div>
+                                <div class="mt-3 text-2xl font-semibold tracking-tight text-slate-950">
+                                    {{ $card['display_value'] ?? $this->formatInt((int) $card['value']) }}
+                                </div>
+                                <p class="mt-2 text-sm leading-6 text-slate-600">{{ $card['description'] }}</p>
+                            </article>
+                        @endforeach
+                    </div>
+                </section>
+
+                <section class="grid gap-6 xl:grid-cols-[minmax(0,1.35fr)_minmax(0,1fr)]">
+                    <div class="rounded-2xl border border-slate-200 bg-white/95 p-5 shadow-sm">
+                        <div class="mb-4">
+                            <h2 class="text-lg font-semibold text-slate-950">Daily Results Trend</h2>
+                            <p class="text-sm text-slate-500">Authority result volume by result day.</p>
+                        </div>
+
+                        <div class="overflow-x-auto">
+                            <table class="min-w-full divide-y divide-slate-200 text-sm">
+                                <thead class="bg-slate-50 text-left text-xs font-semibold uppercase tracking-[0.14em] text-slate-500">
+                                    <tr>
+                                        <th class="px-3 py-3">Day</th>
+                                        <th class="px-3 py-3">Results</th>
+                                        <th class="px-3 py-3">Relative volume</th>
+                                    </tr>
+                                </thead>
+                                <tbody class="divide-y divide-slate-100 bg-white">
+                                    @foreach ($dailyTrend as $row)
+                                        <tr>
+                                            <td class="px-3 py-3 font-medium text-slate-900">{{ $row['day'] }}</td>
+                                            <td class="px-3 py-3">{{ $this->formatInt((int) $row['results_count']) }}</td>
+                                            <td class="px-3 py-3">
+                                                <div class="h-2 rounded-full bg-slate-100">
+                                                    <div class="h-2 rounded-full bg-sky-500" style="width: {{ $row['pct'] }}%;"></div>
+                                                </div>
+                                            </td>
+                                        </tr>
+                                    @endforeach
+                                </tbody>
+                            </table>
+                        </div>
+                    </div>
+
+                    <div class="rounded-2xl border border-slate-200 bg-white/95 p-5 shadow-sm">
+                        <div class="mb-4">
+                            <h2 class="text-lg font-semibold text-slate-950">Locale Split</h2>
+                            <p class="text-sm text-slate-500">Cross-locale summary inside the current org and date/version scope.</p>
+                        </div>
+
+                        <div class="overflow-x-auto">
+                            <table class="min-w-full divide-y divide-slate-200 text-sm">
+                                <thead class="bg-slate-50 text-left text-xs font-semibold uppercase tracking-[0.14em] text-slate-500">
+                                    <tr>
+                                        <th class="px-3 py-3">Locale</th>
+                                        <th class="px-3 py-3">Results</th>
+                                        <th class="px-3 py-3">Share</th>
+                                        <th class="px-3 py-3">Top type</th>
+                                    </tr>
+                                </thead>
+                                <tbody class="divide-y divide-slate-100 bg-white">
+                                    @foreach ($localeSplit as $row)
+                                        <tr>
+                                            <td class="px-3 py-3 font-medium text-slate-900">{{ $row['locale'] }}</td>
+                                            <td class="px-3 py-3">{{ $this->formatInt((int) $row['results_count']) }}</td>
+                                            <td class="px-3 py-3">{{ $this->formatRate($row['share']) }}</td>
+                                            <td class="px-3 py-3">{{ $row['top_type'] }}</td>
+                                        </tr>
+                                    @endforeach
+                                </tbody>
+                            </table>
+                        </div>
+                    </div>
+                </section>
+
+                <section class="rounded-2xl border border-slate-200 bg-white/95 p-5 shadow-sm">
+                    <div class="mb-4">
+                        <h2 class="text-lg font-semibold text-slate-950">Version Split</h2>
+                        <p class="text-sm text-slate-500">Version mix stays visible so first-phase insight pages do not silently pool cross-version results.</p>
+                    </div>
+
+                    <div class="overflow-x-auto">
+                        <table class="min-w-full divide-y divide-slate-200 text-sm">
+                            <thead class="bg-slate-50 text-left text-xs font-semibold uppercase tracking-[0.14em] text-slate-500">
+                                <tr>
+                                    <th class="px-3 py-3">Content</th>
+                                    <th class="px-3 py-3">Scoring</th>
+                                    <th class="px-3 py-3">Norm</th>
+                                    <th class="px-3 py-3">Results</th>
+                                    <th class="px-3 py-3">Share</th>
+                                </tr>
+                            </thead>
+                            <tbody class="divide-y divide-slate-100 bg-white">
+                                @foreach ($versionSplit as $row)
+                                    <tr>
+                                        <td class="px-3 py-3">{{ $row['content_package_version'] }}</td>
+                                        <td class="px-3 py-3">{{ $row['scoring_spec_version'] }}</td>
+                                        <td class="px-3 py-3">{{ $row['norm_version'] }}</td>
+                                        <td class="px-3 py-3">{{ $this->formatInt((int) $row['results_count']) }}</td>
+                                        <td class="px-3 py-3">{{ $this->formatRate($row['share']) }}</td>
+                                    </tr>
+                                @endforeach
+                            </tbody>
+                        </table>
+                    </div>
+                </section>
+            @elseif ($activeTab === 'types')
+                <section class="rounded-2xl border border-slate-200 bg-white/95 p-5 shadow-sm">
+                    <div class="mb-4 flex items-center justify-between gap-3">
+                        <div>
+                            <h2 class="text-lg font-semibold text-slate-950">16-Type Distribution</h2>
+                            <p class="text-sm text-slate-500">Counts and shares are normalized to the 16 base types. A/T stays out of the main type split.</p>
+                        </div>
+                        <a href="/ops/results" class="rounded-full border border-slate-200 px-3 py-1.5 text-sm text-slate-600 transition hover:border-slate-300 hover:text-slate-900">
+                            Open Results Explorer
+                        </a>
+                    </div>
+
+                    <div class="overflow-x-auto">
+                        <table class="min-w-full divide-y divide-slate-200 text-sm">
+                            <thead class="bg-slate-50 text-left text-xs font-semibold uppercase tracking-[0.14em] text-slate-500">
+                                <tr>
+                                    <th class="px-3 py-3">Type</th>
+                                    <th class="px-3 py-3">Count</th>
+                                    <th class="px-3 py-3">Share</th>
+                                    <th class="px-3 py-3">Distribution</th>
+                                    <th class="px-3 py-3">Drill-through</th>
+                                </tr>
+                            </thead>
+                            <tbody class="divide-y divide-slate-100 bg-white">
+                                @foreach ($typeDistribution as $row)
+                                    <tr>
+                                        <td class="px-3 py-3 font-medium text-slate-900">{{ $row['type_code'] }}</td>
+                                        <td class="px-3 py-3">{{ $this->formatInt((int) $row['results_count']) }}</td>
+                                        <td class="px-3 py-3">{{ $this->formatRate($row['share']) }}</td>
+                                        <td class="px-3 py-3">
+                                            <div class="h-2 rounded-full bg-slate-100">
+                                                <div class="h-2 rounded-full bg-sky-500" style="width: {{ round((float) (($row['share'] ?? 0) * 100), 1) }}%;"></div>
+                                            </div>
+                                        </td>
+                                        <td class="px-3 py-3">
+                                            <a href="{{ $row['drill_url'] }}" class="text-sm font-medium text-sky-700 hover:text-sky-900">Search {{ $row['type_code'] }}</a>
+                                        </td>
+                                    </tr>
+                                @endforeach
+                            </tbody>
+                        </table>
+                    </div>
+                </section>
+
+                <section class="rounded-2xl border border-slate-200 bg-white/95 p-5 shadow-sm">
+                    <div class="mb-4">
+                        <h2 class="text-lg font-semibold text-slate-950">Type Trend</h2>
+                        <p class="text-sm text-slate-500">Daily MBTI result volume with the leading type for each day.</p>
+                    </div>
+
+                    <div class="overflow-x-auto">
+                        <table class="min-w-full divide-y divide-slate-200 text-sm">
+                            <thead class="bg-slate-50 text-left text-xs font-semibold uppercase tracking-[0.14em] text-slate-500">
+                                <tr>
+                                    <th class="px-3 py-3">Day</th>
+                                    <th class="px-3 py-3">Results</th>
+                                    <th class="px-3 py-3">Top type</th>
+                                    <th class="px-3 py-3">Top type share</th>
+                                </tr>
+                            </thead>
+                            <tbody class="divide-y divide-slate-100 bg-white">
+                                @foreach ($typeTrend as $row)
+                                    <tr>
+                                        <td class="px-3 py-3 font-medium text-slate-900">{{ $row['day'] }}</td>
+                                        <td class="px-3 py-3">{{ $this->formatInt((int) $row['results_count']) }}</td>
+                                        <td class="px-3 py-3">{{ $row['top_type'] }}</td>
+                                        <td class="px-3 py-3">{{ $this->formatRate($row['top_type_share']) }}</td>
+                                    </tr>
+                                @endforeach
+                            </tbody>
+                        </table>
+                    </div>
+                </section>
+            @else
+                <section class="rounded-2xl border border-slate-200 bg-white/95 p-5 shadow-sm">
+                    <div class="mb-4">
+                        <h2 class="text-lg font-semibold text-slate-950">Axis Distribution</h2>
+                        <p class="text-sm text-slate-500">
+                            E/I, S/N, T/F, and J/P stay authoritative. A/T appears only when the current filtered scope has full A/T coverage.
+                        </p>
+                    </div>
+
+                    <div class="grid gap-4 xl:grid-cols-2">
+                        @foreach ($axisSummary as $axis)
+                            <article class="rounded-2xl border border-slate-200 bg-slate-50/70 p-4">
+                                <div class="flex items-center justify-between gap-3">
+                                    <div>
+                                        <div class="text-xs font-semibold uppercase tracking-[0.16em] text-slate-500">{{ $axis['axis_code'] }}</div>
+                                        <div class="text-lg font-semibold text-slate-950">{{ $axis['label'] }}</div>
+                                    </div>
+                                    <div class="text-sm text-slate-500">{{ $this->formatInt((int) $axis['results_count']) }} side rows</div>
+                                </div>
+
+                                <div class="mt-4 space-y-3">
+                                    @foreach ($axis['sides'] as $side)
+                                        <div class="space-y-1">
+                                            <div class="flex items-center justify-between text-sm">
+                                                <span class="font-medium text-slate-900">{{ $side['side_code'] }}</span>
+                                                <span class="text-slate-600">{{ $this->formatInt((int) $side['results_count']) }} · {{ $this->formatRate($side['share']) }}</span>
+                                            </div>
+                                            <div class="h-2 rounded-full bg-white">
+                                                <div class="h-2 rounded-full bg-sky-500" style="width: {{ round((float) (($side['share'] ?? 0) * 100), 1) }}%;"></div>
+                                            </div>
+                                        </div>
+                                    @endforeach
+                                </div>
+                            </article>
+                        @endforeach
+                    </div>
+                </section>
+
+                <section class="grid gap-6 xl:grid-cols-[minmax(0,1.15fr)_minmax(0,1fr)]">
+                    <div class="rounded-2xl border border-slate-200 bg-white/95 p-5 shadow-sm">
+                        <div class="mb-4">
+                            <h2 class="text-lg font-semibold text-slate-950">Axis Table</h2>
+                            <p class="text-sm text-slate-500">Counts and shares are calculated within each axis, not across all rows.</p>
+                        </div>
+
+                        <div class="overflow-x-auto">
+                            <table class="min-w-full divide-y divide-slate-200 text-sm">
+                                <thead class="bg-slate-50 text-left text-xs font-semibold uppercase tracking-[0.14em] text-slate-500">
+                                    <tr>
+                                        <th class="px-3 py-3">Axis</th>
+                                        <th class="px-3 py-3">Side</th>
+                                        <th class="px-3 py-3">Count</th>
+                                        <th class="px-3 py-3">Share</th>
+                                    </tr>
+                                </thead>
+                                <tbody class="divide-y divide-slate-100 bg-white">
+                                    @foreach ($axisSummary as $axis)
+                                        @foreach ($axis['sides'] as $side)
+                                            <tr>
+                                                <td class="px-3 py-3 font-medium text-slate-900">{{ $axis['axis_code'] }}</td>
+                                                <td class="px-3 py-3">{{ $side['side_code'] }}</td>
+                                                <td class="px-3 py-3">{{ $this->formatInt((int) $side['results_count']) }}</td>
+                                                <td class="px-3 py-3">{{ $this->formatRate($side['share']) }}</td>
+                                            </tr>
+                                        @endforeach
+                                    @endforeach
+                                </tbody>
+                            </table>
+                        </div>
+                    </div>
+
+                    <div class="rounded-2xl border border-slate-200 bg-white/95 p-5 shadow-sm">
+                        <div class="mb-4">
+                            <h2 class="text-lg font-semibold text-slate-950">Locale Comparison</h2>
+                            <p class="text-sm text-slate-500">Compact lead-side view by locale. Keep locale = All to preserve a cross-locale panel.</p>
+                        </div>
+
+                        <div class="overflow-x-auto">
+                            <table class="min-w-full divide-y divide-slate-200 text-sm">
+                                <thead class="bg-slate-50 text-left text-xs font-semibold uppercase tracking-[0.14em] text-slate-500">
+                                    <tr>
+                                        <th class="px-3 py-3">Locale</th>
+                                        <th class="px-3 py-3">Results</th>
+                                        @foreach (array_keys($axisComparisonByLocale[0]['lead_map'] ?? []) as $axisCode)
+                                            <th class="px-3 py-3">{{ $axisCode }}</th>
+                                        @endforeach
+                                    </tr>
+                                </thead>
+                                <tbody class="divide-y divide-slate-100 bg-white">
+                                    @foreach ($axisComparisonByLocale as $row)
+                                        <tr>
+                                            <td class="px-3 py-3 font-medium text-slate-900">{{ $row['locale'] }}</td>
+                                            <td class="px-3 py-3">{{ $this->formatInt((int) $row['results_count']) }}</td>
+                                            @foreach ($row['lead_map'] as $lead)
+                                                <td class="px-3 py-3">{{ $lead }}</td>
+                                            @endforeach
+                                        </tr>
+                                    @endforeach
+                                </tbody>
+                            </table>
+                        </div>
+                    </div>
+                </section>
+
+                <section class="rounded-2xl border border-slate-200 bg-white/95 p-5 shadow-sm">
+                    <div class="mb-4">
+                        <h2 class="text-lg font-semibold text-slate-950">Version Comparison</h2>
+                        <p class="text-sm text-slate-500">Static version summary only. Deeper version drift analysis remains out of scope for AIC-06 v1.</p>
+                    </div>
+
+                    <div class="overflow-x-auto">
+                        <table class="min-w-full divide-y divide-slate-200 text-sm">
+                            <thead class="bg-slate-50 text-left text-xs font-semibold uppercase tracking-[0.14em] text-slate-500">
+                                <tr>
+                                    <th class="px-3 py-3">Content</th>
+                                    <th class="px-3 py-3">Scoring</th>
+                                    <th class="px-3 py-3">Results</th>
+                                    <th class="px-3 py-3">Axis snapshot</th>
+                                </tr>
+                            </thead>
+                            <tbody class="divide-y divide-slate-100 bg-white">
+                                @foreach ($axisComparisonByVersion as $row)
+                                    <tr>
+                                        <td class="px-3 py-3">{{ $row['content_package_version'] }}</td>
+                                        <td class="px-3 py-3">{{ $row['scoring_spec_version'] }}</td>
+                                        <td class="px-3 py-3">{{ $this->formatInt((int) $row['results_count']) }}</td>
+                                        <td class="px-3 py-3 text-slate-600">{{ $row['axis_snapshot'] }}</td>
+                                    </tr>
+                                @endforeach
+                            </tbody>
+                        </table>
+                    </div>
+                </section>
+            @endif
+        @endif
+    </div>
+</x-filament-panels::page>

--- a/backend/tests/Concerns/SeedsMbtiInsightsScenario.php
+++ b/backend/tests/Concerns/SeedsMbtiInsightsScenario.php
@@ -1,0 +1,346 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Concerns;
+
+use Carbon\CarbonImmutable;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Support\Str;
+
+trait SeedsMbtiInsightsScenario
+{
+    /**
+     * @return array{from:string,to:string}
+     */
+    private function seedMbtiInsightsAuthorityScenario(int $orgId): array
+    {
+        $dayOne = CarbonImmutable::parse('2026-01-03 09:00:00');
+        $dayTwo = CarbonImmutable::parse('2026-01-04 10:00:00');
+
+        $attemptA = $this->insertAnalyticsAttempt([
+            'org_id' => $orgId,
+            'scale_code' => 'MBTI',
+            'locale' => 'en',
+            'region' => 'US',
+            'content_package_version' => 'content_2026_01',
+            'scoring_spec_version' => 'scoring_2026_01',
+            'norm_version' => 'norm_2026_01',
+            'created_at' => $dayOne,
+            'submitted_at' => $dayOne->addMinutes(5),
+        ]);
+        $this->insertAnalyticsResult([
+            'attempt_id' => $attemptA,
+            'org_id' => $orgId,
+            'scale_code' => 'MBTI',
+            'type_code' => 'INTJ-A',
+            'scores_pct' => ['EI' => 45, 'SN' => 40, 'TF' => 80, 'JP' => 70, 'AT' => 60],
+            'computed_at' => $dayOne->addMinutes(6),
+            'content_package_version' => 'content_2026_01',
+            'scoring_spec_version' => 'scoring_2026_01',
+        ]);
+
+        $attemptB = $this->insertAnalyticsAttempt([
+            'org_id' => $orgId,
+            'scale_code' => 'MBTI',
+            'locale' => 'en',
+            'region' => 'US',
+            'content_package_version' => 'content_2026_01',
+            'scoring_spec_version' => 'scoring_2026_01',
+            'norm_version' => 'norm_2026_01',
+            'created_at' => $dayOne->addHours(1),
+            'submitted_at' => $dayOne->addHours(1)->addMinutes(5),
+        ]);
+        $this->insertAnalyticsResult([
+            'attempt_id' => $attemptB,
+            'org_id' => $orgId,
+            'scale_code' => 'MBTI',
+            'type_code' => 'ENFP-T',
+            'scores_pct' => ['EI' => 65, 'SN' => 30, 'TF' => 40, 'JP' => 35, 'AT' => 40],
+            'computed_at' => $dayOne->addHours(1)->addMinutes(6),
+            'content_package_version' => 'content_2026_01',
+            'scoring_spec_version' => 'scoring_2026_01',
+        ]);
+
+        $attemptC = $this->insertAnalyticsAttempt([
+            'org_id' => $orgId,
+            'scale_code' => 'MBTI',
+            'locale' => 'zh-CN',
+            'region' => 'CN_MAINLAND',
+            'content_package_version' => 'content_2026_01',
+            'scoring_spec_version' => 'scoring_2026_02',
+            'norm_version' => 'norm_2026_02',
+            'created_at' => $dayOne->addHours(2),
+            'submitted_at' => $dayOne->addHours(2)->addMinutes(5),
+        ]);
+        $this->insertAnalyticsResult([
+            'attempt_id' => $attemptC,
+            'org_id' => $orgId,
+            'scale_code' => 'MBTI',
+            'type_code' => 'INFJ-A',
+            'scores_pct' => ['EI' => 30, 'SN' => 35, 'TF' => 35, 'JP' => 75, 'AT' => 55],
+            'computed_at' => $dayOne->addHours(2)->addMinutes(6),
+            'content_package_version' => 'content_2026_01',
+            'scoring_spec_version' => 'scoring_2026_02',
+        ]);
+
+        $attemptD = $this->insertAnalyticsAttempt([
+            'org_id' => $orgId,
+            'scale_code' => 'MBTI',
+            'locale' => 'en',
+            'region' => 'US',
+            'content_package_version' => 'content_2026_02',
+            'scoring_spec_version' => 'scoring_2026_02',
+            'norm_version' => 'norm_2026_02',
+            'created_at' => $dayTwo,
+            'submitted_at' => $dayTwo->addMinutes(5),
+        ]);
+        $this->insertAnalyticsResult([
+            'attempt_id' => $attemptD,
+            'org_id' => $orgId,
+            'scale_code' => 'MBTI',
+            'type_code' => 'INTJ',
+            'scores_pct' => ['EI' => 40, 'SN' => 35, 'TF' => 78, 'JP' => 68, 'AT' => 62],
+            'computed_at' => $dayTwo->addMinutes(6),
+            'content_package_version' => 'content_2026_02',
+            'scoring_spec_version' => 'scoring_2026_02',
+        ]);
+
+        $attemptE = $this->insertAnalyticsAttempt([
+            'org_id' => $orgId,
+            'scale_code' => 'MBTI',
+            'locale' => 'fr-FR',
+            'region' => 'FR',
+            'content_package_version' => 'content_2026_02',
+            'scoring_spec_version' => 'scoring_2026_02',
+            'norm_version' => 'norm_2026_02',
+            'created_at' => $dayTwo->addHours(1),
+            'submitted_at' => $dayTwo->addHours(1)->addMinutes(5),
+        ]);
+        $this->insertAnalyticsResult([
+            'attempt_id' => $attemptE,
+            'org_id' => $orgId,
+            'scale_code' => 'MBTI',
+            'type_code' => 'ESTP-T',
+            'scores_pct' => ['EI' => 80, 'SN' => 55, 'TF' => 78, 'JP' => 20, 'AT' => 30],
+            'computed_at' => $dayTwo->addHours(1)->addMinutes(6),
+            'content_package_version' => 'content_2026_02',
+            'scoring_spec_version' => 'scoring_2026_02',
+        ]);
+
+        $nonMbtiAttempt = $this->insertAnalyticsAttempt([
+            'org_id' => $orgId,
+            'scale_code' => 'BIG5_OCEAN',
+            'locale' => 'en',
+            'region' => 'US',
+            'content_package_version' => 'content_big5_2026_01',
+            'scoring_spec_version' => 'scoring_big5_2026_01',
+            'norm_version' => 'norm_big5_2026_01',
+            'created_at' => $dayOne->addHours(3),
+        ]);
+        $this->insertAnalyticsResult([
+            'attempt_id' => $nonMbtiAttempt,
+            'org_id' => $orgId,
+            'scale_code' => 'BIG5_OCEAN',
+            'type_code' => 'ENTJ-A',
+            'scores_pct' => ['EI' => 60, 'SN' => 55, 'TF' => 51, 'JP' => 54, 'AT' => 57],
+            'computed_at' => $dayOne->addHours(3)->addMinutes(6),
+            'content_package_version' => 'content_big5_2026_01',
+            'scoring_spec_version' => 'scoring_big5_2026_01',
+        ]);
+
+        $invalidAttempt = $this->insertAnalyticsAttempt([
+            'org_id' => $orgId,
+            'scale_code' => 'MBTI',
+            'locale' => 'en',
+            'region' => 'US',
+            'content_package_version' => 'content_2026_02',
+            'scoring_spec_version' => 'scoring_2026_02',
+            'norm_version' => 'norm_2026_02',
+            'created_at' => $dayTwo->addHours(2),
+        ]);
+        $this->insertAnalyticsResult([
+            'attempt_id' => $invalidAttempt,
+            'org_id' => $orgId,
+            'scale_code' => 'MBTI',
+            'type_code' => 'ENTP-T',
+            'scores_pct' => ['EI' => 62, 'SN' => 64, 'TF' => 71, 'JP' => 28, 'AT' => 35],
+            'computed_at' => $dayTwo->addHours(2)->addMinutes(6),
+            'is_valid' => false,
+            'content_package_version' => 'content_2026_02',
+            'scoring_spec_version' => 'scoring_2026_02',
+        ]);
+
+        $fallbackAttempt = $this->insertAnalyticsAttempt([
+            'org_id' => $orgId,
+            'scale_code' => 'MBTI',
+            'locale' => 'en',
+            'region' => 'US',
+            'content_package_version' => 'content_2026_02',
+            'scoring_spec_version' => 'scoring_2026_02',
+            'norm_version' => 'norm_2026_02',
+            'created_at' => $dayTwo->addHours(3),
+        ]);
+        $this->insertAnalyticsResult([
+            'attempt_id' => $fallbackAttempt,
+            'org_id' => $orgId,
+            'scale_code' => 'MBTI',
+            'type_code' => '',
+            'scores_pct' => ['EI' => 44, 'SN' => 66, 'TF' => 56, 'JP' => 60, 'AT' => 58],
+            'computed_at' => $dayTwo->addHours(3)->addMinutes(6),
+            'result_json' => ['type_code' => 'ISTJ-A'],
+            'content_package_version' => 'content_2026_02',
+            'scoring_spec_version' => 'scoring_2026_02',
+        ]);
+
+        $this->insertAnalyticsResult([
+            'attempt_id' => (string) Str::uuid(),
+            'org_id' => $orgId,
+            'scale_code' => 'MBTI',
+            'type_code' => 'ENTJ-A',
+            'scores_pct' => ['EI' => 65, 'SN' => 55, 'TF' => 80, 'JP' => 75, 'AT' => 60],
+            'computed_at' => $dayTwo->addHours(4)->addMinutes(6),
+            'content_package_version' => 'content_2026_02',
+            'scoring_spec_version' => 'scoring_2026_02',
+        ]);
+
+        return [
+            'from' => $dayOne->toDateString(),
+            'to' => $dayTwo->toDateString(),
+        ];
+    }
+
+    /**
+     * @param  array<string,mixed>  $overrides
+     */
+    private function insertAnalyticsAttempt(array $overrides = []): string
+    {
+        $attemptId = (string) ($overrides['id'] ?? Str::uuid());
+        $createdAt = $overrides['created_at'] ?? CarbonImmutable::parse('2026-01-03 00:00:00');
+        $submittedAt = $overrides['submitted_at'] ?? null;
+        $scaleCode = (string) ($overrides['scale_code'] ?? 'MBTI');
+
+        $row = [
+            'id' => $attemptId,
+            'ticket_code' => 'FMT-'.strtoupper(substr(str_replace('-', '', $attemptId), 0, 8)),
+            'anon_id' => 'anon_'.substr(str_replace('-', '', $attemptId), 0, 10),
+            'user_id' => null,
+            'org_id' => (int) ($overrides['org_id'] ?? 0),
+            'scale_code' => $scaleCode,
+            'scale_version' => (string) ($overrides['scale_version'] ?? 'v0.3'),
+            'question_count' => (int) ($overrides['question_count'] ?? 93),
+            'answers_summary_json' => json_encode(['seed' => true], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES),
+            'client_platform' => 'web',
+            'client_version' => 'test',
+            'channel' => 'web',
+            'referrer' => '/tests/mbti-insights',
+            'region' => (string) ($overrides['region'] ?? 'US'),
+            'locale' => (string) ($overrides['locale'] ?? 'en'),
+            'started_at' => $createdAt,
+            'submitted_at' => $submittedAt,
+            'created_at' => $createdAt,
+            'updated_at' => $submittedAt ?? $createdAt,
+            'pack_id' => (string) ($overrides['pack_id'] ?? $scaleCode),
+            'dir_version' => (string) ($overrides['dir_version'] ?? 'mbti_dir_2026_01'),
+            'content_package_version' => (string) ($overrides['content_package_version'] ?? 'content_2026_01'),
+            'scoring_spec_version' => (string) ($overrides['scoring_spec_version'] ?? 'scoring_2026_01'),
+            'norm_version' => (string) ($overrides['norm_version'] ?? 'norm_2026_01'),
+            'result_json' => json_encode($overrides['result_json'] ?? ['type_code' => 'INTJ-A'], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES),
+        ];
+
+        if (Schema::hasColumn('attempts', 'scale_code_v2')) {
+            $row['scale_code_v2'] = $scaleCode === 'MBTI' ? 'MBTI_PERSONALITY_TEST_16_TYPES' : $scaleCode;
+        }
+
+        if (Schema::hasColumn('attempts', 'scale_uid')) {
+            $row['scale_uid'] = $scaleCode === 'MBTI'
+                ? '11111111-1111-4111-8111-111111111111'
+                : '22222222-2222-4222-8222-222222222222';
+        }
+
+        DB::table('attempts')->insert($row);
+
+        return $attemptId;
+    }
+
+    /**
+     * @param  array<string,mixed>  $overrides
+     */
+    private function insertAnalyticsResult(array $overrides = []): string
+    {
+        $resultId = (string) ($overrides['id'] ?? Str::uuid());
+        $computedAt = $overrides['computed_at'] ?? CarbonImmutable::parse('2026-01-03 00:00:00');
+        $scaleCode = (string) ($overrides['scale_code'] ?? 'MBTI');
+        $typeCode = (string) ($overrides['type_code'] ?? 'INTJ-A');
+        $scoresPct = (array) ($overrides['scores_pct'] ?? ['EI' => 45, 'SN' => 40, 'TF' => 80, 'JP' => 70, 'AT' => 60]);
+        $resultJson = $overrides['result_json'] ?? ['type_code' => $typeCode];
+
+        $row = [
+            'id' => $resultId,
+            'attempt_id' => (string) ($overrides['attempt_id'] ?? Str::uuid()),
+            'org_id' => (int) ($overrides['org_id'] ?? 0),
+            'scale_code' => $scaleCode,
+            'scale_version' => (string) ($overrides['scale_version'] ?? 'v0.3'),
+            'type_code' => $typeCode,
+            'scores_json' => json_encode($overrides['scores_json'] ?? ['EI' => ['sum' => 2]], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES),
+            'profile_version' => (string) ($overrides['profile_version'] ?? 'profile_2026_01'),
+            'is_valid' => array_key_exists('is_valid', $overrides) ? (bool) $overrides['is_valid'] : true,
+            'computed_at' => $computedAt,
+            'created_at' => $computedAt,
+            'updated_at' => $computedAt,
+        ];
+
+        if (Schema::hasColumn('results', 'scores_pct')) {
+            $row['scores_pct'] = json_encode($scoresPct, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES);
+        }
+
+        if (Schema::hasColumn('results', 'axis_states')) {
+            $row['axis_states'] = json_encode($overrides['axis_states'] ?? [
+                'EI' => 'clear',
+                'SN' => 'clear',
+                'TF' => 'clear',
+                'JP' => 'clear',
+                'AT' => 'clear',
+            ], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES);
+        }
+
+        if (Schema::hasColumn('results', 'scale_code_v2')) {
+            $row['scale_code_v2'] = $scaleCode === 'MBTI' ? 'MBTI_PERSONALITY_TEST_16_TYPES' : $scaleCode;
+        }
+
+        if (Schema::hasColumn('results', 'scale_uid')) {
+            $row['scale_uid'] = $scaleCode === 'MBTI'
+                ? '11111111-1111-4111-8111-111111111111'
+                : '22222222-2222-4222-8222-222222222222';
+        }
+
+        if (Schema::hasColumn('results', 'result_json')) {
+            $row['result_json'] = json_encode($resultJson, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES);
+        }
+
+        if (Schema::hasColumn('results', 'pack_id')) {
+            $row['pack_id'] = (string) ($overrides['pack_id'] ?? $scaleCode);
+        }
+
+        if (Schema::hasColumn('results', 'content_package_version')) {
+            $row['content_package_version'] = (string) ($overrides['content_package_version'] ?? 'content_2026_01');
+        }
+
+        if (Schema::hasColumn('results', 'dir_version')) {
+            $row['dir_version'] = (string) ($overrides['dir_version'] ?? 'mbti_dir_2026_01');
+        }
+
+        if (Schema::hasColumn('results', 'scoring_spec_version')) {
+            $row['scoring_spec_version'] = (string) ($overrides['scoring_spec_version'] ?? 'scoring_2026_01');
+        }
+
+        if (Schema::hasColumn('results', 'report_engine_version')) {
+            $row['report_engine_version'] = (string) ($overrides['report_engine_version'] ?? 'v1.2');
+        }
+
+        DB::table('results')->insert($row);
+
+        return $resultId;
+    }
+}

--- a/backend/tests/Feature/Analytics/AnalyticsAxisDailyBuilderTest.php
+++ b/backend/tests/Feature/Analytics/AnalyticsAxisDailyBuilderTest.php
@@ -1,0 +1,69 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Analytics;
+
+use App\Services\Analytics\MbtiDistributionDailyBuilder;
+use Carbon\CarbonImmutable;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\Concerns\SeedsMbtiInsightsScenario;
+use Tests\TestCase;
+
+final class AnalyticsAxisDailyBuilderTest extends TestCase
+{
+    use RefreshDatabase;
+    use SeedsMbtiInsightsScenario;
+
+    public function test_axis_builder_counts_side_distribution_and_keeps_at_out_when_a_row_lacks_at_resolution(): void
+    {
+        $scenario = $this->seedMbtiInsightsAuthorityScenario(601);
+
+        $attemptGap = $this->insertAnalyticsAttempt([
+            'org_id' => 601,
+            'scale_code' => 'MBTI',
+            'locale' => 'en',
+            'region' => 'US',
+            'content_package_version' => 'content_2026_02',
+            'scoring_spec_version' => 'scoring_2026_02',
+            'norm_version' => 'norm_2026_02',
+            'created_at' => CarbonImmutable::parse('2026-01-04 14:00:00'),
+            'submitted_at' => CarbonImmutable::parse('2026-01-04 14:05:00'),
+        ]);
+        $this->insertAnalyticsResult([
+            'attempt_id' => $attemptGap,
+            'org_id' => 601,
+            'scale_code' => 'MBTI',
+            'type_code' => 'ISTJ',
+            'scores_pct' => ['EI' => 45, 'SN' => 55, 'TF' => 55, 'JP' => 55],
+            'computed_at' => CarbonImmutable::parse('2026-01-04 14:06:00'),
+            'content_package_version' => 'content_2026_02',
+            'scoring_spec_version' => 'scoring_2026_02',
+        ]);
+
+        $payload = app(MbtiDistributionDailyBuilder::class)->build(
+            new \DateTimeImmutable($scenario['from']),
+            new \DateTimeImmutable($scenario['to']),
+            [601],
+        );
+
+        $this->assertSame(6, (int) ($payload['source_results'] ?? 0));
+        $this->assertSame(5, (int) ($payload['source_results_with_at'] ?? 0));
+        $this->assertFalse((bool) ($payload['at_authority_complete'] ?? true));
+
+        $axisTotals = collect($payload['axis_rows'])
+            ->groupBy('axis_code')
+            ->map(function ($group): array {
+                return $group
+                    ->groupBy('side_code')
+                    ->map(static fn ($rows): int => (int) collect($rows)->sum('results_count'))
+                    ->all();
+            });
+
+        $this->assertEquals(['E' => 2, 'I' => 4], $axisTotals->get('EI'));
+        $this->assertEquals(['N' => 4, 'S' => 2], $axisTotals->get('SN'));
+        $this->assertEquals(['T' => 4, 'F' => 2], $axisTotals->get('TF'));
+        $this->assertEquals(['J' => 4, 'P' => 2], $axisTotals->get('JP'));
+        $this->assertEquals(['A' => 3, 'T' => 2], $axisTotals->get('AT'));
+    }
+}

--- a/backend/tests/Feature/Analytics/MbtiDistributionDailyBuilderTest.php
+++ b/backend/tests/Feature/Analytics/MbtiDistributionDailyBuilderTest.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Analytics;
+
+use App\Services\Analytics\MbtiDistributionDailyBuilder;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\Concerns\SeedsMbtiInsightsScenario;
+use Tests\TestCase;
+
+final class MbtiDistributionDailyBuilderTest extends TestCase
+{
+    use RefreshDatabase;
+    use SeedsMbtiInsightsScenario;
+
+    public function test_builder_aggregates_mbti_only_authority_rows_and_preserves_attempt_context_dimensions(): void
+    {
+        $scenario = $this->seedMbtiInsightsAuthorityScenario(501);
+
+        $payload = app(MbtiDistributionDailyBuilder::class)->build(
+            new \DateTimeImmutable($scenario['from']),
+            new \DateTimeImmutable($scenario['to']),
+            [501],
+        );
+
+        $this->assertSame('MBTI', (string) ($payload['scale_scope']['scale_code'] ?? ''));
+        $this->assertSame(5, (int) ($payload['source_results'] ?? 0), 'invalid, orphan, fallback-only, and non-MBTI rows must stay out');
+        $this->assertSame(5, (int) collect($payload['type_rows'])->sum('results_count'));
+        $this->assertSame(5, (int) collect($payload['type_rows'])->sum('distinct_attempts_with_results'));
+
+        $rowsByKey = collect($payload['type_rows'])->keyBy(static fn (array $row): string => implode('|', [
+            (string) $row['day'],
+            (string) $row['locale'],
+            (string) $row['content_package_version'],
+            (string) $row['scoring_spec_version'],
+            (string) $row['norm_version'],
+            (string) $row['type_code'],
+        ]));
+
+        $this->assertArrayHasKey('2026-01-03|en|content_2026_01|scoring_2026_01|norm_2026_01|INTJ', $rowsByKey->all());
+        $this->assertArrayHasKey('2026-01-03|en|content_2026_01|scoring_2026_01|norm_2026_01|ENFP', $rowsByKey->all());
+        $this->assertArrayHasKey('2026-01-03|zh-CN|content_2026_01|scoring_2026_02|norm_2026_02|INFJ', $rowsByKey->all());
+        $this->assertArrayHasKey('2026-01-04|en|content_2026_02|scoring_2026_02|norm_2026_02|INTJ', $rowsByKey->all());
+        $this->assertArrayHasKey('2026-01-04|fr-FR|content_2026_02|scoring_2026_02|norm_2026_02|ESTP', $rowsByKey->all());
+
+        $this->assertSame(2, (int) collect($payload['type_rows'])->where('type_code', 'INTJ')->sum('results_count'));
+        $this->assertSame(1, (int) collect($payload['type_rows'])->where('locale', 'zh-CN')->sum('results_count'));
+        $this->assertSame(2, (int) collect($payload['type_rows'])->where('content_package_version', 'content_2026_02')->sum('results_count'));
+    }
+}

--- a/backend/tests/Feature/Analytics/RefreshMbtiDailyCommandTest.php
+++ b/backend/tests/Feature/Analytics/RefreshMbtiDailyCommandTest.php
@@ -1,0 +1,58 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Analytics;
+
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\DB;
+use Tests\Concerns\SeedsMbtiInsightsScenario;
+use Tests\TestCase;
+
+final class RefreshMbtiDailyCommandTest extends TestCase
+{
+    use RefreshDatabase;
+    use SeedsMbtiInsightsScenario;
+
+    public function test_command_supports_dry_run_and_upserts_two_mbti_daily_tables(): void
+    {
+        $scenario = $this->seedMbtiInsightsAuthorityScenario(701);
+
+        $this->artisan('analytics:refresh-mbti-daily', [
+            '--from' => $scenario['from'],
+            '--to' => $scenario['to'],
+            '--org' => [701],
+            '--dry-run' => true,
+        ])
+            ->expectsOutputToContain('dry_run=1')
+            ->expectsOutputToContain('source_results=5')
+            ->expectsOutputToContain('attempted_type_rows=5')
+            ->assertExitCode(0);
+
+        $this->assertSame(0, DB::table('analytics_mbti_type_daily')->count());
+        $this->assertSame(0, DB::table('analytics_axis_daily')->count());
+
+        $this->artisan('analytics:refresh-mbti-daily', [
+            '--from' => $scenario['from'],
+            '--to' => $scenario['to'],
+            '--org' => [701],
+        ])
+            ->expectsOutputToContain('dry_run=0')
+            ->expectsOutputToContain('upserted_type_rows=5')
+            ->expectsOutputToContain('upserted_axis_rows=24')
+            ->assertExitCode(0);
+
+        $this->assertSame(5, DB::table('analytics_mbti_type_daily')->count());
+        $this->assertSame(24, DB::table('analytics_axis_daily')->count());
+        $this->assertSame(5, (int) DB::table('analytics_mbti_type_daily')->sum('results_count'));
+
+        $this->artisan('analytics:refresh-mbti-daily', [
+            '--from' => $scenario['from'],
+            '--to' => $scenario['to'],
+            '--org' => [701],
+        ])->assertExitCode(0);
+
+        $this->assertSame(5, DB::table('analytics_mbti_type_daily')->count());
+        $this->assertSame(24, DB::table('analytics_axis_daily')->count());
+    }
+}

--- a/backend/tests/Feature/Ops/MbtiInsightsPageTest.php
+++ b/backend/tests/Feature/Ops/MbtiInsightsPageTest.php
@@ -1,0 +1,136 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Ops;
+
+use App\Filament\Ops\Pages\MbtiInsightsPage;
+use App\Models\AdminUser;
+use App\Models\Organization;
+use App\Models\Permission;
+use App\Models\Role;
+use App\Services\Analytics\MbtiDistributionDailyBuilder;
+use App\Support\OrgContext;
+use App\Support\Rbac\PermissionNames;
+use Filament\Facades\Filament;
+use Filament\PanelRegistry;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Http\Request;
+use Illuminate\Support\Str;
+use Livewire\Livewire;
+use Tests\Concerns\SeedsMbtiInsightsScenario;
+use Tests\TestCase;
+
+final class MbtiInsightsPageTest extends TestCase
+{
+    use RefreshDatabase;
+    use SeedsMbtiInsightsScenario;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        Filament::setCurrentPanel(app(PanelRegistry::class)->get('ops'));
+    }
+
+    public function test_mbti_insights_page_route_exists_and_tabs_render_basic_mbti_data(): void
+    {
+        $admin = $this->createAdminWithPermissions([
+            PermissionNames::ADMIN_OPS_READ,
+        ]);
+        $selectedOrg = $this->createOrganization('MBTI Insights Org');
+        $scenario = $this->seedMbtiInsightsAuthorityScenario((int) $selectedOrg->id);
+
+        app(MbtiDistributionDailyBuilder::class)->refresh(
+            new \DateTimeImmutable($scenario['from']),
+            new \DateTimeImmutable($scenario['to']),
+            [(int) $selectedOrg->id],
+        );
+
+        $this->withSession($this->opsSession($admin, $selectedOrg))
+            ->actingAs($admin, (string) config('admin.guard', 'admin'))
+            ->get('/ops/mbti-insights')
+            ->assertOk()
+            ->assertSee('MBTI Insights')
+            ->assertSee('Overview')
+            ->assertSee('Type Distribution')
+            ->assertSee('Axis Distribution')
+            ->assertSee('Authority Scope');
+
+        $this->actingAs($admin, (string) config('admin.guard', 'admin'));
+        app()->instance('request', Request::create('/ops/mbti-insights', 'GET'));
+
+        $context = app(OrgContext::class);
+        $context->set((int) $selectedOrg->id, (int) $admin->id, 'admin');
+        app()->instance(OrgContext::class, $context);
+
+        Livewire::test(MbtiInsightsPage::class)
+            ->assertOk()
+            ->set('fromDate', $scenario['from'])
+            ->set('toDate', $scenario['to'])
+            ->call('applyFilters')
+            ->assertSet('hasData', true)
+            ->assertSet('kpis.0.label', 'Total results')
+            ->call('setActiveTab', 'types')
+            ->assertSet('activeTab', 'types')
+            ->assertSet('typeDistribution.0.type_code', 'INTJ')
+            ->call('setActiveTab', 'axes')
+            ->assertSet('activeTab', 'axes')
+            ->assertSet('showsAtAxis', true)
+            ->assertSet('axisSummary.0.axis_code', 'EI');
+    }
+
+    private function createOrganization(string $name): Organization
+    {
+        return Organization::query()->create([
+            'name' => $name,
+            'owner_user_id' => random_int(1000, 9999),
+            'status' => 'active',
+            'domain' => Str::slug($name).'.example.test',
+            'timezone' => 'Asia/Shanghai',
+            'locale' => 'en',
+        ]);
+    }
+
+    /**
+     * @param  list<string>  $permissions
+     */
+    private function createAdminWithPermissions(array $permissions): AdminUser
+    {
+        $admin = AdminUser::query()->create([
+            'name' => 'ops_'.Str::lower(Str::random(6)),
+            'email' => 'ops_'.Str::lower(Str::random(6)).'@example.test',
+            'password' => bcrypt('secret'),
+            'is_active' => 1,
+        ]);
+
+        $role = Role::query()->create([
+            'name' => 'role_'.Str::lower(Str::random(8)),
+            'description' => null,
+        ]);
+
+        foreach ($permissions as $permissionName) {
+            $permission = Permission::query()->firstOrCreate(
+                ['name' => $permissionName],
+                ['description' => null],
+            );
+
+            $role->permissions()->syncWithoutDetaching([$permission->id]);
+        }
+
+        $admin->roles()->syncWithoutDetaching([$role->id]);
+
+        return $admin;
+    }
+
+    /**
+     * @return array{ops_org_id:int,ops_admin_totp_verified_user_id:int}
+     */
+    private function opsSession(AdminUser $admin, Organization $selectedOrg): array
+    {
+        return [
+            'ops_org_id' => (int) $selectedOrg->id,
+            'ops_admin_totp_verified_user_id' => (int) $admin->id,
+        ];
+    }
+}


### PR DESCRIPTION
Summary
- add MBTI Overview, Type Distribution, and Axis Distribution as the first assessment-insights pages
- normalize first-phase MBTI insights around results-based daily aggregation with attempt-side context

What changed
- add analytics_mbti_type_daily and analytics_axis_daily
- add a refresh path for MBTI daily aggregation
- add a custom MBTI Insights page in Filament Ops
- show overview KPI cards, type distribution, axis distribution, trends, and locale/version slices
- document the first-phase MBTI-only authority and non-authoritative metrics

Design choices
- use results as the primary fact axis and supplement with attempt-side locale/region/version context
- keep MBTI-only as the first authoritative scope
- exclude invalid/orphan/fallback results from first-phase authoritative metrics
- defer paid/unlocked/share subset analysis and deeper psychometrics work
- keep the page under Assessment Insights
- show A/T only when the filtered scope has full authoritative coverage

Why this PR is small and safe
- no frontend changes
- no API changes
- no Node/runtime changes
- no write-side behavior changes
- only the first aggregated MBTI insights surface for AIC

Validation
- php artisan about
- php artisan route:list --path=ops --except-vendor
- php artisan migrate
- php artisan analytics:refresh-mbti-daily --from=2026-01-01 --to=2026-01-07
- php artisan test --filter='(Mbti|AnalyticsAxis|AnalyticsMbti|AssessmentInsights)'
- php artisan filament:assets
- npm run build
- bash backend/scripts/ci_verify_mbti.sh

Notes
- ci_verify_mbti.sh completed successfully; one existing non-blocking ACCEPT_D report_view warning still appeared during the run, but the script exited 0 and subsequent gates passed.
- local unrelated dirty files under backend/content_packs/BIG5_OCEAN/v1/compiled/* were intentionally left out of this commit.
