### PR TITLE
feat(seo): add CareerGuide to backend sitemap authority

### DIFF
--- a/backend/app/Services/SEO/SitemapGenerator.php
+++ b/backend/app/Services/SEO/SitemapGenerator.php
@@ -3,10 +3,12 @@
 namespace App\Services\SEO;
 
 use App\Models\Article;
+use App\Models\CareerGuide;
 use App\Models\CareerJob;
 use App\Models\PersonalityProfile;
 use App\Models\TopicProfile;
 use App\Services\Cms\ArticleSeoService;
+use App\Services\Cms\CareerGuideSeoService;
 use App\Services\Cms\CareerJobSeoService;
 use App\Services\Cms\PersonalityProfileSeoService;
 use App\Services\Cms\TopicProfileSeoService;
@@ -19,6 +21,7 @@ class SitemapGenerator
 
     public function __construct(
         private readonly ArticleSeoService $articleSeoService,
+        private readonly CareerGuideSeoService $careerGuideSeoService,
         private readonly CareerJobSeoService $careerJobSeoService,
         private readonly PersonalityProfileSeoService $personalityProfileSeoService,
         private readonly TopicProfileSeoService $topicProfileSeoService,
@@ -39,6 +42,7 @@ class SitemapGenerator
             $this->getScaleUrls($locale),
             $this->getArticleUrls(),
             $this->getCareerJobUrls(),
+            $this->getCareerGuideUrls(),
             $this->getPersonalityUrls(),
             $this->getTopicUrls()
         );
@@ -378,6 +382,108 @@ class SitemapGenerator
         return array_values(array_filter($urls, static fn (array $row): bool => ! empty($row['loc'])));
     }
 
+    private function getCareerGuideUrls(): array
+    {
+        return array_merge(
+            $this->getCareerGuideListUrls(),
+            $this->getCareerGuideDetailUrls()
+        );
+    }
+
+    private function getCareerGuideListUrls(): array
+    {
+        $baseUrl = rtrim((string) config('app.frontend_url', config('app.url', '')), '/');
+        if ($baseUrl === '') {
+            return [];
+        }
+
+        $rows = CareerGuide::query()
+            ->withoutGlobalScopes()
+            ->where('org_id', 0)
+            ->where('status', CareerGuide::STATUS_PUBLISHED)
+            ->where('is_public', true)
+            ->where('is_indexable', true)
+            ->whereIn('locale', CareerGuide::SUPPORTED_LOCALES)
+            ->where(static function ($query): void {
+                $query->whereNull('published_at')
+                    ->orWhere('published_at', '<=', now());
+            })
+            ->select(['locale', 'created_at', 'updated_at', 'published_at'])
+            ->orderBy('locale')
+            ->get();
+
+        $listLastModified = [];
+
+        foreach ($rows as $row) {
+            $locale = trim((string) $row->locale);
+            if ($locale === '') {
+                continue;
+            }
+
+            $segment = $this->careerGuideSeoService->mapBackendLocaleToFrontendSegment($locale);
+            $lastmod = $this->resolveCareerGuideLastmod($row);
+
+            if (! isset($listLastModified[$segment]) || $lastmod->gt($listLastModified[$segment])) {
+                $listLastModified[$segment] = $lastmod;
+            }
+        }
+
+        $urls = [];
+        foreach ($listLastModified as $segment => $lastmod) {
+            $urls[] = [
+                'loc' => $baseUrl.'/'.$segment.'/career/guides',
+                'lastmod' => $lastmod->toAtomString(),
+                'slug' => 'career-guides-list:'.$segment,
+                'updated_at' => $lastmod->toDateTimeString(),
+            ];
+        }
+
+        return $urls;
+    }
+
+    private function getCareerGuideDetailUrls(): array
+    {
+        $rows = CareerGuide::query()
+            ->withoutGlobalScopes()
+            ->where('org_id', 0)
+            ->where('status', CareerGuide::STATUS_PUBLISHED)
+            ->where('is_public', true)
+            ->where('is_indexable', true)
+            ->whereIn('locale', CareerGuide::SUPPORTED_LOCALES)
+            ->whereNotNull('slug')
+            ->where('slug', '<>', '')
+            ->where(static function ($query): void {
+                $query->whereNull('published_at')
+                    ->orWhere('published_at', '<=', now());
+            })
+            ->select(['slug', 'locale', 'created_at', 'updated_at', 'published_at'])
+            ->orderBy('locale')
+            ->orderBy('slug')
+            ->get();
+
+        $urls = [];
+
+        foreach ($rows as $row) {
+            $slug = trim((string) $row->slug);
+            $locale = trim((string) $row->locale);
+
+            if ($slug === '' || $locale === '') {
+                continue;
+            }
+
+            $lastmod = $this->resolveCareerGuideLastmod($row);
+
+            $urls[] = [
+                'loc' => $this->careerGuideSeoService->buildCanonicalUrl($row, $locale),
+                'lastmod' => $lastmod->toAtomString(),
+                'slug' => 'career-guides:'.$this->careerGuideSeoService->mapBackendLocaleToFrontendSegment($locale).':'.$slug,
+                'updated_at' => $lastmod->toDateTimeString(),
+            ];
+        }
+
+        return array_values(array_filter($urls, static fn (array $row): bool => ! empty($row['loc'])));
+    }
+
     private function getTopicUrls(): array
     {
         $baseUrl = rtrim((string) config('app.frontend_url', config('app.url', '')), '/');
@@ -522,6 +628,14 @@ class SitemapGenerator
         }
 
         return true;
