### PR TITLE
[codex] feat(api): unify MBTI public projection across report share personality seo sitemap

### DIFF
--- a/backend/app/Http/Controllers/API/V0_3/AttemptReadController.php
+++ b/backend/app/Http/Controllers/API/V0_3/AttemptReadController.php
@@ -9,6 +9,7 @@ use App\Models\Attempt;
 use App\Models\Result;
 use App\Services\Analytics\EventRecorder;
 use App\Services\Attempts\AttemptSubmissionService;
+use App\Services\Mbti\MbtiPublicProjectionService;
 use App\Services\Mbti\MbtiPublicSummaryV1Builder;
 use App\Services\Observability\ClinicalComboTelemetry;
 use App\Services\Observability\Sds20Telemetry;
@@ -32,6 +33,7 @@ class AttemptReadController extends Controller
         private AttemptSubmissionService $attemptSubmissionService,
         private ReportGatekeeper $reportGatekeeper,
         private ReportPdfDocumentService $reportPdfDocumentService,
+        private MbtiPublicProjectionService $mbtiPublicProjectionService,
         private MbtiPublicSummaryV1Builder $mbtiPublicSummaryV1Builder,
         private EventRecorder $eventRecorder,
         private ScaleCodeResponseProjector $responseProjector,
@@ -311,6 +313,12 @@ class AttemptReadController extends Controller
                 $result,
                 $responsePayload,
                 (string) ($attempt->locale ?? config('content_packs.default_locale', 'zh-CN'))
+            );
+            $responsePayload['mbti_public_projection_v1'] = $this->mbtiPublicProjectionService->buildForReportEnvelope(
+                $result,
+                $responsePayload,
+                (string) ($attempt->locale ?? config('content_packs.default_locale', 'zh-CN')),
+                (int) ($attempt->org_id ?? 0)
             );
         }
 

--- a/backend/app/Http/Controllers/API/V0_5/Cms/PersonalityController.php
+++ b/backend/app/Http/Controllers/API/V0_5/Cms/PersonalityController.php
@@ -78,6 +78,8 @@ class PersonalityController extends Controller
             return $this->notFoundResponse('personality profile not found.');
         }
 
+        $projection = $this->personalityProfileService->buildPublicProjection($profile);
+
         return response()->json([
             'ok' => true,
             'profile' => $this->profileDetailPayload($profile),
@@ -86,6 +88,7 @@ class PersonalityController extends Controller
                 $profile->sections->all()
             ),
             'seo_meta' => $this->seoMetaPayload($profile->seoMeta),
+            'mbti_public_projection_v1' => $projection,
         ]);
     }
 

--- a/backend/app/Services/Cms/PersonalityProfileSeoService.php
+++ b/backend/app/Services/Cms/PersonalityProfileSeoService.php
@@ -5,48 +5,65 @@ declare(strict_types=1);
 namespace App\Services\Cms;
 
 use App\Models\PersonalityProfile;
