### PR TITLE
feat(assessment-insights): add Quality / Psychometrics / Norms & Drift diagnostics

### DIFF
--- a/backend/app/Console/Commands/RefreshQualityDailyCommand.php
+++ b/backend/app/Console/Commands/RefreshQualityDailyCommand.php
@@ -1,0 +1,88 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Console\Commands;
+
+use App\Services\Analytics\QualityInsightsDailyBuilder;
+use Carbon\CarbonImmutable;
+use Illuminate\Console\Command;
+
+final class RefreshQualityDailyCommand extends Command
+{
+    protected $signature = 'analytics:refresh-quality-daily
+        {--from= : Inclusive start date (Y-m-d)}
+        {--to= : Inclusive end date (Y-m-d)}
+        {--scale=* : Limit refresh to one or more scale codes}
+        {--locale=* : Limit refresh to one or more locales}
+        {--org=* : Limit refresh to one or more org ids}
+        {--dry-run : Preview the aggregation without writing rows}';
+
+    protected $description = 'Refresh the scale quality daily aggregation read model.';
+
+    public function __construct(
+        private readonly QualityInsightsDailyBuilder $builder,
+    ) {
+        parent::__construct();
+    }
+
+    public function handle(): int
+    {
+        $from = $this->parseDateOption((string) $this->option('from'), now()->subDays(13)->toDateString());
+        $to = $this->parseDateOption((string) $this->option('to'), now()->toDateString());
+
+        if ($from->greaterThan($to)) {
+            $this->error('The --from date must be on or before --to.');
+
+            return self::FAILURE;
+        }
+
+        $scaleCodes = array_values(array_filter(array_map(
+            static fn (mixed $value): string => strtoupper(trim((string) $value)),
+            (array) $this->option('scale')
+        ), static fn (string $value): bool => $value !== ''));
+
+        $locales = array_values(array_filter(array_map(
+            static fn (mixed $value): string => trim((string) $value),
+            (array) $this->option('locale')
+        ), static fn (string $value): bool => $value !== ''));
+
+        $orgIds = array_values(array_filter(array_map(
+            static fn (mixed $value): int => max(0, (int) $value),
+            (array) $this->option('org')
+        ), static fn (int $value): bool => $value > 0));
+
+        $dryRun = (bool) $this->option('dry-run');
+
+        $result = $this->builder->refresh($from, $to, $orgIds, $scaleCodes, $locales, $dryRun);
+
+        $this->line('from='.$result['from']);
+        $this->line('to='.$result['to']);
+        $this->line('org_scope='.(empty($result['org_scope']) ? '*' : implode(',', $result['org_scope'])));
+        $this->line('scale_scope='.(empty($result['scale_scope']) ? '*' : implode(',', $result['scale_scope'])));
+        $this->line('locale_scope='.(empty($result['locale_scope']) ? '*' : implode(',', $result['locale_scope'])));
+        $this->line('dry_run='.(($result['dry_run'] ?? false) ? '1' : '0'));
+        $this->line('source_started_attempts='.(string) ($result['source_started_attempts'] ?? 0));
+        $this->line('source_completed_attempts='.(string) ($result['source_completed_attempts'] ?? 0));
+        $this->line('source_results='.(string) ($result['source_results'] ?? 0));
+        $this->line('attempted_rows='.(string) ($result['attempted_rows'] ?? 0));
+        $this->line('deleted_rows='.(string) ($result['deleted_rows'] ?? 0));
+        $this->line('upserted_rows='.(string) ($result['upserted_rows'] ?? 0));
+
+        if (($result['attempted_rows'] ?? 0) === 0) {
+            $this->warn('No quality aggregation rows were generated for the selected scope.');
+        } else {
+            $this->info($dryRun ? 'dry-run complete' : 'refresh complete');
+        }
+
+        return self::SUCCESS;
+    }
+
+    private function parseDateOption(string $value, string $fallback): CarbonImmutable
+    {
+        $candidate = trim($value) !== '' ? trim($value) : $fallback;
+
+        return CarbonImmutable::createFromFormat('Y-m-d', $candidate)?->startOfDay()
+            ?? CarbonImmutable::parse($candidate)->startOfDay();
+    }
+}

