### PR TITLE
feat(career-cms): add CareerGuide schema and model foundation

### DIFF
--- a/backend/app/Models/CareerGuide.php
+++ b/backend/app/Models/CareerGuide.php
@@ -1,0 +1,146 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Models;
+
+use App\Models\Concerns\HasOrgScope;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsToMany;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+use Illuminate\Database\Eloquent\Relations\HasOne;
+
+class CareerGuide extends Model
+{
+    use HasFactory, HasOrgScope;
+
+    public const STATUS_DRAFT = 'draft';
+
+    public const STATUS_PUBLISHED = 'published';
+
+    public const SUPPORTED_LOCALES = [
+        'en',
+        'zh-CN',
+    ];
+
+    protected $table = 'career_guides';
+
+    protected $fillable = [
+        'org_id',
+        'guide_code',
+        'slug',
+        'locale',
+        'title',
+        'excerpt',
+        'category_slug',
+        'body_md',
+        'body_html',
+        'related_industry_slugs_json',
+        'status',
+        'is_public',
+        'is_indexable',
+        'sort_order',
+        'published_at',
+        'scheduled_at',
+        'schema_version',
+    ];
+
+    protected $casts = [
+        'org_id' => 'integer',
+        'related_industry_slugs_json' => 'array',
+        'is_public' => 'boolean',
+        'is_indexable' => 'boolean',
+        'sort_order' => 'integer',
+        'published_at' => 'datetime',
+        'scheduled_at' => 'datetime',
+        'created_at' => 'datetime',
+        'updated_at' => 'datetime',
+    ];
+
+    public static function allowOrgZeroContext(): bool
+    {
+        return true;
+    }
+
+    public function seoMeta(): HasOne
+    {
+        return $this->hasOne(CareerGuideSeoMeta::class, 'career_guide_id', 'id');
+    }
+
+    public function revisions(): HasMany
+    {
+        return $this->hasMany(CareerGuideRevision::class, 'career_guide_id', 'id')
+            ->orderByDesc('revision_no')
+            ->orderByDesc('id');
+    }
+
+    public function relatedJobs(): BelongsToMany
+    {
+        return $this->belongsToMany(
+            CareerJob::class,
+            'career_guide_job_map',
+            'career_guide_id',
+            'career_job_id'
+        )
+            ->withPivot('sort_order')
+            ->withTimestamps()
+            ->orderByPivot('sort_order')
+            ->orderBy('career_jobs.id');
+    }
+
+    public function relatedArticles(): BelongsToMany
+    {
+        return $this->belongsToMany(
+            Article::class,
+            'career_guide_article_map',
+            'career_guide_id',
+            'article_id'
+        )
+            ->withPivot('sort_order')
+            ->withTimestamps()
+            ->orderByPivot('sort_order')
+            ->orderBy('articles.id');
+    }
+
+    public function relatedPersonalityProfiles(): BelongsToMany
+    {
+        return $this->belongsToMany(
+            PersonalityProfile::class,
+            'career_guide_personality_map',
+            'career_guide_id',
+            'personality_profile_id'
+        )
+            ->withPivot('sort_order')
+            ->withTimestamps()
+            ->orderByPivot('sort_order')
+            ->orderBy('personality_profiles.id');
+    }
+
+    public function scopePublishedPublic($query)
+    {
+        return $query
+            ->where('status', self::STATUS_PUBLISHED)
+            ->where('is_public', true);
+    }
+
+    public function scopeIndexable($query)
+    {
+        return $query->where('is_indexable', true);
+    }
+
+    public function scopeForLocale($query, string $locale)
+    {
+        return $query->where('locale', trim($locale));
+    }
+
+    public function scopeForSlug($query, string $slug)
+    {
+        return $query->where('slug', strtolower(trim($slug)));
+    }
+
+    public function scopeForGuideCode($query, string $guideCode)
+    {
+        return $query->where('guide_code', strtolower(trim($guideCode)));
+    }
+}

