### PR TITLE
[codex] feat(api): import full 32-type MBTI variant authority and lock 16-type public SEO/sitemap policy

### DIFF
--- a/backend/app/Console/Commands/PersonalityImportLocalBaseline.php
+++ b/backend/app/Console/Commands/PersonalityImportLocalBaseline.php
@@ -65,10 +65,16 @@ final class PersonalityImportLocalBaseline extends Command
             $this->line('upsert='.((bool) $this->option('upsert') ? '1' : '0'));
             $this->line('status_mode='.$status);
             $this->line('profiles_found='.(string) $summary['profiles_found']);
+            $this->line('variants_found='.(string) $summary['variants_found']);
             $this->line('will_create='.(string) $summary['will_create']);
             $this->line('will_update='.(string) $summary['will_update']);
             $this->line('will_skip='.(string) $summary['will_skip']);
             $this->line('revisions_to_create='.(string) $summary['revisions_to_create']);
+            $this->line('variant_will_create='.(string) $summary['variant_will_create']);
+            $this->line('variant_will_update='.(string) $summary['variant_will_update']);
+            $this->line('variant_will_skip='.(string) $summary['variant_will_skip']);
+            $this->line('variant_will_delete='.(string) $summary['variant_will_delete']);
+            $this->line('variant_revisions_to_create='.(string) $summary['variant_revisions_to_create']);
             $this->line('errors_count='.(string) $summary['errors_count']);
 
             $this->info((bool) $this->option('dry-run') ? 'dry-run complete' : 'import complete');

--- a/backend/app/PersonalityCms/Baseline/PersonalityBaselineImporter.php
+++ b/backend/app/PersonalityCms/Baseline/PersonalityBaselineImporter.php
@@ -8,6 +8,11 @@ use App\Models\PersonalityProfile;
 use App\Models\PersonalityProfileRevision;
 use App\Models\PersonalityProfileSection;
 use App\Models\PersonalityProfileSeoMeta;
+use App\Models\PersonalityProfileVariant;
+use App\Models\PersonalityProfileVariantRevision;
+use App\Models\PersonalityProfileVariantSection;
+use App\Models\PersonalityProfileVariantSeoMeta;
+use App\Support\Mbti\MbtiCanonicalSectionRegistry;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Support\Carbon;
 use Illuminate\Support\Facades\DB;
@@ -31,10 +36,19 @@ final class PersonalityBaselineImporter
 
         $summary = [
             'profiles_found' => count($profiles),
+            'variants_found' => array_sum(array_map(
+                static fn (array $profilePayload): int => count((array) ($profilePayload['variants'] ?? [])),
+                $profiles,
+            )),
             'will_create' => 0,
             'will_update' => 0,
             'will_skip' => 0,
             'revisions_to_create' => 0,
+            'variant_will_create' => 0,
+            'variant_will_update' => 0,
+            'variant_will_skip' => 0,
+            'variant_will_delete' => 0,
+            'variant_revisions_to_create' => 0,
             'errors_count' => 0,
             'dry_run' => $dryRun,
             'upsert' => $upsert,
@@ -52,6 +66,7 @@ final class PersonalityBaselineImporter
             if (! $existing instanceof PersonalityProfile) {
                 $summary['will_create']++;
                 $summary['revisions_to_create']++;
+                $this->mergeVariantSummary($summary, $this->calculateVariantSummary(null, $profilePayload, $status, true));
 
                 if (! $dryRun) {
                     DB::transaction(function () use ($profilePayload, $status): void {
@@ -62,6 +77,7 @@ final class PersonalityBaselineImporter
                         $this->syncSections($profile, $profilePayload, false);
                         $this->syncSeoMeta($profile, $profilePayload);
                         $this->createRevision($profile, 'baseline import');
+                        $this->syncVariants($profile, $profilePayload, $status, true);
                     });
                 }
 
@@ -70,30 +86,45 @@ final class PersonalityBaselineImporter
 
             if (! $upsert) {
                 $summary['will_skip']++;
+                $this->mergeVariantSummary($summary, $this->calculateVariantSummary($existing, $profilePayload, $status, false));
 
                 continue;
             }
 
             $desiredState = $this->desiredComparableState($profilePayload, $status, $existing);
             $currentState = $this->currentComparableState($existing);
+            $baseChanged = $desiredState !== $currentState;
+            $variantSummary = $this->calculateVariantSummary($existing, $profilePayload, $status, true);
 
-            if ($desiredState === $currentState) {
+            if (! $baseChanged
+                && (int) $variantSummary['variant_will_create'] === 0
+                && (int) $variantSummary['variant_will_update'] === 0
+                && (int) $variantSummary['variant_will_delete'] === 0) {
                 $summary['will_skip']++;
+                $this->mergeVariantSummary($summary, $variantSummary);
 
                 continue;
             }
 
-            $summary['will_update']++;
-            $summary['revisions_to_create']++;
+            if ($baseChanged) {
+                $summary['will_update']++;
+                $summary['revisions_to_create']++;
+            }
+
+            $this->mergeVariantSummary($summary, $variantSummary);
 
             if (! $dryRun) {
-                DB::transaction(function () use ($existing, $profilePayload, $status): void {
-                    $existing->fill($this->profileAttributes($profilePayload, $status, $existing));
-                    $existing->save();
+                DB::transaction(function () use ($existing, $profilePayload, $status, $baseChanged): void {
+                    if ($baseChanged) {
+                        $existing->fill($this->profileAttributes($profilePayload, $status, $existing));
+                        $existing->save();
 
-                    $this->syncSections($existing, $profilePayload, true);
-                    $this->syncSeoMeta($existing, $profilePayload);
-                    $this->createRevision($existing, 'baseline upsert');
+                        $this->syncSections($existing, $profilePayload, true);
+                        $this->syncSeoMeta($existing, $profilePayload);
+                        $this->createRevision($existing, 'baseline upsert');
+                    }
+
+                    $this->syncVariants($existing, $profilePayload, $status, true);
                 });
             }
         }
@@ -121,13 +152,20 @@ final class PersonalityBaselineImporter
             'org_id' => 0,
             'scale_code' => PersonalityProfile::SCALE_CODE_MBTI,
             'type_code' => (string) $profilePayload['type_code'],
+            'canonical_type_code' => (string) ($profilePayload['canonical_type_code'] ?? $profilePayload['type_code']),
             'slug' => (string) $profilePayload['slug'],
             'locale' => (string) $profilePayload['locale'],
             'title' => (string) $profilePayload['title'],
+            'type_name' => $profilePayload['type_name'],
+            'nickname' => $profilePayload['nickname'],
+            'rarity_text' => $profilePayload['rarity_text'],
+            'keywords_json' => $profilePayload['keywords_json'],
             'subtitle' => $profilePayload['subtitle'],
             'excerpt' => $profilePayload['excerpt'],
             'hero_kicker' => $profilePayload['hero_kicker'],
             'hero_quote' => $profilePayload['hero_quote'],
+            'hero_summary_md' => $profilePayload['hero_summary_md'],
+            'hero_summary_html' => $profilePayload['hero_summary_html'],
             'hero_image_url' => $profilePayload['hero_image_url'],
             'status' => $status,
             'is_public' => (bool) $profilePayload['is_public'],
@@ -136,7 +174,7 @@ final class PersonalityBaselineImporter
             'scheduled_at' => $status === 'draft'
                 ? null
                 : $this->normalizeNullableDate($profilePayload['scheduled_at'] ?? null),
-            'schema_version' => (string) ($profilePayload['schema_version'] ?? 'v1'),
+            'schema_version' => (string) ($profilePayload['schema_version'] ?? PersonalityProfile::SCHEMA_VERSION_V2),
         ];
     }
 
@@ -170,17 +208,15 @@ final class PersonalityBaselineImporter
         }
 
         if ($fullSync) {
-            $managedKeys = array_values(array_intersect(
-                array_keys($desiredSections),
-                PersonalityProfileSection::SECTION_KEYS,
-            ));
+            $managedKeys = $this->managedBaseSectionKeys();
+            $keepKeys = array_values(array_intersect(array_keys($desiredSections), $managedKeys));
 
             $deleteQuery = PersonalityProfileSection::query()
                 ->where('profile_id', (int) $profile->id)
-                ->whereIn('section_key', PersonalityProfileSection::SECTION_KEYS);
+                ->whereIn('section_key', $managedKeys);
 
-            if ($managedKeys !== []) {
-                $deleteQuery->whereNotIn('section_key', $managedKeys);
+            if ($keepKeys !== []) {
+                $deleteQuery->whereNotIn('section_key', $keepKeys);
             }
 
             $deleteQuery->delete();
@@ -264,13 +300,20 @@ final class PersonalityBaselineImporter
                 'org_id' => 0,
                 'scale_code' => PersonalityProfile::SCALE_CODE_MBTI,
                 'type_code' => (string) $profilePayload['type_code'],
+                'canonical_type_code' => (string) ($profilePayload['canonical_type_code'] ?? $profilePayload['type_code']),
                 'slug' => (string) $profilePayload['slug'],
                 'locale' => (string) $profilePayload['locale'],
                 'title' => (string) $profilePayload['title'],
+                'type_name' => $profilePayload['type_name'],
+                'nickname' => $profilePayload['nickname'],
+                'rarity_text' => $profilePayload['rarity_text'],
+                'keywords_json' => $profilePayload['keywords_json'],
                 'subtitle' => $profilePayload['subtitle'],
                 'excerpt' => $profilePayload['excerpt'],
                 'hero_kicker' => $profilePayload['hero_kicker'],
                 'hero_quote' => $profilePayload['hero_quote'],
+                'hero_summary_md' => $profilePayload['hero_summary_md'],
+                'hero_summary_html' => $profilePayload['hero_summary_html'],
                 'hero_image_url' => $profilePayload['hero_image_url'],
                 'status' => $status,
                 'is_public' => (bool) $profilePayload['is_public'],
@@ -281,7 +324,7 @@ final class PersonalityBaselineImporter
                 'scheduled_at' => $status === 'draft'
                     ? null
                     : $this->normalizeDateForComparison($this->normalizeNullableDate($profilePayload['scheduled_at'] ?? null)),
-                'schema_version' => (string) ($profilePayload['schema_version'] ?? 'v1'),
+                'schema_version' => (string) ($profilePayload['schema_version'] ?? PersonalityProfile::SCHEMA_VERSION_V2),
             ],
             'sections' => $sections,
             'seo_meta' => (array) $profilePayload['seo_meta'],
@@ -300,13 +343,20 @@ final class PersonalityBaselineImporter
                 'org_id' => (int) $profile->org_id,
                 'scale_code' => (string) $profile->scale_code,
                 'type_code' => (string) $profile->type_code,
+                'canonical_type_code' => (string) ($profile->canonical_type_code ?: $profile->type_code),
                 'slug' => (string) $profile->slug,
                 'locale' => (string) $profile->locale,
                 'title' => (string) $profile->title,
+                'type_name' => $profile->type_name,
+                'nickname' => $profile->nickname,
+                'rarity_text' => $profile->rarity_text,
+                'keywords_json' => is_array($profile->keywords_json) ? array_values($profile->keywords_json) : [],
                 'subtitle' => $profile->subtitle,
                 'excerpt' => $profile->excerpt,
                 'hero_kicker' => $profile->hero_kicker,
                 'hero_quote' => $profile->hero_quote,
+                'hero_summary_md' => $profile->hero_summary_md,
+                'hero_summary_html' => $profile->hero_summary_html,
                 'hero_image_url' => $profile->hero_image_url,
                 'status' => (string) $profile->status,
                 'is_public' => (bool) $profile->is_public,
@@ -346,19 +396,388 @@ final class PersonalityBaselineImporter
                     'robots' => $profile->seoMeta->robots,
                     'jsonld_overrides_json' => $profile->seoMeta->jsonld_overrides_json,
                 ]
-                : [
-                    'seo_title' => null,
-                    'seo_description' => null,
-                    'canonical_url' => null,
-                    'og_title' => null,
-                    'og_description' => null,
-                    'og_image_url' => null,
-                    'twitter_title' => null,
-                    'twitter_description' => null,
-                    'twitter_image_url' => null,
-                    'robots' => null,
-                    'jsonld_overrides_json' => null,
+                : $this->emptySeoMeta(),
+        ];
+    }
+
+    /**
+     * @param  array<string, mixed>  $profilePayload
+     * @return array<string, int>
+     */
+    private function calculateVariantSummary(
+        ?PersonalityProfile $profile,
+        array $profilePayload,
+        string $status,
+        bool $allowUpdates,
+    ): array {
+        $summary = [
+            'variant_will_create' => 0,
+            'variant_will_update' => 0,
+            'variant_will_skip' => 0,
+            'variant_will_delete' => 0,
+            'variant_revisions_to_create' => 0,
+        ];
+
+        $desiredVariants = (array) ($profilePayload['variants'] ?? []);
+        if (! $profile instanceof PersonalityProfile) {
+            $count = count($desiredVariants);
+
+            return [
+                'variant_will_create' => $count,
+                'variant_will_update' => 0,
+                'variant_will_skip' => 0,
+                'variant_will_delete' => 0,
+                'variant_revisions_to_create' => $count,
+            ];
+        }
+
+        $existingVariants = PersonalityProfileVariant::query()
+            ->where('personality_profile_id', (int) $profile->id)
+            ->with(['sections', 'seoMeta'])
+            ->get()
+            ->keyBy(static fn (PersonalityProfileVariant $variant): string => (string) $variant->runtime_type_code);
+
+        $desiredRuntimeCodes = [];
+
+        foreach ($desiredVariants as $variantPayload) {
+            $runtimeTypeCode = (string) $variantPayload['runtime_type_code'];
+            $desiredRuntimeCodes[] = $runtimeTypeCode;
+            $existing = $existingVariants->get($runtimeTypeCode);
+
+            if (! $existing instanceof PersonalityProfileVariant) {
+                $summary['variant_will_create']++;
+                $summary['variant_revisions_to_create']++;
+
+                continue;
+            }
+
+            if (! $allowUpdates) {
+                $summary['variant_will_skip']++;
+
+                continue;
+            }
+
+            $desiredState = $this->desiredComparableVariantState($variantPayload, $status, $existing);
+            $currentState = $this->currentComparableVariantState($existing);
+
+            if ($desiredState === $currentState) {
+                $summary['variant_will_skip']++;
+
+                continue;
+            }
+
+            $summary['variant_will_update']++;
+            $summary['variant_revisions_to_create']++;
+        }
+
+        if ($allowUpdates) {
+            $summary['variant_will_delete'] += $existingVariants
+                ->keys()
+                ->diff($desiredRuntimeCodes)
+                ->count();
+        }
+
+        return $summary;
+    }
+
+    /**
+     * @param  array<string, int|string|bool>  $summary
+     * @param  array<string, int>  $variantSummary
+     */
+    private function mergeVariantSummary(array &$summary, array $variantSummary): void
+    {
+        foreach ($variantSummary as $key => $value) {
+            $summary[$key] = (int) $summary[$key] + (int) $value;
+        }
+    }
+
+    /**
+     * @param  array<string, mixed>  $profilePayload
+     */
+    private function syncVariants(
+        PersonalityProfile $profile,
+        array $profilePayload,
+        string $status,
+        bool $allowUpdates,
+    ): void {
+        $desiredVariants = (array) ($profilePayload['variants'] ?? []);
+        $existingVariants = PersonalityProfileVariant::query()
+            ->where('personality_profile_id', (int) $profile->id)
+            ->with(['sections', 'seoMeta'])
+            ->get()
+            ->keyBy(static fn (PersonalityProfileVariant $variant): string => (string) $variant->runtime_type_code);
+
+        $desiredRuntimeCodes = [];
+
+        foreach ($desiredVariants as $variantPayload) {
+            $runtimeTypeCode = (string) $variantPayload['runtime_type_code'];
+            $desiredRuntimeCodes[] = $runtimeTypeCode;
+            $existing = $existingVariants->get($runtimeTypeCode);
+
+            if (! $existing instanceof PersonalityProfileVariant) {
+                $variant = PersonalityProfileVariant::query()->create(
+                    $this->variantAttributes($profile, $variantPayload, $status)
+                );
+
+                $this->syncVariantSections($variant, $variantPayload, false);
+                $this->syncVariantSeoMeta($variant, $variantPayload);
+                $this->createVariantRevision($variant, 'baseline import');
+
+                continue;
+            }
+
+            if (! $allowUpdates) {
+                continue;
+            }
+
+            $desiredState = $this->desiredComparableVariantState($variantPayload, $status, $existing);
+            $currentState = $this->currentComparableVariantState($existing);
+
+            if ($desiredState === $currentState) {
+                continue;
+            }
+
+            $existing->fill($this->variantAttributes($profile, $variantPayload, $status, $existing));
+            $existing->save();
+
+            $this->syncVariantSections($existing, $variantPayload, true);
+            $this->syncVariantSeoMeta($existing, $variantPayload);
+            $this->createVariantRevision($existing, 'baseline upsert');
+        }
+
+        if ($allowUpdates) {
+            PersonalityProfileVariant::query()
+                ->where('personality_profile_id', (int) $profile->id)
+                ->whereNotIn('runtime_type_code', $desiredRuntimeCodes === [] ? ['__none__'] : $desiredRuntimeCodes)
+                ->delete();
+        }
+
+        $profile->unsetRelation('variants');
+    }
+
+    /**
+     * @param  array<string, mixed>  $variantPayload
+     * @return array<string, mixed>
+     */
+    private function variantAttributes(
+        PersonalityProfile $profile,
+        array $variantPayload,
+        string $status,
+        ?PersonalityProfileVariant $existing = null,
+    ): array {
+        $profileOverrides = (array) ($variantPayload['profile_overrides'] ?? []);
+
+        return [
+            'personality_profile_id' => (int) $profile->id,
+            'canonical_type_code' => (string) $variantPayload['canonical_type_code'],
+            'variant_code' => (string) $variantPayload['variant_code'],
+            'runtime_type_code' => (string) $variantPayload['runtime_type_code'],
+            'type_name' => $profileOverrides['type_name'],
+            'nickname' => $profileOverrides['nickname'],
+            'rarity_text' => $profileOverrides['rarity_text'],
+            'keywords_json' => $profileOverrides['keywords_json'],
+            'hero_summary_md' => $profileOverrides['hero_summary_md'],
+            'hero_summary_html' => $profileOverrides['hero_summary_html'],
+            'schema_version' => (string) ($variantPayload['schema_version'] ?? PersonalityProfile::SCHEMA_VERSION_V2),
+            'is_published' => $this->resolveVariantPublishedState($variantPayload, $status),
+            'published_at' => $this->resolveVariantPublishedAt($variantPayload, $status, $existing),
+        ];
+    }
+
+    /**
+     * @param  array<string, mixed>  $variantPayload
+     */
+    private function syncVariantSections(
+        PersonalityProfileVariant $variant,
+        array $variantPayload,
+        bool $fullSync,
+    ): void {
+        $desiredSections = [];
+
+        foreach ((array) ($variantPayload['section_overrides'] ?? []) as $section) {
+            $desiredSections[(string) $section['section_key']] = [
+                'render_variant' => (string) $section['render_variant'],
+                'body_md' => $section['body_md'],
+                'body_html' => $section['body_html'],
+                'payload_json' => $section['payload_json'],
+                'sort_order' => (int) $section['sort_order'],
+                'is_enabled' => (bool) $section['is_enabled'],
+            ];
+        }
+
+        foreach ($desiredSections as $sectionKey => $attributes) {
+            PersonalityProfileVariantSection::query()->updateOrCreate(
+                [
+                    'personality_profile_variant_id' => (int) $variant->id,
+                    'section_key' => $sectionKey,
                 ],
+                $attributes,
+            );
+        }
+
+        if ($fullSync) {
+            $managedKeys = MbtiCanonicalSectionRegistry::keys();
+            $keepKeys = array_values(array_intersect(array_keys($desiredSections), $managedKeys));
+
+            $deleteQuery = PersonalityProfileVariantSection::query()
+                ->where('personality_profile_variant_id', (int) $variant->id)
+                ->whereIn('section_key', $managedKeys);
+
+            if ($keepKeys !== []) {
+                $deleteQuery->whereNotIn('section_key', $keepKeys);
+            }
+
+            $deleteQuery->delete();
+        }
+
+        $variant->unsetRelation('sections');
+    }
+
+    /**
+     * @param  array<string, mixed>  $variantPayload
+     */
+    private function syncVariantSeoMeta(PersonalityProfileVariant $variant, array $variantPayload): void
+    {
+        $seoMeta = (array) ($variantPayload['seo_overrides'] ?? []);
+
+        PersonalityProfileVariantSeoMeta::query()->updateOrCreate(
+            [
+                'personality_profile_variant_id' => (int) $variant->id,
+            ],
+            [
+                'seo_title' => $seoMeta['seo_title'],
+                'seo_description' => $seoMeta['seo_description'],
+                'canonical_url' => $seoMeta['canonical_url'],
+                'og_title' => $seoMeta['og_title'],
+                'og_description' => $seoMeta['og_description'],
+                'og_image_url' => $seoMeta['og_image_url'],
+                'twitter_title' => $seoMeta['twitter_title'],
+                'twitter_description' => $seoMeta['twitter_description'],
+                'twitter_image_url' => $seoMeta['twitter_image_url'],
+                'robots' => $seoMeta['robots'],
+                'jsonld_overrides_json' => $seoMeta['jsonld_overrides_json'],
+            ],
+        );
+
+        $variant->unsetRelation('seoMeta');
+    }
+
+    private function createVariantRevision(PersonalityProfileVariant $variant, string $note): void
+    {
+        PersonalityProfileVariantRevision::query()->create([
+            'personality_profile_variant_id' => (int) $variant->id,
+            'revision_no' => ((int) PersonalityProfileVariantRevision::query()
+                ->where('personality_profile_variant_id', (int) $variant->id)
+                ->max('revision_no')) + 1,
+            'snapshot_json' => $this->currentComparableVariantState($variant->fresh(['sections', 'seoMeta'])),
+            'note' => $note,
+            'created_by_admin_user_id' => null,
+            'created_at' => now(),
+        ]);
+    }
+
+    /**
+     * @param  array<string, mixed>  $variantPayload
+     * @return array<string, mixed>
+     */
+    private function desiredComparableVariantState(
+        array $variantPayload,
+        string $status,
+        ?PersonalityProfileVariant $existing = null,
+    ): array {
+        $profileOverrides = (array) ($variantPayload['profile_overrides'] ?? []);
+        $sections = collect((array) ($variantPayload['section_overrides'] ?? []))
+            ->map(static fn (array $section): array => [
+                'section_key' => (string) $section['section_key'],
+                'render_variant' => (string) $section['render_variant'],
+                'body_md' => $section['body_md'],
+                'body_html' => $section['body_html'],
+                'payload_json' => $section['payload_json'],
+                'sort_order' => (int) $section['sort_order'],
+                'is_enabled' => (bool) $section['is_enabled'],
+            ])
+            ->sortBy([
+                ['sort_order', 'asc'],
+                ['section_key', 'asc'],
+            ])
+            ->values()
+            ->all();
+
+        return [
+            'variant_profile' => [
+                'canonical_type_code' => (string) $variantPayload['canonical_type_code'],
+                'variant_code' => (string) $variantPayload['variant_code'],
+                'runtime_type_code' => (string) $variantPayload['runtime_type_code'],
+                'type_name' => $profileOverrides['type_name'],
+                'nickname' => $profileOverrides['nickname'],
+                'rarity_text' => $profileOverrides['rarity_text'],
+                'keywords_json' => $profileOverrides['keywords_json'],
+                'hero_summary_md' => $profileOverrides['hero_summary_md'],
+                'hero_summary_html' => $profileOverrides['hero_summary_html'],
+                'schema_version' => (string) ($variantPayload['schema_version'] ?? PersonalityProfile::SCHEMA_VERSION_V2),
+                'is_published' => $this->resolveVariantPublishedState($variantPayload, $status),
+                'published_at' => $this->normalizeDateForComparison(
+                    $this->resolveVariantPublishedAt($variantPayload, $status, $existing)
+                ),
+            ],
+            'variant_sections' => $sections,
+            'variant_seo_meta' => (array) ($variantPayload['seo_overrides'] ?? []),
+        ];
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function currentComparableVariantState(PersonalityProfileVariant $variant): array
+    {
+        $variant->loadMissing('sections', 'seoMeta');
+
+        return [
+            'variant_profile' => [
+                'canonical_type_code' => (string) $variant->canonical_type_code,
+                'variant_code' => (string) $variant->variant_code,
+                'runtime_type_code' => (string) $variant->runtime_type_code,
+                'type_name' => $variant->type_name,
+                'nickname' => $variant->nickname,
+                'rarity_text' => $variant->rarity_text,
+                'keywords_json' => is_array($variant->keywords_json) ? array_values($variant->keywords_json) : [],
+                'hero_summary_md' => $variant->hero_summary_md,
+                'hero_summary_html' => $variant->hero_summary_html,
+                'schema_version' => (string) $variant->schema_version,
+                'is_published' => (bool) $variant->is_published,
+                'published_at' => $this->normalizeDateForComparison($variant->published_at),
+            ],
+            'variant_sections' => $variant->sections
+                ->map(static fn (PersonalityProfileVariantSection $section): array => [
+                    'section_key' => (string) $section->section_key,
+                    'render_variant' => (string) $section->render_variant,
+                    'body_md' => $section->body_md,
+                    'body_html' => $section->body_html,
+                    'payload_json' => $section->payload_json,
+                    'sort_order' => (int) $section->sort_order,
+                    'is_enabled' => (bool) $section->is_enabled,
+                ])
+                ->sortBy([
+                    ['sort_order', 'asc'],
+                    ['section_key', 'asc'],
+                ])
+                ->values()
+                ->all(),
+            'variant_seo_meta' => $variant->seoMeta instanceof PersonalityProfileVariantSeoMeta
+                ? [
+                    'seo_title' => $variant->seoMeta->seo_title,
+                    'seo_description' => $variant->seoMeta->seo_description,
+                    'canonical_url' => $variant->seoMeta->canonical_url,
+                    'og_title' => $variant->seoMeta->og_title,
+                    'og_description' => $variant->seoMeta->og_description,
+                    'og_image_url' => $variant->seoMeta->og_image_url,
+                    'twitter_title' => $variant->seoMeta->twitter_title,
+                    'twitter_description' => $variant->seoMeta->twitter_description,
+                    'twitter_image_url' => $variant->seoMeta->twitter_image_url,
+                    'robots' => $variant->seoMeta->robots,
+                    'jsonld_overrides_json' => $variant->seoMeta->jsonld_overrides_json,
+                ]
+                : $this->emptySeoMeta(),
         ];
     }
 
@@ -375,6 +794,35 @@ final class PersonalityBaselineImporter
         }
 
         return $this->normalizeNullableDate($profilePayload['published_at'] ?? null)
+            ?? $existing?->published_at
+            ?? now();
+    }
+
+    /**
+     * @param  array<string, mixed>  $variantPayload
+     */
+    private function resolveVariantPublishedState(array $variantPayload, string $status): bool
+    {
+        if ($status === 'draft') {
+            return false;
+        }
+
+        return (bool) ($variantPayload['is_published'] ?? false);
+    }
+
+    /**
+     * @param  array<string, mixed>  $variantPayload
+     */
+    private function resolveVariantPublishedAt(
+        array $variantPayload,
+        string $status,
+        ?PersonalityProfileVariant $existing = null,
+    ): ?Carbon {
+        if (! $this->resolveVariantPublishedState($variantPayload, $status)) {
+            return null;
+        }
+
+        return $this->normalizeNullableDate($variantPayload['published_at'] ?? null)
             ?? $existing?->published_at
             ?? now();
     }
@@ -403,5 +851,36 @@ final class PersonalityBaselineImporter
         $normalized = $this->normalizeNullableDate($value);
 
         return $normalized?->toIso8601String();
+    }
+
+    /**
+     * @return array<int, string>
+     */
+    private function managedBaseSectionKeys(): array
+    {
+        return array_values(array_unique(array_merge(
+            PersonalityProfileSection::SECTION_KEYS,
+            MbtiCanonicalSectionRegistry::keys(),
+        )));
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function emptySeoMeta(): array
+    {
+        return [
+            'seo_title' => null,
+            'seo_description' => null,
+            'canonical_url' => null,
+            'og_title' => null,
+            'og_description' => null,
+            'og_image_url' => null,
+            'twitter_title' => null,
+            'twitter_description' => null,
+            'twitter_image_url' => null,
+            'robots' => null,
+            'jsonld_overrides_json' => null,
+        ];
     }
 }

--- a/backend/app/PersonalityCms/Baseline/PersonalityBaselineNormalizer.php
+++ b/backend/app/PersonalityCms/Baseline/PersonalityBaselineNormalizer.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace App\PersonalityCms\Baseline;
 
 use App\Models\PersonalityProfile;
-use App\Models\PersonalityProfileSection;
+use App\Support\Mbti\MbtiCanonicalSectionRegistry;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Str;
 use RuntimeException;
@@ -20,9 +20,12 @@ final class PersonalityBaselineNormalizer
     public function normalizeDocuments(array $documents, array $selectedTypes = []): array
     {
         $normalizedTypes = $this->normalizeSelectedTypes($selectedTypes);
-        $profiles = [];
+        $profilesByLocaleType = [];
         $seenByLocaleType = [];
         $seenByLocaleSlug = [];
+        $variantsByLocaleType = [];
+        $seenVariantRuntime = [];
+        $seenVariantCode = [];
 
         foreach ($documents as $document) {
             $file = (string) ($document['file'] ?? 'unknown');
@@ -89,8 +92,76 @@ final class PersonalityBaselineNormalizer
 
                 $seenByLocaleType[$typeKey] = true;
                 $seenByLocaleSlug[$slugKey] = true;
-                $profiles[] = $profile;
+                $profilesByLocaleType[$typeKey] = $profile;
             }
+
+            $variantRows = $payload['variants'] ?? [];
+            if (! is_array($variantRows)) {
+                throw new RuntimeException(sprintf(
+                    'Baseline file %s must contain a variants array when provided.',
+                    $file,
+                ));
+            }
+
+            foreach ($variantRows as $index => $row) {
+                if (! is_array($row)) {
+                    throw new RuntimeException(sprintf(
+                        'Baseline file %s contains a non-object variant row at index %d.',
+                        $file,
+                        $index,
+                    ));
+                }
+
+                $variant = $this->normalizeVariant($row, $locale, $schemaVersion, $file, $index);
+                $canonicalTypeCode = (string) $variant['canonical_type_code'];
+                $runtimeTypeCode = (string) $variant['runtime_type_code'];
+                $variantCode = (string) $variant['variant_code'];
+
+                if ($normalizedTypes !== [] && ! in_array($canonicalTypeCode, $normalizedTypes, true)) {
+                    continue;
+                }
+
+                $runtimeKey = $locale.'|'.$runtimeTypeCode;
+                $variantKey = $locale.'|'.$canonicalTypeCode.'|'.$variantCode;
+
+                if (isset($seenVariantRuntime[$runtimeKey])) {
+                    throw new RuntimeException(sprintf(
+                        'Duplicate runtime_type_code %s for locale %s in baseline file %s.',
+                        $runtimeTypeCode,
+                        $locale,
+                        $file,
+                    ));
+                }
+
+                if (isset($seenVariantCode[$variantKey])) {
+                    throw new RuntimeException(sprintf(
+                        'Duplicate variant_code %s for canonical_type_code %s locale %s in baseline file %s.',
+                        $variantCode,
+                        $canonicalTypeCode,
+                        $locale,
+                        $file,
+                    ));
+                }
+
+                $seenVariantRuntime[$runtimeKey] = true;
+                $seenVariantCode[$variantKey] = true;
+                $variantsByLocaleType[$locale.'|'.$canonicalTypeCode][] = $variant;
+            }
+        }
+
+        foreach ($variantsByLocaleType as $typeKey => $variants) {
+            if (! isset($profilesByLocaleType[$typeKey])) {
+                throw new RuntimeException(sprintf(
+                    'Baseline variants reference missing canonical profile %s.',
+                    $typeKey,
+                ));
+            }
+        }
+
+        $profiles = [];
+        foreach ($profilesByLocaleType as $typeKey => $profile) {
+            $profile['variants'] = $this->sortVariants($variantsByLocaleType[$typeKey] ?? []);
+            $profiles[] = $profile;
         }
 
         usort(
@@ -153,24 +224,32 @@ final class PersonalityBaselineNormalizer
             'org_id' => 0,
             'scale_code' => PersonalityProfile::SCALE_CODE_MBTI,
             'type_code' => $typeCode,
+            'canonical_type_code' => $typeCode,
             'slug' => $slug,
             'locale' => $locale,
             'title' => $title,
+            'type_name' => $this->normalizeNullableText($row['type_name'] ?? null),
+            'nickname' => $this->normalizeNullableText($row['nickname'] ?? null),
+            'rarity_text' => $this->normalizeNullableText($row['rarity_text'] ?? null),
+            'keywords_json' => $this->normalizeStringList($row['keywords_json'] ?? []),
             'subtitle' => $this->normalizeNullableText($row['subtitle'] ?? null),
             'excerpt' => $this->normalizeNullableText($row['excerpt'] ?? null),
             'hero_kicker' => $this->normalizeNullableText($row['hero_kicker'] ?? null),
             'hero_quote' => $this->normalizeNullableText($row['hero_quote'] ?? null),
+            'hero_summary_md' => $this->normalizeNullableText($row['hero_summary_md'] ?? null),
+            'hero_summary_html' => $this->normalizeNullableText($row['hero_summary_html'] ?? null),
             'hero_image_url' => $this->normalizeNullableText($row['hero_image_url'] ?? null),
             'status' => $this->normalizeStatus($row['status'] ?? 'published', $file, $index),
             'is_public' => $this->normalizeBool($row['is_public'] ?? true),
             'is_indexable' => $this->normalizeBool($row['is_indexable'] ?? true),
             'published_at' => $this->normalizeNullableText($row['published_at'] ?? null),
             'scheduled_at' => $this->normalizeNullableText($row['scheduled_at'] ?? null),
-            'schema_version' => $schemaVersion !== '' ? $schemaVersion : 'v1',
+            'schema_version' => $schemaVersion !== '' ? $schemaVersion : PersonalityProfile::SCHEMA_VERSION_V2,
             'sections' => $sections,
             'seo_meta' => $this->normalizeSeoMeta(
                 is_array($row['seo_meta'] ?? null) ? $row['seo_meta'] : [],
             ),
+            'variants' => [],
         ];
     }
 
@@ -180,7 +259,6 @@ final class PersonalityBaselineNormalizer
      */
     private function normalizeSections(array $rows, string $file, int $profileIndex): array
     {
-        $known = PersonalityProfileSection::SECTION_KEYS;
         $sections = [];
         $seen = [];
 
@@ -195,16 +273,7 @@ final class PersonalityBaselineNormalizer
             }
 
             $sectionKey = trim((string) ($row['section_key'] ?? ''));
-
-            if ($sectionKey === '' || ! in_array($sectionKey, $known, true)) {
-                throw new RuntimeException(sprintf(
-                    'Baseline file %s contains unsupported section_key=%s at profiles[%d].sections[%d].',
-                    $file,
-                    $sectionKey,
-                    $profileIndex,
-                    $sectionIndex,
-                ));
-            }
+            $definition = $this->canonicalSectionDefinition($sectionKey, $file, $profileIndex, $sectionIndex);
 
             if (isset($seen[$sectionKey])) {
                 throw new RuntimeException(sprintf(
@@ -215,10 +284,10 @@ final class PersonalityBaselineNormalizer
                 ));
             }
 
-            $renderVariant = trim((string) ($row['render_variant'] ?? ''));
-            if ($renderVariant === '' || ! in_array($renderVariant, PersonalityProfileSection::RENDER_VARIANTS, true)) {
+            $renderVariant = trim((string) ($row['render_variant'] ?? $definition['render_variant']));
+            if ($renderVariant === '' || $renderVariant !== (string) $definition['render_variant']) {
                 throw new RuntimeException(sprintf(
-                    'Baseline file %s contains invalid render_variant for section %s at profiles[%d].sections[%d].',
+                    'Baseline file %s contains invalid render_variant for canonical section %s at profiles[%d].sections[%d].',
                     $file,
                     $sectionKey,
                     $profileIndex,
@@ -228,12 +297,161 @@ final class PersonalityBaselineNormalizer
 
             $sections[] = [
                 'section_key' => $sectionKey,
-                'title' => $this->normalizeNullableText($row['title'] ?? null),
+                'title' => $this->normalizeNullableText($row['title'] ?? null) ?? (string) $definition['title'],
                 'render_variant' => $renderVariant,
                 'body_md' => $this->normalizeNullableText($row['body_md'] ?? null),
                 'body_html' => $this->normalizeNullableText($row['body_html'] ?? null),
                 'payload_json' => Arr::exists($row, 'payload_json') ? $this->normalizeNullableArray($row['payload_json']) : null,
-                'sort_order' => (int) ($row['sort_order'] ?? 0),
+                'sort_order' => (int) ($row['sort_order'] ?? $definition['sort_order'] ?? 0),
+                'is_enabled' => $this->normalizeBool($row['is_enabled'] ?? true),
+            ];
+
+            $seen[$sectionKey] = true;
+        }
+
+        usort(
+            $sections,
+            static fn (array $left, array $right): int => [$left['sort_order'], $left['section_key']]
+                <=> [$right['sort_order'], $right['section_key']],
+        );
+
+        return $sections;
+    }
+
+    /**
+     * @param  array<string, mixed>  $row
+     * @return array<string, mixed>
+     */
+    private function normalizeVariant(
+        array $row,
+        string $locale,
+        string $schemaVersion,
+        string $file,
+        int $index,
+    ): array {
+        $canonicalTypeCode = Str::upper(trim((string) ($row['canonical_type_code'] ?? '')));
+        $variantCode = Str::upper(trim((string) ($row['variant_code'] ?? '')));
+        $runtimeTypeCode = Str::upper(trim((string) ($row['runtime_type_code'] ?? '')));
+
+        if (! in_array($canonicalTypeCode, PersonalityProfile::TYPE_CODES, true)) {
+            throw new RuntimeException(sprintf(
+                'Baseline file %s has invalid canonical_type_code at variants[%d].',
+                $file,
+                $index,
+            ));
+        }
+
+        if (! in_array($variantCode, ['A', 'T'], true)) {
+            throw new RuntimeException(sprintf(
+                'Baseline file %s has invalid variant_code at variants[%d].',
+                $file,
+                $index,
+            ));
+        }
+
+        if (preg_match('/^(?<base>[EI][SN][TF][JP])-(?<variant>[AT])$/', $runtimeTypeCode, $matches) !== 1) {
+            throw new RuntimeException(sprintf(
+                'Baseline file %s has invalid runtime_type_code at variants[%d].',
+                $file,
+                $index,
+            ));
+        }
+
+        if ((string) $matches['base'] !== $canonicalTypeCode || (string) $matches['variant'] !== $variantCode) {
+            throw new RuntimeException(sprintf(
+                'Baseline file %s has mismatched runtime_type_code/canonical_type_code/variant_code at variants[%d].',
+                $file,
+                $index,
+            ));
+        }
+
+        return [
+            'canonical_type_code' => $canonicalTypeCode,
+            'variant_code' => $variantCode,
+            'runtime_type_code' => $runtimeTypeCode,
+            'locale' => $locale,
+            'schema_version' => $schemaVersion !== '' ? $schemaVersion : PersonalityProfile::SCHEMA_VERSION_V2,
+            'is_published' => $this->normalizeBool($row['is_published'] ?? false),
+            'published_at' => $this->normalizeNullableText($row['published_at'] ?? null),
+            'profile_overrides' => $this->normalizeVariantProfileOverrides(
+                is_array($row['profile_overrides'] ?? null) ? $row['profile_overrides'] : [],
+            ),
+            'section_overrides' => $this->normalizeVariantSections(
+                is_array($row['section_overrides'] ?? null) ? $row['section_overrides'] : [],
+                $file,
+                $index,
+            ),
+            'seo_overrides' => $this->normalizeSeoMeta(
+                is_array($row['seo_overrides'] ?? null) ? $row['seo_overrides'] : [],
+            ),
+        ];
+    }
+
+    /**
+     * @param  array<string, mixed>  $profileOverrides
+     * @return array<string, mixed>
+     */
+    private function normalizeVariantProfileOverrides(array $profileOverrides): array
+    {
+        return [
+            'type_name' => $this->normalizeNullableText($profileOverrides['type_name'] ?? null),
+            'nickname' => $this->normalizeNullableText($profileOverrides['nickname'] ?? null),
+            'rarity_text' => $this->normalizeNullableText($profileOverrides['rarity_text'] ?? null),
+            'keywords_json' => $this->normalizeStringList($profileOverrides['keywords_json'] ?? []),
+            'hero_summary_md' => $this->normalizeNullableText($profileOverrides['hero_summary_md'] ?? null),
+            'hero_summary_html' => $this->normalizeNullableText($profileOverrides['hero_summary_html'] ?? null),
+        ];
+    }
+
+    /**
+     * @param  array<int, mixed>  $rows
+     * @return array<int, array<string, mixed>>
+     */
+    private function normalizeVariantSections(array $rows, string $file, int $variantIndex): array
+    {
+        $sections = [];
+        $seen = [];
+
+        foreach ($rows as $sectionIndex => $row) {
+            if (! is_array($row)) {
+                throw new RuntimeException(sprintf(
+                    'Baseline file %s contains a non-object variant section at variants[%d].section_overrides[%d].',
+                    $file,
+                    $variantIndex,
+                    $sectionIndex,
+                ));
+            }
+
+            $sectionKey = trim((string) ($row['section_key'] ?? ''));
+            $definition = $this->canonicalSectionDefinition($sectionKey, $file, $variantIndex, $sectionIndex, true);
+
+            if (isset($seen[$sectionKey])) {
+                throw new RuntimeException(sprintf(
+                    'Baseline file %s contains duplicate variant section_key=%s at variants[%d].',
+                    $file,
+                    $sectionKey,
+                    $variantIndex,
+                ));
+            }
+
+            $renderVariant = trim((string) ($row['render_variant'] ?? $definition['render_variant']));
+            if ($renderVariant === '' || $renderVariant !== (string) $definition['render_variant']) {
+                throw new RuntimeException(sprintf(
+                    'Baseline file %s contains invalid render_variant for variant section %s at variants[%d].section_overrides[%d].',
+                    $file,
+                    $sectionKey,
+                    $variantIndex,
+                    $sectionIndex,
+                ));
+            }
+
+            $sections[] = [
+                'section_key' => $sectionKey,
+                'render_variant' => $renderVariant,
+                'body_md' => $this->normalizeNullableText($row['body_md'] ?? null),
+                'body_html' => $this->normalizeNullableText($row['body_html'] ?? null),
+                'payload_json' => Arr::exists($row, 'payload_json') ? $this->normalizeNullableArray($row['payload_json']) : null,
+                'sort_order' => (int) ($row['sort_order'] ?? $definition['sort_order'] ?? 0),
                 'is_enabled' => $this->normalizeBool($row['is_enabled'] ?? true),
             ];
 
@@ -354,6 +572,29 @@ final class PersonalityBaselineNormalizer
     }
 
     /**
+     * @return list<string>
+     */
+    private function normalizeStringList(mixed $value): array
+    {
+        if (! is_array($value)) {
+            return [];
+        }
+
+        $normalized = [];
+
+        foreach ($value as $item) {
+            $candidate = $this->normalizeNullableText($item);
+            if ($candidate === null) {
+                continue;
+            }
+
+            $normalized[$candidate] = true;
+        }
+
+        return array_values(array_keys($normalized));
+    }
+
+    /**
      * @return array<string, mixed>|array<int, mixed>|null
      */
     private function normalizeNullableArray(mixed $value): ?array
@@ -367,5 +608,45 @@ final class PersonalityBaselineNormalizer
         }
 
         return $value === [] ? null : $value;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function canonicalSectionDefinition(
+        string $sectionKey,
+        string $file,
+        int $rowIndex,
+        int $sectionIndex,
+        bool $isVariant = false,
+    ): array {
+        try {
+            return MbtiCanonicalSectionRegistry::definition($sectionKey);
+        } catch (\InvalidArgumentException) {
+            throw new RuntimeException(sprintf(
+                $isVariant
+                    ? 'Baseline file %s contains unsupported variant section_key=%s at variants[%d].section_overrides[%d].'
+                    : 'Baseline file %s contains unsupported section_key=%s at profiles[%d].sections[%d].',
+                $file,
+                $sectionKey,
+                $rowIndex,
+                $sectionIndex,
+            ));
+        }
+    }
+
+    /**
+     * @param  array<int, array<string, mixed>>  $variants
+     * @return array<int, array<string, mixed>>
+     */
+    private function sortVariants(array $variants): array
+    {
+        usort(
+            $variants,
+            static fn (array $left, array $right): int => [$left['variant_code'], $left['runtime_type_code']]
+                <=> [$right['variant_code'], $right['runtime_type_code']],
+        );
+
+        return $variants;
     }
 }

--- a/backend/scripts/ci_verify_mbti.sh
+++ b/backend/scripts/ci_verify_mbti.sh
@@ -1075,6 +1075,20 @@ if [[ "$HARD_CUTOVER_ENV_APPLIED" == "1" ]]; then
   restore_hard_cutover_env
 fi
 
+echo "[CI] personality full-32 authority gate"
+php artisan personality:import-local-baseline --dry-run --upsert --status=published
+php vendor/phpunit/phpunit/phpunit --configuration phpunit.xml \
+  tests/Feature/PersonalityCms/PersonalityBaselineImportTest.php \
+  tests/Feature/PersonalityCms/PersonalityVariantAuthorityTest.php \
+  tests/Unit/Services/Mbti/MbtiPublicProjectionServiceTest.php \
+  tests/Feature/V0_5/PersonalityPublicApiTest.php \
+  tests/Feature/SEO/SitemapGeneratorTest.php \
+  tests/Feature/SEO/SitemapXmlTest.php \
+  tests/Feature/V0_3/MbtiReportHttpContractRegressionTest.php \
+  tests/Feature/V0_3/ShareSummaryContractTest.php \
+  tests/Feature/V0_3/MbtiCompareInviteContractTest.php
+echo "[CI] personality full-32 authority gate OK"
+
 echo "[CI] payment event provider uniqueness gate"
 php artisan test --filter PaymentEventUniquenessAcrossProvidersTest
 echo "[CI] payment event provider uniqueness gate OK"

--- a/backend/tests/Feature/PersonalityCms/PersonalityBaselineImportTest.php
+++ b/backend/tests/Feature/PersonalityCms/PersonalityBaselineImportTest.php
@@ -8,6 +8,10 @@ use App\Models\PersonalityProfile;
 use App\Models\PersonalityProfileRevision;
 use App\Models\PersonalityProfileSection;
 use App\Models\PersonalityProfileSeoMeta;
+use App\Models\PersonalityProfileVariant;
+use App\Models\PersonalityProfileVariantRevision;
+use App\Models\PersonalityProfileVariantSection;
+use App\Models\PersonalityProfileVariantSeoMeta;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\File;
 use Tests\TestCase;
@@ -23,14 +27,21 @@ final class PersonalityBaselineImportTest extends TestCase
             '--source-dir' => 'tests/Fixtures/personality_baseline',
         ])
             ->expectsOutputToContain('profiles_found=4')
+            ->expectsOutputToContain('variants_found=8')
             ->expectsOutputToContain('will_create=4')
             ->expectsOutputToContain('revisions_to_create=4')
+            ->expectsOutputToContain('variant_will_create=8')
+            ->expectsOutputToContain('variant_revisions_to_create=8')
             ->assertExitCode(0);
 
         $this->assertSame(0, PersonalityProfile::query()->count());
         $this->assertSame(0, PersonalityProfileSection::query()->count());
         $this->assertSame(0, PersonalityProfileSeoMeta::query()->count());
         $this->assertSame(0, PersonalityProfileRevision::query()->count());
+        $this->assertSame(0, PersonalityProfileVariant::query()->count());
+        $this->assertSame(0, PersonalityProfileVariantSection::query()->count());
+        $this->assertSame(0, PersonalityProfileVariantSeoMeta::query()->count());
+        $this->assertSame(0, PersonalityProfileVariantRevision::query()->count());
     }
 
     public function test_default_mode_creates_missing_profiles_sections_seo_meta_and_revision(): void
@@ -41,13 +52,20 @@ final class PersonalityBaselineImportTest extends TestCase
             '--source-dir' => 'tests/Fixtures/personality_baseline',
         ])
             ->expectsOutputToContain('profiles_found=2')
+            ->expectsOutputToContain('variants_found=4')
             ->expectsOutputToContain('will_create=2')
+            ->expectsOutputToContain('variant_will_create=4')
+            ->expectsOutputToContain('variant_revisions_to_create=4')
             ->assertExitCode(0);
 
         $this->assertSame(2, PersonalityProfile::query()->count());
         $this->assertSame(5, PersonalityProfileSection::query()->count());
         $this->assertSame(2, PersonalityProfileSeoMeta::query()->count());
         $this->assertSame(2, PersonalityProfileRevision::query()->count());
+        $this->assertSame(4, PersonalityProfileVariant::query()->count());
+        $this->assertSame(4, PersonalityProfileVariantSection::query()->count());
+        $this->assertSame(4, PersonalityProfileVariantSeoMeta::query()->count());
+        $this->assertSame(4, PersonalityProfileVariantRevision::query()->count());
 
         $profile = PersonalityProfile::query()
             ->withoutGlobalScopes()
@@ -57,8 +75,11 @@ final class PersonalityBaselineImportTest extends TestCase
 
         $this->assertSame(0, (int) $profile->org_id);
         $this->assertSame('MBTI', $profile->scale_code);
+        $this->assertSame('INTJ', $profile->canonical_type_code);
         $this->assertSame('draft', $profile->status);
         $this->assertNull($profile->published_at);
+        $this->assertSame('Architect', $profile->type_name);
+        $this->assertSame('Systems builder', $profile->nickname);
 
         $revision = PersonalityProfileRevision::query()
             ->where('profile_id', (int) $profile->id)
@@ -67,6 +88,17 @@ final class PersonalityBaselineImportTest extends TestCase
 
         $this->assertSame(1, (int) $revision->revision_no);
         $this->assertSame('baseline import', $revision->note);
+
+        $variant = PersonalityProfileVariant::query()
+            ->where('personality_profile_id', (int) $profile->id)
+            ->where('runtime_type_code', 'INTJ-A')
+            ->firstOrFail();
+
+        $this->assertSame('INTJ', $variant->canonical_type_code);
+        $this->assertSame('A', $variant->variant_code);
+        $this->assertSame('Architect Assertive', $variant->type_name);
+        $this->assertFalse((bool) $variant->is_published);
+        $this->assertNull($variant->published_at);
     }
 
     public function test_default_mode_skips_existing_profiles_without_overwriting(): void
@@ -98,11 +130,14 @@ final class PersonalityBaselineImportTest extends TestCase
             '--source-dir' => 'tests/Fixtures/personality_baseline',
         ])
             ->expectsOutputToContain('profiles_found=1')
+            ->expectsOutputToContain('variants_found=2')
             ->expectsOutputToContain('will_skip=1')
+            ->expectsOutputToContain('variant_will_create=2')
             ->assertExitCode(0);
 
         $this->assertSame('Do Not Overwrite', (string) $profile->fresh()->title);
         $this->assertSame(1, PersonalityProfileRevision::query()->where('profile_id', (int) $profile->id)->count());
+        $this->assertSame(0, PersonalityProfileVariant::query()->count());
     }
 
     public function test_upsert_updates_existing_profiles_and_only_creates_revision_when_changed(): void
@@ -151,6 +186,38 @@ final class PersonalityBaselineImportTest extends TestCase
             'note' => 'seed',
             'created_at' => now()->subDay(),
         ]);
+        $variant = PersonalityProfileVariant::query()->create([
+            'personality_profile_id' => (int) $profile->id,
+            'canonical_type_code' => 'INTJ',
+            'variant_code' => 'A',
+            'runtime_type_code' => 'INTJ-A',
+            'type_name' => 'Legacy Assertive',
+            'nickname' => 'Legacy strategist',
+            'rarity_text' => 'About 4%',
+            'keywords_json' => ['legacy'],
+            'hero_summary_md' => 'Legacy variant summary',
+            'schema_version' => PersonalityProfile::SCHEMA_VERSION_V2,
+            'is_published' => false,
+        ]);
+        PersonalityProfileVariantSection::query()->create([
+            'personality_profile_variant_id' => (int) $variant->id,
+            'section_key' => 'overview',
+            'render_variant' => 'rich_text',
+            'body_md' => 'Legacy variant body',
+            'sort_order' => 20,
+            'is_enabled' => true,
+        ]);
+        PersonalityProfileVariantSeoMeta::query()->create([
+            'personality_profile_variant_id' => (int) $variant->id,
+            'seo_title' => 'Legacy variant seo',
+        ]);
+        PersonalityProfileVariantRevision::query()->create([
+            'personality_profile_variant_id' => (int) $variant->id,
+            'revision_no' => 1,
+            'snapshot_json' => ['type_name' => 'Legacy Assertive'],
+            'note' => 'seed',
+            'created_at' => now()->subDay(),
+        ]);
 
         $this->artisan('personality:import-local-baseline', [
             '--locale' => ['en'],
@@ -160,17 +227,21 @@ final class PersonalityBaselineImportTest extends TestCase
             '--source-dir' => 'tests/Fixtures/personality_baseline',
         ])
             ->expectsOutputToContain('profiles_found=1')
+            ->expectsOutputToContain('variants_found=2')
             ->expectsOutputToContain('will_update=1')
             ->expectsOutputToContain('revisions_to_create=1')
+            ->expectsOutputToContain('variant_will_create=1')
+            ->expectsOutputToContain('variant_revisions_to_create=2')
             ->assertExitCode(0);
 
         $profile->refresh();
 
         $this->assertSame('INTJ - Architect', $profile->title);
+        $this->assertSame('Architect', $profile->type_name);
         $this->assertTrue((bool) $profile->is_indexable);
         $this->assertNotNull($profile->published_at);
         $this->assertSame(
-            ['career_fit', 'core_snapshot', 'strengths'],
+            ['career.summary', 'growth.strengths', 'overview'],
             PersonalityProfileSection::query()
                 ->where('profile_id', (int) $profile->id)
                 ->orderBy('section_key')
@@ -186,6 +257,33 @@ final class PersonalityBaselineImportTest extends TestCase
             PersonalityProfileRevision::query()->where('profile_id', (int) $profile->id)->max('revision_no'),
         );
 
+        $assertive = PersonalityProfileVariant::query()
+            ->where('personality_profile_id', (int) $profile->id)
+            ->where('runtime_type_code', 'INTJ-A')
+            ->firstOrFail();
+        $turbulent = PersonalityProfileVariant::query()
+            ->where('personality_profile_id', (int) $profile->id)
+            ->where('runtime_type_code', 'INTJ-T')
+            ->firstOrFail();
+
+        $this->assertTrue((bool) $assertive->is_published);
+        $this->assertSame('Architect Assertive', $assertive->type_name);
+        $this->assertSame('Architect Turbulent', $turbulent->type_name);
+        $this->assertFalse((bool) $turbulent->is_published);
+        $this->assertSame(
+            'INTJ-A Personality Guide',
+            PersonalityProfileVariantSeoMeta::query()
+                ->where('personality_profile_variant_id', (int) $assertive->id)
+                ->firstOrFail()
+                ->seo_title,
+        );
+        $this->assertSame(
+            2,
+            PersonalityProfileVariantRevision::query()
+                ->where('personality_profile_variant_id', (int) $assertive->id)
+                ->max('revision_no'),
+        );
+
         $this->artisan('personality:import-local-baseline', [
             '--locale' => ['en'],
             '--type' => ['INTJ'],
@@ -194,12 +292,14 @@ final class PersonalityBaselineImportTest extends TestCase
             '--source-dir' => 'tests/Fixtures/personality_baseline',
         ])
             ->expectsOutputToContain('will_skip=1')
+            ->expectsOutputToContain('variant_will_skip=2')
             ->assertExitCode(0);
 
         $this->assertSame(
             2,
             PersonalityProfileRevision::query()->where('profile_id', (int) $profile->id)->count(),
         );
+        $this->assertSame(3, PersonalityProfileVariantRevision::query()->count());
     }
 
     public function test_locale_and_type_filters_limit_import_scope(): void
@@ -211,10 +311,13 @@ final class PersonalityBaselineImportTest extends TestCase
             '--source-dir' => 'tests/Fixtures/personality_baseline',
         ])
             ->expectsOutputToContain('profiles_found=1')
+            ->expectsOutputToContain('variants_found=2')
             ->expectsOutputToContain('will_create=1')
+            ->expectsOutputToContain('variant_will_create=2')
             ->assertExitCode(0);
 
         $this->assertSame(1, PersonalityProfile::query()->count());
+        $this->assertSame(2, PersonalityProfileVariant::query()->count());
 
         $profile = PersonalityProfile::query()->firstOrFail();
         $this->assertSame('INTJ', $profile->type_code);
@@ -246,7 +349,6 @@ final class PersonalityBaselineImportTest extends TestCase
                     'sections' => [
                         [
                             'section_key' => 'core_snapshot',
-                            'title' => 'Core snapshot',
                             'render_variant' => 'rich_text',
                             'body_md' => 'bad',
                             'payload_json' => null,
@@ -257,6 +359,18 @@ final class PersonalityBaselineImportTest extends TestCase
                     'seo_meta' => [],
                 ],
             ],
+        ], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES | JSON_PRETTY_PRINT));
+
+        File::put($sourceDir.'/mbti.zh-CN.json', json_encode([
+            'meta' => [
+                'schema_version' => 'v2',
+                'scale_code' => 'MBTI',
+                'locale' => 'zh-CN',
+                'source' => 'test fixture',
+                'generated_at' => '2026-03-08T00:00:00Z',
+            ],
+            'profiles' => [],
+            'variants' => [],
         ], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES | JSON_PRETTY_PRINT));
 
         try {

--- a/backend/tests/Feature/PersonalityCms/PersonalityVariantAuthorityTest.php
+++ b/backend/tests/Feature/PersonalityCms/PersonalityVariantAuthorityTest.php
@@ -6,6 +6,8 @@ namespace Tests\Feature\PersonalityCms;
 
 use App\Models\PersonalityProfile;
 use App\Models\PersonalityProfileVariant;
+use App\Models\PersonalityProfileVariantSection;
+use App\Models\PersonalityProfileVariantSeoMeta;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Tests\TestCase;
 
@@ -13,50 +15,52 @@ final class PersonalityVariantAuthorityTest extends TestCase
 {
     use RefreshDatabase;
 
-    public function test_variant_authority_rows_can_coexist_while_public_route_stays_base_only(): void
+    public function test_imported_variant_authority_rows_can_coexist_while_public_route_stays_base_only(): void
     {
-        $profile = PersonalityProfile::query()->create([
-            'org_id' => 0,
-            'scale_code' => PersonalityProfile::SCALE_CODE_MBTI,
-            'type_code' => 'ENFJ',
-            'slug' => 'enfj',
-            'locale' => 'en',
-            'title' => 'ENFJ Personality',
-            'status' => 'published',
-            'is_public' => true,
-            'is_indexable' => true,
-            'published_at' => now()->subMinute(),
-            'schema_version' => PersonalityProfile::SCHEMA_VERSION_V2,
-        ]);
+        $this->artisan('personality:import-local-baseline', [
+            '--locale' => ['en'],
+            '--type' => ['ENFP'],
+            '--upsert' => true,
+            '--status' => 'published',
+            '--source-dir' => 'tests/Fixtures/personality_baseline',
+        ])
+            ->expectsOutputToContain('profiles_found=1')
+            ->expectsOutputToContain('variants_found=2')
+            ->expectsOutputToContain('variant_will_create=2')
+            ->assertExitCode(0);
 
-        $assertive = PersonalityProfileVariant::query()->create([
-            'personality_profile_id' => (int) $profile->id,
-            'canonical_type_code' => 'ENFJ',
-            'variant_code' => 'A',
-            'runtime_type_code' => 'ENFJ-A',
-            'schema_version' => PersonalityProfile::SCHEMA_VERSION_V2,
-        ]);
+        $profile = PersonalityProfile::query()
+            ->withoutGlobalScopes()
+            ->where('type_code', 'ENFP')
+            ->where('locale', 'en')
+            ->firstOrFail();
 
-        $turbulent = PersonalityProfileVariant::query()->create([
-            'personality_profile_id' => (int) $profile->id,
-            'canonical_type_code' => 'ENFJ',
-            'variant_code' => 'T',
-            'runtime_type_code' => 'ENFJ-T',
-            'schema_version' => PersonalityProfile::SCHEMA_VERSION_V2,
-        ]);
+        $assertive = PersonalityProfileVariant::query()
+            ->where('personality_profile_id', (int) $profile->id)
+            ->where('runtime_type_code', 'ENFP-A')
+            ->firstOrFail();
 
-        $this->assertSame('ENFJ', $profile->canonical_type_code);
+        $turbulent = PersonalityProfileVariant::query()
+            ->where('personality_profile_id', (int) $profile->id)
+            ->where('runtime_type_code', 'ENFP-T')
+            ->firstOrFail();
+
+        $this->assertSame('ENFP', $profile->canonical_type_code);
         $this->assertSame('A', $assertive->variant_code);
-        $this->assertSame('ENFJ-A', $assertive->runtime_type_code);
+        $this->assertSame('ENFP-A', $assertive->runtime_type_code);
         $this->assertSame('T', $turbulent->variant_code);
-        $this->assertSame('ENFJ-T', $turbulent->runtime_type_code);
+        $this->assertSame('ENFP-T', $turbulent->runtime_type_code);
+        $this->assertSame(2, PersonalityProfileVariantSection::query()->count());
+        $this->assertSame(2, PersonalityProfileVariantSeoMeta::query()->count());
 
-        $this->getJson('/api/v0.5/personality/enfj?locale=en')
+        $this->getJson('/api/v0.5/personality/enfp?locale=en')
             ->assertOk()
-            ->assertJsonPath('profile.type_code', 'ENFJ')
-            ->assertJsonPath('profile.canonical_type_code', 'ENFJ');
+            ->assertJsonPath('profile.type_code', 'ENFP')
+            ->assertJsonPath('profile.canonical_type_code', 'ENFP')
+            ->assertJsonPath('mbti_public_projection_v1.runtime_type_code', null)
+            ->assertJsonPath('mbti_public_projection_v1.canonical_type_code', 'ENFP');
 
-        $this->getJson('/api/v0.5/personality/enfj-a?locale=en')
+        $this->getJson('/api/v0.5/personality/enfp-a?locale=en')
             ->assertStatus(404);
     }
 }

--- a/backend/tests/Feature/SEO/SitemapGeneratorTest.php
+++ b/backend/tests/Feature/SEO/SitemapGeneratorTest.php
@@ -7,6 +7,8 @@ use App\Models\CareerGuide;
 use App\Models\CareerJob;
 use App\Models\PersonalityProfile;
 use App\Models\PersonalityProfileSeoMeta;
+use App\Models\PersonalityProfileVariant;
+use App\Models\PersonalityProfileVariantSeoMeta;
 use App\Models\TopicProfile;
 use App\Services\Cms\ArticleSeoService;
 use App\Services\Cms\CareerGuideSeoService;
@@ -227,6 +229,28 @@ class SitemapGeneratorTest extends TestCase
         $this->createPersonalitySeoMeta($eligibleZh, [
             'canonical_url' => 'https://staging.fermatmind.com/zh/personality/intj-a',
             'jsonld_overrides_json' => ['mainEntityOfPage' => 'https://staging.fermatmind.com/zh/personality/intj-a'],
+        ]);
+        $eligibleEnVariant = $this->createPersonalityVariant($eligibleEn, [
+            'canonical_type_code' => 'INTJ',
+            'variant_code' => 'A',
+            'runtime_type_code' => 'INTJ-A',
+            'schema_version' => PersonalityProfile::SCHEMA_VERSION_V2,
+            'is_published' => true,
+            'published_at' => Carbon::create(2026, 3, 7, 9, 15, 0, 'UTC'),
+        ]);
+        $this->createPersonalityVariantSeoMeta($eligibleEnVariant, [
+            'canonical_url' => 'https://staging.fermatmind.com/en/personality/intj-a',
+        ]);
+        $eligibleZhVariant = $this->createPersonalityVariant($eligibleZh, [
+            'canonical_type_code' => 'INTJ',
+            'variant_code' => 'T',
+            'runtime_type_code' => 'INTJ-T',
+            'schema_version' => PersonalityProfile::SCHEMA_VERSION_V2,
+            'is_published' => true,
+            'published_at' => Carbon::create(2026, 3, 7, 11, 15, 0, 'UTC'),
+        ]);
+        $this->createPersonalityVariantSeoMeta($eligibleZhVariant, [
+            'canonical_url' => 'https://staging.fermatmind.com/zh/personality/intj-t',
         ]);
 
         $this->createPersonalityProfile([
@@ -658,6 +682,51 @@ class SitemapGeneratorTest extends TestCase
         /** @var PersonalityProfileSeoMeta */
         return PersonalityProfileSeoMeta::query()->create(array_merge([
             'profile_id' => (int) $profile->id,
+            'seo_title' => null,
+            'seo_description' => null,
+            'canonical_url' => null,
+            'og_title' => null,
+            'og_description' => null,
+            'og_image_url' => null,
+            'twitter_title' => null,
+            'twitter_description' => null,
+            'twitter_image_url' => null,
+            'robots' => null,
+            'jsonld_overrides_json' => null,
+        ], $overrides));
+    }
+
+    /**
+     * @param  array<string, mixed>  $overrides
+     */
+    private function createPersonalityVariant(PersonalityProfile $profile, array $overrides = []): PersonalityProfileVariant
+    {
+        /** @var PersonalityProfileVariant */
+        return PersonalityProfileVariant::query()->create(array_merge([
+            'personality_profile_id' => (int) $profile->id,
+            'canonical_type_code' => (string) $profile->type_code,
+            'variant_code' => 'A',
+            'runtime_type_code' => ((string) $profile->type_code).'-A',
+            'type_name' => 'Variant type',
+            'nickname' => 'Variant nickname',
+            'rarity_text' => 'About 3%',
+            'keywords_json' => ['variant'],
+            'hero_summary_md' => 'Variant summary',
+            'hero_summary_html' => null,
+            'schema_version' => PersonalityProfile::SCHEMA_VERSION_V2,
+            'is_published' => true,
+            'published_at' => Carbon::create(2026, 3, 7, 8, 15, 0, 'UTC'),
+        ], $overrides));
+    }
+
+    /**
+     * @param  array<string, mixed>  $overrides
+     */
+    private function createPersonalityVariantSeoMeta(PersonalityProfileVariant $variant, array $overrides = []): PersonalityProfileVariantSeoMeta
+    {
+        /** @var PersonalityProfileVariantSeoMeta */
+        return PersonalityProfileVariantSeoMeta::query()->create(array_merge([
+            'personality_profile_variant_id' => (int) $variant->id,
             'seo_title' => null,
             'seo_description' => null,
             'canonical_url' => null,

--- a/backend/tests/Feature/SEO/SitemapXmlTest.php
+++ b/backend/tests/Feature/SEO/SitemapXmlTest.php
@@ -7,6 +7,8 @@ use App\Models\CareerGuide;
 use App\Models\CareerJob;
 use App\Models\PersonalityProfile;
 use App\Models\PersonalityProfileSeoMeta;
+use App\Models\PersonalityProfileVariant;
+use App\Models\PersonalityProfileVariantSeoMeta;
 use App\Models\TopicProfile;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Carbon;
@@ -138,6 +140,52 @@ class SitemapXmlTest extends TestCase
             'jsonld_overrides_json' => [
                 'mainEntityOfPage' => 'https://staging.fermatmind.com/zh/personality/intj-a',
             ],
+            'created_at' => $nowB,
+            'updated_at' => $nowB,
+        ]);
+        $personalityEnVariant = PersonalityProfileVariant::query()->create([
+            'personality_profile_id' => (int) $personalityEn->id,
+            'canonical_type_code' => 'INTJ',
+            'variant_code' => 'A',
+            'runtime_type_code' => 'INTJ-A',
+            'type_name' => 'Architect Assertive',
+            'nickname' => 'Assertive strategist',
+            'rarity_text' => 'About 3%',
+            'keywords_json' => ['assertive'],
+            'hero_summary_md' => 'Variant summary',
+            'hero_summary_html' => null,
+            'schema_version' => PersonalityProfile::SCHEMA_VERSION_V2,
+            'is_published' => true,
+            'published_at' => Carbon::create(2026, 1, 31, 11, 5, 0),
+            'created_at' => $nowB,
+            'updated_at' => $nowB,
+        ]);
+        PersonalityProfileVariantSeoMeta::query()->create([
+            'personality_profile_variant_id' => (int) $personalityEnVariant->id,
+            'canonical_url' => 'https://staging.fermatmind.com/en/personality/intj-a',
+            'created_at' => $nowB,
+            'updated_at' => $nowB,
+        ]);
+        $personalityZhVariant = PersonalityProfileVariant::query()->create([
+            'personality_profile_id' => (int) $personalityZh->id,
+            'canonical_type_code' => 'INTJ',
+            'variant_code' => 'T',
+            'runtime_type_code' => 'INTJ-T',
+            'type_name' => '建筑师-T',
+            'nickname' => '反思策划者',
+            'rarity_text' => '约 2%',
+            'keywords_json' => ['反思'],
+            'hero_summary_md' => '变体摘要',
+            'hero_summary_html' => null,
+            'schema_version' => PersonalityProfile::SCHEMA_VERSION_V2,
+            'is_published' => true,
+            'published_at' => Carbon::create(2026, 1, 31, 12, 5, 0),
+            'created_at' => $nowB,
+            'updated_at' => $nowB,
+        ]);
+        PersonalityProfileVariantSeoMeta::query()->create([
+            'personality_profile_variant_id' => (int) $personalityZhVariant->id,
+            'canonical_url' => 'https://staging.fermatmind.com/zh/personality/intj-t',
             'created_at' => $nowB,
             'updated_at' => $nowB,
         ]);

--- a/backend/tests/Feature/V0_5/PersonalityPublicApiTest.php
+++ b/backend/tests/Feature/V0_5/PersonalityPublicApiTest.php
@@ -8,6 +8,8 @@ use App\Models\PersonalityProfile;
 use App\Models\PersonalityProfileRevision;
 use App\Models\PersonalityProfileSection;
 use App\Models\PersonalityProfileSeoMeta;
+use App\Models\PersonalityProfileVariant;
+use App\Models\PersonalityProfileVariantSeoMeta;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Tests\TestCase;
 
@@ -155,8 +157,8 @@ final class PersonalityPublicApiTest extends TestCase
         ]);
         PersonalityProfileSection::query()->create([
             'profile_id' => (int) $profile->id,
-            'section_key' => 'strengths',
-            'title' => 'Strengths',
+            'section_key' => 'growth.strengths',
+            'title' => 'Growth strengths',
             'render_variant' => 'bullets',
             'payload_json' => ['items' => [['title' => 'Strategic thinking']]],
             'sort_order' => 20,
@@ -265,6 +267,20 @@ final class PersonalityPublicApiTest extends TestCase
                 'mainEntityOfPage' => 'https://staging.fermatmind.com/en/personality/intj-a',
             ],
         ]);
+        $enVariant = $this->createVariant($enProfile, [
+            'canonical_type_code' => 'INTJ',
+            'variant_code' => 'A',
+            'runtime_type_code' => 'INTJ-A',
+            'schema_version' => PersonalityProfile::SCHEMA_VERSION_V2,
+            'is_published' => true,
+            'published_at' => now()->subMinute(),
+        ]);
+        $this->createVariantSeoMeta($enVariant, [
+            'canonical_url' => 'https://staging.fermatmind.com/en/personality/intj-a',
+            'jsonld_overrides_json' => [
+                'mainEntityOfPage' => 'https://staging.fermatmind.com/en/personality/intj-a',
+            ],
+        ]);
 
         $zhProfile = $this->createProfile([
             'type_code' => 'INTJ',
@@ -283,6 +299,20 @@ final class PersonalityPublicApiTest extends TestCase
             'canonical_url' => 'https://staging.fermatmind.com/zh/personality/intj-a',
             'jsonld_overrides_json' => [
                 'mainEntityOfPage' => 'https://staging.fermatmind.com/zh/personality/intj-a',
+            ],
+        ]);
+        $zhVariant = $this->createVariant($zhProfile, [
+            'canonical_type_code' => 'INTJ',
+            'variant_code' => 'T',
+            'runtime_type_code' => 'INTJ-T',
+            'schema_version' => PersonalityProfile::SCHEMA_VERSION_V2,
+            'is_published' => true,
+            'published_at' => now()->subMinute(),
+        ]);
+        $this->createVariantSeoMeta($zhVariant, [
+            'canonical_url' => 'https://staging.fermatmind.com/zh/personality/intj-t',
+            'jsonld_overrides_json' => [
+                'mainEntityOfPage' => 'https://staging.fermatmind.com/zh/personality/intj-t',
             ],
         ]);
 
@@ -309,7 +339,7 @@ final class PersonalityPublicApiTest extends TestCase
 
     public function test_variant_route_key_remains_invalid_for_public_base_route(): void
     {
-        $this->createProfile([
+        $profile = $this->createProfile([
             'type_code' => 'INTJ',
             'slug' => 'intj',
             'status' => 'published',
@@ -317,6 +347,20 @@ final class PersonalityPublicApiTest extends TestCase
             'published_at' => now()->subMinute(),
             'schema_version' => PersonalityProfile::SCHEMA_VERSION_V2,
         ]);
+        $this->createVariant($profile, [
+            'canonical_type_code' => 'INTJ',
+            'variant_code' => 'A',
+            'runtime_type_code' => 'INTJ-A',
+            'schema_version' => PersonalityProfile::SCHEMA_VERSION_V2,
+            'is_published' => true,
+            'published_at' => now()->subMinute(),
+        ]);
+
+        $this->getJson('/api/v0.5/personality/intj?locale=en')
+            ->assertOk()
+            ->assertJsonPath('profile.canonical_type_code', 'INTJ')
+            ->assertJsonPath('mbti_public_projection_v1.runtime_type_code', null)
+            ->assertJsonPath('mbti_public_projection_v1.display_type', 'INTJ');
 
         $this->getJson('/api/v0.5/personality/intj-a?locale=en')
             ->assertStatus(404)
@@ -355,6 +399,51 @@ final class PersonalityPublicApiTest extends TestCase
         /** @var PersonalityProfileSeoMeta */
         return PersonalityProfileSeoMeta::query()->create(array_merge([
             'profile_id' => (int) $profile->id,
+            'seo_title' => null,
+            'seo_description' => null,
+            'canonical_url' => null,
+            'og_title' => null,
+            'og_description' => null,
+            'og_image_url' => null,
+            'twitter_title' => null,
+            'twitter_description' => null,
+            'twitter_image_url' => null,
+            'robots' => null,
+            'jsonld_overrides_json' => null,
+        ], $overrides));
+    }
+
+    /**
+     * @param  array<string, mixed>  $overrides
+     */
+    private function createVariant(PersonalityProfile $profile, array $overrides = []): PersonalityProfileVariant
+    {
+        /** @var PersonalityProfileVariant */
+        return PersonalityProfileVariant::query()->create(array_merge([
+            'personality_profile_id' => (int) $profile->id,
+            'canonical_type_code' => (string) $profile->type_code,
+            'variant_code' => 'A',
+            'runtime_type_code' => ((string) $profile->type_code).'-A',
+            'type_name' => 'Variant type',
+            'nickname' => 'Variant nickname',
+            'rarity_text' => 'About 3%',
+            'keywords_json' => ['variant'],
+            'hero_summary_md' => 'Variant summary',
+            'hero_summary_html' => null,
+            'schema_version' => PersonalityProfile::SCHEMA_VERSION_V2,
+            'is_published' => true,
+            'published_at' => now()->subMinute(),
+        ], $overrides));
+    }
+
+    /**
+     * @param  array<string, mixed>  $overrides
+     */
+    private function createVariantSeoMeta(PersonalityProfileVariant $variant, array $overrides = []): PersonalityProfileVariantSeoMeta
+    {
+        /** @var PersonalityProfileVariantSeoMeta */
+        return PersonalityProfileVariantSeoMeta::query()->create(array_merge([
+            'personality_profile_variant_id' => (int) $variant->id,
             'seo_title' => null,
             'seo_description' => null,
             'canonical_url' => null,

--- a/backend/tests/Fixtures/personality_baseline/mbti.en.json
+++ b/backend/tests/Fixtures/personality_baseline/mbti.en.json
@@ -1,6 +1,6 @@
 {
   "meta": {
-    "schema_version": "v1",
+    "schema_version": "v2",
     "scale_code": "MBTI",
     "locale": "en",
     "source": "test fixture",
@@ -11,10 +11,19 @@
       "type_code": "INTJ",
       "slug": "intj",
       "title": "INTJ - Architect",
+      "type_name": "Architect",
+      "nickname": "Systems builder",
+      "rarity_text": "About 2%",
+      "keywords_json": [
+        "strategy",
+        "independence"
+      ],
       "subtitle": null,
       "excerpt": "Strategic and future-oriented.",
       "hero_kicker": "Architect",
       "hero_quote": null,
+      "hero_summary_md": "Strategic, independent, and long-range.",
+      "hero_summary_html": null,
       "hero_image_url": null,
       "status": "published",
       "is_public": true,
@@ -23,46 +32,44 @@
       "scheduled_at": null,
       "sections": [
         {
-          "section_key": "core_snapshot",
-          "title": "Core snapshot",
+          "section_key": "overview",
+          "title": "Overview",
           "render_variant": "rich_text",
           "body_md": "INTJs often focus on structure, strategy, and long-range planning.",
           "body_html": null,
           "payload_json": null,
-          "sort_order": 10,
+          "sort_order": 20,
           "is_enabled": true
         },
         {
-          "section_key": "strengths",
-          "title": "Strengths",
+          "section_key": "growth.strengths",
+          "title": "Growth strengths",
           "render_variant": "bullets",
           "body_md": null,
           "body_html": null,
           "payload_json": {
             "items": [
-              { "title": "System thinking", "body": null },
-              { "title": "Strategic planning", "body": null }
+              {
+                "title": "System thinking",
+                "body": null
+              },
+              {
+                "title": "Strategic planning",
+                "body": null
+              }
             ]
           },
-          "sort_order": 20,
+          "sort_order": 100,
           "is_enabled": true
         },
         {
-          "section_key": "career_fit",
-          "title": "Career fit",
-          "render_variant": "cards",
+          "section_key": "career.summary",
+          "title": "Career summary",
+          "render_variant": "rich_text",
           "body_md": "INTJs usually perform best when the environment is structured and autonomous.",
           "body_html": null,
-          "payload_json": {
-            "recommended_jobs": [
-              { "slug": "product-manager", "title": "Product Manager" }
-            ],
-            "avoid_jobs": [
-              { "slug": "teacher", "title": "Teacher" }
-            ],
-            "work_env": "Clear metrics and independent execution"
-          },
-          "sort_order": 80,
+          "payload_json": null,
+          "sort_order": 40,
           "is_enabled": true
         }
       ],
@@ -84,10 +91,19 @@
       "type_code": "ENFP",
       "slug": "enfp",
       "title": "ENFP - Campaigner",
+      "type_name": "Campaigner",
+      "nickname": "Idea spark",
+      "rarity_text": "About 8%",
+      "keywords_json": [
+        "curiosity",
+        "energy"
+      ],
       "subtitle": null,
       "excerpt": "Curious, energetic, and possibility-driven.",
       "hero_kicker": "Campaigner",
       "hero_quote": null,
+      "hero_summary_md": "ENFPs often thrive when they can connect ideas, people, and momentum.",
+      "hero_summary_html": null,
       "hero_image_url": null,
       "status": "published",
       "is_public": true,
@@ -96,34 +112,199 @@
       "scheduled_at": null,
       "sections": [
         {
-          "section_key": "core_snapshot",
-          "title": "Core snapshot",
+          "section_key": "overview",
+          "title": "Overview",
           "render_variant": "rich_text",
           "body_md": "ENFPs often thrive when they can connect ideas, people, and momentum.",
           "body_html": null,
           "payload_json": null,
-          "sort_order": 10,
+          "sort_order": 20,
           "is_enabled": true
         },
         {
-          "section_key": "strengths",
-          "title": "Strengths",
-          "render_variant": "bullets",
-          "body_md": null,
+          "section_key": "relationships.summary",
+          "title": "Relationships summary",
+          "render_variant": "rich_text",
+          "body_md": "ENFPs look for openness, warmth, and room to grow together.",
           "body_html": null,
-          "payload_json": {
-            "items": [
-              { "title": "Creative range", "body": null },
-              { "title": "High social energy", "body": null }
-            ]
-          },
-          "sort_order": 20,
+          "payload_json": null,
+          "sort_order": 140,
           "is_enabled": true
         }
       ],
       "seo_meta": {
         "seo_title": "ENFP Personality Guide",
         "seo_description": "Discover strengths, risks, and career fit for ENFP.",
+        "canonical_url": null,
+        "og_title": null,
+        "og_description": null,
+        "og_image_url": null,
+        "twitter_title": null,
+        "twitter_description": null,
+        "twitter_image_url": null,
+        "robots": null,
+        "jsonld_overrides_json": null
+      }
+    }
+  ],
+  "variants": [
+    {
+      "runtime_type_code": "INTJ-A",
+      "canonical_type_code": "INTJ",
+      "variant_code": "A",
+      "is_published": true,
+      "published_at": "2026-03-08T00:00:00Z",
+      "profile_overrides": {
+        "type_name": "Architect Assertive",
+        "nickname": "Assertive strategist",
+        "rarity_text": "About 3%",
+        "keywords_json": [
+          "assertive",
+          "strategy"
+        ],
+        "hero_summary_md": "More steady under pressure and quicker to trust the plan.",
+        "hero_summary_html": null
+      },
+      "section_overrides": [
+        {
+          "section_key": "overview",
+          "render_variant": "rich_text",
+          "body_md": "INTJ-A tends to stay composed while executing long-range plans.",
+          "body_html": null,
+          "payload_json": null,
+          "sort_order": 20,
+          "is_enabled": true
+        }
+      ],
+      "seo_overrides": {
+        "seo_title": "INTJ-A Personality Guide",
+        "seo_description": "Assertive INTJ strengths, blind spots, and growth advice.",
+        "canonical_url": null,
+        "og_title": "INTJ-A Personality Guide",
+        "og_description": null,
+        "og_image_url": null,
+        "twitter_title": null,
+        "twitter_description": null,
+        "twitter_image_url": null,
+        "robots": null,
+        "jsonld_overrides_json": null
+      }
+    },
+    {
+      "runtime_type_code": "INTJ-T",
+      "canonical_type_code": "INTJ",
+      "variant_code": "T",
+      "is_published": false,
+      "published_at": null,
+      "profile_overrides": {
+        "type_name": "Architect Turbulent",
+        "nickname": "Reflective strategist",
+        "rarity_text": "About 2%",
+        "keywords_json": [
+          "reflective",
+          "precision"
+        ],
+        "hero_summary_md": "More self-questioning and more likely to refine the system twice.",
+        "hero_summary_html": null
+      },
+      "section_overrides": [
+        {
+          "section_key": "overview",
+          "render_variant": "rich_text",
+          "body_md": "INTJ-T often double-checks assumptions before locking the system in place.",
+          "body_html": null,
+          "payload_json": null,
+          "sort_order": 20,
+          "is_enabled": true
+        }
+      ],
+      "seo_overrides": {
+        "seo_title": "INTJ-T Personality Guide",
+        "seo_description": "Turbulent INTJ strengths, blind spots, and growth advice.",
+        "canonical_url": null,
+        "og_title": null,
+        "og_description": null,
+        "og_image_url": null,
+        "twitter_title": null,
+        "twitter_description": null,
+        "twitter_image_url": null,
+        "robots": null,
+        "jsonld_overrides_json": null
+      }
+    },
+    {
+      "runtime_type_code": "ENFP-A",
+      "canonical_type_code": "ENFP",
+      "variant_code": "A",
+      "is_published": false,
+      "published_at": null,
+      "profile_overrides": {
+        "type_name": "Campaigner Assertive",
+        "nickname": "Confident spark",
+        "rarity_text": "About 7%",
+        "keywords_json": [
+          "bold",
+          "optimistic"
+        ],
+        "hero_summary_md": "More comfortable leading with momentum and positive energy.",
+        "hero_summary_html": null
+      },
+      "section_overrides": [
+        {
+          "section_key": "overview",
+          "render_variant": "rich_text",
+          "body_md": "ENFP-A brings visible confidence into new people-and-ideas spaces.",
+          "body_html": null,
+          "payload_json": null,
+          "sort_order": 20,
+          "is_enabled": true
+        }
+      ],
+      "seo_overrides": {
+        "seo_title": "ENFP-A Personality Guide",
+        "seo_description": "Assertive ENFP strengths, blind spots, and growth advice.",
+        "canonical_url": null,
+        "og_title": null,
+        "og_description": null,
+        "og_image_url": null,
+        "twitter_title": null,
+        "twitter_description": null,
+        "twitter_image_url": null,
+        "robots": null,
+        "jsonld_overrides_json": null
+      }
+    },
+    {
+      "runtime_type_code": "ENFP-T",
+      "canonical_type_code": "ENFP",
+      "variant_code": "T",
+      "is_published": true,
+      "published_at": "2026-03-08T00:00:00Z",
+      "profile_overrides": {
+        "type_name": "Campaigner Turbulent",
+        "nickname": "Sensitive spark",
+        "rarity_text": "About 9%",
+        "keywords_json": [
+          "sensitive",
+          "adaptive"
+        ],
+        "hero_summary_md": "More sensitive to feedback and more likely to rework the message.",
+        "hero_summary_html": null
+      },
+      "section_overrides": [
+        {
+          "section_key": "overview",
+          "render_variant": "rich_text",
+          "body_md": "ENFP-T processes emotional feedback deeply before re-entering the room.",
+          "body_html": null,
+          "payload_json": null,
+          "sort_order": 20,
+          "is_enabled": true
+        }
+      ],
+      "seo_overrides": {
+        "seo_title": "ENFP-T Personality Guide",
+        "seo_description": "Turbulent ENFP strengths, blind spots, and growth advice.",
         "canonical_url": null,
         "og_title": null,
         "og_description": null,

--- a/backend/tests/Fixtures/personality_baseline/mbti.zh-CN.json
+++ b/backend/tests/Fixtures/personality_baseline/mbti.zh-CN.json
@@ -1,6 +1,6 @@
 {
   "meta": {
-    "schema_version": "v1",
+    "schema_version": "v2",
     "scale_code": "MBTI",
     "locale": "zh-CN",
     "source": "test fixture",
@@ -11,10 +11,19 @@
       "type_code": "INTJ",
       "slug": "intj",
       "title": "INTJ - 建筑师",
+      "type_name": "建筑师",
+      "nickname": "系统策划者",
+      "rarity_text": "约 2%",
+      "keywords_json": [
+        "战略",
+        "独立"
+      ],
       "subtitle": null,
       "excerpt": "偏好战略与长期规划。",
       "hero_kicker": "建筑师",
       "hero_quote": null,
+      "hero_summary_md": "理性、战略、面向未来。",
+      "hero_summary_html": null,
       "hero_image_url": null,
       "status": "published",
       "is_public": true,
@@ -23,28 +32,44 @@
       "scheduled_at": null,
       "sections": [
         {
-          "section_key": "core_snapshot",
-          "title": "核心概览",
+          "section_key": "overview",
+          "title": "概览",
           "render_variant": "rich_text",
           "body_md": "INTJ 通常重视结构、战略和长期方向。",
           "body_html": null,
           "payload_json": null,
-          "sort_order": 10,
+          "sort_order": 20,
           "is_enabled": true
         },
         {
-          "section_key": "strengths",
-          "title": "优势",
+          "section_key": "growth.strengths",
+          "title": "成长优势",
           "render_variant": "bullets",
           "body_md": null,
           "body_html": null,
           "payload_json": {
             "items": [
-              { "title": "系统化思考", "body": null },
-              { "title": "长期规划", "body": null }
+              {
+                "title": "系统化思考",
+                "body": null
+              },
+              {
+                "title": "长期规划",
+                "body": null
+              }
             ]
           },
-          "sort_order": 20,
+          "sort_order": 100,
+          "is_enabled": true
+        },
+        {
+          "section_key": "career.summary",
+          "title": "职业概览",
+          "render_variant": "rich_text",
+          "body_md": "INTJ 更适合结构清晰且能独立推进的环境。",
+          "body_html": null,
+          "payload_json": null,
+          "sort_order": 40,
           "is_enabled": true
         }
       ],
@@ -66,10 +91,19 @@
       "type_code": "ENFP",
       "slug": "enfp",
       "title": "ENFP - 竞选者",
+      "type_name": "竞选者",
+      "nickname": "灵感点火者",
+      "rarity_text": "约 8%",
+      "keywords_json": [
+        "热情",
+        "好奇"
+      ],
       "subtitle": null,
       "excerpt": "充满好奇、热情且看重可能性。",
       "hero_kicker": "竞选者",
       "hero_quote": null,
+      "hero_summary_md": "擅长连接想法、人与机会。",
+      "hero_summary_html": null,
       "hero_image_url": null,
       "status": "published",
       "is_public": true,
@@ -78,34 +112,199 @@
       "scheduled_at": null,
       "sections": [
         {
-          "section_key": "core_snapshot",
-          "title": "核心概览",
+          "section_key": "overview",
+          "title": "概览",
           "render_variant": "rich_text",
           "body_md": "ENFP 通常在连接想法、人与机会时表现更好。",
           "body_html": null,
           "payload_json": null,
-          "sort_order": 10,
+          "sort_order": 20,
           "is_enabled": true
         },
         {
-          "section_key": "strengths",
-          "title": "优势",
-          "render_variant": "bullets",
-          "body_md": null,
+          "section_key": "relationships.summary",
+          "title": "关系概览",
+          "render_variant": "rich_text",
+          "body_md": "ENFP 重视真诚、温度与共同成长。",
           "body_html": null,
-          "payload_json": {
-            "items": [
-              { "title": "创意延展性", "body": null },
-              { "title": "高社交能量", "body": null }
-            ]
-          },
-          "sort_order": 20,
+          "payload_json": null,
+          "sort_order": 140,
           "is_enabled": true
         }
       ],
       "seo_meta": {
         "seo_title": "ENFP 人格指南",
         "seo_description": "了解 ENFP 的优势、风险与职业匹配。",
+        "canonical_url": null,
+        "og_title": null,
+        "og_description": null,
+        "og_image_url": null,
+        "twitter_title": null,
+        "twitter_description": null,
+        "twitter_image_url": null,
+        "robots": null,
+        "jsonld_overrides_json": null
+      }
+    }
+  ],
+  "variants": [
+    {
+      "runtime_type_code": "INTJ-A",
+      "canonical_type_code": "INTJ",
+      "variant_code": "A",
+      "is_published": true,
+      "published_at": "2026-03-08T00:00:00Z",
+      "profile_overrides": {
+        "type_name": "建筑师-A",
+        "nickname": "稳态策划者",
+        "rarity_text": "约 3%",
+        "keywords_json": [
+          "稳态",
+          "自信"
+        ],
+        "hero_summary_md": "在压力下更稳，更容易相信自己的判断。",
+        "hero_summary_html": null
+      },
+      "section_overrides": [
+        {
+          "section_key": "overview",
+          "render_variant": "rich_text",
+          "body_md": "INTJ-A 在执行长期计划时更稳定，更少被情绪打断。",
+          "body_html": null,
+          "payload_json": null,
+          "sort_order": 20,
+          "is_enabled": true
+        }
+      ],
+      "seo_overrides": {
+        "seo_title": "INTJ-A 人格指南",
+        "seo_description": "了解 INTJ-A 的优势、盲点与成长建议。",
+        "canonical_url": null,
+        "og_title": "INTJ-A 人格指南",
+        "og_description": null,
+        "og_image_url": null,
+        "twitter_title": null,
+        "twitter_description": null,
+        "twitter_image_url": null,
+        "robots": null,
+        "jsonld_overrides_json": null
+      }
+    },
+    {
+      "runtime_type_code": "INTJ-T",
+      "canonical_type_code": "INTJ",
+      "variant_code": "T",
+      "is_published": true,
+      "published_at": "2026-03-08T00:00:00Z",
+      "profile_overrides": {
+        "type_name": "建筑师-T",
+        "nickname": "反思策划者",
+        "rarity_text": "约 2%",
+        "keywords_json": [
+          "反思",
+          "精确"
+        ],
+        "hero_summary_md": "更容易反复校准判断，也更重视精确度。",
+        "hero_summary_html": null
+      },
+      "section_overrides": [
+        {
+          "section_key": "overview",
+          "render_variant": "rich_text",
+          "body_md": "INTJ-T 更常复盘假设，再决定是否推进方案。",
+          "body_html": null,
+          "payload_json": null,
+          "sort_order": 20,
+          "is_enabled": true
+        }
+      ],
+      "seo_overrides": {
+        "seo_title": "INTJ-T 人格指南",
+        "seo_description": "了解 INTJ-T 的优势、盲点与成长建议。",
+        "canonical_url": null,
+        "og_title": null,
+        "og_description": null,
+        "og_image_url": null,
+        "twitter_title": null,
+        "twitter_description": null,
+        "twitter_image_url": null,
+        "robots": null,
+        "jsonld_overrides_json": null
+      }
+    },
+    {
+      "runtime_type_code": "ENFP-A",
+      "canonical_type_code": "ENFP",
+      "variant_code": "A",
+      "is_published": true,
+      "published_at": "2026-03-08T00:00:00Z",
+      "profile_overrides": {
+        "type_name": "竞选者-A",
+        "nickname": "自信点火者",
+        "rarity_text": "约 7%",
+        "keywords_json": [
+          "热情",
+          "果断"
+        ],
+        "hero_summary_md": "更愿意主动带动气氛，也更快把灵感变成行动。",
+        "hero_summary_html": null
+      },
+      "section_overrides": [
+        {
+          "section_key": "overview",
+          "render_variant": "rich_text",
+          "body_md": "ENFP-A 更敢于先开场，再在互动中调整节奏。",
+          "body_html": null,
+          "payload_json": null,
+          "sort_order": 20,
+          "is_enabled": true
+        }
+      ],
+      "seo_overrides": {
+        "seo_title": "ENFP-A 人格指南",
+        "seo_description": "了解 ENFP-A 的优势、盲点与成长建议。",
+        "canonical_url": null,
+        "og_title": null,
+        "og_description": null,
+        "og_image_url": null,
+        "twitter_title": null,
+        "twitter_description": null,
+        "twitter_image_url": null,
+        "robots": null,
+        "jsonld_overrides_json": null
+      }
+    },
+    {
+      "runtime_type_code": "ENFP-T",
+      "canonical_type_code": "ENFP",
+      "variant_code": "T",
+      "is_published": true,
+      "published_at": "2026-03-08T00:00:00Z",
+      "profile_overrides": {
+        "type_name": "竞选者-T",
+        "nickname": "敏感点火者",
+        "rarity_text": "约 9%",
+        "keywords_json": [
+          "敏感",
+          "适应"
+        ],
+        "hero_summary_md": "更会感知反馈，也更容易为关系细节停下来。",
+        "hero_summary_html": null
+      },
+      "section_overrides": [
+        {
+          "section_key": "overview",
+          "render_variant": "rich_text",
+          "body_md": "ENFP-T 会更深地处理反馈，再决定如何重新进入关系和场域。",
+          "body_html": null,
+          "payload_json": null,
+          "sort_order": 20,
+          "is_enabled": true
+        }
+      ],
+      "seo_overrides": {
+        "seo_title": "ENFP-T 人格指南",
+        "seo_description": "了解 ENFP-T 的优势、盲点与成长建议。",
         "canonical_url": null,
         "og_title": null,
         "og_description": null,

--- a/content_baselines/personality/mbti.en.json
+++ b/content_baselines/personality/mbti.en.json
@@ -1,20 +1,26 @@
 {
   "meta": {
-    "schema_version": "v1",
+    "schema_version": "v2",
     "scale_code": "MBTI",
     "locale": "en",
-    "source": "fap-web careerRecommendationProfiles + personality.ts deterministic transforms",
-    "generated_at": "2026-03-08T00:00:00Z"
+    "source": "committed canonical base authority + placeholder variant authority until raw 32 source exists",
+    "generated_at": "2026-03-17T00:00:00Z"
   },
   "profiles": [
     {
       "type_code": "ENFJ",
       "slug": "enfj",
       "title": "ENFJ - Protagonist",
+      "type_name": "Protagonist",
+      "nickname": "Protagonist",
+      "rarity_text": null,
+      "keywords_json": [],
       "subtitle": null,
       "excerpt": "Role recommendations and work-environment guidance for ENFJ profiles.",
       "hero_kicker": "Protagonist",
       "hero_quote": null,
+      "hero_summary_md": "Role recommendations and work-environment guidance for ENFJ profiles.",
+      "hero_summary_html": null,
       "hero_image_url": null,
       "status": "published",
       "is_public": true,
@@ -23,18 +29,18 @@
       "scheduled_at": null,
       "sections": [
         {
-          "section_key": "core_snapshot",
-          "title": "Core snapshot",
+          "section_key": "overview",
+          "title": "Overview",
           "render_variant": "rich_text",
           "body_md": "Role recommendations and work-environment guidance for ENFJ profiles. This profile tends to do best when goals are explicit, feedback is available, and growth loops stay visible.",
           "body_html": null,
           "payload_json": null,
-          "sort_order": 10,
+          "sort_order": 20,
           "is_enabled": true
         },
         {
-          "section_key": "strengths",
-          "title": "Strengths",
+          "section_key": "growth.strengths",
+          "title": "Growth strengths",
           "render_variant": "bullets",
           "body_md": null,
           "body_html": null,
@@ -54,12 +60,12 @@
               }
             ]
           },
-          "sort_order": 20,
+          "sort_order": 100,
           "is_enabled": true
         },
         {
-          "section_key": "growth_edges",
-          "title": "Growth edges",
+          "section_key": "growth.weaknesses",
+          "title": "Growth weaknesses",
           "render_variant": "bullets",
           "body_md": null,
           "body_html": null,
@@ -75,34 +81,44 @@
               }
             ]
           },
-          "sort_order": 30,
+          "sort_order": 110,
           "is_enabled": true
         },
         {
-          "section_key": "work_style",
-          "title": "Work style",
+          "section_key": "growth.summary",
+          "title": "Growth summary",
           "render_variant": "rich_text",
           "body_md": "High-autonomy role scope, clear success metrics, and consistent feedback cadence.",
+          "body_html": null,
+          "payload_json": null,
+          "sort_order": 90,
+          "is_enabled": true
+        },
+        {
+          "section_key": "relationships.summary",
+          "title": "Relationships summary",
+          "render_variant": "rich_text",
+          "body_md": "You usually build trust through direct dialogue, shared activity, and fast feedback. You tend to connect more deeply with people who enjoy discussing patterns, future possibilities, and meaning. In conflict you often default to harmony and emotional tone, so it helps to make your principles explicit. In close relationships and teamwork, you usually prefer clarity, commitment, and predictable pace.",
+          "body_html": null,
+          "payload_json": null,
+          "sort_order": 140,
+          "is_enabled": true
+        },
+        {
+          "section_key": "career.summary",
+          "title": "Career summary",
+          "render_variant": "rich_text",
+          "body_md": "You usually perform best in high-autonomy role scope, clear success metrics, and consistent feedback cadence. Prioritize options like Lawyer, Teacher, Machine Learning Engineer.",
           "body_html": null,
           "payload_json": null,
           "sort_order": 40,
           "is_enabled": true
         },
         {
-          "section_key": "relationships",
-          "title": "Relationships",
-          "render_variant": "rich_text",
-          "body_md": "You usually build trust through direct dialogue, shared activity, and fast feedback. You tend to connect more deeply with people who enjoy discussing patterns, future possibilities, and meaning. In conflict you often default to harmony and emotional tone, so it helps to make your principles explicit. In close relationships and teamwork, you usually prefer clarity, commitment, and predictable pace.",
-          "body_html": null,
-          "payload_json": null,
-          "sort_order": 50,
-          "is_enabled": true
-        },
-        {
-          "section_key": "career_fit",
-          "title": "Career fit",
-          "render_variant": "cards",
-          "body_md": "You usually perform best in high-autonomy role scope, clear success metrics, and consistent feedback cadence. Prioritize options like Lawyer, Teacher, Machine Learning Engineer.",
+          "section_key": "career.preferred_roles",
+          "title": "Preferred roles",
+          "render_variant": "preferred_role_list",
+          "body_md": null,
           "body_html": null,
           "payload_json": {
             "recommended_jobs": [
@@ -147,7 +163,7 @@
             ],
             "work_env": "High-autonomy role scope, clear success metrics, and consistent feedback cadence."
           },
-          "sort_order": 80,
+          "sort_order": 70,
           "is_enabled": true
         }
       ],
@@ -169,10 +185,16 @@
       "type_code": "ENFP",
       "slug": "enfp",
       "title": "ENFP - Campaigner",
+      "type_name": "Campaigner",
+      "nickname": "Campaigner",
+      "rarity_text": null,
+      "keywords_json": [],
       "subtitle": null,
       "excerpt": "Role recommendations and work-environment guidance for ENFP profiles.",
       "hero_kicker": "Campaigner",
       "hero_quote": null,
+      "hero_summary_md": "Role recommendations and work-environment guidance for ENFP profiles.",
+      "hero_summary_html": null,
       "hero_image_url": null,
       "status": "published",
       "is_public": true,
@@ -181,18 +203,18 @@
       "scheduled_at": null,
       "sections": [
         {
-          "section_key": "core_snapshot",
-          "title": "Core snapshot",
+          "section_key": "overview",
+          "title": "Overview",
           "render_variant": "rich_text",
           "body_md": "Role recommendations and work-environment guidance for ENFP profiles. This profile tends to do best when goals are explicit, feedback is available, and growth loops stay visible.",
           "body_html": null,
           "payload_json": null,
-          "sort_order": 10,
+          "sort_order": 20,
           "is_enabled": true
         },
         {
-          "section_key": "strengths",
-          "title": "Strengths",
+          "section_key": "growth.strengths",
+          "title": "Growth strengths",
           "render_variant": "bullets",
           "body_md": null,
           "body_html": null,
@@ -212,12 +234,12 @@
               }
             ]
           },
-          "sort_order": 20,
+          "sort_order": 100,
           "is_enabled": true
         },
         {
-          "section_key": "growth_edges",
-          "title": "Growth edges",
+          "section_key": "growth.weaknesses",
+          "title": "Growth weaknesses",
           "render_variant": "bullets",
           "body_md": null,
           "body_html": null,
@@ -233,34 +255,44 @@
               }
             ]
           },
-          "sort_order": 30,
+          "sort_order": 110,
           "is_enabled": true
         },
         {
-          "section_key": "work_style",
-          "title": "Work style",
+          "section_key": "growth.summary",
+          "title": "Growth summary",
           "render_variant": "rich_text",
           "body_md": "High-autonomy role scope, clear success metrics, and consistent feedback cadence.",
+          "body_html": null,
+          "payload_json": null,
+          "sort_order": 90,
+          "is_enabled": true
+        },
+        {
+          "section_key": "relationships.summary",
+          "title": "Relationships summary",
+          "render_variant": "rich_text",
+          "body_md": "You usually build trust through direct dialogue, shared activity, and fast feedback. You tend to connect more deeply with people who enjoy discussing patterns, future possibilities, and meaning. In conflict you often default to harmony and emotional tone, so it helps to make your principles explicit. In close relationships and teamwork, you usually prefer flexibility, openness, and room to adapt.",
+          "body_html": null,
+          "payload_json": null,
+          "sort_order": 140,
+          "is_enabled": true
+        },
+        {
+          "section_key": "career.summary",
+          "title": "Career summary",
+          "render_variant": "rich_text",
+          "body_md": "You usually perform best in high-autonomy role scope, clear success metrics, and consistent feedback cadence. Prioritize options like Physician, Data Scientist, Frontend Engineer.",
           "body_html": null,
           "payload_json": null,
           "sort_order": 40,
           "is_enabled": true
         },
         {
-          "section_key": "relationships",
-          "title": "Relationships",
-          "render_variant": "rich_text",
-          "body_md": "You usually build trust through direct dialogue, shared activity, and fast feedback. You tend to connect more deeply with people who enjoy discussing patterns, future possibilities, and meaning. In conflict you often default to harmony and emotional tone, so it helps to make your principles explicit. In close relationships and teamwork, you usually prefer flexibility, openness, and room to adapt.",
-          "body_html": null,
-          "payload_json": null,
-          "sort_order": 50,
-          "is_enabled": true
-        },
-        {
-          "section_key": "career_fit",
-          "title": "Career fit",
-          "render_variant": "cards",
-          "body_md": "You usually perform best in high-autonomy role scope, clear success metrics, and consistent feedback cadence. Prioritize options like Physician, Data Scientist, Frontend Engineer.",
+          "section_key": "career.preferred_roles",
+          "title": "Preferred roles",
+          "render_variant": "preferred_role_list",
+          "body_md": null,
           "body_html": null,
           "payload_json": {
             "recommended_jobs": [
@@ -305,7 +337,7 @@
             ],
             "work_env": "High-autonomy role scope, clear success metrics, and consistent feedback cadence."
           },
-          "sort_order": 80,
+          "sort_order": 70,
           "is_enabled": true
         }
       ],
@@ -327,10 +359,16 @@
       "type_code": "ENTJ",
       "slug": "entj",
       "title": "ENTJ - Commander",
+      "type_name": "Commander",
+      "nickname": "Commander",
+      "rarity_text": null,
+      "keywords_json": [],
       "subtitle": null,
       "excerpt": "Role recommendations and work-environment guidance for ENTJ profiles.",
       "hero_kicker": "Commander",
       "hero_quote": null,
+      "hero_summary_md": "Role recommendations and work-environment guidance for ENTJ profiles.",
+      "hero_summary_html": null,
       "hero_image_url": null,
       "status": "published",
       "is_public": true,
@@ -339,18 +377,18 @@
       "scheduled_at": null,
       "sections": [
         {
-          "section_key": "core_snapshot",
-          "title": "Core snapshot",
+          "section_key": "overview",
+          "title": "Overview",
           "render_variant": "rich_text",
           "body_md": "Role recommendations and work-environment guidance for ENTJ profiles. This profile tends to do best when goals are explicit, feedback is available, and growth loops stay visible.",
           "body_html": null,
           "payload_json": null,
-          "sort_order": 10,
+          "sort_order": 20,
           "is_enabled": true
         },
         {
-          "section_key": "strengths",
-          "title": "Strengths",
+          "section_key": "growth.strengths",
+          "title": "Growth strengths",
           "render_variant": "bullets",
           "body_md": null,
           "body_html": null,
@@ -370,12 +408,12 @@
               }
             ]
           },
-          "sort_order": 20,
+          "sort_order": 100,
           "is_enabled": true
         },
         {
-          "section_key": "growth_edges",
-          "title": "Growth edges",
+          "section_key": "growth.weaknesses",
+          "title": "Growth weaknesses",
           "render_variant": "bullets",
           "body_md": null,
           "body_html": null,
@@ -391,34 +429,44 @@
               }
             ]
           },
-          "sort_order": 30,
+          "sort_order": 110,
           "is_enabled": true
         },
         {
-          "section_key": "work_style",
-          "title": "Work style",
+          "section_key": "growth.summary",
+          "title": "Growth summary",
           "render_variant": "rich_text",
           "body_md": "High-autonomy role scope, clear success metrics, and consistent feedback cadence.",
+          "body_html": null,
+          "payload_json": null,
+          "sort_order": 90,
+          "is_enabled": true
+        },
+        {
+          "section_key": "relationships.summary",
+          "title": "Relationships summary",
+          "render_variant": "rich_text",
+          "body_md": "You usually build trust through direct dialogue, shared activity, and fast feedback. You tend to connect more deeply with people who enjoy discussing patterns, future possibilities, and meaning. In conflict you often default to logic and boundaries, so it helps to add explicit emotional acknowledgment. In close relationships and teamwork, you usually prefer clarity, commitment, and predictable pace.",
+          "body_html": null,
+          "payload_json": null,
+          "sort_order": 140,
+          "is_enabled": true
+        },
+        {
+          "section_key": "career.summary",
+          "title": "Career summary",
+          "render_variant": "rich_text",
+          "body_md": "You usually perform best in high-autonomy role scope, clear success metrics, and consistent feedback cadence. Prioritize options like UI/UX Designer, Digital Marketing Manager, Lawyer.",
           "body_html": null,
           "payload_json": null,
           "sort_order": 40,
           "is_enabled": true
         },
         {
-          "section_key": "relationships",
-          "title": "Relationships",
-          "render_variant": "rich_text",
-          "body_md": "You usually build trust through direct dialogue, shared activity, and fast feedback. You tend to connect more deeply with people who enjoy discussing patterns, future possibilities, and meaning. In conflict you often default to logic and boundaries, so it helps to add explicit emotional acknowledgment. In close relationships and teamwork, you usually prefer clarity, commitment, and predictable pace.",
-          "body_html": null,
-          "payload_json": null,
-          "sort_order": 50,
-          "is_enabled": true
-        },
-        {
-          "section_key": "career_fit",
-          "title": "Career fit",
-          "render_variant": "cards",
-          "body_md": "You usually perform best in high-autonomy role scope, clear success metrics, and consistent feedback cadence. Prioritize options like UI/UX Designer, Digital Marketing Manager, Lawyer.",
+          "section_key": "career.preferred_roles",
+          "title": "Preferred roles",
+          "render_variant": "preferred_role_list",
+          "body_md": null,
           "body_html": null,
           "payload_json": {
             "recommended_jobs": [
@@ -463,7 +511,7 @@
             ],
             "work_env": "High-autonomy role scope, clear success metrics, and consistent feedback cadence."
           },
-          "sort_order": 80,
+          "sort_order": 70,
           "is_enabled": true
         }
       ],
@@ -485,10 +533,16 @@
       "type_code": "ENTP",
       "slug": "entp",
       "title": "ENTP - Debater",
+      "type_name": "Debater",
+      "nickname": "Debater",
+      "rarity_text": null,
+      "keywords_json": [],
       "subtitle": null,
       "excerpt": "Role recommendations and work-environment guidance for ENTP profiles.",
       "hero_kicker": "Debater",
       "hero_quote": null,
+      "hero_summary_md": "Role recommendations and work-environment guidance for ENTP profiles.",
+      "hero_summary_html": null,
       "hero_image_url": null,
       "status": "published",
       "is_public": true,
@@ -497,18 +551,18 @@
       "scheduled_at": null,
       "sections": [
         {
-          "section_key": "core_snapshot",
-          "title": "Core snapshot",
+          "section_key": "overview",
+          "title": "Overview",
           "render_variant": "rich_text",
           "body_md": "Role recommendations and work-environment guidance for ENTP profiles. This profile tends to do best when goals are explicit, feedback is available, and growth loops stay visible.",
           "body_html": null,
           "payload_json": null,
-          "sort_order": 10,
+          "sort_order": 20,
           "is_enabled": true
         },
         {
-          "section_key": "strengths",
-          "title": "Strengths",
+          "section_key": "growth.strengths",
+          "title": "Growth strengths",
           "render_variant": "bullets",
           "body_md": null,
           "body_html": null,
@@ -528,12 +582,12 @@
               }
             ]
           },
-          "sort_order": 20,
+          "sort_order": 100,
           "is_enabled": true
         },
         {
-          "section_key": "growth_edges",
-          "title": "Growth edges",
+          "section_key": "growth.weaknesses",
+          "title": "Growth weaknesses",
           "render_variant": "bullets",
           "body_md": null,
           "body_html": null,
@@ -549,34 +603,44 @@
               }
             ]
           },
-          "sort_order": 30,
+          "sort_order": 110,
           "is_enabled": true
         },
         {
-          "section_key": "work_style",
-          "title": "Work style",
+          "section_key": "growth.summary",
+          "title": "Growth summary",
           "render_variant": "rich_text",
           "body_md": "High-autonomy role scope, clear success metrics, and consistent feedback cadence.",
+          "body_html": null,
+          "payload_json": null,
+          "sort_order": 90,
+          "is_enabled": true
+        },
+        {
+          "section_key": "relationships.summary",
+          "title": "Relationships summary",
+          "render_variant": "rich_text",
+          "body_md": "You usually build trust through direct dialogue, shared activity, and fast feedback. You tend to connect more deeply with people who enjoy discussing patterns, future possibilities, and meaning. In conflict you often default to logic and boundaries, so it helps to add explicit emotional acknowledgment. In close relationships and teamwork, you usually prefer flexibility, openness, and room to adapt.",
+          "body_html": null,
+          "payload_json": null,
+          "sort_order": 140,
+          "is_enabled": true
+        },
+        {
+          "section_key": "career.summary",
+          "title": "Career summary",
+          "render_variant": "rich_text",
+          "body_md": "You usually perform best in high-autonomy role scope, clear success metrics, and consistent feedback cadence. Prioritize options like Psychological Counselor, Investment Analyst, Physician.",
           "body_html": null,
           "payload_json": null,
           "sort_order": 40,
           "is_enabled": true
         },
         {
-          "section_key": "relationships",
-          "title": "Relationships",
-          "render_variant": "rich_text",
-          "body_md": "You usually build trust through direct dialogue, shared activity, and fast feedback. You tend to connect more deeply with people who enjoy discussing patterns, future possibilities, and meaning. In conflict you often default to logic and boundaries, so it helps to add explicit emotional acknowledgment. In close relationships and teamwork, you usually prefer flexibility, openness, and room to adapt.",
-          "body_html": null,
-          "payload_json": null,
-          "sort_order": 50,
-          "is_enabled": true
-        },
-        {
-          "section_key": "career_fit",
-          "title": "Career fit",
-          "render_variant": "cards",
-          "body_md": "You usually perform best in high-autonomy role scope, clear success metrics, and consistent feedback cadence. Prioritize options like Psychological Counselor, Investment Analyst, Physician.",
+          "section_key": "career.preferred_roles",
+          "title": "Preferred roles",
+          "render_variant": "preferred_role_list",
+          "body_md": null,
           "body_html": null,
           "payload_json": {
             "recommended_jobs": [
@@ -621,7 +685,7 @@
             ],
             "work_env": "High-autonomy role scope, clear success metrics, and consistent feedback cadence."
           },
-          "sort_order": 80,
+          "sort_order": 70,
           "is_enabled": true
         }
       ],
@@ -643,10 +707,16 @@
       "type_code": "ESFJ",
       "slug": "esfj",
       "title": "ESFJ - Consul",
+      "type_name": "Consul",
+      "nickname": "Consul",
+      "rarity_text": null,
+      "keywords_json": [],
       "subtitle": null,
       "excerpt": "Role recommendations and work-environment guidance for ESFJ profiles.",
       "hero_kicker": "Consul",
       "hero_quote": null,
+      "hero_summary_md": "Role recommendations and work-environment guidance for ESFJ profiles.",
+      "hero_summary_html": null,
       "hero_image_url": null,
       "status": "published",
       "is_public": true,
@@ -655,18 +725,18 @@
       "scheduled_at": null,
       "sections": [
         {
-          "section_key": "core_snapshot",
-          "title": "Core snapshot",
+          "section_key": "overview",
+          "title": "Overview",
           "render_variant": "rich_text",
           "body_md": "Role recommendations and work-environment guidance for ESFJ profiles. This profile tends to do best when goals are explicit, feedback is available, and growth loops stay visible.",
           "body_html": null,
           "payload_json": null,
-          "sort_order": 10,
+          "sort_order": 20,
           "is_enabled": true
         },
         {
-          "section_key": "strengths",
-          "title": "Strengths",
+          "section_key": "growth.strengths",
+          "title": "Growth strengths",
           "render_variant": "bullets",
           "body_md": null,
           "body_html": null,
@@ -686,12 +756,12 @@
               }
             ]
           },
-          "sort_order": 20,
+          "sort_order": 100,
           "is_enabled": true
         },
         {
-          "section_key": "growth_edges",
-          "title": "Growth edges",
+          "section_key": "growth.weaknesses",
+          "title": "Growth weaknesses",
           "render_variant": "bullets",
           "body_md": null,
           "body_html": null,
@@ -707,34 +777,44 @@
               }
             ]
           },
-          "sort_order": 30,
+          "sort_order": 110,
           "is_enabled": true
         },
         {
-          "section_key": "work_style",
-          "title": "Work style",
+          "section_key": "growth.summary",
+          "title": "Growth summary",
           "render_variant": "rich_text",
           "body_md": "High-autonomy role scope, clear success metrics, and consistent feedback cadence.",
+          "body_html": null,
+          "payload_json": null,
+          "sort_order": 90,
+          "is_enabled": true
+        },
+        {
+          "section_key": "relationships.summary",
+          "title": "Relationships summary",
+          "render_variant": "rich_text",
+          "body_md": "You usually build trust through direct dialogue, shared activity, and fast feedback. You tend to value people who are reliable, concrete, and consistent in day-to-day follow-through. In conflict you often default to harmony and emotional tone, so it helps to make your principles explicit. In close relationships and teamwork, you usually prefer clarity, commitment, and predictable pace.",
+          "body_html": null,
+          "payload_json": null,
+          "sort_order": 140,
+          "is_enabled": true
+        },
+        {
+          "section_key": "career.summary",
+          "title": "Career summary",
+          "render_variant": "rich_text",
+          "body_md": "You usually perform best in high-autonomy role scope, clear success metrics, and consistent feedback cadence. Prioritize options like Frontend Engineer, Fullstack Engineer, Cloud Architect.",
           "body_html": null,
           "payload_json": null,
           "sort_order": 40,
           "is_enabled": true
         },
         {
-          "section_key": "relationships",
-          "title": "Relationships",
-          "render_variant": "rich_text",
-          "body_md": "You usually build trust through direct dialogue, shared activity, and fast feedback. You tend to value people who are reliable, concrete, and consistent in day-to-day follow-through. In conflict you often default to harmony and emotional tone, so it helps to make your principles explicit. In close relationships and teamwork, you usually prefer clarity, commitment, and predictable pace.",
-          "body_html": null,
-          "payload_json": null,
-          "sort_order": 50,
-          "is_enabled": true
-        },
-        {
-          "section_key": "career_fit",
-          "title": "Career fit",
-          "render_variant": "cards",
-          "body_md": "You usually perform best in high-autonomy role scope, clear success metrics, and consistent feedback cadence. Prioritize options like Frontend Engineer, Fullstack Engineer, Cloud Architect.",
+          "section_key": "career.preferred_roles",
+          "title": "Preferred roles",
+          "render_variant": "preferred_role_list",
+          "body_md": null,
           "body_html": null,
           "payload_json": {
             "recommended_jobs": [
@@ -779,7 +859,7 @@
             ],
             "work_env": "High-autonomy role scope, clear success metrics, and consistent feedback cadence."
           },
-          "sort_order": 80,
+          "sort_order": 70,
           "is_enabled": true
         }
       ],
@@ -801,10 +881,16 @@
       "type_code": "ESFP",
       "slug": "esfp",
       "title": "ESFP - Entertainer",
+      "type_name": "Entertainer",
+      "nickname": "Entertainer",
+      "rarity_text": null,
+      "keywords_json": [],
       "subtitle": null,
       "excerpt": "Role recommendations and work-environment guidance for ESFP profiles.",
       "hero_kicker": "Entertainer",
       "hero_quote": null,
+      "hero_summary_md": "Role recommendations and work-environment guidance for ESFP profiles.",
+      "hero_summary_html": null,
       "hero_image_url": null,
       "status": "published",
       "is_public": true,
@@ -813,18 +899,18 @@
       "scheduled_at": null,
       "sections": [
         {
-          "section_key": "core_snapshot",
-          "title": "Core snapshot",
+          "section_key": "overview",
+          "title": "Overview",
           "render_variant": "rich_text",
           "body_md": "Role recommendations and work-environment guidance for ESFP profiles. This profile tends to do best when goals are explicit, feedback is available, and growth loops stay visible.",
           "body_html": null,
           "payload_json": null,
-          "sort_order": 10,
+          "sort_order": 20,
           "is_enabled": true
         },
         {
-          "section_key": "strengths",
-          "title": "Strengths",
+          "section_key": "growth.strengths",
+          "title": "Growth strengths",
           "render_variant": "bullets",
           "body_md": null,
           "body_html": null,
@@ -844,12 +930,12 @@
               }
             ]
           },
-          "sort_order": 20,
+          "sort_order": 100,
           "is_enabled": true
         },
         {
-          "section_key": "growth_edges",
-          "title": "Growth edges",
+          "section_key": "growth.weaknesses",
+          "title": "Growth weaknesses",
           "render_variant": "bullets",
           "body_md": null,
           "body_html": null,
@@ -865,34 +951,44 @@
               }
             ]
           },
-          "sort_order": 30,
+          "sort_order": 110,
           "is_enabled": true
         },
         {
-          "section_key": "work_style",
-          "title": "Work style",
+          "section_key": "growth.summary",
+          "title": "Growth summary",
           "render_variant": "rich_text",
           "body_md": "High-autonomy role scope, clear success metrics, and consistent feedback cadence.",
+          "body_html": null,
+          "payload_json": null,
+          "sort_order": 90,
+          "is_enabled": true
+        },
+        {
+          "section_key": "relationships.summary",
+          "title": "Relationships summary",
+          "render_variant": "rich_text",
+          "body_md": "You usually build trust through direct dialogue, shared activity, and fast feedback. You tend to value people who are reliable, concrete, and consistent in day-to-day follow-through. In conflict you often default to harmony and emotional tone, so it helps to make your principles explicit. In close relationships and teamwork, you usually prefer flexibility, openness, and room to adapt.",
+          "body_html": null,
+          "payload_json": null,
+          "sort_order": 140,
+          "is_enabled": true
+        },
+        {
+          "section_key": "career.summary",
+          "title": "Career summary",
+          "render_variant": "rich_text",
+          "body_md": "You usually perform best in high-autonomy role scope, clear success metrics, and consistent feedback cadence. Prioritize options like Cloud Architect, HR Business Partner, Management Consultant.",
           "body_html": null,
           "payload_json": null,
           "sort_order": 40,
           "is_enabled": true
         },
         {
-          "section_key": "relationships",
-          "title": "Relationships",
-          "render_variant": "rich_text",
-          "body_md": "You usually build trust through direct dialogue, shared activity, and fast feedback. You tend to value people who are reliable, concrete, and consistent in day-to-day follow-through. In conflict you often default to harmony and emotional tone, so it helps to make your principles explicit. In close relationships and teamwork, you usually prefer flexibility, openness, and room to adapt.",
-          "body_html": null,
-          "payload_json": null,
-          "sort_order": 50,
-          "is_enabled": true
-        },
-        {
-          "section_key": "career_fit",
-          "title": "Career fit",
-          "render_variant": "cards",
-          "body_md": "You usually perform best in high-autonomy role scope, clear success metrics, and consistent feedback cadence. Prioritize options like Cloud Architect, HR Business Partner, Management Consultant.",
+          "section_key": "career.preferred_roles",
+          "title": "Preferred roles",
+          "render_variant": "preferred_role_list",
+          "body_md": null,
           "body_html": null,
           "payload_json": {
             "recommended_jobs": [
@@ -937,7 +1033,7 @@
             ],
             "work_env": "High-autonomy role scope, clear success metrics, and consistent feedback cadence."
           },
-          "sort_order": 80,
+          "sort_order": 70,
           "is_enabled": true
         }
       ],
@@ -959,10 +1055,16 @@
       "type_code": "ESTJ",
       "slug": "estj",
       "title": "ESTJ - Executive",
+      "type_name": "Executive",
+      "nickname": "Executive",
+      "rarity_text": null,
+      "keywords_json": [],
       "subtitle": null,
       "excerpt": "Role recommendations and work-environment guidance for ESTJ profiles.",
       "hero_kicker": "Executive",
       "hero_quote": null,
+      "hero_summary_md": "Role recommendations and work-environment guidance for ESTJ profiles.",
+      "hero_summary_html": null,
       "hero_image_url": null,
       "status": "published",
       "is_public": true,
@@ -971,18 +1073,18 @@
       "scheduled_at": null,
       "sections": [
         {
-          "section_key": "core_snapshot",
-          "title": "Core snapshot",
+          "section_key": "overview",
+          "title": "Overview",
           "render_variant": "rich_text",
           "body_md": "Role recommendations and work-environment guidance for ESTJ profiles. This profile tends to do best when goals are explicit, feedback is available, and growth loops stay visible.",
           "body_html": null,
           "payload_json": null,
-          "sort_order": 10,
+          "sort_order": 20,
           "is_enabled": true
         },
         {
-          "section_key": "strengths",
-          "title": "Strengths",
+          "section_key": "growth.strengths",
+          "title": "Growth strengths",
           "render_variant": "bullets",
           "body_md": null,
           "body_html": null,
@@ -1002,12 +1104,12 @@
               }
             ]
           },
-          "sort_order": 20,
+          "sort_order": 100,
           "is_enabled": true
         },
         {
-          "section_key": "growth_edges",
-          "title": "Growth edges",
+          "section_key": "growth.weaknesses",
+          "title": "Growth weaknesses",
           "render_variant": "bullets",
           "body_md": null,
           "body_html": null,
@@ -1023,34 +1125,44 @@
               }
             ]
           },
-          "sort_order": 30,
+          "sort_order": 110,
           "is_enabled": true
         },
         {
-          "section_key": "work_style",
-          "title": "Work style",
+          "section_key": "growth.summary",
+          "title": "Growth summary",
           "render_variant": "rich_text",
           "body_md": "High-autonomy role scope, clear success metrics, and consistent feedback cadence.",
+          "body_html": null,
+          "payload_json": null,
+          "sort_order": 90,
+          "is_enabled": true
+        },
+        {
+          "section_key": "relationships.summary",
+          "title": "Relationships summary",
+          "render_variant": "rich_text",
+          "body_md": "You usually build trust through direct dialogue, shared activity, and fast feedback. You tend to value people who are reliable, concrete, and consistent in day-to-day follow-through. In conflict you often default to logic and boundaries, so it helps to add explicit emotional acknowledgment. In close relationships and teamwork, you usually prefer clarity, commitment, and predictable pace.",
+          "body_html": null,
+          "payload_json": null,
+          "sort_order": 140,
+          "is_enabled": true
+        },
+        {
+          "section_key": "career.summary",
+          "title": "Career summary",
+          "render_variant": "rich_text",
+          "body_md": "You usually perform best in high-autonomy role scope, clear success metrics, and consistent feedback cadence. Prioritize options like Machine Learning Engineer, Backend Engineer, Cybersecurity Analyst.",
           "body_html": null,
           "payload_json": null,
           "sort_order": 40,
           "is_enabled": true
         },
         {
-          "section_key": "relationships",
-          "title": "Relationships",
-          "render_variant": "rich_text",
-          "body_md": "You usually build trust through direct dialogue, shared activity, and fast feedback. You tend to value people who are reliable, concrete, and consistent in day-to-day follow-through. In conflict you often default to logic and boundaries, so it helps to add explicit emotional acknowledgment. In close relationships and teamwork, you usually prefer clarity, commitment, and predictable pace.",
-          "body_html": null,
-          "payload_json": null,
-          "sort_order": 50,
-          "is_enabled": true
-        },
-        {
-          "section_key": "career_fit",
-          "title": "Career fit",
-          "render_variant": "cards",
-          "body_md": "You usually perform best in high-autonomy role scope, clear success metrics, and consistent feedback cadence. Prioritize options like Machine Learning Engineer, Backend Engineer, Cybersecurity Analyst.",
+          "section_key": "career.preferred_roles",
+          "title": "Preferred roles",
+          "render_variant": "preferred_role_list",
+          "body_md": null,
           "body_html": null,
           "payload_json": {
             "recommended_jobs": [
@@ -1095,7 +1207,7 @@
             ],
             "work_env": "High-autonomy role scope, clear success metrics, and consistent feedback cadence."
           },
-          "sort_order": 80,
+          "sort_order": 70,
           "is_enabled": true
         }
       ],
@@ -1117,10 +1229,16 @@
       "type_code": "ESTP",
       "slug": "estp",
       "title": "ESTP - Entrepreneur",
+      "type_name": "Entrepreneur",
+      "nickname": "Entrepreneur",
+      "rarity_text": null,
+      "keywords_json": [],
       "subtitle": null,
       "excerpt": "Role recommendations and work-environment guidance for ESTP profiles.",
       "hero_kicker": "Entrepreneur",
       "hero_quote": null,
+      "hero_summary_md": "Role recommendations and work-environment guidance for ESTP profiles.",
+      "hero_summary_html": null,
       "hero_image_url": null,
       "status": "published",
       "is_public": true,
@@ -1129,18 +1247,18 @@
       "scheduled_at": null,
       "sections": [
         {
-          "section_key": "core_snapshot",
-          "title": "Core snapshot",
+          "section_key": "overview",
+          "title": "Overview",
           "render_variant": "rich_text",
           "body_md": "Role recommendations and work-environment guidance for ESTP profiles. This profile tends to do best when goals are explicit, feedback is available, and growth loops stay visible.",
           "body_html": null,
           "payload_json": null,
-          "sort_order": 10,
+          "sort_order": 20,
           "is_enabled": true
         },
         {
-          "section_key": "strengths",
-          "title": "Strengths",
+          "section_key": "growth.strengths",
+          "title": "Growth strengths",
           "render_variant": "bullets",
           "body_md": null,
           "body_html": null,
@@ -1160,12 +1278,12 @@
               }
             ]
           },
-          "sort_order": 20,
+          "sort_order": 100,
           "is_enabled": true
         },
         {
-          "section_key": "growth_edges",
-          "title": "Growth edges",
+          "section_key": "growth.weaknesses",
+          "title": "Growth weaknesses",
           "render_variant": "bullets",
           "body_md": null,
           "body_html": null,
@@ -1181,34 +1299,44 @@
               }
             ]
           },
-          "sort_order": 30,
+          "sort_order": 110,
           "is_enabled": true
         },
         {
-          "section_key": "work_style",
-          "title": "Work style",
+          "section_key": "growth.summary",
+          "title": "Growth summary",
           "render_variant": "rich_text",
           "body_md": "High-autonomy role scope, clear success metrics, and consistent feedback cadence.",
+          "body_html": null,
+          "payload_json": null,
+          "sort_order": 90,
+          "is_enabled": true
+        },
+        {
+          "section_key": "relationships.summary",
+          "title": "Relationships summary",
+          "render_variant": "rich_text",
+          "body_md": "You usually build trust through direct dialogue, shared activity, and fast feedback. You tend to value people who are reliable, concrete, and consistent in day-to-day follow-through. In conflict you often default to logic and boundaries, so it helps to add explicit emotional acknowledgment. In close relationships and teamwork, you usually prefer flexibility, openness, and room to adapt.",
+          "body_html": null,
+          "payload_json": null,
+          "sort_order": 140,
+          "is_enabled": true
+        },
+        {
+          "section_key": "career.summary",
+          "title": "Career summary",
+          "render_variant": "rich_text",
+          "body_md": "You usually perform best in high-autonomy role scope, clear success metrics, and consistent feedback cadence. Prioritize options like Cybersecurity Analyst, Operations Manager, Sales Manager.",
           "body_html": null,
           "payload_json": null,
           "sort_order": 40,
           "is_enabled": true
         },
         {
-          "section_key": "relationships",
-          "title": "Relationships",
-          "render_variant": "rich_text",
-          "body_md": "You usually build trust through direct dialogue, shared activity, and fast feedback. You tend to value people who are reliable, concrete, and consistent in day-to-day follow-through. In conflict you often default to logic and boundaries, so it helps to add explicit emotional acknowledgment. In close relationships and teamwork, you usually prefer flexibility, openness, and room to adapt.",
-          "body_html": null,
-          "payload_json": null,
-          "sort_order": 50,
-          "is_enabled": true
-        },
-        {
-          "section_key": "career_fit",
-          "title": "Career fit",
-          "render_variant": "cards",
-          "body_md": "You usually perform best in high-autonomy role scope, clear success metrics, and consistent feedback cadence. Prioritize options like Cybersecurity Analyst, Operations Manager, Sales Manager.",
+          "section_key": "career.preferred_roles",
+          "title": "Preferred roles",
+          "render_variant": "preferred_role_list",
+          "body_md": null,
           "body_html": null,
           "payload_json": {
             "recommended_jobs": [
@@ -1253,7 +1381,7 @@
             ],
             "work_env": "High-autonomy role scope, clear success metrics, and consistent feedback cadence."
           },
-          "sort_order": 80,
+          "sort_order": 70,
           "is_enabled": true
         }
       ],
@@ -1275,10 +1403,16 @@
       "type_code": "INFJ",
       "slug": "infj",
       "title": "INFJ - Advocate",
+      "type_name": "Advocate",
+      "nickname": "Advocate",
+      "rarity_text": null,
+      "keywords_json": [],
       "subtitle": null,
       "excerpt": "Role recommendations and work-environment guidance for INFJ profiles.",
       "hero_kicker": "Advocate",
       "hero_quote": null,
+      "hero_summary_md": "Role recommendations and work-environment guidance for INFJ profiles.",
+      "hero_summary_html": null,
       "hero_image_url": null,
       "status": "published",
       "is_public": true,
@@ -1287,18 +1421,18 @@
       "scheduled_at": null,
       "sections": [
         {
-          "section_key": "core_snapshot",
-          "title": "Core snapshot",
+          "section_key": "overview",
+          "title": "Overview",
           "render_variant": "rich_text",
           "body_md": "Role recommendations and work-environment guidance for INFJ profiles. This profile tends to do best when goals are explicit, feedback is available, and growth loops stay visible.",
           "body_html": null,
           "payload_json": null,
-          "sort_order": 10,
+          "sort_order": 20,
           "is_enabled": true
         },
         {
-          "section_key": "strengths",
-          "title": "Strengths",
+          "section_key": "growth.strengths",
+          "title": "Growth strengths",
           "render_variant": "bullets",
           "body_md": null,
           "body_html": null,
@@ -1318,12 +1452,12 @@
               }
             ]
           },
-          "sort_order": 20,
+          "sort_order": 100,
           "is_enabled": true
         },
         {
-          "section_key": "growth_edges",
-          "title": "Growth edges",
+          "section_key": "growth.weaknesses",
+          "title": "Growth weaknesses",
           "render_variant": "bullets",
           "body_md": null,
           "body_html": null,
@@ -1339,34 +1473,44 @@
               }
             ]
           },
-          "sort_order": 30,
+          "sort_order": 110,
           "is_enabled": true
         },
         {
-          "section_key": "work_style",
-          "title": "Work style",
+          "section_key": "growth.summary",
+          "title": "Growth summary",
           "render_variant": "rich_text",
           "body_md": "High-autonomy role scope, clear success metrics, and consistent feedback cadence.",
+          "body_html": null,
+          "payload_json": null,
+          "sort_order": 90,
+          "is_enabled": true
+        },
+        {
+          "section_key": "relationships.summary",
+          "title": "Relationships summary",
+          "render_variant": "rich_text",
+          "body_md": "You usually build trust through steady one-on-one conversations, reflection, and protected space. You tend to connect more deeply with people who enjoy discussing patterns, future possibilities, and meaning. In conflict you often default to harmony and emotional tone, so it helps to make your principles explicit. In close relationships and teamwork, you usually prefer clarity, commitment, and predictable pace.",
+          "body_html": null,
+          "payload_json": null,
+          "sort_order": 140,
+          "is_enabled": true
+        },
+        {
+          "section_key": "career.summary",
+          "title": "Career summary",
+          "render_variant": "rich_text",
+          "body_md": "You usually perform best in high-autonomy role scope, clear success metrics, and consistent feedback cadence. Prioritize options like Digital Marketing Manager, Lawyer, Teacher.",
           "body_html": null,
           "payload_json": null,
           "sort_order": 40,
           "is_enabled": true
         },
         {
-          "section_key": "relationships",
-          "title": "Relationships",
-          "render_variant": "rich_text",
-          "body_md": "You usually build trust through steady one-on-one conversations, reflection, and protected space. You tend to connect more deeply with people who enjoy discussing patterns, future possibilities, and meaning. In conflict you often default to harmony and emotional tone, so it helps to make your principles explicit. In close relationships and teamwork, you usually prefer clarity, commitment, and predictable pace.",
-          "body_html": null,
-          "payload_json": null,
-          "sort_order": 50,
-          "is_enabled": true
-        },
-        {
-          "section_key": "career_fit",
-          "title": "Career fit",
-          "render_variant": "cards",
-          "body_md": "You usually perform best in high-autonomy role scope, clear success metrics, and consistent feedback cadence. Prioritize options like Digital Marketing Manager, Lawyer, Teacher.",
+          "section_key": "career.preferred_roles",
+          "title": "Preferred roles",
+          "render_variant": "preferred_role_list",
+          "body_md": null,
           "body_html": null,
           "payload_json": {
             "recommended_jobs": [
@@ -1411,7 +1555,7 @@
             ],
             "work_env": "High-autonomy role scope, clear success metrics, and consistent feedback cadence."
           },
-          "sort_order": 80,
+          "sort_order": 70,
           "is_enabled": true
         }
       ],
@@ -1433,10 +1577,16 @@
       "type_code": "INFP",
       "slug": "infp",
       "title": "INFP - Mediator",
+      "type_name": "Mediator",
+      "nickname": "Mediator",
+      "rarity_text": null,
+      "keywords_json": [],
       "subtitle": null,
       "excerpt": "Role recommendations and work-environment guidance for INFP profiles.",
       "hero_kicker": "Mediator",
       "hero_quote": null,
+      "hero_summary_md": "Role recommendations and work-environment guidance for INFP profiles.",
+      "hero_summary_html": null,
       "hero_image_url": null,
       "status": "published",
       "is_public": true,
@@ -1445,18 +1595,18 @@
       "scheduled_at": null,
       "sections": [
         {
-          "section_key": "core_snapshot",
-          "title": "Core snapshot",
+          "section_key": "overview",
+          "title": "Overview",
           "render_variant": "rich_text",
           "body_md": "Role recommendations and work-environment guidance for INFP profiles. This profile tends to do best when goals are explicit, feedback is available, and growth loops stay visible.",
           "body_html": null,
           "payload_json": null,
-          "sort_order": 10,
+          "sort_order": 20,
           "is_enabled": true
         },
         {
-          "section_key": "strengths",
-          "title": "Strengths",
+          "section_key": "growth.strengths",
+          "title": "Growth strengths",
           "render_variant": "bullets",
           "body_md": null,
           "body_html": null,
@@ -1476,12 +1626,12 @@
               }
             ]
           },
-          "sort_order": 20,
+          "sort_order": 100,
           "is_enabled": true
         },
         {
-          "section_key": "growth_edges",
-          "title": "Growth edges",
+          "section_key": "growth.weaknesses",
+          "title": "Growth weaknesses",
           "render_variant": "bullets",
           "body_md": null,
           "body_html": null,
@@ -1497,34 +1647,44 @@
               }
             ]
           },
-          "sort_order": 30,
+          "sort_order": 110,
           "is_enabled": true
         },
         {
-          "section_key": "work_style",
-          "title": "Work style",
+          "section_key": "growth.summary",
+          "title": "Growth summary",
           "render_variant": "rich_text",
           "body_md": "High-autonomy role scope, clear success metrics, and consistent feedback cadence.",
+          "body_html": null,
+          "payload_json": null,
+          "sort_order": 90,
+          "is_enabled": true
+        },
+        {
+          "section_key": "relationships.summary",
+          "title": "Relationships summary",
+          "render_variant": "rich_text",
+          "body_md": "You usually build trust through steady one-on-one conversations, reflection, and protected space. You tend to connect more deeply with people who enjoy discussing patterns, future possibilities, and meaning. In conflict you often default to harmony and emotional tone, so it helps to make your principles explicit. In close relationships and teamwork, you usually prefer flexibility, openness, and room to adapt.",
+          "body_html": null,
+          "payload_json": null,
+          "sort_order": 140,
+          "is_enabled": true
+        },
+        {
+          "section_key": "career.summary",
+          "title": "Career summary",
+          "render_variant": "rich_text",
+          "body_md": "You usually perform best in high-autonomy role scope, clear success metrics, and consistent feedback cadence. Prioritize options like Investment Analyst, Physician, Data Scientist.",
           "body_html": null,
           "payload_json": null,
           "sort_order": 40,
           "is_enabled": true
         },
         {
-          "section_key": "relationships",
-          "title": "Relationships",
-          "render_variant": "rich_text",
-          "body_md": "You usually build trust through steady one-on-one conversations, reflection, and protected space. You tend to connect more deeply with people who enjoy discussing patterns, future possibilities, and meaning. In conflict you often default to harmony and emotional tone, so it helps to make your principles explicit. In close relationships and teamwork, you usually prefer flexibility, openness, and room to adapt.",
-          "body_html": null,
-          "payload_json": null,
-          "sort_order": 50,
-          "is_enabled": true
-        },
-        {
-          "section_key": "career_fit",
-          "title": "Career fit",
-          "render_variant": "cards",
-          "body_md": "You usually perform best in high-autonomy role scope, clear success metrics, and consistent feedback cadence. Prioritize options like Investment Analyst, Physician, Data Scientist.",
+          "section_key": "career.preferred_roles",
+          "title": "Preferred roles",
+          "render_variant": "preferred_role_list",
+          "body_md": null,
           "body_html": null,
           "payload_json": {
             "recommended_jobs": [
@@ -1569,7 +1729,7 @@
             ],
             "work_env": "High-autonomy role scope, clear success metrics, and consistent feedback cadence."
           },
-          "sort_order": 80,
+          "sort_order": 70,
           "is_enabled": true
         }
       ],
@@ -1591,10 +1751,16 @@
       "type_code": "INTJ",
       "slug": "intj",
       "title": "INTJ - Architect",
+      "type_name": "Architect",
+      "nickname": "Architect",
+      "rarity_text": null,
+      "keywords_json": [],
       "subtitle": null,
       "excerpt": "Role recommendations and work-environment guidance for INTJ profiles.",
       "hero_kicker": "Architect",
       "hero_quote": null,
+      "hero_summary_md": "Role recommendations and work-environment guidance for INTJ profiles.",
+      "hero_summary_html": null,
       "hero_image_url": null,
       "status": "published",
       "is_public": true,
@@ -1603,18 +1769,18 @@
       "scheduled_at": null,
       "sections": [
         {
-          "section_key": "core_snapshot",
-          "title": "Core snapshot",
+          "section_key": "overview",
+          "title": "Overview",
           "render_variant": "rich_text",
           "body_md": "Role recommendations and work-environment guidance for INTJ profiles. This profile tends to do best when goals are explicit, feedback is available, and growth loops stay visible.",
           "body_html": null,
           "payload_json": null,
-          "sort_order": 10,
+          "sort_order": 20,
           "is_enabled": true
         },
         {
-          "section_key": "strengths",
-          "title": "Strengths",
+          "section_key": "growth.strengths",
+          "title": "Growth strengths",
           "render_variant": "bullets",
           "body_md": null,
           "body_html": null,
@@ -1634,12 +1800,12 @@
               }
             ]
           },
-          "sort_order": 20,
+          "sort_order": 100,
           "is_enabled": true
         },
         {
-          "section_key": "growth_edges",
-          "title": "Growth edges",
+          "section_key": "growth.weaknesses",
+          "title": "Growth weaknesses",
           "render_variant": "bullets",
           "body_md": null,
           "body_html": null,
@@ -1655,34 +1821,44 @@
               }
             ]
           },
-          "sort_order": 30,
+          "sort_order": 110,
           "is_enabled": true
         },
         {
-          "section_key": "work_style",
-          "title": "Work style",
+          "section_key": "growth.summary",
+          "title": "Growth summary",
           "render_variant": "rich_text",
           "body_md": "High-autonomy role scope, clear success metrics, and consistent feedback cadence.",
+          "body_html": null,
+          "payload_json": null,
+          "sort_order": 90,
+          "is_enabled": true
+        },
+        {
+          "section_key": "relationships.summary",
+          "title": "Relationships summary",
+          "render_variant": "rich_text",
+          "body_md": "You usually build trust through steady one-on-one conversations, reflection, and protected space. You tend to connect more deeply with people who enjoy discussing patterns, future possibilities, and meaning. In conflict you often default to logic and boundaries, so it helps to add explicit emotional acknowledgment. In close relationships and teamwork, you usually prefer clarity, commitment, and predictable pace.",
+          "body_html": null,
+          "payload_json": null,
+          "sort_order": 140,
+          "is_enabled": true
+        },
+        {
+          "section_key": "career.summary",
+          "title": "Career summary",
+          "render_variant": "rich_text",
+          "body_md": "You usually perform best in high-autonomy role scope, clear success metrics, and consistent feedback cadence. Prioritize options like Product Manager, UI/UX Designer, Digital Marketing Manager.",
           "body_html": null,
           "payload_json": null,
           "sort_order": 40,
           "is_enabled": true
         },
         {
-          "section_key": "relationships",
-          "title": "Relationships",
-          "render_variant": "rich_text",
-          "body_md": "You usually build trust through steady one-on-one conversations, reflection, and protected space. You tend to connect more deeply with people who enjoy discussing patterns, future possibilities, and meaning. In conflict you often default to logic and boundaries, so it helps to add explicit emotional acknowledgment. In close relationships and teamwork, you usually prefer clarity, commitment, and predictable pace.",
-          "body_html": null,
-          "payload_json": null,
-          "sort_order": 50,
-          "is_enabled": true
-        },
-        {
-          "section_key": "career_fit",
-          "title": "Career fit",
-          "render_variant": "cards",
-          "body_md": "You usually perform best in high-autonomy role scope, clear success metrics, and consistent feedback cadence. Prioritize options like Product Manager, UI/UX Designer, Digital Marketing Manager.",
+          "section_key": "career.preferred_roles",
+          "title": "Preferred roles",
+          "render_variant": "preferred_role_list",
+          "body_md": null,
           "body_html": null,
           "payload_json": {
             "recommended_jobs": [
@@ -1727,7 +1903,7 @@
             ],
             "work_env": "High-autonomy role scope, clear success metrics, and consistent feedback cadence."
           },
-          "sort_order": 80,
+          "sort_order": 70,
           "is_enabled": true
         }
       ],
@@ -1749,10 +1925,16 @@
       "type_code": "INTP",
       "slug": "intp",
       "title": "INTP - Logician",
+      "type_name": "Logician",
+      "nickname": "Logician",
+      "rarity_text": null,
+      "keywords_json": [],
       "subtitle": null,
       "excerpt": "Role recommendations and work-environment guidance for INTP profiles.",
       "hero_kicker": "Logician",
       "hero_quote": null,
+      "hero_summary_md": "Role recommendations and work-environment guidance for INTP profiles.",
+      "hero_summary_html": null,
       "hero_image_url": null,
       "status": "published",
       "is_public": true,
@@ -1761,18 +1943,18 @@
       "scheduled_at": null,
       "sections": [
         {
-          "section_key": "core_snapshot",
-          "title": "Core snapshot",
+          "section_key": "overview",
+          "title": "Overview",
           "render_variant": "rich_text",
           "body_md": "Role recommendations and work-environment guidance for INTP profiles. This profile tends to do best when goals are explicit, feedback is available, and growth loops stay visible.",
           "body_html": null,
           "payload_json": null,
-          "sort_order": 10,
+          "sort_order": 20,
           "is_enabled": true
         },
         {
-          "section_key": "strengths",
-          "title": "Strengths",
+          "section_key": "growth.strengths",
+          "title": "Growth strengths",
           "render_variant": "bullets",
           "body_md": null,
           "body_html": null,
@@ -1792,12 +1974,12 @@
               }
             ]
           },
-          "sort_order": 20,
+          "sort_order": 100,
           "is_enabled": true
         },
         {
-          "section_key": "growth_edges",
-          "title": "Growth edges",
+          "section_key": "growth.weaknesses",
+          "title": "Growth weaknesses",
           "render_variant": "bullets",
           "body_md": null,
           "body_html": null,
@@ -1813,34 +1995,44 @@
               }
             ]
           },
-          "sort_order": 30,
+          "sort_order": 110,
           "is_enabled": true
         },
         {
-          "section_key": "work_style",
-          "title": "Work style",
+          "section_key": "growth.summary",
+          "title": "Growth summary",
           "render_variant": "rich_text",
           "body_md": "High-autonomy role scope, clear success metrics, and consistent feedback cadence.",
+          "body_html": null,
+          "payload_json": null,
+          "sort_order": 90,
+          "is_enabled": true
+        },
+        {
+          "section_key": "relationships.summary",
+          "title": "Relationships summary",
+          "render_variant": "rich_text",
+          "body_md": "You usually build trust through steady one-on-one conversations, reflection, and protected space. You tend to connect more deeply with people who enjoy discussing patterns, future possibilities, and meaning. In conflict you often default to logic and boundaries, so it helps to add explicit emotional acknowledgment. In close relationships and teamwork, you usually prefer flexibility, openness, and room to adapt.",
+          "body_html": null,
+          "payload_json": null,
+          "sort_order": 140,
+          "is_enabled": true
+        },
+        {
+          "section_key": "career.summary",
+          "title": "Career summary",
+          "render_variant": "rich_text",
+          "body_md": "You usually perform best in high-autonomy role scope, clear success metrics, and consistent feedback cadence. Prioritize options like Data Analyst, Psychological Counselor, Investment Analyst.",
           "body_html": null,
           "payload_json": null,
           "sort_order": 40,
           "is_enabled": true
         },
         {
-          "section_key": "relationships",
-          "title": "Relationships",
-          "render_variant": "rich_text",
-          "body_md": "You usually build trust through steady one-on-one conversations, reflection, and protected space. You tend to connect more deeply with people who enjoy discussing patterns, future possibilities, and meaning. In conflict you often default to logic and boundaries, so it helps to add explicit emotional acknowledgment. In close relationships and teamwork, you usually prefer flexibility, openness, and room to adapt.",
-          "body_html": null,
-          "payload_json": null,
-          "sort_order": 50,
-          "is_enabled": true
-        },
-        {
-          "section_key": "career_fit",
-          "title": "Career fit",
-          "render_variant": "cards",
-          "body_md": "You usually perform best in high-autonomy role scope, clear success metrics, and consistent feedback cadence. Prioritize options like Data Analyst, Psychological Counselor, Investment Analyst.",
+          "section_key": "career.preferred_roles",
+          "title": "Preferred roles",
+          "render_variant": "preferred_role_list",
+          "body_md": null,
           "body_html": null,
           "payload_json": {
             "recommended_jobs": [
@@ -1885,7 +2077,7 @@
             ],
             "work_env": "High-autonomy role scope, clear success metrics, and consistent feedback cadence."
           },
-          "sort_order": 80,
+          "sort_order": 70,
           "is_enabled": true
         }
       ],
@@ -1907,10 +2099,16 @@
       "type_code": "ISFJ",
       "slug": "isfj",
       "title": "ISFJ - Defender",
+      "type_name": "Defender",
+      "nickname": "Defender",
+      "rarity_text": null,
+      "keywords_json": [],
       "subtitle": null,
       "excerpt": "Role recommendations and work-environment guidance for ISFJ profiles.",
       "hero_kicker": "Defender",
       "hero_quote": null,
+      "hero_summary_md": "Role recommendations and work-environment guidance for ISFJ profiles.",
+      "hero_summary_html": null,
       "hero_image_url": null,
       "status": "published",
       "is_public": true,
@@ -1919,18 +2117,18 @@
       "scheduled_at": null,
       "sections": [
         {
-          "section_key": "core_snapshot",
-          "title": "Core snapshot",
+          "section_key": "overview",
+          "title": "Overview",
           "render_variant": "rich_text",
           "body_md": "Role recommendations and work-environment guidance for ISFJ profiles. This profile tends to do best when goals are explicit, feedback is available, and growth loops stay visible.",
           "body_html": null,
           "payload_json": null,
-          "sort_order": 10,
+          "sort_order": 20,
           "is_enabled": true
         },
         {
-          "section_key": "strengths",
-          "title": "Strengths",
+          "section_key": "growth.strengths",
+          "title": "Growth strengths",
           "render_variant": "bullets",
           "body_md": null,
           "body_html": null,
@@ -1950,12 +2148,12 @@
               }
             ]
           },
-          "sort_order": 20,
+          "sort_order": 100,
           "is_enabled": true
         },
         {
-          "section_key": "growth_edges",
-          "title": "Growth edges",
+          "section_key": "growth.weaknesses",
+          "title": "Growth weaknesses",
           "render_variant": "bullets",
           "body_md": null,
           "body_html": null,
@@ -1971,34 +2169,44 @@
               }
             ]
           },
-          "sort_order": 30,
+          "sort_order": 110,
           "is_enabled": true
         },
         {
-          "section_key": "work_style",
-          "title": "Work style",
+          "section_key": "growth.summary",
+          "title": "Growth summary",
           "render_variant": "rich_text",
           "body_md": "High-autonomy role scope, clear success metrics, and consistent feedback cadence.",
+          "body_html": null,
+          "payload_json": null,
+          "sort_order": 90,
+          "is_enabled": true
+        },
+        {
+          "section_key": "relationships.summary",
+          "title": "Relationships summary",
+          "render_variant": "rich_text",
+          "body_md": "You usually build trust through steady one-on-one conversations, reflection, and protected space. You tend to value people who are reliable, concrete, and consistent in day-to-day follow-through. In conflict you often default to harmony and emotional tone, so it helps to make your principles explicit. In close relationships and teamwork, you usually prefer clarity, commitment, and predictable pace.",
+          "body_html": null,
+          "payload_json": null,
+          "sort_order": 140,
+          "is_enabled": true
+        },
+        {
+          "section_key": "career.summary",
+          "title": "Career summary",
+          "render_variant": "rich_text",
+          "body_md": "You usually perform best in high-autonomy role scope, clear success metrics, and consistent feedback cadence. Prioritize options like Data Scientist, Frontend Engineer, Fullstack Engineer.",
           "body_html": null,
           "payload_json": null,
           "sort_order": 40,
           "is_enabled": true
         },
         {
-          "section_key": "relationships",
-          "title": "Relationships",
-          "render_variant": "rich_text",
-          "body_md": "You usually build trust through steady one-on-one conversations, reflection, and protected space. You tend to value people who are reliable, concrete, and consistent in day-to-day follow-through. In conflict you often default to harmony and emotional tone, so it helps to make your principles explicit. In close relationships and teamwork, you usually prefer clarity, commitment, and predictable pace.",
-          "body_html": null,
-          "payload_json": null,
-          "sort_order": 50,
-          "is_enabled": true
-        },
-        {
-          "section_key": "career_fit",
-          "title": "Career fit",
-          "render_variant": "cards",
-          "body_md": "You usually perform best in high-autonomy role scope, clear success metrics, and consistent feedback cadence. Prioritize options like Data Scientist, Frontend Engineer, Fullstack Engineer.",
+          "section_key": "career.preferred_roles",
+          "title": "Preferred roles",
+          "render_variant": "preferred_role_list",
+          "body_md": null,
           "body_html": null,
           "payload_json": {
             "recommended_jobs": [
@@ -2043,7 +2251,7 @@
             ],
             "work_env": "High-autonomy role scope, clear success metrics, and consistent feedback cadence."
           },
-          "sort_order": 80,
+          "sort_order": 70,
           "is_enabled": true
         }
       ],
@@ -2065,10 +2273,16 @@
       "type_code": "ISFP",
       "slug": "isfp",
       "title": "ISFP - Adventurer",
+      "type_name": "Adventurer",
+      "nickname": "Adventurer",
+      "rarity_text": null,
+      "keywords_json": [],
       "subtitle": null,
       "excerpt": "Role recommendations and work-environment guidance for ISFP profiles.",
       "hero_kicker": "Adventurer",
       "hero_quote": null,
+      "hero_summary_md": "Role recommendations and work-environment guidance for ISFP profiles.",
+      "hero_summary_html": null,
       "hero_image_url": null,
       "status": "published",
       "is_public": true,
@@ -2077,18 +2291,18 @@
       "scheduled_at": null,
       "sections": [
         {
-          "section_key": "core_snapshot",
-          "title": "Core snapshot",
+          "section_key": "overview",
+          "title": "Overview",
           "render_variant": "rich_text",
           "body_md": "Role recommendations and work-environment guidance for ISFP profiles. This profile tends to do best when goals are explicit, feedback is available, and growth loops stay visible.",
           "body_html": null,
           "payload_json": null,
-          "sort_order": 10,
+          "sort_order": 20,
           "is_enabled": true
         },
         {
-          "section_key": "strengths",
-          "title": "Strengths",
+          "section_key": "growth.strengths",
+          "title": "Growth strengths",
           "render_variant": "bullets",
           "body_md": null,
           "body_html": null,
@@ -2108,12 +2322,12 @@
               }
             ]
           },
-          "sort_order": 20,
+          "sort_order": 100,
           "is_enabled": true
         },
         {
-          "section_key": "growth_edges",
-          "title": "Growth edges",
+          "section_key": "growth.weaknesses",
+          "title": "Growth weaknesses",
           "render_variant": "bullets",
           "body_md": null,
           "body_html": null,
@@ -2129,34 +2343,44 @@
               }
             ]
           },
-          "sort_order": 30,
+          "sort_order": 110,
           "is_enabled": true
         },
         {
-          "section_key": "work_style",
-          "title": "Work style",
+          "section_key": "growth.summary",
+          "title": "Growth summary",
           "render_variant": "rich_text",
           "body_md": "High-autonomy role scope, clear success metrics, and consistent feedback cadence.",
+          "body_html": null,
+          "payload_json": null,
+          "sort_order": 90,
+          "is_enabled": true
+        },
+        {
+          "section_key": "relationships.summary",
+          "title": "Relationships summary",
+          "render_variant": "rich_text",
+          "body_md": "You usually build trust through steady one-on-one conversations, reflection, and protected space. You tend to value people who are reliable, concrete, and consistent in day-to-day follow-through. In conflict you often default to harmony and emotional tone, so it helps to make your principles explicit. In close relationships and teamwork, you usually prefer flexibility, openness, and room to adapt.",
+          "body_html": null,
+          "payload_json": null,
+          "sort_order": 140,
+          "is_enabled": true
+        },
+        {
+          "section_key": "career.summary",
+          "title": "Career summary",
+          "render_variant": "rich_text",
+          "body_md": "You usually perform best in high-autonomy role scope, clear success metrics, and consistent feedback cadence. Prioritize options like Fullstack Engineer, Cloud Architect, HR Business Partner.",
           "body_html": null,
           "payload_json": null,
           "sort_order": 40,
           "is_enabled": true
         },
         {
-          "section_key": "relationships",
-          "title": "Relationships",
-          "render_variant": "rich_text",
-          "body_md": "You usually build trust through steady one-on-one conversations, reflection, and protected space. You tend to value people who are reliable, concrete, and consistent in day-to-day follow-through. In conflict you often default to harmony and emotional tone, so it helps to make your principles explicit. In close relationships and teamwork, you usually prefer flexibility, openness, and room to adapt.",
-          "body_html": null,
-          "payload_json": null,
-          "sort_order": 50,
-          "is_enabled": true
-        },
-        {
-          "section_key": "career_fit",
-          "title": "Career fit",
-          "render_variant": "cards",
-          "body_md": "You usually perform best in high-autonomy role scope, clear success metrics, and consistent feedback cadence. Prioritize options like Fullstack Engineer, Cloud Architect, HR Business Partner.",
+          "section_key": "career.preferred_roles",
+          "title": "Preferred roles",
+          "render_variant": "preferred_role_list",
+          "body_md": null,
           "body_html": null,
           "payload_json": {
             "recommended_jobs": [
@@ -2201,7 +2425,7 @@
             ],
             "work_env": "High-autonomy role scope, clear success metrics, and consistent feedback cadence."
           },
-          "sort_order": 80,
+          "sort_order": 70,
           "is_enabled": true
         }
       ],
@@ -2223,10 +2447,16 @@
       "type_code": "ISTJ",
       "slug": "istj",
       "title": "ISTJ - Logistician",
+      "type_name": "Logistician",
+      "nickname": "Logistician",
+      "rarity_text": null,
+      "keywords_json": [],
       "subtitle": null,
       "excerpt": "Role recommendations and work-environment guidance for ISTJ profiles.",
       "hero_kicker": "Logistician",
       "hero_quote": null,
+      "hero_summary_md": "Role recommendations and work-environment guidance for ISTJ profiles.",
+      "hero_summary_html": null,
       "hero_image_url": null,
       "status": "published",
       "is_public": true,
@@ -2235,18 +2465,18 @@
       "scheduled_at": null,
       "sections": [
         {
-          "section_key": "core_snapshot",
-          "title": "Core snapshot",
+          "section_key": "overview",
+          "title": "Overview",
           "render_variant": "rich_text",
           "body_md": "Role recommendations and work-environment guidance for ISTJ profiles. This profile tends to do best when goals are explicit, feedback is available, and growth loops stay visible.",
           "body_html": null,
           "payload_json": null,
-          "sort_order": 10,
+          "sort_order": 20,
           "is_enabled": true
         },
         {
-          "section_key": "strengths",
-          "title": "Strengths",
+          "section_key": "growth.strengths",
+          "title": "Growth strengths",
           "render_variant": "bullets",
           "body_md": null,
           "body_html": null,
@@ -2266,12 +2496,12 @@
               }
             ]
           },
-          "sort_order": 20,
+          "sort_order": 100,
           "is_enabled": true
         },
         {
-          "section_key": "growth_edges",
-          "title": "Growth edges",
+          "section_key": "growth.weaknesses",
+          "title": "Growth weaknesses",
           "render_variant": "bullets",
           "body_md": null,
           "body_html": null,
@@ -2287,34 +2517,44 @@
               }
             ]
           },
-          "sort_order": 30,
+          "sort_order": 110,
           "is_enabled": true
         },
         {
-          "section_key": "work_style",
-          "title": "Work style",
+          "section_key": "growth.summary",
+          "title": "Growth summary",
           "render_variant": "rich_text",
           "body_md": "High-autonomy role scope, clear success metrics, and consistent feedback cadence.",
+          "body_html": null,
+          "payload_json": null,
+          "sort_order": 90,
+          "is_enabled": true
+        },
+        {
+          "section_key": "relationships.summary",
+          "title": "Relationships summary",
+          "render_variant": "rich_text",
+          "body_md": "You usually build trust through steady one-on-one conversations, reflection, and protected space. You tend to value people who are reliable, concrete, and consistent in day-to-day follow-through. In conflict you often default to logic and boundaries, so it helps to add explicit emotional acknowledgment. In close relationships and teamwork, you usually prefer clarity, commitment, and predictable pace.",
+          "body_html": null,
+          "payload_json": null,
+          "sort_order": 140,
+          "is_enabled": true
+        },
+        {
+          "section_key": "career.summary",
+          "title": "Career summary",
+          "render_variant": "rich_text",
+          "body_md": "You usually perform best in high-autonomy role scope, clear success metrics, and consistent feedback cadence. Prioritize options like Teacher, Machine Learning Engineer, Backend Engineer.",
           "body_html": null,
           "payload_json": null,
           "sort_order": 40,
           "is_enabled": true
         },
         {
-          "section_key": "relationships",
-          "title": "Relationships",
-          "render_variant": "rich_text",
-          "body_md": "You usually build trust through steady one-on-one conversations, reflection, and protected space. You tend to value people who are reliable, concrete, and consistent in day-to-day follow-through. In conflict you often default to logic and boundaries, so it helps to add explicit emotional acknowledgment. In close relationships and teamwork, you usually prefer clarity, commitment, and predictable pace.",
-          "body_html": null,
-          "payload_json": null,
-          "sort_order": 50,
-          "is_enabled": true
-        },
-        {
-          "section_key": "career_fit",
-          "title": "Career fit",
-          "render_variant": "cards",
-          "body_md": "You usually perform best in high-autonomy role scope, clear success metrics, and consistent feedback cadence. Prioritize options like Teacher, Machine Learning Engineer, Backend Engineer.",
+          "section_key": "career.preferred_roles",
+          "title": "Preferred roles",
+          "render_variant": "preferred_role_list",
+          "body_md": null,
           "body_html": null,
           "payload_json": {
             "recommended_jobs": [
@@ -2359,7 +2599,7 @@
             ],
             "work_env": "High-autonomy role scope, clear success metrics, and consistent feedback cadence."
           },
-          "sort_order": 80,
+          "sort_order": 70,
           "is_enabled": true
         }
       ],
@@ -2381,10 +2621,16 @@
       "type_code": "ISTP",
       "slug": "istp",
       "title": "ISTP - Virtuoso",
+      "type_name": "Virtuoso",
+      "nickname": "Virtuoso",
+      "rarity_text": null,
+      "keywords_json": [],
       "subtitle": null,
       "excerpt": "Role recommendations and work-environment guidance for ISTP profiles.",
       "hero_kicker": "Virtuoso",
       "hero_quote": null,
+      "hero_summary_md": "Role recommendations and work-environment guidance for ISTP profiles.",
+      "hero_summary_html": null,
       "hero_image_url": null,
       "status": "published",
       "is_public": true,
@@ -2393,18 +2639,18 @@
       "scheduled_at": null,
       "sections": [
         {
-          "section_key": "core_snapshot",
-          "title": "Core snapshot",
+          "section_key": "overview",
+          "title": "Overview",
           "render_variant": "rich_text",
           "body_md": "Role recommendations and work-environment guidance for ISTP profiles. This profile tends to do best when goals are explicit, feedback is available, and growth loops stay visible.",
           "body_html": null,
           "payload_json": null,
-          "sort_order": 10,
+          "sort_order": 20,
           "is_enabled": true
         },
         {
-          "section_key": "strengths",
-          "title": "Strengths",
+          "section_key": "growth.strengths",
+          "title": "Growth strengths",
           "render_variant": "bullets",
           "body_md": null,
           "body_html": null,
@@ -2424,12 +2670,12 @@
               }
             ]
           },
-          "sort_order": 20,
+          "sort_order": 100,
           "is_enabled": true
         },
         {
-          "section_key": "growth_edges",
-          "title": "Growth edges",
+          "section_key": "growth.weaknesses",
+          "title": "Growth weaknesses",
           "render_variant": "bullets",
           "body_md": null,
           "body_html": null,
@@ -2445,34 +2691,44 @@
               }
             ]
           },
-          "sort_order": 30,
+          "sort_order": 110,
           "is_enabled": true
         },
         {
-          "section_key": "work_style",
-          "title": "Work style",
+          "section_key": "growth.summary",
+          "title": "Growth summary",
           "render_variant": "rich_text",
           "body_md": "High-autonomy role scope, clear success metrics, and consistent feedback cadence.",
+          "body_html": null,
+          "payload_json": null,
+          "sort_order": 90,
+          "is_enabled": true
+        },
+        {
+          "section_key": "relationships.summary",
+          "title": "Relationships summary",
+          "render_variant": "rich_text",
+          "body_md": "You usually build trust through steady one-on-one conversations, reflection, and protected space. You tend to value people who are reliable, concrete, and consistent in day-to-day follow-through. In conflict you often default to logic and boundaries, so it helps to add explicit emotional acknowledgment. In close relationships and teamwork, you usually prefer flexibility, openness, and room to adapt.",
+          "body_html": null,
+          "payload_json": null,
+          "sort_order": 140,
+          "is_enabled": true
+        },
+        {
+          "section_key": "career.summary",
+          "title": "Career summary",
+          "render_variant": "rich_text",
+          "body_md": "You usually perform best in high-autonomy role scope, clear success metrics, and consistent feedback cadence. Prioritize options like Backend Engineer, Cybersecurity Analyst, Operations Manager.",
           "body_html": null,
           "payload_json": null,
           "sort_order": 40,
           "is_enabled": true
         },
         {
-          "section_key": "relationships",
-          "title": "Relationships",
-          "render_variant": "rich_text",
-          "body_md": "You usually build trust through steady one-on-one conversations, reflection, and protected space. You tend to value people who are reliable, concrete, and consistent in day-to-day follow-through. In conflict you often default to logic and boundaries, so it helps to add explicit emotional acknowledgment. In close relationships and teamwork, you usually prefer flexibility, openness, and room to adapt.",
-          "body_html": null,
-          "payload_json": null,
-          "sort_order": 50,
-          "is_enabled": true
-        },
-        {
-          "section_key": "career_fit",
-          "title": "Career fit",
-          "render_variant": "cards",
-          "body_md": "You usually perform best in high-autonomy role scope, clear success metrics, and consistent feedback cadence. Prioritize options like Backend Engineer, Cybersecurity Analyst, Operations Manager.",
+          "section_key": "career.preferred_roles",
+          "title": "Preferred roles",
+          "render_variant": "preferred_role_list",
+          "body_md": null,
           "body_html": null,
           "payload_json": {
             "recommended_jobs": [
@@ -2517,13 +2773,943 @@
             ],
             "work_env": "High-autonomy role scope, clear success metrics, and consistent feedback cadence."
           },
-          "sort_order": 80,
+          "sort_order": 70,
           "is_enabled": true
         }
       ],
       "seo_meta": {
         "seo_title": "ISTP Personality Guide",
         "seo_description": "Discover strengths, weaknesses, relationship patterns, and career direction for the ISTP personality type.",
+        "canonical_url": null,
+        "og_title": null,
+        "og_description": null,
+        "og_image_url": null,
+        "twitter_title": null,
+        "twitter_description": null,
+        "twitter_image_url": null,
+        "robots": null,
+        "jsonld_overrides_json": null
+      }
+    }
+  ],
+  "variants": [
+    {
+      "runtime_type_code": "ENFJ-A",
+      "canonical_type_code": "ENFJ",
+      "variant_code": "A",
+      "is_published": false,
+      "published_at": null,
+      "profile_overrides": {
+        "type_name": null,
+        "nickname": null,
+        "rarity_text": null,
+        "keywords_json": [],
+        "hero_summary_md": null,
+        "hero_summary_html": null
+      },
+      "section_overrides": [],
+      "seo_overrides": {
+        "seo_title": null,
+        "seo_description": null,
+        "canonical_url": null,
+        "og_title": null,
+        "og_description": null,
+        "og_image_url": null,
+        "twitter_title": null,
+        "twitter_description": null,
+        "twitter_image_url": null,
+        "robots": null,
+        "jsonld_overrides_json": null
+      }
+    },
+    {
+      "runtime_type_code": "ENFJ-T",
+      "canonical_type_code": "ENFJ",
+      "variant_code": "T",
+      "is_published": false,
+      "published_at": null,
+      "profile_overrides": {
+        "type_name": null,
+        "nickname": null,
+        "rarity_text": null,
+        "keywords_json": [],
+        "hero_summary_md": null,
+        "hero_summary_html": null
+      },
+      "section_overrides": [],
+      "seo_overrides": {
+        "seo_title": null,
+        "seo_description": null,
+        "canonical_url": null,
+        "og_title": null,
+        "og_description": null,
+        "og_image_url": null,
+        "twitter_title": null,
+        "twitter_description": null,
+        "twitter_image_url": null,
+        "robots": null,
+        "jsonld_overrides_json": null
+      }
+    },
+    {
+      "runtime_type_code": "ENFP-A",
+      "canonical_type_code": "ENFP",
+      "variant_code": "A",
+      "is_published": false,
+      "published_at": null,
+      "profile_overrides": {
+        "type_name": null,
+        "nickname": null,
+        "rarity_text": null,
+        "keywords_json": [],
+        "hero_summary_md": null,
+        "hero_summary_html": null
+      },
+      "section_overrides": [],
+      "seo_overrides": {
+        "seo_title": null,
+        "seo_description": null,
+        "canonical_url": null,
+        "og_title": null,
+        "og_description": null,
+        "og_image_url": null,
+        "twitter_title": null,
+        "twitter_description": null,
+        "twitter_image_url": null,
+        "robots": null,
+        "jsonld_overrides_json": null
+      }
+    },
+    {
+      "runtime_type_code": "ENFP-T",
+      "canonical_type_code": "ENFP",
+      "variant_code": "T",
+      "is_published": false,
+      "published_at": null,
+      "profile_overrides": {
+        "type_name": null,
+        "nickname": null,
+        "rarity_text": null,
+        "keywords_json": [],
+        "hero_summary_md": null,
+        "hero_summary_html": null
+      },
+      "section_overrides": [],
+      "seo_overrides": {
+        "seo_title": null,
+        "seo_description": null,
+        "canonical_url": null,
+        "og_title": null,
+        "og_description": null,
+        "og_image_url": null,
+        "twitter_title": null,
+        "twitter_description": null,
+        "twitter_image_url": null,
+        "robots": null,
+        "jsonld_overrides_json": null
+      }
+    },
+    {
+      "runtime_type_code": "ENTJ-A",
+      "canonical_type_code": "ENTJ",
+      "variant_code": "A",
+      "is_published": false,
+      "published_at": null,
+      "profile_overrides": {
+        "type_name": null,
+        "nickname": null,
+        "rarity_text": null,
+        "keywords_json": [],
+        "hero_summary_md": null,
+        "hero_summary_html": null
+      },
+      "section_overrides": [],
+      "seo_overrides": {
+        "seo_title": null,
+        "seo_description": null,
+        "canonical_url": null,
+        "og_title": null,
+        "og_description": null,
+        "og_image_url": null,
+        "twitter_title": null,
+        "twitter_description": null,
+        "twitter_image_url": null,
+        "robots": null,
+        "jsonld_overrides_json": null
+      }
+    },
+    {
+      "runtime_type_code": "ENTJ-T",
+      "canonical_type_code": "ENTJ",
+      "variant_code": "T",
+      "is_published": false,
+      "published_at": null,
+      "profile_overrides": {
+        "type_name": null,
+        "nickname": null,
+        "rarity_text": null,
+        "keywords_json": [],
+        "hero_summary_md": null,
+        "hero_summary_html": null
+      },
+      "section_overrides": [],
+      "seo_overrides": {
+        "seo_title": null,
+        "seo_description": null,
+        "canonical_url": null,
+        "og_title": null,
+        "og_description": null,
+        "og_image_url": null,
+        "twitter_title": null,
+        "twitter_description": null,
+        "twitter_image_url": null,
+        "robots": null,
+        "jsonld_overrides_json": null
+      }
+    },
+    {
+      "runtime_type_code": "ENTP-A",
+      "canonical_type_code": "ENTP",
+      "variant_code": "A",
+      "is_published": false,
+      "published_at": null,
+      "profile_overrides": {
+        "type_name": null,
+        "nickname": null,
+        "rarity_text": null,
+        "keywords_json": [],
+        "hero_summary_md": null,
+        "hero_summary_html": null
+      },
+      "section_overrides": [],
+      "seo_overrides": {
+        "seo_title": null,
+        "seo_description": null,
+        "canonical_url": null,
+        "og_title": null,
+        "og_description": null,
+        "og_image_url": null,
+        "twitter_title": null,
+        "twitter_description": null,
+        "twitter_image_url": null,
+        "robots": null,
+        "jsonld_overrides_json": null
+      }
+    },
+    {
+      "runtime_type_code": "ENTP-T",
+      "canonical_type_code": "ENTP",
+      "variant_code": "T",
+      "is_published": false,
+      "published_at": null,
+      "profile_overrides": {
+        "type_name": null,
+        "nickname": null,
+        "rarity_text": null,
+        "keywords_json": [],
+        "hero_summary_md": null,
+        "hero_summary_html": null
+      },
+      "section_overrides": [],
+      "seo_overrides": {
+        "seo_title": null,
+        "seo_description": null,
+        "canonical_url": null,
+        "og_title": null,
+        "og_description": null,
+        "og_image_url": null,
+        "twitter_title": null,
+        "twitter_description": null,
+        "twitter_image_url": null,
+        "robots": null,
+        "jsonld_overrides_json": null
+      }
+    },
+    {
+      "runtime_type_code": "ESFJ-A",
+      "canonical_type_code": "ESFJ",
+      "variant_code": "A",
+      "is_published": false,
+      "published_at": null,
+      "profile_overrides": {
+        "type_name": null,
+        "nickname": null,
+        "rarity_text": null,
+        "keywords_json": [],
+        "hero_summary_md": null,
+        "hero_summary_html": null
+      },
+      "section_overrides": [],
+      "seo_overrides": {
+        "seo_title": null,
+        "seo_description": null,
+        "canonical_url": null,
+        "og_title": null,
+        "og_description": null,
+        "og_image_url": null,
+        "twitter_title": null,
+        "twitter_description": null,
+        "twitter_image_url": null,
+        "robots": null,
+        "jsonld_overrides_json": null
+      }
+    },
+    {
+      "runtime_type_code": "ESFJ-T",
+      "canonical_type_code": "ESFJ",
+      "variant_code": "T",
+      "is_published": false,
+      "published_at": null,
+      "profile_overrides": {
+        "type_name": null,
+        "nickname": null,
+        "rarity_text": null,
+        "keywords_json": [],
+        "hero_summary_md": null,
+        "hero_summary_html": null
+      },
+      "section_overrides": [],
+      "seo_overrides": {
+        "seo_title": null,
+        "seo_description": null,
+        "canonical_url": null,
+        "og_title": null,
+        "og_description": null,
+        "og_image_url": null,
+        "twitter_title": null,
+        "twitter_description": null,
+        "twitter_image_url": null,
+        "robots": null,
+        "jsonld_overrides_json": null
+      }
+    },
+    {
+      "runtime_type_code": "ESFP-A",
+      "canonical_type_code": "ESFP",
+      "variant_code": "A",
+      "is_published": false,
+      "published_at": null,
+      "profile_overrides": {
+        "type_name": null,
+        "nickname": null,
+        "rarity_text": null,
+        "keywords_json": [],
+        "hero_summary_md": null,
+        "hero_summary_html": null
+      },
+      "section_overrides": [],
+      "seo_overrides": {
+        "seo_title": null,
+        "seo_description": null,
+        "canonical_url": null,
+        "og_title": null,
+        "og_description": null,
+        "og_image_url": null,
+        "twitter_title": null,
+        "twitter_description": null,
+        "twitter_image_url": null,
+        "robots": null,
+        "jsonld_overrides_json": null
+      }
+    },
+    {
+      "runtime_type_code": "ESFP-T",
+      "canonical_type_code": "ESFP",
+      "variant_code": "T",
+      "is_published": false,
+      "published_at": null,
+      "profile_overrides": {
+        "type_name": null,
+        "nickname": null,
+        "rarity_text": null,
+        "keywords_json": [],
+        "hero_summary_md": null,
+        "hero_summary_html": null
+      },
+      "section_overrides": [],
+      "seo_overrides": {
+        "seo_title": null,
+        "seo_description": null,
+        "canonical_url": null,
+        "og_title": null,
+        "og_description": null,
+        "og_image_url": null,
+        "twitter_title": null,
+        "twitter_description": null,
+        "twitter_image_url": null,
+        "robots": null,
+        "jsonld_overrides_json": null
+      }
+    },
+    {
+      "runtime_type_code": "ESTJ-A",
+      "canonical_type_code": "ESTJ",
+      "variant_code": "A",
+      "is_published": false,
+      "published_at": null,
+      "profile_overrides": {
+        "type_name": null,
+        "nickname": null,
+        "rarity_text": null,
+        "keywords_json": [],
+        "hero_summary_md": null,
+        "hero_summary_html": null
+      },
+      "section_overrides": [],
+      "seo_overrides": {
+        "seo_title": null,
+        "seo_description": null,
+        "canonical_url": null,
+        "og_title": null,
+        "og_description": null,
+        "og_image_url": null,
+        "twitter_title": null,
+        "twitter_description": null,
+        "twitter_image_url": null,
+        "robots": null,
+        "jsonld_overrides_json": null
+      }
+    },
+    {
+      "runtime_type_code": "ESTJ-T",
+      "canonical_type_code": "ESTJ",
+      "variant_code": "T",
+      "is_published": false,
+      "published_at": null,
+      "profile_overrides": {
+        "type_name": null,
+        "nickname": null,
+        "rarity_text": null,
+        "keywords_json": [],
+        "hero_summary_md": null,
+        "hero_summary_html": null
+      },
+      "section_overrides": [],
+      "seo_overrides": {
+        "seo_title": null,
+        "seo_description": null,
+        "canonical_url": null,
+        "og_title": null,
+        "og_description": null,
+        "og_image_url": null,
+        "twitter_title": null,
+        "twitter_description": null,
+        "twitter_image_url": null,
+        "robots": null,
+        "jsonld_overrides_json": null
+      }
+    },
+    {
+      "runtime_type_code": "ESTP-A",
+      "canonical_type_code": "ESTP",
+      "variant_code": "A",
+      "is_published": false,
+      "published_at": null,
+      "profile_overrides": {
+        "type_name": null,
+        "nickname": null,
+        "rarity_text": null,
+        "keywords_json": [],
+        "hero_summary_md": null,
+        "hero_summary_html": null
+      },
+      "section_overrides": [],
+      "seo_overrides": {
+        "seo_title": null,
+        "seo_description": null,
+        "canonical_url": null,
+        "og_title": null,
+        "og_description": null,
+        "og_image_url": null,
+        "twitter_title": null,
+        "twitter_description": null,
+        "twitter_image_url": null,
+        "robots": null,
+        "jsonld_overrides_json": null
+      }
+    },
+    {
+      "runtime_type_code": "ESTP-T",
+      "canonical_type_code": "ESTP",
+      "variant_code": "T",
+      "is_published": false,
+      "published_at": null,
+      "profile_overrides": {
+        "type_name": null,
+        "nickname": null,
+        "rarity_text": null,
+        "keywords_json": [],
+        "hero_summary_md": null,
+        "hero_summary_html": null
+      },
+      "section_overrides": [],
+      "seo_overrides": {
+        "seo_title": null,
+        "seo_description": null,
+        "canonical_url": null,
+        "og_title": null,
+        "og_description": null,
+        "og_image_url": null,
+        "twitter_title": null,
+        "twitter_description": null,
+        "twitter_image_url": null,
+        "robots": null,
+        "jsonld_overrides_json": null
+      }
+    },
+    {
+      "runtime_type_code": "INFJ-A",
+      "canonical_type_code": "INFJ",
+      "variant_code": "A",
+      "is_published": false,
+      "published_at": null,
+      "profile_overrides": {
+        "type_name": null,
+        "nickname": null,
+        "rarity_text": null,
+        "keywords_json": [],
+        "hero_summary_md": null,
+        "hero_summary_html": null
+      },
+      "section_overrides": [],
+      "seo_overrides": {
+        "seo_title": null,
+        "seo_description": null,
+        "canonical_url": null,
+        "og_title": null,
+        "og_description": null,
+        "og_image_url": null,
+        "twitter_title": null,
+        "twitter_description": null,
+        "twitter_image_url": null,
+        "robots": null,
+        "jsonld_overrides_json": null
+      }
+    },
+    {
+      "runtime_type_code": "INFJ-T",
+      "canonical_type_code": "INFJ",
+      "variant_code": "T",
+      "is_published": false,
+      "published_at": null,
+      "profile_overrides": {
+        "type_name": null,
+        "nickname": null,
+        "rarity_text": null,
+        "keywords_json": [],
+        "hero_summary_md": null,
+        "hero_summary_html": null
+      },
+      "section_overrides": [],
+      "seo_overrides": {
+        "seo_title": null,
+        "seo_description": null,
+        "canonical_url": null,
+        "og_title": null,
+        "og_description": null,
+        "og_image_url": null,
+        "twitter_title": null,
+        "twitter_description": null,
+        "twitter_image_url": null,
+        "robots": null,
+        "jsonld_overrides_json": null
+      }
+    },
+    {
+      "runtime_type_code": "INFP-A",
+      "canonical_type_code": "INFP",
+      "variant_code": "A",
+      "is_published": false,
+      "published_at": null,
+      "profile_overrides": {
+        "type_name": null,
+        "nickname": null,
+        "rarity_text": null,
+        "keywords_json": [],
+        "hero_summary_md": null,
+        "hero_summary_html": null
+      },
+      "section_overrides": [],
+      "seo_overrides": {
+        "seo_title": null,
+        "seo_description": null,
+        "canonical_url": null,
+        "og_title": null,
+        "og_description": null,
+        "og_image_url": null,
+        "twitter_title": null,
+        "twitter_description": null,
+        "twitter_image_url": null,
+        "robots": null,
+        "jsonld_overrides_json": null
+      }
+    },
+    {
+      "runtime_type_code": "INFP-T",
+      "canonical_type_code": "INFP",
+      "variant_code": "T",
+      "is_published": false,
+      "published_at": null,
+      "profile_overrides": {
+        "type_name": null,
+        "nickname": null,
+        "rarity_text": null,
+        "keywords_json": [],
+        "hero_summary_md": null,
+        "hero_summary_html": null
+      },
+      "section_overrides": [],
+      "seo_overrides": {
+        "seo_title": null,
+        "seo_description": null,
+        "canonical_url": null,
+        "og_title": null,
+        "og_description": null,
+        "og_image_url": null,
+        "twitter_title": null,
+        "twitter_description": null,
+        "twitter_image_url": null,
+        "robots": null,
+        "jsonld_overrides_json": null
+      }
+    },
+    {
+      "runtime_type_code": "INTJ-A",
+      "canonical_type_code": "INTJ",
+      "variant_code": "A",
+      "is_published": false,
+      "published_at": null,
+      "profile_overrides": {
+        "type_name": null,
+        "nickname": null,
+        "rarity_text": null,
+        "keywords_json": [],
+        "hero_summary_md": null,
+        "hero_summary_html": null
+      },
+      "section_overrides": [],
+      "seo_overrides": {
+        "seo_title": null,
+        "seo_description": null,
+        "canonical_url": null,
+        "og_title": null,
+        "og_description": null,
+        "og_image_url": null,
+        "twitter_title": null,
+        "twitter_description": null,
+        "twitter_image_url": null,
+        "robots": null,
+        "jsonld_overrides_json": null
+      }
+    },
+    {
+      "runtime_type_code": "INTJ-T",
+      "canonical_type_code": "INTJ",
+      "variant_code": "T",
+      "is_published": false,
+      "published_at": null,
+      "profile_overrides": {
+        "type_name": null,
+        "nickname": null,
+        "rarity_text": null,
+        "keywords_json": [],
+        "hero_summary_md": null,
+        "hero_summary_html": null
+      },
+      "section_overrides": [],
+      "seo_overrides": {
+        "seo_title": null,
+        "seo_description": null,
+        "canonical_url": null,
+        "og_title": null,
+        "og_description": null,
+        "og_image_url": null,
+        "twitter_title": null,
+        "twitter_description": null,
+        "twitter_image_url": null,
+        "robots": null,
+        "jsonld_overrides_json": null
+      }
+    },
+    {
+      "runtime_type_code": "INTP-A",
+      "canonical_type_code": "INTP",
+      "variant_code": "A",
+      "is_published": false,
+      "published_at": null,
+      "profile_overrides": {
+        "type_name": null,
+        "nickname": null,
+        "rarity_text": null,
+        "keywords_json": [],
+        "hero_summary_md": null,
+        "hero_summary_html": null
+      },
+      "section_overrides": [],
+      "seo_overrides": {
+        "seo_title": null,
+        "seo_description": null,
+        "canonical_url": null,
+        "og_title": null,
+        "og_description": null,
+        "og_image_url": null,
+        "twitter_title": null,
+        "twitter_description": null,
+        "twitter_image_url": null,
+        "robots": null,
+        "jsonld_overrides_json": null
+      }
+    },
+    {
+      "runtime_type_code": "INTP-T",
+      "canonical_type_code": "INTP",
+      "variant_code": "T",
+      "is_published": false,
+      "published_at": null,
+      "profile_overrides": {
+        "type_name": null,
+        "nickname": null,
+        "rarity_text": null,
+        "keywords_json": [],
+        "hero_summary_md": null,
+        "hero_summary_html": null
+      },
+      "section_overrides": [],
+      "seo_overrides": {
+        "seo_title": null,
+        "seo_description": null,
+        "canonical_url": null,
+        "og_title": null,
+        "og_description": null,
+        "og_image_url": null,
+        "twitter_title": null,
+        "twitter_description": null,
+        "twitter_image_url": null,
+        "robots": null,
+        "jsonld_overrides_json": null
+      }
+    },
+    {
+      "runtime_type_code": "ISFJ-A",
+      "canonical_type_code": "ISFJ",
+      "variant_code": "A",
+      "is_published": false,
+      "published_at": null,
+      "profile_overrides": {
+        "type_name": null,
+        "nickname": null,
+        "rarity_text": null,
+        "keywords_json": [],
+        "hero_summary_md": null,
+        "hero_summary_html": null
+      },
+      "section_overrides": [],
+      "seo_overrides": {
+        "seo_title": null,
+        "seo_description": null,
+        "canonical_url": null,
+        "og_title": null,
+        "og_description": null,
+        "og_image_url": null,
+        "twitter_title": null,
+        "twitter_description": null,
+        "twitter_image_url": null,
+        "robots": null,
+        "jsonld_overrides_json": null
+      }
+    },
+    {
+      "runtime_type_code": "ISFJ-T",
+      "canonical_type_code": "ISFJ",
+      "variant_code": "T",
+      "is_published": false,
+      "published_at": null,
+      "profile_overrides": {
+        "type_name": null,
+        "nickname": null,
+        "rarity_text": null,
+        "keywords_json": [],
+        "hero_summary_md": null,
+        "hero_summary_html": null
+      },
+      "section_overrides": [],
+      "seo_overrides": {
+        "seo_title": null,
+        "seo_description": null,
+        "canonical_url": null,
+        "og_title": null,
+        "og_description": null,
+        "og_image_url": null,
+        "twitter_title": null,
+        "twitter_description": null,
+        "twitter_image_url": null,
+        "robots": null,
+        "jsonld_overrides_json": null
+      }
+    },
+    {
+      "runtime_type_code": "ISFP-A",
+      "canonical_type_code": "ISFP",
+      "variant_code": "A",
+      "is_published": false,
+      "published_at": null,
+      "profile_overrides": {
+        "type_name": null,
+        "nickname": null,
+        "rarity_text": null,
+        "keywords_json": [],
+        "hero_summary_md": null,
+        "hero_summary_html": null
+      },
+      "section_overrides": [],
+      "seo_overrides": {
+        "seo_title": null,
+        "seo_description": null,
+        "canonical_url": null,
+        "og_title": null,
+        "og_description": null,
+        "og_image_url": null,
+        "twitter_title": null,
+        "twitter_description": null,
+        "twitter_image_url": null,
+        "robots": null,
+        "jsonld_overrides_json": null
+      }
+    },
+    {
+      "runtime_type_code": "ISFP-T",
+      "canonical_type_code": "ISFP",
+      "variant_code": "T",
+      "is_published": false,
+      "published_at": null,
+      "profile_overrides": {
+        "type_name": null,
+        "nickname": null,
+        "rarity_text": null,
+        "keywords_json": [],
+        "hero_summary_md": null,
+        "hero_summary_html": null
+      },
+      "section_overrides": [],
+      "seo_overrides": {
+        "seo_title": null,
+        "seo_description": null,
+        "canonical_url": null,
+        "og_title": null,
+        "og_description": null,
+        "og_image_url": null,
+        "twitter_title": null,
+        "twitter_description": null,
+        "twitter_image_url": null,
+        "robots": null,
+        "jsonld_overrides_json": null
+      }
+    },
+    {
+      "runtime_type_code": "ISTJ-A",
+      "canonical_type_code": "ISTJ",
+      "variant_code": "A",
+      "is_published": false,
+      "published_at": null,
+      "profile_overrides": {
+        "type_name": null,
+        "nickname": null,
+        "rarity_text": null,
+        "keywords_json": [],
+        "hero_summary_md": null,
+        "hero_summary_html": null
+      },
+      "section_overrides": [],
+      "seo_overrides": {
+        "seo_title": null,
+        "seo_description": null,
+        "canonical_url": null,
+        "og_title": null,
+        "og_description": null,
+        "og_image_url": null,
+        "twitter_title": null,
+        "twitter_description": null,
+        "twitter_image_url": null,
+        "robots": null,
+        "jsonld_overrides_json": null
+      }
+    },
+    {
+      "runtime_type_code": "ISTJ-T",
+      "canonical_type_code": "ISTJ",
+      "variant_code": "T",
+      "is_published": false,
+      "published_at": null,
+      "profile_overrides": {
+        "type_name": null,
+        "nickname": null,
+        "rarity_text": null,
+        "keywords_json": [],
+        "hero_summary_md": null,
+        "hero_summary_html": null
+      },
+      "section_overrides": [],
+      "seo_overrides": {
+        "seo_title": null,
+        "seo_description": null,
+        "canonical_url": null,
+        "og_title": null,
+        "og_description": null,
+        "og_image_url": null,
+        "twitter_title": null,
+        "twitter_description": null,
+        "twitter_image_url": null,
+        "robots": null,
+        "jsonld_overrides_json": null
+      }
+    },
+    {
+      "runtime_type_code": "ISTP-A",
+      "canonical_type_code": "ISTP",
+      "variant_code": "A",
+      "is_published": false,
+      "published_at": null,
+      "profile_overrides": {
+        "type_name": null,
+        "nickname": null,
+        "rarity_text": null,
+        "keywords_json": [],
+        "hero_summary_md": null,
+        "hero_summary_html": null
+      },
+      "section_overrides": [],
+      "seo_overrides": {
+        "seo_title": null,
+        "seo_description": null,
+        "canonical_url": null,
+        "og_title": null,
+        "og_description": null,
+        "og_image_url": null,
+        "twitter_title": null,
+        "twitter_description": null,
+        "twitter_image_url": null,
+        "robots": null,
+        "jsonld_overrides_json": null
+      }
+    },
+    {
+      "runtime_type_code": "ISTP-T",
+      "canonical_type_code": "ISTP",
+      "variant_code": "T",
+      "is_published": false,
+      "published_at": null,
+      "profile_overrides": {
+        "type_name": null,
+        "nickname": null,
+        "rarity_text": null,
+        "keywords_json": [],
+        "hero_summary_md": null,
+        "hero_summary_html": null
+      },
+      "section_overrides": [],
+      "seo_overrides": {
+        "seo_title": null,
+        "seo_description": null,
         "canonical_url": null,
         "og_title": null,
         "og_description": null,

--- a/content_baselines/personality/mbti.zh-CN.json
+++ b/content_baselines/personality/mbti.zh-CN.json
@@ -1,20 +1,26 @@
 {
   "meta": {
-    "schema_version": "v1",
+    "schema_version": "v2",
     "scale_code": "MBTI",
     "locale": "zh-CN",
-    "source": "fap-web careerRecommendationProfiles + personality.ts deterministic transforms",
-    "generated_at": "2026-03-08T00:00:00Z"
+    "source": "committed canonical base authority + raw 32 zh-CN variant authority",
+    "generated_at": "2026-03-17T00:00:00Z"
   },
   "profiles": [
     {
       "type_code": "ENFJ",
       "slug": "enfj",
       "title": "ENFJ - 主人公",
+      "type_name": "主人公",
+      "nickname": "主人公",
+      "rarity_text": null,
+      "keywords_json": [],
       "subtitle": null,
       "excerpt": "基于 ENFJ 人格画像的职业建议与工作环境匹配策略。",
       "hero_kicker": "主人公",
       "hero_quote": null,
+      "hero_summary_md": "基于 ENFJ 人格画像的职业建议与工作环境匹配策略。",
+      "hero_summary_html": null,
       "hero_image_url": null,
       "status": "published",
       "is_public": true,
@@ -23,18 +29,18 @@
       "scheduled_at": null,
       "sections": [
         {
-          "section_key": "core_snapshot",
-          "title": "核心概览",
+          "section_key": "overview",
+          "title": "人格概览",
           "render_variant": "rich_text",
           "body_md": "基于 ENFJ 人格画像的职业建议与工作环境匹配策略。 这类人格通常在目标清晰、反馈可获得、能够持续迭代的环境里更容易稳定发挥。",
           "body_html": null,
           "payload_json": null,
-          "sort_order": 10,
+          "sort_order": 20,
           "is_enabled": true
         },
         {
-          "section_key": "strengths",
-          "title": "优势",
+          "section_key": "growth.strengths",
+          "title": "成长优势",
           "render_variant": "bullets",
           "body_md": null,
           "body_html": null,
@@ -54,12 +60,12 @@
               }
             ]
           },
-          "sort_order": 20,
+          "sort_order": 100,
           "is_enabled": true
         },
         {
-          "section_key": "growth_edges",
-          "title": "成长边界",
+          "section_key": "growth.weaknesses",
+          "title": "成长盲点",
           "render_variant": "bullets",
           "body_md": null,
           "body_html": null,
@@ -75,34 +81,44 @@
               }
             ]
           },
-          "sort_order": 30,
+          "sort_order": 110,
           "is_enabled": true
         },
         {
-          "section_key": "work_style",
-          "title": "工作风格",
+          "section_key": "growth.summary",
+          "title": "成长概览",
           "render_variant": "rich_text",
           "body_md": "高自主度、目标清晰、反馈节奏稳定的工作环境。",
+          "body_html": null,
+          "payload_json": null,
+          "sort_order": 90,
+          "is_enabled": true
+        },
+        {
+          "section_key": "relationships.summary",
+          "title": "关系模式",
+          "render_variant": "rich_text",
+          "body_md": "你往往通过直接交流、共同经历和快速反馈来建立关系。你倾向于和能讨论长期可能性、模式和意义的人建立更深连接。在冲突里你通常优先照顾感受和氛围，因此需要主动讲清原则和底线。亲密关系与协作关系里，你通常更喜欢明确承诺、稳定节奏和可预期安排。",
+          "body_html": null,
+          "payload_json": null,
+          "sort_order": 140,
+          "is_enabled": true
+        },
+        {
+          "section_key": "career.summary",
+          "title": "职业概览",
+          "render_variant": "rich_text",
+          "body_md": "你通常更适合在高自主度、目标清晰、反馈节奏稳定的工作环境中发挥优势。优先探索这些方向：律师, 教师, 机器学习工程师。",
           "body_html": null,
           "payload_json": null,
           "sort_order": 40,
           "is_enabled": true
         },
         {
-          "section_key": "relationships",
-          "title": "关系模式",
-          "render_variant": "rich_text",
-          "body_md": "你往往通过直接交流、共同经历和快速反馈来建立关系。你倾向于和能讨论长期可能性、模式和意义的人建立更深连接。在冲突里你通常优先照顾感受和氛围，因此需要主动讲清原则和底线。亲密关系与协作关系里，你通常更喜欢明确承诺、稳定节奏和可预期安排。",
-          "body_html": null,
-          "payload_json": null,
-          "sort_order": 50,
-          "is_enabled": true
-        },
-        {
-          "section_key": "career_fit",
-          "title": "职业匹配",
-          "render_variant": "cards",
-          "body_md": "你通常更适合在高自主度、目标清晰、反馈节奏稳定的工作环境中发挥优势。优先探索这些方向：律师, 教师, 机器学习工程师。",
+          "section_key": "career.preferred_roles",
+          "title": "推荐职业方向",
+          "render_variant": "preferred_role_list",
+          "body_md": null,
           "body_html": null,
           "payload_json": {
             "recommended_jobs": [
@@ -147,7 +163,7 @@
             ],
             "work_env": "高自主度、目标清晰、反馈节奏稳定的工作环境。"
           },
-          "sort_order": 80,
+          "sort_order": 70,
           "is_enabled": true
         }
       ],
@@ -169,10 +185,16 @@
       "type_code": "ENFP",
       "slug": "enfp",
       "title": "ENFP - 竞选者",
+      "type_name": "竞选者",
+      "nickname": "竞选者",
+      "rarity_text": null,
+      "keywords_json": [],
       "subtitle": null,
       "excerpt": "基于 ENFP 人格画像的职业建议与工作环境匹配策略。",
       "hero_kicker": "竞选者",
       "hero_quote": null,
+      "hero_summary_md": "基于 ENFP 人格画像的职业建议与工作环境匹配策略。",
+      "hero_summary_html": null,
       "hero_image_url": null,
       "status": "published",
       "is_public": true,
@@ -181,18 +203,18 @@
       "scheduled_at": null,
       "sections": [
         {
-          "section_key": "core_snapshot",
-          "title": "核心概览",
+          "section_key": "overview",
+          "title": "人格概览",
           "render_variant": "rich_text",
           "body_md": "基于 ENFP 人格画像的职业建议与工作环境匹配策略。 这类人格通常在目标清晰、反馈可获得、能够持续迭代的环境里更容易稳定发挥。",
           "body_html": null,
           "payload_json": null,
-          "sort_order": 10,
+          "sort_order": 20,
           "is_enabled": true
         },
         {
-          "section_key": "strengths",
-          "title": "优势",
+          "section_key": "growth.strengths",
+          "title": "成长优势",
           "render_variant": "bullets",
           "body_md": null,
           "body_html": null,
@@ -212,12 +234,12 @@
               }
             ]
           },
-          "sort_order": 20,
+          "sort_order": 100,
           "is_enabled": true
         },
         {
-          "section_key": "growth_edges",
-          "title": "成长边界",
+          "section_key": "growth.weaknesses",
+          "title": "成长盲点",
           "render_variant": "bullets",
           "body_md": null,
           "body_html": null,
@@ -233,34 +255,44 @@
               }
             ]
           },
-          "sort_order": 30,
+          "sort_order": 110,
           "is_enabled": true
         },
         {
-          "section_key": "work_style",
-          "title": "工作风格",
+          "section_key": "growth.summary",
+          "title": "成长概览",
           "render_variant": "rich_text",
           "body_md": "高自主度、目标清晰、反馈节奏稳定的工作环境。",
+          "body_html": null,
+          "payload_json": null,
+          "sort_order": 90,
+          "is_enabled": true
+        },
+        {
+          "section_key": "relationships.summary",
+          "title": "关系模式",
+          "render_variant": "rich_text",
+          "body_md": "你往往通过直接交流、共同经历和快速反馈来建立关系。你倾向于和能讨论长期可能性、模式和意义的人建立更深连接。在冲突里你通常优先照顾感受和氛围，因此需要主动讲清原则和底线。亲密关系与协作关系里，你通常更喜欢弹性空间、自然推进和保留选择余地。",
+          "body_html": null,
+          "payload_json": null,
+          "sort_order": 140,
+          "is_enabled": true
+        },
+        {
+          "section_key": "career.summary",
+          "title": "职业概览",
+          "render_variant": "rich_text",
+          "body_md": "你通常更适合在高自主度、目标清晰、反馈节奏稳定的工作环境中发挥优势。优先探索这些方向：医生, 数据科学家, 前端工程师。",
           "body_html": null,
           "payload_json": null,
           "sort_order": 40,
           "is_enabled": true
         },
         {
-          "section_key": "relationships",
-          "title": "关系模式",
-          "render_variant": "rich_text",
-          "body_md": "你往往通过直接交流、共同经历和快速反馈来建立关系。你倾向于和能讨论长期可能性、模式和意义的人建立更深连接。在冲突里你通常优先照顾感受和氛围，因此需要主动讲清原则和底线。亲密关系与协作关系里，你通常更喜欢弹性空间、自然推进和保留选择余地。",
-          "body_html": null,
-          "payload_json": null,
-          "sort_order": 50,
-          "is_enabled": true
-        },
-        {
-          "section_key": "career_fit",
-          "title": "职业匹配",
-          "render_variant": "cards",
-          "body_md": "你通常更适合在高自主度、目标清晰、反馈节奏稳定的工作环境中发挥优势。优先探索这些方向：医生, 数据科学家, 前端工程师。",
+          "section_key": "career.preferred_roles",
+          "title": "推荐职业方向",
+          "render_variant": "preferred_role_list",
+          "body_md": null,
           "body_html": null,
           "payload_json": {
             "recommended_jobs": [
@@ -305,7 +337,7 @@
             ],
             "work_env": "高自主度、目标清晰、反馈节奏稳定的工作环境。"
           },
-          "sort_order": 80,
+          "sort_order": 70,
           "is_enabled": true
         }
       ],
@@ -327,10 +359,16 @@
       "type_code": "ENTJ",
       "slug": "entj",
       "title": "ENTJ - 指挥官",
+      "type_name": "指挥官",
+      "nickname": "指挥官",
+      "rarity_text": null,
+      "keywords_json": [],
       "subtitle": null,
       "excerpt": "基于 ENTJ 人格画像的职业建议与工作环境匹配策略。",
       "hero_kicker": "指挥官",
       "hero_quote": null,
+      "hero_summary_md": "基于 ENTJ 人格画像的职业建议与工作环境匹配策略。",
+      "hero_summary_html": null,
       "hero_image_url": null,
       "status": "published",
       "is_public": true,
@@ -339,18 +377,18 @@
       "scheduled_at": null,
       "sections": [
         {
-          "section_key": "core_snapshot",
-          "title": "核心概览",
+          "section_key": "overview",
+          "title": "人格概览",
           "render_variant": "rich_text",
           "body_md": "基于 ENTJ 人格画像的职业建议与工作环境匹配策略。 这类人格通常在目标清晰、反馈可获得、能够持续迭代的环境里更容易稳定发挥。",
           "body_html": null,
           "payload_json": null,
-          "sort_order": 10,
+          "sort_order": 20,
           "is_enabled": true
         },
         {
-          "section_key": "strengths",
-          "title": "优势",
+          "section_key": "growth.strengths",
+          "title": "成长优势",
           "render_variant": "bullets",
           "body_md": null,
           "body_html": null,
@@ -370,12 +408,12 @@
               }
             ]
           },
-          "sort_order": 20,
+          "sort_order": 100,
           "is_enabled": true
         },
         {
-          "section_key": "growth_edges",
-          "title": "成长边界",
+          "section_key": "growth.weaknesses",
+          "title": "成长盲点",
           "render_variant": "bullets",
           "body_md": null,
           "body_html": null,
@@ -391,34 +429,44 @@
               }
             ]
           },
-          "sort_order": 30,
+          "sort_order": 110,
           "is_enabled": true
         },
         {
-          "section_key": "work_style",
-          "title": "工作风格",
+          "section_key": "growth.summary",
+          "title": "成长概览",
           "render_variant": "rich_text",
           "body_md": "高自主度、目标清晰、反馈节奏稳定的工作环境。",
+          "body_html": null,
+          "payload_json": null,
+          "sort_order": 90,
+          "is_enabled": true
+        },
+        {
+          "section_key": "relationships.summary",
+          "title": "关系模式",
+          "render_variant": "rich_text",
+          "body_md": "你往往通过直接交流、共同经历和快速反馈来建立关系。你倾向于和能讨论长期可能性、模式和意义的人建立更深连接。在冲突里你通常优先讲逻辑和边界，因此需要主动补充情绪确认。亲密关系与协作关系里，你通常更喜欢明确承诺、稳定节奏和可预期安排。",
+          "body_html": null,
+          "payload_json": null,
+          "sort_order": 140,
+          "is_enabled": true
+        },
+        {
+          "section_key": "career.summary",
+          "title": "职业概览",
+          "render_variant": "rich_text",
+          "body_md": "你通常更适合在高自主度、目标清晰、反馈节奏稳定的工作环境中发挥优势。优先探索这些方向：UI/UX 设计师, 数字营销经理, 律师。",
           "body_html": null,
           "payload_json": null,
           "sort_order": 40,
           "is_enabled": true
         },
         {
-          "section_key": "relationships",
-          "title": "关系模式",
-          "render_variant": "rich_text",
-          "body_md": "你往往通过直接交流、共同经历和快速反馈来建立关系。你倾向于和能讨论长期可能性、模式和意义的人建立更深连接。在冲突里你通常优先讲逻辑和边界，因此需要主动补充情绪确认。亲密关系与协作关系里，你通常更喜欢明确承诺、稳定节奏和可预期安排。",
-          "body_html": null,
-          "payload_json": null,
-          "sort_order": 50,
-          "is_enabled": true
-        },
-        {
-          "section_key": "career_fit",
-          "title": "职业匹配",
-          "render_variant": "cards",
-          "body_md": "你通常更适合在高自主度、目标清晰、反馈节奏稳定的工作环境中发挥优势。优先探索这些方向：UI/UX 设计师, 数字营销经理, 律师。",
+          "section_key": "career.preferred_roles",
+          "title": "推荐职业方向",
+          "render_variant": "preferred_role_list",
+          "body_md": null,
           "body_html": null,
           "payload_json": {
             "recommended_jobs": [
@@ -463,7 +511,7 @@
             ],
             "work_env": "高自主度、目标清晰、反馈节奏稳定的工作环境。"
           },
-          "sort_order": 80,
+          "sort_order": 70,
           "is_enabled": true
         }
       ],
@@ -485,10 +533,16 @@
       "type_code": "ENTP",
       "slug": "entp",
       "title": "ENTP - 辩论家",
+      "type_name": "辩论家",
+      "nickname": "辩论家",
+      "rarity_text": null,
+      "keywords_json": [],
       "subtitle": null,
       "excerpt": "基于 ENTP 人格画像的职业建议与工作环境匹配策略。",
       "hero_kicker": "辩论家",
       "hero_quote": null,
+      "hero_summary_md": "基于 ENTP 人格画像的职业建议与工作环境匹配策略。",
+      "hero_summary_html": null,
       "hero_image_url": null,
       "status": "published",
       "is_public": true,
@@ -497,18 +551,18 @@
       "scheduled_at": null,
       "sections": [
         {
-          "section_key": "core_snapshot",
-          "title": "核心概览",
+          "section_key": "overview",
+          "title": "人格概览",
           "render_variant": "rich_text",
           "body_md": "基于 ENTP 人格画像的职业建议与工作环境匹配策略。 这类人格通常在目标清晰、反馈可获得、能够持续迭代的环境里更容易稳定发挥。",
           "body_html": null,
           "payload_json": null,
-          "sort_order": 10,
+          "sort_order": 20,
           "is_enabled": true
         },
         {
-          "section_key": "strengths",
-          "title": "优势",
+          "section_key": "growth.strengths",
+          "title": "成长优势",
           "render_variant": "bullets",
           "body_md": null,
           "body_html": null,
@@ -528,12 +582,12 @@
               }
             ]
           },
-          "sort_order": 20,
+          "sort_order": 100,
           "is_enabled": true
         },
         {
-          "section_key": "growth_edges",
-          "title": "成长边界",
+          "section_key": "growth.weaknesses",
+          "title": "成长盲点",
           "render_variant": "bullets",
           "body_md": null,
           "body_html": null,
@@ -549,34 +603,44 @@
               }
             ]
           },
-          "sort_order": 30,
+          "sort_order": 110,
           "is_enabled": true
         },
         {
-          "section_key": "work_style",
-          "title": "工作风格",
+          "section_key": "growth.summary",
+          "title": "成长概览",
           "render_variant": "rich_text",
           "body_md": "高自主度、目标清晰、反馈节奏稳定的工作环境。",
+          "body_html": null,
+          "payload_json": null,
+          "sort_order": 90,
+          "is_enabled": true
+        },
+        {
+          "section_key": "relationships.summary",
+          "title": "关系模式",
+          "render_variant": "rich_text",
+          "body_md": "你往往通过直接交流、共同经历和快速反馈来建立关系。你倾向于和能讨论长期可能性、模式和意义的人建立更深连接。在冲突里你通常优先讲逻辑和边界，因此需要主动补充情绪确认。亲密关系与协作关系里，你通常更喜欢弹性空间、自然推进和保留选择余地。",
+          "body_html": null,
+          "payload_json": null,
+          "sort_order": 140,
+          "is_enabled": true
+        },
+        {
+          "section_key": "career.summary",
+          "title": "职业概览",
+          "render_variant": "rich_text",
+          "body_md": "你通常更适合在高自主度、目标清晰、反馈节奏稳定的工作环境中发挥优势。优先探索这些方向：心理咨询师, 投资分析师, 医生。",
           "body_html": null,
           "payload_json": null,
           "sort_order": 40,
           "is_enabled": true
         },
         {
-          "section_key": "relationships",
-          "title": "关系模式",
-          "render_variant": "rich_text",
-          "body_md": "你往往通过直接交流、共同经历和快速反馈来建立关系。你倾向于和能讨论长期可能性、模式和意义的人建立更深连接。在冲突里你通常优先讲逻辑和边界，因此需要主动补充情绪确认。亲密关系与协作关系里，你通常更喜欢弹性空间、自然推进和保留选择余地。",
-          "body_html": null,
-          "payload_json": null,
-          "sort_order": 50,
-          "is_enabled": true
-        },
-        {
-          "section_key": "career_fit",
-          "title": "职业匹配",
-          "render_variant": "cards",
-          "body_md": "你通常更适合在高自主度、目标清晰、反馈节奏稳定的工作环境中发挥优势。优先探索这些方向：心理咨询师, 投资分析师, 医生。",
+          "section_key": "career.preferred_roles",
+          "title": "推荐职业方向",
+          "render_variant": "preferred_role_list",
+          "body_md": null,
           "body_html": null,
           "payload_json": {
             "recommended_jobs": [
@@ -621,7 +685,7 @@
             ],
             "work_env": "高自主度、目标清晰、反馈节奏稳定的工作环境。"
           },
-          "sort_order": 80,
+          "sort_order": 70,
           "is_enabled": true
         }
       ],
@@ -643,10 +707,16 @@
       "type_code": "ESFJ",
       "slug": "esfj",
       "title": "ESFJ - 执政官",
+      "type_name": "执政官",
+      "nickname": "执政官",
+      "rarity_text": null,
+      "keywords_json": [],
       "subtitle": null,
       "excerpt": "基于 ESFJ 人格画像的职业建议与工作环境匹配策略。",
       "hero_kicker": "执政官",
       "hero_quote": null,
+      "hero_summary_md": "基于 ESFJ 人格画像的职业建议与工作环境匹配策略。",
+      "hero_summary_html": null,
       "hero_image_url": null,
       "status": "published",
       "is_public": true,
@@ -655,18 +725,18 @@
       "scheduled_at": null,
       "sections": [
         {
-          "section_key": "core_snapshot",
-          "title": "核心概览",
+          "section_key": "overview",
+          "title": "人格概览",
           "render_variant": "rich_text",
           "body_md": "基于 ESFJ 人格画像的职业建议与工作环境匹配策略。 这类人格通常在目标清晰、反馈可获得、能够持续迭代的环境里更容易稳定发挥。",
           "body_html": null,
           "payload_json": null,
-          "sort_order": 10,
+          "sort_order": 20,
           "is_enabled": true
         },
         {
-          "section_key": "strengths",
-          "title": "优势",
+          "section_key": "growth.strengths",
+          "title": "成长优势",
           "render_variant": "bullets",
           "body_md": null,
           "body_html": null,
@@ -686,12 +756,12 @@
               }
             ]
           },
-          "sort_order": 20,
+          "sort_order": 100,
           "is_enabled": true
         },
         {
-          "section_key": "growth_edges",
-          "title": "成长边界",
+          "section_key": "growth.weaknesses",
+          "title": "成长盲点",
           "render_variant": "bullets",
           "body_md": null,
           "body_html": null,
@@ -707,34 +777,44 @@
               }
             ]
           },
-          "sort_order": 30,
+          "sort_order": 110,
           "is_enabled": true
         },
         {
-          "section_key": "work_style",
-          "title": "工作风格",
+          "section_key": "growth.summary",
+          "title": "成长概览",
           "render_variant": "rich_text",
           "body_md": "高自主度、目标清晰、反馈节奏稳定的工作环境。",
+          "body_html": null,
+          "payload_json": null,
+          "sort_order": 90,
+          "is_enabled": true
+        },
+        {
+          "section_key": "relationships.summary",
+          "title": "关系模式",
+          "render_variant": "rich_text",
+          "body_md": "你往往通过直接交流、共同经历和快速反馈来建立关系。你更看重现实可靠、说到做到和细节可落地的人际互动。在冲突里你通常优先照顾感受和氛围，因此需要主动讲清原则和底线。亲密关系与协作关系里，你通常更喜欢明确承诺、稳定节奏和可预期安排。",
+          "body_html": null,
+          "payload_json": null,
+          "sort_order": 140,
+          "is_enabled": true
+        },
+        {
+          "section_key": "career.summary",
+          "title": "职业概览",
+          "render_variant": "rich_text",
+          "body_md": "你通常更适合在高自主度、目标清晰、反馈节奏稳定的工作环境中发挥优势。优先探索这些方向：前端工程师, 全栈工程师, 云架构师。",
           "body_html": null,
           "payload_json": null,
           "sort_order": 40,
           "is_enabled": true
         },
         {
-          "section_key": "relationships",
-          "title": "关系模式",
-          "render_variant": "rich_text",
-          "body_md": "你往往通过直接交流、共同经历和快速反馈来建立关系。你更看重现实可靠、说到做到和细节可落地的人际互动。在冲突里你通常优先照顾感受和氛围，因此需要主动讲清原则和底线。亲密关系与协作关系里，你通常更喜欢明确承诺、稳定节奏和可预期安排。",
-          "body_html": null,
-          "payload_json": null,
-          "sort_order": 50,
-          "is_enabled": true
-        },
-        {
-          "section_key": "career_fit",
-          "title": "职业匹配",
-          "render_variant": "cards",
-          "body_md": "你通常更适合在高自主度、目标清晰、反馈节奏稳定的工作环境中发挥优势。优先探索这些方向：前端工程师, 全栈工程师, 云架构师。",
+          "section_key": "career.preferred_roles",
+          "title": "推荐职业方向",
+          "render_variant": "preferred_role_list",
+          "body_md": null,
           "body_html": null,
           "payload_json": {
             "recommended_jobs": [
@@ -779,7 +859,7 @@
             ],
             "work_env": "高自主度、目标清晰、反馈节奏稳定的工作环境。"
           },
-          "sort_order": 80,
+          "sort_order": 70,
           "is_enabled": true
         }
       ],
@@ -801,10 +881,16 @@
       "type_code": "ESFP",
       "slug": "esfp",
       "title": "ESFP - 表演者",
+      "type_name": "表演者",
+      "nickname": "表演者",
+      "rarity_text": null,
+      "keywords_json": [],
       "subtitle": null,
       "excerpt": "基于 ESFP 人格画像的职业建议与工作环境匹配策略。",
       "hero_kicker": "表演者",
       "hero_quote": null,
+      "hero_summary_md": "基于 ESFP 人格画像的职业建议与工作环境匹配策略。",
+      "hero_summary_html": null,
       "hero_image_url": null,
       "status": "published",
       "is_public": true,
@@ -813,18 +899,18 @@
       "scheduled_at": null,
       "sections": [
         {
-          "section_key": "core_snapshot",
-          "title": "核心概览",
+          "section_key": "overview",
+          "title": "人格概览",
           "render_variant": "rich_text",
           "body_md": "基于 ESFP 人格画像的职业建议与工作环境匹配策略。 这类人格通常在目标清晰、反馈可获得、能够持续迭代的环境里更容易稳定发挥。",
           "body_html": null,
           "payload_json": null,
-          "sort_order": 10,
+          "sort_order": 20,
           "is_enabled": true
         },
         {
-          "section_key": "strengths",
-          "title": "优势",
+          "section_key": "growth.strengths",
+          "title": "成长优势",
           "render_variant": "bullets",
           "body_md": null,
           "body_html": null,
@@ -844,12 +930,12 @@
               }
             ]
           },
-          "sort_order": 20,
+          "sort_order": 100,
           "is_enabled": true
         },
         {
-          "section_key": "growth_edges",
-          "title": "成长边界",
+          "section_key": "growth.weaknesses",
+          "title": "成长盲点",
           "render_variant": "bullets",
           "body_md": null,
           "body_html": null,
@@ -865,34 +951,44 @@
               }
             ]
           },
-          "sort_order": 30,
+          "sort_order": 110,
           "is_enabled": true
         },
         {
-          "section_key": "work_style",
-          "title": "工作风格",
+          "section_key": "growth.summary",
+          "title": "成长概览",
           "render_variant": "rich_text",
           "body_md": "高自主度、目标清晰、反馈节奏稳定的工作环境。",
+          "body_html": null,
+          "payload_json": null,
+          "sort_order": 90,
+          "is_enabled": true
+        },
+        {
+          "section_key": "relationships.summary",
+          "title": "关系模式",
+          "render_variant": "rich_text",
+          "body_md": "你往往通过直接交流、共同经历和快速反馈来建立关系。你更看重现实可靠、说到做到和细节可落地的人际互动。在冲突里你通常优先照顾感受和氛围，因此需要主动讲清原则和底线。亲密关系与协作关系里，你通常更喜欢弹性空间、自然推进和保留选择余地。",
+          "body_html": null,
+          "payload_json": null,
+          "sort_order": 140,
+          "is_enabled": true
+        },
+        {
+          "section_key": "career.summary",
+          "title": "职业概览",
+          "render_variant": "rich_text",
+          "body_md": "你通常更适合在高自主度、目标清晰、反馈节奏稳定的工作环境中发挥优势。优先探索这些方向：云架构师, HRBP, 管理咨询顾问。",
           "body_html": null,
           "payload_json": null,
           "sort_order": 40,
           "is_enabled": true
         },
         {
-          "section_key": "relationships",
-          "title": "关系模式",
-          "render_variant": "rich_text",
-          "body_md": "你往往通过直接交流、共同经历和快速反馈来建立关系。你更看重现实可靠、说到做到和细节可落地的人际互动。在冲突里你通常优先照顾感受和氛围，因此需要主动讲清原则和底线。亲密关系与协作关系里，你通常更喜欢弹性空间、自然推进和保留选择余地。",
-          "body_html": null,
-          "payload_json": null,
-          "sort_order": 50,
-          "is_enabled": true
-        },
-        {
-          "section_key": "career_fit",
-          "title": "职业匹配",
-          "render_variant": "cards",
-          "body_md": "你通常更适合在高自主度、目标清晰、反馈节奏稳定的工作环境中发挥优势。优先探索这些方向：云架构师, HRBP, 管理咨询顾问。",
+          "section_key": "career.preferred_roles",
+          "title": "推荐职业方向",
+          "render_variant": "preferred_role_list",
+          "body_md": null,
           "body_html": null,
           "payload_json": {
             "recommended_jobs": [
@@ -937,7 +1033,7 @@
             ],
             "work_env": "高自主度、目标清晰、反馈节奏稳定的工作环境。"
           },
-          "sort_order": 80,
+          "sort_order": 70,
           "is_enabled": true
         }
       ],
@@ -959,10 +1055,16 @@
       "type_code": "ESTJ",
       "slug": "estj",
       "title": "ESTJ - 总经理",
+      "type_name": "总经理",
+      "nickname": "总经理",
+      "rarity_text": null,
+      "keywords_json": [],
       "subtitle": null,
       "excerpt": "基于 ESTJ 人格画像的职业建议与工作环境匹配策略。",
       "hero_kicker": "总经理",
       "hero_quote": null,
+      "hero_summary_md": "基于 ESTJ 人格画像的职业建议与工作环境匹配策略。",
+      "hero_summary_html": null,
       "hero_image_url": null,
       "status": "published",
       "is_public": true,
@@ -971,18 +1073,18 @@
       "scheduled_at": null,
       "sections": [
         {
-          "section_key": "core_snapshot",
-          "title": "核心概览",
+          "section_key": "overview",
+          "title": "人格概览",
           "render_variant": "rich_text",
           "body_md": "基于 ESTJ 人格画像的职业建议与工作环境匹配策略。 这类人格通常在目标清晰、反馈可获得、能够持续迭代的环境里更容易稳定发挥。",
           "body_html": null,
           "payload_json": null,
-          "sort_order": 10,
+          "sort_order": 20,
           "is_enabled": true
         },
         {
-          "section_key": "strengths",
-          "title": "优势",
+          "section_key": "growth.strengths",
+          "title": "成长优势",
           "render_variant": "bullets",
           "body_md": null,
           "body_html": null,
@@ -1002,12 +1104,12 @@
               }
             ]
           },
-          "sort_order": 20,
+          "sort_order": 100,
           "is_enabled": true
         },
         {
-          "section_key": "growth_edges",
-          "title": "成长边界",
+          "section_key": "growth.weaknesses",
+          "title": "成长盲点",
           "render_variant": "bullets",
           "body_md": null,
           "body_html": null,
@@ -1023,34 +1125,44 @@
               }
             ]
           },
-          "sort_order": 30,
+          "sort_order": 110,
           "is_enabled": true
         },
         {
-          "section_key": "work_style",
-          "title": "工作风格",
+          "section_key": "growth.summary",
+          "title": "成长概览",
           "render_variant": "rich_text",
           "body_md": "高自主度、目标清晰、反馈节奏稳定的工作环境。",
+          "body_html": null,
+          "payload_json": null,
+          "sort_order": 90,
+          "is_enabled": true
+        },
+        {
+          "section_key": "relationships.summary",
+          "title": "关系模式",
+          "render_variant": "rich_text",
+          "body_md": "你往往通过直接交流、共同经历和快速反馈来建立关系。你更看重现实可靠、说到做到和细节可落地的人际互动。在冲突里你通常优先讲逻辑和边界，因此需要主动补充情绪确认。亲密关系与协作关系里，你通常更喜欢明确承诺、稳定节奏和可预期安排。",
+          "body_html": null,
+          "payload_json": null,
+          "sort_order": 140,
+          "is_enabled": true
+        },
+        {
+          "section_key": "career.summary",
+          "title": "职业概览",
+          "render_variant": "rich_text",
+          "body_md": "你通常更适合在高自主度、目标清晰、反馈节奏稳定的工作环境中发挥优势。优先探索这些方向：机器学习工程师, 后端工程师, 网络安全分析师。",
           "body_html": null,
           "payload_json": null,
           "sort_order": 40,
           "is_enabled": true
         },
         {
-          "section_key": "relationships",
-          "title": "关系模式",
-          "render_variant": "rich_text",
-          "body_md": "你往往通过直接交流、共同经历和快速反馈来建立关系。你更看重现实可靠、说到做到和细节可落地的人际互动。在冲突里你通常优先讲逻辑和边界，因此需要主动补充情绪确认。亲密关系与协作关系里，你通常更喜欢明确承诺、稳定节奏和可预期安排。",
-          "body_html": null,
-          "payload_json": null,
-          "sort_order": 50,
-          "is_enabled": true
-        },
-        {
-          "section_key": "career_fit",
-          "title": "职业匹配",
-          "render_variant": "cards",
-          "body_md": "你通常更适合在高自主度、目标清晰、反馈节奏稳定的工作环境中发挥优势。优先探索这些方向：机器学习工程师, 后端工程师, 网络安全分析师。",
+          "section_key": "career.preferred_roles",
+          "title": "推荐职业方向",
+          "render_variant": "preferred_role_list",
+          "body_md": null,
           "body_html": null,
           "payload_json": {
             "recommended_jobs": [
@@ -1095,7 +1207,7 @@
             ],
             "work_env": "高自主度、目标清晰、反馈节奏稳定的工作环境。"
           },
-          "sort_order": 80,
+          "sort_order": 70,
           "is_enabled": true
         }
       ],
@@ -1117,10 +1229,16 @@
       "type_code": "ESTP",
       "slug": "estp",
       "title": "ESTP - 企业家",
+      "type_name": "企业家",
+      "nickname": "企业家",
+      "rarity_text": null,
+      "keywords_json": [],
       "subtitle": null,
       "excerpt": "基于 ESTP 人格画像的职业建议与工作环境匹配策略。",
       "hero_kicker": "企业家",
       "hero_quote": null,
+      "hero_summary_md": "基于 ESTP 人格画像的职业建议与工作环境匹配策略。",
+      "hero_summary_html": null,
       "hero_image_url": null,
       "status": "published",
       "is_public": true,
@@ -1129,18 +1247,18 @@
       "scheduled_at": null,
       "sections": [
         {
-          "section_key": "core_snapshot",
-          "title": "核心概览",
+          "section_key": "overview",
+          "title": "人格概览",
           "render_variant": "rich_text",
           "body_md": "基于 ESTP 人格画像的职业建议与工作环境匹配策略。 这类人格通常在目标清晰、反馈可获得、能够持续迭代的环境里更容易稳定发挥。",
           "body_html": null,
           "payload_json": null,
-          "sort_order": 10,
+          "sort_order": 20,
           "is_enabled": true
         },
         {
-          "section_key": "strengths",
-          "title": "优势",
+          "section_key": "growth.strengths",
+          "title": "成长优势",
           "render_variant": "bullets",
           "body_md": null,
           "body_html": null,
@@ -1160,12 +1278,12 @@
               }
             ]
           },
-          "sort_order": 20,
+          "sort_order": 100,
           "is_enabled": true
         },
         {
-          "section_key": "growth_edges",
-          "title": "成长边界",
+          "section_key": "growth.weaknesses",
+          "title": "成长盲点",
           "render_variant": "bullets",
           "body_md": null,
           "body_html": null,
@@ -1181,34 +1299,44 @@
               }
             ]
           },
-          "sort_order": 30,
+          "sort_order": 110,
           "is_enabled": true
         },
         {
-          "section_key": "work_style",
-          "title": "工作风格",
+          "section_key": "growth.summary",
+          "title": "成长概览",
           "render_variant": "rich_text",
           "body_md": "高自主度、目标清晰、反馈节奏稳定的工作环境。",
+          "body_html": null,
+          "payload_json": null,
+          "sort_order": 90,
+          "is_enabled": true
+        },
+        {
+          "section_key": "relationships.summary",
+          "title": "关系模式",
+          "render_variant": "rich_text",
+          "body_md": "你往往通过直接交流、共同经历和快速反馈来建立关系。你更看重现实可靠、说到做到和细节可落地的人际互动。在冲突里你通常优先讲逻辑和边界，因此需要主动补充情绪确认。亲密关系与协作关系里，你通常更喜欢弹性空间、自然推进和保留选择余地。",
+          "body_html": null,
+          "payload_json": null,
+          "sort_order": 140,
+          "is_enabled": true
+        },
+        {
+          "section_key": "career.summary",
+          "title": "职业概览",
+          "render_variant": "rich_text",
+          "body_md": "你通常更适合在高自主度、目标清晰、反馈节奏稳定的工作环境中发挥优势。优先探索这些方向：网络安全分析师, 运营经理, 销售经理。",
           "body_html": null,
           "payload_json": null,
           "sort_order": 40,
           "is_enabled": true
         },
         {
-          "section_key": "relationships",
-          "title": "关系模式",
-          "render_variant": "rich_text",
-          "body_md": "你往往通过直接交流、共同经历和快速反馈来建立关系。你更看重现实可靠、说到做到和细节可落地的人际互动。在冲突里你通常优先讲逻辑和边界，因此需要主动补充情绪确认。亲密关系与协作关系里，你通常更喜欢弹性空间、自然推进和保留选择余地。",
-          "body_html": null,
-          "payload_json": null,
-          "sort_order": 50,
-          "is_enabled": true
-        },
-        {
-          "section_key": "career_fit",
-          "title": "职业匹配",
-          "render_variant": "cards",
-          "body_md": "你通常更适合在高自主度、目标清晰、反馈节奏稳定的工作环境中发挥优势。优先探索这些方向：网络安全分析师, 运营经理, 销售经理。",
+          "section_key": "career.preferred_roles",
+          "title": "推荐职业方向",
+          "render_variant": "preferred_role_list",
+          "body_md": null,
           "body_html": null,
           "payload_json": {
             "recommended_jobs": [
@@ -1253,7 +1381,7 @@
             ],
             "work_env": "高自主度、目标清晰、反馈节奏稳定的工作环境。"
           },
-          "sort_order": 80,
+          "sort_order": 70,
           "is_enabled": true
         }
       ],
@@ -1275,10 +1403,16 @@
       "type_code": "INFJ",
       "slug": "infj",
       "title": "INFJ - 提倡者",
+      "type_name": "提倡者",
+      "nickname": "提倡者",
+      "rarity_text": null,
+      "keywords_json": [],
       "subtitle": null,
       "excerpt": "基于 INFJ 人格画像的职业建议与工作环境匹配策略。",
       "hero_kicker": "提倡者",
       "hero_quote": null,
+      "hero_summary_md": "基于 INFJ 人格画像的职业建议与工作环境匹配策略。",
+      "hero_summary_html": null,
       "hero_image_url": null,
       "status": "published",
       "is_public": true,
@@ -1287,18 +1421,18 @@
       "scheduled_at": null,
       "sections": [
         {
-          "section_key": "core_snapshot",
-          "title": "核心概览",
+          "section_key": "overview",
+          "title": "人格概览",
           "render_variant": "rich_text",
           "body_md": "基于 INFJ 人格画像的职业建议与工作环境匹配策略。 这类人格通常在目标清晰、反馈可获得、能够持续迭代的环境里更容易稳定发挥。",
           "body_html": null,
           "payload_json": null,
-          "sort_order": 10,
+          "sort_order": 20,
           "is_enabled": true
         },
         {
-          "section_key": "strengths",
-          "title": "优势",
+          "section_key": "growth.strengths",
+          "title": "成长优势",
           "render_variant": "bullets",
           "body_md": null,
           "body_html": null,
@@ -1318,12 +1452,12 @@
               }
             ]
           },
-          "sort_order": 20,
+          "sort_order": 100,
           "is_enabled": true
         },
         {
-          "section_key": "growth_edges",
-          "title": "成长边界",
+          "section_key": "growth.weaknesses",
+          "title": "成长盲点",
           "render_variant": "bullets",
           "body_md": null,
           "body_html": null,
@@ -1339,34 +1473,44 @@
               }
             ]
           },
-          "sort_order": 30,
+          "sort_order": 110,
           "is_enabled": true
         },
         {
-          "section_key": "work_style",
-          "title": "工作风格",
+          "section_key": "growth.summary",
+          "title": "成长概览",
           "render_variant": "rich_text",
           "body_md": "高自主度、目标清晰、反馈节奏稳定的工作环境。",
+          "body_html": null,
+          "payload_json": null,
+          "sort_order": 90,
+          "is_enabled": true
+        },
+        {
+          "section_key": "relationships.summary",
+          "title": "关系模式",
+          "render_variant": "rich_text",
+          "body_md": "你更容易通过稳定的一对一沟通、留白和安静空间来建立信任。你倾向于和能讨论长期可能性、模式和意义的人建立更深连接。在冲突里你通常优先照顾感受和氛围，因此需要主动讲清原则和底线。亲密关系与协作关系里，你通常更喜欢明确承诺、稳定节奏和可预期安排。",
+          "body_html": null,
+          "payload_json": null,
+          "sort_order": 140,
+          "is_enabled": true
+        },
+        {
+          "section_key": "career.summary",
+          "title": "职业概览",
+          "render_variant": "rich_text",
+          "body_md": "你通常更适合在高自主度、目标清晰、反馈节奏稳定的工作环境中发挥优势。优先探索这些方向：数字营销经理, 律师, 教师。",
           "body_html": null,
           "payload_json": null,
           "sort_order": 40,
           "is_enabled": true
         },
         {
-          "section_key": "relationships",
-          "title": "关系模式",
-          "render_variant": "rich_text",
-          "body_md": "你更容易通过稳定的一对一沟通、留白和安静空间来建立信任。你倾向于和能讨论长期可能性、模式和意义的人建立更深连接。在冲突里你通常优先照顾感受和氛围，因此需要主动讲清原则和底线。亲密关系与协作关系里，你通常更喜欢明确承诺、稳定节奏和可预期安排。",
-          "body_html": null,
-          "payload_json": null,
-          "sort_order": 50,
-          "is_enabled": true
-        },
-        {
-          "section_key": "career_fit",
-          "title": "职业匹配",
-          "render_variant": "cards",
-          "body_md": "你通常更适合在高自主度、目标清晰、反馈节奏稳定的工作环境中发挥优势。优先探索这些方向：数字营销经理, 律师, 教师。",
+          "section_key": "career.preferred_roles",
+          "title": "推荐职业方向",
+          "render_variant": "preferred_role_list",
+          "body_md": null,
           "body_html": null,
           "payload_json": {
             "recommended_jobs": [
@@ -1411,7 +1555,7 @@
             ],
             "work_env": "高自主度、目标清晰、反馈节奏稳定的工作环境。"
           },
-          "sort_order": 80,
+          "sort_order": 70,
           "is_enabled": true
         }
       ],
@@ -1433,10 +1577,16 @@
       "type_code": "INFP",
       "slug": "infp",
       "title": "INFP - 调停者",
+      "type_name": "调停者",
+      "nickname": "调停者",
+      "rarity_text": null,
+      "keywords_json": [],
       "subtitle": null,
       "excerpt": "基于 INFP 人格画像的职业建议与工作环境匹配策略。",
       "hero_kicker": "调停者",
       "hero_quote": null,
+      "hero_summary_md": "基于 INFP 人格画像的职业建议与工作环境匹配策略。",
+      "hero_summary_html": null,
       "hero_image_url": null,
       "status": "published",
       "is_public": true,
@@ -1445,18 +1595,18 @@
       "scheduled_at": null,
       "sections": [
         {
-          "section_key": "core_snapshot",
-          "title": "核心概览",
+          "section_key": "overview",
+          "title": "人格概览",
           "render_variant": "rich_text",
           "body_md": "基于 INFP 人格画像的职业建议与工作环境匹配策略。 这类人格通常在目标清晰、反馈可获得、能够持续迭代的环境里更容易稳定发挥。",
           "body_html": null,
           "payload_json": null,
-          "sort_order": 10,
+          "sort_order": 20,
           "is_enabled": true
         },
         {
-          "section_key": "strengths",
-          "title": "优势",
+          "section_key": "growth.strengths",
+          "title": "成长优势",
           "render_variant": "bullets",
           "body_md": null,
           "body_html": null,
@@ -1476,12 +1626,12 @@
               }
             ]
           },
-          "sort_order": 20,
+          "sort_order": 100,
           "is_enabled": true
         },
         {
-          "section_key": "growth_edges",
-          "title": "成长边界",
+          "section_key": "growth.weaknesses",
+          "title": "成长盲点",
           "render_variant": "bullets",
           "body_md": null,
           "body_html": null,
@@ -1497,34 +1647,44 @@
               }
             ]
           },
-          "sort_order": 30,
+          "sort_order": 110,
           "is_enabled": true
         },
         {
-          "section_key": "work_style",
-          "title": "工作风格",
+          "section_key": "growth.summary",
+          "title": "成长概览",
           "render_variant": "rich_text",
           "body_md": "高自主度、目标清晰、反馈节奏稳定的工作环境。",
+          "body_html": null,
+          "payload_json": null,
+          "sort_order": 90,
+          "is_enabled": true
+        },
+        {
+          "section_key": "relationships.summary",
+          "title": "关系模式",
+          "render_variant": "rich_text",
+          "body_md": "你更容易通过稳定的一对一沟通、留白和安静空间来建立信任。你倾向于和能讨论长期可能性、模式和意义的人建立更深连接。在冲突里你通常优先照顾感受和氛围，因此需要主动讲清原则和底线。亲密关系与协作关系里，你通常更喜欢弹性空间、自然推进和保留选择余地。",
+          "body_html": null,
+          "payload_json": null,
+          "sort_order": 140,
+          "is_enabled": true
+        },
+        {
+          "section_key": "career.summary",
+          "title": "职业概览",
+          "render_variant": "rich_text",
+          "body_md": "你通常更适合在高自主度、目标清晰、反馈节奏稳定的工作环境中发挥优势。优先探索这些方向：投资分析师, 医生, 数据科学家。",
           "body_html": null,
           "payload_json": null,
           "sort_order": 40,
           "is_enabled": true
         },
         {
-          "section_key": "relationships",
-          "title": "关系模式",
-          "render_variant": "rich_text",
-          "body_md": "你更容易通过稳定的一对一沟通、留白和安静空间来建立信任。你倾向于和能讨论长期可能性、模式和意义的人建立更深连接。在冲突里你通常优先照顾感受和氛围，因此需要主动讲清原则和底线。亲密关系与协作关系里，你通常更喜欢弹性空间、自然推进和保留选择余地。",
-          "body_html": null,
-          "payload_json": null,
-          "sort_order": 50,
-          "is_enabled": true
-        },
-        {
-          "section_key": "career_fit",
-          "title": "职业匹配",
-          "render_variant": "cards",
-          "body_md": "你通常更适合在高自主度、目标清晰、反馈节奏稳定的工作环境中发挥优势。优先探索这些方向：投资分析师, 医生, 数据科学家。",
+          "section_key": "career.preferred_roles",
+          "title": "推荐职业方向",
+          "render_variant": "preferred_role_list",
+          "body_md": null,
           "body_html": null,
           "payload_json": {
             "recommended_jobs": [
@@ -1569,7 +1729,7 @@
             ],
             "work_env": "高自主度、目标清晰、反馈节奏稳定的工作环境。"
           },
-          "sort_order": 80,
+          "sort_order": 70,
           "is_enabled": true
         }
       ],
@@ -1591,10 +1751,16 @@
       "type_code": "INTJ",
       "slug": "intj",
       "title": "INTJ - 建筑师",
+      "type_name": "建筑师",
+      "nickname": "建筑师",
+      "rarity_text": null,
+      "keywords_json": [],
       "subtitle": null,
       "excerpt": "基于 INTJ 人格画像的职业建议与工作环境匹配策略。",
       "hero_kicker": "建筑师",
       "hero_quote": null,
+      "hero_summary_md": "基于 INTJ 人格画像的职业建议与工作环境匹配策略。",
+      "hero_summary_html": null,
       "hero_image_url": null,
       "status": "published",
       "is_public": true,
@@ -1603,18 +1769,18 @@
       "scheduled_at": null,
       "sections": [
         {
-          "section_key": "core_snapshot",
-          "title": "核心概览",
+          "section_key": "overview",
+          "title": "人格概览",
           "render_variant": "rich_text",
           "body_md": "基于 INTJ 人格画像的职业建议与工作环境匹配策略。 这类人格通常在目标清晰、反馈可获得、能够持续迭代的环境里更容易稳定发挥。",
           "body_html": null,
           "payload_json": null,
-          "sort_order": 10,
+          "sort_order": 20,
           "is_enabled": true
         },
         {
-          "section_key": "strengths",
-          "title": "优势",
+          "section_key": "growth.strengths",
+          "title": "成长优势",
           "render_variant": "bullets",
           "body_md": null,
           "body_html": null,
@@ -1634,12 +1800,12 @@
               }
             ]
           },
-          "sort_order": 20,
+          "sort_order": 100,
           "is_enabled": true
         },
         {
-          "section_key": "growth_edges",
-          "title": "成长边界",
+          "section_key": "growth.weaknesses",
+          "title": "成长盲点",
           "render_variant": "bullets",
           "body_md": null,
           "body_html": null,
@@ -1655,34 +1821,44 @@
               }
             ]
           },
-          "sort_order": 30,
+          "sort_order": 110,
           "is_enabled": true
         },
         {
-          "section_key": "work_style",
-          "title": "工作风格",
+          "section_key": "growth.summary",
+          "title": "成长概览",
           "render_variant": "rich_text",
           "body_md": "高自主度、目标清晰、反馈节奏稳定的工作环境。",
+          "body_html": null,
+          "payload_json": null,
+          "sort_order": 90,
+          "is_enabled": true
+        },
+        {
+          "section_key": "relationships.summary",
+          "title": "关系模式",
+          "render_variant": "rich_text",
+          "body_md": "你更容易通过稳定的一对一沟通、留白和安静空间来建立信任。你倾向于和能讨论长期可能性、模式和意义的人建立更深连接。在冲突里你通常优先讲逻辑和边界，因此需要主动补充情绪确认。亲密关系与协作关系里，你通常更喜欢明确承诺、稳定节奏和可预期安排。",
+          "body_html": null,
+          "payload_json": null,
+          "sort_order": 140,
+          "is_enabled": true
+        },
+        {
+          "section_key": "career.summary",
+          "title": "职业概览",
+          "render_variant": "rich_text",
+          "body_md": "你通常更适合在高自主度、目标清晰、反馈节奏稳定的工作环境中发挥优势。优先探索这些方向：产品经理, UI/UX 设计师, 数字营销经理。",
           "body_html": null,
           "payload_json": null,
           "sort_order": 40,
           "is_enabled": true
         },
         {
-          "section_key": "relationships",
-          "title": "关系模式",
-          "render_variant": "rich_text",
-          "body_md": "你更容易通过稳定的一对一沟通、留白和安静空间来建立信任。你倾向于和能讨论长期可能性、模式和意义的人建立更深连接。在冲突里你通常优先讲逻辑和边界，因此需要主动补充情绪确认。亲密关系与协作关系里，你通常更喜欢明确承诺、稳定节奏和可预期安排。",
-          "body_html": null,
-          "payload_json": null,
-          "sort_order": 50,
-          "is_enabled": true
-        },
-        {
-          "section_key": "career_fit",
-          "title": "职业匹配",
-          "render_variant": "cards",
-          "body_md": "你通常更适合在高自主度、目标清晰、反馈节奏稳定的工作环境中发挥优势。优先探索这些方向：产品经理, UI/UX 设计师, 数字营销经理。",
+          "section_key": "career.preferred_roles",
+          "title": "推荐职业方向",
+          "render_variant": "preferred_role_list",
+          "body_md": null,
           "body_html": null,
           "payload_json": {
             "recommended_jobs": [
@@ -1727,7 +1903,7 @@
             ],
             "work_env": "高自主度、目标清晰、反馈节奏稳定的工作环境。"
           },
-          "sort_order": 80,
+          "sort_order": 70,
           "is_enabled": true
         }
       ],
@@ -1749,10 +1925,16 @@
       "type_code": "INTP",
       "slug": "intp",
       "title": "INTP - 逻辑学家",
+      "type_name": "逻辑学家",
+      "nickname": "逻辑学家",
+      "rarity_text": null,
+      "keywords_json": [],
       "subtitle": null,
       "excerpt": "基于 INTP 人格画像的职业建议与工作环境匹配策略。",
       "hero_kicker": "逻辑学家",
       "hero_quote": null,
+      "hero_summary_md": "基于 INTP 人格画像的职业建议与工作环境匹配策略。",
+      "hero_summary_html": null,
       "hero_image_url": null,
       "status": "published",
       "is_public": true,
@@ -1761,18 +1943,18 @@
       "scheduled_at": null,
       "sections": [
         {
-          "section_key": "core_snapshot",
-          "title": "核心概览",
+          "section_key": "overview",
+          "title": "人格概览",
           "render_variant": "rich_text",
           "body_md": "基于 INTP 人格画像的职业建议与工作环境匹配策略。 这类人格通常在目标清晰、反馈可获得、能够持续迭代的环境里更容易稳定发挥。",
           "body_html": null,
           "payload_json": null,
-          "sort_order": 10,
+          "sort_order": 20,
           "is_enabled": true
         },
         {
-          "section_key": "strengths",
-          "title": "优势",
+          "section_key": "growth.strengths",
+          "title": "成长优势",
           "render_variant": "bullets",
           "body_md": null,
           "body_html": null,
@@ -1792,12 +1974,12 @@
               }
             ]
           },
-          "sort_order": 20,
+          "sort_order": 100,
           "is_enabled": true
         },
         {
-          "section_key": "growth_edges",
-          "title": "成长边界",
+          "section_key": "growth.weaknesses",
+          "title": "成长盲点",
           "render_variant": "bullets",
           "body_md": null,
           "body_html": null,
@@ -1813,34 +1995,44 @@
               }
             ]
           },
-          "sort_order": 30,
+          "sort_order": 110,
           "is_enabled": true
         },
         {
-          "section_key": "work_style",
-          "title": "工作风格",
+          "section_key": "growth.summary",
+          "title": "成长概览",
           "render_variant": "rich_text",
           "body_md": "高自主度、目标清晰、反馈节奏稳定的工作环境。",
+          "body_html": null,
+          "payload_json": null,
+          "sort_order": 90,
+          "is_enabled": true
+        },
+        {
+          "section_key": "relationships.summary",
+          "title": "关系模式",
+          "render_variant": "rich_text",
+          "body_md": "你更容易通过稳定的一对一沟通、留白和安静空间来建立信任。你倾向于和能讨论长期可能性、模式和意义的人建立更深连接。在冲突里你通常优先讲逻辑和边界，因此需要主动补充情绪确认。亲密关系与协作关系里，你通常更喜欢弹性空间、自然推进和保留选择余地。",
+          "body_html": null,
+          "payload_json": null,
+          "sort_order": 140,
+          "is_enabled": true
+        },
+        {
+          "section_key": "career.summary",
+          "title": "职业概览",
+          "render_variant": "rich_text",
+          "body_md": "你通常更适合在高自主度、目标清晰、反馈节奏稳定的工作环境中发挥优势。优先探索这些方向：数据分析师, 心理咨询师, 投资分析师。",
           "body_html": null,
           "payload_json": null,
           "sort_order": 40,
           "is_enabled": true
         },
         {
-          "section_key": "relationships",
-          "title": "关系模式",
-          "render_variant": "rich_text",
-          "body_md": "你更容易通过稳定的一对一沟通、留白和安静空间来建立信任。你倾向于和能讨论长期可能性、模式和意义的人建立更深连接。在冲突里你通常优先讲逻辑和边界，因此需要主动补充情绪确认。亲密关系与协作关系里，你通常更喜欢弹性空间、自然推进和保留选择余地。",
-          "body_html": null,
-          "payload_json": null,
-          "sort_order": 50,
-          "is_enabled": true
-        },
-        {
-          "section_key": "career_fit",
-          "title": "职业匹配",
-          "render_variant": "cards",
-          "body_md": "你通常更适合在高自主度、目标清晰、反馈节奏稳定的工作环境中发挥优势。优先探索这些方向：数据分析师, 心理咨询师, 投资分析师。",
+          "section_key": "career.preferred_roles",
+          "title": "推荐职业方向",
+          "render_variant": "preferred_role_list",
+          "body_md": null,
           "body_html": null,
           "payload_json": {
             "recommended_jobs": [
@@ -1885,7 +2077,7 @@
             ],
             "work_env": "高自主度、目标清晰、反馈节奏稳定的工作环境。"
           },
-          "sort_order": 80,
+          "sort_order": 70,
           "is_enabled": true
         }
       ],
@@ -1907,10 +2099,16 @@
       "type_code": "ISFJ",
       "slug": "isfj",
       "title": "ISFJ - 守卫者",
+      "type_name": "守卫者",
+      "nickname": "守卫者",
+      "rarity_text": null,
+      "keywords_json": [],
       "subtitle": null,
       "excerpt": "基于 ISFJ 人格画像的职业建议与工作环境匹配策略。",
       "hero_kicker": "守卫者",
       "hero_quote": null,
+      "hero_summary_md": "基于 ISFJ 人格画像的职业建议与工作环境匹配策略。",
+      "hero_summary_html": null,
       "hero_image_url": null,
       "status": "published",
       "is_public": true,
@@ -1919,18 +2117,18 @@
       "scheduled_at": null,
       "sections": [
         {
-          "section_key": "core_snapshot",
-          "title": "核心概览",
+          "section_key": "overview",
+          "title": "人格概览",
           "render_variant": "rich_text",
           "body_md": "基于 ISFJ 人格画像的职业建议与工作环境匹配策略。 这类人格通常在目标清晰、反馈可获得、能够持续迭代的环境里更容易稳定发挥。",
           "body_html": null,
           "payload_json": null,
-          "sort_order": 10,
+          "sort_order": 20,
           "is_enabled": true
         },
         {
-          "section_key": "strengths",
-          "title": "优势",
+          "section_key": "growth.strengths",
+          "title": "成长优势",
           "render_variant": "bullets",
           "body_md": null,
           "body_html": null,
@@ -1950,12 +2148,12 @@
               }
             ]
           },
-          "sort_order": 20,
+          "sort_order": 100,
           "is_enabled": true
         },
         {
-          "section_key": "growth_edges",
-          "title": "成长边界",
+          "section_key": "growth.weaknesses",
+          "title": "成长盲点",
           "render_variant": "bullets",
           "body_md": null,
           "body_html": null,
@@ -1971,34 +2169,44 @@
               }
             ]
           },
-          "sort_order": 30,
+          "sort_order": 110,
           "is_enabled": true
         },
         {
-          "section_key": "work_style",
-          "title": "工作风格",
+          "section_key": "growth.summary",
+          "title": "成长概览",
           "render_variant": "rich_text",
           "body_md": "高自主度、目标清晰、反馈节奏稳定的工作环境。",
+          "body_html": null,
+          "payload_json": null,
+          "sort_order": 90,
+          "is_enabled": true
+        },
+        {
+          "section_key": "relationships.summary",
+          "title": "关系模式",
+          "render_variant": "rich_text",
+          "body_md": "你更容易通过稳定的一对一沟通、留白和安静空间来建立信任。你更看重现实可靠、说到做到和细节可落地的人际互动。在冲突里你通常优先照顾感受和氛围，因此需要主动讲清原则和底线。亲密关系与协作关系里，你通常更喜欢明确承诺、稳定节奏和可预期安排。",
+          "body_html": null,
+          "payload_json": null,
+          "sort_order": 140,
+          "is_enabled": true
+        },
+        {
+          "section_key": "career.summary",
+          "title": "职业概览",
+          "render_variant": "rich_text",
+          "body_md": "你通常更适合在高自主度、目标清晰、反馈节奏稳定的工作环境中发挥优势。优先探索这些方向：数据科学家, 前端工程师, 全栈工程师。",
           "body_html": null,
           "payload_json": null,
           "sort_order": 40,
           "is_enabled": true
         },
         {
-          "section_key": "relationships",
-          "title": "关系模式",
-          "render_variant": "rich_text",
-          "body_md": "你更容易通过稳定的一对一沟通、留白和安静空间来建立信任。你更看重现实可靠、说到做到和细节可落地的人际互动。在冲突里你通常优先照顾感受和氛围，因此需要主动讲清原则和底线。亲密关系与协作关系里，你通常更喜欢明确承诺、稳定节奏和可预期安排。",
-          "body_html": null,
-          "payload_json": null,
-          "sort_order": 50,
-          "is_enabled": true
-        },
-        {
-          "section_key": "career_fit",
-          "title": "职业匹配",
-          "render_variant": "cards",
-          "body_md": "你通常更适合在高自主度、目标清晰、反馈节奏稳定的工作环境中发挥优势。优先探索这些方向：数据科学家, 前端工程师, 全栈工程师。",
+          "section_key": "career.preferred_roles",
+          "title": "推荐职业方向",
+          "render_variant": "preferred_role_list",
+          "body_md": null,
           "body_html": null,
           "payload_json": {
             "recommended_jobs": [
@@ -2043,7 +2251,7 @@
             ],
             "work_env": "高自主度、目标清晰、反馈节奏稳定的工作环境。"
           },
-          "sort_order": 80,
+          "sort_order": 70,
           "is_enabled": true
         }
       ],
@@ -2065,10 +2273,16 @@
       "type_code": "ISFP",
       "slug": "isfp",
       "title": "ISFP - 探险家",
+      "type_name": "探险家",
+      "nickname": "探险家",
+      "rarity_text": null,
+      "keywords_json": [],
       "subtitle": null,
       "excerpt": "基于 ISFP 人格画像的职业建议与工作环境匹配策略。",
       "hero_kicker": "探险家",
       "hero_quote": null,
+      "hero_summary_md": "基于 ISFP 人格画像的职业建议与工作环境匹配策略。",
+      "hero_summary_html": null,
       "hero_image_url": null,
       "status": "published",
       "is_public": true,
@@ -2077,18 +2291,18 @@
       "scheduled_at": null,
       "sections": [
         {
-          "section_key": "core_snapshot",
-          "title": "核心概览",
+          "section_key": "overview",
+          "title": "人格概览",
           "render_variant": "rich_text",
           "body_md": "基于 ISFP 人格画像的职业建议与工作环境匹配策略。 这类人格通常在目标清晰、反馈可获得、能够持续迭代的环境里更容易稳定发挥。",
           "body_html": null,
           "payload_json": null,
-          "sort_order": 10,
+          "sort_order": 20,
           "is_enabled": true
         },
         {
-          "section_key": "strengths",
-          "title": "优势",
+          "section_key": "growth.strengths",
+          "title": "成长优势",
           "render_variant": "bullets",
           "body_md": null,
           "body_html": null,
@@ -2108,12 +2322,12 @@
               }
             ]
           },
-          "sort_order": 20,
+          "sort_order": 100,
           "is_enabled": true
         },
         {
-          "section_key": "growth_edges",
-          "title": "成长边界",
+          "section_key": "growth.weaknesses",
+          "title": "成长盲点",
           "render_variant": "bullets",
           "body_md": null,
           "body_html": null,
@@ -2129,34 +2343,44 @@
               }
             ]
           },
-          "sort_order": 30,
+          "sort_order": 110,
           "is_enabled": true
         },
         {
-          "section_key": "work_style",
-          "title": "工作风格",
+          "section_key": "growth.summary",
+          "title": "成长概览",
           "render_variant": "rich_text",
           "body_md": "高自主度、目标清晰、反馈节奏稳定的工作环境。",
+          "body_html": null,
+          "payload_json": null,
+          "sort_order": 90,
+          "is_enabled": true
+        },
+        {
+          "section_key": "relationships.summary",
+          "title": "关系模式",
+          "render_variant": "rich_text",
+          "body_md": "你更容易通过稳定的一对一沟通、留白和安静空间来建立信任。你更看重现实可靠、说到做到和细节可落地的人际互动。在冲突里你通常优先照顾感受和氛围，因此需要主动讲清原则和底线。亲密关系与协作关系里，你通常更喜欢弹性空间、自然推进和保留选择余地。",
+          "body_html": null,
+          "payload_json": null,
+          "sort_order": 140,
+          "is_enabled": true
+        },
+        {
+          "section_key": "career.summary",
+          "title": "职业概览",
+          "render_variant": "rich_text",
+          "body_md": "你通常更适合在高自主度、目标清晰、反馈节奏稳定的工作环境中发挥优势。优先探索这些方向：全栈工程师, 云架构师, HRBP。",
           "body_html": null,
           "payload_json": null,
           "sort_order": 40,
           "is_enabled": true
         },
         {
-          "section_key": "relationships",
-          "title": "关系模式",
-          "render_variant": "rich_text",
-          "body_md": "你更容易通过稳定的一对一沟通、留白和安静空间来建立信任。你更看重现实可靠、说到做到和细节可落地的人际互动。在冲突里你通常优先照顾感受和氛围，因此需要主动讲清原则和底线。亲密关系与协作关系里，你通常更喜欢弹性空间、自然推进和保留选择余地。",
-          "body_html": null,
-          "payload_json": null,
-          "sort_order": 50,
-          "is_enabled": true
-        },
-        {
-          "section_key": "career_fit",
-          "title": "职业匹配",
-          "render_variant": "cards",
-          "body_md": "你通常更适合在高自主度、目标清晰、反馈节奏稳定的工作环境中发挥优势。优先探索这些方向：全栈工程师, 云架构师, HRBP。",
+          "section_key": "career.preferred_roles",
+          "title": "推荐职业方向",
+          "render_variant": "preferred_role_list",
+          "body_md": null,
           "body_html": null,
           "payload_json": {
             "recommended_jobs": [
@@ -2201,7 +2425,7 @@
             ],
             "work_env": "高自主度、目标清晰、反馈节奏稳定的工作环境。"
           },
-          "sort_order": 80,
+          "sort_order": 70,
           "is_enabled": true
         }
       ],
@@ -2223,10 +2447,16 @@
       "type_code": "ISTJ",
       "slug": "istj",
       "title": "ISTJ - 物流师",
+      "type_name": "物流师",
+      "nickname": "物流师",
+      "rarity_text": null,
+      "keywords_json": [],
       "subtitle": null,
       "excerpt": "基于 ISTJ 人格画像的职业建议与工作环境匹配策略。",
       "hero_kicker": "物流师",
       "hero_quote": null,
+      "hero_summary_md": "基于 ISTJ 人格画像的职业建议与工作环境匹配策略。",
+      "hero_summary_html": null,
       "hero_image_url": null,
       "status": "published",
       "is_public": true,
@@ -2235,18 +2465,18 @@
       "scheduled_at": null,
       "sections": [
         {
-          "section_key": "core_snapshot",
-          "title": "核心概览",
+          "section_key": "overview",
+          "title": "人格概览",
           "render_variant": "rich_text",
           "body_md": "基于 ISTJ 人格画像的职业建议与工作环境匹配策略。 这类人格通常在目标清晰、反馈可获得、能够持续迭代的环境里更容易稳定发挥。",
           "body_html": null,
           "payload_json": null,
-          "sort_order": 10,
+          "sort_order": 20,
           "is_enabled": true
         },
         {
-          "section_key": "strengths",
-          "title": "优势",
+          "section_key": "growth.strengths",
+          "title": "成长优势",
           "render_variant": "bullets",
           "body_md": null,
           "body_html": null,
@@ -2266,12 +2496,12 @@
               }
             ]
           },
-          "sort_order": 20,
+          "sort_order": 100,
           "is_enabled": true
         },
         {
-          "section_key": "growth_edges",
-          "title": "成长边界",
+          "section_key": "growth.weaknesses",
+          "title": "成长盲点",
           "render_variant": "bullets",
           "body_md": null,
           "body_html": null,
@@ -2287,34 +2517,44 @@
               }
             ]
           },
-          "sort_order": 30,
+          "sort_order": 110,
           "is_enabled": true
         },
         {
-          "section_key": "work_style",
-          "title": "工作风格",
+          "section_key": "growth.summary",
+          "title": "成长概览",
           "render_variant": "rich_text",
           "body_md": "高自主度、目标清晰、反馈节奏稳定的工作环境。",
+          "body_html": null,
+          "payload_json": null,
+          "sort_order": 90,
+          "is_enabled": true
+        },
+        {
+          "section_key": "relationships.summary",
+          "title": "关系模式",
+          "render_variant": "rich_text",
+          "body_md": "你更容易通过稳定的一对一沟通、留白和安静空间来建立信任。你更看重现实可靠、说到做到和细节可落地的人际互动。在冲突里你通常优先讲逻辑和边界，因此需要主动补充情绪确认。亲密关系与协作关系里，你通常更喜欢明确承诺、稳定节奏和可预期安排。",
+          "body_html": null,
+          "payload_json": null,
+          "sort_order": 140,
+          "is_enabled": true
+        },
+        {
+          "section_key": "career.summary",
+          "title": "职业概览",
+          "render_variant": "rich_text",
+          "body_md": "你通常更适合在高自主度、目标清晰、反馈节奏稳定的工作环境中发挥优势。优先探索这些方向：教师, 机器学习工程师, 后端工程师。",
           "body_html": null,
           "payload_json": null,
           "sort_order": 40,
           "is_enabled": true
         },
         {
-          "section_key": "relationships",
-          "title": "关系模式",
-          "render_variant": "rich_text",
-          "body_md": "你更容易通过稳定的一对一沟通、留白和安静空间来建立信任。你更看重现实可靠、说到做到和细节可落地的人际互动。在冲突里你通常优先讲逻辑和边界，因此需要主动补充情绪确认。亲密关系与协作关系里，你通常更喜欢明确承诺、稳定节奏和可预期安排。",
-          "body_html": null,
-          "payload_json": null,
-          "sort_order": 50,
-          "is_enabled": true
-        },
-        {
-          "section_key": "career_fit",
-          "title": "职业匹配",
-          "render_variant": "cards",
-          "body_md": "你通常更适合在高自主度、目标清晰、反馈节奏稳定的工作环境中发挥优势。优先探索这些方向：教师, 机器学习工程师, 后端工程师。",
+          "section_key": "career.preferred_roles",
+          "title": "推荐职业方向",
+          "render_variant": "preferred_role_list",
+          "body_md": null,
           "body_html": null,
           "payload_json": {
             "recommended_jobs": [
@@ -2359,7 +2599,7 @@
             ],
             "work_env": "高自主度、目标清晰、反馈节奏稳定的工作环境。"
           },
-          "sort_order": 80,
+          "sort_order": 70,
           "is_enabled": true
         }
       ],
@@ -2381,10 +2621,16 @@
       "type_code": "ISTP",
       "slug": "istp",
       "title": "ISTP - 鉴赏家",
+      "type_name": "鉴赏家",
+      "nickname": "鉴赏家",
+      "rarity_text": null,
+      "keywords_json": [],
       "subtitle": null,
       "excerpt": "基于 ISTP 人格画像的职业建议与工作环境匹配策略。",
       "hero_kicker": "鉴赏家",
       "hero_quote": null,
+      "hero_summary_md": "基于 ISTP 人格画像的职业建议与工作环境匹配策略。",
+      "hero_summary_html": null,
       "hero_image_url": null,
       "status": "published",
       "is_public": true,
@@ -2393,18 +2639,18 @@
       "scheduled_at": null,
       "sections": [
         {
-          "section_key": "core_snapshot",
-          "title": "核心概览",
+          "section_key": "overview",
+          "title": "人格概览",
           "render_variant": "rich_text",
           "body_md": "基于 ISTP 人格画像的职业建议与工作环境匹配策略。 这类人格通常在目标清晰、反馈可获得、能够持续迭代的环境里更容易稳定发挥。",
           "body_html": null,
           "payload_json": null,
-          "sort_order": 10,
+          "sort_order": 20,
           "is_enabled": true
         },
         {
-          "section_key": "strengths",
-          "title": "优势",
+          "section_key": "growth.strengths",
+          "title": "成长优势",
           "render_variant": "bullets",
           "body_md": null,
           "body_html": null,
@@ -2424,12 +2670,12 @@
               }
             ]
           },
-          "sort_order": 20,
+          "sort_order": 100,
           "is_enabled": true
         },
         {
-          "section_key": "growth_edges",
-          "title": "成长边界",
+          "section_key": "growth.weaknesses",
+          "title": "成长盲点",
           "render_variant": "bullets",
           "body_md": null,
           "body_html": null,
@@ -2445,34 +2691,44 @@
               }
             ]
           },
-          "sort_order": 30,
+          "sort_order": 110,
           "is_enabled": true
         },
         {
-          "section_key": "work_style",
-          "title": "工作风格",
+          "section_key": "growth.summary",
+          "title": "成长概览",
           "render_variant": "rich_text",
           "body_md": "高自主度、目标清晰、反馈节奏稳定的工作环境。",
+          "body_html": null,
+          "payload_json": null,
+          "sort_order": 90,
+          "is_enabled": true
+        },
+        {
+          "section_key": "relationships.summary",
+          "title": "关系模式",
+          "render_variant": "rich_text",
+          "body_md": "你更容易通过稳定的一对一沟通、留白和安静空间来建立信任。你更看重现实可靠、说到做到和细节可落地的人际互动。在冲突里你通常优先讲逻辑和边界，因此需要主动补充情绪确认。亲密关系与协作关系里，你通常更喜欢弹性空间、自然推进和保留选择余地。",
+          "body_html": null,
+          "payload_json": null,
+          "sort_order": 140,
+          "is_enabled": true
+        },
+        {
+          "section_key": "career.summary",
+          "title": "职业概览",
+          "render_variant": "rich_text",
+          "body_md": "你通常更适合在高自主度、目标清晰、反馈节奏稳定的工作环境中发挥优势。优先探索这些方向：后端工程师, 网络安全分析师, 运营经理。",
           "body_html": null,
           "payload_json": null,
           "sort_order": 40,
           "is_enabled": true
         },
         {
-          "section_key": "relationships",
-          "title": "关系模式",
-          "render_variant": "rich_text",
-          "body_md": "你更容易通过稳定的一对一沟通、留白和安静空间来建立信任。你更看重现实可靠、说到做到和细节可落地的人际互动。在冲突里你通常优先讲逻辑和边界，因此需要主动补充情绪确认。亲密关系与协作关系里，你通常更喜欢弹性空间、自然推进和保留选择余地。",
-          "body_html": null,
-          "payload_json": null,
-          "sort_order": 50,
-          "is_enabled": true
-        },
-        {
-          "section_key": "career_fit",
-          "title": "职业匹配",
-          "render_variant": "cards",
-          "body_md": "你通常更适合在高自主度、目标清晰、反馈节奏稳定的工作环境中发挥优势。优先探索这些方向：后端工程师, 网络安全分析师, 运营经理。",
+          "section_key": "career.preferred_roles",
+          "title": "推荐职业方向",
+          "render_variant": "preferred_role_list",
+          "body_md": null,
           "body_html": null,
           "payload_json": {
             "recommended_jobs": [
@@ -2517,7 +2773,7 @@
             ],
             "work_env": "高自主度、目标清晰、反馈节奏稳定的工作环境。"
           },
-          "sort_order": 80,
+          "sort_order": 70,
           "is_enabled": true
         }
       ],
@@ -2530,6 +2786,14817 @@
         "og_image_url": null,
         "twitter_title": null,
         "twitter_description": null,
+        "twitter_image_url": null,
+        "robots": null,
+        "jsonld_overrides_json": null
+      }
+    }
+  ],
+  "variants": [
+    {
+      "runtime_type_code": "ENFJ-A",
+      "canonical_type_code": "ENFJ",
+      "variant_code": "A",
+      "is_published": true,
+      "published_at": "2026-03-17T00:00:00Z",
+      "profile_overrides": {
+        "type_name": "主人公型",
+        "nickname": "坚定引路人",
+        "rarity_text": "约 2–5%",
+        "keywords_json": [
+          "共情",
+          "愿景感",
+          "协调者",
+          "服务型领导",
+          "价值驱动",
+          "自信感"
+        ],
+        "hero_summary_md": "你像一束有方向感的光：走进人群、点亮人心，也敢为一件相信的事站在最前面。你真心相信，只要有人被好好理解、被坚定支持，他就有机会活成更好的自己，而你愿意做那个“带头向前走的人”。",
+        "hero_summary_html": null
+      },
+      "section_overrides": [
+        {
+          "section_key": "letters_intro",
+          "render_variant": "letters_intro",
+          "body_md": null,
+          "body_html": null,
+          "payload_json": {
+            "headline": "外向 · 直觉 · 情感 · 规划 · 自信型｜温暖与决断并存的“坚定引路人”",
+            "letters": [
+              {
+                "letter": "E",
+                "title": "外向（E）",
+                "description": "让你享受真实的互动场景——讨论、分享会、头脑风暴都是你的能量来源，你擅长营造氛围，也习惯站在场域中央带动节奏。"
+              },
+              {
+                "letter": "N",
+                "title": "直觉（N）",
+                "description": "让你天然关注“更大的意义”，比起只完成任务，你更在意：这件事能推动什么改变？能不能和自己的价值观对齐。"
+              },
+              {
+                "letter": "F",
+                "title": "情感（F）",
+                "description": "使你在决策时会多问一句：“这样做，对每个人公平吗？会不会伤到谁？”你会主动把情绪与关系纳入考量。"
+              },
+              {
+                "letter": "J",
+                "title": "规划（J）",
+                "description": "让你不满足于停留在理想层面，而是习惯制定时间表、划分步骤、明确责任，把“愿景”拆成可落地的路径。"
+              },
+              {
+                "letter": "A",
+                "title": "自信型（-A）",
+                "description": "让你在做出判断后相对笃定，不容易被情绪波动带着走。你愿意反思，但不会长期沉溺于自我怀疑，更倾向于“总结—调整—继续向前”。"
+              }
+            ]
+          },
+          "sort_order": 10,
+          "is_enabled": true
+        },
+        {
+          "section_key": "overview",
+          "render_variant": "rich_text",
+          "body_md": "在费马心理的逻辑模型里，ENFJ-A 通常被视作“有方向感的引路人”。你既有 ENFJ 的共情与愿景感，又多了一份相对稳定、笃定的内在驱动力。\n\n对你来说，理想不是只能拿来讨论的主题，而是应该配得上行动的东西：有一个值得追随的愿景，一群愿意相信的人，再加上一套可以真正推进的执行方案——这三样缺一不可。\n\n当团队迷茫、关系松散、大家只顾各扫门前雪时，你会本能地站出来搭建秩序与共识：“我们到底想要去哪里？谁可以做什么？我们怎样一起走得更好？”\n\n你的人生追求从来不只是“把事情做完”，而是“在推动有意义的事上，真正产生影响，并让身边的人一起成长”。",
+          "body_html": null,
+          "payload_json": null,
+          "sort_order": 20,
+          "is_enabled": true
+        },
+        {
+          "section_key": "trait_overview",
+          "render_variant": "trait_dimension_grid",
+          "body_md": "建议与小程序中 5 条维度进度条搭配展示：外向 / 内向｜天马行空 / 求真务实｜情感细腻 / 理性思考｜运筹帷幄 / 随机应变｜情绪易波动 / 自信果断。",
+          "body_html": null,
+          "payload_json": {
+            "summary": "建议与小程序中 5 条维度进度条搭配展示：外向 / 内向｜天马行空 / 求真务实｜情感细腻 / 理性思考｜运筹帷幄 / 随机应变｜情绪易波动 / 自信果断。",
+            "dimensions": [
+              {
+                "id": "EI",
+                "name": "外向倾向",
+                "label": "外向倾向",
+                "axis_left": "外向",
+                "axis_right": "内向",
+                "summary": "明显偏外向",
+                "description": "你通常是那个主动开场、组织讨论、带动气氛的人。你享受高质量的互动，也习惯在关键场景中“站出来说点什么”。短暂独处能帮你整理思路，但长期与世隔绝会让你迅速失去能量。"
+              },
+              {
+                "id": "SN",
+                "name": "心智模式",
+                "label": "心智模式",
+                "axis_left": "天马行空",
+                "axis_right": "求真务实",
+                "summary": "偏“天马行空”，兼顾落地",
+                "description": "你习惯从宏观高度看问题，很快就能看见趋势与大局，经常一句话点明“我们真正想要的是什么”。同时，你也会思考：要落到执行层面，需要怎样的节奏与配合。"
+              },
+              {
+                "id": "TF",
+                "name": "情绪天性",
+                "label": "情绪天性",
+                "axis_left": "情感细腻",
+                "axis_right": "理性思考",
+                "summary": "偏“情感细腻”",
+                "description": "你能敏锐捕捉氛围与情绪变化，会在意过程是不是足够尊重、足够温柔。但作为 A 型，你更能在关键时刻“稳住自己”，在理解情绪的同时，保持一定的客观与冷静。"
+              },
+              {
+                "id": "JP",
+                "name": "应对方式",
+                "label": "应对方式",
+                "axis_left": "运筹帷幄",
+                "axis_right": "随机应变",
+                "summary": "明显偏“运筹帷幄”",
+                "description": "你喜欢在行动前对整体有一个初步规划：目标是什么、阶段节点在哪里、谁负责哪一块。遇到变化时，你也能根据新情况调整计划，而不是完全被动应对。"
+              },
+              {
+                "id": "AT",
+                "name": "身份特征",
+                "label": "身份特征",
+                "axis_left": "情绪易波动",
+                "axis_right": "自信果断",
+                "summary": "偏“自信果断”",
+                "description": "自信型的你，内心有一条相对稳定的价值主线。你会反思，但不容易长期陷在自责小剧场里，更倾向于：“OK，这次这里没做好，我下次这样改。” 这种稳定感会给周围人带来安全与信任。"
+              }
+            ]
+          },
+          "sort_order": 30,
+          "is_enabled": true
+        },
+        {
+          "section_key": "career.summary",
+          "render_variant": "rich_text",
+          "body_md": "在职业场景中，你往往是那个“又懂人，又能扛事”的角色：既关心团队状态，也在意目标与结果。\n\n你适合站在“人 × 目标”的交汇点上工作——既能陪伴他人成长，又能推动项目、业务或组织向前发展。只要你认同这件事的价值，你就愿意付出高度的投入与责任感。\n\n当工作内容只剩下机械执行、缺乏沟通与影响力空间时，你会明显感到动力下降；而当你被信任、被授权去“带一群人做有意义的事”时，你就会进入持续高能量状态。",
+          "body_html": null,
+          "payload_json": null,
+          "sort_order": 40,
+          "is_enabled": true
+        },
+        {
+          "section_key": "career.advantages",
+          "render_variant": "bullets",
+          "body_md": null,
+          "body_html": null,
+          "payload_json": {
+            "items": [
+              {
+                "title": "自然的号召力与影响力",
+                "body": "你擅长把想法讲清楚、讲透彻，也敢于在关键时刻给出判断。别人往往会因为信任你这个人，而愿意多往前走一步。"
+              },
+              {
+                "title": "价值观驱动的领导方式",
+                "body": "你不只是为了完成指标，而是会不断追问“我们为什么要做这件事”。这让你在团队中成为价值观的定调者与守门人。"
+              },
+              {
+                "title": "情绪敏锐 + 决策果断",
+                "body": "你既能察觉情绪暗流，又不会完全被情绪绑架。你愿意照顾到重要关系，同时也能在必要时做出相对理性、清晰的决定。"
+              },
+              {
+                "title": "善于搭建人与事之间的“桥”",
+                "body": "你可以把成员各自的优势、动机与项目目标连接起来，帮助每个人找到“我在这个事情里的意义”，从而提升整体配合度。"
+              }
+            ]
+          },
+          "sort_order": 50,
+          "is_enabled": true
+        },
+        {
+          "section_key": "career.weaknesses",
+          "render_variant": "bullets",
+          "body_md": null,
+          "body_html": null,
+          "payload_json": {
+            "items": [
+              {
+                "title": "容易承担过多责任",
+                "body": "因为你“能扛事、也愿意扛”，别人很容易把事情往你这边推。久而久之，你会发现自己总在负责关键环节，压力集中在你身上。"
+              },
+              {
+                "title": "对低效和价值观不合容忍度低",
+                "body": "当团队长期低效、反复内耗，或者上级反复摇摆、言行不一时，你会迅速失去耐心与信任感，很难对这种环境保持投入。"
+              },
+              {
+                "title": "容易忽略自己的节奏",
+                "body": "在带动团队、对齐目标的过程中，你可能会不自觉透支自己的时间与精力，把“我也需要休息”排在最后。"
+              },
+              {
+                "title": "不擅长在完全缺乏方向的环境中工作",
+                "body": "如果组织层面完全没有战略、没有边界，只是“做一天算一天”，你会非常难受，需要花大量额外精力来填补这些空白。"
+              }
+            ]
+          },
+          "sort_order": 60,
+          "is_enabled": true
+        },
+        {
+          "section_key": "career.preferred_roles",
+          "render_variant": "preferred_role_list",
+          "body_md": null,
+          "body_html": null,
+          "payload_json": {
+            "intro": "下面这些方向，并不是 ENFJ-A 的唯一选择，但更容易让你感到“这份工作有价值、我也能发挥所长”。你可以把它们当作职业探索的参考坐标。",
+            "groups": [
+              {
+                "group_title": "以人和成长为核心的岗位",
+                "description": "兼具“带人”和“带方向”的角色。",
+                "examples": [
+                  "团队负责人、项目经理、业务小组 Leader",
+                  "教育培训、班主任 / 导师、教练、成长营主理人",
+                  "HRBP、组织发展、人力管理者"
+                ]
+              },
+              {
+                "group_title": "需要传递愿景与价值的岗位",
+                "description": "让你有机会对内对外讲清楚“我们是谁、要去哪里”。",
+                "examples": [
+                  "品牌公关、内容策划、活动主理人",
+                  "社区运营、社群主理、用户成功",
+                  "创业团队合伙人、事业部负责人"
+                ]
+              },
+              {
+                "group_title": "社会影响与公益相关领域",
+                "description": "把理想主义与实际项目结合起来的场景。",
+                "examples": [
+                  "公益机构 / NGO 项目负责人",
+                  "社会企业运营、青年项目组织者",
+                  "心理健康、教育公平等议题相关项目负责人"
+                ]
+              },
+              {
+                "group_title": "复杂协作中的“中枢角色”",
+                "description": "在多方协作中承担“对齐目标 + 沟通协调 + 推进执行”的角色。",
+                "examples": [
+                  "跨部门项目协调、客户成功负责人、大型活动统筹等"
+                ]
+              }
+            ],
+            "outro": "最关键的并不是职位名称本身，而是：这份工作是否允许你带着一群人，围绕一个你真心认同的目标，一起创造看得见的改变。"
+          },
+          "sort_order": 70,
+          "is_enabled": true
+        },
+        {
+          "section_key": "career.upgrade_suggestions",
+          "render_variant": "bullets",
+          "body_md": "对 ENFJ-A 来说，能力与影响力往往不是瓶颈，如何在“为别人负责”与“为自己负责”之间找到平衡，才是决定你能走多远的关键。\n\n你可以把下面这些提醒，当作自己的职场小公式：",
+          "body_html": null,
+          "payload_json": {
+            "items": [
+              {
+                "title": "领导力 = 方向感 × 边界感",
+                "body": "在给出方向之前，先想清楚：什么是我该负责的？什么必须由团队自己承担？清晰的边界不是冷漠，而是让每个人真正成长的前提。"
+              },
+              {
+                "title": "团队信任 = 结果交付 × 情绪承载",
+                "body": "你已经很会照顾情绪了，可以刻意强化“用结果说话”的部分：让别人不仅记得你“很暖”，也记得你“很稳、很能打”。"
+              },
+              {
+                "title": "职业续航力 = 节奏管理 × 优先级清晰",
+                "body": "把自己的时间和能量，当作团队的重要资产来管理。固定留出“不可被打扰的深度工作时段”和“专门的休息窗口”，而不是把自己当成随时在线的客服。"
+              },
+              {
+                "title": "影响力放大 = 个人能力 × 体系化输出",
+                "body": "把你在带人、沟通、推动项目上的经验沉淀成：流程、话术、文档、培训。这样，你就不只是一个“厉害的个人”，而是在搭建一套可复制的影响力系统。"
+              }
+            ]
+          },
+          "sort_order": 80,
+          "is_enabled": true
+        },
+        {
+          "section_key": "growth.summary",
+          "render_variant": "rich_text",
+          "body_md": "对 ENFJ-A 来说，成长更像是一条“持续升级影响力”的路：在保持温度与理想的同时，让自己的内在更加稳、边界更加清晰。\n\n这一章节，会从你的强项、短板，以及能量管理几个角度，帮你看清更适合自己的成长路径。",
+          "body_html": null,
+          "payload_json": null,
+          "sort_order": 90,
+          "is_enabled": true
+        },
+        {
+          "section_key": "growth.strengths",
+          "render_variant": "bullets",
+          "body_md": null,
+          "body_html": null,
+          "payload_json": {
+            "items": [
+              {
+                "title": "自带行动力的理想主义",
+                "body": "你很少停留在“空想”，一旦认定了价值，就会主动策划、拉人、推进，把理想变成具体可执行的计划。"
+              },
+              {
+                "title": "稳定而有弹性的自信",
+                "body": "你内心有相对清晰的价值底线，不容易被一两句评价击溃，也不太会因为一次失误就全盘否定自己。"
+              },
+              {
+                "title": "善于从反馈中迭代自己",
+                "body": "你愿意听取他人的建议与感受，但不会照单全收，而是快速筛选出有价值的部分，转化为下一次的优化方向。"
+              },
+              {
+                "title": "具备长期主义思维",
+                "body": "你不仅关注当下，更会思考几年后的自己想成为什么样的人，从而在日常选择中保持一定的一致性和耐心。"
+              }
+            ]
+          },
+          "sort_order": 100,
+          "is_enabled": true
+        },
+        {
+          "section_key": "growth.weaknesses",
+          "render_variant": "bullets",
+          "body_md": null,
+          "body_html": null,
+          "payload_json": {
+            "items": [
+              {
+                "title": "容易忽略“脆弱的一面”",
+                "body": "由于习惯做那个“稳住局面的人”，你可能会不自觉压抑自己的脆弱和困惑，久而久之，很难对他人开口求助。"
+              },
+              {
+                "title": "对自己要求偏高",
+                "body": "虽然比 ENFJ-T 更少陷入情绪波动，但你对自己的期待并不低，有时会默认自己应该“一直在线、一直可靠”。"
+              },
+              {
+                "title": "容易同时承担太多角色",
+                "body": "你既想做好领导者、同伴、家人、朋友，又想扮演好每一个身份，结果很容易日程被排得满满当当，缺少真正属于自己的空间。"
+              },
+              {
+                "title": "不擅长“停下来什么都不做”",
+                "body": "你更习惯通过“做点什么”来解决不安，很少允许自己彻底空下来感受当下，这可能让你错过一些真正需要消化的情绪。"
+              }
+            ]
+          },
+          "sort_order": 110,
+          "is_enabled": true
+        },
+        {
+          "section_key": "growth.motivators",
+          "render_variant": "premium_teaser",
+          "body_md": "被信任地托付重要任务、看见团队或身边人在你的陪伴下变得更好、以及清晰感受到自己“正在产生正向影响”，会极大激发你的内在动力。",
+          "body_html": null,
+          "payload_json": {
+            "teaser": "被信任地托付重要任务、看见团队或身边人在你的陪伴下变得更好、以及清晰感受到自己“正在产生正向影响”，会极大激发你的内在动力。",
+            "is_premium": true
+          },
+          "sort_order": 120,
+          "is_enabled": true
+        },
+        {
+          "section_key": "growth.drainers",
+          "render_variant": "premium_teaser",
+          "body_md": "长期处在价值观不匹配、角色边界模糊、只被当成“工具人”而非“伙伴”的环境，会一点点消耗你的热情，让你开始怀疑“我还要不要继续这么投入”。",
+          "body_html": null,
+          "payload_json": {
+            "teaser": "长期处在价值观不匹配、角色边界模糊、只被当成“工具人”而非“伙伴”的环境，会一点点消耗你的热情，让你开始怀疑“我还要不要继续这么投入”。",
+            "is_premium": true
+          },
+          "sort_order": 130,
+          "is_enabled": true
+        },
+        {
+          "section_key": "relationships.summary",
+          "render_variant": "rich_text",
+          "body_md": "在关系世界里，你像一位既温暖又靠谱的引路人：你愿意听、愿意懂，也愿意在关键节点上给出清晰的建议与方向。\n\n你希望的亲密关系，不只是“有人陪”，而是：双方能够坦诚交流、一起面对问题、一起成长，成为真正意义上的“并肩作战的队友”。",
+          "body_html": null,
+          "payload_json": null,
+          "sort_order": 140,
+          "is_enabled": true
+        },
+        {
+          "section_key": "relationships.strengths",
+          "render_variant": "bullets",
+          "body_md": null,
+          "body_html": null,
+          "payload_json": {
+            "items": [
+              {
+                "title": "真诚且主动的关心",
+                "body": "你会记得对方的重要日子、在意对方的情绪变化，也会主动问一句“最近怎么样”，而不是等对方开口。"
+              },
+              {
+                "title": "善于给出可执行的支持",
+                "body": "你不仅会安慰人，也会帮助对方一起分析局面、梳理选项，给出兼顾情绪与现实的建议。"
+              },
+              {
+                "title": "愿意一起制定“关系路线图”",
+                "body": "你在意两个人未来是否在同一页上，会期待一起规划生活、目标和节奏，而不是只停留在当下的甜蜜。"
+              },
+              {
+                "title": "能够在冲突中保持相对冷静",
+                "body": "即使情绪被触动，你也较少彻底失控，更倾向于在冷静之后主动作出沟通与修复。"
+              }
+            ]
+          },
+          "sort_order": 150,
+          "is_enabled": true
+        },
+        {
+          "section_key": "relationships.weaknesses",
+          "render_variant": "bullets",
+          "body_md": null,
+          "body_html": null,
+          "payload_json": {
+            "items": [
+              {
+                "title": "容易承担“情绪与方向双重责任”",
+                "body": "你一边照顾对方的感受，一边还在思考“我们这段关系接下来该怎么走”，这会让你在无形中背负很多额外压力。"
+              },
+              {
+                "title": "不太习惯示弱",
+                "body": "你更习惯做那个稳定、可靠的角色，不太愿意把自己的脆弱完全摊开给对方看，担心给别人增加负担。"
+              },
+              {
+                "title": "有时会“替对方走得太前面”",
+                "body": "你会提前想好对方的路，替对方做很多规划，但如果对方暂时跟不上，你可能会感到挫败或失落。"
+              },
+              {
+                "title": "在关系出现长期失衡时，可能会突然抽离",
+                "body": "当你发现自己长期被消耗、却迟迟得不到回应时，你会先努力几次修复；一旦确认改变无望，你可能会做出相当决绝的离开。"
+              }
+            ]
+          },
+          "sort_order": 160,
+          "is_enabled": true
+        },
+        {
+          "section_key": "relationships.rel_advantages",
+          "render_variant": "premium_teaser",
+          "body_md": "在健康的关系中，你会成为对方非常重要的“情绪港湾”和“人生合伙人”：既能提供温暖的理解，又能为对方指出现实可行的下一步。只要被好好对待，你的人际能量可以长期稳定输出。",
+          "body_html": null,
+          "payload_json": {
+            "teaser": "在健康的关系中，你会成为对方非常重要的“情绪港湾”和“人生合伙人”：既能提供温暖的理解，又能为对方指出现实可行的下一步。只要被好好对待，你的人际能量可以长期稳定输出。",
+            "is_premium": true
+          },
+          "sort_order": 170,
+          "is_enabled": true
+        },
+        {
+          "section_key": "relationships.rel_risks",
+          "render_variant": "premium_teaser",
+          "body_md": "当你长期处在一种“我在带、你在躺”“我在付出、你在习惯”的关系模式中时，你的能量会被慢慢掏空。学会识别这种失衡、并且勇敢提出调整甚至止损，是 ENFJ-A 保护自己的关键功课。",
+          "body_html": null,
+          "payload_json": {
+            "teaser": "当你长期处在一种“我在带、你在躺”“我在付出、你在习惯”的关系模式中时，你的能量会被慢慢掏空。学会识别这种失衡、并且勇敢提出调整甚至止损，是 ENFJ-A 保护自己的关键功课。",
+            "is_premium": true
+          },
+          "sort_order": 180,
+          "is_enabled": true
+        }
+      ],
+      "seo_overrides": {
+        "seo_title": "ENFJ-A 主人公型",
+        "seo_description": "你像一束有方向感的光：走进人群、点亮人心，也敢为一件相信的事站在最前面。你真心相信，只要有人被好好理解、被坚定支持，他就有机会活成更好的自己，而你愿意做那个“带头向前走的人”。",
+        "canonical_url": null,
+        "og_title": "ENFJ-A 坚定引路人",
+        "og_description": "你像一束有方向感的光：走进人群、点亮人心，也敢为一件相信的事站在最前面。你真心相信，只要有人被好好理解、被坚定支持，他就有机会活成更好的自己，而你愿意做那个“带头向前走的人”。",
+        "og_image_url": null,
+        "twitter_title": "ENFJ-A 坚定引路人",
+        "twitter_description": "你像一束有方向感的光：走进人群、点亮人心，也敢为一件相信的事站在最前面。你真心相信，只要有人被好好理解、被坚定支持，他就有机会活成更好的自己，而你愿意做那个“带头向前走的人”。",
+        "twitter_image_url": null,
+        "robots": null,
+        "jsonld_overrides_json": null
+      }
+    },
+    {
+      "runtime_type_code": "ENFJ-T",
+      "canonical_type_code": "ENFJ",
+      "variant_code": "T",
+      "is_published": true,
+      "published_at": "2026-03-17T00:00:00Z",
+      "profile_overrides": {
+        "type_name": "主人公型",
+        "nickname": "温柔引路人",
+        "rarity_text": "约 2–5%",
+        "keywords_json": [
+          "共情",
+          "愿景感",
+          "协调者",
+          "服务型领导",
+          "价值驱动",
+          "自我反思"
+        ],
+        "hero_summary_md": "你像一盏不刺眼的灯：愿意走到人群中央，又始终在照亮别人。你真心相信——只要一个人被好好理解、被温柔对待，他就会变得更好，而你愿意做那个先伸手的人。",
+        "hero_summary_html": null
+      },
+      "section_overrides": [
+        {
+          "section_key": "letters_intro",
+          "render_variant": "letters_intro",
+          "body_md": null,
+          "body_html": null,
+          "payload_json": {
+            "headline": "外向 · 直觉 · 情感 · 规划 · 动荡型｜理想主义与现实执行力并存的“温柔引路人”",
+            "letters": [
+              {
+                "letter": "E",
+                "title": "外向（E）",
+                "description": "让你享受真实的互动场景——讨论、分享会、头脑风暴都是你的能量来源，你喜欢和人产生“连上线”的感觉。"
+              },
+              {
+                "letter": "N",
+                "title": "直觉（N）",
+                "description": "让你总在寻找“更大的意义”，比起细节，你更在意：这件事背后真正想改变什么？很难只为了 KPI 或任务而活。"
+              },
+              {
+                "letter": "F",
+                "title": "情感（F）",
+                "description": "使你在决策时会多问一句：这样做，会不会伤到谁？你会主动把价值观和他人感受纳入考量。"
+              },
+              {
+                "letter": "J",
+                "title": "规划（J）",
+                "description": "让你不满足于空谈理想，而是想把愿景拆成可执行的路线和时间表，习惯有节奏地推进事情。"
+              },
+              {
+                "letter": "T",
+                "title": "动荡型（-T）",
+                "description": "让你对自己要求很高，事后还会在心里复盘：“我是不是还能做得更好？” 这既是成长驱动力，也是压力来源。"
+              }
+            ]
+          },
+          "sort_order": 10,
+          "is_enabled": true
+        },
+        {
+          "section_key": "overview",
+          "render_variant": "rich_text",
+          "body_md": "在费马心理的逻辑模型里，ENFJ-T 往往被视作“温柔而坚定的引路人”。你既有外向带来的感染力，也有直觉带来的远景视角，更有情感与规划带来的体贴与执行力。\n\n对你来说，最舒服的状态是：有一个值得相信的愿景，一群值得投入的人，还有一条可以一起走下去的路。当环境变得冷漠、关系出现裂缝、每个人都只顾自己时，你会很自然地站出来：“我们能不能坐下来，好好聊聊，看怎么一起变好？”\n\n你的人生追求从来不只是“把事情做完”，而是“和一群人，把有意义的事做好”。",
+          "body_html": null,
+          "payload_json": null,
+          "sort_order": 20,
+          "is_enabled": true
+        },
+        {
+          "section_key": "trait_overview",
+          "render_variant": "trait_dimension_grid",
+          "body_md": "建议与小程序中 5 条维度进度条搭配展示：外向 / 内向｜天马行空 / 求真务实｜情感细腻 / 理性思考｜运筹帷幄 / 随机应变｜情绪易波动 / 自信果断。",
+          "body_html": null,
+          "payload_json": {
+            "summary": "建议与小程序中 5 条维度进度条搭配展示：外向 / 内向｜天马行空 / 求真务实｜情感细腻 / 理性思考｜运筹帷幄 / 随机应变｜情绪易波动 / 自信果断。",
+            "dimensions": [
+              {
+                "id": "EI",
+                "name": "外向倾向",
+                "label": "外向倾向",
+                "axis_left": "外向",
+                "axis_right": "内向",
+                "summary": "略偏外向",
+                "description": "你更像是那个主动开话题、照顾气氛的人。你享受热烈而真诚的交流，喜欢和人产生“连上线”的感觉。短暂的独处能帮你整理心情，但如果长时间缺少高质量互动，你会觉得生活在“渐渐失真”。"
+              },
+              {
+                "id": "SN",
+                "name": "心智模式",
+                "label": "心智模式",
+                "axis_left": "天马行空",
+                "axis_right": "求真务实",
+                "summary": "偏“天马行空”",
+                "description": "你习惯从更高的视角看问题，很快就能抓住事情的主线和走向，经常一句话帮大家“提纲挈领”：其实，我们真正想要的是…… 细节对你当然重要，但如果失去整体意义，你很难提起劲去执行。"
+              },
+              {
+                "id": "TF",
+                "name": "情绪天性",
+                "label": "情绪天性",
+                "axis_left": "情感细腻",
+                "axis_right": "理性思考",
+                "summary": "偏“情感细腻”",
+                "description": "你对情绪与氛围极其敏感：语气的一点变化、表情的轻微停顿、群体里那一丝紧绷，你都能察觉。你在意的不只是事情有没有做好，更在意“这个过程中，大家是不是被好好对待了”。"
+              },
+              {
+                "id": "JP",
+                "name": "应对方式",
+                "label": "应对方式",
+                "axis_left": "运筹帷幄",
+                "axis_right": "随机应变",
+                "summary": "偏“运筹帷幄”",
+                "description": "在重要场景里，你会本能地预想各种可能：Plan A / B / C 分别是什么？谁适合站在什么位置？出现突发情况时，怎样让大家受到的冲击最小？这种习惯，让你在别人还在迷茫时，已经能给出一条相对清晰、安全的路线。"
+              },
+              {
+                "id": "AT",
+                "name": "身份特征",
+                "label": "身份特征",
+                "axis_left": "情绪易波动",
+                "axis_right": "自信果断",
+                "summary": "略偏“情绪易波动”",
+                "description": "动荡型的你，自我觉察度很高，也很敏感。你会频繁在心里检查自己的表现：“我刚刚是不是说重了？”“他刚才那个反应，是不是我哪儿没处理好？” 这让你在人际相处中格外体贴，但也容易在看不见的地方消耗自己——焦虑、自责、睡前反复回想对白，都是 ENFJ-T 常见的小剧场。"
+              }
+            ]
+          },
+          "sort_order": 30,
+          "is_enabled": true
+        },
+        {
+          "section_key": "career.summary",
+          "render_variant": "rich_text",
+          "body_md": "你的职业选择，通常会围绕“人”和“改变”展开。只要能真实帮助到他人、推动团队或组织向更好的方向发展，你就很容易全情投入。\n\n你不太适合长期做纯事务型、完全与人隔离的工作；当工作内容只剩下流水线式执行、没有价值感和成长空间时，你会明显感到枯竭。\n\n相反，当一份工作允许你：频繁与人沟通、参与策划、传递愿景、陪伴他人成长，并且看到清晰成果时，你就会进入高能量状态。",
+          "body_html": null,
+          "payload_json": null,
+          "sort_order": 40,
+          "is_enabled": true
+        },
+        {
+          "section_key": "career.advantages",
+          "render_variant": "bullets",
+          "body_md": null,
+          "body_html": null,
+          "payload_json": {
+            "items": [
+              {
+                "title": "擅长搭建信任与氛围",
+                "body": "你能快速读懂团队的情绪气候，主动打破尴尬、缓和紧张，营造出相对安全、开放的沟通环境，让大家更愿意说真话。"
+              },
+              {
+                "title": "愿景感强，兼具执行力",
+                "body": "你既能看见长远方向，又愿意卷起袖子落到细节。你擅长把抽象愿景拆成一个个可执行的步骤和分工，让团队知道“接下来该做什么”。"
+              },
+              {
+                "title": "服务型领导风格",
+                "body": "即使担任管理者，你也很少端架子，而是通过支持下属、帮助协调资源、做情绪后盾来领导团队。人们愿意因为你本人去多走一步。"
+              },
+              {
+                "title": "沟通表达有感染力",
+                "body": "你乐于分享想法、善于用故事和比喻阐述观点，能让复杂的理念变得生动可感，在培训、汇报、演讲场景中尤为亮眼。"
+              }
+            ]
+          },
+          "sort_order": 50,
+          "is_enabled": true
+        },
+        {
+          "section_key": "career.weaknesses",
+          "render_variant": "bullets",
+          "body_md": null,
+          "body_html": null,
+          "payload_json": {
+            "items": [
+              {
+                "title": "过度在意他人感受",
+                "body": "你有时会为了“大家都舒服”，而不去说一些必要的真话，导致问题被拖延，或者你自己承担了过多额外工作。"
+              },
+              {
+                "title": "难以说“不”，容易透支",
+                "body": "作为天生的“救火队员”，你习惯别人来找你时先答应，再想办法。久而久之，你会发现自己总是最忙、也最疲惫。"
+              },
+              {
+                "title": "容易把团队氛围扛在自己身上",
+                "body": "一旦出现冲突、流言或士气低落，你会下意识觉得“是不是我哪里没做好”，反而忽略了制度、目标等客观因素。"
+              },
+              {
+                "title": "对混乱和价值观不清晰的环境耐受度低",
+                "body": "如果上级频繁改方向、标准模糊、言行不一，你会迅速失去信任感和动力，很难在这种环境里长期坚持。"
+              }
+            ]
+          },
+          "sort_order": 60,
+          "is_enabled": true
+        },
+        {
+          "section_key": "career.preferred_roles",
+          "render_variant": "preferred_role_list",
+          "body_md": null,
+          "body_html": null,
+          "payload_json": {
+            "intro": "下面这些并不是唯一适合 ENFJ-T 的岗位，而是几类更容易让你感到“这份工作值得”的方向。你可以把它们当作职业探索的起点。",
+            "groups": [
+              {
+                "group_title": "人本与成长相关",
+                "description": "直接陪伴、支持个体或群体成长的角色。",
+                "examples": [
+                  "心理咨询 / 教练 / 心理教育相关岗位",
+                  "学校教师、班主任、辅导员、成长型社群主理人",
+                  "职业发展顾问、培训讲师、HRBP、企业内训师"
+                ]
+              },
+              {
+                "group_title": "公益与社会影响",
+                "description": "把理想主义和实际行动结合起来的领域。",
+                "examples": [
+                  "公益组织、社会企业、NGO 项目负责人",
+                  "社区发展、青年项目、志愿者组织管理",
+                  "倡导类项目（如教育公平、心理健康等）"
+                ]
+              },
+              {
+                "group_title": "沟通与品牌传播",
+                "description": "需要“既懂人心，又懂表达”的岗位。",
+                "examples": [
+                  "内容策划、品牌公关、新媒体运营",
+                  "活动策划 / 主持、用户运营、客户成功",
+                  "需要大量对外沟通与协调的项目经理"
+                ]
+              },
+              {
+                "group_title": "以人为核心的管理岗位",
+                "description": "在小团队或业务单元中承担管理角色，既抓结果，又重视团队氛围与人才成长。",
+                "examples": [
+                  "团队负责人",
+                  "项目经理",
+                  "门店 / 校区负责人等一线管理者"
+                ]
+              }
+            ],
+            "outro": "更重要的不是职位名称，而是这份工作是否允许你：与人深度互动、传递价值、推动改变，并看到实际的成长与回馈。"
+          },
+          "sort_order": 70,
+          "is_enabled": true
+        },
+        {
+          "section_key": "career.upgrade_suggestions",
+          "render_variant": "bullets",
+          "body_md": "对 ENFJ-T 来说，职业上的“天花板”，往往不是能力，而是边界感与自我照顾能力。想要走得更远，你需要学会在温柔之外，加上一点锋利的清晰。\n\n可以把下面这几条，当作你在职场中的“小公式”。",
+          "body_html": null,
+          "payload_json": {
+            "items": [
+              {
+                "title": "温柔 ≠ 好说话",
+                "body": "在给出支持之前，先说清自己的边界：“这部分我可以帮，那一块需要你自己承担。” 当你敢于划清界限时，别人反而会更尊重你的付出。"
+              },
+              {
+                "title": "团队和谐 = 问题能说开 × 分工够清楚",
+                "body": "不要把“让大家不吵架”当成唯一目标。更重要的是：让问题能被提出来，让责任被说清楚。你可以在复盘中刻意加入“合作体验”与“沟通质量”两个维度。"
+              },
+              {
+                "title": "职业成就感 = 价值观匹配度 × 可见成果",
+                "body": "为自己设立“价值账本”：记录你帮助到谁、解决了什么问题、带来了什么改变。定期整理这些故事，在汇报和沟通中用事实呈现出来。"
+              },
+              {
+                "title": "可持续输出 = 节奏感 × 休息权",
+                "body": "给自己设定不被打扰的休息时间，比如每周一个固定的“充电夜晚”。把这视为工作的一部分，而不是奢侈的奖励。只有把自己照顾好，你才能长久地照顾别人。"
+              }
+            ]
+          },
+          "sort_order": 80,
+          "is_enabled": true
+        },
+        {
+          "section_key": "growth.summary",
+          "render_variant": "rich_text",
+          "body_md": "对 ENFJ-T 来说，成长从来不仅是“多学一点技能”，而是“在帮助别人的同时，不要丢失自己”。你既渴望自我提升，又害怕让别人失望，这让你的成长之路既充满动力，也充满拉扯。\n\n这一章节，会从你的强项、短板，以及能量来源与消耗点几个角度，帮你看清自己的成长路径。",
+          "body_html": null,
+          "payload_json": null,
+          "sort_order": 90,
+          "is_enabled": true
+        },
+        {
+          "section_key": "growth.strengths",
+          "render_variant": "bullets",
+          "body_md": null,
+          "body_html": null,
+          "payload_json": {
+            "items": [
+              {
+                "title": "致力于自我提升",
+                "body": "你很少选择“躺平”，更习惯给自己设定成长目标，希望自己在专业、视野和人格上都不断升级。"
+              },
+              {
+                "title": "乐于接受新体验",
+                "body": "只要事情对人有益、又有一点挑战，你通常愿意先试试看。这让你累积了丰富的人生阅历与故事。"
+              },
+              {
+                "title": "保持乐观心态",
+                "body": "即使现实不完美，你依然倾向于看到其中的可能性与改进空间，也愿意把这种乐观传递给身边人。"
+              },
+              {
+                "title": "善于自我反思",
+                "body": "你会经常回看自己的行为、动机与影响，思考“下次我能不能做得更好”，这让你拥有很强的自我修正能力。"
+              }
+            ]
+          },
+          "sort_order": 100,
+          "is_enabled": true
+        },
+        {
+          "section_key": "growth.weaknesses",
+          "render_variant": "bullets",
+          "body_md": null,
+          "body_html": null,
+          "payload_json": {
+            "items": [
+              {
+                "title": "期望过高，容易失望",
+                "body": "你容易以理想化的标准要求自己和他人，一旦现实和期待有落差，就会对自己或他人感到失望。"
+              },
+              {
+                "title": "迷失于他人期待",
+                "body": "在长期迎合他人需求的过程中，你可能逐渐分不清：哪些是自己真正想要的，哪些只是“别人希望我成为的样子”。"
+              },
+              {
+                "title": "忽视休息与节奏",
+                "body": "你习惯在忙碌中不断加码，很难主动停下来休息。直到身心出现明显疲惫信号时，才意识到自己透支太久。"
+              },
+              {
+                "title": "对自己苛刻",
+                "body": "你常常把“还可以更好”当成默认前提，却很少肯定自己已经完成的部分。这会在无形中消耗你的自信与安全感。"
+              }
+            ]
+          },
+          "sort_order": 110,
+          "is_enabled": true
+        },
+        {
+          "section_key": "growth.motivators",
+          "render_variant": "premium_teaser",
+          "body_md": "真实的正向反馈、看见他人的成长、以及被信任地托付重要任务，都会让你感觉“我做这些很值得”。你越能把工作与内在价值感连在一起，就越容易保持高能量。",
+          "body_html": null,
+          "payload_json": {
+            "teaser": "真实的正向反馈、看见他人的成长、以及被信任地托付重要任务，都会让你感觉“我做这些很值得”。你越能把工作与内在价值感连在一起，就越容易保持高能量。",
+            "is_premium": true
+          },
+          "sort_order": 120,
+          "is_enabled": true
+        },
+        {
+          "section_key": "growth.drainers",
+          "render_variant": "premium_teaser",
+          "body_md": "重复而毫无意义的任务、长期得不到回应的付出、以及冲突久拖不决的关系，会一点点抽走你的热情。如果你发现自己越来越容易烦躁、想要逃离，很可能就是能量被悄悄掏空了。",
+          "body_html": null,
+          "payload_json": {
+            "teaser": "重复而毫无意义的任务、长期得不到回应的付出、以及冲突久拖不决的关系，会一点点抽走你的热情。如果你发现自己越来越容易烦躁、想要逃离，很可能就是能量被悄悄掏空了。",
+            "is_premium": true
+          },
+          "sort_order": 130,
+          "is_enabled": true
+        },
+        {
+          "section_key": "relationships.summary",
+          "render_variant": "rich_text",
+          "body_md": "在关系世界里，你更像一位“温柔的教练 + 同行者”。你愿意倾听、理解、安慰，也愿意陪伴对方一起成长、一起规划更好的未来。\n\n你最在意的，并不是关系看起来有多甜蜜，而是：我们能不能好好沟通？我们有没有在朝同一个方向前进？在这个过程中，我有没有也被看见、被在乎？",
+          "body_html": null,
+          "payload_json": null,
+          "sort_order": 140,
+          "is_enabled": true
+        },
+        {
+          "section_key": "relationships.strengths",
+          "render_variant": "bullets",
+          "body_md": null,
+          "body_html": null,
+          "payload_json": {
+            "items": [
+              {
+                "title": "容易敞开心扉",
+                "body": "你愿意分享自己的感受和故事，也鼓励对方说出真实想法，这让关系更容易建立起深层连接。"
+              },
+              {
+                "title": "高度关注对方需求",
+                "body": "你会本能地观察对方的情绪变化，提前准备他们可能需要的帮助或惊喜，让对方感到“被惦记着”。"
+              },
+              {
+                "title": "乐于推动共同成长",
+                "body": "在你看来，好的关系不只是陪伴，而是互相拉着往前走。你愿意一起制定计划、一起尝试新体验。"
+              },
+              {
+                "title": "善于修补裂痕",
+                "body": "当出现误会或冲突时，你通常愿意先冷静下来，寻找双方都能接受的说法和方案，而不是让问题僵在那里。"
+              }
+            ]
+          },
+          "sort_order": 150,
+          "is_enabled": true
+        },
+        {
+          "section_key": "relationships.weaknesses",
+          "render_variant": "bullets",
+          "body_md": null,
+          "body_html": null,
+          "payload_json": {
+            "items": [
+              {
+                "title": "害怕让别人失望",
+                "body": "你可能因为不想让对方难过，而不敢表达真实需求或负面感受，久而久之，你的委屈会悄悄积累。"
+              },
+              {
+                "title": "压抑自己的需要",
+                "body": "你更习惯先问“你想要什么”，却很少认真想过“我到底想要什么”，这会让你在关系中逐渐失去自我感。"
+              },
+              {
+                "title": "过度介入他人问题",
+                "body": "为了帮助对方，你有时会接手并本该由对方自己承担的责任，反而让对方停在原地，也让自己压力倍增。"
+              },
+              {
+                "title": "难以设定界限",
+                "body": "你不想显得冷漠，因此常常把底线往后挪一点点。等到实在受不了时，关系已经积累了很多说不清的怨气。"
+              }
+            ]
+          },
+          "sort_order": 160,
+          "is_enabled": true
+        },
+        {
+          "section_key": "relationships.rel_advantages",
+          "render_variant": "premium_teaser",
+          "body_md": "只要关系是健康的，你会成为周围人非常重要的“情绪基地”和“成长助推器”。你能让人感到被理解、被尊重、被看重，也能在关键时刻给予鼓励和方向。",
+          "body_html": null,
+          "payload_json": {
+            "teaser": "只要关系是健康的，你会成为周围人非常重要的“情绪基地”和“成长助推器”。你能让人感到被理解、被尊重、被看重，也能在关键时刻给予鼓励和方向。",
+            "is_premium": true
+          },
+          "sort_order": 170,
+          "is_enabled": true
+        },
+        {
+          "section_key": "relationships.rel_risks",
+          "render_variant": "premium_teaser",
+          "body_md": "当你长期处在“不被看见”“只有我在付出”的关系模式里时，你的能量会被迅速消耗，甚至会开始怀疑自己的价值。学会识别这些危险信号，并适时抽身，对 ENFJ-T 来说非常重要。",
+          "body_html": null,
+          "payload_json": {
+            "teaser": "当你长期处在“不被看见”“只有我在付出”的关系模式里时，你的能量会被迅速消耗，甚至会开始怀疑自己的价值。学会识别这些危险信号，并适时抽身，对 ENFJ-T 来说非常重要。",
+            "is_premium": true
+          },
+          "sort_order": 180,
+          "is_enabled": true
+        }
+      ],
+      "seo_overrides": {
+        "seo_title": "ENFJ-T 主人公型",
+        "seo_description": "你像一盏不刺眼的灯：愿意走到人群中央，又始终在照亮别人。你真心相信——只要一个人被好好理解、被温柔对待，他就会变得更好，而你愿意做那个先伸手的人。",
+        "canonical_url": null,
+        "og_title": "ENFJ-T 温柔引路人",
+        "og_description": "你像一盏不刺眼的灯：愿意走到人群中央，又始终在照亮别人。你真心相信——只要一个人被好好理解、被温柔对待，他就会变得更好，而你愿意做那个先伸手的人。",
+        "og_image_url": null,
+        "twitter_title": "ENFJ-T 温柔引路人",
+        "twitter_description": "你像一盏不刺眼的灯：愿意走到人群中央，又始终在照亮别人。你真心相信——只要一个人被好好理解、被温柔对待，他就会变得更好，而你愿意做那个先伸手的人。",
+        "twitter_image_url": null,
+        "robots": null,
+        "jsonld_overrides_json": null
+      }
+    },
+    {
+      "runtime_type_code": "ENFP-A",
+      "canonical_type_code": "ENFP",
+      "variant_code": "A",
+      "is_published": true,
+      "published_at": "2026-03-17T00:00:00Z",
+      "profile_overrides": {
+        "type_name": "活动家型",
+        "nickname": "灵感点火者",
+        "rarity_text": "约 6–8%",
+        "keywords_json": [
+          "好奇心",
+          "创意",
+          "热情",
+          "共情力",
+          "自我表达",
+          "自由探索"
+        ],
+        "hero_summary_md": "你像一束突然闯进房间的阳光：热烈、鲜活、充满故事。你真心相信这个世界还可以更有趣一点、更温柔一点，而你愿意用创意、热情和行动，点燃身边人的灵感与勇气。",
+        "hero_summary_html": null
+      },
+      "section_overrides": [
+        {
+          "section_key": "letters_intro",
+          "render_variant": "letters_intro",
+          "body_md": null,
+          "body_html": null,
+          "payload_json": {
+            "headline": "外向 · 直觉 · 情感 · 感知 · 自信型｜用创意和热情点燃世界的“灵感点火者”",
+            "letters": [
+              {
+                "letter": "E",
+                "title": "外向（E）",
+                "description": "让你在真实的交流和碰撞中获得能量。和人聊天、一起脑暴、边走边聊的深夜散步，远比一个人关在房间里更能让你“电量拉满”。"
+              },
+              {
+                "letter": "N",
+                "title": "直觉（N）",
+                "description": "让你本能地放大“可能性”和“想象力”。别人看到的是当下，你看到的是：如果我们这样试试，会不会有 completely different 的结果？"
+              },
+              {
+                "letter": "F",
+                "title": "情感（F）",
+                "description": "让你在做决定时，会问一句：“这件事，对人好不好？”你很难对冷漠、功利的选择完全心安，更愿意让行动与自己的价值观对齐。"
+              },
+              {
+                "letter": "P",
+                "title": "感知（P）",
+                "description": "让你更享受“探索过程”，而不是被死板计划框住。你喜欢给人生保留弹性和惊喜空间，允许自己在变化中及时调整航向。"
+              },
+              {
+                "letter": "A",
+                "title": "自信型（-A）",
+                "description": "让你面对不确定时，内心相对笃定，相信“先试试看总比什么都不做好”。你不太会被小小的质疑击垮，更愿意带着乐观一路向前。"
+              }
+            ]
+          },
+          "sort_order": 10,
+          "is_enabled": true
+        },
+        {
+          "section_key": "overview",
+          "render_variant": "rich_text",
+          "body_md": "在费马心理的逻辑模型里，ENFP-A 往往被视作“自带光源的灵感点火者”。你外向、敏锐、富有想象力，擅长在平凡场景里挖掘出有趣的角度和新的可能。\n\n对你来说，最理想的生活状态是：有一些正在进行的冒险计划，有一群可以随时分享灵感的人，还有足够的空间去试错、探索和重新定义路径。\n\n当环境变得过于僵化、只讲规则不讲人、只看结果不问意义时，你会本能地想要松动一点什么——抛出一个新点子、开启一场新尝试，或者带着大家去看看“除此之外，我们还能怎么活”。",
+          "body_html": null,
+          "payload_json": null,
+          "sort_order": 20,
+          "is_enabled": true
+        },
+        {
+          "section_key": "trait_overview",
+          "render_variant": "trait_dimension_grid",
+          "body_md": "建议与小程序中 5 条维度进度条搭配展示：外向 / 内向｜天马行空 / 求真务实｜情感细腻 / 理性思考｜运筹帷幄 / 随机应变｜情绪易波动 / 自信果断。",
+          "body_html": null,
+          "payload_json": {
+            "summary": "建议与小程序中 5 条维度进度条搭配展示：外向 / 内向｜天马行空 / 求真务实｜情感细腻 / 理性思考｜运筹帷幄 / 随机应变｜情绪易波动 / 自信果断。",
+            "dimensions": [
+              {
+                "id": "EI",
+                "name": "外向倾向",
+                "label": "外向倾向",
+                "axis_left": "外向",
+                "axis_right": "内向",
+                "summary": "明显偏外向",
+                "description": "你很难在长时间的“零交流模式”下保持兴奋。新朋友、新话题、新场景，都会让你瞬间提起精神。对你来说，世界越大，故事越多，生活就越有能量。"
+              },
+              {
+                "id": "SN",
+                "name": "心智模式",
+                "label": "心智模式",
+                "axis_left": "天马行空",
+                "axis_right": "求真务实",
+                "summary": "强烈偏“天马行空”",
+                "description": "你很擅长发散和联想，经常一个点就能串起一整套创意方案。你当然也能落地执行，但如果一件事完全没有想象空间，只剩下机械流程，你会迅速失去兴趣。"
+              },
+              {
+                "id": "TF",
+                "name": "情绪天性",
+                "label": "情绪天性",
+                "axis_left": "情感细腻",
+                "axis_right": "理性思考",
+                "summary": "偏“情感细腻”",
+                "description": "你对人和关系非常敏感，能快速感知一个场域里的温度变化。你希望自己带来的不是压力，而是轻松、被理解和被接纳的感觉。"
+              },
+              {
+                "id": "JP",
+                "name": "应对方式",
+                "label": "应对方式",
+                "axis_left": "运筹帷幄",
+                "axis_right": "随机应变",
+                "summary": "偏“随机应变”",
+                "description": "你更享受边走边看、随时调整的状态。计划对你来说不是“必须严格执行的约束”，而是“可以随时重写的草稿”。你乐于根据新信息改变策略，而不是死守旧方案。"
+              },
+              {
+                "id": "AT",
+                "name": "身份特征",
+                "label": "身份特征",
+                "axis_left": "情绪易波动",
+                "axis_right": "自信果断",
+                "summary": "略偏“自信果断”",
+                "description": "作为自信型 ENFP-A，你会偶尔纠结，但整体更倾向于相信“只要我全力以赴，结果就不会太差”。你通常能较快从小挫折里恢复，用一句“那再试试别的办法”继续向前。"
+              }
+            ]
+          },
+          "sort_order": 30,
+          "is_enabled": true
+        },
+        {
+          "section_key": "career.summary",
+          "render_variant": "rich_text",
+          "body_md": "你的职业选择，往往围绕三个核心要素：自由度、创意空间和人与人之间的真实连接。只要这三点能被满足，你就有机会把工作做成一场持续的、有意义的探索。\n\n高度流程化、完全按部就班、几乎没有人味的工作环境，会迅速耗尽你的热情；相反，那些鼓励创新表达、愿意听你讲故事、允许你“折腾一点新东西”的地方，能让你保持长期高能。",
+          "body_html": null,
+          "payload_json": null,
+          "sort_order": 40,
+          "is_enabled": true
+        },
+        {
+          "section_key": "career.advantages",
+          "render_variant": "bullets",
+          "body_md": null,
+          "body_html": null,
+          "payload_json": {
+            "items": [
+              {
+                "title": "创意爆发力强",
+                "body": "你擅长从不同领域“串门”，把看似无关的点连接成新点子。无论是内容策划、活动创意还是产品包装，只要给你一个主题，你就能迅速抛出一堆有趣的可能。"
+              },
+              {
+                "title": "乐于激励与带动他人",
+                "body": "你很会用语言和情绪点燃团队士气，让大家对一件事重新产生期待感。这种激励并非空洞鸡汤，而是基于你真心相信“我们可以做出点不一样的东西”。"
+              },
+              {
+                "title": "适应变化与不确定",
+                "body": "计划改变、方向调整、项目临时重组，对很多人来说是打击，但对你而言往往是一种“新的冒险”。你能快速找到切入点，并帮助团队调适心态。"
+              },
+              {
+                "title": "共情力 + 表达力兼具",
+                "body": "你既能感知用户 / 同事 / 伙伴的真实需求，又有能力把这些感受转化为文字、画面或方案，帮助团队看见“人真正想要的东西”。"
+              }
+            ]
+          },
+          "sort_order": 50,
+          "is_enabled": true
+        },
+        {
+          "section_key": "career.weaknesses",
+          "render_variant": "bullets",
+          "body_md": null,
+          "body_html": null,
+          "payload_json": {
+            "items": [
+              {
+                "title": "容易被新鲜感带走注意力",
+                "body": "一旦项目进入重复执行阶段、创意空间变少，你的热情可能明显下滑。如果缺乏结构和自律，你可能在“开头很燃、中途松散”的循环里打转。"
+              },
+              {
+                "title": "抗拒过度细节与繁杂流程",
+                "body": "繁琐的报表、冗长的审批、多层级的流程，会让你感到被束缚。若没有支持你的人一起处理细节，你的好点子可能难以完全落地。"
+              },
+              {
+                "title": "容易高估自己的精力与时间",
+                "body": "你常常对很多机会都说“好”，一口气接太多项目，结果在期限逼近时感到焦虑与压力，只能用高强度赶工来填补前期的松散。"
+              },
+              {
+                "title": "不擅长在僵化文化中长期忍耐",
+                "body": "如果一个组织只在乎结果、不允许质疑、不鼓励创新，你会很难长久待下去。与其说你“不够稳定”，不如说你更忠于自己认同的价值观。"
+              }
+            ]
+          },
+          "sort_order": 60,
+          "is_enabled": true
+        },
+        {
+          "section_key": "career.preferred_roles",
+          "render_variant": "preferred_role_list",
+          "body_md": null,
+          "body_html": null,
+          "payload_json": {
+            "intro": "下面这些并不是唯一适合 ENFP-A 的工作，只是更容易让你感到“有意思、值得、又有发挥空间”的几类方向，可以当作职业探索的参考清单。",
+            "groups": [
+              {
+                "group_title": "创意与内容表达相关",
+                "description": "可以持续讲故事、产出新点子的岗位。",
+                "examples": [
+                  "内容策划、品牌故事撰写、新媒体运营",
+                  "短视频 / 播客 / 自媒体创作者",
+                  "广告创意、文案、视觉 / 活动策划"
+                ]
+              },
+              {
+                "group_title": "人与成长相关",
+                "description": "陪伴他人探索、成长与改变的领域。",
+                "examples": [
+                  "教育培训、创新课堂设计、工作坊主理人",
+                  "教练、咨询、职业发展辅导",
+                  "成长型社群运营、学习项目策划"
+                ]
+              },
+              {
+                "group_title": "创新与创业场景",
+                "description": "允许你“边做边想”，不断试错和迭代的空间。",
+                "examples": [
+                  "初创公司多面手 / 项目发起人",
+                  "产品体验官、用户研究与社区共创",
+                  "社会创新、跨界合作项目负责人"
+                ]
+              },
+              {
+                "group_title": "对外沟通与连接角色",
+                "description": "需要你不断结识新的人、建立新的连接。",
+                "examples": [
+                  "商务拓展、合作伙伴关系维护",
+                  "公关、公关活动执行、线下社群运营",
+                  "需要大量沟通与协调的项目 / 活动统筹"
+                ]
+              }
+            ],
+            "outro": "真正适合你的工作，往往同时具备几个特征：可以结识多样的人、可以讲好故事、可以不断尝试新方向，并且你能感觉到——自己的存在，正在让一些事情慢慢变好。"
+          },
+          "sort_order": 70,
+          "is_enabled": true
+        },
+        {
+          "section_key": "career.upgrade_suggestions",
+          "render_variant": "bullets",
+          "body_md": "对 ENFP-A 来说，“天赋上限”往往不在创意，而在于：能否把灵感持续转化为稳定产出。学会为自己的热情搭建一个可持续的结构，是你在职场里升级的关键一步。\n\n你可以把下面这些建议，当成关于职业发展的几个小公式。",
+          "body_html": null,
+          "payload_json": {
+            "items": [
+              {
+                "title": "灵感价值 = 点子数量 × 落地比例",
+                "body": "你并不缺点子，真正决定职业成就的是“能被执行到什么程度”。为每一个重要创意选出 1–2 个最关键的落地动作，并为它们设定清晰的截止时间。"
+              },
+              {
+                "title": "自由度 = 基础稳定 × 可控弹性",
+                "body": "你需要一定的自由度，但完全没有边界的自由会让你分散精力。先确保基本生活与核心项目稳定，然后再为自己预留“探索时间”，去尝试那些有潜力的新方向。"
+              },
+              {
+                "title": "影响力 = 真诚表达 × 持续输出",
+                "body": "你天生适合用故事、内容、作品和他人连接。选择一个你乐于长期使用的表达载体（文字 / 视频 / 分享会等），坚持输出，会让你的影响力远超你的想象。"
+              },
+              {
+                "title": "不被消耗 = 边界感 × 项目筛选",
+                "body": "对项目说“是”之前，问自己两个问题：1）这件事是不是和我在乎的价值有关？2）我是否真的有精力做好？当你学会对不合适的机会说“不”，你会发现自己对真正重要的事更有热情。"
+              }
+            ]
+          },
+          "sort_order": 80,
+          "is_enabled": true
+        },
+        {
+          "section_key": "growth.summary",
+          "render_variant": "rich_text",
+          "body_md": "对 ENFP-A 来说，成长不是把自己变成“更听话、更标准”的样子，而是在保留好奇与热情的前提下，学会更稳定、更持续地发挥天赋。\n\n这一部分，会从你的强项与短板出发，帮你更清晰地看到：怎样设计一条既不压抑自己、又能持续进步的成长路径。",
+          "body_html": null,
+          "payload_json": null,
+          "sort_order": 90,
+          "is_enabled": true
+        },
+        {
+          "section_key": "growth.strengths",
+          "render_variant": "bullets",
+          "body_md": null,
+          "body_html": null,
+          "payload_json": {
+            "items": [
+              {
+                "title": "天生的故事感与洞察力",
+                "body": "你很擅长从日常细节中提炼出有趣、有意义的故事视角，这种能力让你在表达、创作和沟通中非常有优势。"
+              },
+              {
+                "title": "对新事物保持高敏感度",
+                "body": "你能快速捕捉到趋势、风向和新机会，比别人更早嗅到变化，并愿意第一个尝试。"
+              },
+              {
+                "title": "乐观而有韧性",
+                "body": "即使遇到挫折，你也往往能从中找到一点好笑或有趣的部分，带着“那就换个姿势再来”的态度继续前进。"
+              },
+              {
+                "title": "愿意为热爱的事投入",
+                "body": "只要你真心觉得一件事“值得”，你会愿意花很多时间琢磨、打磨、尝试和优化，这种投入一旦找到对的方向，能带来极高的成长速度。"
+              }
+            ]
+          },
+          "sort_order": 100,
+          "is_enabled": true
+        },
+        {
+          "section_key": "growth.weaknesses",
+          "render_variant": "bullets",
+          "body_md": null,
+          "body_html": null,
+          "payload_json": {
+            "items": [
+              {
+                "title": "容易被当下情绪牵着走",
+                "body": "当你对一件事失去兴趣时，很难强迫自己继续坚持，这可能导致一些本可以做出成绩的方向被提前放弃。"
+              },
+              {
+                "title": "难以抵抗“所有都很有趣”的诱惑",
+                "body": "你对很多事情都真心感兴趣，但时间与精力有限。当你同时展开太多尝试时，很难在某一个领域深入扎根。"
+              },
+              {
+                "title": "缺乏节奏感的自我管理",
+                "body": "你更习惯凭感觉工作，如果没有外部节奏或合作伙伴，容易出现“前面拖延，后面爆肝”的极端状态。"
+              },
+              {
+                "title": "容易忽略长期规划",
+                "body": "你倾向于关注“现在想做什么”，而不是“未来三到五年要走到哪里”。这会让你一时很精彩，却难以积累成系统性的成果。"
+              }
+            ]
+          },
+          "sort_order": 110,
+          "is_enabled": true
+        },
+        {
+          "section_key": "growth.motivators",
+          "render_variant": "premium_teaser",
+          "body_md": "真实的共鸣感、被看见的创意、以及“因为你，让别人也敢去尝试”的反馈，都是你的强力燃料。当你感觉自己在用独特的方式影响世界时，你会自然进入高能区。",
+          "body_html": null,
+          "payload_json": {
+            "teaser": "真实的共鸣感、被看见的创意、以及“因为你，让别人也敢去尝试”的反馈，都是你的强力燃料。当你感觉自己在用独特的方式影响世界时，你会自然进入高能区。",
+            "is_premium": true
+          },
+          "sort_order": 120,
+          "is_enabled": true
+        },
+        {
+          "section_key": "growth.drainers",
+          "render_variant": "premium_teaser",
+          "body_md": "被要求机械执行、长期得不到回应的输出、以及被迫按一个你根本不认同的价值体系生活，会让你慢慢“失去颜色”。当你开始频繁想要逃离，很可能就是能量被耗尽的信号。",
+          "body_html": null,
+          "payload_json": {
+            "teaser": "被要求机械执行、长期得不到回应的输出、以及被迫按一个你根本不认同的价值体系生活，会让你慢慢“失去颜色”。当你开始频繁想要逃离，很可能就是能量被耗尽的信号。",
+            "is_premium": true
+          },
+          "sort_order": 130,
+          "is_enabled": true
+        },
+        {
+          "section_key": "relationships.summary",
+          "render_variant": "rich_text",
+          "body_md": "在人际世界里，你像一个移动的“氛围发生器”：带着故事、热情和真诚靠近别人，也希望对方能以真实、开放的状态回应你。\n\n你在意的不是“关系看上去有多体面”，而是：我们能不能自在地做自己？我们有没有在一起长出新的可能？在这段关系里，我的热情有没有被保护，而不是被消耗？",
+          "body_html": null,
+          "payload_json": null,
+          "sort_order": 140,
+          "is_enabled": true
+        },
+        {
+          "section_key": "relationships.strengths",
+          "render_variant": "bullets",
+          "body_md": null,
+          "body_html": null,
+          "payload_json": {
+            "items": [
+              {
+                "title": "善于打破尴尬和距离感",
+                "body": "你能很快找到共同话题，让原本拘谨的场面变得轻松自然。很多人会觉得：和你在一起，不用刻意“端着”。"
+              },
+              {
+                "title": "真诚且热情地支持对方",
+                "body": "当你在乎一个人时，会非常愿意为 TA 加油打气、提供资源和创意，甚至比对方更相信 TA 能做到。"
+              },
+              {
+                "title": "乐于制造惊喜与仪式感",
+                "body": "你很在意情绪氛围，会主动创造一些有趣的小瞬间——特别的消息、突然的约见、用心准备的小礼物，让关系一直保持新鲜。"
+              },
+              {
+                "title": "接纳差异，欣赏独特性",
+                "body": "你不希望别人变成“标准答案”，反而会被那些有点怪、有点不同、但很真实的人吸引。你擅长让别人觉得“这样也很好”。"
+              }
+            ]
+          },
+          "sort_order": 150,
+          "is_enabled": true
+        },
+        {
+          "section_key": "relationships.weaknesses",
+          "render_variant": "bullets",
+          "body_md": null,
+          "body_html": null,
+          "payload_json": {
+            "items": [
+              {
+                "title": "起初很热烈，后续容易疲惫",
+                "body": "在关系初期，你往往投入很多时间与热情，但如果长期缺乏深度连接或共同成长，你会逐渐失去动力，却又不太知道怎么体面地抽身。"
+              },
+              {
+                "title": "难以稳定地表达负面情绪",
+                "body": "你更习惯用幽默和转移话题来化解不适，而不是直接说“我其实不开心”。这会让一些重要的情绪需求一直被搁置。"
+              },
+              {
+                "title": "过度承担“带动气氛”的角色",
+                "body": "你很怕场面冷掉，于是常常自发担任“搞气氛的人”。久而久之，如果对方没有回应，你会感到被消耗和失衡。"
+              },
+              {
+                "title": "害怕被别人贴上“不稳定”的标签",
+                "body": "当你感觉关系不再适合自己时，你会在理智的“我想离开”和情感的“我不想伤害他人”之间摇摆，这种拉扯会消耗大量能量。"
+              }
+            ]
+          },
+          "sort_order": 160,
+          "is_enabled": true
+        },
+        {
+          "section_key": "relationships.rel_advantages",
+          "render_variant": "premium_teaser",
+          "body_md": "在健康的关系里，你是那个为大家带来新鲜感、灵感和情绪支持的人。你能让身边的人更敢于做自己，也更敢去尝试那些曾经不敢想象的生活方式。",
+          "body_html": null,
+          "payload_json": {
+            "teaser": "在健康的关系里，你是那个为大家带来新鲜感、灵感和情绪支持的人。你能让身边的人更敢于做自己，也更敢去尝试那些曾经不敢想象的生活方式。",
+            "is_premium": true
+          },
+          "sort_order": 170,
+          "is_enabled": true
+        },
+        {
+          "section_key": "relationships.rel_risks",
+          "render_variant": "premium_teaser",
+          "body_md": "当你长期处在“只有我在付出创意和热情”的关系模式中时，你会慢慢消耗掉对人和世界的信任感。学会识别单向索取的关系，并允许自己离开，是 ENFP-A 很重要的一课。",
+          "body_html": null,
+          "payload_json": {
+            "teaser": "当你长期处在“只有我在付出创意和热情”的关系模式中时，你会慢慢消耗掉对人和世界的信任感。学会识别单向索取的关系，并允许自己离开，是 ENFP-A 很重要的一课。",
+            "is_premium": true
+          },
+          "sort_order": 180,
+          "is_enabled": true
+        }
+      ],
+      "seo_overrides": {
+        "seo_title": "ENFP-A 活动家型",
+        "seo_description": "你像一束突然闯进房间的阳光：热烈、鲜活、充满故事。你真心相信这个世界还可以更有趣一点、更温柔一点，而你愿意用创意、热情和行动，点燃身边人的灵感与勇气。",
+        "canonical_url": null,
+        "og_title": "ENFP-A 灵感点火者",
+        "og_description": "你像一束突然闯进房间的阳光：热烈、鲜活、充满故事。你真心相信这个世界还可以更有趣一点、更温柔一点，而你愿意用创意、热情和行动，点燃身边人的灵感与勇气。",
+        "og_image_url": null,
+        "twitter_title": "ENFP-A 灵感点火者",
+        "twitter_description": "你像一束突然闯进房间的阳光：热烈、鲜活、充满故事。你真心相信这个世界还可以更有趣一点、更温柔一点，而你愿意用创意、热情和行动，点燃身边人的灵感与勇气。",
+        "twitter_image_url": null,
+        "robots": null,
+        "jsonld_overrides_json": null
+      }
+    },
+    {
+      "runtime_type_code": "ENFP-T",
+      "canonical_type_code": "ENFP",
+      "variant_code": "T",
+      "is_published": true,
+      "published_at": "2026-03-17T00:00:00Z",
+      "profile_overrides": {
+        "type_name": "竞选型",
+        "nickname": "灵感发电机",
+        "rarity_text": "约 6–8%",
+        "keywords_json": [
+          "创意",
+          "热情",
+          "自由",
+          "感染力",
+          "共情",
+          "自我探索"
+        ],
+        "hero_summary_md": "你像一束忽然点亮的焰火：来的时候谁都能感受到气氛被点燃，走后还会留下一点余温和灵感。你天生对新鲜事物和人心故事充满好奇，总想多看一点世界、多体验一点人生。只要想到“也许可以不一样”，你就会忍不住去尝试。",
+        "hero_summary_html": null
+      },
+      "section_overrides": [
+        {
+          "section_key": "letters_intro",
+          "render_variant": "letters_intro",
+          "body_md": null,
+          "body_html": null,
+          "payload_json": {
+            "headline": "外向 · 直觉 · 情感 · 感知 · 动荡型｜把灵感变成链接，把热情洒向人群的“灵感发电机”",
+            "letters": [
+              {
+                "letter": "E",
+                "title": "外向（E）",
+                "description": "让你在真实的互动场景中回血——聚会、聊天、头脑风暴都会让你兴奋。你喜欢和各种类型的人搭上线，交换故事和点子。"
+              },
+              {
+                "letter": "N",
+                "title": "直觉（N）",
+                "description": "让你总在捕捉“更大的可能性”。别人看到的是眼前的事实，你看到的是：如果换一种方式，会不会更有趣、更有意义？"
+              },
+              {
+                "letter": "F",
+                "title": "情感（F）",
+                "description": "让你在选择时，会多问一句：“这样真的符合我的感觉吗？会不会伤到谁？”你重视氛围、价值观和真实性。"
+              },
+              {
+                "letter": "P",
+                "title": "感知（P）",
+                "description": "让你偏爱开放式选项，而不是被固定在唯一答案上。你享受保留选择、随机应变的自由，不喜欢被死死按在计划里。"
+              },
+              {
+                "letter": "T",
+                "title": "动荡型（-T）",
+                "description": "让你对自己保持高度敏感：兴奋时可以秒变“宇宙最自信”，低落时又会怀疑：“我是不是不够好？”这种波动既放大了你的创造力，也放大了你的不安。"
+              }
+            ]
+          },
+          "sort_order": 10,
+          "is_enabled": true
+        },
+        {
+          "section_key": "overview",
+          "render_variant": "rich_text",
+          "body_md": "在费马心理的逻辑模型里，ENFP-T 常被视作“用热情点燃世界的灵感探索者”。你擅长发现有趣的人、好玩的点子和不一样的路，并且用情绪感染力把大家带进这个“可能更好一点”的世界。\n\n对你来说，最舒服的状态是：有自由选择的空间，有能聊心事的人，还有一些正在发生或即将发生的“新鲜事”。如果生活只剩下重复、流程和不得不完成的任务，你会感到被慢慢掏空。\n\n你的人生追求，从来不只是一条稳定安全的直线，而是“多看一点世界、多探索几种人生可能”。你愿意在还不确定答案的时候，就先迈出那一步——因为你知道，很多答案，只能在行动里长出来。",
+          "body_html": null,
+          "payload_json": null,
+          "sort_order": 20,
+          "is_enabled": true
+        },
+        {
+          "section_key": "trait_overview",
+          "render_variant": "trait_dimension_grid",
+          "body_md": "建议与小程序中 5 条维度进度条搭配展示：外向 / 内向｜天马行空 / 求真务实｜情感细腻 / 理性思考｜运筹帷幄 / 随机应变｜情绪易波动 / 自信果断。",
+          "body_html": null,
+          "payload_json": {
+            "summary": "建议与小程序中 5 条维度进度条搭配展示：外向 / 内向｜天马行空 / 求真务实｜情感细腻 / 理性思考｜运筹帷幄 / 随机应变｜情绪易波动 / 自信果断。",
+            "dimensions": [
+              {
+                "id": "EI",
+                "name": "外向倾向",
+                "label": "外向倾向",
+                "axis_left": "外向",
+                "axis_right": "内向",
+                "summary": "明显偏外向",
+                "description": "你很容易和陌生人聊起来，也习惯在语音、群聊、线下活动里活跃气氛。独处对你来说不是问题，但如果连续几天都“一个人 + 固定环境”，你会明显感觉灵感变少、整个人变闷。"
+              },
+              {
+                "id": "SN",
+                "name": "心智模式",
+                "label": "心智模式",
+                "axis_left": "天马行空",
+                "axis_right": "求真务实",
+                "summary": "强烈偏“天马行空”",
+                "description": "你更擅长从宏观和抽象层面理解世界：一个新闻、一个故事、一句话，都可能触发你脑海里一连串联想。你会说：“如果我们换个思路……” 然后抛出一个让人眼前一亮的点子。"
+              },
+              {
+                "id": "TF",
+                "name": "情绪天性",
+                "label": "情绪天性",
+                "axis_left": "情感细腻",
+                "axis_right": "理性思考",
+                "summary": "偏“情感细腻”",
+                "description": "你对氛围、语气和细微的态度变化很敏锐，容易感受到他人的兴奋、尴尬或低落，并迅速被这种情绪感染。你在乎真诚，也在乎自己有没有被当回事。"
+              },
+              {
+                "id": "JP",
+                "name": "应对方式",
+                "label": "应对方式",
+                "axis_left": "运筹帷幄",
+                "axis_right": "随机应变",
+                "summary": "明显偏“随机应变”",
+                "description": "你更喜欢“先试试再说”的节奏，而不是提前把一切锁死在表格和日程里。计划对你来说是参考而不是枷锁，你需要在变化中调整、在现场发挥中找到感觉。"
+              },
+              {
+                "id": "AT",
+                "name": "身份特征",
+                "label": "身份特征",
+                "axis_left": "情绪易波动",
+                "axis_right": "自信果断",
+                "summary": "偏“情绪易波动”",
+                "description": "当事情顺利、被人认可时，你会非常自信、兴奋，像开了无穷电量；一旦遭遇冷场、误解或拖延，你又会迅速跌入“是不是我不够好”的自我怀疑。这种内在波动，是 ENFP-T 很典型的底色。"
+              }
+            ]
+          },
+          "sort_order": 30,
+          "is_enabled": true
+        },
+        {
+          "section_key": "career.summary",
+          "render_variant": "rich_text",
+          "body_md": "你的职业偏好，往往围绕三个关键词：有趣的人、有意义的事、足够的自由度。只要能在工作中表达自己、结识不同的人、创造新的东西，你就能保持高能量。\n\n长期处在高度程式化、只能“按流程机械执行”的环境里，会让你逐渐丧失热情；你需要的是能“玩起来”的工作，而不是只要“做完就行”的任务。\n\n当一份工作允许你：提出新点子、参与前期策划、和人高频互动、并看到自己的想法真的被采纳和落地时，你会非常有存在感和成就感。",
+          "body_html": null,
+          "payload_json": null,
+          "sort_order": 40,
+          "is_enabled": true
+        },
+        {
+          "section_key": "career.advantages",
+          "render_variant": "bullets",
+          "body_md": null,
+          "body_html": null,
+          "payload_json": {
+            "items": [
+              {
+                "title": "创意和点子源源不断",
+                "body": "你擅长把信息、趋势、人心串联在一起，提出别人没想到但一听就觉得“好像可以试试”的方案，是团队里天然的点子王。"
+              },
+              {
+                "title": "连接人与资源的“中枢”",
+                "body": "你喜欢也擅长认识形形色色的人，能在不同圈层之间搭桥。项目需要合作伙伴、嘉宾、资源时，往往可以先来找你。"
+              },
+              {
+                "title": "表达生动，讲故事能力强",
+                "body": "你能用故事、比喻、情绪张力把理念讲得鲜活有趣，让别人不知不觉被你说服，在宣讲、路演、内容创作等场景格外出彩。"
+              },
+              {
+                "title": "适应变化、快速转场",
+                "body": "面对临时变化、突发情况，你虽然会吐槽，但内心其实有种“现场 improv”的兴奋感。你能够迅速调整状态，找到 B 方案、C 方案。"
+              }
+            ]
+          },
+          "sort_order": 50,
+          "is_enabled": true
+        },
+        {
+          "section_key": "career.weaknesses",
+          "render_variant": "bullets",
+          "body_md": null,
+          "body_html": null,
+          "payload_json": {
+            "items": [
+              {
+                "title": "容易“三分钟热度”",
+                "body": "立项、头脑风暴阶段兴致很高，一旦进入冗长的执行和收尾，你的动力就会明显下降，容易出现拖延或频繁被新点子分散注意力。"
+              },
+              {
+                "title": "不喜欢重复和细碎事务",
+                "body": "长时间处理表格、流程、报销、反复对接细节等工作，会严重消耗你的能量，让你怀疑“我是不是浪费了生命”。"
+              },
+              {
+                "title": "承诺太多，难以全部兑现",
+                "body": "你真心想帮忙，也真心好奇很多项目，于是很容易一口答应太多事情，后期却发现时间、精力跟不上，陷入内疚。"
+              },
+              {
+                "title": "抗拒僵化管理与“因为规定所以这样”",
+                "body": "当你遇到死板且不讲道理的制度或上级时，会迅速失去耐心，很难再对这份工作保持忠诚。你需要的是可以讨论、可以优化的规则，而不是“别问，照做”。"
+              }
+            ]
+          },
+          "sort_order": 60,
+          "is_enabled": true
+        },
+        {
+          "section_key": "career.preferred_roles",
+          "render_variant": "preferred_role_list",
+          "body_md": null,
+          "body_html": null,
+          "payload_json": {
+            "intro": "这些方向并不是 ENFP-T 的唯一选项，但更容易让你感到：发挥了创意、连接了人、也对世界做出了一点点不一样的贡献。",
+            "groups": [
+              {
+                "group_title": "内容与创意相关",
+                "description": "可以自由输出观点、讲故事、玩创意的岗位。",
+                "examples": [
+                  "新媒体运营、内容编辑 / 主理人、自媒体创作者",
+                  "品牌策划、活动策划、广告创意、文案",
+                  "播客 / 视频节目主理人、主持、策划编导"
+                ]
+              },
+              {
+                "group_title": "人际与社群相关",
+                "description": "以“连接人与人”为核心价值的工作。",
+                "examples": [
+                  "社区运营、社群主理人、用户运营",
+                  "客户成功 / 客户关系管理、BD 商务拓展",
+                  "线上线下活动组织者、线下空间运营"
+                ]
+              },
+              {
+                "group_title": "教育与成长领域",
+                "description": "能够陪伴他人探索自我、拓展视野的场景。",
+                "examples": [
+                  "成长类课程讲师、体验式教育工作者",
+                  "青少年营地、国际项目、交换项目等带队老师",
+                  "生涯规划 / 个人发展教练"
+                ]
+              },
+              {
+                "group_title": "多变且边界开放的角色",
+                "description": "可以一人身兼多职，参与产品、内容、运营、活动等多个模块，持续尝试新事物。",
+                "examples": [
+                  "早期创业团队成员",
+                  "创新项目经理",
+                  "实验室型新业务运营"
+                ]
+              }
+            ],
+            "outro": "无论你最终走向哪条路，请记得：你真正需要的，不是一个“看起来稳定”的职位，而是一种能持续表达自我、影响他人、并保持好奇心的工作方式。"
+          },
+          "sort_order": 70,
+          "is_enabled": true
+        },
+        {
+          "section_key": "career.upgrade_suggestions",
+          "render_variant": "bullets",
+          "body_md": "对 ENFP-T 来说，关键不是“更忙”，而是“更聚焦”。当你的创意和热情被集中在少数真正重要的事情上时，你的影响力会远远超过自己想象。\n\n可以把下面这几条，当作你在职场中的小升级公式：",
+          "body_html": null,
+          "payload_json": {
+            "items": [
+              {
+                "title": "创意价值 = 点子数量 × 落地比例",
+                "body": "你不缺点子，缺的是筛选和坚持。每次只选择 1–2 个最重要的想法，给它们完整的生命周期——从立项到复盘，而不是在 10 个想法上平均分配精力。"
+              },
+              {
+                "title": "自由度 = 明确边界 × 自主空间",
+                "body": "与其一昧排斥规则，不如主动争取：你愿意为结果负责，但希望在方法上拥有弹性。提前谈清楚目标和边界，会让你更有安全感，也更有发挥空间。"
+              },
+              {
+                "title": "成就感 = 被看见的贡献 × 自我认可",
+                "body": "建立自己的“成就清单”：记录你推动过哪些改变、影响过哪些人。定期翻看，让大脑记住：你不是在原地打转，而是在持续前进。"
+              },
+              {
+                "title": "不焦虑的多线 = 清晰优先级 × 合理放弃",
+                "body": "你可以同时参与多件事，但一定要为它们排出优先级，并允许自己对一些项目说“不”或“暂缓”。真正的自由，是在选择之后敢于对其他可能性道别。"
+              }
+            ]
+          },
+          "sort_order": 80,
+          "is_enabled": true
+        },
+        {
+          "section_key": "growth.summary",
+          "render_variant": "rich_text",
+          "body_md": "对 ENFP-T 来说，成长既是“变得更强”，也是“更清楚地做自己”。你一方面渴望体验更多可能，一方面又希望找到一个不会后悔的方向——这种拉扯，会伴随你很长一段时间。\n\n这一章节，会从你的强项、短板，以及能量的来源与流失几个角度，帮你更有底地走好自己的成长路线。",
+          "body_html": null,
+          "payload_json": null,
+          "sort_order": 90,
+          "is_enabled": true
+        },
+        {
+          "section_key": "growth.strengths",
+          "render_variant": "bullets",
+          "body_md": null,
+          "body_html": null,
+          "payload_json": {
+            "items": [
+              {
+                "title": "好奇心强，学习速度快",
+                "body": "对你来说，很多知识和技能只要“有趣 + 实用”，你就能很快上手。你擅长从不同领域里“串知识”。"
+              },
+              {
+                "title": "勇于尝试，不怕从零开始",
+                "body": "你对未知有天然的吸引力，愿意在不确定中试错，也因此比很多人更有机会遇见意想不到的机会。"
+              },
+              {
+                "title": "天生的乐观恢复力",
+                "body": "虽然你会焦虑、会自我怀疑，但很少长期沉在谷底。一个灵感、一句鼓励、一段新体验，就可能让你迅速回血。"
+              },
+              {
+                "title": "对自我成长有真诚渴望",
+                "body": "你不是为了“看起来厉害”而成长，而是真心想活得更清醒、更自由。这会驱动你不断阅读、探索、内省。"
+              }
+            ]
+          },
+          "sort_order": 100,
+          "is_enabled": true
+        },
+        {
+          "section_key": "growth.weaknesses",
+          "render_variant": "bullets",
+          "body_md": null,
+          "body_html": null,
+          "payload_json": {
+            "items": [
+              {
+                "title": "害怕错过，容易分心",
+                "body": "你会担心：如果现在只选这一条路，是不是就错过了别的精彩？这种 FOMO（错失恐惧）会让你很难安住在一个长期项目里。"
+              },
+              {
+                "title": "难以持续做“无趣但必要”的事",
+                "body": "只要缺乏意义感和新鲜感，你很难长期维持自律——哪怕你知道这些事情对长期目标很重要。"
+              },
+              {
+                "title": "情绪起伏放大一切感受",
+                "body": "心情好时，你觉得“我可以改变世界”；心情差时，你会怀疑“是不是我哪里都不行”。这种波动容易影响你的判断和选择。"
+              },
+              {
+                "title": "自我定位摇摆不定",
+                "body": "你对很多话题都有兴趣，也有一定能力，于是很难快速回答：“我到底是谁？我真正想成为怎样的人？”"
+              }
+            ]
+          },
+          "sort_order": 110,
+          "is_enabled": true
+        },
+        {
+          "section_key": "growth.motivators",
+          "render_variant": "premium_teaser",
+          "body_md": "新鲜的体验、真诚的连接、被理解和被信任、以及“我的存在让世界有一点点不同”的感觉，都是支撑你持续向前的重要燃料。",
+          "body_html": null,
+          "payload_json": {
+            "teaser": "新鲜的体验、真诚的连接、被理解和被信任、以及“我的存在让世界有一点点不同”的感觉，都是支撑你持续向前的重要燃料。",
+            "is_premium": true
+          },
+          "sort_order": 120,
+          "is_enabled": true
+        },
+        {
+          "section_key": "growth.drainers",
+          "render_variant": "premium_teaser",
+          "body_md": "长期被琐事困住、没有表达空间、想法被反复否定、或被迫维持一段“只剩表面”的关系，会让你慢慢失去光和热，只剩下机械的日常。",
+          "body_html": null,
+          "payload_json": {
+            "teaser": "长期被琐事困住、没有表达空间、想法被反复否定、或被迫维持一段“只剩表面”的关系，会让你慢慢失去光和热，只剩下机械的日常。",
+            "is_premium": true
+          },
+          "sort_order": 130,
+          "is_enabled": true
+        },
+        {
+          "section_key": "relationships.summary",
+          "render_variant": "rich_text",
+          "body_md": "在人际关系的世界里，你像一个自带光圈的旅行同伴：会分享零食和故事，也会在深夜认真听人倾诉。你很少把人当成“功能”，而是真心好奇每个人独特的灵魂。\n\n你最在意的，不是这段关系看起来有多稳定，而是：我们能不能真诚地交流？能不能一起探索更多可能？在这个过程中，我有没有被当作一个独立完整的人来对待？",
+          "body_html": null,
+          "payload_json": null,
+          "sort_order": 140,
+          "is_enabled": true
+        },
+        {
+          "section_key": "relationships.strengths",
+          "render_variant": "bullets",
+          "body_md": null,
+          "body_html": null,
+          "payload_json": {
+            "items": [
+              {
+                "title": "很快拉近心理距离",
+                "body": "你愿意先敞开一点自己，也善于制造轻松的氛围，让别人很快觉得可以放心和你分享真实想法。"
+              },
+              {
+                "title": "真诚且热情",
+                "body": "你不会把“在乎”只挂在嘴边，而是通过记住细节、主动关心、制造小惊喜等方式，让对方感受到被重视。"
+              },
+              {
+                "title": "擅长看见他人潜力",
+                "body": "你常常能看到对方身上还没被自己发现的亮点，并习惯用夸奖、鼓励、资源把这些潜力一点点唤醒。"
+              },
+              {
+                "title": "乐于一起成长和冒险",
+                "body": "对你来说，理想的关系不是互相消耗或原地打转，而是“我们一起多体验一点世界”，你愿意带着对方尝试新事物。"
+              }
+            ]
+          },
+          "sort_order": 150,
+          "is_enabled": true
+        },
+        {
+          "section_key": "relationships.weaknesses",
+          "render_variant": "bullets",
+          "body_md": null,
+          "body_html": null,
+          "payload_json": {
+            "items": [
+              {
+                "title": "容易理想化关系",
+                "body": "在刚进入一段关系或认识一个新朋友时，你可能会迅速在脑海里为对方“加戏”，一旦现实和想象落差过大，就很容易失望甚至抽离。"
+              },
+              {
+                "title": "害怕被束缚",
+                "body": "当你感觉对方控制欲太强、界限不清或不断消耗你的能量时，你会下意识想逃离，哪怕这段关系曾经很重要。"
+              },
+              {
+                "title": "不擅长长期维护常规联络",
+                "body": "你在情绪高点时很投入，但在忙碌或低落阶段，可能会突然“消失一阵”，让对方摸不清你的节奏。"
+              },
+              {
+                "title": "难以表达负面感受",
+                "body": "你怕自己一说出来，气氛就会变差，于是选择用幽默化解、用转移话题代替正面沟通，导致一些问题被长期掩盖。"
+              }
+            ]
+          },
+          "sort_order": 160,
+          "is_enabled": true
+        },
+        {
+          "section_key": "relationships.rel_advantages",
+          "render_variant": "premium_teaser",
+          "body_md": "当你处在被尊重、被理解的关系中时，你会成为对方生命里非常珍贵的存在——既是玩伴，也是倾听者，更是那个总能带来新视角和新体验的人。",
+          "body_html": null,
+          "payload_json": {
+            "teaser": "当你处在被尊重、被理解的关系中时，你会成为对方生命里非常珍贵的存在——既是玩伴，也是倾听者，更是那个总能带来新视角和新体验的人。",
+            "is_premium": true
+          },
+          "sort_order": 170,
+          "is_enabled": true
+        },
+        {
+          "section_key": "relationships.rel_risks",
+          "render_variant": "premium_teaser",
+          "body_md": "如果你总是在“付出很多、难以被理解”和“突然抽离关系”之间循环，久而久之，你会对自己的人际能力产生怀疑。学会设定节奏、说清需求、以及在不合适的关系中适时止损，是 ENFP-T 需要重点修炼的课题。",
+          "body_html": null,
+          "payload_json": {
+            "teaser": "如果你总是在“付出很多、难以被理解”和“突然抽离关系”之间循环，久而久之，你会对自己的人际能力产生怀疑。学会设定节奏、说清需求、以及在不合适的关系中适时止损，是 ENFP-T 需要重点修炼的课题。",
+            "is_premium": true
+          },
+          "sort_order": 180,
+          "is_enabled": true
+        }
+      ],
+      "seo_overrides": {
+        "seo_title": "ENFP-T 竞选型",
+        "seo_description": "你像一束忽然点亮的焰火：来的时候谁都能感受到气氛被点燃，走后还会留下一点余温和灵感。你天生对新鲜事物和人心故事充满好奇，总想多看一点世界、多体验一点人生。只要想到“也许可以不一样”，你就会忍不住去尝试。",
+        "canonical_url": null,
+        "og_title": "ENFP-T 灵感发电机",
+        "og_description": "你像一束忽然点亮的焰火：来的时候谁都能感受到气氛被点燃，走后还会留下一点余温和灵感。你天生对新鲜事物和人心故事充满好奇，总想多看一点世界、多体验一点人生。只要想到“也许可以不一样”，你就会忍不住去尝试。",
+        "og_image_url": null,
+        "twitter_title": "ENFP-T 灵感发电机",
+        "twitter_description": "你像一束忽然点亮的焰火：来的时候谁都能感受到气氛被点燃，走后还会留下一点余温和灵感。你天生对新鲜事物和人心故事充满好奇，总想多看一点世界、多体验一点人生。只要想到“也许可以不一样”，你就会忍不住去尝试。",
+        "twitter_image_url": null,
+        "robots": null,
+        "jsonld_overrides_json": null
+      }
+    },
+    {
+      "runtime_type_code": "ENTJ-A",
+      "canonical_type_code": "ENTJ",
+      "variant_code": "A",
+      "is_published": true,
+      "published_at": "2026-03-17T00:00:00Z",
+      "profile_overrides": {
+        "type_name": "指挥官型",
+        "nickname": "战略掌舵者",
+        "rarity_text": "约 2–3%",
+        "keywords_json": [
+          "战略眼光",
+          "决策力",
+          "效率至上",
+          "目标导向",
+          "体系搭建",
+          "领导力"
+        ],
+        "hero_summary_md": "你像一位站在甲板上的掌舵者：目光始终盯着远方的航线，哪怕海面起风，也会果断下达指令。你相信，世界可以被更高效地运转，而你生来就是那个把愿景变成现实的人。",
+        "hero_summary_html": null
+      },
+      "section_overrides": [
+        {
+          "section_key": "letters_intro",
+          "render_variant": "letters_intro",
+          "body_md": null,
+          "body_html": null,
+          "payload_json": {
+            "headline": "外向 · 直觉 · 理性 · 规划 · 自信型｜擅长统筹全局的“战略掌舵者”",
+            "letters": [
+              {
+                "letter": "E",
+                "title": "外向（E）",
+                "description": "让你习惯站到场景中心，掌控局面、调配资源。多人讨论、决策会议、头脑风暴，都是你最容易进入状态的地方。"
+              },
+              {
+                "letter": "N",
+                "title": "直觉（N）",
+                "description": "让你本能地关注趋势和可能性，而不是只盯着当下。你比别人更早看到“这条路的尽头大概是什么样”，擅长从高维度设计策略。"
+              },
+              {
+                "letter": "T",
+                "title": "理性（T）",
+                "description": "让你在决策时优先考虑逻辑、效率和结果。你会问自己：“这样做，是否最接近目标？成本和收益是否匹配？” 情绪可以被尊重，但不会凌驾于判断之上。"
+              },
+              {
+                "letter": "J",
+                "title": "规划（J）",
+                "description": "让你不满足于随遇而安，而是希望一切“各就各位、有章可循”。你倾向制定时间表、里程碑和标准，推动事情按节奏向前。"
+              },
+              {
+                "letter": "A",
+                "title": "自信型（-A）",
+                "description": "让你在压力下依然保持镇定，很少被情绪左右。你对自己的判断相对笃定，不会因为外界质疑就轻易动摇，这既是你的底气，也是你需要学会柔化的锋芒。"
+              }
+            ]
+          },
+          "sort_order": 10,
+          "is_enabled": true
+        },
+        {
+          "section_key": "overview",
+          "render_variant": "rich_text",
+          "body_md": "在费马心理的逻辑模型里，ENTJ-A 常被视作“战略型执行总指挥”。你既能抬头看远方，又能低头做决策，习惯在复杂局面中迅速抓住关键变量，然后给出清晰的方向和打法。\n\n对你来说，最舒服的状态是：目标明确、信息透明、资源可调配、所有人都知道自己该做什么。当环境混乱、标准模糊、反复低效时，你会本能地站出来重组规则：“不能再这么耗下去了，我们需要一个新方案。”\n\n你的人生追求从来不只是“把分内之事做好”，而是“搭建一个更高效、更有秩序的系统”，让更多人因你的判断和行动而走向更好的结果。",
+          "body_html": null,
+          "payload_json": null,
+          "sort_order": 20,
+          "is_enabled": true
+        },
+        {
+          "section_key": "trait_overview",
+          "render_variant": "trait_dimension_grid",
+          "body_md": "建议与小程序中 5 条维度进度条搭配展示：外向 / 内向｜天马行空 / 求真务实｜情感细腻 / 理性思考｜运筹帷幄 / 随机应变｜情绪易波动 / 自信果断。",
+          "body_html": null,
+          "payload_json": {
+            "summary": "建议与小程序中 5 条维度进度条搭配展示：外向 / 内向｜天马行空 / 求真务实｜情感细腻 / 理性思考｜运筹帷幄 / 随机应变｜情绪易波动 / 自信果断。",
+            "dimensions": [
+              {
+                "id": "EI",
+                "name": "外向倾向",
+                "label": "外向倾向",
+                "axis_left": "外向",
+                "axis_right": "内向",
+                "summary": "明显偏外向",
+                "description": "你更像那个自然走到前排、主动主导讨论的人。你在公开场合表达观点、带领团队时状态最好；长时间独处反而会让你觉得“效率太低、节奏太慢”。"
+              },
+              {
+                "id": "SN",
+                "name": "心智模式",
+                "label": "心智模式",
+                "axis_left": "天马行空",
+                "axis_right": "求真务实",
+                "summary": "高维视角 + 落地导向",
+                "description": "你习惯先从宏观结构和长期收益看问题，再回到现实去拆解路径。单纯的天马行空会让你不耐烦，只有“有想象空间、又能实操”的项目，才真正配得上你的投入。"
+              },
+              {
+                "id": "TF",
+                "name": "情绪天性",
+                "label": "情绪天性",
+                "axis_left": "情感细腻",
+                "axis_right": "理性思考",
+                "summary": "明显偏“理性思考”",
+                "description": "你在大部分场景下都能保持冷静、理智。你尊重情感，但不会因为一时的感受就改变整体方向。这让你在关键决策时非常可靠，却也可能被贴上“冷”“不好懂”的标签。"
+              },
+              {
+                "id": "JP",
+                "name": "应对方式",
+                "label": "应对方式",
+                "axis_left": "运筹帷幄",
+                "axis_right": "随机应变",
+                "summary": "强烈“运筹帷幄”倾向",
+                "description": "你喜欢制定路线图和优先级，明确谁在什么时间点完成什么事情。你能在不确定的环境里快速搭建出一个“暂时可用的秩序框架”，然后边走边优化。"
+              },
+              {
+                "id": "AT",
+                "name": "身份特征",
+                "label": "身份特征",
+                "axis_left": "情绪易波动",
+                "axis_right": "自信果断",
+                "summary": "明显偏“自信果断”",
+                "description": "你对自己的分析和判断通常比较笃定，不太会在做出决定后反复后悔或自我怀疑。你更倾向于：“先做出最优解里的一个，然后在行动中修正。” 这让你在他人眼中很有安全感，但也需要留意别人的节奏和承受度。"
+              }
+            ]
+          },
+          "sort_order": 30,
+          "is_enabled": true
+        },
+        {
+          "section_key": "career.summary",
+          "render_variant": "rich_text",
+          "body_md": "你的职业偏好，往往围绕着“三件事”：决策权、影响力和成长空间。你希望自己在一个系统里不是被动执行者，而是能参与制定方向、设计机制的人。\n\n长期重复、缺乏挑战、讲不清意义的工作，会迅速消耗你的耐心；相反，复杂但有潜力、需要整合资源并带队攻坚的任务，会让你兴奋且充满动力。\n\n当一份工作允许你：直面关键问题、整合多方资源、搭建新系统、带领团队打出漂亮一仗，并且能看到清晰的成果回报时，你会进入极佳状态。",
+          "body_html": null,
+          "payload_json": null,
+          "sort_order": 40,
+          "is_enabled": true
+        },
+        {
+          "section_key": "career.advantages",
+          "render_variant": "bullets",
+          "body_md": null,
+          "body_html": null,
+          "payload_json": {
+            "items": [
+              {
+                "title": "强大的战略与规划能力",
+                "body": "你擅长从信息碎片中抽出主线，快速搭建出“全局地图”，并据此制定阶段目标和资源分配方案。别人还在纠结细节时，你已经看清了棋盘。"
+              },
+              {
+                "title": "高速决策与执行推动力",
+                "body": "你能在有限信息下做出相对合理的判断，并迅速推动落地。你不惧怕承担责任，而是更关注：“如果现在不决定，会浪费多少时间和机会？”"
+              },
+              {
+                "title": "组织与体系搭建能力",
+                "body": "你不只会带队冲刺，更在意“如何把一次胜利变成一个可复制的流程”。你愿意设计制度、规范和流程，让团队不靠运气，而是靠系统赢。"
+              },
+              {
+                "title": "高抗压与结果导向",
+                "body": "在高压场景下，你往往比别人更冷静、更清楚优先级。你能把情绪搁置一边，先把最关键的事处理掉，再回头复盘得失。"
+              }
+            ]
+          },
+          "sort_order": 50,
+          "is_enabled": true
+        },
+        {
+          "section_key": "career.weaknesses",
+          "render_variant": "bullets",
+          "body_md": null,
+          "body_html": null,
+          "payload_json": {
+            "items": [
+              {
+                "title": "容易显得过于强势",
+                "body": "在你看来只是“直截了当”和“节省时间”的表达方式，在他人眼里可能显得锋利甚至咄咄逼人，尤其是在对方尚未准备好的时候。"
+              },
+              {
+                "title": "对低效与犹豫容忍度低",
+                "body": "你很难忍受反复拉扯、没有结论的会议，对拖延、推诿、反复踩坑会非常不耐烦。这种不耐烦若不加管理，容易伤害合作关系。"
+              },
+              {
+                "title": "容易忽略情绪与氛围",
+                "body": "你太专注于目标和路径，可能忽略团队的情绪承载力。短期看来，大家“还能扛一扛”，但长期可能在你不知道的地方产生流失和对立。"
+              },
+              {
+                "title": "不易放权，习惯亲自盯紧关键环节",
+                "body": "你习惯亲自盯住核心节点，以确保结果达标。但如果长期缺乏信任与授权，团队会越来越依赖你，反而限制了整体扩张上限。"
+              }
+            ]
+          },
+          "sort_order": 60,
+          "is_enabled": true
+        },
+        {
+          "section_key": "career.preferred_roles",
+          "render_variant": "preferred_role_list",
+          "body_md": null,
+          "body_html": null,
+          "payload_json": {
+            "intro": "这些岗位的共同点是：复杂、有挑战，需要清晰决策与统筹能力——并允许你对结果负真正的责任。",
+            "groups": [
+              {
+                "group_title": "战略与综合管理",
+                "description": "参与制定方向、配置资源、搭建体系的角色。",
+                "examples": [
+                  "企业高潜管理培训生 / 管理岗储备",
+                  "业务负责人、事业部负责人",
+                  "战略规划、企业发展部门相关岗位"
+                ]
+              },
+              {
+                "group_title": "项目与运营统筹",
+                "description": "在限定时间内整合人力、预算与资源完成复杂目标。",
+                "examples": [
+                  "项目经理 / PMO / PM",
+                  "运营总监、城市负责人、区域管理者",
+                  "产品运营 / 增长运营 / 业务运营负责人"
+                ]
+              },
+              {
+                "group_title": "商业与咨询领域",
+                "description": "需要快速学习、拆解问题，并向关键决策者给出方案的环境。",
+                "examples": [
+                  "管理咨询、战略咨询、投行相关岗位",
+                  "商业分析、战略分析、投融资 / PE / VC",
+                  "大型平台或企业的战略 BD、关键合作拓展"
+                ]
+              },
+              {
+                "group_title": "创业与高自主权岗位",
+                "description": "需要在高度不确定中主动识别机会、搭团队、打样板的场景。",
+                "examples": [
+                  "公司合伙人 / 创业者",
+                  "新业务负责人、创新项目 Owner",
+                  "需要“从 0 到 1”推进的内部创业项目"
+                ]
+              }
+            ],
+            "outro": "与其问“我适不适合某个岗位名称”，不如问：这份工作是否允许你——思考大方向、影响关键决策、搭建更高效的系统、带领一群人去完成一件有难度的事。"
+          },
+          "sort_order": 70,
+          "is_enabled": true
+        },
+        {
+          "section_key": "career.upgrade_suggestions",
+          "render_variant": "bullets",
+          "body_md": "对 ENTJ-A 来说，能力往往不是稀缺项，稀缺的是：让别人愿意长期和你一起打仗的体验感。你已经具备带队冲锋的实力，接下来要修炼的，是“如何让队伍在你的节奏里，也能感到被尊重、被看见、愿意跟到底”。\n\n可以把下面这几条，当作你的职场升级小公式。",
+          "body_html": null,
+          "payload_json": {
+            "items": [
+              {
+                "title": "影响力 = 决策质量 × 情绪温度",
+                "body": "你已经有较高的决策质量，加一点“情绪缓冲层”，会让你的指令更容易被接受。比如，在给出结论前，多用一句：“我理解这对大家不容易，但从全局看……” 来承接情绪。"
+              },
+              {
+                "title": "团队战斗力 = 明确目标 × 可承受节奏",
+                "body": "你习惯把节奏拉到极致，但团队可能尚未适应这个频率。定期和核心成员对齐：当前节奏是否可持续？哪里需要补人或调优？这样可以避免“结果出来了，人却散了”。"
+              },
+              {
+                "title": "领导力上限 = 放权能力 × 人才梯队",
+                "body": "短期亲力亲为可以保证结果，长期来看会拖慢整体增速。刻意练习：识别可培养的“二把手”，明确授予权限，并容忍一定的非致命错误，把“自己一个人很强”升级成“让一群人变强”。"
+              },
+              {
+                "title": "职业寿命 = 自我修正能力 × 反馈循环",
+                "body": "你不怕做决定，也不要怕听反馈。定期邀请可信任的同事或伙伴，对你的管理方式、沟通风格给出真诚评价。你越早调整，站得越高越久。"
+              }
+            ]
+          },
+          "sort_order": 80,
+          "is_enabled": true
+        },
+        {
+          "section_key": "growth.summary",
+          "render_variant": "rich_text",
+          "body_md": "对 ENTJ-A 来说，成长不只是“更高的位置”和“更大的盘子”，而是学会在强大的执行力之外，加上一套同样成熟的情绪与关系能力。\n\n这一章节，从你的成长优势、短板，以及驱动你前进或让你消耗的因素入手，帮你看清下一步可以优化的方向。",
+          "body_html": null,
+          "payload_json": null,
+          "sort_order": 90,
+          "is_enabled": true
+        },
+        {
+          "section_key": "growth.strengths",
+          "render_variant": "bullets",
+          "body_md": null,
+          "body_html": null,
+          "payload_json": {
+            "items": [
+              {
+                "title": "强烈的进取心与自我驱动",
+                "body": "你很少满足于“差不多就行”，更习惯不断设立新目标。你会主动寻找更难的任务和更大的舞台，以此检验自己的实力。"
+              },
+              {
+                "title": "快速学习与整合能力",
+                "body": "面对陌生领域，你能迅速抓住关键框架，找到“先学什么最划算”，再在实践中不断迭代。这让你在许多场景中能以“跨界选手”的身份弯道超车。"
+              },
+              {
+                "title": "强大的抗压与韧性",
+                "body": "压力来临时，你不会第一反应躺平，而是冷静分析“最坏会怎样”“现在能做什么”，然后把精力集中在可控范围内。"
+              },
+              {
+                "title": "善于复盘与优化系统",
+                "body": "你不会满足于一次性成功，更在意“能否复制”。你会在项目结束后主动复盘哪里可以改进，把经验固化为方法论。"
+              }
+            ]
+          },
+          "sort_order": 100,
+          "is_enabled": true
+        },
+        {
+          "section_key": "growth.weaknesses",
+          "render_variant": "bullets",
+          "body_md": null,
+          "body_html": null,
+          "payload_json": {
+            "items": [
+              {
+                "title": "对慢节奏与迷茫容忍度低",
+                "body": "当别人需要时间消化或仍在摸索时，你容易觉得“效率太低”，从而直接接手或下指令，忽略了对方的节奏和学习曲线。"
+              },
+              {
+                "title": "情绪表达偏功能化",
+                "body": "你更习惯讨论问题和方案，而不是坦露脆弱或情绪。这会让别人觉得你“有距离”“不好亲近”，也让情感支持变得稀缺。"
+              },
+              {
+                "title": "容易忽略身体与休息",
+                "body": "在冲刺和高压阶段，你常常对自己说“再撑一段时间”，把休息、体检、放松排在最后。长期如此，身体会用更激烈的方式提醒你。"
+              },
+              {
+                "title": "不易承认“我也需要帮助”",
+                "body": "你习惯做那个给别人方案的人，却很少向他人求助。这会让你看起来无懈可击，却在某些时刻感到孤独和疲惫。"
+              }
+            ]
+          },
+          "sort_order": 110,
+          "is_enabled": true
+        },
+        {
+          "section_key": "growth.motivators",
+          "render_variant": "premium_teaser",
+          "body_md": "清晰的成长曲线、可见的影响力、以及在关键局面里被信任地交付重任，都会极大激发你的斗志。你越能在工作与生活中找到“值得一搏的难题”，就越容易保持高能量。",
+          "body_html": null,
+          "payload_json": {
+            "teaser": "清晰的成长曲线、可见的影响力、以及在关键局面里被信任地交付重任，都会极大激发你的斗志。你越能在工作与生活中找到“值得一搏的难题”，就越容易保持高能量。",
+            "is_premium": true
+          },
+          "sort_order": 120,
+          "is_enabled": true
+        },
+        {
+          "section_key": "growth.drainers",
+          "render_variant": "premium_teaser",
+          "body_md": "长期重复的低价值事务、缺乏决策权却要承担后果的环境、以及“说过很多次仍然没人动”的局面，会迅速消耗你的耐心与热情。如果你开始频繁质疑“这事还有意义吗”，很可能就是你的能量在被过度浪费。",
+          "body_html": null,
+          "payload_json": {
+            "teaser": "长期重复的低价值事务、缺乏决策权却要承担后果的环境、以及“说过很多次仍然没人动”的局面，会迅速消耗你的耐心与热情。如果你开始频繁质疑“这事还有意义吗”，很可能就是你的能量在被过度浪费。",
+            "is_premium": true
+          },
+          "sort_order": 130,
+          "is_enabled": true
+        },
+        {
+          "section_key": "relationships.summary",
+          "render_variant": "rich_text",
+          "body_md": "在人际关系里，你更像是“靠谱的指挥官 + 现实中的搭档”。你愿意承担责任、解决问题、替大家挡住一部分风险，却不太擅长用细腻的方式表达关心。\n\n你最看重的是：这段关系是否真诚、是否高质量沟通、是否能一起成长，而不是表面多甜、仪式感多华丽。",
+          "body_html": null,
+          "payload_json": null,
+          "sort_order": 140,
+          "is_enabled": true
+        },
+        {
+          "section_key": "relationships.strengths",
+          "render_variant": "bullets",
+          "body_md": null,
+          "body_html": null,
+          "payload_json": {
+            "items": [
+              {
+                "title": "可靠与担当",
+                "body": "一旦你把某个人视作“自己人”，你会在关键时刻站出来，帮对方解决现实问题，而不是只说几句安慰的话。"
+              },
+              {
+                "title": "愿意为关系升级投入行动",
+                "body": "你不喜欢停留在空洞的承诺，而是更愿意通过实际安排、共同计划、长期目标，来推动关系进入更稳定、更成熟的阶段。"
+              },
+              {
+                "title": "鼓励对方变得更强",
+                "body": "你会自然而然地关注对方的潜力，而不是只有当下的状态。你乐于提供建议、资源和机会，让对方在自己的道路上走得更远。"
+              },
+              {
+                "title": "在危机时非常可靠",
+                "body": "面对现实困境或突发问题时，你不会第一反应情绪化，而是迅速进入“解决问题模式”，为关系提供强有力的支撑。"
+              }
+            ]
+          },
+          "sort_order": 150,
+          "is_enabled": true
+        },
+        {
+          "section_key": "relationships.weaknesses",
+          "render_variant": "bullets",
+          "body_md": null,
+          "body_html": null,
+          "payload_json": {
+            "items": [
+              {
+                "title": "表达方式偏理性，容易被误解为“冷”",
+                "body": "你习惯用分析和建议来回应对方的倾诉，但对方有时只是想被理解和陪伴。久而久之，他们可能觉得你“不够温柔”。"
+              },
+              {
+                "title": "容易把关系变成“项目管理”",
+                "body": "你会本能地规划彼此的未来、安排时间和节奏，但如果缺少情绪交流与柔软时刻，对方可能会觉得压力大或“总被安排”。"
+              },
+              {
+                "title": "不擅长示弱与请求支持",
+                "body": "即使在关系里，你也很难坦率地说出“我也很累”“我也需要你”。这容易把你推向“只负责付出和扛”的位置。"
+              },
+              {
+                "title": "对不成熟与反复拉扯容忍度低",
+                "body": "你很难长期容忍对方一再逃避成长或反复做出相同的错误选择，这会让你逐渐失去耐心，甚至选择抽离。"
+              }
+            ]
+          },
+          "sort_order": 160,
+          "is_enabled": true
+        },
+        {
+          "section_key": "relationships.rel_advantages",
+          "render_variant": "premium_teaser",
+          "body_md": "当你遇到一个愿意真诚沟通、也愿意为关系负责的对象时，你会展现出极强的陪伴与共建能力。你能带着关系一起升级，而不是停留在原地消耗。",
+          "body_html": null,
+          "payload_json": {
+            "teaser": "当你遇到一个愿意真诚沟通、也愿意为关系负责的对象时，你会展现出极强的陪伴与共建能力。你能带着关系一起升级，而不是停留在原地消耗。",
+            "is_premium": true
+          },
+          "sort_order": 170,
+          "is_enabled": true
+        },
+        {
+          "section_key": "relationships.rel_risks",
+          "render_variant": "premium_teaser",
+          "body_md": "如果你长期处在“你负责解决一切、对方只需要享受成果”的关系结构里，你的耐心会被一点点磨光，最终只剩下冷淡与疏离。学会更早识别不对等的模式，并及时调整，对 ENTJ-A 来说尤为重要。",
+          "body_html": null,
+          "payload_json": {
+            "teaser": "如果你长期处在“你负责解决一切、对方只需要享受成果”的关系结构里，你的耐心会被一点点磨光，最终只剩下冷淡与疏离。学会更早识别不对等的模式，并及时调整，对 ENTJ-A 来说尤为重要。",
+            "is_premium": true
+          },
+          "sort_order": 180,
+          "is_enabled": true
+        }
+      ],
+      "seo_overrides": {
+        "seo_title": "ENTJ-A 指挥官型",
+        "seo_description": "你像一位站在甲板上的掌舵者：目光始终盯着远方的航线，哪怕海面起风，也会果断下达指令。你相信，世界可以被更高效地运转，而你生来就是那个把愿景变成现实的人。",
+        "canonical_url": null,
+        "og_title": "ENTJ-A 战略掌舵者",
+        "og_description": "你像一位站在甲板上的掌舵者：目光始终盯着远方的航线，哪怕海面起风，也会果断下达指令。你相信，世界可以被更高效地运转，而你生来就是那个把愿景变成现实的人。",
+        "og_image_url": null,
+        "twitter_title": "ENTJ-A 战略掌舵者",
+        "twitter_description": "你像一位站在甲板上的掌舵者：目光始终盯着远方的航线，哪怕海面起风，也会果断下达指令。你相信，世界可以被更高效地运转，而你生来就是那个把愿景变成现实的人。",
+        "twitter_image_url": null,
+        "robots": null,
+        "jsonld_overrides_json": null
+      }
+    },
+    {
+      "runtime_type_code": "ENTJ-T",
+      "canonical_type_code": "ENTJ",
+      "variant_code": "T",
+      "is_published": true,
+      "published_at": "2026-03-17T00:00:00Z",
+      "profile_overrides": {
+        "type_name": "指挥官型",
+        "nickname": "克制统帅",
+        "rarity_text": "约 1–3%",
+        "keywords_json": [
+          "战略",
+          "决策",
+          "效率",
+          "目标导向",
+          "理性",
+          "自我打磨"
+        ],
+        "hero_summary_md": "你像一位手握全局地图的指挥官：目光锁定远方，又时时检查每一步是否走稳。你天生擅长制定方向、整合资源、推动结果，同时也会在心里不断追问——“我还能做得更好一点吗？”",
+        "hero_summary_html": null
+      },
+      "section_overrides": [
+        {
+          "section_key": "letters_intro",
+          "render_variant": "letters_intro",
+          "body_md": null,
+          "body_html": null,
+          "payload_json": {
+            "headline": "外向 · 直觉 · 思维 · 规划 · 动荡型｜野心与自我审视并存的“克制统帅”",
+            "letters": [
+              {
+                "letter": "E",
+                "title": "外向（E）",
+                "description": "让你乐于站到台前：主持讨论、拍板决策、协调多人合作，对你来说既是挑战，也是天然舞台。"
+              },
+              {
+                "letter": "N",
+                "title": "直觉（N）",
+                "description": "让你习惯从全局看棋局，更在意趋势和结构，而不是困在当下的细枝末节。你常常提前看到“几年后可能会发生什么”。"
+              },
+              {
+                "letter": "T",
+                "title": "思维（T）",
+                "description": "让你在决策时更优先考虑逻辑、效率和结果。你会问的是：“这样做是否最有利于目标？” 而不是“会不会得罪谁？”。"
+              },
+              {
+                "letter": "J",
+                "title": "规划（J）",
+                "description": "让你离不开计划、节奏和里程碑。你希望事情按节点推进，而不是被临时的情绪和偶然因素牵着走。"
+              },
+              {
+                "letter": "T",
+                "title": "动荡型（-T）",
+                "description": "让你在强势果断的外表下，保留着一份“自我校准”的敏感。任务结束后，你会反思：“哪里可以更快、更好、更稳？”。"
+              }
+            ]
+          },
+          "sort_order": 10,
+          "is_enabled": true
+        },
+        {
+          "section_key": "overview",
+          "render_variant": "rich_text",
+          "body_md": "在费马心理的逻辑模型里，ENTJ-T 常被视作“带着自检系统的战略指挥官”。你有清晰的目标感、强大的组织能力，也有罕见的自我修正意识——不会只沉迷于“掌控”，而是愿意不断打磨自己的判断力和领导方式。\n\n对你来说，最舒服的状态是：有一个足够宏大的目标，一支可以被调动的队伍，以及一套清晰而高效的执行路径。当环境混乱、决策低效、没人愿意负责时，你往往会忍不住站出来接管局面。\n\n你的人生追求不仅是“我做到”，而是“在有限时间内，把系统搭好，把局面盘活，把潜力最大化”。",
+          "body_html": null,
+          "payload_json": null,
+          "sort_order": 20,
+          "is_enabled": true
+        },
+        {
+          "section_key": "trait_overview",
+          "render_variant": "trait_dimension_grid",
+          "body_md": "建议与小程序中 5 条维度进度条搭配展示：外向 / 内向｜天马行空 / 求真务实｜情感细腻 / 理性思考｜运筹帷幄 / 随机应变｜情绪易波动 / 自信果断。",
+          "body_html": null,
+          "payload_json": {
+            "summary": "建议与小程序中 5 条维度进度条搭配展示：外向 / 内向｜天马行空 / 求真务实｜情感细腻 / 理性思考｜运筹帷幄 / 随机应变｜情绪易波动 / 自信果断。",
+            "dimensions": [
+              {
+                "id": "EI",
+                "name": "外向倾向",
+                "label": "外向倾向",
+                "axis_left": "外向",
+                "axis_right": "内向",
+                "summary": "明显偏外向",
+                "description": "你更习惯在“人多事杂”的场域中运作：开会、协调、谈判、拍板。你乐于发言、敢于表态，也不惧在关键时刻拍板。短暂独处可以帮你整理思路，但长时间被动旁观会让你觉得浪费时间。"
+              },
+              {
+                "id": "SN",
+                "name": "心智模式",
+                "label": "心智模式",
+                "axis_left": "天马行空",
+                "axis_right": "求真务实",
+                "summary": "略偏“天马行空”",
+                "description": "你天生有战略视角，习惯先弄清“大方向”和“底层逻辑”，再考虑执行细节。你经常一语道破关键：“如果我们不改变 X，后面所有优化都是治标不治本。” 对你来说，没有大局观的忙碌意义不大。"
+              },
+              {
+                "id": "TF",
+                "name": "情绪天性",
+                "label": "情绪天性",
+                "axis_left": "情感细腻",
+                "axis_right": "理性思考",
+                "summary": "明显偏“理性思考”",
+                "description": "你更相信数据、事实和推理。做决策时，你会优先考虑长期收益和整体效率，而不是一时的情绪舒适。这让你在复杂局面中保持冷静，却也可能让一些人觉得你“不够温柔”。"
+              },
+              {
+                "id": "JP",
+                "name": "应对方式",
+                "label": "应对方式",
+                "axis_left": "运筹帷幄",
+                "axis_right": "随机应变",
+                "summary": "偏“运筹帷幄”",
+                "description": "你不喜欢无计划的即兴发挥，更偏好有节奏、有节点、有里程碑的推进方式。你会主动设定优先级、划分责任、制定时间表，在别人还在摸索时，你已经在画路线图。"
+              },
+              {
+                "id": "AT",
+                "name": "身份特征",
+                "label": "身份特征",
+                "axis_left": "情绪易波动",
+                "axis_right": "自信果断",
+                "summary": "理性之下略带“自我起伏”",
+                "description": "作为动荡型 ENTJ，你一方面非常自信、敢于出手，另一方面又会在事后对自己进行严格审视。你会反复咀嚼关键会议、重要决策，既担心自己不够好，也正因这种不满足，持续升级自己的能力。"
+              }
+            ]
+          },
+          "sort_order": 30,
+          "is_enabled": true
+        },
+        {
+          "section_key": "career.summary",
+          "render_variant": "rich_text",
+          "body_md": "你的职业轨迹，往往围绕“目标、系统和影响力”展开。只要能主导方向、优化结构、带领团队达成高难度目标，你就会进入高能量状态。\n\n你很难在长期纯执行、缺乏决策空间和改造权力的岗位上待得舒心；当你只能被动执行、明知方案低效却无权调整时，你会感到强烈的挫败和浪费感。\n\n相反，当一份工作允许你：参与制定战略、搭建流程、评估资源、调动人才，并对结果负责时，你会把自己当成“这艘船的船长”，全情投入。",
+          "body_html": null,
+          "payload_json": null,
+          "sort_order": 40,
+          "is_enabled": true
+        },
+        {
+          "section_key": "career.advantages",
+          "render_variant": "bullets",
+          "body_md": null,
+          "body_html": null,
+          "payload_json": {
+            "items": [
+              {
+                "title": "强大的战略与统筹能力",
+                "body": "你能快速看懂局面、抓住关键变量，并据此设定清晰的方向与优先级。在多线作战的复杂项目中，你擅长“收束混乱”。"
+              },
+              {
+                "title": "决策果断，行动高效",
+                "body": "在信息有限、时间紧迫的情况下，你依然能综合已有信息做出判断，并承担由此带来的责任。这种果断让你在关键节点成为团队的主心骨。"
+              },
+              {
+                "title": "善于搭建和改造系统",
+                "body": "你不满足于“把当前事情做好”，而是会思考：流程是否可以重构？角色是否需要调整？规则是否可以升级？你更像一位“制度与组织结构的设计师”。"
+              },
+              {
+                "title": "自我驱动且不断打磨",
+                "body": "动荡型的特质，让你不会安于现状。“足够好”对别人是终点，对你只是中途站。你会主动学习、反思和迭代自己的管理方式和专业能力。"
+              }
+            ]
+          },
+          "sort_order": 50,
+          "is_enabled": true
+        },
+        {
+          "section_key": "career.weaknesses",
+          "render_variant": "bullets",
+          "body_md": null,
+          "body_html": null,
+          "payload_json": {
+            "items": [
+              {
+                "title": "容易忽视他人的情绪体验",
+                "body": "在你急于推动结果、优化系统时，可能会低估个体的情绪承载力，用语过于直接或动作太快，让部分成员感觉被“推着走”。"
+              },
+              {
+                "title": "不耐烦于低效和犹豫",
+                "body": "当别人动作慢、标准低或频繁改口时，你会很快失去耐心，甚至直接接管任务，从而陷入“越能干越累”的循环。"
+              },
+              {
+                "title": "容易把责任全揽到自己身上",
+                "body": "一旦结果不理想，你往往第一反应是“我方案的问题”“我没盯紧”，在承担责任的同时，也可能放大自责和压力。"
+              },
+              {
+                "title": "在价值观不匹配的环境中耗损严重",
+                "body": "当你发现组织决策短视、权责混乱、评价体系不透明时，你会非常痛苦；继续留下会磨损你的锐度，过早离开又会让你心有不甘。"
+              }
+            ]
+          },
+          "sort_order": 60,
+          "is_enabled": true
+        },
+        {
+          "section_key": "career.preferred_roles",
+          "render_variant": "preferred_role_list",
+          "body_md": null,
+          "body_html": null,
+          "payload_json": {
+            "intro": "下面这些不是 ENTJ-T 唯一适配的岗位，而是几类更容易激活你天赋的方向，可作为职业规划与转型时的参考起点。",
+            "groups": [
+              {
+                "group_title": "战略与管理相关",
+                "description": "需要统筹资源、设定方向并对结果负责的岗位。",
+                "examples": [
+                  "战略规划、业务负责人、事业部总监",
+                  "创新项目负责人、合伙人 / 联合创始人",
+                  "咨询顾问（偏战略 / 管理方向）"
+                ]
+              },
+              {
+                "group_title": "运营与系统建设",
+                "description": "通过流程、制度和数据来提升整体效率与产出。",
+                "examples": [
+                  "运营管理、流程优化、供应链 / 生产管理",
+                  "PMO、项目集管理、业务流程再造（BPR）",
+                  "中后台系统搭建与运营负责人"
+                ]
+              },
+              {
+                "group_title": "对外拓展与商务谈判",
+                "description": "需要判断格局、撮合资源、推进复杂合作的场景。",
+                "examples": [
+                  "商务拓展、关键客户经理（KA）",
+                  "投融资相关岗位（FA、VC / PE 投资等）",
+                  "跨部门 / 跨组织合作项目负责人"
+                ]
+              },
+              {
+                "group_title": "以结果为导向的高压赛道",
+                "description": "能给予你足够空间、报酬与话语权的高难度竞技场。",
+                "examples": [
+                  "互联网 / 科技公司业务 Owner",
+                  "高速成长型初创公司的核心角色",
+                  "需要带队打硬仗的转型项目负责人"
+                ]
+              }
+            ],
+            "outro": "相比“安稳”，你更需要的是：值得一搏的目标、足够大的盘子，以及配得上你投入的舞台。"
+          },
+          "sort_order": 70,
+          "is_enabled": true
+        },
+        {
+          "section_key": "career.upgrade_suggestions",
+          "render_variant": "bullets",
+          "body_md": "对 ENTJ-T 来说，职业的天花板往往不在硬实力，而在“你如何对待人、如何善用团队”。当你学会把锋利的判断力和更细腻的人性理解结合起来，你的影响力会呈指数级上升。\n\n可以把下面几条，当作你在职场中的“升级公式”。",
+          "body_html": null,
+          "payload_json": {
+            "items": [
+              {
+                "title": "领导力 = 判断力 × 被跟随的意愿",
+                "body": "仅仅能看对局面还不够，还要让人“愿意和你一起打这场仗”。在给出指令前，多花一点时间说明“为什么这样做”，会让执行过程顺畅很多。"
+              },
+              {
+                "title": "高效执行 = 清晰目标 × 稳定节奏",
+                "body": "你擅长设定远大目标，但团队需要被拆解后的阶段性成果。试着把“大旗”拆成“这一个月具体要看见什么变化”，既能保留方向感，又更易落地。"
+              },
+              {
+                "title": "个人成长 = 反思深度 × 反馈来源的多样性",
+                "body": "你已经习惯自我复盘，可以刻意增加“来自不同视角的反馈”：下属、平级、跨部门伙伴。你看到的盲点越多，成长就越快。"
+              },
+              {
+                "title": "可持续战斗力 = 边界感 × 恰当授权",
+                "body": "你不需要对所有事亲力亲为；真正的强者，是能通过授权和培养，让系统“在你不在场时”也能高效运转。定期盘点：有哪些事可以教会别人，然后放心交出去。"
+              }
+            ]
+          },
+          "sort_order": 80,
+          "is_enabled": true
+        },
+        {
+          "section_key": "growth.summary",
+          "render_variant": "rich_text",
+          "body_md": "对 ENTJ-T 来说，成长不是“从弱到强”，而是“从只会赢项目，到也会赢人心，从只看结果，到也关照过程”。你已经拥有强大的执行与决策能力，接下来要练习的，是如何与自己和他人更好地相处。\n\n这一章节会从你的内在优势、潜在短板，以及能量的来源与流失，帮你更清晰地看见自己的成长路径。",
+          "body_html": null,
+          "payload_json": null,
+          "sort_order": 90,
+          "is_enabled": true
+        },
+        {
+          "section_key": "growth.strengths",
+          "render_variant": "bullets",
+          "body_md": null,
+          "body_html": null,
+          "payload_json": {
+            "items": [
+              {
+                "title": "极强的目标感与方向感",
+                "body": "你很少迷失在日常琐事里，总能记得“我们究竟要去哪里”，并据此调整节奏与资源配置。"
+              },
+              {
+                "title": "愿意直面问题与挑战",
+                "body": "你不怕冲突、不怕难题，反而把它们视作检验能力的机会。这让你在别人退缩时，仍能选择向前。"
+              },
+              {
+                "title": "自驱且能承担高压",
+                "body": "高标准对别人是压力，对你是一种默认模式。即便在高压环境中，你依然能咬牙顶住，并想办法让局面稳定下来。"
+              },
+              {
+                "title": "具备自我修正意识",
+                "body": "动荡型的你不会长期沉浸在“我一直是对的”的幻觉中，而是会在关键事件后反思：有没有更好的打法？我是否可以更成熟一点？"
+              }
+            ]
+          },
+          "sort_order": 100,
+          "is_enabled": true
+        },
+        {
+          "section_key": "growth.weaknesses",
+          "render_variant": "bullets",
+          "body_md": null,
+          "body_html": null,
+          "payload_json": {
+            "items": [
+              {
+                "title": "习惯用“效率”压过情绪",
+                "body": "在赶进度、冲目标时，你容易忽视自己和他人的情绪需要，久而久之会让团队觉得“被用完就丢”，也让自己很难真正放松。"
+              },
+              {
+                "title": "对脆弱状态缺乏耐心",
+                "body": "当别人表现出犹豫、难过或迷茫时，你会本能地提供解决方案，而不是先陪伴情绪，这可能让对方觉得“被管理，而不是被理解”。"
+              },
+              {
+                "title": "很难允许自己“慢一点”",
+                "body": "你习惯拉高生涯节奏，一次承接多个目标，很少给自己留出真正空白的时间。长期下来容易出现疲惫、易怒、失眠等信号。"
+              },
+              {
+                "title": "自责与完美主义叠加",
+                "body": "表面看你强势自信，实际上，你对自己要求更严格。一旦出现失误，你可能在心里放大责任，把本来可以复盘的问题变成“我不够好”的证据。"
+              }
+            ]
+          },
+          "sort_order": 110,
+          "is_enabled": true
+        },
+        {
+          "section_key": "growth.motivators",
+          "render_variant": "premium_teaser",
+          "body_md": "清晰的挑战目标、可见的成长曲线、以及“这事交给你就放心”的信任感，会极大激发你的战斗力。当你感觉自己正在搭建某种长期有效的系统，而不是做一次性消耗任务时，你的能量会特别充足。",
+          "body_html": null,
+          "payload_json": {
+            "teaser": "清晰的挑战目标、可见的成长曲线、以及“这事交给你就放心”的信任感，会极大激发你的战斗力。当你感觉自己正在搭建某种长期有效的系统，而不是做一次性消耗任务时，你的能量会特别充足。",
+            "is_premium": true
+          },
+          "sort_order": 120,
+          "is_enabled": true
+        },
+        {
+          "section_key": "growth.drainers",
+          "render_variant": "premium_teaser",
+          "body_md": "低效会议、反复拉扯的决策、看得见问题却无权调整的环境，会迅速消耗你的热情。如果你开始频繁抱怨“浪费时间”“没意义”，很可能就是在这些状态里被掏空了。",
+          "body_html": null,
+          "payload_json": {
+            "teaser": "低效会议、反复拉扯的决策、看得见问题却无权调整的环境，会迅速消耗你的热情。如果你开始频繁抱怨“浪费时间”“没意义”，很可能就是在这些状态里被掏空了。",
+            "is_premium": true
+          },
+          "sort_order": 130,
+          "is_enabled": true
+        },
+        {
+          "section_key": "relationships.summary",
+          "render_variant": "rich_text",
+          "body_md": "在人际和亲密关系中，你更像一位“会拉着人一起升级的队长”。你重视共同成长、价值观匹配和长期规划，倾向把重要的人纳入你的“人生蓝图”。\n\n你在意的往往不是表面有多甜，而是：我们有没有在朝一个方向前进？这段关系是否让双方都变得更好？在高压时期，我们还能不能彼此信任？",
+          "body_html": null,
+          "payload_json": null,
+          "sort_order": 140,
+          "is_enabled": true
+        },
+        {
+          "section_key": "relationships.strengths",
+          "render_variant": "bullets",
+          "body_md": null,
+          "body_html": null,
+          "payload_json": {
+            "items": [
+              {
+                "title": "愿意为关系承担责任",
+                "body": "一旦你认定了某段关系的价值，你会真诚投入、主动规划未来，并愿意在关键时刻站出来扛事。"
+              },
+              {
+                "title": "擅长提供方向和支持",
+                "body": "你会帮对方看清局面、评估选择、制定计划，用实际行动而不是空洞安慰，陪对方一起走过难关。"
+              },
+              {
+                "title": "重视成长与共同目标",
+                "body": "你希望关系不仅是“彼此依赖”，更是“一起变强”。你会鼓励对方追求更好的自己，同时也接受对方对你的高期待。"
+              },
+              {
+                "title": "在关键时刻可靠",
+                "body": "当对方真正遇到大事，很多犹豫的人还在情绪里打转时，你已经开始协调资源、提出方案。你用实际行动证明：在关键节点，你是可以被依靠的。"
+              }
+            ]
+          },
+          "sort_order": 150,
+          "is_enabled": true
+        },
+        {
+          "section_key": "relationships.weaknesses",
+          "render_variant": "bullets",
+          "body_md": null,
+          "body_html": null,
+          "payload_json": {
+            "items": [
+              {
+                "title": "表达方式过于直接",
+                "body": "你常常以为“说真话是尊重”，却忽略了对方的接受阈值。你的直率有时会被解读为严厉甚至冷酷。"
+              },
+              {
+                "title": "容易把关系变成“项目”",
+                "body": "你擅长规划和设定目标，也容易不自觉地把关系当作可优化的系统，而忽略了情感本身需要的松弛与无目的陪伴。"
+              },
+              {
+                "title": "不习惯暴露脆弱",
+                "body": "你更习惯以“解决问题者”的姿态出现，很少示弱或求助，这会让亲近的人觉得难以真正走进你的内心。"
+              },
+              {
+                "title": "对停滞和反复容忍度低",
+                "body": "当你屡次带着对方尝试突破，却发现对方始终停在原地，你会逐渐失望，甚至突然抽离，让对方感到“你说走就走”。"
+              }
+            ]
+          },
+          "sort_order": 160,
+          "is_enabled": true
+        },
+        {
+          "section_key": "relationships.rel_advantages",
+          "render_variant": "premium_teaser",
+          "body_md": "在健康的关系里，你是少见的“又能给方向、又能扛风险”的角色。你会成为团队、家庭、伴侣关系中的稳定支点，让身边的人在你的支持下敢于追求更大的目标。",
+          "body_html": null,
+          "payload_json": {
+            "teaser": "在健康的关系里，你是少见的“又能给方向、又能扛风险”的角色。你会成为团队、家庭、伴侣关系中的稳定支点，让身边的人在你的支持下敢于追求更大的目标。",
+            "is_premium": true
+          },
+          "sort_order": 170,
+          "is_enabled": true
+        },
+        {
+          "section_key": "relationships.rel_risks",
+          "render_variant": "premium_teaser",
+          "body_md": "如果长期处在价值观不匹配、沟通无效或责任全落在你身上的关系里，你会从最初的“想改变现状”，变成彻底抽离甚至封闭自己。学会更早辨认这种模式，并在合适的时机画清边界，是对自己也对他人负责。",
+          "body_html": null,
+          "payload_json": {
+            "teaser": "如果长期处在价值观不匹配、沟通无效或责任全落在你身上的关系里，你会从最初的“想改变现状”，变成彻底抽离甚至封闭自己。学会更早辨认这种模式，并在合适的时机画清边界，是对自己也对他人负责。",
+            "is_premium": true
+          },
+          "sort_order": 180,
+          "is_enabled": true
+        }
+      ],
+      "seo_overrides": {
+        "seo_title": "ENTJ-T 指挥官型",
+        "seo_description": "你像一位手握全局地图的指挥官：目光锁定远方，又时时检查每一步是否走稳。你天生擅长制定方向、整合资源、推动结果，同时也会在心里不断追问——“我还能做得更好一点吗？”",
+        "canonical_url": null,
+        "og_title": "ENTJ-T 克制统帅",
+        "og_description": "你像一位手握全局地图的指挥官：目光锁定远方，又时时检查每一步是否走稳。你天生擅长制定方向、整合资源、推动结果，同时也会在心里不断追问——“我还能做得更好一点吗？”",
+        "og_image_url": null,
+        "twitter_title": "ENTJ-T 克制统帅",
+        "twitter_description": "你像一位手握全局地图的指挥官：目光锁定远方，又时时检查每一步是否走稳。你天生擅长制定方向、整合资源、推动结果，同时也会在心里不断追问——“我还能做得更好一点吗？”",
+        "twitter_image_url": null,
+        "robots": null,
+        "jsonld_overrides_json": null
+      }
+    },
+    {
+      "runtime_type_code": "ENTP-A",
+      "canonical_type_code": "ENTP",
+      "variant_code": "A",
+      "is_published": true,
+      "published_at": "2026-03-17T00:00:00Z",
+      "profile_overrides": {
+        "type_name": "辩论家型",
+        "nickname": "头脑风暴者",
+        "rarity_text": "约 2–4%",
+        "keywords_json": [
+          "好奇心",
+          "点子王",
+          "逻辑辩证",
+          "反叛思维",
+          "创新驱动",
+          "快速学习"
+        ],
+        "hero_summary_md": "你像一台随时待命的“头脑加速器”：话题一展开，你就能立刻抛出新观点、新角度、新可能。你不满足于按部就班，更喜欢拆解规则、挑战既定答案，用一场又一场的思维实验，把世界变得更有趣一点。",
+        "hero_summary_html": null
+      },
+      "section_overrides": [
+        {
+          "section_key": "letters_intro",
+          "render_variant": "letters_intro",
+          "body_md": null,
+          "body_html": null,
+          "payload_json": {
+            "headline": "外向 · 直觉 · 思考 · 感知 · 自信型｜用脑洞和逻辑改写规则的“头脑风暴者”",
+            "letters": [
+              {
+                "letter": "E",
+                "title": "外向（E）",
+                "description": "让你在热烈的交流中充电——辩论、头脑风暴、跨界聊天，都是你的能量来源。一个人闷太久，你会觉得思路都慢了下来。"
+              },
+              {
+                "letter": "N",
+                "title": "直觉（N）",
+                "description": "让你总是跳出当下细节，从更高维度看问题。别人还在纠结“怎么做”，你已经在问：“有没有完全不一样的做法？”"
+              },
+              {
+                "letter": "T",
+                "title": "思考（T）",
+                "description": "让你习惯用逻辑和因果来拆解问题。你不会轻易被情绪带走，更关心论点是否自洽、证据是否扎实。"
+              },
+              {
+                "letter": "P",
+                "title": "感知（P）",
+                "description": "让你保持开放和灵活，不喜欢被死板的计划绑住。你享受在变化中捕捉机会，而不是严格按清单走完每一步。"
+              },
+              {
+                "letter": "A",
+                "title": "自信型（-A）",
+                "description": "让你在试错和失败面前更加淡定：“就当测试一个假设。” 你更少陷入自责，更倾向于继续尝试下一种可能性。"
+              }
+            ]
+          },
+          "sort_order": 10,
+          "is_enabled": true
+        },
+        {
+          "section_key": "overview",
+          "render_variant": "rich_text",
+          "body_md": "在费马心理的逻辑模型里，ENTP-A 往往被视作“带着实验精神的创意玩家”。你好奇、反应快、点子密集，很难对世界保持沉默——总想多问一句“为什么非得这样？”\n\n你享受的是拆解和重组：拆旧逻辑、拆惯性思维，再用自己的视角重组一个更有趣、更高效或者更大胆的版本。你未必热衷于长期维护同一套系统，但对“开新坑”“搭新框架”“试新玩法”充满兴趣。\n\n对你来说，世界如果只能照着说明书运行，那就太无聊了。你希望通过对话、争辩、实验和创意，把“不一定”变成日常，把“还有没有别的可能？”变成人生主旋律。",
+          "body_html": null,
+          "payload_json": null,
+          "sort_order": 20,
+          "is_enabled": true
+        },
+        {
+          "section_key": "trait_overview",
+          "render_variant": "trait_dimension_grid",
+          "body_md": "建议与小程序中 5 条维度进度条搭配展示：外向 / 内向｜天马行空 / 求真务实｜情感细腻 / 理性思考｜运筹帷幄 / 随机应变｜情绪易波动 / 自信果断。",
+          "body_html": null,
+          "payload_json": {
+            "summary": "建议与小程序中 5 条维度进度条搭配展示：外向 / 内向｜天马行空 / 求真务实｜情感细腻 / 理性思考｜运筹帷幄 / 随机应变｜情绪易波动 / 自信果断。",
+            "dimensions": [
+              {
+                "id": "EI",
+                "name": "外向倾向",
+                "label": "外向倾向",
+                "axis_left": "外向",
+                "axis_right": "内向",
+                "summary": "显著偏外向",
+                "description": "你往往是讨论里最活跃的那个人，擅长抛话题、接梗、带节奏。信息在脑子里转得越快，你就越需要一个能一起打球的“对手”。没有互动，你的思路就像没有对手的乒乓球，少了几分精彩。"
+              },
+              {
+                "id": "SN",
+                "name": "心智模式",
+                "label": "心智模式",
+                "axis_left": "天马行空",
+                "axis_right": "求真务实",
+                "summary": "高度偏“天马行空”",
+                "description": "你喜欢从各种看似无关的点之间搭桥，把 A 行业的经验用到 B 场景，再顺手想想 C 领域的可能性。比起一步步按流程执行，你更享受“把点子变成原型”的过程。"
+              },
+              {
+                "id": "TF",
+                "name": "情绪天性",
+                "label": "情绪天性",
+                "axis_left": "情感细腻",
+                "axis_right": "理性思考",
+                "summary": "偏“理性思考”",
+                "description": "你更习惯先看逻辑再看感受。吵架对你来说，往往是一场“观点对局”，而不是“关系危机”。你可能真心觉得：观点可以激烈，但关系照样可以很好。"
+              },
+              {
+                "id": "JP",
+                "name": "应对方式",
+                "label": "应对方式",
+                "axis_left": "运筹帷幄",
+                "axis_right": "随机应变",
+                "summary": "偏“随机应变”",
+                "description": "你不爱被繁琐计划锁死，更擅长在信息不断更新的现场做判断。临时调整、即时应对、随时换思路，对你来说不算打扰，反而是一种刺激。"
+              },
+              {
+                "id": "AT",
+                "name": "身份特征",
+                "label": "身份特征",
+                "axis_left": "情绪易波动",
+                "axis_right": "自信果断",
+                "summary": "偏“自信果断”",
+                "description": "作为自信型 ENTP-A，你对自己的判断和学习能力普遍有底气。实验失败了，你更倾向于归因为“这条路径不适合”，而不是“我不行”，然后迅速把注意力转向下一个可能。"
+              }
+            ]
+          },
+          "sort_order": 30,
+          "is_enabled": true
+        },
+        {
+          "section_key": "career.summary",
+          "render_variant": "rich_text",
+          "body_md": "你的职业成就感，往往来自两个关键词：新鲜感 和 可能性。只要这份工作允许你不断接触新问题、新人、新情境，你就能保持高能量。\n\n长期在高度重复、缺少思考空间的位置上，你会明显感觉被“磨平棱角”；而那些鼓励创新、允许试错、愿意听你提出不同观点的环境，才真正适合你发挥。",
+          "body_html": null,
+          "payload_json": null,
+          "sort_order": 40,
+          "is_enabled": true
+        },
+        {
+          "section_key": "career.advantages",
+          "render_variant": "bullets",
+          "body_md": null,
+          "body_html": null,
+          "payload_json": {
+            "items": [
+              {
+                "title": "点子密集，创意输出不断",
+                "body": "你擅长从各种信息碎片里组合出新方案、新模式和新玩法。在产品、策略、内容、业务创新等场景中，你往往是那个“提出新方向”的人。"
+              },
+              {
+                "title": "善于多角度拆解问题",
+                "body": "遇到复杂议题时，你能迅速提出多种可能视角：“如果从用户看呢？从对手看呢？从成本端看呢？” 这种辩证能力让你在决策讨论中很有价值。"
+              },
+              {
+                "title": "适应变化和不确定性",
+                "body": "对许多人来说会带来焦虑的“不稳定”，对你而言反而是机会。只要边走边调，你就能在混乱中找到新路径。"
+              },
+              {
+                "title": "沟通风格轻松有趣",
+                "body": "你擅长用比喻、段子和故事，把复杂的内容讲得既清楚又好玩。在跨部门沟通、对外表达、内部分享时，你很容易成为“气氛担当”。"
+              }
+            ]
+          },
+          "sort_order": 50,
+          "is_enabled": true
+        },
+        {
+          "section_key": "career.weaknesses",
+          "render_variant": "bullets",
+          "body_md": null,
+          "body_html": null,
+          "payload_json": {
+            "items": [
+              {
+                "title": "容易“开局很猛，收尾乏力”",
+                "body": "你对启动新项目很有动力，但一旦进入重复落实和细节打磨阶段，兴趣就会明显下降，如果没有合适的搭档，项目质量容易受影响。"
+              },
+              {
+                "title": "不耐烦于繁琐细节和官僚流程",
+                "body": "面对冗长审批、复杂汇报和细致文档，你很容易失去耐心，甚至直接绕路，这在某些组织环境下会被视为“不够稳重”。"
+              },
+              {
+                "title": "辩论时容易忽略他人感受",
+                "body": "你在讨论中追求的是观点的锐度和逻辑的精彩，但听的人可能只感受到被反驳、被否定。久而久之，有些人会选择对你“收起真话”。"
+              },
+              {
+                "title": "项目落地和持续跟进不足",
+                "body": "你更享受“解决难题”和“探索新方向”，但对长期维护和日常优化缺乏耐心。如果团队缺少执行型角色，成果可能停留在“概念很好”的阶段。"
+              }
+            ]
+          },
+          "sort_order": 60,
+          "is_enabled": true
+        },
+        {
+          "section_key": "career.preferred_roles",
+          "render_variant": "preferred_role_list",
+          "body_md": null,
+          "body_html": null,
+          "payload_json": {
+            "intro": "下面这些方向并不是 ENTP-A 的唯一选项，但更容易让你感觉“好玩、有挑战、值得一试”。",
+            "groups": [
+              {
+                "group_title": "策略与创新相关",
+                "description": "需要不断拆解问题、设计新方案的岗位。",
+                "examples": [
+                  "商业策划、创新顾问、战略规划相关岗位",
+                  "产品经理（偏0-1阶段）、新业务孵化、增长策略",
+                  "创业合伙人、业务负责人、跨界项目主理人"
+                ]
+              },
+              {
+                "group_title": "内容与表达相关",
+                "description": "用观点、故事和表达影响他人的领域。",
+                "examples": [
+                  "创意策划、广告文案、内容主理人",
+                  "播客 / 视频节目主持、访谈类内容创作者",
+                  "科普 / 观点类KOL、自媒体运营"
+                ]
+              },
+              {
+                "group_title": "咨询与解决方案",
+                "description": "面对复杂问题，提供系统化解决路径的角色。",
+                "examples": [
+                  "管理咨询、品牌咨询、运营咨询",
+                  "用户研究、商业分析、投研相关岗位",
+                  "需要大量“诊断 + 建议”的 B 端服务角色"
+                ]
+              },
+              {
+                "group_title": "动态变化中的前沿领域",
+                "description": "迭代快、机会多、规则还在形成中的赛道。",
+                "examples": [
+                  "互联网 / 科技 / AI / Web3 等新兴行业中的复合型职位",
+                  "创新工作室、孵化器、风投机构中的项目角色"
+                ]
+              }
+            ],
+            "outro": "最关键的不是头衔，而是这份工作是否允许你：持续学习、频繁碰撞、自由提出不同意见，并参与把“想法”推到现实世界里。"
+          },
+          "sort_order": 70,
+          "is_enabled": true
+        },
+        {
+          "section_key": "career.upgrade_suggestions",
+          "render_variant": "bullets",
+          "body_md": "对 ENTP-A 来说，真正拉开职场差距的，往往不是“点子多不多”，而是“你能把多少点子走到第几步”。当你把创意优势和稳定输出能力结合起来，你的上限会非常高。\n\n可以把下面几条，当作你的职场进阶小提示。",
+          "body_html": null,
+          "payload_json": {
+            "items": [
+              {
+                "title": "创意价值 = 想法数量 × 落地深度",
+                "body": "为每个重要点子设定一个“最小完成标准”（MVP），哪怕只做到 1.0 小版本，也比停留在脑海里更有价值。习惯给自己的点子一个“交付节点”。"
+              },
+              {
+                "title": "高效合作 = 你负责开路 × 他人负责铺路",
+                "body": "主动寻找执行力强、细节稳定的伙伴，让他们成为你的“收尾保障”。你负责提出方向和突破，他们负责把项目做厚、做稳。"
+              },
+              {
+                "title": "表达友好度 = 逻辑清晰 × 语气柔软",
+                "body": "在进入犀利反驳之前，先用一句“我懂你在说什么，不过我有个不一样的角度”做缓冲。逻辑不需要打折，语气可以温和一点。"
+              },
+              {
+                "title": "个人品牌 = 专业标签 × 可被信任",
+                "body": "你很容易在公司里被记住为“有想法的人”，下一步是让别人也放心把关键项目交给你。按时交付、提前预警问题、对自己的建议负责，都是构建信任的重要一步。"
+              }
+            ]
+          },
+          "sort_order": 80,
+          "is_enabled": true
+        },
+        {
+          "section_key": "growth.summary",
+          "render_variant": "rich_text",
+          "body_md": "对 ENTP-A 来说，成长不是“变得乖一点”，而是“把你的好奇心和实验精神，从随意挥洒升级为有方向的投入”。\n\n当你既保留“爱问为什么”的本能，又学会为重要的事情多走几步，你的影响力会呈指数级放大。",
+          "body_html": null,
+          "payload_json": null,
+          "sort_order": 90,
+          "is_enabled": true
+        },
+        {
+          "section_key": "growth.strengths",
+          "render_variant": "bullets",
+          "body_md": null,
+          "body_html": null,
+          "payload_json": {
+            "items": [
+              {
+                "title": "快速理解与迁移能力",
+                "body": "你能在短时间内抓住一个新领域的关键逻辑，并把已有经验灵活迁移过去，形成独特视角。"
+              },
+              {
+                "title": "勇于质疑与试验",
+                "body": "你不会轻易接受“大家都这么做”的说法，更愿意自己验证，看看到底有没有更好的路径。"
+              },
+              {
+                "title": "面对失败的恢复力",
+                "body": "作为 ENTP-A，你对失败的态度相对轻盈：“行就行，不行就换条路。” 这让你有条件进行多次尝试，从中积累真实经验。"
+              },
+              {
+                "title": "持续学习的内在驱动",
+                "body": "只要话题足够有趣，你会自动进入深潜模式，一路追溯背景、原理和各种边角信息，形成自己的知识网络。"
+              }
+            ]
+          },
+          "sort_order": 100,
+          "is_enabled": true
+        },
+        {
+          "section_key": "growth.weaknesses",
+          "render_variant": "bullets",
+          "body_md": null,
+          "body_html": null,
+          "payload_json": {
+            "items": [
+              {
+                "title": "注意力容易被新鲜感牵走",
+                "body": "一旦旧项目进入“维护”和“重复”阶段，你就很容易被新的兴趣点吸引，导致旧坑没填完、新坑又开一堆。"
+              },
+              {
+                "title": "对他人感受的敏感度偏低",
+                "body": "在你看来只是“讨论观点”，在别人听来可能是“你在否定我”。如果不注意表达方式，很容易在无意间伤人。"
+              },
+              {
+                "title": "缺乏长期节奏规划",
+                "body": "你擅长短期爆发，却不太愿意为一个目标制定长期、稳定的路线图，这可能让你的成果呈现出“高光多、体系少”的状态。"
+              },
+              {
+                "title": "对平凡日常的耐受度有限",
+                "body": "当生活或工作长时间缺少变化时，你会感到明显的无聊和空虚，甚至用冲动的决定来“打破平静”。"
+              }
+            ]
+          },
+          "sort_order": 110,
+          "is_enabled": true
+        },
+        {
+          "section_key": "growth.motivators",
+          "render_variant": "premium_teaser",
+          "body_md": "新鲜的挑战、聪明的对手、开放的环境和「原来还能这样」的顿悟时刻，都会让你感觉人生充满乐趣。你越能把这些元素注入日常，自然就越有动力成长。",
+          "body_html": null,
+          "payload_json": {
+            "teaser": "新鲜的挑战、聪明的对手、开放的环境和「原来还能这样」的顿悟时刻，都会让你感觉人生充满乐趣。你越能把这些元素注入日常，自然就越有动力成长。",
+            "is_premium": true
+          },
+          "sort_order": 120,
+          "is_enabled": true
+        },
+        {
+          "section_key": "growth.drainers",
+          "render_variant": "premium_teaser",
+          "body_md": "长期被要求“照做就好”、没有发言权、不能质疑或尝试新思路的环境，会迅速掏空你的热情。无意义的重复劳动和僵化规则，是 ENTP-A 的主要能量黑洞。",
+          "body_html": null,
+          "payload_json": {
+            "teaser": "长期被要求“照做就好”、没有发言权、不能质疑或尝试新思路的环境，会迅速掏空你的热情。无意义的重复劳动和僵化规则，是 ENTP-A 的主要能量黑洞。",
+            "is_premium": true
+          },
+          "sort_order": 130,
+          "is_enabled": true
+        },
+        {
+          "section_key": "relationships.summary",
+          "render_variant": "rich_text",
+          "body_md": "在人际关系里，你像一个自带“话题引擎”的同伴：会抛观点、讲故事、抬杠开脑洞，让相处变得不无聊。\n\n你更在意的是“我们能不能一起好好玩、一起思考点什么”，而不是只停留在日常寒暄。对你来说，能聊深度的人，比只聊日常的人更有吸引力。",
+          "body_html": null,
+          "payload_json": null,
+          "sort_order": 140,
+          "is_enabled": true
+        },
+        {
+          "section_key": "relationships.strengths",
+          "render_variant": "bullets",
+          "body_md": null,
+          "body_html": null,
+          "payload_json": {
+            "items": [
+              {
+                "title": "相处轻松、有趣不尴尬",
+                "body": "你很会把冷场变成好玩的讨论，把严肃话题讲得有意思，让身边人觉得：跟你在一起，世界变得更立体。"
+              },
+              {
+                "title": "鼓励别人跳出舒适区",
+                "body": "你会不自觉地对朋友说：“不如试试看？” 你愿意拉别人一起冒一点险、探索一点新可能。"
+              },
+              {
+                "title": "不黏人，尊重对方空间",
+                "body": "你享受互动，但也需要自己的思考和探索时间。你理解“各自精彩，再分享给彼此”的关系模式。"
+              },
+              {
+                "title": "面对冲突相对冷静",
+                "body": "只要对方愿意讲道理，你通常不会害怕冲突，甚至愿意把矛盾当成一次升级关系的机会。"
+              }
+            ]
+          },
+          "sort_order": 150,
+          "is_enabled": true
+        },
+        {
+          "section_key": "relationships.weaknesses",
+          "render_variant": "bullets",
+          "body_md": null,
+          "body_html": null,
+          "payload_json": {
+            "items": [
+              {
+                "title": "表达过于直接，容易被误解",
+                "body": "你说话讲求效率和逻辑，但对方可能更在意语气和场合。你以为是在“理性讨论”，对方却感到“被否定”。"
+              },
+              {
+                "title": "热情有起伏，忽冷忽热",
+                "body": "你会在感兴趣的时候高度投入，一起聊到半夜；但在注意力转移后，又容易暂时淡出，这会让部分人感到困惑或不安。"
+              },
+              {
+                "title": "不擅长处理粘稠情绪",
+                "body": "面对反复纠结、长期负面情绪的对象，你会明显感到不耐烦，甚至想抽离，却又可能因此被指责“不够有同理心”。"
+              },
+              {
+                "title": "对承诺的时间感不同",
+                "body": "你愿意真诚承诺自己在当下能看到的可能，但对你来说，世界随时可能发生变化。这种“动态承诺”，在某些人眼里会显得不够可靠。"
+              }
+            ]
+          },
+          "sort_order": 160,
+          "is_enabled": true
+        },
+        {
+          "section_key": "relationships.rel_advantages",
+          "render_variant": "premium_teaser",
+          "body_md": "在健康的关系里，你能带来新鲜视角、持续的对话和大量的灵感碰撞。你会让对方在你身边变得更勇敢、更开放，也更愿意去尝试他们原本不敢想的选择。",
+          "body_html": null,
+          "payload_json": {
+            "teaser": "在健康的关系里，你能带来新鲜视角、持续的对话和大量的灵感碰撞。你会让对方在你身边变得更勇敢、更开放，也更愿意去尝试他们原本不敢想的选择。",
+            "is_premium": true
+          },
+          "sort_order": 170,
+          "is_enabled": true
+        },
+        {
+          "section_key": "relationships.rel_risks",
+          "render_variant": "premium_teaser",
+          "body_md": "如果长期忽略他人的情绪节奏，只把关系当成“聊得来就好”的思想游乐场，你可能在不知不觉间失去一些在意你的人。学会在观点之外，看见对方的需求，是 ENTP-A 关系升级的关键一步。",
+          "body_html": null,
+          "payload_json": {
+            "teaser": "如果长期忽略他人的情绪节奏，只把关系当成“聊得来就好”的思想游乐场，你可能在不知不觉间失去一些在意你的人。学会在观点之外，看见对方的需求，是 ENTP-A 关系升级的关键一步。",
+            "is_premium": true
+          },
+          "sort_order": 180,
+          "is_enabled": true
+        }
+      ],
+      "seo_overrides": {
+        "seo_title": "ENTP-A 辩论家型",
+        "seo_description": "你像一台随时待命的“头脑加速器”：话题一展开，你就能立刻抛出新观点、新角度、新可能。你不满足于按部就班，更喜欢拆解规则、挑战既定答案，用一场又一场的思维实验，把世界变得更有趣一点。",
+        "canonical_url": null,
+        "og_title": "ENTP-A 头脑风暴者",
+        "og_description": "你像一台随时待命的“头脑加速器”：话题一展开，你就能立刻抛出新观点、新角度、新可能。你不满足于按部就班，更喜欢拆解规则、挑战既定答案，用一场又一场的思维实验，把世界变得更有趣一点。",
+        "og_image_url": null,
+        "twitter_title": "ENTP-A 头脑风暴者",
+        "twitter_description": "你像一台随时待命的“头脑加速器”：话题一展开，你就能立刻抛出新观点、新角度、新可能。你不满足于按部就班，更喜欢拆解规则、挑战既定答案，用一场又一场的思维实验，把世界变得更有趣一点。",
+        "twitter_image_url": null,
+        "robots": null,
+        "jsonld_overrides_json": null
+      }
+    },
+    {
+      "runtime_type_code": "ENTP-T",
+      "canonical_type_code": "ENTP",
+      "variant_code": "T",
+      "is_published": true,
+      "published_at": "2026-03-17T00:00:00Z",
+      "profile_overrides": {
+        "type_name": "辩论家型",
+        "nickname": "灵感玩家",
+        "rarity_text": "约 2–4%",
+        "keywords_json": [
+          "好奇心",
+          "脑洞",
+          "辩证思维",
+          "不按套路",
+          "挑战权威",
+          "快速学习"
+        ],
+        "hero_summary_md": "你像一台永远在线的“脑洞引擎”：问题一冒出来，你的大脑就开始飞速拆解、联想、翻新规则。你不满足于照剧本活，更享受在边走边想、边试边改的过程——世界在你眼里，是一块可以不断被重写的草稿纸。",
+        "hero_summary_html": null
+      },
+      "section_overrides": [
+        {
+          "section_key": "letters_intro",
+          "render_variant": "letters_intro",
+          "body_md": null,
+          "body_html": null,
+          "payload_json": {
+            "headline": "外向 · 直觉 · 思维 · 感知 · 动荡型｜用点子与质疑改写规则的“灵感玩家”",
+            "letters": [
+              {
+                "letter": "E",
+                "title": "外向（E）",
+                "description": "让你乐于把想法抛到台面上，和人一起碰撞、吐槽、头脑风暴。独自思考可以，但“边说边想”更让你兴奋。"
+              },
+              {
+                "letter": "N",
+                "title": "直觉（N）",
+                "description": "让你天然关注可能性与模式，而不是只看眼前事实。你总能从零散信息里看出“背后的逻辑”和“还可以怎么玩”。"
+              },
+              {
+                "letter": "T",
+                "title": "思维（T）",
+                "description": "让你习惯用逻辑和框架来分析问题，遇到观点时本能是“先拆解，再判断”，即使对方是权威，你也愿意提出不同看法。"
+              },
+              {
+                "letter": "P",
+                "title": "感知（P）",
+                "description": "让你更偏爱开放式选项，而非被固定方案束缚。你喜欢保留机动空间，随时根据新信息调整路线。"
+              },
+              {
+                "letter": "T",
+                "title": "动荡型（-T）",
+                "description": "让你在兴奋与怀疑之间反复切换：今天觉得“我简直太有潜力了”，明天又会反思“我是不是又拖延了”。这种自我质疑既带来压力，也推动你不断升级。"
+              }
+            ]
+          },
+          "sort_order": 10,
+          "is_enabled": true
+        },
+        {
+          "section_key": "overview",
+          "render_variant": "rich_text",
+          "body_md": "在费马心理的逻辑模型里，ENTP-T 常被视作“用点子撬动世界的规则打破者”。你天生对“为什么要这样？”敏感，不太愿意直接接受现成答案，更想亲自拆一拆、想一想：有没有更好玩、更高效、更不按套路的做法？\n\n你享受的是探索与推演本身：和人辩论、反向思考、把一个观点从正反两面翻来覆去，对你来说都是乐趣。你未必真的想证明别人错了，而是想看看：如果我们换一种角度，会发生什么？\n\n对你来说，最有生命力的状态是：问题足够有挑战，信息足够新鲜，身边有人愿意和你一起头脑风暴，而不是要求你“照原计划安静执行”。在高压、僵化、拒绝质疑的环境里，你会迅速失去能量。",
+          "body_html": null,
+          "payload_json": null,
+          "sort_order": 20,
+          "is_enabled": true
+        },
+        {
+          "section_key": "trait_overview",
+          "render_variant": "trait_dimension_grid",
+          "body_md": "建议与小程序中 5 条维度进度条搭配展示：外向 / 内向｜天马行空 / 求真务实｜情感细腻 / 理性思考｜运筹帷幄 / 随机应变｜情绪易波动 / 自信果断。",
+          "body_html": null,
+          "payload_json": {
+            "summary": "建议与小程序中 5 条维度进度条搭配展示：外向 / 内向｜天马行空 / 求真务实｜情感细腻 / 理性思考｜运筹帷幄 / 随机应变｜情绪易波动 / 自信果断。",
+            "dimensions": [
+              {
+                "id": "EI",
+                "name": "外向倾向",
+                "label": "外向倾向",
+                "axis_left": "外向",
+                "axis_right": "内向",
+                "summary": "偏外向",
+                "description": "你更像是那个主动抛问题、开脑洞、带节奏的人。你喜欢在讨论中即兴输出，越有互动，思路越清晰。独处可以，但如果长时间没人可以聊天对线，你会觉得自己“被闷坏了”。"
+              },
+              {
+                "id": "SN",
+                "name": "心智模式",
+                "label": "心智模式",
+                "axis_left": "天马行空",
+                "axis_right": "求真务实",
+                "summary": "明显偏“天马行空”",
+                "description": "你习惯跳出当下，去看“如果……会怎样”。你爱假设、爱类比、爱把不同领域的点连成线。细节对你来说重要，但只在它能服务一个更大、更有趣的想法时才值得花时间。"
+              },
+              {
+                "id": "TF",
+                "name": "情绪天性",
+                "label": "情绪天性",
+                "axis_left": "情感细腻",
+                "axis_right": "理性思考",
+                "summary": "偏“理性思考”",
+                "description": "你面对问题更倾向于先看逻辑，再看感受。你喜欢在观点层面较真，有时会因为太专注于“论点是否成立”，而忽略“对方的心情是否接受得了”。"
+              },
+              {
+                "id": "JP",
+                "name": "应对方式",
+                "label": "应对方式",
+                "axis_left": "运筹帷幄",
+                "axis_right": "随机应变",
+                "summary": "偏“随机应变”",
+                "description": "你不喜欢把路线锁死，更享受在变化中实时调整。计划对你来说是“当前版本”，而不是“最终答案”。一旦出现新信息，你会立刻更新策略。"
+              },
+              {
+                "id": "AT",
+                "name": "身份特征",
+                "label": "身份特征",
+                "axis_left": "情绪易波动",
+                "axis_right": "自信果断",
+                "summary": "略偏“情绪易波动”",
+                "description": "你表面看起来很自信、很敢说，但内心常在拉扯：一边觉得自己很聪明，一边又担心“是不是又只是想得多，做得不够”。这种自我审视会让你时不时陷入短暂低落，但也逼着你寻找更高效的自我管理方式。"
+              }
+            ]
+          },
+          "sort_order": 30,
+          "is_enabled": true
+        },
+        {
+          "section_key": "career.summary",
+          "render_variant": "rich_text",
+          "body_md": "你的职业偏好，往往围绕“解决有意思的问题”和“创造新东西”展开。只要一份工作允许你提出问题、挑战旧有做法、设计新方案，你就很容易保持高昂的好奇心。\n\n长期只做重复、细碎、缺乏挑战的事务，会严重消耗你的能量；当被要求“不要问为什么，照做就行”时，你会迅速对这份工作失去耐心。\n\n相反，当你被放在探索型、创新型、策略型岗位，有空间去试错、有队友愿意和你一起讨论，你就能把自己的优势发挥到极致。",
+          "body_html": null,
+          "payload_json": null,
+          "sort_order": 40,
+          "is_enabled": true
+        },
+        {
+          "section_key": "career.advantages",
+          "render_variant": "bullets",
+          "body_md": null,
+          "body_html": null,
+          "payload_json": {
+            "items": [
+              {
+                "title": "思维敏捷，善于拆解复杂问题",
+                "body": "你能在很短时间内抓住问题的关键点，从多个角度分析利弊，提出别人一时想不到的切入方式。"
+              },
+              {
+                "title": "创意与点子不断",
+                "body": "你的大脑像一个永不停机的创意工厂。无论是产品方案、营销活动还是商业模式，你都能快速抛出一串“可以试试”的想法。"
+              },
+              {
+                "title": "敢于质疑与挑战",
+                "body": "你不迷信权威，看到不合理的流程或陈旧的规则，会主动提出改进意见。这种气质在需要突破与创新的团队里非常宝贵。"
+              },
+              {
+                "title": "适应变化，抗无聊能力弱但抗变化能力强",
+                "body": "新项目、新赛道、新问题会让你充满干劲。别人害怕的“变”，对你来说反而是刷新游戏关卡的机会。"
+              }
+            ]
+          },
+          "sort_order": 50,
+          "is_enabled": true
+        },
+        {
+          "section_key": "career.weaknesses",
+          "render_variant": "bullets",
+          "body_md": null,
+          "body_html": null,
+          "payload_json": {
+            "items": [
+              {
+                "title": "执行节奏容易碎片化",
+                "body": "你更擅长“开局”和“策划”，对后续细致、重复的执行容易感到厌烦，可能出现开头很猛、后劲不足的情况。"
+              },
+              {
+                "title": "项目收尾能力有待加强",
+                "body": "当一个项目进入收尾阶段、创新空间变少时，你的兴趣也会快速下降，容易在“还差最后一点”时转头去追新的想法。"
+              },
+              {
+                "title": "沟通锋利度偏高",
+                "body": "你在辩论状态下容易火力全开，为了把逻辑讲清楚而忽略对方感受，让一些人觉得“你在杠”而不是“你在讨论”。"
+              },
+              {
+                "title": "对结构化管理环境耐受度低",
+                "body": "高度科层化、强调流程服从与“少问为什么”的公司文化，会让你感到窒息。你很难在这种环境里长期保持热情。"
+              }
+            ]
+          },
+          "sort_order": 60,
+          "is_enabled": true
+        },
+        {
+          "section_key": "career.preferred_roles",
+          "render_variant": "preferred_role_list",
+          "body_md": null,
+          "body_html": null,
+          "payload_json": {
+            "intro": "这些方向的共通点是：问题足够有挑战，思考空间足够大，执行方式不被完全锁死。它们可以作为 ENTP-T 的职业探索灵感库。",
+            "groups": [
+              {
+                "group_title": "策略与解决方案类",
+                "description": "可以大量思考、拆解问题、做方案设计的岗位。",
+                "examples": [
+                  "战略咨询、商业分析、创新项目顾问",
+                  "产品经理、增长策略、商业运营策划",
+                  "创业团队的联合创始人或“智囊型合伙人”"
+                ]
+              },
+              {
+                "group_title": "内容与创意相关",
+                "description": "允许你输出观点、讲故事、玩创意的领域。",
+                "examples": [
+                  "内容创作者 / 自媒体主理人 / 播客主持",
+                  "广告创意、品牌策划、活动策划",
+                  "知识型主播、辩论 / 访谈节目相关岗位"
+                ]
+              },
+              {
+                "group_title": "科技与新兴领域",
+                "description": "变化快、容错高、需要不断试错和迭代的环境。",
+                "examples": [
+                  "互联网 / AI / Web3 等新兴行业产品或运营",
+                  "创新实验室、风投机构的项目挖掘与评估",
+                  "新业务孵化、0→1 项目负责人"
+                ]
+              },
+              {
+                "group_title": "跨界与综合型角色",
+                "description": "不被严格专业边界限制，可以同时兼顾思考、沟通与尝试的岗位。",
+                "examples": [
+                  "社区运营 + 内容 + 活动一体化角色",
+                  "早期创业公司多面手",
+                  "需要频繁对接内外部资源的项目推动者"
+                ]
+              }
+            ],
+            "outro": "相比固定岗位名称，你更需要关注的是：这份工作能否让你持续用大脑拆解问题、提出点子、尝试新路径，而不是被困在“照流程走”的日常里。"
+          },
+          "sort_order": 70,
+          "is_enabled": true
+        },
+        {
+          "section_key": "career.upgrade_suggestions",
+          "render_variant": "bullets",
+          "body_md": "对 ENTP-T 来说，真正的职业天花板往往不在“智商”和“点子”，而在“落地能力”和“长期耐力”。当你学会把创意和执行拉在一起，你会变得非常可怕——既想得远，又做得成。\n\n可以把下面几条公式，当成你在职场里经常自查的提示。",
+          "body_html": null,
+          "payload_json": {
+            "items": [
+              {
+                "title": "创意价值 = 点子数量 × 落地比例",
+                "body": "继续做那个提出好点子的人，但刻意训练自己每个阶段至少“送一两个点子到终点”。对你来说，完成一个项目，比再多想十个新项目更能提升长期影响力。"
+              },
+              {
+                "title": "自由度 = 边界清晰度 × 责任感",
+                "body": "想要更多自主空间，就要更主动地说清楚：我负责哪一块、做到什么程度、在什么时间节点汇报。你越能让别人放心，别人就越愿意放手。"
+              },
+              {
+                "title": "说服力 = 逻辑清晰度 × 共情表达",
+                "body": "在高强度辩论之前，多花 10 秒想一句：“我懂你担心的是……”。当别人感觉被理解时，你的强逻辑才更容易被听进去，而不是被当成“抬杠”。"
+              },
+              {
+                "title": "长期成就感 = 项目闭环数",
+                "body": "定期给自己做一个“小结题清单”：过去半年，我真正完整做完了多少事情？不是只是参与，而是从 0 到 1，或从 1 到收官。闭环越多，你的职业故事就越扎实。"
+              }
+            ]
+          },
+          "sort_order": 80,
+          "is_enabled": true
+        },
+        {
+          "section_key": "growth.summary",
+          "render_variant": "rich_text",
+          "body_md": "对 ENTP-T 来说，成长不是“乖乖变稳定”，而是学会在保持好奇与锋利的同时，让自己的行动更有方向感和持续性。\n\n你既不甘心被日常磨平，又不想永远停留在“想得多、做得少”的悖论里。这一章，会帮你看清：你的天然优势、典型短板，以及能帮你升级的关键杠杆。",
+          "body_html": null,
+          "payload_json": null,
+          "sort_order": 90,
+          "is_enabled": true
+        },
+        {
+          "section_key": "growth.strengths",
+          "render_variant": "bullets",
+          "body_md": null,
+          "body_html": null,
+          "payload_json": {
+            "items": [
+              {
+                "title": "学习速度快，知识迁移能力强",
+                "body": "你能在短时间内抓住一个领域的核心逻辑，并快速将不同领域的知识串联在一起，形成自己的理解框架。"
+              },
+              {
+                "title": "敢于质疑与试错",
+                "body": "你不怕犯错，更怕“从来没试过”。这种勇气让你比别人更容易在新领域抢先一步。"
+              },
+              {
+                "title": "幽默感与自嘲能力",
+                "body": "你擅长用幽默化解尴尬，也能调侃自己的缺点。这让你在人际互动中显得很轻松，降低了沟通成本。"
+              },
+              {
+                "title": "能把无聊的事变得有趣",
+                "body": "你会给生活中的例行公事加点“小游戏”或“自我挑战”，用自己的方式提高可玩性，这也是你长期保持好奇心的秘诀之一。"
+              }
+            ]
+          },
+          "sort_order": 100,
+          "is_enabled": true
+        },
+        {
+          "section_key": "growth.weaknesses",
+          "render_variant": "bullets",
+          "body_md": null,
+          "body_html": null,
+          "payload_json": {
+            "items": [
+              {
+                "title": "计划执行容易碎片化",
+                "body": "你常常同时启动很多项目，却很难用同样的热情把它们逐个收尾，导致“未完成事项清单”越堆越长。"
+              },
+              {
+                "title": "容易被新鲜感牵着走",
+                "body": "只要出现更有趣的诱饵，你就很难对当前任务保持耐心，这会削弱你在长期项目中的稳定表现。"
+              },
+              {
+                "title": "情绪波动被自己当成“无所谓”",
+                "body": "你习惯用玩笑和转移注意力来应对低落，但真正的焦虑和自我怀疑可能被压在很深的地方，没有好好被看见和整理。"
+              },
+              {
+                "title": "容易忽略身体与节奏",
+                "body": "当你对某件事上头时，很容易连夜熬、爆肝式输出，等到项目告一段落才意识到自己已经透支。长期下去会影响健康和持续战斗力。"
+              }
+            ]
+          },
+          "sort_order": 110,
+          "is_enabled": true
+        },
+        {
+          "section_key": "growth.motivators",
+          "render_variant": "premium_teaser",
+          "body_md": "新问题、新视角、新挑战，以及能与你平等讨论、一起对线的人，都会让你感觉“活过来了”。当你被信任去负责有难度的任务，又被允许用自己的方式解决，你会爆发出极强的创造力。",
+          "body_html": null,
+          "payload_json": {
+            "teaser": "新问题、新视角、新挑战，以及能与你平等讨论、一起对线的人，都会让你感觉“活过来了”。当你被信任去负责有难度的任务，又被允许用自己的方式解决，你会爆发出极强的创造力。",
+            "is_premium": true
+          },
+          "sort_order": 120,
+          "is_enabled": true
+        },
+        {
+          "section_key": "growth.drainers",
+          "render_variant": "premium_teaser",
+          "body_md": "机械重复、缺乏意义感的工作；动机不清晰、却要求你闭嘴执行的环境；以及被误解为“只会抬杠、不会做事”的评价，都会悄悄掏空你的能量，让你开始想“要不要直接跑路”。",
+          "body_html": null,
+          "payload_json": {
+            "teaser": "机械重复、缺乏意义感的工作；动机不清晰、却要求你闭嘴执行的环境；以及被误解为“只会抬杠、不会做事”的评价，都会悄悄掏空你的能量，让你开始想“要不要直接跑路”。",
+            "is_premium": true
+          },
+          "sort_order": 130,
+          "is_enabled": true
+        },
+        {
+          "section_key": "relationships.summary",
+          "render_variant": "rich_text",
+          "body_md": "在人际关系里，你像一股“不容易无聊的风”。你带来的是观点碰撞、思维刺激和轻松玩笑，让很多人因为你而第一次发现：原来聊一个话题可以这么有趣。\n\n你在乎的，不只是“合不合拍”，还包括：这个人愿不愿意跟你一起思考？能不能接受你的不按套路？在你真心认定的关系里，你希望对方既是玩伴，也是并肩作战的队友。",
+          "body_html": null,
+          "payload_json": null,
+          "sort_order": 140,
+          "is_enabled": true
+        },
+        {
+          "section_key": "relationships.strengths",
+          "render_variant": "bullets",
+          "body_md": null,
+          "body_html": null,
+          "payload_json": {
+            "items": [
+              {
+                "title": "相处不无聊，随时能打开新话题",
+                "body": "你总能从一个小细节延伸到一个有意思的话题。和你在一起，很少冷场，更多是“怎么又聊嗨了”。"
+              },
+              {
+                "title": "不以“标签”评判人",
+                "body": "你对各种类型的人都抱有好奇心，更愿意探索“你为什么会这样想”，而不是急着给出好坏评判。"
+              },
+              {
+                "title": "愿意在观点上认真交流",
+                "body": "你享受和亲近的人进行深度对话，愿意彼此挑战、互相启发，把对方当成值得认真交流的大脑伙伴。"
+              },
+              {
+                "title": "不黏人，但可以很给空间",
+                "body": "你不喜欢控制别人，也不喜欢被控制。你更擅长的是：在需要你的时候随时出现，在不需要的时候各自精彩。"
+              }
+            ]
+          },
+          "sort_order": 150,
+          "is_enabled": true
+        },
+        {
+          "section_key": "relationships.weaknesses",
+          "render_variant": "bullets",
+          "body_md": null,
+          "body_html": null,
+          "payload_json": {
+            "items": [
+              {
+                "title": "容易被误解为“只会抬杠”",
+                "body": "你本意是从不同角度讨论问题，但在对方看来，可能像是在否定或挑衅，对方的情绪可能跟不上你的辩论节奏。"
+              },
+              {
+                "title": "表达感受时容易转成开玩笑",
+                "body": "你不太习惯赤裸裸地说出自己的脆弱，常常用玩笑、转移话题来掩饰真实感受，结果是对方很难真正读懂你。"
+              },
+              {
+                "title": "新鲜感退去后容易走神",
+                "body": "在关系稳定后，如果缺少共同成长和新体验，你可能会开始心不在焉，把精力转移到其他事情上，让对方感到被冷落。"
+              },
+              {
+                "title": "边界感有时过于“放飞”",
+                "body": "你不喜欢被束缚，但如果完全不说明自己的界限和底线，可能会让对方感到不安全、不确定这段关系能走多远。"
+              }
+            ]
+          },
+          "sort_order": 160,
+          "is_enabled": true
+        },
+        {
+          "section_key": "relationships.rel_advantages",
+          "render_variant": "premium_teaser",
+          "body_md": "在健康的关系里，你能带给对方的是：思维上的拓展、生活上的乐趣，还有“原来我也可以这样想”的新可能。你会成为很多人眼中那个“跟你聊完，世界变大了一圈”的朋友或伴侣。",
+          "body_html": null,
+          "payload_json": {
+            "teaser": "在健康的关系里，你能带给对方的是：思维上的拓展、生活上的乐趣，还有“原来我也可以这样想”的新可能。你会成为很多人眼中那个“跟你聊完，世界变大了一圈”的朋友或伴侣。",
+            "is_premium": true
+          },
+          "sort_order": 170,
+          "is_enabled": true
+        },
+        {
+          "section_key": "relationships.rel_risks",
+          "render_variant": "premium_teaser",
+          "body_md": "当你一路追逐新鲜感，却没停下来照顾好当下的关系时，你可能会突然发现：有些人已经悄悄退出了你的生命。学会在“探索更大的世界”和“维护重要的人”之间找到平衡，是 ENTP-T 需要认真面对的一课。",
+          "body_html": null,
+          "payload_json": {
+            "teaser": "当你一路追逐新鲜感，却没停下来照顾好当下的关系时，你可能会突然发现：有些人已经悄悄退出了你的生命。学会在“探索更大的世界”和“维护重要的人”之间找到平衡，是 ENTP-T 需要认真面对的一课。",
+            "is_premium": true
+          },
+          "sort_order": 180,
+          "is_enabled": true
+        }
+      ],
+      "seo_overrides": {
+        "seo_title": "ENTP-T 辩论家型",
+        "seo_description": "你像一台永远在线的“脑洞引擎”：问题一冒出来，你的大脑就开始飞速拆解、联想、翻新规则。你不满足于照剧本活，更享受在边走边想、边试边改的过程——世界在你眼里，是一块可以不断被重写的草稿纸。",
+        "canonical_url": null,
+        "og_title": "ENTP-T 灵感玩家",
+        "og_description": "你像一台永远在线的“脑洞引擎”：问题一冒出来，你的大脑就开始飞速拆解、联想、翻新规则。你不满足于照剧本活，更享受在边走边想、边试边改的过程——世界在你眼里，是一块可以不断被重写的草稿纸。",
+        "og_image_url": null,
+        "twitter_title": "ENTP-T 灵感玩家",
+        "twitter_description": "你像一台永远在线的“脑洞引擎”：问题一冒出来，你的大脑就开始飞速拆解、联想、翻新规则。你不满足于照剧本活，更享受在边走边想、边试边改的过程——世界在你眼里，是一块可以不断被重写的草稿纸。",
+        "twitter_image_url": null,
+        "robots": null,
+        "jsonld_overrides_json": null
+      }
+    },
+    {
+      "runtime_type_code": "ESFJ-A",
+      "canonical_type_code": "ESFJ",
+      "variant_code": "A",
+      "is_published": true,
+      "published_at": "2026-03-17T00:00:00Z",
+      "profile_overrides": {
+        "type_name": "执政官型",
+        "nickname": "温暖组织者",
+        "rarity_text": "约 6–8%",
+        "keywords_json": [
+          "体贴",
+          "组织力",
+          "责任感",
+          "秩序感",
+          "人际协调",
+          "稳定乐观"
+        ],
+        "hero_summary_md": "你像一位温暖而有条理的「生活总务」：一边照顾每个人的感受，一边让事情稳稳落地。只要有你在，场面就不会乱，细节有人看见，日常会变得更有秩序和温度。",
+        "hero_summary_html": null
+      },
+      "section_overrides": [
+        {
+          "section_key": "letters_intro",
+          "render_variant": "letters_intro",
+          "body_md": null,
+          "body_html": null,
+          "payload_json": {
+            "headline": "外向 · 现实 · 情感 · 规划 · 自信型｜把关怀落到每一个细节的“温暖组织者”",
+            "letters": [
+              {
+                "letter": "E",
+                "title": "外向（E）",
+                "description": "让你享受真实的线下场景——一起吃饭、开会、活动现场，比起独自待着，你更喜欢和人在一起、把气氛带热。"
+              },
+              {
+                "letter": "S",
+                "title": "现实（S）",
+                "description": "让你特别关注「眼前看得见、摸得着」的事情：流程顺不顺、东西够不够、细节到不到位，比起宏大概念，你更信事实和经验。"
+              },
+              {
+                "letter": "F",
+                "title": "情感（F）",
+                "description": "让你在做决定时，会优先考虑「这样做会不会伤到谁？」你希望每个人都被好好对待，而不是只看冷冰冰的结果。"
+              },
+              {
+                "letter": "J",
+                "title": "规划（J）",
+                "description": "让你习惯先排好时间表、列好清单、规划流程。你不喜欢临时变卦和混乱，更希望一切都「有安排、有节奏」。"
+              },
+              {
+                "letter": "A",
+                "title": "自信型（-A）",
+                "description": "让你在多数时候比较稳定、乐观，对自己的判断有基本信心，不容易被小波动彻底打乱节奏，更愿意相信「事情总能被解决」。"
+              }
+            ]
+          },
+          "sort_order": 10,
+          "is_enabled": true
+        },
+        {
+          "section_key": "overview",
+          "render_variant": "rich_text",
+          "body_md": "在费马心理的逻辑模型里，ESFJ-A 常被视作「把关怀落实到日常细节的人」。你不会只停留在口头上的温柔，而是会动手、动脑，把关心变成具体可见的行动——一条条消息、一句句问候、一桌桌饭菜、一次次协调。\n\n对你来说，最舒服的状态是：每个人都有位置、每件事都有安排、氛围是温暖的、规则是清楚的。你很擅长在「人」和「秩序」之间找到平衡，让一个家庭、班级、团队都运转得井井有条。\n\n当场面混乱、没人负责、信息不透明、有人被忽视时，你会很不适应——也会很自然地站出来：「我来理一下，我们一个个来解决。」你的人生追求很实际：让身边的日常更顺一点、人和人之间更近一点。",
+          "body_html": null,
+          "payload_json": null,
+          "sort_order": 20,
+          "is_enabled": true
+        },
+        {
+          "section_key": "trait_overview",
+          "render_variant": "trait_dimension_grid",
+          "body_md": "建议与小程序中 5 条维度进度条搭配展示：外向 / 内向｜天马行空 / 求真务实｜情感细腻 / 理性思考｜运筹帷幄 / 随机应变｜情绪易波动 / 自信果断。",
+          "body_html": null,
+          "payload_json": {
+            "summary": "建议与小程序中 5 条维度进度条搭配展示：外向 / 内向｜天马行空 / 求真务实｜情感细腻 / 理性思考｜运筹帷幄 / 随机应变｜情绪易波动 / 自信果断。",
+            "dimensions": [
+              {
+                "id": "EI",
+                "name": "外向倾向",
+                "label": "外向倾向",
+                "axis_left": "外向",
+                "axis_right": "内向",
+                "summary": "明显偏外向",
+                "description": "你往往是那个主动打招呼、张罗聚会、把人拉进群聊的人。热闹的人际互动会让你感觉「生活在动起来」，长时间一个人待着，会让你觉得有点空。"
+              },
+              {
+                "id": "SN",
+                "name": "心智模式",
+                "label": "心智模式",
+                "axis_left": "天马行空",
+                "axis_right": "求真务实",
+                "summary": "明显偏“求真务实”",
+                "description": "你更习惯从现实细节出发：这件事怎么安排？谁负责？今天先解决哪一步？比起长远的抽象概念，你更愿意一步步把眼前的事情做好。"
+              },
+              {
+                "id": "TF",
+                "name": "情绪天性",
+                "label": "情绪天性",
+                "axis_left": "情感细腻",
+                "axis_right": "理性思考",
+                "summary": "偏“情感细腻”",
+                "description": "你很敏感别人今天开不开心、累不累，是不是被冷落了。你在意的，不只是任务有没有完成，还有「大家在这个过程中有没有被照顾到」。"
+              },
+              {
+                "id": "JP",
+                "name": "应对方式",
+                "label": "应对方式",
+                "axis_left": "运筹帷幄",
+                "axis_right": "随机应变",
+                "summary": "偏“运筹帷幄”",
+                "description": "你喜欢提前想好流程与步骤，从场地、人手到时间安排，都希望提前确定下来。突发状况可以应付，但如果所有事都临时决定，会让你很不安。"
+              },
+              {
+                "id": "AT",
+                "name": "身份特征",
+                "label": "身份特征",
+                "axis_left": "情绪易波动",
+                "axis_right": "自信果断",
+                "summary": "略偏“自信果断”",
+                "description": "自信型的你整体情绪比较平稳，不太会长时间陷在自我怀疑里。你更倾向于相信自己的判断：「先按现在最合理的做，出了问题再一起调整。」"
+              }
+            ]
+          },
+          "sort_order": 30,
+          "is_enabled": true
+        },
+        {
+          "section_key": "career.summary",
+          "render_variant": "rich_text",
+          "body_md": "你的职业选择，往往围绕两个核心：一是「和人打交道」，二是「让日常运转顺畅」。只要能在现实世界里看到自己的付出立刻带来改善，你就会很有成就感。\n\n纯粹孤立、长期只和文件或数据打交道、又看不见对人的影响的工作，会逐渐耗尽你的能量；相反，当一份工作允许你组织、协调、服务、照顾，并看到别人因为你的存在变得更轻松时，你会非常投入。\n\n你适合待在「人群的中间位置」：一手连着具体执行，一手连着规则制度，既能听见真实需求，又能推动事情按照秩序向前走。",
+          "body_html": null,
+          "payload_json": null,
+          "sort_order": 40,
+          "is_enabled": true
+        },
+        {
+          "section_key": "career.advantages",
+          "render_variant": "bullets",
+          "body_md": null,
+          "body_html": null,
+          "payload_json": {
+            "items": [
+              {
+                "title": "强大的执行与落地能力",
+                "body": "你不喜欢空中楼阁式的方案，更擅长把任务拆成「今天要做什么」「谁来做」「做到什么标准」，让计划真正实施起来。"
+              },
+              {
+                "title": "氛围营造者与人际润滑剂",
+                "body": "你擅长照顾团队氛围：谁有压力、谁被忽略、哪里有小矛盾，你往往第一个察觉，并主动去安抚、协调、补位。"
+              },
+              {
+                "title": "高度责任感与守信用",
+                "body": "答应的事情，你会尽量做到；承担的职责，你会认真负责。别人会很自然地把「重要但烦琐的事」交给你，因为你做事细致、值得信任。"
+              },
+              {
+                "title": "善于维护秩序与规则",
+                "body": "你理解制度存在的意义，也愿意做执行规则的人。你会提醒大家遵守流程、照顾集体利益，让团队不至于陷入混乱。"
+              }
+            ]
+          },
+          "sort_order": 50,
+          "is_enabled": true
+        },
+        {
+          "section_key": "career.weaknesses",
+          "render_variant": "bullets",
+          "body_md": null,
+          "body_html": null,
+          "payload_json": {
+            "items": [
+              {
+                "title": "对冲突和负面反馈不太适应",
+                "body": "你偏好和谐的氛围，一旦出现直接冲突、冷处理或者强硬批评，你会很不舒服，有时会下意识回避「说真话」。"
+              },
+              {
+                "title": "过于忙于照顾他人",
+                "body": "你很容易成为团队里的「情绪垃圾桶 + 生活管理员」，承担大量额外工作与情绪劳动，却不一定被正式算进绩效。"
+              },
+              {
+                "title": "对变化和不确定感到焦虑",
+                "body": "如果目标频繁变化、流程经常重来、标准说不清，你会感到非常不安，甚至开始质疑团队或管理的可靠性。"
+              },
+              {
+                "title": "容易忽略长远发展",
+                "body": "你很擅长处理眼前的事，但有时会被日常忙碌吞没，没空停下来思考：我想走向哪里？这份工作三五年后会带我去哪儿？"
+              }
+            ]
+          },
+          "sort_order": 60,
+          "is_enabled": true
+        },
+        {
+          "section_key": "career.preferred_roles",
+          "render_variant": "preferred_role_list",
+          "body_md": null,
+          "body_html": null,
+          "payload_json": {
+            "intro": "下面这些方向并不是 ESFJ-A 唯一的选择，但更容易让你感到「我做的事情，对人有用、对日常有帮助」。",
+            "groups": [
+              {
+                "group_title": "日常运营与行政支持",
+                "description": "让组织顺畅运转的「中枢神经」。",
+                "examples": [
+                  "行政 / 办公室管理 / 前台接待",
+                  "运营专员、班主任助理、店长助理",
+                  "团队助理、项目协调、客户支持"
+                ]
+              },
+              {
+                "group_title": "教育与照顾型岗位",
+                "description": "能在日常陪伴中，看见他人一点点变好的工作。",
+                "examples": [
+                  "幼教老师、小学老师、班主任",
+                  "托育 / 护理 / 社区服务相关岗位",
+                  "社工、学生事务管理"
+                ]
+              },
+              {
+                "group_title": "服务与关系维护",
+                "description": "需要大量一线沟通与关系维护的场景。",
+                "examples": [
+                  "客服、销售支持、会员运营",
+                  "线下门店管理、餐饮 / 酒店运营",
+                  "活动执行、会议 / 展会统筹"
+                ]
+              },
+              {
+                "group_title": "团队文化与人事管理",
+                "description": "在照顾人心与维护秩序之间搭桥，让「制度」与「人性」更好地结合。",
+                "examples": [
+                  "HR 专员 / HRBP 初级岗位",
+                  "团队文化 / 员工关怀 / 内部活动组织",
+                  "中小团队管理者 / 班组长 / 店长"
+                ]
+              }
+            ],
+            "outro": "更重要的不是职位的「名片有多好看」，而是：你有没有机会通过日常行动，让别人因为你的存在，过得更轻松、更安心。"
+          },
+          "sort_order": 70,
+          "is_enabled": true
+        },
+        {
+          "section_key": "career.upgrade_suggestions",
+          "render_variant": "bullets",
+          "body_md": "对 ESFJ-A 来说，职业上的天花板，往往不在于你做事不够认真，而在于：是否敢于争取、能否为自己发声、有没有留出成长空间。\n\n你可以把下面这几条，当作自己的职场小原则。",
+          "body_html": null,
+          "payload_json": {
+            "items": [
+              {
+                "title": "原则一：关心他人之前，先关心自己的边界",
+                "body": "当你总是在「帮别人补位」时，很容易忘了问一句：这是否真的是我的责任？适当地把多余的工作退回流程，而不是全揽在自己身上，是一种成熟。"
+              },
+              {
+                "title": "原则二：不要只做「默默付出」的人",
+                "body": "把自己做过的、对团队有价值的事情记录下来：谁因为你更顺利、哪些麻烦被你提前预防。在合适的场合，用事实而不是抱怨，让重要的人看到你的贡献。"
+              },
+              {
+                "title": "原则三：在稳定中为自己留一块成长区",
+                "body": "在熟悉的岗位上，也可以刻意为自己增加一点点挑战：学一项新技能、主动负责一个小项目，让职业路径不只停留在「我在维持现状」。"
+              },
+              {
+                "title": "原则四：学会在规则内，提出改进建议",
+                "body": "你对流程和细节很敏感，比很多人更早发现问题。不要只在心里吐槽，可以练习提出「具体、可执行」的小建议，让自己从执行者，慢慢走向优化者。"
+              }
+            ]
+          },
+          "sort_order": 80,
+          "is_enabled": true
+        },
+        {
+          "section_key": "growth.summary",
+          "render_variant": "rich_text",
+          "body_md": "对 ESFJ-A 来说，成长不是「变成一个完全不一样的人」，而是：在保持温暖、可靠的同时，学会照顾自己、表达自己、为自己争取更长远的空间。\n\n这一部分，会从你的强项、短板，以及能量来源与消耗点，帮你更理性地看见自己的成长路径。",
+          "body_html": null,
+          "payload_json": null,
+          "sort_order": 90,
+          "is_enabled": true
+        },
+        {
+          "section_key": "growth.strengths",
+          "render_variant": "bullets",
+          "body_md": null,
+          "body_html": null,
+          "payload_json": {
+            "items": [
+              {
+                "title": "稳定靠谱的执行者",
+                "body": "你可以把很多零碎的、繁琐的事情安排得井井有条，让别人真正感受到「放心交给你就好」。"
+              },
+              {
+                "title": "乐于维护关系",
+                "body": "你会主动维系联系、记得他人的重要时刻、营造聚在一起的机会，让一群人之间不至于慢慢疏远。"
+              },
+              {
+                "title": "珍惜眼前的小幸福",
+                "body": "你对生活中的小确幸很敏感：一顿好吃的饭、一句赞美、一点仪式感，都能让你很满足，这让你拥有不俗的「日常幸福感」。"
+              },
+              {
+                "title": "愿意为集体承担",
+                "body": "无论是家庭、宿舍还是团队，你很自然会多承担一点，让整个系统运转得更顺畅。这种责任心，是很多人信任你的原因。"
+              }
+            ]
+          },
+          "sort_order": 100,
+          "is_enabled": true
+        },
+        {
+          "section_key": "growth.weaknesses",
+          "render_variant": "bullets",
+          "body_md": null,
+          "body_html": null,
+          "payload_json": {
+            "items": [
+              {
+                "title": "容易被「别人需要我」绑架",
+                "body": "当别人总是来找你帮忙、求助、倾诉时，你很难拒绝，也不太会说「我也很累」，久而久之把自己压到极限。"
+              },
+              {
+                "title": "害怕被当成「不好相处的人」",
+                "body": "你可能会为了不影响气氛，而压抑真实的不满和边界，宁可自己辛苦一点，也不愿让别人觉得你「难说话」。"
+              },
+              {
+                "title": "忽略自己的真正需求",
+                "body": "你非常清楚别人需要什么，却未必想清楚：我想要的生活到底长什么样？我对自己的人生，有没有更长远的规划？"
+              },
+              {
+                "title": "过于依赖外界反馈",
+                "body": "当别人频频赞赏你时，你会干劲十足；但一旦得不到回应或认可，你可能会开始怀疑自己的价值。"
+              }
+            ]
+          },
+          "sort_order": 110,
+          "is_enabled": true
+        },
+        {
+          "section_key": "growth.motivators",
+          "render_variant": "premium_teaser",
+          "body_md": "被需要、被信任、被感谢，会极大激发你的能量。当你知道「我在这里是有用的」「大家因为我更轻松」，你会心甘情愿地多付出一点。",
+          "body_html": null,
+          "payload_json": {
+            "teaser": "被需要、被信任、被感谢，会极大激发你的能量。当你知道「我在这里是有用的」「大家因为我更轻松」，你会心甘情愿地多付出一点。",
+            "is_premium": true
+          },
+          "sort_order": 120,
+          "is_enabled": true
+        },
+        {
+          "section_key": "growth.drainers",
+          "render_variant": "premium_teaser",
+          "body_md": "长期得不到回应的付出、反复被忽视的感受、持续混乱又无法改变的环境，会一点点磨损你的热情。你越不说，内心的委屈和耗竭感就会越重。",
+          "body_html": null,
+          "payload_json": {
+            "teaser": "长期得不到回应的付出、反复被忽视的感受、持续混乱又无法改变的环境，会一点点磨损你的热情。你越不说，内心的委屈和耗竭感就会越重。",
+            "is_premium": true
+          },
+          "sort_order": 130,
+          "is_enabled": true
+        },
+        {
+          "section_key": "relationships.summary",
+          "render_variant": "rich_text",
+          "body_md": "在人际关系里，你像一位「日常守护者」。你会记得别人爱吃什么、最近在忙什么、身体好不好，也愿意用实际行动让对方感受到被在乎。\n\n你重视互动中的礼貌、体贴与互相尊重，希望彼此是「彼此生活的一部分」，而不是偶尔出现的过客。",
+          "body_html": null,
+          "payload_json": null,
+          "sort_order": 140,
+          "is_enabled": true
+        },
+        {
+          "section_key": "relationships.strengths",
+          "render_variant": "bullets",
+          "body_md": null,
+          "body_html": null,
+          "payload_json": {
+            "items": [
+              {
+                "title": "细节型的关心",
+                "body": "你不会只说「有什么需要可以跟我讲」，而是会主动发现：他今天没怎么说话、她最近看起来很累，然后用吃饭、消息、帮忙做事等方式表达关心。"
+              },
+              {
+                "title": "营造归属感",
+                "body": "你喜欢把人聚在一起，拉群、组织聚会、记得大家的生日和纪念日，让每个人都觉得「我在这个圈子里，是被欢迎的」。"
+              },
+              {
+                "title": "重视礼节与体面",
+                "body": "你会注意说话方式、场合氛围，尽量避免让人难堪。你在意「大家都好看、都舒服」，这让你在人情往来中表现得特别得体。"
+              },
+              {
+                "title": "愿意持久地付出",
+                "body": "只要你认定一段关系值得，你会非常长情、非常稳定地投入：记挂对方的状态、在力所能及的范围内提供支持。"
+              }
+            ]
+          },
+          "sort_order": 150,
+          "is_enabled": true
+        },
+        {
+          "section_key": "relationships.weaknesses",
+          "render_variant": "bullets",
+          "body_md": null,
+          "body_html": null,
+          "payload_json": {
+            "items": [
+              {
+                "title": "难以拒绝别人",
+                "body": "就算心里已经很累，你也很难说出「我现在没办法」，总想再撑一撑，结果让自己越来越疲惫。"
+              },
+              {
+                "title": "容易把「照顾别人」当成本能",
+                "body": "你习惯先考虑别人，久而久之，对方会把你的好当成理所当然，反而忘记你也需要被照顾。"
+              },
+              {
+                "title": "害怕关系破裂而回避冲突",
+                "body": "当你觉得某些地方不公平或受委屈时，你可能会选择沉默或用冷淡表达，而不是直接说出来，让问题有机会被真正解决。"
+              },
+              {
+                "title": "对评价和态度很敏感",
+                "body": "别人语气的一点变化、朋友圈里的一些细节，都会在你心里停留很久。如果长期得不到肯定，你会开始怀疑自己是不是「不够好」。"
+              }
+            ]
+          },
+          "sort_order": 160,
+          "is_enabled": true
+        },
+        {
+          "section_key": "relationships.rel_advantages",
+          "render_variant": "premium_teaser",
+          "body_md": "在健康的关系里，你会成为别人非常重要的「生活锚点」——一个让人感到安心、被照顾、有归属的人。你用稳定的陪伴和实际行动，证明「我是真的把你放在心上」。",
+          "body_html": null,
+          "payload_json": {
+            "teaser": "在健康的关系里，你会成为别人非常重要的「生活锚点」——一个让人感到安心、被照顾、有归属的人。你用稳定的陪伴和实际行动，证明「我是真的把你放在心上」。",
+            "is_premium": true
+          },
+          "sort_order": 170,
+          "is_enabled": true
+        },
+        {
+          "section_key": "relationships.rel_risks",
+          "render_variant": "premium_teaser",
+          "body_md": "如果你总是忽略自己的感受，只为了维持表面的和气，你会在某个时间点突然感到极度疲惫，甚至选择「断联式离开」。在此之前学会设边界、提要求，会让你的关系更健康、也更长久。",
+          "body_html": null,
+          "payload_json": {
+            "teaser": "如果你总是忽略自己的感受，只为了维持表面的和气，你会在某个时间点突然感到极度疲惫，甚至选择「断联式离开」。在此之前学会设边界、提要求，会让你的关系更健康、也更长久。",
+            "is_premium": true
+          },
+          "sort_order": 180,
+          "is_enabled": true
+        }
+      ],
+      "seo_overrides": {
+        "seo_title": "ESFJ-A 执政官型",
+        "seo_description": "你像一位温暖而有条理的「生活总务」：一边照顾每个人的感受，一边让事情稳稳落地。只要有你在，场面就不会乱，细节有人看见，日常会变得更有秩序和温度。",
+        "canonical_url": null,
+        "og_title": "ESFJ-A 温暖组织者",
+        "og_description": "你像一位温暖而有条理的「生活总务」：一边照顾每个人的感受，一边让事情稳稳落地。只要有你在，场面就不会乱，细节有人看见，日常会变得更有秩序和温度。",
+        "og_image_url": null,
+        "twitter_title": "ESFJ-A 温暖组织者",
+        "twitter_description": "你像一位温暖而有条理的「生活总务」：一边照顾每个人的感受，一边让事情稳稳落地。只要有你在，场面就不会乱，细节有人看见，日常会变得更有秩序和温度。",
+        "twitter_image_url": null,
+        "robots": null,
+        "jsonld_overrides_json": null
+      }
+    },
+    {
+      "runtime_type_code": "ESFJ-T",
+      "canonical_type_code": "ESFJ",
+      "variant_code": "T",
+      "is_published": true,
+      "published_at": "2026-03-17T00:00:00Z",
+      "profile_overrides": {
+        "type_name": "执政官型",
+        "nickname": "温暖守护者",
+        "rarity_text": "约 6–9%",
+        "keywords_json": [
+          "体贴",
+          "责任感",
+          "组织力",
+          "秩序感",
+          "关系经营",
+          "服务他人"
+        ],
+        "hero_summary_md": "你像一张细致铺好的长桌：灯光、座位、细节都为别人准备好。你最大的安心感，来自于“大家都照顾到了”，而你愿意默默站在中间，把这一切维持运转。",
+        "hero_summary_html": null
+      },
+      "section_overrides": [
+        {
+          "section_key": "letters_intro",
+          "render_variant": "letters_intro",
+          "body_md": null,
+          "body_html": null,
+          "payload_json": {
+            "headline": "外向 · 实感 · 情感 · 规划 · 动荡型｜把照顾与秩序做到极致的“温暖守护者”",
+            "letters": [
+              {
+                "letter": "E",
+                "title": "外向（E）",
+                "description": "让你享受真实相处的现场感——聚会、协作、面对面沟通，都比单独待着更能让你觉得“活在当下”。"
+              },
+              {
+                "letter": "S",
+                "title": "实感（S）",
+                "description": "让你格外关注具体细节：谁有没有吃饱、表格有没有对齐、流程有没有按规矩来。你更信任眼前可见、可验证的事实。"
+              },
+              {
+                "letter": "F",
+                "title": "情感（F）",
+                "description": "使你在决策时会考虑“这样做，会让谁难受吗？”你习惯在规则和人情之间寻找一个两边都能接受的平衡点。"
+              },
+              {
+                "letter": "J",
+                "title": "规划（J）",
+                "description": "让你偏爱有序、有安排的生活方式。你擅长制定清单、排时间、分配任务，不太喜欢临时起意和无计划的混乱。"
+              },
+              {
+                "letter": "T",
+                "title": "动荡型（-T）",
+                "description": "让你对自己要求很高，遇到差错会立刻反省：“是不是我安排得不够周全？”这既是你进步的动力，也是隐形压力来源。"
+              }
+            ]
+          },
+          "sort_order": 10,
+          "is_enabled": true
+        },
+        {
+          "section_key": "overview",
+          "render_variant": "rich_text",
+          "body_md": "在费马心理的逻辑模型里，ESFJ-T 常被视作“有温度的秩序维护者”。你一方面非常在意关系的和谐与稳定，另一方面又极具组织能力，乐于把杂乱无章的场景收拾得井井有条。\n\n对你来说，最舒服的状态是：每个人都各得其所，有清晰的规则、可预期的节奏，气氛既不冷漠也不过度失控。当有人被忽视、秩序被打乱、承诺被随便对待时，你会本能地站出来“拉一拉场子”。\n\n你的人生追求从来不只是“把事情完成”，而是“把事情做好、也把人照顾好”。在别人眼里，你是那个既靠谱、又很有人情味的存在。",
+          "body_html": null,
+          "payload_json": null,
+          "sort_order": 20,
+          "is_enabled": true
+        },
+        {
+          "section_key": "trait_overview",
+          "render_variant": "trait_dimension_grid",
+          "body_md": "建议与小程序中 5 条维度进度条搭配展示：外向 / 内向｜天马行空 / 求真务实｜情感细腻 / 理性思考｜运筹帷幄 / 随机应变｜情绪易波动 / 自信果断。",
+          "body_html": null,
+          "payload_json": {
+            "summary": "建议与小程序中 5 条维度进度条搭配展示：外向 / 内向｜天马行空 / 求真务实｜情感细腻 / 理性思考｜运筹帷幄 / 随机应变｜情绪易波动 / 自信果断。",
+            "dimensions": [
+              {
+                "id": "EI",
+                "name": "外向倾向",
+                "label": "外向倾向",
+                "axis_left": "外向",
+                "axis_right": "内向",
+                "summary": "明显偏外向",
+                "description": "你习惯站在人群之中，而不是远远旁观。你喜欢和人聊天、协作、一起行动，从这样真实的互动中获得能量。一个人待太久，会让你觉得有点被世界“关了静音”。"
+              },
+              {
+                "id": "SN",
+                "name": "心智模式",
+                "label": "心智模式",
+                "axis_left": "天马行空",
+                "axis_right": "求真务实",
+                "summary": "偏“求真务实”",
+                "description": "你更关心“眼下具体要怎么做”，而不是纯概念和假设。你看重流程是否清晰、资源是否到位、细节是否落实，相比宏大构想，你更愿意踏踏实实把事情一步步推起来。"
+              },
+              {
+                "id": "TF",
+                "name": "情绪天性",
+                "label": "情绪天性",
+                "axis_left": "情感细腻",
+                "axis_right": "理性思考",
+                "summary": "偏“情感细腻”",
+                "description": "你对气氛和人情冷暖特别敏感：谁脸色不对、谁被忽略了、谁说话有点过火，你都能察觉。你希望一件事“办成”的同时，也尽量不伤到任何人的感受。"
+              },
+              {
+                "id": "JP",
+                "name": "应对方式",
+                "label": "应对方式",
+                "axis_left": "运筹帷幄",
+                "axis_right": "随机应变",
+                "summary": "偏“运筹帷幄”",
+                "description": "你习惯事先安排好时间和步骤：什么时候开会、谁负责什么、流程如何走。突发状况出现时你也能应对，但你更喜欢一切“按规矩、有章法”地推进。"
+              },
+              {
+                "id": "AT",
+                "name": "身份特征",
+                "label": "身份特征",
+                "axis_left": "情绪易波动",
+                "axis_right": "自信果断",
+                "summary": "略偏“情绪易波动”",
+                "description": "你对别人的反馈和评价很在意。哪怕只是小小的一句质疑，也会让你在心里反复回放：“是不是我哪里做得不够好？” 这种敏感让你格外认真负责，同时也容易积累压力。"
+              }
+            ]
+          },
+          "sort_order": 30,
+          "is_enabled": true
+        },
+        {
+          "section_key": "career.summary",
+          "render_variant": "rich_text",
+          "body_md": "你的职业选择，通常会围绕“服务他人、稳定运作和关系维系”展开。只要能实打实地帮到人，让一个团队或场景变得更顺畅、更有人情味，你就容易产生强烈的责任感和价值感。\n\n你不太适合长期身处完全冷冰冰、只看数字不看人的环境；如果工作只剩下机械执行、缺乏互动和反馈，你会明显感到疲乏和空虚。\n\n相反，当一份工作既需要你组织协调，又需要你照顾情绪、维持秩序时，你就能自然地进入自己的优势区。",
+          "body_html": null,
+          "payload_json": null,
+          "sort_order": 40,
+          "is_enabled": true
+        },
+        {
+          "section_key": "career.advantages",
+          "render_variant": "bullets",
+          "body_md": null,
+          "body_html": null,
+          "payload_json": {
+            "items": [
+              {
+                "title": "极强的责任感与执行力",
+                "body": "你对“交给你的事”有很强的使命感，会尽量按时、按标准完成，不轻易放鸽子，也不会随便甩锅。"
+              },
+              {
+                "title": "擅长维持秩序与流程",
+                "body": "你敏感于流程中的漏洞和不规范之处，乐于把杂乱的信息、任务和资源整理好，保证事情按既定节奏推进。"
+              },
+              {
+                "title": "善于营造团队氛围",
+                "body": "你会主动关心同事状态、缓和紧张气氛、照顾新人的融入感，让团队在“有效率”的同时也“有温度”。"
+              },
+              {
+                "title": "服务意识强，客户 / 用户体验佳",
+                "body": "无论面对内部同事还是外部客户，你都会尽力让对方感到被尊重、被回应。你擅长站在对方角度思考：对方真正需要的是什么？"
+              }
+            ]
+          },
+          "sort_order": 50,
+          "is_enabled": true
+        },
+        {
+          "section_key": "career.weaknesses",
+          "render_variant": "bullets",
+          "body_md": null,
+          "body_html": null,
+          "payload_json": {
+            "items": [
+              {
+                "title": "不善拒绝，容易被工作淹没",
+                "body": "你习惯说“没问题，我来试试”，很难直接拒绝别人。久而久之，你会发现自己事情越来越多，压力也越来越大。"
+              },
+              {
+                "title": "对改变与不确定性耐受度较低",
+                "body": "频繁调整方向、规则不断变化，会让你感到非常焦虑。你更希望在稳定清晰的框架下，持续打磨和优化。"
+              },
+              {
+                "title": "容易把他人的问题当成自己的责任",
+                "body": "当团队出错或氛围不好时，你会先责备自己“是不是我没照顾好大家”，而忽略了并非所有问题都在你掌控范围之内。"
+              },
+              {
+                "title": "过于在意评价，影响决策",
+                "body": "你在做选择时，有时会过度考虑“大家会怎么看我”“领导会满意吗”，从而忽略了对自己长远发展更合适的方案。"
+              }
+            ]
+          },
+          "sort_order": 60,
+          "is_enabled": true
+        },
+        {
+          "section_key": "career.preferred_roles",
+          "render_variant": "preferred_role_list",
+          "body_md": null,
+          "body_html": null,
+          "payload_json": {
+            "intro": "下面这些并不是唯一适合 ESFJ-T 的岗位，而是几类更容易让你感到“忙得很充实，也很值得”的方向，可以当作职业探索的参考起点。",
+            "groups": [
+              {
+                "group_title": "教育与关怀类角色",
+                "description": "需要长期陪伴、照顾与引导他人的场景。",
+                "examples": [
+                  "幼儿 / 中小学教师、班主任、辅导员",
+                  "教务 / 学生事务管理、培训班运营",
+                  "养老、护理、康复支持等关怀型岗位"
+                ]
+              },
+              {
+                "group_title": "运营与行政支持",
+                "description": "让组织“高效运转、井井有条”的幕后力量。",
+                "examples": [
+                  "行政 / 人事 / 办公室管理",
+                  "活动运营、线下门店管理、前台 / 客服",
+                  "项目协调、后勤统筹、会议与流程管理"
+                ]
+              },
+              {
+                "group_title": "客户与服务体验相关",
+                "description": "直接面向客户 / 用户，提供稳定可靠的服务体验。",
+                "examples": [
+                  "客户成功、售后服务、会员运营",
+                  "酒店 / 餐饮 / 旅游等服务行业管理岗位",
+                  "社群运营、社区负责人"
+                ]
+              },
+              {
+                "group_title": "以“人”为核心的管理岗位",
+                "description": "需要一边抓执行、一边照顾团队氛围和人员状态的职位。",
+                "examples": [
+                  "基层到中层管理者",
+                  "门店 / 校区负责人",
+                  "一线团队班组长"
+                ]
+              }
+            ],
+            "outro": "无论职位名称是什么，只要这份工作允许你：用心照顾他人、维护秩序、让一个小世界运转得更好，你就有机会在其中发光。"
+          },
+          "sort_order": 70,
+          "is_enabled": true
+        },
+        {
+          "section_key": "career.upgrade_suggestions",
+          "render_variant": "bullets",
+          "body_md": "对 ESFJ-T 来说，真正决定你能走多远的，往往不是努力程度，而是“边界感”和“选择能力”。学会区分哪些是你该负责的，哪些属于系统或他人的功课，是你职场升级的关键一步。",
+          "body_html": null,
+          "payload_json": {
+            "items": [
+              {
+                "title": "可靠 ≠ 永远答应",
+                "body": "当别人来求助时，可以先判断：这是不是我的职责？我是否有足够时间和精力？适当地说：“这部分我可以支持，但那一部分需要你自己来完成”，不会让你变得冷漠，只会让你的可靠更可持续。"
+              },
+              {
+                "title": "好人缘 = 真诚关照 × 清晰底线",
+                "body": "你已经做得很好的是“真诚关照”，接下来要补的是“清晰底线”。告诉别人：哪些事情你愿意多帮一把，哪些事情超出你的承受范围。长期看，这能帮你筛选出真正尊重你的人。"
+              },
+              {
+                "title": "职业安全感 = 能力积累 × 结构思考",
+                "body": "在稳定执行之外，多问自己：“我在这份工作里学到了什么？这些能力在别的地方也用得上吗？” 这样，你的安全感就不会只依赖于当前的单位或岗位。"
+              },
+              {
+                "title": "不被掏空 = 节奏管理 × 允许自己“不完美”",
+                "body": "刻意为自己预留“彻底下线”的时间——那一段时间里，你不用回应工作消息，也不用随时待命。并且对自己说：有些事没做到尽善尽美，也不代表我不负责，只代表我是个有限的人类。"
+              }
+            ]
+          },
+          "sort_order": 80,
+          "is_enabled": true
+        },
+        {
+          "section_key": "growth.summary",
+          "render_variant": "rich_text",
+          "body_md": "对 ESFJ-T 来说，成长不是变成一个“完全不在乎别人看法的人”，而是在关心他人的同时，也允许自己按照内心的节奏生活。\n\n这一章节，会从你的强项、短板，以及能量的来源与消耗几个角度，帮你看清：怎样的成长，是真正属于你的。",
+          "body_html": null,
+          "payload_json": null,
+          "sort_order": 90,
+          "is_enabled": true
+        },
+        {
+          "section_key": "growth.strengths",
+          "render_variant": "bullets",
+          "body_md": null,
+          "body_html": null,
+          "payload_json": {
+            "items": [
+              {
+                "title": "高度的责任心与承诺感",
+                "body": "你一旦答应了别人，通常会尽全力做到。别人会因为这股可靠劲，把很多重要的事托付给你。"
+              },
+              {
+                "title": "愿意为关系投入时间和精力",
+                "body": "你会记得别人重要的节点、在他们需要时伸出手，这让你在关系中积累了大量信任与情谊。"
+              },
+              {
+                "title": "乐于遵循并维护共识与规则",
+                "body": "你能理解规则存在的意义，也愿意做那个“提醒大家别忘了规矩”的人，为集体稳定保驾护航。"
+              },
+              {
+                "title": "具备持续改进的意识",
+                "body": "哪怕事情已经做完，你也会在心里复盘：“下次有没有更好的做法？”这种习惯，让你在熟悉领域里不断升级。"
+              }
+            ]
+          },
+          "sort_order": 100,
+          "is_enabled": true
+        },
+        {
+          "section_key": "growth.weaknesses",
+          "render_variant": "bullets",
+          "body_md": null,
+          "body_html": null,
+          "payload_json": {
+            "items": [
+              {
+                "title": "容易被他人期待左右",
+                "body": "你很在意身边人的眼光，很容易把“他们希望我怎样”当成自己的目标，从而忽略了内心真正的声音。"
+              },
+              {
+                "title": "害怕冲突，倾向于自我吞咽",
+                "body": "遇到矛盾时，你更可能选择“算了吧”，把不满压在心里。久而久之，这些情绪会悄悄累积成疲惫与失望。"
+              },
+              {
+                "title": "对变化和不确定性存在焦虑",
+                "body": "你偏爱可预期、可控制的环境，一旦变动过多，你会有一种“所有安全点都在松动”的不安感。"
+              },
+              {
+                "title": "不善于为自己争取空间",
+                "body": "你习惯先照顾别人，很少主动说“我也需要”“我也想要”，久而久之，你的需求在关系和环境中容易被忽视。"
+              }
+            ]
+          },
+          "sort_order": 110,
+          "is_enabled": true
+        },
+        {
+          "section_key": "growth.motivators",
+          "render_variant": "premium_teaser",
+          "body_md": "被需要、被信任、被肯定，是你最重要的内在燃料。当你看到因为自己的存在，某件事变得更顺利、某个人被照顾得更好时，你会由衷地觉得：“这一切都值得”。",
+          "body_html": null,
+          "payload_json": {
+            "teaser": "被需要、被信任、被肯定，是你最重要的内在燃料。当你看到因为自己的存在，某件事变得更顺利、某个人被照顾得更好时，你会由衷地觉得：“这一切都值得”。",
+            "is_premium": true
+          },
+          "sort_order": 120,
+          "is_enabled": true
+        },
+        {
+          "section_key": "growth.drainers",
+          "render_variant": "premium_teaser",
+          "body_md": "没有被感谢的付出、频繁被临时加码的任务、以及长期得不到回应的好意，会慢慢消耗你的耐心与热情。你越是逞强说“没事”，内心往往越是累。",
+          "body_html": null,
+          "payload_json": {
+            "teaser": "没有被感谢的付出、频繁被临时加码的任务、以及长期得不到回应的好意，会慢慢消耗你的耐心与热情。你越是逞强说“没事”，内心往往越是累。",
+            "is_premium": true
+          },
+          "sort_order": 130,
+          "is_enabled": true
+        },
+        {
+          "section_key": "relationships.summary",
+          "render_variant": "rich_text",
+          "body_md": "在关系世界里，你更像一个“把日常经营得有烟火气的人”。你会记得每个人的口味、偏好和小情绪，用具体的照顾和陪伴，让关系在细碎的日子里慢慢沉淀。\n\n你最在意的，是一种“彼此挂念、互相照应”的状态——对你来说，好的关系既要稳，也要暖。",
+          "body_html": null,
+          "payload_json": null,
+          "sort_order": 140,
+          "is_enabled": true
+        },
+        {
+          "section_key": "relationships.strengths",
+          "render_variant": "bullets",
+          "body_md": null,
+          "body_html": null,
+          "payload_json": {
+            "items": [
+              {
+                "title": "贴心而具体的照顾",
+                "body": "你不会只说“有事找我”，而是会主动帮对方订好票、点好饭、安排好细节，让关心变成看得见、摸得着的行动。"
+              },
+              {
+                "title": "善于维系长期关系",
+                "body": "你会时不时问候老朋友、维持家人之间的联络，重视仪式感与团聚，这让你在许多关系里扮演“黏合剂”。"
+              },
+              {
+                "title": "重视承诺与稳定感",
+                "body": "无论是友情还是爱情，你都希望彼此是可以长期依靠的存在。你反感“说一套做一套”的相处方式。"
+              },
+              {
+                "title": "乐于在关系中承担责任",
+                "body": "你愿意为了关系多付出一点、让一步，哪怕是自己辛苦一些，也希望对方过得更舒心。"
+              }
+            ]
+          },
+          "sort_order": 150,
+          "is_enabled": true
+        },
+        {
+          "section_key": "relationships.weaknesses",
+          "render_variant": "bullets",
+          "body_md": null,
+          "body_html": null,
+          "payload_json": {
+            "items": [
+              {
+                "title": "容易把“照顾别人”当成本能",
+                "body": "你习惯先想到对方，很少停下来确认：对方是否也有在照顾你？这会让你在关系里慢慢变成“付出一方”。"
+              },
+              {
+                "title": "不愿承认自己的脆弱与需要",
+                "body": "你不太习惯说“我也很累”“我也需要被理解”，怕给别人添麻烦，于是选择自己默默消化。"
+              },
+              {
+                "title": "界限感模糊",
+                "body": "你会为了成全别人而一次次后退底线，直到有一天突然意识到：“好像谁都可以来找我帮忙，但很少有人真正关心我”。"
+              },
+              {
+                "title": "难以结束不健康的关系",
+                "body": "即使一段关系已经让你反复受伤，你也会为过往的好、对方的可怜找理由，不忍心真正抽身离开。"
+              }
+            ]
+          },
+          "sort_order": 160,
+          "is_enabled": true
+        },
+        {
+          "section_key": "relationships.rel_advantages",
+          "render_variant": "premium_teaser",
+          "body_md": "在健康的关系里，你会成为极其稳定、可靠、温暖的存在。你能用细致入微的照顾，让身边人真正感到“被惦记”“被在乎”，也能通过自己的坚持，把一段关系经营成让双方都安心的归属。",
+          "body_html": null,
+          "payload_json": {
+            "teaser": "在健康的关系里，你会成为极其稳定、可靠、温暖的存在。你能用细致入微的照顾，让身边人真正感到“被惦记”“被在乎”，也能通过自己的坚持，把一段关系经营成让双方都安心的归属。",
+            "is_premium": true
+          },
+          "sort_order": 170,
+          "is_enabled": true
+        },
+        {
+          "section_key": "relationships.rel_risks",
+          "render_variant": "premium_teaser",
+          "body_md": "当你习惯了“多给一点没关系”时，身边的人可能会逐渐默认你的付出，把你的好当成理所当然。如果你在越来越多的关系里感到疲惫、委屈，却又无法开口，这就是需要你停下来、重新划定边界的信号。",
+          "body_html": null,
+          "payload_json": {
+            "teaser": "当你习惯了“多给一点没关系”时，身边的人可能会逐渐默认你的付出，把你的好当成理所当然。如果你在越来越多的关系里感到疲惫、委屈，却又无法开口，这就是需要你停下来、重新划定边界的信号。",
+            "is_premium": true
+          },
+          "sort_order": 180,
+          "is_enabled": true
+        }
+      ],
+      "seo_overrides": {
+        "seo_title": "ESFJ-T 执政官型",
+        "seo_description": "你像一张细致铺好的长桌：灯光、座位、细节都为别人准备好。你最大的安心感，来自于“大家都照顾到了”，而你愿意默默站在中间，把这一切维持运转。",
+        "canonical_url": null,
+        "og_title": "ESFJ-T 温暖守护者",
+        "og_description": "你像一张细致铺好的长桌：灯光、座位、细节都为别人准备好。你最大的安心感，来自于“大家都照顾到了”，而你愿意默默站在中间，把这一切维持运转。",
+        "og_image_url": null,
+        "twitter_title": "ESFJ-T 温暖守护者",
+        "twitter_description": "你像一张细致铺好的长桌：灯光、座位、细节都为别人准备好。你最大的安心感，来自于“大家都照顾到了”，而你愿意默默站在中间，把这一切维持运转。",
+        "twitter_image_url": null,
+        "robots": null,
+        "jsonld_overrides_json": null
+      }
+    },
+    {
+      "runtime_type_code": "ESFP-A",
+      "canonical_type_code": "ESFP",
+      "variant_code": "A",
+      "is_published": true,
+      "published_at": "2026-03-17T00:00:00Z",
+      "profile_overrides": {
+        "type_name": "表演者型",
+        "nickname": "多彩体验家",
+        "rarity_text": "约 4–9%",
+        "keywords_json": [
+          "当下体验",
+          "感染力",
+          "乐观",
+          "随性",
+          "感官享受",
+          "行动派"
+        ],
+        "hero_summary_md": "你像一束打在舞台中央的追光：热烈、鲜活、很真实。你天生会把“此刻的快乐”和“当下的体验”放在心里的重要位置，用笑声、行动和热情提醒身边的人——人生不该只剩下 Excel 和待办清单。",
+        "hero_summary_html": null
+      },
+      "section_overrides": [
+        {
+          "section_key": "letters_intro",
+          "render_variant": "letters_intro",
+          "body_md": null,
+          "body_html": null,
+          "payload_json": {
+            "headline": "外向 · 实感 · 情感 · 感知 · 自信型｜把人生活成一场多彩体验的“气氛玩家”",
+            "letters": [
+              {
+                "letter": "E",
+                "title": "外向（E）",
+                "description": "让你享受热闹而真实的互动场景——聚会、现场活动、当面交流，都比线上消息更能让你感觉“活着”。"
+              },
+              {
+                "letter": "S",
+                "title": "实感（S）",
+                "description": "让你更专注于“眼前能摸得着、感受得到”的东西。你相信真实体验，比遥远的理论和空洞的口号更有说服力。"
+              },
+              {
+                "letter": "F",
+                "title": "情感（F）",
+                "description": "使你在做选择时，会考虑“好不好玩”“气氛好不好”，也会在意身边人的感受，希望大家都能享受过程。"
+              },
+              {
+                "letter": "P",
+                "title": "感知（P）",
+                "description": "让你偏爱保留弹性，而不是被时间表绑死。你更享受“边走边看”的自由感，喜欢顺着灵感和机会前进。"
+              },
+              {
+                "letter": "A",
+                "title": "自信型（-A）",
+                "description": "让你在面对新场面时更敢往前迈一步，即兴发挥、不怕丢脸，对“先试试看”有天然的底气和乐观。"
+              }
+            ]
+          },
+          "sort_order": 10,
+          "is_enabled": true
+        },
+        {
+          "section_key": "overview",
+          "render_variant": "rich_text",
+          "body_md": "在费马心理的逻辑模型里，ESFP-A 常被视作“把生活点亮的体验玩家”。你不喜欢把人生活成一串Deadline，更向往有笑声、有故事、有真实互动的日子。\n\n你对当下的感受非常敏锐：好吃的、好玩的、好笑的、感人的，你都能比别人更快捕捉到，并用自己的反应放大它。你会用幽默、行动力和存在感，让一个本来平平无奇的场景突然“有了色彩”。\n\n对你来说，活得精彩比活得完美重要得多。你不会只盯着五年规划，更在意今天是不是有好好体验、有没有和重要的人认真相处。你的人生哲学，往往是：既然来了，就玩好这一局。",
+          "body_html": null,
+          "payload_json": null,
+          "sort_order": 20,
+          "is_enabled": true
+        },
+        {
+          "section_key": "trait_overview",
+          "render_variant": "trait_dimension_grid",
+          "body_md": "建议与小程序中 5 条维度进度条搭配展示：外向 / 内向｜天马行空 / 求真务实｜情感细腻 / 理性思考｜运筹帷幄 / 随机应变｜情绪易波动 / 自信果断。",
+          "body_html": null,
+          "payload_json": {
+            "summary": "建议与小程序中 5 条维度进度条搭配展示：外向 / 内向｜天马行空 / 求真务实｜情感细腻 / 理性思考｜运筹帷幄 / 随机应变｜情绪易波动 / 自信果断。",
+            "dimensions": [
+              {
+                "id": "EI",
+                "name": "外向倾向",
+                "label": "外向倾向",
+                "axis_left": "外向",
+                "axis_right": "内向",
+                "summary": "明显偏外向",
+                "description": "你很享受在人群中的感觉，擅长主动开话题、炒热气氛。对你来说，“一起玩”远比“一个人想”更有能量，离群索居太久会让你觉得憋闷。"
+              },
+              {
+                "id": "SN",
+                "name": "心智模式",
+                "label": "心智模式",
+                "axis_left": "天马行空",
+                "axis_right": "求真务实",
+                "summary": "偏“求真务实（当下体验型）”",
+                "description": "你会优先关注眼前正在发生的事——现场氛围、真实反馈、能马上体验到的快乐。你并非没想法，只是比起遥远而抽象的未来，你更愿意把精力放在“今天能玩什么、此刻能做什么”。"
+              },
+              {
+                "id": "TF",
+                "name": "情绪天性",
+                "label": "情绪天性",
+                "axis_left": "情感细腻",
+                "axis_right": "理性思考",
+                "summary": "偏“情感细腻”",
+                "description": "你对情绪的变化很敏感，特别是当场的“气氛”。别人一脸无聊、气氛一度尴尬，你马上就能感觉到，并会下意识想办法逗笑大家、让场景轻松一点。"
+              },
+              {
+                "id": "JP",
+                "name": "应对方式",
+                "label": "应对方式",
+                "axis_left": "运筹帷幄",
+                "axis_right": "随机应变",
+                "summary": "明显偏“随机应变”",
+                "description": "你不太喜欢被过于详细的计划束缚，更擅长现场发挥。临时改行程、突然有新机会，对你来说往往是“惊喜”而不是“灾难”。你相信自己能边走边解决。"
+              },
+              {
+                "id": "AT",
+                "name": "身份特征",
+                "label": "身份特征",
+                "axis_left": "情绪易波动",
+                "axis_right": "自信果断",
+                "summary": "略偏“自信果断”",
+                "description": "作为自信型 ESFP-A，你通常不会在做完决定后反复自责“我是不是错了”。你更倾向于：先做了再看反馈，有问题就调整，很少在没发生的场景里过度内耗。"
+              }
+            ]
+          },
+          "sort_order": 30,
+          "is_enabled": true
+        },
+        {
+          "section_key": "career.summary",
+          "render_variant": "rich_text",
+          "body_md": "你的职业满足感，很大程度来自“当下的参与感”和“互动中的反馈”。能现场看到别人因为你的出现而更开心、更放松，你就会觉得这份工作值得。\n\n你不适合长期关在格子间里做重复性的纯文书工作，也很难在缺乏互动、缺少变化的岗位上保持动力。\n\n相反，当一份工作允许你：接触真实的人、创造好体验、灵活处理各种突发状况，并在过程中加入一点自己的风格时，你就能展现出非常耀眼的状态。",
+          "body_html": null,
+          "payload_json": null,
+          "sort_order": 40,
+          "is_enabled": true
+        },
+        {
+          "section_key": "career.advantages",
+          "render_variant": "bullets",
+          "body_md": null,
+          "body_html": null,
+          "payload_json": {
+            "items": [
+              {
+                "title": "天然的“气氛发动机”",
+                "body": "你很擅长打破尴尬、拉近距离，让客户、同事或观众迅速放松下来。很多需要“先让人喜欢你”的工作，你会表现得得心应手。"
+              },
+              {
+                "title": "强大的现场应对能力",
+                "body": "流程临时变了、客人突然有新要求、活动现场出现小意外，你都能快速反应，用玩笑、机智和实际行动把局面稳住。"
+              },
+              {
+                "title": "以人为本的服务意识",
+                "body": "你会真心在意“对方现在开不开心”“体验好不好”，愿意多走一步，给别人带来惊喜，这在服务类与体验类行业非常宝贵。"
+              },
+              {
+                "title": "学习方式贴近实战",
+                "body": "比起看厚厚的手册，你更擅长在“亲手做”中快速上手。边做边学、边试边改，让你很快摸清一个岗位的门道。"
+              }
+            ]
+          },
+          "sort_order": 50,
+          "is_enabled": true
+        },
+        {
+          "section_key": "career.weaknesses",
+          "render_variant": "bullets",
+          "body_md": null,
+          "body_html": null,
+          "payload_json": {
+            "items": [
+              {
+                "title": "对枯燥事务耐心有限",
+                "body": "长时间处理表格、流程、文档整理等细致却缺乏变化的工作，会严重消耗你的耐心与状态，很容易拖延或分心。"
+              },
+              {
+                "title": "规划意识相对薄弱",
+                "body": "你更擅长处理眼前的事，而不是远期规划。有时可能因为缺乏长期路径设计，而在职业发展上出现“卡关感”。"
+              },
+              {
+                "title": "容易被当成“气氛工具人”",
+                "body": "你擅长带动场子，但如果团队只看到你这一点，而不让你参与更深的策划与决策，你也会感觉“不被当回事”。"
+              },
+              {
+                "title": "情绪容易受环境影响",
+                "body": "当周围氛围长期压抑、缺乏认可时，你原本的热情会逐渐被消磨，甚至开始怀疑“是不是自己做错了行业”。"
+              }
+            ]
+          },
+          "sort_order": 60,
+          "is_enabled": true
+        },
+        {
+          "section_key": "career.preferred_roles",
+          "render_variant": "preferred_role_list",
+          "body_md": null,
+          "body_html": null,
+          "payload_json": {
+            "intro": "下面这些方向，并不是 ESFP-A 的“唯一正确答案”，但通常更有机会让你觉得——这份工作很好玩，也很值得。",
+            "groups": [
+              {
+                "group_title": "线下体验与活动相关",
+                "description": "需要大量现场互动、氛围营造和即时反馈的岗位。",
+                "examples": [
+                  "活动策划 / 执行、线下路演、品牌快闪店运营",
+                  "主持、表演、舞台相关工作",
+                  "展会 / 发布会现场运营、场地统筹"
+                ]
+              },
+              {
+                "group_title": "零售与服务体验",
+                "description": "让你能直接面对真实客人，并用服务创造好感的场景。",
+                "examples": [
+                  "高体验感门店的导购 / 店长",
+                  "餐饮、文旅、酒店等行业的一线服务与运营",
+                  "健身 / 美业 / 生活方式相关从业者"
+                ]
+              },
+              {
+                "group_title": "内容与社交媒体",
+                "description": "可以把“好玩”“真实”“有趣”变成作品的领域。",
+                "examples": [
+                  "短视频创作者、直播主播",
+                  "社群运营、线下社交活动主理人",
+                  "生活方式类 / 娱乐类内容创作者"
+                ]
+              },
+              {
+                "group_title": "高互动销售与商务",
+                "description": "需要强烈现场感与人际吸引力的岗位，适合你把“魅力”和“直觉”用在成交上。",
+                "examples": [
+                  "大客户销售",
+                  "品牌拓展 / 商务洽谈",
+                  "文旅 / 教培 / 体育等场景销售"
+                ]
+              }
+            ],
+            "outro": "如果一份工作允许你“做自己”、和不同的人真实接触，并且每一天都有一点不一样，你就更容易在其中发光。"
+          },
+          "sort_order": 70,
+          "is_enabled": true
+        },
+        {
+          "section_key": "career.upgrade_suggestions",
+          "render_variant": "bullets",
+          "body_md": "对于 ESFP-A 来说，真正的职业成长，往往不是“变得不爱玩”，而是学会：一边把生活过得有趣，一边为长期方向打下一些基础。\n\n你可以把下面这几条，当作帮自己升级的实用小公式。",
+          "body_html": null,
+          "payload_json": {
+            "items": [
+              {
+                "title": "自由感 = 有弹性的计划",
+                "body": "你并不一定讨厌计划，你讨厌的是“被计划拴死”。试着用更轻量的方式规划，比如只明确下一个 3–6 个月的大方向和两个关键目标，把细节留给当下发挥。"
+              },
+              {
+                "title": "职业上限 = 公众魅力 × 专业深度",
+                "body": "你的感染力已经是加分项，如果再叠加一个扎实的专业能力（比如某个细分领域的知识或技能），你就会从“好相处”升级为“非常值钱”。"
+              },
+              {
+                "title": "抗消耗能力 = 自我认可度 × 选择环境",
+                "body": "当你发现自己因为环境而一点点丧失活力时，要及时问自己：“是我真的不行，还是这个场所不适合我？” 学会区分问题在“自己”还是在“土壤”。"
+              },
+              {
+                "title": "长线成长 = 体验累积 × 适度复盘",
+                "body": "保持你喜欢的“多体验”，但可以在每个阶段留出一点时间复盘：哪些是让我真的成长了的经历？哪些只是短暂的刺激？把这些答案记下来，它会悄悄帮你形成属于自己的职业路线感。"
+              }
+            ]
+          },
+          "sort_order": 80,
+          "is_enabled": true
+        },
+        {
+          "section_key": "growth.summary",
+          "render_variant": "rich_text",
+          "body_md": "对 ESFP-A 来说，个人成长不是把自己变成“乖乖坐住的人”，而是学会在保留灵动和真实的同时，给自己多一点稳定感与掌控感。\n\n这一章节会从你的优势、短板、能量来源与消耗点几个角度，帮你更清楚地看见：怎样长成一个既好玩、又更踏实的自己。",
+          "body_html": null,
+          "payload_json": null,
+          "sort_order": 90,
+          "is_enabled": true
+        },
+        {
+          "section_key": "growth.strengths",
+          "render_variant": "bullets",
+          "body_md": null,
+          "body_html": null,
+          "payload_json": {
+            "items": [
+              {
+                "title": "对生活保持新鲜感",
+                "body": "你愿意主动去尝试新事物、新地方、新朋友，让人生不断出现小惊喜，也不断拓宽自己的体验边界。"
+              },
+              {
+                "title": "强烈的当下专注力",
+                "body": "当你对一件事感兴趣时，会非常投入其中，哪怕是一场游戏、一次旅行、一段对话，也能被你过得很有存在感。"
+              },
+              {
+                "title": "乐观直率",
+                "body": "你不太喜欢绕弯子，更习惯用直接、真诚的方式表达情绪。这让你在人群中显得真实、有温度、没有距离感。"
+              },
+              {
+                "title": "能把别人拉出低气压",
+                "body": "在朋友情绪低落或气氛压抑的时候，你的幽默、行动力和“走，我们出去透透气”的一句话，往往就是他们最需要的那双手。"
+              }
+            ]
+          },
+          "sort_order": 100,
+          "is_enabled": true
+        },
+        {
+          "section_key": "growth.weaknesses",
+          "render_variant": "bullets",
+          "body_md": null,
+          "body_html": null,
+          "payload_json": {
+            "items": [
+              {
+                "title": "容易被即时感受牵着走",
+                "body": "你容易被当下的情绪和兴趣驱动，有时会忽略长远后果，比如消费、工作选择、作息等方面的“后悔滞后性”。"
+              },
+              {
+                "title": "不爱面对枯燥但必要的事情",
+                "body": "办证件、理账单、长期规划这些事，对你来说都很无聊。但如果长期逃避，它们会在某个时间点集中“反噬”。"
+              },
+              {
+                "title": "难以静下心来深挖一个方向",
+                "body": "你会对很多东西感兴趣，却不一定愿意在其中一个方向长期深挖，这在早期能带来丰富体验，但在后期可能影响专业上的积累。"
+              },
+              {
+                "title": "情绪容易被他人拉着走",
+                "body": "你对环境非常敏感，如果身边的人长期处在负面状态，你也容易被牵着低落，甚至失去本来的活力。"
+              }
+            ]
+          },
+          "sort_order": 110,
+          "is_enabled": true
+        },
+        {
+          "section_key": "growth.motivators",
+          "render_variant": "premium_teaser",
+          "body_md": "有趣的体验、即时的正向反馈、和人一起完成一件“好玩又有成就感”的事情，都会让你感觉人生充满动力。越是能看到当下就有变化的场景，你越容易全力投入。",
+          "body_html": null,
+          "payload_json": {
+            "teaser": "有趣的体验、即时的正向反馈、和人一起完成一件“好玩又有成就感”的事情，都会让你感觉人生充满动力。越是能看到当下就有变化的场景，你越容易全力投入。",
+            "is_premium": true
+          },
+          "sort_order": 120,
+          "is_enabled": true
+        },
+        {
+          "section_key": "growth.drainers",
+          "render_variant": "premium_teaser",
+          "body_md": "一成不变的日常、被迫长时间独自面对枯燥任务、以及身边持续低气压而又无法改变的环境，会慢慢掏空你的热情。如果你开始频繁逃避、刷手机、乱花钱，很可能就是在无意识对抗这种疲惫。",
+          "body_html": null,
+          "payload_json": {
+            "teaser": "一成不变的日常、被迫长时间独自面对枯燥任务、以及身边持续低气压而又无法改变的环境，会慢慢掏空你的热情。如果你开始频繁逃避、刷手机、乱花钱，很可能就是在无意识对抗这种疲惫。",
+            "is_premium": true
+          },
+          "sort_order": 130,
+          "is_enabled": true
+        },
+        {
+          "section_key": "relationships.summary",
+          "render_variant": "rich_text",
+          "body_md": "在人际和亲密关系里，你像是一团很真诚的火焰：靠近你的人会感到被点亮、被带动、被邀请去体验更多生活的可能性。\n\n你珍惜能一起玩、一起疯、也能一起认真聊心事的关系。你不太喜欢冷冰冰的相处方式，更在意“相处的氛围”和“是否好玩又安心”。",
+          "body_html": null,
+          "payload_json": null,
+          "sort_order": 140,
+          "is_enabled": true
+        },
+        {
+          "section_key": "relationships.strengths",
+          "render_variant": "bullets",
+          "body_md": null,
+          "body_html": null,
+          "payload_json": {
+            "items": [
+              {
+                "title": "非常好相处",
+                "body": "你不爱端着，也不会刻意装酷，更擅长用幽默、玩笑和真实的反应，迅速拉近和别人的距离。"
+              },
+              {
+                "title": "会制造共同回忆",
+                "body": "你愿意主动提议一起去做点什么：旅行、活动、小聚、随性出门走走。很多人关于“美好时刻”的记忆里，都有你的身影。"
+              },
+              {
+                "title": "情绪表达直白",
+                "body": "你会把喜欢、开心、不爽、焦虑，以一种相对直接的方式表达出来，这让关系更不容易积攒看不见的误会。"
+              },
+              {
+                "title": "不轻易放弃重要的人",
+                "body": "对你来说，“一起经历过很多事”的人是非常重要的资产。就算关系出现波折，你也愿意再给彼此一点时间和机会。"
+              }
+            ]
+          },
+          "sort_order": 150,
+          "is_enabled": true
+        },
+        {
+          "section_key": "relationships.weaknesses",
+          "render_variant": "bullets",
+          "body_md": null,
+          "body_html": null,
+          "payload_json": {
+            "items": [
+              {
+                "title": "容易用“好玩程度”评估关系",
+                "body": "当一段关系进入平淡期，你可能会下意识觉得“我们是不是不合适了”，而不是去看看是否只是缺少了新的共同体验。"
+              },
+              {
+                "title": "不擅长处理长期、复杂的情绪议题",
+                "body": "面对深层的情感创伤、长期压抑的话题，你会本能想“先别想那么多”，从而延后了一些必须面对的对话。"
+              },
+              {
+                "title": "有时会被误解为“只图一时开心”",
+                "body": "你在当下很投入，但如果没有把“长期承诺”说清楚，别人可能会误以为你只是想玩玩，而不是真的在乎这段关系。"
+              },
+              {
+                "title": "难以拒绝当场的邀请",
+                "body": "不论是聚会、帮忙，还是临时的约，你很难当场说“不”，这可能导致你在关系里被过度消耗时间与精力。"
+              }
+            ]
+          },
+          "sort_order": 160,
+          "is_enabled": true
+        },
+        {
+          "section_key": "relationships.rel_advantages",
+          "render_variant": "premium_teaser",
+          "body_md": "在健康的关系中，你是那个给大家“加彩”的人。你能用自己的活力让空间变得更好玩、更放松，也能用你的真诚和行动，让身边人感受到：“有你在，生活好像没那么难熬了。”",
+          "body_html": null,
+          "payload_json": {
+            "teaser": "在健康的关系中，你是那个给大家“加彩”的人。你能用自己的活力让空间变得更好玩、更放松，也能用你的真诚和行动，让身边人感受到：“有你在，生活好像没那么难熬了。”",
+            "is_premium": true
+          },
+          "sort_order": 170,
+          "is_enabled": true
+        },
+        {
+          "section_key": "relationships.rel_risks",
+          "render_variant": "premium_teaser",
+          "body_md": "如果你长期只做“带气氛、陪大家玩的人”，而不被当成有深度、有想法、值得被认真对待的个体，你会在某个瞬间突然感到极度失落。学会识别这种失衡，是你保护自己、找到更高质量关系的关键一步。",
+          "body_html": null,
+          "payload_json": {
+            "teaser": "如果你长期只做“带气氛、陪大家玩的人”，而不被当成有深度、有想法、值得被认真对待的个体，你会在某个瞬间突然感到极度失落。学会识别这种失衡，是你保护自己、找到更高质量关系的关键一步。",
+            "is_premium": true
+          },
+          "sort_order": 180,
+          "is_enabled": true
+        }
+      ],
+      "seo_overrides": {
+        "seo_title": "ESFP-A 表演者型",
+        "seo_description": "你像一束打在舞台中央的追光：热烈、鲜活、很真实。你天生会把“此刻的快乐”和“当下的体验”放在心里的重要位置，用笑声、行动和热情提醒身边的人——人生不该只剩下 Excel 和待办清单。",
+        "canonical_url": null,
+        "og_title": "ESFP-A 多彩体验家",
+        "og_description": "你像一束打在舞台中央的追光：热烈、鲜活、很真实。你天生会把“此刻的快乐”和“当下的体验”放在心里的重要位置，用笑声、行动和热情提醒身边的人——人生不该只剩下 Excel 和待办清单。",
+        "og_image_url": null,
+        "twitter_title": "ESFP-A 多彩体验家",
+        "twitter_description": "你像一束打在舞台中央的追光：热烈、鲜活、很真实。你天生会把“此刻的快乐”和“当下的体验”放在心里的重要位置，用笑声、行动和热情提醒身边的人——人生不该只剩下 Excel 和待办清单。",
+        "twitter_image_url": null,
+        "robots": null,
+        "jsonld_overrides_json": null
+      }
+    },
+    {
+      "runtime_type_code": "ESFP-T",
+      "canonical_type_code": "ESFP",
+      "variant_code": "T",
+      "is_published": true,
+      "published_at": "2026-03-17T00:00:00Z",
+      "profile_overrides": {
+        "type_name": "表演者型",
+        "nickname": "灵感行动派",
+        "rarity_text": "约 6–10%",
+        "keywords_json": [
+          "当下体验",
+          "感官敏锐",
+          "情绪感染力",
+          "即兴发挥",
+          "享乐与分享",
+          "动荡自省"
+        ],
+        "hero_summary_md": "你像一束突然打在舞台上的灯光：明亮、鲜活、带着一点不按套路的惊喜。你热爱当下的真实体验，也享受把快乐放大、分享给在场的每一个人。只要有你在，气氛就很难一直无聊下去。",
+        "hero_summary_html": null
+      },
+      "section_overrides": [
+        {
+          "section_key": "letters_intro",
+          "render_variant": "letters_intro",
+          "body_md": null,
+          "body_html": null,
+          "payload_json": {
+            "headline": "外向 · 现实 · 情感 · 灵活 · 动荡型｜用体验点亮当下的“灵感行动派”",
+            "letters": [
+              {
+                "letter": "E",
+                "title": "外向（E）",
+                "description": "让你习惯走进人群，而不是远远旁观。聚会、旅行、活动现场、热烈的对话，都是你充电的地方。"
+              },
+              {
+                "letter": "S",
+                "title": "现实（S）",
+                "description": "让你格外关注此时此刻的具体细节：好不好玩、好不好吃、现场氛围舒不舒服，比抽象概念更能打动你。"
+              },
+              {
+                "letter": "F",
+                "title": "情感（F）",
+                "description": "使你在做选择时，会优先考虑人和感受：这样做会不会破坏气氛，会不会伤到谁，而不是只看数字和结果。"
+              },
+              {
+                "letter": "P",
+                "title": "灵活（P）",
+                "description": "让你讨厌被死板计划绑住，更偏爱留点随机的空间。你相信，很多最棒的体验，都是在计划之外发生的。"
+              },
+              {
+                "letter": "T",
+                "title": "动荡型（-T）",
+                "description": "让你在外向洒脱的表面下，其实也会反复确认：大家真的开心吗？我是不是做错了什么？这种敏感一方面推动你变得更好，一方面也会带来压力。"
+              }
+            ]
+          },
+          "sort_order": 10,
+          "is_enabled": true
+        },
+        {
+          "section_key": "overview",
+          "render_variant": "rich_text",
+          "body_md": "在费马心理的逻辑模型里，ESFP-T 被视作现实世界里的体验策展人。你对现场氛围、感官体验和人际互动极其敏锐，天生就擅长让场面活起来。\n\n你很少只停留在想象层面，更喜欢一句：走，去试试看。对你来说，人生不是纸上推演，而是要亲自去感受、去体验、去参与。\n\n表面上，你像是自带主角光环的气氛担当；但在更深的部分，你其实非常在意别人有没有真的开心、有没有被照顾到。你用玩笑缓和尴尬，用行动表达在乎，用陪伴对冲孤独。\n\n你不喜欢长期被困在沉闷、过度规则化、没有活力的环境里。你期待的，是一种既真实鲜活、又能不断遇见新鲜感的人生。",
+          "body_html": null,
+          "payload_json": null,
+          "sort_order": 20,
+          "is_enabled": true
+        },
+        {
+          "section_key": "trait_overview",
+          "render_variant": "trait_dimension_grid",
+          "body_md": "建议与小程序中 5 条维度进度条搭配展示：外向 / 内向｜天马行空 / 求真务实｜情感细腻 / 理性思考｜运筹帷幄 / 随机应变｜情绪易波动 / 自信果断。",
+          "body_html": null,
+          "payload_json": {
+            "summary": "建议与小程序中 5 条维度进度条搭配展示：外向 / 内向｜天马行空 / 求真务实｜情感细腻 / 理性思考｜运筹帷幄 / 随机应变｜情绪易波动 / 自信果断。",
+            "dimensions": [
+              {
+                "id": "EI",
+                "name": "外向倾向",
+                "label": "外向倾向",
+                "axis_left": "外向",
+                "axis_right": "内向",
+                "summary": "明显偏外向",
+                "description": "你习惯站在舞台一侧，而不是角落里旁观。和人一起吃饭、聊天、逛街、出门，是你获取能量的主要方式。长时间无人可约、没人互动，你会感觉生活像被调成了静音模式。"
+              },
+              {
+                "id": "SN",
+                "name": "心智模式",
+                "label": "心智模式",
+                "axis_left": "天马行空",
+                "axis_right": "求真务实",
+                "summary": "偏“求真务实、重体验”",
+                "description": "比起宏大抽象的理论，你更在意眼前能不能玩得开心、吃得舒服、现场有没有氛围。你会用自己的身体和五感去判断一件事值不值得，而不是只看一堆复杂数据。"
+              },
+              {
+                "id": "TF",
+                "name": "情绪天性",
+                "label": "情绪天性",
+                "axis_left": "情感细腻",
+                "axis_right": "理性思考",
+                "summary": "偏“情感细腻”",
+                "description": "你对周围人的表情和气氛变化非常敏感。谁突然安静了、谁笑得有点勉强、哪里开始有一点尴尬，你都能察觉。你在意的是，这一刻大家的感受是否是真实、放松和舒服的。"
+              },
+              {
+                "id": "JP",
+                "name": "应对方式",
+                "label": "应对方式",
+                "axis_left": "运筹帷幄",
+                "axis_right": "随机应变",
+                "summary": "明显偏“随机应变”",
+                "description": "你喜欢留白，不喜欢把人生排成一张密不透风的日程表。遇到变化，你可以迅速调整状态，用幽默和机智接住突发状况。很多时候，你就是靠這種临场反应，把一个普通场景变得有趣起来。"
+              },
+              {
+                "id": "AT",
+                "name": "身份特征",
+                "label": "身份特征",
+                "axis_left": "情绪易波动",
+                "axis_right": "自信果断",
+                "summary": "略偏“情绪易波动”",
+                "description": "动荡型让你在玩得很开的时候，也会有突然安静下来的瞬间。你会在心里悄悄复盘：我是不是太过了？刚刚那句玩笑是不是伤到人了？这让你在人际上非常细腻，但如果缺少自我照顾，也容易感到疲惫和情绪起伏。"
+              }
+            ]
+          },
+          "sort_order": 30,
+          "is_enabled": true
+        },
+        {
+          "section_key": "career.summary",
+          "render_variant": "rich_text",
+          "body_md": "你的职业满足感，往往来自於三件事：有真实的人、有现场的互动、有可以立刻看见的反馈。只要工作里这三样足够充沛，你就很容易打起精神，全身心投入。\n\n过於单调、长时间独立完成、缺乏情绪互动的工作，会让你感觉像被锁在灰色房间里，很难持续保持动力。\n\n相反，那些允许你接触不同的人、感受变化的场景、在实际行动中解决问题并看到成果的岗位，更容易激发出你最有生命力的一面。",
+          "body_html": null,
+          "payload_json": null,
+          "sort_order": 40,
+          "is_enabled": true
+        },
+        {
+          "section_key": "career.advantages",
+          "render_variant": "bullets",
+          "body_md": null,
+          "body_html": null,
+          "payload_json": {
+            "items": [
+              {
+                "title": "自然带动氛围的现场能力",
+                "body": "你不需要刻意学习控场技巧，很多时候，只要你出现，场面就不会一直冷下去。你擅长打破尴尬、点燃气氛，让合作过程变得更好玩。"
+              },
+              {
+                "title": "超强的感知与观察力",
+                "body": "你对用户、客户、同事的即时反应尤其敏锐，能快速捕捉别人真正喜欢什麼、不喜欢什麼，适合做体验优化、现场反馈调整等工作。"
+              },
+              {
+                "title": "行动驱动，执行迅速",
+                "body": "一旦你对某个点有感觉，很容易立刻动起来试一试，而不是停留在讨论里。这种立刻行动的特点，能帮助团队快速验证想法。"
+              },
+              {
+                "title": "乐于服务与分享",
+                "body": "你真心享受让别人玩得开心、体验变好这件事，不管是服务型工作、活动运营，还是品牌体验相关岗位，都能让你找到成就感。"
+              }
+            ]
+          },
+          "sort_order": 50,
+          "is_enabled": true
+        },
+        {
+          "section_key": "career.weaknesses",
+          "render_variant": "bullets",
+          "body_md": null,
+          "body_html": null,
+          "payload_json": {
+            "items": [
+              {
+                "title": "不擅长长期枯燥的任务",
+                "body": "当工作变成反复的表格、文档或流程，没有变化、也看不到人时，你会很难集中注意力，拖延和分心的情况会明显增多。"
+              },
+              {
+                "title": "规划意识相对薄弱",
+                "body": "你更愿意随时调整，而不太喜欢花大量时间做长期规划。这在高不确定、需要快速反应的岗位是优势，但在复杂项目管理里可能会吃亏。"
+              },
+              {
+                "title": "容易冲动决策",
+                "body": "在氛围带动下，你容易因为一时感觉就答应请求或做出决定，事后才发现成本、精力或时间其实不太够，导致压力堆叠。"
+              },
+              {
+                "title": "对批评和否定比较敏感",
+                "body": "当你的用心和热情没有被看见，甚至遭到冷淡或挑剔时，你会比自己以为的更受伤，可能一段时间都不想再多表现。"
+              }
+            ]
+          },
+          "sort_order": 60,
+          "is_enabled": true
+        },
+        {
+          "section_key": "career.preferred_roles",
+          "render_variant": "preferred_role_list",
+          "body_md": null,
+          "body_html": null,
+          "payload_json": {
+            "intro": "下面这些方向，并不是唯一選項，而是更容易让 ESFP-T 感到有活力、有成就感的典型场景。你可以把它当作职业探索的灵感清单。",
+            "groups": [
+              {
+                "group_title": "现场体验与活动相关",
+                "description": "需要你走到第一线、营造氛围、与人实时互动的工作。",
+                "examples": [
+                  "活动策划与执行、演出统筹、线下沙龙主理人",
+                  "旅游行业前线岗位、领队、体验设计师",
+                  "品牌线下活动执行、快闪店运营"
+                ]
+              },
+              {
+                "group_title": "服务与客户体验",
+                "description": "把服務做成一种体验，让人觉得被善待、被重视。",
+                "examples": [
+                  "高端消费场景的前台與顾问，如餐饮、酒店、健身房等",
+                  "客户成功、用户运营、社群运营",
+                  "美容美发、形象顾问等以体验为核心的职业"
+                ]
+              },
+              {
+                "group_title": "表達与创意输出",
+                "description": "可以用你的审美、感受力与表现欲，创造新鲜内容的领域。",
+                "examples": [
+                  "短视频内容创作者、直播主持人、娱乐向主播",
+                  "时尚、生活方式类博主、摄影或视频创作",
+                  "综艺节目的执行、艺人助理、经纪团队一员"
+                ]
+              },
+              {
+                "group_title": "充满变化的一线岗位",
+                "description": "每天会遇到不同的人和状况，需要你灵活应对、快速反应的工作环境。",
+                "examples": [
+                  "销售与业务开拓岗位",
+                  "一线市场推广、地推、路演活动工作人员",
+                  "任何需要频繁面对真实用户的角色"
+                ]
+              }
+            ],
+            "outro": "对你来说，理想的工作不仅要养活生活，更要让你感觉到：我真的把快乐、温度和真实体验带给了许多人。"
+          },
+          "sort_order": 70,
+          "is_enabled": true
+        },
+        {
+          "section_key": "career.upgrade_suggestions",
+          "render_variant": "bullets",
+          "body_md": "如果说天赋让你成为现场的焦点，那麼让你走得更远的，往往是节奏感、自律和边界感。只要稍微加一点结构，你的魅力就不会只停在好玩，而是能转化为稳定的职业优势。\n\n可以把下面这些建议，当作你在职场里慢慢练習的小公式。",
+          "body_html": null,
+          "payload_json": {
+            "items": [
+              {
+                "title": "自由度 = 弹性空间 × 基本底线",
+                "body": "你可以继续保持对变化的热爱，但最好為自己设定一些不动的底线，例如：每天固定完成一小块枯燥但必要的任务，用來支撑你的長期发展。"
+              },
+              {
+                "title": "行动力 = 灵感 × 简单计划",
+                "body": "在立刻开干之前，多花三分钟写个简短步骤清单。这样既不会消灭你的冲动灵感，又能避免做到一半才发现忘了重点。"
+              },
+              {
+                "title": "好人缘 ≠ 好欺负",
+                "body": "保持开朗与好相处的同时，学会在被临时加任务时说一句：我很想帮，不过我今天已经排满了，我们可以看看下次怎麼安排。清晰表达边界，是一种更成熟的魅力。"
+              },
+              {
+                "title": "职业成长 = 体验宽度 × 能力沉淀",
+                "body": "你接触的人和场景可能很多，不妨定期回顾：我从这些体验中学会了哪一道硬技能或软技能。把故事沉淀成能力，你的每一次好玩都会变成未来履历里的亮点。"
+              }
+            ]
+          },
+          "sort_order": 80,
+          "is_enabled": true
+        },
+        {
+          "section_key": "growth.summary",
+          "render_variant": "rich_text",
+          "body_md": "对 ESFP-T 来说，成长并不是把自己变成另一个类型，而是学会：在继续热爱当下的同时，也为未来留一点空间。\n\n你天生就会为别人带来快乐和活力，但若想让自己的生活同样稳定而有质感，你需要在节奏、自律和内在安定感上多花一点心思。",
+          "body_html": null,
+          "payload_json": null,
+          "sort_order": 90,
+          "is_enabled": true
+        },
+        {
+          "section_key": "growth.strengths",
+          "render_variant": "bullets",
+          "body_md": null,
+          "body_html": null,
+          "payload_json": {
+            "items": [
+              {
+                "title": "拥抱生活的勇气",
+                "body": "你敢于尝试、敢于体验、也敢于玩得开心。不管身在何处，你都能找到一些值得当下投入的东西。"
+              },
+              {
+                "title": "及时调整的弹性",
+                "body": "遇到问题时，你不太会一直困在焦虑里，更倾向於先做点什麼试试看，再根据反馈继续调整。"
+              },
+              {
+                "title": "乐观与感染力",
+                "body": "你用轻松和幽默帮身边很多人度过了糟糕时刻。哪怕自己也有情绪起伏，你仍然愿意把比较明亮的一面分享出去。"
+              },
+              {
+                "title": "对真实的敏感",
+                "body": "你很难在完全虚假的场景里久留，更偏爱有人情味和真实情绪的关系与环境。这种敏感，会讓你在选择上逐渐更懂自己。"
+              }
+            ]
+          },
+          "sort_order": 100,
+          "is_enabled": true
+        },
+        {
+          "section_key": "growth.weaknesses",
+          "render_variant": "bullets",
+          "body_md": null,
+          "body_html": null,
+          "payload_json": {
+            "items": [
+              {
+                "title": "容易被当下牵着走",
+                "body": "你很容易被即时的好玩、好吃、好逛牵走注意力，导致长期目标或承诺被一再往后拖。"
+              },
+              {
+                "title": "难以面对沉重议题",
+                "body": "面对严肃冲突、长期压力或深度内心议题时，你可能倾向於用玩笑带过，或者躲进其他活动中，暂时不去碰。"
+              },
+              {
+                "title": "自律感相对较弱",
+                "body": "当生活里没有足够的外部约束时，你可能会在作息、金钱管理或学习节奏上感到吃力，需要更有意识地给自己设限。"
+              },
+              {
+                "title": "情绪时好时坏",
+                "body": "在别人眼里，你总是很开心，但实际上，你也有突然掉线的时刻。如果没有学会表达和处理，压抑久了容易爆发或突然抽离。"
+              }
+            ]
+          },
+          "sort_order": 110,
+          "is_enabled": true
+        },
+        {
+          "section_key": "growth.motivators",
+          "render_variant": "premium_teaser",
+          "body_md": "新鲜体验、即时反馈、真实情绪以及和重要的人一起完成某件好玩的事情，都会迅速点燃你的动力。如果能在成长路上持续拥有这些元素，你会走得又快又开心。",
+          "body_html": null,
+          "payload_json": {
+            "teaser": "新鲜体验、即时反馈、真实情绪以及和重要的人一起完成某件好玩的事情，都会迅速点燃你的动力。如果能在成长路上持续拥有这些元素，你会走得又快又开心。",
+            "is_premium": true
+          },
+          "sort_order": 120,
+          "is_enabled": true
+        },
+        {
+          "section_key": "growth.drainers",
+          "render_variant": "premium_teaser",
+          "body_md": "长期被困在单调重复、没有人味、也看不到成果的环境，或者总是被别人情绪消耗而得不到理解，会让你对生活失去颜色。那往往是你最需要停下来整理自己、换一换节奏的时候。",
+          "body_html": null,
+          "payload_json": {
+            "teaser": "长期被困在单调重复、没有人味、也看不到成果的环境，或者总是被别人情绪消耗而得不到理解，会让你对生活失去颜色。那往往是你最需要停下来整理自己、换一换节奏的时候。",
+            "is_premium": true
+          },
+          "sort_order": 130,
+          "is_enabled": true
+        },
+        {
+          "section_key": "relationships.summary",
+          "render_variant": "rich_text",
+          "body_md": "在关系里，你常常是那个提议出去玩、约人聚会、把平凡日子变得有点仪式感的人。你喜欢和人一起感受生活，而不是只在文字和表情包里维系联系。\n\n你在乎的是：我们在一起的时候，是否真的快乐、放松、做回自己；而不是只维持体面的关系外壳。",
+          "body_html": null,
+          "payload_json": null,
+          "sort_order": 140,
+          "is_enabled": true
+        },
+        {
+          "section_key": "relationships.strengths",
+          "render_variant": "bullets",
+          "body_md": null,
+          "body_html": null,
+          "payload_json": {
+            "items": [
+              {
+                "title": "让相处变得好玩",
+                "body": "你很少让关系只停留在寒暄；你会提议一起去吃点好吃的、看一场电影、来一场说走就走的小出行。和你在一起，生活的体感会明显变好。"
+              },
+              {
+                "title": "愿意照顾对方情绪",
+                "body": "你能迅速觉察到对方今天状态好不好，会用轻松的方式陪伴、哄对方开心，或者默默替他挡掉一些尴尬场面。"
+              },
+              {
+                "title": "真诚直接，不太做作",
+                "body": "你不太擅长也不太愿意玩心机，喜欢就表达、不舒服也会在合适的时候说出来。这种真实感，會吸引很多同样真诚的人靠近。"
+              },
+              {
+                "title": "愿意为关系付出时间与行动",
+                "body": "你不只会说关心，而是会用实际行动表达在乎，比如赶去陪伴、带对方出去透透气、送小礼物或制造惊喜。"
+              }
+            ]
+          },
+          "sort_order": 150,
+          "is_enabled": true
+        },
+        {
+          "section_key": "relationships.weaknesses",
+          "render_variant": "bullets",
+          "body_md": null,
+          "body_html": null,
+          "payload_json": {
+            "items": [
+              {
+                "title": "容易逃避沉重对话",
+                "body": "当关系出现深层问题，需要认真聊清楚时，你可能会因为害怕气氛变得很压抑，而选择先拖一拖，或者用开玩笑的方式略过。"
+              },
+              {
+                "title": "把自己放在最後",
+                "body": "为了让大家都开心，你常常会做那个调节气氛、配合安排的人，却忽略了自己其实也有不想做、不想去的时刻。"
+              },
+              {
+                "title": "难以适应过度理性或疏离的对象",
+                "body": "如果对方长期不表达情绪、不回应你的热情，或者只讲道理、少有温度，你会非常挫败，甚至怀疑是自己不够好。"
+              },
+              {
+                "title": "情绪低谷时选择突然抽离",
+                "body": "当你真的很累时，可能会突然减少联系、少说话、甚至消失一阵子。对方如果不了解你的模式，可能会感到困惑或受伤。"
+              }
+            ]
+          },
+          "sort_order": 160,
+          "is_enabled": true
+        },
+        {
+          "section_key": "relationships.rel_advantages",
+          "render_variant": "premium_teaser",
+          "body_md": "当关系健康且被尊重时，你会成为很多人生命里重要的活力来源。你让聚会不再只是吃饭，让日常不再只是例行公事，也让很多严肃的时刻变得可以被温柔地度過。",
+          "body_html": null,
+          "payload_json": {
+            "teaser": "当关系健康且被尊重时，你会成为很多人生命里重要的活力来源。你让聚会不再只是吃饭，让日常不再只是例行公事，也让很多严肃的时刻变得可以被温柔地度過。",
+            "is_premium": true
+          },
+          "sort_order": 170,
+          "is_enabled": true
+        },
+        {
+          "section_key": "relationships.rel_risks",
+          "render_variant": "premium_teaser",
+          "body_md": "如果你总是待在情绪不稳定、经常被忽视或被利用的关系里，你的热情会一点点被消耗，最后只剩下疲惫和自我怀疑。学会辨认這些信号，并且为自己设定底线，是 ESFP-T 非常关键的一课。",
+          "body_html": null,
+          "payload_json": {
+            "teaser": "如果你总是待在情绪不稳定、经常被忽视或被利用的关系里，你的热情会一点点被消耗，最后只剩下疲惫和自我怀疑。学会辨认這些信号，并且为自己设定底线，是 ESFP-T 非常关键的一课。",
+            "is_premium": true
+          },
+          "sort_order": 180,
+          "is_enabled": true
+        }
+      ],
+      "seo_overrides": {
+        "seo_title": "ESFP-T 表演者型",
+        "seo_description": "你像一束突然打在舞台上的灯光：明亮、鲜活、带着一点不按套路的惊喜。你热爱当下的真实体验，也享受把快乐放大、分享给在场的每一个人。只要有你在，气氛就很难一直无聊下去。",
+        "canonical_url": null,
+        "og_title": "ESFP-T 灵感行动派",
+        "og_description": "你像一束突然打在舞台上的灯光：明亮、鲜活、带着一点不按套路的惊喜。你热爱当下的真实体验，也享受把快乐放大、分享给在场的每一个人。只要有你在，气氛就很难一直无聊下去。",
+        "og_image_url": null,
+        "twitter_title": "ESFP-T 灵感行动派",
+        "twitter_description": "你像一束突然打在舞台上的灯光：明亮、鲜活、带着一点不按套路的惊喜。你热爱当下的真实体验，也享受把快乐放大、分享给在场的每一个人。只要有你在，气氛就很难一直无聊下去。",
+        "twitter_image_url": null,
+        "robots": null,
+        "jsonld_overrides_json": null
+      }
+    },
+    {
+      "runtime_type_code": "ESTJ-A",
+      "canonical_type_code": "ESTJ",
+      "variant_code": "A",
+      "is_published": true,
+      "published_at": "2026-03-17T00:00:00Z",
+      "profile_overrides": {
+        "type_name": "总经理型",
+        "nickname": "秩序掌舵者（自信型）",
+        "rarity_text": "约 8–12%",
+        "keywords_json": [
+          "责任心",
+          "执行力",
+          "规则感",
+          "结果导向",
+          "组织者",
+          "决断力"
+        ],
+        "hero_summary_md": "你像一根稳固的中轴：无论身处哪里，哪里就会慢慢变得有秩序、有节奏、有方向。你相信，世界再复杂，只要目标清晰、分工明确、说到做到，多数问题都能被解决。",
+        "hero_summary_html": null
+      },
+      "section_overrides": [
+        {
+          "section_key": "letters_intro",
+          "render_variant": "letters_intro",
+          "body_md": null,
+          "body_html": null,
+          "payload_json": {
+            "headline": "外向 · 感觉 · 思维 · 规划 · 自信型｜以规则稳住局面、以行动推动结果的“秩序掌舵者”",
+            "letters": [
+              {
+                "letter": "E",
+                "title": "外向（E）",
+                "description": "让你更喜欢站在“人群之中”而不是旁观角落——现场协调、面对面沟通、当面拍板，远比线上文字更让你踏实。"
+              },
+              {
+                "letter": "S",
+                "title": "感觉（S）",
+                "description": "让你格外重视事实和细节，你更信赖看得见、摸得着的数据和经验，而不是空泛的猜测与假设。"
+              },
+              {
+                "letter": "T",
+                "title": "思维（T）",
+                "description": "让你在决策时优先考虑“对不对、合不合理”，你倾向于用逻辑、标准和效率来衡量方案，而不是一时的情绪起伏。"
+              },
+              {
+                "letter": "J",
+                "title": "规划（J）",
+                "description": "让你习惯先定目标、再列计划、再分配任务。你不喜欢混乱和随意，更倾向于让一切“有章可循、按部就班”。"
+              },
+              {
+                "letter": "A",
+                "title": "自信型（-A）",
+                "description": "让你在面对压力和不确定时依然保持稳定，不太容易被情绪左右。你更像是那个“先稳住场面、再想解决方案”的人。"
+              }
+            ]
+          },
+          "sort_order": 10,
+          "is_enabled": true
+        },
+        {
+          "section_key": "overview",
+          "render_variant": "rich_text",
+          "body_md": "在费马心理的逻辑模型里，ESTJ-A 常被视作“现实世界里的项目总监”。你务实、直接、讲原则、重执行，很擅长把一盘散沙的人和事，整合成一支有纪律、有节奏的队伍。\n\n对你来说，最舒服的状态是：目标明确、分工清晰、规则透明，每个人都知道自己该做什么、做到什么程度、在什么时间点交付。面对拖拉、反复、没结论的状态，你会本能地想要站出来收拾局面。\n\n你的人生追求，从来不只是“想一想就好”，而是“说到做到、做出结果”。你相信靠谱比好听重要，长期稳定比一时热闹更有价值。",
+          "body_html": null,
+          "payload_json": null,
+          "sort_order": 20,
+          "is_enabled": true
+        },
+        {
+          "section_key": "trait_overview",
+          "render_variant": "trait_dimension_grid",
+          "body_md": "建议与小程序中 5 条维度进度条搭配展示：外向 / 内向｜天马行空 / 求真务实｜情感细腻 / 理性思考｜运筹帷幄 / 随机应变｜情绪易波动 / 自信果断。",
+          "body_html": null,
+          "payload_json": {
+            "summary": "建议与小程序中 5 条维度进度条搭配展示：外向 / 内向｜天马行空 / 求真务实｜情感细腻 / 理性思考｜运筹帷幄 / 随机应变｜情绪易波动 / 自信果断。",
+            "dimensions": [
+              {
+                "id": "EI",
+                "name": "外向倾向",
+                "label": "外向倾向",
+                "axis_left": "外向",
+                "axis_right": "内向",
+                "summary": "明显偏外向",
+                "description": "你更习惯在现场指挥、当面沟通，而不是躲在幕后发消息。遇到关键问题，你往往是那个主动召集团队、开会拍板的人。"
+              },
+              {
+                "id": "SN",
+                "name": "心智模式",
+                "label": "心智模式",
+                "axis_left": "天马行空",
+                "axis_right": "求真务实",
+                "summary": "明显偏“求真务实”",
+                "description": "你更在意“现在具体能做什么、怎么做”，对天花乱坠、却落不到地上的想法兴趣有限。对你来说，最动听的话，是清晰可执行的行动方案。"
+              },
+              {
+                "id": "TF",
+                "name": "情绪天性",
+                "label": "情绪天性",
+                "axis_left": "情感细腻",
+                "axis_right": "理性思考",
+                "summary": "偏“理性思考”",
+                "description": "你重视事实多于感受，在处理问题时更倾向于先解决“事情本身”，再处理“情绪氛围”。在你看来，真正的负责，是把该做的事做好。"
+              },
+              {
+                "id": "JP",
+                "name": "应对方式",
+                "label": "应对方式",
+                "axis_left": "运筹帷幄",
+                "axis_right": "随机应变",
+                "summary": "明显偏“运筹帷幄”",
+                "description": "你喜欢在事情一开始就理清步骤、明确标准，而不是边走边看。对你来说，提前规划不是束缚，而是一种对自己和团队的负责。"
+              },
+              {
+                "id": "AT",
+                "name": "身份特征",
+                "label": "身份特征",
+                "axis_left": "情绪易波动",
+                "axis_right": "自信果断",
+                "summary": "偏“自信果断”",
+                "description": "作为自信型 ESTJ，你在多数时候都对自己的判断有把握，不太会在做出决定后反复后悔。你更习惯向前看，集中精力解决眼前问题。"
+              }
+            ]
+          },
+          "sort_order": 30,
+          "is_enabled": true
+        },
+        {
+          "section_key": "career.summary",
+          "render_variant": "rich_text",
+          "body_md": "在职业世界里，你天生适合站在“把事情推进下去”的位置上。无论是管理团队、执行项目，还是维护制度、监督流程，只要有一件事需要“有人负责到底”，你就具备天然优势。\n\n你不太适合长期待在完全没有结构、没人做决策的环境里——那会让你觉得时间被浪费、人生在原地打转。你更喜欢有权责边界、有明确目标的岗位。\n\n当一份工作允许你：制定规则、优化流程、带团队拿结果，并且你的付出能被看见、被量化时，你就会进入高效、稳定的发挥状态。",
+          "body_html": null,
+          "payload_json": null,
+          "sort_order": 40,
+          "is_enabled": true
+        },
+        {
+          "section_key": "career.advantages",
+          "render_variant": "bullets",
+          "body_md": null,
+          "body_html": null,
+          "payload_json": {
+            "items": [
+              {
+                "title": "强执行 + 强落地",
+                "body": "你不会只停留在“说一说”，更擅长把计划拆解成可执行的步骤，并盯到结果出来。很多团队里，真正能把项目推进到收尾的人，往往就是你这种类型。"
+              },
+              {
+                "title": "规则与秩序的维护者",
+                "body": "你对流程、制度和标准有高度敏感度，能快速发现“哪里不按规矩来”“哪里在浪费资源”，并推动大家回到合理轨道上。"
+              },
+              {
+                "title": "抗压、稳定、可靠",
+                "body": "在高压或紧急状况下，你反而会更冷静，迅速进入“分配任务、明确优先级”的状态。别人情绪还在波动时，你已经开始安排谁做什么。"
+              },
+              {
+                "title": "组织与管理能力强",
+                "body": "你擅长分工、排期、设定 KPI，并在过程中不断跟进，确保节奏不掉链。对于需要长期稳定运营的项目，你是非常关键的角色。"
+              }
+            ]
+          },
+          "sort_order": 50,
+          "is_enabled": true
+        },
+        {
+          "section_key": "career.weaknesses",
+          "render_variant": "bullets",
+          "body_md": null,
+          "body_html": null,
+          "payload_json": {
+            "items": [
+              {
+                "title": "容易被视作“太强势”",
+                "body": "当你为了效率而提高语气、直接指出问题时，别人可能只记住了你的“严厉”，而没看到你背后的负责与用心。"
+              },
+              {
+                "title": "对低效率高度不耐烦",
+                "body": "你很难容忍拖延、敷衍、推诿等行为，一旦遇到这种情况，很容易亲自接手，久而久之就变成“所有事都压在你身上”。"
+              },
+              {
+                "title": "对变化与模糊的耐受度较低",
+                "body": "频繁变动的目标、说一套做一套的管理，会严重消耗你的耐心与忠诚度，让你对整个环境丧失信任感。"
+              },
+              {
+                "title": "容易忽略情绪层面的管理",
+                "body": "在忙于盯结果的时候，你有时会忽视团队成员的情绪与倦怠，导致对方“事做完了，但心离开了”。"
+              }
+            ]
+          },
+          "sort_order": 60,
+          "is_enabled": true
+        },
+        {
+          "section_key": "career.preferred_roles",
+          "render_variant": "preferred_role_list",
+          "body_md": null,
+          "body_html": null,
+          "payload_json": {
+            "intro": "下面这些方向并不是“只能做这些”，而是更容易让 ESTJ-A 发挥稳定实力、感到“值得投入”的领域。",
+            "groups": [
+              {
+                "group_title": "运营与管理中枢",
+                "description": "需要长期盯流程、控质量、保结果的岗位。",
+                "examples": [
+                  "运营管理、项目管理、生产 / 供应链管理",
+                  "行政管理、人事行政综合岗",
+                  "门店 / 校区 / 分公司负责人"
+                ]
+              },
+              {
+                "group_title": "规则与秩序相关",
+                "description": "需要执行标准、监督合规的领域。",
+                "examples": [
+                  "审计、风控、质检、流程管理",
+                  "政府 / 公共事务相关岗位",
+                  "大型企业的制度设计与执行岗位"
+                ]
+              },
+              {
+                "group_title": "以结果为导向的业务岗位",
+                "description": "重视目标、节奏与成交的工作场景。",
+                "examples": [
+                  "销售管理、渠道拓展",
+                  "B 端客户经理、商务拓展（BD）",
+                  "需要带团队完成指标的中层管理"
+                ]
+              },
+              {
+                "group_title": "需要“压阵”的综合型角色",
+                "description": "当一个团队需要一个“说话算数、关键时刻能拍板”的人，你会是很自然的人选。",
+                "examples": [
+                  "项目负责人",
+                  "部门主管",
+                  "运营总监候选人等"
+                ]
+              }
+            ],
+            "outro": "选择职业时，你可以问自己三个问题：这份工作是否需要我“站出来负责”？是否允许我优化流程、提升效率？是否有清晰可见的结果和成长空间？如果三条都接近“是”，往往会比较适合你。"
+          },
+          "sort_order": 70,
+          "is_enabled": true
+        },
+        {
+          "section_key": "career.upgrade_suggestions",
+          "render_variant": "bullets",
+          "body_md": "你的能力往往不在于“能不能把事做好”，而在于“能不能在把事做好同时，把人带好”。当你在规则和结果之外，加入一些情绪温度和成长空间，你的领导力会提升一个维度。\n\n下面这几条公式，可以作为你在职场中的长期升级方向：",
+          "body_html": null,
+          "payload_json": {
+            "items": [
+              {
+                "title": "权威感 = 专业能力 × 被感受到的尊重",
+                "body": "你本身就不缺专业与判断力，下一步是让别人感到：即使被你要求、被你纠正，也仍然是被尊重的。表达要求前，多加一句肯定和立场说明，往往能让合作顺畅很多。"
+              },
+              {
+                "title": "团队战斗力 = 规则清晰 × 情绪安全",
+                "body": "清晰的规则让人知道怎么做，情绪上的安全感让人愿意全力以赴。你可以在制定流程时，顺带设计一些“反馈与倾诉”的通道，让问题更早暴露、更早解决。"
+              },
+              {
+                "title": "管理杠杆 = 授权深度 ÷ 事必躬亲",
+                "body": "当你什么都亲自盯时，短期效率可能很高，但长期会限制团队成长。刻意练习“把决定权交给合适的人”，并接受他们的成长需要试错空间。"
+              },
+              {
+                "title": "个人续航 = 自律节奏 × 合理留白",
+                "body": "你对自己要求高，很容易长期处在“全开”的状态。适当给自己预留空档时间，不排任务、不做决定，只用来恢复视野与精力，这会让你走得更稳更远。"
+              }
+            ]
+          },
+          "sort_order": 80,
+          "is_enabled": true
+        },
+        {
+          "section_key": "growth.summary",
+          "render_variant": "rich_text",
+          "body_md": "对 ESTJ-A 来说，成长并不只是“承担更多责任”，而是学会在高标准和高效率之外，给自己和别人留一点弹性与余地。\n\n这一章节，会从你的强项、短板以及内在动力与消耗点出发，帮你看清：怎样在保持执行力的同时，让自己活得更轻松、更自在。",
+          "body_html": null,
+          "payload_json": null,
+          "sort_order": 90,
+          "is_enabled": true
+        },
+        {
+          "section_key": "growth.strengths",
+          "render_variant": "bullets",
+          "body_md": null,
+          "body_html": null,
+          "payload_json": {
+            "items": [
+              {
+                "title": "高度自律与靠谱",
+                "body": "你一旦答应的事情，就会竭尽全力做到。你习惯为自己设定时间表与标准，很少放任自己长期失控。"
+              },
+              {
+                "title": "清晰的目标感",
+                "body": "你不太会在“我要做什么”这件事上长期迷茫，更容易在现实约束下做出明确选择，并为之投入。"
+              },
+              {
+                "title": "面对问题的正面迎战",
+                "body": "你不喜欢拖延问题、回避矛盾，更倾向于“现在就解决”。这种直接，让你在很多关键场景里成为可靠的解决者。"
+              },
+              {
+                "title": "持续优化的意识",
+                "body": "你会在实践中不断总结经验，改进流程、提升效率。你不一定热衷抽象反思，但很擅长在现实中“做中学”。"
+              }
+            ]
+          },
+          "sort_order": 100,
+          "is_enabled": true
+        },
+        {
+          "section_key": "growth.weaknesses",
+          "render_variant": "bullets",
+          "body_md": null,
+          "body_html": null,
+          "payload_json": {
+            "items": [
+              {
+                "title": "容易忽略自己的情绪需求",
+                "body": "你习惯把“事情搞定”放在第一位，很少停下来问问自己：我现在的感受怎么样？长期下来，情绪可能会以“突然爆发”或“身体疲惫”形式表现出来。"
+              },
+              {
+                "title": "对他人的差异容忍度有限",
+                "body": "当别人不像你一样高效、自律、有条理时，你很容易产生评判，甚至不自觉用自己的标准去要求对方。"
+              },
+              {
+                "title": "不擅长“示弱”和求助",
+                "body": "你更习惯做那个扛事的人，而不是开口寻求帮助。这会让别人误以为你永远都行，忽略了你也需要被支持的一面。"
+              },
+              {
+                "title": "对“慢热的成长”缺乏耐心",
+                "body": "你希望看到立竿见影的改进，对那些需要时间积累才能显效的改变（比如心态调整、文化建设），可能会缺乏耐心。"
+              }
+            ]
+          },
+          "sort_order": 110,
+          "is_enabled": true
+        },
+        {
+          "section_key": "growth.motivators",
+          "render_variant": "premium_teaser",
+          "body_md": "清晰的目标、实际的成果、被信任的权限，以及“有人看得见你的付出”，都会极大激发你的动力。当你知道“自己负责的这块没人能替代”，你会毫不犹豫地全力以赴。",
+          "body_html": null,
+          "payload_json": {
+            "teaser": "清晰的目标、实际的成果、被信任的权限，以及“有人看得见你的付出”，都会极大激发你的动力。当你知道“自己负责的这块没人能替代”，你会毫不犹豫地全力以赴。",
+            "is_premium": true
+          },
+          "sort_order": 120,
+          "is_enabled": true
+        },
+        {
+          "section_key": "growth.drainers",
+          "render_variant": "premium_teaser",
+          "body_md": "长期混乱的管理、态度散漫的同事、说一套做一套的环境，以及“你在努力但没人当回事”的场景，会持续消耗你的能量。如果这些因素长期存在，你会开始怀疑：继续投入是否值得。",
+          "body_html": null,
+          "payload_json": {
+            "teaser": "长期混乱的管理、态度散漫的同事、说一套做一套的环境，以及“你在努力但没人当回事”的场景，会持续消耗你的能量。如果这些因素长期存在，你会开始怀疑：继续投入是否值得。",
+            "is_premium": true
+          },
+          "sort_order": 130,
+          "is_enabled": true
+        },
+        {
+          "section_key": "relationships.summary",
+          "render_variant": "rich_text",
+          "body_md": "在关系世界里，你更像一位务实的“掌舵者”：不一定会说很多甜言蜜语，却会在关键时刻站出来扛责任、做决定、给安全感。\n\n你表达在乎的方式，常常是：把事情安排好、把风险挡在外面、把资源准备齐全。你最看重的，是彼此是否可靠、是否同向、是否说到做到。",
+          "body_html": null,
+          "payload_json": null,
+          "sort_order": 140,
+          "is_enabled": true
+        },
+        {
+          "section_key": "relationships.strengths",
+          "render_variant": "bullets",
+          "body_md": null,
+          "body_html": null,
+          "payload_json": {
+            "items": [
+              {
+                "title": "稳定可靠的存在感",
+                "body": "一旦你认定一段关系，就会认真对待、长期投入。身边的人往往会觉得：“只要有你在，就不会乱”。"
+              },
+              {
+                "title": "愿意承担现实责任",
+                "body": "你不会只停留在口头关心，更愿意在现实生活中付诸行动，比如处理琐事、规划未来、解决麻烦。"
+              },
+              {
+                "title": "边界清晰、立场明确",
+                "body": "在原则与底线问题上，你的态度很清楚，这让和你在一起的人很有安全感——他们知道什么是可以被依赖的。"
+              },
+              {
+                "title": "危机中的“定海神针”",
+                "body": "在矛盾或突发事件中，你通常不容易慌乱，会本能地进入“先稳住局面、再处理问题”的状态，为关系提供稳定支撑。"
+              }
+            ]
+          },
+          "sort_order": 150,
+          "is_enabled": true
+        },
+        {
+          "section_key": "relationships.weaknesses",
+          "render_variant": "bullets",
+          "body_md": null,
+          "body_html": null,
+          "payload_json": {
+            "items": [
+              {
+                "title": "不太会表达脆弱",
+                "body": "你习惯用“我来解决”来证明自己，很少坦诚承认“我也会累”“我也会害怕”，这让亲近的人有时很难真正走进你的内心。"
+              },
+              {
+                "title": "容易把关心变成“控制感”",
+                "body": "当你试图替对方安排好一切时，在你看来是负责，在对方看来可能是压力甚至被管束。"
+              },
+              {
+                "title": "情绪表达偏功能化",
+                "body": "你更擅长谈事情而不是谈感受，容易用“讲道理”的方式处理对方的情绪，让对方觉得“他懂事，但不一定懂我”。"
+              },
+              {
+                "title": "对“不靠谱的人”容忍度极低",
+                "body": "一旦对方反复失约、言行不一，你很难继续信任，很可能会果断抽离关系，不太愿意再给多次机会。"
+              }
+            ]
+          },
+          "sort_order": 160,
+          "is_enabled": true
+        },
+        {
+          "section_key": "relationships.rel_advantages",
+          "render_variant": "premium_teaser",
+          "body_md": "在健康的关系里，你是非常难得的“现实支柱”：既能提供稳定的物质与现实支持，又能在关键决策时给出清晰判断。你可能不是最浪漫的那种人，但往往是最可靠、最能一起过日子的人之一。",
+          "body_html": null,
+          "payload_json": {
+            "teaser": "在健康的关系里，你是非常难得的“现实支柱”：既能提供稳定的物质与现实支持，又能在关键决策时给出清晰判断。你可能不是最浪漫的那种人，但往往是最可靠、最能一起过日子的人之一。",
+            "is_premium": true
+          },
+          "sort_order": 170,
+          "is_enabled": true
+        },
+        {
+          "section_key": "relationships.rel_risks",
+          "render_variant": "premium_teaser",
+          "body_md": "当你长期处在“只负责、不被理解”的关系模式里时，你会逐渐变得冷硬与疏离，甚至把温柔一并收起。学会在关系中表达自己的需求，而不是只扮演那个“什么都能扛的人”，是你长期维系亲密的关键课题。",
+          "body_html": null,
+          "payload_json": {
+            "teaser": "当你长期处在“只负责、不被理解”的关系模式里时，你会逐渐变得冷硬与疏离，甚至把温柔一并收起。学会在关系中表达自己的需求，而不是只扮演那个“什么都能扛的人”，是你长期维系亲密的关键课题。",
+            "is_premium": true
+          },
+          "sort_order": 180,
+          "is_enabled": true
+        }
+      ],
+      "seo_overrides": {
+        "seo_title": "ESTJ-A 总经理型",
+        "seo_description": "你像一根稳固的中轴：无论身处哪里，哪里就会慢慢变得有秩序、有节奏、有方向。你相信，世界再复杂，只要目标清晰、分工明确、说到做到，多数问题都能被解决。",
+        "canonical_url": null,
+        "og_title": "ESTJ-A 秩序掌舵者（自信型）",
+        "og_description": "你像一根稳固的中轴：无论身处哪里，哪里就会慢慢变得有秩序、有节奏、有方向。你相信，世界再复杂，只要目标清晰、分工明确、说到做到，多数问题都能被解决。",
+        "og_image_url": null,
+        "twitter_title": "ESTJ-A 秩序掌舵者（自信型）",
+        "twitter_description": "你像一根稳固的中轴：无论身处哪里，哪里就会慢慢变得有秩序、有节奏、有方向。你相信，世界再复杂，只要目标清晰、分工明确、说到做到，多数问题都能被解决。",
+        "twitter_image_url": null,
+        "robots": null,
+        "jsonld_overrides_json": null
+      }
+    },
+    {
+      "runtime_type_code": "ESTJ-T",
+      "canonical_type_code": "ESTJ",
+      "variant_code": "T",
+      "is_published": true,
+      "published_at": "2026-03-17T00:00:00Z",
+      "profile_overrides": {
+        "type_name": "总经理型",
+        "nickname": "秩序掌舵者",
+        "rarity_text": "约 8–12%",
+        "keywords_json": [
+          "责任感",
+          "执行力",
+          "结果导向",
+          "原则感",
+          "组织力",
+          "现实主义"
+        ],
+        "hero_summary_md": "你天生擅长把事情“排好队”：目标清晰、行动果断、讲原则、有底线。在别人犹豫不决的时候，你已经开始推动事情前进，并且愿意为结果负责。",
+        "hero_summary_html": null
+      },
+      "section_overrides": [
+        {
+          "section_key": "letters_intro",
+          "render_variant": "letters_intro",
+          "body_md": null,
+          "body_html": null,
+          "payload_json": {
+            "headline": "外向 · 实感 · 思维 · 规划 · 动荡型｜在秩序与效率中找到安全感的“务实掌舵者”",
+            "letters": [
+              {
+                "letter": "E",
+                "title": "外向（E）",
+                "description": "让你更喜欢“在场感”——开会、协调、现场解决问题，比单独在电脑前想象要来得舒服得多。你从人与行动中获取能量。"
+              },
+              {
+                "letter": "S",
+                "title": "实感（S）",
+                "description": "让你优先关注看得见、摸得着的事实与数据。你更关心“现在具体发生了什么”“流程是否跑得通”，而不是过多沉迷于抽象假设。"
+              },
+              {
+                "letter": "T",
+                "title": "思维（T）",
+                "description": "让你在决策时更看重对错、效率与结果。你相信“标准”“逻辑”和“规则”，有时宁愿当那个说出不那么好听真话的人。"
+              },
+              {
+                "letter": "J",
+                "title": "规划（J）",
+                "description": "让你习惯提前安排、设定节奏，喜欢“有计划、有节点、有交付”的状态。临时变卦、朝令夕改会严重消耗你的耐心。"
+              },
+              {
+                "letter": "T",
+                "title": "动荡型（-T）",
+                "description": "让你对自己要求很高，看上去强势，其实也会在心里反复自查：“我是不是还能做得更好？” 这是你的驱动力，也是压力来源。"
+              }
+            ]
+          },
+          "sort_order": 10,
+          "is_enabled": true
+        },
+        {
+          "section_key": "overview",
+          "render_variant": "rich_text",
+          "body_md": "在费马心理的逻辑模型里，ESTJ-T 往往被视作“秩序的掌舵者”。你擅长在复杂局面中迅速厘清目标、划分责任、建立流程，用清晰的结构把一团乱麻变成一张可执行的行动清单。\n\n对你来说，最舒服的状态是：规则清楚、边界分明、每个人各就各位、事情按计划推进。当环境混乱、标准含糊、大家一团散沙时，你会本能地站出来收拾局面，把秩序拉回来。\n\n你的人生追求从来不只是“把时间打发过去”，而是“把该做的事做好，把该承担的责任扛起来”。你希望自己是那个让事情真正发生的人。",
+          "body_html": null,
+          "payload_json": null,
+          "sort_order": 20,
+          "is_enabled": true
+        },
+        {
+          "section_key": "trait_overview",
+          "render_variant": "trait_dimension_grid",
+          "body_md": "建议与小程序中 5 条维度进度条搭配展示：外向 / 内向｜天马行空 / 求真务实｜情感细腻 / 理性思考｜运筹帷幄 / 随机应变｜情绪易波动 / 自信果断。",
+          "body_html": null,
+          "payload_json": {
+            "summary": "建议与小程序中 5 条维度进度条搭配展示：外向 / 内向｜天马行空 / 求真务实｜情感细腻 / 理性思考｜运筹帷幄 / 随机应变｜情绪易波动 / 自信果断。",
+            "dimensions": [
+              {
+                "id": "EI",
+                "name": "外向倾向",
+                "label": "外向倾向",
+                "axis_left": "外向",
+                "axis_right": "内向",
+                "summary": "偏外向",
+                "description": "你更像是那个“站在台前”的人：指挥、协调、发号施令、当场拍板，对你来说都不算难事。偶尔独处可以让你整理思路，但长时间被动脱离现场，会让你觉得失去掌控感。"
+              },
+              {
+                "id": "SN",
+                "name": "心智模式",
+                "label": "心智模式",
+                "axis_left": "天马行空",
+                "axis_right": "求真务实",
+                "summary": "明显偏“求真务实”",
+                "description": "你习惯先落地再谈远方：预算是多少？人手够不够？时间节点怎么排？相较于畅想，你更愿意讨论“具体怎么做”。不接地气的空谈，会很快耗尽你的耐心。"
+              },
+              {
+                "id": "TF",
+                "name": "情绪天性",
+                "label": "情绪天性",
+                "axis_left": "情感细腻",
+                "axis_right": "理性思考",
+                "summary": "偏“理性思考”",
+                "description": "你尊重情绪，但更相信事实与逻辑。面对冲突，你更习惯先对齐客观标准，再考虑感受。有时你以为自己是在“就事论事”，但在别人耳朵里，可能听起来有点直接甚至严厉。"
+              },
+              {
+                "id": "JP",
+                "name": "应对方式",
+                "label": "应对方式",
+                "axis_left": "运筹帷幄",
+                "axis_right": "随机应变",
+                "summary": "偏“运筹帷幄”",
+                "description": "对你来说，“有计划”本身就是一种安全感。你习惯先设好目标和时间表，再按照优先级推进。突发情况出现时，你会迅速调整安排，而不是完全即兴发挥。"
+              },
+              {
+                "id": "AT",
+                "name": "身份特征",
+                "label": "身份特征",
+                "axis_left": "情绪易波动",
+                "axis_right": "自信果断",
+                "summary": "外表果断，内在略偏“情绪易波动”",
+                "description": "动荡型的你，看上去坚定冷静，内心却经常在给自己打分——尤其是当结果不如预期、或别人对你有质疑时。你不喜欢示弱，更不太习惯说“我也会累”，所以很多压力都在悄悄内耗你。"
+              }
+            ]
+          },
+          "sort_order": 30,
+          "is_enabled": true
+        },
+        {
+          "section_key": "career.summary",
+          "render_variant": "rich_text",
+          "body_md": "你的职业选择，通常会围绕“目标、责任和秩序”展开。只要有清晰的指标、明确的权责边界、可控的资源配置，你就能进入高效运转状态。\n\n你不太适合长期处在“没有标准”“没人负责”“天天变来变去”的环境里。那会让你怀疑这件事本身是否值得投入，也很难激发你的耐心。\n\n相反，当一份工作允许你：制定流程、统筹资源、管理团队、把计划真正落地，并且看到实打实的结果时，你会充满干劲。",
+          "body_html": null,
+          "payload_json": null,
+          "sort_order": 40,
+          "is_enabled": true
+        },
+        {
+          "section_key": "career.advantages",
+          "render_variant": "bullets",
+          "body_md": null,
+          "body_html": null,
+          "payload_json": {
+            "items": [
+              {
+                "title": "执行力极强",
+                "body": "一旦目标确定，你会立刻开始拆解任务、分配资源、设定时间表。你不喜欢拖延，用“先动起来”来推动问题解决。"
+              },
+              {
+                "title": "责任心重，愿意扛事",
+                "body": "你愿意对结果负责，而不是只做“流程中的一环”。在项目、团队、家庭事务中，你都容易成为那个大家下意识信任的“负责人”。"
+              },
+              {
+                "title": "结构化与组织能力",
+                "body": "你擅长用规则、流程和制度去梳理混乱，把复杂事务拆成有逻辑的步骤，让团队知道“接下来该做什么”。"
+              },
+              {
+                "title": "原则清晰，立场稳定",
+                "body": "你有一套自己的底线和标准，不会轻易随大流。这让你在需要“把关”“做决策”“守住边界”的岗位上，显得格外可靠。"
+              }
+            ]
+          },
+          "sort_order": 50,
+          "is_enabled": true
+        },
+        {
+          "section_key": "career.weaknesses",
+          "render_variant": "bullets",
+          "body_md": null,
+          "body_html": null,
+          "payload_json": {
+            "items": [
+              {
+                "title": "容易被贴上“太强势”的标签",
+                "body": "当你为了推进事情而提高语气、直接指出问题时，别人可能只记住了你的严厉，却忽略你背后的负责与用心。"
+              },
+              {
+                "title": "对低效率和拖延很难容忍",
+                "body": "你很难接受“磨磨蹭蹭”“说一套做一套”的工作风格，看到别人状态松散时，会忍不住焦躁甚至亲自接手，结果把自己累到极限。"
+              },
+              {
+                "title": "情绪表达偏“功能化”",
+                "body": "你习惯用“解决问题”的方式面对情绪，容易忽略别人当下只是需要被理解与陪伴。这会让某些同事或下属觉得你“不够温柔”。"
+              },
+              {
+                "title": "对变化和模糊的耐受度较低",
+                "body": "频繁改方向、规则朝令夕改、上级说一套做一套，会让你迅速失去信任感，甚至选择抽离。适应高度不确定的环境，对你来说是一个挑战。"
+              }
+            ]
+          },
+          "sort_order": 60,
+          "is_enabled": true
+        },
+        {
+          "section_key": "career.preferred_roles",
+          "render_variant": "preferred_role_list",
+          "body_md": null,
+          "body_html": null,
+          "payload_json": {
+            "intro": "下面这些并不是唯一适合 ESTJ-T 的岗位，而是几类更容易让你发挥组织力与执行力、同时获得成就感的方向。可以当作职业规划与转型思考的参考起点。",
+            "groups": [
+              {
+                "group_title": "管理与运营相关",
+                "description": "需要“把计划落地”“对结果负责”的角色。",
+                "examples": [
+                  "运营管理、项目管理、产品运营负责人",
+                  "企业中层管理者、部门主管、团队 Leader",
+                  "连锁门店 / 校区 / 区域运营负责人"
+                ]
+              },
+              {
+                "group_title": "流程与规则把关",
+                "description": "强调标准、流程与合规性的领域。",
+                "examples": [
+                  "行政管理、人力资源管理（制度与执行方向）",
+                  "质量管理、审计、风控、合规相关岗位",
+                  "生产制造、工程施工等一线管理与监督岗位"
+                ]
+              },
+              {
+                "group_title": "执行导向的业务岗位",
+                "description": "对目标清晰、节奏紧凑、讲求成果的场景。",
+                "examples": [
+                  "销售团队管理、渠道拓展负责人",
+                  "供应链 / 物流调度与统筹",
+                  "大型活动执行、会务统筹、现场运营"
+                ]
+              },
+              {
+                "group_title": "公共秩序与服务体系",
+                "description": "需要高度责任感与规则意识、并为他人安全与秩序负责的工作。",
+                "examples": [
+                  "公务体系、基层管理者",
+                  "安保、消防、交通管理等公共服务岗位",
+                  "校园、社区或园区的综合管理岗位"
+                ]
+              }
+            ],
+            "outro": "比起光鲜的头衔，你更在意这份工作是否“运转有效、责任清晰、结果看得见”。只要能把一摊事情打理得井井有条，你就会觉得这段投入非常值。"
+          },
+          "sort_order": 70,
+          "is_enabled": true
+        },
+        {
+          "section_key": "career.upgrade_suggestions",
+          "render_variant": "bullets",
+          "body_md": "对 ESTJ-T 来说，真正的天花板往往不在“执行力”，而在“别人是否愿意长期跟着你一起做事”。当你在效率与规则之外，再加上一点共情与弹性，你的影响力会显著放大。",
+          "body_html": null,
+          "payload_json": {
+            "items": [
+              {
+                "title": "高效执行 = 清晰目标 × 被认可的方式",
+                "body": "在下达任务前，多花 1 分钟讲清楚“为什么做”和“做到什么程度算合格”。当别人理解你在守护什么，而不是只收到一串指令时，配合度会更高。"
+              },
+              {
+                "title": "权威感 = 专业能力 × 倾听能力",
+                "body": "除了“我来拍板”，也尝试多问一句：“你怎么看？” 你依然可以做最终决策，但这个过程会让团队更有参与感，也更愿意为决定买单。"
+              },
+              {
+                "title": "团队稳定性 = 原则清晰 × 适度弹性",
+                "body": "底线可以坚定，但执行方式可以灵活。对事不对人、先肯定再指出问题、给改正空间，都会让你的“严格”变成“值得信赖的靠谱”。"
+              },
+              {
+                "title": "可持续输出 = 授权能力 × 自我节奏",
+                "body": "学会把一部分任务交给合适的人，而不是所有事都自己扛。把时间留给真正需要你决策和把关的环节，可以避免你陷入“最累但又离不开”的状态。"
+              }
+            ]
+          },
+          "sort_order": 80,
+          "is_enabled": true
+        },
+        {
+          "section_key": "growth.summary",
+          "render_variant": "rich_text",
+          "body_md": "对 ESTJ-T 来说，成长并不只是“做得更快、更准”，而是“在坚持原则的同时，让自己活得更轻松，让关系更顺畅”。\n\n你天生就具备很强的执行力与责任感，这让你在很多场景里成为“关键人物”。而接下来的成长，更像是在你的骨架之上，加上一些柔韧与空间。",
+          "body_html": null,
+          "payload_json": null,
+          "sort_order": 90,
+          "is_enabled": true
+        },
+        {
+          "section_key": "growth.strengths",
+          "render_variant": "bullets",
+          "body_md": null,
+          "body_html": null,
+          "payload_json": {
+            "items": [
+              {
+                "title": "高度自律与可靠",
+                "body": "你说到做到，答应的事情会尽力完成。别人对你的第一印象往往是：靠谱、能托付重要任务。"
+              },
+              {
+                "title": "抗压能力强",
+                "body": "关键时刻你不会轻易慌乱，而是先稳住现场、优先处理最重要的问题。这让你在危机情境中往往发挥关键作用。"
+              },
+              {
+                "title": "务实清醒",
+                "body": "你不会被空泛的口号轻易打动，更关注资源、成本、时间与人手是否匹配。这种现实感，是很多团队稳定运转的底座。"
+              },
+              {
+                "title": "决策与判断力",
+                "body": "你不怕做决定，也习惯为决定负责。面对摇摆不定的局面，你能迅速根据现有信息给出方向。"
+              }
+            ]
+          },
+          "sort_order": 100,
+          "is_enabled": true
+        },
+        {
+          "section_key": "growth.weaknesses",
+          "render_variant": "bullets",
+          "body_md": null,
+          "body_html": null,
+          "payload_json": {
+            "items": [
+              {
+                "title": "控制欲偏强",
+                "body": "你很难看着事情“按照你认为不对的方式”进行，于是会忍不住介入、指导、甚至接手。久而久之，你会觉得“怎么什么都要我来”。"
+              },
+              {
+                "title": "对柔软情绪不耐烦",
+                "body": "你在面对抱怨、犹豫、反复纠结时，可能会不自觉地把耐心用完，更倾向于说：“你到底想怎么办？” 这会让一些人觉得不被理解。"
+              },
+              {
+                "title": "容易忽略自己的感受",
+                "body": "你习惯扛责任、做强者，不太愿意示弱或求助。长期下来，你可能连自己真正的疲惫、委屈和脆弱都不太敢承认。"
+              },
+              {
+                "title": "对变化的包容度有限",
+                "body": "你偏好稳定、可预测的环境。面对高不确定性、频繁试错的阶段，你容易感到烦躁或强烈不安。"
+              }
+            ]
+          },
+          "sort_order": 110,
+          "is_enabled": true
+        },
+        {
+          "section_key": "growth.motivators",
+          "render_variant": "premium_teaser",
+          "body_md": "清晰的目标、可见的成果、被信任地托付重要职责，以及“我守住了底线”的成就感，都会让你感觉这一切非常值得。",
+          "body_html": null,
+          "payload_json": {
+            "teaser": "清晰的目标、可见的成果、被信任地托付重要职责，以及“我守住了底线”的成就感，都会让你感觉这一切非常值得。",
+            "is_premium": true
+          },
+          "sort_order": 120,
+          "is_enabled": true
+        },
+        {
+          "section_key": "growth.drainers",
+          "render_variant": "premium_teaser",
+          "body_md": "模糊的要求、频繁的朝令夕改、责任不清的团队、以及那些只说不做的人，会慢慢耗尽你的耐心与热情。长期一个人扛下所有，也会让你身心俱疲。",
+          "body_html": null,
+          "payload_json": {
+            "teaser": "模糊的要求、频繁的朝令夕改、责任不清的团队、以及那些只说不做的人，会慢慢耗尽你的耐心与热情。长期一个人扛下所有，也会让你身心俱疲。",
+            "is_premium": true
+          },
+          "sort_order": 130,
+          "is_enabled": true
+        },
+        {
+          "section_key": "relationships.summary",
+          "render_variant": "rich_text",
+          "body_md": "在关系世界里，你更像一位“务实的守护者”。你不一定擅长说漂亮话，但会用行动表达在乎——帮忙安排、替对方操心、在关键时刻出手相助。\n\n你在意的是：这段关系是否稳定、是否踏实、对方是否值得你托付真心，以及你们是否能一起把生活打理得更好。",
+          "body_html": null,
+          "payload_json": null,
+          "sort_order": 140,
+          "is_enabled": true
+        },
+        {
+          "section_key": "relationships.strengths",
+          "render_variant": "bullets",
+          "body_md": null,
+          "body_html": null,
+          "payload_json": {
+            "items": [
+              {
+                "title": "可靠的行动派",
+                "body": "你不太会空口许愿，更擅长用具体的事来表达关心：接送、张罗、解决问题、替对方挡事。久而久之，别人会非常信赖你的存在。"
+              },
+              {
+                "title": "界限清晰，讲原则",
+                "body": "你尊重承诺，也希望对方一样。你会在关系中维持一定的秩序感，这能给对方带来安全感——至少和你在一起，很少有“今天这样明天那样”的混乱。"
+              },
+              {
+                "title": "愿意承担责任",
+                "body": "无论是家务分工、经济压力还是共同计划，你都愿意扛起自己那一份，甚至多承担一些，只要你觉得“这是对的事”。"
+              },
+              {
+                "title": "解决问题导向",
+                "body": "当关系遇到现实难题时，你不会只停留在情绪上，而是会主动思考：“那我们要怎么改？” 这让很多风波可以被化解在升级之前。"
+              }
+            ]
+          },
+          "sort_order": 150,
+          "is_enabled": true
+        },
+        {
+          "section_key": "relationships.weaknesses",
+          "render_variant": "bullets",
+          "body_md": null,
+          "body_html": null,
+          "payload_json": {
+            "items": [
+              {
+                "title": "表达方式偏直接",
+                "body": "你习惯就事论事，有时会在无意间用较硬的语气指出问题。你以为是在帮助对方变好，对方可能先听到的是“被批评”和“被否定”。"
+              },
+              {
+                "title": "不擅长示弱",
+                "body": "你很少主动说“我也需要被照顾”，久而久之，身边人会默认你永远很强，很难意识到你其实也会累、也会难过。"
+              },
+              {
+                "title": "容易变成“家长式角色”",
+                "body": "你会帮对方规划、提醒对方该怎么做，不小心就把自己放在“上对下”的位置。长期下来，对方可能会觉得被控制，或者干脆把一切都丢给你。"
+              },
+              {
+                "title": "情绪表达偏迟钝",
+                "body": "你不太习惯细腻地描述自己的感受，也不容易立即理解对方复杂的情绪弯弯绕绕，这有时会被误读为“不够体贴”。"
+              }
+            ]
+          },
+          "sort_order": 160,
+          "is_enabled": true
+        },
+        {
+          "section_key": "relationships.rel_advantages",
+          "render_variant": "premium_teaser",
+          "body_md": "在健康的关系中，你会成为别人生命里那个“关键时刻站得住的人”：稳、靠谱、能扛事。你帮关系搭起现实的地基，让理想不只是嘴上说说。",
+          "body_html": null,
+          "payload_json": {
+            "teaser": "在健康的关系中，你会成为别人生命里那个“关键时刻站得住的人”：稳、靠谱、能扛事。你帮关系搭起现实的地基，让理想不只是嘴上说说。",
+            "is_premium": true
+          },
+          "sort_order": 170,
+          "is_enabled": true
+        },
+        {
+          "section_key": "relationships.rel_risks",
+          "render_variant": "premium_teaser",
+          "body_md": "当你长期处在“我在负责、你在享受”的关系模式里时，你的耐心会被慢慢消耗，最后只剩下冷却的失望。学会在更早的时候表达需求、设定边界，而不是等到爆发，对你尤为重要。",
+          "body_html": null,
+          "payload_json": {
+            "teaser": "当你长期处在“我在负责、你在享受”的关系模式里时，你的耐心会被慢慢消耗，最后只剩下冷却的失望。学会在更早的时候表达需求、设定边界，而不是等到爆发，对你尤为重要。",
+            "is_premium": true
+          },
+          "sort_order": 180,
+          "is_enabled": true
+        }
+      ],
+      "seo_overrides": {
+        "seo_title": "ESTJ-T 总经理型",
+        "seo_description": "你天生擅长把事情“排好队”：目标清晰、行动果断、讲原则、有底线。在别人犹豫不决的时候，你已经开始推动事情前进，并且愿意为结果负责。",
+        "canonical_url": null,
+        "og_title": "ESTJ-T 秩序掌舵者",
+        "og_description": "你天生擅长把事情“排好队”：目标清晰、行动果断、讲原则、有底线。在别人犹豫不决的时候，你已经开始推动事情前进，并且愿意为结果负责。",
+        "og_image_url": null,
+        "twitter_title": "ESTJ-T 秩序掌舵者",
+        "twitter_description": "你天生擅长把事情“排好队”：目标清晰、行动果断、讲原则、有底线。在别人犹豫不决的时候，你已经开始推动事情前进，并且愿意为结果负责。",
+        "twitter_image_url": null,
+        "robots": null,
+        "jsonld_overrides_json": null
+      }
+    },
+    {
+      "runtime_type_code": "ESTP-A",
+      "canonical_type_code": "ESTP",
+      "variant_code": "A",
+      "is_published": true,
+      "published_at": "2026-03-17T00:00:00Z",
+      "profile_overrides": {
+        "type_name": "企业家型",
+        "nickname": "现场操盘手",
+        "rarity_text": "约 4–6%",
+        "keywords_json": [
+          "行动力",
+          "现场反应",
+          "现实主义",
+          "临场应变",
+          "挑战精神",
+          "结果导向"
+        ],
+        "hero_summary_md": "你擅长在“现场”做决定：看到机会就想马上上手，遇到问题就想立刻拆解。你不喜欢空谈大道理，更享受在真实的环境里，亲自试、亲自闯、亲自赢下来。",
+        "hero_summary_html": null
+      },
+      "section_overrides": [
+        {
+          "section_key": "letters_intro",
+          "render_variant": "letters_intro",
+          "body_md": null,
+          "body_html": null,
+          "payload_json": {
+            "headline": "外向 · 现实 · 思考 · 感知 · 自信型｜反应迅速、敢拼敢上的“现场操盘手”",
+            "letters": [
+              {
+                "letter": "E",
+                "title": "外向（E）",
+                "description": "让你享受和人打交道：面对面沟通、现场博弈、一起出门“搞点事情”，比独自在屏幕后面更能让你兴奋。"
+              },
+              {
+                "letter": "S",
+                "title": "现实（S）",
+                "description": "让你更关注“眼前能抓住什么”，你喜欢具体的信息、真实的数据和可见的结果，而不是太虚的空想和口号。"
+              },
+              {
+                "letter": "T",
+                "title": "思考（T）",
+                "description": "让你在关键判断时会先看“利弊得失”，更在意事情是否有效、方案是否可行，而不是每个人当下开不开心。"
+              },
+              {
+                "letter": "P",
+                "title": "感知（P）",
+                "description": "让你更偏向“先干起来再说”，喜欢保留选择、临场调整路线，而不是一开始就把一切都锁死在计划里。"
+              },
+              {
+                "letter": "A",
+                "title": "自信型（-A）",
+                "description": "让你在压力和不确定中仍然相对稳定，对自己的判断有底气，不太会因为外界评价而出现长时间的自我怀疑。"
+              }
+            ]
+          },
+          "sort_order": 10,
+          "is_enabled": true
+        },
+        {
+          "section_key": "overview",
+          "render_variant": "rich_text",
+          "body_md": "在费马心理的逻辑模型里，ESTP-A 常被视作“现场操盘手”：反应快、点子多、敢出手。你习惯走进真实场景，用眼睛看、用耳朵听、用身体去试，边行动边修正路线。\n\n对你来说，最舒服的状态是：信息透明、节奏足够快、机会随时可能出现，而你就站在第一排，随时准备上场。拖沓、含糊、光说不做，会让你迅速失去耐心。\n\n你的人生追求，很少停留在“想清楚”，而是更偏向“做出来”。你更相信：真正的判断，只能在一次次实战中被验证。",
+          "body_html": null,
+          "payload_json": null,
+          "sort_order": 20,
+          "is_enabled": true
+        },
+        {
+          "section_key": "trait_overview",
+          "render_variant": "trait_dimension_grid",
+          "body_md": "建议与小程序中 5 条维度进度条搭配展示：外向 / 内向｜天马行空 / 求真务实｜情感细腻 / 理性思考｜运筹帷幄 / 随机应变｜情绪易波动 / 自信果断。",
+          "body_html": null,
+          "payload_json": {
+            "summary": "建议与小程序中 5 条维度进度条搭配展示：外向 / 内向｜天马行空 / 求真务实｜情感细腻 / 理性思考｜运筹帷幄 / 随机应变｜情绪易波动 / 自信果断。",
+            "dimensions": [
+              {
+                "id": "EI",
+                "name": "外向倾向",
+                "label": "外向倾向",
+                "axis_left": "外向",
+                "axis_right": "内向",
+                "summary": "明显偏外向",
+                "description": "你更像是那个主动发动话题、快速进入状态的人。热闹的场景、充满变化的现场、和人面对面的较量，会让你觉得“这才是活着的感觉”。长时间独处，对你来说更像是暂时的充电，而不是常态。"
+              },
+              {
+                "id": "SN",
+                "name": "心智模式",
+                "label": "心智模式",
+                "axis_left": "天马行空",
+                "axis_right": "求真务实",
+                "summary": "偏“求真务实”",
+                "description": "你会问的往往不是“这个想法有多宏大？”，而是“这个东西到底好不好用？现在能不能试？今天能不能出结果？”。你擅长用事实、反馈和实际表现来评估一件事的价值，而不是被大叙事轻易带走。"
+              },
+              {
+                "id": "TF",
+                "name": "情绪天性",
+                "label": "情绪天性",
+                "axis_left": "情感细腻",
+                "axis_right": "理性思考",
+                "summary": "偏“理性思考”",
+                "description": "你并不是没有感情，而是更习惯用“问题怎么解”来回应情绪。遇到状况时，你会迅速进入分析模式：关键点在哪？怎么最快解决？这让你在紧急场景中很可靠，但有时也会显得“不够温柔”。"
+              },
+              {
+                "id": "JP",
+                "name": "应对方式",
+                "label": "应对方式",
+                "axis_left": "运筹帷幄",
+                "axis_right": "随机应变",
+                "summary": "明显偏“随机应变”",
+                "description": "你喜欢留有余地，不爱被严密的计划绑死。对你来说，计划只是参考，更重要的是临场判断。你擅长在变化中寻找机会，迅速调整打法，在不确定环境中“现场翻盘”。"
+              },
+              {
+                "id": "AT",
+                "name": "身份特征",
+                "label": "身份特征",
+                "axis_left": "情绪易波动",
+                "axis_right": "自信果断",
+                "summary": "偏“自信果断”",
+                "description": "自信型的你，通常不会被一两次失误打倒。你把错误视作“下次会玩得更好”的经验包，很少长时间沉浸在懊悔中。你更习惯说：“再来一次，这次我知道怎么搞了。”"
+              }
+            ]
+          },
+          "sort_order": 30,
+          "is_enabled": true
+        },
+        {
+          "section_key": "career.summary",
+          "render_variant": "rich_text",
+          "body_md": "你的职业偏好，往往指向那些“节奏快、反馈清晰、能见到真实结果”的领域。你不适合长期被困在重复、单调、缺少决定权的位置上，那会让你感觉像被按了暂停键。\n\n当工作允许你：接触真实一线、快速试错、灵活决策、直接看到“今天的选择，明天的数据就不一样”，你会异常投入。\n\n相反，如果工作被繁琐流程、低效会议和抽象汇报占据，看不到实际动作和真实进展，你的状态会明显下滑。",
+          "body_html": null,
+          "payload_json": null,
+          "sort_order": 40,
+          "is_enabled": true
+        },
+        {
+          "section_key": "career.advantages",
+          "render_variant": "bullets",
+          "body_md": null,
+          "body_html": null,
+          "payload_json": {
+            "items": [
+              {
+                "title": "临场反应快，敢于决断",
+                "body": "你擅长在信息不完全的情况下做出相对合理的选择。和许多人需要长时间分析不同，你可以在高速运转的环境里仍然保持清晰判断。"
+              },
+              {
+                "title": "学习速度快，实战中成长",
+                "body": "你在纸面理论里的耐心有限，但只要能动手试，你就能在极短时间内掌握要领。你属于“越干越聪明”的类型。"
+              },
+              {
+                "title": "善于发现机会与缝隙",
+                "body": "你对市场、环境和人情世故很敏锐，能够在变化中看到别人还没注意到的缝隙与机会，并迅速尝试切入。"
+              },
+              {
+                "title": "抗压能力强，不玻璃心",
+                "body": "竞争、指标、压力、临时变动，对你来说更多是一种“游戏难度提升”，而不是灾难。你反而会在这种环境里激发出战斗力。"
+              }
+            ]
+          },
+          "sort_order": 50,
+          "is_enabled": true
+        },
+        {
+          "section_key": "career.weaknesses",
+          "render_variant": "bullets",
+          "body_md": null,
+          "body_html": null,
+          "payload_json": {
+            "items": [
+              {
+                "title": "容易低估长期规划的重要性",
+                "body": "你更习惯盯住“当下这一波”，有时会忽略长期积累和系统建设，导致阶段性表现亮眼，但整体节奏缺乏持续性。"
+              },
+              {
+                "title": "不耐烦慢节奏与繁琐流程",
+                "body": "冗长的流程、重复的表格和无效会议，容易让你心生抵触，甚至直接选择“先做了再说”，从而和一些规范要求发生冲突。"
+              },
+              {
+                "title": "沟通风格可能显得太直接",
+                "body": "在你看来，只是就事论事、直接指出问题；但在一些同事眼中，可能会被理解为“太冲”“不留情面”。"
+              },
+              {
+                "title": "风险控制意识有时偏乐观",
+                "body": "你相信“船到桥头自然直”，这在很多场景下是优势，但在高风险决策中，如果缺乏补位的谨慎角色，可能会带来额外代价。"
+              }
+            ]
+          },
+          "sort_order": 60,
+          "is_enabled": true
+        },
+        {
+          "section_key": "career.preferred_roles",
+          "render_variant": "preferred_role_list",
+          "body_md": null,
+          "body_html": null,
+          "payload_json": {
+            "intro": "下面这些方向，不一定是唯一答案，但更容易让 ESTP-A 体验到“好玩、有效、有成就感”的职场状态。",
+            "groups": [
+              {
+                "group_title": "一线操盘与业务拓展",
+                "description": "直接和市场、客户、数据打交道的场景。",
+                "examples": [
+                  "销售 / 大客户经理 / BD 商务拓展",
+                  "渠道拓展、地推团队负责人",
+                  "门店 / 项目现场 / 活动现场的执行与负责人"
+                ]
+              },
+              {
+                "group_title": "高节奏、强现场感行业",
+                "description": "需要快速决策、实时应对的领域。",
+                "examples": [
+                  "互联网 / 电商运营一线岗位",
+                  "活动策划与现场执行、演出或赛事统筹",
+                  "金融交易、短线投资等高频实战类岗位（需注意风险管理）"
+                ]
+              },
+              {
+                "group_title": "创业与自我主导项目",
+                "description": "能自己做决定、自己承担结果的路径。",
+                "examples": [
+                  "小型创业项目 / 自雇型业务",
+                  "新业务试点、创新项目的一线负责人",
+                  "需要整合资源、快速打样的“0→1”尝试型项目"
+                ]
+              },
+              {
+                "group_title": "需要“敢冲敢上”的岗位",
+                "description": "对执行力、胆识和临场反应要求极高的角色（部分行业还涉及专业资质与安全风险）。",
+                "examples": [
+                  "部分线下运营、应急处理相关岗位（视具体行业而定）",
+                  "危机公关现场协调、舆情一线应对",
+                  "高强度 toB 谈判、签约与推进角色"
+                ]
+              }
+            ],
+            "outro": "判断一份工作是否适合你，可以问自己三个问题：这里有没有真实的挑战？有没有足够的行动空间？能不能很快看到成果和反馈？如果答案都是“是”，你大概率会在这里玩得不错。"
+          },
+          "sort_order": 70,
+          "is_enabled": true
+        },
+        {
+          "section_key": "career.upgrade_suggestions",
+          "render_variant": "bullets",
+          "body_md": "对 ESTP-A 来说，你的“下限”往往就已经比很多人高——只要有足够的空间，你就能在实战中打出不错的成绩。想要真正拉开差距，关键在于补上长期规划与系统性的一块。\n\n可以把下面几条当作你的职场进阶小提醒：",
+          "body_html": null,
+          "payload_json": {
+            "items": [
+              {
+                "title": "持续成绩 = 即时爆发 × 长期积累",
+                "body": "你已经很擅长即时爆发，不妨为自己设计一些“懒人版长期积累”：每次项目结束补一页复盘笔记、每周固定学习 1 小时专业知识，这些看似不刺激的动作，会在几年后拉开巨大差距。"
+              },
+              {
+                "title": "爽快直接 ≠ 不用顾及感受",
+                "body": "保持你的坦率，但在关键反馈前加一句“我会讲得直接一点，是为了我们下次更顺”，往往就能让别人更容易接住你的话，而不是只感受到锋利。"
+              },
+              {
+                "title": "风险可控 = 冲劲 × 刹车系统",
+                "body": "在做高风险决策前，刻意找一两个“谨慎型”同伴帮你看漏洞。不是为了浇你冷水，而是为你的冲劲加上一套刹车和安全带。"
+              },
+              {
+                "title": "自由度 = 结果交付 × 信任度",
+                "body": "你越能稳定交付结果，上级和合作者就越敢给你空间。与其和规则硬碰硬，不如用一次次漂亮的“执行成绩单”，换取下一次更大的自主权。"
+              }
+            ]
+          },
+          "sort_order": 80,
+          "is_enabled": true
+        },
+        {
+          "section_key": "growth.summary",
+          "render_variant": "rich_text",
+          "body_md": "对 ESTP-A 来说，成长并不是把自己变成一个“慢条斯理的人”，而是学会在保持速度与爽快的同时，增加一点前瞻性和深度，让每一场冒险都更有回报。\n\n这一章节，会从你的强项、短板，以及能量来源与消耗点，帮助你更清晰地看见：怎样的节奏，才是既过瘾又长期可持续的。",
+          "body_html": null,
+          "payload_json": null,
+          "sort_order": 90,
+          "is_enabled": true
+        },
+        {
+          "section_key": "growth.strengths",
+          "render_variant": "bullets",
+          "body_md": null,
+          "body_html": null,
+          "payload_json": {
+            "items": [
+              {
+                "title": "敢试、敢错、也敢改",
+                "body": "你不会被“万一失败了怎么办”锁住，相反，你更在意“如果成功了会很酷”。你愿意在现实中快速尝试，然后根据反馈不断微调，这是极具价值的成长能力。"
+              },
+              {
+                "title": "现实感强，不会迷失在幻想里",
+                "body": "你很少被空洞的愿景忽悠，更在意当下能不能落地、有没有实际收益。这让你在复杂局面中，依然能抓住“真正有用的部分”。"
+              },
+              {
+                "title": "能从挫折中迅速恢复",
+                "body": "跌一跤当然会痛，但你不太会长期沉在情绪里。你更倾向于拍拍灰尘、骂一句“下次我弄回来”，然后继续上场。"
+              },
+              {
+                "title": "学习偏“内化到动作”",
+                "body": "你擅长把零碎经验总结为身体记忆和临场判断：做多了，自然知道哪里有坑、哪里有捷径。这是一种难以被书面知识完全替代的成长方式。"
+              }
+            ]
+          },
+          "sort_order": 100,
+          "is_enabled": true
+        },
+        {
+          "section_key": "growth.weaknesses",
+          "render_variant": "bullets",
+          "body_md": null,
+          "body_html": null,
+          "payload_json": {
+            "items": [
+              {
+                "title": "容易忽略情绪层面的整理",
+                "body": "你习惯把事情当事情，很少刻意停下来处理情绪。短期看问题不大，但长期累积会让你在某个时刻突然觉得“怎么什么都不想管了”。"
+              },
+              {
+                "title": "对长期承诺耐心有限",
+                "body": "只要项目新鲜、挑战有趣，你会全力以赴；一旦变成日常维护和琐碎打磨，你的兴趣很可能会快速下滑。"
+              },
+              {
+                "title": "容易被即时刺激带走注意力",
+                "body": "新的机会、新的项目、新的邀约很容易吸引你，若缺乏筛选机制，你可能一下子接太多，反而难以在关键领域做深。"
+              },
+              {
+                "title": "自我反思多停留在“经验层面”",
+                "body": "你会从经历中总结“下次怎么玩得更好”，但较少深入思考：我真正想守护的底层价值是什么？我想成为怎样的人？"
+              }
+            ]
+          },
+          "sort_order": 110,
+          "is_enabled": true
+        },
+        {
+          "section_key": "growth.motivators",
+          "render_variant": "premium_teaser",
+          "body_md": "新鲜感、挑战、真实的竞争场和“立刻能看到变化”的反馈，会极大点燃你的积极性。给你一个足够大的空间、足够明确的目标，再加上一点点自由发挥的余地，你就能打得非常精彩。",
+          "body_html": null,
+          "payload_json": {
+            "teaser": "新鲜感、挑战、真实的竞争场和“立刻能看到变化”的反馈，会极大点燃你的积极性。给你一个足够大的空间、足够明确的目标，再加上一点点自由发挥的余地，你就能打得非常精彩。",
+            "is_premium": true
+          },
+          "sort_order": 120,
+          "is_enabled": true
+        },
+        {
+          "section_key": "growth.drainers",
+          "render_variant": "premium_teaser",
+          "body_md": "冗长而抽象的讨论、毫无作用的流程、看不到结果的付出，以及被过度限制的环境，会让你一点点失去斗志。若再叠加人际关系中的无效消耗，你很可能会突然选择“抽身而退”。",
+          "body_html": null,
+          "payload_json": {
+            "teaser": "冗长而抽象的讨论、毫无作用的流程、看不到结果的付出，以及被过度限制的环境，会让你一点点失去斗志。若再叠加人际关系中的无效消耗，你很可能会突然选择“抽身而退”。",
+            "is_premium": true
+          },
+          "sort_order": 130,
+          "is_enabled": true
+        },
+        {
+          "section_key": "relationships.summary",
+          "render_variant": "rich_text",
+          "body_md": "在人际和亲密关系中，你更像一个“带着大家一起玩剧情的人”：你喜欢一起去体验、去闯、去解决问题，而不是只靠聊天维系联系。\n\n你希望身边的人足够真实、爽快，最好是讲明白、做得快、别太矫情。如果能在一起做点什么、有共同目标，你会比单纯的寒暄更有安全感。",
+          "body_html": null,
+          "payload_json": null,
+          "sort_order": 140,
+          "is_enabled": true
+        },
+        {
+          "section_key": "relationships.strengths",
+          "render_variant": "bullets",
+          "body_md": null,
+          "body_html": null,
+          "payload_json": {
+            "items": [
+              {
+                "title": "相处自然，不做作",
+                "body": "你不会刻意营造“完美人设”，和你在一起的人，很快就能感受到你的真诚和直接，这种真实本身就是一种吸引力。"
+              },
+              {
+                "title": "愿意为在乎的人出手",
+                "body": "一旦你认定某个人“是自己人”，你会在关键时刻站出来，帮忙协调、出面说话、解决问题，用行动表达在意。"
+              },
+              {
+                "title": "擅长带动氛围",
+                "body": "无论是聚会、旅行还是团队活动，你都能让场子活起来，让大家从尴尬中解冻，重新进入更轻松的节奏。"
+              },
+              {
+                "title": "不喜欢拖泥带水",
+                "body": "你倾向于把该说的话说开，把该结束的关系尽快收尾，这让你少了很多“纠缠式消耗”，也帮助你把精力留给更重要的人。"
+              }
+            ]
+          },
+          "sort_order": 150,
+          "is_enabled": true
+        },
+        {
+          "section_key": "relationships.weaknesses",
+          "render_variant": "bullets",
+          "body_md": null,
+          "body_html": null,
+          "payload_json": {
+            "items": [
+              {
+                "title": "不擅长长时间的情绪深聊",
+                "body": "你更习惯用“要不要出去走走”“我们一起来解决这件事”来回应对方情绪，而不是长时间待在纯情绪对话里。这可能让一些人误以为“你不够关心”。"
+              },
+              {
+                "title": "可能忽视对方的细腻感受",
+                "body": "在你看来只是顺口一句玩笑或就事论事的吐槽，对敏感型的人来说，可能会留下比较重的情绪痕迹。"
+              },
+              {
+                "title": "容易把“当下的感觉”放在前面",
+                "body": "如果一段关系长期变得沉闷或充满束缚，你可能很难再提起动力去维护，转而把注意力投向别的刺激。"
+              },
+              {
+                "title": "对承诺的耐久度需要刻意维护",
+                "body": "你通常真心地答应，但如果后续缺乏提醒和共同参与，这些承诺很容易被新的事情盖过去，让对方感到“你好像不当一回事”。"
+              }
+            ]
+          },
+          "sort_order": 160,
+          "is_enabled": true
+        },
+        {
+          "section_key": "relationships.rel_advantages",
+          "render_variant": "premium_teaser",
+          "body_md": "在健康的关系里，你会成为那个“带大家去体验更大世界”的人——你让关系变得好玩、有故事、有行动，同时也能在关键时刻伸出手，把对方从困难里拉一把。",
+          "body_html": null,
+          "payload_json": {
+            "teaser": "在健康的关系里，你会成为那个“带大家去体验更大世界”的人——你让关系变得好玩、有故事、有行动，同时也能在关键时刻伸出手，把对方从困难里拉一把。",
+            "is_premium": true
+          },
+          "sort_order": 170,
+          "is_enabled": true
+        },
+        {
+          "section_key": "relationships.rel_risks",
+          "render_variant": "premium_teaser",
+          "body_md": "当你长期忽略深度沟通，只靠一起玩和一起忙来维系关系时，一些重要的误解和需求可能会悄悄积累。等到问题爆发，你可能会很惊讶：原来对方早就有那么多没说出口的不满。",
+          "body_html": null,
+          "payload_json": {
+            "teaser": "当你长期忽略深度沟通，只靠一起玩和一起忙来维系关系时，一些重要的误解和需求可能会悄悄积累。等到问题爆发，你可能会很惊讶：原来对方早就有那么多没说出口的不满。",
+            "is_premium": true
+          },
+          "sort_order": 180,
+          "is_enabled": true
+        }
+      ],
+      "seo_overrides": {
+        "seo_title": "ESTP-A 企业家型",
+        "seo_description": "你擅长在“现场”做决定：看到机会就想马上上手，遇到问题就想立刻拆解。你不喜欢空谈大道理，更享受在真实的环境里，亲自试、亲自闯、亲自赢下来。",
+        "canonical_url": null,
+        "og_title": "ESTP-A 现场操盘手",
+        "og_description": "你擅长在“现场”做决定：看到机会就想马上上手，遇到问题就想立刻拆解。你不喜欢空谈大道理，更享受在真实的环境里，亲自试、亲自闯、亲自赢下来。",
+        "og_image_url": null,
+        "twitter_title": "ESTP-A 现场操盘手",
+        "twitter_description": "你擅长在“现场”做决定：看到机会就想马上上手，遇到问题就想立刻拆解。你不喜欢空谈大道理，更享受在真实的环境里，亲自试、亲自闯、亲自赢下来。",
+        "twitter_image_url": null,
+        "robots": null,
+        "jsonld_overrides_json": null
+      }
+    },
+    {
+      "runtime_type_code": "ESTP-T",
+      "canonical_type_code": "ESTP",
+      "variant_code": "T",
+      "is_published": true,
+      "published_at": "2026-03-17T00:00:00Z",
+      "profile_overrides": {
+        "type_name": "企业家型",
+        "nickname": "即兴操盘手",
+        "rarity_text": "约 3–5%",
+        "keywords_json": [
+          "临场反应",
+          "行动力",
+          "冒险精神",
+          "现实主义",
+          "随机应变",
+          "直来直往"
+        ],
+        "hero_summary_md": "你像一枚随时待命的“现场引爆点”：风声一响就先动起来的人。别人还在犹豫，你已经开始试、开始改、开始往前冲。对你来说，世界是一个可以现场操盘的游乐场，真正的答案永远在行动里。",
+        "hero_summary_html": null
+      },
+      "section_overrides": [
+        {
+          "section_key": "letters_intro",
+          "render_variant": "letters_intro",
+          "body_md": null,
+          "body_html": null,
+          "payload_json": {
+            "headline": "外向 · 实感 · 思考 · 感知 · 动荡型｜在现场边试边赢的“即兴操盘手”",
+            "letters": [
+              {
+                "letter": "E",
+                "title": "外向（E）",
+                "description": "让你享受真实、鲜活的互动——谈判、博弈、当场拍板都是你的主场。你需要人、声音和现场感来激活大脑。"
+              },
+              {
+                "letter": "S",
+                "title": "实感（S）",
+                "description": "让你更信任肉眼可见的事实和数据，而不是抽象设想。你习惯从“现在发生了什么”出发，直接动手解决问题。"
+              },
+              {
+                "letter": "T",
+                "title": "思考（T）",
+                "description": "让你在关键判断上更看重逻辑、效益和结果。你会冷静评估“这样做值不值”“有没有更快的赢法”，而不是先考虑气氛。"
+              },
+              {
+                "letter": "P",
+                "title": "感知（P）",
+                "description": "让你不爱被流程和计划绑死，更偏好留出调整空间。你喜欢在变化中找机会，而不是按部就班走完固定剧本。"
+              },
+              {
+                "letter": "T",
+                "title": "动荡型（-T）",
+                "description": "让你在外表果断之下，也会在心里给自己打分。有时赢了也会复盘：“下次是不是还能押得更准一点？” 这种敏感既是你的精进动力，也是压力来源。"
+              }
+            ]
+          },
+          "sort_order": 10,
+          "is_enabled": true
+        },
+        {
+          "section_key": "overview",
+          "render_variant": "rich_text",
+          "body_md": "在费马心理的逻辑模型里，ESTP-T 常被视作“现场操盘型问题解决者”。你天生对即时反馈高度敏感，擅长在复杂、混乱、信息不全的场景中迅速做出判断，并通过行动逼出答案。\n\n对你来说，最舒服的状态是：信息在流动、机会在浮现，你有一定的自主权，可以根据现场变化当机立断。当环境充满拖延、空谈和无效会议时，你会明显感觉被浪费生命。\n\n你的人生追求，很少停留在“想象得多完美”，而是更在意“实测能跑多快、多稳”。你更相信：所有纸面方案，都要先丢进现实，才能知道值不值得。",
+          "body_html": null,
+          "payload_json": null,
+          "sort_order": 20,
+          "is_enabled": true
+        },
+        {
+          "section_key": "trait_overview",
+          "render_variant": "trait_dimension_grid",
+          "body_md": "建议与小程序中 5 条维度进度条搭配展示：外向 / 内向｜天马行空 / 求真务实｜情感细腻 / 理性思考｜运筹帷幄 / 随机应变｜情绪易波动 / 自信果断。",
+          "body_html": null,
+          "payload_json": {
+            "summary": "建议与小程序中 5 条维度进度条搭配展示：外向 / 内向｜天马行空 / 求真务实｜情感细腻 / 理性思考｜运筹帷幄 / 随机应变｜情绪易波动 / 自信果断。",
+            "dimensions": [
+              {
+                "id": "EI",
+                "name": "外向倾向",
+                "label": "外向倾向",
+                "axis_left": "外向",
+                "axis_right": "内向",
+                "summary": "明显偏外向",
+                "description": "你更像那个先行动、先发言、先试一试的人。热闹的现场、即时互动和充满变化的局面，会让你迅速进入状态；长期单线程独处，会让你感觉“整个人都钝了”。"
+              },
+              {
+                "id": "SN",
+                "name": "心智模式",
+                "label": "心智模式",
+                "axis_left": "天马行空",
+                "axis_right": "求真务实",
+                "summary": "明显偏“求真务实”",
+                "description": "你关注“此时此地”的真实信号：数据、表情、成交量、系统反馈。抽象理念如果无法落到行动，你很难提起劲。你会下意识问：“所以现在具体要怎么做？”"
+              },
+              {
+                "id": "TF",
+                "name": "情绪天性",
+                "label": "情绪天性",
+                "axis_left": "情感细腻",
+                "axis_right": "理性思考",
+                "summary": "略偏“理性思考”",
+                "description": "你做决定时更看重逻辑效率和成本收益，而不是每个人当下的情绪体验。你不是不在乎感受，只是更习惯先解决问题，再慢慢处理情绪。"
+              },
+              {
+                "id": "JP",
+                "name": "应对方式",
+                "label": "应对方式",
+                "axis_left": "运筹帷幄",
+                "axis_right": "随机应变",
+                "summary": "明显偏“随机应变”",
+                "description": "你不喜欢被复杂的计划框死，更享受“边走边调”的过程。越是预料之外的突发，你越容易兴奋起来，迅速抓住漏洞或机会，做出临场操作。"
+              },
+              {
+                "id": "AT",
+                "name": "身份特征",
+                "label": "身份特征",
+                "axis_left": "情绪易波动",
+                "axis_right": "自信果断",
+                "summary": "略偏“情绪易波动”",
+                "description": "表面上你看起来敢说敢做、刀法利落，但在一些关键输赢上，你会在心里反复回看自己的决定。偶尔的失误会让你短暂地否定自己，然后再通过下一次更漂亮的表现来“找回场子”。"
+              }
+            ]
+          },
+          "sort_order": 30,
+          "is_enabled": true
+        },
+        {
+          "section_key": "career.summary",
+          "render_variant": "rich_text",
+          "body_md": "你的职业满意度，很大程度取决于两点：有没有足够的真实挑战？你能不能在现场直接影响结果？\n\n那些节奏缓慢、规则僵硬、重流程轻行动的环境，会让你迅速失去耐心；而需要你“即时判断、快速执行、敢于拍板”的岗位，更能激活你的优势。\n\n当一份工作允许你频繁接触一线信息、直接参与交易或关键决策，并且有空间试错和调整，你就更容易保持高能量和高战斗力。",
+          "body_html": null,
+          "payload_json": null,
+          "sort_order": 40,
+          "is_enabled": true
+        },
+        {
+          "section_key": "career.advantages",
+          "render_variant": "bullets",
+          "body_md": null,
+          "body_html": null,
+          "payload_json": {
+            "items": [
+              {
+                "title": "临场反应极快",
+                "body": "在信息混乱、时间紧张的场景中，你反而能看得更清楚、动得更果断。你擅长根据眼前局势迅速调整策略。"
+              },
+              {
+                "title": "强执行 + 行动驱动",
+                "body": "你不爱空谈，拿到一个大致方向后，会立刻拆成动作，边做边改，以实际反馈为准不断迭代。"
+              },
+              {
+                "title": "敢于承担风险",
+                "body": "面对不确定性，你不会一味退缩，而是愿意在控制风险的前提下试一试。这让你在机会来临时，比别人更容易抢占先机。"
+              },
+              {
+                "title": "擅长读懂现场",
+                "body": "你对人群气氛、微小变化、数据波动都有快速感知力，能敏锐捕捉到“哪里不对劲”或“哪里可以放大”，并立刻做出应对。"
+              }
+            ]
+          },
+          "sort_order": 50,
+          "is_enabled": true
+        },
+        {
+          "section_key": "career.weaknesses",
+          "render_variant": "bullets",
+          "body_md": null,
+          "body_html": null,
+          "payload_json": {
+            "items": [
+              {
+                "title": "容易厌倦重复与细节",
+                "body": "一旦工作变成长期、可预见的重复流程，你的耐心会迅速下降，容易犯低级错误或频繁拖延。"
+              },
+              {
+                "title": "规划意识相对薄弱",
+                "body": "你更擅长“临场发挥”，但对长期规划、体系化建设容易缺乏耐心，可能导致项目后期收尾混乱或难以复制。"
+              },
+              {
+                "title": "冲动决策的风险",
+                "body": "在高压或高刺激场景下，你有时会为了快速出结果，而忽略潜在的长期影响或隐性成本。"
+              },
+              {
+                "title": "对僵化制度耐受度低",
+                "body": "当你感觉规则是在“拖慢大家的效率”时，很容易产生抵触情绪，甚至会在边缘尝试“打补丁式”的变通，带来组织内的摩擦。"
+              }
+            ]
+          },
+          "sort_order": 60,
+          "is_enabled": true
+        },
+        {
+          "section_key": "career.preferred_roles",
+          "render_variant": "preferred_role_list",
+          "body_md": null,
+          "body_html": null,
+          "payload_json": {
+            "intro": "下面这些并不是唯一适合 ESTP-T 的岗位，而是几类更容易让你感到“有意思、值得拼”的方向，可以当作职业探索的参考起点。",
+            "groups": [
+              {
+                "group_title": "交易与商务一线",
+                "description": "直接影响业绩和结果、需要当场判断的角色。",
+                "examples": [
+                  "销售 / 大客户经理 / 商务拓展",
+                  "投资顾问 / 经纪人 / 业务谈判相关岗位",
+                  "电商 / 实体生意的一线操盘手"
+                ]
+              },
+              {
+                "group_title": "运营与项目执行",
+                "description": "需要你频繁下场、解决实际问题的岗位。",
+                "examples": [
+                  "活动运营 / 营销执行 / 地推与线下项目负责人",
+                  "运营 / 供应链协调 / 店面或项目现场管理",
+                  "新业务试点、一线问题“救火队员”"
+                ]
+              },
+              {
+                "group_title": "高压与实战场景",
+                "description": "在压力下保持冷静，并迅速出手的职业领域。",
+                "examples": [
+                  "应急管理、危机处理、现场指挥相关岗位",
+                  "体育 / 教练 / 户外拓展等高强度现场职业",
+                  "需要迅速判断与行动的前线职能"
+                ]
+              },
+              {
+                "group_title": "自主度高的创业或个体项目",
+                "description": "允许你自己设定节奏、自己对结果负责的路径。",
+                "examples": [
+                  "小型创业 / 个体户 / 联合创始人",
+                  "自由职业的实战类顾问（如渠道拓展、地面运营）"
+                ]
+              }
+            ],
+            "outro": "对你来说，最关键的不是“岗位听起来多光鲜”，而是：这份工作能不能让你下场实战、用行动说话，并且在真实的输赢里不断升级自己的判断力。"
+          },
+          "sort_order": 70,
+          "is_enabled": true
+        },
+        {
+          "section_key": "career.upgrade_suggestions",
+          "render_variant": "bullets",
+          "body_md": "ESTP-T 的职业潜力非常高，只要能把“临场爆发力”与“基础盘的稳定性”结合起来，你会在很多领域走得又快又远。\n\n下面这几条，可以当作你在职场里的升级公式。",
+          "body_html": null,
+          "payload_json": {
+            "items": [
+              {
+                "title": "短期爆发 × 长期盘面 = 可持续战绩",
+                "body": "保留你擅长的快节奏推进，但刻意为自己补上“复盘”和“流程沉淀”。做完之后，问自己：这次经验中，有什么是可以固化为 SOP 的？"
+              },
+              {
+                "title": "冲动决策风险 = 情绪强度 ÷ 暂停能力",
+                "body": "在最想立刻拍板的那几秒里，给自己一条底线：至少多问两个问题——“最坏结果是什么？”“有没有低成本试错版本？” 这会显著降低翻车概率。"
+              },
+              {
+                "title": "个人品牌 = 解决问题的速度 × 兑现承诺的稳定度",
+                "body": "你已经有很强解决问题的速度，再补上“说到做到、不随意放鸽子”，你的口碑会在圈子里非常扎实。"
+              },
+              {
+                "title": "能量管理 = 高强度输出后主动充电",
+                "body": "高压冲刺之后，主动给自己安排“降速区”，而不是无缝衔接下一场战斗。身体和大脑的恢复，本身就是你的核心生产力。"
+              }
+            ]
+          },
+          "sort_order": 80,
+          "is_enabled": true
+        },
+        {
+          "section_key": "growth.summary",
+          "render_variant": "rich_text",
+          "body_md": "对 ESTP-T 来说，成长不是“把自己变成一个慢吞吞的规划型”，而是：在保留你锐利的直觉和行动力的前提下，让它们变得更稳、更可控。\n\n这一章节，会从你的强项、短板，以及能量的来源与消耗几个角度，帮你看清自己的进阶路径。",
+          "body_html": null,
+          "payload_json": null,
+          "sort_order": 90,
+          "is_enabled": true
+        },
+        {
+          "section_key": "growth.strengths",
+          "render_variant": "bullets",
+          "body_md": null,
+          "body_html": null,
+          "payload_json": {
+            "items": [
+              {
+                "title": "学得快，用得狠",
+                "body": "你对“用得上”的知识非常敏感，一旦发现某个技巧真的能提升效率或结果，你会迅速上手并用到极致。"
+              },
+              {
+                "title": "抗压与心理恢复力强",
+                "body": "即便经历短暂挫败，你也很难长期沉溺其中。你更倾向于“下一把再赢回来”，而不是躺在失败里反复翻找原因。"
+              },
+              {
+                "title": "对真实世界的极强感知",
+                "body": "你非常擅长观察市场反应、人群行为和环境变化，从中嗅到趋势的方向，比很多人更早一步做出调整。"
+              },
+              {
+                "title": "敢试、敢改、敢承认错误",
+                "body": "你不太怕承认“这次押错了”，只要能换来下一次更准确的判断，这在长期成长中反而是一种巨大优势。"
+              }
+            ]
+          },
+          "sort_order": 100,
+          "is_enabled": true
+        },
+        {
+          "section_key": "growth.weaknesses",
+          "render_variant": "bullets",
+          "body_md": null,
+          "body_html": null,
+          "payload_json": {
+            "items": [
+              {
+                "title": "三分钟热度倾向",
+                "body": "新鲜感一旦过去，你很容易失去兴趣，导致一些需要长期投入的事情，总是在 70%–80% 的阶段被放下。"
+              },
+              {
+                "title": "忽略长期后果",
+                "body": "在短期收益足够诱人时，你可能低估风险，或者没有为“万一出事”的情况留备选方案。"
+              },
+              {
+                "title": "拖延“无趣但必要”的任务",
+                "body": "报表、文档、流程梳理这类工作，对你来说既不刺激也没成就感，于是经常被拖到最后一刻甚至超时。"
+              },
+              {
+                "title": "情绪出口偏“行动化”",
+                "body": "在情绪上来的时候，你可能通过更激烈的行动（怼回去、当场拍板、立刻摊牌）来释放压力，而不是先把感受说清楚。"
+              }
+            ]
+          },
+          "sort_order": 110,
+          "is_enabled": true
+        },
+        {
+          "section_key": "growth.motivators",
+          "render_variant": "premium_teaser",
+          "body_md": "真实的挑战、清晰的胜负反馈、可见的利益回报、以及被信任的自主空间，都会让你感觉“值得我上场”。当你被当成关键一环来倚重时，你会展现出远超平均线的专注与战斗力。",
+          "body_html": null,
+          "payload_json": {
+            "teaser": "真实的挑战、清晰的胜负反馈、可见的利益回报、以及被信任的自主空间，都会让你感觉“值得我上场”。当你被当成关键一环来倚重时，你会展现出远超平均线的专注与战斗力。",
+            "is_premium": true
+          },
+          "sort_order": 120,
+          "is_enabled": true
+        },
+        {
+          "section_key": "growth.drainers",
+          "render_variant": "premium_teaser",
+          "body_md": "无穷无尽的低效会议、过度细碎又无意义的规则、长时间看不到结果的任务，会一点点磨掉你的热情。如果你发现自己频繁走神、刷手机、想“跑路”，很可能就是被这种消耗型环境拖住了。",
+          "body_html": null,
+          "payload_json": {
+            "teaser": "无穷无尽的低效会议、过度细碎又无意义的规则、长时间看不到结果的任务，会一点点磨掉你的热情。如果你发现自己频繁走神、刷手机、想“跑路”，很可能就是被这种消耗型环境拖住了。",
+            "is_premium": true
+          },
+          "sort_order": 130,
+          "is_enabled": true
+        },
+        {
+          "section_key": "relationships.summary",
+          "render_variant": "rich_text",
+          "body_md": "在人际世界里，你更像一个“不按剧本来但很真诚”的搭档。你愿意带别人体验新鲜事、直截了当地给出建议，也愿意在关键时刻站出来扛事。\n\n你在乎的，不是形式上的浪漫或声称的承诺，而是：对方是否够真实？是否能在关键时刻跟你并肩作战？在日常琐碎里，是否能给你足够的空间和信任？",
+          "body_html": null,
+          "payload_json": null,
+          "sort_order": 140,
+          "is_enabled": true
+        },
+        {
+          "section_key": "relationships.strengths",
+          "render_variant": "bullets",
+          "body_md": null,
+          "body_html": null,
+          "payload_json": {
+            "items": [
+              {
+                "title": "相处真实、不做作",
+                "body": "你不太会玩虚的，人前人后基本一致。跟你在一起的人，很容易感到轻松，因为不用时刻揣测你的真实想法。"
+              },
+              {
+                "title": "陪玩 + 陪战的一体化伙伴",
+                "body": "你愿意拉着对方一起尝试新体验，也愿意在对方面对困难时提供非常实际的帮助：出主意、拉资源、一起上。"
+              },
+              {
+                "title": "当下感很强",
+                "body": "你有能力把一段普通的相处变得生动有趣，让关系在当下就“活起来”，而不是只停留在计划和想象里。"
+              },
+              {
+                "title": "敢说真话",
+                "body": "你不会为了讨好而一味迎合，如果看见对方有明显的盲区或问题，你倾向于直接点出来，帮助对方面对现实。"
+              }
+            ]
+          },
+          "sort_order": 150,
+          "is_enabled": true
+        },
+        {
+          "section_key": "relationships.weaknesses",
+          "render_variant": "bullets",
+          "body_md": null,
+          "body_html": null,
+          "payload_json": {
+            "items": [
+              {
+                "title": "不擅长长篇情绪表达",
+                "body": "你更多通过行动来表达在乎，但在需要细腻沟通的时候，可能显得过于简短或“好像没那么认真对待”。"
+              },
+              {
+                "title": "容易忽略对方的安全感需求",
+                "body": "你习惯“走一步看一步”，但对方可能更想要一个方向感和基本承诺。当你过于强调自由和现场感时，对方会觉得不踏实。"
+              },
+              {
+                "title": "情绪上来时容易说狠话",
+                "body": "在争执中，你可能因为想“当场解决”，而说出一些过于锋利的话，事后才意识到对方其实很受伤。"
+              },
+              {
+                "title": "承诺与执行节奏不一致",
+                "body": "你真心想对关系好，但一旦生活节奏或工作压力变化，你可能会把一些约定或仪式感的安排往后排，久而久之让对方感觉被忽视。"
+              }
+            ]
+          },
+          "sort_order": 160,
+          "is_enabled": true
+        },
+        {
+          "section_key": "relationships.rel_advantages",
+          "render_variant": "premium_teaser",
+          "body_md": "在健康的关系中，你会是那个“带来新鲜感、也能在关键时刻扛事”的人。你能让对方体验到真实、好玩、充满生命力的生活，同时在对方需要时给出实打实的支持与行动。",
+          "body_html": null,
+          "payload_json": {
+            "teaser": "在健康的关系中，你会是那个“带来新鲜感、也能在关键时刻扛事”的人。你能让对方体验到真实、好玩、充满生命力的生活，同时在对方需要时给出实打实的支持与行动。",
+            "is_premium": true
+          },
+          "sort_order": 170,
+          "is_enabled": true
+        },
+        {
+          "section_key": "relationships.rel_risks",
+          "render_variant": "premium_teaser",
+          "body_md": "当你长期待在让你“动不了、玩不动、说不透”的关系里时，你会一点点抽离，甚至用各种外部刺激来转移注意力。识别这种早期信号，并正面谈清楚“我们要什么样的关系”，对 ESTP-T 来说尤为关键。",
+          "body_html": null,
+          "payload_json": {
+            "teaser": "当你长期待在让你“动不了、玩不动、说不透”的关系里时，你会一点点抽离，甚至用各种外部刺激来转移注意力。识别这种早期信号，并正面谈清楚“我们要什么样的关系”，对 ESTP-T 来说尤为关键。",
+            "is_premium": true
+          },
+          "sort_order": 180,
+          "is_enabled": true
+        }
+      ],
+      "seo_overrides": {
+        "seo_title": "ESTP-T 企业家型",
+        "seo_description": "你像一枚随时待命的“现场引爆点”：风声一响就先动起来的人。别人还在犹豫，你已经开始试、开始改、开始往前冲。对你来说，世界是一个可以现场操盘的游乐场，真正的答案永远在行动里。",
+        "canonical_url": null,
+        "og_title": "ESTP-T 即兴操盘手",
+        "og_description": "你像一枚随时待命的“现场引爆点”：风声一响就先动起来的人。别人还在犹豫，你已经开始试、开始改、开始往前冲。对你来说，世界是一个可以现场操盘的游乐场，真正的答案永远在行动里。",
+        "og_image_url": null,
+        "twitter_title": "ESTP-T 即兴操盘手",
+        "twitter_description": "你像一枚随时待命的“现场引爆点”：风声一响就先动起来的人。别人还在犹豫，你已经开始试、开始改、开始往前冲。对你来说，世界是一个可以现场操盘的游乐场，真正的答案永远在行动里。",
+        "twitter_image_url": null,
+        "robots": null,
+        "jsonld_overrides_json": null
+      }
+    },
+    {
+      "runtime_type_code": "INFJ-A",
+      "canonical_type_code": "INFJ",
+      "variant_code": "A",
+      "is_published": true,
+      "published_at": "2026-03-17T00:00:00Z",
+      "profile_overrides": {
+        "type_name": "提倡者型",
+        "nickname": "静默愿景者",
+        "rarity_text": "约 1–3%",
+        "keywords_json": [
+          "理想主义",
+          "洞察力",
+          "共情",
+          "内省",
+          "价值驱动",
+          "使命感"
+        ],
+        "hero_summary_md": "你像一束安静却执拗的光：不喧哗、不抢镜，却始终在心里守着一套标准，温柔而坚定地，把世界往你相信的方向推近一点。",
+        "hero_summary_html": null
+      },
+      "section_overrides": [
+        {
+          "section_key": "letters_intro",
+          "render_variant": "letters_intro",
+          "body_md": null,
+          "body_html": null,
+          "payload_json": {
+            "headline": "内向 · 直觉 · 情感 · 规划 · 自信型｜安静却意志坚定的“愿景守护者”",
+            "letters": [
+              {
+                "letter": "I",
+                "title": "内向（I）",
+                "description": "让你更习惯在安静的空间里思考与感受。你珍惜深度对话胜过浅层社交，真正的陪伴，是灵魂层面的“被理解”。"
+              },
+              {
+                "letter": "N",
+                "title": "直觉（N）",
+                "description": "让你习惯从表象看向本质，总在寻找背后的意义与模式。你敏锐地捕捉趋势与走向，很少只满足于“事情表面”。"
+              },
+              {
+                "letter": "F",
+                "title": "情感（F）",
+                "description": "让你在做决定时，会把“对与错”和“善与不善”分开来想。你在乎的不只是利益结果，更是这件事对人心与关系的影响。"
+              },
+              {
+                "letter": "J",
+                "title": "规划（J）",
+                "description": "让你希望把长期愿景拆成路径与步骤，而不是随波逐流。你习惯有节奏地推进生活与计划，不喜欢长期处于混乱与无序之中。"
+              },
+              {
+                "letter": "A",
+                "title": "自信型（-A）",
+                "description": "让你的内心相对稳定，对价值观与选择有自己的笃定。你会反思，但不容易被短期风评左右，更愿意按心中的“正确”慢慢前行。"
+              }
+            ]
+          },
+          "sort_order": 10,
+          "is_enabled": true
+        },
+        {
+          "section_key": "overview",
+          "render_variant": "rich_text",
+          "body_md": "在费马心理的逻辑模型里，INFJ-A 常被视作“安静但非常坚定的愿景守护者”。你外在温和内敛，内在却有一套清晰的价值坐标，很少随波逐流。\n\n你习惯先在心里搭建一幅“更理想的世界”的蓝图：人应该如何被对待、事应该如何被完成、关系应该如何更真诚。然后，你会在生活、工作、人际中，一点一点地朝那个蓝图靠近。\n\n对你来说，“有意义”远比“好看”“好玩”更重要。你宁愿慢一点、孤独一点，也不愿完全违背自己的原则。哪怕别人看不见，你也希望自己在持续做一个“让世界稍微好一点的人”。",
+          "body_html": null,
+          "payload_json": null,
+          "sort_order": 20,
+          "is_enabled": true
+        },
+        {
+          "section_key": "trait_overview",
+          "render_variant": "trait_dimension_grid",
+          "body_md": "建议与小程序中 5 条维度进度条搭配展示：外向 / 内向｜天马行空 / 求真务实｜情感细腻 / 理性思考｜运筹帷幄 / 随机应变｜情绪易波动 / 自信果断。",
+          "body_html": null,
+          "payload_json": {
+            "summary": "建议与小程序中 5 条维度进度条搭配展示：外向 / 内向｜天马行空 / 求真务实｜情感细腻 / 理性思考｜运筹帷幄 / 随机应变｜情绪易波动 / 自信果断。",
+            "dimensions": [
+              {
+                "id": "EI",
+                "name": "外向倾向",
+                "label": "外向倾向",
+                "axis_left": "外向",
+                "axis_right": "内向",
+                "summary": "明显偏内向",
+                "description": "你更偏爱一对一或小范围的深度交流，大型喧闹场合容易让你感到“人格耗电”。高质量的独处是你的充电方式，让你把零散的感受沉淀成有条理的洞见。"
+              },
+              {
+                "id": "SN",
+                "name": "心智模式",
+                "label": "心智模式",
+                "axis_left": "天马行空",
+                "axis_right": "求真务实",
+                "summary": "偏“天马行空”",
+                "description": "你很少只停留在“眼前发生了什么”，而是本能地追问：这意味着什么？会带来什么后果？你擅长从细节中抽取模式、从故事中提炼主题。"
+              },
+              {
+                "id": "TF",
+                "name": "情绪天性",
+                "label": "情绪天性",
+                "axis_left": "情感细腻",
+                "axis_right": "理性思考",
+                "summary": "偏“情感细腻”",
+                "description": "你对情绪变化极为敏感，能敏锐感知房间里的“气压变化”。你在乎过程是否被尊重、是否温柔，甚至比结果本身更在意“这一切对灵魂的影响”。"
+              },
+              {
+                "id": "JP",
+                "name": "应对方式",
+                "label": "应对方式",
+                "axis_left": "运筹帷幄",
+                "axis_right": "随机应变",
+                "summary": "偏“运筹帷幄”",
+                "description": "你习惯在行动前先把逻辑理清，希望整体方向和边界是明确的，再在其中留出弹性。比起临场救火，你更擅长做“长期设计”和“深度铺垫”。"
+              },
+              {
+                "id": "AT",
+                "name": "身份特征",
+                "label": "身份特征",
+                "axis_left": "情绪易波动",
+                "axis_right": "自信果断",
+                "summary": "略偏“自信果断”",
+                "description": "作为自信型 INFJ-A，你虽然敏感细腻，但总体情绪较为稳定。在重大决策上，你会更相信长期价值和直觉判断，不容易被外界噪音彻底击垮。"
+              }
+            ]
+          },
+          "sort_order": 30,
+          "is_enabled": true
+        },
+        {
+          "section_key": "career.summary",
+          "render_variant": "rich_text",
+          "body_md": "你的职业选择，往往围绕“意义感 + 深度影响”展开。你希望自己的工作，不只是完成任务，而是能实实在在地改善一些人的人生体验，或者让某个系统、某个行业变得更健康一点。\n\n过于功利、只讲结果不讲价值观的环境，会让你迅速失去动力；反之，只要你相信这件事“本身值得”，你就能持续投入很长时间，即使过程艰难也愿意咬牙坚持。\n\n对你来说，理想的职业不是舞台中央的喧闹，而是一个能让你安静思考、深度打磨、影响关键节点的角色——哪怕光芒不在台前，你仍然在背后改变走向。",
+          "body_html": null,
+          "payload_json": null,
+          "sort_order": 40,
+          "is_enabled": true
+        },
+        {
+          "section_key": "career.advantages",
+          "render_variant": "bullets",
+          "body_md": null,
+          "body_html": null,
+          "payload_json": {
+            "items": [
+              {
+                "title": "洞察复杂人性与系统",
+                "body": "你能同时看见个人的情绪、团队的氛围和制度的结构性问题，不会简单把问题归咎于某一个人，更擅长从整体角度找原因。"
+              },
+              {
+                "title": "价值驱动的长期主义",
+                "body": "一旦你认定某件事有意义，你会愿意在看不到短期回报的情况下持续耕耘，这让你在需要长期积累与沉淀的领域中具有独特优势。"
+              },
+              {
+                "title": "善于做深度、一对一影响",
+                "body": "你尤其擅长在一对一或小范围中发挥影响力，通过倾听、洞察与引导，让对方看见自己没有意识到的盲点和潜力。"
+              },
+              {
+                "title": "写作与抽象表达能力",
+                "body": "你往往拥有不错的文字或表达天赋，能把复杂的感受、抽象的理念，用结构清晰、富有画面感的方式呈现出来。"
+              }
+            ]
+          },
+          "sort_order": 50,
+          "is_enabled": true
+        },
+        {
+          "section_key": "career.weaknesses",
+          "render_variant": "bullets",
+          "body_md": null,
+          "body_html": null,
+          "payload_json": {
+            "items": [
+              {
+                "title": "不擅长自我推销",
+                "body": "你更希望“作品自己说话”，很少主动展示成绩或争取资源，这在强调可见度与话语权的职场文化里，容易被低估贡献。"
+              },
+              {
+                "title": "对价值观冲突极度敏感",
+                "body": "当公司目标与你的内心标准严重不符时，你会出现明显的抗拒甚至逃离冲动，而不是先尝试在系统内推动改变。"
+              },
+              {
+                "title": "容易独自扛下过多压力",
+                "body": "你不愿意给别人添麻烦，遇到问题更倾向于自己消化、自己解决，久而久之容易透支，甚至出现倦怠感。"
+              },
+              {
+                "title": "纠结于“完美方案”",
+                "body": "你习惯寻找最符合价值观、兼顾多方影响的做法，有时会因此迟迟不愿做出折衷决策，错过最佳行动窗口。"
+              }
+            ]
+          },
+          "sort_order": 60,
+          "is_enabled": true
+        },
+        {
+          "section_key": "career.preferred_roles",
+          "render_variant": "preferred_role_list",
+          "body_md": null,
+          "body_html": null,
+          "payload_json": {
+            "intro": "这些方向并不是 INFJ-A 的唯一选项，但都更有机会满足你对“深度、意义与长期影响”的追求，可以作为职业探索的参考起点：",
+            "groups": [
+              {
+                "group_title": "助人与心理成长",
+                "description": "直接支持个体内在成长与治愈的角色。",
+                "examples": [
+                  "心理咨询 / 心理治疗 / 心理教育",
+                  "教练、督导、人生发展顾问",
+                  "危机干预、心理健康倡导项目"
+                ]
+              },
+              {
+                "group_title": "教育与内容创作",
+                "description": "通过知识、理念与内容影响更多人的路径。",
+                "examples": [
+                  "教师、课程设计、教育产品研发",
+                  "写作者、策划编辑、知识类内容创作者",
+                  "教育创新项目 / 公益教育组织"
+                ]
+              },
+              {
+                "group_title": "社会价值与系统改变",
+                "description": "在更大系统层面推动价值变革的领域。",
+                "examples": [
+                  "公益组织、社会企业、NGO 项目负责人",
+                  "政策研究、社会研究、智库类岗位",
+                  "企业 ESG / 可持续发展相关角色"
+                ]
+              },
+              {
+                "group_title": "洞察与策略相关岗位",
+                "description": "需要深度思考与长线规划的角色，更少日常琐碎社交，更多“用洞见影响方向”。",
+                "examples": [
+                  "用户研究、战略分析、品牌与价值观相关策略岗位",
+                  "组织发展、人力资源中偏文化与人才发展方向的角色"
+                ]
+              }
+            ],
+            "outro": "真正适合你的工作，不一定荣耀耀眼，但一定会让你觉得：即便过程不易，我依然愿意为它投入时间与生命力。"
+          },
+          "sort_order": 70,
+          "is_enabled": true
+        },
+        {
+          "section_key": "career.upgrade_suggestions",
+          "render_variant": "bullets",
+          "body_md": "对 INFJ-A 来说，职业上的关键命题往往不是“能不能做好”，而是“我能不能一边做好事，一边把自己照顾好”。你拥有深刻洞察与强大责任感，但要学会让这些长处在一个健康的边界内发挥作用。\n\n可以把下面几条，当作你在职场中的小提示：",
+          "body_html": null,
+          "payload_json": {
+            "items": [
+              {
+                "title": "提示一：把“隐形贡献”说出来",
+                "body": "你做了很多别人看不见的思考、协调与情绪劳动。尝试在周会或复盘中，用事实与案例呈现这些工作，而不是默默等待被理解。"
+              },
+              {
+                "title": "提示二：把价值观冲突拆解成问题清单",
+                "body": "当你觉得“这个地方不对劲”时，可以先写下具体是哪些行为、规则或目标与你冲突，再思考：这些是可以沟通与优化的，还是底层不可调和的。如果是前者，尝试推动小范围改变；如果是后者，再考虑退出。"
+              },
+              {
+                "title": "提示三：给自己设定“可妥协区”",
+                "body": "不是所有细节都需要完美符合你心中的标准。可以区分：哪些是绝对原则，哪些只是偏好。把有限的精力，集中在你最在乎的 20% 关键战场。"
+              },
+              {
+                "title": "提示四：建立同频的支持系统",
+                "body": "尝试在职场内外找到少数价值观相近的人，定期交流与互相支持。对于 INFJ 来说，“有人懂我在坚持什么”，本身就是极大的续航来源。"
+              }
+            ]
+          },
+          "sort_order": 80,
+          "is_enabled": true
+        },
+        {
+          "section_key": "growth.summary",
+          "render_variant": "rich_text",
+          "body_md": "对 INFJ-A 来说，成长不是把自己磨成大众模板，而是在复杂世界里，找到一条“既不背叛自己，又能跟现实相处”的路。你既不愿放下理想，又清楚现实有它的重量。\n\n这一部分，会从你的强项与短板入手，帮你看清：哪些地方你已经做得很好，哪些地方只需要稍微松一点手。",
+          "body_html": null,
+          "payload_json": null,
+          "sort_order": 90,
+          "is_enabled": true
+        },
+        {
+          "section_key": "growth.strengths",
+          "render_variant": "bullets",
+          "body_md": null,
+          "body_html": null,
+          "payload_json": {
+            "items": [
+              {
+                "title": "拥有稳定而清晰的价值观",
+                "body": "你对“什么是值得”和“什么是正确”有自己一套判断体系，不轻易被潮流和情绪带走，这是你内在的定海神针。"
+              },
+              {
+                "title": "深度共情与洞察能力",
+                "body": "你能在不多言的情况下理解别人，捕捉到他们自己都说不清的感受，这让你在支持他人、做深度陪伴时有天然优势。"
+              },
+              {
+                "title": "长线规划与耐心",
+                "body": "你乐于为了一个重要目标做长期投入，不怕慢，只要方向对。这种长期主义，会在时间维度上拉开差距。"
+              },
+              {
+                "title": "自我反思与修正意愿",
+                "body": "即使你相对自信稳定，你依然愿意回看自己的言行，思考“有没有更温柔、更有效的方式”，这让你拥有持续进化的能力。"
+              }
+            ]
+          },
+          "sort_order": 100,
+          "is_enabled": true
+        },
+        {
+          "section_key": "growth.weaknesses",
+          "render_variant": "bullets",
+          "body_md": null,
+          "body_html": null,
+          "payload_json": {
+            "items": [
+              {
+                "title": "对自己要求过高",
+                "body": "你很少真正满意自己，很难单纯享受当下成果，总觉得“我还可以做得更好”，这会消耗你的心力与快乐感。"
+              },
+              {
+                "title": "容易陷入“理想 vs 现实”的拉扯",
+                "body": "当理想与现实冲突时，你既不愿完全妥协，又不愿彻底决裂，容易卡在中间，长期处于内耗状态。"
+              },
+              {
+                "title": "难以求助与示弱",
+                "body": "你习惯做那个理解别人、支持别人的人，却很少主动说“我也需要帮助”，这会让你在关键时刻缺乏外部支撑。"
+              },
+              {
+                "title": "容易把情绪内化为自我怀疑",
+                "body": "遇到挫折或关系问题时，你可能会优先责怪自己，而不是看到情境本身的不合理，久而久之影响自我价值感。"
+              }
+            ]
+          },
+          "sort_order": 110,
+          "is_enabled": true
+        },
+        {
+          "section_key": "growth.motivators",
+          "render_variant": "premium_teaser",
+          "body_md": "当你感到自己的坚持正在悄悄改变一些人、一部分系统，或带来哪怕一点点治愈时，你会由衷地觉得：原来我的存在是有意义的。来自少数重要他人的真诚认可，会比大范围的表面掌声更能打动你。",
+          "body_html": null,
+          "payload_json": {
+            "teaser": "当你感到自己的坚持正在悄悄改变一些人、一部分系统，或带来哪怕一点点治愈时，你会由衷地觉得：原来我的存在是有意义的。来自少数重要他人的真诚认可，会比大范围的表面掌声更能打动你。",
+            "is_premium": true
+          },
+          "sort_order": 120,
+          "is_enabled": true
+        },
+        {
+          "section_key": "growth.drainers",
+          "render_variant": "premium_teaser",
+          "body_md": "价值观被反复踩踏、努力得不到回应、长期被当作“情绪垃圾桶”，或者不得不违背本心去做事，这些都会让你迅速枯竭。若你开始频繁失眠、迟迟不愿起床，很可能是内在已经按下了“我不想这样活”的警报。",
+          "body_html": null,
+          "payload_json": {
+            "teaser": "价值观被反复踩踏、努力得不到回应、长期被当作“情绪垃圾桶”，或者不得不违背本心去做事，这些都会让你迅速枯竭。若你开始频繁失眠、迟迟不愿起床，很可能是内在已经按下了“我不想这样活”的警报。",
+            "is_premium": true
+          },
+          "sort_order": 130,
+          "is_enabled": true
+        },
+        {
+          "section_key": "relationships.summary",
+          "render_variant": "rich_text",
+          "body_md": "在关系世界里，你更像一位安静的守护者：不一定最会活跃气氛，但总在关键时刻出现，理解、接住、陪伴。\n\n你不追求关系数量，而是极度重视质量。你更在意的是：我们能不能说真话？我们是否真正尊重彼此？这段关系有没有让我们都成为更好的自己？",
+          "body_html": null,
+          "payload_json": null,
+          "sort_order": 140,
+          "is_enabled": true
+        },
+        {
+          "section_key": "relationships.strengths",
+          "render_variant": "bullets",
+          "body_md": null,
+          "body_html": null,
+          "payload_json": {
+            "items": [
+              {
+                "title": "深度共情与理解力",
+                "body": "你能把自己放到对方的位置上感受世界，让对方在你这里感到“终于有人懂我了”，这是极其珍贵的体验。"
+              },
+              {
+                "title": "忠诚与长期投入",
+                "body": "一旦你认定某段关系有价值，你会愿意跨越距离、时间和困难，长期陪伴与守护，而不是轻易放弃。"
+              },
+              {
+                "title": "温柔但有原则",
+                "body": "你待人真诚温和，却不是一味迎合。当触及底线时，你会安静但坚定地表达立场，维护自己与对方的边界。"
+              },
+              {
+                "title": "擅长做“灵魂层面”的对话",
+                "body": "你不满足于只聊八卦与日常，而是自然地把话题带向价值观、创伤、梦想等更深层的议题，这让与你亲近的人经常在与你的谈话中获得启发与疗愈。"
+              }
+            ]
+          },
+          "sort_order": 150,
+          "is_enabled": true
+        },
+        {
+          "section_key": "relationships.weaknesses",
+          "render_variant": "bullets",
+          "body_md": null,
+          "body_html": null,
+          "payload_json": {
+            "items": [
+              {
+                "title": "不愿轻易表达不满",
+                "body": "你害怕伤害关系，也不喜欢正面冲突，于是很多不满会被你压在心里，直到有一天情绪累积到临界点才爆发。"
+              },
+              {
+                "title": "容易对关系有理想化期待",
+                "body": "你心里或许有一套关于“理想伴侣 / 理想朋友”的蓝图，当现实与之差距过大时，你可能会瞬间抽离，或者深深失望。"
+              },
+              {
+                "title": "习惯自己消化情绪",
+                "body": "你会先在心里把情绪反复拆解、分析清楚，才考虑说给别人听。这让很多人觉得你“什么都能自己搞定”，但也让你错过了被看见的机会。"
+              },
+              {
+                "title": "在不对等关系里待太久",
+                "body": "即便感觉被忽视或被消耗，你仍可能因为“对方也不容易”而原谅很多次。久而久之，你会在关系里逐渐失去活力与自尊感。"
+              }
+            ]
+          },
+          "sort_order": 160,
+          "is_enabled": true
+        },
+        {
+          "section_key": "relationships.rel_advantages",
+          "render_variant": "premium_teaser",
+          "body_md": "在健康的关系中，你会成为他人极其重要的“心灵据点”：他们可以在你这里卸下面具、说真话、面对自己的脆弱，而你会用理解与诚实陪他们一起穿过困难。这样的深度链接，也会反过来滋养你对世界的信任感。",
+          "body_html": null,
+          "payload_json": {
+            "teaser": "在健康的关系中，你会成为他人极其重要的“心灵据点”：他们可以在你这里卸下面具、说真话、面对自己的脆弱，而你会用理解与诚实陪他们一起穿过困难。这样的深度链接，也会反过来滋养你对世界的信任感。",
+            "is_premium": true
+          },
+          "sort_order": 170,
+          "is_enabled": true
+        },
+        {
+          "section_key": "relationships.rel_risks",
+          "render_variant": "premium_teaser",
+          "body_md": "如果一段关系长期只消耗而不滋养你——你总是在理解、原谅、让步，对方却很少真正为你的感受负责——这会悄悄磨损你的自我价值感。对 INFJ-A 来说，学会及时识别“伪装成亲密的消耗关系”，并适当地后退，是非常关键的课题。",
+          "body_html": null,
+          "payload_json": {
+            "teaser": "如果一段关系长期只消耗而不滋养你——你总是在理解、原谅、让步，对方却很少真正为你的感受负责——这会悄悄磨损你的自我价值感。对 INFJ-A 来说，学会及时识别“伪装成亲密的消耗关系”，并适当地后退，是非常关键的课题。",
+            "is_premium": true
+          },
+          "sort_order": 180,
+          "is_enabled": true
+        }
+      ],
+      "seo_overrides": {
+        "seo_title": "INFJ-A 提倡者型",
+        "seo_description": "你像一束安静却执拗的光：不喧哗、不抢镜，却始终在心里守着一套标准，温柔而坚定地，把世界往你相信的方向推近一点。",
+        "canonical_url": null,
+        "og_title": "INFJ-A 静默愿景者",
+        "og_description": "你像一束安静却执拗的光：不喧哗、不抢镜，却始终在心里守着一套标准，温柔而坚定地，把世界往你相信的方向推近一点。",
+        "og_image_url": null,
+        "twitter_title": "INFJ-A 静默愿景者",
+        "twitter_description": "你像一束安静却执拗的光：不喧哗、不抢镜，却始终在心里守着一套标准，温柔而坚定地，把世界往你相信的方向推近一点。",
+        "twitter_image_url": null,
+        "robots": null,
+        "jsonld_overrides_json": null
+      }
+    },
+    {
+      "runtime_type_code": "INFJ-T",
+      "canonical_type_code": "INFJ",
+      "variant_code": "T",
+      "is_published": true,
+      "published_at": "2026-03-17T00:00:00Z",
+      "profile_overrides": {
+        "type_name": "提倡者型",
+        "nickname": "静默理想家",
+        "rarity_text": "约 1–3%",
+        "keywords_json": [
+          "洞察力",
+          "理想主义",
+          "价值观驱动",
+          "共情",
+          "内在深度",
+          "长期主义"
+        ],
+        "hero_summary_md": "你像一束安静却坚定的光：不喜欢站在最显眼的地方，却总在悄悄照亮方向。你相信每个人都带着独特的使命而来，你也认真对待自己这一生的答案。",
+        "hero_summary_html": null
+      },
+      "section_overrides": [
+        {
+          "section_key": "letters_intro",
+          "render_variant": "letters_intro",
+          "body_md": null,
+          "body_html": null,
+          "payload_json": {
+            "headline": "内向 · 直觉 · 情感 · 规划 · 动荡型｜安静外表下，藏着深刻洞察与强大信念的“静默理想家”",
+            "letters": [
+              {
+                "letter": "I",
+                "title": "内向（I）",
+                "description": "让你更习惯从安静和独处中恢复能量。你喜欢与少数深度连接的人长谈，而不是在大型社交场合来回周旋。"
+              },
+              {
+                "letter": "N",
+                "title": "直觉（N）",
+                "description": "让你总在寻找表象背后的“意义”和“模式”。你会下意识思考：这件事会走向哪里？它和更大的图景有什么连接？"
+              },
+              {
+                "letter": "F",
+                "title": "情感（F）",
+                "description": "使你在做决定时，会把价值观与他人感受纳入考量。对你来说，什么是“对的”，往往不止是结果，更包括是否符合内心良知。"
+              },
+              {
+                "letter": "J",
+                "title": "规划（J）",
+                "description": "让你偏好有秩序和可预期的生活。你愿意为重要目标制定路线图，而不是随波逐流，任由生活把你推着走。"
+              },
+              {
+                "letter": "T",
+                "title": "动荡型（-T）",
+                "description": "让你对自己要求很高，会频繁自我审视：“我是不是可以再真诚一点、再做得更好一点？” 这是你持续成长的动力，也是压力来源。"
+              }
+            ]
+          },
+          "sort_order": 10,
+          "is_enabled": true
+        },
+        {
+          "section_key": "overview",
+          "render_variant": "rich_text",
+          "body_md": "在费马心理的逻辑模型里，INFJ-T 常被视作“安静却有强烈使命感的理想主义者”。你外表温和克制，内心却有一整套坚定而清晰的价值体系。\n\n你擅长从纷杂的信息中抽取出本质，看见趋势、意图和深层动机。比起跟随喧闹的潮流，你更在意：这件事是否真的有意义？是否值得用生命的一部分去交换？\n\n对你来说，最理想的状态是：在不违背自我良知的前提下，用稳定而持续的方式，为人、为世界带来一些真正的改善——哪怕是细小但真实的改变。",
+          "body_html": null,
+          "payload_json": null,
+          "sort_order": 20,
+          "is_enabled": true
+        },
+        {
+          "section_key": "trait_overview",
+          "render_variant": "trait_dimension_grid",
+          "body_md": "建议与小程序中 5 条维度进度条搭配展示：外向 / 内向｜天马行空 / 求真务实｜情感细腻 / 理性思考｜运筹帷幄 / 随机应变｜情绪易波动 / 自信果断。",
+          "body_html": null,
+          "payload_json": {
+            "summary": "建议与小程序中 5 条维度进度条搭配展示：外向 / 内向｜天马行空 / 求真务实｜情感细腻 / 理性思考｜运筹帷幄 / 随机应变｜情绪易波动 / 自信果断。",
+            "dimensions": [
+              {
+                "id": "EI",
+                "name": "外向倾向",
+                "label": "外向倾向",
+                "axis_left": "外向",
+                "axis_right": "内向",
+                "summary": "明显偏内向",
+                "description": "你更习惯在安静的空间里整理思绪，与其在陌生人面前寒暄，不如和熟悉的人进行一场深度对话。社交之后，你通常需要独处来“充电”。"
+              },
+              {
+                "id": "SN",
+                "name": "心智模式",
+                "label": "心智模式",
+                "axis_left": "天马行空",
+                "axis_right": "求真务实",
+                "summary": "偏“天马行空”",
+                "description": "你善于从抽象层面思考问题：模式、趋势、隐喻、象征……对你来说都很自然。细节对你来说重要，但如果缺乏整体意义，你很难真正投入。"
+              },
+              {
+                "id": "TF",
+                "name": "情绪天性",
+                "label": "情绪天性",
+                "axis_left": "情感细腻",
+                "axis_right": "理性思考",
+                "summary": "偏“情感细腻”",
+                "description": "你对情绪极为敏感，尤其是那些没有说出口的部分。你在意他人是否被尊重、被善待，也在意自己是否活得忠于内心，而不仅是“看起来不错”。"
+              },
+              {
+                "id": "JP",
+                "name": "应对方式",
+                "label": "应对方式",
+                "axis_left": "运筹帷幄",
+                "axis_right": "随机应变",
+                "summary": "偏“运筹帷幄”",
+                "description": "你喜欢为重要的事提前思考和布局。面对关键抉择，你更倾向于反复咀嚼、谨慎权衡，而不是即兴决策。你希望自己每一步都踩在“值得的地方”。"
+              },
+              {
+                "id": "AT",
+                "name": "身份特征",
+                "label": "身份特征",
+                "axis_left": "情绪易波动",
+                "axis_right": "自信果断",
+                "summary": "略偏“情绪易波动”",
+                "description": "动荡型的你，对自己的内在状态非常敏感。你会反复回放某些对话，思考自己有没有哪里不够体贴、不够真诚。这让你在人际上格外细腻，却也容易在内心世界里消耗过多能量。"
+              }
+            ]
+          },
+          "sort_order": 30,
+          "is_enabled": true
+        },
+        {
+          "section_key": "career.summary",
+          "render_variant": "rich_text",
+          "body_md": "在职业选择上，你往往不会只看“薪水”和“头衔”，而是更在意：这份工作是否和你的价值观匹配，是否真的在创造一些有意义的东西。\n\n长期做与自己信念严重不符的工作，会让你迅速枯竭；相反，只要你相信这件事本身值得，你可以为了一个长期目标默默努力很多年。\n\n你适合集中精力在少数重要项目上，发挥自己的洞察力、判断力和长期规划能力，而不是被大量琐碎、毫无意义的事务绑架。",
+          "body_html": null,
+          "payload_json": null,
+          "sort_order": 40,
+          "is_enabled": true
+        },
+        {
+          "section_key": "career.advantages",
+          "render_variant": "bullets",
+          "body_md": null,
+          "body_html": null,
+          "payload_json": {
+            "items": [
+              {
+                "title": "洞察人心与趋势",
+                "body": "你善于从零碎信息中抽取出模式和方向，看见人背后的动机与需求，看见项目或组织未来可能的走向。"
+              },
+              {
+                "title": "价值观驱动的长期主义",
+                "body": "当一份工作与你的价值观高度一致时，你会展现惊人的投入与韧性，愿意为长期成效打基础，而不是追逐短期噱头。"
+              },
+              {
+                "title": "安静但有力量的领导力",
+                "body": "你不一定喜欢高调指挥，但能通过清晰的理念、稳定的存在感和对个体的真诚关怀，影响身边人做出更成熟的选择。"
+              },
+              {
+                "title": "深度思考与系统性视角",
+                "body": "你习惯从系统层面看问题：结构是否合理？流程是否尊重人性？这让你在策略制定、产品定位、组织发展等领域具有独特优势。"
+              }
+            ]
+          },
+          "sort_order": 50,
+          "is_enabled": true
+        },
+        {
+          "section_key": "career.weaknesses",
+          "render_variant": "bullets",
+          "body_md": null,
+          "body_html": null,
+          "payload_json": {
+            "items": [
+              {
+                "title": "讨厌表面功夫和政治游戏",
+                "body": "你很难在充满权谋、拉帮结派和表演型文化的环境中久待，这会严重消耗你的能量和安全感。"
+              },
+              {
+                "title": "行动节奏偏慢但追求“对”",
+                "body": "在尚未想清楚之前，你不愿贸然出手。这让你看起来有时偏慢，但更多时候是因为你在默默打磨一个更稳妥的方案。"
+              },
+              {
+                "title": "不擅长自我推销",
+                "body": "你更习惯让成果自己说话，而不是主动“刷存在感”。在强调曝光和话语权的职场环境里，你的贡献有时容易被低估。"
+              },
+              {
+                "title": "对失望和价值冲突很敏感",
+                "body": "当你发现团队或上级的真实动机与自己信任的叙事完全不符时，你会产生强烈的幻灭感，甚至迅速萌生离开的冲动。"
+              }
+            ]
+          },
+          "sort_order": 60,
+          "is_enabled": true
+        },
+        {
+          "section_key": "career.preferred_roles",
+          "render_variant": "preferred_role_list",
+          "body_md": null,
+          "body_html": null,
+          "payload_json": {
+            "intro": "下面这些方向并不是“标准答案”，而是更容易让 INFJ-T 感到“值得投入”的领域，你可以把它们当作探索的参考维度。",
+            "groups": [
+              {
+                "group_title": "助人与疗愈相关",
+                "description": "在深度陪伴与理解他人的过程中，提供真正的改变与支持。",
+                "examples": [
+                  "心理咨询、心理治疗、教练、督导相关岗位",
+                  "学校辅导员、升学 / 职业规划顾问",
+                  "危机干预、心理健康项目负责人"
+                ]
+              },
+              {
+                "group_title": "教育与内容创作",
+                "description": "用知识、故事和体系化表达，去启发、教育和影响他人。",
+                "examples": [
+                  "教师、课程设计者、教育产品策划",
+                  "作者、专栏写手、内容策划、纪录片 / 人文类创作者",
+                  "知识型社区运营、深度内容编辑"
+                ]
+              },
+              {
+                "group_title": "社会价值与公益方向",
+                "description": "把理想主义落在实际项目上，推动具体领域的改善。",
+                "examples": [
+                  "公益组织 / NGO / 社会企业项目负责人",
+                  "公共政策研究、社会创新项目、社区发展",
+                  "弱势群体支持项目的筹划与管理"
+                ]
+              },
+              {
+                "group_title": "价值导向的组织与策略角色",
+                "description": "在以长期价值为导向的组织里，从结构和战略层面，帮助团队走得更稳、更远。",
+                "examples": [
+                  "品牌 / 使命型企业的策略岗位",
+                  "以用户价值与长期口碑为核心的产品策划",
+                  "关注组织文化与人本体验的 HR / 组织发展"
+                ]
+              }
+            ],
+            "outro": "对 INFJ-T 来说，更关键的往往不是“具体职位名称”，而是：这份工作是否让你感到自己在参与一件有价值的事，并且能保留你的敏感、共情与判断力，而不是被迫关闭它们。"
+          },
+          "sort_order": 70,
+          "is_enabled": true
+        },
+        {
+          "section_key": "career.upgrade_suggestions",
+          "render_variant": "bullets",
+          "body_md": "你的能力往往不在“会不会做”，而在于“愿不愿意站出来”。当你敢于把自己的洞察说出来、把价值观摆在桌面上，你的影响力会远超自己的想象。\n\n下面这些“小公式”，可以帮助你在职场中一边保护自己，一边放大自己的独特优势。",
+          "body_html": null,
+          "payload_json": {
+            "items": [
+              {
+                "title": "表达力 = 洞察力 × 勇气",
+                "body": "你看到的东西通常比别人多一步，但如果你不说出来，这些洞察就只能停留在你的内心世界。可以从“小范围、可信任的人”开始练习表达，逐步扩展影响圈。"
+              },
+              {
+                "title": "边界感 = 价值观清晰度 × 拒绝能力",
+                "body": "不需要参与每一个和自己价值冲突的项目。允许自己对不认同的事情说“不”，这并不是软弱，而是在为真正重要的事情留出空间。"
+              },
+              {
+                "title": "成就感 = 对齐度 × 可见度",
+                "body": "当工作内容与你的信念高度一致时，再配合适度展示成果，你不仅会更有动力，也更容易获得外界的认可与支持。可以为自己设定固定频率的成果汇报节奏。"
+              },
+              {
+                "title": "长期可持续 = 深度投入 × 节奏管理",
+                "body": "你很容易在认同的事情上“一口气用力过猛”。为自己设置可持续的节奏——比如每周固定的休息仪式、定期的情绪梳理——能让你走得更长远。"
+              }
+            ]
+          },
+          "sort_order": 80,
+          "is_enabled": true
+        },
+        {
+          "section_key": "growth.summary",
+          "render_variant": "rich_text",
+          "body_md": "对 INFJ-T 来说，成长不只是“变得更强”，更是“在复杂世界中，仍然保有自己的善意与清明”。\n\n你的一大课题，是在“照顾他人”和“忠于自己”之间找到平衡，在理想主义与现实世界的间隙里，为自己搭建一个可持续的内在系统。",
+          "body_html": null,
+          "payload_json": null,
+          "sort_order": 90,
+          "is_enabled": true
+        },
+        {
+          "section_key": "growth.strengths",
+          "render_variant": "bullets",
+          "body_md": null,
+          "body_html": null,
+          "payload_json": {
+            "items": [
+              {
+                "title": "内在驱动的自我精进",
+                "body": "你不太需要外力鞭策，就会主动思考如何让自己变得更好——更成熟、更稳重、更有担当。"
+              },
+              {
+                "title": "深度反思能力",
+                "body": "你会认真回看自己的选择、情绪和动机，愿意承认自己的盲点，并尝试在下一次做出更符合初心的决定。"
+              },
+              {
+                "title": "对意义的敏锐嗅觉",
+                "body": "你对“什么值得”“什么不值得”有非常敏锐的直觉，这使你在拒绝无意义消耗、选择长期价值时有天然优势。"
+              },
+              {
+                "title": "情绪与精神世界的丰富度",
+                "body": "你拥有广阔而细腻的内心世界，能对艺术、文字、哲思产生深刻共鸣，这为你的创造力和共情力提供了源源不断的燃料。"
+              }
+            ]
+          },
+          "sort_order": 100,
+          "is_enabled": true
+        },
+        {
+          "section_key": "growth.weaknesses",
+          "render_variant": "bullets",
+          "body_md": null,
+          "body_html": null,
+          "payload_json": {
+            "items": [
+              {
+                "title": "容易陷入“理想与现实的撕扯”",
+                "body": "当现实与内心愿景差距过大时，你可能会经历长时间的沮丧和怀疑，甚至暂停行动，陷入自我质疑。"
+              },
+              {
+                "title": "难以向外求助",
+                "body": "你习惯自己消化情绪，不想增加别人负担。久而久之，你会在看不见的地方悄悄累积压力。"
+              },
+              {
+                "title": "对冲突与粗暴环境高度敏感",
+                "body": "嘈杂、攻击性强、缺乏尊重的环境，会让你迅速想要抽离，哪怕从理性上你知道这“只是工作”。"
+              },
+              {
+                "title": "容易把问题都归因于自己",
+                "body": "当事情不顺利时，你可能会先从自己身上找原因，而忽略了外部条件和他人责任，这会加重你的内疚感。"
+              }
+            ]
+          },
+          "sort_order": 110,
+          "is_enabled": true
+        },
+        {
+          "section_key": "growth.motivators",
+          "render_variant": "premium_teaser",
+          "body_md": "当你感觉自己正在为真实的人带来真实的改变，并且这一切与自己的价值观高度一致时，你会感到无比踏实与满足——这比任何外在奖赏都更能点燃你。",
+          "body_html": null,
+          "payload_json": {
+            "teaser": "当你感觉自己正在为真实的人带来真实的改变，并且这一切与自己的价值观高度一致时，你会感到无比踏实与满足——这比任何外在奖赏都更能点燃你。",
+            "is_premium": true
+          },
+          "sort_order": 120,
+          "is_enabled": true
+        },
+        {
+          "section_key": "growth.drainers",
+          "render_variant": "premium_teaser",
+          "body_md": "需要不断妥协底线的环境、空洞的忙碌、以及长期得不到理解的付出，都会悄悄掏空你的能量。如果你开始频繁怀疑“一切还有意义吗”，通常就是需要按下暂停键的时候。",
+          "body_html": null,
+          "payload_json": {
+            "teaser": "需要不断妥协底线的环境、空洞的忙碌、以及长期得不到理解的付出，都会悄悄掏空你的能量。如果你开始频繁怀疑“一切还有意义吗”，通常就是需要按下暂停键的时候。",
+            "is_premium": true
+          },
+          "sort_order": 130,
+          "is_enabled": true
+        },
+        {
+          "section_key": "relationships.summary",
+          "render_variant": "rich_text",
+          "body_md": "在人际与亲密关系中，你更在意“深度”而不是“数量”。你宁愿维系少数真正理解你、频率相近的人，也不愿在一堆浅层社交里消耗自己。\n\n你希望关系可以成为一个安全、真诚、可以谈论理想与恐惧的空间，而不是彼此演戏、互相迎合的舞台。",
+          "body_html": null,
+          "payload_json": null,
+          "sort_order": 140,
+          "is_enabled": true
+        },
+        {
+          "section_key": "relationships.strengths",
+          "render_variant": "bullets",
+          "body_md": null,
+          "body_html": null,
+          "payload_json": {
+            "items": [
+              {
+                "title": "认真对待每一段重要关系",
+                "body": "你不会轻易把任何人贴上“泛泛之交”的标签，一旦认定对方是重要的人，你会真心投入时间和情感。"
+              },
+              {
+                "title": "深度理解与共情",
+                "body": "你擅长安静地倾听、细致地提问，让对方在你这里感到被真正看见，而不是被随意评判。"
+              },
+              {
+                "title": "愿意一起成长",
+                "body": "在你眼里，好的关系不只是舒服，还应该带来某种程度的共同成长。你愿意和对方一起面对问题、一起修正方向。"
+              },
+              {
+                "title": "有边界感的温柔（在成熟之后）",
+                "body": "随着成长，你会逐渐学会在关心他人和保护自己之间找到平衡，用更加稳健的方式去爱和陪伴。"
+              }
+            ]
+          },
+          "sort_order": 150,
+          "is_enabled": true
+        },
+        {
+          "section_key": "relationships.weaknesses",
+          "render_variant": "bullets",
+          "body_md": null,
+          "body_html": null,
+          "payload_json": {
+            "items": [
+              {
+                "title": "不容易完全信任",
+                "body": "你需要很长的时间，才会真正放下防备。若早期信任被辜负，你可能会对关系整体产生怀疑。"
+              },
+              {
+                "title": "习惯自己消化情绪",
+                "body": "你不想把负担丢给别人，于是总是选择“没事，我能自己消化”，却忘了让对方参与进来，也是关系的一部分。"
+              },
+              {
+                "title": "高期待带来的失落",
+                "body": "你容易对亲密对象抱有很高的道德和成长期待，当对方反复逃避问题或停在原地时，你会感到深深的失望。"
+              },
+              {
+                "title": "不善于表达不满",
+                "body": "为了维持表面和谐，你可能会把不满和伤害藏在心里，直到某个临界点突然爆发，让对方措手不及。"
+              }
+            ]
+          },
+          "sort_order": 160,
+          "is_enabled": true
+        },
+        {
+          "section_key": "relationships.rel_advantages",
+          "render_variant": "premium_teaser",
+          "body_md": "在健康的关系里，你会成为对方极其重要的情感基地和精神伙伴——既能提供安静的陪伴，也能在关键节点给出深刻而温柔的提醒。",
+          "body_html": null,
+          "payload_json": {
+            "teaser": "在健康的关系里，你会成为对方极其重要的情感基地和精神伙伴——既能提供安静的陪伴，也能在关键节点给出深刻而温柔的提醒。",
+            "is_premium": true
+          },
+          "sort_order": 170,
+          "is_enabled": true
+        },
+        {
+          "section_key": "relationships.rel_risks",
+          "render_variant": "premium_teaser",
+          "body_md": "当你长期处在“我懂大家，但没有人真正懂我”的状态中时，你会一点点远离关系中心，把自己锁进内心世界。学会更早表达需求、更早辨认不健康的模式，对 INFJ-T 来说尤为关键。",
+          "body_html": null,
+          "payload_json": {
+            "teaser": "当你长期处在“我懂大家，但没有人真正懂我”的状态中时，你会一点点远离关系中心，把自己锁进内心世界。学会更早表达需求、更早辨认不健康的模式，对 INFJ-T 来说尤为关键。",
+            "is_premium": true
+          },
+          "sort_order": 180,
+          "is_enabled": true
+        }
+      ],
+      "seo_overrides": {
+        "seo_title": "INFJ-T 提倡者型",
+        "seo_description": "你像一束安静却坚定的光：不喜欢站在最显眼的地方，却总在悄悄照亮方向。你相信每个人都带着独特的使命而来，你也认真对待自己这一生的答案。",
+        "canonical_url": null,
+        "og_title": "INFJ-T 静默理想家",
+        "og_description": "你像一束安静却坚定的光：不喜欢站在最显眼的地方，却总在悄悄照亮方向。你相信每个人都带着独特的使命而来，你也认真对待自己这一生的答案。",
+        "og_image_url": null,
+        "twitter_title": "INFJ-T 静默理想家",
+        "twitter_description": "你像一束安静却坚定的光：不喜欢站在最显眼的地方，却总在悄悄照亮方向。你相信每个人都带着独特的使命而来，你也认真对待自己这一生的答案。",
+        "twitter_image_url": null,
+        "robots": null,
+        "jsonld_overrides_json": null
+      }
+    },
+    {
+      "runtime_type_code": "INFP-A",
+      "canonical_type_code": "INFP",
+      "variant_code": "A",
+      "is_published": true,
+      "published_at": "2026-03-17T00:00:00Z",
+      "profile_overrides": {
+        "type_name": "调停者型",
+        "nickname": "坚定理想家",
+        "rarity_text": "约 4–6%",
+        "keywords_json": [
+          "理想主义",
+          "共情",
+          "内在价值观",
+          "想象力",
+          "独立思考",
+          "自我驱动"
+        ],
+        "hero_summary_md": "你像一束安静却执着的光：不喧哗、不张扬，却始终在守护心中那一点“必须坚持的东西”。你宁愿走慢一点、绕远一点，也不愿违背自己的内心。",
+        "hero_summary_html": null
+      },
+      "section_overrides": [
+        {
+          "section_key": "letters_intro",
+          "render_variant": "letters_intro",
+          "body_md": null,
+          "body_html": null,
+          "payload_json": {
+            "headline": "内向 · 直觉 · 情感 · 感知 · 自信型｜温柔却有锋芒的“坚定理想家”",
+            "letters": [
+              {
+                "letter": "I",
+                "title": "内向（I）",
+                "description": "让你更习惯从独处和安静的空间里充电。你喜欢与少数深度连接的人长谈，而不是在大型社交场合奔波。"
+              },
+              {
+                "letter": "N",
+                "title": "直觉（N）",
+                "description": "让你很难只停留在表面事实，你总在思考：这件事背后隐藏着怎样的意义？你更在意“未来的可能性”，而不只是“当下的现实”。"
+              },
+              {
+                "letter": "F",
+                "title": "情感（F）",
+                "description": "让你做决定时，会优先考虑价值观与感受：这是不是对的？会不会伤到谁？你愿意为自己相信的事付出，而不是只看回报率。"
+              },
+              {
+                "letter": "P",
+                "title": "感知（P）",
+                "description": "让你不喜欢被死板的计划锁住，更偏爱保留一点开放度和灵活性。你需要空间去感受、去探索，而不是被时间表压着走。"
+              },
+              {
+                "letter": "A",
+                "title": "自信型（-A）",
+                "description": "让你在关键时刻对自己的判断保有底气。你会犹豫、会思考，但一旦确认了某个方向，便会默默坚定地走下去，不轻易被外界摇动。"
+              }
+            ]
+          },
+          "sort_order": 10,
+          "is_enabled": true
+        },
+        {
+          "section_key": "overview",
+          "render_variant": "rich_text",
+          "body_md": "在费马心理的逻辑模型里，INFP-A 往往被视作“温柔却有锋芒的理想主义者”。你安静、敏感、真诚，对世界有一套自己的价值坐标系。\n\n你不喜欢随波逐流，也不愿活成复制品。对你来说，人生最重要的不是“看起来成功”，而是“活得像自己”，在有限的时间里，尽量让世界因为自己而多一点点温度与意义。\n\n你可以包容很多不完美，但很难接受对灵魂的敷衍——当环境只剩下功利、比较和格式化流程，你会悄悄抽离，转身去寻找更贴近内心的道路。",
+          "body_html": null,
+          "payload_json": null,
+          "sort_order": 20,
+          "is_enabled": true
+        },
+        {
+          "section_key": "trait_overview",
+          "render_variant": "trait_dimension_grid",
+          "body_md": "建议与小程序中 5 条维度进度条搭配展示：外向 / 内向｜天马行空 / 求真务实｜情感细腻 / 理性思考｜运筹帷幄 / 随机应变｜情绪易波动 / 自信果断。",
+          "body_html": null,
+          "payload_json": {
+            "summary": "建议与小程序中 5 条维度进度条搭配展示：外向 / 内向｜天马行空 / 求真务实｜情感细腻 / 理性思考｜运筹帷幄 / 随机应变｜情绪易波动 / 自信果断。",
+            "dimensions": [
+              {
+                "id": "EI",
+                "name": "外向倾向",
+                "label": "外向倾向",
+                "axis_left": "外向",
+                "axis_right": "内向",
+                "summary": "明显偏内向",
+                "description": "你更喜欢小范围、深度的交流，而不是高频、浅层的社交。和懂你的人长聊一晚，比参加十场热闹聚会更让你有“活着”的实感。独处不是逃避，而是你的充电方式。"
+              },
+              {
+                "id": "SN",
+                "name": "心智模式",
+                "label": "心智模式",
+                "axis_left": "天马行空",
+                "axis_right": "求真务实",
+                "summary": "偏“天马行空”",
+                "description": "你习惯在脑中搭建完整的世界观：如果这样改变，会发生什么？如果人们多一点善意，会怎样？你容易被书、电影、音乐唤起思考，也愿意为了抽象却重要的价值持续投入精力。"
+              },
+              {
+                "id": "TF",
+                "name": "情绪天性",
+                "label": "情绪天性",
+                "axis_left": "情感细腻",
+                "axis_right": "理性思考",
+                "summary": "明显偏“情感细腻”",
+                "description": "你对情绪非常敏锐，不仅感受自己的情绪，也会本能地捕捉他人的氛围变化。你在意的不只是事情结果，更在意这一路上是否保留了真诚、尊重和善意。"
+              },
+              {
+                "id": "JP",
+                "name": "应对方式",
+                "label": "应对方式",
+                "axis_left": "运筹帷幄",
+                "axis_right": "随机应变",
+                "summary": "略偏“随机应变”",
+                "description": "你不太喜欢被安排得死死的，更希望在大方向明确的前提下，保留当下的感受与灵感空间。你愿意边走边看、边体验边调节节奏，让生活保持一种松弛而有弹性的状态。"
+              },
+              {
+                "id": "AT",
+                "name": "身份特征",
+                "label": "身份特征",
+                "axis_left": "情绪易波动",
+                "axis_right": "自信果断",
+                "summary": "略偏“自信果断”",
+                "description": "作为自信型 INFP-A，你依然敏感细腻，但不会完全被情绪裹挟。你会认真听从内心那一票的声音，一旦确认“这是我认同的事”，即使外界不理解，你也能安静而坚定地走下去。"
+              }
+            ]
+          },
+          "sort_order": 30,
+          "is_enabled": true
+        },
+        {
+          "section_key": "career.summary",
+          "render_variant": "rich_text",
+          "body_md": "你的职业选择，通常绕不开两个关键词：“意义感”和“自主度”。如果一份工作只剩下机械重复、冷冰冰的数字和无穷无尽的格式化流程，你会很难真正投入。\n\n相反，当一份工作允许你：表达想法、创作内容、帮助他人、参与有温度的项目，同时保留一定自由度，你就更容易进入“忘记时间”的沉浸状态。\n\n对你而言，“我在做的事情，和我相信的价值是否对得上？”远比头衔、薪资曲线更重要——当然，理想状态是二者兼得。",
+          "body_html": null,
+          "payload_json": null,
+          "sort_order": 40,
+          "is_enabled": true
+        },
+        {
+          "section_key": "career.advantages",
+          "render_variant": "bullets",
+          "body_md": null,
+          "body_html": null,
+          "payload_json": {
+            "items": [
+              {
+                "title": "价值驱动的工作热情",
+                "body": "一旦你认同某个项目的意义，你可以非常投入、认真，愿意打磨细节、长期坚持。这种来自内在信念的动力，比外在压力更持久。"
+              },
+              {
+                "title": "真诚细腻的共情力",
+                "body": "你擅长从他人的角度看问题，理解他们的顾虑与脆弱。这让你在用户体验、内容创作、服务支持等领域有天然优势。"
+              },
+              {
+                "title": "富有创造力与想象力",
+                "body": "你能从日常生活的小片段中捕捉灵感，转化为故事、文字、视觉、点子或新路径。你不满足于照本宣科，更喜欢赋予事物一点独特的温度。"
+              },
+              {
+                "title": "独立思考与自我驱动",
+                "body": "你不太容易被潮流绑架，遇到不认同的做法，宁愿退一步思考，也不愿盲目跟随。在适合的岗位上，这会让你成为“安静但可靠的判断者”。"
+              }
+            ]
+          },
+          "sort_order": 50,
+          "is_enabled": true
+        },
+        {
+          "section_key": "career.weaknesses",
+          "render_variant": "bullets",
+          "body_md": null,
+          "body_html": null,
+          "payload_json": {
+            "items": [
+              {
+                "title": "对琐碎重复工作耐受度低",
+                "body": "长期需要面对大量没有价值感的重复任务时，你很容易心力交瘁，进而降低效率、开始拖延。"
+              },
+              {
+                "title": "不擅长“自我包装”",
+                "body": "你习惯让作品、行动自己说话，而不太会主动争取、展示、谈判。这可能让你的贡献被低估，成长机会被别人抢走。"
+              },
+              {
+                "title": "容易在选择前过度纠结",
+                "body": "你会反复琢磨不同选项的意义和影响，担心“选错路会辜负自己”，于是决策周期被拉得很长。"
+              },
+              {
+                "title": "对冲突和硬碰硬场景不适",
+                "body": "在强对抗、高政治性的职场环境中，你会明显消耗加剧，很难发挥出真正的实力。"
+              }
+            ]
+          },
+          "sort_order": 60,
+          "is_enabled": true
+        },
+        {
+          "section_key": "career.preferred_roles",
+          "render_variant": "preferred_role_list",
+          "body_md": null,
+          "body_html": null,
+          "payload_json": {
+            "intro": "下面这些方向，并不是 INFP-A 的“标准答案”，而是更容易让你体验到意义感与创造感的领域，可以作为你探索职业时的参考坐标：",
+            "groups": [
+              {
+                "group_title": "内容与创作相关",
+                "description": "需要耐心打磨作品、通过表达触达他人的岗位。",
+                "examples": [
+                  "文字创作（写作、编辑、文案、策划）",
+                  "插画、设计、摄影、视频创作",
+                  "故事 IP、游戏世界观、剧本 / 设定相关工作"
+                ]
+              },
+              {
+                "group_title": "教育与成长陪伴",
+                "description": "帮助他人成长、陪伴别人找到方向的角色。",
+                "examples": [
+                  "老师、辅导老师、班主任、成长教练",
+                  "职业发展咨询、心理教育、人生规划相关岗位",
+                  "面向青少年或成人的成长社群主理人"
+                ]
+              },
+              {
+                "group_title": "人本与公益领域",
+                "description": "把善意落地、将理想转化为实际行动的场景。",
+                "examples": [
+                  "公益组织、社会企业、NGO 项目执行与策划",
+                  "非营利机构内容与传播岗位",
+                  "心理健康、教育公平等议题相关项目"
+                ]
+              },
+              {
+                "group_title": "以用户体验为核心的岗位",
+                "description": "需要站在用户角度思考和设计体验的角色，你的共情力与想象力很适用。",
+                "examples": [
+                  "用户研究",
+                  "社区运营",
+                  "产品体验策划",
+                  "客户成功 / 客户体验优化"
+                ]
+              }
+            ],
+            "outro": "真正关键的不是职位名称，而是：这份工作是否允许你保留真诚、发挥创造力，并在其中看见自己价值观的倒影。"
+          },
+          "sort_order": 70,
+          "is_enabled": true
+        },
+        {
+          "section_key": "career.upgrade_suggestions",
+          "render_variant": "bullets",
+          "body_md": "对 INFP-A 来说，职业成长更多是“如何在现实世界里保护理想，又不被现实打碎”。你不需要变成另外一种人，而是学会用更合适的方式，让你的温柔和执着发挥更大影响力。\n\n可以把下面几条，当作你在职场中的“小操作指引”。",
+          "body_html": null,
+          "payload_json": {
+            "items": [
+              {
+                "title": "被看见的价值 = 真诚投入 × 主动呈现",
+                "body": "你已经很擅长“真诚投入”，可以在此基础上多做一步：在汇报、复盘或工作记录中，把自己做了什么、为什么这样做、带来了什么效果说清楚。别把是否被看见，完全交给别人。"
+              },
+              {
+                "title": "理想不等于完美 = 允许小范围妥协",
+                "body": "你可以为“大方向的对”坚持，同时对一些细节学会适度妥协。问自己一句：这件事真正在乎的点是什么？不在核心的部分，可以放松一点。"
+              },
+              {
+                "title": "决策清晰度 = 内在价值观 × 最小下一步",
+                "body": "当你卡在“选哪个才是对的”时，可以先问：哪个选项更贴近我的长期价值观？然后再聚焦：我能做的最小下一步是什么？把选择拆小，你会更容易启动。"
+              },
+              {
+                "title": "长期不被消耗 = 边界感 × 休息权",
+                "body": "为自己设定最低能量保护线：当我出现哪些信号时，就必须休息 / 拒绝 / 调整？把这些写下来，放在容易看到的地方，提醒自己别在透支中“假装没事”。"
+              }
+            ]
+          },
+          "sort_order": 80,
+          "is_enabled": true
+        },
+        {
+          "section_key": "growth.summary",
+          "render_variant": "rich_text",
+          "body_md": "对 INFP-A 来说，成长既是“向外找到合适的位置”，也是“向内与自己和解”。你想成为更好的自己，但又不想在这个过程中丢掉本来的那份纯粹。\n\n这一部分，会从你的强项、短板，以及能量的来源与流失几个角度，帮你看清：怎样的成长，才是真的对你有用。",
+          "body_html": null,
+          "payload_json": null,
+          "sort_order": 90,
+          "is_enabled": true
+        },
+        {
+          "section_key": "growth.strengths",
+          "render_variant": "bullets",
+          "body_md": null,
+          "body_html": null,
+          "payload_json": {
+            "items": [
+              {
+                "title": "坚持自我、不盲从",
+                "body": "你愿意认真想清楚“这是不是我真正认同的路”，而不是简单跟着大众标准走。你的每一次选择，都更像是在向自己负责。"
+              },
+              {
+                "title": "拥有强大的内在世界",
+                "body": "你脑海里有很多故事、画面和设想，这些内在资源会在关键时刻支撑你，让你在外界不理解时，依然能保持一份底气。"
+              },
+              {
+                "title": "能够看到他人身上的光",
+                "body": "你很擅长发现别人身上那些尚未被看见的闪光点，并用温柔的方式告诉他们。这会让你成为重要的“情绪补给站”。"
+              },
+              {
+                "title": "具备自我修正能力",
+                "body": "你会在事后反思：我是不是可以更好地表达？有没有什么地方不够真诚？这种自我觉察，使你可以持续微调自己的状态与方式。"
+              }
+            ]
+          },
+          "sort_order": 100,
+          "is_enabled": true
+        },
+        {
+          "section_key": "growth.weaknesses",
+          "render_variant": "bullets",
+          "body_md": null,
+          "body_html": null,
+          "payload_json": {
+            "items": [
+              {
+                "title": "容易在理想与现实之间拉扯",
+                "body": "你对“理想中的自己”和“现实条件”都有清晰感知，却很难接受两者之间的缝隙，于是容易陷入焦虑或迟迟不开始。"
+              },
+              {
+                "title": "逃避让你不舒服的场景",
+                "body": "面对冲突、争执或强对抗的环境，你可能会选择沉默或抽离，用“躲开”代替“正面处理”，久而久之问题会积累。"
+              },
+              {
+                "title": "容易把亏待自己合理化",
+                "body": "你会对自己说“没关系，我可以忍一忍”，却很少认真去争取更好的条件。长期压抑需求，会让你突然在某个点爆发。"
+              },
+              {
+                "title": "对自我要求过高",
+                "body": "你一方面悄悄要求自己“既要真实，又要优秀”，另一方面又会因为暂时达不到而否定自己，这会反复消耗你的自信。"
+              }
+            ]
+          },
+          "sort_order": 110,
+          "is_enabled": true
+        },
+        {
+          "section_key": "growth.motivators",
+          "render_variant": "premium_teaser",
+          "body_md": "当你感到“自己是真实地活着，并且在做对自己和他人都有意义的事”时，你会自然地涌出能量。真诚的认同、被理解的瞬间、作品被看见的那一刻，都是你最重要的燃料。",
+          "body_html": null,
+          "payload_json": {
+            "teaser": "当你感到“自己是真实地活着，并且在做对自己和他人都有意义的事”时，你会自然地涌出能量。真诚的认同、被理解的瞬间、作品被看见的那一刻，都是你最重要的燃料。",
+            "is_premium": true
+          },
+          "sort_order": 120,
+          "is_enabled": true
+        },
+        {
+          "section_key": "growth.drainers",
+          "render_variant": "premium_teaser",
+          "body_md": "需要持续戴着面具的环境、只有输赢没有讨论的关系、以及被迫参与违背自己价值观的决策，会让你迅速失去能量。如果你开始变得麻木、频繁逃避，很可能就是在这些地方被慢慢掏空了。",
+          "body_html": null,
+          "payload_json": {
+            "teaser": "需要持续戴着面具的环境、只有输赢没有讨论的关系、以及被迫参与违背自己价值观的决策，会让你迅速失去能量。如果你开始变得麻木、频繁逃避，很可能就是在这些地方被慢慢掏空了。",
+            "is_premium": true
+          },
+          "sort_order": 130,
+          "is_enabled": true
+        },
+        {
+          "section_key": "relationships.summary",
+          "render_variant": "rich_text",
+          "body_md": "在关系世界里，你更像一位“安静的共感者”。你不一定健谈，但会认真听、认真记、认真回应——你在意的从来不是热闹，而是真实。\n\n你希望关系能成为双方都能卸下面具、好好做自己的地方，而不是又一个需要表现和迎合的舞台。",
+          "body_html": null,
+          "payload_json": null,
+          "sort_order": 140,
+          "is_enabled": true
+        },
+        {
+          "section_key": "relationships.strengths",
+          "render_variant": "bullets",
+          "body_md": null,
+          "body_html": null,
+          "payload_json": {
+            "items": [
+              {
+                "title": "真诚而深度的陪伴",
+                "body": "你不会随便给出空洞安慰，而是愿意静静地在旁边，与对方一起待在情绪里，直到他真的感觉好一点。"
+              },
+              {
+                "title": "尊重他人的边界与独特性",
+                "body": "你不会轻易评判别人“应该怎样”，更愿意理解每个人的背景与故事。相处时，你会给对方留下呼吸感。"
+              },
+              {
+                "title": "擅长用文字或细节表达在乎",
+                "body": "你可能不擅长大张旗鼓地表达爱，却会用长消息、手写卡片、小礼物或默默的行动，告诉对方“你对我很重要”。"
+              },
+              {
+                "title": "愿意为关系成长投入时间",
+                "body": "你不会轻易放弃一段重要关系，而是愿意慢慢调整沟通方式、尝试新的相处模式，让彼此都更舒服。"
+              }
+            ]
+          },
+          "sort_order": 150,
+          "is_enabled": true
+        },
+        {
+          "section_key": "relationships.weaknesses",
+          "render_variant": "bullets",
+          "body_md": null,
+          "body_html": null,
+          "payload_json": {
+            "items": [
+              {
+                "title": "不擅长表达负面情绪",
+                "body": "你宁愿自己消化，也不太愿意在别人面前“麻烦别人”或“显得不够好”，这会让对方误以为你什么都不介意。"
+              },
+              {
+                "title": "容易理想化关系",
+                "body": "当你把某段关系放得很高时，很容易忽略现实中的差异与问题。一旦理想幻灭，你会感到格外失落。"
+              },
+              {
+                "title": "习惯默默付出，不会索取",
+                "body": "你乐于为对方做很多事，却很少主动提出自己的需求。久而久之，关系容易发展成“你给得多，对方习惯接受”的不平衡状态。"
+              },
+              {
+                "title": "难以彻底抽身不健康关系",
+                "body": "即便已经意识到自己被消耗，你仍可能因为回忆、内疚或责任感而迟迟不肯离开。你会为别人找很多理由，却很少真的为自己做决定。"
+              }
+            ]
+          },
+          "sort_order": 160,
+          "is_enabled": true
+        },
+        {
+          "section_key": "relationships.rel_advantages",
+          "render_variant": "premium_teaser",
+          "body_md": "在健康的关系里，你会成为那种“别人一想到就心里发软”的存在——安全、温柔、值得信赖。你能让人放下防备，也能用自己的方式，悄悄推动彼此一点点地变得更好。",
+          "body_html": null,
+          "payload_json": {
+            "teaser": "在健康的关系里，你会成为那种“别人一想到就心里发软”的存在——安全、温柔、值得信赖。你能让人放下防备，也能用自己的方式，悄悄推动彼此一点点地变得更好。",
+            "is_premium": true
+          },
+          "sort_order": 170,
+          "is_enabled": true
+        },
+        {
+          "section_key": "relationships.rel_risks",
+          "render_variant": "premium_teaser",
+          "body_md": "当你习惯于降低自己需求、反复原谅、为对方找各种理由时，你可能已经陷入了不对等的关系模式。学会辨别“我是在爱对方，还是只是在消耗自己”，是 INFP-A 非常关键的一课。",
+          "body_html": null,
+          "payload_json": {
+            "teaser": "当你习惯于降低自己需求、反复原谅、为对方找各种理由时，你可能已经陷入了不对等的关系模式。学会辨别“我是在爱对方，还是只是在消耗自己”，是 INFP-A 非常关键的一课。",
+            "is_premium": true
+          },
+          "sort_order": 180,
+          "is_enabled": true
+        }
+      ],
+      "seo_overrides": {
+        "seo_title": "INFP-A 调停者型",
+        "seo_description": "你像一束安静却执着的光：不喧哗、不张扬，却始终在守护心中那一点“必须坚持的东西”。你宁愿走慢一点、绕远一点，也不愿违背自己的内心。",
+        "canonical_url": null,
+        "og_title": "INFP-A 坚定理想家",
+        "og_description": "你像一束安静却执着的光：不喧哗、不张扬，却始终在守护心中那一点“必须坚持的东西”。你宁愿走慢一点、绕远一点，也不愿违背自己的内心。",
+        "og_image_url": null,
+        "twitter_title": "INFP-A 坚定理想家",
+        "twitter_description": "你像一束安静却执着的光：不喧哗、不张扬，却始终在守护心中那一点“必须坚持的东西”。你宁愿走慢一点、绕远一点，也不愿违背自己的内心。",
+        "twitter_image_url": null,
+        "robots": null,
+        "jsonld_overrides_json": null
+      }
+    },
+    {
+      "runtime_type_code": "INFP-T",
+      "canonical_type_code": "INFP",
+      "variant_code": "T",
+      "is_published": true,
+      "published_at": "2026-03-17T00:00:00Z",
+      "profile_overrides": {
+        "type_name": "调停者型",
+        "nickname": "温柔筑梦者",
+        "rarity_text": "约 4–7%",
+        "keywords_json": [
+          "理想主义",
+          "共情力",
+          "内在价值观",
+          "想象力",
+          "真诚",
+          "自我探索"
+        ],
+        "hero_summary_md": "你像一团安静却倔强的火焰：不喧嚣、不夺目，却一直在用自己的方式温暖世界。你宁愿慢一点、小一点，也想活成和内心价值观一致的样子。外界或许觉得你安静温柔，但在你心里，一直住着一个不肯妥协的理想主义者。",
+        "hero_summary_html": null
+      },
+      "section_overrides": [
+        {
+          "section_key": "letters_intro",
+          "render_variant": "letters_intro",
+          "body_md": null,
+          "body_html": null,
+          "payload_json": {
+            "headline": "内向 · 直觉 · 情感 · 感知 · 动荡型｜在现实世界里守护内心宇宙的“温柔筑梦者”",
+            "letters": [
+              {
+                "letter": "I",
+                "title": "内向（I）",
+                "description": "让你更习惯从独处中充电。人多吵闹的场合会耗尽你的能量，而一个安静角落里的阅读、写作、发呆，反而能让你慢慢“回血”。"
+              },
+              {
+                "letter": "N",
+                "title": "直觉（N）",
+                "description": "让你很少只停留在表面事实，而是总在寻找“背后的意义”。你更在意故事、象征和走向，而不是冰冷的数据本身。"
+              },
+              {
+                "letter": "F",
+                "title": "情感（F）",
+                "description": "让你在做决定时，会本能地问一句：“这是不是符合我的价值观？”你宁愿吃点亏，也不愿做违背良心的选择。"
+              },
+              {
+                "letter": "P",
+                "title": "感知（P）",
+                "description": "让你不太喜欢被僵硬的时间表绑死，更偏爱保留一点即兴和弹性——灵感、心情和当下状态，都是你安排生活的重要参考。"
+              },
+              {
+                "letter": "T",
+                "title": "动荡型（-T）",
+                "description": "让你对自己要求很高，也容易反复自我审视：“我是不是还可以更好？” 这既是你持续成长的动力，也是你焦虑和纠结的来源。"
+              }
+            ]
+          },
+          "sort_order": 10,
+          "is_enabled": true
+        },
+        {
+          "section_key": "overview",
+          "render_variant": "rich_text",
+          "body_md": "在费马心理的逻辑模型里，INFP-T 常被视作“安静而固执的理想主义者”。你敏感细腻、共情力强，总能看见别人忽略的情绪和可能性，却又不太愿意站到聚光灯之下。\n\n对你来说，人生不是一场竞争，而是一条“活得像自己”的旅程。你希望做的事情是真诚的、有意义的，并且在某种程度上，能让世界因为你而变得柔软一点点。\n\n当环境过于功利、粗糙或充满算计时，你会本能地退后半步，用沉默和保持距离来保护自己心里的那块“净土”。你宁愿慢慢来，也不愿彻底放弃心中的那份善良与浪漫。",
+          "body_html": null,
+          "payload_json": null,
+          "sort_order": 20,
+          "is_enabled": true
+        },
+        {
+          "section_key": "trait_overview",
+          "render_variant": "trait_dimension_grid",
+          "body_md": "建议与小程序中 5 条维度进度条搭配展示：外向 / 内向｜天马行空 / 求真务实｜情感细腻 / 理性思考｜运筹帷幄 / 随机应变｜情绪易波动 / 自信果断。",
+          "body_html": null,
+          "payload_json": {
+            "summary": "建议与小程序中 5 条维度进度条搭配展示：外向 / 内向｜天马行空 / 求真务实｜情感细腻 / 理性思考｜运筹帷幄 / 随机应变｜情绪易波动 / 自信果断。",
+            "dimensions": [
+              {
+                "id": "EI",
+                "name": "外向倾向",
+                "label": "外向倾向",
+                "axis_left": "外向",
+                "axis_right": "内向",
+                "summary": "明显偏内向",
+                "description": "你更习惯在熟悉的小圈子或一对一对话中展现自己，在不了解的人群中，你往往安静、礼貌但略显拘谨。独处不是逃避，而是你整理思绪、和自己对话的必要时刻。"
+              },
+              {
+                "id": "SN",
+                "name": "心智模式",
+                "label": "心智模式",
+                "axis_left": "天马行空",
+                "axis_right": "求真务实",
+                "summary": "偏“天马行空”",
+                "description": "你很容易从一个细节联想到一整套故事，脑海里常常上演各种“如果”的场景。具体数据和流程对你固然重要，但如果一件事缺少意义感，你就很难真正投入。"
+              },
+              {
+                "id": "TF",
+                "name": "情绪天性",
+                "label": "情绪天性",
+                "axis_left": "情感细腻",
+                "axis_right": "理性思考",
+                "summary": "明显偏“情感细腻”",
+                "description": "你对自己的情绪、他人的情绪都极为敏感，别人无意的一句话，可能在你心里回荡很久。你不喜欢粗暴的沟通方式，更希望被温柔地理解与对待。"
+              },
+              {
+                "id": "JP",
+                "name": "应对方式",
+                "label": "应对方式",
+                "axis_left": "运筹帷幄",
+                "axis_right": "随机应变",
+                "summary": "略偏“随机应变”",
+                "description": "与其把生活规划到每一分钟，你更喜欢保留一点弹性和即兴空间。你擅长顺着灵感走，按当下的感受调整节奏——虽然这有时也会带来拖延和犹豫。"
+              },
+              {
+                "id": "AT",
+                "name": "身份特征",
+                "label": "身份特征",
+                "axis_left": "情绪易波动",
+                "axis_right": "自信果断",
+                "summary": "略偏“情绪易波动”",
+                "description": "动荡型的你，自我觉察度很高，也更容易被情绪影响。你会反复咀嚼一件小事，对自己提出很多质疑：“我是不是不够好？” 但也正因为这份敏感，你比很多人更懂得温柔以待。"
+              }
+            ]
+          },
+          "sort_order": 30,
+          "is_enabled": true
+        },
+        {
+          "section_key": "career.summary",
+          "render_variant": "rich_text",
+          "body_md": "对 INFP-T 来说，一份“好工作”的核心标准，从来不只是薪资和头衔，更在于：它是否与我的价值观一致？是否让我感觉在做有意义的事情？\n\n你适合那些允许保留个人风格、能照顾到个体感受、并且有一定创造空间的职业环境。在这种地方，你的理想主义不会被当成“矫情”，而是会被视为珍贵的坚持。\n\n相反，如果一份工作长期要求你违背良心、机械执行或者“只看结果不看人”，你会很快感到被掏空，甚至萌生强烈的逃离冲动。",
+          "body_html": null,
+          "payload_json": null,
+          "sort_order": 40,
+          "is_enabled": true
+        },
+        {
+          "section_key": "career.advantages",
+          "render_variant": "bullets",
+          "body_md": null,
+          "body_html": null,
+          "payload_json": {
+            "items": [
+              {
+                "title": "真诚而有温度的同事",
+                "body": "你不擅长做表面功夫，却很愿意在信任建立之后，给予别人实实在在的支持。你能在团队中悄悄扮演“润滑剂”和“倾听者”的角色。"
+              },
+              {
+                "title": "内容与创意表达能力",
+                "body": "你善于把抽象的情绪与想法转化成文字、画面或故事。无论是写作、内容策划还是品牌故事设计，你都能给作品注入独特的灵魂感。"
+              },
+              {
+                "title": "高度的价值感驱动",
+                "body": "一旦觉得这件事值得，你可以非常投入、持续深耕，而不只是“完成任务”。这种由内而外的动力，在需要长期坚持的领域尤其宝贵。"
+              },
+              {
+                "title": "共情与理解个体差异",
+                "body": "你愿意认真聆听他人的想法与处境，尊重差异、不轻易评判，这让你在需要陪伴、辅导或支持他人的岗位上表现出色。"
+              }
+            ]
+          },
+          "sort_order": 50,
+          "is_enabled": true
+        },
+        {
+          "section_key": "career.weaknesses",
+          "render_variant": "bullets",
+          "body_md": null,
+          "body_html": null,
+          "payload_json": {
+            "items": [
+              {
+                "title": "对现实规则的适应度较低",
+                "body": "当工作环境过于功利、冰冷或只看结果时，你会迅速产生疏离感，难以全情投入，甚至会本能选择“精神退场”。"
+              },
+              {
+                "title": "容易拖延与逃避压力",
+                "body": "面对枯燥的任务、频繁的打扰或高压的 KPI，你可能难以马上进入状态，习惯先拖一拖，等自己“感觉好一点再开始”。"
+              },
+              {
+                "title": "不善于为自己“争取”",
+                "body": "你更习惯低调做事，而不是到处展示成果。这容易导致你的贡献被低估，升职加薪或机会分配时，未必轮到你。"
+              },
+              {
+                "title": "抗拒硬性冲突与强势文化",
+                "body": "激烈的争吵、公开的指责、极端“狼性”的竞争氛围，对你来说都非常消耗，你会尽量避开这类环境和角色。"
+              }
+            ]
+          },
+          "sort_order": 60,
+          "is_enabled": true
+        },
+        {
+          "section_key": "career.preferred_roles",
+          "render_variant": "preferred_role_list",
+          "body_md": null,
+          "body_html": null,
+          "payload_json": {
+            "intro": "下面这些方向，并不是 INFP-T 唯一的选择，而是更有可能让你感到“我没有白来这一趟”的职业类型。",
+            "groups": [
+              {
+                "group_title": "文字与创作相关",
+                "description": "可以用故事、文字或视觉，表达你对世界的感受与思考。",
+                "examples": [
+                  "作家、编剧、自媒体创作者、文案 / 内容策划",
+                  "插画师、设计师、创意策划",
+                  "播客主、纪录片 / 短片内容创作者"
+                ]
+              },
+              {
+                "group_title": "心理与助人领域",
+                "description": "把你的共情力和洞察力，变成别人走出困境的力量。",
+                "examples": [
+                  "心理咨询 / 心理相关服务",
+                  "教练、生活规划顾问",
+                  "社工、公益 / NGO 一线服务者"
+                ]
+              },
+              {
+                "group_title": "教育与成长陪伴",
+                "description": "在“陪伴别人长大”的过程中，也不断丰富自己的人生故事。",
+                "examples": [
+                  "教育培训、阅读推广、儿童 / 青少年陪伴",
+                  "成长型社群主理人、线下工作坊主持",
+                  "在线课程设计、知识类内容运营"
+                ]
+              },
+              {
+                "group_title": "价值观导向型组织",
+                "description": "价值观相近的团队，会给你很强的归属感，让你有勇气把理想落到现实。",
+                "examples": [
+                  "社会企业、公益基金会、关注特定议题的项目组",
+                  "重视文化与人文气质的品牌团队",
+                  "允许创作者保留表达自由的内容平台"
+                ]
+              }
+            ],
+            "outro": "与其从职位名称出发，不如从两个问题出发：这份工作是否触碰到我在乎的价值？我能否在其中保留一点自己的风格与节奏？"
+          },
+          "sort_order": 70,
+          "is_enabled": true
+        },
+        {
+          "section_key": "career.upgrade_suggestions",
+          "render_variant": "bullets",
+          "body_md": "在职业发展上，INFP-T 的关键不是“硬逼自己变得很现实”，而是学会在理想与现实之间搭一座小桥：既照顾内心，也考虑长期可持续的生活方式。\n\n你可以尝试用一些小小的“公式”，来帮助自己在喜欢与必须之间找到平衡。",
+          "body_html": null,
+          "payload_json": {
+            "items": [
+              {
+                "title": "热爱 × 结构 = 能落地的理想",
+                "body": "先承认“我需要喜欢这件事”，再为它加上一点点结构和节奏——比如每周固定创作时间、拆分成可完成的小任务，而不是等“完美状态”降临。"
+              },
+              {
+                "title": "温柔 ≠ 一味退让",
+                "body": "对人温柔，不代表对自己要求就必须一降再降。学会在适当的时候说“不”，是为了把你的善意用在真正值得的人和事上。"
+              },
+              {
+                "title": "曝光度 = 被看见的价值",
+                "body": "把你做过的好事、写过的方案、帮助过的人，适度整理、分享出来——这不是炫耀，而是让世界知道你在认真地发光。"
+              },
+              {
+                "title": "安全感 = 基础生活 × 内心空间",
+                "body": "给自己搭好基本的生活保障（收入、时间、界限），再在这个基础上去追求理想，会比“孤注一掷式的燃烧”更适合你，也更长久。"
+              }
+            ]
+          },
+          "sort_order": 80,
+          "is_enabled": true
+        },
+        {
+          "section_key": "growth.summary",
+          "render_variant": "rich_text",
+          "body_md": "对 INFP-T 来说，成长更多是一场“和自己和解”的旅程。你一方面渴望成为更好的自己，另一方面又害怕在这个过程中失去原本的温柔与真诚。\n\n这一章节，会从你的强项、短板，以及能量的来源与流失等角度，帮你更清晰地看见：怎样的成长路径更适合你。",
+          "body_html": null,
+          "payload_json": null,
+          "sort_order": 90,
+          "is_enabled": true
+        },
+        {
+          "section_key": "growth.strengths",
+          "render_variant": "bullets",
+          "body_md": null,
+          "body_html": null,
+          "payload_json": {
+            "items": [
+              {
+                "title": "愿意为“更好的自己”投入时间",
+                "body": "你看重内在成长，愿意阅读、学习、写日记、做自我反思，用自己的方式缓慢但持续地进步。"
+              },
+              {
+                "title": "对世界保持好奇与温柔",
+                "body": "即便经历过失望，你仍然倾向于相信：人心并非全然冷漠，世界依然值得期待。这种不轻易犬儒的温柔，是很难得的力量。"
+              },
+              {
+                "title": "感受力与创作欲望",
+                "body": "你对细节的感受力极强，很多人忽略的瞬间，在你心里都是值得被记录的片段。这让你天然适合用创作的方式和世界对话。"
+              },
+              {
+                "title": "自省与修正能力",
+                "body": "你经常会反问自己：“为什么我会这样想？”“我真正在意的是什么？” 这种向内看的能力，是个人成长中最重要的底层能力之一。"
+              }
+            ]
+          },
+          "sort_order": 100,
+          "is_enabled": true
+        },
+        {
+          "section_key": "growth.weaknesses",
+          "render_variant": "bullets",
+          "body_md": null,
+          "body_html": null,
+          "payload_json": {
+            "items": [
+              {
+                "title": "过度理想化，容易受挫",
+                "body": "你容易用理想中的标准看人看事，一旦现实与期望差距太大，就会感到极度失望，甚至怀疑自己是不是“想太多了”。"
+              },
+              {
+                "title": "行动被情绪严重影响",
+                "body": "当状态不佳或被情绪困住时，你很难动起来，哪怕只是一个小任务，也会因此一拖再拖。"
+              },
+              {
+                "title": "边界感模糊",
+                "body": "你想当一个好人，于是不自觉地接下过多的情绪劳动和责任。久而久之，你会觉得自己被“用力掏空”，却又不好意思表达不满。"
+              },
+              {
+                "title": "很难“彻底放下”",
+                "body": "很多往事在别人心里早已翻篇，但在你心里还会时不时被翻出来回放。这既说明你重感情，也容易让你被过去牵制。"
+              }
+            ]
+          },
+          "sort_order": 110,
+          "is_enabled": true
+        },
+        {
+          "section_key": "growth.motivators",
+          "render_variant": "premium_teaser",
+          "body_md": "当你感觉自己的存在“正在悄悄让某些东西变好”时——无论是一个人、一群人、一个小小的角落，都会给你带来源源不断的动力。真诚的肯定、被理解的瞬间、以及看到自己的作品被人珍惜，都是你的重要燃料。",
+          "body_html": null,
+          "payload_json": {
+            "teaser": "当你感觉自己的存在“正在悄悄让某些东西变好”时——无论是一个人、一群人、一个小小的角落，都会给你带来源源不断的动力。真诚的肯定、被理解的瞬间、以及看到自己的作品被人珍惜，都是你的重要燃料。",
+            "is_premium": true
+          },
+          "sort_order": 120,
+          "is_enabled": true
+        },
+        {
+          "section_key": "growth.drainers",
+          "render_variant": "premium_teaser",
+          "body_md": "空洞的社交、毫无价值感的重复任务、长期被误解或被敷衍的付出，以及不得不在“违背自己”的状态下工作，都会一点点耗尽你的热情。你越是强撑，心里的那团火就越容易变暗。",
+          "body_html": null,
+          "payload_json": {
+            "teaser": "空洞的社交、毫无价值感的重复任务、长期被误解或被敷衍的付出，以及不得不在“违背自己”的状态下工作，都会一点点耗尽你的热情。你越是强撑，心里的那团火就越容易变暗。",
+            "is_premium": true
+          },
+          "sort_order": 130,
+          "is_enabled": true
+        },
+        {
+          "section_key": "relationships.summary",
+          "render_variant": "rich_text",
+          "body_md": "在关系世界里，你更像一个“安静但极其认真的参与者”。你不会到处宣扬自己的好，但一旦认定一段关系，你会投入极高的忠诚与耐心。\n\n你向往的是那种：可以聊很深、可以一起做梦、可以互相保护脆弱的关系，而不是表面热闹却彼此都很孤独的相处模式。",
+          "body_html": null,
+          "payload_json": null,
+          "sort_order": 140,
+          "is_enabled": true
+        },
+        {
+          "section_key": "relationships.strengths",
+          "render_variant": "bullets",
+          "body_md": null,
+          "body_html": null,
+          "payload_json": {
+            "items": [
+              {
+                "title": "真诚而不浮夸",
+                "body": "你不太会说场面话，更习惯用实际行动来表达在乎——记住别人的细节、耐心倾听、在对方难过时陪在身边，这些都是你最自然的表达方式。"
+              },
+              {
+                "title": "能接住对方的脆弱",
+                "body": "很多人不敢展示的情绪，在你面前会慢慢松动。你不会轻易评判，而是尝试理解：“你为什么会这么难过？”"
+              },
+              {
+                "title": "珍惜长期关系",
+                "body": "你不追求“认识很多人”，而是更在意那几个真正懂你、你也愿意为之付出的关系。你愿意花时间一点点修补、打磨、陪伴。"
+              },
+              {
+                "title": "有浪漫与想象力",
+                "body": "你能够在平凡生活里制造温柔的小惊喜：一封信、一张卡片、一段认真的对话，都可能成为别人很难忘的回忆。"
+              }
+            ]
+          },
+          "sort_order": 150,
+          "is_enabled": true
+        },
+        {
+          "section_key": "relationships.weaknesses",
+          "render_variant": "bullets",
+          "body_md": null,
+          "body_html": null,
+          "payload_json": {
+            "items": [
+              {
+                "title": "不擅长直接表达不满",
+                "body": "你害怕自己的情绪会伤到别人，于是选择“自己消化”。但这些没有说出口的在意，会在心里慢慢结成疙瘩。"
+              },
+              {
+                "title": "容易理想化对方",
+                "body": "在感情初期，你很容易把对方放在一个很高的位置，用理想中的样子看他 / 她。一旦现实偏差过大，你会经历从“神坛跌落”的失落感。"
+              },
+              {
+                "title": "难以离开消耗型关系",
+                "body": "就算一段关系已经让你筋疲力尽，你也会不停找理由说服自己再坚持一下：“也许他 / 她会变好。”这让你很难及时抽身。"
+              },
+              {
+                "title": "自我价值感容易被关系绑架",
+                "body": "当一段重要关系不顺利时，你容易把责任全部揽到自己身上，怀疑“是不是我不够好，才让对方这样对我？”"
+              }
+            ]
+          },
+          "sort_order": 160,
+          "is_enabled": true
+        },
+        {
+          "section_key": "relationships.rel_advantages",
+          "render_variant": "premium_teaser",
+          "body_md": "在健康的关系中，你会成为一个极其温柔、可靠又有深度的伙伴——懂得倾听，也有独立的灵魂。你不会把别人当成“填补空缺的人”，而是希望彼此都是各自完整的个体，然后选择并肩同行。",
+          "body_html": null,
+          "payload_json": {
+            "teaser": "在健康的关系中，你会成为一个极其温柔、可靠又有深度的伙伴——懂得倾听，也有独立的灵魂。你不会把别人当成“填补空缺的人”，而是希望彼此都是各自完整的个体，然后选择并肩同行。",
+            "is_premium": true
+          },
+          "sort_order": 170,
+          "is_enabled": true
+        },
+        {
+          "section_key": "relationships.rel_risks",
+          "render_variant": "premium_teaser",
+          "body_md": "如果你长期停留在“只有我在努力维护”的关系里，你会逐渐怀疑自己的价值，甚至质疑“是不是我天生就不值得被好好对待”。识别并远离这种不对等，是 INFP-T 非常关键的一课。",
+          "body_html": null,
+          "payload_json": {
+            "teaser": "如果你长期停留在“只有我在努力维护”的关系里，你会逐渐怀疑自己的价值，甚至质疑“是不是我天生就不值得被好好对待”。识别并远离这种不对等，是 INFP-T 非常关键的一课。",
+            "is_premium": true
+          },
+          "sort_order": 180,
+          "is_enabled": true
+        }
+      ],
+      "seo_overrides": {
+        "seo_title": "INFP-T 调停者型",
+        "seo_description": "你像一团安静却倔强的火焰：不喧嚣、不夺目，却一直在用自己的方式温暖世界。你宁愿慢一点、小一点，也想活成和内心价值观一致的样子。外界或许觉得你安静温柔，但在你心里，一直住着一个不肯妥协的理想主义者。",
+        "canonical_url": null,
+        "og_title": "INFP-T 温柔筑梦者",
+        "og_description": "你像一团安静却倔强的火焰：不喧嚣、不夺目，却一直在用自己的方式温暖世界。你宁愿慢一点、小一点，也想活成和内心价值观一致的样子。外界或许觉得你安静温柔，但在你心里，一直住着一个不肯妥协的理想主义者。",
+        "og_image_url": null,
+        "twitter_title": "INFP-T 温柔筑梦者",
+        "twitter_description": "你像一团安静却倔强的火焰：不喧嚣、不夺目，却一直在用自己的方式温暖世界。你宁愿慢一点、小一点，也想活成和内心价值观一致的样子。外界或许觉得你安静温柔，但在你心里，一直住着一个不肯妥协的理想主义者。",
+        "twitter_image_url": null,
+        "robots": null,
+        "jsonld_overrides_json": null
+      }
+    },
+    {
+      "runtime_type_code": "INTJ-A",
+      "canonical_type_code": "INTJ",
+      "variant_code": "A",
+      "is_published": true,
+      "published_at": "2026-03-17T00:00:00Z",
+      "profile_overrides": {
+        "type_name": "建筑师型",
+        "nickname": "理性远见者",
+        "rarity_text": "约 1–4%",
+        "keywords_json": [
+          "战略思维",
+          "独立判断",
+          "长线规划",
+          "系统化",
+          "高标准",
+          "自我驱动"
+        ],
+        "hero_summary_md": "你像一位安静的战略家：不爱站在舞台中央，却在心里推演过无数种未来。你更在意“事情能不能按最优解运行”，而不是讨好当下的情绪。表面冷静疏离，其实你对「更好的世界」有着极高且清醒的期待。",
+        "hero_summary_html": null
+      },
+      "section_overrides": [
+        {
+          "section_key": "letters_intro",
+          "render_variant": "letters_intro",
+          "body_md": null,
+          "body_html": null,
+          "payload_json": {
+            "headline": "内向 · 直觉 · 思考 · 规划 · 自信型｜既看得远又算得清的“理性远见者”",
+            "letters": [
+              {
+                "letter": "I",
+                "title": "内向（I）",
+                "description": "让你更习惯在安静空间里思考和充电。与其闲聊寒暄，你更享受高质量的深度对话和一个人推演方案的过程。"
+              },
+              {
+                "letter": "N",
+                "title": "直觉（N）",
+                "description": "让你天然关注趋势、底层规律和长远可能性。你很难只盯着当下的一点得失，总会去想：这件事的结构是什么？三年后会变成怎样？"
+              },
+              {
+                "letter": "T",
+                "title": "思考（T）",
+                "description": "让你在决策时优先考虑逻辑、证据和效率，而不是一时的情绪。你会本能地寻找更优解，而不是“大家都觉得差不多就行”。"
+              },
+              {
+                "letter": "J",
+                "title": "规划（J）",
+                "description": "让你习惯先搭好框架、再填内容。你喜欢有节奏地推进，而不是在无尽的变动中被动应付。"
+              },
+              {
+                "letter": "A",
+                "title": "自信型（-A）",
+                "description": "让你在确定好方向后相对坚定，不容易被外界情绪左右。你更相信经过充分思考后的判断，即便是少数派，也愿意为自己的选择负责。"
+              }
+            ]
+          },
+          "sort_order": 10,
+          "is_enabled": true
+        },
+        {
+          "section_key": "overview",
+          "render_variant": "rich_text",
+          "body_md": "在费马心理的逻辑模型里，INTJ-A 常被视作“低调但极具力量的战略规划者”。你不热衷随波逐流，也不喜欢被情绪牵着走，更在意的是：这件事的底层逻辑是否自洽，方向是否值得长期投入。\n\n对你来说，最舒服的状态是：有一个足够有意义、值得深挖的领域，一个相对自主的空间，以及一套由你亲自打磨过的长期路线图。你宁愿默默打基础，也不愿在肤浅的热闹里浪费时间。\n\n你的人生追求从来不是“混得还可以”，而是“把系统搭到更优，把自己打磨到配得上那些雄心”。哪怕外界看不懂你的坚持，你也愿意先走在前面。",
+          "body_html": null,
+          "payload_json": null,
+          "sort_order": 20,
+          "is_enabled": true
+        },
+        {
+          "section_key": "trait_overview",
+          "render_variant": "trait_dimension_grid",
+          "body_md": "建议与小程序中 5 条维度进度条搭配展示：外向 / 内向｜天马行空 / 求真务实｜情感细腻 / 理性思考｜运筹帷幄 / 随机应变｜情绪易波动 / 自信果断。",
+          "body_html": null,
+          "payload_json": {
+            "summary": "建议与小程序中 5 条维度进度条搭配展示：外向 / 内向｜天马行空 / 求真务实｜情感细腻 / 理性思考｜运筹帷幄 / 随机应变｜情绪易波动 / 自信果断。",
+            "dimensions": [
+              {
+                "id": "EI",
+                "name": "外向倾向",
+                "label": "外向倾向",
+                "axis_left": "外向",
+                "axis_right": "内向",
+                "summary": "明显偏内向",
+                "description": "你更倾向把能量花在思考与创造上，而不是高频社交。和熟悉的人深聊远比应付大量泛泛之交更让你觉得有价值。长时间被打断，会让你感觉思路被撕碎。"
+              },
+              {
+                "id": "SN",
+                "name": "心智模式",
+                "label": "心智模式",
+                "axis_left": "天马行空",
+                "axis_right": "求真务实",
+                "summary": "“天马行空”中带强逻辑",
+                "description": "你善于从杂乱信息中提炼出结构和趋势，看问题会直接跳到更高一层：这个模式的本质是什么？还能怎么优化？在别人眼里，你的思考常常“超前半步甚至一步”。"
+              },
+              {
+                "id": "TF",
+                "name": "情绪天性",
+                "label": "情绪天性",
+                "axis_left": "情感细腻",
+                "axis_right": "理性思考",
+                "summary": "明显偏“理性思考”",
+                "description": "你更习惯先分析、后感受。面对问题，你会优先拆解事实、方案和代价，而不是沉溺在“谁对谁错”的情绪里。你在乎的人并不多，但一旦认定，关心会非常深。"
+              },
+              {
+                "id": "JP",
+                "name": "应对方式",
+                "label": "应对方式",
+                "axis_left": "运筹帷幄",
+                "axis_right": "随机应变",
+                "summary": "强烈偏“运筹帷幄”",
+                "description": "你习惯先搭战略框架，再往里填战术细节。信息越充分，你越能冷静地评估路径和风险。即便环境变化，你也倾向于在新旧信息之间迅速重算一遍最优解，而不是只凭直觉瞎撞。"
+              },
+              {
+                "id": "AT",
+                "name": "身份特征",
+                "label": "身份特征",
+                "axis_left": "情绪易波动",
+                "axis_right": "自信果断",
+                "summary": "偏“自信果断”",
+                "description": "一旦你确认了逻辑和方向，就很难被随意动摇。你不会为了取悦所有人而更改判断，更在意“它是不是对的”，而不是“它讨不讨喜”。这种稳定，会被一部分人解读为“冷”或“倔”。"
+              }
+            ]
+          },
+          "sort_order": 30,
+          "is_enabled": true
+        },
+        {
+          "section_key": "career.summary",
+          "render_variant": "rich_text",
+          "body_md": "你的职业选择，通常会围绕“复杂问题、长期价值和系统优化”展开。越是需要长期思考、搭建架构、做艰难决策的领域，你越容易展现优势。\n\n你不太适合长时间做高度碎片化、重复度高、缺乏思考空间的工作；当职场环境只强调“听话照做”、不鼓励独立判断时，你会很快感到厌倦甚至疏离。\n\n相反，当一份工作允许你：深入一个领域、掌控一定决策空间、基于逻辑而不是情绪做判断，并且能看见体系被优化的实质变化时，你会进入高产又高效的状态。",
+          "body_html": null,
+          "payload_json": null,
+          "sort_order": 40,
+          "is_enabled": true
+        },
+        {
+          "section_key": "career.advantages",
+          "render_variant": "bullets",
+          "body_md": null,
+          "body_html": null,
+          "payload_json": {
+            "items": [
+              {
+                "title": "战略视角与长线思维",
+                "body": "你很少只盯着眼前一两步，而是习惯从全局去看行业、产品或组织的走势。这让你在规划路线、判断机会和规避长期风险时格外精准。"
+              },
+              {
+                "title": "高标准与高要求",
+                "body": "你对自己和项目都有不低的标准，倾向于把事情做到“结构清晰、逻辑自洽、细节稳固”。你不追求形式上的忙碌，而是追求实质上的有效。"
+              },
+              {
+                "title": "强大的理性分析力",
+                "body": "你擅长拆解问题、建模、排除干扰因素，以冷静的方式权衡得失。关键时刻，你能坚持基于事实和逻辑作决策，而不是随大流。"
+              },
+              {
+                "title": "独立与自我驱动",
+                "body": "你不需要别人天天“打鸡血”。只要方向合理，你可以长期保持自我驱动，默默输出成果。你更在意是否有成长和突破，而不是是否被频繁表扬。"
+              }
+            ]
+          },
+          "sort_order": 50,
+          "is_enabled": true
+        },
+        {
+          "section_key": "career.weaknesses",
+          "render_variant": "bullets",
+          "body_md": null,
+          "body_html": null,
+          "payload_json": {
+            "items": [
+              {
+                "title": "沟通容易显得过于直接或冷淡",
+                "body": "当你在讲逻辑和事实时，可能忽略了别人的情绪接受度，从而被误解为“强势”“不好相处”，这会影响一些关键合作关系。"
+              },
+              {
+                "title": "对低效和无脑流程极度不耐",
+                "body": "面对反复、无意义的流程和拍脑袋决策，你会很快失去耐心，内心疯狂吐槽，甚至开始“抽离”，只保留最低限度的投入。"
+              },
+              {
+                "title": "不擅长展示自己的价值",
+                "body": "你可能觉得“做好事情本身就足够说明问题”，而忽略了必要的可视化与沟通，导致真正的贡献和思考深度，经常被上级或团队低估。"
+              },
+              {
+                "title": "对情绪与人性的复杂度估计不足",
+                "body": "你非常相信理性和规则，有时会低估情绪、文化与权力结构的影响力，从而在组织博弈中吃亏。"
+              }
+            ]
+          },
+          "sort_order": 60,
+          "is_enabled": true
+        },
+        {
+          "section_key": "career.preferred_roles",
+          "render_variant": "preferred_role_list",
+          "body_md": null,
+          "body_html": null,
+          "payload_json": {
+            "intro": "以下方向并不是 INTJ-A 的唯一选择，但更容易承载你的战略思维、理性判断和系统搭建能力，可以作为职业探索的参考起点。",
+            "groups": [
+              {
+                "group_title": "战略与决策相关",
+                "description": "需要从全局视角出发，做中长期规划与重大决策的岗位。",
+                "examples": [
+                  "战略规划、业务规划、行业研究",
+                  "投研 / 咨询、创新孵化、并购整合",
+                  "中高层管理、事业部负责人"
+                ]
+              },
+              {
+                "group_title": "技术与系统架构",
+                "description": "强调逻辑、结构与长期可扩展性的领域。",
+                "examples": [
+                  "软件架构师、技术负责人、算法 / 数据相关岗位",
+                  "产品经理（尤其偏中后台、工具类产品）",
+                  "复杂系统的设计与优化岗位"
+                ]
+              },
+              {
+                "group_title": "研究与深度思考型工作",
+                "description": "可以长期钻研一个方向、积累认知并沉淀方法论的岗位。",
+                "examples": [
+                  "学术研究、政策研究、智库类岗位",
+                  "专业顾问、行业分析师",
+                  "需要大量独立思考的创作者"
+                ]
+              },
+              {
+                "group_title": "需要理性与责任感结合的管理岗位",
+                "description": "既要算得清账，又要扛得住压力，需要有人在关键节点做冷静决策的角色。",
+                "examples": [
+                  "运营负责人",
+                  "风险管理 / 合规相关岗位",
+                  "关键项目的总负责人"
+                ]
+              }
+            ],
+            "outro": "真正适合你的工作，通常同时具备几个特征：问题够难、逻辑够深、空间够大、成果可见。不要急着照抄他人的路线，问一句：“在哪个领域，我愿意为更优的系统持续动脑？”"
+          },
+          "sort_order": 70,
+          "is_enabled": true
+        },
+        {
+          "section_key": "career.upgrade_suggestions",
+          "render_variant": "bullets",
+          "body_md": "对 INTJ-A 来说，职场上的关键升级点不只是“更聪明”，而是“让聪明更容易被合作、被看见、被信任”。当你愿意在表达方式与合作体验上多花一点心思，你的影响力会显著放大。",
+          "body_html": null,
+          "payload_json": {
+            "items": [
+              {
+                "title": "影响力 = 正确性 × 可被理解度",
+                "body": "你的方案往往逻辑严密，但如果说法过于抽象或冷硬，别人跟不上你的节奏，效果就会打折。尝试用类比、图示和分步骤说明，把“对的事”变成“大家听得懂、做得到的事”。"
+              },
+              {
+                "title": "信任感 = 能力 × 合作体验",
+                "body": "别人是否愿意长期跟你合作，不只看你有多能干，还看“跟你一起工作舒不舒服”。在提出高标准的同时，多给对方一点缓冲和鼓励，会让你的要求更容易被接受。"
+              },
+              {
+                "title": "话语权 = 价值创造 × 可视化程度",
+                "body": "不要只闷头做事。定期把你的思考框架、关键结论与实际成果整理出来，用简单直观的方式呈现给关键决策者，让他们知道“哪些关键节点是你在扛”。"
+              },
+              {
+                "title": "长期成长 = 专业纵深 × 软技能迭代",
+                "body": "在不断加深专业能力的同时，有意识训练沟通、谈判、带人、跨部门协作等软技能。你的天赋在于逻辑，但真正让你走得更高的，往往是你如何与不那么理性的人共事。"
+              }
+            ]
+          },
+          "sort_order": 80,
+          "is_enabled": true
+        },
+        {
+          "section_key": "growth.summary",
+          "render_variant": "rich_text",
+          "body_md": "对 INTJ-A 来说，成长很少只是“多学几项技能”，而更像是在不断升级自己的操作系统：优化认知模型、打磨决策质量、调整人生策略。\n\n这一章节，会从你的强项、短板，以及能量来源与消耗点几个角度，帮你更清晰地看到：如何在保持锋利的同时，变得更柔韧、更耐久。",
+          "body_html": null,
+          "payload_json": null,
+          "sort_order": 90,
+          "is_enabled": true
+        },
+        {
+          "section_key": "growth.strengths",
+          "render_variant": "bullets",
+          "body_md": null,
+          "body_html": null,
+          "payload_json": {
+            "items": [
+              {
+                "title": "强烈的自我驱动",
+                "body": "你有自己的评判标准，不太需要外界不断督促。只要方向经过你自己的验证，你就能长期、稳定地执行。"
+              },
+              {
+                "title": "深度思考与系统构建能力",
+                "body": "你不满足于记住结论，而是要搞清楚“为什么”。这种习惯让你更容易形成一整套可复用的方法论。"
+              },
+              {
+                "title": "对信息的筛选和整合能力",
+                "body": "在信息爆炸的时代，你能相对冷静地筛掉噪音，对关键数据和一手信息保持敏感，从而做出更高质量的判断。"
+              },
+              {
+                "title": "对自我提升有长线视角",
+                "body": "你愿意为长远能力投资，不会只追求短期回报。你更在意的是“我在成为怎样的人”，而不是“这一两次是不是赢了”。"
+              }
+            ]
+          },
+          "sort_order": 100,
+          "is_enabled": true
+        },
+        {
+          "section_key": "growth.weaknesses",
+          "render_variant": "bullets",
+          "body_md": null,
+          "body_html": null,
+          "payload_json": {
+            "items": [
+              {
+                "title": "对自己要求过高，难以放过自己",
+                "body": "你很少真正满意自己的表现，认为“还能更好”，这在推动你前进的同时，也容易累积隐形压力。"
+              },
+              {
+                "title": "对他人耐心有限",
+                "body": "面对在你看来“逻辑不通”“效率很低”的人，你很难控制内心的批判，进而减少沟通投入，错过一些潜在的合作机会。"
+              },
+              {
+                "title": "对情绪照顾不足",
+                "body": "你可能会低估情绪对自己和他人的影响，把“调整心态”的需求压到很后面，直到身心发出强烈抗议。"
+              },
+              {
+                "title": "容易陷入「只要我对就够了」的圈套",
+                "body": "当你太专注于论证“谁对谁错”时，可能会忽略另一个问题：即便我是对的，这样处理，对关系、对团队真的更好吗？"
+              }
+            ]
+          },
+          "sort_order": 110,
+          "is_enabled": true
+        },
+        {
+          "section_key": "growth.motivators",
+          "render_variant": "premium_teaser",
+          "body_md": "结构清晰的成长路径、可感知的能力提升、以及参与到“真正重要的事情”中，是你最核心的动力来源。越能把日常投入与长远目标连接起来，你越容易保持专注和耐心。",
+          "body_html": null,
+          "payload_json": {
+            "teaser": "结构清晰的成长路径、可感知的能力提升、以及参与到“真正重要的事情”中，是你最核心的动力来源。越能把日常投入与长远目标连接起来，你越容易保持专注和耐心。",
+            "is_premium": true
+          },
+          "sort_order": 120,
+          "is_enabled": true
+        },
+        {
+          "section_key": "growth.drainers",
+          "render_variant": "premium_teaser",
+          "body_md": "长期的低质量沟通、无意义的重复劳动、以及看不到希望的环境，会迅速消耗你的能量。如果你开始频繁想“算了，随便吧”，很可能已经透支了对这个系统的耐心。",
+          "body_html": null,
+          "payload_json": {
+            "teaser": "长期的低质量沟通、无意义的重复劳动、以及看不到希望的环境，会迅速消耗你的能量。如果你开始频繁想“算了，随便吧”，很可能已经透支了对这个系统的耐心。",
+            "is_premium": true
+          },
+          "sort_order": 130,
+          "is_enabled": true
+        },
+        {
+          "section_key": "relationships.summary",
+          "render_variant": "rich_text",
+          "body_md": "在人际世界里，你不像传统意义上的“社交高手”，却更像一位慢热但可靠的长期合伙人。你不会把热情平均分给所有人，而是更愿意在少数重要关系上，投入时间和诚意。\n\n你在关系中最看重的是：彼此是否尊重对方的边界？能不能好好说话、讲道理？我们是不是在互相成就，而不是互相拖累？",
+          "body_html": null,
+          "payload_json": null,
+          "sort_order": 140,
+          "is_enabled": true
+        },
+        {
+          "section_key": "relationships.strengths",
+          "render_variant": "bullets",
+          "body_md": null,
+          "body_html": null,
+          "payload_json": {
+            "items": [
+              {
+                "title": "稳重可靠，不轻易失控",
+                "body": "你不太会在关系里无端发脾气或情绪化翻脸。即便出现问题，你也更倾向于冷静分析、找到解决方案。"
+              },
+              {
+                "title": "尊重对方的独立性",
+                "body": "你不会黏人，也反感控制。你希望彼此都是有自己人生目标的个体，在各自道路上前进，同时选择并肩。"
+              },
+              {
+                "title": "重视长期契合度",
+                "body": "你不会因为一时的新鲜感就贸然投入，更关心价值观、思维方式和生活节奏在长期是否匹配。"
+              },
+              {
+                "title": "愿意为真正重要的人调整自己",
+                "body": "虽然你看起来不太“好说话”，但在意的人提出合理诉求时，你会认真思考如何调整，让关系变得更健康。"
+              }
+            ]
+          },
+          "sort_order": 150,
+          "is_enabled": true
+        },
+        {
+          "section_key": "relationships.weaknesses",
+          "render_variant": "bullets",
+          "body_md": null,
+          "body_html": null,
+          "payload_json": {
+            "items": [
+              {
+                "title": "表达关心的方式偏“功能化”",
+                "body": "你往往用“帮对方解决问题”的方式表达在乎，却不一定说出那句简单的“我其实很担心你”。有时对方需要的是情感陪伴，而不是方案。"
+              },
+              {
+                "title": "不擅长处理突发的情绪爆发",
+                "body": "当别人情绪很激烈时，你可能会瞬间“断联”，不知道该如何回应，从而显得疏离或冷漠。"
+              },
+              {
+                "title": "很难主动示弱与求助",
+                "body": "你习惯自己扛，不愿在别人面前暴露脆弱，久而久之容易形成“别人都以为你不需要被照顾”的错觉。"
+              },
+              {
+                "title": "倾向于过早在心里“判死刑”",
+                "body": "一旦你觉得某段关系“欠缺逻辑”“没法沟通”，就可能迅速在心里抽离，不再投入修复的努力，这让一些关系来不及被好好解释就结束了。"
+              }
+            ]
+          },
+          "sort_order": 160,
+          "is_enabled": true
+        },
+        {
+          "section_key": "relationships.rel_advantages",
+          "render_variant": "premium_teaser",
+          "body_md": "当关系足够安全、对方足够成熟时，你会成为极其值得信赖的伙伴——稳、靠谱、有底线、能一起做长期规划。你不善甜言蜜语，却擅长在关键节点给出清醒的判断与实质的支持。",
+          "body_html": null,
+          "payload_json": {
+            "teaser": "当关系足够安全、对方足够成熟时，你会成为极其值得信赖的伙伴——稳、靠谱、有底线、能一起做长期规划。你不善甜言蜜语，却擅长在关键节点给出清醒的判断与实质的支持。",
+            "is_premium": true
+          },
+          "sort_order": 170,
+          "is_enabled": true
+        },
+        {
+          "section_key": "relationships.rel_risks",
+          "render_variant": "premium_teaser",
+          "body_md": "如果长期处在“我在讲道理，对方在发情绪”的关系模式里，你会渐渐对亲密关系本身失去耐心，甚至倾向于“一个人更省事”。学会识别哪些关系值得继续投资，哪些需要礼貌退出，是 INTJ-A 很重要的一课。",
+          "body_html": null,
+          "payload_json": {
+            "teaser": "如果长期处在“我在讲道理，对方在发情绪”的关系模式里，你会渐渐对亲密关系本身失去耐心，甚至倾向于“一个人更省事”。学会识别哪些关系值得继续投资，哪些需要礼貌退出，是 INTJ-A 很重要的一课。",
+            "is_premium": true
+          },
+          "sort_order": 180,
+          "is_enabled": true
+        }
+      ],
+      "seo_overrides": {
+        "seo_title": "INTJ-A 建筑师型",
+        "seo_description": "你像一位安静的战略家：不爱站在舞台中央，却在心里推演过无数种未来。你更在意“事情能不能按最优解运行”，而不是讨好当下的情绪。表面冷静疏离，其实你对「更好的世界」有着极高且清醒的期待。",
+        "canonical_url": null,
+        "og_title": "INTJ-A 理性远见者",
+        "og_description": "你像一位安静的战略家：不爱站在舞台中央，却在心里推演过无数种未来。你更在意“事情能不能按最优解运行”，而不是讨好当下的情绪。表面冷静疏离，其实你对「更好的世界」有着极高且清醒的期待。",
+        "og_image_url": null,
+        "twitter_title": "INTJ-A 理性远见者",
+        "twitter_description": "你像一位安静的战略家：不爱站在舞台中央，却在心里推演过无数种未来。你更在意“事情能不能按最优解运行”，而不是讨好当下的情绪。表面冷静疏离，其实你对「更好的世界」有着极高且清醒的期待。",
+        "twitter_image_url": null,
+        "robots": null,
+        "jsonld_overrides_json": null
+      }
+    },
+    {
+      "runtime_type_code": "INTJ-T",
+      "canonical_type_code": "INTJ",
+      "variant_code": "T",
+      "is_published": true,
+      "published_at": "2026-03-17T00:00:00Z",
+      "profile_overrides": {
+        "type_name": "建筑师型",
+        "nickname": "冷静策划者",
+        "rarity_text": "约 1–3%",
+        "keywords_json": [
+          "战略思维",
+          "独立判断",
+          "深度思考",
+          "系统规划",
+          "自我要求高",
+          "长期主义"
+        ],
+        "hero_summary_md": "你像一位安静搭建结构的建筑师：不爱站在聚光灯下，却习惯在脑海里推演十步之后的世界。你很少被情绪裹挟，更习惯用逻辑、结构和长期布局来回答人生的问题——“现在的选择，会把我带往哪里？”",
+        "hero_summary_html": null
+      },
+      "section_overrides": [
+        {
+          "section_key": "letters_intro",
+          "render_variant": "letters_intro",
+          "body_md": null,
+          "body_html": null,
+          "payload_json": {
+            "headline": "内向 · 直觉 · 思维 · 规划 · 动荡型｜理性与远见兼具的“冷静策划者”",
+            "letters": [
+              {
+                "letter": "I",
+                "title": "内向（I）",
+                "description": "让你更习惯在安静的空间里思考与推演。人际互动可以有，但如果太吵、太肤浅，你会迅速“掉线”，更愿意一个人待着把逻辑理顺。"
+              },
+              {
+                "letter": "N",
+                "title": "直觉（N）",
+                "description": "让你天然关注趋势、模式和底层逻辑。你会问的是：“这背后真正的规律是什么？”比起眼前的小利，你更在意长远的结构与可能性。"
+              },
+              {
+                "letter": "T",
+                "title": "思维（T）",
+                "description": "让你在做决定时优先考虑逻辑、证据和效率。你可以理解情绪的存在，但不会让情绪凌驾于“事情该怎么做”之上。"
+              },
+              {
+                "letter": "J",
+                "title": "规划（J）",
+                "description": "让你不满足于“想到”，而是想“做到并且做好”。你习惯设定目标、拆解路径，用清晰的结构与节奏推动计划落地。"
+              },
+              {
+                "letter": "T",
+                "title": "动荡型（-T）",
+                "description": "让你对自己标准很高，做完之后还会反思：“有没有更好的解法？” 这种自我审查既是你不断进化的引擎，也是你压力的源头。"
+              }
+            ]
+          },
+          "sort_order": 10,
+          "is_enabled": true
+        },
+        {
+          "section_key": "overview",
+          "render_variant": "rich_text",
+          "body_md": "在费马心理的逻辑模型里，INTJ-T 常被视作“冷静而固执的长期主义者”。你习惯先退一步看全局，再决定要不要出手；一旦决定了，你会坚定而专注地走下去，不太在意旁人的质疑。\n\n对你来说，最舒服的状态是：有一个逻辑自洽的长期目标，一套被你认可的路径，以及足够的空间，让你按照自己的节奏去迭代和优化。\n\n当环境混乱、决策随意、大家只在意眼前的小利时，你会本能地产生距离感，甚至选择退出。你宁可慢一点、少一点，也不愿在一套你认为“短视、低效”的系统里消耗自己。",
+          "body_html": null,
+          "payload_json": null,
+          "sort_order": 20,
+          "is_enabled": true
+        },
+        {
+          "section_key": "trait_overview",
+          "render_variant": "trait_dimension_grid",
+          "body_md": "建议与小程序中 5 条维度进度条搭配展示：外向 / 内向｜天马行空 / 求真务实｜情感细腻 / 理性思考｜运筹帷幄 / 随机应变｜情绪易波动 / 自信果断。",
+          "body_html": null,
+          "payload_json": {
+            "summary": "建议与小程序中 5 条维度进度条搭配展示：外向 / 内向｜天马行空 / 求真务实｜情感细腻 / 理性思考｜运筹帷幄 / 随机应变｜情绪易波动 / 自信果断。",
+            "dimensions": [
+              {
+                "id": "EI",
+                "name": "外向倾向",
+                "label": "外向倾向",
+                "axis_left": "外向",
+                "axis_right": "内向",
+                "summary": "明显偏内向",
+                "description": "你更像是那个在角落安静观察的人，而不是主动社交的中心人物。你不排斥交流，但更偏好少而精、对话有内容的互动。长时间的社交会让你感觉被“掏空”，需要独处来充电。"
+              },
+              {
+                "id": "SN",
+                "name": "心智模式",
+                "label": "心智模式",
+                "axis_left": "天马行空",
+                "axis_right": "求真务实",
+                "summary": "偏“天马行空”，但带结构",
+                "description": "你很擅长在信息中抽象出模型和规律，看问题时习惯抬高一个维度思考：“如果从系统层面看，这意味着什么？” 你的“天马行空”并不是随意乱想，而是围绕一套自洽逻辑展开的推演。"
+              },
+              {
+                "id": "TF",
+                "name": "情绪天性",
+                "label": "情绪天性",
+                "axis_left": "情感细腻",
+                "axis_right": "理性思考",
+                "summary": "明显偏“理性思考”",
+                "description": "你倾向于用分析替代情绪，用推理替代立刻的反应。你并非没有感情，只是更习惯先压一压，再问自己：“现在最合理的选择是什么？”在别人眼中，你可能有点“冷”或“不近人情”。"
+              },
+              {
+                "id": "JP",
+                "name": "应对方式",
+                "label": "应对方式",
+                "axis_left": "运筹帷幄",
+                "axis_right": "随机应变",
+                "summary": "偏“运筹帷幄”",
+                "description": "面对重要事情，你很少完全即兴，而是倾向于先搭个框架：目标在哪里、关键节点是什么、哪些变量要重点关注。一旦结构搭好，你反而能在框架内灵活调整。"
+              },
+              {
+                "id": "AT",
+                "name": "身份特征",
+                "label": "身份特征",
+                "axis_left": "情绪易波动",
+                "axis_right": "自信果断",
+                "summary": "理性外表下的“内心拉扯”",
+                "description": "动荡型的你，外表看似笃定，内心却常在给自己挑错：“这个思路是不是还不够优雅？” 你会不断更新自己的认知体系，也不断用更高标准审视自己——这成就了你，也容易让你陷入“永远不够好”的疲惫感。"
+              }
+            ]
+          },
+          "sort_order": 30,
+          "is_enabled": true
+        },
+        {
+          "section_key": "career.summary",
+          "render_variant": "rich_text",
+          "body_md": "你的职业选择，通常会围绕“复杂问题、长期价值和高自主度”展开。只要这份工作能让你持续学习、优化系统、搭建结构，你就愿意长时间深耕。\n\n纯执行、无思考空间、充满低效会议和情绪内耗的环境，会迅速消耗你的耐心，让你开始寻找退出通道。\n\n相反，当一份工作给予你足够的决策参与度、复杂问题的挑战感，以及靠近真实影响力的机会时，你会进入高度专注的“长期投入模式”。",
+          "body_html": null,
+          "payload_json": null,
+          "sort_order": 40,
+          "is_enabled": true
+        },
+        {
+          "section_key": "career.advantages",
+          "render_variant": "bullets",
+          "body_md": null,
+          "body_html": null,
+          "payload_json": {
+            "items": [
+              {
+                "title": "战略视角强，善于看远",
+                "body": "你很少只盯眼前的得失，而是会问：“这条路的尽头是什么？” 你擅长在混乱信息中抽象出趋势与关键路径，为团队提供方向性判断。"
+              },
+              {
+                "title": "逻辑严密，善于搭建系统",
+                "body": "你会本能地把问题拆解成模块和流程，思考怎样在结构层面优化效率，而不是只在表层“救火”。你对规则、机制和系统性改进有天然兴趣。"
+              },
+              {
+                "title": "高度自驱，不需要被盯着干活",
+                "body": "一旦你认可了目标，你会自发去查资料、搭方案、做推演，而不是等任务派发。你对“做得好不好”比“有没有做完”更在意。"
+              },
+              {
+                "title": "独立判断，不轻易随大流",
+                "body": "你不容易被情绪带偏，也不会因为多数人都这么想就放弃自己的分析。你习惯在心里默默算一遍，再决定支不支持这个方向。"
+              }
+            ]
+          },
+          "sort_order": 50,
+          "is_enabled": true
+        },
+        {
+          "section_key": "career.weaknesses",
+          "render_variant": "bullets",
+          "body_md": null,
+          "body_html": null,
+          "payload_json": {
+            "items": [
+              {
+                "title": "沟通风格容易显得冷或难接近",
+                "body": "你说话习惯直奔结论、不绕弯子，这在你看来是高效，在他人眼里可能是“不近人情”“不好相处”，从而影响合作氛围。"
+              },
+              {
+                "title": "容易对低效与愚蠢“零容忍”",
+                "body": "面对重复错误、推卸责任或明显不合理的流程，你会在心里迅速打分并降权，很难再提起积极协作的兴趣。"
+              },
+              {
+                "title": "不擅长展示成果与情绪",
+                "body": "你习惯用结果说话，却不太主动“讲故事”或表达过程中的思考，这会让别人低估你的投入度与难度，也降低你的可见价值。"
+              },
+              {
+                "title": "对自己和他人都偏苛刻",
+                "body": "你对自己有一套很高的标准，也容易用类似标准评判他人。一旦对方达不到，你的耐心和信任感会迅速下降。"
+              }
+            ]
+          },
+          "sort_order": 60,
+          "is_enabled": true
+        },
+        {
+          "section_key": "career.preferred_roles",
+          "render_variant": "preferred_role_list",
+          "body_md": null,
+          "body_html": null,
+          "payload_json": {
+            "intro": "以下方向并不是 INTJ-T 的“唯一解”，而是更可能让你感到“值得长期投入”的领域，你可以把它们当作探索起点：",
+            "groups": [
+              {
+                "group_title": "策略与规划相关",
+                "description": "需要从复杂信息中抽象出方向与路径的岗位。",
+                "examples": [
+                  "战略规划、商业分析、咨询顾问",
+                  "产品经理、增长策略、数据驱动决策岗位",
+                  "投研、资产配置、宏观或行业研究"
+                ]
+              },
+              {
+                "group_title": "技术与工程领域",
+                "description": "逻辑性强、系统感强、需要长期钻研的赛道。",
+                "examples": [
+                  "软件开发、架构设计、算法 / 数据科学",
+                  "工程设计、工业优化、研发类岗位",
+                  "偏底层逻辑与系统搭建的技术岗位"
+                ]
+              },
+              {
+                "group_title": "独立度高的专业型角色",
+                "description": "允许你按照自己的节奏深入研究的职业路径。",
+                "examples": [
+                  "研究人员、学术路线（理工 / 社科均可）",
+                  "专业顾问、自由职业的高技能专家",
+                  "内容创作者（深度分析类）、知识服务者"
+                ]
+              },
+              {
+                "group_title": "小团队 / 创业环境中的“幕后策划者”",
+                "description": "不一定要当台前的人，但适合在背后搭框架、定方向、控质量。",
+                "examples": [
+                  "联合创始人 / 合伙人",
+                  "内部智囊、PMO、关键项目 owner"
+                ]
+              }
+            ],
+            "outro": "对 INTJ-T 来说，比职位名称更重要的，是这份工作是否允许你：持续精进、影响关键决策、在系统层面做优化，并在长期内看到自己搭建的结构真实运转起来。"
+          },
+          "sort_order": 70,
+          "is_enabled": true
+        },
+        {
+          "section_key": "career.upgrade_suggestions",
+          "render_variant": "bullets",
+          "body_md": "很多 INTJ-T 的职业瓶颈，不在“硬实力不够”，而在“如何让别人更愿意跟你一起干”。当你的逻辑与远见能被更多人看见、理解并愿意配合执行时，你的影响力才真正被放大。\n\n你可以把下面这几条，当作自己的职场调优公式。",
+          "body_html": null,
+          "payload_json": {
+            "items": [
+              {
+                "title": "影响力 = 判断力 × 传达度",
+                "body": "判断对，并不代表别人能理解你的判断。刻意练习把复杂思考讲成三段话：现状 → 结论 → 路线。你的观点一旦可被理解，才有机会被采纳。"
+              },
+              {
+                "title": "团队质量 = 标准清晰 × 反馈机制",
+                "body": "与其在心里嫌弃，不如在一开始就把标准讲清楚，在过程中给及时反馈。你不必降低标准，而是要把标准“外显化”，让系统而不是情绪去过滤低质量。"
+              },
+              {
+                "title": "职场可见度 = 结果 × 叙事",
+                "body": "保留一个“成果与思考备忘录”，记录关键项目中的决策点、你做的取舍和带来的影响。复盘或汇报时，适当讲出这部分过程，让别人看到的不只是结果，还有你作为“关键变量”的那一段。"
+              },
+              {
+                "title": "可持续专注 = 深度工作 × 有意识休息",
+                "body": "你擅长长时间沉浸，但也容易忽略身体和情绪的极限。为自己设定“深度工作时段”和“强制下线时段”，把休息当作优化大脑算力的一部分，而不是浪费时间。"
+              }
+            ]
+          },
+          "sort_order": 80,
+          "is_enabled": true
+        },
+        {
+          "section_key": "growth.summary",
+          "render_variant": "rich_text",
+          "body_md": "对 INTJ-T 来说，成长很少是“被推着走”，而更多是“自己发现问题，自己升级系统”。你会不断重构自己的世界观与方法论，希望用更优雅、更高效的方式应对人生。\n\n这一章节，会从你的强项、短板，以及能量的来源与流失角度，帮你看到：如何在保持锋利思维的同时，让自己活得更轻松、更有人味。",
+          "body_html": null,
+          "payload_json": null,
+          "sort_order": 90,
+          "is_enabled": true
+        },
+        {
+          "section_key": "growth.strengths",
+          "render_variant": "bullets",
+          "body_md": null,
+          "body_html": null,
+          "payload_json": {
+            "items": [
+              {
+                "title": "喜欢自我迭代",
+                "body": "你很少原地踏步，会定期检视自己的观念、策略和习惯。一旦发现更优解，你愿意推翻旧设定，重新搭建。"
+              },
+              {
+                "title": "能够长期专注",
+                "body": "只要看好一个方向，你可以在很长时间里保持耐心投入，不被短期噪音轻易干扰，这让你有机会在某些领域达到深度。"
+              },
+              {
+                "title": "善于从失败中抽象经验",
+                "body": "失败对你来说更像一份数据样本。情绪过去之后，你会冷静地分析“哪一步出了问题”，并把结论写进自己的决策系统。"
+              },
+              {
+                "title": "不轻易妥协于环境",
+                "body": "如果环境与你的价值观和底层逻辑严重冲突，你宁可退出，也不愿随波逐流。这让你有机会找到更适配自己的舞台。"
+              }
+            ]
+          },
+          "sort_order": 100,
+          "is_enabled": true
+        },
+        {
+          "section_key": "growth.weaknesses",
+          "render_variant": "bullets",
+          "body_md": null,
+          "body_html": null,
+          "payload_json": {
+            "items": [
+              {
+                "title": "容易活在“脑内模型”里",
+                "body": "你有时会过于相信自己的推演，而忽略现实世界的细节和人心复杂度，导致计划在落地时出现偏差。"
+              },
+              {
+                "title": "对情绪和“非理性”耐受度低",
+                "body": "当别人无法用逻辑讲清楚感受，或者只是“就是觉得不舒服”时，你会本能地烦躁，甚至选择抽离。"
+              },
+              {
+                "title": "对自己几乎没有“宽容模式”",
+                "body": "你很少对自己说“这样已经很好了”，更多的是“还可以再优化”，长期下来容易陷入慢性消耗。"
+              },
+              {
+                "title": "低估连接与支持的价值",
+                "body": "你习惯一个人抗，但事实是：一些情绪和困境，如果有人一起分担和见证，会轻松很多。你并不是非得孤军奋战。"
+              }
+            ]
+          },
+          "sort_order": 110,
+          "is_enabled": true
+        },
+        {
+          "section_key": "growth.motivators",
+          "render_variant": "premium_teaser",
+          "body_md": "高质量的挑战、清晰可见的能力提升、以及在关键问题上的真实影响力，会极大激发你的投入感。你越能看到“这件事逻辑上值得做”，就越愿意在其中长期下注。",
+          "body_html": null,
+          "payload_json": {
+            "teaser": "高质量的挑战、清晰可见的能力提升、以及在关键问题上的真实影响力，会极大激发你的投入感。你越能看到“这件事逻辑上值得做”，就越愿意在其中长期下注。",
+            "is_premium": true
+          },
+          "sort_order": 120,
+          "is_enabled": true
+        },
+        {
+          "section_key": "growth.drainers",
+          "render_variant": "premium_teaser",
+          "body_md": "无休止的低效沟通、频繁被打断的深度工作、以及价值观严重不匹配的合作对象，会快速榨干你的能量。学会识别并有意识地减少这些场景，是你成年后很重要的一课。",
+          "body_html": null,
+          "payload_json": {
+            "teaser": "无休止的低效沟通、频繁被打断的深度工作、以及价值观严重不匹配的合作对象，会快速榨干你的能量。学会识别并有意识地减少这些场景，是你成年后很重要的一课。",
+            "is_premium": true
+          },
+          "sort_order": 130,
+          "is_enabled": true
+        },
+        {
+          "section_key": "relationships.summary",
+          "render_variant": "rich_text",
+          "body_md": "在人际关系世界里，你更像一位“安静可靠的策划者”。你不擅长热闹的社交场，但在少数信任的人面前，你会展现出意想不到的幽默感、洞察力和责任感。\n\n你看重的是：这段关系是否真诚、是否尊重彼此的边界、是否允许双方在各自的道路上成长，而不是强迫对方贴合自己的节奏。",
+          "body_html": null,
+          "payload_json": null,
+          "sort_order": 140,
+          "is_enabled": true
+        },
+        {
+          "section_key": "relationships.strengths",
+          "render_variant": "bullets",
+          "body_md": null,
+          "body_html": null,
+          "payload_json": {
+            "items": [
+              {
+                "title": "稳定而可靠",
+                "body": "一旦你认定一个人值得信任，你会在关键时刻站在对方身边，用实际行动支持，而不是只停留在口头安慰。"
+              },
+              {
+                "title": "能提供深度视角",
+                "body": "你不太会敷衍式地说“别想太多”，而是从结构和长期影响的角度，帮对方重新看待问题，提供冷静的参照系。"
+              },
+              {
+                "title": "尊重边界，不喜欢控制他人",
+                "body": "你不喜欢也不擅长情绪绑架，更倾向于：把自己的想法讲清楚，再让对方自己做选择。你认为真正好的关系，是互相尊重自由的。"
+              },
+              {
+                "title": "在少数关系里投入很深",
+                "body": "你不会把热情平均分给所有人，而是把注意力集中在少数重要的人身上，这让这些关系有机会发展出罕见的深度与信任感。"
+              }
+            ]
+          },
+          "sort_order": 150,
+          "is_enabled": true
+        },
+        {
+          "section_key": "relationships.weaknesses",
+          "render_variant": "bullets",
+          "body_md": null,
+          "body_html": null,
+          "payload_json": {
+            "items": [
+              {
+                "title": "不善于表达当下感受",
+                "body": "你更习惯在脑内处理情绪，而不是当场说出来，这会让对方误以为“你没感觉”“你不在乎”。"
+              },
+              {
+                "title": "容易显得疏离或走神",
+                "body": "当话题在你看来缺乏深度或意义时，你会迅速失去兴趣，注意力转向自己的思考世界，对方则会感到被冷落。"
+              },
+              {
+                "title": "难以接受他人的“非理性”反应",
+                "body": "在冲突中，如果对方只是在情绪爆发而谈不上逻辑，你很可能直接“下线”，冷处理问题，这会被解读为冷漠。"
+              },
+              {
+                "title": "很少主动求助或示弱",
+                "body": "你习惯自己扛问题，很少向亲近的人寻求支持。这会让对方觉得你“不需要被照顾”，从而错过很多本可以被关怀的时刻。"
+              }
+            ]
+          },
+          "sort_order": 160,
+          "is_enabled": true
+        },
+        {
+          "section_key": "relationships.rel_advantages",
+          "render_variant": "premium_teaser",
+          "body_md": "当你遇到同样重视理性与成长的伙伴时，你会成为对方极其重要的“长期合伙人”：一起规划、一起迭代、一起升级彼此的人生系统。这种关系的厚度，远超日常寒暄式的社交。",
+          "body_html": null,
+          "payload_json": {
+            "teaser": "当你遇到同样重视理性与成长的伙伴时，你会成为对方极其重要的“长期合伙人”：一起规划、一起迭代、一起升级彼此的人生系统。这种关系的厚度，远超日常寒暄式的社交。",
+            "is_premium": true
+          },
+          "sort_order": 170,
+          "is_enabled": true
+        },
+        {
+          "section_key": "relationships.rel_risks",
+          "render_variant": "premium_teaser",
+          "body_md": "如果你长期处在“只给建议、不谈感受”的模式里，身边人会逐渐只把你当成“工具型智囊”，而不是一个有情绪、有需要的真实人。这既会让你孤立，也会让关系失去温度。",
+          "body_html": null,
+          "payload_json": {
+            "teaser": "如果你长期处在“只给建议、不谈感受”的模式里，身边人会逐渐只把你当成“工具型智囊”，而不是一个有情绪、有需要的真实人。这既会让你孤立，也会让关系失去温度。",
+            "is_premium": true
+          },
+          "sort_order": 180,
+          "is_enabled": true
+        }
+      ],
+      "seo_overrides": {
+        "seo_title": "INTJ-T 建筑师型",
+        "seo_description": "你像一位安静搭建结构的建筑师：不爱站在聚光灯下，却习惯在脑海里推演十步之后的世界。你很少被情绪裹挟，更习惯用逻辑、结构和长期布局来回答人生的问题——“现在的选择，会把我带往哪里？”",
+        "canonical_url": null,
+        "og_title": "INTJ-T 冷静策划者",
+        "og_description": "你像一位安静搭建结构的建筑师：不爱站在聚光灯下，却习惯在脑海里推演十步之后的世界。你很少被情绪裹挟，更习惯用逻辑、结构和长期布局来回答人生的问题——“现在的选择，会把我带往哪里？”",
+        "og_image_url": null,
+        "twitter_title": "INTJ-T 冷静策划者",
+        "twitter_description": "你像一位安静搭建结构的建筑师：不爱站在聚光灯下，却习惯在脑海里推演十步之后的世界。你很少被情绪裹挟，更习惯用逻辑、结构和长期布局来回答人生的问题——“现在的选择，会把我带往哪里？”",
+        "twitter_image_url": null,
+        "robots": null,
+        "jsonld_overrides_json": null
+      }
+    },
+    {
+      "runtime_type_code": "INTP-A",
+      "canonical_type_code": "INTP",
+      "variant_code": "A",
+      "is_published": true,
+      "published_at": "2026-03-17T00:00:00Z",
+      "profile_overrides": {
+        "type_name": "逻辑学家型",
+        "nickname": "理性解构者",
+        "rarity_text": "约 2–4%",
+        "keywords_json": [
+          "独立思考",
+          "理性分析",
+          "好奇心",
+          "系统化",
+          "喜欢拆解",
+          "冷静自信"
+        ],
+        "hero_summary_md": "你像一台安静却高速运转的「思考引擎」：表面云淡风轻，内心不断拆解世界的规则与漏洞。你不善于热闹的表演，却擅长用一个清晰的模型、一个犀利的问题，让别人突然安静下来，重新思考原本习以为常的东西。",
+        "hero_summary_html": null
+      },
+      "section_overrides": [
+        {
+          "section_key": "letters_intro",
+          "render_variant": "letters_intro",
+          "body_md": null,
+          "body_html": null,
+          "payload_json": {
+            "headline": "内向 · 直觉 · 思维 · 感知 · 自信型｜享受拆解世界规则的“理性解构者”",
+            "letters": [
+              {
+                "letter": "I",
+                "title": "内向（I）",
+                "description": "让你更习惯在自己的世界里思考与打磨想法。社交可以有，但必须有限度；真正让你恢复能量的，是安静的独处与深度思考。"
+              },
+              {
+                "letter": "N",
+                "title": "直觉（N）",
+                "description": "让你天然关注底层逻辑、趋势和抽象概念。相比眼前的琐碎细节，你更在意的是：这套系统背后的原理是什么？能否被改写？"
+              },
+              {
+                "letter": "T",
+                "title": "思维（T）",
+                "description": "让你在判断问题时优先看重「是否合理」而非「是否好相处」。你会下意识把情绪噪音滤掉，只保留事实与推理链条。"
+              },
+              {
+                "letter": "P",
+                "title": "感知（P）",
+                "description": "让你讨厌被过度规划和僵硬流程束缚，更享受在开放的空间里自由探索各种可能性，保留“先看看再说”的弹性。"
+              },
+              {
+                "letter": "A",
+                "title": "自信型（-A）",
+                "description": "让你在大多数时候保持冷静从容，相信自己的判断与逻辑。你不太会因为外界评价就彻底动摇，更愿意用时间和事实来验证自己的思路。"
+              }
+            ]
+          },
+          "sort_order": 10,
+          "is_enabled": true
+        },
+        {
+          "section_key": "overview",
+          "render_variant": "rich_text",
+          "body_md": "在费马心理的逻辑模型里，INTP-A 往往被视作“安静却锋利的理性解构者”。你不一定爱说大道理，但一旦开口，往往直指问题的核心假设。你习惯从系统层面看世界，用模型、结构和推理去理解一切。\n\n对你来说，最舒服的状态是：有足够的认知自由、一块可以任意实验的思维沙盘，以及几个能听得懂你抽象比喻的人。你不害怕复杂，反而会因为问题够难、够新鲜而兴奋。\n\n你的人生追求，很少停留在“照做就好”，而更像是在寻找：有没有更优雅、更高效、更有逻辑美感的解法。",
+          "body_html": null,
+          "payload_json": null,
+          "sort_order": 20,
+          "is_enabled": true
+        },
+        {
+          "section_key": "trait_overview",
+          "render_variant": "trait_dimension_grid",
+          "body_md": "建议与小程序中 5 条维度进度条搭配展示：外向 / 内向｜天马行空 / 求真务实｜情感细腻 / 理性思考｜运筹帷幄 / 随机应变｜情绪易波动 / 自信果断。",
+          "body_html": null,
+          "payload_json": {
+            "summary": "建议与小程序中 5 条维度进度条搭配展示：外向 / 内向｜天马行空 / 求真务实｜情感细腻 / 理性思考｜运筹帷幄 / 随机应变｜情绪易波动 / 自信果断。",
+            "dimensions": [
+              {
+                "id": "EI",
+                "name": "外向倾向",
+                "label": "外向倾向",
+                "axis_left": "外向",
+                "axis_right": "内向",
+                "summary": "明显偏内向",
+                "description": "你更习惯在脑子里开会，而不是在群聊里刷存在感。长期高密度社交会让你感觉「带宽被占用」，需要独处来重启系统。真正重要的关系，对你来说是少而精，而不是多而广。"
+              },
+              {
+                "id": "SN",
+                "name": "心智模式",
+                "label": "心智模式",
+                "axis_left": "天马行空",
+                "axis_right": "求真务实",
+                "summary": "偏“天马行空”",
+                "description": "你大部分时间都在抽象层面思考问题：概念、框架、假设、逻辑链……往往比具体执行更让你兴奋。你擅长问出那句：“如果我们把前提改掉，会发生什么？”"
+              },
+              {
+                "id": "TF",
+                "name": "情绪天性",
+                "label": "情绪天性",
+                "axis_left": "情感细腻",
+                "axis_right": "理性思考",
+                "summary": "明显偏“理性思考”",
+                "description": "你倾向于先分析，再感受。面对他人的情绪，你可能会本能地开始拆解问题，而不是先给拥抱。在你看来，“帮你找到好解法”本身就是一种关心。"
+              },
+              {
+                "id": "JP",
+                "name": "应对方式",
+                "label": "应对方式",
+                "axis_left": "运筹帷幄",
+                "axis_right": "随机应变",
+                "summary": "偏“随机应变”",
+                "description": "你不太喜欢被写死的时间表，更偏爱在开放环境中边探索边修正路径。你会准备多个理论方案，但真正实施时，常常根据现场情况灵活调整。"
+              },
+              {
+                "id": "AT",
+                "name": "身份特征",
+                "label": "身份特征",
+                "axis_left": "情绪易波动",
+                "axis_right": "自信果断",
+                "summary": "略偏“自信果断”",
+                "description": "作为自信型 INTP，你通常不会因为一两句质疑就全盘否定自己。你愿意听反对意见，但会先在脑内过一遍逻辑验证，而不是立刻情绪化反应。真正让你动摇的，是逻辑上站不住脚，而不是对方声音有多大。"
+              }
+            ]
+          },
+          "sort_order": 30,
+          "is_enabled": true
+        },
+        {
+          "section_key": "career.summary",
+          "render_variant": "rich_text",
+          "body_md": "你的职业成就感，很大一部分来自：有没有足够的思考空间，问题本身值不值得解，以及解法是否优雅。有挑战、有难度、有创新空间的工作，更容易点燃你的兴趣。\n\n你不适合长期做高度重复、纯执行、缺乏思考价值的事务工作；当一份工作只剩下「按流程点按钮」时，你的注意力就会自然逃离。\n\n相反，当一份工作允许你：搭建模型、优化系统、拆解复杂问题、用新思路重写旧规则时，你就会进入高度专注的「心流状态」。",
+          "body_html": null,
+          "payload_json": null,
+          "sort_order": 40,
+          "is_enabled": true
+        },
+        {
+          "section_key": "career.advantages",
+          "render_variant": "bullets",
+          "body_md": null,
+          "body_html": null,
+          "payload_json": {
+            "items": [
+              {
+                "title": "逻辑与结构化能力强",
+                "body": "你擅长在信息混乱时快速抓住关键变量，把复杂问题拆成几个可管理的模块，用清晰的逻辑链条说服他人。"
+              },
+              {
+                "title": "善于发现系统漏洞与优化点",
+                "body": "你本能地会去找现有流程、产品或策略中的「不合理之处」，并提出更高效、更优雅的解决方案，是天生的“系统重构者”。"
+              },
+              {
+                "title": "独立研究与自驱学习能力突出",
+                "body": "只要问题足够有趣，你可以在没有太多外界督促的情况下，自己查资料、搭实验、做验证，逐步逼近更好的答案。"
+              },
+              {
+                "title": "情绪稳定，适合处理复杂决策",
+                "body": "在高压或复杂场景中，你通常不会被情绪裹挟，更习惯拉高视角看全局，用冷静的推理辅助决策。"
+              }
+            ]
+          },
+          "sort_order": 50,
+          "is_enabled": true
+        },
+        {
+          "section_key": "career.weaknesses",
+          "render_variant": "bullets",
+          "body_md": null,
+          "body_html": null,
+          "payload_json": {
+            "items": [
+              {
+                "title": "容易卡在「想得太多，动手太晚」",
+                "body": "你会花大量时间优化思路、打磨模型，却可能推迟真正落地的时间，导致好想法停留在草稿阶段。"
+              },
+              {
+                "title": "对「低效沟通」容忍度极低",
+                "body": "冗长会议、模糊指令、反复无效讨论会让你非常消耗，一旦这种情况反复出现，你可能会在心理上“退出”协作。"
+              },
+              {
+                "title": "表达风格容易显得过于犀利或冷淡",
+                "body": "你习惯直接指出问题假设的漏洞，却可能忽略场合和对方感受，让别人觉得你“不近人情”或“太难相处”。"
+              },
+              {
+                "title": "不爱「管理细节」，容易在执行阶段掉线",
+                "body": "你对宏观结构和关键决策更感兴趣，对后续繁琐的跟进和维护容易失去耐心，需要有人和你搭配补足这一块。"
+              }
+            ]
+          },
+          "sort_order": 60,
+          "is_enabled": true
+        },
+        {
+          "section_key": "career.preferred_roles",
+          "render_variant": "preferred_role_list",
+          "body_md": null,
+          "body_html": null,
+          "payload_json": {
+            "intro": "下面这些并不是唯一适合 INTP-A 的岗位，而是几类更容易让你感到“有意思、值得深挖”的方向，可以当作职业探索的参考起点。",
+            "groups": [
+              {
+                "group_title": "研究与策略相关",
+                "description": "可以长期钻研、搭建模型、输出洞见的工作。",
+                "examples": [
+                  "数据分析 / 数据科学 / 算法研究",
+                  "战略分析、商业咨询、用户研究",
+                  "科研工作者、研究员、智库分析师"
+                ]
+              },
+              {
+                "group_title": "产品与系统设计",
+                "description": "从零到一设计结构与规则的角色。",
+                "examples": [
+                  "产品经理、系统设计师、信息架构师",
+                  "游戏策划 / 规则设计、交互设计",
+                  "流程优化、运营策略设计等岗位"
+                ]
+              },
+              {
+                "group_title": "技术与工程领域",
+                "description": "可以用代码或工程方案把思路变成现实的工作。",
+                "examples": [
+                  "后端开发、架构师、技术研发",
+                  "AI / 算法工程师、工具类产品开发",
+                  "自动化与系统集成相关岗位"
+                ]
+              },
+              {
+                "group_title": "偏独立创作与知识输出",
+                "description": "允许你用自己的节奏钻研主题、打磨观点，再以自己的方式输出价值。",
+                "examples": [
+                  "专业博主 / 知识创作者",
+                  "写作、科普、播客、课程设计",
+                  "自由顾问、独立开发者"
+                ]
+              }
+            ],
+            "outro": "判断一份工作适不适合你，可以问三个问题：这个问题本身有没有意思？我在这里能不能持续学到新东西？我是否有空间用自己的方式优化系统？"
+          },
+          "sort_order": 70,
+          "is_enabled": true
+        },
+        {
+          "section_key": "career.upgrade_suggestions",
+          "render_variant": "bullets",
+          "body_md": "对 INTP-A 来说，真正的瓶颈往往不在「想得不够深」，而在「不够早动手」「不够善用他人」以及「忽略沟通带来的复利」。\n\n你可以把下面这些小公式，当作自己的职场升级提示器。",
+          "body_html": null,
+          "payload_json": {
+            "items": [
+              {
+                "title": "好方案 = 80% 逻辑 + 20% 时机",
+                "body": "不要等到方案“完美无缺”才愿意动手。学会在 70% 可信时就先做一个可测试版本，用现实反馈来修正，而不是在脑海里无限迭代。"
+              },
+              {
+                "title": "影响力 = 思考深度 × 表达清晰度",
+                "body": "你已经有不错的思考深度了，接下来要练习的是：把复杂思路讲给不专业的人听。结构化汇报、举例子、画图，都会显著放大你的影响力。"
+              },
+              {
+                "title": "效率 = 专注时间 ÷ 上下文切换次数",
+                "body": "尽量减少被打断和频繁切换任务，为自己保留大块不被打扰的“深度工作时间”，在这段时间里集中解决最复杂的问题。"
+              },
+              {
+                "title": "长期发展 = 专业纵深 × 跨界视野",
+                "body": "在一个领域扎得足够深的同时，有意识地补充一两个邻近领域的知识（如技术 + 业务、研究 + 产品），你会更容易找到独特的定位。"
+              }
+            ]
+          },
+          "sort_order": 80,
+          "is_enabled": true
+        },
+        {
+          "section_key": "growth.summary",
+          "render_variant": "rich_text",
+          "body_md": "对 INTP-A 而言，成长并不只是「学更多知识」，而是逐渐学会：让自己的聪明真正落地，既服务于现实目标，也照顾到关系与自我状态。\n\n这一部分会从你的强项、短板，以及能量的来源与消耗点几个角度，帮你更理性地看懂自己的成长路径。",
+          "body_html": null,
+          "payload_json": null,
+          "sort_order": 90,
+          "is_enabled": true
+        },
+        {
+          "section_key": "growth.strengths",
+          "render_variant": "bullets",
+          "body_md": null,
+          "body_html": null,
+          "payload_json": {
+            "items": [
+              {
+                "title": "强烈的好奇心与探索欲",
+                "body": "只要是你感兴趣的领域，你可以深挖到别人难以想象的程度，从原理、历史到前沿进展，都愿意一点点啃下来。"
+              },
+              {
+                "title": "善于质疑与重新定义问题",
+                "body": "你不太满足于“大多数人都这么做”，更习惯从头审视问题设定本身，这让你有机会看到别人忽略的可能性。"
+              },
+              {
+                "title": "学习速度快，迁移能力强",
+                "body": "你擅长搭建自己的知识框架，一旦掌握核心原理，就能较快地迁移到类似领域，用同一套思考方式解决不同问题。"
+              },
+              {
+                "title": "具备自我驱动的成长倾向",
+                "body": "你不太需要被人盯着学习，更希望由自己定义“接下来要升级的模块”，这种自驱力是长期成长的关键。"
+              }
+            ]
+          },
+          "sort_order": 100,
+          "is_enabled": true
+        },
+        {
+          "section_key": "growth.weaknesses",
+          "render_variant": "bullets",
+          "body_md": null,
+          "body_html": null,
+          "payload_json": {
+            "items": [
+              {
+                "title": "容易拖延，卡在「再想一想」",
+                "body": "在需要做选择或行动时，你可能会因为想要“再验证一下”而一拖再拖，错过一些本可以通过尝试快速获得的反馈。"
+              },
+              {
+                "title": "对情绪主题天然有点“迟钝”",
+                "body": "你更习惯处理清晰、有逻辑的内容，对模糊、流动的情绪不太擅长描述，也不习惯深入面对自己的情绪波动。"
+              },
+              {
+                "title": "容易陷入「只在脑内升级」",
+                "body": "你可能在心里不断迭代自我认知，却很少在现实世界中改变行为模式，导致成长更多停留在认知层面。"
+              },
+              {
+                "title": "自我要求高，却不爱公开表达",
+                "body": "你对自己有一套隐形标准，但不会轻易说出来。当现实表现与内在标准有差距时，你会自我批判，却很少求助或解释。"
+              }
+            ]
+          },
+          "sort_order": 110,
+          "is_enabled": true
+        },
+        {
+          "section_key": "growth.motivators",
+          "render_variant": "premium_teaser",
+          "body_md": "有难度的新课题、足够自由的探索空间、以及来自少数“懂你的人”的认可，都会让你感觉：这些思考是有价值的，我愿意继续往前走。",
+          "body_html": null,
+          "payload_json": {
+            "teaser": "有难度的新课题、足够自由的探索空间、以及来自少数“懂你的人”的认可，都会让你感觉：这些思考是有价值的，我愿意继续往前走。",
+            "is_premium": true
+          },
+          "sort_order": 120,
+          "is_enabled": true
+        },
+        {
+          "section_key": "growth.drainers",
+          "render_variant": "premium_teaser",
+          "body_md": "被迫应付低效社交、长期重复没有新意的任务、以及不得不迎合不讲道理的决策，会慢慢磨掉你对世界的好奇心，让你进入“低电量模式”。",
+          "body_html": null,
+          "payload_json": {
+            "teaser": "被迫应付低效社交、长期重复没有新意的任务、以及不得不迎合不讲道理的决策，会慢慢磨掉你对世界的好奇心，让你进入“低电量模式”。",
+            "is_premium": true
+          },
+          "sort_order": 130,
+          "is_enabled": true
+        },
+        {
+          "section_key": "relationships.summary",
+          "render_variant": "rich_text",
+          "body_md": "在人际世界里，你不像那种到处社交的人，更像是少数人圈子里的“深度对话伙伴”。你会为真正投缘的人打开一个广阔而有层次的精神世界：从科学、哲学到人生系统。\n\n你在意的不是“关系看起来多热闹”，而是：我们能不能在同一个频率上思考？能不能彼此尊重对方的边界？这段关系能不能让彼此变得更清晰、更自由？",
+          "body_html": null,
+          "payload_json": null,
+          "sort_order": 140,
+          "is_enabled": true
+        },
+        {
+          "section_key": "relationships.strengths",
+          "render_variant": "bullets",
+          "body_md": null,
+          "body_html": null,
+          "payload_json": {
+            "items": [
+              {
+                "title": "擅长做「思想层面的同伴」",
+                "body": "你可以和对方一起拆解问题、讨论选择、共建一套对世界的理解，这种精神连结往往比表面的浪漫更稳定。"
+              },
+              {
+                "title": "尊重边界，不强行控制",
+                "body": "你很少去干涉他人的人生安排，更倾向于给对方足够空间，让彼此都保留独立性，这让你在关系中通常不会变得黏人或窒息。"
+              },
+              {
+                "title": "关键时刻能给出冷静理性的建议",
+                "body": "当对方陷在情绪里时，你能从更高视角把问题“翻译”成可处理的选项，帮对方看见更多可能性。"
+              },
+              {
+                "title": "对关系的期待长期且稳定",
+                "body": "一旦你真正认定一个人，你不会轻易放弃，而是愿意在长周期内陪伴关系，一起调整双方的相处方式。"
+              }
+            ]
+          },
+          "sort_order": 150,
+          "is_enabled": true
+        },
+        {
+          "section_key": "relationships.weaknesses",
+          "render_variant": "bullets",
+          "body_md": null,
+          "body_html": null,
+          "payload_json": {
+            "items": [
+              {
+                "title": "外在情感表达偏少",
+                "body": "你心里可能很在乎对方，但不太习惯通过肢体、语气或高频互动来表达，让人误以为你冷淡或不在意。"
+              },
+              {
+                "title": "容易把亲密关系当「思维合作项目」",
+                "body": "你很享受一起讨论问题、设计人生路线，但有时会忽略对方“只是想被安慰”“只是想被陪伴”的当下需求。"
+              },
+              {
+                "title": "不擅长处理高压情绪场景",
+                "body": "当对方情绪激烈、语言无逻辑时，你可能会选择暂时抽离，或者在心里关闭通道，这会被误解为回避或冷漠。"
+              },
+              {
+                "title": "不愿意在关系里“装没事”",
+                "body": "当你觉得逻辑不通、价值观冲突严重时，你很难假装一切正常。这种诚实虽然有价值，但也容易让关系进入艰难的深度对话。"
+              }
+            ]
+          },
+          "sort_order": 160,
+          "is_enabled": true
+        },
+        {
+          "section_key": "relationships.rel_advantages",
+          "render_variant": "premium_teaser",
+          "body_md": "在健康的关系中，你会成为对方极其重要的「思维支点」：你不会轻易评判，却会认真倾听、提出好问题、一起搭建更清晰的人生框架。和你在一起，很多人会慢慢学会独立思考，而不是只是寻找答案。",
+          "body_html": null,
+          "payload_json": {
+            "teaser": "在健康的关系中，你会成为对方极其重要的「思维支点」：你不会轻易评判，却会认真倾听、提出好问题、一起搭建更清晰的人生框架。和你在一起，很多人会慢慢学会独立思考，而不是只是寻找答案。",
+            "is_premium": true
+          },
+          "sort_order": 170,
+          "is_enabled": true
+        },
+        {
+          "section_key": "relationships.rel_risks",
+          "render_variant": "premium_teaser",
+          "body_md": "如果长期身处一个不尊重思考、不重视边界、只期待你无条件配合的关系环境，你的能量会被一点点磨掉，甚至会开始怀疑“是不是只有我太认真”。学会识别这类模式，并适度抽离，是 INTP-A 特别重要的一课。",
+          "body_html": null,
+          "payload_json": {
+            "teaser": "如果长期身处一个不尊重思考、不重视边界、只期待你无条件配合的关系环境，你的能量会被一点点磨掉，甚至会开始怀疑“是不是只有我太认真”。学会识别这类模式，并适度抽离，是 INTP-A 特别重要的一课。",
+            "is_premium": true
+          },
+          "sort_order": 180,
+          "is_enabled": true
+        }
+      ],
+      "seo_overrides": {
+        "seo_title": "INTP-A 逻辑学家型",
+        "seo_description": "你像一台安静却高速运转的「思考引擎」：表面云淡风轻，内心不断拆解世界的规则与漏洞。你不善于热闹的表演，却擅长用一个清晰的模型、一个犀利的问题，让别人突然安静下来，重新思考原本习以为常的东西。",
+        "canonical_url": null,
+        "og_title": "INTP-A 理性解构者",
+        "og_description": "你像一台安静却高速运转的「思考引擎」：表面云淡风轻，内心不断拆解世界的规则与漏洞。你不善于热闹的表演，却擅长用一个清晰的模型、一个犀利的问题，让别人突然安静下来，重新思考原本习以为常的东西。",
+        "og_image_url": null,
+        "twitter_title": "INTP-A 理性解构者",
+        "twitter_description": "你像一台安静却高速运转的「思考引擎」：表面云淡风轻，内心不断拆解世界的规则与漏洞。你不善于热闹的表演，却擅长用一个清晰的模型、一个犀利的问题，让别人突然安静下来，重新思考原本习以为常的东西。",
+        "twitter_image_url": null,
+        "robots": null,
+        "jsonld_overrides_json": null
+      }
+    },
+    {
+      "runtime_type_code": "INTP-T",
+      "canonical_type_code": "INTP",
+      "variant_code": "T",
+      "is_published": true,
+      "published_at": "2026-03-17T00:00:00Z",
+      "profile_overrides": {
+        "type_name": "逻辑学家型",
+        "nickname": "好奇解构者",
+        "rarity_text": "约 3–5%",
+        "keywords_json": [
+          "理性",
+          "好奇心",
+          "解构",
+          "独立思考",
+          "自由探索",
+          "自我反省"
+        ],
+        "hero_summary_md": "你像一台安静却高速运转的“思考引擎”：不爱在人群中央抢镜头，却总在角落里，把复杂的问题拆开、看懂、重组。你不太擅长说漂亮话，但你在乎“这件事是不是讲得通”，也在乎“这个世界还能不能被解释得更优雅一点”。",
+        "hero_summary_html": null
+      },
+      "section_overrides": [
+        {
+          "section_key": "letters_intro",
+          "render_variant": "letters_intro",
+          "body_md": null,
+          "body_html": null,
+          "payload_json": {
+            "headline": "内向 · 直觉 · 思考 · 感知 · 动荡型｜用逻辑和好奇心拆解世界的“安静解谜者”",
+            "letters": [
+              {
+                "letter": "I",
+                "title": "内向（I）",
+                "description": "让你更习惯在自己的思维空间里充电。安静的环境、一个人沉浸式钻研，比热闹的社交更能让你恢复能量。"
+              },
+              {
+                "letter": "N",
+                "title": "直觉（N）",
+                "description": "让你天然关注“底层逻辑”和“可能性”。你容易从细节跳到抽象模型，用自己的方式看见别人没注意到的联系与模式。"
+              },
+              {
+                "letter": "T",
+                "title": "思考（T）",
+                "description": "让你做决策时优先考虑“是否合理、是否自洽”。你习惯从证据、逻辑和假设出发，而不是先看当下气氛或他人期待。"
+              },
+              {
+                "letter": "P",
+                "title": "感知（P）",
+                "description": "让你抗拒过早“定稿”。你更喜欢保持开放、保留余地，边走边修正路线，而不是被死板计划锁死。"
+              },
+              {
+                "letter": "T",
+                "title": "动荡型（-T）",
+                "description": "让你对自己的想法和表现常常“再三检查”。你会反复推敲：这个观点是否足够严谨？我是不是理解错了什么？这既让你持续精进，也让你偶尔过度纠结。"
+              }
+            ]
+          },
+          "sort_order": 10,
+          "is_enabled": true
+        },
+        {
+          "section_key": "overview",
+          "render_variant": "rich_text",
+          "body_md": "在费马心理的逻辑模型里，INTP-T 常被视作“好奇而严谨的解谜者”。你对世界保持着近乎本能的提问欲：为什么是这样？有没有更优雅的解释？如果换一个前提，会不会推导出完全不同的结论？\n\n比起站在台前带动氛围，你更习惯在一旁观察、分析，用自己的节奏吸收信息、重构观点。你不一定外向健谈，但一旦聊到你真正感兴趣的领域，你的思维会像被点燃一样——抽象模型、类比、推演一股脑涌出来。\n\n对你来说，世界既是一个复杂系统，也是一个巨大的“实验场”。你不满足于照单全收，更愿意自己拆开来看一看：规则是怎么长出来的？理论能不能再简化？有没有被我们忽略的变量？",
+          "body_html": null,
+          "payload_json": null,
+          "sort_order": 20,
+          "is_enabled": true
+        },
+        {
+          "section_key": "trait_overview",
+          "render_variant": "trait_dimension_grid",
+          "body_md": "建议与小程序中 5 条维度进度条搭配展示：外向 / 内向｜天马行空 / 求真务实｜情感细腻 / 理性思考｜运筹帷幄 / 随机应变｜情绪易波动 / 自信果断。",
+          "body_html": null,
+          "payload_json": {
+            "summary": "建议与小程序中 5 条维度进度条搭配展示：外向 / 内向｜天马行空 / 求真务实｜情感细腻 / 理性思考｜运筹帷幄 / 随机应变｜情绪易波动 / 自信果断。",
+            "dimensions": [
+              {
+                "id": "EI",
+                "name": "外向倾向",
+                "label": "外向倾向",
+                "axis_left": "外向",
+                "axis_right": "内向",
+                "summary": "明显偏内向",
+                "description": "你更习惯在少数熟悉的人面前展开自己，或一个人安静待着。热闹社交对你来说更像“短暂体验”，而不是日常刚需。长时间应酬之后，你会迫切需要独处来“格式化缓存”。"
+              },
+              {
+                "id": "SN",
+                "name": "心智模式",
+                "label": "心智模式",
+                "axis_left": "天马行空",
+                "axis_right": "求真务实",
+                "summary": "偏“天马行空”但重逻辑",
+                "description": "你的思维可以飘得很远：从一个细节跳到宏观框架，再从现实问题推演到抽象理论。但与其说你“想象力丰富”，不如说你在用各种可能性反复验证、打磨自己的模型。"
+              },
+              {
+                "id": "TF",
+                "name": "情绪天性",
+                "label": "情绪天性",
+                "axis_left": "情感细腻",
+                "axis_right": "理性思考",
+                "summary": "明显偏“理性思考”",
+                "description": "你更习惯先分析，再共情。面对问题时，你可能先在脑内搭一个逻辑结构，而不是立刻投入情绪。你并不是冷漠，只是更擅长用“概念”和“推理”理解世界，而不是用“情绪语言”。"
+              },
+              {
+                "id": "JP",
+                "name": "应对方式",
+                "label": "应对方式",
+                "axis_left": "运筹帷幄",
+                "axis_right": "随机应变",
+                "summary": "偏“随机应变”",
+                "description": "你不太喜欢被时间表和死线严密封死，更偏好弹性的节奏。你会在“灵感来时高强度投入”和“断电式放空”之间切换，在看似“拖延”的背后，其实是在让大脑持续后台运算。"
+              },
+              {
+                "id": "AT",
+                "name": "身份特征",
+                "label": "身份特征",
+                "axis_left": "情绪易波动",
+                "axis_right": "自信果断",
+                "summary": "略偏“情绪易波动”",
+                "description": "动荡型的你，对自己的观点和能力常常持“谨慎乐观”。在外人看来你很聪明，但你自己更关注那些还没搞懂的部分。你会因为一个小漏洞反复推翻重来，也会因为一句质疑在心里琢磨很久。"
+              }
+            ]
+          },
+          "sort_order": 30,
+          "is_enabled": true
+        },
+        {
+          "section_key": "career.summary",
+          "render_variant": "rich_text",
+          "body_md": "你的职业成就感，往往来自“解决了一个很难、但很有意思的问题”。如果一份工作只要求你按流程机械执行、重复固定答案，你很难真正提起劲。\n\n你更适合在可以思考、设计、研究、推演的岗位上发光：给你足够的自由度和探索空间，你会用自己的方式，创造出优雅的解决方案或独到的见解。\n\n相反，如果一个环境强调“服从、流程、盯人”，而轻视逻辑质量和创造性思考，你会很快感到乏味甚至想逃离。",
+          "body_html": null,
+          "payload_json": null,
+          "sort_order": 40,
+          "is_enabled": true
+        },
+        {
+          "section_key": "career.advantages",
+          "render_variant": "bullets",
+          "body_md": null,
+          "body_html": null,
+          "payload_json": {
+            "items": [
+              {
+                "title": "强大的逻辑与分析能力",
+                "body": "你擅长拆解复杂问题，找出关键变量和底层结构。别人只看到混乱的信息，你却能从中理出一条清晰的逻辑线。"
+              },
+              {
+                "title": "创意与点子的源泉",
+                "body": "你经常能提出“别人想不到，但一听又很有道理”的方案。跳脱常规、打破既有设定，对你来说是一种本能。"
+              },
+              {
+                "title": "独立思考，不盲从权威",
+                "body": "你不会因为“这是行业惯例”就停止追问。你习惯自己验证、自己判断，这让你在需要突破和创新的领域尤其有价值。"
+              },
+              {
+                "title": "擅长搭建理论与模型",
+                "body": "你不仅能解决眼前问题，还会尝试抽象出可复用的框架或工具，让后续工作更高效、更系统化。"
+              }
+            ]
+          },
+          "sort_order": 50,
+          "is_enabled": true
+        },
+        {
+          "section_key": "career.weaknesses",
+          "render_variant": "bullets",
+          "body_md": null,
+          "body_html": null,
+          "payload_json": {
+            "items": [
+              {
+                "title": "容易卡在“完美方案”里",
+                "body": "你倾向于不断优化、不断推敲，以至于迟迟不愿意“定版”。在需要快速决策和推进的环境里，这会让你显得犹豫或拖延。"
+              },
+              {
+                "title": "对琐事与流程容忍度低",
+                "body": "重复性、缺乏挑战的任务会迅速消耗你的注意力。你可能在这些环节频繁出错、拖延，或者干脆“精神性逃避”。"
+              },
+              {
+                "title": "沟通有时过于抽象",
+                "body": "你习惯用概念、模型、假设来表达，但并不是每个人都能跟上你的思路。如果缺少耐心翻译，别人会觉得你“说得高深，却不知道怎么落地”。"
+              },
+              {
+                "title": "不擅长自我推销",
+                "body": "你更在乎“方案是否优秀”，而不太习惯主动展示成果或争取资源。这可能导致你的价值被低估，或被更会表达的人抢走功劳。"
+              }
+            ]
+          },
+          "sort_order": 60,
+          "is_enabled": true
+        },
+        {
+          "section_key": "career.preferred_roles",
+          "render_variant": "preferred_role_list",
+          "body_md": null,
+          "body_html": null,
+          "payload_json": {
+            "intro": "下面这些方向并不是 INTP-T 的“限定职业”，而是更容易匹配你的思维方式和动机的领域，可以作为职业探索的起点：",
+            "groups": [
+              {
+                "group_title": "研究与分析类",
+                "description": "适合长期钻研、搭建模型、输出洞见的岗位。",
+                "examples": [
+                  "数据分析 / 算法 / 机器学习相关岗位",
+                  "用户研究、战略研究、产品/行业研究员",
+                  "学术研究、实验室助理、科研助理"
+                ]
+              },
+              {
+                "group_title": "产品与系统设计",
+                "description": "需要用逻辑和抽象思维搭建结构、设计系统。",
+                "examples": [
+                  "互联网 / SaaS 产品经理",
+                  "系统架构师、信息架构设计",
+                  "流程优化、商业模型设计相关岗位"
+                ]
+              },
+              {
+                "group_title": "技术与工程",
+                "description": "可以“边动手边思考”的技术类岗位。",
+                "examples": [
+                  "软件开发 / 工程师 / 全栈开发",
+                  "游戏系统设计 / 工具开发",
+                  "自动化、嵌入式、工程类解决方案岗位"
+                ]
+              },
+              {
+                "group_title": "创意与内容（偏理性向）",
+                "description": "既有自由度，又能承载你的逻辑与表达欲。",
+                "examples": [
+                  "知识类内容创作者、科普写作者",
+                  "逻辑类教育 / 思维训练相关工作",
+                  "策展、交互叙事、系统性内容规划"
+                ]
+              }
+            ],
+            "outro": "与其只纠结“具体职业名字”，不如优先判断这份工作是否允许你：自由思考、深入钻研、搭建体系，并在此基础上不断优化与迭代。"
+          },
+          "sort_order": 70,
+          "is_enabled": true
+        },
+        {
+          "section_key": "career.upgrade_suggestions",
+          "render_variant": "bullets",
+          "body_md": "对 INTP-T 来说，职场的关键问题往往不是“够不够聪明”，而是：你的聪明，能不能被看见、被使用、被持续买单。\n\n下面这些“小公式”，可以帮助你在保持思考深度的同时，提升影响力与落地效率。",
+          "body_html": null,
+          "payload_json": {
+            "items": [
+              {
+                "title": "好点子 = 想法 × 落地率",
+                "body": "再精彩的思路，如果一直停留在脑中或文档里，就很难真正改变什么。练习为每个重要想法配一条“最小可行路径”（MVP），让别人能看到一个可以试一试的版本。"
+              },
+              {
+                "title": "专业影响力 = 解释能力 × 耐心",
+                "body": "不是所有人都对模型和假设感兴趣。尝试用具体例子、类比、图示来解释你的观点，先让别人“听懂”，再谈“认同”。"
+              },
+              {
+                "title": "成长速度 = 反馈质量 × 频率",
+                "body": "主动向靠谱的人要反馈，尤其是关于“你在哪些地方让别人难以合作”。把反馈当作优化自己系统的“补丁”，而不是对能力的否定。"
+              },
+              {
+                "title": "自由度 = 自律程度",
+                "body": "你越能自己管理好时间和产出，上级就越放心给你空间。与其抗拒规则，不如为自己写一套“适合 INTP 的轻量规则”，保证关键节点按时交付，其余时间自由探索。"
+              }
+            ]
+          },
+          "sort_order": 80,
+          "is_enabled": true
+        },
+        {
+          "section_key": "growth.summary",
+          "render_variant": "rich_text",
+          "body_md": "对 INTP-T 来说，成长更像是“不断迭代自己的操作系统”。你会周期性地重新审视：我的世界观有没有过期？我现在用的这些判断标准，还适不适合当前的人生阶段？\n\n这一部分会帮你看见：你天然具备的成长优势、容易绊倒自己的地方，以及在能量管理上的关键提醒。",
+          "body_html": null,
+          "payload_json": null,
+          "sort_order": 90,
+          "is_enabled": true
+        },
+        {
+          "section_key": "growth.strengths",
+          "render_variant": "bullets",
+          "body_md": null,
+          "body_html": null,
+          "payload_json": {
+            "items": [
+              {
+                "title": "强烈的好奇心与求知欲",
+                "body": "你很少满足于“差不多懂了”，而是想搞清楚“真正的原理是什么”。这种持续的探索欲，是你长期成长的内燃机。"
+              },
+              {
+                "title": "善于从错误中学习",
+                "body": "你可以把一次失败当作“数据样本”，冷静地分析原因，并修正自己的认知模型，而不是只停留在情绪里。"
+              },
+              {
+                "title": "能够长期独立思考",
+                "body": "你不怕一个人待着，反而需要这种状态来对信息进行深加工。这让你不容易被外界情绪裹挟，能保持相对清醒的头脑。"
+              },
+              {
+                "title": "愿意推翻自我、重建认知",
+                "body": "当你发现旧观点被证伪时，你有勇气承认“我之前错了”，并在此基础上搭建更精确的模型。这种能力，比“永远正确”更难得。"
+              }
+            ]
+          },
+          "sort_order": 100,
+          "is_enabled": true
+        },
+        {
+          "section_key": "growth.weaknesses",
+          "render_variant": "bullets",
+          "body_md": null,
+          "body_html": null,
+          "payload_json": {
+            "items": [
+              {
+                "title": "行动延迟，容易停在“想得很美”",
+                "body": "你的大脑很忙，但身体不一定跟得上。很多好想法停留在草稿或对话里，没有被真正实验过。"
+              },
+              {
+                "title": "对情绪与关系的“带宽”有限",
+                "body": "你更擅长处理信息，而不是处理情绪。当情绪输入过载时，你可能选择“断网式消失”，让别人摸不着头脑。"
+              },
+              {
+                "title": "容易陷入过度自我怀疑",
+                "body": "动荡型让你不断检查自己的逻辑，这本是好事，但一旦失控，就会演变为：明明已经够好，自己却总觉得哪里不够。"
+              },
+              {
+                "title": "生活执行力与稳定性不足",
+                "body": "在缺乏外部结构时，你可能在作息、健康、财务、长期规划等方面表现得“有点随缘”，这会在更长期产生隐形成本。"
+              }
+            ]
+          },
+          "sort_order": 110,
+          "is_enabled": true
+        },
+        {
+          "section_key": "growth.motivators",
+          "render_variant": "premium_teaser",
+          "body_md": "有智力挑战的问题、能自由设计方法的空间，以及被真正当作“脑力合作者”而不是“执行工具”的体验，都会极大激活你的动力。",
+          "body_html": null,
+          "payload_json": {
+            "teaser": "有智力挑战的问题、能自由设计方法的空间，以及被真正当作“脑力合作者”而不是“执行工具”的体验，都会极大激活你的动力。",
+            "is_premium": true
+          },
+          "sort_order": 120,
+          "is_enabled": true
+        },
+        {
+          "section_key": "growth.drainers",
+          "render_variant": "premium_teaser",
+          "body_md": "重复且无法优化的任务、被迫卷入高情绪对抗、以及“明知不合理却无法改变的规则”，会让你迅速失去兴趣，甚至想要“格式化整个人生”。",
+          "body_html": null,
+          "payload_json": {
+            "teaser": "重复且无法优化的任务、被迫卷入高情绪对抗、以及“明知不合理却无法改变的规则”，会让你迅速失去兴趣，甚至想要“格式化整个人生”。",
+            "is_premium": true
+          },
+          "sort_order": 130,
+          "is_enabled": true
+        },
+        {
+          "section_key": "relationships.summary",
+          "render_variant": "rich_text",
+          "body_md": "在人际世界里，你更像一位“安静、理性、但出乎意料温柔”的同伴。你不是那种全天在线的陪伴型人格，却愿意在关键时刻给出非常真诚、深度、且有建设性的反馈。\n\n你在乎的不是“关系看起来多热络”，而是：我们能不能诚实？能不能尊重彼此的边界？能不能一起聊点有意思的东西，而不是只交换礼貌和日常废话？",
+          "body_html": null,
+          "payload_json": null,
+          "sort_order": 140,
+          "is_enabled": true
+        },
+        {
+          "section_key": "relationships.strengths",
+          "render_variant": "bullets",
+          "body_md": null,
+          "body_html": null,
+          "payload_json": {
+            "items": [
+              {
+                "title": "尊重他人独立性",
+                "body": "你很少黏人，也不会强行干涉别人的选择。你习惯给对方足够的空间，这让你在很多人眼中是“相处很轻松的人”。"
+              },
+              {
+                "title": "善于提供理性建议",
+                "body": "当别人陷在情绪漩涡里时，你可以从更高的视角帮他理清状况，指出被忽略的选项与可能性。"
+              },
+              {
+                "title": "真诚、不做表面功夫",
+                "body": "你不太会或者不太愿意玩人情世故，但一旦认定一个人，你通常会用行动与时间证明自己的在乎。"
+              },
+              {
+                "title": "能够接纳“与众不同”的人",
+                "body": "你不太在意社会标签，更关注一个人的思维方式和价值观。这让你在关系中相对少评判、多理解。"
+              }
+            ]
+          },
+          "sort_order": 150,
+          "is_enabled": true
+        },
+        {
+          "section_key": "relationships.weaknesses",
+          "render_variant": "bullets",
+          "body_md": null,
+          "body_html": null,
+          "payload_json": {
+            "items": [
+              {
+                "title": "表达感受的语言较匮乏",
+                "body": "你在思想上很能说，但一旦要讲“我感觉……”时，可能会卡壳。久而久之，别人会误以为你“不在乎”或“没什么情绪”。"
+              },
+              {
+                "title": "容易“突然消失”",
+                "body": "当你压力大或情绪混乱时，你的本能反应是“先断开一切输入”，包括消息和社交。这种处理方式虽然能让你暂时松一口气，却可能在关系里留下不安与误解。"
+              },
+              {
+                "title": "对“情绪诉求”耐心有限",
+                "body": "当一段对话重复许多遍、却没有新的信息或行动时，你会觉得非常疲惫，甚至下意识想逃离，而不是继续安慰。"
+              },
+              {
+                "title": "不擅长处理关系中的仪式感",
+                "body": "纪念日、节日仪式、日常的甜言蜜语，对你来说不太自然。如果没有意识地补足这一块，伴侣可能会觉得你“太理性、太冷”。"
+              }
+            ]
+          },
+          "sort_order": 160,
+          "is_enabled": true
+        },
+        {
+          "section_key": "relationships.rel_advantages",
+          "render_variant": "premium_teaser",
+          "body_md": "在健康的关系里，你会是那个稳定、诚实、愿意和对方一起思考现实问题的人。你不擅长粉饰太平，但很擅长“我们一起想办法”。",
+          "body_html": null,
+          "payload_json": {
+            "teaser": "在健康的关系里，你会是那个稳定、诚实、愿意和对方一起思考现实问题的人。你不擅长粉饰太平，但很擅长“我们一起想办法”。",
+            "is_premium": true
+          },
+          "sort_order": 170,
+          "is_enabled": true
+        },
+        {
+          "section_key": "relationships.rel_risks",
+          "render_variant": "premium_teaser",
+          "body_md": "如果长期缺乏高质量对话、彼此思想无法交流，或你总是被要求扮演“情绪垃圾桶”，你会逐渐抽离，甚至在心理上提前告别这段关系。",
+          "body_html": null,
+          "payload_json": {
+            "teaser": "如果长期缺乏高质量对话、彼此思想无法交流，或你总是被要求扮演“情绪垃圾桶”，你会逐渐抽离，甚至在心理上提前告别这段关系。",
+            "is_premium": true
+          },
+          "sort_order": 180,
+          "is_enabled": true
+        }
+      ],
+      "seo_overrides": {
+        "seo_title": "INTP-T 逻辑学家型",
+        "seo_description": "你像一台安静却高速运转的“思考引擎”：不爱在人群中央抢镜头，却总在角落里，把复杂的问题拆开、看懂、重组。你不太擅长说漂亮话，但你在乎“这件事是不是讲得通”，也在乎“这个世界还能不能被解释得更优雅一点”。",
+        "canonical_url": null,
+        "og_title": "INTP-T 好奇解构者",
+        "og_description": "你像一台安静却高速运转的“思考引擎”：不爱在人群中央抢镜头，却总在角落里，把复杂的问题拆开、看懂、重组。你不太擅长说漂亮话，但你在乎“这件事是不是讲得通”，也在乎“这个世界还能不能被解释得更优雅一点”。",
+        "og_image_url": null,
+        "twitter_title": "INTP-T 好奇解构者",
+        "twitter_description": "你像一台安静却高速运转的“思考引擎”：不爱在人群中央抢镜头，却总在角落里，把复杂的问题拆开、看懂、重组。你不太擅长说漂亮话，但你在乎“这件事是不是讲得通”，也在乎“这个世界还能不能被解释得更优雅一点”。",
+        "twitter_image_url": null,
+        "robots": null,
+        "jsonld_overrides_json": null
+      }
+    },
+    {
+      "runtime_type_code": "ISFJ-A",
+      "canonical_type_code": "ISFJ",
+      "variant_code": "A",
+      "is_published": true,
+      "published_at": "2026-03-17T00:00:00Z",
+      "profile_overrides": {
+        "type_name": "守护者型",
+        "nickname": "稳定照料者",
+        "rarity_text": "约 6–8%",
+        "keywords_json": [
+          "责任感",
+          "细腻",
+          "守护",
+          "务实",
+          "稳定",
+          "默默付出"
+        ],
+        "hero_summary_md": "你不像站在聚光灯下的人，却总是那盏不灭的小灯。别人眼前一切“理所当然”的安稳背后，往往都有你安静而坚定的守护——你不吵不闹，却习惯把“照顾好身边的人”当成自己的底线。",
+        "hero_summary_html": null
+      },
+      "section_overrides": [
+        {
+          "section_key": "letters_intro",
+          "render_variant": "letters_intro",
+          "body_md": null,
+          "body_html": null,
+          "payload_json": {
+            "headline": "内向 · 实感 · 情感 · 规划 · 自信型｜温柔又有分寸感的“稳定守护者”",
+            "letters": [
+              {
+                "letter": "I",
+                "title": "内向（I）",
+                "description": "让你更习惯在安静、有安全感的环境中充电。你不排斥社交，只是更偏好少数深度关系，而不是大场面的热闹寒暄。"
+              },
+              {
+                "letter": "S",
+                "title": "实感（S）",
+                "description": "让你更关注眼前可见的细节与事实。你踏实、稳重、讲究“看得见摸得着”的靠谱，比起空谈愿景，你更在意当下有没有被照顾好。"
+              },
+              {
+                "letter": "F",
+                "title": "情感（F）",
+                "description": "让你在做决定时下意识考虑他人的感受与关系的温度。你宁愿自己多辛苦一点，也不太愿意让重要的人为难或受伤。"
+              },
+              {
+                "letter": "J",
+                "title": "规划（J）",
+                "description": "让你偏爱有秩序、有节奏的生活。你喜欢提前安排、按计划行事，并通过细致周到的准备，让大家都少一点担心。"
+              },
+              {
+                "letter": "A",
+                "title": "自信型（-A）",
+                "description": "让你在多数时候情绪相对稳定，不容易被一时的波动击垮。你清楚自己的责任边界，对已经做过的努力也更容易心安。"
+              }
+            ]
+          },
+          "sort_order": 10,
+          "is_enabled": true
+        },
+        {
+          "section_key": "overview",
+          "render_variant": "rich_text",
+          "body_md": "在费马心理的逻辑模型里，ISFJ-A 常被视作“安静而可靠的守护者”。你不喜欢太高调的场面，却总会在关键的小细节上，让别人感觉到安心——灯是不是关了、东西有没有准备好、谁是不是最近状态不太对，你都看在眼里，记在心里。\n\n对你来说，所谓的“幸福”，更像是一种被认真照料过的日常：有人被你记挂着，事情有被你好好收拾过，生活虽不轰烈，却有稳定的节奏和温度。你不太需要成为主角，只希望重要的人都能好好地、平稳地向前走。\n\n你的人生追求，从来不只是“做出多大的成绩”，而是“让自己负责的那一小块世界，尽量保持有序、温暖、值得信赖”。",
+          "body_html": null,
+          "payload_json": null,
+          "sort_order": 20,
+          "is_enabled": true
+        },
+        {
+          "section_key": "trait_overview",
+          "render_variant": "trait_dimension_grid",
+          "body_md": "建议与小程序中 5 条维度进度条搭配展示：外向 / 内向｜天马行空 / 求真务实｜情感细腻 / 理性思考｜运筹帷幄 / 随机应变｜情绪易波动 / 自信果断。",
+          "body_html": null,
+          "payload_json": {
+            "summary": "建议与小程序中 5 条维度进度条搭配展示：外向 / 内向｜天马行空 / 求真务实｜情感细腻 / 理性思考｜运筹帷幄 / 随机应变｜情绪易波动 / 自信果断。",
+            "dimensions": [
+              {
+                "id": "EI",
+                "name": "外向倾向",
+                "label": "外向倾向",
+                "axis_left": "外向",
+                "axis_right": "内向",
+                "summary": "偏内向",
+                "description": "你更喜欢有边界、有安全感的相处方式。大型聚会容易让你觉得耗电，而和熟悉的人安静待在一起，或者独处做自己的事，反而能让你慢慢恢复能量。"
+              },
+              {
+                "id": "SN",
+                "name": "心智模式",
+                "label": "心智模式",
+                "axis_left": "天马行空",
+                "axis_right": "求真务实",
+                "summary": "偏“求真务实”",
+                "description": "你习惯先确认事实与细节，再去谈理想与计划。你会默默记住很多“小事”：谁喜欢喝什么、流程里有哪些坑、今天和昨天有什么不一样——这些细节，是你判断世界的基础。"
+              },
+              {
+                "id": "TF",
+                "name": "情绪天性",
+                "label": "情绪天性",
+                "axis_left": "情感细腻",
+                "axis_right": "理性思考",
+                "summary": "偏“情感细腻”",
+                "description": "你对他人的情绪变化很敏感，语气的轻微变化、气氛的一点不对劲，你都能察觉。你在意的不只是事情是否完成，更在意“这个过程中，大家是不是被好好对待了”。"
+              },
+              {
+                "id": "JP",
+                "name": "应对方式",
+                "label": "应对方式",
+                "axis_left": "运筹帷幄",
+                "axis_right": "随机应变",
+                "summary": "偏“运筹帷幄”",
+                "description": "你更喜欢提前安排，而不是临时被“丢进现场”。在重要事情上，你会尽可能提前准备好各种物品和方案，让事情按部就班地进行。"
+              },
+              {
+                "id": "AT",
+                "name": "身份特征",
+                "label": "身份特征",
+                "axis_left": "情绪易波动",
+                "axis_right": "自信果断",
+                "summary": "略偏“自信果断”",
+                "description": "作为自信型 ISFJ，你虽然会在意他人评价，却不至于为每一句话反复失眠。你更清楚自己已经做了什么，也更容易在心里对自己说一句：“我已经尽力了，可以先安心休息一下。”"
+              }
+            ]
+          },
+          "sort_order": 30,
+          "is_enabled": true
+        },
+        {
+          "section_key": "career.summary",
+          "render_variant": "rich_text",
+          "body_md": "你的职业选择，常常围绕着“照顾”“支持”“维护秩序”这些关键词展开。只要能让别人因你而更踏实、更方便，或者让一套系统运转得更顺，你就会觉得这份工作是有意义的。\n\n你不太适合长期处在极度混乱、规则频繁变化、没有明确分工的环境里——那会让你感觉每天都在“救火”，难以踏实。相反，当一份工作有清晰的流程、稳定的节奏，又允许你用心做好细节、照顾到人，你就能持续输出稳定而扎实的价值。",
+          "body_html": null,
+          "payload_json": null,
+          "sort_order": 40,
+          "is_enabled": true
+        },
+        {
+          "section_key": "career.advantages",
+          "render_variant": "bullets",
+          "body_md": null,
+          "body_html": null,
+          "payload_json": {
+            "items": [
+              {
+                "title": "踏实可靠的执行力",
+                "body": "交到你手里的事情，基本不用别人反复盯着。你会按照要求稳稳推进，主动补齐细节，让结果“看起来很安心”。"
+              },
+              {
+                "title": "细致周到的服务意识",
+                "body": "你会从“对方真正需要什么”的角度思考问题，在流程之外多走半步，让同事、用户或客户感受到被照顾和被尊重。"
+              },
+              {
+                "title": "尊重规则，维护秩序",
+                "body": "你会认真对待既定制度，并在日常工作中维护它们的稳定运行。这让你在一些需要“守住底线”的岗位上表现非常可靠。"
+              },
+              {
+                "title": "团队里的“安定力量”",
+                "body": "当其他人忙乱、焦躁、情绪上头时，你往往能用你的沉稳与实际行动，把局面一点点拉回到可控状态。"
+              }
+            ]
+          },
+          "sort_order": 50,
+          "is_enabled": true
+        },
+        {
+          "section_key": "career.weaknesses",
+          "render_variant": "bullets",
+          "body_md": null,
+          "body_html": null,
+          "payload_json": {
+            "items": [
+              {
+                "title": "不擅长自我包装与争取",
+                "body": "你更习惯“把事情做好”而不是“把自己说好”。这可能会让你的贡献在喧闹的环境里被低估，需要你更有意识地呈现自己的价值。"
+              },
+              {
+                "title": "对频繁变化较为敏感",
+                "body": "当目标、流程、上级意图频繁改变而没有清晰解释时，你会感到困惑和消耗，甚至开始怀疑这件事情是否值得投入。"
+              },
+              {
+                "title": "容易承担过多琐碎任务",
+                "body": "因为你做事细致、又不太会拒绝，很多杂事都会自然堆到你这里，时间久了，会挤压你的精力与成长空间。"
+              },
+              {
+                "title": "表达立场时略显保守",
+                "body": "遇到不合理的安排或让你不舒服的合作方式，你可能会先选择忍耐，而不是第一时间提出，这会让问题在暗处积累。"
+              }
+            ]
+          },
+          "sort_order": 60,
+          "is_enabled": true
+        },
+        {
+          "section_key": "career.preferred_roles",
+          "render_variant": "preferred_role_list",
+          "body_md": null,
+          "body_html": null,
+          "payload_json": {
+            "intro": "下面这些职业方向，并不是 ISFJ-A 的唯一选择，而是几类更能发挥你特长、让你感到踏实与值得投入的领域。",
+            "groups": [
+              {
+                "group_title": "支持与照料类角色",
+                "description": "直接为他人提供照顾、支持与稳定感的工作。",
+                "examples": [
+                  "护士、医务辅助人员、康复与护理相关岗位",
+                  "学校行政、宿管、学生事务支持",
+                  "心理助理、咨询机构前台与协调角色"
+                ]
+              },
+              {
+                "group_title": "行政与运营支持",
+                "description": "让系统平稳运转、让团队“有条不紊”的岗位。",
+                "examples": [
+                  "行政文员、办公室管理、后勤与协调岗位",
+                  "运营支持、客服支持、档案与信息管理",
+                  "财务助理、人事行政综合岗"
+                ]
+              },
+              {
+                "group_title": "服务与客户体验",
+                "description": "用细致服务为他人创造“被好好对待”的体验。",
+                "examples": [
+                  "精品客服、会员运营、线下门店店长 / 店员",
+                  "酒店与服务行业中偏重品质与体验的岗位",
+                  "老客户关系维护、社区运营"
+                ]
+              },
+              {
+                "group_title": "秩序与流程相关的岗位",
+                "description": "需要认真执行规定、维护秩序、把风险控制在可接受范围之内。",
+                "examples": [
+                  "质检岗",
+                  "流程合规岗位",
+                  "内部审核与文控相关角色"
+                ]
+              }
+            ],
+            "outro": "对你来说，最重要的从来不是“职位听起来多光鲜”，而是：这份工作是否稳定、有序，是否让你有机会用耐心和责任感，守护住一些具体而真实的需要。"
+          },
+          "sort_order": 70,
+          "is_enabled": true
+        },
+        {
+          "section_key": "career.upgrade_suggestions",
+          "render_variant": "bullets",
+          "body_md": "在职场中，ISFJ-A 往往并不缺“可靠”，而是容易缺“被看见”。升级的核心，不是把自己完全变成另一个人，而是在保持稳重与善良的前提下，多一点边界感与表达度。\n\n你可以把下面这些小提示，当作你的职场升级公式。",
+          "body_html": null,
+          "payload_json": {
+            "items": [
+              {
+                "title": "被看见度 = 结果呈现 × 适度表达",
+                "body": "每完成一件重要的事，不妨简单记录：我解决了什么问题？避免了什么风险？对团队有什么具体帮助？在合适的场合，用简洁的方式呈现出来，让别人知道“这个地方，其实是你在托底”。"
+              },
+              {
+                "title": "精力可持续 = 任务筛选 × 适时说“不”",
+                "body": "当额外任务排队来找你时，可以多问一句：“这件事目前是不是必须由我来做？” 学会把一部分工作退回流程或交给更合适的人，是对自己和团队都负责。"
+              },
+              {
+                "title": "稳定感 = 可控范围 × 接纳变化",
+                "body": "对于无法控制的变化（例如组织调整、外部政策），允许自己有不适，但也可以主动寻找：在这场变化里，有哪些是我仍然可以做得扎实、做得长久的？把注意力放在可控的一小块，会让你更踏实。"
+              },
+              {
+                "title": "成长空间 = 现有优势 × 新场景练习",
+                "body": "你已经很擅长“照顾”“守护”，接下来可以尝试把这些能力带到更广的场景里：例如带新人、优化流程、参与制定规则，而不只是安静执行。你的稳重，可以成为更大范围的支撑力。"
+              }
+            ]
+          },
+          "sort_order": 80,
+          "is_enabled": true
+        },
+        {
+          "section_key": "growth.summary",
+          "render_variant": "rich_text",
+          "body_md": "对 ISFJ-A 来说，成长的关键不在于变得多外向、多张扬，而是在于：在继续照顾他人的同时，也把自己照顾进你关心的范围里。\n\n这一章节，会从你的强项、短板，以及能量的来源和流失几个角度，帮你更立体地看见自己。",
+          "body_html": null,
+          "payload_json": null,
+          "sort_order": 90,
+          "is_enabled": true
+        },
+        {
+          "section_key": "growth.strengths",
+          "render_variant": "bullets",
+          "body_md": null,
+          "body_html": null,
+          "payload_json": {
+            "items": [
+              {
+                "title": "稳定而持久的责任感",
+                "body": "一旦你认定了某份责任，就很难轻易放弃。你会长期、稳定地在同一个位置上，用不张扬的方式持续输出。"
+              },
+              {
+                "title": "细腻的体察力",
+                "body": "你能注意到别人忽略的小地方——环境是否舒适、流程是否顺畅、某个人今天是不是特别安静……这些观察让你在他人真正需要时，给出恰到好处的支持。"
+              },
+              {
+                "title": "珍惜承诺与关系",
+                "body": "你不会轻易许诺，一旦答应了，就会尽力做到。这让你在长期关系中非常值得信赖。"
+              },
+              {
+                "title": "抗压时的安静韧性",
+                "body": "即便在压力之下，你也很少大吵大闹，而是倾向于默默想办法挺过去。这种内在韧性，是你很重要的底层力量。"
+              }
+            ]
+          },
+          "sort_order": 100,
+          "is_enabled": true
+        },
+        {
+          "section_key": "growth.weaknesses",
+          "render_variant": "bullets",
+          "body_md": null,
+          "body_html": null,
+          "payload_json": {
+            "items": [
+              {
+                "title": "过于压抑真实情绪",
+                "body": "为了不添麻烦或不破坏气氛，你常常把自己的不满和疲惫压下去，久而久之容易变成积怨或突然爆发。"
+              },
+              {
+                "title": "不擅长拒绝与求助",
+                "body": "你更习惯自己扛，而不是主动开口请求帮助；也不太会直接拒绝不合理的要求，这会让你悄悄被压到极限。"
+              },
+              {
+                "title": "害怕“给别人添麻烦”",
+                "body": "在很多时候，你会下意识少说一点需求、少争取一点资源，生怕别人觉得你要求太多。但这也让你的很多合理需求长期得不到回应。"
+              },
+              {
+                "title": "容易陷在熟悉的安全区",
+                "body": "你会倾向于做自己已经熟悉、已经证明过的事情，对一些新的、不确定的可能性会有所犹豫，从而错过部分成长机会。"
+              }
+            ]
+          },
+          "sort_order": 110,
+          "is_enabled": true
+        },
+        {
+          "section_key": "growth.motivators",
+          "render_variant": "premium_teaser",
+          "body_md": "当你看到“因为你在，这件事变顺了、这个人安心了、这个环境更有秩序了”，你就会觉得一切付出很值得。真诚的感谢、稳定的关系和可预期的节奏，是你最重要的能量来源。",
+          "body_html": null,
+          "payload_json": {
+            "teaser": "当你看到“因为你在，这件事变顺了、这个人安心了、这个环境更有秩序了”，你就会觉得一切付出很值得。真诚的感谢、稳定的关系和可预期的节奏，是你最重要的能量来源。",
+            "is_premium": true
+          },
+          "sort_order": 120,
+          "is_enabled": true
+        },
+        {
+          "section_key": "growth.drainers",
+          "render_variant": "premium_teaser",
+          "body_md": "频繁且没有解释的变化、对你付出视而不见的环境、以及长期得不到回应的善意，会一点一点磨掉你的热情。如果你开始变得麻木、只想“做好分内那一点”，很可能就是被耗得太久了。",
+          "body_html": null,
+          "payload_json": {
+            "teaser": "频繁且没有解释的变化、对你付出视而不见的环境、以及长期得不到回应的善意，会一点一点磨掉你的热情。如果你开始变得麻木、只想“做好分内那一点”，很可能就是被耗得太久了。",
+            "is_premium": true
+          },
+          "sort_order": 130,
+          "is_enabled": true
+        },
+        {
+          "section_key": "relationships.summary",
+          "render_variant": "rich_text",
+          "body_md": "在关系里，你更像一位安静的守护者：不一定说很多漂亮的话，却会在日常的小动作里，把在乎悄悄做出来——记得对方的习惯，提前准备对方需要的东西，在对方累的时候帮着收拾残局。\n\n你最在意的，从来不是“这段关系外人看起来多精彩”，而是：我们是否彼此负责？我在付出的时候，有没有也被好好对待？",
+          "body_html": null,
+          "payload_json": null,
+          "sort_order": 140,
+          "is_enabled": true
+        },
+        {
+          "section_key": "relationships.strengths",
+          "render_variant": "bullets",
+          "body_md": null,
+          "body_html": null,
+          "payload_json": {
+            "items": [
+              {
+                "title": "用行动表达在乎",
+                "body": "你不一定很会说甜言蜜语，但会用一件件具体的小事让对方感到被照顾、被惦记。对方真正记住的，往往也是这些细节。"
+              },
+              {
+                "title": "高度忠诚与稳定",
+                "body": "一旦认定一段关系对你很重要，你会长期守在那个位置，不轻易离开。这种稳定，是很多人渴望却得不到的安全感来源。"
+              },
+              {
+                "title": "善于照顾他人感受",
+                "body": "你会在冲突时尽量避免说出伤人的话，会在对方脆弱时自然而然地放软语气，给出现实又温和的支持。"
+              },
+              {
+                "title": "重视仪式感与日常经营",
+                "body": "你会记得一些纪念日、共同的习惯、小约定，并在这些细节里不断加温关系，而不是指望“靠一次大的浪漫解决一切问题”。"
+              }
+            ]
+          },
+          "sort_order": 150,
+          "is_enabled": true
+        },
+        {
+          "section_key": "relationships.weaknesses",
+          "render_variant": "bullets",
+          "body_md": null,
+          "body_html": null,
+          "payload_json": {
+            "items": [
+              {
+                "title": "不习惯表达需求",
+                "body": "你更习惯问“你想要什么”，而不是说“我需要什么”。久而久之，对方可能会误以为你“不怎么需要被照顾”。"
+              },
+              {
+                "title": "容易把委屈咽下去",
+                "body": "当你在关系里受了委屈，你可能会先选择沉默和退让，把不满藏在心里，直到堆积到一定程度才爆发。"
+              },
+              {
+                "title": "难以接受突然的疏离",
+                "body": "如果对方突然冷淡、沉默或离开，而没有解释，你会长期想不通“我到底做错了什么”，这对你的自我价值感打击很大。"
+              },
+              {
+                "title": "容易停留在“照顾者”角色",
+                "body": "在很多关系里，你不自觉地扮演“照顾、包容、理解”的那一方，却忘了关系本应是互相支撑，而不是单向付出。"
+              }
+            ]
+          },
+          "sort_order": 160,
+          "is_enabled": true
+        },
+        {
+          "section_key": "relationships.rel_advantages",
+          "render_variant": "premium_teaser",
+          "body_md": "在健康的关系里，你会成为别人非常重要的“情绪避风港”和“生活支撑点”。你让人感觉：就算外面的世界很难，至少回到你身边时，是可以放松、防备值可以调低的。",
+          "body_html": null,
+          "payload_json": {
+            "teaser": "在健康的关系里，你会成为别人非常重要的“情绪避风港”和“生活支撑点”。你让人感觉：就算外面的世界很难，至少回到你身边时，是可以放松、防备值可以调低的。",
+            "is_premium": true
+          },
+          "sort_order": 170,
+          "is_enabled": true
+        },
+        {
+          "section_key": "relationships.rel_risks",
+          "render_variant": "premium_teaser",
+          "body_md": "如果你长期身处“只被需要、不被在乎”的关系里，你会慢慢失去热情，甚至开始怀疑自己的价值。学会识别那些只消耗你、却不愿为你付出的人，是你在人际成长中的重要功课。",
+          "body_html": null,
+          "payload_json": {
+            "teaser": "如果你长期身处“只被需要、不被在乎”的关系里，你会慢慢失去热情，甚至开始怀疑自己的价值。学会识别那些只消耗你、却不愿为你付出的人，是你在人际成长中的重要功课。",
+            "is_premium": true
+          },
+          "sort_order": 180,
+          "is_enabled": true
+        }
+      ],
+      "seo_overrides": {
+        "seo_title": "ISFJ-A 守护者型",
+        "seo_description": "你不像站在聚光灯下的人，却总是那盏不灭的小灯。别人眼前一切“理所当然”的安稳背后，往往都有你安静而坚定的守护——你不吵不闹，却习惯把“照顾好身边的人”当成自己的底线。",
+        "canonical_url": null,
+        "og_title": "ISFJ-A 稳定照料者",
+        "og_description": "你不像站在聚光灯下的人，却总是那盏不灭的小灯。别人眼前一切“理所当然”的安稳背后，往往都有你安静而坚定的守护——你不吵不闹，却习惯把“照顾好身边的人”当成自己的底线。",
+        "og_image_url": null,
+        "twitter_title": "ISFJ-A 稳定照料者",
+        "twitter_description": "你不像站在聚光灯下的人，却总是那盏不灭的小灯。别人眼前一切“理所当然”的安稳背后，往往都有你安静而坚定的守护——你不吵不闹，却习惯把“照顾好身边的人”当成自己的底线。",
+        "twitter_image_url": null,
+        "robots": null,
+        "jsonld_overrides_json": null
+      }
+    },
+    {
+      "runtime_type_code": "ISFJ-T",
+      "canonical_type_code": "ISFJ",
+      "variant_code": "T",
+      "is_published": true,
+      "published_at": "2026-03-17T00:00:00Z",
+      "profile_overrides": {
+        "type_name": "守护者型",
+        "nickname": "温柔守望者",
+        "rarity_text": "约 6–9%",
+        "keywords_json": [
+          "责任感",
+          "细腻体贴",
+          "稳定可靠",
+          "默默付出",
+          "秩序感",
+          "自我要求高"
+        ],
+        "hero_summary_md": "你像一块安静而坚实的基石：不张扬、不抢风头，却始终在那里托住整个场景。你习惯把关心放在行动里，把承诺放在细节里——别人也许察觉得很慢，但真正需要你的那一刻，总能发现你一直都在。",
+        "hero_summary_html": null
+      },
+      "section_overrides": [
+        {
+          "section_key": "letters_intro",
+          "render_variant": "letters_intro",
+          "body_md": null,
+          "body_html": null,
+          "payload_json": {
+            "headline": "内向 · 现实 · 情感 · 规划 · 动荡型｜以稳定与细腻守护他人的“温柔守望者”",
+            "letters": [
+              {
+                "letter": "I",
+                "title": "内向（I）",
+                "description": "让你更习惯安静地在旁边支持，而不是站在聚光灯下。你从独处、熟悉的人和稳定的日常中恢复能量。"
+              },
+              {
+                "letter": "S",
+                "title": "现实（S）",
+                "description": "让你关注眼前可见的细节与事实。你会记住别人无意间提过的小事，也擅长用实际行动去照顾身边人。"
+              },
+              {
+                "letter": "F",
+                "title": "情感（F）",
+                "description": "让你在做决定时格外在意他人的感受与关系的和谐。很多时候，你宁愿多辛苦一点，也不想让别人为难。"
+              },
+              {
+                "letter": "J",
+                "title": "规划（J）",
+                "description": "让你喜欢有秩序、有安排的生活节奏。提前准备、按部就班，比临时应付更让你感到安心和踏实。"
+              },
+              {
+                "letter": "T",
+                "title": "动荡型（-T）",
+                "description": "让你对自己要求很高，事后容易反复复盘：“我是不是还能做得更好？” 这种敏感一方面让你非常认真负责，一方面也容易累到自己。"
+              }
+            ]
+          },
+          "sort_order": 10,
+          "is_enabled": true
+        },
+        {
+          "section_key": "overview",
+          "render_variant": "rich_text",
+          "body_md": "在费马心理的逻辑模型里，ISFJ-T 常常被视为“安静但极其重要的守护力量”。你不一定喜欢站在最前面，却总是愿意站在别人背后，把一切收拾妥当。\n\n你对身边人的需求尤其敏感，会默默记住他们的习惯、喜好和雷区；你也尊重规则、珍惜承诺，相信“答应了就要做到”。对你来说，把日常过踏实、把关系照顾好，比任何华丽的宣言都重要。\n\n当环境混乱、安排反复变动、讲话不算数时，你会强烈不安；而当一切有序、可预期、有人彼此照顾时，你就会自然而然地拿出自己温柔而坚韧的一面，稳稳地撑起一片小小的安全区。",
+          "body_html": null,
+          "payload_json": null,
+          "sort_order": 20,
+          "is_enabled": true
+        },
+        {
+          "section_key": "trait_overview",
+          "render_variant": "trait_dimension_grid",
+          "body_md": "建议与小程序中 5 条维度进度条搭配展示：外向 / 内向｜天马行空 / 求真务实｜情感细腻 / 理性思考｜运筹帷幄 / 随机应变｜情绪易波动 / 自信果断。",
+          "body_html": null,
+          "payload_json": {
+            "summary": "建议与小程序中 5 条维度进度条搭配展示：外向 / 内向｜天马行空 / 求真务实｜情感细腻 / 理性思考｜运筹帷幄 / 随机应变｜情绪易波动 / 自信果断。",
+            "dimensions": [
+              {
+                "id": "EI",
+                "name": "外向倾向",
+                "label": "外向倾向",
+                "axis_left": "外向",
+                "axis_right": "内向",
+                "summary": "明显偏内向",
+                "description": "你更喜欢在熟悉的人、熟悉的环境中自然地展开自己。和一大群人社交会让你很快疲惫，而和少数信任的人细水长流式相处，则让你感觉放松、踏实。"
+              },
+              {
+                "id": "SN",
+                "name": "心智模式",
+                "label": "心智模式",
+                "axis_left": "天马行空",
+                "axis_right": "求真务实",
+                "summary": "偏“求真务实”",
+                "description": "你倾向于从具体事实和经验出发看问题，不太热衷于空洞的口号和遥远的概念。对你来说，看得见、摸得着、做得成，比“听上去很酷”更重要。"
+              },
+              {
+                "id": "TF",
+                "name": "情绪天性",
+                "label": "情绪天性",
+                "axis_left": "情感细腻",
+                "axis_right": "理性思考",
+                "summary": "偏“情感细腻”",
+                "description": "你会认真感受每个人在一段关系里的状态：谁今天有点闷、谁最近特别累，你都能察觉。你在意的不只是结果，更在意过程中有没有伤到谁、有没有谁被忽略。"
+              },
+              {
+                "id": "JP",
+                "name": "应对方式",
+                "label": "应对方式",
+                "axis_left": "运筹帷幄",
+                "axis_right": "随机应变",
+                "summary": "偏“运筹帷幄”",
+                "description": "你习惯提前规划，把事情一步步安排妥当。临时的变动、突如其来的要求会打乱你的节奏，让你需要额外时间去调整心态与计划。"
+              },
+              {
+                "id": "AT",
+                "name": "身份特征",
+                "label": "身份特征",
+                "axis_left": "情绪易波动",
+                "axis_right": "自信果断",
+                "summary": "略偏“情绪易波动”",
+                "description": "动荡型的你，对外界反馈格外敏感，也容易把责任往自己身上揽。别人随口的一句评价，可能会让你在心里反复回想很久，这既体现了你的认真，也提示你需要更多自我照顾。"
+              }
+            ]
+          },
+          "sort_order": 30,
+          "is_enabled": true
+        },
+        {
+          "section_key": "career.summary",
+          "render_variant": "rich_text",
+          "body_md": "工作里，你更像是一套可靠而温柔的“支撑系统”：不一定处在台前，却让很多事情得以顺利运转。你重视责任、秩序和长期稳定，喜欢踏实地把一件件事做好。\n\n当一份工作允许你：有清晰的职责边界、有可预期的节奏、可以实实在在地帮到具体的人，你就更容易投入其中并坚持很久。\n\n相反，如果环境长期混乱、频繁临时加码、承诺说变就变，又缺乏基本尊重，你会明显感到消耗，甚至开始怀疑“是不是自己不够好”，而不是先质疑环境本身。",
+          "body_html": null,
+          "payload_json": null,
+          "sort_order": 40,
+          "is_enabled": true
+        },
+        {
+          "section_key": "career.advantages",
+          "render_variant": "bullets",
+          "body_md": null,
+          "body_html": null,
+          "payload_json": {
+            "items": [
+              {
+                "title": "可靠踏实，值得托付",
+                "body": "你对待工作非常认真，一旦答应就会尽力做到。你不太会夸大其词，而是用稳定的交付赢得别人信任。"
+              },
+              {
+                "title": "细节敏锐，考虑周全",
+                "body": "你会主动检查漏洞、补齐细节，避免“差一点就出问题”的情况发生。在需要严谨与耐心的岗位上，你是非常重要的底盘。"
+              },
+              {
+                "title": "关心团队感受",
+                "body": "你在意同事是否累过头、是否被公平对待，会悄悄帮别人分担一些压力，让整体氛围更柔和、更有人情味。"
+              },
+              {
+                "title": "尊重规章，维护秩序",
+                "body": "你愿意遵守制度，也会提醒大家遵守共同约定。这让你在执行流程、对接客户或维护标准时表现得非常稳定、专业。"
+              }
+            ]
+          },
+          "sort_order": 50,
+          "is_enabled": true
+        },
+        {
+          "section_key": "career.weaknesses",
+          "render_variant": "bullets",
+          "body_md": null,
+          "body_html": null,
+          "payload_json": {
+            "items": [
+              {
+                "title": "不擅长为自己争取",
+                "body": "你习惯先完成任务，很少主动争取资源、话语权或合理的回报。久而久之，你的贡献可能被低估。"
+              },
+              {
+                "title": "难以拒绝额外工作",
+                "body": "同事或上级来拜托时，你往往不好意思说“不”，即使已经很忙也会硬扛下来，最后压垮的是你自己的时间和身体。"
+              },
+              {
+                "title": "害怕冲突，压抑不满",
+                "body": "你不喜欢正面冲突，倾向于“算了”“忍一下”。但这些感受如果长期得不到表达，可能会在某个时刻集中爆发。"
+              },
+              {
+                "title": "对变化适应慢",
+                "body": "频繁变更的目标、模糊而摇摆的决策，会让你极度不安。你需要更多时间消化与调整，却不一定会把这种压力说出来。"
+              }
+            ]
+          },
+          "sort_order": 60,
+          "is_enabled": true
+        },
+        {
+          "section_key": "career.preferred_roles",
+          "render_variant": "preferred_role_list",
+          "body_md": null,
+          "body_html": null,
+          "payload_json": {
+            "intro": "下面这些并不是唯一适合 ISFJ-T 的岗位，而是几类更容易让你感到“踏实又有意义”的方向，可以作为你职业思考的参考起点。",
+            "groups": [
+              {
+                "group_title": "支持与照护相关",
+                "description": "在“照顾他人、提供稳定支持”中发挥优势的角色。",
+                "examples": [
+                  "护士、医务助理、康复机构工作人员",
+                  "学校行政 / 教务、学生事务、宿管等",
+                  "老年照护、儿童照护、社工一线支持者"
+                ]
+              },
+              {
+                "group_title": "行政与运营支持",
+                "description": "让事务井井有条、让团队放心托付的岗位。",
+                "examples": [
+                  "行政助理、人事助理、办公室管理",
+                  "项目执行、运营专员、客户支持",
+                  "质检、后勤管理、档案与信息管理"
+                ]
+              },
+              {
+                "group_title": "稳定且以服务为核心的工作",
+                "description": "节奏可预期，又能看见自己帮助到具体人的领域。",
+                "examples": [
+                  "银行柜员、前台接待、顾客服务岗位",
+                  "线下门店管理、连锁店店员 / 管理者",
+                  "社区服务、政府窗口服务等"
+                ]
+              },
+              {
+                "group_title": "传统与制度感较强的组织",
+                "description": "有明确规章、重视责任与稳定的环境，更能让你发挥长处并获得安全感。",
+                "examples": [
+                  "成熟企业的职能部门",
+                  "制度清晰的公共机构 / 事业单位"
+                ]
+              }
+            ],
+            "outro": "你真正需要的不是“光鲜的名片”，而是一份能发挥你的可靠、细腻与耐心，且能得到基本尊重与回馈的工作。"
+          },
+          "sort_order": 70,
+          "is_enabled": true
+        },
+        {
+          "section_key": "career.upgrade_suggestions",
+          "render_variant": "bullets",
+          "body_md": "对 ISFJ-T 来说，职业上的提升，往往不是“再多做一点”，而是学会更聪明地保护自己：既守住认真负责的底色，也敢为自己争取空间与尊重。\n\n你可以把下面几条，当作自己在职场里的“小提醒”。",
+          "body_html": null,
+          "payload_json": {
+            "items": [
+              {
+                "title": "好说话 ≠ 好欺负",
+                "body": "当别人习惯性把额外工作推给你时，可以学着说：“这部分我可以帮一部分，但现在手头已经有……，剩下的可能需要再分配一下。”既表达善意，也守住底线。"
+              },
+              {
+                "title": "认可感 = 真实贡献 × 被看见的程度",
+                "body": "你已经做了很多，接下来要做的是：在合适的时机，把自己做了什么、解决了什么问题，客观地呈现给上级或团队，而不是默默等待别人发现。"
+              },
+              {
+                "title": "稳定感 = 可控范围 × 清晰边界",
+                "body": "列一份“我能负责的事情清单”，也列一份“超过我能力或职责的事情清单”。当事情落在后者时，学会提出疑问或寻求资源，而不是一个人硬扛。"
+              },
+              {
+                "title": "长期续航 = 休息质量 × 自我照顾",
+                "body": "把休息和放松写进你的计划表，而不是留给“有空再说”。可以给自己固定的“小仪式感时间”：例如每周一晚不加班、不社交，只留给自己调整和恢复。"
+              }
+            ]
+          },
+          "sort_order": 80,
+          "is_enabled": true
+        },
+        {
+          "section_key": "growth.summary",
+          "render_variant": "rich_text",
+          "body_md": "对 ISFJ-T 来说，成长并不是把自己改造成另一个人，而是在保持善良与可靠的同时，慢慢学会：把自己也放进“需要被照顾的人”这个列表里。\n\n这一部分，会从你的强项与短板出发，帮你看清自己如何在不丢失温柔的前提下，活得更有分寸感。",
+          "body_html": null,
+          "payload_json": null,
+          "sort_order": 90,
+          "is_enabled": true
+        },
+        {
+          "section_key": "growth.strengths",
+          "render_variant": "bullets",
+          "body_md": null,
+          "body_html": null,
+          "payload_json": {
+            "items": [
+              {
+                "title": "稳定、持久的责任心",
+                "body": "你不喜欢半途而废，一旦认定了该做的事，就会默默坚持下去。很多人正是因为你的这种稳定，而敢放心把自己的一部分交给你。"
+              },
+              {
+                "title": "细腻的观察与记忆力",
+                "body": "你能记住别人不经意提过的小细节：某个习惯、某次生病、某个重要日子。这些看似微小的记忆，让你的关心格外有温度。"
+              },
+              {
+                "title": "愿意从现实一点点改善生活",
+                "body": "你不太相信一夜翻盘的故事，更愿意通过整理、优化、坚持，把生活和工作一点点变得更顺、更稳。"
+              },
+              {
+                "title": "尊重传统与他人边界",
+                "body": "你不喜欢贸然打破规则，也不会轻易打扰别人的隐私。这让你在很多关系中成为“值得信赖”的那一类人。"
+              }
+            ]
+          },
+          "sort_order": 100,
+          "is_enabled": true
+        },
+        {
+          "section_key": "growth.weaknesses",
+          "render_variant": "bullets",
+          "body_md": null,
+          "body_html": null,
+          "payload_json": {
+            "items": [
+              {
+                "title": "过度压抑负面情绪",
+                "body": "你习惯把不满、委屈、愤怒先藏起来，以为“忍一忍就过去了”。但情绪不会真正消失，只是暂时被你一个人扛着。"
+              },
+              {
+                "title": "容易把问题都归因于自己",
+                "body": "当事情出问题时，你本能地先从自己身上找原因，很少想到“也许是环境或制度有问题”，这会让你承受过多不必要的内疚。"
+              },
+              {
+                "title": "不善于说出自己的需要",
+                "body": "你更熟悉“照顾别人”，而不熟悉“告诉别人怎么照顾你”。久而久之，别人会误以为你“不需要被照顾”。"
+              },
+              {
+                "title": "害怕改变已经习惯的一切",
+                "body": "即便一份工作或关系已经让你疲惫不堪，只要它还算稳定，你也可能选择“将就”，害怕踏出改变的那一步。"
+              }
+            ]
+          },
+          "sort_order": 110,
+          "is_enabled": true
+        },
+        {
+          "section_key": "growth.motivators",
+          "render_variant": "premium_teaser",
+          "body_md": "被真诚地感谢、看到别人因为你的存在而变得更安心、更有秩序，都会让你觉得一切辛苦都是值得的。清晰的期待与稳定的肯定，是你长期坚持的重要燃料。",
+          "body_html": null,
+          "payload_json": {
+            "teaser": "被真诚地感谢、看到别人因为你的存在而变得更安心、更有秩序，都会让你觉得一切辛苦都是值得的。清晰的期待与稳定的肯定，是你长期坚持的重要燃料。",
+            "is_premium": true
+          },
+          "sort_order": 120,
+          "is_enabled": true
+        },
+        {
+          "section_key": "growth.drainers",
+          "render_variant": "premium_teaser",
+          "body_md": "反复被临时加码、永远得不到正面反馈、付出被当成理所当然，以及被迫卷入公开冲突，都会迅速消耗你的能量。如果你越来越常叹气、失眠或想躲开一切，很可能就是过载的信号。",
+          "body_html": null,
+          "payload_json": {
+            "teaser": "反复被临时加码、永远得不到正面反馈、付出被当成理所当然，以及被迫卷入公开冲突，都会迅速消耗你的能量。如果你越来越常叹气、失眠或想躲开一切，很可能就是过载的信号。",
+            "is_premium": true
+          },
+          "sort_order": 130,
+          "is_enabled": true
+        },
+        {
+          "section_key": "relationships.summary",
+          "render_variant": "rich_text",
+          "body_md": "在关系世界里，你更像是一位“默默在旁边守望的人”。你不一定擅长华丽的表达，却擅长用一次次实际行动，慢慢让对方感到：原来被人稳稳放在心上，是这种感觉。\n\n你最重视的，不是表面的热闹，而是长久的可靠——承诺算数、言行一致、记得彼此的好，这些比任何浪漫台词都重要。",
+          "body_html": null,
+          "payload_json": null,
+          "sort_order": 140,
+          "is_enabled": true
+        },
+        {
+          "section_key": "relationships.strengths",
+          "render_variant": "bullets",
+          "body_md": null,
+          "body_html": null,
+          "payload_json": {
+            "items": [
+              {
+                "title": "忠诚与长期投入",
+                "body": "一旦你认定了一段关系，就会认真对待，不轻易放弃。你愿意在日常的细枝末节里，为这段关系不断投入和修补。"
+              },
+              {
+                "title": "体贴入微的照顾方式",
+                "body": "你会记住对方的喜好与雷区，在对方没开口之前就先准备好需要的东西。很多人直到失去这种照顾，才意识到它有多珍贵。"
+              },
+              {
+                "title": "稳定而不过度侵入",
+                "body": "你不会强行闯进对方的边界，而是用恰到好处的关心陪在附近。对很多敏感或内向的人来说，这种“不过度打扰的在场”非常难得。"
+              },
+              {
+                "title": "愿意为关系做实际调整",
+                "body": "如果对方真心在意，你愿意悄悄改变一些习惯、调整自己的节奏，只为让相处更顺、更舒适。"
+              }
+            ]
+          },
+          "sort_order": 150,
+          "is_enabled": true
+        },
+        {
+          "section_key": "relationships.weaknesses",
+          "render_variant": "bullets",
+          "body_md": null,
+          "body_html": null,
+          "payload_json": {
+            "items": [
+              {
+                "title": "不敢表达不满与需求",
+                "body": "你怕自己的真实感受会给对方添麻烦，所以常常选择沉默。可长期不说，委屈只会在心里越积越厚。"
+              },
+              {
+                "title": "容易陷入不对等的关系",
+                "body": "你习惯多付出一点、再多一点，而有些人也会逐渐习惯被照顾，却不懂得回馈。慢慢地，这段关系就变成了单向的“消耗”。"
+              },
+              {
+                "title": "对关系结束有强烈抵抗",
+                "body": "即便已经意识到这段关系让你很累，你也可能因为念旧、因为责任感，而迟迟不愿放手，拖得两个人都不好受。"
+              },
+              {
+                "title": "把“照顾别人”当成默认身份",
+                "body": "很多时候，你忘了自己也有情绪、也有脆弱，只是习惯性地站在照顾者的位置上。久而久之，你会觉得“没有人真的看到我”。"
+              }
+            ]
+          },
+          "sort_order": 160,
+          "is_enabled": true
+        },
+        {
+          "section_key": "relationships.rel_advantages",
+          "render_variant": "premium_teaser",
+          "body_md": "在健康的关系里，你会成为对方强大的后盾——既能提供现实层面的支持，也能在情绪上给予安定感。你用的是细水长流的方式，让对方在长期相处中，慢慢体验到被守护的幸福感。",
+          "body_html": null,
+          "payload_json": {
+            "teaser": "在健康的关系里，你会成为对方强大的后盾——既能提供现实层面的支持，也能在情绪上给予安定感。你用的是细水长流的方式，让对方在长期相处中，慢慢体验到被守护的幸福感。",
+            "is_premium": true
+          },
+          "sort_order": 170,
+          "is_enabled": true
+        },
+        {
+          "section_key": "relationships.rel_risks",
+          "render_variant": "premium_teaser",
+          "body_md": "当一段关系里：你的付出被当成理所当然、你的感受长期不被问起、你的界限一次次被试探甚至踩过，你却仍告诉自己“再忍一忍”，这就是 ISFJ-T 最典型的危险信号。学会在关系中为自己按下“暂停键”，是你走向更健康亲密关系的重要一步。",
+          "body_html": null,
+          "payload_json": {
+            "teaser": "当一段关系里：你的付出被当成理所当然、你的感受长期不被问起、你的界限一次次被试探甚至踩过，你却仍告诉自己“再忍一忍”，这就是 ISFJ-T 最典型的危险信号。学会在关系中为自己按下“暂停键”，是你走向更健康亲密关系的重要一步。",
+            "is_premium": true
+          },
+          "sort_order": 180,
+          "is_enabled": true
+        }
+      ],
+      "seo_overrides": {
+        "seo_title": "ISFJ-T 守护者型",
+        "seo_description": "你像一块安静而坚实的基石：不张扬、不抢风头，却始终在那里托住整个场景。你习惯把关心放在行动里，把承诺放在细节里——别人也许察觉得很慢，但真正需要你的那一刻，总能发现你一直都在。",
+        "canonical_url": null,
+        "og_title": "ISFJ-T 温柔守望者",
+        "og_description": "你像一块安静而坚实的基石：不张扬、不抢风头，却始终在那里托住整个场景。你习惯把关心放在行动里，把承诺放在细节里——别人也许察觉得很慢，但真正需要你的那一刻，总能发现你一直都在。",
+        "og_image_url": null,
+        "twitter_title": "ISFJ-T 温柔守望者",
+        "twitter_description": "你像一块安静而坚实的基石：不张扬、不抢风头，却始终在那里托住整个场景。你习惯把关心放在行动里，把承诺放在细节里——别人也许察觉得很慢，但真正需要你的那一刻，总能发现你一直都在。",
+        "twitter_image_url": null,
+        "robots": null,
+        "jsonld_overrides_json": null
+      }
+    },
+    {
+      "runtime_type_code": "ISFP-A",
+      "canonical_type_code": "ISFP",
+      "variant_code": "A",
+      "is_published": true,
+      "published_at": "2026-03-17T00:00:00Z",
+      "profile_overrides": {
+        "type_name": "探险家型",
+        "nickname": "自在感受者",
+        "rarity_text": "约 5–9%",
+        "keywords_json": [
+          "感受力",
+          "审美",
+          "温柔坚定",
+          "活在当下",
+          "自由自主",
+          "行动表达"
+        ],
+        "hero_summary_md": "你像一阵轻柔的风：不爱高调登场，却总能悄悄把温暖和美感带进别人的生活。你习惯用行动、细节和陪伴去表达在乎，比起“说得多”，你更相信“做得到”。",
+        "hero_summary_html": null
+      },
+      "section_overrides": [
+        {
+          "section_key": "letters_intro",
+          "render_variant": "letters_intro",
+          "body_md": null,
+          "body_html": null,
+          "payload_json": {
+            "headline": "内向 · 现实 · 情感 · 感知 · 自信型｜安静而坚定的“生活美学实践者”",
+            "letters": [
+              {
+                "letter": "I",
+                "title": "内向（I）",
+                "description": "让你更享受小圈子的真实相处，而不是人潮汹涌的社交场。只要能和少数信任的人待在一起，你就觉得很安心。"
+              },
+              {
+                "letter": "S",
+                "title": "现实（S）",
+                "description": "让你更关注当下可以触摸到的事物——一束光、一段旋律、一句真诚的话，比遥远的宏大愿景更能打动你。"
+              },
+              {
+                "letter": "F",
+                "title": "情感（F）",
+                "description": "让你在做决定时，会先体会这件事与你的价值观和感受是否一致。你宁愿慢一点，也不想违背内心。"
+              },
+              {
+                "letter": "P",
+                "title": "感知（P）",
+                "description": "让你偏爱保留选择，而不是被排得满满的计划困住。灵感到了就行动，顺势而为，是你最自然的状态。"
+              },
+              {
+                "letter": "A",
+                "title": "自信型（-A）",
+                "description": "让你在大多数时候可以相对稳定地相信自己：你知道自己独特，只是不太爱解释。你更愿意用作品和行为，而不是辩解，来证明自己。"
+              }
+            ]
+          },
+          "sort_order": 10,
+          "is_enabled": true
+        },
+        {
+          "section_key": "overview",
+          "render_variant": "rich_text",
+          "body_md": "在费马心理的逻辑模型里，ISFP-A 常被视作“安静却有自己色彩的生活艺术家”。你不一定喜欢站在舞台中央，但你的存在本身，就在悄悄调整场景的温度和质感。\n\n你敏锐地感知身边的细节——空气的氛围、灯光的层次、别人的小情绪、环境的和谐与否。你不爱空喊口号，更喜欢用实际行动、实实在在的体验，来让自己和身边人的生活变得“更舒服一点、更好看一点、更真实一点”。\n\n你的人生追求往往不是轰轰烈烈的大场面，而是：活得符合自己，做自己认可的事情，在有限的日常里，创造出属于你的那一份独特质感。",
+          "body_html": null,
+          "payload_json": null,
+          "sort_order": 20,
+          "is_enabled": true
+        },
+        {
+          "section_key": "trait_overview",
+          "render_variant": "trait_dimension_grid",
+          "body_md": "建议与小程序中 5 条维度进度条搭配展示：外向 / 内向｜天马行空 / 求真务实｜情感细腻 / 理性思考｜运筹帷幄 / 随机应变｜情绪易波动 / 自信果断。",
+          "body_html": null,
+          "payload_json": {
+            "summary": "建议与小程序中 5 条维度进度条搭配展示：外向 / 内向｜天马行空 / 求真务实｜情感细腻 / 理性思考｜运筹帷幄 / 随机应变｜情绪易波动 / 自信果断。",
+            "dimensions": [
+              {
+                "id": "EI",
+                "name": "外向倾向",
+                "label": "外向倾向",
+                "axis_left": "外向",
+                "axis_right": "内向",
+                "summary": "偏内向",
+                "description": "你更偏向安静的一侧，喜欢和熟悉的人深聊，而不是在大场合不断切换话题。社交可以有，但你更需要独处时间来“把心收回来”。"
+              },
+              {
+                "id": "SN",
+                "name": "心智模式",
+                "label": "心智模式",
+                "axis_left": "天马行空",
+                "axis_right": "求真务实",
+                "summary": "略偏“求真务实”",
+                "description": "你会想很多，但最后还是会落回“眼前做什么比较实在”。你关注真实的体验和当下的感受，比起空想，你更愿意一边尝试一边调整。"
+              },
+              {
+                "id": "TF",
+                "name": "情绪天性",
+                "label": "情绪天性",
+                "axis_left": "情感细腻",
+                "axis_right": "理性思考",
+                "summary": "明显偏“情感细腻”",
+                "description": "你的感受世界非常丰富，只是大部分时候你不说出来。你会记得别人无意中的一句话，也会因为一个突然的温暖举动而感动很久。"
+              },
+              {
+                "id": "JP",
+                "name": "应对方式",
+                "label": "应对方式",
+                "axis_left": "运筹帷幄",
+                "axis_right": "随机应变",
+                "summary": "偏“随机应变”",
+                "description": "你不太喜欢被时间表和流程绑得死死的，更偏爱根据当下状态做选择。环境变动的时候，你反而能在混乱中找到自己的节奏。"
+              },
+              {
+                "id": "AT",
+                "name": "身份特征",
+                "label": "身份特征",
+                "axis_left": "情绪易波动",
+                "axis_right": "自信果断",
+                "summary": "略偏“自信果断”",
+                "description": "作为自信型 ISFP，你情绪当然也会起伏，但整体更相信“我会找到自己的路”。别人的评价会影响你，却很难彻底动摇你对自己核心价值的判断。"
+              }
+            ]
+          },
+          "sort_order": 30,
+          "is_enabled": true
+        },
+        {
+          "section_key": "career.summary",
+          "render_variant": "rich_text",
+          "body_md": "你的职业满意度，往往取决于两个关键：有没有足够的空间做自己？能不能创造真实的价值和美感？\n\n你不太适合被流程和汇报淹没的环境——如果工作只剩下机械执行、毫无审美与温度，你会很快失去热情。\n\n相反，只要一份工作允许你：亲自上手做事、看得见具体成果、保留一定的自由度，还能在过程中表达你的价值观和审美，你就能默默地发光很久。",
+          "body_html": null,
+          "payload_json": null,
+          "sort_order": 40,
+          "is_enabled": true
+        },
+        {
+          "section_key": "career.advantages",
+          "render_variant": "bullets",
+          "body_md": null,
+          "body_html": null,
+          "payload_json": {
+            "items": [
+              {
+                "title": "审美与体验敏感",
+                "body": "你能本能地察觉“好不好看、舒不舒服、顺不顺手”，这种直觉在产品体验、视觉设计、内容呈现等方面非常宝贵。"
+              },
+              {
+                "title": "以行动为主的可靠感",
+                "body": "你不喜欢夸夸其谈，更习惯用作品和结果说话。交付到你手上的事情，你会尽可能认真地做完，不辜负别人的信任。"
+              },
+              {
+                "title": "温和好相处的同事类型",
+                "body": "你不爱争抢风头，也很少搞职场对立。和你共事的人，通常会觉得你安静、好相处、愿意配合在合理范围内做调整。"
+              },
+              {
+                "title": "现场感与细节执行力",
+                "body": "你会关注许多别人忽视的小细节——灯光、摆放、动线、文案的语气……这些让你在需要落地执行与优化体验的岗位上尤其出彩。"
+              }
+            ]
+          },
+          "sort_order": 50,
+          "is_enabled": true
+        },
+        {
+          "section_key": "career.weaknesses",
+          "render_variant": "bullets",
+          "body_md": null,
+          "body_html": null,
+          "payload_json": {
+            "items": [
+              {
+                "title": "不喜欢硬碰硬的职场博弈",
+                "body": "复杂的人际斗争、明争暗抢的资源竞争，会让你迅速心累。你可能选择沉默或退让，而不是加入“战场”。"
+              },
+              {
+                "title": "对长期规划容易拖延",
+                "body": "你更擅长专注当下，面对需要长时间坚持、且看不到即时回报的目标时，难免会出现动力不足或中途松懈。"
+              },
+              {
+                "title": "不擅长“自我宣传”",
+                "body": "你不太会主动推销自己，哪怕成果很好，也习惯低调带过。这可能导致你的贡献被低估，晋升或机会分配时不够占优势。"
+              },
+              {
+                "title": "边界感有时过于柔软",
+                "body": "你不想让别人失望，因此偶尔会接下自己不想做的事。次数多了，你会觉得自己“被安排的人生太多”，却不好意思说出口。"
+              }
+            ]
+          },
+          "sort_order": 60,
+          "is_enabled": true
+        },
+        {
+          "section_key": "career.preferred_roles",
+          "render_variant": "preferred_role_list",
+          "body_md": null,
+          "body_html": null,
+          "payload_json": {
+            "intro": "以下方向不代表“只能这样选”，而是更有可能让 ISFP-A 体验到成就感与舒适度的职业场景，可作为你规划或转型时的参考。",
+            "groups": [
+              {
+                "group_title": "创意与审美相关",
+                "description": "可以直接参与“看得见的作品”创作或优化的岗位。",
+                "examples": [
+                  "平面 / 视觉设计、插画、摄影与视频创作",
+                  "UI / UX 设计、品牌视觉执行",
+                  "空间陈列、舞美设计、手作 / 工艺相关工作"
+                ]
+              },
+              {
+                "group_title": "服务体验与现场执行",
+                "description": "围绕“让体验变好”展开的具体执行类工作。",
+                "examples": [
+                  "活动执行、线下店铺 / 空间运营",
+                  "文旅体验设计、展会 / 线下市集策划与落地",
+                  "精品零售、咖啡店 / 文创空间运营"
+                ]
+              },
+              {
+                "group_title": "人本与关怀导向",
+                "description": "允许你用温柔和耐心陪伴他人、提供支持的职业。",
+                "examples": [
+                  "护理、康复相关岗位（在符合你情绪承受度的前提下）",
+                  "宠物相关行业、园艺与自然教育",
+                  "支持型岗位：助理、项目支持、客户体验专员"
+                ]
+              },
+              {
+                "group_title": "自由度较高的个人创作",
+                "description": "允许你按自己的节奏创作和工作的路径。",
+                "examples": [
+                  "自由职业创作者 / 独立设计师",
+                  "手作品牌主理人、自媒体内容创作者",
+                  "结合兴趣与小而美项目的个体经营者"
+                ]
+              }
+            ],
+            "outro": "比起头衔本身，你更需要关注：这份工作是否尊重你的节奏？能否让你做出看得见、摸得着、你自己也满意的成果？"
+          },
+          "sort_order": 70,
+          "is_enabled": true
+        },
+        {
+          "section_key": "career.upgrade_suggestions",
+          "render_variant": "bullets",
+          "body_md": "对 ISFP-A 来说，职业成长不是把自己“改造成另一个人”，而是在保留真诚与温柔的前提下，给自己多一点表达、多一点边界感和多一点长期视角。\n\n你可以把下面这些，理解为帮助你在职场中稳步升级的小提示。",
+          "body_html": null,
+          "payload_json": {
+            "items": [
+              {
+                "title": "作品会说话，但你要帮它“被看到”",
+                "body": "适当学会为自己的成果配一段简单说明：我做了什么、为什么这样做、带来了什么改变。这不是炫耀，而是让别人有机会准确评价你的价值。"
+              },
+              {
+                "title": "温柔 ≠ 永远配合",
+                "body": "当任务明显与你的价值观冲突，或超出合理范围时，练习用平和但坚定的方式说“不”，而不是默默硬扛。"
+              },
+              {
+                "title": "当下舒适 × 长期方向",
+                "body": "你可以保持对当下体验的敏感，同时给自己设一个“长线主题”，例如：三年内我想在某个领域更专业一点。然后把它拆成若干小步，慢慢走也没关系。"
+              },
+              {
+                "title": "适度走出舒适区 = 为兴趣续命",
+                "body": "偶尔尝试接触一点点超出你习惯范围的挑战——比如开一次分享会、负责一个小项目。适度的不适感，会让你的才华被更多人看见，也能为你的自由与兴趣带来更多支撑。"
+              }
+            ]
+          },
+          "sort_order": 80,
+          "is_enabled": true
+        },
+        {
+          "section_key": "growth.summary",
+          "render_variant": "rich_text",
+          "body_md": "对 ISFP-A 来说，成长更多是“把自己活得更舒展”，而不是变成一个完全不同的人。你希望在不丢掉真诚与温柔的前提下，让自己更有底气、更有选择。\n\n这一章节，从强项、短板，到能量的来源与消耗，帮你更系统地看见：怎样的生活方式，才真正对你有利。",
+          "body_html": null,
+          "payload_json": null,
+          "sort_order": 90,
+          "is_enabled": true
+        },
+        {
+          "section_key": "growth.strengths",
+          "render_variant": "bullets",
+          "body_md": null,
+          "body_html": null,
+          "payload_json": {
+            "items": [
+              {
+                "title": "感受力强，懂得享受生活",
+                "body": "你能从日常小事中体会快乐——一杯好喝的饮料、一段喜欢的音乐、一次舒服的散步，都能让你“电量回升”。"
+              },
+              {
+                "title": "对自己相对宽容",
+                "body": "作为自信型 ISFP，你虽然也会在意他人评价，但更看重自己的标准，不太愿意为了迎合别人，彻底放弃自我感受。"
+              },
+              {
+                "title": "真诚，不喜欢表演人格",
+                "body": "你不擅长戴面具，也不愿意假装热情或强势。你更愿意用稳定、靠谱和不做作，来维系关系和机会。"
+              },
+              {
+                "title": "能在混乱中保持自己的节奏",
+                "body": "当环境很吵杂时，你反而能抓住“我现在能做什么”，不会轻易被裹挟到别人情绪里。你有一套属于自己的慢节奏。"
+              }
+            ]
+          },
+          "sort_order": 100,
+          "is_enabled": true
+        },
+        {
+          "section_key": "growth.weaknesses",
+          "render_variant": "bullets",
+          "body_md": null,
+          "body_html": null,
+          "payload_json": {
+            "items": [
+              {
+                "title": "不爱冲突，容易选择沉默",
+                "body": "当事情不对劲时，你常常选择“算了”而不是“说出来”。短期看是省事，长期看则可能让问题越积越多。"
+              },
+              {
+                "title": "长线规划容易模糊",
+                "body": "你更会问“我现在想怎样”，而不是“我五年后要变成什么样”。在重要节点，如果缺少一定程度的方向感，容易陷入反复犹豫。"
+              },
+              {
+                "title": "习惯自己消化情绪",
+                "body": "你不想麻烦别人，也不擅长把情绪“端出来”，于是常常自己消化到精疲力竭，对方却完全不知道你经历了什么。"
+              },
+              {
+                "title": "有时过于被动等待机会",
+                "body": "你知道自己有实力，但不太会主动“去争”。这样会让一些本可以属于你的机会，悄悄地绕开。"
+              }
+            ]
+          },
+          "sort_order": 110,
+          "is_enabled": true
+        },
+        {
+          "section_key": "growth.motivators",
+          "render_variant": "premium_teaser",
+          "body_md": "真实的喜欢、被尊重的空间、以及看得见的具体成果，都会让你觉得“继续做下去很值得”。当别人认可你的作品和用心，而不是只看表面的热闹，你会由衷地满足。",
+          "body_html": null,
+          "payload_json": {
+            "teaser": "真实的喜欢、被尊重的空间、以及看得见的具体成果，都会让你觉得“继续做下去很值得”。当别人认可你的作品和用心，而不是只看表面的热闹，你会由衷地满足。",
+            "is_premium": true
+          },
+          "sort_order": 120,
+          "is_enabled": true
+        },
+        {
+          "section_key": "growth.drainers",
+          "render_variant": "premium_teaser",
+          "body_md": "被频繁打断、被强行安排、或长期身处情绪紧绷的环境，会一点点抽干你的能量。尤其是当你既不能做自己，又无法拒绝时，你会很快进入“想逃离一切”的状态。",
+          "body_html": null,
+          "payload_json": {
+            "teaser": "被频繁打断、被强行安排、或长期身处情绪紧绷的环境，会一点点抽干你的能量。尤其是当你既不能做自己，又无法拒绝时，你会很快进入“想逃离一切”的状态。",
+            "is_premium": true
+          },
+          "sort_order": 130,
+          "is_enabled": true
+        },
+        {
+          "section_key": "relationships.summary",
+          "render_variant": "rich_text",
+          "body_md": "在关系里，你不是那种热烈张扬的类型，更像一条安静却稳定的情感河流——不喧哗，但一直存在。\n\n你习惯用“记得细节、默默陪伴、在关键时刻出现”来表达在乎，而不是每天说许多漂亮话。对你来说，真正的亲密，是可以一起安静，又可以放心做自己。",
+          "body_html": null,
+          "payload_json": null,
+          "sort_order": 140,
+          "is_enabled": true
+        },
+        {
+          "section_key": "relationships.strengths",
+          "render_variant": "bullets",
+          "body_md": null,
+          "body_html": null,
+          "payload_json": {
+            "items": [
+              {
+                "title": "用行动表达在乎",
+                "body": "你也许不太擅长热情告白，但会记得对方偏好的口味、讨厌的话题、重要的日子，并在细节里做出回应。"
+              },
+              {
+                "title": "尊重对方的边界与节奏",
+                "body": "你很少强迫别人按你的方式生活，反而会努力理解对方的节奏，让关系在“互相不过度打扰”的前提下自然生长。"
+              },
+              {
+                "title": "情绪稳定、不会无故制造戏剧",
+                "body": "你不爱无端争吵，也不擅长冷暴力。大部分时间你倾向于温和平静，不把小情绪变成大风暴。"
+              },
+              {
+                "title": "愿意在关系中一起体验生活",
+                "body": "你喜欢和亲近的人一起去感受世界——一顿好吃的、一场展览、一趟小旅行，而不是只在屏幕前聊天。"
+              }
+            ]
+          },
+          "sort_order": 150,
+          "is_enabled": true
+        },
+        {
+          "section_key": "relationships.weaknesses",
+          "render_variant": "bullets",
+          "body_md": null,
+          "body_html": null,
+          "payload_json": {
+            "items": [
+              {
+                "title": "不擅长主动谈“问题”",
+                "body": "当你在关系里不舒服时，你往往选择沉默或回避，期待时间慢慢冲淡。可惜很多时候，问题只会被掩盖，而不会自动消失。"
+              },
+              {
+                "title": "容易把失望闷在心里",
+                "body": "你不想伤害对方，也不想搞得太严肃，于是一次次选择“没关系”，结果久而久之，你自己会慢慢抽离。"
+              },
+              {
+                "title": "界限不清，容易被消耗",
+                "body": "如果遇到情绪需求特别高的对象，你可能会不断被拉去当“情绪垃圾桶”，却很少得到真正的回应和支持。"
+              },
+              {
+                "title": "害怕麻烦别人而压抑需求",
+                "body": "你其实也渴望被理解、被偏爱，只是习惯对自己说“算了，没关系”，久了会觉得：好像没有谁真的在意你的感受。"
+              }
+            ]
+          },
+          "sort_order": 160,
+          "is_enabled": true
+        },
+        {
+          "section_key": "relationships.rel_advantages",
+          "render_variant": "premium_teaser",
+          "body_md": "在健康的关系里，你能成为非常稳定、非常温柔的存在——不控制、不绑架、不表演。你给别人的是空间与安心，而不是压力与束缚。",
+          "body_html": null,
+          "payload_json": {
+            "teaser": "在健康的关系里，你能成为非常稳定、非常温柔的存在——不控制、不绑架、不表演。你给别人的是空间与安心，而不是压力与束缚。",
+            "is_premium": true
+          },
+          "sort_order": 170,
+          "is_enabled": true
+        },
+        {
+          "section_key": "relationships.rel_risks",
+          "render_variant": "premium_teaser",
+          "body_md": "当一段关系长期只有你在付出、你在体谅、你在降低期待，而对方习惯性忽视你的感受时，这段关系就开始消耗你的底色。学会识别这种模式，是保护自己的第一步。",
+          "body_html": null,
+          "payload_json": {
+            "teaser": "当一段关系长期只有你在付出、你在体谅、你在降低期待，而对方习惯性忽视你的感受时，这段关系就开始消耗你的底色。学会识别这种模式，是保护自己的第一步。",
+            "is_premium": true
+          },
+          "sort_order": 180,
+          "is_enabled": true
+        }
+      ],
+      "seo_overrides": {
+        "seo_title": "ISFP-A 探险家型",
+        "seo_description": "你像一阵轻柔的风：不爱高调登场，却总能悄悄把温暖和美感带进别人的生活。你习惯用行动、细节和陪伴去表达在乎，比起“说得多”，你更相信“做得到”。",
+        "canonical_url": null,
+        "og_title": "ISFP-A 自在感受者",
+        "og_description": "你像一阵轻柔的风：不爱高调登场，却总能悄悄把温暖和美感带进别人的生活。你习惯用行动、细节和陪伴去表达在乎，比起“说得多”，你更相信“做得到”。",
+        "og_image_url": null,
+        "twitter_title": "ISFP-A 自在感受者",
+        "twitter_description": "你像一阵轻柔的风：不爱高调登场，却总能悄悄把温暖和美感带进别人的生活。你习惯用行动、细节和陪伴去表达在乎，比起“说得多”，你更相信“做得到”。",
+        "twitter_image_url": null,
+        "robots": null,
+        "jsonld_overrides_json": null
+      }
+    },
+    {
+      "runtime_type_code": "ISFP-T",
+      "canonical_type_code": "ISFP",
+      "variant_code": "T",
+      "is_published": true,
+      "published_at": "2026-03-17T00:00:00Z",
+      "profile_overrides": {
+        "type_name": "探险家型",
+        "nickname": "温柔感受者",
+        "rarity_text": "约 4–9%",
+        "keywords_json": [
+          "感受力",
+          "自由",
+          "当下体验",
+          "审美",
+          "共情",
+          "随性"
+        ],
+        "hero_summary_md": "你像一束安静却柔软的光，不喧哗、不争抢，却总能悄悄照亮身边的一小块世界。你更习惯用行动、陪伴和细节去表达关心——不爱说大道理，但会在别人需要的时候，把温柔真实地递过去。",
+        "hero_summary_html": null
+      },
+      "section_overrides": [
+        {
+          "section_key": "letters_intro",
+          "render_variant": "letters_intro",
+          "body_md": null,
+          "body_html": null,
+          "payload_json": {
+            "headline": "内向 · 实感 · 情感 · 感知 · 动荡型｜用细腻感受拥抱世界的“温柔体验者”",
+            "letters": [
+              {
+                "letter": "I",
+                "title": "内向（I）",
+                "description": "让你更习惯在安全的小范围里自然绽放。你不排斥社交，但只有在放松、可信任的人面前，你才会真正打开心门。独处对你来说，是恢复电量、整理心情的必要时刻。"
+              },
+              {
+                "letter": "S",
+                "title": "实感（S）",
+                "description": "让你格外关注“当下的真实体验”：味道、光线、触感、气氛……你喜欢通过双眼、双手和身体去感受世界，而不是只活在概念和假设里。"
+              },
+              {
+                "letter": "F",
+                "title": "情感（F）",
+                "description": "使你在做决定时，会把“感受是否舒适”“对谁会造成影响”一起考虑进去。你不太愿意为了效率，牺牲掉关系的温度与个人的真心。"
+              },
+              {
+                "letter": "P",
+                "title": "感知（P）",
+                "description": "让你偏爱保留一点弹性和空间。你不喜欢被过度安排好的人生节奏，更享受“边走边看”“看到机会再跟进”的流动感。"
+              },
+              {
+                "letter": "T",
+                "title": "动荡型（-T）",
+                "description": "让你对自己的感受异常敏锐，同时对自己的选择略带不安。你会在心里反复确认：“这样做，真的是我想要的吗？” 这种敏感既是创作源泉，也是偶尔的压力来源。"
+              }
+            ]
+          },
+          "sort_order": 10,
+          "is_enabled": true
+        },
+        {
+          "section_key": "overview",
+          "render_variant": "rich_text",
+          "body_md": "在费马心理的逻辑模型里，ISFP-T 常被视作“温柔而真实的体验者”。你不擅长滔滔不绝地讲道理，却非常擅长用细节、行动和陪伴来表达自己——做一顿饭、送一个小礼物、安静地坐在旁边，都是你独特的语言。\n\n你对世界有着天然的审美和感受力：光影、音乐、文字、自然、一个人的情绪变化……都能打动你。你更在意“此刻是不是真实、舒服、有意义”，而不是永远活在抽象的远方目标里。\n\n当环境粗糙、关系功利、节奏被 KPI 和比较完全占据时，你会慢慢退到旁边，悄悄收起热情和创意——不是你没有想法，而是你不想在冷漠的土壤里勉强开花。你真正渴望的，是一种可以做自己、被温柔对待、也能温柔对待别人的生活方式。",
+          "body_html": null,
+          "payload_json": null,
+          "sort_order": 20,
+          "is_enabled": true
+        },
+        {
+          "section_key": "trait_overview",
+          "render_variant": "trait_dimension_grid",
+          "body_md": "建议与小程序中 5 条维度进度条搭配展示：外向 / 内向｜天马行空 / 求真务实｜情感细腻 / 理性思考｜运筹帷幄 / 随机应变｜情绪易波动 / 自信果断。",
+          "body_html": null,
+          "payload_json": {
+            "summary": "建议与小程序中 5 条维度进度条搭配展示：外向 / 内向｜天马行空 / 求真务实｜情感细腻 / 理性思考｜运筹帷幄 / 随机应变｜情绪易波动 / 自信果断。",
+            "dimensions": [
+              {
+                "id": "EI",
+                "name": "外向倾向",
+                "label": "外向倾向",
+                "axis_left": "外向",
+                "axis_right": "内向",
+                "summary": "明显偏内向",
+                "description": "你更像是安静观察世界的那类人：在人群里，你不急着发言，而是先感受气氛、看清每个人的状态。只有当你觉得足够安全、足够熟悉时，你才会慢慢展现出自己的幽默、温柔和独特想法。"
+              },
+              {
+                "id": "SN",
+                "name": "心智模式",
+                "label": "心智模式",
+                "axis_left": "天马行空",
+                "axis_right": "求真务实",
+                "summary": "略偏“求真务实”",
+                "description": "你确实会幻想和憧憬，但你的落脚点依然在“当下的具体体验”。相比遥远的大道理，你更关心：今天这个空间舒不舒服？这件事做起来有没有感觉？这个选择会不会让人很累？"
+              },
+              {
+                "id": "TF",
+                "name": "情绪天性",
+                "label": "情绪天性",
+                "axis_left": "情感细腻",
+                "axis_right": "理性思考",
+                "summary": "明显偏“情感细腻”",
+                "description": "你对情绪和氛围非常敏感：别人语气变了一点、眼神暗了一点、整间屋子的气压不一样了，你都能感觉出来。你不一定会直接指出，但会用更轻柔的方式去照顾和缓冲。"
+              },
+              {
+                "id": "JP",
+                "name": "应对方式",
+                "label": "应对方式",
+                "axis_left": "运筹帷幄",
+                "axis_right": "随机应变",
+                "summary": "偏“随机应变”",
+                "description": "你对严格时间表和过于刚性的计划有些抗拒，更乐于留一点空间给“灵感”和“临时的好主意”。你可以在有大方向的前提下，自然而然地调整细节和节奏。"
+              },
+              {
+                "id": "AT",
+                "name": "身份特征",
+                "label": "身份特征",
+                "axis_left": "情绪易波动",
+                "axis_right": "自信果断",
+                "summary": "略偏“情绪易波动”",
+                "description": "你常常在心里评估自己的表现：“我刚刚是不是有点冷？”“这样选择，会不会让人失望？”你不会大吵大闹，但会在安静的角落里反复回放那些让你在意的细节，这既让你更体贴，也让你更容易疲惫。"
+              }
+            ]
+          },
+          "sort_order": 30,
+          "is_enabled": true
+        },
+        {
+          "section_key": "career.summary",
+          "render_variant": "rich_text",
+          "body_md": "对 ISFP-T 来说，一份理想的工作，应该既能保留一定的自由度，又能让你做一些“有感觉”的事情——最好还能照顾到真实的人，而不是只和冷冰冰的报表打交道。\n\n你不太适合长期处在高度竞争、强控制、只看结果不看人的环境里。那些需要一直“硬撑着去拼”的岗位，会让你慢慢失去对生活的热情。\n\n相反，当一份工作允许你：把审美、手感、同理心、耐心投入进去，看到“因为你的存在，某个体验变得更舒服、更好看、更温柔”时，你会愿意认真地把它做到很细致。",
+          "body_html": null,
+          "payload_json": null,
+          "sort_order": 40,
+          "is_enabled": true
+        },
+        {
+          "section_key": "career.advantages",
+          "render_variant": "bullets",
+          "body_md": null,
+          "body_html": null,
+          "payload_json": {
+            "items": [
+              {
+                "title": "体验导向：善于优化“好不好用、舒不舒服”",
+                "body": "你天生会从使用者或当事人的角度去感受：这个流程顺不顺？这个空间舒服吗？这段服务有没有人味？很多时候，你能静静发现别人忽略的小细节。"
+              },
+              {
+                "title": "审美与品味",
+                "body": "不一定是传统意义上的“艺术家”，但你对配色、质感、氛围、呈现方式有自己的敏感直觉。你能把普通的东西做得更好看、更有温度。"
+              },
+              {
+                "title": "温和可靠的执行者",
+                "body": "在信任的人和团队里，你会认真地把分配给你的事情做到位，不吵不闹，但很稳。尤其在需要耐心、细致、照顾他人感受的工作中，你是一块安静但很重要的基石。"
+              },
+              {
+                "title": "共情与照顾情绪",
+                "body": "你不会把情绪问题简单打发，而是愿意听完对方的故事，以一种不评判的方式陪他走一段路。这在需要面对客户、患者、学员或用户的岗位上，非常难得。"
+              }
+            ]
+          },
+          "sort_order": 50,
+          "is_enabled": true
+        },
+        {
+          "section_key": "career.weaknesses",
+          "render_variant": "bullets",
+          "body_md": null,
+          "body_html": null,
+          "payload_json": {
+            "items": [
+              {
+                "title": "不擅长“自我推销”",
+                "body": "你很少主动刷存在感，不太会在会议上抢话、给自己争功劳。这可能导致你的价值被低估，别人只看到“这件事做完了”，没注意到你投入的心力。"
+              },
+              {
+                "title": "抗拒过度规则化和高压管理",
+                "body": "如果上级特别强势、制度僵硬、每天都在被催、被盯，你很容易本能地想逃离，而不是硬着头皮适应。长时间处在这种环境里，你会变得越来越没有动力。"
+              },
+              {
+                "title": "容易回避冲突与正面表达",
+                "body": "你不喜欢吵架和正面对抗，有时宁愿自己多承担一点，也不愿把不满摊开来说。久而久之，委屈堆积，会让你突然有“想离开一切”的冲动。"
+              },
+              {
+                "title": "节奏管理与长期规划较弱",
+                "body": "你更擅长短程冲刺，而不是长线规划和自我约束。在没有外部节奏或伙伴一起推进的情况下，你可能会在一些重要但不紧急的目标上反复拖延。"
+              }
+            ]
+          },
+          "sort_order": 60,
+          "is_enabled": true
+        },
+        {
+          "section_key": "career.preferred_roles",
+          "render_variant": "preferred_role_list",
+          "body_md": null,
+          "body_html": null,
+          "payload_json": {
+            "intro": "下面这些并不是 ISFP-T 唯一适合的岗位，而是更容易让你觉得“不那么窒息、比较有感觉”的方向，可以作为你职业探索的灵感参考。",
+            "groups": [
+              {
+                "group_title": "创意与审美相关",
+                "description": "可以把你的审美和体验感受，变成看得见的作品。",
+                "examples": [
+                  "平面设计、插画、摄影、视频剪辑",
+                  "服装设计、首饰 / 手作设计、室内软装",
+                  "新媒体内容创作（图文 / 视觉向）"
+                ]
+              },
+              {
+                "group_title": "人本照护与服务类",
+                "description": "在陪伴和服务中，给别人带来真实的安慰与支持。",
+                "examples": [
+                  "护理、康复、心理助理、宠物相关服务",
+                  "烘焙、咖啡、手作体验店、生活方式类门店",
+                  "美容、美甲、美发、芳疗等需要耐心与审美的服务岗位"
+                ]
+              },
+              {
+                "group_title": "教育与陪伴型工作",
+                "description": "用你的耐心、温柔和感受力，陪伴他人一点点变好。",
+                "examples": [
+                  "兴趣班老师（绘画、音乐、手工等）",
+                  "儿童陪伴师、助教、特需教育助理",
+                  "线下工作坊主理人、营地 / 活动辅导员"
+                ]
+              },
+              {
+                "group_title": "小而美的团队与项目",
+                "description": "在氛围好、关系近、人不多的环境里，把事做细、做暖，而不是被卷入大公司冷冰冰的流程。",
+                "examples": [
+                  "独立小店团队成员",
+                  "生活方式品牌 / 文创品牌的一线成员",
+                  "重视氛围与体验的精品团队"
+                ]
+              }
+            ],
+            "outro": "比起“职位名称多好听”，你更需要的是：可以被当作一个完整的人对待，有一定的自由度，可以慢慢把自己的温柔、审美和真诚融进工作里。"
+          },
+          "sort_order": 70,
+          "is_enabled": true
+        },
+        {
+          "section_key": "career.upgrade_suggestions",
+          "render_variant": "bullets",
+          "body_md": "对 ISFP-T 来说，职业发展的关键，不在于把自己变成另一个类型的人，而是：在保持真实与温柔的前提下，学会适度表达、设定边界，并让自己的价值被看见。\n\n下面这些“小公式”，可以帮助你在不违背天性的情况下，把路走得更稳一点。",
+          "body_html": null,
+          "payload_json": {
+            "items": [
+              {
+                "title": "被看见的温柔 = 真实付出 × 适度表达",
+                "body": "当你做了很多看不见的细节时，可以适当地在复盘或日常聊天中提一句：“这块我有稍微调整一下……”“这个部分我试着多做了一点。”这不是邀功，而是让别人知道，你在默默守护的地方。"
+              },
+              {
+                "title": "自由感 = 安排好的底层节奏 × 适度随性",
+                "body": "你不需要把生活排得像军训，但可以给自己设定一些“最低配的规律”，例如固定的工作时段、固定的投入练习时间。基础节奏稳住后，你就能在其上安心地随性。"
+              },
+              {
+                "title": "不爆炸的善良 = 共情力 ÷ 责任边界",
+                "body": "在帮别人之前，先在心里画一条线：“这部分是我愿意承担的，那一部分是对方自己的功课。”学会对自己说：我可以陪你，但不能代替你生活。"
+              },
+              {
+                "title": "长期成长感 = 持续练习 × 作品沉淀",
+                "body": "无论你做的是设计、手作、服务还是内容，都尽量留下“作品痕迹”：作品集、照片记录、故事案例……当你回头看时，这些都是你实力和成长最好的证明。"
+              }
+            ]
+          },
+          "sort_order": 80,
+          "is_enabled": true
+        },
+        {
+          "section_key": "growth.summary",
+          "render_variant": "rich_text",
+          "body_md": "对 ISFP-T 来说，成长不是把自己磨成一颗坚硬的石头，而是在保持柔软、真实与感受力的同时，学会照顾好自己，不再被情绪和环境牵着走。\n\n这一章节，会从你的强项、短板，以及能量相关的提示，帮助你更温柔地理解并升级自己。",
+          "body_html": null,
+          "payload_json": null,
+          "sort_order": 90,
+          "is_enabled": true
+        },
+        {
+          "section_key": "growth.strengths",
+          "render_variant": "bullets",
+          "body_md": null,
+          "body_html": null,
+          "payload_json": {
+            "items": [
+              {
+                "title": "感受力极强",
+                "body": "你能敏锐捕捉到环境和人心的微妙变化，也能从日常生活的细碎之处感受到美和意义——这是很多人羡慕却学不来的能力。"
+              },
+              {
+                "title": "真诚而不做作",
+                "body": "你不擅长装模作样，更不喜欢表面热闹、内里空洞的相处。你愿意慢一点、少一点，但希望每一次付出都是发自内心的。"
+              },
+              {
+                "title": "温柔的坚持",
+                "body": "在你真正重视的事情上，你会默默耗时间、反复打磨，不一定高调宣布，却会一步步把它做得更好。"
+              },
+              {
+                "title": "独特的审美与生活感",
+                "body": "你擅长让生活变得“好看一点、好闻一点、好吃一点”，哪怕预算有限，你也能挖掘出属于自己的小巧思。"
+              }
+            ]
+          },
+          "sort_order": 100,
+          "is_enabled": true
+        },
+        {
+          "section_key": "growth.weaknesses",
+          "render_variant": "bullets",
+          "body_md": null,
+          "body_html": null,
+          "payload_json": {
+            "items": [
+              {
+                "title": "容易被情绪困住",
+                "body": "当情绪下沉时，你会本能地想躲起来，什么都不想面对。有时候，哪怕只是迈出一小步，都会让你觉得很难。"
+              },
+              {
+                "title": "不善于拒绝和表达不满",
+                "body": "你害怕伤害别人，于是总是说“没事、都可以”，但实际上，你的在意一点都没有变少，只是变成了内耗。"
+              },
+              {
+                "title": "对长远规划有点抗拒",
+                "body": "你更擅长关注“眼前的这一段路”。一旦别人开始聊五年、十年规划，你很容易感到空空的、提不起劲。"
+              },
+              {
+                "title": "容易低估自己的价值",
+                "body": "你做了很多“柔软但重要”的事情，却常常不把它们当回事。久而久之，你甚至会怀疑：我好像也没什么厉害的。"
+              }
+            ]
+          },
+          "sort_order": 110,
+          "is_enabled": true
+        },
+        {
+          "section_key": "growth.motivators",
+          "render_variant": "premium_teaser",
+          "body_md": "被真诚地肯定、有人看见你做的小细节、能亲手把一件事做到更好看 / 更舒服 / 更有人味，这些都会让你内心发光。你越能把生活变成“有手感的作品”，就越不会被空洞的比较拖垮。",
+          "body_html": null,
+          "payload_json": {
+            "teaser": "被真诚地肯定、有人看见你做的小细节、能亲手把一件事做到更好看 / 更舒服 / 更有人味，这些都会让你内心发光。你越能把生活变成“有手感的作品”，就越不会被空洞的比较拖垮。",
+            "is_premium": true
+          },
+          "sort_order": 120,
+          "is_enabled": true
+        },
+        {
+          "section_key": "growth.drainers",
+          "render_variant": "premium_teaser",
+          "body_md": "持续被否定、被催促、被比较，以及长期压抑自己的需求、只能扮演“好说话的人”，会迅速掏空你的能量。当你频繁出现“想躲开所有人”的冲动时，很可能已经累积太久了。",
+          "body_html": null,
+          "payload_json": {
+            "teaser": "持续被否定、被催促、被比较，以及长期压抑自己的需求、只能扮演“好说话的人”，会迅速掏空你的能量。当你频繁出现“想躲开所有人”的冲动时，很可能已经累积太久了。",
+            "is_premium": true
+          },
+          "sort_order": 130,
+          "is_enabled": true
+        },
+        {
+          "section_key": "relationships.summary",
+          "render_variant": "rich_text",
+          "body_md": "在关系世界里，你更像一位“安静但很认真”的陪伴者。你不一定会说很多漂亮话，但会用实际行动、细节记忆和长期的在场感，来证明你对这段关系的重视。\n\n你最在意的，是这几件事：我在你面前能不能做自己？我的感受有没有被当回事？我们是不是在互相珍惜，而不是互相消耗？",
+          "body_html": null,
+          "payload_json": null,
+          "sort_order": 140,
+          "is_enabled": true
+        },
+        {
+          "section_key": "relationships.strengths",
+          "render_variant": "bullets",
+          "body_md": null,
+          "body_html": null,
+          "payload_json": {
+            "items": [
+              {
+                "title": "温柔而不打扰",
+                "body": "你习惯在不过界的前提下，默默照顾对方的感受：记住对方的喜好，在对方累的时候递上一杯水、留一句轻声的关心。你不喜欢把照顾变成压力。"
+              },
+              {
+                "title": "忠诚与长情",
+                "body": "一旦你认定了一段关系，很难轻易放弃。你愿意为对方做出调整和付出时间，只要你觉得这段关系仍然是真实和值得的。"
+              },
+              {
+                "title": "不评判的倾听者",
+                "body": "别人向你倾诉时，你很少急着给建议，而是先把对方的故事听完。你让人感觉“我这样也被接纳了”，这对很多人来说是一种很稀有的安全感。"
+              },
+              {
+                "title": "擅长营造小确幸",
+                "body": "你会用一些小巧思，让关系变得更有质感：一顿用心做的饭、一段专门为对方剪的歌单、一次安静散步……这些看起来不夸张，却会长久地留在回忆里。"
+              }
+            ]
+          },
+          "sort_order": 150,
+          "is_enabled": true
+        },
+        {
+          "section_key": "relationships.weaknesses",
+          "render_variant": "bullets",
+          "body_md": null,
+          "body_html": null,
+          "payload_json": {
+            "items": [
+              {
+                "title": "难以开口说“不”",
+                "body": "你宁愿自己多承担一点，也不愿让对方失望或难堪。久而久之，你会在关系里累积很多“说不出口”的不满和委屈。"
+              },
+              {
+                "title": "习惯自己消化情绪",
+                "body": "你不喜欢把负能量丢给别人，于是总是选择自己消化——一个人听歌、走路、发呆。可当压力太多时，这种方式就会变成一种孤独。"
+              },
+              {
+                "title": "容易吸引“索取型”对象",
+                "body": "你的温柔、好说话、愿意付出，很容易吸引那些习惯被照顾、却不太会回馈的人。如果你不设边界，关系会慢慢失衡。"
+              },
+              {
+                "title": "逃避正面冲突",
+                "body": "当问题需要摊开来解决时，你可能会下意识拖延，希望“时间冲淡一切”。但很多时候，该说而没说的，最终都会变成隔阂。"
+              }
+            ]
+          },
+          "sort_order": 160,
+          "is_enabled": true
+        },
+        {
+          "section_key": "relationships.rel_advantages",
+          "render_variant": "premium_teaser",
+          "body_md": "在健康的关系里，你是非常珍贵的存在——你带来的，是不夸张但扎实的温柔，是细致入微的体贴，是那种“被认真对待”的感觉。很多人会在事后才意识到：原来你一直都在。 ",
+          "body_html": null,
+          "payload_json": {
+            "teaser": "在健康的关系里，你是非常珍贵的存在——你带来的，是不夸张但扎实的温柔，是细致入微的体贴，是那种“被认真对待”的感觉。很多人会在事后才意识到：原来你一直都在。 ",
+            "is_premium": true
+          },
+          "sort_order": 170,
+          "is_enabled": true
+        },
+        {
+          "section_key": "relationships.rel_risks",
+          "render_variant": "premium_teaser",
+          "body_md": "如果你长期习惯只付出、不表达，只理解别人、不争取自己，你就很容易走进“看起来谁都喜欢你，但你在任何关系里都不真正被看见”的困境。学会为自己发声、识别不对等的关系，是你非常关键的课题。",
+          "body_html": null,
+          "payload_json": {
+            "teaser": "如果你长期习惯只付出、不表达，只理解别人、不争取自己，你就很容易走进“看起来谁都喜欢你，但你在任何关系里都不真正被看见”的困境。学会为自己发声、识别不对等的关系，是你非常关键的课题。",
+            "is_premium": true
+          },
+          "sort_order": 180,
+          "is_enabled": true
+        }
+      ],
+      "seo_overrides": {
+        "seo_title": "ISFP-T 探险家型",
+        "seo_description": "你像一束安静却柔软的光，不喧哗、不争抢，却总能悄悄照亮身边的一小块世界。你更习惯用行动、陪伴和细节去表达关心——不爱说大道理，但会在别人需要的时候，把温柔真实地递过去。",
+        "canonical_url": null,
+        "og_title": "ISFP-T 温柔感受者",
+        "og_description": "你像一束安静却柔软的光，不喧哗、不争抢，却总能悄悄照亮身边的一小块世界。你更习惯用行动、陪伴和细节去表达关心——不爱说大道理，但会在别人需要的时候，把温柔真实地递过去。",
+        "og_image_url": null,
+        "twitter_title": "ISFP-T 温柔感受者",
+        "twitter_description": "你像一束安静却柔软的光，不喧哗、不争抢，却总能悄悄照亮身边的一小块世界。你更习惯用行动、陪伴和细节去表达关心——不爱说大道理，但会在别人需要的时候，把温柔真实地递过去。",
+        "twitter_image_url": null,
+        "robots": null,
+        "jsonld_overrides_json": null
+      }
+    },
+    {
+      "runtime_type_code": "ISTJ-A",
+      "canonical_type_code": "ISTJ",
+      "variant_code": "A",
+      "is_published": true,
+      "published_at": "2026-03-17T00:00:00Z",
+      "profile_overrides": {
+        "type_name": "物流师型",
+        "nickname": "秩序守护者",
+        "rarity_text": "约 10–14%",
+        "keywords_json": [
+          "责任感",
+          "务实",
+          "条理",
+          "守规则",
+          "可靠",
+          "长期主义"
+        ],
+        "hero_summary_md": "你像一条安静却牢固的主干线：不喧哗、不抢风头，却悄悄撑起一整套秩序与稳定。只要你接手的事情，你就会按标准、一点点做完，让别人可以放心把背后交给你。",
+        "hero_summary_html": null
+      },
+      "section_overrides": [
+        {
+          "section_key": "letters_intro",
+          "render_variant": "letters_intro",
+          "body_md": null,
+          "body_html": null,
+          "payload_json": {
+            "headline": "内向 · 现实 · 思维 · 规划 · 坚定型｜以规则与责任感守住秩序的“秩序守护者”",
+            "letters": [
+              {
+                "letter": "I",
+                "title": "内向（I）",
+                "description": "让你更习惯在安静、有掌控感的环境中充电。你不排斥社交，但更偏好少数熟悉的人和有明确目的的交流。"
+              },
+              {
+                "letter": "S",
+                "title": "现实（S）",
+                "description": "让你关注事实、本地经验和当下细节。你更信服“看得见、摸得着”的东西，不太迷恋空洞的概念和想象。"
+              },
+              {
+                "letter": "T",
+                "title": "思维（T）",
+                "description": "让你在做决定时习惯先看逻辑、标准与效率，再考虑情绪与气氛。你会尽量把事情做对，而不是把话说得好听。"
+              },
+              {
+                "letter": "J",
+                "title": "规划（J）",
+                "description": "让你偏爱有计划、有流程的推进方式。你希望事情有明确的时间表和优先级，讨厌混乱、含糊和临时改来改去。"
+              },
+              {
+                "letter": "A",
+                "title": "坚定型（-A）",
+                "description": "让你的内心相对稳定，不太被外界评价轻易左右。你会先自查是否尽责，确认无愧于心后，就能安稳站在自己的判断上。"
+              }
+            ]
+          },
+          "sort_order": 10,
+          "is_enabled": true
+        },
+        {
+          "section_key": "overview",
+          "render_variant": "rich_text",
+          "body_md": "在费马心理的逻辑模型里，ISTJ-A 经常被视作“安静却不可或缺的秩序守护者”。你不喜欢夸张的场面，却愿意在所有人转身之后，继续把细节收拾好、把流程走完、把标准落实到位。\n\n对你来说，最舒服的状态是：规则清晰、分工明确、信息可靠，每个人都按约定做好自己那一份。在这样的环境里，你可以用稳定的节奏，一件件完成任务，建立起别人对你“交给他就放心”的长期信任。\n\n你的人生追求往往并不华丽，你更在意的是：事情有没有按照应有的标准完成？承诺是不是被兑现了？体系是否经得起时间和压力的检验。",
+          "body_html": null,
+          "payload_json": null,
+          "sort_order": 20,
+          "is_enabled": true
+        },
+        {
+          "section_key": "trait_overview",
+          "render_variant": "trait_dimension_grid",
+          "body_md": "建议与小程序中 5 条维度进度条搭配展示：外向 / 内向｜天马行空 / 求真务实｜情感细腻 / 理性思考｜运筹帷幄 / 随机应变｜情绪易波动 / 自信果断。",
+          "body_html": null,
+          "payload_json": {
+            "summary": "建议与小程序中 5 条维度进度条搭配展示：外向 / 内向｜天马行空 / 求真务实｜情感细腻 / 理性思考｜运筹帷幄 / 随机应变｜情绪易波动 / 自信果断。",
+            "dimensions": [
+              {
+                "id": "EI",
+                "name": "外向倾向",
+                "label": "外向倾向",
+                "axis_left": "外向",
+                "axis_right": "内向",
+                "summary": "明显偏内向",
+                "description": "你更习惯安静、可控的环境。一对一或小范围、有明确目的的交流，比大型聚会更让你舒服。长时间密集社交会让你觉得“电量被掏空”，需要独处来恢复。"
+              },
+              {
+                "id": "SN",
+                "name": "心智模式",
+                "label": "心智模式",
+                "axis_left": "天马行空",
+                "axis_right": "求真务实",
+                "summary": "明显偏“求真务实”",
+                "description": "你会优先关注眼前事实、具体数据和过往经验。你习惯用“证据”和“实际效果”来判断一件事，很难仅凭空想或情绪就被说服。"
+              },
+              {
+                "id": "TF",
+                "name": "情绪天性",
+                "label": "情绪天性",
+                "axis_left": "情感细腻",
+                "axis_right": "理性思考",
+                "summary": "偏“理性思考”",
+                "description": "你在表达时往往简洁直接，更关注“事情对不对、合不合理”，而不是“大家听起来舒不舒服”。你可能不会主动秀情绪，但这并不代表你冷漠。"
+              },
+              {
+                "id": "JP",
+                "name": "应对方式",
+                "label": "应对方式",
+                "axis_left": "运筹帷幄",
+                "axis_right": "随机应变",
+                "summary": "偏“运筹帷幄”",
+                "description": "你习惯事前规划、事中跟进、事后复盘。你不喜欢“走一步看一步”的混乱，更希望一开始就把目标、步骤、注意事项说清楚。"
+              },
+              {
+                "id": "AT",
+                "name": "身份特征",
+                "label": "身份特征",
+                "axis_left": "情绪易波动",
+                "axis_right": "自信果断",
+                "summary": "偏“自信果断”",
+                "description": "坚定型的你，一旦确认信息可靠、方案可行，就能相对笃定地执行下去，不会反复摇摆。你会认真对待反馈，但不会轻易被情绪性的评价带跑偏。"
+              }
+            ]
+          },
+          "sort_order": 30,
+          "is_enabled": true
+        },
+        {
+          "section_key": "career.summary",
+          "render_variant": "rich_text",
+          "body_md": "你的职业选择，通常会围绕“稳定”“可靠”“有明确规则”展开。只要有清晰的职责边界和可执行的标准，你就能用长期、一致的表现，让别人看到你的价值。\n\n你不太享受天天变方向、今天一个说法明天一个决策的环境；一旦目标前后不一致、规则说变就变，你会感到非常疲惫和不信任。\n\n相反，当一份工作允许你：踏实把事情做好、维护秩序、优化流程、守住底线，并在细节中持续打磨品质时，你会很有安全感，也更愿意在其中长期深耕。",
+          "body_html": null,
+          "payload_json": null,
+          "sort_order": 40,
+          "is_enabled": true
+        },
+        {
+          "section_key": "career.advantages",
+          "render_variant": "bullets",
+          "body_md": null,
+          "body_html": null,
+          "payload_json": {
+            "items": [
+              {
+                "title": "执行力稳定可靠",
+                "body": "你不追求耀眼的“爆发”，而是在日复一日的执行中，确保事情按标准完成。很多关键基础工作，正是因为有你这样的人，才能稳稳运转。"
+              },
+              {
+                "title": "注重细节与规范",
+                "body": "你敏感于流程漏洞、规则模糊和执行偏差，能发现别人忽略的小问题，并坚持把事情做到“该有的标准”。"
+              },
+              {
+                "title": "责任心强，说到做到",
+                "body": "一旦答应下来，你就会尽力做到，不喜欢“临时开天窗”。这让你在团队中很容易获得“靠谱”“可以托底”的口碑。"
+              },
+              {
+                "title": "冷静理性，抗压能力佳",
+                "body": "遇到突发情况时，你不会第一时间情绪化，而是先确认信息、理清优先级，再一步步处理。你的冷静，是团队在压力下的重要稳定器。"
+              }
+            ]
+          },
+          "sort_order": 50,
+          "is_enabled": true
+        },
+        {
+          "section_key": "career.weaknesses",
+          "render_variant": "bullets",
+          "body_md": null,
+          "body_html": null,
+          "payload_json": {
+            "items": [
+              {
+                "title": "对频繁变动敏感",
+                "body": "当目标、规则、流程被频繁修改时，你会觉得自己之前的投入被浪费，也很难在情绪上积极配合新的变动。"
+              },
+              {
+                "title": "不擅长表达情绪与功劳",
+                "body": "你习惯默默做好事，但不一定会主动汇报成果或争取认可，容易让人低估你的工作量和贡献。"
+              },
+              {
+                "title": "容易被视为“太死板”",
+                "body": "当你坚持原则、强调标准时，在不理解背景的人眼里，可能会被贴上“教条”“不通融”的标签。"
+              },
+              {
+                "title": "对人际细节不够敏锐",
+                "body": "你更习惯用“事情是否完成”来衡量合作质量，可能不太注意到别人情绪上的微小变化，导致沟通时显得有点生硬。"
+              }
+            ]
+          },
+          "sort_order": 60,
+          "is_enabled": true
+        },
+        {
+          "section_key": "career.preferred_roles",
+          "render_variant": "preferred_role_list",
+          "body_md": null,
+          "body_html": null,
+          "payload_json": {
+            "intro": "下面这些并不是唯一适合 ISTJ-A 的岗位，而是几类更容易发挥你优势的方向，可以作为职业选择与转型时的参考。",
+            "groups": [
+              {
+                "group_title": "流程与运营相关",
+                "description": "需要你用条理、耐心和规范意识来保障体系运转。",
+                "examples": [
+                  "运营专员 / 运营主管",
+                  "行政管理、办公室管理",
+                  "供应链、仓储、物流管理"
+                ]
+              },
+              {
+                "group_title": "专业与技术领域",
+                "description": "重视严谨、标准化和长期积累的岗位。",
+                "examples": [
+                  "财务、审计、税务、风控",
+                  "工程、质检、生产管理",
+                  "数据录入、文档管理、档案管理"
+                ]
+              },
+              {
+                "group_title": "秩序与规则维护",
+                "description": "需要你坚守原则、执行制度、确保公正的角色。",
+                "examples": [
+                  "人事管理、合规与法务助理",
+                  "安防、行政监察",
+                  "政府机关或事业单位中的事务岗位"
+                ]
+              },
+              {
+                "group_title": "稳定型管理职位",
+                "description": "在规则清晰的体系内，带领一个小团队稳步达成目标的岗位。",
+                "examples": [
+                  "班组长 / 线长",
+                  "门店 / 网点负责人",
+                  "成熟业务线的中基层管理者"
+                ]
+              }
+            ],
+            "outro": "对你来说，理想的工作不一定要光鲜，但要可靠、可积累、经得起时间检验——只要你能在其中持续打造秩序和质量，你就能做出长期成绩。"
+          },
+          "sort_order": 70,
+          "is_enabled": true
+        },
+        {
+          "section_key": "career.upgrade_suggestions",
+          "render_variant": "bullets",
+          "body_md": "对 ISTJ-A 来说，真正的升级，不是变成一个完全不一样的人，而是在保留你“可靠、稳、能托底”这些优势的基础上，给自己增加一点弹性与表达，让别人更容易看见你的价值。\n\n下面这几条，可以作为你在职场中持续微调的“小公式”。",
+          "body_html": null,
+          "payload_json": {
+            "items": [
+              {
+                "title": "执行力 × 沟通 = 可见价值",
+                "body": "在按标准把事情做好的同时，适当向上级和关键同事汇报进展与结果，让别人知道“事情为什么顺利”“是谁在托底”。这不是邀功，而是让信息完整。"
+              },
+              {
+                "title": "规则感 + 弹性 = 更高级的专业度",
+                "body": "当你坚持规则时，可以顺带解释“为什么要这样做”，并预留少量可协商空间。别人会发现你不是刻板，而是有原则、有思考的专业人士。"
+              },
+              {
+                "title": "长期主义 = 深耕一块 × 适度更新",
+                "body": "选择一两个你愿意长期钻研的方向（比如某种系统、某个领域的流程），持续迭代自己的方法论；同时每年尝试一点点新工具、新思路，避免陷入“只会老办法”的风险。"
+              },
+              {
+                "title": "稳定输出 = 自律节奏 × 有意识休息",
+                "body": "你已经足够自律，更需要的是“允许自己休息”。把休息看成维持长期战斗力的必须投入，而不是“偷懒”。当体力和情绪恢复，你的执行力才真正可持续。"
+              }
+            ]
+          },
+          "sort_order": 80,
+          "is_enabled": true
+        },
+        {
+          "section_key": "growth.summary",
+          "render_variant": "rich_text",
+          "body_md": "对 ISTJ-A 来说，成长往往不是“轰轰烈烈的大转变”，而是一点点优化：在保持自己可靠、务实、守信用的前提下，让自己在变化中也不至于僵硬，在关系中也不至于孤立。\n\n这一章节，会从你的强项、短板，以及能量来源与消耗点几个角度，帮你看清自己的成长轨迹。",
+          "body_html": null,
+          "payload_json": null,
+          "sort_order": 90,
+          "is_enabled": true
+        },
+        {
+          "section_key": "growth.strengths",
+          "render_variant": "bullets",
+          "body_md": null,
+          "body_html": null,
+          "payload_json": {
+            "items": [
+              {
+                "title": "自律与持续力",
+                "body": "你很少半途而废，更擅长用稳定的节奏把事情推进完。很多需要长期坚持的事情，对别人是挑战，对你只是“照做下去”。"
+              },
+              {
+                "title": "重视承诺与原则",
+                "body": "你会非常严肃地对待“答应”这件事，不轻易许诺，但一旦答应，就会尽力做到最好。你的原则感，也会成为别人信任你的重要原因。"
+              },
+              {
+                "title": "冷静、客观的判断力",
+                "body": "你不容易被情绪裹挟，遇事更愿意先看事实、查证信息，再下结论。这种特质在混乱、情绪化的环境中格外重要。"
+              },
+              {
+                "title": "长期主义的思维方式",
+                "body": "你不太在意短期的浮沉，更关注“这样做三五年后会怎样”。这让你适合搭建稳定体系，而不仅仅是追逐一阵子风口。"
+              }
+            ]
+          },
+          "sort_order": 100,
+          "is_enabled": true
+        },
+        {
+          "section_key": "growth.weaknesses",
+          "render_variant": "bullets",
+          "body_md": null,
+          "body_html": null,
+          "payload_json": {
+            "items": [
+              {
+                "title": "对变化的接受速度偏慢",
+                "body": "当外界要求你快速调整方向、尝试还没验证的新方法时，你会本能地抗拒，甚至需要更长的心理适应期。"
+              },
+              {
+                "title": "容易忽视情绪层面的需要",
+                "body": "你更习惯用“解决问题”的方式对待自己和别人，很少停下来单纯关心情绪感受，久而久之可能让身边人觉得“你不太懂安慰”。"
+              },
+              {
+                "title": "不善于表达内在脆弱",
+                "body": "你通常把压力消化在心里，不太愿意麻烦别人。外界看到的是“稳”，却看不到你独自硬扛的那部分。"
+              },
+              {
+                "title": "容易被贴上“固执”的标签",
+                "body": "当你坚持某个做法时，别人如果不理解你的逻辑，就可能只看到你的抗拒变化，而看不到你背后对风险与质量的担忧。"
+              }
+            ]
+          },
+          "sort_order": 110,
+          "is_enabled": true
+        },
+        {
+          "section_key": "growth.motivators",
+          "render_variant": "premium_teaser",
+          "body_md": "清晰的规则、稳定的预期、看得见的进步、以及来自少数可靠之人的肯定，都会成为你前进的重要燃料。被信任地托付关键任务，是你最有动力的状态之一。",
+          "body_html": null,
+          "payload_json": {
+            "teaser": "清晰的规则、稳定的预期、看得见的进步、以及来自少数可靠之人的肯定，都会成为你前进的重要燃料。被信任地托付关键任务，是你最有动力的状态之一。",
+            "is_premium": true
+          },
+          "sort_order": 120,
+          "is_enabled": true
+        },
+        {
+          "section_key": "growth.drainers",
+          "render_variant": "premium_teaser",
+          "body_md": "反复无常的决策、口头承诺不兑现、标准说变就变、以及“做多少都不被看见”的环境，会一点点消磨你的责任心与投入感。长期下去，你可能会选择只做最低限度。",
+          "body_html": null,
+          "payload_json": {
+            "teaser": "反复无常的决策、口头承诺不兑现、标准说变就变、以及“做多少都不被看见”的环境，会一点点消磨你的责任心与投入感。长期下去，你可能会选择只做最低限度。",
+            "is_premium": true
+          },
+          "sort_order": 130,
+          "is_enabled": true
+        },
+        {
+          "section_key": "relationships.summary",
+          "render_variant": "rich_text",
+          "body_md": "在关系世界里，你更像一位“安静可靠的守护者”。你不一定擅长甜言蜜语，但会通过实际行动、一贯的负责和稳定的陪伴，来表达在乎。\n\n你最看重的，不是表面有多热闹，而是：这个人靠不靠谱？这段关系是否长期？我们彼此是不是都在守信用、有底线？",
+          "body_html": null,
+          "payload_json": null,
+          "sort_order": 140,
+          "is_enabled": true
+        },
+        {
+          "section_key": "relationships.strengths",
+          "render_variant": "bullets",
+          "body_md": null,
+          "body_html": null,
+          "payload_json": {
+            "items": [
+              {
+                "title": "稳定、可依赖的存在",
+                "body": "只要你认定了一段关系，你就不会轻易松手。你会在关键时刻出现、在别人需要时伸手，用“在场”和“行动”证明你的重视。"
+              },
+              {
+                "title": "实际而务实的照顾方式",
+                "body": "你或许不太会说一大段安慰的话，但会默默帮对方处理掉堆在那里的麻烦事，用解决问题来表达关心。"
+              },
+              {
+                "title": "尊重边界、不过度打扰",
+                "body": "你不会对重要的人“粘得喘不过气”，而是保持一种有分寸的陪伴：在对方需要你时，你肯定在；在对方想独处时，你也能理解。"
+              },
+              {
+                "title": "忠诚与长情",
+                "body": "你不喜欢反复换圈子、换立场。一旦真正把谁放进心里，你会尽量为这段关系留下余地、争取机会，不轻易说放弃。"
+              }
+            ]
+          },
+          "sort_order": 150,
+          "is_enabled": true
+        },
+        {
+          "section_key": "relationships.weaknesses",
+          "render_variant": "bullets",
+          "body_md": null,
+          "body_html": null,
+          "payload_json": {
+            "items": [
+              {
+                "title": "情绪表达含蓄",
+                "body": "你更多通过行动而不是言语来表达爱，这在有些人眼里会被误解为“不够热情”或“不在乎”。"
+              },
+              {
+                "title": "不习惯示弱与求助",
+                "body": "你习惯自己扛事，很少坦白自己的疲惫和压力。这容易让对方以为你“什么都不需要”，久而久之，你也会觉得自己在关系里“像个工具人”。"
+              },
+              {
+                "title": "对他人不稳定行为的容忍度低",
+                "body": "迟到、反复爽约、说话不算数，会严重消耗你对一个人的信任，也会让你逐渐疏远这段关系。"
+              },
+              {
+                "title": "不擅长处理情绪化冲突",
+                "body": "当对方在情绪中表达时，你可能会觉得“很不讲道理”，从而选择沉默或退出对话，而不是去理解背后的感受。"
+              }
+            ]
+          },
+          "sort_order": 160,
+          "is_enabled": true
+        },
+        {
+          "section_key": "relationships.rel_advantages",
+          "render_variant": "premium_teaser",
+          "body_md": "当你遇到同样珍惜承诺、尊重边界、重视长期关系的人，你会成为对方生命中极少数“可以一直依靠”的存在。你不制造戏剧性，但能提供极高的安全感和可靠度。",
+          "body_html": null,
+          "payload_json": {
+            "teaser": "当你遇到同样珍惜承诺、尊重边界、重视长期关系的人，你会成为对方生命中极少数“可以一直依靠”的存在。你不制造戏剧性，但能提供极高的安全感和可靠度。",
+            "is_premium": true
+          },
+          "sort_order": 170,
+          "is_enabled": true
+        },
+        {
+          "section_key": "relationships.rel_risks",
+          "render_variant": "premium_teaser",
+          "body_md": "如果你长期把照顾、负责、稳定都揽在自己身上，却得不到足够的回馈与理解，你可能会对关系本身失望，甚至在某一刻突然抽离。学会在过程里表达需求，而不是在临界点才爆发，对你来说非常重要。",
+          "body_html": null,
+          "payload_json": {
+            "teaser": "如果你长期把照顾、负责、稳定都揽在自己身上，却得不到足够的回馈与理解，你可能会对关系本身失望，甚至在某一刻突然抽离。学会在过程里表达需求，而不是在临界点才爆发，对你来说非常重要。",
+            "is_premium": true
+          },
+          "sort_order": 180,
+          "is_enabled": true
+        }
+      ],
+      "seo_overrides": {
+        "seo_title": "ISTJ-A 物流师型",
+        "seo_description": "你像一条安静却牢固的主干线：不喧哗、不抢风头，却悄悄撑起一整套秩序与稳定。只要你接手的事情，你就会按标准、一点点做完，让别人可以放心把背后交给你。",
+        "canonical_url": null,
+        "og_title": "ISTJ-A 秩序守护者",
+        "og_description": "你像一条安静却牢固的主干线：不喧哗、不抢风头，却悄悄撑起一整套秩序与稳定。只要你接手的事情，你就会按标准、一点点做完，让别人可以放心把背后交给你。",
+        "og_image_url": null,
+        "twitter_title": "ISTJ-A 秩序守护者",
+        "twitter_description": "你像一条安静却牢固的主干线：不喧哗、不抢风头，却悄悄撑起一整套秩序与稳定。只要你接手的事情，你就会按标准、一点点做完，让别人可以放心把背后交给你。",
+        "twitter_image_url": null,
+        "robots": null,
+        "jsonld_overrides_json": null
+      }
+    },
+    {
+      "runtime_type_code": "ISTJ-T",
+      "canonical_type_code": "ISTJ",
+      "variant_code": "T",
+      "is_published": true,
+      "published_at": "2026-03-17T00:00:00Z",
+      "profile_overrides": {
+        "type_name": "物流师型",
+        "nickname": "秩序守护者",
+        "rarity_text": "约 10–13%",
+        "keywords_json": [
+          "务实",
+          "责任感",
+          "守规则",
+          "稳健执行",
+          "可靠",
+          "自律"
+        ],
+        "hero_summary_md": "你像一块安静却可靠的基石：不张扬、不抢镜，却在关键处托住全场的稳定。你相信，世界要靠“说到做到”和扎扎实实的执行才不会塌，而你愿意做那个默默把事情做到位的人。",
+        "hero_summary_html": null
+      },
+      "section_overrides": [
+        {
+          "section_key": "letters_intro",
+          "render_variant": "letters_intro",
+          "body_md": null,
+          "body_html": null,
+          "payload_json": {
+            "headline": "内向 · 现实 · 理性 · 规划 · 动荡型｜稳重务实、可靠守序的“秩序守护者”",
+            "letters": [
+              {
+                "letter": "I",
+                "title": "内向（I）",
+                "description": "让你更偏爱安静、专注的环境。你不排斥社交，但更习惯在熟悉的人和稳定的场景里蓄力，而不是在大场面上“刷存在感”。"
+              },
+              {
+                "letter": "S",
+                "title": "现实（S）",
+                "description": "让你更关注看得见、摸得着的事实和细节。相较于遥远的理想，你更在意：现在的数据是否准确？流程是否合理？步骤有没有漏？"
+              },
+              {
+                "letter": "T",
+                "title": "理性（T）",
+                "description": "让你在做决定时更看重逻辑、公平和效率。你会问自己：“这样做合不合理？有没有事实依据？” 而不是单纯为了迎合气氛。"
+              },
+              {
+                "letter": "J",
+                "title": "规划（J）",
+                "description": "让你习惯提前计划、按步骤推进。清晰的时间表、明确的分工会让你感觉踏实，而混乱和临时变动会明显耗损你的能量。"
+              },
+              {
+                "letter": "T",
+                "title": "动荡型（-T）",
+                "description": "让你对自己要求严格，总会在心里复盘：“我有没有更好的做法？” 这种自我审视帮助你不断提升，但有时也会带来压力和自我苛责。"
+              }
+            ]
+          },
+          "sort_order": 10,
+          "is_enabled": true
+        },
+        {
+          "section_key": "overview",
+          "render_variant": "rich_text",
+          "body_md": "在费马心理的逻辑模型里，ISTJ-T 常被视作“秩序的守护者”。你安静、谨慎、负责，习惯站在喧闹背后，用踏实的行动撑起一整套运转体系。\n\n对你来说，最安全、最舒服的状态是：信息清楚、规则明确、流程稳定，每个人知道自己该做什么，事情按标准一步步落地。面对混乱和含糊，你不会大喊大叫，而是默默去查、去核对、去把该理顺的细节理好。\n\n你的人生追求很少停留在“说得好听”，而是更在意“实际到底做到什么程度”。你不一定喜欢站在台前，但很多时候，真正让系统不出错、让承诺不落空的，正是像你这样的人。",
+          "body_html": null,
+          "payload_json": null,
+          "sort_order": 20,
+          "is_enabled": true
+        },
+        {
+          "section_key": "trait_overview",
+          "render_variant": "trait_dimension_grid",
+          "body_md": "建议与小程序中 5 条维度进度条搭配展示：外向 / 内向｜天马行空 / 求真务实｜情感细腻 / 理性思考｜运筹帷幄 / 随机应变｜情绪易波动 / 自信果断。",
+          "body_html": null,
+          "payload_json": {
+            "summary": "建议与小程序中 5 条维度进度条搭配展示：外向 / 内向｜天马行空 / 求真务实｜情感细腻 / 理性思考｜运筹帷幄 / 随机应变｜情绪易波动 / 自信果断。",
+            "dimensions": [
+              {
+                "id": "EI",
+                "name": "外向倾向",
+                "label": "外向倾向",
+                "axis_left": "外向",
+                "axis_right": "内向",
+                "summary": "略偏内向",
+                "description": "你更习惯在熟悉的小圈子里表达自己，在不熟的场合会先观察再开口。独处不会让你觉得孤单，反而能帮你整理思路、恢复能量。长时间高强度的社交，会让你想找个安静角落“缓一缓”。"
+              },
+              {
+                "id": "SN",
+                "name": "心智模式",
+                "label": "心智模式",
+                "axis_left": "天马行空",
+                "axis_right": "求真务实",
+                "summary": "偏“求真务实”",
+                "description": "你更信任数据、经验和验证过的做法。面对一个新想法，你下意识会问：“证据在哪里？流程怎么落地？风险点在哪？” 听上去也许“不够浪漫”，但正是这份务实，让你能在关键时刻守住底线。"
+              },
+              {
+                "id": "TF",
+                "name": "情绪天性",
+                "label": "情绪天性",
+                "axis_left": "情感细腻",
+                "axis_right": "理性思考",
+                "summary": "偏“理性思考”",
+                "description": "你在情绪表达上偏克制，遇事先看事实再谈感受。你很重视“公平”和“合规”，不喜欢被情绪绑架。只是有时候，你心里其实已经在难过或生气，却依然习惯用“没事，我再想想办法”来压住。"
+              },
+              {
+                "id": "JP",
+                "name": "应对方式",
+                "label": "应对方式",
+                "axis_left": "运筹帷幄",
+                "axis_right": "随机应变",
+                "summary": "偏“运筹帷幄”",
+                "description": "你喜欢有计划、有步骤地行动。在你眼里，一件事如果前期没想清楚、没有预案，后面就很容易出问题。你擅长制定流程、梳理标准、设立检查点，用结构化的方式保证事情“不出差错”。"
+              },
+              {
+                "id": "AT",
+                "name": "身份特征",
+                "label": "身份特征",
+                "axis_left": "情绪易波动",
+                "axis_right": "自信果断",
+                "summary": "略偏“情绪易波动”",
+                "description": "动荡型的你，对错误和失误非常敏感。外表上你可能显得冷静，但内心会反复回放细节：“那一步是不是我漏了？”、“当时要是再仔细一点就好了。” 这让你越来越可靠，同时也容易在看不见的地方消耗自己。"
+              }
+            ]
+          },
+          "sort_order": 30,
+          "is_enabled": true
+        },
+        {
+          "section_key": "career.summary",
+          "render_variant": "rich_text",
+          "body_md": "你的职业选择，通常围绕“稳定”“靠谱”“可控”这几个关键词展开。只要工作内容清晰、规则明确、流程可追溯，你就能发挥出很强的执行力和责任感。\n\n长期高不确定、说变就变、没人负责收尾的环境，会让你非常疲惫，也难以真正信任这份工作。你更适合在有一定秩序基础上，持续打磨质量、优化流程、把事做细做稳。\n\n当一份工作允许你：制定或维护标准、保证系统正常运转、让混乱变得有条理，并因自己的可靠而被信任时，你通常会获得比较持久的成就感。",
+          "body_html": null,
+          "payload_json": null,
+          "sort_order": 40,
+          "is_enabled": true
+        },
+        {
+          "section_key": "career.advantages",
+          "render_variant": "bullets",
+          "body_md": null,
+          "body_html": null,
+          "payload_json": {
+            "items": [
+              {
+                "title": "执行力强，落地能力稳",
+                "body": "交到你手上的任务，大概率会被踏踏实实地完成。你不爱空谈，不需要太多口号，只要给出清晰目标和必要资源，你就能把事情一步步推进到位。"
+              },
+              {
+                "title": "重视规则与流程",
+                "body": "你很在意制度、公平和合规性。你会主动发现流程中的漏洞和风险点，提出改进建议，避免团队“踩坑”或重复犯错。"
+              },
+              {
+                "title": "细节敏感度高",
+                "body": "别人一眼看过去“差不多”的地方，你往往能发现数据上的错误、逻辑上的不顺或文档里的疏漏。你是团队中非常重要的“质量把关者”。"
+              },
+              {
+                "title": "稳定可靠的存在感",
+                "body": "你不会刻意抢风头，但周围人会下意识觉得：“这件事交给 TA，我就放心了。” 这种低调的可靠，是许多团队能长久运转的底层支撑。"
+              }
+            ]
+          },
+          "sort_order": 50,
+          "is_enabled": true
+        },
+        {
+          "section_key": "career.weaknesses",
+          "render_variant": "bullets",
+          "body_md": null,
+          "body_html": null,
+          "payload_json": {
+            "items": [
+              {
+                "title": "对变化和模糊不够友好",
+                "body": "当目标总在变、规则说改就改、信息不完整时，你会明显感到焦虑和抗拒，很难像一些人那样“先做了再说”。"
+              },
+              {
+                "title": "说话有时过于直接",
+                "body": "为了保证事情做对，你会直接指出问题和漏洞。但在不熟悉你的人眼中，这种直接可能被理解成“挑剔”或“难相处”。"
+              },
+              {
+                "title": "容易被动承担更多责任",
+                "body": "因为你做事仔细、犯错少，系统会下意识把更多关键环节压在你身上。久而久之，你可能发现：自己总是在收拾别人留下的烂摊子。"
+              },
+              {
+                "title": "不善于“包装成果”",
+                "body": "你习惯“做好比说好更重要”，但在很多组织里，“呈现与沟通”本身也是工作的一部分。如果你只埋头做事，很容易被低估价值。"
+              }
+            ]
+          },
+          "sort_order": 60,
+          "is_enabled": true
+        },
+        {
+          "section_key": "career.preferred_roles",
+          "render_variant": "preferred_role_list",
+          "body_md": null,
+          "body_html": null,
+          "payload_json": {
+            "intro": "下面这些并不是唯一适合 ISTJ-T 的岗位，而是几类更容易让你发挥稳定、可靠特质的方向，可以作为职业探索的参考。",
+            "groups": [
+              {
+                "group_title": "系统与流程相关岗位",
+                "description": "需要长期维护秩序、确保运转稳定的角色。",
+                "examples": [
+                  "行政管理、办公室管理",
+                  "项目执行 / PMO（项目管理办公室）",
+                  "供应链、物流管理、仓储管理"
+                ]
+              },
+              {
+                "group_title": "质量与风控相关岗位",
+                "description": "以“守住底线、降低风险”为目标的领域。",
+                "examples": [
+                  "质检、审计、合规、风控",
+                  "财务管理、数据核查、报表管理",
+                  "生产现场管理、安全管理"
+                ]
+              },
+              {
+                "group_title": "稳定细致型专业岗位",
+                "description": "需要专注力、耐心和高标准执行的工作。",
+                "examples": [
+                  "文档 / 档案管理、采购、合同管理",
+                  "医药、检验、实验室技术类岗位",
+                  "工程技术类中后端执行岗位"
+                ]
+              },
+              {
+                "group_title": "秩序维护类岗位",
+                "description": "强调规则、公平和责任感的领域。",
+                "examples": [
+                  "公务 / 事业单位中的执行岗",
+                  "司法、行政执法、纪检等相关岗位"
+                ]
+              }
+            ],
+            "outro": "对你来说，最重要的不是“多炫的头衔”，而是这份工作是否允许你：把事情做对、把系统维护好，并在长期的可靠中，慢慢积累属于自己的安全感与成就感。"
+          },
+          "sort_order": 70,
+          "is_enabled": true
+        },
+        {
+          "section_key": "career.upgrade_suggestions",
+          "render_variant": "bullets",
+          "body_md": "对 ISTJ-T 来说，职业发展的关键点往往不在“再辛苦一点”，而在于：学会在坚持原则的同时，多一些弹性和表达，让别人真正看见你的价值。",
+          "body_html": null,
+          "payload_json": {
+            "items": [
+              {
+                "title": "规则感 + 弹性度",
+                "body": "你对规则的尊重，是非常难得的优势。但在现实职场里，很多情况并非“非黑即白”。尝试在不违背底线的前提下，为自己预留一些“机动空间”，会让合作更顺畅。"
+              },
+              {
+                "title": "执行力 × 可见度",
+                "body": "不仅要把事情做对，也要适度地让别人知道你做了什么、解决了什么问题。可以在汇报或复盘时，简洁地用数据 + 关键节点呈现你的贡献。"
+              },
+              {
+                "title": "稳定输出 = 节奏管理",
+                "body": "你习惯“有事就扛”，但真正可持续的方式是：在长期项目中，给自己设定阶段性缓冲区。忙完一个大节点，就允许自己短暂放松，而不是立刻接下一波任务。"
+              },
+              {
+                "title": "边界清晰 = 责任更可控",
+                "body": "当别人把本该自己负责的部分推给你时，可以学着说：“这一块我可以帮你一起看，但主要责任还是在你那边。” 这不是冷漠，而是让合作回到更健康的状态。"
+              }
+            ]
+          },
+          "sort_order": 80,
+          "is_enabled": true
+        },
+        {
+          "section_key": "growth.summary",
+          "render_variant": "rich_text",
+          "body_md": "对 ISTJ-T 来说，成长并不意味着变成一个完全不同的人，而是在“稳重、务实、可靠”的底色上，多一点柔软、弹性和自我接纳。\n\n这一章节，会从你的强项、短板，以及能量的来源和消耗几个角度，帮你更清晰地看见自己的成长路径。",
+          "body_html": null,
+          "payload_json": null,
+          "sort_order": 90,
+          "is_enabled": true
+        },
+        {
+          "section_key": "growth.strengths",
+          "render_variant": "bullets",
+          "body_md": null,
+          "body_html": null,
+          "payload_json": {
+            "items": [
+              {
+                "title": "愿意为责任买单",
+                "body": "你不喜欢空头承诺，一旦答应了，就会尽力做到。这种“说到做到”的特质，让人很容易把重要任务放心交给你。"
+              },
+              {
+                "title": "能在长期投入中坚持不懈",
+                "body": "你不追求一时的轰动，更在意长期的稳定积累。无论是学习、工作还是生活习惯，你都有潜力把事情一步步打磨到很扎实。"
+              },
+              {
+                "title": "对风险保持警觉",
+                "body": "你会自然去关注“可能出问题的地方”，提前设防，避免不必要的损失。这让你在很多团队中扮演着“安全阀”的角色。"
+              },
+              {
+                "title": "自我要求高，持续改进",
+                "body": "你习惯复盘自己的行为和决策，找出可改进之处。虽然这种习惯有时会带来压力，但也让你拥有稳定成长的内在驱动力。"
+              }
+            ]
+          },
+          "sort_order": 100,
+          "is_enabled": true
+        },
+        {
+          "section_key": "growth.weaknesses",
+          "render_variant": "bullets",
+          "body_md": null,
+          "body_html": null,
+          "payload_json": {
+            "items": [
+              {
+                "title": "容易被贴上“死板”的标签",
+                "body": "当你坚持规则、按标准办事时，别人可能只看到你的严格，而忽略你背后是在“为结果负责”。如果缺少沟通，这种误解容易积累。"
+              },
+              {
+                "title": "对自己不够温柔",
+                "body": "你很少为自己找借口，更习惯“算在我头上”。久而久之，你会对自己的每一个失误都记得很清楚，却很少认真表扬自己。"
+              },
+              {
+                "title": "不擅长表达脆弱",
+                "body": "即使很累、很委屈，你也习惯咬咬牙继续扛，害怕给别人添麻烦。久而久之，身边人可能真以为你“什么都扛得住”。"
+              },
+              {
+                "title": "对新事物起步时较慢",
+                "body": "面对全新的领域，你会比别人多花时间去查证、对比、思考风险。这在长期是优势，但在需要快速试错的环境里，可能会让你显得“节奏偏慢”。"
+              }
+            ]
+          },
+          "sort_order": 110,
+          "is_enabled": true
+        },
+        {
+          "section_key": "growth.motivators",
+          "render_variant": "premium_teaser",
+          "body_md": "清晰的目标、稳定的环境、被信任地托付重要任务，以及看见自己长期努力换来的可靠成果，都会让你感觉：“我在默默撑着一块很重要的地方。”",
+          "body_html": null,
+          "payload_json": {
+            "teaser": "清晰的目标、稳定的环境、被信任地托付重要任务，以及看见自己长期努力换来的可靠成果，都会让你感觉：“我在默默撑着一块很重要的地方。”",
+            "is_premium": true
+          },
+          "sort_order": 120,
+          "is_enabled": true
+        },
+        {
+          "section_key": "growth.drainers",
+          "render_variant": "premium_teaser",
+          "body_md": "反复无常的要求、缺乏说明的变动、没人负责收尾的烂摊子，以及“做得多、被看见少”的长期状态，会一点点消耗你的耐心和热情。",
+          "body_html": null,
+          "payload_json": {
+            "teaser": "反复无常的要求、缺乏说明的变动、没人负责收尾的烂摊子，以及“做得多、被看见少”的长期状态，会一点点消耗你的耐心和热情。",
+            "is_premium": true
+          },
+          "sort_order": 130,
+          "is_enabled": true
+        },
+        {
+          "section_key": "relationships.summary",
+          "render_variant": "rich_text",
+          "body_md": "在关系世界里，你不像那种特别会“甜言蜜语”的类型，但常常用一种安静而实际的方式在表达在乎——记得对方说过的话，按时完成承诺的事，在关键时刻帮忙顶上。\n\n你最看重的，不是表面多么热络，而是：对方是否可靠？这段关系能不能经得住时间和现实的考验？在彼此都不轻松的时候，还愿不愿意站在一起？",
+          "body_html": null,
+          "payload_json": null,
+          "sort_order": 140,
+          "is_enabled": true
+        },
+        {
+          "section_key": "relationships.strengths",
+          "render_variant": "bullets",
+          "body_md": null,
+          "body_html": null,
+          "payload_json": {
+            "items": [
+              {
+                "title": "稳重踏实的陪伴",
+                "body": "你可能不常把爱挂在嘴边，但会用很具体的方式支持对方：接送、帮忙处理麻烦、记得对方的重要日子、在对方需要时出现。"
+              },
+              {
+                "title": "界限清晰的尊重",
+                "body": "你不会轻易越界干涉别人的私人领域，也不喜欢被人过度打扰。这种对边界的尊重，在健康关系里会成为一种安全感。"
+              },
+              {
+                "title": "忠诚度高",
+                "body": "一旦认定是要长期走下去的关系，你会很认真地维护，尽力做到不轻易食言、不随便离场。你更在意“走得久”，而不是一时的浪漫。"
+              },
+              {
+                "title": "危机时刻值得依靠",
+                "body": "当对方慌乱、情绪失控时，你往往能保持相对冷静，先把关键问题处理好，让事情不至于失控。事后你可能会累，但当下你确实撑住了局面。"
+              }
+            ]
+          },
+          "sort_order": 150,
+          "is_enabled": true
+        },
+        {
+          "section_key": "relationships.weaknesses",
+          "render_variant": "bullets",
+          "body_md": null,
+          "body_html": null,
+          "payload_json": {
+            "items": [
+              {
+                "title": "表达方式偏克制",
+                "body": "你心里可能很在乎，但嘴上常常只说“还好”“没事”，时间久了，对方会误以为“你不需要被安慰”或者“你是不是没那么在意这段关系”。"
+              },
+              {
+                "title": "不善于处理突如其来的情绪",
+                "body": "面对强烈的情绪宣泄（比如哭闹、指责、翻旧账），你会下意识想“先冷静、讲道理”，但对方此刻可能更需要的是情感共鸣而不是分析。"
+              },
+              {
+                "title": "容易把自己的感受排在最后",
+                "body": "你习惯先照顾好事情、顾好责任，再回头看自己。久而久之，你可能连自己真实的情绪需求是什么都不太确定。"
+              },
+              {
+                "title": "不擅长主动求助",
+                "body": "遇到困难时，你更倾向于自己扛，而不是开口说“我也需要帮忙”。这会让关系呈现出一种不平衡：你总扮演“支撑别人”的角色，却很少被别人支撑。"
+              }
+            ]
+          },
+          "sort_order": 160,
+          "is_enabled": true
+        },
+        {
+          "section_key": "relationships.rel_advantages",
+          "render_variant": "premium_teaser",
+          "body_md": "在健康的人际关系里，你是那个“关键时刻绝不会掉链子”的人。你给出的承诺往往很克制，但一旦说出口，就会努力做到，这种可靠感，是很多人一生都在寻找的东西。",
+          "body_html": null,
+          "payload_json": {
+            "teaser": "在健康的人际关系里，你是那个“关键时刻绝不会掉链子”的人。你给出的承诺往往很克制，但一旦说出口，就会努力做到，这种可靠感，是很多人一生都在寻找的东西。",
+            "is_premium": true
+          },
+          "sort_order": 170,
+          "is_enabled": true
+        },
+        {
+          "section_key": "relationships.rel_risks",
+          "render_variant": "premium_teaser",
+          "body_md": "如果长时间处在“我在付出、对方在习惯”的关系模式中，你会一边继续负责，一边在心里慢慢失望。学会识别哪些关系值得继续投入，哪些应该适当抽离，对你尤为重要。",
+          "body_html": null,
+          "payload_json": {
+            "teaser": "如果长时间处在“我在付出、对方在习惯”的关系模式中，你会一边继续负责，一边在心里慢慢失望。学会识别哪些关系值得继续投入，哪些应该适当抽离，对你尤为重要。",
+            "is_premium": true
+          },
+          "sort_order": 180,
+          "is_enabled": true
+        }
+      ],
+      "seo_overrides": {
+        "seo_title": "ISTJ-T 物流师型",
+        "seo_description": "你像一块安静却可靠的基石：不张扬、不抢镜，却在关键处托住全场的稳定。你相信，世界要靠“说到做到”和扎扎实实的执行才不会塌，而你愿意做那个默默把事情做到位的人。",
+        "canonical_url": null,
+        "og_title": "ISTJ-T 秩序守护者",
+        "og_description": "你像一块安静却可靠的基石：不张扬、不抢镜，却在关键处托住全场的稳定。你相信，世界要靠“说到做到”和扎扎实实的执行才不会塌，而你愿意做那个默默把事情做到位的人。",
+        "og_image_url": null,
+        "twitter_title": "ISTJ-T 秩序守护者",
+        "twitter_description": "你像一块安静却可靠的基石：不张扬、不抢镜，却在关键处托住全场的稳定。你相信，世界要靠“说到做到”和扎扎实实的执行才不会塌，而你愿意做那个默默把事情做到位的人。",
+        "twitter_image_url": null,
+        "robots": null,
+        "jsonld_overrides_json": null
+      }
+    },
+    {
+      "runtime_type_code": "ISTP-A",
+      "canonical_type_code": "ISTP",
+      "variant_code": "A",
+      "is_published": true,
+      "published_at": "2026-03-17T00:00:00Z",
+      "profile_overrides": {
+        "type_name": "鉴赏家型",
+        "nickname": "冷静行动者",
+        "rarity_text": "约 4–6%",
+        "keywords_json": [
+          "冷静",
+          "动手能力",
+          "问题解决",
+          "独立",
+          "灵活",
+          "喜欢探索"
+        ],
+        "hero_summary_md": "你像一把随身携带的多功能工具刀：平时安静低调，关键时刻却总能冷静出手，解决别人束手无策的问题。你更相信“试一试”胜过“说一说”，世界对你而言，是一块等着被拆解和探索的巨大实验场。",
+        "hero_summary_html": null
+      },
+      "section_overrides": [
+        {
+          "section_key": "letters_intro",
+          "render_variant": "letters_intro",
+          "body_md": null,
+          "body_html": null,
+          "payload_json": {
+            "headline": "内向 · 实感 · 思考 · 知觉 · 自信型｜冷静务实的“技术探索者”",
+            "letters": [
+              {
+                "letter": "I",
+                "title": "内向（I）",
+                "description": "让你更享受安静、自由的个人空间。相比热闹的社交，你更喜欢在自己的节奏里琢磨东西、打磨技能、一个人把事情摸透。"
+              },
+              {
+                "letter": "S",
+                "title": "实感（S）",
+                "description": "让你特别关注“眼前能看见、摸得着”的事实和数据。你信任自己看到的、体验过的，而不是一堆抽象的空话。"
+              },
+              {
+                "letter": "T",
+                "title": "思考（T）",
+                "description": "让你在做决定时优先考虑逻辑和结果。你习惯先分析问题结构，再下判断，很少被一时的情绪带着走。"
+              },
+              {
+                "letter": "P",
+                "title": "知觉（P）",
+                "description": "让你不喜欢被死板计划锁死，希望保留随时“变招”的空间。你偏爱灵活应对，而不是照本宣科。"
+              },
+              {
+                "letter": "A",
+                "title": "自信型（-A）",
+                "description": "让你在多数时候都相对镇定，从容面对风险与不确定。你相信：即使现在没有答案，自己也能在摸索中找到路。"
+              }
+            ]
+          },
+          "sort_order": 10,
+          "is_enabled": true
+        },
+        {
+          "section_key": "overview",
+          "render_variant": "rich_text",
+          "body_md": "在费马心理的逻辑模型里，ISTP-A 往往被视作“冷静的实干玩家”。表面上你话不多、不抢风头，内核却是一颗爱研究、爱拆解、爱尝试的新奇之心。\n\n你喜欢亲手去摸索世界的运行规则：工具、系统、机器、产品、游戏、流程……都可以是你的实验对象。别人还在讨论理论时，你往往已经开始动手做第一个版本了。\n\n你不太喜欢被管束，也不爱被情绪裹挟。对你来说，最舒服的状态是：有一定自由度、规则别太蠢、事情够有挑战，你能按自己的方式找到“最好玩的解决方案”。",
+          "body_html": null,
+          "payload_json": null,
+          "sort_order": 20,
+          "is_enabled": true
+        },
+        {
+          "section_key": "trait_overview",
+          "render_variant": "trait_dimension_grid",
+          "body_md": "建议与小程序中 5 条维度进度条搭配展示：外向 / 内向｜天马行空 / 求真务实｜情感细腻 / 理性思考｜运筹帷幄 / 随机应变｜情绪易波动 / 自信果断。",
+          "body_html": null,
+          "payload_json": {
+            "summary": "建议与小程序中 5 条维度进度条搭配展示：外向 / 内向｜天马行空 / 求真务实｜情感细腻 / 理性思考｜运筹帷幄 / 随机应变｜情绪易波动 / 自信果断。",
+            "dimensions": [
+              {
+                "id": "EI",
+                "name": "外向倾向",
+                "label": "外向倾向",
+                "axis_left": "外向",
+                "axis_right": "内向",
+                "summary": "明显偏内向",
+                "description": "你更习惯一个人安静做事，或者和少数熟悉的人待在一起。大型社交场合会消耗你的能量，你更像是“旁边默默观察的人”，只有在必要时才开口。"
+              },
+              {
+                "id": "SN",
+                "name": "心智模式",
+                "label": "心智模式",
+                "axis_left": "天马行空",
+                "axis_right": "求真务实",
+                "summary": "偏“求真务实”",
+                "description": "你关注的是当下能做什么、怎么做更高效，而不是长篇大论的宏大叙事。你擅长从真实的数据、手感和反馈中微调方案，一步步把事情做顺。"
+              },
+              {
+                "id": "TF",
+                "name": "情绪天性",
+                "label": "情绪天性",
+                "axis_left": "情感细腻",
+                "axis_right": "理性思考",
+                "summary": "偏“理性思考”",
+                "description": "你处理问题时更像一个技术员或工程师：先拆解，再定位，再修复。你并非没有情感，只是表达方式更收敛，不习惯把情绪挂在脸上。"
+              },
+              {
+                "id": "JP",
+                "name": "应对方式",
+                "label": "应对方式",
+                "axis_left": "运筹帷幄",
+                "axis_right": "随机应变",
+                "summary": "偏“随机应变”",
+                "description": "你不喜欢被过度规划束缚，反而擅长在现场快速判断、即时反应。突发情况对你来说，更像一场临场反应游戏，而不是灾难。"
+              },
+              {
+                "id": "AT",
+                "name": "身份特征",
+                "label": "身份特征",
+                "axis_left": "情绪易波动",
+                "axis_right": "自信果断",
+                "summary": "偏“自信果断”",
+                "description": "面对风险和复杂情况，你通常能保持冷静，不会轻易慌乱。你相信自己的判断，也愿意为自己的决定负责，即便结果不完美，也会把它当成一次经验升级。"
+              }
+            ]
+          },
+          "sort_order": 30,
+          "is_enabled": true
+        },
+        {
+          "section_key": "career.summary",
+          "render_variant": "rich_text",
+          "body_md": "你的职业成就感，通常来自“把问题修好、把系统跑顺、把事情做到位”。相比站在聚光灯下，你更在意：这个东西到底好不好用、效率高不高、结构稳不稳。\n\n你适合去到那些需要冷静判断、动手操作、快速排障的场景——无论是技术系统、产品机制、实际项目还是现实世界的小故障。\n\n如果工作允许你：保持一定的操作自由、接触真实世界（而不只是 PPT）、不断尝试新方法，你就容易进入专注又愉快的状态。相反，若工作只是重复汇报、无聊会议和僵化流程，你会很快失去耐心。",
+          "body_html": null,
+          "payload_json": null,
+          "sort_order": 40,
+          "is_enabled": true
+        },
+        {
+          "section_key": "career.advantages",
+          "render_variant": "bullets",
+          "body_md": null,
+          "body_html": null,
+          "payload_json": {
+            "items": [
+              {
+                "title": "临场反应快，善于排查问题",
+                "body": "系统出问题、现场“翻车”、项目卡壳时，你往往能第一时间冷静下来，迅速找出症结并动手修复，是团队里的“技术型救火队员”。"
+              },
+              {
+                "title": "动手能力强，学习偏实践导向",
+                "body": "你通过“上手做”学习最快。只要给你时间试一试，你就能摸出一套自己的高效做法，并不断改进。"
+              },
+              {
+                "title": "客观冷静，少情绪化决策",
+                "body": "你习惯先看事实，再表达看法，在冲突或压力场景中，能提供相对中立、理性的判断。"
+              },
+              {
+                "title": "适应变化和不确定性",
+                "body": "只要给你一定自由度，你可以很快适应新工具、新项目、新环境，用“试错 +优化”的方式找到自己的操作路径。"
+              }
+            ]
+          },
+          "sort_order": 50,
+          "is_enabled": true
+        },
+        {
+          "section_key": "career.weaknesses",
+          "render_variant": "bullets",
+          "body_md": null,
+          "body_html": null,
+          "payload_json": {
+            "items": [
+              {
+                "title": "不爱繁琐汇报，容易被误解为“不上心”",
+                "body": "你更想把时间花在“把事情做好”上，对写长报告、做形式化沟通兴趣不高，这可能让上级或同事误以为你不在意项目。"
+              },
+              {
+                "title": "对长期规划缺乏耐心",
+                "body": "你更享受当下的挑战，而不是十年路线图。过多的战略讨论会让你觉得空洞，从而对职场晋升路径缺少主动设计。"
+              },
+              {
+                "title": "情感表达偏少，容易显得冷淡",
+                "body": "你习惯用行动代替语言，但在职场中，很多人需要“听到”你的态度。如果你不说，别人可能不知道你其实很在意。"
+              },
+              {
+                "title": "讨厌被过度管理，容易对权威心生抵触",
+                "body": "当你觉得规则低效或上级不专业时，你会在心里关掉“服从开关”，只按自己的标准做事，长期可能造成关系紧张。"
+              }
+            ]
+          },
+          "sort_order": 60,
+          "is_enabled": true
+        },
+        {
+          "section_key": "career.preferred_roles",
+          "render_variant": "preferred_role_list",
+          "body_md": null,
+          "body_html": null,
+          "payload_json": {
+            "intro": "这些并不是唯一适合 ISTP-A 的职业，但往往更符合你的优势：动手、解决问题、保持一定自主权。可以当作你职业探索时的参考清单。",
+            "groups": [
+              {
+                "group_title": "技术与工程类",
+                "description": "需要实际操作、调试、优化系统的工作。",
+                "examples": [
+                  "软件开发 / 测试 / 运维 / DevOps",
+                  "硬件工程、机械设计、设备维护",
+                  "数据工程、自动化控制、产品技术支持"
+                ]
+              },
+              {
+                "group_title": "现场与项目执行类",
+                "description": "在真实场景中解决问题，而不是只在办公室里讨论。",
+                "examples": [
+                  "项目执行 / 实施工程师 / 现场工程师",
+                  "供应链、物流调度、运营一线负责人",
+                  "安全管理、风险控制、质量检测"
+                ]
+              },
+              {
+                "group_title": "高专注度的技能型岗位",
+                "description": "可以不断打磨技术细节、允许你以作品说话的领域。",
+                "examples": [
+                  "摄影 / 剪辑 / 工业设计 / 手作设计",
+                  "运动教练、极限运动 / 户外相关职业",
+                  "游戏设计、系统策划、玩法设计"
+                ]
+              },
+              {
+                "group_title": "带一点“风险”和“挑战”的场景",
+                "description": "在压力场景中保持冷静、任务导向，是你的隐藏特长。",
+                "examples": [
+                  "应急响应、救援相关岗位（需专业训练）",
+                  "部分类型的创业合伙人 / 技术联合创始人",
+                  "需要快速决策和实操的高压岗位（在可控范围内）"
+                ]
+              }
+            ],
+            "outro": "相比头衔，你更在意“这份工作好不好玩、有没有技术含量、能不能提升我的解决问题能力”。当一份工作满足这些时，你就更愿意长期投入。"
+          },
+          "sort_order": 70,
+          "is_enabled": true
+        },
+        {
+          "section_key": "career.upgrade_suggestions",
+          "render_variant": "bullets",
+          "body_md": "对 ISTP-A 来说，真正的职场上限，不只在于“技术做到多强”，还在于你能否学会：把自己的价值讲出来、和关键人保持顺畅协作，以及对自己的长期路径做一点点规划。\n\n可以把下面这几条，当作你的职场小公式：",
+          "body_html": null,
+          "payload_json": {
+            "items": [
+              {
+                "title": "技术力 × 可见度",
+                "body": "你已经很擅长“把事情做好”，下一步是学会让重要的人“知道是你做的”。尝试在阶段性节点，主动用简明扼要的方式汇报成果和思路，不需要夸张，只要让事实被看见。"
+              },
+              {
+                "title": "自由度 = 信任度 ÷ 不确定感",
+                "body": "你越讨厌被管，就越要用“稳定交付”换取信任。提前说明你的计划和预期结果，让上级知道：放手给你，你不会搞砸。"
+              },
+              {
+                "title": "职业成长 = 技术深度 + 软技能一点点",
+                "body": "保持你对硬实力的投入，同时每个阶段给自己加一项小目标：比如“学会在会议中多说一句自己的判断”“每月主动和关键同事喝一次咖啡”。长期来看，这会极大提升你的机会窗口。"
+              },
+              {
+                "title": "不想被困住，就要先选好“游戏地图”",
+                "body": "如果一个环境严重和你的价值观、工作方式冲突（比如只重形式不重结果），与其耗着，不如主动调整赛道。你更适合那些允许用结果说话、给技术和实干留空间的地方。"
+              }
+            ]
+          },
+          "sort_order": 80,
+          "is_enabled": true
+        },
+        {
+          "section_key": "growth.summary",
+          "render_variant": "rich_text",
+          "body_md": "对 ISTP-A 来说，成长不是“变得话多、变得感性”，而是：在保持自己冷静、务实、独立的同时，学会更好地连接他人、理解情绪，并为未来留一点余地。\n\n这一章节会从你的强项、短板，以及能量来源与消耗点的角度，帮你看清：怎样升级，才既不违背本性，又能走得更远。",
+          "body_html": null,
+          "payload_json": null,
+          "sort_order": 90,
+          "is_enabled": true
+        },
+        {
+          "section_key": "growth.strengths",
+          "render_variant": "bullets",
+          "body_md": null,
+          "body_html": null,
+          "payload_json": {
+            "items": [
+              {
+                "title": "强大的动手和实操能力",
+                "body": "你不怕从零开始摸索一件事，只要给你时间和空间，你就能一步步拆解、修正，让它运转顺畅。"
+              },
+              {
+                "title": "冷静客观，不容易被带节奏",
+                "body": "面对复杂局面，你往往先看事实，再决定要不要反应，这让你在很多人慌张的时候，仍然能保持清醒。"
+              },
+              {
+                "title": "喜欢学习“有用的东西”",
+                "body": "只要知识能用在实践中，你就愿意钻研得很深，这会让你在某些垂直领域积累出非常扎实的实力。"
+              },
+              {
+                "title": "自我恢复力强",
+                "body": "遇到失败或挫折，你更倾向于“下次试别的方案”，而不是长时间情绪化。你会把经历当作经验包，而不是永久伤疤。"
+              }
+            ]
+          },
+          "sort_order": 100,
+          "is_enabled": true
+        },
+        {
+          "section_key": "growth.weaknesses",
+          "render_variant": "bullets",
+          "body_md": null,
+          "body_html": null,
+          "payload_json": {
+            "items": [
+              {
+                "title": "不爱表达内心想法",
+                "body": "你更多在脑子里想，而不是说出来。长久下来，别人很难真正了解你在想什么，也可能错判你的态度和立场。"
+              },
+              {
+                "title": "容易拖延“无聊但重要”的事情",
+                "body": "报销、体检、证件更新、长期规划这类事，如果短期没有明显反馈，你会一拖再拖，直到必须处理才动手。"
+              },
+              {
+                "title": "对情感和关系议题耐心有限",
+                "body": "你不擅长长时间的情绪性对话，一旦对方反复纠缠感受而不谈解决方案，你会产生明显的逃离冲动。"
+              },
+              {
+                "title": "习惯单打独斗",
+                "body": "你信任自己的判断和手感，多数时候也确实靠谱，但如果过度依赖“自己来”，会错过很多合作带来的机会与资源。"
+              }
+            ]
+          },
+          "sort_order": 110,
+          "is_enabled": true
+        },
+        {
+          "section_key": "growth.motivators",
+          "render_variant": "premium_teaser",
+          "body_md": "可以清楚看到自己技能升级、成功解决一个棘手问题、在关键时刻被认可为“靠谱的人”，都会极大提高你的能量。你越能把成长和“真实能力提升”绑定，就越愿意投入时间。",
+          "body_html": null,
+          "payload_json": {
+            "teaser": "可以清楚看到自己技能升级、成功解决一个棘手问题、在关键时刻被认可为“靠谱的人”，都会极大提高你的能量。你越能把成长和“真实能力提升”绑定，就越愿意投入时间。",
+            "is_premium": true
+          },
+          "sort_order": 120,
+          "is_enabled": true
+        },
+        {
+          "section_key": "growth.drainers",
+          "render_variant": "premium_teaser",
+          "body_md": "无休止的空谈会议、重复又低效的流程、被强制社交、以及被人情裹挟的关系，会不断消耗你的耐心。如果你开始频繁想“算了随便吧”，很可能就是环境在消磨你。",
+          "body_html": null,
+          "payload_json": {
+            "teaser": "无休止的空谈会议、重复又低效的流程、被强制社交、以及被人情裹挟的关系，会不断消耗你的耐心。如果你开始频繁想“算了随便吧”，很可能就是环境在消磨你。",
+            "is_premium": true
+          },
+          "sort_order": 130,
+          "is_enabled": true
+        },
+        {
+          "section_key": "relationships.summary",
+          "render_variant": "rich_text",
+          "body_md": "在关系世界里，你更像一位安静但可靠的“同伴型角色”。你不擅长花哨的情话，却愿意在对方真正需要的时候出现，帮忙解决现实问题。\n\n你在意的是：关系能不能给彼此留出空间、是否真诚、能不能一起做点有意思的事，而不是每天都腻在一起。",
+          "body_html": null,
+          "payload_json": null,
+          "sort_order": 140,
+          "is_enabled": true
+        },
+        {
+          "section_key": "relationships.strengths",
+          "render_variant": "bullets",
+          "body_md": null,
+          "body_html": null,
+          "payload_json": {
+            "items": [
+              {
+                "title": "用行动表达在乎",
+                "body": "你不一定会说“我很关心你”，但会帮对方修电脑、做规划、查资料、陪他去处理麻烦事——这就是你的爱。"
+              },
+              {
+                "title": "不喜欢戏剧化冲突",
+                "body": "你不会故意制造戏剧张力，通常更愿意用“把事情讲清楚、把问题解决掉”的方式来处理分歧。"
+              },
+              {
+                "title": "尊重对方的自由和界限",
+                "body": "你不爱被管，同样也不爱过度控制别人。你乐于给对方足够的个人空间，让彼此都能保持独立。"
+              },
+              {
+                "title": "关键时刻非常可靠",
+                "body": "当关系走到真正需要“有人站出来”的节点，你往往能放下犹豫，选择实实在在地去做点什么，而不是只在嘴上说支持。"
+              }
+            ]
+          },
+          "sort_order": 150,
+          "is_enabled": true
+        },
+        {
+          "section_key": "relationships.weaknesses",
+          "render_variant": "bullets",
+          "body_md": null,
+          "body_html": null,
+          "payload_json": {
+            "items": [
+              {
+                "title": "情感表达过于简略",
+                "body": "你心里可能很重视一段关系，但如果不说，对方只会看到你的冷静和沉默，很难感受到你真正的在乎。"
+              },
+              {
+                "title": "容易逃避高强度情绪对话",
+                "body": "当对方陷入情绪风暴、需要长时间倾诉时，你会感到手足无措，甚至本能想“先离开现场”，这容易被解读为不关心。"
+              },
+              {
+                "title": "不擅长谈“未来规划”",
+                "body": "你习惯按当下的感觉走，不太喜欢提前把一切都定死。这在亲密关系中，可能被理解为“不够有责任感”或“不够确定”。"
+              },
+              {
+                "title": "不主动求助，也不轻易示弱",
+                "body": "你习惯自己扛问题，很少让别人看到你的脆弱一面。久而久之，别人会误以为你“不需要被照顾”。"
+              }
+            ]
+          },
+          "sort_order": 160,
+          "is_enabled": true
+        },
+        {
+          "section_key": "relationships.rel_advantages",
+          "render_variant": "premium_teaser",
+          "body_md": "当关系建立在互相尊重和真实之上时，你会成为对方生活中非常重要的“稳定存在”：不吵不闹、不玩消耗游戏，但关键时刻总能顶上去。",
+          "body_html": null,
+          "payload_json": {
+            "teaser": "当关系建立在互相尊重和真实之上时，你会成为对方生活中非常重要的“稳定存在”：不吵不闹、不玩消耗游戏，但关键时刻总能顶上去。",
+            "is_premium": true
+          },
+          "sort_order": 170,
+          "is_enabled": true
+        },
+        {
+          "section_key": "relationships.rel_risks",
+          "render_variant": "premium_teaser",
+          "body_md": "如果对方需要的是高频表达、长时间情绪陪伴，而你又没办法或者不愿意满足，就很容易陷入彼此都疲惫的拉扯。及早看清双方期待差异，远比勉强维持来得健康。",
+          "body_html": null,
+          "payload_json": {
+            "teaser": "如果对方需要的是高频表达、长时间情绪陪伴，而你又没办法或者不愿意满足，就很容易陷入彼此都疲惫的拉扯。及早看清双方期待差异，远比勉强维持来得健康。",
+            "is_premium": true
+          },
+          "sort_order": 180,
+          "is_enabled": true
+        }
+      ],
+      "seo_overrides": {
+        "seo_title": "ISTP-A 鉴赏家型",
+        "seo_description": "你像一把随身携带的多功能工具刀：平时安静低调，关键时刻却总能冷静出手，解决别人束手无策的问题。你更相信“试一试”胜过“说一说”，世界对你而言，是一块等着被拆解和探索的巨大实验场。",
+        "canonical_url": null,
+        "og_title": "ISTP-A 冷静行动者",
+        "og_description": "你像一把随身携带的多功能工具刀：平时安静低调，关键时刻却总能冷静出手，解决别人束手无策的问题。你更相信“试一试”胜过“说一说”，世界对你而言，是一块等着被拆解和探索的巨大实验场。",
+        "og_image_url": null,
+        "twitter_title": "ISTP-A 冷静行动者",
+        "twitter_description": "你像一把随身携带的多功能工具刀：平时安静低调，关键时刻却总能冷静出手，解决别人束手无策的问题。你更相信“试一试”胜过“说一说”，世界对你而言，是一块等着被拆解和探索的巨大实验场。",
+        "twitter_image_url": null,
+        "robots": null,
+        "jsonld_overrides_json": null
+      }
+    },
+    {
+      "runtime_type_code": "ISTP-T",
+      "canonical_type_code": "ISTP",
+      "variant_code": "T",
+      "is_published": true,
+      "published_at": "2026-03-17T00:00:00Z",
+      "profile_overrides": {
+        "type_name": "探险家型",
+        "nickname": "冷静实干家",
+        "rarity_text": "约 4–7%",
+        "keywords_json": [
+          "独立",
+          "动手能力",
+          "理性冷静",
+          "现实主义",
+          "爱折腾",
+          "临场反应"
+        ],
+        "hero_summary_md": "你像一把随身携带的多功能工具刀：平时低调收起，不声不响；一到关键时刻，却总能冷静出手，三两下把问题解决。你不太爱说大道理，却习惯用“我来试试”证明自己。",
+        "hero_summary_html": null
+      },
+      "section_overrides": [
+        {
+          "section_key": "letters_intro",
+          "render_variant": "letters_intro",
+          "body_md": null,
+          "body_html": null,
+          "payload_json": {
+            "headline": "内向 · 实感 · 思考 · 知觉 · 动荡型｜安静低调却敢下场的“现实派解决者”",
+            "letters": [
+              {
+                "letter": "I",
+                "title": "内向（I）",
+                "description": "让你更习惯在安静环境中思考和动手，长时间社交会让你“电量见底”，一个人摆弄设备、研究技巧，反而能迅速回血。"
+              },
+              {
+                "letter": "S",
+                "title": "实感（S）",
+                "description": "让你专注于眼前可见的事实与细节。参数、材质、性能、真实反馈，对你来说比宏大口号更可靠。"
+              },
+              {
+                "letter": "T",
+                "title": "思考（T）",
+                "description": "让你在做决定时更偏向逻辑与结果，不太被情绪带着走。你会问的是：“这样做有没有用？可不可行？” 而不是“别人会怎么看我？”。"
+              },
+              {
+                "letter": "P",
+                "title": "知觉（P）",
+                "description": "让你不爱被死板安排束缚，更喜欢灵活调整、随机应变。你适合在开放空间里“边试边改”，而不是被写死在流程里。"
+              },
+              {
+                "letter": "T",
+                "title": "动荡型（-T）",
+                "description": "让你看起来冷静，内心却时常在复盘细节：“那里是不是还能做得更精致？” 这既让你持续打磨技术，也会在不知不觉中增加一些压力。"
+              }
+            ]
+          },
+          "sort_order": 10,
+          "is_enabled": true
+        },
+        {
+          "section_key": "overview",
+          "render_variant": "rich_text",
+          "body_md": "在费马心理的逻辑模型里，ISTP-T 常被视为“现实世界中的问题修理师”。你安静、独立、讲究效率，不爱空谈理念，更愿意直接上手拆解问题、测试方案、看到真实结果。\n\n对你来说，最舒服的状态是：空间不被打扰、规则不过分啰嗦、手上有一个可以专注折腾的项目。别人还在讨论怎么做的时候，你通常已经把第一版原型做出来了。\n\n你的人生追求，很少停留在“说得好听”，而是更接近一句话：东西要能用，方案要靠谱，动作要利索——剩下的交给时间验证就好。",
+          "body_html": null,
+          "payload_json": null,
+          "sort_order": 20,
+          "is_enabled": true
+        },
+        {
+          "section_key": "trait_overview",
+          "render_variant": "trait_dimension_grid",
+          "body_md": "建议与小程序中 5 条维度进度条搭配展示：外向 / 内向｜天马行空 / 求真务实｜情感细腻 / 理性思考｜运筹帷幄 / 随机应变｜情绪易波动 / 自信果断。",
+          "body_html": null,
+          "payload_json": {
+            "summary": "建议与小程序中 5 条维度进度条搭配展示：外向 / 内向｜天马行空 / 求真务实｜情感细腻 / 理性思考｜运筹帷幄 / 随机应变｜情绪易波动 / 自信果断。",
+            "dimensions": [
+              {
+                "id": "EI",
+                "name": "外向倾向",
+                "label": "外向倾向",
+                "axis_left": "外向",
+                "axis_right": "内向",
+                "summary": "明显偏内向",
+                "description": "你不讨厌人，只是不爱被人群包围。和熟人少量、深度的互动比大型聚会更让你舒服。很多时候，你更享受“一个人 + 一件事”的专注时刻。"
+              },
+              {
+                "id": "SN",
+                "name": "心智模式",
+                "label": "心智模式",
+                "axis_left": "天马行空",
+                "axis_right": "求真务实",
+                "summary": "明显偏“求真务实”",
+                "description": "你习惯从事实和数据出发，关注“现在到底是什么情况”。对你来说，再漂亮的想法，如果落不到实处，就只是噪音。你更愿意用实验、测评、实际操作来判断一件事值不值得做。"
+              },
+              {
+                "id": "TF",
+                "name": "情绪天性",
+                "label": "情绪天性",
+                "axis_left": "情感细腻",
+                "axis_right": "理性思考",
+                "summary": "偏“理性思考”",
+                "description": "面对问题时，你先看结构和逻辑，而不是情绪表面。你不太习惯长篇大论地聊感受，但你会用“问题拆解 + 实际行动”的方式，默默帮别人把难题简化。"
+              },
+              {
+                "id": "JP",
+                "name": "应对方式",
+                "label": "应对方式",
+                "axis_left": "运筹帷幄",
+                "axis_right": "随机应变",
+                "summary": "偏“随机应变”",
+                "description": "你不喜欢被行程表写满，反而更享受根据突发情况临场反应——现场出状况时，你的大脑会变得格外清醒，常常在“危机处理”中发挥得最好。"
+              },
+              {
+                "id": "AT",
+                "name": "身份特征",
+                "label": "身份特征",
+                "axis_left": "情绪易波动",
+                "axis_right": "自信果断",
+                "summary": "略偏“情绪易波动”",
+                "description": "表面看起来淡定，但你对自己的技术细节和表现有一套很高的标准。出错时你未必说什么，但会在心里重播现场、默默想着“下次我要怎么做得更干净利落”。"
+              }
+            ]
+          },
+          "sort_order": 30,
+          "is_enabled": true
+        },
+        {
+          "section_key": "career.summary",
+          "render_variant": "rich_text",
+          "body_md": "你的职业选择，往往围绕“动手解决问题”展开。只要有足够的操作空间、技术深度和试错余地，你就能在里面玩出花来。\n\n你不太适合长期做纯口头、纯汇报型工作；如果每天都是会议、表格和流程审批，你很快就会感到无聊甚至想逃离。\n\n相反，当一份工作允许你：自己摸索工具、亲自上手调试、反复迭代方案，并且在关键时刻出来“救火”时，你就会自然进入高水平发挥。",
+          "body_html": null,
+          "payload_json": null,
+          "sort_order": 40,
+          "is_enabled": true
+        },
+        {
+          "section_key": "career.advantages",
+          "render_variant": "bullets",
+          "body_md": null,
+          "body_html": null,
+          "payload_json": {
+            "items": [
+              {
+                "title": "临场反应快",
+                "body": "系统宕机、现场失灵、计划被打乱时，你往往比别人更冷静。你会迅速锁定关键点，优先处理最影响结果的问题。"
+              },
+              {
+                "title": "动手能力强",
+                "body": "你不止会想，还会做。你习惯自己查资料、试配置、拆设备、改参数，在实战中不断升级技能。"
+              },
+              {
+                "title": "客观理性，少情绪化决策",
+                "body": "面对冲突或压力，你一般不会第一时间爆炸，而是先看事实、找数据、测方案。你的判断往往相对冷静、可执行。"
+              },
+              {
+                "title": "独立可靠",
+                "body": "你不喜欢别人盯着才能动，更适合被赋予一个目标和权限后，自己找路走到终点。遇到复杂技术问题时，同事也会习惯来找你“救命”。"
+              }
+            ]
+          },
+          "sort_order": 50,
+          "is_enabled": true
+        },
+        {
+          "section_key": "career.weaknesses",
+          "render_variant": "bullets",
+          "body_md": null,
+          "body_html": null,
+          "payload_json": {
+            "items": [
+              {
+                "title": "不爱应付繁琐流程",
+                "body": "过多的文书工作、层层审批和形式主义，对你来说是很大的消耗。你容易在这些环节里失去耐心和兴趣。"
+              },
+              {
+                "title": "沟通风格偏“惜字如金”",
+                "body": "你习惯用结果说话，不一定会提前说明自己的思路和进度，这可能让同事或上级误以为你“不在状态”或“不够上心”。"
+              },
+              {
+                "title": "长期规划意识较弱",
+                "body": "你更擅长解决眼前的问题，对五年、十年的职业路径不太有兴趣细想。这容易让你的成长停留在“技术很好，但整体节奏有点散”的状态。"
+              },
+              {
+                "title": "容易对重复、无挑战的工作感到厌倦",
+                "body": "当工作变成机械重复，而没有新的难题可解，你会明显松懈，甚至开始下意识拖延或分心。"
+              }
+            ]
+          },
+          "sort_order": 60,
+          "is_enabled": true
+        },
+        {
+          "section_key": "career.preferred_roles",
+          "render_variant": "preferred_role_list",
+          "body_md": null,
+          "body_html": null,
+          "payload_json": {
+            "intro": "下面这些方向，并不是 ISTP-T 唯一的出路，却更容易让你觉得“好玩、带感、有发挥空间”。可以把它们当作职业探索的参考清单。",
+            "groups": [
+              {
+                "group_title": "技术与工程实操类",
+                "description": "需要大量“上手”的岗位，适合你用技能和解决问题说话。",
+                "examples": [
+                  "软件开发 / 运维工程师 / 测试工程师",
+                  "硬件工程、机电维修、自动化相关岗位",
+                  "网络工程、信息安全、系统集成实施"
+                ]
+              },
+              {
+                "group_title": "现场问题解决与支持",
+                "description": "在真实场景里排查、修复、优化系统或流程的工作。",
+                "examples": [
+                  "现场技术支持、售后工程师",
+                  "生产 / 物流 / 仓储一线优化与调度",
+                  "应急保障、设备管理、运维值班"
+                ]
+              },
+              {
+                "group_title": "行动导向与户外探索",
+                "description": "让身体和技术一起工作的职业，更符合你“动起来”的本能。",
+                "examples": [
+                  "户外运动教练、潜水 / 攀岩 / 滑雪等指导",
+                  "摄影师、航拍师、极限运动相关工作",
+                  "交通 / 机车 / 航空相关技术岗位"
+                ]
+              },
+              {
+                "group_title": "项目制与自由度较高的工作形态",
+                "description": "可以自己安排节奏、不被过度监管，但要对结果负责的工作形态。",
+                "examples": [
+                  "自由职业技术顾问",
+                  "独立开发者 / Maker",
+                  "专业领域的个体工匠"
+                ]
+              }
+            ],
+            "outro": "对你来说，理想的工作不一定要“听起来体面”，而是要让你真切感觉：手上有东西可玩，脑子有东西可想，解决完一个难题，会有实实在在的成就感。"
+          },
+          "sort_order": 70,
+          "is_enabled": true
+        },
+        {
+          "section_key": "career.upgrade_suggestions",
+          "render_variant": "bullets",
+          "body_md": "ISTP-T 在职场上，往往不缺实力，缺的是“被看见”与“长期布局”。如果你想让自己的专业能力变成更大的机会，需要在不改变本性的前提下，多加一点“可见度”和“前瞻性”。\n\n可以把下面这几条，当作你的职场进阶小公式。",
+          "body_html": null,
+          "payload_json": {
+            "items": [
+              {
+                "title": "专业度 × 可见度 = 职场议价权",
+                "body": "你已经在默默解决很多问题了，接下来，可以在关键节点上多做一步“说明”：在复盘会上简单讲讲你是怎么定位问题、如何优化的，让别人看到你的思路，而不仅是结果。"
+              },
+              {
+                "title": "短期爽感 ≠ 长期成长",
+                "body": "只追求“好玩”的任务，短期很幸福，但可能错过能让你升级的项目。每个阶段给自己留一点“拉伸型任务”：稍微难一点、稍微烦一点，但能明显提高你的层级。"
+              },
+              {
+                "title": "自由度 = 责任感 × 信任度",
+                "body": "你想要空间，就要让别人放心。按时交付、提前预警风险、适度同步进展，都是帮你争取更多自由度的筹码。"
+              },
+              {
+                "title": "效率升级 = 工具意识 × 复盘能力",
+                "body": "你天生就会找捷径，不妨刻意把“好用的脚本、模板、排查思路”整理下来，变成可复用的资产。时间久了，你不仅是会解决问题的人，还是“提高整体效率的人”。"
+              }
+            ]
+          },
+          "sort_order": 80,
+          "is_enabled": true
+        },
+        {
+          "section_key": "growth.summary",
+          "render_variant": "rich_text",
+          "body_md": "对 ISTP-T 来说，成长不只是“变得更社交”，而是：在保持独立和真实的前提下，学会更好地与世界协作，让你的实力有机会被看见、被需要。\n\n这一章节，会从你的强项、短板，以及能量的来源与流失几个角度，帮你看清自己的成长路径。",
+          "body_html": null,
+          "payload_json": null,
+          "sort_order": 90,
+          "is_enabled": true
+        },
+        {
+          "section_key": "growth.strengths",
+          "render_variant": "bullets",
+          "body_md": null,
+          "body_html": null,
+          "payload_json": {
+            "items": [
+              {
+                "title": "学习速度快，尤其在动手领域",
+                "body": "只要你感兴趣，你可以很快上手一项新技能，并在实践中迅速找到最顺手的用法。"
+              },
+              {
+                "title": "抗压时反而更冷静",
+                "body": "在别人情绪上头的时候，你常常能保持客观判断，这让你在关键时刻特别可靠。"
+              },
+              {
+                "title": "能把复杂问题拆成小块",
+                "body": "面对一团乱麻时，你知道从哪里下手，把问题切成一块块可解决的小部分，再逐个击破。"
+              },
+              {
+                "title": "对规则有自己的判断",
+                "body": "你不会盲从权威，更愿意自己验证。如果某条规则没有用，你也敢质疑和优化。"
+              }
+            ]
+          },
+          "sort_order": 100,
+          "is_enabled": true
+        },
+        {
+          "section_key": "growth.weaknesses",
+          "render_variant": "bullets",
+          "body_md": null,
+          "body_html": null,
+          "payload_json": {
+            "items": [
+              {
+                "title": "对“表达情绪”和“表达需求”不太熟练",
+                "body": "你习惯一个人消化消极情绪，也不喜欢麻烦别人。这会让身边的人很难真正理解你的状态和需要。"
+              },
+              {
+                "title": "容易把生活节奏交给“当下兴趣”",
+                "body": "你做事很看感觉，一旦对某件事失去兴趣，就很难逼自己坚持，这可能影响长期计划的推进。"
+              },
+              {
+                "title": "在亲密关系中显得疏离",
+                "body": "你是那种“有事我就来、平时我就躲角落”的类型，这会让对方误以为你不在乎，明明你只是懒得废话。"
+              },
+              {
+                "title": "不善于争取资源",
+                "body": "你更习惯自己解决问题，很少主动提出“我需要什么帮助”，这会让你错过一些本可以被支持、被抬一手的机会。"
+              }
+            ]
+          },
+          "sort_order": 110,
+          "is_enabled": true
+        },
+        {
+          "section_key": "growth.motivators",
+          "render_variant": "premium_teaser",
+          "body_md": "有自由度的环境、清晰直接的反馈、能看见自己技术或能力升级的过程，以及那种“无人可解、只有你能搞定”的挑战，都会点燃你的内在动力。",
+          "body_html": null,
+          "payload_json": {
+            "teaser": "有自由度的环境、清晰直接的反馈、能看见自己技术或能力升级的过程，以及那种“无人可解、只有你能搞定”的挑战，都会点燃你的内在动力。",
+            "is_premium": true
+          },
+          "sort_order": 120,
+          "is_enabled": true
+        },
+        {
+          "section_key": "growth.drainers",
+          "render_variant": "premium_teaser",
+          "body_md": "没完没了的会议、模糊的指令、重复且无意义的任务、以及被情绪裹挟却解决不了实际问题的关系，会一点点消耗你的耐心，让你开始关闭自己。",
+          "body_html": null,
+          "payload_json": {
+            "teaser": "没完没了的会议、模糊的指令、重复且无意义的任务、以及被情绪裹挟却解决不了实际问题的关系，会一点点消耗你的耐心，让你开始关闭自己。",
+            "is_premium": true
+          },
+          "sort_order": 130,
+          "is_enabled": true
+        },
+        {
+          "section_key": "relationships.summary",
+          "render_variant": "rich_text",
+          "body_md": "在人际和亲密关系里，你更像一位“安静却靠谱的队友”。你可能不是最会说甜言蜜语的那个人，但你擅长在关键时刻出现、用实际行动表达在乎。\n\n你在关系中最介意的是：对方是不是尊重你的边界？会不会给你足够的空间？你是不是可以在这段关系里，自由地做自己？",
+          "body_html": null,
+          "payload_json": null,
+          "sort_order": 140,
+          "is_enabled": true
+        },
+        {
+          "section_key": "relationships.strengths",
+          "render_variant": "bullets",
+          "body_md": null,
+          "body_html": null,
+          "payload_json": {
+            "items": [
+              {
+                "title": "不喜欢虚伪，习惯用真诚相处",
+                "body": "你不太会为了讨好而迎合别人，和你在一起的人，通常能感受到一种踏实的“真实感”。"
+              },
+              {
+                "title": "用行动而不是语言表达关心",
+                "body": "你可能不会长篇大论说爱，但会在对方需要的时候帮忙修电脑、搬东西、查资料、做实际有用的事。"
+              },
+              {
+                "title": "给足对方空间，不黏也不缠",
+                "body": "你很少控制对方的社交和节奏，更愿意把关系建立在“各自独立 + 相互支持”的基础上。"
+              },
+              {
+                "title": "不轻易翻旧账",
+                "body": "你不喜欢反复纠结过去的矛盾，更愿意“解决问题就向前看”。这让你在很多时候，成为关系里的稳定力量。"
+              }
+            ]
+          },
+          "sort_order": 150,
+          "is_enabled": true
+        },
+        {
+          "section_key": "relationships.weaknesses",
+          "render_variant": "bullets",
+          "body_md": null,
+          "body_html": null,
+          "payload_json": {
+            "items": [
+              {
+                "title": "被误解为“不在乎”",
+                "body": "你内心明明很重视一段关系，但因为表达方式太克制、太实用，容易让对方误会你“没有那么用心”。"
+              },
+              {
+                "title": "不擅长处理“纯情绪问题”",
+                "body": "当对方只是需要被倾听、被安慰时，你可能会习惯性给出一堆建议和解决方案，反而被嫌弃“你不懂我”。"
+              },
+              {
+                "title": "习惯一个人扛住所有压力",
+                "body": "你不想把自己的烦恼变成别人的负担，于是越是难搞的部分越往心里压，久而久之，你会在关系中产生一种“只有我在撑”的孤独感。"
+              },
+              {
+                "title": "不太会主动经营关系",
+                "body": "你不擅长刻意维系联系，时间久了，一些本可以很稳固的关系，可能会在“互相都不主动”的沉默中慢慢淡掉。"
+              }
+            ]
+          },
+          "sort_order": 160,
+          "is_enabled": true
+        },
+        {
+          "section_key": "relationships.rel_advantages",
+          "render_variant": "premium_teaser",
+          "body_md": "当遇到懂你、愿意尊重你节奏的人时，你会成为对方极其可靠的伙伴——不多话、不表演，但永远在关键节点给出真正有用的支持。",
+          "body_html": null,
+          "payload_json": {
+            "teaser": "当遇到懂你、愿意尊重你节奏的人时，你会成为对方极其可靠的伙伴——不多话、不表演，但永远在关键节点给出真正有用的支持。",
+            "is_premium": true
+          },
+          "sort_order": 170,
+          "is_enabled": true
+        },
+        {
+          "section_key": "relationships.rel_risks",
+          "render_variant": "premium_teaser",
+          "body_md": "如果你身边的人习惯只要结果、不要过程，只享受你提供的解决方案，却忽略你的感受和付出，你会在某个瞬间突然抽离，选择用“断联”来保护自己。",
+          "body_html": null,
+          "payload_json": {
+            "teaser": "如果你身边的人习惯只要结果、不要过程，只享受你提供的解决方案，却忽略你的感受和付出，你会在某个瞬间突然抽离，选择用“断联”来保护自己。",
+            "is_premium": true
+          },
+          "sort_order": 180,
+          "is_enabled": true
+        }
+      ],
+      "seo_overrides": {
+        "seo_title": "ISTP-T 探险家型",
+        "seo_description": "你像一把随身携带的多功能工具刀：平时低调收起，不声不响；一到关键时刻，却总能冷静出手，三两下把问题解决。你不太爱说大道理，却习惯用“我来试试”证明自己。",
+        "canonical_url": null,
+        "og_title": "ISTP-T 冷静实干家",
+        "og_description": "你像一把随身携带的多功能工具刀：平时低调收起，不声不响；一到关键时刻，却总能冷静出手，三两下把问题解决。你不太爱说大道理，却习惯用“我来试试”证明自己。",
+        "og_image_url": null,
+        "twitter_title": "ISTP-T 冷静实干家",
+        "twitter_description": "你像一把随身携带的多功能工具刀：平时低调收起，不声不响；一到关键时刻，却总能冷静出手，三两下把问题解决。你不太爱说大道理，却习惯用“我来试试”证明自己。",
         "twitter_image_url": null,
         "robots": null,
         "jsonld_overrides_json": null


### PR DESCRIPTION
## Summary
This PR brings the MBTI personality baseline into a committed full-32 source-of-truth shape and wires that authority through the backend import chain without changing the public 16-type route policy.

Before this change, the repo baseline only carried 16 canonical personality rows, the importer only wrote base profile data, and full 32-type authority lived outside the committed backend source path. That meant variant content could appear in runtime contracts, but it was not backed by a committed baseline, a first-class importer write path, or a blocking launch gate.

With this PR, the committed baseline now carries both layers explicitly: 16 canonical base profiles and 32 runtime variants. The importer writes base profile, sections, and SEO as before, and now also writes variant profile authority, variant sections, variant SEO, and variant revisions. Runtime projection continues to consume published variants, while the public personality route, SEO canonical URLs, and sitemap remain locked to 16 canonical pages only.

## Root Cause
The baseline and importer modeled only canonical 16-type authority. Variant authority existed as runtime display behavior, but not as committed repository-owned content or as imported CMS authority. That created a gap between source, import, projection, and launch validation.

## What Changed
- Rebuilt the committed MBTI baselines under `content_baselines/personality/` so each locale contains `profiles` and `variants`.
- Preserved a strict two-layer model: canonical base authority stays separate from variant authority.
- Added variant normalization and validation for `runtime_type_code`, `canonical_type_code`, `variant_code`, published state, profile overrides, section overrides, and SEO overrides.
- Extended the importer summary and write path to create/update/delete variant rows and variant revisions alongside base rows.
- Upgraded test fixtures and import tests to exercise full base+variant import behavior.
- Added regression coverage proving the public route policy does not change:
  - `/api/v0.5/personality/intj` remains valid
  - `/api/v0.5/personality/intj-a` remains 404
  - canonical SEO and sitemap continue to emit only 16-type canonical URLs
- Added a blocking full-32 authority gate into `backend/scripts/ci_verify_mbti.sh`.

## User Impact
Users still see 32-type runtime display where runtime/report/share/compare contracts already support it, but the backend now has a committed and importable authority chain behind that behavior. Public canonical personality pages, SEO, and sitemap behavior do not expand to 32 pages in this PR.

## Validation
I ran:
- `php -l` on all changed PHP files
- focused `pint`
- `vendor/bin/phpunit tests/Feature/PersonalityCms/PersonalityBaselineImportTest.php tests/Feature/PersonalityCms/PersonalityVariantAuthorityTest.php tests/Unit/Services/Mbti/MbtiPublicProjectionServiceTest.php tests/Feature/V0_5/PersonalityPublicApiTest.php tests/Feature/SEO/SitemapGeneratorTest.php tests/Feature/SEO/SitemapXmlTest.php tests/Feature/V0_3/MbtiReportHttpContractRegressionTest.php tests/Feature/V0_3/ShareSummaryContractTest.php tests/Feature/V0_3/MbtiCompareInviteContractTest.php`
- `php artisan personality:import-local-baseline --dry-run --upsert --status=published`
- `php artisan route:list | grep -Ei "personality|seo|sitemap|attempts/.+report|shares|compare"`
- `php artisan migrate`
- `bash scripts/ci_verify_mbti.sh`

## Guardrails Confirmed
- `backend/routes/api.php` unchanged
- `backend/database/` unchanged
- `frontend` unchanged
- `docs` unchanged