+    }
+
+    private function resolveCareerGuideLastmod(CareerGuide $guide): Carbon
+    {
+        return $guide->updated_at
+            ?? $guide->published_at
+            ?? $guide->created_at
+            ?? now();
     }
 
     private function buildXml(array $urls): string

--- a/backend/tests/Feature/SEO/SitemapGeneratorTest.php
+++ b/backend/tests/Feature/SEO/SitemapGeneratorTest.php
@@ -3,10 +3,12 @@
 namespace Tests\Feature\SEO;
 
 use App\Models\Article;
+use App\Models\CareerGuide;
 use App\Models\CareerJob;
 use App\Models\PersonalityProfile;
 use App\Models\TopicProfile;
 use App\Services\Cms\ArticleSeoService;
+use App\Services\Cms\CareerGuideSeoService;
 use App\Services\Cms\CareerJobSeoService;
 use App\Services\Cms\PersonalityProfileSeoService;
 use App\Services\Cms\TopicProfileSeoService;
@@ -490,6 +492,127 @@ class SitemapGeneratorTest extends TestCase
         $this->assertStringContainsString(data_get($seoService->buildMeta($eligibleZh, 'zh-CN'), 'canonical'), $xml);
     }
 
+    public function test_generate_includes_only_indexable_global_career_guide_urls_with_locale_aware_paths_and_lastmod(): void
+    {
+        config(['app.frontend_url' => 'https://staging.fermatmind.com']);
+
+        $eligibleEn = $this->createCareerGuide([
+            'guide_code' => 'career-planning-101',
+            'slug' => 'career-planning-101',
+            'locale' => 'en',
+            'title' => 'Career Planning 101',
+            'published_at' => Carbon::create(2026, 3, 9, 9, 0, 0, 'UTC'),
+            'created_at' => Carbon::create(2026, 3, 9, 8, 0, 0, 'UTC'),
+            'updated_at' => Carbon::create(2026, 3, 9, 10, 0, 0, 'UTC'),
+        ]);
+
+        $latestEn = $this->createCareerGuide([
+            'guide_code' => 'job-search-playbook',
+            'slug' => 'job-search-playbook',
+            'locale' => 'en',
+            'title' => 'Job Search Playbook',
+            'published_at' => Carbon::create(2026, 3, 9, 12, 0, 0, 'UTC'),
+            'created_at' => Carbon::create(2026, 3, 9, 11, 0, 0, 'UTC'),
+            'updated_at' => Carbon::create(2026, 3, 9, 14, 0, 0, 'UTC'),
+        ]);
+
+        DB::table('career_guides')->insert([
+            'org_id' => 0,
+            'guide_code' => 'job-fit-guide',
+            'slug' => 'job-fit-guide',
+            'locale' => 'zh-CN',
+            'title' => '岗位匹配指南',
+            'excerpt' => '理解岗位匹配与职业选择。',
+            'category_slug' => 'job-fit',
+            'body_md' => '# 岗位匹配指南',
+            'body_html' => '<h1>岗位匹配指南</h1>',
+            'related_industry_slugs_json' => json_encode(['technology']),
+            'status' => CareerGuide::STATUS_PUBLISHED,
+            'is_public' => true,
+            'is_indexable' => true,
+            'sort_order' => 0,
+            'published_at' => Carbon::create(2026, 3, 9, 16, 0, 0, 'UTC'),
+            'scheduled_at' => null,
+            'schema_version' => 'v1',
+            'created_at' => Carbon::create(2026, 3, 9, 15, 0, 0, 'UTC'),
+            'updated_at' => null,
+        ]);
+
+        $eligibleZh = CareerGuide::query()
+            ->withoutGlobalScopes()
+            ->where('guide_code', 'job-fit-guide')
+            ->where('locale', 'zh-CN')
+            ->firstOrFail();
+
+        $this->createCareerGuide([
+            'guide_code' => 'draft-guide',
+            'slug' => 'draft-guide',
+            'status' => CareerGuide::STATUS_DRAFT,
+            'updated_at' => Carbon::create(2026, 3, 9, 17, 0, 0, 'UTC'),
+        ]);
+        $this->createCareerGuide([
+            'guide_code' => 'private-guide',
+            'slug' => 'private-guide',
+            'is_public' => false,
+            'updated_at' => Carbon::create(2026, 3, 9, 17, 15, 0, 'UTC'),
+        ]);
+        $this->createCareerGuide([
+            'guide_code' => 'noindex-guide',
+            'slug' => 'noindex-guide',
+            'is_indexable' => false,
+            'updated_at' => Carbon::create(2026, 3, 9, 17, 30, 0, 'UTC'),
+        ]);
+        $this->createCareerGuide([
+            'org_id' => 9,
+            'guide_code' => 'tenant-guide',
+            'slug' => 'tenant-guide',
+            'updated_at' => Carbon::create(2026, 3, 9, 17, 45, 0, 'UTC'),
+        ]);
+        $this->createCareerGuide([
+            'guide_code' => 'future-guide',
+            'slug' => 'future-guide',
+            'published_at' => Carbon::now('UTC')->addDay(),
+            'updated_at' => Carbon::create(2026, 3, 9, 18, 0, 0, 'UTC'),
+        ]);
+        $this->createCareerGuide([
+            'guide_code' => 'fr-guide',
+            'slug' => 'fr-guide',
+            'locale' => 'fr',
+            'updated_at' => Carbon::create(2026, 3, 9, 18, 15, 0, 'UTC'),
+        ]);
+
+        $payload = app(SitemapGenerator::class)->generate();
+        $xml = (string) ($payload['xml'] ?? '');
+        $entries = $this->sitemapEntries($xml);
+
+        $enListUrl = 'https://staging.fermatmind.com/en/career/guides';
+        $zhListUrl = 'https://staging.fermatmind.com/zh/career/guides';
+        $seoService = app(CareerGuideSeoService::class);
+        $enDetailUrl = $seoService->buildCanonicalUrl($eligibleEn);
+        $zhDetailUrl = $seoService->buildCanonicalUrl($eligibleZh);
+
+        $this->assertArrayHasKey($enListUrl, $entries);
+        $this->assertArrayHasKey($zhListUrl, $entries);
+        $this->assertNotNull($enDetailUrl);
+        $this->assertNotNull($zhDetailUrl);
+        $this->assertArrayHasKey($enDetailUrl, $entries);
+        $this->assertArrayHasKey($zhDetailUrl, $entries);
+
+        $this->assertStringNotContainsString('https://staging.fermatmind.com/career/guides', $xml);
+        $this->assertStringNotContainsString('https://staging.fermatmind.com/career/guides/career-planning-101', $xml);
+        $this->assertStringNotContainsString('https://staging.fermatmind.com/en/career/guides/draft-guide', $xml);
+        $this->assertStringNotContainsString('https://staging.fermatmind.com/en/career/guides/private-guide', $xml);
+        $this->assertStringNotContainsString('https://staging.fermatmind.com/en/career/guides/noindex-guide', $xml);
+        $this->assertStringNotContainsString('https://staging.fermatmind.com/en/career/guides/tenant-guide', $xml);
+        $this->assertStringNotContainsString('https://staging.fermatmind.com/en/career/guides/future-guide', $xml);
+        $this->assertStringNotContainsString('https://staging.fermatmind.com/fr/career/guides/fr-guide', $xml);
+
+        $this->assertSame($latestEn->updated_at?->toAtomString(), $entries[$enListUrl]);
+        $this->assertSame($eligibleZh->published_at?->toAtomString(), $entries[$zhListUrl]);
+        $this->assertSame($eligibleEn->updated_at?->toAtomString(), $entries[$enDetailUrl]);
+        $this->assertSame($eligibleZh->published_at?->toAtomString(), $entries[$zhDetailUrl]);
+    }
+
     /**
      * @param  array<string, mixed>  $overrides
      */
