### PR TITLE
[codex] docs(mbti): add audit and implementation blueprints

### DIFF
--- a/docs/audits/mbti-result-copy-as-is.md
+++ b/docs/audits/mbti-result-copy-as-is.md
@@ -1,0 +1,162 @@
+# MBTI 结果页文案现状审计（As-Is）
+
+## 0. 审计边界
+
+- 审计时间：2026-03-16
+- 审计方式：只读扫描，不修改业务代码、测试、脚本和配置
+- 说明：本仓库内未发现用户所说“附件”文件本体；以下“目标结构”判断，基于任务中明确点名的模块集合推断，包括 `lettersIntro`、`traitOverview.dimensions`、分层 `career/growth/relationships`、`premium teaser`、`share/seo/og` 同源化 等
+- 结论先行：当前仓库存在两套并行但不一致的 MBTI 文案权威源
+  - `v0.3 report`：以 `content_packages` 的 32 型内容包为权威，完整保留 `-A/-T`
+  - `v0.5 personality/seo/sitemap`：以 `PersonalityProfile` CMS 为权威，当前只覆盖 16 个基础型
+  - `share`：混合两者，并在 CMS fallback 处把 `-A/-T` 抹平成 4 字母基础型
+
+## 1. 当前结果页文案来源总图
+
+```mermaid
+flowchart LR
+    A["MBTI scoring<br/>MbtiAttemptScorer / MbtiScorer"] --> B["results.result_json<br/>results.type_code / scores / scores_pct"]
+    B --> C["GET /api/v0.3/attempts/{id}/result<br/>AttemptReadController::result"]
+    B --> D["ReportComposer / ReportPayloadAssembler"]
+    E["content_packages/default/...<br/>type_profiles / identity_cards / identity_layers / report_cards_*"] --> D
+    D --> F["GET /api/v0.3/attempts/{id}/report"]
+    D --> G["ShareService::buildShareSummary"]
+    H["personality_profiles<br/>personality_profile_sections<br/>personality_profile_seo_meta"] --> I["GET /api/v0.5/personality/{type}"]
+    H --> J["GET /api/v0.5/personality/{type}/seo"]
+    H --> K["SitemapGenerator::getPersonalityUrls"]
+    L["content_baselines/personality/mbti.*.json<br/>source = old frontend deterministic transforms"] --> M["personality:import-local-baseline"]
+    M --> H
+    I --> G
+```
+
+## 2. 所有结果页渲染入口
+
+### 2.1 当前仓库内实际扫描到的入口
+
+| 面 | 入口文件 | 作用 | 当前文案来源 | A/T |
+| --- | --- | --- | --- | --- |
+| 结果页结果接口 | `backend/app/Http/Controllers/API/V0_3/AttemptReadController.php` | `/api/v0.3/attempts/{id}/result` | `results.result_json` 原样返回，加上 `type_code/scores/scores_pct` 兼容字段 | 保留 |
+| 报告接口 | `backend/app/Http/Controllers/API/V0_3/AttemptReadController.php` | `/api/v0.3/attempts/{id}/report` | `ReportComposer` 组装 `content_packages` 中的权威内容 | 保留 |
+| 分享接口 | `backend/app/Services/V0_3/ShareService.php` | `/api/v0.3/attempts/{id}/share`、`/api/v0.3/shares/{id}` | `result_json` + `report` 快照 + `PersonalityProfile` fallback 混合 | 输出保留，fallback 丢失 |
+| 公共人格页 API | `backend/app/Http/Controllers/API/V0_5/Cms/PersonalityController.php` | `/api/v0.5/personality/{type}` | `personality_profiles` + `personality_profile_sections` | 当前不支持变体 |
+| SEO API | `backend/app/Http/Controllers/API/V0_5/Cms/PersonalityController.php` | `/api/v0.5/personality/{type}/seo` | `seo_meta` + `profile.title/excerpt/subtitle` fallback | 当前不支持变体 |
+| sitemap | `backend/app/Services/SEO/SitemapGenerator.php` | 人格详情页与列表页 sitemap | `personality_profiles` 公共已发布记录 | 当前不支持变体 |
+| 前端 sitemap | `fap-web/app/sitemap.ts` | Next sitemap 入口 | 目前返回空数组 | 无 |
+| 前端 robots | `fap-web/app/robots.ts` | robots + sitemap 地址 | 静态配置 | 无 |
+
+### 2.2 未扫描到的关键前端面
+
+- 当前仓库快照内未发现真正的 React/Next 结果页路由、结果页组件、分享页组件、OG 动态图生成代码
+- 任务要求扫描 `app/**`、`components/**`、`lib/**`、`content/**`、`tests/**`、`next-sitemap.config.js`
+  - 本仓库根目录未发现这些前端目录对应的 MBTI 结果页实现
+  - `next-sitemap.config.js` 未发现
+- 这意味着：
+  - 当前可确认的“结果页文案系统”主体实际在后端 API 与内容包/CMS
+  - 前端真实渲染面大概率在未纳入本仓库的前端代码中，或尚未接入
+
+## 3. 所有 share / seo / og / premium 相关入口
+
+### 3.1 Share
+
+- `backend/routes/api.php`
+  - `GET|POST /api/v0.3/attempts/{id}/share`
+  - `GET /api/v0.3/shares/{id}`
+- `backend/app/Services/V0_3/ShareService.php`
+  - `buildShareSummary()` 是当前分享文案汇总器
+  - 文案来源优先级：
+    - `result.result_json`
+    - `report.profile`
+    - `report.identity_card`
+    - `report.layers.identity`
+    - `public PersonalityProfile` fallback
+  - 关键问题：`resolvePublicProfile()` 会调用 `baseTypeCode()`，通过正则去掉 `-A/-T`
+
+### 3.2 SEO / OG / Metadata
+
+- `backend/app/Services/Cms/PersonalityProfileSeoService.php`
+  - `title`：`seo_title`，否则 `profile.title`
+  - `description`：`seo_description`，否则 `excerpt`，否则 `subtitle`
+  - `og/twitter`：分别 fallback 到 SEO 字段或 title/description
+  - `jsonld`：基于 `type_code`、`scale_code`、canonical 生成
+- `backend/app/Services/SEO/SitemapGenerator.php`
+  - `getPersonalityUrls()` 只看 `personality_profiles` 中已发布且 indexable 的记录
+
+### 3.3 Premium teaser
+
+- `backend/app/Services/Report/ReportGatekeeperTeaserTrait.php`
+  - 当前只有“对锁定 section 做 blur/truncate”的通用门控逻辑
+  - 没有独立作者可维护的 `premium teaser` 字段族
+- `backend/app/Services/Report/ReportGatekeeper.php`
+  - 负责 `cta.visible`、`cta.kind` 等付费门控信号
+
+## 4. 当前 simple version 断点列表
+
+以下判定标准按用户要求写死。
+
+| 判定项 | 当前证据 | 判定 |
+| --- | --- | --- |
+| 只有 1 段泛化 summary，缺少模块化结构 | `content_baselines/personality/mbti.*.json` 的 `core_snapshot`、`work_style`、`relationships` 多为单段文本；`v0.5 personality` 直接暴露这些 section | 命中 simple version |
+| 没有 `lettersIntro` | `PersonalityProfileSection::SECTION_KEYS` 与 Filament `sectionDefinitions()` 均无该字段；`report` 也无标准同名模块 | 命中 |
+| 没有 `traitOverview.dimensions` | 当前只有 `scores_pct`、`axis_states`，以及 share 里的简单 `dimensions[]` 数值摘要；没有统一的维度叙事结构 | 命中 |
+| `career / growth / relationships` 只有短句，没有分层 blocks | `v0.5` 仅有 `career_fit` cards 与 `relationships` rich_text；`growth_edges` 仅 bullets。`v0.3 report` 虽有 cards，但未形成统一公共 schema | 命中 |
+| premium teaser 缺失或只剩占位 | 当前只有 paywall blur，没有独立 teaser 文案承载位 | 命中 |
+| `-A/-T` 被抹平为 4 字母基础类型 | `PersonalityProfile::TYPE_CODES` 仅 16 型；`PersonalityBaselineNormalizer` 只接受 16 型；`ShareService::baseTypeCode()` 会降级 | 命中 |
+| SEO / OG / share 文案没有跟随主结果页结构升级 | SEO 走 CMS，share 走混合，report 走内容包，三者不同源 | 命中 |
+| 前后端字段名不统一，存在本地 fallback 文案 | `result_json`、`report.profile`、`identity_card`、`PersonalityProfile`、`seo_meta` 命名各自为政，且 `content_baselines` 明确来自旧前端 transforms | 命中 |
+
+## 5. 当前 authoritative source 判定
+
+### 5.1 运行时 32 型结果/报告权威源
+
+权威链路：
+
+- `backend/app/Services/Score/MbtiAttemptScorer.php`
+- `backend/app/Domain/Score/MbtiScorer.php`
+- `backend/app/Services/Assessment/Drivers/MbtiDriver.php`
+- `backend/app/Services/Report/Composer/ReportPayloadAssembler*.php`
+- `content_packages/default/CN_MAINLAND/zh-CN/MBTI-CN-v0.3/`
+  - `type_profiles.json`
+  - `report_identity_cards.json`
+  - `identity_layers.json`
+  - `report_cards_traits.json`
+  - `report_cards_career.json`
+  - `report_cards_growth.json`
+  - `report_cards_relationships.json`
+  - `report_recommended_reads.json`
+
+判定：
+
+- 这是当前唯一真正支持 32 个 `type_code` 变体并保持 `-A/-T` 的完整文案系统
+- 也是最接近“后端结果页生成规则”的现存权威实现
+
+### 5.2 公共人格页 / SEO / sitemap 权威源
+
+权威链路：
+
+- `content_baselines/personality/mbti.en.json`
+- `content_baselines/personality/mbti.zh-CN.json`
+- `backend/app/Console/Commands/PersonalityImportLocalBaseline.php`
+- `backend/app/PersonalityCms/Baseline/*`
+- `personality_profiles` / `personality_profile_sections` / `personality_profile_seo_meta`
+
+判定：
+
+- 这是当前公共 `personality` 页面、SEO、OG、sitemap 的权威源
+- 但它只覆盖 16 基础型，且源头明确写着来自旧前端 deterministic transforms，不是当前 report engine 的 32 型权威内容
+
+### 5.3 share 权威源
+
+判定：
+
+- 当前没有单一权威源
+- `share` 是一个混合拼装器
+  - 结果数值与 `type_code` 来自 `Result`
+  - 主标题/副标题/摘要来自 `report` 与 `PersonalityProfile` fallback 混合
+  - CMS fallback 又会把 `-A/-T` 抹平
+- 因此 share 目前不能被视作正式上线级的统一权威面
+
+## 6. As-Is 总结
+
+- 当前仓库不是“没有内容”，而是“有两套内容权威，各自覆盖不同 surface”
+- `report` 已经不是简单版，但它没有沉淀成统一的、可供结果页/分享/SEO/OG 共用的结构化 schema
+- `personality` / SEO / sitemap 仍是简单版体系，并且以 16 型为主
+- 想让“结果页文案能正式上线”，核心不是前端润色，而是把公共人格页、share、SEO、OG、sitemap 与 `report` 的 32 型权威内容收口到一套可导入、可回放、可测试的后端 schema 与 serializer

