### PR TITLE
[codex] feat(api): extend PersonalityProfile for canonical 32-type MBTI authority

### DIFF
--- a/backend/app/Filament/Ops/Resources/PersonalityProfileResource.php
+++ b/backend/app/Filament/Ops/Resources/PersonalityProfileResource.php
@@ -93,12 +93,22 @@ class PersonalityProfileResource extends Resource
                                     ->helperText('V1 supports the 16 base MBTI types only.')
                                     ->live()
                                     ->afterStateUpdated(function (?string $state, Forms\Set $set, Forms\Get $get): void {
+                                        $set('canonical_type_code', PersonalityWorkspace::normalizeCanonicalTypeCode(
+                                            (string) ($get('canonical_type_code') ?? ''),
+                                            $state,
+                                        ));
+
                                         if (trim((string) $get('slug')) !== '') {
                                             return;
                                         }
 
                                         $set('slug', PersonalityWorkspace::normalizeSlug(null, $state));
                                     }),
+                                Forms\Components\TextInput::make('canonical_type_code')
+                                    ->label('Canonical type')
+                                    ->readOnly()
+                                    ->dehydrated(false)
+                                    ->helperText('Auto-synced 16-type canonical identity for the base profile layer.'),
                                 Forms\Components\TextInput::make('slug')
                                     ->required()
                                     ->maxLength(64)
@@ -115,6 +125,16 @@ class PersonalityProfileResource extends Resource
                                     ->options(self::localeOptions())
                                     ->default('en')
                                     ->helperText('Stored as backend locale codes. Frontend URL mapping still resolves to locale-aware paths.'),
+                                Forms\Components\Select::make('schema_version')
+                                    ->required()
+                                    ->native(false)
+                                    ->options([
+                                        PersonalityProfile::SCHEMA_VERSION_V1 => PersonalityProfile::SCHEMA_VERSION_V1,
+                                        PersonalityProfile::SCHEMA_VERSION_V2 => PersonalityProfile::SCHEMA_VERSION_V2,
+                                    ])
+                                    ->default(PersonalityProfile::SCHEMA_VERSION_V2)
+                                    ->live()
+                                    ->helperText('Controls whether the workspace manages the legacy v1 catalog or the canonical MBTI v2 catalog.'),
                                 Forms\Components\TextInput::make('title')
                                     ->required()
                                     ->maxLength(255)
@@ -122,14 +142,35 @@ class PersonalityProfileResource extends Resource
                                     ->helperText('Primary profile heading shown in the workspace, public detail page, and SEO fallback.')
                                     ->extraFieldWrapperAttributes(['class' => 'ops-personality-workspace-field ops-personality-workspace-field--title'])
                                     ->extraInputAttributes(['class' => 'ops-personality-workspace-input ops-personality-workspace-input--title']),
+                                Forms\Components\TextInput::make('type_name')
+                                    ->label('Type name')
+                                    ->maxLength(120)
+                                    ->helperText('Canonical localized type name used by the 32-type content authority.'),
+                                Forms\Components\TextInput::make('nickname')
+                                    ->label('Nickname')
+                                    ->maxLength(160)
+                                    ->helperText('Optional editorial nickname for the canonical base profile.'),
                                 Forms\Components\TextInput::make('subtitle')
                                     ->maxLength(255)
-                                    ->columnSpanFull()
                                     ->helperText('Short supporting line for the hero and quick list scanning.'),
+                                Forms\Components\TextInput::make('rarity_text')
+                                    ->label('Rarity text')
+                                    ->maxLength(64)
+                                    ->helperText('Human-readable rarity label when canonical content provides one.'),
                                 Forms\Components\Textarea::make('excerpt')
                                     ->rows(4)
                                     ->columnSpanFull()
                                     ->helperText('Used as the summary fallback across list, SEO, and public profile contexts.')
+                                    ->extraFieldWrapperAttributes(['class' => 'ops-personality-workspace-field ops-personality-workspace-field--summary']),
+                                Forms\Components\TagsInput::make('keywords_json')
+                                    ->label('Keywords')
+                                    ->columnSpanFull()
+                                    ->helperText('Canonical keyword tags stored as structured JSON on the base profile row.'),
+                                Forms\Components\Textarea::make('hero_summary_md')
+                                    ->label('Hero summary')
+                                    ->rows(4)
+                                    ->columnSpanFull()
+                                    ->helperText('Canonical hero summary stored separately from excerpt and hero quote.')
                                     ->extraFieldWrapperAttributes(['class' => 'ops-personality-workspace-field ops-personality-workspace-field--summary']),
                             ])
                             ->columns(3),
@@ -177,6 +218,12 @@ class PersonalityProfileResource extends Resource
                                     ->content(fn (Forms\Get $get, ?PersonalityProfile $record): string => PersonalityWorkspace::normalizeTypeCode(
                                         (string) ($get('type_code') ?? $record?->type_code ?? '')
                                     ) ?: 'Not set yet'),
+                                Forms\Components\Placeholder::make('identity_canonical')
+                                    ->label('Canonical type')
+                                    ->content(fn (Forms\Get $get, ?PersonalityProfile $record): string => PersonalityWorkspace::normalizeCanonicalTypeCode(
+                                        (string) ($get('canonical_type_code') ?? $record?->canonical_type_code ?? ''),
+                                        (string) ($get('type_code') ?? $record?->type_code ?? ''),
+                                    ) ?: 'Not set yet'),
                                 Forms\Components\Placeholder::make('identity_slug')
                                     ->label('Slug')
                                     ->content(fn (Forms\Get $get, ?PersonalityProfile $record): string => PersonalityWorkspace::normalizeSlug(
@@ -191,6 +238,11 @@ class PersonalityProfileResource extends Resource
                                 Forms\Components\Placeholder::make('identity_org')
                                     ->label('Content scope')
                                     ->content('Global MBTI content (org_id=0)'),
+                                Forms\Components\Placeholder::make('identity_schema_version')
+                                    ->label('Schema version')
+                                    ->content(fn (Forms\Get $get, ?PersonalityProfile $record): string => PersonalityWorkspace::normalizeSchemaVersion(
+                                        (string) ($get('schema_version') ?? $record?->schema_version ?? PersonalityProfile::SCHEMA_VERSION_V1),
+                                    )),
                             ])
                             ->columns(2),
                         Forms\Components\Section::make('Publish')
@@ -325,6 +377,10 @@ class PersonalityProfileResource extends Resource
                     ->copyable()
                     ->formatStateUsing(fn (string $state): string => '/'.trim($state, '/'))
                     ->toggleable(isToggledHiddenByDefault: true),
+                Tables\Columns\TextColumn::make('schema_version')
+                    ->badge()
+                    ->sortable()
+                    ->toggleable(isToggledHiddenByDefault: true),
                 Tables\Columns\TextColumn::make('status')
                     ->badge()
                     ->sortable()
@@ -361,6 +417,11 @@ class PersonalityProfileResource extends Resource
                     ->options(self::localeOptions()),
                 Tables\Filters\SelectFilter::make('status')
                     ->options(self::statusOptions()),
+                Tables\Filters\SelectFilter::make('schema_version')
+                    ->options([
+                        PersonalityProfile::SCHEMA_VERSION_V1 => PersonalityProfile::SCHEMA_VERSION_V1,
+                        PersonalityProfile::SCHEMA_VERSION_V2 => PersonalityProfile::SCHEMA_VERSION_V2,
+                    ]),
                 TernaryFilter::make('is_public')
                     ->label('Public'),
                 TernaryFilter::make('is_indexable')