--- a/backend/app/Models/CareerGuideRevision.php
+++ b/backend/app/Models/CareerGuideRevision.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+class CareerGuideRevision extends Model
+{
+    use HasFactory;
+
+    protected $table = 'career_guide_revisions';
+
+    public $timestamps = false;
+
+    protected $fillable = [
+        'career_guide_id',
+        'revision_no',
+        'snapshot_json',
+        'note',
+        'created_by_admin_user_id',
+        'created_at',
+    ];
+
+    protected $casts = [
+        'career_guide_id' => 'integer',
+        'revision_no' => 'integer',
+        'snapshot_json' => 'array',
+        'created_by_admin_user_id' => 'integer',
+        'created_at' => 'datetime',
+    ];
+
+    public function guide(): BelongsTo
+    {
+        return $this->belongsTo(CareerGuide::class, 'career_guide_id', 'id');
+    }
+}

--- a/backend/app/Models/CareerGuideSeoMeta.php
+++ b/backend/app/Models/CareerGuideSeoMeta.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+class CareerGuideSeoMeta extends Model
+{
+    use HasFactory;
+
+    protected $table = 'career_guide_seo_meta';
+
+    protected $fillable = [
+        'career_guide_id',
+        'seo_title',
+        'seo_description',
+        'canonical_url',
+        'og_title',
+        'og_description',
+        'og_image_url',
+        'twitter_title',
+        'twitter_description',
+        'twitter_image_url',
+        'robots',
+        'jsonld_overrides_json',
+    ];
+
+    protected $casts = [
+        'career_guide_id' => 'integer',
+        'jsonld_overrides_json' => 'array',
+        'created_at' => 'datetime',
+        'updated_at' => 'datetime',
+    ];
+
+    public function guide(): BelongsTo
+    {
+        return $this->belongsTo(CareerGuide::class, 'career_guide_id', 'id');
+    }
+}

--- a/backend/database/migrations/2026_03_15_000100_create_career_guides_table.php
+++ b/backend/database/migrations/2026_03_15_000100_create_career_guides_table.php
@@ -1,0 +1,56 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        $isSqlite = Schema::getConnection()->getDriverName() === 'sqlite';
+
+        Schema::create('career_guides', function (Blueprint $table) use ($isSqlite): void {
+            $table->bigIncrements('id');
+            $table->unsignedBigInteger('org_id')->default(0);
+            $table->string('guide_code', 96);
+            $table->string('slug', 128);
+            $table->string('locale', 16);
+            $table->string('title', 255);
+            $table->text('excerpt')->nullable();
+            $table->string('category_slug', 128)->nullable();
+            $table->longText('body_md')->nullable();
+            $table->longText('body_html')->nullable();
+
+            if ($isSqlite) {
+                $table->text('related_industry_slugs_json')->nullable();
+            } else {
+                $table->json('related_industry_slugs_json')->nullable();
+            }
+
+            $table->string('status', 32)->default('draft');
+            $table->boolean('is_public')->default(true);
+            $table->boolean('is_indexable')->default(true);
+            $table->integer('sort_order')->default(0);
+            $table->timestamp('published_at')->nullable();
+            $table->timestamp('scheduled_at')->nullable();
+            $table->string('schema_version', 32)->default('v1');
+            $table->timestamps();
+
+            $table->unique(['org_id', 'slug', 'locale'], 'uq_career_guide_slug');
+            $table->index(['org_id', 'guide_code', 'locale'], 'idx_career_guide_code');
+            $table->index(['org_id', 'status', 'is_public', 'is_indexable'], 'idx_career_guide_visibility');
+            $table->index(['locale'], 'idx_career_guide_locale');
+            $table->index(['published_at'], 'idx_career_guide_published_at');
+            $table->index(['category_slug'], 'idx_career_guide_category');
+        });
+    }
+
+    public function down(): void
+    {
+        // forward-only migration: rollback disabled to prevent data loss in production.
+        // Irreversible operation: schema/data rollback handled via forward fix migrations.
+    }
+};