--- a/docs/audits/mbti-result-copy-backend-authority-map.md
+++ b/docs/audits/mbti-result-copy-backend-authority-map.md
@@ -1,0 +1,233 @@
+# MBTI 结果页文案后端权威映射（Backend Authority Map）
+
+## 0. 结论
+
+- 当前后端并不存在唯一的 MBTI 结果页文案权威面
+- 实际上存在三条链路：
+  - `results/result_json`：结果存储层，负责数值与基础结果，不是完整文案 authority
+  - `v0.3 report`：32 型、带 `-A/-T`、内容包驱动的深度报告 authority
+  - `v0.5 personality/seo/sitemap`：16 型、CMS/基线导入驱动的公共页面 authority
+
+## 1. 后端结果页权威字段清单
+
+| 字段族 | 当前权威来源 | 读取链路 | `-A/-T` | 备注 |
+| --- | --- | --- | --- | --- |
+| `type_code` | `results.type_code` | `AttemptReadController::result/report/share` | 保留 | runtime 真正的变体身份 |
+| `scores_json` / `scores_pct` / `axis_states` | `results` 表 | `result`、`report`、`share` | 保留 | 5 轴，包含 `AT` |
+| `report.profile.type_name/tagline/rarity/keywords/short_summary` | `content_packages/.../type_profiles.json` | `ReportPayloadAssembler` | 保留 | 32 型 |
+| `report.identity_card.*` | `content_packages/.../report_identity_cards.json` | `ReportPayloadAssembler` | 保留 | 已有 `share_text`、视觉 token |
+| `report.layers.identity.*` | `content_packages/.../identity_layers.json` + `IdentityLayerBuilder` | `ReportPayloadAssembler` | 保留 | 当前最接近结果页“人格介绍层” |
+| `report.sections.traits/career/growth/relationships.cards[]` | `content_packages/.../report_cards_*.json` + 卡片选择器 | `ReportPayloadAssembler` | 保留 | 已是模块化 cards，但不是公共 API 标准 schema |
+| `report.recommended_reads` | `content_packages/.../report_recommended_reads.json` | `ReportPayloadAssembler` | 保留 | 报告内扩展阅读 |
+| `profile.title/subtitle/excerpt/...` | `personality_profiles` | `PersonalityController` / `SeoService` | 不保留 | 只支持 16 型 |
+| `sections[]` | `personality_profile_sections` | `PersonalityController::show` | 不保留 | 泛化 section key |
+| `seo_meta.*` | `personality_profile_seo_meta` | `PersonalityProfileSeoService` | 不保留 | 与 report 无直接耦合 |
+| `share.title/subtitle/summary/tagline/tags` | `ShareService` 运行时拼装 | `ShareController` | 部分保留 | fallback 到 CMS 时丢失变体语义 |
+| personality sitemap | `personality_profiles` | `SitemapGenerator::getPersonalityUrls()` | 不保留 | 只发 16 型公开页 |
+
+## 2. `type code` 规范与 `-A/-T` 保留规则
+
+### 2.1 当前 runtime 规范
+
+实际 runtime 规范来自评分器，而不是 CMS：
+
+- `backend/app/Services/Score/MbtiAttemptScorer.php`
+- `backend/app/Domain/Score/MbtiScorer.php`
+
+当前 runtime 产物是五轴结果：
+
+- 基础四字母：`[EI][SN][TF][JP]`
+- 变体后缀：`-A` 或 `-T`
+- 规范格式：
+
+```text
+^[EI][SN][TF][JP]-(A|T)$
+```
+
+### 2.2 当前能保留 `-A/-T` 的链路
+
+- `results.type_code`
+- `result_json.type_code`
+- `report` 内容包读取
+- `identity_layers.json`、`type_profiles.json`、`report_identity_cards.json`
+- `tests/Feature/Report/MbtiReportContentEnhancementContractTest.php`
+
+### 2.3 当前会抹平 `-A/-T` 的链路
+
+| 位置 | 行为 |
+| --- | --- |
+| `backend/app/Models/PersonalityProfile.php` | `TYPE_CODES` 只有 16 个基础型 |
+| `backend/app/PersonalityCms/Baseline/PersonalityBaselineNormalizer.php` | 导入时只允许基础型 |
+| `backend/app/Services/V0_3/ShareService.php` | `baseTypeCode()` 会去掉 `-A/-T` 再查公共 profile |
+| `backend/app/Services/SEO/SitemapGenerator.php` | 只基于 `personality_profiles` 发 personality URL |
+| `backend/app/Filament/Ops/Resources/PersonalityProfileResource/Support/PersonalityWorkspace.php` | V1 workspace 仍按基础型人格页组织 |
+
+### 2.4 规范建议
+
+正式上线时应写死以下规则：
+
+- 主身份码：始终使用五轴完整码，例如 `ENFJ-T`
+- 基础型：只作为派生字段 `base_type_code`
+- `slug`：
+  - 公共 URL 可继续保留基础型 `enfj`
+  - 但数据层必须保留 `variant = T/A`
+- fallback：
+  - 可以从 `ENFJ-T` 回退到 `ENFJ`
+  - 但只能作为“明确记录的降级策略”，不能把基础型当成主 source
+
+## 3. `profile / sections / seo_meta` 实际来源
+
+## 3.1 `report.profile`
+
+来源：
+
+- `content_packages/default/.../type_profiles.json`
+
+字段：
+
+- `type_code`
+- `type_name`
+- `tagline`
+- `rarity`
+- `keywords`
+- `short_summary`
+
+特点：
+
+- 32 型完整
+- 但字段仍偏“概览层”，不够承接附件式结构化结果页
+
+## 3.2 `report.sections`
+
+来源：
+
+- `report_cards_traits.json`
+- `report_cards_career.json`
+- `report_cards_growth.json`
+- `report_cards_relationships.json`
+- `report_section_policies.json`
+
+特点：
+
+- 已有 cards、bullets、tips、module_code、access_level
+- 更像“报告卡片引擎”
+- 适合生成深度内容，不适合作为公共结果页统一 schema 直接透出
+
+## 3.3 `PersonalityProfile.sections`
+
+来源：
+
+- `content_baselines/personality/mbti.*.json`
+- `PersonalityBaselineImporter`
+
+固定 key：
+
+- `hero`
+- `core_snapshot`
+- `strengths`
+- `growth_edges`
+- `work_style`
+- `relationships`
+- `communication`
+- `stress_and_recovery`
+- `career_fit`
+- `faq`
+- `related_content`
+
+特点：
+
+- 泛化 CMS 结构
+- 只能容纳“简单人格页”
+- 没有 `lettersIntro`、`traitOverview`、`premium_teaser` 等目标模块
+
+## 3.4 `seo_meta`
+
+来源：
+
+- `personality_profile_seo_meta`
+- 由 `PersonalityProfileSeoService` 输出
+
+特点：
+
+- 当前是公共 personality 页的 SEO authority
+- 但不是与 report 同源
+- fallback 基于 `title/excerpt/subtitle`，无法表达更丰富的结果页结构升级
+
+## 4. import / baseline / seed / workspace / public api 关系图
+
+```mermaid
+flowchart TD
+    A["content_baselines/personality/mbti.en.json<br/>mbti.zh-CN.json"] --> B["PersonalityBaselineReader"]
+    B --> C["PersonalityBaselineNormalizer"]
+    C --> D["PersonalityBaselineImporter"]
+    D --> E["personality_profiles"]
+    D --> F["personality_profile_sections"]
+    D --> G["personality_profile_seo_meta"]
+    D --> H["personality_profile_revisions"]
+    E --> I["Filament PersonalityWorkspace"]
+    F --> I
+    G --> I
+    E --> J["/api/v0.5/personality"]
+    F --> J
+    G --> K["/api/v0.5/personality/{type}/seo"]
+    E --> L["SitemapGenerator::getPersonalityUrls"]
+
+    M["content_packages/default/..."] --> N["ReportPayloadAssembler"]
+    N --> O["/api/v0.3/attempts/{id}/report"]
+    N --> P["ShareService runtime snapshot"]
+    E --> P
+```
+
+### 4.1 baseline 与 seed 的关系
+
+- 当前人格页基线不是 seeder 驱动，而是命令导入：
+  - `php artisan personality:import-local-baseline`
+- `tests/Feature/PersonalityCms/PersonalityBaselineImportTest.php` 已验证：
+  - dry-run
+  - create
+  - upsert
+  - revision
+- 但它验证的是 16 型 `v1` baseline，不是 32 型结果页 schema
+
+### 4.2 workspace 与 public api 的关系
+
+- Filament workspace 当前是 `PersonalityProfile` 的编辑壳
+- `sectionDefinitions()` 直接定义了人格页可以编辑哪些 section
+- public API 只是把 DB 中 profile/sections/seo_meta 原样序列化出去
+- 这套壳目前还没有能力表达“附件级结构化结果页”
+
+## 5. 当前 authority map 的关键断层
+
+### 5.1 断层一：runtime 报告 authority 与 public profile authority 不同源
+
+- 32 型权威内容在 `content_packages`
+- 公共人格页 authority 在 `personality_profiles`
+- 两者既不共 schema，也不共 import 来源
+
+### 5.2 断层二：share 在两套 authority 中间拼装
+
+- share 不是第三套正式内容源
+- 它只是运行时聚合器
+- 因此不应继续把 share 作为未来结果页/SEO 的来源
+
+### 5.3 断层三：基础型 CMS 正在把变体人格压扁
+
+- 这会直接影响：
+  - 标题、副标题
+  - summary
+  - SEO title/description
+  - sitemap URL 粒度
+  - public profile 运营口径
+
+## 6. Authority Map 结论
+
+正式上线方案必须明确以下分工：
+
+- `Result / report engine`
+  - 继续负责 runtime 数值、5 轴、付费门控、深度 cards
+- `Personality public authority`
+  - 必须升级为 32 型、结构化结果页 schema 的公共权威读模型
+- `share / seo / og / sitemap`
+  - 必须统一改成消费同一套公共 authority serializer
+
+如果不先做这一步收口，任何前端“接附件文案”的做法都会重新制造第三套 source of truth。

--- a/docs/audits/mbti-result-copy-file-change-list.md
+++ b/docs/audits/mbti-result-copy-file-change-list.md
@@ -1,0 +1,104 @@
+# MBTI 结果页文案未来文件改动清单
+
+## 0. 说明
+
+- 本清单是“未来真正实施时要改的文件”
+- 当前这次任务没有修改这些业务文件
+- 分类按：前端 / 后端 / CMS / import / tests / docs
+- 若某一类关键文件在当前仓库中不存在，会明确标成“当前仓库未扫描到实际文件”
+
+## 1. 前端
+
+| 文件 | 为什么要改 |
+| --- | --- |
+| `fap-web/app/sitemap.ts` | 当前返回空数组，无法把 personality/result authority 正式发到前端 sitemap |
+| `fap-web/app/robots.ts` | 若 sitemap 路径或 personality 收录策略变化，需要同步 robots 输出 |
+| `当前仓库未扫描到的实际结果页 route/component 文件` | 真正结果页必须改成消费统一公共 DTO，移除本地 MBTI fallback 文案 |
+| `当前仓库未扫描到的实际分享页/OG 组件文件` | share / OG 必须改成消费统一 authority，不能再自行拼文案 |
+
+## 2. 后端
+
+| 文件 | 为什么要改 |
+| --- | --- |
+| `backend/routes/api.php` | 若引入新的公共结果页 DTO endpoint 或 version，需要补路由 |
+| `backend/app/Http/Controllers/API/V0_3/AttemptReadController.php` | 当前 `result` 直接返回 `result_json`，需要接入统一结构化 serializer |
+| `backend/app/Http/Controllers/API/V0_5/Cms/PersonalityController.php` | 当前只输出 profile + sections 行，需要升级成结构化结果页 payload |
+| `backend/app/Services/V0_3/ShareService.php` | 当前 share 是混合拼装且会抹平 `-A/-T` fallback，需要改成统一 authority 输出 |
+| `backend/app/Services/Cms/PersonalityProfileService.php` | 当前 public profile 查询按基础型设计，需要支持 32 型与明确回退规则 |
+| `backend/app/Services/Cms/PersonalityProfileSeoService.php` | 当前 SEO/OG 不是从统一结果页 authority 生成，需要重构为同源输出 |
+| `backend/app/Services/SEO/SitemapGenerator.php` | 当前 personality sitemap 只看基础型 CMS，需要对齐统一 authority |
+| `backend/app/Models/PersonalityProfile.php` | 需要把 16 型扩展到 32 型，并约束新的 type code 规则 |
+| `backend/app/Models/PersonalityProfileSection.php` | 需要扩展 section keys / render variants 以承接 `lettersIntro/traitOverview/premium_teaser` |
+| `backend/app/Services/Report/Composer/ReportPayloadAssemblerComposeFinalizeTrait.php` | 若公共结果页 DTO 要复用 report 头部与 cards，需要补统一映射出口 |
+| `backend/app/Services/Report/Composer/ReportPayloadAssemblerComposeBuildTrait.php` | 若把 report cards 映射成公共 `career/growth/relationships` blocks，需要在这里或旁路 serializer 接线 |
+| `backend/app/Services/Report/ReportGatekeeperTeaserTrait.php` | 当前只有 blur，没有 authored premium teaser，需要接入 teaser payload |
+
+## 3. CMS
+
+| 文件 | 为什么要改 |
+| --- | --- |
+| `backend/app/Filament/Ops/Resources/PersonalityProfileResource.php` | 当前资源仍是 V1 人格页编辑壳，需要支持结构化结果页字段与 32 型 |
+| `backend/app/Filament/Ops/Resources/PersonalityProfileResource/Support/PersonalityWorkspace.php` | 当前 `sectionDefinitions()` 只有 V1 section，需要扩展到目标模块 |
+
+## 4. Import
+
+| 文件 | 为什么要改 |
+| --- | --- |
+| `backend/app/Console/Commands/PersonalityImportLocalBaseline.php` | 当前命令只导入 V1 基线，需要支持新的结构化 baseline |
+| `backend/app/PersonalityCms/Baseline/PersonalityBaselineReader.php` | 需要读取新的 baseline 文件与版本格式 |
+| `backend/app/PersonalityCms/Baseline/PersonalityBaselineNormalizer.php` | 当前会拒绝 `-A/-T` 且不识别目标模块，需要升级校验 |
+| `backend/app/PersonalityCms/Baseline/PersonalityBaselineImporter.php` | 需要把结构化模块写入新的 schema / section payload |
+| `content_baselines/personality/mbti.en.json` | 当前内容源来自旧前端 deterministic transforms，需要升级或替换成结构化 32 型基线 |
+| `content_baselines/personality/mbti.zh-CN.json` | 同上 |
+
+## 5. 数据库 / Schema
+
+| 文件 | 为什么要改 |
+| --- | --- |
+| `backend/database/migrations/*` 新迁移 | 需要扩 schema，支持 32 型、结构化模块、premium teaser、统一 payload 版本化 |
+
+## 6. Tests
+
+| 文件 | 为什么要改 |
+| --- | --- |
+| `backend/tests/Feature/V0_5/PersonalityPublicApiTest.php` | 当前只验证基础型 profile + sections，需要升级到结构化公共 DTO |
+| `backend/tests/Feature/PersonalityCms/PersonalityBaselineImportTest.php` | 当前只验证 V1 16 型 baseline，需要增加 32 型结构化导入验证 |
+| `backend/tests/Feature/V0_3/ShareSummaryContractTest.php` | 需要验证 share 与主结果页 authority 同源，并保留 `-A/-T` |
+| `backend/tests/Feature/Report/MbtiReportContentEnhancementContractTest.php` | 需要验证 report 与公共结果页 DTO 的头部/identity/career 等映射一致性 |
+| `新增：公共结果页 serializer 合同测试` | 锁定最终结构，避免回退到“前端本地拼文案” |
+| `新增：四个样例类型 snapshot` | 先用 `ENFJ-T / ENFJ-A / INFP-T / INTJ-T` 验证结构与 A/T 差异 |
+
+## 7. Docs
+
+| 文件 | 为什么要改 |
+| --- | --- |
+| `docs/audits/mbti-result-copy-as-is.md` | 当前审计结论后续需要随着实施更新为对照文档 |
+| `docs/audits/mbti-result-copy-backend-authority-map.md` | 实施后要更新 authority 收口状态 |
+| `docs/audits/mbti-result-copy-target-schema-map.md` | 实施时可作为字段对照单 |
+| `docs/audits/mbti-result-copy-gap-matrix.md` | 实施阶段可逐项关闭 gap |
+| `docs/audits/mbti-result-copy-launch-plan.md` | 作为上线阶段 checklist |
+| `docs/api/*` 或 `docs/content/*` 新 contract 文档 | 需要补正式公共结果页 DTO、import schema、A/T 回退规则文档 |
+
+## 8. 建议先改的最小文件集合
+
+如果按最小可行闭环推进，第一批真正要改的文件建议是：
+
+1. `backend/app/Models/PersonalityProfile.php`
+2. `backend/app/Models/PersonalityProfileSection.php`
+3. `backend/database/migrations/*` 新迁移
+4. `backend/app/PersonalityCms/Baseline/PersonalityBaselineNormalizer.php`
+5. `backend/app/PersonalityCms/Baseline/PersonalityBaselineImporter.php`
+6. `backend/app/Http/Controllers/API/V0_5/Cms/PersonalityController.php`
+7. `backend/app/Services/V0_3/ShareService.php`
+8. `backend/app/Services/Cms/PersonalityProfileSeoService.php`
+9. `backend/tests/Feature/V0_5/PersonalityPublicApiTest.php`
+10. `backend/tests/Feature/V0_3/ShareSummaryContractTest.php`
+
+原因：
+
+- 这批文件正好覆盖：
+  - 32 型 schema
+  - import
+  - public serializer
+  - share / SEO 对齐
+  - 合同测试

