### PR TITLE
[codex] feat(api): add MBTI Public Result Contract V1

### DIFF
--- a/backend/app/Http/Controllers/API/V0_3/AttemptReadController.php
+++ b/backend/app/Http/Controllers/API/V0_3/AttemptReadController.php
@@ -9,6 +9,7 @@ use App\Models\Attempt;
 use App\Models\Result;
 use App\Services\Analytics\EventRecorder;
 use App\Services\Attempts\AttemptSubmissionService;
+use App\Services\Mbti\MbtiPublicSummaryV1Builder;
 use App\Services\Observability\ClinicalComboTelemetry;
 use App\Services\Observability\Sds20Telemetry;
 use App\Services\Report\Pdf\ReportPdfDocumentService;
@@ -31,6 +32,7 @@ class AttemptReadController extends Controller
         private AttemptSubmissionService $attemptSubmissionService,
         private ReportGatekeeper $reportGatekeeper,
         private ReportPdfDocumentService $reportPdfDocumentService,
+        private MbtiPublicSummaryV1Builder $mbtiPublicSummaryV1Builder,
         private EventRecorder $eventRecorder,
         private ScaleCodeResponseProjector $responseProjector,
         protected OrgContext $orgContext,
@@ -286,7 +288,7 @@ class AttemptReadController extends Controller
             $gate['report'] = $this->projectScaleCodePayload($gate['report'], $responseCodes);
         }
 
-        return response()->json(array_merge($gate, [
+        $responsePayload = array_merge($gate, [
             'scale_code' => $responseCodes['scale_code'],
             'scale_code_legacy' => $responseCodes['scale_code_legacy'],
             'scale_code_v2' => $responseCodes['scale_code_v2'],
@@ -302,7 +304,17 @@ class AttemptReadController extends Controller
                 'scoring_spec_version' => (string) ($attempt->scoring_spec_version ?? ''),
                 'report_engine_version' => (string) ($result->report_engine_version ?? 'v1.2'),
             ]),
-        ]));
+        ]);
+
+        if ($scaleCode === 'MBTI') {
+            $responsePayload['mbti_public_summary_v1'] = $this->mbtiPublicSummaryV1Builder->buildFromReportEnvelope(
+                $result,
+                $responsePayload,
+                (string) ($attempt->locale ?? config('content_packs.default_locale', 'zh-CN'))
+            );
+        }
+
+        return response()->json($responsePayload);
     }
 
     private function resolveAttemptForReportRead(Request $request, int $orgId, string $attemptId, string $scaleCode): Attempt