-use App\Models\PersonalityProfileSeoMeta;
 
 final class PersonalityProfileSeoService
 {
+    public function __construct(
+        private readonly PersonalityProfileService $personalityProfileService,
+    ) {}
+
     /**
      * @return array<string, mixed>
      */
     public function buildMeta(PersonalityProfile $profile): array
     {
-        $seoMeta = $this->resolveSeoMeta($profile);
+        $projection = $this->personalityProfileService->buildPublicProjection($profile);
         $title = $this->fallbackText(
-            $seoMeta?->seo_title,
+            data_get($projection, 'seo.title'),
+            data_get($projection, 'summary_card.title'),
             (string) $profile->title
         ) ?? (string) $profile->title;
         $description = $this->fallbackText(
-            $seoMeta?->seo_description,
+            data_get($projection, 'seo.description'),
+            data_get($projection, 'summary_card.summary'),
+            data_get($projection, 'summary_card.subtitle'),
             (string) ($profile->excerpt ?? null),
             (string) ($profile->subtitle ?? null)
         );
-        $canonical = $this->buildCanonicalUrl($profile, (string) $profile->locale);
-        $robots = $this->fallbackText($seoMeta?->robots)
-            ?? ((bool) $profile->is_indexable ? 'index,follow' : 'noindex,follow');
+        $canonical = $this->fallbackText(
+            data_get($projection, 'seo.canonical_url'),
+            $this->buildCanonicalUrl($profile, (string) $profile->locale)
+        );
+        $robots = $this->fallbackText(
+            data_get($projection, 'seo.robots')
+        ) ?? ((bool) $profile->is_indexable ? 'index,follow' : 'noindex,follow');
 
         return [
             'title' => $title,
             'description' => $description,
             'canonical' => $canonical,
             'og' => [
-                'title' => $this->fallbackText($seoMeta?->og_title, $title),
-                'description' => $this->fallbackText($seoMeta?->og_description, $description),
-                'image' => $this->fallbackText($seoMeta?->og_image_url),
+                'title' => $this->fallbackText(data_get($projection, 'seo.og_title'), $title),
+                'description' => $this->fallbackText(data_get($projection, 'seo.og_description'), $description),
+                'image' => $this->fallbackText(data_get($projection, 'seo.og_image_url')),
                 'type' => 'article',
             ],
             'twitter' => [
                 'card' => 'summary_large_image',
-                'title' => $this->fallbackText($seoMeta?->twitter_title, $seoMeta?->og_title, $title),
+                'title' => $this->fallbackText(
+                    data_get($projection, 'seo.twitter_title'),
+                    data_get($projection, 'seo.og_title'),
+                    $title
+                ),
                 'description' => $this->fallbackText(
-                    $seoMeta?->twitter_description,
-                    $seoMeta?->og_description,
+                    data_get($projection, 'seo.twitter_description'),
+                    data_get($projection, 'seo.og_description'),
                     $description
                 ),
-                'image' => $this->fallbackText($seoMeta?->twitter_image_url, $seoMeta?->og_image_url),
+                'image' => $this->fallbackText(
+                    data_get($projection, 'seo.twitter_image_url'),
+                    data_get($projection, 'seo.og_image_url')
+                ),
             ],
             'robots' => $robots,
         ];
@@ -57,6 +74,7 @@ final class PersonalityProfileSeoService
      */
     public function buildJsonLd(PersonalityProfile $profile): array
     {
+        $projection = $this->personalityProfileService->buildPublicProjection($profile);
         $meta = $this->buildMeta($profile);
         $jsonLd = [
             '@context' => 'https://schema.org',
@@ -65,16 +83,18 @@ final class PersonalityProfileSeoService
             'description' => $meta['description'],
             'about' => [
                 '@type' => 'DefinedTerm',
-                'name' => (string) $profile->type_code,
+                'name' => (string) data_get($projection, 'canonical_type_code', $profile->type_code),
                 'inDefinedTermSet' => (string) $profile->scale_code,
             ],
             'mainEntityOfPage' => $meta['canonical'],
         ];
 
-        $seoMeta = $this->resolveSeoMeta($profile);
-        if ($seoMeta instanceof PersonalityProfileSeoMeta && is_array($seoMeta->jsonld_overrides_json)) {
-            return array_replace_recursive($jsonLd, $seoMeta->jsonld_overrides_json);
+        $overrides = data_get($projection, 'seo.jsonld');
+        if (is_array($overrides) && $overrides !== []) {
+            $jsonLd = array_replace_recursive($jsonLd, $overrides);
         }
+
+        $jsonLd['mainEntityOfPage'] = $meta['canonical'];
 
         return $jsonLd;
     }
@@ -97,17 +117,6 @@ final class PersonalityProfileSeoService
     public function mapBackendLocaleToFrontendSegment(string $locale): string
     {
         return trim($locale) === 'zh-CN' ? 'zh' : 'en';
-    }
-
-    private function resolveSeoMeta(PersonalityProfile $profile): ?PersonalityProfileSeoMeta
-    {
-        if ($profile->relationLoaded('seoMeta') && $profile->seoMeta instanceof PersonalityProfileSeoMeta) {
-            return $profile->seoMeta;
-        }
-
-        return PersonalityProfileSeoMeta::query()
-            ->where('profile_id', (int) $profile->id)
-            ->first();
     }
 
     private function publicRouteSlug(PersonalityProfile $profile): string

--- a/backend/app/Services/Cms/PersonalityProfileService.php
+++ b/backend/app/Services/Cms/PersonalityProfileService.php
@@ -5,12 +5,18 @@ declare(strict_types=1);
 namespace App\Services\Cms;
 
 use App\Models\PersonalityProfile;
+use App\Services\Mbti\MbtiPublicProjectionService;
 use Illuminate\Contracts\Pagination\LengthAwarePaginator;
 use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Database\Eloquent\Relations\HasMany;
 
 final class PersonalityProfileService
 {
+    public function __construct(
+        private readonly MbtiPublicProjectionService $mbtiPublicProjectionService,
+    ) {}
+
     public function listPublicProfiles(
         int $orgId,
         string $scaleCode,
@@ -19,7 +25,14 @@ final class PersonalityProfileService
         int $perPage = 20
     ): LengthAwarePaginator {
         return $this->basePublicQuery($orgId, $scaleCode, $locale)
-            ->with('seoMeta')
+            ->with([
+                'seoMeta',
+                'sections' => static function (HasMany $query): void {
+                    $query->where('is_enabled', true)
+                        ->orderBy('sort_order')
+                        ->orderBy('id');
+                },
+            ])
             ->orderBy('canonical_type_code')
             ->orderBy('type_code')
             ->orderBy('id')
@@ -51,6 +64,39 @@ final class PersonalityProfileService
     }
 
     /**
+     * @return Collection<int, PersonalityProfile>
+     */
+    public function getSitemapPublicProfiles(): Collection
+    {
+        return PersonalityProfile::query()
+            ->withoutGlobalScopes()
+            ->where('org_id', 0)
+            ->where('scale_code', PersonalityProfile::SCALE_CODE_MBTI)
+            ->whereIn('type_code', PersonalityProfile::TYPE_CODES)
+            ->where('status', 'published')
+            ->where('is_public', true)
+            ->where('is_indexable', true)
+            ->whereIn('locale', PersonalityProfile::SUPPORTED_LOCALES)
+            ->whereNotNull('slug')
+            ->where('slug', '<>', '')
+            ->where(static function (Builder $query): void {
+                $query->whereNull('published_at')
+                    ->orWhere('published_at', '<=', now());
+            })
+            ->with([
+                'seoMeta',
+                'sections' => static function (HasMany $query): void {
+                    $query->where('is_enabled', true)
+                        ->orderBy('sort_order')
+                        ->orderBy('id');
+                },
+            ])
+            ->orderBy('locale')
+            ->orderBy('slug')
+            ->get();
+    }
+
+    /**
      * @return array{0:string,1:string}
      */
     public function resolveTypeLookup(string $typeLookup): array
@@ -68,15 +114,27 @@ final class PersonalityProfileService
      */
     public function publicCanonicalFields(PersonalityProfile $profile): array
     {
+        $projection = $this->buildPublicProjection($profile);
+
         return [
-            'canonical_type_code' => $profile->canonical_type_code,
-            'schema_version' => (string) $profile->schema_version,
-            'type_name' => $profile->type_name,
-            'nickname' => $profile->nickname,
-            'rarity' => $profile->rarity_text,
-            'keywords' => is_array($profile->keywords_json) ? array_values($profile->keywords_json) : [],
-            'hero_summary' => $profile->hero_summary_md,
+            'canonical_type_code' => data_get($projection, 'canonical_type_code'),
+            'schema_version' => (string) data_get($projection, '_meta.schema_version', $profile->schema_version),
+            'type_name' => data_get($projection, 'profile.type_name'),
+            'nickname' => data_get($projection, 'profile.nickname'),
+            'rarity' => data_get($projection, 'profile.rarity'),
+            'keywords' => is_array(data_get($projection, 'profile.keywords'))
+                ? array_values(data_get($projection, 'profile.keywords'))
+                : [],
+            'hero_summary' => data_get($projection, 'profile.hero_summary'),
         ];
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function buildPublicProjection(PersonalityProfile $profile): array
+    {
+        return $this->mbtiPublicProjectionService->buildForPersonalityProfile($profile);
     }
 
     private function basePublicQuery(int $orgId, string $scaleCode, string $locale): Builder

--- a/backend/app/Services/Mbti/Adapters/MbtiPersonalityProfileAuthoritySourceAdapter.php
+++ b/backend/app/Services/Mbti/Adapters/MbtiPersonalityProfileAuthoritySourceAdapter.php
@@ -1,0 +1,278 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\Mbti\Adapters;
+
+use App\Models\PersonalityProfile;
+use App\Models\PersonalityProfileSection;
+use App\Models\PersonalityProfileSeoMeta;
+use App\Models\PersonalityProfileVariant;
+use App\Models\PersonalityProfileVariantSection;
+use App\Models\PersonalityProfileVariantSeoMeta;
+use App\Support\Mbti\MbtiCanonicalSectionRegistry;
+use Illuminate\Database\Eloquent\Collection;
+use InvalidArgumentException;
+
+final class MbtiPersonalityProfileAuthoritySourceAdapter
+{
+    /**
+     * @return array<string, mixed>
+     */
+    public function fromBaseProfile(PersonalityProfile $profile): array
+    {
+        $profile->loadMissing([
+            'sections' => static function ($query): void {
+                $query->where('is_enabled', true)
+                    ->orderBy('sort_order')
+                    ->orderBy('id');
+            },
+            'seoMeta',
+        ]);
+
+        return [
+            'canonical_type_code' => $this->canonicalTypeCode(
+                $profile->canonical_type_code,
+                (string) $profile->type_code
+            ),
+            'slug' => $this->nullableText($profile->slug),
+            'locale' => $this->nullableText($profile->locale),
+            'is_indexable' => (bool) $profile->is_indexable,
+            'profile' => [
+                'type_name' => $this->nullableText($profile->type_name),
+                'nickname' => $this->nullableText($profile->nickname),
+                'rarity' => $this->nullableText($profile->rarity_text),
+                'keywords' => $this->stringList($profile->keywords_json),
+                'hero_summary' => $this->nullableText($profile->hero_summary_md),
+            ],
+            'summary_card' => [
+                'title' => $this->nullableText($profile->title),
+                'subtitle' => $this->nullableText($profile->subtitle),
+                'summary' => $this->nullableText($profile->excerpt),
+            ],
+            'sections' => $this->sectionMapFromCollection($profile->sections, 'base'),
+            'seo' => $this->seoPayload($profile->seoMeta),
+            '_meta' => [
+                'schema_version' => $this->nullableText($profile->schema_version) ?? PersonalityProfile::SCHEMA_VERSION_V2,
+                'profile_id' => (int) $profile->id,
+            ],
+        ];
+    }
+
+    /**
+     * @param  array<string, mixed>  $baseAuthority
+     * @return array<string, mixed>
+     */
+    public function overlayVariant(array $baseAuthority, ?PersonalityProfileVariant $variant): array
+    {
+        if (! $variant instanceof PersonalityProfileVariant) {
+            return $baseAuthority;
+        }
+
+        $variant->loadMissing([
+            'sections' => static function ($query): void {
+                $query->orderBy('sort_order')
+                    ->orderBy('id');
+            },
+            'seoMeta',
+        ]);
+
+        $baseAuthority['runtime_type_code'] = $this->nullableText($variant->runtime_type_code);
+        $baseAuthority['variant_code'] = $this->nullableText($variant->variant_code);
+
+        foreach ([
+            'type_name' => $variant->type_name,
+            'nickname' => $variant->nickname,
+            'rarity' => $variant->rarity_text,
+            'hero_summary' => $variant->hero_summary_md,
+        ] as $key => $value) {
+            $normalized = $this->nullableText($value);
+            if ($normalized !== null) {
+                $baseAuthority['profile'][$key] = $normalized;
+            }
+        }
+
+        $keywords = $this->stringList($variant->keywords_json);
+        if ($keywords !== []) {
+            $baseAuthority['profile']['keywords'] = $keywords;
+        }
+
+        $sections = is_array($baseAuthority['sections'] ?? null) ? $baseAuthority['sections'] : [];
+        foreach ($variant->sections as $section) {
+            if (! $section instanceof PersonalityProfileVariantSection) {
+                continue;
+            }
+
+            $sectionKey = trim((string) $section->section_key);
+            if (! $this->supportsSectionKey($sectionKey)) {
+                continue;
+            }
+
+            if (! (bool) $section->is_enabled) {
+                unset($sections[$sectionKey]);
+
+                continue;
+            }
+
+            $definition = MbtiCanonicalSectionRegistry::definition($sectionKey);
+            $sections[$sectionKey] = [
+                'key' => $sectionKey,
+                'title' => $this->nullableText($section->title) ?? (string) $definition['title'],
+                'render' => $this->nullableText($section->render_variant) ?? (string) $definition['render_variant'],
+                'body_md' => $this->nullableText($section->body_md),
+                'payload' => $this->arrayOrNull($section->payload_json),
+                'is_enabled' => true,
+                'source' => 'variant',
+            ];
+        }
+        $baseAuthority['sections'] = $sections;
+
+        foreach ($this->seoPayload($variant->seoMeta) as $key => $value) {
+            if ($value === null) {
+                continue;
+            }
+
+            if ($key === 'jsonld' && is_array($value) && $value !== []) {
+                $baseAuthority['seo'][$key] = $value;
+
+                continue;
+            }
+
+            $baseAuthority['seo'][$key] = $value;
+        }
+
+        if (! isset($baseAuthority['_meta']) || ! is_array($baseAuthority['_meta'])) {
+            $baseAuthority['_meta'] = [];
+        }
+        $baseAuthority['_meta']['variant_id'] = (int) $variant->id;
+
+        return $baseAuthority;
+    }
+
+    /**
+     * @param  Collection<int, PersonalityProfileSection|PersonalityProfileVariantSection>  $sections
+     * @return array<string, array<string, mixed>>
+     */
+    private function sectionMapFromCollection(Collection $sections, string $source): array
+    {
+        $mapped = [];
+
+        foreach ($sections as $section) {
+            $sectionKey = trim((string) $section->section_key);
+            if (! $this->supportsSectionKey($sectionKey)) {
+                continue;
+            }
+
+            $definition = MbtiCanonicalSectionRegistry::definition($sectionKey);
+            $mapped[$sectionKey] = [
+                'key' => $sectionKey,
+                'title' => $this->nullableText($section->title) ?? (string) $definition['title'],
+                'render' => $this->nullableText($section->render_variant) ?? (string) $definition['render_variant'],
+                'body_md' => $this->nullableText($section->body_md),
+                'payload' => $this->arrayOrNull($section->payload_json),
+                'is_enabled' => (bool) $section->is_enabled,
+                'source' => $source,
+            ];
+        }
+
+        return $mapped;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function seoPayload(PersonalityProfileSeoMeta|PersonalityProfileVariantSeoMeta|null $seoMeta): array
+    {
+        if ($seoMeta === null) {
+            return [
+                'title' => null,
+                'description' => null,
+                'canonical_url' => null,
+                'og_title' => null,
+                'og_description' => null,
+                'og_image_url' => null,
+                'twitter_title' => null,
+                'twitter_description' => null,
+                'twitter_image_url' => null,
+                'robots' => null,
+                'jsonld' => [],
+            ];
+        }
+
+        return [
+            'title' => $this->nullableText($seoMeta->seo_title),
+            'description' => $this->nullableText($seoMeta->seo_description),
+            'canonical_url' => $this->nullableText($seoMeta->canonical_url),
+            'og_title' => $this->nullableText($seoMeta->og_title),
+            'og_description' => $this->nullableText($seoMeta->og_description),
+            'og_image_url' => $this->nullableText($seoMeta->og_image_url),
+            'twitter_title' => $this->nullableText($seoMeta->twitter_title),
+            'twitter_description' => $this->nullableText($seoMeta->twitter_description),
+            'twitter_image_url' => $this->nullableText($seoMeta->twitter_image_url),
+            'robots' => $this->nullableText($seoMeta->robots),
+            'jsonld' => is_array($seoMeta->jsonld_overrides_json) ? $seoMeta->jsonld_overrides_json : [],
+        ];
+    }
+
+    private function supportsSectionKey(string $sectionKey): bool
+    {
+        try {
+            MbtiCanonicalSectionRegistry::definition($sectionKey);
+
+            return true;
+        } catch (InvalidArgumentException) {
+            return false;
+        }
+    }
+
+    private function canonicalTypeCode(mixed $canonicalTypeCode, string $fallbackTypeCode): string
+    {
+        $normalized = strtoupper(trim((string) $canonicalTypeCode));
+        if ($normalized !== '') {
+            return $normalized;
+        }
+
+        return strtoupper(trim($fallbackTypeCode));
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function stringList(mixed $value): array
+    {
+        if (! is_array($value)) {
+            return [];
+        }
+
+        $items = [];
+        foreach ($value as $item) {
+            $normalized = $this->nullableText($item);
+            if ($normalized === null) {
+                continue;
+            }
+
+            $items[$normalized] = true;
+        }
+
+        return array_keys($items);
+    }
+
+    /**
+     * @return array<string, mixed>|null
+     */
+    private function arrayOrNull(mixed $value): ?array
+    {
+        return is_array($value) ? $value : null;
+    }
+
+    private function nullableText(mixed $value): ?string
+    {
+        if (! is_scalar($value)) {
+            return null;
+        }
+
+        $normalized = trim((string) $value);
+
+        return $normalized === '' ? null : $normalized;
+    }
+}

--- a/backend/app/Services/Mbti/MbtiCanonicalPublicResultPayloadBuilder.php
+++ b/backend/app/Services/Mbti/MbtiCanonicalPublicResultPayloadBuilder.php
@@ -6,7 +6,6 @@ namespace App\Services\Mbti;
 
 use App\Contracts\MbtiPublicResultAuthoritySource;
 use App\Contracts\MbtiPublicResultPayloadBuilder;
-use App\Support\Mbti\MbtiCanonicalPublicResultSchema;
 use App\Support\Mbti\MbtiCanonicalSectionRegistry;
 use App\Support\Mbti\MbtiPublicTypeIdentity;
 use InvalidArgumentException;
@@ -35,11 +34,66 @@ final class MbtiCanonicalPublicResultPayloadBuilder implements MbtiPublicResultP
             ));
         }
 
-        $payload = MbtiCanonicalPublicResultSchema::scaffoldPayload($identity, $source->sourceKey());
-        $profile = $this->arrayOrEmpty($authority['profile'] ?? null);
-        $payload['profile']['hero_summary'] = $this->nullableText($profile['hero_summary'] ?? null);
+        return $this->buildProjection($this->projectionAuthorityFromLegacySource(
+            $identity,
+            $source->sourceKey(),
+            $authority
+        ));
+    }
 
-        foreach ($this->arrayOrEmpty($authority['sections'] ?? null) as $sectionKey => $sectionData) {
+    /**
+     * @param  array<string, mixed>  $authority
+     * @return array<string, mixed>
+     */
+    public function buildProjection(array $authority): array
+    {
+        $routeMode = $this->resolveRouteMode($authority);
+        $canonicalTypeCode = $this->resolveCanonicalTypeCode($authority);
+
+        if ($canonicalTypeCode === null) {
+            throw new InvalidArgumentException('MBTI public projection requires canonical_type_code.');
+        }
+
+        $runtimeTypeCode = $routeMode === 'runtime'
+            ? $this->nullableUpperText($authority['runtime_type_code'] ?? $authority['display_type'] ?? null)
+            : $this->nullableUpperText($authority['runtime_type_code'] ?? null);
+        $displayType = $this->resolveDisplayType($authority, $routeMode, $canonicalTypeCode, $runtimeTypeCode);
+        $variantCode = $routeMode === 'runtime'
+            ? $this->resolveVariantCode($authority, $runtimeTypeCode, $displayType)
+            : null;
+        $sections = $this->normalizeSections($authority['sections'] ?? null);
+        $dimensions = $this->normalizeDimensions($authority['dimensions'] ?? null, $sections);
+
+        return [
+            'runtime_type_code' => $runtimeTypeCode,
+            'canonical_type_code' => $canonicalTypeCode,
+            'display_type' => $displayType,
+            'variant_code' => $variantCode,
+            'profile' => $this->normalizeProfile($authority['profile'] ?? null),
+            'summary_card' => $this->normalizeSummaryCard($authority['summary_card'] ?? null),
+            'dimensions' => $dimensions,
+            'sections' => $sections,
+            'seo' => $this->normalizeSeo($authority['seo'] ?? null),
+            'offer_set' => is_array($authority['offer_set'] ?? null) ? $authority['offer_set'] : [],
+            '_meta' => $this->normalizeMeta(
+                $authority['_meta'] ?? $authority['meta'] ?? null,
+                $routeMode
+            ),
+        ];
+    }
+
+    /**
+     * @param  array<string, mixed>  $authority
+     * @return array<string, mixed>
+     */
+    private function projectionAuthorityFromLegacySource(
+        MbtiPublicTypeIdentity $identity,
+        string $sourceKey,
+        array $authority
+    ): array {
+        $sections = [];
+
+        foreach ((array) ($authority['sections'] ?? []) as $sectionKey => $sectionData) {
             if (! is_array($sectionData)) {
                 throw new InvalidArgumentException(sprintf(
                     'MBTI canonical section payload for [%s] must be an array.',
@@ -55,13 +109,18 @@ final class MbtiCanonicalPublicResultPayloadBuilder implements MbtiPublicResultP
                 ));
             }
 
-            $payload['sections'][(string) $sectionKey] = $this->mergeSectionEntry(
-                $payload['sections'][(string) $sectionKey],
-                $sectionData,
-            );
+            $sections[(string) $sectionKey] = [
+                'key' => (string) $sectionKey,
+                'title' => $sectionData['title'] ?? null,
+                'render' => $sectionData['render_variant'] ?? $definition['render_variant'],
+                'body_md' => $sectionData['body'] ?? null,
+                'payload' => is_array($sectionData['payload'] ?? null) ? $sectionData['payload'] : null,
+                'is_enabled' => true,
+                'source' => $sourceKey,
+            ];
         }
 
-        foreach ($this->arrayOrEmpty($authority['premium_teaser'] ?? null) as $sectionKey => $sectionData) {
+        foreach ((array) ($authority['premium_teaser'] ?? []) as $sectionKey => $sectionData) {
             if (! is_array($sectionData)) {
                 throw new InvalidArgumentException(sprintf(
                     'MBTI premium teaser payload for [%s] must be an array.',
@@ -77,91 +136,430 @@ final class MbtiCanonicalPublicResultPayloadBuilder implements MbtiPublicResultP
                 ));
             }
 
-            $payload['premium_teaser'][(string) $sectionKey] = $this->mergePremiumTeaserEntry(
-                $payload['premium_teaser'][(string) $sectionKey],
-                $sectionData,
-            );
+            $sections[(string) $sectionKey] = [
+                'key' => (string) $sectionKey,
+                'title' => $sectionData['title'] ?? null,
+                'render' => $sectionData['render_variant'] ?? $definition['render_variant'],
+                'body_md' => $sectionData['teaser'] ?? null,
+                'payload' => is_array($sectionData['payload'] ?? null) ? $sectionData['payload'] : null,
+                'is_enabled' => true,
+                'source' => $sourceKey,
+            ];
         }
 
-        foreach ($this->arrayOrEmpty($authority['seo_meta'] ?? null) as $key => $value) {
-            if (! array_key_exists((string) $key, $payload['seo_meta'])) {
+        $summary = $this->nullableText(data_get($authority, 'sections.trait_overview.payload.summary'));
+
+        return [
+            'runtime_type_code' => $identity->typeCode,
+            'canonical_type_code' => $identity->baseTypeCode,
+            'display_type' => $identity->typeCode,
+            'variant_code' => $identity->variant,
+            'profile' => [
+                'hero_summary' => $this->nullableText(data_get($authority, 'profile.hero_summary')),
+            ],
+            'summary_card' => [
+                'summary' => $summary,
+            ],
+            'dimensions' => is_array(data_get($authority, 'sections.trait_overview.payload.dimensions'))
+                ? data_get($authority, 'sections.trait_overview.payload.dimensions')
+                : [],
+            'sections' => $sections,
+            'seo' => [
+                'title' => $this->nullableText($authority['seo_meta']['seo_title'] ?? null),
+                'description' => $this->nullableText($authority['seo_meta']['seo_description'] ?? null),
+                'canonical_url' => $this->nullableText($authority['seo_meta']['canonical_url'] ?? null),
+                'og_title' => $this->nullableText($authority['seo_meta']['og_title'] ?? null),
+                'og_description' => $this->nullableText($authority['seo_meta']['og_description'] ?? null),
+                'og_image_url' => $this->nullableText($authority['seo_meta']['og_image_url'] ?? null),
+                'twitter_title' => $this->nullableText($authority['seo_meta']['twitter_title'] ?? null),
+                'twitter_description' => $this->nullableText($authority['seo_meta']['twitter_description'] ?? null),
+                'twitter_image_url' => $this->nullableText($authority['seo_meta']['twitter_image_url'] ?? null),
+                'robots' => $this->nullableText($authority['seo_meta']['robots'] ?? null),
+                'jsonld' => [],
+            ],
+            'offer_set' => [],
+            '_meta' => [
+                'authority_source' => $sourceKey,
+                'route_mode' => 'runtime',
+                'public_route_type' => '16-type',
+                'schema_version' => 'v2',
+                'authority_meta' => is_array($authority['meta'] ?? null) ? $authority['meta'] : [],
+            ],
+        ];
+    }
+
+    /**
+     * @param  array<string, mixed>  $authority
+     * @return list<array<string, mixed>>
+     */
+    private function normalizeSections(mixed $authority): array
+    {
+        if (! is_array($authority)) {
+            return [];
+        }
+
+        $sections = [];
+
+        foreach ($authority as $sectionKey => $sectionData) {
+            if (! is_array($sectionData)) {
                 continue;
             }
 
-            $payload['seo_meta'][(string) $key] = $this->nullableText($value);
+            $key = trim((string) ($sectionData['key'] ?? $sectionKey));
+            if ($key === '') {
+                continue;
+            }
+
+            $definition = MbtiCanonicalSectionRegistry::definition($key);
+            $render = $this->nullableText($sectionData['render'] ?? $sectionData['render_variant'] ?? null)
+                ?? (string) $definition['render_variant'];
+
+            if ($render !== (string) $definition['render_variant']) {
+                throw new InvalidArgumentException(sprintf(
+                    'MBTI canonical section [%s] requires render_variant [%s], got [%s].',
+                    $key,
+                    (string) $definition['render_variant'],
+                    $render,
+                ));
+            }
+
+            if (($sectionData['is_enabled'] ?? true) === false) {
+                continue;
+            }
+
+            $sections[$key] = [
+                'key' => $key,
+                'title' => $this->nullableText($sectionData['title'] ?? null) ?? (string) $definition['title'],
+                'render' => $render,
+                'body_md' => $this->firstNonEmpty(
+                    $this->nullableText($sectionData['body_md'] ?? null),
+                    $this->nullableText($sectionData['body'] ?? null)
+                ),
+                'payload' => is_array($sectionData['payload'] ?? null) ? $sectionData['payload'] : [],
+                'is_enabled' => true,
+                'source' => $this->nullableText($sectionData['source'] ?? null) ?? 'unknown',
+                '_sort_order' => (int) ($definition['sort_order'] ?? 0),
+            ];
         }
 
-        $payload['_meta']['authority_meta'] = $this->arrayOrEmpty($authority['meta'] ?? null);
+        uasort($sections, static function (array $left, array $right): int {
+            return ($left['_sort_order'] ?? 0) <=> ($right['_sort_order'] ?? 0);
+        });
 
-        return $payload;
+        return array_values(array_map(static function (array $section): array {
+            unset($section['_sort_order']);
+
+            return $section;
+        }, $sections));
     }
 
     /**
-     * @param  array<string, mixed>  $template
-     * @param  array<string, mixed>  $source
+     * @param  list<array<string, mixed>>  $sections
+     * @return list<array<string, mixed>>
+     */
+    private function normalizeDimensions(mixed $dimensions, array $sections): array
+    {
+        $sourceItems = is_array($dimensions) && $dimensions !== []
+            ? $dimensions
+            : $this->traitOverviewDimensionsFromSections($sections);
+
+        if (! is_array($sourceItems)) {
+            return [];
+        }
+
+        $normalized = [];
+
+        foreach ($sourceItems as $item) {
+            if (! is_array($item)) {
+                continue;
+            }
+
+            $axisId = $this->normalizeAxisId($item);
+            if ($axisId === null) {
+                continue;
+            }
+
+            $normalized[$axisId] = [
+                'id' => $axisId,
+                'code' => $axisId,
+                'name' => $this->nullableText($item['name'] ?? $item['label'] ?? $item['axis_label'] ?? null) ?? $axisId,
+                'label' => $this->nullableText($item['label'] ?? $item['name'] ?? $item['axis_label'] ?? null) ?? $axisId,
+                'axis_left' => $this->nullableText($item['axis_left'] ?? null),
+                'axis_right' => $this->nullableText($item['axis_right'] ?? null),
+                'summary' => $this->nullableText($item['summary'] ?? null),
+                'description' => $this->nullableText($item['description'] ?? $item['text'] ?? null),
+                'score_pct' => $this->normalizePercent($item['score_pct'] ?? $item['value_pct'] ?? $item['percent'] ?? $item['pct'] ?? null),
+                'source' => $this->nullableText($item['source'] ?? null)
+                    ?? ($this->normalizePercent($item['score_pct'] ?? $item['value_pct'] ?? $item['percent'] ?? $item['pct'] ?? null) !== null ? 'runtime' : 'authored'),
+                'side' => null,
+                'side_label' => null,
+                'pct' => null,
+                'state' => $this->nullableText($item['state'] ?? null),
+            ];
+        }
+
+        $ordered = [];
+        foreach (MbtiCanonicalSectionRegistry::traitOverviewAxisTargets() as $axisId) {
+            if (isset($normalized[$axisId])) {
+                [$leftCode, $rightCode] = $this->axisLetters($axisId);
+                $scorePct = $normalized[$axisId]['score_pct'];
+                if (is_int($scorePct)) {
+                    $normalized[$axisId]['side'] = $scorePct >= 50 ? $leftCode : $rightCode;
+                    $normalized[$axisId]['side_label'] = $scorePct >= 50
+                        ? $normalized[$axisId]['axis_left']
+                        : $normalized[$axisId]['axis_right'];
+                    $normalized[$axisId]['pct'] = $scorePct >= 50 ? $scorePct : 100 - $scorePct;
+                }
+
+                $ordered[] = $normalized[$axisId];
+            }
+        }
+
+        return $ordered;
+    }
+
+    /**
+     * @param  list<array<string, mixed>>  $sections
+     * @return list<array<string, mixed>>
+     */
+    private function traitOverviewDimensionsFromSections(array $sections): array
+    {
+        foreach ($sections as $section) {
+            if (($section['key'] ?? null) !== 'trait_overview') {
+                continue;
+            }
+
+            $payload = $section['payload'] ?? null;
+            if (is_array($payload['dimensions'] ?? null)) {
+                return array_values($payload['dimensions']);
+            }
+
+            return [];
+        }
+
+        return [];
+    }
+
+    /**
      * @return array<string, mixed>
      */
-    private function mergeSectionEntry(array $template, array $source): array
+    private function normalizeProfile(mixed $profile): array
     {
-        $this->assertRenderVariantMatches((string) $template['section_key'], $template, $source);
+        $payload = is_array($profile) ? $profile : [];
 
-        $template['title'] = $this->nullableText($source['title'] ?? $template['title'] ?? null);
-        $template['body'] = $this->nullableText($source['body'] ?? $template['body'] ?? null);
-
-        if (array_key_exists('payload', $source)) {
-            $template['payload'] = is_array($source['payload']) ? $source['payload'] : null;
-        }
-
-        return $template;
-    }
-
-    /**
-     * @param  array<string, mixed>  $template
-     * @param  array<string, mixed>  $source
-     * @return array<string, mixed>
-     */
-    private function mergePremiumTeaserEntry(array $template, array $source): array
-    {
-        $this->assertRenderVariantMatches((string) $template['section_key'], $template, $source);
-
-        $template['title'] = $this->nullableText($source['title'] ?? $template['title'] ?? null);
-        $template['teaser'] = $this->nullableText($source['teaser'] ?? $template['teaser'] ?? null);
-
-        if (array_key_exists('payload', $source)) {
-            $template['payload'] = is_array($source['payload']) ? $source['payload'] : null;
-        }
-
-        return $template;
-    }
-
-    /**
-     * @param  array<string, mixed>  $template
-     * @param  array<string, mixed>  $source
-     */
-    private function assertRenderVariantMatches(string $sectionKey, array $template, array $source): void
-    {
-        $runtimeVariant = trim((string) ($source['render_variant'] ?? ''));
-        if ($runtimeVariant === '') {
-            return;
-        }
-
-        $expectedVariant = (string) ($template['render_variant'] ?? '');
-        if ($runtimeVariant !== $expectedVariant) {
-            throw new InvalidArgumentException(sprintf(
-                'MBTI canonical section [%s] requires render_variant [%s], got [%s].',
-                $sectionKey,
-                $expectedVariant,
-                $runtimeVariant,
-            ));
-        }
+        return [
+            'type_name' => $this->nullableText($payload['type_name'] ?? null),
+            'nickname' => $this->nullableText($payload['nickname'] ?? null),
+            'rarity' => $this->nullableText($payload['rarity'] ?? null),
+            'keywords' => $this->stringList($payload['keywords'] ?? null),
+            'hero_summary' => $this->nullableText($payload['hero_summary'] ?? null),
+        ];
     }
 
     /**
      * @return array<string, mixed>
      */
-    private function arrayOrEmpty(mixed $value): array
+    private function normalizeSummaryCard(mixed $summaryCard): array
     {
-        return is_array($value) ? $value : [];
+        $payload = is_array($summaryCard) ? $summaryCard : [];
+
+        return [
+            'title' => $this->nullableText($payload['title'] ?? null),
+            'subtitle' => $this->nullableText($payload['subtitle'] ?? null),
+            'summary' => $this->nullableText($payload['summary'] ?? null),
+            'tagline' => $this->nullableText($payload['tagline'] ?? null),
+            'public_tags' => $this->stringList($payload['public_tags'] ?? $payload['tags'] ?? null),
+        ];
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function normalizeSeo(mixed $seo): array
+    {
+        $payload = is_array($seo) ? $seo : [];
+
+        return [
+            'title' => $this->nullableText($payload['title'] ?? $payload['seo_title'] ?? null),
+            'description' => $this->nullableText($payload['description'] ?? $payload['seo_description'] ?? null),
+            'og_title' => $this->nullableText($payload['og_title'] ?? null),
+            'og_description' => $this->nullableText($payload['og_description'] ?? null),
+            'og_image_url' => $this->nullableText($payload['og_image_url'] ?? null),
+            'twitter_title' => $this->nullableText($payload['twitter_title'] ?? null),
+            'twitter_description' => $this->nullableText($payload['twitter_description'] ?? null),
+            'twitter_image_url' => $this->nullableText($payload['twitter_image_url'] ?? null),
+            'canonical_url' => $this->nullableText($payload['canonical_url'] ?? null),
+            'robots' => $this->nullableText($payload['robots'] ?? null),
+            'jsonld' => is_array($payload['jsonld'] ?? null) ? $payload['jsonld'] : [],
+        ];
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function normalizeMeta(mixed $meta, string $routeMode): array
+    {
+        $payload = is_array($meta) ? $meta : [];
+        $normalized = [
+            'authority_source' => $this->nullableText($payload['authority_source'] ?? null) ?? 'unknown',
+            'route_mode' => $this->nullableText($payload['route_mode'] ?? null) ?? $routeMode,
+            'public_route_type' => $this->nullableText($payload['public_route_type'] ?? null) ?? '16-type',
+            'schema_version' => $this->nullableText($payload['schema_version'] ?? null) ?? 'v2',
+        ];
+
+        if (is_array($payload['authority_meta'] ?? null)) {
+            $normalized['authority_meta'] = $payload['authority_meta'];
+        }
+
+        return $normalized;
+    }
+
+    /**
+     * @param  array<string, mixed>  $authority
+     */
+    private function resolveRouteMode(array $authority): string
+    {
+        $normalized = strtolower(trim((string) (($authority['_meta']['route_mode'] ?? $authority['route_mode'] ?? ''))));
+        if (in_array($normalized, ['runtime', 'base'], true)) {
+            return $normalized;
+        }
+
+        return $this->nullableText($authority['runtime_type_code'] ?? null) !== null ? 'runtime' : 'base';
+    }
+
+    /**
+     * @param  array<string, mixed>  $authority
+     */
+    private function resolveCanonicalTypeCode(array $authority): ?string
+    {
+        $canonicalTypeCode = $this->nullableUpperText($authority['canonical_type_code'] ?? null);
+        if ($canonicalTypeCode !== null) {
+            return $canonicalTypeCode;
+        }
+
+        $runtimeTypeCode = $this->nullableUpperText($authority['runtime_type_code'] ?? $authority['display_type'] ?? null);
+        if ($runtimeTypeCode !== null && preg_match('/^(?<base>[EI][SN][TF][JP])-(?<variant>[AT])$/', $runtimeTypeCode, $matches) === 1) {
+            return (string) $matches['base'];
+        }
+
+        return null;
+    }
+
+    /**
+     * @param  array<string, mixed>  $authority
+     */
+    private function resolveDisplayType(array $authority, string $routeMode, string $canonicalTypeCode, ?string $runtimeTypeCode): string
+    {
+        $displayType = $this->nullableUpperText($authority['display_type'] ?? null);
+        if ($displayType !== null) {
+            return $displayType;
+        }
+
+        if ($routeMode === 'runtime' && $runtimeTypeCode !== null) {
+            return $runtimeTypeCode;
+        }
+
+        return $canonicalTypeCode;
+    }
+
+    /**
+     * @param  array<string, mixed>  $authority
+     */
+    private function resolveVariantCode(array $authority, ?string $runtimeTypeCode, string $displayType): ?string
+    {
+        $variantCode = $this->nullableUpperText($authority['variant_code'] ?? null);
+        if ($variantCode !== null) {
+            return $variantCode;
+        }
+
+        $candidate = $runtimeTypeCode ?? $displayType;
+        if ($candidate !== null && preg_match('/^(?<base>[EI][SN][TF][JP])-(?<variant>[AT])$/', $candidate, $matches) === 1) {
+            return (string) $matches['variant'];
+        }
+
+        return null;
+    }
+
+    /**
+     * @param  array<string, mixed>  $item
+     */
+    private function normalizeAxisId(array $item): ?string
+    {
+        $candidate = strtoupper(trim((string) ($item['id'] ?? $item['normalized_axis_code'] ?? $item['axis_code'] ?? $item['code'] ?? '')));
+        if ($candidate === '') {
+            return null;
+        }
+
+        return MbtiCanonicalSectionRegistry::normalizeTraitAxisCode($candidate);
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function stringList(mixed $value): array
+    {
+        if (! is_array($value)) {
+            return [];
+        }
+
+        $items = [];
+
+        foreach ($value as $item) {
+            $normalized = $this->nullableText($item);
+            if ($normalized === null) {
+                continue;
+            }
+
+            $items[$normalized] = true;
+        }
+
+        return array_keys($items);
+    }
+
+    private function nullableUpperText(mixed $value): ?string
+    {
+        $normalized = $this->nullableText($value);
+
+        return $normalized === null ? null : strtoupper($normalized);
+    }
+
+    private function normalizePercent(mixed $value): ?int
+    {
+        if (! is_numeric($value)) {
+            return null;
+        }
+
+        return max(0, min(100, (int) round((float) $value)));
+    }
+
+    /**
+     * @return array{0:string,1:string}
+     */
+    private function axisLetters(string $axisId): array
+    {
+        return match ($axisId) {
+            'EI' => ['E', 'I'],
+            'SN' => ['S', 'N'],
+            'TF' => ['T', 'F'],
+            'JP' => ['J', 'P'],
+            default => ['A', 'T'],
+        };
+    }
+
+    private function firstNonEmpty(?string ...$candidates): ?string
+    {
+        foreach ($candidates as $candidate) {
+            if ($candidate === null) {
+                continue;
+            }
+
+            $normalized = trim($candidate);
+            if ($normalized !== '') {
+                return $normalized;
+            }
+        }
+
+        return null;
     }
 
     private function nullableText(mixed $value): ?string

--- a/backend/app/Services/Mbti/MbtiPublicProjectionService.php
+++ b/backend/app/Services/Mbti/MbtiPublicProjectionService.php
@@ -1,0 +1,802 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\Mbti;
+
+use App\Models\PersonalityProfile;
+use App\Models\PersonalityProfileVariant;
+use App\Models\Result;
+use App\Services\Mbti\Adapters\MbtiPersonalityProfileAuthoritySourceAdapter;
+use App\Services\Mbti\Adapters\MbtiReportAuthoritySourceAdapter;
+use App\Support\Mbti\MbtiPublicTypeIdentity;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+
+final class MbtiPublicProjectionService
+{
+    public function __construct(
+        private readonly MbtiCanonicalPublicResultPayloadBuilder $payloadBuilder,
+        private readonly MbtiPublicSummaryV1Builder $summaryBuilder,
+        private readonly MbtiPersonalityProfileAuthoritySourceAdapter $profileAuthorityAdapter,
+    ) {}
+
+    /**
+     * @param  array<string, mixed>  $reportPayload
+     * @return array<string, mixed>
+     */
+    public function buildForReportEnvelope(Result $result, array $reportPayload, string $locale, int $orgId = 0): array
+    {
+        $summary = $this->resolveReportSummary($result, $reportPayload, $locale);
+        $identity = $this->resolveRuntimeIdentity($summary);
+
+        $authority = $this->baseRuntimeAuthorityFromSummary($summary, $locale);
+
+        if ($identity instanceof MbtiPublicTypeIdentity) {
+            $fallbackAuthority = (new MbtiReportAuthoritySourceAdapter(
+                $this->arrayOrEmpty($reportPayload['report'] ?? null),
+                'report.v0_3.public_fallback'
+            ))->read($identity);
+
+            $authority = $this->mergeReportFallbackAuthority($authority, $fallbackAuthority);
+            $authority = $this->overlayRuntimeCmsAuthority(
+                $authority,
+                $identity->baseTypeCode,
+                $identity->typeCode,
+                $locale,
+                $orgId
+            );
+        }
+
+        return $this->finalizeProjection(
+            $this->payloadBuilder->buildProjection($authority),
+            $authority,
+            $summary
+        );
+    }
+
+    /**
+     * @param  array<string, mixed>  $sharePayload
+     * @param  array<string, mixed>|null  $reportPayload
+     * @param  array<string, mixed>|null  $resultPayload
+     * @return array<string, mixed>
+     */
+    public function buildForSharePayload(
+        array $sharePayload,
+        string $locale,
+        int $orgId = 0,
+        ?array $reportPayload = null,
+        ?array $resultPayload = null
+    ): array {
+        $summary = is_array($sharePayload['mbti_public_summary_v1'] ?? null)
+            ? $sharePayload['mbti_public_summary_v1']
+            : $this->summaryBuilder->buildFromSharePayload($sharePayload, $reportPayload, $locale);
+
+        $identity = $this->resolveRuntimeIdentity($summary);
+        $authority = $this->baseRuntimeAuthorityFromSummary($summary, $locale);
+        $authority['legacy_dimensions'] = is_array($sharePayload['dimensions'] ?? null)
+            ? array_values($sharePayload['dimensions'])
+            : [];
+
+        if ($identity instanceof MbtiPublicTypeIdentity) {
+            if (is_array($reportPayload) && $reportPayload !== []) {
+                $fallbackAuthority = (new MbtiReportAuthoritySourceAdapter(
+                    $reportPayload,
+                    'share.v0_3.public_fallback'
+                ))->read($identity);
+
+                $authority = $this->mergeReportFallbackAuthority($authority, $fallbackAuthority);
+            }
+
+            $authority = $this->mergeShareSnapshotFallbackAuthority($authority, $sharePayload, $resultPayload);
+            $authority = $this->overlayRuntimeCmsAuthority(
+                $authority,
+                $identity->baseTypeCode,
+                $identity->typeCode,
+                $locale,
+                $orgId
+            );
+        }
+
+        return $this->finalizeProjection(
+            $this->payloadBuilder->buildProjection($authority),
+            $authority,
+            $summary
+        );
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function buildForPersonalityProfile(PersonalityProfile $profile): array
+    {
+        $profile->loadMissing([
+            'sections' => static function (HasMany $query): void {
+                $query->where('is_enabled', true)
+                    ->orderBy('sort_order')
+                    ->orderBy('id');
+            },
+            'seoMeta',
+        ]);
+
+        $authority = $this->profileAuthorityAdapter->fromBaseProfile($profile);
+        $authority['runtime_type_code'] = null;
+        $authority['display_type'] = strtoupper(trim((string) ($profile->canonical_type_code ?: $profile->type_code)));
+        $authority['variant_code'] = null;
+        $authority['dimensions'] = [];
+        $authority['offer_set'] = [];
+        $authority['_meta'] = array_merge(
+            is_array($authority['_meta'] ?? null) ? $authority['_meta'] : [],
+            [
+                'authority_source' => 'personality_cms_v2',
+                'route_mode' => 'base',
+                'public_route_type' => '16-type',
+                'schema_version' => (string) ($profile->schema_version ?: PersonalityProfile::SCHEMA_VERSION_V2),
+            ],
+        );
+
+        return $this->finalizeProjection(
+            $this->payloadBuilder->buildProjection($authority),
+            $authority
+        );
+    }
+
+    public function buildCanonicalUrl(?string $slug, string $locale): ?string
+    {
+        $baseUrl = rtrim((string) config('app.frontend_url', config('app.url', '')), '/');
+        $normalizedSlug = trim((string) $slug);
+
+        if ($baseUrl === '' || $normalizedSlug === '') {
+            return null;
+        }
+
+        return $baseUrl
+            .'/'.$this->mapBackendLocaleToFrontendSegment($locale)
+            .'/personality/'
+            .rawurlencode($normalizedSlug);
+    }
+
+    public function mapBackendLocaleToFrontendSegment(string $locale): string
+    {
+        return $this->normalizeLocale($locale) === 'zh-CN' ? 'zh' : 'en';
+    }
+
+    /**
+     * @param  array<string, mixed>  $reportPayload
+     * @return array<string, mixed>
+     */
+    private function resolveReportSummary(Result $result, array $reportPayload, string $locale): array
+    {
+        if (is_array($reportPayload['mbti_public_summary_v1'] ?? null)) {
+            return $reportPayload['mbti_public_summary_v1'];
+        }
+
+        return $this->summaryBuilder->buildFromReportEnvelope($result, $reportPayload, $locale);
+    }
+
+    /**
+     * @param  array<string, mixed>  $summary
+     * @return array<string, mixed>
+     */
+    private function baseRuntimeAuthorityFromSummary(array $summary, string $locale): array
+    {
+        $runtimeTypeCode = $this->nullableText($summary['runtime_type_code'] ?? null);
+        $canonicalTypeCode = strtoupper(trim((string) ($summary['canonical_type_16'] ?? '')));
+
+        return [
+            'runtime_type_code' => $runtimeTypeCode,
+            'canonical_type_code' => $canonicalTypeCode !== '' ? $canonicalTypeCode : null,
+            'display_type' => $this->nullableText($summary['display_type'] ?? null),
+            'variant_code' => $this->nullableText($summary['variant'] ?? null),
+            'profile' => [
+                'type_name' => $this->nullableText(data_get($summary, 'profile.type_name')),
+                'nickname' => $this->nullableText(data_get($summary, 'profile.nickname')),
+                'rarity' => $this->nullableText(data_get($summary, 'profile.rarity')),
+                'keywords' => $this->stringList(data_get($summary, 'profile.keywords')),
+                'hero_summary' => $this->firstNonEmpty(
+                    $this->nullableText(data_get($summary, 'profile.summary')),
+                    $this->nullableText(data_get($summary, 'summary_card.share_text'))
+                ),
+            ],
+            'summary_card' => [
+                'title' => $this->nullableText(data_get($summary, 'summary_card.title')),
+                'subtitle' => $this->nullableText(data_get($summary, 'summary_card.subtitle')),
+                'summary' => $this->firstNonEmpty(
+                    $this->nullableText(data_get($summary, 'summary_card.share_text')),
+                    $this->nullableText(data_get($summary, 'profile.summary'))
+                ),
+                'tagline' => $this->nullableText(data_get($summary, 'profile.nickname')),
+                'public_tags' => $this->stringList(data_get($summary, 'summary_card.tags')),
+            ],
+            'dimensions' => $this->projectionDimensionsFromSummary($summary, $locale),
+            'sections' => [],
+            'seo' => [],
+            'offer_set' => is_array($summary['offer_set'] ?? null) ? $summary['offer_set'] : [],
+            '_meta' => [
+                'authority_source' => 'runtime+report_fallback',
+                'route_mode' => 'runtime',
+                'public_route_type' => '16-type',
+                'schema_version' => PersonalityProfile::SCHEMA_VERSION_V2,
+            ],
+        ];
+    }
+
+    /**
+     * @param  array<string, mixed>  $authority
+     * @param  array<string, mixed>  $fallbackAuthority
+     * @return array<string, mixed>
+     */
+    private function mergeReportFallbackAuthority(array $authority, array $fallbackAuthority): array
+    {
+        $heroSummary = $this->nullableText(data_get($fallbackAuthority, 'profile.hero_summary'));
+        if ($heroSummary !== null && $this->nullableText(data_get($authority, 'profile.hero_summary')) === null) {
+            $authority['profile']['hero_summary'] = $heroSummary;
+        }
+
+        $sections = is_array($authority['sections'] ?? null) ? $authority['sections'] : [];
+
+        foreach ($this->canonicalSectionMapFromAuthoritySource($fallbackAuthority, 'report_fallback') as $sectionKey => $section) {
+            if (! isset($sections[$sectionKey])) {
+                $sections[$sectionKey] = $section;
+
+                continue;
+            }
+
+            $sections[$sectionKey] = array_merge($section, array_filter([
+                'title' => $this->firstNonEmpty(
+                    $this->nullableText($sections[$sectionKey]['title'] ?? null),
+                    $this->nullableText($section['title'] ?? null)
+                ),
+                'body_md' => $this->firstNonEmpty(
+                    $this->nullableText($sections[$sectionKey]['body_md'] ?? null),
+                    $this->nullableText($section['body_md'] ?? null)
+                ),
+                'payload' => is_array($sections[$sectionKey]['payload'] ?? null)
+                    ? $sections[$sectionKey]['payload']
+                    : (is_array($section['payload'] ?? null) ? $section['payload'] : null),
+                'source' => $this->nullableText($sections[$sectionKey]['source'] ?? null) ?? 'report_fallback',
+            ], static fn (mixed $value): bool => $value !== null));
+        }
+
+        $authority['sections'] = $sections;
+
+        return $authority;
+    }
+
+    /**
+     * @param  array<string, mixed>  $authority
+     * @param  array<string, mixed>  $sharePayload
+     * @param  array<string, mixed>|null  $resultPayload
+     * @return array<string, mixed>
+     */
+    private function mergeShareSnapshotFallbackAuthority(array $authority, array $sharePayload, ?array $resultPayload): array
+    {
+        $summary = $this->firstNonEmpty(
+            $this->nullableText($sharePayload['summary'] ?? null),
+            $this->nullableText($resultPayload['summary'] ?? null),
+            $this->nullableText($resultPayload['short_summary'] ?? null)
+        );
+
+        if ($summary !== null) {
+            if ($this->nullableText(data_get($authority, 'profile.hero_summary')) === null) {
+                $authority['profile']['hero_summary'] = $summary;
+            }
+
+            $sections = is_array($authority['sections'] ?? null) ? $authority['sections'] : [];
+            if (! isset($sections['overview'])) {
+                $sections['overview'] = [
+                    'key' => 'overview',
+                    'title' => $this->nullableText($sharePayload['title'] ?? null),
+                    'render' => 'rich_text',
+                    'body_md' => $summary,
+                    'payload' => null,
+                    'is_enabled' => true,
+                    'source' => 'report_fallback',
+                ];
+            }
+
+            $authority['sections'] = $sections;
+        }
+
+        return $authority;
+    }
+
+    /**
+     * @param  array<string, mixed>  $authority
+     * @return array<string, mixed>
+     */
+    private function overlayRuntimeCmsAuthority(
+        array $authority,
+        string $canonicalTypeCode,
+        string $runtimeTypeCode,
+        string $locale,
+        int $orgId
+    ): array {
+        $profile = $this->resolvePublicProfile($canonicalTypeCode, $orgId, $locale);
+        if (! $profile instanceof PersonalityProfile) {
+            return $authority;
+        }
+
+        $cmsAuthority = $this->profileAuthorityAdapter->fromBaseProfile($profile);
+        $variant = $this->resolvePublishedVariant($profile, $runtimeTypeCode);
+        if ($variant instanceof PersonalityProfileVariant) {
+            $cmsAuthority = $this->profileAuthorityAdapter->overlayVariant($cmsAuthority, $variant);
+        }
+
+        $merged = $this->mergeCmsAuthority($authority, $cmsAuthority);
+        $merged['_meta']['authority_source'] = 'runtime+report_fallback+personality_cms_v2';
+
+        return $merged;
+    }
+
+    /**
+     * @param  array<string, mixed>  $authority
+     * @param  array<string, mixed>  $cmsAuthority
+     * @return array<string, mixed>
+     */
+    private function mergeCmsAuthority(array $authority, array $cmsAuthority): array
+    {
+        $authority['canonical_type_code'] = $this->firstNonEmpty(
+            $this->nullableText($cmsAuthority['canonical_type_code'] ?? null),
+            $this->nullableText($authority['canonical_type_code'] ?? null)
+        );
+        $authority['slug'] = $this->firstNonEmpty(
+            $this->nullableText($cmsAuthority['slug'] ?? null),
+            $this->nullableText($authority['slug'] ?? null)
+        );
+        $authority['locale'] = $this->firstNonEmpty(
+            $this->nullableText($cmsAuthority['locale'] ?? null),
+            $this->nullableText($authority['locale'] ?? null)
+        );
+        $authority['is_indexable'] = (bool) ($cmsAuthority['is_indexable'] ?? ($authority['is_indexable'] ?? true));
+
+        foreach (['type_name', 'nickname', 'rarity', 'hero_summary'] as $key) {
+            $value = $this->nullableText(data_get($cmsAuthority, 'profile.'.$key));
+            if ($value !== null) {
+                $authority['profile'][$key] = $value;
+            }
+        }
+
+        $keywords = $this->stringList(data_get($cmsAuthority, 'profile.keywords'));
+        if ($keywords !== []) {
+            $authority['profile']['keywords'] = $keywords;
+        }
+
+        foreach (['title', 'subtitle', 'summary'] as $key) {
+            $value = $this->nullableText(data_get($cmsAuthority, 'summary_card.'.$key));
+            if ($value !== null) {
+                $authority['summary_card'][$key] = $value;
+            }
+        }
+
+        $sections = is_array($authority['sections'] ?? null) ? $authority['sections'] : [];
+        foreach ((array) ($cmsAuthority['sections'] ?? []) as $sectionKey => $section) {
+            if (is_array($section)) {
+                $sections[(string) $sectionKey] = $section;
+            }
+        }
+        $authority['sections'] = $sections;
+
+        foreach ((array) ($cmsAuthority['seo'] ?? []) as $key => $value) {
+            if ($value === null) {
+                continue;
+            }
+
+            if ($key === 'jsonld' && is_array($value) && $value === []) {
+                continue;
+            }
+
+            $authority['seo'][$key] = $value;
+        }
+
+        $authority['_meta'] = array_merge(
+            is_array($authority['_meta'] ?? null) ? $authority['_meta'] : [],
+            is_array($cmsAuthority['_meta'] ?? null) ? $cmsAuthority['_meta'] : [],
+            ['schema_version' => (string) data_get($cmsAuthority, '_meta.schema_version', PersonalityProfile::SCHEMA_VERSION_V2)],
+        );
+
+        return $authority;
+    }
+
+    /**
+     * @param  array<string, mixed>  $projection
+     * @param  array<string, mixed>  $authority
+     * @param  array<string, mixed>|null  $summary
+     * @return array<string, mixed>
+     */
+    private function finalizeProjection(array $projection, array $authority, ?array $summary = null): array
+    {
+        if ($summary !== null) {
+            $projection['dimensions'] = $this->projectionDimensionsFromSummary($summary, (string) ($authority['locale'] ?? 'en'));
+            $projection['dimensions'] = $this->mergeLegacyDimensions(
+                $projection['dimensions'],
+                is_array($authority['legacy_dimensions'] ?? null) ? $authority['legacy_dimensions'] : []
+            );
+            $projection['offer_set'] = is_array($summary['offer_set'] ?? null) ? $summary['offer_set'] : [];
+        }
+
+        $projection['summary_card']['tagline'] = $this->firstNonEmpty(
+            $this->nullableText($projection['summary_card']['tagline'] ?? null),
+            $this->nullableText($projection['profile']['nickname'] ?? null)
+        );
+        $projection['summary_card']['public_tags'] = $this->stringList(
+            ($projection['summary_card']['public_tags'] ?? []) !== []
+                ? $projection['summary_card']['public_tags']
+                : ($projection['profile']['keywords'] ?? [])
+        );
+
+        $canonicalUrl = $this->buildCanonicalUrl(
+            $this->nullableText($authority['slug'] ?? null),
+            (string) ($authority['locale'] ?? 'en')
+        );
+
+        $projection['seo']['title'] = $this->firstNonEmpty(
+            $this->nullableText($projection['seo']['title'] ?? null),
+            $this->nullableText($projection['summary_card']['title'] ?? null),
+            $this->nullableText($projection['display_type'] ?? null)
+        );
+        $projection['seo']['description'] = $this->firstNonEmpty(
+            $this->nullableText($projection['seo']['description'] ?? null),
+            $this->nullableText($projection['summary_card']['summary'] ?? null),
+            $this->nullableText($projection['summary_card']['subtitle'] ?? null),
+            $this->nullableText($projection['profile']['hero_summary'] ?? null)
+        );
+        $projection['seo']['canonical_url'] = $canonicalUrl;
+        $projection['seo']['og_title'] = $this->firstNonEmpty(
+            $this->nullableText($projection['seo']['og_title'] ?? null),
+            $this->nullableText($projection['seo']['title'] ?? null)
+        );
+        $projection['seo']['og_description'] = $this->firstNonEmpty(
+            $this->nullableText($projection['seo']['og_description'] ?? null),
+            $this->nullableText($projection['seo']['description'] ?? null)
+        );
+        $projection['seo']['twitter_title'] = $this->firstNonEmpty(
+            $this->nullableText($projection['seo']['twitter_title'] ?? null),
+            $this->nullableText($projection['seo']['og_title'] ?? null),
+            $this->nullableText($projection['seo']['title'] ?? null)
+        );
+        $projection['seo']['twitter_description'] = $this->firstNonEmpty(
+            $this->nullableText($projection['seo']['twitter_description'] ?? null),
+            $this->nullableText($projection['seo']['og_description'] ?? null),
+            $this->nullableText($projection['seo']['description'] ?? null)
+        );
+        $projection['seo']['robots'] = $this->firstNonEmpty(
+            $this->nullableText($projection['seo']['robots'] ?? null),
+            ($authority['is_indexable'] ?? true) ? 'index,follow' : 'noindex,follow'
+        );
+        $projection['seo']['jsonld'] = is_array($projection['seo']['jsonld'] ?? null)
+            ? $projection['seo']['jsonld']
+            : [];
+
+        return $projection;
+    }
+
+    /**
+     * @param  array<string, mixed>  $summary
+     */
+    private function resolveRuntimeIdentity(array $summary): ?MbtiPublicTypeIdentity
+    {
+        $runtimeTypeCode = $this->nullableText($summary['runtime_type_code'] ?? null);
+
+        return MbtiPublicTypeIdentity::tryFromTypeCode($runtimeTypeCode);
+    }
+
+    private function resolvePublicProfile(string $typeCode, int $orgId, string $locale): ?PersonalityProfile
+    {
+        $normalizedTypeCode = strtoupper(trim($typeCode));
+        if ($normalizedTypeCode === '') {
+            return null;
+        }
+
+        return PersonalityProfile::query()
+            ->withoutGlobalScopes()
+            ->where('org_id', max(0, $orgId))
+            ->where('scale_code', PersonalityProfile::SCALE_CODE_MBTI)
+            ->whereIn('type_code', PersonalityProfile::TYPE_CODES)
+            ->where('type_code', $normalizedTypeCode)
+            ->forLocale($this->normalizeLocale($locale))
+            ->publishedPublic()
+            ->where(static function ($query): void {
+                $query->whereNull('published_at')
+                    ->orWhere('published_at', '<=', now());
+            })
+            ->with([
+                'sections' => static function (HasMany $query): void {
+                    $query->where('is_enabled', true)
+                        ->orderBy('sort_order')
+                        ->orderBy('id');
+                },
+                'seoMeta',
+            ])
+            ->first();
+    }
+
+    private function resolvePublishedVariant(PersonalityProfile $profile, string $runtimeTypeCode): ?PersonalityProfileVariant
+    {
+        $normalized = strtoupper(trim($runtimeTypeCode));
+        if ($normalized === '') {
+            return null;
+        }
+
+        return $profile->variants()
+            ->where('runtime_type_code', $normalized)
+            ->where('is_published', true)
+            ->where(static function ($query): void {
+                $query->whereNull('published_at')
+                    ->orWhere('published_at', '<=', now());
+            })
+            ->with([
+                'sections' => static function (HasMany $query): void {
+                    $query->orderBy('sort_order')
+                        ->orderBy('id');
+                },
+                'seoMeta',
+            ])
+            ->first();
+    }
+
+    /**
+     * @param  array<string, mixed>  $authority
+     * @return array<string, array<string, mixed>>
+     */
+    private function canonicalSectionMapFromAuthoritySource(array $authority, string $source): array
+    {
+        $sections = [];
+
+        foreach ((array) ($authority['sections'] ?? []) as $sectionKey => $sectionData) {
+            if (! is_array($sectionData)) {
+                continue;
+            }
+
+            $sectionKey = trim((string) $sectionKey);
+            if ($sectionKey === '') {
+                continue;
+            }
+
+            $sections[$sectionKey] = [
+                'key' => $sectionKey,
+                'title' => $this->nullableText($sectionData['title'] ?? null),
+                'render' => $this->nullableText($sectionData['render'] ?? $sectionData['render_variant'] ?? null),
+                'body_md' => $this->firstNonEmpty(
+                    $this->nullableText($sectionData['body_md'] ?? null),
+                    $this->nullableText($sectionData['body'] ?? null)
+                ),
+                'payload' => is_array($sectionData['payload'] ?? null) ? $sectionData['payload'] : null,
+                'is_enabled' => true,
+                'source' => $source,
+            ];
+        }
+
+        foreach ((array) ($authority['premium_teaser'] ?? []) as $sectionKey => $sectionData) {
+            if (! is_array($sectionData)) {
+                continue;
+            }
+
+            $sectionKey = trim((string) $sectionKey);
+            if ($sectionKey === '') {
+                continue;
+            }
+
+            $sections[$sectionKey] = [
+                'key' => $sectionKey,
+                'title' => $this->nullableText($sectionData['title'] ?? null),
+                'render' => $this->nullableText($sectionData['render'] ?? $sectionData['render_variant'] ?? null),
+                'body_md' => $this->nullableText($sectionData['teaser'] ?? null),
+                'payload' => is_array($sectionData['payload'] ?? null) ? $sectionData['payload'] : null,
+                'is_enabled' => true,
+                'source' => $source,
+            ];
+        }
+
+        return $sections;
+    }
+
+    /**
+     * @param  array<string, mixed>  $summary
+     * @return list<array<string, mixed>>
+     */
+    private function projectionDimensionsFromSummary(array $summary, string $locale): array
+    {
+        $dimensions = [];
+
+        foreach ((array) ($summary['dimensions'] ?? []) as $item) {
+            if (! is_array($item)) {
+                continue;
+            }
+
+            $axisId = strtoupper(trim((string) ($item['id'] ?? $item['code'] ?? '')));
+            if (! in_array($axisId, ['EI', 'SN', 'TF', 'JP', 'AT'], true)) {
+                continue;
+            }
+
+            $dimensions[$axisId] = [
+                'id' => $axisId,
+                'code' => $axisId,
+                'name' => $this->nullableText($item['name'] ?? $item['label'] ?? null) ?? $axisId,
+                'label' => $this->nullableText($item['label'] ?? $item['name'] ?? null) ?? $axisId,
+                'axis_left' => $this->nullableText($item['axis_left'] ?? null),
+                'axis_right' => $this->nullableText($item['axis_right'] ?? null),
+                'summary' => $this->nullableText($item['summary'] ?? null),
+                'description' => $this->nullableText($item['description'] ?? null),
+                'score_pct' => $this->normalizePercent($item['score_pct'] ?? $item['value_pct'] ?? $item['pct'] ?? null),
+                'source' => 'runtime',
+                'side' => null,
+                'side_label' => null,
+                'pct' => null,
+                'state' => $this->nullableText($item['state'] ?? null),
+            ];
+        }
+
+        $ordered = [];
+        foreach (['EI', 'SN', 'TF', 'JP', 'AT'] as $axisId) {
+            if (! isset($dimensions[$axisId])) {
+                continue;
+            }
+
+            if ($dimensions[$axisId]['axis_left'] === null || $dimensions[$axisId]['axis_right'] === null) {
+                [$left, $right] = $this->defaultAxisLabels($axisId, $locale);
+                $dimensions[$axisId]['axis_left'] = $dimensions[$axisId]['axis_left'] ?? $left;
+                $dimensions[$axisId]['axis_right'] = $dimensions[$axisId]['axis_right'] ?? $right;
+            }
+
+            [$leftCode, $rightCode] = $this->axisLetters($axisId);
+            $scorePct = $dimensions[$axisId]['score_pct'];
+            if (is_int($scorePct)) {
+                $dimensions[$axisId]['side'] = $scorePct >= 50 ? $leftCode : $rightCode;
+                $dimensions[$axisId]['side_label'] = $scorePct >= 50
+                    ? $dimensions[$axisId]['axis_left']
+                    : $dimensions[$axisId]['axis_right'];
+                $dimensions[$axisId]['pct'] = $scorePct >= 50 ? $scorePct : 100 - $scorePct;
+            }
+
+            $ordered[] = $dimensions[$axisId];
+        }
+
+        return $ordered;
+    }
+
+    /**
+     * @param  list<array<string, mixed>>  $dimensions
+     * @param  list<mixed>  $legacyDimensions
+     * @return list<array<string, mixed>>
+     */
+    private function mergeLegacyDimensions(array $dimensions, array $legacyDimensions): array
+    {
+        $legacyMap = [];
+
+        foreach ($legacyDimensions as $item) {
+            if (! is_array($item)) {
+                continue;
+            }
+
+            $axisId = strtoupper(trim((string) ($item['id'] ?? $item['code'] ?? '')));
+            if ($axisId === '') {
+                continue;
+            }
+
+            $legacyMap[$axisId] = $item;
+        }
+
+        foreach ($dimensions as $index => $dimension) {
+            $axisId = strtoupper(trim((string) ($dimension['id'] ?? '')));
+            if ($axisId === '' || ! isset($legacyMap[$axisId])) {
+                continue;
+            }
+
+            $legacy = $legacyMap[$axisId];
+            $dimensions[$index]['code'] = $axisId;
+            $dimensions[$index]['label'] = $this->nullableText($legacy['label'] ?? null)
+                ?? $dimensions[$index]['label'];
+            $dimensions[$index]['side'] = $this->nullableText($legacy['side'] ?? null)
+                ?? $dimensions[$index]['side'];
+            $dimensions[$index]['side_label'] = $this->nullableText($legacy['side_label'] ?? null)
+                ?? $dimensions[$index]['side_label'];
+            $dimensions[$index]['pct'] = $this->normalizePercent($legacy['pct'] ?? null)
+                ?? $dimensions[$index]['pct'];
+            $dimensions[$index]['state'] = $this->nullableText($legacy['state'] ?? null)
+                ?? $dimensions[$index]['state'];
+        }
+
+        return $dimensions;
+    }
+
+    /**
+     * @return array{0:string,1:string}
+     */
+    private function defaultAxisLabels(string $axisId, string $locale): array
+    {
+        $isZh = $this->normalizeLocale($locale) === 'zh-CN';
+
+        return match ($axisId) {
+            'EI' => [$isZh ? '外倾' : 'Extraversion', $isZh ? '内倾' : 'Introversion'],
+            'SN' => [$isZh ? '实感' : 'Sensing', $isZh ? '直觉' : 'Intuition'],
+            'TF' => [$isZh ? '思考' : 'Thinking', $isZh ? '情感' : 'Feeling'],
+            'JP' => [$isZh ? '判断' : 'Judging', $isZh ? '感知' : 'Perceiving'],
+            default => [$isZh ? '果断' : 'Assertive', $isZh ? '敏感' : 'Turbulent'],
+        };
+    }
+
+    /**
+     * @return array{0:string,1:string}
+     */
+    private function axisLetters(string $axisId): array
+    {
+        return match ($axisId) {
+            'EI' => ['E', 'I'],
+            'SN' => ['S', 'N'],
+            'TF' => ['T', 'F'],
+            'JP' => ['J', 'P'],
+            default => ['A', 'T'],
+        };
+    }
+
+    private function normalizeLocale(string $locale): string
+    {
+        return trim($locale) === 'zh-CN' ? 'zh-CN' : 'en';
+    }
+
+    private function normalizePercent(mixed $value): ?int
+    {
+        if (! is_numeric($value)) {
+            return null;
+        }
+
+        return max(0, min(100, (int) round((float) $value)));
+    }
+
+    private function firstNonEmpty(?string ...$candidates): ?string
+    {
+        foreach ($candidates as $candidate) {
+            if ($candidate === null) {
+                continue;
+            }
+
+            $normalized = trim($candidate);
+            if ($normalized !== '') {
+                return $normalized;
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function stringList(mixed $value): array
+    {
+        if (! is_array($value)) {
+            return [];
+        }
+
+        $items = [];
+        foreach ($value as $item) {
+            $normalized = $this->nullableText($item);
+            if ($normalized === null) {
+                continue;
+            }
+
+            $items[$normalized] = true;
+        }
+
+        return array_keys($items);
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function arrayOrEmpty(mixed $value): array
+    {
+        return is_array($value) ? $value : [];
+    }
+
+    private function nullableText(mixed $value): ?string
+    {
+        if (! is_scalar($value)) {
+            return null;
+        }
+
+        $normalized = trim((string) $value);
+
+        return $normalized === '' ? null : $normalized;
+    }
+}

--- a/backend/app/Services/SEO/SitemapGenerator.php
+++ b/backend/app/Services/SEO/SitemapGenerator.php
@@ -5,12 +5,12 @@ namespace App\Services\SEO;
 use App\Models\Article;
 use App\Models\CareerGuide;
 use App\Models\CareerJob;
-use App\Models\PersonalityProfile;
 use App\Models\TopicProfile;
 use App\Services\Cms\ArticleSeoService;
 use App\Services\Cms\CareerGuideSeoService;
 use App\Services\Cms\CareerJobSeoService;
 use App\Services\Cms\PersonalityProfileSeoService;
+use App\Services\Cms\PersonalityProfileService;
 use App\Services\Cms\TopicProfileSeoService;
 use Illuminate\Support\Carbon;
 use Illuminate\Support\Facades\DB;
@@ -23,6 +23,7 @@ class SitemapGenerator
         private readonly ArticleSeoService $articleSeoService,
         private readonly CareerGuideSeoService $careerGuideSeoService,
         private readonly CareerJobSeoService $careerJobSeoService,
+        private readonly PersonalityProfileService $personalityProfileService,
         private readonly PersonalityProfileSeoService $personalityProfileSeoService,
         private readonly TopicProfileSeoService $topicProfileSeoService,
     ) {
@@ -217,33 +218,20 @@ class SitemapGenerator
             return [];
         }
 
-        $rows = PersonalityProfile::query()
-            ->withoutGlobalScopes()
-            ->where('org_id', 0)
-            ->where('scale_code', PersonalityProfile::SCALE_CODE_MBTI)
-            ->where('status', 'published')
-            ->where('is_public', true)
-            ->where('is_indexable', true)
-            ->whereIn('locale', PersonalityProfile::SUPPORTED_LOCALES)
-            ->whereNotNull('slug')
-            ->where('slug', '<>', '')
-            ->where(static function ($query): void {
-                $query->whereNull('published_at')
-                    ->orWhere('published_at', '<=', now());
-            })
-            ->select(['slug', 'locale', 'updated_at', 'published_at'])
-            ->orderBy('locale')
-            ->orderBy('slug')
-            ->get();
+        $rows = $this->personalityProfileService->getSitemapPublicProfiles();
 
         $urls = [];
         $listLastModified = [];
 
         foreach ($rows as $row) {
-            $slug = trim((string) $row->slug);
             $locale = trim((string) $row->locale);
+            $canonical = trim((string) data_get(
+                $this->personalityProfileSeoService->buildMeta($row),
+                'canonical',
+                ''
+            ));
 
-            if ($slug === '' || $locale === '') {
+            if ($canonical === '' || $locale === '') {
                 continue;
             }
 
@@ -253,9 +241,9 @@ class SitemapGenerator
                 ?? now();
 
             $urls[] = [
-                'loc' => $baseUrl.'/'.$segment.'/personality/'.rawurlencode($slug),
+                'loc' => $canonical,
                 'lastmod' => $lastmod->toAtomString(),
-                'slug' => 'personality:'.$segment.':'.$slug,
+                'slug' => 'personality:'.$segment.':'.trim((string) $row->slug),
                 'updated_at' => $lastmod->toDateTimeString(),
             ];
 

--- a/backend/app/Services/V0_3/ShareService.php
+++ b/backend/app/Services/V0_3/ShareService.php
@@ -7,6 +7,7 @@ use App\Models\PersonalityProfile;
 use App\Models\Result;
 use App\Models\Share;
 use App\Services\Cms\PersonalityProfileService;
+use App\Services\Mbti\MbtiPublicProjectionService;
 use App\Services\Mbti\MbtiPublicSummaryV1Builder;
 use App\Services\Report\ReportAccess;
 use App\Services\Report\ReportComposer;
@@ -24,6 +25,7 @@ class ShareService
         private readonly ReportComposer $reportComposer,
         private readonly ScaleRegistry $scaleRegistry,
         private readonly PersonalityProfileService $personalityProfileService,
+        private readonly MbtiPublicProjectionService $mbtiPublicProjectionService,
         private readonly MbtiPublicSummaryV1Builder $mbtiPublicSummaryV1Builder,
     ) {}
 
@@ -667,7 +669,51 @@ class ShareService
                 $publicSafeReport,
                 $locale
             );
+            $payload['mbti_public_projection_v1'] = $this->mbtiPublicProjectionService->buildForSharePayload(
+                $payload,
+                $locale,
+                (int) ($attempt->org_id ?? 0),
+                $publicSafeReport,
+                $this->normalizeArray($result->result_json ?? null)
+            );
+            $payload = $this->applyMbtiProjectionAliases($payload);
         }
+
+        return $payload;
+    }
+
+    /**
+     * @param  array<string, mixed>  $payload
+     * @return array<string, mixed>
+     */
+    private function applyMbtiProjectionAliases(array $payload): array
+    {
+        $projection = is_array($payload['mbti_public_projection_v1'] ?? null)
+            ? $payload['mbti_public_projection_v1']
+            : [];
+
+        if ($projection === []) {
+            return $payload;
+        }
+
+        $publicTags = is_array(data_get($projection, 'summary_card.public_tags'))
+            ? array_values(data_get($projection, 'summary_card.public_tags'))
+            : [];
+        $profileKeywords = is_array(data_get($projection, 'profile.keywords'))
+            ? array_values(data_get($projection, 'profile.keywords'))
+            : [];
+
+        $payload['type_code'] = (string) (data_get($projection, 'display_type') ?? $payload['type_code'] ?? '');
+        $payload['type_name'] = data_get($projection, 'profile.type_name') ?? $payload['type_name'] ?? null;
+        $payload['title'] = data_get($projection, 'summary_card.title') ?? $payload['title'] ?? null;
+        $payload['subtitle'] = data_get($projection, 'summary_card.subtitle') ?? $payload['subtitle'] ?? null;
+        $payload['summary'] = data_get($projection, 'summary_card.summary') ?? $payload['summary'] ?? null;
+        $payload['tagline'] = data_get($projection, 'summary_card.tagline') ?? $payload['tagline'] ?? null;
+        $payload['rarity'] = data_get($projection, 'profile.rarity') ?? $payload['rarity'] ?? null;
+        $payload['tags'] = $publicTags !== [] ? $publicTags : $profileKeywords;
+        $payload['dimensions'] = is_array($projection['dimensions'] ?? null)
+            ? array_values($projection['dimensions'])
+            : [];
 
         return $payload;
     }

--- a/backend/tests/Feature/Report/MbtiCanonicalPublicAuthorityScaffoldTest.php
+++ b/backend/tests/Feature/Report/MbtiCanonicalPublicAuthorityScaffoldTest.php
@@ -42,11 +42,12 @@ final class MbtiCanonicalPublicAuthorityScaffoldTest extends TestCase
             ]),
         );
 
-        $this->assertSame('ENFJ-T', $payload['type_code']);
-        $this->assertSame('ENFJ', $payload['base_type_code']);
-        $this->assertSame('T', $payload['variant']);
+        $this->assertSame('ENFJ-T', $payload['runtime_type_code']);
+        $this->assertSame('ENFJ', $payload['canonical_type_code']);
+        $this->assertSame('ENFJ-T', $payload['display_type']);
+        $this->assertSame('T', $payload['variant_code']);
         $this->assertSame('Pilot report authority summary', $payload['profile']['hero_summary']);
-        $this->assertSame((string) $layer['one_liner'], $payload['sections']['overview']['body']);
+        $this->assertSame((string) $layer['one_liner'], $payload['sections'][0]['body_md']);
         $this->assertSame('report.v0_3.pilot', $payload['_meta']['authority_source']);
     }
 }

--- a/backend/tests/Feature/SEO/SitemapGeneratorTest.php
+++ b/backend/tests/Feature/SEO/SitemapGeneratorTest.php
@@ -6,6 +6,7 @@ use App\Models\Article;
 use App\Models\CareerGuide;
 use App\Models\CareerJob;
 use App\Models\PersonalityProfile;
+use App\Models\PersonalityProfileSeoMeta;
 use App\Models\TopicProfile;
 use App\Services\Cms\ArticleSeoService;
 use App\Services\Cms\CareerGuideSeoService;
@@ -219,6 +220,14 @@ class SitemapGeneratorTest extends TestCase
             'published_at' => Carbon::create(2026, 3, 7, 11, 0, 0, 'UTC'),
             'updated_at' => Carbon::create(2026, 3, 7, 12, 0, 0, 'UTC'),
         ]);
+        $this->createPersonalitySeoMeta($eligibleEn, [
+            'canonical_url' => 'https://staging.fermatmind.com/en/personality/intj-a',
+            'jsonld_overrides_json' => ['mainEntityOfPage' => 'https://staging.fermatmind.com/en/personality/intj-a'],
+        ]);
+        $this->createPersonalitySeoMeta($eligibleZh, [
+            'canonical_url' => 'https://staging.fermatmind.com/zh/personality/intj-a',
+            'jsonld_overrides_json' => ['mainEntityOfPage' => 'https://staging.fermatmind.com/zh/personality/intj-a'],
+        ]);
 
         $this->createPersonalityProfile([
             'type_code' => 'ENTJ',
@@ -281,6 +290,8 @@ class SitemapGeneratorTest extends TestCase
         $this->assertStringContainsString('https://staging.fermatmind.com/zh/personality', $xml);
         $this->assertStringContainsString('https://staging.fermatmind.com/en/personality/intj', $xml);
         $this->assertStringContainsString('https://staging.fermatmind.com/zh/personality/intj', $xml);
+        $this->assertStringNotContainsString('https://staging.fermatmind.com/en/personality/intj-a', $xml);
+        $this->assertStringNotContainsString('https://staging.fermatmind.com/zh/personality/intj-a', $xml);
 
         $this->assertStringNotContainsString('https://staging.fermatmind.com/en/personality/entj', $xml);
         $this->assertStringNotContainsString('https://staging.fermatmind.com/en/personality/entp', $xml);
@@ -636,6 +647,28 @@ class SitemapGeneratorTest extends TestCase
             'schema_version' => 'v1',
             'created_at' => Carbon::create(2026, 3, 7, 8, 0, 0, 'UTC'),
             'updated_at' => Carbon::create(2026, 3, 7, 8, 0, 0, 'UTC'),
+        ], $overrides));
+    }
+
+    /**
+     * @param  array<string, mixed>  $overrides
+     */
+    private function createPersonalitySeoMeta(PersonalityProfile $profile, array $overrides = []): PersonalityProfileSeoMeta
+    {
+        /** @var PersonalityProfileSeoMeta */
+        return PersonalityProfileSeoMeta::query()->create(array_merge([
+            'profile_id' => (int) $profile->id,
+            'seo_title' => null,
+            'seo_description' => null,
+            'canonical_url' => null,
+            'og_title' => null,
+            'og_description' => null,
+            'og_image_url' => null,
+            'twitter_title' => null,
+            'twitter_description' => null,
+            'twitter_image_url' => null,
+            'robots' => null,
+            'jsonld_overrides_json' => null,
         ], $overrides));
     }
 

--- a/backend/tests/Feature/SEO/SitemapXmlTest.php
+++ b/backend/tests/Feature/SEO/SitemapXmlTest.php
@@ -6,6 +6,7 @@ use App\Models\Article;
 use App\Models\CareerGuide;
 use App\Models\CareerJob;
 use App\Models\PersonalityProfile;
+use App\Models\PersonalityProfileSeoMeta;
 use App\Models\TopicProfile;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Carbon;
@@ -84,7 +85,7 @@ class SitemapXmlTest extends TestCase
             ],
         ]);
 
