### PR TITLE
fix(seo): make article canonical and sitemap locale-aware

### DIFF
--- a/backend/app/Http/Controllers/API/V0_5/Cms/ArticleController.php
+++ b/backend/app/Http/Controllers/API/V0_5/Cms/ArticleController.php
@@ -12,6 +12,7 @@ use App\Services\Cms\ArticleSeoService;
 use App\Services\Cms\ArticleService;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Validator;
 use InvalidArgumentException;
 use RuntimeException;
 
@@ -28,16 +29,25 @@ class ArticleController extends Controller
      */
     public function index(Request $request): JsonResponse
     {
-        $orgId = $this->resolveOrgId($request);
+        $validated = $this->validateListQuery($request);
+        if ($validated instanceof JsonResponse) {
+            return $validated;
+        }
 
-        $paginator = Article::query()
+        $query = Article::query()
             ->withoutGlobalScopes()
-            ->where('org_id', $orgId)
+            ->where('org_id', $validated['org_id'])
             ->published()
-            ->with(['category', 'tags', 'seoMeta'])
+            ->with($this->articleRelations());
+
+        if ($validated['locale'] !== null) {
+            $query->where('locale', $validated['locale']);
+        }
+
+        $paginator = $query
             ->orderByDesc('published_at')
             ->orderByDesc('id')
-            ->paginate(20);
+            ->paginate(20, ['*'], 'page', $validated['page']);
 
         $items = [];
         foreach ($paginator->items() as $article) {
@@ -105,7 +115,7 @@ class ArticleController extends Controller
             ], 404);
         }
 