--- a/docs/audits/mbti-result-copy-gap-matrix.md
+++ b/docs/audits/mbti-result-copy-gap-matrix.md
@@ -1,0 +1,70 @@
+# MBTI 结果页文案 Gap Matrix
+
+## 0. 分级标准
+
+- `L0`：只缺内容
+- `L1`：只缺映射
+- `L2`：缺 schema 或 serializer
+- `L3`：缺完整生成链路
+
+## 1. Gap Matrix
+
+| Gap ID | 等级 | 缺口 | 具体文件 | 当前影响 | 需要补什么 |
+| --- | --- | --- | --- | --- | --- |
+| G01 | L3 | 没有单一“结果页公共 authority” | `backend/app/Http/Controllers/API/V0_3/AttemptReadController.php`、`backend/app/Services/V0_3/ShareService.php`、`backend/app/Http/Controllers/API/V0_5/Cms/PersonalityController.php`、`backend/app/Services/Report/Composer/ReportPayloadAssemblerComposeFinalizeTrait.php` | report、personality、share、SEO 分别读不同源 | 建立统一公共结果页 DTO 和 serializer |
+| G02 | L3 | 当前 public personality 链路与 32 型 report 链路分叉 | `content_packages/default/...`、`content_baselines/personality/mbti.en.json`、`content_baselines/personality/mbti.zh-CN.json` | 同一人格在 report 与 public 页面文案不同步 | 收口到单一后端 authority，并建立投影/导入链路 |
+| G03 | L3 | 附件式结构没有完整 import 链路 | `backend/app/Console/Commands/PersonalityImportLocalBaseline.php`、`backend/app/PersonalityCms/Baseline/PersonalityBaselineReader.php`、`backend/app/PersonalityCms/Baseline/PersonalityBaselineNormalizer.php`、`backend/app/PersonalityCms/Baseline/PersonalityBaselineImporter.php` | 无法批量导入 `lettersIntro/traitOverview/premiumTeaser` | 新 baseline schema + upsert/import + dry-run + diff 报表 |
+| G04 | L2 | `PersonalityProfile` 只接受 16 基础型 | `backend/app/Models/PersonalityProfile.php` | public personality / SEO / sitemap 不可能正式承载 `ENFJ-T` 等变体 | 扩展 `TYPE_CODES` 与读取逻辑，显式支持 32 型 |
+| G05 | L2 | baseline normalizer 拒绝 32 型 | `backend/app/PersonalityCms/Baseline/PersonalityBaselineNormalizer.php` | 导入链路无法写入 `-A/-T` 内容 | 修改 normalizer 规则与唯一性校验 |
+| G06 | L2 | `sections` key 集合无法承载目标模块 | `backend/app/Models/PersonalityProfileSection.php`、`backend/app/Filament/Ops/Resources/PersonalityProfileResource/Support/PersonalityWorkspace.php` | 无法保存 `lettersIntro`、`traitOverview`、`premium_teaser` | 扩展 section keys/render variants 或引入显式 payload schema |
+| G07 | L2 | `PersonalityController` 只会吐原始 profile + sections 行 | `backend/app/Http/Controllers/API/V0_5/Cms/PersonalityController.php` | 前端拿不到结构化结果页 DTO | 新增公共 serializer，输出模块化 payload |
+| G08 | L2 | `AttemptReadController::result` 直接回传 `result_json`，不是正式文案 DTO | `backend/app/Http/Controllers/API/V0_3/AttemptReadController.php` | 结果页如果直接用它，必然继续依赖前端 fallback | 让 result/report/share 共享统一公共模块 serializer |
+| G09 | L2 | premium teaser 没有 authored schema | `backend/app/Services/Report/ReportGatekeeperTeaserTrait.php`、`backend/app/Models/PersonalityProfileSection.php` | 只能 blur，不能运营化写 teaser | 新增 teaser payload 字段族并与 CTA 行为接线 |
+| G10 | L2 | SEO/OG/Twitter 未以 32 型 authority 为源 | `backend/app/Services/Cms/PersonalityProfileSeoService.php`、`backend/app/Models/PersonalityProfileSeoMeta.php` | SEO 与主结果页文案不一致 | 改为从统一 DTO 生成，再允许 overrides |
+| G11 | L2 | sitemap 仍以基础型 CMS 为源 | `backend/app/Services/SEO/SitemapGenerator.php` | personality 页收录粒度与正式结果页不一致 | sitemap source 改读统一 32 型 authority 或其 public projection |
+| G12 | L1 | share fallback 会去掉 `-A/-T` | `backend/app/Services/V0_3/ShareService.php` | 变体级标题/摘要可能回落到基础型 | variant-aware lookup + 明确降级规则 |
+| G13 | L1 | share 没有统一消费 `identity_card.share_text` | `backend/app/Services/V0_3/ShareService.php` | 分享文案与 report identity card 不完全同源 | 固定 share 文案字段优先级 |
+| G14 | L1 | report cards 已有，但未映射成公共 `career/growth/relationships` blocks | `backend/app/Services/Report/Composer/ReportPayloadAssemblerComposeBuildTrait.php`、`backend/app/Services/Report/Composer/ReportPayloadAssemblerComposeFinalizeTrait.php` | 结果页仍需要额外二次拼装 | 增加公共 section serializer |
+| G15 | L1 | `fap-web` sitemap 为空，未接 personality sitemap source | `fap-web/app/sitemap.ts` | 前端 sitemap 不覆盖人格页 | 接入后端 authority 输出 |
+| G16 | L1 | `next-sitemap.config.js` 缺失 | 仓库根目录缺失文件 | 现有 Next 侧 sitemap 配置不可审计 | 明确使用 App Router `sitemap.ts` 或补统一配置 |
+| G17 | L0 | 32 型结构化正文内容尚未导入 | 未来结构化 baseline 文件 | schema 就绪后仍需内容投放 | 批量导入 32 型内容，至少覆盖双语目标范围 |
+| G18 | L0 | `lettersIntro` 内容完全缺席 | 未来 baseline 内容文件 | 结果页无法达成目标结构 | 按 32 型批量编写/导入 |
+| G19 | L0 | `traitOverview.dimensions` 叙事内容缺席 | 未来 baseline 内容文件 | 只能显示数值，没有结构化解释 | 导入维度 narrative/tips/blocks |
+| G20 | L0 | premium teaser 正文缺席 | 未来 baseline 内容文件 | 无法做正式付费引导 | 编写 teaser copy 并按 32 型导入 |
+
+## 2. 对 4 个样例类型的 gap 观察
+
+| 样例 | 当前有的 | 当前缺的 | 结论 |
+| --- | --- | --- | --- |
+| `ENFJ-T` | report 32 型 profile / identity / cards / share_text | public personality 32 型记录、lettersIntro、traitOverview narrative、premium teaser、variant SEO | 适合作为第一批试导入样例 |
+| `ENFJ-A` | 同上 | 同上 | 可直接验证 A/T 对照策略 |
+| `INFP-T` | report 32 型内容完整 | public personality 只剩 `INFP` 基础型 | 最能暴露 base-type fallback 问题 |
+| `INTJ-T` | report 32 型内容完整，share 当前也会输出 `type_code` | share/public fallback 仍查 `INTJ` | 最能验证 share/SEO 同源改造是否完成 |
+
+## 3. 缺口优先级判断
+
+### 必须先解的
+
+- `G01` 单一 authority
+- `G04/G05/G06` 32 型 + section schema
+- `G07/G10/G11/G12` public serializer、SEO、sitemap、share 对齐
+
+### 不能后拖的
+
+- `G09` premium teaser schema
+- `G14` report cards 到公共 blocks 的映射
+
+### 可以放到内容导入阶段完成的
+
+- `G17/G18/G19/G20`
+
+## 4. Gap Matrix 结论
+
+当前问题不在“文案写得不够多”，而在：
+
+- authority 分叉
+- schema 不足
+- serializer 缺位
+- import 目标格式缺失
+
+所以正式上线工作不能从前端本地接附件开始，必须从后端 authority 收口开始。

--- a/docs/audits/mbti-result-copy-launch-plan.md
+++ b/docs/audits/mbti-result-copy-launch-plan.md
@@ -1,0 +1,277 @@
+# MBTI 结果页文案正式上线路线
+
+## 0. 路线选择
+
+本方案选择一条明确路线：
+
+- 公共结果页 authority 收口到后端 `PersonalityProfile` 体系的 V2 结构化读模型
+- 保留现有 `v0.3 report` 内容包与 cards 选择器，继续承担深度报告与门控职责
+- 新的结构化基线内容通过 import 批量进入后端
+- `result`、`share`、`personality`、`seo/og`、`sitemap` 统一改为消费同一套公共 serializer
+
+这样做的理由：
+
+- 当前 SEO、OG、sitemap、Filament 编辑壳都已经建立在 `PersonalityProfile` 体系上
+- 当前 report 又已经掌握 32 型和 A/T 权威内容
+- 最稳妥的正式上线方式不是推翻其中一套，而是把它们接到同一套公共 schema 与 serializer 上
+
+## A. 权威源收口
+
+### 输入
+
+- `content_packages/default/...` 的 32 型内容
+- `results` 表中的五轴数值与 `type_code`
+- 现有 `PersonalityProfile` 公共链路
+- 本次审计文档
+
+### 输出
+
+- 一份明确的“公共结果页 authority DTO”定义
+- 明确字段归属：
+  - runtime numeric 归 `results`
+  - 32 型人格文案归 structure baseline / public authority
+  - 深度 cards 归 report content pack
+
+### 改动面
+
+- 新的 DTO/serializer 设计文档
+- `backend/app/Http/Controllers/API/V0_3/AttemptReadController.php`
+- `backend/app/Services/V0_3/ShareService.php`
+- `backend/app/Http/Controllers/API/V0_5/Cms/PersonalityController.php`
+
+### 验收标准
+
+- 所有 surface 都能回答“标题/副标题/summary/SEO/share 来自哪一份 authority”
+- 不再允许出现“share 从 report 取一部分、SEO 从 CMS 取一部分、结果页前端自己再写一部分”
+
+### 风险点
+
+- 双轨期可能同时存在旧 personality API 和新 DTO
+- 需要清晰的版本边界，避免老客户端直接 break
+
+## B. schema / section 映射
+
+### 输入
+
+- 目标模块：`lettersIntro`、`traitOverview.dimensions`、`traits`、`career`、`growth`、`relationships`、`premiumTeaser`
+
+### 输出
+
+- 32 型可承载 schema
+- 新 section keys / render variants / payload 结构
+- `base_type_code` / `variant` 等派生字段约定
+
+### 改动面
+
+- `backend/database/migrations/*` 新迁移
+- `backend/app/Models/PersonalityProfile.php`
+- `backend/app/Models/PersonalityProfileSection.php`
+- `backend/app/Filament/Ops/Resources/PersonalityProfileResource/Support/PersonalityWorkspace.php`
+
+### 验收标准
+
+- `PersonalityProfile` 能正式承接 `ENFJ-T` 等 32 型
+- section schema 能承接：
+  - `letters_intro`
+  - `trait_overview`
+  - `traits_blocks`
+  - `career_blocks`
+  - `growth_blocks`
+  - `relationships_blocks`
+  - `premium_teaser`
+
+### 风险点
+
+- 直接改现有 `SECTION_KEYS` 可能影响 V1 内容
+- 更稳妥做法是：
+  - V1 保留
+  - 增量加入 V2 section keys
+  - serializer 按 schema_version 分流
+
+## C. authoring / import 方案
+
+### 输入
+
+- 附件原始文案
+- 当前 32 型 report 内容包
+- 现有 `content_baselines/personality/mbti.*.json`
+
+### 输出
+
+- 新的结构化 baseline 文件格式
+- dry-run / create / upsert / revision 完整导入链路
+- 双语批量导入能力
+
+### 改动面
+
+- `backend/app/Console/Commands/PersonalityImportLocalBaseline.php`
+- `backend/app/PersonalityCms/Baseline/PersonalityBaselineReader.php`
+- `backend/app/PersonalityCms/Baseline/PersonalityBaselineNormalizer.php`
+- `backend/app/PersonalityCms/Baseline/PersonalityBaselineImporter.php`
+- `content_baselines/personality/*`
+
+### 验收标准
+
+- 能对 `ENFJ-T`、`ENFJ-A`、`INFP-T`、`INTJ-T` 先做试导入
+- upsert 幂等
+- revision 正常生成
+- dry-run 能给出 create/update/skip 统计与 diff 摘要
+
+### 风险点
+
+- 附件如果是半结构化文档，需要先转成稳定 authoring format
+- 双语内容可能存在字段不对齐，需要 import 前 lint
+
+## D. frontend 渲染升级
+
+### 输入
+
+- 新的公共结果页 DTO
+
+### 输出
+
+- 结果页、分享页、人格详情页统一使用后端结构化 payload
+- 去除前端本地 fallback 文案
+
+### 改动面
+
+- 当前仓库内能确认的前端文件只有：
+  - `fap-web/app/sitemap.ts`
+  - `fap-web/app/robots.ts`
+- 实际结果页 route/component 文件未在当前仓库扫描到，需要在真实前端仓库落地
+
+### 验收标准
+
+- 页面渲染不再依赖本地 MBTI 文案常量
+- 32 型 `-A/-T` 在 UI 中可见且一致
+- `lettersIntro`、`traitOverview.dimensions`、分层 `career/growth/relationships` 全部由后端结构化输出驱动
+
+### 风险点
+
+- 当前前端真实文件缺席，必须先补齐 repo 边界
+- 若前端已有隐藏 fallback，必须全部清理
+
+## E. premium teaser 接线
+
+### 输入
+
+- 新 `premium_teaser` authored payload
+- 现有 `ReportGatekeeper` / `cta` 门控行为
+
+### 输出
+
+- 有内容、可维护、可 A/B 的 premium teaser 模块
+
+### 改动面
+
+- `backend/app/Models/PersonalityProfileSection.php`
+- `backend/app/Http/Controllers/API/V0_5/Cms/PersonalityController.php`
+- `backend/app/Services/V0_3/ShareService.php`
+- `backend/app/Services/Report/ReportGatekeeperTeaserTrait.php`
+
+### 验收标准
+
+- premium teaser 文案来自 authoring/import，不是写死在前端
+- CTA 行为继续由 gatekeeper 负责
+- teaser 可独立调整而不影响 report cards
+
+### 风险点
+
+- 容易把 teaser 再做成第二套半硬编码配置
+- 必须规定 teaser 与 CTA 的边界：文案归 content，行为归 gatekeeper
+
+## F. share / seo / og 对齐
+
+### 输入
+
+- 统一公共结果页 DTO
+- SEO overrides 机制
+
+### 输出
+
+- share / SEO / OG / Twitter / JSON-LD 与主结果页同源
+
+### 改动面
+
+- `backend/app/Services/V0_3/ShareService.php`
+- `backend/app/Services/Cms/PersonalityProfileSeoService.php`
+- `backend/app/Services/SEO/SitemapGenerator.php`
+- `fap-web/app/sitemap.ts`
+
+### 验收标准
+
+- `ENFJ-T` 与 `ENFJ-A` 的分享标题/副标题/summary 可区分
+- `INTJ-T` 不再通过 `INTJ` base type 做 silent fallback
+- sitemap 与 personality public pages 的收录来源与结果页 authority 一致
+
+### 风险点
+
+- 若 URL 仍使用基础型 slug，需要明确 canonical 策略
+- 不能让 SEO schema 与前台页面各自生成不同文案
+
+## G. QA / contract / snapshot / acceptance
+
+### 输入
+
+- 新 schema
+- 新 serializer
+- 四个样例类型
+
+### 输出
+
+- 合同测试
+- snapshot
+- acceptance checklist
+
+### 改动面
+
+- `backend/tests/Feature/V0_5/PersonalityPublicApiTest.php`
+- `backend/tests/Feature/PersonalityCms/PersonalityBaselineImportTest.php`
+- `backend/tests/Feature/V0_3/ShareSummaryContractTest.php`
+- `backend/tests/Feature/Report/MbtiReportContentEnhancementContractTest.php`
+- 新增公共结果页 serializer 合同测试
+
+### 验收标准
+
+- 四个样例类型全部通过：
+  - `ENFJ-T`
+  - `ENFJ-A`
+  - `INFP-T`
+  - `INTJ-T`
+- 验证项至少包括：
+  - `typeCode` 保留
+  - `variant` 可读
+  - `lettersIntro` 有值
+  - `traitOverview.dimensions` 结构完整
+  - `career/growth/relationships` blocks 完整
+  - premium teaser 有值
+  - share/SEO/OG 与主结果页主文案同源
+
+### 风险点
+
+- 只测 `report` 不够，必须补 `personality`、`share`、`seo`、`sitemap`
+- snapshot 必须锁定字段结构，不只是锁定几个字符串
+
+## 1. 正式上线最小可行切分
+
+建议最小切分如下：
+
+1. 先打通四个样例类型的 32 型 public authority
+2. 再打通统一 serializer
+3. 再接 share / SEO / sitemap
+4. 最后批量导入所有 32 型与双语内容
+
+原因：
+
+- 先跑通四个样例，最容易暴露 `A/T`、base type fallback、public API schema 的结构问题
+- 先跑通 authority 与 serializer，再铺量导入，返工成本最低
+
+## 2. 路线总结
+
+正式上线不是“把附件接到页面上”，而是把当前三条链路：
+
+- result/report
+- public personality
+- share/SEO/sitemap
+
+收口成一条长期可维护的后端内容链路。