--- a/backend/app/Filament/Ops/Pages/QualityResearchPage.php
+++ b/backend/app/Filament/Ops/Pages/QualityResearchPage.php
@@ -1,0 +1,305 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Filament\Ops\Pages;
+
+use App\Services\Analytics\QualityResearchInsightsSupport;
+use App\Support\OrgContext;
+use App\Support\Rbac\PermissionNames;
+use Filament\Actions\Action;
+use Filament\Pages\Page;
+
+class QualityResearchPage extends Page
+{
+    protected static ?string $navigationIcon = 'heroicon-o-beaker';
+
+    protected static ?string $navigationGroup = 'Assessment Insights';
+
+    protected static ?string $navigationLabel = 'Quality / Psychometrics / Norms & Drift';
+
+    protected static ?int $navigationSort = 4;
+
+    protected static ?string $slug = 'quality-research';
+
+    protected static string $view = 'filament.ops.pages.quality-research-page';
+
+    public string $activeTab = 'quality';
+
+    public string $fromDate = '';
+
+    public string $toDate = '';
+
+    public string $scaleCode = 'all';
+
+    public string $locale = 'all';
+
+    public string $region = 'all';
+
+    public string $contentPackageVersion = 'all';
+
+    public string $scoringSpecVersion = 'all';
+
+    public string $normVersion = 'all';
+
+    public string $qualityLevel = 'all';
+
+    public bool $onlyCrisis = false;
+
+    public bool $onlyInvalid = false;
+
+    public bool $onlyWarnings = false;
+
+    /** @var array<string,string> */
+    public array $scaleOptions = [];
+
+    /** @var array<string,string> */
+    public array $localeOptions = [];
+
+    /** @var array<string,string> */
+    public array $regionOptions = [];
+
+    /** @var array<string,string> */
+    public array $contentPackageVersionOptions = [];
+
+    /** @var array<string,string> */
+    public array $scoringSpecVersionOptions = [];
+
+    /** @var array<string,string> */
+    public array $normVersionOptions = [];
+
+    /** @var list<array<string,mixed>> */
+    public array $qualityKpis = [];
+
+    /** @var list<array<string,mixed>> */
+    public array $qualityDailyRows = [];
+
+    /** @var list<array<string,mixed>> */
+    public array $qualityScaleRows = [];
+
+    /** @var list<array<string,mixed>> */
+    public array $qualityFlagRows = [];
+
+    /** @var list<array<string,mixed>> */
+    public array $psychometricRows = [];
+
+    /** @var list<array<string,mixed>> */
+    public array $normCoverageRows = [];
+
+    /** @var list<array<string,mixed>> */
+    public array $rolloutRows = [];
+
+    /** @var list<array<string,mixed>> */
+    public array $driftRows = [];
+
+    /** @var list<string> */
+    public array $scopeNotes = [];
+
+    /** @var list<string> */
+    public array $qualityNotes = [];
+
+    /** @var list<string> */
+    public array $psychometricNotes = [];
+
+    /** @var list<string> */
+    public array $normNotes = [];
+
+    /** @var list<string> */
+    public array $warnings = [];
+
+    public bool $hasQualityData = false;
+
+    public bool $hasPsychometricsData = false;
+
+    public bool $hasNormsData = false;
+
+    public function mount(): void
+    {
+        $this->fromDate = now()->subDays(13)->toDateString();
+        $this->toDate = now()->toDateString();
+        $this->refreshPage();
+    }
+
+    public static function canAccess(): bool
+    {
+        $guard = (string) config('admin.guard', 'admin');
+        $user = auth($guard)->user();
+
+        return is_object($user)
+            && method_exists($user, 'hasPermission')
+            && (
+                $user->hasPermission(PermissionNames::ADMIN_OPS_READ)
+                || $user->hasPermission(PermissionNames::ADMIN_OWNER)
+            );
+    }
+
+    public static function shouldRegisterNavigation(): bool
+    {
+        $guard = (string) config('admin.guard', 'admin');
+        $user = auth($guard)->user();
+
+        return is_object($user)
+            && method_exists($user, 'hasPermission')
+            && $user->hasPermission(PermissionNames::ADMIN_OWNER);
+    }
+
+    public function getTitle(): string
+    {
+        return 'Quality / Psychometrics / Norms & Drift';
+    }
+
+    public function getSubheading(): ?string
+    {
+        return 'Internal-only diagnostics for quality, psychometric snapshots, norm coverage, and rollout/drift reference views.';
+    }
+
+    public function applyFilters(): void
+    {
+        $this->refreshPage();
+    }
+
+    public function setActiveTab(string $tab): void
+    {
+        if (! in_array($tab, ['quality', 'psychometrics', 'norms-drift'], true)) {
+            return;
+        }
+
+        $this->activeTab = $tab;
+    }
+
+    public function formatInt(int $value): string
+    {
+        return number_format($value);
+    }
+
+    public function formatRate(?float $value): string
+    {
+        if ($value === null) {
+            return 'n/a';
+        }
+
+        return number_format($value * 100, 1).'%';
+    }
+
+    protected function getHeaderActions(): array
+    {
+        return [
+            Action::make('attempts')
+                ->label('Attempts Explorer')
+                ->url('/ops/attempts'),
+            Action::make('results')
+                ->label('Results Explorer')
+                ->url('/ops/results'),
+        ];
+    }
+
+    private function refreshPage(): void
+    {
+        $this->warnings = [];
+        $this->scopeNotes = [];
+        $this->qualityNotes = [];
+        $this->psychometricNotes = [];
+        $this->normNotes = [];
+        $this->qualityKpis = [];
+        $this->qualityDailyRows = [];
+        $this->qualityScaleRows = [];
+        $this->qualityFlagRows = [];
+        $this->psychometricRows = [];
+        $this->normCoverageRows = [];
+        $this->rolloutRows = [];
+        $this->driftRows = [];
+        $this->hasQualityData = false;
+        $this->hasPsychometricsData = false;
+        $this->hasNormsData = false;
+
+        $orgId = $this->selectedOrgId();
+        $support = app(QualityResearchInsightsSupport::class);
+        $this->loadFilterOptions($support, $orgId);
+        $this->scopeNotes = $support->pageScopeNotes();
+
+        if ($orgId <= 0) {
+            $this->warnings[] = 'Select an org before loading Quality / Psychometrics / Norms & Drift.';
+
+            return;
+        }
+
+        $quality = $support->qualityPayload($orgId, $this->sharedFilters(), $this->qualityLocalFilters());
+        $psychometrics = $support->psychometricsPayload($this->sharedFilters());
+        $norms = $support->normsPayload($orgId, $this->sharedFilters());
+
+        $this->qualityKpis = $quality['kpis'];
+        $this->qualityDailyRows = $quality['daily_rows'];
+        $this->qualityScaleRows = $quality['scale_rows'];
+        $this->qualityFlagRows = $quality['flag_rows'];
+        $this->qualityNotes = $quality['notes'];
+        $this->hasQualityData = (bool) $quality['has_data'];
+
+        $this->psychometricRows = $psychometrics['rows'];
+        $this->psychometricNotes = $psychometrics['notes'];
+        $this->hasPsychometricsData = (bool) $psychometrics['has_data'];
+
+        $this->normCoverageRows = $norms['coverage_rows'];
+        $this->rolloutRows = $norms['rollout_rows'];
+        $this->driftRows = $norms['drift_rows'];
+        $this->normNotes = $norms['notes'];
+        $this->hasNormsData = (bool) $norms['has_data'];
+
+        $this->warnings = array_values(array_unique(array_merge(
+            $quality['warnings'],
+            $psychometrics['warnings'],
+            $norms['warnings']
+        )));
+    }
+
+    private function loadFilterOptions(QualityResearchInsightsSupport $support, int $orgId): void
+    {
+        $options = $support->filterOptions($orgId);
+
+        $this->scaleOptions = $options['scaleOptions'];
+        $this->localeOptions = $options['localeOptions'];
+        $this->regionOptions = $options['regionOptions'];
+        $this->contentPackageVersionOptions = $options['contentPackageVersionOptions'];
+        $this->scoringSpecVersionOptions = $options['scoringSpecVersionOptions'];
+        $this->normVersionOptions = $options['normVersionOptions'];
+    }
+
+    /**
+     * @return array<string,string>
+     */
+    private function sharedFilters(): array
+    {
+        return [
+            'from' => $this->fromDate,
+            'to' => $this->toDate,
+            'scale_code' => $this->scaleCode,
+            'locale' => $this->locale,
+            'region' => $this->region,
+            'content_package_version' => $this->contentPackageVersion,
+            'scoring_spec_version' => $this->scoringSpecVersion,
+            'norm_version' => $this->normVersion,
+        ];
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    private function qualityLocalFilters(): array
+    {
+        return [
+            'quality_level' => $this->qualityLevel,
+            'only_crisis' => $this->onlyCrisis,
+            'only_invalid' => $this->onlyInvalid,
+            'only_warnings' => $this->onlyWarnings,
+        ];
+    }
+
+    private function selectedOrgId(): int
+    {
+        $sessionOrgId = max(0, (int) session('ops_org_id', 0));
+        if ($sessionOrgId > 0) {
+            return $sessionOrgId;
+        }
+
+        return max(0, (int) app(OrgContext::class)->orgId());
+    }
+}

--- a/backend/app/Models/AnalyticsScaleQualityDaily.php
+++ b/backend/app/Models/AnalyticsScaleQualityDaily.php
@@ -1,0 +1,72 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Models;
+
+use App\Models\Concerns\HasOrgScope;
+use Illuminate\Database\Eloquent\Model;
+
+class AnalyticsScaleQualityDaily extends Model
+{
+    use HasOrgScope;
+
+    protected $table = 'analytics_scale_quality_daily';
+
+    protected $fillable = [
+        'day',
+        'org_id',
+        'scale_code',
+        'locale',
+        'region',
+        'content_package_version',
+        'scoring_spec_version',
+        'norm_version',
+        'started_attempts',
+        'completed_attempts',
+        'results_count',
+        'valid_results_count',
+        'invalid_results_count',
+        'quality_a_count',
+        'quality_b_count',
+        'quality_c_count',
+        'quality_d_count',
+        'crisis_alert_count',
+        'speeding_count',
+        'longstring_count',
+        'straightlining_count',
+        'extreme_count',
+        'inconsistency_count',
+        'warnings_count',
+        'last_refreshed_at',
+    ];
+
+    protected $casts = [
+        'day' => 'date',
+        'org_id' => 'integer',
+        'started_attempts' => 'integer',
+        'completed_attempts' => 'integer',
+        'results_count' => 'integer',
+        'valid_results_count' => 'integer',
+        'invalid_results_count' => 'integer',
+        'quality_a_count' => 'integer',
+        'quality_b_count' => 'integer',
+        'quality_c_count' => 'integer',
+        'quality_d_count' => 'integer',
+        'crisis_alert_count' => 'integer',
+        'speeding_count' => 'integer',
+        'longstring_count' => 'integer',
+        'straightlining_count' => 'integer',
+        'extreme_count' => 'integer',
+        'inconsistency_count' => 'integer',
+        'warnings_count' => 'integer',
+        'last_refreshed_at' => 'datetime',
+        'created_at' => 'datetime',
+        'updated_at' => 'datetime',
+    ];
+
+    public static function allowOrgZeroContext(): bool
+    {
+        return self::allowOrgZeroWithResolvedContext();
+    }
+}

--- a/backend/app/Services/Analytics/QualityInsightsDailyBuilder.php
+++ b/backend/app/Services/Analytics/QualityInsightsDailyBuilder.php
@@ -1,0 +1,527 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\Analytics;
+
+use App\Support\SchemaBaseline;
+use Carbon\CarbonImmutable;
+use Illuminate\Support\Facades\DB;
+
+final class QualityInsightsDailyBuilder
+{
+    public function __construct(
+        private readonly QualitySignalExtractor $signalExtractor,
+    ) {}
+
+    /**
+     * @param  list<int>  $orgIds
+     * @param  list<string>  $scaleCodes
+     * @param  list<string>  $locales
+     * @return array{
+     *   rows:list<array<string,mixed>>,
+     *   attempted_rows:int,
+     *   source_started_attempts:int,
+     *   source_completed_attempts:int,
+     *   source_results:int,
+     *   org_scope:list<int>,
+     *   scale_scope:list<string>,
+     *   locale_scope:list<string>,
+     *   from:string,
+     *   to:string
+     * }
+     */
+    public function build(
+        \DateTimeInterface $from,
+        \DateTimeInterface $to,
+        array $orgIds = [],
+        array $scaleCodes = [],
+        array $locales = [],
+    ): array {
+        $fromAt = CarbonImmutable::parse($from)->startOfDay();
+        $toAt = CarbonImmutable::parse($to)->endOfDay();
+        $normalizedOrgIds = $this->normalizeOrgIds($orgIds);
+        $normalizedScaleCodes = $this->normalizeScaleCodes($scaleCodes);
+        $normalizedLocales = $this->normalizeLocales($locales);
+
+        if (! SchemaBaseline::hasTable('attempts')) {
+            return [
+                'rows' => [],
+                'attempted_rows' => 0,
+                'source_started_attempts' => 0,
+                'source_completed_attempts' => 0,
+                'source_results' => 0,
+                'org_scope' => $normalizedOrgIds,
+                'scale_scope' => $normalizedScaleCodes,
+                'locale_scope' => $normalizedLocales,
+                'from' => $fromAt->toDateString(),
+                'to' => $toAt->toDateString(),
+            ];
+        }
+
+        $aggregates = [];
+        $sourceStartedAttempts = 0;
+        $sourceCompletedAttempts = 0;
+        $sourceResults = 0;
+        $now = now();
+
+        foreach ($this->startedAttemptCursor($fromAt, $toAt, $normalizedOrgIds, $normalizedScaleCodes, $normalizedLocales) as $row) {
+            $sourceStartedAttempts++;
+            $dimensions = $this->dimensionPayload(
+                $row,
+                $this->resolveDateString($row->started_at ?? null, $row->created_at ?? null)
+            );
+            $key = $this->aggregateKey($dimensions);
+
+            if (! isset($aggregates[$key])) {
+                $aggregates[$key] = $this->baseAggregateRow($dimensions, $now);
+            }
+
+            $aggregates[$key]['started_attempts']++;
+        }
+
+        foreach ($this->completedAttemptCursor($fromAt, $toAt, $normalizedOrgIds, $normalizedScaleCodes, $normalizedLocales) as $row) {
+            $sourceCompletedAttempts++;
+            $dimensions = $this->dimensionPayload(
+                $row,
+                $this->resolveDateString($row->submitted_at ?? null, $row->created_at ?? null)
+            );
+            $key = $this->aggregateKey($dimensions);
+
+            if (! isset($aggregates[$key])) {
+                $aggregates[$key] = $this->baseAggregateRow($dimensions, $now);
+            }
+
+            $aggregates[$key]['completed_attempts']++;
+
+            if (! filled($row->result_id ?? null)) {
+                continue;
+            }
+
+            $sourceResults++;
+            $aggregates[$key]['results_count']++;
+
+            $signal = $this->signalExtractor->extract(
+                $row->result_json ?? null,
+                $row->calculation_snapshot_json ?? null,
+                $row->result_is_valid ?? null
+            );
+
+            $validityBucket = (string) ($signal['validity_bucket'] ?? 'unknown');
+            if ($validityBucket === 'valid') {
+                $aggregates[$key]['valid_results_count']++;
+            } elseif ($validityBucket === 'invalid') {
+                $aggregates[$key]['invalid_results_count']++;
+            }
+
+            $level = (string) ($signal['level'] ?? '');
+            if ($level === 'A') {
+                $aggregates[$key]['quality_a_count']++;
+            } elseif ($level === 'B') {
+                $aggregates[$key]['quality_b_count']++;
+            } elseif ($level === 'C') {
+                $aggregates[$key]['quality_c_count']++;
+            } elseif ($level === 'D') {
+                $aggregates[$key]['quality_d_count']++;
+            }
+
+            if (($signal['crisis_alert'] ?? false) === true) {
+                $aggregates[$key]['crisis_alert_count']++;
+            }
+
+            $flags = array_flip((array) ($signal['flags'] ?? []));
+            if (isset($flags['SPEEDING'])) {
+                $aggregates[$key]['speeding_count']++;
+            }
+            if (isset($flags['LONGSTRING'])) {
+                $aggregates[$key]['longstring_count']++;
+            }
+            if (isset($flags['STRAIGHTLINING'])) {
+                $aggregates[$key]['straightlining_count']++;
+            }
+            if (isset($flags['EXTREME_RESPONDING']) || isset($flags['EXTREME_RESPONSE_BIAS'])) {
+                $aggregates[$key]['extreme_count']++;
+            }
+            if (isset($flags['INCONSISTENT']) || isset($flags['INCONSISTENCY'])) {
+                $aggregates[$key]['inconsistency_count']++;
+            }
+            if (($signal['has_warning_signal'] ?? false) === true) {
+                $aggregates[$key]['warnings_count']++;
+            }
+        }
+
+        return [
+            'rows' => array_values($aggregates),
+            'attempted_rows' => count($aggregates),
+            'source_started_attempts' => $sourceStartedAttempts,
+            'source_completed_attempts' => $sourceCompletedAttempts,
+            'source_results' => $sourceResults,
+            'org_scope' => $normalizedOrgIds,
+            'scale_scope' => $normalizedScaleCodes,
+            'locale_scope' => $normalizedLocales,
+            'from' => $fromAt->toDateString(),
+            'to' => $toAt->toDateString(),
+        ];
+    }
+
+    /**
+     * @param  list<int>  $orgIds
+     * @param  list<string>  $scaleCodes
+     * @param  list<string>  $locales
+     * @return array<string,mixed>
+     */
+    public function refresh(
+        \DateTimeInterface $from,
+        \DateTimeInterface $to,
+        array $orgIds = [],
+        array $scaleCodes = [],
+        array $locales = [],
+        bool $dryRun = false,
+    ): array {
+        $payload = $this->build($from, $to, $orgIds, $scaleCodes, $locales);
+        $deletedRows = 0;
+        $upsertedRows = 0;
+
+        if (! $dryRun && SchemaBaseline::hasTable('analytics_scale_quality_daily')) {
+            DB::transaction(function () use ($payload, &$deletedRows, &$upsertedRows): void {
+                $deletedRows = $this->deleteScope(
+                    $payload['from'],
+                    $payload['to'],
+                    $payload['org_scope'],
+                    $payload['scale_scope'],
+                    $payload['locale_scope']
+                );
+
+                if ($payload['rows'] === []) {
+                    return;
+                }
+
+                DB::table('analytics_scale_quality_daily')->upsert(
+                    $payload['rows'],
+                    [
+                        'day',
+                        'org_id',
+                        'scale_code',
+                        'locale',
+                        'region',
+                        'content_package_version',
+                        'scoring_spec_version',
+                        'norm_version',
+                    ],
+                    [
+                        'started_attempts',
+                        'completed_attempts',
+                        'results_count',
+                        'valid_results_count',
+                        'invalid_results_count',
+                        'quality_a_count',
+                        'quality_b_count',
+                        'quality_c_count',
+                        'quality_d_count',
+                        'crisis_alert_count',
+                        'speeding_count',
+                        'longstring_count',
+                        'straightlining_count',
+                        'extreme_count',
+                        'inconsistency_count',
+                        'warnings_count',
+                        'last_refreshed_at',
+                        'updated_at',
+                    ]
+                );
+                $upsertedRows = count($payload['rows']);
+            });
+        }
+
+        return $payload + [
+            'deleted_rows' => $deletedRows,
+            'upserted_rows' => $upsertedRows,
+            'dry_run' => $dryRun,
+        ];
+    }
+
+    /**
+     * @param  list<int>  $orgIds
+     * @param  list<string>  $scaleCodes
+     * @param  list<string>  $locales
+     */
+    private function startedAttemptCursor(
+        CarbonImmutable $fromAt,
+        CarbonImmutable $toAt,
+        array $orgIds,
+        array $scaleCodes,
+        array $locales,
+    ): \Generator {
+        $query = DB::table('attempts')
+            ->whereRaw('COALESCE(started_at, created_at) >= ?', [$fromAt->toDateTimeString()])
+            ->whereRaw('COALESCE(started_at, created_at) <= ?', [$toAt->toDateTimeString()])
+            ->orderBy('id')
+            ->select([
+                'id',
+                'org_id',
+                'scale_code',
+                'scale_code_v2',
+                'locale',
+                'region',
+                'content_package_version',
+                'dir_version',
+                'pack_id',
+                'scoring_spec_version',
+                'norm_version',
+                'started_at',
+                'created_at',
+            ]);
+
+        $this->applyAttemptFilters($query, $orgIds, $scaleCodes, $locales);
+
+        foreach ($query->cursor() as $row) {
+            yield $row;
+        }
+    }
+
+    /**
+     * @param  list<int>  $orgIds
+     * @param  list<string>  $scaleCodes
+     * @param  list<string>  $locales
+     */
+    private function completedAttemptCursor(
+        CarbonImmutable $fromAt,
+        CarbonImmutable $toAt,
+        array $orgIds,
+        array $scaleCodes,
+        array $locales,
+    ): \Generator {
+        $query = DB::table('attempts')
+            ->leftJoin('results', 'results.attempt_id', '=', 'attempts.id')
+            ->whereNotNull('attempts.submitted_at')
+            ->where('attempts.submitted_at', '>=', $fromAt->toDateTimeString())
+            ->where('attempts.submitted_at', '<=', $toAt->toDateTimeString())
+            ->orderBy('attempts.id')
+            ->select([
+                'attempts.id',
+                'attempts.org_id',
+                'attempts.scale_code',
+                'attempts.scale_code_v2',
+                'attempts.locale',
+                'attempts.region',
+                'attempts.content_package_version',
+                'attempts.dir_version',
+                'attempts.pack_id',
+                'attempts.scoring_spec_version',
+                'attempts.norm_version',
+                'attempts.submitted_at',
+                'attempts.created_at',
+                'attempts.calculation_snapshot_json',
+                'results.id as result_id',
+                'results.result_json',
+                'results.is_valid as result_is_valid',
+            ]);
+
+        $this->applyAttemptFilters($query, $orgIds, $scaleCodes, $locales);
+
+        foreach ($query->cursor() as $row) {
+            yield $row;
+        }
+    }
+
+    /**
+     * @param  list<int>  $orgIds
+     * @param  list<string>  $scaleCodes
+     * @param  list<string>  $locales
+     */
+    private function applyAttemptFilters(\Illuminate\Database\Query\Builder $query, array $orgIds, array $scaleCodes, array $locales): void
+    {
+        if ($orgIds !== []) {
+            $query->whereIn('attempts.org_id', $orgIds);
+        }
+        if ($scaleCodes !== []) {
+            $query->whereIn('attempts.scale_code', $scaleCodes);
+        }
+        if ($locales !== []) {
+            $query->whereIn('attempts.locale', $locales);
+        }
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    private function dimensionPayload(object $row, string $day): array
+    {
+        $contentPackageVersion = trim((string) ($row->content_package_version ?? ''));
+        if ($contentPackageVersion === '') {
+            $contentPackageVersion = trim((string) ($row->dir_version ?? ($row->pack_id ?? '')));
+        }
+
+        return [
+            'day' => $day,
+            'org_id' => max(0, (int) ($row->org_id ?? 0)),
+            'scale_code' => $this->normalizeScaleCode((string) ($row->scale_code ?? ''), (string) ($row->scale_code_v2 ?? '')),
+            'locale' => $this->stringOrUnknown($row->locale ?? null),
+            'region' => $this->stringOrUnknown($row->region ?? null),
+            'content_package_version' => $contentPackageVersion !== '' ? $contentPackageVersion : 'unknown',
+            'scoring_spec_version' => $this->stringOrUnknown($row->scoring_spec_version ?? null),
+            'norm_version' => $this->stringOrUnknown($row->norm_version ?? null),
+        ];
+    }
+
+    /**
+     * @param  array<string,mixed>  $dimensions
+     * @return array<string,mixed>
+     */
+    private function baseAggregateRow(array $dimensions, \DateTimeInterface $now): array
+    {
+        return [
+            'day' => $dimensions['day'],
+            'org_id' => $dimensions['org_id'],
+            'scale_code' => $dimensions['scale_code'],
+            'locale' => $dimensions['locale'],
+            'region' => $dimensions['region'],
+            'content_package_version' => $dimensions['content_package_version'],
+            'scoring_spec_version' => $dimensions['scoring_spec_version'],
+            'norm_version' => $dimensions['norm_version'],
+            'started_attempts' => 0,
+            'completed_attempts' => 0,
+            'results_count' => 0,
+            'valid_results_count' => 0,
+            'invalid_results_count' => 0,
+            'quality_a_count' => 0,
+            'quality_b_count' => 0,
+            'quality_c_count' => 0,
+            'quality_d_count' => 0,
+            'crisis_alert_count' => 0,
+            'speeding_count' => 0,
+            'longstring_count' => 0,
+            'straightlining_count' => 0,
+            'extreme_count' => 0,
+            'inconsistency_count' => 0,
+            'warnings_count' => 0,
+            'last_refreshed_at' => $now,
+            'created_at' => $now,
+            'updated_at' => $now,
+        ];
+    }
+
+    /**
+     * @param  array<string,mixed>  $dimensions
+     */
+    private function aggregateKey(array $dimensions): string
+    {
+        return implode('|', [
+            (string) $dimensions['day'],
+            (string) $dimensions['org_id'],
+            (string) $dimensions['scale_code'],
+            (string) $dimensions['locale'],
+            (string) $dimensions['region'],
+            (string) $dimensions['content_package_version'],
+            (string) $dimensions['scoring_spec_version'],
+            (string) $dimensions['norm_version'],
+        ]);
+    }
+
+    /**
+     * @param  list<int>  $orgIds
+     * @param  list<string>  $scaleCodes
+     * @param  list<string>  $locales
+     */
+    private function deleteScope(string $from, string $to, array $orgIds, array $scaleCodes, array $locales): int
+    {
+        $query = DB::table('analytics_scale_quality_daily')
+            ->whereBetween('day', [$from, $to]);
+
+        if ($orgIds !== []) {
+            $query->whereIn('org_id', $orgIds);
+        }
+        if ($scaleCodes !== []) {
+            $query->whereIn('scale_code', $scaleCodes);
+        }
+        if ($locales !== []) {
+            $query->whereIn('locale', $locales);
+        }
+
+        return $query->delete();
+    }
+
+    private function resolveDateString(mixed ...$candidates): string
+    {
+        foreach ($candidates as $candidate) {
+            $value = trim((string) $candidate);
+            if ($value === '') {
+                continue;
+            }
+
+            return CarbonImmutable::parse($value)->toDateString();
+        }
+
+        return now()->toDateString();
+    }
+
+    /**
+     * @param  list<int>  $orgIds
+     * @return list<int>
+     */
+    private function normalizeOrgIds(array $orgIds): array
+    {
+        $normalized = [];
+        foreach ($orgIds as $orgId) {
+            $value = max(0, (int) $orgId);
+            if ($value > 0) {
+                $normalized[$value] = $value;
+            }
+        }
+
+        return array_values($normalized);
+    }
+
+    /**
+     * @param  list<string>  $scaleCodes
+     * @return list<string>
+     */
+    private function normalizeScaleCodes(array $scaleCodes): array
+    {
+        $normalized = [];
+        foreach ($scaleCodes as $scaleCode) {
+            $value = strtoupper(trim((string) $scaleCode));
+            if ($value !== '') {
+                $normalized[$value] = $value;
+            }
+        }
+
+        return array_values($normalized);
+    }
+
+    /**
+     * @param  list<string>  $locales
+     * @return list<string>
+     */
+    private function normalizeLocales(array $locales): array
+    {
+        $normalized = [];
+        foreach ($locales as $locale) {
+            $value = trim((string) $locale);
+            if ($value !== '') {
+                $normalized[$value] = $value;
+            }
+        }
+
+        return array_values($normalized);
+    }
+
+    private function normalizeScaleCode(string $scaleCode, string $scaleCodeV2): string
+    {
+        $primary = strtoupper(trim($scaleCode));
+        if ($primary !== '') {
+            return $primary;
+        }
+
+        $secondary = strtoupper(trim($scaleCodeV2));
+
+        return $secondary !== '' ? $secondary : 'UNKNOWN';
+    }
+
+    private function stringOrUnknown(mixed $value): string
+    {
+        $normalized = trim((string) $value);
+
+        return $normalized !== '' ? $normalized : 'unknown';
+    }
+}

--- a/backend/app/Services/Analytics/QualityResearchInsightsSupport.php
+++ b/backend/app/Services/Analytics/QualityResearchInsightsSupport.php
@@ -1,0 +1,1403 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\Analytics;
+
+use App\Support\SchemaBaseline;
+use Carbon\CarbonImmutable;
+use Illuminate\Database\Query\Builder as QueryBuilder;
+use Illuminate\Support\Collection;
+use Illuminate\Support\Facades\DB;
+
+final class QualityResearchInsightsSupport
+{
+    /**
+     * @return array{
+     *   scaleOptions:array<string,string>,
+     *   localeOptions:array<string,string>,
+     *   regionOptions:array<string,string>,
+     *   contentPackageVersionOptions:array<string,string>,
+     *   scoringSpecVersionOptions:array<string,string>,
+     *   normVersionOptions:array<string,string>
+     * }
+     */
+    public function filterOptions(int $orgId): array
+    {
+        $scaleOptions = $this->mergeOptionValues([
+            $this->attemptDistinctValues($orgId, 'scale_code'),
+            $this->globalDistinctValues('big5_psychometrics_reports', 'scale_code'),
+            $this->globalDistinctValues('eq60_psychometrics_reports', 'scale_code'),
+            $this->globalDistinctValues('sds_psychometrics_reports', 'scale_code'),
+            $this->globalDistinctValues('scale_norms_versions', 'scale_code'),
+            ['BIG5_OCEAN', 'EQ_60', 'SDS_20'],
+        ]);
+
+        $localeOptions = $this->mergeOptionValues([
+            $this->attemptDistinctValues($orgId, 'locale'),
+            $this->globalDistinctValues('big5_psychometrics_reports', 'locale'),
+            $this->globalDistinctValues('eq60_psychometrics_reports', 'locale'),
+            $this->globalDistinctValues('sds_psychometrics_reports', 'locale'),
+            $this->globalDistinctValues('scale_norms_versions', 'locale'),
+        ]);
+
+        $regionOptions = $this->mergeOptionValues([
+            $this->attemptDistinctValues($orgId, 'region'),
+            $this->globalDistinctValues('big5_psychometrics_reports', 'region'),
+            $this->globalDistinctValues('eq60_psychometrics_reports', 'region'),
+            $this->globalDistinctValues('sds_psychometrics_reports', 'region'),
+            $this->globalDistinctValues('scale_norms_versions', 'region'),
+        ]);
+
+        $contentOptions = $this->mergeOptionValues([
+            $this->attemptDistinctValues($orgId, 'content_package_version'),
+        ]);
+
+        $scoringOptions = $this->mergeOptionValues([
+            $this->attemptDistinctValues($orgId, 'scoring_spec_version'),
+        ]);
+
+        $normOptions = $this->mergeOptionValues([
+            $this->attemptDistinctValues($orgId, 'norm_version'),
+            $this->globalDistinctValues('big5_psychometrics_reports', 'norms_version'),
+            $this->globalDistinctValues('eq60_psychometrics_reports', 'norms_version'),
+            $this->globalDistinctValues('sds_psychometrics_reports', 'norms_version'),
+            $this->globalDistinctValues('scale_norms_versions', 'version'),
+        ]);
+
+        return [
+            'scaleOptions' => $this->toOptionMap($scaleOptions),
+            'localeOptions' => $this->toOptionMap($localeOptions),
+            'regionOptions' => $this->toOptionMap($regionOptions),
+            'contentPackageVersionOptions' => $this->toOptionMap($contentOptions),
+            'scoringSpecVersionOptions' => $this->toOptionMap($scoringOptions),
+            'normVersionOptions' => $this->toOptionMap($normOptions),
+        ];
+    }
+
+    /**
+     * @param  array<string,string>  $filters
+     * @param  array<string,mixed>  $localFilters
+     * @return array{
+     *   has_data:bool,
+     *   kpis:list<array<string,mixed>>,
+     *   daily_rows:list<array<string,mixed>>,
+     *   scale_rows:list<array<string,mixed>>,
+     *   flag_rows:list<array<string,mixed>>,
+     *   warnings:list<string>,
+     *   notes:list<string>
+     * }
+     */
+    public function qualityPayload(int $orgId, array $filters, array $localFilters = []): array
+    {
+        $warnings = [];
+        $notes = [
+            'Quality KPI cards stay rooted in analytics_scale_quality_daily. Local quality filters shape the tables only; drill-through stays in Attempts / Results Explorer.',
+            'Cross-scale validity is derived from stable quality.level buckets first, then falls back to results.is_valid only when quality.level is missing.',
+            'Longstring, straightlining, extreme responding, and inconsistency stay first-phase reference counters. Some flags are available on subset scales only.',
+        ];
+
+        if (! SchemaBaseline::hasTable('analytics_scale_quality_daily')) {
+            return [
+                'has_data' => false,
+                'kpis' => [],
+                'daily_rows' => [],
+                'scale_rows' => [],
+                'flag_rows' => [],
+                'warnings' => ['analytics_scale_quality_daily is missing. Run php artisan migrate and php artisan analytics:refresh-quality-daily first.'],
+                'notes' => $notes,
+            ];
+        }
+
+        $rows = $this->qualityBaseQuery($orgId, $filters)->get([
+            'day',
+            'scale_code',
+            'locale',
+            'region',
+            'content_package_version',
+            'scoring_spec_version',
+            'norm_version',
+            'started_attempts',
+            'completed_attempts',
+            'results_count',
+            'valid_results_count',
+            'invalid_results_count',
+            'quality_a_count',
+            'quality_b_count',
+            'quality_c_count',
+            'quality_d_count',
+            'crisis_alert_count',
+            'speeding_count',
+            'longstring_count',
+            'straightlining_count',
+            'extreme_count',
+            'inconsistency_count',
+            'warnings_count',
+            'last_refreshed_at',
+        ])->map(fn (object $row): array => $this->qualityRowPayload($row));
+
+        if ($rows->isEmpty()) {
+            $warnings[] = 'No quality daily rows match the current org/date/version scope. Refresh the read model or widen the filter range.';
+        }
+
+        $filteredRows = $this->applyQualityLocalFilters($rows, $localFilters);
+        if ($rows->isNotEmpty() && $filteredRows->isEmpty()) {
+            $warnings[] = 'Local quality filters removed every aggregate row in the current scope.';
+        }
+
+        return [
+            'has_data' => $rows->isNotEmpty(),
+            'kpis' => $this->buildQualityKpis($rows),
+            'daily_rows' => $this->buildDailyQualityRows($filteredRows),
+            'scale_rows' => $this->buildScaleQualityRows($filteredRows),
+            'flag_rows' => $this->buildQualityFlagRows($filteredRows),
+            'warnings' => $warnings,
+            'notes' => $notes,
+        ];
+    }
+
+    /**
+     * @param  array<string,string>  $filters
+     * @return array{
+     *   has_data:bool,
+     *   rows:list<array<string,mixed>>,
+     *   warnings:list<string>,
+     *   notes:list<string>
+     * }
+     */
+    public function psychometricsPayload(array $filters): array
+    {
+        $rows = [];
+        $warnings = [];
+        $notes = [
+            'Psychometric snapshots are internal research reference only. Small-sample rows stay reference-only and should not be treated as default product truth.',
+            'Content package and scoring spec filters are not direct psychometrics fact dimensions in v1. Locale / region / norm_version remain the stable selectors here.',
+        ];
+
+        foreach ($this->psychometricSourceDefinitions() as $definition) {
+            $table = (string) $definition['table'];
+            if (! SchemaBaseline::hasTable($table)) {
+                $warnings[] = sprintf('%s is missing.', $table);
+
+                continue;
+            }
+
+            $query = DB::table($table)
+                ->where('scale_code', $definition['scale_code'])
+                ->orderByDesc('generated_at')
+                ->orderByDesc('created_at');
+
+            $this->applyPsychometricFilters($query, $filters);
+
+            $row = $query->first([
+                'scale_code',
+                'locale',
+                'region',
+                'norms_version',
+                'time_window',
+                'sample_n',
+                'metrics_json',
+                'generated_at',
+                'created_at',
+            ]);
+
+            if (! $row) {
+                continue;
+            }
+
+            $metrics = $this->decodeJson($row->metrics_json ?? null);
+            $scaleCode = strtoupper(trim((string) ($row->scale_code ?? $definition['scale_code'])));
+            $threshold = $this->psychometricSampleThreshold($scaleCode);
+            $summary = $this->psychometricSummary($scaleCode, $metrics);
+            $sampleN = max(0, (int) ($row->sample_n ?? 0));
+
+            $rows[] = [
+                'scale_code' => $scaleCode,
+                'locale' => $this->stringOrUnknown($row->locale ?? null),
+                'region' => $this->stringOrUnknown($row->region ?? null),
+                'norm_version' => $this->stringOrUnknown($row->norms_version ?? null),
+                'time_window' => $this->stringOrUnknown($row->time_window ?? null),
+                'sample_n' => $sampleN,
+                'min_display_samples' => $threshold,
+                'latest_snapshot_at' => $this->formatDateTime($row->generated_at ?? $row->created_at ?? null),
+                'reference_state' => $sampleN >= $threshold
+                    ? 'Internal reference'
+                    : 'Internal reference - below display threshold',
+                'summary_primary' => $summary['primary'],
+                'summary_secondary' => $summary['secondary'],
+            ];
+        }
+
+        usort($rows, static function (array $a, array $b): int {
+            return strcmp((string) $a['scale_code'], (string) $b['scale_code']);
+        });
+
+        return [
+            'has_data' => $rows !== [],
+            'rows' => $rows,
+            'warnings' => $warnings,
+            'notes' => $notes,
+        ];
+    }
+
+    /**
+     * @param  array<string,string>  $filters
+     * @return array{
+     *   has_data:bool,
+     *   coverage_rows:list<array<string,mixed>>,
+     *   rollout_rows:list<array<string,mixed>>,
+     *   drift_rows:list<array<string,mixed>>,
+     *   warnings:list<string>,
+     *   notes:list<string>
+     * }
+     */
+    public function normsPayload(int $orgId, array $filters): array
+    {
+        $warnings = [];
+        $notes = [
+            'Norm version coverage is the hard object layer in v1. Drift compare and rollout observation coverage are internal diagnostics, not hard authority metrics.',
+            'Clinical / crisis-sensitive slices remain aggregate-only here. Raw answer payloads, raw checks JSON, and scoring traces stay outside the page.',
+        ];
+
+        $coverageRows = $this->normCoverageRows($filters, $warnings);
+        $rolloutRows = $this->rolloutRows($orgId, $filters, $warnings);
+        $driftRows = $this->driftCompareRows($filters, $warnings);
+
+        return [
+            'has_data' => $coverageRows !== [] || $rolloutRows !== [] || $driftRows !== [],
+            'coverage_rows' => $coverageRows,
+            'rollout_rows' => $rolloutRows,
+            'drift_rows' => $driftRows,
+            'warnings' => $warnings,
+            'notes' => $notes,
+        ];
+    }
+
+    /**
+     * @return list<string>
+     */
+    public function pageScopeNotes(): array
+    {
+        return [
+            'AIC-08 is admin-only / internal-only. Quality uses analytics_scale_quality_daily for daily summary and keeps per-attempt drill-through in existing Attempts / Results explorers.',
+            'Psychometrics is snapshot-driven. Norms coverage reads scale_norms_versions + scale_norm_stats directly. Drift stays a compare reference, not a hard trend dashboard.',
+            'Global filters keep version context explicit. Content/scoring selectors are first-class on Quality and rollout observation coverage, but not direct psychometric snapshot dimensions in v1.',
+        ];
+    }
+
+    /**
+     * @param  list<list<string>>  $sources
+     * @return list<string>
+     */
+    private function mergeOptionValues(array $sources): array
+    {
+        $values = [];
+        foreach ($sources as $source) {
+            foreach ($source as $value) {
+                $normalized = trim((string) $value);
+                if ($normalized === '' || strtolower($normalized) === 'unknown') {
+                    continue;
+                }
+
+                $values[$normalized] = $normalized;
+            }
+        }
+
+        $merged = array_values($values);
+        sort($merged);
+
+        return $merged;
+    }
+
+    /**
+     * @param  list<string>  $values
+     * @return array<string,string>
+     */
+    private function toOptionMap(array $values): array
+    {
+        $options = [];
+        foreach ($values as $value) {
+            $options[$value] = $value;
+        }
+
+        return $options;
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function attemptDistinctValues(int $orgId, string $column): array
+    {
+        if (! SchemaBaseline::hasTable('attempts') || ! SchemaBaseline::hasColumn('attempts', $column)) {
+            return [];
+        }
+
+        $query = DB::table('attempts')
+            ->where('org_id', $orgId)
+            ->whereNotNull($column)
+            ->where($column, '<>', '')
+            ->distinct()
+            ->orderBy($column);
+
+        return $query->pluck($column)->map(static fn ($value): string => (string) $value)->all();
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function globalDistinctValues(string $table, string $column): array
+    {
+        if (! SchemaBaseline::hasTable($table) || ! SchemaBaseline::hasColumn($table, $column)) {
+            return [];
+        }
+
+        return DB::table($table)
+            ->whereNotNull($column)
+            ->where($column, '<>', '')
+            ->distinct()
+            ->orderBy($column)
+            ->pluck($column)
+            ->map(static fn ($value): string => (string) $value)
+            ->all();
+    }
+
+    /**
+     * @param  array<string,string>  $filters
+     */
+    private function qualityBaseQuery(int $orgId, array $filters): QueryBuilder
+    {
+        [$from, $to] = $this->resolvedRange($filters);
+        $query = DB::table('analytics_scale_quality_daily')
+            ->where('org_id', $orgId)
+            ->whereBetween('day', [$from->toDateString(), $to->toDateString()]);
+
+        if (($filters['scale_code'] ?? 'all') !== 'all') {
+            $query->where('scale_code', strtoupper((string) $filters['scale_code']));
+        }
+        if (($filters['locale'] ?? 'all') !== 'all') {
+            $query->where('locale', (string) $filters['locale']);
+        }
+        if (($filters['region'] ?? 'all') !== 'all') {
+            $query->where('region', (string) $filters['region']);
+        }
+        if (($filters['content_package_version'] ?? 'all') !== 'all') {
+            $query->where('content_package_version', (string) $filters['content_package_version']);
+        }
+        if (($filters['scoring_spec_version'] ?? 'all') !== 'all') {
+            $query->where('scoring_spec_version', (string) $filters['scoring_spec_version']);
+        }
+        if (($filters['norm_version'] ?? 'all') !== 'all') {
+            $query->where('norm_version', (string) $filters['norm_version']);
+        }
+
+        return $query;
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    private function qualityRowPayload(object $row): array
+    {
+        $startedAttempts = max(0, (int) ($row->started_attempts ?? 0));
+        $completedAttempts = max(0, (int) ($row->completed_attempts ?? 0));
+        $resultsCount = max(0, (int) ($row->results_count ?? 0));
+        $validResults = max(0, (int) ($row->valid_results_count ?? 0));
+        $invalidResults = max(0, (int) ($row->invalid_results_count ?? 0));
+        $qualityA = max(0, (int) ($row->quality_a_count ?? 0));
+        $qualityB = max(0, (int) ($row->quality_b_count ?? 0));
+        $qualityC = max(0, (int) ($row->quality_c_count ?? 0));
+        $qualityD = max(0, (int) ($row->quality_d_count ?? 0));
+
+        return [
+            'day' => (string) ($row->day ?? ''),
+            'scale_code' => strtoupper(trim((string) ($row->scale_code ?? 'UNKNOWN'))),
+            'locale' => $this->stringOrUnknown($row->locale ?? null),
+            'region' => $this->stringOrUnknown($row->region ?? null),
+            'content_package_version' => $this->stringOrUnknown($row->content_package_version ?? null),
+            'scoring_spec_version' => $this->stringOrUnknown($row->scoring_spec_version ?? null),
+            'norm_version' => $this->stringOrUnknown($row->norm_version ?? null),
+            'started_attempts' => $startedAttempts,
+            'completed_attempts' => $completedAttempts,
+            'results_count' => $resultsCount,
+            'valid_results_count' => $validResults,
+            'invalid_results_count' => $invalidResults,
+            'quality_a_count' => $qualityA,
+            'quality_b_count' => $qualityB,
+            'quality_c_count' => $qualityC,
+            'quality_d_count' => $qualityD,
+            'crisis_alert_count' => max(0, (int) ($row->crisis_alert_count ?? 0)),
+            'speeding_count' => max(0, (int) ($row->speeding_count ?? 0)),
+            'longstring_count' => max(0, (int) ($row->longstring_count ?? 0)),
+            'straightlining_count' => max(0, (int) ($row->straightlining_count ?? 0)),
+            'extreme_count' => max(0, (int) ($row->extreme_count ?? 0)),
+            'inconsistency_count' => max(0, (int) ($row->inconsistency_count ?? 0)),
+            'warnings_count' => max(0, (int) ($row->warnings_count ?? 0)),
+            'completion_rate' => $startedAttempts > 0 ? round($completedAttempts / $startedAttempts, 4) : null,
+            'validity_rate' => $resultsCount > 0 ? round($validResults / $resultsCount, 4) : null,
+            'quality_mix' => $this->qualityMixLabel($qualityA, $qualityB, $qualityC, $qualityD),
+            'last_refreshed_at' => $this->formatDateTime($row->last_refreshed_at ?? null),
+        ];
+    }
+
+    /**
+     * @param  array<string,mixed>  $localFilters
+     */
+    private function applyQualityLocalFilters(Collection $rows, array $localFilters): Collection
+    {
+        $qualityLevel = strtoupper(trim((string) ($localFilters['quality_level'] ?? 'all')));
+        $onlyCrisis = (bool) ($localFilters['only_crisis'] ?? false);
+        $onlyInvalid = (bool) ($localFilters['only_invalid'] ?? false);
+        $onlyWarnings = (bool) ($localFilters['only_warnings'] ?? false);
+
+        return $rows->filter(function (array $row) use ($qualityLevel, $onlyCrisis, $onlyInvalid, $onlyWarnings): bool {
+            if ($qualityLevel !== '' && $qualityLevel !== 'ALL') {
+                $field = match ($qualityLevel) {
+                    'A' => 'quality_a_count',
+                    'B' => 'quality_b_count',
+                    'C' => 'quality_c_count',
+                    'D' => 'quality_d_count',
+                    default => null,
+                };
+                if ($field !== null && (int) ($row[$field] ?? 0) <= 0) {
+                    return false;
+                }
+            }
+
+            if ($onlyCrisis && (int) ($row['crisis_alert_count'] ?? 0) <= 0) {
+                return false;
+            }
+            if ($onlyInvalid && (int) ($row['invalid_results_count'] ?? 0) <= 0) {
+                return false;
+            }
+            if ($onlyWarnings && (int) ($row['warnings_count'] ?? 0) <= 0) {
+                return false;
+            }
+
+            return true;
+        })->values();
+    }
+
+    /**
+     * @return list<array<string,mixed>>
+     */
+    private function buildQualityKpis(Collection $rows): array
+    {
+        $startedAttempts = (int) $rows->sum('started_attempts');
+        $completedAttempts = (int) $rows->sum('completed_attempts');
+        $resultsCount = (int) $rows->sum('results_count');
+        $validResults = (int) $rows->sum('valid_results_count');
+        $qualityA = (int) $rows->sum('quality_a_count');
+        $qualityB = (int) $rows->sum('quality_b_count');
+        $qualityC = (int) $rows->sum('quality_c_count');
+        $qualityD = (int) $rows->sum('quality_d_count');
+
+        return [
+            [
+                'label' => 'Sample size',
+                'display_value' => number_format($resultsCount),
+                'description' => 'Result-rooted count inside the current global scope.',
+            ],
+            [
+                'label' => 'Completion rate',
+                'display_value' => $this->formatRate($startedAttempts > 0 ? $completedAttempts / $startedAttempts : null),
+                'description' => 'Completed attempts divided by started attempts.',
+            ],
+            [
+                'label' => 'Validity pass rate',
+                'display_value' => $this->formatRate($resultsCount > 0 ? $validResults / $resultsCount : null),
+                'description' => 'Quality A/B share, with results.is_valid used only as fallback.',
+            ],
+            [
+                'label' => 'Quality A / B / C / D',
+                'display_value' => $this->qualityMixLabel($qualityA, $qualityB, $qualityC, $qualityD),
+                'description' => 'Stable quality.level buckets across the selected scope.',
+            ],
+            [
+                'label' => 'Crisis alerts',
+                'display_value' => number_format((int) $rows->sum('crisis_alert_count')),
+                'description' => 'Aggregate-only crisis signal count. No sensitive slice ranking in v1.',
+            ],
+            [
+                'label' => 'Longstring',
+                'display_value' => number_format((int) $rows->sum('longstring_count')),
+                'description' => 'Reference counter from stable quality flags when present.',
+            ],
+            [
+                'label' => 'Straightlining',
+                'display_value' => number_format((int) $rows->sum('straightlining_count')),
+                'description' => 'Reference counter from stable quality flags when present.',
+            ],
+            [
+                'label' => 'Extreme / Inconsistency',
+                'display_value' => number_format((int) $rows->sum('extreme_count')).' / '.number_format((int) $rows->sum('inconsistency_count')),
+                'description' => 'Subset-scale quality diagnostics. Keep as internal reference in v1.',
+            ],
+        ];
+    }
+
+    /**
+     * @return list<array<string,mixed>>
+     */
+    private function buildDailyQualityRows(Collection $rows): array
+    {
+        return $rows
+            ->groupBy('day')
+            ->map(function (Collection $group, string $day): array {
+                $started = (int) $group->sum('started_attempts');
+                $completed = (int) $group->sum('completed_attempts');
+                $results = (int) $group->sum('results_count');
+                $valid = (int) $group->sum('valid_results_count');
+
+                return [
+                    'day' => $day,
+                    'started_attempts' => $started,
+                    'completed_attempts' => $completed,
+                    'results_count' => $results,
+                    'completion_rate' => $started > 0 ? $completed / $started : null,
+                    'validity_rate' => $results > 0 ? $valid / $results : null,
+                    'quality_mix' => $this->qualityMixLabel(
+                        (int) $group->sum('quality_a_count'),
+                        (int) $group->sum('quality_b_count'),
+                        (int) $group->sum('quality_c_count'),
+                        (int) $group->sum('quality_d_count')
+                    ),
+                    'crisis_alert_count' => (int) $group->sum('crisis_alert_count'),
+                    'warnings_count' => (int) $group->sum('warnings_count'),
+                    'longstring_count' => (int) $group->sum('longstring_count'),
+                    'straightlining_count' => (int) $group->sum('straightlining_count'),
+                ];
+            })
+            ->sortKeys()
+            ->values()
+            ->all();
+    }
+
+    /**
+     * @return list<array<string,mixed>>
+     */
+    private function buildScaleQualityRows(Collection $rows): array
+    {
+        return $rows
+            ->groupBy('scale_code')
+            ->map(function (Collection $group, string $scaleCode): array {
+                $started = (int) $group->sum('started_attempts');
+                $completed = (int) $group->sum('completed_attempts');
+                $results = (int) $group->sum('results_count');
+                $valid = (int) $group->sum('valid_results_count');
+
+                return [
+                    'scale_code' => $scaleCode,
+                    'results_count' => $results,
+                    'completion_rate' => $started > 0 ? $completed / $started : null,
+                    'validity_rate' => $results > 0 ? $valid / $results : null,
+                    'quality_mix' => $this->qualityMixLabel(
+                        (int) $group->sum('quality_a_count'),
+                        (int) $group->sum('quality_b_count'),
+                        (int) $group->sum('quality_c_count'),
+                        (int) $group->sum('quality_d_count')
+                    ),
+                    'crisis_alert_count' => (int) $group->sum('crisis_alert_count'),
+                    'longstring_count' => (int) $group->sum('longstring_count'),
+                    'straightlining_count' => (int) $group->sum('straightlining_count'),
+                    'extreme_count' => (int) $group->sum('extreme_count'),
+                    'inconsistency_count' => (int) $group->sum('inconsistency_count'),
+                    'version_mix' => $this->versionMixSummary($group),
+                ];
+            })
+            ->sortByDesc('results_count')
+            ->values()
+            ->all();
+    }
+
+    /**
+     * @return list<array<string,mixed>>
+     */
+    private function buildQualityFlagRows(Collection $rows): array
+    {
+        $resultsCount = max(0, (int) $rows->sum('results_count'));
+        $definitions = [
+            'speeding_count' => ['label' => 'Speeding', 'reference' => 'Stable quality flag when present in result_json.'],
+            'longstring_count' => ['label' => 'Longstring', 'reference' => 'Reference counter; stable on subset scales only.'],
+            'straightlining_count' => ['label' => 'Straightlining', 'reference' => 'Reference counter; stable on subset scales only.'],
+            'extreme_count' => ['label' => 'Extreme responding', 'reference' => 'Reference counter; EQ60 / BIG5 / subset-scale semantics only.'],
+            'inconsistency_count' => ['label' => 'Inconsistency', 'reference' => 'Reference counter; subset-scale semantics only.'],
+            'warnings_count' => ['label' => 'Warnings surfaced', 'reference' => 'Includes stable flags and report warnings where available.'],
+        ];
+
+        $rowsOut = [];
+        foreach ($definitions as $field => $definition) {
+            $count = (int) $rows->sum($field);
+            $rowsOut[] = [
+                'label' => $definition['label'],
+                'count' => $count,
+                'rate' => $resultsCount > 0 ? $count / $resultsCount : null,
+                'reference' => $definition['reference'],
+            ];
+        }
+
+        return $rowsOut;
+    }
+
+    /**
+     * @return list<array<string,string>>
+     */
+    private function psychometricSourceDefinitions(): array
+    {
+        return [
+            ['table' => 'big5_psychometrics_reports', 'scale_code' => 'BIG5_OCEAN'],
+            ['table' => 'eq60_psychometrics_reports', 'scale_code' => 'EQ_60'],
+            ['table' => 'sds_psychometrics_reports', 'scale_code' => 'SDS_20'],
+        ];
+    }
+
+    /**
+     * @param  array<string,string>  $filters
+     */
+    private function applyPsychometricFilters(QueryBuilder $query, array $filters): void
+    {
+        if (($filters['scale_code'] ?? 'all') !== 'all') {
+            $query->where('scale_code', strtoupper((string) $filters['scale_code']));
+        }
+        if (($filters['locale'] ?? 'all') !== 'all') {
+            $query->where('locale', (string) $filters['locale']);
+        }
+        if (($filters['region'] ?? 'all') !== 'all') {
+            $query->where('region', (string) $filters['region']);
+        }
+        if (($filters['norm_version'] ?? 'all') !== 'all') {
+            $query->where('norms_version', (string) $filters['norm_version']);
+        }
+    }
+
+    private function psychometricSampleThreshold(string $scaleCode): int
+    {
+        return match (strtoupper(trim($scaleCode))) {
+            'EQ_60' => max(1, (int) config('eq60_norms.psychometrics.min_samples', 100)),
+            'SDS_20' => max(1, (int) config('sds_norms.psychometrics.min_samples', 100)),
+            default => max(1, (int) config('big5_norms.psychometrics.min_samples', 100)),
+        };
+    }
+
+    /**
+     * @param  array<string,mixed>  $metrics
+     * @return array{primary:string,secondary:string}
+     */
+    private function psychometricSummary(string $scaleCode, array $metrics): array
+    {
+        return match (strtoupper(trim($scaleCode))) {
+            'EQ_60' => [
+                'primary' => sprintf(
+                    'Global std %.2f +/- %.2f',
+                    (float) ($metrics['global_std_mean'] ?? 0.0),
+                    (float) ($metrics['global_std_sd'] ?? 0.0)
+                ),
+                'secondary' => sprintf(
+                    'Quality C+ %.1f%%',
+                    100 * (float) ($metrics['quality_c_or_worse_rate'] ?? 0.0)
+                ),
+            ],
+            'SDS_20' => [
+                'primary' => sprintf(
+                    'Index %.2f +/- %.2f',
+                    (float) ($metrics['index_score_mean'] ?? 0.0),
+                    (float) ($metrics['index_score_sd'] ?? 0.0)
+                ),
+                'secondary' => sprintf(
+                    'Crisis %.1f%%',
+                    100 * (float) ($metrics['crisis_rate'] ?? 0.0)
+                ),
+            ],
+            default => $this->big5PsychometricSummary($metrics),
+        };
+    }
+
+    /**
+     * @param  array<string,mixed>  $metrics
+     * @return array{primary:string,secondary:string}
+     */
+    private function big5PsychometricSummary(array $metrics): array
+    {
+        $domainAlpha = collect((array) ($metrics['domain_alpha'] ?? []))
+            ->filter(static fn ($value): bool => is_numeric($value))
+            ->map(static fn ($value): float => (float) $value)
+            ->values();
+
+        if ($domainAlpha->isEmpty()) {
+            return [
+                'primary' => 'Domain alpha n/a',
+                'secondary' => 'Facet/item-total correlation stored in metrics_json',
+            ];
+        }
+
+        return [
+            'primary' => sprintf(
+                'Domain alpha mean %.2f',
+                (float) round((float) $domainAlpha->avg(), 2)
+            ),
+            'secondary' => sprintf(
+                'Alpha range %.2f to %.2f',
+                (float) round((float) $domainAlpha->min(), 2),
+                (float) round((float) $domainAlpha->max(), 2)
+            ),
+        ];
+    }
+
+    /**
+     * @param  array<string,string>  $filters
+     * @param  list<string>  &$warnings
+     * @return list<array<string,mixed>>
+     */
+    private function normCoverageRows(array $filters, array &$warnings): array
+    {
+        if (! SchemaBaseline::hasTable('scale_norms_versions')) {
+            $warnings[] = 'scale_norms_versions is missing.';
+
+            return [];
+        }
+
+        $versionRows = $this->normVersionBaseQuery($filters)
+            ->where('is_active', 1)
+            ->get([
+                'id',
+                'scale_code',
+                'locale',
+                'region',
+                'version',
+                'group_id',
+                'status',
+                'published_at',
+                'updated_at',
+            ]);
+
+        if ($versionRows->isEmpty()) {
+            return [];
+        }
+
+        $sampleByVersion = $this->maxSampleByNormVersion($versionRows->pluck('id')->map(static fn ($id): string => (string) $id)->all());
+
+        return $versionRows
+            ->groupBy(fn (object $row): string => implode('|', [
+                strtoupper(trim((string) ($row->scale_code ?? 'UNKNOWN'))),
+                $this->stringOrUnknown($row->locale ?? null),
+                $this->stringOrUnknown($row->region ?? null),
+                trim((string) ($row->version ?? '')),
+            ]))
+            ->map(function (Collection $group, string $key) use ($sampleByVersion): array {
+                [$scaleCode, $locale, $region, $version] = explode('|', $key);
+                $sampleMax = 0;
+                foreach ($group as $row) {
+                    $sampleMax = max($sampleMax, (int) ($sampleByVersion[(string) ($row->id ?? '')] ?? 0));
+                }
+
+                return [
+                    'scale_code' => $scaleCode,
+                    'locale' => $locale,
+                    'region' => $region,
+                    'active_norm_version' => $version !== '' ? $version : 'unknown',
+                    'active_group_count' => $group->count(),
+                    'coverage_sample_n' => $sampleMax,
+                    'status_summary' => $group->pluck('status')->filter()->unique()->implode(', '),
+                    'latest_published_at' => $this->formatDateTime($group->max('published_at')),
+                    'latest_updated_at' => $this->formatDateTime($group->max('updated_at')),
+                ];
+            })
+            ->sortBy([
+                ['scale_code', 'asc'],
+                ['locale', 'asc'],
+                ['region', 'asc'],
+            ])
+            ->values()
+            ->all();
+    }
+
+    /**
+     * @param  list<string>  &$warnings
+     * @return list<array<string,mixed>>
+     */
+    private function rolloutRows(int $orgId, array $filters, array &$warnings): array
+    {
+        if (! SchemaBaseline::hasTable('scoring_models') || ! SchemaBaseline::hasTable('scoring_model_rollouts')) {
+            $warnings[] = 'scoring_models / scoring_model_rollouts are missing.';
+
+            return [];
+        }
+
+        $orgScope = $orgId > 0 ? [0, $orgId] : [0];
+        $models = DB::table('scoring_models')
+            ->whereIn('org_id', $orgScope)
+            ->when(($filters['scale_code'] ?? 'all') !== 'all', fn (QueryBuilder $query): QueryBuilder => $query->where('scale_code', strtoupper((string) $filters['scale_code'])))
+            ->get([
+                'id',
+                'org_id',
+                'scale_code',
+                'model_key',
+                'driver_type',
+                'scoring_spec_version',
+                'priority',
+                'is_active',
+            ]);
+
+        $rollouts = DB::table('scoring_model_rollouts')
+            ->whereIn('org_id', $orgScope)
+            ->when(($filters['scale_code'] ?? 'all') !== 'all', fn (QueryBuilder $query): QueryBuilder => $query->where('scale_code', strtoupper((string) $filters['scale_code'])))
+            ->orderBy('scale_code')
+            ->orderBy('priority')
+            ->get([
+                'id',
+                'org_id',
+                'scale_code',
+                'model_key',
+                'experiment_key',
+                'experiment_variant',
+                'rollout_percent',
+                'priority',
+                'is_active',
+                'starts_at',
+                'ends_at',
+                'created_at',
+            ]);
+
+        $resolvedModels = $this->resolvePreferredModels($models, $orgId);
+        $observation = $this->rolloutObservationCoverage($orgId, $filters);
+        $referencedModels = [];
+        $rows = [];
+
+        foreach ($rollouts as $rollout) {
+            $scaleCode = strtoupper(trim((string) ($rollout->scale_code ?? 'UNKNOWN')));
+            $modelKey = trim((string) ($rollout->model_key ?? ''));
+            $resolvedModel = $resolvedModels[$scaleCode.'|'.$modelKey] ?? null;
+            $rolloutId = trim((string) ($rollout->id ?? ''));
+            $observedCount = $rolloutId !== ''
+                ? (int) ($observation['by_rollout'][$rolloutId] ?? 0)
+                : (int) ($observation['by_scale_model'][$scaleCode.'|'.$modelKey] ?? 0);
+            $totalScaleResults = (int) ($observation['scale_totals'][$scaleCode] ?? 0);
+            $referencedModels[$scaleCode.'|'.$modelKey] = true;
+
+            $rows[] = [
+                'scale_code' => $scaleCode,
+                'model_key' => $modelKey !== '' ? $modelKey : 'unknown',
+                'driver_type' => strtolower(trim((string) ($resolvedModel->driver_type ?? 'default'))) ?: 'default',
+                'scoring_spec_version' => $this->stringOrUnknown($resolvedModel->scoring_spec_version ?? null),
+                'rollout_rule' => $this->rolloutRuleLabel($rollout),
+                'config_state' => $this->rolloutStateLabel($rollout),
+                'priority' => max(0, (int) ($rollout->priority ?? 0)),
+                'observation_results' => $observedCount,
+                'observation_share' => $totalScaleResults > 0 ? $observedCount / $totalScaleResults : null,
+                'observation_summary' => $totalScaleResults > 0
+                    ? sprintf('%d of %d scoped results', $observedCount, $totalScaleResults)
+                    : 'No scoped observations yet',
+            ];
+        }
+
+        foreach ($resolvedModels as $key => $model) {
+            if (isset($referencedModels[$key])) {
+                continue;
+            }
+
+            $scaleCode = strtoupper(trim((string) ($model->scale_code ?? 'UNKNOWN')));
+            $modelKey = trim((string) ($model->model_key ?? ''));
+            $observedCount = (int) ($observation['by_scale_model'][$scaleCode.'|'.$modelKey] ?? 0);
+            $totalScaleResults = (int) ($observation['scale_totals'][$scaleCode] ?? 0);
+
+            $rows[] = [
+                'scale_code' => $scaleCode,
+                'model_key' => $modelKey !== '' ? $modelKey : 'unknown',
+                'driver_type' => strtolower(trim((string) ($model->driver_type ?? 'default'))) ?: 'default',
+                'scoring_spec_version' => $this->stringOrUnknown($model->scoring_spec_version ?? null),
+                'rollout_rule' => 'No explicit rollout rule',
+                'config_state' => ((int) ($model->is_active ?? 0) === 1) ? 'model-only' : 'inactive-model',
+                'priority' => max(0, (int) ($model->priority ?? 0)),
+                'observation_results' => $observedCount,
+                'observation_share' => $totalScaleResults > 0 ? $observedCount / $totalScaleResults : null,
+                'observation_summary' => $totalScaleResults > 0
+                    ? sprintf('%d of %d scoped results', $observedCount, $totalScaleResults)
+                    : 'No scoped observations yet',
+            ];
+        }
+
+        usort($rows, static function (array $a, array $b): int {
+            $scaleCompare = strcmp((string) $a['scale_code'], (string) $b['scale_code']);
+            if ($scaleCompare !== 0) {
+                return $scaleCompare;
+            }
+
+            $priorityCompare = ((int) $a['priority']) <=> ((int) $b['priority']);
+            if ($priorityCompare !== 0) {
+                return $priorityCompare;
+            }
+
+            return strcmp((string) $a['model_key'], (string) $b['model_key']);
+        });
+
+        return $rows;
+    }
+
+    /**
+     * @param  list<string>  &$warnings
+     * @return list<array<string,mixed>>
+     */
+    private function driftCompareRows(array $filters, array &$warnings): array
+    {
+        if (! SchemaBaseline::hasTable('scale_norms_versions') || ! SchemaBaseline::hasTable('scale_norm_stats')) {
+            $warnings[] = 'scale_norms_versions / scale_norm_stats are required for drift compare.';
+
+            return [];
+        }
+
+        $versionRows = $this->normVersionBaseQuery($filters)
+            ->orderBy('scale_code')
+            ->orderBy('locale')
+            ->orderBy('region')
+            ->orderByDesc('is_active')
+            ->orderByDesc('published_at')
+            ->orderByDesc('created_at')
+            ->get([
+                'id',
+                'scale_code',
+                'locale',
+                'region',
+                'version',
+                'group_id',
+                'is_active',
+                'published_at',
+                'created_at',
+            ]);
+
+        if ($versionRows->isEmpty()) {
+            return [];
+        }
+
+        $statsCache = [];
+        $rows = [];
+
+        foreach ($versionRows->groupBy(fn (object $row): string => implode('|', [
+            strtoupper(trim((string) ($row->scale_code ?? 'UNKNOWN'))),
+            $this->stringOrUnknown($row->locale ?? null),
+            $this->stringOrUnknown($row->region ?? null),
+        ])) as $groupKey => $group) {
+            $activeVersion = $this->selectActiveNormVersion($group, $filters);
+            if ($activeVersion === null) {
+                continue;
+            }
+
+            $previousVersion = $this->selectPreviousNormVersion($group, $activeVersion);
+            if ($previousVersion === null) {
+                continue;
+            }
+
+            $activeRows = $group->where('version', $activeVersion)->values();
+            $previousRows = $group->where('version', $previousVersion)->values();
+            $activeByGroup = $activeRows->keyBy(fn (object $row): string => (string) ($row->group_id ?? ''));
+            $previousByGroup = $previousRows->keyBy(fn (object $row): string => (string) ($row->group_id ?? ''));
+            $commonGroups = array_values(array_intersect($activeByGroup->keys()->all(), $previousByGroup->keys()->all()));
+            sort($commonGroups);
+
+            $comparedMetrics = 0;
+            $maxMeanDiff = 0.0;
+            $maxSdDiff = 0.0;
+
+            foreach ($commonGroups as $groupId) {
+                $activeId = (string) ($activeByGroup[$groupId]->id ?? '');
+                $previousId = (string) ($previousByGroup[$groupId]->id ?? '');
+                $activeStats = $statsCache[$activeId] ??= $this->normStatsByVersion($activeId);
+                $previousStats = $statsCache[$previousId] ??= $this->normStatsByVersion($previousId);
+                $commonMetrics = array_intersect(array_keys($activeStats), array_keys($previousStats));
+
+                foreach ($commonMetrics as $metricKey) {
+                    $comparedMetrics++;
+                    $maxMeanDiff = max(
+                        $maxMeanDiff,
+                        abs((float) ($activeStats[$metricKey]['mean'] ?? 0.0) - (float) ($previousStats[$metricKey]['mean'] ?? 0.0))
+                    );
+                    $maxSdDiff = max(
+                        $maxSdDiff,
+                        abs((float) ($activeStats[$metricKey]['sd'] ?? 0.0) - (float) ($previousStats[$metricKey]['sd'] ?? 0.0))
+                    );
+                }
+            }
+
+            if ($comparedMetrics <= 0) {
+                continue;
+            }
+
+            [$scaleCode, $locale, $region] = explode('|', $groupKey);
+            $rows[] = [
+                'scale_code' => $scaleCode,
+                'locale' => $locale,
+                'region' => $region,
+                'active_norm_version' => $activeVersion,
+                'previous_norm_version' => $previousVersion,
+                'compared_groups' => count($commonGroups),
+                'compared_metrics' => $comparedMetrics,
+                'max_mean_diff' => round($maxMeanDiff, 4),
+                'max_sd_diff' => round($maxSdDiff, 4),
+                'reference_state' => 'Internal compare reference',
+            ];
+        }
+
+        return $rows;
+    }
+
+    /**
+     * @param  array<string,string>  $filters
+     */
+    private function normVersionBaseQuery(array $filters): QueryBuilder
+    {
+        $query = DB::table('scale_norms_versions');
+
+        if (($filters['scale_code'] ?? 'all') !== 'all') {
+            $query->where('scale_code', strtoupper((string) $filters['scale_code']));
+        }
+        if (($filters['locale'] ?? 'all') !== 'all') {
+            $query->where('locale', (string) $filters['locale']);
+        }
+        if (($filters['region'] ?? 'all') !== 'all') {
+            $query->where('region', (string) $filters['region']);
+        }
+        if (($filters['norm_version'] ?? 'all') !== 'all') {
+            $query->where('version', (string) $filters['norm_version']);
+        }
+
+        return $query;
+    }
+
+    /**
+     * @param  list<string>  $versionIds
+     * @return array<string,int>
+     */
+    private function maxSampleByNormVersion(array $versionIds): array
+    {
+        if ($versionIds === [] || ! SchemaBaseline::hasTable('scale_norm_stats')) {
+            return [];
+        }
+
+        return DB::table('scale_norm_stats')
+            ->whereIn('norm_version_id', $versionIds)
+            ->selectRaw('norm_version_id, MAX(sample_n) AS sample_n_max')
+            ->groupBy('norm_version_id')
+            ->pluck('sample_n_max', 'norm_version_id')
+            ->map(static fn ($value): int => (int) $value)
+            ->all();
+    }
+
+    /**
+     * @param  Collection<int,object>  $models
+     * @return array<string,object>
+     */
+    private function resolvePreferredModels(Collection $models, int $orgId): array
+    {
+        $resolved = [];
+
+        foreach ($models->groupBy(fn (object $row): string => strtoupper(trim((string) ($row->scale_code ?? 'UNKNOWN'))).'|'.trim((string) ($row->model_key ?? ''))) as $key => $group) {
+            $resolved[$key] = $group
+                ->sort(function (object $a, object $b) use ($orgId): int {
+                    $aOrgRank = ((int) ($a->org_id ?? 0) === $orgId) ? 0 : 1;
+                    $bOrgRank = ((int) ($b->org_id ?? 0) === $orgId) ? 0 : 1;
+                    if ($aOrgRank !== $bOrgRank) {
+                        return $aOrgRank <=> $bOrgRank;
+                    }
+
+                    $aPriority = (int) ($a->priority ?? 100);
+                    $bPriority = (int) ($b->priority ?? 100);
+                    if ($aPriority !== $bPriority) {
+                        return $aPriority <=> $bPriority;
+                    }
+
+                    return strcmp((string) ($a->id ?? ''), (string) ($b->id ?? ''));
+                })
+                ->first();
+        }
+
+        return $resolved;
+    }
+
+    /**
+     * @param  array<string,string>  $filters
+     * @return array{
+     *   scale_totals:array<string,int>,
+     *   by_rollout:array<string,int>,
+     *   by_scale_model:array<string,int>
+     * }
+     */
+    private function rolloutObservationCoverage(int $orgId, array $filters): array
+    {
+        if (! SchemaBaseline::hasTable('attempts') || ! SchemaBaseline::hasTable('results')) {
+            return [
+                'scale_totals' => [],
+                'by_rollout' => [],
+                'by_scale_model' => [],
+            ];
+        }
+
+        [$from, $to] = $this->resolvedRange($filters);
+
+        $query = DB::table('results')
+            ->join('attempts', 'attempts.id', '=', 'results.attempt_id')
+            ->where('attempts.org_id', $orgId)
+            ->whereNotNull('attempts.submitted_at')
+            ->whereBetween('attempts.submitted_at', [$from->toDateTimeString(), $to->endOfDay()->toDateTimeString()])
+            ->select([
+                'attempts.scale_code',
+                'attempts.locale',
+                'attempts.region',
+                'attempts.content_package_version',
+                'attempts.scoring_spec_version',
+                'attempts.norm_version',
+                'results.result_json',
+            ]);
+
+        if (($filters['scale_code'] ?? 'all') !== 'all') {
+            $query->where('attempts.scale_code', strtoupper((string) $filters['scale_code']));
+        }
+        if (($filters['locale'] ?? 'all') !== 'all') {
+            $query->where('attempts.locale', (string) $filters['locale']);
+        }
+        if (($filters['region'] ?? 'all') !== 'all') {
+            $query->where('attempts.region', (string) $filters['region']);
+        }
+        if (($filters['content_package_version'] ?? 'all') !== 'all') {
+            $query->where('attempts.content_package_version', (string) $filters['content_package_version']);
+        }
+        if (($filters['scoring_spec_version'] ?? 'all') !== 'all') {
+            $query->where('attempts.scoring_spec_version', (string) $filters['scoring_spec_version']);
+        }
+        if (($filters['norm_version'] ?? 'all') !== 'all') {
+            $query->where('attempts.norm_version', (string) $filters['norm_version']);
+        }
+
+        $scaleTotals = [];
+        $byRollout = [];
+        $byScaleModel = [];
+
+        foreach ($query->cursor() as $row) {
+            $scaleCode = strtoupper(trim((string) ($row->scale_code ?? 'UNKNOWN')));
+            $scaleTotals[$scaleCode] = (int) ($scaleTotals[$scaleCode] ?? 0) + 1;
+
+            $payload = $this->decodeJson($row->result_json ?? null);
+            $selection = is_array($payload['model_selection'] ?? null) ? $payload['model_selection'] : [];
+            $modelKey = trim((string) ($selection['model_key'] ?? ''));
+            $rolloutId = trim((string) ($selection['rollout_id'] ?? ''));
+
+            if ($rolloutId !== '') {
+                $byRollout[$rolloutId] = (int) ($byRollout[$rolloutId] ?? 0) + 1;
+            }
+            if ($modelKey !== '') {
+                $compound = $scaleCode.'|'.$modelKey;
+                $byScaleModel[$compound] = (int) ($byScaleModel[$compound] ?? 0) + 1;
+            }
+        }
+
+        return [
+            'scale_totals' => $scaleTotals,
+            'by_rollout' => $byRollout,
+            'by_scale_model' => $byScaleModel,
+        ];
+    }
+
+    private function rolloutRuleLabel(object $rollout): string
+    {
+        $experimentKey = trim((string) ($rollout->experiment_key ?? ''));
+        $experimentVariant = trim((string) ($rollout->experiment_variant ?? ''));
+        $rolloutPercent = max(0, (int) ($rollout->rollout_percent ?? 0));
+
+        if ($experimentKey === '') {
+            return sprintf('Percent-only %d%%', $rolloutPercent);
+        }
+
+        if ($experimentVariant === '') {
+            return sprintf('%s @ %d%%', $experimentKey, $rolloutPercent);
+        }
+
+        return sprintf('%s:%s @ %d%%', $experimentKey, $experimentVariant, $rolloutPercent);
+    }
+
+    private function rolloutStateLabel(object $rollout): string
+    {
+        if ((int) ($rollout->is_active ?? 0) !== 1) {
+            return 'inactive';
+        }
+
+        $now = now();
+        $startsAt = $this->normalizeCarbon($rollout->starts_at ?? null);
+        $endsAt = $this->normalizeCarbon($rollout->ends_at ?? null);
+
+        if ($startsAt !== null && $startsAt->greaterThan($now)) {
+            return 'scheduled';
+        }
+        if ($endsAt !== null && $endsAt->lessThan($now)) {
+            return 'expired';
+        }
+
+        return 'active';
+    }
+
+    /**
+     * @param  Collection<int,object>  $group
+     * @param  array<string,string>  $filters
+     */
+    private function selectActiveNormVersion(Collection $group, array $filters): ?string
+    {
+        $selectedVersion = trim((string) ($filters['norm_version'] ?? ''));
+        if ($selectedVersion !== '' && strtolower($selectedVersion) !== 'all') {
+            $exact = $group->first(static fn (object $row): bool => trim((string) ($row->version ?? '')) === $selectedVersion);
+
+            return $exact ? trim((string) ($exact->version ?? '')) : null;
+        }
+
+        $active = $group->first(static fn (object $row): bool => (int) ($row->is_active ?? 0) === 1);
+        if ($active) {
+            return trim((string) ($active->version ?? ''));
+        }
+
+        $latest = $group->first();
+
+        return $latest ? trim((string) ($latest->version ?? '')) : null;
+    }
+
+    /**
+     * @param  Collection<int,object>  $group
+     */
+    private function selectPreviousNormVersion(Collection $group, string $activeVersion): ?string
+    {
+        return $group
+            ->filter(static fn (object $row): bool => trim((string) ($row->version ?? '')) !== $activeVersion)
+            ->pluck('version')
+            ->map(static fn ($value): string => trim((string) $value))
+            ->filter(static fn (string $value): bool => $value !== '')
+            ->unique()
+            ->values()
+            ->first();
+    }
+
+    /**
+     * @return array<string,array{mean:float,sd:float}>
+     */
+    private function normStatsByVersion(string $versionId): array
+    {
+        if ($versionId === '' || ! SchemaBaseline::hasTable('scale_norm_stats')) {
+            return [];
+        }
+
+        return DB::table('scale_norm_stats')
+            ->where('norm_version_id', $versionId)
+            ->get(['metric_level', 'metric_code', 'mean', 'sd'])
+            ->mapWithKeys(static function (object $row): array {
+                $metricLevel = strtolower(trim((string) ($row->metric_level ?? '')));
+                $metricCode = strtoupper(trim((string) ($row->metric_code ?? '')));
+                if ($metricLevel === '' || $metricCode === '') {
+                    return [];
+                }
+
+                return [
+                    $metricLevel.':'.$metricCode => [
+                        'mean' => (float) ($row->mean ?? 0.0),
+                        'sd' => (float) ($row->sd ?? 0.0),
+                    ],
+                ];
+            })
+            ->all();
+    }
+
+    private function qualityMixLabel(int $a, int $b, int $c, int $d): string
+    {
+        $total = max(0, $a + $b + $c + $d);
+        if ($total <= 0) {
+            return 'n/a';
+        }
+
+        return sprintf(
+            'A %s · B %s · C %s · D %s',
+            $this->formatRate($a / $total),
+            $this->formatRate($b / $total),
+            $this->formatRate($c / $total),
+            $this->formatRate($d / $total)
+        );
+    }
+
+    private function versionMixSummary(Collection $rows): string
+    {
+        $top = $rows
+            ->groupBy(fn (array $row): string => implode(' / ', [
+                (string) $row['content_package_version'],
+                (string) $row['scoring_spec_version'],
+                (string) $row['norm_version'],
+            ]))
+            ->map(static fn (Collection $group): int => (int) $group->sum('results_count'))
+            ->sortDesc()
+            ->keys()
+            ->first();
+
+        return is_string($top) && trim($top) !== '' ? $top : 'n/a';
+    }
+
+    /**
+     * @param  array<string,string>  $filters
+     * @return array{0:CarbonImmutable,1:CarbonImmutable}
+     */
+    private function resolvedRange(array $filters): array
+    {
+        $from = CarbonImmutable::parse(($filters['from'] ?? '') !== '' ? (string) $filters['from'] : now()->subDays(13)->toDateString())->startOfDay();
+        $to = CarbonImmutable::parse(($filters['to'] ?? '') !== '' ? (string) $filters['to'] : now()->toDateString())->startOfDay();
+
+        return [$from, $to];
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    private function decodeJson(mixed $raw): array
+    {
+        if (is_array($raw)) {
+            return $raw;
+        }
+
+        if (! is_string($raw) || trim($raw) === '') {
+            return [];
+        }
+
+        $decoded = json_decode($raw, true);
+
+        return is_array($decoded) ? $decoded : [];
+    }
+
+    private function stringOrUnknown(mixed $value): string
+    {
+        $normalized = trim((string) $value);
+
+        return $normalized !== '' ? $normalized : 'unknown';
+    }
+
+    private function formatRate(?float $value): string
+    {
+        if ($value === null) {
+            return 'n/a';
+        }
+
+        return number_format($value * 100, 1).'%';
+    }
+
+    private function formatDateTime(mixed $value): string
+    {
+        $date = $this->normalizeCarbon($value);
+
+        return $date?->format('Y-m-d H:i') ?? 'n/a';
+    }
+
+    private function normalizeCarbon(mixed $value): ?CarbonImmutable
+    {
+        if ($value instanceof \DateTimeInterface) {
+            return CarbonImmutable::instance(\DateTimeImmutable::createFromInterface($value));
+        }
+
+        $raw = trim((string) $value);
+        if ($raw === '') {
+            return null;
+        }
+
+        try {
+            return CarbonImmutable::parse($raw);
+        } catch (\Throwable) {
+            return null;
+        }
+    }
+}

--- a/backend/app/Services/Analytics/QualitySignalExtractor.php
+++ b/backend/app/Services/Analytics/QualitySignalExtractor.php
@@ -1,0 +1,161 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\Analytics;
+
+final class QualitySignalExtractor
+{
+    /**
+     * @return array{
+     *   level:string,
+     *   flags:list<string>,
+     *   crisis_alert:bool,
+     *   validity_bucket:string,
+     *   has_warning_signal:bool
+     * }
+     */
+    public function extract(mixed $resultJson, mixed $attemptSnapshot = null, mixed $resultIsValid = null): array
+    {
+        $payload = $this->decode($resultJson);
+        $snapshot = $this->decode($attemptSnapshot);
+        $quality = $this->extractQualityNode($payload, $snapshot);
+
+        $level = strtoupper(trim((string) ($quality['level'] ?? '')));
+        $flags = $this->normalizeFlags((array) ($quality['flags'] ?? []));
+        $warnings = $this->normalizeWarnings($payload);
+        $crisisAlert = (bool) ($quality['crisis_alert'] ?? false);
+
+        $validityBucket = 'unknown';
+        if (in_array($level, ['A', 'B'], true)) {
+            $validityBucket = 'valid';
+        } elseif (in_array($level, ['C', 'D'], true)) {
+            $validityBucket = 'invalid';
+        } else {
+            $normalizedIsValid = $this->normalizeBool($resultIsValid);
+            if ($normalizedIsValid === true) {
+                $validityBucket = 'valid';
+            } elseif ($normalizedIsValid === false) {
+                $validityBucket = 'invalid';
+            }
+        }
+
+        return [
+            'level' => $level,
+            'flags' => $flags,
+            'crisis_alert' => $crisisAlert,
+            'validity_bucket' => $validityBucket,
+            'has_warning_signal' => $flags !== [] || $warnings !== [],
+        ];
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    private function extractQualityNode(array $payload, array $snapshot): array
+    {
+        $candidates = [
+            $payload['quality'] ?? null,
+            $payload['normed_json']['quality'] ?? null,
+            $snapshot['quality'] ?? null,
+            $snapshot['eq_60']['quality'] ?? null,
+            $snapshot['sds_20']['quality'] ?? null,
+            $snapshot['clinical_combo_68']['quality'] ?? null,
+        ];
+
+        foreach ($candidates as $candidate) {
+            if (is_array($candidate)) {
+                return $candidate;
+            }
+        }
+
+        return [];
+    }
+
+    /**
+     * @param  array<int,mixed>  $flags
+     * @return list<string>
+     */
+    private function normalizeFlags(array $flags): array
+    {
+        $normalized = [];
+        foreach ($flags as $flag) {
+            $value = strtoupper(trim((string) $flag));
+            if ($value === '') {
+                continue;
+            }
+            $normalized[$value] = true;
+        }
+
+        return array_keys($normalized);
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function normalizeWarnings(array $payload): array
+    {
+        $warnings = $payload['warnings'] ?? null;
+        if (! is_array($warnings)) {
+            $warnings = data_get($payload, 'report.warnings');
+        }
+        if (! is_array($warnings)) {
+            return [];
+        }
+
+        $normalized = [];
+        foreach ($warnings as $warning) {
+            $value = trim((string) (is_array($warning) ? ($warning['code'] ?? $warning['kind'] ?? $warning['title'] ?? '') : $warning));
+            if ($value === '') {
+                $value = 'warning';
+            }
+            $normalized[$value] = true;
+        }
+
+        return array_keys($normalized);
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    private function decode(mixed $raw): array
+    {
+        if (is_array($raw)) {
+            return $raw;
+        }
+
+        if (! is_string($raw) || trim($raw) === '') {
+            return [];
+        }
+
+        $decoded = json_decode($raw, true);
+
+        return is_array($decoded) ? $decoded : [];
+    }
+
+    private function normalizeBool(mixed $value): ?bool
+    {
+        if (is_bool($value)) {
+            return $value;
+        }
+        if (is_numeric($value)) {
+            return ((int) $value) !== 0;
+        }
+        if (! is_string($value)) {
+            return null;
+        }
+
+        $normalized = strtolower(trim($value));
+        if ($normalized === '') {
+            return null;
+        }
+        if (in_array($normalized, ['1', 'true', 'yes'], true)) {
+            return true;
+        }
+        if (in_array($normalized, ['0', 'false', 'no'], true)) {
+            return false;
+        }
+
+        return null;
+    }
+}

--- a/backend/database/migrations/2026_03_15_090000_create_analytics_scale_quality_daily_table.php
+++ b/backend/database/migrations/2026_03_15_090000_create_analytics_scale_quality_daily_table.php
@@ -1,0 +1,190 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Support\Database\SchemaIndex;
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    private const TABLE = 'analytics_scale_quality_daily';
+
+    public function up(): void
+    {
+        if (! Schema::hasTable(self::TABLE)) {
+            Schema::create(self::TABLE, function (Blueprint $table): void {
+                $table->date('day');
+                $table->unsignedBigInteger('org_id')->default(0);
+                $table->string('scale_code', 64)->default('unknown');
+                $table->string('locale', 16)->default('unknown');
+                $table->string('region', 32)->default('unknown');
+                $table->string('content_package_version', 128)->default('unknown');
+                $table->string('scoring_spec_version', 64)->default('unknown');
+                $table->string('norm_version', 64)->default('unknown');
+
+                $table->unsignedInteger('started_attempts')->default(0);
+                $table->unsignedInteger('completed_attempts')->default(0);
+                $table->unsignedInteger('results_count')->default(0);
+                $table->unsignedInteger('valid_results_count')->default(0);
+                $table->unsignedInteger('invalid_results_count')->default(0);
+                $table->unsignedInteger('quality_a_count')->default(0);
+                $table->unsignedInteger('quality_b_count')->default(0);
+                $table->unsignedInteger('quality_c_count')->default(0);
+                $table->unsignedInteger('quality_d_count')->default(0);
+                $table->unsignedInteger('crisis_alert_count')->default(0);
+                $table->unsignedInteger('speeding_count')->default(0);
+                $table->unsignedInteger('longstring_count')->default(0);
+                $table->unsignedInteger('straightlining_count')->default(0);
+                $table->unsignedInteger('extreme_count')->default(0);
+                $table->unsignedInteger('inconsistency_count')->default(0);
+                $table->unsignedInteger('warnings_count')->default(0);
+
+                $table->timestamp('last_refreshed_at')->nullable();
+                $table->timestamps();
+            });
+        } else {
+            Schema::table(self::TABLE, function (Blueprint $table): void {
+                if (! Schema::hasColumn(self::TABLE, 'day')) {
+                    $table->date('day')->nullable();
+                }
+                if (! Schema::hasColumn(self::TABLE, 'org_id')) {
+                    $table->unsignedBigInteger('org_id')->default(0);
+                }
+                if (! Schema::hasColumn(self::TABLE, 'scale_code')) {
+                    $table->string('scale_code', 64)->default('unknown');
+                }
+                if (! Schema::hasColumn(self::TABLE, 'locale')) {
+                    $table->string('locale', 16)->default('unknown');
+                }
+                if (! Schema::hasColumn(self::TABLE, 'region')) {
+                    $table->string('region', 32)->default('unknown');
+                }
+                if (! Schema::hasColumn(self::TABLE, 'content_package_version')) {
+                    $table->string('content_package_version', 128)->default('unknown');
+                }
+                if (! Schema::hasColumn(self::TABLE, 'scoring_spec_version')) {
+                    $table->string('scoring_spec_version', 64)->default('unknown');
+                }
+                if (! Schema::hasColumn(self::TABLE, 'norm_version')) {
+                    $table->string('norm_version', 64)->default('unknown');
+                }
+                if (! Schema::hasColumn(self::TABLE, 'started_attempts')) {
+                    $table->unsignedInteger('started_attempts')->default(0);
+                }
+                if (! Schema::hasColumn(self::TABLE, 'completed_attempts')) {
+                    $table->unsignedInteger('completed_attempts')->default(0);
+                }
+                if (! Schema::hasColumn(self::TABLE, 'results_count')) {
+                    $table->unsignedInteger('results_count')->default(0);
+                }
+                if (! Schema::hasColumn(self::TABLE, 'valid_results_count')) {
+                    $table->unsignedInteger('valid_results_count')->default(0);
+                }
+                if (! Schema::hasColumn(self::TABLE, 'invalid_results_count')) {
+                    $table->unsignedInteger('invalid_results_count')->default(0);
+                }
+                if (! Schema::hasColumn(self::TABLE, 'quality_a_count')) {
+                    $table->unsignedInteger('quality_a_count')->default(0);
+                }
+                if (! Schema::hasColumn(self::TABLE, 'quality_b_count')) {
+                    $table->unsignedInteger('quality_b_count')->default(0);
+                }
+                if (! Schema::hasColumn(self::TABLE, 'quality_c_count')) {
+                    $table->unsignedInteger('quality_c_count')->default(0);
+                }
+                if (! Schema::hasColumn(self::TABLE, 'quality_d_count')) {
+                    $table->unsignedInteger('quality_d_count')->default(0);
+                }
+                if (! Schema::hasColumn(self::TABLE, 'crisis_alert_count')) {
+                    $table->unsignedInteger('crisis_alert_count')->default(0);
+                }
+                if (! Schema::hasColumn(self::TABLE, 'speeding_count')) {
+                    $table->unsignedInteger('speeding_count')->default(0);
+                }
+                if (! Schema::hasColumn(self::TABLE, 'longstring_count')) {
+                    $table->unsignedInteger('longstring_count')->default(0);
+                }
+                if (! Schema::hasColumn(self::TABLE, 'straightlining_count')) {
+                    $table->unsignedInteger('straightlining_count')->default(0);
+                }
+                if (! Schema::hasColumn(self::TABLE, 'extreme_count')) {
+                    $table->unsignedInteger('extreme_count')->default(0);
+                }
+                if (! Schema::hasColumn(self::TABLE, 'inconsistency_count')) {
+                    $table->unsignedInteger('inconsistency_count')->default(0);
+                }
+                if (! Schema::hasColumn(self::TABLE, 'warnings_count')) {
+                    $table->unsignedInteger('warnings_count')->default(0);
+                }
+                if (! Schema::hasColumn(self::TABLE, 'last_refreshed_at')) {
+                    $table->timestamp('last_refreshed_at')->nullable();
+                }
+                if (! Schema::hasColumn(self::TABLE, 'created_at')) {
+                    $table->timestamp('created_at')->nullable();
+                }
+                if (! Schema::hasColumn(self::TABLE, 'updated_at')) {
+                    $table->timestamp('updated_at')->nullable();
+                }
+            });
+        }
+
+        $this->ensureUnique(
+            [
+                'day',
+                'org_id',
+                'scale_code',
+                'locale',
+                'region',
+                'content_package_version',
+                'scoring_spec_version',
+                'norm_version',
+            ],
+            'analytics_scale_quality_daily_scope_unique'
+        );
+        $this->ensureIndex(['org_id', 'day'], 'analytics_scale_quality_daily_org_day_idx');
+        $this->ensureIndex(
+            ['org_id', 'scale_code', 'locale', 'day'],
+            'analytics_scale_quality_daily_org_scale_locale_day_idx'
+        );
+        $this->ensureIndex(
+            ['org_id', 'content_package_version', 'scoring_spec_version', 'norm_version'],
+            'analytics_scale_quality_daily_version_scope_idx'
+        );
+    }
+
+    public function down(): void
+    {
+        // forward-only migration: rollback disabled to prevent data loss in production.
+        // Irreversible operation: schema/data rollback handled via forward fix migrations.
+    }
+
+    /**
+     * @param  array<int,string>  $columns
+     */
+    private function ensureUnique(array $columns, string $indexName): void
+    {
+        if (! Schema::hasTable(self::TABLE) || SchemaIndex::indexExists(self::TABLE, $indexName)) {
+            return;
+        }
+
+        Schema::table(self::TABLE, function (Blueprint $table) use ($columns, $indexName): void {
+            $table->unique($columns, $indexName);
+        });
+    }
+
+    /**
+     * @param  array<int,string>  $columns
+     */
+    private function ensureIndex(array $columns, string $indexName): void
+    {
+        if (! Schema::hasTable(self::TABLE) || SchemaIndex::indexExists(self::TABLE, $indexName)) {
+            return;
+        }
+
+        Schema::table(self::TABLE, function (Blueprint $table) use ($columns, $indexName): void {
+            $table->index($columns, $indexName);
+        });
+    }
+};

--- a/backend/docs/ops/quality-psychometrics-norms-drift.md
+++ b/backend/docs/ops/quality-psychometrics-norms-drift.md
@@ -1,0 +1,68 @@
+# Quality / Psychometrics / Norms & Drift
+
+## First-phase scope
+
+- AIC-08 is an internal-only Assessment Insights page.
+- The page keeps one shell with three tabs:
+  - `Quality`
+  - `Psychometrics`
+  - `Norms & Drift`
+- It does not change write-side behavior, frontend behavior, or scoring router behavior.
+
+## Quality tab fact model
+
+- Daily summary authority comes from `analytics_scale_quality_daily`.
+- Per-record drill-through stays in existing `Attempts Explorer` and `Results Explorer`.
+- `attempt_quality` remains legacy / supplemental only and is not the cross-scale authority table for this page.
+
+## `analytics_scale_quality_daily`
+
+- Purpose: add the missing locale / region / content / scoring / norm version dimensions on top of first-phase quality daily aggregation.
+- Source spine:
+  - started / completed attempts from `attempts`
+  - result-rooted quality from `results.result_json`
+  - fallback validity only when `quality.level` is missing
+- Stable first-phase counters:
+  - started / completed / results
+  - valid / invalid
+  - quality A / B / C / D
+  - crisis alerts
+  - longstring / straightlining / extreme / inconsistency / warnings only when these signals are already stable in current payloads
+
+## Psychometrics tab boundary
+
+- Reads existing psychometrics snapshot tables directly:
+  - `big5_psychometrics_reports`
+  - `eq60_psychometrics_reports`
+  - `sds_psychometrics_reports`
+- These rows are `internal reference` by default.
+- Small-sample rows stay reference-only and should not be treated as hard product truth.
+- First-phase display thresholds reuse existing command/config defaults where available.
+
+## Norms & Drift tab boundary
+
+- Hard coverage view:
+  - `scale_norms_versions`
+  - `scale_norm_stats`
+- Rollout diagnostics:
+  - `scoring_models`
+  - `scoring_model_rollouts`
+  - observation coverage from scoped `results.result_json.model_selection`
+- Drift stays a latest-vs-previous compare reference only in v1.
+- No dedicated drift materialized table is added in this phase.
+
+## Sensitive-data boundary
+
+- Do not expose by default:
+  - raw answer payload
+  - raw quality checks JSON
+  - internal scoring traces
+  - rollout internal payload dumps
+- Crisis / clinical data stays aggregate-only in v1.
+- Tiny sample psychometric summaries and tiny locale/version norm compares should not be presented as hard authority metrics.
+
+## Likely next extensions
+
+- tighter drill-through presets into Attempts / Results explorers
+- command-linked drift comparison affordances when a tab row needs deeper offline verification
+- broader psychometric comparison views after sample governance and threshold rules are hardened further

--- a/backend/resources/views/filament/ops/pages/quality-research-page.blade.php
+++ b/backend/resources/views/filament/ops/pages/quality-research-page.blade.php
@@ -1,0 +1,527 @@
+<x-filament-panels::page>
+    <div class="space-y-6">
+        <form wire:submit.prevent="applyFilters" class="rounded-2xl border border-slate-200 bg-white/95 p-5 shadow-sm">
+            <div class="grid gap-4 xl:grid-cols-[repeat(8,minmax(0,1fr))_auto]">
+                <label class="space-y-2">
+                    <span class="text-xs font-semibold uppercase tracking-[0.16em] text-slate-500">From</span>
+                    <input type="date" wire:model.defer="fromDate" class="block w-full rounded-xl border-slate-300 text-sm shadow-sm" />
+                </label>
+
+                <label class="space-y-2">
+                    <span class="text-xs font-semibold uppercase tracking-[0.16em] text-slate-500">To</span>
+                    <input type="date" wire:model.defer="toDate" class="block w-full rounded-xl border-slate-300 text-sm shadow-sm" />
+                </label>
+
+                <label class="space-y-2">
+                    <span class="text-xs font-semibold uppercase tracking-[0.16em] text-slate-500">Scale</span>
+                    <select wire:model.defer="scaleCode" class="block w-full rounded-xl border-slate-300 text-sm shadow-sm">
+                        <option value="all">All scales</option>
+                        @foreach ($scaleOptions as $value => $label)
+                            <option value="{{ $value }}">{{ $label }}</option>
+                        @endforeach
+                    </select>
+                </label>
+
+                <label class="space-y-2">
+                    <span class="text-xs font-semibold uppercase tracking-[0.16em] text-slate-500">Locale</span>
+                    <select wire:model.defer="locale" class="block w-full rounded-xl border-slate-300 text-sm shadow-sm">
+                        <option value="all">All locales</option>
+                        @foreach ($localeOptions as $value => $label)
+                            <option value="{{ $value }}">{{ $label }}</option>
+                        @endforeach
+                    </select>
+                </label>
+
+                <label class="space-y-2">
+                    <span class="text-xs font-semibold uppercase tracking-[0.16em] text-slate-500">Region</span>
+                    <select wire:model.defer="region" class="block w-full rounded-xl border-slate-300 text-sm shadow-sm">
+                        <option value="all">All regions</option>
+                        @foreach ($regionOptions as $value => $label)
+                            <option value="{{ $value }}">{{ $label }}</option>
+                        @endforeach
+                    </select>
+                </label>
+
+                <label class="space-y-2">
+                    <span class="text-xs font-semibold uppercase tracking-[0.16em] text-slate-500">Content</span>
+                    <select wire:model.defer="contentPackageVersion" class="block w-full rounded-xl border-slate-300 text-sm shadow-sm">
+                        <option value="all">All content versions</option>
+                        @foreach ($contentPackageVersionOptions as $value => $label)
+                            <option value="{{ $value }}">{{ $label }}</option>
+                        @endforeach
+                    </select>
+                </label>
+
+                <label class="space-y-2">
+                    <span class="text-xs font-semibold uppercase tracking-[0.16em] text-slate-500">Scoring</span>
+                    <select wire:model.defer="scoringSpecVersion" class="block w-full rounded-xl border-slate-300 text-sm shadow-sm">
+                        <option value="all">All scoring versions</option>
+                        @foreach ($scoringSpecVersionOptions as $value => $label)
+                            <option value="{{ $value }}">{{ $label }}</option>
+                        @endforeach
+                    </select>
+                </label>
+
+                <label class="space-y-2">
+                    <span class="text-xs font-semibold uppercase tracking-[0.16em] text-slate-500">Norm</span>
+                    <select wire:model.defer="normVersion" class="block w-full rounded-xl border-slate-300 text-sm shadow-sm">
+                        <option value="all">All norm versions</option>
+                        @foreach ($normVersionOptions as $value => $label)
+                            <option value="{{ $value }}">{{ $label }}</option>
+                        @endforeach
+                    </select>
+                </label>
+
+                <div class="flex items-end gap-3">
+                    <x-filament::button type="submit">Apply</x-filament::button>
+                </div>
+            </div>
+        </form>
+
+        <section class="rounded-2xl border border-slate-200 bg-white/95 p-5 shadow-sm">
+            <div class="flex flex-wrap items-center justify-between gap-4">
+                <div>
+                    <h2 class="text-lg font-semibold text-slate-950">Authority Scope</h2>
+                    <p class="text-sm text-slate-500">
+                        Admin-only / internal-only. Quality stays org-scoped; psychometrics and norm objects remain reference layers with explicit authority boundaries.
+                    </p>
+                </div>
+
+                <div class="flex flex-wrap gap-2">
+                    @foreach (['quality' => 'Quality', 'psychometrics' => 'Psychometrics', 'norms-drift' => 'Norms & Drift'] as $tabKey => $label)
+                        <button
+                            type="button"
+                            wire:click="setActiveTab('{{ $tabKey }}')"
+                            class="rounded-full border px-4 py-2 text-sm font-medium transition {{ $activeTab === $tabKey ? 'border-sky-300 bg-sky-50 text-sky-700' : 'border-slate-200 text-slate-600 hover:border-slate-300 hover:text-slate-900' }}"
+                        >
+                            {{ $label }}
+                        </button>
+                    @endforeach
+                </div>
+            </div>
+
+            <div class="mt-4 grid gap-3 lg:grid-cols-3">
+                @foreach ($scopeNotes as $note)
+                    <div class="rounded-2xl border border-slate-200 bg-slate-50/80 px-4 py-3 text-sm leading-6 text-slate-700">
+                        {{ $note }}
+                    </div>
+                @endforeach
+            </div>
+        </section>
+
+        @if ($warnings !== [])
+            <div class="space-y-3">
+                @foreach ($warnings as $warning)
+                    <div class="rounded-2xl border border-amber-200 bg-amber-50 px-4 py-3 text-sm text-amber-900">
+                        {{ $warning }}
+                    </div>
+                @endforeach
+            </div>
+        @endif
+
+        @if ($activeTab === 'quality')
+            <section class="rounded-2xl border border-slate-200 bg-white/95 p-5 shadow-sm">
+                <div class="flex flex-wrap items-center justify-between gap-4">
+                    <div>
+                        <h2 class="text-lg font-semibold text-slate-950">Quality</h2>
+                        <p class="text-sm text-slate-500">analytics_scale_quality_daily drives the summary layer. Attempts / Results explorers remain the drill-through path.</p>
+                    </div>
+
+                    <div class="flex flex-wrap gap-2">
+                        <a href="/ops/attempts" class="rounded-full border border-slate-200 px-3 py-2 text-sm text-slate-600 transition hover:border-slate-300 hover:text-slate-900">Attempts Explorer</a>
+                        <a href="/ops/results" class="rounded-full border border-slate-200 px-3 py-2 text-sm text-slate-600 transition hover:border-slate-300 hover:text-slate-900">Results Explorer</a>
+                    </div>
+                </div>
+
+                <div class="mt-4 grid gap-3 lg:grid-cols-3">
+                    @foreach ($qualityNotes as $note)
+                        <div class="rounded-2xl border border-slate-200 bg-slate-50/80 px-4 py-3 text-sm leading-6 text-slate-700">
+                            {{ $note }}
+                        </div>
+                    @endforeach
+                </div>
+
+                <form wire:submit.prevent="applyFilters" class="mt-5 rounded-2xl border border-slate-200 bg-slate-50/70 p-4">
+                    <div class="grid gap-4 xl:grid-cols-[minmax(0,1fr)_repeat(3,minmax(0,0.7fr))_auto]">
+                        <label class="space-y-2">
+                            <span class="text-xs font-semibold uppercase tracking-[0.16em] text-slate-500">Quality level</span>
+                            <select wire:model.defer="qualityLevel" class="block w-full rounded-xl border-slate-300 text-sm shadow-sm">
+                                <option value="all">All levels</option>
+                                <option value="A">A</option>
+                                <option value="B">B</option>
+                                <option value="C">C</option>
+                                <option value="D">D</option>
+                            </select>
+                        </label>
+
+                        <label class="flex items-end gap-3 rounded-xl border border-slate-200 bg-white px-4 py-3 text-sm text-slate-700">
+                            <input type="checkbox" wire:model.defer="onlyCrisis" class="rounded border-slate-300 text-sky-600 shadow-sm" />
+                            <span>Only crisis</span>
+                        </label>
+
+                        <label class="flex items-end gap-3 rounded-xl border border-slate-200 bg-white px-4 py-3 text-sm text-slate-700">
+                            <input type="checkbox" wire:model.defer="onlyInvalid" class="rounded border-slate-300 text-sky-600 shadow-sm" />
+                            <span>Only invalid</span>
+                        </label>
+
+                        <label class="flex items-end gap-3 rounded-xl border border-slate-200 bg-white px-4 py-3 text-sm text-slate-700">
+                            <input type="checkbox" wire:model.defer="onlyWarnings" class="rounded border-slate-300 text-sky-600 shadow-sm" />
+                            <span>Only warnings</span>
+                        </label>
+
+                        <div class="flex items-end">
+                            <x-filament::button type="submit" color="gray">Apply quality filters</x-filament::button>
+                        </div>
+                    </div>
+                </form>
+            </section>
+
+            @if ($hasQualityData)
+                <section class="rounded-2xl border border-slate-200 bg-white/95 p-5 shadow-sm">
+                    <div class="mb-4">
+                        <h2 class="text-lg font-semibold text-slate-950">KPI Cards</h2>
+                        <p class="text-sm text-slate-500">Cards stay on the global scope. Local quality filters only reshape the tables below.</p>
+                    </div>
+
+                    <div class="grid gap-4 md:grid-cols-2 xl:grid-cols-4">
+                        @foreach ($qualityKpis as $card)
+                            <article class="rounded-2xl border border-slate-200 bg-slate-50/70 p-4">
+                                <div class="text-xs font-semibold uppercase tracking-[0.16em] text-slate-500">{{ $card['label'] }}</div>
+                                <div class="mt-3 text-2xl font-semibold tracking-tight text-slate-950">{{ $card['display_value'] }}</div>
+                                <p class="mt-2 text-sm leading-6 text-slate-600">{{ $card['description'] }}</p>
+                            </article>
+                        @endforeach
+                    </div>
+                </section>
+
+                <section class="grid gap-6 xl:grid-cols-[minmax(0,1.3fr)_minmax(0,1fr)]">
+                    <div class="rounded-2xl border border-slate-200 bg-white/95 p-5 shadow-sm">
+                        <div class="mb-4">
+                            <h2 class="text-lg font-semibold text-slate-950">Daily Quality Summary</h2>
+                            <p class="text-sm text-slate-500">Day-level summary across the selected global scope and current quality table filters.</p>
+                        </div>
+
+                        <div class="overflow-x-auto">
+                            <table class="min-w-full divide-y divide-slate-200 text-sm">
+                                <thead class="bg-slate-50 text-left text-xs font-semibold uppercase tracking-[0.14em] text-slate-500">
+                                    <tr>
+                                        <th class="px-3 py-3">Day</th>
+                                        <th class="px-3 py-3">Results</th>
+                                        <th class="px-3 py-3">Completion</th>
+                                        <th class="px-3 py-3">Validity</th>
+                                        <th class="px-3 py-3">Quality mix</th>
+                                        <th class="px-3 py-3">Crisis</th>
+                                        <th class="px-3 py-3">Warnings</th>
+                                    </tr>
+                                </thead>
+                                <tbody class="divide-y divide-slate-100 bg-white">
+                                    @forelse ($qualityDailyRows as $row)
+                                        <tr>
+                                            <td class="px-3 py-3 font-medium text-slate-900">{{ $row['day'] }}</td>
+                                            <td class="px-3 py-3">{{ $this->formatInt((int) $row['results_count']) }}</td>
+                                            <td class="px-3 py-3">{{ $this->formatRate($row['completion_rate']) }}</td>
+                                            <td class="px-3 py-3">{{ $this->formatRate($row['validity_rate']) }}</td>
+                                            <td class="px-3 py-3">{{ $row['quality_mix'] }}</td>
+                                            <td class="px-3 py-3">{{ $this->formatInt((int) $row['crisis_alert_count']) }}</td>
+                                            <td class="px-3 py-3">{{ $this->formatInt((int) $row['warnings_count']) }}</td>
+                                        </tr>
+                                    @empty
+                                        <tr>
+                                            <td colspan="7" class="px-3 py-6 text-center text-sm text-slate-500">No daily quality rows in the current filtered scope.</td>
+                                        </tr>
+                                    @endforelse
+                                </tbody>
+                            </table>
+                        </div>
+                    </div>
+
+                    <div class="rounded-2xl border border-slate-200 bg-white/95 p-5 shadow-sm">
+                        <div class="mb-4">
+                            <h2 class="text-lg font-semibold text-slate-950">Quality Flags Breakdown</h2>
+                            <p class="text-sm text-slate-500">Reference counters only. Some flags are only stable on subset scales in v1.</p>
+                        </div>
+
+                        <div class="overflow-x-auto">
+                            <table class="min-w-full divide-y divide-slate-200 text-sm">
+                                <thead class="bg-slate-50 text-left text-xs font-semibold uppercase tracking-[0.14em] text-slate-500">
+                                    <tr>
+                                        <th class="px-3 py-3">Flag</th>
+                                        <th class="px-3 py-3">Count</th>
+                                        <th class="px-3 py-3">Rate</th>
+                                        <th class="px-3 py-3">Reference</th>
+                                    </tr>
+                                </thead>
+                                <tbody class="divide-y divide-slate-100 bg-white">
+                                    @forelse ($qualityFlagRows as $row)
+                                        <tr>
+                                            <td class="px-3 py-3 font-medium text-slate-900">{{ $row['label'] }}</td>
+                                            <td class="px-3 py-3">{{ $this->formatInt((int) $row['count']) }}</td>
+                                            <td class="px-3 py-3">{{ $this->formatRate($row['rate']) }}</td>
+                                            <td class="px-3 py-3 text-slate-600">{{ $row['reference'] }}</td>
+                                        </tr>
+                                    @empty
+                                        <tr>
+                                            <td colspan="4" class="px-3 py-6 text-center text-sm text-slate-500">No flag rows in the current filtered scope.</td>
+                                        </tr>
+                                    @endforelse
+                                </tbody>
+                            </table>
+                        </div>
+                    </div>
+                </section>
+
+                <section class="rounded-2xl border border-slate-200 bg-white/95 p-5 shadow-sm">
+                    <div class="mb-4">
+                        <h2 class="text-lg font-semibold text-slate-950">Scale-by-Scale Quality Comparison</h2>
+                        <p class="text-sm text-slate-500">Use Attempts / Results Explorer for record-level review after spotting outliers here.</p>
+                    </div>
+
+                    <div class="overflow-x-auto">
+                        <table class="min-w-full divide-y divide-slate-200 text-sm">
+                            <thead class="bg-slate-50 text-left text-xs font-semibold uppercase tracking-[0.14em] text-slate-500">
+                                <tr>
+                                    <th class="px-3 py-3">Scale</th>
+                                    <th class="px-3 py-3">Results</th>
+                                    <th class="px-3 py-3">Completion</th>
+                                    <th class="px-3 py-3">Validity</th>
+                                    <th class="px-3 py-3">Quality mix</th>
+                                    <th class="px-3 py-3">Crisis</th>
+                                    <th class="px-3 py-3">Longstring</th>
+                                    <th class="px-3 py-3">Straightlining</th>
+                                    <th class="px-3 py-3">Extreme</th>
+                                    <th class="px-3 py-3">Inconsistency</th>
+                                    <th class="px-3 py-3">Version mix</th>
+                                </tr>
+                            </thead>
+                            <tbody class="divide-y divide-slate-100 bg-white">
+                                @forelse ($qualityScaleRows as $row)
+                                    <tr>
+                                        <td class="px-3 py-3 font-medium text-slate-900">{{ $row['scale_code'] }}</td>
+                                        <td class="px-3 py-3">{{ $this->formatInt((int) $row['results_count']) }}</td>
+                                        <td class="px-3 py-3">{{ $this->formatRate($row['completion_rate']) }}</td>
+                                        <td class="px-3 py-3">{{ $this->formatRate($row['validity_rate']) }}</td>
+                                        <td class="px-3 py-3">{{ $row['quality_mix'] }}</td>
+                                        <td class="px-3 py-3">{{ $this->formatInt((int) $row['crisis_alert_count']) }}</td>
+                                        <td class="px-3 py-3">{{ $this->formatInt((int) $row['longstring_count']) }}</td>
+                                        <td class="px-3 py-3">{{ $this->formatInt((int) $row['straightlining_count']) }}</td>
+                                        <td class="px-3 py-3">{{ $this->formatInt((int) $row['extreme_count']) }}</td>
+                                        <td class="px-3 py-3">{{ $this->formatInt((int) $row['inconsistency_count']) }}</td>
+                                        <td class="px-3 py-3 text-slate-600">{{ $row['version_mix'] }}</td>
+                                    </tr>
+                                @empty
+                                    <tr>
+                                        <td colspan="11" class="px-3 py-6 text-center text-sm text-slate-500">No scale comparison rows in the current filtered scope.</td>
+                                    </tr>
+                                @endforelse
+                            </tbody>
+                        </table>
+                    </div>
+                </section>
+            @else
+                <section class="rounded-2xl border border-dashed border-slate-300 bg-white/80 p-8 text-center text-sm text-slate-500">
+                    Quality data is not available for the current scope yet.
+                </section>
+            @endif
+        @elseif ($activeTab === 'psychometrics')
+            <section class="rounded-2xl border border-slate-200 bg-white/95 p-5 shadow-sm">
+                <div class="mb-4">
+                    <h2 class="text-lg font-semibold text-slate-950">Psychometric Summary Table</h2>
+                    <p class="text-sm text-slate-500">Snapshot-driven and internal-reference by default. Small-sample rows stay reference-only.</p>
+                </div>
+
+                <div class="grid gap-3 lg:grid-cols-2">
+                    @foreach ($psychometricNotes as $note)
+                        <div class="rounded-2xl border border-slate-200 bg-slate-50/80 px-4 py-3 text-sm leading-6 text-slate-700">
+                            {{ $note }}
+                        </div>
+                    @endforeach
+                </div>
+            </section>
+
+            <section class="rounded-2xl border border-slate-200 bg-white/95 p-5 shadow-sm">
+                <div class="overflow-x-auto">
+                    <table class="min-w-full divide-y divide-slate-200 text-sm">
+                        <thead class="bg-slate-50 text-left text-xs font-semibold uppercase tracking-[0.14em] text-slate-500">
+                            <tr>
+                                <th class="px-3 py-3">Scale</th>
+                                <th class="px-3 py-3">Latest snapshot</th>
+                                <th class="px-3 py-3">Locale / Region</th>
+                                <th class="px-3 py-3">Norm version</th>
+                                <th class="px-3 py-3">Window</th>
+                                <th class="px-3 py-3">Sample n</th>
+                                <th class="px-3 py-3">Reference state</th>
+                                <th class="px-3 py-3">Primary summary</th>
+                                <th class="px-3 py-3">Secondary summary</th>
+                            </tr>
+                        </thead>
+                        <tbody class="divide-y divide-slate-100 bg-white">
+                            @forelse ($psychometricRows as $row)
+                                <tr>
+                                    <td class="px-3 py-3 font-medium text-slate-900">{{ $row['scale_code'] }}</td>
+                                    <td class="px-3 py-3">{{ $row['latest_snapshot_at'] }}</td>
+                                    <td class="px-3 py-3">{{ $row['locale'] }} / {{ $row['region'] }}</td>
+                                    <td class="px-3 py-3">{{ $row['norm_version'] }}</td>
+                                    <td class="px-3 py-3">{{ $row['time_window'] }}</td>
+                                    <td class="px-3 py-3">
+                                        {{ $this->formatInt((int) $row['sample_n']) }}
+                                        <div class="text-xs text-slate-500">min display {{ $this->formatInt((int) $row['min_display_samples']) }}</div>
+                                    </td>
+                                    <td class="px-3 py-3 text-slate-600">{{ $row['reference_state'] }}</td>
+                                    <td class="px-3 py-3">{{ $row['summary_primary'] }}</td>
+                                    <td class="px-3 py-3">{{ $row['summary_secondary'] }}</td>
+                                </tr>
+                            @empty
+                                <tr>
+                                    <td colspan="9" class="px-3 py-6 text-center text-sm text-slate-500">No psychometric snapshots match the current scope.</td>
+                                </tr>
+                            @endforelse
+                        </tbody>
+                    </table>
+                </div>
+            </section>
+        @else
+            <section class="rounded-2xl border border-slate-200 bg-white/95 p-5 shadow-sm">
+                <div class="mb-4">
+                    <h2 class="text-lg font-semibold text-slate-950">Norms & Drift</h2>
+                    <p class="text-sm text-slate-500">Hard coverage on active norm objects, with rollout and drift staying internal reference diagnostics.</p>
+                </div>
+
+                <div class="grid gap-3 lg:grid-cols-2">
+                    @foreach ($normNotes as $note)
+                        <div class="rounded-2xl border border-slate-200 bg-slate-50/80 px-4 py-3 text-sm leading-6 text-slate-700">
+                            {{ $note }}
+                        </div>
+                    @endforeach
+                </div>
+            </section>
+
+            <section class="rounded-2xl border border-slate-200 bg-white/95 p-5 shadow-sm">
+                <div class="mb-4">
+                    <h2 class="text-lg font-semibold text-slate-950">Norm Version Coverage</h2>
+                    <p class="text-sm text-slate-500">scale_norms_versions + scale_norm_stats drive this object view directly.</p>
+                </div>
+
+                <div class="overflow-x-auto">
+                    <table class="min-w-full divide-y divide-slate-200 text-sm">
+                        <thead class="bg-slate-50 text-left text-xs font-semibold uppercase tracking-[0.14em] text-slate-500">
+                            <tr>
+                                <th class="px-3 py-3">Scale</th>
+                                <th class="px-3 py-3">Locale / Region</th>
+                                <th class="px-3 py-3">Active norm version</th>
+                                <th class="px-3 py-3">Active groups</th>
+                                <th class="px-3 py-3">Coverage sample</th>
+                                <th class="px-3 py-3">Status</th>
+                                <th class="px-3 py-3">Latest published</th>
+                                <th class="px-3 py-3">Latest updated</th>
+                            </tr>
+                        </thead>
+                        <tbody class="divide-y divide-slate-100 bg-white">
+                            @forelse ($normCoverageRows as $row)
+                                <tr>
+                                    <td class="px-3 py-3 font-medium text-slate-900">{{ $row['scale_code'] }}</td>
+                                    <td class="px-3 py-3">{{ $row['locale'] }} / {{ $row['region'] }}</td>
+                                    <td class="px-3 py-3">{{ $row['active_norm_version'] }}</td>
+                                    <td class="px-3 py-3">{{ $this->formatInt((int) $row['active_group_count']) }}</td>
+                                    <td class="px-3 py-3">{{ $this->formatInt((int) $row['coverage_sample_n']) }}</td>
+                                    <td class="px-3 py-3">{{ $row['status_summary'] !== '' ? $row['status_summary'] : 'n/a' }}</td>
+                                    <td class="px-3 py-3">{{ $row['latest_published_at'] }}</td>
+                                    <td class="px-3 py-3">{{ $row['latest_updated_at'] }}</td>
+                                </tr>
+                            @empty
+                                <tr>
+                                    <td colspan="8" class="px-3 py-6 text-center text-sm text-slate-500">No active norm coverage rows match the current scope.</td>
+                                </tr>
+                            @endforelse
+                        </tbody>
+                    </table>
+                </div>
+            </section>
+
+            <section class="rounded-2xl border border-slate-200 bg-white/95 p-5 shadow-sm">
+                <div class="mb-4">
+                    <h2 class="text-lg font-semibold text-slate-950">Scoring Rollout Diagnostics</h2>
+                    <p class="text-sm text-slate-500">Config comes from scoring_models / scoring_model_rollouts. Observation coverage is scoped to selected org + date range.</p>
+                </div>
+
+                <div class="overflow-x-auto">
+                    <table class="min-w-full divide-y divide-slate-200 text-sm">
+                        <thead class="bg-slate-50 text-left text-xs font-semibold uppercase tracking-[0.14em] text-slate-500">
+                            <tr>
+                                <th class="px-3 py-3">Scale</th>
+                                <th class="px-3 py-3">Model key</th>
+                                <th class="px-3 py-3">Driver</th>
+                                <th class="px-3 py-3">Scoring spec</th>
+                                <th class="px-3 py-3">Rollout rule</th>
+                                <th class="px-3 py-3">Config state</th>
+                                <th class="px-3 py-3">Observation coverage</th>
+                                <th class="px-3 py-3">Observation share</th>
+                            </tr>
+                        </thead>
+                        <tbody class="divide-y divide-slate-100 bg-white">
+                            @forelse ($rolloutRows as $row)
+                                <tr>
+                                    <td class="px-3 py-3 font-medium text-slate-900">{{ $row['scale_code'] }}</td>
+                                    <td class="px-3 py-3">{{ $row['model_key'] }}</td>
+                                    <td class="px-3 py-3">{{ $row['driver_type'] }}</td>
+                                    <td class="px-3 py-3">{{ $row['scoring_spec_version'] }}</td>
+                                    <td class="px-3 py-3">{{ $row['rollout_rule'] }}</td>
+                                    <td class="px-3 py-3">{{ $row['config_state'] }}</td>
+                                    <td class="px-3 py-3 text-slate-600">{{ $row['observation_summary'] }}</td>
+                                    <td class="px-3 py-3">{{ $this->formatRate($row['observation_share']) }}</td>
+                                </tr>
+                            @empty
+                                <tr>
+                                    <td colspan="8" class="px-3 py-6 text-center text-sm text-slate-500">No rollout rows match the current scope.</td>
+                                </tr>
+                            @endforelse
+                        </tbody>
+                    </table>
+                </div>
+            </section>
+
+            <section class="rounded-2xl border border-slate-200 bg-white/95 p-5 shadow-sm">
+                <div class="mb-4">
+                    <h2 class="text-lg font-semibold text-slate-950">Latest vs Previous Drift Compare</h2>
+                    <p class="text-sm text-slate-500">Internal compare reference only. If coverage is thin, continue using norms:*:drift-check commands offline.</p>
+                </div>
+
+                <div class="overflow-x-auto">
+                    <table class="min-w-full divide-y divide-slate-200 text-sm">
+                        <thead class="bg-slate-50 text-left text-xs font-semibold uppercase tracking-[0.14em] text-slate-500">
+                            <tr>
+                                <th class="px-3 py-3">Scale</th>
+                                <th class="px-3 py-3">Locale / Region</th>
+                                <th class="px-3 py-3">Active version</th>
+                                <th class="px-3 py-3">Previous version</th>
+                                <th class="px-3 py-3">Groups</th>
+                                <th class="px-3 py-3">Metrics</th>
+                                <th class="px-3 py-3">Max mean diff</th>
+                                <th class="px-3 py-3">Max sd diff</th>
+                                <th class="px-3 py-3">Reference</th>
+                            </tr>
+                        </thead>
+                        <tbody class="divide-y divide-slate-100 bg-white">
+                            @forelse ($driftRows as $row)
+                                <tr>
+                                    <td class="px-3 py-3 font-medium text-slate-900">{{ $row['scale_code'] }}</td>
+                                    <td class="px-3 py-3">{{ $row['locale'] }} / {{ $row['region'] }}</td>
+                                    <td class="px-3 py-3">{{ $row['active_norm_version'] }}</td>
+                                    <td class="px-3 py-3">{{ $row['previous_norm_version'] }}</td>
+                                    <td class="px-3 py-3">{{ $this->formatInt((int) $row['compared_groups']) }}</td>
+                                    <td class="px-3 py-3">{{ $this->formatInt((int) $row['compared_metrics']) }}</td>
+                                    <td class="px-3 py-3">{{ number_format((float) $row['max_mean_diff'], 4) }}</td>
+                                    <td class="px-3 py-3">{{ number_format((float) $row['max_sd_diff'], 4) }}</td>
+                                    <td class="px-3 py-3 text-slate-600">{{ $row['reference_state'] }}</td>
+                                </tr>
+                            @empty
+                                <tr>
+                                    <td colspan="9" class="px-3 py-6 text-center text-sm text-slate-500">No drift compare rows are available for the current scope.</td>
+                                </tr>
+                            @endforelse
+                        </tbody>
+                    </table>
+                </div>
+            </section>
+        @endif
+    </div>
+</x-filament-panels::page>

--- a/backend/tests/Concerns/SeedsQualityResearchScenario.php
+++ b/backend/tests/Concerns/SeedsQualityResearchScenario.php
@@ -1,0 +1,689 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Concerns;
+
+use Carbon\CarbonImmutable;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Support\Str;
+
+trait SeedsQualityResearchScenario
+{
+    /**
+     * @return array{
+     *   from:string,
+     *   to:string,
+     *   big5_rollout_id:string,
+     *   eq60_rollout_id:string,
+     *   big5_active_norm_version:string,
+     *   big5_previous_norm_version:string
+     * }
+     */
+    private function seedQualityResearchScenario(int $orgId): array
+    {
+        $dayOne = CarbonImmutable::parse('2026-01-03 09:00:00');
+        $dayTwo = CarbonImmutable::parse('2026-01-04 09:00:00');
+
+        $big5RolloutId = (string) Str::uuid();
+        $eq60RolloutId = (string) Str::uuid();
+        $big5ActiveNormVersion = 'big5_norm_2026_active';
+        $big5PreviousNormVersion = 'big5_norm_2025_prev';
+        $eq60ActiveNormVersion = 'eq60_norm_2026_active';
+        $eq60PreviousNormVersion = 'eq60_norm_2025_prev';
+        $sdsActiveNormVersion = 'sds_norm_2026_active';
+        $sdsPreviousNormVersion = 'sds_norm_2025_prev';
+
+        $this->insertQualityAttempt([
+            'org_id' => $orgId,
+            'scale_code' => 'BIG5_OCEAN',
+            'locale' => 'en',
+            'region' => 'US',
+            'content_package_version' => 'content_big5_2026_v1',
+            'scoring_spec_version' => 'big5_spec_beta',
+            'norm_version' => $big5ActiveNormVersion,
+            'created_at' => $dayOne,
+            'submitted_at' => $dayOne->addMinutes(8),
+            'result_json' => ['seed' => true],
+        ], [
+            'org_id' => $orgId,
+            'scale_code' => 'BIG5_OCEAN',
+            'content_package_version' => 'content_big5_2026_v1',
+            'scoring_spec_version' => 'big5_spec_beta',
+            'computed_at' => $dayOne->addMinutes(9),
+            'result_json' => [
+                'quality' => [
+                    'level' => 'A',
+                    'flags' => [],
+                    'crisis_alert' => false,
+                ],
+                'model_selection' => [
+                    'model_key' => 'ml_beta',
+                    'driver_type' => 'big5_normed',
+                    'scoring_spec_version' => 'big5_spec_beta',
+                    'source' => 'rollout',
+                    'experiment_key' => 'big5-model',
+                    'experiment_variant' => 'beta',
+                    'rollout_id' => $big5RolloutId,
+                ],
+            ],
+        ]);
+
+        $this->insertQualityAttempt([
+            'org_id' => $orgId,
+            'scale_code' => 'BIG5_OCEAN',
+            'locale' => 'en',
+            'region' => 'US',
+            'content_package_version' => 'content_big5_2026_v1',
+            'scoring_spec_version' => 'big5_spec_beta',
+            'norm_version' => $big5ActiveNormVersion,
+            'created_at' => $dayOne->addHours(1),
+            'submitted_at' => $dayOne->addHours(1)->addMinutes(8),
+        ], [
+            'org_id' => $orgId,
+            'scale_code' => 'BIG5_OCEAN',
+            'content_package_version' => 'content_big5_2026_v1',
+            'scoring_spec_version' => 'big5_spec_beta',
+            'computed_at' => $dayOne->addHours(1)->addMinutes(9),
+            'result_json' => [
+                'quality' => [
+                    'level' => 'C',
+                    'flags' => ['LONGSTRING'],
+                    'crisis_alert' => true,
+                ],
+                'report' => [
+                    'warnings' => ['longstring_detected'],
+                ],
+                'model_selection' => [
+                    'model_key' => 'ml_beta',
+                    'driver_type' => 'big5_normed',
+                    'scoring_spec_version' => 'big5_spec_beta',
+                    'source' => 'rollout',
+                    'experiment_key' => 'big5-model',
+                    'experiment_variant' => 'beta',
+                    'rollout_id' => $big5RolloutId,
+                ],
+            ],
+        ]);
+
+        $this->insertQualityAttempt([
+            'org_id' => $orgId,
+            'scale_code' => 'BIG5_OCEAN',
+            'locale' => 'en',
+            'region' => 'US',
+            'content_package_version' => 'content_big5_2026_v1',
+            'scoring_spec_version' => 'big5_spec_beta',
+            'norm_version' => $big5ActiveNormVersion,
+            'created_at' => $dayOne->addHours(2),
+        ]);
+
+        $this->insertQualityAttempt([
+            'org_id' => $orgId,
+            'scale_code' => 'EQ_60',
+            'locale' => 'zh-CN',
+            'region' => 'CN_MAINLAND',
+            'content_package_version' => 'content_eq60_2026_v1',
+            'scoring_spec_version' => 'eq60_spec_v1',
+            'norm_version' => $eq60ActiveNormVersion,
+            'created_at' => $dayOne->addHours(3),
+            'submitted_at' => $dayOne->addHours(3)->addMinutes(7),
+        ], [
+            'org_id' => $orgId,
+            'scale_code' => 'EQ_60',
+            'content_package_version' => 'content_eq60_2026_v1',
+            'scoring_spec_version' => 'eq60_spec_v1',
+            'computed_at' => $dayOne->addHours(3)->addMinutes(8),
+            'result_json' => [
+                'quality' => [
+                    'level' => 'B',
+                    'flags' => ['STRAIGHTLINING', 'EXTREME_RESPONSE_BIAS'],
+                    'crisis_alert' => false,
+                ],
+                'report' => [
+                    'warnings' => ['review_eq60_quality'],
+                ],
+                'model_selection' => [
+                    'model_key' => 'default',
+                    'driver_type' => 'eq60_normed',
+                    'scoring_spec_version' => 'eq60_spec_v1',
+                    'source' => 'rollout',
+                    'experiment_key' => 'eq60-guardrail',
+                    'experiment_variant' => 'control',
+                    'rollout_id' => $eq60RolloutId,
+                ],
+            ],
+        ]);
+
+        $this->insertQualityAttempt([
+            'org_id' => $orgId,
+            'scale_code' => 'SDS_20',
+            'locale' => 'en',
+            'region' => 'US',
+            'content_package_version' => 'content_sds_2026_v1',
+            'scoring_spec_version' => 'sds_spec_v2',
+            'norm_version' => $sdsActiveNormVersion,
+            'created_at' => $dayTwo,
+            'submitted_at' => $dayTwo->addMinutes(6),
+        ], [
+            'org_id' => $orgId,
+            'scale_code' => 'SDS_20',
+            'content_package_version' => 'content_sds_2026_v1',
+            'scoring_spec_version' => 'sds_spec_v2',
+            'computed_at' => $dayTwo->addMinutes(7),
+            'result_json' => [
+                'quality' => [
+                    'level' => 'D',
+                    'flags' => ['INCONSISTENT'],
+                    'crisis_alert' => true,
+                ],
+            ],
+        ]);
+
+        $this->insertQualityAttempt([
+            'org_id' => $orgId,
+            'scale_code' => 'BIG5_OCEAN',
+            'locale' => 'fr-FR',
+            'region' => 'FR',
+            'content_package_version' => 'content_big5_2026_v2',
+            'scoring_spec_version' => 'big5_spec_default',
+            'norm_version' => $big5ActiveNormVersion,
+            'created_at' => $dayTwo->addHours(1),
+            'submitted_at' => $dayTwo->addHours(1)->addMinutes(7),
+        ], [
+            'org_id' => $orgId,
+            'scale_code' => 'BIG5_OCEAN',
+            'content_package_version' => 'content_big5_2026_v2',
+            'scoring_spec_version' => 'big5_spec_default',
+            'computed_at' => $dayTwo->addHours(1)->addMinutes(8),
+            'is_valid' => false,
+            'result_json' => [
+                'report' => [
+                    'warnings' => ['fallback_invalid'],
+                ],
+                'model_selection' => [
+                    'model_key' => 'default',
+                    'driver_type' => 'big5_normed',
+                    'scoring_spec_version' => 'big5_spec_default',
+                    'source' => 'default',
+                ],
+            ],
+        ]);
+
+        $this->insertPsychometricsReport('big5_psychometrics_reports', [
+            'scale_code' => 'BIG5_OCEAN',
+            'locale' => 'en',
+            'region' => 'US',
+            'norms_version' => $big5PreviousNormVersion,
+            'time_window' => 'last_90_days',
+            'sample_n' => 80,
+            'metrics_json' => [
+                'domain_alpha' => ['O' => 0.73, 'C' => 0.75, 'E' => 0.77, 'A' => 0.74, 'N' => 0.76],
+            ],
+            'generated_at' => $dayOne->subDay(),
+        ]);
+        $this->insertPsychometricsReport('big5_psychometrics_reports', [
+            'scale_code' => 'BIG5_OCEAN',
+            'locale' => 'en',
+            'region' => 'US',
+            'norms_version' => $big5ActiveNormVersion,
+            'time_window' => 'last_90_days',
+            'sample_n' => 160,
+            'metrics_json' => [
+                'domain_alpha' => ['O' => 0.81, 'C' => 0.83, 'E' => 0.84, 'A' => 0.82, 'N' => 0.80],
+            ],
+            'generated_at' => $dayTwo->addDay(),
+        ]);
+        $this->insertPsychometricsReport('eq60_psychometrics_reports', [
+            'scale_code' => 'EQ_60',
+            'locale' => 'zh-CN',
+            'region' => 'CN_MAINLAND',
+            'norms_version' => $eq60ActiveNormVersion,
+            'time_window' => 'last_90_days',
+            'sample_n' => 140,
+            'metrics_json' => [
+                'global_std_mean' => 101.2,
+                'global_std_sd' => 13.4,
+                'quality_c_or_worse_rate' => 0.08,
+            ],
+            'generated_at' => $dayTwo->addDay(),
+        ]);
+        $this->insertPsychometricsReport('sds_psychometrics_reports', [
+            'scale_code' => 'SDS_20',
+            'locale' => 'en',
+            'region' => 'US',
+            'norms_version' => $sdsActiveNormVersion,
+            'time_window' => 'last_90_days',
+            'sample_n' => 90,
+            'metrics_json' => [
+                'index_score_mean' => 54.3,
+                'index_score_sd' => 8.6,
+                'crisis_rate' => 0.11,
+            ],
+            'generated_at' => $dayTwo->addDay(),
+        ]);
+
+        $big5ActiveAdult = $this->insertNormVersion([
+            'scale_code' => 'BIG5_OCEAN',
+            'locale' => 'en',
+            'region' => 'US',
+            'version' => $big5ActiveNormVersion,
+            'group_id' => 'adult',
+            'status' => 'CALIBRATED',
+            'is_active' => 1,
+            'published_at' => $dayTwo->addHours(12),
+        ]);
+        $big5PreviousAdult = $this->insertNormVersion([
+            'scale_code' => 'BIG5_OCEAN',
+            'locale' => 'en',
+            'region' => 'US',
+            'version' => $big5PreviousNormVersion,
+            'group_id' => 'adult',
+            'status' => 'CALIBRATED',
+            'is_active' => 0,
+            'published_at' => $dayOne->subDay(),
+        ]);
+        $eq60Active = $this->insertNormVersion([
+            'scale_code' => 'EQ_60',
+            'locale' => 'zh-CN',
+            'region' => 'CN_MAINLAND',
+            'version' => $eq60ActiveNormVersion,
+            'group_id' => 'standard',
+            'status' => 'CALIBRATED',
+            'is_active' => 1,
+            'published_at' => $dayTwo->addHours(12),
+        ]);
+        $eq60Previous = $this->insertNormVersion([
+            'scale_code' => 'EQ_60',
+            'locale' => 'zh-CN',
+            'region' => 'CN_MAINLAND',
+            'version' => $eq60PreviousNormVersion,
+            'group_id' => 'standard',
+            'status' => 'PROVISIONAL',
+            'is_active' => 0,
+            'published_at' => $dayOne->subDay(),
+        ]);
+        $sdsActive = $this->insertNormVersion([
+            'scale_code' => 'SDS_20',
+            'locale' => 'en',
+            'region' => 'US',
+            'version' => $sdsActiveNormVersion,
+            'group_id' => 'standard',
+            'status' => 'CALIBRATED',
+            'is_active' => 1,
+            'published_at' => $dayTwo->addHours(12),
+        ]);
+        $sdsPrevious = $this->insertNormVersion([
+            'scale_code' => 'SDS_20',
+            'locale' => 'en',
+            'region' => 'US',
+            'version' => $sdsPreviousNormVersion,
+            'group_id' => 'standard',
+            'status' => 'PROVISIONAL',
+            'is_active' => 0,
+            'published_at' => $dayOne->subDay(),
+        ]);
+
+        $this->insertNormStat($big5ActiveAdult, 'domain', 'O', 52.1, 10.8, 220);
+        $this->insertNormStat($big5PreviousAdult, 'domain', 'O', 51.2, 10.5, 210);
+        $this->insertNormStat($big5ActiveAdult, 'facet', 'O1', 53.0, 9.6, 220);
+        $this->insertNormStat($big5PreviousAdult, 'facet', 'O1', 51.8, 9.8, 210);
+
+        $this->insertNormStat($eq60Active, 'global', 'INDEX_SCORE', 100.8, 15.2, 180);
+        $this->insertNormStat($eq60Previous, 'global', 'INDEX_SCORE', 98.6, 14.4, 160);
+
+        $this->insertNormStat($sdsActive, 'index', 'INDEX_SCORE', 54.0, 8.8, 110);
+        $this->insertNormStat($sdsPrevious, 'index', 'INDEX_SCORE', 50.8, 8.1, 95);
+
+        $this->insertScoringModel([
+            'id' => '11111111-1111-4111-8111-111111111111',
+            'org_id' => $orgId,
+            'scale_code' => 'BIG5_OCEAN',
+            'model_key' => 'ml_beta',
+            'driver_type' => 'big5_normed',
+            'scoring_spec_version' => 'big5_spec_beta',
+            'priority' => 10,
+            'is_active' => 1,
+        ]);
+        $this->insertScoringModel([
+            'id' => '22222222-2222-4222-8222-222222222222',
+            'org_id' => 0,
+            'scale_code' => 'BIG5_OCEAN',
+            'model_key' => 'default',
+            'driver_type' => 'big5_normed',
+            'scoring_spec_version' => 'big5_spec_default',
+            'priority' => 100,
+            'is_active' => 1,
+        ]);
+        $this->insertScoringModel([
+            'id' => '33333333-3333-4333-8333-333333333333',
+            'org_id' => 0,
+            'scale_code' => 'EQ_60',
+            'model_key' => 'default',
+            'driver_type' => 'eq60_normed',
+            'scoring_spec_version' => 'eq60_spec_v1',
+            'priority' => 100,
+            'is_active' => 1,
+        ]);
+        $this->insertScoringModel([
+            'id' => '44444444-4444-4444-8444-444444444444',
+            'org_id' => 0,
+            'scale_code' => 'SDS_20',
+            'model_key' => 'default',
+            'driver_type' => 'sds_factor_logic',
+            'scoring_spec_version' => 'sds_spec_v2',
+            'priority' => 100,
+            'is_active' => 1,
+        ]);
+
+        $this->insertScoringRollout([
+            'id' => $big5RolloutId,
+            'org_id' => $orgId,
+            'scale_code' => 'BIG5_OCEAN',
+            'model_key' => 'ml_beta',
+            'experiment_key' => 'big5-model',
+            'experiment_variant' => 'beta',
+            'rollout_percent' => 50,
+            'priority' => 10,
+            'is_active' => 1,
+            'starts_at' => $dayOne->subDay(),
+        ]);
+        $this->insertScoringRollout([
+            'id' => $eq60RolloutId,
+            'org_id' => 0,
+            'scale_code' => 'EQ_60',
+            'model_key' => 'default',
+            'experiment_key' => 'eq60-guardrail',
+            'experiment_variant' => 'control',
+            'rollout_percent' => 100,
+            'priority' => 100,
+            'is_active' => 1,
+            'starts_at' => $dayOne->subDay(),
+        ]);
+
+        return [
+            'from' => $dayOne->toDateString(),
+            'to' => $dayTwo->toDateString(),
+            'big5_rollout_id' => $big5RolloutId,
+            'eq60_rollout_id' => $eq60RolloutId,
+            'big5_active_norm_version' => $big5ActiveNormVersion,
+            'big5_previous_norm_version' => $big5PreviousNormVersion,
+        ];
+    }
+
+    /**
+     * @param  array<string,mixed>  $attemptOverrides
+     * @param  array<string,mixed>|null  $resultOverrides
+     */
+    private function insertQualityAttempt(array $attemptOverrides, ?array $resultOverrides = null): string
+    {
+        $attemptId = (string) ($attemptOverrides['id'] ?? Str::uuid());
+        $createdAt = $attemptOverrides['created_at'] ?? CarbonImmutable::parse('2026-01-03 00:00:00');
+        $submittedAt = $attemptOverrides['submitted_at'] ?? null;
+        $scaleCode = (string) ($attemptOverrides['scale_code'] ?? 'BIG5_OCEAN');
+
+        $row = [
+            'id' => $attemptId,
+            'ticket_code' => 'FMT-'.strtoupper(substr(str_replace('-', '', $attemptId), 0, 8)),
+            'anon_id' => 'anon_'.substr(str_replace('-', '', $attemptId), 0, 10),
+            'user_id' => null,
+            'org_id' => (int) ($attemptOverrides['org_id'] ?? 0),
+            'scale_code' => $scaleCode,
+            'scale_version' => (string) ($attemptOverrides['scale_version'] ?? 'v1'),
+            'question_count' => (int) ($attemptOverrides['question_count'] ?? 60),
+            'answers_summary_json' => json_encode(['seed' => true], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES),
+            'client_platform' => 'web',
+            'client_version' => 'test',
+            'channel' => 'web',
+            'referrer' => '/tests/quality-research',
+            'region' => (string) ($attemptOverrides['region'] ?? 'US'),
+            'locale' => (string) ($attemptOverrides['locale'] ?? 'en'),
+            'started_at' => $createdAt,
+            'submitted_at' => $submittedAt,
+            'created_at' => $createdAt,
+            'updated_at' => $submittedAt ?? $createdAt,
+            'pack_id' => (string) ($attemptOverrides['pack_id'] ?? $scaleCode),
+            'dir_version' => (string) ($attemptOverrides['dir_version'] ?? 'v1'),
+            'content_package_version' => (string) ($attemptOverrides['content_package_version'] ?? 'content_2026_v1'),
+            'scoring_spec_version' => (string) ($attemptOverrides['scoring_spec_version'] ?? 'spec_v1'),
+            'norm_version' => (string) ($attemptOverrides['norm_version'] ?? 'norm_v1'),
+            'result_json' => json_encode($attemptOverrides['result_json'] ?? ['seed' => true], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES),
+        ];
+
+        if (Schema::hasColumn('attempts', 'scale_code_v2')) {
+            $row['scale_code_v2'] = match ($scaleCode) {
+                'BIG5_OCEAN' => 'BIG_FIVE_OCEAN_MODEL',
+                'EQ_60' => 'EQ_EMOTIONAL_INTELLIGENCE',
+                'SDS_20' => 'DEPRESSION_SCREENING_STANDARD',
+                default => $scaleCode,
+            };
+        }
+
+        if (Schema::hasColumn('attempts', 'scale_uid')) {
+            $row['scale_uid'] = match ($scaleCode) {
+                'BIG5_OCEAN' => '22222222-2222-4222-8222-222222222222',
+                'SDS_20' => '44444444-4444-4444-8444-444444444444',
+                'EQ_60' => '66666666-6666-4666-8666-666666666666',
+                default => null,
+            };
+        }
+
+        if (Schema::hasColumn('attempts', 'calculation_snapshot_json')) {
+            $row['calculation_snapshot_json'] = json_encode(
+                $attemptOverrides['calculation_snapshot_json'] ?? [],
+                JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES
+            );
+        }
+
+        DB::table('attempts')->insert($row);
+
+        if ($resultOverrides !== null) {
+            $this->insertQualityResult($attemptId, $resultOverrides);
+        }
+
+        return $attemptId;
+    }
+
+    /**
+     * @param  array<string,mixed>  $overrides
+     */
+    private function insertQualityResult(string $attemptId, array $overrides): string
+    {
+        $resultId = (string) ($overrides['id'] ?? Str::uuid());
+        $computedAt = $overrides['computed_at'] ?? CarbonImmutable::parse('2026-01-03 00:00:00');
+        $scaleCode = (string) ($overrides['scale_code'] ?? 'BIG5_OCEAN');
+        $resultJson = $overrides['result_json'] ?? [];
+
+        $row = [
+            'id' => $resultId,
+            'attempt_id' => $attemptId,
+            'org_id' => (int) ($overrides['org_id'] ?? 0),
+            'scale_code' => $scaleCode,
+            'scale_version' => (string) ($overrides['scale_version'] ?? 'v1'),
+            'type_code' => (string) ($overrides['type_code'] ?? ''),
+            'scores_json' => json_encode($overrides['scores_json'] ?? ['seed' => true], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES),
+            'profile_version' => (string) ($overrides['profile_version'] ?? 'profile_2026_v1'),
+            'is_valid' => array_key_exists('is_valid', $overrides) ? (bool) $overrides['is_valid'] : true,
+            'computed_at' => $computedAt,
+            'created_at' => $computedAt,
+            'updated_at' => $computedAt,
+        ];
+
+        if (Schema::hasColumn('results', 'scores_pct')) {
+            $row['scores_pct'] = json_encode($overrides['scores_pct'] ?? [], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES);
+        }
+        if (Schema::hasColumn('results', 'axis_states')) {
+            $row['axis_states'] = json_encode($overrides['axis_states'] ?? [], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES);
+        }
+        if (Schema::hasColumn('results', 'scale_code_v2')) {
+            $row['scale_code_v2'] = match ($scaleCode) {
+                'BIG5_OCEAN' => 'BIG_FIVE_OCEAN_MODEL',
+                'EQ_60' => 'EQ_EMOTIONAL_INTELLIGENCE',
+                'SDS_20' => 'DEPRESSION_SCREENING_STANDARD',
+                default => $scaleCode,
+            };
+        }
+        if (Schema::hasColumn('results', 'scale_uid')) {
+            $row['scale_uid'] = match ($scaleCode) {
+                'BIG5_OCEAN' => '22222222-2222-4222-8222-222222222222',
+                'SDS_20' => '44444444-4444-4444-8444-444444444444',
+                'EQ_60' => '66666666-6666-4666-8666-666666666666',
+                default => null,
+            };
+        }
+        if (Schema::hasColumn('results', 'result_json')) {
+            $row['result_json'] = json_encode($resultJson, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES);
+        }
+        if (Schema::hasColumn('results', 'pack_id')) {
+            $row['pack_id'] = (string) ($overrides['pack_id'] ?? $scaleCode);
+        }
+        if (Schema::hasColumn('results', 'content_package_version')) {
+            $row['content_package_version'] = (string) ($overrides['content_package_version'] ?? 'content_2026_v1');
+        }
+        if (Schema::hasColumn('results', 'dir_version')) {
+            $row['dir_version'] = (string) ($overrides['dir_version'] ?? 'v1');
+        }
+        if (Schema::hasColumn('results', 'scoring_spec_version')) {
+            $row['scoring_spec_version'] = (string) ($overrides['scoring_spec_version'] ?? 'spec_v1');
+        }
+        if (Schema::hasColumn('results', 'report_engine_version')) {
+            $row['report_engine_version'] = (string) ($overrides['report_engine_version'] ?? 'v1.2');
+        }
+
+        DB::table('results')->insert($row);
+
+        return $resultId;
+    }
+
+    /**
+     * @param  array<string,mixed>  $overrides
+     */
+    private function insertPsychometricsReport(string $table, array $overrides): void
+    {
+        DB::table($table)->insert([
+            'id' => (string) Str::uuid(),
+            'scale_code' => (string) ($overrides['scale_code'] ?? 'BIG5_OCEAN'),
+            'locale' => (string) ($overrides['locale'] ?? 'en'),
+            'region' => $overrides['region'] ?? null,
+            'norms_version' => $overrides['norms_version'] ?? null,
+            'time_window' => (string) ($overrides['time_window'] ?? 'last_90_days'),
+            'sample_n' => (int) ($overrides['sample_n'] ?? 0),
+            'metrics_json' => json_encode($overrides['metrics_json'] ?? [], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES),
+            'generated_at' => $overrides['generated_at'] ?? now(),
+            'created_at' => $overrides['generated_at'] ?? now(),
+            'updated_at' => $overrides['generated_at'] ?? now(),
+        ]);
+    }
+
+    /**
+     * @param  array<string,mixed>  $overrides
+     */
+    private function insertNormVersion(array $overrides): string
+    {
+        $id = (string) ($overrides['id'] ?? Str::uuid());
+        $createdAt = $overrides['published_at'] ?? now();
+        $row = [
+            'id' => $id,
+            'scale_code' => (string) ($overrides['scale_code'] ?? 'BIG5_OCEAN'),
+            'norm_id' => (string) ($overrides['norm_id'] ?? 'default'),
+            'region' => $overrides['region'] ?? null,
+            'locale' => $overrides['locale'] ?? null,
+            'version' => (string) ($overrides['version'] ?? 'norm_v1'),
+            'checksum' => (string) ($overrides['checksum'] ?? 'checksum'),
+            'meta_json' => json_encode($overrides['meta_json'] ?? [], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES),
+            'created_at' => $createdAt,
+        ];
+
+        if (Schema::hasColumn('scale_norms_versions', 'group_id')) {
+            $row['group_id'] = (string) ($overrides['group_id'] ?? 'default');
+        }
+        if (Schema::hasColumn('scale_norms_versions', 'gender')) {
+            $row['gender'] = $overrides['gender'] ?? null;
+        }
+        if (Schema::hasColumn('scale_norms_versions', 'age_min')) {
+            $row['age_min'] = $overrides['age_min'] ?? null;
+        }
+        if (Schema::hasColumn('scale_norms_versions', 'age_max')) {
+            $row['age_max'] = $overrides['age_max'] ?? null;
+        }
+        if (Schema::hasColumn('scale_norms_versions', 'source_id')) {
+            $row['source_id'] = $overrides['source_id'] ?? null;
+        }
+        if (Schema::hasColumn('scale_norms_versions', 'source_type')) {
+            $row['source_type'] = $overrides['source_type'] ?? null;
+        }
+        if (Schema::hasColumn('scale_norms_versions', 'status')) {
+            $row['status'] = (string) ($overrides['status'] ?? 'CALIBRATED');
+        }
+        if (Schema::hasColumn('scale_norms_versions', 'is_active')) {
+            $row['is_active'] = (int) ($overrides['is_active'] ?? 0);
+        }
+        if (Schema::hasColumn('scale_norms_versions', 'published_at')) {
+            $row['published_at'] = $overrides['published_at'] ?? null;
+        }
+        if (Schema::hasColumn('scale_norms_versions', 'updated_at')) {
+            $row['updated_at'] = $overrides['published_at'] ?? $createdAt;
+        }
+
+        DB::table('scale_norms_versions')->insert($row);
+
+        return $id;
+    }
+
+    private function insertNormStat(string $normVersionId, string $metricLevel, string $metricCode, float $mean, float $sd, int $sampleN): void
+    {
+        DB::table('scale_norm_stats')->insert([
+            'id' => (string) Str::uuid(),
+            'norm_version_id' => $normVersionId,
+            'metric_level' => $metricLevel,
+            'metric_code' => $metricCode,
+            'mean' => $mean,
+            'sd' => $sd,
+            'sample_n' => $sampleN,
+            'created_at' => now(),
+            'updated_at' => now(),
+        ]);
+    }
+
+    /**
+     * @param  array<string,mixed>  $overrides
+     */
+    private function insertScoringModel(array $overrides): void
+    {
+        DB::table('scoring_models')->insert([
+            'id' => (string) ($overrides['id'] ?? Str::uuid()),
+            'org_id' => (int) ($overrides['org_id'] ?? 0),
+            'scale_code' => (string) ($overrides['scale_code'] ?? 'BIG5_OCEAN'),
+            'model_key' => (string) ($overrides['model_key'] ?? 'default'),
+            'driver_type' => $overrides['driver_type'] ?? null,
+            'scoring_spec_version' => $overrides['scoring_spec_version'] ?? null,
+            'priority' => (int) ($overrides['priority'] ?? 100),
+            'is_active' => (int) ($overrides['is_active'] ?? 1),
+            'config_json' => json_encode($overrides['config_json'] ?? [], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES),
+            'created_at' => now(),
+            'updated_at' => now(),
+        ]);
+    }
+
+    /**
+     * @param  array<string,mixed>  $overrides
+     */
+    private function insertScoringRollout(array $overrides): void
+    {
+        DB::table('scoring_model_rollouts')->insert([
+            'id' => (string) ($overrides['id'] ?? Str::uuid()),
+            'org_id' => (int) ($overrides['org_id'] ?? 0),
+            'scale_code' => (string) ($overrides['scale_code'] ?? 'BIG5_OCEAN'),
+            'model_key' => (string) ($overrides['model_key'] ?? 'default'),
+            'experiment_key' => $overrides['experiment_key'] ?? null,
+            'experiment_variant' => $overrides['experiment_variant'] ?? null,
+            'rollout_percent' => (int) ($overrides['rollout_percent'] ?? 100),
+            'priority' => (int) ($overrides['priority'] ?? 100),
+            'is_active' => (int) ($overrides['is_active'] ?? 1),
+            'starts_at' => $overrides['starts_at'] ?? null,
+            'ends_at' => $overrides['ends_at'] ?? null,
+            'created_at' => now(),
+            'updated_at' => now(),
+        ]);
+    }
+}

--- a/backend/tests/Feature/Analytics/QualityInsightsDailyBuilderTest.php
+++ b/backend/tests/Feature/Analytics/QualityInsightsDailyBuilderTest.php
@@ -1,0 +1,88 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Analytics;
+
+use App\Services\Analytics\QualityInsightsDailyBuilder;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Collection;
+use Tests\Concerns\SeedsQualityResearchScenario;
+use Tests\TestCase;
+
+final class QualityInsightsDailyBuilderTest extends TestCase
+{
+    use RefreshDatabase;
+    use SeedsQualityResearchScenario;
+
+    public function test_builder_aggregates_quality_rows_by_day_scale_locale_region_and_version_bundle(): void
+    {
+        $scenario = $this->seedQualityResearchScenario(501);
+
+        $payload = app(QualityInsightsDailyBuilder::class)->build(
+            new \DateTimeImmutable($scenario['from']),
+            new \DateTimeImmutable($scenario['to']),
+            [501],
+        );
+
+        $this->assertSame(6, (int) ($payload['source_started_attempts'] ?? 0));
+        $this->assertSame(5, (int) ($payload['source_completed_attempts'] ?? 0));
+        $this->assertSame(5, (int) ($payload['source_results'] ?? 0));
+        $this->assertSame(4, (int) ($payload['attempted_rows'] ?? 0));
+
+        $rows = collect($payload['rows'])->keyBy(fn (array $row): string => implode('|', [
+            (string) $row['day'],
+            (string) $row['scale_code'],
+            (string) $row['locale'],
+            (string) $row['region'],
+            (string) $row['content_package_version'],
+            (string) $row['scoring_spec_version'],
+            (string) $row['norm_version'],
+        ]));
+
+        $big5DayOne = $this->rowByKey($rows, '2026-01-03|BIG5_OCEAN|en|US|content_big5_2026_v1|big5_spec_beta|big5_norm_2026_active');
+        $this->assertSame(3, (int) $big5DayOne['started_attempts']);
+        $this->assertSame(2, (int) $big5DayOne['completed_attempts']);
+        $this->assertSame(2, (int) $big5DayOne['results_count']);
+        $this->assertSame(1, (int) $big5DayOne['valid_results_count']);
+        $this->assertSame(1, (int) $big5DayOne['invalid_results_count']);
+        $this->assertSame(1, (int) $big5DayOne['quality_a_count']);
+        $this->assertSame(1, (int) $big5DayOne['quality_c_count']);
+        $this->assertSame(1, (int) $big5DayOne['crisis_alert_count']);
+        $this->assertSame(1, (int) $big5DayOne['longstring_count']);
+        $this->assertSame(1, (int) $big5DayOne['warnings_count']);
+
+        $eq60Row = $this->rowByKey($rows, '2026-01-03|EQ_60|zh-CN|CN_MAINLAND|content_eq60_2026_v1|eq60_spec_v1|eq60_norm_2026_active');
+        $this->assertSame(1, (int) $eq60Row['quality_b_count']);
+        $this->assertSame(1, (int) $eq60Row['straightlining_count']);
+        $this->assertSame(1, (int) $eq60Row['extreme_count']);
+        $this->assertSame(1, (int) $eq60Row['warnings_count']);
+
+        $sdsRow = $this->rowByKey($rows, '2026-01-04|SDS_20|en|US|content_sds_2026_v1|sds_spec_v2|sds_norm_2026_active');
+        $this->assertSame(1, (int) $sdsRow['quality_d_count']);
+        $this->assertSame(1, (int) $sdsRow['crisis_alert_count']);
+        $this->assertSame(1, (int) $sdsRow['inconsistency_count']);
+
+        $big5Fallback = $this->rowByKey($rows, '2026-01-04|BIG5_OCEAN|fr-FR|FR|content_big5_2026_v2|big5_spec_default|big5_norm_2026_active');
+        $this->assertSame(1, (int) $big5Fallback['results_count']);
+        $this->assertSame(0, (int) $big5Fallback['quality_a_count']);
+        $this->assertSame(0, (int) $big5Fallback['quality_b_count']);
+        $this->assertSame(0, (int) $big5Fallback['quality_c_count']);
+        $this->assertSame(0, (int) $big5Fallback['quality_d_count']);
+        $this->assertSame(0, (int) $big5Fallback['valid_results_count']);
+        $this->assertSame(1, (int) $big5Fallback['invalid_results_count']);
+        $this->assertSame(1, (int) $big5Fallback['warnings_count']);
+    }
+
+    /**
+     * @param  Collection<string,array<string,mixed>>  $rows
+     * @return array<string,mixed>
+     */
+    private function rowByKey(Collection $rows, string $key): array
+    {
+        $row = $rows->get($key);
+        $this->assertIsArray($row, 'Missing aggregate row: '.$key);
+
+        return $row;
+    }
+}

--- a/backend/tests/Feature/Analytics/QualityResearchInsightsSupportTest.php
+++ b/backend/tests/Feature/Analytics/QualityResearchInsightsSupportTest.php
@@ -1,0 +1,65 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Analytics;
+
+use App\Services\Analytics\QualityResearchInsightsSupport;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\Concerns\SeedsQualityResearchScenario;
+use Tests\TestCase;
+
+final class QualityResearchInsightsSupportTest extends TestCase
+{
+    use RefreshDatabase;
+    use SeedsQualityResearchScenario;
+
+    public function test_support_selects_latest_psychometrics_active_norm_coverage_and_rollout_reference_rows(): void
+    {
+        $scenario = $this->seedQualityResearchScenario(611);
+
+        $qualityRefresh = $this->app->make(\App\Services\Analytics\QualityInsightsDailyBuilder::class)->refresh(
+            new \DateTimeImmutable($scenario['from']),
+            new \DateTimeImmutable($scenario['to']),
+            [611],
+        );
+        $this->assertSame(4, (int) ($qualityRefresh['upserted_rows'] ?? 0));
+
+        $support = app(QualityResearchInsightsSupport::class);
+
+        $psychometrics = $support->psychometricsPayload([
+            'from' => $scenario['from'],
+            'to' => $scenario['to'],
+            'scale_code' => 'all',
+            'locale' => 'all',
+            'region' => 'all',
+            'content_package_version' => 'all',
+            'scoring_spec_version' => 'all',
+            'norm_version' => 'all',
+        ]);
+        $norms = $support->normsPayload(611, [
+            'from' => $scenario['from'],
+            'to' => $scenario['to'],
+            'scale_code' => 'all',
+            'locale' => 'all',
+            'region' => 'all',
+            'content_package_version' => 'all',
+            'scoring_spec_version' => 'all',
+            'norm_version' => 'all',
+        ]);
+
+        $this->assertTrue($psychometrics['has_data']);
+        $this->assertCount(3, $psychometrics['rows']);
+        $this->assertSame('big5_norm_2026_active', $psychometrics['rows'][0]['norm_version']);
+        $this->assertSame(160, (int) $psychometrics['rows'][0]['sample_n']);
+        $this->assertSame('Internal reference - below display threshold', $psychometrics['rows'][2]['reference_state']);
+
+        $this->assertNotEmpty($norms['coverage_rows']);
+        $this->assertSame('BIG5_OCEAN', $norms['coverage_rows'][0]['scale_code']);
+        $this->assertSame('big5_norm_2026_active', $norms['coverage_rows'][0]['active_norm_version']);
+        $this->assertNotEmpty($norms['rollout_rows']);
+        $this->assertSame('ml_beta', $norms['rollout_rows'][0]['model_key']);
+        $this->assertNotEmpty($norms['drift_rows']);
+        $this->assertSame('big5_norm_2026_active', $norms['drift_rows'][0]['active_norm_version']);
+    }
+}

--- a/backend/tests/Feature/Analytics/RefreshQualityDailyCommandTest.php
+++ b/backend/tests/Feature/Analytics/RefreshQualityDailyCommandTest.php
@@ -1,0 +1,55 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Analytics;
+
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\DB;
+use Tests\Concerns\SeedsQualityResearchScenario;
+use Tests\TestCase;
+
+final class RefreshQualityDailyCommandTest extends TestCase
+{
+    use RefreshDatabase;
+    use SeedsQualityResearchScenario;
+
+    public function test_command_supports_dry_run_and_upserts_quality_daily_rows(): void
+    {
+        $scenario = $this->seedQualityResearchScenario(901);
+
+        $this->artisan('analytics:refresh-quality-daily', [
+            '--from' => $scenario['from'],
+            '--to' => $scenario['to'],
+            '--org' => [901],
+            '--dry-run' => true,
+        ])
+            ->expectsOutputToContain('dry_run=1')
+            ->expectsOutputToContain('attempted_rows=4')
+            ->assertExitCode(0);
+
+        $this->assertSame(0, DB::table('analytics_scale_quality_daily')->count());
+
+        $this->artisan('analytics:refresh-quality-daily', [
+            '--from' => $scenario['from'],
+            '--to' => $scenario['to'],
+            '--org' => [901],
+        ])
+            ->expectsOutputToContain('dry_run=0')
+            ->expectsOutputToContain('upserted_rows=4')
+            ->assertExitCode(0);
+
+        $this->assertSame(4, DB::table('analytics_scale_quality_daily')->count());
+
+        $this->artisan('analytics:refresh-quality-daily', [
+            '--from' => $scenario['from'],
+            '--to' => $scenario['to'],
+            '--org' => [901],
+            '--scale' => ['BIG5_OCEAN'],
+        ])
+            ->expectsOutputToContain('scale_scope=BIG5_OCEAN')
+            ->assertExitCode(0);
+
+        $this->assertSame(4, DB::table('analytics_scale_quality_daily')->count());
+    }
+}

--- a/backend/tests/Feature/Ops/QualityResearchPageTest.php
+++ b/backend/tests/Feature/Ops/QualityResearchPageTest.php
@@ -1,0 +1,141 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Ops;
+
+use App\Filament\Ops\Pages\QualityResearchPage;
+use App\Models\AdminUser;
+use App\Models\Organization;
+use App\Models\Permission;
+use App\Models\Role;
+use App\Services\Analytics\QualityInsightsDailyBuilder;
+use App\Support\OrgContext;
+use App\Support\Rbac\PermissionNames;
+use Filament\Facades\Filament;
+use Filament\PanelRegistry;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Http\Request;
+use Illuminate\Support\Str;
+use Livewire\Livewire;
+use Tests\Concerns\SeedsQualityResearchScenario;
+use Tests\TestCase;
+
+final class QualityResearchPageTest extends TestCase
+{
+    use RefreshDatabase;
+    use SeedsQualityResearchScenario;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        Filament::setCurrentPanel(app(PanelRegistry::class)->get('ops'));
+    }
+
+    public function test_quality_research_page_route_exists_and_tabs_render_foundational_sections(): void
+    {
+        $admin = $this->createAdminWithPermissions([
+            PermissionNames::ADMIN_OPS_READ,
+        ]);
+        $selectedOrg = $this->createOrganization('Quality Research Org');
+        $scenario = $this->seedQualityResearchScenario((int) $selectedOrg->id);
+
+        app(QualityInsightsDailyBuilder::class)->refresh(
+            new \DateTimeImmutable($scenario['from']),
+            new \DateTimeImmutable($scenario['to']),
+            [(int) $selectedOrg->id],
+        );
+
+        $this->withSession($this->opsSession($admin, $selectedOrg))
+            ->actingAs($admin, (string) config('admin.guard', 'admin'))
+            ->get('/ops/quality-research')
+            ->assertOk()
+            ->assertSee('Quality / Psychometrics / Norms & Drift')
+            ->assertSee('Quality')
+            ->assertSee('Psychometrics')
+            ->assertSee('Norms & Drift')
+            ->assertSee('Admin-only / internal-only');
+
+        $this->actingAs($admin, (string) config('admin.guard', 'admin'));
+        app()->instance('request', Request::create('/ops/quality-research', 'GET'));
+
+        $context = app(OrgContext::class);
+        $context->set((int) $selectedOrg->id, (int) $admin->id, 'admin');
+        app()->instance(OrgContext::class, $context);
+        $this->withSession($this->opsSession($admin, $selectedOrg));
+
+        Livewire::test(QualityResearchPage::class)
+            ->assertOk()
+            ->set('fromDate', $scenario['from'])
+            ->set('toDate', $scenario['to'])
+            ->call('applyFilters')
+            ->assertSet('hasQualityData', true)
+            ->assertSet('hasPsychometricsData', true)
+            ->assertSet('hasNormsData', true)
+            ->assertSet('qualityKpis.0.label', 'Sample size')
+            ->assertSet('qualityDailyRows.0.day', '2026-01-03')
+            ->call('setActiveTab', 'psychometrics')
+            ->assertSet('activeTab', 'psychometrics')
+            ->assertSet('psychometricRows.0.scale_code', 'BIG5_OCEAN')
+            ->call('setActiveTab', 'norms-drift')
+            ->assertSet('activeTab', 'norms-drift')
+            ->assertSet('normCoverageRows.0.scale_code', 'BIG5_OCEAN')
+            ->assertSet('rolloutRows.0.model_key', 'ml_beta')
+            ->assertSet('driftRows.0.reference_state', 'Internal compare reference');
+    }
+
+    private function createOrganization(string $name): Organization
+    {
+        return Organization::query()->create([
+            'name' => $name,
+            'owner_user_id' => random_int(1000, 9999),
+            'status' => 'active',
+            'domain' => Str::slug($name).'.example.test',
+            'timezone' => 'Asia/Shanghai',
+            'locale' => 'en',
+        ]);
+    }
+
+    /**
+     * @param  list<string>  $permissions
+     */
+    private function createAdminWithPermissions(array $permissions): AdminUser
+    {
+        $admin = AdminUser::query()->create([
+            'name' => 'ops_'.Str::lower(Str::random(6)),
+            'email' => 'ops_'.Str::lower(Str::random(6)).'@example.test',
+            'password' => bcrypt('secret'),
+            'is_active' => 1,
+        ]);
+
+        $role = Role::query()->create([
+            'name' => 'role_'.Str::lower(Str::random(8)),
+            'description' => null,
+        ]);
+
+        foreach ($permissions as $permissionName) {
+            $permission = Permission::query()->firstOrCreate(
+                ['name' => $permissionName],
+                ['description' => null],
+            );
+
+            $role->permissions()->syncWithoutDetaching([$permission->id]);
+        }
+
+        $admin->roles()->syncWithoutDetaching([$role->id]);
+
+        return $admin;
+    }
+
+    /**
+     * @return array{ops_org_id:int,ops_admin_totp_verified_user_id:int}
+     */
+    private function opsSession(AdminUser $admin, Organization $selectedOrg): array
+    {
+        return [
+            'ops_org_id' => (int) $selectedOrg->id,
+            'ops_admin_totp_verified_user_id' => (int) $admin->id,
+        ];
+    }
+}


### PR DESCRIPTION
Summary
- add Quality / Psychometrics / Norms & Drift as the next Assessment Insights page
- provide an internal-only diagnostics surface for quality, psychometrics, norm coverage, and rollout/drift references

What changed
- add analytics_scale_quality_daily
- add a refresh path for quality daily aggregation
- add a custom AIC-08 page in Filament Ops
- show Quality, Psychometrics, and Norms & Drift tabs with clear authority/reference boundaries
- document the first-phase internal metrics and sensitive-data boundaries

Design choices
- use a mixed fact model instead of forcing a single-table truth
- keep results + attempts / analytics_scale_quality_daily as the quality backbone
- keep psychometrics and norms/rollout views on existing stable objects
- avoid adding drift/rollout materialized compare tables in v1
- keep the page internal and admin-only under Assessment Insights

Why this PR is small and safe
- no frontend changes
- no API changes
- no Node/runtime changes
- no write-side behavior changes
- only the first internal quality/research diagnostics surface for AIC

Validation
- php artisan about
- php artisan route:list --path=ops --except-vendor
- php artisan migrate
- php artisan analytics:refresh-quality-daily --from=2026-01-01 --to=2026-01-07
- php artisan test --filter='(QualityInsightsDailyBuilderTest|RefreshQualityDailyCommandTest|QualityResearchInsightsSupportTest|QualityResearchPageTest)'
- php artisan test --filter='(Quality|Psychometric|Norms|Drift|AssessmentInsights)'
- php artisan filament:assets
- npm run build
- bash backend/scripts/ci_verify_mbti.sh

Notes
- the broad filtered test run still hits 4 existing out-of-scope failures tied to missing content_pack_activations in clinical/SDS tests
- all AIC-08-targeted tests pass
