### PR TITLE
feat(career-cms): add CareerGuide baseline import pipeline

### DIFF
--- a/backend/app/CareerCms/Baseline/CareerGuideBaselineImporter.php
+++ b/backend/app/CareerCms/Baseline/CareerGuideBaselineImporter.php
@@ -1,0 +1,807 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\CareerCms\Baseline;
+
+use App\Models\Article;
+use App\Models\CareerGuide;
+use App\Models\CareerGuideRevision;
+use App\Models\CareerGuideSeoMeta;
+use App\Models\CareerJob;
+use App\Models\PersonalityProfile;
+use App\Services\Cms\CareerGuideSeoService;
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Support\Carbon;
+use Illuminate\Support\Facades\DB;
+use RuntimeException;
+
+final class CareerGuideBaselineImporter
+{
+    public function __construct(
+        private readonly CareerGuideSeoService $careerGuideSeoService,
+    ) {}
+
+    /**
+     * @param  array<int, array<string, mixed>>  $guides
+     * @param  array{
+     *   dry_run: bool,
+     *   upsert: bool,
+     *   status: 'draft'|'published'|null
+     * }  $options
+     * @return array<string, int|string|bool>
+     */
+    public function import(array $guides, array $options): array
+    {
+        $dryRun = (bool) ($options['dry_run'] ?? false);
+        $upsert = (bool) ($options['upsert'] ?? false);
+        $statusOverride = $options['status'] ?? null;
+        $statusMode = is_string($statusOverride) && $statusOverride !== '' ? $statusOverride : 'baseline';
+
+        $summary = [
+            'guides_found' => count($guides),
+            'will_create' => 0,
+            'will_update' => 0,
+            'will_skip' => 0,
+            'revisions_to_create' => 0,
+            'errors_count' => 0,
+            'dry_run' => $dryRun,
+            'upsert' => $upsert,
+            'status_mode' => $statusMode,
+        ];
+
+        $plannedOperations = [];
+
+        foreach ($guides as $guidePayload) {
+            $operation = $this->planOperation($guidePayload, $upsert, is_string($statusOverride) ? $statusOverride : null);
+            $plannedOperations[] = $operation;
+
+            if ($operation['action'] === 'create') {
+                $summary['will_create']++;
+                $summary['revisions_to_create']++;
+
+                continue;
+            }
+
+            if ($operation['action'] === 'update') {
+                $summary['will_update']++;
+                $summary['revisions_to_create']++;
+
+                continue;
+            }
+
+            $summary['will_skip']++;
+        }
+
+        if ($dryRun) {
+            return $summary;
+        }
+
+        foreach ($plannedOperations as $operation) {
+            if ($operation['action'] === 'skip') {
+                continue;
+            }
+
+            DB::transaction(function () use ($operation): void {
+                $status = (string) $operation['status'];
+                $guidePayload = (array) $operation['payload'];
+                $resolvedRelations = (array) $operation['resolved_relations'];
+
+                if ($operation['action'] === 'create') {
+                    $guide = CareerGuide::query()->create(
+                        $this->guideAttributes($guidePayload, $status)
+                    );
+                    $note = 'baseline import';
+                } else {
+                    /** @var CareerGuide $guide */
+                    $guide = $operation['existing'];
+                    $guide->fill($this->guideAttributes($guidePayload, $status, $guide));
+                    $guide->save();
+                    $note = 'baseline upsert';
+                }
+
+                $this->syncRelatedJobs($guide, (array) ($resolvedRelations['related_jobs'] ?? []));
+                $this->syncRelatedArticles($guide, (array) ($resolvedRelations['related_articles'] ?? []));
+                $this->syncRelatedPersonalityProfiles($guide, (array) ($resolvedRelations['related_personality_profiles'] ?? []));
+                $this->syncSeoMeta($guide, $guidePayload);
+                $this->createRevision($guide, $note);
+            });
+        }
+
+        return $summary;
+    }
+
+    /**
+     * @param  array<string, mixed>  $guidePayload
+     * @return array<string, mixed>
+     */
+    private function planOperation(array $guidePayload, bool $upsert, ?string $statusOverride): array
+    {
+        $existing = $this->resolveExistingGuide($guidePayload);
+        $status = $statusOverride ?? (string) $guidePayload['status'];
+        $resolvedRelations = [
+            'related_jobs' => $this->resolveRelatedJobs($guidePayload),
+            'related_articles' => $this->resolveRelatedArticles($guidePayload),
+            'related_personality_profiles' => $this->resolveRelatedPersonalityProfiles($guidePayload),
+        ];
+        $desiredState = $this->desiredComparableState($guidePayload, $status, $existing, $resolvedRelations);
+
+        if (! $existing instanceof CareerGuide) {
+            return [
+                'action' => 'create',
+                'status' => $status,
+                'payload' => $guidePayload,
+                'resolved_relations' => $resolvedRelations,
+                'existing' => null,
+                'desired_state' => $desiredState,
+            ];
+        }
+
+        if (! $upsert) {
+            return [
+                'action' => 'skip',
+                'status' => $status,
+                'payload' => $guidePayload,
+                'resolved_relations' => $resolvedRelations,
+                'existing' => $existing,
+                'desired_state' => $desiredState,
+            ];
+        }
+
+        $currentState = $this->currentComparableState($existing);
+
+        if ($desiredState === $currentState) {
+            return [
+                'action' => 'skip',
+                'status' => $status,
+                'payload' => $guidePayload,
+                'resolved_relations' => $resolvedRelations,
+                'existing' => $existing,
+                'desired_state' => $desiredState,
+            ];
+        }
+
+        return [
+            'action' => 'update',
+            'status' => $status,
+            'payload' => $guidePayload,
+            'resolved_relations' => $resolvedRelations,
+            'existing' => $existing,
+            'desired_state' => $desiredState,
+        ];
+    }
+
+    private function guideQuery(): Builder
+    {
+        return CareerGuide::query()->withoutGlobalScopes();
+    }
+
+    /**
+     * @param  array<string, mixed>  $guidePayload
+     */
+    private function resolveExistingGuide(array $guidePayload): ?CareerGuide
+    {
+        $guideCode = (string) $guidePayload['guide_code'];
+        $slug = (string) $guidePayload['slug'];
+        $locale = (string) $guidePayload['locale'];
+
+        $existingByGuideCode = $this->guideQuery()
+            ->where('org_id', 0)
+            ->where('guide_code', $guideCode)
+            ->where('locale', $locale)
+            ->first();
+
+        $existingBySlug = $this->guideQuery()
+            ->where('org_id', 0)
+            ->where('slug', $slug)
+            ->where('locale', $locale)
+            ->first();
+
+        if ($existingByGuideCode instanceof CareerGuide && $existingBySlug instanceof CareerGuide && (int) $existingByGuideCode->id !== (int) $existingBySlug->id) {
+            throw new RuntimeException(sprintf(
+                'Career guide slug conflict for %s locale %s: target slug %s is already owned by guide_code=%s.',
+                $guideCode,
+                $locale,
+                $slug,
+                (string) $existingBySlug->guide_code,
+            ));
+        }
+
+        if ($existingByGuideCode instanceof CareerGuide) {
+            return $existingByGuideCode;
+        }
+
+        if ($existingBySlug instanceof CareerGuide) {
+            if ((string) $existingBySlug->guide_code !== $guideCode) {
+                throw new RuntimeException(sprintf(
+                    'Career guide slug conflict for %s locale %s: target slug %s is already owned by guide_code=%s.',
+                    $guideCode,
+                    $locale,
+                    $slug,
+                    (string) $existingBySlug->guide_code,
+                ));
+            }
+
+            return $existingBySlug;
+        }
+
+        return null;
+    }
+
+    /**
+     * @param  array<string, mixed>  $guidePayload
+     * @return array<int, array<string, mixed>>
+     */
+    private function resolveRelatedJobs(array $guidePayload): array
+    {
+        $locale = (string) $guidePayload['locale'];
+        $guideCode = (string) $guidePayload['guide_code'];
+        $resolved = [];
+
+        foreach ((array) $guidePayload['related_jobs'] as $index => $row) {
+            $jobCode = (string) ($row['job_code'] ?? '');
+
+            $job = CareerJob::query()
+                ->withoutGlobalScopes()
+                ->where('org_id', 0)
+                ->where('job_code', $jobCode)
+                ->where('locale', $locale)
+                ->first();
+
+            if (! $job instanceof CareerJob) {
+                throw new RuntimeException(sprintf(
+                    'Unable to resolve related_jobs job_code=%s for guide %s locale %s.',
+                    $jobCode,
+                    $guideCode,
+                    $locale,
+                ));
+            }
+
+            $resolved[] = [
+                'career_job_id' => (int) $job->id,
+                'job_code' => (string) $job->job_code,
+                'slug' => (string) $job->slug,
+                'locale' => (string) $job->locale,
+                'sort_order' => ($index + 1) * 10,
+            ];
+        }
+
+        return $resolved;
+    }
+
+    /**
+     * @param  array<string, mixed>  $guidePayload
+     * @return array<int, array<string, mixed>>
+     */
+    private function resolveRelatedArticles(array $guidePayload): array
+    {
+        $locale = (string) $guidePayload['locale'];
+        $guideCode = (string) $guidePayload['guide_code'];
+        $resolved = [];
+
+        foreach ((array) $guidePayload['related_articles'] as $index => $row) {
+            $slug = (string) ($row['slug'] ?? '');
+
+            $article = Article::query()
+                ->withoutGlobalScopes()
+                ->where('org_id', 0)
+                ->where('slug', $slug)
+                ->where('locale', $locale)
+                ->first();
+
+            if (! $article instanceof Article) {
+                throw new RuntimeException(sprintf(
+                    'Unable to resolve related_articles slug=%s for guide %s locale %s.',
+                    $slug,
+                    $guideCode,
+                    $locale,
+                ));
+            }
+
+            $resolved[] = [
+                'article_id' => (int) $article->id,
+                'slug' => (string) $article->slug,
+                'locale' => (string) $article->locale,
+                'sort_order' => ($index + 1) * 10,
+            ];
+        }
+
+        return $resolved;
+    }
+
+    /**
+     * @param  array<string, mixed>  $guidePayload
+     * @return array<int, array<string, mixed>>
+     */
+    private function resolveRelatedPersonalityProfiles(array $guidePayload): array
+    {
+        $locale = (string) $guidePayload['locale'];
+        $guideCode = (string) $guidePayload['guide_code'];
+        $resolved = [];
+
+        foreach ((array) $guidePayload['related_personality_profiles'] as $index => $row) {
+            $typeCode = (string) ($row['type_code'] ?? '');
+
+            $profile = PersonalityProfile::query()
+                ->withoutGlobalScopes()
+                ->where('org_id', 0)
+                ->where('scale_code', PersonalityProfile::SCALE_CODE_MBTI)
+                ->where('type_code', $typeCode)
+                ->where('locale', $locale)
+                ->first();
+
+            if (! $profile instanceof PersonalityProfile) {
+                throw new RuntimeException(sprintf(
+                    'Unable to resolve related_personality_profiles type_code=%s for guide %s locale %s.',
+                    $typeCode,
+                    $guideCode,
+                    $locale,
+                ));
+            }
+
+            $resolved[] = [
+                'personality_profile_id' => (int) $profile->id,
+                'type_code' => (string) $profile->type_code,
+                'slug' => (string) $profile->slug,
+                'locale' => (string) $profile->locale,
+                'sort_order' => ($index + 1) * 10,
+            ];
+        }
+
+        return $resolved;
+    }
+
+    /**
+     * @param  array<string, mixed>  $guidePayload
+     * @return array<string, mixed>
+     */
+    private function guideAttributes(
+        array $guidePayload,
+        string $status,
+        ?CareerGuide $existing = null,
+    ): array {
+        return [
+            'org_id' => 0,
+            'guide_code' => (string) $guidePayload['guide_code'],
+            'slug' => (string) $guidePayload['slug'],
+            'locale' => (string) $guidePayload['locale'],
+            'title' => (string) $guidePayload['title'],
+            'excerpt' => $guidePayload['excerpt'],
+            'category_slug' => $guidePayload['category_slug'],
+            'body_md' => $guidePayload['body_md'],
+            'body_html' => $guidePayload['body_html'],
+            'related_industry_slugs_json' => $guidePayload['related_industry_slugs_json'],
+            'status' => $status,
+            'is_public' => (bool) $guidePayload['is_public'],
+            'is_indexable' => (bool) $guidePayload['is_indexable'],
+            'sort_order' => (int) ($guidePayload['sort_order'] ?? 0),
+            'published_at' => $this->resolvePublishedAt($guidePayload, $status, $existing),
+            'scheduled_at' => $status === CareerGuide::STATUS_DRAFT
+                ? null
+                : $this->normalizeNullableDate($guidePayload['scheduled_at'] ?? null),
+            'schema_version' => (string) ($guidePayload['schema_version'] ?? 'v1'),
+        ];
+    }
+
+    /**
+     * @param  array<int, array<string, mixed>>  $relations
+     */
+    private function syncRelatedJobs(CareerGuide $guide, array $relations): void
+    {
+        $guide->relatedJobs()->sync(
+            collect($relations)
+                ->mapWithKeys(static fn (array $item): array => [
+                    (int) $item['career_job_id'] => ['sort_order' => (int) $item['sort_order']],
+                ])
+                ->all(),
+        );
+
+        $guide->unsetRelation('relatedJobs');
+    }
+
+    /**
+     * @param  array<int, array<string, mixed>>  $relations
+     */
+    private function syncRelatedArticles(CareerGuide $guide, array $relations): void
+    {
+        $guide->relatedArticles()->sync(
+            collect($relations)
+                ->mapWithKeys(static fn (array $item): array => [
+                    (int) $item['article_id'] => ['sort_order' => (int) $item['sort_order']],
+                ])
+                ->all(),
+        );
+
+        $guide->unsetRelation('relatedArticles');
+    }
+
+    /**
+     * @param  array<int, array<string, mixed>>  $relations
+     */
+    private function syncRelatedPersonalityProfiles(CareerGuide $guide, array $relations): void
+    {
+        $guide->relatedPersonalityProfiles()->sync(
+            collect($relations)
+                ->mapWithKeys(static fn (array $item): array => [
+                    (int) $item['personality_profile_id'] => ['sort_order' => (int) $item['sort_order']],
+                ])
+                ->all(),
+        );
+
+        $guide->unsetRelation('relatedPersonalityProfiles');
+    }
+
+    /**
+     * @param  array<string, mixed>  $guidePayload
+     */
+    private function syncSeoMeta(CareerGuide $guide, array $guidePayload): void
+    {
+        $seoMeta = (array) $guidePayload['seo_meta'];
+
+        if ($this->isEmptySeoMeta($seoMeta)) {
+            $this->careerGuideSeoService->generateSeoMeta((int) $guide->id);
+            $guide->unsetRelation('seoMeta');
+
+            return;
+        }
+
+        CareerGuideSeoMeta::query()->updateOrCreate(
+            [
+                'career_guide_id' => (int) $guide->id,
+            ],
+            [
+                'seo_title' => $seoMeta['seo_title'],
+                'seo_description' => $seoMeta['seo_description'],
+                'canonical_url' => $seoMeta['canonical_url'],
+                'og_title' => $seoMeta['og_title'],
+                'og_description' => $seoMeta['og_description'],
+                'og_image_url' => $seoMeta['og_image_url'],
+                'twitter_title' => $seoMeta['twitter_title'],
+                'twitter_description' => $seoMeta['twitter_description'],
+                'twitter_image_url' => $seoMeta['twitter_image_url'],
+                'robots' => $seoMeta['robots'],
+                'jsonld_overrides_json' => $seoMeta['jsonld_overrides_json'],
+            ],
+        );
+
+        $guide->unsetRelation('seoMeta');
+    }
+
+    private function createRevision(CareerGuide $guide, string $note): void
+    {
+        CareerGuideRevision::query()->create([
+            'career_guide_id' => (int) $guide->id,
+            'revision_no' => ((int) CareerGuideRevision::query()
+                ->where('career_guide_id', (int) $guide->id)
+                ->max('revision_no')) + 1,
+            'snapshot_json' => $this->snapshotPayload($guide->fresh([
+                'seoMeta',
+                'relatedJobs',
+                'relatedArticles',
+                'relatedPersonalityProfiles',
+            ])),
+            'note' => $note,
+            'created_by_admin_user_id' => null,
+            'created_at' => now(),
+        ]);
+    }
+
+    /**
+     * @param  array<string, mixed>  $guidePayload
+     * @param  array<string, array<int, array<string, mixed>>>  $resolvedRelations
+     * @return array<string, mixed>
+     */
+    private function desiredComparableState(
+        array $guidePayload,
+        string $status,
+        ?CareerGuide $existing,
+        array $resolvedRelations,
+    ): array {
+        return [
+            'guide' => [
+                'org_id' => 0,
+                'guide_code' => (string) $guidePayload['guide_code'],
+                'slug' => (string) $guidePayload['slug'],
+                'locale' => (string) $guidePayload['locale'],
+                'title' => (string) $guidePayload['title'],
+                'excerpt' => $guidePayload['excerpt'],
+                'category_slug' => $guidePayload['category_slug'],
+                'body_md' => $guidePayload['body_md'],
+                'body_html' => $guidePayload['body_html'],
+                'related_industry_slugs_json' => $guidePayload['related_industry_slugs_json'],
+                'status' => $status,
+                'is_public' => (bool) $guidePayload['is_public'],
+                'is_indexable' => (bool) $guidePayload['is_indexable'],
+                'sort_order' => (int) ($guidePayload['sort_order'] ?? 0),
+                'published_at' => $this->normalizeDateForComparison(
+                    $this->resolvePublishedAt($guidePayload, $status, $existing)
+                ),
+                'scheduled_at' => $status === CareerGuide::STATUS_DRAFT
+                    ? null
+                    : $this->normalizeDateForComparison($this->normalizeNullableDate($guidePayload['scheduled_at'] ?? null)),
+                'schema_version' => (string) ($guidePayload['schema_version'] ?? 'v1'),
+            ],
+            'related_jobs' => array_map(
+                static fn (array $item): array => [
+                    'job_code' => (string) $item['job_code'],
+                    'locale' => (string) $item['locale'],
+                    'sort_order' => (int) $item['sort_order'],
+                ],
+                (array) ($resolvedRelations['related_jobs'] ?? []),
+            ),
+            'related_articles' => array_map(
+                static fn (array $item): array => [
+                    'slug' => (string) $item['slug'],
+                    'locale' => (string) $item['locale'],
+                    'sort_order' => (int) $item['sort_order'],
+                ],
+                (array) ($resolvedRelations['related_articles'] ?? []),
+            ),
+            'related_personality_profiles' => array_map(
+                static fn (array $item): array => [
+                    'type_code' => (string) $item['type_code'],
+                    'locale' => (string) $item['locale'],
+                    'sort_order' => (int) $item['sort_order'],
+                ],
+                (array) ($resolvedRelations['related_personality_profiles'] ?? []),
+            ),
+            'seo_meta' => $this->desiredSeoMetaState($guidePayload, $status, $existing),
+        ];
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function currentComparableState(CareerGuide $guide): array
+    {
+        $guide->loadMissing('seoMeta', 'relatedJobs', 'relatedArticles', 'relatedPersonalityProfiles');
+
+        return [
+            'guide' => [
+                'org_id' => (int) $guide->org_id,
+                'guide_code' => (string) $guide->guide_code,
+                'slug' => (string) $guide->slug,
+                'locale' => (string) $guide->locale,
+                'title' => (string) $guide->title,
+                'excerpt' => $guide->excerpt,
+                'category_slug' => $guide->category_slug,
+                'body_md' => $guide->body_md,
+                'body_html' => $guide->body_html,
+                'related_industry_slugs_json' => is_array($guide->related_industry_slugs_json)
+                    ? $guide->related_industry_slugs_json
+                    : [],
+                'status' => (string) $guide->status,
+                'is_public' => (bool) $guide->is_public,
+                'is_indexable' => (bool) $guide->is_indexable,
+                'sort_order' => (int) $guide->sort_order,
+                'published_at' => $this->normalizeDateForComparison($guide->published_at),
+                'scheduled_at' => $this->normalizeDateForComparison($guide->scheduled_at),
+                'schema_version' => (string) $guide->schema_version,
+            ],
+            'related_jobs' => $guide->relatedJobs
+                ->map(static fn (CareerJob $job): array => [
+                    'job_code' => (string) $job->job_code,
+                    'locale' => (string) $job->locale,
+                    'sort_order' => (int) ($job->pivot?->sort_order ?? 0),
+                ])
+                ->values()
+                ->all(),
+            'related_articles' => $guide->relatedArticles
+                ->map(static fn (Article $article): array => [
+                    'slug' => (string) $article->slug,
+                    'locale' => (string) $article->locale,
+                    'sort_order' => (int) ($article->pivot?->sort_order ?? 0),
+                ])
+                ->values()
+                ->all(),
+            'related_personality_profiles' => $guide->relatedPersonalityProfiles
+                ->map(static fn (PersonalityProfile $profile): array => [
+                    'type_code' => (string) $profile->type_code,
+                    'locale' => (string) $profile->locale,
+                    'sort_order' => (int) ($profile->pivot?->sort_order ?? 0),
+                ])
+                ->values()
+                ->all(),
+            'seo_meta' => $guide->seoMeta instanceof CareerGuideSeoMeta
+                ? [
+                    'seo_title' => $guide->seoMeta->seo_title,
+                    'seo_description' => $guide->seoMeta->seo_description,
+                    'canonical_url' => $guide->seoMeta->canonical_url,
+                    'og_title' => $guide->seoMeta->og_title,
+                    'og_description' => $guide->seoMeta->og_description,
+                    'og_image_url' => $guide->seoMeta->og_image_url,
+                    'twitter_title' => $guide->seoMeta->twitter_title,
+                    'twitter_description' => $guide->seoMeta->twitter_description,
+                    'twitter_image_url' => $guide->seoMeta->twitter_image_url,
+                    'robots' => $guide->seoMeta->robots,
+                    'jsonld_overrides_json' => $guide->seoMeta->jsonld_overrides_json,
+                ]
+                : [
+                    'seo_title' => null,
+                    'seo_description' => null,
+                    'canonical_url' => null,
+                    'og_title' => null,
+                    'og_description' => null,
+                    'og_image_url' => null,
+                    'twitter_title' => null,
+                    'twitter_description' => null,
+                    'twitter_image_url' => null,
+                    'robots' => null,
+                    'jsonld_overrides_json' => null,
+                ],
+        ];
+    }
+
+    /**
+     * @param  array<string, mixed>  $guidePayload
+     * @return array<string, mixed>
+     */
+    private function desiredSeoMetaState(array $guidePayload, string $status, ?CareerGuide $existing): array
+    {
+        $seoMeta = (array) $guidePayload['seo_meta'];
+
+        if (! $this->isEmptySeoMeta($seoMeta)) {
+            return $seoMeta;
+        }
+
+        $previewGuide = new CareerGuide(
+            $this->guideAttributes($guidePayload, $status, $existing)
+        );
+
+        if ($existing instanceof CareerGuide) {
+            $previewGuide->forceFill([
+                'id' => (int) $existing->id,
+                'created_at' => $existing->created_at,
+                'updated_at' => $existing->updated_at,
+            ]);
+            $previewGuide->exists = true;
+        }
+
+        return $this->careerGuideSeoService->detailSeoMetaPayload($previewGuide) ?? $seoMeta;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function snapshotPayload(CareerGuide $guide): array
+    {
+        $guide->loadMissing('seoMeta', 'relatedJobs', 'relatedArticles', 'relatedPersonalityProfiles');
+
+        return [
+            'guide' => [
+                'id' => (int) $guide->id,
+                'org_id' => (int) $guide->org_id,
+                'guide_code' => (string) $guide->guide_code,
+                'slug' => (string) $guide->slug,
+                'locale' => (string) $guide->locale,
+                'title' => (string) $guide->title,
+                'excerpt' => $guide->excerpt,
+                'category_slug' => $guide->category_slug,
+                'body_md' => $guide->body_md,
+                'body_html' => $guide->body_html,
+                'related_industry_slugs_json' => $guide->related_industry_slugs_json,
+                'status' => (string) $guide->status,
+                'is_public' => (bool) $guide->is_public,
+                'is_indexable' => (bool) $guide->is_indexable,
+                'published_at' => $guide->published_at?->toIso8601String(),
+                'scheduled_at' => $guide->scheduled_at?->toIso8601String(),
+                'schema_version' => (string) $guide->schema_version,
+                'sort_order' => (int) $guide->sort_order,
+            ],
+            'related_jobs' => $guide->relatedJobs
+                ->map(static fn (CareerJob $job): array => [
+                    'career_job_id' => (int) $job->id,
+                    'job_code' => (string) $job->job_code,
+                    'slug' => (string) $job->slug,
+                    'locale' => (string) $job->locale,
+                    'title' => (string) $job->title,
+                    'sort_order' => (int) ($job->pivot?->sort_order ?? 0),
+                ])
+                ->values()
+                ->all(),
+            'related_articles' => $guide->relatedArticles
+                ->map(static fn (Article $article): array => [
+                    'article_id' => (int) $article->id,
+                    'slug' => (string) $article->slug,
+                    'locale' => (string) $article->locale,
+                    'title' => (string) $article->title,
+                    'sort_order' => (int) ($article->pivot?->sort_order ?? 0),
+                ])
+                ->values()
+                ->all(),
+            'related_personality_profiles' => $guide->relatedPersonalityProfiles
+                ->map(static fn (PersonalityProfile $profile): array => [
+                    'personality_profile_id' => (int) $profile->id,
+                    'type_code' => (string) $profile->type_code,
+                    'slug' => (string) $profile->slug,
+                    'locale' => (string) $profile->locale,
+                    'title' => (string) $profile->title,
+                    'sort_order' => (int) ($profile->pivot?->sort_order ?? 0),
+                ])
+                ->values()
+                ->all(),
+            'seo_meta' => $guide->seoMeta instanceof CareerGuideSeoMeta
+                ? [
+                    'seo_title' => $guide->seoMeta->seo_title,
+                    'seo_description' => $guide->seoMeta->seo_description,
+                    'canonical_url' => $guide->seoMeta->canonical_url,
+                    'og_title' => $guide->seoMeta->og_title,
+                    'og_description' => $guide->seoMeta->og_description,
+                    'og_image_url' => $guide->seoMeta->og_image_url,
+                    'twitter_title' => $guide->seoMeta->twitter_title,
+                    'twitter_description' => $guide->seoMeta->twitter_description,
+                    'twitter_image_url' => $guide->seoMeta->twitter_image_url,
+                    'robots' => $guide->seoMeta->robots,
+                    'jsonld_overrides_json' => $guide->seoMeta->jsonld_overrides_json,
+                ]
+                : null,
+        ];
+    }
+
+    /**
+     * @param  array<string, mixed>  $seoMeta
+     */
+    private function isEmptySeoMeta(array $seoMeta): bool
+    {
+        foreach ($seoMeta as $value) {
+            if ($value === null) {
+                continue;
+            }
+
+            if (is_array($value) && $value === []) {
+                continue;
+            }
+
+            if (is_string($value) && trim($value) === '') {
+                continue;
+            }
+
+            return false;
+        }
+
+        return true;
+    }
+
+    /**
+     * @param  array<string, mixed>  $guidePayload
+     */
+    private function resolvePublishedAt(
+        array $guidePayload,
+        string $status,
+        ?CareerGuide $existing = null,
+    ): ?Carbon {
+        if ($status === CareerGuide::STATUS_DRAFT) {
+            return null;
+        }
+
+        return $this->normalizeNullableDate($guidePayload['published_at'] ?? null)
+            ?? $existing?->published_at
+            ?? now();
+    }
+
+    private function normalizeNullableDate(mixed $value): ?Carbon
+    {
+        if ($value instanceof Carbon) {
+            return $value;
+        }
+
+        if ($value instanceof \DateTimeInterface) {
+            return Carbon::instance($value);
+        }
+
+        $normalized = trim((string) $value);
+
+        if ($normalized === '') {
+            return null;
+        }
+
+        return Carbon::parse($normalized);
+    }
+
+    private function normalizeDateForComparison(mixed $value): ?string
+    {
+        $normalized = $this->normalizeNullableDate($value);
+
+        return $normalized?->copy()->utc()->toIso8601String();
+    }
+}

--- a/backend/app/CareerCms/Baseline/CareerGuideBaselineNormalizer.php
+++ b/backend/app/CareerCms/Baseline/CareerGuideBaselineNormalizer.php
@@ -1,0 +1,545 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\CareerCms\Baseline;
+
+use App\Models\CareerGuide;
+use App\Models\PersonalityProfile;
+use Illuminate\Support\Arr;
+use Illuminate\Support\Str;
+use RuntimeException;
+
+final class CareerGuideBaselineNormalizer
+{
+    /**
+     * @var array<int, string>
+     */
+    private const SEO_META_FIELDS = [
+        'seo_title',
+        'seo_description',
+        'canonical_url',
+        'og_title',
+        'og_description',
+        'og_image_url',
+        'twitter_title',
+        'twitter_description',
+        'twitter_image_url',
+        'robots',
+        'jsonld_overrides_json',
+    ];
+
+    /**
+     * @param  array<int, array{file: string, payload: array<string, mixed>}>  $documents
+     * @param  array<int, string>  $selectedGuides
+     * @return array<int, array<string, mixed>>
+     */
+    public function normalizeDocuments(array $documents, array $selectedGuides = []): array
+    {
+        $normalizedGuides = $this->normalizeSelectedGuides($selectedGuides);
+        $guides = [];
+        $seenByLocaleGuide = [];
+        $seenByLocaleSlug = [];
+
+        foreach ($documents as $document) {
+            $file = (string) ($document['file'] ?? 'unknown');
+            $payload = is_array($document['payload'] ?? null) ? $document['payload'] : [];
+            $meta = is_array($payload['meta'] ?? null) ? $payload['meta'] : [];
+            $locale = $this->normalizeLocale($meta['locale'] ?? null, $file);
+            $schemaVersion = trim((string) ($meta['schema_version'] ?? 'v1'));
+            $rows = $payload['guides'] ?? null;
+
+            if (! is_array($rows)) {
+                throw new RuntimeException(sprintf(
+                    'Baseline file %s must contain a guides array.',
+                    $file,
+                ));
+            }
+
+            foreach ($rows as $index => $row) {
+                if (! is_array($row)) {
+                    throw new RuntimeException(sprintf(
+                        'Baseline file %s contains a non-object guide row at index %d.',
+                        $file,
+                        $index,
+                    ));
+                }
+
+                $guide = $this->normalizeGuide($row, $locale, $schemaVersion, $file, $index);
+                $guideCode = (string) $guide['guide_code'];
+                $slug = (string) $guide['slug'];
+
+                if ($normalizedGuides !== [] && ! in_array($guideCode, $normalizedGuides, true)) {
+                    continue;
+                }
+
+                $guideKey = $locale.'|'.$guideCode;
+                $slugKey = $locale.'|'.$slug;
+
+                if (isset($seenByLocaleGuide[$guideKey])) {
+                    throw new RuntimeException(sprintf(
+                        'Duplicate guide_code %s for locale %s in baseline file %s.',
+                        $guideCode,
+                        $locale,
+                        $file,
+                    ));
+                }
+
+                if (isset($seenByLocaleSlug[$slugKey])) {
+                    throw new RuntimeException(sprintf(
+                        'Duplicate slug %s for locale %s in baseline file %s.',
+                        $slug,
+                        $locale,
+                        $file,
+                    ));
+                }
+
+                $seenByLocaleGuide[$guideKey] = true;
+                $seenByLocaleSlug[$slugKey] = true;
+                $guides[] = $guide;
+            }
+        }
+
+        usort(
+            $guides,
+            static fn (array $left, array $right): int => [$left['locale'], $left['guide_code']]
+                <=> [$right['locale'], $right['guide_code']],
+        );
+
+        return $guides;
+    }
+
+    /**
+     * @param  array<string, mixed>  $row
+     * @return array<string, mixed>
+     */
+    private function normalizeGuide(
+        array $row,
+        string $documentLocale,
+        string $schemaVersion,
+        string $file,
+        int $index,
+    ): array {
+        $guideCode = $this->normalizeIdentifier($row['guide_code'] ?? $row['slug'] ?? null, 'guide_code', $file, $index);
+        $slug = $this->normalizeIdentifier($row['slug'] ?? $guideCode, 'slug', $file, $index);
+        $locale = Arr::exists($row, 'locale')
+            ? $this->normalizeLocale($row['locale'], $file)
+            : $documentLocale;
+        $title = trim((string) ($row['title'] ?? ''));
+        $excerpt = $this->normalizeRequiredText($row['excerpt'] ?? null, 'excerpt', $file, $guideCode);
+        $categorySlug = $this->normalizeRequiredSlug($row['category_slug'] ?? null, 'category_slug', $file, $guideCode);
+        $bodyMd = $this->normalizeRequiredText($row['body_md'] ?? null, 'body_md', $file, $guideCode);
+
+        if ($locale !== $documentLocale) {
+            throw new RuntimeException(sprintf(
+                'Baseline file %s has locale mismatch for %s at guides[%d].',
+                $file,
+                $guideCode,
+                $index,
+            ));
+        }
+
+        if ($title === '') {
+            throw new RuntimeException(sprintf(
+                'Baseline file %s is missing title for %s at guides[%d].',
+                $file,
+                $guideCode,
+                $index,
+            ));
+        }
+
+        return [
+            'org_id' => 0,
+            'schema_version' => $schemaVersion !== '' ? $schemaVersion : 'v1',
+            'guide_code' => $guideCode,
+            'slug' => $slug,
+            'locale' => $locale,
+            'title' => $title,
+            'excerpt' => $excerpt,
+            'category_slug' => $categorySlug,
+            'body_md' => $bodyMd,
+            'body_html' => $this->normalizeNullableText($row['body_html'] ?? null),
+            'related_industry_slugs_json' => $this->normalizeSlugArray(
+                $row['related_industry_slugs_json'] ?? null,
+                $file,
+                $guideCode,
+                'related_industry_slugs_json',
+            ),
+            'related_jobs' => $this->normalizeJobRelations(
+                $row['related_jobs'] ?? null,
+                $file,
+                $guideCode,
+            ),
+            'related_articles' => $this->normalizeArticleRelations(
+                $row['related_articles'] ?? null,
+                $file,
+                $guideCode,
+            ),
+            'related_personality_profiles' => $this->normalizePersonalityRelations(
+                $row['related_personality_profiles'] ?? null,
+                $file,
+                $guideCode,
+            ),
+            'seo_meta' => $this->normalizeSeoMeta($row['seo_meta'] ?? null, $file, $guideCode),
+            'status' => $this->normalizeStatus($row['status'] ?? CareerGuide::STATUS_PUBLISHED, $file, $index),
+            'is_public' => $this->normalizeBool($row['is_public'] ?? true),
+            'is_indexable' => $this->normalizeBool($row['is_indexable'] ?? true),
+            'published_at' => $this->normalizeNullableText($row['published_at'] ?? null),
+            'scheduled_at' => $this->normalizeNullableText($row['scheduled_at'] ?? null),
+            'sort_order' => (int) ($row['sort_order'] ?? 0),
+        ];
+    }
+
+    /**
+     * @return array<int, array{job_code: string}>
+     */
+    private function normalizeJobRelations(mixed $value, string $file, string $guideCode): array
+    {
+        return $this->normalizeRelationRows(
+            $value,
+            $file,
+            $guideCode,
+            'related_jobs',
+            'job_code',
+            static fn (mixed $candidate): string => Str::lower(trim((string) $candidate)),
+            null,
+        );
+    }
+
+    /**
+     * @return array<int, array{slug: string}>
+     */
+    private function normalizeArticleRelations(mixed $value, string $file, string $guideCode): array
+    {
+        return $this->normalizeRelationRows(
+            $value,
+            $file,
+            $guideCode,
+            'related_articles',
+            'slug',
+            static fn (mixed $candidate): string => Str::lower(trim((string) $candidate)),
+            null,
+        );
+    }
+
+    /**
+     * @return array<int, array{type_code: string}>
+     */
+    private function normalizePersonalityRelations(mixed $value, string $file, string $guideCode): array
+    {
+        return $this->normalizeRelationRows(
+            $value,
+            $file,
+            $guideCode,
+            'related_personality_profiles',
+            'type_code',
+            static fn (mixed $candidate): string => Str::upper(trim((string) $candidate)),
+            static function (string $typeCode) use ($file, $guideCode): void {
+                if (! in_array($typeCode, PersonalityProfile::TYPE_CODES, true)) {
+                    throw new RuntimeException(sprintf(
+                        'Baseline file %s has invalid related_personality_profiles type_code=%s for %s.',
+                        $file,
+                        $typeCode,
+                        $guideCode,
+                    ));
+                }
+            },
+        );
+    }
+
+    /**
+     * @param  callable(mixed):string  $normalizer
+     * @param  (callable(string):void)|null  $validator
+     * @return array<int, array<string, string>>
+     */
+    private function normalizeRelationRows(
+        mixed $value,
+        string $file,
+        string $guideCode,
+        string $field,
+        string $itemKey,
+        callable $normalizer,
+        ?callable $validator,
+    ): array {
+        if (! is_array($value)) {
+            throw new RuntimeException(sprintf(
+                'Baseline file %s must contain %s as an array for %s.',
+                $file,
+                $field,
+                $guideCode,
+            ));
+        }
+
+        $rows = [];
+        $seen = [];
+
+        foreach ($value as $index => $row) {
+            if (! is_array($row)) {
+                throw new RuntimeException(sprintf(
+                    'Baseline file %s contains a non-object relation row in %s for %s at index %d.',
+                    $file,
+                    $field,
+                    $guideCode,
+                    $index,
+                ));
+            }
+
+            if (! Arr::exists($row, $itemKey)) {
+                throw new RuntimeException(sprintf(
+                    'Baseline file %s is missing %s.%s for %s at index %d.',
+                    $file,
+                    $field,
+                    $itemKey,
+                    $guideCode,
+                    $index,
+                ));
+            }
+
+            $normalized = $normalizer($row[$itemKey]);
+
+            if ($normalized === '') {
+                throw new RuntimeException(sprintf(
+                    'Baseline file %s has empty %s.%s for %s at index %d.',
+                    $file,
+                    $field,
+                    $itemKey,
+                    $guideCode,
+                    $index,
+                ));
+            }
+
+            if ($validator !== null) {
+                $validator($normalized);
+            }
+
+            if (isset($seen[$normalized])) {
+                throw new RuntimeException(sprintf(
+                    'Baseline file %s has duplicate %s.%s=%s for %s.',
+                    $file,
+                    $field,
+                    $itemKey,
+                    $normalized,
+                    $guideCode,
+                ));
+            }
+
+            $rows[] = [
+                $itemKey => $normalized,
+            ];
+            $seen[$normalized] = true;
+        }
+
+        return $rows;
+    }
+
+    /**
+     * @return array<int, string>
+     */
+    private function normalizeSlugArray(mixed $value, string $file, string $guideCode, string $field): array
+    {
+        if (! is_array($value)) {
+            throw new RuntimeException(sprintf(
+                'Baseline file %s must contain %s as an array for %s.',
+                $file,
+                $field,
+                $guideCode,
+            ));
+        }
+
+        $normalized = [];
+
+        foreach ($value as $index => $item) {
+            $slug = Str::lower(trim((string) $item));
+
+            if ($slug === '') {
+                throw new RuntimeException(sprintf(
+                    'Baseline file %s has empty %s item for %s at index %d.',
+                    $file,
+                    $field,
+                    $guideCode,
+                    $index,
+                ));
+            }
+
+            if (in_array($slug, $normalized, true)) {
+                throw new RuntimeException(sprintf(
+                    'Baseline file %s has duplicate %s item=%s for %s.',
+                    $file,
+                    $field,
+                    $slug,
+                    $guideCode,
+                ));
+            }
+
+            $normalized[] = $slug;
+        }
+
+        return $normalized;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function normalizeSeoMeta(mixed $value, string $file, string $guideCode): array
+    {
+        if (! is_array($value)) {
+            throw new RuntimeException(sprintf(
+                'Baseline file %s must contain seo_meta as an object for %s.',
+                $file,
+                $guideCode,
+            ));
+        }
+
+        return [
+            'seo_title' => $this->normalizeNullableText($value['seo_title'] ?? null),
+            'seo_description' => $this->normalizeNullableText($value['seo_description'] ?? null),
+            'canonical_url' => $this->normalizeNullableText($value['canonical_url'] ?? null),
+            'og_title' => $this->normalizeNullableText($value['og_title'] ?? null),
+            'og_description' => $this->normalizeNullableText($value['og_description'] ?? null),
+            'og_image_url' => $this->normalizeNullableText($value['og_image_url'] ?? null),
+            'twitter_title' => $this->normalizeNullableText($value['twitter_title'] ?? null),
+            'twitter_description' => $this->normalizeNullableText($value['twitter_description'] ?? null),
+            'twitter_image_url' => $this->normalizeNullableText($value['twitter_image_url'] ?? null),
+            'robots' => $this->normalizeNullableText($value['robots'] ?? null),
+            'jsonld_overrides_json' => Arr::exists($value, 'jsonld_overrides_json')
+                ? $this->normalizeNullableArray($value['jsonld_overrides_json'])
+                : null,
+        ];
+    }
+
+    private function normalizeLocale(mixed $locale, string $file): string
+    {
+        $normalized = trim((string) $locale);
+        $normalized = $normalized === 'zh' ? 'zh-CN' : $normalized;
+
+        if (! in_array($normalized, CareerGuide::SUPPORTED_LOCALES, true)) {
+            throw new RuntimeException(sprintf(
+                'Baseline file %s has unsupported locale=%s.',
+                $file,
+                (string) $locale,
+            ));
+        }
+
+        return $normalized;
+    }
+
+    /**
+     * @param  array<int, string>  $selectedGuides
+     * @return array<int, string>
+     */
+    private function normalizeSelectedGuides(array $selectedGuides): array
+    {
+        $normalized = [];
+
+        foreach ($selectedGuides as $guide) {
+            $candidate = Str::lower(trim((string) $guide));
+
+            if ($candidate === '') {
+                continue;
+            }
+
+            $normalized[] = $candidate;
+        }
+
+        return array_values(array_unique($normalized));
+    }
+
+    private function normalizeIdentifier(mixed $value, string $field, string $file, int $index): string
+    {
+        $normalized = Str::of((string) $value)
+            ->trim()
+            ->lower()
+            ->replace('_', '-')
+            ->value();
+
+        if ($normalized === '' || ! preg_match('/^[a-z0-9-]+$/', $normalized)) {
+            throw new RuntimeException(sprintf(
+                'Baseline file %s has invalid %s at guides[%d].',
+                $file,
+                $field,
+                $index,
+            ));
+        }
+
+        return $normalized;
+    }
+
+    private function normalizeRequiredText(mixed $value, string $field, string $file, string $guideCode): string
+    {
+        $normalized = $this->normalizeNullableText($value);
+
+        if ($normalized === null) {
+            throw new RuntimeException(sprintf(
+                'Baseline file %s is missing %s for %s.',
+                $file,
+                $field,
+                $guideCode,
+            ));
+        }
+
+        return $normalized;
+    }
+
+    private function normalizeRequiredSlug(mixed $value, string $field, string $file, string $guideCode): string
+    {
+        $normalized = Str::lower(trim((string) $value));
+
+        if ($normalized === '' || ! preg_match('/^[a-z0-9-]+$/', $normalized)) {
+            throw new RuntimeException(sprintf(
+                'Baseline file %s has invalid %s for %s.',
+                $file,
+                $field,
+                $guideCode,
+            ));
+        }
+
+        return $normalized;
+    }
+
+    private function normalizeStatus(mixed $status, string $file, int $index): string
+    {
+        $normalized = trim((string) $status);
+
+        if (! in_array($normalized, [CareerGuide::STATUS_DRAFT, CareerGuide::STATUS_PUBLISHED], true)) {
+            throw new RuntimeException(sprintf(
+                'Baseline file %s has invalid status at guides[%d].',
+                $file,
+                $index,
+            ));
+        }
+
+        return $normalized;
+    }
+
+    private function normalizeBool(mixed $value): bool
+    {
+        return filter_var($value, FILTER_VALIDATE_BOOL, FILTER_NULL_ON_FAILURE) ?? false;
+    }
+
+    private function normalizeNullableText(mixed $value): ?string
+    {
+        if ($value === null) {
+            return null;
+        }
+
+        $normalized = trim((string) $value);
+
+        return $normalized === '' ? null : $normalized;
+    }
+
+    /**
+     * @return array<string, mixed>|list<mixed>|null
+     */
+    private function normalizeNullableArray(mixed $value): ?array
+    {
+        if ($value === null) {
+            return null;
+        }
+
+        if (! is_array($value)) {
+            throw new RuntimeException('Expected jsonld_overrides_json to be an object or array when provided.');
+        }
+
+        return $value;
+    }
+}

--- a/backend/app/CareerCms/Baseline/CareerGuideBaselineReader.php
+++ b/backend/app/CareerCms/Baseline/CareerGuideBaselineReader.php
@@ -1,0 +1,128 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\CareerCms\Baseline;
+
+use App\Models\CareerGuide;
+use RuntimeException;
+
+final class CareerGuideBaselineReader
+{
+    public function resolveSourceDir(?string $sourceDir = null): string
+    {
+        $candidate = trim((string) $sourceDir);
+
+        if ($candidate === '') {
+            $candidate = base_path('../content_baselines/career_guides');
+        } elseif (! str_starts_with($candidate, DIRECTORY_SEPARATOR)) {
+            $candidate = base_path($candidate);
+        }
+
+        $resolved = realpath($candidate);
+
+        if ($resolved === false || ! is_dir($resolved)) {
+            throw new RuntimeException(sprintf(
+                'Career guide baseline source directory not found: %s',
+                $candidate,
+            ));
+        }
+
+        return $resolved;
+    }
+
+    /**
+     * @param  array<int, string>  $selectedLocales
+     * @return array<int, array{file: string, payload: array<string, mixed>}>
+     */
+    public function read(string $sourceDir, array $selectedLocales = []): array
+    {
+        $locales = $this->normalizeSelectedLocales($selectedLocales);
+        $files = $locales === []
+            ? glob(rtrim($sourceDir, DIRECTORY_SEPARATOR).DIRECTORY_SEPARATOR.'career_guides.*.json') ?: []
+            : array_map(
+                static fn (string $locale): string => rtrim($sourceDir, DIRECTORY_SEPARATOR)
+                    .DIRECTORY_SEPARATOR
+                    .sprintf('career_guides.%s.json', $locale),
+                $locales,
+            );
+
+        if ($files === []) {
+            throw new RuntimeException(sprintf(
+                'No career guide baseline files found in %s.',
+                $sourceDir,
+            ));
+        }
+
+        sort($files);
+
+        $documents = [];
+
+        foreach ($files as $file) {
+            if (! is_file($file)) {
+                throw new RuntimeException(sprintf(
+                    'Career guide baseline file missing: %s',
+                    $file,
+                ));
+            }
+
+            $raw = file_get_contents($file);
+
+            if (! is_string($raw) || trim($raw) === '') {
+                throw new RuntimeException(sprintf(
+                    'Career guide baseline file is empty: %s',
+                    $file,
+                ));
+            }
+
+            $decoded = json_decode($raw, true);
+
+            if (! is_array($decoded)) {
+                throw new RuntimeException(sprintf(
+                    'Career guide baseline file is not valid JSON: %s',
+                    $file,
+                ));
+            }
+
+            $documents[] = [
+                'file' => $file,
+                'payload' => $decoded,
+            ];
+        }
+
+        return $documents;
+    }
+
+    /**
+     * @param  array<int, string>  $selectedLocales
+     * @return array<int, string>
+     */
+    private function normalizeSelectedLocales(array $selectedLocales): array
+    {
+        $normalized = [];
+
+        foreach ($selectedLocales as $locale) {
+            $candidate = trim((string) $locale);
+
+            if ($candidate === '') {
+                continue;
+            }
+
+            $candidate = $candidate === 'zh' ? 'zh-CN' : $candidate;
+            $normalized[] = $candidate;
+        }
+
+        $normalized = array_values(array_unique($normalized));
+
+        foreach ($normalized as $locale) {
+            if (! in_array($locale, CareerGuide::SUPPORTED_LOCALES, true)) {
+                throw new RuntimeException(sprintf(
+                    'Unsupported locale selection: %s',
+                    $locale,
+                ));
+            }
+        }
+
+        return $normalized;
+    }
+}

--- a/backend/app/Console/Commands/CareerGuideImportLocalBaseline.php
+++ b/backend/app/Console/Commands/CareerGuideImportLocalBaseline.php
@@ -1,0 +1,90 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Console\Commands;
+
+use App\CareerCms\Baseline\CareerGuideBaselineImporter;
+use App\CareerCms\Baseline\CareerGuideBaselineNormalizer;
+use App\CareerCms\Baseline\CareerGuideBaselineReader;
+use App\Models\CareerGuide;
+use Illuminate\Console\Command;
+use RuntimeException;
+
+final class CareerGuideImportLocalBaseline extends Command
+{
+    protected $signature = 'career-guides:import-local-baseline
+        {--dry-run : Validate and diff without writing to the database}
+        {--locale=* : Import only specific locale(s)}
+        {--guide=* : Import only specific guide_code(s)}
+        {--upsert : Update existing records instead of create-missing only}
+        {--status= : Override imported records to draft or published}
+        {--source-dir= : Override the committed baseline source directory}';
+
+    protected $description = 'Import committed career guide baseline content into CareerGuide CMS tables.';
+
+    public function handle(
+        CareerGuideBaselineReader $reader,
+        CareerGuideBaselineNormalizer $normalizer,
+        CareerGuideBaselineImporter $importer,
+    ): int {
+        try {
+            $statusOption = $this->option('status');
+            $status = $statusOption === null ? null : trim((string) $statusOption);
+            if ($status === '') {
+                $status = null;
+            }
+
+            if ($status !== null && ! in_array($status, [CareerGuide::STATUS_DRAFT, CareerGuide::STATUS_PUBLISHED], true)) {
+                throw new RuntimeException(sprintf(
+                    'Unsupported --status value: %s',
+                    $status,
+                ));
+            }
+
+            $sourceDir = $reader->resolveSourceDir(
+                $this->option('source-dir') !== null
+                    ? (string) $this->option('source-dir')
+                    : null,
+            );
+            $selectedLocales = array_values(array_filter(
+                array_map(static fn (string $value): string => trim($value), (array) $this->option('locale')),
+                static fn (string $value): bool => $value !== '',
+            ));
+            $selectedGuides = array_values(array_filter(
+                array_map(static fn (string $value): string => trim($value), (array) $this->option('guide')),
+                static fn (string $value): bool => $value !== '',
+            ));
+
+            $documents = $reader->read($sourceDir, $selectedLocales);
+            $guides = $normalizer->normalizeDocuments($documents, $selectedGuides);
+            $summary = $importer->import($guides, [
+                'dry_run' => (bool) $this->option('dry-run'),
+                'upsert' => (bool) $this->option('upsert'),
+                'status' => $status,
+            ]);
+
+            $this->line('baseline_source_dir='.$sourceDir);
+            $this->line('locales_selected='.($selectedLocales === [] ? 'all' : implode(',', $selectedLocales)));
+            $this->line('guides_selected='.($selectedGuides === [] ? 'all' : implode(',', $selectedGuides)));
+            $this->line('dry_run='.((bool) $this->option('dry-run') ? '1' : '0'));
+            $this->line('upsert='.((bool) $this->option('upsert') ? '1' : '0'));
+            $this->line('status_mode='.(string) $summary['status_mode']);
+            $this->line('files_found='.(string) count($documents));
+            $this->line('guides_found='.(string) $summary['guides_found']);
+            $this->line('will_create='.(string) $summary['will_create']);
+            $this->line('will_update='.(string) $summary['will_update']);
+            $this->line('will_skip='.(string) $summary['will_skip']);
+            $this->line('revisions_to_create='.(string) $summary['revisions_to_create']);
+            $this->line('errors_count='.(string) $summary['errors_count']);
+
+            $this->info((bool) $this->option('dry-run') ? 'dry-run complete' : 'import complete');
+
+            return self::SUCCESS;
+        } catch (\Throwable $throwable) {
+            $this->error($throwable->getMessage());
+
+            return self::FAILURE;
+        }
+    }
+}

--- a/backend/tests/Feature/CareerCms/CareerGuideBaselineImportTest.php
+++ b/backend/tests/Feature/CareerCms/CareerGuideBaselineImportTest.php
@@ -1,0 +1,724 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\CareerCms;
+
+use App\Models\Article;
+use App\Models\CareerGuide;
+use App\Models\CareerGuideRevision;
+use App\Models\CareerGuideSeoMeta;
+use App\Models\CareerJob;
+use App\Models\PersonalityProfile;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\File;
+use Tests\TestCase;
+
+final class CareerGuideBaselineImportTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        config()->set('app.frontend_url', 'https://www.example.test');
+    }
+
+    public function test_dry_run_does_not_write_database(): void
+    {
+        $this->seedRelationTargets();
+
+        $this->artisan('career-guides:import-local-baseline', [
+            '--dry-run' => true,
+            '--source-dir' => 'tests/Fixtures/career_guide_baseline',
+        ])
+            ->expectsOutputToContain('files_found=2')
+            ->expectsOutputToContain('guides_found=4')
+            ->expectsOutputToContain('will_create=4')
+            ->expectsOutputToContain('revisions_to_create=4')
+            ->assertExitCode(0);
+
+        $this->assertSame(0, $this->guideQuery()->count());
+        $this->assertSame(0, CareerGuideSeoMeta::query()->count());
+        $this->assertSame(0, CareerGuideRevision::query()->count());
+        $this->assertSame(0, DB::table('career_guide_job_map')->count());
+        $this->assertSame(0, DB::table('career_guide_article_map')->count());
+        $this->assertSame(0, DB::table('career_guide_personality_map')->count());
+    }
+
+    public function test_create_missing_imports_guides_relations_seo_meta_and_revision(): void
+    {
+        $this->seedRelationTargets();
+
+        $this->artisan('career-guides:import-local-baseline', [
+            '--locale' => ['en'],
+            '--source-dir' => 'tests/Fixtures/career_guide_baseline',
+        ])
+            ->expectsOutputToContain('guides_found=2')
+            ->expectsOutputToContain('will_create=2')
+            ->assertExitCode(0);
+
+        $this->assertSame(2, $this->guideQuery()->count());
+        $this->assertSame(2, CareerGuideSeoMeta::query()->count());
+        $this->assertSame(2, CareerGuideRevision::query()->count());
+        $this->assertSame(3, DB::table('career_guide_job_map')->count());
+        $this->assertSame(2, DB::table('career_guide_article_map')->count());
+        $this->assertSame(2, DB::table('career_guide_personality_map')->count());
+
+        $guide = $this->guideQuery()
+            ->where('guide_code', 'from-mbti-to-job-fit')
+            ->where('locale', 'en')
+            ->firstOrFail();
+        $guide->load('seoMeta', 'relatedJobs', 'relatedArticles', 'relatedPersonalityProfiles');
+
+        $this->assertSame('published', $guide->status);
+        $this->assertSame('2026-03-05', $guide->published_at?->toDateString());
+        $this->assertSame(['business', 'technology'], $guide->related_industry_slugs_json);
+        $this->assertSame(
+            ['product-manager', 'teacher'],
+            $guide->relatedJobs->pluck('job_code')->all(),
+        );
+        $this->assertSame(
+            ['mbti-basics', 'mbti-growth-guide'],
+            $guide->relatedArticles->pluck('slug')->all(),
+        );
+        $this->assertSame(
+            ['INTJ', 'ENFP'],
+            $guide->relatedPersonalityProfiles->pluck('type_code')->all(),
+        );
+        $this->assertSame('From MBTI to Job Fit', $guide->seoMeta?->seo_title);
+        $this->assertSame(
+            'https://www.example.test/en/career/guides/from-mbti-to-job-fit',
+            $guide->seoMeta?->canonical_url,
+        );
+
+        $quarterlyGuide = $this->guideQuery()
+            ->where('guide_code', 'quarterly-career-review')
+            ->where('locale', 'en')
+            ->firstOrFail();
+
+        $this->assertSame(
+            'Quarterly Career Review Guide',
+            $quarterlyGuide->seoMeta?->seo_title,
+        );
+        $this->assertSame(
+            'baseline import',
+            CareerGuideRevision::query()
+                ->where('career_guide_id', (int) $guide->id)
+                ->orderBy('revision_no')
+                ->firstOrFail()
+                ->note,
+        );
+    }
+
+    public function test_upsert_updates_existing_guides_syncs_relations_and_creates_revision_when_changed(): void
+    {
+        $this->seedRelationTargets();
+        $legacyJob = $this->seedJob([
+            'job_code' => 'legacy-job',
+            'slug' => 'legacy-job',
+            'title' => 'Legacy Job',
+        ]);
+        $legacyArticle = $this->seedArticle([
+            'slug' => 'legacy-article',
+            'title' => 'Legacy Article',
+        ]);
+        $legacyProfile = $this->seedProfile([
+            'type_code' => 'ISTJ',
+            'slug' => 'istj',
+            'title' => 'ISTJ Personality Type',
+        ]);
+
+        $guide = $this->guideQuery()->create([
+            'org_id' => 0,
+            'guide_code' => 'from-mbti-to-job-fit',
+            'slug' => 'from-mbti-to-job-fit',
+            'locale' => 'en',
+            'title' => 'Legacy guide title',
+            'excerpt' => 'Legacy excerpt',
+            'category_slug' => 'legacy-category',
+            'body_md' => 'Legacy body',
+            'body_html' => '<p>Legacy body</p>',
+            'related_industry_slugs_json' => ['legacy'],
+            'status' => CareerGuide::STATUS_PUBLISHED,
+            'is_public' => true,
+            'is_indexable' => false,
+            'sort_order' => 99,
+            'published_at' => now()->subDay(),
+            'schema_version' => 'v1',
+        ]);
+        $guide->relatedJobs()->attach([
+            $legacyJob->id => ['sort_order' => 10],
+            $this->findJob('teacher', 'en')->id => ['sort_order' => 20],
+        ]);
+        $guide->relatedArticles()->attach([
+            $legacyArticle->id => ['sort_order' => 10],
+        ]);
+        $guide->relatedPersonalityProfiles()->attach([
+            $legacyProfile->id => ['sort_order' => 10],
+        ]);
+        $guide->seoMeta()->create([
+            'seo_title' => 'Legacy SEO title',
+            'seo_description' => 'Legacy SEO description',
+            'robots' => 'noindex,follow',
+        ]);
+        CareerGuideRevision::query()->create([
+            'career_guide_id' => (int) $guide->id,
+            'revision_no' => 1,
+            'snapshot_json' => ['title' => 'Legacy guide title'],
+            'note' => 'seed',
+            'created_at' => now()->subDay(),
+        ]);
+
+        $this->artisan('career-guides:import-local-baseline', [
+            '--locale' => ['en'],
+            '--guide' => ['from-mbti-to-job-fit'],
+            '--upsert' => true,
+            '--source-dir' => 'tests/Fixtures/career_guide_baseline',
+        ])
+            ->expectsOutputToContain('guides_found=1')
+            ->expectsOutputToContain('will_update=1')
+            ->expectsOutputToContain('revisions_to_create=1')
+            ->assertExitCode(0);
+
+        $guide->refresh();
+        $guide->load('seoMeta', 'relatedJobs', 'relatedArticles', 'relatedPersonalityProfiles');
+
+        $this->assertSame('From MBTI to Job Fit', $guide->title);
+        $this->assertTrue((bool) $guide->is_indexable);
+        $this->assertSame(['business', 'technology'], $guide->related_industry_slugs_json);
+        $this->assertSame(
+            ['product-manager', 'teacher'],
+            $guide->relatedJobs->pluck('job_code')->all(),
+        );
+        $this->assertSame(
+            ['mbti-basics', 'mbti-growth-guide'],
+            $guide->relatedArticles->pluck('slug')->all(),
+        );
+        $this->assertSame(
+            ['INTJ', 'ENFP'],
+            $guide->relatedPersonalityProfiles->pluck('type_code')->all(),
+        );
+        $this->assertSame('From MBTI to Job Fit', $guide->seoMeta?->seo_title);
+        $this->assertSame(
+            2,
+            CareerGuideRevision::query()->where('career_guide_id', (int) $guide->id)->max('revision_no'),
+        );
+        $this->assertSame(
+            'baseline upsert',
+            CareerGuideRevision::query()
+                ->where('career_guide_id', (int) $guide->id)
+                ->orderByDesc('revision_no')
+                ->firstOrFail()
+                ->note,
+        );
+    }
+
+    public function test_no_op_upsert_skips_revision_creation(): void
+    {
+        $this->seedRelationTargets();
+
+        $this->artisan('career-guides:import-local-baseline', [
+            '--locale' => ['en'],
+            '--guide' => ['quarterly-career-review'],
+            '--source-dir' => 'tests/Fixtures/career_guide_baseline',
+        ])->assertExitCode(0);
+
+        $guide = $this->guideQuery()
+            ->where('guide_code', 'quarterly-career-review')
+            ->where('locale', 'en')
+            ->firstOrFail();
+
+        $this->assertSame(
+            1,
+            CareerGuideRevision::query()->where('career_guide_id', (int) $guide->id)->count(),
+        );
+
+        $this->artisan('career-guides:import-local-baseline', [
+            '--locale' => ['en'],
+            '--guide' => ['quarterly-career-review'],
+            '--upsert' => true,
+            '--source-dir' => 'tests/Fixtures/career_guide_baseline',
+        ])
+            ->expectsOutputToContain('will_skip=1')
+            ->assertExitCode(0);
+
+        $this->assertSame(
+            1,
+            CareerGuideRevision::query()->where('career_guide_id', (int) $guide->id)->count(),
+        );
+    }
+
+    public function test_locale_filter_limits_import_scope(): void
+    {
+        $this->seedRelationTargets();
+
+        $this->artisan('career-guides:import-local-baseline', [
+            '--locale' => ['zh-CN'],
+            '--status' => 'draft',
+            '--source-dir' => 'tests/Fixtures/career_guide_baseline',
+        ])
+            ->expectsOutputToContain('guides_found=2')
+            ->expectsOutputToContain('will_create=2')
+            ->assertExitCode(0);
+
+        $this->assertSame(2, $this->guideQuery()->count());
+        $this->assertSame(
+            ['zh-CN'],
+            $this->guideQuery()->distinct()->orderBy('locale')->pluck('locale')->all(),
+        );
+        $this->assertSame(
+            ['draft'],
+            $this->guideQuery()->distinct()->orderBy('status')->pluck('status')->all(),
+        );
+        $this->assertSame(0, $this->guideQuery()->whereNotNull('published_at')->count());
+    }
+
+    public function test_guide_filter_limits_import_scope(): void
+    {
+        $this->seedRelationTargets();
+
+        $this->artisan('career-guides:import-local-baseline', [
+            '--locale' => ['en'],
+            '--guide' => ['quarterly-career-review'],
+            '--source-dir' => 'tests/Fixtures/career_guide_baseline',
+        ])
+            ->expectsOutputToContain('guides_found=1')
+            ->expectsOutputToContain('will_create=1')
+            ->assertExitCode(0);
+
+        $this->assertSame(1, $this->guideQuery()->count());
+        $this->assertSame(
+            'quarterly-career-review',
+            $this->guideQuery()->firstOrFail()->guide_code,
+        );
+    }
+
+    public function test_invalid_baseline_fails_for_shape_duplicates_and_unsupported_locale(): void
+    {
+        $invalidCases = [
+            'top_level_shape' => [
+                'meta' => [
+                    'schema_version' => 'v1',
+                    'locale' => 'en',
+                    'source' => 'test fixture',
+                    'generated_at' => '2026-03-15T00:00:00Z',
+                ],
+                'guides' => 'bad-shape',
+            ],
+            'relation_shape' => [
+                'meta' => [
+                    'schema_version' => 'v1',
+                    'locale' => 'en',
+                    'source' => 'test fixture',
+                    'generated_at' => '2026-03-15T00:00:00Z',
+                ],
+                'guides' => [
+                    $this->validGuideRow([
+                        'related_jobs' => ['product-manager'],
+                    ]),
+                ],
+            ],
+            'duplicate_guide_code' => [
+                'meta' => [
+                    'schema_version' => 'v1',
+                    'locale' => 'en',
+                    'source' => 'test fixture',
+                    'generated_at' => '2026-03-15T00:00:00Z',
+                ],
+                'guides' => [
+                    $this->validGuideRow(),
+                    $this->validGuideRow([
+                        'slug' => 'sample-guide-2',
+                    ]),
+                ],
+            ],
+            'unsupported_locale' => [
+                'meta' => [
+                    'schema_version' => 'v1',
+                    'locale' => 'fr',
+                    'source' => 'test fixture',
+                    'generated_at' => '2026-03-15T00:00:00Z',
+                ],
+                'guides' => [
+                    $this->validGuideRow([
+                        'locale' => 'fr',
+                    ]),
+                ],
+            ],
+        ];
+
+        foreach ($invalidCases as $suffix => $payload) {
+            $sourceDir = $this->writeFixtureDirectory('career_guide_baseline_invalid_'.$suffix, [
+                'career_guides.en.json' => $payload,
+            ]);
+
+            try {
+                $this->artisan('career-guides:import-local-baseline', [
+                    '--source-dir' => $sourceDir,
+                ])->assertExitCode(1);
+
+                $this->assertSame(0, $this->guideQuery()->count());
+            } finally {
+                File::deleteDirectory(base_path($sourceDir));
+            }
+        }
+    }
+
+    public function test_unresolved_relations_fail_fast_for_job_article_and_personality(): void
+    {
+        $this->seedArticle(['slug' => 'mbti-basics', 'locale' => 'en']);
+        $this->seedProfile(['type_code' => 'INTJ', 'slug' => 'intj', 'locale' => 'en']);
+
+        $jobMissingDir = $this->writeFixtureDirectory('career_guide_baseline_missing_job', [
+            'career_guides.en.json' => $this->validPayload('en', [
+                $this->validGuideRow([
+                    'guide_code' => 'missing-job-guide',
+                    'slug' => 'missing-job-guide',
+                    'related_jobs' => [['job_code' => 'missing-job']],
+                    'related_articles' => [['slug' => 'mbti-basics']],
+                    'related_personality_profiles' => [['type_code' => 'INTJ']],
+                ]),
+            ]),
+        ]);
+
+        try {
+            $this->artisan('career-guides:import-local-baseline', [
+                '--source-dir' => $jobMissingDir,
+            ])
+                ->expectsOutputToContain('Unable to resolve related_jobs')
+                ->assertExitCode(1);
+        } finally {
+            File::deleteDirectory(base_path($jobMissingDir));
+        }
+
+        $this->assertSame(0, $this->guideQuery()->count());
+
+        $this->seedJob(['job_code' => 'product-manager', 'slug' => 'product-manager', 'locale' => 'en']);
+        $articleMissingDir = $this->writeFixtureDirectory('career_guide_baseline_missing_article', [
+            'career_guides.en.json' => $this->validPayload('en', [
+                $this->validGuideRow([
+                    'guide_code' => 'missing-article-guide',
+                    'slug' => 'missing-article-guide',
+                    'related_jobs' => [['job_code' => 'product-manager']],
+                    'related_articles' => [['slug' => 'missing-article']],
+                    'related_personality_profiles' => [['type_code' => 'INTJ']],
+                ]),
+            ]),
+        ]);
+
+        try {
+            $this->artisan('career-guides:import-local-baseline', [
+                '--source-dir' => $articleMissingDir,
+            ])
+                ->expectsOutputToContain('Unable to resolve related_articles')
+                ->assertExitCode(1);
+        } finally {
+            File::deleteDirectory(base_path($articleMissingDir));
+        }
+
+        $this->assertSame(0, $this->guideQuery()->count());
+
+        $this->seedArticle(['slug' => 'mbti-growth-guide', 'locale' => 'en']);
+        $profileMissingDir = $this->writeFixtureDirectory('career_guide_baseline_missing_profile', [
+            'career_guides.en.json' => $this->validPayload('en', [
+                $this->validGuideRow([
+                    'guide_code' => 'missing-profile-guide',
+                    'slug' => 'missing-profile-guide',
+                    'related_jobs' => [['job_code' => 'product-manager']],
+                    'related_articles' => [['slug' => 'mbti-growth-guide']],
+                    'related_personality_profiles' => [['type_code' => 'ENFP']],
+                ]),
+            ]),
+        ]);
+
+        try {
+            $this->artisan('career-guides:import-local-baseline', [
+                '--source-dir' => $profileMissingDir,
+            ])
+                ->expectsOutputToContain('Unable to resolve related_personality_profiles')
+                ->assertExitCode(1);
+        } finally {
+            File::deleteDirectory(base_path($profileMissingDir));
+        }
+
+        $this->assertSame(0, $this->guideQuery()->count());
+    }
+
+    public function test_seo_generation_fallback_runs_when_baseline_seo_meta_is_empty(): void
+    {
+        $this->seedRelationTargets(['en']);
+
+        $this->artisan('career-guides:import-local-baseline', [
+            '--locale' => ['en'],
+            '--guide' => ['from-mbti-to-job-fit'],
+            '--source-dir' => 'tests/Fixtures/career_guide_baseline',
+        ])->assertExitCode(0);
+
+        $guide = $this->guideQuery()
+            ->where('guide_code', 'from-mbti-to-job-fit')
+            ->where('locale', 'en')
+            ->firstOrFail();
+
+        $seoMeta = CareerGuideSeoMeta::query()
+            ->where('career_guide_id', (int) $guide->id)
+            ->firstOrFail();
+
+        $this->assertSame('From MBTI to Job Fit', $seoMeta->seo_title);
+        $this->assertSame(
+            'Translate MBTI signals into practical career choices.',
+            $seoMeta->seo_description,
+        );
+        $this->assertSame(
+            'https://www.example.test/en/career/guides/from-mbti-to-job-fit',
+            $seoMeta->canonical_url,
+        );
+        $this->assertSame('index,follow', $seoMeta->robots);
+    }
+
+    public function test_revision_snapshot_shape_contains_guide_relations_and_seo_meta(): void
+    {
+        $this->seedRelationTargets(['en']);
+
+        $this->artisan('career-guides:import-local-baseline', [
+            '--locale' => ['en'],
+            '--guide' => ['from-mbti-to-job-fit'],
+            '--source-dir' => 'tests/Fixtures/career_guide_baseline',
+        ])->assertExitCode(0);
+
+        $guide = $this->guideQuery()
+            ->where('guide_code', 'from-mbti-to-job-fit')
+            ->where('locale', 'en')
+            ->firstOrFail();
+        $revision = CareerGuideRevision::query()
+            ->where('career_guide_id', (int) $guide->id)
+            ->orderBy('revision_no')
+            ->firstOrFail();
+        $snapshot = $revision->snapshot_json;
+
+        $this->assertSame('from-mbti-to-job-fit', data_get($snapshot, 'guide.guide_code'));
+        $this->assertSame('From MBTI to Job Fit', data_get($snapshot, 'guide.title'));
+        $this->assertSame('product-manager', data_get($snapshot, 'related_jobs.0.job_code'));
+        $this->assertSame('mbti-basics', data_get($snapshot, 'related_articles.0.slug'));
+        $this->assertSame('INTJ', data_get($snapshot, 'related_personality_profiles.0.type_code'));
+        $this->assertSame('From MBTI to Job Fit', data_get($snapshot, 'seo_meta.seo_title'));
+    }
+
+    private function guideQuery()
+    {
+        return CareerGuide::query()->withoutGlobalScopes();
+    }
+
+    /**
+     * @param  array<int, string>  $locales
+     */
+    private function seedRelationTargets(array $locales = ['en', 'zh-CN']): void
+    {
+        foreach ($locales as $locale) {
+            $this->seedJob([
+                'job_code' => 'product-manager',
+                'slug' => 'product-manager',
+                'locale' => $locale,
+                'title' => $locale === 'zh-CN' ? '产品经理' : 'Product Manager',
+            ]);
+            $this->seedJob([
+                'job_code' => 'teacher',
+                'slug' => 'teacher',
+                'locale' => $locale,
+                'title' => $locale === 'zh-CN' ? '教师' : 'Teacher',
+            ]);
+
+            $this->seedArticle([
+                'slug' => 'mbti-basics',
+                'locale' => $locale,
+                'title' => $locale === 'zh-CN' ? 'MBTI 基础' : 'MBTI Basics',
+            ]);
+            $this->seedArticle([
+                'slug' => 'mbti-growth-guide',
+                'locale' => $locale,
+                'title' => $locale === 'zh-CN' ? 'MBTI 成长指南' : 'MBTI Growth Guide',
+            ]);
+
+            $this->seedProfile([
+                'type_code' => 'INTJ',
+                'slug' => 'intj',
+                'locale' => $locale,
+                'title' => $locale === 'zh-CN' ? 'INTJ 人格类型' : 'INTJ Personality Type',
+            ]);
+            $this->seedProfile([
+                'type_code' => 'ENFP',
+                'slug' => 'enfp',
+                'locale' => $locale,
+                'title' => $locale === 'zh-CN' ? 'ENFP 人格类型' : 'ENFP Personality Type',
+            ]);
+        }
+    }
+
+    /**
+     * @param  array<string, mixed>  $overrides
+     */
+    private function seedJob(array $overrides = []): CareerJob
+    {
+        /** @var CareerJob */
+        return CareerJob::query()->create(array_merge([
+            'org_id' => 0,
+            'job_code' => 'career-job',
+            'slug' => 'career-job',
+            'locale' => 'en',
+            'title' => 'Career Job',
+            'excerpt' => 'Career job excerpt.',
+            'status' => CareerJob::STATUS_PUBLISHED,
+            'is_public' => true,
+            'is_indexable' => true,
+            'published_at' => now(),
+            'schema_version' => 'v1',
+            'sort_order' => 0,
+        ], $overrides));
+    }
+
+    /**
+     * @param  array<string, mixed>  $overrides
+     */
+    private function seedArticle(array $overrides = []): Article
+    {
+        /** @var Article */
+        return Article::query()->create(array_merge([
+            'org_id' => 0,
+            'category_id' => null,
+            'author_admin_user_id' => null,
+            'slug' => 'career-article',
+            'locale' => 'en',
+            'title' => 'Career Article',
+            'excerpt' => 'Career article excerpt.',
+            'content_md' => '# Career article',
+            'content_html' => '<h1>Career article</h1>',
+            'cover_image_url' => null,
+            'status' => 'published',
+            'is_public' => true,
+            'is_indexable' => true,
+            'published_at' => now(),
+            'scheduled_at' => null,
+        ], $overrides));
+    }
+
+    /**
+     * @param  array<string, mixed>  $overrides
+     */
+    private function seedProfile(array $overrides = []): PersonalityProfile
+    {
+        /** @var PersonalityProfile */
+        return PersonalityProfile::query()->create(array_merge([
+            'org_id' => 0,
+            'scale_code' => PersonalityProfile::SCALE_CODE_MBTI,
+            'type_code' => 'INTJ',
+            'slug' => 'intj',
+            'locale' => 'en',
+            'title' => 'INTJ Personality Type',
+            'excerpt' => 'Strategic and independent.',
+            'status' => 'published',
+            'is_public' => true,
+            'is_indexable' => true,
+            'published_at' => now(),
+            'scheduled_at' => null,
+            'schema_version' => 'v1',
+        ], $overrides));
+    }
+
+    private function findJob(string $jobCode, string $locale): CareerJob
+    {
+        /** @var CareerJob */
+        return CareerJob::query()
+            ->withoutGlobalScopes()
+            ->where('org_id', 0)
+            ->where('job_code', $jobCode)
+            ->where('locale', $locale)
+            ->firstOrFail();
+    }
+
+    /**
+     * @param  array<int, array<string, mixed>>  $guides
+     * @return array<string, mixed>
+     */
+    private function validPayload(string $locale, array $guides): array
+    {
+        return [
+            'meta' => [
+                'schema_version' => 'v1',
+                'locale' => $locale,
+                'source' => 'test fixture',
+                'generated_at' => '2026-03-15T00:00:00Z',
+            ],
+            'guides' => $guides,
+        ];
+    }
+
+    /**
+     * @param  array<string, mixed>  $overrides
+     * @return array<string, mixed>
+     */
+    private function validGuideRow(array $overrides = []): array
+    {
+        return array_merge([
+            'guide_code' => 'sample-guide',
+            'slug' => 'sample-guide',
+            'locale' => 'en',
+            'title' => 'Sample Guide',
+            'excerpt' => 'Sample excerpt.',
+            'category_slug' => 'career-planning',
+            'body_md' => '# Sample Guide',
+            'body_html' => null,
+            'related_industry_slugs_json' => ['business'],
+            'related_jobs' => [
+                ['job_code' => 'product-manager'],
+            ],
+            'related_articles' => [
+                ['slug' => 'mbti-basics'],
+            ],
+            'related_personality_profiles' => [
+                ['type_code' => 'INTJ'],
+            ],
+            'seo_meta' => [
+                'seo_title' => null,
+                'seo_description' => null,
+                'canonical_url' => null,
+                'og_title' => null,
+                'og_description' => null,
+                'og_image_url' => null,
+                'twitter_title' => null,
+                'twitter_description' => null,
+                'twitter_image_url' => null,
+                'robots' => null,
+                'jsonld_overrides_json' => null,
+            ],
+            'status' => 'published',
+            'is_public' => true,
+            'is_indexable' => true,
+            'published_at' => '2026-03-05',
+            'scheduled_at' => null,
+            'sort_order' => 0,
+        ], $overrides);
+    }
+
+    /**
+     * @param  array<string, array<string, mixed>>  $files
+     */
+    private function writeFixtureDirectory(string $directoryName, array $files): string
+    {
+        $relativeDir = 'tests/Fixtures/'.$directoryName;
+        $absoluteDir = base_path($relativeDir);
+
+        File::deleteDirectory($absoluteDir);
+        File::ensureDirectoryExists($absoluteDir);
+
+        foreach ($files as $fileName => $payload) {
+            File::put(
+                $absoluteDir.'/'.$fileName,
+                json_encode($payload, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES | JSON_PRETTY_PRINT),
+            );
+        }
+
+        return $relativeDir;
+    }
+}

--- a/backend/tests/Fixtures/career_guide_baseline/career_guides.en.json
+++ b/backend/tests/Fixtures/career_guide_baseline/career_guides.en.json
@@ -1,0 +1,107 @@
+{
+  "meta": {
+    "schema_version": "v1",
+    "locale": "en",
+    "source": "test fixture",
+    "generated_at": "2026-03-15T00:00:00Z"
+  },
+  "guides": [
+    {
+      "guide_code": "from-mbti-to-job-fit",
+      "slug": "from-mbti-to-job-fit",
+      "locale": "en",
+      "title": "From MBTI to Job Fit",
+      "excerpt": "Translate MBTI signals into practical career choices.",
+      "category_slug": "assessment-usage",
+      "body_md": "# From MBTI to Job Fit\n\nUse personality signals as one input in career decisions.\n",
+      "body_html": null,
+      "related_industry_slugs_json": [
+        "business",
+        "technology"
+      ],
+      "related_jobs": [
+        {
+          "job_code": "product-manager"
+        },
+        {
+          "job_code": "teacher"
+        }
+      ],
+      "related_articles": [
+        {
+          "slug": "mbti-basics"
+        },
+        {
+          "slug": "mbti-growth-guide"
+        }
+      ],
+      "related_personality_profiles": [
+        {
+          "type_code": "INTJ"
+        },
+        {
+          "type_code": "ENFP"
+        }
+      ],
+      "seo_meta": {
+        "seo_title": null,
+        "seo_description": null,
+        "canonical_url": null,
+        "og_title": null,
+        "og_description": null,
+        "og_image_url": null,
+        "twitter_title": null,
+        "twitter_description": null,
+        "twitter_image_url": null,
+        "robots": null,
+        "jsonld_overrides_json": null
+      },
+      "status": "published",
+      "is_public": true,
+      "is_indexable": true,
+      "published_at": "2026-03-05",
+      "scheduled_at": null,
+      "sort_order": 10
+    },
+    {
+      "guide_code": "quarterly-career-review",
+      "slug": "quarterly-career-review",
+      "locale": "en",
+      "title": "Quarterly Career Review",
+      "excerpt": "Run a short quarterly review to keep career decisions concrete.",
+      "category_slug": "career-planning",
+      "body_md": "# Quarterly Career Review\n\nA short review loop for momentum, evidence, and adjustments.\n",
+      "body_html": null,
+      "related_industry_slugs_json": [
+        "business",
+        "education"
+      ],
+      "related_jobs": [
+        {
+          "job_code": "teacher"
+        }
+      ],
+      "related_articles": [],
+      "related_personality_profiles": [],
+      "seo_meta": {
+        "seo_title": "Quarterly Career Review Guide",
+        "seo_description": "Use a quarterly review cadence to keep your career direction evidence-based.",
+        "canonical_url": null,
+        "og_title": "Quarterly Career Review Guide",
+        "og_description": "A short quarterly review loop for career direction.",
+        "og_image_url": null,
+        "twitter_title": "Quarterly Career Review Guide",
+        "twitter_description": "A short quarterly review loop for career direction.",
+        "twitter_image_url": null,
+        "robots": "index,follow",
+        "jsonld_overrides_json": null
+      },
+      "status": "published",
+      "is_public": true,
+      "is_indexable": true,
+      "published_at": "2026-03-06",
+      "scheduled_at": null,
+      "sort_order": 20
+    }
+  ]
+}

--- a/backend/tests/Fixtures/career_guide_baseline/career_guides.zh-CN.json
+++ b/backend/tests/Fixtures/career_guide_baseline/career_guides.zh-CN.json
@@ -1,0 +1,107 @@
+{
+  "meta": {
+    "schema_version": "v1",
+    "locale": "zh-CN",
+    "source": "test fixture",
+    "generated_at": "2026-03-15T00:00:00Z"
+  },
+  "guides": [
+    {
+      "guide_code": "from-mbti-to-job-fit",
+      "slug": "from-mbti-to-job-fit",
+      "locale": "zh-CN",
+      "title": "从 MBTI 到岗位匹配",
+      "excerpt": "把 MBTI 信号转成更具体的职业判断。",
+      "category_slug": "assessment-usage",
+      "body_md": "# 从 MBTI 到岗位匹配\n\n把人格信号作为职业决策的一项输入，而不是唯一答案。\n",
+      "body_html": null,
+      "related_industry_slugs_json": [
+        "business",
+        "technology"
+      ],
+      "related_jobs": [
+        {
+          "job_code": "product-manager"
+        },
+        {
+          "job_code": "teacher"
+        }
+      ],
+      "related_articles": [
+        {
+          "slug": "mbti-basics"
+        },
+        {
+          "slug": "mbti-growth-guide"
+        }
+      ],
+      "related_personality_profiles": [
+        {
+          "type_code": "INTJ"
+        },
+        {
+          "type_code": "ENFP"
+        }
+      ],
+      "seo_meta": {
+        "seo_title": null,
+        "seo_description": null,
+        "canonical_url": null,
+        "og_title": null,
+        "og_description": null,
+        "og_image_url": null,
+        "twitter_title": null,
+        "twitter_description": null,
+        "twitter_image_url": null,
+        "robots": null,
+        "jsonld_overrides_json": null
+      },
+      "status": "published",
+      "is_public": true,
+      "is_indexable": true,
+      "published_at": "2026-03-05",
+      "scheduled_at": null,
+      "sort_order": 10
+    },
+    {
+      "guide_code": "quarterly-career-review",
+      "slug": "quarterly-career-review",
+      "locale": "zh-CN",
+      "title": "季度职业复盘",
+      "excerpt": "用轻量季度复盘，让职业判断始终基于证据和节奏。",
+      "category_slug": "career-planning",
+      "body_md": "# 季度职业复盘\n\n用短周期复盘来校准方向、证据和下一步动作。\n",
+      "body_html": null,
+      "related_industry_slugs_json": [
+        "business",
+        "education"
+      ],
+      "related_jobs": [
+        {
+          "job_code": "teacher"
+        }
+      ],
+      "related_articles": [],
+      "related_personality_profiles": [],
+      "seo_meta": {
+        "seo_title": "季度职业复盘指南",
+        "seo_description": "用季度复盘维持职业方向的证据感与行动节奏。",
+        "canonical_url": null,
+        "og_title": "季度职业复盘指南",
+        "og_description": "一个短周期的职业复盘方法。",
+        "og_image_url": null,
+        "twitter_title": "季度职业复盘指南",
+        "twitter_description": "一个短周期的职业复盘方法。",
+        "twitter_image_url": null,
+        "robots": "index,follow",
+        "jsonld_overrides_json": null
+      },
+      "status": "published",
+      "is_public": true,
+      "is_indexable": true,
+      "published_at": "2026-03-06",
+      "scheduled_at": null,
+      "sort_order": 20
+    }
+  ]
+}

--- a/content_baselines/career_guides/career_guides.en.json
+++ b/content_baselines/career_guides/career_guides.en.json
@@ -1,0 +1,976 @@
+{
+  "meta": {
+    "schema_version": "v1",
+    "locale": "en",
+    "source": "career guides committed baseline",
+    "generated_at": "2026-03-15T00:00:00Z"
+  },
+  "guides": [
+    {
+      "guide_code": "annual-career-review-system",
+      "slug": "annual-career-review-system",
+      "locale": "en",
+      "title": "Annual Career Review System",
+      "excerpt": "Actionable framework to improve decision quality and execution in career development.",
+      "category_slug": "career-planning",
+      "body_md": "# Annual Career Review System\n\n## Why This Matters\nCareer growth is a compound system. Better decisions early reduce switching costs and improve long-term optionality.\n\n## Practical Framework\n1. Define one 12-month target role with explicit success criteria.\n2. Build a capability backlog across knowledge, projects, and collaboration behavior.\n3. Run 4-week execution sprints and collect measurable evidence.\n4. Review outcomes quarterly and adjust strategy using market and fit signals.\n\n## Implementation Checklist\n- Clear role target and industry context\n- Evidence-based skill gap map\n- Portfolio or project proof\n- Feedback loop with mentors and stakeholders",
+      "body_html": null,
+      "related_industry_slugs_json": [
+        "consulting",
+        "manufacturing"
+      ],
+      "related_jobs": [
+        {
+          "job_code": "business-analyst"
+        },
+        {
+          "job_code": "brand-manager"
+        },
+        {
+          "job_code": "nurse"
+        }
+      ],
+      "related_articles": [],
+      "related_personality_profiles": [],
+      "seo_meta": {
+        "seo_title": null,
+        "seo_description": null,
+        "canonical_url": null,
+        "og_title": null,
+        "og_description": null,
+        "og_image_url": null,
+        "twitter_title": null,
+        "twitter_description": null,
+        "twitter_image_url": null,
+        "robots": null,
+        "jsonld_overrides_json": null
+      },
+      "status": "published",
+      "is_public": true,
+      "is_indexable": true,
+      "published_at": "2026-03-05",
+      "scheduled_at": null,
+      "sort_order": 0
+    },
+    {
+      "guide_code": "big5-for-career-decisions",
+      "slug": "big5-for-career-decisions",
+      "locale": "en",
+      "title": "Using Big Five for Career Decisions",
+      "excerpt": "Actionable framework to improve decision quality and execution in career development.",
+      "category_slug": "assessment-usage",
+      "body_md": "# Using Big Five for Career Decisions\n\n## Why This Matters\nCareer growth is a compound system. Better decisions early reduce switching costs and improve long-term optionality.\n\n## Practical Framework\n1. Define one 12-month target role with explicit success criteria.\n2. Build a capability backlog across knowledge, projects, and collaboration behavior.\n3. Run 4-week execution sprints and collect measurable evidence.\n4. Review outcomes quarterly and adjust strategy using market and fit signals.\n\n## Implementation Checklist\n- Clear role target and industry context\n- Evidence-based skill gap map\n- Portfolio or project proof\n- Feedback loop with mentors and stakeholders",
+      "body_html": null,
+      "related_industry_slugs_json": [
+        "media",
+        "public-service"
+      ],
+      "related_jobs": [
+        {
+          "job_code": "teacher"
+        },
+        {
+          "job_code": "machine-learning-engineer"
+        },
+        {
+          "job_code": "backend-engineer"
+        }
+      ],
+      "related_articles": [
+        {
+          "slug": "big-five-tool-guide"
+        },
+        {
+          "slug": "big-five-growth-guide"
+        },
+        {
+          "slug": "big-five-narrative-portrait"
+        }
+      ],
+      "related_personality_profiles": [],
+      "seo_meta": {
+        "seo_title": null,
+        "seo_description": null,
+        "canonical_url": null,
+        "og_title": null,
+        "og_description": null,
+        "og_image_url": null,
+        "twitter_title": null,
+        "twitter_description": null,
+        "twitter_image_url": null,
+        "robots": null,
+        "jsonld_overrides_json": null
+      },
+      "status": "published",
+      "is_public": true,
+      "is_indexable": true,
+      "published_at": "2026-03-05",
+      "scheduled_at": null,
+      "sort_order": 0
+    },
+    {
+      "guide_code": "build-five-year-career-roadmap",
+      "slug": "build-five-year-career-roadmap",
+      "locale": "en",
+      "title": "Build a Five-Year Career Roadmap",
+      "excerpt": "Actionable framework to improve decision quality and execution in career development.",
+      "category_slug": "career-planning",
+      "body_md": "# Build a Five-Year Career Roadmap\n\n## Why This Matters\nCareer growth is a compound system. Better decisions early reduce switching costs and improve long-term optionality.\n\n## Practical Framework\n1. Define one 12-month target role with explicit success criteria.\n2. Build a capability backlog across knowledge, projects, and collaboration behavior.\n3. Run 4-week execution sprints and collect measurable evidence.\n4. Review outcomes quarterly and adjust strategy using market and fit signals.\n\n## Implementation Checklist\n- Clear role target and industry context\n- Evidence-based skill gap map\n- Portfolio or project proof\n- Feedback loop with mentors and stakeholders",
+      "body_html": null,
+      "related_industry_slugs_json": [
+        "education",
+        "consulting"
+      ],
+      "related_jobs": [
+        {
+          "job_code": "investment-analyst"
+        },
+        {
+          "job_code": "physician"
+        },
+        {
+          "job_code": "data-scientist"
+        }
+      ],
+      "related_articles": [],
+      "related_personality_profiles": [],
+      "seo_meta": {
+        "seo_title": null,
+        "seo_description": null,
+        "canonical_url": null,
+        "og_title": null,
+        "og_description": null,
+        "og_image_url": null,
+        "twitter_title": null,
+        "twitter_description": null,
+        "twitter_image_url": null,
+        "robots": null,
+        "jsonld_overrides_json": null
+      },
+      "status": "published",
+      "is_public": true,
+      "is_indexable": true,
+      "published_at": "2026-03-05",
+      "scheduled_at": null,
+      "sort_order": 0
+    },
+    {
+      "guide_code": "build-portfolio-for-career-switch",
+      "slug": "build-portfolio-for-career-switch",
+      "locale": "en",
+      "title": "Build a Portfolio for Career Switching",
+      "excerpt": "Actionable framework to improve decision quality and execution in career development.",
+      "category_slug": "career-transition",
+      "body_md": "# Build a Portfolio for Career Switching\n\n## Why This Matters\nCareer growth is a compound system. Better decisions early reduce switching costs and improve long-term optionality.\n\n## Practical Framework\n1. Define one 12-month target role with explicit success criteria.\n2. Build a capability backlog across knowledge, projects, and collaboration behavior.\n3. Run 4-week execution sprints and collect measurable evidence.\n4. Review outcomes quarterly and adjust strategy using market and fit signals.\n\n## Implementation Checklist\n- Clear role target and industry context\n- Evidence-based skill gap map\n- Portfolio or project proof\n- Feedback loop with mentors and stakeholders",
+      "body_html": null,
+      "related_industry_slugs_json": [
+        "public-service",
+        "healthcare"
+      ],
+      "related_jobs": [
+        {
+          "job_code": "backend-engineer"
+        },
+        {
+          "job_code": "cybersecurity-analyst"
+        },
+        {
+          "job_code": "operations-manager"
+        }
+      ],
+      "related_articles": [],
+      "related_personality_profiles": [],
+      "seo_meta": {
+        "seo_title": null,
+        "seo_description": null,
+        "canonical_url": null,
+        "og_title": null,
+        "og_description": null,
+        "og_image_url": null,
+        "twitter_title": null,
+        "twitter_description": null,
+        "twitter_image_url": null,
+        "robots": null,
+        "jsonld_overrides_json": null
+      },
+      "status": "published",
+      "is_public": true,
+      "is_indexable": true,
+      "published_at": "2026-03-05",
+      "scheduled_at": null,
+      "sort_order": 0
+    },
+    {
+      "guide_code": "career-growth-with-manager",
+      "slug": "career-growth-with-manager",
+      "locale": "en",
+      "title": "Career Growth with Your Manager",
+      "excerpt": "Actionable framework to improve decision quality and execution in career development.",
+      "category_slug": "workplace-communication",
+      "body_md": "# Career Growth with Your Manager\n\n## Why This Matters\nCareer growth is a compound system. Better decisions early reduce switching costs and improve long-term optionality.\n\n## Practical Framework\n1. Define one 12-month target role with explicit success criteria.\n2. Build a capability backlog across knowledge, projects, and collaboration behavior.\n3. Run 4-week execution sprints and collect measurable evidence.\n4. Review outcomes quarterly and adjust strategy using market and fit signals.\n\n## Implementation Checklist\n- Clear role target and industry context\n- Evidence-based skill gap map\n- Portfolio or project proof\n- Feedback loop with mentors and stakeholders",
+      "body_html": null,
+      "related_industry_slugs_json": [
+        "legal",
+        "finance"
+      ],
+      "related_jobs": [
+        {
+          "job_code": "frontend-engineer"
+        },
+        {
+          "job_code": "fullstack-engineer"
+        },
+        {
+          "job_code": "cloud-architect"
+        }
+      ],
+      "related_articles": [],
+      "related_personality_profiles": [],
+      "seo_meta": {
+        "seo_title": null,
+        "seo_description": null,
+        "canonical_url": null,
+        "og_title": null,
+        "og_description": null,
+        "og_image_url": null,
+        "twitter_title": null,
+        "twitter_description": null,
+        "twitter_image_url": null,
+        "robots": null,
+        "jsonld_overrides_json": null
+      },
+      "status": "published",
+      "is_public": true,
+      "is_indexable": true,
+      "published_at": "2026-03-05",
+      "scheduled_at": null,
+      "sort_order": 0
+    },
+    {
+      "guide_code": "career-risk-management",
+      "slug": "career-risk-management",
+      "locale": "en",
+      "title": "Career Risk Management",
+      "excerpt": "Actionable framework to improve decision quality and execution in career development.",
+      "category_slug": "career-planning",
+      "body_md": "# Career Risk Management\n\n## Why This Matters\nCareer growth is a compound system. Better decisions early reduce switching costs and improve long-term optionality.\n\n## Practical Framework\n1. Define one 12-month target role with explicit success criteria.\n2. Build a capability backlog across knowledge, projects, and collaboration behavior.\n3. Run 4-week execution sprints and collect measurable evidence.\n4. Review outcomes quarterly and adjust strategy using market and fit signals.\n\n## Implementation Checklist\n- Clear role target and industry context\n- Evidence-based skill gap map\n- Portfolio or project proof\n- Feedback loop with mentors and stakeholders",
+      "body_html": null,
+      "related_industry_slugs_json": [
+        "business",
+        "legal"
+      ],
+      "related_jobs": [
+        {
+          "job_code": "management-consultant"
+        },
+        {
+          "job_code": "business-analyst"
+        },
+        {
+          "job_code": "brand-manager"
+        }
+      ],
+      "related_articles": [],
+      "related_personality_profiles": [],
+      "seo_meta": {
+        "seo_title": null,
+        "seo_description": null,
+        "canonical_url": null,
+        "og_title": null,
+        "og_description": null,
+        "og_image_url": null,
+        "twitter_title": null,
+        "twitter_description": null,
+        "twitter_image_url": null,
+        "robots": null,
+        "jsonld_overrides_json": null
+      },
+      "status": "published",
+      "is_public": true,
+      "is_indexable": true,
+      "published_at": "2026-03-05",
+      "scheduled_at": null,
+      "sort_order": 0
+    },
+    {
+      "guide_code": "career-transition-playbook",
+      "slug": "career-transition-playbook",
+      "locale": "en",
+      "title": "Career Transition Playbook",
+      "excerpt": "Actionable framework to improve decision quality and execution in career development.",
+      "category_slug": "career-transition",
+      "body_md": "# Career Transition Playbook\n\n## Why This Matters\nCareer growth is a compound system. Better decisions early reduce switching costs and improve long-term optionality.\n\n## Practical Framework\n1. Define one 12-month target role with explicit success criteria.\n2. Build a capability backlog across knowledge, projects, and collaboration behavior.\n3. Run 4-week execution sprints and collect measurable evidence.\n4. Review outcomes quarterly and adjust strategy using market and fit signals.\n\n## Implementation Checklist\n- Clear role target and industry context\n- Evidence-based skill gap map\n- Portfolio or project proof\n- Feedback loop with mentors and stakeholders",
+      "body_html": null,
+      "related_industry_slugs_json": [
+        "healthcare",
+        "media"
+      ],
+      "related_jobs": [
+        {
+          "job_code": "digital-marketing-manager"
+        },
+        {
+          "job_code": "lawyer"
+        },
+        {
+          "job_code": "teacher"
+        }
+      ],
+      "related_articles": [],
+      "related_personality_profiles": [],
+      "seo_meta": {
+        "seo_title": null,
+        "seo_description": null,
+        "canonical_url": null,
+        "og_title": null,
+        "og_description": null,
+        "og_image_url": null,
+        "twitter_title": null,
+        "twitter_description": null,
+        "twitter_image_url": null,
+        "robots": null,
+        "jsonld_overrides_json": null
+      },
+      "status": "published",
+      "is_public": true,
+      "is_indexable": true,
+      "published_at": "2026-03-05",
+      "scheduled_at": null,
+      "sort_order": 0
+    },
+    {
+      "guide_code": "cross-industry-move-strategy",
+      "slug": "cross-industry-move-strategy",
+      "locale": "en",
+      "title": "Cross-Industry Move Strategy",
+      "excerpt": "Actionable framework to improve decision quality and execution in career development.",
+      "category_slug": "career-transition",
+      "body_md": "# Cross-Industry Move Strategy\n\n## Why This Matters\nCareer growth is a compound system. Better decisions early reduce switching costs and improve long-term optionality.\n\n## Practical Framework\n1. Define one 12-month target role with explicit success criteria.\n2. Build a capability backlog across knowledge, projects, and collaboration behavior.\n3. Run 4-week execution sprints and collect measurable evidence.\n4. Review outcomes quarterly and adjust strategy using market and fit signals.\n\n## Implementation Checklist\n- Clear role target and industry context\n- Evidence-based skill gap map\n- Portfolio or project proof\n- Feedback loop with mentors and stakeholders",
+      "body_html": null,
+      "related_industry_slugs_json": [
+        "design",
+        "operations"
+      ],
+      "related_jobs": [
+        {
+          "job_code": "sales-manager"
+        },
+        {
+          "job_code": "financial-planner"
+        },
+        {
+          "job_code": "content-strategist"
+        }
+      ],
+      "related_articles": [],
+      "related_personality_profiles": [],
+      "seo_meta": {
+        "seo_title": null,
+        "seo_description": null,
+        "canonical_url": null,
+        "og_title": null,
+        "og_description": null,
+        "og_image_url": null,
+        "twitter_title": null,
+        "twitter_description": null,
+        "twitter_image_url": null,
+        "robots": null,
+        "jsonld_overrides_json": null
+      },
+      "status": "published",
+      "is_public": true,
+      "is_indexable": true,
+      "published_at": "2026-03-05",
+      "scheduled_at": null,
+      "sort_order": 0
+    },
+    {
+      "guide_code": "first-90-days-in-new-role",
+      "slug": "first-90-days-in-new-role",
+      "locale": "en",
+      "title": "First 90 Days in a New Role",
+      "excerpt": "Actionable framework to improve decision quality and execution in career development.",
+      "category_slug": "onboarding",
+      "body_md": "# First 90 Days in a New Role\n\n## Why This Matters\nCareer growth is a compound system. Better decisions early reduce switching costs and improve long-term optionality.\n\n## Practical Framework\n1. Define one 12-month target role with explicit success criteria.\n2. Build a capability backlog across knowledge, projects, and collaboration behavior.\n3. Run 4-week execution sprints and collect measurable evidence.\n4. Review outcomes quarterly and adjust strategy using market and fit signals.\n\n## Implementation Checklist\n- Clear role target and industry context\n- Evidence-based skill gap map\n- Portfolio or project proof\n- Feedback loop with mentors and stakeholders",
+      "body_html": null,
+      "related_industry_slugs_json": [
+        "operations",
+        "technology"
+      ],
+      "related_jobs": [
+        {
+          "job_code": "machine-learning-engineer"
+        },
+        {
+          "job_code": "backend-engineer"
+        },
+        {
+          "job_code": "cybersecurity-analyst"
+        }
+      ],
+      "related_articles": [],
+      "related_personality_profiles": [],
+      "seo_meta": {
+        "seo_title": null,
+        "seo_description": null,
+        "canonical_url": null,
+        "og_title": null,
+        "og_description": null,
+        "og_image_url": null,
+        "twitter_title": null,
+        "twitter_description": null,
+        "twitter_image_url": null,
+        "robots": null,
+        "jsonld_overrides_json": null
+      },
+      "status": "published",
+      "is_public": true,
+      "is_indexable": true,
+      "published_at": "2026-03-05",
+      "scheduled_at": null,
+      "sort_order": 0
+    },
+    {
+      "guide_code": "from-mbti-to-job-fit",
+      "slug": "from-mbti-to-job-fit",
+      "locale": "en",
+      "title": "From MBTI to Job Fit",
+      "excerpt": "Actionable framework to improve decision quality and execution in career development.",
+      "category_slug": "assessment-usage",
+      "body_md": "# From MBTI to Job Fit\n\n## Why This Matters\nCareer growth is a compound system. Better decisions early reduce switching costs and improve long-term optionality.\n\n## Practical Framework\n1. Define one 12-month target role with explicit success criteria.\n2. Build a capability backlog across knowledge, projects, and collaboration behavior.\n3. Run 4-week execution sprints and collect measurable evidence.\n4. Review outcomes quarterly and adjust strategy using market and fit signals.\n\n## Implementation Checklist\n- Clear role target and industry context\n- Evidence-based skill gap map\n- Portfolio or project proof\n- Feedback loop with mentors and stakeholders",
+      "body_html": null,
+      "related_industry_slugs_json": [
+        "business",
+        "legal"
+      ],
+      "related_jobs": [
+        {
+          "job_code": "physician"
+        },
+        {
+          "job_code": "data-scientist"
+        },
+        {
+          "job_code": "frontend-engineer"
+        }
+      ],
+      "related_articles": [
+        {
+          "slug": "mbti-basics"
+        },
+        {
+          "slug": "mbti-growth-guide"
+        },
+        {
+          "slug": "mbti-narrative-portrait"
+        }
+      ],
+      "related_personality_profiles": [
+        {
+          "type_code": "INTJ"
+        },
+        {
+          "type_code": "ENFP"
+        },
+        {
+          "type_code": "ISTJ"
+        },
+        {
+          "type_code": "ENTP"
+        }
+      ],
+      "seo_meta": {
+        "seo_title": null,
+        "seo_description": null,
+        "canonical_url": null,
+        "og_title": null,
+        "og_description": null,
+        "og_image_url": null,
+        "twitter_title": null,
+        "twitter_description": null,
+        "twitter_image_url": null,
+        "robots": null,
+        "jsonld_overrides_json": null
+      },
+      "status": "published",
+      "is_public": true,
+      "is_indexable": true,
+      "published_at": "2026-03-05",
+      "scheduled_at": null,
+      "sort_order": 0
+    },
+    {
+      "guide_code": "how-to-choose-college-major",
+      "slug": "how-to-choose-college-major",
+      "locale": "en",
+      "title": "How to Choose a College Major",
+      "excerpt": "Actionable framework to improve decision quality and execution in career development.",
+      "category_slug": "education-decision",
+      "body_md": "# How to Choose a College Major\n\n## Why This Matters\nCareer growth is a compound system. Better decisions early reduce switching costs and improve long-term optionality.\n\n## Practical Framework\n1. Define one 12-month target role with explicit success criteria.\n2. Build a capability backlog across knowledge, projects, and collaboration behavior.\n3. Run 4-week execution sprints and collect measurable evidence.\n4. Review outcomes quarterly and adjust strategy using market and fit signals.\n\n## Implementation Checklist\n- Clear role target and industry context\n- Evidence-based skill gap map\n- Portfolio or project proof\n- Feedback loop with mentors and stakeholders",
+      "body_html": null,
+      "related_industry_slugs_json": [
+        "finance",
+        "business"
+      ],
+      "related_jobs": [
+        {
+          "job_code": "psychological-counselor"
+        },
+        {
+          "job_code": "investment-analyst"
+        },
+        {
+          "job_code": "physician"
+        }
+      ],
+      "related_articles": [],
+      "related_personality_profiles": [],
+      "seo_meta": {
+        "seo_title": null,
+        "seo_description": null,
+        "canonical_url": null,
+        "og_title": null,
+        "og_description": null,
+        "og_image_url": null,
+        "twitter_title": null,
+        "twitter_description": null,
+        "twitter_image_url": null,
+        "robots": null,
+        "jsonld_overrides_json": null
+      },
+      "status": "published",
+      "is_public": true,
+      "is_indexable": true,
+      "published_at": "2026-03-05",
+      "scheduled_at": null,
+      "sort_order": 0
+    },
+    {
+      "guide_code": "how-to-find-right-career-direction",
+      "slug": "how-to-find-right-career-direction",
+      "locale": "en",
+      "title": "How to Find the Right Career Direction",
+      "excerpt": "Actionable framework to improve decision quality and execution in career development.",
+      "category_slug": "career-planning",
+      "body_md": "# How to Find the Right Career Direction\n\n## Why This Matters\nCareer growth is a compound system. Better decisions early reduce switching costs and improve long-term optionality.\n\n## Practical Framework\n1. Define one 12-month target role with explicit success criteria.\n2. Build a capability backlog across knowledge, projects, and collaboration behavior.\n3. Run 4-week execution sprints and collect measurable evidence.\n4. Review outcomes quarterly and adjust strategy using market and fit signals.\n\n## Implementation Checklist\n- Clear role target and industry context\n- Evidence-based skill gap map\n- Portfolio or project proof\n- Feedback loop with mentors and stakeholders",
+      "body_html": null,
+      "related_industry_slugs_json": [
+        "technology",
+        "design"
+      ],
+      "related_jobs": [
+        {
+          "job_code": "ui-ux-designer"
+        },
+        {
+          "job_code": "digital-marketing-manager"
+        },
+        {
+          "job_code": "lawyer"
+        }
+      ],
+      "related_articles": [],
+      "related_personality_profiles": [],
+      "seo_meta": {
+        "seo_title": null,
+        "seo_description": null,
+        "canonical_url": null,
+        "og_title": null,
+        "og_description": null,
+        "og_image_url": null,
+        "twitter_title": null,
+        "twitter_description": null,
+        "twitter_image_url": null,
+        "robots": null,
+        "jsonld_overrides_json": null
+      },
+      "status": "published",
+      "is_public": true,
+      "is_indexable": true,
+      "published_at": "2026-03-05",
+      "scheduled_at": null,
+      "sort_order": 0
+    },
+    {
+      "guide_code": "improve-workplace-competitiveness",
+      "slug": "improve-workplace-competitiveness",
+      "locale": "en",
+      "title": "Improve Workplace Competitiveness",
+      "excerpt": "Actionable framework to improve decision quality and execution in career development.",
+      "category_slug": "skill-growth",
+      "body_md": "# Improve Workplace Competitiveness\n\n## Why This Matters\nCareer growth is a compound system. Better decisions early reduce switching costs and improve long-term optionality.\n\n## Practical Framework\n1. Define one 12-month target role with explicit success criteria.\n2. Build a capability backlog across knowledge, projects, and collaboration behavior.\n3. Run 4-week execution sprints and collect measurable evidence.\n4. Review outcomes quarterly and adjust strategy using market and fit signals.\n\n## Implementation Checklist\n- Clear role target and industry context\n- Evidence-based skill gap map\n- Portfolio or project proof\n- Feedback loop with mentors and stakeholders",
+      "body_html": null,
+      "related_industry_slugs_json": [
+        "design",
+        "operations"
+      ],
+      "related_jobs": [
+        {
+          "job_code": "lawyer"
+        },
+        {
+          "job_code": "teacher"
+        },
+        {
+          "job_code": "machine-learning-engineer"
+        }
+      ],
+      "related_articles": [],
+      "related_personality_profiles": [],
+      "seo_meta": {
+        "seo_title": null,
+        "seo_description": null,
+        "canonical_url": null,
+        "og_title": null,
+        "og_description": null,
+        "og_image_url": null,
+        "twitter_title": null,
+        "twitter_description": null,
+        "twitter_image_url": null,
+        "robots": null,
+        "jsonld_overrides_json": null
+      },
+      "status": "published",
+      "is_public": true,
+      "is_indexable": true,
+      "published_at": "2026-03-05",
+      "scheduled_at": null,
+      "sort_order": 0
+    },
+    {
+      "guide_code": "interview-strategy-by-role",
+      "slug": "interview-strategy-by-role",
+      "locale": "en",
+      "title": "Interview Strategy by Role",
+      "excerpt": "Actionable framework to improve decision quality and execution in career development.",
+      "category_slug": "job-search",
+      "body_md": "# Interview Strategy by Role\n\n## Why This Matters\nCareer growth is a compound system. Better decisions early reduce switching costs and improve long-term optionality.\n\n## Practical Framework\n1. Define one 12-month target role with explicit success criteria.\n2. Build a capability backlog across knowledge, projects, and collaboration behavior.\n3. Run 4-week execution sprints and collect measurable evidence.\n4. Review outcomes quarterly and adjust strategy using market and fit signals.\n\n## Implementation Checklist\n- Clear role target and industry context\n- Evidence-based skill gap map\n- Portfolio or project proof\n- Feedback loop with mentors and stakeholders",
+      "body_html": null,
+      "related_industry_slugs_json": [
+        "technology",
+        "design"
+      ],
+      "related_jobs": [
+        {
+          "job_code": "cybersecurity-analyst"
+        },
+        {
+          "job_code": "operations-manager"
+        },
+        {
+          "job_code": "sales-manager"
+        }
+      ],
+      "related_articles": [],
+      "related_personality_profiles": [],
+      "seo_meta": {
+        "seo_title": null,
+        "seo_description": null,
+        "canonical_url": null,
+        "og_title": null,
+        "og_description": null,
+        "og_image_url": null,
+        "twitter_title": null,
+        "twitter_description": null,
+        "twitter_image_url": null,
+        "robots": null,
+        "jsonld_overrides_json": null
+      },
+      "status": "published",
+      "is_public": true,
+      "is_indexable": true,
+      "published_at": "2026-03-05",
+      "scheduled_at": null,
+      "sort_order": 0
+    },
+    {
+      "guide_code": "iq-eq-balance-at-work",
+      "slug": "iq-eq-balance-at-work",
+      "locale": "en",
+      "title": "Balancing IQ and EQ at Work",
+      "excerpt": "Actionable framework to improve decision quality and execution in career development.",
+      "category_slug": "assessment-usage",
+      "body_md": "# Balancing IQ and EQ at Work\n\n## Why This Matters\nCareer growth is a compound system. Better decisions early reduce switching costs and improve long-term optionality.\n\n## Practical Framework\n1. Define one 12-month target role with explicit success criteria.\n2. Build a capability backlog across knowledge, projects, and collaboration behavior.\n3. Run 4-week execution sprints and collect measurable evidence.\n4. Review outcomes quarterly and adjust strategy using market and fit signals.\n\n## Implementation Checklist\n- Clear role target and industry context\n- Evidence-based skill gap map\n- Portfolio or project proof\n- Feedback loop with mentors and stakeholders",
+      "body_html": null,
+      "related_industry_slugs_json": [
+        "consulting",
+        "manufacturing"
+      ],
+      "related_jobs": [
+        {
+          "job_code": "data-scientist"
+        },
+        {
+          "job_code": "frontend-engineer"
+        },
+        {
+          "job_code": "fullstack-engineer"
+        }
+      ],
+      "related_articles": [
+        {
+          "slug": "iq-test-tool-guide"
+        },
+        {
+          "slug": "iq-test-growth-guide"
+        },
+        {
+          "slug": "iq-test-narrative-portrait"
+        },
+        {
+          "slug": "eq-test-tool-guide"
+        }
+      ],
+      "related_personality_profiles": [],
+      "seo_meta": {
+        "seo_title": null,
+        "seo_description": null,
+        "canonical_url": null,
+        "og_title": null,
+        "og_description": null,
+        "og_image_url": null,
+        "twitter_title": null,
+        "twitter_description": null,
+        "twitter_image_url": null,
+        "robots": null,
+        "jsonld_overrides_json": null
+      },
+      "status": "published",
+      "is_public": true,
+      "is_indexable": true,
+      "published_at": "2026-03-05",
+      "scheduled_at": null,
+      "sort_order": 0
+    },
+    {
+      "guide_code": "leader-track-vs-expert-track",
+      "slug": "leader-track-vs-expert-track",
+      "locale": "en",
+      "title": "Leader Track vs Expert Track",
+      "excerpt": "Actionable framework to improve decision quality and execution in career development.",
+      "category_slug": "career-planning",
+      "body_md": "# Leader Track vs Expert Track\n\n## Why This Matters\nCareer growth is a compound system. Better decisions early reduce switching costs and improve long-term optionality.\n\n## Practical Framework\n1. Define one 12-month target role with explicit success criteria.\n2. Build a capability backlog across knowledge, projects, and collaboration behavior.\n3. Run 4-week execution sprints and collect measurable evidence.\n4. Review outcomes quarterly and adjust strategy using market and fit signals.\n\n## Implementation Checklist\n- Clear role target and industry context\n- Evidence-based skill gap map\n- Portfolio or project proof\n- Feedback loop with mentors and stakeholders",
+      "body_html": null,
+      "related_industry_slugs_json": [
+        "education",
+        "consulting"
+      ],
+      "related_jobs": [
+        {
+          "job_code": "hr-business-partner"
+        },
+        {
+          "job_code": "management-consultant"
+        },
+        {
+          "job_code": "business-analyst"
+        }
+      ],
+      "related_articles": [],
+      "related_personality_profiles": [],
+      "seo_meta": {
+        "seo_title": null,
+        "seo_description": null,
+        "canonical_url": null,
+        "og_title": null,
+        "og_description": null,
+        "og_image_url": null,
+        "twitter_title": null,
+        "twitter_description": null,
+        "twitter_image_url": null,
+        "robots": null,
+        "jsonld_overrides_json": null
+      },
+      "status": "published",
+      "is_public": true,
+      "is_indexable": true,
+      "published_at": "2026-03-05",
+      "scheduled_at": null,
+      "sort_order": 0
+    },
+    {
+      "guide_code": "networking-that-actually-works",
+      "slug": "networking-that-actually-works",
+      "locale": "en",
+      "title": "Networking That Actually Works",
+      "excerpt": "Actionable framework to improve decision quality and execution in career development.",
+      "category_slug": "workplace-communication",
+      "body_md": "# Networking That Actually Works\n\n## Why This Matters\nCareer growth is a compound system. Better decisions early reduce switching costs and improve long-term optionality.\n\n## Practical Framework\n1. Define one 12-month target role with explicit success criteria.\n2. Build a capability backlog across knowledge, projects, and collaboration behavior.\n3. Run 4-week execution sprints and collect measurable evidence.\n4. Review outcomes quarterly and adjust strategy using market and fit signals.\n\n## Implementation Checklist\n- Clear role target and industry context\n- Evidence-based skill gap map\n- Portfolio or project proof\n- Feedback loop with mentors and stakeholders",
+      "body_html": null,
+      "related_industry_slugs_json": [
+        "manufacturing",
+        "education"
+      ],
+      "related_jobs": [
+        {
+          "job_code": "fullstack-engineer"
+        },
+        {
+          "job_code": "cloud-architect"
+        },
+        {
+          "job_code": "hr-business-partner"
+        }
+      ],
+      "related_articles": [],
+      "related_personality_profiles": [],
+      "seo_meta": {
+        "seo_title": null,
+        "seo_description": null,
+        "canonical_url": null,
+        "og_title": null,
+        "og_description": null,
+        "og_image_url": null,
+        "twitter_title": null,
+        "twitter_description": null,
+        "twitter_image_url": null,
+        "robots": null,
+        "jsonld_overrides_json": null
+      },
+      "status": "published",
+      "is_public": true,
+      "is_indexable": true,
+      "published_at": "2026-03-05",
+      "scheduled_at": null,
+      "sort_order": 0
+    },
+    {
+      "guide_code": "personal-brand-for-professionals",
+      "slug": "personal-brand-for-professionals",
+      "locale": "en",
+      "title": "Personal Brand for Professionals",
+      "excerpt": "Actionable framework to improve decision quality and execution in career development.",
+      "category_slug": "workplace-communication",
+      "body_md": "# Personal Brand for Professionals\n\n## Why This Matters\nCareer growth is a compound system. Better decisions early reduce switching costs and improve long-term optionality.\n\n## Practical Framework\n1. Define one 12-month target role with explicit success criteria.\n2. Build a capability backlog across knowledge, projects, and collaboration behavior.\n3. Run 4-week execution sprints and collect measurable evidence.\n4. Review outcomes quarterly and adjust strategy using market and fit signals.\n\n## Implementation Checklist\n- Clear role target and industry context\n- Evidence-based skill gap map\n- Portfolio or project proof\n- Feedback loop with mentors and stakeholders",
+      "body_html": null,
+      "related_industry_slugs_json": [
+        "media",
+        "public-service"
+      ],
+      "related_jobs": [
+        {
+          "job_code": "financial-planner"
+        },
+        {
+          "job_code": "content-strategist"
+        },
+        {
+          "job_code": "researcher"
+        }
+      ],
+      "related_articles": [],
+      "related_personality_profiles": [],
+      "seo_meta": {
+        "seo_title": null,
+        "seo_description": null,
+        "canonical_url": null,
+        "og_title": null,
+        "og_description": null,
+        "og_image_url": null,
+        "twitter_title": null,
+        "twitter_description": null,
+        "twitter_image_url": null,
+        "robots": null,
+        "jsonld_overrides_json": null
+      },
+      "status": "published",
+      "is_public": true,
+      "is_indexable": true,
+      "published_at": "2026-03-05",
+      "scheduled_at": null,
+      "sort_order": 0
+    },
+    {
+      "guide_code": "prevent-burnout-while-growing",
+      "slug": "prevent-burnout-while-growing",
+      "locale": "en",
+      "title": "Prevent Burnout While Growing",
+      "excerpt": "Actionable framework to improve decision quality and execution in career development.",
+      "category_slug": "wellbeing",
+      "body_md": "# Prevent Burnout While Growing\n\n## Why This Matters\nCareer growth is a compound system. Better decisions early reduce switching costs and improve long-term optionality.\n\n## Practical Framework\n1. Define one 12-month target role with explicit success criteria.\n2. Build a capability backlog across knowledge, projects, and collaboration behavior.\n3. Run 4-week execution sprints and collect measurable evidence.\n4. Review outcomes quarterly and adjust strategy using market and fit signals.\n\n## Implementation Checklist\n- Clear role target and industry context\n- Evidence-based skill gap map\n- Portfolio or project proof\n- Feedback loop with mentors and stakeholders",
+      "body_html": null,
+      "related_industry_slugs_json": [
+        "healthcare",
+        "media"
+      ],
+      "related_jobs": [
+        {
+          "job_code": "operations-manager"
+        },
+        {
+          "job_code": "sales-manager"
+        },
+        {
+          "job_code": "financial-planner"
+        }
+      ],
+      "related_articles": [],
+      "related_personality_profiles": [],
+      "seo_meta": {
+        "seo_title": null,
+        "seo_description": null,
+        "canonical_url": null,
+        "og_title": null,
+        "og_description": null,
+        "og_image_url": null,
+        "twitter_title": null,
+        "twitter_description": null,
+        "twitter_image_url": null,
+        "robots": null,
+        "jsonld_overrides_json": null
+      },
+      "status": "published",
+      "is_public": true,
+      "is_indexable": true,
+      "published_at": "2026-03-05",
+      "scheduled_at": null,
+      "sort_order": 0
+    },
+    {
+      "guide_code": "salary-negotiation-framework",
+      "slug": "salary-negotiation-framework",
+      "locale": "en",
+      "title": "Salary Negotiation Framework",
+      "excerpt": "Actionable framework to improve decision quality and execution in career development.",
+      "category_slug": "job-search",
+      "body_md": "# Salary Negotiation Framework\n\n## Why This Matters\nCareer growth is a compound system. Better decisions early reduce switching costs and improve long-term optionality.\n\n## Practical Framework\n1. Define one 12-month target role with explicit success criteria.\n2. Build a capability backlog across knowledge, projects, and collaboration behavior.\n3. Run 4-week execution sprints and collect measurable evidence.\n4. Review outcomes quarterly and adjust strategy using market and fit signals.\n\n## Implementation Checklist\n- Clear role target and industry context\n- Evidence-based skill gap map\n- Portfolio or project proof\n- Feedback loop with mentors and stakeholders",
+      "body_html": null,
+      "related_industry_slugs_json": [
+        "finance",
+        "business"
+      ],
+      "related_jobs": [
+        {
+          "job_code": "cloud-architect"
+        },
+        {
+          "job_code": "hr-business-partner"
+        },
+        {
+          "job_code": "management-consultant"
+        }
+      ],
+      "related_articles": [],
+      "related_personality_profiles": [],
+      "seo_meta": {
+        "seo_title": null,
+        "seo_description": null,
+        "canonical_url": null,
+        "og_title": null,
+        "og_description": null,
+        "og_image_url": null,
+        "twitter_title": null,
+        "twitter_description": null,
+        "twitter_image_url": null,
+        "robots": null,
+        "jsonld_overrides_json": null
+      },
+      "status": "published",
+      "is_public": true,
+      "is_indexable": true,
+      "published_at": "2026-03-05",
+      "scheduled_at": null,
+      "sort_order": 0
+    }
+  ]
+}

--- a/content_baselines/career_guides/career_guides.zh-CN.json
+++ b/content_baselines/career_guides/career_guides.zh-CN.json
@@ -1,0 +1,976 @@
+{
+  "meta": {
+    "schema_version": "v1",
+    "locale": "zh-CN",
+    "source": "career guides committed baseline",
+    "generated_at": "2026-03-15T00:00:00Z"
+  },
+  "guides": [
+    {
+      "guide_code": "annual-career-review-system",
+      "slug": "annual-career-review-system",
+      "locale": "zh-CN",
+      "title": "年度职业复盘系统",
+      "excerpt": "用于提升职业决策质量与执行结果的实操框架。",
+      "category_slug": "career-planning",
+      "body_md": "# 年度职业复盘系统\n\n## 为什么重要\n职业成长是一个长期复利系统。越早建立高质量决策机制，越能降低试错成本并提升未来选择权。\n\n## 实操框架\n1. 明确 12 个月目标岗位及可量化成功标准。\n2. 建立“知识-项目-协作行为”三层能力差距清单。\n3. 以 4 周为一个执行 Sprint，形成可验证证据。\n4. 每季度复盘结果，并结合市场变化与个人匹配度做调整。\n\n## 落地清单\n- 明确岗位目标与行业场景\n- 证据化能力差距地图\n- 作品或项目证明材料\n- 与导师及关键协作方的反馈闭环",
+      "body_html": null,
+      "related_industry_slugs_json": [
+        "consulting",
+        "manufacturing"
+      ],
+      "related_jobs": [
+        {
+          "job_code": "business-analyst"
+        },
+        {
+          "job_code": "brand-manager"
+        },
+        {
+          "job_code": "nurse"
+        }
+      ],
+      "related_articles": [],
+      "related_personality_profiles": [],
+      "seo_meta": {
+        "seo_title": null,
+        "seo_description": null,
+        "canonical_url": null,
+        "og_title": null,
+        "og_description": null,
+        "og_image_url": null,
+        "twitter_title": null,
+        "twitter_description": null,
+        "twitter_image_url": null,
+        "robots": null,
+        "jsonld_overrides_json": null
+      },
+      "status": "published",
+      "is_public": true,
+      "is_indexable": true,
+      "published_at": "2026-03-05",
+      "scheduled_at": null,
+      "sort_order": 0
+    },
+    {
+      "guide_code": "big5-for-career-decisions",
+      "slug": "big5-for-career-decisions",
+      "locale": "zh-CN",
+      "title": "如何用大五人格做职业决策",
+      "excerpt": "用于提升职业决策质量与执行结果的实操框架。",
+      "category_slug": "assessment-usage",
+      "body_md": "# 如何用大五人格做职业决策\n\n## 为什么重要\n职业成长是一个长期复利系统。越早建立高质量决策机制，越能降低试错成本并提升未来选择权。\n\n## 实操框架\n1. 明确 12 个月目标岗位及可量化成功标准。\n2. 建立“知识-项目-协作行为”三层能力差距清单。\n3. 以 4 周为一个执行 Sprint，形成可验证证据。\n4. 每季度复盘结果，并结合市场变化与个人匹配度做调整。\n\n## 落地清单\n- 明确岗位目标与行业场景\n- 证据化能力差距地图\n- 作品或项目证明材料\n- 与导师及关键协作方的反馈闭环",
+      "body_html": null,
+      "related_industry_slugs_json": [
+        "media",
+        "public-service"
+      ],
+      "related_jobs": [
+        {
+          "job_code": "teacher"
+        },
+        {
+          "job_code": "machine-learning-engineer"
+        },
+        {
+          "job_code": "backend-engineer"
+        }
+      ],
+      "related_articles": [
+        {
+          "slug": "big-five-tool-guide"
+        },
+        {
+          "slug": "big-five-growth-guide"
+        },
+        {
+          "slug": "big-five-narrative-portrait"
+        }
+      ],
+      "related_personality_profiles": [],
+      "seo_meta": {
+        "seo_title": null,
+        "seo_description": null,
+        "canonical_url": null,
+        "og_title": null,
+        "og_description": null,
+        "og_image_url": null,
+        "twitter_title": null,
+        "twitter_description": null,
+        "twitter_image_url": null,
+        "robots": null,
+        "jsonld_overrides_json": null
+      },
+      "status": "published",
+      "is_public": true,
+      "is_indexable": true,
+      "published_at": "2026-03-05",
+      "scheduled_at": null,
+      "sort_order": 0
+    },
+    {
+      "guide_code": "build-five-year-career-roadmap",
+      "slug": "build-five-year-career-roadmap",
+      "locale": "zh-CN",
+      "title": "如何制定五年职业路线图",
+      "excerpt": "用于提升职业决策质量与执行结果的实操框架。",
+      "category_slug": "career-planning",
+      "body_md": "# 如何制定五年职业路线图\n\n## 为什么重要\n职业成长是一个长期复利系统。越早建立高质量决策机制，越能降低试错成本并提升未来选择权。\n\n## 实操框架\n1. 明确 12 个月目标岗位及可量化成功标准。\n2. 建立“知识-项目-协作行为”三层能力差距清单。\n3. 以 4 周为一个执行 Sprint，形成可验证证据。\n4. 每季度复盘结果，并结合市场变化与个人匹配度做调整。\n\n## 落地清单\n- 明确岗位目标与行业场景\n- 证据化能力差距地图\n- 作品或项目证明材料\n- 与导师及关键协作方的反馈闭环",
+      "body_html": null,
+      "related_industry_slugs_json": [
+        "education",
+        "consulting"
+      ],
+      "related_jobs": [
+        {
+          "job_code": "investment-analyst"
+        },
+        {
+          "job_code": "physician"
+        },
+        {
+          "job_code": "data-scientist"
+        }
+      ],
+      "related_articles": [],
+      "related_personality_profiles": [],
+      "seo_meta": {
+        "seo_title": null,
+        "seo_description": null,
+        "canonical_url": null,
+        "og_title": null,
+        "og_description": null,
+        "og_image_url": null,
+        "twitter_title": null,
+        "twitter_description": null,
+        "twitter_image_url": null,
+        "robots": null,
+        "jsonld_overrides_json": null
+      },
+      "status": "published",
+      "is_public": true,
+      "is_indexable": true,
+      "published_at": "2026-03-05",
+      "scheduled_at": null,
+      "sort_order": 0
+    },
+    {
+      "guide_code": "build-portfolio-for-career-switch",
+      "slug": "build-portfolio-for-career-switch",
+      "locale": "zh-CN",
+      "title": "转岗时如何构建高质量作品集",
+      "excerpt": "用于提升职业决策质量与执行结果的实操框架。",
+      "category_slug": "career-transition",
+      "body_md": "# 转岗时如何构建高质量作品集\n\n## 为什么重要\n职业成长是一个长期复利系统。越早建立高质量决策机制，越能降低试错成本并提升未来选择权。\n\n## 实操框架\n1. 明确 12 个月目标岗位及可量化成功标准。\n2. 建立“知识-项目-协作行为”三层能力差距清单。\n3. 以 4 周为一个执行 Sprint，形成可验证证据。\n4. 每季度复盘结果，并结合市场变化与个人匹配度做调整。\n\n## 落地清单\n- 明确岗位目标与行业场景\n- 证据化能力差距地图\n- 作品或项目证明材料\n- 与导师及关键协作方的反馈闭环",
+      "body_html": null,
+      "related_industry_slugs_json": [
+        "public-service",
+        "healthcare"
+      ],
+      "related_jobs": [
+        {
+          "job_code": "backend-engineer"
+        },
+        {
+          "job_code": "cybersecurity-analyst"
+        },
+        {
+          "job_code": "operations-manager"
+        }
+      ],
+      "related_articles": [],
+      "related_personality_profiles": [],
+      "seo_meta": {
+        "seo_title": null,
+        "seo_description": null,
+        "canonical_url": null,
+        "og_title": null,
+        "og_description": null,
+        "og_image_url": null,
+        "twitter_title": null,
+        "twitter_description": null,
+        "twitter_image_url": null,
+        "robots": null,
+        "jsonld_overrides_json": null
+      },
+      "status": "published",
+      "is_public": true,
+      "is_indexable": true,
+      "published_at": "2026-03-05",
+      "scheduled_at": null,
+      "sort_order": 0
+    },
+    {
+      "guide_code": "career-growth-with-manager",
+      "slug": "career-growth-with-manager",
+      "locale": "zh-CN",
+      "title": "如何与上级共建职业成长路径",
+      "excerpt": "用于提升职业决策质量与执行结果的实操框架。",
+      "category_slug": "workplace-communication",
+      "body_md": "# 如何与上级共建职业成长路径\n\n## 为什么重要\n职业成长是一个长期复利系统。越早建立高质量决策机制，越能降低试错成本并提升未来选择权。\n\n## 实操框架\n1. 明确 12 个月目标岗位及可量化成功标准。\n2. 建立“知识-项目-协作行为”三层能力差距清单。\n3. 以 4 周为一个执行 Sprint，形成可验证证据。\n4. 每季度复盘结果，并结合市场变化与个人匹配度做调整。\n\n## 落地清单\n- 明确岗位目标与行业场景\n- 证据化能力差距地图\n- 作品或项目证明材料\n- 与导师及关键协作方的反馈闭环",
+      "body_html": null,
+      "related_industry_slugs_json": [
+        "legal",
+        "finance"
+      ],
+      "related_jobs": [
+        {
+          "job_code": "frontend-engineer"
+        },
+        {
+          "job_code": "fullstack-engineer"
+        },
+        {
+          "job_code": "cloud-architect"
+        }
+      ],
+      "related_articles": [],
+      "related_personality_profiles": [],
+      "seo_meta": {
+        "seo_title": null,
+        "seo_description": null,
+        "canonical_url": null,
+        "og_title": null,
+        "og_description": null,
+        "og_image_url": null,
+        "twitter_title": null,
+        "twitter_description": null,
+        "twitter_image_url": null,
+        "robots": null,
+        "jsonld_overrides_json": null
+      },
+      "status": "published",
+      "is_public": true,
+      "is_indexable": true,
+      "published_at": "2026-03-05",
+      "scheduled_at": null,
+      "sort_order": 0
+    },
+    {
+      "guide_code": "career-risk-management",
+      "slug": "career-risk-management",
+      "locale": "zh-CN",
+      "title": "职业风险管理指南",
+      "excerpt": "用于提升职业决策质量与执行结果的实操框架。",
+      "category_slug": "career-planning",
+      "body_md": "# 职业风险管理指南\n\n## 为什么重要\n职业成长是一个长期复利系统。越早建立高质量决策机制，越能降低试错成本并提升未来选择权。\n\n## 实操框架\n1. 明确 12 个月目标岗位及可量化成功标准。\n2. 建立“知识-项目-协作行为”三层能力差距清单。\n3. 以 4 周为一个执行 Sprint，形成可验证证据。\n4. 每季度复盘结果，并结合市场变化与个人匹配度做调整。\n\n## 落地清单\n- 明确岗位目标与行业场景\n- 证据化能力差距地图\n- 作品或项目证明材料\n- 与导师及关键协作方的反馈闭环",
+      "body_html": null,
+      "related_industry_slugs_json": [
+        "business",
+        "legal"
+      ],
+      "related_jobs": [
+        {
+          "job_code": "management-consultant"
+        },
+        {
+          "job_code": "business-analyst"
+        },
+        {
+          "job_code": "brand-manager"
+        }
+      ],
+      "related_articles": [],
+      "related_personality_profiles": [],
+      "seo_meta": {
+        "seo_title": null,
+        "seo_description": null,
+        "canonical_url": null,
+        "og_title": null,
+        "og_description": null,
+        "og_image_url": null,
+        "twitter_title": null,
+        "twitter_description": null,
+        "twitter_image_url": null,
+        "robots": null,
+        "jsonld_overrides_json": null
+      },
+      "status": "published",
+      "is_public": true,
+      "is_indexable": true,
+      "published_at": "2026-03-05",
+      "scheduled_at": null,
+      "sort_order": 0
+    },
+    {
+      "guide_code": "career-transition-playbook",
+      "slug": "career-transition-playbook",
+      "locale": "zh-CN",
+      "title": "职业转型行动手册",
+      "excerpt": "用于提升职业决策质量与执行结果的实操框架。",
+      "category_slug": "career-transition",
+      "body_md": "# 职业转型行动手册\n\n## 为什么重要\n职业成长是一个长期复利系统。越早建立高质量决策机制，越能降低试错成本并提升未来选择权。\n\n## 实操框架\n1. 明确 12 个月目标岗位及可量化成功标准。\n2. 建立“知识-项目-协作行为”三层能力差距清单。\n3. 以 4 周为一个执行 Sprint，形成可验证证据。\n4. 每季度复盘结果，并结合市场变化与个人匹配度做调整。\n\n## 落地清单\n- 明确岗位目标与行业场景\n- 证据化能力差距地图\n- 作品或项目证明材料\n- 与导师及关键协作方的反馈闭环",
+      "body_html": null,
+      "related_industry_slugs_json": [
+        "healthcare",
+        "media"
+      ],
+      "related_jobs": [
+        {
+          "job_code": "digital-marketing-manager"
+        },
+        {
+          "job_code": "lawyer"
+        },
+        {
+          "job_code": "teacher"
+        }
+      ],
+      "related_articles": [],
+      "related_personality_profiles": [],
+      "seo_meta": {
+        "seo_title": null,
+        "seo_description": null,
+        "canonical_url": null,
+        "og_title": null,
+        "og_description": null,
+        "og_image_url": null,
+        "twitter_title": null,
+        "twitter_description": null,
+        "twitter_image_url": null,
+        "robots": null,
+        "jsonld_overrides_json": null
+      },
+      "status": "published",
+      "is_public": true,
+      "is_indexable": true,
+      "published_at": "2026-03-05",
+      "scheduled_at": null,
+      "sort_order": 0
+    },
+    {
+      "guide_code": "cross-industry-move-strategy",
+      "slug": "cross-industry-move-strategy",
+      "locale": "zh-CN",
+      "title": "跨行业转型策略",
+      "excerpt": "用于提升职业决策质量与执行结果的实操框架。",
+      "category_slug": "career-transition",
+      "body_md": "# 跨行业转型策略\n\n## 为什么重要\n职业成长是一个长期复利系统。越早建立高质量决策机制，越能降低试错成本并提升未来选择权。\n\n## 实操框架\n1. 明确 12 个月目标岗位及可量化成功标准。\n2. 建立“知识-项目-协作行为”三层能力差距清单。\n3. 以 4 周为一个执行 Sprint，形成可验证证据。\n4. 每季度复盘结果，并结合市场变化与个人匹配度做调整。\n\n## 落地清单\n- 明确岗位目标与行业场景\n- 证据化能力差距地图\n- 作品或项目证明材料\n- 与导师及关键协作方的反馈闭环",
+      "body_html": null,
+      "related_industry_slugs_json": [
+        "design",
+        "operations"
+      ],
+      "related_jobs": [
+        {
+          "job_code": "sales-manager"
+        },
+        {
+          "job_code": "financial-planner"
+        },
+        {
+          "job_code": "content-strategist"
+        }
+      ],
+      "related_articles": [],
+      "related_personality_profiles": [],
+      "seo_meta": {
+        "seo_title": null,
+        "seo_description": null,
+        "canonical_url": null,
+        "og_title": null,
+        "og_description": null,
+        "og_image_url": null,
+        "twitter_title": null,
+        "twitter_description": null,
+        "twitter_image_url": null,
+        "robots": null,
+        "jsonld_overrides_json": null
+      },
+      "status": "published",
+      "is_public": true,
+      "is_indexable": true,
+      "published_at": "2026-03-05",
+      "scheduled_at": null,
+      "sort_order": 0
+    },
+    {
+      "guide_code": "first-90-days-in-new-role",
+      "slug": "first-90-days-in-new-role",
+      "locale": "zh-CN",
+      "title": "新岗位前 90 天行动指南",
+      "excerpt": "用于提升职业决策质量与执行结果的实操框架。",
+      "category_slug": "onboarding",
+      "body_md": "# 新岗位前 90 天行动指南\n\n## 为什么重要\n职业成长是一个长期复利系统。越早建立高质量决策机制，越能降低试错成本并提升未来选择权。\n\n## 实操框架\n1. 明确 12 个月目标岗位及可量化成功标准。\n2. 建立“知识-项目-协作行为”三层能力差距清单。\n3. 以 4 周为一个执行 Sprint，形成可验证证据。\n4. 每季度复盘结果，并结合市场变化与个人匹配度做调整。\n\n## 落地清单\n- 明确岗位目标与行业场景\n- 证据化能力差距地图\n- 作品或项目证明材料\n- 与导师及关键协作方的反馈闭环",
+      "body_html": null,
+      "related_industry_slugs_json": [
+        "operations",
+        "technology"
+      ],
+      "related_jobs": [
+        {
+          "job_code": "machine-learning-engineer"
+        },
+        {
+          "job_code": "backend-engineer"
+        },
+        {
+          "job_code": "cybersecurity-analyst"
+        }
+      ],
+      "related_articles": [],
+      "related_personality_profiles": [],
+      "seo_meta": {
+        "seo_title": null,
+        "seo_description": null,
+        "canonical_url": null,
+        "og_title": null,
+        "og_description": null,
+        "og_image_url": null,
+        "twitter_title": null,
+        "twitter_description": null,
+        "twitter_image_url": null,
+        "robots": null,
+        "jsonld_overrides_json": null
+      },
+      "status": "published",
+      "is_public": true,
+      "is_indexable": true,
+      "published_at": "2026-03-05",
+      "scheduled_at": null,
+      "sort_order": 0
+    },
+    {
+      "guide_code": "from-mbti-to-job-fit",
+      "slug": "from-mbti-to-job-fit",
+      "locale": "zh-CN",
+      "title": "如何将 MBTI 用于职业匹配",
+      "excerpt": "用于提升职业决策质量与执行结果的实操框架。",
+      "category_slug": "assessment-usage",
+      "body_md": "# 如何将 MBTI 用于职业匹配\n\n## 为什么重要\n职业成长是一个长期复利系统。越早建立高质量决策机制，越能降低试错成本并提升未来选择权。\n\n## 实操框架\n1. 明确 12 个月目标岗位及可量化成功标准。\n2. 建立“知识-项目-协作行为”三层能力差距清单。\n3. 以 4 周为一个执行 Sprint，形成可验证证据。\n4. 每季度复盘结果，并结合市场变化与个人匹配度做调整。\n\n## 落地清单\n- 明确岗位目标与行业场景\n- 证据化能力差距地图\n- 作品或项目证明材料\n- 与导师及关键协作方的反馈闭环",
+      "body_html": null,
+      "related_industry_slugs_json": [
+        "business",
+        "legal"
+      ],
+      "related_jobs": [
+        {
+          "job_code": "physician"
+        },
+        {
+          "job_code": "data-scientist"
+        },
+        {
+          "job_code": "frontend-engineer"
+        }
+      ],
+      "related_articles": [
+        {
+          "slug": "mbti-basics"
+        },
+        {
+          "slug": "mbti-growth-guide"
+        },
+        {
+          "slug": "mbti-narrative-portrait"
+        }
+      ],
+      "related_personality_profiles": [
+        {
+          "type_code": "INTJ"
+        },
+        {
+          "type_code": "ENFP"
+        },
+        {
+          "type_code": "ISTJ"
+        },
+        {
+          "type_code": "ENTP"
+        }
+      ],
+      "seo_meta": {
+        "seo_title": null,
+        "seo_description": null,
+        "canonical_url": null,
+        "og_title": null,
+        "og_description": null,
+        "og_image_url": null,
+        "twitter_title": null,
+        "twitter_description": null,
+        "twitter_image_url": null,
+        "robots": null,
+        "jsonld_overrides_json": null
+      },
+      "status": "published",
+      "is_public": true,
+      "is_indexable": true,
+      "published_at": "2026-03-05",
+      "scheduled_at": null,
+      "sort_order": 0
+    },
+    {
+      "guide_code": "how-to-choose-college-major",
+      "slug": "how-to-choose-college-major",
+      "locale": "zh-CN",
+      "title": "如何选择大学专业",
+      "excerpt": "用于提升职业决策质量与执行结果的实操框架。",
+      "category_slug": "education-decision",
+      "body_md": "# 如何选择大学专业\n\n## 为什么重要\n职业成长是一个长期复利系统。越早建立高质量决策机制，越能降低试错成本并提升未来选择权。\n\n## 实操框架\n1. 明确 12 个月目标岗位及可量化成功标准。\n2. 建立“知识-项目-协作行为”三层能力差距清单。\n3. 以 4 周为一个执行 Sprint，形成可验证证据。\n4. 每季度复盘结果，并结合市场变化与个人匹配度做调整。\n\n## 落地清单\n- 明确岗位目标与行业场景\n- 证据化能力差距地图\n- 作品或项目证明材料\n- 与导师及关键协作方的反馈闭环",
+      "body_html": null,
+      "related_industry_slugs_json": [
+        "finance",
+        "business"
+      ],
+      "related_jobs": [
+        {
+          "job_code": "psychological-counselor"
+        },
+        {
+          "job_code": "investment-analyst"
+        },
+        {
+          "job_code": "physician"
+        }
+      ],
+      "related_articles": [],
+      "related_personality_profiles": [],
+      "seo_meta": {
+        "seo_title": null,
+        "seo_description": null,
+        "canonical_url": null,
+        "og_title": null,
+        "og_description": null,
+        "og_image_url": null,
+        "twitter_title": null,
+        "twitter_description": null,
+        "twitter_image_url": null,
+        "robots": null,
+        "jsonld_overrides_json": null
+      },
+      "status": "published",
+      "is_public": true,
+      "is_indexable": true,
+      "published_at": "2026-03-05",
+      "scheduled_at": null,
+      "sort_order": 0
+    },
+    {
+      "guide_code": "how-to-find-right-career-direction",
+      "slug": "how-to-find-right-career-direction",
+      "locale": "zh-CN",
+      "title": "如何找到适合自己的职业方向",
+      "excerpt": "用于提升职业决策质量与执行结果的实操框架。",
+      "category_slug": "career-planning",
+      "body_md": "# 如何找到适合自己的职业方向\n\n## 为什么重要\n职业成长是一个长期复利系统。越早建立高质量决策机制，越能降低试错成本并提升未来选择权。\n\n## 实操框架\n1. 明确 12 个月目标岗位及可量化成功标准。\n2. 建立“知识-项目-协作行为”三层能力差距清单。\n3. 以 4 周为一个执行 Sprint，形成可验证证据。\n4. 每季度复盘结果，并结合市场变化与个人匹配度做调整。\n\n## 落地清单\n- 明确岗位目标与行业场景\n- 证据化能力差距地图\n- 作品或项目证明材料\n- 与导师及关键协作方的反馈闭环",
+      "body_html": null,
+      "related_industry_slugs_json": [
+        "technology",
+        "design"
+      ],
+      "related_jobs": [
+        {
+          "job_code": "ui-ux-designer"
+        },
+        {
+          "job_code": "digital-marketing-manager"
+        },
+        {
+          "job_code": "lawyer"
+        }
+      ],
+      "related_articles": [],
+      "related_personality_profiles": [],
+      "seo_meta": {
+        "seo_title": null,
+        "seo_description": null,
+        "canonical_url": null,
+        "og_title": null,
+        "og_description": null,
+        "og_image_url": null,
+        "twitter_title": null,
+        "twitter_description": null,
+        "twitter_image_url": null,
+        "robots": null,
+        "jsonld_overrides_json": null
+      },
+      "status": "published",
+      "is_public": true,
+      "is_indexable": true,
+      "published_at": "2026-03-05",
+      "scheduled_at": null,
+      "sort_order": 0
+    },
+    {
+      "guide_code": "improve-workplace-competitiveness",
+      "slug": "improve-workplace-competitiveness",
+      "locale": "zh-CN",
+      "title": "如何提升职场竞争力",
+      "excerpt": "用于提升职业决策质量与执行结果的实操框架。",
+      "category_slug": "skill-growth",
+      "body_md": "# 如何提升职场竞争力\n\n## 为什么重要\n职业成长是一个长期复利系统。越早建立高质量决策机制，越能降低试错成本并提升未来选择权。\n\n## 实操框架\n1. 明确 12 个月目标岗位及可量化成功标准。\n2. 建立“知识-项目-协作行为”三层能力差距清单。\n3. 以 4 周为一个执行 Sprint，形成可验证证据。\n4. 每季度复盘结果，并结合市场变化与个人匹配度做调整。\n\n## 落地清单\n- 明确岗位目标与行业场景\n- 证据化能力差距地图\n- 作品或项目证明材料\n- 与导师及关键协作方的反馈闭环",
+      "body_html": null,
+      "related_industry_slugs_json": [
+        "design",
+        "operations"
+      ],
+      "related_jobs": [
+        {
+          "job_code": "lawyer"
+        },
+        {
+          "job_code": "teacher"
+        },
+        {
+          "job_code": "machine-learning-engineer"
+        }
+      ],
+      "related_articles": [],
+      "related_personality_profiles": [],
+      "seo_meta": {
+        "seo_title": null,
+        "seo_description": null,
+        "canonical_url": null,
+        "og_title": null,
+        "og_description": null,
+        "og_image_url": null,
+        "twitter_title": null,
+        "twitter_description": null,
+        "twitter_image_url": null,
+        "robots": null,
+        "jsonld_overrides_json": null
+      },
+      "status": "published",
+      "is_public": true,
+      "is_indexable": true,
+      "published_at": "2026-03-05",
+      "scheduled_at": null,
+      "sort_order": 0
+    },
+    {
+      "guide_code": "interview-strategy-by-role",
+      "slug": "interview-strategy-by-role",
+      "locale": "zh-CN",
+      "title": "按岗位定制面试策略",
+      "excerpt": "用于提升职业决策质量与执行结果的实操框架。",
+      "category_slug": "job-search",
+      "body_md": "# 按岗位定制面试策略\n\n## 为什么重要\n职业成长是一个长期复利系统。越早建立高质量决策机制，越能降低试错成本并提升未来选择权。\n\n## 实操框架\n1. 明确 12 个月目标岗位及可量化成功标准。\n2. 建立“知识-项目-协作行为”三层能力差距清单。\n3. 以 4 周为一个执行 Sprint，形成可验证证据。\n4. 每季度复盘结果，并结合市场变化与个人匹配度做调整。\n\n## 落地清单\n- 明确岗位目标与行业场景\n- 证据化能力差距地图\n- 作品或项目证明材料\n- 与导师及关键协作方的反馈闭环",
+      "body_html": null,
+      "related_industry_slugs_json": [
+        "technology",
+        "design"
+      ],
+      "related_jobs": [
+        {
+          "job_code": "cybersecurity-analyst"
+        },
+        {
+          "job_code": "operations-manager"
+        },
+        {
+          "job_code": "sales-manager"
+        }
+      ],
+      "related_articles": [],
+      "related_personality_profiles": [],
+      "seo_meta": {
+        "seo_title": null,
+        "seo_description": null,
+        "canonical_url": null,
+        "og_title": null,
+        "og_description": null,
+        "og_image_url": null,
+        "twitter_title": null,
+        "twitter_description": null,
+        "twitter_image_url": null,
+        "robots": null,
+        "jsonld_overrides_json": null
+      },
+      "status": "published",
+      "is_public": true,
+      "is_indexable": true,
+      "published_at": "2026-03-05",
+      "scheduled_at": null,
+      "sort_order": 0
+    },
+    {
+      "guide_code": "iq-eq-balance-at-work",
+      "slug": "iq-eq-balance-at-work",
+      "locale": "zh-CN",
+      "title": "IQ 与 EQ 如何协同影响职业表现",
+      "excerpt": "用于提升职业决策质量与执行结果的实操框架。",
+      "category_slug": "assessment-usage",
+      "body_md": "# IQ 与 EQ 如何协同影响职业表现\n\n## 为什么重要\n职业成长是一个长期复利系统。越早建立高质量决策机制，越能降低试错成本并提升未来选择权。\n\n## 实操框架\n1. 明确 12 个月目标岗位及可量化成功标准。\n2. 建立“知识-项目-协作行为”三层能力差距清单。\n3. 以 4 周为一个执行 Sprint，形成可验证证据。\n4. 每季度复盘结果，并结合市场变化与个人匹配度做调整。\n\n## 落地清单\n- 明确岗位目标与行业场景\n- 证据化能力差距地图\n- 作品或项目证明材料\n- 与导师及关键协作方的反馈闭环",
+      "body_html": null,
+      "related_industry_slugs_json": [
+        "consulting",
+        "manufacturing"
+      ],
+      "related_jobs": [
+        {
+          "job_code": "data-scientist"
+        },
+        {
+          "job_code": "frontend-engineer"
+        },
+        {
+          "job_code": "fullstack-engineer"
+        }
+      ],
+      "related_articles": [
+        {
+          "slug": "iq-test-tool-guide"
+        },
+        {
+          "slug": "iq-test-growth-guide"
+        },
+        {
+          "slug": "iq-test-narrative-portrait"
+        },
+        {
+          "slug": "eq-test-tool-guide"
+        }
+      ],
+      "related_personality_profiles": [],
+      "seo_meta": {
+        "seo_title": null,
+        "seo_description": null,
+        "canonical_url": null,
+        "og_title": null,
+        "og_description": null,
+        "og_image_url": null,
+        "twitter_title": null,
+        "twitter_description": null,
+        "twitter_image_url": null,
+        "robots": null,
+        "jsonld_overrides_json": null
+      },
+      "status": "published",
+      "is_public": true,
+      "is_indexable": true,
+      "published_at": "2026-03-05",
+      "scheduled_at": null,
+      "sort_order": 0
+    },
+    {
+      "guide_code": "leader-track-vs-expert-track",
+      "slug": "leader-track-vs-expert-track",
+      "locale": "zh-CN",
+      "title": "管理路径与专家路径如何选择",
+      "excerpt": "用于提升职业决策质量与执行结果的实操框架。",
+      "category_slug": "career-planning",
+      "body_md": "# 管理路径与专家路径如何选择\n\n## 为什么重要\n职业成长是一个长期复利系统。越早建立高质量决策机制，越能降低试错成本并提升未来选择权。\n\n## 实操框架\n1. 明确 12 个月目标岗位及可量化成功标准。\n2. 建立“知识-项目-协作行为”三层能力差距清单。\n3. 以 4 周为一个执行 Sprint，形成可验证证据。\n4. 每季度复盘结果，并结合市场变化与个人匹配度做调整。\n\n## 落地清单\n- 明确岗位目标与行业场景\n- 证据化能力差距地图\n- 作品或项目证明材料\n- 与导师及关键协作方的反馈闭环",
+      "body_html": null,
+      "related_industry_slugs_json": [
+        "education",
+        "consulting"
+      ],
+      "related_jobs": [
+        {
+          "job_code": "hr-business-partner"
+        },
+        {
+          "job_code": "management-consultant"
+        },
+        {
+          "job_code": "business-analyst"
+        }
+      ],
+      "related_articles": [],
+      "related_personality_profiles": [],
+      "seo_meta": {
+        "seo_title": null,
+        "seo_description": null,
+        "canonical_url": null,
+        "og_title": null,
+        "og_description": null,
+        "og_image_url": null,
+        "twitter_title": null,
+        "twitter_description": null,
+        "twitter_image_url": null,
+        "robots": null,
+        "jsonld_overrides_json": null
+      },
+      "status": "published",
+      "is_public": true,
+      "is_indexable": true,
+      "published_at": "2026-03-05",
+      "scheduled_at": null,
+      "sort_order": 0
+    },
+    {
+      "guide_code": "networking-that-actually-works",
+      "slug": "networking-that-actually-works",
+      "locale": "zh-CN",
+      "title": "高质量职业人脉搭建方法",
+      "excerpt": "用于提升职业决策质量与执行结果的实操框架。",
+      "category_slug": "workplace-communication",
+      "body_md": "# 高质量职业人脉搭建方法\n\n## 为什么重要\n职业成长是一个长期复利系统。越早建立高质量决策机制，越能降低试错成本并提升未来选择权。\n\n## 实操框架\n1. 明确 12 个月目标岗位及可量化成功标准。\n2. 建立“知识-项目-协作行为”三层能力差距清单。\n3. 以 4 周为一个执行 Sprint，形成可验证证据。\n4. 每季度复盘结果，并结合市场变化与个人匹配度做调整。\n\n## 落地清单\n- 明确岗位目标与行业场景\n- 证据化能力差距地图\n- 作品或项目证明材料\n- 与导师及关键协作方的反馈闭环",
+      "body_html": null,
+      "related_industry_slugs_json": [
+        "manufacturing",
+        "education"
+      ],
+      "related_jobs": [
+        {
+          "job_code": "fullstack-engineer"
+        },
+        {
+          "job_code": "cloud-architect"
+        },
+        {
+          "job_code": "hr-business-partner"
+        }
+      ],
+      "related_articles": [],
+      "related_personality_profiles": [],
+      "seo_meta": {
+        "seo_title": null,
+        "seo_description": null,
+        "canonical_url": null,
+        "og_title": null,
+        "og_description": null,
+        "og_image_url": null,
+        "twitter_title": null,
+        "twitter_description": null,
+        "twitter_image_url": null,
+        "robots": null,
+        "jsonld_overrides_json": null
+      },
+      "status": "published",
+      "is_public": true,
+      "is_indexable": true,
+      "published_at": "2026-03-05",
+      "scheduled_at": null,
+      "sort_order": 0
+    },
+    {
+      "guide_code": "personal-brand-for-professionals",
+      "slug": "personal-brand-for-professionals",
+      "locale": "zh-CN",
+      "title": "专业人士个人品牌建设",
+      "excerpt": "用于提升职业决策质量与执行结果的实操框架。",
+      "category_slug": "workplace-communication",
+      "body_md": "# 专业人士个人品牌建设\n\n## 为什么重要\n职业成长是一个长期复利系统。越早建立高质量决策机制，越能降低试错成本并提升未来选择权。\n\n## 实操框架\n1. 明确 12 个月目标岗位及可量化成功标准。\n2. 建立“知识-项目-协作行为”三层能力差距清单。\n3. 以 4 周为一个执行 Sprint，形成可验证证据。\n4. 每季度复盘结果，并结合市场变化与个人匹配度做调整。\n\n## 落地清单\n- 明确岗位目标与行业场景\n- 证据化能力差距地图\n- 作品或项目证明材料\n- 与导师及关键协作方的反馈闭环",
+      "body_html": null,
+      "related_industry_slugs_json": [
+        "media",
+        "public-service"
+      ],
+      "related_jobs": [
+        {
+          "job_code": "financial-planner"
+        },
+        {
+          "job_code": "content-strategist"
+        },
+        {
+          "job_code": "researcher"
+        }
+      ],
+      "related_articles": [],
+      "related_personality_profiles": [],
+      "seo_meta": {
+        "seo_title": null,
+        "seo_description": null,
+        "canonical_url": null,
+        "og_title": null,
+        "og_description": null,
+        "og_image_url": null,
+        "twitter_title": null,
+        "twitter_description": null,
+        "twitter_image_url": null,
+        "robots": null,
+        "jsonld_overrides_json": null
+      },
+      "status": "published",
+      "is_public": true,
+      "is_indexable": true,
+      "published_at": "2026-03-05",
+      "scheduled_at": null,
+      "sort_order": 0
+    },
+    {
+      "guide_code": "prevent-burnout-while-growing",
+      "slug": "prevent-burnout-while-growing",
+      "locale": "zh-CN",
+      "title": "成长阶段如何预防职业倦怠",
+      "excerpt": "用于提升职业决策质量与执行结果的实操框架。",
+      "category_slug": "wellbeing",
+      "body_md": "# 成长阶段如何预防职业倦怠\n\n## 为什么重要\n职业成长是一个长期复利系统。越早建立高质量决策机制，越能降低试错成本并提升未来选择权。\n\n## 实操框架\n1. 明确 12 个月目标岗位及可量化成功标准。\n2. 建立“知识-项目-协作行为”三层能力差距清单。\n3. 以 4 周为一个执行 Sprint，形成可验证证据。\n4. 每季度复盘结果，并结合市场变化与个人匹配度做调整。\n\n## 落地清单\n- 明确岗位目标与行业场景\n- 证据化能力差距地图\n- 作品或项目证明材料\n- 与导师及关键协作方的反馈闭环",
+      "body_html": null,
+      "related_industry_slugs_json": [
+        "healthcare",
+        "media"
+      ],
+      "related_jobs": [
+        {
+          "job_code": "operations-manager"
+        },
+        {
+          "job_code": "sales-manager"
+        },
+        {
+          "job_code": "financial-planner"
+        }
+      ],
+      "related_articles": [],
+      "related_personality_profiles": [],
+      "seo_meta": {
+        "seo_title": null,
+        "seo_description": null,
+        "canonical_url": null,
+        "og_title": null,
+        "og_description": null,
+        "og_image_url": null,
+        "twitter_title": null,
+        "twitter_description": null,
+        "twitter_image_url": null,
+        "robots": null,
+        "jsonld_overrides_json": null
+      },
+      "status": "published",
+      "is_public": true,
+      "is_indexable": true,
+      "published_at": "2026-03-05",
+      "scheduled_at": null,
+      "sort_order": 0
+    },
+    {
+      "guide_code": "salary-negotiation-framework",
+      "slug": "salary-negotiation-framework",
+      "locale": "zh-CN",
+      "title": "薪资谈判实战框架",
+      "excerpt": "用于提升职业决策质量与执行结果的实操框架。",
+      "category_slug": "job-search",
+      "body_md": "# 薪资谈判实战框架\n\n## 为什么重要\n职业成长是一个长期复利系统。越早建立高质量决策机制，越能降低试错成本并提升未来选择权。\n\n## 实操框架\n1. 明确 12 个月目标岗位及可量化成功标准。\n2. 建立“知识-项目-协作行为”三层能力差距清单。\n3. 以 4 周为一个执行 Sprint，形成可验证证据。\n4. 每季度复盘结果，并结合市场变化与个人匹配度做调整。\n\n## 落地清单\n- 明确岗位目标与行业场景\n- 证据化能力差距地图\n- 作品或项目证明材料\n- 与导师及关键协作方的反馈闭环",
+      "body_html": null,
+      "related_industry_slugs_json": [
+        "finance",
+        "business"
+      ],
+      "related_jobs": [
+        {
+          "job_code": "cloud-architect"
+        },
+        {
+          "job_code": "hr-business-partner"
+        },
+        {
+          "job_code": "management-consultant"
+        }
+      ],
+      "related_articles": [],
+      "related_personality_profiles": [],
+      "seo_meta": {
+        "seo_title": null,
+        "seo_description": null,
+        "canonical_url": null,
+        "og_title": null,
+        "og_description": null,
+        "og_image_url": null,
+        "twitter_title": null,
+        "twitter_description": null,
+        "twitter_image_url": null,
+        "robots": null,
+        "jsonld_overrides_json": null
+      },
+      "status": "published",
+      "is_public": true,
+      "is_indexable": true,
+      "published_at": "2026-03-05",
+      "scheduled_at": null,
+      "sort_order": 0
+    }
+  ]
+}


### PR DESCRIPTION
Summary
- add the committed baseline import pipeline for CareerGuide
- move CareerGuide source-of-truth preparation from frontend-local content into repeatable backend import inputs

What changed
- add committed baseline files for CareerGuide by locale
- add reader / normalizer / importer classes for guide baseline ingestion
- add a career-guides:import-local-baseline command with dry-run/upsert/filter support
- materialize related jobs/articles/personality links explicitly in baseline files
- add focused import tests covering creation, updates, relation sync, SEO fallback, and revisions

Design choices
- use committed baseline files as the only import source
- follow a hybrid importer pattern based on CareerJob-style command flow and full relation sync
- keep body storage flat with body_md
- keep industry links as slug arrays
- resolve jobs/articles/personality by stable cross-environment keys
- fail fast on unresolved relations instead of silently skipping them

Why this PR is small and safe
- no frontend changes
- no sitemap/runtime changes
- no API changes
- no workspace changes
- only the baseline import pipeline for the next Career CMS object

Validation
- php artisan about
- php artisan route:list
- php artisan migrate
- php artisan career-guides:import-local-baseline --dry-run --locale=en
- php artisan test --filter=CareerGuideBaselineImportTest
- bash scripts/ci_verify_mbti.sh

Rollout note
- this PR intentionally does not depend on runtime web authority or sitemap behavior
- later frontend/runtime integration must be treated separately from baseline import correctness
