### PR TITLE
[codex] feat(api): add compare participant MBTI public projection v1

### DIFF
--- a/backend/app/Services/V0_3/MbtiCompareInviteService.php
+++ b/backend/app/Services/V0_3/MbtiCompareInviteService.php
@@ -9,6 +9,7 @@ use App\Models\Attempt;
 use App\Models\MbtiCompareInvite;
 use App\Models\Result;
 use App\Models\Share;
+use App\Services\Mbti\MbtiPublicProjectionService;
 use App\Services\Mbti\MbtiPublicSummaryV1Builder;
 use Illuminate\Database\Eloquent\ModelNotFoundException;
 use Illuminate\Support\Carbon;
@@ -18,6 +19,7 @@ final class MbtiCompareInviteService
 {
     public function __construct(
         private readonly ShareService $shareService,
+        private readonly MbtiPublicProjectionService $mbtiPublicProjectionService,
         private readonly MbtiPublicSummaryV1Builder $mbtiPublicSummaryV1Builder,
     ) {}
 
@@ -69,10 +71,13 @@ final class MbtiCompareInviteService
         );
 
         $status = $this->normalizeStatus((string) ($invite->status ?? 'pending'));
-        $inviter = $this->toSummaryLite($inviterPayload, true);
-        $invitee = [
-            'mbti_public_summary_v1' => $this->mbtiPublicSummaryV1Builder->scaffold(),
-        ];
+        $inviter = $this->toSummaryLiteWithProjection(
+            $inviterPayload,
+            true,
+            (int) ($attempt->org_id ?? 0),
+            $locale
+        );
+        $invitee = $this->pendingInviteePayload();
         $compare = [
             'mbti_public_summary_v1' => $this->mbtiPublicSummaryV1Builder->buildFromComparePayload([
                 'title' => null,
@@ -93,7 +98,12 @@ final class MbtiCompareInviteService
 
                     if ($inviteeResult instanceof Result) {
                         $inviteePayload = $this->shareService->buildPublicSummaryPayload($inviteeAttempt, $inviteeResult);
-                        $invitee = $this->toSummaryLite($inviteePayload, false);
+                        $invitee = $this->toSummaryLiteWithProjection(
+                            $inviteePayload,
+                            false,
+                            (int) ($inviteeAttempt->org_id ?? 0),
+                            $locale
+                        );
                         $compare = $this->buildComparePayload(
                             $inviter,
                             $invitee,
@@ -219,6 +229,108 @@ final class MbtiCompareInviteService
         }
 
         return $summary;
+    }
+
+    /**
+     * @param  array<string, mixed>  $payload
+     * @return array<string, mixed>
+     */
+    private function toSummaryLiteWithProjection(array $payload, bool $includeShareId, int $orgId, string $locale): array
+    {
+        $summary = $this->toSummaryLite($payload, $includeShareId);
+        $summary['mbti_public_projection_v1'] = $this->resolveParticipantProjection($payload, $orgId, $locale);
+
+        return $summary;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function pendingInviteePayload(): array
+    {
+        $summary = $this->mbtiPublicSummaryV1Builder->scaffold();
+
+        return [
+            'mbti_public_summary_v1' => $summary,
+            'mbti_public_projection_v1' => $this->scaffoldParticipantProjection($summary),
+        ];
+    }
+
+    /**
+     * @param  array<string, mixed>  $payload
+     * @return array<string, mixed>
+     */
+    private function resolveParticipantProjection(array $payload, int $orgId, string $locale): array
+    {
+        if (is_array($payload['mbti_public_projection_v1'] ?? null)) {
+            return $payload['mbti_public_projection_v1'];
+        }
+
+        $summary = is_array($payload['mbti_public_summary_v1'] ?? null)
+            ? $payload['mbti_public_summary_v1']
+            : $this->mbtiPublicSummaryV1Builder->buildFromSharePayload($payload, null, $locale);
+
+        return $this->mbtiPublicProjectionService->buildForSharePayload(
+            $payload + ['mbti_public_summary_v1' => $summary],
+            $locale,
+            $orgId
+        );
+    }
+
+    /**
+     * @param  array<string, mixed>  $summary
+     * @return array<string, mixed>
+     */
+    private function scaffoldParticipantProjection(array $summary): array
+    {
+        return [
+            'runtime_type_code' => $this->nullableString($summary['runtime_type_code'] ?? null),
+            'canonical_type_code' => $this->nullableString($summary['canonical_type_16'] ?? null),
+            'display_type' => $this->nullableString($summary['display_type'] ?? null),
+            'variant_code' => $this->nullableString($summary['variant'] ?? null),
+            'profile' => [
+                'type_name' => $this->nullableString(data_get($summary, 'profile.type_name')),
+                'nickname' => $this->nullableString(data_get($summary, 'profile.nickname')),
+                'rarity' => $this->nullableString(data_get($summary, 'profile.rarity')),
+                'keywords' => is_array(data_get($summary, 'profile.keywords'))
+                    ? array_values(data_get($summary, 'profile.keywords'))
+                    : [],
+                'hero_summary' => $this->nullableString(data_get($summary, 'profile.summary')),
+            ],
+            'summary_card' => [
+                'title' => $this->nullableString(data_get($summary, 'summary_card.title')),
+                'subtitle' => $this->nullableString(data_get($summary, 'summary_card.subtitle')),
+                'summary' => $this->nullableString(data_get($summary, 'summary_card.share_text')),
+                'tagline' => $this->nullableString(data_get($summary, 'profile.nickname')),
+                'public_tags' => is_array(data_get($summary, 'summary_card.tags'))
+                    ? array_values(data_get($summary, 'summary_card.tags'))
+                    : [],
+            ],
+            'dimensions' => [],
+            'sections' => [],
+            'seo' => [
+                'title' => null,
+                'description' => null,
+                'og_title' => null,
+                'og_description' => null,
+                'og_image_url' => null,
+                'twitter_title' => null,
+                'twitter_description' => null,
+                'twitter_image_url' => null,
+                'canonical_url' => null,
+                'robots' => null,
+                'jsonld' => [],
+            ],
+            'offer_set' => is_array($summary['offer_set'] ?? null)
+                ? $summary['offer_set']
+                : [],
+            '_meta' => [
+                'authority_source' => 'compare.pending_scaffold',
+                'route_mode' => 'runtime',
+                'public_route_type' => '16-type',
+                'schema_version' => 'v2',
+            ],
+        ];
     }
 
     private function buildTakePath(string $locale, string $shareId, string $inviteId, string $primaryCtaPath): string

--- a/backend/tests/Feature/V0_3/MbtiCompareInviteContractTest.php
+++ b/backend/tests/Feature/V0_3/MbtiCompareInviteContractTest.php
@@ -98,8 +98,11 @@ final class MbtiCompareInviteContractTest extends TestCase
             ->assertJsonPath('inviter.type_code', 'INTJ-A')
             ->assertJsonPath('inviter.summary', 'Public-safe share summary.')
             ->assertJsonPath('inviter.mbti_public_summary_v1.runtime_type_code', 'INTJ-A')
+            ->assertJsonPath('inviter.mbti_public_projection_v1.runtime_type_code', 'INTJ-A')
             ->assertJsonPath('invitee.mbti_public_summary_v1.runtime_type_code', null)
-            ->assertJsonPath('compare.mbti_public_summary_v1.runtime_type_code', null);
+            ->assertJsonPath('invitee.mbti_public_projection_v1.runtime_type_code', null)
+            ->assertJsonPath('compare.mbti_public_summary_v1.runtime_type_code', null)
+            ->assertJsonMissingPath('compare.mbti_public_projection_v1');
 
         $this->assertSame(
             ['EI', 'SN', 'TF', 'JP', 'AT'],
@@ -108,6 +111,25 @@ final class MbtiCompareInviteContractTest extends TestCase
                 (array) $response->json('inviter.mbti_public_summary_v1.dimensions')
             )
         );
+        $this->assertStableMbtiPublicProjectionV1(
+            (array) $response->json('inviter.mbti_public_projection_v1'),
+            'INTJ-A',
+            'INTJ',
+            'INTJ-A',
+            'A',
+            ['EI', 'SN', 'TF', 'JP', 'AT']
+        );
+        $this->assertStableMbtiPublicProjectionV1(
+            (array) $response->json('invitee.mbti_public_projection_v1'),
+            null,
+            null,
+            null,
+            null
+        );
+        $this->assertSame([], (array) $response->json('invitee.mbti_public_projection_v1.dimensions'));
+        $this->assertSame([], (array) $response->json('invitee.mbti_public_projection_v1.sections'));
+        $this->assertSame([], (array) $response->json('invitee.mbti_public_projection_v1.seo.jsonld'));
+        $this->assertSame('compare.pending_scaffold', $response->json('invitee.mbti_public_projection_v1._meta.authority_source'));
 
         foreach ([
             'report',
@@ -159,12 +181,16 @@ final class MbtiCompareInviteContractTest extends TestCase
             ->assertJsonPath('status', 'ready')
             ->assertJsonPath('inviter.mbti_public_summary_v1.runtime_type_code', 'INTJ-A')
             ->assertJsonPath('inviter.mbti_public_summary_v1.variant', 'A')
+            ->assertJsonPath('inviter.mbti_public_projection_v1.runtime_type_code', 'INTJ-A')
             ->assertJsonPath('invitee.mbti_public_summary_v1.runtime_type_code', 'ENFP-T')
             ->assertJsonPath('invitee.mbti_public_summary_v1.canonical_type_16', 'ENFP')
             ->assertJsonPath('invitee.mbti_public_summary_v1.variant', 'T')
+            ->assertJsonPath('invitee.mbti_public_projection_v1.runtime_type_code', 'ENFP-T')
+            ->assertJsonPath('invitee.mbti_public_projection_v1.canonical_type_code', 'ENFP')
             ->assertJsonPath('compare.mbti_public_summary_v1.runtime_type_code', null)
             ->assertJsonPath('compare.mbti_public_summary_v1.summary_card.title', $response->json('compare.title'))
-            ->assertJsonPath('compare.mbti_public_summary_v1.summary_card.share_text', $response->json('compare.summary'));
+            ->assertJsonPath('compare.mbti_public_summary_v1.summary_card.share_text', $response->json('compare.summary'))
+            ->assertJsonMissingPath('compare.mbti_public_projection_v1');
 
         $this->assertSame(
             ['EI', 'SN', 'TF', 'JP', 'AT'],
@@ -172,6 +198,22 @@ final class MbtiCompareInviteContractTest extends TestCase
                 static fn (array $item): string => (string) ($item['id'] ?? ''),
                 (array) $response->json('compare.mbti_public_summary_v1.dimensions')
             )
+        );
+        $this->assertStableMbtiPublicProjectionV1(
+            (array) $response->json('inviter.mbti_public_projection_v1'),
+            'INTJ-A',
+            'INTJ',
+            'INTJ-A',
+            'A',
+            ['EI', 'SN', 'TF', 'JP', 'AT']
+        );
+        $this->assertStableMbtiPublicProjectionV1(
+            (array) $response->json('invitee.mbti_public_projection_v1'),
+            'ENFP-T',
+            'ENFP',
+            'ENFP-T',
+            'T',
+            ['EI', 'SN', 'TF', 'JP', 'AT']
         );
     }
 
@@ -302,5 +344,53 @@ final class MbtiCompareInviteContractTest extends TestCase
         ]);
 
         return $attemptId;
+    }
+
+    /**
+     * @param  array<string, mixed>  $projection
+     * @param  list<string>  $expectedDimensionIds
+     */
+    private function assertStableMbtiPublicProjectionV1(
+        array $projection,
+        ?string $expectedRuntimeTypeCode,
+        ?string $expectedCanonicalType,
+        ?string $expectedDisplayType,
+        ?string $expectedVariant,
+        array $expectedDimensionIds = []
+    ): void {
+        foreach ([
+            'runtime_type_code',
+            'canonical_type_code',
+            'display_type',
+            'variant_code',
+            'profile',
+            'summary_card',
+            'dimensions',
+            'sections',
+            'seo',
+            'offer_set',
+            '_meta',
+        ] as $key) {
+            $this->assertArrayHasKey($key, $projection);
+        }
+
+        $this->assertSame($expectedRuntimeTypeCode, $projection['runtime_type_code'] ?? null);
+        $this->assertSame($expectedCanonicalType, $projection['canonical_type_code'] ?? null);
+        $this->assertSame($expectedDisplayType, $projection['display_type'] ?? null);
+        $this->assertSame($expectedVariant, $projection['variant_code'] ?? null);
+        $this->assertIsArray($projection['profile'] ?? null);
+        $this->assertIsArray($projection['summary_card'] ?? null);
+        $this->assertIsArray($projection['dimensions'] ?? null);
+        $this->assertIsArray($projection['sections'] ?? null);
+        $this->assertIsArray($projection['seo'] ?? null);
+        $this->assertIsArray($projection['offer_set'] ?? null);
+        $this->assertIsArray($projection['_meta'] ?? null);
+        $this->assertSame(
+            $expectedDimensionIds,
+            array_map(
+                static fn (array $item): string => (string) ($item['id'] ?? ''),
+                (array) ($projection['dimensions'] ?? [])
+            )
+        );
     }
 }