-        PersonalityProfile::query()->create([
+        $personalityEn = PersonalityProfile::query()->create([
             'org_id' => 0,
             'scale_code' => PersonalityProfile::SCALE_CODE_MBTI,
             'type_code' => 'INTJ',
@@ -103,7 +104,7 @@ class SitemapXmlTest extends TestCase
             'updated_at' => $nowB,
         ]);
 
-        PersonalityProfile::query()->create([
+        $personalityZh = PersonalityProfile::query()->create([
             'org_id' => 0,
             'scale_code' => PersonalityProfile::SCALE_CODE_MBTI,
             'type_code' => 'INTJ',
@@ -118,6 +119,25 @@ class SitemapXmlTest extends TestCase
             'published_at' => Carbon::create(2026, 1, 31, 12, 0, 0),
             'scheduled_at' => null,
             'schema_version' => 'v1',
+            'created_at' => $nowB,
+            'updated_at' => $nowB,
+        ]);
+
+        PersonalityProfileSeoMeta::query()->create([
+            'profile_id' => (int) $personalityEn->id,
+            'canonical_url' => 'https://staging.fermatmind.com/en/personality/intj-a',
+            'jsonld_overrides_json' => [
+                'mainEntityOfPage' => 'https://staging.fermatmind.com/en/personality/intj-a',
+            ],
+            'created_at' => $nowB,
+            'updated_at' => $nowB,
+        ]);
+        PersonalityProfileSeoMeta::query()->create([
+            'profile_id' => (int) $personalityZh->id,
+            'canonical_url' => 'https://staging.fermatmind.com/zh/personality/intj-a',
+            'jsonld_overrides_json' => [
+                'mainEntityOfPage' => 'https://staging.fermatmind.com/zh/personality/intj-a',
+            ],
             'created_at' => $nowB,
             'updated_at' => $nowB,
         ]);
@@ -384,6 +404,8 @@ class SitemapXmlTest extends TestCase
         $this->assertStringContainsString('<loc>https://staging.fermatmind.com/zh/personality</loc>', $body);
         $this->assertStringContainsString('<loc>https://staging.fermatmind.com/en/personality/intj</loc>', $body);
         $this->assertStringContainsString('<loc>https://staging.fermatmind.com/zh/personality/intj</loc>', $body);
+        $this->assertStringNotContainsString('<loc>https://staging.fermatmind.com/en/personality/intj-a</loc>', $body);
+        $this->assertStringNotContainsString('<loc>https://staging.fermatmind.com/zh/personality/intj-a</loc>', $body);
         $this->assertStringContainsString('<loc>https://staging.fermatmind.com/en/topics</loc>', $body);
         $this->assertStringContainsString('<loc>https://staging.fermatmind.com/zh/topics</loc>', $body);
         $this->assertStringContainsString('<loc>https://staging.fermatmind.com/en/topics/mbti</loc>', $body);

--- a/backend/tests/Feature/V0_3/MbtiReportHttpContractRegressionTest.php
+++ b/backend/tests/Feature/V0_3/MbtiReportHttpContractRegressionTest.php
@@ -133,6 +133,12 @@ final class MbtiReportHttpContractRegressionTest extends TestCase
             'ENFP',
             'T'
         );
+        $this->assertStableMbtiPublicProjectionV1(
+            (array) $resp->json('mbti_public_projection_v1'),
+            'ENFP-T',
+            'ENFP',
+            'T'
+        );
     }
 
     public function test_unlocked_paid_mbti_report_http_contract_keeps_section_gate_semantics(): void
@@ -182,6 +188,12 @@ final class MbtiReportHttpContractRegressionTest extends TestCase
             'INTJ',
             'A'
         );
+        $this->assertStableMbtiPublicProjectionV1(
+            (array) $resp->json('mbti_public_projection_v1'),
+            'INTJ-A',
+            'INTJ',
+            'A'
+        );
     }
 
     private function assertStableMbtiEnvelope(TestResponse $response): void