--- a/backend/database/migrations/2026_03_15_000110_create_career_guide_seo_meta_table.php
+++ b/backend/database/migrations/2026_03_15_000110_create_career_guide_seo_meta_table.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        $isSqlite = Schema::getConnection()->getDriverName() === 'sqlite';
+
+        Schema::create('career_guide_seo_meta', function (Blueprint $table) use ($isSqlite): void {
+            $table->bigIncrements('id');
+            $table->unsignedBigInteger('career_guide_id');
+            $table->string('seo_title', 255)->nullable();
+            $table->text('seo_description')->nullable();
+            $table->text('canonical_url')->nullable();
+            $table->string('og_title', 255)->nullable();
+            $table->text('og_description')->nullable();
+            $table->text('og_image_url')->nullable();
+            $table->string('twitter_title', 255)->nullable();
+            $table->text('twitter_description')->nullable();
+            $table->text('twitter_image_url')->nullable();
+            $table->string('robots', 64)->nullable();
+            if ($isSqlite) {
+                $table->text('jsonld_overrides_json')->nullable();
+            } else {
+                $table->json('jsonld_overrides_json')->nullable();
+            }
+            $table->timestamps();
+
+            $table->unique(['career_guide_id'], 'uq_career_guide_seo');
+            $table->foreign('career_guide_id', 'fk_career_guide_seo_guide')
+                ->references('id')
+                ->on('career_guides')
+                ->cascadeOnDelete();
+        });
+    }
+
+    public function down(): void
+    {
+        // forward-only migration: rollback disabled to prevent data loss in production.
+        // Irreversible operation: schema/data rollback handled via forward fix migrations.
+    }
+};

--- a/backend/database/migrations/2026_03_15_000120_create_career_guide_revisions_table.php
+++ b/backend/database/migrations/2026_03_15_000120_create_career_guide_revisions_table.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        $isSqlite = Schema::getConnection()->getDriverName() === 'sqlite';
+
+        Schema::create('career_guide_revisions', function (Blueprint $table) use ($isSqlite): void {
+            $table->bigIncrements('id');
+            $table->unsignedBigInteger('career_guide_id');
+            $table->unsignedInteger('revision_no');
+            if ($isSqlite) {
+                $table->text('snapshot_json');
+            } else {
+                $table->json('snapshot_json');
+            }
+            $table->string('note', 255)->nullable();
+            $table->unsignedBigInteger('created_by_admin_user_id')->nullable();
+            $table->timestamp('created_at')->nullable();
+
+            $table->unique(['career_guide_id', 'revision_no'], 'uq_career_guide_revision');
+            $table->index(['career_guide_id', 'created_at'], 'idx_career_guide_revision_created');
+            $table->foreign('career_guide_id', 'fk_career_guide_revision_guide')
+                ->references('id')
+                ->on('career_guides')
+                ->cascadeOnDelete();
+        });
+    }
+
+    public function down(): void
+    {
+        // forward-only migration: rollback disabled to prevent data loss in production.
+        // Irreversible operation: schema/data rollback handled via forward fix migrations.
+    }
+};

--- a/backend/database/migrations/2026_03_15_000130_create_career_guide_job_map_table.php
+++ b/backend/database/migrations/2026_03_15_000130_create_career_guide_job_map_table.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('career_guide_job_map', function (Blueprint $table): void {
+            $table->bigIncrements('id');
+            $table->unsignedBigInteger('career_guide_id');
+            $table->unsignedBigInteger('career_job_id');
+            $table->integer('sort_order')->default(0);
+            $table->timestamps();
+
+            $table->unique(['career_guide_id', 'career_job_id'], 'uq_career_guide_job');
+            $table->index(['career_guide_id', 'sort_order'], 'idx_career_guide_job_sort');
+            $table->index(['career_job_id'], 'idx_career_guide_job_target');
+            $table->foreign('career_guide_id', 'fk_career_guide_job_guide')
+                ->references('id')
+                ->on('career_guides')
+                ->cascadeOnDelete();
+            $table->foreign('career_job_id', 'fk_career_guide_job_job')
+                ->references('id')
+                ->on('career_jobs')
+                ->cascadeOnDelete();
+        });
+    }
+
+    public function down(): void
+    {
+        // forward-only migration: rollback disabled to prevent data loss in production.
+        // Irreversible operation: schema/data rollback handled via forward fix migrations.
+    }
+};