--- a/docs/audits/mbti-result-copy-target-schema-map.md
+++ b/docs/audits/mbti-result-copy-target-schema-map.md
@@ -1,0 +1,320 @@
+# MBTI 结果页目标结构到当前后端 Schema 的映射
+
+## 0. 目标结构说明
+
+本文件把“附件目标结构”按任务中点名模块进行推断映射。目标不是把附件硬编码进前端，而是定义：
+
+- 哪些字段当前后端已能承接
+- 哪些字段可以先塞进现有 `sections.payload_json`
+- 哪些字段必须扩 schema
+- 哪些字段必须新增 serializer / renderer
+
+判定标签固定为四种：
+
+- `已可直接承载`
+- `可通过现有 sections 承载`
+- `需要小幅扩 schema`
+- `需要新增 renderer / serializer`
+
+## 1. 目标字段逐项映射
+
+| 目标字段 | 当前后端落点 | 判定 | 说明 |
+| --- | --- | --- | --- |
+| `typeCode` | `results.type_code`、`report.profile.type_code` | 已可直接承载 | runtime 已保留 `ENFJ-T` 这类完整码 |
+| `baseTypeCode` | 可由 `typeCode` 派生 | 需要新增 renderer / serializer | 当前没有统一显式字段，只在 `ShareService` 内部临时派生 |
+| `variant` | 可由 `typeCode` 派生 | 需要新增 renderer / serializer | 当前没有公开输出的 `A/T` 独立字段 |
+| `typeName` | `type_profiles.json.type_name` | 已可直接承载 | 32 型 report 已有 |
+| `headlineTitle` | `report_identity_cards.json.title` 或 `identity_layers.json.title` | 已可直接承载 | 已有更适合结果页首屏的标题 |
+| `headlineSubtitle` | `report_identity_cards.json.subtitle` / `identity_layers.json.subtitle` | 已可直接承载 | 但未统一暴露给 public personality API |
+| `tagline` | `type_profiles.json.tagline` / `report_identity_cards.json.tagline` | 已可直接承载 | 当前 share/report 都在用 |
+| `summary` | `type_profiles.json.short_summary` + `identity_card.summary` | 已可直接承载 | 需统一优先级 |
+| `rarity` | `type_profiles.json.rarity` | 已可直接承载 | 32 型 report 已有 |
+| `keywords[]` | `type_profiles.json.keywords` / `identity_card.tags` | 已可直接承载 | 当前命名不统一 |
+| `lettersIntro.title` | 无 | 需要小幅扩 schema | 需要新增 section key，例如 `letters_intro` |
+| `lettersIntro.items[]` | 无 | 需要小幅扩 schema | 现有 `sections` 无法表达按字母拆解的人格介绍 |
+| `traitOverview.title` | 无统一字段 | 可通过现有 sections 承载 | 可暂放新 section，但最好升级为显式结构 |
+| `traitOverview.dimensions[].code` | `scores_pct` / `axis_states` | 已可直接承载 | 五轴数据已有 |
+| `traitOverview.dimensions[].letter` | `typeCode` + `scores_pct` | 需要新增 renderer / serializer | 当前无标准输出对象 |
+| `traitOverview.dimensions[].pct` | `results.scores_pct` | 已可直接承载 | 五轴包括 `AT` |
+| `traitOverview.dimensions[].state` | `results.axis_states` | 已可直接承载 | 已有 `clear/strong/...` |
+| `traitOverview.dimensions[].title` | 无 | 需要小幅扩 schema | 需要维度叙事文案 |
+| `traitOverview.dimensions[].summary` | 无 | 需要小幅扩 schema | 不能继续靠前端词典拼装 |
+| `traitOverview.dimensions[].strengthBlock` | 当前仅可从 `report_cards_*` 间接选取 | 需要新增 renderer / serializer | 需要统一 serializer 把维度摘要结构化 |
+| `traitOverview.dimensions[].riskBlock` | 同上 | 需要新增 renderer / serializer | 同上 |
+| `traitOverview.dimensions[].tips[]` | 当前 `cards[].tips` 有碎片 | 可通过现有 sections 承载 | 但建议做标准维度 payload |
+| `career.intro` | 可取自 `career` cards 顶层描述组合 | 需要新增 renderer / serializer | 现有只有卡片池，没有 section intro |
+| `career.blocks[]` | `report.sections.career.cards[]` | 已可直接承载 | 已有 cards、bullets、tips、module_code |
+| `growth.intro` | 同理 | 需要新增 renderer / serializer | 需要将 card 池升为公共 section DTO |
+| `growth.blocks[]` | `report.sections.growth.cards[]` | 已可直接承载 | 当前仅在 report 中可见 |
+| `relationships.intro` | 同理 | 需要新增 renderer / serializer | 需要公共 DTO |
+| `relationships.blocks[]` | `report.sections.relationships.cards[]` | 已可直接承载 | 但 public profile 当前只有单段文本 |
+| `traits.blocks[]` | `report.sections.traits.cards[]` | 已可直接承载 | 适合作为“你的人格表现”区块 |
+| `premiumTeaser.headline` | 无 | 需要小幅扩 schema | 当前只有 paywall blur，不是 authored teaser |
+| `premiumTeaser.body` | 无 | 需要小幅扩 schema | 需要运营可维护内容位 |
+| `premiumTeaser.bullets[]` | 无 | 需要小幅扩 schema | 同上 |
+| `premiumTeaser.cta` | `ReportGatekeeper.cta` 可提供行为 | 可通过现有 sections 承载 | 行为已有，文案位缺失 |
+| `share.title` | `ShareService` 运行时可拼出 | 需要新增 renderer / serializer | 应统一改由结果页 authority 输出 |
+| `share.subtitle` | `ShareService` 运行时可拼出 | 需要新增 renderer / serializer | 当前 fallback 会丢 `-A/-T` |
+| `share.summary` | `identity_card.summary` / `report.profile.short_summary` / `publicProfile.excerpt` | 需要新增 renderer / serializer | 应固定优先级并与主结果页同源 |
+| `share.shareText` | `report_identity_cards.json.share_text` | 已可直接承载 | 当前 share API 没有充分消费这一字段 |
+| `seo.title` | `seo_meta.seo_title` | 已可直接承载 | 但不是从 32 型公共 authority 生成 |
+| `seo.description` | `seo_meta.seo_description` | 已可直接承载 | 同上 |
+| `seo.og.*` | `seo_meta.og_*` | 已可直接承载 | 同上 |
+| `seo.twitter.*` | `seo_meta.twitter_*` | 已可直接承载 | 同上 |
+| `seo.jsonld` | `seo_meta.jsonld_overrides_json` + `PersonalityProfileSeoService` | 已可直接承载 | 需要改为消费 32 型 authority |
+| `metadata.contentVersion` | `report.versions`、`profile.schema_version` | 已可直接承载 | 现有来源分裂 |
+| `metadata.sourceVersion` | `content_package_version`、baseline `schema_version` | 已可直接承载 | 需要统一写法 |
+
+## 2. 推荐的目标后端承载形态
+
+推荐把公共结果页 authority 升级为“32 型 + 结构化 payload”的后端读模型：
+
+```yaml
+profile:
+  type_code: ENFJ-T
+  base_type_code: ENFJ
+  variant: T
+  locale: zh-CN
+  title: 主人公
+  subtitle: 把人心与目标组织成统一节奏的引导者，校准感更强
+  tagline: 先理解人，再推动群体走向同一方向
+  summary: ...
+  rarity: 约 2–3%
+  keywords: [...]
+modules:
+  letters_intro:
+    title: ...
+    items: [...]
+  trait_overview:
+    title: ...
+    dimensions: [...]
+  traits:
+    intro: ...
+    blocks: [...]
+  career:
+    intro: ...
+    blocks: [...]
+  growth:
+    intro: ...
+    blocks: [...]
+  relationships:
+    intro: ...
+    blocks: [...]
+  premium_teaser:
+    headline: ...
+    body: ...
+    bullets: [...]
+share:
+  title: ...
+  subtitle: ...
+  summary: ...
+  share_text: ...
+seo:
+  title: ...
+  description: ...
+  og: ...
+  twitter: ...
+```
+
+落地建议：
+
+- `profile` 继续放在 `personality_profiles`
+- 结构化模块优先走 `personality_profile_sections.payload_json`
+- 但 section key 必须升级，不能继续只用 `core_snapshot/strengths/...`
+- 输出必须新增一个“公共结果页 serializer”，不能继续靠 `PersonalityController` 直接吐原始 section 行
+
+## 3. 明确禁止继续留在前端本地硬编码的字段
+
+以下字段不允许继续作为前端本地大常量：
+
+- 任何 32 型 `type_code` 对应的 `title/subtitle/tagline/summary`
+- `lettersIntro` 全部内容
+- `traitOverview.dimensions` 的叙事标题、解释、tips
+- `career/growth/relationships` 的 block 文案
+- `premium teaser` 全部文案
+- `share.title/share.subtitle/share.summary/shareText`
+- `seo.title/description/og/twitter`
+- `-A/-T` 与基础型之间的回退映射词典
+
+原因：
+
+- 当前后端已有 32 型 runtime authority 基础
+- 前端本地硬编码会制造第三套 source of truth
+- 未来批量导入、CMS 修改、SEO 同步都无法闭环
+
+## 4. 4 个样例类型试映射
+
+以下只给“目标字段结构示意”，不写最终业务代码。
+
+### 4.1 `ENFJ-T`
+
+```yaml
+typeCode: ENFJ-T
+baseTypeCode: ENFJ
+variant: T
+profile:
+  typeName:
+    source: content_packages/.../type_profiles.json.items.ENFJ-T.type_name
+  title:
+    source: content_packages/.../report_identity_cards.json.items.ENFJ-T.title
+  subtitle:
+    source: content_packages/.../report_identity_cards.json.items.ENFJ-T.subtitle
+  tagline:
+    source: content_packages/.../type_profiles.json.items.ENFJ-T.tagline
+  summary:
+    source:
+      - content_packages/.../type_profiles.json.items.ENFJ-T.short_summary
+      - content_packages/.../report_identity_cards.json.items.ENFJ-T.summary
+      - content_packages/.../identity_layers.json.items.ENFJ-T.one_liner
+lettersIntro:
+  source: none
+  targetLanding: personality_profile_sections.section_key=letters_intro
+traitOverview:
+  dimensions:
+    numeric:
+      source: results.scores_pct + results.axis_states
+    narrative:
+      source: none
+      targetLanding: personality_profile_sections.section_key=trait_overview
+career:
+  blocks:
+    source: report.sections.career.cards[]
+growth:
+  blocks:
+    source: report.sections.growth.cards[]
+relationships:
+  blocks:
+    source: report.sections.relationships.cards[]
+premiumTeaser:
+  source: none
+share:
+  shareText:
+    source: content_packages/.../report_identity_cards.json.items.ENFJ-T.share_text
+seo:
+  source: current seo_meta only, not variant-aware
+```
+
+缺口：
+
+- `lettersIntro` 缺字段
+- `traitOverview` 缺维度叙事与公共 serializer
+- `premiumTeaser` 缺字段
+- `seo/share` 仍未以 `ENFJ-T` 为公共 authority
+
+### 4.2 `ENFJ-A`
+
+```yaml
+typeCode: ENFJ-A
+baseTypeCode: ENFJ
+variant: A
+profile:
+  typeName:
+    source: type_profiles.json.items.ENFJ-A.type_name
+  title:
+    source: report_identity_cards.json.items.ENFJ-A.title
+  subtitle:
+    source: report_identity_cards.json.items.ENFJ-A.subtitle
+  summary:
+    source:
+      - type_profiles.json.items.ENFJ-A.short_summary
+      - report_identity_cards.json.items.ENFJ-A.summary
+      - identity_layers.json.items.ENFJ-A.one_liner
+lettersIntro:
+  targetLanding: new section payload
+traitOverview:
+  dimensions:
+    numeric: results 5-axis
+    narrative: new section payload
+career/growth/relationships:
+  blocks: report cards serializer
+premiumTeaser:
+  targetLanding: new section payload
+seo/share:
+  currentFallback: personality_profiles.type_code = ENFJ
+```
+
+缺口：
+
+- 与 `ENFJ-T` 同类
+- A/T 差异虽在 report pack 中存在，但未沉淀到公共 personality/SEO/share
+
+### 4.3 `INFP-T`
+
+```yaml
+typeCode: INFP-T
+baseTypeCode: INFP
+variant: T
+profile:
+  authored32:
+    source:
+      - type_profiles.json.items.INFP-T
+      - report_identity_cards.json.items.INFP-T
+      - identity_layers.json.items.INFP-T
+  publicCms:
+    currentFallback:
+      - personality_profiles.type_code = INFP
+      - personality_profile_sections (base type only)
+traitOverview:
+  numeric: results.scores_pct + axis_states
+  narrative: missing
+sections:
+  traits/career/growth/relationships:
+    source: report cards
+premiumTeaser:
+  missing: true
+seo:
+  currentFallback: seo_meta attached to INFP base type only
+```
+
+缺口：
+
+- `INFP-T` 虽有 32 型权威内容，但公共链路只能退到 `INFP`
+- 结果页结构升级字段全部未进入 CMS/public API
+
+### 4.4 `INTJ-T`
+
+```yaml
+typeCode: INTJ-T
+baseTypeCode: INTJ
+variant: T
+profile:
+  authored32:
+    source:
+      - type_profiles.json.items.INTJ-T
+      - report_identity_cards.json.items.INTJ-T
+      - identity_layers.json.items.INTJ-T
+  publicCms:
+    currentFallback:
+      - personality_profiles.type_code = INTJ
+share:
+  currentBehavior:
+    type_code: INTJ-T
+    publicProfileLookup: strips_to_INTJ
+traitOverview:
+  numeric: available
+  narrative: missing
+lettersIntro:
+  missing: true
+premiumTeaser:
+  missing: true
+```
+
+缺口：
+
+- `share` 最容易出现“标题/摘要与 `INTJ-T` 本体不完全对齐”的问题
+- `INTJ-T` 的 SEO/OG 目前仍要借 `INTJ` base type 页面兜底
+
+## 5. 目标 Schema Map 结论
+
+可以直接复用的部分其实不少：
+
+- 32 型 identity/profile 内容已经存在于 report 内容包
+- 五轴 numeric 数据已经存在于 results
+- cards 化的 `career/growth/relationships/traits` 已经存在于 report
+
+真正缺的是四件事：
+
+- 公共 authority 必须升为 32 型
+- section key/payload 必须升级到能承接 `lettersIntro/traitOverview/premiumTeaser`
+- public API 必须提供统一结构化 serializer
+- share/seo/og 必须改为消费同一套结构化 authority

