### PR TITLE
feat(assessment-insights): add Question Analytics for safe row-capable scales

### DIFF
--- a/backend/app/Console/Commands/RefreshQuestionDailyCommand.php
+++ b/backend/app/Console/Commands/RefreshQuestionDailyCommand.php
@@ -1,0 +1,92 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Console\Commands;
+
+use App\Services\Analytics\QuestionAnalyticsDailyBuilder;
+use Carbon\CarbonImmutable;
+use Illuminate\Console\Command;
+
+class RefreshQuestionDailyCommand extends Command
+{
+    protected $signature = 'analytics:refresh-question-daily
+        {--from= : Inclusive start date (Y-m-d)}
+        {--to= : Inclusive end date (Y-m-d)}
+        {--scale=* : Limit refresh to one or more scale codes inside the authoritative scope}
+        {--locale=* : Limit refresh to one or more locales}
+        {--org=* : Limit refresh to one or more org ids}
+        {--dry-run : Preview the aggregation without writing rows}';
+
+    protected $description = 'Refresh first-phase Question Analytics daily read models for authoritative safe scales.';
+
+    public function __construct(
+        private readonly QuestionAnalyticsDailyBuilder $builder,
+    ) {
+        parent::__construct();
+    }
+
+    public function handle(): int
+    {
+        $from = $this->parseDateOption((string) $this->option('from'), now()->subDays(13)->toDateString());
+        $to = $this->parseDateOption((string) $this->option('to'), now()->toDateString());
+
+        if ($from->greaterThan($to)) {
+            $this->error('The --from date must be on or before --to.');
+
+            return self::FAILURE;
+        }
+
+        $scaleCodes = array_values(array_filter(array_map(
+            static fn (mixed $value): string => strtoupper(trim((string) $value)),
+            (array) $this->option('scale')
+        ), static fn (string $value): bool => $value !== ''));
+
+        $locales = array_values(array_filter(array_map(
+            static fn (mixed $value): string => trim((string) $value),
+            (array) $this->option('locale')
+        ), static fn (string $value): bool => $value !== ''));
+
+        $orgIds = array_values(array_filter(array_map(
+            static fn (mixed $value): int => max(0, (int) $value),
+            (array) $this->option('org')
+        ), static fn (int $value): bool => $value > 0));
+
+        $dryRun = (bool) $this->option('dry-run');
+
+        $result = $this->builder->refresh($from, $to, $orgIds, $scaleCodes, $locales, $dryRun);
+
+        $this->line('from='.$result['from']);
+        $this->line('to='.$result['to']);
+        $this->line('org_scope='.(empty($result['org_scope']) ? '*' : implode(',', $result['org_scope'])));
+        $this->line('locale_scope='.(empty($result['locale_scope']) ? '*' : implode(',', $result['locale_scope'])));
+        $this->line('requested_scale_scope='.(empty($result['requested_scales']) ? '*' : implode(',', $result['requested_scales'])));
+        $this->line('effective_scale_scope='.(empty($result['authoritative_scales']) ? '-' : implode(',', $result['authoritative_scales'])));
+        $this->line('ignored_requested_scales='.(empty($result['ignored_requested_scales']) ? '-' : implode(',', $result['ignored_requested_scales'])));
+        $this->line('dry_run='.(($result['dry_run'] ?? false) ? '1' : '0'));
+        $this->line('source_answer_rows='.(string) ($result['source_answer_rows'] ?? 0));
+        $this->line('source_attempts='.(string) ($result['source_attempts'] ?? 0));
+        $this->line('attempted_option_rows='.(string) ($result['attempted_option_rows'] ?? 0));
+        $this->line('attempted_progress_rows='.(string) ($result['attempted_progress_rows'] ?? 0));
+        $this->line('deleted_option_rows='.(string) ($result['deleted_option_rows'] ?? 0));
+        $this->line('deleted_progress_rows='.(string) ($result['deleted_progress_rows'] ?? 0));
+        $this->line('upserted_option_rows='.(string) ($result['upserted_option_rows'] ?? 0));
+        $this->line('upserted_progress_rows='.(string) ($result['upserted_progress_rows'] ?? 0));
+
+        if ((($result['attempted_option_rows'] ?? 0) === 0) && (($result['attempted_progress_rows'] ?? 0) === 0)) {
+            $this->warn('No authoritative question analytics rows were generated for the selected scope.');
+        } else {
+            $this->info($dryRun ? 'dry-run complete' : 'refresh complete');
+        }
+
+        return self::SUCCESS;
+    }
+
+    private function parseDateOption(string $value, string $fallback): CarbonImmutable
+    {
+        $candidate = trim($value) !== '' ? trim($value) : $fallback;
+
+        return CarbonImmutable::createFromFormat('Y-m-d', $candidate)?->startOfDay()
+            ?? CarbonImmutable::parse($candidate)->startOfDay();
+    }
+}