--- a/backend/database/migrations/2026_03_15_000140_create_career_guide_article_map_table.php
+++ b/backend/database/migrations/2026_03_15_000140_create_career_guide_article_map_table.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('career_guide_article_map', function (Blueprint $table): void {
+            $table->bigIncrements('id');
+            $table->unsignedBigInteger('career_guide_id');
+            $table->unsignedBigInteger('article_id');
+            $table->integer('sort_order')->default(0);
+            $table->timestamps();
+
+            $table->unique(['career_guide_id', 'article_id'], 'uq_career_guide_article');
+            $table->index(['career_guide_id', 'sort_order'], 'idx_career_guide_article_sort');
+            $table->index(['article_id'], 'idx_career_guide_article_target');
+            $table->foreign('career_guide_id', 'fk_career_guide_article_guide')
+                ->references('id')
+                ->on('career_guides')
+                ->cascadeOnDelete();
+            $table->foreign('article_id', 'fk_career_guide_article_article')
+                ->references('id')
+                ->on('articles')
+                ->cascadeOnDelete();
+        });
+    }
+
+    public function down(): void
+    {
+        // forward-only migration: rollback disabled to prevent data loss in production.
+        // Irreversible operation: schema/data rollback handled via forward fix migrations.
+    }
+};

--- a/backend/database/migrations/2026_03_15_000150_create_career_guide_personality_map_table.php
+++ b/backend/database/migrations/2026_03_15_000150_create_career_guide_personality_map_table.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('career_guide_personality_map', function (Blueprint $table): void {
+            $table->bigIncrements('id');
+            $table->unsignedBigInteger('career_guide_id');
+            $table->unsignedBigInteger('personality_profile_id');
+            $table->integer('sort_order')->default(0);
+            $table->timestamps();
+
+            $table->unique(['career_guide_id', 'personality_profile_id'], 'uq_career_guide_personality');
+            $table->index(['career_guide_id', 'sort_order'], 'idx_career_guide_personality_sort');
+            $table->index(['personality_profile_id'], 'idx_career_guide_personality_target');
+            $table->foreign('career_guide_id', 'fk_career_guide_personality_guide')
+                ->references('id')
+                ->on('career_guides')
+                ->cascadeOnDelete();
+            $table->foreign('personality_profile_id', 'fk_career_guide_personality_profile')
+                ->references('id')
+                ->on('personality_profiles')
+                ->cascadeOnDelete();
+        });
+    }
+
+    public function down(): void
+    {
+        // forward-only migration: rollback disabled to prevent data loss in production.
+        // Irreversible operation: schema/data rollback handled via forward fix migrations.
+    }
+};