--- a/docs/audits/pr1-mbti-authority-special-scan.md
+++ b/docs/audits/pr1-mbti-authority-special-scan.md
@@ -1,0 +1,262 @@
+# PR-1 MBTI Authority Special Scan
+
+## Scope
+
+- Scan mode: read-only
+- Allowed changes in this round: audit markdown only
+- Forbidden in this round: business code, tests, scripts, config, migrations, routes, frontend components
+- Workspaces scanned:
+  - `fap-api` at `0748c24798cbbfdbaf8a3d12b450ac42593fb912`
+  - `fap-web` at `767b538ebea78f3e572f237db6291a0d69ac6aa2`
+
+## Command Baseline
+
+### `fap-api`
+
+- `git checkout main`: already on `main`
+- `git pull --ff-only origin main`: already up to date
+- `git rev-parse HEAD`: `0748c24798cbbfdbaf8a3d12b450ac42593fb912`
+- `git status --short --branch`: `## main...origin/main`
+- Worktree note: existing unrelated modified compiled content-pack files and untracked docs directories were already present before this scan
+
+### `fap-web`
+
+- `git checkout main`: already on `main`
+- `git pull --ff-only origin main`: already up to date
+- `git rev-parse HEAD`: `767b538ebea78f3e572f237db6291a0d69ac6aa2`
+- `git status --short --branch`: `## main...origin/main`
+
+### Attachment
+
+- `/Users/rainie/Desktop/微信小程序结果页文案.txt` contains `32` authored objects under `MBTI_PROFILES` and a `getProfile(rawType)` fallback that:
+  - accepts `5`-char codes first
+  - silently degrades `4`-char codes to `-T` or `-A`
+  - hard-defaults to `ENFJ-T`
+- Evidence: `/Users/rainie/Desktop/微信小程序结果页文案.txt:13648-13701`
+
+## Current Authority Total Graph
+
+```text
+MBTI public surfaces today are split across three different source systems:
+
+1. v0.3 result/report/share
+   routes/api.php
+   -> AttemptReadController / ShareController
+   -> Result rows + ReportComposer + ShareService
+   -> content_packages/default/.../MBTI-CN-v0.3/*
+
+2. v0.5 personality/seo
+   routes/api.php
+   -> PersonalityController
+   -> PersonalityProfileService / PersonalityProfileSeoService
+   -> personality_profiles + personality_profile_sections + personality_profile_seo_meta
+   -> imported from content_baselines/personality/mbti.*.json
+
+3. frontend share/og/metadata presentation
+   fap-web app routes
+   -> getShareSummary / getPersonalityProfileBySlugOrType / getPersonalitySeoBySlugOrType
+   -> local metadata and OG copy builders
+   -> local render-time fallback/normalization
+```
+
+## Data Chain by Surface
+
+### 1. `v0.3 result`
+
+- Route: `backend/routes/api.php:163-165`
+- Controller: `backend/app/Http/Controllers/API/V0_3/AttemptReadController.php:68-210`
+- Source:
+  - `results.result_json`
+  - `results.type_code`
+  - `results.scores_json`
+  - `results.scores_pct`
+- Identity behavior:
+  - keeps `type_code` as stored on the result row
+  - does not expose `base_type_code`
+  - does not expose a dedicated `variant` field
+- Narrative shape:
+  - simple payload only
+  - frontend fallback surface reads only `summary + dimensions`
+
+### 2. `v0.3 report`
+
+- Route: `backend/routes/api.php:166-168`
+- Controller: `backend/app/Http/Controllers/API/V0_3/AttemptReadController.php:213-260`
+- Gate/composer:
+  - `backend/app/Services/Report/ReportComposer.php:25-82`
+  - `backend/app/Services/Report/Composer/ReportPayloadAssemblerComposeBuildTrait.php:84-169`
+  - `backend/app/Services/Report/Composer/ReportPayloadAssemblerComposeFinalizeTrait.php:50-91`
+  - `backend/app/Services/Report/Composer/ReportPayloadAssemblerProfilesTrait.php:41-118`
+- Source files:
+  - `type_profiles.json`
+  - `report_identity_cards.json`
+  - `identity_layers.json`
+  - `report_recommended_reads.json`
+  - section cards generated from pack/store/rules
+- Identity behavior:
+  - `32`-type authored chain exists
+  - `A/T` is preserved in `report.profile.type_code` and in identity layer lookups
+- Proof:
+  - `backend/tests/Feature/Report/MbtiReportContentEnhancementContractTest.php:23-32`
+  - `backend/tests/Feature/Report/MbtiReportContentEnhancementContractTest.php:132-171`
+
+### 3. `v0.3 share`
+
+- Routes:
+  - `backend/routes/api.php:173-174`
+  - `backend/routes/api.php:220-228`
+- Controller/service chain:
+  - `backend/app/Http/Controllers/API/V0_3/ShareController.php:40-58`
+  - `backend/app/Services/V0_3/ShareFlowService.php:45-76`
+  - `backend/app/Services/V0_3/ShareService.php:193-347`
+- Actual source mix inside `ShareService::buildShareSummary()`:
+  - `results.result_json`
+  - free report snapshot from `ReportComposer`
+  - `identity_card`
+  - `identity layer`
+  - `personality_profiles` public profile fallback
+- Identity behavior:
+  - outward payload keeps `type_code` from the result row
+  - internal public-profile lookup strips `-A/-T` with `baseTypeCode()`
+  - no dedicated `base_type_code` or `variant` field is emitted
+- Proof of downgrade path:
+  - `backend/app/Services/V0_3/ShareService.php:330-362`
+
+### 4. `v0.5 personality`
+
+- Route: `backend/routes/api.php:347-349`
+- Controller: `backend/app/Http/Controllers/API/V0_5/Cms/PersonalityController.php:63-90`
+- Service/model chain:
+  - `backend/app/Services/Cms/PersonalityProfileService.php:28-50`
+  - `backend/app/Models/PersonalityProfile.php:17-36`
+  - `backend/app/Models/PersonalityProfileSection.php:15-36`
+- Source:
+  - `personality_profiles`
+  - `personality_profile_sections`
+  - `personality_profile_seo_meta`
+- Origin:
+  - `backend/content_baselines/personality/mbti.zh-CN.json:2-7`
+  - source metadata explicitly says it came from old frontend deterministic transforms
+- Identity behavior:
+  - only `16` base types exist
+  - `ENFJ-T` style lookups do not resolve
+  - `A/T` is not modeled
+
+### 5. `v0.5 seo`
+
+- Route: `backend/routes/api.php:348`
+- Controller: `backend/app/Http/Controllers/API/V0_5/Cms/PersonalityController.php:92-114`
+- Builder:
+  - `backend/app/Services/Cms/PersonalityProfileSeoService.php:15-80`
+- Source:
+  - `personality_profile_seo_meta`
+  - fallback to `profile.title`, `profile.excerpt`, `profile.subtitle`
+- Identity behavior:
+  - tied to `v0.5 personality`, therefore base-type only
+
+### 6. OG
+
+#### Share OG
+
+- Frontend route: `fap-web/app/og/share/[id]/route.tsx:10-32`
+- Source:
+  - `getShareSummary()` from `v0.3 share`
+  - local OG renderer `fap-web/lib/og/mbtiShare.tsx:130-307`
+- Behavior:
+  - same upstream share payload
+  - but title, description, narrative, tag filtering, truncation, and dimension wording are recomposed on the frontend
+
+#### Personality OG
+
+- No dedicated OG image route was found for personality detail
+- Current personality page OG comes from Next metadata in:
+  - `fap-web/app/(localized)/[locale]/personality/[type]/page.tsx:42-95`
+  - `fap-web/lib/cms/personality.ts:407-455`
+- Source remains `v0.5 seo`
+
+### 7. Sitemap source
+
+#### `v0.3 /scales/sitemap-source`
+
+- Route: `backend/routes/api.php:143`
+- Controller: `backend/app/Http/Controllers/API/V0_3/ScalesSitemapSourceController.php:18-66`
+- Source:
+  - `scales_registry`
+- This endpoint is not a personality narrative authority source
+
+#### Backend personality sitemap
+
+- Generator: `backend/app/Services/SEO/SitemapGenerator.php:213-260`
+- Source:
+  - `personality_profiles`
+- Behavior:
+  - emits only current CMS public rows
+  - therefore emits only the `16` simple-version personality pages
+
+#### Frontend sitemap
+
+- `fap-web/next-sitemap.config.js:17-33`
+- Frontend explicitly excludes:
+  - `/share/*`
+  - `/result/*`
+  - `/compare/*`
+  - `/history/*`
+- `fap-web/tests/contracts/personality-cleanup.contract.test.ts:25-31` also locks that frontend no longer claims personality detail authority in its own sitemap generation
+
+## Which Chain Preserves `32` Types and `A/T`
+
+| Surface | Preserves `32` types | Preserves `A/T` | Notes |
+| --- | --- | --- | --- |
+| `v0.3 result` | Yes, if stored on `results.type_code` | Yes, inside `type_code` only | Simple payload |
+| `v0.3 report` | Yes | Yes | Current strongest narrative authority |
+| `v0.3 share` | Partial | Partial | Public profile fallback strips `-A/-T` internally |
+| `v0.5 personality` | No | No | `16` base types only |
+| `v0.5 seo` | No | No | Derived from base-type CMS rows |
+| Share OG | Depends on `v0.3 share` | Depends on `v0.3 share` | Frontend recomposes copy |
+| Backend personality sitemap | No | No | Enumerates `personality_profiles` only |
+
+## Which Chain Loses `A/T`
+
+| Chain | Loss point | Evidence |
+| --- | --- | --- |
+| `v0.3 share -> public profile lookup` | `baseTypeCode()` strips suffix before `getPublicProfileByType()` | `backend/app/Services/V0_3/ShareService.php:336-362` |
+| `v0.5 personality` | Model/type registry has only base types | `backend/app/Models/PersonalityProfile.php:19-36` |
+| `v0.5 baseline import` | Normalizer rejects `ENFJ-T` style types | `backend/app/PersonalityCms/Baseline/PersonalityBaselineNormalizer.php:116-126` |
+| `backend sitemap personality` | Reads only base-type `personality_profiles` | `backend/app/Services/SEO/SitemapGenerator.php:220-237` |
+
+## Evidence That A Unique Authority Does Not Exist Today
+
+1. Public result/report narrative authority is the content pack chain, not CMS.
+   - Evidence: `backend/app/Services/Report/Composer/ReportPayloadAssemblerProfilesTrait.php:41-118`
+2. Public personality detail authority is CMS baseline content imported from an old frontend transform, not the report content pack.
+   - Evidence: `backend/content_baselines/personality/mbti.zh-CN.json:2-7`
+3. Public share is a hybrid object composed from result row, report snapshot, and base-type CMS fallback.
+   - Evidence: `backend/app/Services/V0_3/ShareService.php:221-296`
+4. Public SEO is generated from CMS `seo_meta` plus local fallback text rules, not from the report payload.
+   - Evidence: `backend/app/Services/Cms/PersonalityProfileSeoService.php:15-52`
+5. Share page metadata and share OG still do a second frontend-side copy composition pass.
+   - Evidence:
+     - `fap-web/app/(localized)/[locale]/share/[id]/page.tsx:36-55`
+     - `fap-web/lib/og/mbtiShare.tsx:130-173`
+6. Personality sitemap enumerates CMS rows only, while report authority lives elsewhere.
+   - Evidence: `backend/app/Services/SEO/SitemapGenerator.php:213-260`
+
+## PR-1 Conclusion
+
+Current MBTI public result infrastructure is split like this:
+
+- `v0.3 report` is the only live chain that already behaves like a `32`-type narrative authority.
+- `v0.5 personality/seo/sitemap` is still the `16`-type simple-version CMS chain.
+- `v0.3 share` is neither fully report-authoritative nor fully CMS-authoritative; it is a hybrid with a silent base-type downgrade.
+
+That means PR-1 cannot be a content-import PR. It must first introduce a shared authority skeleton that can later power:
+
+- `result`
+- `report`
+- `share`
+- `personality`
+- `seo`
+- `og`
+- `sitemap`
+
+without letting `base_type_code` replace the `5`-character `type_code`.