@@ -205,6 +217,7 @@ final class MbtiReportHttpContractRegressionTest extends TestCase
             'meta',
             'report',
             'mbti_public_summary_v1',
+            'mbti_public_projection_v1',
             'scale_code',
             'scale_code_legacy',
             'scale_code_v2',
@@ -229,6 +242,7 @@ final class MbtiReportHttpContractRegressionTest extends TestCase
         $this->assertIsArray($payload['meta']);
         $this->assertIsArray($payload['report']);
         $this->assertIsArray($payload['mbti_public_summary_v1']);
+        $this->assertIsArray($payload['mbti_public_projection_v1']);
         $this->assertNotSame('', trim((string) $payload['scale_code']));
         $this->assertNotSame('', trim((string) $payload['scale_code_legacy']));
         $this->assertNotSame('', trim((string) $payload['scale_code_v2']));
@@ -285,6 +299,44 @@ final class MbtiReportHttpContractRegressionTest extends TestCase
             data_get($summary, 'offer_set.cta.target_sku_effective')
                 ?? data_get($summary, 'offer_set.cta.target_sku')
                 ?? data_get($summary, 'offer_set.upgrade_sku')
+        );
+    }
+
+    /**
+     * @param  array<string,mixed>  $projection
+     */
+    private function assertStableMbtiPublicProjectionV1(
+        array $projection,
+        string $expectedRuntimeTypeCode,
+        string $expectedCanonicalType,
+        ?string $expectedVariant
+    ): void {
+        foreach ([
+            'runtime_type_code',
+            'canonical_type_code',
+            'display_type',
+            'variant_code',
+            'profile',
+            'summary_card',
+            'dimensions',
+            'sections',
+            'seo',
+            'offer_set',
+            '_meta',
+        ] as $key) {
+            $this->assertArrayHasKey($key, $projection);
+        }
+
+        $this->assertSame($expectedRuntimeTypeCode, $projection['runtime_type_code'] ?? null);
+        $this->assertSame($expectedCanonicalType, $projection['canonical_type_code'] ?? null);
+        $this->assertSame($expectedRuntimeTypeCode, $projection['display_type'] ?? null);
+        $this->assertSame($expectedVariant, $projection['variant_code'] ?? null);
+        $this->assertSame(
+            ['EI', 'SN', 'TF', 'JP', 'AT'],
+            array_map(
+                static fn (array $item): string => (string) ($item['id'] ?? ''),
+                (array) ($projection['dimensions'] ?? [])
+            )
         );
     }
 