--- a/backend/app/Services/Mbti/MbtiPublicSummaryV1Builder.php
+++ b/backend/app/Services/Mbti/MbtiPublicSummaryV1Builder.php
@@ -1,0 +1,643 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\Mbti;
+
+use App\Models\Result;
+
+final class MbtiPublicSummaryV1Builder
+{
+    /**
+     * @var list<string>
+     */
+    private const AXIS_ORDER = ['EI', 'SN', 'TF', 'JP', 'AT'];
+
+    /**
+     * @var array<string, array{
+     *   letters: array{left:string,right:string},
+     *   locales: array<string, array{label:string,left:string,right:string}>
+     * }>
+     */
+    private const AXIS_DEFINITIONS = [
+        'EI' => [
+            'letters' => ['left' => 'E', 'right' => 'I'],
+            'locales' => [
+                'zh-CN' => ['label' => '能量方向', 'left' => '外倾', 'right' => '内倾'],
+                'en' => ['label' => 'Energy', 'left' => 'Extraversion', 'right' => 'Introversion'],
+            ],
+        ],
+        'SN' => [
+            'letters' => ['left' => 'S', 'right' => 'N'],
+            'locales' => [
+                'zh-CN' => ['label' => '信息偏好', 'left' => '实感', 'right' => '直觉'],
+                'en' => ['label' => 'Information', 'left' => 'Sensing', 'right' => 'Intuition'],
+            ],
+        ],
+        'TF' => [
+            'letters' => ['left' => 'T', 'right' => 'F'],
+            'locales' => [
+                'zh-CN' => ['label' => '决策偏好', 'left' => '思考', 'right' => '情感'],
+                'en' => ['label' => 'Decision', 'left' => 'Thinking', 'right' => 'Feeling'],
+            ],
+        ],
+        'JP' => [
+            'letters' => ['left' => 'J', 'right' => 'P'],
+            'locales' => [
+                'zh-CN' => ['label' => '生活方式', 'left' => '判断', 'right' => '感知'],
+                'en' => ['label' => 'Lifestyle', 'left' => 'Judging', 'right' => 'Perceiving'],
+            ],
+        ],
+        'AT' => [
+            'letters' => ['left' => 'A', 'right' => 'T'],
+            'locales' => [
+                'zh-CN' => ['label' => '稳定度', 'left' => '果断', 'right' => '敏感'],
+                'en' => ['label' => 'Identity', 'left' => 'Assertive', 'right' => 'Turbulent'],
+            ],
+        ],
+    ];
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function scaffold(?string $runtimeTypeCode = null): array
+    {
+        $identity = $this->normalizeTypeIdentity($runtimeTypeCode);
+
+        return [
+            'runtime_type_code' => $identity['runtime_type_code'],
+            'canonical_type_16' => $identity['canonical_type_16'],
+            'display_type' => $identity['display_type'],
+            'variant' => $identity['variant'],
+            'profile' => [
+                'type_name' => null,
+                'nickname' => null,
+                'subtitle' => null,
+                'summary' => null,
+                'rarity' => null,
+                'keywords' => [],
+            ],
+            'summary_card' => [
+                'title' => null,
+                'subtitle' => null,
+                'share_text' => null,
+                'tags' => [],
+            ],
+            'dimensions' => [],
+            'sections' => [],
+            'offer_set' => [
+                'offer_key' => null,
+                'upgrade_sku' => null,
+                'modules_allowed' => [],
+                'modules_preview' => [],
+                'view_policy' => null,
+                'cta' => null,
+            ],
+        ];
+    }
+
+    /**
+     * @param  array<string, mixed>  $reportEnvelope
+     * @return array<string, mixed>
+     */
+    public function buildFromReportEnvelope(Result $result, array $reportEnvelope, ?string $locale = null): array
+    {
+        $report = $this->arrayOrEmpty($reportEnvelope['report'] ?? null);
+        $resultJson = $this->arrayOrEmpty($result->result_json ?? null);
+        $profile = $this->arrayOrEmpty($report['profile'] ?? null);
+        $identityCard = $this->arrayOrEmpty($report['identity_card'] ?? null);
+        $identityLayer = $this->arrayOrEmpty(data_get($report, 'layers.identity'));
+        $resolvedLocale = $this->normalizeLocale($locale);
+        $payload = $this->scaffold($this->firstNonEmpty(
+            $profile['type_code'] ?? null,
+            $resultJson['type_code'] ?? null,
+            $result->type_code ?? null,
+            $identityCard['type_code'] ?? null,
+        ));
+
+        $payload['profile'] = [
+            'type_name' => $this->nullableText(
+                $profile['type_name'] ?? $resultJson['type_name'] ?? null
+            ),
+            'nickname' => $this->nullableText(
+                $profile['tagline'] ?? $resultJson['tagline'] ?? null
+            ),
+            'subtitle' => $this->nullableText(
+                $identityLayer['subtitle'] ?? $identityCard['subtitle'] ?? $resultJson['subtitle'] ?? null
+            ),
+            'summary' => $this->nullableText(
+                $profile['short_summary'] ?? $identityCard['summary'] ?? $resultJson['summary'] ?? null
+            ),
+            'rarity' => $this->nullableScalar(
+                $profile['rarity'] ?? $resultJson['rarity'] ?? null
+            ),
+            'keywords' => $this->stringList(
+                $profile['keywords'] ?? $resultJson['keywords'] ?? null
+            ),
+        ];
+
+        $payload['summary_card'] = [
+            'title' => $this->nullableText(
+                $identityCard['title'] ?? $identityLayer['title'] ?? null
+            ),
+            'subtitle' => $this->nullableText(
+                $identityCard['subtitle'] ?? $identityLayer['subtitle'] ?? null
+            ),
+            'share_text' => $this->nullableText(
+                $identityCard['share_text'] ?? $identityCard['summary'] ?? $resultJson['summary'] ?? null
+            ),
+            'tags' => $this->stringList(
+                $identityCard['tags'] ?? $profile['keywords'] ?? $resultJson['keywords'] ?? null
+            ),
+        ];
+
+        $payload['dimensions'] = $this->buildDimensionsFromScoreMap(
+            $this->arrayOrEmpty($report['scores_pct'] ?? null),
+            $resolvedLocale,
+            $this->arrayOrEmpty($result->scores_pct ?? null)
+        );
+        $payload['sections'] = $this->buildOverviewSections(
+            $payload['summary_card']['title'],
+            $this->firstNonEmpty(
+                $identityCard['share_text'] ?? null,
+                $identityCard['summary'] ?? null,
+                $identityLayer['one_liner'] ?? null,
+                $profile['short_summary'] ?? null,
+                $resultJson['summary'] ?? null
+            )
+        );
+        $payload['offer_set'] = $this->buildOfferSet($reportEnvelope);
+
+        return $payload;
+    }
+
+    /**
+     * @param  array<string, mixed>  $sharePayload
+     * @param  array<string, mixed>|null  $reportPayload
+     * @return array<string, mixed>
+     */
+    public function buildFromSharePayload(array $sharePayload, ?array $reportPayload = null, ?string $locale = null): array
+    {
+        $report = $this->arrayOrEmpty($reportPayload);
+        $profile = $this->arrayOrEmpty($report['profile'] ?? null);
+        $identityCard = $this->arrayOrEmpty($report['identity_card'] ?? null);
+        $identityLayer = $this->arrayOrEmpty(data_get($report, 'layers.identity'));
+        $resolvedLocale = $this->normalizeLocale(
+            $locale ?? $this->nullableText($sharePayload['locale'] ?? null)
+        );
+        $payload = $this->scaffold($this->firstNonEmpty(
+            $sharePayload['type_code'] ?? null,
+            $sharePayload['runtime_type_code'] ?? null,
+            $profile['type_code'] ?? null,
+            $identityCard['type_code'] ?? null,
+        ));
+
+        $payload['profile'] = [
+            'type_name' => $this->nullableText(
+                $sharePayload['type_name'] ?? $profile['type_name'] ?? null
+            ),
+            'nickname' => $this->nullableText(
+                $sharePayload['tagline'] ?? $profile['tagline'] ?? null
+            ),
+            'subtitle' => $this->nullableText(
+                $sharePayload['subtitle'] ?? $identityLayer['subtitle'] ?? $identityCard['subtitle'] ?? null
+            ),
+            'summary' => $this->nullableText(
+                $sharePayload['summary'] ?? $profile['short_summary'] ?? $identityCard['summary'] ?? null
+            ),
+            'rarity' => $this->nullableScalar(
+                $sharePayload['rarity'] ?? $profile['rarity'] ?? null
+            ),
+            'keywords' => $this->stringList(
+                $profile['keywords'] ?? null
+            ),
+        ];
+
+        $payload['summary_card'] = [
+            'title' => $this->nullableText(
+                $sharePayload['title'] ?? $identityCard['title'] ?? $identityLayer['title'] ?? null
+            ),
+            'subtitle' => $this->nullableText(
+                $sharePayload['subtitle'] ?? $identityCard['subtitle'] ?? $identityLayer['subtitle'] ?? null
+            ),
+            'share_text' => $this->nullableText(
+                $sharePayload['summary'] ?? $identityCard['share_text'] ?? $identityCard['summary'] ?? null
+            ),
+            'tags' => $this->stringList(
+                $sharePayload['tags'] ?? $identityCard['tags'] ?? null
+            ),
+        ];
+
+        $payload['dimensions'] = $this->buildDimensionsFromSharePayload(
+            $sharePayload,
+            $report,
+            $resolvedLocale
+        );
+        $payload['sections'] = $this->buildOverviewSections(
+            $payload['summary_card']['title'],
+            $this->firstNonEmpty(
+                $identityCard['share_text'] ?? null,
+                $identityCard['summary'] ?? null,
+                $identityLayer['one_liner'] ?? null,
+                $sharePayload['summary'] ?? null,
+                $profile['short_summary'] ?? null
+            )
+        );
+
+        return $payload;
+    }
+
+    /**
+     * @param  array<string, mixed>|null  $comparePayload
+     * @return array<string, mixed>
+     */
+    public function buildFromComparePayload(?array $comparePayload, ?string $locale = null): array
+    {
+        $payload = $this->scaffold();
+        $compare = $this->arrayOrEmpty($comparePayload);
+        $resolvedLocale = $this->normalizeLocale($locale);
+
+        $payload['summary_card'] = [
+            'title' => $this->nullableText($compare['title'] ?? null),
+            'subtitle' => null,
+            'share_text' => $this->nullableText($compare['summary'] ?? null),
+            'tags' => [],
+        ];
+        $payload['dimensions'] = $this->buildDimensionsFromCompareAxes(
+            $this->arrayValues($compare['axes'] ?? null),
+            $resolvedLocale
+        );
+        $payload['sections'] = $this->buildOverviewSections(
+            $payload['summary_card']['title'],
+            $payload['summary_card']['share_text']
+        );
+
+        return $payload;
+    }
+
+    /**
+     * @param  array<string, mixed>  $reportEnvelope
+     * @return array<string, mixed>
+     */
+    private function buildOfferSet(array $reportEnvelope): array
+    {
+        $offers = $this->arrayValues($reportEnvelope['offers'] ?? null);
+        $cta = $this->arrayOrNull($reportEnvelope['cta'] ?? null);
+        $firstOffer = is_array($offers[0] ?? null) ? $offers[0] : [];
+
+        return [
+            'offer_key' => $this->nullableText(
+                $firstOffer['sku'] ?? $cta['target_sku_effective'] ?? $cta['target_sku'] ?? null
+            ),
+            'upgrade_sku' => $this->nullableText(
+                $reportEnvelope['upgrade_sku_effective'] ?? $reportEnvelope['upgrade_sku'] ?? $cta['target_sku_effective'] ?? $cta['target_sku'] ?? null
+            ),
+            'modules_allowed' => $this->stringList($reportEnvelope['modules_allowed'] ?? null),
+            'modules_preview' => $this->stringList($reportEnvelope['modules_preview'] ?? null),
+            'view_policy' => $this->arrayOrNull($reportEnvelope['view_policy'] ?? null),
+            'cta' => $cta,
+        ];
+    }
+
+    /**
+     * @param  array<string, mixed>  $sharePayload
+     * @param  array<string, mixed>  $reportPayload
+     * @return list<array<string, mixed>>
+     */
+    private function buildDimensionsFromSharePayload(array $sharePayload, array $reportPayload, string $locale): array
+    {
+        $scoreMap = $this->normalizeScoreMap($this->arrayOrEmpty($reportPayload['scores_pct'] ?? null));
+        if ($scoreMap !== []) {
+            return $this->buildDimensionsFromScoreMap($scoreMap, $locale);
+        }
+
+        $dimensions = [];
+        foreach ($this->arrayValues($sharePayload['dimensions'] ?? null) as $item) {
+            if (! is_array($item)) {
+                continue;
+            }
+
+            $axisId = $this->normalizeAxisId((string) ($item['id'] ?? $item['code'] ?? ''));
+            if ($axisId === null) {
+                continue;
+            }
+
+            $definition = self::AXIS_DEFINITIONS[$axisId]['locales'][$locale];
+            $letters = self::AXIS_DEFINITIONS[$axisId]['letters'];
+            $valuePct = null;
+
+            if (is_numeric($item['value_pct'] ?? null)) {
+                $valuePct = $this->normalizePercentValue($item['value_pct']);
+            } else {
+                $dominantPct = $this->normalizePercentValue($item['pct'] ?? $item['percent'] ?? null);
+                $side = strtoupper(trim((string) ($item['side'] ?? '')));
+                if ($dominantPct !== null) {
+                    if ($side === $letters['left']) {
+                        $valuePct = $dominantPct;
+                    } elseif ($side === $letters['right']) {
+                        $valuePct = 100 - $dominantPct;
+                    }
+                }
+            }
+
+            $dimensions[$axisId] = [
+                'id' => $axisId,
+                'label' => $this->nullableText($item['label'] ?? $item['axis_label'] ?? null) ?? $definition['label'],
+                'axis_left' => $definition['left'],
+                'axis_right' => $definition['right'],
+                'summary' => $this->nullableText($item['summary'] ?? null),
+                'value_pct' => $valuePct,
+            ];
+        }
+
+        return $this->orderedDimensions($dimensions);
+    }
+
+    /**
+     * @param  array<string, mixed>  $scoresPct
+     * @param  array<string, mixed>  $fallbackScoresPct
+     * @return list<array<string, mixed>>
+     */
+    private function buildDimensionsFromScoreMap(array $scoresPct, string $locale, array $fallbackScoresPct = []): array
+    {
+        $normalized = $this->normalizeScoreMap($scoresPct);
+        if ($normalized === []) {
+            $normalized = $this->normalizeScoreMap($fallbackScoresPct);
+        }
+
+        $dimensions = [];
+        foreach (self::AXIS_ORDER as $axisId) {
+            if (! array_key_exists($axisId, $normalized)) {
+                continue;
+            }
+
+            $definition = self::AXIS_DEFINITIONS[$axisId]['locales'][$locale];
+            $dimensions[$axisId] = [
+                'id' => $axisId,
+                'label' => $definition['label'],
+                'axis_left' => $definition['left'],
+                'axis_right' => $definition['right'],
+                'summary' => null,
+                'value_pct' => $normalized[$axisId],
+            ];
+        }
+
+        return $this->orderedDimensions($dimensions);
+    }
+
+    /**
+     * @param  list<mixed>  $axes
+     * @return list<array<string, mixed>>
+     */
+    private function buildDimensionsFromCompareAxes(array $axes, string $locale): array
+    {
+        $dimensions = [];
+        foreach ($axes as $item) {
+            if (! is_array($item)) {
+                continue;
+            }
+
+            $axisId = $this->normalizeAxisId((string) ($item['id'] ?? $item['code'] ?? $item['key'] ?? ''));
+            if ($axisId === null) {
+                continue;
+            }
+
+            $definition = self::AXIS_DEFINITIONS[$axisId]['locales'][$locale];
+            $dimensions[$axisId] = [
+                'id' => $axisId,
+                'label' => $this->nullableText($item['label'] ?? $item['title'] ?? null) ?? $definition['label'],
+                'axis_left' => $definition['left'],
+                'axis_right' => $definition['right'],
+                'summary' => $this->nullableText($item['summary'] ?? $item['description'] ?? $item['text'] ?? null),
+                'value_pct' => null,
+            ];
+        }
+
+        return $this->orderedDimensions($dimensions);
+    }
+
+    /**
+     * @param  array<string, array<string, mixed>>  $dimensions
+     * @return list<array<string, mixed>>
+     */
+    private function orderedDimensions(array $dimensions): array
+    {
+        $ordered = [];
+        foreach (self::AXIS_ORDER as $axisId) {
+            if (isset($dimensions[$axisId])) {
+                $ordered[] = $dimensions[$axisId];
+            }
+        }
+
+        return $ordered;
+    }
+
+    /**
+     * @return list<array<string, mixed>>
+     */
+    private function buildOverviewSections(?string $title, ?string $paragraph): array
+    {
+        $normalizedParagraph = $this->nullableText($paragraph);
+        $normalizedTitle = $this->nullableText($title);
+        if ($normalizedTitle === null && $normalizedParagraph === null) {
+            return [];
+        }
+
+        return [[
+            'key' => 'overview',
+            'render' => 'paragraphs',
+            'title' => $normalizedTitle,
+            'is_premium' => false,
+            'is_preview' => false,
+            'payload' => $normalizedParagraph === null
+                ? null
+                : ['paragraphs' => [$normalizedParagraph]],
+        ]];
+    }
+
+    /**
+     * @return array{runtime_type_code:?string,canonical_type_16:?string,display_type:?string,variant:?string}
+     */
+    private function normalizeTypeIdentity(?string $runtimeTypeCode): array
+    {
+        $raw = trim((string) $runtimeTypeCode);
+        if ($raw === '') {
+            return [
+                'runtime_type_code' => null,
+                'canonical_type_16' => null,
+                'display_type' => null,
+                'variant' => null,
+            ];
+        }
+
+        $candidate = strtoupper($raw);
+        if (preg_match('/^(?<base>[EI][SN][TF][JP])(?:-(?<variant>[AT]))?$/', $candidate, $matches) === 1) {
+            $base = (string) $matches['base'];
+            $variant = isset($matches['variant']) && $matches['variant'] !== ''
+                ? (string) $matches['variant']
+                : null;
+            $resolved = $variant !== null ? $base.'-'.$variant : $base;
+
+            return [
+                'runtime_type_code' => $resolved,
+                'canonical_type_16' => $base,
+                'display_type' => $resolved,
+                'variant' => $variant,
+            ];
+        }
+
+        return [
+            'runtime_type_code' => $raw,
+            'canonical_type_16' => null,
+            'display_type' => $raw,
+            'variant' => null,
+        ];
+    }
+
+    private function normalizeLocale(?string $locale): string
+    {
+        return trim((string) $locale) === 'zh-CN' ? 'zh-CN' : 'en';
+    }
+
+    /**
+     * @param  array<string, mixed>  $scores
+     * @return array<string, int>
+     */
+    private function normalizeScoreMap(array $scores): array
+    {
+        $normalized = [];
+        foreach ($scores as $axisCode => $value) {
+            $axisId = $this->normalizeAxisId((string) $axisCode);
+            $percent = $this->normalizePercentValue($value);
+            if ($axisId === null || $percent === null) {
+                continue;
+            }
+
+            $normalized[$axisId] = $percent;
+        }
+
+        return $normalized;
+    }
+
+    private function normalizeAxisId(string $axisCode): ?string
+    {
+        return match (strtoupper(trim($axisCode))) {
+            'EI' => 'EI',
+            'SN', 'NS' => 'SN',
+            'TF', 'FT' => 'TF',
+            'JP' => 'JP',
+            'AT' => 'AT',
+            default => null,
+        };
+    }
+
+    private function normalizePercentValue(mixed $value): ?int
+    {
+        if (! is_numeric($value)) {
+            return null;
+        }
+
+        $normalized = (float) $value;
+        if ($normalized <= 1.0) {
+            $normalized *= 100.0;
+        }
+
+        return max(0, min(100, (int) round($normalized)));
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function arrayOrEmpty(mixed $value): array
+    {
+        if (is_array($value)) {
+            return $value;
+        }
+
+        if (! is_string($value) || trim($value) === '') {
+            return [];
+        }
+
+        $decoded = json_decode($value, true);
+
+        return is_array($decoded) ? $decoded : [];
+    }
+
+    /**
+     * @return array<string, mixed>|null
+     */
+    private function arrayOrNull(mixed $value): ?array
+    {
+        $normalized = $this->arrayOrEmpty($value);
+
+        return $normalized === [] ? null : $normalized;
+    }
+
+    /**
+     * @return list<mixed>
+     */
+    private function arrayValues(mixed $value): array
+    {
+        return is_array($value) ? array_values($value) : [];
+    }
+
+    private function nullableText(mixed $value): ?string
+    {
+        if (! is_scalar($value)) {
+            return null;
+        }
+
+        $normalized = trim((string) $value);
+
+        return $normalized === '' ? null : $normalized;
+    }
+
+    private function nullableScalar(mixed $value): string|int|float|null
+    {
+        if (is_int($value) || is_float($value)) {
+            return $value;
+        }
+
+        if (is_string($value)) {
+            $normalized = trim($value);
+
+            return $normalized === '' ? null : $normalized;
+        }
+
+        return null;
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function stringList(mixed $value): array
+    {
+        if (! is_array($value)) {
+            return [];
+        }
+
+        $items = [];
+        foreach ($value as $item) {
+            $normalized = $this->nullableText($item);
+            if ($normalized === null) {
+                continue;
+            }
+
+            $items[$normalized] = true;
+        }
+
+        return array_keys($items);
+    }
+
+    private function firstNonEmpty(mixed ...$values): ?string
+    {
+        foreach ($values as $value) {
+            $normalized = $this->nullableText($value);
+            if ($normalized !== null) {
+                return $normalized;
+            }
+        }
+
+        return null;
+    }
+}

--- a/backend/app/Services/V0_3/MbtiCompareInviteService.php
+++ b/backend/app/Services/V0_3/MbtiCompareInviteService.php
@@ -9,6 +9,7 @@ use App\Models\Attempt;
 use App\Models\MbtiCompareInvite;
 use App\Models\Result;
 use App\Models\Share;
+use App\Services\Mbti\MbtiPublicSummaryV1Builder;
 use Illuminate\Database\Eloquent\ModelNotFoundException;
 use Illuminate\Support\Carbon;
 use Illuminate\Support\Str;
@@ -17,6 +18,7 @@ final class MbtiCompareInviteService
 {
     public function __construct(
         private readonly ShareService $shareService,
+        private readonly MbtiPublicSummaryV1Builder $mbtiPublicSummaryV1Builder,
     ) {}
 
     /**
@@ -67,8 +69,17 @@ final class MbtiCompareInviteService
         );
 
         $status = $this->normalizeStatus((string) ($invite->status ?? 'pending'));
-        $invitee = null;
-        $compare = null;
+        $inviter = $this->toSummaryLite($inviterPayload, true);
+        $invitee = [
+            'mbti_public_summary_v1' => $this->mbtiPublicSummaryV1Builder->scaffold(),
+        ];
+        $compare = [
+            'mbti_public_summary_v1' => $this->mbtiPublicSummaryV1Builder->buildFromComparePayload([
+                'title' => null,
+                'summary' => null,
+                'axes' => [],
+            ], $locale),
+        ];
 
         if (in_array($status, ['ready', 'purchased'], true)) {
             $inviteeAttemptId = trim((string) ($invite->invitee_attempt_id ?? ''));
@@ -84,7 +95,7 @@ final class MbtiCompareInviteService
                         $inviteePayload = $this->shareService->buildPublicSummaryPayload($inviteeAttempt, $inviteeResult);
                         $invitee = $this->toSummaryLite($inviteePayload, false);
                         $compare = $this->buildComparePayload(
-                            $this->toSummaryLite($inviterPayload, true),
+                            $inviter,
                             $invitee,
                             $locale
                         );
@@ -99,7 +110,7 @@ final class MbtiCompareInviteService
             'scale_code' => 'MBTI',
             'locale' => $locale,
             'status' => $status,
-            'inviter' => $this->toSummaryLite($inviterPayload, true),
+            'inviter' => $inviter,
             'invitee' => $invitee,
             'compare' => $compare,
             'primary_cta_label' => $locale === 'zh-CN' ? '开始测试' : 'Take the test',
@@ -196,6 +207,9 @@ final class MbtiCompareInviteService
             'rarity' => $payload['rarity'] ?? null,
             'tags' => is_array($payload['tags'] ?? null) ? array_values($payload['tags']) : [],
             'dimensions' => is_array($payload['dimensions'] ?? null) ? array_values($payload['dimensions']) : [],
+            'mbti_public_summary_v1' => is_array($payload['mbti_public_summary_v1'] ?? null)
+                ? $payload['mbti_public_summary_v1']
+                : $this->mbtiPublicSummaryV1Builder->buildFromSharePayload($payload),
         ];
 
         if ($includeShareId) {
@@ -303,6 +317,11 @@ final class MbtiCompareInviteService
             'axes' => $axes,
             'title' => $title,
             'summary' => $summary,
+            'mbti_public_summary_v1' => $this->mbtiPublicSummaryV1Builder->buildFromComparePayload([
+                'title' => $title,
+                'summary' => $summary,
+                'axes' => $axes,
+            ], $locale),
         ];
     }
 

--- a/backend/app/Services/V0_3/ShareService.php
+++ b/backend/app/Services/V0_3/ShareService.php
@@ -7,6 +7,7 @@ use App\Models\PersonalityProfile;
 use App\Models\Result;
 use App\Models\Share;
 use App\Services\Cms\PersonalityProfileService;
+use App\Services\Mbti\MbtiPublicSummaryV1Builder;
 use App\Services\Report\ReportAccess;
 use App\Services\Report\ReportComposer;
 use App\Services\Scale\ScaleIdentityWriteProjector;
@@ -23,6 +24,7 @@ class ShareService
         private readonly ReportComposer $reportComposer,
         private readonly ScaleRegistry $scaleRegistry,
         private readonly PersonalityProfileService $personalityProfileService,
+        private readonly MbtiPublicSummaryV1Builder $mbtiPublicSummaryV1Builder,
     ) {}
 
     public function getOrCreateShare(string $attemptId, OrgContext $ctx): array
@@ -218,10 +220,10 @@ class ShareService
      *   primary_cta_path:string
      * }
      */
-    private function buildShareSummary(?Share $share, Attempt $attempt, Result $result): array
+    private function buildShareSummary(?Share $share, Attempt $attempt, Result $result, ?array $report = null): array
     {
         $resultJson = $this->normalizeArray($result->result_json ?? null);
-        $report = $this->buildPublicSafeReportSnapshot($attempt, $result);
+        $report = is_array($report) ? $report : $this->buildPublicSafeReportSnapshot($attempt, $result);
         $reportProfile = $this->normalizeArray($report['profile'] ?? null);
         $identityCard = $this->normalizeArray($report['identity_card'] ?? null);
         $identityLayer = $this->normalizeArray(data_get($report, 'layers.identity'));
@@ -627,12 +629,12 @@ class ShareService
         ?string $shareId,
         ?string $createdAt
     ): array {
-        $summary = $this->buildShareSummary($share, $attempt, $result);
+        $publicSafeReport = $this->buildPublicSafeReportSnapshot($attempt, $result);
+        $summary = $this->buildShareSummary($share, $attempt, $result, $publicSafeReport);
         $resolvedShareId = trim((string) $shareId);
         $locale = (string) ($summary['locale'] ?? 'zh-CN');
         $compareEnabled = strtoupper((string) ($summary['scale_code'] ?? '')) === 'MBTI';
-
-        return [
+        $payload = [
             'share_id' => $resolvedShareId !== '' ? $resolvedShareId : null,
             'share_url' => $resolvedShareId !== '' ? $this->buildLocalizedShareUrl($resolvedShareId, $locale) : null,
             'attempt_id' => (string) $attempt->id,
@@ -658,6 +660,16 @@ class ShareService
                 ? $this->resolveCompareCtaLabel($locale)
                 : null,
         ];
+
+        if ($compareEnabled) {
+            $payload['mbti_public_summary_v1'] = $this->mbtiPublicSummaryV1Builder->buildFromSharePayload(
+                $payload,
+                $publicSafeReport,
+                $locale
+            );
+        }
+
+        return $payload;
     }
 
     private function buildLocalizedShareUrl(string $shareId, string $locale): string

--- a/backend/tests/Feature/V0_3/MbtiCompareInviteContractTest.php
+++ b/backend/tests/Feature/V0_3/MbtiCompareInviteContractTest.php
@@ -92,13 +92,22 @@ final class MbtiCompareInviteContractTest extends TestCase
             ->assertJsonPath('scale_code', 'MBTI')
             ->assertJsonPath('locale', 'zh-CN')
             ->assertJsonPath('status', 'pending')
-            ->assertJsonPath('invitee', null)
-            ->assertJsonPath('compare', null)
             ->assertJsonPath('primary_cta_label', '开始测试')
             ->assertJsonPath('primary_cta_path', '/zh/tests/mbti-personality-test-16-personality-types/take?share_id='.$shareId.'&compare_invite_id='.$inviteId)
             ->assertJsonPath('inviter.share_id', $shareId)
             ->assertJsonPath('inviter.type_code', 'INTJ-A')
-            ->assertJsonPath('inviter.summary', 'Public-safe share summary.');
+            ->assertJsonPath('inviter.summary', 'Public-safe share summary.')
+            ->assertJsonPath('inviter.mbti_public_summary_v1.runtime_type_code', 'INTJ-A')
+            ->assertJsonPath('invitee.mbti_public_summary_v1.runtime_type_code', null)
+            ->assertJsonPath('compare.mbti_public_summary_v1.runtime_type_code', null);
+
+        $this->assertSame(
+            ['EI', 'SN', 'TF', 'JP', 'AT'],
+            array_map(
+                static fn (array $item): string => (string) ($item['id'] ?? ''),
+                (array) $response->json('inviter.mbti_public_summary_v1.dimensions')
+            )
+        );
 
         foreach ([
             'report',
@@ -118,13 +127,61 @@ final class MbtiCompareInviteContractTest extends TestCase
         $this->assertStringNotContainsString('PRIVATE_PAID_SECTION_BODY', (string) $response->getContent());
     }
 
+    public function test_ready_compare_contract_keeps_nested_public_summary_v1_for_inviter_invitee_and_compare(): void
+    {
+        $this->seedScales();
+
+        [$attemptId, $anonId, $token] = $this->createOwnerContext();
+        $shareId = $this->createShareViaApi($attemptId, $anonId, $token);
+        $invite = $this->postJson("/api/v0.3/shares/{$shareId}/compare-invites", [
+            'anon_id' => 'scan_probe',
+            'entrypoint' => 'share_page',
+            'compare_intent' => true,
+            'utm_source' => 'share',
+        ]);
+        $invite->assertOk();
+
+        $inviteId = (string) $invite->json('invite_id');
+        $inviteeAttemptId = $this->createMbtiAttemptWithResult('anon_compare_invitee', 'ENFP-T');
+
+        DB::table('mbti_compare_invites')
+            ->where('id', $inviteId)
+            ->update([
+                'invitee_attempt_id' => $inviteeAttemptId,
+                'status' => 'ready',
+                'accepted_at' => now(),
+                'completed_at' => now(),
+            ]);
+
+        $response = $this->getJson("/api/v0.3/compare/mbti/{$inviteId}");
+
+        $response->assertOk()
+            ->assertJsonPath('status', 'ready')
+            ->assertJsonPath('inviter.mbti_public_summary_v1.runtime_type_code', 'INTJ-A')
+            ->assertJsonPath('inviter.mbti_public_summary_v1.variant', 'A')
+            ->assertJsonPath('invitee.mbti_public_summary_v1.runtime_type_code', 'ENFP-T')
+            ->assertJsonPath('invitee.mbti_public_summary_v1.canonical_type_16', 'ENFP')
+            ->assertJsonPath('invitee.mbti_public_summary_v1.variant', 'T')
+            ->assertJsonPath('compare.mbti_public_summary_v1.runtime_type_code', null)
+            ->assertJsonPath('compare.mbti_public_summary_v1.summary_card.title', $response->json('compare.title'))
+            ->assertJsonPath('compare.mbti_public_summary_v1.summary_card.share_text', $response->json('compare.summary'));
+
+        $this->assertSame(
+            ['EI', 'SN', 'TF', 'JP', 'AT'],
+            array_map(
+                static fn (array $item): string => (string) ($item['id'] ?? ''),
+                (array) $response->json('compare.mbti_public_summary_v1.dimensions')
+            )
+        );
+    }
+
     /**
      * @return array{0:string,1:string,2:string}
      */
     private function createOwnerContext(): array
     {
         $anonId = 'anon_compare_invite_owner';
-        $attemptId = $this->createMbtiAttemptWithResult($anonId);
+        $attemptId = $this->createMbtiAttemptWithResult($anonId, 'INTJ-A');
         $token = $this->issueAnonToken($anonId);
 
         return [$attemptId, $anonId, $token];
@@ -166,9 +223,26 @@ final class MbtiCompareInviteContractTest extends TestCase
         return (string) $response->json('share_id');
     }
 
-    private function createMbtiAttemptWithResult(string $anonId): string
+    private function createMbtiAttemptWithResult(string $anonId, string $typeCode = 'INTJ-A'): string
     {
         $attemptId = (string) Str::uuid();
+        $resultProfile = $typeCode === 'ENFP-T'
+            ? [
+                'type_name' => '竞选者型',
+                'summary' => 'Invitee public-safe share summary.',
+                'tagline' => '热情的连接者',
+                'rarity' => '约 8%',
+                'keywords' => ['热情', '灵感', '共情'],
+                'scores_pct' => ['EI' => 72, 'SN' => 74, 'TF' => 41, 'JP' => 38, 'AT' => 43],
+            ]
+            : [
+                'type_name' => '建筑师型',
+                'summary' => 'Public-safe share summary.',
+                'tagline' => '冷静的长期规划者',
+                'rarity' => '约 2%',
+                'keywords' => ['战略', '独立', '前瞻'],
+                'scores_pct' => ['EI' => 35, 'SN' => 72, 'TF' => 68, 'JP' => 63, 'AT' => 58],
+            ];
 
         Attempt::create([
             'id' => $attemptId,
@@ -195,15 +269,9 @@ final class MbtiCompareInviteContractTest extends TestCase
             'attempt_id' => $attemptId,
             'scale_code' => 'MBTI',
             'scale_version' => 'v0.3',
-            'type_code' => 'INTJ-A',
+            'type_code' => $typeCode,
             'scores_json' => ['total' => 100],
-            'scores_pct' => [
-                'EI' => 35,
-                'SN' => 72,
-                'TF' => 68,
-                'JP' => 63,
-                'AT' => 58,
-            ],
+            'scores_pct' => $resultProfile['scores_pct'],
             'axis_states' => [
                 'EI' => 'clear',
                 'SN' => 'clear',
@@ -213,12 +281,12 @@ final class MbtiCompareInviteContractTest extends TestCase
             ],
             'content_package_version' => 'v0.3',
             'result_json' => [
-                'type_code' => 'INTJ-A',
-                'type_name' => '建筑师型',
-                'summary' => 'Public-safe share summary.',
-                'tagline' => '冷静的长期规划者',
-                'rarity' => '约 2%',
-                'keywords' => ['战略', '独立', '前瞻'],
+                'type_code' => $typeCode,
+                'type_name' => $resultProfile['type_name'],
+                'summary' => $resultProfile['summary'],
+                'tagline' => $resultProfile['tagline'],
+                'rarity' => $resultProfile['rarity'],
+                'keywords' => $resultProfile['keywords'],
                 'layers' => [
                     'identity' => [
                         'body' => 'PRIVATE_PAID_SECTION_BODY',

--- a/backend/tests/Feature/V0_3/MbtiReportHttpContractRegressionTest.php
+++ b/backend/tests/Feature/V0_3/MbtiReportHttpContractRegressionTest.php
@@ -10,9 +10,9 @@ use App\Services\Commerce\EntitlementManager;
 use Database\Seeders\Pr19CommerceSeeder;
 use Database\Seeders\ScaleRegistrySeeder;
 use Illuminate\Foundation\Testing\RefreshDatabase;
-use Illuminate\Testing\TestResponse;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Str;
+use Illuminate\Testing\TestResponse;
 use Tests\TestCase;
 
 final class MbtiReportHttpContractRegressionTest extends TestCase
@@ -21,13 +21,13 @@ final class MbtiReportHttpContractRegressionTest extends TestCase
 
     private function seedScales(): void
     {
-        (new ScaleRegistrySeeder())->run();
-        (new Pr19CommerceSeeder())->run();
+        (new ScaleRegistrySeeder)->run();
+        (new Pr19CommerceSeeder)->run();
     }
 
     private function issueAnonToken(string $anonId): string
     {
-        $token = 'fm_' . (string) Str::uuid();
+        $token = 'fm_'.(string) Str::uuid();
 
         DB::table('fm_tokens')->insert([
             'token' => $token,
@@ -110,7 +110,7 @@ final class MbtiReportHttpContractRegressionTest extends TestCase
 
         $resp = $this->withHeaders([
             'X-Anon-Id' => $anonId,
-            'Authorization' => 'Bearer ' . $token,
+            'Authorization' => 'Bearer '.$token,
         ])->getJson("/api/v0.3/attempts/{$attemptId}/report");
 
         $resp->assertStatus(200);
@@ -127,6 +127,12 @@ final class MbtiReportHttpContractRegressionTest extends TestCase
         $this->assertSame('upsell', $cta['kind']);
         $this->assertSame('MBTI_REPORT_FULL', $cta['target_sku']);
         $this->assertNotSame('', trim((string) $cta['target_sku_effective']));
+        $this->assertStableMbtiPublicSummaryV1(
+            (array) $resp->json('mbti_public_summary_v1'),
+            'ENFP-T',
+            'ENFP',
+            'T'
+        );
     }
 
     public function test_unlocked_paid_mbti_report_http_contract_keeps_section_gate_semantics(): void
@@ -154,7 +160,7 @@ final class MbtiReportHttpContractRegressionTest extends TestCase
 
         $resp = $this->withHeaders([
             'X-Anon-Id' => $anonId,
-            'Authorization' => 'Bearer ' . $token,
+            'Authorization' => 'Bearer '.$token,
         ])->getJson("/api/v0.3/attempts/{$attemptId}/report");
 
         $resp->assertStatus(200);
@@ -170,6 +176,12 @@ final class MbtiReportHttpContractRegressionTest extends TestCase
         $this->assertFalse((bool) $cta['visible']);
         $this->assertSame('none', $cta['kind']);
         $this->assertContains('paid', $this->collectAccessLevels($resp->json('report')));
+        $this->assertStableMbtiPublicSummaryV1(
+            (array) $resp->json('mbti_public_summary_v1'),
+            'INTJ-A',
+            'INTJ',
+            'A'
+        );
     }
 
     private function assertStableMbtiEnvelope(TestResponse $response): void
@@ -192,6 +204,7 @@ final class MbtiReportHttpContractRegressionTest extends TestCase
             'view_policy',
             'meta',
             'report',
+            'mbti_public_summary_v1',
             'scale_code',
             'scale_code_legacy',
             'scale_code_v2',
@@ -215,6 +228,7 @@ final class MbtiReportHttpContractRegressionTest extends TestCase
         $this->assertIsArray($payload['view_policy']);
         $this->assertIsArray($payload['meta']);
         $this->assertIsArray($payload['report']);
+        $this->assertIsArray($payload['mbti_public_summary_v1']);
         $this->assertNotSame('', trim((string) $payload['scale_code']));
         $this->assertNotSame('', trim((string) $payload['scale_code_legacy']));
         $this->assertNotSame('', trim((string) $payload['scale_code_v2']));
@@ -225,7 +239,57 @@ final class MbtiReportHttpContractRegressionTest extends TestCase
     }
 
     /**
-     * @param array<string,mixed> $cta
+     * @param  array<string,mixed>  $summary
+     */
+    private function assertStableMbtiPublicSummaryV1(
+        array $summary,
+        string $expectedRuntimeTypeCode,
+        string $expectedCanonicalType,
+        ?string $expectedVariant
+    ): void {
+        foreach ([
+            'runtime_type_code',
+            'canonical_type_16',
+            'display_type',
+            'variant',
+            'profile',
+            'summary_card',
+            'dimensions',
+            'sections',
+            'offer_set',
+        ] as $key) {
+            $this->assertArrayHasKey($key, $summary);
+        }
+
+        $this->assertSame($expectedRuntimeTypeCode, $summary['runtime_type_code']);
+        $this->assertSame($expectedCanonicalType, $summary['canonical_type_16']);
+        $this->assertSame($expectedRuntimeTypeCode, $summary['display_type']);
+        $this->assertSame($expectedVariant, $summary['variant']);
+        $this->assertIsArray($summary['profile']);
+        $this->assertIsArray($summary['summary_card']);
+        $this->assertIsArray($summary['dimensions']);
+        $this->assertIsArray($summary['sections']);
+        $this->assertIsArray($summary['offer_set']);
+
+        $this->assertSame(
+            ['EI', 'SN', 'TF', 'JP', 'AT'],
+            array_map(
+                static fn (array $item): string => (string) ($item['id'] ?? ''),
+                (array) $summary['dimensions']
+            )
+        );
+        $this->assertSame($expectedRuntimeTypeCode, data_get($summary, 'display_type'));
+        $this->assertNotNull(data_get($summary, 'summary_card.share_text'));
+        $this->assertSame(
+            data_get($summary, 'offer_set.upgrade_sku'),
+            data_get($summary, 'offer_set.cta.target_sku_effective')
+                ?? data_get($summary, 'offer_set.cta.target_sku')
+                ?? data_get($summary, 'offer_set.upgrade_sku')
+        );
+    }
+
+    /**
+     * @param  array<string,mixed>  $cta
      */
     private function assertStableCtaShape(array $cta): void
     {
@@ -257,7 +321,7 @@ final class MbtiReportHttpContractRegressionTest extends TestCase
     }
 
     /**
-     * @param array<string,mixed> $report
+     * @param  array<string,mixed>  $report
      */
     private function assertStableMbtiReportShape(array $report): void
     {
@@ -289,7 +353,7 @@ final class MbtiReportHttpContractRegressionTest extends TestCase
     }
 
     /**
-     * @param array<string,mixed> $profile
+     * @param  array<string,mixed>  $profile
      */
     private function assertStableProfileShape(array $profile): void
     {
@@ -313,7 +377,7 @@ final class MbtiReportHttpContractRegressionTest extends TestCase
     }
 
     /**
-     * @param array<string,mixed> $identityCard
+     * @param  array<string,mixed>  $identityCard
      */
     private function assertStableIdentityCardShape(array $identityCard): void
     {
@@ -339,7 +403,7 @@ final class MbtiReportHttpContractRegressionTest extends TestCase
     }
 
     /**
-     * @param array<int,array<string,mixed>> $highlights
+     * @param  array<int,array<string,mixed>>  $highlights
      */
     private function assertStableHighlightsShape(array $highlights): void
     {
@@ -357,7 +421,7 @@ final class MbtiReportHttpContractRegressionTest extends TestCase
     }
 
     /**
-     * @param array<string,mixed> $layers
+     * @param  array<string,mixed>  $layers
      */
     private function assertStableLayersShape(array $layers): void
     {
@@ -379,7 +443,7 @@ final class MbtiReportHttpContractRegressionTest extends TestCase
     }
 
     /**
-     * @param array<string,mixed> $sections
+     * @param  array<string,mixed>  $sections
      */
     private function assertStableSectionsShape(array $sections): void
     {
@@ -390,7 +454,7 @@ final class MbtiReportHttpContractRegressionTest extends TestCase
     }
 
     /**
-     * @param array<int,array<string,mixed>> $reads
+     * @param  array<int,array<string,mixed>>  $reads
      */
     private function assertStableRecommendedReadsShape(array $reads): void
     {

--- a/backend/tests/Feature/V0_3/ShareSummaryContractTest.php
+++ b/backend/tests/Feature/V0_3/ShareSummaryContractTest.php
@@ -62,6 +62,7 @@ final class ShareSummaryContractTest extends TestCase
         $this->assertSame('I', $response->json('dimensions.0.side'));
         $this->assertSame(65, $response->json('dimensions.0.pct'));
         $this->assertSame('clear', $response->json('dimensions.0.state'));
+        $this->assertStableMbtiPublicSummaryV1((array) $response->json('mbti_public_summary_v1'), 'INTJ-A', 'INTJ', 'A');
         $this->assertStringContainsString('/share/'.$response->json('share_id'), (string) $response->json('share_url'));
         $this->assertStringNotContainsString('PRIVATE_PAID_SECTION_BODY', (string) $response->getContent());
         $this->assertStringNotContainsString('PRIVATE_RESULT_PATH', (string) $response->getContent());
@@ -124,9 +125,26 @@ final class ShareSummaryContractTest extends TestCase
             'dimensions',
             'primary_cta_label',
             'primary_cta_path',
+            'mbti_public_summary_v1',
         ] as $key) {
             $this->assertSame($share->json($key), $view->json($key), "share field mismatch: {$key}");
         }
+
+        $this->assertSame(
+            'INTJ-A',
+            $view->json('mbti_public_summary_v1.display_type')
+        );
+        $this->assertSame(
+            $view->json('summary'),
+            $view->json('mbti_public_summary_v1.summary_card.share_text')
+        );
+        $this->assertSame(
+            ['EI', 'SN', 'TF', 'JP', 'AT'],
+            array_map(
+                static fn (array $item): string => (string) ($item['id'] ?? ''),
+                (array) $view->json('mbti_public_summary_v1.dimensions')
+            )
+        );
 
         $this->assertStringNotContainsString('PRIVATE_PAID_SECTION_BODY', (string) $view->getContent());
         $this->assertStringNotContainsString('PRIVATE_RESULT_PATH', (string) $view->getContent());
@@ -279,5 +297,30 @@ final class ShareSummaryContractTest extends TestCase
             'published_at' => now()->subMinute(),
             'schema_version' => 'v1',
         ]);
+    }
+
+    /**
+     * @param  array<string,mixed>  $summary
+     */
+    private function assertStableMbtiPublicSummaryV1(
+        array $summary,
+        string $expectedRuntimeTypeCode,
+        string $expectedCanonicalType,
+        ?string $expectedVariant
+    ): void {
+        $this->assertSame($expectedRuntimeTypeCode, $summary['runtime_type_code'] ?? null);
+        $this->assertSame($expectedCanonicalType, $summary['canonical_type_16'] ?? null);
+        $this->assertSame($expectedRuntimeTypeCode, $summary['display_type'] ?? null);
+        $this->assertSame($expectedVariant, $summary['variant'] ?? null);
+        $this->assertSame('建筑师型', data_get($summary, 'profile.type_name'));
+        $this->assertSame('冷静的长期规划者', data_get($summary, 'profile.nickname'));
+        $this->assertSame('Public-safe share summary.', data_get($summary, 'summary_card.share_text'));
+        $this->assertSame(
+            ['EI', 'SN', 'TF', 'JP', 'AT'],
+            array_map(
+                static fn (array $item): string => (string) ($item['id'] ?? ''),
+                (array) ($summary['dimensions'] ?? [])
+            )
+        );
     }
 }

--- a/backend/tests/Unit/Services/Mbti/MbtiPublicSummaryV1BuilderTest.php
+++ b/backend/tests/Unit/Services/Mbti/MbtiPublicSummaryV1BuilderTest.php
@@ -1,0 +1,66 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Services\Mbti;
+
+use App\Services\Mbti\MbtiPublicSummaryV1Builder;
+use Tests\TestCase;
+
+final class MbtiPublicSummaryV1BuilderTest extends TestCase
+{
+    public function test_scaffold_keeps_stable_shape_without_inventing_missing_identity_or_summary(): void
+    {
+        $builder = new MbtiPublicSummaryV1Builder;
+        $payload = $builder->scaffold();
+
+        $this->assertSame([
+            'runtime_type_code' => null,
+            'canonical_type_16' => null,
+            'display_type' => null,
+            'variant' => null,
+        ], [
+            'runtime_type_code' => $payload['runtime_type_code'],
+            'canonical_type_16' => $payload['canonical_type_16'],
+            'display_type' => $payload['display_type'],
+            'variant' => $payload['variant'],
+        ]);
+        $this->assertSame([], $payload['dimensions']);
+        $this->assertSame([], $payload['sections']);
+        $this->assertSame([], data_get($payload, 'profile.keywords'));
+        $this->assertSame([], data_get($payload, 'summary_card.tags'));
+        $this->assertSame([], data_get($payload, 'offer_set.modules_allowed'));
+        $this->assertSame([], data_get($payload, 'offer_set.modules_preview'));
+        $this->assertNull(data_get($payload, 'profile.summary'));
+        $this->assertNull(data_get($payload, 'summary_card.share_text'));
+    }
+
+    public function test_share_payload_builder_preserves_base_type_without_fabricating_variant_and_normalizes_axis_aliases(): void
+    {
+        $builder = new MbtiPublicSummaryV1Builder;
+        $payload = $builder->buildFromSharePayload([
+            'type_code' => ' enfj ',
+            'title' => 'ENFJ - Mentor',
+            'summary' => null,
+            'dimensions' => [
+                ['code' => 'NS', 'side' => 'N', 'pct' => 74],
+                ['code' => 'FT', 'side' => 'F', 'pct' => 65],
+            ],
+        ], null, 'en');
+
+        $this->assertSame('ENFJ', $payload['runtime_type_code']);
+        $this->assertSame('ENFJ', $payload['canonical_type_16']);
+        $this->assertSame('ENFJ', $payload['display_type']);
+        $this->assertNull($payload['variant']);
+        $this->assertSame(['SN', 'TF'], array_map(
+            static fn (array $item): string => (string) ($item['id'] ?? ''),
+            $payload['dimensions']
+        ));
+        $this->assertSame(26, data_get($payload, 'dimensions.0.value_pct'));
+        $this->assertSame(35, data_get($payload, 'dimensions.1.value_pct'));
+        $this->assertSame('overview', data_get($payload, 'sections.0.key'));
+        $this->assertSame('ENFJ - Mentor', data_get($payload, 'sections.0.title'));
+        $this->assertNull(data_get($payload, 'sections.0.payload'));
+        $this->assertNull(data_get($payload, 'summary_card.share_text'));
+    }
+}


### PR DESCRIPTION
## Summary
This PR adds a single additive MBTI public result contract, `mbti_public_summary_v1`, and wires it into the existing MBTI report, share, and compare APIs without changing the current consumer surface. The goal is to stop the public MBTI identity, summary, and dimension payloads from diverging across endpoints while keeping all existing fields intact for downstream clients.

On the user-facing side, this gives every MBTI public surface the same backend-owned contract for runtime type identity, canonical 16-type mapping, A/T preservation, canonical axis ids, safe summary content, and report offer metadata where it already exists. That makes the contract usable later by share, compare, personality, SEO, OG, and sitemap work without forcing frontend changes in this PR.

## Root cause
Before this change, report, share, and compare each exposed different MBTI slices from different sources. Report payloads were shaped from the report envelope, share payloads were flattened from a separate public summary path, and compare payloads used another summary-lite structure. As a result, `type_code`, A/T handling, axis naming, and summary fields were not normalized in one place, and consumers had to infer or reconcile differences themselves.

The underlying runtime authority already existed, but there was no single builder responsible for translating that authority into a stable public contract. Identity bridging such as `ENFJ-T -> ENFJ`, axis alias cleanup such as `NS -> SN` and `FT -> TF`, and null-safe shaping were therefore spread across endpoint-specific logic or left implicit.

## What changed
A dedicated `MbtiPublicSummaryV1Builder` was added under the MBTI service layer. It owns the contract scaffold, runtime type normalization, canonical 16-type derivation, A/T extraction, canonical dimension id normalization, overview section shaping, and report-offer serialization.

The builder is now used additively in three existing response flows:
- `GET /api/v0.3/attempts/{id}/report` adds top-level `mbti_public_summary_v1`
- `GET /api/v0.3/shares/{id}` and the attempt share flow add top-level `mbti_public_summary_v1`
- `GET /api/v0.3/compare/mbti/{inviteId}` adds nested `mbti_public_summary_v1` under `inviter`, `invitee`, and `compare`

The contract does not fabricate missing identities, A/T variants, dimensions, or summary content. It only exposes data already present in the runtime/report/share/compare pipeline and keeps empty shapes stable when data is partial.

## Scope boundaries
This PR does not change frontend consumers, importer behavior, CMS schema, sitemap generation, career logic, team/pro logic, scoring, checkout, pricing, payment, orders, or delivery flows. It also does not add new routes or remove legacy fields.

## Validation
The change was validated with focused MBTI coverage and existing repository checks:
- `php artisan route:list | grep -E "api/.+(report|shares|compare)"`
- `php artisan migrate`
- `php artisan fap:schema:verify`
- `vendor/bin/phpunit tests/Unit/Services/Mbti/MbtiPublicSummaryV1BuilderTest.php tests/Feature/V0_3/MbtiReportHttpContractRegressionTest.php tests/Feature/V0_3/ShareSummaryContractTest.php tests/Feature/V0_3/MbtiCompareInviteContractTest.php`
- `vendor/bin/phpunit --filter Mbti`
- `bash backend/scripts/ci_verify_mbti.sh`

Those checks confirmed that the additive contract is present across report/share/compare, preserves A/T, normalizes dimension ids to `EI/SN/TF/JP/AT`, and leaves the existing MBTI chain green.