--- a/docs/audits/pr1-mbti-consumer-matrix.md
+++ b/docs/audits/pr1-mbti-consumer-matrix.md
@@ -1,0 +1,129 @@
+# PR-1 MBTI Consumer Matrix
+
+## Matrix Scope
+
+- Backend public consumers:
+  - `v0.3 result`
+  - `v0.3 report`
+  - `v0.3 share`
+  - `v0.5 personality`
+  - `v0.5 seo`
+  - backend personality sitemap
+- Frontend public consumers:
+  - `fap-web /result/[id]`
+  - `fap-web /share/[id]`
+  - `fap-web /og/share/[id]`
+  - `fap-web /personality/[type]`
+  - `fap-web next-sitemap`
+
+## Consumer Matrix
+
+| Surface | Controller / route | Service / serializer / adapter | Frontend consumer | `type_code` status | `base_type_code` / `variant` status | Fallback present | Current attachment-structure capacity |
+| --- | --- | --- | --- | --- | --- | --- | --- |
+| `v0.3 result` | `AttemptReadController::result` `backend/app/Http/Controllers/API/V0_3/AttemptReadController.php:68-210` | raw `results.result_json` compat wrapper | `ResultClient` fallback path `fap-web/app/(localized)/[locale]/(app)/result/[id]/ResultClient.tsx:197-245` | keeps `5`-char `type_code` if result row has it | no explicit `base_type_code`; no explicit A/T field | Yes | `heroSummary` only, no `lettersIntro`, no structured `traitOverview/career/growth/relationships`, no premium teaser |
+| `v0.3 report` | `AttemptReadController::report` `backend/app/Http/Controllers/API/V0_3/AttemptReadController.php:213-260` | `ReportGatekeeper -> ReportComposer -> ReportPayloadAssembler` | `RichResultReport` path via `ResultClient` `fap-web/app/(localized)/[locale]/(app)/result/[id]/ResultClient.tsx:317-319` | keeps `5`-char `type_code` | no explicit `base_type_code`; access `variant` means free/full, not A/T | Limited authored fallbacks only | Can carry rich narrative cards, identity layers, recommended reads; does not match attachment block structure one-to-one yet |
+| `v0.3 share` | `ShareController::getShare/getShareView` `backend/app/Http/Controllers/API/V0_3/ShareController.php:40-58` | `ShareFlowService -> ShareService::buildShareSummary()` | `ShareClient` + `MbtiShareSummaryCard` | outward `type_code` keeps `5` chars | internal public-profile lookup strips to base type; no outward `base_type_code` or `variant` field | Yes | Only lightweight summary, tags, rarity, dimensions, CTA; cannot carry attachment sections |
+| `v0.5 personality` | `PersonalityController::show` `backend/app/Http/Controllers/API/V0_5/Cms/PersonalityController.php:63-90` | `PersonalityProfileService` + section payload | `fap-web/app/(localized)/[locale]/personality/[type]/page.tsx:98-228` | only `4`-char base `type_code` today | no `base_type_code`; no A/T field | Page-level empty-state fallback if sections absent | Partial hero and section list only; no attachment-aligned canonical blocks |
+| `v0.5 seo` | `PersonalityController::seo` `backend/app/Http/Controllers/API/V0_5/Cms/PersonalityController.php:92-114` | `PersonalityProfileSeoService` | Next metadata on personality page | no direct type identity fields in payload | N/A | Yes | SEO only; cannot carry narrative modules |
+| Backend personality sitemap | internal service only | `SitemapGenerator::getPersonalityUrls()` `backend/app/Services/SEO/SitemapGenerator.php:213-260` | consumed by backend sitemap generation, not `fap-web` | none | N/A | No | URL enumeration only |
+| `fap-web /result/[id]` | page route `fap-web/app/(localized)/[locale]/(app)/result/[id]/page.tsx:1-33` | `fetchAttemptReport` then `fetchAttemptResult` `fap-web/lib/api/v0_3.ts:1332-1373` | actual result page | prefers report `type_code`; fallback uses result `type_code` | no parsed `base_type_code` / `variant` | Yes | Rich report when available; otherwise collapses to simple result summary + dimensions |
+| `fap-web /share/[id]` | page route `fap-web/app/(localized)/[locale]/share/[id]/page.tsx:29-66` | `getShareSummary` + local metadata copy builder | `ShareClient` and `MbtiShareSummaryCard` | uses share payload `type_code` if present | no explicit parsed `base_type_code`; no A/T field | Yes | Lightweight share only; no attachment modules |
+| `fap-web /og/share/[id]` | OG route `fap-web/app/og/share/[id]/route.tsx:21-32` | `renderShareOgImage()` local formatter | social preview only | uses share payload `type_code` | no explicit `base_type_code` / `variant` | Yes | OG snapshot only |
+| `fap-web /personality/[type]` | page route `fap-web/app/(localized)/[locale]/personality/[type]/page.tsx:42-228` | `getPersonalityProfileBySlugOrType` + `getPersonalitySeoBySlugOrType` + `normalizePersonalitySeoPayload` | personality detail page | base-type only | no `base_type_code`; no A/T field | Yes | CMS sections only; attachment modules cannot land without schema/renderer work |
+| `fap-web next-sitemap` | `fap-web/next-sitemap.config.js:158-183` | local static path builder | sitemap build only | no MBTI type identity | N/A | N/A | personality/share/result are intentionally excluded |
+
+## Attachment Module Capacity by Consumer
+
+Legend:
+
+- `Yes`: can already carry the module without schema change
+- `Partial`: can carry an approximate equivalent only
+- `No`: cannot carry without schema/serializer/render work
+
+| Surface | `heroSummary` | `lettersIntro` | `traitOverview` | `career` | `growth` | `relationships` | `premium teaser` |
+| --- | --- | --- | --- | --- | --- | --- | --- |
+| `v0.3 result` | Partial | No | No | No | No | No | No |
+| `v0.3 report` | Partial | Partial | Partial | Partial | Partial | Partial | Partial |
+| `v0.3 share` | Partial | No | No | No | No | No | No |
+| `v0.5 personality` | Partial | No | No | Partial | Partial | Partial | No |
+| `v0.5 seo` | No | No | No | No | No | No | No |
+| Backend personality sitemap | No | No | No | No | No | No | No |
+| `fap-web /result/[id]` | Partial | No | No | No on fallback path, Partial on report path | No on fallback path, Partial on report path | No on fallback path, Partial on report path | No |
+| `fap-web /share/[id]` | Partial | No | No | No | No | No | No |
+| `fap-web /og/share/[id]` | Partial | No | No | No | No | No | No |
+| `fap-web /personality/[type]` | Partial | No | No | Partial | Partial | Partial | No |
+
+## Current Frontend Consumer Notes
+
+### `fap-web /result/[id]`
+
+- Entry: `fap-web/app/(localized)/[locale]/(app)/result/[id]/ResultClient.tsx:219-245`
+- Behavior:
+  - first tries `v0.3 report`
+  - falls back to `v0.3 result`
+  - fallback UI is explicitly simple: `ResultSummary + DimensionBars`
+- Contract proof:
+  - `fap-web/tests/contracts/result-client-view-state.contract.test.tsx:182-237`
+
+### `fap-web /share/[id]`
+
+- Page metadata comes from local helper:
+  - `fap-web/app/(localized)/[locale]/share/[id]/page.tsx:36-55`
+  - `fap-web/lib/og/mbtiShare.tsx:155-173`
+- Share card accepts multiple incompatible upstream shapes:
+  - `fap-web/components/share/MbtiShareSummaryCard.tsx:142-214`
+- Contract proof:
+  - `fap-web/tests/contracts/mbti-share-consumer.contract.test.tsx:134-157`
+  - `fap-web/tests/contracts/mbti-share-consumer.contract.test.tsx:251-323`
+
+### `fap-web /personality/[type]`
+
+- Page reads CMS profile + CMS SEO separately:
+  - `fap-web/app/(localized)/[locale]/personality/[type]/page.tsx:49-60`
+  - `fap-web/app/(localized)/[locale]/personality/[type]/page.tsx:105-128`
+- No local MBTI constant fallback remains in this repo:
+  - `fap-web/tests/contracts/personality-cleanup.contract.test.ts:33-42`
+- But the page is still locked to the base-type CMS chain
+
+## Current Backend Narrative-Carrying Files
+
+### Report narrative chain
+
+- Controller: `backend/app/Http/Controllers/API/V0_3/AttemptReadController.php`
+- Gatekeeper: `backend/app/Services/Report/ReportGatekeeper.php`
+- Composer: `backend/app/Services/Report/ReportComposer.php`
+- Assembler:
+  - `backend/app/Services/Report/Composer/ReportPayloadAssembler.php`
+  - `backend/app/Services/Report/Composer/ReportPayloadAssemblerProfilesTrait.php`
+  - `backend/app/Services/Report/Composer/ReportPayloadAssemblerComposeBuildTrait.php`
+  - `backend/app/Services/Report/Composer/ReportPayloadAssemblerComposeFinalizeTrait.php`
+
+### CMS narrative chain
+
+- Controller: `backend/app/Http/Controllers/API/V0_5/Cms/PersonalityController.php`
+- Service: `backend/app/Services/Cms/PersonalityProfileService.php`
+- SEO builder: `backend/app/Services/Cms/PersonalityProfileSeoService.php`
+- Models:
+  - `backend/app/Models/PersonalityProfile.php`
+  - `backend/app/Models/PersonalityProfileSection.php`
+  - `backend/app/Models/PersonalityProfileSeoMeta.php`
+- Import normalizer:
+  - `backend/app/PersonalityCms/Baseline/PersonalityBaselineNormalizer.php`
+
+## Consumer Matrix Conclusion
+
+Today there is no surface where:
+
+- `5`-char `type_code` is the first-class identity
+- `base_type_code` is only derived
+- attachment blocks can render end-to-end
+- `share / seo / og / sitemap` are all downstream consumers of the same canonical payload
+
+PR-1 therefore needs to start below the public API level:
+
+- canonical identity helper
+- canonical section registry
+- canonical payload-builder interface
+- red-flag tests
+
+and must not start with frontend wiring or content import.