@@ -431,11 +492,13 @@ class PersonalityProfileResource extends Resource
      */
     private static function sectionTabs(): array
     {
-        $variantOptions = PersonalityWorkspace::renderVariantOptions();
-
-        return collect(PersonalityWorkspace::sectionDefinitions())
-            ->map(function (array $definition, string $sectionKey) use ($variantOptions): Forms\Components\Tabs\Tab {
+        return collect(PersonalityWorkspace::allSectionDefinitions())
+            ->map(function (array $definition, string $sectionKey): Forms\Components\Tabs\Tab {
                 return Forms\Components\Tabs\Tab::make($definition['label'])
+                    ->visible(fn (Forms\Get $get): bool => PersonalityWorkspace::isManagedSectionKeyForSchemaVersion(
+                        $sectionKey,
+                        (string) ($get('schema_version') ?? PersonalityProfile::SCHEMA_VERSION_V1),
+                    ))
                     ->schema([
                         Forms\Components\Toggle::make("workspace_sections.{$sectionKey}.is_enabled")
                             ->label('Enable this section')
@@ -443,13 +506,22 @@ class PersonalityProfileResource extends Resource
                             ->columnSpanFull(),
                         Forms\Components\TextInput::make("workspace_sections.{$sectionKey}.title")
                             ->label('Section title')
-                            ->required()
+                            ->required(fn (Forms\Get $get): bool => PersonalityWorkspace::isManagedSectionKeyForSchemaVersion(
+                                $sectionKey,
+                                (string) ($get('schema_version') ?? PersonalityProfile::SCHEMA_VERSION_V1),
+                            ))
                             ->maxLength(255),
                         Forms\Components\Select::make("workspace_sections.{$sectionKey}.render_variant")
                             ->label('Render variant')
                             ->native(false)
-                            ->options($variantOptions)
-                            ->required(),
+                            ->options(fn (Forms\Get $get): array => PersonalityWorkspace::renderVariantOptions(
+                                (string) ($get('schema_version') ?? PersonalityProfile::SCHEMA_VERSION_V1),
+                                $sectionKey,
+                            ))
+                            ->required(fn (Forms\Get $get): bool => PersonalityWorkspace::isManagedSectionKeyForSchemaVersion(
+                                $sectionKey,
+                                (string) ($get('schema_version') ?? PersonalityProfile::SCHEMA_VERSION_V1),
+                            )),
                         Forms\Components\Textarea::make("workspace_sections.{$sectionKey}.body_md")
                             ->label('Narrative body')
                             ->rows(8)

--- a/backend/app/Filament/Ops/Resources/PersonalityProfileResource/Pages/CreatePersonalityProfile.php
+++ b/backend/app/Filament/Ops/Resources/PersonalityProfileResource/Pages/CreatePersonalityProfile.php
@@ -92,8 +92,15 @@ class CreatePersonalityProfile extends CreateRecord
         $data['org_id'] = 0;
         $data['scale_code'] = PersonalityProfile::SCALE_CODE_MBTI;
         $data['type_code'] = $typeCode;
+        $data['canonical_type_code'] = PersonalityWorkspace::normalizeCanonicalTypeCode(
+            (string) ($data['canonical_type_code'] ?? ''),
+            $typeCode,
+        );
         $data['slug'] = PersonalityWorkspace::normalizeSlug((string) ($data['slug'] ?? ''), $typeCode);
         $data['locale'] = PersonalityWorkspace::normalizeLocale((string) ($data['locale'] ?? 'en'));
+        $data['schema_version'] = PersonalityWorkspace::normalizeSchemaVersion(
+            (string) ($data['schema_version'] ?? PersonalityProfile::SCHEMA_VERSION_V2),
+        );
         $data['created_by_admin_user_id'] = $this->currentAdminId();
         $data['updated_by_admin_user_id'] = $this->currentAdminId();
 

--- a/backend/app/Filament/Ops/Resources/PersonalityProfileResource/Pages/EditPersonalityProfile.php
+++ b/backend/app/Filament/Ops/Resources/PersonalityProfileResource/Pages/EditPersonalityProfile.php
@@ -89,8 +89,15 @@ class EditPersonalityProfile extends EditRecord
         $data['org_id'] = 0;
         $data['scale_code'] = PersonalityProfile::SCALE_CODE_MBTI;
         $data['type_code'] = $typeCode;
+        $data['canonical_type_code'] = PersonalityWorkspace::normalizeCanonicalTypeCode(
+            (string) ($data['canonical_type_code'] ?? ''),
+            $typeCode,
+        );
         $data['slug'] = PersonalityWorkspace::normalizeSlug((string) ($data['slug'] ?? ''), $typeCode);
         $data['locale'] = PersonalityWorkspace::normalizeLocale((string) ($data['locale'] ?? 'en'));
+        $data['schema_version'] = PersonalityWorkspace::normalizeSchemaVersion(
+            (string) ($data['schema_version'] ?? $this->getRecord()->schema_version ?? PersonalityProfile::SCHEMA_VERSION_V1),
+        );
         $data['updated_by_admin_user_id'] = $this->currentAdminId();
 
         return $data;

--- a/backend/app/Filament/Ops/Resources/PersonalityProfileResource/Support/PersonalityWorkspace.php
+++ b/backend/app/Filament/Ops/Resources/PersonalityProfileResource/Support/PersonalityWorkspace.php
@@ -10,8 +10,10 @@ use App\Models\PersonalityProfileRevision;
 use App\Models\PersonalityProfileSection;
 use App\Models\PersonalityProfileSeoMeta;
 use App\Services\Cms\PersonalityProfileSeoService;
+use App\Support\Mbti\MbtiCanonicalSectionRegistry;
 use Filament\Forms\Get;
 use Illuminate\Contracts\Support\Htmlable;
+use Illuminate\Support\Arr;
 use Illuminate\Support\Carbon;
 use Illuminate\Support\HtmlString;
 use Illuminate\Support\Str;
@@ -22,7 +24,7 @@ final class PersonalityWorkspace
     /**
      * @return array<string, array{label: string, title: string, description: string, render_variant: string, sort_order: int, enabled: bool}>
      */
-    public static function sectionDefinitions(): array
+    public static function legacySectionDefinitions(): array
     {
         return [
             'core_snapshot' => [
@@ -109,10 +111,64 @@ final class PersonalityWorkspace
     }
 
     /**
+     * @return array<string, array{label: string, title: string, description: string, render_variant: string, sort_order: int, enabled: bool}>
+     */
+    public static function canonicalSectionDefinitions(): array
+    {
+        return collect(MbtiCanonicalSectionRegistry::definitions())
+            ->mapWithKeys(static fn (array $definition, string $sectionKey): array => [
+                $sectionKey => [
+                    'label' => (string) ($definition['label'] ?? Str::of($sectionKey)->replace(['.', '_'], ' ')->headline()->value()),
+                    'title' => (string) ($definition['title'] ?? Str::of($sectionKey)->replace(['.', '_'], ' ')->headline()->value()),
+                    'description' => (string) ($definition['description'] ?? ''),
+                    'render_variant' => (string) $definition['render_variant'],
+                    'sort_order' => (int) ($definition['sort_order'] ?? 0),
+                    'enabled' => (bool) ($definition['enabled'] ?? true),
+                ],
+            ])
+            ->all();
+    }
+
+    /**
+     * @return array<string, array{label: string, title: string, description: string, render_variant: string, sort_order: int, enabled: bool}>
+     */
+    public static function allSectionDefinitions(): array
+    {
+        return array_merge(
+            self::legacySectionDefinitions(),
+            self::canonicalSectionDefinitions(),
+        );
+    }
+
+    /**
+     * @return array<string, array{label: string, title: string, description: string, render_variant: string, sort_order: int, enabled: bool}>
+     */
+    public static function sectionDefinitions(?string $schemaVersion = null): array
+    {
+        return self::normalizeSchemaVersion($schemaVersion) === PersonalityProfile::SCHEMA_VERSION_V2
+            ? self::canonicalSectionDefinitions()
+            : self::legacySectionDefinitions();
+    }
+
+    /**
      * @return array<string, string>
      */
-    public static function renderVariantOptions(): array
+    public static function renderVariantOptions(?string $schemaVersion = null, ?string $sectionKey = null): array
     {
+        $normalizedSchemaVersion = self::normalizeSchemaVersion($schemaVersion);
+
+        if (
+            $normalizedSchemaVersion === PersonalityProfile::SCHEMA_VERSION_V2
+            && $sectionKey !== null
+            && array_key_exists($sectionKey, self::canonicalSectionDefinitions())
+        ) {
+            $renderVariant = (string) self::canonicalSectionDefinitions()[$sectionKey]['render_variant'];
+
+            return [
+                $renderVariant => Str::of($renderVariant)->replace('_', ' ')->headline()->value(),
+            ];
+        }
+
         return collect(PersonalityProfileSection::RENDER_VARIANTS)
             ->mapWithKeys(static fn (string $variant): array => [
                 $variant => Str::of($variant)->replace('_', ' ')->headline()->value(),
@@ -129,13 +185,20 @@ final class PersonalityWorkspace
             'org_id' => 0,
             'scale_code' => PersonalityProfile::SCALE_CODE_MBTI,
             'type_code' => '',
+            'canonical_type_code' => '',
             'slug' => '',
             'locale' => 'en',
+            'schema_version' => PersonalityProfile::SCHEMA_VERSION_V2,
             'title' => '',
+            'type_name' => '',
+            'nickname' => '',
+            'rarity_text' => '',
+            'keywords_json' => [],
             'subtitle' => '',
             'excerpt' => '',
             'hero_kicker' => '',
             'hero_quote' => '',
+            'hero_summary_md' => '',
             'hero_image_url' => '',
             'status' => 'draft',
             'is_public' => true,
@@ -154,7 +217,7 @@ final class PersonalityWorkspace
     {
         $state = [];
 
-        foreach (self::sectionDefinitions() as $sectionKey => $definition) {
+        foreach (self::allSectionDefinitions() as $sectionKey => $definition) {
             $state[$sectionKey] = [
                 'title' => $definition['title'],
                 'render_variant' => $definition['render_variant'],
@@ -259,18 +322,26 @@ final class PersonalityWorkspace
      */
     public static function syncWorkspaceSections(PersonalityProfile $profile, array $state): void
     {
-        $definitions = self::sectionDefinitions();
-        $knownSectionKeys = array_keys($definitions);
-
-        PersonalityProfileSection::query()
-            ->where('profile_id', (int) $profile->id)
-            ->whereNotIn('section_key', $knownSectionKeys)
-            ->delete();
+        $definitions = self::sectionDefinitions((string) $profile->schema_version);
+        $defaults = self::defaultWorkspaceSectionsState();
+        $submittedKeys = [];
 
         foreach ($definitions as $sectionKey => $definition) {
-            $sectionState = array_merge(
-                self::defaultWorkspaceSectionsState()[$sectionKey],
-                is_array($state[$sectionKey] ?? null) ? $state[$sectionKey] : [],
+            if (! is_array($state[$sectionKey] ?? null)) {
+                continue;
+            }
+
+            $submittedKeys[] = $sectionKey;
+            $sectionState = array_merge($defaults[$sectionKey], $state[$sectionKey]);
+
+            $payloadJson = self::normalizeSectionPayload(
+                $sectionKey,
+                self::decodeJsonText(
+                    $sectionState['payload_json_text'] ?? null,
+                    "workspace_sections.{$sectionKey}.payload_json_text",
+                ),
+                (string) $profile->schema_version,
+                "workspace_sections.{$sectionKey}.payload_json_text",
             );
 
             PersonalityProfileSection::query()->updateOrCreate(
@@ -280,17 +351,27 @@ final class PersonalityWorkspace
                 ],
                 [
                     'title' => self::normalizeNullableText((string) ($sectionState['title'] ?? '')) ?? $definition['title'],
-                    'render_variant' => self::normalizeRenderVariant((string) ($sectionState['render_variant'] ?? $definition['render_variant']), $definition['render_variant']),
+                    'render_variant' => self::normalizeRenderVariant(
+                        (string) ($sectionState['render_variant'] ?? $definition['render_variant']),
+                        $definition['render_variant'],
+                        array_keys(self::renderVariantOptions((string) $profile->schema_version, $sectionKey))
+                    ),
                     'body_md' => self::normalizeNullableText((string) ($sectionState['body_md'] ?? '')),
                     'body_html' => null,
-                    'payload_json' => self::decodeJsonText(
-                        $sectionState['payload_json_text'] ?? null,
-                        "workspace_sections.{$sectionKey}.payload_json_text",
-                    ),
+                    'payload_json' => $payloadJson,
                     'sort_order' => (int) ($sectionState['sort_order'] ?? $definition['sort_order']),
                     'is_enabled' => StatusBadge::isTruthy($sectionState['is_enabled'] ?? $definition['enabled']),
                 ],
             );
+        }
+
+        $removedKeys = array_values(array_diff(array_keys($definitions), $submittedKeys));
+
+        if ($removedKeys !== []) {
+            PersonalityProfileSection::query()
+                ->where('profile_id', (int) $profile->id)
+                ->whereIn('section_key', $removedKeys)
+                ->delete();
         }
 
         $profile->unsetRelation('sections');
@@ -346,13 +427,20 @@ final class PersonalityWorkspace
                 'org_id' => (int) $profile->org_id,
                 'scale_code' => (string) $profile->scale_code,
                 'type_code' => (string) $profile->type_code,
+                'canonical_type_code' => $profile->canonical_type_code,
                 'slug' => (string) $profile->slug,
                 'locale' => (string) $profile->locale,
                 'title' => (string) $profile->title,
+                'type_name' => $profile->type_name,
+                'nickname' => $profile->nickname,
+                'rarity_text' => $profile->rarity_text,
+                'keywords_json' => $profile->keywords_json,
                 'subtitle' => $profile->subtitle,
                 'excerpt' => $profile->excerpt,
                 'hero_kicker' => $profile->hero_kicker,
                 'hero_quote' => $profile->hero_quote,
+                'hero_summary_md' => $profile->hero_summary_md,
+                'hero_summary_html' => $profile->hero_summary_html,
                 'hero_image_url' => $profile->hero_image_url,
                 'status' => (string) $profile->status,
                 'is_public' => (bool) $profile->is_public,
@@ -515,7 +603,20 @@ final class PersonalityWorkspace
     {
         $normalized = Str::upper(trim((string) $typeCode));
 
-        return in_array($normalized, PersonalityProfile::TYPE_CODES, true) ? $normalized : $normalized;
+        return in_array($normalized, PersonalityProfile::BASE_TYPE_CODES, true) ? $normalized : $normalized;
+    }
+
+    public static function normalizeCanonicalTypeCode(?string $canonicalTypeCode, ?string $typeCode = null): ?string
+    {
+        $normalizedTypeCode = self::normalizeTypeCode($typeCode);
+
+        if (in_array($normalizedTypeCode, PersonalityProfile::BASE_TYPE_CODES, true)) {
+            return $normalizedTypeCode;
+        }
+
+        $normalized = Str::upper(trim((string) $canonicalTypeCode));
+
+        return $normalized !== '' ? $normalized : null;
     }
 
     public static function normalizeSlug(?string $slug, ?string $typeCode = null): string
@@ -538,6 +639,25 @@ final class PersonalityWorkspace
         $normalized = trim((string) $locale);
 
         return in_array($normalized, PersonalityProfile::SUPPORTED_LOCALES, true) ? $normalized : 'en';
+    }
+
+    public static function normalizeSchemaVersion(?string $schemaVersion): string
+    {
+        $normalized = trim((string) $schemaVersion);
+
+        return $normalized === PersonalityProfile::SCHEMA_VERSION_V2
+            ? PersonalityProfile::SCHEMA_VERSION_V2
+            : PersonalityProfile::SCHEMA_VERSION_V1;
+    }
+
+    public static function usesCanonicalSchema(?string $schemaVersion): bool
+    {
+        return self::normalizeSchemaVersion($schemaVersion) === PersonalityProfile::SCHEMA_VERSION_V2;
+    }
+
+    public static function isManagedSectionKeyForSchemaVersion(string $sectionKey, ?string $schemaVersion): bool
+    {
+        return array_key_exists($sectionKey, self::sectionDefinitions($schemaVersion));
     }
 
     /**
@@ -599,11 +719,17 @@ final class PersonalityWorkspace
         return (int) $user->getAuthIdentifier();
     }
 
-    private static function normalizeRenderVariant(string $variant, string $fallback): string
+    /**
+     * @param  list<string>|null  $allowedVariants
+     */
+    private static function normalizeRenderVariant(string $variant, string $fallback, ?array $allowedVariants = null): string
     {
         $normalized = trim($variant);
+        $variants = $allowedVariants !== null && $allowedVariants !== []
+            ? $allowedVariants
+            : PersonalityProfileSection::RENDER_VARIANTS;
 
-        return in_array($normalized, PersonalityProfileSection::RENDER_VARIANTS, true) ? $normalized : $fallback;
+        return in_array($normalized, $variants, true) ? $normalized : $fallback;
     }
 
     private static function normalizeNullableText(string $value): ?string
@@ -639,6 +765,50 @@ final class PersonalityWorkspace
         }
 
         return is_array($decoded) ? $decoded : null;
+    }
+
+    /**
+     * @param  array<string, mixed>|null  $payload
+     * @return array<string, mixed>|null
+     */
+    private static function normalizeSectionPayload(
+        string $sectionKey,
+        ?array $payload,
+        ?string $schemaVersion,
+        string $field
+    ): ?array {
+        if ($payload === null) {
+            return null;
+        }
+
+        if (
+            self::usesCanonicalSchema($schemaVersion)
+            && $sectionKey === 'trait_overview'
+            && is_array($payload['dimensions'] ?? null)
+        ) {
+            $allowedAxisIds = MbtiCanonicalSectionRegistry::traitOverviewAxisTargets();
+
+            foreach (array_values($payload['dimensions']) as $index => $dimension) {
+                if (! is_array($dimension)) {
+                    throw ValidationException::withMessages([
+                        $field => sprintf('trait_overview.dimensions[%d] must be an object.', $index),
+                    ]);
+                }
+
+                $axisId = strtoupper(trim((string) Arr::get($dimension, 'id', '')));
+                if (! in_array($axisId, $allowedAxisIds, true)) {
+                    throw ValidationException::withMessages([
+                        $field => sprintf(
+                            'trait_overview.dimensions[%d].id must be one of %s.',
+                            $index,
+                            implode(', ', $allowedAxisIds),
+                        ),
+                    ]);
+                }
+            }
+        }
+
+        return $payload;
     }
 
     private static function normalizeTimestamp(mixed $value): ?string

--- a/backend/app/Http/Controllers/API/V0_5/Cms/PersonalityController.php
+++ b/backend/app/Http/Controllers/API/V0_5/Cms/PersonalityController.php
@@ -118,7 +118,7 @@ class PersonalityController extends Controller
      */
     private function profileListPayload(PersonalityProfile $profile): array
     {
-        return [
+        return array_merge([
             'id' => (int) $profile->id,
             'org_id' => (int) $profile->org_id,
             'scale_code' => (string) $profile->scale_code,
@@ -134,7 +134,7 @@ class PersonalityController extends Controller
             'published_at' => $profile->published_at?->toISOString(),
             'updated_at' => $profile->updated_at?->toISOString(),
             'seo_meta' => $this->seoMetaSummaryPayload($profile->seoMeta),
-        ];
+        ], $this->personalityProfileService->publicCanonicalFields($profile));
     }
 
     /**
@@ -142,7 +142,7 @@ class PersonalityController extends Controller
      */
     private function profileDetailPayload(PersonalityProfile $profile): array
     {
-        return [
+        return array_merge([
             'id' => (int) $profile->id,
             'org_id' => (int) $profile->org_id,
             'scale_code' => (string) $profile->scale_code,
@@ -160,7 +160,7 @@ class PersonalityController extends Controller
             'is_indexable' => (bool) $profile->is_indexable,
             'published_at' => $profile->published_at?->toISOString(),
             'updated_at' => $profile->updated_at?->toISOString(),
-        ];
+        ], $this->personalityProfileService->publicCanonicalFields($profile));
     }
 
     /**

--- a/backend/app/Models/PersonalityProfile.php
+++ b/backend/app/Models/PersonalityProfile.php
@@ -16,7 +16,11 @@ class PersonalityProfile extends Model
 
     public const SCALE_CODE_MBTI = 'MBTI';
 
-    public const TYPE_CODES = [
+    public const SCHEMA_VERSION_V1 = 'v1';
+
+    public const SCHEMA_VERSION_V2 = 'v2';
+
+    public const BASE_TYPE_CODES = [
         'INTJ',
         'INTP',
         'ENTJ',
@@ -35,6 +39,8 @@ class PersonalityProfile extends Model
         'ESFP',
     ];
 
+    public const TYPE_CODES = self::BASE_TYPE_CODES;
+
     public const SUPPORTED_LOCALES = [
         'en',
         'zh-CN',
@@ -46,13 +52,20 @@ class PersonalityProfile extends Model
         'org_id',
         'scale_code',
         'type_code',
+        'canonical_type_code',
         'slug',
         'locale',
         'title',
+        'type_name',
+        'nickname',
+        'rarity_text',
+        'keywords_json',
         'subtitle',
         'excerpt',
         'hero_kicker',
         'hero_quote',
+        'hero_summary_md',
+        'hero_summary_html',
         'hero_image_url',
         'status',
         'is_public',
@@ -68,6 +81,7 @@ class PersonalityProfile extends Model
         'org_id' => 'integer',
         'created_by_admin_user_id' => 'integer',
         'updated_by_admin_user_id' => 'integer',
+        'keywords_json' => 'array',
         'is_public' => 'boolean',
         'is_indexable' => 'boolean',
         'published_at' => 'datetime',
@@ -79,6 +93,21 @@ class PersonalityProfile extends Model
     public static function allowOrgZeroContext(): bool
     {
         return true;
+    }
+
+    protected static function booted(): void
+    {
+        static::saving(function (self $profile): void {
+            $profile->scale_code = strtoupper(trim((string) $profile->scale_code));
+            $profile->type_code = strtoupper(trim((string) $profile->type_code));
+            $profile->canonical_type_code = self::resolveCanonicalTypeCode(
+                (string) $profile->scale_code,
+                $profile->canonical_type_code,
+                (string) $profile->type_code
+            );
+            $profile->schema_version = self::normalizeSchemaVersion($profile->schema_version);
+            $profile->keywords_json = self::normalizeKeywords($profile->keywords_json);
+        });
     }
 
     public function sections(): HasMany
@@ -100,6 +129,13 @@ class PersonalityProfile extends Model
             ->orderByDesc('id');
     }
 
+    public function variants(): HasMany
+    {
+        return $this->hasMany(PersonalityProfileVariant::class, 'personality_profile_id', 'id')
+            ->orderBy('variant_code')
+            ->orderBy('id');
+    }
+
     public function scopePublishedPublic($query)
     {
         return $query
@@ -115,5 +151,48 @@ class PersonalityProfile extends Model
     public function scopeForType($query, string $typeCode)
     {
         return $query->where('type_code', strtoupper($typeCode));
+    }
+
+    private static function resolveCanonicalTypeCode(
+        string $scaleCode,
+        mixed $canonicalTypeCode,
+        string $typeCode
+    ): ?string {
+        $normalizedCanonical = strtoupper(trim((string) $canonicalTypeCode));
+
+        if ($scaleCode === self::SCALE_CODE_MBTI && in_array($typeCode, self::BASE_TYPE_CODES, true)) {
+            return $typeCode;
+        }
+
+        return $normalizedCanonical !== '' ? $normalizedCanonical : null;
+    }
+
+    private static function normalizeSchemaVersion(mixed $schemaVersion): string
+    {
+        $normalized = trim((string) $schemaVersion);
+
+        return $normalized === self::SCHEMA_VERSION_V2
+            ? self::SCHEMA_VERSION_V2
+            : self::SCHEMA_VERSION_V1;
+    }
+
+    /**
+     * @return array<int, string>
+     */
+    private static function normalizeKeywords(mixed $keywords): array
+    {
+        if (! is_array($keywords)) {
+            return [];
+        }
+
+        return array_values(array_filter(array_map(static function (mixed $keyword): ?string {
+            if (! is_scalar($keyword)) {
+                return null;
+            }
+
+            $normalized = trim((string) $keyword);
+
+            return $normalized !== '' ? $normalized : null;
+        }, $keywords)));
     }
 }

--- a/backend/app/Models/PersonalityProfileSection.php
+++ b/backend/app/Models/PersonalityProfileSection.php
@@ -33,6 +33,10 @@ class PersonalityProfileSection extends Model
         'faq',
         'links',
         'callout',
+        'letters_intro',
+        'trait_dimension_grid',
+        'preferred_role_list',
+        'premium_teaser',
     ];
 
     protected $table = 'personality_profile_sections';

--- a/backend/app/Models/PersonalityProfileVariant.php
+++ b/backend/app/Models/PersonalityProfileVariant.php
@@ -1,0 +1,124 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+use Illuminate\Database\Eloquent\Relations\HasOne;
+use InvalidArgumentException;
+
+class PersonalityProfileVariant extends Model
+{
+    use HasFactory;
+
+    protected $table = 'personality_profile_variants';
+
+    protected $fillable = [
+        'personality_profile_id',
+        'canonical_type_code',
+        'variant_code',
+        'runtime_type_code',
+        'type_name',
+        'nickname',
+        'rarity_text',
+        'keywords_json',
+        'hero_summary_md',
+        'hero_summary_html',
+        'schema_version',
+        'is_published',
+        'published_at',
+    ];
+
+    protected $casts = [
+        'personality_profile_id' => 'integer',
+        'keywords_json' => 'array',
+        'is_published' => 'boolean',
+        'published_at' => 'datetime',
+        'created_at' => 'datetime',
+        'updated_at' => 'datetime',
+    ];
+
+    protected static function booted(): void
+    {
+        static::saving(function (self $variant): void {
+            $variant->canonical_type_code = strtoupper(trim((string) $variant->canonical_type_code));
+            $variant->variant_code = strtoupper(trim((string) $variant->variant_code));
+            $variant->runtime_type_code = strtoupper(trim((string) $variant->runtime_type_code));
+            $variant->schema_version = trim((string) $variant->schema_version) !== ''
+                ? trim((string) $variant->schema_version)
+                : PersonalityProfile::SCHEMA_VERSION_V2;
+            $variant->keywords_json = self::normalizeKeywords($variant->keywords_json);
+
+            if (! in_array($variant->variant_code, ['A', 'T'], true)) {
+                throw new InvalidArgumentException('Personality profile variant_code must be A or T.');
+            }
+
+            if (preg_match('/^(?<base>[EI][SN][TF][JP])-(?<variant>[AT])$/', $variant->runtime_type_code, $matches) !== 1) {
+                throw new InvalidArgumentException('Personality profile runtime_type_code must be a full MBTI runtime identity such as ENFJ-A.');
+            }
+
+            $baseType = (string) $matches['base'];
+            $variantCode = (string) $matches['variant'];
+
+            if ($variant->canonical_type_code === '') {
+                $variant->canonical_type_code = $baseType;
+            }
+
+            if ($variant->canonical_type_code !== $baseType) {
+                throw new InvalidArgumentException('Personality profile canonical_type_code must match the runtime_type_code base type.');
+            }
+
+            if ($variant->variant_code !== $variantCode) {
+                throw new InvalidArgumentException('Personality profile variant_code must match the runtime_type_code suffix.');
+            }
+        });
+    }
+
+    public function profile(): BelongsTo
+    {
+        return $this->belongsTo(PersonalityProfile::class, 'personality_profile_id', 'id');
+    }
+
+    public function sections(): HasMany
+    {
+        return $this->hasMany(PersonalityProfileVariantSection::class, 'personality_profile_variant_id', 'id')
+            ->orderBy('sort_order')
+            ->orderBy('id');
+    }
+
+    public function seoMeta(): HasOne
+    {
+        return $this->hasOne(PersonalityProfileVariantSeoMeta::class, 'personality_profile_variant_id', 'id');
+    }
+
+    public function revisions(): HasMany
+    {
+        return $this->hasMany(PersonalityProfileVariantRevision::class, 'personality_profile_variant_id', 'id')
+            ->orderByDesc('revision_no')
+            ->orderByDesc('id');
+    }
+
+    /**
+     * @return array<int, string>
+     */
+    private static function normalizeKeywords(mixed $keywords): array
+    {
+        if (! is_array($keywords)) {
+            return [];
+        }
+
+        return array_values(array_filter(array_map(static function (mixed $keyword): ?string {
+            if (! is_scalar($keyword)) {
+                return null;
+            }
+
+            $normalized = trim((string) $keyword);
+
+            return $normalized !== '' ? $normalized : null;
+        }, $keywords)));
+    }
+}

--- a/backend/app/Models/PersonalityProfileVariantRevision.php
+++ b/backend/app/Models/PersonalityProfileVariantRevision.php
@@ -8,18 +8,16 @@ use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 
-class PersonalityProfileRevision extends Model
+class PersonalityProfileVariantRevision extends Model
 {
     use HasFactory;
 
-    public const PROFILE_FOREIGN_KEY = 'profile_id';
-
-    protected $table = 'personality_profile_revisions';
+    protected $table = 'personality_profile_variant_revisions';
 
     public $timestamps = false;
 
     protected $fillable = [
-        'profile_id',
+        'personality_profile_variant_id',
         'revision_no',
         'snapshot_json',
         'note',
@@ -28,15 +26,15 @@ class PersonalityProfileRevision extends Model
     ];
 
     protected $casts = [
-        'profile_id' => 'integer',
+        'personality_profile_variant_id' => 'integer',
         'revision_no' => 'integer',
         'snapshot_json' => 'array',
         'created_by_admin_user_id' => 'integer',
         'created_at' => 'datetime',
     ];
 
-    public function profile(): BelongsTo
+    public function variant(): BelongsTo
     {
-        return $this->belongsTo(PersonalityProfile::class, self::PROFILE_FOREIGN_KEY, 'id');
+        return $this->belongsTo(PersonalityProfileVariant::class, 'personality_profile_variant_id', 'id');
     }
 }

--- a/backend/app/Models/PersonalityProfileVariantSection.php
+++ b/backend/app/Models/PersonalityProfileVariantSection.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+class PersonalityProfileVariantSection extends Model
+{
+    use HasFactory;
+
+    protected $table = 'personality_profile_variant_sections';
+
+    protected $fillable = [
+        'personality_profile_variant_id',
+        'section_key',
+        'render_variant',
+        'body_md',
+        'body_html',
+        'payload_json',
+        'sort_order',
+        'is_enabled',
+    ];
+
+    protected $casts = [
+        'personality_profile_variant_id' => 'integer',
+        'payload_json' => 'array',
+        'sort_order' => 'integer',
+        'is_enabled' => 'boolean',
+        'created_at' => 'datetime',
+        'updated_at' => 'datetime',
+    ];
+
+    public function variant(): BelongsTo
+    {
+        return $this->belongsTo(PersonalityProfileVariant::class, 'personality_profile_variant_id', 'id');
+    }
+}

--- a/backend/app/Models/PersonalityProfileVariantSeoMeta.php
+++ b/backend/app/Models/PersonalityProfileVariantSeoMeta.php
@@ -8,16 +8,14 @@ use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 
-class PersonalityProfileSeoMeta extends Model
+class PersonalityProfileVariantSeoMeta extends Model
 {
     use HasFactory;
 
-    public const PROFILE_FOREIGN_KEY = 'profile_id';
-
-    protected $table = 'personality_profile_seo_meta';
+    protected $table = 'personality_profile_variant_seo_meta';
 
     protected $fillable = [
-        'profile_id',
+        'personality_profile_variant_id',
         'seo_title',
         'seo_description',
         'canonical_url',
@@ -32,14 +30,14 @@ class PersonalityProfileSeoMeta extends Model
     ];
 
     protected $casts = [
-        'profile_id' => 'integer',
+        'personality_profile_variant_id' => 'integer',
         'jsonld_overrides_json' => 'array',
         'created_at' => 'datetime',
         'updated_at' => 'datetime',
     ];
 
-    public function profile(): BelongsTo
+    public function variant(): BelongsTo
     {
-        return $this->belongsTo(PersonalityProfile::class, self::PROFILE_FOREIGN_KEY, 'id');
+        return $this->belongsTo(PersonalityProfileVariant::class, 'personality_profile_variant_id', 'id');
     }
 }

--- a/backend/app/Services/Cms/PersonalityProfileSeoService.php
+++ b/backend/app/Services/Cms/PersonalityProfileSeoService.php
@@ -82,7 +82,7 @@ final class PersonalityProfileSeoService
     public function buildCanonicalUrl(PersonalityProfile $profile, string $locale): ?string
     {
         $baseUrl = rtrim((string) config('app.frontend_url', config('app.url', '')), '/');
-        $slug = trim((string) $profile->slug);
+        $slug = $this->publicRouteSlug($profile);
 
         if ($baseUrl === '' || $slug === '') {
             return null;
@@ -108,6 +108,11 @@ final class PersonalityProfileSeoService
         return PersonalityProfileSeoMeta::query()
             ->where('profile_id', (int) $profile->id)
             ->first();
+    }
+
+    private function publicRouteSlug(PersonalityProfile $profile): string
+    {
+        return trim((string) $profile->slug);
     }
 
     private function fallbackText(?string ...$candidates): ?string

--- a/backend/app/Services/Cms/PersonalityProfileService.php
+++ b/backend/app/Services/Cms/PersonalityProfileService.php
@@ -20,6 +20,7 @@ final class PersonalityProfileService
     ): LengthAwarePaginator {
         return $this->basePublicQuery($orgId, $scaleCode, $locale)
             ->with('seoMeta')
+            ->orderBy('canonical_type_code')
             ->orderBy('type_code')
             ->orderBy('id')
             ->paginate($perPage, ['*'], 'page', $page);
@@ -62,12 +63,29 @@ final class PersonalityProfileService
         ];
     }
 
+    /**
+     * @return array<string, mixed>
+     */
+    public function publicCanonicalFields(PersonalityProfile $profile): array
+    {
+        return [
+            'canonical_type_code' => $profile->canonical_type_code,
+            'schema_version' => (string) $profile->schema_version,
+            'type_name' => $profile->type_name,
+            'nickname' => $profile->nickname,
+            'rarity' => $profile->rarity_text,
+            'keywords' => is_array($profile->keywords_json) ? array_values($profile->keywords_json) : [],
+            'hero_summary' => $profile->hero_summary_md,
+        ];
+    }
+
     private function basePublicQuery(int $orgId, string $scaleCode, string $locale): Builder
     {
         return PersonalityProfile::query()
             ->withoutGlobalScopes()
             ->where('org_id', max(0, $orgId))
             ->where('scale_code', $this->normalizeScaleCode($scaleCode))
+            ->whereIn('type_code', PersonalityProfile::TYPE_CODES)
             ->forLocale($this->normalizeLocale($locale))
             ->publishedPublic()
             ->where(static function (Builder $query): void {

--- a/backend/app/Support/Mbti/MbtiCanonicalSectionRegistry.php
+++ b/backend/app/Support/Mbti/MbtiCanonicalSectionRegistry.php
@@ -12,9 +12,11 @@ final class MbtiCanonicalSectionRegistry
 
     public const BUCKET_PREMIUM_TEASER = 'premium_teaser';
 
+    public const RENDER_VARIANT_LETTERS_INTRO = 'letters_intro';
+
     public const RENDER_VARIANT_RICH_TEXT = 'rich_text';
 
-    public const RENDER_VARIANT_BULLET_LIST = 'bullet_list';
+    public const RENDER_VARIANT_BULLET_LIST = 'bullets';
 
     public const RENDER_VARIANT_TRAIT_DIMENSION_GRID = 'trait_dimension_grid';
 
@@ -27,6 +29,11 @@ final class MbtiCanonicalSectionRegistry
      *   bucket:string,
      *   render_variant:string,
      *   group:string,
+     *   label:string,
+     *   title:string,
+     *   description:string,
+     *   sort_order:int,
+     *   enabled:bool,
      *   premium_teaser?:bool,
      *   payload_schema?:array<string,mixed>
      * }>
@@ -36,18 +43,33 @@ final class MbtiCanonicalSectionRegistry
         return [
             'letters_intro' => [
                 'bucket' => self::BUCKET_SECTIONS,
-                'render_variant' => self::RENDER_VARIANT_RICH_TEXT,
+                'render_variant' => self::RENDER_VARIANT_LETTERS_INTRO,
                 'group' => 'top',
+                'label' => 'Letters Intro',
+                'title' => 'Letter-by-letter introduction',
+                'description' => 'Headline and per-letter copy for the 32-type MBTI identity block.',
+                'sort_order' => 10,
+                'enabled' => true,
             ],
             'overview' => [
                 'bucket' => self::BUCKET_SECTIONS,
                 'render_variant' => self::RENDER_VARIANT_RICH_TEXT,
                 'group' => 'top',
+                'label' => 'Overview',
+                'title' => 'Overview',
+                'description' => 'Narrative overview of the canonical personality profile.',
+                'sort_order' => 20,
+                'enabled' => true,
             ],
             'trait_overview' => [
                 'bucket' => self::BUCKET_SECTIONS,
                 'render_variant' => self::RENDER_VARIANT_TRAIT_DIMENSION_GRID,
                 'group' => 'trait_overview',
+                'label' => 'Trait Overview',
+                'title' => 'Trait overview',
+                'description' => 'Canonical MBTI dimension grid using EI / SN / TF / JP / AT axis ids.',
+                'sort_order' => 30,
+                'enabled' => true,
                 'payload_schema' => [
                     'summary' => 'string|null',
                     'dimensions' => 'list<trait_dimension>',
@@ -58,79 +80,154 @@ final class MbtiCanonicalSectionRegistry
                 'bucket' => self::BUCKET_SECTIONS,
                 'render_variant' => self::RENDER_VARIANT_RICH_TEXT,
                 'group' => 'career',
+                'label' => 'Career Summary',
+                'title' => 'Career summary',
+                'description' => 'Narrative career overview for the canonical base profile.',
+                'sort_order' => 40,
+                'enabled' => true,
             ],
             'career.advantages' => [
                 'bucket' => self::BUCKET_SECTIONS,
                 'render_variant' => self::RENDER_VARIANT_BULLET_LIST,
                 'group' => 'career',
+                'label' => 'Career Advantages',
+                'title' => 'Career advantages',
+                'description' => 'Bullet list of work strengths in career contexts.',
+                'sort_order' => 50,
+                'enabled' => true,
             ],
             'career.weaknesses' => [
                 'bucket' => self::BUCKET_SECTIONS,
                 'render_variant' => self::RENDER_VARIANT_BULLET_LIST,
                 'group' => 'career',
+                'label' => 'Career Weaknesses',
+                'title' => 'Career weaknesses',
+                'description' => 'Bullet list of career blind spots and trade-offs.',
+                'sort_order' => 60,
+                'enabled' => true,
             ],
             'career.preferred_roles' => [
                 'bucket' => self::BUCKET_SECTIONS,
                 'render_variant' => self::RENDER_VARIANT_PREFERRED_ROLE_LIST,
                 'group' => 'career',
+                'label' => 'Preferred Roles',
+                'title' => 'Preferred roles',
+                'description' => 'Grouped role recommendations for the canonical profile.',
+                'sort_order' => 70,
+                'enabled' => true,
             ],
             'career.upgrade_suggestions' => [
                 'bucket' => self::BUCKET_SECTIONS,
                 'render_variant' => self::RENDER_VARIANT_BULLET_LIST,
                 'group' => 'career',
+                'label' => 'Upgrade Suggestions',
+                'title' => 'Career upgrade suggestions',
+                'description' => 'Upgrade formulas and bullet suggestions for career growth.',
+                'sort_order' => 80,
+                'enabled' => true,
             ],
             'growth.summary' => [
                 'bucket' => self::BUCKET_SECTIONS,
                 'render_variant' => self::RENDER_VARIANT_RICH_TEXT,
                 'group' => 'growth',
+                'label' => 'Growth Summary',
+                'title' => 'Growth summary',
+                'description' => 'Narrative personal growth overview.',
+                'sort_order' => 90,
+                'enabled' => true,
             ],
             'growth.strengths' => [
                 'bucket' => self::BUCKET_SECTIONS,
                 'render_variant' => self::RENDER_VARIANT_BULLET_LIST,
                 'group' => 'growth',
+                'label' => 'Growth Strengths',
+                'title' => 'Growth strengths',
+                'description' => 'Bullet list of personal growth strengths.',
+                'sort_order' => 100,
+                'enabled' => true,
             ],
             'growth.weaknesses' => [
                 'bucket' => self::BUCKET_SECTIONS,
                 'render_variant' => self::RENDER_VARIANT_BULLET_LIST,
                 'group' => 'growth',
+                'label' => 'Growth Weaknesses',
+                'title' => 'Growth weaknesses',
+                'description' => 'Bullet list of growth liabilities and tensions.',
+                'sort_order' => 110,
+                'enabled' => true,
             ],
             'growth.motivators' => [
                 'bucket' => self::BUCKET_PREMIUM_TEASER,
                 'render_variant' => self::RENDER_VARIANT_PREMIUM_TEASER,
                 'group' => 'growth',
+                'label' => 'Growth Motivators',
+                'title' => 'Growth motivators',
+                'description' => 'Premium teaser describing what energizes the profile.',
+                'sort_order' => 120,
+                'enabled' => true,
                 'premium_teaser' => true,
             ],
             'growth.drainers' => [
                 'bucket' => self::BUCKET_PREMIUM_TEASER,
                 'render_variant' => self::RENDER_VARIANT_PREMIUM_TEASER,
                 'group' => 'growth',
+                'label' => 'Growth Drainers',
+                'title' => 'Growth drainers',
+                'description' => 'Premium teaser describing what depletes the profile.',
+                'sort_order' => 130,
+                'enabled' => true,
                 'premium_teaser' => true,
             ],
             'relationships.summary' => [
                 'bucket' => self::BUCKET_SECTIONS,
                 'render_variant' => self::RENDER_VARIANT_RICH_TEXT,
                 'group' => 'relationships',
+                'label' => 'Relationships Summary',
+                'title' => 'Relationships summary',
+                'description' => 'Narrative overview for relationships and close dynamics.',
+                'sort_order' => 140,
+                'enabled' => true,
             ],
             'relationships.strengths' => [
                 'bucket' => self::BUCKET_SECTIONS,
                 'render_variant' => self::RENDER_VARIANT_BULLET_LIST,
                 'group' => 'relationships',
+                'label' => 'Relationships Strengths',
+                'title' => 'Relationships strengths',
+                'description' => 'Bullet list of relationship strengths.',
+                'sort_order' => 150,
+                'enabled' => true,
             ],
             'relationships.weaknesses' => [
                 'bucket' => self::BUCKET_SECTIONS,
                 'render_variant' => self::RENDER_VARIANT_BULLET_LIST,
                 'group' => 'relationships',
+                'label' => 'Relationships Weaknesses',
+                'title' => 'Relationships weaknesses',
+                'description' => 'Bullet list of relationship weak points.',
+                'sort_order' => 160,
+                'enabled' => true,
             ],
             'relationships.rel_advantages' => [
                 'bucket' => self::BUCKET_PREMIUM_TEASER,
                 'render_variant' => self::RENDER_VARIANT_PREMIUM_TEASER,
                 'group' => 'relationships',
+                'label' => 'Relationship Advantages',
+                'title' => 'Relationship advantages',
+                'description' => 'Premium teaser for interpersonal advantages.',
+                'sort_order' => 170,
+                'enabled' => true,
                 'premium_teaser' => true,
             ],
             'relationships.rel_risks' => [
                 'bucket' => self::BUCKET_PREMIUM_TEASER,
                 'render_variant' => self::RENDER_VARIANT_PREMIUM_TEASER,
                 'group' => 'relationships',
+                'label' => 'Relationship Risks',
+                'title' => 'Relationship risks',
+                'description' => 'Premium teaser for interpersonal risks.',
+                'sort_order' => 180,
+                'enabled' => true,
                 'premium_teaser' => true,
             ],
         ];
@@ -150,6 +247,14 @@ final class MbtiCanonicalSectionRegistry
             'JP' => 'JP',
             'AT' => 'AT',
         ];
+    }
+
+    /**
+     * @return list<string>
+     */
+    public static function traitOverviewAxisTargets(): array
+    {
+        return ['EI', 'SN', 'TF', 'JP', 'AT'];
     }
 
     public static function normalizeTraitAxisCode(string $axisCode): string

--- a/backend/database/migrations/2026_03_16_000100_add_canonical_v2_fields_to_personality_profiles_table.php
+++ b/backend/database/migrations/2026_03_16_000100_add_canonical_v2_fields_to_personality_profiles_table.php
@@ -1,0 +1,61 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('personality_profiles', function (Blueprint $table): void {
+            $table->string('canonical_type_code', 4)
+                ->nullable()
+                ->after('type_code');
+            $table->string('type_name', 120)
+                ->nullable()
+                ->after('title');
+            $table->string('nickname', 160)
+                ->nullable()
+                ->after('type_name');
+            $table->string('rarity_text', 64)
+                ->nullable()
+                ->after('nickname');
+            $table->json('keywords_json')
+                ->nullable()
+                ->after('rarity_text');
+            $table->text('hero_summary_md')
+                ->nullable()
+                ->after('hero_quote');
+            $table->longText('hero_summary_html')
+                ->nullable()
+                ->after('hero_summary_md');
+
+            $table->index(
+                ['org_id', 'scale_code', 'canonical_type_code', 'locale'],
+                'personality_profiles_org_scale_canonical_locale_idx'
+            );
+        });
+
+        DB::table('personality_profiles')
+            ->whereNull('canonical_type_code')
+            ->update([
+                'canonical_type_code' => DB::raw('UPPER(type_code)'),
+            ]);
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        // Intentionally non-destructive: rollback does not remove additive schema.
+        return;
+    }
+};

--- a/backend/database/migrations/2026_03_16_000110_create_personality_profile_variant_authority_tables.php
+++ b/backend/database/migrations/2026_03_16_000110_create_personality_profile_variant_authority_tables.php
@@ -1,0 +1,111 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('personality_profile_variants', function (Blueprint $table): void {
+            $table->id();
+            $table->foreignId('personality_profile_id')
+                ->constrained('personality_profiles')
+                ->cascadeOnDelete();
+            $table->string('canonical_type_code', 4);
+            $table->char('variant_code', 1);
+            $table->string('runtime_type_code', 8);
+            $table->string('type_name', 120)->nullable();
+            $table->string('nickname', 160)->nullable();
+            $table->string('rarity_text', 64)->nullable();
+            $table->json('keywords_json')->nullable();
+            $table->text('hero_summary_md')->nullable();
+            $table->longText('hero_summary_html')->nullable();
+            $table->string('schema_version', 32)->default('v2');
+            $table->boolean('is_published')->default(false);
+            $table->timestamp('published_at')->nullable();
+            $table->timestamps();
+
+            $table->unique(
+                ['personality_profile_id', 'variant_code'],
+                'personality_profile_variants_profile_variant_unique'
+            );
+            $table->unique(
+                ['personality_profile_id', 'runtime_type_code'],
+                'personality_profile_variants_profile_runtime_unique'
+            );
+            $table->index('canonical_type_code', 'personality_profile_variants_canonical_idx');
+        });
+
+        Schema::create('personality_profile_variant_sections', function (Blueprint $table): void {
+            $table->id();
+            $table->foreignId('personality_profile_variant_id')
+                ->constrained('personality_profile_variants')
+                ->cascadeOnDelete();
+            $table->string('section_key', 100);
+            $table->string('render_variant', 100);
+            $table->longText('body_md')->nullable();
+            $table->longText('body_html')->nullable();
+            $table->json('payload_json')->nullable();
+            $table->unsignedInteger('sort_order')->default(0);
+            $table->boolean('is_enabled')->default(true);
+            $table->timestamps();
+
+            $table->unique(
+                ['personality_profile_variant_id', 'section_key'],
+                'personality_profile_variant_sections_variant_section_unique'
+            );
+        });
+
+        Schema::create('personality_profile_variant_seo_meta', function (Blueprint $table): void {
+            $table->id();
+            $table->foreignId('personality_profile_variant_id')
+                ->constrained('personality_profile_variants')
+                ->cascadeOnDelete();
+            $table->string('seo_title', 255)->nullable();
+            $table->text('seo_description')->nullable();
+            $table->string('canonical_url', 2048)->nullable();
+            $table->string('og_title', 255)->nullable();
+            $table->text('og_description')->nullable();
+            $table->string('og_image_url', 2048)->nullable();
+            $table->string('twitter_title', 255)->nullable();
+            $table->text('twitter_description')->nullable();
+            $table->string('twitter_image_url', 2048)->nullable();
+            $table->string('robots', 64)->nullable();
+            $table->json('jsonld_overrides_json')->nullable();
+            $table->timestamps();
+
+            $table->unique(
+                ['personality_profile_variant_id'],
+                'personality_profile_variant_seo_meta_variant_unique'
+            );
+        });
+
+        Schema::create('personality_profile_variant_revisions', function (Blueprint $table): void {
+            $table->id();
+            $table->foreignId('personality_profile_variant_id')
+                ->constrained('personality_profile_variants')
+                ->cascadeOnDelete();
+            $table->unsignedInteger('revision_no');
+            $table->json('snapshot_json');
+            $table->string('note', 255)->nullable();
+            $table->unsignedBigInteger('created_by_admin_user_id')->nullable();
+            $table->timestamp('created_at')->useCurrent();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        // Intentionally non-destructive: rollback does not remove authority tables.
+        return;
+    }
+};

--- a/backend/tests/Feature/Ops/PersonalityWorkspaceTest.php
+++ b/backend/tests/Feature/Ops/PersonalityWorkspaceTest.php
@@ -11,6 +11,7 @@ use App\Models\Organization;
 use App\Models\Permission;
 use App\Models\PersonalityProfile;
 use App\Models\PersonalityProfileRevision;
+use App\Models\PersonalityProfileSection;
 use App\Models\Role;
 use App\Support\OrgContext;
 use App\Support\Rbac\PermissionNames;
@@ -154,6 +155,102 @@ final class PersonalityWorkspaceTest extends TestCase
         $this->assertSame('Updated long-range systems framing.', $latestRevision->snapshot_json['sections'][0]['body_md']);
     }
 
+    public function test_v1_profiles_use_legacy_catalog_while_v2_profiles_use_canonical_registry(): void
+    {
+        $legacyProfile = $this->seedProfile([
+            'type_code' => 'INTJ',
+            'slug' => 'intj-v1',
+            'schema_version' => PersonalityProfile::SCHEMA_VERSION_V1,
+        ]);
+        $canonicalProfile = $this->seedProfile([
+            'type_code' => 'ENFJ',
+            'slug' => 'enfj-v2',
+            'schema_version' => PersonalityProfile::SCHEMA_VERSION_V2,
+        ]);
+
+        PersonalityWorkspace::syncWorkspaceSections($legacyProfile, $this->workspaceSectionsState());
+        PersonalityWorkspace::syncWorkspaceSections($canonicalProfile, $this->v2WorkspaceSectionsState());
+
+        $this->assertSame(
+            array_keys(PersonalityWorkspace::legacySectionDefinitions()),
+            array_keys(PersonalityWorkspace::sectionDefinitions(PersonalityProfile::SCHEMA_VERSION_V1))
+        );
+        $this->assertSame(
+            array_keys(PersonalityWorkspace::canonicalSectionDefinitions()),
+            array_keys(PersonalityWorkspace::sectionDefinitions(PersonalityProfile::SCHEMA_VERSION_V2))
+        );
+        $this->assertDatabaseHas('personality_profile_sections', [
+            'profile_id' => (int) $legacyProfile->id,
+            'section_key' => 'core_snapshot',
+        ]);
+        $this->assertDatabaseHas('personality_profile_sections', [
+            'profile_id' => (int) $canonicalProfile->id,
+            'section_key' => 'letters_intro',
+            'render_variant' => 'letters_intro',
+        ]);
+    }
+
+    public function test_v2_workspace_sync_keeps_canonical_sections_and_preserves_unmanaged_keys(): void
+    {
+        $profile = $this->seedProfile([
+            'type_code' => 'ENFJ',
+            'slug' => 'enfj',
+            'schema_version' => PersonalityProfile::SCHEMA_VERSION_V2,
+        ]);
+
+        PersonalityProfileSection::query()->create([
+            'profile_id' => (int) $profile->id,
+            'section_key' => 'core_snapshot',
+            'title' => 'Legacy carry-over',
+            'render_variant' => 'rich_text',
+            'body_md' => 'Keep me.',
+            'sort_order' => 5,
+            'is_enabled' => true,
+        ]);
+
+        PersonalityWorkspace::syncWorkspaceSections($profile, $this->v2WorkspaceSectionsState());
+
+        $freshProfile = $profile->fresh(['sections']);
+        $workspaceState = PersonalityWorkspace::workspaceSectionsFromRecord($freshProfile);
+
+        $this->assertDatabaseHas('personality_profile_sections', [
+            'profile_id' => (int) $profile->id,
+            'section_key' => 'letters_intro',
+            'render_variant' => 'letters_intro',
+        ]);
+        $this->assertDatabaseHas('personality_profile_sections', [
+            'profile_id' => (int) $profile->id,
+            'section_key' => 'trait_overview',
+            'render_variant' => 'trait_dimension_grid',
+        ]);
+        $this->assertDatabaseHas('personality_profile_sections', [
+            'profile_id' => (int) $profile->id,
+            'section_key' => 'career.preferred_roles',
+            'render_variant' => 'preferred_role_list',
+        ]);
+        $this->assertDatabaseHas('personality_profile_sections', [
+            'profile_id' => (int) $profile->id,
+            'section_key' => 'growth.motivators',
+            'render_variant' => 'premium_teaser',
+        ]);
+        $this->assertDatabaseHas('personality_profile_sections', [
+            'profile_id' => (int) $profile->id,
+            'section_key' => 'relationships.rel_risks',
+            'render_variant' => 'premium_teaser',
+        ]);
+        $this->assertDatabaseHas('personality_profile_sections', [
+            'profile_id' => (int) $profile->id,
+            'section_key' => 'core_snapshot',
+            'body_md' => 'Keep me.',
+        ]);
+
+        $this->assertSame('letters_intro', $workspaceState['letters_intro']['render_variant']);
+        $this->assertSame('trait_dimension_grid', $workspaceState['trait_overview']['render_variant']);
+        $this->assertSame('preferred_role_list', $workspaceState['career.preferred_roles']['render_variant']);
+        $this->assertSame('premium_teaser', $workspaceState['growth.motivators']['render_variant']);
+        $this->assertSame('premium_teaser', $workspaceState['relationships.rel_risks']['render_variant']);
+    }
+
     public function test_resource_query_is_locked_to_global_mbti_profiles(): void
     {
         $globalProfile = $this->seedProfile([
@@ -258,6 +355,7 @@ final class PersonalityWorkspaceTest extends TestCase
             'status' => 'draft',
             'is_public' => true,
             'is_indexable' => true,
+            'schema_version' => PersonalityProfile::SCHEMA_VERSION_V1,
         ], $overrides));
     }
 
@@ -311,5 +409,35 @@ final class PersonalityWorkspaceTest extends TestCase
             'robots' => 'index,follow',
             'jsonld_overrides_json_text' => '',
         ];
+    }
+
+    /**
+     * @return array<string, array<string, mixed>>
+     */
+    private function v2WorkspaceSectionsState(): array
+    {
+        $state = PersonalityWorkspace::defaultWorkspaceSectionsState();
+
+        $state['letters_intro']['body_md'] = 'E sees people, N sees patterns, F weighs values, J creates structure.';
+        $state['trait_overview']['payload_json_text'] = json_encode([
+            'summary' => 'Canonical MBTI dimensions for ENFJ.',
+            'dimensions' => [
+                ['id' => 'EI', 'label' => 'Energy', 'value_pct' => 68],
+                ['id' => 'SN', 'label' => 'Perception', 'value_pct' => 72],
+                ['id' => 'TF', 'label' => 'Decision', 'value_pct' => 64],
+                ['id' => 'JP', 'label' => 'Lifestyle', 'value_pct' => 58],
+                ['id' => 'AT', 'label' => 'Identity', 'value_pct' => 47],
+            ],
+        ], JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE);
+        $state['career.preferred_roles']['payload_json_text'] = json_encode([
+            'items' => [
+                ['title' => 'Teacher', 'fit' => 'high'],
+                ['title' => 'Coach', 'fit' => 'high'],
+            ],
+        ], JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE);
+        $state['growth.motivators']['body_md'] = 'Preview: recognition, purpose, and interpersonal momentum.';
+        $state['relationships.rel_risks']['body_md'] = 'Preview: overextending emotionally when mutuality is low.';
+
+        return $state;
     }
 }

--- a/backend/tests/Feature/PersonalityCms/PersonalitySchemaSmokeTest.php
+++ b/backend/tests/Feature/PersonalityCms/PersonalitySchemaSmokeTest.php
@@ -8,6 +8,10 @@ use App\Models\PersonalityProfile;
 use App\Models\PersonalityProfileRevision;
 use App\Models\PersonalityProfileSection;
 use App\Models\PersonalityProfileSeoMeta;
+use App\Models\PersonalityProfileVariant;
+use App\Models\PersonalityProfileVariantRevision;
+use App\Models\PersonalityProfileVariantSection;
+use App\Models\PersonalityProfileVariantSeoMeta;
 use Illuminate\Database\QueryException;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Tests\TestCase;
@@ -87,6 +91,7 @@ final class PersonalitySchemaSmokeTest extends TestCase
             $freshProfile->sections()->pluck('section_key')->all()
         );
         $this->assertSame('INTJ personality', $freshProfile->seoMeta?->seo_title);
+        $this->assertSame('INTJ', $freshProfile->canonical_type_code);
         $this->assertSame(
             [2, 1],
             $freshProfile->revisions()->pluck('revision_no')->all()
@@ -99,10 +104,12 @@ final class PersonalitySchemaSmokeTest extends TestCase
 
     public function test_unique_org_scale_type_locale_constraint_is_enforced(): void
     {
-        PersonalityProfile::query()->create($this->profilePayload([
+        $profile = PersonalityProfile::query()->create($this->profilePayload([
             'type_code' => 'ENFP',
             'slug' => 'enfp',
         ]));
+
+        $this->assertSame('ENFP', $profile->canonical_type_code);
 
         $this->expectException(QueryException::class);
 
@@ -158,6 +165,94 @@ final class PersonalitySchemaSmokeTest extends TestCase
         $this->assertDatabaseMissing('personality_profile_sections', ['id' => $section->id]);
         $this->assertDatabaseMissing('personality_profile_seo_meta', ['id' => $seoMeta->id]);
         $this->assertDatabaseMissing('personality_profile_revisions', ['id' => $revision->id]);
+    }
+
+    public function test_base_profile_can_hold_both_a_and_t_variants_but_not_duplicate_variant_codes(): void
+    {
+        $profile = PersonalityProfile::query()->create($this->profilePayload([
+            'type_code' => 'ENFJ',
+            'slug' => 'enfj',
+            'schema_version' => PersonalityProfile::SCHEMA_VERSION_V2,
+        ]));
+
+        $assertive = PersonalityProfileVariant::query()->create([
+            'personality_profile_id' => (int) $profile->id,
+            'canonical_type_code' => 'ENFJ',
+            'variant_code' => 'A',
+            'runtime_type_code' => 'ENFJ-A',
+            'schema_version' => PersonalityProfile::SCHEMA_VERSION_V2,
+        ]);
+
+        $turbulent = PersonalityProfileVariant::query()->create([
+            'personality_profile_id' => (int) $profile->id,
+            'canonical_type_code' => 'ENFJ',
+            'variant_code' => 'T',
+            'runtime_type_code' => 'ENFJ-T',
+            'schema_version' => PersonalityProfile::SCHEMA_VERSION_V2,
+        ]);
+
+        $this->assertSame(
+            ['ENFJ-A', 'ENFJ-T'],
+            $profile->fresh()->variants()->pluck('runtime_type_code')->all()
+        );
+        $this->assertSame('A', $assertive->variant_code);
+        $this->assertSame('T', $turbulent->variant_code);
+
+        $this->expectException(QueryException::class);
+
+        PersonalityProfileVariant::query()->create([
+            'personality_profile_id' => (int) $profile->id,
+            'canonical_type_code' => 'ENFJ',
+            'variant_code' => 'A',
+            'runtime_type_code' => 'ENFJ-A',
+            'schema_version' => PersonalityProfile::SCHEMA_VERSION_V2,
+        ]);
+    }
+
+    public function test_deleting_profile_cascades_variant_authority_tables(): void
+    {
+        $profile = PersonalityProfile::query()->create($this->profilePayload([
+            'type_code' => 'ENFJ',
+            'slug' => 'enfj',
+            'schema_version' => PersonalityProfile::SCHEMA_VERSION_V2,
+        ]));
+
+        $variant = PersonalityProfileVariant::query()->create([
+            'personality_profile_id' => (int) $profile->id,
+            'canonical_type_code' => 'ENFJ',
+            'variant_code' => 'T',
+            'runtime_type_code' => 'ENFJ-T',
+            'schema_version' => PersonalityProfile::SCHEMA_VERSION_V2,
+        ]);
+
+        $section = PersonalityProfileVariantSection::query()->create([
+            'personality_profile_variant_id' => (int) $variant->id,
+            'section_key' => 'overview',
+            'render_variant' => 'rich_text',
+        ]);
+
+        $seoMeta = PersonalityProfileVariantSeoMeta::query()->create([
+            'personality_profile_variant_id' => (int) $variant->id,
+            'seo_title' => 'ENFJ-T',
+        ]);
+
+        $revision = PersonalityProfileVariantRevision::query()->create([
+            'personality_profile_variant_id' => (int) $variant->id,
+            'revision_no' => 1,
+            'snapshot_json' => [
+                'variant_profile' => ['runtime_type_code' => 'ENFJ-T'],
+                'variant_sections' => [['section_key' => 'overview']],
+                'variant_seo_meta' => ['seo_title' => 'ENFJ-T'],
+            ],
+            'created_at' => now(),
+        ]);
+
+        $profile->delete();
+
+        $this->assertDatabaseMissing('personality_profile_variants', ['id' => $variant->id]);
+        $this->assertDatabaseMissing('personality_profile_variant_sections', ['id' => $section->id]);
+        $this->assertDatabaseMissing('personality_profile_variant_seo_meta', ['id' => $seoMeta->id]);
+        $this->assertDatabaseMissing('personality_profile_variant_revisions', ['id' => $revision->id]);
     }
 
     /**

--- a/backend/tests/Feature/PersonalityCms/PersonalityVariantAuthorityTest.php
+++ b/backend/tests/Feature/PersonalityCms/PersonalityVariantAuthorityTest.php
@@ -1,0 +1,62 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\PersonalityCms;
+
+use App\Models\PersonalityProfile;
+use App\Models\PersonalityProfileVariant;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+final class PersonalityVariantAuthorityTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_variant_authority_rows_can_coexist_while_public_route_stays_base_only(): void
+    {
+        $profile = PersonalityProfile::query()->create([
+            'org_id' => 0,
+            'scale_code' => PersonalityProfile::SCALE_CODE_MBTI,
+            'type_code' => 'ENFJ',
+            'slug' => 'enfj',
+            'locale' => 'en',
+            'title' => 'ENFJ Personality',
+            'status' => 'published',
+            'is_public' => true,
+            'is_indexable' => true,
+            'published_at' => now()->subMinute(),
+            'schema_version' => PersonalityProfile::SCHEMA_VERSION_V2,
+        ]);
+
+        $assertive = PersonalityProfileVariant::query()->create([
+            'personality_profile_id' => (int) $profile->id,
+            'canonical_type_code' => 'ENFJ',
+            'variant_code' => 'A',
+            'runtime_type_code' => 'ENFJ-A',
+            'schema_version' => PersonalityProfile::SCHEMA_VERSION_V2,
+        ]);
+
+        $turbulent = PersonalityProfileVariant::query()->create([
+            'personality_profile_id' => (int) $profile->id,
+            'canonical_type_code' => 'ENFJ',
+            'variant_code' => 'T',
+            'runtime_type_code' => 'ENFJ-T',
+            'schema_version' => PersonalityProfile::SCHEMA_VERSION_V2,
+        ]);
+
+        $this->assertSame('ENFJ', $profile->canonical_type_code);
+        $this->assertSame('A', $assertive->variant_code);
+        $this->assertSame('ENFJ-A', $assertive->runtime_type_code);
+        $this->assertSame('T', $turbulent->variant_code);
+        $this->assertSame('ENFJ-T', $turbulent->runtime_type_code);
+
+        $this->getJson('/api/v0.5/personality/enfj?locale=en')
+            ->assertOk()
+            ->assertJsonPath('profile.type_code', 'ENFJ')
+            ->assertJsonPath('profile.canonical_type_code', 'ENFJ');
+
+        $this->getJson('/api/v0.5/personality/enfj-a?locale=en')
+            ->assertStatus(404);
+    }
+}

--- a/backend/tests/Feature/V0_5/PersonalityPublicApiTest.php
+++ b/backend/tests/Feature/V0_5/PersonalityPublicApiTest.php
@@ -21,6 +21,12 @@ final class PersonalityPublicApiTest extends TestCase
             'type_code' => 'INTJ',
             'slug' => 'intj',
             'title' => 'INTJ - Architect',
+            'type_name' => 'Architect',
+            'nickname' => 'Systems builder',
+            'rarity_text' => 'About 2%',
+            'keywords_json' => ['strategy', 'independence'],
+            'hero_summary_md' => 'Strategic, independent, and long-range.',
+            'schema_version' => PersonalityProfile::SCHEMA_VERSION_V2,
             'status' => 'published',
             'is_public' => true,
             'published_at' => now()->subMinute(),
@@ -61,7 +67,14 @@ final class PersonalityPublicApiTest extends TestCase
             ->assertJsonPath('pagination.total', 1)
             ->assertJsonCount(1, 'items')
             ->assertJsonPath('items.0.slug', 'intj')
-            ->assertJsonPath('items.0.seo_meta.seo_title', 'INTJ Personality');
+            ->assertJsonPath('items.0.seo_meta.seo_title', 'INTJ Personality')
+            ->assertJsonPath('items.0.canonical_type_code', 'INTJ')
+            ->assertJsonPath('items.0.schema_version', PersonalityProfile::SCHEMA_VERSION_V2)
+            ->assertJsonPath('items.0.type_name', 'Architect')
+            ->assertJsonPath('items.0.nickname', 'Systems builder')
+            ->assertJsonPath('items.0.rarity', 'About 2%')
+            ->assertJsonPath('items.0.keywords.0', 'strategy')
+            ->assertJsonPath('items.0.hero_summary', 'Strategic, independent, and long-range.');
     }
 
     public function test_list_respects_locale_and_org_scope(): void
@@ -120,6 +133,12 @@ final class PersonalityPublicApiTest extends TestCase
             'type_code' => 'INTJ',
             'slug' => 'intj',
             'title' => 'INTJ - Architect',
+            'type_name' => 'Architect',
+            'nickname' => 'Systems builder',
+            'rarity_text' => 'About 2%',
+            'keywords_json' => ['strategy', 'independence'],
+            'hero_summary_md' => 'Strategic, independent, and long-range.',
+            'schema_version' => PersonalityProfile::SCHEMA_VERSION_V2,
             'status' => 'published',
             'is_public' => true,
             'published_at' => now()->subMinute(),
@@ -163,6 +182,13 @@ final class PersonalityPublicApiTest extends TestCase
             ->assertJsonPath('ok', true)
             ->assertJsonPath('profile.type_code', 'INTJ')
             ->assertJsonPath('profile.slug', 'intj')
+            ->assertJsonPath('profile.canonical_type_code', 'INTJ')
+            ->assertJsonPath('profile.schema_version', PersonalityProfile::SCHEMA_VERSION_V2)
+            ->assertJsonPath('profile.type_name', 'Architect')
+            ->assertJsonPath('profile.nickname', 'Systems builder')
+            ->assertJsonPath('profile.rarity', 'About 2%')
+            ->assertJsonPath('profile.keywords.1', 'independence')
+            ->assertJsonPath('profile.hero_summary', 'Strategic, independent, and long-range.')
             ->assertJsonCount(1, 'sections')
             ->assertJsonPath('sections.0.section_key', 'core_snapshot')
             ->assertJsonPath('seo_meta.seo_title', 'INTJ Personality Type')
@@ -266,6 +292,22 @@ final class PersonalityPublicApiTest extends TestCase
             'https://staging.fermatmind.com/zh/personality/intj',
             data_get($zhResponse->json(), 'jsonld.mainEntityOfPage')
         );
+    }
+
+    public function test_variant_route_key_remains_invalid_for_public_base_route(): void
+    {
+        $this->createProfile([
+            'type_code' => 'INTJ',
+            'slug' => 'intj',
+            'status' => 'published',
+            'is_public' => true,
+            'published_at' => now()->subMinute(),
+            'schema_version' => PersonalityProfile::SCHEMA_VERSION_V2,
+        ]);
+
+        $this->getJson('/api/v0.5/personality/intj-a?locale=en')
+            ->assertStatus(404)
+            ->assertJsonPath('error_code', 'NOT_FOUND');
     }
 
     /**


### PR DESCRIPTION
## Summary
This PR extends the backend `PersonalityProfile` authority schema so MBTI content can evolve from a 16-type simple base row model into a two-layer model: a 16-type canonical base profile layer plus a dedicated A/T variant authority layer. The change is intentionally additive. It does not change the current public route semantics, does not expose 32-type public slugs, and does not alter importer, projection, frontend, runtime result wiring, or sitemap behavior.

From the product side, this closes the schema gap that prevented backend content from storing canonical 32-type authority safely. Base public personality pages still resolve from the existing 16-type slug and 4-letter type code, while variant authority now has its own storage and constraints for `ENFJ-A` / `ENFJ-T` style content. That lets later PRs build importer and projection work on top of a stable backend authority model instead of overloading the public row.

## Root cause
Before this change, `personality_profiles` only represented a single base row per type/locale. That was enough for a 16-type public page, but not enough to store 32-type canonical authority without either duplicating public rows, polluting slug routing, or forcing runtime overlays into every consumer.

The CMS workspace also assumed a single legacy section catalog. During save, any section key outside that catalog was treated as removable, which meant canonical MBTI v2 sections would be deleted as soon as editors touched a profile. The repo therefore had two blockers: no schema slot for variant authority, and a destructive workspace sync model for newer section catalogs.

## What changed
The base table `personality_profiles` remains the 16-type canonical base layer, but now includes additive canonical v2 fields such as `canonical_type_code`, `type_name`, `nickname`, `rarity_text`, `keywords_json`, and `hero_summary_*`. Existing rows are backfilled safely by copying `type_code` into `canonical_type_code`.

A separate variant authority layer was added through four new tables:
- `personality_profile_variants`
- `personality_profile_variant_sections`
- `personality_profile_variant_seo_meta`
- `personality_profile_variant_revisions`

Those tables store A/T authority with strict uniqueness and runtime identity validation, while keeping variant routing out of the current public surface.

The Filament personality workspace is now schema-version aware. `v1` continues to use the legacy section catalog. `v2` uses the canonical MBTI section registry with fixed render strategies for `letters_intro`, `trait_overview`, career/growth/relationships sections, and teaser sections. Section sync is now non-destructive for unmanaged keys, which prevents canonical v2 rows from being deleted when the active form does not explicitly manage them.

The public v0.5 personality API keeps the existing route semantics and base lookup rules, but now returns additive canonical fields from the base row on list/detail responses. The SEO service still emits canonical URLs using the 16-type slug, so `/personality/intj` remains canonical and `/personality/intj-a` is still not introduced here.

## Scope boundaries
This PR does not change:
- `backend/routes/api.php`
- runtime MBTI identity bridging in `MbtiPublicSummaryV1Builder`
- V0.3 report/share/compare flows
- importer or attachment ingestion
- share/OG/sitemap projection logic
- frontend or `fap-web`
- career, commerce, Team, Pro, or other scales

## Validation
The change was validated with focused backend checks and the repo CI chain:
- `php artisan route:list | grep -Ei "personality|seo"`
- `php artisan migrate`
- `php artisan fap:schema:verify`
- `vendor/bin/phpunit tests/Feature/PersonalityCms/PersonalitySchemaSmokeTest.php tests/Feature/PersonalityCms/PersonalityVariantAuthorityTest.php tests/Feature/V0_5/PersonalityPublicApiTest.php tests/Feature/Ops/PersonalityWorkspaceTest.php`
- `./vendor/bin/pint ...changed files...`
- `bash scripts/ci_verify_mbti.sh`

Manual API spot checks also confirmed:
- `/api/v0.5/personality?locale=en` still resolves base rows
- `/api/v0.5/personality/intj?locale=en` still resolves the base public page
- `/api/v0.5/personality/intj/seo?locale=en` still emits a 16-type canonical URL
- `/api/v0.5/personality/intj-a?locale=en` still returns `404`
