### PR TITLE
feat(career-cms): add CareerGuide public API and SEO contract

### DIFF
--- a/backend/app/Http/Controllers/API/V0_5/Cms/CareerGuideController.php
+++ b/backend/app/Http/Controllers/API/V0_5/Cms/CareerGuideController.php
@@ -1,0 +1,170 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Controllers\API\V0_5\Cms;
+
+use App\Http\Controllers\Concerns\RespondsWithNotFound;
+use App\Http\Controllers\Controller;
+use App\Models\CareerGuide;
+use App\Services\Cms\CareerGuideSeoService;
+use App\Services\Cms\CareerGuideService;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Validator;
+
+final class CareerGuideController extends Controller
+{
+    use RespondsWithNotFound;
+
+    public function __construct(
+        private readonly CareerGuideService $careerGuideService,
+        private readonly CareerGuideSeoService $careerGuideSeoService,
+    ) {}
+
+    public function index(Request $request): JsonResponse
+    {
+        $validated = $this->validateListQuery($request);
+        if ($validated instanceof JsonResponse) {
+            return $validated;
+        }
+
+        $paginator = $this->careerGuideService->listPublicGuides(
+            $validated['org_id'],
+            $validated['locale'],
+            $validated['page'],
+            $validated['per_page'],
+            $validated['category'],
+        );
+
+        $items = [];
+        foreach ($paginator->items() as $guide) {
+            if (! $guide instanceof CareerGuide) {
+                continue;
+            }
+
+            $items[] = $this->careerGuideService->listPayload($guide);
+        }
+
+        return response()->json([
+            'ok' => true,
+            'items' => $items,
+            'pagination' => [
+                'current_page' => (int) $paginator->currentPage(),
+                'per_page' => (int) $paginator->perPage(),
+                'total' => (int) $paginator->total(),
+                'last_page' => (int) $paginator->lastPage(),
+            ],
+        ]);
+    }
+
+    public function show(Request $request, string $slug): JsonResponse
+    {
+        $validated = $this->validateReadQuery($request);
+        if ($validated instanceof JsonResponse) {
+            return $validated;
+        }
+
+        $guide = $this->careerGuideService->getPublicGuideBySlug(
+            $slug,
+            $validated['org_id'],
+            $validated['locale'],
+        );
+
+        if (! $guide instanceof CareerGuide) {
+            return $this->notFoundResponse('career guide not found.');
+        }
+
+        return response()->json([
+            'ok' => true,
+            'guide' => $this->careerGuideService->detailPayload($guide),
+            'related_jobs' => $this->careerGuideService->relatedJobsPayload($guide),
+            'related_industries' => $this->careerGuideService->relatedIndustriesPayload($guide),
+            'related_articles' => $this->careerGuideService->relatedArticlesPayload($guide),
+            'related_personality_profiles' => $this->careerGuideService->relatedPersonalityProfilesPayload($guide),
+            'seo_meta' => $this->careerGuideService->seoMetaPayload($guide),
+        ]);
+    }
+
+    public function seo(Request $request, string $slug): JsonResponse
+    {
+        $validated = $this->validateReadQuery($request);
+        if ($validated instanceof JsonResponse) {
+            return $validated;
+        }
+
+        $guide = $this->careerGuideService->getPublicGuideBySlug(
+            $slug,
+            $validated['org_id'],
+            $validated['locale'],
+        );
+
+        if (! $guide instanceof CareerGuide) {
+            return response()->json(['error' => 'not found'], 404);
+        }
+
+        return response()->json([
+            'meta' => $this->careerGuideSeoService->buildSeoPayload($guide),
+            'jsonld' => $this->careerGuideSeoService->buildJsonLd($guide),
+        ]);
+    }
+
+    /**
+     * @return array{org_id:int,locale:string,category:?string,page:int,per_page:int}|JsonResponse
+     */
+    private function validateListQuery(Request $request): array|JsonResponse
+    {
+        $validator = Validator::make($request->query(), [
+            'org_id' => ['nullable', 'integer', 'min:0'],
+            'locale' => ['required', 'in:en,zh-CN'],
+            'category' => ['nullable', 'string', 'max:128'],
+            'page' => ['nullable', 'integer', 'min:1'],
+            'per_page' => ['nullable', 'integer', 'min:1', 'max:100'],
+        ]);
+
+        if ($validator->fails()) {
+            return $this->invalidArgument($validator->errors()->first());
+        }
+
+        $validated = $validator->validated();
+
+        return [
+            'org_id' => (int) ($validated['org_id'] ?? 0),
+            'locale' => (string) $validated['locale'],
+            'category' => isset($validated['category']) ? (string) $validated['category'] : null,
+            'page' => (int) ($validated['page'] ?? 1),
+            'per_page' => (int) ($validated['per_page'] ?? 20),
+        ];
+    }
+
+    /**
+     * @return array{org_id:int,locale:string}|JsonResponse
+     */
+    private function validateReadQuery(Request $request): array|JsonResponse
+    {
+        $validator = Validator::make($request->query(), [
+            'org_id' => ['nullable', 'integer', 'min:0'],
+            'locale' => ['required', 'in:en,zh-CN'],
+        ]);
+
+        if ($validator->fails()) {
+            return $this->invalidArgument($validator->errors()->first());
+        }
+
+        $validated = $validator->validated();
+
+        return [
+            'org_id' => (int) ($validated['org_id'] ?? 0),
+            'locale' => (string) $validated['locale'],
+        ];
+    }
+
+    private function invalidArgument(string $message): JsonResponse
+    {
+        return response()->json([
+            'ok' => false,
+            'error_code' => 'INVALID_ARGUMENT',
+            'message' => $message,
+        ], 422);
+    }
+}

