### PR TITLE
[codex] add mbti access hub v1

### DIFF
--- a/backend/app/Http/Controllers/API/V0_3/AttemptReadController.php
+++ b/backend/app/Http/Controllers/API/V0_3/AttemptReadController.php
@@ -9,11 +9,13 @@ use App\Models\Attempt;
 use App\Models\Result;
 use App\Services\Analytics\EventRecorder;
 use App\Services\Attempts\AttemptSubmissionService;
+use App\Services\Commerce\MbtiAccessHubBuilder;
 use App\Services\Mbti\MbtiPublicProjectionService;
 use App\Services\Mbti\MbtiPublicSummaryV1Builder;
 use App\Services\Observability\ClinicalComboTelemetry;
 use App\Services\Observability\Sds20Telemetry;
 use App\Services\Report\Pdf\ReportPdfDocumentService;
+use App\Services\Report\ReportAccess;
 use App\Services\Report\ReportGatekeeper;
 use App\Services\Scale\ScaleCodeResponseProjector;
 use App\Support\OrgContext;
@@ -35,6 +37,7 @@ class AttemptReadController extends Controller
         private ReportPdfDocumentService $reportPdfDocumentService,
         private MbtiPublicProjectionService $mbtiPublicProjectionService,
         private MbtiPublicSummaryV1Builder $mbtiPublicSummaryV1Builder,
+        private MbtiAccessHubBuilder $mbtiAccessHubBuilder,
         private EventRecorder $eventRecorder,
         private ScaleCodeResponseProjector $responseProjector,
         protected OrgContext $orgContext,
@@ -319,6 +322,12 @@ class AttemptReadController extends Controller
                 $responsePayload,
                 (string) ($attempt->locale ?? config('content_packs.default_locale', 'zh-CN')),
                 (int) ($attempt->org_id ?? 0)
+            );
+            $responsePayload[ReportAccess::ACCESS_HUB_KEY] = $this->mbtiAccessHubBuilder->buildForReportContext(
+                $attempt,
+                $gate,
+                $userId !== null ? (string) $userId : null,
+                $anonId
             );
         }
 

--- a/backend/app/Http/Controllers/API/V0_3/CommerceController.php
+++ b/backend/app/Http/Controllers/API/V0_3/CommerceController.php
@@ -6,10 +6,12 @@ use App\Http\Controllers\Controller;
 use App\Services\Commerce\Checkout\AlipayCheckoutService;
 use App\Services\Commerce\Checkout\LemonSqueezyCheckoutService;
 use App\Services\Commerce\Checkout\WechatPayCheckoutService;
+use App\Services\Commerce\MbtiAccessHubBuilder;
 use App\Services\Commerce\OrderManager;
 use App\Services\Commerce\SkuCatalog;
 use App\Services\Email\EmailCaptureService;
 use App\Services\Payments\PaymentRouter;
+use App\Services\Report\ReportAccess;
 use App\Support\OrgContext;
 use App\Support\RegionContext;
 use Illuminate\Http\JsonResponse;
@@ -29,6 +31,7 @@ class CommerceController extends Controller
         private EmailCaptureService $emailCaptures,
         private SkuCatalog $skus,
         private PaymentRouter $paymentRouter,
+        private MbtiAccessHubBuilder $mbtiAccessHubBuilder,
         private LemonSqueezyCheckoutService $lemonSqueezyCheckout,
         private WechatPayCheckoutService $wechatPayCheckout,
         private AlipayCheckoutService $alipayCheckout,
@@ -141,7 +144,7 @@ class CommerceController extends Controller
             ], 404);
         }
 