--- a/docs/audits/pr1-mbti-fallback-redflags.md
+++ b/docs/audits/pr1-mbti-fallback-redflags.md
@@ -1,0 +1,214 @@
+# PR-1 MBTI Fallback Red Flags
+
+## Red-Flag Standard
+
+The following patterns are blocking for a production MBTI public-result launch:
+
+- `5`-char `type_code` is not treated as the primary identity
+- `base_type_code` silently replaces `type_code`
+- share / seo / og / sitemap do not read from the same canonical payload
+- frontend performs copy-authoring or fallback assembly
+- attachment-style `getProfile()` fallback logic leaks into public authority design
+
+## RF-01 `v0.3 share` silently strips `-A/-T` before CMS lookup
+
+- File: `backend/app/Services/V0_3/ShareService.php`
+- Code location: `330-362`
+- Current behavior:
+  - `resolvePublicProfile()` calls `baseTypeCode($typeCode)`
+  - `baseTypeCode()` runs `preg_replace('/-[A-Z]$/', '', $typeCode)`
+  - the share summary then queries CMS by base type only
+- Why this blocks launch:
+  - `ENFJ-T` and `ENFJ-A` can no longer attach to different authoritative public copy
+  - share becomes a hybrid of `5`-type result data and `4`-type CMS copy
+
+## RF-02 CMS personality model only authorizes `16` base types
+
+- File: `backend/app/Models/PersonalityProfile.php`
+- Code location: `19-36`
+- Related file: `backend/app/Filament/Ops/Resources/PersonalityProfileResource.php`
+- Code location: `422-427`
+- Current behavior:
+  - `PersonalityProfile::TYPE_CODES` enumerates only `INTJ ... ESFP`
+  - Filament type dropdown is built directly from that same list
+- Why this blocks launch:
+  - public CMS cannot store `ENFJ-T`, `ENFJ-A`, `INFP-T`, `INTJ-T`, or any other variant row
+  - `v0.5 personality`, `seo`, and personality sitemap cannot ever align with `v0.3 report`
+
+## RF-03 Baseline import rejects variant types and future canonical sections
+
+- File: `backend/app/PersonalityCms/Baseline/PersonalityBaselineNormalizer.php`
+- Code location:
+  - `116-126` invalid `type_code`
+  - `181-239` section key and render-variant validation
+  - `295-316` selected type validation
+- Current behavior:
+  - import accepts only `PersonalityProfile::TYPE_CODES`
+  - sections must be inside the current simple list:
+    - `core_snapshot`
+    - `strengths`
+    - `growth_edges`
+    - `work_style`
+    - `relationships`
+    - `communication`
+    - `stress_and_recovery`
+    - `career_fit`
+    - `faq`
+    - `related_content`
+- Why this blocks launch:
+  - attachment structure cannot be migrated as-is
+  - PR-2+ import cannot land until the schema scaffold exists
+
+## RF-04 Current CMS source is an old frontend-derived simple version
+
+- File: `backend/content_baselines/personality/mbti.zh-CN.json`
+- Code location: `2-7`, sample profile `11-166`
+- Current behavior:
+  - `meta.source` is `fap-web careerRecommendationProfiles + personality.ts deterministic transforms`
+  - sample rows contain only base types and simple sections
+- Why this blocks launch:
+  - current CMS body is not the authored narrative authority
+  - current personality pages and SEO are structurally behind the attachment content
+
+## RF-05 Section registry cannot carry attachment modules
+
+- File: `backend/app/Models/PersonalityProfileSection.php`
+- Code location: `15-36`
+- Related file: `backend/app/Filament/Ops/Resources/PersonalityProfileResource/Support/PersonalityWorkspace.php`
+- Code location: `25-108`
+- Current behavior:
+  - registry still models the simple section families
+  - render variants are only `rich_text`, `bullets`, `cards`, `faq`, `links`, `callout`
+- Why this blocks launch:
+  - there is no canonical place for:
+    - `lettersIntro`
+    - `traitOverview.dimensions`
+    - layered `career`
+    - layered `growth`
+    - layered `relationships`
+    - premium teaser blocks
+
+## RF-06 SEO is not built from the same authority as the report
+
+- File: `backend/app/Services/Cms/PersonalityProfileSeoService.php`
+- Code location: `15-52`
+- Current behavior:
+  - SEO text falls back through `seo_meta -> profile.title -> profile.excerpt -> profile.subtitle`
+  - OG/Twitter text follows the same CMS-first fallback chain
+- Why this blocks launch:
+  - SEO/OG copy can diverge from report-authoritative narrative copy
+  - even after content import, SEO can still lag unless canonical payload ownership is unified
+
+## RF-07 Backend personality sitemap only publishes the simple CMS chain
+
+- File: `backend/app/Services/SEO/SitemapGenerator.php`
+- Code location: `213-260`
+- Current behavior:
+  - personality URLs are built entirely from `personality_profiles`
+  - only published public indexable CMS rows are emitted
+- Why this blocks launch:
+  - sitemap will stay `16`-type simple version while the report chain is already `32`-type
+  - search engines cannot see the eventual canonical variant coverage from the current authority setup
+
+## RF-08 `v0.3 /scales/sitemap-source` is not a personality authority source
+
+- File: `backend/app/Http/Controllers/API/V0_3/ScalesSitemapSourceController.php`
+- Code location: `18-66`
+- Current behavior:
+  - endpoint reads only `scales_registry`
+  - returns scale slug/indexability metadata only
+- Why this blocks launch:
+  - there is no shared public sitemap payload for MBTI personality/result authority
+  - public sitemap responsibilities are already split between unrelated systems
+
+## RF-09 Share page metadata is locally recomposed on the frontend
+
+- File: `fap-web/app/(localized)/[locale]/share/[id]/page.tsx`
+- Code location: `36-55`
+- Related file: `fap-web/lib/og/mbtiShare.tsx`
+- Code location: `130-173`
+- Current behavior:
+  - metadata title/description are rebuilt from share summary fields locally
+  - local helper truncates, filters, and reorders copy
+- Why this blocks launch:
+  - frontend remains a text-assembly layer for public MBTI copy
+  - metadata can drift from the future backend canonical payload
+
+## RF-10 Share OG is also locally authored at render time
+
+- File: `fap-web/app/og/share/[id]/route.tsx`
+- Code location: `10-32`
+- Related file: `fap-web/lib/og/mbtiShare.tsx`
+- Code location: `175-307`
+- Current behavior:
+  - the OG image uses share payload as input
+  - but narrative, rarity, tag, dimension detail, CTA label, and truncation logic are local
+- Why this blocks launch:
+  - share OG is not a pure rendering of backend-authored copy
+  - later share payload changes could still be reinterpreted differently by the frontend
+
+## RF-11 Share card consumes multiple incompatible shapes and hides payload drift
+
+- File: `fap-web/components/share/MbtiShareSummaryCard.tsx`
+- Code location: `142-214`
+- Current behavior:
+  - consumer tries `root`, `result`, `profile`, `identity_card`, `report`, `summary_card`
+  - it normalizes whichever fields happen to exist
+- Why this blocks launch:
+  - public consumer is not locked to a single canonical payload contract
+  - backend divergence can survive unnoticed because the frontend will patch over it
+
+## RF-12 Result page still has a simple-version fallback mode
+
+- File: `fap-web/app/(localized)/[locale]/(app)/result/[id]/ResultClient.tsx`
+- Code location:
+  - `197-217`
+  - `219-245`
+  - `317-334`
+- Contract proof: `fap-web/tests/contracts/result-client-view-state.contract.test.tsx:182-237`
+- Current behavior:
+  - if report is unavailable or not renderable, page falls back to `v0.3 result`
+  - fallback UI renders only `ResultSummary` and `DimensionBars`
+- Why this blocks launch:
+  - public result page can still collapse to a simple version
+  - attachment-style modular narrative is not guaranteed on the public result route
+
+## RF-13 Attachment source itself contains forbidden authority fallback logic
+
+- File: `/Users/rainie/Desktop/微信小程序结果页文案.txt`
+- Code location: `13648-13701`
+- Current behavior:
+  - local `MBTI_PROFILES` constant holds all `32` authored records
+  - `getProfile(rawType)` silently degrades `4`-char codes to `-T` then `-A`
+  - final fallback hard-defaults to `ENFJ-T`
+- Why this blocks launch:
+  - this is acceptable only as an attachment source to be transformed
+  - it cannot be copied into backend public authority semantics
+
+## RF-14 `v0.5 personality` does not preserve `5`-char identity even at lookup time
+
+- File: `backend/app/Services/Cms/PersonalityProfileService.php`
+- Code location: `28-63`
+- Current behavior:
+  - lookup only lowercases the slug and uppercases the provided type
+  - no variant-aware identity helper exists
+  - because model rows are base-type only, `ENFJ-T` paths simply miss
+- Why this blocks launch:
+  - `5`-char type identity is not a first-class public key
+  - canonical variant pages cannot be introduced safely without a shared helper
+
+## Red-Flag Summary
+
+The blocking pattern is consistent across the stack:
+
+- report is `32`-type and authored
+- personality/seo/sitemap are `16`-type and CMS-simple
+- share sits between them and downgrades type identity internally
+- frontend metadata/OG/share rendering still performs protective copy assembly
+
+PR-1 must therefore target infrastructure, not content:
+
+- canonical identity helper
+- canonical section registry
+- canonical payload-builder interface
+- explicit red-flag tests that ban silent fallback in new code

--- a/docs/audits/pr1-mbti-pr1-file-change-plan.md
+++ b/docs/audits/pr1-mbti-pr1-file-change-plan.md
@@ -1,0 +1,236 @@
+# PR-1 MBTI File Change Plan
+
+## PR-1 Scope Lock
+
+PR-1 only does this:
+
+- authority收口骨架
+- canonical schema scaffold
+- type identity helper
+- section key registry
+- public payload builder interface
+- red-flag test
+
+PR-1 explicitly does not do this:
+
+- full `32`-type import
+- frontend wiring
+- `share / seo / og / sitemap` traffic switch
+- public API contract switch
+- scoring change
+- business-rule change
+- other scale result-page work
+
+## Minimum Implementable Change Surface
+
+### New skeleton files to add
+
+- `backend/app/Support/Mbti/MbtiTypeIdentity.php`
+  - Purpose: normalize and validate `5`-char MBTI identity
+  - Must expose:
+    - `type_code`
+    - derived `base_type_code`
+    - derived `variant`
+    - `isVariantType()`
+    - no silent default
+    - no silent downgrade
+- `backend/app/Support/Mbti/MbtiCanonicalSectionRegistry.php`
+  - Purpose: define canonical section keys for the future unified payload
+  - Must include future block families:
+    - top / hero
+    - letters intro
+    - trait overview
+    - career
+    - growth
+    - relationships
+    - premium teaser
+    - seo/meta references
+- `backend/app/Support/Mbti/MbtiCanonicalSchema.php`
+  - Purpose: document canonical payload field ownership in code
+  - Must separate:
+    - `profile`
+    - `sections`
+    - `seo_meta`
+    - `premium_teaser`
+- `backend/app/Contracts/MbtiPublicPayloadBuilder.php`
+  - Purpose: one interface for future public payload builders
+  - Must not be wired to live endpoints yet
+- `backend/app/Services/Mbti/MbtiPublicPayloadBuilderScaffold.php`
+  - Purpose: non-live scaffold implementation for tests and later adapters
+  - Should accept a typed identity object, not a raw string
+
+### Tests to add in PR-1
+
+- `backend/tests/Unit/Mbti/MbtiTypeIdentityTest.php`
+  - Verifies:
+    - `ENFJ-T` remains primary identity
+    - `base_type_code` is derived only
+    - blank or invalid types do not default
+    - no helper method silently rewrites `ENFJ-T` to `ENFJ`
+- `backend/tests/Unit/Mbti/MbtiCanonicalSectionRegistryTest.php`
+  - Verifies:
+    - canonical section keys exist
+    - future attachment modules have a registry slot
+    - current simple keys can be mapped intentionally, not implicitly
+- `backend/tests/Unit/Mbti/MbtiCanonicalSchemaTest.php`
+  - Verifies:
+    - field ownership is frozen for `profile`, `sections`, `seo_meta`, `premium_teaser`
+- `backend/tests/Unit/Mbti/MbtiPublicPayloadBuilderContractTest.php`
+  - Verifies:
+    - builder interface accepts a typed identity object
+    - builder contract returns a canonical payload shell, not live legacy payloads
+- `backend/tests/Feature/Mbti/MbtiAuthorityRedFlagTest.php`
+  - Verifies new PR-1 helpers do not permit:
+    - silent base-type fallback
+    - default type injection
+    - attachment-style `getProfile()` semantics
+
+## Files PR-1 Should Not Change
+
+### Backend files to leave untouched in PR-1
+
+- `backend/routes/api.php`
+- `backend/database/migrations/*`
+- `backend/app/Http/Controllers/API/V0_3/AttemptReadController.php`
+- `backend/app/Http/Controllers/API/V0_3/ShareController.php`
+- `backend/app/Services/V0_3/ShareService.php`
+- `backend/app/Http/Controllers/API/V0_5/Cms/PersonalityController.php`
+- `backend/app/Services/Cms/PersonalityProfileSeoService.php`
+- `backend/app/Services/SEO/SitemapGenerator.php`
+- `backend/app/PersonalityCms/Baseline/PersonalityBaselineImporter.php`
+- `backend/app/PersonalityCms/Baseline/PersonalityBaselineNormalizer.php`
+- `backend/content_baselines/personality/*`
+- `content_packages/default/**`
+
+### Frontend files to leave untouched in PR-1
+
+- `fap-web/app/**`
+- `fap-web/components/**`
+- `fap-web/lib/**`
+- `fap-web/tests/**`
+- `fap-web/next-sitemap.config.js`
+
+## Files That Are Skeleton-Only in PR-1
+
+These files are allowed to be added in PR-1, but they must not yet receive live route traffic:
+
+- `backend/app/Support/Mbti/MbtiTypeIdentity.php`
+- `backend/app/Support/Mbti/MbtiCanonicalSectionRegistry.php`
+- `backend/app/Support/Mbti/MbtiCanonicalSchema.php`
+- `backend/app/Contracts/MbtiPublicPayloadBuilder.php`
+- `backend/app/Services/Mbti/MbtiPublicPayloadBuilderScaffold.php`
+
+That means PR-1 does not yet:
+
+- rewire `ShareService`
+- rewire `PersonalityController`
+- rewire sitemap generation
+- change `v0.3` or `v0.5` response bodies
+
+## External APIs That Must Not Switch in PR-1
+
+- `GET /api/v0.3/attempts/{id}/result`
+- `GET /api/v0.3/attempts/{id}/report`
+- `GET|POST /api/v0.3/attempts/{id}/share`
+- `GET /api/v0.3/shares/{id}`
+- `GET /api/v0.5/personality`
+- `GET /api/v0.5/personality/{type}`
+- `GET /api/v0.5/personality/{type}/seo`
+- backend sitemap output
+- frontend share OG route
+
+## Why This Is The Minimum Safe PR-1
+
+Because the current live system has three authorities at once:
+
+- content-pack report authority
+- CMS personality/SEO authority
+- frontend local share/OG copy composition
+
+If PR-1 jumps directly to import, frontend wiring, or route switching, it will either:
+
+- preserve the current divergence under a bigger schema, or
+- ship a partial chain where some surfaces still downgrade to base type
+
+PR-1 has to create the shared vocabulary first.
+
+## A. Changed Files List
+
+### Added
+
+- `backend/app/Support/Mbti/MbtiTypeIdentity.php`
+- `backend/app/Support/Mbti/MbtiCanonicalSectionRegistry.php`
+- `backend/app/Support/Mbti/MbtiCanonicalSchema.php`
+- `backend/app/Contracts/MbtiPublicPayloadBuilder.php`
+- `backend/app/Services/Mbti/MbtiPublicPayloadBuilderScaffold.php`
+- `backend/tests/Unit/Mbti/MbtiTypeIdentityTest.php`
+- `backend/tests/Unit/Mbti/MbtiCanonicalSectionRegistryTest.php`
+- `backend/tests/Unit/Mbti/MbtiCanonicalSchemaTest.php`
+- `backend/tests/Unit/Mbti/MbtiPublicPayloadBuilderContractTest.php`
+- `backend/tests/Feature/Mbti/MbtiAuthorityRedFlagTest.php`
+
+### Modified
+
+- None required for PR-1 if the scaffold remains off the live path
+
+## B. Copy-Paste Blocks
+
+```text
+[ADD FILE] backend/app/Support/Mbti/MbtiTypeIdentity.php
+Insertion position: whole new file
+
+[ADD FILE] backend/app/Support/Mbti/MbtiCanonicalSectionRegistry.php
+Insertion position: whole new file
+
+[ADD FILE] backend/app/Support/Mbti/MbtiCanonicalSchema.php
+Insertion position: whole new file
+
+[ADD FILE] backend/app/Contracts/MbtiPublicPayloadBuilder.php
+Insertion position: whole new file
+
+[ADD FILE] backend/app/Services/Mbti/MbtiPublicPayloadBuilderScaffold.php
+Insertion position: whole new file
+
+[ADD FILE] backend/tests/Unit/Mbti/MbtiTypeIdentityTest.php
+Insertion position: whole new file
+
+[ADD FILE] backend/tests/Unit/Mbti/MbtiCanonicalSectionRegistryTest.php
+Insertion position: whole new file
+
+[ADD FILE] backend/tests/Unit/Mbti/MbtiCanonicalSchemaTest.php
+Insertion position: whole new file
+
+[ADD FILE] backend/tests/Unit/Mbti/MbtiPublicPayloadBuilderContractTest.php
+Insertion position: whole new file
+
+[ADD FILE] backend/tests/Feature/Mbti/MbtiAuthorityRedFlagTest.php
+Insertion position: whole new file
+```
+
+## C. Acceptance Commands
+
+```bash
+cd /Users/rainie/Desktop/GitHub/fap-api/backend && php artisan route:list
+
+cd /Users/rainie/Desktop/GitHub/fap-api/backend && php artisan migrate
+
+curl "http://127.0.0.1:8000/api/v0.3/attempts/$ATTEMPT_ID/result"
+curl -H "Authorization: Bearer $FM_TOKEN" -H "X-Anon-Id: $ANON_ID" \
+  "http://127.0.0.1:8000/api/v0.3/attempts/$ATTEMPT_ID/share"
+curl "http://127.0.0.1:8000/api/v0.5/personality/enfj?locale=zh-CN"
+curl "http://127.0.0.1:8000/api/v0.5/personality/enfj/seo?locale=zh-CN"
+
+cd /Users/rainie/Desktop/GitHub/fap-api && bash backend/scripts/ci_verify_mbti.sh
+```
+
+## PR-1 Exit Criteria
+
+PR-1 is complete only if all of the following are true:
+
+- a single typed identity helper exists
+- a canonical section registry exists
+- a canonical payload-builder interface exists
+- scaffold classes are covered by tests
+- no public route is switched yet
+- no frontend route is switched yet
+- no import path is switched yet