--- a/backend/tests/Feature/V0_3/ShareSummaryContractTest.php
+++ b/backend/tests/Feature/V0_3/ShareSummaryContractTest.php
@@ -41,7 +41,7 @@ final class ShareSummaryContractTest extends TestCase
             ->assertJsonPath('locale', 'zh-CN')
             ->assertJsonPath('title', 'INTJ - Architect')
             ->assertJsonPath('subtitle', '独立、冷静、面向长期规划')
-            ->assertJsonPath('summary', 'Public-safe share summary.')
+            ->assertJsonPath('summary', '公开人格简介兜底文案')
             ->assertJsonPath('type_code', 'INTJ-A')
             ->assertJsonPath('type_name', '建筑师型')
             ->assertJsonPath('tagline', '冷静的长期规划者')
@@ -58,11 +58,18 @@ final class ShareSummaryContractTest extends TestCase
             ->assertJsonMissingPath('cta');
 
         $this->assertCount(5, (array) $response->json('dimensions'));
-        $this->assertSame('EI', $response->json('dimensions.0.code'));
+        $this->assertSame('EI', $response->json('dimensions.0.id'));
         $this->assertSame('I', $response->json('dimensions.0.side'));
         $this->assertSame(65, $response->json('dimensions.0.pct'));
         $this->assertSame('clear', $response->json('dimensions.0.state'));
         $this->assertStableMbtiPublicSummaryV1((array) $response->json('mbti_public_summary_v1'), 'INTJ-A', 'INTJ', 'A');
