### PR TITLE
[codex] feat(mbti): add canonical public result authority scaffold

### DIFF
--- a/backend/app/Contracts/MbtiPublicResultAuthoritySource.php
+++ b/backend/app/Contracts/MbtiPublicResultAuthoritySource.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Contracts;
+
+use App\Support\Mbti\MbtiPublicTypeIdentity;
+
+interface MbtiPublicResultAuthoritySource
+{
+    public function sourceKey(): string;
+
+    /**
+     * @return array{
+     *   resolved_type_code:string,
+     *   profile?:array<string,mixed>,
+     *   sections?:array<string,array<string,mixed>>,
+     *   premium_teaser?:array<string,array<string,mixed>>,
+     *   seo_meta?:array<string,mixed>,
+     *   meta?:array<string,mixed>
+     * }
+     */
+    public function read(MbtiPublicTypeIdentity $identity): array;
+}

--- a/backend/app/Contracts/MbtiPublicResultPayloadBuilder.php
+++ b/backend/app/Contracts/MbtiPublicResultPayloadBuilder.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Contracts;
+
+use App\Support\Mbti\MbtiPublicTypeIdentity;
+
+interface MbtiPublicResultPayloadBuilder
+{
+    /**
+     * @return array<string, mixed>
+     */
+    public function build(MbtiPublicTypeIdentity $identity, MbtiPublicResultAuthoritySource $source): array;
+}