-        $article->loadMissing(['category', 'tags', 'seoMeta']);
+        $article->loadMissing($this->articleRelations());
 
         return response()->json([
             'ok' => true,
@@ -187,7 +197,7 @@ class ArticleController extends Controller
             return $this->runtimeError($e);
         }
 
-        $article->loadMissing(['category', 'tags', 'seoMeta']);
+        $article->loadMissing($this->articleRelations());
 
         return response()->json([
             'ok' => true,
@@ -245,7 +255,7 @@ class ArticleController extends Controller
             return $this->runtimeError($e);
         }
 
-        $article->loadMissing(['category', 'tags', 'seoMeta']);
+        $article->loadMissing($this->articleRelations());
 
         return response()->json([
             'ok' => true,
@@ -276,7 +286,7 @@ class ArticleController extends Controller
             return $this->runtimeError($e);
         }
 
-        $article->loadMissing(['category', 'tags', 'seoMeta']);
+        $article->loadMissing($this->articleRelations());
 
         return response()->json([
             'ok' => true,
@@ -307,7 +317,7 @@ class ArticleController extends Controller
             return $this->runtimeError($e);
         }
 
-        $article->loadMissing(['category', 'tags', 'seoMeta']);
+        $article->loadMissing($this->articleRelations());
 
         return response()->json([
             'ok' => true,
@@ -363,6 +373,30 @@ class ArticleController extends Controller
         $raw = trim((string) $request->query('org_id', '0'));
 
         return preg_match('/^\d+$/', $raw) === 1 ? (int) $raw : 0;
+    }
+
+    /**
+     * @return array{org_id:int,locale:?string,page:int}|JsonResponse
+     */
+    private function validateListQuery(Request $request): array|JsonResponse
+    {
+        $validator = Validator::make($request->query(), [
+            'org_id' => ['nullable', 'integer', 'min:0'],
+            'locale' => ['nullable', 'in:en,zh-CN'],
+            'page' => ['nullable', 'integer', 'min:1'],
+        ]);
+
+        if ($validator->fails()) {
+            return $this->invalidArgumentMessage($validator->errors()->first());
+        }
+
+        $validated = $validator->validated();
+
+        return [
+            'org_id' => (int) ($validated['org_id'] ?? 0),
+            'locale' => isset($validated['locale']) ? (string) $validated['locale'] : null,
+            'page' => (int) ($validated['page'] ?? 1),
+        ];
     }
 
     private function resolveTrustedOrgId(Request $request): int
@@ -425,6 +459,18 @@ class ArticleController extends Controller
     }
 
     /**
+     * @return array<string, \Closure>
+     */
+    private function articleRelations(): array
+    {
+        return [
+            'category' => static fn ($query) => $query->withoutGlobalScopes(),
+            'tags' => static fn ($query) => $query->withoutGlobalScopes(),
+            'seoMeta' => static fn ($query) => $query->withoutGlobalScopes(),
+        ];
+    }
+
+    /**
      * @return array<string,mixed>
      */
     private function articlePayload(Article $article): array
@@ -456,10 +502,15 @@ class ArticleController extends Controller
 
     private function invalidArgument(InvalidArgumentException $e): JsonResponse
     {
+        return $this->invalidArgumentMessage($e->getMessage());
+    }
+
+    private function invalidArgumentMessage(string $message): JsonResponse
+    {
         return response()->json([
             'ok' => false,
             'error_code' => 'INVALID_ARGUMENT',
-            'message' => $e->getMessage(),
+            'message' => $message,
         ], 422);
     }
 

--- a/backend/app/Services/Cms/ArticleSeoService.php
+++ b/backend/app/Services/Cms/ArticleSeoService.php
@@ -13,6 +13,8 @@ use RuntimeException;
 
 final class ArticleSeoService
 {
+    public const SUPPORTED_LOCALES = ['en', 'zh-CN'];
+
     public function generateSeoMeta(int $articleId): ArticleSeoMeta
     {
         if ($articleId <= 0) {
@@ -30,10 +32,7 @@ final class ArticleSeoService
                 throw new RuntimeException('article not found.');
             }
 
-            $locale = trim((string) $article->locale);
-            if ($locale === '') {
-                $locale = 'en';
-            }
+            $locale = $this->normalizeLocale((string) $article->locale);
 
             $title = trim((string) $article->title);
             $descSource = trim((string) ($article->excerpt ?? ''));
@@ -43,7 +42,7 @@ final class ArticleSeoService
 
             $seoTitle = Str::limit($title, 60, '');
             $seoDescription = Str::limit($this->normalizeWhitespace($descSource), 160, '');
-            $canonicalUrl = $this->buildCanonicalUrl($locale, (string) $article->slug);
+            $canonicalUrl = $this->buildCanonicalUrl((string) $article->slug, $locale);
             $ogTitle = Str::limit($title, 90, '');
             $ogDescription = Str::limit($this->normalizeWhitespace($descSource), 200, '');
 
@@ -73,36 +72,20 @@ final class ArticleSeoService
      */
     public function buildSeoPayload(Article $article): array
     {
-        $locale = trim((string) $article->locale);
-        if ($locale === '') {
-            $locale = 'en';
-        }
-
-        $seo = null;
-        if ($article->relationLoaded('seoMeta') && $article->seoMeta instanceof ArticleSeoMeta) {
-            $seo = $article->seoMeta;
-        }
-
-        if (! $seo instanceof ArticleSeoMeta) {
-            $seo = ArticleSeoMeta::query()
-                ->withoutGlobalScopes()
-                ->where('org_id', (int) $article->org_id)
-                ->where('article_id', (int) $article->id)
-                ->where('locale', $locale)
-                ->first();
-        }
+        $locale = $this->normalizeLocale((string) $article->locale);
+        $seo = $this->resolveSeoMeta($article, $locale);
 
         $title = $seo?->seo_title ?? $article->title;
         $descriptionSource = (string) ($article->excerpt ?? $article->content_md);
-        $description = $seo?->seo_description ?? Str::limit(strip_tags($descriptionSource), 160);
-
-        $canonical = $seo?->canonical_url
-            ?? rtrim((string) config('app.url', ''), '/').'/articles/'.rawurlencode((string) $article->slug);
+        $description = $seo?->seo_description
+            ?? Str::limit($this->normalizeWhitespace(strip_tags($descriptionSource)), 160);
+        $canonical = $this->buildCanonicalUrl((string) $article->slug, $locale);
 
         return [
             'title' => $title,
             'description' => $description,
             'canonical' => $canonical,
+            'alternates' => $this->buildAlternates($article),
 
             'og' => [
                 'title' => $seo?->og_title ?? $title,
@@ -118,7 +101,7 @@ final class ArticleSeoService
                 'image' => $seo?->og_image_url,
             ],
 
-            'robots' => $seo?->robots ?? 'index,follow',
+            'robots' => $seo?->robots ?? ((bool) $article->is_indexable ? 'index,follow' : 'noindex,nofollow'),
         ];
     }
 
@@ -127,18 +110,63 @@ final class ArticleSeoService
      */
     public function generateJsonLd(Article $article): array
     {
-        return [
+        $locale = $this->normalizeLocale((string) $article->locale);
+        $seo = $this->resolveSeoMeta($article, $locale);
+        $canonical = $this->buildCanonicalUrl((string) $article->slug, $locale);
+        $descriptionSource = (string) ($article->excerpt ?? $article->content_md);
+
+        $jsonLd = [
             '@context' => 'https://schema.org',
             '@type' => 'Article',
-            'headline' => $article->title,
+            'headline' => $seo?->seo_title ?? $article->title,
+            'description' => $seo?->seo_description
+                ?? Str::limit($this->normalizeWhitespace(strip_tags($descriptionSource)), 160),
             'datePublished' => optional($article->published_at)->toAtomString(),
             'dateModified' => optional($article->updated_at)->toAtomString(),
             'author' => [
                 '@type' => 'Organization',
                 'name' => 'FermatMind',
             ],
-            'mainEntityOfPage' => rtrim((string) config('app.url', ''), '/').'/articles/'.rawurlencode((string) $article->slug),
+            '@id' => $canonical,
+            'url' => $canonical,
+            'mainEntityOfPage' => $canonical,
         ];
+
+        if ($seo instanceof ArticleSeoMeta && is_array($seo->schema_json)) {
+            $jsonLd = array_replace_recursive($jsonLd, $seo->schema_json);
+        }
+
+        return $this->normalizeJsonLdUrls($jsonLd, $canonical, (string) $article->slug);
+    }
+
+    public function buildCanonicalUrl(string $slug, string $locale): ?string
+    {
+        $baseUrl = $this->frontendBaseUrl();
+        $resolvedSlug = trim($slug);
+
+        if ($baseUrl === '' || $resolvedSlug === '') {
+            return null;
+        }
+
+        return $baseUrl
+            .'/'.$this->mapBackendLocaleToFrontendSegment($locale)
+            .'/articles/'
+            .rawurlencode($resolvedSlug);
+    }
+
+    public function buildListUrl(string $locale): ?string
+    {
+        $baseUrl = $this->frontendBaseUrl();
+        if ($baseUrl === '') {
+            return null;
+        }
+
+        return $baseUrl.'/'.$this->mapBackendLocaleToFrontendSegment($locale).'/articles';
+    }
+
+    public function mapBackendLocaleToFrontendSegment(string $locale): string
+    {
+        return $this->normalizeLocale($locale) === 'zh-CN' ? 'zh' : 'en';
     }
 
     private function extractDescription(string $contentMd): string
@@ -168,15 +196,120 @@ final class ArticleSeoService
         return is_string($normalized) ? $normalized : trim($value);
     }
 
-    private function buildCanonicalUrl(string $locale, string $slug): ?string
+    private function resolveSeoMeta(Article $article, string $locale): ?ArticleSeoMeta
     {
-        $baseUrl = rtrim((string) config('app.url', ''), '/');
-        $slug = trim($slug);
-
-        if ($baseUrl === '' || $slug === '') {
-            return null;
+        if (
+            $article->relationLoaded('seoMeta')
+            && $article->seoMeta instanceof ArticleSeoMeta
+            && $this->normalizeLocale((string) $article->seoMeta->locale) === $locale
+        ) {
+            return $article->seoMeta;
         }
 
-        return $baseUrl.'/articles/'.rawurlencode($slug);
+        return ArticleSeoMeta::query()
+            ->withoutGlobalScopes()
+            ->where('org_id', (int) $article->org_id)
+            ->where('article_id', (int) $article->id)
+            ->where('locale', $locale)
+            ->first();
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    private function buildAlternates(Article $article): array
+    {
+        $variants = Article::query()
+            ->withoutGlobalScopes()
+            ->where('org_id', (int) $article->org_id)
+            ->where('slug', (string) $article->slug)
+            ->where('status', 'published')
+            ->where('is_public', true)
+            ->whereIn('locale', self::SUPPORTED_LOCALES)
+            ->pluck('locale')
+            ->all();
+
+        $availableLocales = [];
+        foreach ($variants as $variantLocale) {
+            $availableLocales[$this->normalizeLocale((string) $variantLocale)] = true;
+        }
+
+        $alternates = [];
+        foreach (self::SUPPORTED_LOCALES as $supportedLocale) {
+            if (! isset($availableLocales[$supportedLocale])) {
+                continue;
+            }
+
+            $canonical = $this->buildCanonicalUrl((string) $article->slug, $supportedLocale);
+            if ($canonical === null) {
+                continue;
+            }
+
+            $alternates[$supportedLocale] = $canonical;
+            if ($supportedLocale === 'zh-CN') {
+                $alternates['zh'] = $canonical;
+            }
+        }
+
+        return $alternates;
+    }
+
+    /**
+     * @param  array<string, mixed>  $jsonLd
+     * @return array<string, mixed>
+     */
+    private function normalizeJsonLdUrls(array $jsonLd, ?string $canonical, string $slug): array
+    {
+        $walk = function (mixed $value) use (&$walk, $canonical, $slug): mixed {
+            if (is_array($value)) {
+                $normalized = [];
+                foreach ($value as $key => $nested) {
+                    $normalized[$key] = $walk($nested);
+                }
+
+                return $normalized;
+            }
+
+            if (! is_string($value) || $canonical === null || trim($value) === '') {
+                return $value;
+            }
+
+            $legacyCandidates = [];
+            foreach (array_unique(array_filter([
+                rtrim((string) config('app.url', ''), '/'),
+                $this->frontendBaseUrl(),
+            ])) as $baseUrl) {
+                $legacyCandidates[] = $baseUrl.'/articles/'.rawurlencode(trim($slug));
+            }
+            $legacyCandidates[] = '/articles/'.rawurlencode(trim($slug));
+
+            foreach ($legacyCandidates as $candidate) {
+                if ($candidate === '') {
+                    continue;
+                }
+
+                if ($value === $candidate) {
+                    return $canonical;
+                }
+
+                if (str_starts_with($value, $candidate.'#')) {
+                    return $canonical.substr($value, strlen($candidate));
+                }
+            }
+
+            return $value;
+        };
+
+        return $walk($jsonLd);
+    }
+
+    private function frontendBaseUrl(): string
+    {
+        return rtrim((string) config('app.frontend_url', config('app.url', '')), '/');
+    }
+
+    private function normalizeLocale(string $locale): string
+    {
+        return trim($locale) === 'zh-CN' ? 'zh-CN' : 'en';
     }
 }

--- a/backend/app/Services/SEO/SitemapGenerator.php
+++ b/backend/app/Services/SEO/SitemapGenerator.php
@@ -2,9 +2,11 @@
 
 namespace App\Services\SEO;
 
+use App\Models\Article;
 use App\Models\CareerJob;
 use App\Models\PersonalityProfile;
 use App\Models\TopicProfile;
+use App\Services\Cms\ArticleSeoService;
 use App\Services\Cms\CareerJobSeoService;
 use App\Services\Cms\PersonalityProfileSeoService;
 use App\Services\Cms\TopicProfileSeoService;
@@ -16,6 +18,7 @@ class SitemapGenerator
     private string $urlPrefix;
 
     public function __construct(
+        private readonly ArticleSeoService $articleSeoService,
         private readonly CareerJobSeoService $careerJobSeoService,
         private readonly PersonalityProfileSeoService $personalityProfileSeoService,
         private readonly TopicProfileSeoService $topicProfileSeoService,
@@ -34,7 +37,7 @@ class SitemapGenerator
 
         $urls = array_merge(
             $this->getScaleUrls($locale),
-            $this->getArticleUrls($locale),
+            $this->getArticleUrls(),
             $this->getCareerJobUrls(),
             $this->getPersonalityUrls(),
             $this->getTopicUrls()
@@ -132,33 +135,70 @@ class SitemapGenerator
         return $urls;
     }
 
-    private function getArticleUrls(string $locale): array
+    private function getArticleUrls(): array
     {
-        $rows = \App\Models\Article::query()
+        $rows = Article::query()
             ->withoutGlobalScopes()
             ->where('org_id', 0)
             ->where('status', 'published')
             ->where('is_public', true)
             ->where('is_indexable', true)
-            ->select(['slug', 'updated_at', 'published_at'])
-            ->orderByDesc('updated_at')
+            ->whereIn('locale', ArticleSeoService::SUPPORTED_LOCALES)
+            ->whereNotNull('slug')
+            ->where('slug', '<>', '')
+            ->where(static function ($query): void {
+                $query->whereNull('published_at')
+                    ->orWhere('published_at', '<=', now());
+            })
+            ->select(['slug', 'locale', 'updated_at', 'published_at'])
+            ->orderBy('locale')
+            ->orderBy('slug')
             ->get();
 
-        $prefix = rtrim((string) config('services.seo.articles_url_prefix'), '/');
-
         $urls = [];
+        $listLastModified = [];
 
         foreach ($rows as $row) {
-            $url = $prefix.'/'.rawurlencode($row->slug);
+            $slug = trim((string) $row->slug);
+            $locale = trim((string) $row->locale);
+
+            if ($slug === '' || $locale === '') {
+                continue;
+            }
 
             $lastmod = $row->updated_at
                 ?? $row->published_at
                 ?? now();
 
+            $segment = $this->articleSeoService->mapBackendLocaleToFrontendSegment($locale);
+            $url = $this->articleSeoService->buildCanonicalUrl($slug, $locale);
+
+            if ($url === null) {
+                continue;
+            }
+
             $urls[] = [
                 'loc' => $url,
                 'lastmod' => $lastmod->toAtomString(),
-                'slug' => (string) $row->slug,
+                'slug' => 'articles:'.$segment.':'.$slug,
+                'updated_at' => $lastmod->toDateTimeString(),
+            ];
+
+            if (! isset($listLastModified[$locale]) || $lastmod->gt($listLastModified[$locale])) {
+                $listLastModified[$locale] = $lastmod;
+            }
+        }
+
+        foreach ($listLastModified as $locale => $lastmod) {
+            $url = $this->articleSeoService->buildListUrl((string) $locale);
+            if ($url === null) {
+                continue;
+            }
+
+            $urls[] = [
+                'loc' => $url,
+                'lastmod' => $lastmod->toAtomString(),
+                'slug' => 'articles-list:'.$this->articleSeoService->mapBackendLocaleToFrontendSegment((string) $locale),
                 'updated_at' => $lastmod->toDateTimeString(),
             ];
         }

--- a/backend/tests/Feature/SEO/ArticleSeoServiceTest.php
+++ b/backend/tests/Feature/SEO/ArticleSeoServiceTest.php
@@ -1,0 +1,63 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\SEO;
+
+use App\Models\Article;
+use App\Models\ArticleSeoMeta;
+use App\Services\Cms\ArticleSeoService;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Carbon;
+use Tests\TestCase;
+
+final class ArticleSeoServiceTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_generate_seo_meta_persists_localized_frontend_canonical_url(): void
+    {
+        config([
+            'app.url' => 'https://api.staging.fermatmind.com',
+            'app.frontend_url' => 'https://staging.fermatmind.com',
+        ]);
+
+        $article = Article::query()->create([
+            'org_id' => 0,
+            'slug' => 'mbti-basics',
+            'locale' => 'zh-CN',
+            'title' => 'MBTI 基础',
+            'excerpt' => '了解 MBTI 的核心概念。',
+            'content_md' => '# MBTI 基础',
+            'status' => 'published',
+            'is_public' => true,
+            'is_indexable' => true,
+            'published_at' => Carbon::create(2026, 3, 12, 8, 0, 0, 'UTC'),
+            'scheduled_at' => null,
+            'created_at' => Carbon::create(2026, 3, 12, 8, 0, 0, 'UTC'),
+            'updated_at' => Carbon::create(2026, 3, 12, 9, 0, 0, 'UTC'),
+        ]);
+
+        ArticleSeoMeta::query()->create([
+            'org_id' => 0,
+            'article_id' => (int) $article->id,
+            'locale' => 'zh-CN',
+            'seo_title' => 'MBTI 基础',
+            'seo_description' => '旧的 seo 描述',
+            'canonical_url' => 'https://api.staging.fermatmind.com/articles/mbti-basics',
+            'og_title' => 'MBTI 基础',
+            'og_description' => '旧的 seo 描述',
+            'robots' => 'index,follow',
+            'is_indexable' => true,
+        ]);
+
+        $seoMeta = app(ArticleSeoService::class)->generateSeoMeta((int) $article->id);
+
+        $this->assertSame('https://staging.fermatmind.com/zh/articles/mbti-basics', $seoMeta->canonical_url);
+        $this->assertDatabaseHas('article_seo_meta', [
+            'article_id' => (int) $article->id,
+            'locale' => 'zh-CN',
+            'canonical_url' => 'https://staging.fermatmind.com/zh/articles/mbti-basics',
+        ]);
+    }
+}

--- a/backend/tests/Feature/SEO/SitemapGeneratorTest.php
+++ b/backend/tests/Feature/SEO/SitemapGeneratorTest.php
@@ -2,9 +2,11 @@
 
 namespace Tests\Feature\SEO;
 
+use App\Models\Article;
 use App\Models\CareerJob;
 use App\Models\PersonalityProfile;
 use App\Models\TopicProfile;
+use App\Services\Cms\ArticleSeoService;
 use App\Services\Cms\CareerJobSeoService;
 use App\Services\Cms\PersonalityProfileSeoService;
 use App\Services\Cms\TopicProfileSeoService;
@@ -101,6 +103,97 @@ class SitemapGeneratorTest extends TestCase
         $this->assertStringNotContainsString($prefix.'private-global-alt', $xml);
         $this->assertStringNotContainsString($prefix.'tenant-public', $xml);
         $this->assertStringNotContainsString($prefix.'tenant-public-alt', $xml);
+    }
+
+    public function test_generate_includes_only_indexable_global_article_urls_with_locale_aware_paths(): void
+    {
+        config([
+            'app.url' => 'https://api.staging.fermatmind.com',
+            'app.frontend_url' => 'https://staging.fermatmind.com',
+        ]);
+
+        $eligibleEn = $this->createArticle([
+            'slug' => 'mbti-basics',
+            'locale' => 'en',
+            'title' => 'MBTI Basics',
+            'excerpt' => 'Learn the core concepts behind MBTI.',
+            'published_at' => Carbon::create(2026, 3, 6, 9, 0, 0, 'UTC'),
+            'updated_at' => Carbon::create(2026, 3, 6, 10, 0, 0, 'UTC'),
+        ]);
+
+        $eligibleZh = $this->createArticle([
+            'slug' => 'mbti-basics',
+            'locale' => 'zh-CN',
+            'title' => 'MBTI 基础',
+            'excerpt' => '了解 MBTI 的核心概念。',
+            'published_at' => Carbon::create(2026, 3, 6, 11, 0, 0, 'UTC'),
+            'updated_at' => Carbon::create(2026, 3, 6, 12, 0, 0, 'UTC'),
+        ]);
+
+        $this->createArticle([
+            'slug' => 'draft-article',
+            'locale' => 'en',
+            'status' => 'draft',
+            'updated_at' => Carbon::create(2026, 3, 6, 12, 30, 0, 'UTC'),
+        ]);
+        $this->createArticle([
+            'slug' => 'private-article',
+            'locale' => 'en',
+            'is_public' => false,
+            'updated_at' => Carbon::create(2026, 3, 6, 12, 45, 0, 'UTC'),
+        ]);
+        $this->createArticle([
+            'slug' => 'noindex-article',
+            'locale' => 'en',
+            'is_indexable' => false,
+            'updated_at' => Carbon::create(2026, 3, 6, 13, 0, 0, 'UTC'),
+        ]);
+        $this->createArticle([
+            'org_id' => 9,
+            'slug' => 'tenant-article',
+            'locale' => 'en',
+            'updated_at' => Carbon::create(2026, 3, 6, 13, 15, 0, 'UTC'),
+        ]);
+        $this->createArticle([
+            'slug' => 'future-article',
+            'locale' => 'en',
+            'published_at' => Carbon::now('UTC')->addDay(),
+            'updated_at' => Carbon::create(2026, 3, 6, 13, 30, 0, 'UTC'),
+        ]);
+        $this->createArticle([
+            'slug' => 'fr-article',
+            'locale' => 'fr',
+            'updated_at' => Carbon::create(2026, 3, 6, 13, 45, 0, 'UTC'),
+        ]);
+
+        $payload = app(SitemapGenerator::class)->generate();
+        $xml = (string) ($payload['xml'] ?? '');
+
+        $this->assertStringContainsString('https://staging.fermatmind.com/en/articles', $xml);
+        $this->assertStringContainsString('https://staging.fermatmind.com/zh/articles', $xml);
+        $this->assertStringContainsString('https://staging.fermatmind.com/en/articles/mbti-basics', $xml);
+        $this->assertStringContainsString('https://staging.fermatmind.com/zh/articles/mbti-basics', $xml);
+
+        $this->assertStringNotContainsString('https://staging.fermatmind.com/articles/mbti-basics', $xml);
+        $this->assertStringNotContainsString('https://staging.fermatmind.com/en/articles/draft-article', $xml);
+        $this->assertStringNotContainsString('https://staging.fermatmind.com/en/articles/private-article', $xml);
+        $this->assertStringNotContainsString('https://staging.fermatmind.com/en/articles/noindex-article', $xml);
+        $this->assertStringNotContainsString('https://staging.fermatmind.com/en/articles/tenant-article', $xml);
+        $this->assertStringNotContainsString('https://staging.fermatmind.com/en/articles/future-article', $xml);
+        $this->assertStringNotContainsString('https://staging.fermatmind.com/fr/articles/fr-article', $xml);
+
+        $seoService = app(ArticleSeoService::class);
+
+        $this->assertSame(
+            $seoService->buildCanonicalUrl((string) $eligibleEn->slug, (string) $eligibleEn->locale),
+            data_get($seoService->buildSeoPayload($eligibleEn), 'canonical')
+        );
+        $this->assertSame(
+            $seoService->buildCanonicalUrl((string) $eligibleZh->slug, (string) $eligibleZh->locale),
+            data_get($seoService->buildSeoPayload($eligibleZh), 'canonical')
+        );
+        $this->assertStringContainsString(data_get($seoService->buildSeoPayload($eligibleEn), 'canonical'), $xml);
+        $this->assertStringContainsString(data_get($seoService->buildSeoPayload($eligibleZh), 'canonical'), $xml);
     }
 
     public function test_generate_includes_only_indexable_global_personality_urls_with_locale_aware_paths(): void
@@ -356,7 +449,7 @@ class SitemapGeneratorTest extends TestCase
             'job_code' => 'future-role',
             'slug' => 'future-role',
             'locale' => 'en',
-            'published_at' => Carbon::create(2026, 3, 12, 9, 0, 0, 'UTC'),
+            'published_at' => Carbon::now('UTC')->addDay(),
             'updated_at' => Carbon::create(2026, 3, 8, 13, 30, 0, 'UTC'),
         ]);
         $this->createCareerJob([
@@ -420,6 +513,33 @@ class SitemapGeneratorTest extends TestCase
             'schema_version' => 'v1',
             'created_at' => Carbon::create(2026, 3, 7, 8, 0, 0, 'UTC'),
             'updated_at' => Carbon::create(2026, 3, 7, 8, 0, 0, 'UTC'),
+        ], $overrides));
+    }
+
+    /**
+     * @param  array<string, mixed>  $overrides
+     */
+    private function createArticle(array $overrides = []): Article
+    {
+        /** @var Article */
+        return Article::query()->create(array_merge([
+            'org_id' => 0,
+            'category_id' => null,
+            'author_admin_user_id' => null,
+            'slug' => 'article-slug',
+            'locale' => 'en',
+            'title' => 'Article Title',
+            'excerpt' => 'Article excerpt.',
+            'content_md' => '# Article body',
+            'content_html' => null,
+            'cover_image_url' => null,
+            'status' => 'published',
+            'is_public' => true,
+            'is_indexable' => true,
+            'published_at' => Carbon::create(2026, 3, 6, 8, 0, 0, 'UTC'),
+            'scheduled_at' => null,
+            'created_at' => Carbon::create(2026, 3, 6, 8, 0, 0, 'UTC'),
+            'updated_at' => Carbon::create(2026, 3, 6, 8, 0, 0, 'UTC'),
         ], $overrides));
     }
 

--- a/backend/tests/Feature/SEO/SitemapXmlTest.php
+++ b/backend/tests/Feature/SEO/SitemapXmlTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Feature\SEO;
 
+use App\Models\Article;
 use App\Models\CareerJob;
 use App\Models\PersonalityProfile;
 use App\Models\TopicProfile;
@@ -177,6 +178,60 @@ class SitemapXmlTest extends TestCase
             'updated_at' => $nowB,
         ]);
 
+        Article::query()->create([
+            'org_id' => 0,
+            'slug' => 'mbti-basics',
+            'locale' => 'en',
+            'title' => 'MBTI Basics',
+            'excerpt' => 'Learn the core concepts behind MBTI.',
+            'content_md' => '# MBTI Basics',
+            'content_html' => null,
+            'cover_image_url' => null,
+            'status' => 'published',
+            'is_public' => true,
+            'is_indexable' => true,
+            'published_at' => Carbon::create(2026, 1, 31, 11, 35, 0),
+            'scheduled_at' => null,
+            'created_at' => $nowB,
+            'updated_at' => $nowB,
+        ]);
+
+        Article::query()->create([
+            'org_id' => 0,
+            'slug' => 'mbti-basics',
+            'locale' => 'zh-CN',
+            'title' => 'MBTI 基础',
+            'excerpt' => '了解 MBTI 的核心概念。',
+            'content_md' => '# MBTI 基础',
+            'content_html' => null,
+            'cover_image_url' => null,
+            'status' => 'published',
+            'is_public' => true,
+            'is_indexable' => true,
+            'published_at' => Carbon::create(2026, 1, 31, 12, 35, 0),
+            'scheduled_at' => null,
+            'created_at' => $nowB,
+            'updated_at' => $nowB,
+        ]);
+
+        Article::query()->create([
+            'org_id' => 0,
+            'slug' => 'article-draft',
+            'locale' => 'en',
+            'title' => 'Draft Article',
+            'excerpt' => 'Draft article should stay out of sitemap.',
+            'content_md' => '# Draft Article',
+            'content_html' => null,
+            'cover_image_url' => null,
+            'status' => 'draft',
+            'is_public' => true,
+            'is_indexable' => true,
+            'published_at' => null,
+            'scheduled_at' => null,
+            'created_at' => $nowB,
+            'updated_at' => $nowB,
+        ]);
+
         CareerJob::query()->create([
             'org_id' => 0,
             'job_code' => 'product-manager',
@@ -262,6 +317,12 @@ class SitemapXmlTest extends TestCase
         $this->assertStringContainsString('<loc>https://staging.fermatmind.com/en/topics/mbti</loc>', $body);
         $this->assertStringContainsString('<loc>https://staging.fermatmind.com/zh/topics/mbti</loc>', $body);
         $this->assertStringNotContainsString('<loc>https://staging.fermatmind.com/en/topics/big-five</loc>', $body);
+        $this->assertStringContainsString('<loc>https://staging.fermatmind.com/en/articles</loc>', $body);
+        $this->assertStringContainsString('<loc>https://staging.fermatmind.com/zh/articles</loc>', $body);
+        $this->assertStringContainsString('<loc>https://staging.fermatmind.com/en/articles/mbti-basics</loc>', $body);
+        $this->assertStringContainsString('<loc>https://staging.fermatmind.com/zh/articles/mbti-basics</loc>', $body);
+        $this->assertStringNotContainsString('<loc>https://staging.fermatmind.com/articles/mbti-basics</loc>', $body);
+        $this->assertStringNotContainsString('<loc>https://staging.fermatmind.com/en/articles/article-draft</loc>', $body);
         $this->assertStringContainsString('<loc>https://staging.fermatmind.com/en/career/jobs</loc>', $body);
         $this->assertStringContainsString('<loc>https://staging.fermatmind.com/zh/career/jobs</loc>', $body);
         $this->assertStringContainsString('<loc>https://staging.fermatmind.com/en/career/jobs/product-manager</loc>', $body);

--- a/backend/tests/Feature/V0_5/ArticlePublicApiTest.php
+++ b/backend/tests/Feature/V0_5/ArticlePublicApiTest.php
@@ -1,0 +1,194 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\V0_5;
+
+use App\Models\Article;
+use App\Models\ArticleSeoMeta;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Carbon;
+use Tests\TestCase;
+
+final class ArticlePublicApiTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_list_locale_query_filters_items_and_pagination(): void
+    {
+        foreach (range(1, 21) as $index) {
+            $this->createArticle([
+                'slug' => sprintf('english-article-%02d', $index),
+                'locale' => 'en',
+                'title' => sprintf('English Article %02d', $index),
+                'published_at' => Carbon::create(2026, 3, 10, 8, $index, 0, 'UTC'),
+                'updated_at' => Carbon::create(2026, 3, 10, 9, $index, 0, 'UTC'),
+            ]);
+        }
+
+        $zhArticle = $this->createArticle([
+            'slug' => 'zh-only-article',
+            'locale' => 'zh-CN',
+            'title' => '中文文章',
+            'published_at' => Carbon::create(2026, 3, 11, 8, 0, 0, 'UTC'),
+            'updated_at' => Carbon::create(2026, 3, 11, 9, 0, 0, 'UTC'),
+        ]);
+
+        $enPageOne = $this->getJson('/api/v0.5/articles?locale=en&page=1');
+
+        $enPageOne->assertOk()
+            ->assertJsonPath('ok', true)
+            ->assertJsonPath('pagination.current_page', 1)
+            ->assertJsonPath('pagination.per_page', 20)
+            ->assertJsonPath('pagination.total', 21)
+            ->assertJsonPath('pagination.last_page', 2)
+            ->assertJsonCount(20, 'items');
+
+        $this->assertSame(
+            ['en'],
+            array_values(array_unique(array_column($enPageOne->json('items') ?? [], 'locale')))
+        );
+
+        $this->getJson('/api/v0.5/articles?locale=en&page=2')
+            ->assertOk()
+            ->assertJsonPath('pagination.current_page', 2)
+            ->assertJsonPath('pagination.total', 21)
+            ->assertJsonPath('pagination.last_page', 2)
+            ->assertJsonCount(1, 'items')
+            ->assertJsonPath('items.0.locale', 'en');
+
+        $this->getJson('/api/v0.5/articles?locale=zh-CN&page=1')
+            ->assertOk()
+            ->assertJsonPath('pagination.current_page', 1)
+            ->assertJsonPath('pagination.total', 1)
+            ->assertJsonPath('pagination.last_page', 1)
+            ->assertJsonCount(1, 'items')
+            ->assertJsonPath('items.0.slug', (string) $zhArticle->slug)
+            ->assertJsonPath('items.0.locale', 'zh-CN');
+    }
+
+    public function test_article_seo_detail_returns_localized_frontend_canonical_alternates_and_jsonld_urls(): void
+    {
+        config([
+            'app.url' => 'https://api.staging.fermatmind.com',
+            'app.frontend_url' => 'https://staging.fermatmind.com',
+        ]);
+
+        $articleEn = $this->createArticle([
+            'slug' => 'mbti-basics',
+            'locale' => 'en',
+            'title' => 'MBTI Basics',
+            'excerpt' => 'Learn the core concepts behind MBTI.',
+        ]);
+        $this->createArticle([
+            'slug' => 'mbti-basics',
+            'locale' => 'zh-CN',
+            'title' => 'MBTI 基础',
+            'excerpt' => '了解 MBTI 的核心概念。',
+        ]);
+
+        $legacyCanonical = 'https://api.staging.fermatmind.com/articles/mbti-basics';
+        $this->createSeoMeta($articleEn, [
+            'seo_title' => 'MBTI Basics | FermatMind',
+            'seo_description' => 'Learn the core concepts behind MBTI.',
+            'canonical_url' => $legacyCanonical,
+            'schema_json' => [
+                '@id' => $legacyCanonical.'#article',
+                'url' => $legacyCanonical,
+                'mainEntityOfPage' => $legacyCanonical.'#webpage',
+            ],
+        ]);
+
+        $canonical = 'https://staging.fermatmind.com/en/articles/mbti-basics';
+        $zhCanonical = 'https://staging.fermatmind.com/zh/articles/mbti-basics';
+
+        $response = $this->getJson('/api/v0.5/articles/mbti-basics/seo?locale=en');
+
+        $response->assertOk()
+            ->assertJsonPath('meta.canonical', $canonical)
+            ->assertJsonPath('meta.alternates.en', $canonical)
+            ->assertJsonPath('meta.alternates.zh', $zhCanonical)
+            ->assertJsonPath('meta.alternates.zh-CN', $zhCanonical)
+            ->assertJsonPath('jsonld.url', $canonical)
+            ->assertJsonPath('jsonld.mainEntityOfPage', $canonical.'#webpage');
+
+        $this->assertSame($canonical.'#article', data_get($response->json(), 'jsonld.@id'));
+        $this->assertStringNotContainsString($legacyCanonical, (string) $response->getContent());
+    }
+
+    public function test_article_seo_does_not_fake_missing_locale_alternates(): void
+    {
+        config([
+            'app.url' => 'https://api.staging.fermatmind.com',
+            'app.frontend_url' => 'https://staging.fermatmind.com',
+        ]);
+
+        $this->createArticle([
+            'slug' => 'solo-article',
+            'locale' => 'en',
+            'title' => 'Solo Article',
+            'excerpt' => 'Only one locale exists for this article.',
+        ]);
+
+        $canonical = 'https://staging.fermatmind.com/en/articles/solo-article';
+        $response = $this->getJson('/api/v0.5/articles/solo-article/seo?locale=en');
+
+        $response->assertOk()
+            ->assertJsonPath('meta.canonical', $canonical)
+            ->assertJsonPath('meta.alternates.en', $canonical)
+            ->assertJsonPath('jsonld.url', $canonical)
+            ->assertJsonPath('jsonld.mainEntityOfPage', $canonical);
+
+        $this->assertNull(data_get($response->json(), 'meta.alternates.zh'));
+        $this->assertNull(data_get($response->json(), 'meta.alternates.zh-CN'));
+    }
+
+    /**
+     * @param  array<string, mixed>  $overrides
+     */
+    private function createArticle(array $overrides = []): Article
+    {
+        /** @var Article */
+        return Article::query()->create(array_merge([
+            'org_id' => 0,
+            'category_id' => null,
+            'author_admin_user_id' => null,
+            'slug' => 'article-slug',
+            'locale' => 'en',
+            'title' => 'Article Title',
+            'excerpt' => 'Article excerpt.',
+            'content_md' => '# Article body',
+            'content_html' => null,
+            'cover_image_url' => null,
+            'status' => 'published',
+            'is_public' => true,
+            'is_indexable' => true,
+            'published_at' => Carbon::create(2026, 3, 9, 8, 0, 0, 'UTC'),
+            'scheduled_at' => null,
+            'created_at' => Carbon::create(2026, 3, 9, 8, 0, 0, 'UTC'),
+            'updated_at' => Carbon::create(2026, 3, 9, 9, 0, 0, 'UTC'),
+        ], $overrides));
+    }
+
+    /**
+     * @param  array<string, mixed>  $overrides
+     */
+    private function createSeoMeta(Article $article, array $overrides = []): ArticleSeoMeta
+    {
+        /** @var ArticleSeoMeta */
+        return ArticleSeoMeta::query()->create(array_merge([
+            'org_id' => (int) $article->org_id,
+            'article_id' => (int) $article->id,
+            'locale' => (string) $article->locale,
+            'seo_title' => (string) $article->title,
+            'seo_description' => (string) ($article->excerpt ?? ''),
+            'canonical_url' => null,
+            'og_title' => (string) $article->title,
+            'og_description' => (string) ($article->excerpt ?? ''),
+            'og_image_url' => null,
+            'robots' => 'index,follow',
+            'schema_json' => null,
+            'is_indexable' => true,
+        ], $overrides));
+    }
+}


### PR DESCRIPTION
Summary
- make backend article canonical and sitemap output locale-aware
- provide the backend foundation required for later frontend article authority cleanup

What changed
- update Article SEO output to use localized frontend canonical URLs
- add article alternates and align JSON-LD URLs with localized canonical URLs
- make backend sitemap include localized article list/detail URLs
- make article list API locale-aware for stable frontend enumeration

Design choices
- keep the existing article API surface and apply only minimal contract fixes
- use backend as the authoritative source for localized article canonical and sitemap output
- avoid adding a list SEO endpoint in this PR
- defer frontend sitemap/llms cleanup to the next PR

Why this PR is small and safe
- no frontend changes
- no route changes
- no content-model changes
- no workspace changes
- only the backend SEO/sitemap/list-contract foundation for articles

Validation
- php artisan about
- php artisan route:list
- php artisan migrate
- php artisan test --filter='(ArticlePublicApi|SitemapGenerator|SitemapXml|ArticleSeo)'
- php artisan filament:assets
- npm run build
- bash scripts/ci_verify_mbti.sh

Merge note
- merge only after confirming how production https://fermatmind.com/sitemap.xml is currently served, since the follow-up frontend cleanup depends on that authority handoff being understood