+        $this->assertSame('INTJ-A', $response->json('mbti_public_projection_v1.display_type'));
+        $this->assertSame('INTJ', $response->json('mbti_public_projection_v1.canonical_type_code'));
+        $this->assertSame('建筑师型', $response->json('mbti_public_projection_v1.profile.type_name'));
+        $this->assertSame('公开人格简介兜底文案', $response->json('mbti_public_projection_v1.summary_card.summary'));
+        $this->assertSame($response->json('type_code'), $response->json('mbti_public_projection_v1.display_type'));
+        $this->assertSame($response->json('type_name'), $response->json('mbti_public_projection_v1.profile.type_name'));
+        $this->assertSame($response->json('dimensions'), $response->json('mbti_public_projection_v1.dimensions'));
         $this->assertStringContainsString('/share/'.$response->json('share_id'), (string) $response->json('share_url'));
         $this->assertStringNotContainsString('PRIVATE_PAID_SECTION_BODY', (string) $response->getContent());
         $this->assertStringNotContainsString('PRIVATE_RESULT_PATH', (string) $response->getContent());
@@ -95,7 +102,7 @@ final class ShareSummaryContractTest extends TestCase
             ->assertJsonPath('id', $shareId)
             ->assertJsonPath('title', 'INTJ - Architect')
             ->assertJsonPath('subtitle', '独立、冷静、面向长期规划')