--- a/backend/app/Services/Cms/CareerGuideSeoService.php
+++ b/backend/app/Services/Cms/CareerGuideSeoService.php
@@ -1,0 +1,327 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\Cms;
+
+use App\Models\CareerGuide;
+use App\Models\CareerGuideSeoMeta;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Str;
+use InvalidArgumentException;
+use RuntimeException;
+
+final class CareerGuideSeoService
+{
+    public const SUPPORTED_LOCALES = [
+        'en',
+        'zh-CN',
+    ];
+
+    public function generateSeoMeta(int $guideId): CareerGuideSeoMeta
+    {
+        if ($guideId <= 0) {
+            throw new InvalidArgumentException('career_guide_id must be positive.');
+        }
+
+        return DB::transaction(function () use ($guideId): CareerGuideSeoMeta {
+            $guide = CareerGuide::query()
+                ->withoutGlobalScopes()
+                ->where('id', $guideId)
+                ->lockForUpdate()
+                ->first();
+
+            if (! $guide instanceof CareerGuide) {
+                throw new RuntimeException('career guide not found.');
+            }
+
+            $canonical = $this->buildCanonicalUrl($guide);
+            $title = trim((string) $guide->title);
+            $description = $this->resolveDescription($guide, null);
+            $robots = $this->resolveRobots($guide, null);
+
+            return CareerGuideSeoMeta::query()->updateOrCreate(
+                [
+                    'career_guide_id' => (int) $guide->id,
+                ],
+                [
+                    'seo_title' => Str::limit($title, 60, ''),
+                    'seo_description' => Str::limit($description, 160, ''),
+                    'canonical_url' => $canonical,
+                    'og_title' => Str::limit($title, 90, ''),
+                    'og_description' => Str::limit($description, 200, ''),
+                    'twitter_title' => Str::limit($title, 70, ''),
+                    'twitter_description' => Str::limit($description, 200, ''),
+                    'robots' => $robots,
+                ]
+            );
+        });
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function buildSeoPayload(CareerGuide $guide): array
+    {
+        $seoMeta = $this->resolveSeoMeta($guide);
+        $title = $this->resolveTitle($guide, $seoMeta);
+        $description = $this->resolveDescription($guide, $seoMeta);
+        $canonical = $this->buildCanonicalUrl($guide);
+        $image = $this->fallbackText($seoMeta?->og_image_url, $seoMeta?->twitter_image_url);
+
+        return [
+            'title' => $title,
+            'description' => $description,
+            'canonical' => $canonical,
+            'alternates' => $this->buildAlternates($guide),
+            'og' => [
+                'title' => $this->fallbackText($seoMeta?->og_title, $title),
+                'description' => $this->fallbackText($seoMeta?->og_description, $description),
+                'image' => $image,
+                'type' => 'article',
+            ],
+            'twitter' => [
+                'card' => 'summary_large_image',
+                'title' => $this->fallbackText($seoMeta?->twitter_title, $seoMeta?->og_title, $title),
+                'description' => $this->fallbackText(
+                    $seoMeta?->twitter_description,
+                    $seoMeta?->og_description,
+                    $description
+                ),
+                'image' => $this->fallbackText($seoMeta?->twitter_image_url, $image),
+            ],
+            'robots' => $this->resolveRobots($guide, $seoMeta),
+        ];
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function buildJsonLd(CareerGuide $guide): array
+    {
+        $seoMeta = $this->resolveSeoMeta($guide);
+        $canonical = $this->buildCanonicalUrl($guide);
+        $payload = $this->buildSeoPayload($guide);
+
+        $jsonLd = [
+            '@context' => 'https://schema.org',
+            '@type' => 'WebPage',
+            '@id' => $canonical !== null ? $canonical.'#webpage' : null,
+            'url' => $canonical,
+            'name' => $payload['title'],
+            'description' => $payload['description'],
+            'inLanguage' => $this->normalizeLocale((string) $guide->locale),
+            'mainEntityOfPage' => $canonical,
+        ];
+
+        if ($seoMeta instanceof CareerGuideSeoMeta && is_array($seoMeta->jsonld_overrides_json)) {
+            $jsonLd = array_replace_recursive($jsonLd, $seoMeta->jsonld_overrides_json);
+        }
+
+        return $this->normalizeJsonLdUrls($jsonLd, $canonical, $seoMeta?->canonical_url);
+    }
+
+    /**
+     * @return array<string, mixed>|null
+     */
+    public function detailSeoMetaPayload(CareerGuide $guide): ?array
+    {
+        $payload = $this->buildSeoPayload($guide);
+        $seoMeta = $this->resolveSeoMeta($guide);
+
+        return [
+            'seo_title' => $payload['title'],
+            'seo_description' => $payload['description'],
+            'canonical_url' => $payload['canonical'],
+            'og_title' => data_get($payload, 'og.title'),
+            'og_description' => data_get($payload, 'og.description'),
+            'og_image_url' => data_get($payload, 'og.image'),
+            'twitter_title' => data_get($payload, 'twitter.title'),
+            'twitter_description' => data_get($payload, 'twitter.description'),
+            'twitter_image_url' => data_get($payload, 'twitter.image'),
+            'robots' => $payload['robots'],
+            'jsonld_overrides_json' => $seoMeta?->jsonld_overrides_json,
+        ];
+    }
+
+    public function buildCanonicalUrl(CareerGuide $guide, ?string $locale = null, ?string $slug = null): ?string
+    {
+        $baseUrl = rtrim((string) config('app.frontend_url', config('app.url', '')), '/');
+        $resolvedSlug = strtolower(trim((string) ($slug ?? $guide->slug)));
+        $resolvedLocale = $this->normalizeLocale((string) ($locale ?? $guide->locale));
+
+        if ($baseUrl === '' || $resolvedSlug === '') {
+            return null;
+        }
+
+        return $baseUrl
+            .'/'.$this->mapBackendLocaleToFrontendSegment($resolvedLocale)
+            .'/career/guides/'
+            .rawurlencode($resolvedSlug);
+    }
+
+    public function mapBackendLocaleToFrontendSegment(string $locale): string
+    {
+        return $this->normalizeLocale($locale) === 'zh-CN' ? 'zh' : 'en';
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    private function buildAlternates(CareerGuide $guide): array
+    {
+        $variants = CareerGuide::query()
+            ->withoutGlobalScopes()
+            ->where('org_id', (int) $guide->org_id)
+            ->where('guide_code', (string) $guide->guide_code)
+            ->where('status', CareerGuide::STATUS_PUBLISHED)
+            ->where('is_public', true)
+            ->whereIn('locale', self::SUPPORTED_LOCALES)
+            ->where(static function ($query): void {
+                $query->whereNull('published_at')
+                    ->orWhere('published_at', '<=', now());
+            })
+            ->get(['slug', 'locale']);
+
+        $alternates = [];
+        foreach ($variants as $variant) {
+            if (! $variant instanceof CareerGuide) {
+                continue;
+            }
+
+            $locale = $this->normalizeLocale((string) $variant->locale);
+            $canonical = $this->buildCanonicalUrl($guide, $locale, (string) $variant->slug);
+            if ($canonical === null) {
+                continue;
+            }
+
+            $alternates[$locale] = $canonical;
+        }
+
+        ksort($alternates);
+
+        return $alternates;
+    }
+
+    private function resolveSeoMeta(CareerGuide $guide): ?CareerGuideSeoMeta
+    {
+        if ($guide->relationLoaded('seoMeta') && $guide->seoMeta instanceof CareerGuideSeoMeta) {
+            return $guide->seoMeta;
+        }
+
+        return CareerGuideSeoMeta::query()
+            ->where('career_guide_id', (int) $guide->id)
+            ->first();
+    }
+
+    private function resolveTitle(CareerGuide $guide, ?CareerGuideSeoMeta $seoMeta): string
+    {
+        return $this->fallbackText($seoMeta?->seo_title, (string) $guide->title) ?? (string) $guide->title;
+    }
+
+    private function resolveDescription(CareerGuide $guide, ?CareerGuideSeoMeta $seoMeta): string
+    {
+        return $this->fallbackText(
+            $seoMeta?->seo_description,
+            (string) ($guide->excerpt ?? null),
+            $this->extractDescription((string) ($guide->body_md ?? '')),
+            (string) $guide->title
+        ) ?? (string) $guide->title;
+    }
+
+    private function resolveRobots(CareerGuide $guide, ?CareerGuideSeoMeta $seoMeta): string
+    {
+        return $this->fallbackText($seoMeta?->robots)
+            ?? ((bool) $guide->is_indexable ? 'index,follow' : 'noindex,follow');
+    }
+
+    private function normalizeLocale(string $locale): string
+    {
+        return trim($locale) === 'zh-CN' ? 'zh-CN' : 'en';
+    }
+
+    private function extractDescription(string $bodyMarkdown): string
+    {
+        $text = preg_replace('/`{1,3}[^`]*`{1,3}/u', ' ', $bodyMarkdown);
+        if (! is_string($text)) {
+            $text = $bodyMarkdown;
+        }
+
+        $text = preg_replace('/\[[^\]]+\]\(([^)]+)\)/u', '$1', $text);
+        if (! is_string($text)) {
+            $text = $bodyMarkdown;
+        }
+
+        $text = preg_replace('/[#>*_~\-]+/u', ' ', $text);
+        if (! is_string($text)) {
+            return $this->normalizeWhitespace($bodyMarkdown);
+        }
+
+        return $this->normalizeWhitespace($text);
+    }
+
+    private function normalizeWhitespace(string $value): string
+    {
+        $normalized = preg_replace('/\s+/u', ' ', trim($value));
+
+        return is_string($normalized) ? $normalized : trim($value);
+    }
+
+    private function fallbackText(?string ...$candidates): ?string
+    {
+        foreach ($candidates as $candidate) {
+            if ($candidate === null) {
+                continue;
+            }
+
+            $normalized = trim($candidate);
+            if ($normalized !== '') {
+                return $normalized;
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * @param  array<string, mixed>  $jsonLd
+     * @return array<string, mixed>
+     */
+    private function normalizeJsonLdUrls(array $jsonLd, ?string $canonical, ?string $sourceCanonical): array
+    {
+        $walk = function (mixed $value) use (&$walk, $canonical, $sourceCanonical): mixed {
+            if (is_array($value)) {
+                $normalized = [];
+                foreach ($value as $key => $item) {
+                    $normalized[$key] = $walk($item);
+                }
+
+                return $normalized;
+            }
+
+            if (! is_string($value) || $canonical === null) {
+                return $value;
+            }
+
+            $legacyCanonical = trim((string) $sourceCanonical);
+            if ($legacyCanonical === '') {
+                return $value;
+            }
+
+            if ($value === $legacyCanonical) {
+                return $canonical;
+            }
+
+            if (str_starts_with($value, $legacyCanonical.'#')) {
+                return $canonical.substr($value, strlen($legacyCanonical));
+            }
+
+            return $value;
+        };
+
+        /** @var array<string, mixed> $normalized */
+        $normalized = $walk($jsonLd);
+
+        return $normalized;
+    }
+}

--- a/backend/app/Services/Cms/CareerGuideService.php
+++ b/backend/app/Services/Cms/CareerGuideService.php
@@ -1,0 +1,265 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\Cms;
+
+use App\Models\Article;
+use App\Models\CareerGuide;
+use App\Models\CareerJob;
+use App\Models\PersonalityProfile;
+use Illuminate\Contracts\Pagination\LengthAwarePaginator;
+use Illuminate\Database\Eloquent\Builder;
+
+final class CareerGuideService
+{
+    public function __construct(
+        private readonly CareerGuideSeoService $careerGuideSeoService,
+    ) {}
+
+    public function listPublicGuides(
+        int $orgId,
+        string $locale,
+        int $page = 1,
+        int $perPage = 20,
+        ?string $category = null,
+    ): LengthAwarePaginator {
+        return $this->basePublicQuery($orgId, $locale, $category)
+            ->orderBy('sort_order')
+            ->orderByDesc('published_at')
+            ->orderBy('guide_code')
+            ->orderBy('id')
+            ->paginate($perPage, ['*'], 'page', $page);
+    }
+
+    public function getPublicGuideBySlug(string $slug, int $orgId, string $locale): ?CareerGuide
+    {
+        return $this->basePublicQuery($orgId, $locale)
+            ->forSlug($this->normalizeSlug($slug))
+            ->with('seoMeta')
+            ->first();
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function listPayload(CareerGuide $guide): array
+    {
+        return [
+            'id' => (int) $guide->id,
+            'org_id' => (int) $guide->org_id,
+            'guide_code' => (string) $guide->guide_code,
+            'slug' => (string) $guide->slug,
+            'locale' => (string) $guide->locale,
+            'title' => (string) $guide->title,
+            'excerpt' => $guide->excerpt,
+            'category_slug' => $guide->category_slug,
+            'is_public' => (bool) $guide->is_public,
+            'is_indexable' => (bool) $guide->is_indexable,
+            'published_at' => $guide->published_at?->toISOString(),
+            'updated_at' => $guide->updated_at?->toISOString(),
+        ];
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function detailPayload(CareerGuide $guide): array
+    {
+        return [
+            'id' => (int) $guide->id,
+            'org_id' => (int) $guide->org_id,
+            'guide_code' => (string) $guide->guide_code,
+            'slug' => (string) $guide->slug,
+            'locale' => (string) $guide->locale,
+            'title' => (string) $guide->title,
+            'excerpt' => $guide->excerpt,
+            'category_slug' => $guide->category_slug,
+            'body_md' => $guide->body_md,
+            'body_html' => $guide->body_html,
+            'is_public' => (bool) $guide->is_public,
+            'is_indexable' => (bool) $guide->is_indexable,
+            'published_at' => $guide->published_at?->toISOString(),
+            'updated_at' => $guide->updated_at?->toISOString(),
+        ];
+    }
+
+    /**
+     * @return array<int, array<string, mixed>>
+     */
+    public function relatedJobsPayload(CareerGuide $guide): array
+    {
+        return CareerJob::query()
+            ->withoutGlobalScopes()
+            ->select('career_jobs.*')
+            ->join('career_guide_job_map', 'career_guide_job_map.career_job_id', '=', 'career_jobs.id')
+            ->where('career_guide_job_map.career_guide_id', (int) $guide->id)
+            ->where('career_jobs.org_id', (int) $guide->org_id)
+            ->where('career_jobs.locale', $this->normalizeLocale((string) $guide->locale))
+            ->where('career_jobs.status', CareerJob::STATUS_PUBLISHED)
+            ->where('career_jobs.is_public', true)
+            ->where(static function (Builder $query): void {
+                $query->whereNull('career_jobs.published_at')
+                    ->orWhere('career_jobs.published_at', '<=', now());
+            })
+            ->orderBy('career_guide_job_map.sort_order')
+            ->orderBy('career_jobs.id')
+            ->get()
+            ->map(static fn (CareerJob $job): array => [
+                'id' => (int) $job->id,
+                'job_code' => (string) $job->job_code,
+                'slug' => (string) $job->slug,
+                'locale' => (string) $job->locale,
+                'title' => (string) $job->title,
+                'excerpt' => $job->excerpt,
+                'industry_slug' => $job->industry_slug,
+                'industry_label' => $job->industry_label,
+            ])
+            ->all();
+    }
+
+    /**
+     * @return array<int, string>
+     */
+    public function relatedIndustriesPayload(CareerGuide $guide): array
+    {
+        $slugs = $guide->related_industry_slugs_json;
+        if (! is_array($slugs)) {
+            return [];
+        }
+
+        $normalized = [];
+        foreach ($slugs as $slug) {
+            if (! is_string($slug)) {
+                continue;
+            }
+
+            $trimmed = strtolower(trim($slug));
+            if ($trimmed === '') {
+                continue;
+            }
+
+            $normalized[$trimmed] = $trimmed;
+        }
+
+        return array_values($normalized);
+    }
+
+    /**
+     * @return array<int, array<string, mixed>>
+     */
+    public function relatedArticlesPayload(CareerGuide $guide): array
+    {
+        return Article::query()
+            ->withoutGlobalScopes()
+            ->select('articles.*')
+            ->join('career_guide_article_map', 'career_guide_article_map.article_id', '=', 'articles.id')
+            ->where('career_guide_article_map.career_guide_id', (int) $guide->id)
+            ->where('articles.org_id', (int) $guide->org_id)
+            ->where('articles.locale', $this->normalizeLocale((string) $guide->locale))
+            ->where('articles.status', 'published')
+            ->where('articles.is_public', true)
+            ->where(static function (Builder $query): void {
+                $query->whereNull('articles.published_at')
+                    ->orWhere('articles.published_at', '<=', now());
+            })
+            ->orderBy('career_guide_article_map.sort_order')
+            ->orderBy('articles.id')
+            ->get()
+            ->map(static fn (Article $article): array => [
+                'id' => (int) $article->id,
+                'slug' => (string) $article->slug,
+                'locale' => (string) $article->locale,
+                'title' => (string) $article->title,
+                'excerpt' => $article->excerpt,
+                'published_at' => $article->published_at?->toISOString(),
+            ])
+            ->all();
+    }
+
+    /**
+     * @return array<int, array<string, mixed>>
+     */
+    public function relatedPersonalityProfilesPayload(CareerGuide $guide): array
+    {
+        return PersonalityProfile::query()
+            ->withoutGlobalScopes()
+            ->select('personality_profiles.*')
+            ->join(
+                'career_guide_personality_map',
+                'career_guide_personality_map.personality_profile_id',
+                '=',
+                'personality_profiles.id'
+            )
+            ->where('career_guide_personality_map.career_guide_id', (int) $guide->id)
+            ->where('personality_profiles.org_id', (int) $guide->org_id)
+            ->where('personality_profiles.locale', $this->normalizeLocale((string) $guide->locale))
+            ->where('personality_profiles.status', 'published')
+            ->where('personality_profiles.is_public', true)
+            ->where(static function (Builder $query): void {
+                $query->whereNull('personality_profiles.published_at')
+                    ->orWhere('personality_profiles.published_at', '<=', now());
+            })
+            ->orderBy('career_guide_personality_map.sort_order')
+            ->orderBy('personality_profiles.id')
+            ->get()
+            ->map(static fn (PersonalityProfile $profile): array => [
+                'id' => (int) $profile->id,
+                'type_code' => (string) $profile->type_code,
+                'slug' => (string) $profile->slug,
+                'locale' => (string) $profile->locale,
+                'title' => (string) $profile->title,
+                'excerpt' => $profile->excerpt,
+            ])
+            ->all();
+    }
+
+    /**
+     * @return array<string, mixed>|null
+     */
+    public function seoMetaPayload(CareerGuide $guide): ?array
+    {
+        return $this->careerGuideSeoService->detailSeoMetaPayload($guide);
+    }
+
+    private function basePublicQuery(int $orgId, string $locale, ?string $category = null): Builder
+    {
+        $query = CareerGuide::query()
+            ->withoutGlobalScopes()
+            ->where('org_id', max(0, $orgId))
+            ->forLocale($this->normalizeLocale($locale))
+            ->publishedPublic()
+            ->where(static function (Builder $builder): void {
+                $builder->whereNull('published_at')
+                    ->orWhere('published_at', '<=', now());
+            });
+
+        $normalizedCategory = $this->normalizeCategory($category);
+        if ($normalizedCategory !== null) {
+            $query->where('category_slug', $normalizedCategory);
+        }
+
+        return $query;
+    }
+
+    private function normalizeLocale(string $locale): string
+    {
+        return trim($locale) === 'zh-CN' ? 'zh-CN' : 'en';
+    }
+
+    private function normalizeSlug(string $slug): string
+    {
+        return strtolower(trim($slug));
+    }
+
+    private function normalizeCategory(?string $category): ?string
+    {
+        if ($category === null) {
+            return null;
+        }
+
+        $normalized = strtolower(trim($category));
+
+        return $normalized !== '' ? $normalized : null;
+    }
+}

--- a/backend/docs/contracts/openapi.snapshot.json
+++ b/backend/docs/contracts/openapi.snapshot.json
@@ -1896,6 +1896,57 @@
                 ]
             }
         },
+        "/api/v0.5/career-guides": {
+            "get": {
+                "operationId": "get_api_v0_5_career_guides",
+                "tags": [
+                    "api:v0.5"
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK"
+                    }
+                },
+                "x-laravel-action": "App\\Http\\Controllers\\API\\V0_5\\Cms\\CareerGuideController@index",
+                "x-laravel-middleware": [
+                    "api"
+                ]
+            }
+        },
+        "/api/v0.5/career-guides/{slug}": {
+            "get": {
+                "operationId": "get_api_v0_5_career_guides_slug_",
+                "tags": [
+                    "api:v0.5"
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK"
+                    }
+                },
+                "x-laravel-action": "App\\Http\\Controllers\\API\\V0_5\\Cms\\CareerGuideController@show",
+                "x-laravel-middleware": [
+                    "api"
+                ]
+            }
+        },
+        "/api/v0.5/career-guides/{slug}/seo": {
+            "get": {
+                "operationId": "get_api_v0_5_career_guides_slug_seo",
+                "tags": [
+                    "api:v0.5"
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK"
+                    }
+                },
+                "x-laravel-action": "App\\Http\\Controllers\\API\\V0_5\\Cms\\CareerGuideController@seo",
+                "x-laravel-middleware": [
+                    "api"
+                ]
+            }
+        },
         "/api/v0.5/career-jobs": {
             "get": {
                 "operationId": "get_api_v0_5_career_jobs",

--- a/backend/routes/api.php
+++ b/backend/routes/api.php
@@ -27,6 +27,7 @@ use App\Http\Controllers\API\V0_4\ExperimentGovernanceController;
 use App\Http\Controllers\API\V0_4\PartnerController;
 use App\Http\Controllers\API\V0_4\RotationAuditController;
 use App\Http\Controllers\API\V0_5\Cms\ArticleController;
+use App\Http\Controllers\API\V0_5\Cms\CareerGuideController;
 use App\Http\Controllers\API\V0_5\Cms\CareerJobController;
 use App\Http\Controllers\API\V0_5\Cms\PersonalityController;
 use App\Http\Controllers\API\V0_5\Cms\TopicController;
@@ -337,6 +338,9 @@ Route::prefix('v0.5')->group(function () {
     Route::get('/articles', [ArticleController::class, 'index']);
     Route::get('/articles/{slug}', [ArticleController::class, 'show']);
     Route::get('/articles/{slug}/seo', [ArticleController::class, 'seo']);
+    Route::get('/career-guides', [CareerGuideController::class, 'index']);
+    Route::get('/career-guides/{slug}/seo', [CareerGuideController::class, 'seo']);
+    Route::get('/career-guides/{slug}', [CareerGuideController::class, 'show']);
     Route::get('/career-jobs', [CareerJobController::class, 'index']);
     Route::get('/career-jobs/{slug}/seo', [CareerJobController::class, 'seo']);
     Route::get('/career-jobs/{slug}', [CareerJobController::class, 'show']);

--- a/backend/tests/Feature/SEO/CareerGuideSeoServiceTest.php
+++ b/backend/tests/Feature/SEO/CareerGuideSeoServiceTest.php
@@ -1,0 +1,181 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\SEO;
+
+use App\Models\CareerGuide;
+use App\Models\CareerGuideSeoMeta;
+use App\Services\Cms\CareerGuideSeoService;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Carbon;
+use Tests\TestCase;
+
+final class CareerGuideSeoServiceTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_generate_seo_meta_persists_localized_frontend_canonical_and_robots_defaults(): void
+    {
+        config(['app.frontend_url' => 'https://staging.fermatmind.com']);
+
+        $guide = $this->createGuide([
+            'guide_code' => 'from-mbti-to-job-fit',
+            'slug' => 'from-mbti-to-job-fit',
+            'locale' => 'zh-CN',
+            'title' => '从 MBTI 到职业匹配',
+            'excerpt' => '把人格洞察转成职业决策。',
+            'status' => CareerGuide::STATUS_PUBLISHED,
+            'is_public' => true,
+            'is_indexable' => false,
+            'published_at' => Carbon::create(2026, 3, 5, 8, 0, 0, 'UTC'),
+        ]);
+
+        CareerGuideSeoMeta::query()->create([
+            'career_guide_id' => (int) $guide->id,
+            'seo_title' => '旧标题',
+            'seo_description' => '旧描述',
+            'canonical_url' => 'https://api.staging.fermatmind.com/career-guides/from-mbti-to-job-fit',
+            'robots' => 'index,follow',
+        ]);
+
+        $seoMeta = app(CareerGuideSeoService::class)->generateSeoMeta((int) $guide->id);
+
+        $this->assertSame(
+            'https://staging.fermatmind.com/zh/career/guides/from-mbti-to-job-fit',
+            $seoMeta->canonical_url
+        );
+        $this->assertSame('noindex,follow', $seoMeta->robots);
+        $this->assertDatabaseHas('career_guide_seo_meta', [
+            'career_guide_id' => (int) $guide->id,
+            'canonical_url' => 'https://staging.fermatmind.com/zh/career/guides/from-mbti-to-job-fit',
+            'robots' => 'noindex,follow',
+        ]);
+    }
+
+    public function test_build_seo_payload_only_emits_real_sibling_locale_alternates(): void
+    {
+        config(['app.frontend_url' => 'https://staging.fermatmind.com']);
+
+        $service = app(CareerGuideSeoService::class);
+
+        $enGuide = $this->createGuide([
+            'guide_code' => 'from-mbti-to-job-fit',
+            'slug' => 'from-mbti-to-job-fit',
+            'locale' => 'en',
+            'title' => 'From MBTI to Job Fit',
+            'excerpt' => 'Translate personality insights into practical career decisions.',
+            'status' => CareerGuide::STATUS_PUBLISHED,
+            'is_public' => true,
+            'published_at' => Carbon::create(2026, 3, 5, 8, 0, 0, 'UTC'),
+        ]);
+        $this->createGuide([
+            'guide_code' => 'from-mbti-to-job-fit',
+            'slug' => 'from-mbti-to-job-fit',
+            'locale' => 'zh-CN',
+            'title' => '从 MBTI 到职业匹配',
+            'excerpt' => '把人格洞察转成职业决策。',
+            'status' => CareerGuide::STATUS_PUBLISHED,
+            'is_public' => true,
+            'published_at' => Carbon::create(2026, 3, 5, 8, 15, 0, 'UTC'),
+        ]);
+
+        $payload = $service->buildSeoPayload($enGuide);
+        $this->assertSame(
+            'https://staging.fermatmind.com/en/career/guides/from-mbti-to-job-fit',
+            data_get($payload, 'alternates.en')
+        );
+        $this->assertSame(
+            'https://staging.fermatmind.com/zh/career/guides/from-mbti-to-job-fit',
+            data_get($payload, 'alternates.zh-CN')
+        );
+
+        $soloGuide = $this->createGuide([
+            'guide_code' => 'solo-guide',
+            'slug' => 'solo-guide',
+            'locale' => 'en',
+            'title' => 'Solo Guide',
+            'excerpt' => 'Only one locale exists.',
+            'status' => CareerGuide::STATUS_PUBLISHED,
+            'is_public' => true,
+            'published_at' => Carbon::create(2026, 3, 5, 9, 0, 0, 'UTC'),
+        ]);
+
+        $soloPayload = $service->buildSeoPayload($soloGuide);
+        $this->assertSame(
+            'https://staging.fermatmind.com/en/career/guides/solo-guide',
+            data_get($soloPayload, 'alternates.en')
+        );
+        $this->assertNull(data_get($soloPayload, 'alternates.zh-CN'));
+    }
+
+    public function test_build_jsonld_normalizes_legacy_override_urls(): void
+    {
+        config(['app.frontend_url' => 'https://staging.fermatmind.com']);
+
+        $guide = $this->createGuide([
+            'guide_code' => 'from-mbti-to-job-fit',
+            'slug' => 'from-mbti-to-job-fit',
+            'locale' => 'en',
+            'title' => 'From MBTI to Job Fit',
+            'excerpt' => 'Translate personality insights into practical career decisions.',
+            'status' => CareerGuide::STATUS_PUBLISHED,
+            'is_public' => true,
+            'published_at' => Carbon::create(2026, 3, 5, 8, 0, 0, 'UTC'),
+        ]);
+        CareerGuideSeoMeta::query()->create([
+            'career_guide_id' => (int) $guide->id,
+            'canonical_url' => 'https://api.staging.fermatmind.com/career-guides/from-mbti-to-job-fit',
+            'jsonld_overrides_json' => [
+                '@id' => 'https://api.staging.fermatmind.com/career-guides/from-mbti-to-job-fit#webpage',
+                'url' => 'https://api.staging.fermatmind.com/career-guides/from-mbti-to-job-fit',
+                'mainEntityOfPage' => 'https://api.staging.fermatmind.com/career-guides/from-mbti-to-job-fit',
+            ],
+        ]);
+
+        $jsonLd = app(CareerGuideSeoService::class)->buildJsonLd($guide);
+
+        $this->assertSame('WebPage', data_get($jsonLd, '@type'));
+        $this->assertSame(
+            'https://staging.fermatmind.com/en/career/guides/from-mbti-to-job-fit#webpage',
+            data_get($jsonLd, '@id')
+        );
+        $this->assertSame(
+            'https://staging.fermatmind.com/en/career/guides/from-mbti-to-job-fit',
+            data_get($jsonLd, 'url')
+        );
+        $this->assertSame(
+            'https://staging.fermatmind.com/en/career/guides/from-mbti-to-job-fit',
+            data_get($jsonLd, 'mainEntityOfPage')
+        );
+    }
+
+    /**
+     * @param  array<string, mixed>  $overrides
+     */
+    private function createGuide(array $overrides = []): CareerGuide
+    {
+        /** @var CareerGuide */
+        return CareerGuide::query()->create(array_merge([
+            'org_id' => 0,
+            'guide_code' => 'career-guide',
+            'slug' => 'career-guide',
+            'locale' => 'en',
+            'title' => 'Career guide',
+            'excerpt' => 'Career guide excerpt.',
+            'category_slug' => 'career-planning',
+            'body_md' => '# Career guide',
+            'body_html' => '<h1>Career guide</h1>',
+            'related_industry_slugs_json' => ['technology'],
+            'status' => CareerGuide::STATUS_DRAFT,
+            'is_public' => false,
+            'is_indexable' => true,
+            'sort_order' => 0,
+            'published_at' => null,
+            'scheduled_at' => null,
+            'schema_version' => 'v1',
+            'created_at' => Carbon::create(2026, 3, 5, 8, 0, 0, 'UTC'),
+            'updated_at' => Carbon::create(2026, 3, 5, 9, 0, 0, 'UTC'),
+        ], $overrides));
+    }
+}

--- a/backend/tests/Feature/V0_5/CareerGuidePublicApiTest.php
+++ b/backend/tests/Feature/V0_5/CareerGuidePublicApiTest.php
@@ -1,0 +1,515 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\V0_5;
+
+use App\Models\Article;
+use App\Models\CareerGuide;
+use App\Models\CareerGuideSeoMeta;
+use App\Models\CareerJob;
+use App\Models\PersonalityProfile;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Carbon;
+use Tests\TestCase;
+
+final class CareerGuidePublicApiTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_list_validates_locale_and_filters_visibility_locale_category_and_org_scope(): void
+    {
+        $primary = $this->createGuide([
+            'guide_code' => 'from-mbti-to-job-fit',
+            'slug' => 'from-mbti-to-job-fit',
+            'title' => 'From MBTI to Job Fit',
+            'category_slug' => 'assessment-usage',
+            'status' => CareerGuide::STATUS_PUBLISHED,
+            'is_public' => true,
+            'is_indexable' => false,
+            'published_at' => Carbon::create(2026, 3, 5, 8, 0, 0, 'UTC'),
+            'updated_at' => Carbon::create(2026, 3, 5, 9, 0, 0, 'UTC'),
+            'sort_order' => 10,
+        ]);
+        $secondary = $this->createGuide([
+            'guide_code' => 'annual-career-review-system',
+            'slug' => 'annual-career-review-system',
+            'title' => 'Annual Career Review System',
+            'category_slug' => 'career-planning',
+            'status' => CareerGuide::STATUS_PUBLISHED,
+            'is_public' => true,
+            'published_at' => Carbon::create(2026, 3, 6, 8, 0, 0, 'UTC'),
+            'updated_at' => Carbon::create(2026, 3, 6, 9, 0, 0, 'UTC'),
+            'sort_order' => 20,
+        ]);
+
+        $this->createGuide([
+            'guide_code' => 'from-mbti-to-job-fit',
+            'slug' => 'from-mbti-to-job-fit',
+            'locale' => 'zh-CN',
+            'title' => '从 MBTI 到职业匹配',
+            'category_slug' => 'assessment-usage',
+            'status' => CareerGuide::STATUS_PUBLISHED,
+            'is_public' => true,
+            'published_at' => Carbon::create(2026, 3, 5, 10, 0, 0, 'UTC'),
+        ]);
+        $this->createGuide([
+            'org_id' => 7,
+            'guide_code' => 'from-mbti-to-job-fit',
+            'slug' => 'from-mbti-to-job-fit',
+            'title' => 'Tenant Guide',
+            'category_slug' => 'assessment-usage',
+            'status' => CareerGuide::STATUS_PUBLISHED,
+            'is_public' => true,
+            'published_at' => Carbon::create(2026, 3, 5, 11, 0, 0, 'UTC'),
+        ]);
+        $this->createGuide([
+            'guide_code' => 'draft-guide',
+            'slug' => 'draft-guide',
+            'status' => CareerGuide::STATUS_DRAFT,
+            'is_public' => true,
+        ]);
+        $this->createGuide([
+            'guide_code' => 'private-guide',
+            'slug' => 'private-guide',
+            'status' => CareerGuide::STATUS_PUBLISHED,
+            'is_public' => false,
+            'published_at' => Carbon::create(2026, 3, 5, 12, 0, 0, 'UTC'),
+        ]);
+        $this->createGuide([
+            'guide_code' => 'future-guide',
+            'slug' => 'future-guide',
+            'status' => CareerGuide::STATUS_PUBLISHED,
+            'is_public' => true,
+            'published_at' => now()->addDay(),
+        ]);
+
+        $this->getJson('/api/v0.5/career-guides')
+            ->assertStatus(422)
+            ->assertJsonPath('ok', false)
+            ->assertJsonPath('error_code', 'INVALID_ARGUMENT');
+
+        $this->getJson('/api/v0.5/career-guides?locale=en')
+            ->assertOk()
+            ->assertJsonPath('ok', true)
+            ->assertJsonPath('pagination.total', 2)
+            ->assertJsonCount(2, 'items')
+            ->assertJsonPath('items.0.slug', (string) $primary->slug)
+            ->assertJsonPath('items.0.is_indexable', false)
+            ->assertJsonPath('items.1.slug', (string) $secondary->slug)
+            ->assertJsonMissingPath('items.0.body_md')
+            ->assertJsonMissingPath('items.0.seo_meta');
+
+        $this->getJson('/api/v0.5/career-guides?locale=en&category=assessment-usage')
+            ->assertOk()
+            ->assertJsonPath('pagination.total', 1)
+            ->assertJsonPath('items.0.slug', (string) $primary->slug)
+            ->assertJsonPath('items.0.category_slug', 'assessment-usage');
+
+        $this->getJson('/api/v0.5/career-guides?locale=zh-CN')
+            ->assertOk()
+            ->assertJsonPath('pagination.total', 1)
+            ->assertJsonPath('items.0.locale', 'zh-CN')
+            ->assertJsonPath('items.0.title', '从 MBTI 到职业匹配');
+
+        $this->getJson('/api/v0.5/career-guides?locale=en&org_id=7')
+            ->assertOk()
+            ->assertJsonPath('pagination.total', 1)
+            ->assertJsonPath('items.0.org_id', 7)
+            ->assertJsonPath('items.0.title', 'Tenant Guide');
+    }
+
+    public function test_detail_returns_guide_related_summaries_industry_slugs_and_resolved_seo_meta(): void
+    {
+        config(['app.frontend_url' => 'https://staging.fermatmind.com']);
+
+        $guide = $this->createGuide([
+            'guide_code' => 'from-mbti-to-job-fit',
+            'slug' => 'from-mbti-to-job-fit',
+            'title' => 'From MBTI to Job Fit',
+            'excerpt' => 'How to translate MBTI insights into career decisions.',
+            'category_slug' => 'assessment-usage',
+            'body_md' => '# Guide body',
+            'body_html' => '<h1>Guide body</h1>',
+            'related_industry_slugs_json' => ['consulting', 'manufacturing'],
+            'status' => CareerGuide::STATUS_PUBLISHED,
+            'is_public' => true,
+            'published_at' => Carbon::create(2026, 3, 5, 8, 0, 0, 'UTC'),
+        ]);
+        $this->createSeoMeta($guide, [
+            'seo_title' => 'From MBTI to Job Fit | FermatMind',
+            'seo_description' => 'Translate personality insights into practical career decisions.',
+            'canonical_url' => 'https://api.staging.fermatmind.com/career-guides/from-mbti-to-job-fit',
+            'og_title' => 'MBTI to Job Fit',
+            'og_description' => 'Practical MBTI career guide.',
+            'robots' => 'index,follow',
+            'jsonld_overrides_json' => ['@id' => 'https://api.staging.fermatmind.com/career-guides/from-mbti-to-job-fit#webpage'],
+        ]);
+
+        $job = $this->createJob([
+            'job_code' => 'product-manager',
+            'slug' => 'product-manager',
+            'title' => 'Product Manager',
+            'excerpt' => 'Translate ambiguity into roadmap decisions.',
+            'industry_slug' => 'technology',
+            'industry_label' => 'Technology',
+            'status' => CareerJob::STATUS_PUBLISHED,
+            'is_public' => true,
+            'published_at' => Carbon::create(2026, 3, 5, 8, 30, 0, 'UTC'),
+        ]);
+        $hiddenJob = $this->createJob([
+            'job_code' => 'private-role',
+            'slug' => 'private-role',
+            'title' => 'Private Role',
+            'status' => CareerJob::STATUS_PUBLISHED,
+            'is_public' => false,
+            'published_at' => Carbon::create(2026, 3, 5, 8, 45, 0, 'UTC'),
+        ]);
+
+        $article = $this->createArticle([
+            'slug' => 'how-to-read-mbti-results',
+            'title' => 'How to Read MBTI Results',
+            'excerpt' => 'A practical guide to understanding type results.',
+            'status' => 'published',
+            'is_public' => true,
+            'published_at' => Carbon::create(2026, 3, 5, 9, 0, 0, 'UTC'),
+        ]);
+        $hiddenArticle = $this->createArticle([
+            'slug' => 'hidden-article',
+            'title' => 'Hidden Article',
+            'status' => 'published',
+            'is_public' => false,
+            'published_at' => Carbon::create(2026, 3, 5, 9, 15, 0, 'UTC'),
+        ]);
+
+        $profile = $this->createProfile([
+            'type_code' => 'INTJ',
+            'slug' => 'intj',
+            'title' => 'INTJ Personality Type',
+            'excerpt' => 'Strategic and future-oriented.',
+            'status' => 'published',
+            'is_public' => true,
+            'published_at' => Carbon::create(2026, 3, 5, 9, 30, 0, 'UTC'),
+        ]);
+        $hiddenProfile = $this->createProfile([
+            'type_code' => 'ENFP',
+            'slug' => 'enfp',
+            'title' => 'ENFP Personality Type',
+            'status' => 'published',
+            'is_public' => false,
+            'published_at' => Carbon::create(2026, 3, 5, 9, 45, 0, 'UTC'),
+        ]);
+
+        $guide->relatedJobs()->attach($job->id, ['sort_order' => 10]);
+        $guide->relatedJobs()->attach($hiddenJob->id, ['sort_order' => 20]);
+        $guide->relatedArticles()->attach($article->id, ['sort_order' => 10]);
+        $guide->relatedArticles()->attach($hiddenArticle->id, ['sort_order' => 20]);
+        $guide->relatedPersonalityProfiles()->attach($profile->id, ['sort_order' => 10]);
+        $guide->relatedPersonalityProfiles()->attach($hiddenProfile->id, ['sort_order' => 20]);
+
+        $response = $this->getJson('/api/v0.5/career-guides/from-mbti-to-job-fit?locale=en');
+
+        $response->assertOk()
+            ->assertJsonPath('ok', true)
+            ->assertJsonPath('guide.guide_code', 'from-mbti-to-job-fit')
+            ->assertJsonPath('guide.category_slug', 'assessment-usage')
+            ->assertJsonPath('guide.body_md', '# Guide body')
+            ->assertJsonPath('related_jobs.0.job_code', 'product-manager')
+            ->assertJsonPath('related_jobs.0.industry_slug', 'technology')
+            ->assertJsonCount(2, 'related_industries')
+            ->assertJsonPath('related_industries.0', 'consulting')
+            ->assertJsonPath('related_articles.0.slug', 'how-to-read-mbti-results')
+            ->assertJsonPath('related_personality_profiles.0.type_code', 'INTJ')
+            ->assertJsonPath('seo_meta.seo_title', 'From MBTI to Job Fit | FermatMind')
+            ->assertJsonPath(
+                'seo_meta.canonical_url',
+                'https://staging.fermatmind.com/en/career/guides/from-mbti-to-job-fit'
+            )
+            ->assertJsonPath('seo_meta.robots', 'index,follow')
+            ->assertJsonMissingPath('guide.related_jobs')
+            ->assertJsonMissingPath('revisions')
+            ->assertJsonMissingPath('related_jobs.0.pivot');
+    }
+
+    public function test_detail_returns_not_found_for_missing_hidden_and_locale_mismatch_guides(): void
+    {
+        $draft = $this->createGuide([
+            'guide_code' => 'draft-guide',
+            'slug' => 'draft-guide',
+            'status' => CareerGuide::STATUS_DRAFT,
+            'is_public' => true,
+        ]);
+        $this->createGuide([
+            'guide_code' => 'private-guide',
+            'slug' => 'private-guide',
+            'status' => CareerGuide::STATUS_PUBLISHED,
+            'is_public' => false,
+            'published_at' => Carbon::create(2026, 3, 5, 8, 0, 0, 'UTC'),
+        ]);
+        $this->createGuide([
+            'guide_code' => 'zh-guide',
+            'slug' => 'zh-guide',
+            'locale' => 'zh-CN',
+            'status' => CareerGuide::STATUS_PUBLISHED,
+            'is_public' => true,
+            'published_at' => Carbon::create(2026, 3, 5, 8, 15, 0, 'UTC'),
+        ]);
+
+        $this->getJson('/api/v0.5/career-guides/missing?locale=en')
+            ->assertStatus(404)
+            ->assertJsonPath('ok', false)
+            ->assertJsonPath('error_code', 'NOT_FOUND');
+
+        $this->getJson('/api/v0.5/career-guides/'.$draft->slug.'?locale=en')
+            ->assertStatus(404)
+            ->assertJsonPath('error_code', 'NOT_FOUND');
+
+        $this->getJson('/api/v0.5/career-guides/private-guide?locale=en')
+            ->assertStatus(404)
+            ->assertJsonPath('error_code', 'NOT_FOUND');
+
+        $this->getJson('/api/v0.5/career-guides/zh-guide?locale=en')
+            ->assertStatus(404)
+            ->assertJsonPath('error_code', 'NOT_FOUND');
+    }
+
+    public function test_seo_endpoint_returns_localized_meta_real_alternates_and_webpage_jsonld(): void
+    {
+        config(['app.frontend_url' => 'https://staging.fermatmind.com']);
+
+        $enGuide = $this->createGuide([
+            'guide_code' => 'from-mbti-to-job-fit',
+            'slug' => 'from-mbti-to-job-fit',
+            'locale' => 'en',
+            'title' => 'From MBTI to Job Fit',
+            'excerpt' => 'How to translate MBTI insights into career decisions.',
+            'status' => CareerGuide::STATUS_PUBLISHED,
+            'is_public' => true,
+            'published_at' => Carbon::create(2026, 3, 5, 8, 0, 0, 'UTC'),
+        ]);
+        $this->createSeoMeta($enGuide, [
+            'seo_title' => 'From MBTI to Job Fit | FermatMind',
+            'seo_description' => 'How to translate MBTI insights into career decisions.',
+            'canonical_url' => 'https://api.staging.fermatmind.com/career-guides/from-mbti-to-job-fit',
+            'jsonld_overrides_json' => [
+                '@id' => 'https://api.staging.fermatmind.com/career-guides/from-mbti-to-job-fit#webpage',
+                'url' => 'https://api.staging.fermatmind.com/career-guides/from-mbti-to-job-fit',
+                'mainEntityOfPage' => 'https://api.staging.fermatmind.com/career-guides/from-mbti-to-job-fit',
+            ],
+        ]);
+
+        $this->createGuide([
+            'guide_code' => 'from-mbti-to-job-fit',
+            'slug' => 'from-mbti-to-job-fit',
+            'locale' => 'zh-CN',
+            'title' => '从 MBTI 到职业匹配',
+            'excerpt' => '把人格洞察转成职业决策。',
+            'status' => CareerGuide::STATUS_PUBLISHED,
+            'is_public' => true,
+            'published_at' => Carbon::create(2026, 3, 5, 8, 15, 0, 'UTC'),
+        ]);
+
+        $response = $this->getJson('/api/v0.5/career-guides/from-mbti-to-job-fit/seo?locale=en');
+
+        $response->assertOk()
+            ->assertJsonPath('meta.title', 'From MBTI to Job Fit | FermatMind')
+            ->assertJsonPath(
+                'meta.canonical',
+                'https://staging.fermatmind.com/en/career/guides/from-mbti-to-job-fit'
+            )
+            ->assertJsonPath(
+                'meta.alternates.en',
+                'https://staging.fermatmind.com/en/career/guides/from-mbti-to-job-fit'
+            )
+            ->assertJsonPath(
+                'meta.alternates.zh-CN',
+                'https://staging.fermatmind.com/zh/career/guides/from-mbti-to-job-fit'
+            )
+            ->assertJsonPath('jsonld.@type', 'WebPage')
+            ->assertJsonPath(
+                'jsonld.@id',
+                'https://staging.fermatmind.com/en/career/guides/from-mbti-to-job-fit#webpage'
+            )
+            ->assertJsonPath(
+                'jsonld.mainEntityOfPage',
+                'https://staging.fermatmind.com/en/career/guides/from-mbti-to-job-fit'
+            );
+
+        $this->assertStringNotContainsString(
+            'https://api.staging.fermatmind.com/career-guides/from-mbti-to-job-fit',
+            (string) $response->getContent()
+        );
+    }
+
+    public function test_seo_endpoint_does_not_fake_missing_locale_alternates_and_returns_not_found_for_hidden_guides(): void
+    {
+        config(['app.frontend_url' => 'https://staging.fermatmind.com']);
+
+        $this->createGuide([
+            'guide_code' => 'solo-guide',
+            'slug' => 'solo-guide',
+            'locale' => 'en',
+            'title' => 'Solo Guide',
+            'excerpt' => 'Only one locale exists.',
+            'status' => CareerGuide::STATUS_PUBLISHED,
+            'is_public' => true,
+            'published_at' => Carbon::create(2026, 3, 5, 8, 0, 0, 'UTC'),
+        ]);
+        $this->createGuide([
+            'guide_code' => 'hidden-guide',
+            'slug' => 'hidden-guide',
+            'locale' => 'en',
+            'title' => 'Hidden Guide',
+            'status' => CareerGuide::STATUS_PUBLISHED,
+            'is_public' => false,
+            'published_at' => Carbon::create(2026, 3, 5, 8, 15, 0, 'UTC'),
+        ]);
+
+        $response = $this->getJson('/api/v0.5/career-guides/solo-guide/seo?locale=en');
+
+        $response->assertOk()
+            ->assertJsonPath(
+                'meta.canonical',
+                'https://staging.fermatmind.com/en/career/guides/solo-guide'
+            )
+            ->assertJsonPath(
+                'meta.alternates.en',
+                'https://staging.fermatmind.com/en/career/guides/solo-guide'
+            )
+            ->assertJsonMissingPath('meta.alternates.zh-CN');
+
+        $this->getJson('/api/v0.5/career-guides/missing/seo?locale=en')
+            ->assertStatus(404)
+            ->assertJsonPath('error', 'not found');
+
+        $this->getJson('/api/v0.5/career-guides/hidden-guide/seo?locale=en')
+            ->assertStatus(404)
+            ->assertJsonPath('error', 'not found');
+    }
+
+    /**
+     * @param  array<string, mixed>  $overrides
+     */
+    private function createGuide(array $overrides = []): CareerGuide
+    {
+        /** @var CareerGuide */
+        return CareerGuide::query()->create(array_merge([
+            'org_id' => 0,
+            'guide_code' => 'career-guide',
+            'slug' => 'career-guide',
+            'locale' => 'en',
+            'title' => 'Career guide',
+            'excerpt' => 'Career guide excerpt.',
+            'category_slug' => 'career-planning',
+            'body_md' => '# Career guide',
+            'body_html' => '<h1>Career guide</h1>',
+            'related_industry_slugs_json' => ['technology'],
+            'status' => CareerGuide::STATUS_DRAFT,
+            'is_public' => false,
+            'is_indexable' => true,
+            'sort_order' => 0,
+            'published_at' => null,
+            'scheduled_at' => null,
+            'schema_version' => 'v1',
+            'created_at' => Carbon::create(2026, 3, 5, 8, 0, 0, 'UTC'),
+            'updated_at' => Carbon::create(2026, 3, 5, 9, 0, 0, 'UTC'),
+        ], $overrides));
+    }
+
+    /**
+     * @param  array<string, mixed>  $overrides
+     */
+    private function createSeoMeta(CareerGuide $guide, array $overrides = []): CareerGuideSeoMeta
+    {
+        /** @var CareerGuideSeoMeta */
+        return CareerGuideSeoMeta::query()->create(array_merge([
+            'career_guide_id' => (int) $guide->id,
+            'seo_title' => null,
+            'seo_description' => null,
+            'canonical_url' => null,
+            'og_title' => null,
+            'og_description' => null,
+            'og_image_url' => null,
+            'twitter_title' => null,
+            'twitter_description' => null,
+            'twitter_image_url' => null,
+            'robots' => null,
+            'jsonld_overrides_json' => null,
+        ], $overrides));
+    }
+
+    /**
+     * @param  array<string, mixed>  $overrides
+     */
+    private function createJob(array $overrides = []): CareerJob
+    {
+        /** @var CareerJob */
+        return CareerJob::query()->create(array_merge([
+            'org_id' => 0,
+            'job_code' => 'career-job',
+            'slug' => 'career-job',
+            'locale' => 'en',
+            'title' => 'Career job',
+            'excerpt' => 'Career job excerpt.',
+            'industry_slug' => 'technology',
+            'industry_label' => 'Technology',
+            'status' => CareerJob::STATUS_DRAFT,
+            'is_public' => false,
+            'is_indexable' => true,
+            'published_at' => null,
+            'scheduled_at' => null,
+            'schema_version' => 'v1',
+            'sort_order' => 0,
+        ], $overrides));
+    }
+
+    /**
+     * @param  array<string, mixed>  $overrides
+     */
+    private function createArticle(array $overrides = []): Article
+    {
+        /** @var Article */
+        return Article::query()->create(array_merge([
+            'org_id' => 0,
+            'category_id' => null,
+            'author_admin_user_id' => null,
+            'slug' => 'career-article',
+            'locale' => 'en',
+            'title' => 'Career article',
+            'excerpt' => 'Career article excerpt.',
+            'content_md' => '# Career article',
+            'content_html' => '<h1>Career article</h1>',
+            'cover_image_url' => null,
+            'status' => 'draft',
+            'is_public' => false,
+            'is_indexable' => true,
+            'published_at' => null,
+            'scheduled_at' => null,
+            'created_at' => Carbon::create(2026, 3, 5, 8, 0, 0, 'UTC'),
+            'updated_at' => Carbon::create(2026, 3, 5, 9, 0, 0, 'UTC'),
+        ], $overrides));
+    }
+
+    /**
+     * @param  array<string, mixed>  $overrides
+     */
+    private function createProfile(array $overrides = []): PersonalityProfile
+    {
+        /** @var PersonalityProfile */
+        return PersonalityProfile::query()->create(array_merge([
+            'org_id' => 0,
+            'scale_code' => PersonalityProfile::SCALE_CODE_MBTI,
+            'type_code' => 'INTJ',
+            'slug' => 'intj',
+            'locale' => 'en',
+            'title' => 'INTJ Personality Type',
+            'excerpt' => 'Strategic and future-oriented.',
+            'status' => 'draft',
+            'is_public' => false,
+            'is_indexable' => true,
+            'published_at' => null,
+            'scheduled_at' => null,
+            'schema_version' => 'v1',
+        ], $overrides));
+    }
+}


### PR DESCRIPTION
Summary
- add the first public API and SEO contract for CareerGuide
- provide the runtime backend foundation required for later workspace/importer/frontend cutover work

What changed
- add career-guides list/detail/seo routes under the v0.5 CMS surface
- add a CareerGuide public read controller and service
- add a CareerGuide SEO service with localized canonical, sibling-aware alternates, and JSON-LD output
- return guide detail payloads with related jobs/articles/personality summaries and industry slug arrays
- update backend route snapshot and add focused API/SEO tests

Design choices
- follow the CareerJob-style public API pattern
- keep body storage flat with body_md/body_html
- keep related_industries as slug arrays in v1
- use guide_code for sibling-locale alternate resolution
- defer workspace/importer/frontend/sitemap integration to later PRs

Why this PR is small and safe
- no migration changes
- no frontend changes
- no workspace/importer changes
- no sitemap generator changes
- only the public runtime contract for the next Career CMS object

Validation
- php artisan about
- php artisan route:list
- php artisan migrate
- php artisan test --filter='(CareerGuidePublicApi|CareerGuideSeo|OpenApiDiff)'
- php artisan filament:assets
- npm run build
- bash scripts/ci_verify_mbti.sh

Rollout note
- this PR does not wire CareerGuide into sitemap/runtime authority yet
- later runtime/sitemap integration must only be deployed after migrations are present, because backend sitemap paths are sensitive to schema drift