-        return response()->json([
+        $payload = [
             'ok' => true,
             'ownership_verified' => true,
             'order' => $order,
@@ -152,7 +155,14 @@ class CommerceController extends Controller
             'amount_cents' => $order->amount_cents ?? $order->amount_total ?? null,
             'currency' => $order->currency ?? null,
             'delivery' => $delivery['delivery'],
-        ]);
+        ];
+
+        $mbtiAccessHub = $this->mbtiAccessHubBuilder->buildForOrderContext($order);
+        if ($mbtiAccessHub !== null) {
+            $payload[ReportAccess::ACCESS_HUB_KEY] = $mbtiAccessHub;
+        }
+
+        return response()->json($payload);
     }
 
     /**
@@ -378,13 +388,20 @@ class CommerceController extends Controller
 
         $delivery = $this->buildOrderDelivery($order);
 
-        return response()->json([
+        $payload = [
             'ok' => true,
             'order_no' => $order->order_no ?? $orderNo,
             'status' => $this->normalizePublicOrderStatus((string) ($order->status ?? '')),
             'attempt_id' => $delivery['attempt_id'],
             'delivery' => $delivery['delivery'],
-        ]);
+        ];
+
+        $mbtiAccessHub = $this->mbtiAccessHubBuilder->buildForLookupHit($order);
+        if ($mbtiAccessHub !== null) {
+            $payload[ReportAccess::ACCESS_HUB_KEY] = $mbtiAccessHub;
+        }
+
+        return response()->json($payload);
     }
 
     /**

--- a/backend/app/Services/Commerce/MbtiAccessHubBuilder.php
+++ b/backend/app/Services/Commerce/MbtiAccessHubBuilder.php
@@ -1,0 +1,271 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\Commerce;
+
+use App\Models\Attempt;
+use App\Services\Report\ReportAccess;
+use Illuminate\Support\Facades\DB;
+
+final class MbtiAccessHubBuilder
+{
+    public function __construct(
+        private OrderManager $orders,
+    ) {}
+
+    /**
+     * @param  array<string,mixed>  $gate
+     * @return array<string,mixed>|null
+     */
+    public function buildForReportContext(Attempt $attempt, array $gate, ?string $userId, ?string $anonId): ?array
+    {
+        if (! $this->isMbtiScale($attempt->scale_code ?? null)) {
+            return null;
+        }
+
+        $attemptId = $this->stringOrNull($attempt->id ?? null);
+        $orgId = (int) ($attempt->org_id ?? 0);
+        $order = $attemptId !== null
+            ? $this->orders->findLatestAccessibleOrderForAttempt($orgId, $userId, $anonId, $attemptId)
+            : null;
+        $attribution = $order !== null ? $this->orders->extractAttributionFromOrder($order) : [];
+        $orderNo = $order !== null ? $this->stringOrNull($order->order_no ?? null) : null;
+        $delivery = $order !== null ? $this->presentDelivery($order) : $this->emptyDelivery();
+
+        $reportUrl = $this->attemptReportUrl($attemptId);
+        $reportPdfUrl = $this->attemptReportPdfUrl($attemptId);
+        $locked = (bool) ($gate['locked'] ?? false);
+
+        return [
+            'access_state' => $locked
+                ? ReportAccess::ACCESS_HUB_STATE_LOCKED
+                : ReportAccess::ACCESS_HUB_STATE_READY,
+            'report_access' => [
+                'can_view_report' => $reportUrl !== null,
+                'attempt_id' => $attemptId,
+                'order_no' => $orderNo,
+                'report_url' => $reportUrl,
+                'source' => $reportUrl !== null
+                    ? ReportAccess::ACCESS_HUB_SOURCE_REPORT_GATE
+                    : ReportAccess::ACCESS_HUB_SOURCE_NONE,
+            ],
+            'pdf_access' => [
+                'can_download_pdf' => ! $locked && $reportPdfUrl !== null,
+                'report_pdf_url' => $reportPdfUrl,
+                'source' => $reportPdfUrl !== null
+                    ? ReportAccess::ACCESS_HUB_SOURCE_ATTEMPT_PDF
+                    : ReportAccess::ACCESS_HUB_SOURCE_NONE,
+            ],
+            'recovery' => $this->buildRecoveryBlock(
+                $attemptId,
+                true,
+                (bool) ($delivery['can_request_claim_email'] ?? false),
+                (bool) ($delivery['can_resend'] ?? false),
+                $attribution
+            ),
+            'workspace_lite' => $this->buildWorkspaceLiteBlock($attemptId),
+        ];
+    }
+
+    /**
+     * @return array<string,mixed>|null
+     */
+    public function buildForOrderContext(object $order): ?array
+    {
+        return $this->buildForDeliveryContext($order);
+    }
+
+    /**
+     * @return array<string,mixed>|null
+     */
+    public function buildForLookupHit(object $order): ?array
+    {
+        return $this->buildForDeliveryContext($order);
+    }
+
+    /**
+     * @return array<string,mixed>|null
+     */
+    private function buildForDeliveryContext(object $order): ?array
+    {
+        $attemptId = $this->resolveMbtiAttemptIdForOrder($order);
+        if ($attemptId === null) {
+            return null;
+        }
+
+        $delivery = $this->presentDelivery($order);
+        $reportUrl = $this->stringOrNull($delivery['report_url'] ?? null);
+        $reportPdfUrl = $this->stringOrNull($delivery['report_pdf_url'] ?? null);
+        $canViewReport = (bool) ($delivery['can_view_report'] ?? false);
+        $canDownloadPdf = (bool) ($delivery['can_download_pdf'] ?? false);
+        $canRequestClaimEmail = (bool) ($delivery['can_request_claim_email'] ?? false);
+        $canResend = (bool) ($delivery['can_resend'] ?? false);
+        $attribution = $this->orders->extractAttributionFromOrder($order);
+
+        return [
+            'access_state' => $this->resolveDeliveryAccessState(
+                (string) ($order->status ?? ''),
+                $canViewReport,
+                $canRequestClaimEmail,
+                $canResend
+            ),
+            'report_access' => [
+                'can_view_report' => $canViewReport,
+                'attempt_id' => $attemptId,
+                'order_no' => $this->stringOrNull($order->order_no ?? null),
+                'report_url' => $reportUrl,
+                'source' => $reportUrl !== null
+                    ? ReportAccess::ACCESS_HUB_SOURCE_ORDER_DELIVERY
+                    : ReportAccess::ACCESS_HUB_SOURCE_NONE,
+            ],
+            'pdf_access' => [
+                'can_download_pdf' => $canDownloadPdf,
+                'report_pdf_url' => $reportPdfUrl,
+                'source' => $reportPdfUrl !== null
+                    ? ReportAccess::ACCESS_HUB_SOURCE_ORDER_DELIVERY
+                    : ReportAccess::ACCESS_HUB_SOURCE_NONE,
+            ],
+            'recovery' => $this->buildRecoveryBlock(
+                $attemptId,
+                true,
+                $canRequestClaimEmail,
+                $canResend,
+                $attribution
+            ),
+            'workspace_lite' => $this->buildWorkspaceLiteBlock($attemptId),
+        ];
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    private function buildRecoveryBlock(
+        ?string $attemptId,
+        bool $canLookupOrder,
+        bool $canRequestClaimEmail,
+        bool $canResend,
+        array $attribution
+    ): array {
+        return [
+            'can_lookup_order' => $canLookupOrder,
+            'can_request_claim_email' => $canRequestClaimEmail,
+            'can_resend' => $canResend,
+            'attempt_id' => $attemptId,
+            'share_id' => $this->stringOrNull($attribution['share_id'] ?? null),
+            'compare_invite_id' => $this->stringOrNull($attribution['compare_invite_id'] ?? null),
+        ];
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    private function buildWorkspaceLiteBlock(?string $attemptId): array
+    {
+        return [
+            'has_entry' => $attemptId !== null,
+            'entry_kind' => ReportAccess::ACCESS_HUB_ENTRY_KIND_MBTI_HISTORY,
+            'attempt_id' => $attemptId,
+        ];
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    private function presentDelivery(object $order): array
+    {
+        $delivery = $this->orders->presentOrderDelivery($order);
+
+        return is_array($delivery['delivery'] ?? null) ? $delivery['delivery'] : [];
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    private function emptyDelivery(): array
+    {
+        return [
+            'can_view_report' => false,
+            'report_url' => null,
+            'can_download_pdf' => false,
+            'report_pdf_url' => null,
+            'can_resend' => false,
+            'can_request_claim_email' => false,
+        ];
+    }
+
+    private function resolveDeliveryAccessState(
+        string $status,
+        bool $canViewReport,
+        bool $canRequestClaimEmail,
+        bool $canResend
+    ): string {
+        if ($canViewReport) {
+            return ReportAccess::ACCESS_HUB_STATE_READY;
+        }
+
+        if ($this->isPendingStatus($status)) {
+            return ReportAccess::ACCESS_HUB_STATE_PENDING;
+        }
+
+        if ($canRequestClaimEmail || $canResend) {
+            return ReportAccess::ACCESS_HUB_STATE_RECOVERY_AVAILABLE;
+        }
+
+        return ReportAccess::ACCESS_HUB_STATE_RECOVERY_AVAILABLE;
+    }
+
+    private function resolveMbtiAttemptIdForOrder(object $order): ?string
+    {
+        $attemptId = $this->stringOrNull($order->target_attempt_id ?? null);
+        if ($attemptId === null) {
+            return null;
+        }
+
+        $attempt = DB::table('attempts')
+            ->where('org_id', (int) ($order->org_id ?? 0))
+            ->where('id', $attemptId)
+            ->first(['id', 'scale_code']);
+
+        if (! $attempt || ! $this->isMbtiScale($attempt->scale_code ?? null)) {
+            return null;
+        }
+
+        return $this->stringOrNull($attempt->id ?? null);
+    }
+
+    private function attemptReportUrl(?string $attemptId): ?string
+    {
+        return $attemptId !== null
+            ? "/api/v0.3/attempts/{$attemptId}/report"
+            : null;
+    }
+
+    private function attemptReportPdfUrl(?string $attemptId): ?string
+    {
+        return $attemptId !== null
+            ? "/api/v0.3/attempts/{$attemptId}/report.pdf"
+            : null;
+    }
+
+    private function isPendingStatus(string $status): bool
+    {
+        return ! in_array(
+            strtolower(trim($status)),
+            ['paid', 'fulfilled', 'failed', 'canceled', 'cancelled', 'refunded'],
+            true
+        );
+    }
+
+    private function isMbtiScale(mixed $scaleCode): bool
+    {
+        return strtoupper(trim((string) $scaleCode)) === ReportAccess::SCALE_MBTI;
+    }
+
+    private function stringOrNull(mixed $value): ?string
+    {
+        $normalized = trim((string) $value);
+
+        return $normalized !== '' ? $normalized : null;
+    }
+}

--- a/backend/app/Services/Commerce/OrderManager.php
+++ b/backend/app/Services/Commerce/OrderManager.php
@@ -311,6 +311,48 @@ class OrderManager
             ->first();
     }
 
+    public function findLatestAccessibleOrderForAttempt(
+        int $orgId,
+        ?string $userId,
+        ?string $anonId,
+        string $attemptId
+    ): ?object {
+        $normalizedAttemptId = $this->trimOrNull($attemptId);
+        if ($normalizedAttemptId === null) {
+            return null;
+        }
+
+        $uid = $this->trimOrNull($userId);
+        $aid = $this->trimOrNull($anonId);
+        if ($uid === null && $aid === null) {
+            return null;
+        }
+
+        $query = DB::table('orders')
+            ->where('org_id', $orgId)
+            ->where('target_attempt_id', $normalizedAttemptId)
+            ->where(function ($scoped) use ($uid, $aid): void {
+                if ($uid !== null) {
+                    $scoped->orWhere('user_id', $uid);
+                }
+
+                if ($aid !== null) {
+                    $scoped->orWhere('anon_id', $aid);
+                }
+            })
+            ->orderByRaw("
+                case
+                    when lower(coalesce(status, '')) in ('paid', 'fulfilled') then 0
+                    when lower(coalesce(status, '')) in ('created', 'pending') then 1
+                    else 2
+                end
+            ")
+            ->orderByDesc('updated_at')
+            ->orderByDesc('created_at');
+
+        return $query->first();
+    }
+
     public function isPaidOrFulfilledStatus(?string $status): bool
     {
         return $this->isDeliveryEligibleStatus((string) $status);

--- a/backend/app/Services/Report/ReportAccess.php
+++ b/backend/app/Services/Report/ReportAccess.php
@@ -6,41 +6,88 @@ namespace App\Services\Report;
 
 final class ReportAccess
 {
+    public const ACCESS_HUB_KEY = 'mbti_access_hub_v1';
+
+    public const ACCESS_HUB_STATE_LOCKED = 'locked';
+
+    public const ACCESS_HUB_STATE_READY = 'ready';
+
+    public const ACCESS_HUB_STATE_PENDING = 'pending';
+
+    public const ACCESS_HUB_STATE_RECOVERY_AVAILABLE = 'recovery_available';
+
+    public const ACCESS_HUB_SOURCE_REPORT_GATE = 'report_gate';
+
+    public const ACCESS_HUB_SOURCE_ORDER_DELIVERY = 'order_delivery';
+
+    public const ACCESS_HUB_SOURCE_ATTEMPT_PDF = 'attempt_pdf';
+
+    public const ACCESS_HUB_SOURCE_NONE = 'none';
+
+    public const ACCESS_HUB_ENTRY_KIND_MBTI_HISTORY = 'mbti_history';
+
     public const SCALE_MBTI = 'MBTI';
+
     public const SCALE_BIG5_OCEAN = 'BIG5_OCEAN';
+
     public const SCALE_CLINICAL_COMBO_68 = 'CLINICAL_COMBO_68';
+
     public const SCALE_SDS_20 = 'SDS_20';
+
     public const SCALE_EQ_60 = 'EQ_60';
 
     public const VARIANT_FREE = 'free';
+
     public const VARIANT_FULL = 'full';
 
     public const REPORT_ACCESS_FREE = 'free';
+
     public const REPORT_ACCESS_FULL = 'full';
 
     public const CARD_ACCESS_FREE = 'free';
+
     public const CARD_ACCESS_PREVIEW = 'preview';
+
     public const CARD_ACCESS_PAID = 'paid';
 
     public const MODULE_CORE_FREE = 'core_free';
+
     public const MODULE_CORE_FULL = 'core_full';
+
     public const MODULE_CAREER = 'career';
+
     public const MODULE_RELATIONSHIPS = 'relationships';
+
     public const MODULE_BIG5_CORE = 'big5_core';
+
     public const MODULE_BIG5_FULL = 'big5_full';
+
     public const MODULE_BIG5_ACTION_PLAN = 'big5_action_plan';
+
     public const MODULE_CLINICAL_CORE = 'clinical_core';
+
     public const MODULE_CLINICAL_FULL = 'clinical_full';
+
     public const MODULE_CLINICAL_RESILIENCE = 'clinical_resilience';
+
     public const MODULE_CLINICAL_PERFECTIONISM = 'clinical_perfectionism';
+
     public const MODULE_CLINICAL_ACTION_PLAN = 'clinical_action_plan';
+
     public const MODULE_SDS_CORE = 'sds_core';
+
     public const MODULE_SDS_FULL = 'sds_full';
+
     public const MODULE_SDS_FACTOR_DEEPDIVE = 'sds_factor_deepdive';
+
     public const MODULE_SDS_ACTION_PLAN = 'sds_action_plan';
+
     public const MODULE_EQ_CORE = 'eq_core';
+
     public const MODULE_EQ_FULL = 'eq_full';
+
     public const MODULE_EQ_CROSS_INSIGHTS = 'eq_cross_insights';
+
     public const MODULE_EQ_GROWTH_PLAN = 'eq_growth_plan';
 
     /**

--- a/backend/tests/Feature/V0_3/CommerceOrderLookupSecurityTest.php
+++ b/backend/tests/Feature/V0_3/CommerceOrderLookupSecurityTest.php
@@ -68,6 +68,44 @@ final class CommerceOrderLookupSecurityTest extends TestCase
             ->assertJsonPath('delivery.can_request_claim_email', true);
     }
 
+    public function test_lookup_with_matching_email_hash_returns_mbti_access_hub_for_mbti_attempt(): void
+    {
+        $orderNo = 'ord_lookup_mbti_'.Str::lower(Str::random(8));
+        $userId = $this->createUser('owner@example.com');
+        $attemptId = (string) Str::uuid();
+        $compareInviteId = (string) Str::uuid();
+        $this->insertAttempt($attemptId, self::ANON_OWNER, (string) $userId, 'MBTI');
+        $this->insertOrderForLookup($orderNo, 'owner@example.com', $attemptId, 'paid', (string) $userId, [
+            'attribution' => [
+                'share_id' => 'share_001',
+                'compare_invite_id' => $compareInviteId,
+            ],
+        ]);
+
+        $response = $this->postJson('/api/v0.3/orders/lookup', [
+            'order_no' => $orderNo,
+            'email' => 'owner@example.com',
+        ]);
+
+        $response->assertStatus(200)
+            ->assertJsonPath('mbti_access_hub_v1.access_state', 'ready')
+            ->assertJsonPath('mbti_access_hub_v1.report_access.can_view_report', true)
+            ->assertJsonPath('mbti_access_hub_v1.report_access.attempt_id', $attemptId)
+            ->assertJsonPath('mbti_access_hub_v1.report_access.order_no', $orderNo)
+            ->assertJsonPath('mbti_access_hub_v1.report_access.source', 'order_delivery')
+            ->assertJsonPath('mbti_access_hub_v1.pdf_access.can_download_pdf', true)
+            ->assertJsonPath('mbti_access_hub_v1.pdf_access.source', 'order_delivery')
+            ->assertJsonPath('mbti_access_hub_v1.recovery.can_lookup_order', true)
+            ->assertJsonPath('mbti_access_hub_v1.recovery.can_request_claim_email', true)
+            ->assertJsonPath('mbti_access_hub_v1.recovery.can_resend', true)
+            ->assertJsonPath('mbti_access_hub_v1.recovery.attempt_id', $attemptId)
+            ->assertJsonPath('mbti_access_hub_v1.recovery.share_id', 'share_001')
+            ->assertJsonPath('mbti_access_hub_v1.recovery.compare_invite_id', $compareInviteId)
+            ->assertJsonPath('mbti_access_hub_v1.workspace_lite.has_entry', true)
+            ->assertJsonPath('mbti_access_hub_v1.workspace_lite.entry_kind', 'mbti_history')
+            ->assertJsonPath('mbti_access_hub_v1.workspace_lite.attempt_id', $attemptId);
+    }
+
     public function test_lookup_with_token_owner_works_without_email(): void
     {
         $orderNo = 'ord_lookup_'.Str::lower(Str::random(8));
@@ -147,15 +185,19 @@ final class CommerceOrderLookupSecurityTest extends TestCase
         return $token;
     }
 
-    private function insertAttempt(string $attemptId, string $anonId, ?string $userId = null): void
-    {
+    private function insertAttempt(
+        string $attemptId,
+        string $anonId,
+        ?string $userId = null,
+        string $scaleCode = 'BIG5_OCEAN'
+    ): void {
         DB::table('attempts')->insert([
             'id' => $attemptId,
             'ticket_code' => 'FMT-'.strtoupper(substr(str_replace('-', '', $attemptId), 0, 8)),
             'org_id' => 0,
             'user_id' => $userId,
             'anon_id' => $anonId,
-            'scale_code' => 'BIG5_OCEAN',
+            'scale_code' => $scaleCode,
             'scale_version' => 'v0.3',
             'region' => 'CN_MAINLAND',
             'locale' => 'zh-CN',
@@ -180,7 +222,8 @@ final class CommerceOrderLookupSecurityTest extends TestCase
         string $email,
         ?string $attemptId = null,
         string $status = 'created',
-        ?string $userId = null
+        ?string $userId = null,
+        ?array $meta = null
     ): void {
         $now = now();
         $row = [
@@ -206,7 +249,9 @@ final class CommerceOrderLookupSecurityTest extends TestCase
             $row['contact_email_hash'] = hash('sha256', mb_strtolower(trim($email), 'UTF-8'));
         }
         if (Schema::hasColumn('orders', 'meta_json')) {
-            $row['meta_json'] = null;
+            $row['meta_json'] = $meta !== null
+                ? json_encode($meta, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES)
+                : null;
         }
         if (Schema::hasColumn('orders', 'amount_total')) {
             $row['amount_total'] = 1990;

--- a/backend/tests/Feature/V0_3/CommerceOrderReadFallbackTest.php
+++ b/backend/tests/Feature/V0_3/CommerceOrderReadFallbackTest.php
@@ -71,6 +71,37 @@ final class CommerceOrderReadFallbackTest extends TestCase
             ->assertJsonPath('delivery.can_resend', false);
     }
 
+    public function test_matching_token_identity_returns_mbti_access_hub_for_mbti_attempt(): void
+    {
+        $orderNo = 'ord_fallback_mbti_'.Str::lower(Str::random(10));
+        $attemptId = (string) Str::uuid();
+        $this->insertAttempt($attemptId, self::ANON_OWNER, 'MBTI');
+        $this->insertOrderForOwner($orderNo, $attemptId, 'paid');
+
+        $token = $this->issueAnonToken(self::ANON_OWNER);
+        $response = $this->withHeaders([
+            'Authorization' => 'Bearer '.$token,
+        ])->getJson('/api/v0.3/orders/'.$orderNo);
+
+        $response->assertStatus(200)
+            ->assertJsonPath('mbti_access_hub_v1.access_state', 'ready')
+            ->assertJsonPath('mbti_access_hub_v1.report_access.can_view_report', true)
+            ->assertJsonPath('mbti_access_hub_v1.report_access.attempt_id', $attemptId)
+            ->assertJsonPath('mbti_access_hub_v1.report_access.order_no', $orderNo)
+            ->assertJsonPath('mbti_access_hub_v1.report_access.report_url', "/api/v0.3/attempts/{$attemptId}/report")
+            ->assertJsonPath('mbti_access_hub_v1.report_access.source', 'order_delivery')
+            ->assertJsonPath('mbti_access_hub_v1.pdf_access.can_download_pdf', true)
+            ->assertJsonPath('mbti_access_hub_v1.pdf_access.report_pdf_url', "/api/v0.3/attempts/{$attemptId}/report.pdf")
+            ->assertJsonPath('mbti_access_hub_v1.pdf_access.source', 'order_delivery')
+            ->assertJsonPath('mbti_access_hub_v1.recovery.can_lookup_order', true)
+            ->assertJsonPath('mbti_access_hub_v1.recovery.can_request_claim_email', false)
+            ->assertJsonPath('mbti_access_hub_v1.recovery.can_resend', false)
+            ->assertJsonPath('mbti_access_hub_v1.recovery.attempt_id', $attemptId)
+            ->assertJsonPath('mbti_access_hub_v1.workspace_lite.has_entry', true)
+            ->assertJsonPath('mbti_access_hub_v1.workspace_lite.entry_kind', 'mbti_history')
+            ->assertJsonPath('mbti_access_hub_v1.workspace_lite.attempt_id', $attemptId);
+    }
+
     private function issueAnonToken(string $anonId): string
     {
         $token = 'fm_'.(string) Str::uuid();
@@ -106,7 +137,7 @@ final class CommerceOrderReadFallbackTest extends TestCase
         return $token;
     }
 
-    private function insertAttempt(string $attemptId, string $anonId): void
+    private function insertAttempt(string $attemptId, string $anonId, string $scaleCode = 'BIG5_OCEAN'): void
     {
         DB::table('attempts')->insert([
             'id' => $attemptId,
@@ -114,7 +145,7 @@ final class CommerceOrderReadFallbackTest extends TestCase
             'org_id' => 0,
             'user_id' => null,
             'anon_id' => $anonId,
-            'scale_code' => 'BIG5_OCEAN',
+            'scale_code' => $scaleCode,
             'scale_version' => 'v0.3',
             'region' => 'CN_MAINLAND',
             'locale' => 'zh-CN',

--- a/backend/tests/Feature/V0_3/MbtiReportHttpContractRegressionTest.php
+++ b/backend/tests/Feature/V0_3/MbtiReportHttpContractRegressionTest.php
@@ -139,6 +139,22 @@ final class MbtiReportHttpContractRegressionTest extends TestCase
             'ENFP',
             'T'
         );
+        $resp->assertJsonPath('mbti_access_hub_v1.access_state', 'locked')
+            ->assertJsonPath('mbti_access_hub_v1.report_access.can_view_report', true)
+            ->assertJsonPath('mbti_access_hub_v1.report_access.attempt_id', $attemptId)
+            ->assertJsonPath('mbti_access_hub_v1.report_access.order_no', null)
+            ->assertJsonPath('mbti_access_hub_v1.report_access.report_url', "/api/v0.3/attempts/{$attemptId}/report")
+            ->assertJsonPath('mbti_access_hub_v1.report_access.source', 'report_gate')
+            ->assertJsonPath('mbti_access_hub_v1.pdf_access.can_download_pdf', false)
+            ->assertJsonPath('mbti_access_hub_v1.pdf_access.report_pdf_url', "/api/v0.3/attempts/{$attemptId}/report.pdf")
+            ->assertJsonPath('mbti_access_hub_v1.pdf_access.source', 'attempt_pdf')
+            ->assertJsonPath('mbti_access_hub_v1.recovery.can_lookup_order', true)
+            ->assertJsonPath('mbti_access_hub_v1.recovery.can_request_claim_email', false)
+            ->assertJsonPath('mbti_access_hub_v1.recovery.can_resend', false)
+            ->assertJsonPath('mbti_access_hub_v1.recovery.attempt_id', $attemptId)
+            ->assertJsonPath('mbti_access_hub_v1.workspace_lite.has_entry', true)
+            ->assertJsonPath('mbti_access_hub_v1.workspace_lite.entry_kind', 'mbti_history')
+            ->assertJsonPath('mbti_access_hub_v1.workspace_lite.attempt_id', $attemptId);
     }
 
     public function test_unlocked_paid_mbti_report_http_contract_keeps_section_gate_semantics(): void
@@ -194,6 +210,22 @@ final class MbtiReportHttpContractRegressionTest extends TestCase
             'INTJ',
             'A'
         );
+        $resp->assertJsonPath('mbti_access_hub_v1.access_state', 'ready')
+            ->assertJsonPath('mbti_access_hub_v1.report_access.can_view_report', true)
+            ->assertJsonPath('mbti_access_hub_v1.report_access.attempt_id', $attemptId)
+            ->assertJsonPath('mbti_access_hub_v1.report_access.order_no', null)
+            ->assertJsonPath('mbti_access_hub_v1.report_access.report_url', "/api/v0.3/attempts/{$attemptId}/report")
+            ->assertJsonPath('mbti_access_hub_v1.report_access.source', 'report_gate')
+            ->assertJsonPath('mbti_access_hub_v1.pdf_access.can_download_pdf', true)
+            ->assertJsonPath('mbti_access_hub_v1.pdf_access.report_pdf_url', "/api/v0.3/attempts/{$attemptId}/report.pdf")
+            ->assertJsonPath('mbti_access_hub_v1.pdf_access.source', 'attempt_pdf')
+            ->assertJsonPath('mbti_access_hub_v1.recovery.can_lookup_order', true)
+            ->assertJsonPath('mbti_access_hub_v1.recovery.can_request_claim_email', false)
+            ->assertJsonPath('mbti_access_hub_v1.recovery.can_resend', false)
+            ->assertJsonPath('mbti_access_hub_v1.recovery.attempt_id', $attemptId)
+            ->assertJsonPath('mbti_access_hub_v1.workspace_lite.has_entry', true)
+            ->assertJsonPath('mbti_access_hub_v1.workspace_lite.entry_kind', 'mbti_history')
+            ->assertJsonPath('mbti_access_hub_v1.workspace_lite.attempt_id', $attemptId);
     }
 
     private function assertStableMbtiEnvelope(TestResponse $response): void
@@ -223,6 +255,7 @@ final class MbtiReportHttpContractRegressionTest extends TestCase
             'scale_code_v2',
             'scale_uid',
             'cta',
+            'mbti_access_hub_v1',
         ] as $key) {
             $this->assertArrayHasKey($key, $payload);
         }
@@ -250,6 +283,63 @@ final class MbtiReportHttpContractRegressionTest extends TestCase
 
         $this->assertStableCtaShape((array) $payload['cta']);
         $this->assertStableMbtiReportShape((array) $payload['report']);
+        $this->assertStableMbtiAccessHubShape((array) $payload['mbti_access_hub_v1']);
+    }
+
+    /**
+     * @param  array<string,mixed>  $hub
+     */
+    private function assertStableMbtiAccessHubShape(array $hub): void
+    {
+        foreach ([
+            'access_state',
+            'report_access',
+            'pdf_access',
+            'recovery',
+            'workspace_lite',
+        ] as $key) {
+            $this->assertArrayHasKey($key, $hub);
+        }
+
+        $this->assertContains((string) ($hub['access_state'] ?? ''), ['locked', 'ready', 'pending', 'recovery_available']);
+
+        $reportAccess = (array) ($hub['report_access'] ?? []);
+        foreach (['can_view_report', 'attempt_id', 'order_no', 'report_url', 'source'] as $key) {
+            $this->assertArrayHasKey($key, $reportAccess);
+        }
+        $this->assertTrue($reportAccess['attempt_id'] === null || is_string($reportAccess['attempt_id']));
+        $this->assertTrue($reportAccess['order_no'] === null || is_string($reportAccess['order_no']));
+        $this->assertTrue($reportAccess['report_url'] === null || is_string($reportAccess['report_url']));
+        $this->assertContains((string) ($reportAccess['source'] ?? ''), ['report_gate', 'order_delivery', 'none']);
+
+        $pdfAccess = (array) ($hub['pdf_access'] ?? []);
+        foreach (['can_download_pdf', 'report_pdf_url', 'source'] as $key) {
+            $this->assertArrayHasKey($key, $pdfAccess);
+        }
+        $this->assertTrue($pdfAccess['report_pdf_url'] === null || is_string($pdfAccess['report_pdf_url']));
+        $this->assertContains((string) ($pdfAccess['source'] ?? ''), ['attempt_pdf', 'order_delivery', 'none']);
+
+        $recovery = (array) ($hub['recovery'] ?? []);
+        foreach ([
+            'can_lookup_order',
+            'can_request_claim_email',
+            'can_resend',
+            'attempt_id',
+            'share_id',
+            'compare_invite_id',
+        ] as $key) {
+            $this->assertArrayHasKey($key, $recovery);
+        }
+        $this->assertTrue($recovery['attempt_id'] === null || is_string($recovery['attempt_id']));
+        $this->assertTrue($recovery['share_id'] === null || is_string($recovery['share_id']));
+        $this->assertTrue($recovery['compare_invite_id'] === null || is_string($recovery['compare_invite_id']));
+
+        $workspaceLite = (array) ($hub['workspace_lite'] ?? []);
+        foreach (['has_entry', 'entry_kind', 'attempt_id'] as $key) {
+            $this->assertArrayHasKey($key, $workspaceLite);
+        }
+        $this->assertSame('mbti_history', $workspaceLite['entry_kind'] ?? null);
+        $this->assertTrue($workspaceLite['attempt_id'] === null || is_string($workspaceLite['attempt_id']));
     }
 
     /**


### PR DESCRIPTION
## Summary
This PR adds `mbti_access_hub_v1` as a single additive backend contract for the MBTI access hub work in PR-8A. The goal is to stop forcing the frontend to reconcile three different authorities on its own: the report gate on `/attempts/{id}/report`, the attempt-PDF authority on `/attempts/{id}/report.pdf`, and the order delivery / lookup recovery authority on `/orders/{orderNo}` and `/orders/lookup`.

The new contract is intentionally additive. It does not replace or reshape the existing `offers`, `cta`, `view_policy`, `modules_*`, `delivery`, `claim`, or checkout responses. Instead, it composes the existing backend truths into one stable envelope that PR-8B can wire against without changing routes or inventing frontend-only authority.

## Root Cause
The MBTI paid lifecycle already existed, but authority was split across multiple backend contracts:

- report access came from the report gate payload
- PDF access on result pages came from the attempt PDF endpoint
- delivery, resend, and recovery came from order read / lookup delivery state
- workspace-lite entry did not exist as a unified backend concept at all

That split made the frontend responsible for stitching together incompatible sources and implicitly guessing which authority should drive post-purchase actions.

## Fix
This PR introduces `backend/app/Services/Commerce/MbtiAccessHubBuilder.php` as the only owner for `mbti_access_hub_v1` composition.

The builder now constructs a stable hub with four areas:

- `report_access`
- `pdf_access`
- `recovery`
- `workspace_lite`

The contract is now attached additively to these existing endpoints only:

- `GET /api/v0.3/attempts/{id}/report`
- `GET /api/v0.3/orders/{orderNo}`
- `POST /api/v0.3/orders/lookup`

Key rules preserved in this implementation:

- `report_access.report_url` continues to reuse the existing attempt report entry
- `pdf_access.report_pdf_url` exposes one stable field while still distinguishing source via `attempt_pdf` vs `order_delivery`
- `workspace_lite.entry_kind` is fixed to `mbti_history`
- no route signatures changed
- no migrations or schema changes were introduced
- no pricing fields, Team/Pro/org/credits fields, or frontend wiring were added

## Tests
Validated with:

- `php artisan route:list | grep -Ei "orders|checkout|attempts/.+report|claim|email|lookup|shares|compare"`
- `php artisan fap:schema:verify`
- `vendor/bin/phpunit tests/Feature/V0_3/MbtiReportHttpContractRegressionTest.php tests/Feature/V0_3/CommerceOrderReadFallbackTest.php tests/Feature/V0_3/CommerceOrderLookupSecurityTest.php tests/Feature/V0_3/ClaimReportEmailRequestTest.php`
- `git diff --name-only -- routes/api.php database`

The regression coverage was extended inside existing MBTI report, order read, and lookup contract tests instead of adding new test shells.
