### PR TITLE
[codex] feat(api): resolve 32-type MBTI public aliases and keep 16-type canonical SEO/sitemap policy

### DIFF
--- a/backend/app/Http/Controllers/API/V0_5/Cms/PersonalityController.php
+++ b/backend/app/Http/Controllers/API/V0_5/Cms/PersonalityController.php
@@ -9,6 +9,9 @@ use App\Http\Controllers\Controller;
 use App\Models\PersonalityProfile;
 use App\Models\PersonalityProfileSection;
 use App\Models\PersonalityProfileSeoMeta;
+use App\Models\PersonalityProfileVariant;
+use App\Models\PersonalityProfileVariantSection;
+use App\Models\PersonalityProfileVariantSeoMeta;
 use App\Services\Cms\PersonalityProfileSeoService;
 use App\Services\Cms\PersonalityProfileService;
 use Illuminate\Http\JsonResponse;
@@ -67,27 +70,28 @@ class PersonalityController extends Controller
             return $validated;
         }
 
-        $profile = $this->personalityProfileService->getPublicProfileByType(
+        $routeProfile = $this->personalityProfileService->getPublicDetailRouteProfileByType(
             $type,
             $validated['org_id'],
             $validated['scale_code'],
             $validated['locale'],
         );
 
-        if (! $profile instanceof PersonalityProfile) {
+        if (! is_array($routeProfile)) {
             return $this->notFoundResponse('personality profile not found.');
         }
 
-        $projection = $this->personalityProfileService->buildPublicProjection($profile);
+        /** @var PersonalityProfile $profile */
+        $profile = $routeProfile['profile'];
+        /** @var PersonalityProfileVariant|null $variant */
+        $variant = $routeProfile['variant'];
+        $projection = $this->personalityProfileService->buildPublicProjection($profile, $variant);
 
         return response()->json([
             'ok' => true,
-            'profile' => $this->profileDetailPayload($profile),
-            'sections' => array_map(
-                fn (PersonalityProfileSection $section): array => $this->sectionPayload($section),
-                $profile->sections->all()
-            ),
-            'seo_meta' => $this->seoMetaPayload($profile->seoMeta),
+            'profile' => $this->profileDetailPayload($profile, $variant),
+            'sections' => $this->publicSectionPayloads($profile, $variant),
+            'seo_meta' => $this->seoMetaPayload($profile, $variant),
             'mbti_public_projection_v1' => $projection,
         ]);
     }
@@ -99,20 +103,25 @@ class PersonalityController extends Controller
             return $validated;
         }
 
-        $profile = $this->personalityProfileService->getPublicProfileByType(
+        $routeProfile = $this->personalityProfileService->getPublicDetailRouteProfileByType(
             $type,
             $validated['org_id'],
             $validated['scale_code'],
             $validated['locale'],
         );
 
-        if (! $profile instanceof PersonalityProfile) {
+        if (! is_array($routeProfile)) {
             return response()->json(['error' => 'not found'], 404);
         }
 
+        /** @var PersonalityProfile $profile */
+        $profile = $routeProfile['profile'];
+        /** @var PersonalityProfileVariant|null $variant */
+        $variant = $routeProfile['variant'];
+
         return response()->json([
-            'meta' => $this->personalityProfileSeoService->buildMeta($profile),
-            'jsonld' => $this->personalityProfileSeoService->buildJsonLd($profile),
+            'meta' => $this->personalityProfileSeoService->buildMeta($profile, $variant),
+            'jsonld' => $this->personalityProfileSeoService->buildJsonLd($profile, $variant),
         ]);
     }
 
@@ -143,7 +152,7 @@ class PersonalityController extends Controller
     /**
      * @return array<string, mixed>
      */
-    private function profileDetailPayload(PersonalityProfile $profile): array
+    private function profileDetailPayload(PersonalityProfile $profile, ?PersonalityProfileVariant $variant = null): array
     {
         return array_merge([
             'id' => (int) $profile->id,
@@ -163,7 +172,7 @@ class PersonalityController extends Controller
             'is_indexable' => (bool) $profile->is_indexable,
             'published_at' => $profile->published_at?->toISOString(),
             'updated_at' => $profile->updated_at?->toISOString(),
-        ], $this->personalityProfileService->publicCanonicalFields($profile));
+        ], $this->personalityProfileService->publicCanonicalFields($profile, $variant));
     }
 
     /**
@@ -186,25 +195,105 @@ class PersonalityController extends Controller
     /**
      * @return array<string, mixed>|null
      */