--- a/backend/tests/Feature/CareerCms/CareerGuideSchemaModelTest.php
+++ b/backend/tests/Feature/CareerCms/CareerGuideSchemaModelTest.php
@@ -1,0 +1,206 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\CareerCms;
+
+use App\Models\Article;
+use App\Models\CareerGuide;
+use App\Models\CareerJob;
+use App\Models\PersonalityProfile;
+use Illuminate\Database\QueryException;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+final class CareerGuideSchemaModelTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_guide_schema_relations_casts_and_scopes_work(): void
+    {
+        $guide = CareerGuide::query()->create($this->guidePayload([
+            'status' => CareerGuide::STATUS_PUBLISHED,
+            'published_at' => now(),
+            'sort_order' => 10,
+        ]));
+
+        $localizedGuide = CareerGuide::query()->create($this->guidePayload([
+            'locale' => 'zh-CN',
+            'title' => 'Annual career review system zh',
+            'excerpt' => 'Localized zh-CN guide content.',
+            'body_md' => 'Localized zh-CN body.',
+            'body_html' => '<p>Localized zh-CN body.</p>',
+        ]));
+
+        $job = CareerJob::query()->create($this->jobPayload());
+        $article = Article::query()->create($this->articlePayload());
+        $profile = PersonalityProfile::query()->create($this->profilePayload());
+
+        $guide->seoMeta()->create([
+            'seo_title' => 'Annual career review system',
+            'seo_description' => 'A structured annual career review guide.',
+            'jsonld_overrides_json' => ['@type' => 'WebPage'],
+        ]);
+
+        $guide->revisions()->create([
+            'revision_no' => 1,
+            'snapshot_json' => ['title' => 'Annual career review system'],
+            'note' => 'Initial snapshot',
+            'created_by_admin_user_id' => 7,
+            'created_at' => now(),
+        ]);
+
+        $guide->relatedJobs()->attach($job->id, ['sort_order' => 10]);
+        $guide->relatedArticles()->attach($article->id, ['sort_order' => 20]);
+        $guide->relatedPersonalityProfiles()->attach($profile->id, ['sort_order' => 30]);
+
+        $freshGuide = CareerGuide::query()->findOrFail($guide->id);
+
+        $this->assertSame(['technology', 'strategy'], $freshGuide->related_industry_slugs_json);
+        $this->assertSame('Annual career review system', $freshGuide->seoMeta?->seo_title);
+        $this->assertSame([1], $freshGuide->revisions()->pluck('revision_no')->all());
+        $this->assertSame([$job->id], $freshGuide->relatedJobs()->pluck('career_jobs.id')->all());
+        $this->assertSame([$article->id], $freshGuide->relatedArticles()->pluck('articles.id')->all());
+        $this->assertSame(
+            [$profile->id],
+            $freshGuide->relatedPersonalityProfiles()->pluck('personality_profiles.id')->all()
+        );
+        $this->assertSame(
+            [$guide->id],
+            CareerGuide::query()
+                ->publishedPublic()
+                ->indexable()
+                ->forLocale('en')
+                ->forSlug('ANNUAL-CAREER-REVIEW-SYSTEM')
+                ->forGuideCode('ANNUAL-CAREER-REVIEW-SYSTEM')
+                ->pluck('id')
+                ->all()
+        );
+        $this->assertSame('zh-CN', $localizedGuide->locale);
+
+        $this->assertDatabaseHas('career_guide_seo_meta', [
+            'career_guide_id' => $guide->id,
+            'seo_title' => 'Annual career review system',
+        ]);
+        $this->assertDatabaseHas('career_guide_revisions', [
+            'career_guide_id' => $guide->id,
+            'revision_no' => 1,
+        ]);
+        $this->assertDatabaseHas('career_guide_job_map', [
+            'career_guide_id' => $guide->id,
+            'career_job_id' => $job->id,
+            'sort_order' => 10,
+        ]);
+        $this->assertDatabaseHas('career_guide_article_map', [
+            'career_guide_id' => $guide->id,
+            'article_id' => $article->id,
+            'sort_order' => 20,
+        ]);
+        $this->assertDatabaseHas('career_guide_personality_map', [
+            'career_guide_id' => $guide->id,
+            'personality_profile_id' => $profile->id,
+            'sort_order' => 30,
+        ]);
+    }
+
+    public function test_unique_org_slug_locale_constraint_is_enforced(): void
+    {
+        CareerGuide::query()->create($this->guidePayload());
+
+        $this->expectException(QueryException::class);
+
+        CareerGuide::query()->create($this->guidePayload([
+            'guide_code' => 'annual-career-review-system-v2',
+            'title' => 'Duplicate slug in same locale',
+        ]));
+    }
+
+    /**
+     * @param  array<string, mixed>  $overrides
+     * @return array<string, mixed>
+     */
+    private function guidePayload(array $overrides = []): array
+    {
+        return array_merge([
+            'org_id' => 0,
+            'guide_code' => 'annual-career-review-system',
+            'slug' => 'annual-career-review-system',
+            'locale' => 'en',
+            'title' => 'Annual career review system',
+            'excerpt' => 'A repeatable system for reviewing your career once a year.',
+            'category_slug' => 'career-planning',
+            'body_md' => 'Use this guide to review your career progress.',
+            'body_html' => '<p>Use this guide to review your career progress.</p>',
+            'related_industry_slugs_json' => ['technology', 'strategy'],
+            'status' => CareerGuide::STATUS_DRAFT,
+            'is_public' => true,
+            'is_indexable' => true,
+            'sort_order' => 0,
+            'schema_version' => 'v1',
+        ], $overrides);
+    }
+
+    /**
+     * @param  array<string, mixed>  $overrides
+     * @return array<string, mixed>
+     */
+    private function jobPayload(array $overrides = []): array
+    {
+        return array_merge([
+            'org_id' => 0,
+            'job_code' => 'product-manager',
+            'slug' => 'product-manager',
+            'locale' => 'en',
+            'title' => 'Product Manager',
+            'status' => CareerJob::STATUS_PUBLISHED,
+            'is_public' => true,
+            'is_indexable' => true,
+            'published_at' => now(),
+            'schema_version' => 'v1',
+            'sort_order' => 0,
+        ], $overrides);
+    }
+
+    /**
+     * @param  array<string, mixed>  $overrides
+     * @return array<string, mixed>
+     */
+    private function articlePayload(array $overrides = []): array
+    {
+        return array_merge([
+            'org_id' => 0,
+            'slug' => 'career-review-mistakes',
+            'locale' => 'en',
+            'title' => 'Career review mistakes',
+            'excerpt' => 'What to avoid during a yearly career review.',
+            'content_md' => 'Article body',
+            'content_html' => '<p>Article body</p>',
+            'status' => 'published',
+            'is_public' => true,
+            'is_indexable' => true,
+            'published_at' => now(),
+        ], $overrides);
+    }
+
+    /**
+     * @param  array<string, mixed>  $overrides
+     * @return array<string, mixed>
+     */
+    private function profilePayload(array $overrides = []): array
+    {
+        return array_merge([
+            'org_id' => 0,
+            'scale_code' => PersonalityProfile::SCALE_CODE_MBTI,
+            'type_code' => 'INTJ',
+            'slug' => 'intj',
+            'locale' => 'en',
+            'title' => 'INTJ',
+            'excerpt' => 'Strategic and independent.',
+            'status' => 'published',
+            'is_public' => true,
+            'is_indexable' => true,
+            'published_at' => now(),
+            'schema_version' => 'v1',
+        ], $overrides);
+    }
+}


### PR DESCRIPTION
Summary
- add the backend schema and model foundation for CareerGuide
- establish CareerGuide as a first-class CMS object without yet wiring runtime/API/frontend paths

What changed
- add the career_guides main table
- add SEO, revision, and normalized relation tables for jobs/articles/personality
- add CareerGuide-related models and relations
- keep industry links as JSON slug arrays for v1
- add minimal schema/model tests

Design choices
- model CareerGuide as its own structured guide object instead of reusing Article or Topic directly
- keep body_md/body_html as the v1 body storage
- keep related_industry_slugs_json in the main table for now
- normalize relations only where backend objects already exist
- defer API/workspace/importer/frontend/sitemap integration to later PRs

Why this PR is small and safe
- no route changes
- no controller/service changes
- no frontend changes
- no sitemap/runtime changes
- only the backend schema/model foundation for the next Career CMS object

Validation
- php artisan about
- php artisan route:list
- php artisan migrate
- php artisan test --filter=CareerGuideSchemaModelTest
- bash scripts/ci_verify_mbti.sh

Rollout note
- this PR intentionally does not wire CareerGuide into runtime or sitemap paths
- later guide runtime/sitemap work must be deployed only after migrations are present, because backend sitemap paths are sensitive to schema drift