### PR DESCRIPTION
## Summary
This PR completes PR-5A by making the compare participant contract additive and consistent with the existing share/report public projection contract. The change is intentionally narrow: it only updates the compare read path for `/api/v0.3/compare/mbti/{inviteId}` so that `inviter` and `invitee` now expose `mbti_public_projection_v1` alongside the existing flat summary shell and `mbti_public_summary_v1`.

For users and frontend consumers, the effect is that compare participants now carry the same public projection shape already available on share and report responses, without forcing any compare frontend migration. Existing flat fields such as `type_code`, `type_name`, `title`, `subtitle`, `summary`, `tagline`, `rarity`, `tags`, and `dimensions` remain unchanged, and compare-level summary fields remain unchanged as well.

## Root Cause
The compare service was reusing the share summary-lite shell but stopped at `mbti_public_summary_v1`. That meant the participant payload lost the canonical `mbti_public_projection_v1` contract already established in the share/report paths. Pending invitees were even more limited: they only returned a summary scaffold, so there was no stable projection object for clients to rely on.

## Fix
`MbtiCompareInviteService` now injects and reuses `MbtiPublicProjectionService` instead of introducing a second serializer. Ready participants derive `mbti_public_projection_v1` directly from the existing participant share-style authority. Pending invitees now return a stable scaffold object for `mbti_public_projection_v1` rather than `null`, so clients always see the same top-level keys.

The compare root intentionally stays untouched. This PR does not add `compare.mbti_public_projection_v1`, does not change `compare.mbti_public_summary_v1`, does not change the compare flat summary shell, and does not touch routes, migrations, share contracts, report contracts, or frontend code.

## Validation
I ran the required contract and regression checks:

- `php artisan route:list | grep -Ei "compare|shares|report"`
- `php artisan migrate`
- `php artisan fap:schema:verify`
- `vendor/bin/phpunit tests/Feature/V0_3/MbtiCompareInviteContractTest.php tests/Feature/V0_3/ShareSummaryContractTest.php tests/Feature/V0_3/MbtiReportHttpContractRegressionTest.php`
- `bash scripts/ci_verify_mbti.sh`

The compare contract test now explicitly verifies that ready and pending compare responses both include participant `mbti_public_projection_v1`, that pending invitee projection is a scaffold object, and that `compare.mbti_public_projection_v1` is still absent.