@@ -593,5 +716,64 @@ class SitemapGeneratorTest extends TestCase
             'created_at' => Carbon::create(2026, 3, 8, 8, 0, 0, 'UTC'),
             'updated_at' => Carbon::create(2026, 3, 8, 8, 0, 0, 'UTC'),
         ], $overrides));
+    }
+
+    /**
+     * @param  array<string, mixed>  $overrides
+     */
+    private function createCareerGuide(array $overrides = []): CareerGuide
+    {
+        /** @var CareerGuide */
+        return CareerGuide::query()->create(array_merge([
+            'org_id' => 0,
+            'guide_code' => 'career-guide',
+            'slug' => 'career-guide',
+            'locale' => 'en',
+            'title' => 'Career guide',
+            'excerpt' => 'Career guide excerpt.',
+            'category_slug' => 'career-planning',
+            'body_md' => '# Career guide',
+            'body_html' => '<h1>Career guide</h1>',
+            'related_industry_slugs_json' => ['technology'],
+            'status' => CareerGuide::STATUS_PUBLISHED,
+            'is_public' => true,
+            'is_indexable' => true,
+            'sort_order' => 0,
+            'published_at' => Carbon::create(2026, 3, 9, 8, 0, 0, 'UTC'),
+            'scheduled_at' => null,
+            'schema_version' => 'v1',
+            'created_at' => Carbon::create(2026, 3, 9, 8, 0, 0, 'UTC'),
+            'updated_at' => Carbon::create(2026, 3, 9, 8, 0, 0, 'UTC'),
+        ], $overrides));
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    private function sitemapEntries(string $xml): array
+    {
+        $document = simplexml_load_string($xml);
+        if ($document === false) {
+            $this->fail('Failed to parse sitemap XML.');
+        }
+
+        $document->registerXPathNamespace('s', 'http://www.sitemaps.org/schemas/sitemap/0.9');
+        $nodes = $document->xpath('/s:urlset/s:url');
+        if ($nodes === false) {
+            return [];
+        }
+
+        $entries = [];
+        foreach ($nodes as $node) {
+            $children = $node->children('http://www.sitemaps.org/schemas/sitemap/0.9');
+            $loc = trim((string) $children->loc);
+            if ($loc === '') {
+                continue;
+            }
+
+            $entries[$loc] = trim((string) $children->lastmod);
+        }
+
+        return $entries;
     }
 }