-            ->assertJsonPath('summary', 'Public-safe share summary.')
+            ->assertJsonPath('summary', '公开人格简介兜底文案')
             ->assertJsonPath('type_code', 'INTJ-A')
             ->assertJsonPath('type_name', '建筑师型')
             ->assertJsonPath('tagline', '冷静的长期规划者')
@@ -126,6 +133,7 @@ final class ShareSummaryContractTest extends TestCase
             'primary_cta_label',
             'primary_cta_path',
             'mbti_public_summary_v1',
+            'mbti_public_projection_v1',
         ] as $key) {
             $this->assertSame($share->json($key), $view->json($key), "share field mismatch: {$key}");
         }
@@ -135,15 +143,16 @@ final class ShareSummaryContractTest extends TestCase
             $view->json('mbti_public_summary_v1.display_type')
         );
         $this->assertSame(
-            $view->json('summary'),
-            $view->json('mbti_public_summary_v1.summary_card.share_text')
+            $view->json('type_code'),
+            $view->json('mbti_public_projection_v1.display_type')
         );
         $this->assertSame(
-            ['EI', 'SN', 'TF', 'JP', 'AT'],
-            array_map(
-                static fn (array $item): string => (string) ($item['id'] ?? ''),
-                (array) $view->json('mbti_public_summary_v1.dimensions')
-            )
+            $view->json('type_name'),
+            $view->json('mbti_public_projection_v1.profile.type_name')
+        );
+        $this->assertSame(
+            $view->json('dimensions'),
+            $view->json('mbti_public_projection_v1.dimensions')
         );
 
         $this->assertStringNotContainsString('PRIVATE_PAID_SECTION_BODY', (string) $view->getContent());

--- a/backend/tests/Feature/V0_5/PersonalityPublicApiTest.php
+++ b/backend/tests/Feature/V0_5/PersonalityPublicApiTest.php
@@ -146,8 +146,8 @@ final class PersonalityPublicApiTest extends TestCase
 
         PersonalityProfileSection::query()->create([
             'profile_id' => (int) $profile->id,
-            'section_key' => 'core_snapshot',
-            'title' => 'Core snapshot',
+            'section_key' => 'overview',
+            'title' => 'Overview',
             'render_variant' => 'rich_text',
             'body_md' => 'INTJ body',
             'sort_order' => 10,
@@ -190,8 +190,13 @@ final class PersonalityPublicApiTest extends TestCase
             ->assertJsonPath('profile.keywords.1', 'independence')
             ->assertJsonPath('profile.hero_summary', 'Strategic, independent, and long-range.')
             ->assertJsonCount(1, 'sections')
-            ->assertJsonPath('sections.0.section_key', 'core_snapshot')
+            ->assertJsonPath('sections.0.section_key', 'overview')
             ->assertJsonPath('seo_meta.seo_title', 'INTJ Personality Type')
+            ->assertJsonPath('mbti_public_projection_v1.display_type', 'INTJ')
+            ->assertJsonPath('mbti_public_projection_v1.canonical_type_code', 'INTJ')
+            ->assertJsonPath('mbti_public_projection_v1.runtime_type_code', null)
+            ->assertJsonPath('mbti_public_projection_v1.summary_card.title', 'INTJ - Architect')
+            ->assertJsonPath('mbti_public_projection_v1.sections.0.key', 'overview')
             ->assertJsonMissingPath('revisions');
     }
 
@@ -255,6 +260,10 @@ final class PersonalityPublicApiTest extends TestCase
         $this->createSeoMeta($enProfile, [
             'seo_title' => 'INTJ Personality Type: Traits, Careers, and Growth | FermatMind',
             'seo_description' => 'Explore INTJ traits, strengths, blind spots, work style, relationships, and growth advice.',
+            'canonical_url' => 'https://staging.fermatmind.com/en/personality/intj-a',
+            'jsonld_overrides_json' => [
+                'mainEntityOfPage' => 'https://staging.fermatmind.com/en/personality/intj-a',
+            ],
         ]);
 
         $zhProfile = $this->createProfile([
@@ -271,6 +280,10 @@ final class PersonalityPublicApiTest extends TestCase
         $this->createSeoMeta($zhProfile, [
             'seo_title' => 'INTJ 人格类型：特质、职业与成长 | FermatMind',
             'seo_description' => '探索 INTJ 的特质、优势、关系模式与成长建议。',
+            'canonical_url' => 'https://staging.fermatmind.com/zh/personality/intj-a',
+            'jsonld_overrides_json' => [
+                'mainEntityOfPage' => 'https://staging.fermatmind.com/zh/personality/intj-a',
+            ],
         ]);
 
         $enResponse = $this->getJson('/api/v0.5/personality/INTJ/seo?locale=en');

--- a/backend/tests/Unit/Services/Mbti/Adapters/MbtiPersonalityProfileAuthoritySourceAdapterTest.php
+++ b/backend/tests/Unit/Services/Mbti/Adapters/MbtiPersonalityProfileAuthoritySourceAdapterTest.php
@@ -1,0 +1,116 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Services\Mbti\Adapters;
+
+use App\Models\PersonalityProfile;
+use App\Models\PersonalityProfileSection;
+use App\Models\PersonalityProfileSeoMeta;
+use App\Models\PersonalityProfileVariant;
+use App\Models\PersonalityProfileVariantSection;
+use App\Models\PersonalityProfileVariantSeoMeta;
+use App\Services\Mbti\Adapters\MbtiPersonalityProfileAuthoritySourceAdapter;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+final class MbtiPersonalityProfileAuthoritySourceAdapterTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_it_maps_base_and_variant_authority_without_guessing_runtime_identity(): void
+    {
+        $profile = PersonalityProfile::query()->create([
+            'org_id' => 0,
+            'scale_code' => PersonalityProfile::SCALE_CODE_MBTI,
+            'type_code' => 'ENFJ',
+            'slug' => 'enfj',
+            'locale' => 'en',
+            'title' => 'ENFJ Personality',
+            'subtitle' => 'Warm and future-aware',
+            'excerpt' => 'Base excerpt',
+            'type_name' => 'Protagonist',
+            'nickname' => 'Warm guide',
+            'rarity_text' => 'About 2%',
+            'keywords_json' => ['empathy', 'vision'],
+            'hero_summary_md' => 'Base hero summary',
+            'status' => 'published',
+            'is_public' => true,
+            'is_indexable' => true,
+            'published_at' => now()->subMinute(),
+            'schema_version' => PersonalityProfile::SCHEMA_VERSION_V2,
+        ]);
+
+        PersonalityProfileSection::query()->create([
+            'profile_id' => (int) $profile->id,
+            'section_key' => 'overview',
+            'title' => 'Overview',
+            'render_variant' => 'rich_text',
+            'body_md' => 'Base overview',
+            'sort_order' => 10,
+            'is_enabled' => true,
+        ]);
+
+        PersonalityProfileSeoMeta::query()->create([
+            'profile_id' => (int) $profile->id,
+            'seo_title' => 'Base SEO title',
+        ]);
+
+        $variant = PersonalityProfileVariant::query()->create([
+            'personality_profile_id' => (int) $profile->id,
+            'canonical_type_code' => 'ENFJ',
+            'variant_code' => 'T',
+            'runtime_type_code' => 'ENFJ-T',
+            'type_name' => 'Protagonist T',
+            'nickname' => 'Sensitive guide',
+            'rarity_text' => 'About 5%',
+            'keywords_json' => ['sensitivity', 'vision'],
+            'hero_summary_md' => 'Variant hero summary',
+            'schema_version' => PersonalityProfile::SCHEMA_VERSION_V2,
+            'is_published' => true,
+            'published_at' => now()->subMinute(),
+        ]);
+
+        PersonalityProfileVariantSection::query()->create([
+            'personality_profile_variant_id' => (int) $variant->id,
+            'section_key' => 'overview',
+            'render_variant' => 'rich_text',
+            'is_enabled' => false,
+        ]);
+        PersonalityProfileVariantSection::query()->create([
+            'personality_profile_variant_id' => (int) $variant->id,
+            'section_key' => 'growth.summary',
+            'title' => 'Growth summary',
+            'render_variant' => 'rich_text',
+            'body_md' => 'Variant growth summary',
+            'sort_order' => 20,
+            'is_enabled' => true,
+        ]);
+
+        PersonalityProfileVariantSeoMeta::query()->create([
+            'personality_profile_variant_id' => (int) $variant->id,
+            'seo_title' => 'Variant SEO title',
+        ]);
+
+        $adapter = new MbtiPersonalityProfileAuthoritySourceAdapter;
+        $baseAuthority = $adapter->fromBaseProfile($profile);
+        $variantAuthority = $adapter->overlayVariant($baseAuthority, $variant);
+
+        $this->assertSame('ENFJ', $baseAuthority['canonical_type_code']);
+        $this->assertSame('ENFJ Personality', data_get($baseAuthority, 'summary_card.title'));
+        $this->assertSame('Base excerpt', data_get($baseAuthority, 'summary_card.summary'));
+        $this->assertSame('Warm guide', data_get($baseAuthority, 'profile.nickname'));
+        $this->assertSame('base', data_get($baseAuthority, 'sections.overview.source'));
+        $this->assertSame('Base SEO title', data_get($baseAuthority, 'seo.title'));
+
+        $this->assertSame('ENFJ-T', $variantAuthority['runtime_type_code']);
+        $this->assertSame('T', $variantAuthority['variant_code']);
+        $this->assertSame('Protagonist T', data_get($variantAuthority, 'profile.type_name'));
+        $this->assertSame('Sensitive guide', data_get($variantAuthority, 'profile.nickname'));
+        $this->assertSame(['sensitivity', 'vision'], data_get($variantAuthority, 'profile.keywords'));
+        $this->assertArrayNotHasKey('overview', $variantAuthority['sections']);
+        $this->assertSame('variant', $variantAuthority['sections']['growth.summary']['source'] ?? null);
+        $this->assertSame('Variant growth summary', $variantAuthority['sections']['growth.summary']['body_md'] ?? null);
+        $this->assertSame('Variant SEO title', data_get($variantAuthority, 'seo.title'));
+    }
+}

--- a/backend/tests/Unit/Services/Mbti/MbtiCanonicalPublicResultPayloadBuilderTest.php
+++ b/backend/tests/Unit/Services/Mbti/MbtiCanonicalPublicResultPayloadBuilderTest.php
@@ -57,18 +57,25 @@ final class MbtiCanonicalPublicResultPayloadBuilderTest extends TestCase
             ],
         ]));
 
-        $this->assertSame('ENFJ-T', $payload['type_code']);
-        $this->assertSame('ENFJ', $payload['base_type_code']);
-        $this->assertSame('T', $payload['variant']);
+        $this->assertSame('ENFJ-T', $payload['runtime_type_code']);
+        $this->assertSame('ENFJ', $payload['canonical_type_code']);
+        $this->assertSame('ENFJ-T', $payload['display_type']);
+        $this->assertSame('T', $payload['variant_code']);
         $this->assertSame('Pilot hero summary', $payload['profile']['hero_summary']);
-        $this->assertSame('Leads with warmth, structure, and anticipation.', $payload['sections']['overview']['body']);
-        $this->assertSame('Career pilot summary.', $payload['sections']['career.summary']['body']);
+        $this->assertSame(
+            'Leads with warmth, structure, and anticipation.',
+            $this->findSection($payload['sections'], 'overview')['body_md'] ?? null
+        );
+        $this->assertSame(
+            'Career pilot summary.',
+            $this->findSection($payload['sections'], 'career.summary')['body_md'] ?? null
+        );
         $this->assertSame(
             MbtiCanonicalSectionRegistry::RENDER_VARIANT_PREMIUM_TEASER,
-            $payload['premium_teaser']['growth.motivators']['render_variant']
+            $this->findSection($payload['sections'], 'growth.motivators')['render'] ?? null
         );
-        $this->assertSame('SN', $payload['sections']['trait_overview']['payload']['dimensions'][1]['normalized_axis_code']);
-        $this->assertSame('TF', $payload['sections']['trait_overview']['payload']['dimensions'][2]['normalized_axis_code']);
+        $this->assertSame('SN', $payload['dimensions'][1]['id']);
+        $this->assertSame('TF', $payload['dimensions'][2]['id']);
     }
 
     public function test_builder_rejects_base_type_only_resolution_without_silent_fallback(): void
@@ -196,5 +203,20 @@ final class MbtiCanonicalPublicResultPayloadBuilderTest extends TestCase
                 ];
             }
         });
+    }
+
+    /**
+     * @param  list<array<string, mixed>>  $sections
+     * @return array<string, mixed>
+     */
+    private function findSection(array $sections, string $sectionKey): array
+    {
+        foreach ($sections as $section) {
+            if (($section['key'] ?? null) === $sectionKey) {
+                return $section;
+            }
+        }
+
+        return [];
     }
 }