--- a/docs/implementation/mbti-result-copy-import-strategy.md
+++ b/docs/implementation/mbti-result-copy-import-strategy.md
@@ -1,0 +1,379 @@
+# MBTI 结果页文案导入策略
+
+## 0. 目标
+
+本策略回答两个问题：
+
+1. 附件 `/Users/rainie/Desktop/微信小程序结果页文案.txt` 如何批量转成后端可导入内容
+2. 如何按 32 型、保留 `-A/-T`、可回滚地迁入后端
+
+## 1. 源文件现实情况
+
+附件不是可直接导入的 baseline JSON，而是一个 JS-like 源文件：
+
+- 32 个类型对象
+- 1 个聚合对象 `MBTI_PROFILES`
+- 每个类型对象包含固定 6 个一级模块
+
+已确认的导入风险：
+
+- 维度 ID 为 `NS/FT`，与后端 runtime `SN/TF` 不一致
+- 一些块标题带有装饰编号或语义不完整
+- 文件没有单独的 SEO/share authoring
+- 文件没有 full premium body，只有 teaser
+
+因此不能把附件原文直接当最终 baseline 写库，必须经过“抽取 -> 规范化 -> 映射 -> 校验 -> 导入”五步。
+
+## 2. 批量导入总体流程
+
+```mermaid
+flowchart LR
+    A["微信小程序结果页文案.txt"] --> B["AST/对象抽取"]
+    B --> C["标准化转换"]
+    C --> D["Canonical Baseline JSON"]
+    D --> E["Dry-run 校验"]
+    E --> F["Pilot 导入 4 个样例"]
+    F --> G["按波次导入剩余 28 个"]
+    G --> H["发布 / 验收 / 回滚窗口"]
+```
+
+## 3. 附件到导入基线的转换规则
+
+## 3.1 对象抽取
+
+抽取规则：
+
+- 识别所有 `const XXX = { ... }`
+- 忽略 `const MBTI_PROFILES = { ... }`
+- 将常量名转回标准 `type_code`
+  - `ENFJ_T` -> `ENFJ-T`
+  - `INFP_T` -> `INFP-T`
+
+校验：
+
+- 必须正好抽到 32 条类型记录
+- 每条必须包含：
+  - `code`
+  - `type`
+  - `name`
+  - `nickname`
+  - `rarity`
+  - `keywords`
+  - `heroSummary`
+  - `lettersIntro`
+  - `overview`
+  - `traitOverview`
+  - `career`
+  - `growth`
+  - `relationships`
+
+## 3.2 类型对齐规则
+
+| 附件字段 | 规范化规则 |
+| --- | --- |
+| `code` | 必须转成 `^[EI][SN][TF][JP]-(A|T)$` |
+| `type` | 必须是基础型，例如 `ENFJ` |
+| `variant` | 从 `code` 后缀派生 |
+| 常量名与 `code` | 必须完全一致，否则阻断导入 |
+
+示例：
+
+- `const ENFJ_T` + `code: 'ENFJ-T'` + `type: 'ENFJ'` => 合法
+- 若出现 `const ENFJ_T` 但 `code: 'ENFJ-A'` => 直接报错
+
+## 3.3 轴向标准化规则
+
+这是导入中必须写死的规则：
+
+| 附件轴 ID | 后端 canonical 轴 ID | 原因 |
+| --- | --- | --- |
+| `EI` | `EI` | 一致 |
+| `NS` | `SN` | 后端评分/runtime 使用 `SN` |
+| `FT` | `TF` | 后端评分/runtime 使用 `TF` |
+| `JP` | `JP` | 一致 |
+| `AT` | `AT` | 一致 |
+
+同时要保留附件的展示极性：
+
+- `NS` 中左侧其实是 `N`，右侧是 `S`
+- `FT` 中左侧其实是 `F`，右侧是 `T`
+
+导入后 payload 需保留：
+
+- `axis_code`
+- `source_axis_code`
+- `left_pole`
+- `right_pole`
+
+这样前端不需要再根据轴名猜极性。
+
+## 3.4 标题规范化规则
+
+### 不能直接保留原样的情况
+
+- `1. 人格概要｜你是怎样的 ENFJ-T？`
+- ` 的短板`
+- ` 系中的强项`
+
+导入规则：
+
+- 顺序号剥离，进入 `sort_order`
+- `display_title` 与 `full_title` 分离
+- 异常块标题统一用 canonical label dictionary 修复
+
+导入字典示例：
+
+```yaml
+career.advantages: 你的职场优势
+career.weaknesses: 你的职场短板
+growth.strengths: 你的强项
+growth.weaknesses: 你的短板
+relationships.strengths: 关系中的强项
+relationships.weaknesses: 关系中的短板
+```
+
+## 3.5 premium teaser 处理规则
+
+附件中以下模块只导 teaser：
+
+- `growth.motivators`
+- `growth.drainers`
+- `relationships.relAdvantages`
+- `relationships.relRisks`
+
+导入规则：
+
+- 落入所属 section 的 `premium_teasers[]`
+- `access_level = premium_teaser`
+- 不补 full premium body
+
+## 3.6 SEO / Share 处理规则
+
+附件没有显式提供：
+
+- `seo_title`
+- `seo_description`
+- `og_title`
+- `share_text`
+
+因此导入规则不是“从附件硬提”，而是：
+
+- `seo_meta` 先生成默认值
+- `share_text` 先沿用现有 `report_identity_cards.share_text`
+- 如需运营覆盖，再追加 override 文件
+
+## 4. 批量导入步骤
+
+## Step 1. 生成中间标准化文件
+
+输出建议：
+
+- `content_baselines/personality/mbti-result-v2.zh-CN.json`
+- `content_baselines/personality/mbti-result-v2.en.json`
+
+每条记录包含：
+
+- `profile`
+- `sections`
+- `seo_meta`
+
+## Step 2. Dry-run 校验
+
+dry-run 必须输出：
+
+- `profiles_found`
+- `will_create`
+- `will_update`
+- `will_skip`
+- `section_count`
+- `premium_teaser_count`
+- `axis_code_mismatch_count`
+
+## Step 3. Pilot 导入
+
+先只导 4 个样例：
+
+- `ENFJ-T`
+- `ENFJ-A`
+- `INFP-T`
+- `INTJ-T`
+
+目标：
+
+- 验证 A/T 保留
+- 验证 `NS/FT -> SN/TF` 转换
+- 验证 `growth/relationships` teaser 落点
+- 验证 share / SEO / public serializer
+
+## Step 4. 扩到配对基础型
+
+Pilot 稳定后，补齐对应 pair：
+
+- `INFP-A`
+- `INTJ-A`
+
+原因：
+
+- 这样能完整验证两组 base type 的双变体对照
+
+## Step 5. 分波次迁移全部 32 型
+
+建议波次：
+
+### Wave 0
+
+- `ENFJ-T`
+- `ENFJ-A`
+- `INFP-T`
+- `INTJ-T`
+
+### Wave 1
+
+- `INFP-A`
+- `INTJ-A`
+- `INFJ-A`
+- `INFJ-T`
+
+### Wave 2
+
+- 全部 NF：
+  - `ENFJ-*`
+  - `ENFP-*`
+  - `INFJ-*`
+  - `INFP-*`
+
+### Wave 3
+
+- 全部 NT：
+  - `ENTJ-*`
+  - `ENTP-*`
+  - `INTJ-*`
+  - `INTP-*`
+
+### Wave 4
+
+- 全部 SJ：
+  - `ESFJ-*`
+  - `ESTJ-*`
+  - `ISFJ-*`
+  - `ISTJ-*`
+
+### Wave 5
+
+- 全部 SP：
+  - `ESFP-*`
+  - `ESTP-*`
+  - `ISFP-*`
+  - `ISTP-*`
+
+这么排的理由：
+
+- 先覆盖用户关注的样例
+- 再按气质组迁移，方便内容 QA 和运营复审
+
+## 5. A/T 双变体策略
+
+正式迁移时，A/T 必须遵循以下策略：
+
+### 5.1 存储策略
+
+- 每个 `type_code` 独立一条 record
+- 不允许把 `ENFJ-A` / `ENFJ-T` 合并成一条基础型内容
+
+### 5.2 共享规则
+
+允许共享的是：
+
+- `base_type_code`
+- route alias / compare 逻辑
+- 统计归类
+
+不允许共享的是：
+
+- 头部 headline
+- AT 维度 summary/description
+- premium teaser
+- share 标题与摘要
+
+### 5.3 回退规则
+
+仅允许服务端显式降级：
+
+- `ENFJ-T` -> `ENFJ`
+
+但必须满足两个条件：
+
+- 当前变体记录不存在
+- 降级行为被日志记录 / 指标监控
+
+禁止：
+
+- 前端自行把 `ENFJ-T` 截成 `ENFJ`
+- SEO/share 默认 silent fallback 到基础型
+
+## 6. 回滚方式
+
+回滚必须支持两层：
+
+## 6.1 内容回滚
+
+依赖现有 `personality_profile_revisions`：
+
+- 每次 `upsert` 生成 revision snapshot
+- 若某一波内容错误，可按 `type_code + locale` 恢复上一 revision
+
+## 6.2 发布回滚
+
+建议保留双版本开关：
+
+- `schema_version = v1`
+- `schema_version = mbti_result_v2`
+
+回滚方式：
+
+- serializer 回退只读 `v1`
+- 或将新导入记录降为 draft / not public
+
+## 6.3 全量回滚顺序
+
+1. 先关闭新 serializer
+2. 再回退 public profile 可见版本
+3. 最后按 wave 逐步恢复 revision
+
+## 7. 导入验收前置校验
+
+每次导入前必须通过：
+
+- 32 条记录数正确
+- 每条 6 个 section 均存在
+- 每条 `trait_overview.dimensions` 数量为 5
+- `axis_code` 只允许 `EI/SN/TF/JP/AT`
+- 每条 `growth` 有 2 个 premium teaser
+- 每条 `relationships` 有 2 个 premium teaser
+- `type_code` 唯一
+- `slug` 唯一
+
+## 8. 导入后的验收信号
+
+导入完成后必须能回答：
+
+- 32 型是否都存在？
+- `ENFJ-T` 与 `ENFJ-A` 是否头部文案不同？
+- `INFP-T` 是否仍保持 `INFP-T` 而不是退成 `INFP`？
+- `trait_overview` 是否已全部使用 `SN/TF` canonical 轴？
+- teaser 是否只显示 teaser，没有伪造 full premium？
+
+## 9. Import Strategy 结论
+
+附件可直接作为“文案素材源”，但不能直接作为“数据库导入格式”。
+
+正式导入必须经过：
+
+- 对象抽取
+- 类型对齐
+- 轴向标准化
+- 标题规范化
+- premium teaser 分流
+- dry-run + pilot + 分波次迁移 + revision 回滚
+
+否则会把一份前端对象稿再次复制成一套难维护的后端脏数据。


### PR DESCRIPTION
## Summary

This PR packages the MBTI result-copy audit and implementation planning documents into a docs-only branch so the analysis can be reviewed independently from the backend scaffold PR.

It captures the current authority layout, fallback red flags, consumer matrix, target canonical schema mapping, import strategy, launch plan, and PR-1 file change plan in one place. No business code, tests, routes, migrations, or frontend runtime behavior are changed in this PR.

## Root Cause

The earlier audit and implementation outputs existed only as local working-tree documents and were not yet captured in version control. Leaving them uncommitted makes the MBTI result-copy rollout plan hard to review, hard to reference, and easy to drift from the actual repository state.

## What Changed

Added 11 documentation files only:

- 6 audit documents describing the as-is state, backend authority map, target schema map, gap matrix, launch plan, and future file change list
- 4 PR-1 special-scan documents describing authority sources, consumer matrix, fallback red flags, and the PR-1 minimal file-change plan
- 1 implementation document covering the MBTI result-copy import strategy

These docs are intended to support the MBTI public-result rollout sequence and provide a stable written reference for subsequent implementation PRs.

## Explicit Non-Goals

This PR does not:

- modify backend runtime code
- modify tests or CI behavior
- switch any API contract
- change `fap-web`
- import any 32-type copy into production paths
- alter compiled content-pack outputs

## Validation

Validation for this PR is structural rather than behavioral:

- verified the branch diff contains only 11 markdown files under `docs/audits/` and `docs/implementation/`
- verified no backend or frontend source files are included in the diff
- verified the working-tree compiled content-pack changes remain outside this PR

## User Impact

There is no live product impact. This PR only adds repository documentation that records the MBTI authority audit and rollout blueprint.