--- a/backend/tests/Feature/SEO/SitemapXmlTest.php
+++ b/backend/tests/Feature/SEO/SitemapXmlTest.php
@@ -3,6 +3,7 @@
 namespace Tests\Feature\SEO;
 
 use App\Models\Article;
+use App\Models\CareerGuide;
 use App\Models\CareerJob;
 use App\Models\PersonalityProfile;
 use App\Models\TopicProfile;
@@ -285,6 +286,77 @@ class SitemapXmlTest extends TestCase
             'updated_at' => $nowB,
         ]);
 
+        $guideEn = $this->createCareerGuide([
+            'guide_code' => 'career-planning-101',
+            'slug' => 'career-planning-101',
+            'locale' => 'en',
+            'title' => 'Career Planning 101',
+            'published_at' => Carbon::create(2026, 1, 31, 13, 0, 0, 'UTC'),
+            'created_at' => Carbon::create(2026, 1, 31, 12, 50, 0, 'UTC'),
+            'updated_at' => Carbon::create(2026, 1, 31, 13, 30, 0, 'UTC'),
+        ]);
+
+        $guideZhPublishedAt = Carbon::create(2026, 1, 31, 14, 0, 0, 'UTC');
+
+        DB::table('career_guides')->insert([
+            'org_id' => 0,
+            'guide_code' => 'job-fit-guide',
+            'slug' => 'job-fit-guide',
+            'locale' => 'zh-CN',
+            'title' => '岗位匹配指南',
+            'excerpt' => '理解岗位匹配与职业选择。',
+            'category_slug' => 'job-fit',
+            'body_md' => '# 岗位匹配指南',
+            'body_html' => '<h1>岗位匹配指南</h1>',
+            'related_industry_slugs_json' => json_encode(['technology']),
+            'status' => CareerGuide::STATUS_PUBLISHED,
+            'is_public' => true,
+            'is_indexable' => true,
+            'sort_order' => 0,
+            'published_at' => $guideZhPublishedAt,
+            'scheduled_at' => null,
+            'schema_version' => 'v1',
+            'created_at' => Carbon::create(2026, 1, 31, 13, 45, 0, 'UTC'),
+            'updated_at' => null,
+        ]);
+
+        $this->createCareerGuide([
+            'guide_code' => 'guide-draft',
+            'slug' => 'guide-draft',
+            'status' => CareerGuide::STATUS_DRAFT,
+            'updated_at' => Carbon::create(2026, 1, 31, 14, 10, 0, 'UTC'),
+        ]);
+        $this->createCareerGuide([
+            'guide_code' => 'guide-private',
+            'slug' => 'guide-private',
+            'is_public' => false,
+            'updated_at' => Carbon::create(2026, 1, 31, 14, 20, 0, 'UTC'),
+        ]);
+        $this->createCareerGuide([
+            'guide_code' => 'guide-noindex',
+            'slug' => 'guide-noindex',
+            'is_indexable' => false,
+            'updated_at' => Carbon::create(2026, 1, 31, 14, 30, 0, 'UTC'),
+        ]);
+        $this->createCareerGuide([
+            'guide_code' => 'guide-future',
+            'slug' => 'guide-future',
+            'published_at' => Carbon::now('UTC')->addDay(),
+            'updated_at' => Carbon::create(2026, 1, 31, 14, 40, 0, 'UTC'),
+        ]);
+        $this->createCareerGuide([
+            'org_id' => 9,
+            'guide_code' => 'guide-tenant',
+            'slug' => 'guide-tenant',
+            'updated_at' => Carbon::create(2026, 1, 31, 14, 50, 0, 'UTC'),
+        ]);
+        $this->createCareerGuide([
+            'guide_code' => 'guide-fr',
+            'slug' => 'guide-fr',
+            'locale' => 'fr',
+            'updated_at' => Carbon::create(2026, 1, 31, 15, 0, 0, 'UTC'),
+        ]);
+
         $response = $this->get('/sitemap.xml');
 
         $response->assertStatus(200);