--- a/backend/app/Services/Mbti/Adapters/MbtiReportAuthoritySourceAdapter.php
+++ b/backend/app/Services/Mbti/Adapters/MbtiReportAuthoritySourceAdapter.php
@@ -1,0 +1,147 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\Mbti\Adapters;
+
+use App\Contracts\MbtiPublicResultAuthoritySource;
+use App\Support\Mbti\MbtiCanonicalSectionRegistry;
+use App\Support\Mbti\MbtiPublicTypeIdentity;
+
+final readonly class MbtiReportAuthoritySourceAdapter implements MbtiPublicResultAuthoritySource
+{
+    /**
+     * @param  array<string, mixed>  $reportPayload
+     */
+    public function __construct(
+        private array $reportPayload,
+        private string $sourceKeyLabel = 'report.v0_3.pilot',
+    ) {}
+
+    public function sourceKey(): string
+    {
+        return $this->sourceKeyLabel;
+    }
+
+    /**
+     * @return array{
+     *   resolved_type_code:string,
+     *   profile:array<string,mixed>,
+     *   sections:array<string,array<string,mixed>>,
+     *   premium_teaser:array<string,array<string,mixed>>,
+     *   seo_meta:array<string,mixed>,
+     *   meta:array<string,mixed>
+     * }
+     */
+    public function read(MbtiPublicTypeIdentity $identity): array
+    {
+        $profile = $this->arrayOrEmpty($this->reportPayload['profile'] ?? null);
+        $layers = $this->arrayOrEmpty($this->reportPayload['layers'] ?? null);
+        $identityLayer = $this->arrayOrEmpty($layers['identity'] ?? null);
+        $sections = $this->arrayOrEmpty($this->reportPayload['sections'] ?? null);
+
+        return [
+            'resolved_type_code' => (string) ($profile['type_code'] ?? $identity->typeCode),
+            'profile' => [
+                'hero_summary' => $profile['short_summary'] ?? null,
+            ],
+            'sections' => [
+                'overview' => [
+                    'title' => $identityLayer['title'] ?? 'Overview',
+                    'body' => $identityLayer['one_liner'] ?? null,
+                ],
+                'trait_overview' => [
+                    'payload' => [
+                        'summary' => $identityLayer['subtitle'] ?? null,
+                        'dimensions' => $this->buildTraitDimensions(),
+                    ],
+                ],
+                'career.summary' => [
+                    'body' => $this->extractFirstCardBody($sections['career'] ?? null),
+                ],
+                'growth.summary' => [
+                    'body' => $this->extractFirstCardBody($sections['growth'] ?? null),
+                ],
+                'relationships.summary' => [
+                    'body' => $this->extractFirstCardBody($sections['relationships'] ?? null),
+                ],
+            ],
+            'premium_teaser' => [
+                'growth.motivators' => [
+                    'render_variant' => MbtiCanonicalSectionRegistry::RENDER_VARIANT_PREMIUM_TEASER,
+                    'title' => 'Growth motivators',
+                    'teaser' => null,
+                ],
+                'growth.drainers' => [
+                    'render_variant' => MbtiCanonicalSectionRegistry::RENDER_VARIANT_PREMIUM_TEASER,
+                    'title' => 'Growth drainers',
+                    'teaser' => null,
+                ],
+                'relationships.rel_advantages' => [
+                    'render_variant' => MbtiCanonicalSectionRegistry::RENDER_VARIANT_PREMIUM_TEASER,
+                    'title' => 'Relationship advantages',
+                    'teaser' => null,
+                ],
+                'relationships.rel_risks' => [
+                    'render_variant' => MbtiCanonicalSectionRegistry::RENDER_VARIANT_PREMIUM_TEASER,
+                    'title' => 'Relationship risks',
+                    'teaser' => null,
+                ],
+            ],
+            'seo_meta' => [],
+            'meta' => [
+                'adapter' => $this->sourceKey(),
+                'pilot' => true,
+            ],
+        ];
+    }
+
+    /**
+     * @return list<array<string, mixed>>
+     */
+    private function buildTraitDimensions(): array
+    {
+        $scoresPct = $this->arrayOrEmpty($this->reportPayload['scores_pct'] ?? null);
+        $dimensions = [];
+
+        foreach ($scoresPct as $axisCode => $pct) {
+            $axisKey = strtoupper(trim((string) $axisCode));
+
+            $dimensions[] = [
+                'axis_code' => $axisKey,
+                'normalized_axis_code' => MbtiCanonicalSectionRegistry::normalizeTraitAxisCode($axisKey),
+                'percent' => is_numeric($pct) ? (float) $pct : null,
+            ];
+        }
+
+        return $dimensions;
+    }
+
+    private function extractFirstCardBody(mixed $section): ?string
+    {
+        $sectionData = $this->arrayOrEmpty($section);
+        $cards = $sectionData['cards'] ?? null;
+        if (! is_array($cards) || $cards === []) {
+            return null;
+        }
+
+        $firstCard = is_array($cards[0] ?? null) ? $cards[0] : [];
+
+        foreach (['body', 'summary', 'title'] as $key) {
+            $value = trim((string) ($firstCard[$key] ?? ''));
+            if ($value !== '') {
+                return $value;
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function arrayOrEmpty(mixed $value): array
+    {
+        return is_array($value) ? $value : [];
+    }
+}

--- a/backend/app/Services/Mbti/MbtiCanonicalPublicResultPayloadBuilder.php
+++ b/backend/app/Services/Mbti/MbtiCanonicalPublicResultPayloadBuilder.php
@@ -1,0 +1,177 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\Mbti;
+
+use App\Contracts\MbtiPublicResultAuthoritySource;
+use App\Contracts\MbtiPublicResultPayloadBuilder;
+use App\Support\Mbti\MbtiCanonicalPublicResultSchema;
+use App\Support\Mbti\MbtiCanonicalSectionRegistry;
+use App\Support\Mbti\MbtiPublicTypeIdentity;
+use InvalidArgumentException;
+use RuntimeException;
+
+final class MbtiCanonicalPublicResultPayloadBuilder implements MbtiPublicResultPayloadBuilder
+{
+    /**
+     * @return array<string, mixed>
+     */
+    public function build(MbtiPublicTypeIdentity $identity, MbtiPublicResultAuthoritySource $source): array
+    {
+        $authority = $source->read($identity);
+        $resolvedTypeCode = strtoupper(trim((string) ($authority['resolved_type_code'] ?? '')));
+
+        if ($resolvedTypeCode === '') {
+            throw new InvalidArgumentException('MBTI canonical public payload builder requires a resolved_type_code from the authority source.');
+        }
+
+        $resolvedIdentity = MbtiPublicTypeIdentity::fromTypeCode($resolvedTypeCode);
+        if (! $resolvedIdentity->equals($identity)) {
+            throw new RuntimeException(sprintf(
+                'MBTI canonical public payload builder cannot rewrite runtime type identity from [%s] to [%s].',
+                $identity->typeCode,
+                $resolvedIdentity->typeCode,
+            ));
+        }
+
+        $payload = MbtiCanonicalPublicResultSchema::scaffoldPayload($identity, $source->sourceKey());
+        $profile = $this->arrayOrEmpty($authority['profile'] ?? null);
+        $payload['profile']['hero_summary'] = $this->nullableText($profile['hero_summary'] ?? null);
+
+        foreach ($this->arrayOrEmpty($authority['sections'] ?? null) as $sectionKey => $sectionData) {
+            if (! is_array($sectionData)) {
+                throw new InvalidArgumentException(sprintf(
+                    'MBTI canonical section payload for [%s] must be an array.',
+                    $sectionKey,
+                ));
+            }
+
+            $definition = MbtiCanonicalSectionRegistry::definition((string) $sectionKey);
+            if (($definition['bucket'] ?? null) === MbtiCanonicalSectionRegistry::BUCKET_PREMIUM_TEASER) {
+                throw new InvalidArgumentException(sprintf(
+                    'MBTI premium teaser block [%s] must be supplied through the premium_teaser bucket.',
+                    $sectionKey,
+                ));
+            }
+
+            $payload['sections'][(string) $sectionKey] = $this->mergeSectionEntry(
+                $payload['sections'][(string) $sectionKey],
+                $sectionData,
+            );
+        }
+
+        foreach ($this->arrayOrEmpty($authority['premium_teaser'] ?? null) as $sectionKey => $sectionData) {
+            if (! is_array($sectionData)) {
+                throw new InvalidArgumentException(sprintf(
+                    'MBTI premium teaser payload for [%s] must be an array.',
+                    $sectionKey,
+                ));
+            }
+
+            $definition = MbtiCanonicalSectionRegistry::definition((string) $sectionKey);
+            if (($definition['bucket'] ?? null) !== MbtiCanonicalSectionRegistry::BUCKET_PREMIUM_TEASER) {
+                throw new InvalidArgumentException(sprintf(
+                    'MBTI canonical section [%s] is not a premium teaser key.',
+                    $sectionKey,
+                ));
+            }
+
+            $payload['premium_teaser'][(string) $sectionKey] = $this->mergePremiumTeaserEntry(
+                $payload['premium_teaser'][(string) $sectionKey],
+                $sectionData,
+            );
+        }
+
+        foreach ($this->arrayOrEmpty($authority['seo_meta'] ?? null) as $key => $value) {
+            if (! array_key_exists((string) $key, $payload['seo_meta'])) {
+                continue;
+            }
+
+            $payload['seo_meta'][(string) $key] = $this->nullableText($value);
+        }
+
+        $payload['_meta']['authority_meta'] = $this->arrayOrEmpty($authority['meta'] ?? null);
+
+        return $payload;
+    }
+
+    /**
+     * @param  array<string, mixed>  $template
+     * @param  array<string, mixed>  $source
+     * @return array<string, mixed>
+     */
+    private function mergeSectionEntry(array $template, array $source): array
+    {
+        $this->assertRenderVariantMatches((string) $template['section_key'], $template, $source);
+
+        $template['title'] = $this->nullableText($source['title'] ?? $template['title'] ?? null);
+        $template['body'] = $this->nullableText($source['body'] ?? $template['body'] ?? null);
+
+        if (array_key_exists('payload', $source)) {
+            $template['payload'] = is_array($source['payload']) ? $source['payload'] : null;
+        }
+
+        return $template;
+    }
+
+    /**
+     * @param  array<string, mixed>  $template
+     * @param  array<string, mixed>  $source
+     * @return array<string, mixed>
+     */
+    private function mergePremiumTeaserEntry(array $template, array $source): array
+    {
+        $this->assertRenderVariantMatches((string) $template['section_key'], $template, $source);
+
+        $template['title'] = $this->nullableText($source['title'] ?? $template['title'] ?? null);
+        $template['teaser'] = $this->nullableText($source['teaser'] ?? $template['teaser'] ?? null);
+
+        if (array_key_exists('payload', $source)) {
+            $template['payload'] = is_array($source['payload']) ? $source['payload'] : null;
+        }
+
+        return $template;
+    }
+
+    /**
+     * @param  array<string, mixed>  $template
+     * @param  array<string, mixed>  $source
+     */
+    private function assertRenderVariantMatches(string $sectionKey, array $template, array $source): void
+    {
+        $runtimeVariant = trim((string) ($source['render_variant'] ?? ''));
+        if ($runtimeVariant === '') {
+            return;
+        }
+
+        $expectedVariant = (string) ($template['render_variant'] ?? '');
+        if ($runtimeVariant !== $expectedVariant) {
+            throw new InvalidArgumentException(sprintf(
+                'MBTI canonical section [%s] requires render_variant [%s], got [%s].',
+                $sectionKey,
+                $expectedVariant,
+                $runtimeVariant,
+            ));
+        }
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function arrayOrEmpty(mixed $value): array
+    {
+        return is_array($value) ? $value : [];
+    }
+
+    private function nullableText(mixed $value): ?string
+    {
+        if (! is_scalar($value)) {
+            return null;
+        }
+
+        $normalized = trim((string) $value);
+
+        return $normalized === '' ? null : $normalized;
+    }
+}

--- a/backend/app/Support/Mbti/MbtiCanonicalPublicResultSchema.php
+++ b/backend/app/Support/Mbti/MbtiCanonicalPublicResultSchema.php
@@ -1,0 +1,100 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Support\Mbti;
+
+final class MbtiCanonicalPublicResultSchema
+{
+    public const SCHEMA_VERSION = 'mbti-public-canonical-pr1';
+
+    /**
+     * @return array<string, array{path:string,render_variant:string}>
+     */
+    public static function profileFieldDefinitions(): array
+    {
+        return [
+            'hero_summary' => [
+                'path' => 'profile.hero_summary',
+                'render_variant' => MbtiCanonicalSectionRegistry::RENDER_VARIANT_RICH_TEXT,
+            ],
+        ];
+    }
+
+    /**
+     * @return list<string>
+     */
+    public static function seoFieldKeys(): array
+    {
+        return [
+            'seo_title',
+            'seo_description',
+            'canonical_url',
+            'og_title',
+            'og_description',
+            'og_image_url',
+            'twitter_title',
+            'twitter_description',
+            'twitter_image_url',
+            'robots',
+        ];
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public static function scaffoldPayload(MbtiPublicTypeIdentity $identity, string $authoritySource): array
+    {
+        $sections = [];
+        $premiumTeaser = [];
+
+        foreach (MbtiCanonicalSectionRegistry::definitions() as $sectionKey => $definition) {
+            $entry = [
+                'section_key' => $sectionKey,
+                'render_variant' => (string) $definition['render_variant'],
+                'title' => null,
+                'body' => null,
+                'payload' => $sectionKey === 'trait_overview'
+                    ? [
+                        'summary' => null,
+                        'dimensions' => [],
+                        'axis_aliases' => MbtiCanonicalSectionRegistry::traitOverviewAxisAliases(),
+                    ]
+                    : null,
+            ];
+
+            if (($definition['bucket'] ?? null) === MbtiCanonicalSectionRegistry::BUCKET_PREMIUM_TEASER) {
+                $premiumTeaser[$sectionKey] = [
+                    'section_key' => $sectionKey,
+                    'render_variant' => (string) $definition['render_variant'],
+                    'title' => null,
+                    'teaser' => null,
+                    'payload' => null,
+                    'is_premium_teaser' => true,
+                ];
+
+                continue;
+            }
+
+            $sections[$sectionKey] = $entry;
+        }
+
+        return [
+            'type_code' => $identity->typeCode,
+            'base_type_code' => $identity->baseTypeCode,
+            'variant' => $identity->variant,
+            'profile' => [
+                'hero_summary' => null,
+            ],
+            'sections' => $sections,
+            'premium_teaser' => $premiumTeaser,
+            'seo_meta' => array_fill_keys(self::seoFieldKeys(), null),
+            '_meta' => [
+                'authority_source' => $authoritySource,
+                'schema_version' => self::SCHEMA_VERSION,
+                'scaffold' => true,
+                'resolved_type_code' => $identity->typeCode,
+            ],
+        ];
+    }
+}

--- a/backend/app/Support/Mbti/MbtiCanonicalSectionRegistry.php
+++ b/backend/app/Support/Mbti/MbtiCanonicalSectionRegistry.php
@@ -1,0 +1,221 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Support\Mbti;
+
+use InvalidArgumentException;
+
+final class MbtiCanonicalSectionRegistry
+{
+    public const BUCKET_SECTIONS = 'sections';
+
+    public const BUCKET_PREMIUM_TEASER = 'premium_teaser';
+
+    public const RENDER_VARIANT_RICH_TEXT = 'rich_text';
+
+    public const RENDER_VARIANT_BULLET_LIST = 'bullet_list';
+
+    public const RENDER_VARIANT_TRAIT_DIMENSION_GRID = 'trait_dimension_grid';
+
+    public const RENDER_VARIANT_PREFERRED_ROLE_LIST = 'preferred_role_list';
+
+    public const RENDER_VARIANT_PREMIUM_TEASER = 'premium_teaser';
+
+    /**
+     * @return array<string, array{
+     *   bucket:string,
+     *   render_variant:string,
+     *   group:string,
+     *   premium_teaser?:bool,
+     *   payload_schema?:array<string,mixed>
+     * }>
+     */
+    public static function definitions(): array
+    {
+        return [
+            'letters_intro' => [
+                'bucket' => self::BUCKET_SECTIONS,
+                'render_variant' => self::RENDER_VARIANT_RICH_TEXT,
+                'group' => 'top',
+            ],
+            'overview' => [
+                'bucket' => self::BUCKET_SECTIONS,
+                'render_variant' => self::RENDER_VARIANT_RICH_TEXT,
+                'group' => 'top',
+            ],
+            'trait_overview' => [
+                'bucket' => self::BUCKET_SECTIONS,
+                'render_variant' => self::RENDER_VARIANT_TRAIT_DIMENSION_GRID,
+                'group' => 'trait_overview',
+                'payload_schema' => [
+                    'summary' => 'string|null',
+                    'dimensions' => 'list<trait_dimension>',
+                    'axis_aliases' => self::traitOverviewAxisAliases(),
+                ],
+            ],
+            'career.summary' => [
+                'bucket' => self::BUCKET_SECTIONS,
+                'render_variant' => self::RENDER_VARIANT_RICH_TEXT,
+                'group' => 'career',
+            ],
+            'career.advantages' => [
+                'bucket' => self::BUCKET_SECTIONS,
+                'render_variant' => self::RENDER_VARIANT_BULLET_LIST,
+                'group' => 'career',
+            ],
+            'career.weaknesses' => [
+                'bucket' => self::BUCKET_SECTIONS,
+                'render_variant' => self::RENDER_VARIANT_BULLET_LIST,
+                'group' => 'career',
+            ],
+            'career.preferred_roles' => [
+                'bucket' => self::BUCKET_SECTIONS,
+                'render_variant' => self::RENDER_VARIANT_PREFERRED_ROLE_LIST,
+                'group' => 'career',
+            ],
+            'career.upgrade_suggestions' => [
+                'bucket' => self::BUCKET_SECTIONS,
+                'render_variant' => self::RENDER_VARIANT_BULLET_LIST,
+                'group' => 'career',
+            ],
+            'growth.summary' => [
+                'bucket' => self::BUCKET_SECTIONS,
+                'render_variant' => self::RENDER_VARIANT_RICH_TEXT,
+                'group' => 'growth',
+            ],
+            'growth.strengths' => [
+                'bucket' => self::BUCKET_SECTIONS,
+                'render_variant' => self::RENDER_VARIANT_BULLET_LIST,
+                'group' => 'growth',
+            ],
+            'growth.weaknesses' => [
+                'bucket' => self::BUCKET_SECTIONS,
+                'render_variant' => self::RENDER_VARIANT_BULLET_LIST,
+                'group' => 'growth',
+            ],
+            'growth.motivators' => [
+                'bucket' => self::BUCKET_PREMIUM_TEASER,
+                'render_variant' => self::RENDER_VARIANT_PREMIUM_TEASER,
+                'group' => 'growth',
+                'premium_teaser' => true,
+            ],
+            'growth.drainers' => [
+                'bucket' => self::BUCKET_PREMIUM_TEASER,
+                'render_variant' => self::RENDER_VARIANT_PREMIUM_TEASER,
+                'group' => 'growth',
+                'premium_teaser' => true,
+            ],
+            'relationships.summary' => [
+                'bucket' => self::BUCKET_SECTIONS,
+                'render_variant' => self::RENDER_VARIANT_RICH_TEXT,
+                'group' => 'relationships',
+            ],
+            'relationships.strengths' => [
+                'bucket' => self::BUCKET_SECTIONS,
+                'render_variant' => self::RENDER_VARIANT_BULLET_LIST,
+                'group' => 'relationships',
+            ],
+            'relationships.weaknesses' => [
+                'bucket' => self::BUCKET_SECTIONS,
+                'render_variant' => self::RENDER_VARIANT_BULLET_LIST,
+                'group' => 'relationships',
+            ],
+            'relationships.rel_advantages' => [
+                'bucket' => self::BUCKET_PREMIUM_TEASER,
+                'render_variant' => self::RENDER_VARIANT_PREMIUM_TEASER,
+                'group' => 'relationships',
+                'premium_teaser' => true,
+            ],
+            'relationships.rel_risks' => [
+                'bucket' => self::BUCKET_PREMIUM_TEASER,
+                'render_variant' => self::RENDER_VARIANT_PREMIUM_TEASER,
+                'group' => 'relationships',
+                'premium_teaser' => true,
+            ],
+        ];
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    public static function traitOverviewAxisAliases(): array
+    {
+        return [
+            'EI' => 'EI',
+            'NS' => 'SN',
+            'SN' => 'SN',
+            'FT' => 'TF',
+            'TF' => 'TF',
+            'JP' => 'JP',
+            'AT' => 'AT',
+        ];
+    }
+
+    public static function normalizeTraitAxisCode(string $axisCode): string
+    {
+        $normalized = strtoupper(trim($axisCode));
+        $mapped = self::traitOverviewAxisAliases()[$normalized] ?? null;
+
+        if ($mapped === null) {
+            throw new InvalidArgumentException(sprintf(
+                'Unsupported MBTI trait_overview axis code [%s].',
+                $axisCode,
+            ));
+        }
+
+        return $mapped;
+    }
+
+    /**
+     * @return list<string>
+     */
+    public static function keys(): array
+    {
+        return array_keys(self::definitions());
+    }
+
+    /**
+     * @return list<string>
+     */
+    public static function renderVariants(): array
+    {
+        return array_values(array_unique(array_map(
+            static fn (array $definition): string => (string) $definition['render_variant'],
+            self::definitions(),
+        )));
+    }
+
+    /**
+     * @return list<string>
+     */
+    public static function premiumTeaserKeys(): array
+    {
+        return array_values(array_keys(array_filter(
+            self::definitions(),
+            static fn (array $definition): bool => (($definition['bucket'] ?? null) === self::BUCKET_PREMIUM_TEASER),
+        )));
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public static function definition(string $sectionKey): array
+    {
+        $definition = self::definitions()[$sectionKey] ?? null;
+
+        if ($definition === null) {
+            throw new InvalidArgumentException(sprintf(
+                'Unsupported MBTI canonical section key [%s].',
+                $sectionKey,
+            ));
+        }
+
+        return $definition;
+    }
+
+    public static function isPremiumTeaser(string $sectionKey): bool
+    {
+        return (self::definition($sectionKey)['bucket'] ?? null) === self::BUCKET_PREMIUM_TEASER;
+    }
+}

--- a/backend/app/Support/Mbti/MbtiPublicTypeIdentity.php
+++ b/backend/app/Support/Mbti/MbtiPublicTypeIdentity.php
@@ -1,0 +1,66 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Support\Mbti;
+
+use InvalidArgumentException;
+
+final readonly class MbtiPublicTypeIdentity
+{
+    private const TYPE_CODE_PATTERN = '/^(?<base>[EI][SN][TF][JP])-(?<variant>[AT])$/';
+
+    public function __construct(
+        public string $typeCode,
+        public string $baseTypeCode,
+        public string $variant,
+    ) {}
+
+    public static function fromTypeCode(string $typeCode): self
+    {
+        $normalized = strtoupper(trim($typeCode));
+        if ($normalized === '') {
+            throw new InvalidArgumentException('MBTI public type_code is required.');
+        }
+
+        if (preg_match(self::TYPE_CODE_PATTERN, $normalized, $matches) !== 1) {
+            throw new InvalidArgumentException(sprintf(
+                'MBTI public type_code must be a 5-character runtime identity like ENFJ-T, got [%s].',
+                $typeCode,
+            ));
+        }
+
+        $baseTypeCode = (string) $matches['base'];
+        $variant = (string) $matches['variant'];
+
+        return new self($normalized, $baseTypeCode, $variant);
+    }
+
+    public static function tryFromTypeCode(?string $typeCode): ?self
+    {
+        $normalized = strtoupper(trim((string) $typeCode));
+
+        if ($normalized === '') {
+            return null;
+        }
+
+        return self::fromTypeCode($normalized);
+    }
+
+    /**
+     * @return array{type_code:string,base_type_code:string,variant:string}
+     */
+    public function toArray(): array
+    {
+        return [
+            'type_code' => $this->typeCode,
+            'base_type_code' => $this->baseTypeCode,
+            'variant' => $this->variant,
+        ];
+    }
+
+    public function equals(self $other): bool
+    {
+        return $this->typeCode === $other->typeCode;
+    }
+}

--- a/backend/tests/Feature/Report/MbtiCanonicalPublicAuthorityScaffoldTest.php
+++ b/backend/tests/Feature/Report/MbtiCanonicalPublicAuthorityScaffoldTest.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Report;
+
+use App\Services\Mbti\Adapters\MbtiReportAuthoritySourceAdapter;
+use App\Services\Mbti\MbtiCanonicalPublicResultPayloadBuilder;
+use App\Support\Mbti\MbtiPublicTypeIdentity;
+use Tests\TestCase;
+
+final class MbtiCanonicalPublicAuthorityScaffoldTest extends TestCase
+{
+    public function test_pilot_builder_can_read_current_report_authority_assets_without_switching_public_routes(): void
+    {
+        $identityLayers = json_decode((string) file_get_contents(
+            base_path('../content_packages/default/CN_MAINLAND/zh-CN/MBTI-CN-v0.3/identity_layers.json')
+        ), true);
+
+        $layer = $identityLayers['items']['ENFJ-T'] ?? null;
+        $this->assertIsArray($layer);
+
+        $builder = new MbtiCanonicalPublicResultPayloadBuilder;
+        $payload = $builder->build(
+            MbtiPublicTypeIdentity::fromTypeCode('ENFJ-T'),
+            new MbtiReportAuthoritySourceAdapter([
+                'profile' => [
+                    'type_code' => 'ENFJ-T',
+                    'short_summary' => 'Pilot report authority summary',
+                ],
+                'layers' => [
+                    'identity' => $layer,
+                ],
+                'scores_pct' => [
+                    'EI' => 64,
+                    'NS' => 71,
+                    'FT' => 41,
+                    'JP' => 66,
+                    'AT' => 57,
+                ],
+                'sections' => [],
+            ]),
+        );
+
+        $this->assertSame('ENFJ-T', $payload['type_code']);
+        $this->assertSame('ENFJ', $payload['base_type_code']);
+        $this->assertSame('T', $payload['variant']);
+        $this->assertSame('Pilot report authority summary', $payload['profile']['hero_summary']);
+        $this->assertSame((string) $layer['one_liner'], $payload['sections']['overview']['body']);
+        $this->assertSame('report.v0_3.pilot', $payload['_meta']['authority_source']);
+    }
+}

--- a/backend/tests/Unit/Services/Mbti/MbtiCanonicalPublicResultPayloadBuilderTest.php
+++ b/backend/tests/Unit/Services/Mbti/MbtiCanonicalPublicResultPayloadBuilderTest.php
@@ -1,0 +1,200 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Services\Mbti;
+
+use App\Contracts\MbtiPublicResultAuthoritySource;
+use App\Services\Mbti\Adapters\MbtiReportAuthoritySourceAdapter;
+use App\Services\Mbti\MbtiCanonicalPublicResultPayloadBuilder;
+use App\Support\Mbti\MbtiCanonicalSectionRegistry;
+use App\Support\Mbti\MbtiPublicTypeIdentity;
+use InvalidArgumentException;
+use RuntimeException;
+use Tests\TestCase;
+
+final class MbtiCanonicalPublicResultPayloadBuilderTest extends TestCase
+{
+    public function test_builder_creates_canonical_payload_from_report_adapter_pilot_input(): void
+    {
+        $builder = new MbtiCanonicalPublicResultPayloadBuilder;
+        $identity = MbtiPublicTypeIdentity::fromTypeCode('ENFJ-T');
+        $payload = $builder->build($identity, new MbtiReportAuthoritySourceAdapter([
+            'profile' => [
+                'type_code' => 'ENFJ-T',
+                'short_summary' => 'Pilot hero summary',
+            ],
+            'layers' => [
+                'identity' => [
+                    'title' => 'Warm guide',
+                    'subtitle' => 'Empathic and future-aware',
+                    'one_liner' => 'Leads with warmth, structure, and anticipation.',
+                ],
+            ],
+            'scores_pct' => [
+                'EI' => 62,
+                'NS' => 74,
+                'FT' => 35,
+                'JP' => 68,
+                'AT' => 49,
+            ],
+            'sections' => [
+                'career' => [
+                    'cards' => [
+                        ['body' => 'Career pilot summary.'],
+                    ],
+                ],
+                'growth' => [
+                    'cards' => [
+                        ['summary' => 'Growth pilot summary.'],
+                    ],
+                ],
+                'relationships' => [
+                    'cards' => [
+                        ['title' => 'Relationship pilot summary.'],
+                    ],
+                ],
+            ],
+        ]));
+
+        $this->assertSame('ENFJ-T', $payload['type_code']);
+        $this->assertSame('ENFJ', $payload['base_type_code']);
+        $this->assertSame('T', $payload['variant']);
+        $this->assertSame('Pilot hero summary', $payload['profile']['hero_summary']);
+        $this->assertSame('Leads with warmth, structure, and anticipation.', $payload['sections']['overview']['body']);
+        $this->assertSame('Career pilot summary.', $payload['sections']['career.summary']['body']);
+        $this->assertSame(
+            MbtiCanonicalSectionRegistry::RENDER_VARIANT_PREMIUM_TEASER,
+            $payload['premium_teaser']['growth.motivators']['render_variant']
+        );
+        $this->assertSame('SN', $payload['sections']['trait_overview']['payload']['dimensions'][1]['normalized_axis_code']);
+        $this->assertSame('TF', $payload['sections']['trait_overview']['payload']['dimensions'][2]['normalized_axis_code']);
+    }
+
+    public function test_builder_rejects_base_type_only_resolution_without_silent_fallback(): void
+    {
+        $builder = new MbtiCanonicalPublicResultPayloadBuilder;
+        $identity = MbtiPublicTypeIdentity::fromTypeCode('ENFJ-T');
+
+        $this->expectException(InvalidArgumentException::class);
+        $builder->build($identity, new class implements MbtiPublicResultAuthoritySource
+        {
+            public function sourceKey(): string
+            {
+                return 'unit.base-type-only';
+            }
+
+            public function read(MbtiPublicTypeIdentity $identity): array
+            {
+                return [
+                    'resolved_type_code' => 'ENFJ',
+                    'profile' => [],
+                    'sections' => [],
+                    'premium_teaser' => [],
+                    'seo_meta' => [],
+                    'meta' => [],
+                ];
+            }
+        });
+    }
+
+    public function test_builder_rejects_blank_resolution_without_defaulting_to_enfj_t(): void
+    {
+        $builder = new MbtiCanonicalPublicResultPayloadBuilder;
+        $identity = MbtiPublicTypeIdentity::fromTypeCode('INFP-T');
+
+        try {
+            $builder->build($identity, new class implements MbtiPublicResultAuthoritySource
+            {
+                public function sourceKey(): string
+                {
+                    return 'unit.blank-type';
+                }
+
+                public function read(MbtiPublicTypeIdentity $identity): array
+                {
+                    return [
+                        'resolved_type_code' => '',
+                        'profile' => [],
+                        'sections' => [],
+                        'premium_teaser' => [],
+                        'seo_meta' => [],
+                        'meta' => [],
+                    ];
+                }
+            });
+        } catch (InvalidArgumentException $e) {
+            $this->assertStringNotContainsString('ENFJ-T', $e->getMessage());
+
+            return;
+        }
+
+        $this->fail('Expected blank resolved_type_code to throw without defaulting.');
+    }
+
+    public function test_builder_rejects_premium_teaser_blocks_masquerading_as_full_sections(): void
+    {
+        $builder = new MbtiCanonicalPublicResultPayloadBuilder;
+        $identity = MbtiPublicTypeIdentity::fromTypeCode('INTJ-T');
+
+        $this->expectException(RuntimeException::class);
+        $builder->build($identity, new class implements MbtiPublicResultAuthoritySource
+        {
+            public function sourceKey(): string
+            {
+                return 'unit.identity-rewrite';
+            }
+
+            public function read(MbtiPublicTypeIdentity $identity): array
+            {
+                return [
+                    'resolved_type_code' => 'INTJ-A',
+                    'profile' => [],
+                    'sections' => [],
+                    'premium_teaser' => [
+                        'growth.motivators' => [
+                            'render_variant' => 'rich_text',
+                            'title' => 'Wrong variant',
+                            'teaser' => 'Should not pass.',
+                        ],
+                    ],
+                    'seo_meta' => [],
+                    'meta' => [],
+                ];
+            }
+        });
+    }
+
+    public function test_builder_rejects_wrong_render_variant_for_premium_teaser_even_when_identity_matches(): void
+    {
+        $builder = new MbtiCanonicalPublicResultPayloadBuilder;
+        $identity = MbtiPublicTypeIdentity::fromTypeCode('INTJ-T');
+
+        $this->expectException(InvalidArgumentException::class);
+        $builder->build($identity, new class implements MbtiPublicResultAuthoritySource
+        {
+            public function sourceKey(): string
+            {
+                return 'unit.premium-variant';
+            }
+
+            public function read(MbtiPublicTypeIdentity $identity): array
+            {
+                return [
+                    'resolved_type_code' => 'INTJ-T',
+                    'profile' => [],
+                    'sections' => [],
+                    'premium_teaser' => [
+                        'growth.motivators' => [
+                            'render_variant' => 'rich_text',
+                            'title' => 'Wrong variant',
+                            'teaser' => 'Should not pass.',
+                        ],
+                    ],
+                    'seo_meta' => [],
+                    'meta' => [],
+                ];
+            }
+        });
+    }
+}

--- a/backend/tests/Unit/Support/Mbti/MbtiCanonicalPublicResultSchemaTest.php
+++ b/backend/tests/Unit/Support/Mbti/MbtiCanonicalPublicResultSchemaTest.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Support\Mbti;
+
+use App\Support\Mbti\MbtiCanonicalPublicResultSchema;
+use App\Support\Mbti\MbtiPublicTypeIdentity;
+use Tests\TestCase;
+
+final class MbtiCanonicalPublicResultSchemaTest extends TestCase
+{
+    public function test_schema_scaffold_keeps_top_level_identity_and_profile_hero_summary_slot(): void
+    {
+        $payload = MbtiCanonicalPublicResultSchema::scaffoldPayload(
+            MbtiPublicTypeIdentity::fromTypeCode('INFP-T'),
+            'unit.test',
+        );
+
+        $this->assertSame('INFP-T', $payload['type_code']);
+        $this->assertSame('INFP', $payload['base_type_code']);
+        $this->assertSame('T', $payload['variant']);
+        $this->assertSame(MbtiCanonicalPublicResultSchema::SCHEMA_VERSION, $payload['_meta']['schema_version']);
+        $this->assertArrayHasKey('hero_summary', $payload['profile']);
+        $this->assertArrayHasKey('letters_intro', $payload['sections']);
+        $this->assertArrayHasKey('growth.motivators', $payload['premium_teaser']);
+    }
+}

--- a/backend/tests/Unit/Support/Mbti/MbtiCanonicalSectionRegistryTest.php
+++ b/backend/tests/Unit/Support/Mbti/MbtiCanonicalSectionRegistryTest.php
@@ -1,0 +1,53 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Support\Mbti;
+
+use App\Support\Mbti\MbtiCanonicalSectionRegistry;
+use InvalidArgumentException;
+use Tests\TestCase;
+
+final class MbtiCanonicalSectionRegistryTest extends TestCase
+{
+    public function test_registry_exposes_the_pr1_canonical_section_keys_and_variants(): void
+    {
+        $definitions = MbtiCanonicalSectionRegistry::definitions();
+
+        $this->assertArrayHasKey('letters_intro', $definitions);
+        $this->assertArrayHasKey('trait_overview', $definitions);
+        $this->assertArrayHasKey('career.preferred_roles', $definitions);
+        $this->assertArrayHasKey('growth.motivators', $definitions);
+        $this->assertArrayHasKey('relationships.rel_risks', $definitions);
+
+        $this->assertSame(
+            MbtiCanonicalSectionRegistry::RENDER_VARIANT_TRAIT_DIMENSION_GRID,
+            $definitions['trait_overview']['render_variant']
+        );
+        $this->assertSame(
+            MbtiCanonicalSectionRegistry::RENDER_VARIANT_PREFERRED_ROLE_LIST,
+            $definitions['career.preferred_roles']['render_variant']
+        );
+    }
+
+    public function test_premium_teaser_blocks_are_fixed_to_premium_teaser_render_variant(): void
+    {
+        foreach (MbtiCanonicalSectionRegistry::premiumTeaserKeys() as $sectionKey) {
+            $definition = MbtiCanonicalSectionRegistry::definition($sectionKey);
+
+            $this->assertSame(MbtiCanonicalSectionRegistry::BUCKET_PREMIUM_TEASER, $definition['bucket']);
+            $this->assertSame(MbtiCanonicalSectionRegistry::RENDER_VARIANT_PREMIUM_TEASER, $definition['render_variant']);
+            $this->assertTrue(MbtiCanonicalSectionRegistry::isPremiumTeaser($sectionKey));
+        }
+    }
+
+    public function test_trait_overview_axis_aliases_are_normalized_explicitly(): void
+    {
+        $this->assertSame('SN', MbtiCanonicalSectionRegistry::normalizeTraitAxisCode('NS'));
+        $this->assertSame('TF', MbtiCanonicalSectionRegistry::normalizeTraitAxisCode('FT'));
+        $this->assertSame('AT', MbtiCanonicalSectionRegistry::normalizeTraitAxisCode('AT'));
+
+        $this->expectException(InvalidArgumentException::class);
+        MbtiCanonicalSectionRegistry::normalizeTraitAxisCode('XY');
+    }
+}

--- a/backend/tests/Unit/Support/Mbti/MbtiPublicTypeIdentityTest.php
+++ b/backend/tests/Unit/Support/Mbti/MbtiPublicTypeIdentityTest.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Support\Mbti;
+
+use App\Support\Mbti\MbtiPublicTypeIdentity;
+use InvalidArgumentException;
+use Tests\TestCase;
+
+final class MbtiPublicTypeIdentityTest extends TestCase
+{
+    public function test_from_type_code_preserves_five_character_runtime_identity(): void
+    {
+        $identity = MbtiPublicTypeIdentity::fromTypeCode(' enfj-t ');
+
+        $this->assertSame('ENFJ-T', $identity->typeCode);
+        $this->assertSame('ENFJ', $identity->baseTypeCode);
+        $this->assertSame('T', $identity->variant);
+        $this->assertSame([
+            'type_code' => 'ENFJ-T',
+            'base_type_code' => 'ENFJ',
+            'variant' => 'T',
+        ], $identity->toArray());
+    }
+
+    public function test_try_from_type_code_returns_null_for_blank_input_without_defaulting(): void
+    {
+        $this->assertNull(MbtiPublicTypeIdentity::tryFromTypeCode(null));
+        $this->assertNull(MbtiPublicTypeIdentity::tryFromTypeCode('  '));
+    }
+
+    public function test_from_type_code_rejects_base_type_and_invalid_variant_inputs(): void
+    {
+        foreach (['ENFJ', 'ENFJ-X', '', 'ENFJT'] as $invalidTypeCode) {
+            try {
+                MbtiPublicTypeIdentity::fromTypeCode($invalidTypeCode);
+            } catch (InvalidArgumentException $e) {
+                $this->assertStringContainsString('type_code', $e->getMessage());
+
+                continue;
+            }
+
+            $this->fail(sprintf('Expected invalid MBTI type_code [%s] to throw.', $invalidTypeCode));
+        }
+    }
+}

--- a/docs/implementation/mbti-result-copy-acceptance.md
+++ b/docs/implementation/mbti-result-copy-acceptance.md
@@ -1,0 +1,263 @@
+# MBTI 结果页文案正式上线验收清单
+
+## 0. 验收目标
+
+上线验收必须证明三件事：
+
+1. 后端 canonical schema 已经成为唯一公共 authority
+2. 前端已完全消费 canonical payload，而不是本地常量
+3. 32 型、`-A/-T`、premium teaser、share/SEO/OG 都已经闭环
+
+## 0.1 PR-1 实际验收范围
+
+PR-1 还不是“正式上线验收”，本轮只验收 scaffold 是否正确落地。
+
+PR-1 必须通过的实际检查项：
+
+1. `MbtiPublicTypeIdentity` 对 `5` 位 `type_code` 的校验是强约束
+2. `MbtiCanonicalSectionRegistry` 已定义 PR-1 要求的 canonical section keys
+3. premium teaser key 的 render type 固定为 `premium_teaser`
+4. `MbtiCanonicalPublicResultPayloadBuilder` 不会 silent fallback 到 base type
+5. `MbtiCanonicalPublicResultPayloadBuilder` 不会默认兜底 `ENFJ-T`
+6. pilot adapter 可以从当前 report-like authority 读出 internal canonical payload
+7. live public route 未切换
+
+PR-1 当前不要求通过的事项：
+
+- `32` 型全文导入
+- frontend render 接线
+- share / seo / og / sitemap 切流
+- personality public contract 切换
+
+## 1. API Contract 验收
+
+PR-1 当前不切 live API contract，因此这一章在本轮只保留“不得提前变更”的检查：
+
+- `GET /api/v0.3/attempts/{id}/result` 不改
+- `GET /api/v0.3/attempts/{id}/report` 不改
+- `GET|POST /api/v0.3/attempts/{id}/share` 不改
+- `GET /api/v0.3/shares/{id}` 不改
+- `GET /api/v0.5/personality/{type}` 不改
+- `GET /api/v0.5/personality/{type}/seo` 不改
+
+## 1.1 必须存在的 contract
+
+对每个目标类型，API 必须稳定输出：
+
+- `profile`
+- `sections`
+- `seo_meta` 或 metadata projection
+- `share` projection
+
+### 必验字段
+
+| 层 | 必验字段 |
+| --- | --- |
+| profile | `type_code`, `base_type_code`, `variant`, `title`, `hero_kicker`, `excerpt`, `tagline`, `rarity_text`, `keywords` |
+| sections | `letters_intro`, `overview`, `trait_overview`, `career`, `growth`, `relationships` |
+| trait_overview | `dimensions` 长度必须为 5，轴只能是 `EI/SN/TF/JP/AT` |
+| premium teaser | `growth` 中 2 条，`relationships` 中 2 条 |
+| share | `title`, `subtitle`, `summary`, `type_code` |
+| metadata | `title`, `description`, `og`, `twitter`, `canonical` |
+
+## 1.2 API 不允许出现的情况
+
+- `type_code = ENFJ-T`，但 `base_type_code/variant` 缺失
+- `trait_overview` 中出现 `NS` 或 `FT`
+- `share` 只输出 `ENFJ`
+- `sections` 缺少 `letters_intro`
+- premium teaser 缺少 `title` 或 `teaser`
+
+## 2. Frontend Render 验收
+
+## 2.1 页面级验收
+
+结果页必须完整显示：
+
+- 顶部区
+- 维度区
+- 职业区
+- 成长区
+- 关系区
+- premium teaser 区
+
+## 2.2 渲染来源验收
+
+前端必须证明：
+
+- 页面 copy 全来自 backend payload
+- 代码库内不再存在 32 型 MBTI 本地对象常量
+- 页面没有本地 string fallback
+
+验收方式：
+
+- 代码审查
+- 搜索本地常量
+- network payload 对照
+
+## 3. A/T 类型验收
+
+最少必须覆盖以下样例：
+
+- `ENFJ-T`
+- `ENFJ-A`
+- `INFP-T`
+- `INTJ-T`
+
+### 验收点
+
+| 验收项 | 要求 |
+| --- | --- |
+| `ENFJ-T` vs `ENFJ-A` 顶部 headline | 必须不同 |
+| `ENFJ-T` vs `ENFJ-A` `AT` 维度 summary | 必须不同 |
+| `INFP-T` `type_code` | 不得被抹平成 `INFP` |
+| `INTJ-T` share/SEO | 不得 silently fallback 到 `INTJ` |
+
+## 4. Premium Teaser 验收
+
+每个类型至少必须具备：
+
+- `growth.motivators.teaser`
+- `growth.drainers.teaser`
+- `relationships.relAdvantages.teaser`
+- `relationships.relRisks.teaser`
+
+### 验收点
+
+- teaser 文案存在
+- teaser 只展示 teaser，不展示伪造 full premium 内容
+- CTA 状态正确
+- 未购买时可见 teaser
+- 已购买时 teaser 行为与 full report 行为不冲突
+
+## 5. Share / SEO / OG 验收
+
+## 5.1 Share
+
+必须验证：
+
+- `share.title/subtitle/summary` 与主结果页同源
+- `share.type_code` 保留完整变体
+- `ENFJ-T` 与 `ENFJ-A` 的 share 不得完全相同
+
+## 5.2 SEO
+
+必须验证：
+
+- 页面 `title` 与当前 canonical payload 对齐
+- `description` 来自统一规则，而不是前端模板
+- `canonical` 可追溯到 variant-aware route 规则
+
+## 5.3 OG / Twitter
+
+必须验证：
+
+- `og_title` 与 `title` 同步
+- `og_description` 与 `description` 同步
+- 若无 override，使用 derived 默认值
+
+## 6. 32 型覆盖率验收
+
+## 6.1 最低覆盖率门槛
+
+- 每个 locale 32 条 `type_code`
+- 每条都有 6 个主 section
+- 每条都有 4 个 premium teaser
+
+## 6.2 覆盖率报表要求
+
+验收时必须生成覆盖率清单：
+
+| 指标 | 目标 |
+| --- | --- |
+| 32 型记录数 | 32 |
+| 每型 section 数 | 6 |
+| 每型维度数 | 5 |
+| 每型 premium teaser 数 | 4 |
+| 轴名异常数 | 0 |
+| A/T 降级 fallback 次数 | 0 |
+
+## 7. 样例截图 / Snapshot / E2E 要求
+
+## 7.1 截图要求
+
+至少对以下类型输出整页截图：
+
+- `ENFJ-T`
+- `ENFJ-A`
+- `INFP-T`
+- `INTJ-T`
+
+每个类型至少包含 5 张关键截图：
+
+1. 顶部区
+2. 维度区
+3. 职业区
+4. 成长区 + premium teaser
+5. 关系区 + premium teaser
+
+## 7.2 Snapshot 要求
+
+必须锁定以下 snapshot：
+
+- canonical payload snapshot
+- share payload snapshot
+- SEO metadata snapshot
+
+推荐至少对以下类型锁定：
+
+- `ENFJ-T`
+- `ENFJ-A`
+- `INFP-T`
+- `INTJ-T`
+
+## 7.3 E2E 要求
+
+E2E 至少覆盖：
+
+- result page open
+- 5 维度正确渲染
+- premium teaser 正确显示
+- share card 内容正确
+- metadata 正确注入
+
+## 8. 上线阻断条件
+
+出现以下任一情况，禁止上线：
+
+- 任一 type_code 被抹平成基础型
+- 任一类型缺少 `letters_intro`
+- 任一类型维度区出现 `NS/FT`
+- 任一 premium teaser 缺失
+- share / SEO / OG 与主结果页文案不同源
+- 前端代码库内仍存在 32 型本地 copy 常量
+
+## 9. 上线通过条件
+
+只有满足以下全部条件，才算“文案可正式上线”：
+
+- 32 型完整导入
+- public serializer 稳定
+- 前端只消费后端 canonical payload
+- premium teaser 接线完成
+- share / SEO / OG 对齐完成
+- Pilot 4 型截图、snapshot、e2e 全绿
+
+## 10. 验收结论格式
+
+建议上线验收结论固定输出为：
+
+```markdown
+- Schema: pass / fail
+- Import: pass / fail
+- API contract: pass / fail
+- Frontend render: pass / fail
+- A/T preservation: pass / fail
+- Premium teaser: pass / fail
+- Share / SEO / OG: pass / fail
+- 32-type coverage: pass / fail
+- Screenshots: pass / fail
+- Snapshot / E2E: pass / fail
+```
+
+只要有任一 `fail`，就不能宣称“正式上线可用”。

--- a/docs/implementation/mbti-result-copy-canonical-schema.md
+++ b/docs/implementation/mbti-result-copy-canonical-schema.md
@@ -1,0 +1,685 @@
+# MBTI 结果页文案 Canonical Schema
+
+## 0. 目标
+
+本文件定义一份正式可实施的 MBTI 结果页 canonical schema，用于把附件 `/Users/rainie/Desktop/微信小程序结果页文案.txt` 中的前端对象结构，转成当前后端链路可承载、可批量导入、可测试、可验收的后端读模型。
+
+设计原则固定如下：
+
+- 只保留一个公共文案 authority，不能继续让 `report`、`personality`、`share`、前端本地常量各持一份
+- `type_code` 必须以 `ENFJ-T` 这类 32 型完整码为主身份
+- 数值维度继续由 `results` runtime 提供，叙事文案由 canonical content 提供
+- `growth` / `relationships` 中当前只有 teaser 的模块继续走 premium teaser，不伪造完整版
+- `seo/share/og` 尽量做 derived projection，只在确有运营覆盖需求时写 override
+
+## 0.1 PR-1 已落地骨架
+
+本轮已经实际落地、但尚未接入 live controller 的代码骨架如下：
+
+- `backend/app/Support/Mbti/MbtiPublicTypeIdentity.php`
+- `backend/app/Support/Mbti/MbtiCanonicalSectionRegistry.php`
+- `backend/app/Support/Mbti/MbtiCanonicalPublicResultSchema.php`
+- `backend/app/Contracts/MbtiPublicResultAuthoritySource.php`
+- `backend/app/Contracts/MbtiPublicResultPayloadBuilder.php`
+- `backend/app/Services/Mbti/MbtiCanonicalPublicResultPayloadBuilder.php`
+- `backend/app/Services/Mbti/Adapters/MbtiReportAuthoritySourceAdapter.php`
+
+PR-1 当前已锁定的事实：
+
+- `type_code` 必须是 `ENFJ-T` 这类 `5` 位 runtime identity
+- `base_type_code` 与 `variant` 只允许派生，不允许反向覆盖 `type_code`
+- canonical payload scaffold 当前固定输出：
+  - 顶层 `type_code`
+  - 顶层 `base_type_code`
+  - 顶层 `variant`
+  - `profile.hero_summary`
+  - `sections`
+  - `premium_teaser`
+  - `seo_meta`
+  - `_meta`
+- `trait_overview` 已有 axis 标准化入口：
+  - `NS -> SN`
+  - `FT -> TF`
+- premium teaser key 已固定到 `premium_teaser` render type，PR-1 测试禁止伪装成 full section
+- 本轮没有切换任何 public route，也没有开始导入 `32` 型正文
+
+## 1. 附件实际结构结论
+
+附件并不是纯文案 TXT，而是一个 JS-like 数据文件：
+
+- 共 32 个类型对象
+- 另有一个聚合对象 `MBTI_PROFILES`
+- 每个类型对象固定包含 6 个一级模块：
+  - `lettersIntro`
+  - `overview`
+  - `traitOverview`
+  - `career`
+  - `growth`
+  - `relationships`
+- 顶部还有：
+  - `code`
+  - `type`
+  - `name`
+  - `nickname`
+  - `rarity`
+  - `keywords`
+  - `heroSummary`
+
+已确认的结构差异：
+
+- 附件里的维度 ID 使用 `NS` / `FT`
+- 后端 runtime 维度规范使用 `SN` / `TF`
+- canonical schema 必须统一到后端规范：`EI / SN / TF / JP / AT`
+
+## 2. Canonical 实体拆分
+
+正式落地时，公共结果页 authority 拆成四层：
+
+1. `profile`
+2. `sections`
+3. `seo_meta`
+4. `derived projections`
+
+其中：
+
+- `profile`：承接类型身份、头部展示、公共摘要
+- `sections`：承接结构化结果页正文
+- `seo_meta`：只承接 override，不承接正文正文块
+- `derived projections`：运行时投影，不建议直接持久化
+  - `share`
+  - `og`
+  - `page metadata`
+
+## 3. 正式 canonical object 形态
+
+PR-1 当前真实落地的是“scaffold 版 canonical payload”，比最终导入完成态更窄，但顶层 identity 和 bucket 已锁住：
+
+```yaml
+type_code: ENFJ-T
+base_type_code: ENFJ
+variant: T
+
+profile:
+  slug: enfj-t
+  slug_base: enfj
+  locale: zh-CN
+  hero_summary: null
+
+sections:
+  letters_intro:
+    section_key: letters_intro
+    render_variant: rich_text
+    title: null
+    body: null
+    payload: null
+  trait_overview:
+    section_key: trait_overview
+    render_variant: trait_dimension_grid
+    payload:
+      summary: null
+      dimensions: []
+      axis_aliases:
+        NS: SN
+        FT: TF
+  career.summary:
+    section_key: career.summary
+    render_variant: rich_text
+    body: null
+
+premium_teaser:
+  growth.motivators:
+    section_key: growth.motivators
+    render_variant: premium_teaser
+    teaser: null
+    is_premium_teaser: true
+  relationships.rel_risks:
+    section_key: relationships.rel_risks
+    render_variant: premium_teaser
+    teaser: null
+    is_premium_teaser: true
+
+seo_meta:
+  seo_title: null
+  seo_description: null
+  og_title: null
+  og_description: null
+  og_image_url: null
+  twitter_title: null
+  twitter_description: null
+  twitter_image_url: null
+  robots: null
+  jsonld_overrides_json: null
+
+derived:
+  share: generated
+  page_metadata: generated
+  og: generated
+
+_meta:
+  authority_source: report.v0_3.pilot
+  schema_version: mbti-public-canonical-pr1
+  scaffold: true
+```
+
+## 4. 哪些字段进入 `profile`
+
+### 4.1 `profile` 必须承接的字段
+
+| Canonical 字段 | 来源 | 当前是否已有位置 | 处理方式 |
+| --- | --- | --- | --- |
+| `type_code` | 附件 `code` / runtime result | 已有 | 直接用 |
+| `base_type_code` | 附件 `type` / `type_code` 派生 | 无 | 扩 schema |
+| `variant` | `type_code` 后缀 | 无 | 扩 schema |
+| `slug` | 由 `type_code` 生成 | 已有但当前是基础型 | 改为 variant-aware |
+| `slug_base` | `base_type_code` 生成 | 无 | 扩 schema 或 alias 规则 |
+| `locale` | 导入上下文 | 已有 | 直接用 |
+| `title` | 附件 `name` | 已有 | 直接映射到 `title` |
+| `hero_kicker` | 附件 `nickname` | 已有 | 复用现有字段 |
+| `subtitle` | 由 `lettersIntro.headline` 压缩版或规范化摘要生成 | 已有 | 走导入规则，不直接生吞 headline 原文 |
+| `excerpt` | 附件 `heroSummary` | 已有 | 直接映射到 `excerpt` |
+| `tagline` | 优先现有 `report_identity_cards` / `type_profiles`；附件无独立字段 | 无 | 扩 schema |
+| `rarity_text` | 附件 `rarity` | 无 | 扩 schema |
+| `keywords_json` | 附件 `keywords[]` | 无 | 扩 schema |
+| `schema_version` | 导入流程 | 已有 | 升为 `mbti_result_v2` |
+
+### 4.2 `profile` 不建议直接承接的字段
+
+以下字段不应塞进 `profile`：
+
+- `lettersIntro.letters[]`
+- `overview.paragraphs[]`
+- `traitOverview.dimensions[]`
+- `career` / `growth` / `relationships` 的正文块
+
+原因：
+
+- 这些字段是结构化正文，不是 profile 头部字段
+- 塞进 profile 会让 SEO/share/public API 变成“单表吃一切”的脆弱结构
+
+## 5. 哪些字段进入 `sections`
+
+建议 section 粒度固定为 6 个，和附件的一致：
+
+- `letters_intro`
+- `overview`
+- `trait_overview`
+- `career`
+- `growth`
+- `relationships`
+
+不建议拆成 20+ 个 section row。正文块层级保留在 `payload_json` 内部。
+
+### 5.1 `letters_intro`
+
+```yaml
+section_key: letters_intro
+render_variant: letters_intro_v2
+payload_json:
+  headline: 外向 · 直觉 · 情感 · 规划 · 动荡型｜...
+  items:
+    - order: 1
+      letter: E
+      title: 外向（E）
+      description: ...
+    - order: 2
+      letter: N
+      title: 直觉（N）
+      description: ...
+    - order: 3
+      letter: F
+      title: 情感（F）
+      description: ...
+    - order: 4
+      letter: J
+      title: 规划（J）
+      description: ...
+    - order: 5
+      letter: T
+      title: 动荡型（-T）
+      description: ...
+```
+
+### 5.2 `overview`
+
+```yaml
+section_key: overview
+render_variant: longform_v2
+payload_json:
+  display_title: 人格概要
+  full_title: 你是怎样的 ENFJ-T？
+  paragraphs:
+    - ...
+    - ...
+    - ...
+```
+
+### 5.3 `trait_overview`
+
+`trait_overview` 的 canonical payload 必须显式区分“文案层”和“数值层”：
+
+```yaml
+section_key: trait_overview
+render_variant: trait_overview_v2
+payload_json:
+  intro: 建议与小程序中 5 条维度进度条搭配展示...
+  dimensions:
+    - axis_code: EI
+      display_name: 外向倾向
+      left_pole:
+        letter: E
+        label: 外向
+      right_pole:
+        letter: I
+        label: 内向
+      summary: 略偏外向
+      description: ...
+    - axis_code: SN
+      source_axis_code: NS
+      display_name: 心智模式
+      left_pole:
+        letter: N
+        label: 天马行空
+      right_pole:
+        letter: S
+        label: 求真务实
+      summary: 偏天马行空
+      description: ...
+    - axis_code: TF
+      source_axis_code: FT
+      display_name: 情绪天性
+      left_pole:
+        letter: F
+        label: 情感细腻
+      right_pole:
+        letter: T
+        label: 理性思考
+      summary: 偏情感细腻
+      description: ...
+    - axis_code: JP
+      ...
+    - axis_code: AT
+      ...
+```
+
+强制规则：
+
+- canonical `axis_code` 只能是 `EI/SN/TF/JP/AT`
+- `source_axis_code` 可选，仅在导入层保留附件原始 `NS/FT`
+- 前端禁止再根据 `NS/FT` 做本地猜测
+
+### 5.4 `career`
+
+```yaml
+section_key: career
+render_variant: structured_blocks_v2
+payload_json:
+  summary:
+    title: 职业概览
+    paragraphs: [...]
+  strengths:
+    title: 你的职场优势
+    items:
+      - title: ...
+        description: ...
+  weaknesses:
+    title: 你的职场短板
+    items:
+      - title: ...
+        description: ...
+  preferred_roles:
+    title: 你可能会喜欢的职业方向
+    intro: ...
+    groups:
+      - group_title: ...
+        description: ...
+        examples: [...]
+    outro: ...
+  upgrade_suggestions:
+    title: 职场升级建议
+    paragraphs: [...]
+    bullets:
+      - label: ...
+        content: ...
+```
+
+### 5.5 `growth`
+
+```yaml
+section_key: growth
+render_variant: structured_blocks_v2
+payload_json:
+  summary:
+    title: 成长概览
+    paragraphs: [...]
+  strengths:
+    title: 你的强项
+    items: [...]
+  weaknesses:
+    title: 你的短板
+    items: [...]
+  premium_teasers:
+    - premium_key: motivators
+      title: 什么在激励着你
+      teaser: ...
+      access_level: premium_teaser
+    - premium_key: drainers
+      title: 什么让你感到疲惫
+      teaser: ...
+      access_level: premium_teaser
+  upgrade_suggestions:
+    optional: true
+    title: 个人成长小公式
+    paragraphs: [...]
+    bullets: [...]
+```
+
+### 5.6 `relationships`
+
+```yaml
+section_key: relationships
+render_variant: structured_blocks_v2
+payload_json:
+  summary:
+    title: 关系概览
+    paragraphs: [...]
+  strengths:
+    title: 关系中的强项
+    items: [...]
+  weaknesses:
+    title: 关系中的短板
+    items: [...]
+  premium_teasers:
+    - premium_key: rel_advantages
+      title: 你的人际关系优势
+      teaser: ...
+      access_level: premium_teaser
+    - premium_key: rel_risks
+      title: 人际关系风险
+      teaser: ...
+      access_level: premium_teaser
+```
+
+## 6. 哪些字段进入 `seo_meta`
+
+`seo_meta` 只承接 override，不承接正文结构本体。
+
+### 6.1 可进入 `seo_meta` 的字段
+
+- `seo_title`
+- `seo_description`
+- `canonical_url`
+- `og_title`
+- `og_description`
+- `og_image_url`
+- `twitter_title`
+- `twitter_description`
+- `twitter_image_url`
+- `robots`
+- `jsonld_overrides_json`
+
+### 6.2 不应直接从附件导入到 `seo_meta` 的字段
+
+- `heroSummary`
+- `overview.paragraphs`
+- `traitOverview.dimensions[].description`
+- `career/growth/relationships` 正文
+
+处理方式：
+
+- Phase 1：先按 canonical rules 自动生成
+- Phase 2：运营确需覆盖时再写 `seo_meta`
+
+建议默认生成规则：
+
+- `seo_title`：`{type_code} {title}：特质、职业、成长与关系 | FermatMind`
+- `seo_description`：优先 `excerpt`，长度超限时截断
+- `og_title`：默认同 `seo_title`
+- `og_description`：默认同 `seo_description`
+
+## 7. 哪些字段继续走 premium teaser
+
+附件里目前明确只有以下 4 个模块应继续走 premium teaser：
+
+- `growth.motivators`
+- `growth.drainers`
+- `relationships.relAdvantages`
+- `relationships.relRisks`
+
+处理规则：
+
+- 持久化位置：仍在所属 section 的 `payload_json.premium_teasers[]`
+- 展示位置：结果页 public surface 只展示 teaser，不展示 full premium body
+- 行为链接：仍接 `ReportGatekeeper` / `cta`
+
+明确不做的事：
+
+- 不从 teaser 伪造出完整 premium 长文
+- 不把 teaser 单独拷成前端本地付费弹窗文案
+
+## 8. 哪些字段不能进入当前链路，必须扩 schema
+
+以下字段或能力，不能靠当前 schema 原样承接，必须扩 schema 或扩约束：
+
+| 项目 | 原因 | 建议 |
+| --- | --- | --- |
+| `base_type_code` | 当前无字段 | `personality_profiles` 新增字段 |
+| `variant` | 当前无字段 | `personality_profiles` 新增字段 |
+| 32 型 `type_code` 约束 | 当前模型/normalizer 只接受 16 型 | 扩 `TYPE_CODES` 与 baseline 校验 |
+| `tagline` | 当前 `personality_profiles` 无字段 | 顶层新增字段 |
+| `rarity_text` | 当前无字段 | 顶层新增字段 |
+| `keywords_json` | 当前无字段 | 顶层新增 JSON 字段 |
+| variant-aware `slug` 规则 | 当前 personality slug 只按基础型假设 | 增加 variant slug / alias 规则 |
+| `letters_intro` / `trait_overview` / `career` / `growth` / `relationships` 新 section keys | 当前 `SECTION_KEYS` 无法承载 | 扩 `SECTION_KEYS` |
+| 新 `render_variant` | 当前只有 `rich_text/bullets/cards/...` | 新增 `letters_intro_v2/trait_overview_v2/structured_blocks_v2` |
+| share 自定义 authoring | 当前无 share_meta 存储 | Phase 1 不扩；沿用 derived projection。若要单独 authoring，再扩 schema |
+
+## 9. 哪些字段不应直接进入当前链路，而应保持 derived
+
+这些字段建议继续走 derived projection，而不是直接存库：
+
+- `share.title`
+- `share.subtitle`
+- `share.summary`
+- `share.share_text`
+- `page metadata`
+- `og projection`
+
+理由：
+
+- 附件没有提供专门的 share / SEO authoring
+- 当前 backend 已有 `report_identity_cards.share_text` 可兜住 share 文案
+- 先用 derived projection，能减少 schema 爆炸
+
+## 10. 标题规范化规则
+
+附件中存在两类不适合直接存库的标题：
+
+- 带顺序号的标题，例如 `1. 人格概要｜你是怎样的 ENFJ-T？`
+- 语义不完整的块标题，例如：
+  - ` 的短板`
+  - ` 系中的强项`
+
+正式 canonical 规则：
+
+- 顺序号不落库，用 `sort_order` 表达顺序
+- section/block 标题优先使用 canonical label dictionary
+- 附件标题只作为原始素材参考，不作为唯一 truth
+
+canonical label dictionary 示例：
+
+- `career.advantages.title` => `你的职场优势`
+- `growth.weaknesses.title` => `你的短板`
+- `relationships.strengths.title` => `关系中的强项`
+- `relationships.weaknesses.title` => `关系中的短板`
+
+## 11. Pilot Mapping
+
+## 11.1 `ENFJ-T` 完整样板
+
+下面是“后端可承载结构示意”，不是最终业务代码。
+
+```yaml
+profile:
+  type_code: ENFJ-T
+  base_type_code: ENFJ
+  variant: T
+  slug: enfj-t
+  slug_base: enfj
+  locale: zh-CN
+  title: 主人公型
+  hero_kicker: 温柔引路人
+  subtitle: 理想主义与现实执行力并存的温柔引路人
+  excerpt: 你像一盏不刺眼的灯：愿意走到人群中央，又始终在照亮别人...
+  tagline:
+    source: report_identity_cards/type_profiles existing authority
+  rarity_text: 约 2–5%
+  keywords:
+    - 共情
+    - 愿景感
+    - 协调者
+    - 服务型领导
+    - 价值驱动
+    - 自我反思
+  schema_version: mbti_result_v2
+
+sections:
+  - section_key: letters_intro
+    payload_json:
+      headline: 外向 · 直觉 · 情感 · 规划 · 动荡型｜理想主义与现实执行力并存的温柔引路人
+      items:
+        - {order: 1, letter: E, title: 外向（E）, description: ...}
+        - {order: 2, letter: N, title: 直觉（N）, description: ...}
+        - {order: 3, letter: F, title: 情感（F）, description: ...}
+        - {order: 4, letter: J, title: 规划（J）, description: ...}
+        - {order: 5, letter: T, title: 动荡型（-T）, description: ...}
+  - section_key: overview
+    payload_json:
+      display_title: 人格概要
+      full_title: 你是怎样的 ENFJ-T？
+      paragraphs: [...]
+  - section_key: trait_overview
+    payload_json:
+      intro: 建议与小程序中 5 条维度进度条搭配展示...
+      dimensions:
+        - {axis_code: EI, source_axis_code: EI, display_name: 外向倾向, left_pole: {letter: E, label: 外向}, right_pole: {letter: I, label: 内向}, summary: 略偏外向, description: ...}
+        - {axis_code: SN, source_axis_code: NS, display_name: 心智模式, left_pole: {letter: N, label: 天马行空}, right_pole: {letter: S, label: 求真务实}, summary: 偏天马行空, description: ...}
+        - {axis_code: TF, source_axis_code: FT, display_name: 情绪天性, left_pole: {letter: F, label: 情感细腻}, right_pole: {letter: T, label: 理性思考}, summary: 偏情感细腻, description: ...}
+        - {axis_code: JP, source_axis_code: JP, ...}
+        - {axis_code: AT, source_axis_code: AT, ...}
+  - section_key: career
+    payload_json:
+      summary: {...}
+      strengths: {...}
+      weaknesses: {...}
+      preferred_roles: {...}
+      upgrade_suggestions: {...}
+  - section_key: growth
+    payload_json:
+      summary: {...}
+      strengths: {...}
+      weaknesses: {...}
+      premium_teasers:
+        - {premium_key: motivators, title: 什么在激励着你, teaser: ...}
+        - {premium_key: drainers, title: 什么让你感到疲惫, teaser: ...}
+  - section_key: relationships
+    payload_json:
+      summary: {...}
+      strengths: {...}
+      weaknesses: {...}
+      premium_teasers:
+        - {premium_key: rel_advantages, title: 你的人际关系优势, teaser: ...}
+        - {premium_key: rel_risks, title: 人际关系风险, teaser: ...}
+
+seo_meta:
+  seo_title: null
+  seo_description: null
+  og_title: null
+  og_description: null
+```
+
+### `ENFJ-T` 中 100% 可落的字段
+
+- `code/type/name/nickname/rarity/keywords/heroSummary`
+- `lettersIntro.headline`
+- `lettersIntro.letters[]`
+- `overview.paragraphs[]`
+- `traitOverview.intro`
+- `traitOverview.dimensions[].summary/description`
+- `career.summary/advantages/weaknesses/preferredRoles/upgradeSuggestions`
+- `growth.summary/strengths/weaknesses`
+- `growth.motivators.teaser`
+- `growth.drainers.teaser`
+- `relationships.summary/strengths/weaknesses`
+- `relationships.relAdvantages.teaser`
+- `relationships.relRisks.teaser`
+
+### `ENFJ-T` 仍需扩 schema 的字段
+
+- `base_type_code`
+- `variant`
+- `tagline`
+- `keywords_json`
+- `rarity_text`
+- `slug_base`
+- 新 section keys / render variants
+
+## 11.2 `INFP-T` 对照样板
+
+`INFP-T` 与 `ENFJ-T` 结构完全同型，只是值不同。关键对照点如下：
+
+```yaml
+profile:
+  type_code: INFP-T
+  base_type_code: INFP
+  variant: T
+  title: 调停者型
+  hero_kicker: 温柔筑梦者
+  excerpt: 你像一团安静却倔强的火焰...
+sections:
+  letters_intro:
+    items:
+      - I
+      - N
+      - F
+      - P
+      - T
+  trait_overview:
+    dimensions:
+      - axis_code: EI
+        summary: 明显偏内向
+      - axis_code: SN
+        source_axis_code: NS
+        summary: 偏天马行空
+      - axis_code: TF
+        source_axis_code: FT
+        summary: 明显偏情感细腻
+      - axis_code: JP
+        summary: 略偏随机应变
+      - axis_code: AT
+        summary: 略偏情绪易波动
+  growth:
+    premium_teasers:
+      - motivators
+      - drainers
+  relationships:
+    premium_teasers:
+      - rel_advantages
+      - rel_risks
+```
+
+### `INFP-T` 中 100% 可落的字段
+
+- 与 `ENFJ-T` 同结构，全量可落到 canonical content
+
+### `INFP-T` 仍需扩 schema 的字段
+
+- 与 `ENFJ-T` 同一批扩 schema 项
+
+## 12. Canonical Schema 结论
+
+附件的主体内容并不需要拆回前端常量。真正要做的是：
+
+- 以 `profile + 6 sections + seo override + derived share/meta` 的形态入后端
+- 明确 `growth/relationships` 的 4 个 teaser 继续走 premium teaser
+- 用 canonical axis code 统一掉 `NS/FT`
+- 对标题和顺序做规范化，而不是把附件文本原样视为数据库 schema

--- a/docs/implementation/mbti-result-copy-render-plan.md
+++ b/docs/implementation/mbti-result-copy-render-plan.md
@@ -1,0 +1,330 @@
+# MBTI 结果页文案渲染方案
+
+## 0. 目标
+
+本方案定义前端每个 block 的渲染责任，以及它们在后端 canonical schema 中的落点。目标是：
+
+- 前端只负责展示，不再持有 MBTI 文案 source of truth
+- simple fallback 从前端移到后端 serializer
+- share / seo / og / page metadata 和主结果页同源
+
+## 0.1 PR-1 已完成边界
+
+PR-1 本轮只完成 backend scaffold，没有改任何 `fap-web` 文件，也没有切换任何 live consumer。
+
+已落地的后端骨架：
+
+- `backend/app/Support/Mbti/MbtiPublicTypeIdentity.php`
+- `backend/app/Support/Mbti/MbtiCanonicalSectionRegistry.php`
+- `backend/app/Support/Mbti/MbtiCanonicalPublicResultSchema.php`
+- `backend/app/Contracts/MbtiPublicResultAuthoritySource.php`
+- `backend/app/Contracts/MbtiPublicResultPayloadBuilder.php`
+- `backend/app/Services/Mbti/MbtiCanonicalPublicResultPayloadBuilder.php`
+- `backend/app/Services/Mbti/Adapters/MbtiReportAuthoritySourceAdapter.php`
+
+PR-1 对渲染层真正产生的影响只有两个：
+
+- future frontend block 落点已经在 backend canonical scaffold 里固定
+- premium teaser render type 与 `trait_overview` axis 标准化入口已经被后端测试锁住
+
+PR-1 尚未完成的事项：
+
+- 前端结果页接 canonical payload
+- share / seo / og / sitemap 切到 canonical projection
+- 删除当前 live fallback render path
+
+## 1. 渲染总原则
+
+- 文案内容必须来自后端 canonical payload
+- 结果数值必须来自 runtime `result`
+- premium 行为必须来自 gatekeeper / cta
+- 前端不允许再维护 32 型本地常量
+- 若内容缺失，前端只能：
+  - 显示 skeleton
+  - 隐藏 block
+  - 显示后端给出的 `degraded/fallback` 状态
+- 前端不能自行补字
+
+PR-1 额外锁定：
+
+- backend canonical payload 顶层 identity 已固定为 `type_code / base_type_code / variant`
+- `profile.hero_summary` 已固定为顶部文案唯一 profile 槽位
+- 以下 key 已固定进入 `premium_teaser` bucket，而不是普通 section：
+  - `growth.motivators`
+  - `growth.drainers`
+  - `relationships.rel_advantages`
+  - `relationships.rel_risks`
+- `trait_overview` 已固定保留 axis alias 标准化入口，不允许前端直接消费 `NS / FT`
+
+## 2. 页面 block 到后端字段落点
+
+| 页面区域 | 后端落点 | 前端责任 | 不允许做的事 |
+| --- | --- | --- | --- |
+| 顶部区 | `profile` + `sections.letters_intro` | 渲染标题、昵称、稀有度、关键词、hero summary、headline | 不能本地拼接 `主人公型 · 温柔引路人` |
+| 维度区 | `sections.trait_overview` + runtime `scores_pct/axis_states` | 渲染 5 条进度条、维度说明、summary | 不能本地把 `NS`/`FT` 解释成轴文案 |
+| 职业区 | `sections.career` | 渲染概览、优势、短板、职业方向、升级建议 | 不能回退到旧 `career_fit` 简版 bullets |
+| 成长区 | `sections.growth` | 渲染概览、强项、短板、premium teaser | 不能把 teaser 当完整内容 |
+| 关系区 | `sections.relationships` | 渲染概览、强项、短板、premium teaser | 不能再用基础型单段 `relationships` 旧文案兜底 |
+| premium teaser | `sections.growth/relationships.payload_json.premium_teasers[]` + `cta` | 渲染 teaser 卡片与引导按钮 | 不能本地写一套通用付费提示文案 |
+| share | canonical derived share projection | 渲染分享卡片 / 文案 / CTA | 不能本地从 `profile.title + summary` 自己拼 |
+| SEO | canonical derived metadata + `seo_meta` override | 页面 title/description/canonical | 不能本地单独维护一套 meta 模板 |
+| OG | canonical derived metadata + `seo_meta` override | 输出 og title/description/image | 不能和页面主文案脱节 |
+
+## 3. 顶部区渲染责任
+
+## 3.1 后端输入
+
+- `profile.title`
+- `profile.hero_kicker`
+- `profile.subtitle`
+- `profile.excerpt`
+- `profile.rarity_text`
+- `profile.keywords`
+- `sections.letters_intro.payload_json.headline`
+
+## 3.2 前端负责
+
+- 版式与排版
+- 稀有度标签视觉
+- keywords tag 样式
+- head title + hero summary 可读性
+
+## 3.3 前端不负责
+
+- 拼接类型标题
+- 解释 `A/T`
+- 生成 hero summary
+
+## 4. 维度区渲染责任
+
+## 4.1 后端输入
+
+- `sections.trait_overview.payload_json.dimensions[]`
+- runtime `scores_pct`
+- runtime `axis_states`
+
+## 4.2 前端负责
+
+- 将 5 个维度按固定顺序渲染：
+  - `EI`
+  - `SN`
+  - `TF`
+  - `JP`
+  - `AT`
+- 将 `scores_pct` 映射为 bar 长度
+- 将 `axis_states` 渲染成“明显偏 / 略偏 / 清晰”等视觉状态
+
+## 4.3 前端不负责
+
+- 从 `type_code` 猜维度 summary
+- 从 `scores_pct` 猜维度说明
+- 把附件的 `NS/FT` 当 runtime 轴名直接消费
+
+## 4.4 维度区 fallback 规则
+
+若 narrative payload 缺失：
+
+- 前端只显示数值条与极性标签
+- 不显示本地维度说明长文
+- 显示后端下发的 `degraded = true`
+
+## 5. 职业区渲染责任
+
+## 5.1 后端输入
+
+- `sections.career.payload_json.summary`
+- `sections.career.payload_json.strengths`
+- `sections.career.payload_json.weaknesses`
+- `sections.career.payload_json.preferred_roles`
+- `sections.career.payload_json.upgrade_suggestions`
+
+## 5.2 前端负责
+
+- 将结构化 blocks 分为：
+  - 概览段落
+  - 优势项
+  - 短板项
+  - 职业方向分组
+  - 升级建议公式卡
+
+## 5.3 替换 simple fallback 的计划
+
+旧 simple version 常见做法：
+
+- 只显示一句 `career_fit`
+- 或只显示推荐职业列表
+
+替换计划：
+
+1. 先接 `sections.career`
+2. 若存在 `career_fit` 旧字段，只作为 backend migration fallback
+3. 前端不再消费旧 `career_fit` 结构
+
+## 6. 成长区渲染责任
+
+## 6.1 后端输入
+
+- `sections.growth.payload_json.summary`
+- `sections.growth.payload_json.strengths`
+- `sections.growth.payload_json.weaknesses`
+- `sections.growth.payload_json.premium_teasers`
+- 可选 `upgrade_suggestions`
+
+## 6.2 前端负责
+
+- 渲染公共可见块：
+  - 成长概览
+  - 强项
+  - 短板
+- 渲染付费引导块：
+  - motivators teaser
+  - drainers teaser
+
+## 6.3 前端不负责
+
+- 自己写“什么在激励着你 / 什么让你疲惫”的默认文案
+- 自行决定 teaser 是否显示
+
+## 7. 关系区渲染责任
+
+## 7.1 后端输入
+
+- `sections.relationships.payload_json.summary`
+- `sections.relationships.payload_json.strengths`
+- `sections.relationships.payload_json.weaknesses`
+- `sections.relationships.payload_json.premium_teasers`
+
+## 7.2 前端负责
+
+- 公共区块：
+  - 关系概览
+  - 关系中的强项
+  - 关系中的短板
+- premium teaser 区块：
+  - 人际关系优势 teaser
+  - 人际关系风险 teaser
+
+## 7.3 替换 simple fallback 的计划
+
+当前简单版常见形态：
+
+- 单段 `relationships` rich_text
+
+替换计划：
+
+1. 后端优先返回 `sections.relationships`
+2. 前端只认结构化 block
+3. 旧 rich_text 只在 migration 期间由 backend serializer 转成结构化 fallback
+
+## 8. premium teaser 渲染责任
+
+## 8.1 后端输入
+
+- `premium_teasers[]`
+- `cta.visible`
+- `cta.kind`
+- `cta.label`
+- `cta.path`
+
+## 8.2 前端负责
+
+- teaser 卡片视觉
+- CTA 按钮交互
+- 锁定态样式
+
+## 8.3 前端不负责
+
+- 决定哪些内容属于 premium
+- 生成通用 teaser copy
+
+## 9. SEO / OG / Share 渲染责任
+
+## 9.1 SEO
+
+前端页面 metadata 只能直接消费服务端输出：
+
+- `meta.title`
+- `meta.description`
+- `meta.canonical`
+- `meta.robots`
+
+## 9.2 OG / Twitter
+
+只能消费：
+
+- `meta.og.*`
+- `meta.twitter.*`
+
+## 9.3 Share
+
+只能消费 canonical derived share projection：
+
+- `title`
+- `subtitle`
+- `summary`
+- `tagline`
+- `share_text` 或等价分享字段
+
+禁止：
+
+- 前端把 `profile.title` 与 `profile.excerpt` 再拼一遍当 share 文案
+
+## 10. simple fallback 替换计划
+
+## Phase 0
+
+- 保留旧页面结构
+- 新 canonical payload 先并行输出
+
+## Phase 1
+
+- 前端优先消费 canonical payload
+- 所有 fallback 改到后端 serializer
+
+## Phase 2
+
+- 删除前端本地 MBTI copy 常量
+- 删除旧 simple block 渲染逻辑
+
+## Phase 3
+
+- share / SEO / OG 全量改为 canonical projection
+- 前端只做视觉层
+
+## 11. 前端禁止继续持有的本地文案字段
+
+以下字段不能继续存在于前端本地常量或 utils 中：
+
+- `heroSummary`
+- `lettersIntro.headline`
+- `lettersIntro.letters[]`
+- `overview.paragraphs`
+- `traitOverview.intro`
+- `traitOverview.dimensions[].summary`
+- `traitOverview.dimensions[].description`
+- `career.*`
+- `growth.*`
+- `relationships.*`
+- `premium teaser` 所有 teaser 文案
+- `share.title`
+- `share.subtitle`
+- `share.summary`
+- SEO title/description 模板
+- A/T 与基础型的本地映射词典
+
+## 12. 渲染方案结论
+
+正式上线后，前端的职责应该被压缩为：
+
+- 布局
+- 视觉
+- 交互
+- 状态展示
+
+而不是：
+
+- 管内容
+- 猜结构
+- 自己补 fallback
+
+只要前端继续持有 32 型 copy，本次 authority 收口就会失效。


### PR DESCRIPTION
## Summary

This PR introduces the PR-1 backend-only scaffold for MBTI public result authority without switching any live public route or contract.

It adds a canonical MBTI public identity layer, a canonical section registry, a canonical public payload scaffold, and a builder contract that future import and serializer work can converge on. The scaffold explicitly preserves 5-character MBTI runtime identity such as `ENFJ-T`, exposes `base_type_code` and `variant` as derived fields, and forbids silent fallback to the 4-letter base type.

## Root Cause

The current MBTI public surfaces do not share a single canonical authority shape. Some report flows can already preserve 32-type content, but public result consumers still have multiple source paths and multiple fallback behaviors. Without a dedicated authority layer, `type_code`, `base_type_code`, `variant`, canonical section keys, and premium teaser boundaries are not enforced in one place.

That leaves the system vulnerable to silent degradation such as `ENFJ-T -> ENFJ`, mixed section vocabularies, and future serializer drift across report, share, SEO, and personality surfaces.

## What Changed

Backend scaffold only:

- Added `MbtiPublicTypeIdentity` to make `type_code`, `base_type_code`, and `variant` explicit and validation-driven.
- Added `MbtiCanonicalSectionRegistry` to define PR-1 canonical section keys and render variants.
- Added `MbtiCanonicalPublicResultSchema` to provide a stable canonical payload scaffold.
- Added `MbtiPublicResultAuthoritySource` and `MbtiPublicResultPayloadBuilder` contracts.
- Added `MbtiCanonicalPublicResultPayloadBuilder` to enforce identity preservation and premium teaser rules.
- Added `MbtiReportAuthoritySourceAdapter` as a pilot adapter that can read current report-like authority into the canonical shape for internal testing.
- Updated implementation docs to reflect what PR-1 actually ships and what it explicitly does not ship.

## Explicit Non-Goals

This PR does not:

- import the 32-type body content
- switch live result, report, share, SEO, OG, sitemap, or personality contracts
- change `fap-web`
- change scoring, commerce, payment, or non-MBTI modules
- add any new fallback behavior

## Validation

Checks run locally:

- `cd backend && ./vendor/bin/pint --test app/Support/Mbti app/Contracts/MbtiPublicResultAuthoritySource.php app/Contracts/MbtiPublicResultPayloadBuilder.php app/Services/Mbti tests/Unit/Support/Mbti tests/Unit/Services/Mbti tests/Feature/Report/MbtiCanonicalPublicAuthorityScaffoldTest.php`
- `cd backend && php artisan test tests/Unit/Support/Mbti tests/Unit/Services/Mbti tests/Feature/Report/MbtiCanonicalPublicAuthorityScaffoldTest.php`
- `cd backend && php artisan test tests/Feature/V0_3/ShareSummaryContractTest.php tests/Feature/Report/MbtiReportContentEnhancementContractTest.php`

## User Impact

There is no live traffic change in this PR. The user-visible effect is indirect: it creates the backend authority scaffold required for later PRs to import structured MBTI result copy and move public result, share, SEO, and OG surfaces onto one canonical payload.