--- a/backend/app/Filament/Ops/Pages/QuestionAnalyticsPage.php
+++ b/backend/app/Filament/Ops/Pages/QuestionAnalyticsPage.php
@@ -1,0 +1,862 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Filament\Ops\Pages;
+
+use App\Services\Analytics\QuestionAnalyticsSupport;
+use App\Support\OrgContext;
+use App\Support\Rbac\PermissionNames;
+use App\Support\SchemaBaseline;
+use Carbon\CarbonImmutable;
+use Filament\Pages\Page;
+use Illuminate\Support\Collection;
+use Illuminate\Support\Facades\DB;
+
+class QuestionAnalyticsPage extends Page
+{
+    protected static ?string $navigationIcon = 'heroicon-o-queue-list';
+
+    protected static ?string $navigationGroup = 'Assessment Insights';
+
+    protected static ?string $navigationLabel = 'Question Analytics';
+
+    protected static ?int $navigationSort = 3;
+
+    protected static ?string $slug = 'question-analytics';
+
+    protected static string $view = 'filament.ops.pages.question-analytics-page';
+
+    public string $activeTab = 'option-distribution';
+
+    public string $fromDate = '';
+
+    public string $toDate = '';
+
+    public string $scaleCode = 'BIG5_OCEAN';
+
+    public string $locale = 'all';
+
+    public string $region = 'all';
+
+    public string $contentPackageVersion = 'all';
+
+    public string $scoringSpecVersion = 'all';
+
+    public string $normVersion = 'all';
+
+    public string $questionId = 'all';
+
+    public bool $onlyCompletedAttempts = false;
+
+    public bool $excludeNonAuthoritativeScales = true;
+
+    /** @var array<string,string> */
+    public array $scaleOptions = [];
+
+    /** @var array<string,string> */
+    public array $localeOptions = [];
+
+    /** @var array<string,string> */
+    public array $regionOptions = [];
+
+    /** @var array<string,string> */
+    public array $contentPackageVersionOptions = [];
+
+    /** @var array<string,string> */
+    public array $scoringSpecVersionOptions = [];
+
+    /** @var array<string,string> */
+    public array $normVersionOptions = [];
+
+    /** @var array<string,string> */
+    public array $questionIdOptions = [];
+
+    /** @var list<array<string,mixed>> */
+    public array $optionKpis = [];
+
+    /** @var list<array<string,mixed>> */
+    public array $progressKpis = [];
+
+    /** @var list<array<string,mixed>> */
+    public array $optionDistributionRows = [];
+
+    /** @var list<array<string,mixed>> */
+    public array $optionRankingRows = [];
+
+    /** @var list<array<string,mixed>> */
+    public array $optionLocaleCompareRows = [];
+
+    /** @var list<array<string,mixed>> */
+    public array $optionVersionCompareRows = [];
+
+    /** @var list<array<string,mixed>> */
+    public array $progressRows = [];
+
+    /** @var list<array<string,mixed>> */
+    public array $highestDropoffRows = [];
+
+    /** @var list<array<string,mixed>> */
+    public array $lowestCompletionRows = [];
+
+    /** @var list<array<string,mixed>> */
+    public array $progressLocaleCompareRows = [];
+
+    /** @var list<array<string,mixed>> */
+    public array $progressVersionCompareRows = [];
+
+    /** @var list<string> */
+    public array $scopeNotes = [];
+
+    /** @var list<string> */
+    public array $warnings = [];
+
+    /** @var list<array<string,string>> */
+    public array $drillLinks = [];
+
+    /** @var array{scale_code:string,scale_code_v2:string,scale_uid:?string} */
+    public array $canonicalScale = [
+        'scale_code' => 'BIG5_OCEAN',
+        'scale_code_v2' => 'BIG_FIVE_OCEAN_MODEL',
+        'scale_uid' => null,
+    ];
+
+    public bool $hasOptionData = false;
+
+    public bool $hasProgressData = false;
+
+    public function mount(): void
+    {
+        $this->canonicalScale = app(QuestionAnalyticsSupport::class)->canonicalScale('BIG5_OCEAN');
+        $this->scaleCode = $this->canonicalScale['scale_code'];
+        $this->fromDate = now()->subDays(13)->toDateString();
+        $this->toDate = now()->toDateString();
+        $this->refreshPage();
+    }
+
+    public static function canAccess(): bool
+    {
+        $guard = (string) config('admin.guard', 'admin');
+        $user = auth($guard)->user();
+
+        return is_object($user)
+            && method_exists($user, 'hasPermission')
+            && (
+                $user->hasPermission(PermissionNames::ADMIN_OPS_READ)
+                || $user->hasPermission(PermissionNames::ADMIN_OWNER)
+            );
+    }
+
+    public function getTitle(): string
+    {
+        return 'Question Analytics';
+    }
+
+    public function getSubheading(): ?string
+    {
+        return 'First-phase authoritative question-level option distribution and dropoff/completion for safe row-capable scales.';
+    }
+
+    public function applyFilters(): void
+    {
+        $this->refreshPage();
+    }
+
+    public function setActiveTab(string $tab): void
+    {
+        if (! in_array($tab, ['option-distribution', 'dropoff-completion'], true)) {
+            return;
+        }
+
+        $this->activeTab = $tab;
+    }
+
+    public function formatInt(int $value): string
+    {
+        return number_format($value);
+    }
+
+    public function formatRate(?float $value): string
+    {
+        if ($value === null) {
+            return 'n/a';
+        }
+
+        return number_format($value * 100, 1).'%';
+    }
+
+    public function questionLabel(string $questionId): string
+    {
+        $definition = app(QuestionAnalyticsSupport::class)->big5Definition();
+        $question = $definition['questions'][$questionId] ?? null;
+        if (! is_array($question)) {
+            return $questionId;
+        }
+
+        $preferZh = str_starts_with(strtolower($this->locale), 'zh');
+        $text = trim((string) ($preferZh ? ($question['text_zh'] ?? '') : ($question['text_en'] ?? '')));
+        if ($text === '') {
+            $text = trim((string) ($question['text_en'] ?? $question['text_zh'] ?? ''));
+        }
+
+        return $text !== '' ? $text : $questionId;
+    }
+
+    public function optionLabel(string $optionKey): string
+    {
+        $definition = app(QuestionAnalyticsSupport::class)->big5Definition();
+        $labels = $definition['option_labels'][$optionKey] ?? null;
+        if (! is_array($labels)) {
+            return $optionKey;
+        }
+
+        $preferZh = str_starts_with(strtolower($this->locale), 'zh');
+        $label = trim((string) ($preferZh ? ($labels['label_zh'] ?? '') : ($labels['label_en'] ?? '')));
+        if ($label === '') {
+            $label = trim((string) ($labels['label_en'] ?? $labels['label_zh'] ?? ''));
+        }
+
+        return $label !== '' ? $label : $optionKey;
+    }
+
+    public function barColor(string $key): string
+    {
+        return match (trim($key)) {
+            '1' => '#dbeafe',
+            '2' => '#93c5fd',
+            '3' => '#60a5fa',
+            '4' => '#2563eb',
+            '5' => '#1d4ed8',
+            default => '#94a3b8',
+        };
+    }
+
+    private function refreshPage(): void
+    {
+        $this->enforceScope();
+        $this->warnings = [];
+        $this->scopeNotes = [];
+        $this->drillLinks = [];
+        $this->hasOptionData = false;
+        $this->hasProgressData = false;
+        $this->resetPanels();
+        $this->loadFilterOptions();
+        $this->drillLinks = $this->buildDrillLinks();
+
+        if (! SchemaBaseline::hasTable('analytics_question_option_daily') || ! SchemaBaseline::hasTable('analytics_question_progress_daily')) {
+            $this->warnings[] = 'Question Analytics daily read models are missing. Run php artisan migrate first.';
+            $this->scopeNotes = $this->buildScopeNotes();
+
+            return;
+        }
+
+        [$from, $to] = $this->resolvedRange();
+        if ($from->greaterThan($to)) {
+            $this->warnings[] = 'The selected date range is invalid. Keep the start date on or before the end date.';
+            $this->scopeNotes = $this->buildScopeNotes();
+
+            return;
+        }
+
+        $orgId = $this->selectedOrgId();
+        if ($orgId <= 0) {
+            $this->warnings[] = 'Select an org before loading Question Analytics.';
+            $this->scopeNotes = $this->buildScopeNotes();
+
+            return;
+        }
+
+        $optionRows = $this->scopedOptionQuery()
+            ->orderBy('question_order')
+            ->orderBy('option_key')
+            ->get([
+                'day',
+                'locale',
+                'region',
+                'content_package_version',
+                'scoring_spec_version',
+                'norm_version',
+                'question_id',
+                'question_order',
+                'option_key',
+                'answered_rows_count',
+                'distinct_attempts_answered',
+            ]);
+
+        $progressRows = $this->scopedProgressQuery()
+            ->orderBy('question_order')
+            ->get([
+                'day',
+                'locale',
+                'region',
+                'content_package_version',
+                'scoring_spec_version',
+                'norm_version',
+                'question_id',
+                'question_order',
+                'reached_attempts_count',
+                'answered_attempts_count',
+                'completed_attempts_count',
+                'dropoff_attempts_count',
+            ]);
+
+        $this->hasOptionData = $optionRows->isNotEmpty();
+        $this->hasProgressData = $progressRows->isNotEmpty();
+
+        if (! $this->hasOptionData && ! $this->hasProgressData) {
+            $this->warnings[] = 'No authoritative BIG5 question rows match the current scope. Refresh with php artisan analytics:refresh-question-daily --from='.$from->toDateString().' --to='.$to->toDateString().'.';
+            $this->scopeNotes = $this->buildScopeNotes();
+
+            return;
+        }
+
+        if ($this->hasOptionData) {
+            $this->buildOptionPanels($optionRows);
+        }
+
+        if ($this->hasProgressData) {
+            $this->buildProgressPanels($progressRows);
+        }
+
+        $this->scopeNotes = $this->buildScopeNotes();
+    }
+
+    private function loadFilterOptions(): void
+    {
+        $this->scaleOptions = [
+            $this->canonicalScale['scale_code'] => $this->canonicalScale['scale_code'].' (authoritative)',
+        ];
+        $this->localeOptions = [];
+        $this->regionOptions = [];
+        $this->contentPackageVersionOptions = [];
+        $this->scoringSpecVersionOptions = [];
+        $this->normVersionOptions = [];
+        $this->questionIdOptions = $this->buildQuestionIdOptions();
+
+        if (! SchemaBaseline::hasTable('analytics_question_progress_daily')) {
+            return;
+        }
+
+        $orgId = $this->selectedOrgId();
+        if ($orgId <= 0) {
+            return;
+        }
+
+        $base = DB::table('analytics_question_progress_daily')
+            ->where('org_id', $orgId)
+            ->where('scale_code', $this->canonicalScale['scale_code']);
+
+        $this->localeOptions = $this->distinctOptions(clone $base, 'locale');
+        $this->regionOptions = $this->distinctOptions(clone $base, 'region');
+        $this->contentPackageVersionOptions = $this->distinctOptions(clone $base, 'content_package_version');
+        $this->scoringSpecVersionOptions = $this->distinctOptions(clone $base, 'scoring_spec_version');
+        $this->normVersionOptions = $this->distinctOptions(clone $base, 'norm_version');
+    }
+
+    private function scopedOptionQuery(): \Illuminate\Database\Query\Builder
+    {
+        [$from, $to] = $this->resolvedRange();
+
+        $query = DB::table('analytics_question_option_daily')
+            ->where('org_id', $this->selectedOrgId())
+            ->whereBetween('day', [$from->toDateString(), $to->toDateString()])
+            ->where('scale_code', $this->canonicalScale['scale_code']);
+
+        $this->applySharedFilters($query);
+
+        return $query;
+    }
+
+    private function scopedProgressQuery(): \Illuminate\Database\Query\Builder
+    {
+        [$from, $to] = $this->resolvedRange();
+
+        $query = DB::table('analytics_question_progress_daily')
+            ->where('org_id', $this->selectedOrgId())
+            ->whereBetween('day', [$from->toDateString(), $to->toDateString()])
+            ->where('scale_code', $this->canonicalScale['scale_code']);
+
+        $this->applySharedFilters($query);
+
+        return $query;
+    }
+
+    private function applySharedFilters(\Illuminate\Database\Query\Builder $query): void
+    {
+        if ($this->locale !== 'all') {
+            $query->where('locale', $this->locale);
+        }
+        if ($this->region !== 'all') {
+            $query->where('region', $this->region);
+        }
+        if ($this->contentPackageVersion !== 'all') {
+            $query->where('content_package_version', $this->contentPackageVersion);
+        }
+        if ($this->scoringSpecVersion !== 'all') {
+            $query->where('scoring_spec_version', $this->scoringSpecVersion);
+        }
+        if ($this->normVersion !== 'all') {
+            $query->where('norm_version', $this->normVersion);
+        }
+        if ($this->questionId !== 'all') {
+            $query->where('question_id', $this->questionId);
+        }
+    }
+
+    /**
+     * @return array{0:CarbonImmutable,1:CarbonImmutable}
+     */
+    private function resolvedRange(): array
+    {
+        $from = CarbonImmutable::parse($this->fromDate !== '' ? $this->fromDate : now()->subDays(13)->toDateString())->startOfDay();
+        $to = CarbonImmutable::parse($this->toDate !== '' ? $this->toDate : now()->toDateString())->startOfDay();
+
+        return [$from, $to];
+    }
+
+    private function selectedOrgId(): int
+    {
+        $sessionOrgId = max(0, (int) session('ops_org_id', 0));
+        if ($sessionOrgId > 0) {
+            return $sessionOrgId;
+        }
+
+        return max(0, (int) app(OrgContext::class)->orgId());
+    }
+
+    /**
+     * @return array<string,string>
+     */
+    private function distinctOptions(\Illuminate\Database\Query\Builder $query, string $column): array
+    {
+        return $query
+            ->whereNotNull($column)
+            ->where($column, '<>', '')
+            ->distinct()
+            ->orderBy($column)
+            ->pluck($column, $column)
+            ->mapWithKeys(static fn ($value): array => [(string) $value => (string) $value])
+            ->all();
+    }
+
+    private function buildOptionPanels(Collection $rows): void
+    {
+        $questionRows = $this->optionQuestionSummaries($rows);
+        $totalAnsweredRows = (int) $rows->sum('answered_rows_count');
+        $attemptsWithAnswers = $this->scopeAttemptCountFromOptionQuestions($questionRows);
+        $topAnsweredQuestion = $questionRows->sortByDesc('answer_count')->first();
+        $totalQuestionsInScope = $this->questionId === 'all'
+            ? (int) (app(QuestionAnalyticsSupport::class)->big5Definition()['total_questions'] ?? $questionRows->count())
+            : 1;
+
+        $this->optionKpis = [
+            [
+                'label' => 'Total answered rows',
+                'value' => $totalAnsweredRows,
+                'description' => 'Submitted BIG5 answer rows only. Clinical, SDS, redacted, and rowless scales stay out.',
+            ],
+            [
+                'label' => 'Distinct attempts with answers',
+                'value' => $attemptsWithAnswers,
+                'description' => 'Question-level answer authority count in the current BIG5 scope.',
+            ],
+            [
+                'label' => 'Total questions in scope',
+                'value' => $totalQuestionsInScope,
+                'description' => 'Question order comes from the BIG5 content pack, not from frontend question_index alone.',
+            ],
+            [
+                'label' => 'Top answered question',
+                'value' => 0,
+                'display_value' => is_array($topAnsweredQuestion)
+                    ? '#'.$topAnsweredQuestion['question_order'].' / '.$topAnsweredQuestion['question_id']
+                    : 'n/a',
+                'description' => 'Highest answer volume inside the current scope.',
+            ],
+        ];
+
+        $this->optionDistributionRows = $questionRows
+            ->sortBy('question_order')
+            ->values()
+            ->all();
+
+        $this->optionRankingRows = $questionRows
+            ->sortByDesc('answer_count')
+            ->values()
+            ->take(12)
+            ->all();
+
+        $this->optionLocaleCompareRows = $this->buildOptionLocaleCompareRows($rows);
+        $this->optionVersionCompareRows = $this->buildOptionVersionCompareRows($rows);
+    }
+
+    private function buildProgressPanels(Collection $rows): void
+    {
+        $questionRows = $this->progressQuestionSummaries($rows);
+        $selectedQuestion = $questionRows->sortBy('question_order')->first();
+        $this->progressRows = $questionRows
+            ->sortBy('question_order')
+            ->values()
+            ->all();
+
+        $this->progressKpis = [
+            [
+                'label' => 'Reached attempts',
+                'value' => $this->questionId === 'all'
+                    ? $this->firstQuestionMetric($questionRows, 'reached_attempts_count')
+                    : (int) (($selectedQuestion['reached_attempts_count'] ?? 0)),
+                'description' => 'Attempts that reached the current question scope using attempts + drafts + rows.',
+            ],
+            [
+                'label' => 'Answered attempts',
+                'value' => $this->questionId === 'all'
+                    ? $this->firstQuestionMetric($questionRows, 'answered_attempts_count')
+                    : (int) (($selectedQuestion['answered_attempts_count'] ?? 0)),
+                'description' => 'Attempts with a recorded answer at the question level.',
+            ],
+            [
+                'label' => 'Completed attempts',
+                'value' => $this->questionId === 'all'
+                    ? $this->firstQuestionMetric($questionRows, 'completed_attempts_count')
+                    : (int) (($selectedQuestion['completed_attempts_count'] ?? 0)),
+                'description' => 'Attempts that completed the full BIG5 after entering the current question scope.',
+            ],
+            [
+                'label' => 'Dropoff attempts',
+                'value' => $this->questionId === 'all'
+                    ? (int) $questionRows->sum('dropoff_attempts_count')
+                    : (int) (($selectedQuestion['dropoff_attempts_count'] ?? 0)),
+                'description' => 'Attempt terminal question under the current scope. Completed-only mode zeros this by design.',
+            ],
+        ];
+
+        $this->highestDropoffRows = $questionRows
+            ->filter(static fn (array $row): bool => (int) ($row['reached_attempts_count'] ?? 0) > 0)
+            ->sortByDesc(static fn (array $row): array => [
+                (float) ($row['dropoff_rate'] ?? 0),
+                (int) ($row['dropoff_attempts_count'] ?? 0),
+            ])
+            ->values()
+            ->take(12)
+            ->all();
+
+        $this->lowestCompletionRows = $questionRows
+            ->filter(static fn (array $row): bool => (int) ($row['reached_attempts_count'] ?? 0) > 0)
+            ->sortBy(static fn (array $row): array => [
+                (float) ($row['completion_rate'] ?? 1),
+                -1 * (int) ($row['dropoff_attempts_count'] ?? 0),
+            ])
+            ->values()
+            ->take(12)
+            ->all();
+
+        $this->progressLocaleCompareRows = $this->buildProgressLocaleCompareRows($rows);
+        $this->progressVersionCompareRows = $this->buildProgressVersionCompareRows($rows);
+    }
+
+    /**
+     * @return Collection<int,array<string,mixed>>
+     */
+    private function optionQuestionSummaries(Collection $rows): Collection
+    {
+        return $rows
+            ->groupBy(static fn ($row): string => (string) $row->question_id)
+            ->map(function (Collection $group, string $questionId): array {
+                $answerCount = (int) $group->sum('answered_rows_count');
+                $optionSegments = $group
+                    ->sortBy(static fn ($row): string => sprintf('%05s', (string) $row->option_key))
+                    ->map(function ($row) use ($answerCount): array {
+                        $count = (int) $row->answered_rows_count;
+                        $share = $answerCount > 0 ? $count / $answerCount : null;
+
+                        return [
+                            'option_key' => (string) $row->option_key,
+                            'label' => $this->optionLabel((string) $row->option_key),
+                            'count' => $count,
+                            'share' => $share,
+                            'pct' => $share !== null ? round($share * 100, 1) : 0.0,
+                        ];
+                    })
+                    ->values();
+
+                $topOption = $optionSegments->sortByDesc('count')->first();
+
+                return [
+                    'question_id' => $questionId,
+                    'question_order' => (int) ($group->min('question_order') ?? 0),
+                    'question_label' => $this->questionLabel($questionId),
+                    'answer_count' => $answerCount,
+                    'distinct_attempts_answered' => (int) $group->sum('distinct_attempts_answered'),
+                    'option_segments' => $optionSegments->all(),
+                    'top_option_key' => (string) ($topOption['option_key'] ?? 'n/a'),
+                    'top_option_share' => $topOption['share'] ?? null,
+                ];
+            });
+    }
+
+    private function scopeAttemptCountFromOptionQuestions(Collection $questionRows): int
+    {
+        if ($questionRows->isEmpty()) {
+            return 0;
+        }
+
+        if ($this->questionId !== 'all') {
+            return (int) (($questionRows->first()['distinct_attempts_answered'] ?? 0));
+        }
+
+        return (int) ($questionRows
+            ->sortBy('question_order')
+            ->first()['distinct_attempts_answered'] ?? 0);
+    }
+
+    /**
+     * @return Collection<int,array<string,mixed>>
+     */
+    private function progressQuestionSummaries(Collection $rows): Collection
+    {
+        return $rows
+            ->groupBy(static fn ($row): string => (string) $row->question_id)
+            ->map(function (Collection $group, string $questionId): array {
+                $reached = (int) $group->sum('reached_attempts_count');
+                $answered = (int) $group->sum('answered_attempts_count');
+                $completed = (int) $group->sum('completed_attempts_count');
+                $dropoff = (int) $group->sum('dropoff_attempts_count');
+
+                if ($this->onlyCompletedAttempts) {
+                    $reached = $completed;
+                    $answered = $completed;
+                    $dropoff = 0;
+                }
+
+                return [
+                    'question_id' => $questionId,
+                    'question_order' => (int) ($group->min('question_order') ?? 0),
+                    'question_label' => $this->questionLabel($questionId),
+                    'reached_attempts_count' => $reached,
+                    'answered_attempts_count' => $answered,
+                    'completed_attempts_count' => $completed,
+                    'dropoff_attempts_count' => $dropoff,
+                    'dropoff_rate' => $reached > 0 ? $dropoff / $reached : null,
+                    'completion_rate' => $reached > 0 ? $completed / $reached : null,
+                ];
+            });
+    }
+
+    private function firstQuestionMetric(Collection $rows, string $metric): int
+    {
+        if ($rows->isEmpty()) {
+            return 0;
+        }
+
+        return (int) ($rows->sortBy('question_order')->first()[$metric] ?? 0);
+    }
+
+    /**
+     * @return list<array<string,mixed>>
+     */
+    private function buildOptionLocaleCompareRows(Collection $rows): array
+    {
+        return $rows
+            ->groupBy('locale')
+            ->map(function (Collection $group, string $locale): array {
+                $questionRows = $this->optionQuestionSummaries($group);
+
+                return [
+                    'locale' => $locale,
+                    'answered_rows_count' => (int) $group->sum('answered_rows_count'),
+                    'distinct_attempts_answered' => $this->scopeAttemptCountFromOptionQuestions($questionRows),
+                ];
+            })
+            ->sortByDesc('answered_rows_count')
+            ->values()
+            ->all();
+    }
+
+    /**
+     * @return list<array<string,mixed>>
+     */
+    private function buildOptionVersionCompareRows(Collection $rows): array
+    {
+        return $rows
+            ->groupBy(static fn ($row): string => implode('|', [
+                (string) $row->content_package_version,
+                (string) $row->scoring_spec_version,
+                (string) $row->norm_version,
+            ]))
+            ->map(function (Collection $group, string $key): array {
+                [$contentVersion, $scoringVersion, $normVersion] = explode('|', $key);
+                $questionRows = $this->optionQuestionSummaries($group);
+
+                return [
+                    'content_package_version' => $contentVersion,
+                    'scoring_spec_version' => $scoringVersion,
+                    'norm_version' => $normVersion,
+                    'answered_rows_count' => (int) $group->sum('answered_rows_count'),
+                    'distinct_attempts_answered' => $this->scopeAttemptCountFromOptionQuestions($questionRows),
+                ];
+            })
+            ->sortByDesc('answered_rows_count')
+            ->values()
+            ->all();
+    }
+
+    /**
+     * @return list<array<string,mixed>>
+     */
+    private function buildProgressLocaleCompareRows(Collection $rows): array
+    {
+        return $rows
+            ->groupBy('locale')
+            ->map(function (Collection $group, string $locale): array {
+                $questionRows = $this->progressQuestionSummaries($group);
+
+                return [
+                    'locale' => $locale,
+                    'reached_attempts_count' => $this->firstQuestionMetric($questionRows, 'reached_attempts_count'),
+                    'answered_attempts_count' => $this->firstQuestionMetric($questionRows, 'answered_attempts_count'),
+                    'completed_attempts_count' => $this->firstQuestionMetric($questionRows, 'completed_attempts_count'),
+                    'dropoff_attempts_count' => (int) $questionRows->sum('dropoff_attempts_count'),
+                    'dropoff_rate' => $this->firstQuestionMetric($questionRows, 'reached_attempts_count') > 0
+                        ? ((int) $questionRows->sum('dropoff_attempts_count')) / $this->firstQuestionMetric($questionRows, 'reached_attempts_count')
+                        : null,
+                    'completion_rate' => $this->firstQuestionMetric($questionRows, 'reached_attempts_count') > 0
+                        ? $this->firstQuestionMetric($questionRows, 'completed_attempts_count') / $this->firstQuestionMetric($questionRows, 'reached_attempts_count')
+                        : null,
+                ];
+            })
+            ->sortByDesc('reached_attempts_count')
+            ->values()
+            ->all();
+    }
+
+    /**
+     * @return list<array<string,mixed>>
+     */
+    private function buildProgressVersionCompareRows(Collection $rows): array
+    {
+        return $rows
+            ->groupBy(static fn ($row): string => implode('|', [
+                (string) $row->content_package_version,
+                (string) $row->scoring_spec_version,
+                (string) $row->norm_version,
+            ]))
+            ->map(function (Collection $group, string $key): array {
+                [$contentVersion, $scoringVersion, $normVersion] = explode('|', $key);
+                $questionRows = $this->progressQuestionSummaries($group);
+                $reached = $this->firstQuestionMetric($questionRows, 'reached_attempts_count');
+                $completed = $this->firstQuestionMetric($questionRows, 'completed_attempts_count');
+                $dropoff = (int) $questionRows->sum('dropoff_attempts_count');
+
+                return [
+                    'content_package_version' => $contentVersion,
+                    'scoring_spec_version' => $scoringVersion,
+                    'norm_version' => $normVersion,
+                    'reached_attempts_count' => $reached,
+                    'answered_attempts_count' => $this->firstQuestionMetric($questionRows, 'answered_attempts_count'),
+                    'completed_attempts_count' => $completed,
+                    'dropoff_attempts_count' => $dropoff,
+                    'dropoff_rate' => $reached > 0 ? $dropoff / $reached : null,
+                    'completion_rate' => $reached > 0 ? $completed / $reached : null,
+                ];
+            })
+            ->sortByDesc('reached_attempts_count')
+            ->values()
+            ->all();
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function buildScopeNotes(): array
+    {
+        $notes = [
+            'Current authoritative scope is fixed to BIG5_OCEAN only. MBTI, EQ_60, IQ_RAVEN, SDS_20, and CLINICAL_COMBO_68 stay out of this first-phase authority page.',
+            'Question order is reconstructed from the BIG5 content pack. Frontend question_index is not treated as the sole source of truth.',
+            'Option Distribution uses attempt_answer_rows + attempt context only. events and attempt_answer_sets do not act as the main fact axis here.',
+            'Dropoff / Completion uses attempts + attempt_drafts + attempt_answer_rows. Duration is intentionally deferred and is not a first-phase authority metric.',
+            'Mixed version pools and tiny locale slices should be read cautiously. The page keeps content, scoring, and norm versions visible instead of silently pooling them.',
+        ];
+
+        if ($this->onlyCompletedAttempts) {
+            $notes[] = 'Completed-only mode is enabled. In Dropoff / Completion this collapses dropoff behavior by definition and should be read as a completion-only cut.';
+        }
+
+        return $notes;
+    }
+
+    /**
+     * @return array<string,string>
+     */
+    private function buildQuestionIdOptions(): array
+    {
+        $definition = app(QuestionAnalyticsSupport::class)->big5Definition();
+        $questions = is_array($definition['questions'] ?? null) ? $definition['questions'] : [];
+
+        $options = [];
+        foreach ($questions as $questionId => $question) {
+            if (! is_array($question)) {
+                continue;
+            }
+
+            $order = (int) ($question['question_order'] ?? 0);
+            $label = trim((string) (($question['text_en'] ?? '') ?: ($question['text_zh'] ?? '')));
+            $options[(string) $questionId] = sprintf('#%d · %s · %s', $order, (string) $questionId, $label !== '' ? $label : (string) $questionId);
+        }
+
+        return $options;
+    }
+
+    /**
+     * @return list<array<string,string>>
+     */
+    private function buildDrillLinks(): array
+    {
+        $locale = $this->locale !== 'all' ? $this->locale : 'en';
+        $frontendUrls = app(QuestionAnalyticsSupport::class)->frontendUrls($locale);
+
+        $links = [];
+        if ($frontendUrls['detail'] !== null) {
+            $links[] = [
+                'label' => 'Frontend test detail',
+                'url' => (string) $frontendUrls['detail'],
+            ];
+        }
+        if ($frontendUrls['take'] !== null) {
+            $links[] = [
+                'label' => 'Frontend take page',
+                'url' => (string) $frontendUrls['take'],
+            ];
+        }
+
+        $links[] = [
+            'label' => 'Attempts Explorer',
+            'url' => app(QuestionAnalyticsSupport::class)->attemptExplorerUrl($this->questionId !== 'all' ? $this->questionId : null),
+        ];
+
+        return $links;
+    }
+
+    private function enforceScope(): void
+    {
+        $this->scaleCode = $this->canonicalScale['scale_code'];
+        $this->excludeNonAuthoritativeScales = true;
+        if ($this->activeTab === '') {
+            $this->activeTab = 'option-distribution';
+        }
+    }
+
+    private function resetPanels(): void
+    {
+        $this->optionKpis = [];
+        $this->progressKpis = [];
+        $this->optionDistributionRows = [];
+        $this->optionRankingRows = [];
+        $this->optionLocaleCompareRows = [];
+        $this->optionVersionCompareRows = [];
+        $this->progressRows = [];
+        $this->highestDropoffRows = [];
+        $this->lowestCompletionRows = [];
+        $this->progressLocaleCompareRows = [];
+        $this->progressVersionCompareRows = [];
+    }
+}

--- a/backend/app/Models/AnalyticsQuestionOptionDaily.php
+++ b/backend/app/Models/AnalyticsQuestionOptionDaily.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Models;
+
+use App\Models\Concerns\HasOrgScope;
+use Illuminate\Database\Eloquent\Model;
+
+class AnalyticsQuestionOptionDaily extends Model
+{
+    use HasOrgScope;
+
+    protected $table = 'analytics_question_option_daily';
+
+    protected $fillable = [
+        'day',
+        'org_id',
+        'locale',
+        'region',
+        'scale_code',
+        'content_package_version',
+        'scoring_spec_version',
+        'norm_version',
+        'question_id',
+        'question_order',
+        'option_key',
+        'answered_rows_count',
+        'distinct_attempts_answered',
+        'last_refreshed_at',
+    ];
+
+    protected $casts = [
+        'day' => 'date',
+        'org_id' => 'integer',
+        'question_order' => 'integer',
+        'answered_rows_count' => 'integer',
+        'distinct_attempts_answered' => 'integer',
+        'last_refreshed_at' => 'datetime',
+        'created_at' => 'datetime',
+        'updated_at' => 'datetime',
+    ];
+
+    public static function allowOrgZeroContext(): bool
+    {
+        return self::allowOrgZeroWithResolvedContext();
+    }
+}

--- a/backend/app/Models/AnalyticsQuestionProgressDaily.php
+++ b/backend/app/Models/AnalyticsQuestionProgressDaily.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Models;
+
+use App\Models\Concerns\HasOrgScope;
+use Illuminate\Database\Eloquent\Model;
+
+class AnalyticsQuestionProgressDaily extends Model
+{
+    use HasOrgScope;
+
+    protected $table = 'analytics_question_progress_daily';
+
+    protected $fillable = [
+        'day',
+        'org_id',
+        'locale',
+        'region',
+        'scale_code',
+        'content_package_version',
+        'scoring_spec_version',
+        'norm_version',
+        'question_id',
+        'question_order',
+        'reached_attempts_count',
+        'answered_attempts_count',
+        'completed_attempts_count',
+        'dropoff_attempts_count',
+        'last_refreshed_at',
+    ];
+
+    protected $casts = [
+        'day' => 'date',
+        'org_id' => 'integer',
+        'question_order' => 'integer',
+        'reached_attempts_count' => 'integer',
+        'answered_attempts_count' => 'integer',
+        'completed_attempts_count' => 'integer',
+        'dropoff_attempts_count' => 'integer',
+        'last_refreshed_at' => 'datetime',
+        'created_at' => 'datetime',
+        'updated_at' => 'datetime',
+    ];
+
+    public static function allowOrgZeroContext(): bool
+    {
+        return self::allowOrgZeroWithResolvedContext();
+    }
+}

--- a/backend/app/Services/Analytics/QuestionAnalyticsDailyBuilder.php
+++ b/backend/app/Services/Analytics/QuestionAnalyticsDailyBuilder.php
@@ -1,0 +1,917 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\Analytics;
+
+use App\Support\SchemaBaseline;
+use Carbon\CarbonImmutable;
+use Illuminate\Database\Query\Builder as QueryBuilder;
+use Illuminate\Support\Collection;
+use Illuminate\Support\Facades\DB;
+
+final class QuestionAnalyticsDailyBuilder
+{
+    public function __construct(
+        private readonly QuestionAnalyticsSupport $support,
+    ) {}
+
+    /**
+     * @param  list<int>  $orgIds
+     * @param  list<string>  $scaleCodes
+     * @param  list<string>  $locales
+     * @return array{
+     *     option_rows:list<array<string,mixed>>,
+     *     progress_rows:list<array<string,mixed>>,
+     *     attempted_option_rows:int,
+     *     attempted_progress_rows:int,
+     *     source_answer_rows:int,
+     *     source_attempts:int,
+     *     authoritative_scales:list<string>,
+     *     requested_scales:list<string>,
+     *     ignored_requested_scales:list<string>,
+     *     org_scope:list<int>,
+     *     locale_scope:list<string>,
+     *     from:string,
+     *     to:string
+     * }
+     */
+    public function build(
+        \DateTimeInterface $from,
+        \DateTimeInterface $to,
+        array $orgIds = [],
+        array $scaleCodes = [],
+        array $locales = [],
+    ): array {
+        $fromAt = CarbonImmutable::parse($from)->startOfDay();
+        $toAt = CarbonImmutable::parse($to)->endOfDay();
+        $normalizedOrgIds = $this->normalizeOrgIds($orgIds);
+        $normalizedScaleCodes = $this->normalizeScaleCodes($scaleCodes);
+        $normalizedLocales = $this->normalizeLocales($locales);
+        $scaleConfigs = $this->support->authoritativeScaleConfigs($normalizedScaleCodes);
+        $effectiveScaleCodes = array_keys($scaleConfigs);
+        $ignoredRequestedScales = array_values(array_diff($normalizedScaleCodes, $effectiveScaleCodes));
+
+        if (
+            ! SchemaBaseline::hasTable('attempts')
+            || ! SchemaBaseline::hasTable('attempt_answer_rows')
+        ) {
+            return [
+                'option_rows' => [],
+                'progress_rows' => [],
+                'attempted_option_rows' => 0,
+                'attempted_progress_rows' => 0,
+                'source_answer_rows' => 0,
+                'source_attempts' => 0,
+                'authoritative_scales' => $effectiveScaleCodes,
+                'requested_scales' => $normalizedScaleCodes,
+                'ignored_requested_scales' => $ignoredRequestedScales,
+                'org_scope' => $normalizedOrgIds,
+                'locale_scope' => $normalizedLocales,
+                'from' => $fromAt->toDateString(),
+                'to' => $toAt->toDateString(),
+            ];
+        }
+
+        if ($effectiveScaleCodes === []) {
+            return [
+                'option_rows' => [],
+                'progress_rows' => [],
+                'attempted_option_rows' => 0,
+                'attempted_progress_rows' => 0,
+                'source_answer_rows' => 0,
+                'source_attempts' => 0,
+                'authoritative_scales' => [],
+                'requested_scales' => $normalizedScaleCodes,
+                'ignored_requested_scales' => $ignoredRequestedScales,
+                'org_scope' => $normalizedOrgIds,
+                'locale_scope' => $normalizedLocales,
+                'from' => $fromAt->toDateString(),
+                'to' => $toAt->toDateString(),
+            ];
+        }
+
+        $optionPayload = $this->buildOptionRows($fromAt, $toAt, $normalizedOrgIds, $normalizedLocales, $scaleConfigs);
+        $progressPayload = $this->buildProgressRows($fromAt, $toAt, $normalizedOrgIds, $normalizedLocales, $scaleConfigs);
+
+        return [
+            'option_rows' => $optionPayload['rows'],
+            'progress_rows' => $progressPayload['rows'],
+            'attempted_option_rows' => count($optionPayload['rows']),
+            'attempted_progress_rows' => count($progressPayload['rows']),
+            'source_answer_rows' => $optionPayload['source_answer_rows'],
+            'source_attempts' => $progressPayload['source_attempts'],
+            'authoritative_scales' => $effectiveScaleCodes,
+            'requested_scales' => $normalizedScaleCodes,
+            'ignored_requested_scales' => $ignoredRequestedScales,
+            'org_scope' => $normalizedOrgIds,
+            'locale_scope' => $normalizedLocales,
+            'from' => $fromAt->toDateString(),
+            'to' => $toAt->toDateString(),
+        ];
+    }
+
+    /**
+     * @param  list<int>  $orgIds
+     * @param  list<string>  $scaleCodes
+     * @param  list<string>  $locales
+     * @return array<string,mixed>
+     */
+    public function refresh(
+        \DateTimeInterface $from,
+        \DateTimeInterface $to,
+        array $orgIds = [],
+        array $scaleCodes = [],
+        array $locales = [],
+        bool $dryRun = false,
+    ): array {
+        $payload = $this->build($from, $to, $orgIds, $scaleCodes, $locales);
+        $deletedOptionRows = 0;
+        $deletedProgressRows = 0;
+        $upsertedOptionRows = 0;
+        $upsertedProgressRows = 0;
+
+        if (! $dryRun && SchemaBaseline::hasTable('analytics_question_option_daily') && SchemaBaseline::hasTable('analytics_question_progress_daily')) {
+            DB::transaction(function () use (
+                $payload,
+                &$deletedOptionRows,
+                &$deletedProgressRows,
+                &$upsertedOptionRows,
+                &$upsertedProgressRows
+            ): void {
+                $deletedOptionRows = $this->deleteScope(
+                    'analytics_question_option_daily',
+                    $payload['from'],
+                    $payload['to'],
+                    $payload['org_scope'],
+                    $payload['locale_scope'],
+                    $payload['authoritative_scales']
+                );
+                $deletedProgressRows = $this->deleteScope(
+                    'analytics_question_progress_daily',
+                    $payload['from'],
+                    $payload['to'],
+                    $payload['org_scope'],
+                    $payload['locale_scope'],
+                    $payload['authoritative_scales']
+                );
+
+                if ($payload['option_rows'] !== []) {
+                    DB::table('analytics_question_option_daily')->upsert(
+                        $payload['option_rows'],
+                        [
+                            'day',
+                            'org_id',
+                            'locale',
+                            'region',
+                            'scale_code',
+                            'content_package_version',
+                            'scoring_spec_version',
+                            'norm_version',
+                            'question_id',
+                            'option_key',
+                        ],
+                        [
+                            'question_order',
+                            'answered_rows_count',
+                            'distinct_attempts_answered',
+                            'last_refreshed_at',
+                            'updated_at',
+                        ]
+                    );
+                    $upsertedOptionRows = count($payload['option_rows']);
+                }
+
+                if ($payload['progress_rows'] !== []) {
+                    DB::table('analytics_question_progress_daily')->upsert(
+                        $payload['progress_rows'],
+                        [
+                            'day',
+                            'org_id',
+                            'locale',
+                            'region',
+                            'scale_code',
+                            'content_package_version',
+                            'scoring_spec_version',
+                            'norm_version',
+                            'question_id',
+                        ],
+                        [
+                            'question_order',
+                            'reached_attempts_count',
+                            'answered_attempts_count',
+                            'completed_attempts_count',
+                            'dropoff_attempts_count',
+                            'last_refreshed_at',
+                            'updated_at',
+                        ]
+                    );
+                    $upsertedProgressRows = count($payload['progress_rows']);
+                }
+            });
+        }
+
+        return $payload + [
+            'deleted_option_rows' => $deletedOptionRows,
+            'deleted_progress_rows' => $deletedProgressRows,
+            'upserted_option_rows' => $upsertedOptionRows,
+            'upserted_progress_rows' => $upsertedProgressRows,
+            'dry_run' => $dryRun,
+        ];
+    }
+
+    /**
+     * @param  list<int>  $orgIds
+     * @param  list<string>  $locales
+     * @param  array<string,array<string,mixed>>  $scaleConfigs
+     * @return array{rows:list<array<string,mixed>>,source_answer_rows:int}
+     */
+    private function buildOptionRows(
+        CarbonImmutable $fromAt,
+        CarbonImmutable $toAt,
+        array $orgIds,
+        array $locales,
+        array $scaleConfigs,
+    ): array {
+        $aggregates = [];
+        $attemptIdsByKey = [];
+        $sourceAnswerRows = 0;
+        $now = now();
+
+        foreach ($this->authoritativeAnswerRowCursor($fromAt, $toAt, $orgIds, $locales) as $row) {
+            $scaleCode = $this->support->resolveAuthoritativeScaleCode(
+                (string) ($row->attempt_scale_code ?? $row->row_scale_code ?? ''),
+                (string) ($row->attempt_scale_code_v2 ?? $row->row_scale_code_v2 ?? ''),
+                (string) ($row->attempt_scale_uid ?? $row->row_scale_uid ?? '')
+            );
+
+            if ($scaleCode === null || ! isset($scaleConfigs[$scaleCode])) {
+                continue;
+            }
+
+            $questionId = trim((string) ($row->question_id ?? ''));
+            if ($questionId === '') {
+                continue;
+            }
+
+            $questionDefinition = $scaleConfigs[$scaleCode]['question_definition'] ?? [];
+            $questionOrder = (int) ($questionDefinition['order_by_question_id'][$questionId] ?? 0);
+            if ($questionOrder <= 0) {
+                continue;
+            }
+
+            $optionKey = $this->extractOptionKey($row->answer_json ?? null);
+            if ($optionKey === null || $optionKey === '') {
+                continue;
+            }
+
+            $sourceAnswerRows++;
+            $day = $this->resolveDateString(
+                $row->row_submitted_at ?? null,
+                $row->attempt_submitted_at ?? null,
+                $row->attempt_created_at ?? null
+            );
+            $dimensions = $this->dimensionPayload($row, $day, $scaleCode);
+            $aggregateKey = $this->optionAggregateKey($dimensions, $questionId, $questionOrder, $optionKey);
+
+            if (! isset($aggregates[$aggregateKey])) {
+                $aggregates[$aggregateKey] = [
+                    'day' => $dimensions['day'],
+                    'org_id' => $dimensions['org_id'],
+                    'locale' => $dimensions['locale'],
+                    'region' => $dimensions['region'],
+                    'scale_code' => $dimensions['scale_code'],
+                    'content_package_version' => $dimensions['content_package_version'],
+                    'scoring_spec_version' => $dimensions['scoring_spec_version'],
+                    'norm_version' => $dimensions['norm_version'],
+                    'question_id' => $questionId,
+                    'question_order' => $questionOrder,
+                    'option_key' => $optionKey,
+                    'answered_rows_count' => 0,
+                    'distinct_attempts_answered' => 0,
+                    'last_refreshed_at' => $now,
+                    'created_at' => $now,
+                    'updated_at' => $now,
+                ];
+                $attemptIdsByKey[$aggregateKey] = [];
+            }
+
+            $aggregates[$aggregateKey]['answered_rows_count']++;
+            $attemptId = trim((string) ($row->attempt_id ?? ''));
+            if ($attemptId !== '') {
+                $attemptIdsByKey[$aggregateKey][$attemptId] = true;
+            }
+        }
+
+        foreach ($aggregates as $aggregateKey => &$payload) {
+            $payload['distinct_attempts_answered'] = count($attemptIdsByKey[$aggregateKey] ?? []);
+        }
+        unset($payload);
+
+        return [
+            'rows' => array_values($aggregates),
+            'source_answer_rows' => $sourceAnswerRows,
+        ];
+    }
+
+    /**
+     * @param  list<int>  $orgIds
+     * @param  list<string>  $locales
+     * @param  array<string,array<string,mixed>>  $scaleConfigs
+     * @return array{rows:list<array<string,mixed>>,source_attempts:int}
+     */
+    private function buildProgressRows(
+        CarbonImmutable $fromAt,
+        CarbonImmutable $toAt,
+        array $orgIds,
+        array $locales,
+        array $scaleConfigs,
+    ): array {
+        if (! SchemaBaseline::hasTable('attempts')) {
+            return ['rows' => [], 'source_attempts' => 0];
+        }
+
+        $attempts = $this->candidateAttemptCollection($fromAt, $toAt, $orgIds, $locales);
+        if ($attempts->isEmpty()) {
+            return ['rows' => [], 'source_attempts' => 0];
+        }
+
+        $candidateAttempts = $attempts
+            ->map(function (object $row) use ($scaleConfigs): ?object {
+                $scaleCode = $this->support->resolveAuthoritativeScaleCode(
+                    (string) ($row->attempt_scale_code ?? ''),
+                    (string) ($row->attempt_scale_code_v2 ?? ''),
+                    (string) ($row->attempt_scale_uid ?? '')
+                );
+
+                if ($scaleCode === null || ! isset($scaleConfigs[$scaleCode])) {
+                    return null;
+                }
+
+                $row->authoritative_scale_code = $scaleCode;
+
+                return $row;
+            })
+            ->filter()
+            ->values();
+
+        if ($candidateAttempts->isEmpty()) {
+            return ['rows' => [], 'source_attempts' => 0];
+        }
+
+        $rowsByAttemptId = $this->loadAnswerRowsByAttemptId(
+            $candidateAttempts->pluck('attempt_id')->map(static fn (mixed $value): string => (string) $value)->all()
+        );
+
+        $aggregates = [];
+        $now = now();
+
+        foreach ($candidateAttempts as $attempt) {
+            $scaleCode = (string) ($attempt->authoritative_scale_code ?? '');
+            $questionDefinition = $scaleConfigs[$scaleCode]['question_definition'] ?? null;
+            if (! is_array($questionDefinition)) {
+                continue;
+            }
+
+            $questionOrders = is_array($questionDefinition['order_by_question_id'] ?? null)
+                ? $questionDefinition['order_by_question_id']
+                : [];
+            $questionIdsByOrder = is_array($questionDefinition['question_ids_by_order'] ?? null)
+                ? $questionDefinition['question_ids_by_order']
+                : [];
+            $totalQuestions = max(0, (int) ($questionDefinition['total_questions'] ?? count($questionIdsByOrder)));
+            if ($totalQuestions <= 0 || $questionOrders === [] || $questionIdsByOrder === []) {
+                continue;
+            }
+
+            $attemptId = trim((string) ($attempt->attempt_id ?? ''));
+            if ($attemptId === '') {
+                continue;
+            }
+
+            $answeredOrderMap = [];
+            foreach ($rowsByAttemptId[$attemptId] ?? [] as $questionId) {
+                $questionOrder = (int) ($questionOrders[(string) $questionId] ?? 0);
+                if ($questionOrder > 0) {
+                    $answeredOrderMap[$questionOrder] = (string) $questionId;
+                }
+            }
+
+            foreach ($this->extractDraftQuestionIds($attempt->draft_answers_json ?? null) as $questionId) {
+                $questionOrder = (int) ($questionOrders[$questionId] ?? 0);
+                if ($questionOrder > 0) {
+                    $answeredOrderMap[$questionOrder] = $questionId;
+                }
+            }
+
+            ksort($answeredOrderMap);
+            $maxAnsweredOrder = $answeredOrderMap === [] ? 0 : max(array_keys($answeredOrderMap));
+            $cursorOrder = $this->cursorToQuestionOrder(
+                (string) ($attempt->draft_cursor ?? ''),
+                $questionOrders,
+                $totalQuestions
+            );
+            $isCompleted = $attempt->attempt_submitted_at !== null;
+
+            if ($isCompleted) {
+                if ($answeredOrderMap === []) {
+                    continue;
+                }
+
+                $reachedMax = $totalQuestions;
+            } else {
+                $reachedMax = max($maxAnsweredOrder, $cursorOrder);
+                if ($reachedMax <= 0) {
+                    continue;
+                }
+            }
+
+            $day = $this->resolveDateString(
+                $attempt->attempt_submitted_at ?? null,
+                $attempt->draft_updated_at ?? null,
+                $attempt->attempt_updated_at ?? null,
+                $attempt->attempt_created_at ?? null
+            );
+            $dimensions = $this->dimensionPayload($attempt, $day, $scaleCode);
+
+            for ($order = 1; $order <= $reachedMax; $order++) {
+                $questionId = $questionIdsByOrder[$order] ?? null;
+                if (! is_string($questionId) || $questionId === '') {
+                    continue;
+                }
+
+                $aggregateKey = $this->progressAggregateKey($dimensions, $questionId, $order);
+                if (! isset($aggregates[$aggregateKey])) {
+                    $aggregates[$aggregateKey] = [
+                        'day' => $dimensions['day'],
+                        'org_id' => $dimensions['org_id'],
+                        'locale' => $dimensions['locale'],
+                        'region' => $dimensions['region'],
+                        'scale_code' => $dimensions['scale_code'],
+                        'content_package_version' => $dimensions['content_package_version'],
+                        'scoring_spec_version' => $dimensions['scoring_spec_version'],
+                        'norm_version' => $dimensions['norm_version'],
+                        'question_id' => $questionId,
+                        'question_order' => $order,
+                        'reached_attempts_count' => 0,
+                        'answered_attempts_count' => 0,
+                        'completed_attempts_count' => 0,
+                        'dropoff_attempts_count' => 0,
+                        'last_refreshed_at' => $now,
+                        'created_at' => $now,
+                        'updated_at' => $now,
+                    ];
+                }
+
+                $aggregates[$aggregateKey]['reached_attempts_count']++;
+                if ($isCompleted) {
+                    $aggregates[$aggregateKey]['completed_attempts_count']++;
+                }
+            }
+
+            foreach ($answeredOrderMap as $questionOrder => $questionId) {
+                $aggregateKey = $this->progressAggregateKey($dimensions, $questionId, (int) $questionOrder);
+                if (! isset($aggregates[$aggregateKey])) {
+                    $aggregates[$aggregateKey] = [
+                        'day' => $dimensions['day'],
+                        'org_id' => $dimensions['org_id'],
+                        'locale' => $dimensions['locale'],
+                        'region' => $dimensions['region'],
+                        'scale_code' => $dimensions['scale_code'],
+                        'content_package_version' => $dimensions['content_package_version'],
+                        'scoring_spec_version' => $dimensions['scoring_spec_version'],
+                        'norm_version' => $dimensions['norm_version'],
+                        'question_id' => $questionId,
+                        'question_order' => (int) $questionOrder,
+                        'reached_attempts_count' => 0,
+                        'answered_attempts_count' => 0,
+                        'completed_attempts_count' => 0,
+                        'dropoff_attempts_count' => 0,
+                        'last_refreshed_at' => $now,
+                        'created_at' => $now,
+                        'updated_at' => $now,
+                    ];
+                }
+
+                $aggregates[$aggregateKey]['answered_attempts_count']++;
+            }
+
+            if (! $isCompleted) {
+                $dropoffOrder = min($reachedMax, $totalQuestions);
+                $dropoffQuestionId = $questionIdsByOrder[$dropoffOrder] ?? null;
+                if (is_string($dropoffQuestionId) && $dropoffQuestionId !== '') {
+                    $aggregateKey = $this->progressAggregateKey($dimensions, $dropoffQuestionId, $dropoffOrder);
+                    if (! isset($aggregates[$aggregateKey])) {
+                        $aggregates[$aggregateKey] = [
+                            'day' => $dimensions['day'],
+                            'org_id' => $dimensions['org_id'],
+                            'locale' => $dimensions['locale'],
+                            'region' => $dimensions['region'],
+                            'scale_code' => $dimensions['scale_code'],
+                            'content_package_version' => $dimensions['content_package_version'],
+                            'scoring_spec_version' => $dimensions['scoring_spec_version'],
+                            'norm_version' => $dimensions['norm_version'],
+                            'question_id' => $dropoffQuestionId,
+                            'question_order' => $dropoffOrder,
+                            'reached_attempts_count' => 0,
+                            'answered_attempts_count' => 0,
+                            'completed_attempts_count' => 0,
+                            'dropoff_attempts_count' => 0,
+                            'last_refreshed_at' => $now,
+                            'created_at' => $now,
+                            'updated_at' => $now,
+                        ];
+                    }
+
+                    $aggregates[$aggregateKey]['dropoff_attempts_count']++;
+                }
+            }
+        }
+
+        return [
+            'rows' => array_values($aggregates),
+            'source_attempts' => $candidateAttempts->count(),
+        ];
+    }
+
+    /**
+     * @param  list<int>  $orgIds
+     * @param  list<string>  $locales
+     */
+    private function authoritativeAnswerRowCursor(
+        CarbonImmutable $fromAt,
+        CarbonImmutable $toAt,
+        array $orgIds,
+        array $locales,
+    ): \Traversable {
+        $query = DB::table('attempt_answer_rows as rows')
+            ->join('attempts as attempts', 'attempts.id', '=', 'rows.attempt_id')
+            ->select([
+                'rows.attempt_id',
+                'rows.question_id',
+                'rows.answer_json',
+                'rows.scale_code as row_scale_code',
+                'rows.scale_code_v2 as row_scale_code_v2',
+                'rows.scale_uid as row_scale_uid',
+                'rows.submitted_at as row_submitted_at',
+                'attempts.org_id',
+                'attempts.scale_code as attempt_scale_code',
+                'attempts.scale_code_v2 as attempt_scale_code_v2',
+                'attempts.scale_uid as attempt_scale_uid',
+                'attempts.locale',
+                'attempts.region',
+                'attempts.content_package_version',
+                'attempts.scoring_spec_version',
+                'attempts.norm_version',
+                'attempts.submitted_at as attempt_submitted_at',
+                'attempts.created_at as attempt_created_at',
+            ])
+            ->whereBetween(DB::raw('coalesce(rows.submitted_at, attempts.submitted_at, attempts.created_at)'), [$fromAt, $toAt]);
+
+        if ($orgIds !== []) {
+            $query->whereIn('attempts.org_id', $orgIds);
+        }
+        if ($locales !== []) {
+            $query->whereIn('attempts.locale', $locales);
+        }
+
+        return $query
+            ->orderBy('rows.attempt_id')
+            ->orderBy('rows.question_id')
+            ->cursor();
+    }
+
+    /**
+     * @param  list<int>  $orgIds
+     * @param  list<string>  $locales
+     * @return Collection<int,object>
+     */
+    private function candidateAttemptCollection(
+        CarbonImmutable $fromAt,
+        CarbonImmutable $toAt,
+        array $orgIds,
+        array $locales,
+    ): Collection {
+        $query = DB::table('attempts as attempts')
+            ->leftJoin('attempt_drafts as drafts', 'drafts.attempt_id', '=', 'attempts.id')
+            ->select([
+                'attempts.id as attempt_id',
+                'attempts.org_id',
+                'attempts.scale_code as attempt_scale_code',
+                'attempts.scale_code_v2 as attempt_scale_code_v2',
+                'attempts.scale_uid as attempt_scale_uid',
+                'attempts.locale',
+                'attempts.region',
+                'attempts.content_package_version',
+                'attempts.scoring_spec_version',
+                'attempts.norm_version',
+                'attempts.submitted_at as attempt_submitted_at',
+                'attempts.created_at as attempt_created_at',
+                'attempts.updated_at as attempt_updated_at',
+                'drafts.cursor as draft_cursor',
+                'drafts.answers_json as draft_answers_json',
+                'drafts.updated_at as draft_updated_at',
+            ])
+            ->whereBetween(DB::raw('coalesce(attempts.submitted_at, drafts.updated_at, attempts.updated_at, attempts.created_at)'), [$fromAt, $toAt]);
+
+        if ($orgIds !== []) {
+            $query->whereIn('attempts.org_id', $orgIds);
+        }
+        if ($locales !== []) {
+            $query->whereIn('attempts.locale', $locales);
+        }
+
+        return $query
+            ->orderBy('attempts.id')
+            ->get();
+    }
+
+    /**
+     * @param  list<string>  $attemptIds
+     * @return array<string,list<string>>
+     */
+    private function loadAnswerRowsByAttemptId(array $attemptIds): array
+    {
+        if ($attemptIds === [] || ! SchemaBaseline::hasTable('attempt_answer_rows')) {
+            return [];
+        }
+
+        $rowsByAttemptId = [];
+
+        foreach (array_chunk($attemptIds, 500) as $chunk) {
+            $rows = DB::table('attempt_answer_rows')
+                ->whereIn('attempt_id', $chunk)
+                ->get(['attempt_id', 'question_id']);
+
+            foreach ($rows as $row) {
+                $attemptId = trim((string) ($row->attempt_id ?? ''));
+                $questionId = trim((string) ($row->question_id ?? ''));
+
+                if ($attemptId === '' || $questionId === '') {
+                    continue;
+                }
+
+                $rowsByAttemptId[$attemptId] ??= [];
+                $rowsByAttemptId[$attemptId][$questionId] = $questionId;
+            }
+        }
+
+        foreach ($rowsByAttemptId as $attemptId => $questionIds) {
+            $rowsByAttemptId[$attemptId] = array_values($questionIds);
+        }
+
+        return $rowsByAttemptId;
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function extractDraftQuestionIds(mixed $rawAnswers): array
+    {
+        if (! is_string($rawAnswers) || trim($rawAnswers) === '') {
+            return [];
+        }
+
+        $decoded = json_decode($rawAnswers, true);
+        if (! is_array($decoded)) {
+            return [];
+        }
+
+        $questionIds = [];
+
+        foreach ($decoded as $answer) {
+            if (! is_array($answer)) {
+                continue;
+            }
+
+            $questionId = trim((string) ($answer['question_id'] ?? ''));
+            if ($questionId !== '') {
+                $questionIds[$questionId] = $questionId;
+            }
+        }
+
+        return array_values($questionIds);
+    }
+
+    /**
+     * @param  array<string,int>  $questionOrders
+     */
+    private function cursorToQuestionOrder(string $cursor, array $questionOrders, int $totalQuestions): int
+    {
+        $normalized = trim($cursor);
+        if ($normalized === '') {
+            return 0;
+        }
+
+        if (isset($questionOrders[$normalized])) {
+            return (int) $questionOrders[$normalized];
+        }
+
+        if (preg_match('/(\d+)/', $normalized, $matches) !== 1) {
+            return 0;
+        }
+
+        $candidate = (int) ($matches[1] ?? 0);
+        if ($candidate <= 0) {
+            return 0;
+        }
+
+        if (isset($questionOrders[(string) $candidate])) {
+            return (int) $questionOrders[(string) $candidate];
+        }
+
+        return min($candidate, $totalQuestions);
+    }
+
+    private function extractOptionKey(mixed $rawAnswerJson): ?string
+    {
+        if (! is_string($rawAnswerJson) || trim($rawAnswerJson) === '') {
+            return null;
+        }
+
+        $decoded = json_decode($rawAnswerJson, true);
+        if (! is_array($decoded)) {
+            return null;
+        }
+
+        foreach (['code', 'option_key', 'option_code', 'value'] as $key) {
+            $candidate = $decoded[$key] ?? null;
+            if (is_scalar($candidate)) {
+                $normalized = trim((string) $candidate);
+                if ($normalized !== '') {
+                    return $normalized;
+                }
+            }
+        }
+
+        $answer = $decoded['answer'] ?? null;
+        if (is_array($answer)) {
+            foreach (['code', 'value'] as $key) {
+                $candidate = $answer[$key] ?? null;
+                if (is_scalar($candidate)) {
+                    $normalized = trim((string) $candidate);
+                    if ($normalized !== '') {
+                        return $normalized;
+                    }
+                }
+            }
+        }
+
+        return null;
+    }
+
+    private function resolveDateString(mixed ...$values): string
+    {
+        foreach ($values as $value) {
+            if ($value === null || $value === '') {
+                continue;
+            }
+
+            return CarbonImmutable::parse($value)->toDateString();
+        }
+
+        return now()->toDateString();
+    }
+
+    /**
+     * @param  object  $row
+     * @return array{
+     *     day:string,
+     *     org_id:int,
+     *     locale:string,
+     *     region:string,
+     *     scale_code:string,
+     *     content_package_version:string,
+     *     scoring_spec_version:string,
+     *     norm_version:string
+     * }
+     */
+    private function dimensionPayload(object $row, string $day, string $scaleCode): array
+    {
+        return [
+            'day' => $day,
+            'org_id' => max(0, (int) ($row->org_id ?? 0)),
+            'locale' => $this->stringOrDefault($row->locale ?? null, 'unknown'),
+            'region' => $this->stringOrDefault($row->region ?? null, 'unknown'),
+            'scale_code' => $scaleCode,
+            'content_package_version' => $this->stringOrDefault($row->content_package_version ?? null, 'unknown'),
+            'scoring_spec_version' => $this->stringOrDefault($row->scoring_spec_version ?? null, 'unknown'),
+            'norm_version' => $this->stringOrDefault($row->norm_version ?? null, 'unknown'),
+        ];
+    }
+
+    /**
+     * @param  array<string,mixed>  $dimensions
+     */
+    private function optionAggregateKey(array $dimensions, string $questionId, int $questionOrder, string $optionKey): string
+    {
+        return implode('|', [
+            $dimensions['day'],
+            (string) $dimensions['org_id'],
+            $dimensions['locale'],
+            $dimensions['region'],
+            $dimensions['scale_code'],
+            $dimensions['content_package_version'],
+            $dimensions['scoring_spec_version'],
+            $dimensions['norm_version'],
+            $questionId,
+            (string) $questionOrder,
+            $optionKey,
+        ]);
+    }
+
+    /**
+     * @param  array<string,mixed>  $dimensions
+     */
+    private function progressAggregateKey(array $dimensions, string $questionId, int $questionOrder): string
+    {
+        return implode('|', [
+            $dimensions['day'],
+            (string) $dimensions['org_id'],
+            $dimensions['locale'],
+            $dimensions['region'],
+            $dimensions['scale_code'],
+            $dimensions['content_package_version'],
+            $dimensions['scoring_spec_version'],
+            $dimensions['norm_version'],
+            $questionId,
+            (string) $questionOrder,
+        ]);
+    }
+
+    /**
+     * @param  list<int>  $orgIds
+     * @param  list<string>  $locales
+     * @param  list<string>  $scaleCodes
+     */
+    private function deleteScope(
+        string $table,
+        string $from,
+        string $to,
+        array $orgIds,
+        array $locales,
+        array $scaleCodes,
+    ): int {
+        if (! SchemaBaseline::hasTable($table)) {
+            return 0;
+        }
+
+        $query = DB::table($table)
+            ->whereBetween('day', [$from, $to]);
+
+        if ($orgIds !== []) {
+            $query->whereIn('org_id', $orgIds);
+        }
+        if ($locales !== []) {
+            $query->whereIn('locale', $locales);
+        }
+        if ($scaleCodes !== []) {
+            $query->whereIn('scale_code', $scaleCodes);
+        }
+
+        return $query->delete();
+    }
+
+    /**
+     * @param  list<int>  $orgIds
+     * @return list<int>
+     */
+    private function normalizeOrgIds(array $orgIds): array
+    {
+        return array_values(array_unique(array_filter(array_map(
+            static fn (mixed $value): int => max(0, (int) $value),
+            $orgIds
+        ), static fn (int $value): bool => $value > 0)));
+    }
+
+    /**
+     * @param  list<string>  $scaleCodes
+     * @return list<string>
+     */
+    private function normalizeScaleCodes(array $scaleCodes): array
+    {
+        return array_values(array_unique(array_map(
+            static fn (string $value): string => strtoupper(trim($value)),
+            array_filter($scaleCodes, static fn (string $value): bool => trim($value) !== '')
+        )));
+    }
+
+    /**
+     * @param  list<string>  $locales
+     * @return list<string>
+     */
+    private function normalizeLocales(array $locales): array
+    {
+        return array_values(array_unique(array_map(
+            static fn (string $value): string => trim($value),
+            array_filter($locales, static fn (string $value): bool => trim($value) !== '')
+        )));
+    }
+
+    private function stringOrDefault(mixed $value, string $fallback): string
+    {
+        $normalized = trim((string) $value);
+
+        return $normalized !== '' ? $normalized : $fallback;
+    }
+}

--- a/backend/app/Services/Analytics/QuestionAnalyticsSupport.php
+++ b/backend/app/Services/Analytics/QuestionAnalyticsSupport.php
@@ -1,0 +1,261 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\Analytics;
+
+use App\Services\Content\BigFivePackLoader;
+use App\Services\Scale\ScaleIdentityResolver;
+
+final class QuestionAnalyticsSupport
+{
+    private const BIG5_FRONTEND_SLUG = 'big-five-personality-test-ocean-model';
+
+    /** @var array<string,mixed>|null */
+    private ?array $big5DefinitionCache = null;
+
+    public function __construct(
+        private readonly BigFivePackLoader $bigFivePackLoader,
+        private readonly ScaleIdentityResolver $scaleIdentityResolver,
+    ) {}
+
+    /**
+     * @return list<string>
+     */
+    public function enabledAuthoritativeScaleCodes(): array
+    {
+        return ['BIG5_OCEAN'];
+    }
+
+    /**
+     * @return array{
+     *     scale_code:string,
+     *     scale_code_v2:string,
+     *     scale_uid:?string
+     * }
+     */
+    public function canonicalScale(string $scaleCode = 'BIG5_OCEAN'): array
+    {
+        $resolved = $this->scaleIdentityResolver->resolveByAnyCode($scaleCode);
+
+        $legacy = strtoupper(trim((string) ($resolved['scale_code_v1'] ?? 'BIG5_OCEAN')));
+        $v2 = strtoupper(trim((string) ($resolved['scale_code_v2'] ?? (config('scale_identity.code_map_v1_to_v2.BIG5_OCEAN') ?? 'BIG_FIVE_OCEAN_MODEL'))));
+        $uid = trim((string) ($resolved['scale_uid'] ?? (config('scale_identity.scale_uid_map.BIG5_OCEAN') ?? '')));
+
+        return [
+            'scale_code' => $legacy !== '' ? $legacy : 'BIG5_OCEAN',
+            'scale_code_v2' => $v2 !== '' ? $v2 : 'BIG_FIVE_OCEAN_MODEL',
+            'scale_uid' => $uid !== '' ? $uid : null,
+        ];
+    }
+
+    /**
+     * @param  list<string>  $requestedScaleCodes
+     * @return array<string,array<string,mixed>>
+     */
+    public function authoritativeScaleConfigs(array $requestedScaleCodes = []): array
+    {
+        $requested = array_map(
+            static fn (string $value): string => strtoupper(trim($value)),
+            array_filter($requestedScaleCodes, static fn (string $value): bool => trim($value) !== '')
+        );
+        $requested = array_values(array_unique($requested));
+
+        $configs = [
+            'BIG5_OCEAN' => $this->big5Config(),
+        ];
+
+        if ($requested === []) {
+            return $configs;
+        }
+
+        return array_intersect_key($configs, array_flip($requested));
+    }
+
+    public function resolveAuthoritativeScaleCode(
+        ?string $scaleCode,
+        ?string $scaleCodeV2 = null,
+        ?string $scaleUid = null,
+    ): ?string {
+        $legacy = strtoupper(trim((string) $scaleCode));
+        $v2 = strtoupper(trim((string) $scaleCodeV2));
+        $uid = trim((string) $scaleUid);
+
+        $canonical = $this->canonicalScale();
+
+        if ($legacy === $canonical['scale_code'] || $v2 === $canonical['scale_code_v2']) {
+            return $canonical['scale_code'];
+        }
+
+        if ($uid !== '' && $canonical['scale_uid'] !== null && $uid === $canonical['scale_uid']) {
+            return $canonical['scale_code'];
+        }
+
+        return null;
+    }
+
+    public function frontendLocaleSegment(string $locale): string
+    {
+        return str_starts_with(strtolower(trim($locale)), 'zh') ? 'zh' : 'en';
+    }
+
+    /**
+     * @return array{detail:?string,take:?string}
+     */
+    public function frontendUrls(string $locale): array
+    {
+        $base = rtrim((string) config('app.frontend_url', config('app.url', '')), '/');
+        if ($base === '') {
+            return [
+                'detail' => null,
+                'take' => null,
+            ];
+        }
+
+        $segment = $this->frontendLocaleSegment($locale);
+
+        return [
+            'detail' => $base.'/'.$segment.'/tests/'.self::BIG5_FRONTEND_SLUG,
+            'take' => $base.'/'.$segment.'/tests/'.self::BIG5_FRONTEND_SLUG.'/take',
+        ];
+    }
+
+    public function attemptExplorerUrl(?string $questionId = null): string
+    {
+        $url = '/ops/attempts?tableSearch=BIG5_OCEAN';
+
+        if ($questionId === null || trim($questionId) === '') {
+            return $url;
+        }
+
+        return $url.'%20'.rawurlencode(trim($questionId));
+    }
+
+    /**
+     * @return array{
+     *     order_by_question_id:array<string,int>,
+     *     question_ids_by_order:array<int,string>,
+     *     questions:array<string,array<string,mixed>>,
+     *     option_labels:array<string,array<string,string>>,
+     *     total_questions:int
+     * }
+     */
+    public function big5Definition(): array
+    {
+        if ($this->big5DefinitionCache !== null) {
+            return $this->big5DefinitionCache;
+        }
+
+        $questionsCompiled = $this->bigFivePackLoader->readCompiledJson('questions.compiled.json');
+        $compiledQuestions = is_array($questionsCompiled['questions'] ?? null)
+            ? array_values(array_filter(
+                $questionsCompiled['questions'],
+                static fn (mixed $row): bool => is_array($row)
+            ))
+            : [];
+
+        $orderByQuestionId = [];
+        $questionIdsByOrder = [];
+        $questions = [];
+
+        if ($compiledQuestions !== []) {
+            foreach ($compiledQuestions as $index => $question) {
+                $questionId = trim((string) ($question['question_id'] ?? ''));
+                if ($questionId === '') {
+                    continue;
+                }
+
+                $order = $index + 1;
+                $orderByQuestionId[$questionId] = $order;
+                $questionIdsByOrder[$order] = $questionId;
+                $questions[$questionId] = [
+                    'question_id' => $questionId,
+                    'question_order' => $order,
+                    'dimension' => strtoupper(trim((string) ($question['dimension'] ?? ''))),
+                    'facet_code' => strtoupper(trim((string) ($question['facet_code'] ?? ''))),
+                    'direction' => (int) ($question['direction'] ?? 0),
+                    'text_en' => trim((string) ($question['text_en'] ?? '')),
+                    'text_zh' => trim((string) ($question['text_zh'] ?? '')),
+                ];
+            }
+        }
+
+        if ($orderByQuestionId === []) {
+            $questionIndex = $this->bigFivePackLoader->readQuestionIndexPreferred() ?? [];
+            $order = 0;
+
+            foreach ($questionIndex as $questionId => $question) {
+                if (! is_array($question)) {
+                    continue;
+                }
+
+                $normalizedQuestionId = trim((string) $questionId);
+                if ($normalizedQuestionId === '') {
+                    continue;
+                }
+
+                $order++;
+                $orderByQuestionId[$normalizedQuestionId] = $order;
+                $questionIdsByOrder[$order] = $normalizedQuestionId;
+                $questions[$normalizedQuestionId] = [
+                    'question_id' => $normalizedQuestionId,
+                    'question_order' => $order,
+                    'dimension' => strtoupper(trim((string) ($question['dimension'] ?? ''))),
+                    'facet_code' => strtoupper(trim((string) ($question['facet_code'] ?? ''))),
+                    'direction' => (int) ($question['direction'] ?? 0),
+                    'text_en' => '',
+                    'text_zh' => '',
+                ];
+            }
+        }
+
+        $questionMinCompiled = $this->bigFivePackLoader->readCompiledJson('questions.min.compiled.json');
+        $optionSets = is_array($questionMinCompiled['option_sets'] ?? null)
+            ? $questionMinCompiled['option_sets']
+            : [];
+        $likertOptions = is_array($optionSets['LIKERT5'] ?? null) ? $optionSets['LIKERT5'] : [];
+        $optionLabels = [];
+
+        foreach ($likertOptions as $option) {
+            if (! is_array($option)) {
+                continue;
+            }
+
+            $code = trim((string) ($option['code'] ?? ''));
+            if ($code === '') {
+                continue;
+            }
+
+            $optionLabels[$code] = [
+                'label_en' => trim((string) ($option['label_en'] ?? $code)),
+                'label_zh' => trim((string) ($option['label_zh'] ?? $code)),
+            ];
+        }
+
+        $this->big5DefinitionCache = [
+            'order_by_question_id' => $orderByQuestionId,
+            'question_ids_by_order' => $questionIdsByOrder,
+            'questions' => $questions,
+            'option_labels' => $optionLabels,
+            'total_questions' => count($questionIdsByOrder),
+        ];
+
+        return $this->big5DefinitionCache;
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    private function big5Config(): array
+    {
+        $canonical = $this->canonicalScale('BIG5_OCEAN');
+        $definition = $this->big5Definition();
+
+        return $canonical + [
+            'label' => 'BIG5_OCEAN',
+            'frontend_slug' => self::BIG5_FRONTEND_SLUG,
+            'question_definition' => $definition,
+            'total_questions' => (int) ($definition['total_questions'] ?? 0),
+        ];
+    }
+}

--- a/backend/database/migrations/2026_03_14_150000_create_analytics_question_daily_tables.php
+++ b/backend/database/migrations/2026_03_14_150000_create_analytics_question_daily_tables.php
@@ -1,0 +1,262 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Support\Database\SchemaIndex;
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    private const OPTION_TABLE = 'analytics_question_option_daily';
+
+    private const PROGRESS_TABLE = 'analytics_question_progress_daily';
+
+    public function up(): void
+    {
+        $this->createOptionTable();
+        $this->createProgressTable();
+    }
+
+    public function down(): void
+    {
+        // forward-only migration: rollback disabled to prevent data loss in production.
+        // Irreversible operation: schema/data rollback handled via forward fix migrations.
+    }
+
+    private function createOptionTable(): void
+    {
+        if (! Schema::hasTable(self::OPTION_TABLE)) {
+            Schema::create(self::OPTION_TABLE, function (Blueprint $table): void {
+                $table->date('day');
+                $table->unsignedBigInteger('org_id')->default(0);
+                $table->string('locale', 16)->default('unknown');
+                $table->string('region', 32)->default('unknown');
+                $table->string('scale_code', 64)->default('BIG5_OCEAN');
+                $table->string('content_package_version', 128)->default('unknown');
+                $table->string('scoring_spec_version', 64)->default('unknown');
+                $table->string('norm_version', 64)->default('unknown');
+                $table->string('question_id', 128);
+                $table->unsignedInteger('question_order')->default(0);
+                $table->string('option_key', 64);
+                $table->unsignedInteger('answered_rows_count')->default(0);
+                $table->unsignedInteger('distinct_attempts_answered')->default(0);
+                $table->timestamp('last_refreshed_at')->nullable();
+                $table->timestamps();
+            });
+        } else {
+            Schema::table(self::OPTION_TABLE, function (Blueprint $table): void {
+                if (! Schema::hasColumn(self::OPTION_TABLE, 'day')) {
+                    $table->date('day')->nullable();
+                }
+                if (! Schema::hasColumn(self::OPTION_TABLE, 'org_id')) {
+                    $table->unsignedBigInteger('org_id')->default(0);
+                }
+                if (! Schema::hasColumn(self::OPTION_TABLE, 'locale')) {
+                    $table->string('locale', 16)->default('unknown');
+                }
+                if (! Schema::hasColumn(self::OPTION_TABLE, 'region')) {
+                    $table->string('region', 32)->default('unknown');
+                }
+                if (! Schema::hasColumn(self::OPTION_TABLE, 'scale_code')) {
+                    $table->string('scale_code', 64)->default('BIG5_OCEAN');
+                }
+                if (! Schema::hasColumn(self::OPTION_TABLE, 'content_package_version')) {
+                    $table->string('content_package_version', 128)->default('unknown');
+                }
+                if (! Schema::hasColumn(self::OPTION_TABLE, 'scoring_spec_version')) {
+                    $table->string('scoring_spec_version', 64)->default('unknown');
+                }
+                if (! Schema::hasColumn(self::OPTION_TABLE, 'norm_version')) {
+                    $table->string('norm_version', 64)->default('unknown');
+                }
+                if (! Schema::hasColumn(self::OPTION_TABLE, 'question_id')) {
+                    $table->string('question_id', 128)->nullable();
+                }
+                if (! Schema::hasColumn(self::OPTION_TABLE, 'question_order')) {
+                    $table->unsignedInteger('question_order')->default(0);
+                }
+                if (! Schema::hasColumn(self::OPTION_TABLE, 'option_key')) {
+                    $table->string('option_key', 64)->nullable();
+                }
+                if (! Schema::hasColumn(self::OPTION_TABLE, 'answered_rows_count')) {
+                    $table->unsignedInteger('answered_rows_count')->default(0);
+                }
+                if (! Schema::hasColumn(self::OPTION_TABLE, 'distinct_attempts_answered')) {
+                    $table->unsignedInteger('distinct_attempts_answered')->default(0);
+                }
+                if (! Schema::hasColumn(self::OPTION_TABLE, 'last_refreshed_at')) {
+                    $table->timestamp('last_refreshed_at')->nullable();
+                }
+                if (! Schema::hasColumn(self::OPTION_TABLE, 'created_at')) {
+                    $table->timestamp('created_at')->nullable();
+                }
+                if (! Schema::hasColumn(self::OPTION_TABLE, 'updated_at')) {
+                    $table->timestamp('updated_at')->nullable();
+                }
+            });
+        }
+
+        $this->ensureUnique(
+            self::OPTION_TABLE,
+            [
+                'day',
+                'org_id',
+                'locale',
+                'region',
+                'scale_code',
+                'content_package_version',
+                'scoring_spec_version',
+                'norm_version',
+                'question_id',
+                'option_key',
+            ],
+            'analytics_question_option_daily_scope_unique'
+        );
+        $this->ensureIndex(self::OPTION_TABLE, ['org_id', 'day'], 'analytics_question_option_daily_org_day_idx');
+        $this->ensureIndex(
+            self::OPTION_TABLE,
+            ['org_id', 'scale_code', 'day'],
+            'analytics_question_option_daily_org_scale_day_idx'
+        );
+        $this->ensureIndex(
+            self::OPTION_TABLE,
+            ['org_id', 'question_order', 'day'],
+            'analytics_question_option_daily_org_question_day_idx'
+        );
+    }
+
+    private function createProgressTable(): void
+    {
+        if (! Schema::hasTable(self::PROGRESS_TABLE)) {
+            Schema::create(self::PROGRESS_TABLE, function (Blueprint $table): void {
+                $table->date('day');
+                $table->unsignedBigInteger('org_id')->default(0);
+                $table->string('locale', 16)->default('unknown');
+                $table->string('region', 32)->default('unknown');
+                $table->string('scale_code', 64)->default('BIG5_OCEAN');
+                $table->string('content_package_version', 128)->default('unknown');
+                $table->string('scoring_spec_version', 64)->default('unknown');
+                $table->string('norm_version', 64)->default('unknown');
+                $table->string('question_id', 128);
+                $table->unsignedInteger('question_order')->default(0);
+                $table->unsignedInteger('reached_attempts_count')->default(0);
+                $table->unsignedInteger('answered_attempts_count')->default(0);
+                $table->unsignedInteger('completed_attempts_count')->default(0);
+                $table->unsignedInteger('dropoff_attempts_count')->default(0);
+                $table->timestamp('last_refreshed_at')->nullable();
+                $table->timestamps();
+            });
+        } else {
+            Schema::table(self::PROGRESS_TABLE, function (Blueprint $table): void {
+                if (! Schema::hasColumn(self::PROGRESS_TABLE, 'day')) {
+                    $table->date('day')->nullable();
+                }
+                if (! Schema::hasColumn(self::PROGRESS_TABLE, 'org_id')) {
+                    $table->unsignedBigInteger('org_id')->default(0);
+                }
+                if (! Schema::hasColumn(self::PROGRESS_TABLE, 'locale')) {
+                    $table->string('locale', 16)->default('unknown');
+                }
+                if (! Schema::hasColumn(self::PROGRESS_TABLE, 'region')) {
+                    $table->string('region', 32)->default('unknown');
+                }
+                if (! Schema::hasColumn(self::PROGRESS_TABLE, 'scale_code')) {
+                    $table->string('scale_code', 64)->default('BIG5_OCEAN');
+                }
+                if (! Schema::hasColumn(self::PROGRESS_TABLE, 'content_package_version')) {
+                    $table->string('content_package_version', 128)->default('unknown');
+                }
+                if (! Schema::hasColumn(self::PROGRESS_TABLE, 'scoring_spec_version')) {
+                    $table->string('scoring_spec_version', 64)->default('unknown');
+                }
+                if (! Schema::hasColumn(self::PROGRESS_TABLE, 'norm_version')) {
+                    $table->string('norm_version', 64)->default('unknown');
+                }
+                if (! Schema::hasColumn(self::PROGRESS_TABLE, 'question_id')) {
+                    $table->string('question_id', 128)->nullable();
+                }
+                if (! Schema::hasColumn(self::PROGRESS_TABLE, 'question_order')) {
+                    $table->unsignedInteger('question_order')->default(0);
+                }
+                if (! Schema::hasColumn(self::PROGRESS_TABLE, 'reached_attempts_count')) {
+                    $table->unsignedInteger('reached_attempts_count')->default(0);
+                }
+                if (! Schema::hasColumn(self::PROGRESS_TABLE, 'answered_attempts_count')) {
+                    $table->unsignedInteger('answered_attempts_count')->default(0);
+                }
+                if (! Schema::hasColumn(self::PROGRESS_TABLE, 'completed_attempts_count')) {
+                    $table->unsignedInteger('completed_attempts_count')->default(0);
+                }
+                if (! Schema::hasColumn(self::PROGRESS_TABLE, 'dropoff_attempts_count')) {
+                    $table->unsignedInteger('dropoff_attempts_count')->default(0);
+                }
+                if (! Schema::hasColumn(self::PROGRESS_TABLE, 'last_refreshed_at')) {
+                    $table->timestamp('last_refreshed_at')->nullable();
+                }
+                if (! Schema::hasColumn(self::PROGRESS_TABLE, 'created_at')) {
+                    $table->timestamp('created_at')->nullable();
+                }
+                if (! Schema::hasColumn(self::PROGRESS_TABLE, 'updated_at')) {
+                    $table->timestamp('updated_at')->nullable();
+                }
+            });
+        }
+
+        $this->ensureUnique(
+            self::PROGRESS_TABLE,
+            [
+                'day',
+                'org_id',
+                'locale',
+                'region',
+                'scale_code',
+                'content_package_version',
+                'scoring_spec_version',
+                'norm_version',
+                'question_id',
+            ],
+            'analytics_question_progress_daily_scope_unique'
+        );
+        $this->ensureIndex(self::PROGRESS_TABLE, ['org_id', 'day'], 'analytics_question_progress_daily_org_day_idx');
+        $this->ensureIndex(
+            self::PROGRESS_TABLE,
+            ['org_id', 'scale_code', 'day'],
+            'analytics_question_progress_daily_org_scale_day_idx'
+        );
+        $this->ensureIndex(
+            self::PROGRESS_TABLE,
+            ['org_id', 'question_order', 'day'],
+            'analytics_question_progress_daily_org_question_day_idx'
+        );
+    }
+
+    /**
+     * @param  array<int,string>  $columns
+     */
+    private function ensureUnique(string $tableName, array $columns, string $indexName): void
+    {
+        if (! Schema::hasTable($tableName) || SchemaIndex::indexExists($tableName, $indexName)) {
+            return;
+        }
+
+        Schema::table($tableName, function (Blueprint $table) use ($columns, $indexName): void {
+            $table->unique($columns, $indexName);
+        });
+    }
+
+    /**
+     * @param  array<int,string>  $columns
+     */
+    private function ensureIndex(string $tableName, array $columns, string $indexName): void
+    {
+        if (! Schema::hasTable($tableName) || SchemaIndex::indexExists($tableName, $indexName)) {
+            return;
+        }
+
+        Schema::table($tableName, function (Blueprint $table) use ($columns, $indexName): void {
+            $table->index($columns, $indexName);
+        });
+    }
+};

--- a/backend/docs/ops/question-analytics.md
+++ b/backend/docs/ops/question-analytics.md
@@ -1,0 +1,69 @@
+# Question Analytics
+
+## First-phase authoritative scope
+
+- The page is fixed to `BIG5_OCEAN` in v1.
+- `CLINICAL_COMBO_68` is excluded because it is rowless.
+- `SDS_20` stays out of authoritative option distribution because answer rows are redacted.
+- `MBTI`, `EQ_60`, and `IQ_RAVEN` are intentionally deferred until their row coverage and question-order reconstruction are verified separately.
+
+## Read models
+
+### `analytics_question_option_daily`
+
+Authority table for question-level option distribution.
+
+- Source axis: `attempt_answer_rows + attempts`
+- Granularity: day + org + locale + region + scale + version bundle + question + option
+- Main metrics:
+  - `answered_rows_count`
+  - `distinct_attempts_answered`
+
+### `analytics_question_progress_daily`
+
+Authority table for question-level progression, completion, and dropoff.
+
+- Source axis: `attempts + attempt_drafts + attempt_answer_rows`
+- Granularity: day + org + locale + region + scale + version bundle + question
+- Main metrics:
+  - `reached_attempts_count`
+  - `answered_attempts_count`
+  - `completed_attempts_count`
+  - `dropoff_attempts_count`
+
+## Hard metrics in v1
+
+- total answered rows
+- distinct attempts with answers
+- per-question answer count
+- option share
+- reached / answered / completed / dropoff counts
+- dropoff rate
+- completion rate
+
+## Reference-only / non-authoritative metrics
+
+- duration metrics
+- duration heatmaps
+- slowest question rankings
+- events-only question analytics
+- raw answer payload exposure
+- Clinical / SDS option-level comparisons
+- mixed-version pooled conclusions
+- tiny-locale conclusions
+
+## Why duration is deferred
+
+`attempt_answer_rows.duration_ms` is currently an attempt-level duration copied onto each row, not a trustworthy question-level duration fact. Because of that, Question Analytics v1 does not ship an authoritative duration panel or duration read model.
+
+## Question order rule
+
+- Question order is reconstructed from the BIG5 content pack.
+- Frontend `question_index` is not used as the sole authority.
+- If a scale cannot reconstruct stable question order from content definitions, it should not enter the authoritative Question Analytics scope.
+
+## Next likely extensions
+
+- enablement PRs for other safe row-capable scales after row coverage checks
+- a reference-layer duration tab once question-level duration facts are reliable
+- deeper research / psychometrics pages in later AIC phases

--- a/backend/resources/views/filament/ops/pages/question-analytics-page.blade.php
+++ b/backend/resources/views/filament/ops/pages/question-analytics-page.blade.php
@@ -1,0 +1,522 @@
+<x-filament-panels::page>
+    <div class="space-y-6">
+        <form wire:submit.prevent="applyFilters" class="rounded-2xl border border-slate-200 bg-white/95 p-5 shadow-sm">
+            <div class="grid gap-4 xl:grid-cols-[repeat(4,minmax(0,1fr))]">
+                <label class="space-y-2">
+                    <span class="text-xs font-semibold uppercase tracking-[0.16em] text-slate-500">From</span>
+                    <input type="date" wire:model.defer="fromDate" class="block w-full rounded-xl border-slate-300 text-sm shadow-sm" />
+                </label>
+
+                <label class="space-y-2">
+                    <span class="text-xs font-semibold uppercase tracking-[0.16em] text-slate-500">To</span>
+                    <input type="date" wire:model.defer="toDate" class="block w-full rounded-xl border-slate-300 text-sm shadow-sm" />
+                </label>
+
+                <label class="space-y-2">
+                    <span class="text-xs font-semibold uppercase tracking-[0.16em] text-slate-500">Scale</span>
+                    <select wire:model.defer="scaleCode" class="block w-full rounded-xl border-slate-300 text-sm shadow-sm" disabled>
+                        @foreach ($scaleOptions as $value => $label)
+                            <option value="{{ $value }}">{{ $label }}</option>
+                        @endforeach
+                    </select>
+                </label>
+
+                <label class="space-y-2">
+                    <span class="text-xs font-semibold uppercase tracking-[0.16em] text-slate-500">Locale</span>
+                    <select wire:model.defer="locale" class="block w-full rounded-xl border-slate-300 text-sm shadow-sm">
+                        <option value="all">All locales</option>
+                        @foreach ($localeOptions as $value => $label)
+                            <option value="{{ $value }}">{{ $label }}</option>
+                        @endforeach
+                    </select>
+                </label>
+
+                <label class="space-y-2">
+                    <span class="text-xs font-semibold uppercase tracking-[0.16em] text-slate-500">Region</span>
+                    <select wire:model.defer="region" class="block w-full rounded-xl border-slate-300 text-sm shadow-sm">
+                        <option value="all">All regions</option>
+                        @foreach ($regionOptions as $value => $label)
+                            <option value="{{ $value }}">{{ $label }}</option>
+                        @endforeach
+                    </select>
+                </label>
+
+                <label class="space-y-2">
+                    <span class="text-xs font-semibold uppercase tracking-[0.16em] text-slate-500">Content</span>
+                    <select wire:model.defer="contentPackageVersion" class="block w-full rounded-xl border-slate-300 text-sm shadow-sm">
+                        <option value="all">All content versions</option>
+                        @foreach ($contentPackageVersionOptions as $value => $label)
+                            <option value="{{ $value }}">{{ $label }}</option>
+                        @endforeach
+                    </select>
+                </label>
+
+                <label class="space-y-2">
+                    <span class="text-xs font-semibold uppercase tracking-[0.16em] text-slate-500">Scoring</span>
+                    <select wire:model.defer="scoringSpecVersion" class="block w-full rounded-xl border-slate-300 text-sm shadow-sm">
+                        <option value="all">All scoring versions</option>
+                        @foreach ($scoringSpecVersionOptions as $value => $label)
+                            <option value="{{ $value }}">{{ $label }}</option>
+                        @endforeach
+                    </select>
+                </label>
+
+                <label class="space-y-2">
+                    <span class="text-xs font-semibold uppercase tracking-[0.16em] text-slate-500">Norm</span>
+                    <select wire:model.defer="normVersion" class="block w-full rounded-xl border-slate-300 text-sm shadow-sm">
+                        <option value="all">All norm versions</option>
+                        @foreach ($normVersionOptions as $value => $label)
+                            <option value="{{ $value }}">{{ $label }}</option>
+                        @endforeach
+                    </select>
+                </label>
+
+                <label class="space-y-2 xl:col-span-2">
+                    <span class="text-xs font-semibold uppercase tracking-[0.16em] text-slate-500">Question</span>
+                    <select wire:model.defer="questionId" class="block w-full rounded-xl border-slate-300 text-sm shadow-sm">
+                        <option value="all">All questions</option>
+                        @foreach ($questionIdOptions as $value => $label)
+                            <option value="{{ $value }}">{{ $label }}</option>
+                        @endforeach
+                    </select>
+                </label>
+
+                <label class="flex items-center gap-3 rounded-2xl border border-slate-200 bg-slate-50/70 px-4 py-3 text-sm text-slate-700">
+                    <input type="checkbox" wire:model.defer="onlyCompletedAttempts" class="rounded border-slate-300 text-sky-600 shadow-sm" />
+                    <span>Only completed attempts</span>
+                </label>
+
+                <label class="flex items-center gap-3 rounded-2xl border border-slate-200 bg-slate-50/70 px-4 py-3 text-sm text-slate-500">
+                    <input type="checkbox" wire:model.defer="excludeNonAuthoritativeScales" class="rounded border-slate-300 text-sky-600 shadow-sm" checked disabled />
+                    <span>Exclude non-authoritative scales</span>
+                </label>
+
+                <div class="flex items-end gap-3">
+                    <x-filament::button type="submit">Apply</x-filament::button>
+                </div>
+            </div>
+        </form>
+
+        <section class="rounded-2xl border border-slate-200 bg-white/95 p-5 shadow-sm">
+            <div class="flex flex-wrap items-center justify-between gap-4">
+                <div>
+                    <h2 class="text-lg font-semibold text-slate-950">Authority Scope</h2>
+                    <p class="text-sm text-slate-500">
+                        Fixed to {{ $canonicalScale['scale_code'] }} only, with legacy / v2 recognition for {{ $canonicalScale['scale_code_v2'] }}.
+                    </p>
+                </div>
+
+                <div class="flex flex-wrap gap-2">
+                    @foreach (['option-distribution' => 'Option Distribution', 'dropoff-completion' => 'Dropoff / Completion'] as $tabKey => $label)
+                        <button
+                            type="button"
+                            wire:click="setActiveTab('{{ $tabKey }}')"
+                            class="rounded-full border px-4 py-2 text-sm font-medium transition {{ $activeTab === $tabKey ? 'border-sky-300 bg-sky-50 text-sky-700' : 'border-slate-200 text-slate-600 hover:border-slate-300 hover:text-slate-900' }}"
+                        >
+                            {{ $label }}
+                        </button>
+                    @endforeach
+                </div>
+            </div>
+
+            <div class="mt-4 grid gap-3 lg:grid-cols-2">
+                @foreach ($scopeNotes as $note)
+                    <div class="rounded-2xl border border-slate-200 bg-slate-50/80 px-4 py-3 text-sm leading-6 text-slate-700">
+                        {{ $note }}
+                    </div>
+                @endforeach
+            </div>
+
+            <div class="mt-4 grid gap-3 lg:grid-cols-[minmax(0,1fr)_minmax(0,1fr)_minmax(0,1fr)]">
+                @foreach ($drillLinks as $link)
+                    <a href="{{ $link['url'] }}" class="inline-flex items-center justify-between rounded-2xl border border-slate-200 bg-white px-4 py-3 text-sm font-medium text-slate-700 transition hover:border-slate-300 hover:text-slate-950">
+                        <span>{{ $link['label'] }}</span>
+                        <span class="text-slate-400">Open</span>
+                    </a>
+                @endforeach
+
+                <div class="rounded-2xl border border-dashed border-slate-300 bg-slate-50 px-4 py-3 text-sm text-slate-600">
+                    Duration is deferred in v1. No authority duration panel or heatmap is shown on this page.
+                </div>
+            </div>
+        </section>
+
+        @if ($warnings !== [])
+            <div class="space-y-3">
+                @foreach ($warnings as $warning)
+                    <div class="rounded-2xl border border-amber-200 bg-amber-50 px-4 py-3 text-sm text-amber-900">
+                        {{ $warning }}
+                    </div>
+                @endforeach
+            </div>
+        @endif
+
+        @if ($activeTab === 'option-distribution')
+            @if ($hasOptionData)
+                <section class="rounded-2xl border border-slate-200 bg-white/95 p-5 shadow-sm">
+                    <div class="mb-4">
+                        <h2 class="text-lg font-semibold text-slate-950">Option Distribution KPI Cards</h2>
+                        <p class="text-sm text-slate-500">Authoritative rows only. No events-based fallback and no redacted / rowless scales.</p>
+                    </div>
+
+                    <div class="grid gap-4 md:grid-cols-2 xl:grid-cols-4">
+                        @foreach ($optionKpis as $card)
+                            <article class="rounded-2xl border border-slate-200 bg-slate-50/70 p-4">
+                                <div class="text-xs font-semibold uppercase tracking-[0.16em] text-slate-500">{{ $card['label'] }}</div>
+                                <div class="mt-3 text-2xl font-semibold tracking-tight text-slate-950">
+                                    {{ $card['display_value'] ?? $this->formatInt((int) $card['value']) }}
+                                </div>
+                                <p class="mt-2 text-sm leading-6 text-slate-600">{{ $card['description'] }}</p>
+                            </article>
+                        @endforeach
+                    </div>
+                </section>
+
+                <section class="rounded-2xl border border-slate-200 bg-white/95 p-5 shadow-sm">
+                    <div class="mb-4">
+                        <h2 class="text-lg font-semibold text-slate-950">Question Option Distribution Table</h2>
+                        <p class="text-sm text-slate-500">Question ranking, answer count, and option share stacked bars come from daily authority rows.</p>
+                    </div>
+
+                    <div class="overflow-x-auto">
+                        <table class="min-w-full divide-y divide-slate-200 text-sm">
+                            <thead class="bg-slate-50 text-left text-xs font-semibold uppercase tracking-[0.14em] text-slate-500">
+                                <tr>
+                                    <th class="px-3 py-3">Order</th>
+                                    <th class="px-3 py-3">Question</th>
+                                    <th class="px-3 py-3">Answer count</th>
+                                    <th class="px-3 py-3">Distinct attempts</th>
+                                    <th class="px-3 py-3">Option share</th>
+                                    <th class="px-3 py-3">Top option</th>
+                                    <th class="px-3 py-3">Attempts Explorer</th>
+                                </tr>
+                            </thead>
+                            <tbody class="divide-y divide-slate-100 bg-white">
+                                @foreach ($optionDistributionRows as $row)
+                                    <tr>
+                                        <td class="px-3 py-3 font-medium text-slate-900">#{{ $row['question_order'] }}</td>
+                                        <td class="px-3 py-3">
+                                            <div class="font-medium text-slate-900">{{ $row['question_id'] }}</div>
+                                            <div class="mt-1 max-w-[28rem] text-xs leading-5 text-slate-500">{{ $row['question_label'] }}</div>
+                                        </td>
+                                        <td class="px-3 py-3">{{ $this->formatInt((int) $row['answer_count']) }}</td>
+                                        <td class="px-3 py-3">{{ $this->formatInt((int) $row['distinct_attempts_answered']) }}</td>
+                                        <td class="px-3 py-3">
+                                            <div class="min-w-[260px]">
+                                                <div class="flex h-3 overflow-hidden rounded-full bg-slate-100">
+                                                    @foreach ($row['option_segments'] as $segment)
+                                                        <div
+                                                            title="{{ $segment['label'] }}: {{ $this->formatRate($segment['share']) }}"
+                                                            class="h-3"
+                                                            style="width: {{ $segment['pct'] }}%; background-color: {{ $this->barColor($segment['option_key']) }};"
+                                                        ></div>
+                                                    @endforeach
+                                                </div>
+                                                <div class="mt-2 flex flex-wrap gap-2 text-xs text-slate-500">
+                                                    @foreach ($row['option_segments'] as $segment)
+                                                        <span class="inline-flex items-center gap-1">
+                                                            <span class="inline-block h-2.5 w-2.5 rounded-full" style="background-color: {{ $this->barColor($segment['option_key']) }};"></span>
+                                                            {{ $segment['label'] }} · {{ $this->formatRate($segment['share']) }}
+                                                        </span>
+                                                    @endforeach
+                                                </div>
+                                            </div>
+                                        </td>
+                                        <td class="px-3 py-3">{{ $row['top_option_key'] }} · {{ $this->formatRate($row['top_option_share']) }}</td>
+                                        <td class="px-3 py-3">
+                                            <a href="/ops/attempts?tableSearch=BIG5_OCEAN%20{{ urlencode($row['question_id']) }}" class="text-sky-700 transition hover:text-sky-900">
+                                                Open
+                                            </a>
+                                        </td>
+                                    </tr>
+                                @endforeach
+                            </tbody>
+                        </table>
+                    </div>
+                </section>
+
+                <section class="grid gap-6 xl:grid-cols-3">
+                    <div class="rounded-2xl border border-slate-200 bg-white/95 p-5 shadow-sm">
+                        <div class="mb-4">
+                            <h2 class="text-lg font-semibold text-slate-950">Top Answered Questions</h2>
+                            <p class="text-sm text-slate-500">Fast ranking for question-level answer volume.</p>
+                        </div>
+
+                        <div class="overflow-x-auto">
+                            <table class="min-w-full divide-y divide-slate-200 text-sm">
+                                <thead class="bg-slate-50 text-left text-xs font-semibold uppercase tracking-[0.14em] text-slate-500">
+                                    <tr>
+                                        <th class="px-3 py-3">Question</th>
+                                        <th class="px-3 py-3">Answer count</th>
+                                        <th class="px-3 py-3">Top share</th>
+                                    </tr>
+                                </thead>
+                                <tbody class="divide-y divide-slate-100 bg-white">
+                                    @foreach ($optionRankingRows as $row)
+                                        <tr>
+                                            <td class="px-3 py-3 font-medium text-slate-900">#{{ $row['question_order'] }} / {{ $row['question_id'] }}</td>
+                                            <td class="px-3 py-3">{{ $this->formatInt((int) $row['answer_count']) }}</td>
+                                            <td class="px-3 py-3">{{ $this->formatRate($row['top_option_share']) }}</td>
+                                        </tr>
+                                    @endforeach
+                                </tbody>
+                            </table>
+                        </div>
+                    </div>
+
+                    <div class="rounded-2xl border border-slate-200 bg-white/95 p-5 shadow-sm">
+                        <div class="mb-4">
+                            <h2 class="text-lg font-semibold text-slate-950">Locale Compare</h2>
+                            <p class="text-sm text-slate-500">Table cut only. No tiny-locale charting in v1.</p>
+                        </div>
+
+                        <div class="overflow-x-auto">
+                            <table class="min-w-full divide-y divide-slate-200 text-sm">
+                                <thead class="bg-slate-50 text-left text-xs font-semibold uppercase tracking-[0.14em] text-slate-500">
+                                    <tr>
+                                        <th class="px-3 py-3">Locale</th>
+                                        <th class="px-3 py-3">Answered rows</th>
+                                        <th class="px-3 py-3">Attempts</th>
+                                    </tr>
+                                </thead>
+                                <tbody class="divide-y divide-slate-100 bg-white">
+                                    @foreach ($optionLocaleCompareRows as $row)
+                                        <tr>
+                                            <td class="px-3 py-3 font-medium text-slate-900">{{ $row['locale'] }}</td>
+                                            <td class="px-3 py-3">{{ $this->formatInt((int) $row['answered_rows_count']) }}</td>
+                                            <td class="px-3 py-3">{{ $this->formatInt((int) $row['distinct_attempts_answered']) }}</td>
+                                        </tr>
+                                    @endforeach
+                                </tbody>
+                            </table>
+                        </div>
+                    </div>
+
+                    <div class="rounded-2xl border border-slate-200 bg-white/95 p-5 shadow-sm">
+                        <div class="mb-4">
+                            <h2 class="text-lg font-semibold text-slate-950">Version Compare</h2>
+                            <p class="text-sm text-slate-500">Content, scoring, and norm stay explicit so cross-version pools remain visible.</p>
+                        </div>
+
+                        <div class="overflow-x-auto">
+                            <table class="min-w-full divide-y divide-slate-200 text-sm">
+                                <thead class="bg-slate-50 text-left text-xs font-semibold uppercase tracking-[0.14em] text-slate-500">
+                                    <tr>
+                                        <th class="px-3 py-3">Content</th>
+                                        <th class="px-3 py-3">Scoring</th>
+                                        <th class="px-3 py-3">Norm</th>
+                                        <th class="px-3 py-3">Answered rows</th>
+                                    </tr>
+                                </thead>
+                                <tbody class="divide-y divide-slate-100 bg-white">
+                                    @foreach ($optionVersionCompareRows as $row)
+                                        <tr>
+                                            <td class="px-3 py-3">{{ $row['content_package_version'] }}</td>
+                                            <td class="px-3 py-3">{{ $row['scoring_spec_version'] }}</td>
+                                            <td class="px-3 py-3">{{ $row['norm_version'] }}</td>
+                                            <td class="px-3 py-3">{{ $this->formatInt((int) $row['answered_rows_count']) }}</td>
+                                        </tr>
+                                    @endforeach
+                                </tbody>
+                            </table>
+                        </div>
+                    </div>
+                </section>
+            @else
+                <div class="rounded-2xl border border-slate-200 bg-white/95 px-4 py-5 text-sm text-slate-500 shadow-sm">
+                    No option-distribution data matches the current scope.
+                </div>
+            @endif
+        @elseif ($activeTab === 'dropoff-completion')
+            @if ($hasProgressData)
+                <section class="rounded-2xl border border-slate-200 bg-white/95 p-5 shadow-sm">
+                    <div class="mb-4">
+                        <h2 class="text-lg font-semibold text-slate-950">Dropoff / Completion KPI Cards</h2>
+                        <p class="text-sm text-slate-500">Progression comes from attempts + drafts + rows, not from events. Completed-only mode is explicit.</p>
+                    </div>
+
+                    <div class="grid gap-4 md:grid-cols-2 xl:grid-cols-4">
+                        @foreach ($progressKpis as $card)
+                            <article class="rounded-2xl border border-slate-200 bg-slate-50/70 p-4">
+                                <div class="text-xs font-semibold uppercase tracking-[0.16em] text-slate-500">{{ $card['label'] }}</div>
+                                <div class="mt-3 text-2xl font-semibold tracking-tight text-slate-950">
+                                    {{ $this->formatInt((int) $card['value']) }}
+                                </div>
+                                <p class="mt-2 text-sm leading-6 text-slate-600">{{ $card['description'] }}</p>
+                            </article>
+                        @endforeach
+                    </div>
+                </section>
+
+                <section class="rounded-2xl border border-slate-200 bg-white/95 p-5 shadow-sm">
+                    <div class="mb-4">
+                        <h2 class="text-lg font-semibold text-slate-950">Question Dropoff / Completion Table</h2>
+                        <p class="text-sm text-slate-500">Rates are computed from reached attempts inside the current filtered scope.</p>
+                    </div>
+
+                    <div class="overflow-x-auto">
+                        <table class="min-w-full divide-y divide-slate-200 text-sm">
+                            <thead class="bg-slate-50 text-left text-xs font-semibold uppercase tracking-[0.14em] text-slate-500">
+                                <tr>
+                                    <th class="px-3 py-3">Order</th>
+                                    <th class="px-3 py-3">Question</th>
+                                    <th class="px-3 py-3">Reached</th>
+                                    <th class="px-3 py-3">Answered</th>
+                                    <th class="px-3 py-3">Completed</th>
+                                    <th class="px-3 py-3">Dropoff</th>
+                                    <th class="px-3 py-3">Dropoff rate</th>
+                                    <th class="px-3 py-3">Completion rate</th>
+                                </tr>
+                            </thead>
+                            <tbody class="divide-y divide-slate-100 bg-white">
+                                @foreach ($progressRows as $row)
+                                    <tr>
+                                        <td class="px-3 py-3 font-medium text-slate-900">#{{ $row['question_order'] }}</td>
+                                        <td class="px-3 py-3">
+                                            <div class="font-medium text-slate-900">{{ $row['question_id'] }}</div>
+                                            <div class="mt-1 max-w-[28rem] text-xs leading-5 text-slate-500">{{ $row['question_label'] }}</div>
+                                        </td>
+                                        <td class="px-3 py-3">{{ $this->formatInt((int) $row['reached_attempts_count']) }}</td>
+                                        <td class="px-3 py-3">{{ $this->formatInt((int) $row['answered_attempts_count']) }}</td>
+                                        <td class="px-3 py-3">{{ $this->formatInt((int) $row['completed_attempts_count']) }}</td>
+                                        <td class="px-3 py-3">{{ $this->formatInt((int) $row['dropoff_attempts_count']) }}</td>
+                                        <td class="px-3 py-3">{{ $this->formatRate($row['dropoff_rate']) }}</td>
+                                        <td class="px-3 py-3">{{ $this->formatRate($row['completion_rate']) }}</td>
+                                    </tr>
+                                @endforeach
+                            </tbody>
+                        </table>
+                    </div>
+                </section>
+
+                <section class="grid gap-6 xl:grid-cols-2">
+                    <div class="rounded-2xl border border-slate-200 bg-white/95 p-5 shadow-sm">
+                        <div class="mb-4">
+                            <h2 class="text-lg font-semibold text-slate-950">Highest Dropoff Questions</h2>
+                            <p class="text-sm text-slate-500">Ranking by dropoff rate, then dropoff attempt count.</p>
+                        </div>
+
+                        <div class="overflow-x-auto">
+                            <table class="min-w-full divide-y divide-slate-200 text-sm">
+                                <thead class="bg-slate-50 text-left text-xs font-semibold uppercase tracking-[0.14em] text-slate-500">
+                                    <tr>
+                                        <th class="px-3 py-3">Question</th>
+                                        <th class="px-3 py-3">Dropoff</th>
+                                        <th class="px-3 py-3">Rate</th>
+                                    </tr>
+                                </thead>
+                                <tbody class="divide-y divide-slate-100 bg-white">
+                                    @foreach ($highestDropoffRows as $row)
+                                        <tr>
+                                            <td class="px-3 py-3 font-medium text-slate-900">#{{ $row['question_order'] }} / {{ $row['question_id'] }}</td>
+                                            <td class="px-3 py-3">{{ $this->formatInt((int) $row['dropoff_attempts_count']) }}</td>
+                                            <td class="px-3 py-3">{{ $this->formatRate($row['dropoff_rate']) }}</td>
+                                        </tr>
+                                    @endforeach
+                                </tbody>
+                            </table>
+                        </div>
+                    </div>
+
+                    <div class="rounded-2xl border border-slate-200 bg-white/95 p-5 shadow-sm">
+                        <div class="mb-4">
+                            <h2 class="text-lg font-semibold text-slate-950">Lowest Completion Questions</h2>
+                            <p class="text-sm text-slate-500">Ranking by completion rate inside the current scope.</p>
+                        </div>
+
+                        <div class="overflow-x-auto">
+                            <table class="min-w-full divide-y divide-slate-200 text-sm">
+                                <thead class="bg-slate-50 text-left text-xs font-semibold uppercase tracking-[0.14em] text-slate-500">
+                                    <tr>
+                                        <th class="px-3 py-3">Question</th>
+                                        <th class="px-3 py-3">Completed</th>
+                                        <th class="px-3 py-3">Rate</th>
+                                    </tr>
+                                </thead>
+                                <tbody class="divide-y divide-slate-100 bg-white">
+                                    @foreach ($lowestCompletionRows as $row)
+                                        <tr>
+                                            <td class="px-3 py-3 font-medium text-slate-900">#{{ $row['question_order'] }} / {{ $row['question_id'] }}</td>
+                                            <td class="px-3 py-3">{{ $this->formatInt((int) $row['completed_attempts_count']) }}</td>
+                                            <td class="px-3 py-3">{{ $this->formatRate($row['completion_rate']) }}</td>
+                                        </tr>
+                                    @endforeach
+                                </tbody>
+                            </table>
+                        </div>
+                    </div>
+                </section>
+
+                <section class="grid gap-6 xl:grid-cols-2">
+                    <div class="rounded-2xl border border-slate-200 bg-white/95 p-5 shadow-sm">
+                        <div class="mb-4">
+                            <h2 class="text-lg font-semibold text-slate-950">Locale Compare</h2>
+                            <p class="text-sm text-slate-500">Simple locale table cut for reached / answered / completed / dropoff.</p>
+                        </div>
+
+                        <div class="overflow-x-auto">
+                            <table class="min-w-full divide-y divide-slate-200 text-sm">
+                                <thead class="bg-slate-50 text-left text-xs font-semibold uppercase tracking-[0.14em] text-slate-500">
+                                    <tr>
+                                        <th class="px-3 py-3">Locale</th>
+                                        <th class="px-3 py-3">Reached</th>
+                                        <th class="px-3 py-3">Completed</th>
+                                        <th class="px-3 py-3">Dropoff</th>
+                                        <th class="px-3 py-3">Dropoff rate</th>
+                                    </tr>
+                                </thead>
+                                <tbody class="divide-y divide-slate-100 bg-white">
+                                    @foreach ($progressLocaleCompareRows as $row)
+                                        <tr>
+                                            <td class="px-3 py-3 font-medium text-slate-900">{{ $row['locale'] }}</td>
+                                            <td class="px-3 py-3">{{ $this->formatInt((int) $row['reached_attempts_count']) }}</td>
+                                            <td class="px-3 py-3">{{ $this->formatInt((int) $row['completed_attempts_count']) }}</td>
+                                            <td class="px-3 py-3">{{ $this->formatInt((int) $row['dropoff_attempts_count']) }}</td>
+                                            <td class="px-3 py-3">{{ $this->formatRate($row['dropoff_rate']) }}</td>
+                                        </tr>
+                                    @endforeach
+                                </tbody>
+                            </table>
+                        </div>
+                    </div>
+
+                    <div class="rounded-2xl border border-slate-200 bg-white/95 p-5 shadow-sm">
+                        <div class="mb-4">
+                            <h2 class="text-lg font-semibold text-slate-950">Version Compare</h2>
+                            <p class="text-sm text-slate-500">Version pool stays explicit to avoid silent cross-version authority claims.</p>
+                        </div>
+
+                        <div class="overflow-x-auto">
+                            <table class="min-w-full divide-y divide-slate-200 text-sm">
+                                <thead class="bg-slate-50 text-left text-xs font-semibold uppercase tracking-[0.14em] text-slate-500">
+                                    <tr>
+                                        <th class="px-3 py-3">Content</th>
+                                        <th class="px-3 py-3">Scoring</th>
+                                        <th class="px-3 py-3">Norm</th>
+                                        <th class="px-3 py-3">Reached</th>
+                                        <th class="px-3 py-3">Dropoff</th>
+                                    </tr>
+                                </thead>
+                                <tbody class="divide-y divide-slate-100 bg-white">
+                                    @foreach ($progressVersionCompareRows as $row)
+                                        <tr>
+                                            <td class="px-3 py-3">{{ $row['content_package_version'] }}</td>
+                                            <td class="px-3 py-3">{{ $row['scoring_spec_version'] }}</td>
+                                            <td class="px-3 py-3">{{ $row['norm_version'] }}</td>
+                                            <td class="px-3 py-3">{{ $this->formatInt((int) $row['reached_attempts_count']) }}</td>
+                                            <td class="px-3 py-3">{{ $this->formatInt((int) $row['dropoff_attempts_count']) }}</td>
+                                        </tr>
+                                    @endforeach
+                                </tbody>
+                            </table>
+                        </div>
+                    </div>
+                </section>
+            @else
+                <div class="rounded-2xl border border-slate-200 bg-white/95 px-4 py-5 text-sm text-slate-500 shadow-sm">
+                    No dropoff / completion data matches the current scope.
+                </div>
+            @endif
+        @endif
+    </div>
+</x-filament-panels::page>

--- a/backend/tests/Concerns/SeedsQuestionAnalyticsScenario.php
+++ b/backend/tests/Concerns/SeedsQuestionAnalyticsScenario.php
@@ -1,0 +1,319 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Concerns;
+
+use App\Services\Analytics\QuestionAnalyticsSupport;
+use Carbon\CarbonImmutable;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Support\Str;
+
+trait SeedsQuestionAnalyticsScenario
+{
+    /**
+     * @return array{from:string,to:string}
+     */
+    private function seedQuestionAnalyticsScenario(int $orgId): array
+    {
+        $definition = app(QuestionAnalyticsSupport::class)->big5Definition();
+        /** @var array<int,string> $questionIdsByOrder */
+        $questionIdsByOrder = $definition['question_ids_by_order'] ?? [];
+
+        $dayOne = CarbonImmutable::parse('2026-01-03 09:00:00');
+        $dayTwo = CarbonImmutable::parse('2026-01-04 10:00:00');
+
+        $attemptA = $this->insertQuestionAnalyticsAttempt([
+            'org_id' => $orgId,
+            'scale_code' => 'BIG5_OCEAN',
+            'locale' => 'en',
+            'region' => 'US',
+            'content_package_version' => 'content_2026_01',
+            'scoring_spec_version' => 'scoring_2026_01',
+            'norm_version' => 'norm_2026_01',
+            'created_at' => $dayOne,
+            'submitted_at' => $dayOne->addMinutes(8),
+        ]);
+        $this->insertQuestionAnalyticsAnswerRows($attemptA, $orgId, $questionIdsByOrder, '1', $dayOne->addMinutes(8));
+
+        $attemptB = $this->insertQuestionAnalyticsAttempt([
+            'org_id' => $orgId,
+            'scale_code' => 'BIG5_OCEAN',
+            'locale' => 'zh-CN',
+            'region' => 'CN_MAINLAND',
+            'content_package_version' => 'content_2026_01',
+            'scoring_spec_version' => 'scoring_2026_02',
+            'norm_version' => 'norm_2026_02',
+            'created_at' => $dayOne->addHours(1),
+            'submitted_at' => $dayOne->addHours(1)->addMinutes(8),
+        ]);
+        $this->insertQuestionAnalyticsAnswerRows($attemptB, $orgId, $questionIdsByOrder, '5', $dayOne->addHours(1)->addMinutes(8));
+
+        $attemptC = $this->insertQuestionAnalyticsAttempt([
+            'org_id' => $orgId,
+            'scale_code' => 'BIG5_OCEAN',
+            'locale' => 'en',
+            'region' => 'US',
+            'content_package_version' => 'content_2026_02',
+            'scoring_spec_version' => 'scoring_2026_02',
+            'norm_version' => 'norm_2026_02',
+            'created_at' => $dayTwo,
+            'updated_at' => $dayTwo->addMinutes(12),
+        ]);
+        $this->insertQuestionAnalyticsDraft($attemptC, $orgId, [
+            'cursor' => 'page-3',
+            'updated_at' => $dayTwo->addMinutes(12),
+            'answers' => [
+                $this->draftAnswer($questionIdsByOrder[1] ?? '1', 0, '2'),
+                $this->draftAnswer($questionIdsByOrder[2] ?? '2', 1, '3'),
+            ],
+        ]);
+
+        $attemptD = $this->insertQuestionAnalyticsAttempt([
+            'org_id' => $orgId,
+            'scale_code' => 'BIG5_OCEAN',
+            'locale' => 'fr-FR',
+            'region' => 'FR',
+            'content_package_version' => 'content_2026_02',
+            'scoring_spec_version' => 'scoring_2026_02',
+            'norm_version' => 'norm_2026_02',
+            'created_at' => $dayTwo->addHours(1),
+            'updated_at' => $dayTwo->addHours(1)->addMinutes(6),
+        ]);
+        $this->insertQuestionAnalyticsDraft($attemptD, $orgId, [
+            'cursor' => 'page-2',
+            'updated_at' => $dayTwo->addHours(1)->addMinutes(6),
+            'answers' => [
+                $this->draftAnswer($questionIdsByOrder[1] ?? '1', 0, '4'),
+            ],
+        ]);
+
+        $clinicalAttempt = $this->insertQuestionAnalyticsAttempt([
+            'org_id' => $orgId,
+            'scale_code' => 'CLINICAL_COMBO_68',
+            'locale' => 'en',
+            'region' => 'US',
+            'content_package_version' => 'content_clinical_2026_01',
+            'scoring_spec_version' => 'scoring_clinical_2026_01',
+            'norm_version' => 'norm_clinical_2026_01',
+            'created_at' => $dayOne->addHours(2),
+            'submitted_at' => $dayOne->addHours(2)->addMinutes(5),
+        ]);
+        $this->insertSingleAnswerRow($clinicalAttempt, $orgId, 'CLINICAL_COMBO_68', 'CLIN-1', 0, '1', $dayOne->addHours(2)->addMinutes(5));
+
+        $sdsAttempt = $this->insertQuestionAnalyticsAttempt([
+            'org_id' => $orgId,
+            'scale_code' => 'SDS_20',
+            'locale' => 'en',
+            'region' => 'US',
+            'content_package_version' => 'content_sds_2026_01',
+            'scoring_spec_version' => 'scoring_sds_2026_01',
+            'norm_version' => 'norm_sds_2026_01',
+            'created_at' => $dayOne->addHours(3),
+            'submitted_at' => $dayOne->addHours(3)->addMinutes(5),
+        ]);
+        $this->insertSingleAnswerRow($sdsAttempt, $orgId, 'SDS_20', 'SDS-1', 0, null, $dayOne->addHours(3)->addMinutes(5), true);
+
+        return [
+            'from' => $dayOne->toDateString(),
+            'to' => $dayTwo->toDateString(),
+        ];
+    }
+
+    /**
+     * @param  array<string,mixed>  $overrides
+     */
+    private function insertQuestionAnalyticsAttempt(array $overrides = []): string
+    {
+        $attemptId = (string) ($overrides['id'] ?? Str::uuid());
+        $createdAt = $overrides['created_at'] ?? CarbonImmutable::parse('2026-01-03 00:00:00');
+        $submittedAt = $overrides['submitted_at'] ?? null;
+        $updatedAt = $overrides['updated_at'] ?? ($submittedAt ?? $createdAt);
+        $scaleCode = (string) ($overrides['scale_code'] ?? 'BIG5_OCEAN');
+
+        $row = [
+            'id' => $attemptId,
+            'ticket_code' => 'FMT-'.strtoupper(substr(str_replace('-', '', $attemptId), 0, 8)),
+            'anon_id' => 'anon_'.substr(str_replace('-', '', $attemptId), 0, 10),
+            'user_id' => null,
+            'org_id' => (int) ($overrides['org_id'] ?? 0),
+            'scale_code' => $scaleCode,
+            'scale_version' => (string) ($overrides['scale_version'] ?? 'v1'),
+            'question_count' => (int) ($overrides['question_count'] ?? 120),
+            'answers_summary_json' => json_encode(['seed' => true], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES),
+            'client_platform' => 'web',
+            'client_version' => 'test',
+            'channel' => 'web',
+            'referrer' => '/tests/question-analytics',
+            'region' => (string) ($overrides['region'] ?? 'US'),
+            'locale' => (string) ($overrides['locale'] ?? 'en'),
+            'started_at' => $createdAt,
+            'submitted_at' => $submittedAt,
+            'created_at' => $createdAt,
+            'updated_at' => $updatedAt,
+            'pack_id' => (string) ($overrides['pack_id'] ?? $scaleCode),
+            'dir_version' => (string) ($overrides['dir_version'] ?? 'v1'),
+            'content_package_version' => (string) ($overrides['content_package_version'] ?? 'content_2026_01'),
+            'scoring_spec_version' => (string) ($overrides['scoring_spec_version'] ?? 'scoring_2026_01'),
+            'norm_version' => (string) ($overrides['norm_version'] ?? 'norm_2026_01'),
+            'result_json' => json_encode($overrides['result_json'] ?? ['seed' => true], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES),
+        ];
+
+        if (Schema::hasColumn('attempts', 'scale_code_v2')) {
+            $row['scale_code_v2'] = match ($scaleCode) {
+                'BIG5_OCEAN' => 'BIG_FIVE_OCEAN_MODEL',
+                'CLINICAL_COMBO_68' => 'CLINICAL_DEPRESSION_ANXIETY_PRO',
+                'SDS_20' => 'DEPRESSION_SCREENING_STANDARD',
+                default => $scaleCode,
+            };
+        }
+
+        if (Schema::hasColumn('attempts', 'scale_uid')) {
+            $row['scale_uid'] = match ($scaleCode) {
+                'BIG5_OCEAN' => '22222222-2222-4222-8222-222222222222',
+                'CLINICAL_COMBO_68' => '33333333-3333-4333-8333-333333333333',
+                'SDS_20' => '44444444-4444-4444-8444-444444444444',
+                default => null,
+            };
+        }
+
+        DB::table('attempts')->insert($row);
+
+        return $attemptId;
+    }
+
+    /**
+     * @param  array<int,string>  $questionIdsByOrder
+     */
+    private function insertQuestionAnalyticsAnswerRows(
+        string $attemptId,
+        int $orgId,
+        array $questionIdsByOrder,
+        string $optionCode,
+        \DateTimeInterface $submittedAt,
+    ): void {
+        $rows = [];
+        $createdAt = CarbonImmutable::parse($submittedAt);
+
+        foreach ($questionIdsByOrder as $order => $questionId) {
+            $rows[] = $this->answerRowPayload(
+                $attemptId,
+                $orgId,
+                'BIG5_OCEAN',
+                (string) $questionId,
+                max(0, $order - 1),
+                $optionCode,
+                $createdAt
+            );
+        }
+
+        DB::table('attempt_answer_rows')->insert($rows);
+    }
+
+    private function insertSingleAnswerRow(
+        string $attemptId,
+        int $orgId,
+        string $scaleCode,
+        string $questionId,
+        int $questionIndex,
+        ?string $optionCode,
+        \DateTimeInterface $submittedAt,
+        bool $redacted = false,
+    ): void {
+        DB::table('attempt_answer_rows')->insert([
+            $this->answerRowPayload($attemptId, $orgId, $scaleCode, $questionId, $questionIndex, $optionCode, $submittedAt, $redacted),
+        ]);
+    }
+
+    /**
+     * @param  array{cursor:string,updated_at:\DateTimeInterface,answers:list<array<string,mixed>>}  $overrides
+     */
+    private function insertQuestionAnalyticsDraft(string $attemptId, int $orgId, array $overrides): void
+    {
+        DB::table('attempt_drafts')->insert([
+            'attempt_id' => $attemptId,
+            'org_id' => $orgId,
+            'resume_token_hash' => hash('sha256', 'resume-'.$attemptId),
+            'last_seq' => 2,
+            'cursor' => $overrides['cursor'],
+            'duration_ms' => 2400,
+            'answers_json' => json_encode($overrides['answers'], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES),
+            'answered_count' => count($overrides['answers']),
+            'created_at' => CarbonImmutable::parse($overrides['updated_at'])->subMinutes(5),
+            'updated_at' => $overrides['updated_at'],
+            'expires_at' => CarbonImmutable::parse($overrides['updated_at'])->addDays(7),
+        ]);
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    private function draftAnswer(string $questionId, int $questionIndex, string $code): array
+    {
+        return [
+            'question_id' => $questionId,
+            'question_type' => 'likert',
+            'question_index' => $questionIndex,
+            'code' => $code,
+            'answer' => ['value' => (int) $code],
+        ];
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    private function answerRowPayload(
+        string $attemptId,
+        int $orgId,
+        string $scaleCode,
+        string $questionId,
+        int $questionIndex,
+        ?string $optionCode,
+        \DateTimeInterface $submittedAt,
+        bool $redacted = false,
+    ): array {
+        $payload = $redacted
+            ? ['question_id' => $questionId, 'redacted' => true]
+            : [
+                'question_id' => $questionId,
+                'question_index' => $questionIndex,
+                'question_type' => 'likert',
+                'code' => (string) $optionCode,
+                'answer' => ['value' => $optionCode !== null ? (int) $optionCode : null],
+            ];
+
+        $row = [
+            'attempt_id' => $attemptId,
+            'org_id' => $orgId,
+            'scale_code' => $scaleCode,
+            'question_id' => $questionId,
+            'question_index' => $questionIndex,
+            'question_type' => 'likert',
+            'answer_json' => json_encode($payload, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES),
+            'duration_ms' => 5000,
+            'submitted_at' => $submittedAt,
+            'created_at' => $submittedAt,
+        ];
+
+        if (Schema::hasColumn('attempt_answer_rows', 'scale_code_v2')) {
+            $row['scale_code_v2'] = match ($scaleCode) {
+                'BIG5_OCEAN' => 'BIG_FIVE_OCEAN_MODEL',
+                'CLINICAL_COMBO_68' => 'CLINICAL_DEPRESSION_ANXIETY_PRO',
+                'SDS_20' => 'DEPRESSION_SCREENING_STANDARD',
+                default => $scaleCode,
+            };
+        }
+
+        if (Schema::hasColumn('attempt_answer_rows', 'scale_uid')) {
+            $row['scale_uid'] = match ($scaleCode) {
+                'BIG5_OCEAN' => '22222222-2222-4222-8222-222222222222',
+                'CLINICAL_COMBO_68' => '33333333-3333-4333-8333-333333333333',
+                'SDS_20' => '44444444-4444-4444-8444-444444444444',
+                default => null,
+            };
+        }
+
+        return $row;
+    }
+}

--- a/backend/tests/Feature/Analytics/QuestionAnalyticsDailyBuilderTest.php
+++ b/backend/tests/Feature/Analytics/QuestionAnalyticsDailyBuilderTest.php
@@ -1,0 +1,103 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Analytics;
+
+use App\Services\Analytics\QuestionAnalyticsDailyBuilder;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Collection;
+use Tests\Concerns\SeedsQuestionAnalyticsScenario;
+use Tests\TestCase;
+
+final class QuestionAnalyticsDailyBuilderTest extends TestCase
+{
+    use RefreshDatabase;
+    use SeedsQuestionAnalyticsScenario;
+
+    public function test_builder_aggregates_big5_only_question_option_and_progress_rows(): void
+    {
+        $scenario = $this->seedQuestionAnalyticsScenario(801);
+
+        $payload = app(QuestionAnalyticsDailyBuilder::class)->build(
+            new \DateTimeImmutable($scenario['from']),
+            new \DateTimeImmutable($scenario['to']),
+            [801],
+        );
+
+        $this->assertSame(['BIG5_OCEAN'], $payload['authoritative_scales']);
+        $this->assertSame(240, (int) ($payload['source_answer_rows'] ?? 0));
+        $this->assertSame(4, (int) ($payload['source_attempts'] ?? 0));
+
+        $optionRows = collect($payload['option_rows']);
+        $progressRows = collect($payload['progress_rows']);
+
+        $this->assertSame(240, $optionRows->count());
+        $this->assertSame(245, $progressRows->count());
+        $this->assertSame(['BIG5_OCEAN'], $optionRows->pluck('scale_code')->unique()->values()->all());
+        $this->assertFalse($optionRows->contains(static fn (array $row): bool => str_starts_with((string) $row['question_id'], 'CLIN')));
+        $this->assertFalse($optionRows->contains(static fn (array $row): bool => str_starts_with((string) $row['question_id'], 'SDS')));
+
+        $optionRowQ1En = $optionRows->first(static fn (array $row): bool => (string) $row['question_id'] === '1' && (string) $row['locale'] === 'en');
+        $this->assertIsArray($optionRowQ1En);
+        $this->assertSame(1, (int) ($optionRowQ1En['question_order'] ?? 0));
+        $this->assertSame('1', (string) ($optionRowQ1En['option_key'] ?? ''));
+        $this->assertSame(1, (int) ($optionRowQ1En['answered_rows_count'] ?? 0));
+        $this->assertSame(1, (int) ($optionRowQ1En['distinct_attempts_answered'] ?? 0));
+
+        $optionRowQ120Zh = $optionRows->first(static fn (array $row): bool => (string) $row['question_id'] === '120' && (string) $row['locale'] === 'zh-CN');
+        $this->assertIsArray($optionRowQ120Zh);
+        $this->assertSame(120, (int) ($optionRowQ120Zh['question_order'] ?? 0));
+
+        $progressByQuestion = $this->summarizeProgressByQuestion($progressRows);
+
+        $this->assertSame([
+            'reached' => 4,
+            'answered' => 4,
+            'completed' => 2,
+            'dropoff' => 0,
+        ], $progressByQuestion['1']);
+        $this->assertSame([
+            'reached' => 4,
+            'answered' => 3,
+            'completed' => 2,
+            'dropoff' => 1,
+        ], $progressByQuestion['2']);
+        $this->assertSame([
+            'reached' => 3,
+            'answered' => 2,
+            'completed' => 2,
+            'dropoff' => 1,
+        ], $progressByQuestion['3']);
+        $this->assertSame([
+            'reached' => 2,
+            'answered' => 2,
+            'completed' => 2,
+            'dropoff' => 0,
+        ], $progressByQuestion['120']);
+
+        $this->assertSame(
+            ['en', 'fr-FR', 'zh-CN'],
+            $progressRows->pluck('locale')->unique()->sort()->values()->all()
+        );
+        $this->assertTrue($progressRows->contains(static fn (array $row): bool => (string) $row['content_package_version'] === 'content_2026_02'));
+    }
+
+    /**
+     * @return array<string,array{reached:int,answered:int,completed:int,dropoff:int}>
+     */
+    private function summarizeProgressByQuestion(Collection $rows): array
+    {
+        return $rows
+            ->groupBy('question_id')
+            ->map(static function (Collection $group): array {
+                return [
+                    'reached' => (int) $group->sum('reached_attempts_count'),
+                    'answered' => (int) $group->sum('answered_attempts_count'),
+                    'completed' => (int) $group->sum('completed_attempts_count'),
+                    'dropoff' => (int) $group->sum('dropoff_attempts_count'),
+                ];
+            })
+            ->all();
+    }
+}

--- a/backend/tests/Feature/Analytics/RefreshQuestionDailyCommandTest.php
+++ b/backend/tests/Feature/Analytics/RefreshQuestionDailyCommandTest.php
@@ -1,0 +1,58 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Analytics;
+
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\DB;
+use Tests\Concerns\SeedsQuestionAnalyticsScenario;
+use Tests\TestCase;
+
+final class RefreshQuestionDailyCommandTest extends TestCase
+{
+    use RefreshDatabase;
+    use SeedsQuestionAnalyticsScenario;
+
+    public function test_command_supports_dry_run_and_upserts_two_question_daily_tables(): void
+    {
+        $scenario = $this->seedQuestionAnalyticsScenario(901);
+
+        $this->artisan('analytics:refresh-question-daily', [
+            '--from' => $scenario['from'],
+            '--to' => $scenario['to'],
+            '--org' => [901],
+            '--dry-run' => true,
+        ])
+            ->expectsOutputToContain('dry_run=1')
+            ->expectsOutputToContain('effective_scale_scope=BIG5_OCEAN')
+            ->expectsOutputToContain('attempted_option_rows=240')
+            ->expectsOutputToContain('attempted_progress_rows=245')
+            ->assertExitCode(0);
+
+        $this->assertSame(0, DB::table('analytics_question_option_daily')->count());
+        $this->assertSame(0, DB::table('analytics_question_progress_daily')->count());
+
+        $this->artisan('analytics:refresh-question-daily', [
+            '--from' => $scenario['from'],
+            '--to' => $scenario['to'],
+            '--org' => [901],
+        ])
+            ->expectsOutputToContain('dry_run=0')
+            ->expectsOutputToContain('upserted_option_rows=240')
+            ->expectsOutputToContain('upserted_progress_rows=245')
+            ->assertExitCode(0);
+
+        $this->assertSame(240, DB::table('analytics_question_option_daily')->count());
+        $this->assertSame(245, DB::table('analytics_question_progress_daily')->count());
+
+        $this->artisan('analytics:refresh-question-daily', [
+            '--from' => $scenario['from'],
+            '--to' => $scenario['to'],
+            '--org' => [901],
+        ])->assertExitCode(0);
+
+        $this->assertSame(240, DB::table('analytics_question_option_daily')->count());
+        $this->assertSame(245, DB::table('analytics_question_progress_daily')->count());
+    }
+}

--- a/backend/tests/Feature/Ops/QuestionAnalyticsPageTest.php
+++ b/backend/tests/Feature/Ops/QuestionAnalyticsPageTest.php
@@ -1,0 +1,139 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Ops;
+
+use App\Filament\Ops\Pages\QuestionAnalyticsPage;
+use App\Models\AdminUser;
+use App\Models\Organization;
+use App\Models\Permission;
+use App\Models\Role;
+use App\Services\Analytics\QuestionAnalyticsDailyBuilder;
+use App\Support\OrgContext;
+use App\Support\Rbac\PermissionNames;
+use Filament\Facades\Filament;
+use Filament\PanelRegistry;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Http\Request;
+use Illuminate\Support\Str;
+use Livewire\Livewire;
+use Tests\Concerns\SeedsQuestionAnalyticsScenario;
+use Tests\TestCase;
+
+final class QuestionAnalyticsPageTest extends TestCase
+{
+    use RefreshDatabase;
+    use SeedsQuestionAnalyticsScenario;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        Filament::setCurrentPanel(app(PanelRegistry::class)->get('ops'));
+    }
+
+    public function test_question_analytics_page_route_exists_and_tabs_render_big5_authority_data(): void
+    {
+        $admin = $this->createAdminWithPermissions([
+            PermissionNames::ADMIN_OPS_READ,
+        ]);
+        $selectedOrg = $this->createOrganization('Question Analytics Org');
+        $scenario = $this->seedQuestionAnalyticsScenario((int) $selectedOrg->id);
+
+        app(QuestionAnalyticsDailyBuilder::class)->refresh(
+            new \DateTimeImmutable($scenario['from']),
+            new \DateTimeImmutable($scenario['to']),
+            [(int) $selectedOrg->id],
+        );
+
+        $this->withSession($this->opsSession($admin, $selectedOrg))
+            ->actingAs($admin, (string) config('admin.guard', 'admin'))
+            ->get('/ops/question-analytics')
+            ->assertOk()
+            ->assertSee('Question Analytics')
+            ->assertSee('Option Distribution')
+            ->assertSee('Dropoff / Completion')
+            ->assertSee('Authority Scope')
+            ->assertSee('Duration is deferred in v1');
+
+        $this->actingAs($admin, (string) config('admin.guard', 'admin'));
+        app()->instance('request', Request::create('/ops/question-analytics', 'GET'));
+
+        $context = app(OrgContext::class);
+        $context->set((int) $selectedOrg->id, (int) $admin->id, 'admin');
+        app()->instance(OrgContext::class, $context);
+        $this->withSession($this->opsSession($admin, $selectedOrg));
+
+        Livewire::test(QuestionAnalyticsPage::class)
+            ->assertOk()
+            ->assertSet('scaleCode', 'BIG5_OCEAN')
+            ->assertSet('excludeNonAuthoritativeScales', true)
+            ->set('fromDate', $scenario['from'])
+            ->set('toDate', $scenario['to'])
+            ->call('applyFilters')
+            ->assertSet('hasOptionData', true)
+            ->assertSet('hasProgressData', true)
+            ->assertSet('optionKpis.0.label', 'Total answered rows')
+            ->assertSet('optionDistributionRows.0.question_order', 1)
+            ->call('setActiveTab', 'dropoff-completion')
+            ->assertSet('activeTab', 'dropoff-completion')
+            ->assertSet('progressKpis.0.label', 'Reached attempts')
+            ->assertSet('progressRows.0.question_order', 1)
+            ->assertSet('scopeNotes.0', 'Current authoritative scope is fixed to BIG5_OCEAN only. MBTI, EQ_60, IQ_RAVEN, SDS_20, and CLINICAL_COMBO_68 stay out of this first-phase authority page.');
+    }
+
+    private function createOrganization(string $name): Organization
+    {
+        return Organization::query()->create([
+            'name' => $name,
+            'owner_user_id' => random_int(1000, 9999),
+            'status' => 'active',
+            'domain' => Str::slug($name).'.example.test',
+            'timezone' => 'Asia/Shanghai',
+            'locale' => 'en',
+        ]);
+    }
+
+    /**
+     * @param  list<string>  $permissions
+     */
+    private function createAdminWithPermissions(array $permissions): AdminUser
+    {
+        $admin = AdminUser::query()->create([
+            'name' => 'ops_'.Str::lower(Str::random(6)),
+            'email' => 'ops_'.Str::lower(Str::random(6)).'@example.test',
+            'password' => bcrypt('secret'),
+            'is_active' => 1,
+        ]);
+
+        $role = Role::query()->create([
+            'name' => 'role_'.Str::lower(Str::random(8)),
+            'description' => null,
+        ]);
+
+        foreach ($permissions as $permissionName) {
+            $permission = Permission::query()->firstOrCreate(
+                ['name' => $permissionName],
+                ['description' => null],
+            );
+
+            $role->permissions()->syncWithoutDetaching([$permission->id]);
+        }
+
+        $admin->roles()->syncWithoutDetaching([$role->id]);
+
+        return $admin;
+    }
+
+    /**
+     * @return array{ops_org_id:int,ops_admin_totp_verified_user_id:int}
+     */
+    private function opsSession(AdminUser $admin, Organization $selectedOrg): array
+    {
+        return [
+            'ops_org_id' => (int) $selectedOrg->id,
+            'ops_admin_totp_verified_user_id' => (int) $admin->id,
+        ];
+    }
+}


### PR DESCRIPTION
Summary
- add Question Analytics as the next Assessment Insights page
- provide first-phase authoritative question-level analytics for safe row-capable scales

What changed
- add analytics_question_option_daily and analytics_question_progress_daily
- add a refresh path for question analytics aggregation
- add a custom Question Analytics page in Filament Ops
- show option distribution and dropoff/completion views with authoritative scope notes
- document the first-phase safe-scale scope and non-authoritative metrics

Design choices
- use attempt_answer_rows + attempts as the main fact axis
- enable only BIG5_OCEAN in the first authoritative phase
- exclude rowless/redacted scales from first-phase authoritative option analytics
- defer duration-based analytics until question-level duration facts are reliable
- keep the page under Assessment Insights

Why this PR is small and safe
- no frontend changes
- no API changes
- no Node/runtime changes
- no write-side behavior changes
- only the first authoritative Question Analytics surface for AIC

Validation
- php artisan about
- php artisan route:list --path=ops --except-vendor
- php artisan migrate
- php artisan analytics:refresh-question-daily --from=2026-01-01 --to=2026-01-07
- php artisan test --filter='(QuestionAnalytics|AnalyticsQuestion|AssessmentInsights)'
- php artisan test --filter=RefreshQuestionDailyCommandTest
- php artisan filament:assets
- npm run build
- bash backend/scripts/ci_verify_mbti.sh