@@ -328,11 +400,36 @@ class SitemapXmlTest extends TestCase
         $this->assertStringContainsString('<loc>https://staging.fermatmind.com/en/career/jobs/product-manager</loc>', $body);
         $this->assertStringContainsString('<loc>https://staging.fermatmind.com/zh/career/jobs/product-manager</loc>', $body);
         $this->assertStringNotContainsString('<loc>https://staging.fermatmind.com/en/career/jobs/private-role</loc>', $body);
+        $this->assertStringContainsString('<loc>https://staging.fermatmind.com/en/career/guides</loc>', $body);
+        $this->assertStringContainsString('<loc>https://staging.fermatmind.com/zh/career/guides</loc>', $body);
+        $this->assertStringContainsString('<loc>https://staging.fermatmind.com/en/career/guides/career-planning-101</loc>', $body);
+        $this->assertStringContainsString('<loc>https://staging.fermatmind.com/zh/career/guides/job-fit-guide</loc>', $body);
+        $this->assertStringNotContainsString('<loc>https://staging.fermatmind.com/career/guides/career-planning-101</loc>', $body);
+        $this->assertStringNotContainsString('<loc>https://staging.fermatmind.com/en/career/guides/guide-draft</loc>', $body);
+        $this->assertStringNotContainsString('<loc>https://staging.fermatmind.com/en/career/guides/guide-private</loc>', $body);
+        $this->assertStringNotContainsString('<loc>https://staging.fermatmind.com/en/career/guides/guide-noindex</loc>', $body);
+        $this->assertStringNotContainsString('<loc>https://staging.fermatmind.com/en/career/guides/guide-future</loc>', $body);
+        $this->assertStringNotContainsString('<loc>https://staging.fermatmind.com/en/career/guides/guide-tenant</loc>', $body);
+        $this->assertStringNotContainsString('<loc>https://staging.fermatmind.com/fr/career/guides/guide-fr</loc>', $body);
         $this->assertStringContainsString('<changefreq>weekly</changefreq>', $body);
         $this->assertStringContainsString('<priority>0.7</priority>', $body);
         $this->assertStringContainsString('<lastmod>2026-01-30</lastmod>', $body);
         $this->assertStringContainsString('<lastmod>2026-01-31</lastmod>', $body);
         $this->assertSame(1, substr_count($body, '<loc>'.$prefix.'alpha</loc>'));