--- a/backend/tests/Unit/Services/Mbti/MbtiPublicProjectionServiceTest.php
+++ b/backend/tests/Unit/Services/Mbti/MbtiPublicProjectionServiceTest.php
@@ -1,0 +1,249 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Services\Mbti;
+
+use App\Models\PersonalityProfile;
+use App\Models\PersonalityProfileSection;
+use App\Models\PersonalityProfileSeoMeta;
+use App\Models\PersonalityProfileVariant;
+use App\Models\PersonalityProfileVariantSection;
+use App\Models\PersonalityProfileVariantSeoMeta;
+use App\Services\Mbti\MbtiPublicProjectionService;
+use App\Services\Mbti\MbtiPublicSummaryV1Builder;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+final class MbtiPublicProjectionServiceTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_it_builds_base_route_projection_from_personality_cms_only(): void
+    {
+        config(['app.frontend_url' => 'https://staging.fermatmind.com']);
+
+        $profile = $this->createBaseProfile([
+            'title' => 'INTJ - Architect',
+        ]);
+        PersonalityProfileSection::query()->create([
+            'profile_id' => (int) $profile->id,
+            'section_key' => 'overview',
+            'title' => 'Overview',
+            'render_variant' => 'rich_text',
+            'body_md' => 'Base overview',
+            'sort_order' => 10,
+            'is_enabled' => true,
+        ]);
+        PersonalityProfileSeoMeta::query()->create([
+            'profile_id' => (int) $profile->id,
+            'seo_title' => 'Base SEO title',
+        ]);
+
+        $projection = app(MbtiPublicProjectionService::class)->buildForPersonalityProfile($profile);
+
+        $this->assertSame(null, $projection['runtime_type_code']);
+        $this->assertSame('INTJ', $projection['canonical_type_code']);
+        $this->assertSame('INTJ', $projection['display_type']);
+        $this->assertSame('Architect', data_get($projection, 'profile.type_name'));
+        $this->assertSame('INTJ - Architect', data_get($projection, 'summary_card.title'));
+        $this->assertSame('Base overview', data_get($projection, 'sections.0.body_md'));
+        $this->assertSame('Base SEO title', data_get($projection, 'seo.title'));
+        $this->assertSame('https://staging.fermatmind.com/en/personality/intj', data_get($projection, 'seo.canonical_url'));
+        $this->assertSame('base', data_get($projection, '_meta.route_mode'));
+        $this->assertSame([], $projection['offer_set']);
+    }
+
+    public function test_it_merges_runtime_identity_report_fallback_and_cms_variant_authority_for_share_projection(): void
+    {
+        config(['app.frontend_url' => 'https://staging.fermatmind.com']);
+
+        $profile = $this->createBaseProfile([
+            'title' => 'INTJ - Architect',
+            'subtitle' => 'Base subtitle',
+            'excerpt' => 'Base excerpt',
+            'hero_summary_md' => 'Base hero summary',
+        ]);
+        PersonalityProfileSection::query()->create([
+            'profile_id' => (int) $profile->id,
+            'section_key' => 'overview',
+            'title' => 'Overview',
+            'render_variant' => 'rich_text',
+            'body_md' => 'Base overview',
+            'sort_order' => 10,
+            'is_enabled' => true,
+        ]);
+        PersonalityProfileSeoMeta::query()->create([
+            'profile_id' => (int) $profile->id,
+            'seo_title' => 'Base SEO title',
+        ]);
+
+        $variant = PersonalityProfileVariant::query()->create([
+            'personality_profile_id' => (int) $profile->id,
+            'canonical_type_code' => 'INTJ',
+            'variant_code' => 'A',
+            'runtime_type_code' => 'INTJ-A',
+            'type_name' => 'Architect A',
+            'nickname' => 'Assertive strategist',
+            'rarity_text' => 'About 3%',
+            'keywords_json' => ['assertive', 'strategy'],
+            'hero_summary_md' => 'Variant hero summary',
+            'schema_version' => PersonalityProfile::SCHEMA_VERSION_V2,
+            'is_published' => true,
+            'published_at' => now()->subMinute(),
+        ]);
+        PersonalityProfileVariantSection::query()->create([
+            'personality_profile_variant_id' => (int) $variant->id,
+            'section_key' => 'overview',
+            'title' => 'Overview',
+            'render_variant' => 'rich_text',
+            'body_md' => 'Variant overview',
+            'sort_order' => 10,
+            'is_enabled' => true,
+        ]);
+        PersonalityProfileVariantSeoMeta::query()->create([
+            'personality_profile_variant_id' => (int) $variant->id,
+            'seo_title' => 'Variant SEO title',
+        ]);
+
+        $summaryBuilder = app(MbtiPublicSummaryV1Builder::class);
+        $summary = $summaryBuilder->scaffold('INTJ-A');
+        $summary['profile']['type_name'] = 'Runtime Architect';
+        $summary['profile']['nickname'] = 'Runtime strategist';
+        $summary['profile']['rarity'] = 'About 2%';
+        $summary['profile']['keywords'] = ['runtime', 'strategy'];
+        $summary['profile']['summary'] = 'Runtime hero summary';
+        $summary['summary_card']['title'] = 'Runtime title';
+        $summary['summary_card']['subtitle'] = 'Runtime subtitle';
+        $summary['summary_card']['share_text'] = 'Runtime share summary';
+        $summary['summary_card']['tags'] = ['runtime'];
+        $summary['dimensions'] = [
+            ['id' => 'EI', 'label' => 'Energy', 'axis_left' => 'Extraversion', 'axis_right' => 'Introversion', 'value_pct' => 35],
+            ['id' => 'SN', 'label' => 'Information', 'axis_left' => 'Sensing', 'axis_right' => 'Intuition', 'value_pct' => 72],
+            ['id' => 'TF', 'label' => 'Decision', 'axis_left' => 'Thinking', 'axis_right' => 'Feeling', 'value_pct' => 68],
+            ['id' => 'JP', 'label' => 'Lifestyle', 'axis_left' => 'Judging', 'axis_right' => 'Perceiving', 'value_pct' => 63],
+            ['id' => 'AT', 'label' => 'Identity', 'axis_left' => 'Assertive', 'axis_right' => 'Turbulent', 'value_pct' => 58],
+        ];
+        $summary['offer_set'] = [
+            'cta' => ['target_sku' => 'MBTI_REPORT_FULL'],
+        ];
+
+        $sharePayload = [
+            'type_code' => 'INTJ-A',
+            'type_name' => 'Runtime Architect',
+            'title' => 'Runtime title',
+            'subtitle' => 'Runtime subtitle',
+            'summary' => 'Runtime share summary',
+            'tagline' => 'Runtime strategist',
+            'rarity' => 'About 2%',
+            'tags' => ['runtime'],
+            'dimensions' => [
+                ['code' => 'EI', 'label' => 'Energy', 'side' => 'I', 'side_label' => 'Introversion', 'pct' => 65, 'state' => 'clear'],
+                ['code' => 'SN', 'label' => 'Information', 'side' => 'N', 'side_label' => 'Intuition', 'pct' => 72, 'state' => 'clear'],
+                ['code' => 'TF', 'label' => 'Decision', 'side' => 'T', 'side_label' => 'Thinking', 'pct' => 68, 'state' => 'clear'],
+                ['code' => 'JP', 'label' => 'Lifestyle', 'side' => 'J', 'side_label' => 'Judging', 'pct' => 63, 'state' => 'moderate'],
+                ['code' => 'AT', 'label' => 'Identity', 'side' => 'A', 'side_label' => 'Assertive', 'pct' => 58, 'state' => 'moderate'],
+            ],
+            'mbti_public_summary_v1' => $summary,
+        ];
+        $reportPayload = [
+            'profile' => [
+                'type_code' => 'INTJ-A',
+                'short_summary' => 'Fallback hero summary',
+            ],
+            'layers' => [
+                'identity' => [
+                    'title' => 'Fallback title',
+                    'subtitle' => 'Fallback subtitle',
+                    'one_liner' => 'Fallback overview body',
+                ],
+            ],
+            'scores_pct' => [
+                'EI' => 35,
+                'NS' => 72,
+                'FT' => 68,
+                'JP' => 63,
+                'AT' => 58,
+            ],
+            'sections' => [
+                'career' => [
+                    'cards' => [
+                        ['body' => 'Career fallback body'],
+                    ],
+                ],
+            ],
+        ];
+
+        $projection = app(MbtiPublicProjectionService::class)->buildForSharePayload(
+            $sharePayload,
+            'en',
+            0,
+            $reportPayload,
+            ['summary' => 'Runtime result summary']
+        );
+
+        $this->assertSame('INTJ-A', $projection['runtime_type_code']);
+        $this->assertSame('INTJ', $projection['canonical_type_code']);
+        $this->assertSame('INTJ-A', $projection['display_type']);
+        $this->assertSame('A', $projection['variant_code']);
+        $this->assertSame('Architect A', data_get($projection, 'profile.type_name'));
+        $this->assertSame('Assertive strategist', data_get($projection, 'profile.nickname'));
+        $this->assertSame('INTJ - Architect', data_get($projection, 'summary_card.title'));
+        $this->assertSame('Base excerpt', data_get($projection, 'summary_card.summary'));
+        $this->assertSame('Variant overview', $this->findSection($projection['sections'], 'overview')['body_md'] ?? null);
+        $this->assertSame('Career fallback body', $this->findSection($projection['sections'], 'career.summary')['body_md'] ?? null);
+        $this->assertSame('Variant SEO title', data_get($projection, 'seo.title'));
+        $this->assertSame('https://staging.fermatmind.com/en/personality/intj', data_get($projection, 'seo.canonical_url'));
+        $this->assertSame('runtime+report_fallback+personality_cms_v2', data_get($projection, '_meta.authority_source'));
+        $this->assertSame(
+            ['EI', 'SN', 'TF', 'JP', 'AT'],
+            array_map(static fn (array $item): string => (string) ($item['id'] ?? ''), $projection['dimensions'])
+        );
+        $this->assertSame('I', data_get($projection, 'dimensions.0.side'));
+        $this->assertSame('clear', data_get($projection, 'dimensions.0.state'));
+        $this->assertSame('MBTI_REPORT_FULL', data_get($projection, 'offer_set.cta.target_sku'));
+    }
+
+    /**
+     * @param  array<string, mixed>  $overrides
+     */
+    private function createBaseProfile(array $overrides = []): PersonalityProfile
+    {
+        /** @var PersonalityProfile */
+        return PersonalityProfile::query()->create(array_merge([
+            'org_id' => 0,
+            'scale_code' => PersonalityProfile::SCALE_CODE_MBTI,
+            'type_code' => 'INTJ',
+            'slug' => 'intj',
+            'locale' => 'en',
+            'title' => 'INTJ',
+            'subtitle' => 'Strategic and future-oriented',
+            'excerpt' => 'Base excerpt',
+            'type_name' => 'Architect',
+            'nickname' => 'Systems builder',
+            'rarity_text' => 'About 2%',
+            'keywords_json' => ['strategy', 'independence'],
+            'hero_summary_md' => 'Base hero summary',
+            'status' => 'published',
+            'is_public' => true,
+            'is_indexable' => true,
+            'published_at' => now()->subMinute(),
+            'schema_version' => PersonalityProfile::SCHEMA_VERSION_V2,
+        ], $overrides));
+    }
+
+    /**
+     * @param  list<array<string, mixed>>  $sections
+     * @return array<string, mixed>
+     */
+    private function findSection(array $sections, string $sectionKey): array
+    {
+        foreach ($sections as $section) {
+            if (($section['key'] ?? null) === $sectionKey) {
+                return $section;
+            }
+        }
+
+        return [];
+    }
+}


### PR DESCRIPTION
## Summary
This PR adds a unified `mbti_public_projection_v1` contract across the backend MBTI public read surfaces and keeps `mbti_public_summary_v1` as the PR-1 compatibility layer.

The implementation reuses `MbtiCanonicalPublicResultPayloadBuilder` as the single serializer owner, adds `MbtiPublicProjectionService` as the orchestration layer, and adds `MbtiPersonalityProfileAuthoritySourceAdapter` to adapt PR-2 CMS profile, section, variant, and SEO data into a single projection authority shape.

The projection is now available on:
- `/api/v0.3/attempts/{id}/report`
- `/api/v0.3/shares/{id}`
- `/api/v0.5/personality/{type}`

The same backend projection source now also drives:
- `/api/v0.5/personality` canonical field derivation
- `/api/v0.5/personality/{type}/seo`
- `SitemapGenerator`

## Problem
Before this change, MBTI public data came from multiple partially overlapping sources:
- PR-1 runtime identity summary for report/share
- report/share fallback snapshots
- PR-2 personality CMS base and variant authority
- separate SEO and sitemap derivations

That split caused two practical risks:
1. Runtime-bound report/share surfaces could become thin when canonical 32-type CMS content had not been fully imported.
2. Personality detail, SEO, and sitemap could drift from the report/share public payload shape and precedence rules.

## Root Cause
We had the identity bridge and the CMS schema, but we did not yet have one backend projection owner that could merge them with a fixed precedence model.

The missing piece was a service that could compose, in order:
1. runtime identity from `mbti_public_summary_v1`
2. runtime/report fallback authority for report/share surfaces
3. base personality CMS authority
4. variant overlay authority
5. SEO canonical policy
6. sitemap derivation policy

## Fix
This PR introduces a single projection pipeline with these rules:
- Runtime identity remains owned only by `MbtiPublicSummaryV1Builder`.
- `MbtiCanonicalPublicResultPayloadBuilder` is the only serializer that emits `mbti_public_projection_v1`.
- `MbtiPublicProjectionService` orchestrates runtime summary, report/share fallback authority, and CMS overlay.
- `MbtiPersonalityProfileAuthoritySourceAdapter` maps base profile, base sections, base SEO, variant profile, variant sections, and variant SEO into the builder's authority shape.
- Report and share add `mbti_public_projection_v1` additively and keep existing fields.
- Share top-level legacy fields are now compatibility aliases derived from the new projection.
- Personality detail adds `mbti_public_projection_v1` additively and keeps the current `profile`, `sections`, and `seo_meta` wrappers.
- SEO and sitemap are internally rewritten to read from the same projection source while preserving the existing external response shape.
- Canonical route policy stays 16-type only. Runtime display may stay 32-type on runtime-bound surfaces, but canonical URLs and sitemap entries never emit `-A/-T` public routes.

## Scope
Included:
- backend MBTI projection serialization
- backend report/share/personality detail additive contract work
- backend SEO and sitemap source unification
- unit and feature coverage for the new contract and route policy

Explicitly not included:
- route changes
- migrations or schema changes
- compare payload changes
- importer changes
- frontend rewiring
- commerce, career, Team, or Pro changes

## Validation
Validated locally with:
- `php artisan route:list | grep -Ei "report|shares|compare|personality|seo|sitemap"`
- `php artisan migrate`
- `php artisan fap:schema:verify`
- focused PHPUnit suite for MBTI projection/report/share/personality/seo/sitemap coverage
- `./vendor/bin/pint` on changed files
- `bash scripts/ci_verify_mbti.sh`

Key assertions covered:
- `/report` keeps `mbti_public_summary_v1` and adds `mbti_public_projection_v1`
- `/shares/{id}` keeps old top-level fields and derives them from projection aliases
- `/personality/{type}` keeps current wrappers and adds `mbti_public_projection_v1`
- `/personality/{type}/seo` canonical stays on 16-type routes even if authored overrides attempt `-A/-T`
- sitemap includes `/personality/intj` and excludes `/personality/intj-a`
- compare contract remains unchanged