-    private function seoMetaPayload(?PersonalityProfileSeoMeta $seoMeta): ?array
+    private function seoMetaPayload(PersonalityProfile $profile, ?PersonalityProfileVariant $variant = null): ?array
     {
-        if (! $seoMeta instanceof PersonalityProfileSeoMeta) {
+        $seoMeta = $profile->seoMeta;
+
+        if (! $seoMeta instanceof PersonalityProfileSeoMeta && ! ($variant?->seoMeta instanceof PersonalityProfileVariantSeoMeta)) {
             return null;
         }
 
-        return [
-            'seo_title' => $seoMeta->seo_title,
-            'seo_description' => $seoMeta->seo_description,
-            'canonical_url' => $seoMeta->canonical_url,
-            'og_title' => $seoMeta->og_title,
-            'og_description' => $seoMeta->og_description,
-            'og_image_url' => $seoMeta->og_image_url,
-            'twitter_title' => $seoMeta->twitter_title,
-            'twitter_description' => $seoMeta->twitter_description,
-            'twitter_image_url' => $seoMeta->twitter_image_url,
-            'robots' => $seoMeta->robots,
-            'jsonld_overrides_json' => $seoMeta->jsonld_overrides_json,
+        $meta = [
+            'seo_title' => $seoMeta?->seo_title,
+            'seo_description' => $seoMeta?->seo_description,
+            'canonical_url' => $this->personalityProfileSeoService->buildCanonicalUrl($profile, (string) $profile->locale),
+            'og_title' => $seoMeta?->og_title,
+            'og_description' => $seoMeta?->og_description,
+            'og_image_url' => $seoMeta?->og_image_url,
+            'twitter_title' => $seoMeta?->twitter_title,
+            'twitter_description' => $seoMeta?->twitter_description,
+            'twitter_image_url' => $seoMeta?->twitter_image_url,
+            'robots' => $seoMeta?->robots,
+            'jsonld_overrides_json' => $seoMeta?->jsonld_overrides_json,
         ];
+
+        $variantSeoMeta = $variant?->seoMeta;
+        if ($variantSeoMeta instanceof PersonalityProfileVariantSeoMeta) {
+            foreach ([
+                'seo_title',
+                'seo_description',
+                'og_title',
+                'og_description',
+                'og_image_url',
+                'twitter_title',
+                'twitter_description',
+                'twitter_image_url',
+                'robots',
+            ] as $field) {
+                if ($variantSeoMeta->{$field} !== null) {
+                    $meta[$field] = $variantSeoMeta->{$field};
+                }
+            }
+
+            if (is_array($variantSeoMeta->jsonld_overrides_json) && $variantSeoMeta->jsonld_overrides_json !== []) {
+                $meta['jsonld_overrides_json'] = $variantSeoMeta->jsonld_overrides_json;
+            }
+        }
+
+        return $meta;
+    }
+
+    /**
+     * @return list<array<string, mixed>>
+     */
+    private function publicSectionPayloads(PersonalityProfile $profile, ?PersonalityProfileVariant $variant = null): array
+    {
+        $sections = $profile->sections
+            ->mapWithKeys(fn (PersonalityProfileSection $section): array => [
+                (string) $section->section_key => $this->sectionPayload($section),
+            ]);
+
+        if ($variant instanceof PersonalityProfileVariant) {
+            foreach ($variant->sections as $section) {
+                if (! $section instanceof PersonalityProfileVariantSection) {
+                    continue;
+                }
+
+                $sectionKey = trim((string) $section->section_key);
+                if ($sectionKey === '') {
+                    continue;
+                }
+
+                if (! (bool) $section->is_enabled) {
+                    $sections->forget($sectionKey);
+
+                    continue;
+                }
+
+                /** @var array<string, mixed>|null $baseSection */
+                $baseSection = $sections->get($sectionKey);
+                $sections->put($sectionKey, [
+                    'section_key' => $sectionKey,
+                    'title' => $section->title ?? $baseSection['title'] ?? null,
+                    'render_variant' => (string) ($section->render_variant ?: ($baseSection['render_variant'] ?? 'rich_text')),
+                    'body_md' => $section->body_md ?? $baseSection['body_md'] ?? null,
+                    'body_html' => $section->body_html ?? $baseSection['body_html'] ?? null,
+                    'payload_json' => is_array($section->payload_json)
+                        ? $section->payload_json
+                        : ($baseSection['payload_json'] ?? null),
+                    'sort_order' => (int) ($section->sort_order ?? $baseSection['sort_order'] ?? 0),
+                    'is_enabled' => true,
+                ]);
+            }
+        }
+
+        return $sections
+            ->sortBy([
+                ['sort_order', 'asc'],
+                ['section_key', 'asc'],
+            ])
+            ->values()
+            ->all();
     }
 
     /**

--- a/backend/app/Services/Cms/PersonalityProfileSeoService.php
+++ b/backend/app/Services/Cms/PersonalityProfileSeoService.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Services\Cms;
 
 use App\Models\PersonalityProfile;
+use App\Models\PersonalityProfileVariant;
 
 final class PersonalityProfileSeoService
 {
@@ -15,9 +16,9 @@ final class PersonalityProfileSeoService
     /**
      * @return array<string, mixed>
      */
-    public function buildMeta(PersonalityProfile $profile): array
+    public function buildMeta(PersonalityProfile $profile, ?PersonalityProfileVariant $variant = null): array
     {
-        $projection = $this->personalityProfileService->buildPublicProjection($profile);
+        $projection = $this->personalityProfileService->buildPublicProjection($profile, $variant);
         $title = $this->fallbackText(
             data_get($projection, 'seo.title'),
             data_get($projection, 'summary_card.title'),
@@ -72,10 +73,10 @@ final class PersonalityProfileSeoService
     /**
      * @return array<string, mixed>
      */
-    public function buildJsonLd(PersonalityProfile $profile): array
+    public function buildJsonLd(PersonalityProfile $profile, ?PersonalityProfileVariant $variant = null): array
     {
-        $projection = $this->personalityProfileService->buildPublicProjection($profile);
-        $meta = $this->buildMeta($profile);
+        $projection = $this->personalityProfileService->buildPublicProjection($profile, $variant);
+        $meta = $this->buildMeta($profile, $variant);
         $jsonLd = [
             '@context' => 'https://schema.org',
             '@type' => 'AboutPage',

--- a/backend/app/Services/Cms/PersonalityProfileService.php
+++ b/backend/app/Services/Cms/PersonalityProfileService.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Services\Cms;
 
 use App\Models\PersonalityProfile;
+use App\Models\PersonalityProfileVariant;
 use App\Services\Mbti\MbtiPublicProjectionService;
 use Illuminate\Contracts\Pagination\LengthAwarePaginator;
 use Illuminate\Database\Eloquent\Builder;
@@ -64,6 +65,52 @@ final class PersonalityProfileService
     }
 
     /**
+     * @return array{profile:PersonalityProfile,variant:?PersonalityProfileVariant}|null
+     */
+    public function getPublicDetailRouteProfileByType(
+        string $typeLookup,
+        int $orgId,
+        string $scaleCode,
+        string $locale
+    ): ?array {
+        $lookup = $this->resolvePublicTypeLookup($typeLookup);
+
+        $profile = $this->basePublicQuery($orgId, $scaleCode, $locale)
+            ->where(function (Builder $query) use ($lookup): void {
+                $query->where('slug', $lookup['canonical_slug'])
+                    ->orWhere('type_code', $lookup['canonical_type_code']);
+            })
+            ->with([
+                'sections' => static function (HasMany $query): void {
+                    $query->where('is_enabled', true)
+                        ->orderBy('sort_order')
+                        ->orderBy('id');
+                },
+                'seoMeta',
+            ])
+            ->first();
+
+        if (! $profile instanceof PersonalityProfile) {
+            return null;
+        }
+
+        $variant = null;
+
+        if ($lookup['runtime_type_code'] !== null) {
+            $variant = $this->resolvePublishedVariantForPublicRoute($profile, $lookup['runtime_type_code']);
+
+            if (! $variant instanceof PersonalityProfileVariant) {
+                return null;
+            }
+        }
+
+        return [
+            'profile' => $profile,
+            'variant' => $variant,
+        ];
+    }
+
+    /**
      * @return Collection<int, PersonalityProfile>
      */
     public function getSitemapPublicProfiles(): Collection
@@ -112,9 +159,9 @@ final class PersonalityProfileService
     /**
      * @return array<string, mixed>
      */
-    public function publicCanonicalFields(PersonalityProfile $profile): array
+    public function publicCanonicalFields(PersonalityProfile $profile, ?PersonalityProfileVariant $variant = null): array
     {
-        $projection = $this->buildPublicProjection($profile);
+        $projection = $this->buildPublicProjection($profile, $variant);
 
         return [
             'canonical_type_code' => data_get($projection, 'canonical_type_code'),
@@ -132,9 +179,9 @@ final class PersonalityProfileService
     /**
      * @return array<string, mixed>
      */
-    public function buildPublicProjection(PersonalityProfile $profile): array
+    public function buildPublicProjection(PersonalityProfile $profile, ?PersonalityProfileVariant $variant = null): array
     {
-        return $this->mbtiPublicProjectionService->buildForPersonalityProfile($profile);
+        return $this->mbtiPublicProjectionService->buildForPublicPersonalityRoute($profile, $variant);
     }
 
     private function basePublicQuery(int $orgId, string $scaleCode, string $locale): Builder
@@ -162,5 +209,64 @@ final class PersonalityProfileService
         $normalized = strtoupper(trim($scaleCode));
 
         return $normalized !== '' ? $normalized : PersonalityProfile::SCALE_CODE_MBTI;
+    }
+
+    /**
+     * @return array{
+     *   canonical_slug:string,
+     *   canonical_type_code:string,
+     *   runtime_type_code:?string,
+     *   variant_code:?string
+     * }
+     */
+    private function resolvePublicTypeLookup(string $typeLookup): array
+    {
+        $normalized = trim($typeLookup);
+
+        if (preg_match('/^(?<base>[A-Za-z]{4})(?:-(?<variant>[AaTt]))?$/', $normalized, $matches) === 1) {
+            $baseTypeCode = strtoupper($matches['base']);
+            $variantCode = isset($matches['variant']) ? strtoupper($matches['variant']) : null;
+
+            return [
+                'canonical_slug' => strtolower($matches['base']),
+                'canonical_type_code' => $baseTypeCode,
+                'runtime_type_code' => $variantCode !== null ? $baseTypeCode.'-'.$variantCode : null,
+                'variant_code' => $variantCode,
+            ];
+        }
+
+        return [
+            'canonical_slug' => strtolower($normalized),
+            'canonical_type_code' => strtoupper($normalized),
+            'runtime_type_code' => null,
+            'variant_code' => null,
+        ];
+    }
+
+    private function resolvePublishedVariantForPublicRoute(
+        PersonalityProfile $profile,
+        string $runtimeTypeCode
+    ): ?PersonalityProfileVariant {
+        $normalizedRuntimeTypeCode = strtoupper(trim($runtimeTypeCode));
+
+        if ($normalizedRuntimeTypeCode === '') {
+            return null;
+        }
+
+        return $profile->variants()
+            ->where('runtime_type_code', $normalizedRuntimeTypeCode)
+            ->where('is_published', true)
+            ->where(static function (Builder $query): void {
+                $query->whereNull('published_at')
+                    ->orWhere('published_at', '<=', now());
+            })
+            ->with([
+                'sections' => static function (HasMany $query): void {
+                    $query->orderBy('sort_order')
+                        ->orderBy('id');
+                },
+                'seoMeta',
+            ])
+            ->first();
     }
 }

--- a/backend/app/Services/Mbti/MbtiPublicProjectionService.php
+++ b/backend/app/Services/Mbti/MbtiPublicProjectionService.php
@@ -109,6 +109,16 @@ final class MbtiPublicProjectionService
      */
     public function buildForPersonalityProfile(PersonalityProfile $profile): array
     {
+        return $this->buildForPublicPersonalityRoute($profile);
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function buildForPublicPersonalityRoute(
+        PersonalityProfile $profile,
+        ?PersonalityProfileVariant $variant = null
+    ): array {
         $profile->loadMissing([
             'sections' => static function (HasMany $query): void {
                 $query->where('is_enabled', true)
@@ -119,16 +129,21 @@ final class MbtiPublicProjectionService
         ]);
 
         $authority = $this->profileAuthorityAdapter->fromBaseProfile($profile);
-        $authority['runtime_type_code'] = null;
-        $authority['display_type'] = strtoupper(trim((string) ($profile->canonical_type_code ?: $profile->type_code)));
-        $authority['variant_code'] = null;
+        $authority = $this->profileAuthorityAdapter->overlayVariant($authority, $variant);
+
+        $runtimeTypeCode = $this->nullableText($authority['runtime_type_code'] ?? null);
+        $canonicalTypeCode = strtoupper(trim((string) ($profile->canonical_type_code ?: $profile->type_code)));
+
+        $authority['runtime_type_code'] = $runtimeTypeCode;
+        $authority['display_type'] = $runtimeTypeCode ?? $canonicalTypeCode;
+        $authority['variant_code'] = $this->nullableText($authority['variant_code'] ?? null);
         $authority['dimensions'] = [];
         $authority['offer_set'] = [];
         $authority['_meta'] = array_merge(
             is_array($authority['_meta'] ?? null) ? $authority['_meta'] : [],
             [
                 'authority_source' => 'personality_cms_v2',
-                'route_mode' => 'base',
+                'route_mode' => $variant instanceof PersonalityProfileVariant ? 'public_alias' : 'base',
                 'public_route_type' => '16-type',
                 'schema_version' => (string) ($profile->schema_version ?: PersonalityProfile::SCHEMA_VERSION_V2),
             ],

--- a/backend/tests/Feature/PersonalityCms/PersonalityVariantAuthorityTest.php
+++ b/backend/tests/Feature/PersonalityCms/PersonalityVariantAuthorityTest.php
@@ -15,7 +15,7 @@ final class PersonalityVariantAuthorityTest extends TestCase
 {
     use RefreshDatabase;
 
-    public function test_imported_variant_authority_rows_can_coexist_while_public_route_stays_base_only(): void
+    public function test_imported_variant_authority_rows_can_resolve_published_public_aliases_while_canonical_stays_base_only(): void
     {
         $this->artisan('personality:import-local-baseline', [
             '--locale' => ['en'],
@@ -59,6 +59,15 @@ final class PersonalityVariantAuthorityTest extends TestCase
             ->assertJsonPath('profile.canonical_type_code', 'ENFP')
             ->assertJsonPath('mbti_public_projection_v1.runtime_type_code', null)
             ->assertJsonPath('mbti_public_projection_v1.canonical_type_code', 'ENFP');
+
+        $this->getJson('/api/v0.5/personality/enfp-t?locale=en')
+            ->assertOk()
+            ->assertJsonPath('profile.type_code', 'ENFP')
+            ->assertJsonPath('profile.canonical_type_code', 'ENFP')
+            ->assertJsonPath('mbti_public_projection_v1.runtime_type_code', 'ENFP-T')
+            ->assertJsonPath('mbti_public_projection_v1.display_type', 'ENFP-T')
+            ->assertJsonPath('mbti_public_projection_v1.variant_code', 'T')
+            ->assertJsonPath('mbti_public_projection_v1._meta.public_route_type', '16-type');
 
         $this->getJson('/api/v0.5/personality/enfp-a?locale=en')
             ->assertStatus(404);

--- a/backend/tests/Feature/V0_5/PersonalityPublicApiTest.php
+++ b/backend/tests/Feature/V0_5/PersonalityPublicApiTest.php
@@ -9,6 +9,7 @@ use App\Models\PersonalityProfileRevision;
 use App\Models\PersonalityProfileSection;
 use App\Models\PersonalityProfileSeoMeta;
 use App\Models\PersonalityProfileVariant;
+use App\Models\PersonalityProfileVariantSection;
 use App\Models\PersonalityProfileVariantSeoMeta;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Tests\TestCase;
@@ -276,6 +277,8 @@ final class PersonalityPublicApiTest extends TestCase
             'published_at' => now()->subMinute(),
         ]);
         $this->createVariantSeoMeta($enVariant, [
+            'seo_title' => 'INTJ-A Personality Type: Traits, Careers, and Growth | FermatMind',
+            'seo_description' => 'Explore INTJ-A traits, strengths, blind spots, work style, relationships, and growth advice.',
             'canonical_url' => 'https://staging.fermatmind.com/en/personality/intj-a',
             'jsonld_overrides_json' => [
                 'mainEntityOfPage' => 'https://staging.fermatmind.com/en/personality/intj-a',
@@ -310,15 +313,18 @@ final class PersonalityPublicApiTest extends TestCase
             'published_at' => now()->subMinute(),
         ]);
         $this->createVariantSeoMeta($zhVariant, [
+            'seo_title' => 'INTJ-T 人格类型：特质、职业与成长 | FermatMind',
+            'seo_description' => '探索 INTJ-T 的特质、优势、关系模式与成长建议。',
             'canonical_url' => 'https://staging.fermatmind.com/zh/personality/intj-t',
             'jsonld_overrides_json' => [
                 'mainEntityOfPage' => 'https://staging.fermatmind.com/zh/personality/intj-t',
             ],
         ]);
 
-        $enResponse = $this->getJson('/api/v0.5/personality/INTJ/seo?locale=en');
+        $enResponse = $this->getJson('/api/v0.5/personality/intj-a/seo?locale=en');
         $enResponse->assertOk()
-            ->assertJsonPath('meta.title', 'INTJ Personality Type: Traits, Careers, and Growth | FermatMind')
+            ->assertJsonPath('meta.title', 'INTJ-A Personality Type: Traits, Careers, and Growth | FermatMind')
+            ->assertJsonPath('meta.description', 'Explore INTJ-A traits, strengths, blind spots, work style, relationships, and growth advice.')
             ->assertJsonPath('meta.canonical', 'https://staging.fermatmind.com/en/personality/intj')
             ->assertJsonPath('meta.robots', 'index,follow');
         self::assertSame('AboutPage', data_get($enResponse->json(), 'jsonld.@type'));
@@ -327,8 +333,10 @@ final class PersonalityPublicApiTest extends TestCase
             data_get($enResponse->json(), 'jsonld.mainEntityOfPage')
         );
 
-        $zhResponse = $this->getJson('/api/v0.5/personality/intj/seo?locale=zh-CN');
+        $zhResponse = $this->getJson('/api/v0.5/personality/intj-t/seo?locale=zh-CN');
         $zhResponse->assertOk()
+            ->assertJsonPath('meta.title', 'INTJ-T 人格类型：特质、职业与成长 | FermatMind')
+            ->assertJsonPath('meta.description', '探索 INTJ-T 的特质、优势、关系模式与成长建议。')
             ->assertJsonPath('meta.canonical', 'https://staging.fermatmind.com/zh/personality/intj')
             ->assertJsonPath('meta.robots', 'noindex,follow');
         self::assertSame(
@@ -337,23 +345,70 @@ final class PersonalityPublicApiTest extends TestCase
         );
     }
 
-    public function test_variant_route_key_remains_invalid_for_public_base_route(): void
+    public function test_detail_accepts_published_public_aliases_while_base_canonical_stays_frozen(): void
     {
+        config(['app.frontend_url' => 'https://staging.fermatmind.com']);
+
         $profile = $this->createProfile([
             'type_code' => 'INTJ',
             'slug' => 'intj',
+            'type_name' => 'Architect',
+            'nickname' => 'Systems builder',
+            'rarity_text' => 'About 2%',
+            'keywords_json' => ['strategy', 'independence'],
+            'hero_summary_md' => 'Base hero summary',
             'status' => 'published',
             'is_public' => true,
             'published_at' => now()->subMinute(),
             'schema_version' => PersonalityProfile::SCHEMA_VERSION_V2,
         ]);
-        $this->createVariant($profile, [
+        PersonalityProfileSection::query()->create([
+            'profile_id' => (int) $profile->id,
+            'section_key' => 'overview',
+            'title' => 'Overview',
+            'render_variant' => 'rich_text',
+            'body_md' => 'Base overview',
+            'sort_order' => 10,
+            'is_enabled' => true,
+        ]);
+        $this->createSeoMeta($profile, [
+            'seo_title' => 'Base INTJ title',
+            'canonical_url' => 'https://staging.fermatmind.com/en/personality/intj-a',
+        ]);
+
+        $publishedVariant = $this->createVariant($profile, [
             'canonical_type_code' => 'INTJ',
             'variant_code' => 'A',
             'runtime_type_code' => 'INTJ-A',
+            'type_name' => 'Architect Assertive',
+            'nickname' => 'Assertive strategist',
+            'rarity_text' => 'About 3%',
+            'keywords_json' => ['assertive', 'strategy'],
+            'hero_summary_md' => 'Variant hero summary',
             'schema_version' => PersonalityProfile::SCHEMA_VERSION_V2,
             'is_published' => true,
             'published_at' => now()->subMinute(),
+        ]);
+        $this->createVariantSeoMeta($publishedVariant, [
+            'seo_title' => 'Variant INTJ-A title',
+            'canonical_url' => 'https://staging.fermatmind.com/en/personality/intj-a',
+        ]);
+        PersonalityProfileVariantSection::query()->create([
+            'personality_profile_variant_id' => (int) $publishedVariant->id,
+            'section_key' => 'overview',
+            'render_variant' => 'rich_text',
+            'body_md' => 'Variant overview',
+            'sort_order' => 10,
+            'is_enabled' => true,
+        ]);
+        $this->createVariant($profile, [
+            'canonical_type_code' => 'INTJ',
+            'variant_code' => 'T',
+            'runtime_type_code' => 'INTJ-T',
+            'type_name' => 'Architect Turbulent',
+            'schema_version' => PersonalityProfile::SCHEMA_VERSION_V2,
+            'is_published' => false,
+            'published_at' => null,
         ]);
 
         $this->getJson('/api/v0.5/personality/intj?locale=en')
@@ -363,6 +418,26 @@ final class PersonalityPublicApiTest extends TestCase
             ->assertJsonPath('mbti_public_projection_v1.display_type', 'INTJ');
 
         $this->getJson('/api/v0.5/personality/intj-a?locale=en')
+            ->assertOk()
+            ->assertJsonPath('profile.type_code', 'INTJ')
+            ->assertJsonPath('profile.slug', 'intj')
+            ->assertJsonPath('profile.canonical_type_code', 'INTJ')
+            ->assertJsonPath('profile.type_name', 'Architect Assertive')
+            ->assertJsonPath('profile.nickname', 'Assertive strategist')
+            ->assertJsonPath('profile.rarity', 'About 3%')
+            ->assertJsonPath('profile.hero_summary', 'Variant hero summary')
+            ->assertJsonPath('sections.0.section_key', 'overview')
+            ->assertJsonPath('sections.0.body_md', 'Variant overview')
+            ->assertJsonPath('seo_meta.seo_title', 'Variant INTJ-A title')
+            ->assertJsonPath('seo_meta.canonical_url', 'https://staging.fermatmind.com/en/personality/intj')
+            ->assertJsonPath('mbti_public_projection_v1.runtime_type_code', 'INTJ-A')
+            ->assertJsonPath('mbti_public_projection_v1.display_type', 'INTJ-A')
+            ->assertJsonPath('mbti_public_projection_v1.variant_code', 'A')
+            ->assertJsonPath('mbti_public_projection_v1._meta.route_mode', 'public_alias')
+            ->assertJsonPath('mbti_public_projection_v1._meta.public_route_type', '16-type')
+            ->assertJsonPath('mbti_public_projection_v1.seo.canonical_url', 'https://staging.fermatmind.com/en/personality/intj');
+
+        $this->getJson('/api/v0.5/personality/intj-t?locale=en')
             ->assertStatus(404)
             ->assertJsonPath('error_code', 'NOT_FOUND');
     }

--- a/backend/tests/Unit/Services/Mbti/MbtiPublicProjectionServiceTest.php
+++ b/backend/tests/Unit/Services/Mbti/MbtiPublicProjectionServiceTest.php
@@ -54,6 +54,71 @@ final class MbtiPublicProjectionServiceTest extends TestCase
         $this->assertSame([], $projection['offer_set']);
     }
 
+    public function test_it_builds_public_alias_projection_from_published_variant_authority(): void
+    {
+        config(['app.frontend_url' => 'https://staging.fermatmind.com']);
+
+        $profile = $this->createBaseProfile([
+            'title' => 'INTJ - Architect',
+            'subtitle' => 'Base subtitle',
+            'excerpt' => 'Base excerpt',
+        ]);
+        PersonalityProfileSection::query()->create([
+            'profile_id' => (int) $profile->id,
+            'section_key' => 'overview',
+            'title' => 'Overview',
+            'render_variant' => 'rich_text',
+            'body_md' => 'Base overview',
+            'sort_order' => 10,
+            'is_enabled' => true,
+        ]);
+        PersonalityProfileSeoMeta::query()->create([
+            'profile_id' => (int) $profile->id,
+            'seo_title' => 'Base SEO title',
+        ]);
+
+        $variant = PersonalityProfileVariant::query()->create([
+            'personality_profile_id' => (int) $profile->id,
+            'canonical_type_code' => 'INTJ',
+            'variant_code' => 'A',
+            'runtime_type_code' => 'INTJ-A',
+            'type_name' => 'Architect A',
+            'nickname' => 'Assertive strategist',
+            'rarity_text' => 'About 3%',
+            'keywords_json' => ['assertive', 'strategy'],
+            'hero_summary_md' => 'Variant hero summary',
+            'schema_version' => PersonalityProfile::SCHEMA_VERSION_V2,
+            'is_published' => true,
+            'published_at' => now()->subMinute(),
+        ]);
+        PersonalityProfileVariantSection::query()->create([
+            'personality_profile_variant_id' => (int) $variant->id,
+            'section_key' => 'overview',
+            'render_variant' => 'rich_text',
+            'body_md' => 'Variant overview',
+            'sort_order' => 10,
+            'is_enabled' => true,
+        ]);
+        PersonalityProfileVariantSeoMeta::query()->create([
+            'personality_profile_variant_id' => (int) $variant->id,
+            'seo_title' => 'Variant SEO title',
+        ]);
+
+        $projection = app(MbtiPublicProjectionService::class)->buildForPublicPersonalityRoute($profile, $variant);
+
+        $this->assertSame('INTJ-A', $projection['runtime_type_code']);
+        $this->assertSame('INTJ', $projection['canonical_type_code']);
+        $this->assertSame('INTJ-A', $projection['display_type']);
+        $this->assertSame('A', $projection['variant_code']);
+        $this->assertSame('Architect A', data_get($projection, 'profile.type_name'));
+        $this->assertSame('Assertive strategist', data_get($projection, 'profile.nickname'));
+        $this->assertSame('Variant overview', data_get($projection, 'sections.0.body_md'));
+        $this->assertSame('Variant SEO title', data_get($projection, 'seo.title'));
+        $this->assertSame('https://staging.fermatmind.com/en/personality/intj', data_get($projection, 'seo.canonical_url'));
+        $this->assertSame('public_alias', data_get($projection, '_meta.route_mode'));
+        $this->assertSame('16-type', data_get($projection, '_meta.public_route_type'));
+    }
+
     public function test_it_merges_runtime_identity_report_fallback_and_cms_variant_authority_for_share_projection(): void
     {
         config(['app.frontend_url' => 'https://staging.fermatmind.com']);


### PR DESCRIPTION
## Summary
This PR makes the public MBTI personality detail and SEO endpoints accept published 32-type aliases such as `intj-a` and `enfj-t` while keeping the 16-type canonical policy frozen.

Before this change, `/api/v0.5/personality/{type}` and `/api/v0.5/personality/{type}/seo` only resolved the 16 canonical base records. The repo already had full 32-type committed authority and runtime projection support, but the public lookup path stopped at `PersonalityProfileService` base-only resolution. That meant published variant authority existed in CMS/runtime, yet public alias detail routes still 404ed.

With this PR, the detail and SEO routes now parse 4-letter aliases, resolve them against published variant authority for the same canonical base profile, and project the variant overlay into the existing public response contract. Canonical ownership remains with the 16-type base profile: public canonical URLs, JSON-LD mainEntityOfPage, and sitemap output all stay on `/personality/{4-letter}` only.

## Root Cause
The public personality read path only loaded base `PersonalityProfile` rows. It did not have a route-scoped way to parse `INTJ-A` into `INTJ` + `A`, check whether the matching variant was published, and then build a public projection using that variant overlay. As a result, the backend had variant authority but no public alias resolution path.

## What Changed
- Added a route-scoped alias resolver in `PersonalityProfileService` that accepts 4-letter base types and 4-letter `-A` / `-T` aliases for public detail reads only.
- Preserved the existing base-only `getPublicProfileByType()` behavior so other callers such as share/topic resolution do not widen their lookup behavior accidentally.
- Added public alias projection support in `MbtiPublicProjectionService`, allowing alias detail responses to expose runtime/display identity from a published variant while keeping `_meta.public_route_type` at `16-type` and canonical URLs on the base slug.
- Updated `PersonalityProfileSeoService` so alias SEO responses can use variant title/description overlays while canonical and JSON-LD mainEntityOfPage still point to the 16-type base route.
- Updated `PersonalityController` to resolve detail/SEO routes through the new alias-aware path and return variant-overlaid detail payloads without introducing any new top-level contract names.
- Added regression coverage for published alias 200s, unpublished alias 404s, canonical freeze, and sitemap 16-only behavior.

## User Impact
Users and crawlers can now request public alias detail pages for published 32-type variants, for example `intj-a`, and receive variant-resolved public content. However, SEO canonical ownership is unchanged: canonical URLs, structured-data mainEntityOfPage, and sitemap URLs remain on the 16-type base paths only. This PR does not expand public canonical coverage to 32 pages and does not change frontend canonical/hreflang/redirect policy.

## Validation
I ran:
- `php -l` on all changed PHP files
- `./vendor/bin/pint app/Services/Cms/PersonalityProfileService.php app/Services/Mbti/MbtiPublicProjectionService.php app/Services/Cms/PersonalityProfileSeoService.php app/Http/Controllers/API/V0_5/Cms/PersonalityController.php tests/Feature/V0_5/PersonalityPublicApiTest.php tests/Feature/PersonalityCms/PersonalityVariantAuthorityTest.php tests/Unit/Services/Mbti/MbtiPublicProjectionServiceTest.php`
- `vendor/bin/phpunit tests/Feature/V0_5/PersonalityPublicApiTest.php tests/Feature/PersonalityCms/PersonalityVariantAuthorityTest.php tests/Unit/Services/Mbti/MbtiPublicProjectionServiceTest.php tests/Feature/SEO/SitemapGeneratorTest.php tests/Feature/SEO/SitemapXmlTest.php tests/Feature/V0_3/MbtiReportHttpContractRegressionTest.php tests/Feature/V0_3/ShareSummaryContractTest.php tests/Feature/V0_3/MbtiCompareInviteContractTest.php`
- `php artisan route:list | grep -Ei "personality|seo|sitemap"`
- `php artisan migrate`
- `php artisan personality:import-local-baseline --locale=zh-CN --locale=en --type=INTJ --upsert --status=published` for local curl verification only
- `php artisan serve --host=127.0.0.1 --port=8000`
- `curl -s "http://127.0.0.1:8000/api/v0.5/personality/intj?locale=zh-CN" | jq`
- `curl -s "http://127.0.0.1:8000/api/v0.5/personality/intj-a?locale=zh-CN" | jq`
- `curl -s "http://127.0.0.1:8000/api/v0.5/personality/intj-a/seo?locale=zh-CN" | jq .meta.canonical`
- `curl -s -o /dev/null -w "%{http_code}\n" "http://127.0.0.1:8000/api/v0.5/personality/intj-a?locale=en"`
- `curl -s "http://127.0.0.1:8000/sitemap.xml" | grep -E "personality/[a-z]{4}-[at]" || true`
- `bash scripts/ci_verify_mbti.sh`

## Guardrails Confirmed
- `backend/routes/api.php` unchanged
- `backend/database/` unchanged
- `content_baselines/personality/` unchanged
- `fap-web/` unchanged
- No importer or baseline pipeline files changed
- No share / compare / result / orders / payment / access hub files changed