+
+        $entries = $this->sitemapEntries($body);
+        $this->assertSame(
+            $guideEn->updated_at?->toAtomString(),
+            $entries['https://staging.fermatmind.com/en/career/guides/career-planning-101'] ?? null
+        );
+        $this->assertSame(
+            $guideZhPublishedAt->toAtomString(),
+            $entries['https://staging.fermatmind.com/zh/career/guides'] ?? null
+        );
+        $this->assertSame(
+            $guideZhPublishedAt->toAtomString(),
+            $entries['https://staging.fermatmind.com/zh/career/guides/job-fit-guide'] ?? null
+        );
 
         $second = $this->withHeaders(['If-None-Match' => $etag])->get('/sitemap.xml');
         $second->assertStatus(304);
@@ -344,5 +441,64 @@ class SitemapXmlTest extends TestCase
         $second->assertHeader('ETag', $etag);
         $second->assertHeaderMissing('Set-Cookie');
         $this->assertSame('', (string) $second->getContent());
+    }
+
+    /**
+     * @param  array<string, mixed>  $overrides
+     */
+    private function createCareerGuide(array $overrides = []): CareerGuide
+    {
+        /** @var CareerGuide */
+        return CareerGuide::query()->create(array_merge([
+            'org_id' => 0,
+            'guide_code' => 'career-guide',
+            'slug' => 'career-guide',
+            'locale' => 'en',
+            'title' => 'Career guide',
+            'excerpt' => 'Career guide excerpt.',
+            'category_slug' => 'career-planning',
+            'body_md' => '# Career guide',
+            'body_html' => '<h1>Career guide</h1>',
+            'related_industry_slugs_json' => ['technology'],
+            'status' => CareerGuide::STATUS_PUBLISHED,
+            'is_public' => true,
+            'is_indexable' => true,
+            'sort_order' => 0,
+            'published_at' => Carbon::create(2026, 1, 31, 12, 40, 0, 'UTC'),
+            'scheduled_at' => null,
+            'schema_version' => 'v1',
+            'created_at' => Carbon::create(2026, 1, 31, 12, 30, 0, 'UTC'),
+            'updated_at' => Carbon::create(2026, 1, 31, 12, 40, 0, 'UTC'),
+        ], $overrides));
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    private function sitemapEntries(string $xml): array
+    {
+        $document = simplexml_load_string($xml);
+        if ($document === false) {
+            $this->fail('Failed to parse sitemap XML.');
+        }
+
+        $document->registerXPathNamespace('s', 'http://www.sitemaps.org/schemas/sitemap/0.9');
+        $nodes = $document->xpath('/s:urlset/s:url');
+        if ($nodes === false) {
+            return [];
+        }
+
+        $entries = [];
+        foreach ($nodes as $node) {
+            $children = $node->children('http://www.sitemaps.org/schemas/sitemap/0.9');
+            $loc = trim((string) $children->loc);
+            if ($loc === '') {
+                continue;
+            }
+
+            $entries[$loc] = trim((string) $children->lastmod);
+        }
+
+        return $entries;
     }
 }


### PR DESCRIPTION
CareerGuide runtime is already CMS-first, but backend `/sitemap.xml` still omitted CareerGuide list/detail URLs. That left backend sitemap authority incomplete for guide content and blocked the backend-first sitemap rollout for this domain. This PR closes that gap by teaching the backend sitemap generator to emit localized public/indexable CareerGuide URLs without changing public API or runtime routing.

## Summary
- add CareerGuide list/detail URLs to backend sitemap authority
- make backend `/sitemap.xml` capable of emitting localized guide sitemap coverage

## What changed
- extend `SitemapGenerator` with localized CareerGuide list/detail URLs
- filter guides by published/public/indexable/public-org constraints
- add sitemap generator and XML coverage for CareerGuide

## Design choices
- keep backend `/sitemap.xml` as the authoritative guide sitemap source for this step
- use localized frontend paths only: `/en/career/guides` and `/zh/career/guides`
- align sitemap inclusion with public plus indexable semantics rather than minimum readable detail semantics
- preserve existing generator structure and ordering with a minimal insertion after career jobs
- defer frontend static sitemap cleanup, llms cleanup, and next-sitemap cleanup to G06B

## Why this PR is small and safe
- no frontend changes
- no API changes
- no workspace/importer changes
- only backend sitemap authority for CareerGuide
- no route, controller, model, or migration edits

## Validation
- `php artisan about`
- `php artisan route:list --path=sitemap.xml --except-vendor`
- `php artisan migrate`
- `php artisan test --filter='(SitemapGenerator|SitemapXml)'`
- `php artisan filament:assets`
- `npm run build`
- `bash scripts/ci_verify_mbti.sh`

## Rollout note
- G06A only makes backend `/sitemap.xml` capable of emitting CareerGuide URLs
- G06A does not mean public `/sitemap.xml` has already switched to backend authority
- staging/backend `/sitemap.xml` is schema-drift sensitive, so target environments must have the G01 CareerGuide tables before runtime code is deployed
- migration must land before runtime code
- do not merge frontend cleanup / G06B until public `/sitemap.xml` is confirmed to be served by backend authority and to include CareerGuide URLs
- the latest PM2 direct probe shows relative 308 behavior recovered, so runtime origin leakage is no longer the main G06A blocker, but public-domain acceptance still needs separate confirmation
